### PR TITLE
fix(YouTube Node): Fix misspelled "unlisted" privacy status value in Video Update operation

### DIFF
--- a/packages/nodes-base/nodes/Google/YouTube/VideoDescription.ts
+++ b/packages/nodes-base/nodes/Google/YouTube/VideoDescription.ts
@@ -776,7 +776,7 @@ export const videoFields: INodeProperties[] = [
 					},
 					{
 						name: 'Unlisted',
-						value: 'unlistef',
+						value: 'unlisted',
 					},
 				],
 				default: '',


### PR DESCRIPTION
## Summary

Fixes a single-character typo in the YouTube node's Video Update operation where the privacy status value `'unlisted'` was misspelled as `'unlistef'` (keyboard proximity: `d` → `f`). This caused a 100% failure rate when users selected "Unlisted" as the privacy status — the YouTube API rejected the invalid value.

The Video Upload operation was not affected (it already had the correct spelling).

### Non-breaking change

This fix **cannot break existing workflows**. Any workflow that had "Unlisted" selected in the Video Update operation was already failing on every execution because `'unlistef'` is not a valid YouTube API privacy status value. After this fix, users will need to re-open the node and re-select "Unlisted" to save the corrected value in their workflow JSON.

### How to test

1. Use the YouTube node with the "Update a Video" operation
2. Add "Privacy Status" and set it to "Unlisted"
3. Execute the node — it should now succeed instead of returning `Invalid value at 'resource.status.privacy_status'`

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-5015
- Fixes #30133

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)