### PR TITLE
fix(Basic LLM Chain Node): Parse plain object output from structured output parser

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/promptUtils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/promptUtils.ts
@@ -191,5 +191,13 @@ export const getAgentStepsParser =
 			return parsedOutput;
 		}
 
+		if (typeof steps === 'object' && steps !== null && !Array.isArray(steps)) {
+			const parsedOutput = (await outputParser.parse(JSON.stringify(steps))) as Record<
+				string,
+				unknown
+			>;
+			return parsedOutput;
+		}
+
 		throw new Error('Failed to parse agent steps');
 	};

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/promptUtils.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/promptUtils.test.ts
@@ -349,5 +349,31 @@ describe('promptUtils', () => {
 
 			await expect(parser(steps)).rejects.toThrow('Failed to parse agent steps');
 		});
+
+		it('should parse plain object via outputParser (regression for #29903)', async () => {
+			const parser = getAgentStepsParser(mockOutputParser);
+			const plainObject = { output: { isValid: false, message: 'error' } };
+
+			const parsedResult = { isValid: false, message: 'error' };
+			mockOutputParser.parse.mockResolvedValue(parsedResult);
+
+			const result = await parser(plainObject as unknown as AgentFinish);
+
+			expect(mockOutputParser.parse).toHaveBeenCalledWith(JSON.stringify(plainObject));
+			expect(result).toEqual(parsedResult);
+		});
+
+		it('should parse plain object with arbitrary shape via outputParser', async () => {
+			const parser = getAgentStepsParser(mockOutputParser);
+			const plainObject = { foo: 'bar', count: 42 };
+
+			const parsedResult = { foo: 'bar', count: 42 };
+			mockOutputParser.parse.mockResolvedValue(parsedResult);
+
+			const result = await parser(plainObject as unknown as AgentFinish);
+
+			expect(mockOutputParser.parse).toHaveBeenCalledWith(JSON.stringify(plainObject));
+			expect(result).toEqual(parsedResult);
+		});
 	});
 });


### PR DESCRIPTION
## Summary

The Basic LLM Chain node (v1.9+) fails with `Failed to parse agent steps` when wired up to a Structured Output Parser. The chain pipes the model output through `getAgentStepsParser()`, which only handles `string`, `BaseMessage`, `AgentAction[]`, and `AgentFinish` shapes. Models that produce structured JSON directly as a plain object (e.g. through tool-bound structured output) fall through to the final `throw`.

This PR adds a fallback branch in `getAgentStepsParser()` that stringifies a plain non-array object and feeds it to the supplied `outputParser`, letting the parser validate against its schema. Existing branches are unchanged, so the regression case for `AgentAction[]` without `format_final_json_response` still throws.

### Root cause

In [`promptUtils.ts`](packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/promptUtils.ts) the type guards run in this order: `string` → `Array` → `BaseMessage` (`instanceof`) → `AgentFinish` (has `returnValues`). A plain object like `{"output":{"isValid":false,"message":"..."}}` matches none of these and reaches `throw new Error('Failed to parse agent steps')`. The wrapper was added in #22936 to support OpenAI Responses API + tools; this PR extends it to also handle plain structured output without removing that support.

### Changes

- `packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/promptUtils.ts` — add a final fallback branch that runs `outputParser.parse(JSON.stringify(steps))` for plain non-array objects.
- `packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/test/promptUtils.test.ts` — two regression tests covering the bug scenario (`{output: {...}}`) and an arbitrary plain object shape.

### How to test

1. Create a workflow with a Basic LLM Chain node (version 1.9 or later).
2. Connect a Structured Output Parser configured with a JSON schema.
3. Execute the workflow.
4. Expected: the parsed object is returned. Previously: `Failed to parse agent steps`.

`pnpm --filter @n8n/n8n-nodes-langchain test ChainLLM` — 85/85 passing (83 existing + 2 new).

## Related Linear tickets, Github issues, and Community forum posts

Closes #29903
[GHC-8186](https://linear.app/n8n/issue/GHC-8186)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported).