### PR TITLE
fix(LinkedIn Node): Surface clear error when OAuth refresh token is missing

### DIFF
--- a/packages/@n8n/client-oauth2/src/client-oauth2-token.ts
+++ b/packages/@n8n/client-oauth2/src/client-oauth2-token.ts
@@ -1,5 +1,3 @@
-import * as a from 'node:assert';
-
 import type { ClientOAuth2, ClientOAuth2Options, ClientOAuth2RequestObject } from './client-oauth2';
 import { DEFAULT_HEADERS } from './constants';
 import { auth, getRequestOptions } from './utils';
@@ -74,7 +72,11 @@ export class ClientOAuth2Token {
 	async refresh(opts?: ClientOAuth2Options): Promise<ClientOAuth2Token> {
 		const options = { ...this.client.options, ...opts };
 
-		a.ok(this.refreshToken, 'refreshToken is required');
+		if (!this.refreshToken) {
+			throw new Error(
+				'OAuth access token has expired and no refresh token is available. Please reconnect the credential.',
+			);
+		}
 
 		const { clientId, clientSecret } = options;
 		const headers = { ...DEFAULT_HEADERS };

--- a/packages/@n8n/client-oauth2/test/code-flow.test.ts
+++ b/packages/@n8n/client-oauth2/test/code-flow.test.ts
@@ -187,6 +187,17 @@ describe('CodeFlow', () => {
 				expect(token1.refreshToken).toEqual(config.refreshedRefreshToken);
 				expect(token1.tokenType).toEqual('bearer');
 			});
+
+			it('should throw a clear error when no refresh token is present', async () => {
+				const token = githubAuth.createToken({
+					access_token: config.accessToken,
+					refresh_token: '',
+				});
+
+				await expect(token.refresh()).rejects.toThrow(
+					'OAuth access token has expired and no refresh token is available. Please reconnect the credential.',
+				);
+			});
 		});
 	});
 });

--- a/packages/nodes-base/credentials/LinkedInOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/LinkedInOAuth2Api.credentials.ts
@@ -11,6 +11,13 @@ export class LinkedInOAuth2Api implements ICredentialType {
 
 	properties: INodeProperties[] = [
 		{
+			displayName:
+				'Standard LinkedIn apps issue access tokens valid for 60 days and do not return a refresh token. You will need to reconnect this credential when the token expires. Automatic token refresh requires <a href="https://learn.microsoft.com/en-us/linkedin/marketing/" target="_blank">Marketing Developer Platform</a> access from LinkedIn.',
+			name: 'tokenExpiryNotice',
+			type: 'notice',
+			default: '',
+		},
+		{
 			displayName: 'Grant Type',
 			name: 'grantType',
 			type: 'hidden',


### PR DESCRIPTION
## Summary

LinkedIn standard apps (those without Marketing Developer Platform access) only receive a 60-day access token and **no refresh token** — this is documented LinkedIn behavior, not a misconfiguration. When the access token expired and n8n attempted to refresh, `@n8n/client-oauth2` hit a hard `assert.ok(this.refreshToken, ...)` that threw an `AssertionError` surfacing in the execution UI as the opaque `httpCode: \"ERR_ASSERTION\"` with message \"refreshToken is required\". Users had no actionable guidance for what was a normal lifecycle event.

This PR:

- Replaces the `assert.ok` in `client-oauth2-token.ts` with a regular `Error` whose message tells the user exactly what to do: *\"OAuth access token has expired and no refresh token is available. Please reconnect the credential.\"* This benefits every OAuth2 provider that doesn't return refresh tokens, not just LinkedIn.
- Adds a `notice` property to the LinkedIn OAuth2 credential explaining the 60-day expiry, the need to reconnect, and that automatic refresh requires Marketing Developer Platform access (with a link to LinkedIn's docs). The notice renders in both standard and managed (n8n Cloud) OAuth modes.
- Adds a unit test asserting `token.refresh()` rejects with the new message when no refresh token is present.

### How to test

**Unit test:**
\`\`\`bash
pnpm --filter=@n8n/client-oauth2 test
\`\`\`
The new test \`should throw a clear error when no refresh token is present\` (in \`code-flow.test.ts\` under \`#refresh\`) covers the regression.

**End-to-end against a running n8n:**
1. Create a LinkedIn OAuth2 credential and complete the OAuth flow.
2. Manipulate the saved credential via the REST API to clear \`refresh_token\` and use an invalid \`access_token\`:
   \`\`\`bash
   curl -X PATCH -b cookies.txt -H 'Content-Type: application/json' \\
     http://localhost:5678/rest/credentials/<ID> \\
     -d '{\"data\":{\"oauthTokenData\":{\"access_token\":\"invalid\",\"refresh_token\":\"\"}}}'
   \`\`\`
3. Run a LinkedIn workflow → execution UI now shows \`OAuth access token has expired and no refresh token is available. Please reconnect the credential.\` instead of \`ERR_ASSERTION\`.

**Notice rendering:** open the LinkedIn OAuth2 credential setup in the UI; the notice appears at the top of the property list in both standard and managed OAuth modes.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4943

closes #29434

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI