### PR TITLE
fix(core): Gate agent node tools behind node-tools-searcher module (no-changelog)

### DIFF
--- a/packages/cli/src/modules/agents/__tests__/agents-service-reconstruct-gating.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-service-reconstruct-gating.test.ts
@@ -1,5 +1,6 @@
 import type * as agents from '@n8n/agents';
 import type { CredentialProvider, BuiltTool } from '@n8n/agents';
+import type { AgentsConfig } from '@n8n/config';
 
 import type { ToolRegistry } from '../tool-registry';
 import type { Logger } from '@n8n/backend-common';
@@ -42,7 +43,10 @@ jest.mock('../integrations/rich-interaction-tool', () => ({
 	createRichInteractionTool: () => ({}) as never,
 }));
 
-function makeService(agentsToolsService: AgentsToolsService): AgentsService {
+function makeService(
+	agentsToolsService: AgentsToolsService,
+	modules: string[] = [],
+): AgentsService {
 	return new AgentsService(
 		mock<Logger>(),
 		mock<AgentRepository>(),
@@ -63,6 +67,7 @@ function makeService(agentsToolsService: AgentsToolsService): AgentsService {
 		mock<AgentPublishedVersionRepository>(),
 		mock<AgentSkillsService>(),
 		mock(),
+		{ modules } as unknown as AgentsConfig,
 		mock(),
 	);
 }
@@ -98,41 +103,69 @@ describe('AgentsService.reconstructFromConfig — node tools gating', () => {
 		builtAgent.hasCheckpointStorage.mockReturnValue(true);
 	});
 
-	function setup() {
+	function setup(options: { nodeToolsModuleEnabled?: boolean } = {}) {
 		const agentsToolsService = mock<AgentsToolsService>();
 		agentsToolsService.getRuntimeTools.mockReturnValue([] as BuiltTool[]);
 		const credentialProvider = mock<CredentialProvider>();
-		const service = makeService(agentsToolsService);
+		const service = makeService(
+			agentsToolsService,
+			options.nodeToolsModuleEnabled ? ['node-tools-searcher'] : [],
+		);
 		return { service, agentsToolsService, credentialProvider };
 	}
 
-	it('does not attach node tools when config.nodeTools is absent (default-off)', async () => {
-		const { service, agentsToolsService, credentialProvider } = setup();
-		const entity = makeAgentEntity(); // no config block at all
+	it.each([
+		{
+			name: 'config.nodeTools is absent and the module is disabled',
+			nodeToolsModuleEnabled: false,
+			schemaConfig: undefined,
+			attaches: false,
+		},
+		{
+			name: 'config.nodeTools is absent and the module is enabled',
+			nodeToolsModuleEnabled: true,
+			schemaConfig: undefined,
+			attaches: false,
+		},
+		{
+			name: 'config.nodeTools.enabled is true but the module is disabled',
+			nodeToolsModuleEnabled: false,
+			schemaConfig: { nodeTools: { enabled: true } },
+			attaches: false,
+		},
+		{
+			name: 'config.nodeTools.enabled is true and the module is enabled',
+			nodeToolsModuleEnabled: true,
+			schemaConfig: { nodeTools: { enabled: true } },
+			attaches: true,
+		},
+		{
+			name: 'config.nodeTools.enabled is false and the module is disabled',
+			nodeToolsModuleEnabled: false,
+			schemaConfig: { nodeTools: { enabled: false } },
+			attaches: false,
+		},
+		{
+			name: 'config.nodeTools.enabled is false and the module is enabled',
+			nodeToolsModuleEnabled: true,
+			schemaConfig: { nodeTools: { enabled: false } },
+			attaches: false,
+		},
+	])('$name', async ({ nodeToolsModuleEnabled, schemaConfig, attaches }) => {
+		const { service, agentsToolsService, credentialProvider } = setup({
+			nodeToolsModuleEnabled,
+		});
+		const entity = makeAgentEntity(schemaConfig);
 
 		await (service as unknown as Reconstructable).reconstructFromConfig(entity, credentialProvider);
 
-		expect(agentsToolsService.getRuntimeTools).not.toHaveBeenCalled();
-	});
-
-	it('attaches node tools when config.nodeTools.enabled is true', async () => {
-		const { service, agentsToolsService, credentialProvider } = setup();
-		const entity = makeAgentEntity({ nodeTools: { enabled: true } });
-
-		await (service as unknown as Reconstructable).reconstructFromConfig(entity, credentialProvider);
-
-		expect(agentsToolsService.getRuntimeTools).toHaveBeenCalledWith(
-			credentialProvider,
-			'project-1',
-		);
-	});
-
-	it('does not attach node tools when config.nodeTools.enabled is false', async () => {
-		const { service, agentsToolsService, credentialProvider } = setup();
-		const entity = makeAgentEntity({ nodeTools: { enabled: false } });
-
-		await (service as unknown as Reconstructable).reconstructFromConfig(entity, credentialProvider);
-
-		expect(agentsToolsService.getRuntimeTools).not.toHaveBeenCalled();
+		if (attaches) {
+			expect(agentsToolsService.getRuntimeTools).toHaveBeenCalledWith(
+				credentialProvider,
+				'project-1',
+			);
+		} else {
+			expect(agentsToolsService.getRuntimeTools).not.toHaveBeenCalled();
+		}
 	});
 });

--- a/packages/cli/src/modules/agents/__tests__/agents-service-sync.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-service-sync.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/require-await -- mock implementations kept async for future-proofing */
 import type { Logger } from '@n8n/backend-common';
+import type { AgentsConfig } from '@n8n/config';
 import type {
 	ExecutionRepository,
 	ProjectRelationRepository,
@@ -75,6 +76,7 @@ describe('AgentsService — updateName / updateDescription schema sync', () => {
 			mock(),
 			mock<AgentSkillsService>(),
 			mock(),
+			{ modules: [] } as unknown as AgentsConfig,
 			mock(),
 		);
 	});

--- a/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/require-await, @typescript-eslint/unbound-method, id-denylist -- async mock stubs, unbound-method references and short `cb` names are acceptable test idioms */
-import type { GlobalConfig } from '@n8n/config';
+import type { AgentsConfig, GlobalConfig } from '@n8n/config';
 import { Container } from '@n8n/di';
 import { DEFAULT_AGENT_SCHEDULE_WAKE_UP_PROMPT, type AgentIntegration } from '@n8n/api-types';
 import { mockLogger } from '@n8n/backend-test-utils';
@@ -76,6 +76,7 @@ describe('AgentsService', () => {
 	let agentExecutionService: jest.Mocked<AgentExecutionService>;
 	let scheduleService: jest.Mocked<AgentScheduleService>;
 	let publisher: jest.Mocked<Publisher>;
+	let agentsConfig: AgentsConfig;
 	let globalConfig: jest.Mocked<GlobalConfig>;
 
 	beforeEach(() => {
@@ -90,6 +91,7 @@ describe('AgentsService', () => {
 		scheduleService = mock<AgentScheduleService>();
 		publisher = mock<Publisher>();
 		publisher.publishCommand.mockResolvedValue();
+		agentsConfig = { modules: [] } as unknown as AgentsConfig;
 		globalConfig = mock<GlobalConfig>({
 			multiMainSetup: { enabled: false },
 		} as Partial<GlobalConfig>);
@@ -115,6 +117,7 @@ describe('AgentsService', () => {
 			agentPublishedVersionRepository,
 			new AgentSkillsService(logger, agentRepository),
 			publisher,
+			agentsConfig,
 			globalConfig,
 		);
 	});
@@ -156,6 +159,33 @@ describe('AgentsService', () => {
 			if (result.valid) return;
 
 			expect(result.error).toContain('inputSchema');
+		});
+
+		it('rejects config.nodeTools.enabled when the node tools module is disabled', async () => {
+			const result = await service.validateConfig({
+				name: 'Test Agent',
+				model: 'anthropic/claude-sonnet-4-5',
+				instructions: 'Help the user.',
+				config: { nodeTools: { enabled: true } },
+			});
+
+			expect(result.valid).toBe(false);
+			if (result.valid) return;
+
+			expect(result.error).toContain('node-tools-searcher');
+		});
+
+		it('allows config.nodeTools.enabled when the node tools module is enabled', async () => {
+			agentsConfig.modules = ['node-tools-searcher'] as unknown as AgentsConfig['modules'];
+
+			const result = await service.validateConfig({
+				name: 'Test Agent',
+				model: 'anthropic/claude-sonnet-4-5',
+				instructions: 'Help the user.',
+				config: { nodeTools: { enabled: true } },
+			});
+
+			expect(result.valid).toBe(true);
 		});
 	});
 

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -17,7 +17,7 @@ import {
 import * as agents from '@n8n/agents';
 import { extractFromAIParameters } from '@n8n/ai-utilities';
 import { Logger } from '@n8n/backend-common';
-import { GlobalConfig } from '@n8n/config';
+import { AgentsConfig, GlobalConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
 import {
 	CredentialsRepository,
@@ -258,8 +258,17 @@ export class AgentsService {
 		private readonly agentPublishedVersionRepository: AgentPublishedVersionRepository,
 		private readonly agentSkillsService: AgentSkillsService,
 		private readonly publisher: Publisher,
+		private readonly agentsConfig: AgentsConfig,
 		private readonly globalConfig: GlobalConfig,
 	) {}
+
+	private isNodeToolsModuleEnabled(): boolean {
+		return this.agentsConfig.modules.includes('node-tools-searcher');
+	}
+
+	private shouldAttachNodeTools(config: AgentJsonConfig['config']): boolean {
+		return this.isNodeToolsModuleEnabled() && isNodeToolsEnabled(config);
+	}
 
 	/**
 	 * Return the list of registered chat platform integrations with their
@@ -684,7 +693,7 @@ export class AgentsService {
 	 * `fromSchema()`, so this method only handles host-side singletons.
 	 *
 	 * `nodeToolsEnabled` comes from the agent's `config.nodeTools.enabled` flag
-	 * (opt-in, defaults to false) — see {@link isNodeToolsEnabled}.
+	 * (opt-in, defaults to false) — see {@link shouldAttachNodeTools}.
 	 */
 	private async injectRuntimeDependencies(params: InjectRuntimeDependenciesParams): Promise<void> {
 		const { agent, agentId, projectId, credentialProvider, nodeToolsEnabled, integrationType } =
@@ -1253,6 +1262,14 @@ export class AgentsService {
 
 		const config = parsed.data;
 
+		if (isNodeToolsEnabled(config.config) && !this.isNodeToolsModuleEnabled()) {
+			return {
+				valid: false,
+				error:
+					'config.nodeTools.enabled requires the node-tools-searcher agents module to be enabled.',
+			};
+		}
+
 		try {
 			this.validateNodeToolExpressions(config);
 		} catch (error) {
@@ -1715,7 +1732,7 @@ export class AgentsService {
 			agentId: agentEntity.id,
 			projectId: agentEntity.projectId,
 			credentialProvider,
-			nodeToolsEnabled: isNodeToolsEnabled(config.config),
+			nodeToolsEnabled: this.shouldAttachNodeTools(config.config),
 			integrationType,
 		});
 


### PR DESCRIPTION
## Summary

Gates the agent `config.nodeTools.enabled` flag behind the `node-tools-searcher` agents module being enabled. Previously, agents could opt into node tools via their config regardless of whether the supporting module was loaded; now `AgentsService` checks `agentsConfig.modules` before attaching runtime node tools and rejects validation of configs that enable node tools when the module is disabled.

**How to test:** Run `pnpm --filter=n8n test packages/cli/src/modules/agents/__tests__` — the updated unit tests cover the new gating matrix (module on/off × `nodeTools.enabled` on/off/absent) and the `validateConfig` rejection path.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Add Linear ticket URL here if applicable -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI