### PR TITLE
docs: Add Cursor setup instructions for n8n skills plugin

### DIFF
--- a/.claude/plugins/n8n/README.md
+++ b/.claude/plugins/n8n/README.md
@@ -4,7 +4,7 @@ Shared skills, commands, and agents for n8n development. All items are
 namespaced under `n8n:` to avoid collisions with personal or third-party
 plugins.
 
-## Usage
+## Usage in Claude Code
 
 Skills, commands, and agents are auto-discovered by Claude Code from this
 plugin directory. Everything gets the `n8n:` namespace prefix automatically.
@@ -14,6 +14,34 @@ plugin directory. Everything gets the `n8n:` namespace prefix automatically.
 | Skill | `skills/create-pr/SKILL.md` | `n8n:create-pr` |
 | Command | `commands/plan.md` | `/n8n:plan PAY-XXX` |
 | Agent | `agents/developer.md` | `n8n:developer` |
+
+## Usage in Cursor
+
+Cursor does **not** auto-discover plugins from `.claude/plugins/`. You need
+to register the plugin once by adding an `"n8n@n8n"` entry to
+`~/.claude/plugins/installed_plugins.json` (create the file if it doesn't
+exist):
+
+```jsonc
+{
+  "plugins": {
+    "n8n@n8n": [
+      {
+        "scope": "project",
+        "installPath": "/absolute/path/to/your/n8n/.claude/plugins/n8n",
+        "projectPath": "/absolute/path/to/your/n8n",
+        "version": "1.0.0",
+        "installedAt": "2025-01-01T00:00:00.000Z"
+      }
+    ]
+  }
+}
+```
+
+Replace both paths with wherever you have the repo cloned, then restart
+Cursor. Skills will appear without the `n8n:` namespace prefix. Since the
+path points to the repo, new skills are picked up automatically after
+`git pull`.
 
 ## Plugin Structure
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,12 +20,17 @@ frontend, and extensible node-based workflow engine.
   Hygiene below)
 - Use mermaid diagrams in MD files when you need to visualise something
 
-## Claude Code Plugin
+## n8n Skills Plugin
 
 n8n-specific skills, commands, and agents live in `.claude/plugins/n8n/` and
 are namespaced under `n8n:`. Use `n8n:` prefix when invoking them
 (e.g. `/n8n:create-pr`, `/n8n:plan`, `n8n:developer` agent).
 See [plugin README](.claude/plugins/n8n/README.md) for structure and details.
+
+**Cursor users:** Cursor does not auto-discover plugins from
+`.claude/plugins/`. If n8n skills are not available, register the plugin in
+`~/.claude/plugins/installed_plugins.json` and restart Cursor. Full setup
+instructions are in the [plugin README](.claude/plugins/n8n/README.md#usage-in-cursor).
 
 ## Essential Commands
 


### PR DESCRIPTION
## Summary

Adds setup instructions for using n8n skills in Cursor to the plugin README and updates AGENTS.md with a callout for Cursor users pointing to the setup guide.

Cursor doesn't auto-discover plugins from `.claude/plugins/` — users need to register the plugin manually in `~/.claude/plugins/installed_plugins.json`. This documents the fix so both agents and developers can find it.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/RLY-37

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.