### PR TITLE
feat: Add fully dynamic disclaimer to Quick Connect offer

### DIFF
--- a/packages/@n8n/api-types/src/quick-connect.ts
+++ b/packages/@n8n/api-types/src/quick-connect.ts
@@ -1,3 +1,9 @@
+export type QuickConnectDisclaimer = {
+	text: string;
+	linkUrl: string;
+	linkLabel?: string;
+};
+
 type QuickConnectGenericOption = {
 	packageName: string;
 	credentialType: string;
@@ -5,6 +11,7 @@ type QuickConnectGenericOption = {
 	quickConnectType: string;
 	consentText?: string;
 	consentCheckbox?: string;
+	disclaimer?: QuickConnectDisclaimer;
 	config?: never;
 };
 

--- a/packages/cli/src/modules/quick-connect/__tests__/quick-connect.config.test.ts
+++ b/packages/cli/src/modules/quick-connect/__tests__/quick-connect.config.test.ts
@@ -55,6 +55,48 @@ describe('QuickConnectConfig', () => {
 		expect(options[0].consentText).toBe('Allow access to your account?');
 	});
 
+	it('parses valid config with disclaimer', () => {
+		const testConfig = [
+			{
+				packageName: '@n8n/superagent',
+				credentialType: 'agentApi',
+				text: 'Superagent for everyone',
+				quickConnectType: 'oauth',
+				disclaimer: {
+					text: 'Offer subject to terms (available {link}).',
+					linkUrl: 'https://example.com/terms',
+					linkLabel: 'here',
+				},
+			},
+		];
+		process.env.N8N_QUICK_CONNECT_OPTIONS = JSON.stringify(testConfig);
+
+		const { options } = Container.get(QuickConnectConfig);
+
+		expect(options).toEqual(testConfig);
+		expect(options[0].disclaimer?.linkUrl).toBe('https://example.com/terms');
+	});
+
+	it('parses disclaimer without optional linkLabel', () => {
+		const testConfig = [
+			{
+				packageName: '@n8n/superagent',
+				credentialType: 'agentApi',
+				text: 'Superagent for everyone',
+				quickConnectType: 'oauth',
+				disclaimer: {
+					text: 'Offer subject to terms (available {link}).',
+					linkUrl: 'https://example.com/terms',
+				},
+			},
+		];
+		process.env.N8N_QUICK_CONNECT_OPTIONS = JSON.stringify(testConfig);
+
+		const { options } = Container.get(QuickConnectConfig);
+
+		expect(options).toEqual(testConfig);
+	});
+
 	it('handles empty JSON array', () => {
 		process.env.N8N_QUICK_CONNECT_OPTIONS = '[]';
 
@@ -155,6 +197,50 @@ describe('QuickConnectConfig', () => {
 					quickConnectType: 'backend',
 					backendFlowConfig: {
 						secret: 'test',
+					},
+				},
+			]),
+		],
+		[
+			'disclaimer text missing {link} placeholder',
+			JSON.stringify([
+				{
+					packageName: '@n8n/superagent',
+					credentialType: 'agentApi',
+					text: 'Superagent for everyone',
+					quickConnectType: 'oauth',
+					disclaimer: {
+						text: 'No placeholder here.',
+						linkUrl: 'https://example.com/terms',
+					},
+				},
+			]),
+		],
+		[
+			'disclaimer linkUrl is not a valid URL',
+			JSON.stringify([
+				{
+					packageName: '@n8n/superagent',
+					credentialType: 'agentApi',
+					text: 'Superagent for everyone',
+					quickConnectType: 'oauth',
+					disclaimer: {
+						text: 'Subject to terms (available {link}).',
+						linkUrl: 'not-a-url',
+					},
+				},
+			]),
+		],
+		[
+			'disclaimer missing linkUrl',
+			JSON.stringify([
+				{
+					packageName: '@n8n/superagent',
+					credentialType: 'agentApi',
+					text: 'Superagent for everyone',
+					quickConnectType: 'oauth',
+					disclaimer: {
+						text: 'Subject to terms (available {link}).',
 					},
 				},
 			]),

--- a/packages/cli/src/modules/quick-connect/quick-connect.config.ts
+++ b/packages/cli/src/modules/quick-connect/quick-connect.config.ts
@@ -1,6 +1,14 @@
 import { Config, Env } from '@n8n/config';
 import { z } from 'zod';
 
+const disclaimerSchema = z.object({
+	text: z.string().refine((s) => s.includes('{link}'), {
+		message: '`disclaimer.text` must contain the {link} placeholder',
+	}),
+	linkUrl: z.string().url(),
+	linkLabel: z.string().optional(),
+});
+
 const baseQuickConnectOptionSchema = z.object({
 	packageName: z.string(),
 	credentialType: z.string(),
@@ -8,6 +16,7 @@ const baseQuickConnectOptionSchema = z.object({
 	quickConnectType: z.string(),
 	consentText: z.string().optional(),
 	consentCheckbox: z.string().optional(),
+	disclaimer: disclaimerSchema.optional(),
 	config: z.never().optional(),
 	backendFlowConfig: z.never().optional(),
 });

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.vue
@@ -293,7 +293,11 @@ watch(showOAuthSuccessBanner, (newValue, oldValue) => {
 			/>
 
 			<template v-if="isQuickConnectMode">
-				<QuickConnectBanner v-if="quickConnectBannerText" :text="quickConnectBannerText" />
+				<QuickConnectBanner
+					v-if="quickConnectBannerText || quickConnectOption?.disclaimer"
+					:text="quickConnectBannerText"
+					:disclaimer="quickConnectOption?.disclaimer"
+				/>
 				<QuickConnectButton
 					:service-name="serviceName"
 					:credential-type-name="credentialType.name"

--- a/packages/frontend/editor-ui/src/features/credentials/quickConnect/components/QuickConnectBanner.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/quickConnect/components/QuickConnectBanner.test.ts
@@ -23,9 +23,83 @@ describe('QuickConnectBanner', () => {
 		expect(wrapper.getByText(text)).toBeInTheDocument();
 	});
 
-	it('should not render callout when text is empty', () => {
+	it('should not render when text is empty and no disclaimer is provided', () => {
 		const wrapper = renderComponent({ pinia, props: { text: '' } });
 
 		expect(wrapper.queryByTestId('quick-connect-banner')).not.toBeInTheDocument();
+	});
+
+	it('should render the disclaimer text and link with provided linkUrl and linkLabel', () => {
+		const wrapper = renderComponent({
+			pinia,
+			props: {
+				disclaimer: {
+					text: 'Subject to terms (available {link}).',
+					linkUrl: 'https://example.com/terms',
+					linkLabel: 'over here',
+				},
+			},
+		});
+
+		const disclaimer = wrapper.getByTestId('quick-connect-banner-disclaimer');
+		expect(disclaimer).toBeInTheDocument();
+		expect(disclaimer).toHaveTextContent('Subject to terms (available over here).');
+		const link = disclaimer.querySelector('a');
+		expect(link).not.toBeNull();
+		expect(link).toHaveAttribute('href', 'https://example.com/terms');
+		expect(link).toHaveAttribute('target', '_blank');
+		expect(link).toHaveTextContent('over here');
+	});
+
+	it('should default linkLabel to "here" when omitted', () => {
+		const wrapper = renderComponent({
+			pinia,
+			props: {
+				disclaimer: {
+					text: 'Subject to terms (available {link}).',
+					linkUrl: 'https://example.com/terms',
+				},
+			},
+		});
+
+		const disclaimer = wrapper.getByTestId('quick-connect-banner-disclaimer');
+		expect(disclaimer.querySelector('a')).toHaveTextContent('here');
+	});
+
+	it('should render disclaimer alongside callout text', () => {
+		const wrapper = renderComponent({
+			pinia,
+			props: {
+				text: 'Offer text',
+				disclaimer: {
+					text: 'Subject to terms (available {link}).',
+					linkUrl: 'https://example.com/terms',
+				},
+			},
+		});
+
+		expect(wrapper.getByText('Offer text')).toBeInTheDocument();
+		expect(wrapper.getByTestId('quick-connect-banner-disclaimer')).toBeInTheDocument();
+	});
+
+	it('should not render the disclaimer paragraph when disclaimer prop is omitted', () => {
+		const wrapper = renderComponent({ pinia, props: { text: 'Offer text' } });
+
+		expect(wrapper.queryByTestId('quick-connect-banner-disclaimer')).not.toBeInTheDocument();
+	});
+
+	it('should render only the disclaimer when text is empty but disclaimer is provided', () => {
+		const wrapper = renderComponent({
+			pinia,
+			props: {
+				disclaimer: {
+					text: 'Subject to terms (available {link}).',
+					linkUrl: 'https://example.com/terms',
+				},
+			},
+		});
+
+		expect(wrapper.getByTestId('quick-connect-banner')).toBeInTheDocument();
+		expect(wrapper.getByTestId('quick-connect-banner-disclaimer')).toBeInTheDocument();
 	});
 });

--- a/packages/frontend/editor-ui/src/features/credentials/quickConnect/components/QuickConnectBanner.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/quickConnect/components/QuickConnectBanner.test.ts
@@ -66,6 +66,28 @@ describe('QuickConnectBanner', () => {
 		expect(disclaimer.querySelector('a')).toHaveTextContent('here');
 	});
 
+	it('should escape HTML in disclaimer text, linkLabel, and linkUrl', () => {
+		const wrapper = renderComponent({
+			pinia,
+			props: {
+				disclaimer: {
+					text: 'Read <terms> (available {link}).',
+					linkUrl: 'https://example.com/terms?a=1&b=2',
+					linkLabel: '<b>evil</b>',
+				},
+			},
+		});
+
+		const disclaimer = wrapper.getByTestId('quick-connect-banner-disclaimer');
+		expect(disclaimer.querySelector('b')).toBeNull();
+		expect(disclaimer).toHaveTextContent('Read <terms> (available <b>evil</b>).');
+
+		const link = disclaimer.querySelector('a');
+		expect(link).not.toBeNull();
+		expect(link).toHaveTextContent('<b>evil</b>');
+		expect(link).toHaveAttribute('href', 'https://example.com/terms?a=1&b=2');
+	});
+
 	it('should render disclaimer alongside callout text', () => {
 		const wrapper = renderComponent({
 			pinia,

--- a/packages/frontend/editor-ui/src/features/credentials/quickConnect/components/QuickConnectBanner.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/quickConnect/components/QuickConnectBanner.vue
@@ -31,12 +31,12 @@ const disclaimerHtml = computed(() => {
 		<N8nCallout v-if="text" theme="secondary" iconless>
 			<div v-n8n-html="text"></div>
 		</N8nCallout>
-		<p
+		<div
 			v-if="disclaimer"
 			:class="$style.disclaimer"
 			data-test-id="quick-connect-banner-disclaimer"
 			v-n8n-html="disclaimerHtml"
-		></p>
+		></div>
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/features/credentials/quickConnect/components/QuickConnectBanner.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/quickConnect/components/QuickConnectBanner.vue
@@ -1,13 +1,61 @@
 <script setup lang="ts">
+import type { QuickConnectDisclaimer } from '@n8n/api-types';
 import { N8nCallout } from '@n8n/design-system';
+import { computed } from 'vue';
 
-const { text } = defineProps<{
-	text: string;
+const { text, disclaimer } = defineProps<{
+	text?: string;
+	disclaimer?: QuickConnectDisclaimer;
 }>();
+
+const escapeHtml = (value: string) =>
+	value
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;');
+
+const disclaimerHtml = computed(() => {
+	if (!disclaimer) return '';
+	const label = escapeHtml(disclaimer.linkLabel ?? 'here');
+	const url = escapeHtml(disclaimer.linkUrl);
+	const link = `<a href="${url}" target="_blank" rel="noopener noreferrer">${label}</a>`;
+	const parts = disclaimer.text.split('{link}').map(escapeHtml);
+	return parts.join(link);
+});
 </script>
 
 <template>
-	<N8nCallout v-if="text" theme="secondary" iconless data-test-id="quick-connect-banner">
-		<div v-n8n-html="text"></div>
-	</N8nCallout>
+	<div v-if="text || disclaimer" :class="$style.wrapper" data-test-id="quick-connect-banner">
+		<N8nCallout v-if="text" theme="secondary" iconless>
+			<div v-n8n-html="text"></div>
+		</N8nCallout>
+		<p
+			v-if="disclaimer"
+			:class="$style.disclaimer"
+			data-test-id="quick-connect-banner-disclaimer"
+			v-n8n-html="disclaimerHtml"
+		></p>
+	</div>
 </template>
+
+<style lang="scss" module>
+.wrapper {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--2xs);
+}
+
+.disclaimer {
+	margin: 0;
+	font-size: var(--font-size--2xs);
+	font-style: italic;
+	color: var(--text-color--subtler);
+
+	a {
+		color: inherit;
+		text-decoration: underline;
+	}
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
@@ -764,6 +764,7 @@ function handleSelectAction(params: INodeParameters) {
 					<QuickConnectBanner
 						v-if="showQuickConnectBanner"
 						:text="quickConnect?.text ?? ''"
+						:disclaimer="quickConnect?.disclaimer"
 						:class="$style.quickConnectBanner"
 					/>
 					<NodeCredentials

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeInfo.vue
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/components/nodeCreator/CommunityNodeInfo.vue
@@ -175,7 +175,11 @@ onMounted(async () => {
 			</N8nTooltip>
 		</div>
 
-		<QuickConnectBanner v-if="quickConnect" :text="quickConnect?.text" />
+		<QuickConnectBanner
+			v-if="quickConnect"
+			:text="quickConnect?.text"
+			:disclaimer="quickConnect?.disclaimer"
+		/>
 		<ContactAdministratorToInstall v-if="!isAdminOrOwner && !communityNodeDetails?.installed" />
 	</div>
 </template>

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/ActionsMode.vue
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Modes/ActionsMode.vue
@@ -273,7 +273,7 @@ const callouts = computed<INodeCreateElement[]>(() => []);
 
 		<CommunityNodeInfo v-if="communityNodeDetails" />
 		<div :class="$style.banner" v-if="quickConnect">
-			<QuickConnectBanner :text="quickConnect.text" />
+			<QuickConnectBanner :text="quickConnect.text" :disclaimer="quickConnect.disclaimer" />
 		</div>
 		<OrderSwitcher v-if="rootView" :root-view="rootView">
 			<template v-if="shouldShowTriggers" #triggers>


### PR DESCRIPTION
## Summary

Adds an optional `disclaimer` field to Quick Connect options so the disclaimer text and link can be configured per offer via `N8N_QUICK_CONNECT_OPTIONS`. The schema validates that `disclaimer.text` contains a `{link}` placeholder and that `linkUrl` is a valid URL; `linkLabel` defaults to `here`. The frontend renders the disclaimer below the existing callout in `QuickConnectBanner`, and all four call sites (`CredentialConfig`, `NodeSettings`, `CommunityNodeInfo`, `ActionsMode`) forward the new prop. HTML is escaped before being passed through the sanitizing `v-n8n-html` directive.

How to test: configure `N8N_QUICK_CONNECT_OPTIONS` with a `disclaimer` block (e.g. `{ text: "Subject to terms (available {link}).", linkUrl: "https://example.com/terms", linkLabel: "here" }`) and verify the disclaimer renders with a working link in the credential edit view, NDV, community node info, and node creator actions panel.

<img width="1015" height="289" alt="Bildschirmfoto 2026-05-06 um 10 19 39" src="https://github.com/user-attachments/assets/fca244ae-cafa-46b6-b45b-d8c3063ea484" />



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/RLY-38

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI