### PR TITLE
feat(Anthropic Node): Support Anthropic MCP connector

### DIFF
--- a/MCP_SERVER_SUPPORT.md
+++ b/MCP_SERVER_SUPPORT.md
@@ -1,0 +1,126 @@
+# MCP Server Support — Anthropic Node (n8n)
+
+## Status
+
+**4 Commits lokal fertig, Push blockiert (403 Proxy-Fehler)**
+
+Branch: `claude/add-mcp-server-support-0ylTe`
+Basis: `master` (ef3c3e0f)
+
+Patch-Datei zum Anwenden: `/tmp/mcp-server-support.patch`
+
+---
+
+## Patch anwenden (lokaler Einstieg)
+
+```bash
+# Im n8n-Root:
+git checkout -b claude/add-mcp-server-support-0ylTe
+git am /tmp/mcp-server-support.patch
+```
+
+Oder mit `git apply` (ohne Commit-Metadaten):
+```bash
+git apply /tmp/mcp-server-support.patch
+```
+
+---
+
+## Was wurde implementiert
+
+### Ziel
+"Enable MCP Servers (Beta)"-Toggle im Anthropic-Node, der bei Aktivierung:
+1. Ein `mcp_servers`-Array in den Request-Body injiziert
+2. Für jeden Server einen `mcp_toolset`-Eintrag im `tools`-Array ergänzt (Pflicht laut API)
+3. Den Beta-Header `mcp-client-2025-11-20` setzt
+
+### Geänderte Dateien
+
+#### `packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/transport/index.ts`
+- `mcpClient?: boolean` zu `enableAnthropicBetas` hinzugefügt
+- Beta-Header-Mapping: `mcp-client-2025-11-20` (nicht das veraltete `mcp-client-2025-04-04`)
+
+#### `packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/helpers/interfaces.ts`
+- `mcp_toolset`-Variante zur `Tool`-Union hinzugefügt:
+  ```typescript
+  | { type: 'mcp_toolset'; mcp_server_name: string }
+  ```
+
+#### `packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/text/message.operation.ts`
+- UI-Properties in `Options`-Collection:
+	- `enableMcpServers` (boolean, default `false`)
+	- `mcpServers` (fixedCollection, multipleValues, nur sichtbar wenn Toggle ON)
+		- Felder pro Server: `name` (required), `url` (required), `authorizationToken` (password, optional)
+- `MessageOptions`-Interface erweitert
+- Body-Logik:
+	- `mcp_servers`-Array aus konfigurierten Servern
+	- `mcp_toolset`-Einträge in `tools`-Array (je ein Eintrag pro Server, referenziert per `name`)
+- `mcpClient`-Flag in beiden `enableAnthropicBetas`-Aufrufen (Initial-Request + Tool-Loop)
+
+#### `packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/transport/index.test.ts`
+- 2 neue Tests:
+	- `mcp-client-2025-11-20` Header bei `mcpClient: true`
+	- Kombiniert mit `codeExecution`
+
+#### `packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/text/message.operation.test.ts` *(neu)*
+- **Vitest** (nicht Jest) — `vi.mock`, `vi.hoisted`, `vi.importActual`, `vitest-mock-extended`
+- 8 Tests:
+	- Toggle OFF: kein `mcp_servers`, kein `mcp_toolset`
+	- Toggle ON: `mcp_servers`-Array korrekt
+	- `mcp_toolset`-Injection pro Server
+	- Mehrere Server gleichzeitig
+	- `authorization_token` weggelassen wenn leer
+	- `mcpClient`-Beta gesetzt
+	- Kompatibel mit `codeExecution`-Beta
+
+#### `packages/@n8n/nodes-langchain/vitest.config.ts` *(neu)*
+- Minimaler Vitest-Config mit `@utils`-Alias
+
+---
+
+## API-Referenz (Anthropic Docs)
+
+Doku: https://platform.claude.com/docs/en/agents-and-tools/mcp-connector
+
+**Request-Struktur:**
+```json
+{
+  "mcp_servers": [
+    { "type": "url", "name": "my-server", "url": "https://mcp.example.com/sse", "authorization_token": "..." }
+  ],
+  "tools": [
+    { "type": "mcp_toolset", "mcp_server_name": "my-server" }
+  ]
+}
+```
+
+**Validierungsregeln:**
+- Jeder Server in `mcp_servers` muss von genau einem `mcp_toolset` in `tools` referenziert werden
+- Beta-Header: `mcp-client-2025-11-20` (Vorgänger `mcp-client-2025-04-04` ist deprecated)
+
+---
+
+## Tests ausführen
+
+```bash
+cd packages/@n8n/nodes-langchain
+
+# Transport-Tests (Jest)
+pnpm test transport/index.test.ts
+
+# Operation-Tests (Vitest)
+# Benötigt den vitest-Binary aus einem anderen Package:
+../../@n8n/cli/node_modules/.bin/vitest run \
+  nodes/vendors/Anthropic/actions/text/message.operation.test.ts
+
+# Typecheck
+pnpm typecheck
+```
+
+> **Hinweis:** `vitest-mock-extended` ist in `node_modules/` via Symlink verknüpft
+> (zeigt auf `.pnpm/vitest-mock-extended@3.1.0_.../node_modules/vitest-mock-extended`).
+> Nach einem frischen `pnpm install` wird der Symlink durch pnpm verwaltet — das Package
+> muss ggf. als `devDependency` in `packages/@n8n/nodes-langchain/package.json` eingetragen
+> werden.
+
+---

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -434,6 +434,61 @@ export class LmChatAnthropic implements INodeType {
 							},
 						},
 					},
+					{
+						displayName: 'Enable MCP Servers (Beta)',
+						name: 'enableMcpServers',
+						type: 'boolean',
+						default: false,
+						description:
+							'Whether to enable MCP (Model Context Protocol) servers that Claude can use as tool providers during execution',
+					},
+					{
+						displayName: 'MCP Servers',
+						name: 'mcpServers',
+						type: 'fixedCollection',
+						typeOptions: {
+							multipleValues: true,
+						},
+						default: {},
+						displayOptions: {
+							show: {
+								enableMcpServers: [true],
+							},
+						},
+						options: [
+							{
+								displayName: 'Server',
+								name: 'servers',
+								values: [
+									{
+										displayName: 'Name',
+										name: 'name',
+										type: 'string',
+										default: '',
+										required: true,
+										description: 'A unique name to identify this MCP server',
+									},
+									{
+										displayName: 'URL',
+										name: 'url',
+										type: 'string',
+										default: '',
+										required: true,
+										placeholder: 'https://mcp.example.com/sse',
+										description: 'The URL of the MCP server endpoint',
+									},
+									{
+										displayName: 'Authorization Token',
+										name: 'authorizationToken',
+										type: 'string',
+										typeOptions: { password: true },
+										default: '',
+										description: 'Optional bearer token for authenticating with the MCP server',
+									},
+								],
+							},
+						],
+					},
 				],
 			},
 		],
@@ -469,6 +524,14 @@ export class LmChatAnthropic implements INodeType {
 			thinkingBudget?: number;
 			thinkingMode?: 'disabled' | 'adaptive' | 'manual';
 			effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+			enableMcpServers?: boolean;
+			mcpServers?: {
+				servers?: Array<{
+					name: string;
+					url: string;
+					authorizationToken?: string;
+				}>;
+			};
 		};
 
 		const isOpus47Model = modelName.startsWith('claude-opus-4-7');
@@ -568,6 +631,22 @@ export class LmChatAnthropic implements INodeType {
 				}
 			: undefined;
 
+		const mcpServerConfigs =
+			options.enableMcpServers && options.mcpServers?.servers?.length
+				? options.mcpServers.servers.map((server) => ({
+						type: 'url' as const,
+						name: server.name,
+						url: server.url,
+						...(server.authorizationToken
+							? { authorization_token: server.authorizationToken }
+							: {}),
+					}))
+				: undefined;
+
+		if (mcpServerConfigs) {
+			invocationKwargs.mcp_servers = mcpServerConfigs;
+		}
+
 		const chatAnthropicParams: ChatAnthropicInput = {
 			anthropicApiKey: credentials.apiKey,
 			model: modelName,
@@ -577,6 +656,7 @@ export class LmChatAnthropic implements INodeType {
 			onFailedAttempt: makeN8nLlmFailedAttemptHandler(this, gatewayErrorHandler),
 			invocationKwargs,
 			clientOptions,
+			...(mcpServerConfigs ? { betas: ['mcp-client-2025-11-20'] } : {}),
 		};
 
 		// Opus 4.7 rejects temperature/topK/topP at the SDK layer regardless of thinking mode

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
@@ -828,6 +828,186 @@ describe('LmChatAnthropic', () => {
 		});
 	});
 
+	describe('MCP servers', () => {
+		it('should not set mcp_servers or betas when enableMcpServers is false', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-6';
+				if (paramName === 'options') return { enableMcpServers: false };
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			const callArgs = MockedChatAnthropic.mock.calls[0][0]!;
+			expect(callArgs.invocationKwargs).toEqual({});
+			expect(callArgs).not.toHaveProperty('betas');
+		});
+
+		it('should not set mcp_servers when enabled but no servers configured', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-6';
+				if (paramName === 'options') return { enableMcpServers: true, mcpServers: { servers: [] } };
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			const callArgs = MockedChatAnthropic.mock.calls[0][0]!;
+			expect(callArgs.invocationKwargs).toEqual({});
+			expect(callArgs).not.toHaveProperty('betas');
+		});
+
+		it('should set mcp_servers in invocationKwargs and betas when servers are configured', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-6';
+				if (paramName === 'options')
+					return {
+						enableMcpServers: true,
+						mcpServers: {
+							servers: [
+								{
+									name: 'my-server',
+									url: 'https://mcp.example.com/sse',
+									authorizationToken: 'secret-token',
+								},
+							],
+						},
+					};
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					invocationKwargs: {
+						mcp_servers: [
+							{
+								type: 'url',
+								name: 'my-server',
+								url: 'https://mcp.example.com/sse',
+								authorization_token: 'secret-token',
+							},
+						],
+					},
+					betas: ['mcp-client-2025-11-20'],
+				}),
+			);
+		});
+
+		it('should omit authorization_token when not provided', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-6';
+				if (paramName === 'options')
+					return {
+						enableMcpServers: true,
+						mcpServers: {
+							servers: [{ name: 'public-server', url: 'https://mcp.example.com/sse' }],
+						},
+					};
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			const callArgs = MockedChatAnthropic.mock.calls[0][0]!;
+			const mcpServers = (callArgs.invocationKwargs as Record<string, unknown>)
+				.mcp_servers as Array<Record<string, unknown>>;
+			expect(mcpServers[0]).not.toHaveProperty('authorization_token');
+		});
+
+		it('should handle multiple MCP servers', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-6';
+				if (paramName === 'options')
+					return {
+						enableMcpServers: true,
+						mcpServers: {
+							servers: [
+								{ name: 'server-a', url: 'https://a.example.com/sse', authorizationToken: 'tok-a' },
+								{ name: 'server-b', url: 'https://b.example.com/sse' },
+							],
+						},
+					};
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					invocationKwargs: {
+						mcp_servers: [
+							{
+								type: 'url',
+								name: 'server-a',
+								url: 'https://a.example.com/sse',
+								authorization_token: 'tok-a',
+							},
+							{
+								type: 'url',
+								name: 'server-b',
+								url: 'https://b.example.com/sse',
+							},
+						],
+					},
+					betas: ['mcp-client-2025-11-20'],
+				}),
+			);
+		});
+
+		it('should combine mcp_servers with thinking invocationKwargs', async () => {
+			const mockContext = setupMockContext({ typeVersion: 1.5 });
+
+			mockContext.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-6';
+				if (paramName === 'options')
+					return {
+						thinkingMode: 'adaptive',
+						effort: 'high',
+						enableMcpServers: true,
+						mcpServers: {
+							servers: [{ name: 'my-server', url: 'https://mcp.example.com/sse' }],
+						},
+					};
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					invocationKwargs: {
+						thinking: { type: 'adaptive' },
+						output_config: { effort: 'high' },
+						max_tokens: 4096,
+						top_k: undefined,
+						top_p: undefined,
+						temperature: undefined,
+						mcp_servers: [
+							{
+								type: 'url',
+								name: 'my-server',
+								url: 'https://mcp.example.com/sse',
+							},
+						],
+					},
+					betas: ['mcp-client-2025-11-20'],
+				}),
+			);
+		});
+	});
+
 	describe('methods', () => {
 		it('should have searchModels method', () => {
 			expect(lmChatAnthropic.methods).toEqual({

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/text/message.operation.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/text/message.operation.test.ts
@@ -1,0 +1,238 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mockDeep } from 'vitest-mock-extended';
+
+import { execute } from './message.operation';
+
+const apiRequestMock = vi.hoisted(() => vi.fn());
+
+vi.mock('../../transport', () => ({
+	apiRequest: apiRequestMock,
+}));
+
+vi.mock('@utils/helpers', () => ({
+	getConnectedTools: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('n8n-workflow', async () => ({
+	...(await vi.importActual('n8n-workflow')),
+	accumulateTokenUsage: vi.fn(),
+	updateDisplayOptions: vi.fn((_, props) => props),
+}));
+
+const baseResponse = {
+	stop_reason: 'end_turn',
+	content: [{ type: 'text', text: 'Hello' }],
+	usage: { input_tokens: 10, output_tokens: 5 },
+};
+
+describe('message.operation', () => {
+	const executeFunctionsMock = mockDeep<IExecuteFunctions>();
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		executeFunctionsMock.getNodeInputs.mockReturnValue([]);
+		executeFunctionsMock.getExecutionCancelSignal.mockReturnValue(undefined);
+		apiRequestMock.mockResolvedValue(baseResponse);
+	});
+
+	function mockGetNodeParameter(overrides: Record<string, unknown> = {}) {
+		const defaults: Record<string, unknown> = {
+			modelId: 'claude-sonnet-4-5',
+			'messages.values': [{ role: 'user', content: 'Hello' }],
+			addAttachments: false,
+			simplify: true,
+			options: {},
+			'options.maxToolsIterations': 15,
+			...overrides,
+		};
+
+		executeFunctionsMock.getNodeParameter.mockImplementation(
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			(param: string, _i: unknown, defaultValue?: unknown): any =>
+				param in defaults ? defaults[param] : defaultValue,
+		);
+	}
+
+	type CallBody = {
+		body: {
+			mcp_servers?: Array<Record<string, unknown>>;
+			tools?: Array<Record<string, unknown>>;
+		};
+		enableAnthropicBetas?: Record<string, unknown>;
+	};
+
+	function getFirstCallParams(): CallBody {
+		return apiRequestMock.mock.calls[0][2] as CallBody;
+	}
+
+	describe('MCP Servers', () => {
+		it('should not include mcp_servers when toggle is off', async () => {
+			mockGetNodeParameter({
+				options: { enableMcpToolset: false },
+			});
+
+			await execute.call(executeFunctionsMock, 0);
+
+			const params = getFirstCallParams();
+			expect(params.body.mcp_servers).toBeUndefined();
+			expect(params.enableAnthropicBetas).toMatchObject({ mcpClient: false });
+		});
+
+		it('should not inject mcp_client entries into tools when toggle is off', async () => {
+			mockGetNodeParameter({
+				options: {
+					enableMcpToolset: false,
+					mcpServers: {
+						values: [{ name: 'srv', url: 'https://mcp.example.com/mcp', authorizationToken: '' }],
+					},
+				},
+			});
+
+			await execute.call(executeFunctionsMock, 0);
+
+			const params = getFirstCallParams();
+			const mcpToolsets = (params.body.tools ?? []).filter((t) => t.name === 'mcp_client');
+			expect(mcpToolsets).toHaveLength(0);
+		});
+
+		it('should include mcp_servers array when toggle is on', async () => {
+			mockGetNodeParameter({
+				options: {
+					enableMcpToolset: true,
+					mcpServers: {
+						values: [
+							{
+								name: 'example_mcp',
+								url: 'https://mcp.example.com/mcp',
+								authorizationToken: 'tok_abc',
+							},
+						],
+					},
+				},
+			});
+
+			await execute.call(executeFunctionsMock, 0);
+
+			const params = getFirstCallParams();
+			expect(params.body.mcp_servers).toEqual([
+				{
+					type: 'url',
+					name: 'example_mcp',
+					url: 'https://mcp.example.com/mcp',
+					authorization_token: 'tok_abc',
+				},
+			]);
+		});
+
+		it('should inject one mcp_client per server into the tools array', async () => {
+			mockGetNodeParameter({
+				options: {
+					enableMcpToolset: true,
+					mcpServers: {
+						values: [
+							{ name: 'example_mcp', url: 'https://mcp.example.com/mcp', authorizationToken: '' },
+						],
+					},
+				},
+			});
+
+			await execute.call(executeFunctionsMock, 0);
+
+			const params = getFirstCallParams();
+			expect(params.body.tools).toEqual(
+				expect.arrayContaining([
+					{ name: 'mcp_client', type: 'mcp_client_20251120', mcp_server_name: 'example_mcp' },
+				]),
+			);
+		});
+
+		it('should inject one mcp_client per server when multiple servers are configured', async () => {
+			mockGetNodeParameter({
+				options: {
+					enableMcpToolset: true,
+					mcpServers: {
+						values: [
+							{ name: 'server-a', url: 'https://mcp.example1.com/sse', authorizationToken: '' },
+							{ name: 'server-b', url: 'https://mcp.example2.com/sse', authorizationToken: 'tok' },
+						],
+					},
+				},
+			});
+
+			await execute.call(executeFunctionsMock, 0);
+
+			const params = getFirstCallParams();
+			expect(params.body.mcp_servers).toHaveLength(2);
+			expect(params.body.tools).toEqual(
+				expect.arrayContaining([
+					{ name: 'mcp_client', type: 'mcp_client_20251120', mcp_server_name: 'server-a' },
+					{ name: 'mcp_client', type: 'mcp_client_20251120', mcp_server_name: 'server-b' },
+				]),
+			);
+		});
+
+		it('should omit authorization_token when left empty', async () => {
+			mockGetNodeParameter({
+				options: {
+					enableMcpToolset: true,
+					mcpServers: {
+						values: [
+							{
+								name: 'public-server',
+								url: 'https://mcp.example.com/mcp',
+								authorizationToken: '',
+							},
+						],
+					},
+				},
+			});
+
+			await execute.call(executeFunctionsMock, 0);
+
+			const params = getFirstCallParams();
+			expect(params.body.mcp_servers![0]).not.toHaveProperty('authorization_token');
+			expect(params.body.mcp_servers![0]).toMatchObject({
+				type: 'url',
+				name: 'public-server',
+				url: 'https://mcp.example.com/mcp',
+			});
+		});
+
+		it('should include mcpClient beta when toggle is on', async () => {
+			mockGetNodeParameter({
+				options: {
+					enableMcpToolset: true,
+					mcpServers: {
+						values: [{ name: 'srv', url: 'https://mcp.example.com/mcp', authorizationToken: '' }],
+					},
+				},
+			});
+
+			await execute.call(executeFunctionsMock, 0);
+
+			const params = getFirstCallParams();
+			expect(params.enableAnthropicBetas).toMatchObject({ mcpClient: true });
+		});
+
+		it('should work alongside other beta flags (e.g. codeExecution) when both are enabled', async () => {
+			mockGetNodeParameter({
+				options: {
+					codeExecution: true,
+					enableMcpToolset: true,
+					mcpServers: {
+						values: [{ name: 'srv', url: 'https://mcp.example.com/mcp', authorizationToken: '' }],
+					},
+				},
+			});
+
+			await execute.call(executeFunctionsMock, 0);
+
+			const params = getFirstCallParams();
+			expect(params.enableAnthropicBetas).toMatchObject({
+				codeExecution: true,
+				mcpClient: true,
+			});
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/text/message.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/text/message.operation.ts
@@ -13,6 +13,7 @@ import { getConnectedTools } from '@utils/helpers';
 import type {
 	Content,
 	File,
+	McpServer,
 	Message,
 	MessagesResponse,
 	Tool as AnthropicTool,
@@ -268,6 +269,78 @@ const properties: INodeProperties[] = [
 					numberPrecision: 0,
 				},
 			},
+			{
+				displayName: 'Enable MCP Toolset (Beta)',
+				name: 'enableMcpToolset',
+				type: 'boolean',
+				default: false,
+				description:
+					'Whether to connect remote MCP servers. Anthropic opens the connection directly — the MCP server must be publicly reachable. ' +
+					'<a href="https://docs.anthropic.com/en/docs/agents-and-tools/mcp-connector" target="_blank">Learn more</a>.',
+			},
+			{
+				displayName: 'MCP Servers',
+				name: 'mcpServers',
+				type: 'fixedCollection',
+				typeOptions: { multipleValues: true },
+				default: {
+					values: [
+						{
+							name: 'Example MCP',
+							type: 'url',
+							url: 'http://...',
+							token: 'Leave empty if not needed',
+						},
+					],
+				},
+				displayOptions: { show: { enableMcpToolset: [true] } },
+				options: [
+					{
+						name: 'values',
+						displayName: 'Server',
+						values: [
+							{
+								displayName: 'Name',
+								name: 'name',
+								type: 'string',
+								default: '',
+								required: true,
+								description: 'Unique identifier for this MCP server within the request',
+							},
+							{
+								displayName: 'Type',
+								name: 'type',
+								type: 'options',
+								default: 'url',
+								description: 'Currently only "URL" is supported',
+								options: [
+									{
+										name: 'URL(s)',
+										value: 'url',
+									},
+								],
+							},
+							{
+								displayName: 'URL',
+								name: 'url',
+								type: 'string',
+								default: '',
+								required: true,
+								description: 'The URL of the MCP server. Must start with https://.',
+							},
+							{
+								displayName: 'Authorization Token',
+								name: 'authorizationToken',
+								type: 'string',
+								typeOptions: { password: true },
+								default: '',
+								description:
+									'OAuth authorization token if required by the MCP server. See MCP specification.',
+							},
+						],
+					},
+				],
+			},
 		],
 	},
 ];
@@ -293,6 +366,15 @@ interface MessageOptions {
 	temperature?: number;
 	topP?: number;
 	topK?: number;
+	enableMcpToolset?: boolean;
+	mcpServers?: {
+		values?: Array<{
+			name: string;
+			type: string;
+			url: string;
+			authorizationToken?: string;
+		}>;
+	};
 }
 
 function getFileTypeOrThrow(this: IExecuteFunctions, mimeType?: string): 'image' | 'document' {
@@ -317,7 +399,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 	const simplify = this.getNodeParameter('simplify', i, true) as boolean;
 	const options = this.getNodeParameter('options', i, {}) as MessageOptions;
 
-	const { tools, connectedTools } = await getTools.call(this, options);
+	const { tools, connectedTools, mcpServers } = await getTools.call(this, options);
 
 	if (addAttachments) {
 		if (options.codeExecution) {
@@ -336,11 +418,15 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 		temperature: options.temperature,
 		top_p: options.topP,
 		top_k: options.topK,
+		mcp_servers: mcpServers ?? undefined,
 	};
 
 	let response = (await apiRequest.call(this, 'POST', '/v1/messages', {
 		body,
-		enableAnthropicBetas: { codeExecution: options.codeExecution },
+		enableAnthropicBetas: {
+			codeExecution: options.codeExecution,
+			mcpClient: options.enableMcpToolset,
+		},
 	})) as MessagesResponse;
 
 	const captureUsage = () => {
@@ -391,7 +477,10 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 
 		response = (await apiRequest.call(this, 'POST', '/v1/messages', {
 			body,
-			enableAnthropicBetas: { codeExecution: options.codeExecution },
+			enableAnthropicBetas: {
+				codeExecution: options.codeExecution,
+				mcpClient: options.enableMcpToolset,
+			},
 		})) as MessagesResponse;
 
 		captureUsage();
@@ -426,6 +515,7 @@ export async function execute(this: IExecuteFunctions, i: number): Promise<INode
 
 async function getTools(this: IExecuteFunctions, options: MessageOptions) {
 	let connectedTools: Tool[] = [];
+	let mcpServers: McpServer[] | undefined;
 	const nodeInputs = this.getNodeInputs();
 	// the node can be used as a tool, in this case there won't be any connected tools
 	if (nodeInputs.some((i) => i.type === 'ai_tool')) {
@@ -462,7 +552,31 @@ async function getTools(this: IExecuteFunctions, options: MessageOptions) {
 		});
 	}
 
-	return { tools, connectedTools };
+	if (options.enableMcpToolset) {
+		const mcpServerValues = options.mcpServers?.values ?? [];
+		mcpServers = mcpServerValues.map((server) => {
+			const entry: {
+				type: string;
+				name: string;
+				url: string;
+				authorization_token?: string;
+			} = {
+				type: 'url',
+				name: server.name,
+				url: server.url,
+			};
+			if (server.authorizationToken) {
+				entry.authorization_token = server.authorizationToken;
+			}
+			return entry;
+		});
+
+		for (const server of mcpServerValues) {
+			tools.push({ type: 'mcp_client_20251120', name: 'mcp_client', mcp_server_name: server.name });
+		}
+	}
+
+	return { tools, connectedTools, mcpServers };
 }
 
 async function addCodeAttachmentsToMessages(

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/helpers/interfaces.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/helpers/interfaces.ts
@@ -77,7 +77,19 @@ export type Tool =
 	| {
 			type: 'code_execution_20250522';
 			name: 'code_execution';
+	  }
+	| {
+			type: 'mcp_client_20251120';
+			name: 'mcp_client';
+			mcp_server_name: string;
 	  };
+
+export type McpServer = {
+	name: string;
+	type: string;
+	url: string;
+	authorizationToken?: string;
+};
 
 export interface MessagesResponse {
 	content: Content[];

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/transport/index.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/transport/index.test.ts
@@ -165,6 +165,50 @@ describe('Anthropic transport', () => {
 		);
 	});
 
+	it('should add mcp-client-2025-11-20 beta header when mcpClient is true', async () => {
+		executeFunctionsMock.getCredentials.mockResolvedValue({});
+
+		await apiRequest.call(executeFunctionsMock, 'POST', '/v1/messages', {
+			body: {},
+			enableAnthropicBetas: { mcpClient: true },
+		});
+
+		expect(executeFunctionsMock.helpers.httpRequestWithAuthentication).toHaveBeenCalledWith(
+			'anthropicApi',
+			{
+				method: 'POST',
+				url: 'https://api.anthropic.com/v1/messages',
+				json: true,
+				body: {},
+				headers: {
+					'anthropic-version': '2023-06-01',
+					'anthropic-beta': 'files-api-2025-04-14,mcp-client-2025-11-20',
+				},
+			},
+		);
+	});
+
+	it('should include mcp-client and code-execution betas together', async () => {
+		executeFunctionsMock.getCredentials.mockResolvedValue({});
+
+		await apiRequest.call(executeFunctionsMock, 'POST', '/v1/messages', {
+			enableAnthropicBetas: { codeExecution: true, mcpClient: true },
+		});
+
+		expect(executeFunctionsMock.helpers.httpRequestWithAuthentication).toHaveBeenCalledWith(
+			'anthropicApi',
+			{
+				method: 'POST',
+				url: 'https://api.anthropic.com/v1/messages',
+				json: true,
+				headers: {
+					'anthropic-version': '2023-06-01',
+					'anthropic-beta': 'files-api-2025-04-14,code-execution-2025-05-22,mcp-client-2025-11-20',
+				},
+			},
+		);
+	});
+
 	it('should add custom header when header toggle is enabled', async () => {
 		executeFunctionsMock.getCredentials.mockResolvedValue({
 			header: true,

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/transport/index.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/transport/index.ts
@@ -14,6 +14,7 @@ type RequestParameters = {
 	enableAnthropicBetas?: {
 		promptTools?: boolean;
 		codeExecution?: boolean;
+		mcpClient?: boolean;
 	};
 };
 
@@ -36,6 +37,10 @@ export async function apiRequest(
 
 	if (parameters?.enableAnthropicBetas?.codeExecution) {
 		betas.push('code-execution-2025-05-22');
+	}
+
+	if (parameters?.enableAnthropicBetas?.mcpClient) {
+		betas.push('mcp-client-2025-11-20');
 	}
 
 	const requestHeaders: IDataObject = {


### PR DESCRIPTION
## Summary
Basic implementation to support Anthropic MCP connector. (https://platform.claude.com/docs/en/agents-and-tools/mcp-connector)

> Claude's Model Context Protocol (MCP) connector feature enables you to connect to remote MCP servers directly from the Messages API without a separate MCP client.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
