### PR TITLE
fix(core): Simplify Slack redirect URL verification process for agents (no-changelog)

### DIFF
--- a/packages/cli/src/modules/agents/agents.controller.ts
+++ b/packages/cli/src/modules/agents/agents.controller.ts
@@ -49,6 +49,7 @@ import {
 import { AgentsService } from './agents.service';
 import { AgentsBuilderService } from './builder/agents-builder.service';
 import { BUILDER_TOOLS } from './builder/builder-tool-names';
+import { ChatIntegrationRegistry } from './integrations/agent-chat-integration';
 import { AgentScheduleService } from './integrations/agent-schedule.service';
 import { ChatIntegrationService } from './integrations/chat-integration.service';
 import { AgentRepository } from './repositories/agent.repository';
@@ -99,6 +100,7 @@ export class AgentsController {
 		private readonly agentScheduleService: AgentScheduleService,
 		private readonly agentRepository: AgentRepository,
 		private readonly agentExecutionService: AgentExecutionService,
+		private readonly chatIntegrationRegistry: ChatIntegrationRegistry,
 	) {}
 
 	@Post('/')
@@ -784,6 +786,16 @@ export class AgentsController {
 		const webhookHandler = this.chatIntegrationService.getWebhookHandler(agentId, platform);
 
 		if (!webhookHandler) {
+			// Allow platforms to respond to setup-time webhooks (e.g. Slack's
+			// `url_verification` challenge) before credentials are configured,
+			// so the user doesn't have to come back and re-verify URLs after
+			// connecting the credential.
+			const integration = this.chatIntegrationRegistry.get(platform);
+			const earlyResponse = integration?.handleUnauthenticatedWebhook?.(req.body);
+			if (earlyResponse) {
+				res.status(earlyResponse.status).json(earlyResponse.body);
+				return;
+			}
 			res.status(404).json({ error: `No active ${platform} integration for agent "${agentId}"` });
 			return;
 		}

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -181,13 +181,6 @@ export class AgentsService {
 		{ agent: agents.Agent; agentId: string; toolRegistry: ToolRegistry; projectId: string }
 	>(30 * Time.minutes.toMilliseconds);
 
-	/**
-	 * Stash of user messages for suspended tool calls.
-	 * When executeForChat suspends, we store the original message here so
-	 * resumeForChat can record it against the execution.
-	 */
-	private readonly pendingUserMessages = new Map<string, string>();
-
 	private computeRuntimeCacheKey(params: GetRuntimeParams): string {
 		if (params.usePublishedVersion) {
 			const parts = [params.agentId, 'published'];
@@ -775,9 +768,6 @@ export class AgentsService {
 
 		// Always record resumed executions — even if they suspend again (chained HITL).
 		// Don't repeat the original user message — the pre-suspension execution already has it.
-		if (!recorder.suspended) {
-			this.pendingUserMessages.delete(agentId);
-		}
 		const messageRecord = recorder.getMessageRecord();
 		void this.agentExecutionService
 			.recordMessage({
@@ -1005,10 +995,6 @@ export class AgentsService {
 
 		// Always record — even if suspended, the pre-suspension response text
 		// and tool calls are valuable. Usage/model will be null for suspended runs.
-		if (recorder.suspended) {
-			this.pendingUserMessages.set(agentId, message);
-		}
-
 		const messageRecord = recorder.getMessageRecord();
 		void this.agentExecutionService
 			.recordMessage({

--- a/packages/cli/src/modules/agents/integrations/__tests__/slack-integration.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/slack-integration.test.ts
@@ -1,0 +1,45 @@
+import { SlackIntegration } from '../platforms/slack-integration';
+
+describe('SlackIntegration', () => {
+	let integration: SlackIntegration;
+
+	beforeEach(() => {
+		integration = new SlackIntegration();
+	});
+
+	describe('handleUnauthenticatedWebhook', () => {
+		it('echoes the challenge for a url_verification event', () => {
+			const result = integration.handleUnauthenticatedWebhook({
+				type: 'url_verification',
+				challenge: 'abc123',
+			});
+
+			expect(result).toEqual({ status: 200, body: { challenge: 'abc123' } });
+		});
+
+		it('returns undefined for non-verification events', () => {
+			const result = integration.handleUnauthenticatedWebhook({
+				type: 'event_callback',
+				event: { type: 'message', text: 'hi' },
+			});
+
+			expect(result).toBeUndefined();
+		});
+
+		it.each([
+			['missing challenge', { type: 'url_verification' }],
+			['non-string challenge', { type: 'url_verification', challenge: 42 }],
+		])('returns undefined for malformed url_verification body (%s)', (_label, body) => {
+			expect(integration.handleUnauthenticatedWebhook(body)).toBeUndefined();
+		});
+
+		it.each([
+			['null', null],
+			['undefined', undefined],
+			['string', 'hello'],
+			['number', 42],
+		])('returns undefined for non-object body (%s)', (_label, body) => {
+			expect(integration.handleUnauthenticatedWebhook(body)).toBeUndefined();
+		});
+	});
+});

--- a/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
@@ -13,6 +13,12 @@ export interface AgentChatIntegrationContext {
 	webhookUrlFor: (platform: string) => string;
 }
 
+/** Response shape returned by `handleUnauthenticatedWebhook`. */
+export interface UnauthenticatedWebhookResponse {
+	status: number;
+	body: unknown;
+}
+
 /**
  * A chat platform (Slack, Telegram, …) that an agent can be connected to.
  *
@@ -63,6 +69,23 @@ export abstract class AgentChatIntegration {
 
 	/** Build the Chat SDK adapter for this platform. */
 	abstract createAdapter(ctx: AgentChatIntegrationContext): Promise<unknown>;
+
+	/**
+	 * Handle a webhook request that arrives before an integration is connected
+	 * (i.e. before credentials are configured). The canonical case is Slack's
+	 * `url_verification` challenge — sent when the user creates a Slack app
+	 * from the manifest, before they have pasted bot token / signing secret
+	 * into n8n. Without this hook, the standard handler returns 404 and the
+	 * user has to manually re-verify URLs after configuring the credential.
+	 *
+	 * Implementations inspect the parsed JSON body; return a response to send
+	 * back, or undefined to fall through to the standard 404.
+	 *
+	 * Security note: this hook bypasses signature verification, so it must
+	 * only echo non-sensitive data (e.g. a challenge token sent by the caller
+	 * in the request itself).
+	 */
+	handleUnauthenticatedWebhook?(body: unknown): UnauthenticatedWebhookResponse | undefined;
 
 	/**
 	 * Optional hook run BEFORE the adapter is built. Use it to reject the

--- a/packages/cli/src/modules/agents/integrations/platforms/slack-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/slack-integration.ts
@@ -1,6 +1,10 @@
 import { Service } from '@n8n/di';
 
-import { AgentChatIntegration, type AgentChatIntegrationContext } from '../agent-chat-integration';
+import {
+	AgentChatIntegration,
+	type AgentChatIntegrationContext,
+	type UnauthenticatedWebhookResponse,
+} from '../agent-chat-integration';
 import { loadSlackAdapter } from '../esm-loader';
 
 /**
@@ -35,6 +39,21 @@ export class SlackIntegration extends AgentChatIntegration {
 		const signingSecret = this.extractSigningSecret(ctx.credential);
 		const { createSlackAdapter } = await loadSlackAdapter();
 		return createSlackAdapter({ botToken, signingSecret });
+	}
+
+	/**
+	 * Echo Slack's `url_verification` challenge so the webhook URL can be
+	 * verified during manifest install — before the user has configured the
+	 * bot token + signing secret in n8n. Slack's docs:
+	 * https://api.slack.com/events/url_verification
+	 */
+	handleUnauthenticatedWebhook(body: unknown): UnauthenticatedWebhookResponse | undefined {
+		if (!body || typeof body !== 'object') return undefined;
+		const evt = body as { type?: unknown; challenge?: unknown };
+		if (evt.type === 'url_verification' && typeof evt.challenge === 'string') {
+			return { status: 200, body: { challenge: evt.challenge } };
+		}
+		return undefined;
 	}
 
 	/**

--- a/packages/frontend/@n8n/stores/src/useRootStore.ts
+++ b/packages/frontend/@n8n/stores/src/useRootStore.ts
@@ -98,6 +98,8 @@ export const useRootStore = defineStore(STORES.ROOT, () => {
 
 	const urlBaseEditor = computed(() => state.value.urlBaseEditor);
 
+	const urlBaseWebhook = computed(() => state.value.urlBaseWebhook);
+
 	const instanceId = computed(() => state.value.instanceId);
 
 	const versionCli = computed(() => state.value.versionCli);
@@ -227,6 +229,7 @@ export const useRootStore = defineStore(STORES.ROOT, () => {
 		restUrl,
 		restApiContext,
 		urlBaseEditor,
+		urlBaseWebhook,
 		versionCli,
 		instanceId,
 		pushRef,

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentAddTriggerModal.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentAddTriggerModal.vue
@@ -125,17 +125,15 @@ function integrationConnectedText(type: string): string {
 	return key ? i18n.baseText(key) : '';
 }
 
-// Use the browser origin (rather than the configured `urlBaseEditor`) so the
-// generated URLs match whichever host the user is currently viewing the UI
-// from — e.g. an ngrok tunnel or a reverse-proxy port. The instance's
-// configured editor URL might be `http://localhost:5678` while the user is
-// actually serving Slack the URL via `https://<id>.ngrok.app`.
-function browserOrigin(): string {
-	return typeof window !== 'undefined' ? window.location.origin : rootStore.urlBaseEditor;
-}
-
+// URLs in the integration manifests must use the instance's configured
+// `WEBHOOK_URL` (`urlBaseWebhook`), not the browser origin: in production the
+// editor and webhook receiver may be on different hosts, and the chat platform
+// (Slack, Linear) needs a publicly reachable host. The same base is reused for
+// the OAuth callback URL — Slack redirects to it after the user installs the
+// app, so it must be reachable from outside the local machine too.
 function webhookUrlFor(platform: string): string {
-	return `${browserOrigin()}/rest/projects/${props.data.projectId}/agents/v2/${props.data.agentId}/webhooks/${platform}`;
+	const base = rootStore.urlBaseWebhook.replace(/\/$/, '');
+	return `${base}/rest/projects/${props.data.projectId}/agents/v2/${props.data.agentId}/webhooks/${platform}`;
 }
 
 async function copyLinearWebhookUrl() {
@@ -151,9 +149,12 @@ const oauthCallbackUrl = computed(() => {
 	if (!configured) return '';
 	try {
 		// Preserve the configured path (which may include a custom rest endpoint
-		// or base path) but rebase onto the current browser origin.
+		// or base path) but rebase onto `urlBaseWebhook` so the callback uses
+		// the publicly reachable host from `WEBHOOK_URL` instead of the local
+		// browser origin (which is `http://localhost:5678` in dev).
 		const parsed = new URL(configured);
-		return `${browserOrigin()}${parsed.pathname}${parsed.search}`;
+		const base = rootStore.urlBaseWebhook.replace(/\/$/, '');
+		return `${base}${parsed.pathname}${parsed.search}`;
 	} catch {
 		return configured;
 	}

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentIntegrationsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentIntegrationsPanel.vue
@@ -131,9 +131,13 @@ function hasError(type: string): boolean {
 	return (errorMessages.value[type] ?? '').length > 0;
 }
 
+// Webhook URLs in the integration manifests must use the instance's configured
+// `WEBHOOK_URL` (`urlBaseWebhook`), not the editor URL: in production the
+// editor and webhook receiver may be on different hosts, and the chat platform
+// (Slack, Linear) needs the publicly reachable webhook host.
 function webhookUrlFor(platform: string): string {
-	const base = rootStore.urlBaseEditor;
-	return `${base}rest/projects/${props.projectId}/agents/v2/${props.agentId}/webhooks/${platform}`;
+	const base = rootStore.urlBaseWebhook.replace(/\/$/, '');
+	return `${base}/rest/projects/${props.projectId}/agents/v2/${props.agentId}/webhooks/${platform}`;
 }
 
 const linearCopied = ref(false);


### PR DESCRIPTION
## Summary
Making the slack verification process a bit easier, right now you need to add credentials before you can verify the redirect URLs are working correctly, I've made it so that the verification endpoints do not require the signing secret to work. I've also updated the manifest generation to use the webhook URL rather than the browser address.

Previously the process involved taking the manifest, creating credentials, setting up creds in the agent, then going back and verifying the redirect URLs in slack before it would function, now the user can add the manifest, immediately verify and then add the creds to n8n.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
