### PR TITLE
fix(core): Stop applying node-defined sensitive output fields to runtime data

### DIFF
--- a/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
+++ b/packages/cli/src/modules/redaction/executions/__tests__/execution-redaction.service.test.ts
@@ -15,7 +15,6 @@ import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 import { ExecutionRedactionService } from '../execution-redaction.service';
 import { FullItemRedactionStrategy } from '../strategies/full-item-redaction.strategy';
-import { NodeDefinedFieldRedactionStrategy } from '../strategies/node-defined-field-redaction.strategy';
 
 describe('ExecutionRedactionService', () => {
 	const logger = mockInstance(Logger);
@@ -23,7 +22,6 @@ describe('ExecutionRedactionService', () => {
 	const workflowFinderService = mockInstance(WorkflowFinderService);
 	const eventService = mock<EventService>();
 	const fullItemRedactionStrategy = mockInstance(FullItemRedactionStrategy);
-	const nodeDefinedFieldRedactionStrategy = mockInstance(NodeDefinedFieldRedactionStrategy);
 
 	let service: ExecutionRedactionService;
 
@@ -44,12 +42,10 @@ describe('ExecutionRedactionService', () => {
 			workflowFinderService,
 			eventService,
 			fullItemRedactionStrategy,
-			nodeDefinedFieldRedactionStrategy,
 		);
 		// Default: user lacks execution:reveal scope
 		workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(new Set());
 		fullItemRedactionStrategy.apply.mockResolvedValue(undefined);
-		nodeDefinedFieldRedactionStrategy.apply.mockResolvedValue(undefined);
 	});
 
 	const makeExecution = (
@@ -195,8 +191,6 @@ describe('ExecutionRedactionService', () => {
 
 			// FullItemRedactionStrategy called only for allExecution and nonManualTrigger
 			expect(fullItemRedactionStrategy.apply).toHaveBeenCalledTimes(2);
-			// NodeDefinedFieldRedactionStrategy called for all 4
-			expect(nodeDefinedFieldRedactionStrategy.apply).toHaveBeenCalledTimes(4);
 		});
 
 		it('uses a single DB query for N executions when redactExecutionData === true', async () => {
@@ -233,8 +227,6 @@ describe('ExecutionRedactionService', () => {
 
 			// FullItemRedactionStrategy.requiresRedaction always returns true when in the pipeline
 			fullItemRedactionStrategy.requiresRedaction.mockReturnValue(true);
-			// NodeDefinedFieldRedactionStrategy.requiresRedaction returns false (no sensitive fields)
-			nodeDefinedFieldRedactionStrategy.requiresRedaction.mockReturnValue(false);
 
 			const executions = [noneExecution, allExecution, nonManualManual];
 			const options: ExecutionRedactionOptions = { user: mockUser, keepOriginal: true };
@@ -305,46 +297,6 @@ describe('ExecutionRedactionService', () => {
 		});
 	});
 
-	describe('NodeDefinedFieldRedactionStrategy inclusion', () => {
-		it('is always included when redacting', async () => {
-			const execution = makeExecution({ policy: 'all', mode: 'trigger' });
-			await service.processExecution(execution, { user: mockUser });
-			expect(nodeDefinedFieldRedactionStrategy.apply).toHaveBeenCalledTimes(1);
-		});
-
-		it('is included even when policy is "none" (no item clearing)', async () => {
-			const execution = makeExecution({ policy: 'none', mode: 'trigger' });
-			await service.processExecution(execution, { user: mockUser });
-			expect(nodeDefinedFieldRedactionStrategy.apply).toHaveBeenCalledTimes(1);
-		});
-
-		it('is included on reveal path (redactExecutionData === false)', async () => {
-			workflowFinderService.findWorkflowIdsWithScopeForUser.mockResolvedValue(
-				new Set(['workflow-123']),
-			);
-			const execution = makeExecution({ policy: 'all', mode: 'trigger' });
-			await service.processExecution(execution, { user: mockUser, redactExecutionData: false });
-			expect(nodeDefinedFieldRedactionStrategy.apply).toHaveBeenCalledTimes(1);
-		});
-	});
-
-	describe('strategy ordering', () => {
-		it('runs FullItemRedactionStrategy before NodeDefinedFieldRedactionStrategy', async () => {
-			const callOrder: string[] = [];
-			fullItemRedactionStrategy.apply.mockImplementation(async () => {
-				callOrder.push('full');
-			});
-			nodeDefinedFieldRedactionStrategy.apply.mockImplementation(async () => {
-				callOrder.push('node-defined');
-			});
-
-			const execution = makeExecution({ policy: 'all', mode: 'trigger' });
-			await service.processExecution(execution, { user: mockUser });
-
-			expect(callOrder).toEqual(['full', 'node-defined']);
-		});
-	});
-
 	describe('context passed to strategies', () => {
 		it('passes redactExecutionData from options', async () => {
 			const execution = makeExecution({ policy: 'all', mode: 'trigger' });
@@ -371,22 +323,6 @@ describe('ExecutionRedactionService', () => {
 
 			const [, context] = fullItemRedactionStrategy.apply.mock.calls[0];
 			expect(context.userCanReveal).toBe(false);
-		});
-
-		it('passes userCanReveal: true when policyAllowsReveal (policy=none)', async () => {
-			const execution = makeExecution({ policy: 'none', mode: 'trigger' });
-			await service.processExecution(execution, { user: mockUser });
-
-			const [, context] = nodeDefinedFieldRedactionStrategy.apply.mock.calls[0];
-			expect(context.userCanReveal).toBe(true);
-		});
-
-		it('passes userCanReveal: true when policyAllowsReveal (policy=non-manual, mode=manual)', async () => {
-			const execution = makeExecution({ policy: 'non-manual', mode: 'manual' });
-			await service.processExecution(execution, { user: mockUser });
-
-			const [, context] = nodeDefinedFieldRedactionStrategy.apply.mock.calls[0];
-			expect(context.userCanReveal).toBe(true);
 		});
 	});
 

--- a/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
+++ b/packages/cli/src/modules/redaction/executions/execution-redaction.service.ts
@@ -17,7 +17,6 @@ import type {
 	RedactionContext,
 } from './execution-redaction.interfaces';
 import { FullItemRedactionStrategy } from './strategies/full-item-redaction.strategy';
-import { NodeDefinedFieldRedactionStrategy } from './strategies/node-defined-field-redaction.strategy';
 
 const MANUAL_MODES: ReadonlySet<WorkflowExecuteMode> = new Set(['manual']);
 
@@ -41,7 +40,6 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 		private readonly workflowFinderService: WorkflowFinderService,
 		private readonly eventService: EventService,
 		private readonly fullItemRedactionStrategy: FullItemRedactionStrategy,
-		private readonly nodeDefinedFieldRedactionStrategy: NodeDefinedFieldRedactionStrategy,
 	) {}
 
 	async init(): Promise<void> {
@@ -123,8 +121,7 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 		}
 
 		// Unified pipeline execution. buildPipeline excludes FullItemRedactionStrategy on the
-		// reveal path (redactExecutionData === false). NodeDefinedFieldRedactionStrategy
-		// always runs — node-declared sensitive fields are never revealable.
+		// reveal path (redactExecutionData === false).
 
 		for (let i = 0; i < executions.length; i++) {
 			const execution = executions[i];
@@ -184,8 +181,12 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 	 *   explicit redact (`redactExecutionData === true`), policy=all, or
 	 *   policy=non-manual on a non-manual execution mode, or dynamic credentials.
 	 *   It is never included on the reveal path (`redactExecutionData === false`).
-	 * - `NodeDefinedFieldRedactionStrategy` is always appended last — node-declared
-	 *   sensitive fields are never revealable.
+	 *
+	 * Note: `NodeDefinedFieldRedactionStrategy` (node-declared `sensitiveOutputFields`)
+	 * is intentionally not wired in here. The previous always-on behaviour broke
+	 * partial/single-step execution because the FE replays the redacted push payload
+	 * back to the server, and is being redesigned. Re-introduce only after the
+	 * product approach (per-workflow gating + partial-run rehydration) is settled.
 	 */
 	private buildPipeline(
 		execution: RedactableExecution,
@@ -208,8 +209,6 @@ export class ExecutionRedactionService implements ExecutionRedaction {
 		if (shouldClearItems) {
 			pipeline.push(this.fullItemRedactionStrategy);
 		}
-
-		pipeline.push(this.nodeDefinedFieldRedactionStrategy);
 
 		return pipeline;
 	}


### PR DESCRIPTION
## Summary

Disconnects `NodeDefinedFieldRedactionStrategy` from the execution redaction pipeline. The node-declared `sensitiveOutputFields` (e.g. `headers.authorization` and `headers.cookie` on the Webhook node) were unconditionally redacted in the WebSocket push to the editor. The editor then replays that push payload back to the server when a user runs a single step, which made the redacted marker object reach downstream nodes — breaking common patterns like JWT/HMAC verification on Webhook headers.

The strategy class, the `sensitiveOutputFields` declarations on `Webhook.node.ts` and `DynamicCredentialCheck.node.ts`, the `IRedactedFieldMarker` type, and the `INodeTypeDescription.sensitiveOutputFields` field are all kept in place — only the pipeline wiring is removed. `FullItemRedactionStrategy` (policy-driven item clearing) and dynamic-credential force-redaction are unchanged. The behaviour will be reintroduced once the product approach (per-workflow gating + partial-run rehydration) is settled.

How to test:
- Webhook → Code workflow that reads `$json.headers.authorization`. Trigger via webhook, then re-run the Code node alone via "Execute step". Previously failed with a `dict + str` type error; now passes the real bearer token through.
- Existing unit tests in `execution-redaction.service.test.ts` updated (40 passing); `execution-lifecycle-hooks`, `execution.service`, `execution-redaction-proxy`, and the strategy's own tests still pass.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-607
Closes #29819

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI