### PR TITLE
fix(core): Sanitize untrusted input passed to template renderers

### DIFF
--- a/packages/cli/src/__tests__/response-helper.test.ts
+++ b/packages/cli/src/__tests__/response-helper.test.ts
@@ -1,6 +1,7 @@
 import type { Response } from 'express';
 import { mock } from 'jest-mock-extended';
 
+import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { LicenseEulaRequiredError } from '@/errors/response-errors/license-eula-required.error';
 import { sendErrorResponse } from '@/response-helper';
 
@@ -11,6 +12,8 @@ describe('sendErrorResponse', () => {
 		mockResponse = mock<Response>({
 			status: jest.fn().mockReturnThis(),
 			json: jest.fn().mockReturnThis(),
+			render: jest.fn().mockReturnThis(),
+			req: { originalUrl: '' } as any,
 		});
 	});
 
@@ -49,5 +52,27 @@ describe('sendErrorResponse', () => {
 				meta: expect.anything(),
 			}),
 		);
+	});
+
+	it('should escape HTML in message when rendering form-trigger-409', () => {
+		mockResponse.req.originalUrl = '/form-waiting/abc123';
+		const error = new ConflictError('<img src=x onerror=alert(1)>');
+
+		sendErrorResponse(mockResponse, error);
+
+		expect(mockResponse.render).toHaveBeenCalledWith('form-trigger-409', {
+			message: '&lt;img src=x onerror=alert(1)&gt;',
+		});
+	});
+
+	it('should escape template syntax in message when rendering form-trigger-409', () => {
+		mockResponse.req.originalUrl = '/form-waiting/abc123';
+		const error = new ConflictError('{{constructor.constructor("return this")()}}');
+
+		sendErrorResponse(mockResponse, error);
+
+		expect(mockResponse.render).toHaveBeenCalledWith('form-trigger-409', {
+			message: '{{constructor.constructor(&quot;return this&quot;)()}}',
+		});
 	});
 });

--- a/packages/cli/src/modules/sso-oidc/views/__tests__/oidc-test-result.test.ts
+++ b/packages/cli/src/modules/sso-oidc/views/__tests__/oidc-test-result.test.ts
@@ -1,0 +1,42 @@
+import { renderOidcTestSuccess, renderOidcTestFailure } from '../oidc-test-result';
+
+describe('renderOidcTestSuccess', () => {
+	it('should escape HTML in user info fields', () => {
+		const html = renderOidcTestSuccess({
+			claims: {},
+			userInfo: {
+				email: '<script>alert(1)</script>',
+				given_name: 'Test',
+				family_name: 'User',
+				sub: '123',
+			},
+		});
+
+		expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+		expect(html).not.toContain('<script>alert(1)</script>');
+	});
+
+	it('should show (n/a) for missing fields', () => {
+		const html = renderOidcTestSuccess({
+			claims: {},
+			userInfo: {},
+		});
+
+		expect(html).toContain('(n/a)');
+	});
+});
+
+describe('renderOidcTestFailure', () => {
+	it('should escape HTML in error message', () => {
+		const html = renderOidcTestFailure(new Error('<img src=x onerror=alert(1)>'));
+
+		expect(html).toContain('&lt;img src=x onerror=alert(1)&gt;');
+		expect(html).not.toContain('<img src=x');
+	});
+
+	it('should handle non-Error values', () => {
+		const html = renderOidcTestFailure('plain string error');
+
+		expect(html).toContain('plain string error');
+	});
+});

--- a/packages/cli/src/modules/sso-oidc/views/oidc-test-result.ts
+++ b/packages/cli/src/modules/sso-oidc/views/oidc-test-result.ts
@@ -1,3 +1,5 @@
+import { escapeHtml as escapeHtmlBase } from '@/utils/escape-html';
+
 const PAGE_STYLES = `
 body { background: rgb(251,252,254); font-family: 'Open Sans', sans-serif; padding: 10px; margin: auto; width: 500px; top: 40%; position: relative; }
 h1 { font-size: 16px; font-weight: 400; margin: 0 0 10px 0; }
@@ -8,11 +10,7 @@ li { list-style: none; margin: 0; color: rgb(125, 125, 125); font-size: 12px; }
 `;
 
 function escapeHtml(value: unknown): string {
-	return String(value ?? '(n/a)')
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;')
-		.replace(/"/g, '&quot;');
+	return escapeHtmlBase(value) || '(n/a)';
 }
 
 export function renderOidcTestSuccess({

--- a/packages/cli/src/oauth/__tests__/oauth.service.test.ts
+++ b/packages/cli/src/oauth/__tests__/oauth.service.test.ts
@@ -1057,7 +1057,7 @@ describe('OauthService', () => {
 			service.renderCallbackError(res, message);
 
 			expect(res.render).toHaveBeenCalledWith('oauth-error-callback', {
-				error: { message },
+				error: { message, reason: '' },
 			});
 		});
 
@@ -2780,6 +2780,32 @@ describe('OauthService', () => {
 			expect(
 				OauthService.extractAccountIdentifier({ email: 'direct@example.com', id_token: idToken }),
 			).toBe('direct@example.com');
+		});
+	});
+
+	describe('renderCallbackError', () => {
+		it('should escape HTML in message before rendering', () => {
+			const res = mock<Response>();
+			service.renderCallbackError(res, '<img src=x onerror=alert(1)>');
+
+			expect(res.render).toHaveBeenCalledWith('oauth-error-callback', {
+				error: {
+					message: '&lt;img src=x onerror=alert(1)&gt;',
+					reason: '',
+				},
+			});
+		});
+
+		it('should escape HTML in reason before rendering', () => {
+			const res = mock<Response>();
+			service.renderCallbackError(res, 'error', '<script>alert(1)</script>');
+
+			expect(res.render).toHaveBeenCalledWith('oauth-error-callback', {
+				error: {
+					message: 'error',
+					reason: '&lt;script&gt;alert(1)&lt;/script&gt;',
+				},
+			});
 		});
 	});
 });

--- a/packages/cli/src/oauth/oauth.service.ts
+++ b/packages/cli/src/oauth/oauth.service.ts
@@ -13,6 +13,7 @@ import {
 	GENERIC_OAUTH2_CREDENTIALS_WITH_EDITABLE_SCOPE,
 	RESPONSE_ERROR_MESSAGES,
 } from '@/constants';
+import { escapeHtml } from '@/utils/escape-html';
 import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
 import { CredentialsHelper } from '@/credentials-helper';
 import { AuthError } from '@/errors/response-errors/auth.error';
@@ -339,7 +340,9 @@ export class OauthService {
 	}
 
 	renderCallbackError(res: Response, message: string, reason?: string) {
-		res.render('oauth-error-callback', { error: { message, reason } });
+		res.render('oauth-error-callback', {
+			error: { message: escapeHtml(message), reason: escapeHtml(reason) },
+		});
 	}
 
 	async getOAuthCredentials<T>(credential: CredentialsEntity): Promise<T> {

--- a/packages/cli/src/response-helper.ts
+++ b/packages/cli/src/response-helper.ts
@@ -11,6 +11,7 @@ import picocolors from 'picocolors';
 import { classifyHttpError, isResponseError } from './errors/http-error-classifier';
 import { serializeInternalRestError } from './errors/http-error-serializers';
 import { ResponseError } from './errors/response-errors/abstract/response.error';
+import { escapeHtml } from './utils/escape-html';
 
 export function sendSuccessResponse(
 	res: Response,
@@ -69,7 +70,7 @@ export function sendErrorResponse(res: Response, error: Error) {
 			//codes other than 200  breaks redirection to form-waiting page from form trigger
 			//render form page instead of json
 			return res.render('form-trigger-409', {
-				message: error.message,
+				message: escapeHtml(error.message),
 			});
 		}
 	}

--- a/packages/cli/src/utils/__tests__/escape-html.test.ts
+++ b/packages/cli/src/utils/__tests__/escape-html.test.ts
@@ -1,0 +1,35 @@
+import { escapeHtml } from '../escape-html';
+
+describe('escapeHtml', () => {
+	it('should escape HTML tags', () => {
+		expect(escapeHtml('<script>alert(1)</script>')).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+	});
+
+	it('should escape ampersands', () => {
+		expect(escapeHtml('foo & bar')).toBe('foo &amp; bar');
+	});
+
+	it('should escape double quotes', () => {
+		expect(escapeHtml('"hello"')).toBe('&quot;hello&quot;');
+	});
+
+	it('should escape single quotes', () => {
+		expect(escapeHtml("it's")).toBe('it&#x27;s');
+	});
+
+	it('should escape template-syntax payloads', () => {
+		expect(escapeHtml('{{constructor.constructor("return this")()}}')).toBe(
+			'{{constructor.constructor(&quot;return this&quot;)()}}',
+		);
+	});
+
+	it('should handle null and undefined', () => {
+		expect(escapeHtml(null)).toBe('');
+		expect(escapeHtml(undefined)).toBe('');
+	});
+
+	it('should convert non-string values to strings', () => {
+		expect(escapeHtml(42)).toBe('42');
+		expect(escapeHtml(true)).toBe('true');
+	});
+});

--- a/packages/cli/src/utils/escape-html.ts
+++ b/packages/cli/src/utils/escape-html.ts
@@ -1,0 +1,12 @@
+/**
+ * Escapes HTML special characters in a string to prevent them from being
+ * interpreted as markup when inserted into an HTML context.
+ */
+export function escapeHtml(value: unknown): string {
+	return String(value ?? '')
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#x27;');
+}

--- a/packages/cli/test/integration/controllers/oauth/oauth2.api.test.ts
+++ b/packages/cli/test/integration/controllers/oauth/oauth2.api.test.ts
@@ -146,7 +146,7 @@ describe('OAuth2 API', () => {
 			.expect(200);
 
 		expect(renderSpy).toHaveBeenCalledWith('oauth-error-callback', {
-			error: { message: 'Unauthorized' },
+			error: { message: 'Unauthorized', reason: '' },
 		});
 	});
 

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/useMarkdown.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/useMarkdown.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../../composables/useI18n', () => ({
+	useI18n: () => ({
+		t: (key: string) => key,
+	}),
+}));
+
+import { useMarkdown } from './useMarkdown';
+
+describe('useMarkdown', () => {
+	const { renderMarkdown } = useMarkdown();
+
+	it('should render standard markdown', () => {
+		const result = renderMarkdown('**bold** text');
+		expect(result).toContain('<strong>bold</strong>');
+	});
+
+	it('should not render raw script tags', () => {
+		const result = renderMarkdown('<script>alert(1)</script>');
+		expect(result).not.toContain('<script>');
+		expect(result).not.toContain('</script>');
+	});
+
+	it('should not render raw img tags with event handlers', () => {
+		const result = renderMarkdown('<img src=x onerror=alert(1)>');
+		expect(result).not.toContain('<img');
+	});
+
+	it('should not render raw iframe tags', () => {
+		const result = renderMarkdown('<iframe src="https://evil.com"></iframe>');
+		expect(result).not.toContain('<iframe');
+	});
+});

--- a/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/useMarkdown.ts
+++ b/packages/frontend/@n8n/design-system/src/components/AskAssistantChat/messages/useMarkdown.ts
@@ -1,5 +1,6 @@
 import Markdown from 'markdown-it';
 import markdownLink from 'markdown-it-link-attributes';
+import sanitizeHtml from 'sanitize-html';
 
 import { useI18n } from '../../../composables/useI18n';
 
@@ -7,6 +8,7 @@ export function useMarkdown() {
 	const { t } = useI18n();
 
 	const md = new Markdown({
+		html: false,
 		breaks: true,
 	});
 
@@ -19,7 +21,8 @@ export function useMarkdown() {
 
 	function renderMarkdown(content: string) {
 		try {
-			return md.render(content);
+			const rendered = md.render(content);
+			return sanitizeHtml(rendered);
 		} catch (e) {
 			console.error(`Error parsing markdown content ${content}`);
 			return `<p>${t('assistantChat.errorParsingMarkdown')}</p>`;


### PR DESCRIPTION
## Summary

- Add shared `escapeHtml` utility and escape user-controlled fields (`message`, `reason`, `error.message`) before passing them to Handlebars `res.render()` calls
- Add `html: false` (explicit) and `sanitize-html` post-processing to the `useMarkdown` composable as defense-in-depth
- Refactor existing OIDC views to reuse the shared `escapeHtml` utility

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/SEC-460

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)