### PR TITLE
fix(editor): Increase timeout in workflow archive spec (no-changelog)

### DIFF
--- a/packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/archive.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/archive.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '../../../../../fixtures/base';
 import type { n8nPage } from '../../../../../pages/n8nPage';
 
 async function addNodeAndGetWorkflowId(n8n: n8nPage): Promise<string> {
-	const saveResponsePromise = n8n.canvas.waitForSaveWorkflowCompleted({ timeout: 5000 });
+	const saveResponsePromise = n8n.canvas.waitForSaveWorkflowCompleted({ timeout: 10000 });
 	await n8n.canvas.addNode(SCHEDULE_TRIGGER_NODE_NAME, { closeNDV: true });
 	const {
 		data: { id },


### PR DESCRIPTION
## Summary

Increases the `waitForSaveWorkflowCompleted` timeout in the workflow archive Playwright spec from 5000ms to 10000ms to reduce flakiness in CI environments where the save response can take longer than expected.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3040

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI