### PR TITLE
ci: Fix flacky test error assertion

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/test/OutputParserStructured.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/output_parser/OutputParserStructured/test/OutputParserStructured.node.test.ts
@@ -822,11 +822,11 @@ describe('OutputParserStructured', () => {
 					.calledWith('prompt', 0, NAIVE_FIX_PROMPT)
 					.mockReturnValueOnce('Invalid prompt without error placeholder');
 
-				await expect(outputParser.supplyData.call(thisArg, 0)).rejects.toThrow(
-					new NodeOperationError(
-						thisArg.getNode(),
-						'Auto-fixing parser prompt has to contain {error} placeholder',
-					),
+				const execution = outputParser.supplyData.call(thisArg, 0);
+
+				await expect(execution).rejects.toThrow(NodeOperationError);
+				await expect(execution).rejects.toThrow(
+					'Auto-fixing parser prompt has to contain {error} placeholder',
 				);
 			});
 


### PR DESCRIPTION
## Summary

ci: Fix flacky test error assertion

## Related Linear tickets, Github issues, and Community forum posts




## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
