### PR TITLE
fix(core): Exclude error workflows from "Time saved" Insights metric

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights-collection.service.integration.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-collection.service.integration.test.ts
@@ -228,7 +228,7 @@ describe('workflowExecuteAfterHandler', () => {
 		});
 
 		const allInsights = await insightsRawRepository.find();
-		expect(allInsights).toHaveLength(3);
+		expect(allInsights).toHaveLength(mode === 'error' ? 2 : 3);
 		expect(allInsights).toContainEqual(
 			expect.objectContaining({ metaId: metadata.metaId, type: 'success', value: 1 }),
 		);
@@ -239,13 +239,19 @@ describe('workflowExecuteAfterHandler', () => {
 				value: stoppedAt.diff(startedAt).toMillis(),
 			}),
 		);
-		expect(allInsights).toContainEqual(
-			expect.objectContaining({
-				metaId: metadata.metaId,
-				type: 'time_saved_min',
-				value: 3,
-			}),
-		);
+		if (mode !== 'error') {
+			expect(allInsights).toContainEqual(
+				expect.objectContaining({
+					metaId: metadata.metaId,
+					type: 'time_saved_min',
+					value: 3,
+				}),
+			);
+		} else {
+			expect(allInsights).not.toContainEqual(
+				expect.objectContaining({ metaId: metadata.metaId, type: 'time_saved_min' }),
+			);
+		}
 	});
 });
 

--- a/packages/cli/src/modules/insights/insights-collection.service.ts
+++ b/packages/cli/src/modules/insights/insights-collection.service.ts
@@ -189,7 +189,8 @@ export class InsightsCollectionService {
 		}
 
 		// time saved event
-		if (status === 'success') {
+		// Skip for error workflows: their executions represent failure handling, not work saved.
+		if (status === 'success' && ctx.runData.mode !== 'error') {
 			const finalTimeSaved = this.calculateTimeSaved(ctx);
 			if (finalTimeSaved !== undefined) {
 				this.bufferedInsights.add({


### PR DESCRIPTION
## Summary

Error-workflow executions (`mode: 'error'`) were contributing to the **Time saved** Insights metric, contradicting the Insights documentation which states sub-workflows and error workflows should not count.

The fix gates only the `time_saved_min` event on `mode !== 'error'`. Success/failure and runtime metrics for error-workflow executions remain tracked, keeping the Insights collector consistent with `workflow-statistics.service.ts` (both treat error-mode runs as root executions).

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->
https://linear.app/n8n/issue/GHC-8103
fixes #29622


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
