### PR TITLE
ci: Flip order of npm releases for idempotency

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -76,11 +76,9 @@ jobs:
           cp README.md packages/cli/README.md
           sed -i "s/default: 'dev'/default: '${{ needs.determine-version-info.outputs.release_type }}'/g" packages/cli/dist/config/schema.js
 
-      - name: Publish n8n to NPM with rc tag
-        env:
-          PUBLISH_BRANCH: ${{ github.event.pull_request.base.ref }}
-        run: pnpm --filter n8n publish --publish-branch "$PUBLISH_BRANCH" --access public --tag rc --no-git-checks
-
+      # Publishing via `pnpm publish -r` is idempotent, as it checks if the package exists
+      # and only publishes if it doesn't. This is why we do the sub-packages before the main n8n package.
+      # So if anything goes wrong, we can easily re-try the run instead of abandoning the release.
       - name: Publish other packages to NPM
         env:
           PUBLISH_BRANCH: ${{ github.event.pull_request.base.ref }}
@@ -91,6 +89,12 @@ jobs:
             PUBLISH_TAG="release-${PUBLISH_TAG}"
           fi
           pnpm publish -r --filter '!n8n' --publish-branch "$PUBLISH_BRANCH" --access public --tag "$PUBLISH_TAG" --no-git-checks
+
+      # If we don't use the --tag rc, all releases will default to "latest".
+      - name: Publish n8n to NPM with rc tag
+        env:
+          PUBLISH_BRANCH: ${{ github.event.pull_request.base.ref }}
+        run: pnpm --filter n8n publish --publish-branch "$PUBLISH_BRANCH" --access public --tag rc --no-git-checks
 
       - name: Cleanup rc tag
         run: npm dist-tag rm n8n rc


### PR DESCRIPTION
## Summary

As `pnpm publish -r `commands are idempotent, it makes more sense to run those before running the non-idempotent `pnpm publish n8n`. This will allow us to more safely retry publish actions if something fails instead of abandoning releases and starting the whole pipeline from step 1.

## Related Linear tickets, Github issues, and Community forum posts

Discovered during the safe-chain exclusion insidents.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
