### PR TITLE
fix(core): Log errors from fire-and-forget test webhook deactivation (no-changelog)

### DIFF
--- a/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
@@ -1,3 +1,4 @@
+import type { Logger } from '@n8n/backend-common';
 import type { WorkflowEntity } from '@n8n/db';
 import { generateNanoId } from '@n8n/db';
 import type * as express from 'express';
@@ -43,10 +44,12 @@ const webhook = mock<IWebhookData>({
 });
 
 describe('TestWebhooks', () => {
+	const logger = mock<Logger>();
 	const registrations = mock<TestWebhookRegistrationsService>();
 	const webhookService = mock<WebhookService>();
 
 	const testWebhooks = new TestWebhooks(
+		logger,
 		mock(),
 		mock(),
 		registrations,

--- a/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/test-webhooks.test.ts
@@ -474,6 +474,31 @@ describe('TestWebhooks', () => {
 			expect(acquireOrder).toBeLessThan(deactivateOrder);
 			expect(deactivateOrder).toBeLessThan(releaseOrder);
 		});
+
+		test('releases isolate and logs when deactivateWebhooks throws', async () => {
+			const expression = mock<WorkflowExpression>();
+			const workflow = mock<Workflow>({ id: workflowEntity.id, expression });
+
+			jest.spyOn(testWebhooks, 'toWorkflow').mockReturnValue(workflow);
+			registrations.getAllKeys.mockResolvedValue(['key1']);
+			registrations.get.mockResolvedValue({
+				version: 1,
+				workflowEntity,
+				webhook,
+			} as TestWebhookRegistration);
+			const error = new Error('boom');
+			jest.spyOn(testWebhooks, 'deactivateWebhooks').mockRejectedValue(error);
+
+			await testWebhooks.cancelWebhook(workflowEntity.id);
+			await flushMicrotasks();
+
+			expect(expression.acquireIsolate).toHaveBeenCalledTimes(1);
+			expect(expression.releaseIsolate).toHaveBeenCalledTimes(1);
+			expect(logger.error).toHaveBeenCalledWith(
+				'Failed to deactivate test webhooks on cancel',
+				expect.objectContaining({ error, workflowId: workflowEntity.id }),
+			);
+		});
 	});
 
 	describe('handleClearTestWebhooks()', () => {

--- a/packages/cli/src/webhooks/test-webhooks.ts
+++ b/packages/cli/src/webhooks/test-webhooks.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@n8n/backend-common';
 import { OnPubSubEvent } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import type express from 'express';
@@ -53,6 +54,7 @@ const SINGLE_WEBHOOK_TRIGGERS = [
 @Service()
 export class TestWebhooks implements IWebhookManager {
 	constructor(
+		private readonly logger: Logger,
 		private readonly push: Push,
 		private readonly nodeTypes: NodeTypes,
 		private readonly registrations: TestWebhookRegistrationsService,
@@ -488,7 +490,12 @@ export class TestWebhooks implements IWebhookManager {
 					} finally {
 						await workflow.expression.releaseIsolate();
 					}
-				})();
+				})().catch((error) => {
+					this.logger.error('Failed to deactivate test webhooks on cancel', {
+						error,
+						workflowId,
+					});
+				});
 			}
 
 			foundWebhook = true;


### PR DESCRIPTION
## Summary

Two small follow-ups to #29703 (which has merged):

1. **Surface errors from the fire-and-forget IIFE in `cancelWebhook`.** The IIFE wrapping `deactivateWebhooks` is intentionally not awaited (preserved from prior code), but it previously swallowed any rejection from `acquireIsolate`, `deactivateWebhooks`, or `releaseIsolate`. Inject `Logger` into `TestWebhooks` and add a `.catch` that logs the failure with the workflow id, so unexpected cleanup failures are visible instead of becoming unhandled rejections.
2. **Cover the error path of `cancelWebhook` with a test**, mirroring the existing error-path test for `handleClearTestWebhooks`.

### How to test

- `pnpm --filter n8n test src/webhooks/__tests__/test-webhooks.test.ts` — 24 tests pass, including the new `releases isolate and logs when deactivateWebhooks throws`.
- `pnpm --filter n8n typecheck` clean.

## Related Linear tickets, Github issues, and Community forum posts

n/a — follow-up on #29703.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI