### PR TITLE
fix(core): preserve AxiosHeaders instance when applying OpenAI vendor defaults

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/__tests__/axios-config.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/__tests__/axios-config.test.ts
@@ -1,0 +1,74 @@
+import { AiConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
+import type { InternalAxiosRequestConfig } from 'axios';
+import axios, { AxiosHeaders } from 'axios';
+
+import '../axios-config';
+
+const getRequestInterceptor = () => {
+	const handlers = (
+		axios.interceptors.request as unknown as {
+			handlers: Array<{
+				fulfilled: (config: InternalAxiosRequestConfig) => InternalAxiosRequestConfig;
+			} | null>;
+		}
+	).handlers;
+	const handler = handlers.find((h) => h !== null);
+	if (!handler) throw new Error('axios request interceptor not registered');
+	return handler.fulfilled;
+};
+
+const buildConfig = (
+	overrides: Partial<InternalAxiosRequestConfig> = {},
+): InternalAxiosRequestConfig =>
+	({
+		headers: new AxiosHeaders(),
+		...overrides,
+	}) as InternalAxiosRequestConfig;
+
+describe('axios request interceptor', () => {
+	describe('applyVendorHeaders for api.openai.com', () => {
+		const [vendorHeaderName, vendorHeaderValue] = Object.entries(
+			Container.get(AiConfig).openAiDefaultHeaders,
+		)[0];
+
+		it('keeps config.headers as an AxiosHeaders instance so the interceptor is re-runnable', () => {
+			const interceptor = getRequestInterceptor();
+			const config = buildConfig({ url: 'https://api.openai.com/v1/models' });
+
+			interceptor(config);
+
+			expect(() => interceptor(config)).not.toThrow();
+			expect(config.headers).toBeInstanceOf(AxiosHeaders);
+		});
+
+		it('applies vendor headers to api.openai.com requests', () => {
+			const interceptor = getRequestInterceptor();
+			const config = buildConfig({ url: 'https://api.openai.com/v1/models' });
+
+			interceptor(config);
+
+			expect(new AxiosHeaders(config.headers).get(vendorHeaderName)).toBe(vendorHeaderValue);
+		});
+
+		it('lets caller-provided headers win over vendor defaults', () => {
+			const interceptor = getRequestInterceptor();
+			const headers = new AxiosHeaders();
+			headers.set(vendorHeaderName, 'caller-override');
+			const config = buildConfig({ url: 'https://api.openai.com/v1/models', headers });
+
+			interceptor(config);
+
+			expect(new AxiosHeaders(config.headers).get(vendorHeaderName)).toBe('caller-override');
+		});
+
+		it('does not apply vendor headers to non-OpenAI URLs', () => {
+			const interceptor = getRequestInterceptor();
+			const config = buildConfig({ url: 'https://example.com/api' });
+
+			interceptor(config);
+
+			expect(new AxiosHeaders(config.headers).get(vendorHeaderName)).toBeFalsy();
+		});
+	});
+});

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/axios-config.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/axios-config.ts
@@ -1,7 +1,7 @@
 import { AiConfig } from '@n8n/config';
 import { Container } from '@n8n/di';
-import type { AxiosRequestConfig } from 'axios';
 import axios from 'axios';
+import type { InternalAxiosRequestConfig } from 'axios';
 import { stringify } from 'qs';
 
 import { setAxiosAgents } from './axios-utils';
@@ -36,11 +36,8 @@ axios.interceptors.request.use((config) => {
 	return config;
 });
 
-function applyVendorHeaders(config: AxiosRequestConfig) {
+function applyVendorHeaders(config: InternalAxiosRequestConfig) {
 	if ([config.url, config.baseURL].some((url) => url?.startsWith('https://api.openai.com/'))) {
-		config.headers = {
-			...Container.get(AiConfig).openAiDefaultHeaders,
-			...(config.headers ?? {}),
-		};
+		config.headers.set(Container.get(AiConfig).openAiDefaultHeaders, false);
 	}
 }


### PR DESCRIPTION
## Summary

`applyVendorHeaders` was rebuilding `config.headers` as a plain object via spread (`{ ...vendorDefaults, ...callerHeaders }`), which discarded the `AxiosHeaders` prototype. This caused `config.headers.setContentType()` to throw `TypeError` on subsequent interceptor runs for `api.openai.com` requests.

## Changes

- Use `headers.set(defaults, false)` instead of spread, which merges vendor defaults without overwriting caller-provided headers and preserves the `AxiosHeaders` instance
- Type `applyVendorHeaders` parameter as `InternalAxiosRequestConfig` (guarantees `headers` is `AxiosHeaders`)
- Add unit tests covering re-runnability, vendor header application, caller header priority, and non-OpenAI URL passthrough

## Testing

- All 4 new unit tests pass
- All 47 existing `axios-utils` tests pass (no regressions)
- Manually verified via HTTP Request node targeting `api.openai.com`

Fixes #29471