### PR TITLE
feat(core): Scaffold inbound-secrets module (no-changelog)

### DIFF
--- a/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
+++ b/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
@@ -44,6 +44,7 @@ describe('eligibleModules', () => {
 			'instance-version-history',
 			'encryption-key-manager',
 			'oauth-jwe',
+			'inbound-secrets',
 		]);
 	});
 
@@ -74,6 +75,7 @@ describe('eligibleModules', () => {
 			'instance-version-history',
 			'encryption-key-manager',
 			'oauth-jwe',
+			'inbound-secrets',
 			'instance-ai',
 		]);
 	});

--- a/packages/@n8n/backend-common/src/modules/module-registry.ts
+++ b/packages/@n8n/backend-common/src/modules/module-registry.ts
@@ -55,6 +55,7 @@ export class ModuleRegistry {
 		'instance-version-history',
 		'encryption-key-manager',
 		'oauth-jwe',
+		'inbound-secrets',
 	];
 
 	private readonly activeModules: string[] = [];

--- a/packages/@n8n/backend-common/src/modules/modules.config.ts
+++ b/packages/@n8n/backend-common/src/modules/modules.config.ts
@@ -30,6 +30,7 @@ export const MODULE_NAMES = [
 	'instance-version-history',
 	'encryption-key-manager',
 	'oauth-jwe',
+	'inbound-secrets',
 ] as const;
 
 export type ModuleName = (typeof MODULE_NAMES)[number];

--- a/packages/cli/src/modules/inbound-secrets/__tests__/inbound-secrets.module.test.ts
+++ b/packages/cli/src/modules/inbound-secrets/__tests__/inbound-secrets.module.test.ts
@@ -1,0 +1,27 @@
+import { Container } from '@n8n/di';
+
+import { InboundSecretsModule } from '../inbound-secrets.module';
+
+describe('InboundSecretsModule', () => {
+	let module: InboundSecretsModule;
+
+	beforeEach(() => {
+		Container.reset();
+		module = new InboundSecretsModule();
+	});
+
+	afterEach(() => {
+		delete process.env.N8N_ENV_FEAT_INBOUND_SECRETS;
+	});
+
+	describe('init', () => {
+		it('is a no-op when the feature flag is off', async () => {
+			await expect(module.init()).resolves.toBeUndefined();
+		});
+
+		it('loads without error when the feature flag is on', async () => {
+			process.env.N8N_ENV_FEAT_INBOUND_SECRETS = 'true';
+			await expect(module.init()).resolves.toBeUndefined();
+		});
+	});
+});

--- a/packages/cli/src/modules/inbound-secrets/inbound-secrets.config.ts
+++ b/packages/cli/src/modules/inbound-secrets/inbound-secrets.config.ts
@@ -1,0 +1,4 @@
+import { Config } from '@n8n/config';
+
+@Config
+export class InboundSecretsConfig {}

--- a/packages/cli/src/modules/inbound-secrets/inbound-secrets.module.ts
+++ b/packages/cli/src/modules/inbound-secrets/inbound-secrets.module.ts
@@ -1,0 +1,15 @@
+import type { ModuleInterface } from '@n8n/decorators';
+import { BackendModule } from '@n8n/decorators';
+
+function isFeatureFlagEnabled(): boolean {
+	return process.env.N8N_ENV_FEAT_INBOUND_SECRETS === 'true';
+}
+
+@BackendModule({ name: 'inbound-secrets' })
+export class InboundSecretsModule implements ModuleInterface {
+	async init() {
+		if (!isFeatureFlagEnabled()) return;
+
+		await import('./inbound-secrets.config');
+	}
+}


### PR DESCRIPTION
## Summary

Scaffolds an empty backend module `inbound-secrets` under `packages/cli/src/modules/`. The module is registered with the loader and instantiated on startup, but its `init()` is gated behind `N8N_ENV_FEAT_INBOUND_SECRETS` and currently does nothing beyond importing the (empty) config class. No runtime behavior changes for any user.

This is the first slice of the inbound-secrets initiative, which will progressively introduce stripping of secret-shaped values from inbound trigger payloads, an encrypted artifact slot for the original payload, hook plumbing into the execution lifecycle, and an access API. Doing the scaffolding up front isolates the scope of the follow-up tickets so each one stays small and reviewable.

## How to test manually

Because the gated init body is empty, manual verification is limited to confirming the module is discovered, instantiated, and a no-op:

1. Pull the branch and `pnpm install && pnpm build`.
2. Start n8n with default flags: `pnpm start`. Enable debug logging (`N8N_LOG_LEVEL=debug`) and confirm the line `Initialized module "inbound-secrets"` appears among the other module init logs. No errors.
3. Stop n8n, export `N8N_ENV_FEAT_INBOUND_SECRETS=true`, and start again. Same line, still no errors. (The gated path currently only does `await import('./inbound-secrets.config')`.)
4. Optional: add `inbound-secrets` to `N8N_DISABLED_MODULES` and confirm it is skipped without errors.

Automated coverage:
- `packages/cli/src/modules/inbound-secrets/__tests__/inbound-secrets.module.test.ts` — smoke test exercising both gated (`init` is no-op) and ungated (`init` resolves cleanly) paths.

## Key implementation decisions

- **Feature-flag gated**: matches the in-progress-feature pattern used by `oauth-jwe`, `token-exchange`, and `encryption-key-manager`. Subsequent tickets extend the gated path; the module never accidentally activates before it's ready.
- **Registered in `defaultModules`**: required by AC1 ("module is discovered and instantiated by the module loader on n8n startup"). Visibility on startup ≠ activation — the flag controls whether `init()` does anything.
- **No services/controllers/entities yet**: deliberately deferred. The stripper service, hook registrar, encrypted artifact slot, and access API arrive in follow-up tickets so each lands as an atomic, reviewable change.
- **Empty `@Config` class**: reserves the env-var entrypoint so future flags slot in without restructuring.

## Related Links

closes https://linear.app/n8n/issue/IAM-614

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
