### PR TITLE
feat(Microsoft Outlook Node): Add support for recurring event instances

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/event/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/event/getAll.test.ts
@@ -1,0 +1,58 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+describe('Test MicrosoftOutlookV2, event => getAll', () => {
+	const calendarId =
+		'AAMkADlhOTA0MTc5LWUwOTMtNDRkZS05NzE0LTNlYmI0ZWM5OWI5OABGAAAAAABPLqzvT6b9RLP0CKzHiJrRBwBZf4De-LkrSqpPI8eyjUmAAAAAAAEGAABZf4De-LkrSqpPI8eyjUmAAAAJ9-JDAAA=';
+
+	const singleEvent = {
+		id: 'AAMkADlhOTA0MTc5event1',
+		subject: 'Single Event',
+		bodyPreview: 'A one-time event',
+		start: { dateTime: '2023-09-05T07:00:00.0000000', timeZone: 'UTC' },
+		end: { dateTime: '2023-09-05T08:00:00.0000000', timeZone: 'UTC' },
+		organizer: { emailAddress: { name: 'Test User', address: 'test@example.com' } },
+		attendees: [],
+		webLink: 'https://outlook.office365.com/owa/?itemid=event1',
+	};
+
+	const recurringInstance1 = {
+		id: 'AAMkADlhOTA0MTc5recurring1',
+		subject: 'Weekly Standup',
+		bodyPreview: 'Recurring weekly meeting - instance 1',
+		start: { dateTime: '2023-09-04T09:00:00.0000000', timeZone: 'UTC' },
+		end: { dateTime: '2023-09-04T09:30:00.0000000', timeZone: 'UTC' },
+		organizer: { emailAddress: { name: 'Test User', address: 'test@example.com' } },
+		attendees: [],
+		webLink: 'https://outlook.office365.com/owa/?itemid=recurring1',
+	};
+
+	const recurringInstance2 = {
+		id: 'AAMkADlhOTA0MTc5recurring2',
+		subject: 'Weekly Standup',
+		bodyPreview: 'Recurring weekly meeting - instance 2',
+		start: { dateTime: '2023-09-11T09:00:00.0000000', timeZone: 'UTC' },
+		end: { dateTime: '2023-09-11T09:30:00.0000000', timeZone: 'UTC' },
+		organizer: { emailAddress: { name: 'Test User', address: 'test@example.com' } },
+		attendees: [],
+		webLink: 'https://outlook.office365.com/owa/?itemid=recurring2',
+	};
+
+	const scope = nock('https://graph.microsoft.com/v1.0/me').persist();
+
+	scope
+		.get(`/calendars/${calendarId}/events`)
+		.query(true)
+		.reply(200, { value: [singleEvent] });
+
+	scope
+		.get(`/calendars/${calendarId}/calendarView`)
+		.query(true)
+		.reply(200, { value: [singleEvent, recurringInstance1, recurringInstance2] });
+
+	afterAll(() => nock.cleanAll());
+
+	new NodeTestHarness().setupTests({
+		workflowFiles: ['getAll.workflow.json', 'getAllCalendarView.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/event/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/event/getAll.test.ts
@@ -2,57 +2,27 @@ import { NodeTestHarness } from '@nodes-testing/node-test-harness';
 import nock from 'nock';
 
 describe('Test MicrosoftOutlookV2, event => getAll', () => {
-	const calendarId =
-		'AAMkADlhOTA0MTc5LWUwOTMtNDRkZS05NzE0LTNlYmI0ZWM5OWI5OABGAAAAAABPLqzvT6b9RLP0CKzHiJrRBwBZf4De-LkrSqpPI8eyjUmAAAAAAAEGAABZf4De-LkrSqpPI8eyjUmAAAAJ9-JDAAA=';
-
-	const singleEvent = {
-		id: 'AAMkADlhOTA0MTc5event1',
-		subject: 'Single Event',
-		bodyPreview: 'A one-time event',
-		start: { dateTime: '2023-09-05T07:00:00.0000000', timeZone: 'UTC' },
-		end: { dateTime: '2023-09-05T08:00:00.0000000', timeZone: 'UTC' },
-		organizer: { emailAddress: { name: 'Test User', address: 'test@example.com' } },
-		attendees: [],
-		webLink: 'https://outlook.office365.com/owa/?itemid=event1',
-	};
-
-	const recurringInstance1 = {
-		id: 'AAMkADlhOTA0MTc5recurring1',
-		subject: 'Weekly Standup',
-		bodyPreview: 'Recurring weekly meeting - instance 1',
-		start: { dateTime: '2023-09-04T09:00:00.0000000', timeZone: 'UTC' },
-		end: { dateTime: '2023-09-04T09:30:00.0000000', timeZone: 'UTC' },
-		organizer: { emailAddress: { name: 'Test User', address: 'test@example.com' } },
-		attendees: [],
-		webLink: 'https://outlook.office365.com/owa/?itemid=recurring1',
-	};
-
-	const recurringInstance2 = {
-		id: 'AAMkADlhOTA0MTc5recurring2',
-		subject: 'Weekly Standup',
-		bodyPreview: 'Recurring weekly meeting - instance 2',
-		start: { dateTime: '2023-09-11T09:00:00.0000000', timeZone: 'UTC' },
-		end: { dateTime: '2023-09-11T09:30:00.0000000', timeZone: 'UTC' },
-		organizer: { emailAddress: { name: 'Test User', address: 'test@example.com' } },
-		attendees: [],
-		webLink: 'https://outlook.office365.com/owa/?itemid=recurring2',
-	};
-
-	const scope = nock('https://graph.microsoft.com/v1.0/me').persist();
-
-	scope
-		.get(`/calendars/${calendarId}/events`)
+	nock('https://graph.microsoft.com/v1.0/me')
+		.get(
+			'/calendars/AAMkADlhOTA0MTc5LWUwOTMtNDRkZS05NzE0LTNlYmI0ZWM5OWI5OABGAAAAAABPLqzvT6b9RLP0CKzHiJrRBwBZf4De-LkrSqpPI8eyjUmAAAAAAAEGAABZf4De-LkrSqpPI8eyjUmAAAAJ9-JDAAA=/events',
+		)
 		.query(true)
-		.reply(200, { value: [singleEvent] });
-
-	scope
-		.get(`/calendars/${calendarId}/calendarView`)
-		.query(true)
-		.reply(200, { value: [singleEvent, recurringInstance1, recurringInstance2] });
-
-	afterAll(() => nock.cleanAll());
+		.reply(200, {
+			value: [
+				{
+					id: 'AAMkADlhOTA0MTc5event1',
+					subject: 'Single Event',
+					bodyPreview: 'A one-time event',
+					start: { dateTime: '2023-09-05T07:00:00.0000000', timeZone: 'UTC' },
+					end: { dateTime: '2023-09-05T08:00:00.0000000', timeZone: 'UTC' },
+					organizer: { emailAddress: { name: 'Test User', address: 'test@example.com' } },
+					attendees: [],
+					webLink: 'https://outlook.office365.com/owa/?itemid=event1',
+				},
+			],
+		});
 
 	new NodeTestHarness().setupTests({
-		workflowFiles: ['getAll.workflow.json', 'getAllCalendarView.workflow.json'],
+		workflowFiles: ['getAll.workflow.json'],
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/event/getAll.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/event/getAll.workflow.json
@@ -1,0 +1,92 @@
+{
+	"name": "Test getAll events",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "e524f588-b6a3-4849-8777-b32a8a755ae5",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [820, 360]
+		},
+		{
+			"parameters": {
+				"resource": "event",
+				"operation": "getAll",
+				"fromAllCalendars": false,
+				"calendarId": {
+					"__rl": true,
+					"value": "AAMkADlhOTA0MTc5LWUwOTMtNDRkZS05NzE0LTNlYmI0ZWM5OWI5OABGAAAAAABPLqzvT6b9RLP0CKzHiJrRBwBZf4De-LkrSqpPI8eyjUmAAAAAAAEGAABZf4De-LkrSqpPI8eyjUmAAAAJ9-JDAAA=",
+					"mode": "list",
+					"cachedResultName": "Calendar"
+				},
+				"includeRecurringInstances": false,
+				"returnAll": false,
+				"limit": 10,
+				"output": "simple",
+				"filters": {}
+			},
+			"id": "baff6798-0304-4255-bdb0-dd3f2659373b",
+			"name": "Get Many Events",
+			"type": "n8n-nodes-base.microsoftOutlook",
+			"typeVersion": 2,
+			"position": [1040, 360],
+			"credentials": {
+				"microsoftOutlookOAuth2Api": {
+					"id": "iXJCki7i5Vz0bdks",
+					"name": "Microsoft Outlook account 2"
+				}
+			}
+		}
+	],
+	"pinData": {
+		"Get Many Events": [
+			{
+				"json": {
+					"id": "AAMkADlhOTA0MTc5event1",
+					"subject": "Single Event",
+					"bodyPreview": "A one-time event",
+					"start": {
+						"dateTime": "2023-09-05T07:00:00.0000000",
+						"timeZone": "UTC"
+					},
+					"end": {
+						"dateTime": "2023-09-05T08:00:00.0000000",
+						"timeZone": "UTC"
+					},
+					"organizer": {
+						"emailAddress": {
+							"name": "Test User",
+							"address": "test@example.com"
+						}
+					},
+					"attendees": [],
+					"webLink": "https://outlook.office365.com/owa/?itemid=event1"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Get Many Events",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "dceb08aa-5897-44d1-afbc-748d1e8a2627",
+	"id": "2CYHzBXQw1nfPGtC",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/event/getAllCalendarView.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/event/getAllCalendarView.test.ts
@@ -1,0 +1,48 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+describe('Test MicrosoftOutlookV2, event => getAll (calendarView)', () => {
+	nock('https://graph.microsoft.com/v1.0/me')
+		.get(
+			'/calendars/AAMkADlhOTA0MTc5LWUwOTMtNDRkZS05NzE0LTNlYmI0ZWM5OWI5OABGAAAAAABPLqzvT6b9RLP0CKzHiJrRBwBZf4De-LkrSqpPI8eyjUmAAAAAAAEGAABZf4De-LkrSqpPI8eyjUmAAAAJ9-JDAAA=/calendarView',
+		)
+		.query(true)
+		.reply(200, {
+			value: [
+				{
+					id: 'AAMkADlhOTA0MTc5event1',
+					subject: 'Single Event',
+					bodyPreview: 'A one-time event',
+					start: { dateTime: '2023-09-05T07:00:00.0000000', timeZone: 'UTC' },
+					end: { dateTime: '2023-09-05T08:00:00.0000000', timeZone: 'UTC' },
+					organizer: { emailAddress: { name: 'Test User', address: 'test@example.com' } },
+					attendees: [],
+					webLink: 'https://outlook.office365.com/owa/?itemid=event1',
+				},
+				{
+					id: 'AAMkADlhOTA0MTc5recurring1',
+					subject: 'Weekly Standup',
+					bodyPreview: 'Recurring weekly meeting - instance 1',
+					start: { dateTime: '2023-09-04T09:00:00.0000000', timeZone: 'UTC' },
+					end: { dateTime: '2023-09-04T09:30:00.0000000', timeZone: 'UTC' },
+					organizer: { emailAddress: { name: 'Test User', address: 'test@example.com' } },
+					attendees: [],
+					webLink: 'https://outlook.office365.com/owa/?itemid=recurring1',
+				},
+				{
+					id: 'AAMkADlhOTA0MTc5recurring2',
+					subject: 'Weekly Standup',
+					bodyPreview: 'Recurring weekly meeting - instance 2',
+					start: { dateTime: '2023-09-11T09:00:00.0000000', timeZone: 'UTC' },
+					end: { dateTime: '2023-09-11T09:30:00.0000000', timeZone: 'UTC' },
+					organizer: { emailAddress: { name: 'Test User', address: 'test@example.com' } },
+					attendees: [],
+					webLink: 'https://outlook.office365.com/owa/?itemid=recurring2',
+				},
+			],
+		});
+
+	new NodeTestHarness().setupTests({
+		workflowFiles: ['getAllCalendarView.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/event/getAllCalendarView.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/test/v2/node/event/getAllCalendarView.workflow.json
@@ -1,0 +1,139 @@
+{
+	"name": "Test getAll events with calendar view",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "e524f588-b6a3-4849-8777-b32a8a755ae5",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [820, 360]
+		},
+		{
+			"parameters": {
+				"resource": "event",
+				"operation": "getAll",
+				"fromAllCalendars": false,
+				"calendarId": {
+					"__rl": true,
+					"value": "AAMkADlhOTA0MTc5LWUwOTMtNDRkZS05NzE0LTNlYmI0ZWM5OWI5OABGAAAAAABPLqzvT6b9RLP0CKzHiJrRBwBZf4De-LkrSqpPI8eyjUmAAAAAAAEGAABZf4De-LkrSqpPI8eyjUmAAAAJ9-JDAAA=",
+					"mode": "list",
+					"cachedResultName": "Calendar"
+				},
+				"includeRecurringInstances": true,
+				"startDateTime": "2023-09-01T00:00:00.000Z",
+				"endDateTime": "2023-09-30T23:59:59.000Z",
+				"returnAll": false,
+				"limit": 10,
+				"output": "simple"
+			},
+			"id": "calendar-view-node",
+			"name": "Get Many Events Calendar View",
+			"type": "n8n-nodes-base.microsoftOutlook",
+			"typeVersion": 2,
+			"position": [1040, 360],
+			"credentials": {
+				"microsoftOutlookOAuth2Api": {
+					"id": "iXJCki7i5Vz0bdks",
+					"name": "Microsoft Outlook account 2"
+				}
+			}
+		}
+	],
+	"pinData": {
+		"Get Many Events Calendar View": [
+			{
+				"json": {
+					"id": "AAMkADlhOTA0MTc5event1",
+					"subject": "Single Event",
+					"bodyPreview": "A one-time event",
+					"start": {
+						"dateTime": "2023-09-05T07:00:00.0000000",
+						"timeZone": "UTC"
+					},
+					"end": {
+						"dateTime": "2023-09-05T08:00:00.0000000",
+						"timeZone": "UTC"
+					},
+					"organizer": {
+						"emailAddress": {
+							"name": "Test User",
+							"address": "test@example.com"
+						}
+					},
+					"attendees": [],
+					"webLink": "https://outlook.office365.com/owa/?itemid=event1"
+				}
+			},
+			{
+				"json": {
+					"id": "AAMkADlhOTA0MTc5recurring1",
+					"subject": "Weekly Standup",
+					"bodyPreview": "Recurring weekly meeting - instance 1",
+					"start": {
+						"dateTime": "2023-09-04T09:00:00.0000000",
+						"timeZone": "UTC"
+					},
+					"end": {
+						"dateTime": "2023-09-04T09:30:00.0000000",
+						"timeZone": "UTC"
+					},
+					"organizer": {
+						"emailAddress": {
+							"name": "Test User",
+							"address": "test@example.com"
+						}
+					},
+					"attendees": [],
+					"webLink": "https://outlook.office365.com/owa/?itemid=recurring1"
+				}
+			},
+			{
+				"json": {
+					"id": "AAMkADlhOTA0MTc5recurring2",
+					"subject": "Weekly Standup",
+					"bodyPreview": "Recurring weekly meeting - instance 2",
+					"start": {
+						"dateTime": "2023-09-11T09:00:00.0000000",
+						"timeZone": "UTC"
+					},
+					"end": {
+						"dateTime": "2023-09-11T09:30:00.0000000",
+						"timeZone": "UTC"
+					},
+					"organizer": {
+						"emailAddress": {
+							"name": "Test User",
+							"address": "test@example.com"
+						}
+					},
+					"attendees": [],
+					"webLink": "https://outlook.office365.com/owa/?itemid=recurring2"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Get Many Events Calendar View",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "dceb08aa-5897-44d1-afbc-748d1e8a2628",
+	"id": "3CYHzBXQw1nfPGtD",
+	"meta": {
+		"instanceId": "b888bd11cd1ddbb95450babf3e199556799d999b896f650de768b8370ee50363"
+	},
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/event/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v2/actions/event/getAll.operation.ts
@@ -21,6 +21,40 @@ export const properties: INodeProperties[] = [
 			},
 		},
 	},
+	{
+		displayName: 'Include Recurring Event Instances',
+		name: 'includeRecurringInstances',
+		type: 'boolean',
+		default: false,
+		description:
+			'Whether to expand recurring events into individual instances within the specified date range. When disabled, recurring events are returned as a single series master event.',
+	},
+	{
+		displayName: 'Start Date',
+		name: 'startDateTime',
+		type: 'dateTime',
+		default: '',
+		required: true,
+		description: 'Start of the date range to retrieve event instances for',
+		displayOptions: {
+			show: {
+				includeRecurringInstances: [true],
+			},
+		},
+	},
+	{
+		displayName: 'End Date',
+		name: 'endDateTime',
+		type: 'dateTime',
+		default: '',
+		required: true,
+		description: 'End of the date range to retrieve event instances for',
+		displayOptions: {
+			show: {
+				includeRecurringInstances: [true],
+			},
+		},
+	},
 	...returnAllOrLimit,
 	{
 		displayName: 'Output',
@@ -61,6 +95,11 @@ export const properties: INodeProperties[] = [
 		type: 'collection',
 		placeholder: 'Add Filter',
 		default: {},
+		displayOptions: {
+			show: {
+				includeRecurringInstances: [false],
+			},
+		},
 		options: [
 			{
 				displayName: 'Filter Query',
@@ -88,8 +127,11 @@ export async function execute(this: IExecuteFunctions, index: number) {
 	const qs = {} as IDataObject;
 
 	const returnAll = this.getNodeParameter('returnAll', index);
-	const filters = this.getNodeParameter('filters', index, {});
 	const output = this.getNodeParameter('output', index) as string;
+	const includeRecurringInstances = this.getNodeParameter(
+		'includeRecurringInstances',
+		index,
+	) as boolean;
 
 	if (output === 'fields') {
 		const fields = this.getNodeParameter('fields', index) as string[];
@@ -100,15 +142,22 @@ export async function execute(this: IExecuteFunctions, index: number) {
 		qs.$select = 'id,subject,bodyPreview,start,end,organizer,attendees,webLink';
 	}
 
-	if (Object.keys(filters).length) {
-		const filterString: string[] = [];
+	if (includeRecurringInstances) {
+		qs.startDateTime = this.getNodeParameter('startDateTime', index) as string;
+		qs.endDateTime = this.getNodeParameter('endDateTime', index) as string;
+	} else {
+		const filters = this.getNodeParameter('filters', index, {});
 
-		if (filters.custom) {
-			filterString.push(filters.custom as string);
-		}
+		if (Object.keys(filters).length) {
+			const filterString: string[] = [];
 
-		if (filterString.length) {
-			qs.$filter = filterString.join(' and ');
+			if (filters.custom) {
+				filterString.push(filters.custom as string);
+			}
+
+			if (filterString.length) {
+				qs.$filter = filterString.join(' and ');
+			}
 		}
 	}
 
@@ -133,7 +182,9 @@ export async function execute(this: IExecuteFunctions, index: number) {
 	const limit = this.getNodeParameter('limit', index, 0);
 
 	for (const calendarId of calendars) {
-		const endpoint = `/calendars/${calendarId}/events`;
+		const endpoint = includeRecurringInstances
+			? `/calendars/${calendarId}/calendarView`
+			: `/calendars/${calendarId}/events`;
 
 		if (returnAll) {
 			const response = await microsoftApiRequestAllItems.call(


### PR DESCRIPTION
## Summary

The Microsoft Outlook node's "Get Many Events" operation only returns series master events for recurring calendar events, missing individual occurrences. This is because it uses the `/calendars/{id}/events` Graph API endpoint, which by design does not expand recurring events.

This PR adds an **"Include Recurring Event Instances"** toggle to the Get Many Events operation. When enabled, the node switches to Microsoft Graph's [`/calendarView`](https://learn.microsoft.com/en-us/graph/api/calendar-list-calendarview) endpoint, which expands recurring events into individual instances within a user-specified date range. The toggle defaults to `false` for backward compatibility.

**How to test:**
1. Configure a Microsoft Outlook node with Event → Get Many
2. With "Include Recurring Event Instances" **off** — behavior is unchanged, recurring events appear as series masters
3. With "Include Recurring Event Instances" **on** — set a date range, recurring events are expanded into individual occurrences

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-3383
- closes #17747

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)