### PR TITLE
chore(ai-builder): Improve eval comparison alert clarity (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -181,12 +181,12 @@ LangSmith appends a random suffix (e.g. `instance-ai-baseline-7abc1234`); the mo
 Each scenario lands in one of three regression tiers, evaluated in order of strictness:
 
 - **Regression** — high-confidence flag, gating-grade. The drop must be statistically significant (chance of seeing it by noise < 5%), at least 30 percentage points in size, and the baseline must have been reliable (≥ 70% pass rate).
-- **Soft regression** — looser bar for visibility on borderline cases. Looser confidence threshold (chance by noise < 20%), drop ≥ 15 percentage points, baseline ≥ 50%. Frequently natural variance — worth a glance only if your changes touch related code paths.
-- **Notable movement** — any scenario whose pass rate moved by ≥ 35 percentage points without reaching either flag tier. Pure visibility, no implication of cause.
+- **Likely regression** — looser bar for visibility on borderline cases. Looser confidence threshold (chance by noise < 20%), drop ≥ 15 percentage points, baseline ≥ 50%. Frequently natural variance — worth a glance only if your changes touch related code paths.
+- **Worth watching** — any scenario whose pass rate moved by ≥ 35 percentage points but wasn't flagged as a regression (hard or likely tier). Pure visibility, no implication of cause.
 
 Other verdicts: `improvement` (PR significantly better, skips the reliability gate), `unreliable_baseline` (confident drop but baseline was too flaky to call a regression — surfaced but not flagged), `stable`, `insufficient_data`.
 
-Why these tiers and not a flat percentage threshold? At the small N PR runs use (typically 3 iterations), a flat threshold can't tell a real regression from coin-flip noise. The confidence cutoff filters out gaps that could plausibly happen by chance, and the reliability gate avoids chasing noise on already-flaky scenarios. Implementation lives in `comparison/statistics.ts` (Fisher's exact test for the confidence check, Wilson interval for the headline aggregate band). Tune the soft tier first if the false-positive rate looks off — keep the hard tier strict.
+Why these tiers and not a flat percentage threshold? At the small N PR runs use (typically 3 iterations), a flat threshold can't tell a real regression from coin-flip noise. The confidence cutoff filters out gaps that could plausibly happen by chance, and the reliability gate avoids chasing noise on already-flaky scenarios. Implementation lives in `comparison/statistics.ts` (Fisher's exact test for the confidence check, Wilson interval for the headline aggregate band). Tune the likely-regression tier first if the false-positive rate looks off — keep the hard tier strict.
 
 ### Failure-category drift
 

--- a/packages/@n8n/instance-ai/evaluations/__tests__/comparison-format.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/comparison-format.test.ts
@@ -209,11 +209,29 @@ describe('formatComparisonMarkdown', () => {
 		expect(md).toMatch(/\*\*notable\*\*/);
 	});
 
-	it('always includes all five tier counts in the alert line', () => {
+	it('always includes all five tier counts in the alert, split across two lines', () => {
 		const pr = bucket('pr', [s('a', 'happy', 8, 10)]);
 		const base = bucket('master', [s('a', 'happy', 8, 10)]);
 		const md = formatComparisonMarkdown(evalFixture, ok(compareBuckets(pr, base)));
-		expect(md).toMatch(/0 regressions, 0 soft, 0 notable, 0 improvements, 1 stable/);
+		expect(md).toMatch(/0 regressions · 0 likely regressions · 0 worth watching/);
+		expect(md).toMatch(/0 improvements · 1 stable · pass rate/);
+	});
+
+	it('places the pass-rate delta on the concerns line when negative', () => {
+		// PR pass rate < baseline → delta is negative, so the pass-rate text
+		// tails the regression-tier line instead of the wins line.
+		const pr = bucket('pr', [s('a', 'happy', 1, 10)]);
+		const base = bucket('master', [s('a', 'happy', 8, 10)]);
+		const md = formatComparisonMarkdown(evalFixture, ok(compareBuckets(pr, base)));
+		expect(md).toMatch(/regression.*pass rate -/);
+		expect(md).not.toMatch(/stable · pass rate/);
+	});
+
+	it('places the pass-rate delta on the wins line when positive or zero', () => {
+		const pr = bucket('pr', [s('a', 'happy', 8, 10)]);
+		const base = bucket('master', [s('a', 'happy', 1, 10)]);
+		const md = formatComparisonMarkdown(evalFixture, ok(compareBuckets(pr, base)));
+		expect(md).toMatch(/stable · pass rate \+/);
 	});
 
 	it('renders a per-scenario breakdown collapsible inside the regression section', () => {

--- a/packages/@n8n/instance-ai/evaluations/comparison/format.ts
+++ b/packages/@n8n/instance-ai/evaluations/comparison/format.ts
@@ -12,7 +12,7 @@
 // When no comparison is available (no baseline yet, LangSmith offline)
 // the renderers still produce a useful per-test-case summary. When a
 // comparison is available, sections render in priority order:
-// regressions, soft regressions, notable movement, improvements,
+// regressions, likely regressions, worth watching, improvements,
 // failure-category drift. Only sections with content are emitted.
 // ---------------------------------------------------------------------------
 
@@ -87,8 +87,8 @@ export function formatComparisonMarkdown(
 		if (soft.length > 0) {
 			lines.push(
 				...renderScenarioSection(
-					'Soft regressions',
-					'— investigate if related to your changes',
+					'Likely regressions',
+					'— looser statistical flag, investigate if related to your changes',
 					soft,
 					true,
 					failedIndex,
@@ -98,8 +98,8 @@ export function formatComparisonMarkdown(
 		if (watch.length > 0) {
 			lines.push(
 				...renderScenarioSection(
-					'Notable movement',
-					'— large gap, no statistical flag',
+					'Worth watching',
+					'— large change, not flagged as a regression',
 					watch,
 					false,
 					failedIndex,
@@ -177,16 +177,24 @@ function formatTopAlert(outcome?: ComparisonOutcome): string {
 
 	const aggDelta = comparison.aggregate.delta * 100;
 	const aggDeltaText = `${aggDelta >= 0 ? '+' : ''}${aggDelta.toFixed(1)}pp`;
+	const passRateText = `pass rate ${aggDeltaText} vs master`;
 
-	// Always include all five tier counts so readers see what's being tracked,
-	// not just what's > 0. The hard count is bolded when nonzero for emphasis.
-	const summary = [
+	// Two-line summary: regression-tier counts on top, positives/neutrals on the
+	// bottom. The pass-rate delta tails whichever line matches its sign so the
+	// per-line story stays coherent (negative delta lives with the concerns).
+	const concernsParts = [
 		hard > 0 ? `**${hard} regression${hard === 1 ? '' : 's'}**` : '0 regressions',
-		`${soft} soft`,
-		`${watch} notable`,
-		`${imps} improvement${imps === 1 ? '' : 's'}`,
-		`${stable} stable`,
-	].join(', ');
+		`${soft} likely regression${soft === 1 ? '' : 's'}`,
+		`${watch} worth watching`,
+	];
+	const winsParts = [`${imps} improvement${imps === 1 ? '' : 's'}`, `${stable} stable`];
+	if (aggDelta < 0) {
+		concernsParts.push(passRateText);
+	} else {
+		winsParts.push(passRateText);
+	}
+	const concerns = concernsParts.join(' · ');
+	const wins = winsParts.join(' · ');
 
 	let icon: string;
 	let alertKind: 'CAUTION' | 'WARNING' | 'NOTE' | 'TIP';
@@ -205,7 +213,7 @@ function formatTopAlert(outcome?: ComparisonOutcome): string {
 		alertKind = 'TIP';
 	}
 
-	return `> [!${alertKind}]\n> ${icon} ${summary}. Pass rate ${aggDeltaText} vs master.`;
+	return `> [!${alertKind}]\n> ${icon} ${concerns}\n> ${wins}`;
 }
 
 function formatAggregateBlock(
@@ -650,13 +658,13 @@ export function formatComparisonTerminal(
 		if (soft.length > 0) {
 			lines.push(
 				TERMINAL_INDENT +
-					'SOFT REGRESSIONS  (likely natural variance — investigate if related to your changes)',
+					'LIKELY REGRESSIONS  (looser statistical flag — investigate if related to your changes)',
 			);
 			lines.push(formatTerminalScenarioTable(soft, true));
 			lines.push('');
 		}
 		if (watch.length > 0) {
-			lines.push(TERMINAL_INDENT + 'NOTABLE MOVEMENT  (large gap, no statistical flag)');
+			lines.push(TERMINAL_INDENT + 'WORTH WATCHING  (large change, not flagged as a regression)');
 			lines.push(formatTerminalScenarioTable(watch, false));
 			lines.push('');
 		}
@@ -714,16 +722,24 @@ function formatTerminalVerdictLine(outcome?: ComparisonOutcome): string {
 
 	const aggDelta = comparison.aggregate.delta * 100;
 	const aggDeltaText = `${aggDelta >= 0 ? '+' : ''}${aggDelta.toFixed(1)}pp`;
+	const passRateText = `pass rate ${aggDeltaText} vs master`;
 
-	const summary = [
+	const concernsParts = [
 		`${hard} regression${hard === 1 ? '' : 's'}`,
-		`${soft} soft`,
-		`${watch} notable`,
-		`${imps} improvement${imps === 1 ? '' : 's'}`,
-		`${stable} stable`,
-	].join(', ');
+		`${soft} likely regression${soft === 1 ? '' : 's'}`,
+		`${watch} worth watching`,
+	];
+	const winsParts = [`${imps} improvement${imps === 1 ? '' : 's'}`, `${stable} stable`];
+	if (aggDelta < 0) {
+		concernsParts.push(passRateText);
+	} else {
+		winsParts.push(passRateText);
+	}
 
-	return `▶ ${summary}. Pass rate ${aggDeltaText} vs master.`;
+	// The caller prepends TERMINAL_INDENT to the start of this string. Embed an
+	// extra TERMINAL_INDENT after the line break so the wins line aligns under
+	// the concerns text (past the `▶ ` arrow).
+	return `▶ ${concernsParts.join(' · ')}\n${TERMINAL_INDENT}  ${winsParts.join(' · ')}`;
 }
 
 function formatTerminalAggregate(


### PR DESCRIPTION
## Summary

UX cleanup of the Instance AI eval PR-comment alert. Three changes:

- **Clearer category labels.** `soft` → `likely regression` and `notable` → `worth watching` in the headline counts and section headings. The original adjectives were bare (no noun) and used internal stats jargon; the new labels are self-describing.
- **Two-line layout.** The alert now splits regression-tier counts (top line) from improvements/stable (bottom line), with `·` separators replacing comma chaining.
- **Sign-aware pass-rate placement.** The `pass rate ±Xpp vs master` tail moves to the concerns line when the delta is negative, and to the wins line when it's zero or positive — so each line tells a coherent story.

Section subtitles for `Likely regressions` / `Worth watching` were also rephrased in plain English (no more "no statistical flag"). README and tests updated to match. No behavior change — this is purely renderer wording.

### Before
```
> [!WARNING]
> 🟡 0 regressions, 2 soft, 1 notable, 3 improvements, 23 stable. Pass rate +3.1pp vs master.
```

### After (positive delta)
```
> [!WARNING]
> 🟡 0 regressions · 2 likely regressions · 1 worth watching
> 3 improvements · 23 stable · pass rate +3.1pp vs master
```

### After (negative delta)
```
> [!CAUTION]
> 🔴 1 regression · 3 likely regressions · 1 worth watching · pass rate -4.2pp vs master
> 0 improvements · 18 stable
```

### How to test

```bash
cd packages/@n8n/instance-ai
pnpm typecheck
pnpm test comparison
```

All 55 tests in `evaluations/__tests__/comparison*` pass; new tests cover the two-line layout and the sign-aware placement of the pass-rate tail.

## Related Linear tickets, Github issues, and Community forum posts

No ticket — UX iteration during eval review.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated (README inside `packages/@n8n/instance-ai/evaluations/`).
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI