### PR TITLE
fix(core): Resolve waiting webhook resume tokens

### DIFF
--- a/packages/cli/src/webhooks/__tests__/waiting-webhooks.test.ts
+++ b/packages/cli/src/webhooks/__tests__/waiting-webhooks.test.ts
@@ -30,6 +30,10 @@ class TestWaitingWebhooks extends WaitingWebhooks {
 	): { valid: boolean; webhookPath?: string } {
 		return this.validateToken(req, execution);
 	}
+
+	async exposeGetExecutionByResumeToken(token: string) {
+		return await this.getExecutionByResumeToken(token);
+	}
 }
 
 describe('WaitingWebhooks', () => {
@@ -70,6 +74,65 @@ describe('WaitingWebhooks', () => {
 		 * Assert
 		 */
 		await expect(promise).rejects.toThrowError(NotFoundError);
+	});
+
+	it('should not query a token-shaped path as an execution ID', async () => {
+		/**
+		 * Arrange
+		 */
+		const resumeToken = 'a'.repeat(64);
+		executionRepository.findMultipleExecutions.mockResolvedValue([]);
+
+		/**
+		 * Act
+		 */
+		const promise = waitingWebhooks.executeWebhook(
+			mock<WaitingWebhookRequest>({
+				params: { path: resumeToken, suffix: 'approval' },
+			}),
+			mock<express.Response>(),
+		);
+
+		/**
+		 * Assert
+		 */
+		await expect(promise).rejects.toThrowError(NotFoundError);
+		expect(executionRepository.findSingleExecution).not.toHaveBeenCalled();
+		expect(executionRepository.findMultipleExecutions).toHaveBeenCalledWith(
+			{
+				where: {
+					status: 'waiting',
+					executionData: { data: expect.any(Object) },
+				},
+			},
+			{ includeData: true, unflattenData: true },
+		);
+	});
+
+	it('should resolve waiting executions by resume token', async () => {
+		/**
+		 * Arrange
+		 */
+		const resumeToken = 'a'.repeat(64);
+		const matchingExecution = mock<IExecutionResponse>({
+			id: '123',
+			data: { resumeToken },
+		});
+		const otherExecution = mock<IExecutionResponse>({
+			id: '456',
+			data: { resumeToken: 'b'.repeat(64) },
+		});
+		executionRepository.findMultipleExecutions.mockResolvedValue([otherExecution, matchingExecution]);
+
+		/**
+		 * Act
+		 */
+		const execution = await waitingWebhooks.exposeGetExecutionByResumeToken(resumeToken);
+
+		/**
+		 * Assert
+		 */
+		expect(execution).toBe(matchingExecution);
 	});
 
 	it('should throw ConflictError if the execution to resume is already running', async () => {
@@ -302,6 +365,179 @@ describe('WaitingWebhooks', () => {
 			expect(mockRender).toHaveBeenCalledWith('form-invalid-token');
 			expect(mockJson).not.toHaveBeenCalled();
 			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		it('should require a valid signature for token-shaped send-and-wait requests', async () => {
+			/* Arrange */
+			const nodeId = 'send-and-wait-node-id';
+			const resumeToken = 'a'.repeat(64);
+			const execution = mock<IExecutionResponse>({
+				id: '123',
+				finished: false,
+				status: 'waiting',
+				data: {
+					resultData: {
+						lastNodeExecuted: 'SendAndWaitNode',
+						runData: {},
+						error: undefined,
+					},
+					resumeToken,
+				},
+				workflowData: {
+					id: 'workflow1',
+					name: 'Test Workflow',
+					nodes: [
+						{
+							id: nodeId,
+							name: 'SendAndWaitNode',
+							type: 'n8n-nodes-base.sendAndWait',
+							parameters: { operation: SEND_AND_WAIT_OPERATION },
+							typeVersion: 1,
+							position: [0, 0],
+						},
+					],
+					connections: {},
+					active: false,
+					settings: {},
+					staticData: {},
+				},
+			});
+			executionRepository.findMultipleExecutions.mockResolvedValue([execution]);
+
+			const mockStatus = jest.fn().mockReturnThis();
+			const mockRender = jest.fn();
+			const mockJson = jest.fn();
+			const res = mock<express.Response>({
+				status: mockStatus,
+				render: mockRender,
+				json: mockJson,
+			});
+			const req = mock<WaitingWebhookRequest>({
+				params: { path: resumeToken, suffix: nodeId },
+				method: 'GET',
+				url: `/webhook-waiting/${resumeToken}/${nodeId}?approved=true&${WAITING_TOKEN_QUERY_PARAM}=wrong-signature`,
+				headers: { host: 'example.com' },
+			});
+
+			/* Act */
+			const result = await waitingWebhooks.executeWebhook(req, res);
+
+			/* Assert */
+			expect(executionRepository.findSingleExecution).not.toHaveBeenCalled();
+			expect(mockStatus).toHaveBeenCalledWith(401);
+			expect(mockRender).toHaveBeenCalledWith('form-invalid-token');
+			expect(mockJson).not.toHaveBeenCalled();
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		it('should use legacy suffix from query token for token-shaped wait requests', async () => {
+			/* Arrange */
+			const resumeToken = 'a'.repeat(64);
+			const execution = mock<IExecutionResponse>({
+				id: '123',
+				finished: false,
+				status: 'waiting',
+				mode: 'manual',
+				data: {
+					executionData: {
+						nodeExecutionStack: [
+							{
+								node: {
+									name: 'WaitNode',
+									type: 'n8n-nodes-base.wait',
+									typeVersion: 1,
+									parameters: { operation: 'webhook' },
+									id: 'wait-node-id',
+									position: [0, 0],
+									disabled: false,
+								},
+								data: {},
+								source: null,
+							},
+						],
+					},
+					resultData: {
+						lastNodeExecuted: 'WaitNode',
+						runData: {
+							WaitNode: [
+								{
+									startTime: 123,
+									executionTime: 456,
+									executionIndex: 0,
+									source: [],
+								},
+							],
+						},
+						error: undefined,
+					},
+					resumeToken,
+				},
+				workflowData: {
+					id: 'workflow1',
+					name: 'Test Workflow',
+					nodes: [
+						{
+							id: 'wait-node-id',
+							name: 'WaitNode',
+							type: 'n8n-nodes-base.wait',
+							parameters: { operation: 'webhook' },
+							typeVersion: 1,
+							position: [0, 0],
+						},
+					],
+					connections: {},
+					active: false,
+					settings: {},
+					staticData: {},
+				},
+			});
+			executionRepository.findMultipleExecutions.mockResolvedValue([execution]);
+			jest.spyOn(WorkflowExecuteAdditionalData, 'getBase').mockResolvedValue({} as any);
+			jest.spyOn(WebhookHelpers, 'executeWebhook').mockImplementation(
+				async (
+					_workflow,
+					_webhookData,
+					_workflowData,
+					_workflowStartNode,
+					_mode,
+					_pushRef,
+					_runExecutionData,
+					_executionId,
+					_req,
+					_res,
+					callback,
+				) => {
+					callback(null, { noWebhookResponse: true });
+					return undefined;
+				},
+			);
+			mockWebhookService.getNodeWebhooks.mockReturnValue([
+				{
+					httpMethod: 'POST',
+					path: 'custom-suffix',
+					webhookDescription: {
+						restartWebhook: true,
+						httpMethod: 'POST',
+						name: 'default',
+						path: 'custom-suffix',
+						nodeType: undefined,
+					} as any,
+				},
+			] as any);
+
+			const req = mock<WaitingWebhookRequest>({
+				params: { path: resumeToken, suffix: undefined },
+				method: 'POST',
+				url: `/webhook-waiting/${resumeToken}?${WAITING_TOKEN_QUERY_PARAM}=${resumeToken}/custom-suffix`,
+				headers: { host: 'example.com' },
+			});
+
+			/* Act */
+			await waitingWebhooks.executeWebhook(req, mock<express.Response>());
+
+			/* Assert */
+			expect(mockWebhookService.getNodeWebhooks).toHaveBeenCalled();
+			expect(WebhookHelpers.executeWebhook).toHaveBeenCalled();
 		});
 
 		it('should return 401 with JSON for non-send-and-wait requests with invalid token', async () => {

--- a/packages/cli/src/webhooks/waiting-webhooks.ts
+++ b/packages/cli/src/webhooks/waiting-webhooks.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@n8n/backend-common';
 import type { IExecutionResponse } from '@n8n/db';
-import { ExecutionRepository } from '@n8n/db';
+import { ExecutionRepository, Like } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { timingSafeEqual } from 'crypto';
 import type express from 'express';
@@ -31,6 +31,8 @@ import { applyCors } from '@/utils/cors.util';
 import * as WebhookHelpers from '@/webhooks/webhook-helpers';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 import { preserveInputOverride } from '@/workflow-helpers';
+
+const RESUME_TOKEN_REGEX = /^[a-f0-9]{64}$/;
 
 /**
  * Service for handling the execution of webhooks of Wait nodes that use the
@@ -97,6 +99,33 @@ export class WaitingWebhooks implements IWebhookManager {
 			includeData: true,
 			unflattenData: true,
 		});
+	}
+
+	private hasMatchingResumeToken(token: string, execution: IExecutionResponse) {
+		const storedToken = execution.data.resumeToken;
+
+		if (!storedToken || token.length !== storedToken.length) {
+			return false;
+		}
+
+		return timingSafeEqual(Buffer.from(token), Buffer.from(storedToken));
+	}
+
+	protected async getExecutionByResumeToken(token: string) {
+		const executions = await this.executionRepository.findMultipleExecutions(
+			{
+				where: {
+					status: 'waiting',
+					executionData: { data: Like(`%${token}%`) },
+				},
+			},
+			{
+				includeData: true,
+				unflattenData: true,
+			},
+		);
+
+		return executions.find((execution) => this.hasMatchingResumeToken(token, execution));
 	}
 
 	/**
@@ -175,8 +204,10 @@ export class WaitingWebhooks implements IWebhookManager {
 		req: WaitingWebhookRequest,
 		res: express.Response,
 	): Promise<IWebhookResponseCallbackData> {
-		const { path: executionId } = req.params;
+		const { path } = req.params;
+		let executionId = path;
 		let { suffix } = req.params;
+		const pathIsResumeToken = RESUME_TOKEN_REGEX.test(path);
 
 		this.logReceivedWebhook(req.method, executionId);
 
@@ -185,7 +216,13 @@ export class WaitingWebhooks implements IWebhookManager {
 		// Reset request parameters
 		req.params = {} as WaitingWebhookRequest['params'];
 
-		const execution = await this.getExecution(executionId);
+		const execution = pathIsResumeToken
+			? await this.getExecutionByResumeToken(path)
+			: await this.getExecution(executionId);
+
+		if (execution) {
+			executionId = execution.id;
+		}
 
 		// Only validate for executions that have a resumeToken.
 		// Old executions created before token validation are skipped (backwards compat).
@@ -198,6 +235,8 @@ export class WaitingWebhooks implements IWebhookManager {
 			// All other waiting URLs use a simple random token comparison.
 			const { valid, webhookPath } = isSendAndWait
 				? this.validateSignature(req)
+				: pathIsResumeToken
+					? { valid: true, webhookPath: this.parseSignatureParam(req).webhookPath }
 				: this.validateToken(req, execution);
 
 			if (!valid) {


### PR DESCRIPTION
## Summary

Fixes waiting webhook resume requests when the route path contains a resume token instead of an execution ID.

The waiting webhook handler now detects token-shaped paths and resolves them against waiting executions before continuing. This avoids passing a resume token into the execution ID lookup.

No docs update needed: this fixes existing Wait node resume behavior without changing the documented user flow.

Tested with:

- `corepack pnpm exec jest waiting-webhooks.test.ts`
- `corepack pnpm exec eslint src/webhooks/waiting-webhooks.ts src/webhooks/__tests__/waiting-webhooks.test.ts --quiet`

## Related Linear tickets, Github issues, and Community forum posts

Fixes #30142

https://linear.app/n8n/issue/GHC-8249

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
