### PR TITLE
fix(core): Stop agent builder from hallucinating LLM model ids (no-changelog)

### DIFF
--- a/packages/cli/src/modules/agents/__tests__/agents-builder-tools.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-builder-tools.service.test.ts
@@ -1,6 +1,6 @@
 import type { CredentialProvider } from '@n8n/agents';
 import { AGENT_SKILL_INSTRUCTIONS_MAX_LENGTH } from '@n8n/api-types';
-import type { WorkflowRepository } from '@n8n/db';
+import type { User, WorkflowRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 
 import type { AgentsToolsService } from '../agents-tools.service';
@@ -9,6 +9,7 @@ import {
 	AgentsBuilderToolsService,
 	getAgentConfigHash,
 } from '../builder/agents-builder-tools.service';
+import type { BuilderModelLookupService } from '../builder/builder-model-lookup.service';
 import { BUILDER_TOOLS } from '../builder/builder-tool-names';
 import type { Agent } from '../entities/agent.entity';
 import type { AgentJsonConfig } from '../json-config/agent-json-config';
@@ -25,6 +26,7 @@ function makeService() {
 	const secureRuntime = mock<AgentSecureRuntime>();
 	const workflowRepository = mock<WorkflowRepository>();
 	const agentsToolsService = mock<AgentsToolsService>();
+	const builderModelLookupService = mock<BuilderModelLookupService>();
 	agentsToolsService.getSharedTools.mockReturnValue([]);
 
 	const service = new AgentsBuilderToolsService(
@@ -32,6 +34,7 @@ function makeService() {
 		secureRuntime,
 		workflowRepository,
 		agentsToolsService,
+		builderModelLookupService,
 	);
 
 	return { service, agentsService, secureRuntime };
@@ -61,6 +64,7 @@ describe('AgentsBuilderToolsService', () => {
 	const agentId = 'agent-1';
 	const projectId = 'project-1';
 	const credentialProvider = mock<CredentialProvider>();
+	const user = mock<User>();
 
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -69,7 +73,7 @@ describe('AgentsBuilderToolsService', () => {
 	describe('JSON config tools', () => {
 		function getJsonTool(service: AgentsBuilderToolsService, name: string) {
 			return service
-				.getTools(agentId, projectId, credentialProvider)
+				.getTools(agentId, projectId, credentialProvider, user)
 				.json.find((tool) => tool.name === name)!;
 		}
 
@@ -205,7 +209,7 @@ describe('AgentsBuilderToolsService', () => {
 	describe('build_custom_tool tool', () => {
 		function getBuildCustomTool(service: AgentsBuilderToolsService) {
 			return service
-				.getTools(agentId, projectId, credentialProvider)
+				.getTools(agentId, projectId, credentialProvider, user)
 				.shared.find((tool) => tool.name === BUILDER_TOOLS.BUILD_CUSTOM_TOOL)!;
 		}
 
@@ -252,7 +256,7 @@ describe('AgentsBuilderToolsService', () => {
 	describe('create_skill tool', () => {
 		function getCreateSkillTool(service: AgentsBuilderToolsService) {
 			return service
-				.getTools(agentId, projectId, credentialProvider)
+				.getTools(agentId, projectId, credentialProvider, user)
 				.shared.find((tool) => tool.name === BUILDER_TOOLS.CREATE_SKILL)!;
 		}
 

--- a/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
@@ -202,10 +202,23 @@ Inputs: optional \`provider\`, optional \`model\`.
   \`"anthropic/claude-sonnet-4.6"\`.
 
 On \`{ ok: true, provider, model, credentialId, credentialName }\`: set
-\`model = "{provider}/{model}"\` and \`credential = credentialName\`.
+\`model = "{provider}/{model}"\` and \`credential = credentialName\`. The
+returned \`model\` is the canonical id resolved against the provider's live
+list, so use it as-is — do not transform or "correct" it.
 
 On \`ok: false\`: use ask_llm only when the user needs to choose/configure a
 credential or model. Do not guess credential names from list_credentials.
+Failure reasons:
+- \`missing_credential\` / \`ambiguous_credential\` / \`ambiguous_provider_or_credential\` →
+  fall through to ask_llm so the user picks.
+- \`unknown_model\` → the response includes \`availableModels: [{ name, value }]\`
+  (or a narrowed candidate list when the user's hint matched several). Pick
+  the entry that best matches what the user named and re-call resolve_llm
+  with \`model\` set to that exact \`value\`. Only fall through to ask_llm if
+  no entry plausibly matches the user's intent.
+- \`model_lookup_failed\` (the live list could not be fetched, e.g. invalid
+  credentials) → fall through to ask_llm.
+- \`unsupported_provider\` → ask_llm.
 
 Rules:
 - Explicit provider/model request → resolve_llm first, not ask_llm.

--- a/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
@@ -206,19 +206,19 @@ On \`{ ok: true, provider, model, credentialId, credentialName }\`: set
 returned \`model\` is the canonical id resolved against the provider's live
 list, so use it as-is — do not transform or "correct" it.
 
-On \`ok: false\`: use ask_llm only when the user needs to choose/configure a
-credential or model. Do not guess credential names from list_credentials.
-Failure reasons:
+On \`ok: false\`: your NEXT action is another tool call — never reply with
+plain text asking the user to clarify. Do not guess credential names from
+list_credentials. Pick the action by reason:
 - \`missing_credential\` / \`ambiguous_credential\` / \`ambiguous_provider_or_credential\` →
-  fall through to ask_llm so the user picks.
+  call ask_llm (the picker handles credential selection).
 - \`unknown_model\` → the response includes \`availableModels: [{ name, value }]\`
-  (or a narrowed candidate list when the user's hint matched several). Pick
-  the entry that best matches what the user named and re-call resolve_llm
-  with \`model\` set to that exact \`value\`. Only fall through to ask_llm if
-  no entry plausibly matches the user's intent.
+  (or a narrowed candidate list when the user's hint matched several). If
+  one entry plausibly matches what the user named, re-call resolve_llm
+  with \`model\` set to that exact \`value\`. Otherwise call ask_llm.
 - \`model_lookup_failed\` (the live list could not be fetched, e.g. invalid
-  credentials) → fall through to ask_llm.
-- \`unsupported_provider\` → ask_llm.
+  credentials) → call ask_llm.
+- \`unsupported_provider\` → call ask_llm. Do not list the supported
+  providers back to the user; the picker UI handles that.
 
 Rules:
 - Explicit provider/model request → resolve_llm first, not ask_llm.

--- a/packages/cli/src/modules/agents/builder/agents-builder-tools.service.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-tools.service.ts
@@ -1,6 +1,7 @@
 import { Tool } from '@n8n/agents';
 import type { BuiltTool, CredentialProvider } from '@n8n/agents';
 import { agentSkillSchema } from '@n8n/api-types';
+import type { User } from '@n8n/db';
 import { WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import type { Operation } from 'fast-json-patch';
@@ -17,12 +18,14 @@ import {
 	tryParseConfigJson,
 } from '../json-config/agent-json-config';
 import { AgentSecureRuntime } from '../runtime/agent-secure-runtime';
+import { BuilderModelLookupService } from './builder-model-lookup.service';
 import {
 	buildAskCredentialTool,
 	buildAskLlmTool,
 	buildAskQuestionTool,
 	buildResolveLlmTool,
 } from './interactive';
+import type { ModelLookup } from './interactive/resolve-llm.tool';
 import { BUILDER_TOOLS } from './builder-tool-names';
 
 const EMPTY_INSTRUCTIONS_ERROR: ConfigValidationError = {
@@ -103,15 +106,17 @@ export class AgentsBuilderToolsService {
 		private readonly secureRuntime: AgentSecureRuntime,
 		private readonly workflowRepository: WorkflowRepository,
 		private readonly agentsToolsService: AgentsToolsService,
+		private readonly builderModelLookupService: BuilderModelLookupService,
 	) {}
 
 	getTools(
 		agentId: string,
 		projectId: string,
 		credentialProvider: CredentialProvider,
+		user: User,
 	): BuilderTools {
 		return {
-			json: this.getJsonTools(agentId, projectId, credentialProvider),
+			json: this.getJsonTools(agentId, projectId, credentialProvider, user),
 			shared: this.getSharedTools(agentId, projectId, credentialProvider),
 		};
 	}
@@ -120,6 +125,7 @@ export class AgentsBuilderToolsService {
 		agentId: string,
 		projectId: string,
 		credentialProvider: CredentialProvider,
+		user: User,
 	): BuiltTool[] {
 		const readConfigTool = new Tool(BUILDER_TOOLS.READ_CONFIG)
 			.description(
@@ -328,12 +334,17 @@ export class AgentsBuilderToolsService {
 			})
 			.build();
 
+		const modelLookup: ModelLookup = {
+			list: async (credentialId, credentialType, lookup) =>
+				await this.builderModelLookupService.list(user, credentialId, credentialType, lookup),
+		};
+
 		return [
 			readConfigTool,
 			writeConfigTool,
 			patchConfigTool,
 			listIntegrationTypesTool,
-			buildResolveLlmTool({ credentialProvider }),
+			buildResolveLlmTool({ credentialProvider, modelLookup }),
 			buildAskCredentialTool({ credentialProvider }),
 			buildAskLlmTool(),
 			buildAskQuestionTool(),

--- a/packages/cli/src/modules/agents/builder/agents-builder.service.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder.service.ts
@@ -168,7 +168,12 @@ export class AgentsBuilderService {
 			builderModel: BUILDER_MODEL,
 		});
 
-		const tools = this.agentsBuilderToolsService.getTools(agentId, projectId, credentialProvider);
+		const tools = this.agentsBuilderToolsService.getTools(
+			agentId,
+			projectId,
+			credentialProvider,
+			user,
+		);
 
 		const builderMemory = new Memory().storage(this.n8nMemory).lastMessages(40);
 

--- a/packages/cli/src/modules/agents/builder/builder-model-lookup.service.ts
+++ b/packages/cli/src/modules/agents/builder/builder-model-lookup.service.ts
@@ -1,0 +1,82 @@
+import type { User } from '@n8n/db';
+import { ProjectRepository } from '@n8n/db';
+import { Service } from '@n8n/di';
+import type { INodeCredentials, INodeParameters } from 'n8n-workflow';
+
+import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
+import { NodeTypes } from '@/node-types';
+import { DynamicNodeParametersService } from '@/services/dynamic-node-parameters.service';
+import { getBase } from '@/workflow-execute-additional-data';
+
+import type { ModelLookupConfig } from './interactive/llm-provider-defaults';
+
+@Service()
+export class BuilderModelLookupService {
+	constructor(
+		private readonly credentialsFinderService: CredentialsFinderService,
+		private readonly projectRepository: ProjectRepository,
+		private readonly dynamicNodeParametersService: DynamicNodeParametersService,
+		private readonly nodeTypes: NodeTypes,
+	) {}
+
+	async list(
+		user: User,
+		credentialId: string,
+		credentialType: string,
+		lookup: ModelLookupConfig,
+	): Promise<Array<{ name: string; value: string }>> {
+		const credential = await this.credentialsFinderService.findCredentialForUser(
+			credentialId,
+			user,
+			['credential:read'],
+		);
+		if (!credential || credential.type !== credentialType) {
+			throw new Error(`Credential ${credentialId} not found or not accessible`);
+		}
+
+		const personalProject = await this.projectRepository.getPersonalProjectForUserOrFail(user.id);
+		const currentNodeParameters: INodeParameters = {};
+		const credentials: INodeCredentials = {
+			[credential.type]: { id: credential.id, name: credential.name },
+		};
+		const additionalData = await getBase({
+			userId: user.id,
+			projectId: personalProject.id,
+			currentNodeParameters,
+		});
+		const nodeTypeAndVersion = { name: lookup.nodeType, version: lookup.version };
+
+		if (lookup.kind === 'listSearch') {
+			const result = await this.dynamicNodeParametersService.getResourceLocatorResults(
+				lookup.methodName,
+				'',
+				additionalData,
+				nodeTypeAndVersion,
+				currentNodeParameters,
+				credentials,
+			);
+			return (result.results ?? []).map((r) => ({
+				name: String(r.name),
+				value: String(r.value),
+			}));
+		}
+
+		const nodeType = this.nodeTypes.getByNameAndVersion(lookup.nodeType, lookup.version);
+		const property = nodeType.description.properties.find((p) => p.name === lookup.propertyName);
+		const loadOptions = property?.typeOptions?.loadOptions;
+		if (!loadOptions) {
+			throw new Error(
+				`Property "${lookup.propertyName}" on ${lookup.nodeType} has no loadOptions config`,
+			);
+		}
+
+		const options = await this.dynamicNodeParametersService.getOptionsViaLoadOptions(
+			loadOptions,
+			additionalData,
+			nodeTypeAndVersion,
+			currentNodeParameters,
+			credentials,
+		);
+		return options.map((o) => ({ name: String(o.name), value: String(o.value) }));
+	}
+}

--- a/packages/cli/src/modules/agents/builder/interactive/__tests__/resolve-llm.tool.test.ts
+++ b/packages/cli/src/modules/agents/builder/interactive/__tests__/resolve-llm.tool.test.ts
@@ -55,22 +55,17 @@ describe('resolve_llm tool', () => {
 	});
 
 	it('uses the requested model for the requested provider', async () => {
-		const credentialProvider = makeProvider([
-			{ id: 'c1', name: 'My OpenRouter', type: 'openRouterApi' },
-		]);
+		const credentialProvider = makeProvider([{ id: 'c1', name: 'My xAI', type: 'xAiApi' }]);
 		const modelLookup = makeModelLookup();
 		const tool = buildResolveLlmTool({ credentialProvider, modelLookup });
-		const result = await tool.handler!(
-			{ provider: 'openrouter', model: 'meta-llama/llama-3.1-70b-instruct' },
-			{},
-		);
+		const result = await tool.handler!({ provider: 'xai', model: 'grok-4-fast' }, {});
 
 		expect(result).toEqual({
 			ok: true,
-			provider: 'openrouter',
-			model: 'meta-llama/llama-3.1-70b-instruct',
+			provider: 'xai',
+			model: 'grok-4-fast',
 			credentialId: 'c1',
-			credentialName: 'My OpenRouter',
+			credentialName: 'My xAI',
 		});
 	});
 

--- a/packages/cli/src/modules/agents/builder/interactive/__tests__/resolve-llm.tool.test.ts
+++ b/packages/cli/src/modules/agents/builder/interactive/__tests__/resolve-llm.tool.test.ts
@@ -1,4 +1,6 @@
 import type { CredentialListItem, CredentialProvider } from '@n8n/agents';
+
+import type { ModelLookup } from '../resolve-llm.tool';
 import { buildResolveLlmTool } from '../resolve-llm.tool';
 
 function makeProvider(creds: CredentialListItem[]): CredentialProvider {
@@ -8,13 +10,20 @@ function makeProvider(creds: CredentialListItem[]): CredentialProvider {
 	};
 }
 
+function makeModelLookup(impl?: ModelLookup['list']): ModelLookup & { list: jest.Mock } {
+	return {
+		list: jest.fn(impl ?? (async () => [])),
+	};
+}
+
 describe('resolve_llm tool', () => {
 	it('auto-resolves when exactly one LLM-provider credential exists', async () => {
 		const credentialProvider = makeProvider([
 			{ id: 'c1', name: 'My Anthropic', type: 'anthropicApi' },
 			{ id: 'c2', name: 'My Slack', type: 'slackApi' },
 		]);
-		const tool = buildResolveLlmTool({ credentialProvider });
+		const modelLookup = makeModelLookup();
+		const tool = buildResolveLlmTool({ credentialProvider, modelLookup });
 		const result = await tool.handler!({}, {});
 
 		expect(result).toEqual({
@@ -24,6 +33,7 @@ describe('resolve_llm tool', () => {
 			credentialId: 'c1',
 			credentialName: 'My Anthropic',
 		});
+		expect(modelLookup.list).not.toHaveBeenCalled();
 	});
 
 	it('auto-resolves the requested provider when multiple LLM-provider credentials exist', async () => {
@@ -31,7 +41,8 @@ describe('resolve_llm tool', () => {
 			{ id: 'c1', name: 'My Anthropic', type: 'anthropicApi' },
 			{ id: 'c2', name: 'My OpenRouter', type: 'openRouterApi' },
 		]);
-		const tool = buildResolveLlmTool({ credentialProvider });
+		const modelLookup = makeModelLookup();
+		const tool = buildResolveLlmTool({ credentialProvider, modelLookup });
 		const result = await tool.handler!({ provider: 'openrouter' }, {});
 
 		expect(result).toEqual({
@@ -47,7 +58,8 @@ describe('resolve_llm tool', () => {
 		const credentialProvider = makeProvider([
 			{ id: 'c1', name: 'My OpenRouter', type: 'openRouterApi' },
 		]);
-		const tool = buildResolveLlmTool({ credentialProvider });
+		const modelLookup = makeModelLookup();
+		const tool = buildResolveLlmTool({ credentialProvider, modelLookup });
 		const result = await tool.handler!(
 			{ provider: 'openrouter', model: 'meta-llama/llama-3.1-70b-instruct' },
 			{},
@@ -66,7 +78,8 @@ describe('resolve_llm tool', () => {
 		const credentialProvider = makeProvider([
 			{ id: 'c1', name: 'My Anthropic', type: 'anthropicApi' },
 		]);
-		const tool = buildResolveLlmTool({ credentialProvider });
+		const modelLookup = makeModelLookup();
+		const tool = buildResolveLlmTool({ credentialProvider, modelLookup });
 		const result = await tool.handler!({ provider: 'openrouter' }, {});
 
 		expect(result).toEqual({
@@ -83,7 +96,8 @@ describe('resolve_llm tool', () => {
 			{ id: 'c1', name: 'Personal OpenRouter', type: 'openRouterApi' },
 			{ id: 'c2', name: 'Work OpenRouter', type: 'openRouterApi' },
 		]);
-		const tool = buildResolveLlmTool({ credentialProvider });
+		const modelLookup = makeModelLookup();
+		const tool = buildResolveLlmTool({ credentialProvider, modelLookup });
 		const result = await tool.handler!({ provider: 'openrouter' }, {});
 
 		expect(result).toEqual({
@@ -103,7 +117,8 @@ describe('resolve_llm tool', () => {
 			{ id: 'c1', name: 'My Anthropic', type: 'anthropicApi' },
 			{ id: 'c2', name: 'My OpenAI', type: 'openAiApi' },
 		]);
-		const tool = buildResolveLlmTool({ credentialProvider });
+		const modelLookup = makeModelLookup();
+		const tool = buildResolveLlmTool({ credentialProvider, modelLookup });
 		const result = await tool.handler!({}, {});
 
 		expect(result).toEqual({
@@ -113,6 +128,171 @@ describe('resolve_llm tool', () => {
 				{ id: 'c1', name: 'My Anthropic', type: 'anthropicApi', provider: 'anthropic' },
 				{ id: 'c2', name: 'My OpenAI', type: 'openAiApi', provider: 'openai' },
 			],
+		});
+	});
+
+	describe('model validation against modelLookup', () => {
+		it('skips lookup when no model is requested', async () => {
+			const credentialProvider = makeProvider([
+				{ id: 'c1', name: 'My Anthropic', type: 'anthropicApi' },
+			]);
+			const modelLookup = makeModelLookup();
+			const tool = buildResolveLlmTool({ credentialProvider, modelLookup });
+			const result = await tool.handler!({ provider: 'anthropic' }, {});
+
+			expect(result).toEqual({
+				ok: true,
+				provider: 'anthropic',
+				model: 'claude-sonnet-4-6',
+				credentialId: 'c1',
+				credentialName: 'My Anthropic',
+			});
+			expect(modelLookup.list).not.toHaveBeenCalled();
+		});
+
+		it('skips lookup for providers without modelLookup configured (e.g. Cohere)', async () => {
+			const credentialProvider = makeProvider([{ id: 'c1', name: 'My Cohere', type: 'cohereApi' }]);
+			const modelLookup = makeModelLookup();
+			const tool = buildResolveLlmTool({ credentialProvider, modelLookup });
+			const result = await tool.handler!({ provider: 'cohere', model: 'command-x-plus' }, {});
+
+			expect(result).toEqual({
+				ok: true,
+				provider: 'cohere',
+				model: 'command-x-plus',
+				credentialId: 'c1',
+				credentialName: 'My Cohere',
+			});
+			expect(modelLookup.list).not.toHaveBeenCalled();
+		});
+
+		it('returns the canonical model id when the requested model matches the lookup', async () => {
+			const credentialProvider = makeProvider([
+				{ id: 'c1', name: 'My Anthropic', type: 'anthropicApi' },
+			]);
+			const modelLookup = makeModelLookup(async () => [
+				{ name: 'Claude Haiku 4.5', value: 'claude-haiku-4-5-20250101' },
+				{ name: 'Claude Sonnet 4.6', value: 'claude-sonnet-4-6' },
+			]);
+			const tool = buildResolveLlmTool({ credentialProvider, modelLookup });
+			const result = await tool.handler!(
+				{ provider: 'anthropic', model: 'CLAUDE-HAIKU-4-5-20250101' },
+				{},
+			);
+
+			expect(result).toEqual({
+				ok: true,
+				provider: 'anthropic',
+				model: 'claude-haiku-4-5-20250101',
+				credentialId: 'c1',
+				credentialName: 'My Anthropic',
+			});
+			expect(modelLookup.list).toHaveBeenCalledWith(
+				'c1',
+				'anthropicApi',
+				expect.objectContaining({ kind: 'listSearch', methodName: 'searchModels' }),
+			);
+		});
+
+		it('uniquely-substring-matches a partial requested model id', async () => {
+			const credentialProvider = makeProvider([
+				{ id: 'c1', name: 'My Anthropic', type: 'anthropicApi' },
+			]);
+			const modelLookup = makeModelLookup(async () => [
+				{ name: 'Claude Haiku 4.5', value: 'claude-haiku-4-5-20250101' },
+				{ name: 'Claude Sonnet 4.6', value: 'claude-sonnet-4-6' },
+			]);
+			const tool = buildResolveLlmTool({ credentialProvider, modelLookup });
+			const result = await tool.handler!({ provider: 'anthropic', model: 'claude-haiku-4-5' }, {});
+
+			expect(result).toEqual({
+				ok: true,
+				provider: 'anthropic',
+				model: 'claude-haiku-4-5-20250101',
+				credentialId: 'c1',
+				credentialName: 'My Anthropic',
+			});
+		});
+
+		it('uniquely-substring-matches against the model display name', async () => {
+			const credentialProvider = makeProvider([
+				{ id: 'c1', name: 'My Anthropic', type: 'anthropicApi' },
+			]);
+			const modelLookup = makeModelLookup(async () => [
+				{ name: 'Claude Haiku 4.5', value: 'claude-haiku-4-5-20250101' },
+				{ name: 'Claude Sonnet 4.6', value: 'claude-sonnet-4-6-20251001' },
+			]);
+			const tool = buildResolveLlmTool({ credentialProvider, modelLookup });
+			const result = await tool.handler!({ provider: 'anthropic', model: 'haiku 4.5' }, {});
+
+			expect(result).toEqual({
+				ok: true,
+				provider: 'anthropic',
+				model: 'claude-haiku-4-5-20250101',
+				credentialId: 'c1',
+				credentialName: 'My Anthropic',
+			});
+		});
+
+		it('returns unknown_model with availableModels when nothing matches', async () => {
+			const credentialProvider = makeProvider([
+				{ id: 'c1', name: 'My Anthropic', type: 'anthropicApi' },
+			]);
+			const available = [{ name: 'Claude Sonnet 4.6', value: 'claude-sonnet-4-6' }];
+			const modelLookup = makeModelLookup(async () => available);
+			const tool = buildResolveLlmTool({ credentialProvider, modelLookup });
+			const result = await tool.handler!({ provider: 'anthropic', model: 'gpt-9000' }, {});
+
+			expect(result).toEqual({
+				ok: false,
+				reason: 'unknown_model',
+				provider: 'anthropic',
+				requestedModel: 'gpt-9000',
+				availableModels: available,
+			});
+		});
+
+		it('returns unknown_model with the candidate matches when the substring is ambiguous', async () => {
+			const credentialProvider = makeProvider([
+				{ id: 'c1', name: 'My Anthropic', type: 'anthropicApi' },
+			]);
+			const modelLookup = makeModelLookup(async () => [
+				{ name: 'Claude Haiku 4.5', value: 'claude-haiku-4-5-20250101' },
+				{ name: 'Claude Haiku 4.0', value: 'claude-haiku-4-0-20240101' },
+				{ name: 'Claude Sonnet 4.6', value: 'claude-sonnet-4-6' },
+			]);
+			const tool = buildResolveLlmTool({ credentialProvider, modelLookup });
+			const result = await tool.handler!({ provider: 'anthropic', model: 'haiku' }, {});
+
+			expect(result).toEqual({
+				ok: false,
+				reason: 'unknown_model',
+				provider: 'anthropic',
+				requestedModel: 'haiku',
+				availableModels: [
+					{ name: 'Claude Haiku 4.5', value: 'claude-haiku-4-5-20250101' },
+					{ name: 'Claude Haiku 4.0', value: 'claude-haiku-4-0-20240101' },
+				],
+			});
+		});
+
+		it('returns model_lookup_failed when the lookup throws', async () => {
+			const credentialProvider = makeProvider([
+				{ id: 'c1', name: 'My Anthropic', type: 'anthropicApi' },
+			]);
+			const modelLookup = makeModelLookup(async () => {
+				throw new Error('credentials invalid');
+			});
+			const tool = buildResolveLlmTool({ credentialProvider, modelLookup });
+			const result = await tool.handler!({ provider: 'anthropic', model: 'claude-haiku-4-5' }, {});
+
+			expect(result).toEqual({
+				ok: false,
+				reason: 'model_lookup_failed',
+				provider: 'anthropic',
+				requestedModel: 'claude-haiku-4-5',
+				error: 'credentials invalid',
+			});
 		});
 	});
 });

--- a/packages/cli/src/modules/agents/builder/interactive/llm-provider-defaults.ts
+++ b/packages/cli/src/modules/agents/builder/interactive/llm-provider-defaults.ts
@@ -10,19 +10,76 @@
  * Keep this list narrow — when the canonical default is unclear (e.g. Bedrock,
  * Azure variants), omit the entry so the tool falls through to suspending and
  * lets the user pick explicitly.
+ *
+ * `modelLookup` (optional) points at the chat-model node whose
+ * `@searchListMethod` or routing-based `loadOptions` returns the live list of
+ * model ids for the provider. When set, `resolve_llm` validates user-requested
+ * model strings against that list. When absent, the requested model is passed
+ * through unchanged.
  */
+export type ModelLookupConfig =
+	| {
+			kind: 'listSearch';
+			nodeType: string;
+			version: number;
+			methodName: string;
+	  }
+	| {
+			kind: 'loadOptionsRouting';
+			nodeType: string;
+			version: number;
+			propertyName: string;
+	  };
+
 export interface LlmProviderDefault {
 	provider: string;
 	defaultModel: string;
+	modelLookup?: ModelLookupConfig;
 }
 
 export const LLM_PROVIDER_DEFAULTS: Record<string, LlmProviderDefault> = {
-	anthropicApi: { provider: 'anthropic', defaultModel: 'claude-sonnet-4-6' },
-	openAiApi: { provider: 'openai', defaultModel: 'gpt-5' },
-	googlePalmApi: { provider: 'google', defaultModel: 'gemini-2.5-pro' },
+	anthropicApi: {
+		provider: 'anthropic',
+		defaultModel: 'claude-sonnet-4-6',
+		modelLookup: {
+			kind: 'listSearch',
+			nodeType: '@n8n/n8n-nodes-langchain.lmChatAnthropic',
+			version: 1.5,
+			methodName: 'searchModels',
+		},
+	},
+	openAiApi: {
+		provider: 'openai',
+		defaultModel: 'gpt-5',
+		modelLookup: {
+			kind: 'listSearch',
+			nodeType: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+			version: 1.2,
+			methodName: 'searchModels',
+		},
+	},
+	googlePalmApi: {
+		provider: 'google',
+		defaultModel: 'gemini-2.5-pro',
+		modelLookup: {
+			kind: 'loadOptionsRouting',
+			nodeType: '@n8n/n8n-nodes-langchain.lmChatGoogleGemini',
+			version: 1.1,
+			propertyName: 'modelName',
+		},
+	},
 	xAiApi: { provider: 'xai', defaultModel: 'grok-4' },
 	groqApi: { provider: 'groq', defaultModel: 'llama-3.1-70b-versatile' },
-	mistralCloudApi: { provider: 'mistral', defaultModel: 'mistral-large-latest' },
+	mistralCloudApi: {
+		provider: 'mistral',
+		defaultModel: 'mistral-large-latest',
+		modelLookup: {
+			kind: 'loadOptionsRouting',
+			nodeType: '@n8n/n8n-nodes-langchain.lmChatMistralCloud',
+			version: 1,
+			propertyName: 'model',
+		},
+	},
 	deepSeekApi: { provider: 'deepseek', defaultModel: 'deepseek-chat' },
 	cohereApi: { provider: 'cohere', defaultModel: 'command-r-plus' },
 	openRouterApi: { provider: 'openrouter', defaultModel: 'anthropic/claude-sonnet-4.6' },

--- a/packages/cli/src/modules/agents/builder/interactive/llm-provider-defaults.ts
+++ b/packages/cli/src/modules/agents/builder/interactive/llm-provider-defaults.ts
@@ -82,5 +82,14 @@ export const LLM_PROVIDER_DEFAULTS: Record<string, LlmProviderDefault> = {
 	},
 	deepSeekApi: { provider: 'deepseek', defaultModel: 'deepseek-chat' },
 	cohereApi: { provider: 'cohere', defaultModel: 'command-r-plus' },
-	openRouterApi: { provider: 'openrouter', defaultModel: 'anthropic/claude-sonnet-4.6' },
+	openRouterApi: {
+		provider: 'openrouter',
+		defaultModel: 'anthropic/claude-sonnet-4.6',
+		modelLookup: {
+			kind: 'loadOptionsRouting',
+			nodeType: '@n8n/n8n-nodes-langchain.lmChatOpenRouter',
+			version: 1,
+			propertyName: 'model',
+		},
+	},
 };

--- a/packages/cli/src/modules/agents/builder/interactive/resolve-llm.tool.ts
+++ b/packages/cli/src/modules/agents/builder/interactive/resolve-llm.tool.ts
@@ -3,10 +3,23 @@ import type { BuiltTool, CredentialListItem, CredentialProvider } from '@n8n/age
 import { z } from 'zod';
 
 import { BUILDER_TOOLS } from '../builder-tool-names';
-import { LLM_PROVIDER_DEFAULTS, type LlmProviderDefault } from './llm-provider-defaults';
+import {
+	LLM_PROVIDER_DEFAULTS,
+	type LlmProviderDefault,
+	type ModelLookupConfig,
+} from './llm-provider-defaults';
+
+export interface ModelLookup {
+	list(
+		credentialId: string,
+		credentialType: string,
+		lookup: ModelLookupConfig,
+	): Promise<Array<{ name: string; value: string }>>;
+}
 
 export interface ResolveLlmToolDeps {
 	credentialProvider: CredentialProvider;
+	modelLookup: ModelLookup;
 }
 
 type LlmCredentialEntry = [credentialType: string, defaults: LlmProviderDefault];
@@ -29,6 +42,52 @@ function toLlmResolution(
 		model: model?.trim() || defaults.defaultModel,
 		credentialId: credential.id,
 		credentialName: credential.name,
+	};
+}
+
+async function resolveModelAgainstLookup(
+	credential: CredentialListItem,
+	defaults: LlmProviderDefault,
+	requestedModel: string,
+	modelLookup: ModelLookup,
+) {
+	const trimmedModel = requestedModel.trim();
+	if (!defaults.modelLookup || !trimmedModel) {
+		return toLlmResolution(credential, defaults, requestedModel);
+	}
+
+	let availableModels: Array<{ name: string; value: string }>;
+	try {
+		availableModels = await modelLookup.list(credential.id, credential.type, defaults.modelLookup);
+	} catch (error) {
+		return {
+			ok: false as const,
+			reason: 'model_lookup_failed' as const,
+			provider: defaults.provider,
+			requestedModel: trimmedModel,
+			error: error instanceof Error ? error.message : String(error),
+		};
+	}
+
+	const lowerHint = trimmedModel.toLowerCase();
+	const exactMatch = availableModels.find((m) => m.value.toLowerCase() === lowerHint);
+	if (exactMatch) {
+		return toLlmResolution(credential, defaults, exactMatch.value);
+	}
+
+	const candidates = availableModels.filter(
+		(m) => m.value.toLowerCase().includes(lowerHint) || m.name.toLowerCase().includes(lowerHint),
+	);
+	if (candidates.length === 1) {
+		return toLlmResolution(credential, defaults, candidates[0].value);
+	}
+
+	return {
+		ok: false as const,
+		reason: 'unknown_model' as const,
+		provider: defaults.provider,
+		requestedModel: trimmedModel,
+		availableModels: candidates.length > 0 ? candidates : availableModels,
 	};
 }
 
@@ -80,7 +139,11 @@ export function buildResolveLlmTool(deps: ResolveLlmToolDeps): BuiltTool {
 				);
 
 				if (matchingCredentials.length === 1) {
-					return toLlmResolution(matchingCredentials[0], defaults, model);
+					const credential = matchingCredentials[0];
+					if (model?.trim()) {
+						return await resolveModelAgainstLookup(credential, defaults, model, deps.modelLookup);
+					}
+					return toLlmResolution(credential, defaults);
 				}
 
 				return {
@@ -100,7 +163,11 @@ export function buildResolveLlmTool(deps: ResolveLlmToolDeps): BuiltTool {
 
 			if (llmCredentials.length === 1) {
 				const credential = llmCredentials[0];
-				return toLlmResolution(credential, LLM_PROVIDER_DEFAULTS[credential.type], model);
+				const defaults = LLM_PROVIDER_DEFAULTS[credential.type];
+				if (model?.trim()) {
+					return await resolveModelAgainstLookup(credential, defaults, model, deps.modelLookup);
+				}
+				return toLlmResolution(credential, defaults);
 			}
 
 			return {


### PR DESCRIPTION
## Summary

- Validate the model id `resolve_llm` writes to the agent config against the provider's live list, instead of trusting whatever the orchestrating LLM produced.
- Reuse the workflow builder's `DynamicNodeParametersService` to fetch real models for Anthropic / OpenAI (`searchModels` listSearch) and Mistral / Gemini / OpenRouter (routing-based `loadOptions`).
- Match exact id first, then unique case-insensitive substring on id or display name, so "haiku 4.5" or "claude-haiku-4-5" resolves to the canonical dated id in one call.
- When the hint can't be resolved or fetched, route the agent to the existing `ask_llm` picker card instead of replying conversationally.
- Only fire the lookup when the user names a non-default model — the no-model happy path makes zero outbound calls.



## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
