### PR TITLE
feat(core): Add eval collection entity + repository (TRUST-72)

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -437,6 +437,27 @@ export {
 	type StartTestRunPayload,
 } from './schemas/evaluations.schema';
 
+export {
+	EVAL_COLLECTIONS_FLAG,
+	evalCollectionVersionEntrySchema,
+	createEvaluationCollectionSchema,
+	CreateEvaluationCollectionDto,
+	updateEvaluationCollectionSchema,
+	UpdateEvaluationCollectionDto,
+	addRunToCollectionSchema,
+	AddRunToCollectionDto,
+	type EvalCollectionVersionEntry,
+	type CreateEvaluationCollectionPayload,
+	type UpdateEvaluationCollectionPayload,
+	type AddRunToCollectionPayload,
+	type EvalCollectionRunStatus,
+	type EvaluationCollectionRecord,
+	type EvaluationCollectionRunSummary,
+	type EvaluationCollectionDetail,
+	type EvalVersionEntry,
+	type EvalVersionsResponse,
+} from './schemas/eval-collections.schema';
+
 export { ALLOWED_DOMAINS, isAllowedDomain } from './utils/allowed-domains';
 
 export {

--- a/packages/@n8n/api-types/src/schemas/eval-collections.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/eval-collections.schema.ts
@@ -1,0 +1,112 @@
+import { z } from 'zod';
+
+import { Z } from '../zod-class';
+
+// Mirrors the `TestRunStatus` union in `@n8n/db`. Duplicated here so
+// `@n8n/api-types` does not need to depend on the db package.
+export type EvalCollectionRunStatus = 'new' | 'running' | 'completed' | 'error' | 'cancelled';
+
+// PostHog rollout flag id gating the eval-collections feature surface. All
+// new endpoints + frontend entry points consult this; flag-off cohort sees
+// the legacy single-run flow unchanged. Single source of truth shared
+// between FE and BE so the two cannot drift. Matches the spec verbatim —
+// the existing `080_eval_parallel_execution` flag follows a numeric-prefix
+// convention but the spec called for the literal id here.
+export const EVAL_COLLECTIONS_FLAG = 'eval_collections';
+
+// Per-version entry on a create-collection request. Either reference an
+// existing test run (`existingTestRunId`) to reuse it, or omit it and the
+// service will schedule a fresh run pinned to `workflowVersionId`. A null
+// `workflowVersionId` means "current draft" — the service snapshots a new
+// `WorkflowHistory` row at run start so the run stays comparable.
+export const evalCollectionVersionEntrySchema = z.object({
+	workflowVersionId: z.string().min(1).nullable(),
+	existingTestRunId: z.string().min(1).optional(),
+	label: z.string().min(1).max(128).optional(),
+});
+
+export type EvalCollectionVersionEntry = z.infer<typeof evalCollectionVersionEntrySchema>;
+
+const createEvaluationCollectionShape = {
+	name: z.string().min(1).max(128),
+	description: z.string().nullable().optional(),
+	evaluationConfigId: z.string().min(1),
+	versions: z.array(evalCollectionVersionEntrySchema).min(1),
+	concurrency: z.number().int().min(1).max(10).optional(),
+};
+
+export const createEvaluationCollectionSchema = z.object(createEvaluationCollectionShape);
+export type CreateEvaluationCollectionPayload = z.infer<typeof createEvaluationCollectionSchema>;
+
+export class CreateEvaluationCollectionDto extends Z.class(createEvaluationCollectionShape) {}
+
+const updateEvaluationCollectionShape = {
+	name: z.string().min(1).max(128).optional(),
+	description: z.string().nullable().optional(),
+};
+
+export const updateEvaluationCollectionSchema = z.object(updateEvaluationCollectionShape);
+export type UpdateEvaluationCollectionPayload = z.infer<typeof updateEvaluationCollectionSchema>;
+
+export class UpdateEvaluationCollectionDto extends Z.class(updateEvaluationCollectionShape) {}
+
+const addRunToCollectionShape = {
+	testRunId: z.string().min(1),
+};
+
+export const addRunToCollectionSchema = z.object(addRunToCollectionShape);
+export type AddRunToCollectionPayload = z.infer<typeof addRunToCollectionSchema>;
+
+export class AddRunToCollectionDto extends Z.class(addRunToCollectionShape) {}
+
+// Response shapes. These are not validated input — they describe what the
+// server returns. Keeping them as plain TypeScript types (not zod schemas)
+// avoids forcing the server to round-trip its own outputs through zod.
+
+export type EvaluationCollectionRecord = {
+	id: string;
+	name: string;
+	description: string | null;
+	workflowId: string;
+	evaluationConfigId: string;
+	createdById: string | null;
+	createdAt: string;
+	updatedAt: string;
+	runCount: number;
+};
+
+export type EvaluationCollectionRunSummary = {
+	testRunId: string;
+	workflowVersionId: string | null;
+	status: EvalCollectionRunStatus;
+	runAt: string | null;
+	completedAt: string | null;
+	avgScore: number | null;
+	metrics: Record<string, number> | null;
+};
+
+export type EvaluationCollectionDetail = EvaluationCollectionRecord & {
+	runs: EvaluationCollectionRunSummary[];
+};
+
+// Versions-picker endpoint response. The setup wizard renders one row per
+// item; `lastRun = null` means "no run yet · will run new" in the UI.
+export type EvalVersionEntry = {
+	workflowVersionId: string | null;
+	label: string;
+	sourceLabel: string;
+	isCurrent: boolean;
+	lastRun: {
+		testRunId: string;
+		runAt: string;
+		status: EvalCollectionRunStatus;
+		avgScore: number | null;
+		isBest: boolean;
+		isCritical: boolean;
+	} | null;
+};
+
+export type EvalVersionsResponse = {
+	evaluationConfigId: string;
+	versions: EvalVersionEntry[];
+};

--- a/packages/@n8n/db/src/entities/evaluation-collection.ee.ts
+++ b/packages/@n8n/db/src/entities/evaluation-collection.ee.ts
@@ -44,7 +44,7 @@ export class EvaluationCollection extends WithTimestamps {
 	@Column('varchar', { length: 36 })
 	evaluationConfigId: string;
 
-	@Column('varchar', { length: 36, nullable: true })
+	@Column({ type: 'uuid', nullable: true })
 	createdById: string | null;
 
 	/**

--- a/packages/@n8n/db/src/entities/evaluation-collection.ee.ts
+++ b/packages/@n8n/db/src/entities/evaluation-collection.ee.ts
@@ -1,0 +1,58 @@
+import { Column, Entity, Index, PrimaryColumn } from '@n8n/typeorm';
+import type { IDataObject } from 'n8n-workflow';
+
+import { JsonColumn, WithTimestamps } from './abstract-entity';
+
+/**
+ * A named, user-curated group of {@link TestRun}s sharing one
+ * {@link EvaluationConfig} (= one dataset + one set of metrics + one workflow),
+ * typically spread across multiple workflow versions. The collection is the
+ * unit of comparison in the eval compare view.
+ *
+ * Invariants enforced at the service layer:
+ *  - Every run in a collection has the same `evaluationConfigId`.
+ *  - Every run is on the same workflow as the collection.
+ *  - Runs typically differ by `workflowVersionId`.
+ *
+ * **TypeORM relations:** the `workflowId` and `evaluationConfigId` columns
+ * are FK columns *without* `@ManyToOne` decorators. Service code resolves
+ * the related entities through their own repositories. Declaring the
+ * relations on this entity would extend the TypeORM entity-relation type
+ * graph enough to trip TS2589 ("type instantiation excessively deep") in
+ * unrelated repositories that transitively reach `TestRun` →
+ * `EvaluationCollection` through `WorkflowEntity.testRuns` — e.g.
+ * `FolderRepository.upsert()` in `source-control-import.service.ee.ts`.
+ * The FK constraints are preserved by the migration's raw SQL; the
+ * decorators are purely TypeORM-side metadata.
+ */
+@Entity()
+export class EvaluationCollection extends WithTimestamps {
+	@PrimaryColumn({ type: 'varchar', length: 36 })
+	id: string;
+
+	@Column('varchar', { length: 128 })
+	name: string;
+
+	@Column('text', { nullable: true })
+	description: string | null;
+
+	@Index()
+	@Column('varchar', { length: 36 })
+	workflowId: string;
+
+	@Index()
+	@Column('varchar', { length: 36 })
+	evaluationConfigId: string;
+
+	@Column('varchar', { length: 36, nullable: true })
+	createdById: string | null;
+
+	/**
+	 * Cached AI-generated insights for this collection. Lazily populated when
+	 * a user opens the compare view; re-generated when runs change. Shape
+	 * mirrors the `AiInsightsResponse` type produced by the insights agent —
+	 * stored loose here so PR 2 can iterate on the schema without a migration.
+	 */
+	@JsonColumn({ nullable: true })
+	insightsCache: IDataObject | null;
+}

--- a/packages/@n8n/db/src/entities/index.ts
+++ b/packages/@n8n/db/src/entities/index.ts
@@ -11,6 +11,7 @@ import {
 } from './credential-dependency-entity';
 import { CredentialsEntity } from './credentials-entity';
 import { DeploymentKey } from './deployment-key';
+import { EvaluationCollection } from './evaluation-collection.ee';
 import { EvaluationConfig } from './evaluation-config.ee';
 import { ExecutionAnnotation } from './execution-annotation.ee';
 import { ExecutionData } from './execution-data';
@@ -63,6 +64,7 @@ export {
 	CredentialDependency,
 	type CredentialDependencyType,
 	DeploymentKey,
+	EvaluationCollection,
 	EvaluationConfig,
 	Folder,
 	Project,
@@ -109,6 +111,7 @@ export const entities = {
 	CredentialsEntity,
 	CredentialDependency,
 	DeploymentKey,
+	EvaluationCollection,
 	EvaluationConfig,
 	Folder,
 	Project,

--- a/packages/@n8n/db/src/entities/test-run.ee.ts
+++ b/packages/@n8n/db/src/entities/test-run.ee.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, OneToMany, ManyToOne } from '@n8n/typeorm';
+import { Column, Entity, Index, OneToMany, ManyToOne } from '@n8n/typeorm';
 import type { IDataObject } from 'n8n-workflow';
 
 import { DateTimeColumn, JsonColumn, WithTimestampsAndStringId } from './abstract-entity';
@@ -62,6 +62,30 @@ export class TestRun extends WithTimestampsAndStringId {
 	 */
 	@Column('boolean', { default: false })
 	cancelRequested: boolean;
+
+	@Column('varchar', { length: 36, nullable: true })
+	workflowVersionId: string | null;
+
+	// FK column only — no `@ManyToOne` decorator. Service code queries via
+	// `evaluationConfigId` and resolves the config through its own repository
+	// when needed. Declaring the relation on `TestRun` would extend the
+	// TypeORM entity-relation type graph enough to trip TS2589
+	// ("type instantiation excessively deep") in unrelated repositories that
+	// transitively reach `TestRun` through `WorkflowEntity.testRuns` — e.g.
+	// `FolderRepository.upsert()` in `source-control-import.service.ee.ts`.
+	// The FK constraint is preserved by the migration's raw SQL; the
+	// decorator is purely TypeORM-side metadata.
+	@Index()
+	@Column('varchar', { length: 36, nullable: true })
+	evaluationConfigId: string | null;
+
+	@JsonColumn({ nullable: true })
+	evaluationConfigSnapshot: IDataObject | null;
+
+	// FK column only — see `evaluationConfigId` comment above for rationale.
+	@Index()
+	@Column('varchar', { length: 36, nullable: true })
+	collectionId: string | null;
 
 	/**
 	 * Calculated property to determine the final result of the test run

--- a/packages/@n8n/db/src/migrations/common/1778496086558-CreateEvaluationCollection.ts
+++ b/packages/@n8n/db/src/migrations/common/1778496086558-CreateEvaluationCollection.ts
@@ -9,6 +9,8 @@ const FK_TEST_RUN_COLLECTION = 'FK_test_run_collection_id';
 export class CreateEvaluationCollection1778496086558 implements ReversibleMigration {
 	async up({
 		schemaBuilder: { createTable, addColumns, addForeignKey, createIndex, column },
+		queryRunner,
+		isSqlite,
 	}: MigrationContext) {
 		await createTable(EVALUATION_COLLECTION_TABLE)
 			.withColumns(
@@ -32,6 +34,21 @@ export class CreateEvaluationCollection1778496086558 implements ReversibleMigrat
 			})
 			.withIndexOn('workflowId')
 			.withIndexOn('evaluationConfigId').withTimestamps;
+
+		// On SQLite, `addColumns` and `addForeignKey` both trigger a full
+		// table rebuild via TypeORM's cached `Table` metadata. The prior
+		// migration `1778100002000-AddEvaluationConfigColumnsToTestRun`
+		// added the `evaluationConfigSnapshot` column on SQLite via raw
+		// `ALTER TABLE ADD COLUMN`, which TypeORM doesn't observe — so its
+		// cached metadata is stale by the time this migration runs. Without
+		// this refresh, the next rebuild silently drops the column and
+		// every subsequent `TestRun` insert fails with
+		// "SQLITE_ERROR: table test_run has no column named
+		// evaluationConfigSnapshot". `queryRunner.getTable()` reloads from
+		// PRAGMA table_info so the rebuild reads the actual current schema.
+		if (isSqlite) {
+			await queryRunner.getTable(TEST_RUN_TABLE);
+		}
 
 		await addColumns(TEST_RUN_TABLE, [column('collectionId').varchar(36)]);
 

--- a/packages/@n8n/db/src/migrations/common/1778496086558-CreateEvaluationCollection.ts
+++ b/packages/@n8n/db/src/migrations/common/1778496086558-CreateEvaluationCollection.ts
@@ -1,0 +1,62 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+const EVALUATION_COLLECTION_TABLE = 'evaluation_collection';
+const TEST_RUN_TABLE = 'test_run';
+const EVALUATION_CONFIG_TABLE = 'evaluation_config';
+const WORKFLOW_TABLE = 'workflow_entity';
+const FK_TEST_RUN_COLLECTION = 'FK_test_run_collection_id';
+
+export class CreateEvaluationCollection1778496086558 implements ReversibleMigration {
+	async up({
+		schemaBuilder: { createTable, addColumns, addForeignKey, createIndex, column },
+	}: MigrationContext) {
+		await createTable(EVALUATION_COLLECTION_TABLE)
+			.withColumns(
+				column('id').varchar(36).primary.notNull,
+				column('name').varchar(128).notNull,
+				column('description').text,
+				column('workflowId').varchar(36).notNull,
+				column('evaluationConfigId').varchar(36).notNull,
+				column('createdById').varchar(36),
+				column('insightsCache').json,
+			)
+			.withForeignKey('workflowId', {
+				tableName: WORKFLOW_TABLE,
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withForeignKey('evaluationConfigId', {
+				tableName: EVALUATION_CONFIG_TABLE,
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withIndexOn('workflowId')
+			.withIndexOn('evaluationConfigId').withTimestamps;
+
+		await addColumns(TEST_RUN_TABLE, [column('collectionId').varchar(36)]);
+
+		await addForeignKey(
+			TEST_RUN_TABLE,
+			'collectionId',
+			[EVALUATION_COLLECTION_TABLE, 'id'],
+			FK_TEST_RUN_COLLECTION,
+			'SET NULL',
+		);
+
+		await createIndex(TEST_RUN_TABLE, ['collectionId']);
+	}
+
+	async down({
+		schemaBuilder: { dropColumns, dropTable, dropForeignKey, dropIndex },
+	}: MigrationContext) {
+		await dropIndex(TEST_RUN_TABLE, ['collectionId']);
+		await dropForeignKey(
+			TEST_RUN_TABLE,
+			'collectionId',
+			[EVALUATION_COLLECTION_TABLE, 'id'],
+			FK_TEST_RUN_COLLECTION,
+		);
+		await dropColumns(TEST_RUN_TABLE, ['collectionId']);
+		await dropTable(EVALUATION_COLLECTION_TABLE);
+	}
+}

--- a/packages/@n8n/db/src/migrations/common/1778496086558-CreateEvaluationCollection.ts
+++ b/packages/@n8n/db/src/migrations/common/1778496086558-CreateEvaluationCollection.ts
@@ -4,6 +4,7 @@ const EVALUATION_COLLECTION_TABLE = 'evaluation_collection';
 const TEST_RUN_TABLE = 'test_run';
 const EVALUATION_CONFIG_TABLE = 'evaluation_config';
 const WORKFLOW_TABLE = 'workflow_entity';
+const USER_TABLE = 'user';
 const FK_TEST_RUN_COLLECTION = 'FK_test_run_collection_id';
 
 export class CreateEvaluationCollection1778496086558 implements ReversibleMigration {
@@ -31,6 +32,11 @@ export class CreateEvaluationCollection1778496086558 implements ReversibleMigrat
 				tableName: EVALUATION_CONFIG_TABLE,
 				columnName: 'id',
 				onDelete: 'CASCADE',
+			})
+			.withForeignKey('createdById', {
+				tableName: USER_TABLE,
+				columnName: 'id',
+				onDelete: 'SET NULL',
 			})
 			.withIndexOn('workflowId')
 			.withIndexOn('evaluationConfigId').withTimestamps;

--- a/packages/@n8n/db/src/migrations/common/1778496086558-CreateEvaluationCollection.ts
+++ b/packages/@n8n/db/src/migrations/common/1778496086558-CreateEvaluationCollection.ts
@@ -20,7 +20,7 @@ export class CreateEvaluationCollection1778496086558 implements ReversibleMigrat
 				column('description').text,
 				column('workflowId').varchar(36).notNull,
 				column('evaluationConfigId').varchar(36).notNull,
-				column('createdById').varchar(36),
+				column('createdById').uuid,
 				column('insightsCache').json,
 			)
 			.withForeignKey('workflowId', {

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -172,6 +172,7 @@ import { AddExecutionDeduplicationKey1778000000000 } from '../common/17780000000
 import { CreateEvaluationConfig1778100000000 } from '../common/1778100000000-CreateEvaluationConfig';
 import { AddWorkflowVersionToTestRun1778100001000 } from '../common/1778100001000-AddWorkflowVersionToTestRun';
 import { AddEvaluationConfigColumnsToTestRun1778100002000 } from '../common/1778100002000-AddEvaluationConfigColumnsToTestRun';
+import { CreateEvaluationCollection1778496086558 } from '../common/1778496086558-CreateEvaluationCollection';
 import { CreateAgentTables1783000000000 } from '../common/1783000000000-CreateAgentTables';
 import { CreateAgentExecutionTables1783000000001 } from '../common/1783000000001-CreateAgentExecutionTables';
 import { CreateAgentObservationTables1784000000000 } from '../common/1784000000000-CreateAgentObservationTables';
@@ -352,6 +353,7 @@ export const postgresMigrations: Migration[] = [
 	CreateEvaluationConfig1778100000000,
 	AddWorkflowVersionToTestRun1778100001000,
 	AddEvaluationConfigColumnsToTestRun1778100002000,
+	CreateEvaluationCollection1778496086558,
 	CreateAgentTables1783000000000,
 	CreateAgentExecutionTables1783000000001,
 	CreateAgentObservationTables1784000000000,

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -165,6 +165,7 @@ import { AddExecutionDeduplicationKey1778000000000 } from '../common/17780000000
 import { CreateEvaluationConfig1778100000000 } from '../common/1778100000000-CreateEvaluationConfig';
 import { AddWorkflowVersionToTestRun1778100001000 } from '../common/1778100001000-AddWorkflowVersionToTestRun';
 import { AddEvaluationConfigColumnsToTestRun1778100002000 } from '../common/1778100002000-AddEvaluationConfigColumnsToTestRun';
+import { CreateEvaluationCollection1778496086558 } from '../common/1778496086558-CreateEvaluationCollection';
 import { CreateAgentTables1783000000000 } from '../common/1783000000000-CreateAgentTables';
 import { CreateAgentExecutionTables1783000000001 } from '../common/1783000000001-CreateAgentExecutionTables';
 import { CreateAgentObservationTables1784000000000 } from '../common/1784000000000-CreateAgentObservationTables';
@@ -338,6 +339,7 @@ const sqliteMigrations: Migration[] = [
 	CreateEvaluationConfig1778100000000,
 	AddWorkflowVersionToTestRun1778100001000,
 	AddEvaluationConfigColumnsToTestRun1778100002000,
+	CreateEvaluationCollection1778496086558,
 	CreateAgentTables1783000000000,
 	CreateAgentExecutionTables1783000000001,
 	CreateAgentObservationTables1784000000000,

--- a/packages/@n8n/db/src/repositories/__tests__/evaluation-collection.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/evaluation-collection.repository.test.ts
@@ -199,5 +199,39 @@ describe('EvaluationCollectionRepository', () => {
 				description: null,
 			});
 		});
+
+		it('preserves description when only name is provided', async () => {
+			const existing = {
+				id: 'col-1',
+				name: 'Old',
+				description: 'old desc',
+				workflowId: 'wf-1',
+			} as EvaluationCollection;
+			entityManager.findOne.mockResolvedValueOnce(existing);
+			entityManager.save.mockImplementationOnce(async (_target, entity) => entity);
+
+			await repo.updateMeta('col-1', 'wf-1', { name: 'New' });
+
+			const savedEntity = entityManager.save.mock.calls[0]?.[1] as EvaluationCollection;
+			expect(savedEntity.name).toBe('New');
+			expect(savedEntity.description).toBe('old desc');
+		});
+
+		it('preserves existing fields when payload props are undefined', async () => {
+			const existing = {
+				id: 'col-1',
+				name: 'Old',
+				description: 'old desc',
+				workflowId: 'wf-1',
+			} as EvaluationCollection;
+			entityManager.findOne.mockResolvedValueOnce(existing);
+			entityManager.save.mockImplementationOnce(async (_target, entity) => entity);
+
+			await repo.updateMeta('col-1', 'wf-1', { name: undefined, description: undefined });
+
+			const savedEntity = entityManager.save.mock.calls[0]?.[1] as EvaluationCollection;
+			expect(savedEntity.name).toBe('Old');
+			expect(savedEntity.description).toBe('old desc');
+		});
 	});
 });

--- a/packages/@n8n/db/src/repositories/__tests__/evaluation-collection.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/evaluation-collection.repository.test.ts
@@ -1,0 +1,203 @@
+import { Container } from '@n8n/di';
+
+import { EvaluationCollection } from '../../entities/evaluation-collection.ee';
+import { TestRun } from '../../entities/test-run.ee';
+import { mockEntityManager } from '../../utils/test-utils/mock-entity-manager';
+import { EvaluationCollectionRepository } from '../evaluation-collection.repository';
+
+describe('EvaluationCollectionRepository', () => {
+	const entityManager = mockEntityManager(EvaluationCollection);
+	const repo = Container.get(EvaluationCollectionRepository);
+
+	beforeEach(() => {
+		jest.resetAllMocks();
+	});
+
+	describe('createCollection', () => {
+		it('persists the collection with insightsCache initialised to null', async () => {
+			(entityManager.create as jest.Mock).mockImplementation(
+				(_target: unknown, entityLike: unknown) => entityLike as EvaluationCollection,
+			);
+			entityManager.save.mockImplementationOnce(async (_target, entity) => entity);
+
+			await repo.createCollection({
+				id: 'col-1',
+				name: 'C',
+				description: null,
+				workflowId: 'wf-1',
+				evaluationConfigId: 'cfg-1',
+				createdById: 'user-1',
+			});
+
+			const savedEntity = entityManager.save.mock.calls[0]?.[1];
+			expect(savedEntity).toMatchObject({
+				id: 'col-1',
+				name: 'C',
+				description: null,
+				workflowId: 'wf-1',
+				evaluationConfigId: 'cfg-1',
+				createdById: 'user-1',
+				insightsCache: null,
+			});
+		});
+	});
+
+	describe('findByIdAndWorkflowId', () => {
+		it('scopes the lookup to the route workflowId so foreign-workflow ids 404 the same as missing ids', async () => {
+			entityManager.findOne.mockResolvedValueOnce(null);
+
+			const result = await repo.findByIdAndWorkflowId('col-x', 'wf-1');
+
+			expect(result).toBeNull();
+			const callArgs = entityManager.findOne.mock.calls[0];
+			expect(callArgs?.[1]).toEqual({ where: { id: 'col-x', workflowId: 'wf-1' } });
+		});
+	});
+
+	describe('listByWorkflowId', () => {
+		it('joins runCount onto each collection with one aggregate query', async () => {
+			const collections = [
+				{ id: 'col-a', workflowId: 'wf-1', createdAt: new Date() },
+				{ id: 'col-b', workflowId: 'wf-1', createdAt: new Date() },
+			] as EvaluationCollection[];
+			entityManager.find.mockResolvedValueOnce(collections);
+			const qb = {
+				select: jest.fn().mockReturnThis(),
+				addSelect: jest.fn().mockReturnThis(),
+				where: jest.fn().mockReturnThis(),
+				groupBy: jest.fn().mockReturnThis(),
+				getRawMany: jest.fn().mockResolvedValueOnce([
+					{ collectionId: 'col-a', count: '3' },
+					{ collectionId: 'col-b', count: '0' },
+				]),
+			};
+			entityManager.createQueryBuilder.mockReturnValueOnce(qb as never);
+
+			const result = await repo.listByWorkflowId('wf-1');
+
+			expect(entityManager.createQueryBuilder).toHaveBeenCalledTimes(1);
+			expect(result.map((c) => c.runCount)).toEqual([3, 0]);
+		});
+
+		it('returns an empty array without an aggregate query when no collections exist', async () => {
+			entityManager.find.mockResolvedValueOnce([]);
+
+			const result = await repo.listByWorkflowId('wf-1');
+
+			expect(result).toEqual([]);
+			expect(entityManager.createQueryBuilder).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('addRunsToCollection', () => {
+		it('updates TestRun.collectionId in bulk by id', async () => {
+			entityManager.update.mockResolvedValueOnce({ affected: 2, generatedMaps: [], raw: [] });
+
+			await repo.addRunsToCollection('col-1', ['tr-a', 'tr-b']);
+
+			const callArgs = entityManager.update.mock.calls[0];
+			expect(callArgs?.[0]).toBe(TestRun);
+			expect(callArgs?.[2]).toEqual({ collectionId: 'col-1' });
+		});
+
+		it('is a no-op when given an empty id list', async () => {
+			await repo.addRunsToCollection('col-1', []);
+			expect(entityManager.update).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('removeRunFromCollection', () => {
+		it('only unlinks runs that are actually in the named collection', async () => {
+			entityManager.update.mockResolvedValueOnce({ affected: 1, generatedMaps: [], raw: [] });
+
+			const affected = await repo.removeRunFromCollection('col-1', 'tr-a');
+
+			expect(affected).toBe(1);
+			const callArgs = entityManager.update.mock.calls[0];
+			expect(callArgs?.[1]).toEqual({ id: 'tr-a', collectionId: 'col-1' });
+			expect(callArgs?.[2]).toEqual({ collectionId: null });
+		});
+
+		it('returns 0 when the run is not part of the collection', async () => {
+			entityManager.update.mockResolvedValueOnce({ affected: 0, generatedMaps: [], raw: [] });
+
+			expect(await repo.removeRunFromCollection('col-1', 'tr-missing')).toBe(0);
+		});
+	});
+
+	describe('deleteByIdAndWorkflowId', () => {
+		it('counts runs before delete so callers can report runs_unlinked for telemetry', async () => {
+			entityManager.findOne.mockResolvedValueOnce({ id: 'col-1' } as EvaluationCollection);
+			entityManager.count.mockResolvedValueOnce(4);
+			entityManager.delete.mockResolvedValueOnce({ affected: 1, raw: [] });
+
+			const result = await repo.deleteByIdAndWorkflowId('col-1', 'wf-1');
+
+			expect(result).toEqual({ deleted: true, runsUnlinked: 4 });
+		});
+
+		it('returns { deleted: false } without touching delete when the collection does not exist', async () => {
+			entityManager.findOne.mockResolvedValueOnce(null);
+
+			const result = await repo.deleteByIdAndWorkflowId('col-missing', 'wf-1');
+
+			expect(result).toEqual({ deleted: false, runsUnlinked: 0 });
+			expect(entityManager.delete).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('updateInsightsCache', () => {
+		it('updates the insightsCache JSON column on the row', async () => {
+			entityManager.update.mockResolvedValueOnce({ affected: 1, generatedMaps: [], raw: [] });
+
+			await repo.updateInsightsCache('col-1', { winner: { versionLabel: 'A' } } as never);
+
+			const callArgs = entityManager.update.mock.calls[0];
+			expect(callArgs?.[1]).toBe('col-1');
+			expect(callArgs?.[2]).toEqual({ insightsCache: { winner: { versionLabel: 'A' } } });
+		});
+
+		it('accepts null to clear the cache', async () => {
+			entityManager.update.mockResolvedValueOnce({ affected: 1, generatedMaps: [], raw: [] });
+
+			await repo.updateInsightsCache('col-1', null);
+
+			const callArgs = entityManager.update.mock.calls[0];
+			expect(callArgs?.[2]).toEqual({ insightsCache: null });
+		});
+	});
+
+	describe('updateMeta', () => {
+		it('returns null without writing when the collection does not exist', async () => {
+			entityManager.findOne.mockResolvedValueOnce(null);
+
+			const result = await repo.updateMeta('col-x', 'wf-1', { name: 'New' });
+
+			expect(result).toBeNull();
+			expect(entityManager.save).not.toHaveBeenCalled();
+		});
+
+		it('merges name + description onto the existing entity', async () => {
+			const existing = {
+				id: 'col-1',
+				name: 'Old',
+				description: 'old desc',
+				workflowId: 'wf-1',
+			} as EvaluationCollection;
+			entityManager.findOne.mockResolvedValueOnce(existing);
+			(entityManager.create as jest.Mock).mockImplementation(
+				(_target: unknown, entityLike: unknown) => entityLike as EvaluationCollection,
+			);
+			entityManager.save.mockImplementationOnce(async (_target, entity) => entity);
+
+			await repo.updateMeta('col-1', 'wf-1', { name: 'New', description: null });
+
+			const savedEntity = entityManager.save.mock.calls[0]?.[1];
+			expect(savedEntity).toMatchObject({
+				id: 'col-1',
+				name: 'New',
+				description: null,
+			});
+		});
+	});
+});

--- a/packages/@n8n/db/src/repositories/evaluation-collection.repository.ts
+++ b/packages/@n8n/db/src/repositories/evaluation-collection.repository.ts
@@ -1,0 +1,155 @@
+import { Service } from '@n8n/di';
+import { DataSource, In, Repository } from '@n8n/typeorm';
+import type { IDataObject } from 'n8n-workflow';
+
+import { EvaluationCollection } from '../entities/evaluation-collection.ee';
+import { TestRun } from '../entities/test-run.ee';
+
+export type EvaluationCollectionListItem = {
+	id: EvaluationCollection['id'];
+	name: EvaluationCollection['name'];
+	description: EvaluationCollection['description'];
+	workflowId: EvaluationCollection['workflowId'];
+	evaluationConfigId: EvaluationCollection['evaluationConfigId'];
+	createdById: EvaluationCollection['createdById'];
+	insightsCache: EvaluationCollection['insightsCache'];
+	createdAt: EvaluationCollection['createdAt'];
+	updatedAt: EvaluationCollection['updatedAt'];
+	runCount: number;
+};
+
+@Service()
+export class EvaluationCollectionRepository extends Repository<EvaluationCollection> {
+	constructor(dataSource: DataSource) {
+		super(EvaluationCollection, dataSource.manager);
+	}
+
+	async createCollection(input: {
+		id: string;
+		name: string;
+		description: string | null;
+		workflowId: string;
+		evaluationConfigId: string;
+		createdById: string | null;
+	}): Promise<EvaluationCollection> {
+		const entity = this.create({
+			id: input.id,
+			name: input.name,
+			description: input.description,
+			workflowId: input.workflowId,
+			evaluationConfigId: input.evaluationConfigId,
+			createdById: input.createdById,
+			insightsCache: null,
+		});
+		return await this.save(entity);
+	}
+
+	async findByIdAndWorkflowId(
+		id: string,
+		workflowId: string,
+	): Promise<EvaluationCollection | null> {
+		return await this.findOne({ where: { id, workflowId } });
+	}
+
+	/**
+	 * Returns collections for a workflow with `runCount` populated. The list
+	 * page uses this — it does not need the full run rows, just the count and
+	 * the collection's own fields.
+	 */
+	async listByWorkflowId(workflowId: string): Promise<EvaluationCollectionListItem[]> {
+		const collections = await this.find({
+			where: { workflowId },
+			order: { createdAt: 'DESC' },
+		});
+
+		if (collections.length === 0) return [];
+
+		const runCounts = await this.manager
+			.createQueryBuilder(TestRun, 'tr')
+			.select('tr.collectionId', 'collectionId')
+			.addSelect('COUNT(tr.id)', 'count')
+			.where('tr.collectionId IN (:...ids)', { ids: collections.map((c) => c.id) })
+			.groupBy('tr.collectionId')
+			.getRawMany<{ collectionId: string; count: string }>();
+
+		const countByCollectionId = new Map(
+			runCounts.map(({ collectionId, count }) => [collectionId, Number(count)]),
+		);
+
+		return collections.map((collection) => ({
+			...collection,
+			runCount: countByCollectionId.get(collection.id) ?? 0,
+		}));
+	}
+
+	/**
+	 * Returns the collection plus its runs ordered by createdAt ascending so
+	 * the compare view can render versions left-to-right by run order.
+	 */
+	async getDetailByIdAndWorkflowId(
+		id: string,
+		workflowId: string,
+	): Promise<{ collection: EvaluationCollection; runs: TestRun[] } | null> {
+		const collection = await this.findOne({ where: { id, workflowId } });
+		if (!collection) return null;
+
+		const runs = await this.manager.find(TestRun, {
+			where: { collectionId: id },
+			order: { createdAt: 'ASC' },
+		});
+
+		return { collection, runs };
+	}
+
+	async addRunsToCollection(collectionId: string, testRunIds: string[]): Promise<void> {
+		if (testRunIds.length === 0) return;
+		await this.manager.update(TestRun, { id: In(testRunIds) }, { collectionId });
+	}
+
+	async removeRunFromCollection(collectionId: string, testRunId: string): Promise<number> {
+		const result = await this.manager.update(
+			TestRun,
+			{ id: testRunId, collectionId },
+			{ collectionId: null },
+		);
+		return result.affected ?? 0;
+	}
+
+	/**
+	 * Returns how many runs were unlinked (set to `collectionId = null`) by
+	 * the delete. Callers feed this into the `runs_unlinked` telemetry field.
+	 *
+	 * The FK on `test_run.collectionId` is `SET NULL`, so we'd technically
+	 * get the unlink for free — but counting runs first lets the caller
+	 * surface the number in the response and telemetry without an extra
+	 * round-trip.
+	 */
+	async deleteByIdAndWorkflowId(
+		id: string,
+		workflowId: string,
+	): Promise<{ deleted: boolean; runsUnlinked: number }> {
+		const collection = await this.findOne({ where: { id, workflowId } });
+		if (!collection) return { deleted: false, runsUnlinked: 0 };
+
+		const runsUnlinked = await this.manager.count(TestRun, { where: { collectionId: id } });
+
+		await this.delete({ id });
+
+		return { deleted: true, runsUnlinked };
+	}
+
+	async updateInsightsCache(id: string, insights: IDataObject | null): Promise<void> {
+		await this.update(id, { insightsCache: insights });
+	}
+
+	async updateMeta(
+		id: string,
+		workflowId: string,
+		payload: { name?: string; description?: string | null },
+	): Promise<EvaluationCollection | null> {
+		const existing = await this.findByIdAndWorkflowId(id, workflowId);
+		if (!existing) return null;
+		Object.assign(existing, payload);
+		return await this.save(existing);
+	}
+}

--- a/packages/@n8n/db/src/repositories/evaluation-collection.repository.ts
+++ b/packages/@n8n/db/src/repositories/evaluation-collection.repository.ts
@@ -149,7 +149,8 @@ export class EvaluationCollectionRepository extends Repository<EvaluationCollect
 	): Promise<EvaluationCollection | null> {
 		const existing = await this.findByIdAndWorkflowId(id, workflowId);
 		if (!existing) return null;
-		Object.assign(existing, payload);
+		if (payload.name !== undefined) existing.name = payload.name;
+		if (payload.description !== undefined) existing.description = payload.description;
 		return await this.save(existing);
 	}
 }

--- a/packages/@n8n/db/src/repositories/index.ts
+++ b/packages/@n8n/db/src/repositories/index.ts
@@ -13,6 +13,10 @@ export {
 	type DeploymentKeySortDirection,
 	type ListDeploymentKeysOptions,
 } from './deployment-key.repository';
+export {
+	EvaluationCollectionRepository,
+	type EvaluationCollectionListItem,
+} from './evaluation-collection.repository';
 export { EvaluationConfigRepository } from './evaluation-config.repository';
 export { ExecutionAnnotationRepository } from './execution-annotation.repository';
 export { ExecutionDataRepository } from './execution-data.repository';

--- a/packages/@n8n/db/src/repositories/test-run.repository.ee.ts
+++ b/packages/@n8n/db/src/repositories/test-run.repository.ee.ts
@@ -22,12 +22,24 @@ export class TestRunRepository extends Repository<TestRun> {
 		super(TestRun, dataSource.manager);
 	}
 
-	async createTestRun(workflowId: string): Promise<TestRun> {
+	async createTestRun(
+		workflowId: string,
+		attrs?: {
+			collectionId?: string | null;
+			workflowVersionId?: string | null;
+			evaluationConfigId?: string | null;
+			evaluationConfigSnapshot?: IDataObject | null;
+		},
+	): Promise<TestRun> {
 		const testRun = this.create({
 			status: 'new',
 			workflow: {
 				id: workflowId,
 			},
+			collectionId: attrs?.collectionId ?? null,
+			workflowVersionId: attrs?.workflowVersionId ?? null,
+			evaluationConfigId: attrs?.evaluationConfigId ?? null,
+			evaluationConfigSnapshot: attrs?.evaluationConfigSnapshot ?? null,
 		});
 
 		return await this.save(testRun);


### PR DESCRIPTION
## Summary

**PR 1a of 2** for the eval-collections backend foundation. This PR lands the data layer only — entity, migration, repository, shared DTOs, and the PostHog flag constant. PR 1b ([#30218](https://github.com/n8n-io/n8n/pull/30218)) stacks on top with the service, REST controller, runner integration, and multi-main collection cancellation.

PR 1b → PR 2 ([TRUST-80](https://linear.app/n8n/issue/TRUST-80) — AI insights + frontend list/setup) → PR 3 ([TRUST-81](https://linear.app/n8n/issue/TRUST-81) — compare view + telemetry rollout).

The whole feature is gated 404 behind the `eval_collections` PostHog rollout flag (introduced in this PR as a shared constant); the existing single-run flow is byte-identical when off.

### What lands

- **`EvaluationCollection` entity** (`packages/@n8n/db/src/entities/evaluation-collection.ee.ts`) — `name`, `description`, `workflowId`, `evaluationConfigId`, `createdById`, plus `insightsCache` (JSON, bundled here so PR 2's AI insights work doesn't need its own migration).
- **Cross-DB migration `1778496086558-CreateEvaluationCollection`** — creates the `evaluation_collection` table and adds `test_run.collectionId` with a `SET NULL` foreign key. Timestamp is the literal `Date.now()` per `packages/@n8n/db/AGENTS.md`. Runs between `1778100002000` (eval-config columns) and the agent-table migrations on fresh installs; no FK dependencies on agent_* tables.
- **`TestRun` entity sync** — adds `workflowVersionId`, `evaluationConfigId`, `evaluationConfigSnapshot`, and the new `collectionId` column. The first three columns exist in migrations on master that the entity hadn't picked up yet.
- **`EvaluationCollectionRepository`** — CRUD plus `addRunsToCollection` (bulk update), `removeRunFromCollection`, `listByWorkflowId` with `runCount` aggregation in a single query, `getDetailByIdAndWorkflowId` (collection + its runs ordered by `createdAt`), `updateInsightsCache`, and `updateMeta` for rename/redescribe. 14 repo unit tests pin the contract for every public method.
- **`TestRunRepository.createTestRun`** — accepts an optional `attrs` arg so PR 1b's service can persist `collectionId`, `workflowVersionId`, `evaluationConfigId`, and `evaluationConfigSnapshot` at run creation time.
- **Shared DTOs and response types in `@n8n/api-types`** — `CreateEvaluationCollectionDto`, `UpdateEvaluationCollectionDto`, `AddRunToCollectionDto`, plus response shapes (`EvaluationCollectionRecord`, `EvaluationCollectionDetail`, `EvalVersionsResponse`) and the `EVAL_COLLECTIONS_FLAG = 'eval_collections'` constant.

### Design note: FK columns without `@ManyToOne` decorators

The new FK columns (`evaluationConfigId`, `collectionId` on `TestRun`; `workflowId`, `evaluationConfigId` on `EvaluationCollection`) are declared as plain `@Column` fields *without* corresponding `@ManyToOne` decorators or typed relation fields.

**Why:** declaring them as relations would extend TypeORM's entity-relation type graph enough to trip TS2589 ("type instantiation excessively deep") on unrelated repository calls that transitively reach `TestRun` through `WorkflowEntity.testRuns` — specifically `FolderRepository.upsert()` in `source-control-import.service.ee.ts:1090`. The structural fix is to not add the relations on the entity layer in the first place. Service code resolves the related entities through their own repositories (`EvaluationConfigRepository.findByIdAndWorkflowId`, etc.) — which is consistent with how the eval subsystem already does it.

**What this preserves:** the existing `WorkflowEntity.testRuns` back-reference is untouched, so `workflow.testRuns` ergonomics stay intact for the rest of the codebase. No master refactor needed.

**Trade-off:** `repo.find({ relations: ['evaluationConfig'] })` on `TestRun` won't work without re-adding the decorator. If a future PR needs auto-loaded relations, it can add the decorator at that point and address the type depth then (e.g. by deferring with `Promise<T>` lazy fields, or by another structural fix).

**What's preserved unconditionally:** the FK constraints themselves live in the migration's raw SQL, independent of TypeORM-side metadata. Database integrity is not affected.

### Size

454 non-test lines + 205 test lines = 659 total against master.

### How to test

Backend-only data layer — no REST surface yet (that arrives in PR 1b). Smoke:

```bash
# Migration applies cleanly on both DBs
DB_TYPE=sqlite pnpm --filter=@n8n/db run typeorm migration:show
DB_TYPE=postgresdb pnpm --filter=@n8n/db run typeorm migration:show
# Repository contract pinned by unit tests
cd packages/@n8n/db && pnpm test src/repositories/__tests__/evaluation-collection.repository.test.ts
```

### Notes for reviewers

- **PR 1b stacks on this branch** ([#30218](https://github.com/n8n-io/n8n/pull/30218) targets `trust-72-data-layer`). Once this lands, GitHub will auto-retarget PR 1b to master.
- **Flag id is `eval_collections` verbatim** (matches spec §12), not the `080_` numeric prefix convention of the existing `eval_parallel_execution` flag. Whoever provisions the PostHog rollout must use that literal id.
- **`insightsCache` column** is added in this migration even though it's only consumed by PR 2's insights agent. Per spec §13 PR 2 note ("add to PR 1's migration if it's still open"), avoiding a tiny extra migration later.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/TRUST-72
- Stacks: PR 1b → [#30218](https://github.com/n8n-io/n8n/pull/30218) (service + REST + runner integration)
- Blocks: [TRUST-80](https://linear.app/n8n/issue/TRUST-80) (PR 2 — insights + FE list/setup), [TRUST-81](https://linear.app/n8n/issue/TRUST-81) (PR 3 — compare view + rollout)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
