### PR TITLE
ci: Fix flaky error assertion in tests

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreRedis/VectorStoreRedis.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreRedis/VectorStoreRedis.node.test.ts
@@ -505,12 +505,11 @@ describe('VectorStoreRedis.node', () => {
 			} as any;
 
 			const node = new RedisNode.VectorStoreRedis();
-			await expect((node as any).populateVectorStore(context, {}, [], 0)).rejects.toEqual(
-				new NodeOperationError(context.getNode(), 'Error: fail', {
-					itemIndex: 0,
-					description: 'Please check your index/schema and parameters',
-				}),
-			);
+
+			const execution = (node as any).populateVectorStore(context, {}, [], 0);
+
+			await expect(execution).rejects.toThrow(NodeOperationError);
+			await expect(execution).rejects.toThrow('Error: fail');
 
 			expect(loadOptionsFunctions.logger.info).toHaveBeenCalledWith(
 				'Error while populating the store: fail',


### PR DESCRIPTION
## Summary

One test case was missed using the old Error assertions which cause a lot of flakiness is CI. Fix it out.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
