### PR TITLE
ci: Allow removal of deprecated release candidate branches

### DIFF
--- a/.github/workflows/util-ensure-release-candidate-branches.yml
+++ b/.github/workflows/util-ensure-release-candidate-branches.yml
@@ -31,4 +31,6 @@ jobs:
           install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
 
       - name: Ensure release-candidate branches
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: node ./.github/scripts/ensure-release-candidate-branches.mjs


### PR DESCRIPTION
## Summary

The `ensure-release-candidate-branches` step is supposed to remove deprecated release candidate branches but wasn't doing it due to [lack of permissions](https://github.com/n8n-io/n8n/actions/runs/25499621637/job/74848517396#step:5:23). This is due to the workflow not passing the n8n asisstant github token to the script's env and it defaulting to default GitHub bot creds.

Add the correct token to the script run to allow cleaning up deprecated release candidate branches.


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
