### PR TITLE
chore: Clarify decorators ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -196,7 +196,7 @@ packages/@n8n/codemirror-lang/                          @n8n-io/nodes
 packages/@n8n/codemirror-lang-html/                     @n8n-io/nodes
 packages/@n8n/codemirror-lang-sql/                      @n8n-io/nodes
 packages/nodes-base/                                    @n8n-io/nodes
-packages/@n8n/decorators/                               @n8n-io/nodes
+packages/@n8n/decorators/                               @n8n-io/catalysts
 packages/node-dev/                                      @n8n-io/nodes
 packages/@n8n/create-node/                              @n8n-io/nodes
 packages/@n8n/node-cli/                                 @n8n-io/nodes

--- a/.github/workflows/ci-codeowners-validation.yml
+++ b/.github/workflows/ci-codeowners-validation.yml
@@ -1,5 +1,5 @@
 # .github/workflows/ci-codeowners-validation.yml
-name: Validate CODEOWNERS
+name: "CI: Validate CODEOWNERS"
 
 # Only run when CODEOWNERS or packages change
 on:


### PR DESCRIPTION
## Summary

- Change decorators to be owned by CATS team
- Rename `CODEOWNERS` validation workflow for consistency

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- ~[ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- ~[ ] Tests included.~ <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] ~PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)~
