### PR TITLE
fix(nodes): correct unlisted privacy status typo in YouTube Video node

### DIFF
--- a/packages/nodes-base/nodes/Google/YouTube/VideoDescription.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/VideoDescription.ts
@@ -776,7 +776,7 @@ export const videoFields: INodeProperties[] = [
 					},
 					{
 						name: 'Unlisted',
-						value: 'unlistef',
+						value: 'unlisted',
 					},
 				],
 				default: '',


### PR DESCRIPTION
Fixes a typo where the privacy status value for Unlisted videos was set to unlistef instead of unlisted in VideoDescription.ts line 779. This caused the YouTube API to reject update requests with: Invalid value at resource.status.privacy_status, unlistef. Closes #30133.