### PR TITLE
test(core): Cover JWE decryption on dynamic-credential OAuth2 callback

### DIFF
--- a/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
@@ -830,6 +830,71 @@ describe('OAuth2CredentialController', () => {
 					['csrfSecret'],
 				);
 			});
+
+			it('routes the decrypted response to saveDynamicCredential when origin is dynamic-credential', async () => {
+				const dynamicState = {
+					token: 'token',
+					cid: '1',
+					userId: '123',
+					origin: 'dynamic-credential' as const,
+					credentialResolverId: 'resolver-1',
+					authorizationHeader: 'Bearer caller-token',
+					authMetadata: { tenant: 'acme' },
+					createdAt: timestamp,
+					data: 'encrypted-data',
+				};
+
+				const mockGetToken = jest
+					.fn()
+					.mockResolvedValue({ data: { access_token: 'jwe-blob', refresh_token: 'r' } });
+				const { ClientOAuth2 } = await import('@n8n/client-oauth2');
+				jest
+					.mocked(ClientOAuth2)
+					.mockImplementation(() => ({ code: { getToken: mockGetToken } }) as any);
+				const mockResolvedCredential = mock<CredentialsEntity>({ id: '1' });
+				oauthService.resolveCredential.mockResolvedValueOnce([
+					mockResolvedCredential,
+					{ csrfSecret: 'csrf-secret' },
+					{
+						clientId: 'client_id',
+						clientSecret: 'client_secret',
+						authUrl: 'https://example.domain/oauth2/auth',
+						accessTokenUrl: 'https://example.domain/oauth2/token',
+						scope: 'openid',
+						grantType: 'authorizationCode',
+						authentication: 'header',
+						jweEnabled: true,
+					} as any,
+					dynamicState,
+				]);
+				oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
+				externalHooks.run.mockResolvedValue(undefined);
+				oauthJweServiceProxy.decryptOAuth2TokenData.mockResolvedValue({
+					access_token: 'decrypted',
+					refresh_token: 'r',
+				});
+
+				const req = mock<OAuthRequest.OAuth2Credential.Callback>({
+					query: { code: 'auth_code', state: validState },
+					originalUrl: '/oauth2-credential/callback?code=auth_code&state=state',
+				});
+
+				await controller.handleCallback(req, res);
+
+				expect(oauthJweServiceProxy.decryptOAuth2TokenData).toHaveBeenCalledWith(
+					expect.objectContaining({ access_token: 'jwe-blob' }),
+				);
+				expect(oauthService.saveDynamicCredential).toHaveBeenCalledWith(
+					mockResolvedCredential,
+					expect.objectContaining({
+						oauthTokenData: expect.objectContaining({ access_token: 'decrypted' }),
+					}),
+					'caller-token',
+					'resolver-1',
+					{ tenant: 'acme' },
+				);
+				expect(oauthService.encryptAndSaveData).not.toHaveBeenCalled();
+			});
 		});
 
 		it('should handle errors and render error page', async () => {


### PR DESCRIPTION
## Summary

Adds a regression test pinning the IAM-584 compatibility contract: when an OAuth2 credential has `jweEnabled: true` and the callback originates from a dynamic-credential flow (`state.origin === 'dynamic-credential'`), the controller decrypts the token response via the JWE proxy *before* the static/dynamic branch and routes the decrypted `oauthTokenData` into `OauthService.saveDynamicCredential` (with `authorizationHeader`, `credentialResolverId`, `authMetadata`) — never `encryptAndSaveData`. The refresh-time half of the same pipeline is already covered by `request-helper-functions.test.ts`.

To test: `cd packages/cli && pnpm test:unit oauth2-credential.controller`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-584

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI