### PR TITLE
fix(api): scope public API insights summary projectId by member access

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/insights/insights.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/insights/insights.handler.ts
@@ -6,8 +6,10 @@ import { z } from 'zod';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { InsightsService } from '@/modules/insights/insights.service';
 import type { InsightsRequest } from '@/public-api/types';
+import { ProjectService } from '@/services/project.service.ee';
 
 import type { PublicAPIEndpoint } from '../../shared/handler.types';
 import { publicApiScope } from '../../shared/middlewares/global.middleware';
@@ -66,10 +68,22 @@ const insightsHandlers: InsightsHandlers = {
 				return handleError(error);
 			}
 
+			const { projectId } = query.data;
+			if (projectId) {
+				const project = await Container.get(ProjectService).getProjectWithScope(
+					req.user,
+					projectId,
+					['project:read'],
+				);
+				if (!project) {
+					throw new NotFoundError(`Could not find project with ID "${projectId}"`);
+				}
+			}
+
 			const summary = await Container.get(InsightsService).getInsightsSummary({
 				startDate,
 				endDate,
-				projectId: query.data.projectId,
+				projectId,
 			});
 
 			return res.json(summary);

--- a/packages/cli/test/integration/public-api/insights.test.ts
+++ b/packages/cli/test/integration/public-api/insights.test.ts
@@ -1,9 +1,14 @@
 import { insightsSummarySchema } from '@n8n/api-types';
-import { createTeamProject, createWorkflow, testDb } from '@n8n/backend-test-utils';
+import {
+	createTeamProject,
+	createWorkflow,
+	linkUserToProject,
+	testDb,
+} from '@n8n/backend-test-utils';
 import { type User } from '@n8n/db';
 import { DateTime } from 'luxon';
 
-import { createOwnerWithApiKey } from '../shared/db/users';
+import { createMemberWithApiKey, createOwnerWithApiKey } from '../shared/db/users';
 import type { SuperAgentTest } from '../shared/types';
 import * as utils from '../shared/utils';
 
@@ -172,6 +177,47 @@ describe('GET /insights/summary', () => {
 			.expect(200);
 
 		expect(response.body.total.value).toBe(4);
+		expect(response.body.failed.value).toBe(1);
+	});
+
+	test('returns 404 when projectId does not match a project the caller can read', async () => {
+		const memberAlpha = await createMemberWithApiKey({ scopes: ['insights:read'] });
+		const projectAlpha = await createTeamProject();
+		const projectBeta = await createTeamProject();
+		await linkUserToProject(memberAlpha, projectAlpha, 'project:viewer');
+
+		const memberAgent = testServer.publicApiAgentFor(memberAlpha);
+
+		await memberAgent
+			.get('/insights/summary')
+			.query({
+				projectId: projectBeta.id,
+				startDate: DateTime.utc().minus({ days: 2 }).toISO(),
+				endDate: DateTime.utc().plus({ days: 1 }).toISO(),
+			})
+			.expect(404);
+	});
+
+	test('returns 200 when projectId matches a project the caller can read', async () => {
+		const memberAlpha = await createMemberWithApiKey({ scopes: ['insights:read'] });
+		const projectAlpha = await createTeamProject();
+		await linkUserToProject(memberAlpha, projectAlpha, 'project:viewer');
+
+		const workflow = await createWorkflow({}, projectAlpha);
+		await createSummaryMetrics(workflow, { success: 2, failure: 1 });
+
+		const memberAgent = testServer.publicApiAgentFor(memberAlpha);
+
+		const response = await memberAgent
+			.get('/insights/summary')
+			.query({
+				projectId: projectAlpha.id,
+				startDate: DateTime.utc().minus({ days: 2 }).toISO(),
+				endDate: DateTime.utc().plus({ days: 1 }).toISO(),
+			})
+			.expect(200);
+
+		expect(response.body.total.value).toBe(3);
 		expect(response.body.failed.value).toBe(1);
 	});
 });


### PR DESCRIPTION
## Summary

Closes #30139.

`GET /api/v1/insights/summary` accepts a caller-supplied `projectId` query parameter and forwards it to `InsightsService.getInsightsSummary` with no caller-side scoping. This change adds a `ProjectService.getProjectWithScope(req.user, projectId, ['project:read'])` check before the service call, mirroring the pattern already used in the adjacent public API handler `projects.handler.ts:130` (`getProjectUsers`). When the caller cannot read the requested project, the handler returns 404 — symmetric with how the projects-by-id endpoint behaves today.

This brings the insights handler in line with the variables handler fix that shipped in 2.18.1 (GHSA-756q-gq9h-fp22): when a public API endpoint accepts a `projectId` filter, the projectId is gated through the project-membership check rather than passed straight to the service. `getProjectWithScope` already short-circuits for users carrying the global scope (`packages/cli/src/services/project.service.ee.ts:581`), so global admins keep their existing behaviour.

## Changes

- `packages/cli/src/public-api/v1/handlers/insights/insights.handler.ts` — when `projectId` is supplied, call `ProjectService.getProjectWithScope(req.user, projectId, ['project:read'])` and return 404 if the project is not visible to the caller.
- `packages/cli/test/integration/public-api/insights.test.ts` — add two integration tests:
  - Member with `insights:read` who is not a member of the requested project receives 404.
  - Member with `insights:read` who is linked to the project as `project:viewer` receives 200 with the expected summary.

## Test plan

- [x] Existing `GET /insights/summary` tests still pass for owner-with-API-key callers (they have global `insights:read` scope so the new check short-circuits).
- [x] New negative test confirms a member-tier API key cannot read a project they are not a member of.
- [x] New positive test confirms a member-tier API key linked to a project as `project:viewer` can still read its summary.
- [ ] CI integration suite

## Notes

The framing follows the security-fix hygiene rules in `AGENTS.md`: branch name, commit message, test descriptions, and PR title describe the change in functional terms (membership scoping) without exposing attack vectors.