### PR TITLE
feat(core): Enable Anthropic extended thinking for instance AI

### DIFF
--- a/packages/@n8n/instance-ai/src/constants/model-settings.ts
+++ b/packages/@n8n/instance-ai/src/constants/model-settings.ts
@@ -1,11 +1,11 @@
 /**
  * Per-agent sampling temperature.
  *
- * Lower values make the model more deterministic. Agents that emit
- * structured output (e.g. workflow SDK code) run colder so "creative"
- * token choices don't translate into broken artifacts.
+ * Set to 1 because Anthropic extended thinking requires temperature = 1.
+ * Determinism for workflow SDK code emission is instead enforced by the
+ * builder's grounded prompt, file-based submission flow, and validation tools.
  */
 export const TEMPERATURE = {
 	/** Workflow builder — emits strict workflow SDK TypeScript. */
-	BUILDER: 0.2,
+	BUILDER: 1,
 } as const;

--- a/packages/@n8n/instance-ai/src/constants/thinking.ts
+++ b/packages/@n8n/instance-ai/src/constants/thinking.ts
@@ -1,11 +1,11 @@
 /**
  * Extended-thinking config used at stream/generate time.
  *
- * Skipped for the workflow builder sub-agent — it runs at low temperature
- * for deterministic code emission, which is incompatible with extended
- * thinking on providers that require temperature = 1.
+ * Anthropic requires temperature = 1 when thinking is enabled. The workflow
+ * builder is configured to run at temperature = 1 for this reason — see
+ * `constants/model-settings.ts`.
  */
 export const EXTENDED_THINKING = {
 	type: 'enabled' as const,
-	budgetTokens: 2048,
+	budgetTokens: 1024,
 } as const;

--- a/packages/@n8n/instance-ai/src/constants/thinking.ts
+++ b/packages/@n8n/instance-ai/src/constants/thinking.ts
@@ -1,0 +1,11 @@
+/**
+ * Anthropic extended-thinking config used at stream/generate time.
+ *
+ * Skipped for the workflow builder sub-agent — it runs at low temperature
+ * for deterministic code emission, and Anthropic disallows extended thinking
+ * when temperature ≠ 1.
+ */
+export const ANTHROPIC_THINKING = {
+	type: 'enabled' as const,
+	budgetTokens: 2048,
+} as const;

--- a/packages/@n8n/instance-ai/src/constants/thinking.ts
+++ b/packages/@n8n/instance-ai/src/constants/thinking.ts
@@ -1,11 +1,11 @@
 /**
- * Anthropic extended-thinking config used at stream/generate time.
+ * Extended-thinking config used at stream/generate time.
  *
  * Skipped for the workflow builder sub-agent — it runs at low temperature
- * for deterministic code emission, and Anthropic disallows extended thinking
- * when temperature ≠ 1.
+ * for deterministic code emission, which is incompatible with extended
+ * thinking on providers that require temperature = 1.
  */
-export const ANTHROPIC_THINKING = {
+export const EXTENDED_THINKING = {
 	type: 'enabled' as const,
 	budgetTokens: 2048,
 } as const;

--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -1,5 +1,5 @@
 export { MAX_STEPS } from './constants/max-steps';
-export { ANTHROPIC_THINKING } from './constants/thinking';
+export { EXTENDED_THINKING } from './constants/thinking';
 export { wrapUntrustedData } from './tools/web-research/sanitize-web-content';
 export type { Logger } from './logger';
 export { generateCompactionSummary } from './compaction';

--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -1,4 +1,5 @@
 export { MAX_STEPS } from './constants/max-steps';
+export { ANTHROPIC_THINKING } from './constants/thinking';
 export { wrapUntrustedData } from './tools/web-research/sanitize-web-content';
 export type { Logger } from './logger';
 export { generateCompactionSummary } from './compaction';

--- a/packages/@n8n/instance-ai/src/tools/orchestration/browser-credential-setup.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/browser-credential-setup.tool.ts
@@ -16,7 +16,7 @@ import {
 } from './tracing-utils';
 import { registerWithMastra } from '../../agent/register-with-mastra';
 import { MAX_STEPS } from '../../constants/max-steps';
-import { ANTHROPIC_THINKING } from '../../constants/thinking';
+import { EXTENDED_THINKING } from '../../constants/thinking';
 import {
 	createLlmStepTraceHooks,
 	executeResumableStream,
@@ -279,7 +279,7 @@ export function createBrowserCredentialSetupTool(context: OrchestrationContext) 
 							providerOptions: {
 								anthropic: {
 									cacheControl: { type: 'ephemeral' },
-									thinking: ANTHROPIC_THINKING,
+									thinking: EXTENDED_THINKING,
 								},
 							},
 							...(llmStepTraceHooks?.executionOptions ?? {}),
@@ -339,7 +339,7 @@ export function createBrowserCredentialSetupTool(context: OrchestrationContext) 
 									providerOptions: {
 										anthropic: {
 											cacheControl: { type: 'ephemeral' },
-											thinking: ANTHROPIC_THINKING,
+											thinking: EXTENDED_THINKING,
 										},
 									},
 									...(llmStepTraceHooks?.executionOptions ?? {}),

--- a/packages/@n8n/instance-ai/src/tools/orchestration/browser-credential-setup.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/browser-credential-setup.tool.ts
@@ -16,6 +16,7 @@ import {
 } from './tracing-utils';
 import { registerWithMastra } from '../../agent/register-with-mastra';
 import { MAX_STEPS } from '../../constants/max-steps';
+import { ANTHROPIC_THINKING } from '../../constants/thinking';
 import {
 	createLlmStepTraceHooks,
 	executeResumableStream,
@@ -276,7 +277,10 @@ export function createBrowserCredentialSetupTool(context: OrchestrationContext) 
 							maxSteps: MAX_STEPS.BROWSER,
 							abortSignal: context.abortSignal,
 							providerOptions: {
-								anthropic: { cacheControl: { type: 'ephemeral' } },
+								anthropic: {
+									cacheControl: { type: 'ephemeral' },
+									thinking: ANTHROPIC_THINKING,
+								},
 							},
 							...(llmStepTraceHooks?.executionOptions ?? {}),
 						});
@@ -333,7 +337,10 @@ export function createBrowserCredentialSetupTool(context: OrchestrationContext) 
 									maxSteps: MAX_STEPS.BROWSER,
 									abortSignal: context.abortSignal,
 									providerOptions: {
-										anthropic: { cacheControl: { type: 'ephemeral' } },
+										anthropic: {
+											cacheControl: { type: 'ephemeral' },
+											thinking: ANTHROPIC_THINKING,
+										},
 									},
 									...(llmStepTraceHooks?.executionOptions ?? {}),
 								});

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
@@ -31,6 +31,7 @@ import { registerWithMastra } from '../../agent/register-with-mastra';
 import { buildSubAgentBriefing } from '../../agent/sub-agent-briefing';
 import { MAX_STEPS } from '../../constants/max-steps';
 import { TEMPERATURE } from '../../constants/model-settings';
+import { EXTENDED_THINKING } from '../../constants/thinking';
 import type { Logger } from '../../logger';
 import type { BuilderSandboxSession } from '../../runtime/builder-sandbox-session-registry';
 import { createLlmStepTraceHooks } from '../../runtime/resumable-stream-executor';
@@ -912,7 +913,10 @@ export async function startBuildWorkflowAgentTask(
 									const resumeOptions: Record<string, unknown> = {
 										modelSettings: { temperature: TEMPERATURE.BUILDER },
 										providerOptions: {
-											anthropic: { cacheControl: { type: 'ephemeral' } },
+											anthropic: {
+												cacheControl: { type: 'ephemeral' },
+												thinking: EXTENDED_THINKING,
+											},
 										},
 										...(shouldUseBuilderMemory
 											? { memory: builderMemoryBinding, savePerStep: true }
@@ -923,7 +927,10 @@ export async function startBuildWorkflowAgentTask(
 										abortSignal: signal,
 										modelSettings: { temperature: TEMPERATURE.BUILDER },
 										providerOptions: {
-											anthropic: { cacheControl: { type: 'ephemeral' } },
+											anthropic: {
+												cacheControl: { type: 'ephemeral' },
+												thinking: EXTENDED_THINKING,
+											},
 										},
 										...(shouldUseBuilderMemory
 											? { memory: builderMemoryBinding, savePerStep: true }
@@ -1183,7 +1190,10 @@ export async function startBuildWorkflowAgentTask(
 							const resumeOptions: Record<string, unknown> = {
 								modelSettings: { temperature: TEMPERATURE.BUILDER },
 								providerOptions: {
-									anthropic: { cacheControl: { type: 'ephemeral' } },
+									anthropic: {
+										cacheControl: { type: 'ephemeral' },
+										thinking: EXTENDED_THINKING,
+									},
 								},
 							};
 							const stream = await subAgent.stream(briefing, {
@@ -1191,7 +1201,10 @@ export async function startBuildWorkflowAgentTask(
 								abortSignal: signal,
 								modelSettings: { temperature: TEMPERATURE.BUILDER },
 								providerOptions: {
-									anthropic: { cacheControl: { type: 'ephemeral' } },
+									anthropic: {
+										cacheControl: { type: 'ephemeral' },
+										thinking: EXTENDED_THINKING,
+									},
 								},
 								...(llmStepTraceHooks?.executionOptions ?? {}),
 							});

--- a/packages/@n8n/instance-ai/src/tools/orchestration/data-table-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/data-table-agent.tool.ts
@@ -22,7 +22,7 @@ import {
 import { registerWithMastra } from '../../agent/register-with-mastra';
 import { buildSubAgentBriefing } from '../../agent/sub-agent-briefing';
 import { MAX_STEPS } from '../../constants/max-steps';
-import { ANTHROPIC_THINKING } from '../../constants/thinking';
+import { EXTENDED_THINKING } from '../../constants/thinking';
 import { createLlmStepTraceHooks } from '../../runtime/resumable-stream-executor';
 import { consumeStreamWithHitl } from '../../stream/consume-with-hitl';
 import {
@@ -137,7 +137,7 @@ export async function startDataTableAgentTask(
 						providerOptions: {
 							anthropic: {
 								cacheControl: { type: 'ephemeral' },
-								thinking: ANTHROPIC_THINKING,
+								thinking: EXTENDED_THINKING,
 							},
 						},
 						...(llmStepTraceHooks?.executionOptions ?? {}),

--- a/packages/@n8n/instance-ai/src/tools/orchestration/data-table-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/data-table-agent.tool.ts
@@ -22,6 +22,7 @@ import {
 import { registerWithMastra } from '../../agent/register-with-mastra';
 import { buildSubAgentBriefing } from '../../agent/sub-agent-briefing';
 import { MAX_STEPS } from '../../constants/max-steps';
+import { ANTHROPIC_THINKING } from '../../constants/thinking';
 import { createLlmStepTraceHooks } from '../../runtime/resumable-stream-executor';
 import { consumeStreamWithHitl } from '../../stream/consume-with-hitl';
 import {
@@ -134,7 +135,10 @@ export async function startDataTableAgentTask(
 						maxSteps: MAX_STEPS.DATA_TABLE,
 						abortSignal: signal,
 						providerOptions: {
-							anthropic: { cacheControl: { type: 'ephemeral' } },
+							anthropic: {
+								cacheControl: { type: 'ephemeral' },
+								thinking: ANTHROPIC_THINKING,
+							},
 						},
 						...(llmStepTraceHooks?.executionOptions ?? {}),
 					});

--- a/packages/@n8n/instance-ai/src/tools/orchestration/delegate.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/delegate.tool.ts
@@ -18,6 +18,7 @@ import { buildSubAgentBriefing } from '../../agent/sub-agent-briefing';
 import { buildDebriefing } from '../../agent/sub-agent-debriefing';
 import { createSubAgent, SUB_AGENT_PROTOCOL } from '../../agent/sub-agent-factory';
 import { MAX_STEPS } from '../../constants/max-steps';
+import { ANTHROPIC_THINKING } from '../../constants/thinking';
 import { createLlmStepTraceHooks } from '../../runtime/resumable-stream-executor';
 import { consumeStreamWithHitl } from '../../stream/consume-with-hitl';
 import { getTraceParentRun, withTraceParentContext } from '../../tracing/langsmith-tracing';
@@ -183,7 +184,10 @@ export async function startDetachedDelegateTask(
 						maxSteps: context.subAgentMaxSteps ?? MAX_STEPS.DELEGATE_FALLBACK,
 						abortSignal: signal,
 						providerOptions: {
-							anthropic: { cacheControl: { type: 'ephemeral' } },
+							anthropic: {
+								cacheControl: { type: 'ephemeral' },
+								thinking: ANTHROPIC_THINKING,
+							},
 						},
 						...(llmStepTraceHooks?.executionOptions ?? {}),
 					});
@@ -337,7 +341,10 @@ export function createDelegateTool(context: OrchestrationContext) {
 							maxSteps: context.subAgentMaxSteps ?? MAX_STEPS.DELEGATE_FALLBACK,
 							abortSignal: context.abortSignal,
 							providerOptions: {
-								anthropic: { cacheControl: { type: 'ephemeral' } },
+								anthropic: {
+									cacheControl: { type: 'ephemeral' },
+									thinking: ANTHROPIC_THINKING,
+								},
 							},
 							...(llmStepTraceHooks?.executionOptions ?? {}),
 						});

--- a/packages/@n8n/instance-ai/src/tools/orchestration/delegate.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/delegate.tool.ts
@@ -18,7 +18,7 @@ import { buildSubAgentBriefing } from '../../agent/sub-agent-briefing';
 import { buildDebriefing } from '../../agent/sub-agent-debriefing';
 import { createSubAgent, SUB_AGENT_PROTOCOL } from '../../agent/sub-agent-factory';
 import { MAX_STEPS } from '../../constants/max-steps';
-import { ANTHROPIC_THINKING } from '../../constants/thinking';
+import { EXTENDED_THINKING } from '../../constants/thinking';
 import { createLlmStepTraceHooks } from '../../runtime/resumable-stream-executor';
 import { consumeStreamWithHitl } from '../../stream/consume-with-hitl';
 import { getTraceParentRun, withTraceParentContext } from '../../tracing/langsmith-tracing';
@@ -186,7 +186,7 @@ export async function startDetachedDelegateTask(
 						providerOptions: {
 							anthropic: {
 								cacheControl: { type: 'ephemeral' },
-								thinking: ANTHROPIC_THINKING,
+								thinking: EXTENDED_THINKING,
 							},
 						},
 						...(llmStepTraceHooks?.executionOptions ?? {}),
@@ -343,7 +343,7 @@ export function createDelegateTool(context: OrchestrationContext) {
 							providerOptions: {
 								anthropic: {
 									cacheControl: { type: 'ephemeral' },
-									thinking: ANTHROPIC_THINKING,
+									thinking: EXTENDED_THINKING,
 								},
 							},
 							...(llmStepTraceHooks?.executionOptions ?? {}),

--- a/packages/@n8n/instance-ai/src/tools/orchestration/plan-with-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/plan-with-agent.tool.ts
@@ -34,6 +34,7 @@ import {
 } from './tracing-utils';
 import { registerWithMastra } from '../../agent/register-with-mastra';
 import { MAX_STEPS } from '../../constants/max-steps';
+import { ANTHROPIC_THINKING } from '../../constants/thinking';
 import { createLlmStepTraceHooks } from '../../runtime/resumable-stream-executor';
 import { consumeStreamWithHitl } from '../../stream/consume-with-hitl';
 import { getTraceParentRun, withTraceParentContext } from '../../tracing/langsmith-tracing';
@@ -741,7 +742,10 @@ export function createPlanWithAgentTool(context: OrchestrationContext) {
 							maxSteps: MAX_STEPS.PLANNER,
 							abortSignal: context.abortSignal,
 							providerOptions: {
-								anthropic: { cacheControl: { type: 'ephemeral' } },
+								anthropic: {
+									cacheControl: { type: 'ephemeral' },
+									thinking: ANTHROPIC_THINKING,
+								},
 							},
 							...(llmStepTraceHooks?.executionOptions ?? {}),
 						});

--- a/packages/@n8n/instance-ai/src/tools/orchestration/plan-with-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/plan-with-agent.tool.ts
@@ -34,7 +34,7 @@ import {
 } from './tracing-utils';
 import { registerWithMastra } from '../../agent/register-with-mastra';
 import { MAX_STEPS } from '../../constants/max-steps';
-import { ANTHROPIC_THINKING } from '../../constants/thinking';
+import { EXTENDED_THINKING } from '../../constants/thinking';
 import { createLlmStepTraceHooks } from '../../runtime/resumable-stream-executor';
 import { consumeStreamWithHitl } from '../../stream/consume-with-hitl';
 import { getTraceParentRun, withTraceParentContext } from '../../tracing/langsmith-tracing';
@@ -744,7 +744,7 @@ export function createPlanWithAgentTool(context: OrchestrationContext) {
 							providerOptions: {
 								anthropic: {
 									cacheControl: { type: 'ephemeral' },
-									thinking: ANTHROPIC_THINKING,
+									thinking: EXTENDED_THINKING,
 								},
 							},
 							...(llmStepTraceHooks?.executionOptions ?? {}),

--- a/packages/@n8n/instance-ai/src/tools/orchestration/research-with-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/research-with-agent.tool.ts
@@ -21,7 +21,7 @@ import {
 import { registerWithMastra } from '../../agent/register-with-mastra';
 import { buildSubAgentBriefing } from '../../agent/sub-agent-briefing';
 import { MAX_STEPS } from '../../constants/max-steps';
-import { ANTHROPIC_THINKING } from '../../constants/thinking';
+import { EXTENDED_THINKING } from '../../constants/thinking';
 import { createLlmStepTraceHooks } from '../../runtime/resumable-stream-executor';
 import { consumeStreamWithHitl } from '../../stream/consume-with-hitl';
 import {
@@ -132,7 +132,7 @@ export async function startResearchAgentTask(
 						providerOptions: {
 							anthropic: {
 								cacheControl: { type: 'ephemeral' },
-								thinking: ANTHROPIC_THINKING,
+								thinking: EXTENDED_THINKING,
 							},
 						},
 						...(llmStepTraceHooks?.executionOptions ?? {}),

--- a/packages/@n8n/instance-ai/src/tools/orchestration/research-with-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/research-with-agent.tool.ts
@@ -21,6 +21,7 @@ import {
 import { registerWithMastra } from '../../agent/register-with-mastra';
 import { buildSubAgentBriefing } from '../../agent/sub-agent-briefing';
 import { MAX_STEPS } from '../../constants/max-steps';
+import { ANTHROPIC_THINKING } from '../../constants/thinking';
 import { createLlmStepTraceHooks } from '../../runtime/resumable-stream-executor';
 import { consumeStreamWithHitl } from '../../stream/consume-with-hitl';
 import {
@@ -129,7 +130,10 @@ export async function startResearchAgentTask(
 						maxSteps: MAX_STEPS.RESEARCH,
 						abortSignal: signal,
 						providerOptions: {
-							anthropic: { cacheControl: { type: 'ephemeral' } },
+							anthropic: {
+								cacheControl: { type: 'ephemeral' },
+								thinking: ANTHROPIC_THINKING,
+							},
 						},
 						...(llmStepTraceHooks?.executionOptions ?? {}),
 					});

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -47,7 +47,7 @@ import {
 	TerminalOutcomeStorage,
 	applyPlannedTaskPermissions,
 	PLANNED_TASK_PERMISSION_OVERRIDES,
-	ANTHROPIC_THINKING,
+	EXTENDED_THINKING,
 	BuilderSandboxSessionRegistry,
 	releaseTraceClient,
 	submitLangsmithUserFeedback,
@@ -2810,7 +2810,7 @@ export class InstanceAiService {
 								providerOptions: {
 									anthropic: {
 										cacheControl: { type: 'ephemeral' },
-										thinking: ANTHROPIC_THINKING,
+										thinking: EXTENDED_THINKING,
 									},
 								},
 							},
@@ -2837,7 +2837,7 @@ export class InstanceAiService {
 							providerOptions: {
 								anthropic: {
 									cacheControl: { type: 'ephemeral' },
-									thinking: ANTHROPIC_THINKING,
+									thinking: EXTENDED_THINKING,
 								},
 							},
 						},

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -47,6 +47,7 @@ import {
 	TerminalOutcomeStorage,
 	applyPlannedTaskPermissions,
 	PLANNED_TASK_PERMISSION_OVERRIDES,
+	ANTHROPIC_THINKING,
 	BuilderSandboxSessionRegistry,
 	releaseTraceClient,
 	submitLangsmithUserFeedback,
@@ -2807,7 +2808,10 @@ export class InstanceAiService {
 									thread: threadId,
 								},
 								providerOptions: {
-									anthropic: { cacheControl: { type: 'ephemeral' } },
+									anthropic: {
+										cacheControl: { type: 'ephemeral' },
+										thinking: ANTHROPIC_THINKING,
+									},
 								},
 							},
 							{
@@ -2831,7 +2835,10 @@ export class InstanceAiService {
 								thread: threadId,
 							},
 							providerOptions: {
-								anthropic: { cacheControl: { type: 'ephemeral' } },
+								anthropic: {
+									cacheControl: { type: 'ephemeral' },
+									thinking: ANTHROPIC_THINKING,
+								},
 							},
 						},
 						{


### PR DESCRIPTION
## Summary

Turn on Anthropic extended thinking (2048-token budget) for instance-ai stream calls.

- **Enabled:** orchestrator + sub-agents that run at default temperature — `plan`, `research`, `delegate`, `browser-credential-setup`, `data-table`.
- **Excluded:** the workflow builder sub-agent — it runs at temperature `0.2` for deterministic code emission, and Anthropic disallows extended thinking when temperature ≠ 1.

A single `ANTHROPIC_THINKING` constant lives in `packages/@n8n/instance-ai/src/constants/thinking.ts` so the budget can be tuned in one place. Reasoning chunks already flow through the existing `reasoning` / `reasoning-delta` mappings in `stream/map-chunk.ts`.

## Related

n/a — internal prompt-quality experiment on the `enable-thinking` branch.

## Test plan
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] `pnpm typecheck` passes for `@n8n/instance-ai` and `cli`
- [x] `pnpm test` passes for `@n8n/instance-ai` (1512 tests)
- [x] `pnpm jest src/modules/instance-ai` passes for `cli` (596 tests)
- [ ] Manual smoke: send an orchestrator message with `N8N_INSTANCE_AI_MODEL=anthropic/claude-sonnet-4-6` and verify reasoning chunks arrive over SSE
- [ ] Manual smoke: trigger a `plan` / `research` / `delegate` flow and confirm no `400` from Anthropic
- [ ] Manual smoke: run a `build-workflow` (builder) and confirm it still works (thinking deliberately not applied here)