### PR TITLE
fix(EditImage Node): Fix composite operation failing with stream empty buffer

### DIFF
--- a/packages/nodes-base/nodes/EditImage/EditImage.node.ts
+++ b/packages/nodes-base/nodes/EditImage/EditImage.node.ts
@@ -1139,16 +1139,10 @@ export class EditImage implements INodeType {
 						cleanupFunctions.push(cleanup);
 						await fsWriteFile(path, binaryDataBuffer);
 
-						if (operations[0].operation === 'create') {
-							// It seems like if the image gets created newly we have to create a new gm instance
-							// else it fails for some reason
-							gmInstance = gm(gmInstance!.stream('png'))
-								.compose(operator)
-								.geometry(geometryString)
-								.composite(path);
-						} else {
-							gmInstance = gmInstance!.compose(operator).geometry(geometryString).composite(path);
-						}
+						gmInstance = gm(gmInstance!.stream('png'))
+							.compose(operator)
+							.geometry(geometryString)
+							.composite(path);
 
 						if (operations.length !== i + 1) {
 							// If there are other operations after the current one create a new gm instance


### PR DESCRIPTION
## Summary

Fixes a regression introduced in https://github.com/n8n-io/n8n/pull/28970 where the Edit Image node's **Composite** operation throws `"Stream yields empty buffer"` on n8n v2.19.0+.

**Root cause:** PR #28970 added `.autoOrient()` and `.out('-orient', 'TopLeft')` to the image loading pipeline to fix orientation issues. However, gm's `.composite()` method switches from the `convert` command to the `composite` command internally, which doesn't support `-auto-orient` in the same pipeline. This causes GraphicsMagick to produce an empty stream.

**Fix:** Always materialize the current gm pipeline (including autoOrient) into a PNG stream before applying the composite operation. This was already done for the `create` → composite path, but not for the regular path. The if/else branch is now unified — all composite operations first flush pending operations via `.stream('png')`, then apply the composite on a fresh gm instance.

**How to test:**
1. Create a workflow with two binary image inputs (e.g., a background and an overlay)
2. Use the Edit Image node with Operation: Composite
3. Set Property Name to one image, Composite Image Property to the other
4. Execute — should succeed without "Stream yields empty buffer" error

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4998
fixes #29934

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)