### PR TITLE
chore: Move stylelint-config codeowners to qa-dx (no-changelog)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -175,7 +175,7 @@ packages/frontend/@n8n/composables/                     @n8n-io/frontend
 packages/frontend/@n8n/rest-api-client/                 @n8n-io/frontend
 packages/frontend/@n8n/storybook/                       @n8n-io/design
 packages/frontend/@n8n/i18n/                            @n8n-io/adore
-packages/@n8n/stylelint-config/                         @n8n-io/adore
+packages/@n8n/stylelint-config/                         @n8n-io/qa-dx
 
 # AI
 


### PR DESCRIPTION
## Summary

Update CODEOWNERS so `packages/@n8n/stylelint-config/` is owned by `@n8n-io/qa-dx` instead of `@n8n-io/adore`, aligning ownership with related tooling configs (eslint-config, typescript-config).

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI