### PR TITLE
fix(nodes): Edit Image composite fails with Stream yields empty buffer on certain PNGs

### DIFF
--- a/packages/nodes-base/nodes/EditImage/EditImage.node.ts
+++ b/packages/nodes-base/nodes/EditImage/EditImage.node.ts
@@ -1139,10 +1139,16 @@ export class EditImage implements INodeType {
 						cleanupFunctions.push(cleanup);
 						await fsWriteFile(path, binaryDataBuffer);
 
-						gmInstance = gm(gmInstance!.stream('png'))
-							.compose(operator)
-							.geometry(geometryString)
-							.composite(path);
+						const { path: mainImgPath, cleanup: mainImgCleanup } = await file({ postfix: '.png' });
+						cleanupFunctions.push(mainImgCleanup);
+						await new Promise<void>((resolve, reject) => {
+							gmInstance!.write(mainImgPath, (err) => {
+								if (err) reject(err);
+								else resolve();
+							});
+						});
+
+						gmInstance = gm(mainImgPath).compose(operator).geometry(geometryString).composite(path);
 
 						if (operations.length !== i + 1) {
 							// If there are other operations after the current one create a new gm instance

--- a/packages/nodes-base/nodes/EditImage/EditImage.node.ts
+++ b/packages/nodes-base/nodes/EditImage/EditImage.node.ts
@@ -1005,6 +1005,7 @@ export class EditImage implements INodeType {
 		let item: INodeExecutionData;
 
 		for (let itemIndex = 0; itemIndex < length; itemIndex++) {
+			const cleanupFunctions: Array<() => Promise<void>> = [];
 			try {
 				item = items[itemIndex];
 
@@ -1019,8 +1020,6 @@ export class EditImage implements INodeType {
 				if (!binaryPropertyName) {
 					binaryPropertyName = typeof dataPropertyName === 'string' ? dataPropertyName : 'data';
 				}
-
-				const cleanupFunctions: Array<() => void> = [];
 
 				let gmInstance: gm.State;
 
@@ -1320,8 +1319,6 @@ export class EditImage implements INodeType {
 				returnData.push(
 					await new Promise<INodeExecutionData>((resolve, reject) => {
 						gmInstance.toBuffer(async (error: Error | null, buffer: Buffer) => {
-							cleanupFunctions.forEach(async (cleanup) => cleanup());
-
 							if (error) {
 								return reject(error);
 							}
@@ -1349,6 +1346,8 @@ export class EditImage implements INodeType {
 					continue;
 				}
 				throw error;
+			} finally {
+				await Promise.allSettled(cleanupFunctions.map((fn) => fn()));
 			}
 		}
 		return [returnData];

--- a/packages/nodes-base/nodes/EditImage/test/EditImage.node.test.ts
+++ b/packages/nodes-base/nodes/EditImage/test/EditImage.node.test.ts
@@ -12,6 +12,10 @@ const createTestBuffer = () =>
 	]);
 
 const mockGmInstance: any = {
+	write: jest.fn(function (this: any, path: string, callback: (err: any) => void) {
+		callback(null);
+		return this;
+	}),
 	background: jest.fn(function (this: any) {
 		return this;
 	}),


### PR DESCRIPTION
## Problem
When using the **Edit Image** node's **Composite** operation, certain PNG files (e.g., those generated by the Gemini API) cause the node to fail with:
```
Stream yields empty buffer
```

Fixes #30170.

## Root Cause
The composite operation piped the main image through GraphicsMagick via `gm(gmInstance.stream('png'))`. For some PNG formats, gm's child process produced no stdout output, resulting in an empty buffer.

## Fix
Instead of streaming, write the current `gmInstance` to a temporary file first, then pass the file path to `gm()`. Reading from a file descriptor is reliable regardless of PNG format.

## Changes
- `packages/nodes-base/nodes/EditImage/EditImage.node.ts`: In the composite operation, replace stdin stream with temp-file write before calling `gm(mainImgPath)`.