### PR TITLE
test(stores): Cover duplicate tab push refs

### DIFF
--- a/packages/frontend/@n8n/stores/src/useRootStore.test.ts
+++ b/packages/frontend/@n8n/stores/src/useRootStore.test.ts
@@ -1,0 +1,44 @@
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useRootStore } from './useRootStore';
+
+const { randomStringMock } = vi.hoisted(() => ({
+	randomStringMock: vi.fn(),
+}));
+
+vi.mock('n8n-workflow', () => ({
+	randomString: randomStringMock,
+	setGlobalState: vi.fn(),
+}));
+
+describe('root.store', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		randomStringMock.mockReset();
+		sessionStorage.clear();
+		setActivePinia(createPinia());
+		window.BASE_PATH = '/';
+	});
+
+	it('creates a fresh pushRef for each store instance instead of reusing session storage', () => {
+		randomStringMock.mockReturnValueOnce('FIRSTPUSHREF').mockReturnValueOnce('SECONDPUSHREF');
+		sessionStorage.setItem('n8n-client-id', 'copied-tab-pushref');
+
+		const getItemSpy = vi.spyOn(Storage.prototype, 'getItem');
+		const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+
+		const firstStore = useRootStore();
+		const firstPushRef = firstStore.pushRef;
+
+		setActivePinia(createPinia());
+		const secondStore = useRootStore();
+
+		expect(firstPushRef).toBe('firstpushref');
+		expect(secondStore.pushRef).toBe('secondpushref');
+		expect(secondStore.pushRef).not.toBe(firstPushRef);
+		expect(secondStore.pushRef).not.toBe('copied-tab-pushref');
+		expect(getItemSpy).not.toHaveBeenCalledWith('n8n-client-id');
+		expect(setItemSpy).not.toHaveBeenCalledWith('n8n-client-id', expect.anything());
+	});
+});


### PR DESCRIPTION
## Summary

- add root store regression coverage for duplicate browser tabs receiving different `pushRef` values
- assert the root store does not read or write the old `sessionStorage('n8n-client-id')` key when initializing the push ref

## Why

This protects the duplicate-tab fix from #28769, which resolved #28741 by no longer persisting the client id in session storage. Duplicating a tab copies session storage, so reusing that value can make both tabs share a push ref and lose websocket updates.

## Related Linear tickets, Github issues, and Community forum posts

Related to #28741
Follow-up for #28769

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

## Validation

- `git diff --check`
- Attempted `pnpm --filter @n8n/stores test -- useRootStore.test.ts`, but this checkout has no `node_modules`, so `vitest` is not installed locally.
