### PR TITLE
fix(core): Allow profile edits when SSO is no longer active

### DIFF
--- a/packages/cli/src/controllers/__tests__/me.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/me.controller.test.ts
@@ -19,7 +19,22 @@ import { License } from '@/license';
 import { MfaService } from '@/mfa/mfa.service';
 import type { MeRequest } from '@/requests';
 import { UserService } from '@/services/user.service';
+import {
+	isSamlLicensedAndEnabled,
+	isLdapCurrentAuthenticationMethod,
+	isOidcCurrentAuthenticationMethod,
+} from '@/sso.ee/sso-helpers';
 import { badPasswords } from '@test/test-data';
+
+jest.mock('@/sso.ee/sso-helpers', () => ({
+	isSamlLicensedAndEnabled: jest.fn(),
+	isLdapCurrentAuthenticationMethod: jest.fn(),
+	isOidcCurrentAuthenticationMethod: jest.fn(),
+}));
+
+const isSamlLicensedAndEnabledMock = isSamlLicensedAndEnabled as jest.Mock;
+const isLdapCurrentAuthenticationMethodMock = isLdapCurrentAuthenticationMethod as jest.Mock;
+const isOidcCurrentAuthenticationMethodMock = isOidcCurrentAuthenticationMethod as jest.Mock;
 
 const browserId = 'test-browser-id';
 
@@ -34,26 +49,28 @@ describe('MeController', () => {
 	const controller = Container.get(MeController);
 
 	beforeEach(() => {
-		// Default: user has no SSO identities (email-based auth)
 		userService.findSsoIdentity.mockResolvedValue(undefined);
+		isSamlLicensedAndEnabledMock.mockReturnValue(false);
+		isLdapCurrentAuthenticationMethodMock.mockReturnValue(false);
+		isOidcCurrentAuthenticationMethodMock.mockReturnValue(false);
 	});
 
 	describe('updateCurrentUser', () => {
 		it('should update the user in the DB, and issue a new cookie', async () => {
-			const user = mock<User>({
+			const user = {
 				id: '123',
 				email: 'valid@email.com',
 				password: 'password',
 				authIdentities: [],
 				role: GLOBAL_OWNER_ROLE,
 				mfaEnabled: false,
-			});
+			} as unknown as User;
 			const payload = new UserUpdateRequestDto({
 				email: 'valid@email.com',
 				firstName: 'John',
 				lastName: 'Potato',
 			});
-			const req = mock<AuthenticatedRequest>({ user, browserId });
+			const req = { user, browserId } as unknown as AuthenticatedRequest;
 			const res = mock<Response>();
 			userRepository.findOneByOrFail.mockResolvedValue(user);
 			userService.findUserWithAuthIdentities.mockResolvedValue(user);
@@ -91,15 +108,15 @@ describe('MeController', () => {
 		});
 
 		it('should throw BadRequestError if beforeUpdate hook throws BadRequestError', async () => {
-			const user = mock<User>({
+			const user = {
 				id: '123',
 				password: 'password',
 				email: 'current@email.com',
 				authIdentities: [],
 				role: GLOBAL_OWNER_ROLE,
 				mfaEnabled: false,
-			});
-			const req = mock<AuthenticatedRequest>({ user });
+			} as unknown as User;
+			const req = { user } as unknown as AuthenticatedRequest;
 
 			externalHooks.run.mockImplementationOnce(async (hookName) => {
 				if (hookName === 'user.profile.beforeUpdate') {
@@ -118,7 +135,7 @@ describe('MeController', () => {
 
 		describe('when user is authenticated via LDAP or OIDC', () => {
 			it('should throw BadRequestError when LDAP user tries to change their profile', async () => {
-				const user = mock<User>({
+				const user = {
 					id: '123',
 					email: 'ldap@email.com',
 					firstName: 'John',
@@ -127,10 +144,13 @@ describe('MeController', () => {
 					authIdentities: [],
 					role: GLOBAL_OWNER_ROLE,
 					mfaEnabled: false,
-				});
-				const req = mock<AuthenticatedRequest>({ user, browserId });
+				} as unknown as User;
+				const req = { user, browserId } as unknown as AuthenticatedRequest;
 
-				userService.findSsoIdentity.mockResolvedValue(mock<AuthIdentity>({ providerType: 'ldap' }));
+				userService.findSsoIdentity.mockResolvedValue({
+					providerType: 'ldap',
+				} as unknown as AuthIdentity);
+				isLdapCurrentAuthenticationMethodMock.mockReturnValue(true);
 
 				await expect(
 					controller.updateCurrentUser(
@@ -148,7 +168,7 @@ describe('MeController', () => {
 			});
 
 			it('should throw BadRequestError when OIDC user tries to change their profile', async () => {
-				const user = mock<User>({
+				const user = {
 					id: '123',
 					email: 'oidc@email.com',
 					firstName: 'John',
@@ -157,10 +177,13 @@ describe('MeController', () => {
 					authIdentities: [],
 					role: GLOBAL_OWNER_ROLE,
 					mfaEnabled: false,
-				});
-				const req = mock<AuthenticatedRequest>({ user, browserId });
+				} as unknown as User;
+				const req = { user, browserId } as unknown as AuthenticatedRequest;
 
-				userService.findSsoIdentity.mockResolvedValue(mock<AuthIdentity>({ providerType: 'oidc' }));
+				userService.findSsoIdentity.mockResolvedValue({
+					providerType: 'oidc',
+				} as unknown as AuthIdentity);
+				isOidcCurrentAuthenticationMethodMock.mockReturnValue(true);
 
 				await expect(
 					controller.updateCurrentUser(
@@ -178,20 +201,20 @@ describe('MeController', () => {
 			});
 
 			it('should allow non-LDAP/OIDC users to update their profile', async () => {
-				const user = mock<User>({
+				const user = {
 					id: '123',
 					email: 'valid@email.com',
 					password: 'password',
 					authIdentities: [],
 					role: GLOBAL_OWNER_ROLE,
 					mfaEnabled: false,
-				});
+				} as unknown as User;
 				const payload = new UserUpdateRequestDto({
 					email: 'valid@email.com',
 					firstName: 'John',
 					lastName: 'Potato',
 				});
-				const req = mock<AuthenticatedRequest>({ user, browserId });
+				const req = { user, browserId } as unknown as AuthenticatedRequest;
 				const res = mock<Response>();
 
 				userRepository.findOneByOrFail.mockResolvedValue(user);
@@ -205,7 +228,7 @@ describe('MeController', () => {
 			});
 
 			it('should block user with multiple identities if one is LDAP', async () => {
-				const user = mock<User>({
+				const user = {
 					id: '123',
 					email: 'multi@email.com',
 					firstName: 'John',
@@ -214,11 +237,14 @@ describe('MeController', () => {
 					authIdentities: [],
 					role: GLOBAL_OWNER_ROLE,
 					mfaEnabled: false,
-				});
-				const req = mock<AuthenticatedRequest>({ user, browserId });
+				} as unknown as User;
+				const req = { user, browserId } as unknown as AuthenticatedRequest;
 
 				// User has multiple identities, one of which is LDAP - findSsoIdentity returns the SSO one
-				userService.findSsoIdentity.mockResolvedValue(mock<AuthIdentity>({ providerType: 'ldap' }));
+				userService.findSsoIdentity.mockResolvedValue({
+					providerType: 'ldap',
+				} as unknown as AuthIdentity);
+				isLdapCurrentAuthenticationMethodMock.mockReturnValue(true);
 
 				await expect(
 					controller.updateCurrentUser(
@@ -236,17 +262,260 @@ describe('MeController', () => {
 			});
 		});
 
+		describe('when an auth_identity exists but the SSO provider is no longer active', () => {
+			const passwordHash = '$2a$10$ffitcKrHT.Ls.m9FfWrMrOod76aaI0ogKbc3S96Q320impWpCbgj6'; // Hashed 'old_password'
+
+			const setUpdateMocks = (user: User) => {
+				userRepository.findOneByOrFail.mockResolvedValue(user);
+				userService.findUserWithAuthIdentities.mockResolvedValue(user);
+				jest.spyOn(jwt, 'sign').mockImplementation(() => 'signed-token');
+				userService.toPublic.mockResolvedValue({} as unknown as PublicUser);
+			};
+
+			it('should throw BadRequestError when SAML user tries to change their profile while SAML is enabled', async () => {
+				const user = {
+					id: '123',
+					email: 'saml@email.com',
+					firstName: 'John',
+					lastName: 'Doe',
+					password: 'password',
+					authIdentities: [],
+					role: GLOBAL_OWNER_ROLE,
+					mfaEnabled: false,
+				} as unknown as User;
+				const req = { user, browserId } as unknown as AuthenticatedRequest;
+
+				userService.findSsoIdentity.mockResolvedValue({
+					providerType: 'saml',
+				} as unknown as AuthIdentity);
+				isSamlLicensedAndEnabledMock.mockReturnValue(true);
+
+				await expect(
+					controller.updateCurrentUser(
+						req,
+						mock(),
+						new UserUpdateRequestDto({
+							email: 'saml@email.com',
+							firstName: 'Jane',
+							lastName: 'Doe',
+						}),
+					),
+				).rejects.toThrowError(
+					new BadRequestError('SAML user may not change their profile information'),
+				);
+			});
+
+			it('should allow profile update when SAML auth_identity exists but SAML is disabled', async () => {
+				const user = {
+					id: '123',
+					email: 'saml@email.com',
+					firstName: 'John',
+					lastName: 'Doe',
+					password: 'password',
+					authIdentities: [],
+					role: GLOBAL_OWNER_ROLE,
+					mfaEnabled: false,
+				} as unknown as User;
+				const payload = new UserUpdateRequestDto({
+					email: 'saml@email.com',
+					firstName: 'NewFirst',
+					lastName: 'NewLast',
+				});
+				const req = { user, browserId } as unknown as AuthenticatedRequest;
+				const res = mock<Response>();
+
+				userService.findSsoIdentity.mockResolvedValue({
+					providerType: 'saml',
+				} as unknown as AuthIdentity);
+				isSamlLicensedAndEnabledMock.mockReturnValue(false);
+				setUpdateMocks(user);
+
+				await controller.updateCurrentUser(req, res, payload);
+
+				expect(userService.update).toHaveBeenCalledWith(user.id, {
+					email: 'saml@email.com',
+					firstName: 'NewFirst',
+					lastName: 'NewLast',
+				});
+				expect(eventService.emit).toHaveBeenCalledWith('user-updated', {
+					user,
+					fieldsChanged: ['firstName', 'lastName'],
+				});
+			});
+
+			it('should allow profile update when LDAP auth_identity exists but LDAP is disabled', async () => {
+				const user = {
+					id: '123',
+					email: 'ldap@email.com',
+					firstName: 'John',
+					lastName: 'Doe',
+					password: 'password',
+					authIdentities: [],
+					role: GLOBAL_OWNER_ROLE,
+					mfaEnabled: false,
+				} as unknown as User;
+				const payload = new UserUpdateRequestDto({
+					email: 'ldap@email.com',
+					firstName: 'NewFirst',
+					lastName: 'NewLast',
+				});
+				const req = { user, browserId } as unknown as AuthenticatedRequest;
+				const res = mock<Response>();
+
+				userService.findSsoIdentity.mockResolvedValue({
+					providerType: 'ldap',
+				} as unknown as AuthIdentity);
+				isLdapCurrentAuthenticationMethodMock.mockReturnValue(false);
+				setUpdateMocks(user);
+
+				await controller.updateCurrentUser(req, res, payload);
+
+				expect(userService.update).toHaveBeenCalled();
+			});
+
+			it('should allow profile update when OIDC auth_identity exists but OIDC is disabled', async () => {
+				const user = {
+					id: '123',
+					email: 'oidc@email.com',
+					firstName: 'John',
+					lastName: 'Doe',
+					password: 'password',
+					authIdentities: [],
+					role: GLOBAL_OWNER_ROLE,
+					mfaEnabled: false,
+				} as unknown as User;
+				const payload = new UserUpdateRequestDto({
+					email: 'oidc@email.com',
+					firstName: 'NewFirst',
+					lastName: 'NewLast',
+				});
+				const req = { user, browserId } as unknown as AuthenticatedRequest;
+				const res = mock<Response>();
+
+				userService.findSsoIdentity.mockResolvedValue({
+					providerType: 'oidc',
+				} as unknown as AuthIdentity);
+				isOidcCurrentAuthenticationMethodMock.mockReturnValue(false);
+				setUpdateMocks(user);
+
+				await controller.updateCurrentUser(req, res, payload);
+
+				expect(userService.update).toHaveBeenCalled();
+			});
+
+			it('should allow email change for previously-SAML user once SAML is disabled', async () => {
+				const user = {
+					id: '123',
+					email: 'saml-old@email.com',
+					firstName: 'John',
+					lastName: 'Doe',
+					password: passwordHash,
+					authIdentities: [],
+					role: GLOBAL_OWNER_ROLE,
+					mfaEnabled: false,
+				} as unknown as User;
+				const req = { user, browserId } as unknown as AuthenticatedRequest;
+				const res = mock<Response>();
+
+				userService.findSsoIdentity.mockResolvedValue({
+					providerType: 'saml',
+				} as unknown as AuthIdentity);
+				isSamlLicensedAndEnabledMock.mockReturnValue(false);
+				setUpdateMocks(user);
+
+				await controller.updateCurrentUser(
+					req,
+					res,
+					new UserUpdateRequestDto({
+						email: 'saml-new@email.com',
+						firstName: 'John',
+						lastName: 'Doe',
+						currentPassword: 'old_password',
+					}),
+				);
+
+				expect(userService.update).toHaveBeenCalled();
+			});
+
+			it('should allow profile update when providerType is token-exchange', async () => {
+				const user = {
+					id: '123',
+					email: 'token@email.com',
+					firstName: 'John',
+					lastName: 'Doe',
+					password: 'password',
+					authIdentities: [],
+					role: GLOBAL_OWNER_ROLE,
+					mfaEnabled: false,
+				} as unknown as User;
+				const req = { user, browserId } as unknown as AuthenticatedRequest;
+				const res = mock<Response>();
+
+				userService.findSsoIdentity.mockResolvedValue({
+					providerType: 'token-exchange',
+				} as unknown as AuthIdentity);
+				setUpdateMocks(user);
+
+				await controller.updateCurrentUser(
+					req,
+					res,
+					new UserUpdateRequestDto({
+						email: 'token@email.com',
+						firstName: 'NewFirst',
+						lastName: 'NewLast',
+					}),
+				);
+
+				expect(userService.update).toHaveBeenCalled();
+			});
+
+			it('should bypass the SSO guard when no profile fields are changing', async () => {
+				const user = {
+					id: '123',
+					email: 'unchanged@email.com',
+					firstName: 'Same',
+					lastName: 'Name',
+					password: 'password',
+					authIdentities: [],
+					role: GLOBAL_OWNER_ROLE,
+					mfaEnabled: false,
+				} as unknown as User;
+				const req = { user, browserId } as unknown as AuthenticatedRequest;
+				const res = mock<Response>();
+
+				userService.findSsoIdentity.mockClear();
+				userService.findSsoIdentity.mockResolvedValue({
+					providerType: 'saml',
+				} as unknown as AuthIdentity);
+				isSamlLicensedAndEnabledMock.mockReturnValue(true);
+				setUpdateMocks(user);
+
+				await controller.updateCurrentUser(
+					req,
+					res,
+					new UserUpdateRequestDto({
+						email: 'unchanged@email.com',
+						firstName: 'Same',
+						lastName: 'Name',
+					}),
+				);
+
+				expect(userService.findSsoIdentity).not.toHaveBeenCalled();
+				expect(userService.update).toHaveBeenCalled();
+			});
+		});
+
 		describe('when mfa is enabled', () => {
 			it('should throw BadRequestError if mfa code is missing', async () => {
-				const user = mock<User>({
+				const user = {
 					id: '123',
 					email: 'valid@email.com',
 					password: 'password',
 					authIdentities: [],
 					role: GLOBAL_OWNER_ROLE,
 					mfaEnabled: true,
-				});
-				const req = mock<AuthenticatedRequest>({ user, browserId });
+				} as unknown as User;
+				const req = { user, browserId } as unknown as AuthenticatedRequest;
 
 				await expect(
 					controller.updateCurrentUser(
@@ -262,15 +531,15 @@ describe('MeController', () => {
 			});
 
 			it('should throw InvalidMfaCodeError if mfa code is invalid', async () => {
-				const user = mock<User>({
+				const user = {
 					id: '123',
 					email: 'valid@email.com',
 					password: 'password',
 					authIdentities: [],
 					role: GLOBAL_OWNER_ROLE,
 					mfaEnabled: true,
-				});
-				const req = mock<AuthenticatedRequest>({ user, browserId });
+				} as unknown as User;
+				const req = { user, browserId } as unknown as AuthenticatedRequest;
 				mockMfaService.validateMfa.mockResolvedValue(false);
 
 				await expect(
@@ -288,7 +557,7 @@ describe('MeController', () => {
 			});
 
 			it("should update the user's email if mfa code is valid", async () => {
-				const user = mock<User>({
+				const user = {
 					id: '123',
 					email: 'valid@email.com',
 					password: 'password',
@@ -296,8 +565,8 @@ describe('MeController', () => {
 					role: GLOBAL_OWNER_ROLE,
 					mfaEnabled: true,
 					mfaSecret: 'secret',
-				});
-				const req = mock<AuthenticatedRequest>({ user, browserId });
+				} as unknown as User;
+				const req = { user, browserId } as unknown as AuthenticatedRequest;
 				const res = mock<Response>();
 				userRepository.findOneByOrFail.mockResolvedValue(user);
 				userService.findUserWithAuthIdentities.mockResolvedValue(user);
@@ -325,13 +594,13 @@ describe('MeController', () => {
 			const passwordHash = '$2a$10$ffitcKrHT.Ls.m9FfWrMrOod76aaI0ogKbc3S96Q320impWpCbgj6'; // Hashed 'old_password'
 
 			it('should throw BadRequestError if currentPassword is missing', async () => {
-				const user = mock<User>({
+				const user = {
 					id: '123',
 					email: 'michel-old@email.com',
 					password: passwordHash,
 					mfaEnabled: false,
-				});
-				const req = mock<AuthenticatedRequest>({ user, browserId });
+				} as unknown as User;
+				const req = { user, browserId } as unknown as AuthenticatedRequest;
 
 				await expect(
 					controller.updateCurrentUser(
@@ -347,13 +616,13 @@ describe('MeController', () => {
 			});
 
 			it('should throw BadRequestError if currentPassword is not a string', async () => {
-				const user = mock<User>({
+				const user = {
 					id: '123',
 					email: 'michel-old@email.com',
 					password: passwordHash,
 					mfaEnabled: false,
-				});
-				const req = mock<AuthenticatedRequest>({ user, browserId });
+				} as unknown as User;
+				const req = { user, browserId } as unknown as AuthenticatedRequest;
 
 				await expect(
 					controller.updateCurrentUser(req, mock(), {
@@ -366,12 +635,12 @@ describe('MeController', () => {
 			});
 
 			it('should throw BadRequestError if currentPassword is incorrect', async () => {
-				const user = mock<User>({
+				const user = {
 					email: 'michel-old@email.com',
 					password: passwordHash,
 					mfaEnabled: false,
-				});
-				const req = mock<AuthenticatedRequest>({ user, browserId });
+				} as unknown as User;
+				const req = { user, browserId } as unknown as AuthenticatedRequest;
 
 				await expect(
 					controller.updateCurrentUser(
@@ -392,12 +661,13 @@ describe('MeController', () => {
 			});
 
 			it('should update the user email if currentPassword is correct', async () => {
-				const user = mock<User>({
+				const user = {
 					email: 'michel-old@email.com',
 					password: passwordHash,
 					mfaEnabled: false,
-				});
-				const req = mock<AuthenticatedRequest>({ user, browserId });
+					role: GLOBAL_OWNER_ROLE,
+				} as unknown as User;
+				const req = { user, browserId } as unknown as AuthenticatedRequest;
 				const res = mock<Response>();
 				userRepository.findOneByOrFail.mockResolvedValue(user);
 				userService.findUserWithAuthIdentities.mockResolvedValue(user);
@@ -420,12 +690,13 @@ describe('MeController', () => {
 			});
 
 			it('should not require currentPassword when email is not being changed', async () => {
-				const user = mock<User>({
+				const user = {
 					email: 'michel@email.com',
 					password: passwordHash,
 					mfaEnabled: false,
-				});
-				const req = mock<AuthenticatedRequest>({ user, browserId });
+					role: GLOBAL_OWNER_ROLE,
+				} as unknown as User;
+				const req = { user, browserId } as unknown as AuthenticatedRequest;
 				const res = mock<Response>();
 				userRepository.findOneByOrFail.mockResolvedValue(user);
 				userService.findUserWithAuthIdentities.mockResolvedValue(user);
@@ -462,13 +733,13 @@ describe('MeController', () => {
 		});
 
 		it('should reject profile update for env-managed user', async () => {
-			const user = mock<User>({
+			const user = {
 				id: '123',
 				email: 'managed@example.com',
 				password: 'password',
 				role: GLOBAL_OWNER_ROLE,
-			});
-			const req = mock<AuthenticatedRequest>({ user, browserId });
+			} as unknown as User;
+			const req = { user, browserId } as unknown as AuthenticatedRequest;
 
 			await expect(
 				controller.updateCurrentUser(
@@ -484,12 +755,12 @@ describe('MeController', () => {
 		});
 
 		it('should reject password update for env-managed user', async () => {
-			const req = mock<AuthenticatedRequest>({
-				user: mock<User>({
+			const req = {
+				user: {
 					email: 'managed@example.com',
 					password: '$2a$10$ffitcKrHT.Ls.m9FfWrMrOod76aaI0ogKbc3S96Q320impWpCbgj6',
-				}),
-			});
+				} as unknown as User,
+			} as unknown as AuthenticatedRequest;
 
 			await expect(
 				controller.updatePassword(
@@ -505,15 +776,15 @@ describe('MeController', () => {
 		});
 
 		it('should allow profile update for non-env-managed owner', async () => {
-			const user = mock<User>({
+			const user = {
 				id: '456',
 				email: 'other-owner@example.com',
 				password: 'password',
 				authIdentities: [],
 				role: GLOBAL_OWNER_ROLE,
 				mfaEnabled: false,
-			});
-			const req = mock<AuthenticatedRequest>({ user, browserId });
+			} as unknown as User;
+			const req = { user, browserId } as unknown as AuthenticatedRequest;
 			const res = mock<Response>();
 			userRepository.findOneByOrFail.mockResolvedValue(user);
 			userService.findUserWithAuthIdentities.mockResolvedValue(user);
@@ -534,18 +805,18 @@ describe('MeController', () => {
 		const passwordHash = '$2a$10$ffitcKrHT.Ls.m9FfWrMrOod76aaI0ogKbc3S96Q320impWpCbgj6'; // Hashed 'old_password'
 
 		it('should throw if the user does not have a password set', async () => {
-			const req = mock<AuthenticatedRequest>({
+			const req = {
 				user: mock({ password: undefined }),
-			});
+			} as unknown as AuthenticatedRequest;
 			await expect(
 				controller.updatePassword(req, mock(), mock({ currentPassword: '', newPassword: '' })),
 			).rejects.toThrowError(new BadRequestError('Requesting user not set up.'));
 		});
 
 		it("should throw if currentPassword does not match the user's password", async () => {
-			const req = mock<AuthenticatedRequest>({
+			const req = {
 				user: mock({ password: passwordHash }),
-			});
+			} as unknown as AuthenticatedRequest;
 			await expect(
 				controller.updatePassword(
 					req,
@@ -558,10 +829,10 @@ describe('MeController', () => {
 		describe('should throw if newPassword is not valid', () => {
 			Object.entries(badPasswords).forEach(([newPassword, errorMessage]) => {
 				it(newPassword, async () => {
-					const req = mock<AuthenticatedRequest>({
+					const req = {
 						user: mock({ password: passwordHash }),
 						browserId,
-					});
+					} as unknown as AuthenticatedRequest;
 					await expect(
 						controller.updatePassword(
 							req,
@@ -574,10 +845,10 @@ describe('MeController', () => {
 		});
 
 		it('should update the password in the DB, and issue a new cookie', async () => {
-			const req = mock<AuthenticatedRequest>({
+			const req = {
 				user: mock({ password: passwordHash, mfaEnabled: false }),
 				browserId,
-			});
+			} as unknown as AuthenticatedRequest;
 			const res = mock<Response>();
 			userRepository.save.calledWith(req.user).mockResolvedValue(req.user);
 			jest.spyOn(jwt, 'sign').mockImplementation(() => 'new-signed-token');
@@ -614,9 +885,9 @@ describe('MeController', () => {
 
 		describe('mfa enabled', () => {
 			it('should throw BadRequestError if mfa code is missing', async () => {
-				const req = mock<AuthenticatedRequest>({
+				const req = {
 					user: mock({ password: passwordHash, mfaEnabled: true }),
-				});
+				} as unknown as AuthenticatedRequest;
 
 				await expect(
 					controller.updatePassword(
@@ -630,9 +901,9 @@ describe('MeController', () => {
 			});
 
 			it('should throw InvalidMfaCodeError if invalid mfa code is given', async () => {
-				const req = mock<AuthenticatedRequest>({
+				const req = {
 					user: mock({ password: passwordHash, mfaEnabled: true }),
-				});
+				} as unknown as AuthenticatedRequest;
 				mockMfaService.validateMfa.mockResolvedValue(false);
 
 				await expect(
@@ -649,10 +920,10 @@ describe('MeController', () => {
 			});
 
 			it('should succeed when mfa code is correct', async () => {
-				const req = mock<AuthenticatedRequest>({
+				const req = {
 					user: mock({ password: passwordHash, mfaEnabled: true, mfaSecret: 'secret' }),
 					browserId,
-				});
+				} as unknown as AuthenticatedRequest;
 				const res = mock<Response>();
 				userRepository.save.calledWith(req.user).mockResolvedValue(req.user);
 				jest.spyOn(jwt, 'sign').mockImplementation(() => 'new-signed-token');

--- a/packages/cli/src/controllers/__tests__/me.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/me.controller.test.ts
@@ -19,22 +19,15 @@ import { License } from '@/license';
 import { MfaService } from '@/mfa/mfa.service';
 import type { MeRequest } from '@/requests';
 import { UserService } from '@/services/user.service';
-import {
-	isSamlLicensedAndEnabled,
-	isLdapCurrentAuthenticationMethod,
-	isOidcCurrentAuthenticationMethod,
-} from '@/sso.ee/sso-helpers';
+import { getCurrentAuthenticationMethod } from '@/sso.ee/sso-helpers';
 import { badPasswords } from '@test/test-data';
 
 jest.mock('@/sso.ee/sso-helpers', () => ({
-	isSamlLicensedAndEnabled: jest.fn(),
-	isLdapCurrentAuthenticationMethod: jest.fn(),
-	isOidcCurrentAuthenticationMethod: jest.fn(),
+	...jest.requireActual('@/sso.ee/sso-helpers'),
+	getCurrentAuthenticationMethod: jest.fn(),
 }));
 
-const isSamlLicensedAndEnabledMock = isSamlLicensedAndEnabled as jest.Mock;
-const isLdapCurrentAuthenticationMethodMock = isLdapCurrentAuthenticationMethod as jest.Mock;
-const isOidcCurrentAuthenticationMethodMock = isOidcCurrentAuthenticationMethod as jest.Mock;
+const getCurrentAuthenticationMethodMock = getCurrentAuthenticationMethod as jest.Mock;
 
 const browserId = 'test-browser-id';
 
@@ -50,9 +43,7 @@ describe('MeController', () => {
 
 	beforeEach(() => {
 		userService.findSsoIdentity.mockResolvedValue(undefined);
-		isSamlLicensedAndEnabledMock.mockReturnValue(false);
-		isLdapCurrentAuthenticationMethodMock.mockReturnValue(false);
-		isOidcCurrentAuthenticationMethodMock.mockReturnValue(false);
+		getCurrentAuthenticationMethodMock.mockReturnValue('email');
 	});
 
 	describe('updateCurrentUser', () => {
@@ -150,7 +141,7 @@ describe('MeController', () => {
 				userService.findSsoIdentity.mockResolvedValue({
 					providerType: 'ldap',
 				} as unknown as AuthIdentity);
-				isLdapCurrentAuthenticationMethodMock.mockReturnValue(true);
+				getCurrentAuthenticationMethodMock.mockReturnValue('ldap');
 
 				await expect(
 					controller.updateCurrentUser(
@@ -183,7 +174,7 @@ describe('MeController', () => {
 				userService.findSsoIdentity.mockResolvedValue({
 					providerType: 'oidc',
 				} as unknown as AuthIdentity);
-				isOidcCurrentAuthenticationMethodMock.mockReturnValue(true);
+				getCurrentAuthenticationMethodMock.mockReturnValue('oidc');
 
 				await expect(
 					controller.updateCurrentUser(
@@ -244,7 +235,7 @@ describe('MeController', () => {
 				userService.findSsoIdentity.mockResolvedValue({
 					providerType: 'ldap',
 				} as unknown as AuthIdentity);
-				isLdapCurrentAuthenticationMethodMock.mockReturnValue(true);
+				getCurrentAuthenticationMethodMock.mockReturnValue('ldap');
 
 				await expect(
 					controller.updateCurrentUser(
@@ -288,7 +279,7 @@ describe('MeController', () => {
 				userService.findSsoIdentity.mockResolvedValue({
 					providerType: 'saml',
 				} as unknown as AuthIdentity);
-				isSamlLicensedAndEnabledMock.mockReturnValue(true);
+				getCurrentAuthenticationMethodMock.mockReturnValue('saml');
 
 				await expect(
 					controller.updateCurrentUser(
@@ -327,7 +318,6 @@ describe('MeController', () => {
 				userService.findSsoIdentity.mockResolvedValue({
 					providerType: 'saml',
 				} as unknown as AuthIdentity);
-				isSamlLicensedAndEnabledMock.mockReturnValue(false);
 				setUpdateMocks(user);
 
 				await controller.updateCurrentUser(req, res, payload);
@@ -365,7 +355,6 @@ describe('MeController', () => {
 				userService.findSsoIdentity.mockResolvedValue({
 					providerType: 'ldap',
 				} as unknown as AuthIdentity);
-				isLdapCurrentAuthenticationMethodMock.mockReturnValue(false);
 				setUpdateMocks(user);
 
 				await controller.updateCurrentUser(req, res, payload);
@@ -395,7 +384,6 @@ describe('MeController', () => {
 				userService.findSsoIdentity.mockResolvedValue({
 					providerType: 'oidc',
 				} as unknown as AuthIdentity);
-				isOidcCurrentAuthenticationMethodMock.mockReturnValue(false);
 				setUpdateMocks(user);
 
 				await controller.updateCurrentUser(req, res, payload);
@@ -420,7 +408,6 @@ describe('MeController', () => {
 				userService.findSsoIdentity.mockResolvedValue({
 					providerType: 'saml',
 				} as unknown as AuthIdentity);
-				isSamlLicensedAndEnabledMock.mockReturnValue(false);
 				setUpdateMocks(user);
 
 				await controller.updateCurrentUser(
@@ -487,7 +474,7 @@ describe('MeController', () => {
 				userService.findSsoIdentity.mockResolvedValue({
 					providerType: 'saml',
 				} as unknown as AuthIdentity);
-				isSamlLicensedAndEnabledMock.mockReturnValue(true);
+				getCurrentAuthenticationMethodMock.mockReturnValue('saml');
 				setUpdateMocks(user);
 
 				await controller.updateCurrentUser(

--- a/packages/cli/src/controllers/me.controller.ts
+++ b/packages/cli/src/controllers/me.controller.ts
@@ -24,6 +24,7 @@ import { MeRequest } from '@/requests';
 import { PasswordUtility } from '@/services/password.utility';
 import { UserService } from '@/services/user.service';
 import {
+	getCurrentAuthenticationMethod,
 	isLdapCurrentAuthenticationMethod,
 	isOidcCurrentAuthenticationMethod,
 	isSamlLicensedAndEnabled,
@@ -185,15 +186,7 @@ export class MeController {
 	}
 
 	private isAuthIdentityActive(authIdentity: AuthIdentity) {
-		switch (authIdentity.providerType) {
-			case 'saml':
-				return isSamlLicensedAndEnabled();
-			case 'oidc':
-				return isOidcCurrentAuthenticationMethod();
-			case 'ldap':
-				return isLdapCurrentAuthenticationMethod();
-		}
-		return false;
+		return authIdentity.providerType === getCurrentAuthenticationMethod();
 	}
 
 	/**

--- a/packages/cli/src/controllers/me.controller.ts
+++ b/packages/cli/src/controllers/me.controller.ts
@@ -23,12 +23,7 @@ import { MfaService } from '@/mfa/mfa.service';
 import { MeRequest } from '@/requests';
 import { PasswordUtility } from '@/services/password.utility';
 import { UserService } from '@/services/user.service';
-import {
-	getCurrentAuthenticationMethod,
-	isLdapCurrentAuthenticationMethod,
-	isOidcCurrentAuthenticationMethod,
-	isSamlLicensedAndEnabled,
-} from '@/sso.ee/sso-helpers';
+import { getCurrentAuthenticationMethod, isSamlLicensedAndEnabled } from '@/sso.ee/sso-helpers';
 
 import { PersonalizationSurveyAnswersV4 } from './survey-answers.dto';
 

--- a/packages/cli/src/controllers/me.controller.ts
+++ b/packages/cli/src/controllers/me.controller.ts
@@ -6,7 +6,7 @@ import {
 } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
-import type { User, PublicUser } from '@n8n/db';
+import type { User, PublicUser, AuthIdentity } from '@n8n/db';
 import { UserRepository, AuthenticatedRequest } from '@n8n/db';
 import { Body, createUserKeyedRateLimiter, Patch, Post, RestController } from '@n8n/decorators';
 import { plainToInstance } from 'class-transformer';
@@ -23,7 +23,11 @@ import { MfaService } from '@/mfa/mfa.service';
 import { MeRequest } from '@/requests';
 import { PasswordUtility } from '@/services/password.utility';
 import { UserService } from '@/services/user.service';
-import { isSamlLicensedAndEnabled } from '@/sso.ee/sso-helpers';
+import {
+	isLdapCurrentAuthenticationMethod,
+	isOidcCurrentAuthenticationMethod,
+	isSamlLicensedAndEnabled,
+} from '@/sso.ee/sso-helpers';
 
 import { PersonalizationSurveyAnswersV4 } from './survey-answers.dto';
 
@@ -73,7 +77,7 @@ export class MeController {
 		if (isEmailBeingChanged || isFirstNameChanged || isLastNameChanged) {
 			const ssoIdentity = await this.userService.findSsoIdentity(userId);
 
-			if (ssoIdentity) {
+			if (ssoIdentity && this.isAuthIdentityActive(ssoIdentity)) {
 				this.logger.debug(
 					`Request to update user failed because ${ssoIdentity.providerType} user may not change their profile information`,
 					{
@@ -178,6 +182,18 @@ export class MeController {
 			!!user.email &&
 			user.email.toLowerCase() === instanceSettingsLoader.ownerEmail.toLowerCase()
 		);
+	}
+
+	private isAuthIdentityActive(authIdentity: AuthIdentity) {
+		switch (authIdentity.providerType) {
+			case 'saml':
+				return isSamlLicensedAndEnabled();
+			case 'oidc':
+				return isOidcCurrentAuthenticationMethod();
+			case 'ldap':
+				return isLdapCurrentAuthenticationMethod();
+		}
+		return false;
 	}
 
 	/**

--- a/packages/cli/test/integration/saml/saml.api.test.ts
+++ b/packages/cli/test/integration/saml/saml.api.test.ts
@@ -12,7 +12,14 @@ import {
 	randomValidPassword,
 } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
-import { type User, UserRepository, RoleRepository, RoleMappingRuleRepository } from '@n8n/db';
+import {
+	AuthIdentity,
+	AuthIdentityRepository,
+	type User,
+	UserRepository,
+	RoleRepository,
+	RoleMappingRuleRepository,
+} from '@n8n/db';
 import { Container } from '@n8n/di';
 import type express from 'express';
 import { CREDENTIAL_BLANKING_VALUE } from 'n8n-workflow';
@@ -43,11 +50,17 @@ import * as utils from '../shared/utils/';
 
 let someUser: User;
 let owner: User;
+let samlUser: User;
 let authMemberAgent: SuperAgentTest;
 let authOwnerAgent: SuperAgentTest;
+let authSamlUserAgent: SuperAgentTest;
 
 async function enableSaml(enable: boolean) {
 	await setSamlLoginEnabled(enable);
+}
+
+async function attachSamlIdentity(user: User, providerId: string) {
+	await Container.get(AuthIdentityRepository).save(AuthIdentity.create(user, providerId, 'saml'));
 }
 
 const testServer = utils.setupTestServer({
@@ -56,12 +69,16 @@ const testServer = utils.setupTestServer({
 });
 
 const memberPassword = randomValidPassword();
+const samlUserPassword = randomValidPassword();
 
 beforeAll(async () => {
 	owner = await createOwner();
 	someUser = await createUser({ password: memberPassword });
+	samlUser = await createUser({ password: samlUserPassword });
+	await attachSamlIdentity(samlUser, `saml-${samlUser.id}`);
 	authOwnerAgent = testServer.authAgentFor(owner);
 	authMemberAgent = testServer.authAgentFor(someUser);
+	authSamlUserAgent = testServer.authAgentFor(samlUser);
 	Container.get(GlobalConfig).sso.saml.loginEnabled = true;
 });
 
@@ -91,6 +108,63 @@ describe('Instance owner', () => {
 					lastName: randomName(),
 				})
 				.expect(400, { code: 400, message: 'SAML user may not change their email' });
+		});
+	});
+
+	describe('PATCH /me for a user with a SAML auth_identity', () => {
+		test('should reject profile update while SAML is enabled', async () => {
+			await enableSaml(true);
+			await authSamlUserAgent
+				.patch('/me')
+				.send({
+					email: samlUser.email,
+					firstName: 'NewFirst',
+					lastName: samlUser.lastName,
+				})
+				.expect(400, {
+					code: 400,
+					message: 'SAML user may not change their profile information',
+				});
+		});
+
+		test('should allow profile update once SAML is disabled', async () => {
+			await enableSaml(false);
+			const newFirstName = randomName();
+			const newLastName = randomName();
+
+			await authSamlUserAgent
+				.patch('/me')
+				.send({
+					email: samlUser.email,
+					firstName: newFirstName,
+					lastName: newLastName,
+				})
+				.expect(200);
+
+			const refreshed = await Container.get(UserRepository).findOneByOrFail({ id: samlUser.id });
+			expect(refreshed.firstName).toBe(newFirstName);
+			expect(refreshed.lastName).toBe(newLastName);
+			samlUser.firstName = newFirstName;
+			samlUser.lastName = newLastName;
+		});
+
+		test('should allow email change once SAML is disabled', async () => {
+			await enableSaml(false);
+			const newEmail = randomEmail();
+
+			await authSamlUserAgent
+				.patch('/me')
+				.send({
+					email: newEmail,
+					firstName: samlUser.firstName,
+					lastName: samlUser.lastName,
+					currentPassword: samlUserPassword,
+				})
+				.expect(200);
+
+			const refreshed = await Container.get(UserRepository).findOneByOrFail({ id: samlUser.id });
+			expect(refreshed.email).toBe(newEmail);
+			samlUser.email = newEmail;
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/core/auth/views/SettingsPersonalView.vue
+++ b/packages/frontend/editor-ui/src/features/core/auth/views/SettingsPersonalView.vue
@@ -100,7 +100,9 @@ const isExternalAuthEnabled = computed((): boolean => {
 		ssoStore.isEnterpriseLdapEnabled && currentUser.value?.signInType === 'ldap';
 	const isSamlEnabled = ssoStore.isSamlLoginEnabled && ssoStore.isDefaultAuthenticationSaml;
 	const isOidcEnabled =
-		ssoStore.isEnterpriseOidcEnabled && currentUser.value?.signInType === 'oidc';
+		ssoStore.isEnterpriseOidcEnabled &&
+		ssoStore.isOidcLoginEnabled &&
+		currentUser.value?.signInType === 'oidc';
 	return isLdapEnabled || isSamlEnabled || isOidcEnabled;
 });
 


### PR DESCRIPTION
## Summary

After enabling and then disabling SAML SSO, users who previously authenticated via SAML were permanently blocked from updating their profile (name, email) through `PATCH /me`. The endpoint returned `400: "SAML user may not change their profile information"`, requiring a manual `auth_identity` row deletion in the database to unblock them.

The guard at `me.controller.ts` checked only for the existence of an `auth_identity` row; it did not check whether the user's SSO provider was still active. This PR fixes the guard so it gates on the matching provider also being currently licensed/enabled, restoring profile-edit capability when SSO has been switched off.

## Why

Bug report: an instance owner enabled SAML, authenticated through it (which created their `auth_identity` row), then disabled SAML to fall back to email auth. The `auth_identity` row persists by design (it's still meaningful data in case SAML is re-enabled), but the profile guard was ignoring whether the provider was actually serving traffic. Net effect: a high-impact lockout in an Enterprise feature surface, with the only workaround being a DB row deletion.

## How to test manually

Prerequisites: a self-hosted instance with the SAML feature licensed (`feat:saml`).

1. Sign in as the instance owner with email auth.
2. Enable SAML SSO (Settings → SSO → SAML), point it at any IdP, complete the loginEnabled toggle.
3. Authenticate as the owner via SAML (creates the `auth_identity` row of type `saml`).
4. Disable SAML SSO (toggle `loginEnabled` off).
5. Go to Settings → Personal and change the first name. Save.
   - **Before this PR**: `400 "SAML user may not change their profile information"`.
   - **After this PR**: `200`, profile updates persist.
6. Re-enable SAML and repeat step 5 — the request should be rejected again with `400` (regression guard).
7. Repeat the cycle for an OIDC-enabled instance — same behavior expected (profile edits allowed when OIDC is disabled, blocked while OIDC is the active method).

Edge cases covered by automated tests:
- LDAP active vs. disabled with a stale `ldap` `auth_identity`.
- Email change is also unblocked once SAML is disabled (separate guard inside `validateChangingUserEmail`).
- A `token-exchange` `auth_identity` no longer blocks profile edits regardless of OIDC state.
- Email-only users (no `auth_identity`) are unaffected.

## Key implementation decisions

- **Per-provider active check.** Added `isAuthIdentityActive(authIdentity)` to `MeController`, dispatching on `providerType`:
  - `saml` → `isSamlLicensedAndEnabled()`
  - `oidc` → `isOidcCurrentAuthenticationMethod()`
  - `ldap` → `isLdapCurrentAuthenticationMethod()`
  - default (incl. `token-exchange`) → `false`
  Chose this over a single "is the user's provider the current auth method?" check so each provider can keep its own licensing/enable semantics (SAML in particular must also be licensed, not just current).
- **No `auth_identity` cleanup on SSO disable.** Considered but rejected — the rows are intentionally retained so re-enabling the provider doesn't lose binding state. Fixing the guard is the correct layer.
- **Test layer split.**
  - Unit tests in `me.controller.test.ts` cover the guard branches (SAML/LDAP/OIDC active vs inactive, `token-exchange`, no-op payload).
  - One integration test in `saml/saml.api.test.ts` exercises the full flow with a real DB and the `setSamlLoginEnabled` toggle, mirroring the reported repro.
- **Test performance.** Refactored the `me.controller.test.ts` away from `mock<User>(...)` / `mock<AuthIdentity>(...)` / `mock<AuthenticatedRequest>(...)` to plain literals + `as unknown as Type` casts. The `jest-mock-extended` deep proxies were causing severe super-linear slowdown when many tests ran in the same file (CI saw the file at **436 s**, with `should allow profile update for non-env-managed owner` alone at **322 s**). After the refactor the whole file runs in **~3 s** (47 tests). The slow tests were not new — they have been silently dominating backend unit-test wall time.

## Related Links

- Linear ticket: https://linear.app/n8n/issue/IAM-581

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
