### PR TITLE
fix(core): Add support for context establishment hooks in webhook mode

### DIFF
--- a/packages/cli/src/commands/__tests__/webhook.test.ts
+++ b/packages/cli/src/commands/__tests__/webhook.test.ts
@@ -1,13 +1,19 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import { DbConnection, DeploymentKeyRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
+import { BinaryDataConfig } from 'n8n-core';
 
+import { DeprecationService } from '@/deprecation/deprecation.service';
+import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
+import { LogStreamingEventRelay } from '@/events/relays/log-streaming.event-relay';
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import { PubSubRegistry } from '@/scaling/pubsub/pubsub.registry';
 import { Subscriber } from '@/scaling/pubsub/subscriber.service';
+import { JwtService } from '@/services/jwt.service';
 import { RedisClientService } from '@/services/redis-client.service';
 import { WebhookServer } from '@/webhooks/webhook-server';
 
+import { BaseCommand } from '../base-command';
 import { Webhook } from '../webhook';
 
 jest.mock('@/scaling/scaling.service', () => ({
@@ -26,7 +32,14 @@ mockInstance(RedisClientService);
 mockInstance(PubSubRegistry);
 const mockSubscriber = mockInstance(Subscriber);
 const mockWebhookServer = mockInstance(WebhookServer);
-mockInstance(LoadNodesAndCredentials);
+const mockLoadNodesAndCredentials = mockInstance(LoadNodesAndCredentials);
+mockLoadNodesAndCredentials.postProcessLoaders.mockResolvedValue(undefined);
+
+mockInstance(DeprecationService);
+mockInstance(JwtService, { initialize: jest.fn().mockResolvedValue(undefined) });
+mockInstance(BinaryDataConfig, { initialize: jest.fn().mockResolvedValue(undefined) });
+mockInstance(MessageEventBus, { initialize: jest.fn().mockResolvedValue(undefined) });
+mockInstance(LogStreamingEventRelay);
 
 describe('Webhook', () => {
 	beforeEach(() => {
@@ -72,6 +85,59 @@ describe('Webhook', () => {
 
 			expect(mockWebhookServer.start).toHaveBeenCalled();
 			expect(mockWebhookServer.markAsReady).toHaveBeenCalled();
+		});
+	});
+
+	describe('init', () => {
+		let baseInitSpy: jest.SpyInstance;
+
+		beforeEach(() => {
+			baseInitSpy = jest.spyOn(BaseCommand.prototype, 'init').mockResolvedValue(undefined);
+		});
+
+		afterEach(() => {
+			baseInitSpy.mockRestore();
+		});
+
+		it('should call executionContextHookRegistry.init before LoadNodesAndCredentials.postProcessLoaders', async () => {
+			const webhook = new Webhook();
+
+			// @ts-expect-error - Accessing protected property for testing
+			webhook.globalConfig = { executions: { mode: 'queue' } };
+			// @ts-expect-error - Accessing protected method for testing
+			webhook.initCrashJournal = jest.fn().mockResolvedValue(undefined);
+			webhook.initLicense = jest.fn().mockResolvedValue(undefined);
+			// @ts-expect-error - Accessing protected method for testing
+			webhook.initCommunityPackages = jest.fn().mockResolvedValue(undefined);
+			webhook.initOrchestration = jest.fn().mockResolvedValue(undefined);
+			webhook.initBinaryDataService = jest.fn().mockResolvedValue(undefined);
+			// @ts-expect-error - Accessing protected method for testing
+			webhook.initDataDeduplicationService = jest.fn().mockResolvedValue(undefined);
+			webhook.initExternalHooks = jest.fn().mockResolvedValue(undefined);
+			// @ts-expect-error - Accessing protected property for testing
+			webhook.moduleRegistry = { initModules: jest.fn().mockResolvedValue(undefined) };
+			// @ts-expect-error - Accessing protected property for testing
+			webhook.instanceSettings = {
+				hostId: 'test',
+				instanceType: 'webhook',
+				initialize: jest.fn().mockResolvedValue(undefined),
+			};
+			// @ts-expect-error - Accessing protected property for testing
+			webhook.executionContextHookRegistry = {
+				init: jest.fn().mockResolvedValue(undefined),
+			};
+
+			await webhook.init();
+
+			// @ts-expect-error - Accessing protected property for testing
+			const hookInitMock = webhook.executionContextHookRegistry.init as jest.Mock;
+			const postProcessMock = mockLoadNodesAndCredentials.postProcessLoaders as jest.Mock;
+
+			expect(hookInitMock).toHaveBeenCalled();
+			expect(postProcessMock).toHaveBeenCalled();
+			expect(hookInitMock.mock.invocationCallOrder[0]).toBeLessThan(
+				postProcessMock.mock.invocationCallOrder[0],
+			);
 		});
 	});
 });

--- a/packages/cli/src/commands/webhook.ts
+++ b/packages/cli/src/commands/webhook.ts
@@ -92,6 +92,9 @@ export class Webhook extends BaseCommand {
 		Container.get(LogStreamingEventRelay).init();
 
 		await this.moduleRegistry.initModules(this.instanceSettings.instanceType);
+
+		await this.executionContextHookRegistry.init();
+		await Container.get(LoadNodesAndCredentials).postProcessLoaders();
 	}
 
 	async run() {


### PR DESCRIPTION
## Summary

In webhook mode the node definitions are not patched at bootup with the discovered extractors. So when a webhook trigger is handled in the webhook mode, the generated workflow definition has its set up extractor hooks removed.

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
