### PR TITLE
fix(editor): Auto-derive data table name from CSV filename

### DIFF
--- a/packages/frontend/editor-ui/src/features/core/dataTable/components/AddDataTableModal.vue
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/components/AddDataTableModal.vue
@@ -208,11 +208,23 @@ const deriveNameFromFileName = (fileName: string): string => {
 		.trim();
 };
 
-const handleFileChange = (uploadFile: UploadFile) => {
-	if (uploadFile.raw) {
-		selectedFile.value = uploadFile.raw;
+const handleFileChange = async (uploadFile: UploadFile) => {
+	if (!uploadFile.raw) return;
+	selectedFile.value = uploadFile.raw;
+	if (dataTableName.value) return;
+
+	const baseName = deriveNameFromFileName(uploadFile.raw.name);
+	if (!baseName) return;
+
+	const projectId = route.params.projectId as string;
+	try {
+		const suggested = await dataTableStore.findAvailableDataTableName(baseName, projectId);
 		if (!dataTableName.value) {
-			dataTableName.value = deriveNameFromFileName(uploadFile.raw.name);
+			dataTableName.value = suggested;
+		}
+	} catch {
+		if (!dataTableName.value) {
+			dataTableName.value = baseName;
 		}
 	}
 };

--- a/packages/frontend/editor-ui/src/features/core/dataTable/components/AddDataTableModal.vue
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/components/AddDataTableModal.vue
@@ -199,9 +199,21 @@ const reset = (clearTableName = false) => {
 	creationMode.value = 'select';
 };
 
+const deriveNameFromFileName = (fileName: string): string => {
+	return fileName
+		.replace(/\.csv$/i, '')
+		.replace(/[^a-zA-Z0-9]+/g, ' ')
+		.trim()
+		.slice(0, 128)
+		.trim();
+};
+
 const handleFileChange = (uploadFile: UploadFile) => {
 	if (uploadFile.raw) {
 		selectedFile.value = uploadFile.raw;
+		if (!dataTableName.value) {
+			dataTableName.value = deriveNameFromFileName(uploadFile.raw.name);
+		}
 	}
 };
 
@@ -231,11 +243,6 @@ const uploadFile = async () => {
 				csvColumnName: col.name,
 			};
 		});
-
-		if (!dataTableName.value) {
-			const fileName = selectedFile.value.name.replace(/\.csv$/i, '');
-			dataTableName.value = fileName;
-		}
 	} catch (error) {
 		toast.showError(error, i18n.baseText('dataTable.upload.error'));
 		reset();

--- a/packages/frontend/editor-ui/src/features/core/dataTable/components/AddDataTableModal.vue
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/components/AddDataTableModal.vue
@@ -210,20 +210,21 @@ const deriveNameFromFileName = (fileName: string): string => {
 
 const handleFileChange = async (uploadFile: UploadFile) => {
 	if (!uploadFile.raw) return;
-	selectedFile.value = uploadFile.raw;
+	const file = uploadFile.raw;
+	selectedFile.value = file;
 	if (dataTableName.value) return;
 
-	const baseName = deriveNameFromFileName(uploadFile.raw.name);
+	const baseName = deriveNameFromFileName(file.name);
 	if (!baseName) return;
 
 	const projectId = route.params.projectId as string;
 	try {
 		const suggested = await dataTableStore.findAvailableDataTableName(baseName, projectId);
-		if (!dataTableName.value) {
+		if (selectedFile.value === file && !dataTableName.value) {
 			dataTableName.value = suggested;
 		}
 	} catch {
-		if (!dataTableName.value) {
+		if (selectedFile.value === file && !dataTableName.value) {
 			dataTableName.value = baseName;
 		}
 	}

--- a/packages/frontend/editor-ui/src/features/core/dataTable/dataTable.store.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/dataTable.store.ts
@@ -132,7 +132,8 @@ export const useDataTableStore = defineStore(DATA_TABLE_STORE, () => {
 		baseName: string,
 		projectId: string,
 	): Promise<string> => {
-		const trimmed = baseName.trim();
+		const MAX_NAME_LENGTH = 128;
+		const trimmed = baseName.trim().slice(0, MAX_NAME_LENGTH).trim();
 		if (!trimmed || !projectId) return trimmed;
 
 		const response = await fetchDataTablesApi(
@@ -144,11 +145,18 @@ export const useDataTableStore = defineStore(DATA_TABLE_STORE, () => {
 		const existingNames = new Set(response.data.map((t) => t.name.toLowerCase()));
 		if (!existingNames.has(trimmed.toLowerCase())) return trimmed;
 
-		let suffix = 2;
-		while (existingNames.has(`${trimmed} ${suffix}`.toLowerCase())) {
-			suffix++;
+		const buildCandidate = (n: number): string => {
+			const suffix = ` ${n}`;
+			const maxBaseLen = MAX_NAME_LENGTH - suffix.length;
+			const base = trimmed.length > maxBaseLen ? trimmed.slice(0, maxBaseLen).trim() : trimmed;
+			return `${base}${suffix}`;
+		};
+
+		let n = 2;
+		while (existingNames.has(buildCandidate(n).toLowerCase())) {
+			n++;
 		}
-		return `${trimmed} ${suffix}`;
+		return buildCandidate(n);
 	};
 
 	const importCsvToDataTable = async (dataTableId: string, projectId: string, fileId: string) => {

--- a/packages/frontend/editor-ui/src/features/core/dataTable/dataTable.store.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/dataTable.store.ts
@@ -128,6 +128,29 @@ export const useDataTableStore = defineStore(DATA_TABLE_STORE, () => {
 		return await uploadCsvFileApi(rootStore.restApiContext, file, hasHeaders);
 	};
 
+	const findAvailableDataTableName = async (
+		baseName: string,
+		projectId: string,
+	): Promise<string> => {
+		const trimmed = baseName.trim();
+		if (!trimmed || !projectId) return trimmed;
+
+		const response = await fetchDataTablesApi(
+			rootStore.restApiContext,
+			projectId,
+			{ skip: 0, take: 100 },
+			{ name: trimmed },
+		);
+		const existingNames = new Set(response.data.map((t) => t.name.toLowerCase()));
+		if (!existingNames.has(trimmed.toLowerCase())) return trimmed;
+
+		let suffix = 2;
+		while (existingNames.has(`${trimmed} ${suffix}`.toLowerCase())) {
+			suffix++;
+		}
+		return `${trimmed} ${suffix}`;
+	};
+
 	const importCsvToDataTable = async (dataTableId: string, projectId: string, fileId: string) => {
 		return await importCsvToDataTableApi(rootStore.restApiContext, dataTableId, projectId, fileId);
 	};
@@ -385,6 +408,7 @@ export const useDataTableStore = defineStore(DATA_TABLE_STORE, () => {
 		maxSizeMB,
 		createDataTable,
 		uploadCsvFile,
+		findAvailableDataTableName,
 		importCsvToDataTable,
 		deleteDataTable,
 		updateDataTable,

--- a/packages/frontend/editor-ui/src/features/core/dataTable/dataTable.store.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/dataTable.store.ts
@@ -133,16 +133,26 @@ export const useDataTableStore = defineStore(DATA_TABLE_STORE, () => {
 		projectId: string,
 	): Promise<string> => {
 		const MAX_NAME_LENGTH = 128;
+		const PAGE_SIZE = 250;
 		const trimmed = baseName.trim().slice(0, MAX_NAME_LENGTH).trim();
 		if (!trimmed || !projectId) return trimmed;
 
-		const response = await fetchDataTablesApi(
-			rootStore.restApiContext,
-			projectId,
-			{ skip: 0, take: 100 },
-			{ name: trimmed },
-		);
-		const existingNames = new Set(response.data.map((t) => t.name.toLowerCase()));
+		const existingNames = new Set<string>();
+		let skip = 0;
+		while (true) {
+			const response = await fetchDataTablesApi(
+				rootStore.restApiContext,
+				projectId,
+				{ skip, take: PAGE_SIZE },
+				{ name: trimmed },
+			);
+			for (const t of response.data) {
+				existingNames.add(t.name.toLowerCase());
+			}
+			skip += response.data.length;
+			if (response.data.length < PAGE_SIZE || skip >= response.count) break;
+		}
+
 		if (!existingNames.has(trimmed.toLowerCase())) return trimmed;
 
 		const buildCandidate = (n: number): string => {


### PR DESCRIPTION
## Summary

When creating a data table by importing a CSV, the name field is now auto-populated from the uploaded filename if the user hasn't entered one. The derived name strips the `.csv` extension, replaces non-alphanumeric runs with single spaces, and is capped at 128 chars (the schema max). Any name the user has already typed is preserved.

**How to test:** Open the "Add data table" modal, choose "Import CSV", select a file (e.g. `customers-2024 (final).csv`) without typing a name — the name field should populate with `customers 2024 final`.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI