### PR TITLE
fix(editor): Refactor archive workflow spec to use API helpers for stability (no-changelog)

### DIFF
--- a/packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/archive.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/archive.spec.ts
@@ -3,7 +3,7 @@ import { test, expect } from '../../../../../fixtures/base';
 import type { n8nPage } from '../../../../../pages/n8nPage';
 
 async function addNodeAndGetWorkflowId(n8n: n8nPage): Promise<string> {
-	const saveResponsePromise = n8n.canvas.waitForSaveWorkflowCompleted({ timeout: 5000 });
+	const saveResponsePromise = n8n.canvas.waitForSaveWorkflowCompleted({ timeout: 10000 });
 	await n8n.canvas.addNode(SCHEDULE_TRIGGER_NODE_NAME, { closeNDV: true });
 	const {
 		data: { id },

--- a/packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/archive.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/archive.spec.ts
@@ -1,25 +1,26 @@
+import { nanoid } from 'nanoid';
+
 import { SCHEDULE_TRIGGER_NODE_NAME } from '../../../../../config/constants';
 import { test, expect } from '../../../../../fixtures/base';
-import type { n8nPage } from '../../../../../pages/n8nPage';
+import type { ApiHelpers } from '../../../../../services/api-helper';
 
-async function addNodeAndGetWorkflowId(n8n: n8nPage): Promise<string> {
-	const saveResponsePromise = n8n.canvas.waitForSaveWorkflowCompleted({ timeout: 10000 });
-	await n8n.canvas.addNode(SCHEDULE_TRIGGER_NODE_NAME, { closeNDV: true });
-	const {
-		data: { id },
-	} = await saveResponsePromise.then((r) => r.json());
-	return id;
-}
+async function createWorkflowWithSingleNode(api: ApiHelpers): Promise<string> {
+	const { id: workflowId } = await api.workflows.createWorkflow({
+		name: `Test Workflow ${nanoid()}`,
+		nodes: [
+			{
+				id: nanoid(),
+				name: 'Schedule Trigger',
+				type: 'n8n-nodes-base.scheduleTrigger',
+				typeVersion: 1.2,
+				position: [250, 300] as [number, number],
+				parameters: {},
+			},
+		],
+		connections: {},
+	});
 
-async function goToWorkflow(n8n: n8nPage, workflowId: string): Promise<void> {
-	const loadResponsePromise = n8n.page.waitForResponse(
-		(response) =>
-			response.url().includes(`/rest/workflows/${workflowId}`) &&
-			response.request().method() === 'GET' &&
-			response.status() === 200,
-	);
-	await n8n.page.goto(`/workflow/${workflowId}`);
-	await loadResponsePromise;
+	return String(workflowId);
 }
 
 test.describe(
@@ -28,22 +29,10 @@ test.describe(
 		annotation: [{ type: 'owner', description: 'Adore' }],
 	},
 	() => {
-		test.beforeEach(async ({ n8n }) => {
-			await n8n.start.fromBlankCanvas();
-		});
-
-		test('should display archived workflow in read-only mode on canvas', async ({ n8n }) => {
-			// Create and save a workflow
-			const workflowId = await addNodeAndGetWorkflowId(n8n);
-
-			// Archive the workflow
-			await n8n.workflowSettingsModal.getWorkflowMenu().click();
-			await n8n.workflowSettingsModal.clickArchiveMenuItem();
-			await expect(n8n.notifications.getSuccessNotifications().first()).toBeVisible();
-			await expect(n8n.page).toHaveURL(/\/workflows$/);
-
-			// Open the archived workflow
-			await goToWorkflow(n8n, workflowId);
+		test('should display archived workflow in read-only mode on canvas', async ({ n8n, api }) => {
+			const workflowId = await createWorkflowWithSingleNode(api);
+			await api.workflows.archive(workflowId);
+			await n8n.navigate.toWorkflow(workflowId);
 
 			// Verify archived tag is visible
 			await expect(n8n.canvas.getArchivedTag()).toBeVisible();
@@ -99,15 +88,11 @@ test.describe(
 
 		test('should not trigger autosave when pasting nodes on an archived workflow', async ({
 			n8n,
+			api,
 		}) => {
-			const workflowId = await addNodeAndGetWorkflowId(n8n);
-
-			await n8n.workflowSettingsModal.getWorkflowMenu().click();
-			await n8n.workflowSettingsModal.clickArchiveMenuItem();
-			await expect(n8n.notifications.getSuccessNotifications().first()).toBeVisible();
-			await expect(n8n.page).toHaveURL(/\/workflows$/);
-
-			await goToWorkflow(n8n, workflowId);
+			const workflowId = await createWorkflowWithSingleNode(api);
+			await api.workflows.archive(workflowId);
+			await n8n.navigate.toWorkflow(workflowId);
 			await expect(n8n.canvas.getArchivedTag()).toBeVisible();
 
 			let saveRequestDetected = false;
@@ -140,6 +125,8 @@ test.describe(
 		});
 
 		test('should not be able to archive or delete unsaved workflow', async ({ n8n }) => {
+			await n8n.start.fromBlankCanvas();
+
 			await expect(n8n.workflowSettingsModal.getWorkflowMenu()).toBeVisible();
 			await n8n.workflowSettingsModal.getWorkflowMenu().click();
 
@@ -149,19 +136,10 @@ test.describe(
 			);
 		});
 
-		test('should archive nonactive workflow and then delete it', async ({ n8n }) => {
-			const workflowId = await addNodeAndGetWorkflowId(n8n);
-			await expect(n8n.canvas.getArchivedTag()).not.toBeAttached();
-
-			await expect(n8n.workflowSettingsModal.getWorkflowMenu()).toBeVisible();
-			await n8n.workflowSettingsModal.getWorkflowMenu().click();
-
-			await n8n.workflowSettingsModal.clickArchiveMenuItem();
-
-			await expect(n8n.notifications.getSuccessNotifications().first()).toBeVisible();
-			await expect(n8n.page).toHaveURL(/\/workflows$/);
-
-			await goToWorkflow(n8n, workflowId);
+		test('should archive nonactive workflow and then delete it', async ({ n8n, api }) => {
+			const workflowId = await createWorkflowWithSingleNode(api);
+			await api.workflows.archive(workflowId);
+			await n8n.navigate.toWorkflow(workflowId);
 
 			await expect(n8n.canvas.getArchivedTag()).toBeVisible();
 			await expect(n8n.canvas.getNodeCreatorPlusButton()).not.toBeAttached();
@@ -176,8 +154,9 @@ test.describe(
 		});
 
 		// Flaky in multi-main mode
-		test.fixme('should archive published workflow and then delete it', async ({ n8n }) => {
-			const workflowId = await addNodeAndGetWorkflowId(n8n);
+		test.fixme('should archive published workflow and then delete it', async ({ n8n, api }) => {
+			const workflowId = await createWorkflowWithSingleNode(api);
+			await n8n.navigate.toWorkflow(workflowId);
 			await n8n.canvas.publishWorkflow();
 			await n8n.page.keyboard.press('Escape');
 
@@ -192,7 +171,7 @@ test.describe(
 			await expect(n8n.notifications.getSuccessNotifications().first()).toBeVisible();
 			await expect(n8n.page).toHaveURL(/\/workflows$/);
 
-			await goToWorkflow(n8n, workflowId);
+			await n8n.navigate.toWorkflow(workflowId);
 
 			await expect(n8n.canvas.getArchivedTag()).toBeVisible();
 			await expect(n8n.canvas.getNodeCreatorPlusButton()).not.toBeAttached();
@@ -207,19 +186,10 @@ test.describe(
 			await expect(n8n.page).toHaveURL(/\/workflows$/);
 		});
 
-		test('should archive nonactive workflow and then unarchive it', async ({ n8n }) => {
-			const workflowId = await addNodeAndGetWorkflowId(n8n);
-			await expect(n8n.canvas.getArchivedTag()).not.toBeAttached();
-
-			await expect(n8n.workflowSettingsModal.getWorkflowMenu()).toBeVisible();
-			await n8n.workflowSettingsModal.getWorkflowMenu().click();
-
-			await n8n.workflowSettingsModal.clickArchiveMenuItem();
-
-			await expect(n8n.notifications.getSuccessNotifications().first()).toBeVisible();
-			await expect(n8n.page).toHaveURL(/\/workflows$/);
-
-			await goToWorkflow(n8n, workflowId);
+		test('should archive nonactive workflow and then unarchive it', async ({ n8n, api }) => {
+			const workflowId = await createWorkflowWithSingleNode(api);
+			await api.workflows.archive(workflowId);
+			await n8n.navigate.toWorkflow(workflowId);
 
 			await expect(n8n.canvas.getArchivedTag()).toBeVisible();
 			await expect(n8n.canvas.getNodeCreatorPlusButton()).not.toBeAttached();
@@ -233,8 +203,13 @@ test.describe(
 			await expect(n8n.canvas.getNodeCreatorPlusButton()).toBeVisible();
 		});
 
-		test('should not show unpublish menu item for non-published workflow', async ({ n8n }) => {
-			await addNodeAndGetWorkflowId(n8n);
+		test('should not show unpublish menu item for non-published workflow', async ({ n8n, api }) => {
+			const { id: workflowId } = await api.workflows.createWorkflow({
+				name: `Test Workflow ${nanoid()}`,
+				nodes: [],
+				connections: {},
+			});
+			await n8n.navigate.toWorkflow(workflowId);
 
 			await expect(n8n.canvas.getPublishedIndicator()).toBeHidden();
 
@@ -244,6 +219,7 @@ test.describe(
 
 		// TODO: flaky test - 18 similar failures across 10 branches in last 14 days
 		test.fixme('should unpublish a published workflow', async ({ n8n }) => {
+			await n8n.start.fromBlankCanvas();
 			await n8n.canvas.addNode(SCHEDULE_TRIGGER_NODE_NAME, { closeNDV: true });
 			await n8n.canvas.publishWorkflow();
 			await n8n.page.keyboard.press('Escape');
@@ -261,8 +237,9 @@ test.describe(
 		});
 
 		// Flaky in multi-main mode
-		test.fixme('should unpublish published workflow on archive', async ({ n8n }) => {
-			const workflowId = await addNodeAndGetWorkflowId(n8n);
+		test.fixme('should unpublish published workflow on archive', async ({ n8n, api }) => {
+			const workflowId = await createWorkflowWithSingleNode(api);
+			await n8n.navigate.toWorkflow(workflowId);
 			await n8n.canvas.publishWorkflow();
 			await n8n.page.keyboard.press('Escape');
 
@@ -275,7 +252,7 @@ test.describe(
 			await expect(n8n.notifications.getSuccessNotifications().first()).toBeVisible();
 			await expect(n8n.page).toHaveURL(/\/workflows$/);
 
-			await goToWorkflow(n8n, workflowId);
+			await n8n.navigate.toWorkflow(workflowId);
 
 			await expect(n8n.canvas.getArchivedTag()).toBeVisible();
 			await expect(n8n.canvas.getPublishedIndicator()).toBeHidden();

--- a/packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/archive.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/archive.spec.ts
@@ -153,8 +153,7 @@ test.describe(
 			await expect(n8n.page).toHaveURL(/\/workflows$/);
 		});
 
-		// Flaky in multi-main mode
-		test.fixme('should archive published workflow and then delete it', async ({ n8n, api }) => {
+		test('should archive published workflow and then delete it', async ({ n8n, api }) => {
 			const workflowId = await createWorkflowWithSingleNode(api);
 			await n8n.navigate.toWorkflow(workflowId);
 			await n8n.canvas.publishWorkflow();
@@ -236,8 +235,7 @@ test.describe(
 			await expect(n8n.canvas.getPublishedIndicator()).toBeHidden();
 		});
 
-		// Flaky in multi-main mode
-		test.fixme('should unpublish published workflow on archive', async ({ n8n, api }) => {
+		test('should unpublish published workflow on archive', async ({ n8n, api }) => {
 			const workflowId = await createWorkflowWithSingleNode(api);
 			await n8n.navigate.toWorkflow(workflowId);
 			await n8n.canvas.publishWorkflow();


### PR DESCRIPTION
## Summary

Refactors the workflow archive E2E spec to replace slow UI-driven workflow creation with API helpers, reducing test overhead and improving stability.

**Changes:**
- Removes the `addNodeAndGetWorkflowId` helper that created workflows by driving the UI (adding a node and waiting for autosave)
- Removes the `goToWorkflow` helper in favour of `n8n.navigate.toWorkflow()`
- Replaces the shared `beforeEach` with per-test setup
- Most tests now create and archive workflows via `api.workflows.createWorkflow()` + `api.workflows.archive()`, then navigate directly to the already-archived workflow
- A `createWorkflowWithSingleNode(api)` helper consolidates the common creation pattern for tests that need a trigger node on the canvas

**How to test:**
Run the spec locally:
```
pnpm --filter=n8n-playwright test:local packages/testing/playwright/tests/e2e/workflows/editor/workflow-actions/archive.spec.ts --reporter=list
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3040

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI