### PR TITLE
chore: Bump vm2 to 3.11.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,8 +265,8 @@ catalogs:
       specifier: ^3.1.0
       version: 3.1.0
     vm2:
-      specifier: ^3.10.5
-      version: 3.10.5
+      specifier: ^3.11.2
+      version: 3.11.2
     xml2js:
       specifier: 0.6.2
       version: 0.6.2
@@ -2222,7 +2222,7 @@ importers:
         version: 3.0.3
       vm2:
         specifier: 'catalog:'
-        version: 3.10.5
+        version: 3.11.2
       weaviate-client:
         specifier: 3.9.0
         version: 3.9.0(encoding@0.1.13)
@@ -4402,7 +4402,7 @@ importers:
         version: 10.0.0
       vm2:
         specifier: 'catalog:'
-        version: 3.10.5
+        version: 3.11.2
       xlsx:
         specifier: https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz
         version: https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz
@@ -22004,8 +22004,8 @@ packages:
   vm-browserify@1.1.2:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
 
-  vm2@3.10.5:
-    resolution: {integrity: sha512-3P/2QDccVFBcujfCOeP8vVNuGfuBJHEuvGR8eMmI10p/iwLL2UwF5PDaNaoOS2pRGQEDmJRyeEcc8kmm2Z59RA==}
+  vm2@3.11.2:
+    resolution: {integrity: sha512-hnsYAgBSAgwwPM/Gq66gMmUY0VlY9mKC8nvVRAZiJp+tYxF4sfNRlZymP8uqzIUK2U/7+SVZ/H8p7USxNHLlZA==}
     engines: {node: '>=6.0'}
     hasBin: true
 
@@ -45086,9 +45086,9 @@ snapshots:
 
   vm-browserify@1.1.2: {}
 
-  vm2@3.10.5:
+  vm2@3.11.2:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
       acorn-walk: 8.3.4
 
   void-elements@3.1.0: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -112,7 +112,7 @@ catalog:
   vite-plugin-dts: ^4.5.4
   vitest: ^4.1.1
   vitest-mock-extended: ^3.1.0
-  vm2: ^3.10.5
+  vm2: ^3.11.2
   xml2js: 0.6.2
   xss: 1.0.15
   yaml: 2.8.3


### PR DESCRIPTION
## Summary

Bumps the shared `vm2` catalog dependency from `^3.10.5` to `^3.11.2` and refreshes the lockfile resolution used by `n8n-nodes-base` and `@n8n/nodes-langchain`.

This addresses current vm2 sandbox escape advisories reported against `vm2 <= 3.10.5`, including GHSA-47x8-96vw-5wg6 / CVE-2026-43997 and related Critical findings fixed by `vm2 >= 3.11.0`.

Validation run locally:

- `pnpm install --lockfile-only`
- `pnpm install`
- `pnpm --filter n8n-nodes-base... --filter @n8n/n8n-nodes-langchain... build`
- `pnpm --filter n8n-nodes-base exec jest nodes/Code/test/Code.node.test.ts nodes/Code/test/utils.test.ts nodes/Code/test/ExecutionError.test.ts nodes/Code/test/JsCodeValidator.test.ts --runInBand`
- `pnpm --filter @n8n/n8n-nodes-langchain exec jest nodes/code/Code.node.test.ts --runInBand`
- `pnpm --filter n8n-nodes-base typecheck`
- `pnpm --filter @n8n/n8n-nodes-langchain typecheck`
- NodeVM smoke test loading `vm2@3.11.2`

## Related Linear tickets, Github issues, and Community forum posts

Security advisory context: GHSA-47x8-96vw-5wg6 / CVE-2026-43997.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created. Dependency-only security remediation; no docs change needed.
- [x] Tests included. Existing sandbox-related tests and typechecks were run against the dependency bump.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
