### PR TITLE
refactor(core): Combine insights by workflow count and page query

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights.service.integration.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.integration.test.ts
@@ -513,6 +513,30 @@ describe('InsightsService (Integration)', () => {
 			expect(byWorkflow.data[0].workflowId).toEqual(workflow2.id);
 		});
 
+		test('returns total count when page is past the end', async () => {
+			const now = DateTime.utc();
+			for (const workflow of [workflow1, workflow2, workflow3]) {
+				await createCompactedInsightsEvent(workflow, {
+					type: 'success',
+					value: 1,
+					periodUnit: 'day',
+					periodStart: now,
+				});
+			}
+
+			const startDate = now.minus({ days: 14 }).startOf('day').toJSDate();
+
+			const byWorkflow = await insightsService.getInsightsByWorkflow({
+				startDate,
+				endDate: today,
+				skip: 10,
+				take: 10,
+			});
+
+			expect(byWorkflow.count).toEqual(3);
+			expect(byWorkflow.data).toHaveLength(0);
+		});
+
 		test('compacted data are grouped by workflow correctly with projectId filter', async () => {
 			// ARRANGE
 			const now = DateTime.utc();

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -307,6 +307,27 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 		return [column, order.toUpperCase() as 'ASC' | 'DESC'];
 	}
 
+	private async countInsightsByWorkflowGroups(
+		groupedQuery: SelectQueryBuilder<InsightsByPeriod>,
+	): Promise<number> {
+		const groupsSubQuery = groupedQuery
+			.clone()
+			.select('metadata.workflowId', 'workflowId')
+			.addSelect('metadata.workflowName', 'workflowName')
+			.addSelect('metadata.projectId', 'projectId')
+			.addSelect('metadata.projectName', 'projectName');
+		groupsSubQuery.orderBy();
+
+		const row = await this.manager
+			.createQueryBuilder()
+			.select('COUNT(*)', 'count')
+			.from(`(${groupsSubQuery.getQuery()})`, 'workflow_groups')
+			.setParameters(groupsSubQuery.getParameters())
+			.getRawOne<{ count: string | number | undefined }>();
+
+		return row?.count !== undefined ? Number(row.count) : 0;
+	}
+
 	async getInsightsByWorkflow({
 		startDate,
 		endDate,
@@ -348,6 +369,7 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 								ELSE 1.0 * SUM(CASE WHEN insights.type = ${TypeToNumber.runtime_ms.toString()} THEN value ELSE 0 END) / ${sumOfExecutions}
 							END AS "averageRunTime"`,
 			])
+			.addSelect('COUNT(*) OVER()', 'totalCount')
 			.innerJoin('insights.metadata', 'metadata')
 			// Use a cross join with the CTE
 			.innerJoin('date_ranges', 'date_ranges', '1=1')
@@ -363,8 +385,11 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 			rawRowsQuery.andWhere('metadata.projectId = :projectId', { projectId });
 		}
 
-		const count = (await rawRowsQuery.getRawMany()).length;
-		const rawRows = await rawRowsQuery.offset(skip).limit(take).getRawMany();
+		const rawRows = await rawRowsQuery.clone().offset(skip).limit(take).getRawMany();
+		const count =
+			rawRows.length > 0
+				? Number(rawRows[0].totalCount as string | number)
+				: await this.countInsightsByWorkflowGroups(rawRowsQuery);
 
 		return { count, rows: aggregatedInsightsByWorkflowParser.parse(rawRows) };
 	}

--- a/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
+++ b/packages/cli/src/modules/insights/database/repositories/insights-by-period.repository.ts
@@ -308,24 +308,16 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 	}
 
 	private async countInsightsByWorkflowGroups(
-		groupedQuery: SelectQueryBuilder<InsightsByPeriod>,
+		rawRowsQuery: SelectQueryBuilder<InsightsByPeriod>,
 	): Promise<number> {
-		const groupsSubQuery = groupedQuery
-			.clone()
-			.select('metadata.workflowId', 'workflowId')
-			.addSelect('metadata.workflowName', 'workflowName')
-			.addSelect('metadata.projectId', 'projectId')
-			.addSelect('metadata.projectName', 'projectName');
-		groupsSubQuery.orderBy();
-
-		const row = await this.manager
+		const resultRow = await this.manager
 			.createQueryBuilder()
 			.select('COUNT(*)', 'count')
-			.from(`(${groupsSubQuery.getQuery()})`, 'workflow_groups')
-			.setParameters(groupsSubQuery.getParameters())
-			.getRawOne<{ count: string | number | undefined }>();
+			.from(`(${rawRowsQuery.getQuery()})`, 'workflow_groups')
+			.setParameters(rawRowsQuery.getParameters())
+			.getRawOne<{ count: string | number }>();
 
-		return row?.count !== undefined ? Number(row.count) : 0;
+		return Number(resultRow?.count ?? 0);
 	}
 
 	async getInsightsByWorkflow({
@@ -369,7 +361,6 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 								ELSE 1.0 * SUM(CASE WHEN insights.type = ${TypeToNumber.runtime_ms.toString()} THEN value ELSE 0 END) / ${sumOfExecutions}
 							END AS "averageRunTime"`,
 			])
-			.addSelect('COUNT(*) OVER()', 'totalCount')
 			.innerJoin('insights.metadata', 'metadata')
 			// Use a cross join with the CTE
 			.innerJoin('date_ranges', 'date_ranges', '1=1')
@@ -378,18 +369,22 @@ export class InsightsByPeriodRepository extends Repository<InsightsByPeriod> {
 			.groupBy('metadata.workflowId')
 			.addGroupBy('metadata.workflowName')
 			.addGroupBy('metadata.projectId')
-			.addGroupBy('metadata.projectName')
-			.orderBy(this.escapeField(sortField), sortOrder);
+			.addGroupBy('metadata.projectName');
 
 		if (projectId) {
 			rawRowsQuery.andWhere('metadata.projectId = :projectId', { projectId });
 		}
 
-		const rawRows = await rawRowsQuery.clone().offset(skip).limit(take).getRawMany();
-		const count =
-			rawRows.length > 0
-				? Number(rawRows[0].totalCount as string | number)
-				: await this.countInsightsByWorkflowGroups(rawRowsQuery);
+		const paginatedQuery = rawRowsQuery
+			.clone()
+			.orderBy(this.escapeField(sortField), sortOrder)
+			.offset(skip)
+			.limit(take);
+
+		const [count, rawRows] = await Promise.all([
+			this.countInsightsByWorkflowGroups(rawRowsQuery),
+			paginatedQuery.getRawMany(),
+		]);
 
 		return { count, rows: aggregatedInsightsByWorkflowParser.parse(rawRows) };
 	}


### PR DESCRIPTION
## Summary

**Problem:**

The "Insights by-workflow" pagination was making two heavy traversals over the database: one to count the total grouped results and a second to fetch the actual page data.

**Solution:**
We’re not using COUNT(*) OVER() on the page query. We’ll run the page fetch and a separate total count in parallel instead.

The old code loaded every grouped workflow row just to get a count, then ran the same work again for the page. Now the page query only returns the slice we need, and the count is a lighter grouped count that doesn’t follow the page sort.

**Outdated**

First attempt (commit [1bf01a2](https://github.com/n8n-io/n8n/pull/29787/changes/1bf01a2dbd2704711fd687634a13f9ae42349a90)) was to reduce the call into a single query with including the row count on each row. This got dismissed (see [comment](https://github.com/n8n-io/n8n/pull/29787#discussion_r3204076865)).


## Related Linear tickets, Github issues, and Community forum posts

Closes [LIGO-504](https://linear.app/n8n/issue/LIGO-504/optimize-insights-pagination-performance)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
