### PR TITLE
fix(editor): Improve dedicated MCP tools connection experience (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/utils/nodeTypesUtils.ts
+++ b/packages/frontend/editor-ui/src/app/utils/nodeTypesUtils.ts
@@ -32,7 +32,7 @@ import {
 	or manipulate node types and nodes.
 */
 
-const CRED_KEYWORDS_TO_FILTER = ['API', 'OAuth1', 'OAuth2'];
+const CRED_KEYWORDS_TO_FILTER = ['API', 'OAuth1', 'OAuth2', 'MCP'];
 const NODE_KEYWORDS_TO_FILTER = ['Trigger'];
 const RESOURCE_MAPPER_FIELD_NAME_REGEX = /value\["(.+?)"\]/s;
 

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialModeSelector.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialModeSelector.test.ts
@@ -379,6 +379,26 @@ describe('CredentialModeSelector', () => {
 			],
 		};
 
+		const nonConfigurableOAuthType: ICredentialType = {
+			name: 'mcpOAuth2Api',
+			extends: ['oAuth2Api'],
+			displayName: 'MCP OAuth2 API',
+			properties: [
+				{
+					displayName: 'Use Dynamic Client Registration',
+					name: 'useDynamicClientRegistration',
+					type: 'hidden',
+					default: true,
+				},
+				{
+					displayName: 'Server URL',
+					name: 'serverURL',
+					type: 'hidden',
+					default: 'https://mcp.example.com/mcp',
+				},
+			],
+		};
+
 		const singleCredNodeType = {
 			displayName: 'Firecrawl',
 			name: 'n8n-nodes-base.firecrawl',
@@ -391,6 +411,24 @@ describe('CredentialModeSelector', () => {
 			credentials: [
 				{
 					name: 'firecrawlApi',
+					required: true,
+				},
+			],
+			properties: [],
+		} as unknown as INodeTypeDescription;
+
+		const singleCredMcpNodeType = {
+			displayName: 'Notion MCP',
+			name: '@n8n/n8n-nodes-langchain.mcpClientTool',
+			group: ['transform'],
+			version: 1,
+			description: 'MCP tool node',
+			defaults: { name: 'Notion MCP' },
+			inputs: [NodeConnectionTypes.Main],
+			outputs: [NodeConnectionTypes.Main],
+			credentials: [
+				{
+					name: 'mcpOAuth2Api',
 					required: true,
 				},
 			],
@@ -457,6 +495,27 @@ describe('CredentialModeSelector', () => {
 				expect(emitted('update:authType')).toHaveLength(1);
 				expect(emitted('update:authType')[0]).toEqual([{ type: '' }]);
 			});
+		});
+
+		it('should not show selector when there are no configurable credential fields', () => {
+			const pinia = setupStores({
+				nodeType: singleCredMcpNodeType,
+				node: makeNode('@n8n/n8n-nodes-langchain.mcpClientTool', ''),
+				credentialTypes: {
+					mcpOAuth2Api: nonConfigurableOAuthType,
+				},
+			});
+
+			renderComponent({
+				pinia,
+				props: {
+					credentialType: nonConfigurableOAuthType,
+					quickConnectAvailable: true,
+					isQuickConnectMode: true,
+				},
+			});
+
+			expect(screen.queryByTestId('credential-mode-selector')).not.toBeInTheDocument();
 		});
 
 		it('should not show selector when quickConnectAvailable is false for single-cred nodes', () => {

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialModeSelector.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialModeSelector.vue
@@ -36,7 +36,7 @@ const emit = defineEmits<{
 const nodeTypesStore = useNodeTypesStore();
 const ndvStore = useNDVStore();
 const i18n = useI18n();
-const { isOAuthCredentialType } = useCredentialOAuth();
+const { isOAuthCredentialType, hasManualCredentialInputFields } = useCredentialOAuth();
 
 const activeNode = computed<INode | null>(() => props.contextNode ?? ndvStore.activeNode);
 const activeNodeType = computed<INodeTypeDescription | null>(() => {
@@ -54,6 +54,9 @@ const selectedAuthType = computed(() => {
 
 const isOAuthCredential = computed(() => isOAuthCredentialType(props.credentialType.name));
 const hasManagedOAuth = computed(() => isOAuthCredential.value && props.showManagedOauthOptions);
+const hasManualCredentialFields = computed(() =>
+	hasManualCredentialInputFields(props.credentialType),
+);
 
 const managedOAuthOptions = computed<Option[]>(() => [
 	{
@@ -108,16 +111,17 @@ const options = computed<Option[]>(() => {
 	if (!qc) return manual;
 
 	// When QC is available but no manual auth options exist (single-credential nodes),
-	// add a generic "Enter manually" option so the user can switch between QC and manual
-	const manualOrFallback =
-		manual.length > 0
-			? manual
-			: [
+	// add a generic "Enter manually" option only when manual input fields exist
+	const manualOrFallback = manual.length
+		? manual
+		: hasManualCredentialFields.value
+			? [
 					{
 						name: i18n.baseText('credentialEdit.credentialConfig.setupManually'),
 						value: { type: '' },
 					},
-				];
+				]
+			: [];
 
 	return [qc, ...manualOrFallback];
 });

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
@@ -619,6 +619,60 @@ describe('NodeCredentials', () => {
 			expect(screen.getByText('Connect to Slack')).toBeInTheDocument();
 		});
 
+		it('should remove MCP from derived service name in quick connect CTA', () => {
+			setupQuickConnectStores();
+
+			const linearMcpOAuth2ApiType: ICredentialType = {
+				name: 'linearMcpOAuth2Api',
+				extends: ['oAuth2Api'],
+				displayName: 'Linear MCP OAuth2 API',
+				properties: [
+					{
+						displayName: 'Use Dynamic Client Registration',
+						name: 'useDynamicClientRegistration',
+						type: 'hidden',
+						default: true,
+					},
+					{
+						displayName: 'Server URL',
+						name: 'serverUrl',
+						type: 'hidden',
+						default: 'https://mcp.linear.app/mcp',
+					},
+				],
+			};
+
+			const linearMcpNode: INodeUi = {
+				parameters: {},
+				type: 'n8n-nodes-base.linearMcp',
+				typeVersion: 1,
+				position: [0, 0],
+				id: 'linear-mcp-node-id',
+				name: 'Linear MCP',
+				credentials: {},
+			};
+
+			credentialsStore.state.credentialTypes = {
+				...credentialsStore.state.credentialTypes,
+				linearMcpOAuth2Api: linearMcpOAuth2ApiType,
+			};
+
+			ndvStore.activeNode = linearMcpNode;
+
+			renderComponent(
+				{
+					props: {
+						node: linearMcpNode,
+						overrideCredType: 'linearMcpOAuth2Api',
+					},
+				},
+				{ merge: true },
+			);
+
+			expect(screen.getByText('Connect to Linear')).toBeInTheDocument();
+			expect(screen.queryByText('Connect to Linear MCP')).not.toBeInTheDocument();
+		});
+
 		it('should show node-credentials-empty-state for non-OAuth type with no credentials', () => {
 			setupQuickConnectStores();
 

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
@@ -710,6 +710,53 @@ describe('NodeCredentials', () => {
 			expect(screen.queryByTestId('setup-manually-link')).toBeInTheDocument();
 		});
 
+		it('should hide "setup manually" link when credential has no manual fields', () => {
+			setupQuickConnectStores();
+
+			const mcpOAuth2ApiType: ICredentialType = {
+				name: 'mcpOAuth2Api',
+				extends: ['oAuth2Api'],
+				displayName: 'MCP OAuth2 API',
+				properties: [
+					{
+						displayName: 'Use Dynamic Client Registration',
+						name: 'useDynamicClientRegistration',
+						type: 'hidden',
+						default: true,
+					},
+				],
+			};
+
+			const mcpNode: INodeUi = {
+				parameters: {},
+				type: '@n8n/n8n-nodes-langchain.mcpClientTool',
+				typeVersion: 1,
+				position: [0, 0],
+				id: 'mcp-node-id',
+				name: 'Notion MCP',
+				credentials: {},
+			};
+
+			credentialsStore.state.credentialTypes = {
+				...credentialsStore.state.credentialTypes,
+				mcpOAuth2Api: mcpOAuth2ApiType,
+			};
+
+			ndvStore.activeNode = mcpNode;
+
+			renderComponent(
+				{
+					props: {
+						node: mcpNode,
+						overrideCredType: 'mcpOAuth2Api',
+					},
+				},
+				{ merge: true },
+			);
+
+			expect(screen.queryByTestId('setup-manually-link')).not.toBeInTheDocument();
+		});
+
 		it('should open credential modal when "setup manually" is clicked', async () => {
 			setupQuickConnectStores();
 

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -11,7 +11,13 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { I18nT } from 'vue-i18n';
 
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
-import { hasProxyAuth } from '@/app/utils/nodeTypesUtils';
+import {
+	hasProxyAuth,
+	getAppNameFromCredType,
+	getAuthTypeForNodeCredential,
+	getNodeCredentialForSelectedAuthType,
+	updateNodeAuthType,
+} from '@/app/utils/nodeTypesUtils';
 import { useToast } from '@/app/composables/useToast';
 
 import TitledList from '@/app/components/TitledList.vue';
@@ -29,12 +35,6 @@ import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { assert } from '@n8n/utils/assert';
-import {
-	getAppNameFromCredType,
-	getAuthTypeForNodeCredential,
-	getNodeCredentialForSelectedAuthType,
-	updateNodeAuthType,
-} from '@/app/utils/nodeTypesUtils';
 import { isEmpty } from '@/app/utils/typesUtils';
 import { getResourcePermissions } from '@n8n/permissions';
 import { useNodeCredentialOptions } from '../composables/useNodeCredentialOptions';
@@ -110,7 +110,7 @@ const {
 	connect,
 	cancelConnect,
 } = useQuickConnect();
-const { canOAuthCredentialQuickConnect } = useCredentialOAuth();
+const { canOAuthCredentialQuickConnect, hasManualCredentialInputFields } = useCredentialOAuth();
 
 const aiGateway = useAiGateway();
 
@@ -651,6 +651,15 @@ function showStandardEmptyState(type: INodeCredentialDescription): boolean {
 	return !isCredentialExisting(type) && !quickConnectCredentialType.value;
 }
 
+function canManuallySetUpCredential(credentialTypeName: string): boolean {
+	const credentialType = credentialsStore.getCredentialTypeByName(credentialTypeName);
+	if (!credentialType) {
+		return true;
+	}
+
+	return hasManualCredentialInputFields(credentialType);
+}
+
 async function onQuickConnectSignIn(credentialTypeName: string) {
 	subscribedToCredentialType.value = credentialTypeName;
 	const serviceName = getServiceName(credentialTypeName);
@@ -725,7 +734,7 @@ async function onQuickConnectSignIn(credentialTypeName: string) {
 						:service-name="getServiceName(quickConnectCredentialType)"
 						@click="onQuickConnectSignIn(quickConnectCredentialType)"
 					/>
-					<span :class="$style.setupManuallyContainer">
+					<span v-if="canManuallySetUpCredential(type.name)" :class="$style.setupManuallyContainer">
 						<N8nText size="small" :class="$style.setupManuallyOr">
 							{{ i18n.baseText('nodeCredentials.quickConnect.or') }}
 						</N8nText>

--- a/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialOAuth.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/composables/useCredentialOAuth.ts
@@ -2,7 +2,13 @@ import { useToast } from '@/app/composables/useToast';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { useI18n } from '@n8n/i18n';
 import { ref } from 'vue';
-import { createResultError, createResultOk, type GenericValue, type Result } from 'n8n-workflow';
+import {
+	createResultError,
+	createResultOk,
+	type GenericValue,
+	type ICredentialType,
+	type Result,
+} from 'n8n-workflow';
 
 import { useCredentialsStore } from '../credentials.store';
 import type { ICredentialsResponse } from '../credentials.types';
@@ -84,14 +90,11 @@ export function useCredentialOAuth() {
 		}
 
 		const overwrittenProperties = credentialType.__overwrittenProperties ?? [];
-		const visibleProperties = credentialType.properties.filter(
-			(prop) =>
-				prop.type !== 'hidden' &&
-				prop.type !== 'notice' &&
-				!overwrittenProperties.includes(prop.name),
-		);
+		const nonOverwrittenConfigurableProperties = getManuallyConfigurableProperties(
+			credentialType,
+		).filter((prop) => !overwrittenProperties.includes(prop.name));
 
-		if (visibleProperties.length === 0) {
+		if (nonOverwrittenConfigurableProperties.length === 0) {
 			return true;
 		}
 
@@ -99,9 +102,19 @@ export function useCredentialOAuth() {
 			return false;
 		}
 
-		return visibleProperties.every(
+		return nonOverwrittenConfigurableProperties.every(
 			(prop) => prop.required !== true || (prop.type !== 'string' && prop.type !== 'number'),
 		);
+	}
+
+	function getManuallyConfigurableProperties(credentialType: ICredentialType) {
+		return credentialType.properties.filter(
+			(prop) => prop.type !== 'hidden' && prop.type !== 'notice',
+		);
+	}
+
+	function hasManualCredentialInputFields(credentialType: ICredentialType): boolean {
+		return getManuallyConfigurableProperties(credentialType).length > 0;
 	}
 
 	async function getOAuthAuthorizationUrl(
@@ -308,6 +321,7 @@ export function useCredentialOAuth() {
 		isOAuthCredentialType,
 		isGoogleOAuthType,
 		canOAuthCredentialQuickConnect,
+		hasManualCredentialInputFields,
 		authorize,
 		createAndAuthorize,
 		cancelAuthorize,


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Two improvements to the UX of connecting to dedicated MCP tools:
1. Remove the `MCP` suffix from `Connect to <service>` CTA in the NDV.
2. Remove `or setup manually` option from the NDV for service-specific MCP credentials, since those credentials don't have any parameters that can be specified by the user

Before:
<img width="547" height="380" alt="image" src="https://github.com/user-attachments/assets/ce7158f2-b0b6-47eb-8f0a-7dfd9bcd4870" />

After:
<img width="626" height="353" alt="image" src="https://github.com/user-attachments/assets/610d2e59-edee-4f2d-b7f0-6c5e9b0fc052" />


### To test
1. Launch n8n with `N8N_ENABLED_MODULES=mcp-registry`, `CREDENTIALS_OVERWRITE_DATA='{"googleOAuth2Api": {"clientId":"client-id","clientSecret":"client-secret"}}'`
2. Create a workflow
3. Add an AI agent node with a dedicated MCP tool (Notion or Linear)
4. Verify that the `MCP` part of the CTA is gone
5. Verify that there is no option to `setup manually`
6. Add any Google node for which you don't have any credentials set up
7. Verify that the `Connect to Google` button shows up correctly and `setup manually` option is there

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/NODE-5010/remove-the-set-up-manually-link-for-mcp
https://linear.app/n8n/issue/NODE-5011/shorten-mcp-cta-text-to-connect-to-notion

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
