### PR TITLE
fix(core): Export boolean CSV values as true/false for Data Tables

### DIFF
--- a/packages/cli/src/modules/data-table/__tests__/data-table-csv.controller.integration.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-table-csv.controller.integration.test.ts
@@ -225,8 +225,7 @@ describe('GET /projects/:projectId/data-tables/:dataTableId/download-csv', () =>
 		expect(lines[0]).toBe('id,text,number,flag,timestamp,createdAt,updatedAt');
 		expect(lines[1]).toContain('hello');
 		expect(lines[1]).toContain('42');
-		// Boolean values vary by database: SQLite use 0/1, PostgreSQL uses true/false
-		expect(lines[1]).toMatch(/,(true|1),/);
+		expect(lines[1]).toContain(',true,');
 		// Check for date in ISO format (timezone may vary)
 		expect(lines[1]).toMatch(/2025-01-15T\d{2}:\d{2}:\d{2}\.\d{3}Z/);
 	});

--- a/packages/cli/src/modules/data-table/__tests__/data-table-csv.controller.integration.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/data-table-csv.controller.integration.test.ts
@@ -210,6 +210,12 @@ describe('GET /projects/:projectId/data-tables/:dataTableId/download-csv', () =>
 					flag: true,
 					timestamp: testDate,
 				},
+				{
+					text: 'world',
+					number: 99,
+					flag: false,
+					timestamp: testDate,
+				},
 			],
 			columns,
 			'id',
@@ -226,6 +232,9 @@ describe('GET /projects/:projectId/data-tables/:dataTableId/download-csv', () =>
 		expect(lines[1]).toContain('hello');
 		expect(lines[1]).toContain('42');
 		expect(lines[1]).toContain(',true,');
+		expect(lines[2]).toContain('world');
+		expect(lines[2]).toContain('99');
+		expect(lines[2]).toContain(',false,');
 		// Check for date in ISO format (timezone may vary)
 		expect(lines[1]).toMatch(/2025-01-15T\d{2}:\d{2}:\d{2}\.\d{3}Z/);
 	});

--- a/packages/cli/src/modules/data-table/data-table.service.ts
+++ b/packages/cli/src/modules/data-table/data-table.service.ts
@@ -830,6 +830,12 @@ export class DataTableService {
 		}
 
 		if (columnType === 'boolean') {
+			if (value === 1 || value === '1') {
+				return 'true';
+			}
+			if (value === 0 || value === '0') {
+				return 'false';
+			}
 			return String(value);
 		}
 


### PR DESCRIPTION
## Summary

This PR fixes boolean values in Data Table CSV exports.

In some cases (SQLite), boolean columns were exported as `0` and `1`. When that CSV was imported back into n8n, the column was detected as a number instead of a boolean.

This change exports boolean values as `true` and `false`, so exported CSV files can be imported back with the correct type.

### How to test:
  - Create a data table with a boolean column
  - Add rows with `true` and `false`
  - Export the table as CSV
  - Check that the CSV contains `true` and `false`
  - Import the CSV into a new data table
  - Check that the column is recognized as boolean

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-5186](https://linear.app/n8n/issue/ADO-5186/community-issue-data-table-csv-export-and-re-import-does-not-recognize)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
