### PR TITLE
fix(editor): Suppress all toasts in Instance AI workflow preview iframe (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowPreview.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowPreview.test.ts
@@ -83,7 +83,7 @@ describe('InstanceAiWorkflowPreview', () => {
 		});
 	});
 
-	it('should allow error notifications for executable preview', async () => {
+	it('should suppress all notifications including errors for executable preview', async () => {
 		mockFetchWorkflow.mockResolvedValue(fakeWorkflow);
 
 		const { getByTestId } = renderComponent({
@@ -94,7 +94,7 @@ describe('InstanceAiWorkflowPreview', () => {
 			const preview = getByTestId('workflow-preview');
 			expect(preview).toHaveAttribute('data-can-execute', 'true');
 			expect(preview).toHaveAttribute('data-suppress-notifications', 'true');
-			expect(preview).toHaveAttribute('data-allow-error-notifications', 'true');
+			expect(preview).toHaveAttribute('data-allow-error-notifications', 'false');
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowPreview.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowPreview.vue
@@ -129,7 +129,7 @@ defineExpose({ relayPushEvent });
 			:can-execute="true"
 			:hide-controls="false"
 			:suppress-notifications="true"
-			:allow-error-notifications="true"
+			:allow-error-notifications="false"
 			loader-type="spinner"
 		/>
 


### PR DESCRIPTION
## Summary

The Instance AI builder embeds an iframe to preview workflows. Toasts surfaced from inside this preview — most notably execution error toasts from AI-driven test runs — are confusing because the user didn't trigger the action and the AI surfaces failures in its own UI.

This PR sets `allow-error-notifications` to `false` on the embedded `<WorkflowPreview>`. Combined with the existing `:suppress-notifications="true"`, the iframe-side `useToast` gate (`if (suppressed && !(allowErrors && type === 'error')) return`) now mutes every toast type — success, info, warning, and error.

This is a smaller replacement for #29709, which tracked AI-initiated execution IDs and gated two specific toast paths.

### Test plan

- Open the Instance AI builder, ask the AI to build/test a workflow that fails (e.g. missing credential). No error toast appears in the preview.
- Trigger another action that would normally toast inside the preview (e.g. iframe-side workflow save error). No toast appears.
- Toasts in the rest of the editor (outside the AI preview) still work normally.

## Related Linear tickets, Github issues, and Community forum posts

- closes https://linear.app/n8n/issue/INS-195
- closes #29709 (this PR replaces that approach)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created — N/A (internal behavior change).
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)