### PR TITLE
fix(Webhook Node): Add opt-out for sensitiveOutputFields masking

### DIFF
--- a/packages/cli/src/modules/redaction/executions/strategies/__tests__/node-defined-field-redaction.strategy.test.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/__tests__/node-defined-field-redaction.strategy.test.ts
@@ -18,7 +18,12 @@ const makeContext = (overrides: Partial<RedactionContext> = {}): RedactionContex
 });
 
 const makeExecution = (
-	nodes: Array<{ name: string; type: string; typeVersion: number }>,
+	nodes: Array<{
+		name: string;
+		type: string;
+		typeVersion: number;
+		parameters?: Record<string, unknown>;
+	}>,
 	runData: Record<
 		string,
 		Array<{
@@ -48,7 +53,7 @@ const makeExecution = (
 				type: n.type,
 				typeVersion: n.typeVersion,
 				position: [0, 0] as [number, number],
-				parameters: {},
+				parameters: n.parameters ?? {},
 			})),
 		},
 	}) as unknown as RedactableExecution;
@@ -427,6 +432,196 @@ describe('NodeDefinedFieldRedactionStrategy', () => {
 						unknown
 					>
 				).authorization,
+			).toEqual(REDACTED_MARKER);
+		});
+	});
+
+	describe('sensitiveOutputFieldsOptOutPath', () => {
+		const optOutDescription = (sensitiveOutputFields: string[], optOutPath: string) => ({
+			name: 'n8n-nodes-base.webhook',
+			sensitiveOutputFields,
+			sensitiveOutputFieldsOptOutPath: optOutPath,
+		});
+
+		it('skips redaction when the per-instance opt-out parameter is true', async () => {
+			nodeTypes.getByNameAndVersion.mockReturnValue({
+				description: optOutDescription(['headers.authorization'], 'options.exposeAuthHeaders'),
+			} as ReturnType<typeof nodeTypes.getByNameAndVersion>);
+
+			const execution = makeExecution(
+				[
+					{
+						name: 'Webhook',
+						type: 'n8n-nodes-base.webhook',
+						typeVersion: 1,
+						parameters: { options: { exposeAuthHeaders: true } },
+					},
+				],
+				{
+					Webhook: [
+						{ data: { main: [[{ json: { headers: { authorization: 'Bearer secret' } } }]] } },
+					],
+				},
+			);
+
+			await strategy.apply(execution, makeContext());
+
+			expect(
+				(
+					execution.data.resultData.runData.Webhook[0].data!.main[0]![0].json.headers as Record<
+						string,
+						unknown
+					>
+				).authorization,
+			).toBe('Bearer secret');
+		});
+
+		it('still redacts when the opt-out parameter is false', async () => {
+			nodeTypes.getByNameAndVersion.mockReturnValue({
+				description: optOutDescription(['headers.authorization'], 'options.exposeAuthHeaders'),
+			} as ReturnType<typeof nodeTypes.getByNameAndVersion>);
+
+			const execution = makeExecution(
+				[
+					{
+						name: 'Webhook',
+						type: 'n8n-nodes-base.webhook',
+						typeVersion: 1,
+						parameters: { options: { exposeAuthHeaders: false } },
+					},
+				],
+				{
+					Webhook: [
+						{ data: { main: [[{ json: { headers: { authorization: 'Bearer secret' } } }]] } },
+					],
+				},
+			);
+
+			await strategy.apply(execution, makeContext());
+
+			expect(
+				(
+					execution.data.resultData.runData.Webhook[0].data!.main[0]![0].json.headers as Record<
+						string,
+						unknown
+					>
+				).authorization,
+			).toEqual(REDACTED_MARKER);
+		});
+
+		it('still redacts when the opt-out parameter is missing entirely (default)', async () => {
+			nodeTypes.getByNameAndVersion.mockReturnValue({
+				description: optOutDescription(['headers.authorization'], 'options.exposeAuthHeaders'),
+			} as ReturnType<typeof nodeTypes.getByNameAndVersion>);
+
+			const execution = makeExecution(
+				[
+					{
+						name: 'Webhook',
+						type: 'n8n-nodes-base.webhook',
+						typeVersion: 1,
+						parameters: {},
+					},
+				],
+				{
+					Webhook: [
+						{ data: { main: [[{ json: { headers: { authorization: 'Bearer secret' } } }]] } },
+					],
+				},
+			);
+
+			await strategy.apply(execution, makeContext());
+
+			expect(
+				(
+					execution.data.resultData.runData.Webhook[0].data!.main[0]![0].json.headers as Record<
+						string,
+						unknown
+					>
+				).authorization,
+			).toEqual(REDACTED_MARKER);
+		});
+
+		it('still redacts when the opt-out parameter is a truthy non-boolean (fail-safe)', async () => {
+			nodeTypes.getByNameAndVersion.mockReturnValue({
+				description: optOutDescription(['headers.authorization'], 'options.exposeAuthHeaders'),
+			} as ReturnType<typeof nodeTypes.getByNameAndVersion>);
+
+			const execution = makeExecution(
+				[
+					{
+						name: 'Webhook',
+						type: 'n8n-nodes-base.webhook',
+						typeVersion: 1,
+						parameters: { options: { exposeAuthHeaders: 'true' as unknown } },
+					},
+				],
+				{
+					Webhook: [
+						{ data: { main: [[{ json: { headers: { authorization: 'Bearer secret' } } }]] } },
+					],
+				},
+			);
+
+			await strategy.apply(execution, makeContext());
+
+			expect(
+				(
+					execution.data.resultData.runData.Webhook[0].data!.main[0]![0].json.headers as Record<
+						string,
+						unknown
+					>
+				).authorization,
+			).toEqual(REDACTED_MARKER);
+		});
+
+		it('does not affect other nodes that lack an opt-out path on their description', async () => {
+			nodeTypes.getByNameAndVersion
+				.mockReturnValueOnce({
+					description: optOutDescription(['headers.authorization'], 'options.exposeAuthHeaders'),
+				} as ReturnType<typeof nodeTypes.getByNameAndVersion>)
+				.mockReturnValueOnce({
+					description: mockNodeDescription(['body.password']),
+				} as ReturnType<typeof nodeTypes.getByNameAndVersion>);
+
+			const execution = makeExecution(
+				[
+					{
+						name: 'NodeA',
+						type: 'n8n-nodes-base.webhook',
+						typeVersion: 1,
+						parameters: { options: { exposeAuthHeaders: true } },
+					},
+					{
+						name: 'NodeB',
+						type: 'n8n-nodes-base.httpRequest',
+						typeVersion: 1,
+						parameters: { options: { exposeAuthHeaders: true } },
+					},
+				],
+				{
+					NodeA: [{ data: { main: [[{ json: { headers: { authorization: 'secret-a' } } }]] } }],
+					NodeB: [{ data: { main: [[{ json: { body: { password: 'hunter2' } } }]] } }],
+				},
+			);
+
+			await strategy.apply(execution, makeContext());
+
+			expect(
+				(
+					execution.data.resultData.runData.NodeA[0].data!.main[0]![0].json.headers as Record<
+						string,
+						unknown
+					>
+				).authorization,
+			).toBe('secret-a');
+			expect(
+				(
+					execution.data.resultData.runData.NodeB[0].data!.main[0]![0].json.body as Record<
+						string,
+						unknown
+					>
+				).password,
 			).toEqual(REDACTED_MARKER);
 		});
 	});

--- a/packages/cli/src/modules/redaction/executions/strategies/node-defined-field-redaction.strategy.ts
+++ b/packages/cli/src/modules/redaction/executions/strategies/node-defined-field-redaction.strategy.ts
@@ -102,6 +102,12 @@ export class NodeDefinedFieldRedactionStrategy implements IExecutionRedactionStr
 	 * node is added to `unknownNodes` so its entire output is wiped conservatively
 	 * (fail-closed), honouring the contract that `sensitiveOutputFields` are
 	 * always redacted and never revealable.
+	 *
+	 * If the node type declares `sensitiveOutputFieldsOptOutPath`, the strategy
+	 * checks that path on the per-instance `node.parameters`. When the resolved
+	 * value is `true`, the node is skipped — the workflow author has explicitly
+	 * opted that instance out of redaction (e.g. to expose auth headers for
+	 * downstream JWT/HMAC verification).
 	 */
 	private buildSensitiveFieldsMap(execution: RedactableExecution): {
 		sensitiveFields: Map<string, string[]>;
@@ -122,12 +128,37 @@ export class NodeDefinedFieldRedactionStrategy implements IExecutionRedactionStr
 				continue;
 			}
 
-			if (description.sensitiveOutputFields?.length) {
-				sensitiveFields.set(node.name, description.sensitiveOutputFields);
+			if (!description.sensitiveOutputFields?.length) continue;
+
+			if (
+				description.sensitiveOutputFieldsOptOutPath &&
+				this.isOptedOut(node.parameters, description.sensitiveOutputFieldsOptOutPath)
+			) {
+				continue;
 			}
+
+			sensitiveFields.set(node.name, description.sensitiveOutputFields);
 		}
 
 		return { sensitiveFields, unknownNodes };
+	}
+
+	/**
+	 * Resolves a dot-notation path on a node's parameters object and returns
+	 * `true` only when the resolved value is strictly the boolean `true`.
+	 * Anything else (missing key, non-record intermediate, falsey value, or a
+	 * truthy non-boolean) leaves redaction enabled — the opt-out is fail-safe.
+	 */
+	private isOptedOut(parameters: unknown, path: string): boolean {
+		if (!this.isRecord(parameters)) return false;
+
+		const segments = path.split('.');
+		let current: unknown = parameters;
+		for (const segment of segments) {
+			if (!this.isRecord(current)) return false;
+			current = current[segment];
+		}
+		return current === true;
 	}
 
 	/**

--- a/packages/nodes-base/nodes/Webhook/Webhook.node.ts
+++ b/packages/nodes-base/nodes/Webhook/Webhook.node.ts
@@ -74,6 +74,7 @@ export class Webhook extends Node {
 		credentials: credentialsProperty(this.authPropertyName),
 		webhooks: [defaultWebhookDescription],
 		sensitiveOutputFields: ['headers.authorization', 'headers.cookie'],
+		sensitiveOutputFieldsOptOutPath: 'options.exposeAuthHeaders',
 		properties: [
 			{
 				displayName: 'Allow Multiple HTTP Methods',

--- a/packages/nodes-base/nodes/Webhook/description.ts
+++ b/packages/nodes-base/nodes/Webhook/description.ts
@@ -290,6 +290,14 @@ export const optionsProperty: INodeProperties = {
 				'The name of the output field to put any binary file data in. Only relevant if binary data is received.',
 		},
 		{
+			displayName: 'Expose Authentication Headers',
+			name: 'exposeAuthHeaders',
+			type: 'boolean',
+			default: false,
+			description:
+				"Whether to keep the Authorization and Cookie request headers in this node's output instead of redacting them. Enable only when downstream nodes need the raw values (e.g. JWT signature or HMAC verification). Anyone with execution-read access on the workflow will be able to see these headers in execution data.",
+		},
+		{
 			displayName: 'Ignore Bots',
 			name: 'ignoreBots',
 			type: 'boolean',

--- a/packages/nodes-base/nodes/Webhook/test/Webhook.test.ts
+++ b/packages/nodes-base/nodes/Webhook/test/Webhook.test.ts
@@ -165,5 +165,23 @@ describe('Test Webhook Node', () => {
 			const node = new Webhook();
 			expect(node.description.sensitiveOutputFields).not.toContain('headers.content-type');
 		});
+
+		it('declares the opt-out parameter path so users can expose auth headers when needed', () => {
+			const node = new Webhook();
+			expect(node.description.sensitiveOutputFieldsOptOutPath).toBe('options.exposeAuthHeaders');
+		});
+
+		it('exposes the opt-out as a boolean option, defaulted to false (security-by-default)', () => {
+			const node = new Webhook();
+			const optionsParam = node.description.properties.find((p) => p.name === 'options');
+			expect(optionsParam).toBeDefined();
+			const subOptions = (
+				optionsParam as { options?: Array<{ name: string; type: string; default: unknown }> }
+			).options;
+			const expose = subOptions?.find((o) => o.name === 'exposeAuthHeaders');
+			expect(expose).toBeDefined();
+			expect(expose?.type).toBe('boolean');
+			expect(expose?.default).toBe(false);
+		});
 	});
 });

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2539,6 +2539,19 @@ export interface INodeTypeDescription extends INodeTypeBaseDescription {
 	 * permissions and are never revealable.
 	 */
 	sensitiveOutputFields?: string[];
+	/**
+	 * Optional dot-notation path on `INode.parameters` that, when present and
+	 * truthy on a node instance, opts that instance out of
+	 * `sensitiveOutputFields` redaction. Allows a node author to expose an
+	 * explicit per-node toggle for users who need raw values downstream
+	 * (e.g. JWT/HMAC signature verification on a Webhook auth header).
+	 *
+	 * The opt-out is opt-in by node author and opt-in by node instance:
+	 * the field is left unset on every existing node, and instances default
+	 * to redacting. Only when the author declares this path AND the user
+	 * sets the parameter to `true` does the strategy skip redaction.
+	 */
+	sensitiveOutputFieldsOptOutPath?: string;
 }
 
 export type TriggerPanelDefinition = {


### PR DESCRIPTION
## Summary

Closes #29819.

The Webhook node hardcodes `sensitiveOutputFields: ['headers.authorization', 'headers.cookie']`, which `NodeDefinedFieldRedactionStrategy` applies unconditionally — even on the reveal path and even when the workflow's redaction policy is `none`. The redacted dict propagates to downstream nodes as runtime data, so workflows that previously read the auth header for JWT signature verification, HMAC verification, or Bot Framework token validation break on upgrade. There is currently no per-workflow or per-node opt-out short of disabling the entire redaction module instance-wide.

This PR adds a node-instance-scoped escape hatch so the security-by-default behaviour stays in place for every existing workflow, while users with a legitimate need to inspect the raw auth header can opt their specific Webhook node in.

### Use case

The motivating example from the issue: validating a Microsoft Bot Framework JWT against the published JWKS in a Code node. The Bot Framework signs every inbound request with a JWT in the `Authorization` header, and the bot is required to verify that signature before responding. The same shape applies to Slack, GitHub, Stripe, and Shopify HMAC verifications and any pattern where a downstream node reads the bearer token or the `Cookie` header as a string.

## Design

A two-piece change in the redaction protocol:

1. **`INodeTypeDescription.sensitiveOutputFieldsOptOutPath?: string`** (`packages/workflow`). A node author may declare a dot-notation path on `INode.parameters`. When that path resolves to *strictly* the boolean `true` on a given node instance, `NodeDefinedFieldRedactionStrategy.buildSensitiveFieldsMap` skips that node when building the redaction map.

   - Opt-in by node author: every existing node leaves the field unset, so the prior "always redacted, never revealable" guarantee continues to hold for all of them.
   - Opt-in by node instance: even on a node that declares the path, the per-instance default is to redact.
   - Fail-safe: missing keys, non-record intermediates, falsey values, and truthy non-booleans (e.g. the string `"true"`) all leave redaction enabled.

2. **Webhook node** (`packages/nodes-base/nodes/Webhook`). The Webhook node sets `sensitiveOutputFieldsOptOutPath: 'options.exposeAuthHeaders'` and adds an `Expose Authentication Headers` boolean inside its existing Options collection, defaulted to `false`. The option's description spells out the security trade-off (anyone with execution-read access on the workflow will see the headers in execution data).

### Parameter UI shape

```ts
{
    displayName: 'Expose Authentication Headers',
    name: 'exposeAuthHeaders',
    type: 'boolean',
    default: false,
    description:
        "Whether to keep the Authorization and Cookie request headers in this node's output instead of redacting them. Enable only when downstream nodes need the raw values (e.g. JWT signature or HMAC verification). Anyone with execution-read access on the workflow will be able to see these headers in execution data.",
},
```

The opt-out is wired into the description as:

```ts
sensitiveOutputFields: ['headers.authorization', 'headers.cookie'],
sensitiveOutputFieldsOptOutPath: 'options.exposeAuthHeaders',
```

## Why this shape over the alternatives in the issue

The issue suggests three approaches in priority order. I went with #2 (node-level toggle) for these reasons:

- **#1 (honour workflow `Do not redact`)** would walk back the explicit guarantee from #26546 that node-declared sensitive fields are *always* redacted regardless of workflow policy. Workflow-level redaction settings and node-author-declared sensitive fields are deliberately decoupled so that "redact most fields but reveal everything in this workflow" remains a coherent permission model. Tying the two together would change the semantics for every node, not just Webhook.
- **#3 (typeVersion bump that defaults pre-existing instances to un-redacted)** would silently un-redact existing webhooks on upgrade, which is a lateral regression from the user perspective: workflows that *should* keep redacting headers (the security default the original PR was added for) suddenly stop. A typeVersion bump where the *new* version defaults to redacting and the *old* version defaults to un-redacting would also leak the old behaviour forever for any pre-2.18 webhook, undoing the fix.
- **#2 (node-level toggle)** preserves security-by-default for every existing instance, surfaces the trade-off in the UI text, and keeps the opt-out scoped to the one node-instance that needs it. Generic enough that other nodes can opt in to the same pattern without each baking their own toggle plumbing.

## Test coverage

`packages/cli/src/modules/redaction/executions/strategies/__tests__/node-defined-field-redaction.strategy.test.ts` (`sensitiveOutputFieldsOptOutPath` describe block, 5 new cases):

1. `skips redaction when the per-instance opt-out parameter is true` — happy path: opt-out `true` leaves `headers.authorization` as the original `Bearer secret` string.
2. `still redacts when the opt-out parameter is false` — explicit-false still redacts to the marker.
3. `still redacts when the opt-out parameter is missing entirely (default)` — missing key still redacts.
4. `still redacts when the opt-out parameter is a truthy non-boolean (fail-safe)` — string `"true"` does *not* opt out.
5. `does not affect other nodes that lack an opt-out path on their description` — a Webhook with the opt-out path opts out, while a sibling node without the path on its description keeps redacting even when the parameter is set on its instance.

`packages/nodes-base/nodes/Webhook/test/Webhook.test.ts` (`sensitiveOutputFields` describe block, 2 new cases):

1. `declares the opt-out parameter path so users can expose auth headers when needed` — asserts `description.sensitiveOutputFieldsOptOutPath === 'options.exposeAuthHeaders'`.
2. `exposes the opt-out as a boolean option, defaulted to false (security-by-default)` — asserts the new option exists in the Options collection with `type: 'boolean'` and `default: false`.

Local results:
- `pnpm --filter n8n-nodes-base test -- nodes/Webhook` — 64/64 passed.
- `pnpm --filter n8n test -- modules/redaction` — 87/87 passed (all 4 redaction suites including the strategy and orchestrator).
- `pnpm build --filter='n8n-workflow'`, `--filter='n8n-nodes-base'`, `--filter='n8n'` — all green.
- `eslint nodes/Webhook` — 0 errors.

## Related Linear tickets, Github issues, and Community forum posts

- Closes https://github.com/n8n-io/n8n/issues/29819
- Original feature: #26546 (sensitiveOutputFields strategy pipeline)
- Earlier opt-in attempt: #20783 (closed; went the other direction — opt-in redaction)
- Community: https://community.n8n.io/t/headers-redaction-for-webhooks-output-to-cut-out-auth-data/230083 / https://community.n8n.io/t/how-do-we-redact-the-headers-that-are-sent-to-the-webhook-trigger-node/205437

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. Suggested doc edit: add a paragraph to https://docs.n8n.io/workflows/executions/execution-data-redaction/ noting the Webhook node now exposes a per-instance `Expose Authentication Headers` toggle for downstream JWT/HMAC verification.
- [x] Tests included.
- [ ] PR Labeled with `release/backport` (worth considering — the regression breaks Bot Framework / HMAC / Stripe / Shopify webhooks on upgrade).