### PR TITLE
feat(editor): Make execution run time column easier to scan

### DIFF
--- a/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsListItem.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsListItem.test.ts
@@ -213,6 +213,6 @@ describe('GlobalExecutionsListItem', () => {
 
 		const executionTimeElement = getByTestId('execution-time');
 		expect(executionTimeElement).toBeVisible();
-		expect(executionTimeElement.textContent).toBe('30m 0s');
+		expect(executionTimeElement.textContent).toBe('1,800.000s');
 	});
 });

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsListItem.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsListItem.vue
@@ -130,14 +130,25 @@ const formattedWaitTillDate = computed(() => {
 	return props.execution.waitTill ? formatDate(props.execution.waitTill) : '';
 });
 
+const durationFormatter = new Intl.NumberFormat(undefined, {
+	minimumFractionDigits: 3,
+	maximumFractionDigits: 3,
+});
+
+function formatRuntime(milliseconds: number) {
+	return `${durationFormatter.format(milliseconds / 1000)}s`;
+}
+
 const formattedStoppedAtDate = computed(() => {
-	return props.execution.stoppedAt
-		? locale.displayTimer(
-				new Date(props.execution.stoppedAt).getTime() -
-					new Date(props.execution.startedAt ?? props.execution.createdAt).getTime(),
-				true,
-			)
-		: '';
+	if (!props.execution.stoppedAt) {
+		return '';
+	}
+
+	const durationMs =
+		new Date(props.execution.stoppedAt).getTime() -
+		new Date(props.execution.startedAt ?? props.execution.createdAt).getTime();
+
+	return formatRuntime(durationMs);
 });
 
 function getStatusLabel(status: ExecutionStatus) {
@@ -243,7 +254,7 @@ async function handleActionItemClick(commandData: Command) {
 		<td>
 			{{ formattedStartedAtDate }}
 		</td>
-		<td data-test-id="execution-time">
+		<td :class="$style.runTime" data-test-id="execution-time">
 			<template v-if="formattedStoppedAtDate">
 				{{ formattedStoppedAtDate }}
 			</template>
@@ -341,4 +352,10 @@ tr.dangerBg {
 	line-height: var(--line-height--lg);
 	max-width: 450px;
 }
+
+.runTime {
+	text-align: right;
+	font-variant-numeric: tabular-nums;
+}
+
 </style>

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsListItem.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsListItem.vue
@@ -354,8 +354,7 @@ tr.dangerBg {
 }
 
 .runTime {
-	text-align: right;
+	font-family: var(--font-family--monospace);
 	font-variant-numeric: tabular-nums;
 }
-
 </style>


### PR DESCRIPTION
## Summary 
Improve scan-ability of the "Run Time" column by using a single unit and consistent precision so values can be compared visually 

- Right-align numeic values and use tabular numerals so the decimal separator lines up vertically and column-wide comparisons are easier. 
- Format completed run durations as seconds with fixed 3-decimal precision using a small formatter (`durationFormatter` + `formatRuntime`) and render as e.g. `1,800.000s`. 
- Replace the previous `locale.displayTimer(..., true)` output for stopped runs with the new `formatRuntime` value computed from `startedAt/createdAt` and `stoppedAt`. 
- Add a CSS module class `.runTime` to the run time cell that makes font monospace and `font-variant-numeric: tabular-nums` for visual alignment. 
- Update the related unit test expectation in `GlobalExecutionsListItem.test.ts` to match the new formatting. 

| Before | After |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/2dce9452-5844-485c-9cc2-27ff3ab442f2" width="960px" /> | <img src="https://github.com/user-attachments/assets/f6dde67e-4e94-4afd-9907-7fd6a7680f63" width="960px" /> |

### Linear ticket
[DS-476](https://linear.app/n8n/issue/DS-476)

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](<../blob/master/.github/pull_request_title_conventions.md>))
- [ ] [Docs updated](<https://github.com/n8n-io/n8n-docs>) or follow-up ticket created.
- [X] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)