### PR TITLE
feat(core): Track no results in code-builder search tool (no-changelog)

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/index.ts
@@ -20,8 +20,14 @@ export { generateCodeBuilderThreadId } from './utils/code-builder-session';
 // Core utilities for MCP integration
 export { NodeTypeParser } from './utils/node-type-parser';
 export { ParseValidateHandler, WorkflowCodeParseError } from './handlers/parse-validate-handler';
-export { createCodeBuilderSearchTool } from './tools/code-builder-search.tool';
-export type { CodeBuilderSearchToolOptions } from './tools/code-builder-search.tool';
+export {
+	createCodeBuilderSearchTool,
+	searchCodeBuilderNodes,
+} from './tools/code-builder-search.tool';
+export type {
+	CodeBuilderSearchResult,
+	CodeBuilderSearchToolOptions,
+} from './tools/code-builder-search.tool';
 export { createCodeBuilderGetTool } from './tools/code-builder-get.tool';
 export type { CodeBuilderGetToolOptions } from './tools/code-builder-get.tool';
 export { createGetSuggestedNodesTool } from './tools/get-suggested-nodes.tool';

--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/tools/code-builder-search.tool.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/tools/code-builder-search.tool.ts
@@ -431,19 +431,32 @@ export interface CodeBuilderSearchToolOptions {
 	nodeFilter?: (nodeId: string) => boolean;
 }
 
+export interface CodeBuilderSearchResult {
+	results: string;
+	queriesWithNoResults: string[];
+}
+
+interface SearchForQueryResult {
+	result: string;
+	hasResults: boolean;
+}
+
 /**
- * Search for a single query and return the formatted result block.
+ * Search for a single query and return the formatted result block with match metadata.
  * Extracted to keep the tool handler's cyclomatic complexity within limits.
  */
 function searchForQuery(
 	nodeTypeParser: NodeTypeParser,
 	query: string,
 	nodeFilter?: (nodeId: string) => boolean,
-): string {
+): SearchForQueryResult {
 	const results = nodeTypeParser.searchNodeTypes(query, 5, nodeFilter);
 
 	if (results.length === 0) {
-		return `## "${query}"\nNo nodes found. Try a different search term.`;
+		return {
+			result: `## "${query}"\nNo nodes found. Try a different search term.`,
+			hasResults: false,
+		};
 	}
 
 	// Track which node IDs have been shown to avoid duplicates
@@ -528,7 +541,29 @@ function searchForQuery(
 	}
 
 	const countSuffix = totalRelatedCount > 0 ? ` (+ ${totalRelatedCount} related)` : '';
-	return `## "${query}"\nFound ${results.length} nodes${countSuffix}:\n\n${allNodeLines.join('\n\n')}`;
+	return {
+		result: `## "${query}"\nFound ${results.length} nodes${countSuffix}:\n\n${allNodeLines.join('\n\n')}`,
+		hasResults: true,
+	};
+}
+
+export function searchCodeBuilderNodes(
+	nodeTypeParser: NodeTypeParser,
+	queries: string[],
+	options?: CodeBuilderSearchToolOptions,
+): CodeBuilderSearchResult {
+	const { nodeFilter } = options ?? {};
+	const searchResults = queries.map((query) => ({
+		query,
+		...searchForQuery(nodeTypeParser, query, nodeFilter),
+	}));
+
+	return {
+		results: searchResults.map(({ result }) => result).join('\n\n---\n\n'),
+		queriesWithNoResults: searchResults
+			.filter(({ hasResults }) => !hasResults)
+			.map(({ query }) => query),
+	};
 }
 
 /**
@@ -540,14 +575,9 @@ export function createCodeBuilderSearchTool(
 	nodeTypeParser: NodeTypeParser,
 	options?: CodeBuilderSearchToolOptions,
 ) {
-	const { nodeFilter } = options ?? {};
-
 	return tool(
 		async (input: { queries: string[] }) => {
-			const allResults = input.queries.map((query) =>
-				searchForQuery(nodeTypeParser, query, nodeFilter),
-			);
-			return allResults.join('\n\n---\n\n');
+			return searchCodeBuilderNodes(nodeTypeParser, input.queries, options).results;
 		},
 		{
 			name: 'search_nodes',

--- a/packages/@n8n/ai-workflow-builder.ee/src/code-builder/tools/test/code-builder-search.tool.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/code-builder/tools/test/code-builder-search.tool.test.ts
@@ -1,7 +1,7 @@
 import { NodeConnectionTypes, type INodeTypeDescription } from 'n8n-workflow';
 
 import { NodeTypeParser } from '../../utils/node-type-parser';
-import { createCodeBuilderSearchTool } from '../code-builder-search.tool';
+import { createCodeBuilderSearchTool, searchCodeBuilderNodes } from '../code-builder-search.tool';
 
 // Mock node type with resource/operation pattern (like Freshservice)
 const mockFreshserviceNode: INodeTypeDescription = {
@@ -828,6 +828,16 @@ describe('CodeBuilderSearchTool', () => {
 
 			expect(result).toContain('No nodes found');
 			expect(result).toContain('Try a different search term');
+		});
+
+		it('should return queries with no results in metadata', () => {
+			const nodeTypeParser = new NodeTypeParser([mockHttpRequestNode]);
+
+			const result = searchCodeBuilderNodes(nodeTypeParser, ['http request', 'missing-node']);
+
+			expect(result.results).toContain('HTTP Request');
+			expect(result.results).toContain('No nodes found');
+			expect(result.queriesWithNoResults).toEqual(['missing-node']);
 		});
 	});
 

--- a/packages/@n8n/ai-workflow-builder.ee/src/index.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/index.ts
@@ -18,6 +18,7 @@ export {
 	ParseValidateHandler,
 	WorkflowCodeParseError,
 	createCodeBuilderSearchTool,
+	searchCodeBuilderNodes,
 	type CodeBuilderSearchToolOptions,
 	createCodeBuilderGetTool,
 	createGetSuggestedNodesTool,
@@ -37,6 +38,7 @@ export {
 	MCP_UPDATE_WORKFLOW_TOOL,
 } from './code-builder';
 export type {
+	CodeBuilderSearchResult,
 	CodeBuilderGetToolOptions,
 	ParseAndValidateResult,
 	ValidationWarning,

--- a/packages/cli/src/modules/agents/__tests__/agents-tools.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-tools.service.test.ts
@@ -24,7 +24,10 @@ const ctx = {
 
 function makeService() {
 	const nodeCatalogService = mock<NodeCatalogService>();
-	nodeCatalogService.searchNodes.mockResolvedValue('search-result');
+	nodeCatalogService.searchNodes.mockResolvedValue({
+		results: 'search-result',
+		queriesWithNoResults: [],
+	});
 	nodeCatalogService.getNodeTypes.mockResolvedValue('node-types-string');
 
 	const ephemeralNodeExecutor = mock<EphemeralNodeExecutor>();

--- a/packages/cli/src/modules/agents/agents-tools.service.ts
+++ b/packages/cli/src/modules/agents/agents-tools.service.ts
@@ -142,7 +142,7 @@ export class AgentsToolsService {
 			)
 			.input(searchNodesInputSchema)
 			.handler(async ({ queries }: { queries: string[] }) => {
-				const results = await this.nodeCatalogService.searchNodes(queries, {
+				const { results } = await this.nodeCatalogService.searchNodes(queries, {
 					nodeFilter: isAgentToolNodeType,
 				});
 				return { results };

--- a/packages/cli/src/modules/mcp/__tests__/search-workflow-nodes.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/search-workflow-nodes.tool.test.ts
@@ -1,0 +1,113 @@
+import { User } from '@n8n/db';
+import { mock } from 'jest-mock-extended';
+
+import { USER_CALLED_MCP_TOOL_EVENT } from '../mcp.constants';
+import { createSearchWorkflowNodesTool } from '../tools/workflow-builder/search-workflow-nodes.tool';
+
+import type { NodeCatalogService } from '@/node-catalog';
+import type { Telemetry } from '@/telemetry';
+
+jest.mock('@n8n/ai-workflow-builder', () => ({
+	CODE_BUILDER_SEARCH_NODES_TOOL: {
+		toolName: 'search_workflow_nodes',
+		displayTitle: 'Search Workflow Nodes',
+	},
+	CODE_BUILDER_GET_NODE_TYPES_TOOL: { toolName: 'get', displayTitle: 'Get' },
+	CODE_BUILDER_GET_SUGGESTED_NODES_TOOL: { toolName: 'suggest', displayTitle: 'Suggest' },
+	CODE_BUILDER_VALIDATE_TOOL: { toolName: 'validate_workflow_code', displayTitle: 'Validate' },
+	MCP_GET_SDK_REFERENCE_TOOL: { toolName: 'sdk_ref', displayTitle: 'SDK Ref' },
+	MCP_CREATE_WORKFLOW_FROM_CODE_TOOL: {
+		toolName: 'create_workflow_from_code',
+		displayTitle: 'Create',
+	},
+	MCP_ARCHIVE_WORKFLOW_TOOL: { toolName: 'archive_workflow', displayTitle: 'Archive' },
+	MCP_UPDATE_WORKFLOW_TOOL: { toolName: 'update_workflow', displayTitle: 'Update' },
+}));
+
+describe('search-workflow-nodes MCP tool', () => {
+	const user = Object.assign(new User(), { id: 'user-1' });
+	let nodeCatalogService: jest.Mocked<NodeCatalogService>;
+	let telemetry: jest.Mocked<Telemetry>;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		nodeCatalogService = mock<NodeCatalogService>();
+		telemetry = mock<Telemetry>();
+		nodeCatalogService.searchNodes.mockResolvedValue({
+			results: 'search-result',
+			queriesWithNoResults: [],
+		});
+	});
+
+	const createTool = () => createSearchWorkflowNodesTool(user, nodeCatalogService, telemetry);
+
+	test('returns search results and tracks queries with no results', async () => {
+		nodeCatalogService.searchNodes.mockResolvedValueOnce({
+			results: 'search-result',
+			queriesWithNoResults: ['missing-node'],
+		});
+
+		const tool = createTool();
+		const result = await tool.handler({ queries: ['gmail', 'missing-node'] }, {} as never);
+
+		expect(nodeCatalogService.searchNodes).toHaveBeenCalledWith(['gmail', 'missing-node']);
+		expect(result.content).toEqual([{ type: 'text', text: 'search-result' }]);
+		expect(result.structuredContent).toEqual({ results: 'search-result' });
+		expect(telemetry.track).toHaveBeenCalledWith(
+			USER_CALLED_MCP_TOOL_EVENT,
+			expect.objectContaining({
+				user_id: 'user-1',
+				tool_name: 'search_workflow_nodes',
+				parameters: { queries: ['gmail', 'missing-node'] },
+				results: {
+					success: true,
+					data: {
+						queryCount: 2,
+						noResultQueryCount: 1,
+						queriesWithNoResults: ['missing-node'],
+					},
+				},
+			}),
+		);
+	});
+
+	test('tracks empty no-result metadata when every query has results', async () => {
+		const tool = createTool();
+		await tool.handler({ queries: ['gmail'] }, {} as never);
+
+		expect(telemetry.track).toHaveBeenCalledWith(
+			USER_CALLED_MCP_TOOL_EVENT,
+			expect.objectContaining({
+				results: {
+					success: true,
+					data: {
+						queryCount: 1,
+						noResultQueryCount: 0,
+						queriesWithNoResults: [],
+					},
+				},
+			}),
+		);
+	});
+
+	test('tracks telemetry on search failure', async () => {
+		nodeCatalogService.searchNodes.mockRejectedValueOnce(new Error('Search failed'));
+
+		const tool = createTool();
+		await expect(tool.handler({ queries: ['gmail'] }, {} as never)).rejects.toThrow(
+			'Search failed',
+		);
+
+		expect(telemetry.track).toHaveBeenCalledWith(
+			USER_CALLED_MCP_TOOL_EVENT,
+			expect.objectContaining({
+				user_id: 'user-1',
+				tool_name: 'search_workflow_nodes',
+				results: {
+					success: false,
+					error: 'Search failed',
+				},
+			}),
+		);
+	});
+});

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/search-workflow-nodes.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/search-workflow-nodes.tool.ts
@@ -66,7 +66,6 @@ export const createSearchWorkflowNodesTool = (
 				},
 			};
 			telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
-			console.log(telemetryPayload.results.data);
 
 			return {
 				content: [{ type: 'text', text: results }],

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/search-workflow-nodes.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/search-workflow-nodes.tool.ts
@@ -55,14 +55,22 @@ export const createSearchWorkflowNodesTool = (
 		};
 
 		try {
-			const result = await nodeCatalogService.searchNodes(queries);
+			const { results, queriesWithNoResults } = await nodeCatalogService.searchNodes(queries);
 
-			telemetryPayload.results = { success: true, data: { queryCount: queries.length } };
+			telemetryPayload.results = {
+				success: true,
+				data: {
+					queryCount: queries.length,
+					noResultQueryCount: queriesWithNoResults.length,
+					queriesWithNoResults,
+				},
+			};
 			telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
+			console.log(telemetryPayload.results.data);
 
 			return {
-				content: [{ type: 'text', text: result }],
-				structuredContent: { results: result },
+				content: [{ type: 'text', text: results }],
+				structuredContent: { results },
 			};
 		} catch (error) {
 			telemetryPayload.results = {

--- a/packages/cli/src/node-catalog/__tests__/node-catalog.service.test.ts
+++ b/packages/cli/src/node-catalog/__tests__/node-catalog.service.test.ts
@@ -8,14 +8,13 @@ import { NodeCatalogService } from '../node-catalog.service';
 
 const MockNodeTypeParser = jest.fn();
 const mockSetSchemaBaseDirs = jest.fn();
-const mockSearchInvoke = jest.fn().mockResolvedValue('search-result');
+const mockSearchCodeBuilderNodes = jest.fn();
 const mockGetInvoke = jest.fn().mockResolvedValue('get-result');
 const mockSuggestInvoke = jest.fn().mockResolvedValue('suggest-result');
-const mockCreateSearchTool = jest.fn((..._args: unknown[]) => ({ invoke: mockSearchInvoke }));
 
 jest.mock('@n8n/ai-workflow-builder', () => ({
 	NodeTypeParser: MockNodeTypeParser,
-	createCodeBuilderSearchTool: (...args: unknown[]) => mockCreateSearchTool(...args),
+	searchCodeBuilderNodes: (...args: unknown[]) => mockSearchCodeBuilderNodes(...args),
 	createCodeBuilderGetTool: jest.fn(() => ({ invoke: mockGetInvoke })),
 	createGetSuggestedNodesTool: jest.fn(() => ({ invoke: mockSuggestInvoke })),
 }));
@@ -38,6 +37,10 @@ describe('NodeCatalogService', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
+		mockSearchCodeBuilderNodes.mockReturnValue({
+			results: 'search-result',
+			queriesWithNoResults: [],
+		});
 		postProcessorCallback = undefined;
 
 		loadNodesAndCredentials = mock<LoadNodesAndCredentials>({
@@ -153,9 +156,24 @@ describe('NodeCatalogService', () => {
 			const result1 = await service.searchNodes(['gmail', 'slack']);
 			const result2 = await service.searchNodes(['gmail', 'slack']);
 
-			expect(result1).toBe('search-result');
-			expect(result2).toBe('search-result');
-			expect(mockSearchInvoke).toHaveBeenCalledTimes(1);
+			expect(result1.results).toBe('search-result');
+			expect(result2.results).toBe('search-result');
+			expect(mockSearchCodeBuilderNodes).toHaveBeenCalledTimes(1);
+		});
+
+		test('returns queriesWithNoResults metadata', async () => {
+			mockSearchCodeBuilderNodes.mockReturnValueOnce({
+				results: 'search-result',
+				queriesWithNoResults: ['missing-node'],
+			});
+			await service.initialize();
+
+			const result = await service.searchNodes(['missing-node']);
+
+			expect(result).toEqual({
+				results: 'search-result',
+				queriesWithNoResults: ['missing-node'],
+			});
 		});
 
 		test('returns cached result regardless of query order', async () => {
@@ -164,19 +182,19 @@ describe('NodeCatalogService', () => {
 			await service.searchNodes(['gmail', 'slack']);
 			await service.searchNodes(['slack', 'gmail']);
 
-			expect(mockSearchInvoke).toHaveBeenCalledTimes(1);
+			expect(mockSearchCodeBuilderNodes).toHaveBeenCalledTimes(1);
 		});
 
-		test('calls tool for different queries', async () => {
+		test('calls search for different queries', async () => {
 			await service.initialize();
 
 			await service.searchNodes(['gmail']);
 			await service.searchNodes(['slack']);
 
-			expect(mockSearchInvoke).toHaveBeenCalledTimes(2);
+			expect(mockSearchCodeBuilderNodes).toHaveBeenCalledTimes(2);
 		});
 
-		test('creates a separate tool instance per nodeFilter reference', async () => {
+		test('uses separate search state per nodeFilter reference', async () => {
 			await service.initialize();
 
 			const filterA = () => true;
@@ -185,15 +203,17 @@ describe('NodeCatalogService', () => {
 			await service.searchNodes(['gmail'], { nodeFilter: filterA });
 			await service.searchNodes(['gmail'], { nodeFilter: filterB });
 
-			expect(mockCreateSearchTool).toHaveBeenCalledTimes(2);
-			expect(mockCreateSearchTool).toHaveBeenNthCalledWith(
+			expect(mockSearchCodeBuilderNodes).toHaveBeenCalledTimes(2);
+			expect(mockSearchCodeBuilderNodes).toHaveBeenNthCalledWith(
 				1,
 				expect.anything(),
+				['gmail'],
 				expect.objectContaining({ nodeFilter: filterA }),
 			);
-			expect(mockCreateSearchTool).toHaveBeenNthCalledWith(
+			expect(mockSearchCodeBuilderNodes).toHaveBeenNthCalledWith(
 				2,
 				expect.anything(),
+				['gmail'],
 				expect.objectContaining({ nodeFilter: filterB }),
 			);
 		});
@@ -207,8 +227,8 @@ describe('NodeCatalogService', () => {
 			await service.searchNodes(['gmail']);
 			await service.searchNodes(['gmail'], { nodeFilter: filter });
 
-			// Two distinct tool instances, each invoked once.
-			expect(mockSearchInvoke).toHaveBeenCalledTimes(2);
+			// Two distinct search states, each invoked once.
+			expect(mockSearchCodeBuilderNodes).toHaveBeenCalledTimes(2);
 		});
 	});
 
@@ -266,7 +286,7 @@ describe('NodeCatalogService', () => {
 			await service.getNodeTypes(['n8n-nodes-base.set']);
 			await service.getSuggestedNodes(['chatbot']);
 
-			expect(mockSearchInvoke).toHaveBeenCalledTimes(2);
+			expect(mockSearchCodeBuilderNodes).toHaveBeenCalledTimes(2);
 			expect(mockGetInvoke).toHaveBeenCalledTimes(1);
 			expect(mockSuggestInvoke).toHaveBeenCalledTimes(1);
 
@@ -278,7 +298,7 @@ describe('NodeCatalogService', () => {
 			await service.getNodeTypes(['n8n-nodes-base.set']);
 			await service.getSuggestedNodes(['chatbot']);
 
-			expect(mockSearchInvoke).toHaveBeenCalledTimes(4);
+			expect(mockSearchCodeBuilderNodes).toHaveBeenCalledTimes(4);
 			expect(mockGetInvoke).toHaveBeenCalledTimes(2);
 			expect(mockSuggestInvoke).toHaveBeenCalledTimes(2);
 		});

--- a/packages/cli/src/node-catalog/node-catalog.service.ts
+++ b/packages/cli/src/node-catalog/node-catalog.service.ts
@@ -54,7 +54,10 @@ export class NodeCatalogService {
 
 	private initPromise: Promise<void> | undefined;
 
-	/** Search function + cache per unique `nodeFilter` reference (plus one unfiltered slot). */
+	/**
+	 * Search function + full result cache per unique `nodeFilter` reference (plus one unfiltered slot).
+	 * The cache stores the complete `CodeBuilderSearchResult`, so callers can consume only the fields they need.
+	 */
 	private readonly searchStates = new Map<NodeFilter | typeof UNFILTERED, SearchState>();
 
 	private getTool: InvokableTool<{ nodeIds: NodeRequest[] }> | undefined;

--- a/packages/cli/src/node-catalog/node-catalog.service.ts
+++ b/packages/cli/src/node-catalog/node-catalog.service.ts
@@ -1,4 +1,4 @@
-import type { NodeTypeParser } from '@n8n/ai-workflow-builder';
+import type { CodeBuilderSearchResult, NodeTypeParser } from '@n8n/ai-workflow-builder';
 import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
 import * as fs from 'fs/promises';
@@ -21,7 +21,7 @@ export type NodeFilter = (nodeId: string) => boolean;
 export interface SearchNodesOptions {
 	/**
 	 * Optional predicate restricting which node IDs are included in search results.
-	 * Each unique filter reference gets its own tool instance and result cache;
+	 * Each unique filter reference gets its own search state and result cache;
 	 * callers should use module-level function references to avoid unbounded growth.
 	 */
 	nodeFilter?: NodeFilter;
@@ -32,8 +32,8 @@ interface InvokableTool<TInput> {
 }
 
 interface SearchState {
-	tool?: InvokableTool<{ queries: string[] }>;
-	cache: Map<string, string>;
+	search?: (queries: string[]) => CodeBuilderSearchResult;
+	cache: Map<string, CodeBuilderSearchResult>;
 }
 
 const UNFILTERED: unique symbol = Symbol('unfiltered');
@@ -54,7 +54,7 @@ export class NodeCatalogService {
 
 	private initPromise: Promise<void> | undefined;
 
-	/** Tool + cache per unique `nodeFilter` reference (plus one unfiltered slot). */
+	/** Search function + cache per unique `nodeFilter` reference (plus one unfiltered slot). */
 	private readonly searchStates = new Map<NodeFilter | typeof UNFILTERED, SearchState>();
 
 	private getTool: InvokableTool<{ nodeIds: NodeRequest[] }> | undefined;
@@ -92,7 +92,10 @@ export class NodeCatalogService {
 	 * Search the node catalog for node IDs matching `queries`.
 	 * Results are cached per `(filter, queries)` pair and invalidated on node-type refresh.
 	 */
-	async searchNodes(queries: string[], options: SearchNodesOptions = {}): Promise<string> {
+	async searchNodes(
+		queries: string[],
+		options: SearchNodesOptions = {},
+	): Promise<CodeBuilderSearchResult> {
 		const { nodeFilter } = options;
 		const stateKey: NodeFilter | typeof UNFILTERED = nodeFilter ?? UNFILTERED;
 
@@ -106,14 +109,16 @@ export class NodeCatalogService {
 		const cached = state.cache.get(cacheKey);
 		if (cached) return cached;
 
-		if (!state.tool) {
-			const { createCodeBuilderSearchTool } = await import('@n8n/ai-workflow-builder');
-			state.tool = nodeFilter
-				? createCodeBuilderSearchTool(this.getNodeTypeParser(), { nodeFilter })
-				: createCodeBuilderSearchTool(this.getNodeTypeParser());
+		if (!state.search) {
+			const { searchCodeBuilderNodes } = await import('@n8n/ai-workflow-builder');
+			const nodeTypeParser = this.getNodeTypeParser();
+			state.search = (searchQueries: string[]) =>
+				nodeFilter
+					? searchCodeBuilderNodes(nodeTypeParser, searchQueries, { nodeFilter })
+					: searchCodeBuilderNodes(nodeTypeParser, searchQueries);
 		}
 
-		const result = await state.tool.invoke({ queries });
+		const result = state.search(queries);
 		state.cache.set(cacheKey, result);
 		return result;
 	}


### PR DESCRIPTION
## Summary
Track `queriesWithNoResults` in `search-nodes` mcp tool. This should help us detect the gaps in user requirements and current integrations.
In order to do this, `NodeCatalogService.searchNodes()` has been updated to return an object with results and new metadata.

## How to test:
1. Try building a workflow trough mcp and ask the client to include a non-existing node
2. Observe the telemetry (or add a console.log)
3. Make sure AI workflow builder search nodes tool still works correctly

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
