### PR TITLE
feat(editor): Add toggle components (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nToggle/Toggle.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nToggle/Toggle.stories.ts
@@ -1,0 +1,101 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import { ref } from 'vue';
+
+import N8nToggle from './Toggle.vue';
+
+const meta = {
+	title: 'Core/Toggle',
+	component: N8nToggle,
+	argTypes: {
+		variant: {
+			control: 'select',
+			options: ['solid', 'subtle', 'ghost', 'outline', 'destructive', 'success'],
+		},
+		size: {
+			control: 'select',
+			options: ['xsmall', 'small', 'medium', 'large', 'xlarge'],
+		},
+		disabled: { control: 'boolean' },
+		label: { control: 'text' },
+		icon: { control: 'text' },
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'An icon-only two-state button built on Reka UI Toggle and styled to match N8nButton variants and sizes. The label renders as both the accessible name and tooltip content.',
+			},
+			source: { type: 'dynamic' },
+		},
+	},
+} satisfies Meta<typeof N8nToggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+	render: (args) => ({
+		components: { N8nToggle },
+		setup() {
+			const pressed = ref(false);
+			return { args, pressed };
+		},
+		template: `
+			<div style="display: grid; place-items: center;">
+				<N8nToggle v-model="pressed" v-bind="args" />
+			</div>
+		`,
+	}),
+	args: {
+		label: 'Toggle bold',
+		icon: 'text',
+		variant: 'solid',
+		size: 'medium',
+		disabled: false,
+	},
+};
+
+export const Variants: Story = {
+	args: { label: 'Toggle text' },
+	render: () => ({
+		components: { N8nToggle },
+		setup() {
+			const variants = ['solid', 'subtle', 'ghost', 'outline', 'destructive', 'success'];
+			return { variants };
+		},
+		template: `
+			<div style="display: flex; gap: 12px; align-items: center; justify-content: center;">
+				<N8nToggle
+					v-for="variant in variants"
+					:key="variant"
+					:variant="variant"
+					:label="variant"
+					icon="text"
+					model-value
+				/>
+			</div>
+		`,
+	}),
+};
+
+export const Sizes: Story = {
+	args: { label: 'Toggle text' },
+	render: () => ({
+		components: { N8nToggle },
+		setup() {
+			const sizes = ['xsmall', 'small', 'medium', 'large', 'xlarge'];
+			return { sizes };
+		},
+		template: `
+			<div style="display: flex; gap: 12px; align-items: center; justify-content: center;">
+				<N8nToggle
+					v-for="size in sizes"
+					:key="size"
+					:size="size"
+					:label="size"
+					icon="text"
+				/>
+			</div>
+		`,
+	}),
+};

--- a/packages/frontend/@n8n/design-system/src/components/N8nToggle/Toggle.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nToggle/Toggle.test.ts
@@ -55,8 +55,11 @@ describe('components/N8nToggle', () => {
 			global: { stubs: { N8nTooltip: tooltipStub, N8nIcon: true } },
 		});
 
-		await userEvent.click(wrapper.getByRole('button', { name: 'Italic' }));
+		const toggle = wrapper.getByRole('button', { name: 'Italic' });
+		await userEvent.click(toggle);
+
 		expect(onUpdate).toHaveBeenCalledWith(true);
+		expect(toggle).toHaveAttribute('data-state', 'off');
 	});
 
 	it('renders pressed state from modelValue', () => {
@@ -136,5 +139,24 @@ describe('components/N8nToggle', () => {
 
 		await userEvent.click(toggle);
 		expect(onUpdate).not.toHaveBeenCalled();
+	});
+
+	it('passes disabled state from N8nToggleGroup slot props to child toggles', () => {
+		const TestComponent = defineComponent({
+			components: { N8nToggleGroup, N8nToggle },
+			template: `
+				<N8nToggleGroup disabled>
+					<template #default="slotProps">
+						<N8nToggle value="left" label="Align left" v-bind="slotProps">L</N8nToggle>
+					</template>
+				</N8nToggleGroup>
+			`,
+		});
+
+		const wrapper = render(TestComponent, {
+			global: { stubs: { N8nTooltip: tooltipStub, N8nIcon: true } },
+		});
+
+		expect(wrapper.getByRole('button', { name: 'Align left' })).toBeDisabled();
 	});
 });

--- a/packages/frontend/@n8n/design-system/src/components/N8nToggle/Toggle.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nToggle/Toggle.test.ts
@@ -72,6 +72,21 @@ describe('components/N8nToggle', () => {
 		expect(wrapper.getByRole('button')).toHaveAttribute('data-state', 'on');
 	});
 
+	it('treats null modelValue as unpressed when reset from a pressed state', async () => {
+		const wrapper = render(N8nToggle, {
+			props: { label: 'Underline', modelValue: true },
+			slots: { default: '<span>U</span>' },
+			global: { stubs: { N8nTooltip: tooltipStub, N8nIcon: true } },
+		});
+
+		const toggle = wrapper.getByRole('button');
+		expect(toggle).toHaveAttribute('data-state', 'on');
+
+		await wrapper.rerender({ modelValue: null });
+
+		expect(toggle).toHaveAttribute('data-state', 'off');
+	});
+
 	it('can be used inside N8nToggleGroup as a single-selection item', async () => {
 		const TestComponent = defineComponent({
 			components: { N8nToggleGroup, N8nToggle },

--- a/packages/frontend/@n8n/design-system/src/components/N8nToggle/Toggle.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nToggle/Toggle.test.ts
@@ -1,0 +1,140 @@
+import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/vue';
+import { defineComponent, ref } from 'vue';
+
+import N8nToggle from './Toggle.vue';
+import N8nToggleGroup from '../N8nToggleGroup/ToggleGroup.vue';
+
+const tooltipStub = {
+	template: '<span data-test-id="tooltip" :data-content="content"><slot /></span>',
+	props: ['content'],
+};
+
+describe('components/N8nToggle', () => {
+	it('renders an icon-only button with the label as accessible name and tooltip content', () => {
+		const wrapper = render(N8nToggle, {
+			props: { label: 'Bold', icon: 'text' },
+			global: { stubs: { N8nTooltip: tooltipStub, N8nIcon: true } },
+		});
+
+		const toggle = wrapper.getByRole('button', { name: 'Bold' });
+		expect(toggle).toBeInTheDocument();
+		expect(toggle.className).toContain('iconOnly');
+		expect(wrapper.getByTestId('tooltip')).toHaveAttribute('data-content', 'Bold');
+	});
+
+	it.each(['solid', 'subtle', 'ghost', 'outline', 'destructive', 'success'] as const)(
+		'renders %s variant like N8nButton',
+		(variant) => {
+			const wrapper = render(N8nToggle, {
+				props: { label: 'Align left', icon: 'align-right', variant },
+				global: { stubs: { N8nTooltip: tooltipStub, N8nIcon: true } },
+			});
+
+			expect(wrapper.getByRole('button').className).toContain(variant);
+		},
+	);
+
+	it.each(['xsmall', 'small', 'medium', 'large', 'xlarge'] as const)(
+		'renders %s size like N8nButton',
+		(size) => {
+			const wrapper = render(N8nToggle, {
+				props: { label: 'Align left', icon: 'align-right', size },
+				global: { stubs: { N8nTooltip: tooltipStub, N8nIcon: true } },
+			});
+
+			expect(wrapper.getByRole('button').className).toContain(size);
+		},
+	);
+
+	it('supports controlled pressed state', async () => {
+		const onUpdate = vi.fn();
+		const wrapper = render(N8nToggle, {
+			props: { label: 'Italic', modelValue: false, 'onUpdate:modelValue': onUpdate },
+			slots: { default: '<span>I</span>' },
+			global: { stubs: { N8nTooltip: tooltipStub, N8nIcon: true } },
+		});
+
+		await userEvent.click(wrapper.getByRole('button', { name: 'Italic' }));
+		expect(onUpdate).toHaveBeenCalledWith(true);
+	});
+
+	it('renders pressed state from modelValue', () => {
+		const wrapper = render(N8nToggle, {
+			props: { label: 'Underline', modelValue: true },
+			slots: { default: '<span>U</span>' },
+			global: { stubs: { N8nTooltip: tooltipStub, N8nIcon: true } },
+		});
+
+		expect(wrapper.getByRole('button')).toHaveAttribute('data-state', 'on');
+	});
+
+	it('can be used inside N8nToggleGroup as a single-selection item', async () => {
+		const TestComponent = defineComponent({
+			components: { N8nToggleGroup, N8nToggle },
+			setup() {
+				const value = ref('left');
+				return { value };
+			},
+			template: `
+				<N8nToggleGroup v-model="value">
+					<N8nToggle value="left" label="Align left">L</N8nToggle>
+					<N8nToggle value="center" label="Align center">C</N8nToggle>
+				</N8nToggleGroup>
+			`,
+		});
+
+		const wrapper = render(TestComponent, {
+			global: { stubs: { N8nTooltip: tooltipStub, N8nIcon: true } },
+		});
+
+		expect(wrapper.getByRole('button', { name: 'Align left' })).toHaveAttribute('data-state', 'on');
+
+		await userEvent.click(wrapper.getByRole('button', { name: 'Align center' }));
+
+		expect(wrapper.getByRole('button', { name: 'Align center' })).toHaveAttribute(
+			'data-state',
+			'on',
+		);
+	});
+
+	it('can be used inside N8nToggleGroup as a multiple-selection item', async () => {
+		const TestComponent = defineComponent({
+			components: { N8nToggleGroup, N8nToggle },
+			setup() {
+				const value = ref(['bold']);
+				return { value };
+			},
+			template: `
+				<N8nToggleGroup v-model="value" type="multiple">
+					<N8nToggle value="bold" label="Bold">B</N8nToggle>
+					<N8nToggle value="italic" label="Italic">I</N8nToggle>
+				</N8nToggleGroup>
+			`,
+		});
+
+		const wrapper = render(TestComponent, {
+			global: { stubs: { N8nTooltip: tooltipStub, N8nIcon: true } },
+		});
+
+		await userEvent.click(wrapper.getByRole('button', { name: 'Italic' }));
+
+		expect(wrapper.getByRole('button', { name: 'Bold' })).toHaveAttribute('data-state', 'on');
+		expect(wrapper.getByRole('button', { name: 'Italic' })).toHaveAttribute('data-state', 'on');
+	});
+
+	it('does not emit updates when disabled', async () => {
+		const onUpdate = vi.fn();
+		const wrapper = render(N8nToggle, {
+			props: { label: 'Disabled', disabled: true, 'onUpdate:modelValue': onUpdate },
+			slots: { default: '<span>D</span>' },
+			global: { stubs: { N8nTooltip: tooltipStub, N8nIcon: true } },
+		});
+
+		const toggle = wrapper.getByRole('button', { name: 'Disabled' });
+		expect(toggle).toBeDisabled();
+
+		await userEvent.click(toggle);
+		expect(onUpdate).not.toHaveBeenCalled();
+	});
+});

--- a/packages/frontend/@n8n/design-system/src/components/N8nToggle/Toggle.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nToggle/Toggle.vue
@@ -1,0 +1,403 @@
+<script setup lang="ts">
+import { Toggle, ToggleGroupItem, type AcceptableValue } from 'reka-ui';
+import { computed, ref, useAttrs, useCssModule, watch } from 'vue';
+
+import type { IconName } from '@n8n/design-system/components/N8nIcon/icons';
+
+import type { IconSize } from '../../types';
+import type { ButtonProps } from '../../types/button';
+import { cn } from '../../utils/cn';
+import N8nIcon from '../N8nIcon';
+import N8nTooltip from '../N8nTooltip';
+
+export interface ToggleProps extends Pick<ButtonProps, 'variant' | 'size' | 'disabled' | 'class'> {
+	modelValue?: boolean | null;
+	value?: AcceptableValue;
+	label: string;
+	icon?: IconName;
+	name?: string;
+	required?: boolean;
+}
+
+const props = withDefaults(defineProps<ToggleProps>(), {
+	variant: 'solid',
+	size: 'medium',
+	disabled: false,
+});
+
+const emit = defineEmits<{
+	'update:modelValue': [value: boolean];
+}>();
+
+const attrs = useAttrs();
+const $style = useCssModule();
+
+const effectiveSize = computed(() => {
+	if (props.size === 'mini' || props.size === 'xmini') return 'xsmall';
+	return props.size;
+});
+
+const effectiveVariant = computed(() => {
+	if (props.variant === 'highlight') return 'ghost';
+	if (props.variant === 'highlight-fill') return 'ghost';
+	return props.variant;
+});
+
+const computedIconSize = computed((): IconSize => {
+	if (effectiveSize.value === 'xsmall') return 'xsmall';
+	return effectiveSize.value as IconSize;
+});
+
+const classes = computed(() =>
+	cn(
+		'button',
+		$style.toggle,
+		$style[effectiveVariant.value],
+		$style[effectiveSize.value],
+		$style.iconOnly,
+		props.disabled && $style.disabled,
+		props.class,
+	),
+);
+const pressed = ref(props.modelValue ?? false);
+
+watch(
+	() => props.modelValue,
+	(value) => {
+		if (value !== undefined) pressed.value = value ?? false;
+	},
+);
+
+const handleUpdate = (value: boolean) => {
+	pressed.value = value;
+	emit('update:modelValue', value);
+};
+</script>
+
+<template>
+	<N8nTooltip v-if="!disabled" :content="label">
+		<ToggleGroupItem
+			v-if="value !== undefined"
+			v-bind="attrs"
+			:value="value"
+			:class="classes"
+			:aria-label="label"
+			data-icon-only="true"
+		>
+			<span :class="$style['toggle-inner']">
+				<N8nIcon v-if="icon" :icon="icon" :size="computedIconSize" />
+				<slot />
+			</span>
+		</ToggleGroupItem>
+
+		<Toggle
+			v-else
+			v-bind="attrs"
+			v-model="pressed"
+			:name="name"
+			:required="required"
+			:class="classes"
+			:aria-label="label"
+			data-icon-only="true"
+			@update:model-value="handleUpdate"
+		>
+			<span :class="$style['toggle-inner']">
+				<N8nIcon v-if="icon" :icon="icon" :size="computedIconSize" />
+				<slot />
+			</span>
+		</Toggle>
+	</N8nTooltip>
+
+	<ToggleGroupItem
+		v-else-if="value !== undefined"
+		v-bind="attrs"
+		:value="value"
+		disabled
+		:class="classes"
+		:aria-label="label"
+		data-icon-only="true"
+	>
+		<span :class="$style['toggle-inner']">
+			<N8nIcon v-if="icon" :icon="icon" :size="computedIconSize" />
+			<slot />
+		</span>
+	</ToggleGroupItem>
+
+	<Toggle
+		v-else
+		v-bind="attrs"
+		v-model="pressed"
+		disabled
+		:name="name"
+		:required="required"
+		:class="classes"
+		:aria-label="label"
+		data-icon-only="true"
+		@update:model-value="handleUpdate"
+	>
+		<span :class="$style['toggle-inner']">
+			<N8nIcon v-if="icon" :icon="icon" :size="computedIconSize" />
+			<slot />
+		</span>
+	</Toggle>
+</template>
+
+<style lang="scss" module>
+@use '../../css/mixins/focus';
+
+.toggle {
+	appearance: none;
+	touch-action: manipulation;
+	-webkit-tap-highlight-color: transparent;
+	user-select: none;
+	width: fit-content;
+	display: grid;
+	align-items: center;
+	font-weight: var(--font-weight--medium);
+	line-height: 1;
+	cursor: pointer;
+	text-decoration: none;
+
+	height: var(--button--height);
+	padding: var(--button--padding);
+	border-radius: var(--button--radius);
+	font-size: var(--button--font-size);
+
+	--button--color--background: transparent;
+	--button--color--background-hover: var(--background--hover);
+	--button--color--background-active: var(--background--active);
+	--button--color: var(--text-color);
+	--button--shadow: 0 0 0 0 transparent;
+	--button--shadow--hover: 0 0 0 0 transparent;
+	--button--shadow--active: 0 0 0 0 transparent;
+	--button--border--shadow: 0 0 0 0 transparent;
+	--button--border--shadow--hover: 0 0 0 0 transparent;
+	--button--border--shadow--active: 0 0 0 0 transparent;
+	--button--border-color: transparent;
+	--button--border-color--hover: transparent;
+	--button--border-color--active: transparent;
+
+	background-color: var(--button--color--background);
+	color: var(--button--color);
+	box-shadow:
+		inset var(--button--border--shadow),
+		var(--button--shadow);
+	border: none;
+
+	> * {
+		grid-area: 1 / 1;
+	}
+
+	&:hover {
+		background-color: var(--button--color--background-hover);
+		box-shadow:
+			inset var(--button--border--shadow--hover),
+			var(--button--shadow--hover);
+	}
+
+	&:active,
+	&[data-state='on'] {
+		background-color: var(--button--color--background-active);
+		box-shadow:
+			inset var(--button--border--shadow--active),
+			var(--button--shadow--active);
+	}
+
+	&:focus {
+		outline: none;
+	}
+
+	&:focus-visible {
+		@include focus.focus-ring;
+		--button--border-color: var(--focus--border-color) !important;
+	}
+
+	&.xsmall {
+		--button--height: var(--height--xs);
+		--button--padding: 0 var(--spacing--2xs);
+		--button--radius: var(--radius--3xs);
+		--button--font-size: var(--font-size--2xs);
+	}
+
+	&.small {
+		--button--height: var(--height--sm);
+		--button--padding: 0 var(--spacing--xs);
+		--button--radius: var(--radius--3xs);
+		--button--font-size: var(--font-size--xs);
+	}
+
+	&.medium {
+		--button--height: var(--height--md);
+		--button--padding: 0 var(--spacing--xs);
+		--button--radius: var(--radius--3xs);
+		--button--font-size: var(--font-size--sm);
+	}
+
+	&.large {
+		--button--height: var(--height--lg);
+		--button--padding: 0 var(--spacing--sm);
+		--button--radius: var(--radius--2xs);
+		--button--font-size: var(--font-size--sm);
+	}
+
+	&.xlarge {
+		--button--height: var(--height--xl);
+		--button--padding: 0 var(--spacing--sm);
+		--button--radius: var(--radius--xs);
+		--button--font-size: var(--font-size--md);
+	}
+
+	&.solid {
+		--button--color--background: var(--background--brand);
+		--button--color--background-hover: var(--background--brand--hover);
+		--button--color--background-active: var(--background--brand--active);
+		--button--color: var(--color--neutral-white);
+		--button--shadow: var(--shadow--xs);
+		--button--shadow--hover: var(--shadow--xs);
+		--button--shadow--active: var(--shadow--xs);
+		--button--border-color: var(--background--brand);
+		--button--border-color--hover: var(--background--brand--hover);
+		--button--border-color--active: var(--background--brand--active);
+		--button--border--shadow: 0 0 0 1px var(--button--border-color);
+		--button--border--shadow--hover: 0 0 0 1px var(--button--border-color--hover);
+		--button--border--shadow--active: 0 0 0 1px var(--button--border-color--active);
+	}
+
+	&.subtle {
+		--button--color--background: var(--background--surface);
+		--button--color--background-hover: color-mix(
+			in srgb,
+			var(--button--color--background),
+			var(--background--hover)
+		);
+		--button--color--background-active: color-mix(
+			in srgb,
+			var(--button--color--background),
+			var(--background--active)
+		);
+		--button--shadow: var(--shadow--xs);
+		--button--shadow--hover: var(--shadow--xs);
+		--button--shadow--active: var(--shadow--xs);
+		--button--border-color: var(--border-color);
+		--button--border-color--hover: light-dark(
+			var(--color--black-alpha-200),
+			var(--color--white-alpha-200)
+		);
+		--button--border-color--active: light-dark(
+			var(--color--black-alpha-300),
+			var(--color--white-alpha-300)
+		);
+		--button--border--shadow: 0 0 0 1px var(--button--border-color);
+		--button--border--shadow--hover: 0 0 0 1px var(--button--border-color--hover);
+		--button--border--shadow--active: 0 0 0 1px var(--button--border-color--active);
+	}
+
+	&.outline {
+		--button--color--background: transparent;
+		--button--border-color: var(--border-color);
+		--button--border-color--hover: light-dark(
+			var(--color--black-alpha-200),
+			var(--color--white-alpha-200)
+		);
+		--button--border-color--active: light-dark(
+			var(--color--black-alpha-300),
+			var(--color--white-alpha-300)
+		);
+		--button--border--shadow: 0 0 0 1px var(--button--border-color);
+		--button--border--shadow--hover: 0 0 0 1px var(--button--border-color--hover);
+		--button--border--shadow--active: 0 0 0 1px var(--button--border-color--active);
+	}
+
+	&.ghost {
+		--button--color--background: transparent;
+		--button--border-color: transparent;
+		--button--border--shadow: 0 0 0 1px var(--button--border-color);
+		--button--border--shadow--hover: 0 0 0 1px var(--button--border-color);
+		--button--border--shadow--active: 0 0 0 1px var(--button--border-color);
+	}
+
+	&.destructive {
+		--button--color--background: light-dark(var(--color--red-500), var(--color--red-600));
+		--button--color--background-hover: light-dark(var(--color--red-600), var(--color--red-500));
+		--button--color--background-active: light-dark(var(--color--red-600), var(--color--red-400));
+		--button--color: var(--color--neutral-white);
+		--button--shadow: light-dark(
+			0 1px 3px 0 var(--color--black-alpha-100),
+			0 1px 3px 0 var(--color--black-alpha-200)
+		);
+		--button--shadow--hover: light-dark(
+			0 1px 3px 0 var(--color--black-alpha-100),
+			0 1px 3px 0 var(--color--black-alpha-200)
+		);
+		--button--shadow--active: light-dark(
+			0 1px 3px 0 var(--color--black-alpha-100),
+			0 1px 3px 0 var(--color--black-alpha-200)
+		);
+		--button--border-color: light-dark(var(--color--red-500), var(--color--red-600));
+		--button--border-color--hover: light-dark(var(--color--red-600), var(--color--red-500));
+		--button--border-color--active: light-dark(var(--color--red-600), var(--color--red-400));
+		--button--border--shadow: 0 0 0 1px var(--button--border-color);
+		--button--border--shadow--hover: 0 0 0 1px var(--button--border-color--hover);
+		--button--border--shadow--active: 0 0 0 1px var(--button--border-color--active);
+	}
+
+	&.success {
+		--button--color--background: light-dark(var(--color--green-600), var(--color--green-700));
+		--button--color--background-hover: light-dark(var(--color--green-700), var(--color--green-600));
+		--button--color--background-active: light-dark(
+			var(--color--green-700),
+			var(--color--green-500)
+		);
+		--button--color: var(--color--neutral-white);
+		--button--shadow: light-dark(
+			0 1px 3px 0 var(--color--black-alpha-100),
+			0 1px 3px 0 var(--color--black-alpha-200)
+		);
+		--button--shadow--hover: light-dark(
+			0 1px 3px 0 var(--color--black-alpha-100),
+			0 1px 3px 0 var(--color--black-alpha-200)
+		);
+		--button--shadow--active: light-dark(
+			0 1px 3px 0 var(--color--black-alpha-100),
+			0 1px 3px 0 var(--color--black-alpha-200)
+		);
+		--button--border-color: light-dark(var(--color--green-600), var(--color--green-700));
+		--button--border-color--hover: light-dark(var(--color--green-700), var(--color--green-600));
+		--button--border-color--active: light-dark(var(--color--green-700), var(--color--green-500));
+		--button--border--shadow: 0 0 0 1px var(--button--border-color);
+		--button--border--shadow--hover: 0 0 0 1px var(--button--border-color--hover);
+		--button--border--shadow--active: 0 0 0 1px var(--button--border-color--active);
+	}
+
+	&.disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+
+		&:hover {
+			background-color: var(--button--color--background);
+			box-shadow:
+				inset var(--button--border--shadow),
+				var(--button--shadow);
+		}
+	}
+
+	&.iconOnly {
+		width: var(--button--height);
+		padding: 0;
+		justify-content: center;
+		align-items: center;
+
+		> * {
+			width: var(--button--height);
+		}
+	}
+}
+
+.toggle-inner {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: var(--spacing--3xs);
+	white-space: nowrap;
+}
+</style>

--- a/packages/frontend/@n8n/design-system/src/components/N8nToggle/Toggle.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nToggle/Toggle.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { Toggle, ToggleGroupItem, type AcceptableValue } from 'reka-ui';
-import { computed, ref, useAttrs, useCssModule, watch } from 'vue';
+import { computed, ref, useAttrs, useCssModule } from 'vue';
 
 import type { IconName } from '@n8n/design-system/components/N8nIcon/icons';
 
@@ -59,27 +59,24 @@ const classes = computed(() =>
 		props.class,
 	),
 );
-const pressed = ref(props.modelValue ?? false);
+const uncontrolledPressed = ref(props.modelValue ?? false);
 
-watch(
-	() => props.modelValue,
-	(value) => {
-		if (value !== undefined) pressed.value = value ?? false;
+const pressed = computed({
+	get: () => props.modelValue ?? uncontrolledPressed.value,
+	set: (value: boolean) => {
+		if (props.modelValue === undefined) uncontrolledPressed.value = value;
+		emit('update:modelValue', value);
 	},
-);
-
-const handleUpdate = (value: boolean) => {
-	pressed.value = value;
-	emit('update:modelValue', value);
-};
+});
 </script>
 
 <template>
-	<N8nTooltip v-if="!disabled" :content="label">
+	<N8nTooltip :content="label" :disabled="disabled">
 		<ToggleGroupItem
 			v-if="value !== undefined"
 			v-bind="attrs"
 			:value="value"
+			:disabled="disabled"
 			:class="classes"
 			:aria-label="label"
 			data-icon-only="true"
@@ -94,12 +91,12 @@ const handleUpdate = (value: boolean) => {
 			v-else
 			v-bind="attrs"
 			v-model="pressed"
+			:disabled="disabled"
 			:name="name"
 			:required="required"
 			:class="classes"
 			:aria-label="label"
 			data-icon-only="true"
-			@update:model-value="handleUpdate"
 		>
 			<span :class="$style['toggle-inner']">
 				<N8nIcon v-if="icon" :icon="icon" :size="computedIconSize" />
@@ -107,39 +104,6 @@ const handleUpdate = (value: boolean) => {
 			</span>
 		</Toggle>
 	</N8nTooltip>
-
-	<ToggleGroupItem
-		v-else-if="value !== undefined"
-		v-bind="attrs"
-		:value="value"
-		disabled
-		:class="classes"
-		:aria-label="label"
-		data-icon-only="true"
-	>
-		<span :class="$style['toggle-inner']">
-			<N8nIcon v-if="icon" :icon="icon" :size="computedIconSize" />
-			<slot />
-		</span>
-	</ToggleGroupItem>
-
-	<Toggle
-		v-else
-		v-bind="attrs"
-		v-model="pressed"
-		disabled
-		:name="name"
-		:required="required"
-		:class="classes"
-		:aria-label="label"
-		data-icon-only="true"
-		@update:model-value="handleUpdate"
-	>
-		<span :class="$style['toggle-inner']">
-			<N8nIcon v-if="icon" :icon="icon" :size="computedIconSize" />
-			<slot />
-		</span>
-	</Toggle>
 </template>
 
 <style lang="scss" module>

--- a/packages/frontend/@n8n/design-system/src/components/N8nToggle/Toggle.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nToggle/Toggle.vue
@@ -62,7 +62,8 @@ const classes = computed(() =>
 const uncontrolledPressed = ref(props.modelValue ?? false);
 
 const pressed = computed({
-	get: () => props.modelValue ?? uncontrolledPressed.value,
+	get: () =>
+		props.modelValue === undefined ? uncontrolledPressed.value : (props.modelValue ?? false),
 	set: (value: boolean) => {
 		if (props.modelValue === undefined) uncontrolledPressed.value = value;
 		emit('update:modelValue', value);

--- a/packages/frontend/@n8n/design-system/src/components/N8nToggle/index.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nToggle/index.ts
@@ -1,0 +1,3 @@
+import N8nToggle from './Toggle.vue';
+
+export default N8nToggle;

--- a/packages/frontend/@n8n/design-system/src/components/N8nToggleGroup/ToggleGroup.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nToggleGroup/ToggleGroup.stories.ts
@@ -77,10 +77,10 @@ export const SingleSelection: Story = {
 		template: `
 			<div style="display: grid; place-items: center;">
 				<N8nToggleGroup v-model="value" v-bind="args">
-					<template #default="{ variant, size }">
-						<N8nToggle value="left" label="Align left" icon="align-right" :variant="variant" :size="size" />
-						<N8nToggle value="center" label="Align center" icon="stream" :variant="variant" :size="size" />
-						<N8nToggle value="right" label="Align right" icon="align-right" :variant="variant" :size="size" />
+					<template #default="{ variant, size, disabled }">
+						<N8nToggle value="left" label="Align left" icon="align-right" :variant="variant" :size="size" :disabled="disabled" />
+						<N8nToggle value="center" label="Align center" icon="stream" :variant="variant" :size="size" :disabled="disabled" />
+						<N8nToggle value="right" label="Align right" icon="align-right" :variant="variant" :size="size" :disabled="disabled" />
 					</template>
 				</N8nToggleGroup>
 			</div>
@@ -105,10 +105,10 @@ export const MultipleSelection: Story = {
 		template: `
 			<div style="display: grid; place-items: center;">
 				<N8nToggleGroup v-model="value" v-bind="args">
-					<template #default="{ variant, size }">
-						<N8nToggle value="bold" label="Bold" icon="text" :variant="variant" :size="size" />
-						<N8nToggle value="italic" label="Italic" icon="case-upper" :variant="variant" :size="size" />
-						<N8nToggle value="underline" label="Underline" icon="text" :variant="variant" :size="size" />
+					<template #default="{ variant, size, disabled }">
+						<N8nToggle value="bold" label="Bold" icon="text" :variant="variant" :size="size" :disabled="disabled" />
+						<N8nToggle value="italic" label="Italic" icon="case-upper" :variant="variant" :size="size" :disabled="disabled" />
+						<N8nToggle value="underline" label="Underline" icon="text" :variant="variant" :size="size" :disabled="disabled" />
 					</template>
 				</N8nToggleGroup>
 			</div>

--- a/packages/frontend/@n8n/design-system/src/components/N8nToggleGroup/ToggleGroup.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nToggleGroup/ToggleGroup.stories.ts
@@ -1,0 +1,146 @@
+import type { Meta, StoryObj } from '@storybook/vue3-vite';
+import { ref } from 'vue';
+
+import N8nToggle from '../N8nToggle/Toggle.vue';
+import N8nToggleGroup from './ToggleGroup.vue';
+
+const meta = {
+	title: 'Core/ToggleGroup',
+	component: N8nToggleGroup,
+	argTypes: {
+		type: {
+			control: 'select',
+			options: ['single', 'multiple'],
+		},
+		variant: {
+			control: 'select',
+			options: ['solid', 'subtle', 'ghost', 'outline', 'destructive', 'success'],
+		},
+		size: {
+			control: 'select',
+			options: ['xsmall', 'small', 'medium', 'large', 'xlarge'],
+		},
+		orientation: {
+			control: 'select',
+			options: ['horizontal', 'vertical'],
+		},
+		disabled: { control: 'boolean' },
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'Icon-only toggle and toggle group components built on Reka UI and styled with N8nButton variants and sizes.',
+			},
+			source: { type: 'dynamic' },
+		},
+	},
+} satisfies Meta<typeof N8nToggleGroup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Toggle: Story = {
+	render: (args) => ({
+		components: { N8nToggle },
+		setup() {
+			const pressed = ref(false);
+			return { args, pressed };
+		},
+		template: `
+			<div style="display: grid; place-items: center;">
+				<N8nToggle
+					v-model="pressed"
+					label="Toggle bold"
+					icon="text"
+					:variant="args.variant"
+					:size="args.size"
+					:disabled="args.disabled"
+				/>
+			</div>
+		`,
+	}),
+	args: {
+		variant: 'solid',
+		size: 'medium',
+		disabled: false,
+	},
+};
+
+export const SingleSelection: Story = {
+	render: (args) => ({
+		components: { N8nToggleGroup, N8nToggle },
+		setup() {
+			const value = ref('left');
+			return { args, value };
+		},
+		template: `
+			<div style="display: grid; place-items: center;">
+				<N8nToggleGroup v-model="value" v-bind="args">
+					<template #default="{ variant, size }">
+						<N8nToggle value="left" label="Align left" icon="align-right" :variant="variant" :size="size" />
+						<N8nToggle value="center" label="Align center" icon="stream" :variant="variant" :size="size" />
+						<N8nToggle value="right" label="Align right" icon="align-right" :variant="variant" :size="size" />
+					</template>
+				</N8nToggleGroup>
+			</div>
+		`,
+	}),
+	args: {
+		type: 'single',
+		variant: 'subtle',
+		size: 'medium',
+		orientation: 'horizontal',
+		disabled: false,
+	},
+};
+
+export const MultipleSelection: Story = {
+	render: (args) => ({
+		components: { N8nToggleGroup, N8nToggle },
+		setup() {
+			const value = ref(['bold']);
+			return { args, value };
+		},
+		template: `
+			<div style="display: grid; place-items: center;">
+				<N8nToggleGroup v-model="value" v-bind="args">
+					<template #default="{ variant, size }">
+						<N8nToggle value="bold" label="Bold" icon="text" :variant="variant" :size="size" />
+						<N8nToggle value="italic" label="Italic" icon="case-upper" :variant="variant" :size="size" />
+						<N8nToggle value="underline" label="Underline" icon="text" :variant="variant" :size="size" />
+					</template>
+				</N8nToggleGroup>
+			</div>
+		`,
+	}),
+	args: {
+		type: 'multiple',
+		variant: 'outline',
+		size: 'medium',
+		orientation: 'horizontal',
+		disabled: false,
+	},
+};
+
+export const Variants: Story = {
+	render: () => ({
+		components: { N8nToggleGroup, N8nToggle },
+		setup() {
+			return {
+				variants: ['solid', 'subtle', 'ghost', 'outline', 'destructive', 'success'],
+			};
+		},
+		template: `
+			<div style="display: grid; gap: 12px; place-items: center;">
+				<N8nToggleGroup v-for="variant in variants" :key="variant" :default-value="'left'" :variant="variant">
+					<template #default="slotProps">
+						<N8nToggle value="left" label="Align left" icon="align-right" v-bind="slotProps" />
+						<N8nToggle value="center" label="Align center" icon="stream" v-bind="slotProps" />
+						<N8nToggle value="right" label="Align right" icon="align-right" v-bind="slotProps" />
+					</template>
+				</N8nToggleGroup>
+			</div>
+		`,
+	}),
+};

--- a/packages/frontend/@n8n/design-system/src/components/N8nToggleGroup/ToggleGroup.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nToggleGroup/ToggleGroup.stories.ts
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/vue3-vite';
 import { ref } from 'vue';
 
-import N8nToggle from '../N8nToggle/Toggle.vue';
 import N8nToggleGroup from './ToggleGroup.vue';
+import N8nToggle from '../N8nToggle/Toggle.vue';
 
 const meta = {
 	title: 'Core/ToggleGroup',

--- a/packages/frontend/@n8n/design-system/src/components/N8nToggleGroup/ToggleGroup.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nToggleGroup/ToggleGroup.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import { ToggleGroupRoot, type AcceptableValue } from 'reka-ui';
+
+import type { ButtonProps } from '../../types/button';
+
+export interface ToggleGroupProps {
+	modelValue?: AcceptableValue | AcceptableValue[];
+	defaultValue?: AcceptableValue | AcceptableValue[];
+	type?: 'single' | 'multiple';
+	orientation?: 'horizontal' | 'vertical';
+	disabled?: boolean;
+	loop?: boolean;
+	rovingFocus?: boolean;
+	name?: string;
+	required?: boolean;
+	variant?: ButtonProps['variant'];
+	size?: ButtonProps['size'];
+}
+
+withDefaults(defineProps<ToggleGroupProps>(), {
+	type: 'single',
+	orientation: 'horizontal',
+	disabled: false,
+	loop: true,
+	rovingFocus: true,
+	variant: 'solid',
+	size: 'medium',
+});
+
+const emit = defineEmits<{
+	'update:modelValue': [value: AcceptableValue | AcceptableValue[]];
+}>();
+</script>
+
+<template>
+	<ToggleGroupRoot
+		:class="$style.group"
+		:model-value="modelValue"
+		:default-value="defaultValue"
+		:type="type"
+		:orientation="orientation"
+		:disabled="disabled"
+		:loop="loop"
+		:roving-focus="rovingFocus"
+		:name="name"
+		:required="required"
+		@update:model-value="emit('update:modelValue', $event)"
+	>
+		<slot :variant="variant" :size="size" />
+	</ToggleGroupRoot>
+</template>
+
+<style lang="scss" module>
+.group {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--spacing--4xs);
+}
+</style>

--- a/packages/frontend/@n8n/design-system/src/components/N8nToggleGroup/ToggleGroup.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nToggleGroup/ToggleGroup.vue
@@ -46,7 +46,7 @@ const emit = defineEmits<{
 		:required="required"
 		@update:model-value="emit('update:modelValue', $event)"
 	>
-		<slot :variant="variant" :size="size" />
+		<slot :variant="variant" :size="size" :disabled="disabled" />
 	</ToggleGroupRoot>
 </template>
 

--- a/packages/frontend/@n8n/design-system/src/components/N8nToggleGroup/index.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nToggleGroup/index.ts
@@ -1,0 +1,3 @@
+import N8nToggleGroup from './ToggleGroup.vue';
+
+export default N8nToggleGroup;

--- a/packages/frontend/@n8n/design-system/src/components/index.ts
+++ b/packages/frontend/@n8n/design-system/src/components/index.ts
@@ -90,6 +90,8 @@ export { default as N8nTag } from './N8nTag';
 export { default as N8nTags } from './N8nTags';
 export { default as N8nText } from './N8nText';
 export { default as N8nTooltip } from './N8nTooltip';
+export { default as N8nToggle } from './N8nToggle';
+export { default as N8nToggleGroup } from './N8nToggleGroup';
 export { default as N8nTree } from './N8nTree';
 export { default as N8nUserStack } from './N8nUserStack';
 export { default as N8nUserInfo } from './N8nUserInfo';


### PR DESCRIPTION
## Summary

Add `N8nToggle` and `N8nToggleGroup` components to the design system so toolbar-style controls can share a consistent toggle API and styling.

This PR includes:
- New toggle and toggle group Vue components
- Component stories for visual review
- Unit tests for toggle behavior

<img width="536" height="246" alt="CleanShot 2026-05-07 at 11 54 12@2x" src="https://github.com/user-attachments/assets/56412937-cbf9-4976-bf06-4879f5adae71" />


This is part of a wider PR split for AGENT-84: https://linear.app/n8n/issue/AGENT-84

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-84

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
