### PR TITLE
feat(editor): Add "New agent" to the universal add menu (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4637,6 +4637,7 @@
 	"projects.menu.chat": "Chat",
 	"projects.menu.create.workflow": "New workflow",
 	"projects.menu.create.credential": "New credential",
+	"projects.menu.create.agent": "New agent",
 	"projects.menu.create.project": "New project",
 	"projects.settings": "Project settings",
 	"projects.settings.info": "Project info",

--- a/packages/frontend/editor-ui/src/app/composables/useGlobalEntityCreation.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useGlobalEntityCreation.test.ts
@@ -12,6 +12,7 @@ import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/
 import type { CloudPlanState } from '@/Interface';
 
 import { VIEWS } from '@/app/constants';
+import { NEW_AGENT_VIEW, AGENTS_MODULE_NAME } from '@/features/agents/constants';
 import type { Project, ProjectListItem } from '@/features/collaboration/projects/projects.types';
 
 import { useGlobalEntityCreation } from './useGlobalEntityCreation';
@@ -241,5 +242,167 @@ describe('useGlobalEntityCreation', () => {
 
 		expect(menu.value[0].submenu).toBe(undefined);
 		expect(menu.value[1].submenu).toBe(undefined);
+	});
+
+	describe('agents module', () => {
+		const enableAgentsModule = () => {
+			const settingsStore = mockedStore(useSettingsStore);
+			settingsStore.isModuleActive.mockImplementation(
+				(name: string) => name === AGENTS_MODULE_NAME,
+			);
+			return settingsStore;
+		};
+
+		it('omits the agent entry from the community shape when the module is inactive', () => {
+			const projectsStore = mockedStore(useProjectsStore);
+			projectsStore.isTeamProjectFeatureEnabled = false;
+			projectsStore.personalProject = { id: 'personal-project' } as Project;
+
+			const { menu } = useGlobalEntityCreation();
+
+			expect(menu.value.find((item) => item.id === 'agent')).toBeUndefined();
+		});
+
+		it('inserts a flat agent entry between credential and create-project in community shape', () => {
+			enableAgentsModule();
+
+			const projectsStore = mockedStore(useProjectsStore);
+			const personalProjectId = 'personal-project';
+			projectsStore.isTeamProjectFeatureEnabled = false;
+			projectsStore.personalProject = { id: personalProjectId } as Project;
+
+			const { menu } = useGlobalEntityCreation();
+
+			expect(menu.value).toHaveLength(4);
+			expect(menu.value[2]).toStrictEqual(
+				expect.objectContaining({
+					id: 'agent',
+					route: { name: NEW_AGENT_VIEW, query: { projectId: personalProjectId } },
+				}),
+			);
+			expect(menu.value[3].id).toBe('create-project');
+		});
+
+		it('inserts a flat agent entry when team feature is enabled but no team projects exist', () => {
+			enableAgentsModule();
+
+			const projectsStore = mockedStore(useProjectsStore);
+			projectsStore.teamProjectsLimit = -1;
+			const personalProjectId = 'personal-project';
+			projectsStore.isTeamProjectFeatureEnabled = true;
+			projectsStore.personalProject = {
+				id: personalProjectId,
+				scopes: ['agent:create'],
+			} as Project;
+			projectsStore.myProjects = [];
+
+			const { menu } = useGlobalEntityCreation();
+
+			expect(menu.value).toHaveLength(4);
+			expect(menu.value[2]).toStrictEqual(
+				expect.objectContaining({
+					id: 'agent',
+					disabled: false,
+					route: { name: NEW_AGENT_VIEW, query: { projectId: personalProjectId } },
+				}),
+			);
+		});
+
+		it('disables the flat agent entry when the user lacks the agent:create scope', () => {
+			enableAgentsModule();
+
+			const projectsStore = mockedStore(useProjectsStore);
+			projectsStore.teamProjectsLimit = -1;
+			projectsStore.isTeamProjectFeatureEnabled = true;
+			projectsStore.personalProject = {
+				id: 'personal-project',
+				scopes: [],
+			} as unknown as Project;
+			projectsStore.myProjects = [];
+
+			const { menu } = useGlobalEntityCreation();
+
+			expect(menu.value[2]).toStrictEqual(expect.objectContaining({ id: 'agent', disabled: true }));
+		});
+
+		it('shows agent submenu with personal + team projects in the global shape', () => {
+			enableAgentsModule();
+
+			const projectsStore = mockedStore(useProjectsStore);
+			projectsStore.teamProjectsLimit = -1;
+			const personalProjectId = 'personal-project';
+			projectsStore.isTeamProjectFeatureEnabled = true;
+			projectsStore.personalProject = {
+				id: personalProjectId,
+				scopes: ['agent:create'],
+			} as Project;
+			projectsStore.myProjects = [
+				{ id: '1', name: '1', type: 'team', scopes: ['agent:create'] },
+				{ id: '2', name: '2', type: 'public' },
+				{ id: '3', name: '3', type: 'team', scopes: [] },
+			] as ProjectListItem[];
+
+			const { menu } = useGlobalEntityCreation();
+
+			expect(menu.value).toHaveLength(4);
+
+			const agentEntry = menu.value[2];
+			expect(agentEntry.id).toBe('agent');
+			expect(agentEntry.submenu).toHaveLength(4);
+
+			const personal = agentEntry.submenu?.find((s) => s.id === 'agent-personal');
+			expect(personal).toStrictEqual(
+				expect.objectContaining({
+					disabled: false,
+					route: { name: NEW_AGENT_VIEW, query: { projectId: personalProjectId } },
+				}),
+			);
+
+			const teamWithScope = agentEntry.submenu?.find((s) => s.id === 'agent-1');
+			expect(teamWithScope?.disabled).toBe(false);
+			expect(teamWithScope?.route).toEqual({
+				name: NEW_AGENT_VIEW,
+				query: { projectId: '1' },
+			});
+
+			const teamWithoutScope = agentEntry.submenu?.find((s) => s.id === 'agent-3');
+			expect(teamWithoutScope?.disabled).toBe(true);
+		});
+
+		it('omits the agent entry from the global shape when the module is inactive', () => {
+			const projectsStore = mockedStore(useProjectsStore);
+			projectsStore.teamProjectsLimit = -1;
+			projectsStore.isTeamProjectFeatureEnabled = true;
+			projectsStore.personalProject = { id: 'personal-project' } as Project;
+			projectsStore.myProjects = [{ id: '1', name: '1', type: 'team' }] as ProjectListItem[];
+
+			const { menu } = useGlobalEntityCreation();
+
+			expect(menu.value.find((item) => item.id === 'agent')).toBeUndefined();
+		});
+
+		it('disables the agent submenu in the global shape when branch is read-only', () => {
+			enableAgentsModule();
+
+			const sourceControlStore = mockedStore(useSourceControlStore);
+			sourceControlStore.preferences.branchReadOnly = true;
+
+			const projectsStore = mockedStore(useProjectsStore);
+			projectsStore.teamProjectsLimit = -1;
+			projectsStore.isTeamProjectFeatureEnabled = true;
+			projectsStore.personalProject = {
+				id: 'personal-project',
+				scopes: ['agent:create'],
+			} as Project;
+			projectsStore.myProjects = [
+				{ id: '1', name: '1', type: 'team', scopes: ['agent:create'] },
+			] as ProjectListItem[];
+
+			const { menu } = useGlobalEntityCreation();
+
+			const agentEntry = menu.value.find((item) => item.id === 'agent');
+			expect(agentEntry?.disabled).toBe(true);
+			expect(agentEntry?.submenu).toBeUndefined();
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/useGlobalEntityCreation.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useGlobalEntityCreation.test.ts
@@ -273,14 +273,13 @@ describe('useGlobalEntityCreation', () => {
 
 			const { menu } = useGlobalEntityCreation();
 
-			expect(menu.value).toHaveLength(4);
-			expect(menu.value[2]).toStrictEqual(
+			const ids = menu.value.map((item) => item.id);
+			expect(ids).toEqual(['workflow', 'credential', 'agent', 'create-project']);
+			expect(menu.value.find((item) => item.id === 'agent')).toStrictEqual(
 				expect.objectContaining({
-					id: 'agent',
 					route: { name: NEW_AGENT_VIEW, query: { projectId: personalProjectId } },
 				}),
 			);
-			expect(menu.value[3].id).toBe('create-project');
 		});
 
 		it('inserts a flat agent entry when team feature is enabled but no team projects exist', () => {
@@ -298,10 +297,8 @@ describe('useGlobalEntityCreation', () => {
 
 			const { menu } = useGlobalEntityCreation();
 
-			expect(menu.value).toHaveLength(4);
-			expect(menu.value[2]).toStrictEqual(
+			expect(menu.value.find((item) => item.id === 'agent')).toStrictEqual(
 				expect.objectContaining({
-					id: 'agent',
 					disabled: false,
 					route: { name: NEW_AGENT_VIEW, query: { projectId: personalProjectId } },
 				}),
@@ -322,7 +319,9 @@ describe('useGlobalEntityCreation', () => {
 
 			const { menu } = useGlobalEntityCreation();
 
-			expect(menu.value[2]).toStrictEqual(expect.objectContaining({ id: 'agent', disabled: true }));
+			expect(menu.value.find((item) => item.id === 'agent')).toStrictEqual(
+				expect.objectContaining({ disabled: true }),
+			);
 		});
 
 		it('shows agent submenu with personal + team projects in the global shape', () => {
@@ -344,13 +343,11 @@ describe('useGlobalEntityCreation', () => {
 
 			const { menu } = useGlobalEntityCreation();
 
-			expect(menu.value).toHaveLength(4);
+			const agentEntry = menu.value.find((item) => item.id === 'agent');
+			expect(agentEntry).toBeDefined();
+			expect(agentEntry?.submenu).toHaveLength(4);
 
-			const agentEntry = menu.value[2];
-			expect(agentEntry.id).toBe('agent');
-			expect(agentEntry.submenu).toHaveLength(4);
-
-			const personal = agentEntry.submenu?.find((s) => s.id === 'agent-personal');
+			const personal = agentEntry?.submenu?.find((s) => s.id === 'agent-personal');
 			expect(personal).toStrictEqual(
 				expect.objectContaining({
 					disabled: false,
@@ -358,14 +355,14 @@ describe('useGlobalEntityCreation', () => {
 				}),
 			);
 
-			const teamWithScope = agentEntry.submenu?.find((s) => s.id === 'agent-1');
+			const teamWithScope = agentEntry?.submenu?.find((s) => s.id === 'agent-1');
 			expect(teamWithScope?.disabled).toBe(false);
 			expect(teamWithScope?.route).toEqual({
 				name: NEW_AGENT_VIEW,
 				query: { projectId: '1' },
 			});
 
-			const teamWithoutScope = agentEntry.submenu?.find((s) => s.id === 'agent-3');
+			const teamWithoutScope = agentEntry?.submenu?.find((s) => s.id === 'agent-3');
 			expect(teamWithoutScope?.disabled).toBe(true);
 		});
 

--- a/packages/frontend/editor-ui/src/app/composables/useGlobalEntityCreation.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useGlobalEntityCreation.ts
@@ -1,5 +1,6 @@
 import { computed, ref } from 'vue';
 import { VIEWS } from '@/app/constants';
+import { AGENTS_MODULE_NAME, NEW_AGENT_VIEW } from '@/features/agents/constants';
 import { useRouter } from 'vue-router';
 import { useI18n } from '@n8n/i18n';
 import { sortByProperty } from '@n8n/utils/sort/sortByProperty';
@@ -44,6 +45,7 @@ export const useGlobalEntityCreation = () => {
 	const CREATE_PROJECT_ID = 'create-project';
 	const WORKFLOWS_MENU_ID = 'workflow';
 	const CREDENTIALS_MENU_ID = 'credential';
+	const AGENTS_MENU_ID = 'agent';
 	const DEFAULT_ICON: IconName = 'layers';
 
 	const settingsStore = useSettingsStore();
@@ -72,9 +74,15 @@ export const useGlobalEntityCreation = () => {
 		sourceControlStore.preferences.branchReadOnly ||
 		!getResourcePermissions(scopes).credential.create;
 
+	const disabledAgent = (scopes: Scope[] = []): boolean =>
+		sourceControlStore.preferences.branchReadOnly || !getResourcePermissions(scopes).agent?.create;
+
+	const isAgentsModuleActive = computed(() => settingsStore.isModuleActive(AGENTS_MODULE_NAME));
+
 	const menu = computed<Item[]>(() => {
 		const workflowTitle = i18n.baseText('projects.menu.create.workflow');
 		const credentialTitle = i18n.baseText('projects.menu.create.credential');
+		const agentTitle = i18n.baseText('projects.menu.create.agent');
 		const projectTitle = i18n.baseText('projects.menu.create.project');
 
 		// Community
@@ -101,6 +109,18 @@ export const useGlobalEntityCreation = () => {
 						},
 					},
 				},
+				...(isAgentsModuleActive.value
+					? [
+							{
+								id: AGENTS_MENU_ID,
+								title: agentTitle,
+								route: {
+									name: NEW_AGENT_VIEW,
+									query: { projectId: projectsStore.personalProject?.id },
+								},
+							},
+						]
+					: []),
 				{
 					id: CREATE_PROJECT_ID,
 					title: projectTitle,
@@ -134,6 +154,19 @@ export const useGlobalEntityCreation = () => {
 						params: { projectId: projectsStore.personalProject?.id, credentialId: 'create' },
 					},
 				},
+				...(isAgentsModuleActive.value
+					? [
+							{
+								id: AGENTS_MENU_ID,
+								title: agentTitle,
+								disabled: disabledAgent(projectsStore.personalProject?.scopes),
+								route: {
+									name: NEW_AGENT_VIEW,
+									query: { projectId: projectsStore.personalProject?.id },
+								},
+							},
+						]
+					: []),
 				{
 					id: CREATE_PROJECT_ID,
 					title: projectTitle,
@@ -214,6 +247,44 @@ export const useGlobalEntityCreation = () => {
 					],
 				}),
 			},
+			...(isAgentsModuleActive.value
+				? [
+						{
+							id: AGENTS_MENU_ID,
+							title: agentTitle,
+							disabled: sourceControlStore.preferences.branchReadOnly,
+							...(!sourceControlStore.preferences.branchReadOnly && {
+								submenu: [
+									{
+										id: 'agent-title',
+										title: 'Create in',
+										disabled: true,
+									},
+									{
+										id: 'agent-personal',
+										title: i18n.baseText('projects.menu.personal'),
+										icon: 'user' as const,
+										disabled: disabledAgent(projectsStore.personalProject?.scopes),
+										route: {
+											name: NEW_AGENT_VIEW,
+											query: { projectId: projectsStore.personalProject?.id },
+										},
+									},
+									...displayProjects.value.map((project) => ({
+										id: `agent-${project.id}`,
+										title: project.name as string,
+										icon: isProjectIcon(project.icon) ? project.icon : DEFAULT_ICON,
+										disabled: disabledAgent(project.scopes),
+										route: {
+											name: NEW_AGENT_VIEW,
+											query: { projectId: project.id },
+										},
+									})),
+								],
+							}),
+						},
+					]
+				: []),
 			{
 				id: CREATE_PROJECT_ID,
 				title: projectTitle,

--- a/packages/frontend/editor-ui/src/app/utils/modules/tabUtils.ts
+++ b/packages/frontend/editor-ui/src/app/utils/modules/tabUtils.ts
@@ -20,22 +20,21 @@ export type ProcessedDynamicTab = TabOptions<string> & { insertAfter?: string };
  * Resolves dynamic routes with project IDs and other parameters
  */
 export function processDynamicTab(tab: DynamicTabOptions, projectId?: string): ProcessedDynamicTab {
-	const { dynamicRoute, ...rest } = tab;
-
-	if (!dynamicRoute) {
-		return rest;
+	if (!tab.dynamicRoute) {
+		return tab;
 	}
 
 	const tabRoute: RouteLocationRaw = {
-		name: dynamicRoute.name,
+		name: tab.dynamicRoute.name,
 	};
 
-	if (dynamicRoute.includeProjectId && projectId) {
+	if (tab.dynamicRoute.includeProjectId && projectId) {
 		tabRoute.params = { projectId };
 	}
 
+	const { dynamicRoute, ...tabWithoutDynamic } = tab;
 	return {
-		...rest,
+		...tabWithoutDynamic,
 		to: tabRoute,
 	};
 }

--- a/packages/frontend/editor-ui/src/app/utils/modules/tabUtils.ts
+++ b/packages/frontend/editor-ui/src/app/utils/modules/tabUtils.ts
@@ -6,28 +6,36 @@ export type DynamicTabOptions = TabOptions<string> & {
 		name: string;
 		includeProjectId?: boolean;
 	};
+	/**
+	 * Insert this tab immediately after the tab whose `value` matches.
+	 * If unset (or no match is found at render time), the tab is appended at the end.
+	 */
+	insertAfter?: string;
 };
+
+export type ProcessedDynamicTab = TabOptions<string> & { insertAfter?: string };
 
 /**
  * Process dynamic route configuration for tabs
  * Resolves dynamic routes with project IDs and other parameters
  */
-export function processDynamicTab(tab: DynamicTabOptions, projectId?: string): TabOptions<string> {
-	if (!tab.dynamicRoute) {
-		return tab;
+export function processDynamicTab(tab: DynamicTabOptions, projectId?: string): ProcessedDynamicTab {
+	const { dynamicRoute, ...rest } = tab;
+
+	if (!dynamicRoute) {
+		return rest;
 	}
 
 	const tabRoute: RouteLocationRaw = {
-		name: tab.dynamicRoute.name,
+		name: dynamicRoute.name,
 	};
 
-	if (tab.dynamicRoute.includeProjectId && projectId) {
+	if (dynamicRoute.includeProjectId && projectId) {
 		tabRoute.params = { projectId };
 	}
 
-	const { dynamicRoute, ...tabWithoutDynamic } = tab;
 	return {
-		...tabWithoutDynamic,
+		...rest,
 		to: tabRoute,
 	};
 }
@@ -38,6 +46,6 @@ export function processDynamicTab(tab: DynamicTabOptions, projectId?: string): T
 export function processDynamicTabs(
 	tabs: DynamicTabOptions[],
 	projectId?: string,
-): Array<TabOptions<string>> {
+): ProcessedDynamicTab[] {
 	return tabs.map((tab) => processDynamicTab(tab, projectId));
 }

--- a/packages/frontend/editor-ui/src/features/agents/module.descriptor.ts
+++ b/packages/frontend/editor-ui/src/features/agents/module.descriptor.ts
@@ -1,4 +1,5 @@
 import { i18n } from '@n8n/i18n';
+import { VIEWS } from '@/app/constants';
 import { type FrontendModuleDescription } from '@/app/moduleInitializer/module.types';
 import { hasPermission } from '@/app/utils/rbac/permissions';
 import {
@@ -164,6 +165,7 @@ export const AgentsModule: FrontendModuleDescription = {
 				label: 'Agents',
 				value: AGENTS_LIST_VIEW,
 				preview: true,
+				insertAfter: VIEWS.WORKFLOWS,
 				to: {
 					name: AGENTS_LIST_VIEW,
 				},
@@ -174,6 +176,7 @@ export const AgentsModule: FrontendModuleDescription = {
 				label: 'Agents',
 				value: PROJECT_AGENTS,
 				preview: true,
+				insertAfter: VIEWS.PROJECTS_WORKFLOWS,
 				dynamicRoute: {
 					name: PROJECT_AGENTS,
 					includeProjectId: true,

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectTabs.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectTabs.test.ts
@@ -81,4 +81,41 @@ describe('ProjectTabs', () => {
 		expect(getByText('Preview')).toBeInTheDocument();
 		expect(container.querySelector('.preview')).toBeInTheDocument();
 	});
+
+	const getTabValuesInOrder = (container: ParentNode) =>
+		Array.from(container.querySelectorAll('[data-test-id^="tab-"]'))
+			.map((el) => el.getAttribute('data-test-id')?.replace(/^tab-/, ''))
+			.filter((v): v is string => !!v);
+
+	it('should insert an additional tab right after the matching base tab when insertAfter is set', () => {
+		const { container } = renderComponent({
+			props: {
+				pageType: 'overview',
+				additionalTabs: [
+					{ label: 'Agents', value: 'agents', preview: true, insertAfter: 'WorkflowsView' },
+					{ label: 'Data tables', value: 'dataTables' },
+				],
+			},
+		});
+
+		expect(getTabValuesInOrder(container)).toEqual([
+			'WorkflowsView',
+			'agents',
+			'CredentialsView',
+			'Executions',
+			'HomeVariables',
+			'dataTables',
+		]);
+	});
+
+	it('appends the additional tab when insertAfter does not match any base tab', () => {
+		const { container } = renderComponent({
+			props: {
+				additionalTabs: [{ label: 'Agents', value: 'agents', insertAfter: 'NonExistent' }],
+			},
+		});
+
+		const tabValues = getTabValuesInOrder(container);
+		expect(tabValues[tabValues.length - 1]).toBe('agents');
+	});
 });

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectTabs.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectTabs.vue
@@ -116,7 +116,15 @@ const options = computed<Array<TabOptions<string>>>(() => {
 
 	if (props.additionalTabs?.length) {
 		const processedAdditionalTabs = processDynamicTabs(props.additionalTabs, projectId.value);
-		tabs.push(...processedAdditionalTabs);
+		for (const processed of processedAdditionalTabs) {
+			const { insertAfter, ...tab } = processed;
+			const anchorIndex = insertAfter ? tabs.findIndex((t) => t.value === insertAfter) : -1;
+			if (anchorIndex !== -1) {
+				tabs.splice(anchorIndex + 1, 0, tab);
+			} else {
+				tabs.push(tab);
+			}
+		}
 	}
 
 	if (props.showSettings) {


### PR DESCRIPTION
## Summary

Two related improvements to the agent surface area:

1. **New agent in the universal add menu** — adds a `New agent` entry to the global "+" menu in the main sidebar, alongside Workflow, Credentials, and Create Project. The entry follows the existing per-project submenu pattern (Personal + each team project), is gated by `settingsStore.isModuleActive('agents')`, respects per-project `agent:create` scope, and routes to `/new-agent?projectId=<id>`.

2. **Agents tab positioned right after Workflows** — extends `DynamicTabOptions` with an `insertAfter` field so module-registered project tabs can be placed at a specific position relative to the base tabs. Used to move the Agents tab from the end of the row to immediately after Workflows in both the per-project and overview pages.

**How to test:**
1. Start the editor with the agents module enabled.
2. Click the "+" button in the main sidebar header — verify a `New agent` entry appears between Credentials and Create Project, with a submenu listing Personal and each team project. Clicking any sublink opens `/new-agent?projectId=<id>`.
3. Open a project (e.g. `/projects/<id>/workflows`) — verify the tab order is `Workflows → Agents (Preview) → Credentials → Executions → Data tables`. The same applies to the overview page.
4. Disable the agents module — both the menu entry and the tab should disappear.
5. With a source-control read-only branch, the top-level menu entry should be disabled.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AGENT-105/feature-add-new-agent-to-universal-add-menu

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
