### PR TITLE
ci: Fix race condition between npm releases and daytona snapshots

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -107,7 +107,7 @@ jobs:
 
   build-daytona-snapshot:
     name: Build Daytona snapshot
-    needs: [determine-version-info]
+    needs: [determine-version-info, publish-to-npm]
     if: github.event.pull_request.merged == true
     uses: ./.github/workflows/release-build-daytona-snapshot.yml
     with:


### PR DESCRIPTION
## Summary

Fix a race condition of Daytona snapshots requiring all of the npm packages to be published, but not waiting for `publish-to-npm` to finish.

## Related Linear tickets, Github issues, and Community forum posts

[Failed Release pipeline](https://github.com/n8n-io/n8n/actions/runs/25367875645/job/74383484801#step:4:165). Fixed via retry.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
