### PR TITLE
fix: Redact issuer-shaped secrets from MCP browser tool outputs

### DIFF
--- a/packages/@n8n/mcp-browser/src/redaction/__tests__/redact.test.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/__tests__/redact.test.ts
@@ -1,0 +1,184 @@
+import type { CallToolResult } from '../../types';
+import { BUILTIN_PATTERNS } from '../patterns';
+import { findRegexSecretHits, redactCallToolResult, redactString } from '../redact';
+
+const ANTHROPIC = `sk-ant-api03-${'a'.repeat(93)}AA`;
+const GITHUB = `ghp_${'b'.repeat(36)}`;
+
+const FIXTURES: Array<{ slug: string; secret: string }> = [
+	{
+		slug: 'pem_private_key',
+		secret:
+			'-----BEGIN RSA PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSj\n-----END RSA PRIVATE KEY-----',
+	},
+	{
+		slug: 'openssh_private_key',
+		secret:
+			'-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjEAAAAA\n-----END OPENSSH PRIVATE KEY-----',
+	},
+	{ slug: 'anthropic_api_key', secret: ANTHROPIC },
+	{ slug: 'anthropic_admin_key', secret: `sk-ant-admin01-${'c'.repeat(93)}AA` },
+	{ slug: 'openai_api_key', secret: `sk-proj-${'d'.repeat(74)}` },
+	{ slug: 'openai_legacy_api_key', secret: `sk-${'e'.repeat(48)}` },
+	{ slug: 'huggingface_token', secret: `hf_${'f'.repeat(34)}` },
+	{ slug: 'google_api_key', secret: `AIza${'A'.repeat(35)}` },
+	{ slug: 'aws_access_key_id', secret: `AKIA${'A'.repeat(16)}` },
+	{ slug: 'azure_ad_client_secret', secret: `aaa1Q~${'a'.repeat(31)}` },
+	{ slug: 'github_pat', secret: GITHUB },
+	{ slug: 'github_fine_grained_pat', secret: `github_pat_${'g'.repeat(82)}` },
+	{ slug: 'github_oauth', secret: `gho_${'h'.repeat(36)}` },
+	{ slug: 'github_app_token', secret: `ghu_${'i'.repeat(36)}` },
+	{ slug: 'github_refresh_token', secret: `ghr_${'j'.repeat(36)}` },
+	{ slug: 'gitlab_pat', secret: `glpat-${'k'.repeat(20)}` },
+	{ slug: 'slack_bot_token', secret: `xoxb-1111111111-1111111111-${'l'.repeat(24)}` },
+	{ slug: 'slack_user_token', secret: `xoxp-1111111111-1111111111-1111111111-${'m'.repeat(12)}` },
+	{ slug: 'slack_webhook_url', secret: `https://hooks.slack.com/services/${'N'.repeat(43)}` },
+	{ slug: 'twilio_api_key_sid', secret: `SK${'0'.repeat(32)}` },
+	{ slug: 'twilio_account_sid', secret: `AC${'1'.repeat(32)}` },
+	{ slug: 'stripe_secret_key', secret: `sk_live_${'o'.repeat(20)}` },
+	{ slug: 'square_access_token', secret: `sq0atp-${'p'.repeat(22)}` },
+	{ slug: 'npm_token', secret: `npm_${'q'.repeat(36)}` },
+	{ slug: 'pypi_token', secret: `pypi-AgEIcHlwaS5vcmc${'r'.repeat(50)}` },
+	{ slug: 'sentry_user_token', secret: `sntryu_${'s'.repeat(64)}` },
+	{ slug: 'grafana_api_key', secret: `eyJrIjoi${'t'.repeat(70)}` },
+	{ slug: 'jwt', secret: `eyJ${'u'.repeat(10)}.eyJ${'v'.repeat(10)}.${'w'.repeat(10)}` },
+];
+
+describe('BUILTIN_PATTERNS coverage', () => {
+	it('has a fixture for every shipped pattern', () => {
+		expect(FIXTURES.map((fixture) => fixture.slug).sort()).toEqual(
+			BUILTIN_PATTERNS.map((pattern) => pattern.slug).sort(),
+		);
+	});
+
+	it('keeps pattern slugs unique', () => {
+		const slugs = BUILTIN_PATTERNS.map((pattern) => pattern.slug);
+		expect(new Set(slugs).size).toBe(slugs.length);
+	});
+});
+
+describe('redactString', () => {
+	it('redacts issuer-shaped secrets', () => {
+		expect(redactString(`key=${ANTHROPIC}`)).toBe('key=[REDACTED:anthropic_api_key]');
+		expect(redactString(`token=${GITHUB}`)).toBe('token=[REDACTED:github_pat]');
+	});
+
+	it.each(FIXTURES)('redacts $slug', ({ slug, secret }) => {
+		expect(redactString(`before ${secret} after`)).toBe(`before [REDACTED:${slug}] after`);
+	});
+
+	it('redacts multiple different patterns in one string', () => {
+		expect(redactString(`anthropic=${ANTHROPIC} github=${GITHUB}`)).toBe(
+			'anthropic=[REDACTED:anthropic_api_key] github=[REDACTED:github_pat]',
+		);
+	});
+
+	it('preserves aria-tree refs around redacted values', () => {
+		expect(redactString(`button "Copy ${ANTHROPIC}" [ref=e42]`)).toBe(
+			'button "Copy [REDACTED:anthropic_api_key]" [ref=e42]',
+		);
+	});
+
+	it('does not redact common browser trace strings', () => {
+		const input = 'commit a1b2c3d4e5f60718293a4b5c6d7e8f9012345678 by alice';
+		expect(redactString(input)).toBe(input);
+	});
+
+	it.each([
+		'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4',
+		'https://example.com/?utm_source=newsletter&fbclid=IwAR0xQ8mN1kJyZpQrStUvWxYzAbCdEf',
+		'Press the Enter key to submit',
+		'group "Account" [ref=e1]\n  text "Bernhard" [ref=e2]\n  link "Sign out" [ref=e3]',
+	])('does not falsely redact %j', (input) => {
+		expect(redactString(input)).toBe(input);
+	});
+});
+
+describe('findRegexSecretHits', () => {
+	it('dedupes matches by type and value', () => {
+		expect(findRegexSecretHits(`${ANTHROPIC} ${ANTHROPIC}`)).toEqual([
+			{ type: 'anthropic_api_key', value: ANTHROPIC },
+		]);
+	});
+});
+
+describe('redactCallToolResult', () => {
+	it('redacts both text content and structured content', () => {
+		const result: CallToolResult = {
+			content: [{ type: 'text', text: JSON.stringify({ result: ANTHROPIC }) }],
+			structuredContent: { result: ANTHROPIC },
+		};
+
+		redactCallToolResult(result);
+
+		expect(result.content[0]).toEqual({
+			type: 'text',
+			text: JSON.stringify({ result: '[REDACTED:anthropic_api_key]' }),
+		});
+		expect(result.structuredContent).toEqual({ result: '[REDACTED:anthropic_api_key]' });
+	});
+
+	it('leaves image content blocks untouched', () => {
+		const result: CallToolResult = {
+			content: [
+				{ type: 'image', data: ANTHROPIC, mimeType: 'image/png' },
+				{ type: 'text', text: ANTHROPIC },
+			],
+		};
+
+		redactCallToolResult(result);
+
+		expect(result.content[0]).toEqual({ type: 'image', data: ANTHROPIC, mimeType: 'image/png' });
+		expect(result.content[1]).toEqual({ type: 'text', text: '[REDACTED:anthropic_api_key]' });
+	});
+
+	it('redacts nested plain object and array values', () => {
+		const result: CallToolResult = {
+			content: [{ type: 'text', text: '{}' }],
+			structuredContent: {
+				entries: [{ text: ANTHROPIC }, { text: 'safe' }],
+			},
+		};
+
+		redactCallToolResult(result);
+
+		expect(result.structuredContent).toEqual({
+			entries: [{ text: '[REDACTED:anthropic_api_key]' }, { text: 'safe' }],
+		});
+	});
+
+	it('does not recurse into class instances', () => {
+		const error = new Error(ANTHROPIC);
+		const result: CallToolResult = {
+			content: [{ type: 'text', text: '{}' }],
+			structuredContent: { error },
+		};
+
+		redactCallToolResult(result);
+
+		expect((result.structuredContent as { error: Error }).error).toBe(error);
+		expect(error.message).toBe(ANTHROPIC);
+	});
+
+	it('caps recursion depth', () => {
+		type Chain = { a?: Chain; leak?: string };
+		const root: Chain = {};
+		let current = root;
+		for (let i = 0; i < 11; i++) {
+			current.a = {};
+			current = current.a;
+		}
+		current.leak = ANTHROPIC;
+
+		const result: CallToolResult = {
+			content: [{ type: 'text', text: '{}' }],
+			structuredContent: root as Record<string, unknown>,
+		};
+
+		redactCallToolResult(result);
+
+		let walk = result.structuredContent as Chain;
+		for (let i = 0; i < 11; i++) walk = walk.a!;
+		expect(walk.leak).toBe(ANTHROPIC);
+	});
+});

--- a/packages/@n8n/mcp-browser/src/redaction/patterns.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/patterns.ts
@@ -1,0 +1,45 @@
+export interface SecretPattern {
+	slug: string;
+	pattern: RegExp;
+}
+
+const PEM_PRIVATE_KEY =
+	/-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----|-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----/;
+
+export const BUILTIN_PATTERNS: SecretPattern[] = [
+	{
+		slug: 'openssh_private_key',
+		pattern:
+			/-----BEGIN OPENSSH PRIVATE KEY-----[\s\S]*?-----END OPENSSH PRIVATE KEY-----|-----BEGIN OPENSSH PRIVATE KEY-----/,
+	},
+	{ slug: 'pem_private_key', pattern: PEM_PRIVATE_KEY },
+	{ slug: 'anthropic_api_key', pattern: /sk-ant-api\d{2}-[A-Za-z0-9_-]{80,}/ },
+	{ slug: 'anthropic_admin_key', pattern: /sk-ant-admin\d{2}-[A-Za-z0-9_-]{80,}/ },
+	{ slug: 'openai_api_key', pattern: /sk-proj-[A-Za-z0-9_-]{40,}/ },
+	{ slug: 'openai_legacy_api_key', pattern: /sk-[A-Za-z0-9]{48}/ },
+	{ slug: 'huggingface_token', pattern: /hf_[A-Za-z0-9]{34,}/ },
+	{ slug: 'google_api_key', pattern: /AIza[0-9A-Za-z_-]{35}/ },
+	{ slug: 'aws_access_key_id', pattern: /(?:AKIA|ASIA)[A-Z0-9]{16}/ },
+	{ slug: 'azure_ad_client_secret', pattern: /[A-Za-z0-9_-]{3,}~[A-Za-z0-9_-]{31,}/ },
+	{ slug: 'github_pat', pattern: /ghp_[A-Za-z0-9]{36}/ },
+	{ slug: 'github_fine_grained_pat', pattern: /github_pat_[A-Za-z0-9_]{22,}/ },
+	{ slug: 'github_oauth', pattern: /gho_[A-Za-z0-9]{36}/ },
+	{ slug: 'github_app_token', pattern: /ghu_[A-Za-z0-9]{36}/ },
+	{ slug: 'github_refresh_token', pattern: /ghr_[A-Za-z0-9]{36}/ },
+	{ slug: 'gitlab_pat', pattern: /glpat-[A-Za-z0-9_-]{20,}/ },
+	{ slug: 'slack_bot_token', pattern: /xoxb-\d{10,13}-\d{10,13}-[A-Za-z0-9]{20,}/ },
+	{ slug: 'slack_user_token', pattern: /xoxp-\d{10,13}-\d{10,13}-\d{10,13}-[A-Za-z0-9]{10,}/ },
+	{
+		slug: 'slack_webhook_url',
+		pattern: /https:\/\/hooks\.slack\.com\/services\/[A-Za-z0-9/_-]{30,}/,
+	},
+	{ slug: 'twilio_api_key_sid', pattern: /SK[0-9a-fA-F]{32}/ },
+	{ slug: 'twilio_account_sid', pattern: /AC[0-9a-fA-F]{32}/ },
+	{ slug: 'stripe_secret_key', pattern: /sk_(?:live|test)_[A-Za-z0-9]{20,}/ },
+	{ slug: 'square_access_token', pattern: /sq0atp-[A-Za-z0-9_-]{22,}/ },
+	{ slug: 'npm_token', pattern: /npm_[A-Za-z0-9]{36,}/ },
+	{ slug: 'pypi_token', pattern: /pypi-AgEIcHlwaS5vcmc[A-Za-z0-9_-]{20,}/ },
+	{ slug: 'sentry_user_token', pattern: /sntryu_[A-Za-z0-9_-]{32,}/ },
+	{ slug: 'grafana_api_key', pattern: /eyJrIjoi[A-Za-z0-9_-]{30,}/ },
+	{ slug: 'jwt', pattern: /eyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/ },
+];

--- a/packages/@n8n/mcp-browser/src/redaction/redact.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/redact.ts
@@ -1,0 +1,83 @@
+import type { CallToolResult } from '../types';
+import { BUILTIN_PATTERNS, type SecretPattern } from './patterns';
+
+const MAX_DEPTH = 10;
+
+export interface SecretHit {
+	type: string;
+	value: string;
+	ref?: string;
+}
+
+const GLOBAL_PATTERNS: ReadonlyArray<{ slug: string; regex: RegExp }> = BUILTIN_PATTERNS.map(
+	(p: SecretPattern) => ({
+		slug: p.slug,
+		regex: new RegExp(
+			p.pattern.source,
+			p.pattern.flags.includes('g') ? p.pattern.flags : `${p.pattern.flags}g`,
+		),
+	}),
+);
+
+export function formatRedactionMarker(hit: Pick<SecretHit, 'type' | 'ref'>): string {
+	return `[REDACTED:${hit.type}]${hit.ref ? `@${hit.ref}` : ''}`;
+}
+
+export function findRegexSecretHits(input: string): SecretHit[] {
+	const hits = new Map<string, SecretHit>();
+	for (const { slug, regex } of GLOBAL_PATTERNS) {
+		regex.lastIndex = 0;
+		for (const match of input.matchAll(regex)) {
+			const value = match[0];
+			if (!value) continue;
+			const key = `${slug}:${value}`;
+			if (!hits.has(key)) hits.set(key, { type: slug, value });
+		}
+	}
+	return [...hits.values()];
+}
+
+export function redactString(input: string): string {
+	let output = input;
+	for (const hit of findRegexSecretHits(input)) {
+		output = replaceLiteral(output, hit.value, formatRedactionMarker(hit));
+	}
+	return output;
+}
+
+export function replaceLiteral(input: string, value: string, replacement: string): string {
+	if (!value) return input;
+	return input.split(value).join(replacement);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	if (value === null || typeof value !== 'object') return false;
+	return Object.getPrototypeOf(value) === Object.prototype;
+}
+
+export function redactValue(value: unknown, depth = 0): unknown {
+	if (depth > MAX_DEPTH || value === null || value === undefined) return value;
+	if (typeof value === 'string') return redactString(value);
+	if (Array.isArray(value)) return value.map((entry) => redactValue(entry, depth + 1));
+	if (isPlainObject(value)) {
+		const out: Record<string, unknown> = {};
+		for (const [k, v] of Object.entries(value)) {
+			out[k] = redactValue(v, depth + 1);
+		}
+		return out;
+	}
+	return value;
+}
+
+export function redactCallToolResult(result: CallToolResult): CallToolResult {
+	for (const item of result.content) {
+		if (item.type === 'text' && typeof item.text === 'string') {
+			item.text = redactString(item.text);
+		}
+	}
+	if (result.structuredContent !== undefined) {
+		const redacted = redactValue(result.structuredContent);
+		if (isPlainObject(redacted)) result.structuredContent = redacted;
+	}
+	return result;
+}

--- a/packages/@n8n/mcp-browser/src/tools/helpers.ts
+++ b/packages/@n8n/mcp-browser/src/tools/helpers.ts
@@ -3,6 +3,7 @@ import type { z } from 'zod';
 import type { BrowserConnection } from '../connection';
 import { ConnectionLostError } from '../errors';
 import { createLogger } from '../logger';
+import { redactCallToolResult } from '../redaction/redact';
 import type {
 	AffectedResource,
 	CallToolResult,
@@ -111,19 +112,23 @@ export function createConnectedTool<
 					if (pageInfo) pageInfo.url = currentUrl;
 				}
 
-				return result;
+				return redactCallToolResult(result);
 			} catch (error) {
 				// Playwright throws TargetClosedError when browser/page dies mid-operation.
 				// Re-throw as our typed error so the AI gets a clear message + hint.
 				if (error instanceof Error && error.name === 'TargetClosedError') {
-					return await buildErrorResponse(
-						new ConnectionLostError('browser_closed'),
-						connection,
-						args,
-						options ?? {},
+					return redactCallToolResult(
+						await buildErrorResponse(
+							new ConnectionLostError('browser_closed'),
+							connection,
+							args,
+							options ?? {},
+						),
 					);
 				}
-				return await buildErrorResponse(error, connection, args, options ?? {});
+				return redactCallToolResult(
+					await buildErrorResponse(error, connection, args, options ?? {}),
+				);
 			}
 		},
 		getAffectedResources(args: z.infer<TSchema>, _context: ToolContext): AffectedResource[] {


### PR DESCRIPTION
## Summary

Adds a redaction layer to the `@n8n/mcp-browser` package that scrubs issuer-shaped credentials (API keys, tokens, private keys) from browser tool responses before they reach the LLM.

- New `src/redaction/patterns.ts` with deterministic-prefix/fixed-shape patterns (Anthropic, OpenAI, GitHub, AWS, Slack, Stripe, Twilio, Square, npm, PyPI, JWT, PEM/OpenSSH private keys, etc.). Curation rule: prefix-anchored or fixed-shape only, no length/entropy heuristics.
- New `src/redaction/redact.ts` with `redactString`, `redactValue`, and `redactCallToolResult`.
- Wires the response chokepoint in `tools/helpers.ts` so connected tool responses go through `redactCallToolResult`.
- Keeps the `SecretHit` contract slim: `type`, `value`, and optional `ref` only.

**Stacking notice**

This is PR 1 of 3 in the mcp-browser sensitivity stack:

1. This PR - regex backstop for issuer-shaped secrets in tool responses
2. #30118 - slim HTML probe plus host-side sensitivity analysis and redaction
3. #30514 - gate screenshot, PDF, and evaluate when the current page is sensitive

### How to test

- `pnpm --dir packages/@n8n/mcp-browser test src/redaction`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4988

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.