### PR TITLE
fix(core): Advance Postgres IDENTITY sequences after entity import

### DIFF
--- a/packages/cli/src/services/__tests__/import.service.test.ts
+++ b/packages/cli/src/services/__tests__/import.service.test.ts
@@ -1095,4 +1095,57 @@ describe('ImportService', () => {
 			expect(mockDataTableDDLService.dropTable).not.toHaveBeenCalled();
 		});
 	});
+
+	describe('advanceIdentitySequences', () => {
+		it('should run setval for each identity column on Postgres', async () => {
+			// @ts-expect-error overriding for the test
+			mockDataSource.options = { type: 'postgres' };
+
+			mockEntityManager.query = jest
+				.fn()
+				// information_schema lookup for "workflow_dependency"
+				.mockResolvedValueOnce([{ column_name: 'id' }])
+				// setval call returns nothing meaningful
+				.mockResolvedValueOnce(undefined)
+				// information_schema lookup for "insights_metadata" (has 'metaId')
+				.mockResolvedValueOnce([{ column_name: 'metaId' }])
+				.mockResolvedValueOnce(undefined)
+				// information_schema lookup for "user" (no identity columns)
+				.mockResolvedValueOnce([]);
+
+			await importService.advanceIdentitySequences(mockEntityManager, [
+				'workflow_dependency',
+				'insights_metadata',
+				'user',
+			]);
+
+			const setvalCalls = (mockEntityManager.query as jest.Mock).mock.calls.filter(
+				([sql]) => typeof sql === 'string' && sql.includes('setval('),
+			);
+			expect(setvalCalls).toHaveLength(2);
+			// Quoted table identifier passed through to pg_get_serial_sequence
+			// (regclass folds unquoted names to lowercase, so the quoted form is required).
+			expect(setvalCalls[0][1]).toEqual(['"workflow_dependency"', 'id']);
+			expect(setvalCalls[1][1]).toEqual(['"insights_metadata"', 'metaId']);
+		});
+
+		it('should be a no-op on SQLite', async () => {
+			// SQLite is the default in beforeEach.
+			mockEntityManager.query = jest.fn();
+
+			await importService.advanceIdentitySequences(mockEntityManager, ['workflow_dependency']);
+
+			expect(mockEntityManager.query).not.toHaveBeenCalled();
+		});
+
+		it('should be a no-op when no tables are provided', async () => {
+			// @ts-expect-error overriding for the test
+			mockDataSource.options = { type: 'postgres' };
+			mockEntityManager.query = jest.fn();
+
+			await importService.advanceIdentitySequences(mockEntityManager, []);
+
+			expect(mockEntityManager.query).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/packages/cli/src/services/import.service.ts
+++ b/packages/cli/src/services/import.service.ts
@@ -444,6 +444,11 @@ export class ImportService {
 				customEncryptionKey,
 			);
 
+			// Postgres IDENTITY sequences don't auto-advance when explicit ids are
+			// inserted, so subsequent implicit inserts would collide. Reset each
+			// imported table's sequence to MAX(col).
+			await this.advanceIdentitySequences(transactionManager, tableNames);
+
 			// After the data_table / data_table_column registry rows are imported,
 			// recreate the dynamic backing tables (empty) so the imported tables work.
 			await this.recreateDataTableUserTablesFromRegistry(transactionManager);
@@ -710,6 +715,50 @@ export class ImportService {
 		}
 
 		this.logger.info(`✅ Recreated ${dataTables.length} data-table backing table(s)`);
+	}
+
+	/**
+	 * Advance Postgres IDENTITY sequences to MAX(col) for every identity column
+	 * in the given tables. No-op on SQLite, where INTEGER PRIMARY KEY auto-bumps
+	 * its rowid sequence on inserts with explicit ids.
+	 */
+	async advanceIdentitySequences(
+		transactionManager: EntityManager,
+		tableNames: string[],
+	): Promise<void> {
+		if (this.dataSource.options.type !== 'postgres') return;
+		if (tableNames.length === 0) return;
+
+		this.logger.info('\n🔢 Advancing Postgres IDENTITY sequences...');
+		let advanced = 0;
+
+		for (const tableName of tableNames) {
+			const identityColumns: Array<{ column_name: string }> = await transactionManager.query(
+				`SELECT column_name FROM information_schema.columns
+					WHERE table_schema = current_schema()
+						AND table_name = $1
+						AND identity_generation IS NOT NULL`,
+				[tableName],
+			);
+
+			if (identityColumns.length === 0) continue;
+
+			const escapedTable = this.dataSource.driver.escape(tableName);
+			for (const { column_name: columnName } of identityColumns) {
+				const escapedCol = this.dataSource.driver.escape(columnName);
+				await transactionManager.query(
+					`SELECT setval(
+						pg_get_serial_sequence($1, $2),
+						COALESCE((SELECT MAX(${escapedCol}) FROM ${escapedTable}), 1),
+						(SELECT MAX(${escapedCol}) FROM ${escapedTable}) IS NOT NULL
+					)`,
+					[escapedTable, columnName],
+				);
+				advanced++;
+			}
+		}
+
+		this.logger.info(`✅ Advanced ${advanced} sequence(s) across ${tableNames.length} table(s)`);
 	}
 
 	async disableForeignKeyConstraints(transactionManager: EntityManager) {


### PR DESCRIPTION
## Summary

Manually verified locally - workflow indexing no longer throws the error message I posted in the ticket.

Claude generated below:

The entity importer inserts rows with explicit ids, but Postgres IDENTITY sequences only advance on implicit (`nextval`-driven) inserts. After import, the next implicit insert into any affected table starts the sequence at 1, colliding with rows the import just wrote and failing the PK constraint.

This adds `advanceIdentitySequences` to `ImportService`, which runs `setval(pg_get_serial_sequence(table, col), MAX(col))` for every IDENTITY column in every imported table. SQLite is unaffected (its `INTEGER PRIMARY KEY` auto-bumps on explicit-id inserts), so the helper is gated on `dbType === 'postgres'`.

### How to reproduce (before this fix)

1. Run `n8n export:entities --outputDir=/tmp/export` against a SQLite instance with at least one workflow.
2. Run `n8n import:entities --inputDir=/tmp/export --truncateTables` against a fresh Postgres instance (matching encryption key).
3. Start that Postgres-backed n8n. The workflow-index builder runs on startup and errors:

   > duplicate key value violates unique constraint "PK_52325e34cd7a2f0f67b0f3cad65"

   Affects every imported table with an integer auto-id PK, including `workflow_dependency`, `workflow_publish_history`, `insights_by_period`, `insights_metadata`, and `user_favorites`.

### Verification

End-to-end smoke test against a fresh Postgres 16 container after import:

| table | MAX(id) | sequence last_value |
|---|---|---|
| workflow_dependency | 116 | 116 |
| workflow_publish_history | 13 | 13 |
| user_favorites | 2 | 2 |
| insights_metadata | 1 | 1 |
| insights_by_period | 12 | 12 |

Pre-fix `workflow_dependency` was at sequence value `12` against `MAX = 67`, which produced the duplicate-key error on the first downstream write.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5179 — discovered while testing https://linear.app/n8n/issue/ADO-5143 against Postgres.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. _(N/A — internal behavior fix, not user-facing)_
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)