### PR TITLE
fix(ai-builder): Improve filesystem read handling (no-changelog)

### DIFF
--- a/packages/@n8n/computer-use/src/config.test.ts
+++ b/packages/@n8n/computer-use/src/config.test.ts
@@ -41,6 +41,21 @@ describe('isProtectedSettingsPath', () => {
 	it('catches paths with trailing slash', () => {
 		expect(isProtectedSettingsPath(settingsDir + '/')).toBe(true);
 	});
+
+	it('matches case variants on case-insensitive platforms', () => {
+		const originalPlatform = process.platform;
+		Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true });
+		try {
+			const caseMismatched = path.join(
+				settingsDir.replace('.n8n-gateway', '.N8N-Gateway'),
+				'settings.json',
+			);
+
+			expect(isProtectedSettingsPath(caseMismatched)).toBe(true);
+		} finally {
+			Object.defineProperty(process, 'platform', { value: originalPlatform, configurable: true });
+		}
+	});
 });
 
 describe('parseConfig — allowedOrigins', () => {

--- a/packages/@n8n/computer-use/src/config.ts
+++ b/packages/@n8n/computer-use/src/config.ts
@@ -257,8 +257,12 @@ export function getSettingsDir(): string {
  * Used to prevent computer-use tools from modifying their own configuration.
  */
 export function isProtectedSettingsPath(absolutePath: string): boolean {
-	const dir = path.resolve(getSettingsDir());
-	const target = path.resolve(absolutePath);
+	let dir = path.resolve(getSettingsDir());
+	let target = path.resolve(absolutePath);
+	if (process.platform === 'darwin' || process.platform === 'win32') {
+		dir = dir.toLowerCase();
+		target = target.toLowerCase();
+	}
 	return target === dir || target.startsWith(dir + path.sep);
 }
 

--- a/packages/@n8n/computer-use/src/tools/filesystem/copy-file.test.ts
+++ b/packages/@n8n/computer-use/src/tools/filesystem/copy-file.test.ts
@@ -108,6 +108,15 @@ describe('copyFileTool', () => {
 			).rejects.toThrow('escapes');
 		});
 
+		it('rejects excluded directories on source', async () => {
+			await expect(
+				copyFileTool.execute(
+					{ sourcePath: 'node_modules/pkg/index.js', destinationPath: 'dst.txt' },
+					CONTEXT,
+				),
+			).rejects.toThrow('excluded');
+		});
+
 		it('rejects path traversal on destination', async () => {
 			mockMkdir();
 

--- a/packages/@n8n/computer-use/src/tools/filesystem/copy-file.ts
+++ b/packages/@n8n/computer-use/src/tools/filesystem/copy-file.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 import type { ToolDefinition } from '../types';
 import { formatCallToolResult } from '../utils';
-import { buildFilesystemResource, resolveSafePath } from './fs-utils';
+import { buildFilesystemResource, resolveReadablePath, resolveSafePath } from './fs-utils';
 
 const inputSchema = z.object({
 	sourcePath: z.string().describe('Source file path relative to root'),
@@ -34,7 +34,7 @@ export const copyFileTool: ToolDefinition<typeof inputSchema> = {
 		];
 	},
 	async execute({ sourcePath, destinationPath }, { dir }) {
-		const resolvedSrc = await resolveSafePath(dir, sourcePath);
+		const resolvedSrc = await resolveReadablePath(dir, sourcePath);
 		const resolvedDest = await resolveSafePath(dir, destinationPath);
 
 		await fs.mkdir(path.dirname(resolvedDest), { recursive: true });

--- a/packages/@n8n/computer-use/src/tools/filesystem/edit-file.test.ts
+++ b/packages/@n8n/computer-use/src/tools/filesystem/edit-file.test.ts
@@ -79,6 +79,41 @@ describe('editFileTool', () => {
 		});
 	});
 
+	describe('getAffectedResources', () => {
+		it('declares both read and write access for the edited file', async () => {
+			const resources = await editFileTool.getAffectedResources(
+				{ filePath: 'src/index.ts', oldString: 'foo', newString: 'bar' },
+				CONTEXT,
+			);
+
+			expect(resources).toEqual([
+				{
+					toolGroup: 'filesystemRead',
+					resource: '/base/src/index.ts',
+					description: 'Read file: src/index.ts',
+				},
+				{
+					toolGroup: 'filesystemWrite',
+					resource: '/base/src/index.ts',
+					description: 'Edit file: src/index.ts',
+				},
+			]);
+		});
+
+		it('rejects excluded paths for the read phase', async () => {
+			await expect(
+				editFileTool.getAffectedResources(
+					{
+						filePath: 'node_modules/pkg/index.js',
+						oldString: 'foo',
+						newString: 'bar',
+					},
+					CONTEXT,
+				),
+			).rejects.toThrow('excluded from filesystem reads');
+		});
+	});
+
 	describe('execute', () => {
 		it('replaces the first occurrence of oldString with newString', async () => {
 			mockStat(100);
@@ -157,6 +192,20 @@ describe('editFileTool', () => {
 					CONTEXT,
 				),
 			).rejects.toThrow('escapes');
+		});
+
+		it.each([
+			'node_modules/pkg/index.js',
+			'Node_Modules/pkg/index.js',
+			'.git/config',
+			'dist/out.js',
+		])('rejects edit reads under excluded directory %s', async (filePath) => {
+			await expect(
+				editFileTool.execute({ filePath, oldString: 'foo', newString: 'bar' }, CONTEXT),
+			).rejects.toThrow('excluded from filesystem reads');
+			expect(fs.stat).not.toHaveBeenCalled();
+			expect(fs.readFile).not.toHaveBeenCalled();
+			expect(fs.writeFile).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/@n8n/computer-use/src/tools/filesystem/edit-file.ts
+++ b/packages/@n8n/computer-use/src/tools/filesystem/edit-file.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 import type { ToolDefinition } from '../types';
 import { formatCallToolResult } from '../utils';
 import { MAX_FILE_SIZE } from './constants';
-import { buildFilesystemResource, resolveSafePath } from './fs-utils';
+import { buildFilesystemResource, resolveReadablePath, resolveSafePath } from './fs-utils';
 
 const inputSchema = z.object({
 	filePath: z.string().describe('File path relative to root'),
@@ -20,26 +20,28 @@ export const editFileTool: ToolDefinition<typeof inputSchema> = {
 	annotations: {},
 	async getAffectedResources({ filePath }, { dir }) {
 		return [
+			await buildFilesystemResource(dir, filePath, 'filesystemRead', `Read file: ${filePath}`),
 			await buildFilesystemResource(dir, filePath, 'filesystemWrite', `Edit file: ${filePath}`),
 		];
 	},
 	async execute({ filePath, oldString, newString }, { dir }) {
-		const resolvedPath = await resolveSafePath(dir, filePath);
+		const resolvedReadablePath = await resolveReadablePath(dir, filePath);
+		const resolvedWritablePath = await resolveSafePath(dir, filePath);
 
-		const stat = await fs.stat(resolvedPath);
+		const stat = await fs.stat(resolvedReadablePath);
 		if (stat.size > MAX_FILE_SIZE) {
 			throw new Error(
 				`File too large: ${stat.size} bytes (max ${MAX_FILE_SIZE} bytes). Use write_file to replace the entire content.`,
 			);
 		}
 
-		const content = await fs.readFile(resolvedPath, 'utf-8');
+		const content = await fs.readFile(resolvedReadablePath, 'utf-8');
 
 		if (!content.includes(oldString)) {
 			throw new Error(`oldString not found in file: ${filePath}`);
 		}
 
-		await fs.writeFile(resolvedPath, content.replace(oldString, newString), 'utf-8');
+		await fs.writeFile(resolvedWritablePath, content.replace(oldString, newString), 'utf-8');
 
 		return formatCallToolResult({ path: filePath });
 	},

--- a/packages/@n8n/computer-use/src/tools/filesystem/fs-utils.test.ts
+++ b/packages/@n8n/computer-use/src/tools/filesystem/fs-utils.test.ts
@@ -1,7 +1,12 @@
 import type { Stats } from 'node:fs';
 import * as fs from 'node:fs/promises';
 
-import { buildFilesystemResource, resolveSafePath } from './fs-utils';
+import {
+	buildFilesystemResource,
+	isLikelyBinaryContent,
+	resolveReadablePath,
+	resolveSafePath,
+} from './fs-utils';
 import * as config from '../../config';
 
 jest.mock('node:fs/promises');
@@ -153,6 +158,38 @@ describe('resolveSafePath', () => {
 	});
 });
 
+describe('isLikelyBinaryContent', () => {
+	it('treats text as valid when a multibyte character crosses the sample boundary', () => {
+		const buffer = Buffer.concat([Buffer.alloc(8191, 'a'), Buffer.from('é')]);
+
+		expect(isLikelyBinaryContent(buffer)).toBe(false);
+	});
+
+	it('detects null bytes outside the sample boundary', () => {
+		const buffer = Buffer.concat([Buffer.alloc(8192, 'a'), Buffer.from([0])]);
+
+		expect(isLikelyBinaryContent(buffer)).toBe(true);
+	});
+});
+
+describe('resolveReadablePath', () => {
+	beforeEach(() => {
+		jest.resetAllMocks();
+		jest.mocked(fs.lstat).mockRejectedValue(enoent());
+	});
+
+	it('throws when a symlink resolves into an excluded directory segment', async () => {
+		mockRealpath([
+			[BASE, BASE],
+			[`${BASE}/link`, `${BASE}/node_modules`],
+		]);
+
+		await expect(resolveReadablePath(BASE, 'link/pkg/index.js')).rejects.toThrow(
+			'excluded from filesystem reads',
+		);
+	});
+});
+
 describe('buildFilesystemResource — settings self-protection', () => {
 	const settingsDir = config.getSettingsDir();
 	const settingsFile = config.getSettingsFilePath();
@@ -195,5 +232,45 @@ describe('buildFilesystemResource — settings self-protection', () => {
 			'Write file',
 		);
 		expect(result.resource).toBe('/base/src/index.ts');
+	});
+
+	it('throws for filesystemRead targeting an excluded directory segment', async () => {
+		mockRealpath([[BASE, BASE]]);
+
+		await expect(
+			buildFilesystemResource(BASE, 'node_modules/pkg/index.js', 'filesystemRead', 'Read file'),
+		).rejects.toThrow('excluded from filesystem reads');
+	});
+
+	it('throws for filesystemRead when a symlink targets an excluded directory segment', async () => {
+		mockRealpath([
+			[BASE, BASE],
+			[`${BASE}/link`, `${BASE}/node_modules`],
+		]);
+
+		await expect(
+			buildFilesystemResource(BASE, 'link/pkg/index.js', 'filesystemRead', 'Read file'),
+		).rejects.toThrow('excluded from filesystem reads');
+	});
+
+	it('matches excluded directory segments case-insensitively', async () => {
+		mockRealpath([[BASE, BASE]]);
+
+		await expect(
+			buildFilesystemResource(BASE, 'Node_Modules/pkg/index.js', 'filesystemRead', 'Read file'),
+		).rejects.toThrow('excluded from filesystem reads');
+	});
+
+	it('does not apply excluded segment policy to filesystemWrite resources', async () => {
+		mockRealpath([[BASE, BASE]]);
+
+		const result = await buildFilesystemResource(
+			BASE,
+			'dist/generated.js',
+			'filesystemWrite',
+			'Write generated file',
+		);
+
+		expect(result.resource).toBe('/base/dist/generated.js');
 	});
 });

--- a/packages/@n8n/computer-use/src/tools/filesystem/fs-utils.ts
+++ b/packages/@n8n/computer-use/src/tools/filesystem/fs-utils.ts
@@ -1,11 +1,15 @@
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
+import { TextDecoder } from 'node:util';
 
 import { isProtectedSettingsPath } from '../../config';
 import type { AffectedResource } from '../types';
 
 const MAX_ENTRIES = 10_000;
 const DEFAULT_MAX_DEPTH = 8;
+const BINARY_CHECK_SIZE = 8192;
+const MAX_CONTROL_CHAR_RATIO = 0.3;
+const utf8Decoder = new TextDecoder('utf-8', { fatal: true });
 
 export const EXCLUDED_DIRS = new Set([
 	'node_modules',
@@ -25,6 +29,9 @@ export const EXCLUDED_DIRS = new Set([
 	'.output',
 	'.svelte-kit',
 ]);
+const NORMALIZED_EXCLUDED_DIRS = new Set(
+	[...EXCLUDED_DIRS].map((segment) => segment.toLowerCase()),
+);
 
 export interface TreeEntry {
 	path: string;
@@ -82,7 +89,7 @@ export async function scanDirectory(
 				break;
 			}
 
-			if (EXCLUDED_DIRS.has(entry.name) && entry.isDirectory()) continue;
+			if (isExcludedDirName(entry.name) && entry.isDirectory()) continue;
 			if (entry.name.startsWith('.') && !isAllowedDotFile(entry.name)) continue;
 
 			const entryRelPath = relativePath ? `${relativePath}/${entry.name}` : entry.name;
@@ -131,6 +138,47 @@ function isAllowedDotFile(name: string): boolean {
 	return allowed.has(name);
 }
 
+export function assertNoExcludedSegments(absolutePath: string, basePath: string): void {
+	const relativePath = path.relative(path.resolve(basePath), path.resolve(absolutePath));
+	const segments = relativePath.split(path.sep).filter(Boolean);
+	const excludedSegment = segments.find(isExcludedDirName);
+	if (excludedSegment) {
+		throw new Error(`Access denied: "${excludedSegment}" is excluded from filesystem reads`);
+	}
+}
+
+export function isExcludedDirName(segment: string): boolean {
+	return NORMALIZED_EXCLUDED_DIRS.has(segment.toLowerCase());
+}
+
+export function isLikelyBinaryContent(buffer: Buffer): boolean {
+	if (buffer.length === 0) return false;
+	if (buffer.includes(0)) return true;
+
+	try {
+		utf8Decoder.decode(buffer);
+	} catch {
+		return true;
+	}
+
+	const checkSlice = buffer.subarray(0, Math.min(BINARY_CHECK_SIZE, buffer.length));
+	let controlChars = 0;
+	for (const byte of checkSlice) {
+		const isAllowedControl = byte === 9 || byte === 10 || byte === 12 || byte === 13;
+		if (byte < 32 && !isAllowedControl) {
+			controlChars++;
+		}
+	}
+
+	return controlChars / checkSlice.length > MAX_CONTROL_CHAR_RATIO;
+}
+
+interface ResolvedSafePath {
+	absolutePath: string;
+	realBasePath: string;
+	resolvedPath: string;
+}
+
 /**
  * Resolve a path safely within the base directory.
  *
@@ -150,7 +198,10 @@ function isAllowedDotFile(name: string): boolean {
  * Returns the logical absolute path (without resolving symlinks), so the
  * caller never needs to know that a symlink is involved.
  */
-export async function resolveSafePath(basePath: string, relativePath: string): Promise<string> {
+async function resolveSafePathDetails(
+	basePath: string,
+	relativePath: string,
+): Promise<ResolvedSafePath> {
 	const realBase = await fs.realpath(basePath);
 	const absolute = path.resolve(basePath, relativePath);
 
@@ -199,7 +250,22 @@ export async function resolveSafePath(basePath: string, relativePath: string): P
 		throw new Error(`Access denied: cannot access "${relativePath}"`);
 	}
 
-	return absolute;
+	return { absolutePath: absolute, realBasePath: realBase, resolvedPath: current };
+}
+
+export async function resolveSafePath(basePath: string, relativePath: string): Promise<string> {
+	const { absolutePath } = await resolveSafePathDetails(basePath, relativePath);
+	return absolutePath;
+}
+
+export async function resolveReadablePath(basePath: string, relativePath: string): Promise<string> {
+	const { absolutePath, realBasePath, resolvedPath } = await resolveSafePathDetails(
+		basePath,
+		relativePath,
+	);
+	assertNoExcludedSegments(absolutePath, basePath);
+	assertNoExcludedSegments(resolvedPath, realBasePath);
+	return absolutePath;
 }
 
 /**
@@ -213,7 +279,10 @@ export async function buildFilesystemResource(
 	toolGroup: 'filesystemRead' | 'filesystemWrite',
 	description: string,
 ): Promise<AffectedResource> {
-	const absolutePath = await resolveSafePath(dir, inputPath);
+	const absolutePath =
+		toolGroup === 'filesystemRead'
+			? await resolveReadablePath(dir, inputPath)
+			: await resolveSafePath(dir, inputPath);
 
 	return { toolGroup, resource: absolutePath, description };
 }

--- a/packages/@n8n/computer-use/src/tools/filesystem/get-file-tree.ts
+++ b/packages/@n8n/computer-use/src/tools/filesystem/get-file-tree.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 
 import type { ToolDefinition } from '../types';
-import { buildFilesystemResource, resolveSafePath, scanDirectory } from './fs-utils';
+import { buildFilesystemResource, resolveReadablePath, scanDirectory } from './fs-utils';
 
 const inputSchema = z.object({
 	dirPath: z.string().describe('Directory path relative to root (use "." for root)'),
@@ -24,7 +24,7 @@ export const getFileTreeTool: ToolDefinition<typeof inputSchema> = {
 		];
 	},
 	async execute({ dirPath, maxDepth }, { dir }) {
-		const resolvedDir = await resolveSafePath(dir, dirPath || '.');
+		const resolvedDir = await resolveReadablePath(dir, dirPath || '.');
 		const depth = maxDepth ?? 2;
 		const { rootPath, tree, truncated } = await scanDirectory(resolvedDir, depth);
 

--- a/packages/@n8n/computer-use/src/tools/filesystem/list-files.ts
+++ b/packages/@n8n/computer-use/src/tools/filesystem/list-files.ts
@@ -2,7 +2,7 @@ import * as path from 'node:path';
 import { z } from 'zod';
 
 import type { ToolDefinition } from '../types';
-import { buildFilesystemResource, resolveSafePath, scanDirectory } from './fs-utils';
+import { buildFilesystemResource, resolveReadablePath, scanDirectory } from './fs-utils';
 
 const inputSchema = z.object({
 	dirPath: z.string().describe('Directory path relative to root'),
@@ -29,7 +29,7 @@ export const listFilesTool: ToolDefinition<typeof inputSchema> = {
 		];
 	},
 	async execute({ dirPath, type, maxResults }, { dir }) {
-		const resolvedDir = await resolveSafePath(dir, dirPath || '.');
+		const resolvedDir = await resolveReadablePath(dir, dirPath || '.');
 		// maxDepth=0 → immediate children only, no recursion
 		const { tree } = await scanDirectory(resolvedDir, 0);
 

--- a/packages/@n8n/computer-use/src/tools/filesystem/move.test.ts
+++ b/packages/@n8n/computer-use/src/tools/filesystem/move.test.ts
@@ -119,6 +119,15 @@ describe('moveFileTool', () => {
 			).rejects.toThrow('escapes');
 		});
 
+		it('rejects excluded directories on source', async () => {
+			await expect(
+				moveFileTool.execute(
+					{ sourcePath: 'node_modules/pkg/index.js', destinationPath: 'dest.txt' },
+					CONTEXT,
+				),
+			).rejects.toThrow('excluded');
+		});
+
 		it('rejects path traversal on destination', async () => {
 			mockMkdir();
 

--- a/packages/@n8n/computer-use/src/tools/filesystem/move.ts
+++ b/packages/@n8n/computer-use/src/tools/filesystem/move.ts
@@ -4,7 +4,7 @@ import { z } from 'zod';
 
 import type { ToolDefinition } from '../types';
 import { formatCallToolResult } from '../utils';
-import { buildFilesystemResource, resolveSafePath } from './fs-utils';
+import { buildFilesystemResource, resolveReadablePath, resolveSafePath } from './fs-utils';
 
 const inputSchema = z.object({
 	sourcePath: z.string().describe('Source path relative to root (file or directory)'),
@@ -34,7 +34,7 @@ export const moveFileTool: ToolDefinition<typeof inputSchema> = {
 		];
 	},
 	async execute({ sourcePath, destinationPath }, { dir }) {
-		const resolvedSrc = await resolveSafePath(dir, sourcePath);
+		const resolvedSrc = await resolveReadablePath(dir, sourcePath);
 		const resolvedDest = await resolveSafePath(dir, destinationPath);
 
 		await fs.mkdir(path.dirname(resolvedDest), { recursive: true });

--- a/packages/@n8n/computer-use/src/tools/filesystem/read-file.test.ts
+++ b/packages/@n8n/computer-use/src/tools/filesystem/read-file.test.ts
@@ -139,6 +139,15 @@ describe('readFileTool', () => {
 			);
 		});
 
+		it('rejects binary files without null bytes', async () => {
+			mockStat(100);
+			mockReadFile(Buffer.from([0xff, 0xfe, 0xfd, 0xfc]));
+
+			await expect(readFileTool.execute({ filePath: 'binary.dat' }, CONTEXT)).rejects.toThrow(
+				'Binary file',
+			);
+		});
+
 		it('rejects files larger than 512KB', async () => {
 			mockStat(600 * 1024);
 
@@ -152,6 +161,15 @@ describe('readFileTool', () => {
 				readFileTool.execute({ filePath: '../../../etc/passwd' }, CONTEXT),
 			).rejects.toThrow('escapes');
 		});
+
+		it.each(['node_modules/foo/.env', 'Node_Modules/foo/.env', '.git/config', 'dist/bundle.js'])(
+			'rejects direct reads under excluded directory %s',
+			async (filePath) => {
+				await expect(readFileTool.execute({ filePath }, CONTEXT)).rejects.toThrow(
+					'excluded from filesystem reads',
+				);
+			},
+		);
 
 		it.each([
 			{ startLine: undefined, maxLines: undefined },

--- a/packages/@n8n/computer-use/src/tools/filesystem/read-file.ts
+++ b/packages/@n8n/computer-use/src/tools/filesystem/read-file.ts
@@ -4,9 +4,8 @@ import { z } from 'zod';
 import type { ToolDefinition } from '../types';
 import { formatCallToolResult } from '../utils';
 import { MAX_FILE_SIZE } from './constants';
-import { buildFilesystemResource, resolveSafePath } from './fs-utils';
+import { buildFilesystemResource, isLikelyBinaryContent, resolveReadablePath } from './fs-utils';
 const DEFAULT_MAX_LINES = 200;
-const BINARY_CHECK_SIZE = 8192;
 
 const inputSchema = z.object({
 	filePath: z.string().describe('File path relative to root'),
@@ -25,7 +24,7 @@ export const readFileTool: ToolDefinition<typeof inputSchema> = {
 		];
 	},
 	async execute({ filePath, startLine, maxLines }, { dir }) {
-		const resolvedPath = await resolveSafePath(dir, filePath);
+		const resolvedPath = await resolveReadablePath(dir, filePath);
 
 		const stat = await fs.stat(resolvedPath);
 		if (stat.size > MAX_FILE_SIZE) {
@@ -34,11 +33,10 @@ export const readFileTool: ToolDefinition<typeof inputSchema> = {
 			);
 		}
 
-		const buffer = await fs.readFile(resolvedPath);
+		const fileContent = await fs.readFile(resolvedPath);
+		const buffer = Buffer.isBuffer(fileContent) ? fileContent : Buffer.from(fileContent);
 
-		// Binary detection: check first 8KB for null bytes
-		const checkSlice = buffer.subarray(0, Math.min(BINARY_CHECK_SIZE, buffer.length));
-		if (checkSlice.includes(0)) {
+		if (isLikelyBinaryContent(buffer)) {
 			throw new Error('Binary file detected — cannot read binary files');
 		}
 

--- a/packages/@n8n/computer-use/src/tools/filesystem/search-files.test.ts
+++ b/packages/@n8n/computer-use/src/tools/filesystem/search-files.test.ts
@@ -212,6 +212,31 @@ describe('searchFilesTool', () => {
 			).rejects.toThrow('escapes');
 		});
 
+		it.each(['node_modules', 'Node_Modules', '.git', 'dist'])(
+			'rejects direct search roots under excluded directory %s',
+			async (dirPath) => {
+				await expect(searchFilesTool.execute({ dirPath, query: 'foo' }, CONTEXT)).rejects.toThrow(
+					'excluded from filesystem reads',
+				);
+			},
+		);
+
+		it('skips likely binary files', async () => {
+			(fs.readdir as jest.Mock).mockResolvedValue([dirent('binary.dat', false)]);
+			mockStat();
+			(fs.readFile as jest.Mock).mockResolvedValue(Buffer.from([0xff, 0xfe, 0xfd, 0xfc]));
+
+			const result = await searchFilesTool.execute({ dirPath: '.', query: 'foo' }, CONTEXT);
+			// eslint-disable-next-line n8n-local-rules/no-uncaught-json-parse
+			const data = JSON.parse(textOf(result)) as {
+				matches: unknown[];
+				totalMatches: number;
+			};
+
+			expect(data.matches).toHaveLength(0);
+			expect(data.totalMatches).toBe(0);
+		});
+
 		it.each([
 			{ query: 'foo', ignoreCase: undefined, label: 'case-sensitive' },
 			{ query: 'foo', ignoreCase: true, label: 'case-insensitive' },

--- a/packages/@n8n/computer-use/src/tools/filesystem/search-files.ts
+++ b/packages/@n8n/computer-use/src/tools/filesystem/search-files.ts
@@ -5,7 +5,12 @@ import { z } from 'zod';
 import type { ToolDefinition } from '../types';
 import { formatCallToolResult } from '../utils';
 import { MAX_FILE_SIZE } from './constants';
-import { EXCLUDED_DIRS, buildFilesystemResource, resolveSafePath } from './fs-utils';
+import {
+	buildFilesystemResource,
+	isExcludedDirName,
+	isLikelyBinaryContent,
+	resolveReadablePath,
+} from './fs-utils';
 
 const inputSchema = z.object({
 	dirPath: z.string().describe('Directory to search in'),
@@ -26,7 +31,7 @@ export const searchFilesTool: ToolDefinition<typeof inputSchema> = {
 		];
 	},
 	async execute({ dirPath, query, filePattern, ignoreCase, maxResults }, { dir }) {
-		const resolvedDir = await resolveSafePath(dir, dirPath);
+		const resolvedDir = await resolveReadablePath(dir, dirPath);
 		const limit = maxResults ?? 50;
 		const flags = ignoreCase ? 'gi' : 'g';
 		const regex = new RegExp(escapeRegex(query), flags);
@@ -44,7 +49,10 @@ export const searchFilesTool: ToolDefinition<typeof inputSchema> = {
 				const stat = await fs.stat(fullPath);
 				if (stat.size > MAX_FILE_SIZE) continue;
 
-				const content = await fs.readFile(fullPath, 'utf-8');
+				const fileContent = await fs.readFile(fullPath);
+				const buffer = Buffer.isBuffer(fileContent) ? fileContent : Buffer.from(fileContent);
+				if (isLikelyBinaryContent(buffer)) continue;
+				const content = buffer.toString('utf-8');
 				const lines = content.split('\n');
 
 				for (let i = 0; i < lines.length; i++) {
@@ -77,7 +85,7 @@ async function collectFiles(
 	const entries = await fs.readdir(dir, { withFileTypes: true });
 
 	for (const entry of entries) {
-		if (EXCLUDED_DIRS.has(entry.name) && entry.isDirectory()) continue;
+		if (isExcludedDirName(entry.name) && entry.isDirectory()) continue;
 
 		const fullPath = path.join(dir, entry.name);
 		const relativePath = path.relative(basePath, fullPath);


### PR DESCRIPTION
## Summary


- Enforces excluded filesystem segments consistently across read, search, list, copy, and move operations.
- Normalizes excluded paths for case-insensitive matching.
- Improves text and binary detection before read/search operations.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-193

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.