### PR TITLE
feat(core): Add encrypted secureArtifacts slot to IExecutionContext (no-changelog)

### DIFF
--- a/packages/core/src/execution-engine/__tests__/execution-context.service.test.ts
+++ b/packages/core/src/execution-engine/__tests__/execution-context.service.test.ts
@@ -6,6 +6,7 @@ import type {
 	IExecutionContext,
 	INode,
 	INodeExecutionData,
+	ISecureArtifacts,
 	PlaintextExecutionContext,
 	Workflow,
 } from 'n8n-workflow';
@@ -19,11 +20,32 @@ import { ExecutionContextService } from '../execution-context.service';
 jest.mock('n8n-workflow', () => ({
 	...jest.requireActual('n8n-workflow'),
 	toCredentialContext: jest.fn((data: string) => JSON.parse(data)),
+	toSecureArtifacts: jest.fn((data: string) => JSON.parse(data)),
 	toExecutionContextEstablishmentHookParameter: jest.fn(),
 }));
 
-const { toCredentialContext, toExecutionContextEstablishmentHookParameter } =
+const { toCredentialContext, toSecureArtifacts, toExecutionContextEstablishmentHookParameter } =
 	jest.requireMock('n8n-workflow');
+
+const sampleArtifacts: ISecureArtifacts = {
+	version: 1,
+	artifacts: {
+		Webhook: [
+			{
+				'headers.authorization': 'Bearer A',
+				'body.count': 42,
+				'body.flag': true,
+				'body.maybe': null,
+			},
+			{
+				'headers.authorization': 'Bearer B',
+				'body.nested': { id: 'x', tags: ['a', 'b'] },
+			},
+		],
+		OtherTrigger: [{ 'a.b': ['v1', 'v2'] }],
+	},
+	metadata: { source: 'stripper' },
+};
 
 describe('ExecutionContextService', () => {
 	let service: ExecutionContextService;
@@ -97,6 +119,79 @@ describe('ExecutionContextService', () => {
 				credentials: parsedCreds,
 			});
 		});
+
+		it('should leave secureArtifacts undefined when not present', async () => {
+			const context: IExecutionContext = {
+				version: 1,
+				establishedAt: Date.now(),
+				source: 'manual',
+			};
+
+			const result = await service.decryptExecutionContext(context);
+
+			expect(result.secureArtifacts).toBeUndefined();
+			expect(mockCipher.decryptV2).not.toHaveBeenCalled();
+			expect(toSecureArtifacts).not.toHaveBeenCalled();
+		});
+
+		it('should decrypt secureArtifacts when present', async () => {
+			const encryptedArtifacts = 'encrypted_artifacts';
+			const decryptedArtifacts = JSON.stringify(sampleArtifacts);
+
+			const context: IExecutionContext = {
+				version: 1,
+				establishedAt: Date.now(),
+				source: 'webhook',
+				secureArtifacts: encryptedArtifacts,
+			};
+
+			mockCipher.decryptV2.mockResolvedValue(decryptedArtifacts);
+			toSecureArtifacts.mockReturnValue(sampleArtifacts);
+
+			const result = await service.decryptExecutionContext(context);
+
+			expect(mockCipher.decryptV2).toHaveBeenCalledWith(encryptedArtifacts);
+			expect(toSecureArtifacts).toHaveBeenCalledWith(decryptedArtifacts);
+			expect(result).toEqual({
+				...context,
+				credentials: undefined,
+				secureArtifacts: sampleArtifacts,
+			});
+		});
+
+		it('should decrypt both credentials and secureArtifacts when both present', async () => {
+			const encryptedCreds = 'encrypted_creds';
+			const encryptedArtifacts = 'encrypted_artifacts';
+			const decryptedCreds = '{"version":1,"identity":"token"}';
+			const parsedCreds = { version: 1, identity: 'token' };
+			const decryptedArtifacts = JSON.stringify(sampleArtifacts);
+
+			const context: IExecutionContext = {
+				version: 1,
+				establishedAt: Date.now(),
+				source: 'webhook',
+				credentials: encryptedCreds,
+				secureArtifacts: encryptedArtifacts,
+			};
+
+			mockCipher.decryptV2.mockImplementation(async (data: string) => {
+				if (data === encryptedCreds) return decryptedCreds;
+				if (data === encryptedArtifacts) return decryptedArtifacts;
+				throw new Error(`Unexpected ciphertext: ${data}`);
+			});
+			toCredentialContext.mockReturnValue(parsedCreds);
+			toSecureArtifacts.mockReturnValue(sampleArtifacts);
+
+			const result = await service.decryptExecutionContext(context);
+
+			expect(mockCipher.decryptV2).toHaveBeenCalledWith(encryptedCreds);
+			expect(mockCipher.decryptV2).toHaveBeenCalledWith(encryptedArtifacts);
+			expect(result).toEqual({
+				...context,
+				credentials: parsedCreds,
+				secureArtifacts: sampleArtifacts,
+			});
+		});
 	});
 
 	describe('encryptExecutionContext()', () => {
@@ -136,6 +231,95 @@ describe('ExecutionContextService', () => {
 				...context,
 				credentials: encryptedCreds,
 			});
+		});
+
+		it('should leave secureArtifacts undefined when not present', async () => {
+			const context: PlaintextExecutionContext = {
+				version: 1,
+				establishedAt: Date.now(),
+				source: 'manual',
+			};
+
+			const result = await service.encryptExecutionContext(context);
+
+			expect(result.secureArtifacts).toBeUndefined();
+			expect(mockCipher.encryptV2).not.toHaveBeenCalled();
+		});
+
+		it('should encrypt secureArtifacts when present', async () => {
+			const encryptedArtifacts = 'encrypted_artifacts';
+
+			const context: PlaintextExecutionContext = {
+				version: 1,
+				establishedAt: Date.now(),
+				source: 'webhook',
+				secureArtifacts: sampleArtifacts,
+			};
+
+			mockCipher.encryptV2.mockResolvedValue(encryptedArtifacts);
+
+			const result = await service.encryptExecutionContext(context);
+
+			expect(mockCipher.encryptV2).toHaveBeenCalledWith(sampleArtifacts);
+			expect(result).toEqual({
+				...context,
+				credentials: undefined,
+				secureArtifacts: encryptedArtifacts,
+			});
+		});
+
+		it('should encrypt both credentials and secureArtifacts when both present', async () => {
+			const plaintextCreds = { version: 1 as const, identity: 'token' };
+			const encryptedCreds = 'encrypted_creds';
+			const encryptedArtifacts = 'encrypted_artifacts';
+
+			const context: PlaintextExecutionContext = {
+				version: 1,
+				establishedAt: Date.now(),
+				source: 'webhook',
+				credentials: plaintextCreds,
+				secureArtifacts: sampleArtifacts,
+			};
+
+			mockCipher.encryptV2.mockImplementation(async (data: unknown) => {
+				if (data === plaintextCreds) return encryptedCreds;
+				if (data === sampleArtifacts) return encryptedArtifacts;
+				throw new Error('Unexpected encryption input');
+			});
+
+			const result = await service.encryptExecutionContext(context);
+
+			expect(result).toEqual({
+				...context,
+				credentials: encryptedCreds,
+				secureArtifacts: encryptedArtifacts,
+			});
+		});
+	});
+
+	describe('encrypt → decrypt round-trip', () => {
+		it('should preserve secureArtifacts through a full round-trip', async () => {
+			// JSON-stringify on encrypt, identity on decrypt — simulates a symmetric cipher
+			// on the JSON serialization that Cipher.encryptV2/decryptV2 perform around the payload.
+			mockCipher.encryptV2.mockImplementation(async (data: unknown) => JSON.stringify(data));
+			mockCipher.decryptV2.mockImplementation(async (data: string) => data);
+
+			// Use the real toSecureArtifacts so the round-trip exercises actual schema parsing.
+			const realToSecureArtifacts = jest.requireActual('n8n-workflow').toSecureArtifacts;
+			toSecureArtifacts.mockImplementation(realToSecureArtifacts);
+
+			const plaintext: PlaintextExecutionContext = {
+				version: 1,
+				establishedAt: 12345,
+				source: 'webhook',
+				secureArtifacts: sampleArtifacts,
+			};
+
+			const encrypted = await service.encryptExecutionContext(plaintext);
+			expect(typeof encrypted.secureArtifacts).toBe('string');
+
+			const decrypted = await service.decryptExecutionContext(encrypted);
+			expect(decrypted.secureArtifacts).toEqual(sampleArtifacts);
 		});
 	});
 

--- a/packages/core/src/execution-engine/execution-context.service.ts
+++ b/packages/core/src/execution-engine/execution-context.service.ts
@@ -4,9 +4,11 @@ import {
 	IExecuteData,
 	IExecutionContext,
 	INodeExecutionData,
+	ISecureArtifacts,
 	PlaintextExecutionContext,
 	toCredentialContext,
 	toExecutionContextEstablishmentHookParameter,
+	toSecureArtifacts,
 	Workflow,
 } from 'n8n-workflow';
 
@@ -29,9 +31,15 @@ export class ExecutionContextService {
 			const decrypted = await this.cipher.decryptV2(context.credentials);
 			credentials = toCredentialContext(decrypted);
 		}
+		let secureArtifacts: ISecureArtifacts | undefined = undefined;
+		if (context.secureArtifacts) {
+			const decrypted = await this.cipher.decryptV2(context.secureArtifacts);
+			secureArtifacts = toSecureArtifacts(decrypted);
+		}
 		return {
 			...context,
 			credentials,
+			secureArtifacts,
 		};
 	}
 
@@ -40,9 +48,14 @@ export class ExecutionContextService {
 		if (context.credentials) {
 			credentials = await this.cipher.encryptV2(context.credentials);
 		}
+		let secureArtifacts = undefined;
+		if (context.secureArtifacts) {
+			secureArtifacts = await this.cipher.encryptV2(context.secureArtifacts);
+		}
 		return {
 			...context,
 			credentials,
+			secureArtifacts,
 		};
 	}
 

--- a/packages/workflow/src/execution-context.ts
+++ b/packages/workflow/src/execution-context.ts
@@ -237,7 +237,10 @@ export type IExecutionContext = z.output<typeof ExecutionContextSchema>;
  * };
  * ```
  */
-export type PlaintextExecutionContext = Omit<IExecutionContext, 'credentials' | 'secureArtifacts'> & {
+export type PlaintextExecutionContext = Omit<
+	IExecutionContext,
+	'credentials' | 'secureArtifacts'
+> & {
 	credentials?: ICredentialContext;
 	secureArtifacts?: ISecureArtifacts;
 };

--- a/packages/workflow/src/execution-context.ts
+++ b/packages/workflow/src/execution-context.ts
@@ -2,6 +2,64 @@ import z, { type ZodType } from 'zod/v4';
 
 import { jsonParse } from './utils';
 
+/**
+ * JSON-shaped value type — what survives an encrypt → JSON serialize →
+ * decrypt → JSON parse round-trip. Used as the leaf type for secure artifacts.
+ */
+type JsonPrimitive = string | number | boolean | null;
+type JsonValue = JsonPrimitive | { [key: string]: JsonValue } | JsonValue[];
+
+const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
+	z.union([
+		z.string(),
+		z.number(),
+		z.boolean(),
+		z.null(),
+		z.record(z.string(), JsonValueSchema),
+		z.array(JsonValueSchema),
+	]),
+);
+
+const SecureArtifactsSchemaV1 = z.object({
+	version: z.literal(1),
+
+	/**
+	 * Artifacts produced by context-establishment hooks (e.g. a trigger
+	 * stripper) and consumed by node backends later in the execution.
+	 *
+	 * - Outer key: source node name.
+	 * - Inner array is parallel to the trigger items array — index `i`
+	 *   corresponds to `triggerItems[i]`.
+	 * - Each per-item map is keyed by the extraction path; values are the
+	 *   leaf data extracted from that item.
+	 */
+	artifacts: z.record(z.string(), z.array(z.record(z.string(), JsonValueSchema))),
+
+	/**
+	 * Optional metadata produced by the hook (e.g. provenance, hook id).
+	 */
+	metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type ISecureArtifactsV1 = z.output<typeof SecureArtifactsSchemaV1>;
+
+export const SecureArtifactsSchema = z
+	.discriminatedUnion('version', [SecureArtifactsSchemaV1])
+	.meta({
+		title: 'ISecureArtifacts',
+	});
+
+/**
+ * Decrypted structure of the `secureArtifacts` field on the execution context.
+ * Carries values produced by context-establishment hooks (e.g. trigger
+ * stripping) for later consumption by node backends. Always encrypted as a
+ * single string when stored on `IExecutionContext`; only exists in this
+ * structured form on `PlaintextExecutionContext` during runtime.
+ *
+ * @see PlaintextExecutionContext.secureArtifacts
+ */
+export type ISecureArtifacts = z.output<typeof SecureArtifactsSchema>;
+
 const CredentialContextSchemaV1 = z.object({
 	version: z.literal(1),
 	/**
@@ -101,6 +159,18 @@ const ExecutionContextSchemaV1 = z.object({
 	}),
 
 	/**
+	 * Encrypted artifacts produced by context-establishment hooks
+	 * (e.g. a trigger stripper) for later consumption by node backends.
+	 * Always encrypted when stored, decrypted on demand by
+	 * `ExecutionContextService`.
+	 * @see ISecureArtifacts for the decrypted structure.
+	 */
+	secureArtifacts: z.string().optional().meta({
+		description:
+			'Encrypted artifacts produced by context-establishment hooks. Always encrypted when stored, decrypted on-demand by ExecutionContextService. @see ISecureArtifacts for decrypted structure',
+	}),
+
+	/**
 	 * Redaction setting captured at execution time.
 	 * Persisted so the correct redaction policy is applied when reading execution data,
 	 * regardless of any subsequent changes to the workflow setting.
@@ -167,8 +237,9 @@ export type IExecutionContext = z.output<typeof ExecutionContextSchema>;
  * };
  * ```
  */
-export type PlaintextExecutionContext = Omit<IExecutionContext, 'credentials'> & {
+export type PlaintextExecutionContext = Omit<IExecutionContext, 'credentials' | 'secureArtifacts'> & {
 	credentials?: ICredentialContext;
+	secureArtifacts?: ISecureArtifacts;
 };
 
 export const safeParse = <T extends ZodType>(value: string | object, schema: T) => {
@@ -209,4 +280,9 @@ export const toExecutionContext = (value: string | object): IExecutionContext =>
 export const toCredentialContext = (value: string | object): ICredentialContext => {
 	// here we could implement a mgiration policy for migrating old credential context versions to newer ones
 	return safeParse(value, CredentialContextSchema);
+};
+
+export const toSecureArtifacts = (value: string | object): ISecureArtifacts => {
+	// here we could implement a migration policy for migrating old secure artifacts versions to newer ones
+	return safeParse(value, SecureArtifactsSchema);
 };


### PR DESCRIPTION
## Summary

Adds an optional `secureArtifacts` slot to `IExecutionContext` and round-trips
it through `ExecutionContextService.encrypt/decrypt` using the same pattern
as the existing `credentials` field. No producers or consumers are wired up —
this is the schema + plumbing foundation for upcoming work.

### Why

Phase 2 of the secure-trigger initiative needs an encrypted slot on the
per-execution context to carry stripped trigger values from a future
context-establishment hook (the "stripper") into consumer node backends.
Because the execution context is serialized into execution state and crosses
DB boundaries during queue mode handoff and wait/resume, anything carried in
this slot must be encrypted at rest.

This PR lays the foundation only. The stripper write side and consumer-side
accessors will follow in subsequent tickets.

### Shape

The new field mirrors the `ICredentialContext` design — a versioned
discriminated-union envelope, persisted as one encrypted string:

```ts
// IExecutionContext (persisted)
secureArtifacts?: string;          // encrypted JSON of ISecureArtifacts

// PlaintextExecutionContext (runtime)
secureArtifacts?: ISecureArtifacts;

type ISecureArtifactsV1 = {
  version: 1;
  // sourceNodeName -> array parallel to triggerItems -> { path: jsonValue }
  artifacts: Record<string, Array<Record<string, JsonValue>>>;
  metadata?: Record<string, unknown>;
};
```

Per-item array layout (index `i` corresponds to `triggerItems[i]`) lets a
future stripper attach different extracted values per item. Leaf values are
validated against a recursive `JsonValue` schema (string/number/boolean/null/
object/array) — strict enough to reject non-JSON content, wide enough to
carry anything a stripper might extract from an item.

### Key implementation decisions

- **Single encrypted blob, not per-leaf encryption.** Matches the
  `credentials` pattern, keeps `Cipher.encryptV2/decryptV2` calls O(1) per
  context, and concentrates the trust boundary at one symmetric point.
- **Versioned discriminated union envelope.** Lets us add `V2` later without
  breaking persisted data.
- **`JsonValue` leaf schema** (recursive `z.lazy()`). Tightens the contract
  vs. `z.unknown()` while remaining assignable to `IDataObject[string]` for
  consumer ergonomics.
- **No schema migration.** `IExecutionContext` is already serialized as part
  of execution state for queue handoff and wait/resume; the new field is
  optional and rides along on the existing serialization path.
- **No merge logic adjustment.** `deepMerge` already handles nested records;
  revisit when a real consumer needs partial-merge semantics.

### How to test manually

This change is not user-visible — there is no UI, no API, no producer, no
consumer. Manual testing is intentionally limited:

1. Spin up a regular execution (any workflow). Existing executions must
   continue to behave identically — `secureArtifacts` stays `undefined`
   throughout encrypt/decrypt and is not present on persisted execution
   data.
2. Run with `EXECUTIONS_MODE=queue` and a manual webhook execution that
   pauses at a Wait node and resumes on a different worker. Verify the
   resume succeeds (existing `IExecutionContext` round-trip still works).

The encryption/decryption contract — including the round-trip preservation
required by the ACs — is covered by the new unit tests in
`execution-context.service.test.ts`:

- `should leave secureArtifacts undefined when not present` (decrypt + encrypt)
- `should decrypt secureArtifacts when present`
- `should encrypt secureArtifacts when present`
- `should decrypt both credentials and secureArtifacts when both present`
- `should encrypt both credentials and secureArtifacts when both present`
- `should preserve secureArtifacts through a full round-trip` — uses the
  real `toSecureArtifacts` schema parser to verify primitives, nested
  objects, and arrays are preserved exactly.

The key-rotation AC is satisfied transitively by `Cipher.encryptV2`/
`decryptV2`'s existing rotation behaviour
(`packages/core/src/encryption/__tests__/cipher.test.ts`); this change only
delegates to those primitives, so no rotation-specific test is added at this
layer.

## Related

- Linear ticket: https://linear.app/n8n/issue/IAM-616

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
