### PR TITLE
feat(editor): Land users to instance AI on root if the module is enabled (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/init.ts
+++ b/packages/frontend/editor-ui/src/app/init.ts
@@ -267,7 +267,7 @@ function registerAuthenticationHooks() {
 		});
 		postHogStore.init(user.featureFlags);
 		npsSurveyStore.setupNpsSurveyOnLogin(user.id, user.settings);
-		void settingsStore.getModuleSettings();
+		await settingsStore.getModuleSettings();
 		void bannersStore.loadDynamicBanners();
 	});
 

--- a/packages/frontend/editor-ui/src/app/router.test.ts
+++ b/packages/frontend/editor-ui/src/app/router.test.ts
@@ -268,7 +268,8 @@ describe('router', () => {
 			const next = ((arg?: unknown) => {
 				nextArg = arg;
 			}) as Parameters<typeof beforeEnter>[2];
-			beforeEnter(
+			beforeEnter.call(
+				undefined,
 				{} as Parameters<typeof beforeEnter>[0],
 				{} as Parameters<typeof beforeEnter>[1],
 				next,

--- a/packages/frontend/editor-ui/src/app/router.test.ts
+++ b/packages/frontend/editor-ui/src/app/router.test.ts
@@ -2,6 +2,7 @@ import { createPinia, setActivePinia } from 'pinia';
 import { createComponentRenderer } from '@/__tests__/render';
 import router, { routes } from '@/app/router';
 import { VIEWS } from '@/app/constants';
+import { INSTANCE_AI_VIEW } from '@/features/ai/instanceAi/constants';
 import { RESOURCE_CENTER_EXPERIMENT } from '@/app/constants/experiments';
 import { setupServer } from '@/__tests__/server';
 import { useSettingsStore } from '@/app/stores/settings.store';
@@ -243,6 +244,74 @@ describe('router', () => {
 				waitForFeatureFlagsSpy.mockRestore();
 				hasPendingFeatureFlagsSpy.mockRestore();
 			}
+		});
+	});
+
+	describe('root / redirect', () => {
+		// The instance-ai route is registered dynamically by its module, so we can't
+		// drive this through `router.push('/')` in the unit test environment.
+		// Drive the `/` route's beforeEnter directly with a captured `next` instead.
+		const instanceAiModuleSettings = {
+			enabled: true,
+			localGatewayDisabled: false,
+			proxyEnabled: false,
+			cloudManaged: false,
+		};
+
+		const runRootRedirect = () => {
+			const rootRoute = routes.find((r) => r.path === '/');
+			const beforeEnter = rootRoute?.beforeEnter;
+			if (typeof beforeEnter !== 'function') {
+				throw new Error('Expected `/` route to define a beforeEnter guard');
+			}
+			let nextArg: unknown;
+			const next = ((arg?: unknown) => {
+				nextArg = arg;
+			}) as Parameters<typeof beforeEnter>[2];
+			beforeEnter(
+				{} as Parameters<typeof beforeEnter>[0],
+				{} as Parameters<typeof beforeEnter>[1],
+				next,
+			);
+			return nextArg;
+		};
+
+		beforeEach(() => {
+			settingsStore.settings.activeModules = [];
+			settingsStore.moduleSettings = {};
+			useRBACStore().setGlobalScopes([]);
+		});
+
+		test('redirects to /instance-ai when module is active, enabled, and user has instanceAi:message', () => {
+			settingsStore.settings.activeModules = ['instance-ai'];
+			settingsStore.moduleSettings = { 'instance-ai': { ...instanceAiModuleSettings } };
+			useRBACStore().setGlobalScopes(['instanceAi:message']);
+
+			expect(runRootRedirect()).toEqual({ name: INSTANCE_AI_VIEW });
+		});
+
+		test('falls back to /home/workflows when admin has disabled the module', () => {
+			settingsStore.settings.activeModules = ['instance-ai'];
+			settingsStore.moduleSettings = {
+				'instance-ai': { ...instanceAiModuleSettings, enabled: false },
+			};
+			useRBACStore().setGlobalScopes(['instanceAi:message']);
+
+			expect(runRootRedirect()).toBe('/home/workflows');
+		});
+
+		test('falls back to /home/workflows when user lacks instanceAi:message scope', () => {
+			settingsStore.settings.activeModules = ['instance-ai'];
+			settingsStore.moduleSettings = { 'instance-ai': { ...instanceAiModuleSettings } };
+			useRBACStore().setGlobalScopes([]);
+
+			expect(runRootRedirect()).toBe('/home/workflows');
+		});
+
+		test('falls back to /home/workflows when the module is not active', () => {
+			useRBACStore().setGlobalScopes(['instanceAi:message']);
+
+			expect(runRootRedirect()).toBe('/home/workflows');
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/router.ts
+++ b/packages/frontend/editor-ui/src/app/router.ts
@@ -25,6 +25,8 @@ import { usePostHog } from '@/app/stores/posthog.store';
 import { RESOURCE_CENTER_EXPERIMENT, TEMPLATE_SETUP_EXPERIENCE } from '@/app/constants/experiments';
 import { useDynamicCredentials } from '@/features/resolvers/composables/useDynamicCredentials';
 import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
+import { INSTANCE_AI_VIEW } from '@/features/ai/instanceAi/constants';
+import { canMessageInstanceAi } from '@/features/ai/instanceAi/instanceAiPermissions';
 
 const ChangePasswordView = async () =>
 	await import('@/features/core/auth/views/ChangePasswordView.vue');
@@ -165,7 +167,21 @@ const allowResourceCenterRoute = (
 export const routes: RouteRecordRaw[] = [
 	{
 		path: '/',
-		redirect: '/home/workflows',
+		// Stub component — beforeEnter always navigates away, so it is never rendered.
+		// Required because vue-router resolves `redirect` before guards run, and we need
+		// stores populated by `initializeCore` to decide where to send the user.
+		component: { render: () => null },
+		beforeEnter: (_to, _from, next) => {
+			const settingsStore = useSettingsStore();
+			if (
+				settingsStore.isModuleActive('instance-ai') &&
+				settingsStore.moduleSettings['instance-ai']?.enabled !== false &&
+				canMessageInstanceAi()
+			) {
+				return next({ name: INSTANCE_AI_VIEW });
+			}
+			next('/home/workflows');
+		},
 		meta: {
 			middleware: ['authenticated'],
 		},

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAiPermissions.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAiPermissions.ts
@@ -4,3 +4,8 @@ import { hasPermission } from '@/app/utils/rbac/permissions';
 export function canManageInstanceAi(): boolean {
 	return hasPermission(['rbac'], { rbac: { scope: 'instanceAi:manage' } });
 }
+
+/** Sending messages to Instance AI (and reaching the chat view) requires this scope. */
+export function canMessageInstanceAi(): boolean {
+	return hasPermission(['rbac'], { rbac: { scope: 'instanceAi:message' } });
+}


### PR DESCRIPTION
## Summary

Instead of landing `/` redirect on `/home/workflows` land the users to `/instance-ai` if the feature is enabled and user can access it.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-214

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
