### PR TITLE
ci: Make Chromatic visual checks non-blocking (no-changelog)

### DIFF
--- a/.github/workflows/ci-pull-request-review.yml
+++ b/.github/workflows/ci-pull-request-review.yml
@@ -41,7 +41,12 @@ jobs:
   chromatic:
     name: Chromatic
     needs: filter
-    if: needs.filter.outputs.design_system == 'true'
+    # Skip on fork PRs — they don't have access to the Chromatic secret.
+    # This job is intentionally not in `required-review-checks` needs, so it
+    # is non-blocking and won't gate merging.
+    if: >-
+      needs.filter.outputs.design_system == 'true' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/test-visual-chromatic.yml
     with:
       ref: ${{ needs.filter.outputs.commit_sha }}
@@ -51,7 +56,7 @@ jobs:
   # PRs cannot be merged unless this job passes.
   required-review-checks:
     name: Required Review Checks
-    needs: [filter, chromatic]
+    needs: [filter]
     if: always()
     runs-on: ubuntu-slim
     steps:

--- a/.github/workflows/test-visual-chromatic.yml
+++ b/.github/workflows/test-visual-chromatic.yml
@@ -34,4 +34,4 @@ jobs:
           skip: 'release/**'
           onlyChanged: true
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          exitZeroOnChanges: false
+          exitZeroOnChanges: true

--- a/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.stories.ts
@@ -65,7 +65,7 @@ export const Default: Story = {
 		variant: 'solid',
 		size: 'medium',
 		loading: false,
-		default: 'Button (Smoke test)',
+		default: 'Button',
 	},
 };
 

--- a/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.stories.ts
@@ -65,7 +65,7 @@ export const Default: Story = {
 		variant: 'solid',
 		size: 'medium',
 		loading: false,
-		default: 'Button',
+		default: 'Button (Smoke test)',
 	},
 };
 


### PR DESCRIPTION
## Summary

Makes the Chromatic visual regression check non-blocking so it never gates PR merges.

Three changes:

1. **`exitZeroOnChanges: true`** in `test-visual-chromatic.yml` — visual diffs no longer fail the job; they are surfaced via the Chromatic UI for review instead.
2. **Skip Chromatic on fork PRs** in `ci-pull-request-review.yml` — fork PRs don't get the `CHROMATIC_PROJECT_TOKEN` secret, so the job would always fail there. The job now only runs when `head.repo.full_name == github.repository`. Skipped jobs are treated as success by `required-review-checks`.
3. **Drop `chromatic` from `required-review-checks` needs** — `required-review-checks` is the gate for branch protection. Removing chromatic from its `needs` makes Chromatic informational only; it shows up as its own check in the PR but cannot block merging.

### How to test

- Open an internal (non-fork) PR touching `packages/frontend/@n8n/design-system/**` after a review approval — Chromatic should run and report results, but the `Required Review Checks` job should pass even if Chromatic reports visual changes or fails.
- Open a fork PR touching the same paths — Chromatic should be skipped entirely and `Required Review Checks` should pass.

## Related Linear tickets, Github issues, and Community forum posts

N/A — internal CI hygiene.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI