### PR TITLE
fix(core): Fix user access control logic and update tests for global (backport to release-candidate/2.17.x)

### DIFF
--- a/packages/cli/src/controllers/__tests__/users.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/users.controller.test.ts
@@ -1,4 +1,3 @@
-import type { UsersListFilterDto } from '@n8n/api-types';
 import type { AuthenticatedRequest, User, UserRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 import type { Response } from 'express';
@@ -8,7 +7,6 @@ import type { JwtService } from '@/services/jwt.service';
 import type { ProvisioningService } from '@/modules/provisioning.ee/provisioning.service.ee';
 import type { ProjectService } from '@/services/project.service.ee';
 import type { UrlService } from '@/services/url.service';
-import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
 import { UsersController } from '../users.controller';
@@ -66,81 +64,6 @@ describe('UsersController', () => {
 				targetUserNewRole: 'global:member',
 				publicApi: false,
 			});
-		});
-	});
-
-	describe('listUsers', () => {
-		const mockQueryBuilder = () => mock({ getManyAndCount: jest.fn().mockResolvedValue([[], 0]) });
-
-		it('should allow global:owner to list users without checking project scopes', async () => {
-			userRepository.buildUserQuery.mockReturnValue(mockQueryBuilder() as never);
-			const req = mock<AuthenticatedRequest>({
-				user: mock<User>({ role: { slug: 'global:owner', scopes: [] } }),
-			});
-
-			await expect(
-				controller.listUsers(
-					req,
-					mock<Response>(),
-					mock<UsersListFilterDto>({ filter: undefined, select: undefined }),
-				),
-			).resolves.toBeDefined();
-
-			expect(projectService.getProjectIdsWithScope).not.toHaveBeenCalled();
-		});
-
-		it('should allow user with project:update scope to list all users without projectId filter', async () => {
-			userRepository.buildUserQuery.mockReturnValue(mockQueryBuilder() as never);
-			projectService.getProjectIdsWithScope.mockResolvedValue(['project-1']);
-			const req = mock<AuthenticatedRequest>({
-				user: mock<User>({ role: { slug: 'global:member', scopes: [] } }),
-			});
-
-			await expect(
-				controller.listUsers(
-					req,
-					mock<Response>(),
-					mock<UsersListFilterDto>({ filter: undefined, select: undefined }),
-				),
-			).resolves.toBeDefined();
-
-			expect(projectService.getProjectIdsWithScope).toHaveBeenCalledWith(req.user, [
-				'project:update',
-			]);
-		});
-
-		it('should throw ForbiddenError when member has no project:update scope and no projectId filter', async () => {
-			projectService.getProjectIdsWithScope.mockResolvedValue([]);
-			const req = mock<AuthenticatedRequest>({
-				user: mock<User>({ role: { slug: 'global:member' } }),
-			});
-
-			await expect(
-				controller.listUsers(
-					req,
-					mock<Response>(),
-					mock<UsersListFilterDto>({ filter: undefined }),
-				),
-			).rejects.toThrow(ForbiddenError);
-
-			expect(projectService.getProjectIdsWithScope).toHaveBeenCalledWith(req.user, [
-				'project:update',
-			]);
-		});
-
-		it('should throw NotFoundError when filtering by an unknown projectId', async () => {
-			projectService.getProjectWithScope.mockResolvedValue(null);
-			const req = mock<AuthenticatedRequest>({
-				user: mock<User>({ role: { slug: 'global:member' } }),
-			});
-
-			await expect(
-				controller.listUsers(
-					req,
-					mock<Response>(),
-					mock<UsersListFilterDto>({ filter: { projectId: 'unknown-project-id' } }),
-				),
-			).rejects.toThrow(NotFoundError);
 		});
 	});
 

--- a/packages/cli/src/controllers/users.controller.ts
+++ b/packages/cli/src/controllers/users.controller.ts
@@ -127,15 +127,6 @@ export class UsersController {
 			if (!project) {
 				throw new NotFoundError('Project not found');
 			}
-		} else if (!['global:owner', 'global:admin'].includes(req.user.role.slug)) {
-			// Project admins need to search all users to invite them into their projects
-			const isProjectAdmin =
-				(await this.projectService.getProjectIdsWithScope(req.user, ['project:update'])).length > 0;
-			if (!isProjectAdmin) {
-				throw new ForbiddenError(
-					'Listing all users is limited to instance administrators and project admins. Filter by project to list project members.',
-				);
-			}
 		}
 
 		const userQuery = this.userRepository.buildUserQuery(listQueryOptions);


### PR DESCRIPTION
# Description
Backport of #29481 to `release-candidate/2.17.x`.

## Checklist for the author (@sandra0503) to go through.

- [x] Review the backport changes
- [x] Fix possible conflicts
- [ ] Merge to target branch

After this PR has been merged, it will be picked up in the next patch release for release track.

# Original description

## Summary

Allow listing users for all users with `user:list` scope. 
Permissions based on user roles is not in line with how we model permissions now.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ligo-479](https://linear.app/n8n/issue/LIGO-479/cant-invite-users-to-a-project)


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
