### PR TITLE
ci: Apply SafeChain @n8n/* exclusion to all setup-nodejs steps

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -54,13 +54,16 @@ runs:
         echo "${EXPECTED_SHA256}  install-safe-chain.sh" | sha256sum -c -
         sh install-safe-chain.sh --ci
         rm install-safe-chain.sh
+        # Exclude first-party @n8n/* packages from SafeChain's minimum-package-age
+        # filter so freshly-published versions stay visible to every subsequent
+        # step in the job (install, build, and publish).
+        echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS=@n8n/*" >> "$GITHUB_ENV"
       shell: bash
 
     - name: Install Dependencies
       if: ${{ inputs.install-command != '' }}
       env:
         INSTALL_COMMAND: ${{ inputs.install-command }}
-        SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS: '@n8n/*'
       run: |
         $INSTALL_COMMAND
       shell: bash


### PR DESCRIPTION
## Summary

Follow-up to #29881. That PR added `SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS: '@n8n/*'` directly on the `Install Dependencies` step's `env:` block, so the exclusion was scoped to that single step. Steps that run later in the same job — most importantly the publish steps in `release-publish.yml` — never saw the variable, and SafeChain 1.5.1 kept hiding recently-published `@n8n/*` versions from them.

That hiding broke `pnpm publish -r`. pnpm decides whether to skip a package by asking the registry which versions exist; with the freshly-published version filtered out, pnpm thought the version was new, called `PUT`, and npm rejected the duplicate upload:

```
npm error code E403
npm error 403 403 Forbidden - PUT https://registry.npmjs.org/@n8n%2fdesign-system
        - You cannot publish over the previously published versions: 2.20.0.
```

This PR moves the exclusion into a `\$GITHUB_ENV` export co-located with the SafeChain install, so it propagates to every subsequent step in the calling job — install, build, and publish — through a single source of truth. Same exclusion scope (`@n8n/*`) as #29881.

## Test plan

The failure repros on the `release/2.20.2` pipeline:
- ✅ Successful run on 2.19.3 (SafeChain 1.4.1, no minimum-age filter): https://github.com/n8n-io/n8n/actions/runs/25430054993/job/74593767500
- ❌ Failed run on 2.20.2 (SafeChain 1.5.1): https://github.com/n8n-io/n8n/actions/runs/25432157412/job/74601019718

After this change the publish steps inherit the exclusion and pnpm's "skip already-published" check sees the existing version and short-circuits, matching pre-1.5.1 behavior.

## Review / Merge checklist

- [x] PR title and summary are descriptive.
- [x] I have seen this code, I have run this code, and I take responsibility for this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)