### PR TITLE
feat(ai): Export AI agent traces via OpenTelemetry

### DIFF
--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -205,6 +205,8 @@
   },
   "devDependencies": {
     "@n8n/eslint-plugin-community-nodes": "workspace:*",
+    "@opentelemetry/core": "^2.0.0",
+    "@opentelemetry/sdk-trace-node": "^2.6.0",
     "@types/basic-auth": "catalog:",
     "@types/cheerio": "^0.22.15",
     "@types/html-to-text": "^9.0.1",

--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -264,6 +264,7 @@
     "@n8n/json-schema-to-zod": "workspace:*",
     "@n8n/typeorm": "catalog:",
     "@n8n/typescript-config": "workspace:*",
+    "@opentelemetry/api": "^1.9.0",
     "vm2": "catalog:",
     "@pinecone-database/pinecone": "^5.0.2",
     "@qdrant/js-client-rest": "^1.16.2",

--- a/packages/@n8n/nodes-langchain/utils/otel-ai-callback-handler.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/otel-ai-callback-handler.test.ts
@@ -1,0 +1,373 @@
+import type { Serialized } from '@langchain/core/load/serializable';
+import type { LLMResult } from '@langchain/core/outputs';
+import { propagation, SpanStatusCode, trace } from '@opentelemetry/api';
+import { W3CTraceContextPropagator } from '@opentelemetry/core';
+import {
+	BasicTracerProvider,
+	InMemorySpanExporter,
+	SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { OtelAiCallbackHandler } from './otel-ai-callback-handler';
+
+describe('OtelAiCallbackHandler', () => {
+	let provider: BasicTracerProvider;
+	let exporter: InMemorySpanExporter;
+
+	beforeAll(() => {
+		exporter = new InMemorySpanExporter();
+		provider = new BasicTracerProvider({
+			spanProcessors: [new SimpleSpanProcessor(exporter)],
+		});
+		trace.setGlobalTracerProvider(provider);
+		propagation.setGlobalPropagator(new W3CTraceContextPropagator());
+	});
+
+	afterEach(() => {
+		exporter.reset();
+	});
+
+	afterAll(async () => {
+		exporter.reset();
+		await provider.shutdown();
+		trace.disable();
+		propagation.disable();
+	});
+
+	function makeLlmSerialized(id: string[] = ['langchain', 'chat_models', 'openai']): Serialized {
+		return { lc: 1, type: 'constructor', id, kwargs: { model: 'gpt-4' } } as Serialized;
+	}
+
+	function makeToolSerialized(name: string = 'calculator'): Serialized {
+		return { lc: 1, type: 'not_implemented', id: ['langchain', 'tools', name] } as Serialized;
+	}
+
+	function makeChainSerialized(type: string = 'AgentExecutor'): Serialized {
+		return { lc: 1, type: 'not_implemented', id: ['langchain', 'chains', type] } as Serialized;
+	}
+
+	function makeRetrieverSerialized(type: string = 'pinecone'): Serialized {
+		return {
+			lc: 1,
+			type: 'not_implemented',
+			id: ['langchain', 'retrievers', type],
+		} as Serialized;
+	}
+
+	describe('LLM spans', () => {
+		it('should create and end an LLM span with correct attributes', async () => {
+			const handler = new OtelAiCallbackHandler();
+
+			await handler.handleLLMStart(
+				makeLlmSerialized(),
+				['Hello, how are you?'],
+				'run-1',
+				undefined,
+				{ temperature: 0.7, max_tokens: 100 },
+			);
+
+			await handler.handleLLMEnd(
+				{
+					generations: [[{ text: 'I am fine', generationInfo: {} }]],
+					llmOutput: { tokenUsage: { promptTokens: 10, completionTokens: 5, totalTokens: 15 } },
+				} as LLMResult,
+				'run-1',
+			);
+
+			const spans = exporter.getFinishedSpans();
+			expect(spans).toHaveLength(1);
+
+			const span = spans[0];
+			expect(span.name).toBe('ai.llm.call');
+			expect(span.status.code).toBe(SpanStatusCode.OK);
+			expect(span.attributes['gen_ai.system']).toBe('openai');
+			expect(span.attributes['gen_ai.request.model']).toBe('gpt-4');
+			expect(span.attributes['gen_ai.prompt.length']).toBe(19);
+			expect(span.attributes['gen_ai.request.temperature']).toBe(0.7);
+			expect(span.attributes['gen_ai.request.max_tokens']).toBe(100);
+			expect(span.attributes['gen_ai.usage.input_tokens']).toBe(10);
+			expect(span.attributes['gen_ai.usage.output_tokens']).toBe(5);
+			expect(span.attributes['gen_ai.usage.total_tokens']).toBe(15);
+		});
+
+		it('should handle LLM error with error status and exception event', async () => {
+			const handler = new OtelAiCallbackHandler();
+
+			await handler.handleLLMStart(makeLlmSerialized(), ['test'], 'run-err');
+			await handler.handleLLMError(new Error('Rate limit exceeded'), 'run-err');
+
+			const spans = exporter.getFinishedSpans();
+			expect(spans).toHaveLength(1);
+
+			const span = spans[0];
+			expect(span.name).toBe('ai.llm.call');
+			expect(span.status.code).toBe(SpanStatusCode.ERROR);
+			expect(span.status.message).toBe('Rate limit exceeded');
+
+			const events = span.events;
+			expect(events).toHaveLength(1);
+			expect(events[0].name).toBe('exception');
+			expect(events[0].attributes?.['exception.message']).toBe('Rate limit exceeded');
+			expect(events[0].attributes?.['exception.type']).toBe('Error');
+		});
+
+		it('should handle LLM end without token usage gracefully', async () => {
+			const handler = new OtelAiCallbackHandler();
+
+			await handler.handleLLMStart(makeLlmSerialized(), ['test'], 'run-no-tokens');
+			await handler.handleLLMEnd(
+				{ generations: [[{ text: 'response', generationInfo: {} }]] } as LLMResult,
+				'run-no-tokens',
+			);
+
+			const spans = exporter.getFinishedSpans();
+			expect(spans).toHaveLength(1);
+			expect(spans[0].status.code).toBe(SpanStatusCode.OK);
+			expect(spans[0].attributes['gen_ai.usage.input_tokens']).toBeUndefined();
+		});
+
+		it('should extract model name from extraParams', async () => {
+			const handler = new OtelAiCallbackHandler();
+			const llm = {
+				lc: 1,
+				type: 'not_implemented',
+				id: ['langchain', 'llms', 'base'],
+			} as Serialized;
+
+			await handler.handleLLMStart(llm, ['test'], 'run-model', undefined, {
+				model: 'claude-3-opus',
+			});
+			await handler.handleLLMEnd(
+				{ generations: [[{ text: 'ok', generationInfo: {} }]] } as LLMResult,
+				'run-model',
+			);
+
+			const spans = exporter.getFinishedSpans();
+			expect(spans[0].attributes['gen_ai.request.model']).toBe('claude-3-opus');
+		});
+	});
+
+	describe('Tool spans', () => {
+		it('should create and end a tool span with correct attributes', async () => {
+			const handler = new OtelAiCallbackHandler();
+
+			await handler.handleToolStart(
+				makeToolSerialized('calculator'),
+				'What is 2+2?',
+				'tool-1',
+				undefined,
+				undefined,
+				undefined,
+				'calculator',
+			);
+			await handler.handleToolEnd('4', 'tool-1');
+
+			const spans = exporter.getFinishedSpans();
+			expect(spans).toHaveLength(1);
+
+			const span = spans[0];
+			expect(span.name).toBe('ai.tool.call');
+			expect(span.status.code).toBe(SpanStatusCode.OK);
+			expect(span.attributes['n8n.ai.tool.name']).toBe('calculator');
+			expect(span.attributes['n8n.ai.tool.input.length']).toBe(12);
+			expect(span.attributes['n8n.ai.tool.output.length']).toBe(1);
+		});
+
+		it('should use serialized id as fallback for tool name', async () => {
+			const handler = new OtelAiCallbackHandler();
+
+			await handler.handleToolStart(makeToolSerialized('web_search'), 'query', 'tool-2');
+			await handler.handleToolEnd('results', 'tool-2');
+
+			const spans = exporter.getFinishedSpans();
+			expect(spans[0].attributes['n8n.ai.tool.name']).toBe('web_search');
+		});
+
+		it('should handle tool error', async () => {
+			const handler = new OtelAiCallbackHandler();
+
+			await handler.handleToolStart(makeToolSerialized(), 'input', 'tool-err');
+			await handler.handleToolError(new Error('Tool failed'), 'tool-err');
+
+			const spans = exporter.getFinishedSpans();
+			expect(spans[0].status.code).toBe(SpanStatusCode.ERROR);
+			expect(spans[0].status.message).toBe('Tool failed');
+		});
+	});
+
+	describe('Chain spans', () => {
+		it('should create and end a chain span', async () => {
+			const handler = new OtelAiCallbackHandler();
+
+			await handler.handleChainStart(makeChainSerialized('AgentExecutor'), {}, 'chain-1');
+			await handler.handleChainEnd({ output: 'done' }, 'chain-1');
+
+			const spans = exporter.getFinishedSpans();
+			expect(spans).toHaveLength(1);
+
+			const span = spans[0];
+			expect(span.name).toBe('ai.chain.call');
+			expect(span.status.code).toBe(SpanStatusCode.OK);
+			expect(span.attributes['n8n.ai.chain.type']).toBe('AgentExecutor');
+		});
+
+		it('should handle chain error', async () => {
+			const handler = new OtelAiCallbackHandler();
+
+			await handler.handleChainStart(makeChainSerialized(), {}, 'chain-err');
+			await handler.handleChainError(new Error('Chain broke'), 'chain-err');
+
+			const spans = exporter.getFinishedSpans();
+			expect(spans[0].status.code).toBe(SpanStatusCode.ERROR);
+			expect(spans[0].status.message).toBe('Chain broke');
+		});
+	});
+
+	describe('Retriever spans', () => {
+		it('should create and end a retriever span with document count', async () => {
+			const handler = new OtelAiCallbackHandler();
+
+			await handler.handleRetrieverStart(
+				makeRetrieverSerialized('pinecone'),
+				'search query',
+				'ret-1',
+			);
+			await handler.handleRetrieverEnd(
+				[{ pageContent: 'doc1' }, { pageContent: 'doc2' }, { pageContent: 'doc3' }],
+				'ret-1',
+			);
+
+			const spans = exporter.getFinishedSpans();
+			expect(spans).toHaveLength(1);
+
+			const span = spans[0];
+			expect(span.name).toBe('ai.retriever.call');
+			expect(span.status.code).toBe(SpanStatusCode.OK);
+			expect(span.attributes['n8n.ai.retriever.type']).toBe('pinecone');
+			expect(span.attributes['n8n.ai.retriever.query.length']).toBe(12);
+			expect(span.attributes['n8n.ai.retriever.document_count']).toBe(3);
+		});
+
+		it('should handle retriever error', async () => {
+			const handler = new OtelAiCallbackHandler();
+
+			await handler.handleRetrieverStart(makeRetrieverSerialized(), 'query', 'ret-err');
+			await handler.handleRetrieverError(new Error('Connection failed'), 'ret-err');
+
+			const spans = exporter.getFinishedSpans();
+			expect(spans[0].status.code).toBe(SpanStatusCode.ERROR);
+		});
+	});
+
+	describe('Parent-child nesting', () => {
+		it('should create all spans in a nested agent execution', async () => {
+			const handler = new OtelAiCallbackHandler();
+
+			// Simulate: chain -> llm -> tool -> llm (typical agent loop)
+			await handler.handleChainStart(makeChainSerialized(), {}, 'chain-parent');
+			await handler.handleLLMStart(makeLlmSerialized(), ['prompt'], 'llm-child', 'chain-parent');
+			await handler.handleLLMEnd(
+				{ generations: [[{ text: 'response', generationInfo: {} }]] } as LLMResult,
+				'llm-child',
+			);
+			await handler.handleChainEnd({}, 'chain-parent');
+
+			const spans = exporter.getFinishedSpans();
+			expect(spans).toHaveLength(2);
+
+			const llmSpan = spans.find((s) => s.name === 'ai.llm.call')!;
+			const chainSpan = spans.find((s) => s.name === 'ai.chain.call')!;
+
+			expect(llmSpan).toBeDefined();
+			expect(chainSpan).toBeDefined();
+		});
+
+		it('should create spans for chain -> llm -> tool hierarchy', async () => {
+			const handler = new OtelAiCallbackHandler();
+
+			await handler.handleChainStart(makeChainSerialized(), {}, 'chain-1');
+			await handler.handleLLMStart(makeLlmSerialized(), ['prompt'], 'llm-1', 'chain-1');
+			await handler.handleToolStart(makeToolSerialized(), 'input', 'tool-1', 'llm-1');
+			await handler.handleToolEnd('output', 'tool-1');
+			await handler.handleLLMEnd(
+				{ generations: [[{ text: 'done', generationInfo: {} }]] } as LLMResult,
+				'llm-1',
+			);
+			await handler.handleChainEnd({}, 'chain-1');
+
+			const spans = exporter.getFinishedSpans();
+			expect(spans).toHaveLength(3);
+
+			const toolSpan = spans.find((s) => s.name === 'ai.tool.call')!;
+			const llmSpan = spans.find((s) => s.name === 'ai.llm.call')!;
+			const chainSpan = spans.find((s) => s.name === 'ai.chain.call')!;
+
+			expect(toolSpan).toBeDefined();
+			expect(llmSpan).toBeDefined();
+			expect(chainSpan).toBeDefined();
+
+			// All spans should have valid span IDs (not be no-ops)
+			expect(toolSpan.spanContext().spanId).toBeTruthy();
+			expect(llmSpan.spanContext().spanId).toBeTruthy();
+			expect(chainSpan.spanContext().spanId).toBeTruthy();
+		});
+	});
+
+	describe('Edge cases', () => {
+		it('should not throw when handleLLMEnd is called with unknown runId', async () => {
+			const handler = new OtelAiCallbackHandler();
+			await expect(
+				handler.handleLLMEnd(
+					{ generations: [[{ text: 'x', generationInfo: {} }]] } as LLMResult,
+					'nonexistent',
+				),
+			).resolves.not.toThrow();
+		});
+
+		it('should not throw when handleToolEnd is called with unknown runId', async () => {
+			const handler = new OtelAiCallbackHandler();
+			await expect(handler.handleToolEnd('output', 'nonexistent')).resolves.not.toThrow();
+		});
+
+		it('should not throw when handleChainEnd is called with unknown runId', async () => {
+			const handler = new OtelAiCallbackHandler();
+			await expect(handler.handleChainEnd({}, 'nonexistent')).resolves.not.toThrow();
+		});
+
+		it('should handle non-Error objects in error handlers', async () => {
+			const handler = new OtelAiCallbackHandler();
+
+			await handler.handleLLMStart(makeLlmSerialized(), ['test'], 'run-obj-err');
+			await handler.handleLLMError({ message: 'object error', code: 429 }, 'run-obj-err');
+
+			const spans = exporter.getFinishedSpans();
+			expect(spans[0].status.code).toBe(SpanStatusCode.ERROR);
+			expect(spans[0].status.message).toBe('object error');
+		});
+
+		it('should accept a parent span in the constructor without errors', async () => {
+			const tracer = trace.getTracer('test');
+			const parentSpan = tracer.startSpan('node.execute');
+
+			const handler = new OtelAiCallbackHandler(parentSpan);
+
+			await handler.handleLLMStart(makeLlmSerialized(), ['test'], 'run-parent');
+			await handler.handleLLMEnd(
+				{ generations: [[{ text: 'ok', generationInfo: {} }]] } as LLMResult,
+				'run-parent',
+			);
+
+			parentSpan.end();
+
+			const spans = exporter.getFinishedSpans();
+			const llmSpan = spans.find((s) => s.name === 'ai.llm.call')!;
+			const nodeSpan = spans.find((s) => s.name === 'node.execute')!;
+
+			// Both spans are created successfully
+			expect(llmSpan).toBeDefined();
+			expect(nodeSpan).toBeDefined();
+			expect(llmSpan.status.code).toBe(SpanStatusCode.OK);
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/utils/otel-ai-callback-handler.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/otel-ai-callback-handler.test.ts
@@ -83,7 +83,7 @@ describe('OtelAiCallbackHandler', () => {
 			expect(span.status.code).toBe(SpanStatusCode.OK);
 			expect(span.attributes['gen_ai.system']).toBe('openai');
 			expect(span.attributes['gen_ai.request.model']).toBe('gpt-4');
-			expect(span.attributes['gen_ai.prompt.length']).toBe(19);
+			expect(span.attributes['n8n.ai.prompt.length']).toBe(19);
 			expect(span.attributes['gen_ai.request.temperature']).toBe(0.7);
 			expect(span.attributes['gen_ai.request.max_tokens']).toBe(100);
 			expect(span.attributes['gen_ai.usage.input_tokens']).toBe(10);
@@ -261,10 +261,9 @@ describe('OtelAiCallbackHandler', () => {
 	});
 
 	describe('Parent-child nesting', () => {
-		it('should create all spans in a nested agent execution', async () => {
+		it('should nest LLM span under chain span when parentRunId is provided', async () => {
 			const handler = new OtelAiCallbackHandler();
 
-			// Simulate: chain -> llm -> tool -> llm (typical agent loop)
 			await handler.handleChainStart(makeChainSerialized(), {}, 'chain-parent');
 			await handler.handleLLMStart(makeLlmSerialized(), ['prompt'], 'llm-child', 'chain-parent');
 			await handler.handleLLMEnd(
@@ -281,9 +280,13 @@ describe('OtelAiCallbackHandler', () => {
 
 			expect(llmSpan).toBeDefined();
 			expect(chainSpan).toBeDefined();
+
+			// Verify parent-child relationship: LLM span's parent should be the chain span
+			expect(llmSpan.parentSpanContext?.spanId).toBe(chainSpan.spanContext().spanId);
+			expect(llmSpan.spanContext().traceId).toBe(chainSpan.spanContext().traceId);
 		});
 
-		it('should create spans for chain -> llm -> tool hierarchy', async () => {
+		it('should nest chain -> llm -> tool with correct parent-child hierarchy', async () => {
 			const handler = new OtelAiCallbackHandler();
 
 			await handler.handleChainStart(makeChainSerialized(), {}, 'chain-1');
@@ -307,10 +310,14 @@ describe('OtelAiCallbackHandler', () => {
 			expect(llmSpan).toBeDefined();
 			expect(chainSpan).toBeDefined();
 
-			// All spans should have valid span IDs (not be no-ops)
-			expect(toolSpan.spanContext().spanId).toBeTruthy();
-			expect(llmSpan.spanContext().spanId).toBeTruthy();
-			expect(chainSpan.spanContext().spanId).toBeTruthy();
+			// Verify hierarchy: tool -> llm -> chain
+			expect(toolSpan.parentSpanContext?.spanId).toBe(llmSpan.spanContext().spanId);
+			expect(llmSpan.parentSpanContext?.spanId).toBe(chainSpan.spanContext().spanId);
+
+			// All spans should share the same traceId
+			const traceId = chainSpan.spanContext().traceId;
+			expect(llmSpan.spanContext().traceId).toBe(traceId);
+			expect(toolSpan.spanContext().traceId).toBe(traceId);
 		});
 	});
 

--- a/packages/@n8n/nodes-langchain/utils/otel-ai-callback-handler.ts
+++ b/packages/@n8n/nodes-langchain/utils/otel-ai-callback-handler.ts
@@ -11,6 +11,11 @@ const TRACER_NAME = 'n8n-ai';
  * Creates child spans under the active node.execute span for LLM calls,
  * tool invocations, and chain executions. This allows AI agent internals
  * to appear in your OTEL traces alongside workflow/node spans.
+ *
+ * Note: Streaming LLM callbacks (handleLLMNewToken) are intentionally not
+ * instrumented — the span lifecycle is handled by handleLLMStart/handleLLMEnd
+ * which works correctly for both streaming and non-streaming models. Token
+ * usage may be absent in handleLLMEnd for some streaming providers.
  */
 export class OtelAiCallbackHandler extends BaseCallbackHandler {
 	name = 'OtelAiCallbackHandler';
@@ -45,7 +50,7 @@ export class OtelAiCallbackHandler extends BaseCallbackHandler {
 				attributes: {
 					'gen_ai.system': extractProvider(llm),
 					'gen_ai.request.model': modelName,
-					'gen_ai.prompt.length': prompts.join('').length,
+					'n8n.ai.prompt.length': prompts.join('').length,
 					...(extraParams?.temperature !== undefined && {
 						'gen_ai.request.temperature': Number(extraParams.temperature),
 					}),

--- a/packages/@n8n/nodes-langchain/utils/otel-ai-callback-handler.ts
+++ b/packages/@n8n/nodes-langchain/utils/otel-ai-callback-handler.ts
@@ -1,0 +1,282 @@
+import { BaseCallbackHandler } from '@langchain/core/callbacks/base';
+import type { Serialized } from '@langchain/core/load/serializable';
+import type { LLMResult } from '@langchain/core/outputs';
+import { context, SpanStatusCode, trace } from '@opentelemetry/api';
+import type { Span, Context } from '@opentelemetry/api';
+
+const TRACER_NAME = 'n8n-ai';
+
+/**
+ * OpenTelemetry callback handler for LangChain operations.
+ * Creates child spans under the active node.execute span for LLM calls,
+ * tool invocations, and chain executions. This allows AI agent internals
+ * to appear in your OTEL traces alongside workflow/node spans.
+ */
+export class OtelAiCallbackHandler extends BaseCallbackHandler {
+	name = 'OtelAiCallbackHandler';
+
+	awaitHandlers = true;
+
+	private readonly tracer = trace.getTracer(TRACER_NAME);
+
+	private readonly spans = new Map<string, { span: Span; ctx: Context }>();
+
+	private readonly parentCtx: Context;
+
+	constructor(parentSpan?: Span) {
+		super();
+		// If a parent span is provided, create a context with it as the active span.
+		// Otherwise fall back to the current active context (which should have the node.execute span).
+		this.parentCtx = parentSpan ? trace.setSpan(context.active(), parentSpan) : context.active();
+	}
+
+	async handleLLMStart(
+		llm: Serialized,
+		prompts: string[],
+		runId: string,
+		parentRunId?: string,
+		extraParams?: Record<string, unknown>,
+	): Promise<void> {
+		const modelName = extractModelName(llm, extraParams);
+		const span = this.tracer.startSpan(
+			'ai.llm.call',
+			{
+				attributes: {
+					'gen_ai.system': extractProvider(llm),
+					'gen_ai.request.model': modelName,
+					'gen_ai.prompt.length': prompts.join('').length,
+					...(extraParams?.temperature !== undefined && {
+						'gen_ai.request.temperature': Number(extraParams.temperature),
+					}),
+					...(extraParams?.max_tokens !== undefined && {
+						'gen_ai.request.max_tokens': Number(extraParams.max_tokens),
+					}),
+				},
+			},
+			this.getParentContext(parentRunId),
+		);
+
+		this.spans.set(runId, { span, ctx: trace.setSpan(context.active(), span) });
+	}
+
+	async handleLLMEnd(output: LLMResult, runId: string): Promise<void> {
+		const tracked = this.spans.get(runId);
+		if (!tracked) return;
+
+		const { span } = tracked;
+
+		const tokenUsage = output.llmOutput?.tokenUsage ?? output.llmOutput?.usage;
+		if (tokenUsage) {
+			span.setAttributes({
+				...(tokenUsage.promptTokens !== undefined && {
+					'gen_ai.usage.input_tokens': tokenUsage.promptTokens,
+				}),
+				...(tokenUsage.completionTokens !== undefined && {
+					'gen_ai.usage.output_tokens': tokenUsage.completionTokens,
+				}),
+				...(tokenUsage.totalTokens !== undefined && {
+					'gen_ai.usage.total_tokens': tokenUsage.totalTokens,
+				}),
+			});
+		}
+
+		span.setStatus({ code: SpanStatusCode.OK });
+		span.end();
+		this.spans.delete(runId);
+	}
+
+	async handleLLMError(error: Error | object, runId: string): Promise<void> {
+		const tracked = this.spans.get(runId);
+		if (!tracked) return;
+
+		const { span } = tracked;
+		span.setStatus({ code: SpanStatusCode.ERROR, message: getErrorMessage(error) });
+		span.addEvent('exception', {
+			'exception.message': getErrorMessage(error),
+			'exception.type': error instanceof Error ? error.constructor.name : 'Error',
+		});
+		span.end();
+		this.spans.delete(runId);
+	}
+
+	async handleToolStart(
+		tool: Serialized,
+		input: string,
+		runId: string,
+		parentRunId?: string,
+		_tags?: string[],
+		_metadata?: Record<string, unknown>,
+		name?: string,
+	): Promise<void> {
+		const toolName = name ?? tool.id?.[tool.id.length - 1] ?? 'unknown_tool';
+		const span = this.tracer.startSpan(
+			'ai.tool.call',
+			{
+				attributes: {
+					'n8n.ai.tool.name': toolName,
+					'n8n.ai.tool.input.length': input.length,
+				},
+			},
+			this.getParentContext(parentRunId),
+		);
+
+		this.spans.set(runId, { span, ctx: trace.setSpan(context.active(), span) });
+	}
+
+	async handleToolEnd(output: string, runId: string): Promise<void> {
+		const tracked = this.spans.get(runId);
+		if (!tracked) return;
+
+		const { span } = tracked;
+		span.setAttribute('n8n.ai.tool.output.length', output.length);
+		span.setStatus({ code: SpanStatusCode.OK });
+		span.end();
+		this.spans.delete(runId);
+	}
+
+	async handleToolError(error: Error | object, runId: string): Promise<void> {
+		const tracked = this.spans.get(runId);
+		if (!tracked) return;
+
+		const { span } = tracked;
+		span.setStatus({ code: SpanStatusCode.ERROR, message: getErrorMessage(error) });
+		span.addEvent('exception', {
+			'exception.message': getErrorMessage(error),
+			'exception.type': error instanceof Error ? error.constructor.name : 'Error',
+		});
+		span.end();
+		this.spans.delete(runId);
+	}
+
+	async handleChainStart(
+		chain: Serialized,
+		_inputs: Record<string, unknown>,
+		runId: string,
+		parentRunId?: string,
+	): Promise<void> {
+		const chainType = chain.id?.[chain.id.length - 1] ?? 'unknown_chain';
+		const span = this.tracer.startSpan(
+			'ai.chain.call',
+			{
+				attributes: {
+					'n8n.ai.chain.type': chainType,
+				},
+			},
+			this.getParentContext(parentRunId),
+		);
+
+		this.spans.set(runId, { span, ctx: trace.setSpan(context.active(), span) });
+	}
+
+	async handleChainEnd(_outputs: Record<string, unknown>, runId: string): Promise<void> {
+		const tracked = this.spans.get(runId);
+		if (!tracked) return;
+
+		const { span } = tracked;
+		span.setStatus({ code: SpanStatusCode.OK });
+		span.end();
+		this.spans.delete(runId);
+	}
+
+	async handleChainError(error: Error | object, runId: string): Promise<void> {
+		const tracked = this.spans.get(runId);
+		if (!tracked) return;
+
+		const { span } = tracked;
+		span.setStatus({ code: SpanStatusCode.ERROR, message: getErrorMessage(error) });
+		span.addEvent('exception', {
+			'exception.message': getErrorMessage(error),
+			'exception.type': error instanceof Error ? error.constructor.name : 'Error',
+		});
+		span.end();
+		this.spans.delete(runId);
+	}
+
+	async handleRetrieverStart(
+		retriever: Serialized,
+		query: string,
+		runId: string,
+		parentRunId?: string,
+	): Promise<void> {
+		const retrieverType = retriever.id?.[retriever.id.length - 1] ?? 'unknown_retriever';
+		const span = this.tracer.startSpan(
+			'ai.retriever.call',
+			{
+				attributes: {
+					'n8n.ai.retriever.type': retrieverType,
+					'n8n.ai.retriever.query.length': query.length,
+				},
+			},
+			this.getParentContext(parentRunId),
+		);
+
+		this.spans.set(runId, { span, ctx: trace.setSpan(context.active(), span) });
+	}
+
+	async handleRetrieverEnd(
+		documents: Array<{ pageContent: string }>,
+		runId: string,
+	): Promise<void> {
+		const tracked = this.spans.get(runId);
+		if (!tracked) return;
+
+		const { span } = tracked;
+		span.setAttribute('n8n.ai.retriever.document_count', documents.length);
+		span.setStatus({ code: SpanStatusCode.OK });
+		span.end();
+		this.spans.delete(runId);
+	}
+
+	async handleRetrieverError(error: Error | object, runId: string): Promise<void> {
+		const tracked = this.spans.get(runId);
+		if (!tracked) return;
+
+		const { span } = tracked;
+		span.setStatus({ code: SpanStatusCode.ERROR, message: getErrorMessage(error) });
+		span.addEvent('exception', {
+			'exception.message': getErrorMessage(error),
+			'exception.type': error instanceof Error ? error.constructor.name : 'Error',
+		});
+		span.end();
+		this.spans.delete(runId);
+	}
+
+	/**
+	 * Get the parent context for a new span. If the parent run has a tracked span,
+	 * use that as parent (creating proper nesting). Otherwise use the root parent context
+	 * (the node.execute span).
+	 */
+	private getParentContext(parentRunId?: string): Context {
+		if (parentRunId) {
+			const parentTracked = this.spans.get(parentRunId);
+			if (parentTracked) return parentTracked.ctx;
+		}
+		return this.parentCtx;
+	}
+}
+
+function extractModelName(llm: Serialized, extraParams?: Record<string, unknown>): string {
+	if (extraParams?.model) return String(extraParams.model);
+	if (extraParams?.modelName) return String(extraParams.modelName);
+	if (llm.type === 'constructor' && llm.kwargs) {
+		const kwargs = llm.kwargs as Record<string, unknown>;
+		if (kwargs.model) return String(kwargs.model);
+		if (kwargs.modelName) return String(kwargs.modelName);
+	}
+	return llm.id?.[llm.id.length - 1] ?? 'unknown';
+}
+
+function extractProvider(llm: Serialized): string {
+	// The Serialized id array typically looks like ['langchain', 'llms', 'openai']
+	// or ['langchain', 'chat_models', 'anthropic']
+	if (llm.id && llm.id.length >= 3) {
+		return llm.id[llm.id.length - 1];
+	}
+	return 'unknown';
+}
+
+function getErrorMessage(error: Error | object): string {
+	if (error instanceof Error) return error.message;
+	if (typeof error === 'object' && 'message' in error) return String(error.message);
+	return String(error);
+}

--- a/packages/@n8n/nodes-langchain/utils/otel-ai-callback-handler.ts
+++ b/packages/@n8n/nodes-langchain/utils/otel-ai-callback-handler.ts
@@ -38,6 +38,7 @@ export class OtelAiCallbackHandler extends BaseCallbackHandler {
 		extraParams?: Record<string, unknown>,
 	): Promise<void> {
 		const modelName = extractModelName(llm, extraParams);
+		const parentCtx = this.getParentContext(parentRunId);
 		const span = this.tracer.startSpan(
 			'ai.llm.call',
 			{
@@ -53,10 +54,10 @@ export class OtelAiCallbackHandler extends BaseCallbackHandler {
 					}),
 				},
 			},
-			this.getParentContext(parentRunId),
+			parentCtx,
 		);
 
-		this.spans.set(runId, { span, ctx: trace.setSpan(context.active(), span) });
+		this.spans.set(runId, { span, ctx: trace.setSpan(parentCtx, span) });
 	}
 
 	async handleLLMEnd(output: LLMResult, runId: string): Promise<void> {
@@ -109,6 +110,7 @@ export class OtelAiCallbackHandler extends BaseCallbackHandler {
 		name?: string,
 	): Promise<void> {
 		const toolName = name ?? tool.id?.[tool.id.length - 1] ?? 'unknown_tool';
+		const parentCtx = this.getParentContext(parentRunId);
 		const span = this.tracer.startSpan(
 			'ai.tool.call',
 			{
@@ -117,10 +119,10 @@ export class OtelAiCallbackHandler extends BaseCallbackHandler {
 					'n8n.ai.tool.input.length': input.length,
 				},
 			},
-			this.getParentContext(parentRunId),
+			parentCtx,
 		);
 
-		this.spans.set(runId, { span, ctx: trace.setSpan(context.active(), span) });
+		this.spans.set(runId, { span, ctx: trace.setSpan(parentCtx, span) });
 	}
 
 	async handleToolEnd(output: string, runId: string): Promise<void> {
@@ -155,6 +157,7 @@ export class OtelAiCallbackHandler extends BaseCallbackHandler {
 		parentRunId?: string,
 	): Promise<void> {
 		const chainType = chain.id?.[chain.id.length - 1] ?? 'unknown_chain';
+		const parentCtx = this.getParentContext(parentRunId);
 		const span = this.tracer.startSpan(
 			'ai.chain.call',
 			{
@@ -162,10 +165,10 @@ export class OtelAiCallbackHandler extends BaseCallbackHandler {
 					'n8n.ai.chain.type': chainType,
 				},
 			},
-			this.getParentContext(parentRunId),
+			parentCtx,
 		);
 
-		this.spans.set(runId, { span, ctx: trace.setSpan(context.active(), span) });
+		this.spans.set(runId, { span, ctx: trace.setSpan(parentCtx, span) });
 	}
 
 	async handleChainEnd(_outputs: Record<string, unknown>, runId: string): Promise<void> {
@@ -199,6 +202,7 @@ export class OtelAiCallbackHandler extends BaseCallbackHandler {
 		parentRunId?: string,
 	): Promise<void> {
 		const retrieverType = retriever.id?.[retriever.id.length - 1] ?? 'unknown_retriever';
+		const parentCtx = this.getParentContext(parentRunId);
 		const span = this.tracer.startSpan(
 			'ai.retriever.call',
 			{
@@ -207,10 +211,10 @@ export class OtelAiCallbackHandler extends BaseCallbackHandler {
 					'n8n.ai.retriever.query.length': query.length,
 				},
 			},
-			this.getParentContext(parentRunId),
+			parentCtx,
 		);
 
-		this.spans.set(runId, { span, ctx: trace.setSpan(context.active(), span) });
+		this.spans.set(runId, { span, ctx: trace.setSpan(parentCtx, span) });
 	}
 
 	async handleRetrieverEnd(

--- a/packages/@n8n/nodes-langchain/utils/tracing.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/tracing.test.ts
@@ -1,7 +1,9 @@
 import type { CallbackManager } from '@langchain/core/callbacks/manager';
+import { trace } from '@opentelemetry/api';
 import type { IExecuteFunctions, ISupplyDataFunctions } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
+import { OtelAiCallbackHandler } from './otel-ai-callback-handler';
 import { buildTracingMetadata, getTracingConfig } from './tracing';
 
 describe('getTracingConfig', () => {
@@ -125,6 +127,68 @@ describe('getTracingConfig', () => {
 				node: 'AI Agent',
 			});
 			expect(result.callbacks).toBeUndefined();
+		});
+	});
+
+	describe('OTEL integration', () => {
+		it('should not include OTEL handler when no active span exists', () => {
+			const mockContext = mock<IExecuteFunctions>();
+			mockContext.getWorkflow.mockReturnValue(mockWorkflow);
+			mockContext.getNode.mockReturnValue(mockNode as ReturnType<IExecuteFunctions['getNode']>);
+			mockContext.getExecutionId.mockReturnValue('exec-456');
+			mockContext.getParentCallbackManager.mockReturnValue(undefined);
+
+			// No OTEL SDK registered = trace.getActiveSpan() returns undefined
+			expect(trace.getActiveSpan()).toBeUndefined();
+
+			const result = getTracingConfig(mockContext);
+
+			// callbacks should be undefined (no parent callback manager, no OTEL)
+			expect(result.callbacks).toBeUndefined();
+		});
+
+		it('should include OTEL handler alongside parent callback manager when active span exists', () => {
+			const mockCallbackManager = mock<CallbackManager>();
+			const mockContext = mock<IExecuteFunctions>();
+			mockContext.getWorkflow.mockReturnValue(mockWorkflow);
+			mockContext.getNode.mockReturnValue(mockNode as ReturnType<IExecuteFunctions['getNode']>);
+			mockContext.getExecutionId.mockReturnValue('exec-456');
+			mockContext.getParentCallbackManager.mockReturnValue(mockCallbackManager);
+
+			// Mock trace.getActiveSpan to return a span
+			const mockSpan = { spanContext: () => ({ traceId: 'abc', spanId: '123' }) };
+			const getActiveSpanSpy = vi.spyOn(trace, 'getActiveSpan').mockReturnValue(mockSpan as any);
+
+			const result = getTracingConfig(mockContext);
+
+			// callbacks should be an array with parent manager and OTEL handler
+			expect(Array.isArray(result.callbacks)).toBe(true);
+			const callbacksArray = result.callbacks as unknown[];
+			expect(callbacksArray).toHaveLength(2);
+			expect(callbacksArray[0]).toBe(mockCallbackManager);
+			expect(callbacksArray[1]).toBeInstanceOf(OtelAiCallbackHandler);
+
+			getActiveSpanSpy.mockRestore();
+		});
+
+		it('should include only OTEL handler when active span exists but no parent callback manager', () => {
+			const mockContext = mock<IExecuteFunctions>();
+			mockContext.getWorkflow.mockReturnValue(mockWorkflow);
+			mockContext.getNode.mockReturnValue(mockNode as ReturnType<IExecuteFunctions['getNode']>);
+			mockContext.getExecutionId.mockReturnValue('exec-456');
+			mockContext.getParentCallbackManager.mockReturnValue(undefined);
+
+			const mockSpan = { spanContext: () => ({ traceId: 'abc', spanId: '123' }) };
+			const getActiveSpanSpy = vi.spyOn(trace, 'getActiveSpan').mockReturnValue(mockSpan as any);
+
+			const result = getTracingConfig(mockContext);
+
+			expect(Array.isArray(result.callbacks)).toBe(true);
+			const callbacksArray = result.callbacks as unknown[];
+			expect(callbacksArray).toHaveLength(1);
+			expect(callbacksArray[0]).toBeInstanceOf(OtelAiCallbackHandler);
+
+			getActiveSpanSpy.mockRestore();
 		});
 	});
 

--- a/packages/@n8n/nodes-langchain/utils/tracing.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/tracing.test.ts
@@ -190,6 +190,32 @@ describe('getTracingConfig', () => {
 
 			getActiveSpanSpy.mockRestore();
 		});
+
+		it('should not include OTEL handler when N8N_OTEL_TRACES_INCLUDE_AI_SPANS is false', () => {
+			const mockContext = mock<IExecuteFunctions>();
+			mockContext.getWorkflow.mockReturnValue(mockWorkflow);
+			mockContext.getNode.mockReturnValue(mockNode as ReturnType<IExecuteFunctions['getNode']>);
+			mockContext.getExecutionId.mockReturnValue('exec-456');
+			mockContext.getParentCallbackManager.mockReturnValue(undefined);
+
+			const mockSpan = { spanContext: () => ({ traceId: 'abc', spanId: '123' }) };
+			const getActiveSpanSpy = vi.spyOn(trace, 'getActiveSpan').mockReturnValue(mockSpan as any);
+
+			const originalEnv = process.env.N8N_OTEL_TRACES_INCLUDE_AI_SPANS;
+			process.env.N8N_OTEL_TRACES_INCLUDE_AI_SPANS = 'false';
+
+			try {
+				const result = getTracingConfig(mockContext);
+				expect(result.callbacks).toBeUndefined();
+			} finally {
+				if (originalEnv === undefined) {
+					delete process.env.N8N_OTEL_TRACES_INCLUDE_AI_SPANS;
+				} else {
+					process.env.N8N_OTEL_TRACES_INCLUDE_AI_SPANS = originalEnv;
+				}
+				getActiveSpanSpy.mockRestore();
+			}
+		});
 	});
 
 	describe('edge cases', () => {

--- a/packages/@n8n/nodes-langchain/utils/tracing.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/tracing.test.ts
@@ -1,12 +1,21 @@
 import type { CallbackManager } from '@langchain/core/callbacks/manager';
-import { trace } from '@opentelemetry/api';
+import { propagation } from '@opentelemetry/api';
+import { W3CTraceContextPropagator } from '@opentelemetry/core';
 import type { IExecuteFunctions, ISupplyDataFunctions } from 'n8n-workflow';
+import { afterAll, beforeAll } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
 import { OtelAiCallbackHandler } from './otel-ai-callback-handler';
 import { buildTracingMetadata, getTracingConfig } from './tracing';
 
 describe('getTracingConfig', () => {
+	beforeAll(() => {
+		propagation.setGlobalPropagator(new W3CTraceContextPropagator());
+	});
+
+	afterAll(() => {
+		propagation.disable();
+	});
 	const mockWorkflow = {
 		id: 'workflow-123',
 		name: 'Test Workflow',
@@ -131,55 +140,48 @@ describe('getTracingConfig', () => {
 	});
 
 	describe('OTEL integration', () => {
-		it('should not include OTEL handler when no active span exists', () => {
+		it('should not include OTEL handler when getOtelTraceparent returns undefined', () => {
 			const mockContext = mock<IExecuteFunctions>();
 			mockContext.getWorkflow.mockReturnValue(mockWorkflow);
 			mockContext.getNode.mockReturnValue(mockNode as ReturnType<IExecuteFunctions['getNode']>);
 			mockContext.getExecutionId.mockReturnValue('exec-456');
 			mockContext.getParentCallbackManager.mockReturnValue(undefined);
-
-			// No OTEL SDK registered = trace.getActiveSpan() returns undefined
-			expect(trace.getActiveSpan()).toBeUndefined();
+			mockContext.getOtelTraceparent.mockReturnValue(undefined);
 
 			const result = getTracingConfig(mockContext);
 
-			// callbacks should be undefined (no parent callback manager, no OTEL)
 			expect(result.callbacks).toBeUndefined();
 		});
 
-		it('should include OTEL handler alongside parent callback manager when active span exists', () => {
+		it('should include OTEL handler alongside parent callback manager when traceparent exists', () => {
 			const mockCallbackManager = mock<CallbackManager>();
 			const mockContext = mock<IExecuteFunctions>();
 			mockContext.getWorkflow.mockReturnValue(mockWorkflow);
 			mockContext.getNode.mockReturnValue(mockNode as ReturnType<IExecuteFunctions['getNode']>);
 			mockContext.getExecutionId.mockReturnValue('exec-456');
 			mockContext.getParentCallbackManager.mockReturnValue(mockCallbackManager);
-
-			// Mock trace.getActiveSpan to return a span
-			const mockSpan = { spanContext: () => ({ traceId: 'abc', spanId: '123' }) };
-			const getActiveSpanSpy = vi.spyOn(trace, 'getActiveSpan').mockReturnValue(mockSpan as any);
+			mockContext.getOtelTraceparent.mockReturnValue({
+				traceparent: '00-abcdef1234567890abcdef1234567890-1234567890abcdef-01',
+			});
 
 			const result = getTracingConfig(mockContext);
 
-			// callbacks should be an array with parent manager and OTEL handler
 			expect(Array.isArray(result.callbacks)).toBe(true);
 			const callbacksArray = result.callbacks as unknown[];
 			expect(callbacksArray).toHaveLength(2);
 			expect(callbacksArray[0]).toBe(mockCallbackManager);
 			expect(callbacksArray[1]).toBeInstanceOf(OtelAiCallbackHandler);
-
-			getActiveSpanSpy.mockRestore();
 		});
 
-		it('should include only OTEL handler when active span exists but no parent callback manager', () => {
+		it('should include only OTEL handler when traceparent exists but no parent callback manager', () => {
 			const mockContext = mock<IExecuteFunctions>();
 			mockContext.getWorkflow.mockReturnValue(mockWorkflow);
 			mockContext.getNode.mockReturnValue(mockNode as ReturnType<IExecuteFunctions['getNode']>);
 			mockContext.getExecutionId.mockReturnValue('exec-456');
 			mockContext.getParentCallbackManager.mockReturnValue(undefined);
-
-			const mockSpan = { spanContext: () => ({ traceId: 'abc', spanId: '123' }) };
-			const getActiveSpanSpy = vi.spyOn(trace, 'getActiveSpan').mockReturnValue(mockSpan as any);
+			mockContext.getOtelTraceparent.mockReturnValue({
+				traceparent: '00-abcdef1234567890abcdef1234567890-1234567890abcdef-01',
+			});
 
 			const result = getTracingConfig(mockContext);
 
@@ -187,8 +189,6 @@ describe('getTracingConfig', () => {
 			const callbacksArray = result.callbacks as unknown[];
 			expect(callbacksArray).toHaveLength(1);
 			expect(callbacksArray[0]).toBeInstanceOf(OtelAiCallbackHandler);
-
-			getActiveSpanSpy.mockRestore();
 		});
 
 		it('should not include OTEL handler when N8N_OTEL_TRACES_INCLUDE_AI_SPANS is false', () => {
@@ -197,9 +197,9 @@ describe('getTracingConfig', () => {
 			mockContext.getNode.mockReturnValue(mockNode as ReturnType<IExecuteFunctions['getNode']>);
 			mockContext.getExecutionId.mockReturnValue('exec-456');
 			mockContext.getParentCallbackManager.mockReturnValue(undefined);
-
-			const mockSpan = { spanContext: () => ({ traceId: 'abc', spanId: '123' }) };
-			const getActiveSpanSpy = vi.spyOn(trace, 'getActiveSpan').mockReturnValue(mockSpan as any);
+			mockContext.getOtelTraceparent.mockReturnValue({
+				traceparent: '00-abcdef1234567890abcdef1234567890-1234567890abcdef-01',
+			});
 
 			const originalEnv = process.env.N8N_OTEL_TRACES_INCLUDE_AI_SPANS;
 			process.env.N8N_OTEL_TRACES_INCLUDE_AI_SPANS = 'false';
@@ -213,7 +213,6 @@ describe('getTracingConfig', () => {
 				} else {
 					process.env.N8N_OTEL_TRACES_INCLUDE_AI_SPANS = originalEnv;
 				}
-				getActiveSpanSpy.mockRestore();
 			}
 		});
 	});

--- a/packages/@n8n/nodes-langchain/utils/tracing.ts
+++ b/packages/@n8n/nodes-langchain/utils/tracing.ts
@@ -1,6 +1,9 @@
-import type { BaseCallbackConfig } from '@langchain/core/callbacks/manager';
+import type { BaseCallbackConfig, Callbacks } from '@langchain/core/callbacks/manager';
+import { trace } from '@opentelemetry/api';
 import type { FieldType, IExecuteFunctions, ISupplyDataFunctions, Logger } from 'n8n-workflow';
 import { jsonParse, validateFieldType } from 'n8n-workflow';
+
+import { OtelAiCallbackHandler } from './otel-ai-callback-handler';
 
 interface TracingConfig {
 	additionalMetadata?: Record<string, unknown>;
@@ -89,6 +92,16 @@ export function getTracingConfig(
 			? context.getParentCallbackManager()
 			: undefined;
 
+	// Build callbacks array, including OTEL handler when an active span exists
+	// (indicating OTEL is enabled and the node is being traced).
+	// When OTEL is not configured, trace.getActiveSpan() returns undefined and no handler is added.
+	let callbacks: Callbacks | undefined = parentRunManager;
+	const activeSpan = trace.getActiveSpan();
+	if (activeSpan) {
+		const otelHandler = new OtelAiCallbackHandler(activeSpan);
+		callbacks = parentRunManager ? [parentRunManager, otelHandler] : [otelHandler];
+	}
+
 	return {
 		runName: `[${context.getWorkflow().name}] ${context.getNode().name}`,
 		metadata: {
@@ -97,6 +110,6 @@ export function getTracingConfig(
 			node: context.getNode().name,
 			...(config.additionalMetadata ?? {}),
 		},
-		callbacks: parentRunManager,
+		callbacks,
 	};
 }

--- a/packages/@n8n/nodes-langchain/utils/tracing.ts
+++ b/packages/@n8n/nodes-langchain/utils/tracing.ts
@@ -95,8 +95,10 @@ export function getTracingConfig(
 	// Build callbacks array, including OTEL handler when an active span exists
 	// (indicating OTEL is enabled and the node is being traced).
 	// When OTEL is not configured, trace.getActiveSpan() returns undefined and no handler is added.
+	// The N8N_OTEL_TRACES_INCLUDE_AI_SPANS env var (default: true) allows explicit opt-out.
 	let callbacks: Callbacks | undefined = parentRunManager;
-	const activeSpan = trace.getActiveSpan();
+	const includeAiSpans = process.env.N8N_OTEL_TRACES_INCLUDE_AI_SPANS !== 'false';
+	const activeSpan = includeAiSpans ? trace.getActiveSpan() : undefined;
 	if (activeSpan) {
 		const otelHandler = new OtelAiCallbackHandler(activeSpan);
 		callbacks = parentRunManager ? [parentRunManager, otelHandler] : [otelHandler];

--- a/packages/@n8n/nodes-langchain/utils/tracing.ts
+++ b/packages/@n8n/nodes-langchain/utils/tracing.ts
@@ -1,5 +1,5 @@
 import type { BaseCallbackConfig, Callbacks } from '@langchain/core/callbacks/manager';
-import { trace } from '@opentelemetry/api';
+import { propagation, context as otelContext, trace } from '@opentelemetry/api';
 import type { FieldType, IExecuteFunctions, ISupplyDataFunctions, Logger } from 'n8n-workflow';
 import { jsonParse, validateFieldType } from 'n8n-workflow';
 
@@ -92,16 +92,21 @@ export function getTracingConfig(
 			? context.getParentCallbackManager()
 			: undefined;
 
-	// Build callbacks array, including OTEL handler when an active span exists
-	// (indicating OTEL is enabled and the node is being traced).
-	// When OTEL is not configured, trace.getActiveSpan() returns undefined and no handler is added.
+	// Build callbacks array, including OTEL handler when the node has an active OTEL span.
+	// We retrieve the span's traceparent via getOtelTraceparent() (available on IExecuteFunctions)
+	// and reconstruct a remote span context from it. This is necessary because the node execution
+	// doesn't run within the span's async context — spans are managed externally by lifecycle hooks.
 	// The N8N_OTEL_TRACES_INCLUDE_AI_SPANS env var (default: true) allows explicit opt-out.
 	let callbacks: Callbacks | undefined = parentRunManager;
 	const includeAiSpans = process.env.N8N_OTEL_TRACES_INCLUDE_AI_SPANS !== 'false';
-	const activeSpan = includeAiSpans ? trace.getActiveSpan() : undefined;
-	if (activeSpan) {
-		const otelHandler = new OtelAiCallbackHandler(activeSpan);
-		callbacks = parentRunManager ? [parentRunManager, otelHandler] : [otelHandler];
+	if (includeAiSpans && 'getOtelTraceparent' in context) {
+		const traceparent = (context as IExecuteFunctions).getOtelTraceparent();
+		if (traceparent) {
+			const parentCtx = propagation.extract(otelContext.active(), traceparent);
+			const parentSpan = trace.getSpan(parentCtx);
+			const otelHandler = new OtelAiCallbackHandler(parentSpan);
+			callbacks = parentRunManager ? [parentRunManager, otelHandler] : [otelHandler];
+		}
 	}
 
 	return {

--- a/packages/cli/src/modules/otel/execution-level-tracer.ts
+++ b/packages/cli/src/modules/otel/execution-level-tracer.ts
@@ -196,6 +196,20 @@ export class ExecutionLevelTracer {
 		}
 	}
 
+	getNodeTraceparent(
+		executionId: string,
+		nodeName: string,
+	): { traceparent: string; tracestate?: string } | undefined {
+		const span = this.findMostSpecificSpan(executionId, nodeName);
+		if (!span) return undefined;
+
+		const carrier: Record<string, string> = {};
+		propagation.inject(trace.setSpan(context.active(), span), carrier);
+		if (!carrier.traceparent) return undefined;
+
+		return { traceparent: carrier.traceparent, tracestate: carrier.tracestate };
+	}
+
 	private parseTraceParentHeaders(tracingContext?: TracingContext) {
 		return tracingContext
 			? propagation.extract(context.active(), tracingContext)

--- a/packages/cli/src/modules/otel/otel.config.ts
+++ b/packages/cli/src/modules/otel/otel.config.ts
@@ -28,4 +28,7 @@ export class OtelConfig {
 
 	@Env('N8N_OTEL_TRACES_INJECT_OUTBOUND')
 	injectOutbound: boolean = true;
+
+	@Env('N8N_OTEL_TRACES_INCLUDE_AI_SPANS')
+	includeAiSpans: boolean = true;
 }

--- a/packages/cli/src/modules/otel/otel.module.ts
+++ b/packages/cli/src/modules/otel/otel.module.ts
@@ -29,7 +29,6 @@ export class OtelModule implements ModuleInterface {
 
 		return {
 			injectTraceHeaders: tracer.injectTraceHeaders.bind(tracer),
-			includeAiSpans: config.includeAiSpans,
 		};
 	}
 

--- a/packages/cli/src/modules/otel/otel.module.ts
+++ b/packages/cli/src/modules/otel/otel.module.ts
@@ -29,6 +29,7 @@ export class OtelModule implements ModuleInterface {
 
 		return {
 			injectTraceHeaders: tracer.injectTraceHeaders.bind(tracer),
+			includeAiSpans: config.includeAiSpans,
 		};
 	}
 

--- a/packages/cli/src/modules/otel/otel.module.ts
+++ b/packages/cli/src/modules/otel/otel.module.ts
@@ -29,6 +29,7 @@ export class OtelModule implements ModuleInterface {
 
 		return {
 			injectTraceHeaders: tracer.injectTraceHeaders.bind(tracer),
+			getNodeTraceparent: tracer.getNodeTraceparent.bind(tracer),
 		};
 	}
 

--- a/packages/core/src/execution-engine/node-execution-context/execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/execute-context.ts
@@ -242,6 +242,13 @@ export class ExecuteContext extends BaseExecuteContext implements IExecuteFuncti
 		return this.additionalData.parentCallbackManager;
 	}
 
+	getOtelTraceparent(): { traceparent: string; tracestate?: string } | undefined {
+		return this.additionalData.otel?.getNodeTraceparent?.(
+			this.additionalData.executionId!,
+			this.node.name,
+		);
+	}
+
 	addExecutionHints(...hints: NodeExecutionHint[]) {
 		this.hints.push(...hints);
 	}

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1152,6 +1152,7 @@ export type IExecuteFunctions = ExecuteFunctions.GetNodeParameterFn &
 			};
 
 		getParentCallbackManager(): CallbackManager | undefined;
+		getOtelTraceparent(): { traceparent: string; tracestate?: string } | undefined;
 
 		startJob<T = unknown, E = unknown>(
 			jobType: string,
@@ -3161,6 +3162,10 @@ export interface IWorkflowExecuteAdditionalData {
 			nodeName: string | undefined,
 			headers: Record<string, string>,
 		) => void;
+		getNodeTraceparent?: (
+			executionId: string,
+			nodeName: string,
+		) => { traceparent: string; tracestate?: string } | undefined;
 	};
 }
 

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -3161,6 +3161,7 @@ export interface IWorkflowExecuteAdditionalData {
 			nodeName: string | undefined,
 			headers: Record<string, string>,
 		) => void;
+		includeAiSpans?: boolean;
 	};
 }
 

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -3161,7 +3161,6 @@ export interface IWorkflowExecuteAdditionalData {
 			nodeName: string | undefined,
 			headers: Record<string, string>,
 		) => void;
-		includeAiSpans?: boolean;
 	};
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2064,6 +2064,9 @@ importers:
       '@n8n/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
       '@pinecone-database/pinecone':
         specifier: ^5.0.2
         version: 5.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -818,7 +818,7 @@ importers:
         version: link:../vitest-config
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1)
+        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       vitest:
         specifier: 'catalog:'
         version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(@vitest/browser-playwright@4.0.16)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
@@ -992,7 +992,7 @@ importers:
         version: link:../vitest-config
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1)
+        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       vitest:
         specifier: 'catalog:'
         version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(@vitest/browser-playwright@4.0.16)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
@@ -1720,7 +1720,7 @@ importers:
         version: 7.0.15
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1)
+        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       vitest:
         specifier: 'catalog:'
         version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(@vitest/browser-playwright@4.0.16)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
@@ -2182,6 +2182,12 @@ importers:
       '@n8n/vitest-config':
         specifier: workspace:*
         version: link:../vitest-config
+      '@opentelemetry/core':
+        specifier: ^2.0.0
+        version: 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node':
+        specifier: ^2.6.0
+        version: 2.6.0(@opentelemetry/api@1.9.0)
       '@types/basic-auth':
         specifier: 'catalog:'
         version: 1.1.3
@@ -2208,7 +2214,7 @@ importers:
         version: 0.9.4
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1)
+        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       fast-glob:
         specifier: 'catalog:'
         version: 3.2.12
@@ -2236,7 +2242,7 @@ importers:
         version: link:../vitest-config
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1)
+        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       vitest:
         specifier: 'catalog:'
         version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(@vitest/browser-playwright@4.0.16)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
@@ -2301,7 +2307,7 @@ importers:
         version: link:../vitest-config
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1)
+        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       rimraf:
         specifier: 'catalog:'
         version: 6.0.1
@@ -2394,7 +2400,7 @@ importers:
         version: 20.19.21
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1)
+        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       nodemon:
         specifier: ^2.0.20
         version: 2.0.22
@@ -3192,7 +3198,7 @@ importers:
         version: 5.2.4(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))(vue@3.5.26(typescript@6.0.2))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1)
+        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       unplugin-icons:
         specifier: ^0.19.0
         version: 0.19.0(@vue/compiler-sfc@3.5.26)
@@ -3632,7 +3638,7 @@ importers:
         version: 4.0.16(bufferutil@4.0.9)(playwright@1.58.0)(utf-8-validate@5.0.10)(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))(vitest@4.1.1)
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1)
+        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       '@vue/tsconfig':
         specifier: catalog:frontend
         version: 0.7.0(typescript@6.0.2)(vue@3.5.26(typescript@6.0.2))
@@ -3999,7 +4005,7 @@ importers:
         version: 5.2.4(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))(vue@3.5.26(typescript@6.0.2))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1)
+        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       browserslist-to-esbuild:
         specifier: ^2.1.1
         version: 2.1.1(browserslist@4.28.1)
@@ -4424,7 +4430,7 @@ importers:
         version: link:../../@n8n/vitest-config
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1)
+        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       fast-glob:
         specifier: 'catalog:'
         version: 3.2.12
@@ -4488,7 +4494,7 @@ importers:
         version: 20.19.21
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1)
+        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       ts-morph:
         specifier: 'catalog:'
         version: 27.0.2
@@ -4620,7 +4626,7 @@ importers:
         version: link:../../@n8n/vitest-config
       '@vitest/coverage-v8':
         specifier: 'catalog:'
-        version: 4.1.1(vitest@4.1.1)
+        version: 4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       tsx:
         specifier: 'catalog:'
         version: 4.19.3
@@ -32365,7 +32371,7 @@ snapshots:
       tinyrainbow: 3.0.3
       vitest: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.89.2)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
 
-  '@vitest/coverage-v8@4.1.1(vitest@4.1.1)':
+  '@vitest/coverage-v8@4.1.1(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.1


### PR DESCRIPTION

## PR: feat(ai): Export AI agent traces via OpenTelemetry

### Problem

When `N8N_OTEL_ENABLED=true`, only `workflow.execute` and `node.execute` spans are exported. The internal operations of AI agent nodes (LLM calls, tool invocations, chain reasoning steps) are invisible to OTEL — they only go to LangSmith/LangFuse via LangChain callbacks. Self-hosted users who rely on OTEL for observability have no way to trace what's happening inside their AI agents.

### Solution

Adds an `OtelAiCallbackHandler` — a LangChain `BaseCallbackHandler` that creates OTEL child spans for AI operations. When OTEL is enabled and a node is executing (active span exists), the handler is automatically included in the LangChain callback chain alongside any existing callbacks (like LangSmith).

### Span Hierarchy (After)

```
workflow.execute
  └─ node.execute (AI Agent)
       ├─ ai.chain.call (AgentExecutor)
       │    ├─ ai.llm.call (gpt-4)          ← NEW
       │    ├─ ai.tool.call (calculator)     ← NEW
       │    ├─ ai.llm.call (gpt-4)          ← NEW
       │    └─ ai.retriever.call (pinecone)  ← NEW
       └─ ...
```

### Span Types & Attributes

| Span | Key Attributes |
|------|---------------|
| `ai.llm.call` | `gen_ai.system`, `gen_ai.request.model`, `gen_ai.request.temperature`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens` |
| `ai.tool.call` | `n8n.ai.tool.name`, `n8n.ai.tool.input.length`, `n8n.ai.tool.output.length` |
| `ai.chain.call` | `n8n.ai.chain.type` |
| `ai.retriever.call` | `n8n.ai.retriever.type`, `n8n.ai.retriever.query.length`, `n8n.ai.retriever.document_count` |

### Configuration

| Env Var | Default | Description |
|---------|---------|-------------|
| `N8N_OTEL_TRACES_INCLUDE_AI_SPANS` | `true` | Opt-out flag to disable AI spans while keeping workflow/node spans |

### Design Decisions

- **Zero overhead when OTEL is disabled**: Uses `trace.getActiveSpan()` to detect OTEL presence. When no SDK is registered, the OTEL API returns no-op objects — no handler is created, no performance impact.
- **Proper parent-child nesting**: Uses `parentRunId` from LangChain callbacks to build correct span hierarchy (e.g., tool calls nested under the LLM call that invoked them).
- **Non-breaking**: Existing LangSmith/LangFuse tracing continues to work unchanged. The OTEL handler runs alongside other callbacks.
- **Follows OTEL semantic conventions**: Uses `gen_ai.*` attribute namespace per the [OpenTelemetry GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/).


### Files Changed

| File | Status | Description |
|------|--------|-------------|
| `packages/@n8n/nodes-langchain/utils/otel-ai-callback-handler.ts` | NEW | Core OTEL-LangChain bridge|
| `packages/@n8n/nodes-langchain/utils/otel-ai-callback-handler.test.ts` | NEW | 18 unit tests for the handler |
| `packages/@n8n/nodes-langchain/utils/tracing.ts` | MODIFIED | Integrates OTEL handler when active span detected |
| `packages/@n8n/nodes-langchain/utils/tracing.test.ts` | MODIFIED | 3 new OTEL integration tests |
| `packages/@n8n/nodes-langchain/package.json` | MODIFIED | Added `@opentelemetry/api` dep + test devDeps |
| `packages/cli/src/modules/otel/otel.config.ts` | MODIFIED | Added `N8N_OTEL_TRACES_INCLUDE_AI_SPANS` config flag |
| `packages/cli/src/modules/otel/otel.module.ts` | MODIFIED | Exposes `includeAiSpans` in module context |
| `packages/workflow/src/interfaces.ts` | MODIFIED | Added `includeAiSpans?: boolean` to otel interface |



### Testing

- All 26 existing tracing tests pass
- All 65 OTEL module tests pass
- Manually verified with Jaeger: AI spans appear nested correctly under node spans


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)