### PR TITLE
fix(core): Make instance AI use the correct instance URL for OAuth callbacks (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -901,15 +901,14 @@ describe('InstanceAiService — OAuth callback URL', () => {
 	it('builds oauth2CallbackUrl from urlService.getInstanceBaseUrl()', () => {
 		const source = InstanceAiService.toString();
 
-		expect(source).toContain(
-			'this.urlService.getInstanceBaseUrl()}/${restEndpoint}/oauth2-credential/callback',
+		expect(source).toMatch(
+			/this\.oauth2CallbackUrl\s*=[^;]*this\.urlService\.getInstanceBaseUrl\(\)[^;]*oauth2-credential\/callback/,
 		);
 	});
 
 	it('does not fall back to localhost when editorBaseUrl is empty', () => {
 		const source = InstanceAiService.toString();
 
-		expect(source).not.toContain('http://localhost:${globalConfig.port}');
-		expect(source).not.toContain('globalConfig.editorBaseUrl ||');
+		expect(source).not.toMatch(/globalConfig\.editorBaseUrl\s*\|\|/);
 	});
 });

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -891,3 +891,25 @@ describe('InstanceAiService — AI temporary workflow cleanup', () => {
 		expect(archiveIfAiTemporary).toHaveBeenNthCalledWith(2, 'wf-created');
 	});
 });
+
+describe('InstanceAiService — OAuth callback URL', () => {
+	// Regression: the OAuth callback URL handed to the browser-credential-setup
+	// sub-agent must come from urlService.getInstanceBaseUrl() (which honors
+	// WEBHOOK_URL on cloud), not from globalConfig.editorBaseUrl with a
+	// localhost fallback. With the old fallback the agent pasted
+	// http://localhost:5678/... into the user's Slack app on a cloud instance.
+	it('builds oauth2CallbackUrl from urlService.getInstanceBaseUrl()', () => {
+		const source = InstanceAiService.toString();
+
+		expect(source).toContain(
+			'this.urlService.getInstanceBaseUrl()}/${restEndpoint}/oauth2-credential/callback',
+		);
+	});
+
+	it('does not fall back to localhost when editorBaseUrl is empty', () => {
+		const source = InstanceAiService.toString();
+
+		expect(source).not.toContain('http://localhost:${globalConfig.port}');
+		expect(source).not.toContain('globalConfig.editorBaseUrl ||');
+	});
+});

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -432,9 +432,8 @@ export class InstanceAiService {
 			this.instanceAiConfig.builderSandboxTtlMs,
 		);
 		this.defaultTimeZone = globalConfig.generic.timezone;
-		const editorBaseUrl = globalConfig.editorBaseUrl || `http://localhost:${globalConfig.port}`;
 		const restEndpoint = globalConfig.endpoints.rest;
-		this.oauth2CallbackUrl = `${editorBaseUrl.replace(/\/$/, '')}/${restEndpoint}/oauth2-credential/callback`;
+		this.oauth2CallbackUrl = `${this.urlService.getInstanceBaseUrl()}/${restEndpoint}/oauth2-credential/callback`;
 		this.webhookBaseUrl = `${this.urlService.getWebhookBaseUrl()}${globalConfig.endpoints.webhook}`;
 		this.formBaseUrl = `${this.urlService.getWebhookBaseUrl()}${globalConfig.endpoints.form}`;
 


### PR DESCRIPTION
## Summary

Build the OAuth callback URL via UrlService.getInstanceBaseUrl() so it picks up `WEBHOOK_URL` and other fallbacks the same way the OAuth service and frontend do. Previously the URL was derived from editorBaseUrl with a hardcoded http://localhost:${port} fallback, causing the browser sub-agent to paste localhost into the user's OAuth app on cloud instances where editorBaseUrl wasn't set.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-210

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
