### PR TITLE
chore: Clean up min release age exclude list (no-changelog)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -154,33 +154,5 @@ catalogs:
 minimumReleaseAge: 4320
 
 minimumReleaseAgeExclude:
-  - '@isaacs/brace-expansion'
   - '@n8n/*'
   - '@n8n_io/*'
-  - tsdown@0.16.5
-  - eslint-plugin-storybook
-  - eslint-plugin-n8n-nodes-base
-  - '@langchain/*'
-  - langchain
-  - '@anthropic-ai/sdk'
-  - '@google/generative-ai'
-  - '@google/genai'
-  - body-parser
-  - node-forge
-  - vm2
-  - tar
-  - qs
-  - ajv
-  - bn.js
-  - fast-xml-parser
-  - '@hono/node-server'
-  - express-rate-limit
-  - hono
-  - minimatch
-  - multer
-  - simple-git
-  - underscore
-  - protobufjs
-  - follow-redirects
-  # Renovate security update: zod@3.25.76
-  - zod@3.25.76


### PR DESCRIPTION
## Summary

Remove stale entries from the `minimumReleaseAgeExclude` list in `pnpm-workspace.yaml`. These packages no longer need to bypass the minimum release age check — only `@n8n/*` and `@n8n_io/*` scoped packages are kept as standing exclusions.

- [x] I have seen this code, I have run this code, and I take responsibility for this code.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

🤖 PR Summary generated by AI