### PR TITLE
fix(editor): Add hover delay to chat prompt tooltips for intentional interaction

### DIFF
--- a/packages/frontend/editor-ui/src/app/constants/durations.ts
+++ b/packages/frontend/editor-ui/src/app/constants/durations.ts
@@ -44,6 +44,8 @@ export const DEBOUNCE_TIME = {
 		RESIZE: 50,
 		/** Quick UI state changes */
 		QUICK: 10,
+		/** Tooltip hover delay for intentional hover (300ms) */
+		TOOLTIP_DELAY: 300,
 	},
 
 	/** Input validation and real-time feedback */

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPromptCompact.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPromptCompact.vue
@@ -4,6 +4,7 @@ import { N8nIconButton, N8nInput, N8nTooltip } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import { useTemplateRef } from 'vue';
 import type { MessagingState } from '@/features/ai/chatHub/chat.types';
+import { DEBOUNCE_TIME } from '@/app/constants';
 
 const props = defineProps<{
 	message: string;
@@ -98,6 +99,7 @@ defineExpose({
 									: i18n.baseText('chatHub.chat.prompt.button.attach')
 							"
 							:disabled="canUploadFiles && messagingState === 'idle'"
+							:show-after="DEBOUNCE_TIME.UI.TOOLTIP_DELAY"
 							placement="top"
 						>
 							<N8nIconButton

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPromptFull.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ChatPromptFull.vue
@@ -7,6 +7,7 @@ import { useTemplateRef } from 'vue';
 import ToolsSelector from './ToolsSelector.vue';
 import { useI18n } from '@n8n/i18n';
 import type { MessagingState } from '@/features/ai/chatHub/chat.types';
+import { DEBOUNCE_TIME } from '@/app/constants';
 
 const props = defineProps<{
 	message: string;
@@ -117,6 +118,7 @@ defineExpose({
 							: i18n.baseText('chatHub.chat.prompt.button.attach')
 					"
 					:disabled="canUploadFiles && messagingState === 'idle'"
+					:show-after="DEBOUNCE_TIME.UI.TOOLTIP_DELAY"
 					placement="top"
 				>
 					<N8nIconButton

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/ToolsSelector.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/ToolsSelector.vue
@@ -7,6 +7,7 @@ import type { DropdownMenuItemProps } from '@n8n/design-system';
 import type { INode, INodeTypeDescription } from 'n8n-workflow';
 import { useI18n } from '@n8n/i18n';
 import { useUIStore } from '@/app/stores/ui.store';
+import { DEBOUNCE_TIME } from '@/app/constants';
 import { TOOLS_MANAGER_MODAL_KEY, TOOL_SETTINGS_MODAL_KEY } from '@/features/ai/chatHub/constants';
 import { useChatStore } from '@/features/ai/chatHub/chat.store';
 
@@ -162,6 +163,7 @@ onMounted(async () => {
 			v-if="chatStore.configuredTools.length === 0"
 			:content="disabledTooltip"
 			:disabled="!disabledTooltip || !disabled"
+			:show-after="DEBOUNCE_TIME.UI.TOOLTIP_DELAY"
 			placement="bottom"
 		>
 			<N8nButton
@@ -181,6 +183,7 @@ onMounted(async () => {
 			v-else
 			:content="disabledTooltip"
 			:disabled="!disabledTooltip || !disabled"
+			:show-after="DEBOUNCE_TIME.UI.TOOLTIP_DELAY"
 			placement="bottom"
 		>
 			<N8nDropdownMenu


### PR DESCRIPTION

Adds a 300ms hover delay to tooltips on buttons below the chat prompt so they only appear on intentional hover, reducing visual noise during normal cursor movement.

https://claude.ai/code/session_01VUZ966AvstJsdbJ9QFUFf5

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
