### PR TITLE
fix(expression-runtime): defer idle scale-down during borrows

### DIFF
--- a/packages/@n8n/expression-runtime/src/pool/__tests__/idle-scaling-pool.test.ts
+++ b/packages/@n8n/expression-runtime/src/pool/__tests__/idle-scaling-pool.test.ts
@@ -136,7 +136,7 @@ describe('IdleScalingPool', () => {
 		await pool.dispose();
 	});
 
-	it('should not replenish on release while idle', async () => {
+	it('should wait for borrowed bridges to be released before scaling to zero', async () => {
 		const factory = createFactory();
 		const pool = new IdleScalingPool(factory, 2, IDLE_TIMEOUT_MS);
 		await pool.initialize();
@@ -147,12 +147,14 @@ describe('IdleScalingPool', () => {
 
 		vi.advanceTimersByTime(IDLE_TIMEOUT_MS);
 		await flushMicrotasks();
+		expect(bridge.dispose).not.toHaveBeenCalled();
 
-		const callsBeforeRelease = factory.mock.calls.length;
 		await pool.release(bridge);
 		await flushMicrotasks();
 
-		expect(factory.mock.calls.length).toBe(callsBeforeRelease);
+		vi.advanceTimersByTime(IDLE_TIMEOUT_MS);
+		await flushMicrotasks();
+
 		expect(() => pool.acquire()).toThrow(PoolExhaustedError);
 		await pool.dispose();
 	});

--- a/packages/@n8n/expression-runtime/src/pool/idle-scaling-pool.ts
+++ b/packages/@n8n/expression-runtime/src/pool/idle-scaling-pool.ts
@@ -13,6 +13,7 @@ export class IdleScalingPool implements IPool {
 	private innerPool: IsolatePool | null = null;
 	private pendingScaleUp: Promise<void> | null = null;
 	private pendingScaleDown: Promise<void> | null = null;
+	private readonly borrowedBridges = new Set<RuntimeBridge>();
 	private idleTimer?: NodeJS.Timeout;
 	private disposed = false;
 	private disposePromise?: Promise<void>;
@@ -38,11 +39,14 @@ export class IdleScalingPool implements IPool {
 			this.triggerScaleUp();
 			throw new PoolExhaustedError();
 		}
-		this.resetIdleTimer();
-		return this.innerPool.acquire();
+		this.clearIdleTimer();
+		const bridge = this.innerPool.acquire();
+		this.borrowedBridges.add(bridge);
+		return bridge;
 	}
 
 	async release(bridge: RuntimeBridge): Promise<void> {
+		const wasBorrowed = this.borrowedBridges.delete(bridge);
 		if (this.innerPool && !this.disposed) {
 			// Pool is live: delegate so the inner pool disposes and replenishes.
 			await this.innerPool.release(bridge);
@@ -50,6 +54,9 @@ export class IdleScalingPool implements IPool {
 			// Pool is idle, disposed, or the bridge came from cold-start fallback:
 			// no pool to delegate to, just dispose to free the V8 isolate.
 			await bridge.dispose();
+		}
+		if (wasBorrowed && this.borrowedBridges.size === 0 && this.innerPool && !this.disposed) {
+			this.resetIdleTimer();
 		}
 	}
 
@@ -59,10 +66,7 @@ export class IdleScalingPool implements IPool {
 
 	private async doDispose(): Promise<void> {
 		this.disposed = true;
-		if (this.idleTimer) {
-			clearTimeout(this.idleTimer);
-			this.idleTimer = undefined;
-		}
+		this.clearIdleTimer();
 		await this.drainPendingTransitions();
 		if (this.innerPool) {
 			const toDispose = this.innerPool;
@@ -92,9 +96,16 @@ export class IdleScalingPool implements IPool {
 
 	private resetIdleTimer(): void {
 		if (this.idleTimeoutMs === undefined) return;
-		if (this.idleTimer) clearTimeout(this.idleTimer);
+		this.clearIdleTimer();
 		this.idleTimer = setTimeout(() => this.triggerScaleDown(), this.idleTimeoutMs);
 		this.idleTimer.unref();
+	}
+
+	private clearIdleTimer(): void {
+		if (this.idleTimer) {
+			clearTimeout(this.idleTimer);
+			this.idleTimer = undefined;
+		}
 	}
 
 	private triggerScaleUp(): void {
@@ -123,7 +134,15 @@ export class IdleScalingPool implements IPool {
 	}
 
 	private triggerScaleDown(): void {
-		if (this.pendingScaleDown || this.pendingScaleUp || !this.innerPool || this.disposed) return;
+		if (
+			this.pendingScaleDown ||
+			this.pendingScaleUp ||
+			!this.innerPool ||
+			this.disposed ||
+			this.borrowedBridges.size > 0
+		) {
+			return;
+		}
 		this.logger?.info('[IdleScalingPool] Scaling to 0 after inactivity', {
 			idleTimeoutMs: this.idleTimeoutMs,
 		});


### PR DESCRIPTION
## Summary
- keep `IdleScalingPool` from treating borrowed bridges as idle
- clear the idle timer while a bridge is checked out and restart it only after the last borrowed bridge is released
- update the existing idle-scaling regression test so scale-down only happens after release plus the idle interval

## Tests
- `git diff --check`
- `pnpm --filter @n8n/expression-runtime test -- idle-scaling-pool.test.ts` (blocked locally: this checkout has no `vitest`/`node_modules`; scoped install retried through the proxy but npm registry downloads repeatedly failed with `ECONNRESET`)
