### PR TITLE
fix(editor-ui): Fix ChatHub prompt background to surface token (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPromptFull.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPromptFull.vue
@@ -181,6 +181,7 @@ defineExpose({
 		color: var(--color--text--shade-1);
 		box-shadow: 0 10px 24px 0 #00000010;
 		border-radius: 16px;
+		background: var(--color--background--surface);
 
 		&::placeholder {
 			color: var(--color--text--tint-1);
@@ -208,7 +209,7 @@ defineExpose({
 	left: 1px;
 	width: calc(100% - 2px);
 	z-index: 10;
-	background: var(--color--background--light-2);
+	background: var(--color--background--surface);
 	border-radius: 16px;
 	pointer-events: none; /* click to focus textarea */
 


### PR DESCRIPTION
### Summary

Align the ChatHub prompt background with the surface token so the full input area renders consistently in dark mode.

* updated `ChatPromptFull.vue`
* changed the prompt textarea background to `var(--color--background--surface)`
* changed the prompt header and footer background from `var(--color--background--light-2)` to `var(--color--background--surface)`

| Before | After |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/a55cc33c-7eaa-43d7-9b5d-4d07a79f211b" alt="CleanShot 2026-05-06 at 15 36 57@2x" width="960" /> | <img width="1574" height="276" alt="CleanShot 2026-05-06 at 16 03 57@2x" src="https://github.com/user-attachments/assets/e45efeac-9e58-45a1-adca-56f974414954" /> |

### Linear ticket
[CHA-175](https://linear.app/n8n/issue/CHA-175)

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](<../blob/master/.github/pull_request_title_conventions.md>))
- [ ] [Docs updated](<https://github.com/n8n-io/n8n-docs>) or follow-up ticket created.
- [X] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)