### PR TITLE
ci: Exclude @n8n packages from SafeChain minimum package age check (no-changelog)

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -60,6 +60,7 @@ runs:
       if: ${{ inputs.install-command != '' }}
       env:
         INSTALL_COMMAND: ${{ inputs.install-command }}
+        SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS: '@n8n/*'
       run: |
         $INSTALL_COMMAND
       shell: bash


### PR DESCRIPTION
## Summary

Adds `SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS: '@n8n/*'` to the CI install step so that newly-published `@n8n/*` scoped packages (e.g. `@n8n/sandbox-client`) are not blocked by SafeChain's minimum package age filter.

The package age check was conflicting with pnpm's own check, causing `ERR_PNPM_FETCH_403` errors when installing recently-published n8n packages.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.