### PR TITLE
fix(core): Initialise encryption key proxy on worker and webhook instances

### DIFF
--- a/packages/cli/src/modules/encryption-key-manager/__tests__/encryption-bootstrap.service.integration.test.ts
+++ b/packages/cli/src/modules/encryption-key-manager/__tests__/encryption-bootstrap.service.integration.test.ts
@@ -11,6 +11,7 @@ beforeAll(async () => {
 	mockInstance(InstanceSettings, {
 		encryptionKey: INSTANCE_ENCRYPTION_KEY,
 		n8nFolder: '/tmp/n8n-test',
+		instanceType: 'main',
 	});
 	await testDb.init();
 });

--- a/packages/cli/src/modules/encryption-key-manager/__tests__/encryption-bootstrap.service.test.ts
+++ b/packages/cli/src/modules/encryption-key-manager/__tests__/encryption-bootstrap.service.test.ts
@@ -14,10 +14,10 @@ describe('EncryptionBootstrapService', () => {
 		keyManager.bootstrapGcmKey.mockResolvedValue(undefined);
 	});
 
-	const createService = () =>
+	const createService = (instanceType: InstanceSettings['instanceType'] = 'main') =>
 		new EncryptionBootstrapService(
 			keyManager,
-			mockInstance(InstanceSettings, { encryptionKey: 'test-instance-key' }),
+			mockInstance(InstanceSettings, { encryptionKey: 'test-instance-key', instanceType }),
 			encryptionKeyProxy,
 			mockLogger(),
 		);
@@ -38,6 +38,17 @@ describe('EncryptionBootstrapService', () => {
 		await createService().run();
 
 		expect(encryptionKeyProxy.setProvider).toHaveBeenCalledWith(keyManager);
+	});
+
+	it('skips key creation on non-main instances but still sets the provider', async () => {
+		for (const instanceType of ['worker', 'webhook'] as const) {
+			jest.clearAllMocks();
+			await createService(instanceType).run();
+
+			expect(keyManager.bootstrapLegacyCbcKey).not.toHaveBeenCalled();
+			expect(keyManager.bootstrapGcmKey).not.toHaveBeenCalled();
+			expect(encryptionKeyProxy.setProvider).toHaveBeenCalledWith(keyManager);
+		}
 	});
 
 	it('bootstraps CBC before GCM', async () => {

--- a/packages/cli/src/modules/encryption-key-manager/encryption-bootstrap.service.ts
+++ b/packages/cli/src/modules/encryption-key-manager/encryption-bootstrap.service.ts
@@ -16,8 +16,10 @@ export class EncryptionBootstrapService {
 	}
 
 	async run(): Promise<void> {
-		await this.keyManager.bootstrapLegacyCbcKey(this.instanceSettings.encryptionKey);
-		await this.keyManager.bootstrapGcmKey();
+		if (this.instanceSettings.instanceType === 'main') {
+			await this.keyManager.bootstrapLegacyCbcKey(this.instanceSettings.encryptionKey);
+			await this.keyManager.bootstrapGcmKey();
+		}
 		this.encryptionKeyProxy.setProvider(this.keyManager);
 		this.logger.debug('Encryption key bootstrap complete');
 	}

--- a/packages/cli/src/modules/encryption-key-manager/encryption-key-manager.module.ts
+++ b/packages/cli/src/modules/encryption-key-manager/encryption-key-manager.module.ts
@@ -1,17 +1,20 @@
 import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule } from '@n8n/decorators';
 import { Container } from '@n8n/di';
+import { InstanceSettings } from 'n8n-core';
 
 function isKeyRotationApiEnabled(): boolean {
 	return process.env.N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION === 'true';
 }
 
-@BackendModule({ name: 'encryption-key-manager', instanceTypes: ['main'] })
+@BackendModule({ name: 'encryption-key-manager' })
 export class EncryptionKeyManagerModule implements ModuleInterface {
 	async init() {
 		if (isKeyRotationApiEnabled()) {
 			await import('./key-manager.service');
-			await import('./encryption-key.controller');
+			if (Container.get(InstanceSettings).instanceType === 'main') {
+				await import('./encryption-key.controller');
+			}
 			const { EncryptionBootstrapService } = await import('./encryption-bootstrap.service');
 			await Container.get(EncryptionBootstrapService).run();
 		}


### PR DESCRIPTION
## Summary

When `N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION=true`, the `EncryptionKeyManagerModule` was restricted to `main` instances only. As a result, `EncryptionKeyProxy.setProvider()` was never called on worker or webhook instances, so `isConfigured()` always returned `false` and those instances silently fell back to legacy CBC decryption — meaning they could not decrypt GCM-encrypted credentials.

This fix removes the `instanceTypes` restriction from the module so it loads on all instance types. Key creation (bootstrapping) is guarded to `main` only — workers and webhooks only wire up the provider so they can read existing keys from the database.

**Before:** Workers and webhook instances always used the legacy CBC path, failing to decrypt credentials encrypted with the active GCM DEK.

**After:** Workers and webhook instances initialise the key proxy on startup and correctly decrypt GCM-encrypted credentials using the existing DEKs in `deployment_key`.

### Changes

- `encryption-key-manager.module.ts` — removed `instanceTypes: ['main']` restriction; controller import guarded to `main` only
- `encryption-bootstrap.service.ts` — key creation (`bootstrapLegacyCbcKey` / `bootstrapGcmKey`) guarded to `main` only; `setProvider()` runs on all instance types

### How to test

1. Start n8n in queue mode with `N8N_ENV_FEAT_ENCRYPTION_KEY_ROTATION=true` (main + worker).
2. Create a credential via the main — confirm `credentials_entity.data` has a UUID prefix (GCM-encrypted).
3. Run a workflow on the worker that uses that credential — it should decrypt successfully.
4. Confirm worker logs show `Encryption key bootstrap complete`.
5. Confirm no new rows appear in `deployment_key` after the worker starts (key creation skipped).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
