### PR TITLE
fix(mcp): preserve workflow layout coordinates during AI updates (#30134)

### DIFF
--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -147,16 +147,26 @@ export const createUpdateWorkflowTool = (
 
 			stripNullCredentialStubs(workflowUpdateData.nodes);
 
-			// Preserve user-configured credentials from the existing workflow.
+			// Preserve user-configured credentials and layout positions from the existing workflow.
 			// Match nodes by name + type so that auto-assign skips them.
-			const existingCredsByNode = new Map(
-				existingWorkflow.nodes.map((n) => [n.name, { type: n.type, credentials: n.credentials }]),
+			const existingNodesByName = new Map(
+				existingWorkflow.nodes.map((n) => [
+					n.name,
+					{ type: n.type, credentials: n.credentials, position: n.position },
+				]),
 			);
 			for (const node of workflowUpdateData.nodes) {
-				if (!node.credentials) {
-					const existing = existingCredsByNode.get(node.name);
-					if (existing?.type === node.type && existing.credentials) {
+				const existing = existingNodesByName.get(node.name);
+
+				if (existing?.type === node.type) {
+					// 1. Preserve credentials if not explicitly provided by the update
+					if (!node.credentials && existing.credentials) {
 						node.credentials = { ...existing.credentials };
+					}
+
+					// 2. Preserve node position on the canvas to prevent layout breakage (#30134)
+					if (existing.position) {
+						node.position = [...existing.position];
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

**The Problem:**
When using Codex/MCP (or the built-in AI Workflow Builder) to update an existing workflow, the incoming SDK code payload lacks visual coordinate data. This caused a regression where updating a workflow would wipe out the `position` arrays of all existing nodes, causing them to stack on top of each other at `[0,0]` on the canvas.

**The Fix:**
In `packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts`, the backend previously mapped through `existingWorkflow.nodes` solely to preserve user-configured `credentials` before overwriting the workflow. 

This PR expands that mapping logic to also preserve the `position` array. Now, when the AI payload is processed, the backend intelligently checks if a node already existed (matching by `name` and `type`) and stitches the exact original `[x,y]` coordinates back onto the node before saving it to the database.

**How to test:**
1. Open n8n and create a new workflow.
2. Manually drag two nodes onto the canvas (e.g., a Webhook and an HTTP Request) and **spread them far apart** so they have distinct coordinates.
3. Save the workflow.
4. Open the **Chat (Preview)** in the left sidebar (or connect via the MCP Inspector).
5. Prompt the AI to modify the workflow (e.g., *"Add a Schedule trigger to the canvas"*).
6. **Expected Behavior:** The new node is added, and the original Webhook and HTTP Request nodes perfectly retain their original positions on the canvas instead of collapsing.

## Related Linear tickets, Github issues, and Community forum posts

fixes #30134

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) 
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. 
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)