### PR TITLE
feat(core): Add redaction enforcement feature-flag helpers (no-changelog)

### DIFF
--- a/packages/cli/src/modules/redaction/__tests__/redaction-enforcement.feature-flag.test.ts
+++ b/packages/cli/src/modules/redaction/__tests__/redaction-enforcement.feature-flag.test.ts
@@ -1,0 +1,26 @@
+import {
+	N8N_ENV_FEAT_REDACTION_ENFORCEMENT,
+	isRedactionEnforcementEnabled,
+} from '../redaction-enforcement.feature-flag';
+
+describe('isRedactionEnforcementEnabled', () => {
+	const original = process.env[N8N_ENV_FEAT_REDACTION_ENFORCEMENT];
+
+	afterEach(() => {
+		if (original === undefined) {
+			delete process.env[N8N_ENV_FEAT_REDACTION_ENFORCEMENT];
+		} else {
+			process.env[N8N_ENV_FEAT_REDACTION_ENFORCEMENT] = original;
+		}
+	});
+
+	it('returns false when the flag is unset', () => {
+		delete process.env[N8N_ENV_FEAT_REDACTION_ENFORCEMENT];
+		expect(isRedactionEnforcementEnabled()).toBe(false);
+	});
+
+	it("returns true when the flag is 'true'", () => {
+		process.env[N8N_ENV_FEAT_REDACTION_ENFORCEMENT] = 'true';
+		expect(isRedactionEnforcementEnabled()).toBe(true);
+	});
+});

--- a/packages/cli/src/modules/redaction/redaction-enforcement.feature-flag.ts
+++ b/packages/cli/src/modules/redaction/redaction-enforcement.feature-flag.ts
@@ -1,0 +1,5 @@
+export const N8N_ENV_FEAT_REDACTION_ENFORCEMENT = 'N8N_ENV_FEAT_REDACTION_ENFORCEMENT';
+
+export function isRedactionEnforcementEnabled(): boolean {
+	return process.env[N8N_ENV_FEAT_REDACTION_ENFORCEMENT] === 'true';
+}

--- a/packages/frontend/editor-ui/src/features/redaction-enforcement/composables/useRedactionEnforcementFeatureFlag.test.ts
+++ b/packages/frontend/editor-ui/src/features/redaction-enforcement/composables/useRedactionEnforcementFeatureFlag.test.ts
@@ -1,0 +1,27 @@
+import type { FrontendSettings } from '@n8n/api-types';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+
+import { useSettingsStore } from '@/app/stores/settings.store';
+
+import { useRedactionEnforcementFeatureFlag } from './useRedactionEnforcementFeatureFlag';
+
+describe('useRedactionEnforcementFeatureFlag', () => {
+	const setup = (flagValue?: string) => {
+		setActivePinia(createTestingPinia());
+		const settingsStore = useSettingsStore();
+		settingsStore.settings = {
+			envFeatureFlags:
+				flagValue === undefined ? {} : { N8N_ENV_FEAT_REDACTION_ENFORCEMENT: flagValue },
+		} as unknown as FrontendSettings;
+		return useRedactionEnforcementFeatureFlag();
+	};
+
+	it('is disabled when the flag is unset', () => {
+		expect(setup().isEnabled.value).toBe(false);
+	});
+
+	it("is enabled when the flag is 'true'", () => {
+		expect(setup('true').isEnabled.value).toBe(true);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/redaction-enforcement/composables/useRedactionEnforcementFeatureFlag.ts
+++ b/packages/frontend/editor-ui/src/features/redaction-enforcement/composables/useRedactionEnforcementFeatureFlag.ts
@@ -1,0 +1,11 @@
+import { computed } from 'vue';
+
+import { useEnvFeatureFlag } from '@/features/shared/envFeatureFlag/useEnvFeatureFlag';
+
+export const useRedactionEnforcementFeatureFlag = () => {
+	const { check } = useEnvFeatureFlag();
+
+	const isEnabled = computed(() => check.value('REDACTION_ENFORCEMENT'));
+
+	return { isEnabled };
+};


### PR DESCRIPTION
## Summary

Introduces typed helpers for the new `N8N_ENV_FEAT_REDACTION_ENFORCEMENT` env feature flag so the downstream tickets that build the data-redaction enforcement feature have a single import to gate their entrypoints, instead of repeating the literal flag string across 8 PRs.

- **Backend** (`packages/cli/src/modules/redaction/redaction-enforcement.feature-flag.ts`): exports the flag name constant and an `isRedactionEnforcementEnabled()` predicate (strict `=== 'true'`, matching the existing `N8N_ENV_FEAT_SIGNED_SAML_REQUESTS` precedent).
- **Frontend** (`packages/frontend/editor-ui/src/features/redaction-enforcement/composables/useRedactionEnforcementFeatureFlag.ts`): exposes a `useRedactionEnforcementFeatureFlag()` composable that mirrors `useDynamicCredentials`, wrapping the shared `useEnvFeatureFlag().check.value('REDACTION_ENFORCEMENT')`.

No production call sites are added in this PR — the helpers are exported but unused until downstream tickets (IAM-425, IAM-427, IAM-612, IAM-619, IAM-622, IAM-626, IAM-433, IAM-428) wrap their entrypoints with them.

## Why

The 2026-05-08 kickoff decision for the data-redaction enforcement feature was to gate the entire rollout behind a dedicated env feature flag, kept separate from the existing base `N8N_ENV_FEAT_REDACTION_POLICY` (same separation pattern as base SAML vs. SAML signing). The flag infrastructure (`collectEnvFeatureFlags`, `useEnvFeatureFlag`, Vite `envPrefix`) already supports any `N8N_ENV_FEAT_*` value with no parser changes, so this PR ships only the typed shims that make the gate ergonomic and typo-safe for the eight downstream tickets that will consume it.

## How to test

This PR has no user-visible behaviour change. Verification is via the unit tests and a one-off smoke check that the flag propagates end-to-end:

1. Run the unit tests:
   ```bash
   pushd packages/cli && pnpm test redaction-enforcement.feature-flag && popd
   pushd packages/frontend/editor-ui && pnpm test useRedactionEnforcementFeatureFlag --run && popd
   ```
2. (Optional) Smoke-check the runtime propagation:
   - Start n8n with `N8N_ENV_FEAT_REDACTION_ENFORCEMENT=true pnpm dev`.
   - Hit `GET /rest/settings`, confirm the response includes `envFeatureFlags.N8N_ENV_FEAT_REDACTION_ENFORCEMENT: "true"`.
   - In browser DevTools: `useRedactionEnforcementFeatureFlag().isEnabled.value` returns `true`.
   - Restart without the env var: the same call returns `false`, confirming the AC1 fallback.

## Key implementation decisions

- **Two flag semantics by design.** The backend predicate uses strict `=== 'true'` (matches the ticket spec and other backend flag checks). The frontend composable defers to `useEnvFeatureFlag`, which is more permissive (`!== 'false' && !!value`). Keeping each side consistent with its sibling flags is more important than making the two sides identical, since they never compare values directly.
- **No call sites in this PR.** The ACs are vacuously satisfied today (no caller exists to fall back from) and become substantive as downstream tickets land. This avoids speculative gating in places the enforcement feature does not yet touch.
- **No `N8nEnvFeatFlags` type addition.** That type is a generic template literal (`Record<\`N8N_ENV_FEAT_${Uppercase<string>}\`, …>`); the new flag is already a valid key without further edits.
- **Frontend folder placement.** The composable lives in a new `features/redaction-enforcement/` directory, which anticipates IAM-433 / IAM-428 frontend work landing in the same feature folder.

## Related links

- Linear: https://linear.app/n8n/issue/IAM-624

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
