### PR TITLE
fix(editor): Add expand/collapse to chat panel in Agents

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -5733,6 +5733,8 @@
 	"agents.builder.chat.sessionPicker.empty": "No previous chats",
 	"agents.builder.chat.newChat.ariaLabel": "Start a new chat",
 	"agents.builder.chat.newChat.label": "New chat",
+	"agents.builder.chat.fullWidth.expand.ariaLabel": "Expand",
+	"agents.builder.chat.fullWidth.collapse.ariaLabel": "Collapse",
 	"agents.chat.loadHistory.error": "Could not load chat history",
 	"agents.chat.clearHistory.error": "Could not clear chat history",
 	"agents.chat.clearHistory": "Clear chat history",

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
@@ -174,8 +174,8 @@ const baseTextFn = (key: string) => {
 		'agents.builder.chatMode.build': 'Build',
 		'agents.builder.chatMode.test': 'Test',
 		'agents.builder.chatMode.ariaLabel': 'Switch chat mode',
-		'agents.builder.chat.fullWidth.expand.ariaLabel': 'Expand chat',
-		'agents.builder.chat.fullWidth.collapse.ariaLabel': 'Show configuration editor',
+		'agents.builder.chat.fullWidth.expand.ariaLabel': 'Expand',
+		'agents.builder.chat.fullWidth.collapse.ariaLabel': 'Collapse',
 		'projects.menu.personal': 'Personal',
 	};
 	return map[key] ?? key;

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
@@ -174,6 +174,8 @@ const baseTextFn = (key: string) => {
 		'agents.builder.chatMode.build': 'Build',
 		'agents.builder.chatMode.test': 'Test',
 		'agents.builder.chatMode.ariaLabel': 'Switch chat mode',
+		'agents.builder.chat.fullWidth.expand.ariaLabel': 'Expand chat',
+		'agents.builder.chat.fullWidth.collapse.ariaLabel': 'Show configuration editor',
 		'projects.menu.personal': 'Personal',
 	};
 	return map[key] ?? key;
@@ -533,6 +535,31 @@ describe('AgentBuilderView — three-column shell', () => {
 		const wrapper = await renderView();
 		expect(wrapper.find('[data-testid="agent-builder-chat-column"]').exists()).toBe(true);
 		expect(wrapper.find('[data-testid="agent-builder-editor-column"]').exists()).toBe(true);
+	});
+
+	it('hides the editor column when the chat full-width toggle is enabled', async () => {
+		const wrapper = await renderView();
+
+		const chatColumn = wrapper.findComponent({ name: 'AgentBuilderChatColumn' });
+		chatColumn.vm.$emit('update:full-width', true);
+		await nextTick();
+
+		expect(wrapper.find('[data-testid="agent-builder-editor-column"]').exists()).toBe(false);
+		expect(chatColumn.props('isFullWidth')).toBe(true);
+
+		wrapper.findComponent({ name: 'AgentBuilderChatColumn' }).vm.$emit('update:full-width', false);
+		await nextTick();
+
+		expect(wrapper.find('[data-testid="agent-builder-editor-column"]').exists()).toBe(true);
+		expect(wrapper.findComponent({ name: 'AgentBuilderChatColumn' }).props('isFullWidth')).toBe(
+			false,
+		);
+	});
+
+	it('renders a floating full-width toggle in build chat mode', async () => {
+		const wrapper = await renderView();
+
+		expect(wrapper.find('[data-testid="agent-build-chat-full-width-toggle"]').exists()).toBe(true);
 	});
 
 	it('renders the Build/Test toggle inside the chat input footer', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderChatColumn.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderChatColumn.vue
@@ -32,6 +32,7 @@ const props = defineProps<{
 	isBuilderConfigured: boolean;
 	isBuildChatStreaming: boolean;
 	isPublished: boolean;
+	isFullWidth: boolean;
 	beforeBuildSend?: () => Promise<void> | void;
 }>();
 
@@ -45,6 +46,7 @@ const emit = defineEmits<{
 	'update:streaming': [streaming: boolean];
 	'update:tools': [tools: AgentJsonToolRef[]];
 	'update:connected-triggers': [triggers: string[]];
+	'update:full-width': [fullWidth: boolean];
 	'trigger-added': [payload: { triggerType: string; triggers: string[] }];
 	'agent-published': [agent: AgentResource];
 }>();
@@ -54,6 +56,13 @@ const sessionMenuMaxHeight = 'calc((var(--spacing--xl) * 5) + var(--spacing--xs)
 
 // `sessionOptions` already match `DropdownMenuItemProps`; alias for template clarity.
 const sessionMenuItems = computed<Array<DropdownMenuItemProps<string>>>(() => props.sessionOptions);
+const fullWidthToggleLabel = computed(() =>
+	i18n.baseText(
+		props.isFullWidth
+			? 'agents.builder.chat.fullWidth.collapse.ariaLabel'
+			: 'agents.builder.chat.fullWidth.expand.ariaLabel',
+	),
+);
 </script>
 
 <template>
@@ -87,24 +96,56 @@ const sessionMenuItems = computed<Array<DropdownMenuItemProps<string>>>(() => pr
 					</N8nButton>
 				</template>
 			</N8nDropdownMenu>
-			<N8nTooltip
-				placement="left"
-				:content="i18n.baseText('agents.builder.chat.newChat.ariaLabel')"
-			>
-				<N8nButton
-					v-if="currentSessionHasMessages"
-					variant="ghost"
-					iconOnly
-					size="small"
-					:class="$style.newChatBtn"
-					:aria-label="i18n.baseText('agents.builder.chat.newChat.ariaLabel')"
-					data-testid="agent-chat-new-chat-btn"
-					@click="emit('new-chat')"
+			<div :class="$style.sessionActions">
+				<N8nTooltip
+					placement="left"
+					:content="i18n.baseText('agents.builder.chat.newChat.ariaLabel')"
 				>
-					<N8nIcon icon="plus" :size="14" />
-				</N8nButton>
-			</N8nTooltip>
+					<N8nButton
+						v-if="currentSessionHasMessages"
+						variant="ghost"
+						icon-only
+						size="small"
+						:class="$style.headerIconBtn"
+						:aria-label="i18n.baseText('agents.builder.chat.newChat.ariaLabel')"
+						data-testid="agent-chat-new-chat-btn"
+						@click="emit('new-chat')"
+					>
+						<N8nIcon icon="plus" :size="14" />
+					</N8nButton>
+				</N8nTooltip>
+				<N8nTooltip placement="left" :content="fullWidthToggleLabel">
+					<N8nButton
+						variant="ghost"
+						icon-only
+						size="small"
+						:class="$style.headerIconBtn"
+						:aria-label="fullWidthToggleLabel"
+						data-testid="agent-chat-full-width-toggle"
+						@click="emit('update:full-width', !isFullWidth)"
+					>
+						<N8nIcon :icon="isFullWidth ? 'minimize-2' : 'maximize-2'" :size="14" />
+					</N8nButton>
+				</N8nTooltip>
+			</div>
 		</div>
+		<N8nTooltip
+			v-if="initialized && chatMode === 'build'"
+			placement="left"
+			:content="fullWidthToggleLabel"
+		>
+			<N8nButton
+				variant="ghost"
+				icon-only
+				size="small"
+				:class="[$style.headerIconBtn, $style.floatingFullWidthToggle]"
+				:aria-label="fullWidthToggleLabel"
+				data-testid="agent-build-chat-full-width-toggle"
+				@click="emit('update:full-width', !isFullWidth)"
+			>
+				<N8nIcon :icon="isFullWidth ? 'minimize-2' : 'maximize-2'" :size="14" />
+			</N8nButton>
+		</N8nTooltip>
 		<div :class="$style.chatBody">
 			<AgentChatPanel
 				v-if="initialized && chatModeOpened.test && effectiveSessionId"
@@ -220,13 +261,26 @@ const sessionMenuItems = computed<Array<DropdownMenuItemProps<string>>>(() => pr
 	margin-left: calc(var(--spacing--5xs) * -1);
 }
 
-.newChatBtn {
+.sessionActions {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing--4xs);
+}
+
+.headerIconBtn {
 	color: var(--text-color--subtle);
 
 	&:hover,
 	&:focus-visible {
 		color: var(--text-color);
 	}
+}
+
+.floatingFullWidthToggle {
+	position: absolute;
+	top: var(--spacing--2xs);
+	right: var(--spacing--sm);
+	z-index: 2;
 }
 
 .sessionMenu {
@@ -246,5 +300,7 @@ const sessionMenuItems = computed<Array<DropdownMenuItemProps<string>>>(() => pr
 .chatBody > * {
 	flex: 1;
 	min-height: 0;
+	max-width: 45rem;
+	margin: 0 auto;
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChatMessageList.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChatMessageList.vue
@@ -248,14 +248,12 @@ watch(
 	display: flex;
 	flex-direction: column;
 	gap: var(--spacing--lg);
-	scrollbar-width: thin;
-	scrollbar-color: transparent transparent;
+	scrollbar-width: none;
 
 	mask-image: linear-gradient(to bottom, transparent 0%, black 5%, black 95%, transparent 100%);
 
-	&:hover,
-	&:focus-within {
-		scrollbar-color: var(--border-color) transparent;
+	&::-webkit-scrollbar {
+		display: none;
 	}
 }
 

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -117,6 +117,7 @@ const { config, fetchConfig, updateConfig } = useAgentConfig();
 const localConfig = ref<AgentJsonConfig | null>(null);
 const connectedTriggers = ref<string[]>([]);
 const builderContainer = useTemplateRef<HTMLElement>('builderContainer');
+const isChatFullWidth = ref(false);
 
 const { ensureLoaded: ensureIntegrationsCatalog } = useAgentIntegrationsCatalog();
 
@@ -845,10 +846,14 @@ function onSwitchAgent(nextAgentId: string) {
 			}"
 		>
 			<N8nResizeWrapper
-				:class="$style.chatResizer"
-				:width="chatPanelResizer.size.value"
-				:style="{ width: `${chatPanelResizer.size.value}px` }"
-				:supported-directions="['right']"
+				:class="{
+					[$style.chatResizer]: true,
+					[$style.chatResizerFullWidth]: isChatFullWidth,
+				}"
+				:width="isChatFullWidth ? 0 : chatPanelResizer.size.value"
+				:style="{ width: isChatFullWidth ? '100%' : `${chatPanelResizer.size.value}px` }"
+				:is-resizing-enabled="!isChatFullWidth"
+				:supported-directions="isChatFullWidth ? [] : ['right']"
 				:min-width="AGENT_CHAT_PANEL_MIN_WIDTH"
 				:max-width="AGENT_CHAT_PANEL_MAX_WIDTH"
 				:grid-size="8"
@@ -877,6 +882,7 @@ function onSwitchAgent(nextAgentId: string) {
 					:is-builder-configured="isBuilderConfigured"
 					:is-build-chat-streaming="isBuildChatStreaming"
 					:is-published="Boolean(agent?.publishedVersion)"
+					:is-full-width="isChatFullWidth"
 					:before-build-send="flushAutosave"
 					@session-select="onSessionPick"
 					@new-chat="onNewChat"
@@ -887,12 +893,14 @@ function onSwitchAgent(nextAgentId: string) {
 					@update:streaming="onBuildChatStreamingChange"
 					@update:tools="onQuickActionAddTool"
 					@update:connected-triggers="onConnectedTriggersUpdate"
+					@update:full-width="isChatFullWidth = $event"
 					@trigger-added="onTriggerAdded"
 					@agent-published="onPublished"
 				/>
 			</N8nResizeWrapper>
 
 			<AgentBuilderEditorColumn
+				v-if="!isChatFullWidth"
 				:class="$style.editorColumn"
 				v-model:active-main-tab="activeMainTab"
 				:local-config="localConfig"
@@ -960,6 +968,10 @@ function onSwitchAgent(nextAgentId: string) {
 			opacity: 1;
 		}
 	}
+}
+
+.chatResizerFullWidth {
+	flex: 1 1 auto;
 }
 
 .isResizingChat {


### PR DESCRIPTION
## Summary
Adds a full-width toggle for the Agent Builder chat panel so users can focus on the chat when needed, then return to the configuration editor without losing context. Makes it better to do testing.

What changed:
- Added an expand/collapse icon button in the test chat session header.
- Added a floating expand/collapse icon button in build chat mode so users are not locked into full-width chat after switching modes.
- Hides the editor column while chat is full-width and restores it when collapsed.
- Added i18n strings for the full-width toggle labels.
- Added Agent Builder view test coverage for the full-width behavior and build-mode floating toggle.

<img width="2049" height="1024" alt="CleanShot 2026-05-08 at 09 01 31@2x" src="https://github.com/user-attachments/assets/1b80162c-6ce1-48d1-8394-ea2fb9fa4256" />
<img width="2557" height="1280" alt="CleanShot 2026-05-08 at 09 08 10@2x" src="https://github.com/user-attachments/assets/0c067663-4a35-45d9-aefc-6774482de46c" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-115

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created. Not needed, UI-only Agent Builder control.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
