### PR TITLE
fix(core): Prevent proxy layer accumulation in ObservableObject

### DIFF
--- a/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
+++ b/packages/@n8n/task-runner/src/js-task-runner/js-task-runner.ts
@@ -2,13 +2,7 @@ import isObject from 'lodash/isObject';
 import set from 'lodash/set';
 import { DateTime, Duration, Interval } from 'luxon';
 import { getAdditionalKeys } from 'n8n-core';
-import {
-	WorkflowDataProxy,
-	Workflow,
-	ObservableObject,
-	Expression,
-	jsonStringify,
-} from 'n8n-workflow';
+import { WorkflowDataProxy, Workflow, Expression, jsonStringify } from 'n8n-workflow';
 import type {
 	CodeExecutionMode,
 	IWorkflowExecuteAdditionalData,
@@ -251,8 +245,6 @@ export class JsTaskRunner extends TaskRunner {
 			...workflowParams,
 			nodeTypes: this.nodeTypes,
 		});
-
-		workflow.staticData = ObservableObject.create(workflow.staticData);
 
 		const result =
 			settings.nodeMode === 'runOnceForAllItems'

--- a/packages/workflow/src/observable-object.ts
+++ b/packages/workflow/src/observable-object.ts
@@ -19,6 +19,7 @@ export function create(
 
 	for (const key in target) {
 		if (typeof target[key] === 'object' && target[key] !== null) {
+			if ('__dataChanged' in (target[key] as object)) continue;
 			target[key] = create(
 				target[key] as IDataObject,
 				// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing

--- a/packages/workflow/test/observable-object.test.ts
+++ b/packages/workflow/test/observable-object.test.ts
@@ -154,6 +154,20 @@ describe('ObservableObject', () => {
 		expect((testObject.a! as IDataObject).b).toEqual({ c: 2 });
 	});
 
+	test('should not stack overflow when create is called repeatedly on the same object', () => {
+		const source = { a: { b: { c: 1 } } };
+
+		for (let i = 0; i < 10_000; i++) {
+			ObservableObject.create(source);
+		}
+
+		const observable = ObservableObject.create(source);
+		expect(observable.__dataChanged).toBeFalsy();
+		((observable.a! as IDataObject).b! as IDataObject).c = 2;
+		expect(observable.__dataChanged).toBeTruthy();
+		expect(((observable.a! as IDataObject).b! as IDataObject).c).toEqual(2);
+	});
+
 	// test('xxxxxx', () => {
 	// 	const testObject = ObservableObject.create({ a: { } }, undefined, { ignoreEmptyOnFirstChild: true });
 	// 	expect(testObject.__dataChanged).toBeFalsy();


### PR DESCRIPTION
## Summary

`ObservableObject.create()` mutates its input's children in place, replacing them with Proxies. In the trigger activation flow, the same `dbWorkflow.staticData` reference is captured by closure and reused on every trigger firing. Each firing creates new `Workflow` instances via the same reference, so `ObservableObject.create` wraps already-wrapped children in another Proxy layer. After thousands of firings the nested `set` traps overflow the call stack.

This happens specifically with Schedule Trigger node, which stores the recurrence rules in the static data.

The fix makes `ObservableObject.create` idempotent by skipping children that are already observed (detected via the `__dataChanged` marker). Also removes a redundant double-wrapping call in the JS task runner.

- [x] I have seen this code, I have run this code, and I take responsibility for this code.

**How to test:** The regression test calls `create` 10,000 times on the same object, then verifies nested property writes work without stack overflow and change tracking still functions.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3046

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI