### PR TITLE
fix: prevent crash when config.headers.setContentType is not a function

### DIFF
--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -145,7 +145,7 @@ export class Telemetry {
 			const { default: RudderStack } = await import('@rudderstack/rudder-sdk-node');
 			const axiosInstance = axios.create();
 			axiosInstance.interceptors.request.use((cfg) => {
-				cfg.headers.setContentType('application/json', false);
+				cfg.headers.setContentType && cfg.headers.setContentType('application/json', false);
 				return cfg;
 			});
 			this.rudderStack = new RudderStack(key, {

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/axios-config.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/axios-config.ts
@@ -27,7 +27,7 @@ axios.defaults.proxy = false;
 axios.interceptors.request.use((config) => {
 	// If no content-type is set by us, prevent axios from force-setting the content-type to `application/x-www-form-urlencoded`
 	if (config.data === undefined) {
-		config.headers.setContentType(false, false);
+		config.headers.setContentType && config.headers.setContentType(false, false);
 	}
 
 	setAxiosAgents(config);
@@ -38,9 +38,16 @@ axios.interceptors.request.use((config) => {
 
 function applyVendorHeaders(config: AxiosRequestConfig) {
 	if ([config.url, config.baseURL].some((url) => url?.startsWith('https://api.openai.com/'))) {
-		config.headers = {
-			...Container.get(AiConfig).openAiDefaultHeaders,
-			...(config.headers ?? {}),
-		};
+		const openAiHeaders = Container.get(AiConfig).openAiDefaultHeaders;
+		if (config.headers && typeof config.headers.set === 'function') {
+			for (const [key, value] of Object.entries(openAiHeaders)) {
+				config.headers.set(key, value as string);
+			}
+		} else {
+			config.headers = {
+				...openAiHeaders,
+				...(config.headers ?? {}),
+			};
+		}
 	}
 }


### PR DESCRIPTION
Fixes #30150

This PR addresses the issue where config.headers.setContentType is called on a plain object instead of an AxiosHeaders instance, causing a crash. This often happens when applyVendorHeaders replaces the headers object with a plain object using the spread operator.

Changes:
1. Added defensive checks for setContentType in request interceptors.
2. Updated applyVendorHeaders to use config.headers.set() if available, preserving the AxiosHeaders instance.
3. Added the same defensive check to the telemetry interceptor.