### PR TITLE
fix(core): Simple-git update broke https connection

### DIFF
--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-git.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-git.service.test.ts
@@ -329,6 +329,7 @@ describe('SourceControlGitService', () => {
 					maxConcurrentProcesses: 6,
 					trimmed: false,
 					config: [`credential.helper=${expectedCredentialScript}`, 'credential.useHttpPath=true'],
+					unsafe: { allowUnsafeCredentialHelper: true },
 				}),
 			);
 		});

--- a/packages/cli/src/modules/source-control.ee/source-control-git.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-git.service.ee.ts
@@ -140,6 +140,7 @@ export class SourceControlGitService {
 					// ensures that the credentials are only used for the configured repositoryUrl of the environment
 					'credential.useHttpPath=true',
 				],
+				unsafe: { allowUnsafeCredentialHelper: true },
 			};
 
 			// Add proxy configuration if proxy environment variables are set


### PR DESCRIPTION


## Summary

simple-git was updated in 5af9d0729fb22c0c110add70e04ff03a650ec18f yesterday. A similar issue was fixed for ssh connections in f42be9030e7f549da5ed6dc3902d058c2ebbadcb

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/LIGO-543/community-issue-upgrade-to-version-2194-failed-to-start-the-instance
Closes https://github.com/n8n-io/n8n/issues/29943


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
