### PR TITLE
fix(core): Allow GIT_SSH_COMMAND in simple-git after 3.36.0 upgrade

### DIFF
--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-git.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-git.service.test.ts
@@ -366,9 +366,15 @@ describe('SourceControlGitService', () => {
 			mockSourceControlPreferencesService.getPreferences.mockReturnValue({
 				connectionType: 'ssh',
 			} as never);
+			(simpleGit as jest.Mock).mockClear();
 
 			await sourceControlGitService.setGitCommand();
 
+			expect(simpleGit).toHaveBeenCalledWith(
+				expect.objectContaining({
+					unsafe: { allowUnsafeSshCommand: true },
+				}),
+			);
 			expect(mockGitInstance.env).toHaveBeenCalledWith(
 				'GIT_SSH_COMMAND',
 				'ssh -o UserKnownHostsFile=".ssh/known_hosts" -o StrictHostKeyChecking=accept-new -i "private-key"',

--- a/packages/cli/src/modules/source-control.ee/source-control-git.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-git.service.ee.ts
@@ -171,7 +171,12 @@ export class SourceControlGitService {
 			// - Subsequent connections: verifies against saved key
 			const sshCommand = `ssh -o UserKnownHostsFile="${escapedKnownHostsPath}" -o StrictHostKeyChecking=accept-new -i "${escapedPrivateKeyPath}"`;
 
-			this.git = simpleGit(this.gitOptions)
+			// Allow GIT_SSH_COMMAND so we can point SSH at n8n's own private key and known_hosts.
+			// This is safe because the command is constructed internally above, not from user input.
+			this.git = simpleGit({
+				...this.gitOptions,
+				unsafe: { allowUnsafeSshCommand: true },
+			})
 				.env('GIT_SSH_COMMAND', sshCommand)
 				.env('GIT_TERMINAL_PROMPT', '0');
 		}


### PR DESCRIPTION
## Summary

https://github.com/n8n-io/n8n/pull/29834 bumped `simple-git` to 3.36.0 which blocks `GIT_SSH_COMMAND` by default as a security hardening measure. This broke n8n startup when source control is configured with an SSH connection.                                                
                                                                                                                                                              
This PR adds `allowUnsafeSshCommand: true` to opt in to the `GIT_SSH_COMMAND` usage. This is safe because the SSH command is constructed internally from n8n-managed paths, not from user input.

Also adds a test assertion to catch this if the option is ever removed.

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-5184](https://linear.app/n8n/issue/ADO-5184/bug-app-crashes-when-git-is-connected-to-the-instance)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
