### PR TITLE
fix(editor): Make agent publish indicator dot use correct color (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentPublishButton.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentPublishButton.test.ts
@@ -335,4 +335,36 @@ describe('AgentPublishButton', () => {
 		expect(unpublishAgent).not.toHaveBeenCalled();
 		expect(wrapper.emitted('unpublished')).toBeUndefined();
 	});
+
+	// Indicator dot styling — guards against regressions like
+	// using subtle text-color tokens that render an invisible dot.
+	describe('indicator dot', () => {
+		it('does not render the indicator when the agent is not published', async () => {
+			const wrapper = await renderComponent({
+				agent: createAgent({ publishedVersion: null }),
+			});
+			const button = wrapper.find('[data-testid="publish-agent-button"]');
+			expect(button.find('span[class*="indicatorDot"]').exists()).toBe(false);
+		});
+
+		it('renders the published indicator when latest version is published', async () => {
+			const wrapper = await renderComponent({
+				agent: createAgent({ versionId: 'v1', publishedVersion }),
+			});
+			const dot = wrapper.find('[data-testid="publish-agent-button"] span[class*="indicatorDot"]');
+			expect(dot.exists()).toBe(true);
+			expect(dot.classes().some((c) => c.includes('indicatorPublished'))).toBe(true);
+			expect(dot.classes().some((c) => c.includes('indicatorChanges'))).toBe(false);
+		});
+
+		it('renders the changes indicator when there are unpublished changes', async () => {
+			const wrapper = await renderComponent({
+				agent: createAgent({ versionId: 'v2', publishedVersion }),
+			});
+			const dot = wrapper.find('[data-testid="publish-agent-button"] span[class*="indicatorDot"]');
+			expect(dot.exists()).toBe(true);
+			expect(dot.classes().some((c) => c.includes('indicatorChanges'))).toBe(true);
+			expect(dot.classes().some((c) => c.includes('indicatorPublished'))).toBe(false);
+		});
+	});
 });

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentPublishButton.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentPublishButton.vue
@@ -191,15 +191,15 @@ async function onDropdownSelect(action: string) {
 }
 
 .indicatorPublished {
-	background-color: var(--text-color--success);
+	background-color: var(--color--mint-600);
 }
 
 .indicatorPublishedText {
-	color: var(--text-color--subtle);
+	color: var(--color--text--tint-1);
 }
 
 .indicatorChanges {
-	background-color: var(--text-color--warning);
+	background-color: var(--color--yellow-500);
 }
 
 .flex {


### PR DESCRIPTION
## Summary

The colored indicator dot next to the **Publish/Published** button on an agent's detail page was using incorrect colors. Cause: `AgentPublishButton.vue` styled the dot using `--text-color--success` / `--text-color--warning`, which are subdued *text* tokens, instead of the vibrant indicator primitives (`--color--mint-600`, `--color--yellow-500`) that every other status dot in the app already uses (workflow Publish button, agent list card, workflow card, version-history indicator).

Fix: align the three CSS rules in `AgentPublishButton.vue` with the workflow Publish button. Components were already shared (`N8nButton`, `N8nActionDropdown`, `N8nIconButton`) — only the CSS values diverged.

Also added a regression test that asserts the right CSS-module class lands on the indicator span per publish state.

### How to test

1. Open an agent detail page (e.g. `/projects/<projectId>/agents/<agentId>`).
2. **Not published**: button reads "Publish", no dot.
3. **Published, no changes**: click Publish — button reads "Published", dot is **vibrant mint green**, clearly visible in both light and dark mode.
4. **Published with changes**: edit the agent — button reverts to "Publish" with a **vibrant yellow** dot.
5. Cross-check against any published workflow — the dot on its Published button should look identical.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-104

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI