### PR TITLE
fix(core): Resolve additional keys in routing postReceive

### DIFF
--- a/packages/core/src/execution-engine/__tests__/routing-node.test.ts
+++ b/packages/core/src/execution-engine/__tests__/routing-node.test.ts
@@ -2061,6 +2061,69 @@ describe('RoutingNode', () => {
 				],
 			},
 			{
+				description: 'single parameter, postReceive: setKeyValue resolves $execution.id',
+				input: {
+					nodeType: {
+						requestDefaults: {
+							baseURL: 'http://127.0.0.1:5678',
+							url: '/test-url',
+						},
+						properties: [
+							{
+								displayName: 'JSON Data',
+								name: 'jsonData',
+								type: 'string',
+								routing: {
+									send: {
+										property: 'jsonData',
+										type: 'body',
+									},
+									output: {
+										postReceive: [
+											{
+												type: 'rootProperty',
+												properties: {
+													property: 'requestOptions.body.jsonData.root',
+												},
+											},
+											{
+												type: 'setKeyValue',
+												properties: {
+													name: '={{ $responseItem.name }}',
+													executionId: '={{ $execution.id }}',
+												},
+											},
+										],
+									},
+								},
+								default: '',
+							},
+						],
+					},
+					node: {
+						parameters: {
+							jsonData: {
+								root: [
+									{
+										name: 'Jim',
+									},
+								],
+							},
+						},
+					},
+				},
+				output: [
+					[
+						{
+							json: {
+								name: 'Jim',
+								executionId: 'test-exec-123',
+							},
+						},
+					],
+				],
+			},
+			{
 				description: 'single parameter, routing.request.url resolves $execution.id',
 				input: {
 					node: {

--- a/packages/core/src/execution-engine/routing-node.ts
+++ b/packages/core/src/execution-engine/routing-node.ts
@@ -254,6 +254,7 @@ export class RoutingNode {
 					credentialDescription?.name,
 					itemContext[itemIndex].requestData.requestOperations,
 					credentialsDecrypted,
+					additionalKeys,
 				),
 			);
 		}
@@ -331,6 +332,7 @@ export class RoutingNode {
 		parameterValue: string | IDataObject | undefined,
 		itemIndex: number,
 		runIndex: number,
+		additionalKeys?: IWorkflowDataProxyAdditionalKeys,
 	): Promise<INodeExecutionData[]> {
 		if (typeof action === 'function') {
 			return await action.call(executeSingleFunctions, inputData, responseData);
@@ -373,6 +375,7 @@ export class RoutingNode {
 					runIndex,
 					executeSingleFunctions.getExecuteData(),
 					{
+						...additionalKeys,
 						$credentials: credentials,
 						$response: responseData,
 						$responseItem: item.json,
@@ -392,7 +395,12 @@ export class RoutingNode {
 				itemIndex,
 				runIndex,
 				executeSingleFunctions.getExecuteData(),
-				{ $response: responseData, $value: parameterValue, $version: node.typeVersion },
+				{
+					...additionalKeys,
+					$response: responseData,
+					$value: parameterValue,
+					$version: node.typeVersion,
+				},
 				false,
 			) as string;
 			return inputData.slice(0, parseInt(maxResults, 10));
@@ -408,7 +416,12 @@ export class RoutingNode {
 						itemIndex,
 						runIndex,
 						executeSingleFunctions.getExecuteData(),
-						{ $response: responseData, $value: parameterValue, $version: node.typeVersion },
+						{
+							...additionalKeys,
+							$response: responseData,
+							$value: parameterValue,
+							$version: node.typeVersion,
+						},
 						false,
 					) as IDataObject,
 				},
@@ -453,6 +466,7 @@ export class RoutingNode {
 						runIndex,
 						executeSingleFunctions.getExecuteData(),
 						{
+							...additionalKeys,
 							$response: responseData,
 							$responseItem: item.json,
 							$value: parameterValue,
@@ -478,7 +492,12 @@ export class RoutingNode {
 				itemIndex,
 				runIndex,
 				executeSingleFunctions.getExecuteData(),
-				{ $response: responseData, $value: parameterValue, $version: node.typeVersion },
+				{
+					...additionalKeys,
+					$response: responseData,
+					$value: parameterValue,
+					$version: node.typeVersion,
+				},
 				false,
 			) as string;
 
@@ -507,6 +526,7 @@ export class RoutingNode {
 		requestData: DeclarativeRestApiSettings.ResultOptions,
 		itemIndex: number,
 		runIndex: number,
+		additionalKeys?: IWorkflowDataProxyAdditionalKeys,
 	): Promise<INodeExecutionData[]> {
 		let returnData: INodeExecutionData[] = [
 			{
@@ -526,6 +546,7 @@ export class RoutingNode {
 						postReceiveMethod.data.parameterValue,
 						itemIndex,
 						runIndex,
+						additionalKeys,
 					);
 				}
 			}
@@ -578,6 +599,7 @@ export class RoutingNode {
 		credentialType?: string,
 		requestOperations?: IN8nRequestOperations,
 		credentialsDecrypted?: ICredentialsDecrypted,
+		workflowAdditionalKeys?: IWorkflowDataProxyAdditionalKeys,
 	): Promise<INodeExecutionData[]> {
 		let responseData: INodeExecutionData[];
 		for (const preSendMethod of requestData.preSend) {
@@ -601,6 +623,7 @@ export class RoutingNode {
 						requestData,
 						itemIndex,
 						runIndex,
+						workflowAdditionalKeys,
 					),
 			);
 		};
@@ -634,6 +657,7 @@ export class RoutingNode {
 					let paginateRequestData: IHttpRequestOptions;
 
 					const additionalKeys = {
+						...workflowAdditionalKeys,
 						$request: requestData.options,
 						$response: {} as IN8nHttpFullResponse,
 						$version: node.typeVersion,
@@ -667,6 +691,7 @@ export class RoutingNode {
 							requestData,
 							itemIndex,
 							runIndex,
+							workflowAdditionalKeys,
 						);
 
 						responseData.push(...tempResponseItems);
@@ -716,6 +741,7 @@ export class RoutingNode {
 									requestData,
 									itemIndex,
 									runIndex,
+									workflowAdditionalKeys,
 								),
 						);
 
@@ -762,6 +788,7 @@ export class RoutingNode {
 						requestData,
 						itemIndex,
 						runIndex,
+						workflowAdditionalKeys,
 					),
 			);
 		}


### PR DESCRIPTION
## Summary

- pass workflow additional keys through routing response post-processing
- make postReceive action expressions resolve the same keys as declarative request expressions
- add a regression test for `$execution.id` inside a postReceive `setKeyValue` action

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

## Tests

- `git diff --check`
- Attempted: `pnpm --filter n8n-core test -- routing-node.test.ts --runInBand` (local checkout has no installed `node_modules`, so `jest` is unavailable)
- Attempted: `pnpm install --frozen-lockfile --ignore-scripts --filter n8n-core...` (npm registry downloads repeatedly failed with `ECONNRESET`)
