### PR TITLE
fix(core): Add origin-only fallback to MCP OAuth discovery for path-bearing server URLs

### DIFF
--- a/packages/cli/src/oauth/__tests__/oauth.service.test.ts
+++ b/packages/cli/src/oauth/__tests__/oauth.service.test.ts
@@ -2057,6 +2057,80 @@ describe('OauthService', () => {
 			);
 		});
 
+		it('should fall back to origin-only discovery when path-aware variants fail (Atlassian MCP)', async () => {
+			const axios = require('axios');
+			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
+			const mockGetUri = jest.fn().mockReturnValue({
+				toString: () => 'https://mcp.atlassian.com/authorize?client_id=test_id',
+			});
+			jest.mocked(ClientOAuth2).mockImplementation(
+				() =>
+					({
+						code: { getUri: mockGetUri },
+					}) as any,
+			);
+
+			const credential = mock<CredentialsEntity>({ id: '1', type: 'mcpOAuth2Api' });
+			const oauthCredentials = {
+				serverUrl: 'https://mcp.atlassian.com/v1/mcp',
+				useDynamicClientRegistration: true,
+			} as OAuth2CredentialData;
+
+			jest.spyOn(service, 'getOAuthCredentials').mockResolvedValue(oauthCredentials);
+
+			jest
+				.mocked(axios.get)
+				.mockRejectedValueOnce(new Error('404')) // protected resource path-specific
+				.mockRejectedValueOnce(new Error('404')) // protected resource root
+				.mockRejectedValueOnce(new Error('404')) // RFC 8414 path insertion
+				.mockRejectedValueOnce(new Error('404')) // OpenID Connect path insertion
+				.mockRejectedValueOnce(new Error('401')) // OpenID Connect path appending
+				.mockResolvedValueOnce({
+					data: {
+						authorization_endpoint: 'https://mcp.atlassian.com/authorize',
+						token_endpoint: 'https://mcp.atlassian.com/token',
+						registration_endpoint: 'https://mcp.atlassian.com/register',
+						grant_types_supported: ['authorization_code', 'refresh_token'],
+						token_endpoint_auth_methods_supported: ['client_secret_basic'],
+						code_challenge_methods_supported: ['S256'],
+					},
+				} as any); // origin-only fallback succeeds
+
+			jest.mocked(axios.post).mockResolvedValue({
+				data: { client_id: 'test_id', client_secret: 'test_secret' },
+			} as any);
+
+			jest.spyOn(service, 'encryptAndSaveData').mockResolvedValue(undefined);
+
+			await service.generateAOauth2AuthUri(credential, {
+				cid: credential.id,
+				origin: 'static-credential',
+				userId: 'user-id',
+			});
+
+			expect(axios.get).toHaveBeenCalledTimes(6);
+			expect(axios.get).toHaveBeenNthCalledWith(
+				3,
+				'https://mcp.atlassian.com/.well-known/oauth-authorization-server/v1/mcp',
+				expect.any(Object),
+			);
+			expect(axios.get).toHaveBeenNthCalledWith(
+				4,
+				'https://mcp.atlassian.com/.well-known/openid-configuration/v1/mcp',
+				expect.any(Object),
+			);
+			expect(axios.get).toHaveBeenNthCalledWith(
+				5,
+				'https://mcp.atlassian.com/v1/mcp/.well-known/openid-configuration',
+				expect.any(Object),
+			);
+			expect(axios.get).toHaveBeenNthCalledWith(
+				6,
+				'https://mcp.atlassian.com/.well-known/oauth-authorization-server',
+				expect.any(Object),
+			);
+		});
+
 		it('should throw error when all discovery endpoints fail', async () => {
 			const axios = require('axios');
 			const credential = mock<CredentialsEntity>({ id: '1', type: 'oAuth2Api' });
@@ -2086,8 +2160,8 @@ describe('OauthService', () => {
 				}),
 			).rejects.toThrow('Failed to discover OAuth2 authorization server metadata');
 
-			// Should have tried all endpoints (2 protected resource + 3 auth server per invocation)
-			expect(axios.get).toHaveBeenCalledTimes(10); // 5 calls per invocation × 2 invocations
+			// Should have tried all endpoints (2 protected resource + 4 auth server per invocation)
+			expect(axios.get).toHaveBeenCalledTimes(12); // 6 calls per invocation × 2 invocations
 		});
 
 		it('should discover authorization server via protected resource metadata (MCP flow)', async () => {

--- a/packages/cli/src/oauth/oauth.service.ts
+++ b/packages/cli/src/oauth/oauth.service.ts
@@ -451,6 +451,8 @@ export class OauthService {
 							`${issuerUrl.origin}/.well-known/openid-configuration${pathComponent}`,
 							// 3. OpenID Connect Discovery 1.0 (path appending)
 							`${authorizationServerUrl}/.well-known/openid-configuration`,
+							// 4. RFC 8414 origin-only fallback (matches MCP TypeScript SDK behavior)
+							`${issuerUrl.origin}/.well-known/oauth-authorization-server`,
 						]
 					: [
 							// For root-level issuers or already-well-known paths


### PR DESCRIPTION
## Summary

When the MCP OAuth credential's `serverUrl` has a path (e.g. `https://mcp.atlassian.com/v1/mcp`), the DCR discovery flow tried three path-aware well-known URL variants but never attempted the origin-only `/.well-known/oauth-authorization-server`. Servers like Atlassian MCP that only publish OAuth metadata at the origin could not be connected.

This adds `${origin}/.well-known/oauth-authorization-server` as a 4th fallback in the path-bearing discovery list, matching the MCP TypeScript SDK's discovery order and restoring compatibility with n8n 2.6.3 behavior.

### Regression history

- **n8n 2.6.3** -- Discovery only tried `${origin}/.well-known/oauth-authorization-server`. Worked for Atlassian MCP.
- **n8n 2.10.0** (#25174) -- Switched to `${serverUrl}/.well-known/...` to fix path-based servers like VEED.io. This inadvertently dropped the origin-only URL, breaking servers that publish metadata only at the origin.
- **n8n 2.12.0** (#26290, NODE-4390) -- Introduced RFC 9727 + 8414 compliant three-URL discovery sequence. Carried forward the same gap -- no origin-only fallback in the path-bearing branch.
- **n8n 2.20.0** (#27283, NODE-4662) -- Added short-circuit for `/.well-known/` paths to prevent double well-known URLs, but still no origin-only fallback.

### Fix

Appends `${origin}/.well-known/oauth-authorization-server` as a final fallback in the path-bearing discovery list. The three existing path-aware URLs still run first, so VEED.io, Smithery, Notion, and other path-based servers continue to work exactly as before.

**How to test:**
1. Create an MCP OAuth2 API credential with DCR enabled
2. Set Server URL to `https://mcp.atlassian.com/v1/mcp`
3. Click Connect -- discovery should now succeed by falling back to the origin-only URL

**Workaround (still valid):** Set Server URL to origin only (`https://mcp.atlassian.com`), set the actual MCP path on the node's Endpoint field.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5013

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI