### PR TITLE
fix(core): Inline AI_NODE_SDK_VERSION to save memory by not loading @n8n/ai-utilities on boot

### DIFF
--- a/packages/@n8n/ai-utilities/src/ai-node-sdk-version.ts
+++ b/packages/@n8n/ai-utilities/src/ai-node-sdk-version.ts
@@ -1,3 +1,5 @@
 // Controls which SDK version is supported by the current n8n
 // Check README.md for explanation
+// NOTE: also inlined in packages/cli/src/modules/community-packages/community-packages.config.ts
+// to avoid loading the @n8n/ai-utilities barrel at boot. Keep both values in sync.
 export const AI_NODE_SDK_VERSION: number = 1;

--- a/packages/cli/src/modules/community-packages/community-packages.config.ts
+++ b/packages/cli/src/modules/community-packages/community-packages.config.ts
@@ -1,5 +1,9 @@
-import { AI_NODE_SDK_VERSION } from '@n8n/ai-utilities';
 import { Config, Env } from '@n8n/config';
+
+// Keep in sync with AI_NODE_SDK_VERSION in
+// packages/@n8n/ai-utilities/src/ai-node-sdk-version.ts.
+// Inlined to avoid loading the @n8n/ai-utilities barrel at boot.
+const AI_NODE_SDK_VERSION = 1;
 
 @Config
 export class CommunityPackagesConfig {


### PR DESCRIPTION
## Summary

It turns out this import cost about ~5MB of idle memory use to import value "1" for the SDK version.

Inlining the value changes `pnpm --filter=n8n-playwright test:performance --grep "Memory consumption baseline"` measurement from

```
Heap Used: 127.27 MB
```

to
```
Heap Used: 122.36 MB
```

## Related Linear tickets, Github issues, and Community forum posts

https://n8nio.slack.com/archives/C03MZF137FV/p1778240828095139

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
