### PR TITLE
chore(core): Add CLI to print Instance AI agent prompts (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/package.json
+++ b/packages/@n8n/instance-ai/package.json
@@ -14,7 +14,8 @@
     "eval:pairwise": "tsx evaluations/cli/pairwise.ts",
     "eval:pairwise:report": "tsx evaluations/cli/report.ts",
     "eval:pairwise:compare": "tsx evaluations/cli/compare-pairwise.ts",
-    "eval:subagent": "tsx evaluations/subagent/cli.ts"
+    "eval:subagent": "tsx evaluations/subagent/cli.ts",
+    "prompts:print": "tsx scripts/print-prompts.ts"
   },
   "main": "dist/index.js",
   "module": "src/index.ts",

--- a/packages/@n8n/instance-ai/scripts/print-prompts.ts
+++ b/packages/@n8n/instance-ai/scripts/print-prompts.ts
@@ -3,9 +3,10 @@
 // Print Prompts CLI
 //
 // Renders the final system prompt for the main Instance Agent and every
-// orchestration sub-agent, then writes one markdown file per agent into
-// `.output/prompts/` (gitignored). Useful for auditing, diffing across
-// branches, or sharing the full prompt outside the codebase.
+// orchestration sub-agent, then writes one markdown file per agent variant
+// into `.output/prompts/<agent>/<variant>.md` (gitignored). Useful for
+// auditing the full prompt verbatim, diffing prompts across branches, or
+// sharing them outside the codebase.
 // ---------------------------------------------------------------------------
 
 import { mkdirSync, writeFileSync } from 'fs';
@@ -22,12 +23,20 @@ import { DATA_TABLE_AGENT_PROMPT } from '../src/tools/orchestration/data-table-a
 import { PLANNER_AGENT_PROMPT } from '../src/tools/orchestration/plan-agent-prompt';
 import { RESEARCH_AGENT_PROMPT } from '../src/tools/orchestration/research-agent-prompt';
 
-interface PromptEntry {
+interface Variant {
+	/** File name (without extension) inside the agent's folder. */
 	file: string;
+	/** Short human-readable label for the variant header (omit when only one variant). */
+	label?: string;
+	body: string;
+}
+
+interface AgentEntry {
+	/** Folder name under `.output/prompts/`. */
+	folder: string;
 	displayName: string;
 	source: string;
-	variant?: string;
-	body: string;
+	variants: Variant[];
 }
 
 function parseArgs(argv: string[]): { outDir: string } {
@@ -51,118 +60,135 @@ function parseArgs(argv: string[]): { outDir: string } {
 	return { outDir };
 }
 
-function collectPrompts(): PromptEntry[] {
-	const mainAgentPrompt = getSystemPrompt({
-		researchMode: true,
-		webhookBaseUrl: 'https://your-instance.example.com',
-		filesystemAccess: true,
-		localGateway: { status: 'connected' },
-		toolSearchEnabled: true,
-		licenseHints: ['<sample license hint — replace with real hint at runtime>'],
-		timeZone: 'UTC',
-		browserAvailable: true,
-		branchReadOnly: false,
-	});
-
-	const delegateTemplate = buildSubAgentPrompt(
-		'<example-role>',
-		'<example task instructions — orchestrator fills this in per delegation>',
-		'UTC',
-	);
-
+function collectAgents(): AgentEntry[] {
 	return [
 		{
-			file: 'main-agent.md',
+			folder: 'main-agent',
 			displayName: 'Main Instance Agent',
 			source: 'src/agent/system-prompt.ts → getSystemPrompt',
-			variant: 'all features enabled (research, filesystem, gateway, tool-search, browser)',
-			body: mainAgentPrompt,
+			variants: [
+				{
+					file: 'prompt',
+					label: 'all features enabled (research, filesystem, gateway, tool-search, browser)',
+					body: getSystemPrompt({
+						researchMode: true,
+						webhookBaseUrl: 'https://your-instance.example.com',
+						filesystemAccess: true,
+						localGateway: { status: 'connected' },
+						toolSearchEnabled: true,
+						licenseHints: ['<sample license hint — replace with real hint at runtime>'],
+						timeZone: 'UTC',
+						browserAvailable: true,
+						branchReadOnly: false,
+					}),
+				},
+			],
 		},
 		{
-			file: 'subagent-planner.md',
+			folder: 'planner',
 			displayName: 'Sub-Agent — Workflow Planner',
 			source: 'src/tools/orchestration/plan-agent-prompt.ts → PLANNER_AGENT_PROMPT',
-			body: PLANNER_AGENT_PROMPT,
+			variants: [{ file: 'prompt', body: PLANNER_AGENT_PROMPT }],
 		},
 		{
-			file: 'subagent-builder-tool.md',
-			displayName: 'Sub-Agent — Workflow Builder (tool mode)',
-			source: 'src/tools/orchestration/build-workflow-agent.prompt.ts → BUILDER_AGENT_PROMPT',
-			variant: 'tool mode (no sandbox)',
-			body: BUILDER_AGENT_PROMPT,
+			folder: 'builder',
+			displayName: 'Sub-Agent — Workflow Builder',
+			source: 'src/tools/orchestration/build-workflow-agent.prompt.ts',
+			variants: [
+				{
+					file: 'tool',
+					label: 'tool mode (no sandbox) → BUILDER_AGENT_PROMPT',
+					body: BUILDER_AGENT_PROMPT,
+				},
+				{
+					file: 'sandbox',
+					label: 'sandbox mode → createSandboxBuilderAgentPrompt(workspaceRoot: /workspace)',
+					body: createSandboxBuilderAgentPrompt('/workspace'),
+				},
+			],
 		},
 		{
-			file: 'subagent-builder-sandbox.md',
-			displayName: 'Sub-Agent — Workflow Builder (sandbox mode)',
-			source:
-				'src/tools/orchestration/build-workflow-agent.prompt.ts → createSandboxBuilderAgentPrompt',
-			variant: 'sandbox mode — workspaceRoot: /workspace',
-			body: createSandboxBuilderAgentPrompt('/workspace'),
-		},
-		{
-			file: 'subagent-researcher.md',
+			folder: 'researcher',
 			displayName: 'Sub-Agent — Web Researcher',
 			source: 'src/tools/orchestration/research-agent-prompt.ts → RESEARCH_AGENT_PROMPT',
-			body: RESEARCH_AGENT_PROMPT,
+			variants: [{ file: 'prompt', body: RESEARCH_AGENT_PROMPT }],
 		},
 		{
-			file: 'subagent-data-table.md',
+			folder: 'data-table',
 			displayName: 'Sub-Agent — Data Table Manager',
 			source: 'src/tools/orchestration/data-table-agent.prompt.ts → DATA_TABLE_AGENT_PROMPT',
-			body: DATA_TABLE_AGENT_PROMPT,
+			variants: [{ file: 'prompt', body: DATA_TABLE_AGENT_PROMPT }],
 		},
 		{
-			file: 'subagent-browser-gateway.md',
-			displayName: 'Sub-Agent — Browser Credential Setup (gateway)',
+			folder: 'browser-credential-setup',
+			displayName: 'Sub-Agent — Browser Credential Setup',
 			source:
 				'src/tools/orchestration/browser-credential-setup.prompt.ts → buildBrowserAgentPrompt',
-			variant: "source: 'gateway'",
-			body: buildBrowserAgentPrompt('gateway'),
+			variants: [
+				{
+					file: 'gateway',
+					label: "source: 'gateway' (local gateway browser tools)",
+					body: buildBrowserAgentPrompt('gateway'),
+				},
+				{
+					file: 'chrome-mcp',
+					label: "source: 'chrome-devtools-mcp' (Chrome DevTools MCP server)",
+					body: buildBrowserAgentPrompt('chrome-devtools-mcp'),
+				},
+			],
 		},
 		{
-			file: 'subagent-browser-chrome-mcp.md',
-			displayName: 'Sub-Agent — Browser Credential Setup (Chrome DevTools MCP)',
-			source:
-				'src/tools/orchestration/browser-credential-setup.prompt.ts → buildBrowserAgentPrompt',
-			variant: "source: 'chrome-devtools-mcp'",
-			body: buildBrowserAgentPrompt('chrome-devtools-mcp'),
-		},
-		{
-			file: 'subagent-delegate-template.md',
+			folder: 'delegate',
 			displayName: 'Sub-Agent — Generic Delegate (template)',
 			source: 'src/agent/sub-agent-factory.ts → buildSubAgentPrompt',
-			variant: 'placeholder role/instructions — orchestrator fills these per delegation at runtime',
-			body: delegateTemplate,
+			variants: [
+				{
+					file: 'template',
+					label:
+						'placeholder role/instructions — orchestrator fills these per delegation at runtime',
+					body: buildSubAgentPrompt(
+						'<example-role>',
+						'<example task instructions — orchestrator fills this in per delegation>',
+						'UTC',
+					),
+				},
+			],
 		},
 	];
 }
 
-function renderFile(entry: PromptEntry): string {
-	const header: string[] = [`# ${entry.displayName}`, '', `> Source: \`${entry.source}\``];
-	if (entry.variant) {
-		header.push(`> Variant: ${entry.variant}`);
+function renderFile(agent: AgentEntry, variant: Variant): string {
+	const header: string[] = [`# ${agent.displayName}`, '', `> Source: \`${agent.source}\``];
+	if (variant.label) {
+		header.push(`> Variant: ${variant.label}`);
 	}
 	header.push('', '---', '');
-	return header.join('\n') + entry.body;
+	return header.join('\n') + variant.body;
 }
 
 function main(): void {
 	const { outDir } = parseArgs(process.argv);
-	mkdirSync(outDir, { recursive: true });
+	const agents = collectAgents();
 
-	const entries = collectPrompts();
-
-	for (const entry of entries) {
-		const target = join(outDir, entry.file);
-		writeFileSync(target, renderFile(entry), 'utf8');
+	const written: Array<{ relPath: string; chars: number }> = [];
+	for (const agent of agents) {
+		const agentDir = join(outDir, agent.folder);
+		mkdirSync(agentDir, { recursive: true });
+		for (const variant of agent.variants) {
+			const target = join(agentDir, `${variant.file}.md`);
+			writeFileSync(target, renderFile(agent, variant), 'utf8');
+			written.push({
+				relPath: `${agent.folder}/${variant.file}.md`,
+				chars: variant.body.length,
+			});
+		}
 	}
 
-	const longestName = Math.max(...entries.map((e) => e.file.length));
-	console.log(`Wrote ${entries.length} prompts to ${outDir}`);
-	for (const entry of entries) {
-		const padded = entry.file.padEnd(longestName);
-		const chars = entry.body.length.toLocaleString();
-		console.log(`  ${padded}  ${chars.padStart(7)} chars`);
+	const longestName = Math.max(...written.map((w) => w.relPath.length));
+	console.log(`Wrote ${written.length} prompts to ${outDir}`);
+	for (const { relPath, chars } of written) {
+		const padded = relPath.padEnd(longestName);
+		console.log(`  ${padded}  ${chars.toLocaleString().padStart(7)} chars`);
 	}
 }
 

--- a/packages/@n8n/instance-ai/scripts/print-prompts.ts
+++ b/packages/@n8n/instance-ai/scripts/print-prompts.ts
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// ---------------------------------------------------------------------------
+// Print Prompts CLI
+//
+// Renders the final system prompt for the main Instance Agent and every
+// orchestration sub-agent, then writes one markdown file per agent into
+// `.output/prompts/` (gitignored). Useful for auditing, diffing across
+// branches, or sharing the full prompt outside the codebase.
+// ---------------------------------------------------------------------------
+
+import { mkdirSync, writeFileSync } from 'fs';
+import { join, resolve } from 'path';
+
+import { buildSubAgentPrompt } from '../src/agent/sub-agent-factory';
+import { getSystemPrompt } from '../src/agent/system-prompt';
+import { buildBrowserAgentPrompt } from '../src/tools/orchestration/browser-credential-setup.prompt';
+import {
+	BUILDER_AGENT_PROMPT,
+	createSandboxBuilderAgentPrompt,
+} from '../src/tools/orchestration/build-workflow-agent.prompt';
+import { DATA_TABLE_AGENT_PROMPT } from '../src/tools/orchestration/data-table-agent.prompt';
+import { PLANNER_AGENT_PROMPT } from '../src/tools/orchestration/plan-agent-prompt';
+import { RESEARCH_AGENT_PROMPT } from '../src/tools/orchestration/research-agent-prompt';
+
+interface PromptEntry {
+	file: string;
+	displayName: string;
+	source: string;
+	variant?: string;
+	body: string;
+}
+
+function parseArgs(argv: string[]): { outDir: string } {
+	const args = argv.slice(2);
+	let outDir = resolve(__dirname, '..', '.output', 'prompts');
+	for (let i = 0; i < args.length; i++) {
+		if (args[i] === '--out' || args[i] === '-o') {
+			const next = args[i + 1];
+			if (!next) {
+				console.error('Error: --out requires a directory argument');
+				process.exit(1);
+			}
+			outDir = resolve(next);
+			i++;
+		} else if (args[i] === '--help' || args[i] === '-h') {
+			console.log('Usage: pnpm prompts:print [--out <dir>]');
+			console.log('  --out, -o   Output directory (default: <package>/.output/prompts)');
+			process.exit(0);
+		}
+	}
+	return { outDir };
+}
+
+function collectPrompts(): PromptEntry[] {
+	const mainAgentPrompt = getSystemPrompt({
+		researchMode: true,
+		webhookBaseUrl: 'https://your-instance.example.com',
+		filesystemAccess: true,
+		localGateway: { status: 'connected' },
+		toolSearchEnabled: true,
+		licenseHints: ['<sample license hint — replace with real hint at runtime>'],
+		timeZone: 'UTC',
+		browserAvailable: true,
+		branchReadOnly: false,
+	});
+
+	const delegateTemplate = buildSubAgentPrompt(
+		'<example-role>',
+		'<example task instructions — orchestrator fills this in per delegation>',
+		'UTC',
+	);
+
+	return [
+		{
+			file: 'main-agent.md',
+			displayName: 'Main Instance Agent',
+			source: 'src/agent/system-prompt.ts → getSystemPrompt',
+			variant: 'all features enabled (research, filesystem, gateway, tool-search, browser)',
+			body: mainAgentPrompt,
+		},
+		{
+			file: 'subagent-planner.md',
+			displayName: 'Sub-Agent — Workflow Planner',
+			source: 'src/tools/orchestration/plan-agent-prompt.ts → PLANNER_AGENT_PROMPT',
+			body: PLANNER_AGENT_PROMPT,
+		},
+		{
+			file: 'subagent-builder-tool.md',
+			displayName: 'Sub-Agent — Workflow Builder (tool mode)',
+			source: 'src/tools/orchestration/build-workflow-agent.prompt.ts → BUILDER_AGENT_PROMPT',
+			variant: 'tool mode (no sandbox)',
+			body: BUILDER_AGENT_PROMPT,
+		},
+		{
+			file: 'subagent-builder-sandbox.md',
+			displayName: 'Sub-Agent — Workflow Builder (sandbox mode)',
+			source:
+				'src/tools/orchestration/build-workflow-agent.prompt.ts → createSandboxBuilderAgentPrompt',
+			variant: 'sandbox mode — workspaceRoot: /workspace',
+			body: createSandboxBuilderAgentPrompt('/workspace'),
+		},
+		{
+			file: 'subagent-researcher.md',
+			displayName: 'Sub-Agent — Web Researcher',
+			source: 'src/tools/orchestration/research-agent-prompt.ts → RESEARCH_AGENT_PROMPT',
+			body: RESEARCH_AGENT_PROMPT,
+		},
+		{
+			file: 'subagent-data-table.md',
+			displayName: 'Sub-Agent — Data Table Manager',
+			source: 'src/tools/orchestration/data-table-agent.prompt.ts → DATA_TABLE_AGENT_PROMPT',
+			body: DATA_TABLE_AGENT_PROMPT,
+		},
+		{
+			file: 'subagent-browser-gateway.md',
+			displayName: 'Sub-Agent — Browser Credential Setup (gateway)',
+			source:
+				'src/tools/orchestration/browser-credential-setup.prompt.ts → buildBrowserAgentPrompt',
+			variant: "source: 'gateway'",
+			body: buildBrowserAgentPrompt('gateway'),
+		},
+		{
+			file: 'subagent-browser-chrome-mcp.md',
+			displayName: 'Sub-Agent — Browser Credential Setup (Chrome DevTools MCP)',
+			source:
+				'src/tools/orchestration/browser-credential-setup.prompt.ts → buildBrowserAgentPrompt',
+			variant: "source: 'chrome-devtools-mcp'",
+			body: buildBrowserAgentPrompt('chrome-devtools-mcp'),
+		},
+		{
+			file: 'subagent-delegate-template.md',
+			displayName: 'Sub-Agent — Generic Delegate (template)',
+			source: 'src/agent/sub-agent-factory.ts → buildSubAgentPrompt',
+			variant: 'placeholder role/instructions — orchestrator fills these per delegation at runtime',
+			body: delegateTemplate,
+		},
+	];
+}
+
+function renderFile(entry: PromptEntry): string {
+	const header: string[] = [`# ${entry.displayName}`, '', `> Source: \`${entry.source}\``];
+	if (entry.variant) {
+		header.push(`> Variant: ${entry.variant}`);
+	}
+	header.push('', '---', '');
+	return header.join('\n') + entry.body;
+}
+
+function main(): void {
+	const { outDir } = parseArgs(process.argv);
+	mkdirSync(outDir, { recursive: true });
+
+	const entries = collectPrompts();
+
+	for (const entry of entries) {
+		const target = join(outDir, entry.file);
+		writeFileSync(target, renderFile(entry), 'utf8');
+	}
+
+	const longestName = Math.max(...entries.map((e) => e.file.length));
+	console.log(`Wrote ${entries.length} prompts to ${outDir}`);
+	for (const entry of entries) {
+		const padded = entry.file.padEnd(longestName);
+		const chars = entry.body.length.toLocaleString();
+		console.log(`  ${padded}  ${chars.padStart(7)} chars`);
+	}
+}
+
+main();

--- a/packages/@n8n/instance-ai/scripts/print-prompts.ts
+++ b/packages/@n8n/instance-ai/scripts/print-prompts.ts
@@ -68,8 +68,9 @@ function collectAgents(): AgentEntry[] {
 			source: 'src/agent/system-prompt.ts → getSystemPrompt',
 			variants: [
 				{
-					file: 'prompt',
-					label: 'all features enabled (research, filesystem, gateway, tool-search, browser)',
+					file: 'all-features',
+					label:
+						'all features enabled (research, filesystem, gateway connected, tool-search, browser, sample license hint)',
 					body: getSystemPrompt({
 						researchMode: true,
 						webhookBaseUrl: 'https://your-instance.example.com',
@@ -80,6 +81,42 @@ function collectAgents(): AgentEntry[] {
 						timeZone: 'UTC',
 						browserAvailable: true,
 						branchReadOnly: false,
+					}),
+				},
+				{
+					file: 'default',
+					label:
+						'no options set — what a fresh OSS install sees (no webhook URL, no filesystem, no gateway, no browser, no tool search)',
+					body: getSystemPrompt({}),
+				},
+				{
+					file: 'read-only',
+					label:
+						'branchReadOnly: true — instance protected by source control settings; otherwise default',
+					body: getSystemPrompt({ branchReadOnly: true }),
+				},
+				{
+					file: 'computer-use-prompting',
+					label:
+						"localGateway disconnected with filesystem + browser capabilities — renders the 'install Computer Use' pitch and 'Browser Automation (Unavailable)' note",
+					body: getSystemPrompt({
+						webhookBaseUrl: 'https://your-instance.example.com',
+						localGateway: {
+							status: 'disconnected',
+							capabilities: ['filesystem', 'browser'],
+						},
+						browserAvailable: false,
+					}),
+				},
+				{
+					file: 'gateway-no-browser',
+					label:
+						"localGateway connected, filesystemAccess: true, browserAvailable: false — renders 'Project Filesystem Access' and 'Browser Automation (Disabled in Computer Use)'",
+					body: getSystemPrompt({
+						webhookBaseUrl: 'https://your-instance.example.com',
+						filesystemAccess: true,
+						localGateway: { status: 'connected' },
+						browserAvailable: false,
 					}),
 				},
 			],

--- a/packages/@n8n/instance-ai/scripts/tsconfig.json
+++ b/packages/@n8n/instance-ai/scripts/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"extends": [
+		"@n8n/typescript-config/tsconfig.common.json",
+		"@n8n/typescript-config/tsconfig.backend.json"
+	],
+	"compilerOptions": {
+		"target": "es2023",
+		"lib": ["es2023"],
+		"emitDecoratorMetadata": true,
+		"experimentalDecorators": true,
+		"types": ["node"]
+	},
+	"include": ["**/*.ts"]
+}

--- a/packages/@n8n/instance-ai/src/agent/sub-agent-factory.ts
+++ b/packages/@n8n/instance-ai/src/agent/sub-agent-factory.ts
@@ -48,7 +48,7 @@ Keep diagnostics to 2-3 sentences maximum. Omit entirely when the task succeeded
 
 export { SUB_AGENT_PROTOCOL };
 
-function buildSubAgentPrompt(role: string, instructions: string, timeZone?: string): string {
+export function buildSubAgentPrompt(role: string, instructions: string, timeZone?: string): string {
 	return `${SUB_AGENT_PROTOCOL}
 ${getDateTimeSection(timeZone)}
 


### PR DESCRIPTION
## Summary

Adds a developer CLI in `@n8n/instance-ai` that renders the final system prompt for the main Instance Agent and every orchestration sub-agent, then writes one markdown file per agent into the package's gitignored `.output/prompts/` directory.

Useful for auditing the full prompt verbatim, diffing prompts across branches, or sharing them outside the codebase.

**Run:**

```bash
cd packages/@n8n/instance-ai
pnpm prompts:print
# → writes .output/prompts/*.md (gitignored)
```

**What it covers (9 files):**

- `main-agent.md` — `getSystemPrompt` rendered with all features enabled (research, filesystem, gateway, tool-search, browser)
- `subagent-planner.md`
- `subagent-builder-tool.md` and `subagent-builder-sandbox.md` (both builder variants)
- `subagent-researcher.md`
- `subagent-data-table.md`
- `subagent-browser-gateway.md` and `subagent-browser-chrome-mcp.md` (both browser-tool sources)
- `subagent-delegate-template.md` — generic delegate prompt with placeholder role/instructions

The CLI is a pure consumer of existing prompt exports. The only source-side change is exporting `buildSubAgentPrompt` from `sub-agent-factory.ts` so the delegate template can reuse it instead of duplicating logic. A small `scripts/tsconfig.json` mirrors `evaluations/tsconfig.json` so lint picks up the new file.

**How to test:**

```bash
cd packages/@n8n/instance-ai
pnpm prompts:print
ls .output/prompts/
# Spot-check the main agent prompt
grep -E '^## (When to Plan|Delegation|Workflow Building)' .output/prompts/main-agent.md
# Confirm nothing accidentally tracked
git status --short .output/   # expected: empty
pnpm typecheck && pnpm lint
```

## Related Linear tickets, Github issues, and Community forum posts

_Internal tooling — no ticket._

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.  <!-- N/A: developer-only CLI, output verified manually via spot-checks above -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
🤖 PR Summary generated by AI