### PR TITLE
feat(ai-builder): Add n8n and workflow SDK versions to LangSmith trace metadata (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/orchestration/tracing-utils.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/tracing-utils.ts
@@ -62,6 +62,14 @@ export async function createDetachedSubAgentTracing(
 		typeof context.tracing.actorRun.metadata?.agent_id === 'string'
 			? context.tracing.actorRun.metadata.agent_id
 			: context.orchestratorAgentId;
+	const n8nVersion =
+		typeof context.tracing.actorRun.metadata?.n8n_version === 'string'
+			? context.tracing.actorRun.metadata.n8n_version
+			: undefined;
+	const workflowSdkVersion =
+		typeof context.tracing.actorRun.metadata?.workflow_sdk_version === 'string'
+			? context.tracing.actorRun.metadata.workflow_sdk_version
+			: undefined;
 	const tracing = await createDetachedSubAgentTraceContext({
 		projectName: context.tracing.projectName,
 		threadId: context.threadId,
@@ -73,6 +81,8 @@ export async function createDetachedSubAgentTracing(
 		modelId: context.modelId,
 		input: options.inputs,
 		metadata: options.metadata,
+		n8nVersion,
+		workflowSdkVersion,
 		agentId: options.agentId,
 		role: options.role,
 		kind: options.kind,

--- a/packages/@n8n/instance-ai/src/tracing/__tests__/langsmith-tracing.test.ts
+++ b/packages/@n8n/instance-ai/src/tracing/__tests__/langsmith-tracing.test.ts
@@ -502,6 +502,44 @@ describe('createInstanceAiTraceContext', () => {
 		expect(JSON.stringify(inputs)).not.toContain('custom.endpoint');
 	});
 
+	it('includes n8n and workflow SDK versions in trace metadata when provided', async () => {
+		const tracing = await createInstanceAiTraceContext({
+			threadId: 'thread-1',
+			messageId: 'message-1',
+			runId: 'run-1',
+			userId: 'user-1',
+			n8nVersion: '1.123.4',
+			workflowSdkVersion: '0.13.0',
+			input: { message: 'What workflows do I have?' },
+		});
+
+		expect(tracing?.messageRun.metadata).toEqual(
+			expect.objectContaining({
+				n8n_version: '1.123.4',
+				workflow_sdk_version: '0.13.0',
+			}),
+		);
+		expect(tracing?.orchestratorRun.metadata).toEqual(
+			expect.objectContaining({
+				n8n_version: '1.123.4',
+				workflow_sdk_version: '0.13.0',
+			}),
+		);
+	});
+
+	it('omits version metadata when not provided', async () => {
+		const tracing = await createInstanceAiTraceContext({
+			threadId: 'thread-1',
+			messageId: 'message-1',
+			runId: 'run-1',
+			userId: 'user-1',
+			input: { message: 'What workflows do I have?' },
+		});
+
+		expect(tracing?.messageRun.metadata).not.toHaveProperty('n8n_version');
+		expect(tracing?.messageRun.metadata).not.toHaveProperty('workflow_sdk_version');
+	});
+
 	it('redacts model secrets from trace metadata', async () => {
 		const tracing = await createInstanceAiTraceContext({
 			threadId: 'thread-1',

--- a/packages/@n8n/instance-ai/src/tracing/langsmith-tracing.ts
+++ b/packages/@n8n/instance-ai/src/tracing/langsmith-tracing.ts
@@ -104,6 +104,8 @@ interface CreateInstanceAiTraceContextOptions {
 	modelId?: unknown;
 	input: unknown;
 	metadata?: Record<string, unknown>;
+	n8nVersion?: string;
+	workflowSdkVersion?: string;
 	/** When set, traces are routed through the AI service proxy instead of directly to LangSmith. */
 	proxyConfig?: ServiceProxyConfig;
 }
@@ -1311,6 +1313,10 @@ function buildBaseMetadata(options: CreateInstanceAiTraceContextOptions): Record
 		user_id: options.userId,
 		...(options.modelId !== undefined
 			? { model_id: serializeModelIdForTrace(options.modelId) }
+			: {}),
+		...(options.n8nVersion !== undefined ? { n8n_version: options.n8nVersion } : {}),
+		...(options.workflowSdkVersion !== undefined
+			? { workflow_sdk_version: options.workflowSdkVersion }
 			: {}),
 		...options.metadata,
 	};

--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -24,12 +24,17 @@ export const EDITOR_UI_DIST_DIR = join(dirname(require.resolve('n8n-editor-ui'))
 
 const packageJsonPath = join(CLI_DIR, 'package.json');
 const aiAssistantPackageJsonPath = join(AI_ASSISTANT_SDK_DIR, 'package.json');
+const workflowSdkPackageJsonPath = require.resolve('@n8n/workflow-sdk/package.json');
 const n8nPackageJson = jsonParse<n8n.PackageJson>(readFileSync(packageJsonPath, 'utf8'));
 const aiAssistantPackageJson = jsonParse<n8n.PackageJson>(
 	readFileSync(aiAssistantPackageJsonPath, 'utf8'),
 );
+const workflowSdkPackageJson = jsonParse<n8n.PackageJson>(
+	readFileSync(workflowSdkPackageJsonPath, 'utf8'),
+);
 export const N8N_VERSION = n8nPackageJson.version;
 export const AI_ASSISTANT_SDK_VERSION = aiAssistantPackageJson.version;
+export const WORKFLOW_SDK_VERSION = workflowSdkPackageJson.version;
 export const N8N_RELEASE_DATE = statSync(packageJsonPath).mtime;
 
 export const STARTING_NODES = [

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -89,7 +89,7 @@ import { OperationalError, UnexpectedError, UserError } from 'n8n-workflow';
 import type * as Undici from 'undici';
 import { v5 as uuidv5 } from 'uuid';
 
-import { N8N_VERSION } from '@/constants';
+import { N8N_VERSION, WORKFLOW_SDK_VERSION } from '@/constants';
 import { EventService } from '@/events/event.service';
 import { SourceControlPreferencesService } from '@/modules/source-control.ee/source-control-preferences.service.ee';
 import { AiService } from '@/services/ai.service';
@@ -2636,6 +2636,8 @@ export class InstanceAiService {
 				userId: user.id,
 				modelId,
 				input: traceInput,
+				n8nVersion: N8N_VERSION,
+				workflowSdkVersion: WORKFLOW_SDK_VERSION,
 				proxyConfig: orchestrationContext.tracingProxyConfig,
 			});
 


### PR DESCRIPTION
## Summary

Adds `n8n_version` and `workflow_sdk_version` to the base trace metadata emitted by Instance AI so traces can be filtered/grouped by release in LangSmith.

- Extended `CreateInstanceAiTraceContextOptions` and `buildBaseMetadata` in `langsmith-tracing.ts` to accept and emit `n8n_version` and `workflow_sdk_version`.
- Wired both values through `createInstanceAiTraceContext` in `instance-ai.service.ts`, sourcing them from `N8N_VERSION` (already loaded from `packages/cli/package.json`) and a new `WORKFLOW_SDK_VERSION` constant (loaded from `@n8n/workflow-sdk/package.json`).
- Propagated the same values through `createDetachedSubAgentTraceContext` by reading them off the parent actor run's metadata, so sub-agent traces are tagged with the same versions.

## Related

- [Slack discussion / context — internal](https://linear.app/n8n) (no Linear ticket — small observability follow-up to today's question about whether LangSmith captured the n8n version)

## Test plan

- [x] Added unit tests in `packages/@n8n/instance-ai/src/tracing/__tests__/langsmith-tracing.test.ts` covering both presence and absence of the new metadata fields
- [x] `pnpm --filter @n8n/instance-ai typecheck`
- [x] `pnpm --filter n8n typecheck`
- [x] Existing Instance AI service unit tests pass (`packages/cli`)
- [ ] Verify in LangSmith that runs now carry `n8n_version` and `workflow_sdk_version` metadata

## Responsibility

- [x] I have seen this code, I have run this code, and I take responsibility for this code.