### PR TITLE
ci: Validate required pr quality checks with ci-filter

### DIFF
--- a/.github/workflows/ci-pr-quality.yml
+++ b/.github/workflows/ci-pr-quality.yml
@@ -106,6 +106,7 @@ jobs:
     needs: [check-ownership-checkbox, check-pr-size]
     if: always()
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/ci-pr-quality.yml
+++ b/.github/workflows/ci-pr-quality.yml
@@ -1,6 +1,7 @@
 name: 'CI: PR Quality Checks'
 
 on:
+  merge_group:
   pull_request:
     types:
       - opened
@@ -99,3 +100,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/quality/check-pr-size.mjs
+
+  required-pr-quality-checks:
+    name: Required PR Quality Checks
+    needs: [check-ownership-checkbox, check-pr-size]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions/ci-filter
+          sparse-checkout-cone-mode: false
+      - name: Validate required checks
+        uses: ./.github/actions/ci-filter
+        with:
+          mode: validate
+          job-results: ${{ toJSON(needs) }}
+


### PR DESCRIPTION
## Summary

Instead of adding a required check for each step in `ci-pr-quality.yml`, combine results behind one `Required PR Quality Checks` job. Uses ci-filter to validate runs and allow skipped runs.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2958/

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
