### PR TITLE
fix(editor): Match input height with mode selector in resource locator

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/resourceLocator.scss
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/resourceLocator.scss
@@ -80,6 +80,11 @@ $--mode-selector-width: 92px;
 			flex-grow: 1;
 		}
 
+		/** NOTE (@heymynameisrob): Manual override to match legacy size of Select. Will need removing when sizes are unified **/
+		.inputField {
+			--input--height: 30px !important;
+		}
+
 		.inputContainerInputCorners {
 			input {
 				border-radius: 0 var(--radius) var(--radius) 0;
@@ -102,11 +107,6 @@ $--mode-selector-width: 92px;
 	input {
 		cursor: grabbing !important;
 	}
-}
-
-/** NOTE (@heymynameisrob): Manual override to match legacy size of Select. Will need removing when sizes are unified **/
-.selectInput {
-	--input--height: 30px !important;
 }
 
 .selectInput input {


### PR DESCRIPTION
## Summary

**Problem**: When the ResourceLocator component has multiple modes (e.g. "From list", "By ID", "By URL"), the mode selector (N8nSelect) renders at `30px` height while the text input (N8nInput) next to it renders at `28px`. There was already a height override to fix this, but it was only applied in list mode via the `.selectInput` class.

**Fix**: Move the height override to `.multipleModes .inputField` so it applies in all modes whenever the mode selector is visible, not just in list mode. The text truncation styles (`overflow: hidden; text-overflow: ellipsis`) remain in `.selectInput` since those are only needed for the readonly list display.

**Before**:
- From list (correct height):
    - <img width="378" height="63" alt="image" src="https://github.com/user-attachments/assets/539e501f-8a0d-41e3-9fe5-8cccb5d2379a" />

- By ID (wrong height):
    - <img width="378" height="63" alt="image" src="https://github.com/user-attachments/assets/f80e2733-3b69-4db4-b54f-fef62f9242d8" />

- By URL (wrong height):
    - <img width="378" height="63" alt="image" src="https://github.com/user-attachments/assets/c2a4e5ae-8784-4f38-9b3b-c75f476baf0c" />

**After**:
- From list:
   - <img width="420" alt="image" src="https://github.com/user-attachments/assets/76fcbbe0-fad0-4866-9377-5f25bda9aa5b" />

- By ID:
   - <img width="420" alt="image" src="https://github.com/user-attachments/assets/ed013f80-4551-4bbc-b232-01943ce11c54" />

- By URL:
   - <img width="420" alt="image" src="https://github.com/user-attachments/assets/c2fdce89-982e-4b24-ab2c-7499380b4024" />

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-5058](https://linear.app/n8n/issue/ADO-5058/resource-locator-input-different-heights-when-a-select-and-text-input)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
