### PR TITLE
refactor(core): Drop unused WorkflowEntity.testRuns back-reference

### DIFF
--- a/packages/@n8n/db/src/entities/workflow-entity.ts
+++ b/packages/@n8n/db/src/entities/workflow-entity.ts
@@ -16,7 +16,6 @@ import { JsonColumn, WithTimestampsAndStringId, dbType } from './abstract-entity
 import { type Folder } from './folder';
 import type { SharedWorkflow } from './shared-workflow';
 import type { TagEntity } from './tag-entity';
-import type { TestRun } from './test-run.ee';
 import type { ISimplifiedPinData, IWorkflowDb } from './types-db';
 import type { WorkflowHistory } from './workflow-history';
 import type { WorkflowTagMapping } from './workflow-tag-mapping';
@@ -121,7 +120,4 @@ export class WorkflowEntity extends WithTimestampsAndStringId implements IWorkfl
 	})
 	@JoinColumn({ name: 'parentFolderId' })
 	parentFolder: Folder | null;
-
-	@OneToMany('TestRun', 'workflow')
-	testRuns: TestRun[];
 }

--- a/packages/@n8n/db/src/repositories/workflow.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow.repository.ts
@@ -227,9 +227,16 @@ export class WorkflowRepository extends Repository<WorkflowEntity> {
 	}
 
 	async getWorkflowsWithEvaluationCount() {
-		// Count workflows having test runs
+		// Count workflows having at least one test run. Uses an explicit
+		// join on the FK column rather than a `workflow.testRuns` relation
+		// so `WorkflowEntity` doesn't need to carry a back-reference into
+		// the eval entity sub-graph. The relation drags the eval sub-graph
+		// into every `QueryDeepPartialEntity` expansion that touches
+		// workflows, which hits TS's type-instantiation budget once that
+		// sub-graph grows (TRUST-72 trips it on `FolderRepository.upsert`
+		// in `source-control-import.service.ee.ts`).
 		const totalWorkflowCount = await this.createQueryBuilder('workflow')
-			.innerJoin('workflow.testRuns', 'testrun')
+			.innerJoin('test_run', 'testrun', 'testrun.workflowId = workflow.id')
 			.distinct(true)
 			.getCount();
 


### PR DESCRIPTION
## Summary

Removes `WorkflowEntity.testRuns: TestRun[]` — an `@OneToMany` back-reference into the eval sub-graph that's consulted in exactly one place at the entity-access layer: an `.innerJoin('workflow.testRuns', ...)` in `WorkflowRepository.getWorkflowsWithEvaluationCount()`. That query is rewritten to use an explicit FK join, producing identical SQL.

**This isn't dead-code cleanup for its own sake — it's a precursor for [TRUST-72](https://linear.app/n8n/issue/TRUST-72).** With the back-reference in place, TypeORM's `_QueryDeepPartialEntity<T>` type expansion drags the eval sub-graph into every `upsert()` / `insert()` call site that touches a workflow-adjacent entity. The expansion stays within TypeScript's instantiation budget on master today, but TRUST-72 adds two new `@ManyToOne` relations on `TestRun` (`evaluationConfig`, `collection`) — once those land, the budget is exceeded and `FolderRepository.upsert()` in `source-control-import.service.ee.ts:1090` fails to type-check with TS2589 ("type instantiation excessively deep"). Dropping this back-reference is the structural fix; without it TRUST-72 needs a localized `as Repository<ObjectLiteral>` cast at the failing line which is fine as a tactical patch but leaves a foreign artifact in an unrelated file.

### Why it's safe to drop

- **One consumer, one rewrite.** `grep -rn "\.testRuns\b" packages/cli/src packages/@n8n/db/src packages/workflow/src packages/core/src packages/frontend` returns exactly one result: the query above. Rewriting the query inline.
- **Identical SQL.** `qb.innerJoin('workflow.testRuns', 'testrun')` is TypeORM-syntax sugar over `qb.innerJoin('test_run', 'testrun', 'testrun.workflowId = workflow.id')`. The runtime query is the same.
- **Migration unaffected.** The FK constraint on `test_run.workflowId` is declared in `1669739707124-AddWorkflowVersionIdColumn` and successors via raw SQL; it does not depend on the entity-side decorator.

### How to test

```bash
cd packages/@n8n/db && pnpm typecheck && pnpm lint && pnpm test
# 264 tests pass, lint clean, typecheck clean (matches master).

# Integration test covering the rewritten query:
cd packages/cli && pnpm test -- test/integration/database/repositories/workflow.repository.test.ts
# `getWorkflowsWithEvaluationCount` test cases assert the count is correct
# with 0, some, and many test runs per workflow.
```

## Related Linear tickets, Github issues, and Community forum posts

- Precursor for [TRUST-72](https://linear.app/n8n/issue/TRUST-72) — PRs [#30224](https://github.com/n8n-io/n8n/pull/30224) (data layer) and [#30218](https://github.com/n8n-io/n8n/pull/30218) (service + REST + runner) need this to land first to avoid a tactical cast at an unrelated call site.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. *(existing integration tests in `workflow.repository.test.ts:230-296` cover the rewritten query — they pass against the new SQL since it's identical.)*
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI