### PR TITLE
fix(core): Propagate waitTill from worker to main in scaling mode

### DIFF
--- a/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/job-processor.service.test.ts
@@ -8,6 +8,7 @@ import { ExternalSecretsProxy } from 'n8n-core';
 import { mockInstance } from 'n8n-core/test/utils';
 import {
 	type IPinData,
+	type IRun,
 	type ITaskData,
 	type IWorkflowExecuteAdditionalData,
 	Workflow,
@@ -919,6 +920,103 @@ describe('JobProcessor', () => {
 				response: unknown;
 			};
 			expect(lastResponse.response).toBe('supply data tool result');
+		});
+	});
+
+	describe('waitTill propagation', () => {
+		it('carries waitTill on JobFinishedProps from the worker run (lightweight path)', () => {
+			const waitTill = new Date(Date.now() + 60_000);
+			const jobProcessor = new JobProcessor(
+				logger,
+				mock<ExecutionRepository>(),
+				mock(),
+				mock(),
+				mock(),
+				mock(),
+				executionsConfig,
+				mock(),
+			);
+			const run = mock<IRun>({
+				status: 'waiting',
+				stoppedAt: new Date(),
+				data: mock<IRunExecutionData>({
+					resultData: { runData: {}, error: undefined },
+					executionData: undefined,
+				}),
+			});
+			// set Date field after construction, else jest-mock-extended serializes them otherwise.
+			run.waitTill = waitTill;
+
+			const props = jobProcessor['deriveJobFinishedProps'](run, new Date());
+
+			expect(props.waitTill).toBe(waitTill);
+			expect(props.status).toBe('waiting');
+		});
+
+		it('carries waitTill on JobFinishedProps from the persisted execution (DB-fetch path)', async () => {
+			const waitTill = new Date(Date.now() + 60_000);
+			const executionRepository = mock<ExecutionRepository>();
+			const persisted = mock<IExecutionResponse>({
+				status: 'waiting',
+				stoppedAt: new Date(),
+				data: mock<IRunExecutionData>({
+					resultData: { runData: {}, error: undefined },
+					executionData: undefined,
+				}),
+			});
+			persisted.waitTill = waitTill;
+			executionRepository.findSingleExecution.mockResolvedValueOnce(persisted);
+			const jobProcessor = new JobProcessor(
+				logger,
+				executionRepository,
+				mock(),
+				mock(),
+				mock(),
+				mock(),
+				executionsConfig,
+				mock(),
+			);
+
+			const props = await jobProcessor['fetchJobFinishedResult']('exec-1');
+
+			expect(props.waitTill).toBe(waitTill);
+			expect(props.status).toBe('waiting');
+		});
+
+		it('defaults waitTill to null on JobFinishedProps when the run is not waiting', async () => {
+			const executionRepository = mock<ExecutionRepository>();
+			const jobProcessor = new JobProcessor(
+				logger,
+				executionRepository,
+				mock(),
+				mock(),
+				mock(),
+				mock(),
+				executionsConfig,
+				mock(),
+			);
+			const run = mock<IRun>({
+				status: 'success',
+				stoppedAt: new Date(),
+				data: mock<IRunExecutionData>({
+					resultData: { runData: {}, error: undefined },
+					executionData: undefined,
+				}),
+			});
+			run.waitTill = undefined;
+			expect(jobProcessor['deriveJobFinishedProps'](run, new Date()).waitTill).toBeNull();
+
+			const persisted = mock<IExecutionResponse>({
+				status: 'success',
+				stoppedAt: new Date(),
+				data: mock<IRunExecutionData>({
+					resultData: { runData: {}, error: undefined },
+					executionData: undefined,
+				}),
+			});
+			persisted.waitTill = null;
+			executionRepository.findSingleExecution.mockResolvedValueOnce(persisted);
+			expect((await jobProcessor['fetchJobFinishedResult']('exec-1')).waitTill).toBeNull();
 		});
 	});
 

--- a/packages/cli/src/scaling/job-processor.ts
+++ b/packages/cli/src/scaling/job-processor.ts
@@ -397,6 +397,7 @@ export class JobProcessor {
 			lastNodeExecuted: run.data.resultData.lastNodeExecuted,
 			usedDynamicCredentials: !!run.data.executionData?.runtimeData?.credentials,
 			metadata: run.data.resultData.metadata,
+			waitTill: run.waitTill ?? null,
 		};
 	}
 
@@ -421,6 +422,7 @@ export class JobProcessor {
 			lastNodeExecuted: execution.data?.resultData?.lastNodeExecuted,
 			usedDynamicCredentials: !!execution.data?.executionData?.runtimeData?.credentials,
 			metadata: execution.data?.resultData?.metadata,
+			waitTill: execution.waitTill ?? null,
 		};
 	}
 

--- a/packages/cli/src/scaling/scaling.types.ts
+++ b/packages/cli/src/scaling/scaling.types.ts
@@ -80,6 +80,7 @@ export type JobFinishedProps = {
 	lastNodeExecuted?: string;
 	usedDynamicCredentials?: boolean;
 	metadata?: Record<string, string>;
+	waitTill?: Date | null;
 	startedAt: Date;
 	stoppedAt: Date;
 };

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -616,6 +616,7 @@ export class WorkflowRunner {
 						startedAt: fullExecutionData.startedAt,
 						stoppedAt: fullExecutionData.stoppedAt,
 						status: fullExecutionData.status,
+						waitTill: fullExecutionData.waitTill,
 						data: fullExecutionData.data,
 						jobId: job.id.toString(),
 						storedAt: fullExecutionData.storedAt,
@@ -627,6 +628,7 @@ export class WorkflowRunner {
 						startedAt: jobResult.startedAt,
 						stoppedAt: jobResult.stoppedAt,
 						status: jobResult.status,
+						waitTill: jobResult.waitTill,
 						data: createRunExecutionData({
 							resultData: {
 								runData: {},


### PR DESCRIPTION
## Summary

In scaling mode, parent workflows configured with "Save successful production executions: Do not save" were being soft-deleted while still parked at a `Wait` node, so sub-workflows trying to resume them via `GET /webhook-waiting/<id>` were finding "404 - The execution <id> does not exist".

Two independent things lined up to cause it:

1. Top-level `waitTill` was never carried across the worker → main boundary
2. `determineFinalExecutionStatus` now checks `waitTill` and when missing treats the execution as successful

The old check `if (!fullRunData.finished) return` before #28774 in the scaling-main hook used to bail out on the default DB fetch path, where `finished` correctly came back from the DB as `false` for waiting runs, protecting the parent. #28774 replaced that guard with a status-based check, inadvertently removing the protection, i.e. the rewritten success status started flowing through `shouldNotSave`, soft-deleting the parent before the resume webhook could find it.

## Related Linear tickets, Github issues, and Community forum posts

- Linear: https://linear.app/n8n/issue/CAT-3025
- Fixes #29924

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
