### PR TITLE
fix(core): Scope credential resolution

### DIFF
--- a/packages/cli/src/modules/agents/__tests__/agents-credential-provider.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-credential-provider.test.ts
@@ -1,0 +1,94 @@
+import type { CredentialListItem } from '@n8n/agents';
+import type { CredentialsEntity, User } from '@n8n/db';
+import { mock } from 'jest-mock-extended';
+
+import type { CredentialsService } from '@/credentials/credentials.service';
+
+import { AgentsCredentialProvider } from '../adapters/agents-credential-provider';
+
+function credential(overrides: Partial<CredentialsEntity>): CredentialsEntity {
+	return {
+		id: 'cred-1',
+		name: 'Slack',
+		type: 'slackApi',
+		...overrides,
+	} as CredentialsEntity;
+}
+
+function listItem(overrides: Partial<CredentialListItem>): CredentialListItem {
+	return {
+		id: 'cred-1',
+		name: 'Slack',
+		type: 'slackApi',
+		...overrides,
+	};
+}
+
+describe('AgentsCredentialProvider', () => {
+	it('lists workflow-scoped credentials when a request user is provided', async () => {
+		const credentialsService = mock<CredentialsService>();
+		const user = { id: 'user-1' } as User;
+		credentialsService.getCredentialsAUserCanUseInAWorkflow.mockResolvedValue([
+			{
+				...listItem({ id: 'allowed' }),
+				scopes: [],
+				isManaged: false,
+				isGlobal: false,
+				isResolvable: true,
+			},
+		]);
+
+		const provider = new AgentsCredentialProvider(credentialsService, 'project-1', user);
+
+		await expect(provider.list()).resolves.toEqual([
+			{ id: 'allowed', name: 'Slack', type: 'slackApi' },
+		]);
+		expect(credentialsService.getCredentialsAUserCanUseInAWorkflow).toHaveBeenCalledWith(user, {
+			projectId: 'project-1',
+		});
+		expect(credentialsService.findAllCredentialIdsForProject).not.toHaveBeenCalled();
+	});
+
+	it('keeps project-scoped listing when no request user is provided', async () => {
+		const credentialsService = mock<CredentialsService>();
+		credentialsService.findAllCredentialIdsForProject.mockResolvedValue([
+			credential({ id: 'project-cred', name: 'Project Slack' }),
+		]);
+
+		const provider = new AgentsCredentialProvider(credentialsService, 'project-1');
+
+		await expect(provider.list()).resolves.toEqual([
+			{ id: 'project-cred', name: 'Project Slack', type: 'slackApi' },
+		]);
+		expect(credentialsService.findAllCredentialIdsForProject).toHaveBeenCalledWith('project-1');
+		expect(credentialsService.getCredentialsAUserCanUseInAWorkflow).not.toHaveBeenCalled();
+	});
+
+	it('resolves only credentials included in the workflow-scoped user list', async () => {
+		const credentialsService = mock<CredentialsService>();
+		const user = { id: 'user-1' } as User;
+		const allowedCredential = credential({ id: 'allowed', name: 'Allowed Slack' });
+		credentialsService.getCredentialsAUserCanUseInAWorkflow.mockResolvedValue([
+			{
+				...listItem({ id: 'allowed', name: 'Allowed Slack' }),
+				scopes: [],
+				isManaged: false,
+				isGlobal: false,
+				isResolvable: true,
+			},
+		]);
+		credentialsService.findAllCredentialIdsForProject.mockResolvedValue([
+			allowedCredential,
+			credential({ id: 'project-only', name: 'Project Only Slack' }),
+		]);
+		credentialsService.decrypt.mockResolvedValue({ apiKey: 'secret' });
+
+		const provider = new AgentsCredentialProvider(credentialsService, 'project-1', user);
+
+		await expect(provider.resolve('project-only')).rejects.toThrow(
+			'Credential "project-only" not found or not accessible',
+		);
+		await expect(provider.resolve('allowed')).resolves.toEqual({ apiKey: 'secret' });
+		expect(credentialsService.decrypt).toHaveBeenCalledWith(allowedCredential, true);
+	});
+});

--- a/packages/cli/src/modules/agents/__tests__/agents.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.controller.test.ts
@@ -1,6 +1,17 @@
 import { ControllerRegistryMetadata } from '@n8n/decorators';
 import { Container } from '@n8n/di';
+import { mock } from 'jest-mock-extended';
 
+import type { CredentialsService } from '@/credentials/credentials.service';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+
+import type { AgentsService } from '../agents.service';
+import type { AgentsBuilderService } from '../builder/agents-builder.service';
+import type { ChatIntegrationRegistry } from '../integrations/agent-chat-integration';
+import type { AgentScheduleService } from '../integrations/agent-schedule.service';
+import type { ChatIntegrationService } from '../integrations/chat-integration.service';
+import type { AgentExecutionService } from '../agent-execution.service';
+import type { AgentRepository } from '../repositories/agent.repository';
 import { AgentsController } from '../agents.controller';
 
 // The webhook route is the single exception: it is `skipAuth: true` (no
@@ -42,5 +53,60 @@ describe('AgentsController route access scopes', () => {
 		['revertToPublished', 'agent:update'],
 	])('%s uses %s', (handlerName, scope) => {
 		expect(metadata.routes.get(handlerName)?.accessScope?.scope).toBe(scope);
+	});
+});
+
+describe('AgentsController integration credentials', () => {
+	it('rejects credentials that are not usable in the agent project', async () => {
+		const credentialsService = mock<CredentialsService>();
+		credentialsService.getCredentialsAUserCanUseInAWorkflow.mockResolvedValue([
+			{
+				id: 'cred-allowed',
+				name: 'Allowed Slack',
+				type: 'slackApi',
+				scopes: [],
+				isManaged: false,
+				isGlobal: false,
+				isResolvable: true,
+			},
+		]);
+
+		const chatIntegrationService = mock<ChatIntegrationService>();
+		const agentRepository = mock<AgentRepository>();
+		agentRepository.findByIdAndProjectId.mockResolvedValue({
+			id: 'agent-1',
+			projectId: 'project-1',
+			publishedVersion: {},
+			integrations: [],
+		} as never);
+
+		const controller = new AgentsController(
+			mock<AgentsService>(),
+			mock<AgentsBuilderService>(),
+			credentialsService,
+			chatIntegrationService,
+			mock<AgentScheduleService>(),
+			agentRepository,
+			mock<AgentExecutionService>(),
+			mock<ChatIntegrationRegistry>(),
+		);
+
+		await expect(
+			controller.connectIntegration(
+				{
+					params: { projectId: 'project-1' },
+					user: { id: 'user-1' },
+				} as never,
+				undefined as never,
+				'agent-1',
+				{ type: 'slack', credentialId: 'cred-outside-project' },
+			),
+		).rejects.toThrow(NotFoundError);
+
+		expect(credentialsService.getCredentialsAUserCanUseInAWorkflow).toHaveBeenCalledWith(
+			{ id: 'user-1' },
+			{ projectId: 'project-1' },
+		);
+		expect(chatIntegrationService.connect).not.toHaveBeenCalled();
 	});
 });

--- a/packages/cli/src/modules/agents/__tests__/agents.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.controller.test.ts
@@ -57,6 +57,45 @@ describe('AgentsController route access scopes', () => {
 });
 
 describe('AgentsController integration credentials', () => {
+	it('lists credentials through the workflow-scoped user project resolver', async () => {
+		const credentialsService = mock<CredentialsService>();
+		credentialsService.getCredentialsAUserCanUseInAWorkflow.mockResolvedValue([
+			{
+				id: 'cred-allowed',
+				name: 'Allowed Slack',
+				type: 'slackApi',
+				scopes: [],
+				isManaged: false,
+				isGlobal: false,
+				isResolvable: true,
+			},
+		]);
+
+		const controller = new AgentsController(
+			mock<AgentsService>(),
+			mock<AgentsBuilderService>(),
+			credentialsService,
+			mock<ChatIntegrationService>(),
+			mock<AgentScheduleService>(),
+			mock<AgentRepository>(),
+			mock<AgentExecutionService>(),
+			mock<ChatIntegrationRegistry>(),
+		);
+
+		await expect(
+			controller.listCredentials({
+				params: { projectId: 'project-1', agentId: 'agent-1' },
+				user: { id: 'user-1' },
+			} as never),
+		).resolves.toEqual([{ id: 'cred-allowed', name: 'Allowed Slack', type: 'slackApi' }]);
+
+		expect(credentialsService.getCredentialsAUserCanUseInAWorkflow).toHaveBeenCalledWith(
+			{ id: 'user-1' },
+			{ projectId: 'project-1' },
+		);
+		expect(credentialsService.findAllCredentialIdsForProject).not.toHaveBeenCalled();
+	});
+
 	it('rejects credentials that are not usable in the agent project', async () => {
 		const credentialsService = mock<CredentialsService>();
 		credentialsService.getCredentialsAUserCanUseInAWorkflow.mockResolvedValue([

--- a/packages/cli/src/modules/agents/adapters/agents-credential-provider.ts
+++ b/packages/cli/src/modules/agents/adapters/agents-credential-provider.ts
@@ -1,51 +1,75 @@
 import type { CredentialProvider, ResolvedCredential, CredentialListItem } from '@n8n/agents';
+import type { CredentialsEntity, User } from '@n8n/db';
 
 import type { CredentialsService } from '@/credentials/credentials.service';
+
+function toResolvedCredential(data: unknown): ResolvedCredential {
+	const resolved = data !== null && typeof data === 'object' && !Array.isArray(data) ? data : {};
+	const apiKey = 'apiKey' in resolved && typeof resolved.apiKey === 'string' ? resolved.apiKey : '';
+
+	return { ...resolved, apiKey };
+}
+
+function findCredential<T extends Pick<CredentialListItem, 'id' | 'name'>>(
+	credentials: T[],
+	credentialIdOrName: string,
+): T | null {
+	return (
+		credentials.find((c) => c.id === credentialIdOrName) ??
+		credentials.find((c) => c.name.toLowerCase() === credentialIdOrName.toLowerCase()) ??
+		null
+	);
+}
 
 /**
  * Resolves and lists n8n credentials for use by SDK agents.
  *
  * This is not a DI-managed singleton — a new instance is created per request,
- * scoped to a specific project. Agents always belong to a project, so credential
- * access is always project-scoped, matching how workflow execution resolves
- * credentials and preventing cross-project credential leakage.
+ * scoped to a specific project. When a request user is provided, list/resolve
+ * follows the same credential set as the workflow editor for that project.
+ * Published runtime execution can omit the user and stays project-scoped.
  */
 export class AgentsCredentialProvider implements CredentialProvider {
 	constructor(
 		private readonly credentialsService: CredentialsService,
 		private readonly projectId: string,
+		private readonly user?: User,
 	) {}
 
 	/**
 	 * Resolve a credential by ID or name, then decrypt and return the raw data.
 	 *
-	 * Only credentials shared with the agent's project are considered. ID is
+	 * Only credentials visible to this provider's scope are considered. ID is
 	 * tried first, then name (case-insensitive).
 	 */
 	async resolve(credentialIdOrName: string): Promise<ResolvedCredential> {
-		const projectCredentials = await this.credentialsService.findAllCredentialIdsForProject(
-			this.projectId,
-		);
-
-		const credential =
-			projectCredentials.find((c) => c.id === credentialIdOrName) ??
-			projectCredentials.find((c) => c.name.toLowerCase() === credentialIdOrName.toLowerCase()) ??
-			null;
+		const credential = await this.findCredentialEntity(credentialIdOrName);
 
 		if (!credential) {
 			throw new Error(`Credential "${credentialIdOrName}" not found or not accessible`);
 		}
 
 		const data = await this.credentialsService.decrypt(credential, true);
-		const apiKey = typeof data.apiKey === 'string' ? data.apiKey : '';
-
-		return { ...data, apiKey };
+		return toResolvedCredential(data);
 	}
 
 	/**
-	 * List all credentials shared with the agent's project.
+	 * List all credentials available in this provider's scope.
 	 */
 	async list(): Promise<CredentialListItem[]> {
+		if (this.user) {
+			const workflowCredentials =
+				await this.credentialsService.getCredentialsAUserCanUseInAWorkflow(this.user, {
+					projectId: this.projectId,
+				});
+
+			return workflowCredentials.map((c) => ({
+				id: c.id,
+				name: c.name,
+				type: c.type,
+			}));
+		}
+
 		const projectCredentials = await this.credentialsService.findAllCredentialIdsForProject(
 			this.projectId,
 		);
@@ -55,5 +79,28 @@ export class AgentsCredentialProvider implements CredentialProvider {
 			name: c.name,
 			type: c.type,
 		}));
+	}
+
+	private async findCredentialEntity(
+		credentialIdOrName: string,
+	): Promise<CredentialsEntity | null> {
+		if (!this.user) {
+			const projectCredentials = await this.credentialsService.findAllCredentialIdsForProject(
+				this.projectId,
+			);
+			return findCredential(projectCredentials, credentialIdOrName);
+		}
+
+		const scopedCredential = findCredential(await this.list(), credentialIdOrName);
+		if (!scopedCredential) return null;
+
+		const projectCredentials = await this.credentialsService.findAllCredentialIdsForProject(
+			this.projectId,
+		);
+		const projectCredential = projectCredentials.find((c) => c.id === scopedCredential.id);
+		if (projectCredential) return projectCredential;
+
+		const globalCredentials = await this.credentialsService.findAllGlobalCredentialIds(true);
+		return globalCredentials.find((c) => c.id === scopedCredential.id) ?? null;
 	}
 }

--- a/packages/cli/src/modules/agents/agents.controller.ts
+++ b/packages/cli/src/modules/agents/agents.controller.ts
@@ -225,7 +225,11 @@ export class AgentsController {
 	@ProjectScope('agent:read')
 	async listCredentials(req: AuthenticatedRequest<{ projectId: string; agentId: string }>) {
 		const { projectId } = req.params;
-		const credentialProvider = new AgentsCredentialProvider(this.credentialsService, projectId);
+		const credentialProvider = new AgentsCredentialProvider(
+			this.credentialsService,
+			projectId,
+			req.user,
+		);
 		return await credentialProvider.list();
 	}
 
@@ -401,7 +405,11 @@ export class AgentsController {
 		const { projectId } = req.params;
 		const { message, sessionId } = payload;
 
-		const credentialProvider = new AgentsCredentialProvider(this.credentialsService, projectId);
+		const credentialProvider = new AgentsCredentialProvider(
+			this.credentialsService,
+			projectId,
+			req.user,
+		);
 
 		const { send } = initSseStream(res);
 
@@ -553,7 +561,11 @@ export class AgentsController {
 		const agent = await this.agentsService.findById(agentId, projectId);
 		if (!agent) throw new NotFoundError(`Agent "${agentId}" not found`);
 
-		const credentialProvider = new AgentsCredentialProvider(this.credentialsService, projectId);
+		const credentialProvider = new AgentsCredentialProvider(
+			this.credentialsService,
+			projectId,
+			req.user,
+		);
 
 		const { send } = initSseStream(res);
 
@@ -606,7 +618,11 @@ export class AgentsController {
 		const agent = await this.agentsService.findById(agentId, projectId);
 		if (!agent) throw new NotFoundError(`Agent "${agentId}" not found`);
 
-		const credentialProvider = new AgentsCredentialProvider(this.credentialsService, projectId);
+		const credentialProvider = new AgentsCredentialProvider(
+			this.credentialsService,
+			projectId,
+			req.user,
+		);
 
 		const { send } = initSseStream(res);
 

--- a/packages/cli/src/modules/agents/agents.controller.ts
+++ b/packages/cli/src/modules/agents/agents.controller.ts
@@ -652,6 +652,13 @@ export class AgentsController {
 				`Agent "${agentId}" must be published before connecting an integration`,
 			);
 
+		const usableCredentials = await this.credentialsService.getCredentialsAUserCanUseInAWorkflow(
+			req.user,
+			{ projectId: agent.projectId },
+		);
+		const credential = usableCredentials.find((c) => c.id === credentialId);
+		if (!credential) throw new NotFoundError(`Credential "${credentialId}" not found`);
+
 		await this.chatIntegrationService.connect(
 			agentId,
 			credentialId,
@@ -666,7 +673,6 @@ export class AgentsController {
 			(i) => isAgentCredentialIntegration(i) && i.type === type && i.credentialId === credentialId,
 		);
 		if (!alreadyExists) {
-			const credential = await this.credentialsService.getOne(req.user, credentialId, false);
 			agent.integrations = [...existing, { type, credentialId, credentialName: credential.name }];
 			await this.agentRepository.save(agent);
 		}

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
@@ -11,6 +11,17 @@ const routeQuery: Record<string, string | undefined> = {};
 const openModalWithDataMock = vi.fn();
 const closeModalMock = vi.fn();
 const showMessageMock = vi.fn();
+const {
+	fetchAllCredentialsForWorkflowMock,
+	fetchAllCredentialsMock,
+	fetchCredentialTypesMock,
+	setCredentialsMock,
+} = vi.hoisted(() => ({
+	fetchAllCredentialsForWorkflowMock: vi.fn().mockResolvedValue(undefined),
+	fetchAllCredentialsMock: vi.fn().mockResolvedValue(undefined),
+	fetchCredentialTypesMock: vi.fn().mockResolvedValue(undefined),
+	setCredentialsMock: vi.fn(),
+}));
 vi.mock('vue-router', () => ({
 	useRouter: () => ({ push: routerPush, replace: routerReplace }),
 	useRoute: () => ({ params: { projectId: 'p1', agentId: 'a1' }, query: routeQuery }),
@@ -33,8 +44,10 @@ vi.mock('@/features/collaboration/projects/projects.store', () => ({
 
 vi.mock('@/features/credentials/credentials.store', () => ({
 	useCredentialsStore: () => ({
-		fetchAllCredentials: vi.fn().mockResolvedValue(undefined),
-		fetchCredentialTypes: vi.fn().mockResolvedValue(undefined),
+		fetchAllCredentials: fetchAllCredentialsMock,
+		fetchAllCredentialsForWorkflow: fetchAllCredentialsForWorkflowMock,
+		fetchCredentialTypes: fetchCredentialTypesMock,
+		setCredentials: setCredentialsMock,
 	}),
 }));
 
@@ -358,6 +371,14 @@ describe('AgentBuilderView — chat mode toggle', () => {
 		expect(toggle.exists()).toBe(true);
 		const vm = wrapper.vm as unknown as { chatMode: string };
 		expect(vm.chatMode).toBe('build');
+	});
+
+	it('loads credentials through the workflow-scoped credentials endpoint for the agent project', async () => {
+		await renderView();
+
+		expect(setCredentialsMock).toHaveBeenCalledWith([]);
+		expect(fetchAllCredentialsForWorkflowMock).toHaveBeenCalledWith({ projectId: 'p1' });
+		expect(fetchAllCredentialsMock).not.toHaveBeenCalled();
 	});
 
 	it('lazy-mounts each chat panel on first activation and toggles visibility via v-show afterwards', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentCredentialSelect.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentCredentialSelect.test.ts
@@ -85,12 +85,13 @@ vi.mock('@n8n/design-system', async () => {
 	};
 });
 
-function renderSelect() {
+function renderSelect({ canCreateCredential = true } = {}) {
 	return mount(AgentCredentialSelect, {
 		props: {
 			modelValue: '',
 			placeholder: 'Select a credential...',
 			dataTestId: 'agent-credential-select',
+			credentialPermissions: { create: canCreateCredential },
 			credentials: [
 				{ id: 'z', name: 'Zulu Slack', typeDisplayName: 'Slack' },
 				{ id: 'a', name: 'alpha Slack', typeDisplayName: 'Slack' },
@@ -138,6 +139,14 @@ describe('AgentCredentialSelect', () => {
 		const footer = wrapper.find('[data-testid="credential-select-footer"]');
 		expect(footer.text()).toContain('Create new credential');
 		expect(wrapper.find('[data-test-id="node-credentials-select-item-new"]').exists()).toBe(true);
+	});
+
+	it('disables the create action when the caller cannot create credentials', () => {
+		const wrapper = renderSelect({ canCreateCredential: false });
+
+		expect(
+			wrapper.find('[data-test-id="node-credentials-select-item-new"]').attributes(),
+		).toHaveProperty('disabled');
 	});
 
 	it('emits create when the footer action is clicked', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentCredentialSelect.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentCredentialSelect.test.ts
@@ -5,48 +5,65 @@ import { nextTick } from 'vue';
 
 import AgentCredentialSelect from '../components/AgentCredentialSelect.vue';
 
-vi.mock('@n8n/design-system', () => ({
-	N8nIcon: { template: '<i />' },
+vi.mock('@n8n/i18n', () => ({
+	useI18n: () => ({
+		baseText: (key: string) => {
+			const translations: Record<string, string> = {
+				'nodeCredentials.createNew': 'Create new credential',
+				'nodeCredentials.createNew.permissionDenied':
+					'Your current role does not allow you to create credentials',
+			};
+			return translations[key] ?? key;
+		},
+	}),
 }));
 
-vi.mock('@n8n/design-system/components/N8nSelect', async () => {
-	const { defineComponent, provide } = await import('vue');
+vi.mock('@n8n/design-system', async () => {
+	const { defineComponent, inject, provide } = await import('vue');
+
+	const N8nSelect = defineComponent({
+		props: {
+			modelValue: { type: String, default: '' },
+			filterable: { type: Boolean, default: false },
+			filterMethod: { type: Function, default: undefined },
+			size: { type: String, default: '' },
+			placeholder: { type: String, default: '' },
+			loading: { type: Boolean, default: false },
+			disabled: { type: Boolean, default: false },
+		},
+		emits: ['update:modelValue'],
+		setup(props, { emit }) {
+			provide('selectOption', (value: string) => emit('update:modelValue', value));
+
+			function onInput(event: Event) {
+				props.filterMethod?.((event.target as HTMLInputElement).value);
+			}
+
+			function blur() {}
+
+			return { onInput, blur };
+		},
+		template: `
+			<div
+				:data-filterable="String(filterable)"
+				:data-size="size"
+				:data-placeholder="placeholder"
+				:data-loading="String(loading)"
+				:data-disabled="String(disabled)"
+			>
+				<input data-testid="credential-search" @input="onInput" />
+				<slot />
+				<div data-testid="credential-select-footer"><slot name="footer" /></div>
+			</div>
+		`,
+	});
 
 	return {
-		default: defineComponent({
-			props: {
-				modelValue: { type: String, default: '' },
-				filterable: { type: Boolean, default: false },
-				filterMethod: { type: Function, default: undefined },
-			},
-			emits: ['update:modelValue'],
-			setup(props, { emit }) {
-				provide('selectOption', (value: string) => emit('update:modelValue', value));
-
-				function onInput(event: Event) {
-					props.filterMethod?.((event.target as HTMLInputElement).value);
-				}
-
-				function blur() {}
-
-				return { onInput, blur };
-			},
-			template: `
-				<div :data-filterable="String(filterable)">
-					<input data-testid="credential-search" @input="onInput" />
-					<slot />
-					<div data-testid="credential-select-footer"><slot name="footer" /></div>
-				</div>
-			`,
-		}),
-	};
-});
-
-vi.mock('@n8n/design-system/components/N8nOption', async () => {
-	const { defineComponent, inject } = await import('vue');
-
-	return {
-		default: defineComponent({
+		N8nIcon: { template: '<i />' },
+		N8nText: { template: '<span><slot /></span>' },
+		N8nTooltip: { template: '<span><slot /></span>' },
+		N8nSelect,
+		N8nOption: defineComponent({
 			props: {
 				value: { type: String, required: true },
 				label: { type: String, required: true },
@@ -60,8 +77,9 @@ vi.mock('@n8n/design-system/components/N8nOption', async () => {
 					type="button"
 					data-testid="credential-option"
 					:data-value="value"
+					:data-label="label"
 					@click="selectOption?.(value)"
-				>{{ label }}</button>
+				><slot>{{ label }}</slot></button>
 			`,
 		}),
 	};
@@ -72,19 +90,20 @@ function renderSelect() {
 		props: {
 			modelValue: '',
 			placeholder: 'Select a credential...',
-			createLabel: 'New credential',
 			dataTestId: 'agent-credential-select',
 			credentials: [
-				{ id: 'z', name: 'Zulu Slack' },
-				{ id: 'a', name: 'alpha Slack' },
-				{ id: 'b', name: 'Beta Slack' },
+				{ id: 'z', name: 'Zulu Slack', typeDisplayName: 'Slack' },
+				{ id: 'a', name: 'alpha Slack', typeDisplayName: 'Slack' },
+				{ id: 'b', name: 'Beta Slack', typeDisplayName: 'Slack' },
 			],
 		},
 	});
 }
 
 function optionLabels(wrapper: ReturnType<typeof renderSelect>) {
-	return wrapper.findAll('[data-testid="credential-option"]').map((option) => option.text());
+	return wrapper
+		.findAll('[data-testid="credential-option"]')
+		.map((option) => option.attributes('data-label'));
 }
 
 describe('AgentCredentialSelect', () => {
@@ -92,6 +111,7 @@ describe('AgentCredentialSelect', () => {
 		const wrapper = renderSelect();
 
 		expect(wrapper.find('[data-filterable="true"]').exists()).toBe(true);
+		expect(wrapper.find('[data-size="small"]').exists()).toBe(true);
 		expect(optionLabels(wrapper)).toEqual(['alpha Slack', 'Beta Slack', 'Zulu Slack']);
 	});
 
@@ -116,14 +136,14 @@ describe('AgentCredentialSelect', () => {
 		const wrapper = renderSelect();
 
 		const footer = wrapper.find('[data-testid="credential-select-footer"]');
-		expect(footer.text()).toContain('New credential');
-		expect(wrapper.find('[data-testid="agent-credential-select-create"]').exists()).toBe(true);
+		expect(footer.text()).toContain('Create new credential');
+		expect(wrapper.find('[data-test-id="node-credentials-select-item-new"]').exists()).toBe(true);
 	});
 
 	it('emits create when the footer action is clicked', async () => {
 		const wrapper = renderSelect();
 
-		await wrapper.find('[data-testid="agent-credential-select-create"]').trigger('click');
+		await wrapper.find('[data-test-id="node-credentials-select-item-new"]').trigger('click');
 
 		expect(wrapper.emitted('create')).toHaveLength(1);
 	});

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentCredentialSelect.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentCredentialSelect.test.ts
@@ -1,0 +1,130 @@
+/* eslint-disable import-x/no-extraneous-dependencies -- test-only pattern */
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { nextTick } from 'vue';
+
+import AgentCredentialSelect from '../components/AgentCredentialSelect.vue';
+
+vi.mock('@n8n/design-system', () => ({
+	N8nIcon: { template: '<i />' },
+}));
+
+vi.mock('@n8n/design-system/components/N8nSelect', async () => {
+	const { defineComponent, provide } = await import('vue');
+
+	return {
+		default: defineComponent({
+			props: {
+				modelValue: { type: String, default: '' },
+				filterable: { type: Boolean, default: false },
+				filterMethod: { type: Function, default: undefined },
+			},
+			emits: ['update:modelValue'],
+			setup(props, { emit }) {
+				provide('selectOption', (value: string) => emit('update:modelValue', value));
+
+				function onInput(event: Event) {
+					props.filterMethod?.((event.target as HTMLInputElement).value);
+				}
+
+				function blur() {}
+
+				return { onInput, blur };
+			},
+			template: `
+				<div :data-filterable="String(filterable)">
+					<input data-testid="credential-search" @input="onInput" />
+					<slot />
+					<div data-testid="credential-select-footer"><slot name="footer" /></div>
+				</div>
+			`,
+		}),
+	};
+});
+
+vi.mock('@n8n/design-system/components/N8nOption', async () => {
+	const { defineComponent, inject } = await import('vue');
+
+	return {
+		default: defineComponent({
+			props: {
+				value: { type: String, required: true },
+				label: { type: String, required: true },
+			},
+			setup() {
+				const selectOption = inject<(value: string) => void>('selectOption');
+				return { selectOption };
+			},
+			template: `
+				<button
+					type="button"
+					data-testid="credential-option"
+					:data-value="value"
+					@click="selectOption?.(value)"
+				>{{ label }}</button>
+			`,
+		}),
+	};
+});
+
+function renderSelect() {
+	return mount(AgentCredentialSelect, {
+		props: {
+			modelValue: '',
+			placeholder: 'Select a credential...',
+			createLabel: 'New credential',
+			dataTestId: 'agent-credential-select',
+			credentials: [
+				{ id: 'z', name: 'Zulu Slack' },
+				{ id: 'a', name: 'alpha Slack' },
+				{ id: 'b', name: 'Beta Slack' },
+			],
+		},
+	});
+}
+
+function optionLabels(wrapper: ReturnType<typeof renderSelect>) {
+	return wrapper.findAll('[data-testid="credential-option"]').map((option) => option.text());
+}
+
+describe('AgentCredentialSelect', () => {
+	it('renders credential options alphabetically by name', () => {
+		const wrapper = renderSelect();
+
+		expect(wrapper.find('[data-filterable="true"]').exists()).toBe(true);
+		expect(optionLabels(wrapper)).toEqual(['alpha Slack', 'Beta Slack', 'Zulu Slack']);
+	});
+
+	it('filters credential options by case-insensitive search text', async () => {
+		const wrapper = renderSelect();
+
+		await wrapper.find('[data-testid="credential-search"]').setValue('be');
+		await nextTick();
+
+		expect(optionLabels(wrapper)).toEqual(['Beta Slack']);
+	});
+
+	it('emits the selected credential id', async () => {
+		const wrapper = renderSelect();
+
+		await wrapper.find('[data-value="b"]').trigger('click');
+
+		expect(wrapper.emitted('update:modelValue')).toEqual([['b']]);
+	});
+
+	it('renders the create action in the select footer when credentials exist', () => {
+		const wrapper = renderSelect();
+
+		const footer = wrapper.find('[data-testid="credential-select-footer"]');
+		expect(footer.text()).toContain('New credential');
+		expect(wrapper.find('[data-testid="agent-credential-select-create"]').exists()).toBe(true);
+	});
+
+	it('emits create when the footer action is clicked', async () => {
+		const wrapper = renderSelect();
+
+		await wrapper.find('[data-testid="agent-credential-select-create"]').trigger('click');
+
+		expect(wrapper.emitted('create')).toHaveLength(1);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentIntegrationCredentialPickers.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentIntegrationCredentialPickers.test.ts
@@ -1,0 +1,205 @@
+/* eslint-disable import-x/no-extraneous-dependencies -- test-only pattern */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+import AgentAddTriggerModal from '../components/AgentAddTriggerModal.vue';
+import AgentIntegrationsPanel from '../components/AgentIntegrationsPanel.vue';
+
+const {
+	fetchAllCredentialsForWorkflow,
+	openNewCredential,
+	openExistingCredential,
+	getIntegrationStatus,
+	connectIntegration,
+	disconnectIntegration,
+	ensureLoaded,
+} = vi.hoisted(() => ({
+	fetchAllCredentialsForWorkflow: vi.fn(),
+	openNewCredential: vi.fn(),
+	openExistingCredential: vi.fn(),
+	getIntegrationStatus: vi.fn(),
+	connectIntegration: vi.fn(),
+	disconnectIntegration: vi.fn(),
+	ensureLoaded: vi.fn(),
+}));
+
+const slackIntegration = {
+	type: 'slack',
+	label: 'Slack',
+	icon: 'slack',
+	description: 'Connect Slack',
+	connectedDescription: 'Connected to Slack',
+	credentialTypes: ['slackOAuth2Api', 'slackApi'],
+	noCredentialsMessage: 'No Slack credentials found.',
+};
+
+vi.mock('@n8n/i18n', () => ({
+	useI18n: () => ({ baseText: (key: string) => key }),
+	i18n: { baseText: (key: string) => key },
+}));
+
+vi.mock('@n8n/stores/useRootStore', () => ({
+	useRootStore: () => ({
+		restApiContext: {},
+		urlBaseWebhook: 'https://hooks.example',
+		OAuthCallbackUrls: { oauth2: 'https://hooks.example/rest/oauth2-credential/callback' },
+	}),
+}));
+
+vi.mock('@/app/stores/ui.store', () => ({
+	useUIStore: () => ({
+		isModalActiveById: {},
+		openNewCredential,
+		openExistingCredential,
+		closeModal: vi.fn(),
+	}),
+}));
+
+vi.mock('@/features/credentials/credentials.store', () => ({
+	useCredentialsStore: () => ({
+		setCredentials: vi.fn(),
+		fetchAllCredentialsForWorkflow,
+	}),
+}));
+
+vi.mock('../composables/useAgentApi', () => ({
+	getIntegrationStatus,
+	connectIntegration,
+	disconnectIntegration,
+}));
+
+vi.mock('../composables/useAgentIntegrationsCatalog', () => ({
+	useAgentIntegrationsCatalog: () => ({
+		catalog: { value: [slackIntegration] },
+		ensureLoaded,
+	}),
+}));
+
+vi.mock('../composables/useAgentPublish', () => ({
+	useAgentPublish: () => ({
+		publish: vi.fn(),
+		publishing: false,
+	}),
+}));
+
+vi.mock('../composables/useAgentConfirmationModal', () => ({
+	useAgentConfirmationModal: () => ({
+		openAgentConfirmationModal: vi.fn(),
+	}),
+}));
+
+const AgentCredentialSelectStub = {
+	props: ['modelValue', 'credentials', 'createLabel', 'dataTestId', 'placeholder'],
+	emits: ['create', 'update:modelValue'],
+	template: `
+		<div
+			data-testid="agent-credential-select-stub"
+			:data-create-label="createLabel"
+			:data-test-id-prop="dataTestId"
+			:data-options="credentials.map((credential) => credential.name).join('|')"
+		>
+			<button data-testid="stub-create-credential" @click="$emit('create')" />
+		</div>
+	`,
+};
+
+const globalStubs = {
+	AgentCredentialSelect: AgentCredentialSelectStub,
+	AgentScheduleTriggerCard: { template: '<div data-testid="schedule-trigger-card" />' },
+	Modal: {
+		template:
+			'<section><slot name="header" /><slot name="content" /><slot name="footer" /></section>',
+	},
+	N8nButton: {
+		props: ['disabled', 'loading'],
+		emits: ['click'],
+		template:
+			'<button v-bind="$attrs" :disabled="disabled || loading" @click="$emit(\'click\', $event)"><slot name="prefix" /><slot /></button>',
+	},
+	N8nCard: { template: '<article><slot name="header" /><slot /></article>' },
+	N8nDialog: { template: '<div><slot /></div>' },
+	N8nHeading: { template: '<h2><slot /></h2>' },
+	N8nIcon: { template: '<i />' },
+	N8nOption: { template: '<option><slot /></option>' },
+	N8nSelect: { template: '<div><slot name="prefix" /><slot /></div>' },
+	N8nText: { template: '<span><slot /></span>' },
+};
+
+describe('agent integration credential picker usage', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		getIntegrationStatus.mockResolvedValue({ integrations: [] });
+		ensureLoaded.mockResolvedValue([slackIntegration]);
+		fetchAllCredentialsForWorkflow.mockResolvedValue([
+			{ id: 'cred-1', name: 'Workspace Slack', type: 'slackOAuth2Api' },
+		]);
+	});
+
+	it('uses the shared credential picker in the add-trigger modal', async () => {
+		const wrapper = mount(AgentAddTriggerModal, {
+			props: {
+				modalName: 'agentAddTriggerModal',
+				data: {
+					projectId: 'project-1',
+					agentId: 'agent-1',
+					agentName: 'Agent',
+					isPublished: true,
+					initialTriggerType: 'slack',
+					connectedTriggers: [],
+					onConnectedTriggersChange: vi.fn(),
+					onTriggerAdded: vi.fn(),
+				},
+			},
+			global: { stubs: globalStubs },
+		});
+		await flushPromises();
+
+		const picker = wrapper.find('[data-testid="agent-credential-select-stub"]');
+		expect(picker.exists()).toBe(true);
+		expect(picker.attributes('data-test-id-prop')).toBe('slack-credential-select');
+		expect(picker.attributes('data-create-label')).toBe('agents.builder.addTrigger.newCredential');
+
+		await wrapper.find('[data-testid="stub-create-credential"]').trigger('click');
+
+		expect(openNewCredential).toHaveBeenCalledWith(
+			'slackOAuth2Api',
+			false,
+			false,
+			'project-1',
+			undefined,
+			undefined,
+			{ hideAskAssistant: true },
+		);
+	});
+
+	it('uses the shared credential picker in the integrations panel', async () => {
+		const wrapper = mount(AgentIntegrationsPanel, {
+			props: {
+				projectId: 'project-1',
+				agentId: 'agent-1',
+				agentName: 'Agent',
+				isPublished: true,
+				focusType: 'slack',
+			},
+			global: { stubs: globalStubs },
+		});
+		await flushPromises();
+
+		const picker = wrapper.find('[data-testid="agent-credential-select-stub"]');
+		expect(picker.exists()).toBe(true);
+		expect(picker.attributes('data-test-id-prop')).toBe('slack-credential-select');
+		expect(picker.attributes('data-create-label')).toBe('New credential');
+
+		await wrapper.find('[data-testid="stub-create-credential"]').trigger('click');
+
+		expect(openNewCredential).toHaveBeenCalledWith(
+			'slackApi',
+			false,
+			false,
+			'project-1',
+			undefined,
+			undefined,
+			{ hideAskAssistant: true },
+		);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentIntegrationCredentialPickers.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentIntegrationCredentialPickers.test.ts
@@ -59,6 +59,7 @@ vi.mock('@/features/credentials/credentials.store', () => ({
 	useCredentialsStore: () => ({
 		setCredentials: vi.fn(),
 		fetchAllCredentialsForWorkflow,
+		getCredentialTypeByName: () => ({ displayName: 'Slack' }),
 	}),
 }));
 
@@ -89,12 +90,11 @@ vi.mock('../composables/useAgentConfirmationModal', () => ({
 }));
 
 const AgentCredentialSelectStub = {
-	props: ['modelValue', 'credentials', 'createLabel', 'dataTestId', 'placeholder'],
+	props: ['modelValue', 'credentials', 'dataTestId', 'placeholder'],
 	emits: ['create', 'update:modelValue'],
 	template: `
 		<div
 			data-testid="agent-credential-select-stub"
-			:data-create-label="createLabel"
 			:data-test-id-prop="dataTestId"
 			:data-options="credentials.map((credential) => credential.name).join('|')"
 		>
@@ -157,7 +157,6 @@ describe('agent integration credential picker usage', () => {
 		const picker = wrapper.find('[data-testid="agent-credential-select-stub"]');
 		expect(picker.exists()).toBe(true);
 		expect(picker.attributes('data-test-id-prop')).toBe('slack-credential-select');
-		expect(picker.attributes('data-create-label')).toBe('agents.builder.addTrigger.newCredential');
 
 		await wrapper.find('[data-testid="stub-create-credential"]').trigger('click');
 
@@ -188,7 +187,6 @@ describe('agent integration credential picker usage', () => {
 		const picker = wrapper.find('[data-testid="agent-credential-select-stub"]');
 		expect(picker.exists()).toBe(true);
 		expect(picker.attributes('data-test-id-prop')).toBe('slack-credential-select');
-		expect(picker.attributes('data-create-label')).toBe('New credential');
 
 		await wrapper.find('[data-testid="stub-create-credential"]').trigger('click');
 

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentIntegrationCredentialPickers.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentIntegrationCredentialPickers.test.ts
@@ -23,6 +23,12 @@ const {
 	ensureLoaded: vi.fn(),
 }));
 
+const projectState = vi.hoisted(() => ({
+	currentProject: { id: 'project-1', name: 'Project', scopes: ['credential:create'] },
+	personalProject: null,
+	myProjects: [],
+}));
+
 const slackIntegration = {
 	type: 'slack',
 	label: 'Slack',
@@ -63,6 +69,10 @@ vi.mock('@/features/credentials/credentials.store', () => ({
 	}),
 }));
 
+vi.mock('@/features/collaboration/projects/projects.store', () => ({
+	useProjectsStore: () => projectState,
+}));
+
 vi.mock('../composables/useAgentApi', () => ({
 	getIntegrationStatus,
 	connectIntegration,
@@ -90,12 +100,13 @@ vi.mock('../composables/useAgentConfirmationModal', () => ({
 }));
 
 const AgentCredentialSelectStub = {
-	props: ['modelValue', 'credentials', 'dataTestId', 'placeholder'],
+	props: ['modelValue', 'credentials', 'dataTestId', 'placeholder', 'credentialPermissions'],
 	emits: ['create', 'update:modelValue'],
 	template: `
 		<div
 			data-testid="agent-credential-select-stub"
 			:data-test-id-prop="dataTestId"
+			:data-can-create="String(credentialPermissions.create)"
 			:data-options="credentials.map((credential) => credential.name).join('|')"
 		>
 			<button data-testid="stub-create-credential" @click="$emit('create')" />
@@ -128,6 +139,13 @@ const globalStubs = {
 describe('agent integration credential picker usage', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		projectState.currentProject = {
+			id: 'project-1',
+			name: 'Project',
+			scopes: ['credential:create'],
+		};
+		projectState.personalProject = null;
+		projectState.myProjects = [];
 		getIntegrationStatus.mockResolvedValue({ integrations: [] });
 		ensureLoaded.mockResolvedValue([slackIntegration]);
 		fetchAllCredentialsForWorkflow.mockResolvedValue([
@@ -157,6 +175,7 @@ describe('agent integration credential picker usage', () => {
 		const picker = wrapper.find('[data-testid="agent-credential-select-stub"]');
 		expect(picker.exists()).toBe(true);
 		expect(picker.attributes('data-test-id-prop')).toBe('slack-credential-select');
+		expect(picker.attributes('data-can-create')).toBe('true');
 
 		await wrapper.find('[data-testid="stub-create-credential"]').trigger('click');
 
@@ -187,6 +206,7 @@ describe('agent integration credential picker usage', () => {
 		const picker = wrapper.find('[data-testid="agent-credential-select-stub"]');
 		expect(picker.exists()).toBe(true);
 		expect(picker.attributes('data-test-id-prop')).toBe('slack-credential-select');
+		expect(picker.attributes('data-can-create')).toBe('true');
 
 		await wrapper.find('[data-testid="stub-create-credential"]').trigger('click');
 
@@ -199,5 +219,25 @@ describe('agent integration credential picker usage', () => {
 			undefined,
 			{ hideAskAssistant: true },
 		);
+	});
+
+	it('passes denied credential creation permission to the shared picker', async () => {
+		projectState.currentProject = { id: 'project-1', name: 'Project', scopes: [] };
+
+		const wrapper = mount(AgentIntegrationsPanel, {
+			props: {
+				projectId: 'project-1',
+				agentId: 'agent-1',
+				agentName: 'Agent',
+				isPublished: true,
+				focusType: 'slack',
+			},
+			global: { stubs: globalStubs },
+		});
+		await flushPromises();
+
+		expect(
+			wrapper.find('[data-testid="agent-credential-select-stub"]').attributes('data-can-create'),
+		).toBe('false');
 	});
 });

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentToolConfigModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentToolConfigModal.test.ts
@@ -26,7 +26,7 @@ vi.mock('uuid', () => ({ v4: () => 'mocked-uuid' }));
 
 function createToolSettingsStub(emitValid: boolean) {
 	return defineComponent({
-		props: ['initialNode', 'existingToolNames'],
+		props: ['initialNode', 'existingToolNames', 'projectId'],
 		emits: ['update:valid', 'update:node-name'],
 		setup(props, { emit, expose }) {
 			// Expose what the modal reads from ref(...). The stub carries through
@@ -50,7 +50,7 @@ function createToolSettingsStub(emitValid: boolean) {
 			});
 			return {};
 		},
-		template: '<div data-test-id="node-tool-settings-content" />',
+		template: '<div data-test-id="node-tool-settings-content" :data-project-id="projectId" />',
 	});
 }
 
@@ -124,11 +124,15 @@ function renderModal({
 	onConfirm = vi.fn(),
 	ref = toolRef(),
 	customTool,
+	projectId,
+	agentId,
 }: {
 	valid?: boolean;
 	onConfirm?: (updated: AgentJsonToolRef) => void;
 	ref?: AgentJsonToolRef;
 	customTool?: CustomToolEntry;
+	projectId?: string;
+	agentId?: string;
 } = {}) {
 	const renderComponent = createComponentRenderer(AgentToolConfigModal, {
 		global: {
@@ -147,7 +151,7 @@ function renderModal({
 	return renderComponent({
 		props: {
 			modalName: MODAL_NAME,
-			data: { toolRef: ref, customTool, existingToolNames: [], onConfirm },
+			data: { toolRef: ref, customTool, existingToolNames: [], projectId, agentId, onConfirm },
 		},
 	});
 }
@@ -166,6 +170,13 @@ describe('AgentToolConfigModal', () => {
 	it('renders the shared node-tool settings content', () => {
 		const { getByTestId } = renderModal();
 		expect(getByTestId('node-tool-settings-content')).toBeTruthy();
+	});
+
+	it('passes agent project context to the node-tool settings content', () => {
+		const { getByTestId } = renderModal({ projectId: 'project-1', agentId: 'agent-1' });
+
+		const settings = getByTestId('node-tool-settings-content');
+		expect(settings.getAttribute('data-project-id')).toBe('project-1');
 	});
 
 	it('does not render the removed Configure / Permissions outer tabs', () => {

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentAddTriggerModal.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentAddTriggerModal.vue
@@ -11,6 +11,7 @@ import N8nSelect from '@n8n/design-system/components/N8nSelect';
 import N8nOption from '@n8n/design-system/components/N8nOption';
 import Modal from '@/app/components/Modal.vue';
 import { useI18n } from '@n8n/i18n';
+import { useRootStore } from '@n8n/stores/useRootStore';
 import { useUIStore } from '@/app/stores/ui.store';
 import { CREDENTIAL_EDIT_MODAL_KEY } from '@/features/credentials/credentials.constants';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
@@ -44,6 +45,7 @@ const props = defineProps<{
 }>();
 
 const i18n = useI18n();
+const rootStore = useRootStore();
 const uiStore = useUIStore();
 const credentialsStore = useCredentialsStore();
 const { catalog, ensureLoaded } = useAgentIntegrationsCatalog();

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentAddTriggerModal.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentAddTriggerModal.vue
@@ -15,6 +15,8 @@ import { useRootStore } from '@n8n/stores/useRootStore';
 import { useUIStore } from '@/app/stores/ui.store';
 import { CREDENTIAL_EDIT_MODAL_KEY } from '@/features/credentials/credentials.constants';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
+import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
+import { getResourcePermissions } from '@n8n/permissions';
 import { AGENT_SCHEDULE_TRIGGER_TYPE, type ChatIntegrationDescriptor } from '@n8n/api-types';
 import { MODAL_CONFIRM } from '@/app/constants';
 import { useAgentIntegrationsCatalog } from '../composables/useAgentIntegrationsCatalog';
@@ -44,6 +46,7 @@ const i18n = useI18n();
 const rootStore = useRootStore();
 const uiStore = useUIStore();
 const credentialsStore = useCredentialsStore();
+const projectsStore = useProjectsStore();
 const { catalog, ensureLoaded } = useAgentIntegrationsCatalog();
 const { publish, publishing } = useAgentPublish();
 const { openAgentConfirmationModal } = useAgentConfirmationModal();
@@ -88,6 +91,19 @@ const SCHEDULE_ICON: IconName = 'clock';
 const currentIntegration = computed<ChatIntegrationDescriptor | null>(
 	() => integrations.value.find((i) => i.type === selectedTriggerType.value) ?? null,
 );
+
+const projectForPermissions = computed(() => {
+	if (projectsStore.currentProject?.id === props.data.projectId)
+		return projectsStore.currentProject;
+	if (projectsStore.personalProject?.id === props.data.projectId)
+		return projectsStore.personalProject;
+	return projectsStore.myProjects.find((project) => project.id === props.data.projectId) ?? null;
+});
+
+const credentialPermissions = computed(() => {
+	const permissions = getResourcePermissions(projectForPermissions.value?.scopes).credential;
+	return { ...permissions, create: !!permissions.create };
+});
 
 // Backend integration descriptors ship icon names that may include legacy
 // aliases (e.g. `hashtag`, `paper-plane`); N8nIcon resolves them at runtime
@@ -526,6 +542,7 @@ onMounted(async () => {
 								:class="$style.select"
 								:placeholder="i18n.baseText('agents.builder.addTrigger.selectCredential')"
 								:credentials="credentialsByType[currentIntegration.type] ?? []"
+								:credential-permissions="credentialPermissions"
 								:loading="credentialsLoading"
 								:disabled="isLoading(currentIntegration.type)"
 								:data-test-id="`${currentIntegration.type}-credential-select`"

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentAddTriggerModal.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentAddTriggerModal.vue
@@ -23,12 +23,7 @@ import { useAgentPublish } from '../composables/useAgentPublish';
 import { useAgentConfirmationModal } from '../composables/useAgentConfirmationModal';
 import type { AgentResource } from '../types';
 import AgentScheduleTriggerCard from './AgentScheduleTriggerCard.vue';
-import AgentCredentialSelect from './AgentCredentialSelect.vue';
-
-interface CredentialOption {
-	id: string;
-	name: string;
-}
+import AgentCredentialSelect, { type AgentCredentialOption } from './AgentCredentialSelect.vue';
 
 const props = defineProps<{
 	modalName: string;
@@ -76,7 +71,7 @@ const {
 } = useAgentIntegrationStatus(props.data.projectId, props.data.agentId);
 
 const selectedCredentials = ref<Record<string, string>>({});
-const credentialsByType = ref<Record<string, CredentialOption[]>>({});
+const credentialsByType = ref<Record<string, AgentCredentialOption[]>>({});
 const credentialsLoading = ref(false);
 
 // Track credentials that existed before the user opened the "new credential"
@@ -299,7 +294,12 @@ async function fetchCredentials() {
 		for (const integration of integrations.value) {
 			credentialsByType.value[integration.type] = allCredentials
 				.filter((c) => integration.credentialTypes.includes(c.type))
-				.map((c) => ({ id: c.id, name: c.name }));
+				.map((c) => ({
+					id: c.id,
+					name: c.name,
+					typeDisplayName: credentialsStore.getCredentialTypeByName(c.type)?.displayName,
+					homeProject: c.homeProject,
+				}));
 		}
 	} catch {
 		for (const integration of integrations.value) {
@@ -526,7 +526,6 @@ onMounted(async () => {
 								:class="$style.select"
 								:placeholder="i18n.baseText('agents.builder.addTrigger.selectCredential')"
 								:credentials="credentialsByType[currentIntegration.type] ?? []"
-								:create-label="i18n.baseText('agents.builder.addTrigger.newCredential')"
 								:loading="credentialsLoading"
 								:disabled="isLoading(currentIntegration.type)"
 								:data-test-id="`${currentIntegration.type}-credential-select`"

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentAddTriggerModal.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentAddTriggerModal.vue
@@ -11,10 +11,9 @@ import N8nSelect from '@n8n/design-system/components/N8nSelect';
 import N8nOption from '@n8n/design-system/components/N8nOption';
 import Modal from '@/app/components/Modal.vue';
 import { useI18n } from '@n8n/i18n';
-import { useRootStore } from '@n8n/stores/useRootStore';
 import { useUIStore } from '@/app/stores/ui.store';
 import { CREDENTIAL_EDIT_MODAL_KEY } from '@/features/credentials/credentials.constants';
-import { makeRestApiRequest } from '@n8n/rest-api-client';
+import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { AGENT_SCHEDULE_TRIGGER_TYPE, type ChatIntegrationDescriptor } from '@n8n/api-types';
 import { MODAL_CONFIRM } from '@/app/constants';
 import { useAgentIntegrationsCatalog } from '../composables/useAgentIntegrationsCatalog';
@@ -45,8 +44,8 @@ const props = defineProps<{
 }>();
 
 const i18n = useI18n();
-const rootStore = useRootStore();
 const uiStore = useUIStore();
+const credentialsStore = useCredentialsStore();
 const { catalog, ensureLoaded } = useAgentIntegrationsCatalog();
 const { publish, publishing } = useAgentPublish();
 const { openAgentConfirmationModal } = useAgentConfirmationModal();
@@ -289,9 +288,10 @@ function closeModal() {
 async function fetchCredentials() {
 	credentialsLoading.value = true;
 	try {
-		const allCredentials = await makeRestApiRequest<
-			Array<{ id: string; name: string; type: string }>
-		>(rootStore.restApiContext, 'GET', '/credentials');
+		credentialsStore.setCredentials([]);
+		const allCredentials = await credentialsStore.fetchAllCredentialsForWorkflow({
+			projectId: props.data.projectId,
+		});
 
 		for (const integration of integrations.value) {
 			credentialsByType.value[integration.type] = allCredentials
@@ -354,9 +354,17 @@ function onCreateCredential(integration: ChatIntegrationDescriptor) {
 	const existing = credentialsByType.value[integration.type] ?? [];
 	credentialIdsBeforeNew.value[integration.type] = new Set(existing.map((c) => c.id));
 	pendingNewCredentialType.value = integration.type;
-	uiStore.openNewCredential(primaryCredentialType, false, false, undefined, undefined, undefined, {
-		hideAskAssistant: true,
-	});
+	uiStore.openNewCredential(
+		primaryCredentialType,
+		false,
+		false,
+		props.data.projectId,
+		undefined,
+		undefined,
+		{
+			hideAskAssistant: true,
+		},
+	);
 }
 
 function onEditCredential(type: string) {

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentAddTriggerModal.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentAddTriggerModal.vue
@@ -23,6 +23,7 @@ import { useAgentPublish } from '../composables/useAgentPublish';
 import { useAgentConfirmationModal } from '../composables/useAgentConfirmationModal';
 import type { AgentResource } from '../types';
 import AgentScheduleTriggerCard from './AgentScheduleTriggerCard.vue';
+import AgentCredentialSelect from './AgentCredentialSelect.vue';
 
 interface CredentialOption {
 	id: string;
@@ -520,22 +521,17 @@ onMounted(async () => {
 							</N8nText>
 						</label>
 						<div :class="$style.selectRow">
-							<N8nSelect
+							<AgentCredentialSelect
 								v-model="selectedCredentials[currentIntegration.type]"
 								:class="$style.select"
 								:placeholder="i18n.baseText('agents.builder.addTrigger.selectCredential')"
+								:credentials="credentialsByType[currentIntegration.type] ?? []"
+								:create-label="i18n.baseText('agents.builder.addTrigger.newCredential')"
 								:loading="credentialsLoading"
 								:disabled="isLoading(currentIntegration.type)"
-								size="medium"
-								:data-testid="`${currentIntegration.type}-credential-select`"
-							>
-								<N8nOption
-									v-for="cred in credentialsByType[currentIntegration.type] ?? []"
-									:key="cred.id"
-									:value="cred.id"
-									:label="cred.name"
-								/>
-							</N8nSelect>
+								:data-test-id="`${currentIntegration.type}-credential-select`"
+								@create="onCreateCredential(currentIntegration)"
+							/>
 							<N8nButton
 								v-if="selectedCredentials[currentIntegration.type]"
 								variant="outline"
@@ -609,15 +605,6 @@ onMounted(async () => {
 			<div :class="$style.footer">
 				<div :class="$style.footerActions">
 					<template v-if="!isConnected(currentIntegration.type)">
-						<N8nButton
-							variant="outline"
-							size="small"
-							:data-testid="`${currentIntegration.type}-create-another-credential`"
-							@click="onCreateCredential(currentIntegration)"
-						>
-							<template #prefix><N8nIcon icon="plus" size="xsmall" /></template>
-							{{ i18n.baseText('agents.builder.addTrigger.newCredential') }}
-						</N8nButton>
 						<N8nButton
 							variant="solid"
 							:disabled="

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentCredentialSelect.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentCredentialSelect.vue
@@ -17,6 +17,7 @@ const props = defineProps<{
 	credentials: AgentCredentialOption[];
 	placeholder: string;
 	dataTestId: string;
+	credentialPermissions: PermissionsRecord['credential'];
 	loading?: boolean;
 	disabled?: boolean;
 }>();
@@ -25,10 +26,6 @@ const emit = defineEmits<{
 	'update:modelValue': [credentialId: string];
 	create: [];
 }>();
-
-const credentialPermissions = {
-	create: true,
-} satisfies PermissionsRecord['credential'];
 
 const credentialOptions = computed<DropdownCredentialOption[]>(() =>
 	[...props.credentials]

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentCredentialSelect.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentCredentialSelect.vue
@@ -1,0 +1,135 @@
+<script setup lang="ts">
+import { computed, nextTick, ref } from 'vue';
+import { N8nIcon } from '@n8n/design-system';
+import N8nSelect from '@n8n/design-system/components/N8nSelect';
+import N8nOption from '@n8n/design-system/components/N8nOption';
+
+export interface AgentCredentialOption {
+	id: string;
+	name: string;
+}
+
+const props = defineProps<{
+	modelValue?: string;
+	credentials: AgentCredentialOption[];
+	placeholder: string;
+	createLabel: string;
+	dataTestId: string;
+	loading?: boolean;
+	disabled?: boolean;
+}>();
+
+const emit = defineEmits<{
+	'update:modelValue': [credentialId: string];
+	create: [];
+}>();
+
+const selectRef = ref<InstanceType<typeof N8nSelect> | null>(null);
+const filter = ref('');
+
+const sortedCredentials = computed(() =>
+	[...props.credentials].sort((a, b) => {
+		const byName = a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+		return byName === 0 ? a.id.localeCompare(b.id) : byName;
+	}),
+);
+
+const filteredCredentials = computed(() =>
+	sortedCredentials.value.filter((credential) => matches(filter.value, credential.name)),
+);
+
+function setFilter(newFilter = '') {
+	filter.value = newFilter;
+}
+
+function matches(needle: string, haystack: string) {
+	return haystack.toLocaleLowerCase().includes(needle.toLocaleLowerCase());
+}
+
+async function onCreateCredential() {
+	selectRef.value?.blur();
+	await nextTick();
+	emit('create');
+}
+</script>
+
+<template>
+	<N8nSelect
+		ref="selectRef"
+		:model-value="modelValue"
+		:placeholder="placeholder"
+		:loading="loading"
+		:disabled="disabled"
+		size="medium"
+		filterable
+		:filter-method="setFilter"
+		:popper-class="$style.selectPopper"
+		:data-testid="dataTestId"
+		@update:model-value="(value: string) => emit('update:modelValue', value)"
+	>
+		<N8nOption
+			v-for="credential in filteredCredentials"
+			:key="credential.id"
+			:value="credential.id"
+			:label="credential.name"
+		/>
+		<template #empty> </template>
+		<template #footer>
+			<button
+				type="button"
+				:class="$style.newCredential"
+				:data-testid="`${dataTestId}-create`"
+				@click="onCreateCredential"
+			>
+				<N8nIcon icon="plus" size="xsmall" />
+				{{ createLabel }}
+			</button>
+		</template>
+	</N8nSelect>
+</template>
+
+<style lang="scss" module>
+.selectPopper {
+	:global(.el-select-dropdown__list) {
+		padding: 0;
+	}
+
+	:has(.newCredential:hover) :global(.hover) {
+		background-color: transparent;
+	}
+
+	&:not(:has(li)) .newCredential {
+		border-top: none;
+		box-shadow: none;
+		border-radius: var(--radius);
+	}
+}
+
+.newCredential {
+	display: flex;
+	width: 100%;
+	gap: var(--spacing--3xs);
+	align-items: center;
+	font-weight: var(--font-weight--bold);
+	padding: var(--spacing--xs) var(--spacing--md);
+	background-color: var(--color--background--light-2);
+	color: var(--color--text--shade-1);
+
+	border: 0;
+	border-top: var(--border);
+	box-shadow: var(--shadow--light);
+	clip-path: inset(-12px 0 0 0); // Only show box shadow on top
+
+	&:not([disabled]) {
+		cursor: pointer;
+		&:hover {
+			color: var(--color--primary);
+		}
+	}
+
+	&[disabled] {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentCredentialSelect.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentCredentialSelect.vue
@@ -1,19 +1,21 @@
 <script setup lang="ts">
-import { computed, nextTick, ref } from 'vue';
-import { N8nIcon } from '@n8n/design-system';
-import N8nSelect from '@n8n/design-system/components/N8nSelect';
-import N8nOption from '@n8n/design-system/components/N8nOption';
+import { computed } from 'vue';
+import type { PermissionsRecord } from '@n8n/permissions';
+import CredentialsDropdown, {
+	type CredentialOption as DropdownCredentialOption,
+} from '@/features/credentials/components/CredentialPicker/CredentialsDropdown.vue';
 
 export interface AgentCredentialOption {
 	id: string;
 	name: string;
+	typeDisplayName?: string;
+	homeProject?: DropdownCredentialOption['homeProject'];
 }
 
 const props = defineProps<{
 	modelValue?: string;
 	credentials: AgentCredentialOption[];
 	placeholder: string;
-	createLabel: string;
 	dataTestId: string;
 	loading?: boolean;
 	disabled?: boolean;
@@ -24,112 +26,39 @@ const emit = defineEmits<{
 	create: [];
 }>();
 
-const selectRef = ref<InstanceType<typeof N8nSelect> | null>(null);
-const filter = ref('');
+const credentialPermissions = {
+	create: true,
+} satisfies PermissionsRecord['credential'];
 
-const sortedCredentials = computed(() =>
-	[...props.credentials].sort((a, b) => {
-		const byName = a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
-		return byName === 0 ? a.id.localeCompare(b.id) : byName;
-	}),
+const credentialOptions = computed<DropdownCredentialOption[]>(() =>
+	[...props.credentials]
+		.sort((a, b) => {
+			const byName = a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+			return byName === 0 ? a.id.localeCompare(b.id) : byName;
+		})
+		.map((credential) => ({
+			id: credential.id,
+			name: credential.name,
+			typeDisplayName: credential.typeDisplayName,
+			homeProject: credential.homeProject,
+		})),
 );
 
-const filteredCredentials = computed(() =>
-	sortedCredentials.value.filter((credential) => matches(filter.value, credential.name)),
-);
-
-function setFilter(newFilter = '') {
-	filter.value = newFilter;
-}
-
-function matches(needle: string, haystack: string) {
-	return haystack.toLocaleLowerCase().includes(needle.toLocaleLowerCase());
-}
-
-async function onCreateCredential() {
-	selectRef.value?.blur();
-	await nextTick();
-	emit('create');
+function onCredentialSelected(credentialId: string) {
+	emit('update:modelValue', credentialId);
 }
 </script>
 
 <template>
-	<N8nSelect
-		ref="selectRef"
-		:model-value="modelValue"
+	<CredentialsDropdown
+		:credential-options="credentialOptions"
+		:selected-credential-id="modelValue ?? null"
+		:permissions="credentialPermissions"
 		:placeholder="placeholder"
 		:loading="loading"
 		:disabled="disabled"
-		size="medium"
-		filterable
-		:filter-method="setFilter"
-		:popper-class="$style.selectPopper"
-		:data-testid="dataTestId"
-		@update:model-value="(value: string) => emit('update:modelValue', value)"
-	>
-		<N8nOption
-			v-for="credential in filteredCredentials"
-			:key="credential.id"
-			:value="credential.id"
-			:label="credential.name"
-		/>
-		<template #empty> </template>
-		<template #footer>
-			<button
-				type="button"
-				:class="$style.newCredential"
-				:data-testid="`${dataTestId}-create`"
-				@click="onCreateCredential"
-			>
-				<N8nIcon icon="plus" size="xsmall" />
-				{{ createLabel }}
-			</button>
-		</template>
-	</N8nSelect>
+		:data-test-id="dataTestId"
+		@credential-selected="onCredentialSelected"
+		@new-credential="emit('create')"
+	/>
 </template>
-
-<style lang="scss" module>
-.selectPopper {
-	:global(.el-select-dropdown__list) {
-		padding: 0;
-	}
-
-	:has(.newCredential:hover) :global(.hover) {
-		background-color: transparent;
-	}
-
-	&:not(:has(li)) .newCredential {
-		border-top: none;
-		box-shadow: none;
-		border-radius: var(--radius);
-	}
-}
-
-.newCredential {
-	display: flex;
-	width: 100%;
-	gap: var(--spacing--3xs);
-	align-items: center;
-	font-weight: var(--font-weight--bold);
-	padding: var(--spacing--xs) var(--spacing--md);
-	background-color: var(--color--background--light-2);
-	color: var(--color--text--shade-1);
-
-	border: 0;
-	border-top: var(--border);
-	box-shadow: var(--shadow--light);
-	clip-path: inset(-12px 0 0 0); // Only show box shadow on top
-
-	&:not([disabled]) {
-		cursor: pointer;
-		&:hover {
-			color: var(--color--primary);
-		}
-	}
-
-	&[disabled] {
-		opacity: 0.5;
-		cursor: not-allowed;
-	}
-}
-</style>

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentIntegrationsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentIntegrationsPanel.vue
@@ -4,6 +4,7 @@ import { ref, computed, onMounted, watch } from 'vue';
 import { N8nButton, N8nCard, N8nDialog, N8nIcon, N8nText } from '@n8n/design-system';
 import N8nSelect from '@n8n/design-system/components/N8nSelect';
 import N8nOption from '@n8n/design-system/components/N8nOption';
+import { useRootStore } from '@n8n/stores/useRootStore';
 import { useUIStore } from '@/app/stores/ui.store';
 import { CREDENTIAL_EDIT_MODAL_KEY } from '@/features/credentials/credentials.constants';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
@@ -45,6 +46,7 @@ const emit = defineEmits<{
 	'trigger-added': [payload: { triggerType: string; triggers: string[] }];
 }>();
 
+const rootStore = useRootStore();
 const uiStore = useUIStore();
 const credentialsStore = useCredentialsStore();
 

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentIntegrationsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentIntegrationsPanel.vue
@@ -8,7 +8,7 @@ import { CREDENTIAL_EDIT_MODAL_KEY } from '@/features/credentials/credentials.co
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { useAgentIntegrationStatus } from '../composables/useAgentIntegrationStatus';
 import AgentScheduleTriggerCard from './AgentScheduleTriggerCard.vue';
-import AgentCredentialSelect from './AgentCredentialSelect.vue';
+import AgentCredentialSelect, { type AgentCredentialOption } from './AgentCredentialSelect.vue';
 
 const props = withDefaults(
 	defineProps<{
@@ -48,11 +48,6 @@ const emit = defineEmits<{
 const rootStore = useRootStore();
 const uiStore = useUIStore();
 const credentialsStore = useCredentialsStore();
-
-interface CredentialOption {
-	id: string;
-	name: string;
-}
 
 interface IntegrationConfig {
 	type: string;
@@ -114,7 +109,7 @@ const {
 
 // UI-only state — stays local.
 const selectedCredentials = ref<Record<string, string>>({});
-const credentialsByType = ref<Record<string, CredentialOption[]>>({});
+const credentialsByType = ref<Record<string, AgentCredentialOption[]>>({});
 const credentialsLoading = ref(false);
 const copied = ref(false);
 const showManifest = ref(false);
@@ -260,7 +255,12 @@ async function fetchCredentials() {
 		for (const config of integrationConfigs) {
 			credentialsByType.value[config.type] = allCredentials
 				.filter((c) => config.credentialTypes.includes(c.type))
-				.map((c) => ({ id: c.id, name: c.name }));
+				.map((c) => ({
+					id: c.id,
+					name: c.name,
+					typeDisplayName: credentialsStore.getCredentialTypeByName(c.type)?.displayName,
+					homeProject: c.homeProject,
+				}));
 		}
 	} catch {
 		for (const config of integrationConfigs) {
@@ -397,7 +397,6 @@ onMounted(async () => {
 							:class="$style.select"
 							placeholder="Select a credential..."
 							:credentials="credentialsByType[config.type] ?? []"
-							create-label="New credential"
 							:loading="credentialsLoading"
 							:disabled="isLoading(config.type)"
 							:data-test-id="`${config.type}-credential-select`"

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentIntegrationsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentIntegrationsPanel.vue
@@ -2,14 +2,13 @@
 import { AGENT_SCHEDULE_TRIGGER_TYPE } from '@n8n/api-types';
 import { ref, computed, onMounted, watch } from 'vue';
 import { N8nButton, N8nCard, N8nDialog, N8nIcon, N8nText } from '@n8n/design-system';
-import N8nSelect from '@n8n/design-system/components/N8nSelect';
-import N8nOption from '@n8n/design-system/components/N8nOption';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useUIStore } from '@/app/stores/ui.store';
 import { CREDENTIAL_EDIT_MODAL_KEY } from '@/features/credentials/credentials.constants';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { useAgentIntegrationStatus } from '../composables/useAgentIntegrationStatus';
 import AgentScheduleTriggerCard from './AgentScheduleTriggerCard.vue';
+import AgentCredentialSelect from './AgentCredentialSelect.vue';
 
 const props = withDefaults(
 	defineProps<{
@@ -122,10 +121,6 @@ const showManifest = ref(false);
 
 function isLoading(type: string): boolean {
 	return loadingMap.value[type] ?? false;
-}
-
-function hasCredentials(type: string): boolean {
-	return (credentialsByType.value[type] ?? []).length > 0;
 }
 
 function hasError(type: string): boolean {
@@ -393,49 +388,37 @@ onMounted(async () => {
 				</div>
 
 				<div v-if="!isConnected(config.type)" :class="$style.connectForm">
-					<template v-if="hasCredentials(config.type)">
-						<label :class="$style.label">
-							<N8nText size="small" bold>{{ config.label }} Credential</N8nText>
-						</label>
-						<div :class="$style.selectRow">
-							<N8nSelect
-								v-model="selectedCredentials[config.type]"
-								:class="$style.select"
-								placeholder="Select a credential..."
-								:loading="credentialsLoading"
-								:disabled="isLoading(config.type)"
-								size="medium"
-								:data-testid="`${config.type}-credential-select`"
-							>
-								<N8nOption
-									v-for="cred in credentialsByType[config.type] ?? []"
-									:key="cred.id"
-									:value="cred.id"
-									:label="cred.name"
-								/>
-							</N8nSelect>
-							<N8nButton
-								v-if="selectedCredentials[config.type]"
-								type="tertiary"
-								size="small"
-								icon="pen"
-								aria-label="Edit credential"
-								:data-testid="`${config.type}-edit-credential`"
-								@click="onEditCredential(config.type)"
-							/>
-						</div>
-					</template>
-
-					<div v-else-if="!credentialsLoading" :class="$style.emptyCredentials">
-						<N8nText size="small">{{ config.noCredentialsMessage }}</N8nText>
+					<label :class="$style.label">
+						<N8nText size="small" bold>{{ config.label }} Credential</N8nText>
+					</label>
+					<div :class="$style.selectRow">
+						<AgentCredentialSelect
+							v-model="selectedCredentials[config.type]"
+							:class="$style.select"
+							placeholder="Select a credential..."
+							:credentials="credentialsByType[config.type] ?? []"
+							create-label="New credential"
+							:loading="credentialsLoading"
+							:disabled="isLoading(config.type)"
+							:data-test-id="`${config.type}-credential-select`"
+							@create="onCreateCredential(config.type)"
+						/>
 						<N8nButton
+							v-if="selectedCredentials[config.type]"
+							type="tertiary"
 							size="small"
-							:data-testid="`${config.type}-create-credential`"
-							@click="onCreateCredential(config.type)"
-						>
-							<N8nIcon icon="plus" :size="14" />
-							Add {{ config.label }} credential
-						</N8nButton>
+							icon="pen"
+							aria-label="Edit credential"
+							:data-testid="`${config.type}-edit-credential`"
+							@click="onEditCredential(config.type)"
+						/>
+					</div>
+
+					<div
+						v-if="!credentialsLoading && (credentialsByType[config.type] ?? []).length === 0"
+						:class="$style.emptyCredentials"
+					>
+						<N8nText size="small">{{ config.noCredentialsMessage }}</N8nText>
 					</div>
 
 					<N8nText v-if="hasError(config.type)" :class="$style.errorText" size="small">
@@ -459,16 +442,6 @@ onMounted(async () => {
 						>
 							<N8nIcon icon="plug" :size="14" />
 							Connect
-						</N8nButton>
-						<N8nButton
-							v-if="hasCredentials(config.type)"
-							type="tertiary"
-							size="small"
-							:data-testid="`${config.type}-create-another-credential`"
-							@click="onCreateCredential(config.type)"
-						>
-							<N8nIcon icon="plus" :size="14" />
-							New credential
 						</N8nButton>
 					</div>
 				</div>

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentIntegrationsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentIntegrationsPanel.vue
@@ -6,6 +6,8 @@ import { useRootStore } from '@n8n/stores/useRootStore';
 import { useUIStore } from '@/app/stores/ui.store';
 import { CREDENTIAL_EDIT_MODAL_KEY } from '@/features/credentials/credentials.constants';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
+import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
+import { getResourcePermissions } from '@n8n/permissions';
 import { useAgentIntegrationStatus } from '../composables/useAgentIntegrationStatus';
 import AgentScheduleTriggerCard from './AgentScheduleTriggerCard.vue';
 import AgentCredentialSelect, { type AgentCredentialOption } from './AgentCredentialSelect.vue';
@@ -48,6 +50,7 @@ const emit = defineEmits<{
 const rootStore = useRootStore();
 const uiStore = useUIStore();
 const credentialsStore = useCredentialsStore();
+const projectsStore = useProjectsStore();
 
 interface IntegrationConfig {
 	type: string;
@@ -113,6 +116,17 @@ const credentialsByType = ref<Record<string, AgentCredentialOption[]>>({});
 const credentialsLoading = ref(false);
 const copied = ref(false);
 const showManifest = ref(false);
+
+const projectForPermissions = computed(() => {
+	if (projectsStore.currentProject?.id === props.projectId) return projectsStore.currentProject;
+	if (projectsStore.personalProject?.id === props.projectId) return projectsStore.personalProject;
+	return projectsStore.myProjects.find((project) => project.id === props.projectId) ?? null;
+});
+
+const credentialPermissions = computed(() => {
+	const permissions = getResourcePermissions(projectForPermissions.value?.scopes).credential;
+	return { ...permissions, create: !!permissions.create };
+});
 
 function isLoading(type: string): boolean {
 	return loadingMap.value[type] ?? false;
@@ -397,6 +411,7 @@ onMounted(async () => {
 							:class="$style.select"
 							placeholder="Select a credential..."
 							:credentials="credentialsByType[config.type] ?? []"
+							:credential-permissions="credentialPermissions"
 							:loading="credentialsLoading"
 							:disabled="isLoading(config.type)"
 							:data-test-id="`${config.type}-credential-select`"

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentIntegrationsPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentIntegrationsPanel.vue
@@ -4,10 +4,9 @@ import { ref, computed, onMounted, watch } from 'vue';
 import { N8nButton, N8nCard, N8nDialog, N8nIcon, N8nText } from '@n8n/design-system';
 import N8nSelect from '@n8n/design-system/components/N8nSelect';
 import N8nOption from '@n8n/design-system/components/N8nOption';
-import { useRootStore } from '@n8n/stores/useRootStore';
 import { useUIStore } from '@/app/stores/ui.store';
 import { CREDENTIAL_EDIT_MODAL_KEY } from '@/features/credentials/credentials.constants';
-import { makeRestApiRequest } from '@n8n/rest-api-client';
+import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { useAgentIntegrationStatus } from '../composables/useAgentIntegrationStatus';
 import AgentScheduleTriggerCard from './AgentScheduleTriggerCard.vue';
 
@@ -46,8 +45,8 @@ const emit = defineEmits<{
 	'trigger-added': [payload: { triggerType: string; triggers: string[] }];
 }>();
 
-const rootStore = useRootStore();
 const uiStore = useUIStore();
+const credentialsStore = useCredentialsStore();
 
 interface CredentialOption {
 	id: string;
@@ -256,9 +255,10 @@ function onScheduleTriggerAdded() {
 async function fetchCredentials() {
 	credentialsLoading.value = true;
 	try {
-		const allCredentials = await makeRestApiRequest<
-			Array<{ id: string; name: string; type: string }>
-		>(rootStore.restApiContext, 'GET', '/credentials');
+		credentialsStore.setCredentials([]);
+		const allCredentials = await credentialsStore.fetchAllCredentialsForWorkflow({
+			projectId: props.projectId,
+		});
 
 		for (const config of integrationConfigs) {
 			credentialsByType.value[config.type] = allCredentials
@@ -302,7 +302,7 @@ function onCreateCredential(type: string) {
 			config.credentialTypes[0],
 			false,
 			false,
-			undefined,
+			props.projectId,
 			undefined,
 			undefined,
 			{

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentToolConfigModal.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentToolConfigModal.vue
@@ -44,6 +44,8 @@ const props = defineProps<{
 		toolRef: AgentJsonToolRef;
 		customTool?: CustomToolEntry;
 		existingToolNames?: string[];
+		projectId?: string;
+		agentId?: string;
 		onConfirm: (updatedRef: AgentJsonToolRef) => void;
 		onRemove?: () => void;
 	};
@@ -220,6 +222,7 @@ function handleNodeNameUpdate(name: string) {
 							ref="nodeContentRef"
 							:initial-node="initialNode"
 							:existing-tool-names="data.existingToolNames"
+							:project-id="data.projectId"
 							:hide-ask-assistant="true"
 							@update:valid="handleValidUpdate"
 							@update:node-name="handleNodeNameUpdate"

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentToolsModal.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentToolsModal.vue
@@ -323,6 +323,8 @@ function openConfigForNewRef(newRef: AgentJsonToolRef) {
 		name: AGENT_TOOL_CONFIG_MODAL_KEY,
 		data: {
 			toolRef: newRef,
+			projectId: props.data.projectId,
+			agentId: props.data.agentId,
 			existingToolNames: getExistingToolNames(workingTools.value),
 			onConfirm: (savedRef: AgentJsonToolRef) => {
 				addToolRef(savedRef);
@@ -393,6 +395,8 @@ function handleConfigureTool(tool: ConfiguredToolView | ConfiguredWorkflowView) 
 		name: AGENT_TOOL_CONFIG_MODAL_KEY,
 		data: {
 			toolRef,
+			projectId: props.data.projectId,
+			agentId: props.data.agentId,
 			existingToolNames: getExistingToolNames(workingTools.value, toolRef),
 			onConfirm: (updatedRef: AgentJsonToolRef) => {
 				workingToolEntries.value = workingToolEntries.value.map((entry) =>

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -540,10 +540,13 @@ async function initialize() {
 	await fetchConfig(projectId.value, agentId.value);
 	builderTelemetry.captureToolsBaseline();
 	builderTelemetry.captureSkillsBaseline();
-	// Fire-and-forget: the interactive ask_credential tool card reads these
-	// stores. Failures are non-fatal — the cards stay disabled until data lands.
-	void credentialsStore.fetchAllCredentials({ projectId: projectId.value }).catch(() => undefined);
-	void credentialsStore.fetchCredentialTypes(false).catch(() => undefined);
+	// Keep agent credential pickers aligned with the workflow editor: load only
+	// credentials the current user can use in this project context.
+	credentialsStore.setCredentials([]);
+	await Promise.all([
+		credentialsStore.fetchAllCredentialsForWorkflow({ projectId: projectId.value }),
+		credentialsStore.fetchCredentialTypes(false),
+	]).catch(() => undefined);
 	// Stop any in-flight auto-refresh from the previous agent before kicking
 	// off a new fetch — keeps the store tied to the current project/agent.
 	sessionsStore.stopAutoRefresh();
@@ -652,6 +655,8 @@ function onOpenToolFromList(index: number) {
 		data: {
 			toolRef: tool,
 			customTool,
+			projectId: projectId.value,
+			agentId: agentId.value,
 			existingToolNames: tools
 				.map((toolRef, i) => (i === index ? null : toolRef.name))
 				.filter((name): name is string => !!name),

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialPicker/CredentialsDropdown.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialPicker/CredentialsDropdown.vue
@@ -17,6 +17,9 @@ const props = defineProps<{
 	credentialOptions: CredentialOption[];
 	selectedCredentialId: string | null;
 	permissions: PermissionsRecord['credential'];
+	placeholder?: string;
+	loading?: boolean;
+	disabled?: boolean;
 }>();
 
 const emit = defineEmits<{
@@ -64,6 +67,9 @@ const onCreateNewCredential = async () => {
 		filterable
 		:filter-method="onFilter"
 		:model-value="props.selectedCredentialId"
+		:placeholder="props.placeholder"
+		:loading="props.loading"
+		:disabled="props.disabled"
 		:popper-class="$style.selectPopper"
 		@update:model-value="onCredentialSelected"
 	>

--- a/packages/frontend/editor-ui/src/features/shared/toolConfig/NodeToolSettingsContent.vue
+++ b/packages/frontend/editor-ui/src/features/shared/toolConfig/NodeToolSettingsContent.vue
@@ -356,14 +356,12 @@ onMounted(async () => {
 		projectsStore.setCurrentProject(projectsStore.personalProject);
 	}
 
-	// Ensure credentials are loaded for the credentials selector to work. When
-	// a project is supplied, always refresh so previously loaded personal
-	// credentials do not bleed into this tool config.
+	// Ensure credentials are loaded for the credentials selector to work.
+	// Always refresh for the resolved project context so previously loaded
+	// credentials from another project do not bleed into this tool config.
 	const projectId = credentialProjectId.value;
-	if (projectId && (props.projectId || credentialsStore.allCredentials.length === 0)) {
-		if (props.projectId) {
-			credentialsStore.setCredentials([]);
-		}
+	if (projectId) {
+		credentialsStore.setCredentials([]);
 		await Promise.all([
 			credentialsStore.fetchCredentialTypes(false),
 			credentialsStore.fetchAllCredentialsForWorkflow({ projectId }),

--- a/packages/frontend/editor-ui/src/features/shared/toolConfig/NodeToolSettingsContent.vue
+++ b/packages/frontend/editor-ui/src/features/shared/toolConfig/NodeToolSettingsContent.vue
@@ -44,6 +44,7 @@ const props = defineProps<{
 	initialNode: INode;
 	existingToolNames?: string[];
 	hideAskAssistant?: boolean;
+	projectId?: string;
 }>();
 
 const emit = defineEmits<{
@@ -62,6 +63,7 @@ const node = shallowRef<INode | null>(props.initialNode);
 const userEditedName = ref(false);
 
 const existingToolNames = computed(() => props.existingToolNames ?? []);
+const credentialProjectId = computed(() => props.projectId ?? projectsStore.personalProject?.id);
 
 const nodeTypeDescription = computed(() => {
 	if (!props.initialNode) {
@@ -347,18 +349,25 @@ onMounted(async () => {
 		emit('update:node-name', node.value.name);
 	}
 
-	// Set personal project as current project for dynamic parameter loading
-	const personalProject = projectsStore.personalProject;
-	if (personalProject) {
-		projectsStore.setCurrentProject(personalProject);
+	// Set project context for dynamic parameter loading and credential creation.
+	if (props.projectId) {
+		await projectsStore.fetchAndSetProject(props.projectId);
+	} else if (projectsStore.personalProject) {
+		projectsStore.setCurrentProject(projectsStore.personalProject);
+	}
 
-		// Ensure credentials are loaded for the credentials selector to work
-		if (credentialsStore.allCredentials.length === 0) {
-			await Promise.all([
-				credentialsStore.fetchCredentialTypes(false),
-				credentialsStore.fetchAllCredentialsForWorkflow({ projectId: personalProject.id }),
-			]);
+	// Ensure credentials are loaded for the credentials selector to work. When
+	// a project is supplied, always refresh so previously loaded personal
+	// credentials do not bleed into this tool config.
+	const projectId = credentialProjectId.value;
+	if (projectId && (props.projectId || credentialsStore.allCredentials.length === 0)) {
+		if (props.projectId) {
+			credentialsStore.setCredentials([]);
 		}
+		await Promise.all([
+			credentialsStore.fetchCredentialTypes(false),
+			credentialsStore.fetchAllCredentialsForWorkflow({ projectId }),
+		]);
 	}
 });
 
@@ -396,6 +405,7 @@ defineExpose({ node, isValid, nodeTypeDescription, handleChangeName });
 						:node="node"
 						:readonly="false"
 						:show-all="true"
+						:project-id="credentialProjectId"
 						:hide-issues="false"
 						:hide-ask-assistant="props.hideAskAssistant"
 						@credential-selected="handleChangeCredential"

--- a/packages/frontend/editor-ui/src/features/shared/toolConfig/__tests__/NodeToolSettingsContent.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/toolConfig/__tests__/NodeToolSettingsContent.test.ts
@@ -150,10 +150,12 @@ describe('NodeToolSettingsContent', () => {
 		nodeTypesStore.getNodeType = vi.fn().mockReturnValue(MOCK_NODE_TYPE);
 		environmentsStore.variablesAsObject = {};
 		credentialsStore.allCredentials = [];
+		credentialsStore.setCredentials = vi.fn();
 		credentialsStore.fetchCredentialTypes = vi.fn().mockResolvedValue(undefined);
 		credentialsStore.fetchAllCredentialsForWorkflow = vi.fn().mockResolvedValue(undefined);
 		projectsStore.personalProject = { id: 'personal-project', name: 'Personal' } as never;
 		projectsStore.setCurrentProject = vi.fn();
+		projectsStore.fetchAndSetProject = vi.fn().mockResolvedValue(undefined);
 	});
 
 	it('should hide settings tab when there are no settings', () => {
@@ -269,6 +271,31 @@ describe('NodeToolSettingsContent', () => {
 			expect(credentialsStore.fetchCredentialTypes).toHaveBeenCalledWith(false);
 			expect(credentialsStore.fetchAllCredentialsForWorkflow).toHaveBeenCalledWith({
 				projectId: 'personal-project',
+			});
+		});
+	});
+
+	it('fetches workflow-scoped credentials for the provided project even when the shared store is already populated', async () => {
+		credentialsStore.allCredentials = [
+			{
+				id: 'personal-cred',
+				name: 'Personal credential',
+				type: 'testApi',
+				createdAt: '2026-01-01T00:00:00.000Z',
+				updatedAt: '2026-01-01T00:00:00.000Z',
+				isManaged: false,
+				data: '',
+			},
+		];
+
+		renderComponent({
+			props: { initialNode: createMockNode(), projectId: 'team-project' },
+		});
+
+		await waitFor(() => {
+			expect(credentialsStore.setCredentials).toHaveBeenCalledWith([]);
+			expect(credentialsStore.fetchAllCredentialsForWorkflow).toHaveBeenCalledWith({
+				projectId: 'team-project',
 			});
 		});
 	});

--- a/packages/frontend/editor-ui/src/features/shared/toolConfig/__tests__/NodeToolSettingsContent.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/toolConfig/__tests__/NodeToolSettingsContent.test.ts
@@ -275,6 +275,31 @@ describe('NodeToolSettingsContent', () => {
 		});
 	});
 
+	it('reloads personal project credentials when the shared store is already populated', async () => {
+		credentialsStore.allCredentials = [
+			{
+				id: 'team-cred',
+				name: 'Team credential',
+				type: 'testApi',
+				createdAt: '2026-01-01T00:00:00.000Z',
+				updatedAt: '2026-01-01T00:00:00.000Z',
+				isManaged: false,
+				data: '',
+			},
+		];
+
+		renderComponent({
+			props: { initialNode: createMockNode() },
+		});
+
+		await waitFor(() => {
+			expect(credentialsStore.setCredentials).toHaveBeenCalledWith([]);
+			expect(credentialsStore.fetchAllCredentialsForWorkflow).toHaveBeenCalledWith({
+				projectId: 'personal-project',
+			});
+		});
+	});
+
 	it('fetches workflow-scoped credentials for the provided project even when the shared store is already populated', async () => {
 		credentialsStore.allCredentials = [
 			{


### PR DESCRIPTION
## Summary:

- Load agent credential pickers through the workflow-scoped credential endpoint so project and personal credential rules match workflow behavior.
- Pass agent project context through manual tool configuration and new credential creation.
- Clear stale credential store state before agent-scoped loads.
- Guard integration connect on the backend by checking the credential is usable in the agent project before attaching it.

## Related Linear tickets, Github issues, and Community forum posts

https://www.notion.so/n8n/All-credentials-are-visible-despite-being-in-a-project-3595b6e0c94f80c59014dc14346eafb7?source=copy_link
https://www.notion.so/n8n/Credential-picker-has-issues-3595b6e0c94f8029a13fd1d25f46d1c6?source=copy_link

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
