### PR TITLE
fix(core): Allow same-domain redirects in instance-ai web research (TRUST-73)

### DIFF
--- a/packages/@n8n/instance-ai/package.json
+++ b/packages/@n8n/instance-ai/package.json
@@ -62,6 +62,7 @@
     "nanoid": "catalog:",
     "p-limit": "^3.1.0",
     "pdf-parse": "2.4.5",
+    "psl": "1.9.0",
     "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz",
     "turndown": "^7.2.0",
     "zod": "catalog:",
@@ -78,6 +79,7 @@
     "@n8n/ai-workflow-builder": "workspace:*",
     "@n8n/typescript-config": "workspace:*",
     "@types/luxon": "3.2.0",
+    "@types/psl": "1.1.3",
     "@types/turndown": "^5.0.5",
     "tsx": "catalog:"
   }

--- a/packages/@n8n/instance-ai/src/tools/__tests__/research.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/research.tool.test.ts
@@ -694,5 +694,99 @@ describe('research tool', () => {
 				expect.objectContaining({ maxContentLength: 5000 }),
 			);
 		});
+
+		// ── Same-eTLD+1 redirect auto-allow (TRUST-73) ───────────────
+		// The research tool builds an `authorizeUrl` callback that the fetch
+		// loop calls on each redirect hop. We capture that callback by mocking
+		// the underlying webResearchService.fetchUrl, then exercise it directly
+		// to assert security boundaries without spinning up a real network stack.
+
+		describe('redirect authorizer (same-eTLD+1)', () => {
+			type AuthorizeUrl = (targetUrl: string) => Promise<void>;
+
+			async function captureAuthorizeUrl(inputUrl: string): Promise<AuthorizeUrl> {
+				// Tracker: original host pre-allowed (so the initial fetch passes
+				// without suspending), but every other host is unknown — that
+				// keeps the redirect check live, which is what we want to test.
+				const inputHost = new URL(inputUrl).hostname;
+				const tracker = {
+					isHostAllowed: jest.fn((host: string) => host === inputHost),
+					approveDomain: jest.fn(),
+					approveAllDomains: jest.fn(),
+					approveOnce: jest.fn(),
+					clearRun: jest.fn(),
+					setPendingApprovalHost: jest.fn(),
+					consumePendingApprovalHost: jest.fn(),
+					isAllDomainsApproved: jest.fn().mockReturnValue(false),
+					isWebSearchAllowed: jest.fn().mockReturnValue(false),
+					approveWebSearch: jest.fn(),
+					approveWebSearchOnce: jest.fn(),
+				};
+				let captured: AuthorizeUrl | undefined;
+				const context = createMockContext({
+					domainAccessTracker: tracker as never,
+					permissions: {},
+				});
+				context.webResearchService!.fetchUrl = jest.fn(
+					async (_url: string, options?: { authorizeUrl?: AuthorizeUrl }) => {
+						captured = options?.authorizeUrl;
+						return {
+							url: inputUrl,
+							finalUrl: inputUrl,
+							title: '',
+							content: '',
+							truncated: false,
+							contentLength: 0,
+						};
+					},
+				) as never;
+
+				const tool = createResearchTool(context);
+				await tool.execute!(
+					{ action: 'fetch-url' as const, url: inputUrl },
+					createAgentCtx() as never,
+				);
+				if (!captured) throw new Error('authorizeUrl was not captured');
+				return captured;
+			}
+
+			it('allows redirect within the same registrable domain over HTTPS', async () => {
+				const authorize = await captureAuthorizeUrl('https://developers.linear.app/docs/graphql');
+				await expect(authorize('https://linear.app/developers')).resolves.toBeUndefined();
+			});
+
+			it('blocks redirect to a host that only superficially resembles the source', async () => {
+				// `attacker-linear.app` "ends with" `linear.app` for naive checks —
+				// PSL correctly identifies it as a different registrable domain.
+				const authorize = await captureAuthorizeUrl('https://developers.linear.app/docs/graphql');
+				await expect(authorize('https://attacker-linear.app/x')).rejects.toThrow(
+					/redirect.*not allowed/i,
+				);
+			});
+
+			it('blocks HTTPS-to-HTTP redirect even within the same registrable domain', async () => {
+				const authorize = await captureAuthorizeUrl('https://developers.linear.app/docs/graphql');
+				await expect(authorize('http://linear.app/developers')).rejects.toThrow(
+					/redirect.*not allowed/i,
+				);
+			});
+
+			it('blocks redirect to a different registrable domain', async () => {
+				const authorize = await captureAuthorizeUrl('https://developers.linear.app/docs/graphql');
+				await expect(authorize('https://evil.example/x')).rejects.toThrow(/redirect.*not allowed/i);
+			});
+
+			it('rejection error does not echo the blocked URL as a retry hint (TRUST-73)', async () => {
+				// Pre-fix wording was "Retry with the direct URL: <blocked>" — that
+				// caused the LLM to retry the same blocked host forever. Lock in
+				// the new clearer phrasing so the message can't regress.
+				const authorize = await captureAuthorizeUrl('https://developers.linear.app/docs/graphql');
+				const err = await authorize('https://evil.example/x').catch((e: unknown) => e);
+				expect(err).toBeInstanceOf(Error);
+				const message = (err as Error).message;
+				expect(message).toMatch(/skip this URL/i);
+				expect(message).not.toMatch(/retry with the direct URL/i);
+			});
+		});
 	});
 });

--- a/packages/@n8n/instance-ai/src/tools/__tests__/research.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/research.tool.test.ts
@@ -729,6 +729,7 @@ describe('research tool', () => {
 				});
 				context.webResearchService!.fetchUrl = jest.fn(
 					async (_url: string, options?: { authorizeUrl?: AuthorizeUrl }) => {
+						await Promise.resolve();
 						captured = options?.authorizeUrl;
 						return {
 							url: inputUrl,
@@ -781,9 +782,9 @@ describe('research tool', () => {
 				// caused the LLM to retry the same blocked host forever. Lock in
 				// the new clearer phrasing so the message can't regress.
 				const authorize = await captureAuthorizeUrl('https://developers.linear.app/docs/graphql');
-				const err = await authorize('https://evil.example/x').catch((e: unknown) => e);
-				expect(err).toBeInstanceOf(Error);
-				const message = (err as Error).message;
+				const caught = await authorize('https://evil.example/x').catch((e: unknown) => e);
+				expect(caught).toBeInstanceOf(Error);
+				const message = (caught as Error).message;
 				expect(message).toMatch(/skip this URL/i);
 				expect(message).not.toMatch(/retry with the direct URL/i);
 			});

--- a/packages/@n8n/instance-ai/src/tools/research.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/research.tool.ts
@@ -2,6 +2,7 @@
  * Consolidated research tool — web-search + fetch-url.
  */
 import { createTool } from '@mastra/core/tools';
+import { get as pslGet } from 'psl';
 import { z } from 'zod';
 
 import { sanitizeInputSchema } from '../agent/sanitize-mcp-schemas';
@@ -15,6 +16,22 @@ import {
 } from '../domain-access';
 import type { InstanceAiContext } from '../types';
 import { sanitizeWebContent, wrapUntrustedData } from './web-research/sanitize-web-content';
+
+/** True when both URLs share an eTLD+1 (per Public Suffix List) and target is HTTPS. */
+function isSameRegistrableDomainOverHttps(originalUrl: string, redirectUrl: string): boolean {
+	let originalHost: string;
+	let redirectUrlObj: URL;
+	try {
+		originalHost = new URL(originalUrl).hostname;
+		redirectUrlObj = new URL(redirectUrl);
+	} catch {
+		return false;
+	}
+	if (redirectUrlObj.protocol !== 'https:') return false;
+	const originalDomain = pslGet(originalHost);
+	const redirectDomain = pslGet(redirectUrlObj.hostname);
+	return originalDomain !== null && redirectDomain !== null && originalDomain === redirectDomain;
+}
 
 // ── Action schemas ──────────────────────────────────────────────────────────
 
@@ -202,13 +219,15 @@ async function handleFetchUrl(
 			permissionMode: context.permissions?.fetchUrl,
 			runId: context.runId,
 		});
-		if (!redirectCheck.allowed) {
-			const reason = redirectCheck.blocked
-				? `Access to ${new URL(targetUrl).hostname} is blocked by admin.`
-				: `Redirect to ${new URL(targetUrl).hostname} requires approval. ` +
-					`Retry with the direct URL: ${targetUrl}`;
-			throw new Error(reason);
+		if (redirectCheck.allowed) return;
+		if (redirectCheck.blocked) {
+			throw new Error(`Access to ${new URL(targetUrl).hostname} is blocked by admin.`);
 		}
+		if (isSameRegistrableDomainOverHttps(input.url, targetUrl)) return;
+		throw new Error(
+			`Redirect from ${new URL(input.url).hostname} to ${new URL(targetUrl).hostname} is not allowed. ` +
+				'Skip this URL and try a different research strategy — retrying the same URL will not help.',
+		);
 	};
 
 	const result = await context.webResearchService.fetchUrl(input.url, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1742,6 +1742,9 @@ importers:
       pdf-parse:
         specifier: 2.4.5
         version: 2.4.5
+      psl:
+        specifier: 1.9.0
+        version: 1.9.0
       turndown:
         specifier: ^7.2.0
         version: 7.2.2
@@ -1773,6 +1776,9 @@ importers:
       '@types/luxon':
         specifier: 3.2.0
         version: 3.2.0
+      '@types/psl':
+        specifier: 1.1.3
+        version: 1.1.3
       '@types/turndown':
         specifier: ^5.0.5
         version: 5.0.6
@@ -11790,6 +11796,9 @@ packages:
 
   '@types/psl@1.1.0':
     resolution: {integrity: sha512-HhZnoLAvI2koev3czVPzBNRYvdrzJGLjQbWZhqFmS9Q6a0yumc5qtfSahBGb5g+6qWvA8iiQktqGkwoIXa/BNQ==}
+
+  '@types/psl@1.1.3':
+    resolution: {integrity: sha512-Iu174JHfLd7i/XkXY6VDrqSlPvTDQOtQI7wNAXKKOAADJ9TduRLkNdMgjGiMxSttUIZnomv81JAbAbC0DhggxA==}
 
   '@types/qs@6.9.15':
     resolution: {integrity: sha512-uXHQKES6DQKKCLh441Xv/dwxOq1TVS3JPUMlEqoEglvlhR6Mxnlew/Xq/LRVHpLyk7iK3zODe1qYHIMltO7XGg==}
@@ -32281,6 +32290,8 @@ snapshots:
       '@types/node': 20.19.21
 
   '@types/psl@1.1.0': {}
+
+  '@types/psl@1.1.3': {}
 
   '@types/qs@6.9.15': {}
 


### PR DESCRIPTION
## Summary

The instance-ai web-research tool maintains an allowlist of domains that the agent may fetch documentation from. When a fetch follows a redirect to a host **not** on the allowlist, the redirect-hop authorizer throws — this is correct for cross-domain redirects, but is the wrong behavior for the very common case of an allowlisted docs subdomain that 301-redirects to its root (`developers.linear.app` → `linear.app`, `developer.atlassian.com` → `atlassian.com`, …). It also produces an error message that the agent can't recover from, causing a runaway retry loop.

Linear ticket: https://linear.app/n8n/issue/TRUST-73

## Observed error

When the planner sub-agent tries to research Linear's GraphQL API, it fetches `https://developers.linear.app/docs/graphql/working-with-the-graphql-api`. That URL 301-redirects to `https://linear.app/developers`. The agent saw the redirect blocked with this error:

> Redirect to linear.app requires approval. Retry with the direct URL: https://linear.app/developers

The "retry the direct URL" hint points at the *same* blocked host the redirect just tried to reach, so the model has no actionable recovery — it retries the same URL, gets the same error, and loops until it hits a token/turn ceiling. In practice this manifested as eval/build timeouts on Linear-touching scenarios, with the dev log showing 20+ identical "Redirect to linear.app requires approval" lines.

The pattern reproduces against any service whose docs subdomain is allowlisted but whose root domain is not. Linear was the visible example; Airtable, Atlassian, GitHub Pages-style setups, and most "developer.X / developers.X" docs hosts that use a docs.example.com → example.com redirect have the same shape.

## Fix

Treat redirects within the same **registrable domain** (eTLD+1) over **HTTPS** as same-domain trust extension and follow them transparently. Cross-domain or HTTPS-to-HTTP redirects continue to throw, but with a clearer non-looping error message that does not echo the blocked URL as a retry target — so the model gives up on this URL and tries a different research strategy instead of looping.

The registrable-domain boundary is computed via the [Public Suffix List](https://publicsuffix.org/) (`psl` package). PSL is the only correct way to do this:
- Naive `endsWith('.linear.app')` is trivially spoofable (`attacker-linear.app` falsely matches without the leading dot, and even with it `evil.linear.app.attacker.com` matches).
- Splitting on dots fails for compound TLDs (`co.uk`, `github.io`, `vercel.app` — these are themselves public suffixes; `foo.github.io` and `bar.github.io` are different registrable domains).

Requiring HTTPS on the redirect target keeps one common downgrade-attack class out of the picture.

## Security characterization

- **Same registrable domain + HTTPS → allow**: industry-standard same-domain trust extension. If `developers.linear.app` is on the allowlist, the redirect to `linear.app` stays under the same DNS authority and inherits that trust.
- **Different registrable domain → throw**: even if the source is allowlisted, a cross-domain redirect requires explicit approval. The new error message says "Skip this URL and try a different research strategy — retrying the same URL will not help." (no echoing of the blocked URL).
- **HTTPS → HTTP downgrade → throw**: covers passive-attack scenarios where a TLS-downgraded redirect could land on a non-encrypted hop.
- **Failed URL parse → throw (fail-closed)**: malformed redirect targets are rejected.

## Residual risk

**Subdomain takeover**: if a domain on the allowlist has a forgotten subdomain pointed at an abandoned external service (Heroku, S3 bucket, GitHub Pages, etc.), an attacker who re-registers that external service can serve content under that subdomain. Our check would still allow it. This is a standard trade-off for same-domain trust extension — fundamentally the allowlisted domain owner's responsibility (DNS hygiene), not the consumer's. We accept the residual risk; alternatives (block all redirects, require per-host approval) break legitimate flows in normal use.

## Dependency

Adds `psl: 1.9.0` (runtime) and `@types/psl: 1.1.3` (dev) to `@n8n/instance-ai`. `psl` is already a direct dep of `packages/cli` (used by telemetry); the version is matched.

The `@types/psl` package versioning is unusual: `@types/psl@1.11.0` is a stub that declares "psl provides its own types" (it doesn't, in `psl@1.9.x`); only `@types/psl@1.1.x` ships actual types compatible with our pinned `psl@1.9.0`. We use `1.1.3` accordingly.

Note that pinning `psl@1.9.0` (matching telemetry's existing pin) means PSL data updates require a manual bump. Acceptable for this use case — the public suffix list changes infrequently and a stale list errs on the side of *under*-allowing.

## Test plan

Five focused security tests added:
- [x] Allows same-registrable-domain redirect over HTTPS (`developers.linear.app` → `linear.app`)
- [x] Blocks naive-suffix-spoof (`developers.linear.app` → `attacker-linear.app`)
- [x] Blocks HTTPS-to-HTTP downgrade even within the same registrable domain
- [x] Blocks cross-domain redirect (different eTLD+1)
- [x] Lock-in test: rejection error does **not** echo the blocked URL as a "retry" hint

Plus all existing research-tool tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
