### PR TITLE
fix(editor): Refresh node icon when diff sidebar selection changes

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/NodeIcon.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/NodeIcon.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
+import { ref, computed, defineComponent, h } from 'vue';
+import type { SimplifiedNodeType } from '@/Interface';
+
+const useNodeIconSourceMock = vi.fn();
+
+vi.mock('@/app/composables/useNodeIconSource', () => ({
+	useNodeIconSource: (...args: unknown[]) => {
+		useNodeIconSourceMock(...args);
+		return computed(() => undefined);
+	},
+}));
+
+vi.mock('@n8n/design-system', () => ({
+	N8nNodeIcon: defineComponent({
+		props: ['type', 'src', 'name', 'disabled', 'size', 'circle'],
+		setup() {
+			return () => h('div', { class: 'stubbed-node-icon' });
+		},
+	}),
+}));
+
+import NodeIcon from './NodeIcon.vue';
+
+const setNodeType: SimplifiedNodeType = {
+	name: 'n8n-nodes-base.set',
+	displayName: 'Edit Fields',
+	description: '',
+	group: ['input'],
+	defaults: {},
+	outputs: [],
+};
+
+const calendarNodeType: SimplifiedNodeType = {
+	name: 'n8n-nodes-base.googleCalendar',
+	displayName: 'Google Calendar',
+	description: '',
+	group: ['input'],
+	defaults: {},
+	outputs: [],
+};
+
+describe('NodeIcon.vue', () => {
+	it('passes reactive getters to useNodeIconSource so the icon refreshes when the nodeType prop changes', () => {
+		useNodeIconSourceMock.mockClear();
+
+		const nodeTypeRef = ref<SimplifiedNodeType>(setNodeType);
+
+		mount(NodeIcon, {
+			global: {
+				plugins: [createTestingPinia({ stubActions: false })],
+			},
+			props: {
+				nodeType: nodeTypeRef.value,
+			},
+		});
+
+		expect(useNodeIconSourceMock).toHaveBeenCalledTimes(1);
+		const [nodeTypeArg, nodeArg] = useNodeIconSourceMock.mock.calls[0];
+
+		expect(typeof nodeTypeArg).toBe('function');
+		expect(typeof nodeArg).toBe('function');
+	});
+
+	it('the nodeType getter passed to useNodeIconSource reflects the latest prop value', async () => {
+		useNodeIconSourceMock.mockClear();
+
+		const wrapper = mount(NodeIcon, {
+			global: {
+				plugins: [createTestingPinia({ stubActions: false })],
+			},
+			props: {
+				nodeType: setNodeType,
+			},
+		});
+
+		const [nodeTypeGetter] = useNodeIconSourceMock.mock.calls[0];
+		expect((nodeTypeGetter as () => SimplifiedNodeType)()).toEqual(setNodeType);
+
+		await wrapper.setProps({ nodeType: calendarNodeType });
+
+		expect((nodeTypeGetter as () => SimplifiedNodeType)()).toEqual(calendarNodeType);
+	});
+});

--- a/packages/frontend/editor-ui/src/app/components/NodeIcon.vue
+++ b/packages/frontend/editor-ui/src/app/components/NodeIcon.vue
@@ -40,7 +40,10 @@ const emit = defineEmits<{
 	click: [];
 }>();
 
-const iconSourceFromNodeType = useNodeIconSource(props.nodeType, props.node ?? null);
+const iconSourceFromNodeType = useNodeIconSource(
+	() => props.nodeType,
+	() => props.node ?? null,
+);
 
 const iconSource = computed(() => props.iconSource ?? iconSourceFromNodeType.value);
 

--- a/packages/frontend/editor-ui/src/app/composables/useNodeIconSource.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeIconSource.ts
@@ -1,6 +1,6 @@
 import type { INode } from 'n8n-workflow';
 import { getNodeIconSource, type IconNodeType, type NodeIconSource } from '../utils/nodeIcon';
-import { computed, toValue, type ComputedRef, type MaybeRef } from 'vue';
+import { computed, toValue, type ComputedRef, type MaybeRefOrGetter } from 'vue';
 import { useWorkflowsStore } from '../stores/workflows.store';
 import {
 	createWorkflowDocumentId,
@@ -8,8 +8,8 @@ import {
 } from '../stores/workflowDocument.store';
 
 export function useNodeIconSource(
-	nodeType: MaybeRef<IconNodeType | string | null | undefined>,
-	node?: MaybeRef<INode | null>,
+	nodeType: MaybeRefOrGetter<IconNodeType | string | null | undefined>,
+	node?: MaybeRefOrGetter<INode | null>,
 ): ComputedRef<NodeIconSource | undefined> {
 	const workflowsStore = useWorkflowsStore();
 	const workflowDocumentStore = computed(() =>

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiffUI.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiffUI.test.ts
@@ -321,6 +321,53 @@ describe('useWorkflowDiffUI', () => {
 
 			expect(selectedNode.value).toEqual(mockNode);
 		});
+
+		it('should return target node for modified nodes when type changed', () => {
+			const baseNode = createMockNode({
+				id: 'node-1',
+				name: 'Edit Fields',
+				type: 'n8n-nodes-base.set',
+			});
+			const targetNode = createMockNode({
+				id: 'node-1',
+				name: 'Get Calendar Events',
+				type: 'n8n-nodes-base.googleCalendar',
+			});
+			const nodesDiff = ref(
+				new Map([['node-1', { status: NodeDiffStatus.Modified, node: baseNode }]]),
+			);
+
+			const { selectedNode } = useWorkflowDiffUI({
+				sourceWorkflow: computed(() => createMockWorkflow({ nodes: [baseNode] })),
+				targetWorkflow: computed(() => createMockWorkflow({ nodes: [targetNode] })),
+				nodesDiff,
+				connectionsDiff: ref(new Map()),
+				selectedDetailId: ref('node-1'),
+			});
+
+			expect(selectedNode.value).toEqual(targetNode);
+		});
+
+		it('should fall back to source node for deleted nodes', () => {
+			const deletedNode = createMockNode({
+				id: 'node-1',
+				name: 'Removed Node',
+				type: 'n8n-nodes-base.slack',
+			});
+			const nodesDiff = ref(
+				new Map([['node-1', { status: NodeDiffStatus.Deleted, node: deletedNode }]]),
+			);
+
+			const { selectedNode } = useWorkflowDiffUI({
+				sourceWorkflow: computed(() => createMockWorkflow({ nodes: [deletedNode] })),
+				targetWorkflow: computed(() => createMockWorkflow({ nodes: [] })),
+				nodesDiff,
+				connectionsDiff: ref(new Map()),
+				selectedDetailId: ref('node-1'),
+			});
+
+			expect(selectedNode.value).toEqual(deletedNode);
+		});
 	});
 
 	describe('changesCount', () => {

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiffUI.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiffUI.ts
@@ -165,12 +165,17 @@ export function useWorkflowDiffUI(options: UseWorkflowDiffUIOptions) {
 
 	// Selected node
 	const selectedNode = computed<INodeUi | undefined>(() => {
-		if (!selectedDetailId.value) return undefined;
+		const id = selectedDetailId.value;
+		if (!id) return undefined;
 
-		const node = nodesDiff.value.get(selectedDetailId.value)?.node;
-		if (!node) return undefined;
-
-		return node;
+		// Prefer the target workflow so modified nodes whose type changed
+		// surface the new node (and its icon) rather than the base version.
+		// Falls back to source for deleted nodes, then to the diff entry.
+		return (
+			targetWorkflow.value?.nodes.find((node) => node.id === id) ??
+			sourceWorkflow.value?.nodes.find((node) => node.id === id) ??
+			nodesDiff.value.get(id)?.node
+		);
 	});
 
 	// Node diffs for aside panel


### PR DESCRIPTION
## Summary

In the workflow version-history diff view, the sidebar header's node icon stayed locked to whatever was first rendered — clicking a different node would update the title text but not the icon. Root cause was a Vue reactivity bug in `NodeIcon.vue`: prop values were passed to `useNodeIconSource` as plain values rather than getters, so the inner `computed`/`toValue` chain captured a one-time snapshot and never re-tracked. Passing getters restores the reactive contract the composable was designed for.

A second smaller correctness fix in `useWorkflowDiffUI` resolves the selected node from the target workflow first (then source, then the diff entry) so that nodes whose type changed between versions surface the new icon, mirroring the existing pattern in `useReviewChanges`.

To test: open Version History on a workflow with multiple saved versions that differ by node, open the diff, click between nodes — the sidebar icon should now switch with each click.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-521

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use \`(no-changelog)\` otherwise.**
-->
- ~[ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI