### PR TITLE
fix(YouTube Node): Correct 'Unlisted' privacy status value from 'unlistef' to 'unlisted'

### DIFF
--- a/packages/nodes-base/nodes/Google/YouTube/VideoDescription.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/VideoDescription.ts
@@ -774,10 +774,10 @@ export const videoFields: INodeProperties[] = [
 						name: 'Public',
 						value: 'public',
 					},
-					{
-						name: 'Unlisted',
-						value: 'unlistef',
-					},
+				{
+					name: 'Unlisted',
+					value: 'unlisted',
+				},
 				],
 				default: '',
 				description: "The playlist's privacy status",


### PR DESCRIPTION
## Summary

Fixes #30133 

This PR fixes a typo in the YouTube node where the "Unlisted" privacy status option was incorrectly mapped to `'unlistef'` instead of `'unlisted'`, causing API errors when users tried to update video privacy settings.

## Related tickets and documents

- Fixes #30133

## Review / Merge checklist

- [x] PR title and summary are descriptive
- [x] Docs updated (N/A - typo fix only)
- [x] Tests updated (N/A - simple value correction)
- [x] Contributor license agreement signed

## Problem

When users tried to update a YouTube video's privacy status to "Unlisted" using the "Update a Video" operation, they received this error:

```
Bad request - please check your parameters
Invalid value at 'resource.status.privacy_status' (type.googleapis.com/youtube.api.v3.PrivacyStatusWrapper.PrivacyStatus), "unlistef"
```

## Root Cause

In `packages/nodes-base/nodes/Google/YouTube/VideoDescription.ts` line 779, the privacy status dropdown option for "Unlisted" was mapped to the value `'unlistef'` (typo) instead of `'unlisted'`.

## Solution

Changed the value from `'unlistef'` to `'unlisted'` to match the YouTube API's expected value.

## Changes

**Modified file**: `packages/nodes-base/nodes/Google/YouTube/VideoDescription.ts`
- Line 779: Changed `value: 'unlistef'` to `value: 'unlisted'`

## Testing

This is a simple typo fix that corrects the value sent to the YouTube API. The correct value `'unlisted'` is documented in the [YouTube Data API v3 documentation](https://developers.google.com/youtube/v3/docs/videos#status.privacyStatus).

## Impact

Users can now successfully set YouTube videos to "Unlisted" privacy status without encountering API errors.