### PR TITLE
chore: Update CODEOWNERS to reflect the new group name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 packages/@n8n/db/src/migrations/ @n8n-io/migrations-review
-.github/workflows @n8n-io/ci-admins
-.github/scripts @n8n-io/ci-admins
-.github/actions @n8n-io/ci-admins
-.github/poutine-rules @n8n-io/ci-admins
+.github/workflows @n8n-io/qa-dx
+.github/scripts @n8n-io/qa-dx
+.github/actions @n8n-io/qa-dx
+.github/poutine-rules @n8n-io/qa-dx
 


### PR DESCRIPTION
## Summary

Rename ci-admins to qa-dx to reflect new groups in github org.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
