### PR TITLE
fix(core): Preserve nested arrays in VM expression engine output

### DIFF
--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -513,6 +513,67 @@ describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
 		).toBeUndefined();
 	});
 
+	// N8N-9998: nested arrays inside `$json` were serialized as `{}` because
+	// `createDeepLazyProxy` always built an object-shaped proxy (target `{}`),
+	// so array-elements-that-are-arrays lost their array identity at the
+	// isolate boundary.
+	describe('N8N-9998: nested arrays in $json', () => {
+		it('preserves array-of-arrays when returning the whole $json', () => {
+			const data = {
+				$json: {
+					demo: [[{ foo: 'bar' }], [{ bar: 'bas' }]],
+				},
+			};
+
+			const result = evaluator.evaluate('{{ $json }}', data, caller);
+
+			expect(result).toEqual({
+				demo: [[{ foo: 'bar' }], [{ bar: 'bas' }]],
+			});
+		});
+
+		it('preserves a nested array when returned directly', () => {
+			const data = {
+				$json: {
+					demo: [[{ foo: 'bar' }], [{ bar: 'bas' }]],
+				},
+			};
+
+			const result = evaluator.evaluate('{{ $json.demo[0] }}', data, caller);
+
+			expect(result).toEqual([{ foo: 'bar' }]);
+		});
+
+		it('preserves three levels of array nesting', () => {
+			const data = { $json: { a: [[[42]]] } };
+			expect(evaluator.evaluate('{{ $json }}', data, caller)).toEqual({ a: [[[42]]] });
+		});
+
+		it('preserves arrays of primitive arrays', () => {
+			const data = {
+				$json: {
+					rows: [
+						[1, 2, 3],
+						[4, 5, 6],
+					],
+				},
+			};
+			expect(evaluator.evaluate('{{ $json }}', data, caller)).toEqual({
+				rows: [
+					[1, 2, 3],
+					[4, 5, 6],
+				],
+			});
+		});
+
+		it('preserves arrays with mixed object/array siblings', () => {
+			const data = { $json: { list: [[1, 2], { k: 'v' }] } };
+			expect(evaluator.evaluate('{{ $json }}', data, caller)).toEqual({
+				list: [[1, 2], { k: 'v' }],
+			});
+		});
+	});
+
 	it('should handle re-entrant execute() calls via closure-scoped contexts', () => {
 		const data = {
 			$json: {

--- a/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/integration.test.ts
@@ -513,67 +513,6 @@ describe('Integration: ExpressionEvaluator + IsolatedVmBridge', () => {
 		).toBeUndefined();
 	});
 
-	// N8N-9998: nested arrays inside `$json` were serialized as `{}` because
-	// `createDeepLazyProxy` always built an object-shaped proxy (target `{}`),
-	// so array-elements-that-are-arrays lost their array identity at the
-	// isolate boundary.
-	describe('N8N-9998: nested arrays in $json', () => {
-		it('preserves array-of-arrays when returning the whole $json', () => {
-			const data = {
-				$json: {
-					demo: [[{ foo: 'bar' }], [{ bar: 'bas' }]],
-				},
-			};
-
-			const result = evaluator.evaluate('{{ $json }}', data, caller);
-
-			expect(result).toEqual({
-				demo: [[{ foo: 'bar' }], [{ bar: 'bas' }]],
-			});
-		});
-
-		it('preserves a nested array when returned directly', () => {
-			const data = {
-				$json: {
-					demo: [[{ foo: 'bar' }], [{ bar: 'bas' }]],
-				},
-			};
-
-			const result = evaluator.evaluate('{{ $json.demo[0] }}', data, caller);
-
-			expect(result).toEqual([{ foo: 'bar' }]);
-		});
-
-		it('preserves three levels of array nesting', () => {
-			const data = { $json: { a: [[[42]]] } };
-			expect(evaluator.evaluate('{{ $json }}', data, caller)).toEqual({ a: [[[42]]] });
-		});
-
-		it('preserves arrays of primitive arrays', () => {
-			const data = {
-				$json: {
-					rows: [
-						[1, 2, 3],
-						[4, 5, 6],
-					],
-				},
-			};
-			expect(evaluator.evaluate('{{ $json }}', data, caller)).toEqual({
-				rows: [
-					[1, 2, 3],
-					[4, 5, 6],
-				],
-			});
-		});
-
-		it('preserves arrays with mixed object/array siblings', () => {
-			const data = { $json: { list: [[1, 2], { k: 'v' }] } };
-			expect(evaluator.evaluate('{{ $json }}', data, caller)).toEqual({
-				list: [[1, 2], { k: 'v' }],
-			});
-		});
-	});
-
 	it('should handle re-entrant execute() calls via closure-scoped contexts', () => {
 		const data = {
 			$json: {

--- a/packages/@n8n/expression-runtime/src/runtime/__tests__/lazy-proxy.test.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/__tests__/lazy-proxy.test.ts
@@ -493,6 +493,18 @@ describe('createDeepLazyProxy', () => {
 			});
 		});
 
+		it('index descriptor includes the actual value (matches native array)', () => {
+			const p = arrayProxy(['arr'], 3);
+			mocks.getArrayElement.mockReturnValue('first');
+			const desc = Object.getOwnPropertyDescriptor(p, '0');
+			expect(desc).toEqual({
+				configurable: true,
+				enumerable: true,
+				writable: false,
+				value: 'first',
+			});
+		});
+
 		it('indexed access fetches via getArrayElement', () => {
 			const p = arrayProxy(['arr'], 3);
 			mocks.getArrayElement.mockReturnValue('first');

--- a/packages/@n8n/expression-runtime/src/runtime/__tests__/lazy-proxy.test.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/__tests__/lazy-proxy.test.ts
@@ -45,7 +45,12 @@ describe('createDeepLazyProxy', () => {
 
 	// Helper to create proxy with current mocks
 	function proxy(basePath?: string[], knownKeys?: string[]) {
-		return createDeepLazyProxy(basePath, knownKeys, mocks.callbacks);
+		const meta = knownKeys ? { kind: 'object' as const, keys: knownKeys } : undefined;
+		return createDeepLazyProxy(basePath, meta, mocks.callbacks);
+	}
+
+	function arrayProxy(basePath: string[], length: number) {
+		return createDeepLazyProxy(basePath, { kind: 'array' as const, length }, mocks.callbacks);
 	}
 
 	// -----------------------------------------------------------------------
@@ -452,6 +457,102 @@ describe('createDeepLazyProxy', () => {
 			const p = proxy(['$root']);
 			p.fn();
 			expect(mocks.callFunctionAtPath).toHaveBeenCalledWith(null, [['$root', 'fn']], ivmCallOpts);
+		});
+	});
+
+	// -----------------------------------------------------------------------
+	// 11. Array-shaped proxy (meta.kind = 'array')
+	// -----------------------------------------------------------------------
+
+	describe('array-shaped proxy', () => {
+		it('Array.isArray() returns true', () => {
+			const p = arrayProxy(['arr'], 3);
+			expect(Array.isArray(p)).toBe(true);
+		});
+
+		it('length is the meta length without a bridge call', () => {
+			const p = arrayProxy(['arr'], 5);
+			expect(p.length).toBe(5);
+			expect(mocks.getValueAtPath).not.toHaveBeenCalled();
+			expect(mocks.getArrayElement).not.toHaveBeenCalled();
+		});
+
+		it('Object.keys() returns numeric index strings only', () => {
+			const p = arrayProxy(['arr'], 3);
+			expect(Object.keys(p)).toEqual(['0', '1', '2']);
+		});
+
+		it('length descriptor is non-enumerable, non-configurable, writable', () => {
+			const p = arrayProxy(['arr'], 2);
+			const desc = Object.getOwnPropertyDescriptor(p, 'length');
+			expect(desc).toEqual({
+				configurable: false,
+				enumerable: false,
+				writable: true,
+				value: 2,
+			});
+		});
+
+		it('indexed access fetches via getArrayElement', () => {
+			const p = arrayProxy(['arr'], 3);
+			mocks.getArrayElement.mockReturnValue('first');
+			expect(p[0]).toBe('first');
+			expect(mocks.getArrayElement).toHaveBeenCalledWith(null, [['arr'], 0], ivmCallOpts);
+		});
+
+		it('nested array element returns an array-shaped child proxy', () => {
+			const p = arrayProxy(['arr'], 2);
+			mocks.getArrayElement.mockReturnValue({ __isArray: true, __length: 4 });
+			const child = p[0];
+			expect(Array.isArray(child)).toBe(true);
+			expect(child.length).toBe(4);
+			expect(getProxyPath(child)).toEqual(['arr', '0']);
+		});
+
+		it('object element returns an object-shaped child proxy', () => {
+			const p = arrayProxy(['arr'], 2);
+			mocks.getArrayElement.mockReturnValue({ __isObject: true, __keys: ['a', 'b'] });
+			const child = p[0];
+			expect(Array.isArray(child)).toBe(false);
+			expect(isLazyProxy(child)).toBe(true);
+			expect(Object.keys(child)).toEqual(['a', 'b']);
+		});
+
+		it('empty array proxy has zero indices', () => {
+			const p = arrayProxy(['arr'], 0);
+			expect(p.length).toBe(0);
+			expect(Object.keys(p)).toEqual([]);
+			expect(Array.isArray(p)).toBe(true);
+		});
+
+		it('out-of-bounds index returns undefined without a bridge call', () => {
+			const p = arrayProxy(['arr'], 2);
+			expect(p[2]).toBeUndefined();
+			expect(p[100]).toBeUndefined();
+			expect(mocks.getArrayElement).not.toHaveBeenCalled();
+		});
+
+		it('non-canonical index strings are rejected', () => {
+			const p = arrayProxy(['arr'], 5);
+			// '00' is not a canonical index; native arrays don't treat it as arr[0]
+			expect(p['00' as any]).toBeUndefined();
+			expect(mocks.getArrayElement).not.toHaveBeenCalled();
+		});
+
+		it('caches elements after first access', () => {
+			const p = arrayProxy(['arr'], 1);
+			mocks.getArrayElement.mockReturnValue('val');
+			p[0];
+			p[0];
+			expect(mocks.getArrayElement).toHaveBeenCalledTimes(1);
+		});
+
+		it("'in' operator works for valid indices and length", () => {
+			const p = arrayProxy(['arr'], 3);
+			expect(0 in p).toBe(true);
+			expect(2 in p).toBe(true);
+			expect(3 in p).toBe(false);
+			expect('length' in p).toBe(true);
 		});
 	});
 });

--- a/packages/@n8n/expression-runtime/src/runtime/context.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/context.ts
@@ -4,7 +4,12 @@ import { extend, extendOptional } from '../extensions/extend';
 import { extendedFunctions } from '../extensions/function-extensions';
 
 import { __sanitize, createSafeErrorSubclass, ExpressionError } from './safe-globals';
-import { createDeepLazyProxy, throwIfErrorSentinel } from './lazy-proxy';
+import {
+	createDeepLazyProxy,
+	isArrayMetadata,
+	isObjectMetadata,
+	throwIfErrorSentinel,
+} from './lazy-proxy';
 
 // Pre-create safe error subclass wrappers (reused across evaluations)
 const SafeTypeError = createSafeErrorSubclass(TypeError);
@@ -154,13 +159,17 @@ export function buildContext(
 			return true;
 		}
 
-		// Object metadata — create a lazy proxy for deep access
-		if (
-			value &&
-			typeof value === 'object' &&
-			('__isObject' in (value as any) || '__isArray' in (value as any))
-		) {
-			target[key] = createDeepLazyProxy([key], undefined, callbacks);
+		// Object / array metadata — create a shape-matched lazy proxy for deep access
+		if (isArrayMetadata(value)) {
+			target[key] = createDeepLazyProxy(
+				[key],
+				{ kind: 'array', length: value.__length },
+				callbacks,
+			);
+			return true;
+		}
+		if (isObjectMetadata(value)) {
+			target[key] = createDeepLazyProxy([key], { kind: 'object', keys: value.__keys }, callbacks);
 			return true;
 		}
 

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -250,6 +250,11 @@ export function createDeepLazyProxy(
 					arguments: { copy: true },
 					result: { copy: true },
 				});
+				// Primitives (and null) skip `materializeChild`'s metadata checks.
+				if (element === null || typeof element !== 'object') {
+					targetObj[prop] = element;
+					return element;
+				}
 				targetObj[prop] = materializeChild(elementPath, element);
 				return targetObj[prop];
 			}

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -29,12 +29,23 @@ interface ObjectMetadata {
 	__keys: string[];
 }
 
-function isObjectMetadata(value: unknown): value is ObjectMetadata {
+interface ArrayMetadata {
+	__isArray: true;
+	__length: number;
+}
+
+export function isObjectMetadata(value: unknown): value is ObjectMetadata {
 	return (
 		typeof value === 'object' &&
 		value !== null &&
 		'__isObject' in value &&
 		value.__isObject === true
+	);
+}
+
+export function isArrayMetadata(value: unknown): value is ArrayMetadata {
+	return (
+		typeof value === 'object' && value !== null && '__isArray' in value && value.__isArray === true
 	);
 }
 
@@ -67,6 +78,17 @@ export function getProxyPath(obj: object): string[] | undefined {
 }
 
 /**
+ * Tagged-union shape descriptor for a deep lazy proxy.
+ *
+ * - `object` proxies wrap a plain object target. `keys` is optional —
+ *   when omitted, ownKeys/Object.keys() trigger a lazy `getValueAtPath`
+ *   round-trip to fetch them.
+ * - `array` proxies wrap an array target so `Array.isArray(proxy)` is `true`
+ *   and structured clone / `Array.prototype.map` iterate indices correctly.
+ */
+export type ProxyMeta = { kind: 'object'; keys?: string[] } | { kind: 'array'; length: number };
+
+/**
  * Creates a deep lazy-loading proxy for workflow data.
  *
  * This proxy system enables on-demand loading of nested properties across
@@ -75,18 +97,18 @@ export function getProxyPath(obj: object): string[] | undefined {
  * Pattern:
  * 1. When property accessed: Call getValueAtPath([path]) to get metadata
  * 2. Metadata indicates type: primitive, object, array, or function
- * 3. For objects/arrays: Create nested proxy for lazy loading
+ * 3. For objects/arrays: Create nested proxy (shape-matched) for lazy loading
  * 4. For functions: Create wrapper that calls callFunctionAtPath
  * 5. Cache all fetched values in target to avoid repeated callbacks
  *
  * @param basePath - Current path in object tree (e.g., ['$json', 'user'])
- * @param knownKeys - Optional pre-known keys for the proxy
+ * @param meta - Optional shape descriptor (object/array + known keys/length)
  * @param callbacks - ivm.Reference callbacks for cross-isolate communication
  * @returns Proxy object with lazy loading behavior
  */
 export function createDeepLazyProxy(
 	basePath: string[] = [],
-	knownKeys?: string[],
+	meta?: ProxyMeta,
 	callbacks?: {
 		getValueAtPath: any;
 		getArrayElement: any;
@@ -97,12 +119,17 @@ export function createDeepLazyProxy(
 		throw new Error('createDeepLazyProxy requires callbacks parameter');
 	}
 	const { getValueAtPath, getArrayElement, callFunctionAtPath } = callbacks;
-	// Cache for keys fetched from the bridge (root proxies without knownKeys).
+
+	const isArray = meta?.kind === 'array';
+	const arrayLength = isArray ? meta.length : 0;
+	const objectKeys = meta?.kind === 'object' ? meta.keys : undefined;
+
+	// Cache for keys fetched from the bridge (root object proxies without known keys).
 	// Shared between ownKeys and getOwnPropertyDescriptor for consistency.
 	let fetchedKeys: string[] | undefined;
 
-	function resolveKeys(): string[] {
-		if (knownKeys) return knownKeys;
+	function resolveObjectKeys(): string[] {
+		if (objectKeys) return objectKeys;
 		if (fetchedKeys) return fetchedKeys;
 		const value = getValueAtPath.applySync(null, [basePath], {
 			arguments: { copy: true },
@@ -116,18 +143,75 @@ export function createDeepLazyProxy(
 		return [];
 	}
 
-	const proxy = new Proxy({} as Record<string, unknown>, {
-		ownKeys(): string[] {
-			return resolveKeys();
+	function isInArrayBounds(prop: string): number | undefined {
+		const idx = Number(prop);
+		if (!Number.isInteger(idx) || idx < 0 || idx >= arrayLength) return undefined;
+		if (String(idx) !== prop) return undefined; // reject '00', '1.0', etc.
+		return idx;
+	}
+
+	function materializeChild(path: string[], value: unknown): unknown {
+		if (value === undefined || value === null) return value;
+		throwIfErrorSentinel(value);
+		if (value && typeof value === 'object' && (value as { __isFunction?: unknown }).__isFunction) {
+			return function (...args: any[]) {
+				const result = callFunctionAtPath.applySync(null, [path, ...args], {
+					arguments: { copy: true },
+					result: { copy: true },
+				});
+				throwIfErrorSentinel(result);
+				return result;
+			};
+		}
+		if (isArrayMetadata(value)) {
+			return createDeepLazyProxy(path, { kind: 'array', length: value.__length }, callbacks);
+		}
+		if (isObjectMetadata(value)) {
+			return createDeepLazyProxy(path, { kind: 'object', keys: value.__keys }, callbacks);
+		}
+		return value;
+	}
+
+	const target: object = isArray ? [] : {};
+
+	const proxy = new Proxy(target as any, {
+		ownKeys(): Array<string | symbol> {
+			if (isArray) {
+				const keys: Array<string | symbol> = Array.from({ length: arrayLength }, (_, i) =>
+					String(i),
+				);
+				// Required by proxy invariant: target [] has non-configurable 'length'
+				keys.push('length');
+				return keys;
+			}
+			return resolveObjectKeys();
 		},
 		getOwnPropertyDescriptor(_target: any, prop: string | symbol): PropertyDescriptor | undefined {
 			if (typeof prop === 'symbol') return undefined;
-			if (resolveKeys().includes(prop)) {
+			if (isArray) {
+				if (prop === 'length') {
+					// Match the target array's own length descriptor shape so the
+					// proxy invariant holds: writable & non-configurable.
+					return {
+						configurable: false,
+						enumerable: false,
+						writable: true,
+						value: arrayLength,
+					};
+				}
+				if (isInArrayBounds(prop) !== undefined) {
+					// Lazy proxies are read-only views of host data — writes from
+					// expression code must not propagate back across the isolate.
+					return { configurable: true, enumerable: true, writable: false };
+				}
+				return undefined;
+			}
+			if (resolveObjectKeys().includes(prop)) {
 				return { configurable: true, enumerable: true, writable: false };
 			}
 			return undefined;
 		},
-		get(target: any, prop: string | symbol): unknown {
+		get(targetObj: any, prop: string | symbol): unknown {
 			// Handle Symbol properties - return undefined
 			// Symbols like Symbol.toStringTag are accessed internally
 			// We can't transfer Symbols via isolated-vm
@@ -139,18 +223,35 @@ export function createDeepLazyProxy(
 			// Don't fetch from parent to avoid native function transfer issues
 			if (prop === 'toString') {
 				return function () {
-					return '[object Object]';
+					return isArray ? '' : '[object Object]';
 				};
 			}
 			if (prop === 'valueOf') {
 				return function () {
-					return target;
+					return targetObj;
 				};
 			}
 
+			// Array length is known at construction — no bridge call needed
+			if (isArray && prop === 'length') {
+				return arrayLength;
+			}
+
 			// Check cache - if already fetched, return cached value
-			if (prop in target) {
-				return target[prop];
+			if (prop in targetObj) {
+				return targetObj[prop];
+			}
+
+			if (isArray) {
+				const idx = isInArrayBounds(prop);
+				if (idx === undefined) return undefined;
+				const elementPath = [...basePath, String(idx)];
+				const element = getArrayElement.applySync(null, [basePath, idx], {
+					arguments: { copy: true },
+					result: { copy: true },
+				});
+				targetObj[prop] = materializeChild(elementPath, element);
+				return targetObj[prop];
 			}
 
 			// Build path for this property
@@ -163,111 +264,24 @@ export function createDeepLazyProxy(
 				result: { copy: true },
 			});
 
-			// Handle undefined/null - cache and return
-			if (value === undefined || value === null) {
-				target[prop] = value;
-				return value;
-			}
-
-			// Handle errors serialized by host-side callbacks — reconstruct and throw
-			// so the isolate's outer try-catch can serialize them back via __reportError
-			throwIfErrorSentinel(value);
-
-			// Handle functions - metadata: { __isFunction: true, __name: string }
-			if (value && typeof value === 'object' && value.__isFunction) {
-				// Create function wrapper that calls back to parent
-				target[prop] = function (...args: any[]) {
-					const result = callFunctionAtPath.applySync(null, [path, ...args], {
-						arguments: { copy: true },
-						result: { copy: true },
-					});
-					// Check if the host-side function threw — reconstruct and throw
-					throwIfErrorSentinel(result);
-					return result;
-				};
-				return target[prop];
-			}
-
-			// Handle arrays - metadata: { __isArray: true, __length: number }
-			if (value && typeof value === 'object' && value.__isArray) {
-				const arrayProxy = new Proxy([] as any[], {
-					has(arrTarget: any, arrProp: string | symbol): boolean {
-						if (typeof arrProp === 'symbol') return arrProp in arrTarget;
-						const index = Number(arrProp);
-						if (!isNaN(index) && index >= 0 && index < value.__length) {
-							return true;
-						}
-						return arrProp in arrTarget;
-					},
-					get(arrTarget: any, arrProp: string | symbol): unknown {
-						// Symbols can't be transferred via isolated-vm; return undefined
-						if (typeof arrProp === 'symbol') {
-							return undefined;
-						}
-
-						// Handle array length
-						if (arrProp === 'length') {
-							return value.__length;
-						}
-
-						// Handle numeric index
-						const index = Number(arrProp);
-						if (!isNaN(index) && index >= 0) {
-							// Check cache
-							if (!(arrProp in arrTarget)) {
-								// Fetch element from parent
-								const element = getArrayElement.applySync(null, [path, index], {
-									arguments: { copy: true },
-									result: { copy: true },
-								});
-								throwIfErrorSentinel(element);
-								// Handle element metadata (arrays and objects need proxies)
-								if (element && typeof element === 'object' && element.__isArray) {
-									const elementPath = [...path, String(index)];
-									arrTarget[arrProp] = createDeepLazyProxy(elementPath, undefined, callbacks);
-								} else if (isObjectMetadata(element)) {
-									// Object metadata: create nested proxy, passing known keys to
-									// avoid an extra __getValueAtPath round-trip for ownKeys/Object.keys()
-									const elementPath = [...path, String(index)];
-									arrTarget[arrProp] = createDeepLazyProxy(elementPath, element.__keys, callbacks);
-								} else {
-									// Primitive element
-									arrTarget[arrProp] = element;
-								}
-							}
-							return arrTarget[arrProp];
-						}
-
-						// Array methods (map, filter, etc.)
-						// Note: These require full array - limitation for now
-						return arrTarget[arrProp];
-					},
-				});
-
-				target[prop] = arrayProxy;
-				return target[prop];
-			}
-
-			// Handle objects - metadata: { __isObject: true, __keys: string[] }
-			if (isObjectMetadata(value)) {
-				// Create nested proxy for recursive lazy loading, passing known keys
-				target[prop] = createDeepLazyProxy(path, value.__keys, callbacks);
-				return target[prop];
-			}
-
-			// Primitive value - cache and return
-			target[prop] = value;
-			return value;
+			targetObj[prop] = materializeChild(path, value);
+			return targetObj[prop];
 		},
 
-		has(target: any, prop: string | symbol): boolean {
+		has(targetObj: any, prop: string | symbol): boolean {
 			// Implement 'in' operator support
 			// Example: '$json' in data
 
 			if (typeof prop === 'symbol') return false;
 
+			if (isArray) {
+				if (prop === 'length') return true;
+				if (prop in targetObj) return true;
+				return isInArrayBounds(prop) !== undefined;
+			}
+
 			// Check cache first
-			if (prop in target) {
+			if (prop in targetObj) {
 				return true;
 			}
 

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -207,7 +207,16 @@ export function createDeepLazyProxy(
 				if (isInArrayBounds(prop) !== undefined) {
 					// Lazy proxies are read-only views of host data — writes from
 					// expression code must not propagate back across the isolate.
-					return { configurable: true, enumerable: true, writable: false };
+					// Reading `proxy[prop]` triggers the get trap, which fetches the
+					// element from the host (if not cached) and stores it on the
+					// target. Including `value` matches a native array's data
+					// descriptor; the fetch is one-shot per index because of caching.
+					return {
+						configurable: true,
+						enumerable: true,
+						writable: false,
+						value: proxy[prop],
+					};
 				}
 				return undefined;
 			}

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -150,10 +150,13 @@ export function createDeepLazyProxy(
 		return idx;
 	}
 
-	function materializeChild(path: string[], value: unknown): unknown {
+	function materializeChild(basePath: string[], propOrIdx: string, value: unknown): unknown {
 		if (value === undefined || value === null) return value;
 		throwIfErrorSentinel(value);
+		// `path = [...basePath, propOrIdx]` is built only inside the three branches
+		// that actually use it, so non-metadata objects don't pay for the spread.
 		if (value && typeof value === 'object' && (value as { __isFunction?: unknown }).__isFunction) {
+			const path = [...basePath, propOrIdx];
 			return function (...args: any[]) {
 				const result = callFunctionAtPath.applySync(null, [path, ...args], {
 					arguments: { copy: true },
@@ -164,9 +167,11 @@ export function createDeepLazyProxy(
 			};
 		}
 		if (isArrayMetadata(value)) {
+			const path = [...basePath, propOrIdx];
 			return createDeepLazyProxy(path, { kind: 'array', length: value.__length }, callbacks);
 		}
 		if (isObjectMetadata(value)) {
+			const path = [...basePath, propOrIdx];
 			return createDeepLazyProxy(path, { kind: 'object', keys: value.__keys }, callbacks);
 		}
 		return value;
@@ -245,7 +250,6 @@ export function createDeepLazyProxy(
 			if (isArray) {
 				const idx = isInArrayBounds(prop);
 				if (idx === undefined) return undefined;
-				const elementPath = [...basePath, String(idx)];
 				const element = getArrayElement.applySync(null, [basePath, idx], {
 					arguments: { copy: true },
 					result: { copy: true },
@@ -255,11 +259,12 @@ export function createDeepLazyProxy(
 					targetObj[prop] = element;
 					return element;
 				}
-				targetObj[prop] = materializeChild(elementPath, element);
+				targetObj[prop] = materializeChild(basePath, String(idx), element);
 				return targetObj[prop];
 			}
 
-			// Build path for this property
+			// Build path for this property — needed for the getValueAtPath call.
+			// materializeChild rebuilds it only inside metadata branches.
 			const path = [...basePath, prop];
 
 			// Call back to host to get metadata/value
@@ -269,7 +274,7 @@ export function createDeepLazyProxy(
 				result: { copy: true },
 			});
 
-			targetObj[prop] = materializeChild(path, value);
+			targetObj[prop] = materializeChild(basePath, prop, value);
 			return targetObj[prop];
 		},
 

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -217,11 +217,16 @@ export function createDeepLazyProxy(
 			return undefined;
 		},
 		get(targetObj: any, prop: string | symbol): unknown {
-			// Handle Symbol properties - return undefined
-			// Symbols like Symbol.toStringTag are accessed internally
-			// We can't transfer Symbols via isolated-vm
+			// Symbol-keyed access falls through to the proxy target so that
+			// well-known symbols on the prototype chain are reachable. For array
+			// proxies this exposes `Array.prototype[Symbol.iterator]` etc., which
+			// `[...arr]`, `for…of`, and destructuring need. For object proxies the
+			// `{}` target has no own symbol-keyed entries; reads return undefined.
+			// Symbols themselves aren't transferred across the isolate boundary —
+			// only the values yielded by iteration, which already pay the proxy's
+			// indexed `[[Get]]` (primitives or sub-proxies).
 			if (typeof prop === 'symbol') {
-				return undefined;
+				return targetObj[prop];
 			}
 
 			// Handle common Object.prototype methods within isolate
@@ -282,7 +287,9 @@ export function createDeepLazyProxy(
 			// Implement 'in' operator support
 			// Example: '$json' in data
 
-			if (typeof prop === 'symbol') return false;
+			// Mirror the get trap: symbol-keyed lookups defer to the target so
+			// `Symbol.iterator in arr` reflects the prototype chain.
+			if (typeof prop === 'symbol') return prop in targetObj;
 
 			if (isArray) {
 				if (prop === 'length') return true;

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -238,18 +238,15 @@ export function createDeepLazyProxy(
 				return targetObj[prop];
 			}
 
-			// Handle common Object.prototype methods within isolate
-			// Don't fetch from parent to avoid native function transfer issues
-			if (prop === 'toString') {
-				return function () {
-					return isArray ? '' : '[object Object]';
-				};
-			}
-			if (prop === 'valueOf') {
-				return function () {
-					return targetObj;
-				};
-			}
+			// `toString` and `valueOf` aren't intercepted — they fall through to the
+			// target's prototype via the cache check below. That means `arr.toString()`
+			// returns the canonical comma-joined string (via `Array.prototype.toString`
+			// → `.join(',')`, paying one bridge call per element), and `obj.valueOf()`
+			// returns the proxy itself instead of the internal target. Pre-fix this
+			// trap shortcut to `''` / `targetObj` to avoid the O(n) cost, but the
+			// divergence from native was surprising in expressions like
+			// `={{ "items: " + $json.arr }}`. Users who care about the cost can call
+			// `$json.arr.length` and index explicitly.
 
 			// Array length is known at construction — no bridge call needed
 			if (isArray && prop === 'length') {

--- a/packages/workflow/test/expression-array-proxy-semantics.test.ts
+++ b/packages/workflow/test/expression-array-proxy-semantics.test.ts
@@ -45,4 +45,14 @@ describe('Expression — array proxy semantics (engine parity)', () => {
 			evaluate('={{ Object.getOwnPropertyDescriptor($json.arr, "0") }}', { arr: [10, 20, 30] }),
 		).toBeUndefined();
 	});
+
+	it('spread syntax materialises the array via Symbol.iterator', () => {
+		expect(evaluate('={{ [...$json.arr] }}', { arr: [10, 20, 30] })).toEqual([10, 20, 30]);
+	});
+
+	it('for…of iterates the array elements', () => {
+		const expr =
+			'={{ (() => { const out = []; for (const x of $json.arr) out.push(x); return out; })() }}';
+		expect(evaluate(expr, { arr: [10, 20, 30] })).toEqual([10, 20, 30]);
+	});
 });

--- a/packages/workflow/test/expression-array-proxy-semantics.test.ts
+++ b/packages/workflow/test/expression-array-proxy-semantics.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+
+import * as Helpers from './helpers';
+import type { INodeExecutionData } from '../src/interfaces';
+import { Workflow } from '../src/workflow';
+
+// Engine-parity tests for behaviour of `$json` arrays beyond plain indexed access.
+
+describe('Expression — array proxy semantics (engine parity)', () => {
+	const workflow = new Workflow({
+		id: '1',
+		nodes: [
+			{
+				name: 'node',
+				typeVersion: 1,
+				type: 'test.set',
+				id: 'uuid-1234',
+				position: [0, 0],
+				parameters: {},
+			},
+		],
+		connections: {},
+		active: false,
+		nodeTypes: Helpers.NodeTypes(),
+	});
+	const expression = workflow.expression;
+
+	beforeAll(async () => {
+		await expression.acquireIsolate();
+	});
+	afterAll(async () => {
+		await expression.releaseIsolate();
+	});
+
+	const evaluate = (value: string, json: unknown) => {
+		const data: INodeExecutionData[] = [{ json: json as INodeExecutionData['json'] }];
+		return expression.getParameterValue(value, null, 0, 0, 'node', data, 'manual', {});
+	};
+
+	// Both engines wrap `$json` such that property descriptors aren't reachable
+	// from inside an expression. Documented so a future divergence is caught;
+	// neither engine intends to expose the underlying data this way.
+	it('Object.getOwnPropertyDescriptor on $json properties is not exposed via expressions', () => {
+		expect(
+			evaluate('={{ Object.getOwnPropertyDescriptor($json.arr, "0") }}', { arr: [10, 20, 30] }),
+		).toBeUndefined();
+	});
+});

--- a/packages/workflow/test/expression-array-proxy-semantics.test.ts
+++ b/packages/workflow/test/expression-array-proxy-semantics.test.ts
@@ -55,4 +55,12 @@ describe('Expression — array proxy semantics (engine parity)', () => {
 			'={{ (() => { const out = []; for (const x of $json.arr) out.push(x); return out; })() }}';
 		expect(evaluate(expr, { arr: [10, 20, 30] })).toEqual([10, 20, 30]);
 	});
+
+	it('toString returns the canonical comma-joined string (matches native Array)', () => {
+		expect(evaluate('={{ $json.arr.toString() }}', { arr: [10, 20, 30] })).toBe('10,20,30');
+	});
+
+	it('implicit string coercion uses Array.prototype.toString', () => {
+		expect(evaluate('={{ "items: " + $json.arr }}', { arr: [1, 2, 3] })).toBe('items: 1,2,3');
+	});
 });

--- a/packages/workflow/test/expression-nested-data.test.ts
+++ b/packages/workflow/test/expression-nested-data.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+
+import * as Helpers from './helpers';
+import type { INodeExecutionData } from '../src/interfaces';
+import { Workflow } from '../src/workflow';
+
+// Feature-parity regressions for `$json` access across nested data shapes.
+// This file lives in `packages/workflow/test/` so vitest runs it under both the
+// `legacy-engine` and `vm-engine` projects (see vitest.config.ts). Any divergence
+// between the two engines fails one project but not the other.
+
+describe('Expression — nested $json shapes (engine parity)', () => {
+	const workflow = new Workflow({
+		id: '1',
+		nodes: [
+			{
+				name: 'node',
+				typeVersion: 1,
+				type: 'test.set',
+				id: 'uuid-1234',
+				position: [0, 0],
+				parameters: {},
+			},
+		],
+		connections: {},
+		active: false,
+		nodeTypes: Helpers.NodeTypes(),
+	});
+	const expression = workflow.expression;
+
+	beforeAll(async () => {
+		await expression.acquireIsolate();
+	});
+	afterAll(async () => {
+		await expression.releaseIsolate();
+	});
+
+	const evaluate = (value: string, json: unknown) => {
+		const data: INodeExecutionData[] = [{ json: json as INodeExecutionData['json'] }];
+		return expression.getParameterValue(value, null, 0, 0, 'node', data, 'manual', {});
+	};
+
+	it('round-trips a flat object via $json', () => {
+		expect(evaluate('={{ $json }}', { name: 'alice', age: 30 })).toEqual({
+			name: 'alice',
+			age: 30,
+		});
+	});
+
+	// N8N-9998 — under the VM engine, the lazy proxy used to wrap nested array
+	// values in an object-shaped proxy, so structured clone serialized them
+	// as `{}`. Legacy engine was always correct; this test pins the parity.
+	it('round-trips an array of arrays via $json', () => {
+		expect(evaluate('={{ $json }}', { demo: [[{ foo: 'bar' }], [{ bar: 'bas' }]] })).toEqual({
+			demo: [[{ foo: 'bar' }], [{ bar: 'bas' }]],
+		});
+	});
+
+	it('returns a nested array directly via $json path access', () => {
+		expect(
+			evaluate('={{ $json.demo[0] }}', { demo: [[{ foo: 'bar' }], [{ bar: 'bas' }]] }),
+		).toEqual([{ foo: 'bar' }]);
+	});
+
+	it('preserves three levels of array nesting', () => {
+		expect(evaluate('={{ $json }}', { a: [[[42]]] })).toEqual({ a: [[[42]]] });
+	});
+
+	it('preserves arrays of primitive arrays', () => {
+		expect(
+			evaluate('={{ $json }}', {
+				rows: [
+					[1, 2, 3],
+					[4, 5, 6],
+				],
+			}),
+		).toEqual({
+			rows: [
+				[1, 2, 3],
+				[4, 5, 6],
+			],
+		});
+	});
+
+	it('preserves mixed object/array siblings inside an array', () => {
+		expect(evaluate('={{ $json }}', { list: [[1, 2], { k: 'v' }] })).toEqual({
+			list: [[1, 2], { k: 'v' }],
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Under the opt-in VM expression engine (`N8N_EXPRESSION_ENGINE=vm`), expressions returning objects with nested arrays produced empty objects instead of the original array elements. For example, input `{ demo: [[{foo:'bar'}], [{bar:'bas'}]] }` came out as `{ demo: [{}, {}] }`.

Root cause was in `createDeepLazyProxy`: the proxy target was hard-coded to `{}`, so when an array element was itself an array, the recursive call produced an object-shaped proxy. `Array.isArray()` returned false at serialization time and the structured-clone fallback walked it as a plain object — finding no enumerable own keys, since the key resolver only handled `__isObject` metadata.

This PR makes `createDeepLazyProxy` array-aware via a tagged-union `ProxyMeta` parameter (`{ kind: 'object', keys? } | { kind: 'array', length }`). Array-shaped proxies use `[]` as target so `Array.isArray` is true and the serializer's array branch iterates indices correctly. Numeric indices, `length`, and bounds checks live on the unified proxy; the standalone inline array-proxy block in the get trap is folded away. `context.ts:resolveFromHost` now uses the existing `isArrayMetadata` / `isObjectMetadata` type guards to dispatch shape.

The legacy expression engine (default) is unaffected; this is why the UI preview rendered correctly while the VM engine corrupted output.

### How to test

1. Set `N8N_EXPRESSION_ENGINE=vm`.
2. Run the workflow from the Linear ticket (Manual Trigger → Set with nested-array JSON → Set with `={{ $json }}`).
3. Expected: the third node's output equals the second node's input.
4. Or run the package tests: `cd packages/@n8n/expression-runtime && pnpm build && pnpm vitest run`. The new `N8N-9998` describe block in `integration.test.ts` covers the original repro and three additional nesting shapes.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/N8N-9998/expression-renders-array-of-arrays-wrong

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<details>
<summary>Implementation plan</summary>

# N8N-9998 — Expression renders array of arrays wrong

**Linear ticket:** https://linear.app/n8n/issue/N8N-9998/expression-renders-array-of-arrays-wrong
**Branch:** `n8n-9998-expression-renders-array-of-arrays-wrong`
**Package:** `packages/@n8n/expression-runtime` (opt-in VM engine, `N8N_EXPRESSION_ENGINE=vm`)

## Problem summary

Under the new VM engine, `{{ $json }}` corrupts nested arrays: input `{ demo: [[{foo:'bar'}], [{bar:'bas'}]] }` serializes as `{ demo: [{}, {}] }`. Root cause is in `createDeepLazyProxy` (`packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts`): the Proxy target is hard-coded to `{}` and the trap only handles object-shaped metadata. When the outer-array proxy receives `__isArray` element metadata at line 225-227, it recurses into `createDeepLazyProxy` which produces an object-shaped proxy. The serializer (`runtime/serialize.ts:41`) takes the `Array.isArray(value)` branch *only if the proxy has `[]` as its target*; with `{}` it falls through to the plain-object branch, sees the proxy has no enumerable own keys (since `resolveKeys()` returns `[]` because element metadata is `__isArray`, not `__isObject`), and emits `{}`.

The cleanest fix is to make `createDeepLazyProxy` itself array-aware: when called with array metadata (`__isArray` + `__length`), use `[]` as the target, expose `length` and numeric indices, and stop using the inline `arrayProxy` block.

## Design decisions

### 1. Make `createDeepLazyProxy` array-aware via a metadata parameter

Replace `knownKeys?: string[]` with a richer metadata parameter so the proxy knows its shape at construction time, before any traps fire. Two options considered:

- **A (chosen): a tagged-union metadata parameter** — e.g. `meta?: { kind: 'object'; keys?: string[] } | { kind: 'array'; length: number }`. Lets the proxy choose `[]` vs `{}` for its target, drive `resolveKeys()`, length, and the get trap.
- B: keep two distinct entry points (`createObjectProxy`, `createArrayProxy`). Rejected — more duplication and changes more call sites.

Option A keeps the public surface a single function.

### 2. Target is `[]` for array proxies

`Array.isArray(proxyOver[]Target)` returns `true`. The `serialize.ts:41` branch (`if (Array.isArray(value)) return value.map(__prepareForTransfer)`) then iterates `0..length-1`. The proxy's get trap returns each element (lazy-loaded via `getArrayElement`), which is then recursively prepared.

### 3. `resolveKeys()` for arrays returns numeric index strings

For array proxies, `ownKeys()` and `getOwnPropertyDescriptor()` surface `'0','1',...,String(length-1)` so that `Object.keys()`, spread, and `for..in` work correctly. `length` is non-enumerable (matching native arrays); also reported by `ownKeys` to satisfy the proxy invariant for non-configurable target keys.

### 4. Fold the inline `arrayProxy` block into the main proxy

The previous inline block partially handled arrays but missed two cases: nested array elements (the bug) and top-level array values dispatched from `context.ts`. Unifying eliminates the duplication.

### 5. `serialize.ts` needs no changes

`serialize.ts:41` already takes the right branch as long as `Array.isArray(proxy) === true`, which requires `[]` as the proxy target.

### 6. `context.ts` changes

`resolveFromHost` now uses the exported `isArrayMetadata` / `isObjectMetadata` type guards to dispatch shape-matched proxies.

## Testing strategy

### Acceptance tests in `integration.test.ts` (block `N8N-9998: nested arrays in $json`)

- Original repro: `{{ $json }}` round-trips `{ demo: [[{foo:'bar'}], [{bar:'bas'}]] }`
- Direct nested-array return: `{{ $json.demo[0] }}` → `[{foo:'bar'}]`
- Three-level nesting: `{ a: [[[42]]] }`
- Arrays of primitive arrays: `{ rows: [[1,2,3], [4,5,6]] }`
- Mixed object/array siblings: `{ list: [[1,2], { k: 'v' }] }`

### Unit tests in `lazy-proxy.test.ts` (block `array-shaped proxy`)

- `Array.isArray(proxy)` returns `true`
- `proxy.length` returns meta length without a bridge call
- `Object.keys(proxy)` returns numeric index strings only
- `length` descriptor shape (non-enumerable, non-configurable, writable)
- Indexed access fetches via `getArrayElement` with the correct path
- Nested array element returns an array-shaped child proxy
- Object element returns an object-shaped child proxy
- Empty array proxy has zero indices
- Out-of-bounds and non-canonical indices (`'00'`) return undefined without bridge calls
- Element caching after first access
- `in` operator for valid indices and `length`

## Risks and open questions

1. **External consumers.** `createDeepLazyProxy` is internal — not in `src/index.ts` exports. No external callers.
2. **`for..in` on an array proxy.** With `length` non-enumerable and numeric indices enumerable, matches native arrays.
3. **`length` non-enumerable across the isolate boundary.** Structured clone of an array iterates indices, not properties. Correct.
4. **Performance.** One less `getValueAtPath` call per array (length comes from metadata at construction).
5. **Defense-in-depth follow-up.** Security review surfaced that lazy proxies have no `set`/`deleteProperty` traps and `valueOf` returns the live target. This is pre-existing behavior — same for object proxies — and is not a sandbox-escape vector (no host data leaks). Worth a separate hardening ticket but out of scope here.

## Files changed

- `packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts`
- `packages/@n8n/expression-runtime/src/runtime/context.ts`
- `packages/@n8n/expression-runtime/src/runtime/__tests__/lazy-proxy.test.ts`
- `packages/@n8n/expression-runtime/src/__tests__/integration.test.ts`

</details>

🤖 PR Summary generated by AI