### PR TITLE
feat(design-system): increase N8nIcon size mapping defaults

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nIcon/Icon.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nIcon/Icon.vue
@@ -39,11 +39,11 @@ const classes = computed(() => {
 });
 
 const sizesInPixels: Record<IconSize, number> = {
-	xsmall: 10,
-	small: 12,
-	medium: 14,
-	large: 16,
-	xlarge: 20,
+	xsmall: 12,
+	small: 14,
+	medium: 16,
+	large: 20,
+	xlarge: 24,
 	xxlarge: 40,
 };
 


### PR DESCRIPTION
### Motivation
- Align default rendered icon sizes with updated design expectations by increasing the pixel mapping for the `N8nIcon` sizes.

### Description
- Update `sizesInPixels` in `packages/frontend/@n8n/design-system/src/components/N8nIcon/Icon.vue` to `xsmall: 12, small: 14, medium: 16, large: 20, xlarge: 24, xxlarge: 40` and commit the change on branch `codex-DS-540` (Linear: https://linear.app/n8n/issue/DS-540).

### Testing
- No automated tests were run for this constant-only mapping change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc618a019c832db32973a53a03144a)