### PR TITLE
fix(core): Preserve node positions on AI workflow updates

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/handlers/parse-validate-handler.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/handlers/parse-validate-handler.ts
@@ -195,8 +195,8 @@ export class ParseValidateHandler {
 				builder.generatePinData({ beforeWorkflow: currentWorkflow });
 			}
 
-			// Convert to JSON
-			const workflowJson: WorkflowJSON = builder.toJSON();
+			// Convert to JSON with Dagre layout matching the FE's tidy-up
+			const workflowJson: WorkflowJSON = builder.toJSON({ tidyUp: true });
 
 			this.logger?.debug('Parsed workflow', {
 				id: workflowJson.id,

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/submit-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/submit-workflow.tool.test.ts
@@ -16,7 +16,6 @@ jest.mock('@mastra/core/tools', () => ({
 
 jest.mock('@n8n/workflow-sdk', () => ({
 	validateWorkflow: jest.fn(() => ({ errors: [], warnings: [] })),
-	layoutWorkflowJSON: jest.fn((wf: unknown) => wf),
 }));
 
 // `require` (rather than `import`) is needed because `submit-workflow.tool`

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -1,5 +1,5 @@
 import { createTool } from '@mastra/core/tools';
-import { generateWorkflowCode, layoutWorkflowJSON } from '@n8n/workflow-sdk';
+import { generateWorkflowCode } from '@n8n/workflow-sdk';
 import { z } from 'zod';
 
 import { buildCredentialMap, resolveCredentials } from './resolve-credentials';
@@ -149,9 +149,7 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 				};
 			}
 
-			// Apply Dagre layout to produce positions matching the FE's tidy-up.
-			// Temporary: remove once the SDK is published with toJSON({ tidyUp: true }).
-			const json = layoutWorkflowJSON(result.workflow);
+			const json = result.workflow;
 			if (name) {
 				json.name = name;
 			} else if (!json.name && !workflowId) {

--- a/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow.tool.ts
@@ -10,7 +10,7 @@ import { createTool } from '@mastra/core/tools';
 import type { Workspace } from '@mastra/core/workspace';
 import { hasPlaceholderDeep } from '@n8n/utils';
 import type { WorkflowJSON } from '@n8n/workflow-sdk';
-import { validateWorkflow, layoutWorkflowJSON } from '@n8n/workflow-sdk';
+import { validateWorkflow } from '@n8n/workflow-sdk';
 import { createHash, randomUUID } from 'node:crypto';
 import { z } from 'zod';
 
@@ -398,10 +398,7 @@ export function createSubmitWorkflowTool(
 				};
 			}
 
-			// Apply Dagre layout to produce positions matching the FE's tidy-up.
-			// Temporary: until the SDK is published with toJSON({ tidyUp: true }) support,
-			// the sandbox's SDK doesn't have Dagre layout, so we apply it server-side.
-			const json = layoutWorkflowJSON(buildOutput.workflow);
+			const json = buildOutput.workflow;
 			if (name) {
 				json.name = name;
 			} else if (!json.name && !workflowId) {

--- a/packages/@n8n/instance-ai/src/workflow-builder/parse-validate.ts
+++ b/packages/@n8n/instance-ai/src/workflow-builder/parse-validate.ts
@@ -78,7 +78,7 @@ export function parseAndValidate(
 		collectValidationIssues(graphValidation.errors, allWarnings);
 		collectValidationIssues(graphValidation.warnings, allWarnings);
 
-		const json = builder.toJSON();
+		const json = builder.toJSON({ tidyUp: true });
 
 		// Stage 2: Schema validation via Zod schemas from schemaBaseDirs.
 		// strictMode is hardcoded on at AI-builder call sites — we want every

--- a/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
+++ b/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
@@ -169,7 +169,7 @@ try {
     process.exit(1);
   }
   const validation = wf.validate();
-  const json = wf.toJSON();
+  const json = wf.toJSON({ tidyUp: true });
   const warnings = [...(validation.errors || []), ...(validation.warnings || [])];
   // Use a replacer to preserve undefined values as null — newCredential() produces
   // NewCredentialImpl which serializes to undefined in toJSON(). Without this,

--- a/packages/@n8n/workflow-sdk/src/index.ts
+++ b/packages/@n8n/workflow-sdk/src/index.ts
@@ -148,9 +148,6 @@ export { runOnceForAllItems, runOnceForEachItem } from './utils/code-helpers';
 // Utility functions
 export { isPlainObject, getProperty, hasProperty } from './utils/safe-access';
 
-// Layout
-export { layoutWorkflowJSON } from './workflow-builder/layout-utils';
-
 // Validation
 export {
 	validateWorkflow,

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.test.ts
@@ -383,5 +383,41 @@ describe('calculateNodePositionsDagre', () => {
 			const positions2 = calculateNodePositionsDagre(nodes2);
 			expect(positions2.has('remote-note')).toBe(false);
 		});
+
+		it('preserves explicit positions and anchors new nodes around them', () => {
+			const nodes = new Map<string, GraphNode>();
+			const triggerConns = makeMainConns([[0, [makeTarget('set')]]]);
+
+			nodes.set(
+				'trigger',
+				createGraphNode('trigger', 'n8n-nodes-base.manualTrigger', triggerConns, [500, 600]),
+			);
+			nodes.set('set', createGraphNode('set', 'n8n-nodes-base.set'));
+
+			const positions = calculateNodePositionsDagre(nodes);
+
+			// Explicit position is not overwritten (function only returns positions for unpositioned nodes)
+			expect(positions.has('trigger')).toBe(false);
+			// New node gets a position from dagre
+			expect(positions.has('set')).toBe(true);
+		});
+
+		it('reanchors sticky notes using explicit positions of covered nodes', () => {
+			const nodes = new Map<string, GraphNode>();
+			const triggerConns = makeMainConns([[0, [makeTarget('set')]]]);
+
+			nodes.set(
+				'trigger',
+				createGraphNode('trigger', 'n8n-nodes-base.manualTrigger', triggerConns, [500, 600]),
+			);
+			nodes.set('set', createGraphNode('set', 'n8n-nodes-base.set'));
+			// Sticky overlapping the explicitly positioned trigger
+			nodes.set('note', createGraphNode('note', STICKY_NODE_TYPE, undefined, [500, 600]));
+
+			const positions = calculateNodePositionsDagre(nodes);
+
+			// Sticky is reanchored relative to trigger's explicit position, not dagre's guess
+			expect(positions.get('note')).toEqual([496, 672]);
+		});
 	});
 });

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/layout-utils.ts
@@ -4,7 +4,7 @@
  * Two layout strategies:
  * 1. BFS layout (calculateNodePositions) — simple left-to-right BFS, used by default toJSON()
  * 2. Dagre layout (calculateNodePositionsDagre) — mirrors the FE's useCanvasLayout algorithm,
- *    used by toJSON({ tidyUp: true }) and layoutWorkflowJSON()
+ *    used by toJSON({ tidyUp: true })
  */
 
 import dagre from '@dagrejs/dagre';
@@ -27,7 +27,7 @@ import {
 	DEFAULT_Y,
 	START_X,
 } from './constants';
-import type { GraphNode, WorkflowJSON, ConnectionTarget } from '../types/base';
+import type { GraphNode } from '../types/base';
 
 // ===========================================================================
 // BFS Layout (default)
@@ -465,7 +465,12 @@ export function calculateNodePositionsDagre(
 
 	for (const name of nonStickyNames) {
 		const { width, height } = getNodeDimensions(name, aiParentNames, aiConfigNames, nodes);
-		parentGraph.setNode(name, { width, height });
+		const explicitPosition = nodes.get(name)?.instance.config?.position;
+		parentGraph.setNode(name, {
+			width,
+			height,
+			...(explicitPosition ? { x: explicitPosition[0], y: explicitPosition[1] } : {}),
+		});
 	}
 
 	// Add edges from connections
@@ -637,88 +642,27 @@ export function calculateNodePositionsDagre(
 		}
 
 		const positionsAfter = new Map<string, BoundingBox>();
-		for (const [name, box] of Object.entries(boundingBoxByNodeId)) {
-			positionsAfter.set(name, box);
+		for (const [name, graphNode] of nodes) {
+			const explicitPosition = graphNode.instance.config?.position;
+			if (explicitPosition) {
+				const { width, height } = getNodeDimensions(name, aiParentNames, aiConfigNames, nodes);
+				positionsAfter.set(name, {
+					x: explicitPosition[0],
+					y: explicitPosition[1],
+					width,
+					height,
+				});
+				continue;
+			}
+
+			const box = boundingBoxByNodeId[name];
+			if (box) {
+				positionsAfter.set(name, box);
+			}
 		}
 
 		repositionStickyNotes(stickyNames, nonStickyNames, positionsBefore, positionsAfter, positions);
 	}
 
 	return positions;
-}
-
-// ===========================================================================
-// WorkflowJSON layout (operates on serialized workflow, not builder graph)
-// ===========================================================================
-
-/**
- * Return a new WorkflowJSON with Dagre-computed node positions.
- * Builds a GraphNode map from the serialized JSON and delegates to calculateNodePositionsDagre.
- *
- * Pure function — does not mutate the input.
- *
- * This is the entry point for code paths that receive pre-built WorkflowJSON
- * (e.g., sandbox-compiled workflows in instance-ai) and need proper layout
- * before the SDK is published with tidyUp support.
- */
-export function layoutWorkflowJSON(json: WorkflowJSON): WorkflowJSON {
-	const jsonNodes = json.nodes;
-	if (!jsonNodes || jsonNodes.length === 0) return json;
-
-	const connections = json.connections ?? {};
-
-	// Build a GraphNode map from WorkflowJSON
-	const graphNodes = new Map<string, GraphNode>();
-
-	for (const node of jsonNodes) {
-		if (!node.name) continue;
-		const connectionsMap = new Map<string, Map<number, ConnectionTarget[]>>();
-		connectionsMap.set('main', new Map());
-		graphNodes.set(node.name, {
-			instance: {
-				type: node.type,
-				name: node.name,
-				version: node.typeVersion,
-				config: {},
-			} as unknown as GraphNode['instance'],
-			connections: connectionsMap,
-		});
-	}
-
-	// Populate connections from WorkflowJSON connections structure
-	for (const [sourceName, nodeConns] of Object.entries(connections)) {
-		const graphNode = graphNodes.get(sourceName);
-		if (!graphNode) continue;
-
-		for (const [connType, outputs] of Object.entries(nodeConns)) {
-			if (!Array.isArray(outputs)) continue;
-			let outputMap = graphNode.connections.get(connType);
-			if (!outputMap) {
-				outputMap = new Map();
-				graphNode.connections.set(connType, outputMap);
-			}
-			for (let outputIdx = 0; outputIdx < outputs.length; outputIdx++) {
-				const slot = outputs[outputIdx];
-				if (!Array.isArray(slot)) continue;
-				const targets: ConnectionTarget[] = slot
-					.filter((t): t is { node: string; type: string; index: number } => !!t?.node)
-					.map((t) => ({ node: t.node, type: t.type, index: t.index }));
-				if (targets.length > 0) {
-					outputMap.set(outputIdx, targets);
-				}
-			}
-		}
-	}
-
-	// Calculate positions using the Dagre layout
-	const positions = calculateNodePositionsDagre(graphNodes);
-
-	// Return new WorkflowJSON with updated positions
-	return {
-		...json,
-		nodes: jsonNodes.map((node) => {
-			const pos = node.name ? positions.get(node.name) : undefined;
-			return pos ? { ...node, position: pos } : node;
-		}),
-	};
 }

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
@@ -1,5 +1,4 @@
 import { type User, type ProjectRepository, WorkflowEntity } from '@n8n/db';
-import { layoutWorkflowJSON } from '@n8n/workflow-sdk';
 import z from 'zod';
 
 import { MCP_CREATE_WORKFLOW_FROM_CODE_TOOL, CODE_BUILDER_VALIDATE_TOOL } from './constants';
@@ -149,7 +148,7 @@ export const createCreateWorkflowFromCodeTool = (
 			const strippedCode = stripImportStatements(code);
 			const result = await handler.parseAndValidate(strippedCode);
 
-			const workflowJson = layoutWorkflowJSON(result.workflow);
+			const workflowJson = result.workflow;
 
 			newWorkflow = new WorkflowEntity();
 			Object.assign(newWorkflow, {

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -1,5 +1,4 @@
 import { type User, type SharedWorkflowRepository, WorkflowEntity } from '@n8n/db';
-import { layoutWorkflowJSON } from '@n8n/workflow-sdk';
 import z from 'zod';
 
 import { USER_CALLED_MCP_TOOL_EVENT } from '../../mcp.constants';
@@ -132,7 +131,7 @@ export const createUpdateWorkflowTool = (
 			const strippedCode = stripImportStatements(code);
 			const result = await handler.parseAndValidate(strippedCode);
 
-			const workflowJson = layoutWorkflowJSON(result.workflow);
+			const workflowJson = result.workflow;
 
 			const workflowUpdateData = new WorkflowEntity();
 			Object.assign(workflowUpdateData, {


### PR DESCRIPTION
## Summary

When AI tools (MCP and the instance-ai deep agent) updated an existing workflow, server-side `layoutWorkflowJSON` re-ran the Dagre layout from scratch over the parsed result. For content-only edits this caused sticky notes to drift over different nodes than the user originally placed them on:

<img height="150" alt="image" src="https://github.com/user-attachments/assets/d8b00dc0-0fb2-4425-ad64-806b77a3f998"/>

This PR removes the temporary `layoutWorkflowJSON` post-processing in favor of the SDK's native `toJSON({ tidyUp: true })`, which already respects explicit `config.position`. Positions roundtrip through SDK code via `parseWorkflowCodeToBuilder` → `builder.toJSON({ tidyUp: true })`, so the layout step becomes a no-op for fully positioned workflows.

Also extends `calculateNodePositionsDagre` with two improvements that make mixed positioned/unpositioned workflows lay out cleanly:

- Seed Dagre with explicit `x,y` so newly added nodes anchor to existing positioned neighbors.
- Reanchor sticky notes using explicit positions (not Dagre's guess) for already-positioned covered nodes.

Replaces #28902. Net result: smaller surface — no `preservePositions` flag, no `LayoutableWorkflowJSON`/`LayoutableNodeJSON` types, no server-side post-processing layer. Layout is owned by the SDK.

### How to test

1. Use an MCP client or the instance-ai deep agent to update a workflow that already has manually positioned nodes and a sticky note.
2. Change content only — for example update a sticky note's text or a node parameter — without asking for a relayout.
3. Confirm content changes apply, existing positioned nodes stay put, and sticky notes remain anchored over the same nodes.
4. Confirm that brand-new workflows or newly added nodes still receive automatic Dagre layout.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-5104](https://linear.app/n8n/issue/ADO-5104/bug-sticky-note-position-is-always-changed-when-updated-through-layout)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)