### PR TITLE
chore: Assign workflow-sdk and instance-ai to instance-ai team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,7 +17,7 @@ packages/@n8n/errors/                                   @n8n-io/catalysts
 packages/@n8n/constants/                                @n8n-io/catalysts
 packages/@n8n/utils/                                    @n8n-io/catalysts
 packages/@n8n/api-types/                                @n8n-io/catalysts
-packages/@n8n/workflow-sdk/                             @n8n-io/catalysts
+packages/@n8n/workflow-sdk/                             @n8n-io/instance-ai
 packages/@n8n/task-runner/                              @n8n-io/catalysts
 packages/@n8n/task-runner-python/                       @n8n-io/catalysts
 packages/@n8n/expression-runtime/                       @n8n-io/catalysts
@@ -179,6 +179,7 @@ packages/@n8n/stylelint-config/                         @n8n-io/qa-dx
 
 # AI
 
+packages/@n8n/instance-ai/                              @n8n-io/instance-ai
 packages/@n8n/nodes-langchain/                          @n8n-io/ai
 packages/@n8n/ai-utilities/                             @n8n-io/ai
 packages/@n8n/ai-node-sdk/                              @n8n-io/ai


### PR DESCRIPTION
## Summary
- Move `packages/@n8n/workflow-sdk/` ownership from `@n8n-io/catalysts` to `@n8n-io/instance-ai`
- Add `packages/@n8n/instance-ai/` ownership to `@n8n-io/instance-ai`

## Related

Slack thread: https://n8nio.slack.com/archives/C035KBDA917/p1778237873197649?thread_ts=1778169282.281969&cid=C035KBDA917

https://claude.ai/code/session_01Q56ZXhGiYfBCGSRmtG63mo
- [x] I have seen this code, I have run this code, and I take responsibility for this code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q56ZXhGiYfBCGSRmtG63mo)_