### PR TITLE
fix(core): Throw clear error when AI agent omits path parameter in HTTP Request Tool

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/test/ToolHttpRequest.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/test/ToolHttpRequest.node.test.ts
@@ -359,4 +359,45 @@ describe('ToolHttpRequest', () => {
 			);
 		});
 	});
+
+	describe('Path parameter handling', () => {
+		it('should throw a clear error when model omits a path parameter', async () => {
+			executeFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+				switch (paramName) {
+					case 'method':
+						return 'GET';
+					case 'url':
+						return 'https://httpbin.org/users/{userId}/posts';
+					case 'options':
+						return {};
+					case 'sendInQuery':
+						return false;
+					case 'sendInBody':
+						return false;
+					case 'sendInHeaders':
+						return false;
+					case 'placeholderDefinitions.values':
+						return [
+							{
+								name: 'userId',
+								type: 'string',
+								description: 'The user ID',
+							},
+						];
+					default:
+						return undefined;
+				}
+			});
+
+			const { response } = await httpTool.supplyData.call(executeFunctions, 0);
+
+			// Invoke with empty input — model omitted userId
+			const res = await (response as N8nTool).invoke({});
+
+			expect(res).toContain('error');
+			expect(res).toContain("path parameter 'userId'");
+			// Verify the bug fix: we throw BEFORE making any HTTP request
+			expect(helpers.httpRequest).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts
@@ -655,6 +655,14 @@ export const configureToolFunction = (
 					}
 
 					if (parameter.sendIn === 'path') {
+						if (argument === undefined || argument === null) {
+							throw new NodeOperationError(
+								ctx.getNode(),
+								`Model did not provide path parameter '${parameter.name}'. Path parameters must always be provided to construct a valid URL.`,
+								{ itemIndex },
+							);
+						}
+
 						argument = String(argument);
 
 						//remove " or ' from start or end


### PR DESCRIPTION
## Summary

Fixes opaque \`NodeApiError: Invalid URL\` errors that surface when an AI Agent invokes the HTTP Request Tool (\`toolHttpRequest\`) without providing a path parameter. The new behavior throws a clear \`NodeOperationError\` naming the missing parameter, instead of silently constructing a URL containing the literal string \`\"undefined\"\` that later fails inside axios's \`new URL()\` call.

## Problem

In \`configureToolFunction\` (\`packages/@n8n/nodes-langchain/nodes/tools/ToolHttpRequest/utils.ts\`, line 657), when a path parameter is missing from the LLM's tool input:

\`\`\`typescript
if (parameter.sendIn === 'path') {
    argument = String(argument);  // String(undefined) → \"undefined\"
    // ...
    options.url = options.url.replace(\`{\${parameter.name}}\`, argument);
    // URL becomes \"https://api.example.com/users/undefined/posts\"
}
\`\`\`

The malformed URL eventually crashes in axios's URL constructor (\`packages/core/src/execution-engine/node-execution-context/utils/request-helpers/axios-utils.ts\`), surfacing through \`RoutingNode.runNode\` as \`NodeApiError: Invalid URL\`. The error gives no indication which parameter was missing, making it difficult to debug — particularly for agentic workflows where the user can't easily inspect what the LLM passed to the tool.

The Zod schema generated in \`makeToolInputSchema\` allows path parameters to be omitted (any non-required field becomes \`.optional()\`), so the LLM can legally skip them, then we crash without explaining why.

This is reported in:
- #14290 (WhatsApp Business Cloud Tool — same root cause when AI agent omits a required-but-not-validated argument)
- Multiple n8n community threads describing the same opaque \`Invalid URL\` error from agentic tool calls

## Fix

Add a guard before \`String(argument)\` to detect undefined/null path parameters and throw a clear \`NodeOperationError\` that names the parameter. The AI agent (or developer reviewing logs) immediately knows which parameter the LLM omitted.

\`\`\`typescript
if (parameter.sendIn === 'path') {
    if (argument === undefined || argument === null) {
        throw new NodeOperationError(
            ctx.getNode(),
            \`Model did not provide path parameter '\${parameter.name}'. Path parameters must always be provided to construct a valid URL.\`,
            { itemIndex },
        );
    }
    argument = String(argument);
    // ... existing logic unchanged
}
\`\`\`

\`NodeOperationError\` is already imported in this file (line 17), so no new imports needed.

## Tests

Added a unit test in \`ToolHttpRequest.node.test.ts\` (\`describe('Path parameter handling')\`) that:

1. Defines a tool URL with a \`{userId}\` path placeholder
2. Invokes the tool with empty input (LLM omitted \`userId\`)
3. Asserts the error message contains \`\"path parameter 'userId'\"\`
4. Asserts the HTTP request was NOT made (we fail fast before any network call)

## Backward compatibility

This is strictly an error-message improvement:

- **Tools that previously worked**: Behavior is identical (the \`if\` guard only triggers when \`argument\` is undefined/null, which previously caused the silent \`String(undefined)\` bug).
- **Tools that previously crashed with \`Invalid URL\`**: Still fail (correctly — you cannot make an HTTP request to an invalid URL), but now with a useful, actionable error message that names the missing parameter.

No public API changes. No type changes. No new dependencies.