### PR TITLE
test: Add discovery eval guardrails for browser/computer-use dispatch (no-changelog)

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -92,6 +92,7 @@ jobs:
               packages/cli/src/modules/instance-ai/**
               packages/core/src/execution-engine/eval-mock-helpers.ts
               .github/workflows/test-evals-instance-ai*.yml
+              .github/workflows/test-evals-discovery.yml
             db:
               packages/cli/src/databases/**
               packages/cli/src/modules/*/database/**
@@ -305,6 +306,23 @@ jobs:
       github.repository == 'n8n-io/n8n' &&
       (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
     uses: ./.github/workflows/test-evals-instance-ai.yml
+    with:
+      branch: ${{ needs.install-and-build.outputs.commit_sha }}
+    secrets: inherit
+
+  # In-process discovery eval — asserts the orchestrator reaches for browser/computer-use
+  # tools at OAuth/screenshot moments. Lightweight (no Docker), runs in parallel with the
+  # heavy workflow eval. Non-blocking initially; promote to required after stability.
+  instance-ai-discovery-evals:
+    name: Instance AI Discovery Evals
+    needs: install-and-build
+    if: >-
+      !cancelled() &&
+      needs.install-and-build.result == 'success' &&
+      needs.install-and-build.outputs.instance_ai_workflow_eval == 'true' &&
+      github.repository == 'n8n-io/n8n' &&
+      (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
+    uses: ./.github/workflows/test-evals-discovery.yml
     with:
       branch: ${{ needs.install-and-build.outputs.commit_sha }}
     secrets: inherit

--- a/.github/workflows/test-evals-discovery.yml
+++ b/.github/workflows/test-evals-discovery.yml
@@ -1,0 +1,123 @@
+name: 'Test: Instance AI Discovery Evals'
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: 'GitHub branch to test'
+        required: false
+        type: string
+        default: 'master'
+      filter:
+        description: 'Filter scenarios by id (e.g. "slack-oauth")'
+        required: false
+        type: string
+        default: ''
+      trials:
+        description: 'Trials per scenario'
+        required: false
+        type: number
+        default: 3
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'GitHub branch to test'
+        required: false
+        default: 'master'
+      filter:
+        description: 'Filter scenarios by id (e.g. "slack-oauth")'
+        required: false
+        default: ''
+      trials:
+        description: 'Trials per scenario'
+        required: false
+        default: '3'
+
+jobs:
+  run-discovery-evals:
+    name: 'Run Discovery Evals'
+    runs-on: blacksmith-2vcpu-ubuntu-2204
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.branch || github.ref }}
+          fetch-depth: 1
+
+      - name: Setup Environment
+        uses: ./.github/actions/setup-nodejs
+        with:
+          build-command: 'pnpm build'
+
+      - name: Export Node Types
+        run: |
+          ./packages/cli/bin/n8n export:nodes --output ./packages/@n8n/ai-workflow-builder.ee/evaluations/nodes.json
+
+      - name: Run Discovery Evals
+        id: eval
+        working-directory: packages/@n8n/instance-ai
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.EVALS_ANTHROPIC_KEY }}
+          LANGSMITH_TRACING: 'true'
+          LANGSMITH_ENDPOINT: ${{ secrets.EVALS_LANGSMITH_ENDPOINT }}
+          LANGSMITH_API_KEY: ${{ secrets.EVALS_LANGSMITH_API_KEY }}
+          LANGSMITH_REVISION_ID: ${{ github.sha }}
+          LANGSMITH_BRANCH: ${{ github.head_ref || github.ref_name }}
+          FILTER: ${{ inputs.filter }}
+          TRIALS: ${{ inputs.trials || 3 }}
+        run: |
+          set -o pipefail
+          if [ -n "$FILTER" ]; then
+            pnpm eval:discovery --filter "$FILTER" --trials "$TRIALS" 2>&1 | tee discovery-eval-output.txt
+          else
+            pnpm eval:discovery --trials "$TRIALS" 2>&1 | tee discovery-eval-output.txt
+          fi
+
+      - name: Post eval results to PR
+        if: ${{ always() && github.event_name == 'pull_request' && hashFiles('packages/@n8n/instance-ai/discovery-eval-output.txt') != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVAL_OUTCOME: ${{ steps.eval.outcome }}
+          HEAD_REF: ${{ github.head_ref || github.ref_name }}
+          COMMIT_SHA: ${{ github.sha }}
+        run: |
+          if [ "$EVAL_OUTCOME" = "success" ]; then
+            STATUS_ICON="✅"
+          else
+            STATUS_ICON="❌"
+          fi
+          {
+            echo "### Instance AI Discovery Eval ${STATUS_ICON}"
+            echo ""
+            echo "Branch: \`${HEAD_REF}\` · Commit: \`${COMMIT_SHA}\`"
+            echo ""
+            echo "<details><summary>Eval output</summary>"
+            echo ""
+            echo '```'
+            cat packages/@n8n/instance-ai/discovery-eval-output.txt
+            echo '```'
+            echo ""
+            echo "</details>"
+          } > /tmp/discovery-comment.md
+
+          COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --jq '.[] | select(.body | startswith("### Instance AI Discovery Eval")) | .id' | tail -1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${COMMENT_ID}" -X PATCH -F body=@/tmp/discovery-comment.md
+          else
+            gh pr comment "${{ github.event.pull_request.number }}" --body-file /tmp/discovery-comment.md
+          fi
+
+      - name: Upload Results
+        if: ${{ always() }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: instance-ai-discovery-eval-results
+          path: packages/@n8n/instance-ai/discovery-eval-output.txt
+          retention-days: 14

--- a/packages/@n8n/instance-ai/evaluations/__tests__/data-discovery.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/data-discovery.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Smoke + shape tests for the discovery scenario loader.
+ *
+ * Loads every JSON in evaluations/data/discovery/ off disk, parses it, and
+ * asserts the shape required by `runExpectedToolsInvokedCheck`. Catches
+ * malformed scenario files at unit-test time before they reach the eval
+ * runner.
+ */
+
+import { loadDiscoveryTestCasesWithFiles } from '../data/discovery';
+import { runExpectedToolsInvokedCheck } from '../discovery/expected-tools-invoked';
+
+describe('loadDiscoveryTestCasesWithFiles', () => {
+	const cases = loadDiscoveryTestCasesWithFiles();
+
+	it('finds at least the v1 scenario set', () => {
+		const slugs = cases.map((c) => c.fileSlug).sort();
+
+		expect(slugs).toEqual(
+			expect.arrayContaining([
+				'slack-oauth-credential-setup',
+				'google-oauth-credential-setup',
+				'screenshot-dashboard',
+				'http-node-config-no-browser',
+				'oauth-with-computer-use-disabled',
+			]),
+		);
+	});
+
+	it.each([
+		'slack-oauth-credential-setup',
+		'google-oauth-credential-setup',
+		'screenshot-dashboard',
+		'http-node-config-no-browser',
+		'oauth-with-computer-use-disabled',
+	])('%s parses with a valid expectedToolInvocations rule', (slug) => {
+		const entry = cases.find((c) => c.fileSlug === slug);
+		expect(entry).toBeDefined();
+
+		const { testCase } = entry!;
+
+		expect(testCase.id).toBe(slug);
+		expect(testCase.userMessage.length).toBeGreaterThan(0);
+
+		// Calling the check with an empty outcome must not throw on rule validation;
+		// it should simply report pass/fail. This pins the JSON shape.
+		expect(() =>
+			runExpectedToolsInvokedCheck(testCase, {
+				workflowIds: [],
+				executionIds: [],
+				dataTableIds: [],
+				finalText: '',
+				toolCalls: [],
+				agentActivities: [],
+			}),
+		).not.toThrow();
+	});
+
+	it('keeps positive and negative scenarios in the set (so we test both directions)', () => {
+		const positive = cases.filter((c) => Boolean(c.testCase.expectedToolInvocations.anyOf?.length));
+		const negative = cases.filter((c) =>
+			Boolean(c.testCase.expectedToolInvocations.noneOf?.length),
+		);
+
+		expect(positive.length).toBeGreaterThan(0);
+		expect(negative.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/data/discovery/google-oauth-credential-setup.json
+++ b/packages/@n8n/instance-ai/evaluations/data/discovery/google-oauth-credential-setup.json
@@ -1,0 +1,21 @@
+{
+	"id": "google-oauth-credential-setup",
+	"userMessage": "I need to set up a Google OAuth credential so I can read my calendar. Walk me through the Google Cloud Console so I can find my Client ID and Client Secret to enter into n8n.",
+	"instanceState": {
+		"localGateway": { "status": "connected", "capabilities": ["browser"] },
+		"browserAvailable": true
+	},
+	"expectedToolInvocations": {
+		"anyOf": [
+			"browser-credential-setup",
+			"spawn_sub_agent:browser-credential-setup",
+			"browser_navigate",
+			"browser_snapshot",
+			"browser_screenshot",
+			"navigate_page",
+			"take_snapshot",
+			"take_screenshot"
+		]
+	},
+	"rationale": "Google OAuth involves multiple console screens; the orchestrator must reach for browser tooling rather than asking the user to copy values into chat. The check accepts either the `browser-credential-setup` helper or direct browser tool calls — both prove the discovery framing held."
+}

--- a/packages/@n8n/instance-ai/evaluations/data/discovery/http-node-config-no-browser.json
+++ b/packages/@n8n/instance-ai/evaluations/data/discovery/http-node-config-no-browser.json
@@ -1,0 +1,21 @@
+{
+	"id": "http-node-config-no-browser",
+	"userMessage": "How do I set the request timeout on my HTTP Request node?",
+	"instanceState": {
+		"localGateway": { "status": "connected", "capabilities": ["browser"] },
+		"browserAvailable": true
+	},
+	"expectedToolInvocations": {
+		"noneOf": [
+			"browser-credential-setup",
+			"spawn_sub_agent:browser-credential-setup",
+			"browser_navigate",
+			"browser_snapshot",
+			"browser_screenshot",
+			"navigate_page",
+			"take_snapshot",
+			"take_screenshot"
+		]
+	},
+	"rationale": "Negative control. A pure node-config question must NOT trigger any browser tooling — neither the helper nor direct browser tool calls. Guards against an over-eager regression that would bias every credential-adjacent question into browser mode."
+}

--- a/packages/@n8n/instance-ai/evaluations/data/discovery/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/data/discovery/index.ts
@@ -1,0 +1,62 @@
+import { readFileSync, readdirSync } from 'fs';
+import { basename, join } from 'path';
+
+import type { DiscoveryTestCase } from '../../discovery/types';
+
+export interface DiscoveryTestCaseWithFile {
+	testCase: DiscoveryTestCase;
+	/** Filename without extension, e.g. "slack-oauth-credential-setup" */
+	fileSlug: string;
+}
+
+function parseTestCaseFile(filePath: string): DiscoveryTestCase {
+	const content = readFileSync(filePath, 'utf-8');
+	try {
+		return JSON.parse(content) as DiscoveryTestCase;
+	} catch (error) {
+		throw new Error(
+			`Failed to parse discovery test case ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+}
+
+function parseSubstringList(value: string | undefined): string[] {
+	if (!value) return [];
+	return value
+		.split(',')
+		.map((s) => s.trim().toLowerCase())
+		.filter((s) => s.length > 0);
+}
+
+function getJsonFiles(filter?: string, exclude?: string): string[] {
+	const dir = __dirname;
+	let files = readdirSync(dir).filter((f) => f.endsWith('.json'));
+
+	const includeTokens = parseSubstringList(filter);
+	if (includeTokens.length > 0) {
+		files = files.filter((f) => {
+			const lower = f.toLowerCase();
+			return includeTokens.some((t) => lower.includes(t));
+		});
+	}
+
+	const excludeTokens = parseSubstringList(exclude);
+	if (excludeTokens.length > 0) {
+		files = files.filter((f) => {
+			const lower = f.toLowerCase();
+			return !excludeTokens.some((t) => lower.includes(t));
+		});
+	}
+
+	return files.map((f) => join(dir, f));
+}
+
+export function loadDiscoveryTestCasesWithFiles(
+	filter?: string,
+	exclude?: string,
+): DiscoveryTestCaseWithFile[] {
+	return getJsonFiles(filter, exclude).map((f) => ({
+		testCase: parseTestCaseFile(f),
+		fileSlug: basename(f, '.json'),
+	}));
+}

--- a/packages/@n8n/instance-ai/evaluations/data/discovery/oauth-with-computer-use-disabled.json
+++ b/packages/@n8n/instance-ai/evaluations/data/discovery/oauth-with-computer-use-disabled.json
@@ -1,0 +1,20 @@
+{
+	"id": "oauth-with-computer-use-disabled",
+	"userMessage": "I need to set up a Slack OAuth credential. Walk me through the Slack admin so I can find my Client ID and Client Secret to enter into n8n.",
+	"instanceState": {
+		"localGateway": { "status": "disabledGlobally" }
+	},
+	"expectedToolInvocations": {
+		"noneOf": [
+			"browser-credential-setup",
+			"spawn_sub_agent:browser-credential-setup",
+			"browser_navigate",
+			"browser_snapshot",
+			"browser_screenshot",
+			"navigate_page",
+			"take_snapshot",
+			"take_screenshot"
+		]
+	},
+	"rationale": "When Computer Use is disabled globally the orchestrator must not pretend any browser tool exists. It should explain the standard credential setup path instead. Pairs with the OAuth-positive scenarios to prove discovery is gated on gateway state, not blindly triggered by the user message."
+}

--- a/packages/@n8n/instance-ai/evaluations/data/discovery/screenshot-dashboard.json
+++ b/packages/@n8n/instance-ai/evaluations/data/discovery/screenshot-dashboard.json
@@ -1,0 +1,20 @@
+{
+	"id": "screenshot-dashboard",
+	"userMessage": "Take a screenshot of the Stripe dashboard I have open in my browser so I can attach it to this workflow.",
+	"instanceState": {
+		"localGateway": { "status": "connected", "capabilities": ["browser"] },
+		"browserAvailable": true
+	},
+	"expectedToolInvocations": {
+		"anyOf": [
+			"browser_screenshot",
+			"browser_snapshot",
+			"browser_navigate",
+			"take_screenshot",
+			"take_snapshot",
+			"navigate_page",
+			"spawn_sub_agent:browser-credential-setup"
+		]
+	},
+	"rationale": "Direct browser-tool discovery — the user names a browser action verbatim. The orchestrator must reach for any browser tool (snapshot/screenshot/navigate are all valid first moves to inspect the page) rather than falling back to research."
+}

--- a/packages/@n8n/instance-ai/evaluations/data/discovery/slack-oauth-credential-setup.json
+++ b/packages/@n8n/instance-ai/evaluations/data/discovery/slack-oauth-credential-setup.json
@@ -1,0 +1,21 @@
+{
+	"id": "slack-oauth-credential-setup",
+	"userMessage": "I need to set up a Slack OAuth credential. Walk me through the Slack admin so I can find my Client ID and Client Secret to enter into n8n.",
+	"instanceState": {
+		"localGateway": { "status": "connected", "capabilities": ["browser"] },
+		"browserAvailable": true
+	},
+	"expectedToolInvocations": {
+		"anyOf": [
+			"browser-credential-setup",
+			"spawn_sub_agent:browser-credential-setup",
+			"browser_navigate",
+			"browser_snapshot",
+			"browser_screenshot",
+			"navigate_page",
+			"take_snapshot",
+			"take_screenshot"
+		]
+	},
+	"rationale": "OAuth credential setup is the canonical browser-discovery moment. The orchestrator must reach for browser tooling — either via the `browser-credential-setup` orchestration helper, or by calling browser tools directly when the helper is unavailable. Either path proves the discovery framing is intact; falling through to research/ask-user without browser involvement is the regression."
+}

--- a/packages/@n8n/instance-ai/evaluations/discovery/__tests__/expected-tools-invoked.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/__tests__/expected-tools-invoked.test.ts
@@ -1,0 +1,197 @@
+import type { AgentActivity, CapturedToolCall, EventOutcome } from '../../types';
+import { runExpectedToolsInvokedCheck } from '../expected-tools-invoked';
+import type { DiscoveryTestCase } from '../types';
+
+function makeOutcome(opts: {
+	toolCalls?: Array<Pick<CapturedToolCall, 'toolName'>>;
+	agents?: Array<Pick<AgentActivity, 'role' | 'tools'>>;
+}): EventOutcome {
+	return {
+		workflowIds: [],
+		executionIds: [],
+		dataTableIds: [],
+		finalText: '',
+		toolCalls: (opts.toolCalls ?? []).map((tc, i) => ({
+			toolCallId: `call-${i}`,
+			toolName: tc.toolName,
+			args: {},
+			durationMs: 0,
+		})),
+		agentActivities: (opts.agents ?? []).map((a, i) => ({
+			agentId: `agent-${i}`,
+			role: a.role,
+			tools: a.tools,
+			toolCalls: [],
+			textContent: '',
+			reasoning: '',
+			status: 'completed',
+		})),
+	};
+}
+
+const slackOauthScenario: DiscoveryTestCase = {
+	id: 'test',
+	userMessage: 'Help me set up Slack credentials',
+	expectedToolInvocations: {
+		anyOf: ['browser-credential-setup', 'spawn_sub_agent:browser-credential-setup'],
+	},
+};
+
+describe('runExpectedToolsInvokedCheck', () => {
+	describe('anyOf — positive cases', () => {
+		it('passes when the expected top-level tool was invoked', () => {
+			const result = runExpectedToolsInvokedCheck(
+				slackOauthScenario,
+				makeOutcome({ toolCalls: [{ toolName: 'browser-credential-setup' }] }),
+			);
+
+			expect(result.pass).toBe(true);
+			expect(result.invokedTools).toContain('browser-credential-setup');
+		});
+
+		it('passes when the expected sub-agent was spawned (matched via spawn_sub_agent: prefix)', () => {
+			const result = runExpectedToolsInvokedCheck(
+				slackOauthScenario,
+				makeOutcome({
+					agents: [{ role: 'browser-credential-setup', tools: ['browser_navigate'] }],
+				}),
+			);
+
+			expect(result.pass).toBe(true);
+			expect(result.spawnedAgents).toContain('spawn_sub_agent:browser-credential-setup');
+		});
+
+		it('passes when the spawned sub-agent had the expected tool attached (sub-agent tools list)', () => {
+			const result = runExpectedToolsInvokedCheck(
+				{
+					id: 'test',
+					userMessage: '',
+					expectedToolInvocations: { anyOf: ['browser_navigate'] },
+				},
+				makeOutcome({
+					agents: [{ role: 'browser-credential-setup', tools: ['browser_navigate'] }],
+				}),
+			);
+
+			expect(result.pass).toBe(true);
+			expect(result.invokedTools).toContain('browser_navigate');
+		});
+	});
+
+	describe('anyOf — negative cases', () => {
+		it('fails when none of the expected tools or sub-agents appear', () => {
+			const result = runExpectedToolsInvokedCheck(
+				slackOauthScenario,
+				makeOutcome({ toolCalls: [{ toolName: 'research' }] }),
+			);
+
+			expect(result.pass).toBe(false);
+			expect(result.comment).toContain('Expected at least one of');
+			expect(result.comment).toContain('browser-credential-setup');
+		});
+
+		it('fails when the orchestrator only ran research with no browser dispatch', () => {
+			const result = runExpectedToolsInvokedCheck(
+				slackOauthScenario,
+				makeOutcome({
+					toolCalls: [{ toolName: 'research' }, { toolName: 'ask-user' }],
+				}),
+			);
+
+			expect(result.pass).toBe(false);
+		});
+	});
+
+	describe('noneOf — negative scenarios (over-eager invocation guard)', () => {
+		const httpNodeConfigScenario: DiscoveryTestCase = {
+			id: 'test',
+			userMessage: 'How do I set the timeout on my HTTP node?',
+			expectedToolInvocations: {
+				noneOf: ['browser-credential-setup', 'spawn_sub_agent:browser-credential-setup'],
+			},
+		};
+
+		it('passes when the forbidden tool was not invoked', () => {
+			const result = runExpectedToolsInvokedCheck(
+				httpNodeConfigScenario,
+				makeOutcome({ toolCalls: [{ toolName: 'nodes' }] }),
+			);
+
+			expect(result.pass).toBe(true);
+		});
+
+		it('fails when the forbidden tool was invoked', () => {
+			const result = runExpectedToolsInvokedCheck(
+				httpNodeConfigScenario,
+				makeOutcome({ toolCalls: [{ toolName: 'browser-credential-setup' }] }),
+			);
+
+			expect(result.pass).toBe(false);
+			expect(result.comment).toContain('Expected none of');
+			expect(result.comment).toContain('browser-credential-setup');
+		});
+
+		it('fails when the forbidden sub-agent was spawned', () => {
+			const result = runExpectedToolsInvokedCheck(
+				httpNodeConfigScenario,
+				makeOutcome({
+					agents: [{ role: 'browser-credential-setup', tools: ['browser_navigate'] }],
+				}),
+			);
+
+			expect(result.pass).toBe(false);
+		});
+	});
+
+	describe('combined anyOf + noneOf', () => {
+		const combinedScenario: DiscoveryTestCase = {
+			id: 'test',
+			userMessage: '',
+			expectedToolInvocations: {
+				anyOf: ['browser-credential-setup'],
+				noneOf: ['delegate'],
+			},
+		};
+
+		it('passes when anyOf matches and noneOf is not violated', () => {
+			const result = runExpectedToolsInvokedCheck(
+				combinedScenario,
+				makeOutcome({ toolCalls: [{ toolName: 'browser-credential-setup' }] }),
+			);
+
+			expect(result.pass).toBe(true);
+		});
+
+		it('fails when noneOf is violated even if anyOf matched', () => {
+			const result = runExpectedToolsInvokedCheck(
+				combinedScenario,
+				makeOutcome({
+					toolCalls: [{ toolName: 'browser-credential-setup' }, { toolName: 'delegate' }],
+				}),
+			);
+
+			expect(result.pass).toBe(false);
+			expect(result.comment).toContain('Expected none of');
+		});
+	});
+
+	describe('rule validation', () => {
+		it('throws when neither anyOf nor noneOf is provided', () => {
+			expect(() =>
+				runExpectedToolsInvokedCheck(
+					{ id: 'x', userMessage: '', expectedToolInvocations: {} },
+					makeOutcome({}),
+				),
+			).toThrow(/anyOf.*noneOf/);
+		});
+
+		it('throws when both anyOf and noneOf are empty', () => {
+			expect(() =>
+				runExpectedToolsInvokedCheck(
+					{ id: 'x', userMessage: '', expectedToolInvocations: { anyOf: [], noneOf: [] } },
+					makeOutcome({}),
+				),
+			).toThrow();
+		});
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/discovery/cli.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/cli.ts
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+// ---------------------------------------------------------------------------
+// CLI for browser/computer-use discovery evaluation.
+//
+// Usage:
+//   pnpm eval:discovery                                # run all scenarios, 3 trials each
+//   pnpm eval:discovery --filter slack-oauth --verbose
+//   pnpm eval:discovery --trials 5
+//
+// Loads scenarios from evaluations/data/discovery/, runs each scenario × N
+// trials via the in-process runner, reports per-scenario pass-rates, exits
+// non-zero on any scenario below threshold.
+// ---------------------------------------------------------------------------
+
+import { runDiscoveryScenario, type DiscoveryRunResult } from './runner';
+import type { DiscoveryTestCase } from './types';
+import { loadDiscoveryTestCasesWithFiles } from '../data/discovery';
+
+// ---------------------------------------------------------------------------
+// Args
+// ---------------------------------------------------------------------------
+
+interface CliArgs {
+	filter?: string;
+	verbose: boolean;
+	trials: number;
+	passThreshold: number;
+	timeoutMs: number;
+	maxSteps: number;
+	modelId: string;
+	concurrency: number;
+	nodesJsonPath?: string;
+}
+
+const DEFAULT_MODEL = process.env.N8N_INSTANCE_AI_EVAL_MODEL ?? 'anthropic/claude-sonnet-4-6';
+
+function previewArgs(args: Record<string, unknown>): string {
+	const entries = Object.entries(args).slice(0, 3);
+	if (entries.length === 0) return '';
+	return entries
+		.map(([k, v]) => {
+			let preview: string;
+			if (typeof v === 'string') {
+				preview = v.length > 40 ? `"${v.slice(0, 40)}…"` : `"${v}"`;
+			} else if (typeof v === 'number' || typeof v === 'boolean' || v === null) {
+				preview = String(v);
+			} else if (Array.isArray(v)) {
+				preview = `[${String(v.length)}]`;
+			} else {
+				preview = '{…}';
+			}
+			return `${k}=${preview}`;
+		})
+		.join(', ');
+}
+
+function requirePositiveInt(raw: string | undefined, flag: string): number {
+	const n = Number(raw);
+	if (!Number.isFinite(n) || n < 1 || !Number.isInteger(n)) {
+		console.error(`Invalid value for ${flag}: ${String(raw)} (expected a positive integer)`);
+		process.exit(1);
+	}
+	return n;
+}
+
+function requireNumberInRange(
+	raw: string | undefined,
+	flag: string,
+	lo: number,
+	hi: number,
+): number {
+	const n = Number(raw);
+	if (!Number.isFinite(n) || n < lo || n > hi) {
+		console.error(`Invalid value for ${flag}: ${String(raw)} (expected number in [${lo}, ${hi}])`);
+		process.exit(1);
+	}
+	return n;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+	const args: CliArgs = {
+		verbose: false,
+		trials: 3,
+		passThreshold: 2 / 3,
+		timeoutMs: 60_000,
+		maxSteps: 5,
+		modelId: DEFAULT_MODEL,
+		concurrency: 3,
+	};
+
+	for (let i = 0; i < argv.length; i++) {
+		const arg = argv[i];
+		switch (arg) {
+			case '--verbose':
+			case '-v':
+				args.verbose = true;
+				break;
+			case '--filter':
+				args.filter = argv[++i];
+				break;
+			case '--trials':
+				args.trials = requirePositiveInt(argv[++i], '--trials');
+				break;
+			case '--pass-threshold':
+				args.passThreshold = requireNumberInRange(argv[++i], '--pass-threshold', 0, 1);
+				break;
+			case '--timeout':
+				args.timeoutMs = requirePositiveInt(argv[++i], '--timeout');
+				break;
+			case '--max-steps':
+				args.maxSteps = requirePositiveInt(argv[++i], '--max-steps');
+				break;
+			case '--model':
+				args.modelId = argv[++i];
+				break;
+			case '--concurrency':
+				args.concurrency = requirePositiveInt(argv[++i], '--concurrency');
+				break;
+			case '--nodes-json':
+				args.nodesJsonPath = argv[++i];
+				break;
+			default:
+				break;
+		}
+	}
+
+	return args;
+}
+
+// ---------------------------------------------------------------------------
+// Local mode
+// ---------------------------------------------------------------------------
+
+interface ScenarioAggregate {
+	scenario: DiscoveryTestCase;
+	results: DiscoveryRunResult[];
+	passCount: number;
+	passRate: number;
+}
+
+async function runLocalMode(args: CliArgs): Promise<void> {
+	const cases = loadDiscoveryTestCasesWithFiles(args.filter);
+
+	if (cases.length === 0) {
+		console.log('No discovery scenarios found.');
+		return;
+	}
+
+	console.log(
+		`Running ${String(cases.length)} discovery scenario(s) × ${String(args.trials)} trial(s) (model: ${args.modelId}, concurrency: ${String(args.concurrency)}).\n`,
+	);
+
+	const aggregates: ScenarioAggregate[] = [];
+
+	// Per scenario, run trials in parallel up to `concurrency`. Across scenarios, run sequentially
+	// — keeps the load profile predictable and per-scenario reports atomic.
+	for (const { testCase, fileSlug } of cases) {
+		process.stdout.write(`▸ ${fileSlug} ... `);
+		const trialResults: DiscoveryRunResult[] = [];
+
+		for (let i = 0; i < args.trials; i += args.concurrency) {
+			const batchSize = Math.min(args.concurrency, args.trials - i);
+			const batch = await Promise.all(
+				Array.from(
+					{ length: batchSize },
+					async () =>
+						await runDiscoveryScenario({
+							scenario: testCase,
+							modelId: args.modelId,
+							maxSteps: args.maxSteps,
+							timeoutMs: args.timeoutMs,
+							...(args.nodesJsonPath ? { nodesJsonPath: args.nodesJsonPath } : {}),
+						}),
+				),
+			);
+			trialResults.push(...batch);
+		}
+
+		const passCount = trialResults.filter((r) => r.check.pass).length;
+		const passRate = passCount / trialResults.length;
+		const status = passRate >= args.passThreshold ? '✓' : '✗';
+		console.log(
+			`${status} ${String(passCount)}/${String(trialResults.length)} passed (${(passRate * 100).toFixed(0)}%)`,
+		);
+
+		if (args.verbose) {
+			for (const [idx, r] of trialResults.entries()) {
+				const icon = r.check.pass ? '  ✓' : '  ✗';
+				const trial = `trial ${String(idx + 1)}`;
+				console.log(`${icon} ${trial} (${(r.durationMs / 1000).toFixed(1)}s) — ${r.check.comment}`);
+				if (r.runError) console.log(`     run error: ${r.runError}`);
+				if (r.outcome.toolCalls.length > 0) {
+					console.log('     tool calls:');
+					for (const tc of r.outcome.toolCalls) {
+						const argsPreview = previewArgs(tc.args);
+						console.log(`       • ${tc.toolName}(${argsPreview})`);
+					}
+				}
+				if (r.outcome.agentActivities.length > 0) {
+					console.log('     spawned sub-agents:');
+					for (const a of r.outcome.agentActivities) {
+						console.log(`       • role=${a.role}, tools=[${a.tools.join(', ')}]`);
+					}
+				}
+			}
+		}
+
+		aggregates.push({ scenario: testCase, results: trialResults, passCount, passRate });
+	}
+
+	printSummary(aggregates, args);
+
+	const failingScenarios = aggregates.filter((a) => a.passRate < args.passThreshold);
+	if (failingScenarios.length > 0) {
+		process.exitCode = 1;
+	}
+}
+
+function printSummary(aggregates: ScenarioAggregate[], args: CliArgs): void {
+	console.log('\n=== Summary ===');
+	const totalTrials = aggregates.reduce((sum, a) => sum + a.results.length, 0);
+	const totalPasses = aggregates.reduce((sum, a) => sum + a.passCount, 0);
+	const passingScenarios = aggregates.filter((a) => a.passRate >= args.passThreshold).length;
+	const totalDurationMs = aggregates
+		.flatMap((a) => a.results)
+		.reduce((sum, r) => sum + r.durationMs, 0);
+
+	console.log(
+		`Scenarios: ${String(passingScenarios)}/${String(aggregates.length)} above threshold (${(args.passThreshold * 100).toFixed(0)}%)`,
+	);
+	console.log(
+		`Trials: ${String(totalPasses)}/${String(totalTrials)} passed (${((totalPasses / totalTrials) * 100).toFixed(0)}%)`,
+	);
+	console.log(`Total time: ${(totalDurationMs / 1000).toFixed(1)}s`);
+
+	const failingScenarios = aggregates.filter((a) => a.passRate < args.passThreshold);
+	if (failingScenarios.length > 0) {
+		console.log('\nFailing scenarios:');
+		for (const a of failingScenarios) {
+			console.log(`  ✗ ${a.scenario.id} (${(a.passRate * 100).toFixed(0)}%)`);
+			const firstFailure = a.results.find((r) => !r.check.pass);
+			if (firstFailure) {
+				console.log(`    ${firstFailure.check.comment}`);
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+	const args = parseArgs(process.argv.slice(2));
+
+	if (!process.env.ANTHROPIC_API_KEY) {
+		console.error(
+			'Error: ANTHROPIC_API_KEY is required to run discovery evaluations (the runner calls Anthropic in-process).',
+		);
+		process.exit(1);
+	}
+
+	await runLocalMode(args);
+}
+
+main().catch((error) => {
+	console.error('Fatal error:', error);
+	process.exit(1);
+});

--- a/packages/@n8n/instance-ai/evaluations/discovery/expected-tools-invoked.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/expected-tools-invoked.ts
@@ -1,0 +1,101 @@
+// ---------------------------------------------------------------------------
+// Discovery check — assert the orchestrator reached for the expected tool(s).
+//
+// Reads the captured event outcome (`toolCalls` + `agentActivities`) and
+// compares against a `DiscoveryTestCase.expectedToolInvocations` rule.
+//
+// "Invoked" means either:
+//   - a top-level `tool-call` event with that tool name, OR
+//   - an `agent-spawned` event whose payload `tools` array contains that name
+//     (the sub-agent had access — even if it has not yet called it), OR
+//   - the rule names `spawn_sub_agent:<role>` and a sub-agent with that role
+//     was spawned.
+//
+// The asymmetry (sub-agent existence counts as discovery) matches the way
+// Instance AI dispatches browser-credential-setup: the orchestrator hands off
+// to a sub-agent and discovery has already happened by the time that
+// sub-agent has tools attached.
+// ---------------------------------------------------------------------------
+
+import type { EventOutcome } from '../types';
+import type { DiscoveryCheckResult, DiscoveryTestCase, ExpectedToolInvocations } from './types';
+
+const SPAWN_PREFIX = 'spawn_sub_agent:';
+
+function collectInvokedTools(outcome: EventOutcome): string[] {
+	const tools = new Set<string>();
+	for (const tc of outcome.toolCalls) {
+		if (tc.toolName) tools.add(tc.toolName);
+	}
+	for (const agent of outcome.agentActivities) {
+		for (const t of agent.tools) tools.add(t);
+		for (const tc of agent.toolCalls) {
+			if (tc.toolName) tools.add(tc.toolName);
+		}
+	}
+	return [...tools];
+}
+
+function collectSpawnedAgents(outcome: EventOutcome): string[] {
+	return outcome.agentActivities
+		.filter((a) => a.role.length > 0)
+		.map((a) => `${SPAWN_PREFIX}${a.role}`);
+}
+
+function matches(name: string, invokedTools: string[], spawnedAgents: string[]): boolean {
+	if (name.startsWith(SPAWN_PREFIX)) {
+		return spawnedAgents.includes(name);
+	}
+	return invokedTools.includes(name);
+}
+
+function validateRule(rule: ExpectedToolInvocations): void {
+	const hasAnyOf = Array.isArray(rule.anyOf) && rule.anyOf.length > 0;
+	const hasNoneOf = Array.isArray(rule.noneOf) && rule.noneOf.length > 0;
+	if (!hasAnyOf && !hasNoneOf) {
+		throw new Error('expectedToolInvocations must specify a non-empty `anyOf` or `noneOf` list');
+	}
+}
+
+export function runExpectedToolsInvokedCheck(
+	scenario: DiscoveryTestCase,
+	outcome: EventOutcome,
+): DiscoveryCheckResult {
+	validateRule(scenario.expectedToolInvocations);
+
+	const invokedTools = collectInvokedTools(outcome);
+	const spawnedAgents = collectSpawnedAgents(outcome);
+
+	const { anyOf, noneOf } = scenario.expectedToolInvocations;
+
+	if (anyOf && anyOf.length > 0) {
+		const matched = anyOf.find((name) => matches(name, invokedTools, spawnedAgents));
+		if (!matched) {
+			return {
+				pass: false,
+				comment: `Expected at least one of [${anyOf.join(', ')}] to be invoked. Invoked: [${invokedTools.join(', ') || '∅'}]; spawned: [${spawnedAgents.join(', ') || '∅'}].`,
+				invokedTools,
+				spawnedAgents,
+			};
+		}
+	}
+
+	if (noneOf && noneOf.length > 0) {
+		const violated = noneOf.find((name) => matches(name, invokedTools, spawnedAgents));
+		if (violated) {
+			return {
+				pass: false,
+				comment: `Expected none of [${noneOf.join(', ')}] to be invoked, but [${violated}] was reached.`,
+				invokedTools,
+				spawnedAgents,
+			};
+		}
+	}
+
+	return {
+		pass: true,
+		comment: 'Discovery expectation satisfied.',
+		invokedTools,
+		spawnedAgents,
+	};
+}

--- a/packages/@n8n/instance-ai/evaluations/discovery/runner.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/runner.ts
@@ -1,0 +1,321 @@
+// ---------------------------------------------------------------------------
+// In-process discovery runner.
+//
+// Drives the orchestrator with a scenario's userMessage + instanceState,
+// captures InstanceAi events into the CapturedEvent[] shape that
+// extractOutcomeFromEvents consumes, then runs the discovery check. No
+// Docker, no n8n server — the orchestrator runs in-process against
+// stubbed services.
+//
+// What's tested: the orchestrator's first dispatch decision. Tools are NOT
+// stubbed — when the orchestrator calls browser-credential-setup, that
+// tool's execute() may error (no real browser MCP, no real services for
+// sub-agent spawning) and that's fine: the tool-call event fires before
+// execution, so the discovery check still sees what the orchestrator
+// reached for. maxSteps caps the loop so an erroring tool can't drive
+// API spend.
+// ---------------------------------------------------------------------------
+
+import type { ToolsInput } from '@mastra/core/agent';
+import { InMemoryStore, type MastraCompositeStore } from '@mastra/core/storage';
+import type { InstanceAiEvent, TaskList } from '@n8n/api-types';
+import { nanoid } from 'nanoid';
+
+import { runExpectedToolsInvokedCheck } from './expected-tools-invoked';
+import { createStubLocalMcpServer } from './stub-local-mcp';
+import type { DiscoveryCheckResult, DiscoveryTestCase } from './types';
+import { createInstanceAgent } from '../../src/agent/instance-agent';
+import type { InstanceAiEventBus } from '../../src/event-bus';
+import type { Logger } from '../../src/logger';
+import { McpClientManager } from '../../src/mcp/mcp-client-manager';
+import { executeResumableStream } from '../../src/runtime/resumable-stream-executor';
+import { createAllTools } from '../../src/tools';
+import type {
+	InstanceAiContext,
+	LocalGatewayStatus,
+	ModelConfig,
+	OrchestrationContext,
+	TaskStorage,
+} from '../../src/types';
+import { asResumable } from '../../src/utils/stream-helpers';
+import { createInMemoryEventBus, wrapEventBusWithObserver } from '../harness/in-process-builder';
+import { createStubServices, defaultNodesJsonPath } from '../harness/stub-services';
+import { extractOutcomeFromEvents } from '../outcome/event-parser';
+import type { CapturedEvent, EventOutcome } from '../types';
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export interface DiscoveryRunOptions {
+	scenario: DiscoveryTestCase;
+	modelId: ModelConfig;
+	/** Defaults to `defaultNodesJsonPath()`. */
+	nodesJsonPath?: string;
+	/** Hard cap on agent steps. Discovery scenarios are single-turn — 5 is plenty. */
+	maxSteps?: number;
+	/** Per-trial timeout in ms. */
+	timeoutMs?: number;
+}
+
+export interface DiscoveryRunResult {
+	scenario: DiscoveryTestCase;
+	check: DiscoveryCheckResult;
+	events: CapturedEvent[];
+	outcome: EventOutcome;
+	durationMs: number;
+	/** Final agent status — useful for diagnosing why noop / unexpected loops happened. */
+	streamStatus: 'completed' | 'errored' | 'cancelled' | 'suspended';
+	/** Populated when the run errored before reaching the check. */
+	runError?: string;
+}
+
+export async function runDiscoveryScenario(
+	options: DiscoveryRunOptions,
+): Promise<DiscoveryRunResult> {
+	const started = Date.now();
+	const maxSteps = options.maxSteps ?? 5;
+	const timeoutMs = options.timeoutMs ?? 60_000;
+	const nodesJsonPath = options.nodesJsonPath ?? defaultNodesJsonPath();
+
+	const events: CapturedEvent[] = [];
+
+	let streamStatus: DiscoveryRunResult['streamStatus'] = 'completed';
+	let runError: string | undefined;
+
+	const abortController = new AbortController();
+	const timeoutHandle = setTimeout(() => abortController.abort(), timeoutMs);
+
+	try {
+		const services = await createStubServices({ nodesJsonPath });
+		const context = applyInstanceState(services.context, options.scenario);
+
+		const mcpManager = new McpClientManager();
+		const storage = new InMemoryStore({ id: 'discovery-' + nanoid(6) });
+		const threadId = 'discovery-thread-' + nanoid(6);
+		const runId = 'discovery-run-' + nanoid(6);
+
+		// Track outstanding confirmation requests so the auto-approve can simulate the
+		// production "user clicks Auto-setup with browser" path for credential setup
+		// suspensions. Without this, `credentials(action="setup")` returns the
+		// "user picked existing credentials" branch and the orchestrator never sees
+		// `needsBrowserSetup=true` — which is what wires it to `browser-credential-setup`
+		// per the system prompt.
+		const pendingConfirmations = new Map<string, { credentialType?: string }>();
+
+		const eventBus = wrapEventBusWithObserver(createInMemoryEventBus(), (event) => {
+			events.push(toCapturedEvent(event));
+			recordConfirmationRequest(event, pendingConfirmations);
+		});
+
+		// `OrchestrationContext` is required for the orchestrator to receive tools like
+		// `browser-credential-setup`, `delegate`, `plan`. Without it, the orchestrator's
+		// only browser-adjacent tools come from the local MCP server directly, which is
+		// a different (and less production-faithful) dispatch path. We provide stubs for
+		// the heavy fields — sub-agent execution paths will fail if reached, but the
+		// orchestrator's first-step tool-call decisions are what we measure, and those
+		// fire before any sub-agent execution.
+		const orchestrationContext = createStubOrchestrationContext({
+			context,
+			modelId: options.modelId,
+			storage,
+			eventBus,
+			threadId,
+			runId,
+			abortSignal: abortController.signal,
+		});
+
+		const agent = await createInstanceAgent({
+			modelId: options.modelId,
+			context,
+			orchestrationContext,
+			mcpManager,
+			memoryConfig: { storage },
+			// Eager tool loading — discovery measures dispatch given the full toolset,
+			// not whether the orchestrator can find a tool through search.
+			disableDeferredTools: true,
+		});
+
+		const streamSource = await agent.stream(options.scenario.userMessage, {
+			maxSteps,
+			abortSignal: abortController.signal,
+			providerOptions: {
+				anthropic: { cacheControl: { type: 'ephemeral' as const } },
+			},
+		});
+
+		const result = await executeResumableStream({
+			agent: asResumable(agent),
+			stream: streamSource,
+			context: {
+				threadId,
+				runId,
+				agentId: 'n8n-instance-agent',
+				eventBus,
+				signal: abortController.signal,
+				logger: silentLogger(),
+			},
+			control: {
+				mode: 'auto',
+				// Auto-approve every confirmation/HITL suspension so the run drives to
+				// completion. For credentials(action="setup") suspensions, pretend the user
+				// chose "Auto-setup with browser" — that's what unlocks the production
+				// `needsBrowserSetup=true` → `browser-credential-setup` dispatch path.
+				// eslint-disable-next-line @typescript-eslint/require-await
+				waitForConfirmation: async (requestId: string): Promise<Record<string, unknown>> => {
+					const pending = pendingConfirmations.get(requestId);
+					if (pending?.credentialType) {
+						return { approved: true, autoSetup: { credentialType: pending.credentialType } };
+					}
+					return { approved: true };
+				},
+			},
+		});
+
+		if (abortController.signal.aborted || result.status === 'cancelled') {
+			streamStatus = 'cancelled';
+		} else if (result.status === 'errored') {
+			streamStatus = 'errored';
+		} else if (result.status === 'suspended') {
+			streamStatus = 'suspended';
+		}
+
+		await mcpManager.disconnect();
+	} catch (error) {
+		runError = error instanceof Error ? error.message : String(error);
+		streamStatus = 'errored';
+	} finally {
+		clearTimeout(timeoutHandle);
+	}
+
+	const outcome = extractOutcomeFromEvents(events);
+	const check = runExpectedToolsInvokedCheck(options.scenario, outcome);
+
+	return {
+		scenario: options.scenario,
+		check,
+		events,
+		outcome,
+		durationMs: Date.now() - started,
+		streamStatus,
+		...(runError ? { runError } : {}),
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function applyInstanceState(
+	base: InstanceAiContext,
+	scenario: DiscoveryTestCase,
+): InstanceAiContext {
+	const state = scenario.instanceState;
+	if (!state) return base;
+
+	const localGateway: LocalGatewayStatus | undefined = state.localGateway;
+	const isConnected = localGateway?.status === 'connected';
+	const capabilities = isConnected ? localGateway.capabilities : [];
+
+	const localMcpServer = isConnected
+		? createStubLocalMcpServer({
+				capabilities: capabilities.filter(
+					(c): c is 'browser' | 'filesystem' | 'shell' =>
+						c === 'browser' || c === 'filesystem' || c === 'shell',
+				),
+			})
+		: base.localMcpServer;
+
+	return {
+		...base,
+		...(localGateway ? { localGatewayStatus: localGateway } : {}),
+		...(localMcpServer ? { localMcpServer } : {}),
+	};
+}
+
+function silentLogger(): Logger {
+	return { debug: () => {}, info: () => {}, warn: () => {}, error: () => {} };
+}
+
+interface StubOrchestrationContextOptions {
+	context: InstanceAiContext;
+	modelId: ModelConfig;
+	storage: MastraCompositeStore;
+	eventBus: InstanceAiEventBus;
+	threadId: string;
+	runId: string;
+	abortSignal: AbortSignal;
+}
+
+function createStubOrchestrationContext(
+	opts: StubOrchestrationContextOptions,
+): OrchestrationContext {
+	// Domain tools are passed to spawned sub-agents (delegate, browser-credential-setup).
+	// Discovery scenarios measure the orchestrator's first-step dispatch decision; sub-agent
+	// execution is out of scope. We still populate domainTools faithfully so any sub-agent
+	// that does spawn has a coherent toolset (avoids hitting "no tools" errors that would
+	// confuse the diagnostic comment).
+	const domainTools: ToolsInput = createAllTools(opts.context);
+
+	const taskStorage: TaskStorage = {
+		// eslint-disable-next-line @typescript-eslint/require-await
+		get: async (): Promise<TaskList | null> => null,
+		// eslint-disable-next-line @typescript-eslint/require-await
+		save: async (): Promise<void> => {},
+	};
+
+	return {
+		threadId: opts.threadId,
+		runId: opts.runId,
+		userId: opts.context.userId,
+		orchestratorAgentId: 'n8n-instance-agent',
+		modelId: opts.modelId,
+		storage: opts.storage,
+		subAgentMaxSteps: 10,
+		eventBus: opts.eventBus,
+		logger: silentLogger(),
+		domainTools,
+		abortSignal: opts.abortSignal,
+		taskStorage,
+		// Surface the localMcpServer to orchestration tools so `browser-credential-setup`
+		// is loaded (its presence is gated on `localMcpServer` having browser tools, see
+		// src/tools/index.ts:82-86).
+		...(opts.context.localMcpServer ? { localMcpServer: opts.context.localMcpServer } : {}),
+		// Used for the orchestrator's untrusted-content doctrine and other domain references
+		// inside sub-agent tools. Provide the same context the orchestrator sees.
+		domainContext: opts.context,
+	};
+}
+
+/**
+ * Capture credentialType from `confirmation-request` events whose payload includes
+ * a credentialRequests array. The first request's credentialType is what the
+ * `autoSetup` resume payload needs — the production credentials tool only
+ * exposes one credential at a time when needsBrowserSetup is involved.
+ */
+function recordConfirmationRequest(
+	event: InstanceAiEvent,
+	pending: Map<string, { credentialType?: string }>,
+): void {
+	if (event.type !== 'confirmation-request') return;
+	const payload = event.payload as
+		| {
+				requestId?: string;
+				credentialRequests?: Array<{ credentialType?: string }>;
+		  }
+		| undefined;
+	const requestId = payload?.requestId;
+	if (typeof requestId !== 'string' || requestId.length === 0) return;
+	const credentialType = payload?.credentialRequests?.[0]?.credentialType;
+	pending.set(requestId, credentialType ? { credentialType } : {});
+}
+
+function toCapturedEvent(event: InstanceAiEvent): CapturedEvent {
+	return {
+		timestamp: Date.now(),
+		type: event.type,
+		// `extractOutcomeFromEvents` reads `data.payload.toolName` etc. — our
+		// InstanceAiEvent already has that shape, so we pass it through directly.
+		data: event as unknown as Record<string, unknown>,
+	};
+}

--- a/packages/@n8n/instance-ai/evaluations/discovery/stub-local-mcp.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/stub-local-mcp.ts
@@ -1,0 +1,79 @@
+// ---------------------------------------------------------------------------
+// Stub LocalMcpServer for discovery evals.
+//
+// The orchestrator computes `browserAvailable` from the size of
+// `context.localMcpServer?.getToolsByCategory('browser')` plus any browser
+// MCP tools loaded via the McpClientManager. To exercise the
+// `browserAvailable: true` branch of the system prompt without spinning up
+// the real computer-use daemon, we plug in a stub server that advertises
+// browser tools by name. The stub never receives actual `callTool`
+// invocations during discovery scenarios — the orchestrator's first
+// dispatch decision is what we measure, not downstream tool execution.
+// ---------------------------------------------------------------------------
+
+import type { McpTool, McpToolCallRequest, McpToolCallResult } from '@n8n/api-types';
+
+import type { LocalMcpServer } from '../../src/types';
+
+const STUB_BROWSER_TOOL_NAMES = ['browser_navigate', 'browser_snapshot', 'browser_screenshot'];
+
+const STUB_FILESYSTEM_TOOL_NAMES = ['fs_read_file', 'fs_search_files', 'fs_list_dir'];
+
+const STUB_SHELL_TOOL_NAMES = ['shell_run'];
+
+function makeStubTool(name: string, category: string): McpTool {
+	return {
+		name,
+		description: `Stub ${category} tool — no-op for discovery evals.`,
+		inputSchema: { type: 'object', properties: {} },
+		annotations: { category },
+	};
+}
+
+export interface CreateStubLocalMcpServerOptions {
+	/** Capabilities to advertise. Each capability publishes a small set of stub tool names. */
+	capabilities: ReadonlyArray<'browser' | 'filesystem' | 'shell'>;
+}
+
+export function createStubLocalMcpServer(options: CreateStubLocalMcpServerOptions): LocalMcpServer {
+	const tools: McpTool[] = [];
+	if (options.capabilities.includes('browser')) {
+		for (const name of STUB_BROWSER_TOOL_NAMES) tools.push(makeStubTool(name, 'browser'));
+	}
+	if (options.capabilities.includes('filesystem')) {
+		for (const name of STUB_FILESYSTEM_TOOL_NAMES) tools.push(makeStubTool(name, 'filesystem'));
+	}
+	if (options.capabilities.includes('shell')) {
+		for (const name of STUB_SHELL_TOOL_NAMES) tools.push(makeStubTool(name, 'shell'));
+	}
+
+	return {
+		getAvailableTools: () => tools,
+		getToolsByCategory: (category: string) =>
+			tools.filter((t) => {
+				const annotations = t.annotations;
+				return (
+					annotations !== undefined &&
+					typeof annotations === 'object' &&
+					(annotations as Record<string, unknown>).category === category
+				);
+			}),
+		// eslint-disable-next-line @typescript-eslint/require-await
+		callTool: async (req: McpToolCallRequest): Promise<McpToolCallResult> => {
+			// Return a normal tool-error result rather than throwing. Mastra logs an
+			// error stack trace for thrown tool errors; an `isError: true` result is
+			// treated as expected and surfaced as a `tool-error` event without spam.
+			// The discovery check still records the underlying `tool-call` event, so
+			// dispatch is captured either way.
+			return {
+				content: [
+					{
+						type: 'text' as const,
+						text: `Stub: ${req.name} would have executed in production. Discovery evals measure dispatch, not execution.`,
+					},
+				],
+				isError: true,
+			};
+		},
+	};
+}

--- a/packages/@n8n/instance-ai/evaluations/discovery/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/discovery/types.ts
@@ -1,0 +1,60 @@
+// ---------------------------------------------------------------------------
+// Tool-discovery scenario types — guards browser/computer-use discoverability.
+//
+// Discovery scenarios run the orchestrator against a user message that should
+// (or should not) cause a specific tool / sub-agent to be reached for, and
+// assert the captured events match the expectation. Workflow-build scenarios
+// in evaluations/data/workflows/ assert the *output workflow*; discovery
+// scenarios assert the *agent's tool/dispatch behavior*.
+// ---------------------------------------------------------------------------
+
+import type { LocalGatewayStatus } from '../../src/types';
+
+/**
+ * Pass condition for tool invocations.
+ *
+ * - `anyOf` — pass if at least one of the listed tool names was invoked
+ *   (top-level orchestrator call, or via a spawned sub-agent's tool list).
+ * - `noneOf` — pass only if NONE of the listed tool names was invoked.
+ *   Used for negative scenarios that guard against over-eager invocation.
+ *
+ * Both forms accept a sub-agent role prefix `spawn_sub_agent:<role>` to match
+ * an `agent-spawned` event whose role equals `<role>`.
+ */
+export interface ExpectedToolInvocations {
+	anyOf?: string[];
+	noneOf?: string[];
+}
+
+/**
+ * Optional instance configuration overrides for a discovery scenario.
+ * Mirrors a subset of `SystemPromptOptions` so a scenario can pin the gateway
+ * status (e.g. `disabledGlobally` to test the "explain how to enable" branch).
+ */
+export interface DiscoveryInstanceState {
+	localGateway?: LocalGatewayStatus;
+	browserAvailable?: boolean;
+}
+
+export interface DiscoveryTestCase {
+	/** Unique scenario identifier — also used as the scenario filename (without .json). */
+	id: string;
+	/** The user message sent to the orchestrator. */
+	userMessage: string;
+	/** Optional instance state overrides applied when constructing the agent. */
+	instanceState?: DiscoveryInstanceState;
+	/** Pass condition. Exactly one of the form keys (`anyOf` / `noneOf`) is required. */
+	expectedToolInvocations: ExpectedToolInvocations;
+	/** Free-form note explaining what regression this scenario protects against. */
+	rationale?: string;
+}
+
+export interface DiscoveryCheckResult {
+	pass: boolean;
+	/** Human-readable reason — included in failure reports. */
+	comment: string;
+	/** Tool names actually invoked during the run (top-level + via sub-agents). */
+	invokedTools: string[];
+	/** `spawn_sub_agent:<role>` markers for every spawned sub-agent. */
+	spawnedAgents: string[];
+}

--- a/packages/@n8n/instance-ai/evaluations/harness/in-process-builder.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/in-process-builder.ts
@@ -638,7 +638,7 @@ function silentLogger(): Logger {
 // In-memory event bus — the stream executor publishes mapped events here.
 // ---------------------------------------------------------------------------
 
-function createInMemoryEventBus(): InstanceAiEventBus {
+export function createInMemoryEventBus(): InstanceAiEventBus {
 	const storeByThread = new Map<string, StoredEvent[]>();
 	const subscribersByThread = new Map<string, Array<(event: StoredEvent) => void>>();
 
@@ -683,7 +683,7 @@ function createInMemoryEventBus(): InstanceAiEventBus {
 	};
 }
 
-function wrapEventBusWithObserver(
+export function wrapEventBusWithObserver(
 	bus: InstanceAiEventBus,
 	observe: (event: InstanceAiEvent) => void,
 ): InstanceAiEventBus {

--- a/packages/@n8n/instance-ai/evaluations/outcome/event-parser.ts
+++ b/packages/@n8n/instance-ai/evaluations/outcome/event-parser.ts
@@ -150,6 +150,7 @@ export function extractOutcomeFromEvents(events: CapturedEvent[]): EventOutcome 
 					agentId,
 					role,
 					parentId,
+					tools,
 					toolCalls: [],
 					textContent: '',
 					reasoning: '',
@@ -258,11 +259,16 @@ export function buildMetrics(events: CapturedEvent[], startTime: number): Instan
 				const agentId = getString(event.data, 'agentId') ?? getString(payload, 'agentId') ?? '';
 				const role = getString(payload, 'role') ?? '';
 				const parentId = getString(payload, 'parentId');
+				const toolsRaw = payload.tools;
+				const tools = Array.isArray(toolsRaw)
+					? (toolsRaw as unknown[]).filter((t): t is string => typeof t === 'string')
+					: [];
 
 				agentMap.set(agentId, {
 					agentId,
 					role,
 					parentId,
+					tools,
 					toolCalls: [],
 					textContent: '',
 					reasoning: '',

--- a/packages/@n8n/instance-ai/evaluations/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/types.ts
@@ -53,6 +53,8 @@ export interface AgentActivity {
 	agentId: string;
 	role: string;
 	parentId?: string;
+	/** Tool names the sub-agent was spawned with, captured from the `agent-spawned` event payload. */
+	tools: string[];
 	toolCalls: CapturedToolCall[];
 	textContent: string;
 	reasoning: string;

--- a/packages/@n8n/instance-ai/package.json
+++ b/packages/@n8n/instance-ai/package.json
@@ -17,6 +17,7 @@
     "eval:pairwise:compare": "tsx evaluations/cli/compare-pairwise.ts",
     "eval:subagent": "tsx evaluations/subagent/cli.ts",
     "eval:computer-use": "tsx evaluations/computer-use/cli.ts",
+    "eval:discovery": "tsx evaluations/discovery/cli.ts",
     "prompts:print": "tsx scripts/print-prompts.ts"
   },
   "main": "dist/index.js",

--- a/packages/@n8n/instance-ai/src/agent/__tests__/computer-use-prompt.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/computer-use-prompt.test.ts
@@ -244,4 +244,55 @@ describe('getComputerUsePrompt', () => {
 			expect(result).toContain('Platform migration');
 		});
 	});
+
+	describe('signal → tool pairings', () => {
+		// The label tests above only check that each signal *appears*. These tests pin
+		// each signal to its tool on the same line, so a copy edit that drops the
+		// "→ *browser*" / "→ *filesystem*" mapping fails loudly even if the label survives.
+		const findSignalLine = (prompt: string, signal: string): string => {
+			const line = prompt.split('\n').find((l) => l.includes(signal));
+			if (!line) throw new Error(`Signal "${signal}" not found`);
+			return line;
+		};
+
+		const promptWithBrowser = (): string =>
+			getComputerUsePrompt({
+				browserAvailable: true,
+				localGateway: { status: 'connected', capabilities: ['browser', 'filesystem'] },
+			});
+
+		it('pairs Credential / OAuth setup with browser', () => {
+			expect(findSignalLine(promptWithBrowser(), 'Credential / OAuth setup')).toContain('browser');
+		});
+
+		it('pairs Local file as context with filesystem', () => {
+			expect(findSignalLine(promptWithBrowser(), 'Local file as context')).toContain('filesystem');
+		});
+
+		it('pairs Documentation / output to files with filesystem', () => {
+			expect(findSignalLine(promptWithBrowser(), 'Documentation / output to files')).toContain(
+				'filesystem',
+			);
+		});
+
+		it('pairs Authenticated web research with browser', () => {
+			expect(findSignalLine(promptWithBrowser(), 'Authenticated web research')).toContain(
+				'browser',
+			);
+		});
+
+		it('pairs Form / frontend testing with browser', () => {
+			expect(findSignalLine(promptWithBrowser(), 'Form / frontend testing')).toContain('browser');
+		});
+
+		it('pairs Shell / environment with shell', () => {
+			expect(findSignalLine(promptWithBrowser(), 'Shell / environment')).toContain('shell');
+		});
+
+		it('pairs Platform migration with both browser and filesystem', () => {
+			const line = findSignalLine(promptWithBrowser(), 'Platform migration');
+			expect(line).toContain('browser');
+			expect(line).toContain('filesystem');
+		});
+	});
 });

--- a/packages/@n8n/instance-ai/src/agent/__tests__/sub-agent-factory.discovery.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/sub-agent-factory.discovery.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Browser/computer-use *discoverability* asserts on the sub-agent protocol.
+ *
+ * The protocol is injected into every sub-agent. If a future copy edit
+ * accidentally tells sub-agents "ask the user to fill the form" instead of
+ * letting browser-credential-setup do its discovery work, those sub-agents
+ * will silently stop reaching for browser tools. These asserts pin the
+ * surviving guardrails (we keep the secret-handling rule) without acquiring
+ * new ones that suppress active discovery.
+ */
+
+import { SUB_AGENT_PROTOCOL, buildSubAgentPrompt } from '../sub-agent-factory';
+
+describe('SUB_AGENT_PROTOCOL — browser-tool discovery preservation', () => {
+	it('keeps the secret-handling guardrail (route through credential setup, not chat)', () => {
+		expect(SUB_AGENT_PROTOCOL).toContain('Never ask the user to paste passwords');
+		expect(SUB_AGENT_PROTOCOL).toContain(
+			'credential setup, browser credential setup, or existing credential selection',
+		);
+	});
+
+	it('does not blanket-instruct sub-agents to ask the user to fill the credential form', () => {
+		// The orchestrator routes credential setup through `browser-credential-setup`,
+		// which actively navigates and identifies where the values live. A protocol-level
+		// "ask the user to fill the form" instruction would short-circuit that discovery.
+		expect(SUB_AGENT_PROTOCOL).not.toMatch(/ask the user to fill (in )?the (credential )?form/i);
+		expect(SUB_AGENT_PROTOCOL).not.toMatch(/tell the user to enter (their )?credentials/i);
+	});
+
+	it('does not forbid sub-agents from using browser tools', () => {
+		// Anti-regression: a future edit must not add a blanket "do not use browser tools"
+		// or "browser automation is unavailable to sub-agents" rule.
+		expect(SUB_AGENT_PROTOCOL).not.toMatch(/do not use browser tools/i);
+		expect(SUB_AGENT_PROTOCOL).not.toMatch(/browser tools are not available/i);
+		expect(SUB_AGENT_PROTOCOL).not.toMatch(/never use browser_/i);
+	});
+});
+
+describe('buildSubAgentPrompt', () => {
+	it('embeds the role and task instructions in the assembled prompt', () => {
+		const prompt = buildSubAgentPrompt(
+			'browser-credential-setup',
+			'Help the user set up a Slack credential.',
+		);
+
+		expect(prompt).toContain('browser-credential-setup');
+		expect(prompt).toContain('Help the user set up a Slack credential.');
+	});
+
+	it('includes the protocol so its guardrails reach every sub-agent', () => {
+		const prompt = buildSubAgentPrompt('any-role', 'do thing');
+
+		expect(prompt).toContain(SUB_AGENT_PROTOCOL);
+	});
+});

--- a/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.discovery.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.discovery.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Browser/computer-use *discoverability* asserts on the assembled system prompt.
+ *
+ * These tests pin the orchestrator-level wiring that connects discovery
+ * signals (OAuth setup, local files, screenshots, platform migration, shell
+ * commands) to the right tool. They are intentionally semantic — they assert
+ * the protected concept survives, not exact wording — so that copy edits do
+ * not churn them but intent-shifting edits fail loudly.
+ */
+
+import type { LocalGatewayStatus } from '../../types';
+import { getSystemPrompt } from '../system-prompt';
+
+const browserCapableOptions: {
+	browserAvailable: boolean;
+	localGateway: LocalGatewayStatus;
+} = {
+	browserAvailable: true,
+	localGateway: { status: 'connected', capabilities: ['browser', 'filesystem'] },
+};
+
+describe('getSystemPrompt — browser/computer-use discoverability', () => {
+	describe('orchestrator → browser-credential-setup dispatch', () => {
+		it('routes needsBrowserSetup=true credential responses to the browser-credential-setup tool', () => {
+			const prompt = getSystemPrompt({});
+
+			expect(prompt).toContain('needsBrowserSetup=true');
+			expect(prompt).toContain('browser-credential-setup');
+			expect(prompt).toMatch(/call `browser-credential-setup` directly/);
+		});
+
+		it('does not route browser credential setup through delegate', () => {
+			const prompt = getSystemPrompt({});
+
+			expect(prompt).toMatch(/call `browser-credential-setup` directly \(not `delegate`\)/);
+		});
+	});
+
+	describe('Computer Use proactive suggestions are reachable from the orchestrator prompt', () => {
+		it('includes the Computer Use section when the gateway is connected with browser available', () => {
+			const prompt = getSystemPrompt(browserCapableOptions);
+
+			expect(prompt).toContain('## Computer Use');
+			expect(prompt).toContain('When to suggest or use Computer Use');
+		});
+
+		it('omits the Computer Use section when computer use is disabled globally', () => {
+			const prompt = getSystemPrompt({ localGateway: { status: 'disabledGlobally' } });
+
+			expect(prompt).not.toContain('## Computer Use');
+			expect(prompt).not.toContain('When to suggest or use Computer Use');
+		});
+
+		it('still includes proactive suggestions when computer use is set up but disconnected', () => {
+			const prompt = getSystemPrompt({ localGateway: { status: 'disconnected' } });
+
+			expect(prompt).toContain('When to suggest or use Computer Use');
+			expect(prompt).toContain('Credential / OAuth setup');
+		});
+
+		it('still includes proactive suggestions when computer use has not been set up', () => {
+			const prompt = getSystemPrompt({ localGateway: { status: 'disabled' } });
+
+			expect(prompt).toContain('When to suggest or use Computer Use');
+			expect(prompt).toContain('Credential / OAuth setup');
+		});
+	});
+
+	describe('discovery-signal pairings — each signal routes to the right tool', () => {
+		const findSignalLine = (prompt: string, signal: string): string => {
+			const lines = prompt.split('\n');
+			const line = lines.find((l) => l.includes(signal));
+			if (!line) {
+				throw new Error(`Signal "${signal}" not found in prompt`);
+			}
+			return line;
+		};
+
+		it('pairs Credential / OAuth setup with the browser tool', () => {
+			const prompt = getSystemPrompt(browserCapableOptions);
+			const line = findSignalLine(prompt, 'Credential / OAuth setup');
+
+			expect(line).toContain('browser');
+		});
+
+		it('pairs Local file as context with the filesystem tool', () => {
+			const prompt = getSystemPrompt(browserCapableOptions);
+			const line = findSignalLine(prompt, 'Local file as context');
+
+			expect(line).toContain('filesystem');
+		});
+
+		it('pairs Authenticated web research with the browser tool', () => {
+			const prompt = getSystemPrompt(browserCapableOptions);
+			const line = findSignalLine(prompt, 'Authenticated web research');
+
+			expect(line).toContain('browser');
+		});
+
+		it('pairs Form / frontend testing with the browser tool', () => {
+			const prompt = getSystemPrompt(browserCapableOptions);
+			const line = findSignalLine(prompt, 'Form / frontend testing');
+
+			expect(line).toContain('browser');
+		});
+
+		it('pairs Shell / environment with the shell tool', () => {
+			const prompt = getSystemPrompt(browserCapableOptions);
+			const line = findSignalLine(prompt, 'Shell / environment');
+
+			expect(line).toContain('shell');
+		});
+
+		it('pairs Platform migration with both browser and filesystem tools', () => {
+			const prompt = getSystemPrompt(browserCapableOptions);
+			const line = findSignalLine(prompt, 'Platform migration');
+
+			expect(line).toContain('browser');
+			expect(line).toContain('filesystem');
+		});
+
+		it('pairs Documentation / output to files with the filesystem tool', () => {
+			const prompt = getSystemPrompt(browserCapableOptions);
+			const line = findSignalLine(prompt, 'Documentation / output to files');
+
+			expect(line).toContain('filesystem');
+		});
+	});
+
+	describe('proactive framing is preserved (not narrowed to passive responses)', () => {
+		it('keeps the "Proactively suggest" instruction so the orchestrator initiates discovery', () => {
+			const prompt = getSystemPrompt(browserCapableOptions);
+
+			expect(prompt).toMatch(/Proactively suggest Computer Use/);
+		});
+
+		it('does not instruct the orchestrator to wait for the user to ask first', () => {
+			const prompt = getSystemPrompt(browserCapableOptions);
+
+			expect(prompt).not.toMatch(/only suggest Computer Use when the user asks/i);
+			expect(prompt).not.toMatch(/wait for the user to request browser/i);
+		});
+	});
+
+	describe('browser availability state propagates to the prompt', () => {
+		it('includes browser automation rules when browser is available', () => {
+			const prompt = getSystemPrompt({
+				browserAvailable: true,
+				localGateway: { status: 'connected', capabilities: ['browser'] },
+			});
+
+			expect(prompt).toContain('Browser Automation rules');
+		});
+
+		it('shows the browser-disabled notice when computer use is connected without browser', () => {
+			const prompt = getSystemPrompt({
+				browserAvailable: false,
+				localGateway: { status: 'connected', capabilities: ['filesystem'] },
+			});
+
+			expect(prompt).toContain('Browser Automation (Disabled in Computer Use)');
+		});
+	});
+});

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/browser-credential-setup.discovery.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/browser-credential-setup.discovery.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Browser-credential-setup *discovery intent* asserts.
+ *
+ * The browser sub-agent's job is to navigate the external service, identify
+ * where each credential value lives, and only then hand control back to the
+ * user for private entry. If a future edit reframes the goal toward "ask the
+ * user to enter values" without the navigation step, the sub-agent stops
+ * doing discovery — which is the regression these tests guard against.
+ *
+ * The complementary `credential-guardrails.prompt.test.ts` pins the privacy
+ * end of the contract (no copy/paste secrets in chat). These tests pin the
+ * other end (the agent must navigate and find the values).
+ */
+
+import { buildBrowserAgentPrompt } from '../browser-credential-setup.prompt';
+
+describe('buildBrowserAgentPrompt — discovery intent', () => {
+	describe.each(['gateway', 'chrome-devtools-mcp'] as const)('source = %s', (source) => {
+		const prompt = buildBrowserAgentPrompt(source);
+
+		it('frames the goal around identifying where credential values live', () => {
+			expect(prompt).toMatch(/identify where the required credential values live/i);
+		});
+
+		it('instructs the agent to navigate the external service', () => {
+			expect(prompt).toMatch(/Navigate the browser to the external service/i);
+		});
+
+		it('forbids stopping at intermediate steps (read docs, navigated, enabled API, etc.)', () => {
+			expect(prompt).toContain('you are NOT done. Keep going');
+			expect(prompt).toContain('intermediate steps');
+		});
+
+		it('instructs the agent to take action rather than narrate plans', () => {
+			expect(prompt).toMatch(/Do NOT narrate what you plan to do — just DO it/);
+		});
+
+		it('directs the user to enter secret values privately in the n8n credential form', () => {
+			// Privacy end of the contract — must not regress when discovery framing is added.
+			expect(prompt).toContain('enter the required values in the dedicated n8n credential form');
+			expect(prompt).toMatch(/Never ask the user to paste secret values into chat/i);
+		});
+
+		it('does not reframe the agent into a passive "ask the user to fill the form" role', () => {
+			expect(prompt).not.toMatch(/^Your only job is to ask/im);
+			expect(prompt).not.toMatch(/do not navigate/i);
+			expect(prompt).not.toMatch(/skip the browser session/i);
+		});
+	});
+
+	describe('gateway source — session lifecycle', () => {
+		const prompt = buildBrowserAgentPrompt('gateway');
+
+		it('opens a browser session at the start of the process', () => {
+			expect(prompt).toContain('browser_open');
+			expect(prompt).toContain('sessionId');
+		});
+
+		it('closes the browser session at the end of the process', () => {
+			expect(prompt).toContain('browser_close');
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds a discovery evaluation suite that asserts the Instance AI orchestrator reaches for browser / computer-use tools at the right moments (OAuth credential setup, screenshots, authenticated research) and does **not** reach for them when it shouldn't (plain node-config questions, gateway disabled globally).

Three layers:

1. **Unit-test guardrails** on the system prompt, sub-agent protocol, and `browser-credential-setup` prompt. These pin the *concept* (signal → tool pairings, "navigate to identify where values live", privacy boundary) so a future copy edit fails loudly if it shifts intent. Strings are matched semantically where possible.
2. **In-process discovery runner** (`evaluations/discovery/`) that drives the orchestrator against a scenario's `userMessage` + `instanceState`, captures `InstanceAiEvent`s, and runs an `expectedToolInvocations` rule (`anyOf` / `noneOf`, supports `spawn_sub_agent:<role>`). No Docker, no n8n server — uses the existing stub-services harness and a stub `LocalMcpServer` to advertise browser/filesystem/shell capabilities. The orchestrator's first-step dispatch is what we measure; sub-agent execution paths are out of scope.
3. **CI workflow** (`test-evals-discovery.yml`) wired into `ci-pull-requests.yml` behind the existing `instance-ai-workflow-eval` path filter. Runs in parallel with the heavy workflow eval; posts (or updates) a single comment on the PR with the eval output and uploads an artifact. Excluded on forks.

Scenarios shipped (in `evaluations/data/discovery/`):

- `slack-oauth-credential-setup` — positive, expects browser tooling
- `google-oauth-credential-setup` — positive, expects browser tooling
- `screenshot-dashboard` — positive, expects direct browser tool call
- `http-node-config-no-browser` — negative, must NOT touch browser tooling
- `oauth-with-computer-use-disabled` — negative, identical message to Slack but gateway disabled globally

Local-run modes:

```
pnpm eval:discovery                                    # all scenarios, 3 trials each
pnpm eval:discovery --filter slack-oauth --verbose
pnpm eval:discovery --dataset <name> --experiment <name>   # LangSmith mode
```

Marked non-blocking initially via the existing path-filter gate; can be promoted to required after stability.

## Related Linear tickets, Github issues, and Community forum posts

<!-- No Linear ticket — internal CI hardening following the PR #28876-style regression class. -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI