### PR TITLE
fix(Git Node): Restore Clone and other operations on simple-git 3.36+

### DIFF
--- a/packages/nodes-base/nodes/Git/Git.node.ts
+++ b/packages/nodes-base/nodes/Git/Git.node.ts
@@ -337,6 +337,10 @@ export class Git implements INodeType {
 				const gitOptions: Partial<SimpleGitOptions> = {
 					baseDir: resolvedRepositoryPath,
 					config: gitConfig,
+					// simple-git blocks callers from setting `core.hooksPath` via `config`
+					// unless this flag is set. We set it deliberately as a mitigation, so
+					// opt in to keep that mitigation working.
+					...(!enableHooks && { unsafe: { allowUnsafeHooksPath: true } }),
 				};
 
 				const git: SimpleGit = simpleGit(gitOptions)

--- a/packages/nodes-base/nodes/Git/__test__/Git.node.test.ts
+++ b/packages/nodes-base/nodes/Git/__test__/Git.node.test.ts
@@ -130,6 +130,18 @@ describe('Git Node', () => {
 			);
 		});
 
+		it('should opt into allowUnsafeHooksPath when enableGitNodeHooks is false', async () => {
+			securityConfig.enableGitNodeHooks = false;
+
+			await gitNode.execute.call(executeFunctions);
+
+			expect(mockSimpleGit).toHaveBeenCalledWith(
+				expect.objectContaining({
+					unsafe: { allowUnsafeHooksPath: true },
+				}),
+			);
+		});
+
 		it('should not add core.hooksPath=/dev/null when enableGitNodeHooks is true', async () => {
 			securityConfig.enableGitNodeHooks = true;
 
@@ -140,6 +152,15 @@ describe('Git Node', () => {
 					config: [],
 				}),
 			);
+		});
+
+		it('should not opt into allowUnsafeHooksPath when enableGitNodeHooks is true', async () => {
+			securityConfig.enableGitNodeHooks = true;
+
+			await gitNode.execute.call(executeFunctions);
+
+			const options = mockSimpleGit.mock.calls[0][0] as { unsafe?: unknown };
+			expect(options.unsafe).toBeUndefined();
 		});
 	});
 


### PR DESCRIPTION
## Summary

The Git node's `Clone` operation (and all other operations) fails on n8n Cloud and self-hosted instances bundling `simple-git@3.36.0` with:

```
Error: Configuring core.hooksPath is not permitted without enabling allowUnsafeHooksPath
```

Two defensive layers were colliding:

1. The Git node injects `core.hooksPath=/dev/null` into every `simpleGit(...)` call when `securityConfig.enableGitNodeHooks` is `false` (the default).
2. `simple-git@3.36.0` shipped a `block-unsafe-operations-plugin` that rejects any caller passing `core.hooksPath` via the `config` option unless it opts in with `unsafe: { allowUnsafeHooksPath: true }`.

simple-git's flag is specifically designed for trusted callers that deliberately control `core.hooksPath` for safety reasons — which is exactly our case. This PR sets the flag in `SimpleGitOptions` whenever the node is injecting the hook-disabling config, restoring the mitigation and making the existing `N8N_GIT_NODE_ENABLE_HOOKS=true` workaround unnecessary (Cloud users could not apply that workaround anyway).

### How to test

1. Start n8n locally (or in Cloud) with default settings (`N8N_GIT_NODE_ENABLE_HOOKS` unset).
2. Add a Git node, select `Clone`, point it at any public repo and a writable local path.
3. Execute the node — it should complete successfully.
4. Repeat with `N8N_GIT_NODE_ENABLE_HOOKS=true` to confirm the hooks-enabled path is unchanged.

### Unit test coverage

Added two cases to `nodes/Git/__test__/Git.node.test.ts`:

- `simpleGit` is called with `unsafe: { allowUnsafeHooksPath: true }` when `enableGitNodeHooks=false`.
- `unsafe` is not set when `enableGitNodeHooks=true` (no behavior change on that branch).

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-5003
- closes #30043

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI