### PR TITLE
feat(editor): Add copy execution data button on dev builds

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1438,6 +1438,7 @@
 	"executionsList.statusTooltipText.waitingForConcurrencyCapacity.self": "This instance is limited to {concurrencyCap} concurrent production executions. {link}",
 	"executionsList.statusTooltipText.theWorkflowIsWaitingIndefinitely": "The workflow is waiting indefinitely for an incoming webhook call.",
 	"executionsList.debug.button.copyToEditor": "Copy to editor",
+	"executionsList.debug.button.copyExecutionData": "Copy execution data",
 	"executionsList.debug.button.debugInEditor": "Debug in editor",
 	"executionsList.debug.paywall.title": "Upgrade to access Debug In Editor",
 	"executionsList.debug.paywall.content": "Debug in Editor allows you to debug a previous execution with the actual data pinned, right in your editor.",

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsPreview.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsPreview.test.ts
@@ -8,7 +8,9 @@ import WorkflowExecutionsPreview from './WorkflowExecutionsPreview.vue';
 import { EnterpriseEditionFeature, VIEWS } from '@/app/constants';
 import { WorkflowIdKey } from '@/app/constants/injectionKeys';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useWorkflowHistoryStore } from '@/features/workflows/workflowHistory/workflowHistory.store';
+import type { IExecutionResponse } from '../../executions.types';
 import type { IWorkflowDb } from '@/Interface';
 import type { ExecutionSummaryWithScopes } from '../../executions.types';
 import { createComponentRenderer } from '@/__tests__/render';
@@ -24,6 +26,11 @@ const showError = vi.fn();
 const showToast = vi.fn();
 vi.mock('@/app/composables/useToast', () => ({
 	useToast: () => ({ showMessage, showError, showToast }),
+}));
+
+const copyMock = vi.fn();
+vi.mock('@/app/composables/useClipboard', () => ({
+	useClipboard: () => ({ copy: copyMock }),
 }));
 
 const routes = [
@@ -325,6 +332,99 @@ describe('WorkflowExecutionsPreview.vue', () => {
 		// Should not show annotation-related elements
 		expect(queryByTestId('annotation-tags-container')).not.toBeInTheDocument();
 		expect(queryByTestId('execution-preview-ellipsis-button')).not.toBeInTheDocument();
+	});
+
+	describe('copy execution data button', () => {
+		beforeEach(() => {
+			copyMock.mockClear();
+			showMessage.mockClear();
+			showError.mockClear();
+		});
+
+		it('should not show button when release channel is not dev', async () => {
+			const settingsStore = mockedStore(useSettingsStore);
+			settingsStore.settings.releaseChannel = 'stable';
+
+			const { queryByTestId } = renderComponent({
+				props: { execution: executionData },
+			});
+
+			await nextTick();
+
+			expect(queryByTestId('execution-preview-copy-data-button')).not.toBeInTheDocument();
+		});
+
+		it('should show button when release channel is dev', async () => {
+			const settingsStore = mockedStore(useSettingsStore);
+			settingsStore.settings.releaseChannel = 'dev';
+
+			const { getByTestId } = renderComponent({
+				props: { execution: executionData },
+			});
+
+			await nextTick();
+
+			expect(getByTestId('execution-preview-copy-data-button')).toBeInTheDocument();
+		});
+
+		it('should copy execution data as JSON and show success toast on click', async () => {
+			const settingsStore = mockedStore(useSettingsStore);
+			settingsStore.settings.releaseChannel = 'dev';
+
+			const fullExecution = {
+				id: executionData.id,
+				data: { resultData: { runData: { Node: [] } } },
+			} as unknown as IExecutionResponse;
+
+			const workflowsStore = mockedStore(useWorkflowsStore);
+			workflowsStore.getExecution.mockResolvedValueOnce(fullExecution);
+
+			const { getByTestId } = renderComponent({
+				props: { execution: executionData },
+			});
+
+			await userEvent.click(getByTestId('execution-preview-copy-data-button'));
+
+			expect(workflowsStore.getExecution).toHaveBeenCalledWith(executionData.id);
+			expect(copyMock).toHaveBeenCalledWith(JSON.stringify(fullExecution, null, 2));
+			expect(showMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
+		});
+
+		it('should not copy or toast when getExecution returns undefined', async () => {
+			const settingsStore = mockedStore(useSettingsStore);
+			settingsStore.settings.releaseChannel = 'dev';
+
+			const workflowsStore = mockedStore(useWorkflowsStore);
+			workflowsStore.getExecution.mockResolvedValueOnce(undefined);
+
+			const { getByTestId } = renderComponent({
+				props: { execution: executionData },
+			});
+
+			await userEvent.click(getByTestId('execution-preview-copy-data-button'));
+
+			expect(workflowsStore.getExecution).toHaveBeenCalledWith(executionData.id);
+			expect(copyMock).not.toHaveBeenCalled();
+			expect(showMessage).not.toHaveBeenCalled();
+		});
+
+		it('should show error toast when getExecution rejects', async () => {
+			const settingsStore = mockedStore(useSettingsStore);
+			settingsStore.settings.releaseChannel = 'dev';
+
+			const error = new Error('fetch failed');
+			const workflowsStore = mockedStore(useWorkflowsStore);
+			workflowsStore.getExecution.mockRejectedValueOnce(error);
+
+			const { getByTestId } = renderComponent({
+				props: { execution: executionData },
+			});
+
+			await userEvent.click(getByTestId('execution-preview-copy-data-button'));
+
+			expect(copyMock).not.toHaveBeenCalled();
+			expect(showError).toHaveBeenCalledWith(error, expect.any(String));
+		});
 	});
 
 	describe('workflow version link', () => {

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsPreview.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsPreview.vue
@@ -9,6 +9,8 @@ import type { WorkflowVersion } from '@n8n/rest-api-client/api/workflowHistory';
 import { useI18n } from '@n8n/i18n';
 import { useToast } from '@/app/composables/useToast';
 import { useMessage } from '@/app/composables/useMessage';
+import { useClipboard } from '@/app/composables/useClipboard';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { EnterpriseEditionFeature, MODAL_CONFIRM, VIEWS } from '@/app/constants';
 import { convertToDisplayDate } from '@/app/utils/formatters/dateFormatter';
 import { useInjectWorkflowId } from '@/app/composables/useInjectWorkflowId';
@@ -39,12 +41,14 @@ const emit = defineEmits<{
 
 const route = useRoute();
 const locale = useI18n();
-const { showError } = useToast();
+const { showError, showMessage } = useToast();
+const clipboard = useClipboard();
 
 const executionHelpers = useExecutionHelpers();
 const message = useMessage();
 const executionDebugging = useExecutionDebugging();
 const workflowsListStore = useWorkflowsListStore();
+const workflowsStore = useWorkflowsStore();
 const settingsStore = useSettingsStore();
 const retryDropdownRef = ref<RetryDropdownRef | null>(null);
 const workflowId = useInjectWorkflowId();
@@ -204,6 +208,25 @@ function onRetryButtonBlur(event: FocusEvent) {
 	// Hide dropdown when clicking outside of current document
 	if (retryDropdownRef.value && event.relatedTarget === null) {
 		retryDropdownRef.value.handleClose();
+	}
+}
+
+async function onCopyExecutionData() {
+	if (!props.execution) {
+		return;
+	}
+	try {
+		const execution = await workflowsStore.getExecution(props.execution.id);
+		if (!execution) {
+			return;
+		}
+		await clipboard.copy(JSON.stringify(execution, null, 2));
+		showMessage({
+			title: locale.baseText('generic.copiedToClipboard'),
+			type: 'success',
+		});
+	} catch (error) {
+		showError(error, locale.baseText('generic.copiedToClipboard'));
 	}
 }
 
@@ -373,6 +396,16 @@ const onVoteClick = async (voteValue: AnnotationVote) => {
 						</span>
 					</N8nButton>
 				</RouterLink>
+
+				<N8nIconButton
+					v-if="settingsStore.isDevRelease"
+					variant="subtle"
+					size="medium"
+					icon="clipboard"
+					:title="locale.baseText('executionsList.debug.button.copyExecutionData')"
+					data-test-id="execution-preview-copy-data-button"
+					@click="onCopyExecutionData"
+				/>
 
 				<ElDropdown
 					v-if="isRetriable"


### PR DESCRIPTION
## Summary

Adds a clipboard icon button next to "Copy to editor" in the workflow execution
preview header. Clicking it fetches the full execution and copies the data as
pretty-printed JSON to the clipboard. The button is only rendered when
`settingsStore.isDevRelease` is true (i.e. `releaseChannel === 'dev'`), so it
ships only on internal dev builds — production users won't see it.

The button uses the same `title`-based hover tooltip pattern as the other icon
buttons in that toolbar (retry, delete).

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
