### PR TITLE
refactor(editor): Finish per-workflow NDV store migration

### DIFF
--- a/packages/frontend/editor-ui/src/__tests__/utils.ts
+++ b/packages/frontend/editor-ui/src/__tests__/utils.ts
@@ -122,6 +122,32 @@ export const mockedStore = <TStoreDef extends () => unknown>(
 
 export type MockedStore<T extends () => unknown> = ReturnType<typeof mockedStore<T>>;
 
+/**
+ * Build the `global.provide` object needed to render a component that calls
+ * `injectNDVStore()` (or `injectWorkflowDocumentStore()`). Pass the workflow id
+ * the test's pinia is set up around so the injected stores are workflow-scoped.
+ */
+export async function provideStoresForNDVRender(workflowId: string) {
+	const { shallowRef, computed } = await import('vue');
+	const { WorkflowDocumentStoreKey, WorkflowIdKey, NDVStoreKey } = await import(
+		'@/app/constants/injectionKeys'
+	);
+	const { useWorkflowDocumentStore, createWorkflowDocumentId } = await import(
+		'@/app/stores/workflowDocument.store'
+	);
+	const { useNDVStore } = await import('@/features/ndv/shared/ndv.store');
+
+	const documentId = createWorkflowDocumentId(workflowId);
+	const workflowDocumentStoreRef = shallowRef(useWorkflowDocumentStore(documentId));
+	const ndvStoreRef = shallowRef(useNDVStore(documentId));
+
+	return {
+		[WorkflowIdKey as unknown as string]: computed(() => workflowId),
+		[WorkflowDocumentStoreKey as symbol]: workflowDocumentStoreRef,
+		[NDVStoreKey as symbol]: ndvStoreRef,
+	};
+}
+
 export type Emitter = (event: string, ...args: unknown[]) => void;
 export type Emitters<T extends string> = Record<
 	T,

--- a/packages/frontend/editor-ui/src/app/App.vue
+++ b/packages/frontend/editor-ui/src/app/App.vue
@@ -16,6 +16,8 @@ import { INSTANCE_AI_OPTIN_MODAL_KEY } from '@/app/constants/modals';
 import { canManageInstanceAi } from '@/features/ai/instanceAi/instanceAiPermissions';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import LoadingView from '@/app/views/LoadingView.vue';
 import { locale } from '@n8n/design-system';
@@ -35,7 +37,12 @@ import type { useWorkflowDocumentStore } from '@/app/stores/workflowDocument.sto
 const route = useRoute();
 const rootStore = useRootStore();
 const settingsStore = useSettingsStore();
-const ndvStore = useNDVStore();
+const workflowsStore = useWorkflowsStore();
+const ndvStore = computed(() =>
+	workflowsStore.workflowId
+		? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: null,
+);
 const uiStore = useUIStore();
 const { setAppZIndexes } = useStyles();
 const { toastBottomOffset, toastRightOffset, askAiFloatingButtonBottomOffset } =
@@ -64,7 +71,7 @@ const currentWorkflowDocumentStore = shallowRef<ReturnType<typeof useWorkflowDoc
 provide(WorkflowIdKey, workflowId);
 provide(WorkflowDocumentStoreKey, currentWorkflowDocumentStore);
 
-useTelemetryContext({ ndv_source: computed(() => ndvStore.lastSetActiveNodeSource) });
+useTelemetryContext({ ndv_source: computed(() => ndvStore.value?.lastSetActiveNodeSource) });
 
 onMounted(async () => {
 	setAppZIndexes();

--- a/packages/frontend/editor-ui/src/app/components/DraggableTarget.vue
+++ b/packages/frontend/editor-ui/src/app/components/DraggableTarget.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { XYPosition } from '@/Interface';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { v4 as uuid } from 'uuid';
 import { computed, ref, watch } from 'vue';
 
@@ -27,7 +27,7 @@ const hovering = ref(false);
 const targetRef = ref<HTMLElement>();
 const id = ref(uuid());
 
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const isDragging = computed(() => ndvStore.isDraggableDragging);
 const draggableType = computed(() => ndvStore.draggableType);
 const draggableDimensions = computed(() => ndvStore.draggable.dimensions);

--- a/packages/frontend/editor-ui/src/app/components/FocusPanel.vue
+++ b/packages/frontend/editor-ui/src/app/components/FocusPanel.vue
@@ -41,7 +41,7 @@ import { useExecutionData } from '@/features/execution/executions/composables/us
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import ExperimentalNodeDetailsDrawer from '@/features/workflows/canvas/experimental/components/ExperimentalNodeDetailsDrawer.vue';
 import { useExperimentalNdvStore } from '@/features/workflows/canvas/experimental/experimentalNdv.store';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useVueFlow } from '@vue-flow/core';
 import ExperimentalFocusPanelHeader from '@/features/workflows/canvas/experimental/components/ExperimentalFocusPanelHeader.vue';
 import { type ContextMenuAction } from '@/features/shared/contextMenu/composables/useContextMenuItems';
@@ -80,7 +80,7 @@ const telemetry = useTelemetry();
 const nodeSettingsParameters = useNodeSettingsParameters();
 const environmentsStore = useEnvironmentsStore();
 const experimentalNdvStore = useExperimentalNdvStore();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const vueFlow = useVueFlow(workflowId.value);
 const { renameNode } = useCanvasOperations();
 

--- a/packages/frontend/editor-ui/src/app/components/FreeAiCreditsCallout.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/FreeAiCreditsCallout.test.ts
@@ -34,6 +34,7 @@ vi.mock('@/features/settings/users/users.store', () => ({
 
 vi.mock('@/features/ndv/shared/ndv.store', () => ({
 	useNDVStore: vi.fn(),
+	injectNDVStore: vi.fn(),
 }));
 
 vi.mock('@/features/collaboration/projects/projects.store', () => ({

--- a/packages/frontend/editor-ui/src/app/components/FreeAiCreditsCallout.vue
+++ b/packages/frontend/editor-ui/src/app/components/FreeAiCreditsCallout.vue
@@ -1,6 +1,8 @@
 <script lang="ts" setup>
 import { useI18n } from '@n8n/i18n';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
 import { useFreeAiCredits } from '@/app/composables/useFreeAiCredits';
 import { computed, ref } from 'vue';
 import { OPEN_AI_API_CREDENTIAL_TYPE } from 'n8n-workflow';
@@ -24,7 +26,12 @@ const NODES_WITH_OPEN_AI_API_CREDENTIAL = [
 
 const showSuccessCallout = ref(false);
 
-const ndvStore = useNDVStore();
+const workflowsStore = useWorkflowsStore();
+const ndvStore = computed(() =>
+	workflowsStore.workflowId
+		? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: null,
+);
 const i18n = useI18n();
 
 const { aiCreditsQuota, userCanClaimOpenAiCredits, claimingCredits, claimCredits } =
@@ -36,8 +43,8 @@ const isEditingOpenAiCredential = computed(
 
 const activeNodeHasOpenAiApiCredential = computed(
 	() =>
-		ndvStore.activeNode?.type &&
-		NODES_WITH_OPEN_AI_API_CREDENTIAL.includes(ndvStore.activeNode.type),
+		ndvStore.value?.activeNode?.type &&
+		NODES_WITH_OPEN_AI_API_CREDENTIAL.includes(ndvStore.value.activeNode.type),
 );
 
 const showCallout = computed(() => {

--- a/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.vue
+++ b/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.vue
@@ -38,9 +38,13 @@ const inputs = ref<{
 }>();
 const i18n = useI18n();
 const telemetry = useTelemetry();
-const ndvStore = useNDVStore();
 const modalBus = createEventBus();
 const workflowsStore = useWorkflowsStore();
+const ndvStore = computed(() =>
+	workflowsStore.workflowId
+		? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: null,
+);
 const workflowDocumentStore = computed(() =>
 	useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId)),
 );
@@ -102,7 +106,7 @@ const onExecute = async () => {
 		node_type: node.value.type,
 		workflow_id: workflowsStore.workflowId,
 		source: 'from-ai-parameters-modal',
-		push_ref: ndvStore.pushRef,
+		push_ref: ndvStore.value?.pushRef,
 	};
 
 	telemetry.track('User clicked execute node button in modal', telemetryPayload);

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
@@ -11,7 +11,7 @@ import {
 	N8N_MAIN_GITHUB_REPO_URL,
 } from '@/app/constants';
 import { useExecutionsStore } from '@/features/execution/executions/executions.store';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
@@ -32,7 +32,7 @@ const route = useRoute();
 const locale = useI18n();
 const pushConnection = usePushConnection({ router });
 const toast = useToast();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const uiStore = useUIStore();
 const workflowsListStore = useWorkflowsListStore();
 const executionsStore = useExecutionsStore();

--- a/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.vue
+++ b/packages/frontend/editor-ui/src/app/components/NodeExecuteButton.vue
@@ -6,7 +6,7 @@ import type { ButtonVariant } from '@n8n/design-system';
 import { type IconName } from '@n8n/design-system/components/N8nIcon/icons';
 import { N8nButton, N8nTooltip } from '@n8n/design-system';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeExecution } from '@/app/composables/useNodeExecution';
 
 const NODE_TEST_STEP_POPUP_COUNT_KEY = 'N8N_NODE_TEST_STEP_POPUP_COUNT';
@@ -54,7 +54,7 @@ defineOptions({
 
 const i18n = useI18n();
 const workflowDocumentStore = injectWorkflowDocumentStore();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 
 const node = computed(() => workflowDocumentStore?.value?.getNodeByName(props.nodeName) ?? null);
 

--- a/packages/frontend/editor-ui/src/app/composables/useAutocompleteTelemetry.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useAutocompleteTelemetry.test.ts
@@ -14,12 +14,16 @@ vi.mock('@/app/composables/useTelemetry', () => ({
 	useTelemetry: vi.fn(() => ({ track: trackSpy })),
 }));
 
-vi.mock('@/features/ndv/shared/ndv.store', () => ({
-	useNDVStore: vi.fn(() => ({
+vi.mock('@/features/ndv/shared/ndv.store', () => {
+	const mockStore = {
 		activeNode: { type: 'n8n-nodes-base.test' },
 		setAutocompleteOnboarded: setAutocompleteOnboardedSpy,
-	})),
-}));
+	};
+	return {
+		useNDVStore: vi.fn(() => mockStore),
+		injectNDVStore: vi.fn(() => mockStore),
+	};
+});
 
 vi.mock('@n8n/stores/useRootStore', () => ({
 	useRootStore: vi.fn(() => ({

--- a/packages/frontend/editor-ui/src/app/composables/useAutocompleteTelemetry.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useAutocompleteTelemetry.ts
@@ -3,6 +3,8 @@ import { ExpressionExtensions } from 'n8n-workflow';
 import { EditorView, type ViewUpdate } from '@codemirror/view';
 
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useTelemetry } from '../composables/useTelemetry';
 import type { Compartment } from '@codemirror/state';
@@ -17,7 +19,12 @@ export const useAutocompleteTelemetry = ({
 	parameterPath: MaybeRefOrGetter<string>;
 	compartment: MaybeRefOrGetter<Compartment>;
 }) => {
-	const ndvStore = useNDVStore();
+	const workflowsStore = useWorkflowsStore();
+	const ndvStore = computed(() =>
+		workflowsStore.workflowId
+			? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: null,
+	);
 	const rootStore = useRootStore();
 	const telemetry = useTelemetry();
 
@@ -60,7 +67,7 @@ export const useAutocompleteTelemetry = ({
 
 		if (!completionTx) return;
 
-		ndvStore.setAutocompleteOnboarded();
+		ndvStore.value?.setAutocompleteOnboarded();
 
 		let completion = '';
 		let completionBase = '';
@@ -80,7 +87,7 @@ export const useAutocompleteTelemetry = ({
 
 		const payload = {
 			instance_id: rootStore.instanceId,
-			node_type: ndvStore.activeNode?.type,
+			node_type: ndvStore.value?.activeNode?.type,
 			field_name: path,
 			field_type: 'expression',
 			context: completionBase,

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -178,7 +178,11 @@ export function useCanvasOperations() {
 	const credentialsStore = useCredentialsStore();
 	const historyStore = useHistoryStore();
 	const uiStore = useUIStore();
-	const ndvStore = useNDVStore();
+	const ndvStore = computed(() =>
+		workflowsStore.workflowId
+			? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: null,
+	);
 	const nodeTypesStore = useNodeTypesStore();
 	const canvasStore = useCanvasStore();
 	const settingsStore = useSettingsStore();
@@ -383,9 +387,9 @@ export function useCanvasOperations() {
 		workflowDocumentStore.value.setNodes(Object.values(workflow.nodes));
 		workflowDocumentStore.value.setConnections(workflow.connectionsBySourceNode);
 
-		const isRenamingActiveNode = ndvStore.activeNodeName === currentName;
+		const isRenamingActiveNode = ndvStore.value?.activeNodeName === currentName;
 		if (isRenamingActiveNode) {
-			ndvStore.setActiveNodeName(newName, 'other');
+			ndvStore.value?.setActiveNodeName(newName, 'other');
 		}
 
 		if (trackHistory && trackBulk) {
@@ -630,11 +634,11 @@ export function useCanvasOperations() {
 	}
 
 	function setNodeActiveByName(name: string, source: TelemetryNdvSource) {
-		ndvStore.setActiveNodeName(name, source);
+		ndvStore.value?.setActiveNodeName(name, source);
 	}
 
 	function clearNodeActive() {
-		ndvStore.unsetActiveNodeName();
+		ndvStore.value?.unsetActiveNodeName();
 	}
 
 	function setNodeParameters(id: string, parameters: Record<string, unknown>) {
@@ -923,7 +927,7 @@ export function useCanvasOperations() {
 				} else if (nextView === 'zoomed_view') {
 					experimentalNdvStore.setNodeNameToBeFocused(nodeData.name);
 				} else if (nextView === 'ndv') {
-					ndvStore.setActiveNodeName(nodeData.name, 'added_new_node');
+					ndvStore.value?.setActiveNodeName(nodeData.name, 'added_new_node');
 				}
 			}
 		});
@@ -2960,7 +2964,7 @@ export function useCanvasOperations() {
 		if (nodeId) {
 			const node = workflowDocumentStore.value.getNodeById(nodeId);
 			if (node) {
-				ndvStore.setActiveNodeName(node.name, 'other');
+				ndvStore.value?.setActiveNodeName(node.name, 'other');
 			} else {
 				toast.showError(
 					new Error(`Node with id "${nodeId}" could not be found!`),

--- a/packages/frontend/editor-ui/src/app/composables/useExternalHooks.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useExternalHooks.ts
@@ -1,11 +1,15 @@
 import type { IDataObject } from 'n8n-workflow';
 import type {
+	ExternalHookStore,
 	ExternalHooks,
 	ExternalHooksKey,
 	ExternalHooksGenericContext,
 	ExtractExternalHooksMethodPayloadFromKey,
 } from '@/app/types/externalHooks';
 import { useWebhooksStore } from '@/app/stores/webhooks.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
 
 export async function runExternalHook<T extends ExternalHooksKey>(
 	eventName: T,
@@ -15,7 +19,13 @@ export async function runExternalHook<T extends ExternalHooksKey>(
 		return;
 	}
 
-	const store = useWebhooksStore();
+	// Resolve workflow-scoped NDV state at hook invocation time so each hook
+	// run sees the currently active workflow's state (or none, off-workflow).
+	const webhooksStore = useWebhooksStore();
+	const workflowId = useWorkflowsStore().workflowId;
+	const store: ExternalHookStore = workflowId
+		? Object.assign({}, webhooksStore, useNDVStore(createWorkflowDocumentId(workflowId)))
+		: webhooksStore;
 
 	const [resource, operator] = eventName.split('.') as [
 		keyof ExternalHooks,

--- a/packages/frontend/editor-ui/src/app/composables/useFloatingUiOffsets.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useFloatingUiOffsets.ts
@@ -2,6 +2,8 @@ import { useAssistantStore } from '@/features/ai/assistant/assistant.store';
 import { useChatPanelStore } from '@/features/ai/assistant/chatPanel.store';
 import { useLogsStore } from '@/app/stores/logs.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
 import { computed } from 'vue';
 
 const ASSISTANT_FLOATING_BUTTON_SIZE = 42;
@@ -9,16 +11,22 @@ const ASSISTANT_FLOATING_BUTTON_SIZE = 42;
 export function useFloatingUiOffsets() {
 	const assistantStore = useAssistantStore();
 	const chatPanelStore = useChatPanelStore();
-	const ndvStore = useNDVStore();
+	const workflowsStore = useWorkflowsStore();
+	const ndvStore = computed(() =>
+		workflowsStore.workflowId
+			? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: null,
+	);
 	const logsStore = useLogsStore();
 
 	const isNDVV2 = computed(() => true);
-	const askAiOffset = computed(() => (ndvStore.isNDVOpen && !isNDVV2.value ? 48 : 16));
+	const isNDVOpen = computed(() => ndvStore.value?.isNDVOpen ?? false);
+	const askAiOffset = computed(() => (isNDVOpen.value && !isNDVV2.value ? 48 : 16));
 
 	return {
 		askAiFloatingButtonBottomOffset: computed(() => `${askAiOffset.value}px`),
 		toastBottomOffset: computed(() => {
-			const logsPanelOffset = ndvStore.isNDVOpen || chatPanelStore.isOpen ? 0 : logsStore.height;
+			const logsPanelOffset = isNDVOpen.value || chatPanelStore.isOpen ? 0 : logsStore.height;
 			const assistantOffset = assistantStore.isFloatingButtonShown
 				? ASSISTANT_FLOATING_BUTTON_SIZE + askAiOffset.value
 				: 0;

--- a/packages/frontend/editor-ui/src/app/composables/useHistoryHelper.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useHistoryHelper.test.ts
@@ -31,13 +31,17 @@ const uiStoreMock = {
 
 const telemetryTrackMock = vi.fn();
 
-vi.mock('@/features/ndv/shared/ndv.store', () => ({
-	useNDVStore: () => ({
+vi.mock('@/features/ndv/shared/ndv.store', () => {
+	const mockStore = {
 		activeNodeName: null,
 		activeNode: {},
 		isNDVOpen: false,
-	}),
-}));
+	};
+	return {
+		useNDVStore: () => mockStore,
+		injectNDVStore: () => mockStore,
+	};
+});
 
 vi.mock('@/app/stores/history.store', () => ({
 	useHistoryStore: () => historyStoreMock,

--- a/packages/frontend/editor-ui/src/app/composables/useHistoryHelper.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useHistoryHelper.ts
@@ -1,11 +1,13 @@
 import { MAIN_HEADER_TABS } from '@/app/constants';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
 import type { Undoable } from '@/app/models/history';
 import { BulkCommand, Command } from '@/app/models/history';
 import { useHistoryStore } from '@/app/stores/history.store';
 import { useUIStore } from '@/app/stores/ui.store';
 
-import { onMounted, onUnmounted, nextTick } from 'vue';
+import { computed, onMounted, onUnmounted, nextTick } from 'vue';
 import { useDeviceSupport } from '@n8n/composables/useDeviceSupport';
 import { getNodeViewTab } from '@/app/utils/nodeViewUtils';
 import type { RouteLocationNormalizedLoaded } from 'vue-router';
@@ -17,7 +19,12 @@ const ELEMENT_UI_OVERLAY_SELECTOR = '.el-overlay';
 export function useHistoryHelper(activeRoute: RouteLocationNormalizedLoaded) {
 	const telemetry = useTelemetry();
 
-	const ndvStore = useNDVStore();
+	const workflowsStore = useWorkflowsStore();
+	const ndvStore = computed(() =>
+		workflowsStore.workflowId
+			? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: null,
+	);
 	const historyStore = useHistoryStore();
 	const uiStore = useUIStore();
 
@@ -91,7 +98,7 @@ export function useHistoryHelper(activeRoute: RouteLocationNormalizedLoaded) {
 	}
 
 	function trackUndoAttempt() {
-		const activeNode = ndvStore.activeNode;
+		const activeNode = ndvStore.value?.activeNode;
 		if (activeNode) {
 			telemetry?.track('User hit undo in NDV', { node_type: activeNode.type });
 		}
@@ -110,7 +117,7 @@ export function useHistoryHelper(activeRoute: RouteLocationNormalizedLoaded) {
 
 	function handleKeyDown(event: KeyboardEvent) {
 		const currentNodeViewTab = getNodeViewTab(activeRoute);
-		const isNDVOpen = ndvStore.isNDVOpen;
+		const isNDVOpen = ndvStore.value?.isNDVOpen ?? false;
 		const isAnyModalOpen = uiStore.isAnyModalOpen || isMessageDialogOpen();
 		const undoKeysPressed = isCtrlKeyPressed(event) && event.key.toLowerCase() === 'z';
 

--- a/packages/frontend/editor-ui/src/app/composables/useNodeExecution.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeExecution.test.ts
@@ -104,6 +104,7 @@ vi.mock('@/app/stores/nodeTypes.store', () => ({
 
 vi.mock('@/features/ndv/shared/ndv.store', () => ({
 	useNDVStore: vi.fn().mockReturnValue(mockNdvStore),
+	injectNDVStore: vi.fn().mockReturnValue(mockNdvStore),
 }));
 
 vi.mock('@/app/stores/ui.store', () => ({

--- a/packages/frontend/editor-ui/src/app/composables/useNodeExecution.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeExecution.ts
@@ -99,7 +99,11 @@ export function useNodeExecution(
 
 	const workflowsStore = useWorkflowsStore();
 	const nodeTypesStore = useNodeTypesStore();
-	const ndvStore = useNDVStore();
+	const ndvStore = computed(() =>
+		workflowsStore.workflowId
+			? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: null,
+	);
 	const uiStore = useUIStore();
 	const workflowState = injectWorkflowState();
 
@@ -364,7 +368,7 @@ export function useNodeExecution(
 		// Chat nodes — open chat when: it's a chat trigger itself, or it's a child of
 		// a chat trigger that has no execution/pin data yet (needs chat input first).
 		if (isChatNode.value || (isChatChild.value && !chatTriggerHasInputData())) {
-			ndvStore.unsetActiveNodeName();
+			ndvStore.value?.unsetActiveNodeName();
 			await runWorkflow({
 				destinationNode: { nodeName, mode: toValue(executionMode) },
 				source,
@@ -419,7 +423,7 @@ export function useNodeExecution(
 				node_type: nodeType.value ? nodeType.value.name : null,
 				workflow_id: workflowsStore.workflowId,
 				source: telemetrySource,
-				push_ref: ndvStore.pushRef,
+				push_ref: ndvStore.value?.pushRef,
 			};
 
 			telemetry.track('User clicked execute node button', telemetryPayload);

--- a/packages/frontend/editor-ui/src/app/composables/useResolvedExpression.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useResolvedExpression.ts
@@ -38,8 +38,12 @@ export function useResolvedExpression({
 	stringifyObject?: MaybeRefOrGetter<boolean>;
 	contextNodeName?: MaybeRefOrGetter<string>;
 }) {
-	const ndvStore = useNDVStore();
 	const workflowsStore = useWorkflowsStore();
+	const ndvStore = computed(() =>
+		workflowsStore.workflowId
+			? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: null,
+	);
 	const workflowDocumentStore = computed(() =>
 		useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId)),
 	);
@@ -54,8 +58,8 @@ export function useResolvedExpression({
 	const resolvedExpression = ref<unknown>(null);
 	const resolvedExpressionString = ref('');
 
-	const targetItem = computed(() => ndvStore.expressionTargetItem ?? undefined);
-	const activeNode = computed(() => ndvStore.activeNode);
+	const targetItem = computed(() => ndvStore.value?.expressionTargetItem ?? undefined);
+	const activeNode = computed(() => ndvStore.value?.activeNode ?? null);
 	const hasRunData = computed(() =>
 		Boolean(
 			workflowsStore.workflowExecutionData?.data?.resultData?.runData[activeNode.value?.name ?? ''],
@@ -74,12 +78,12 @@ export function useResolvedExpression({
 			isForCredential: toValue(isForCredential),
 			additionalKeys: toValue(additionalData),
 			contextNodeName: toValue(contextNodeName),
-			...(contextNodeName === undefined && ndvStore.isInputParentOfActiveNode
+			...(contextNodeName === undefined && ndvStore.value?.isInputParentOfActiveNode
 				? {
 						targetItem: targetItem.value ?? undefined,
-						inputNodeName: ndvStore.ndvInputNodeName,
-						inputRunIndex: ndvStore.ndvInputRunIndex,
-						inputBranchIndex: ndvStore.ndvInputBranchIndex,
+						inputNodeName: ndvStore.value.ndvInputNodeName,
+						inputRunIndex: ndvStore.value.ndvInputRunIndex,
+						inputBranchIndex: ndvStore.value.ndvInputBranchIndex,
 					}
 				: {}),
 		};

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowHelpers.ts
@@ -95,13 +95,16 @@ export async function resolveParameter<T = IDataObject>(
 	const workflowDocumentStore = useWorkflowDocumentStore(
 		createWorkflowDocumentId(workflowsStore.workflowId),
 	);
+	const ndvStore = workflowsStore.workflowId
+		? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: null;
 
 	return await resolveParameterImpl(
 		parameter,
 		workflowDocumentStore.getWorkflowObjectAccessorSnapshot(),
 		workflowDocumentStore.connectionsBySourceNode,
 		useEnvironmentsStore().variablesAsObject,
-		useNDVStore().activeNode,
+		ndvStore?.activeNode ?? null,
 		workflowsStore.workflowExecutionData,
 		workflowDocumentStore.getPinDataSnapshot(),
 		opts,

--- a/packages/frontend/editor-ui/src/app/init.ts
+++ b/packages/frontend/editor-ui/src/app/init.ts
@@ -219,9 +219,13 @@ export async function initializeAuthenticatedFeatures(
 
 	// Initialize run data worker and load node types
 	if (window.localStorage.getItem(LOCAL_STORAGE_DATA_WORKER) === 'true') {
-		const coordinator = await import('@/app/workers');
-		await coordinator.initialize({ version: settingsStore.settings.versionCli });
-		await coordinator.loadNodeTypes(rootStore.baseUrl);
+		try {
+			const coordinator = await import('@/app/workers');
+			await coordinator.initialize({ version: settingsStore.settings.versionCli });
+			await coordinator.loadNodeTypes(rootStore.baseUrl);
+		} catch (error) {
+			console.error('Failed to initialize data worker', error);
+		}
 	}
 
 	authenticatedFeaturesInitialized = true;

--- a/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/WorkflowLayout.vue
@@ -95,7 +95,7 @@ onBeforeUnmount(() => {
 		<LoadingView v-if="isLoading" />
 		<RouterView v-else />
 		<template v-if="layoutProps.logs" #footer>
-			<LogsPanel />
+			<LogsPanel v-if="!isLoading" />
 		</template>
 		<template v-if="!isCanvasOnly" #overlays>
 			<AskAssistantFloatingButton v-if="assistantStore.isFloatingButtonShown" />

--- a/packages/frontend/editor-ui/src/app/plugins/telemetry/index.ts
+++ b/packages/frontend/editor-ui/src/app/plugins/telemetry/index.ts
@@ -13,6 +13,8 @@ import {
 } from '@/app/constants';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { usePostHog } from '@/app/stores/posthog.store';
@@ -166,8 +168,10 @@ export class Telemetry {
 
 	trackAskAI(event: string, properties: IDataObject = {}) {
 		if (this.rudderStack) {
+			const workflowId = useWorkflowsStore().workflowId;
+			if (!workflowId) return;
 			properties.session_id = useRootStore().pushRef;
-			properties.ndv_session_id = useNDVStore().pushRef;
+			properties.ndv_session_id = useNDVStore(createWorkflowDocumentId(workflowId)).pushRef;
 
 			switch (event) {
 				case 'askAi.generationFinished':
@@ -180,8 +184,10 @@ export class Telemetry {
 
 	trackAiTransform(event: string, properties: IDataObject = {}) {
 		if (this.rudderStack) {
+			const workflowId = useWorkflowsStore().workflowId;
+			if (!workflowId) return;
 			properties.session_id = useRootStore().pushRef;
-			properties.ndv_session_id = useNDVStore().pushRef;
+			properties.ndv_session_id = useNDVStore(createWorkflowDocumentId(workflowId)).pushRef;
 
 			switch (event) {
 				case 'generationFinished':

--- a/packages/frontend/editor-ui/src/app/router.ts
+++ b/packages/frontend/editor-ui/src/app/router.ts
@@ -1152,6 +1152,7 @@ router.beforeEach(async (to: RouteLocationNormalized, from, next) => {
 		} else {
 			console.error(failure);
 		}
+		return next(false);
 	}
 });
 

--- a/packages/frontend/editor-ui/src/app/stores/webhooks.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/webhooks.store.ts
@@ -1,19 +1,19 @@
 import { STORES } from '@n8n/stores';
 import { defineStore } from 'pinia';
 import { useRootStore } from '@n8n/stores/useRootStore';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useUIStore } from './ui.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { useWorkflowsStore } from './workflows.store';
 import { useSettingsStore } from './settings.store';
 
+// Per-workflow state (e.g. NDV) is NOT included here — it is resolved by the
+// external hook runner at invocation time so it is scoped to the active workflow.
 export const useWebhooksStore = defineStore(STORES.WEBHOOKS, () => {
 	return {
 		...useRootStore(),
 		...useWorkflowsStore(),
 		...useUIStore(),
 		...useUsersStore(),
-		...useNDVStore(),
 		...useSettingsStore(),
 	};
 });

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -762,7 +762,8 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 
 	function activeNode(): INodeUi | null {
 		// kept here for FE hooks
-		const ndvStore = useNDVStore();
+		if (!workflowId.value) return null;
+		const ndvStore = useNDVStore(createWorkflowDocumentId(workflowId.value));
 		return ndvStore.activeNode;
 	}
 

--- a/packages/frontend/editor-ui/src/app/types/externalHooks.ts
+++ b/packages/frontend/editor-ui/src/app/types/externalHooks.ts
@@ -24,10 +24,21 @@ import type { IPersonalizationLatestVersion } from '@n8n/rest-api-client/api/use
 import type { IWorkflowTemplateNode } from '@n8n/rest-api-client/api/templates';
 import type { ComponentPublicInstance } from 'vue';
 import type { useWebhooksStore } from '@/app/stores/webhooks.store';
+import type { useNDVStore } from '@/features/ndv/shared/ndv.store';
+
+// NDV-only keys are optional because NDV state is not present off-workflow.
+// We narrow to NDV-only keys (excluding webhook keys) to avoid Pinia internals
+// (`$state`, `$id`, etc.) colliding as required intersections.
+type WebhooksHookStore = ReturnType<typeof useWebhooksStore>;
+type NDVHookStore = ReturnType<typeof useNDVStore>;
+type NDVOnlyKeys = Exclude<keyof NDVHookStore, keyof WebhooksHookStore>;
+export type ExternalHookStore = WebhooksHookStore & {
+	[K in NDVOnlyKeys]?: NDVHookStore[K];
+};
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export interface ExternalHooksMethod<T = any, R = void> {
-	(store: ReturnType<typeof useWebhooksStore>, metadata: T): R | Promise<R>;
+	(store: ExternalHookStore, metadata: T): R | Promise<R>;
 }
 
 export interface ExternalHooksGenericContext {

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -99,7 +99,7 @@ import { useUsersStore } from '@/features/settings/users/users.store';
 import { sourceControlEventBus } from '@/features/integrations/sourceControl.ee/sourceControl.eventBus';
 import { useTagsStore } from '@/features/shared/tags/tags.store';
 
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { getBounds, getNodeViewTab } from '@/app/utils/nodeViewUtils';
 import { isChatNode } from '@/app/utils/aiUtils';
 import CanvasStopCurrentExecutionButton from '@/features/workflows/canvas/components/elements/buttons/CanvasStopCurrentExecutionButton.vue';
@@ -191,7 +191,7 @@ const projectsStore = useProjectsStore();
 const usersStore = useUsersStore();
 const tagsStore = useTagsStore();
 
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const focusPanelStore = useFocusPanelStore();
 const builderStore = useBuilderStore();
 const agentRequestStore = useAgentRequestStore();

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
@@ -256,7 +256,11 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 	const workflowDocumentStore = computed(() =>
 		useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId)),
 	);
-	const ndvStore = useNDVStore();
+	const ndvStore = computed(() =>
+		workflowsStore.workflowId
+			? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: null,
+	);
 	const route = useRoute();
 	const locale = useI18n();
 	const telemetry = useTelemetry();
@@ -285,7 +289,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 		chatMessages,
 		getTargetNodeName: (msg) =>
 			msg.nodeName ??
-			ndvStore.activeNodeName ??
+			ndvStore.value?.activeNodeName ??
 			focusedNodesStore.confirmedNodes[0]?.nodeName ??
 			'',
 		getSessionId: (msg) => {
@@ -933,7 +937,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 		}
 
 		// Close NDV on new message
-		ndvStore.unsetActiveNodeName();
+		ndvStore.value?.unsetActiveNodeName();
 
 		const {
 			text,

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/NodeIssueItem.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/NodeIssueItem.vue
@@ -7,6 +7,9 @@ interface WorkflowNodeIssue {
 	value: string | string[];
 }
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
+import { computed } from 'vue';
 import NodeIcon from '@/app/components/NodeIcon.vue';
 import { N8nIcon } from '@n8n/design-system';
 
@@ -26,10 +29,15 @@ interface Emits {
 const props = defineProps<Props>();
 const emit = defineEmits<Emits>();
 
-const ndvStore = useNDVStore();
+const workflowsStore = useWorkflowsStore();
+const ndvStore = computed(() =>
+	workflowsStore.workflowId
+		? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: null,
+);
 
 function handleEditClick() {
-	ndvStore.setActiveNodeName(props.issue.node, 'other');
+	ndvStore.value?.setActiveNodeName(props.issue.node, 'other');
 
 	emit('click');
 }

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useAIAssistantHelpers.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useAIAssistantHelpers.ts
@@ -16,8 +16,10 @@ import type {
 	NodeOperationError,
 	NodeParameterValueType,
 } from 'n8n-workflow';
+import { computed } from 'vue';
 import { useWorkflowHelpers } from '@/app/composables/useWorkflowHelpers';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import {
 	executionDataToJson,
@@ -41,7 +43,12 @@ const WORKFLOW_LIST_VIEWS = [VIEWS.WORKFLOWS, VIEWS.PROJECTS_WORKFLOWS];
 const CREDENTIALS_LIST_VIEWS = [VIEWS.CREDENTIALS, VIEWS.PROJECTS_CREDENTIALS];
 
 export const useAIAssistantHelpers = () => {
-	const ndvStore = useNDVStore();
+	const workflowsStore = useWorkflowsStore();
+	const ndvStore = computed(() =>
+		workflowsStore.workflowId
+			? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: null,
+	);
 	const nodeTypesStore = useNodeTypesStore();
 
 	const workflowHelpers = useWorkflowHelpers();
@@ -250,10 +257,10 @@ export const useAIAssistantHelpers = () => {
 		let nodeInputData: { inputNodeName?: string; inputData?: IDataObject } | undefined = {};
 		// Only include input data if the node references it and we are allowed to send it
 		if (!options?.excludeParameterValues) {
-			const ndvInput = ndvStore.ndvInputData;
+			const ndvInput = ndvStore.value?.ndvInputData;
 			if (isNodeReferencingInputData(node) && ndvInput?.length) {
-				const inputData = ndvStore.ndvInputData[0].json;
-				const inputNodeName = ndvStore.input.nodeName;
+				const inputData = ndvInput[0].json;
+				const inputNodeName = ndvStore.value?.input.nodeName;
 				nodeInputData = {
 					inputNodeName,
 					inputData,

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useCodeDiff.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useCodeDiff.ts
@@ -1,4 +1,5 @@
-import { ref, h } from 'vue';
+import { computed, ref, h } from 'vue';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import type { Ref } from 'vue';
 import type { ChatUI } from '@n8n/design-system/types/assistant';
 import type { INodeParameters } from 'n8n-workflow';
@@ -26,7 +27,12 @@ export interface UseCodeDiffOptions {
 
 export function useCodeDiff(options: UseCodeDiffOptions) {
 	const rootStore = useRootStore();
-	const ndvStore = useNDVStore();
+	const workflowsStore = useWorkflowsStore();
+	const ndvStore = computed(() =>
+		workflowsStore.workflowId
+			? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: null,
+	);
 	const locale = useI18n();
 
 	const suggestions = ref<{
@@ -37,7 +43,7 @@ export function useCodeDiff(options: UseCodeDiffOptions) {
 	}>({});
 
 	function updateParameters(workflowId: string, nodeName: string, parameters: INodeParameters) {
-		if (ndvStore.activeNodeName === nodeName) {
+		if (ndvStore.value?.activeNodeName === nodeName) {
 			Object.keys(parameters).forEach((key) => {
 				const update: IUpdateInformation = {
 					node: nodeName,
@@ -70,7 +76,7 @@ export function useCodeDiff(options: UseCodeDiffOptions) {
 	}
 
 	function showCodeUpdateToastIfNeeded(errorNodeName: string) {
-		if (errorNodeName !== ndvStore.activeNodeName) {
+		if (errorNodeName !== ndvStore.value?.activeNodeName) {
 			useToast().showMessage({
 				type: 'success',
 				title: locale.baseText('aiAssistant.codeUpdated.message.title'),

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useNodeMention.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useNodeMention.test.ts
@@ -17,9 +17,13 @@ vi.mock('@/app/composables/useTelemetry', () => ({
 	useTelemetry: () => ({ track: vi.fn() }),
 }));
 
-vi.mock('@/features/ndv/shared/ndv.store', () => ({
-	useNDVStore: () => ({ activeNode: null }),
-}));
+vi.mock('@/features/ndv/shared/ndv.store', () => {
+	const mockStore = { activeNode: null };
+	return {
+		useNDVStore: () => mockStore,
+		injectNDVStore: () => mockStore,
+	};
+});
 
 const { mockWorkflowDocumentStore } = vi.hoisted(() => ({
 	mockWorkflowDocumentStore: {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/focusedNodes.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/focusedNodes.store.ts
@@ -30,7 +30,11 @@ export const useFocusedNodesStore = defineStore(STORES.FOCUSED_NODES, () => {
 	const posthogStore = usePostHog();
 	const telemetry = useTelemetry();
 	const chatPanelStateStore = useChatPanelStateStore();
-	const ndvStore = useNDVStore();
+	const ndvStore = computed(() =>
+		workflowsStore.workflowId
+			? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: null,
+	);
 
 	const isFeatureEnabled = computed(() => {
 		return posthogStore.isVariantEnabled(
@@ -322,7 +326,7 @@ export const useFocusedNodesStore = defineStore(STORES.FOCUSED_NODES, () => {
 	);
 
 	watch(
-		() => ndvStore.activeNode,
+		() => ndvStore.value?.activeNode,
 		(node) => {
 			if (!isFeatureEnabled.value || !chatPanelStateStore.isOpen) return;
 			if (node && !focusedNodesMap.value[node.id]) {

--- a/packages/frontend/editor-ui/src/features/core/dataTable/components/NodeStorageLimitCallout.vue
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/components/NodeStorageLimitCallout.vue
@@ -1,13 +1,13 @@
 <script lang="ts" setup>
 import { computed } from 'vue';
 import { useI18n } from '@n8n/i18n';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { DATA_TABLE_NODES } from '@/app/constants';
 import { useDataTableStore } from '@/features/core/dataTable/dataTable.store';
 
 import { N8nCallout } from '@n8n/design-system';
 const i18n = useI18n();
-const nvdStore = useNDVStore();
+const nvdStore = injectNDVStore();
 const dataTableStore = useDataTableStore();
 
 const calloutType = computed(() => {

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.vue
@@ -24,6 +24,7 @@ import {
 import type { PermissionsRecord } from '@n8n/permissions';
 import { useCredentialsStore } from '../../credentials.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
@@ -92,10 +93,14 @@ const emit = defineEmits<{
 }>();
 
 const credentialsStore = useCredentialsStore();
-const ndvStore = useNDVStore();
 const rootStore = useRootStore();
 const uiStore = useUIStore();
 const workflowsStore = useWorkflowsStore();
+const ndvStore = computed(() =>
+	workflowsStore.workflowId
+		? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: null,
+);
 const assistantStore = useAssistantStore();
 const chatPanelStore = useChatPanelStore();
 
@@ -138,7 +143,7 @@ const credentialOwnerName = computed(() =>
 );
 const documentationUrl = computed(() => {
 	const type = props.credentialType;
-	const activeNode = ndvStore.activeNode;
+	const activeNode = ndvStore.value?.activeNode;
 	const isCommunityNode = activeNode ? isCommunityPackageName(activeNode.type) : false;
 
 	const docUrl = type?.documentationUrl;
@@ -216,7 +221,7 @@ const canWrite = computed(() => {
 	return canCreate.value || canEdit.value;
 });
 
-const activeNode = computed(() => ndvStore.activeNode);
+const activeNode = computed(() => ndvStore.value?.activeNode);
 
 const quickConnectOption = computed(() => {
 	if (!activeNode.value) return undefined;

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -83,10 +83,14 @@ type Props = {
 const props = withDefaults(defineProps<Props>(), { mode: 'new', activeId: undefined });
 
 const credentialsStore = useCredentialsStore();
-const ndvStore = useNDVStore();
 const settingsStore = useSettingsStore();
 const uiStore = useUIStore();
 const workflowsStore = useWorkflowsStore();
+const ndvStore = computed(() =>
+	workflowsStore.workflowId
+		? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: null,
+);
 const nodeTypesStore = useNodeTypesStore();
 const projectsStore = useProjectsStore();
 const externalSecretsStore = useExternalSecretsStore();
@@ -136,7 +140,7 @@ const workflowDocumentStore = computed(() =>
 );
 
 const contextNode = computed<INode | null>(() => {
-	if (ndvStore.activeNode) return ndvStore.activeNode;
+	if (ndvStore.value?.activeNode) return ndvStore.value?.activeNode;
 	const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
 	const fallbackName = isCredentialModalState(modalState) ? modalState.nodeName : undefined;
 	return fallbackName ? (workflowDocumentStore.value?.getNodeByName(fallbackName) ?? null) : null;
@@ -488,8 +492,16 @@ onMounted(async () => {
 	}
 
 	// Default to quick connect mode for new credentials when available and not forced to manual
-	if (props.mode === 'new' && !forceManual && credentialTypeName.value && ndvStore.activeNode) {
-		const qcOption = getQuickConnectOption(credentialTypeName.value, ndvStore.activeNode.type);
+	if (
+		props.mode === 'new' &&
+		!forceManual &&
+		credentialTypeName.value &&
+		ndvStore.value?.activeNode
+	) {
+		const qcOption = getQuickConnectOption(
+			credentialTypeName.value,
+			ndvStore.value?.activeNode.type,
+		);
 		if (qcOption) {
 			isQuickConnectMode.value = true;
 		}
@@ -498,7 +510,7 @@ onMounted(async () => {
 	await externalHooks.run('credentialsEdit.credentialModalOpened', {
 		credentialType: credentialTypeName.value,
 		isEditingCredential: props.mode === 'edit',
-		activeNode: ndvStore.activeNode,
+		activeNode: ndvStore.value?.activeNode,
 	});
 
 	setTimeout(async () => {
@@ -677,7 +689,7 @@ async function loadCurrentCredential(id = props.activeId ?? '') {
 function onTabSelect(tab: string) {
 	activeTab.value = tab;
 	const credType: string = credentialType.value ? credentialType.value.name : '';
-	const activeNode: INode | null = ndvStore.activeNode;
+	const activeNode: INode | null = ndvStore.value?.activeNode;
 
 	telemetry.track('User viewed credential tab', {
 		credential_type: credType,
@@ -952,8 +964,8 @@ async function saveCredential(): Promise<ICredentialsResponse | null> {
 			trackProperties.is_valid = !!testedSuccessfully.value;
 		}
 
-		if (ndvStore.activeNode) {
-			trackProperties.node_type = ndvStore.activeNode.type;
+		if (ndvStore.value?.activeNode) {
+			trackProperties.node_type = ndvStore.value?.activeNode.type;
 		}
 
 		if (authError.value && authError.value !== '') {
@@ -1269,8 +1281,8 @@ async function oAuthCredentialAuthorize() {
 			uses_external_secrets: usesExternalSecrets(credentialData.value),
 		};
 
-		if (ndvStore.activeNode) {
-			trackProperties.node_type = ndvStore.activeNode.type;
+		if (ndvStore.value?.activeNode) {
+			trackProperties.node_type = ndvStore.value?.activeNode.type;
 		}
 
 		telemetry.track('User saved credentials', trackProperties);
@@ -1331,13 +1343,13 @@ async function onAuthTypeChanged(payload: CredentialModeOption): Promise<void> {
 }
 
 async function onQuickConnect(): Promise<void> {
-	if (!credentialTypeName.value || !ndvStore.activeNode) return;
+	if (!credentialTypeName.value || !ndvStore.value?.activeNode) return;
 
 	const serviceName = getAppNameFromCredType(credentialType.value?.displayName ?? '');
 
 	const credential = await quickConnect({
 		credentialTypeName: credentialTypeName.value,
-		nodeType: ndvStore.activeNode.type,
+		nodeType: ndvStore.value?.activeNode.type,
 		source: 'credential_type',
 		serviceName,
 	});

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialModeSelector.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialModeSelector.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
 import { useI18n } from '@n8n/i18n';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import type { ICredentialType, INode, INodeTypeDescription } from 'n8n-workflow';
 import { computed } from 'vue';
 import { N8nButton, N8nIcon, N8nText } from '@n8n/design-system';
@@ -37,11 +39,18 @@ const emit = defineEmits<{
 }>();
 
 const nodeTypesStore = useNodeTypesStore();
-const ndvStore = useNDVStore();
+const workflowsStore = useWorkflowsStore();
+const ndvStore = computed(() =>
+	workflowsStore.workflowId
+		? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: null,
+);
 const i18n = useI18n();
 const { isOAuthCredentialType } = useCredentialOAuth();
 
-const activeNode = computed<INode | null>(() => props.contextNode ?? ndvStore.activeNode);
+const activeNode = computed<INode | null>(
+	() => props.contextNode ?? ndvStore.value?.activeNode ?? null,
+);
 const activeNodeType = computed<INodeTypeDescription | null>(() => {
 	if (!activeNode.value) return null;
 	return nodeTypesStore.getNodeType(activeNode.value.type, activeNode.value.typeVersion);

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -24,6 +24,7 @@ import { useQuickConnect } from '../quickConnect/composables/useQuickConnect';
 import { useCredentialOAuth } from '../composables/useCredentialOAuth';
 import QuickConnectButton from '../quickConnect/components/QuickConnectButton.vue';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
@@ -93,9 +94,13 @@ const NEW_CREDENTIALS_TEXT = i18n.baseText('nodeCredentials.createNew');
 
 const credentialsStore = useCredentialsStore();
 const nodeTypesStore = useNodeTypesStore();
-const ndvStore = useNDVStore();
 const uiStore = useUIStore();
 const workflowsStore = useWorkflowsStore();
+const ndvStore = computed(() =>
+	workflowsStore.workflowId
+		? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: null,
+);
 const projectsStore = useProjectsStore();
 const workflowDocumentStore = props.standalone ? undefined : injectWorkflowDocumentStore();
 const { isEnabled: isDynamicCredentialsEnabled } = useDynamicCredentials();
@@ -188,7 +193,7 @@ watch(
 	(newValue, oldValue) => {
 		// When active node parameters change, check if authentication type has been changed
 		// and set `subscribedToCredentialType` to corresponding credential type
-		const isActive = props.node.name === ndvStore.activeNode?.name;
+		const isActive = props.node.name === ndvStore.value?.activeNode?.name;
 		// Only do this for active node and if it's listening for auth change
 		if (isActive && nodeType.value && listeningForAuthChange.value) {
 			if (mainNodeAuthField.value && oldValue && newValue) {

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogDetailsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogDetailsPanel.vue
@@ -19,7 +19,7 @@ import {
 	isPlaceholderLog,
 } from '@/features/execution/logs/logs.utils';
 import { LOG_DETAILS_PANEL_STATE } from '@/features/execution/logs/logs.constants';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useExperimentalNdvStore } from '@/features/workflows/canvas/experimental/experimentalNdv.store';
 
 import { useExecutionRedaction } from '@/features/execution/executions/composables/useExecutionRedaction';
@@ -61,7 +61,7 @@ defineSlots<{ actions: {} }>();
 
 const locale = useI18n();
 const nodeTypeStore = useNodeTypesStore();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const experimentalNdvStore = useExperimentalNdvStore();
 const uiStore = useUIStore();
 const { isRedacted, canReveal, isDynamicCredentials, revealData } = useExecutionRedaction();

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsPanel.vue
@@ -6,7 +6,7 @@ import ChatMessagesPanel from '@/features/execution/logs/components/ChatMessages
 import LogsDetailsPanel from '@/features/execution/logs/components/LogDetailsPanel.vue';
 import LogsPanelActions from '@/features/execution/logs/components/LogsPanelActions.vue';
 import { useLogsExecutionData } from '@/features/execution/logs/composables/useLogsExecutionData';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { ndvEventBus } from '@/features/ndv/shared/ndv.eventBus';
 import { useLogsSelection } from '@/features/execution/logs/composables/useLogsSelection';
 import { useLogsTreeExpand } from '@/features/execution/logs/composables/useLogsTreeExpand';
@@ -30,7 +30,7 @@ const popOutContainer = useTemplateRef('popOutContainer');
 const popOutContent = useTemplateRef('popOutContent');
 
 const logsStore = useLogsStore();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const workflowsStore = useWorkflowsStore();
 const workflowDocumentStore = computed(() =>
 	useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId)),

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsViewRunData.vue
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsViewRunData.vue
@@ -4,7 +4,7 @@ import { type LogEntry } from '@/features/execution/logs/logs.types';
 import { useI18n } from '@n8n/i18n';
 import type { IRunDataDisplayMode } from '@/Interface';
 import type { NodePanelType } from '@/features/ndv/shared/ndv.types';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { waitingNodeTooltip } from '@/features/execution/executions/executions.utils';
 import { useExecutionRedaction } from '@/features/execution/executions/composables/useExecutionRedaction';
 import { computed, inject, ref } from 'vue';
@@ -39,7 +39,7 @@ const emit = defineEmits<{
 }>();
 
 const locale = useI18n();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const uiStore = useUIStore();
 const { canReveal, isDynamicCredentials, revealData } = useExecutionRedaction();
 

--- a/packages/frontend/editor-ui/src/features/integrations/logStreaming.ee/components/EventDestinationSettingsModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/logStreaming.ee/components/EventDestinationSettingsModal.vue
@@ -87,8 +87,12 @@ const i18n = useI18n();
 const { confirm } = useMessage();
 const telemetry = useTelemetry();
 const logStreamingStore = useLogStreamingStore();
-const ndvStore = useNDVStore();
 const workflowsStore = useWorkflowsStore();
+const ndvStore = computed(() =>
+	workflowsStore.workflowId
+		? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: null,
+);
 const workflowDocumentStore = computed(() =>
 	useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId)),
 );
@@ -229,7 +233,7 @@ function onLabelChange(value: string) {
 
 function setupNode(options: MessageEventBusDestinationOptions) {
 	workflowDocumentStore.value.removeNode(node.value);
-	ndvStore.setActiveNodeName(options.id ?? 'thisshouldnothappen', 'other');
+	ndvStore.value?.setActiveNodeName(options.id ?? 'thisshouldnothappen', 'other');
 	workflowDocumentStore.value.addNode(destinationToFakeINodeUi(options));
 	nodeParameters.value = options as INodeParameters;
 	logStreamingStore.items[destination.id!].destination = options;
@@ -340,7 +344,7 @@ function onModalClose() {
 			logStreamingStore.removeDestination(nodeParameters.value.id.toString());
 		}
 	}
-	ndvStore.unsetActiveNodeName();
+	ndvStore.value?.unsetActiveNodeName();
 	callEventBus('closing', destination.id);
 	uiStore.markStateClean();
 }

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/InputNodeSelect.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/InputNodeSelect.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { useI18n } from '@n8n/i18n';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { isPresent } from '@/app/utils/typesUtils';
@@ -24,7 +24,7 @@ const emit = defineEmits<{
 const i18n = useI18n();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const nodeTypesStore = useNodeTypesStore();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 
 const selectedInputNode = computed(
 	() => workflowDocumentStore?.value?.getNodeByName(props.modelValue ?? '') ?? null,

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/NDVDraggablePanels.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/NDVDraggablePanels.vue
@@ -5,7 +5,7 @@ import type { INodeTypeDescription } from 'n8n-workflow';
 import PanelDragButton from './PanelDragButton.vue';
 
 import { LOCAL_STORAGE_MAIN_PANEL_RELATIVE_WIDTH, MAIN_NODE_PANEL_WIDTH } from '@/app/constants';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { ndvEventBus } from '@/features/ndv/shared/ndv.eventBus';
 import NDVFloatingNodes from './NDVFloatingNodes.vue';
 import type { Direction, XYPosition } from '@/Interface';
@@ -38,7 +38,7 @@ interface Props {
 
 const throttledOnResize = useThrottleFn(onResize, 100);
 
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const uiStore = useUIStore();
 
 const props = defineProps<Props>();

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/NDVSubConnections.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/NDVSubConnections.vue
@@ -15,7 +15,7 @@ import type {
 import { useDebounce } from '@/app/composables/useDebounce';
 import { OnClickOutside } from '@vueuse/components';
 import { useI18n } from '@n8n/i18n';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 
 import { N8nIconButton, N8nTooltip } from '@n8n/design-system';
 interface Props {
@@ -61,7 +61,7 @@ const nodeType = computed(() =>
 const nodeData = computed(
 	() => workflowDocumentStore?.value?.getNodeByName(props.rootNode.name) ?? null,
 );
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 
 const workflowObjectAccessors = computed(() =>
 	workflowDocumentStore?.value

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/OutputPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/OutputPanel.vue
@@ -5,7 +5,7 @@ import RunData from '@/features/ndv/runData/components/RunData.vue';
 import RunInfo from '@/features/ndv/runData/components/RunInfo.vue';
 import { storeToRefs } from 'pinia';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import type { WorkflowObjectAccessors } from '@/app/types/workflow';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import RunDataAi from '@/features/ndv/runData/components/ai/RunDataAi.vue';
@@ -79,7 +79,7 @@ const emit = defineEmits<{
 // Stores
 
 const workflowId = useInjectWorkflowId();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const nodeTypesStore = useNodeTypesStore();
 const workflowsStore = useWorkflowsStore();
 const workflowState = injectWorkflowState();

--- a/packages/frontend/editor-ui/src/features/ndv/panel/components/TriggerPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/panel/components/TriggerPanel.vue
@@ -16,7 +16,7 @@ import CopyInput from '@/app/components/CopyInput.vue';
 import NodeIcon from '@/app/components/NodeIcon.vue';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { createEventBus } from '@n8n/utils/event-bus';
 import { useRouter } from 'vue-router';
@@ -56,7 +56,7 @@ const nodesTypeStore = useNodeTypesStore();
 const uiStore = useUIStore();
 const workflowsStore = useWorkflowsStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 
 const router = useRouter();
 const workflowHelpers = useWorkflowHelpers();

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/AssignmentCollection/Assignment.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/AssignmentCollection/Assignment.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { useResolvedExpression } from '@/app/composables/useResolvedExpression';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useBinaryDataAccessTooltip } from '@/features/ndv/shared/composables/useBinaryDataAccessTooltip';
 import useEnvironmentsStore from '@/features/settings/environments.ee/environments.store';
 import type { IUpdateInformation } from '@/Interface';
@@ -45,7 +45,7 @@ const emit = defineEmits<{
 }>();
 
 const i18n = useI18n();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const environmentsStore = useEnvironmentsStore();
 const { binaryDataAccessTooltip } = useBinaryDataAccessTooltip();
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/AssignmentCollection/AssignmentCollection.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/AssignmentCollection/AssignmentCollection.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useDebounce } from '@/app/composables/useDebounce';
 import { useI18n } from '@n8n/i18n';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import isEqual from 'lodash/isEqual';
 import type {
 	AssignmentCollectionValue,
@@ -60,7 +60,7 @@ const state = reactive<{ paramValue: AssignmentCollectionValue }>({
 	paramValue: createParamValue(props.value),
 });
 
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const experimentalNdvStore = useExperimentalNdvStore();
 const { callDebounced } = useDebounce();
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ButtonParameter/ButtonParameter.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ButtonParameter/ButtonParameter.test.ts
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { createTestingPinia } from '@pinia/testing';
 import ButtonParameter, { type Props } from './ButtonParameter.vue';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore, useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { usePostHog } from '@/app/stores/posthog.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
@@ -61,11 +61,13 @@ describe('ButtonParameter', () => {
 	};
 
 	beforeEach(() => {
-		vi.mocked(useNDVStore).mockReturnValue({
+		const ndvMock = {
 			ndvInputData: [{}],
 			activeNode: { name: 'TestNode', parameters: {} },
 			isDraggableDragging: false,
-		} as any);
+		} as any;
+		vi.mocked(useNDVStore).mockReturnValue(ndvMock);
+		vi.mocked(injectNDVStore).mockReturnValue(ndvMock);
 
 		vi.mocked(useWorkflowsStore).mockReturnValue({
 			workflowId: 'test-workflow-id',
@@ -114,9 +116,9 @@ describe('ButtonParameter', () => {
 	});
 
 	it('disables submit button when there is no execution data', async () => {
-		vi.mocked(useNDVStore).mockReturnValue({
-			ndvInputData: [],
-		} as any);
+		const ndvMock = { ndvInputData: [] } as any;
+		vi.mocked(useNDVStore).mockReturnValue(ndvMock);
+		vi.mocked(injectNDVStore).mockReturnValue(ndvMock);
 		const wrapper = mountComponent();
 		expect(wrapper.find('button').attributes('disabled')).toBeDefined();
 	});

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ButtonParameter/ButtonParameter.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ButtonParameter/ButtonParameter.vue
@@ -5,7 +5,7 @@ import { ref, computed, onMounted } from 'vue';
 import { N8nButton, N8nInput, N8nInputLabel, N8nTooltip } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import { useToast } from '@/app/composables/useToast';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import {
 	getParentNodes,
 	generateCodeForAiTransform,
@@ -31,7 +31,7 @@ export type Props = {
 };
 const props = defineProps<Props>();
 
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const activeNode = computed(() => ndvStore.activeNode);
 
 const i18n = useI18n();
@@ -41,7 +41,7 @@ const prompt = ref(props.value);
 const parentNodes = ref<INodeUi[]>([]);
 const textareaRowsData = ref<TextareaRowData | null>(null);
 
-const hasExecutionData = computed(() => (useNDVStore().ndvInputData || []).length > 0);
+const hasExecutionData = computed(() => (injectNDVStore().ndvInputData || []).length > 0);
 const hasInputField = computed(() => props.parameter.typeOptions?.buttonConfig?.hasInputField);
 const inputFieldMaxLength = computed(
 	() => props.parameter.typeOptions?.buttonConfig?.inputFieldMaxLength,

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/Collection/CollectionParameterLegacy.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/Collection/CollectionParameterLegacy.vue
@@ -14,7 +14,7 @@ import { deepCopy, isINodeProperties, isINodePropertyCollection } from 'n8n-work
 
 import get from 'lodash/get';
 
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { useI18n } from '@n8n/i18n';
 import { storeToRefs } from 'pinia';
@@ -38,7 +38,7 @@ const emit = defineEmits<{
 }>();
 
 const props = defineProps<Props>();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const i18n = useI18n();
 const nodeHelpers = useNodeHelpers();
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/Collection/CollectionParameterNew.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/Collection/CollectionParameterNew.vue
@@ -14,7 +14,7 @@ import { deepCopy, isINodeProperties, isINodePropertyCollection } from 'n8n-work
 
 import get from 'lodash/get';
 
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { useI18n } from '@n8n/i18n';
 import { storeToRefs } from 'pinia';
@@ -51,7 +51,7 @@ const props = withDefaults(defineProps<Props>(), {
 	isNested: false,
 	isNewlyAdded: false,
 });
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const i18n = useI18n();
 const nodeHelpers = useNodeHelpers();
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ExpressionEditModal.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ExpressionEditModal.vue
@@ -4,7 +4,7 @@ import { computed, ref, toRaw, watch } from 'vue';
 import Close from 'virtual:icons/mdi/close';
 
 import { useExternalHooks } from '@/app/composables/useExternalHooks';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { createExpressionTelemetryPayload } from '@/app/utils/telemetryUtils';
 
@@ -60,7 +60,7 @@ const emit = defineEmits<{
 	closeDialog: [];
 }>();
 
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const workflowsStore = useWorkflowsStore();
 const workflowDocumentStore = computed(() =>
 	useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId)),

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ExpressionParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ExpressionParameterInput.vue
@@ -6,7 +6,7 @@ import DraggableTarget from '@/app/components/DraggableTarget.vue';
 import ExpressionFunctionIcon from './ExpressionFunctionIcon.vue';
 import InlineExpressionEditorInput from '@/features/shared/editors/components/InlineExpressionEditor/InlineExpressionEditorInput.vue';
 import InlineExpressionEditorOutput from '@/features/shared/editors/components/InlineExpressionEditor/InlineExpressionEditorOutput.vue';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { createExpressionTelemetryPayload } from '@/app/utils/telemetryUtils';
 
@@ -58,7 +58,7 @@ const emit = defineEmits<{
 }>();
 
 const telemetry = useTelemetry();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const workflowsStore = useWorkflowsStore();
 
 const canvas = inject(CanvasKey, undefined);

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FilterConditions/FilterConditions.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FilterConditions/FilterConditions.vue
@@ -11,7 +11,7 @@ import {
 	type NodeParameterValue,
 } from 'n8n-workflow';
 import { computed, reactive, watch, watchEffect } from 'vue';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import {
 	DEFAULT_FILTER_OPTIONS,
 	DEFAULT_MAX_CONDITIONS,
@@ -52,7 +52,7 @@ const emit = defineEmits<{
 }>();
 
 const i18n = useI18n();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const { debounce } = useDebounce();
 
 const debouncedEmitChange = debounce(emitChange, { debounceTime: 1000 });

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterLegacy.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterLegacy.vue
@@ -17,7 +17,7 @@ import { useI18n } from '@n8n/i18n';
 import ParameterInputList from '../ParameterInputList.vue';
 import Draggable from 'vuedraggable';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { telemetry } from '@/app/plugins/telemetry';
 import { storeToRefs } from 'pinia';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
@@ -62,7 +62,7 @@ const emit = defineEmits<{
 }>();
 
 const workflowsStore = useWorkflowsStore();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 
 const { activeNode } = storeToRefs(ndvStore);
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.vue
@@ -3,7 +3,7 @@ import { useFixedCollectionItemState } from '@/app/composables/useFixedCollectio
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { telemetry } from '@/app/plugins/telemetry';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import type { IUpdateInformation } from '@/Interface';
 import type { N8nDropdownOption } from '@n8n/design-system';
 import {
@@ -31,7 +31,7 @@ import ParameterInputList from '../ParameterInputList.vue';
 import FixedCollectionItemList from './FixedCollectionItemList.vue';
 
 const locale = useI18n();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const workflowsStore = useWorkflowsStore();
 const nodeHelpers = useNodeHelpers();
 const { activeNode } = storeToRefs(ndvStore);

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ImportCurlModal.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ImportCurlModal.vue
@@ -7,7 +7,7 @@ import { createEventBus } from '@n8n/utils/event-bus';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useToast } from '@/app/composables/useToast';
 import { useI18n } from '@n8n/i18n';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 
 import { N8nButton, N8nInput, N8nInputLabel, N8nNotice } from '@n8n/design-system';
 const telemetry = useTelemetry();
@@ -15,7 +15,7 @@ const toast = useToast();
 const i18n = useI18n();
 
 const uiStore = useUIStore();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 
 const curlCommand = ref('');
 const modalBus = createEventBus();

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/MultipleParameter.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/MultipleParameter.vue
@@ -8,7 +8,7 @@ import { useI18n } from '@n8n/i18n';
 import type { IUpdateInformation } from '@/Interface';
 import CollectionParameter from './Collection/CollectionParameter.vue';
 import ParameterInputFull from './ParameterInputFull.vue';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { storeToRefs } from 'pinia';
 
 import { N8nButton, N8nIcon, N8nInputLabel, N8nText } from '@n8n/design-system';
@@ -32,7 +32,7 @@ const emit = defineEmits<{
 	valueChanged: [parameterData: IUpdateInformation];
 }>();
 
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const i18n = useI18n();
 
 const { activeNode } = storeToRefs(ndvStore);

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.test.ts
@@ -72,6 +72,7 @@ beforeEach(() => {
 vi.mock('@/features/ndv/shared/ndv.store', () => {
 	return {
 		useNDVStore: vi.fn(() => mockNdvState),
+		injectNDVStore: vi.fn(() => mockNdvState),
 	};
 });
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -73,7 +73,7 @@ import { useWorkflowHelpers } from '@/app/composables/useWorkflowHelpers';
 import { useNodeSettingsParameters } from '@/features/ndv/settings/composables/useNodeSettingsParameters';
 import { htmlEditorEventBus } from '@/app/event-bus';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
@@ -173,7 +173,7 @@ const nodeSettingsParameters = useNodeSettingsParameters();
 const telemetry = useTelemetry();
 
 const credentialsStore = useCredentialsStore();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const workflowsStore = useWorkflowsStore();
 const workflowsListStore = useWorkflowsListStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputFull.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputFull.test.ts
@@ -49,6 +49,7 @@ beforeEach(() => {
 vi.mock('@/features/ndv/shared/ndv.store', () => {
 	return {
 		useNDVStore: vi.fn(() => mockNdvState),
+		injectNDVStore: vi.fn(() => mockNdvState),
 	};
 });
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputFull.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputFull.vue
@@ -10,7 +10,7 @@ import FromAiOverrideField from './ParameterInputOverrides/FromAiOverrideField.v
 import ParameterOverrideSelectableList from './ParameterInputOverrides/ParameterOverrideSelectableList.vue';
 import { useI18n } from '@n8n/i18n';
 import { useToast } from '@/app/composables/useToast';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { getMappedResult } from '@/app/utils/mappingUtils';
 import {
 	hasExpressionMapping,
@@ -85,7 +85,7 @@ const menuExpanded = ref(false);
 const forceShowExpression = ref(false);
 const wrapperHovered = ref(false);
 
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const telemetry = useTelemetry();
 const { isEnabled: isCollectionOverhaulEnabled } = useCollectionOverhaul();
 

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
@@ -28,7 +28,7 @@ import {
 } from '@/app/constants';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useNodeSettingsParameters } from '@/features/ndv/settings/composables/useNodeSettingsParameters';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useI18n } from '@n8n/i18n';
 import AssignmentCollection from './AssignmentCollection/AssignmentCollection.vue';
 import ButtonParameter from './ButtonParameter/ButtonParameter.vue';
@@ -102,7 +102,7 @@ const emit = defineEmits<{
 }>();
 
 const nodeTypesStore = useNodeTypesStore();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 
 const message = useMessage();

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputWrapper.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputWrapper.vue
@@ -14,7 +14,7 @@ import {
 import { useResolvedExpression } from '@/app/composables/useResolvedExpression';
 import useEnvironmentsStore from '@/features/settings/environments.ee/environments.store';
 import { useExternalSecretsStore } from '@/features/integrations/externalSecrets.ee/externalSecrets.ee.store';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useBinaryDataAccessTooltip } from '@/features/ndv/shared/composables/useBinaryDataAccessTooltip';
 import { isValueExpression, parseResourceMapperFieldName } from '@/app/utils/nodeTypesUtils';
 import type { EventBus } from '@n8n/utils/event-bus';
@@ -62,7 +62,7 @@ const emit = defineEmits<{
 	textInput: [value: IUpdateInformation];
 }>();
 
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const externalSecretsStore = useExternalSecretsStore();
 const environmentsStore = useEnvironmentsStore();
 const { binaryDataAccessTooltip } = useBinaryDataAccessTooltip();

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterOptions.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterOptions.vue
@@ -8,7 +8,7 @@ import {
 import { isValueExpression } from '@/app/utils/nodeTypesUtils';
 import { computed, inject } from 'vue';
 import { ChatHubToolContextKey } from '@/app/constants';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { AI_TRANSFORM_NODE_TYPE } from '@/app/constants/nodeTypes';
 import { getParameterTypeOption } from '@/features/ndv/shared/ndv.utils';
 import { useIsInExperimentalNdv } from '@/features/workflows/canvas/experimental/composables/useIsInExperimentalNdv';
@@ -56,7 +56,7 @@ const emit = defineEmits<{
 }>();
 
 const i18n = useI18n();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 
 const activeNode = computed(() => ndvStore.activeNode);
 const isDefault = computed(() => props.parameter.default === props.value);

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
@@ -9,7 +9,7 @@ import { useI18n } from '@n8n/i18n';
 import type { BaseTextKey } from '@n8n/i18n';
 import { useWorkflowHelpers } from '@/app/composables/useWorkflowHelpers';
 import { ndvEventBus } from '@/features/ndv/shared/ndv.eventBus';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useUIStore } from '@/app/stores/ui.store';
@@ -157,7 +157,7 @@ const showSlowLoadNotice = ref(false);
 const longLoadingTimer = ref<NodeJS.Timeout | null>(null);
 
 const nodeTypesStore = useNodeTypesStore();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const rootStore = useRootStore();
 const uiStore = useUIStore();
 const workflowsStore = useWorkflowsStore();
@@ -567,7 +567,7 @@ onMounted(() => {
 	props.eventBus.on('refreshList', refreshList);
 	window.addEventListener('resize', setWidth);
 
-	useNDVStore().$subscribe(() => {
+	injectNDVStore().$subscribe(() => {
 		// Update the width when main panel dimension change
 		setWidth();
 	});

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/MappingFields.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/MappingFields.vue
@@ -13,7 +13,7 @@ import ParameterIssues from '../ParameterIssues.vue';
 import ParameterOptions from '../ParameterOptions.vue';
 import { computed } from 'vue';
 import { i18n as locale, useI18n } from '@n8n/i18n';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import {
 	fieldCannotBeDeleted,
 	isMatchingField,
@@ -69,7 +69,7 @@ const emit = defineEmits<{
 	refreshFieldList: [];
 }>();
 
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 
 function markAsReadOnly(field: ResourceMapperField): boolean {
 	if (

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/ResourceMapper.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/ResourceMapper.vue
@@ -26,7 +26,7 @@ import {
 } from '@/app/utils/nodeTypesUtils';
 import { isFullExecutionResponse, isResourceMapperValue } from '@/app/utils/typeGuards';
 import { i18n as locale } from '@n8n/i18n';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useDocumentVisibility } from '@/app/composables/useDocumentVisibility';
 import isEqual from 'lodash/isEqual';
@@ -47,7 +47,7 @@ type Props = {
 };
 
 const nodeTypesStore = useNodeTypesStore();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const workflowsStore = useWorkflowsStore();
 const projectsStore = useProjectsStore();
 const expressionLocalResolveCtx = inject(ExpressionLocalResolveContextSymbol, undefined);

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/TextEdit.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/TextEdit.vue
@@ -3,7 +3,7 @@ import { ref, watch, onMounted, nextTick } from 'vue';
 import type { INodeProperties } from 'n8n-workflow';
 import { APP_MODALS_ELEMENT_ID } from '@/app/constants';
 import { useI18n } from '@n8n/i18n';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { storeToRefs } from 'pinia';
 
 import { ElDialog } from 'element-plus';
@@ -24,7 +24,7 @@ const emit = defineEmits<{
 const inputField = ref<HTMLInputElement | null>(null);
 const tempValue = ref('');
 
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const i18n = useI18n();
 
 const { activeNode } = storeToRefs(ndvStore);

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/composables/useWorkflowResourcesLocator.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/composables/useWorkflowResourcesLocator.ts
@@ -1,5 +1,7 @@
 import { ref, computed } from 'vue';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
 import type { Router } from 'vue-router';
 import { VIEWS } from '@/app/constants';
 
@@ -10,7 +12,12 @@ import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 
 export function useWorkflowResourcesLocator(router: Router) {
 	const workflowsListStore = useWorkflowsListStore();
-	const ndvStore = useNDVStore();
+	const workflowsStore = useWorkflowsStore();
+	const ndvStore = computed(() =>
+		workflowsStore.workflowId
+			? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: null,
+	);
 	const { renameNode } = useCanvasOperations();
 
 	const workflowsResources = ref<
@@ -103,7 +110,7 @@ export function useWorkflowResourcesLocator(router: Router) {
 	function applyDefaultExecuteWorkflowNodeName(workflowId: NodeParameterValue) {
 		if (typeof workflowId !== 'string') return;
 
-		const nodeName = ndvStore.activeNodeName;
+		const nodeName = ndvStore.value?.activeNodeName;
 		if (
 			nodeName &&
 			(/^Execute Workflow\d*$/.test(nodeName) ||

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/utils/buttonParameter.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/utils/buttonParameter.utils.test.ts
@@ -23,11 +23,13 @@ vi.mock('@n8n/stores/useRootStore', () => ({
 	}),
 }));
 
-vi.mock('@/features/ndv/shared/ndv.store', () => ({
-	useNDVStore: () => ({
-		pushRef: 'mockNdvPushRef',
-	}),
-}));
+vi.mock('@/features/ndv/shared/ndv.store', () => {
+	const mockStore = { pushRef: 'mockNdvPushRef' };
+	return {
+		useNDVStore: () => mockStore,
+		injectNDVStore: () => mockStore,
+	};
+});
 
 vi.mock('@/app/stores/settings.store', () => ({
 	useSettingsStore: vi.fn(() => ({ settings: {}, isAskAiEnabled: true })),

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/utils/buttonParameter.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/utils/buttonParameter.utils.ts
@@ -22,8 +22,10 @@ export type TextareaRowData = {
 };
 
 export function getParentNodes() {
-	const activeNode = useNDVStore().activeNode;
 	const { workflowId } = useWorkflowsStore();
+	if (!workflowId) return [];
+	const ndvStore = useNDVStore(createWorkflowDocumentId(workflowId));
+	const activeNode = ndvStore.activeNode;
 	const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
 
 	if (!activeNode) return [];
@@ -188,12 +190,14 @@ export function reducePayloadSizeOrThrow(
 export async function generateCodeForAiTransform(prompt: string, path: string, retries = 1) {
 	const schemas = getSchemas();
 
+	const { workflowId } = useWorkflowsStore();
+	const ndvStore = workflowId ? useNDVStore(createWorkflowDocumentId(workflowId)) : null;
 	const payload: AskAiRequest.RequestPayload = {
 		question: prompt,
 		context: {
 			schema: schemas.parentNodesSchemas,
 			inputSchema: schemas.inputSchema!,
-			ndvPushRef: useNDVStore().pushRef,
+			ndvPushRef: ndvStore?.pushRef ?? '',
 			pushRef: useRootStore().pushRef,
 		},
 		forNode: 'transform',

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
@@ -53,7 +53,7 @@ import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useToast } from '@/app/composables/useToast';
 import { dataPinningEventBus } from '@/app/event-bus';
 import { ndvEventBus } from '@/features/ndv/shared/ndv.eventBus';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
@@ -227,7 +227,7 @@ const dataContainerRef = ref<HTMLDivElement>();
 
 const workflowId = useInjectWorkflowId();
 const nodeTypesStore = useNodeTypesStore();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const workflowsStore = useWorkflowsStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const sourceControlStore = useSourceControlStore();

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataJson.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataJson.vue
@@ -7,7 +7,7 @@ import { executionDataToJson } from '@/app/utils/nodeTypesUtils';
 import { isString } from '@/app/utils/typeGuards';
 import { shorten } from '@/app/utils/typesUtils';
 import type { INodeUi } from '@/Interface';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import MappingPill from './MappingPill.vue';
 import { getMappedExpression } from '@/app/utils/mappingUtils';
 import { nonExistingJsonPath } from '@/app/constants';
@@ -43,7 +43,7 @@ const props = withDefaults(
 	},
 );
 
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 
 const externalHooks = useExternalHooks();

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataJsonActions.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataJsonActions.vue
@@ -5,7 +5,7 @@ import { NodeConnectionTypes, type IDataObject, type IRunExecutionData } from 'n
 import { clearJsonKey, convertPath } from '@/app/utils/typesUtils';
 import { executionDataToJson } from '@/app/utils/nodeTypesUtils';
 import { useInjectWorkflowId } from '@/app/composables/useInjectWorkflowId';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { useToast } from '@/app/composables/useToast';
 import { useI18n } from '@n8n/i18n';
@@ -43,7 +43,7 @@ const popOutWindow = inject(PopOutWindowKey, ref<Window | undefined>());
 const isInPopOutWindow = computed(() => popOutWindow?.value !== undefined);
 
 const workflowId = useInjectWorkflowId();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 
 const clipboard = useClipboard();
 

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataTable.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunDataTable.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useExternalHooks } from '@/app/composables/useExternalHooks';
 import type { INodeUi, IRunDataDisplayMode, ITableData } from '@/Interface';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { getMappedExpression } from '@/app/utils/mappingUtils';
@@ -76,7 +76,7 @@ const columnLimitExceeded = ref(false);
 const draggableRef = ref<DraggableRef>();
 const fixedColumnWidths = ref<number[] | undefined>();
 
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const workflowsStore = useWorkflowsStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.test.ts
@@ -27,7 +27,7 @@ import { fireEvent } from '@testing-library/dom';
 import { userEvent } from '@testing-library/user-event';
 import { cleanup, waitFor } from '@testing-library/vue';
 import { computed, shallowRef } from 'vue';
-import { WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
+import { NDVStoreKey, WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
 import {
 	createResultOk,
 	NodeConnectionTypes,
@@ -291,6 +291,7 @@ describe('VirtualSchema.vue', () => {
 		);
 		workflowDocumentStore.setActiveState({ activeVersionId: 'v1', activeVersion: null });
 		workflowDocumentStore.setName(workflowsStore.workflow.name);
+		const ndvStoreForRender = useNDVStore(createWorkflowDocumentId(workflowsStore.workflow.id));
 
 		renderComponent = createComponentRenderer(VirtualSchema, {
 			global: {
@@ -305,6 +306,7 @@ describe('VirtualSchema.vue', () => {
 				},
 				provide: {
 					[WorkflowDocumentStoreKey as symbol]: shallowRef(workflowDocumentStore),
+					[NDVStoreKey as symbol]: shallowRef(ndvStoreForRender),
 				},
 				mocks: {
 					$locale: {

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/VirtualSchema.vue
@@ -18,7 +18,7 @@ import { useI18n } from '@n8n/i18n';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useCalloutHelpers } from '@/app/composables/useCalloutHelpers';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { executionDataToJson } from '@/app/utils/nodeTypesUtils';
@@ -83,7 +83,7 @@ const props = withDefaults(defineProps<Props>(), {
 const telemetry = useTelemetry();
 const telemetryContext = useTelemetryContext();
 const i18n = useI18n();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const nodeTypesStore = useNodeTypesStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const schemaPreviewStore = useSchemaPreviewStore();

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/error/NodeErrorView.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/error/NodeErrorView.vue
@@ -6,7 +6,7 @@ import { useClipboard } from '@/app/composables/useClipboard';
 import { useInjectWorkflowId } from '@/app/composables/useInjectWorkflowId';
 import { useToast } from '@/app/composables/useToast';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import type {
@@ -52,7 +52,7 @@ const assistantHelpers = useAIAssistantHelpers();
 
 const workflowId = useInjectWorkflowId();
 const nodeTypesStore = useNodeTypesStore();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const workflowsStore = useWorkflowsStore();
 const rootStore = useRootStore();
 const assistantStore = useAssistantStore();

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
@@ -41,7 +41,7 @@ import NodeTitle from '@/app/components/NodeTitle.vue';
 import { RenameNodeCommand } from '@/app/models/history';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { useHistoryStore } from '@/app/stores/history.store';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
@@ -122,7 +122,7 @@ const slots = defineSlots<{ actions?: {} }>();
 const nodeValues = ref<INodeParameters>(getNodeSettingsInitialValues());
 
 const nodeTypesStore = useNodeTypesStore();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const workflowsStore = useWorkflowsStore();
 const workflowsListStore = useWorkflowsListStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsInvalidNodeWarning.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsInvalidNodeWarning.vue
@@ -4,7 +4,7 @@ import { useTelemetry } from '@/app/composables/useTelemetry';
 import { CUSTOM_NODES_DOCS_URL } from '@/app/constants';
 import { COMMUNITY_PACKAGE_INSTALL_MODAL_KEY } from '@/features/settings/communityNodes/communityNodes.constants';
 import type { INodeUi } from '@/Interface';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeCreatorStore } from '@/features/shared/nodeCreator/nodeCreator.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUIStore } from '@/app/stores/ui.store';
@@ -24,7 +24,7 @@ const i18n = useI18n();
 const telemetry = useTelemetry();
 const nodeTypesStore = useNodeTypesStore();
 const uiStore = useUIStore();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const nodeCreatorStore = useNodeCreatorStore();
 const usersStore = useUsersStore();
 

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsTabs.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsTabs.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { ITab } from '@/Interface';
 import { COMMUNITY_NODES_INSTALLATION_DOCS_URL } from '@/features/settings/communityNodes/communityNodes.constants';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import type { INodeTypeDescription } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
@@ -39,7 +39,7 @@ const emit = defineEmits<{
 }>();
 
 const externalHooks = useExternalHooks();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const workflowsStore = useWorkflowsStore();
 const i18n = useI18n();
 const telemetry = useTelemetry();

--- a/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/composables/useNodeSettingsParameters.ts
@@ -62,6 +62,11 @@ export function useNodeSettingsParameters() {
 	const workflowDocumentStore = computed(() =>
 		useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId)),
 	);
+	const ndvStore = computed(() =>
+		workflowsStore.workflowId
+			? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: null,
+	);
 	const nodeTypesStore = useNodeTypesStore();
 	const settingsStore = useSettingsStore();
 	const telemetry = useTelemetry();
@@ -175,7 +180,6 @@ export function useNodeSettingsParameters() {
 	function handleFocus(node: INodeUi | undefined, path: string, parameter: INodeProperties) {
 		if (!node) return;
 
-		const ndvStore = useNDVStore();
 		const focusPanelStore = useFocusPanelStore();
 
 		focusPanelStore.openWithFocusedNodeParameter({
@@ -184,9 +188,9 @@ export function useNodeSettingsParameters() {
 			parameter,
 		});
 
-		if (ndvStore.activeNode) {
-			ndvStore.unsetActiveNodeName();
-			ndvStore.resetNDVPushRef();
+		if (ndvStore.value?.activeNode) {
+			ndvStore.value.unsetActiveNodeName();
+			ndvStore.value.resetNDVPushRef();
 		}
 	}
 

--- a/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.test.ts
@@ -28,4 +28,24 @@ describe('ndv.store', () => {
 		expect(recreatedNDVStore).not.toBe(ndvStore);
 		expect(recreatedNDVStore.activeNodeName).toBeNull();
 	});
+
+	it('keeps state isolated between stores keyed by different workflow ids', () => {
+		const storeA = useNDVStore(createWorkflowDocumentId('workflow-a'));
+		const storeB = useNDVStore(createWorkflowDocumentId('workflow-b'));
+
+		storeA.setActiveNodeName('Node from A', 'other');
+		storeA.draggableStartDragging('mapping', 'value-from-a');
+
+		expect(storeA.activeNodeName).toBe('Node from A');
+		expect(storeA.draggable.isDragging).toBe(true);
+		expect(storeA.draggable.data).toBe('value-from-a');
+
+		expect(storeB.activeNodeName).toBeNull();
+		expect(storeB.draggable.isDragging).toBe(false);
+		expect(storeB.draggable.data).toBe('');
+
+		storeB.setActiveNodeName('Node from B', 'other');
+		expect(storeA.activeNodeName).toBe('Node from A');
+		expect(storeB.activeNodeName).toBe('Node from B');
+	});
 });

--- a/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.ts
@@ -28,6 +28,8 @@ import {
 } from '@/app/stores/workflowDocument.store';
 import { computed, ref } from 'vue';
 import type { TelemetryNdvSource } from '@/app/types/telemetry';
+import { NDVStoreKey } from '@/app/constants/injectionKeys';
+import { injectStrict } from '@/app/utils/injectStrict';
 
 export type NDVStoreId = WorkflowDocumentId;
 
@@ -487,4 +489,12 @@ export function disposeNDVStore(store: NDVStore) {
 	if (pinia) {
 		delete pinia.state.value[store.$id];
 	}
+}
+
+export function injectNDVStore(): NDVStore {
+	const storeRef = injectStrict(NDVStoreKey);
+	if (!storeRef.value) {
+		throw new Error('NDV store is not initialized for the current workflow');
+	}
+	return storeRef.value;
 }

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.test.ts
@@ -17,7 +17,11 @@ import { createComponentRenderer } from '@/__tests__/render';
 import { setupServer } from '@/__tests__/server';
 import { createTestWorkflow, defaultNodeDescriptions, mockNodes } from '@/__tests__/mocks';
 import { computed, shallowRef } from 'vue';
-import { WorkflowDocumentStoreKey, WorkflowIdKey } from '@/app/constants/injectionKeys';
+import {
+	NDVStoreKey,
+	WorkflowDocumentStoreKey,
+	WorkflowIdKey,
+} from '@/app/constants/injectionKeys';
 
 vi.mock('vue-router', () => {
 	return {
@@ -40,7 +44,7 @@ async function createPiniaStore(isActiveNode: boolean) {
 
 	const workflowsStore = useWorkflowsStore();
 	const nodeTypesStore = useNodeTypesStore();
-	const ndvStore = useNDVStore();
+	const ndvStore = useNDVStore(createWorkflowDocumentId(workflow.id));
 
 	nodeTypesStore.setNodeTypes(defaultNodeDescriptions);
 	workflowsStore.workflow = workflow;
@@ -51,6 +55,7 @@ async function createPiniaStore(isActiveNode: boolean) {
 	workflowDocumentStore.initPristineNodeMetadata(node.name);
 
 	const workflowDocumentStoreRef = shallowRef(workflowDocumentStore);
+	const ndvStoreRef = shallowRef(ndvStore);
 
 	if (isActiveNode) {
 		ndvStore.setActiveNodeName(node.name, 'other');
@@ -63,6 +68,7 @@ async function createPiniaStore(isActiveNode: boolean) {
 		pinia,
 		workflow,
 		workflowDocumentStoreRef,
+		ndvStoreRef,
 		nodeName: node.name,
 	};
 }
@@ -83,13 +89,14 @@ describe('NodeDetailsView', () => {
 	});
 
 	it('should render correctly', async () => {
-		const { pinia, workflow, workflowDocumentStoreRef } = await createPiniaStore(true);
+		const { pinia, workflow, workflowDocumentStoreRef, ndvStoreRef } = await createPiniaStore(true);
 
 		const renderComponent = createComponentRenderer(NodeDetailsView, {
 			global: {
 				provide: {
 					[WorkflowIdKey as unknown as string]: computed(() => workflow.id),
 					[WorkflowDocumentStoreKey as symbol]: workflowDocumentStoreRef,
+					[NDVStoreKey as symbol]: ndvStoreRef,
 				},
 				mocks: {
 					$route: {
@@ -108,13 +115,15 @@ describe('NodeDetailsView', () => {
 
 	describe('keyboard listener', () => {
 		test('should register and unregister keydown listener based on modal open state', async () => {
-			const { pinia, workflow, workflowDocumentStoreRef } = await createPiniaStore(true);
+			const { pinia, workflow, workflowDocumentStoreRef, ndvStoreRef } =
+				await createPiniaStore(true);
 
 			const renderComponent = createComponentRenderer(NodeDetailsView, {
 				global: {
 					provide: {
 						[WorkflowIdKey as unknown as string]: computed(() => workflow.id),
 						[WorkflowDocumentStoreKey as symbol]: workflowDocumentStoreRef,
+						[NDVStoreKey as symbol]: ndvStoreRef,
 					},
 					mocks: {
 						$route: {
@@ -148,7 +157,8 @@ describe('NodeDetailsView', () => {
 		});
 
 		test('should unregister keydown listener on unmount', async () => {
-			const { pinia, workflow, workflowDocumentStoreRef, nodeName } = await createPiniaStore(false);
+			const { pinia, workflow, workflowDocumentStoreRef, ndvStoreRef, nodeName } =
+				await createPiniaStore(false);
 			const ndvStore = useNDVStore(pinia);
 
 			const renderComponent = createComponentRenderer(NodeDetailsView, {
@@ -156,6 +166,7 @@ describe('NodeDetailsView', () => {
 					provide: {
 						[WorkflowIdKey as unknown as string]: computed(() => workflow.id),
 						[WorkflowDocumentStoreKey as symbol]: workflowDocumentStoreRef,
+						[NDVStoreKey as symbol]: ndvStoreRef,
 					},
 					mocks: {
 						$route: {

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.vue
@@ -24,7 +24,7 @@ import { dataPinningEventBus } from '@/app/event-bus';
 import { ndvEventBus } from '@/features/ndv/shared/ndv.eventBus';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useDeviceSupport } from '@n8n/composables/useDeviceSupport';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
@@ -63,7 +63,7 @@ const props = withDefaults(
 	},
 );
 
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const externalHooks = useExternalHooks();
 const nodeHelpers = useNodeHelpers();
 const { activeNode } = storeToRefs(ndvStore);

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.test.ts
@@ -16,7 +16,11 @@ import {
 import { createComponentRenderer } from '@/__tests__/render';
 import { createTestNode, createTestWorkflow, defaultNodeDescriptions } from '@/__tests__/mocks';
 import { computed, shallowRef } from 'vue';
-import { WorkflowDocumentStoreKey, WorkflowIdKey } from '@/app/constants/injectionKeys';
+import {
+	NDVStoreKey,
+	WorkflowDocumentStoreKey,
+	WorkflowIdKey,
+} from '@/app/constants/injectionKeys';
 
 vi.mock('vue-router', () => ({
 	useRouter: () => ({}),
@@ -48,11 +52,13 @@ const setupStore = (nodes: Array<ReturnType<typeof createTestNode>>) => {
 	);
 
 	const workflowDocumentStoreRef = shallowRef(workflowDocumentStore);
+	const ndvStoreRef = shallowRef(useNDVStore(createWorkflowDocumentId(workflow.id)));
 
 	return {
 		pinia,
 		workflow,
 		workflowDocumentStoreRef,
+		ndvStoreRef,
 	};
 };
 
@@ -60,6 +66,7 @@ describe('NodeDetailsViewV2', () => {
 	let pinia: ReturnType<typeof createTestingPinia>;
 	let workflowId: string;
 	let workflowDocumentStoreRef: ReturnType<typeof setupStore>['workflowDocumentStoreRef'];
+	let ndvStoreRef: ReturnType<typeof setupStore>['ndvStoreRef'];
 	const manualTriggerNode = createTestNode({
 		name: 'Manual Trigger',
 		type: MANUAL_TRIGGER_NODE_TYPE,
@@ -70,7 +77,7 @@ describe('NodeDetailsViewV2', () => {
 	const renderComponent = (props: { readOnly?: boolean; activeNodeName?: string | null } = {}) => {
 		const { activeNodeName = null, ...componentProps } = props;
 
-		const ndvStore = useNDVStore();
+		const ndvStore = ndvStoreRef.value;
 		if (activeNodeName) {
 			ndvStore.setActiveNodeName(activeNodeName, 'other');
 		} else {
@@ -85,6 +92,7 @@ describe('NodeDetailsViewV2', () => {
 				provide: {
 					[WorkflowIdKey as unknown as string]: computed(() => workflowId),
 					[WorkflowDocumentStoreKey as symbol]: workflowDocumentStoreRef,
+					[NDVStoreKey as symbol]: ndvStoreRef,
 				},
 				mocks: {
 					$route: {
@@ -121,6 +129,7 @@ describe('NodeDetailsViewV2', () => {
 			pinia = store.pinia;
 			workflowId = store.workflow.id;
 			workflowDocumentStoreRef = store.workflowDocumentStoreRef;
+			ndvStoreRef = store.ndvStoreRef;
 		});
 
 		test('should not render when no node is active', () => {
@@ -165,6 +174,7 @@ describe('NodeDetailsViewV2', () => {
 			pinia = store.pinia;
 			workflowId = store.workflow.id;
 			workflowDocumentStoreRef = store.workflowDocumentStoreRef;
+			ndvStoreRef = store.ndvStoreRef;
 		});
 
 		test('should register keydown listener on mount', async () => {
@@ -199,6 +209,7 @@ describe('NodeDetailsViewV2', () => {
 			pinia = store.pinia;
 			workflowId = store.workflow.id;
 			workflowDocumentStoreRef = store.workflowDocumentStoreRef;
+			ndvStoreRef = store.ndvStoreRef;
 		});
 
 		test('should open dialog on mount', async () => {
@@ -236,6 +247,7 @@ describe('NodeDetailsViewV2', () => {
 			pinia = store.pinia;
 			workflowId = store.workflow.id;
 			workflowDocumentStoreRef = store.workflowDocumentStoreRef;
+			ndvStoreRef = store.ndvStoreRef;
 		});
 
 		test('should close NDV when close button is clicked', async () => {

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.vue
@@ -28,7 +28,7 @@ import {
 import type { DataPinningDiscoveryEvent } from '@/app/event-bus';
 import { dataPinningEventBus } from '@/app/event-bus';
 import { ndvEventBus } from '../ndv.eventBus';
-import { useNDVStore } from '../ndv.store';
+import { injectNDVStore } from '../ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
@@ -64,7 +64,7 @@ const props = withDefaults(
 	},
 );
 
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const externalHooks = useExternalHooks();
 const nodeHelpers = useNodeHelpers();
 const { activeNode } = storeToRefs(ndvStore);

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/cards/SetupCardBody.vue
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/cards/SetupCardBody.vue
@@ -59,7 +59,11 @@ const workflowsStore = useWorkflowsStore();
 const workflowDocumentStore = computed(() =>
 	useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId)),
 );
-const ndvStore = useNDVStore();
+const ndvStore = computed(() =>
+	workflowsStore.workflowId
+		? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: null,
+);
 
 const nodeType = computed(() =>
 	nodeTypesStore.getNodeType(props.state.node.type, props.state.node.typeVersion),
@@ -121,7 +125,7 @@ const nodeNames = computed(() => (props.state.allNodesUsingCredential ?? []).map
 const nodeNamesTooltip = computed(() => nodeNames.value.join(', '));
 
 const openNdv = () => {
-	ndvStore.setActiveNodeName(props.state.node.name, 'other');
+	ndvStore.value?.setActiveNodeName(props.state.node.name, 'other');
 };
 
 // Hide parameter issues until the user interacts with a parameter.

--- a/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/AskAI/AskAI.vue
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/AskAI/AskAI.vue
@@ -15,7 +15,7 @@ import { useDataSchema } from '@/app/composables/useDataSchema';
 import { useI18n } from '@n8n/i18n';
 import { useMessage } from '@/app/composables/useMessage';
 import { useToast } from '@/app/composables/useToast';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { executionDataToJson } from '@/app/utils/nodeTypesUtils';
@@ -64,13 +64,13 @@ const isSubmitEnabled = computed(() => {
 	);
 });
 const hasExecutionData = computed(
-	() => (useNDVStore().ndvInputDataWithPinnedData || []).length > 0,
+	() => (injectNDVStore().ndvInputDataWithPinnedData || []).length > 0,
 );
 const loadingString = computed(() =>
 	i18n.baseText(`codeNodeEditor.askAi.loadingPhrase${loadingPhraseIndex.value}` as BaseTextKey),
 );
 const isEachItemMode = computed(() => {
-	const mode = useNDVStore().activeNode?.parameters.mode as CodeExecutionMode;
+	const mode = injectNDVStore().activeNode?.parameters.mode as CodeExecutionMode;
 
 	return mode === 'runOnceForEachItem';
 });
@@ -93,7 +93,7 @@ function getErrorMessageByStatusCode(statusCode: number, message: string | undef
 }
 
 function getParentNodes() {
-	const activeNode = useNDVStore().activeNode;
+	const activeNode = injectNDVStore().activeNode;
 	const { workflowId } = useWorkflowsStore();
 
 	if (!activeNode || !workflowId) return [];
@@ -154,7 +154,7 @@ function stopLoading() {
 
 async function onSubmit() {
 	const { restApiContext } = useRootStore();
-	const { activeNode } = useNDVStore();
+	const { activeNode } = injectNDVStore();
 	const { showMessage } = useToast();
 	const { alert } = useMessage();
 	if (!activeNode) return;
@@ -182,7 +182,7 @@ async function onSubmit() {
 		context: {
 			schema: schemas.parentNodesSchemas,
 			inputSchema: schemas.inputSchema,
-			ndvPushRef: useNDVStore().pushRef,
+			ndvPushRef: injectNDVStore().pushRef,
 			pushRef: rootStore.pushRef,
 		},
 		forNode: 'code',
@@ -246,7 +246,7 @@ function triggerLoadingChange() {
 }
 
 function getSessionStoragePrompt() {
-	const codeNodeName = (useNDVStore().activeNode?.name as string) ?? '';
+	const codeNodeName = (injectNDVStore().activeNode?.name as string) ?? '';
 	const hashedCode = snakeCase(codeNodeName);
 
 	return useSessionStorage(`ask_ai_prompt__${hashedCode}`, '');

--- a/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/completions/jsonField.completions.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/completions/jsonField.completions.ts
@@ -5,12 +5,20 @@ import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { isAllowedInDotNotation } from '@/features/shared/editors/plugins/codemirror/completions/utils';
 import { useI18n } from '@n8n/i18n';
 import type { IRunData, IDataObject } from 'n8n-workflow';
-import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import {
+	createWorkflowDocumentId,
+	injectWorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
+import { computed } from 'vue';
 
 function useJsonFieldCompletions() {
 	const i18n = useI18n();
-	const ndvStore = useNDVStore();
 	const workflowsStore = useWorkflowsStore();
+	const ndvStore = computed(() =>
+		workflowsStore.workflowId
+			? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: null,
+	);
 	const workflowDocumentStore = injectWorkflowDocumentStore();
 
 	/**
@@ -174,7 +182,7 @@ function useJsonFieldCompletions() {
 
 	const getInputNodeName = (): string | null => {
 		try {
-			const activeNode = ndvStore.activeNode;
+			const activeNode = ndvStore.value?.activeNode;
 			if (activeNode) {
 				const input = (workflowDocumentStore?.value?.connectionsByDestinationNode ?? {})[
 					activeNode.name

--- a/packages/frontend/editor-ui/src/features/shared/editors/components/InlineExpressionEditor/InlineExpressionEditorOutput.vue
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/InlineExpressionEditor/InlineExpressionEditorOutput.vue
@@ -2,7 +2,7 @@
 import type { EditorState, SelectionRange } from '@codemirror/state';
 
 import { useI18n } from '@n8n/i18n';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import type { Segment } from '@/app/types/expressions';
 import { onBeforeUnmount, useTemplateRef } from 'vue';
 import ExpressionOutput from './ExpressionOutput.vue';
@@ -31,7 +31,7 @@ withDefaults(defineProps<InlineExpressionEditorOutputProps>(), {
 
 const i18n = useI18n();
 const theme = outputTheme();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const contentRef = useTemplateRef('content');
 const { APP_Z_INDEXES } = useStyles();
 

--- a/packages/frontend/editor-ui/src/features/shared/editors/components/InlineExpressionEditor/InlineExpressionTip.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/InlineExpressionEditor/InlineExpressionTip.test.ts
@@ -13,6 +13,7 @@ let mockCompletionResult: Partial<CompletionResult>;
 vi.mock('@/features/ndv/shared/ndv.store', () => {
 	return {
 		useNDVStore: vi.fn(() => mockNdvState),
+		injectNDVStore: vi.fn(() => mockNdvState),
 	};
 });
 

--- a/packages/frontend/editor-ui/src/features/shared/editors/components/InlineExpressionEditor/InlineExpressionTip.vue
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/InlineExpressionEditor/InlineExpressionTip.vue
@@ -3,7 +3,7 @@ import { useI18n } from '@n8n/i18n';
 import { FIELDS_SECTION } from '../../plugins/codemirror/completions/constants';
 import { datatypeCompletions } from '../../plugins/codemirror/completions/datatype.completions';
 import { isCompletionSection } from '../../plugins/codemirror/completions/utils';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { type Completion, CompletionContext } from '@codemirror/autocomplete';
 import { EditorSelection, EditorState, type SelectionRange } from '@codemirror/state';
 import { watchDebounced } from '@vueuse/core';
@@ -25,7 +25,7 @@ const props = withDefaults(defineProps<Props>(), {
 });
 
 const i18n = useI18n();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 
 const canAddDotToExpression = ref(false);
 const resolvedExpressionHasFields = ref(false);

--- a/packages/frontend/editor-ui/src/features/shared/editors/components/InlineExpressionEditor/OutputItemSelect.vue
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/InlineExpressionEditor/OutputItemSelect.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import { useI18n } from '@n8n/i18n';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { computed } from 'vue';
 
 import { N8nIconButton, N8nInputNumber, N8nText, N8nTooltip } from '@n8n/design-system';
 const i18n = useI18n();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 
 const hoveringItem = computed(() => ndvStore.getHoveringItem);
 const hoveringItemIndex = computed(() => hoveringItem.value?.itemIndex);

--- a/packages/frontend/editor-ui/src/features/shared/editors/composables/useExpressionEditor.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/composables/useExpressionEditor.test.ts
@@ -17,11 +17,13 @@ vi.mock('@/app/composables/useAutocompleteTelemetry', () => ({
 	useAutocompleteTelemetry: vi.fn(),
 }));
 
-vi.mock('@/features/ndv/shared/ndv.store', () => ({
-	useNDVStore: vi.fn(() => ({
-		activeNode: { type: 'n8n-nodes-base.test' },
-	})),
-}));
+vi.mock('@/features/ndv/shared/ndv.store', () => {
+	const mockStore = { activeNode: { type: 'n8n-nodes-base.test' } };
+	return {
+		useNDVStore: vi.fn(() => mockStore),
+		injectNDVStore: vi.fn(() => mockStore),
+	};
+});
 
 vi.mock(import('../plugins/codemirror/completions/utils'), async (importOriginal) => {
 	const actual = await importOriginal();

--- a/packages/frontend/editor-ui/src/features/shared/editors/composables/useExpressionEditor.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/composables/useExpressionEditor.ts
@@ -22,6 +22,7 @@ import {
 	ExpressionLocalResolveContextSymbol,
 } from '@/app/constants';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
 
 import type { TargetItem, TargetNodeParameterContext } from '@/Interface';
 import {
@@ -75,8 +76,12 @@ export const useExpressionEditor = ({
 	disableSearchDialog?: MaybeRefOrGetter<boolean>;
 	onChange?: (viewUpdate: ViewUpdate) => void;
 }) => {
-	const ndvStore = useNDVStore();
 	const workflowsStore = useWorkflowsStore();
+	const ndvStore = computed(() =>
+		workflowsStore.workflowId
+			? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: null,
+	);
 	const workflowHelpers = useWorkflowHelpers();
 	const { isMacOs } = useDeviceSupport();
 	const i18n = useI18n();
@@ -357,7 +362,7 @@ export const useExpressionEditor = ({
 				});
 			} else if (
 				isCredentialsModalOpen() ||
-				(!ndvStore.activeNode && toValue(targetNodeParameterContext) === undefined)
+				(!ndvStore.value?.activeNode && toValue(targetNodeParameterContext) === undefined)
 			) {
 				// e.g. credential modal
 				result.resolved = Expression.resolveWithoutWorkflow(resolvable, toValue(additionalData));
@@ -368,13 +373,13 @@ export const useExpressionEditor = ({
 				};
 				if (
 					toValue(targetNodeParameterContext) === undefined &&
-					ndvStore.isInputParentOfActiveNode
+					ndvStore.value?.isInputParentOfActiveNode
 				) {
 					opts = {
 						targetItem: target ?? undefined,
-						inputNodeName: ndvStore.ndvInputNodeName,
-						inputRunIndex: ndvStore.ndvInputRunIndex,
-						inputBranchIndex: ndvStore.ndvInputBranchIndex,
+						inputNodeName: ndvStore.value.ndvInputNodeName,
+						inputRunIndex: ndvStore.value.ndvInputRunIndex,
+						inputBranchIndex: ndvStore.value.ndvInputBranchIndex,
 					};
 				}
 				result.resolved = await workflowHelpers.resolveExpression(
@@ -386,7 +391,7 @@ export const useExpressionEditor = ({
 		} catch (error) {
 			const hasRunData =
 				!!workflowsStore.workflowExecutionData?.data?.resultData?.runData[
-					ndvStore.activeNode?.name ?? ''
+					ndvStore.value?.activeNode?.name ?? ''
 				];
 			result.resolved = `[${getExpressionErrorMessage(error, hasRunData)}]`;
 			result.error = true;
@@ -404,7 +409,9 @@ export const useExpressionEditor = ({
 		return result;
 	}
 
-	const targetItem = computed<TargetItem | null>(() => ndvStore.expressionTargetItem);
+	const targetItem = computed<TargetItem | null>(
+		() => ndvStore.value?.expressionTargetItem ?? null,
+	);
 
 	const resolvableSegments = computed<Resolvable[]>(() => {
 		return segments.value.filter((s): s is Resolvable => s.kind === 'resolvable');

--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/completions/utils.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/completions/utils.ts
@@ -194,9 +194,10 @@ export async function hasNoParams(toResolve: string, contextNodeName?: string) {
 }
 
 export async function resolveAutocompleteExpression(expression: string, contextNodeName?: string) {
-	const ndvStore = useNDVStore();
+	const workflowId = useWorkflowsStore().workflowId;
+	const ndvStore = workflowId ? useNDVStore(createWorkflowDocumentId(workflowId)) : null;
 	const inputData =
-		contextNodeName === undefined && ndvStore.isInputParentOfActiveNode
+		contextNodeName === undefined && ndvStore?.isInputParentOfActiveNode
 			? {
 					targetItem: ndvStore.expressionTargetItem ?? undefined,
 					inputNodeName: ndvStore.ndvInputNodeName,
@@ -223,16 +224,21 @@ export const isInHttpNodePagination = (targetNodeParameterContext?: TargetNodePa
 		nodeType = targetNodeParameterContext.nodeName;
 		path = targetNodeParameterContext.parameterPath;
 	} else {
-		const ndvStore = useNDVStore();
-		nodeType = ndvStore.activeNode?.type;
-		path = ndvStore.focusedInputPath;
+		const workflowId = useWorkflowsStore().workflowId;
+		const ndvStore = workflowId ? useNDVStore(createWorkflowDocumentId(workflowId)) : null;
+		nodeType = ndvStore?.activeNode?.type;
+		path = ndvStore?.focusedInputPath ?? '';
 	}
 
 	return nodeType === HTTP_REQUEST_NODE_TYPE && path.startsWith('parameters.options.pagination');
 };
 
 export const hasActiveNode = (targetNodeParameterContext?: TargetNodeParameterContext) => {
-	if (useNDVStore().activeNode?.name !== undefined) {
+	const workflowsStore = useWorkflowsStore();
+	const ndvStore = workflowsStore.workflowId
+		? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: null;
+	if (ndvStore?.activeNode?.name !== undefined) {
 		return true;
 	}
 
@@ -240,7 +246,6 @@ export const hasActiveNode = (targetNodeParameterContext?: TargetNodeParameterCo
 		return false;
 	}
 
-	const workflowsStore = useWorkflowsStore();
 	const workflowDocumentStore = useWorkflowDocumentStore(
 		createWorkflowDocumentId(workflowsStore.workflowId),
 	);
@@ -262,9 +267,12 @@ export function autocompletableNodeNames(targetNodeParameterContext?: TargetNode
 	const workflowDocumentStore = useWorkflowDocumentStore(
 		createWorkflowDocumentId(workflowsStore.workflowId),
 	);
+	const ndvStore = workflowsStore.workflowId
+		? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: null;
 	const activeNode =
 		targetNodeParameterContext === undefined
-			? useNDVStore().activeNode
+			? (ndvStore?.activeNode ?? null)
 			: workflowDocumentStore.getNodeByName(targetNodeParameterContext.nodeName);
 
 	if (!activeNode) return [];

--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/dragAndDrop.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/dragAndDrop.ts
@@ -1,4 +1,6 @@
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
 import { unwrapExpression } from '@/app/utils/expressions';
 import { syntaxTree } from '@codemirror/language';
 import { EditorSelection, StateEffect, StateField, type Extension } from '@codemirror/state';
@@ -37,11 +39,12 @@ const drawDropCursor = ViewPlugin.fromClass(
 
 		measureReq: MeasureRequest<{ left: number; top: number; height: number } | null>;
 
-		ndvStore: ReturnType<typeof useNDVStore>;
+		ndvStore: ReturnType<typeof useNDVStore> | null;
 
 		constructor(readonly view: EditorView) {
 			this.measureReq = { read: this.readPos.bind(this), write: this.drawCursor.bind(this) };
-			this.ndvStore = useNDVStore();
+			const workflowId = useWorkflowsStore().workflowId;
+			this.ndvStore = workflowId ? useNDVStore(createWorkflowDocumentId(workflowId)) : null;
 		}
 
 		update(update: ViewUpdate) {
@@ -103,7 +106,8 @@ const drawDropCursor = ViewPlugin.fromClass(
 	{
 		eventObservers: {
 			mousemove(event) {
-				if (!this.ndvStore.isDraggableDragging || this.ndvStore.draggableType !== 'mapping') return;
+				if (!this.ndvStore?.isDraggableDragging || this.ndvStore.draggableType !== 'mapping')
+					return;
 				const pos = this.view.posAtCoords(eventToCoord(event), false);
 				this.setDropPos(pos);
 			},

--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/typescript/client/useTypescript.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/typescript/client/useTypescript.ts
@@ -5,7 +5,10 @@ import { autocompletableNodeNames } from '@/features/shared/editors/plugins/code
 import useEnvironmentsStore from '@/features/settings/environments.ee/environments.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import {
+	createWorkflowDocumentId,
+	injectWorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
 import { forceParse } from '@/app/utils/forceParse';
 import { executionDataToJson } from '@/app/utils/nodeTypesUtils';
 import { autocompletion } from '@codemirror/autocomplete';
@@ -32,11 +35,13 @@ export function useTypescript(
 	targetNodeParameterContext?: MaybeRefOrGetter<TargetNodeParameterContext | undefined>,
 ) {
 	const { getInputDataWithPinned, getSchemaForExecutionData } = useDataSchema();
-	const ndvStore = useNDVStore();
 	const workflowsStore = useWorkflowsStore();
+	const ndvStore = workflowsStore.workflowId
+		? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+		: null;
 	const workflowDocumentStore = injectWorkflowDocumentStore();
 	const { debounce } = useDebounce();
-	const activeNodeName = toValue(targetNodeParameterContext)?.nodeName ?? ndvStore.activeNodeName;
+	const activeNodeName = toValue(targetNodeParameterContext)?.nodeName ?? ndvStore?.activeNodeName;
 	const worker = ref<Comlink.Remote<LanguageServiceWorker>>();
 	const webWorker = ref<Worker>();
 

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.store.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.store.ts
@@ -51,7 +51,11 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 	const workflowDocumentStore = computed(() =>
 		useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId)),
 	);
-	const ndvStore = useNDVStore();
+	const ndvStore = computed(() =>
+		workflowsStore.workflowId
+			? useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId))
+			: null,
+	);
 	const uiStore = useUIStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const telemetry = useTelemetry();
@@ -105,12 +109,12 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 		creatorView?: NodeFilterType;
 		connectionIndex?: number;
 	}) {
-		const nodeName = node ?? ndvStore.activeNodeName;
+		const nodeName = node ?? ndvStore.value?.activeNodeName;
 		const nodeData = nodeName
 			? (workflowDocumentStore.value.getNodeByName(nodeName) ?? null)
 			: null;
 
-		ndvStore.unsetActiveNodeName();
+		ndvStore.value?.unsetActiveNodeName();
 
 		setTimeout(() => {
 			if (creatorView) {
@@ -229,7 +233,7 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 		if (!nodeData) {
 			return;
 		}
-		ndvStore.unsetActiveNodeName();
+		ndvStore.value?.unsetActiveNodeName();
 		const nodeType =
 			nodeTypesStore.getNodeType(nodeData?.type) ??
 			nodeTypesStore.communityNodeType(nodeData?.type)?.nodeDescription;
@@ -257,7 +261,7 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 	}
 
 	function openNodeCreatorForTriggerNodes(source: NodeCreatorOpenSource) {
-		ndvStore.unsetActiveNodeName();
+		ndvStore.value?.unsetActiveNodeName();
 		setSelectedView(TRIGGER_NODE_CREATOR_VIEW);
 		setNodeCreatorState({
 			source,
@@ -267,7 +271,7 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 	}
 
 	function openNodeCreatorForRegularNodes(source: NodeCreatorOpenSource) {
-		ndvStore.unsetActiveNodeName();
+		ndvStore.value?.unsetActiveNodeName();
 		setSelectedView(REGULAR_NODE_CREATOR_VIEW);
 		setNodeCreatorState({
 			source,
@@ -289,7 +293,7 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 			transformNodeType(a, actionNode.properties.displayName, 'action'),
 		);
 
-		ndvStore.unsetActiveNodeName();
+		ndvStore.value?.unsetActiveNodeName();
 		setSelectedView(REGULAR_NODE_CREATOR_VIEW);
 		setNodeCreatorState({
 			source: eventSource,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalCanvasNodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalCanvasNodeSettings.vue
@@ -3,7 +3,7 @@ import NodeSettings from '@/features/ndv/settings/components/NodeSettings.vue';
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { type IUpdateInformation } from '@/Interface';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
@@ -27,7 +27,7 @@ const workflowDocumentStore = injectWorkflowDocumentStore();
 const uiStore = useUIStore();
 const { renameNode } = useCanvasOperations();
 const nodeHelpers = useNodeHelpers();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 
 const activeNode = computed(() => workflowDocumentStore?.value?.getNodeById(nodeId));
 const foreignCredentials = computed(() =>

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalEmbeddedNdvMapper.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalEmbeddedNdvMapper.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import InputPanel from '@/features/ndv/panel/components/InputPanel.vue';
 import type { INodeUi } from '@/Interface';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { onBeforeUnmount, watch, computed, ref, useTemplateRef } from 'vue';
 import { useStyles } from '@/app/composables/useStyles';
 import {
@@ -36,7 +36,7 @@ const {
 
 const state = ref<MapperState>({ isOpen: false });
 const contentRef = useTemplateRef('content');
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const experimentalNdvStore = useExperimentalNdvStore();
 const contentElRef = computed<HTMLElement | null>(() => contentRef.value?.$el ?? null);
 const { APP_Z_INDEXES } = useStyles();

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalEmbeddedNodeDetails.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalEmbeddedNodeDetails.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ExpressionLocalResolveContextSymbol } from '@/app/constants';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useVueFlow } from '@vue-flow/core';
 import { watchOnce } from '@vueuse/core';
@@ -23,7 +23,7 @@ const { nodeId, isReadOnly } = defineProps<{
 }>();
 
 const i18n = useI18n();
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 const experimentalNdvStore = useExperimentalNdvStore();
 const isExpanded = computed(() => !experimentalNdvStore.collapsedNodes[nodeId]);
 const nodeTypesStore = useNodeTypesStore();

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalNodeDetailsDrawer.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/experimental/components/ExperimentalNodeDetailsDrawer.vue
@@ -8,7 +8,7 @@ import { ExpressionLocalResolveContextSymbol } from '@/app/constants';
 import { type INodeUi } from '@/Interface';
 import { computed, provide, ref, watch } from 'vue';
 import ExperimentalCanvasNodeSettings from './ExperimentalCanvasNodeSettings.vue';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 
 import { N8nButton, N8nKeyboardShortcut, N8nText } from '@n8n/design-system';
 const { node, nodeIds, isReadOnly } = defineProps<{
@@ -25,7 +25,7 @@ const emit = defineEmits<{
 
 const expressionResolveCtx = useExpressionResolveCtx(computed(() => node));
 const contextMenuItems = useContextMenuItems(computed(() => nodeIds));
-const ndvStore = useNDVStore();
+const ndvStore = injectNDVStore();
 
 const ndvCloseTimes = ref(0);
 


### PR DESCRIPTION
## Summary

Completes the per-workflow `useNDVStore` factory migration started in #29392 so every NDV callsite resolves a workflow-scoped store. Adds a strict `injectNDVStore()` helper for components mounted under WorkflowLayout/DemoLayout, migrates ~64 Vue SFCs and ~22 stores/composables/utils to the new pattern, removes the NDV spread from `webhooksStore` (NDV is now merged into the external-hook payload at invocation time via the new `ExternalHookStore` type), and patches three latent edge cases (router failure handling returns `next(false)`, data-worker init wrapped in try/catch, `LogsPanel` deferred until the workflow has loaded). NDV state (active node, draggable, panel modes, mapping telemetry) no longer leaks across workflows.

**How to test:** open workflow A, focus a node and adjust input/output panels, navigate to workflow B — NDV state must not carry over; navigate back to A and confirm its state is preserved while still open. Verify the demo route renders on first load and that an external-hook handler reading `store.activeNodeName` continues to receive the correct value when a workflow is loaded.

## Related Linear tickets, Github issues, and Community forum posts

Completes #29392.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI