### PR TITLE
fix(core): Always create instance-ai sandbox workspace dirs (TRUST-79)

### DIFF
--- a/packages/@n8n/instance-ai/src/workspace/__tests__/sandbox-setup.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/sandbox-setup.test.ts
@@ -25,12 +25,14 @@ function createSetupContext(): InstanceAiContext {
 
 function createLocalWorkspace(
 	writeFile: jest.Mock<Promise<void>, [string, string, { recursive: true }]>,
+	mkdir?: jest.Mock<Promise<void>, [string, { recursive?: boolean }]>,
 ): Workspace {
 	return {
 		filesystem: {
 			provider: 'local',
 			basePath: '/sandbox',
 			writeFile,
+			mkdir: mkdir ?? jest.fn(async () => {}),
 		},
 	} as unknown as Workspace;
 }
@@ -139,6 +141,33 @@ describe('setupSandboxWorkspace', () => {
 		expect(markerCallIndex).toBeGreaterThan(-1);
 		expect(writeFile.mock.invocationCallOrder[markerCallIndex]).toBeGreaterThan(
 			runInSandbox.mock.invocationCallOrder[0],
+		);
+	});
+
+	it('always creates workflows/, src/, and chunks/ even when no workflows exist', async () => {
+		const runInSandbox: RunInSandboxMock = jest.fn<
+			Promise<{ exitCode: number; stdout: string; stderr: string }>,
+			[Workspace, string, string?]
+		>();
+		runInSandbox.mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' });
+		const readFileViaSandbox: ReadFileViaSandboxMock = jest.fn<
+			Promise<string | null>,
+			[Workspace, string]
+		>();
+		readFileViaSandbox.mockResolvedValue(null);
+		const setupSandboxWorkspace = loadSetupSandboxWorkspaceWithFsMocks(
+			runInSandbox,
+			readFileViaSandbox,
+		);
+		const writeFile = jest.fn<Promise<void>, [string, string, { recursive: true }]>(async () => {});
+		const mkdir = jest.fn<Promise<void>, [string, { recursive?: boolean }]>(async () => {});
+
+		// Setup context defaults to an empty workflow list, mirroring a fresh DB.
+		await setupSandboxWorkspace(createLocalWorkspace(writeFile, mkdir), createSetupContext());
+
+		const mkdirPaths = mkdir.mock.calls.map(([path]) => path);
+		expect(mkdirPaths).toEqual(
+			expect.arrayContaining(['/sandbox/src', '/sandbox/chunks', '/sandbox/workflows']),
 		);
 	});
 

--- a/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
+++ b/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
@@ -221,6 +221,9 @@ export function formatNodeCatalogLine(node: SearchableNodeDescription): string {
 	return parts.join(' | ');
 }
 
+/** Dirs the agent's `list_files` may probe; some providers 404 on missing dirs. */
+const ALWAYS_PRESENT_DIRS: readonly string[] = ['src', 'chunks', 'workflows'];
+
 /**
  * Build a shell script that writes all files at once.
  * Each file is base64-encoded and decoded in-place.
@@ -230,7 +233,7 @@ function buildBatchWriteScript(root: string, files: Map<string, string>): string
 	const lines: string[] = ['#!/bin/bash', 'set -e'];
 
 	// Collect all unique directories
-	const dirs = new Set<string>();
+	const dirs = new Set<string>(ALWAYS_PRESENT_DIRS);
 	for (const path of files.keys()) {
 		const lastSlash = path.lastIndexOf('/');
 		if (lastSlash > 0) {
@@ -240,15 +243,7 @@ function buildBatchWriteScript(root: string, files: Map<string, string>): string
 
 	// Create all directories in one mkdir call (single-quoted + escaped to prevent shell injection)
 	const dirList = [...dirs].map((d) => `'${escapeSingleQuotes(`${root}/${d}`)}'`).join(' ');
-	if (dirList) {
-		lines.push(
-			`mkdir -p '${escapeSingleQuotes(`${root}/src`)}' '${escapeSingleQuotes(`${root}/chunks`)}' ${dirList}`,
-		);
-	} else {
-		lines.push(
-			`mkdir -p '${escapeSingleQuotes(`${root}/src`)}' '${escapeSingleQuotes(`${root}/chunks`)}'`,
-		);
-	}
+	lines.push(`mkdir -p ${dirList}`);
 
 	// Write each file via base64 decode (single-quoted paths to prevent shell injection)
 	for (const [path, content] of files) {
@@ -266,6 +261,12 @@ async function writeWorkspaceFiles(
 ): Promise<void> {
 	const filesystem = workspace.filesystem;
 	if (filesystem) {
+		// `writeFile` only creates parent dirs as a side-effect of writing a file.
+		await Promise.all(
+			ALWAYS_PRESENT_DIRS.map(
+				async (dir) => await filesystem.mkdir(`${root}/${dir}`, { recursive: true }),
+			),
+		);
 		await Promise.all(
 			[...files].map(async ([path, content]) => {
 				await filesystem.writeFile(`${root}/${path}`, content, { recursive: true });


### PR DESCRIPTION
## Summary

The instance-ai builder agent's first interaction with the sandbox workspace often calls `list_files ~/workspace/workflows` to learn what existing workflows it can reference. On any n8n instance with no pre-existing workflows, that call fails because the directory was never created.

Linear ticket: https://linear.app/n8n/issue/TRUST-79

## Observed error

On a fresh n8n instance (or any instance whose workflow list is empty), the builder receives a Daytona `FileSystem.listFiles` 404 error on its first attempt to enumerate `~/workspace/workflows/`. The error masquerades as a tool failure rather than an empty result, and the agent loses time recovering.

## Root cause

`setupSandboxWorkspace` populates `workflows/` with one JSON file per existing workflow:

```ts
for (const r of results) {
  if (r.status === 'fulfilled') {
    files.set(`workflows/${r.value.id}.json`, r.value.json);
  }
}
```

When `workflowService.list()` returns zero results, no entry is added to the file map. Both write paths (the bash-script batch-mkdir for Daytona, and the filesystem-API path for the local provider) only create a directory as a side-effect of writing a file into it — so `workflows/` is silently skipped.

Daytona's `FileSystem.listFiles` returns **404 for missing directories** rather than an empty array. The agent gets an error instead of `[]`. Other providers may behave the same way; the contract isn't uniformly "empty list on missing dir."

## Fix

Always create the dirs the agent's read-only tools may probe, regardless of whether files are written into them. Both code paths now mkdir `src/`, `chunks/`, and `workflows/` unconditionally:

```ts
const ALWAYS_PRESENT_DIRS: readonly string[] = ['src', 'chunks', 'workflows'];
```

mkdir is idempotent (`mkdir -p` / `{ recursive: true }`), so this is safe on re-init and on instances where the dirs already exist.

## Test plan

- [x] Unit test added: with empty workflow list, asserts the three dirs are mkdir'd anyway.
- [x] Existing `setupSandboxWorkspace` tests pass (4/4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
