### PR TITLE
fix(core): Keep runtime telemetry provider-neutral (no-changelog)

### DIFF
--- a/packages/@n8n/agents/src/__tests__/agent-runtime.test.ts
+++ b/packages/@n8n/agents/src/__tests__/agent-runtime.test.ts
@@ -2417,12 +2417,12 @@ describe('AgentRuntime — telemetry propagation', () => {
 			'test-agent.generate',
 			{
 				// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-				attributes: expect.objectContaining<Record<string, string>>({
-					'langsmith.traceable': 'true',
-					'langsmith.trace.name': 'test-agent.generate',
-					'langsmith.span.kind': 'chain',
-					'langsmith.metadata.agent_name': 'telemetry-root-test',
-					'langsmith.metadata.env': 'test',
+				attributes: expect.objectContaining<Record<string, string | boolean>>({
+					'telemetry.traceable': true,
+					'telemetry.trace.name': 'test-agent.generate',
+					'telemetry.span.kind': 'chain',
+					'telemetry.metadata.agent_name': 'telemetry-root-test',
+					'telemetry.metadata.env': 'test',
 				}),
 			},
 			expect.any(Function),
@@ -2463,7 +2463,7 @@ describe('AgentRuntime — telemetry propagation', () => {
 		);
 	});
 
-	it('adds a LangSmith tool catalog to telemetry root spans', async () => {
+	it('adds a generic tool catalog to telemetry root spans', async () => {
 		generateText.mockResolvedValue(makeGenerateSuccess());
 		const span = {
 			end: jest.fn(),
@@ -2511,9 +2511,10 @@ describe('AgentRuntime — telemetry propagation', () => {
 		const { attributes } = rootSpanOptions;
 		expect(attributes).toEqual(
 			expect.objectContaining({
-				'langsmith.metadata.available_tools': ['lookup'],
+				'telemetry.metadata.available_tools': ['lookup'],
 			}),
 		);
+		expect(attributes).not.toHaveProperty('langsmith.metadata.available_tools');
 		expect(attributes).not.toHaveProperty('langsmith.trace.id');
 		expect(attributes).not.toHaveProperty('langsmith.span.parent_id');
 		expect(attributes['gen_ai.prompt']).toEqual(expect.stringContaining('"name":"lookup"'));

--- a/packages/@n8n/agents/src/__tests__/langsmith-telemetry.test.ts
+++ b/packages/@n8n/agents/src/__tests__/langsmith-telemetry.test.ts
@@ -135,6 +135,49 @@ describe('LangSmithTelemetry', () => {
 		]);
 	});
 
+	it('maps generic telemetry attributes to LangSmith attributes before export', async () => {
+		await new LangSmithTelemetry({
+			apiKey: 'ls-test-key',
+			project: 'instance-ai',
+		}).build();
+
+		const processor = mockProviderConfigs[0] as {
+			spanProcessors: Array<{
+				onStart(span: unknown, parentContext: unknown): void;
+			}>;
+		};
+		const filteredProcessor = processor.spanProcessors[0];
+		const delegate = mockBatchProcessorInstances[0];
+		const root = {
+			attributes: {
+				'telemetry.traceable': true,
+				'telemetry.trace.name': 'test-agent.generate',
+				'telemetry.span.kind': 'chain',
+				'telemetry.metadata.agent_name': 'test-agent',
+				'telemetry.metadata.available_tools': ['lookup'],
+			},
+			spanContext: () => ({ traceId: 'trace-1', spanId: '1111111111111111' }),
+		};
+
+		filteredProcessor.onStart(root, {});
+
+		expect(delegate.onStart).toHaveBeenCalledWith(root, {});
+		expect(root.attributes).toEqual(
+			expect.objectContaining({
+				'langsmith.traceable': 'true',
+				'langsmith.trace.name': 'test-agent.generate',
+				'langsmith.span.kind': 'chain',
+				'langsmith.metadata.agent_name': 'test-agent',
+				'langsmith.metadata.available_tools': ['lookup'],
+			}),
+		);
+		expect(root.attributes).not.toHaveProperty('telemetry.traceable');
+		expect(root.attributes).not.toHaveProperty('telemetry.trace.name');
+		expect(root.attributes).not.toHaveProperty('telemetry.span.kind');
+		expect(root.attributes).not.toHaveProperty('telemetry.metadata.agent_name');
+		expect(root.attributes).not.toHaveProperty('telemetry.metadata.available_tools');
+	});
+
 	it('filters noisy AI SDK operation wrappers while preserving provider and tool spans', async () => {
 		await new LangSmithTelemetry({
 			apiKey: 'ls-test-key',
@@ -159,7 +202,7 @@ describe('LangSmithTelemetry', () => {
 			...(parentSpanId ? { parentSpanContext: { spanId: parentSpanId } } : {}),
 		});
 
-		const root = makeSpan('1111111111111111', { 'langsmith.traceable': 'true' });
+		const root = makeSpan('1111111111111111', { 'telemetry.traceable': true });
 		const streamWrapper = makeSpan(
 			'2222222222222222',
 			{ 'ai.operationId': 'ai.streamText' },

--- a/packages/@n8n/agents/src/integrations/langsmith.ts
+++ b/packages/@n8n/agents/src/integrations/langsmith.ts
@@ -7,6 +7,13 @@ const LANGSMITH_TRACEABLE = 'langsmith.traceable';
 const LANGSMITH_IS_ROOT = 'langsmith.is_root';
 const LANGSMITH_PARENT_RUN_ID = 'langsmith.span.parent_id';
 const LANGSMITH_TRACEABLE_PARENT_OTEL_SPAN_ID = 'langsmith.traceable_parent_otel_span_id';
+const LANGSMITH_TRACE_NAME = 'langsmith.trace.name';
+const LANGSMITH_SPAN_KIND = 'langsmith.span.kind';
+const LANGSMITH_METADATA_PREFIX = 'langsmith.metadata.';
+const TELEMETRY_TRACEABLE = 'telemetry.traceable';
+const TELEMETRY_TRACE_NAME = 'telemetry.trace.name';
+const TELEMETRY_SPAN_KIND = 'telemetry.span.kind';
+const TELEMETRY_METADATA_PREFIX = 'telemetry.metadata.';
 const AI_OPERATION_ID = 'ai.operationId';
 const TRACEABLE_AI_SDK_OPERATIONS = new Set([
 	'ai.generateText.doGenerate',
@@ -71,6 +78,37 @@ function isTraceableSpan(span: OtelSpanLike): boolean {
 	);
 }
 
+function mapAttribute(
+	attributes: Record<string, unknown>,
+	sourceKey: string,
+	targetKey: string,
+	transformValue: (value: unknown) => unknown = (value) => value,
+): void {
+	if (!(sourceKey in attributes)) return;
+
+	attributes[targetKey] = transformValue(attributes[sourceKey]);
+	delete attributes[sourceKey];
+}
+
+function toLangSmithTraceableValue(value: unknown): unknown {
+	return value === true ? 'true' : value === false ? 'false' : value;
+}
+
+function mapTelemetryAttributesToLangSmith(span: OtelSpanLike): void {
+	const { attributes } = span;
+	mapAttribute(attributes, TELEMETRY_TRACEABLE, LANGSMITH_TRACEABLE, toLangSmithTraceableValue);
+	mapAttribute(attributes, TELEMETRY_TRACE_NAME, LANGSMITH_TRACE_NAME);
+	mapAttribute(attributes, TELEMETRY_SPAN_KIND, LANGSMITH_SPAN_KIND);
+
+	for (const [key, value] of Object.entries(attributes)) {
+		if (!key.startsWith(TELEMETRY_METADATA_PREFIX)) continue;
+
+		const metadataKey = key.slice(TELEMETRY_METADATA_PREFIX.length);
+		attributes[`${LANGSMITH_METADATA_PREFIX}${metadataKey}`] = value;
+		delete attributes[key];
+	}
+}
+
 function createLangSmithSpanProcessor(options: {
 	exporter: unknown;
 	BatchSpanProcessor: BatchSpanProcessorConstructor;
@@ -95,6 +133,8 @@ function createLangSmithSpanProcessor(options: {
 				delegate.onStart(span, parentContext);
 				return;
 			}
+
+			mapTelemetryAttributesToLangSmith(span);
 
 			const spanContext = span.spanContext();
 			traceMap[spanContext.traceId] ??= {

--- a/packages/@n8n/agents/src/runtime/agent-runtime.ts
+++ b/packages/@n8n/agents/src/runtime/agent-runtime.ts
@@ -148,7 +148,7 @@ function buildAgentRootInputAttributes(config: AgentRuntimeConfig): Record<strin
 	});
 
 	return {
-		...(toolNames.length > 0 ? { 'langsmith.metadata.available_tools': toolNames } : {}),
+		...(toolNames.length > 0 ? { 'telemetry.metadata.available_tools': toolNames } : {}),
 		...(serialized ? { 'gen_ai.prompt': serialized } : {}),
 	};
 }
@@ -723,14 +723,14 @@ export class AgentRuntime {
 		spanName: string,
 		runId: string,
 	): Record<string, AttributeValue> {
-		const metadataAttributes = this.buildTelemetryMetadataAttributes(t, 'langsmith.metadata');
+		const metadataAttributes = this.buildTelemetryMetadataAttributes(t, 'telemetry.metadata');
 
 		return {
-			'langsmith.traceable': 'true',
-			'langsmith.trace.name': spanName,
-			'langsmith.span.kind': 'chain',
-			'langsmith.metadata.agent_name': this.config.name,
-			'langsmith.metadata.agent_run_id': runId,
+			'telemetry.traceable': true,
+			'telemetry.trace.name': spanName,
+			'telemetry.span.kind': 'chain',
+			'telemetry.metadata.agent_name': this.config.name,
+			'telemetry.metadata.agent_run_id': runId,
 			...metadataAttributes,
 			...buildAgentRootInputAttributes(this.config),
 		};


### PR DESCRIPTION
## Summary

Follow-up to #30014, it keeps AgentRuntime telemetry metadata provider-neutral by emitting generic `telemetry.*` attributes, then maps them to LangSmith-specific `langsmith.*` attributes inside the LangSmith integration. Also updates the related tests to cover the runtime attributes and the LangSmith mapping boundary
## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
