### PR TITLE
ci: Gate PRs on code-health and janitor checks

### DIFF
--- a/.code-health-baseline.json
+++ b/.code-health-baseline.json
@@ -1,7 +1,7 @@
 {
 	"version": 1,
-	"generated": "2026-05-08T11:29:48.337Z",
-	"totalViolations": 115,
+	"generated": "2026-05-08T12:51:46.599Z",
+	"totalViolations": 118,
 	"violations": {
 		"packages/core/package.json": [
 			{
@@ -69,6 +69,12 @@
 				"line": 61,
 				"message": "@mozilla/readability appears in 5 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "d2120f012c93"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 70,
+				"message": "csv-parse appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "94f80b083b76"
 			},
 			{
 				"rule": "catalog-violations",
@@ -293,6 +299,32 @@
 				"hash": "50fb70481f8f"
 			}
 		],
+		"packages/@n8n/node-cli/src/template/templates/declarative/github-issues/template/package.json": [
+			{
+				"rule": "catalog-violations",
+				"line": 43,
+				"message": "eslint@9.32.0 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
+				"hash": "c3815ab2677d"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 46,
+				"message": "typescript@5.9.2 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
+				"hash": "11608ee90ba9"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 44,
+				"message": "prettier appears in 10 packages with 3 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "70fc7a306272"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 49,
+				"message": "n8n-workflow appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "4514689aef5c"
+			}
+		],
 		"packages/@n8n/node-cli/src/template/templates/declarative/custom/template/package.json": [
 			{
 				"rule": "catalog-violations",
@@ -345,30 +377,30 @@
 				"hash": "fd2577d9c87b"
 			}
 		],
-		"packages/@n8n/node-cli/src/template/templates/declarative/github-issues/template/package.json": [
+		"packages/@n8n/node-cli/src/template/templates/programmatic/ai/model-ai-custom-example/template/package.json": [
 			{
 				"rule": "catalog-violations",
 				"line": 43,
 				"message": "eslint@9.32.0 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
-				"hash": "c3815ab2677d"
+				"hash": "91ea1dbe7d4e"
 			},
 			{
 				"rule": "catalog-violations",
 				"line": 46,
 				"message": "typescript@5.9.2 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
-				"hash": "11608ee90ba9"
+				"hash": "72d08eab5625"
 			},
 			{
 				"rule": "catalog-violations",
 				"line": 44,
 				"message": "prettier appears in 10 packages with 3 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "70fc7a306272"
+				"hash": "030ae6daa9ec"
 			},
 			{
 				"rule": "catalog-violations",
 				"line": 49,
 				"message": "n8n-workflow appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "4514689aef5c"
+				"hash": "91b58c718e73"
 			}
 		],
 		"packages/@n8n/node-cli/src/template/templates/programmatic/ai/memory-custom/template/package.json": [
@@ -449,32 +481,6 @@
 				"hash": "6b5e714159dc"
 			}
 		],
-		"packages/@n8n/node-cli/src/template/templates/programmatic/ai/model-ai-custom-example/template/package.json": [
-			{
-				"rule": "catalog-violations",
-				"line": 43,
-				"message": "eslint@9.32.0 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
-				"hash": "91ea1dbe7d4e"
-			},
-			{
-				"rule": "catalog-violations",
-				"line": 46,
-				"message": "typescript@5.9.2 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
-				"hash": "72d08eab5625"
-			},
-			{
-				"rule": "catalog-violations",
-				"line": 44,
-				"message": "prettier appears in 10 packages with 3 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "030ae6daa9ec"
-			},
-			{
-				"rule": "catalog-violations",
-				"line": 49,
-				"message": "n8n-workflow appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "91b58c718e73"
-			}
-		],
 		"packages/cli/package.json": [
 			{
 				"rule": "catalog-violations",
@@ -522,37 +528,43 @@
 		"packages/@n8n/instance-ai/package.json": [
 			{
 				"rule": "catalog-violations",
-				"line": 63,
+				"line": 75,
 				"message": "@ai-sdk/anthropic appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "5b2153508e47"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 43,
+				"line": 53,
 				"message": "@mozilla/readability appears in 5 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "8fa6b9a8fc91"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 54,
+				"line": 60,
+				"message": "csv-parse appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "8f082fc2e8b6"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 66,
 				"message": "turndown appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "9a9d97065952"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 69,
+				"line": 81,
 				"message": "@types/turndown appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "12e346c47b39"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 37,
+				"line": 47,
 				"message": "@joplin/turndown-plugin-gfm appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "a3cf1504b5c2"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 53,
+				"line": 64,
 				"message": "pdf-parse appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "283fa9114c03"
 			}
@@ -607,6 +619,12 @@
 				"line": 911,
 				"message": "cheerio appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "1a1b5bbc50c9"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 914,
+				"message": "csv-parse appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "781db4a1e068"
 			},
 			{
 				"rule": "catalog-violations",

--- a/.code-health-baseline.json
+++ b/.code-health-baseline.json
@@ -1,7 +1,7 @@
 {
 	"version": 1,
-	"generated": "2026-05-08T12:51:46.599Z",
-	"totalViolations": 118,
+	"generated": "2026-05-11T13:19:04.573Z",
+	"totalViolations": 120,
 	"violations": {
 		"packages/core/package.json": [
 			{
@@ -377,32 +377,6 @@
 				"hash": "fd2577d9c87b"
 			}
 		],
-		"packages/@n8n/node-cli/src/template/templates/programmatic/ai/model-ai-custom-example/template/package.json": [
-			{
-				"rule": "catalog-violations",
-				"line": 43,
-				"message": "eslint@9.32.0 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
-				"hash": "91ea1dbe7d4e"
-			},
-			{
-				"rule": "catalog-violations",
-				"line": 46,
-				"message": "typescript@5.9.2 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
-				"hash": "72d08eab5625"
-			},
-			{
-				"rule": "catalog-violations",
-				"line": 44,
-				"message": "prettier appears in 10 packages with 3 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "030ae6daa9ec"
-			},
-			{
-				"rule": "catalog-violations",
-				"line": 49,
-				"message": "n8n-workflow appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "91b58c718e73"
-			}
-		],
 		"packages/@n8n/node-cli/src/template/templates/programmatic/ai/memory-custom/template/package.json": [
 			{
 				"rule": "catalog-violations",
@@ -453,6 +427,32 @@
 				"line": 49,
 				"message": "n8n-workflow appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "e1734c74601d"
+			}
+		],
+		"packages/@n8n/node-cli/src/template/templates/programmatic/ai/model-ai-custom-example/template/package.json": [
+			{
+				"rule": "catalog-violations",
+				"line": 43,
+				"message": "eslint@9.32.0 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
+				"hash": "91ea1dbe7d4e"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 46,
+				"message": "typescript@5.9.2 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
+				"hash": "72d08eab5625"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 44,
+				"message": "prettier appears in 10 packages with 3 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "030ae6daa9ec"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 49,
+				"message": "n8n-workflow appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "91b58c718e73"
 			}
 		],
 		"packages/@n8n/node-cli/src/template/templates/programmatic/ai/model-openai-compatible/template/package.json": [
@@ -523,14 +523,26 @@
 				"line": 218,
 				"message": "ws appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "cd07242e8163"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 75,
+				"message": "@types/psl appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "6e62e0076b0a"
 			}
 		],
 		"packages/@n8n/instance-ai/package.json": [
 			{
 				"rule": "catalog-violations",
-				"line": 75,
+				"line": 76,
 				"message": "@ai-sdk/anthropic appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "5b2153508e47"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 82,
+				"message": "@types/psl appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "56dabb51b433"
 			},
 			{
 				"rule": "catalog-violations",
@@ -546,13 +558,13 @@
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 66,
+				"line": 67,
 				"message": "turndown appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "9a9d97065952"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 81,
+				"line": 83,
 				"message": "@types/turndown appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "12e346c47b39"
 			},
@@ -592,61 +604,61 @@
 		"packages/nodes-base/package.json": [
 			{
 				"rule": "catalog-violations",
-				"line": 910,
+				"line": 911,
 				"message": "change-case appears in 5 packages with 3 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "2d1fab7a5b05"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 960,
+				"line": 961,
 				"message": "semver appears in 4 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "2daf37aa14e4"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 965,
+				"line": 966,
 				"message": "tmp-promise appears in 4 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "3f93c404ae9c"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 899,
+				"line": 900,
 				"message": "@mozilla/readability appears in 5 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "ca4ac788adc6"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 911,
+				"line": 912,
 				"message": "cheerio appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "1a1b5bbc50c9"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 914,
+				"line": 915,
 				"message": "csv-parse appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "781db4a1e068"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 916,
+				"line": 917,
 				"message": "eventsource appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "9795e6c6d9e9"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 929,
+				"line": 930,
 				"message": "jsdom appears in 4 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "02341f2b5e3e"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 940,
+				"line": 941,
 				"message": "mongodb appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "f688907d087a"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 891,
+				"line": 892,
 				"message": "eslint-plugin-n8n-nodes-base appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "ac254baa61f9"
 			}
@@ -762,7 +774,7 @@
 		"packages/@n8n/computer-use/package.json": [
 			{
 				"rule": "catalog-violations",
-				"line": 46,
+				"line": 47,
 				"message": "eventsource appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "f50c1eee2ed6"
 			}

--- a/.code-health-baseline.json
+++ b/.code-health-baseline.json
@@ -1,7 +1,7 @@
 {
 	"version": 1,
-	"generated": "2026-05-11T13:19:04.573Z",
-	"totalViolations": 120,
+	"generated": "2026-05-12T08:06:05.095Z",
+	"totalViolations": 122,
 	"violations": {
 		"packages/core/package.json": [
 			{
@@ -49,6 +49,12 @@
 				"line": 28,
 				"message": "@ai-sdk/anthropic appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "b58f03d0d5c1"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 50,
+				"message": "@opentelemetry/sdk-trace-base appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "c5c495ac3508"
 			},
 			{
 				"rule": "catalog-violations",
@@ -147,6 +153,56 @@
 				"hash": "0e18482e8781"
 			}
 		],
+		"packages/@n8n/nodes-langchain/package.json": [
+			{
+				"rule": "catalog-violations",
+				"line": 292,
+				"message": "openai@^6.34.0 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
+				"hash": "3c1f53f0afe3"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 303,
+				"message": "zod-to-json-schema@3.23.3 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
+				"hash": "081b5d0b5ca5"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 299,
+				"message": "tmp-promise appears in 4 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "88d67e2ef747"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 259,
+				"message": "@mozilla/readability appears in 5 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "69d6fa7e46f9"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 274,
+				"message": "cheerio appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "8cd029bb871e"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 284,
+				"message": "jsdom appears in 4 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "26f20ebea4b1"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 289,
+				"message": "mongodb appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "46cb48884e22"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 293,
+				"message": "pdf-parse appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "0c7d44a9c2e4"
+			}
+		],
 		"packages/@n8n/node-cli/package.json": [
 			{
 				"rule": "catalog-violations",
@@ -177,56 +233,6 @@
 				"line": 55,
 				"message": "eslint-plugin-n8n-nodes-base appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "6a9e12780943"
-			}
-		],
-		"packages/@n8n/nodes-langchain/package.json": [
-			{
-				"rule": "catalog-violations",
-				"line": 293,
-				"message": "openai@^6.34.0 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
-				"hash": "3c1f53f0afe3"
-			},
-			{
-				"rule": "catalog-violations",
-				"line": 303,
-				"message": "zod-to-json-schema@3.23.3 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
-				"hash": "081b5d0b5ca5"
-			},
-			{
-				"rule": "catalog-violations",
-				"line": 300,
-				"message": "tmp-promise appears in 4 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "88d67e2ef747"
-			},
-			{
-				"rule": "catalog-violations",
-				"line": 258,
-				"message": "@mozilla/readability appears in 5 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "69d6fa7e46f9"
-			},
-			{
-				"rule": "catalog-violations",
-				"line": 274,
-				"message": "cheerio appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "8cd029bb871e"
-			},
-			{
-				"rule": "catalog-violations",
-				"line": 284,
-				"message": "jsdom appears in 4 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "26f20ebea4b1"
-			},
-			{
-				"rule": "catalog-violations",
-				"line": 290,
-				"message": "mongodb appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "46cb48884e22"
-			},
-			{
-				"rule": "catalog-violations",
-				"line": 294,
-				"message": "pdf-parse appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "0c7d44a9c2e4"
 			}
 		],
 		"packages/@n8n/tournament/package.json": [
@@ -491,36 +497,42 @@
 			{
 				"rule": "catalog-violations",
 				"line": 139,
+				"message": "@opentelemetry/sdk-trace-base appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "1cf7f6bcf5d1"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 140,
 				"message": "@opentelemetry/sdk-trace-node appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "a3dad0b8dc21"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 149,
+				"line": 150,
 				"message": "change-case appears in 5 packages with 3 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "949e802528f7"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 200,
+				"line": 202,
 				"message": "prettier appears in 10 packages with 3 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "dee51c035f89"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 207,
+				"line": 209,
 				"message": "semver appears in 4 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "5b7e9b03fb10"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 215,
+				"line": 217,
 				"message": "undici appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "91c29775e961"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 218,
+				"line": 220,
 				"message": "ws appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "cd07242e8163"
 			},
@@ -534,49 +546,49 @@
 		"packages/@n8n/instance-ai/package.json": [
 			{
 				"rule": "catalog-violations",
-				"line": 76,
+				"line": 78,
 				"message": "@ai-sdk/anthropic appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "5b2153508e47"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 82,
+				"line": 84,
 				"message": "@types/psl appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "56dabb51b433"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 53,
+				"line": 55,
 				"message": "@mozilla/readability appears in 5 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "8fa6b9a8fc91"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 60,
+				"line": 62,
 				"message": "csv-parse appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "8f082fc2e8b6"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 67,
+				"line": 69,
 				"message": "turndown appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "9a9d97065952"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 83,
+				"line": 85,
 				"message": "@types/turndown appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "12e346c47b39"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 47,
+				"line": 49,
 				"message": "@joplin/turndown-plugin-gfm appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "a3cf1504b5c2"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 64,
+				"line": 66,
 				"message": "pdf-parse appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "283fa9114c03"
 			}
@@ -692,7 +704,7 @@
 		"packages/@n8n/scan-community-package/package.json": [
 			{
 				"rule": "catalog-violations",
-				"line": 23,
+				"line": 20,
 				"message": "semver appears in 4 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "ac0e4301d694"
 			}

--- a/.code-health-baseline.json
+++ b/.code-health-baseline.json
@@ -1,24 +1,58 @@
 {
 	"version": 1,
-	"generated": "2026-04-23T08:42:21.615Z",
-	"totalViolations": 102,
+	"generated": "2026-05-08T11:29:48.337Z",
+	"totalViolations": 115,
 	"violations": {
+		"packages/core/package.json": [
+			{
+				"rule": "catalog-violations",
+				"line": 44,
+				"message": "zod@>=3.25.0 <4 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
+				"hash": "7206fdd3f507"
+			}
+		],
+		"packages/workflow/package.json": [
+			{
+				"rule": "catalog-violations",
+				"line": 76,
+				"message": "zod@>=3.25.0 <4 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
+				"hash": "db77d12f5a47"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 58,
+				"message": "ast-types appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "1c7d7cf0b0fe"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 60,
+				"message": "esprima-next appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "627a716b5d23"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 68,
+				"message": "recast appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "b660317b5f6f"
+			}
+		],
 		"packages/@n8n/agents/package.json": [
 			{
 				"rule": "catalog-violations",
-				"line": 40,
+				"line": 52,
 				"message": "langsmith@>=0.3.0 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
 				"hash": "193bb785d0b4"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 27,
+				"line": 28,
 				"message": "@ai-sdk/anthropic appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "b58f03d0d5c1"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 41,
+				"line": 51,
 				"message": "@opentelemetry/sdk-trace-node appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "a77ced903cdf"
 			}
@@ -26,7 +60,7 @@
 		"packages/@n8n/ai-workflow-builder.ee/package.json": [
 			{
 				"rule": "catalog-violations",
-				"line": 72,
+				"line": 73,
 				"message": "langsmith@^0.4.6 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
 				"hash": "6ee5e003d795"
 			},
@@ -38,21 +72,29 @@
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 70,
+				"line": 71,
 				"message": "jsdom appears in 4 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "9c770d66baf2"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 76,
+				"line": 77,
 				"message": "turndown appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "85c311d87491"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 82,
+				"line": 83,
 				"message": "@types/turndown appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "407c8d1b3428"
+			}
+		],
+		"packages/@n8n/api-types/package.json": [
+			{
+				"rule": "catalog-violations",
+				"line": 39,
+				"message": "zod@>=3.25.0 <4 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
+				"hash": "3ace050c7ffc"
 			}
 		],
 		"packages/@n8n/cli/package.json": [
@@ -95,8 +137,8 @@
 			{
 				"rule": "catalog-violations",
 				"line": 63,
-				"message": "zod@^3.0.0 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
-				"hash": "436de7cbc5ea"
+				"message": "zod@^3.25.76 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
+				"hash": "0e18482e8781"
 			}
 		],
 		"packages/@n8n/node-cli/package.json": [
@@ -114,6 +156,12 @@
 			},
 			{
 				"rule": "catalog-violations",
+				"line": 59,
+				"message": "prettier appears in 10 packages with 3 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "9e47058c6edb"
+			},
+			{
+				"rule": "catalog-violations",
 				"line": 51,
 				"message": "@oclif/core appears in 4 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "9711a9b00bf9"
@@ -123,68 +171,94 @@
 				"line": 55,
 				"message": "eslint-plugin-n8n-nodes-base appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "6a9e12780943"
-			},
-			{
-				"rule": "catalog-violations",
-				"line": 59,
-				"message": "prettier appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "d536f5a9c3f8"
 			}
 		],
 		"packages/@n8n/nodes-langchain/package.json": [
 			{
 				"rule": "catalog-violations",
-				"line": 289,
-				"message": "openai@^6.9.0 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
-				"hash": "b9b214e61fdc"
+				"line": 293,
+				"message": "openai@^6.34.0 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
+				"hash": "3c1f53f0afe3"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 299,
+				"line": 303,
 				"message": "zod-to-json-schema@3.23.3 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
 				"hash": "081b5d0b5ca5"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 296,
+				"line": 300,
 				"message": "tmp-promise appears in 4 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "88d67e2ef747"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 254,
+				"line": 258,
 				"message": "@mozilla/readability appears in 5 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "69d6fa7e46f9"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 270,
+				"line": 274,
 				"message": "cheerio appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "8cd029bb871e"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 280,
+				"line": 284,
 				"message": "jsdom appears in 4 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "26f20ebea4b1"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 286,
+				"line": 290,
 				"message": "mongodb appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "46cb48884e22"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 290,
+				"line": 294,
 				"message": "pdf-parse appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "0c7d44a9c2e4"
+			}
+		],
+		"packages/@n8n/tournament/package.json": [
+			{
+				"rule": "catalog-violations",
+				"line": 44,
+				"message": "@types/node@^18.13.0 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
+				"hash": "6368b5d3b924"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 52,
+				"message": "typescript@^5.0.0 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
+				"hash": "f668021a144e"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 55,
+				"message": "ast-types appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "27edcbb2b4f8"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 56,
+				"message": "esprima-next appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "75058f9a4d30"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 57,
+				"message": "recast appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "5f2b50fef19d"
 			}
 		],
 		"packages/testing/janitor/package.json": [
 			{
 				"rule": "catalog-violations",
-				"line": 39,
+				"line": 36,
 				"message": "ts-morph@>=20.0.0 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
 				"hash": "4a2907301983"
 			}
@@ -214,7 +288,7 @@
 		"packages/frontend/@n8n/storybook/package.json": [
 			{
 				"rule": "catalog-violations",
-				"line": 31,
+				"line": 32,
 				"message": "@types/node@^24.10.1 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
 				"hash": "50fb70481f8f"
 			}
@@ -234,41 +308,15 @@
 			},
 			{
 				"rule": "catalog-violations",
+				"line": 41,
+				"message": "prettier appears in 10 packages with 3 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "4268f09633aa"
+			},
+			{
+				"rule": "catalog-violations",
 				"line": 46,
 				"message": "n8n-workflow appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "2f772d0b5a09"
-			},
-			{
-				"rule": "catalog-violations",
-				"line": 41,
-				"message": "prettier appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "6ded3ee6fafe"
-			}
-		],
-		"packages/@n8n/node-cli/src/template/templates/declarative/github-issues/template/package.json": [
-			{
-				"rule": "catalog-violations",
-				"line": 43,
-				"message": "eslint@9.32.0 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
-				"hash": "c3815ab2677d"
-			},
-			{
-				"rule": "catalog-violations",
-				"line": 46,
-				"message": "typescript@5.9.2 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
-				"hash": "11608ee90ba9"
-			},
-			{
-				"rule": "catalog-violations",
-				"line": 49,
-				"message": "n8n-workflow appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "4514689aef5c"
-			},
-			{
-				"rule": "catalog-violations",
-				"line": 44,
-				"message": "prettier appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "ce8e04a67c4c"
 			}
 		],
 		"packages/@n8n/node-cli/src/template/templates/programmatic/example/template/package.json": [
@@ -286,15 +334,41 @@
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 46,
-				"message": "n8n-workflow appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "fd2577d9c87b"
+				"line": 41,
+				"message": "prettier appears in 10 packages with 3 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "0c7bd1cbf6cb"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 41,
-				"message": "prettier appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "a931f101c8a0"
+				"line": 46,
+				"message": "n8n-workflow appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "fd2577d9c87b"
+			}
+		],
+		"packages/@n8n/node-cli/src/template/templates/declarative/github-issues/template/package.json": [
+			{
+				"rule": "catalog-violations",
+				"line": 43,
+				"message": "eslint@9.32.0 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
+				"hash": "c3815ab2677d"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 46,
+				"message": "typescript@5.9.2 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
+				"hash": "11608ee90ba9"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 44,
+				"message": "prettier appears in 10 packages with 3 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "70fc7a306272"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 49,
+				"message": "n8n-workflow appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "4514689aef5c"
 			}
 		],
 		"packages/@n8n/node-cli/src/template/templates/programmatic/ai/memory-custom/template/package.json": [
@@ -312,15 +386,15 @@
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 47,
-				"message": "n8n-workflow appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "42aefb6c9989"
+				"line": 42,
+				"message": "prettier appears in 10 packages with 3 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "b7f8b2a358d8"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 42,
-				"message": "prettier appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "cf4f2ca88b59"
+				"line": 47,
+				"message": "n8n-workflow appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "42aefb6c9989"
 			}
 		],
 		"packages/@n8n/node-cli/src/template/templates/programmatic/ai/model-ai-custom/template/package.json": [
@@ -338,41 +412,15 @@
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 49,
-				"message": "n8n-workflow appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "e1734c74601d"
-			},
-			{
-				"rule": "catalog-violations",
 				"line": 44,
-				"message": "prettier appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "2a2dea670608"
-			}
-		],
-		"packages/@n8n/node-cli/src/template/templates/programmatic/ai/model-ai-custom-example/template/package.json": [
-			{
-				"rule": "catalog-violations",
-				"line": 43,
-				"message": "eslint@9.32.0 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
-				"hash": "91ea1dbe7d4e"
-			},
-			{
-				"rule": "catalog-violations",
-				"line": 46,
-				"message": "typescript@5.9.2 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
-				"hash": "72d08eab5625"
+				"message": "prettier appears in 10 packages with 3 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "f10c6c40e67c"
 			},
 			{
 				"rule": "catalog-violations",
 				"line": 49,
 				"message": "n8n-workflow appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "91b58c718e73"
-			},
-			{
-				"rule": "catalog-violations",
-				"line": 44,
-				"message": "prettier appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "83b610ec607a"
+				"hash": "e1734c74601d"
 			}
 		],
 		"packages/@n8n/node-cli/src/template/templates/programmatic/ai/model-openai-compatible/template/package.json": [
@@ -390,51 +438,83 @@
 			},
 			{
 				"rule": "catalog-violations",
+				"line": 44,
+				"message": "prettier appears in 10 packages with 3 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "cd6a1b0be867"
+			},
+			{
+				"rule": "catalog-violations",
 				"line": 49,
 				"message": "n8n-workflow appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "6b5e714159dc"
+			}
+		],
+		"packages/@n8n/node-cli/src/template/templates/programmatic/ai/model-ai-custom-example/template/package.json": [
+			{
+				"rule": "catalog-violations",
+				"line": 43,
+				"message": "eslint@9.32.0 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
+				"hash": "91ea1dbe7d4e"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 46,
+				"message": "typescript@5.9.2 should use \"catalog:\" (exists in pnpm-workspace.yaml)",
+				"hash": "72d08eab5625"
 			},
 			{
 				"rule": "catalog-violations",
 				"line": 44,
-				"message": "prettier appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "ba672d26d64d"
+				"message": "prettier appears in 10 packages with 3 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "030ae6daa9ec"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 49,
+				"message": "n8n-workflow appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "91b58c718e73"
 			}
 		],
 		"packages/cli/package.json": [
 			{
 				"rule": "catalog-violations",
-				"line": 97,
+				"line": 98,
 				"message": "@ai-sdk/anthropic appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "1e3686e1923b"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 132,
+				"line": 139,
 				"message": "@opentelemetry/sdk-trace-node appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "a3dad0b8dc21"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 142,
+				"line": 149,
 				"message": "change-case appears in 5 packages with 3 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "949e802528f7"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 193,
+				"line": 200,
+				"message": "prettier appears in 10 packages with 3 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "dee51c035f89"
+			},
+			{
+				"rule": "catalog-violations",
+				"line": 207,
 				"message": "semver appears in 4 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "5b7e9b03fb10"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 200,
+				"line": 215,
 				"message": "undici appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "91c29775e961"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 203,
+				"line": 218,
 				"message": "ws appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "cd07242e8163"
 			}
@@ -442,37 +522,37 @@
 		"packages/@n8n/instance-ai/package.json": [
 			{
 				"rule": "catalog-violations",
-				"line": 56,
+				"line": 63,
 				"message": "@ai-sdk/anthropic appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "5b2153508e47"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 37,
+				"line": 43,
 				"message": "@mozilla/readability appears in 5 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "8fa6b9a8fc91"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 47,
+				"line": 54,
 				"message": "turndown appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "9a9d97065952"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 59,
+				"line": 69,
 				"message": "@types/turndown appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "12e346c47b39"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 31,
+				"line": 37,
 				"message": "@joplin/turndown-plugin-gfm appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "a3cf1504b5c2"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 46,
+				"line": 53,
 				"message": "pdf-parse appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "283fa9114c03"
 			}
@@ -500,55 +580,55 @@
 		"packages/nodes-base/package.json": [
 			{
 				"rule": "catalog-violations",
-				"line": 908,
+				"line": 910,
 				"message": "change-case appears in 5 packages with 3 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "2d1fab7a5b05"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 958,
+				"line": 960,
 				"message": "semver appears in 4 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "2daf37aa14e4"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 963,
+				"line": 965,
 				"message": "tmp-promise appears in 4 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "3f93c404ae9c"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 897,
+				"line": 899,
 				"message": "@mozilla/readability appears in 5 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "ca4ac788adc6"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 909,
+				"line": 911,
 				"message": "cheerio appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "1a1b5bbc50c9"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 914,
+				"line": 916,
 				"message": "eventsource appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "9795e6c6d9e9"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 927,
+				"line": 929,
 				"message": "jsdom appears in 4 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "02341f2b5e3e"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 938,
+				"line": 940,
 				"message": "mongodb appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "f688907d087a"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 889,
+				"line": 891,
 				"message": "eslint-plugin-n8n-nodes-base appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "ac254baa61f9"
 			}
@@ -562,21 +642,27 @@
 			},
 			{
 				"rule": "catalog-violations",
+				"line": 90,
+				"message": "prettier appears in 10 packages with 3 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "1d2d6bb68778"
+			},
+			{
+				"rule": "catalog-violations",
 				"line": 92,
 				"message": "semver appears in 4 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "d8c606e42c92"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 90,
-				"message": "prettier appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
-				"hash": "8a66e00b94fa"
+				"line": 77,
+				"message": "esprima-next appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
+				"hash": "62156c2613b2"
 			}
 		],
 		"packages/@n8n/scan-community-package/package.json": [
 			{
 				"rule": "catalog-violations",
-				"line": 15,
+				"line": 23,
 				"message": "semver appears in 4 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "ac0e4301d694"
 			}
@@ -584,19 +670,19 @@
 		"packages/@n8n/ai-utilities/package.json": [
 			{
 				"rule": "catalog-violations",
-				"line": 57,
+				"line": 69,
 				"message": "undici appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "c14cd05614e8"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 53,
+				"line": 65,
 				"message": "tmp-promise appears in 4 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "884a45bdbcf2"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 60,
+				"line": 72,
 				"message": "n8n-workflow appears in 9 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "717de3a58c50"
 			}
@@ -604,37 +690,37 @@
 		"packages/@n8n/mcp-browser/package.json": [
 			{
 				"rule": "catalog-violations",
-				"line": 37,
+				"line": 36,
 				"message": "ws appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "9650c1b55f3c"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 31,
+				"line": 28,
 				"message": "@mozilla/readability appears in 5 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "0c97891a24f4"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 32,
+				"line": 30,
 				"message": "jsdom appears in 4 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "8466b03b1044"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 36,
+				"line": 35,
 				"message": "turndown appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "f23a9d3d7aa2"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 44,
+				"line": 42,
 				"message": "@types/turndown appears in 3 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "3f9e46e56803"
 			},
 			{
 				"rule": "catalog-violations",
-				"line": 29,
+				"line": 26,
 				"message": "@joplin/turndown-plugin-gfm appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "743e3a7dbb32"
 			}
@@ -658,7 +744,7 @@
 		"packages/@n8n/computer-use/package.json": [
 			{
 				"rule": "catalog-violations",
-				"line": 44,
+				"line": 46,
 				"message": "eventsource appears in 2 packages with 2 different versions — add to pnpm-workspace.yaml catalog",
 				"hash": "f50c1eee2ed6"
 			}

--- a/.github/workflows/ci-pr-quality.yml
+++ b/.github/workflows/ci-pr-quality.yml
@@ -103,7 +103,7 @@ jobs:
 
   changes:
     name: Detect Changes
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
@@ -132,7 +132,10 @@ jobs:
   check-static-analysis:
     name: Static Analysis
     needs: changes
-    if: needs.changes.outputs.code-health == 'true' || needs.changes.outputs.janitor == 'true'
+    if: |
+      github.event_name == 'merge_group' ||
+      needs.changes.outputs.code-health == 'true' ||
+      needs.changes.outputs.janitor == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -146,11 +149,11 @@ jobs:
           build-command: pnpm turbo run build --filter=@n8n/code-health --filter=@n8n/playwright-janitor
 
       - name: Run code-health
-        if: needs.changes.outputs.code-health == 'true'
-        run: pnpm --filter=@n8n/code-health exec tsx src/cli.ts
+        if: github.event_name == 'merge_group' || needs.changes.outputs.code-health == 'true'
+        run: pnpm --filter=@n8n/code-health check
 
       - name: Run janitor
-        if: needs.changes.outputs.janitor == 'true' && !cancelled()
+        if: ${{ !cancelled() && (github.event_name == 'merge_group' || needs.changes.outputs.janitor == 'true') }}
         run: pnpm --filter=n8n-playwright janitor
 
   required-pr-quality-checks:

--- a/.github/workflows/ci-pr-quality.yml
+++ b/.github/workflows/ci-pr-quality.yml
@@ -129,10 +129,10 @@ jobs:
               .code-health-baseline.json
               packages/testing/code-health/**
 
-  check-code-health:
-    name: Code Health
+  check-static-analysis:
+    name: Static Analysis
     needs: changes
-    if: needs.changes.outputs.code-health == 'true'
+    if: needs.changes.outputs.code-health == 'true' || needs.changes.outputs.janitor == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -143,33 +143,19 @@ jobs:
       - name: Setup Node.js
         uses: ./.github/actions/setup-nodejs
         with:
-          build-command: pnpm turbo run build --filter=@n8n/code-health
+          build-command: pnpm turbo run build --filter=@n8n/code-health --filter=@n8n/playwright-janitor
 
       - name: Run code-health
+        if: needs.changes.outputs.code-health == 'true'
         run: pnpm --filter=@n8n/code-health exec tsx src/cli.ts
 
-  check-janitor:
-    name: Janitor
-    needs: changes
-    if: needs.changes.outputs.janitor == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Setup Node.js
-        uses: ./.github/actions/setup-nodejs
-        with:
-          build-command: pnpm turbo run build --filter=@n8n/playwright-janitor
-
       - name: Run janitor
+        if: needs.changes.outputs.janitor == 'true' && !cancelled()
         run: pnpm --filter=n8n-playwright janitor
 
   required-pr-quality-checks:
     name: Required PR Quality Checks
-    needs: [check-ownership-checkbox, check-pr-size, check-code-health, check-janitor]
+    needs: [check-ownership-checkbox, check-pr-size, check-static-analysis]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/ci-pr-quality.yml
+++ b/.github/workflows/ci-pr-quality.yml
@@ -101,9 +101,75 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: node .github/scripts/quality/check-pr-size.mjs
 
+  changes:
+    name: Detect Changes
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      janitor: ${{ fromJSON(steps.filter.outputs.results).janitor == true }}
+      code-health: ${{ fromJSON(steps.filter.outputs.results)['code-health'] == true }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Detect changed paths
+        id: filter
+        uses: ./.github/actions/ci-filter
+        with:
+          mode: filter
+          filters: |
+            janitor:
+              packages/testing/playwright/**
+              packages/testing/janitor/**
+            code-health:
+              **/package.json
+              pnpm-workspace.yaml
+              .code-health-baseline.json
+              packages/testing/code-health/**
+
+  check-code-health:
+    name: Code Health
+    needs: changes
+    if: needs.changes.outputs.code-health == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-nodejs
+        with:
+          build-command: ''
+
+      - name: Run code-health
+        run: pnpm --filter=@n8n/code-health exec tsx src/cli.ts
+
+  check-janitor:
+    name: Janitor
+    needs: changes
+    if: needs.changes.outputs.janitor == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js
+        uses: ./.github/actions/setup-nodejs
+        with:
+          build-command: ''
+
+      - name: Run janitor
+        run: pnpm --filter=n8n-playwright janitor
+
   required-pr-quality-checks:
     name: Required PR Quality Checks
-    needs: [check-ownership-checkbox, check-pr-size]
+    needs: [check-ownership-checkbox, check-pr-size, check-code-health, check-janitor]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/ci-pr-quality.yml
+++ b/.github/workflows/ci-pr-quality.yml
@@ -143,7 +143,7 @@ jobs:
       - name: Setup Node.js
         uses: ./.github/actions/setup-nodejs
         with:
-          build-command: ''
+          build-command: pnpm turbo run build --filter=@n8n/code-health
 
       - name: Run code-health
         run: pnpm --filter=@n8n/code-health exec tsx src/cli.ts
@@ -162,7 +162,7 @@ jobs:
       - name: Setup Node.js
         uses: ./.github/actions/setup-nodejs
         with:
-          build-command: ''
+          build-command: pnpm turbo run build --filter=@n8n/playwright-janitor
 
       - name: Run janitor
         run: pnpm --filter=n8n-playwright janitor

--- a/packages/testing/code-health/package.json
+++ b/packages/testing/code-health/package.json
@@ -12,6 +12,7 @@
 		"dist"
 	],
 	"scripts": {
+		"check": "tsx src/cli.ts",
 		"build": "tsc -p tsconfig.build.json",
 		"dev": "tsc --watch",
 		"test": "vitest run",

--- a/packages/testing/playwright/.janitor-baseline.json
+++ b/packages/testing/playwright/.janitor-baseline.json
@@ -1,7 +1,7 @@
 {
 	"version": 1,
-	"generated": "2026-04-08T13:49:08.611Z",
-	"totalViolations": 405,
+	"generated": "2026-05-08T11:30:02.651Z",
+	"totalViolations": 445,
 	"violations": {
 		"pages/AIAssistantPage.ts": [
 			{
@@ -41,20 +41,168 @@
 				"hash": "0d4d5092768f"
 			}
 		],
-		"pages/AIBuilderPage.ts": [
+		"pages/InstanceAiPage.ts": [
 			{
 				"rule": "scope-lockdown",
-				"line": 8,
-				"message": "AIBuilderPage: Ambiguous page - add a container (for scoped components) or a navigation method (for top-level pages)",
-				"hash": "37ad1e349434"
-			}
-		],
-		"pages/InteractionsPage.ts": [
+				"line": 19,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
 			{
 				"rule": "scope-lockdown",
-				"line": 6,
-				"message": "InteractionsPage: Ambiguous page - add a container (for scoped components) or a navigation method (for top-level pages)",
-				"hash": "02f0790cba2a"
+				"line": 45,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 49,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 53,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 57,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 61,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 69,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 73,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 78,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 82,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 88,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 92,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 96,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 100,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 104,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 110,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 129,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 147,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 151,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 181,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 197,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 201,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 222,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 228,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 228,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "deduplication",
+				"line": 129,
+				"message": "Duplicate locator: this.page.getByTestId(\"workflow-preview-iframe\") in pages scope",
+				"hash": "d333305f8c67"
+			},
+			{
+				"rule": "deduplication",
+				"line": 151,
+				"message": "Duplicate locator: this.page.getByTestId(\"workflow-preview-iframe\") in pages scope",
+				"hash": "d333305f8c67"
 			}
 		],
 		"pages/NodeDetailsViewPage.ts": [
@@ -84,7 +232,13 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 274,
+				"line": 270,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "4087a9cf20cb"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 319,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
@@ -102,7 +256,7 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 331,
+				"line": 347,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
@@ -132,25 +286,31 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 367,
+				"line": 369,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 373,
+				"line": 395,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 399,
+				"line": 431,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 435,
+				"line": 459,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "4087a9cf20cb"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 463,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
@@ -168,19 +328,13 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 467,
-				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "4087a9cf20cb"
-			},
-			{
-				"rule": "scope-lockdown",
 				"line": 471,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 475,
+				"line": 489,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
@@ -192,43 +346,49 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 497,
+				"line": 493,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 497,
+				"line": 504,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 508,
+				"line": 513,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 517,
+				"line": 575,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 579,
+				"line": 620,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 624,
+				"line": 626,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 630,
+				"line": 650,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "4087a9cf20cb"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 650,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
@@ -240,25 +400,19 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 654,
+				"line": 761,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 658,
+				"line": 806,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 765,
-				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "4087a9cf20cb"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 810,
+				"line": 860,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
@@ -270,137 +424,69 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 868,
+				"line": 873,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 877,
+				"line": 879,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 883,
-				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "4087a9cf20cb"
-			},
-			{
-				"rule": "dead-code",
-				"line": 942,
-				"message": "Unused method: NodeDetailsViewPage.getAddOptionDropdown()",
-				"hash": "a3acba0a44bc"
-			}
-		],
-		"pages/NotificationsPage.ts": [
-			{
-				"rule": "scope-lockdown",
-				"line": 3,
-				"message": "NotificationsPage: Ambiguous page - add a container (for scoped components) or a navigation method (for top-level pages)",
-				"hash": "de71d54deec0"
 			}
 		],
 		"pages/SidebarPage.ts": [
 			{
 				"rule": "scope-lockdown",
-				"line": 31,
+				"line": 23,
 				"message": "SidebarPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "b15fa9cfe2ac"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 35,
+				"line": 43,
 				"message": "SidebarPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "b15fa9cfe2ac"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 39,
+				"line": 47,
 				"message": "SidebarPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "b15fa9cfe2ac"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 44,
+				"line": 98,
 				"message": "SidebarPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "b15fa9cfe2ac"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 44,
+				"line": 102,
 				"message": "SidebarPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "b15fa9cfe2ac"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 45,
+				"line": 115,
 				"message": "SidebarPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "b15fa9cfe2ac"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 45,
+				"line": 123,
 				"message": "SidebarPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "b15fa9cfe2ac"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 50,
+				"line": 131,
 				"message": "SidebarPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "b15fa9cfe2ac"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 50,
-				"message": "SidebarPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "b15fa9cfe2ac"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 51,
-				"message": "SidebarPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "b15fa9cfe2ac"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 51,
-				"message": "SidebarPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "b15fa9cfe2ac"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 68,
-				"message": "SidebarPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "b15fa9cfe2ac"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 72,
-				"message": "SidebarPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "b15fa9cfe2ac"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 85,
-				"message": "SidebarPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "b15fa9cfe2ac"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 93,
-				"message": "SidebarPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "b15fa9cfe2ac"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 101,
-				"message": "SidebarPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "b15fa9cfe2ac"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 109,
+				"line": 139,
 				"message": "SidebarPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "b15fa9cfe2ac"
 			}
@@ -499,36 +585,28 @@
 				"hash": "0de6cf556dcf"
 			}
 		],
-		"pages/nodes/EditFieldsNode.ts": [
-			{
-				"rule": "scope-lockdown",
-				"line": 5,
-				"message": "EditFieldsNode: Ambiguous page - add a container (for scoped components) or a navigation method (for top-level pages)",
-				"hash": "7db586b8b01c"
-			}
-		],
 		"composables/WorkflowComposer.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 155,
+				"line": 137,
 				"message": "Direct page locator call: this.n8n.page.getByTestId('move-to-folder-option').getByT...",
 				"hash": "976ff11703b6"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 155,
+				"line": 137,
 				"message": "Direct page locator call: this.n8n.page.getByTestId('move-to-folder-option')",
 				"hash": "abb175fbdb8c"
 			},
 			{
 				"rule": "no-page-in-flow",
-				"line": 21,
+				"line": 20,
 				"message": "Direct page access in composable: this.n8n.page.waitForResponse",
 				"hash": "652001b1476b"
 			},
 			{
 				"rule": "no-page-in-flow",
-				"line": 155,
+				"line": 137,
 				"message": "Direct page access in composable: this.n8n.page.getByTestId",
 				"hash": "8fce14c01c57"
 			}
@@ -813,46 +891,60 @@
 				"hash": "840a1c453e83"
 			}
 		],
+		"tests/e2e/instance-ai/instance-ai-workflow-setup-actions.spec.ts": [
+			{
+				"rule": "selector-purity",
+				"line": 158,
+				"message": "Direct page locator call: n8n.page.getByTestId('instance-ai-workflow-setup-applying')",
+				"hash": "7f6477b17241"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 235,
+				"message": "Direct page locator call: n8n.page.getByTestId('instance-ai-workflow-setup-applying')",
+				"hash": "7f6477b17241"
+			}
+		],
 		"tests/e2e/node-creator/categories.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 25,
+				"line": 27,
 				"message": "Chained locator call in test: n8n.canvas.nodeCreator.getCategoryItem('Triggers').locato...",
 				"hash": "606eea72385e"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 28,
+				"line": 30,
 				"message": "Chained locator call in test: n8n.canvas.nodeCreator.getCategoryItem('Actions').locator...",
 				"hash": "c101ff91c020"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 34,
+				"line": 36,
 				"message": "Chained locator call in test: n8n.canvas.nodeCreator.getCategoryItem('Actions').locator...",
 				"hash": "c101ff91c020"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 49,
+				"line": 51,
 				"message": "Chained locator call in test: n8n.canvas.nodeCreator.getCategoryItem('Actions').locator...",
 				"hash": "c101ff91c020"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 55,
+				"line": 57,
 				"message": "Chained locator call in test: n8n.canvas.nodeCreator.getCategoryItem('Actions').locator...",
 				"hash": "c101ff91c020"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 61,
+				"line": 63,
 				"message": "Chained locator call in test: n8n.canvas.nodeCreator.getCategoryItem('Triggers').locato...",
 				"hash": "606eea72385e"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 66,
+				"line": 68,
 				"message": "Chained locator call in test: n8n.canvas.nodeCreator.getCategoryItem('Triggers').locato...",
 				"hash": "606eea72385e"
 			}
@@ -1106,7 +1198,7 @@
 			},
 			{
 				"rule": "selector-purity",
-				"line": 211,
+				"line": 263,
 				"message": "Direct page locator call: n8n.page.getByText('Project Persisted Project Name saved ...",
 				"hash": "9d14d3ddd7f7"
 			}
@@ -1953,6 +2045,32 @@
 				"hash": "0eb6824192ab"
 			}
 		],
+		"tests/e2e/workflows/editor/workflow-actions/archive.spec.ts": [
+			{
+				"rule": "selector-purity",
+				"line": 55,
+				"message": "Direct page locator call: n8n.page.getByTestId('node-creator-plus-button')",
+				"hash": "2b61afc80039"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 66,
+				"message": "Direct page locator call: n8n.page.getByTestId('execute-node-button')",
+				"hash": "af9330ed3874"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 67,
+				"message": "Direct page locator call: n8n.page.getByTestId('delete-node-button')",
+				"hash": "01554562f936"
+			},
+			{
+				"rule": "selector-purity",
+				"line": 68,
+				"message": "Direct page locator call: n8n.page.getByTestId('disable-node-button')",
+				"hash": "4f683821335f"
+			}
+		],
 		"tests/e2e/workflows/editor/workflow-actions/settings.spec.ts": [
 			{
 				"rule": "selector-purity",
@@ -2114,99 +2232,87 @@
 		"tests/e2e/workflows/executions/list.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 52,
+				"line": 51,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Success' }).click()",
 				"hash": "b6e254523b81"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 52,
+				"line": 51,
 				"message": "Direct page locator call: n8n.page.getByRole('option', { name: 'Success' })",
 				"hash": "553272ee7950"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 197,
+				"line": 196,
 				"message": "Chained locator call in test: iframe.locator('body')",
 				"hash": "6b73753fc26c"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 238,
+				"line": 237,
 				"message": "Chained locator call in test: iframe.locator('body')",
 				"hash": "6b73753fc26c"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 241,
+				"line": 240,
 				"message": "Chained locator call in test: iframe.locator('body')",
 				"hash": "6b73753fc26c"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 244,
+				"line": 243,
 				"message": "Chained locator call in test: iframe.locator('body')",
 				"hash": "6b73753fc26c"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 247,
+				"line": 246,
 				"message": "Chained locator call in test: iframe.locator('body')",
 				"hash": "6b73753fc26c"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 250,
+				"line": 249,
 				"message": "Chained locator call in test: iframe.locator('body')",
 				"hash": "6b73753fc26c"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 253,
+				"line": 252,
 				"message": "Chained locator call in test: iframe.locator('body')",
 				"hash": "6b73753fc26c"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 256,
+				"line": 255,
 				"message": "Chained locator call in test: iframe.locator('body')",
 				"hash": "6b73753fc26c"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 323,
+				"line": 325,
 				"message": "Direct page locator call: n8n.page.getByTestId('workflow-execution-no-trigger-conte...",
 				"hash": "9f1081df0a8a"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 325,
+				"line": 327,
 				"message": "Direct page locator call: n8n.page.getByRole('button', { name: 'Add first step' })....",
 				"hash": "3b12669e6a7f"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 325,
+				"line": 327,
 				"message": "Direct page locator call: n8n.page.getByRole('button', { name: 'Add first step' })",
 				"hash": "ff575079b421"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 331,
+				"line": 333,
 				"message": "Direct page locator call: n8n.page.getByTestId('workflow-execution-no-content')",
 				"hash": "10cc160abd6b"
-			},
-			{
-				"rule": "api-purity",
-				"line": 273,
-				"message": "Raw API call detected: request.post(",
-				"hash": "307c2b28449d"
-			},
-			{
-				"rule": "api-purity",
-				"line": 289,
-				"message": "Raw API call detected: request.get(",
-				"hash": "f27339291410"
 			}
 		],
 		"composables/BuilderWizardComposer.ts": [
@@ -2327,6 +2433,98 @@
 				"hash": "a4b289961490"
 			}
 		],
+		"tests/e2e/auth/token-exchange.spec.ts": [
+			{
+				"rule": "api-purity",
+				"line": 48,
+				"message": "Raw API call detected: request.post(",
+				"hash": "b424b14bc8c1"
+			},
+			{
+				"rule": "api-purity",
+				"line": 69,
+				"message": "Raw API call detected: request.get(",
+				"hash": "17c4932db849"
+			},
+			{
+				"rule": "api-purity",
+				"line": 87,
+				"message": "Raw API call detected: request.post(",
+				"hash": "b424b14bc8c1"
+			},
+			{
+				"rule": "api-purity",
+				"line": 98,
+				"message": "Raw API call detected: request.get(",
+				"hash": "17c4932db849"
+			},
+			{
+				"rule": "api-purity",
+				"line": 121,
+				"message": "Raw API call detected: request.post(",
+				"hash": "b424b14bc8c1"
+			},
+			{
+				"rule": "api-purity",
+				"line": 133,
+				"message": "Raw API call detected: request.post(",
+				"hash": "b424b14bc8c1"
+			},
+			{
+				"rule": "api-purity",
+				"line": 168,
+				"message": "Raw API call detected: request.post(",
+				"hash": "b424b14bc8c1"
+			},
+			{
+				"rule": "api-purity",
+				"line": 183,
+				"message": "Raw API call detected: request.get(",
+				"hash": "17c4932db849"
+			},
+			{
+				"rule": "api-purity",
+				"line": 208,
+				"message": "Raw API call detected: request.post(",
+				"hash": "b424b14bc8c1"
+			},
+			{
+				"rule": "api-purity",
+				"line": 223,
+				"message": "Raw API call detected: request.post(",
+				"hash": "b424b14bc8c1"
+			},
+			{
+				"rule": "api-purity",
+				"line": 238,
+				"message": "Raw API call detected: request.post(",
+				"hash": "b424b14bc8c1"
+			},
+			{
+				"rule": "api-purity",
+				"line": 256,
+				"message": "Raw API call detected: request.post(",
+				"hash": "b424b14bc8c1"
+			},
+			{
+				"rule": "api-purity",
+				"line": 273,
+				"message": "Raw API call detected: request.get(",
+				"hash": "17c4932db849"
+			},
+			{
+				"rule": "api-purity",
+				"line": 285,
+				"message": "Raw API call detected: request.get(",
+				"hash": "17c4932db849"
+			},
+			{
+				"rule": "api-purity",
+				"line": 302,
+				"message": "Raw API call detected: request.post(",
+				"hash": "b424b14bc8c1"
+			}
+		],
 		"tests/e2e/building-blocks/workflow-entry-points.spec.ts": [
 			{
 				"rule": "api-purity",
@@ -2406,7 +2604,7 @@
 		"tests/e2e/workflows/editor/execution/logs.spec.ts": [
 			{
 				"rule": "api-purity",
-				"line": 275,
+				"line": 270,
 				"message": "Raw API call detected: request.get(",
 				"hash": "3783a2d87c82"
 			}
@@ -2437,12 +2635,24 @@
 				"hash": "0acea681877b"
 			}
 		],
-		"pages/CanvasPage.ts": [
+		"utils/benchmark/instance-ai-driver.ts": [
 			{
-				"rule": "deduplication",
-				"line": 79,
-				"message": "Duplicate locator: this.page.getByTestId(\"canvas-choice-prompt\") in pages scope",
-				"hash": "677879f95f57"
+				"rule": "dead-code",
+				"line": 263,
+				"message": "Unused method: InstanceAiDriver.deleteAllThreads()",
+				"hash": "84fa4accc8fa"
+			},
+			{
+				"rule": "dead-code",
+				"line": 302,
+				"message": "Unused method: InstanceAiDriver.measureHeap()",
+				"hash": "40ed597f87ba"
+			},
+			{
+				"rule": "dead-code",
+				"line": 307,
+				"message": "Unused method: InstanceAiDriver.snapshot()",
+				"hash": "70bd4d633512"
 			}
 		],
 		"pages/ChatHubSettingsPage.ts": [
@@ -2488,25 +2698,25 @@
 		"pages/WorkflowsPage.ts": [
 			{
 				"rule": "deduplication",
-				"line": 36,
+				"line": 40,
 				"message": "Duplicate locator: this.page.getByTestId(\"resources-list-search\") in pages scope",
 				"hash": "ec6324dc7eb8"
 			},
 			{
 				"rule": "deduplication",
-				"line": 117,
+				"line": 121,
 				"message": "Duplicate locator: this.page.getByTestId(\"action-toggle-dropdown\") in pages scope",
 				"hash": "0bcc0c5c11f6"
 			},
 			{
 				"rule": "deduplication",
-				"line": 32,
+				"line": 36,
 				"message": "Duplicate locator: this.page.getByTestId(\"project-name\") in pages scope",
 				"hash": "206b89bd1594"
 			},
 			{
 				"rule": "deduplication",
-				"line": 46,
+				"line": 50,
 				"message": "Duplicate locator: this.page.getByTestId(\"action-delete\") in pages scope",
 				"hash": "2f37cf533810"
 			}
@@ -2533,6 +2743,14 @@
 				"line": 36,
 				"message": "Duplicate method logic: VariableModal.close() has identical structure to pages/components/CredentialModal.ts:CredentialModal.close()",
 				"hash": "0da4699677e2"
+			}
+		],
+		"tests/e2e/instance-ai/instance-ai-timeline.spec.ts": [
+			{
+				"rule": "duplicate-logic",
+				"line": 11,
+				"message": "Duplicate test logic: \"should show artifact cards after workflow build completes\" has identical structure to tests/e2e/instance-ai/instance-ai-artifacts.spec.ts:\"should display artifact card in timeline after workflow build\"",
+				"hash": "da9226aef0eb"
 			}
 		],
 		"tests/infrastructure/benchmarks/kafka/load-30n-10kb-steady-300.spec.ts": [
@@ -2597,6 +2815,38 @@
 				"line": 17,
 				"message": "Duplicate test logic: \"sync: 10 nodes, 10KB payload, 10KB output/node, 50 connections, 60s\" has identical structure to tests/infrastructure/benchmarks/webhook/throughput-async.spec.ts:\"async: 10 nodes, 10KB payload, 10KB output/node, 50 connections, 60s\"",
 				"hash": "6481e87468af"
+			}
+		],
+		"tests/infrastructure/benchmarks-local/instance-ai/thread-churn-delegation.spec.ts": [
+			{
+				"rule": "duplicate-logic",
+				"line": 24,
+				"message": "Duplicate test logic: \"heap returns to baseline after delegation rounds\" has identical structure to tests/infrastructure/benchmarks-local/instance-ai/thread-churn-datatables.spec.ts:\"heap returns to baseline after data table create/delete rounds\"",
+				"hash": "08c6be48273d"
+			}
+		],
+		"tests/infrastructure/benchmarks-local/instance-ai/thread-churn.spec.ts": [
+			{
+				"rule": "duplicate-logic",
+				"line": 17,
+				"message": "Duplicate test logic: \"heap returns to baseline after parallel build rounds\" has identical structure to tests/infrastructure/benchmarks-local/instance-ai/thread-churn-datatables.spec.ts:\"heap returns to baseline after data table create/delete rounds\"",
+				"hash": "3ac5475c5814"
+			}
+		],
+		"tests/infrastructure/benchmarks-local/instance-ai/cancel-abort.spec.ts": [
+			{
+				"rule": "no-direct-page-instantiation",
+				"line": 38,
+				"message": "Direct page instantiation: new InstanceAiPage(page)",
+				"hash": "4464b47c5e2c"
+			}
+		],
+		"tests/infrastructure/benchmarks-local/instance-ai/sse-reconnection.spec.ts": [
+			{
+				"rule": "no-direct-page-instantiation",
+				"line": 44,
+				"message": "Direct page instantiation: new InstanceAiPage(threadPage)",
+				"hash": "99e5606866b2"
 			}
 		]
 	}

--- a/packages/testing/playwright/.janitor-baseline.json
+++ b/packages/testing/playwright/.janitor-baseline.json
@@ -1,6 +1,6 @@
 {
 	"version": 1,
-	"generated": "2026-05-08T11:30:02.651Z",
+	"generated": "2026-05-08T12:51:58.412Z",
 	"totalViolations": 445,
 	"violations": {
 		"pages/AIAssistantPage.ts": [
@@ -104,31 +104,19 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 88,
+				"line": 98,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 92,
+				"line": 102,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 96,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 100,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 104,
+				"line": 106,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
@@ -140,67 +128,79 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 129,
+				"line": 114,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 147,
+				"line": 120,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 151,
+				"line": 139,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 181,
+				"line": 157,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 197,
+				"line": 161,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 201,
+				"line": 191,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 222,
+				"line": 207,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 228,
+				"line": 211,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 228,
+				"line": 232,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 238,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 238,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
 			{
 				"rule": "deduplication",
-				"line": 129,
+				"line": 139,
 				"message": "Duplicate locator: this.page.getByTestId(\"workflow-preview-iframe\") in pages scope",
 				"hash": "d333305f8c67"
 			},
 			{
 				"rule": "deduplication",
-				"line": 151,
+				"line": 161,
 				"message": "Duplicate locator: this.page.getByTestId(\"workflow-preview-iframe\") in pages scope",
 				"hash": "d333305f8c67"
 			}

--- a/packages/testing/playwright/.janitor-baseline.json
+++ b/packages/testing/playwright/.janitor-baseline.json
@@ -1,7 +1,7 @@
 {
 	"version": 1,
-	"generated": "2026-05-11T13:19:16.191Z",
-	"totalViolations": 443,
+	"generated": "2026-05-12T08:06:17.170Z",
+	"totalViolations": 416,
 	"violations": {
 		"pages/AIAssistantPage.ts": [
 			{
@@ -44,165 +44,15 @@
 		"pages/InstanceAiPage.ts": [
 			{
 				"rule": "scope-lockdown",
-				"line": 23,
+				"line": 85,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 49,
+				"line": 130,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 53,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 57,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 61,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 65,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 73,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 77,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 82,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 86,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 102,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 106,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 110,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 114,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 118,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 124,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 143,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 161,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 165,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 195,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 211,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 215,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 236,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 242,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 242,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "deduplication",
-				"line": 143,
-				"message": "Duplicate locator: this.page.getByTestId(\"workflow-preview-iframe\") in pages scope",
-				"hash": "d333305f8c67"
-			},
-			{
-				"rule": "deduplication",
-				"line": 165,
-				"message": "Duplicate locator: this.page.getByTestId(\"workflow-preview-iframe\") in pages scope",
-				"hash": "d333305f8c67"
 			}
 		],
 		"pages/NodeDetailsViewPage.ts": [
@@ -889,20 +739,6 @@
 				"line": 146,
 				"message": "Chained locator call in test: n8n.credentials.cards .getCredential('Global HTTP Header ...",
 				"hash": "840a1c453e83"
-			}
-		],
-		"tests/e2e/instance-ai/instance-ai-workflow-setup-actions.spec.ts": [
-			{
-				"rule": "selector-purity",
-				"line": 158,
-				"message": "Direct page locator call: n8n.page.getByTestId('instance-ai-workflow-setup-applying')",
-				"hash": "7f6477b17241"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 235,
-				"message": "Direct page locator call: n8n.page.getByTestId('instance-ai-workflow-setup-applying')",
-				"hash": "7f6477b17241"
 			}
 		],
 		"tests/e2e/node-creator/categories.spec.ts": [

--- a/packages/testing/playwright/.janitor-baseline.json
+++ b/packages/testing/playwright/.janitor-baseline.json
@@ -1,7 +1,7 @@
 {
 	"version": 1,
-	"generated": "2026-05-08T12:51:58.412Z",
-	"totalViolations": 445,
+	"generated": "2026-05-11T13:19:16.191Z",
+	"totalViolations": 443,
 	"violations": {
 		"pages/AIAssistantPage.ts": [
 			{
@@ -44,13 +44,7 @@
 		"pages/InstanceAiPage.ts": [
 			{
 				"rule": "scope-lockdown",
-				"line": 19,
-				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "713916b2be0f"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 45,
+				"line": 23,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
@@ -80,7 +74,7 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 69,
+				"line": 65,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
@@ -92,7 +86,7 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 78,
+				"line": 77,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
@@ -104,7 +98,7 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 98,
+				"line": 86,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
@@ -134,19 +128,19 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 120,
+				"line": 118,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 139,
+				"line": 124,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 157,
+				"line": 143,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
@@ -158,13 +152,13 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 191,
+				"line": 165,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 207,
+				"line": 195,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
@@ -176,42 +170,42 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 232,
+				"line": 215,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 238,
+				"line": 236,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 238,
+				"line": 242,
+				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "713916b2be0f"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 242,
 				"message": "InstanceAiPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "713916b2be0f"
 			},
 			{
 				"rule": "deduplication",
-				"line": 139,
+				"line": 143,
 				"message": "Duplicate locator: this.page.getByTestId(\"workflow-preview-iframe\") in pages scope",
 				"hash": "d333305f8c67"
 			},
 			{
 				"rule": "deduplication",
-				"line": 161,
+				"line": 165,
 				"message": "Duplicate locator: this.page.getByTestId(\"workflow-preview-iframe\") in pages scope",
 				"hash": "d333305f8c67"
 			}
 		],
 		"pages/NodeDetailsViewPage.ts": [
-			{
-				"rule": "scope-lockdown",
-				"line": 34,
-				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "4087a9cf20cb"
-			},
 			{
 				"rule": "scope-lockdown",
 				"line": 38,
@@ -226,19 +220,19 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 114,
+				"line": 46,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 270,
+				"line": 118,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 319,
+				"line": 274,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
@@ -256,7 +250,7 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 347,
+				"line": 331,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
@@ -286,31 +280,25 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 369,
+				"line": 367,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 395,
+				"line": 373,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 431,
+				"line": 399,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 459,
-				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "4087a9cf20cb"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 463,
+				"line": 435,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
@@ -328,13 +316,19 @@
 			},
 			{
 				"rule": "scope-lockdown",
+				"line": 467,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "4087a9cf20cb"
+			},
+			{
+				"rule": "scope-lockdown",
 				"line": 471,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 489,
+				"line": 475,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
@@ -346,49 +340,43 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 493,
+				"line": 497,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 504,
+				"line": 497,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 513,
+				"line": 508,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 575,
+				"line": 517,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 620,
+				"line": 579,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 626,
+				"line": 624,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 650,
-				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "4087a9cf20cb"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 650,
+				"line": 630,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
@@ -400,19 +388,25 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 761,
+				"line": 654,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 806,
+				"line": 658,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 860,
+				"line": 765,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "4087a9cf20cb"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 810,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
@@ -424,13 +418,19 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 873,
+				"line": 868,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 879,
+				"line": 877,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "4087a9cf20cb"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 883,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			}
@@ -2048,25 +2048,25 @@
 		"tests/e2e/workflows/editor/workflow-actions/archive.spec.ts": [
 			{
 				"rule": "selector-purity",
-				"line": 55,
+				"line": 44,
 				"message": "Direct page locator call: n8n.page.getByTestId('node-creator-plus-button')",
 				"hash": "2b61afc80039"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 66,
+				"line": 55,
 				"message": "Direct page locator call: n8n.page.getByTestId('execute-node-button')",
 				"hash": "af9330ed3874"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 67,
+				"line": 56,
 				"message": "Direct page locator call: n8n.page.getByTestId('delete-node-button')",
 				"hash": "01554562f936"
 			},
 			{
 				"rule": "selector-purity",
-				"line": 68,
+				"line": 57,
 				"message": "Direct page locator call: n8n.page.getByTestId('disable-node-button')",
 				"hash": "4f683821335f"
 			}
@@ -2753,68 +2753,52 @@
 				"hash": "da9226aef0eb"
 			}
 		],
-		"tests/infrastructure/benchmarks/kafka/load-30n-10kb-steady-300.spec.ts": [
-			{
-				"rule": "duplicate-logic",
-				"line": 13,
-				"message": "Duplicate test logic: \"30 nodes, 10KB payload, steady 300 msg/s\" has identical structure to tests/infrastructure/benchmarks/kafka/load-30n-10kb-steady-200.spec.ts:\"30 nodes, 10KB payload, steady 200 msg/s\"",
-				"hash": "b2b06b5bf9cc"
-			}
-		],
-		"tests/infrastructure/benchmarks/kafka/load-30n-10kb-steady.spec.ts": [
-			{
-				"rule": "duplicate-logic",
-				"line": 13,
-				"message": "Duplicate test logic: \"30 nodes, 10KB payload, steady 100 msg/s\" has identical structure to tests/infrastructure/benchmarks/kafka/load-30n-10kb-steady-200.spec.ts:\"30 nodes, 10KB payload, steady 200 msg/s\"",
-				"hash": "523a788d9cb3"
-			}
-		],
-		"tests/infrastructure/benchmarks/kafka/load-60n-1kb-burst.spec.ts": [
-			{
-				"rule": "duplicate-logic",
-				"line": 13,
-				"message": "Duplicate test logic: \"60 nodes, 1KB payload, burst drain 10000 backlog\" has identical structure to tests/infrastructure/benchmarks/kafka/load-30n-10kb-steady-200.spec.ts:\"30 nodes, 10KB payload, steady 200 msg/s\"",
-				"hash": "1fb8c721e201"
-			}
-		],
-		"tests/infrastructure/benchmarks/kafka/throughput-10n-100kb.spec.ts": [
-			{
-				"rule": "duplicate-logic",
-				"line": 19,
-				"message": "Duplicate test logic: \"10 nodes, 1KB payload, 100KB output/node, 5000 msgs\" has identical structure to tests/infrastructure/benchmarks/kafka/load-30n-10kb-steady-200.spec.ts:\"30 nodes, 10KB payload, steady 200 msg/s\"",
-				"hash": "53c1e0072183"
-			}
-		],
-		"tests/infrastructure/benchmarks/kafka/throughput-10n-10kb.spec.ts": [
-			{
-				"rule": "duplicate-logic",
-				"line": 19,
-				"message": "Duplicate test logic: \"10 nodes, 10KB payload, 10KB output/node, 5000 msgs\" has identical structure to tests/infrastructure/benchmarks/kafka/load-30n-10kb-steady-200.spec.ts:\"30 nodes, 10KB payload, steady 200 msg/s\"",
-				"hash": "fdf7b9dd7186"
-			}
-		],
-		"tests/infrastructure/benchmarks/kafka/throughput-30n-10kb.spec.ts": [
-			{
-				"rule": "duplicate-logic",
-				"line": 19,
-				"message": "Duplicate test logic: \"30 nodes, 10KB payload, 10KB output/node, 5000 msgs\" has identical structure to tests/infrastructure/benchmarks/kafka/load-30n-10kb-steady-200.spec.ts:\"30 nodes, 10KB payload, steady 200 msg/s\"",
-				"hash": "3d757209f969"
-			}
-		],
-		"tests/infrastructure/benchmarks/kafka/throughput-60n-10kb.spec.ts": [
-			{
-				"rule": "duplicate-logic",
-				"line": 19,
-				"message": "Duplicate test logic: \"60 nodes, 10KB payload, 10KB output/node, 5000 msgs\" has identical structure to tests/infrastructure/benchmarks/kafka/load-30n-10kb-steady-200.spec.ts:\"30 nodes, 10KB payload, steady 200 msg/s\"",
-				"hash": "28822d0ca517"
-			}
-		],
-		"tests/infrastructure/benchmarks/webhook/throughput-sync.spec.ts": [
+		"tests/infrastructure/benchmarks/kafka/queue-mode-sustained-rate.spec.ts": [
 			{
 				"rule": "duplicate-logic",
 				"line": 17,
-				"message": "Duplicate test logic: \"sync: 10 nodes, 10KB payload, 10KB output/node, 50 connections, 60s\" has identical structure to tests/infrastructure/benchmarks/webhook/throughput-async.spec.ts:\"async: 10 nodes, 10KB payload, 10KB output/node, 50 connections, 60s\"",
-				"hash": "6481e87468af"
+				"message": "Duplicate test logic: \"Kafka trigger + 1 noop, 1KB payload, 250 msg/s × 240s (1 main + 1 worker)\" has identical structure to tests/infrastructure/benchmarks/kafka/burst-drain-capacity.spec.ts:\"Kafka trigger + 1 noop, 1KB payload, drain 100k preloaded backlog (1 main + 1 worker)\"",
+				"hash": "388616eecbaa"
+			}
+		],
+		"tests/infrastructure/benchmarks/kafka/single-instance-ceiling.spec.ts": [
+			{
+				"rule": "duplicate-logic",
+				"line": 17,
+				"message": "Duplicate test logic: \"Kafka trigger + 1 noop, 1KB payload, 150k msgs\" has identical structure to tests/infrastructure/benchmarks/kafka/burst-drain-capacity.spec.ts:\"Kafka trigger + 1 noop, 1KB payload, drain 100k preloaded backlog (1 main + 1 worker)\"",
+				"hash": "1c5033214063"
+			}
+		],
+		"tests/infrastructure/benchmarks/kafka/steady-rate-breaking-point.spec.ts": [
+			{
+				"rule": "duplicate-logic",
+				"line": 34,
+				"message": "Duplicate test logic: \"anonymous\" has identical structure to tests/infrastructure/benchmarks/kafka/burst-drain-capacity.spec.ts:\"Kafka trigger + 1 noop, 1KB payload, drain 100k preloaded backlog (1 main + 1 worker)\"",
+				"hash": "5579d3e330e1"
+			}
+		],
+		"tests/infrastructure/benchmarks/kafka/output-size-impact.spec.ts": [
+			{
+				"rule": "duplicate-logic",
+				"line": 25,
+				"message": "Duplicate test logic: \"anonymous\" has identical structure to tests/infrastructure/benchmarks/kafka/node-count-scaling.spec.ts:\"anonymous\"",
+				"hash": "d676f700b46d"
+			}
+		],
+		"tests/infrastructure/benchmarks/webhook/webhook-otel-overhead.spec.ts": [
+			{
+				"rule": "duplicate-logic",
+				"line": 26,
+				"message": "Duplicate test logic: \"anonymous\" has identical structure to tests/infrastructure/benchmarks/webhook/webhook-main-scaling.spec.ts:\"anonymous\"",
+				"hash": "61c8c9b0f1ff"
+			}
+		],
+		"tests/infrastructure/benchmarks/webhook/webhook-single-instance.spec.ts": [
+			{
+				"rule": "duplicate-logic",
+				"line": 27,
+				"message": "Duplicate test logic: \"anonymous\" has identical structure to tests/infrastructure/benchmarks/webhook/webhook-queue-baseline.spec.ts:\"anonymous\"",
+				"hash": "51d2d4fe3fdb"
 			}
 		],
 		"tests/infrastructure/benchmarks-local/instance-ai/thread-churn-delegation.spec.ts": [


### PR DESCRIPTION
## Summary

- Adds `check-code-health` and `check-janitor` jobs to the PR Quality Checks workflow, both gated by `ci-filter` so they only run when relevant paths change.
- Adds both jobs to `required-pr-quality-checks` so they participate in the merge gate (skipped jobs pass via `ci-filter`'s `validate` mode).
- Runs the tools from source via `tsx`, mirroring the existing `pnpm janitor` script — no extra build step required.

The `@n8n/code-health` package and the playwright janitor already exist with committed baselines (`.code-health-baseline.json` at repo root, `packages/testing/playwright/.janitor-baseline.json`). This PR is purely the CI wiring; no rule logic changes.

### Filter scope

- **Janitor** — runs only when `packages/testing/playwright/**` or `packages/testing/janitor/**` changes.
- **Code-health** — runs when any `package.json`, `pnpm-workspace.yaml`, the baseline, or the code-health package changes (catalog/version-drift rules are monorepo-wide, so the filter is broader).

### Out of scope

- No `/override` escape-hatch comment like `check-pr-size` has — the only escape from new violations is to update the baseline manually.

## Test plan

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
🤖 Generated with [Claude Code](https://claude.com/claude-code)