### PR TITLE
chore: Reassign i18n package codeownership to frontend team (no-changelog)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -174,7 +174,7 @@ packages/frontend/@n8n/stores/                          @n8n-io/frontend
 packages/frontend/@n8n/composables/                     @n8n-io/frontend
 packages/frontend/@n8n/rest-api-client/                 @n8n-io/frontend
 packages/frontend/@n8n/storybook/                       @n8n-io/design
-packages/frontend/@n8n/i18n/                            @n8n-io/adore
+packages/frontend/@n8n/i18n/                            @n8n-io/frontend
 packages/@n8n/stylelint-config/                         @n8n-io/adore
 
 # AI


### PR DESCRIPTION
## Summary

Updates `.github/CODEOWNERS` to reassign ownership of `packages/frontend/@n8n/i18n/` from `@n8n-io/adore` to `@n8n-io/frontend`, so the frontend team is the default reviewer for changes in the i18n package.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI