### PR TITLE
feat(core): Add JSON Schema for .node.json codex files

### DIFF
--- a/packages/workflow/README.md
+++ b/packages/workflow/README.md
@@ -8,6 +8,57 @@ Workflow base code for n8n
 npm install n8n-workflow
 ```
 
+## Codex (`.node.json`) schema
+
+This package owns the canonical zod schema for `.node.json` (codex) files
+(`src/codex-file-schema.ts`). At build time it is compiled to JSON Schema
+artifacts under `schemas/`, which are shipped with the published package
+and can be consumed via jsDelivr for IDE intellisense.
+
+The recommended `$schema` URL for community node authors is the unpinned
+`@latest` form — matching how Renovate, Turborepo and most other projects
+publish their schemas:
+
+```
+https://cdn.jsdelivr.net/npm/n8n-workflow@latest/schemas/community-node-codex-file.schema.json
+```
+
+Authors who want reproducible pinning (so editor behaviour can't shift
+underneath them) can pin to an exact `n8n-workflow` release instead:
+
+```
+https://cdn.jsdelivr.net/npm/n8n-workflow@<exact-version>/schemas/community-node-codex-file.schema.json
+```
+
+The base profile (`schemas/node-codex-file.schema.json`) is intended for
+internal n8n usage; community authors should use the community profile.
+
+To regenerate the artifacts after changing the zod source, run
+`pnpm --filter n8n-workflow generate-schemas` (also runs as part of
+`pnpm --filter n8n-workflow build`). The generator detects drift between
+the committed files and the zod source: it writes the updated content (so
+`git status` shows the change) and exits non-zero, so any build with stale
+schemas fails — both locally and in CI, with no separate verification
+step.
+
+### Semver discipline
+
+Changes to the codex schema are **public API** because community node
+authors reference a `$schema` URL that is served from the published
+`n8n-workflow` package. Treat them as semver events:
+
+- **Patch / minor** — adding a new optional field, broadening an existing
+  constraint, fixing a bug in the regex.
+- **Major (breaking)** — adding a required field, tightening an existing
+  constraint (e.g. narrowing a regex, marking an optional field required,
+  removing a previously accepted field). A breaking change requires a
+  major bump of `n8n-workflow`.
+
+Authors using the recommended `@latest` URL will track schema changes
+automatically and may see new editor warnings after a major bump if their
+files use removed or tightened fields. Authors who pinned to `@<exact>`
+keep their previous validation behaviour until they choose to upgrade.
+
 ## License
 
 You can find the license information [here](https://github.com/n8n-io/n8n/blob/master/README.md#license)

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -23,7 +23,8 @@
     "dev": "pnpm watch",
     "typecheck": "tsc --noEmit",
     "build:vite": "vite build",
-    "build": "tsc --build tsconfig.build.esm.json tsconfig.build.cjs.json",
+    "build": "pnpm generate-schemas && tsc --build tsconfig.build.esm.json tsconfig.build.cjs.json",
+    "generate-schemas": "tsx scripts/generate-codex-schemas.ts",
     "format": "biome format --write .",
     "format:check": "biome ci .",
     "lint": "eslint src --quiet",
@@ -34,7 +35,8 @@
     "test:dev": "vitest --watch"
   },
   "files": [
-    "dist/**/*"
+    "dist/**/*",
+    "schemas/**/*.json"
   ],
   "devDependencies": {
     "@langchain/core": "catalog:",
@@ -47,9 +49,11 @@
     "@types/luxon": "3.2.0",
     "@types/md5": "^2.3.5",
     "@types/xml2js": "catalog:",
+    "tsx": "catalog:",
     "vitest": "catalog:",
     "vitest-mock-extended": "catalog:",
-    "zod": "catalog:"
+    "zod": "catalog:",
+    "zod-to-json-schema": "catalog:"
   },
   "dependencies": {
     "@n8n/errors": "workspace:*",

--- a/packages/workflow/schemas/community-node-codex-file.schema.json
+++ b/packages/workflow/schemas/community-node-codex-file.schema.json
@@ -1,0 +1,86 @@
+{
+	"$ref": "#/definitions/CommunityNodeCodexFile",
+	"definitions": {
+		"CommunityNodeCodexFile": {
+			"type": "object",
+			"properties": {
+				"categories": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"description": "Top-level editor categories this node belongs to (e.g. 'Development', 'Communication')."
+				},
+				"resources": {
+					"type": "object",
+					"properties": {
+						"credentialDocumentation": {
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"url": {
+										"type": "string",
+										"format": "uri",
+										"description": "Absolute URL of the documentation page."
+									}
+								},
+								"required": ["url"],
+								"additionalProperties": false
+							},
+							"description": "Links to credential setup documentation for this node."
+						},
+						"primaryDocumentation": {
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"url": {
+										"type": "string",
+										"format": "uri",
+										"description": "Absolute URL of the documentation page."
+									}
+								},
+								"required": ["url"],
+								"additionalProperties": false
+							},
+							"description": "Links to the node's main documentation."
+						}
+					},
+					"additionalProperties": false,
+					"description": "External resources linked from the node's editor entry."
+				},
+				"alias": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"description": "Search aliases that surface this node when users type related terms (e.g. 'pause' for the Wait node)."
+				},
+				"$schema": {
+					"type": "string",
+					"format": "uri",
+					"description": "URL of the JSON Schema this codex file conforms to. Drives IDE autocompletion and validation; safe to omit."
+				},
+				"node": {
+					"type": "string",
+					"pattern": "^(@[a-z0-9-]+\\/)?[a-z0-9-]+\\.[a-zA-Z][a-zA-Z0-9]*$",
+					"description": "Fully-qualified node identifier of the form `<package-name>.<nodeType>` (e.g. `n8n-nodes-base.httpRequest`, `@n8n/n8n-nodes-langchain.lmChatOpenAi`)."
+				},
+				"nodeVersion": {
+					"type": "string",
+					"description": "Version of the node this codex describes, expressed as a string (e.g. '1.0', '2.1'). Distinct from the package's npm version."
+				},
+				"codexVersion": {
+					"type": "string",
+					"description": "Version of the codex format this file targets (e.g. '1.0'). Bumped only when the codex contract itself changes."
+				}
+			},
+			"required": ["node", "nodeVersion", "codexVersion"],
+			"additionalProperties": false
+		}
+	},
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://cdn.jsdelivr.net/npm/n8n-workflow@latest/schemas/community-node-codex-file.schema.json",
+	"description": "Canonical schema for `.node.json` (codex) files of community nodes. Generated from `communityNodeCodexFileSchema` in `n8n-workflow`."
+}

--- a/packages/workflow/schemas/node-codex-file.schema.json
+++ b/packages/workflow/schemas/node-codex-file.schema.json
@@ -1,0 +1,96 @@
+{
+	"$ref": "#/definitions/NodeCodexFile",
+	"definitions": {
+		"NodeCodexFile": {
+			"type": "object",
+			"properties": {
+				"categories": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"description": "Top-level editor categories this node belongs to (e.g. 'Development', 'Communication')."
+				},
+				"subcategories": {
+					"type": "object",
+					"additionalProperties": {
+						"type": "array",
+						"items": {
+							"type": "string"
+						}
+					},
+					"description": "Subcategories under each category for finer-grained editor placement. Built-in profile only — community nodes should omit this; the runtime ignores it for them."
+				},
+				"resources": {
+					"type": "object",
+					"properties": {
+						"credentialDocumentation": {
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"url": {
+										"type": "string",
+										"format": "uri",
+										"description": "Absolute URL of the documentation page."
+									}
+								},
+								"required": ["url"],
+								"additionalProperties": false
+							},
+							"description": "Links to credential setup documentation for this node."
+						},
+						"primaryDocumentation": {
+							"type": "array",
+							"items": {
+								"type": "object",
+								"properties": {
+									"url": {
+										"type": "string",
+										"format": "uri",
+										"description": "Absolute URL of the documentation page."
+									}
+								},
+								"required": ["url"],
+								"additionalProperties": false
+							},
+							"description": "Links to the node's main documentation."
+						}
+					},
+					"additionalProperties": false,
+					"description": "External resources linked from the node's editor entry."
+				},
+				"alias": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"description": "Search aliases that surface this node when users type related terms (e.g. 'pause' for the Wait node)."
+				},
+				"$schema": {
+					"type": "string",
+					"format": "uri",
+					"description": "URL of the JSON Schema this codex file conforms to. Drives IDE autocompletion and validation; safe to omit."
+				},
+				"node": {
+					"type": "string",
+					"pattern": "^(@[a-z0-9-]+\\/)?[a-z0-9-]+\\.[a-zA-Z][a-zA-Z0-9]*$",
+					"description": "Fully-qualified node identifier of the form `<package-name>.<nodeType>` (e.g. `n8n-nodes-base.httpRequest`, `@n8n/n8n-nodes-langchain.lmChatOpenAi`)."
+				},
+				"nodeVersion": {
+					"type": "string",
+					"description": "Version of the node this codex describes, expressed as a string (e.g. '1.0', '2.1'). Distinct from the package's npm version."
+				},
+				"codexVersion": {
+					"type": "string",
+					"description": "Version of the codex format this file targets (e.g. '1.0'). Bumped only when the codex contract itself changes."
+				}
+			},
+			"required": ["node", "nodeVersion", "codexVersion"],
+			"additionalProperties": false
+		}
+	},
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$id": "https://cdn.jsdelivr.net/npm/n8n-workflow@latest/schemas/node-codex-file.schema.json",
+	"description": "Canonical schema for `.node.json` (codex) files of built-in n8n nodes. Generated from `nodeCodexFileSchema` in `n8n-workflow`."
+}

--- a/packages/workflow/scripts/generate-codex-schemas.ts
+++ b/packages/workflow/scripts/generate-codex-schemas.ts
@@ -1,0 +1,121 @@
+/**
+ * Build-time generator: compiles the canonical zod schemas for `.node.json`
+ * (codex) files into JSON Schema artifacts shipped with the package.
+ *
+ * Outputs:
+ *   schemas/node-codex-file.schema.json
+ *   schemas/community-node-codex-file.schema.json
+ *
+ * Drift enforcement is intrinsic to this script (no separate CI step
+ * required): if regenerating produces output that differs from the
+ * committed file, the new content is written so the contributor sees the
+ * change in `git status`, and the script exits non-zero. The build of
+ * `n8n-workflow` therefore fails whenever the zod source has changed but
+ * the JSON Schema artifacts weren't regenerated and committed.
+ *
+ * To regenerate locally, run `pnpm --filter n8n-workflow generate-schemas`
+ * (or the parent `pnpm --filter n8n-workflow build`), commit the updated
+ * files, and re-run.
+ */
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+import { communityNodeCodexFileSchema, nodeCodexFileSchema } from '../src/codex-file-schema';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const schemasDir = resolve(__dirname, '..', 'schemas');
+
+/**
+ * Base URL used for the generated schemas' `$id` field. Points at the
+ * canonical jsDelivr-served path of the latest published version of
+ * `n8n-workflow`. Authors who need reproducible pinning can reference
+ * the same file under `n8n-workflow@<exact-version>` instead — see
+ * `packages/workflow/README.md`.
+ */
+const SCHEMA_ID_BASE_URL = 'https://cdn.jsdelivr.net/npm/n8n-workflow@latest/schemas';
+
+type Target = {
+	filename: string;
+	name: string;
+	schema: Parameters<typeof zodToJsonSchema>[0];
+	description: string;
+};
+
+const targets: Target[] = [
+	{
+		filename: 'node-codex-file.schema.json',
+		name: 'NodeCodexFile',
+		schema: nodeCodexFileSchema,
+		description:
+			'Canonical schema for `.node.json` (codex) files of built-in n8n nodes. Generated from `nodeCodexFileSchema` in `n8n-workflow`.',
+	},
+	{
+		filename: 'community-node-codex-file.schema.json',
+		name: 'CommunityNodeCodexFile',
+		schema: communityNodeCodexFileSchema,
+		description:
+			'Canonical schema for `.node.json` (codex) files of community nodes. Generated from `communityNodeCodexFileSchema` in `n8n-workflow`.',
+	},
+];
+
+async function main() {
+	await mkdir(schemasDir, { recursive: true });
+
+	const drifted: string[] = [];
+
+	for (const target of targets) {
+		const jsonSchema = zodToJsonSchema(target.schema, {
+			name: target.name,
+			$refStrategy: 'none',
+		}) as Record<string, unknown>;
+
+		jsonSchema.$id = `${SCHEMA_ID_BASE_URL}/${target.filename}`;
+		jsonSchema.description = target.description;
+
+		// Stable, formatted output so the on-disk comparison below is
+		// byte-meaningful across machines.
+		const serialised = JSON.stringify(jsonSchema, null, '\t') + '\n';
+		const outPath = resolve(schemasDir, target.filename);
+
+		const previous = existsSync(outPath) ? await readFile(outPath, 'utf8') : null;
+		if (previous === serialised) continue;
+
+		await writeFile(outPath, serialised, 'utf8');
+
+		if (previous === null) {
+			// First-time generation (e.g. fresh `schemas/` dir) — not drift.
+			// eslint-disable-next-line no-console
+			console.log(`Wrote ${outPath}`);
+		} else {
+			drifted.push(target.filename);
+		}
+	}
+
+	if (drifted.length > 0) {
+		// eslint-disable-next-line no-console
+		console.error(
+			[
+				'',
+				'❌ Codex JSON Schema artifacts are out of date:',
+				...drifted.map((f) => `   - packages/workflow/schemas/${f}`),
+				'',
+				'The files have been regenerated from the zod source in',
+				'`packages/workflow/src/codex-file-schema.ts`. Commit the updated',
+				'schemas and re-run the build.',
+				'',
+			].join('\n'),
+		);
+		process.exit(1);
+	}
+}
+
+void main().catch((error: unknown) => {
+	// eslint-disable-next-line no-console
+	console.error(error);
+	process.exit(1);
+});

--- a/packages/workflow/src/codex-file-schema.ts
+++ b/packages/workflow/src/codex-file-schema.ts
@@ -1,0 +1,145 @@
+/**
+ * Canonical zod schemas for `.node.json` (codex) files.
+ *
+ * Two profiles are exported:
+ *
+ *  - `nodeCodexFileSchema` — base profile, covers the runtime surface of
+ *    built-in n8n nodes. Allows `subcategories` (used by built-in nodes to
+ *    influence editor placement).
+ *  - `communityNodeCodexFileSchema` — derived from the base profile via
+ *    `omit({ subcategories: true })`. The runtime ignores `subcategories` for
+ *    community nodes (the backend overrides it for AI tools, see
+ *    `community-node-types.service.ts:createAiTools`), so writing it gives
+ *    community authors a false sense of control. The community profile makes
+ *    that explicit.
+ *
+ * Both schemas are compiled to JSON Schema artifacts at build time by
+ * `scripts/generate-codex-schemas.ts` and shipped in the published package
+ * under `schemas/`. Community node authors can consume the JSON Schema via
+ * JSDelivr for IDE intellisense (see README for details).
+ *
+ * Schema changes follow semver: adding a required field or tightening an
+ * existing constraint is a breaking change and requires a major bump of
+ * `n8n-workflow`.
+ */
+
+import { z } from 'zod';
+
+/**
+ * Regex enforcing the *shape* of the `node` field: an optional npm scope
+ * followed by a package name, a dot, and a node type identifier.
+ *
+ *   n8n-nodes-base.httpRequest
+ *   @n8n/n8n-nodes-langchain.lmChatOpenAi
+ *   n8n-nodes-acme.myNode
+ *
+ * This is intentionally a shape check only. Cross-package validation
+ * (matching the prefix against the consumer's `package.json` name) lives in
+ * the eslint plugin (slice 2) and the runtime loader (slice 3).
+ */
+export const NODE_FIELD_REGEX = /^(@[a-z0-9-]+\/)?[a-z0-9-]+\.[a-zA-Z][a-zA-Z0-9]*$/;
+
+const documentationLinkSchema = z
+	.object({
+		url: z.string().url().describe('Absolute URL of the documentation page.'),
+	})
+	.strict();
+
+const resourcesSchema = z
+	.object({
+		credentialDocumentation: z
+			.array(documentationLinkSchema)
+			.optional()
+			.describe('Links to credential setup documentation for this node.'),
+		primaryDocumentation: z
+			.array(documentationLinkSchema)
+			.optional()
+			.describe("Links to the node's main documentation."),
+	})
+	.strict()
+	.describe("External resources linked from the node's editor entry.");
+
+/**
+ * Inline body shape shared between built-in and community profiles, and
+ * between the file-level schema and the embedded `codex` property on a
+ * node description.
+ *
+ * `CodexData` is derived from this schema (see {@link CodexData}).
+ */
+export const codexBodySchema = z
+	.object({
+		categories: z
+			.array(z.string())
+			.optional()
+			.describe(
+				"Top-level editor categories this node belongs to (e.g. 'Development', 'Communication').",
+			),
+		subcategories: z
+			.record(z.string(), z.array(z.string()))
+			.optional()
+			.describe(
+				'Subcategories under each category for finer-grained editor placement. Built-in profile only — community nodes should omit this; the runtime ignores it for them.',
+			),
+		resources: resourcesSchema.optional(),
+		alias: z
+			.array(z.string())
+			.optional()
+			.describe(
+				"Search aliases that surface this node when users type related terms (e.g. 'pause' for the Wait node).",
+			),
+	})
+	.strict();
+
+/**
+ * Full `.node.json` file schema for built-in n8n nodes. Extends the body
+ * shape with the required envelope fields (`node`, `nodeVersion`,
+ * `codexVersion`) and an optional `$schema` URL for IDE integration.
+ */
+export const nodeCodexFileSchema = codexBodySchema
+	.extend({
+		$schema: z
+			.string()
+			.url()
+			.optional()
+			.describe(
+				'URL of the JSON Schema this codex file conforms to. Drives IDE autocompletion and validation; safe to omit.',
+			),
+		node: z
+			.string()
+			.regex(NODE_FIELD_REGEX)
+			.describe(
+				'Fully-qualified node identifier of the form `<package-name>.<nodeType>` (e.g. `n8n-nodes-base.httpRequest`, `@n8n/n8n-nodes-langchain.lmChatOpenAi`).',
+			),
+		nodeVersion: z
+			.string()
+			.describe(
+				"Version of the node this codex describes, expressed as a string (e.g. '1.0', '2.1'). Distinct from the package's npm version.",
+			),
+		codexVersion: z
+			.string()
+			.describe(
+				"Version of the codex format this file targets (e.g. '1.0'). Bumped only when the codex contract itself changes.",
+			),
+	})
+	.strict();
+
+/**
+ * `.node.json` schema for community nodes. Identical to the base profile
+ * but without `subcategories` — see module-level docs for the rationale.
+ */
+export const communityNodeCodexFileSchema = nodeCodexFileSchema.omit({
+	subcategories: true,
+});
+
+/**
+ * Inline body of a codex (used for both file-level and embedded usage).
+ * Replaces the previously hand-written `CodexData` type so the schema is
+ * the single source of truth.
+ */
+export type CodexData = z.infer<typeof codexBodySchema>;
+
+/** Full `.node.json` payload for built-in n8n nodes. */
+export type NodeCodexFile = z.infer<typeof nodeCodexFileSchema>;
+
+/** `.node.json` payload for community nodes (no `subcategories`). */
+export type CommunityNodeCodexFile = z.infer<typeof communityNodeCodexFileSchema>;

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -12,6 +12,7 @@ export * from './deferred-promise';
 export * from './execution-context';
 export * from './execution-context-establishment-hooks';
 export * from './global-state';
+export * from './codex-file-schema';
 export * from './interfaces';
 export * from './run-execution-data-factory';
 export * from './message-event-bus';

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -3246,15 +3246,11 @@ export type DocumentationLink = {
 	url: string;
 };
 
-export type CodexData = {
-	categories?: string[];
-	subcategories?: { [category: string]: string[] };
-	resources?: {
-		credentialDocumentation?: DocumentationLink[];
-		primaryDocumentation?: DocumentationLink[];
-	};
-	alias?: string[];
-};
+// `CodexData` is the single source-of-truth schema for `.node.json` (codex)
+// files; see `./codex-file-schema.ts`. The public re-export goes through
+// `./index.ts` (`export * from './codex-file-schema'`), so the symbol is
+// only imported here for local use to avoid duplicate-export errors.
+import type { CodexData } from './codex-file-schema';
 
 export type JsonValue = string | number | boolean | null | JsonObject | JsonValue[];
 

--- a/packages/workflow/test/codex-file-schema.test.ts
+++ b/packages/workflow/test/codex-file-schema.test.ts
@@ -1,0 +1,183 @@
+import {
+	codexBodySchema,
+	communityNodeCodexFileSchema,
+	NODE_FIELD_REGEX,
+	nodeCodexFileSchema,
+} from '../src/codex-file-schema';
+
+describe('codex-file-schema', () => {
+	describe('NODE_FIELD_REGEX', () => {
+		it.each([
+			['n8n-nodes-base.httpRequest'],
+			['n8n-nodes-base.s3'],
+			['n8n-nodes-base.gmailTrigger'],
+			['@n8n/n8n-nodes-langchain.lmChatOpenAi'],
+			['n8n-nodes-acme.myNode'],
+			['n8n-nodes-acme.aB'], // single-char tail after the leading letter
+		])('accepts well-formed node identifier %s', (value) => {
+			expect(NODE_FIELD_REGEX.test(value)).toBe(true);
+		});
+
+		it.each([
+			[''],
+			['NoDot'],
+			['n8n-nodes-base.'], // missing identifier
+			['n8n-nodes-base.1Bad'], // identifier must start with a letter
+			['n8n-nodes-base.Has-Dash'], // dash inside identifier
+			['n8n-nodes-base.has space'],
+			['Bad-Casing.foo'], // package name lowercase only
+			['@Scope/n8n-nodes-foo.bar'], // scope must be lowercase
+			['n8n-nodes-base..foo'], // empty segment
+		])('rejects malformed node identifier %s', (value) => {
+			expect(NODE_FIELD_REGEX.test(value)).toBe(false);
+		});
+	});
+
+	describe('nodeCodexFileSchema', () => {
+		const validBuiltIn = {
+			node: 'n8n-nodes-base.s3',
+			nodeVersion: '1.0',
+			codexVersion: '1.0',
+			categories: ['Development', 'Data & Storage'],
+			resources: {
+				credentialDocumentation: [
+					{ url: 'https://docs.n8n.io/integrations/builtin/credentials/s3/' },
+				],
+				primaryDocumentation: [
+					{
+						url: 'https://docs.n8n.io/integrations/builtin/app-nodes/n8n-nodes-base.s3/',
+					},
+				],
+			},
+		} as const;
+
+		it('accepts a clean built-in `.node.json` payload', () => {
+			expect(nodeCodexFileSchema.safeParse(validBuiltIn).success).toBe(true);
+		});
+
+		it('accepts subcategories on the base profile', () => {
+			const result = nodeCodexFileSchema.safeParse({
+				...validBuiltIn,
+				subcategories: { 'Core Nodes': ['Helpers', 'Flow'] },
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it('accepts an optional `$schema` URL', () => {
+			const result = nodeCodexFileSchema.safeParse({
+				...validBuiltIn,
+				$schema: 'https://cdn.jsdelivr.net/npm/n8n-workflow@2/schemas/node-codex-file.schema.json',
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it.each(['node', 'nodeVersion', 'codexVersion'] as const)(
+			'rejects when required field %s is missing',
+			(missingField) => {
+				const { [missingField]: _omitted, ...partial } = validBuiltIn;
+				const result = nodeCodexFileSchema.safeParse(partial);
+				expect(result.success).toBe(false);
+				if (!result.success) {
+					expect(result.error.issues.some((issue) => issue.path[0] === missingField)).toBe(true);
+				}
+			},
+		);
+
+		it('rejects unknown top-level fields (e.g. `details`)', () => {
+			const result = nodeCodexFileSchema.safeParse({
+				...validBuiltIn,
+				details: 'this field is silently dropped at runtime',
+			});
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues.some((issue) => issue.code === 'unrecognized_keys')).toBe(true);
+			}
+		});
+
+		it('rejects the `aliases` typo (correct field is `alias`)', () => {
+			const result = nodeCodexFileSchema.safeParse({
+				...validBuiltIn,
+				aliases: ['pause', 'sleep'],
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('rejects malformed `node` values that violate the regex', () => {
+			const result = nodeCodexFileSchema.safeParse({
+				...validBuiltIn,
+				node: 'NotAValidPackageName',
+			});
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(result.error.issues.some((issue) => issue.path[0] === 'node')).toBe(true);
+			}
+		});
+
+		it('rejects malformed documentation URLs', () => {
+			const result = nodeCodexFileSchema.safeParse({
+				...validBuiltIn,
+				resources: {
+					primaryDocumentation: [{ url: 'not-a-url' }],
+				},
+			});
+			expect(result.success).toBe(false);
+		});
+
+		it('rejects unknown keys inside `resources` (e.g. `generic`)', () => {
+			const result = nodeCodexFileSchema.safeParse({
+				...validBuiltIn,
+				resources: {
+					primaryDocumentation: [{ url: 'https://example.com/docs' }],
+					generic: [{ url: 'https://example.com/blog' }],
+				},
+			});
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe('communityNodeCodexFileSchema', () => {
+		const validCommunity = {
+			node: 'n8n-nodes-acme.myNode',
+			nodeVersion: '1.0',
+			codexVersion: '1.0',
+			categories: ['Communication'],
+			resources: {
+				primaryDocumentation: [{ url: 'https://example.com/docs' }],
+			},
+			alias: ['acme'],
+		} as const;
+
+		it('accepts a clean community `.node.json` payload', () => {
+			const result = communityNodeCodexFileSchema.safeParse(validCommunity);
+			expect(result.success).toBe(true);
+		});
+
+		it('rejects `subcategories` on the community profile', () => {
+			const result = communityNodeCodexFileSchema.safeParse({
+				...validCommunity,
+				subcategories: { 'Core Nodes': ['Helpers'] },
+			});
+			expect(result.success).toBe(false);
+			if (!result.success) {
+				expect(
+					result.error.issues.some(
+						(issue) =>
+							issue.code === 'unrecognized_keys' &&
+							Array.isArray((issue as { keys?: unknown }).keys) &&
+							(issue as { keys: string[] }).keys.includes('subcategories'),
+					),
+				).toBe(true);
+			}
+		});
+	});
+
+	describe('codexBodySchema', () => {
+		it('accepts an empty body (all fields optional)', () => {
+			expect(codexBodySchema.safeParse({}).success).toBe(true);
+		});
+
+		it('rejects unknown body fields', () => {
+			expect(codexBodySchema.safeParse({ unknown: true }).success).toBe(false);
+		});
+	});
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4696,6 +4696,9 @@ importers:
       '@types/xml2js':
         specifier: 'catalog:'
         version: 0.4.14
+      tsx:
+        specifier: 'catalog:'
+        version: 4.19.3
       vitest:
         specifier: 'catalog:'
         version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(@vitest/browser-playwright@4.0.16)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
@@ -4705,6 +4708,9 @@ importers:
       zod:
         specifier: 3.25.67
         version: 3.25.67
+      zod-to-json-schema:
+        specifier: 'catalog:'
+        version: 3.23.3(zod@3.25.67)
 
 packages:
 


### PR DESCRIPTION
## Summary

Adds the canonical zod schema for `.node.json` (codex) files to `n8n-workflow`, generates JSON Schema artifacts at build time, and ships them with the published package. Foundation slice for the codex-schema effort ([CE-1012](https://linear.app/n8n/issue/CE-1012)); on its own it ships a published schema community node authors can consume via jsDelivr for IDE intellisense.

### What this PR ships

- **`packages/workflow/src/codex-file-schema.ts`** — single source-of-truth zod schemas. Two profiles:
  - `nodeCodexFileSchema` — base profile, allows `subcategories`
  - `communityNodeCodexFileSchema` = `nodeCodexFileSchema.omit({ subcategories: true })`
  - `NODE_FIELD_REGEX` enforcing `[@scope/]package-name.nodeType` shape. Cross-package validation (matching the prefix against the consumer's `package.json` name) lives in the eslint plugin (CE-743) and the runtime loader (CE-1014).
  - All fields carry `.describe()` annotations that propagate to per-property `description` in the JSON Schema for IDE hover help.
- **`CodexData`** is now `z.infer<typeof codexBodySchema>` — the hand-written type was removed; existing `import type { CodexData }` paths continue to resolve.
- **`packages/workflow/scripts/generate-codex-schemas.ts`** — `tsx` build script using `zod-to-json-schema`. Self-verifies by comparing regenerated content to the on-disk file; writes the new content + exits non-zero on drift, so `pnpm build` itself fails when committed schemas are stale. No CI step required, no git dependency.
- **`packages/workflow/schemas/{node,community-node}-codex-file.schema.json`** — generated artifacts. `draft-07`, `additionalProperties: false`, `$id` set to the jsDelivr `@latest` URL. Included in the `files` field so they ship with the npm package.
- **`packages/workflow/README.md`** — distribution guidance (`@latest` URL recommended, `@<exact>` for pinning) and semver discipline (breaking schema changes require a major bump of `n8n-workflow`).
- **30 fixture-based unit tests** covering missing-required, unknown top-level fields (`details`/`aliases` typo), malformed `node` regex, malformed URL, base profile accepts `subcategories`, community profile rejects it, unknown `resources` keys, regex shape acceptance and rejection.

### Decisions documented in the slice

- **JSON Schema draft-07**, the most widely-supported draft in VS Code's JSON LSP and what SchemaStore recommends. zod-to-json-schema doesn't support 2020-12 yet; Biome is the only major project on 2020-12 in the comparison set we surveyed.
- **`additionalProperties: false`** pervasively, via zod `.strict()`. Catches typos like `categores`/`details`/`aliases` from day one — these are the actual bugs in the existing built-in `.node.json` files this effort is unblocking.
- **jsDelivr distribution** with `@latest` recommended URL — zero-infra, tracks npm releases. Other projects use their own domain (Biome, Renovate, Turborepo) or SchemaStore (tsconfig, package.json, eslint); jsDelivr is a pragmatic interim, and the `$id` field can be updated in a future major if hosting moves.
- **Inline refs** (no `$defs`) for flatter editor error messages.
- Schema changes are public API and follow semver — breaking schema changes require a major bump of `n8n-workflow`.

### How to test

```bash
pnpm --filter n8n-workflow build       # regenerates + drift-checks + compiles
pnpm --filter n8n-workflow test        # runs all tests including the 30 new ones
pnpm --filter n8n-workflow lint
pnpm --filter n8n-workflow typecheck
cd packages/workflow && npm pack --dry-run  # confirms schemas/*.json ship in the tarball
```

**Drift detection**: edit a field in `packages/workflow/src/codex-file-schema.ts` and run `pnpm --filter n8n-workflow generate-schemas`. The generator updates `schemas/*.json` and exits non-zero. Re-run after committing → exits zero. `pnpm build` behaves the same way.

### Out of scope (covered by sibling slices)

- Eslint rule changes — [CE-743](https://linear.app/n8n/issue/CE-743)
- Runtime validation in `directory-loader.ts`, cleanup of `details`/`aliases` in built-in files, workspace `.vscode/settings.json` — [CE-1014](https://linear.app/n8n/issue/CE-1014)
- `@n8n/node-cli` template `$schema` integration — [CE-1015](https://linear.app/n8n/issue/CE-1015)
- SchemaStore registration — [CE-1016](https://linear.app/n8n/issue/CE-1016)

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/CE-1013
- Parent: https://linear.app/n8n/issue/CE-1012

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI