### PR TITLE
chore: Match production builder step cap in pairwise eval

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/harness/in-process-builder.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/in-process-builder.ts
@@ -42,6 +42,7 @@ import { stringifyError, truncate } from './redact';
 import { createStubServices, defaultNodesJsonPath, type StubServiceHandle } from './stub-services';
 import type { SimpleWorkflow } from '../../../ai-workflow-builder.ee/evaluations/evaluators/pairwise';
 import { registerWithMastra } from '../../src/agent/register-with-mastra';
+import { MAX_STEPS } from '../../src/constants/max-steps';
 import type { InstanceAiEventBus, StoredEvent } from '../../src/event-bus';
 import type { Logger } from '../../src/logger';
 import { executeResumableStream } from '../../src/runtime/resumable-stream-executor';
@@ -141,7 +142,11 @@ export async function buildInProcess(
 	const started = Date.now();
 	const timeoutMs = options.timeoutMs ?? 20 * 60 * 1000;
 	const modelId: ModelConfig = options.modelId ?? 'anthropic/claude-sonnet-4-6';
-	const maxSteps = options.maxSteps ?? 30;
+	// Match production: builds run with the same MAX_STEPS.BUILDER cap as
+	// `build-workflow-agent.tool.ts` uses inside the orchestrator. Halving
+	// the budget for evals makes the harness run out of steps on examples
+	// that production would complete, inflating `no_workflow_built` rates.
+	const maxSteps = options.maxSteps ?? MAX_STEPS.BUILDER;
 
 	const interactivity = {
 		askUserCount: 0,


### PR DESCRIPTION
## Summary

The pairwise eval harness was pinning the builder sub-agent's `maxSteps` to **30**, while production runs it at **60** (`MAX_STEPS.BUILDER` in `src/constants/max-steps.ts`, used by `build-workflow-agent.tool.ts`). Half the budget meant the harness was hitting the step ceiling on examples production would complete, which pessimistically inflated `no_workflow_built` rates in our reports.

This PR sources the eval default from the same constant production already uses, so the two stay in lock-step by construction. `BuildInProcessOptions.maxSteps` is still overridable per-call if a future eval mode needs a different cap.

### Why this surfaced

While analyzing a full pairwise run against the new builder dataset, 47 of 91 examples (52%) failed with `no_workflow_built` — most of them mid-`tsc` fix-loop. Tracing through the harness vs. production confirmed the step ceiling was the artifact, not the builder's capability.

### How to test

```bash
cd packages/@n8n/instance-ai && pnpm typecheck && pnpm lint
```

No behavioural change for tests (no test assertions on `maxSteps`).

## Related Linear tickets, Github issues, and Community forum posts

n/a — internal eval tooling fix.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included. <!-- N/A — constant default, no behavioural test surface. -->
- [ ] PR Labeled with backport tag (not a hotfix).

🤖 PR Summary generated by AI