### PR TITLE
fix(editor): Change read-only background color so it's visible (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/css/_tokens.scss
+++ b/packages/frontend/@n8n/design-system/src/css/_tokens.scss
@@ -72,7 +72,7 @@
 	// Canvas
 	--canvas--color--background: var(--color--neutral-125);
 	--canvas--dot--color: var(--color--neutral-500);
-	--canvas--read-only-line--color: var(--color--neutral-100);
+	--canvas--read-only-line--color: var(--color--neutral-200);
 	--canvas--color--selected: var(--color--neutral-150);
 	--canvas--color--selected-transparent: hsla(220, 47%, 30%, 0.1);
 	--canvas--label--color: var(--color--neutral-600);


### PR DESCRIPTION
[AI-2446](https://linear.app/n8n/issue/AI-2446/read-only-canvas-stripes-invisible-in-light-mode)

## Summary

Fixes the read-only canvas stripes in light mode by increasing the contrast between the stripe color and the canvas background.

## Changes

* updates `--canvas--read-only-line--color` from `var(--color--neutral-100)` to `var(--color--neutral-200)`
* restores visibility of the striped read-only canvas in light mode
* leaves dark mode behavior unchanged

## Linear

Closes [AI-2446](https://linear.app/n8n/issue/AI-2446/read-only-canvas-stripes-invisible-in-light-mode)

## Checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.