### PR TITLE
feat(Weaviate Vector Store Node): Add custom collection schema option and fix hybrid filters

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/VectorStoreWeaviate.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/VectorStoreWeaviate.node.test.ts
@@ -1,0 +1,194 @@
+import type { MockedFunction } from 'vitest';
+
+import type * as WeaviateUtils from './Weaviate.utils';
+
+const hoisted = vi.hoisted(() => ({
+	hybridSearchSpy: vi.fn(),
+	superSimilaritySearchSpy: vi.fn(),
+}));
+
+vi.mock('@langchain/weaviate', () => {
+	class WeaviateStore {
+		args: unknown;
+		embeddings: unknown;
+		constructor(embeddings: unknown, args: unknown) {
+			this.embeddings = embeddings;
+			this.args = args;
+		}
+		static async fromExistingIndex(embeddings: unknown, args: unknown) {
+			// `this` refers to the calling class, so ExtendedWeaviateVectorStore inherits this
+			// and gets an instance of itself.
+			const Ctor = this as unknown as new (e: unknown, a: unknown) => WeaviateStore;
+			return new Ctor(embeddings, args);
+		}
+		async hybridSearch(query: string, options: unknown) {
+			return await hoisted.hybridSearchSpy(query, options);
+		}
+		async similaritySearchVectorWithScore(query: number[], k: number, filter: unknown) {
+			return await hoisted.superSimilaritySearchSpy(query, k, filter);
+		}
+	}
+	return { WeaviateStore };
+});
+
+vi.mock('@n8n/ai-utilities', () => ({
+	createVectorStoreNode: (config: {
+		getVectorStoreClient: (...args: unknown[]) => unknown;
+		populateVectorStore: (...args: unknown[]) => unknown;
+	}) =>
+		class BaseNode {
+			async getVectorStoreClient(...args: unknown[]) {
+				return await config.getVectorStoreClient.apply(config, args);
+			}
+			async populateVectorStore(...args: unknown[]) {
+				return await config.populateVectorStore.apply(config, args);
+			}
+		},
+}));
+
+vi.mock('./Weaviate.utils', async () => {
+	const actual = await vi.importActual<typeof WeaviateUtils>('./Weaviate.utils');
+	return {
+		...actual,
+		createWeaviateClient: vi.fn(),
+	};
+});
+
+vi.mock('../shared/methods/listSearch', () => ({
+	weaviateCollectionsSearch: vi.fn(),
+}));
+
+vi.mock('../shared/descriptions', () => ({
+	weaviateCollectionRLC: {},
+}));
+
+import { createWeaviateClient } from './Weaviate.utils';
+import { VectorStoreWeaviate } from './VectorStoreWeaviate.node';
+
+const MockCreateClient = createWeaviateClient as MockedFunction<typeof createWeaviateClient>;
+
+type NodeWithGetVectorStoreClient = {
+	getVectorStoreClient: (
+		context: unknown,
+		filter: unknown,
+		embeddings: unknown,
+		itemIndex: number,
+	) => Promise<{
+		similaritySearchVectorWithScore: (
+			query: number[],
+			k: number,
+			filter?: unknown,
+		) => Promise<unknown>;
+	}>;
+};
+
+describe('VectorStoreWeaviate.node', () => {
+	const baseCredentials = {
+		weaviate_cloud_endpoint: 'https://test.weaviate.io',
+		weaviate_api_key: 'test-api-key',
+	};
+
+	const buildContext = (hybridQuery?: string) =>
+		({
+			getCredentials: vi.fn().mockResolvedValue(baseCredentials),
+			getNodeParameter: vi.fn((name: string) => {
+				if (name === 'weaviateCollection') return 'TestCollection';
+				if (name === 'options') {
+					return {
+						hybridQuery,
+						alpha: 0.5,
+						fusionType: 'RelativeScore',
+					};
+				}
+				return {};
+			}),
+			getNode: () => ({ name: 'VectorStoreWeaviate' }),
+		}) as never;
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		MockCreateClient.mockResolvedValue({} as never);
+		hoisted.hybridSearchSpy.mockResolvedValue([]);
+		hoisted.superSimilaritySearchSpy.mockResolvedValue([]);
+	});
+
+	describe('hybrid search filter', () => {
+		// Regression test for https://github.com/weaviate/weaviate/issues/11262
+		// weaviate-client expects the option key `filters` (plural); using `filter` (singular)
+		// causes weaviate-client to silently drop the filter.
+		it('passes the filter under the "filters" key when hybridQuery is set', async () => {
+			const filter = {
+				path: ['metadata_document_type'],
+				operator: 'Equal',
+				valueString: 'Ticket',
+			};
+
+			const node = new VectorStoreWeaviate() as unknown as NodeWithGetVectorStoreClient;
+			const store = await node.getVectorStoreClient(buildContext('find tickets'), filter, {}, 0);
+
+			await store.similaritySearchVectorWithScore([0.1, 0.2, 0.3], 5);
+
+			expect(hoisted.hybridSearchSpy).toHaveBeenCalledTimes(1);
+			const [query, options] = hoisted.hybridSearchSpy.mock.calls[0] as [
+				string,
+				Record<string, unknown>,
+			];
+			expect(query).toBe('find tickets');
+			expect(options).toHaveProperty('filters');
+			expect(options.filters).toBeDefined();
+			expect(options).not.toHaveProperty('filter');
+		});
+
+		it('passes the inline filter argument under the "filters" key', async () => {
+			const filter = {
+				path: ['metadata_document_type'],
+				operator: 'Equal',
+				valueString: 'Ticket',
+			};
+
+			const node = new VectorStoreWeaviate() as unknown as NodeWithGetVectorStoreClient;
+			const store = await node.getVectorStoreClient(buildContext('find tickets'), undefined, {}, 0);
+
+			await store.similaritySearchVectorWithScore([0.1, 0.2, 0.3], 5, filter);
+
+			expect(hoisted.hybridSearchSpy).toHaveBeenCalledTimes(1);
+			const [, options] = hoisted.hybridSearchSpy.mock.calls[0] as [
+				string,
+				Record<string, unknown>,
+			];
+			expect(options).toHaveProperty('filters');
+			expect(options.filters).toBeDefined();
+			expect(options).not.toHaveProperty('filter');
+		});
+
+		it('leaves filters undefined when no filter is provided', async () => {
+			const node = new VectorStoreWeaviate() as unknown as NodeWithGetVectorStoreClient;
+			const store = await node.getVectorStoreClient(buildContext('find tickets'), undefined, {}, 0);
+
+			await store.similaritySearchVectorWithScore([0.1, 0.2, 0.3], 5);
+
+			expect(hoisted.hybridSearchSpy).toHaveBeenCalledTimes(1);
+			const [, options] = hoisted.hybridSearchSpy.mock.calls[0] as [
+				string,
+				Record<string, unknown>,
+			];
+			expect(options.filters).toBeUndefined();
+		});
+
+		it('does not call hybridSearch when hybridQuery is not set', async () => {
+			const filter = {
+				path: ['metadata_document_type'],
+				operator: 'Equal',
+				valueString: 'Ticket',
+			};
+
+			const node = new VectorStoreWeaviate() as unknown as NodeWithGetVectorStoreClient;
+			const store = await node.getVectorStoreClient(buildContext(undefined), undefined, {}, 0);
+
+			await store.similaritySearchVectorWithScore([0.1, 0.2, 0.3], 5, filter);
+
+			expect(hoisted.hybridSearchSpy).not.toHaveBeenCalled();
+			expect(hoisted.superSimilaritySearchSpy).toHaveBeenCalledTimes(1);
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/VectorStoreWeaviate.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/VectorStoreWeaviate.node.test.ts
@@ -5,6 +5,7 @@ import type * as WeaviateUtils from './Weaviate.utils';
 const hoisted = vi.hoisted(() => ({
 	hybridSearchSpy: vi.fn(),
 	superSimilaritySearchSpy: vi.fn(),
+	fromDocumentsSpy: vi.fn(),
 }));
 
 vi.mock('@langchain/weaviate', () => {
@@ -20,6 +21,9 @@ vi.mock('@langchain/weaviate', () => {
 			// and gets an instance of itself.
 			const Ctor = this as unknown as new (e: unknown, a: unknown) => WeaviateStore;
 			return new Ctor(embeddings, args);
+		}
+		static async fromDocuments(documents: unknown, embeddings: unknown, args: unknown) {
+			return await hoisted.fromDocumentsSpy(documents, embeddings, args);
 		}
 		async hybridSearch(query: string, options: unknown) {
 			return await hoisted.hybridSearchSpy(query, options);
@@ -82,6 +86,15 @@ type NodeWithGetVectorStoreClient = {
 	}>;
 };
 
+type NodeWithPopulateVectorStore = {
+	populateVectorStore: (
+		context: unknown,
+		embeddings: unknown,
+		documents: unknown,
+		itemIndex: number,
+	) => Promise<unknown>;
+};
+
 describe('VectorStoreWeaviate.node', () => {
 	const baseCredentials = {
 		weaviate_cloud_endpoint: 'https://test.weaviate.io',
@@ -111,6 +124,7 @@ describe('VectorStoreWeaviate.node', () => {
 		MockCreateClient.mockResolvedValue({} as never);
 		hoisted.hybridSearchSpy.mockResolvedValue([]);
 		hoisted.superSimilaritySearchSpy.mockResolvedValue([]);
+		hoisted.fromDocumentsSpy.mockResolvedValue({});
 	});
 
 	describe('hybrid search filter', () => {
@@ -228,6 +242,68 @@ describe('VectorStoreWeaviate.node', () => {
 
 			expect(hoisted.hybridSearchSpy).not.toHaveBeenCalled();
 			expect(hoisted.superSimilaritySearchSpy).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('populateVectorStore json schema', () => {
+		const jsonSchemaObject = {
+			class: 'TestCollection',
+			properties: [{ name: 'text', dataType: ['text'] }],
+		};
+
+		it('passes a parsed jsonSchema to fromDocuments when provided as a string', async () => {
+			const node = new VectorStoreWeaviate() as unknown as NodeWithPopulateVectorStore;
+			const documents = [{ pageContent: 'hello', metadata: {} }];
+
+			await node.populateVectorStore(
+				buildContext(undefined, { jsonSchema: JSON.stringify(jsonSchemaObject) }),
+				{},
+				documents,
+				0,
+			);
+
+			expect(hoisted.fromDocumentsSpy).toHaveBeenCalledTimes(1);
+			const [, , config] = hoisted.fromDocumentsSpy.mock.calls[0] as [
+				unknown,
+				unknown,
+				Record<string, unknown>,
+			];
+			expect(config.jsonSchema).toEqual(jsonSchemaObject);
+		});
+
+		it('passes an object jsonSchema through to fromDocuments unchanged', async () => {
+			const node = new VectorStoreWeaviate() as unknown as NodeWithPopulateVectorStore;
+			const documents = [{ pageContent: 'hello', metadata: {} }];
+
+			await node.populateVectorStore(
+				buildContext(undefined, { jsonSchema: jsonSchemaObject }),
+				{},
+				documents,
+				0,
+			);
+
+			expect(hoisted.fromDocumentsSpy).toHaveBeenCalledTimes(1);
+			const [, , config] = hoisted.fromDocumentsSpy.mock.calls[0] as [
+				unknown,
+				unknown,
+				Record<string, unknown>,
+			];
+			expect(config.jsonSchema).toEqual(jsonSchemaObject);
+		});
+
+		it('leaves jsonSchema undefined when not provided', async () => {
+			const node = new VectorStoreWeaviate() as unknown as NodeWithPopulateVectorStore;
+			const documents = [{ pageContent: 'hello', metadata: {} }];
+
+			await node.populateVectorStore(buildContext(undefined), {}, documents, 0);
+
+			expect(hoisted.fromDocumentsSpy).toHaveBeenCalledTimes(1);
+			const [, , config] = hoisted.fromDocumentsSpy.mock.calls[0] as [
+				unknown,
+				unknown,
+				Record<string, unknown>,
+			];
+			expect(config.jsonSchema).toBeUndefined();
 		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/VectorStoreWeaviate.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/VectorStoreWeaviate.node.test.ts
@@ -88,7 +88,7 @@ describe('VectorStoreWeaviate.node', () => {
 		weaviate_api_key: 'test-api-key',
 	};
 
-	const buildContext = (hybridQuery?: string) =>
+	const buildContext = (hybridQuery?: string, extraOptions: Record<string, unknown> = {}) =>
 		({
 			getCredentials: vi.fn().mockResolvedValue(baseCredentials),
 			getNodeParameter: vi.fn((name: string) => {
@@ -98,6 +98,7 @@ describe('VectorStoreWeaviate.node', () => {
 						hybridQuery,
 						alpha: 0.5,
 						fusionType: 'RelativeScore',
+						...extraOptions,
 					};
 				}
 				return {};
@@ -173,6 +174,44 @@ describe('VectorStoreWeaviate.node', () => {
 				Record<string, unknown>,
 			];
 			expect(options.filters).toBeUndefined();
+		});
+
+		it('requests the "explainScore" metadata key when hybridExplainScore is enabled', async () => {
+			const node = new VectorStoreWeaviate() as unknown as NodeWithGetVectorStoreClient;
+			const store = await node.getVectorStoreClient(
+				buildContext('find tickets', { hybridExplainScore: true }),
+				undefined,
+				{},
+				0,
+			);
+
+			await store.similaritySearchVectorWithScore([0.1, 0.2, 0.3], 5);
+
+			expect(hoisted.hybridSearchSpy).toHaveBeenCalledTimes(1);
+			const [, options] = hoisted.hybridSearchSpy.mock.calls[0] as [
+				string,
+				Record<string, unknown>,
+			];
+			expect(options.returnMetadata).toEqual(['explainScore']);
+		});
+
+		it('leaves returnMetadata undefined when hybridExplainScore is disabled', async () => {
+			const node = new VectorStoreWeaviate() as unknown as NodeWithGetVectorStoreClient;
+			const store = await node.getVectorStoreClient(
+				buildContext('find tickets', { hybridExplainScore: false }),
+				undefined,
+				{},
+				0,
+			);
+
+			await store.similaritySearchVectorWithScore([0.1, 0.2, 0.3], 5);
+
+			expect(hoisted.hybridSearchSpy).toHaveBeenCalledTimes(1);
+			const [, options] = hoisted.hybridSearchSpy.mock.calls[0] as [
+				string,
+				Record<string, unknown>,
+			];
+			expect(options.returnMetadata).toBeUndefined();
 		});
 
 		it('does not call hybridSearch when hybridQuery is not set', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/VectorStoreWeaviate.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/VectorStoreWeaviate.node.ts
@@ -67,7 +67,7 @@ class ExtendedWeaviateVectorStore extends WeaviateStore {
 				autoLimit: args.autoCutLimit ?? undefined,
 				alpha: args.alpha ?? undefined,
 				vector: query,
-				filter: filter ? parseCompositeFilter(filter as WeaviateCompositeFilter) : undefined,
+				filters: filter ? parseCompositeFilter(filter as WeaviateCompositeFilter) : undefined,
 				queryProperties: args.queryProperties
 					? args.queryProperties.split(',').map((prop) => prop.trim())
 					: undefined,

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/VectorStoreWeaviate.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/VectorStoreWeaviate.node.ts
@@ -370,7 +370,7 @@ export class VectorStoreWeaviate extends createVectorStoreNode<ExtendedWeaviateV
 			client,
 			indexName: collection,
 			tenant: options.tenant ?? undefined,
-			textKey: options.textKey ?? 'text',
+			textKey: options.textKey || 'text',
 			metadataKeys: metadataKeys as string[] | undefined,
 			hybridQuery: options.hybridQuery ?? undefined,
 			autoCutLimit: options.autoCutLimit ?? undefined,
@@ -421,7 +421,7 @@ export class VectorStoreWeaviate extends createVectorStoreNode<ExtendedWeaviateV
 			client,
 			indexName: collectionName,
 			tenant: options.tenant ?? undefined,
-			textKey: options.textKey ?? 'text',
+			textKey: options.textKey || 'text',
 			metadataKeys: metadataKeys as string[] | undefined,
 			jsonSchema,
 		};

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/VectorStoreWeaviate.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/VectorStoreWeaviate.node.ts
@@ -5,12 +5,18 @@ import { WeaviateStore } from '@langchain/weaviate';
 import { createVectorStoreNode } from '@n8n/ai-utilities';
 import {
 	UnexpectedError,
+	jsonParse,
 	type IDataObject,
 	type INodeProperties,
 	type INodePropertyCollection,
 	type INodePropertyOptions,
 } from 'n8n-workflow';
-import { type MetadataKeys, type ProxiesParams, type TimeoutParams } from 'weaviate-client';
+import {
+	type MetadataKeys,
+	type ProxiesParams,
+	type TimeoutParams,
+	type WeaviateClass,
+} from 'weaviate-client';
 
 import type { WeaviateCompositeFilter, WeaviateCredential } from './Weaviate.utils';
 import { createWeaviateClient, parseCompositeFilter } from './Weaviate.utils';
@@ -177,6 +183,17 @@ const insertFields: INodeProperties[] = [
 				type: 'boolean',
 				default: false,
 				description: 'Whether to clear the Collection/Tenant before inserting new data',
+			},
+			{
+				displayName: 'Collection JSON Schema',
+				name: 'jsonSchema',
+				type: 'json',
+				typeOptions: {
+					rows: 5,
+				},
+				default: '',
+				description:
+					'Raw Weaviate collection definition used to create the collection when it does not already exist. Provide the JSON shape returned by Weaviate\'s REST API or by <code>client.collections.exportToJson()</code>, or generate it with the <a href="https://weaviate.github.io/weaviate-add-collection/" target="_blank">collection builder</a>. The "class" in the schema must match the selected collection name. Ignored when the collection already exists.',
 			},
 		],
 	},
@@ -383,6 +400,7 @@ export class VectorStoreWeaviate extends createVectorStoreNode<ExtendedWeaviateV
 			textKey?: string;
 			clearStore?: boolean;
 			metadataKeys?: string;
+			jsonSchema?: string | IDataObject;
 		};
 
 		const credentials = await context.getCredentials('weaviateApi');
@@ -391,12 +409,21 @@ export class VectorStoreWeaviate extends createVectorStoreNode<ExtendedWeaviateV
 
 		const client = await createWeaviateClient(credentials as WeaviateCredential);
 
+		let jsonSchema: WeaviateClass | undefined;
+		if (options.jsonSchema) {
+			jsonSchema =
+				typeof options.jsonSchema === 'string'
+					? jsonParse<WeaviateClass>(options.jsonSchema)
+					: (options.jsonSchema as WeaviateClass);
+		}
+
 		const config: WeaviateLibArgs = {
 			client,
 			indexName: collectionName,
 			tenant: options.tenant ?? undefined,
 			textKey: options.textKey ?? 'text',
 			metadataKeys: metadataKeys as string[] | undefined,
+			jsonSchema,
 		};
 
 		if (options.clearStore) {

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/VectorStoreWeaviate.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/VectorStoreWeaviate.node.ts
@@ -2,6 +2,7 @@ import { Document } from '@langchain/core/documents';
 import type { Embeddings } from '@langchain/core/embeddings';
 import type { WeaviateLibArgs as OriginalWeaviateLibArgs } from '@langchain/weaviate';
 import { WeaviateStore } from '@langchain/weaviate';
+import { createVectorStoreNode } from '@n8n/ai-utilities';
 import {
 	UnexpectedError,
 	type IDataObject,
@@ -9,13 +10,12 @@ import {
 	type INodePropertyCollection,
 	type INodePropertyOptions,
 } from 'n8n-workflow';
-import { type ProxiesParams, type TimeoutParams } from 'weaviate-client';
+import { type MetadataKeys, type ProxiesParams, type TimeoutParams } from 'weaviate-client';
 
 import type { WeaviateCompositeFilter, WeaviateCredential } from './Weaviate.utils';
 import { createWeaviateClient, parseCompositeFilter } from './Weaviate.utils';
-import { createVectorStoreNode } from '@n8n/ai-utilities';
-import { weaviateCollectionsSearch } from '../shared/methods/listSearch';
 import { weaviateCollectionRLC } from '../shared/descriptions';
+import { weaviateCollectionsSearch } from '../shared/methods/listSearch';
 
 type WeaviateLibArgs = OriginalWeaviateLibArgs & {
 	hybridQuery?: string;
@@ -62,6 +62,9 @@ class ExtendedWeaviateVectorStore extends WeaviateStore {
 		const args = this.args;
 
 		if (args.hybridQuery) {
+			const returnMetadata: MetadataKeys | undefined = args.hybridExplainScore
+				? ['explainScore']
+				: undefined;
 			const options = {
 				limit: k ?? undefined,
 				autoLimit: args.autoCutLimit ?? undefined,
@@ -73,7 +76,7 @@ class ExtendedWeaviateVectorStore extends WeaviateStore {
 					: undefined,
 				maxVectorDistance: args.maxVectorDistance ?? undefined,
 				fusionType: args.fusionType,
-				returnMetadata: args.hybridExplainScore ? ['explainScore'] : undefined,
+				returnMetadata,
 			};
 			const content = await super.hybridSearch(args.hybridQuery, options);
 			return content.map((doc) => {
@@ -350,7 +353,7 @@ export class VectorStoreWeaviate extends createVectorStoreNode<ExtendedWeaviateV
 			client,
 			indexName: collection,
 			tenant: options.tenant ?? undefined,
-			textKey: options.textKey ? options.textKey : 'text',
+			textKey: options.textKey ?? 'text',
 			metadataKeys: metadataKeys as string[] | undefined,
 			hybridQuery: options.hybridQuery ?? undefined,
 			autoCutLimit: options.autoCutLimit ?? undefined,
@@ -392,7 +395,7 @@ export class VectorStoreWeaviate extends createVectorStoreNode<ExtendedWeaviateV
 			client,
 			indexName: collectionName,
 			tenant: options.tenant ?? undefined,
-			textKey: options.textKey ? options.textKey : 'text',
+			textKey: options.textKey ?? 'text',
 			metadataKeys: metadataKeys as string[] | undefined,
 		};
 

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/Weaviate.utils.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/Weaviate.utils.test.ts
@@ -1,0 +1,64 @@
+import type { WeaviateClient } from 'weaviate-client';
+
+import { registerIntegrationHeader, getN8nVersion } from './Weaviate.utils';
+
+const INTEGRATION_HEADER = 'X-Weaviate-Client-Integration';
+
+describe('getN8nVersion', () => {
+	const originalVersion = process.env.N8N_VERSION;
+
+	afterEach(() => {
+		if (originalVersion === undefined) {
+			delete process.env.N8N_VERSION;
+		} else {
+			process.env.N8N_VERSION = originalVersion;
+		}
+	});
+
+	it('returns the N8N_VERSION env var when set', () => {
+		process.env.N8N_VERSION = '1.2.3';
+		expect(getN8nVersion()).toBe('1.2.3');
+	});
+
+	it('falls back to the package version when the env var is missing', () => {
+		delete process.env.N8N_VERSION;
+		// The package.json version is a non-empty semver-like string.
+		expect(getN8nVersion()).toMatch(/^\d+\.\d+\.\d+/);
+	});
+});
+
+describe('registerIntegrationHeader', () => {
+	beforeEach(() => {
+		process.env.N8N_VERSION = '9.9.9';
+	});
+
+	it('tags the live headers object with the integration header', async () => {
+		const headers: Record<string, string> = {};
+		const client = {
+			getConnectionDetails: vi.fn().mockResolvedValue({ host: 'localhost', headers }),
+		} as unknown as WeaviateClient;
+
+		await registerIntegrationHeader(client);
+
+		// Mutates the live headers object by reference, so subsequent client
+		// requests carry the telemetry header on both transports.
+		expect(headers[INTEGRATION_HEADER]).toBe('n8n-langchain/9.9.9');
+	});
+
+	it('never throws when the client does not support getConnectionDetails', async () => {
+		const client = {} as unknown as WeaviateClient;
+
+		await expect(registerIntegrationHeader(client)).resolves.toBeUndefined();
+	});
+
+	it('leaves array-form headers untouched', async () => {
+		const headers: Array<[string, string]> = [['X-Existing', '1']];
+		const client = {
+			getConnectionDetails: vi.fn().mockResolvedValue({ headers }),
+		} as unknown as WeaviateClient;
+
+		await registerIntegrationHeader(client);
+
+		expect(headers).toEqual([['X-Existing', '1']]);
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/Weaviate.utils.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/Weaviate.utils.test.ts
@@ -20,10 +20,13 @@ describe('getN8nVersion', () => {
 		expect(getN8nVersion()).toBe('1.2.3');
 	});
 
-	it('falls back to the package version when the env var is missing', () => {
+	it('falls back to the resolved package version when the env var is missing', () => {
 		delete process.env.N8N_VERSION;
-		// The package.json version is a non-empty semver-like string.
-		expect(getN8nVersion()).toMatch(/^\d+\.\d+\.\d+/);
+		const version = getN8nVersion();
+		// The package.json version is a non-empty semver-like string, and crucially
+		// not the '0.0.0' default that signals the package.json could not be found.
+		expect(version).toMatch(/^\d+\.\d+\.\d+/);
+		expect(version).not.toBe('0.0.0');
 	});
 });
 

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/Weaviate.utils.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/Weaviate.utils.test.ts
@@ -1,41 +1,20 @@
 import type { WeaviateClient } from 'weaviate-client';
 
-import { registerIntegrationHeader, getN8nVersion } from './Weaviate.utils';
+import { registerIntegrationHeader, getIntegrationVersion } from './Weaviate.utils';
 
 const INTEGRATION_HEADER = 'X-Weaviate-Client-Integration';
 
-describe('getN8nVersion', () => {
-	const originalVersion = process.env.N8N_VERSION;
-
-	afterEach(() => {
-		if (originalVersion === undefined) {
-			delete process.env.N8N_VERSION;
-		} else {
-			process.env.N8N_VERSION = originalVersion;
-		}
-	});
-
-	it('returns the N8N_VERSION env var when set', () => {
-		process.env.N8N_VERSION = '1.2.3';
-		expect(getN8nVersion()).toBe('1.2.3');
-	});
-
-	it('falls back to the resolved package version when the env var is missing', () => {
-		delete process.env.N8N_VERSION;
-		const version = getN8nVersion();
-		// The package.json version is a non-empty semver-like string, and crucially
-		// not the '0.0.0' default that signals the package.json could not be found.
+describe('getIntegrationVersion', () => {
+	it('resolves the package version from the nearest package.json', () => {
+		const version = getIntegrationVersion();
+		// A non-empty semver-like string read from package.json — never a default
+		// or empty value, which would mean the package.json could not be found.
 		expect(version).toMatch(/^\d+\.\d+\.\d+/);
-		expect(version).not.toBe('0.0.0');
 	});
 });
 
 describe('registerIntegrationHeader', () => {
-	beforeEach(() => {
-		process.env.N8N_VERSION = '9.9.9';
-	});
-
-	it('tags the live headers object with the integration header', async () => {
+	it('tags the live headers object with the integration header and package version', async () => {
 		const headers: Record<string, string> = {};
 		const client = {
 			getConnectionDetails: vi.fn().mockResolvedValue({ host: 'localhost', headers }),
@@ -45,7 +24,7 @@ describe('registerIntegrationHeader', () => {
 
 		// Mutates the live headers object by reference, so subsequent client
 		// requests carry the telemetry header on both transports.
-		expect(headers[INTEGRATION_HEADER]).toBe('n8n-langchain/9.9.9');
+		expect(headers[INTEGRATION_HEADER]).toBe(`n8n-langchain/${getIntegrationVersion()}`);
 	});
 
 	it('never throws when the client does not support getConnectionDetails', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/Weaviate.utils.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/Weaviate.utils.test.ts
@@ -1,30 +1,88 @@
+import { jsonParse } from 'n8n-workflow';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import type { WeaviateClient } from 'weaviate-client';
 
 import { registerIntegrationHeader, getIntegrationVersion } from './Weaviate.utils';
 
+/**
+ * Counts `readFile` calls while delegating to the real implementation, so the
+ * walk-up still runs against the real filesystem and only the memoization
+ * assertion depends on the instrumentation.
+ *
+ * Held in hoisted state rather than a `vi.fn()` for two reasons: the shared
+ * config sets `restoreMocks: true`, which would wipe a mock implementation
+ * before each test; and the identity must survive `vi.resetModules()`, which
+ * re-runs the factory below for the fresh module graph.
+ */
+const fsReads = vi.hoisted(() => ({ paths: [] as string[] }));
+
+vi.mock('node:fs/promises', async () => {
+	const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises');
+	return {
+		...actual,
+		readFile: async (...args: Parameters<typeof actual.readFile>) => {
+			fsReads.paths.push(String(args[0]));
+			return await actual.readFile(...args);
+		},
+	};
+});
+
 const INTEGRATION_HEADER = 'X-Weaviate-Client-Integration';
 
+/**
+ * Read synchronously, and via an explicit path to the package root, so it is
+ * independent of both the walk-up under test and the instrumented `readFile`
+ * above. The assertions fail if the walk resolves some other `package.json`.
+ */
+const packageJsonPath = resolve(__dirname, '../../../package.json');
+
+const { version: packageVersion } = jsonParse<{ version: string }>(
+	readFileSync(packageJsonPath, 'utf8'),
+);
+
+const clientWithHeaders = (headers: unknown) =>
+	({
+		getConnectionDetails: vi.fn().mockResolvedValue({ host: 'localhost', headers }),
+	}) as unknown as WeaviateClient;
+
 describe('getIntegrationVersion', () => {
-	it('resolves the package version from the nearest package.json', () => {
-		const version = getIntegrationVersion();
-		// A non-empty semver-like string read from package.json — never a default
-		// or empty value, which would mean the package.json could not be found.
-		expect(version).toMatch(/^\d+\.\d+\.\d+/);
+	it('resolves the version of this package, not of some other package.json', async () => {
+		await expect(getIntegrationVersion()).resolves.toBe(packageVersion);
+		expect(packageVersion).toMatch(/^\d+\.\d+\.\d+/);
+	});
+
+	it('reads package.json once, even for concurrent first callers', async () => {
+		// Fresh module instance, so the memo cache starts empty.
+		vi.resetModules();
+		const { getIntegrationVersion: freshGetIntegrationVersion } =
+			await import('./Weaviate.utils.js');
+
+		// Reset after the import, so only the calls below are counted.
+		fsReads.paths.length = 0;
+
+		const [first, second] = await Promise.all([
+			freshGetIntegrationVersion(),
+			freshGetIntegrationVersion(),
+		]);
+		const third = await freshGetIntegrationVersion();
+
+		expect([first, second, third]).toEqual([packageVersion, packageVersion, packageVersion]);
+		// The walk probes several directories, but the package.json it resolves is
+		// read exactly once: without the memo each of the three calls would read it.
+		expect(fsReads.paths.filter((path) => path === packageJsonPath)).toHaveLength(1);
 	});
 });
 
 describe('registerIntegrationHeader', () => {
 	it('tags the live headers object with the integration header and package version', async () => {
 		const headers: Record<string, string> = {};
-		const client = {
-			getConnectionDetails: vi.fn().mockResolvedValue({ host: 'localhost', headers }),
-		} as unknown as WeaviateClient;
 
-		await registerIntegrationHeader(client);
+		await registerIntegrationHeader(clientWithHeaders(headers));
 
 		// Mutates the live headers object by reference, so subsequent client
 		// requests carry the telemetry header on both transports.
-		expect(headers[INTEGRATION_HEADER]).toBe(`n8n-langchain/${getIntegrationVersion()}`);
+		expect(headers[INTEGRATION_HEADER]).toBe(`n8n-langchain/${packageVersion}`);
 	});
 
 	it('never throws when the client does not support getConnectionDetails', async () => {
@@ -35,11 +93,8 @@ describe('registerIntegrationHeader', () => {
 
 	it('leaves array-form headers untouched', async () => {
 		const headers: Array<[string, string]> = [['X-Existing', '1']];
-		const client = {
-			getConnectionDetails: vi.fn().mockResolvedValue({ headers }),
-		} as unknown as WeaviateClient;
 
-		await registerIntegrationHeader(client);
+		await registerIntegrationHeader(clientWithHeaders(headers));
 
 		expect(headers).toEqual([['X-Existing', '1']]);
 	});

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/Weaviate.utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/Weaviate.utils.ts
@@ -1,4 +1,6 @@
-import { OperationalError } from 'n8n-workflow';
+import { readFileSync } from 'fs';
+import { jsonParse, OperationalError } from 'n8n-workflow';
+import { join, resolve } from 'path';
 import type {
 	FilterValue,
 	GeoRangeFilter,
@@ -19,6 +21,62 @@ export type WeaviateCredential = {
 	custom_connection_grpc_secure: boolean;
 };
 
+/**
+ * Integration identifier reported to Weaviate telemetry, so Weaviate can track
+ * usage originating from the n8n LangChain nodes.
+ */
+const INTEGRATION_NAME = 'n8n-langchain';
+
+/**
+ * Telemetry header that tags the connection so Weaviate can track integration
+ * usage across both the HTTP and gRPC transports.
+ */
+const INTEGRATION_HEADER = 'X-Weaviate-Client-Integration';
+
+/**
+ * Resolves the running n8n version, used as the integration version reported to
+ * Weaviate. Mirrors the helper used by the Airtop node: prefer the
+ * `N8N_VERSION` env var (set at runtime) and fall back to the package version.
+ */
+export function getN8nVersion(): string {
+	if (process.env.N8N_VERSION) {
+		return process.env.N8N_VERSION;
+	}
+
+	try {
+		const packageJsonPath = join(resolve(__dirname, '../../../'), 'package.json');
+		const packageJson = jsonParse<{ version: string }>(readFileSync(packageJsonPath, 'utf8'));
+		return packageJson.version;
+	} catch {
+		return '0.0.0';
+	}
+}
+
+/**
+ * Best-effort registration of the {@link INTEGRATION_HEADER} on a Weaviate
+ * client. Never throws.
+ *
+ * The JS `weaviate-client` exposes no public `integrations.configure(...)` API
+ * (unlike the Python client). However, `getConnectionDetails()` returns the
+ * client's live `headers` object by reference, and the client spreads that same
+ * object into every HTTP and gRPC request. Mutating it therefore tags all
+ * subsequent requests with `X-Weaviate-Client-Integration: n8n-langchain/<version>`
+ * without depending on any private internals. If a future client version
+ * changes shape, registration is silently skipped instead of breaking the node.
+ */
+export async function registerIntegrationHeader(client: WeaviateClient): Promise<void> {
+	try {
+		const { headers } = await client.getConnectionDetails();
+		// The client only spreads object-form headers into requests, so only the
+		// `Record<string, string>` form can be augmented in place.
+		if (headers && !Array.isArray(headers)) {
+			headers[INTEGRATION_HEADER] = `${INTEGRATION_NAME}/${getN8nVersion()}`;
+		}
+	} catch {
+		// Best-effort telemetry: never let header registration break the node.
+	}
+}
+
 export async function createWeaviateClient(
 	credentials: WeaviateCredential,
 	timeout?: TimeoutParams,
@@ -34,6 +92,7 @@ export async function createWeaviateClient(
 				skipInitChecks,
 			},
 		);
+		await registerIntegrationHeader(weaviateClient);
 		return weaviateClient;
 	} else {
 		const weaviateClient: WeaviateClient = await weaviate.connectToCustom({
@@ -50,6 +109,7 @@ export async function createWeaviateClient(
 			proxies,
 			skipInitChecks,
 		});
+		await registerIntegrationHeader(weaviateClient);
 		return weaviateClient;
 	}
 }

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/Weaviate.utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/Weaviate.utils.ts
@@ -1,6 +1,6 @@
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { jsonParse, OperationalError } from 'n8n-workflow';
-import { join, resolve } from 'path';
+import { dirname, join } from 'path';
 import type {
 	FilterValue,
 	GeoRangeFilter,
@@ -35,8 +35,13 @@ const INTEGRATION_HEADER = 'X-Weaviate-Client-Integration';
 
 /**
  * Resolves the running n8n version, used as the integration version reported to
- * Weaviate. Mirrors the helper used by the Airtop node: prefer the
- * `N8N_VERSION` env var (set at runtime) and fall back to the package version.
+ * Weaviate. Prefers the `N8N_VERSION` env var (when a deployment sets it) and
+ * otherwise reads the package version. All packages in the monorepo share the
+ * same version, so the local `package.json` version matches the n8n version.
+ *
+ * The package version is found by walking up from this module to the nearest
+ * `package.json`, which is robust to the differing directory depth between the
+ * compiled (`dist/nodes/...`) and source/test (`nodes/...`) layouts.
  */
 export function getN8nVersion(): string {
 	if (process.env.N8N_VERSION) {
@@ -44,12 +49,23 @@ export function getN8nVersion(): string {
 	}
 
 	try {
-		const packageJsonPath = join(resolve(__dirname, '../../../'), 'package.json');
-		const packageJson = jsonParse<{ version: string }>(readFileSync(packageJsonPath, 'utf8'));
-		return packageJson.version;
+		let dir = __dirname;
+		// Walk up until a package.json is found or the filesystem root is reached.
+		while (true) {
+			const packageJsonPath = join(dir, 'package.json');
+			if (existsSync(packageJsonPath)) {
+				const packageJson = jsonParse<{ version: string }>(readFileSync(packageJsonPath, 'utf8'));
+				return packageJson.version;
+			}
+			const parent = dirname(dir);
+			if (parent === dir) break;
+			dir = parent;
+		}
 	} catch {
-		return '0.0.0';
+		// Fall through to the default below.
 	}
+
+	return '0.0.0';
 }
 
 /**

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/Weaviate.utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/Weaviate.utils.ts
@@ -1,5 +1,5 @@
 import { jsonParse, OperationalError } from 'n8n-workflow';
-import { existsSync, readFileSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import type {
 	FilterValue,
@@ -33,39 +33,80 @@ const INTEGRATION_NAME = 'n8n-langchain';
  */
 const INTEGRATION_HEADER = 'X-Weaviate-Client-Integration';
 
+/** Errors that mean "nothing here", so the walk should continue upwards. */
+const MISSING_PATH_CODES = new Set(['ENOENT', 'ENOTDIR']);
+
 /**
- * Resolves the `@n8n/n8n-nodes-langchain` package version, reported alongside
- * {@link INTEGRATION_NAME} to Weaviate telemetry. This is a single, consistent
- * source — the package version — and all packages in the monorepo share the
- * same version, so it also matches the n8n version.
- *
- * The version is read from the nearest `package.json` by walking up from this
- * module, which is robust to the differing directory depth between the compiled
- * (`dist/nodes/...`) and source/test (`nodes/...`) layouts. `moduleResolution`
- * is classic `node` here, so a direct `package.json` import is not an option.
- *
- * Memoized, since a client is created per node execution but the version cannot
- * change while the process is running.
+ * Filesystem errors worth retrying. Everything else — a missing or malformed
+ * `package.json` — is a permanent property of the installation, so its failure
+ * is cached rather than re-walked on every client creation.
  */
-let cachedIntegrationVersion: string | undefined;
+const TRANSIENT_FS_CODES = new Set(['EMFILE', 'ENFILE', 'EAGAIN', 'EBUSY', 'EIO']);
 
-export function getIntegrationVersion(): string {
-	if (cachedIntegrationVersion !== undefined) return cachedIntegrationVersion;
-
+/**
+ * Resolves the `@n8n/n8n-nodes-langchain` package version by walking up from
+ * this module to the nearest `package.json`. The walk keeps this robust to the
+ * differing directory depth between the compiled (`dist/nodes/...`) and
+ * source/test (`nodes/...`) layouts.
+ *
+ * A direct `package.json` import is not an option: the build config
+ * (`@n8n/typescript-config/modern/tsconfig.cjs.go.json`) sets
+ * `resolveJsonModule: false`.
+ *
+ * Only "path does not exist" errors continue the walk — a `package.json` that
+ * exists but cannot be read or parsed is a real problem, and must not silently
+ * resolve some other package's version further up the tree.
+ */
+async function resolveIntegrationVersion(): Promise<string> {
 	let dir = __dirname;
-	// Walk up until a package.json is found or the filesystem root is reached.
 	while (true) {
-		const packageJsonPath = join(dir, 'package.json');
-		if (existsSync(packageJsonPath)) {
-			const packageJson = jsonParse<{ version: string }>(readFileSync(packageJsonPath, 'utf8'));
-			cachedIntegrationVersion = packageJson.version;
-			return cachedIntegrationVersion;
+		try {
+			const contents = await readFile(join(dir, 'package.json'), 'utf8');
+			const { version } = jsonParse<{ version?: string }>(contents);
+			// A package.json without a version is not the one we are looking for;
+			// returning it would tag requests with `n8n-langchain/undefined`.
+			if (version) return version;
+		} catch (error) {
+			const code = (error as NodeJS.ErrnoException).code;
+			if (code === undefined || !MISSING_PATH_CODES.has(code)) throw error;
 		}
 		const parent = dirname(dir);
 		if (parent === dir) break;
 		dir = parent;
 	}
 	throw new OperationalError('Could not resolve the n8n-nodes-langchain package version');
+}
+
+let cachedIntegrationVersion: Promise<string> | undefined;
+
+/**
+ * The version reported alongside {@link INTEGRATION_NAME} to Weaviate
+ * telemetry. This is the version of the integration itself — the
+ * nodes-langchain package — which is the value the `n8n-langchain/<version>`
+ * header is meant to carry.
+ *
+ * The in-flight promise is memoized rather than the resolved value, so that
+ * concurrent first calls share a single filesystem read.
+ *
+ * A rejection is cached too, since a missing or malformed `package.json` is a
+ * permanent property of the installation and re-walking it on every client
+ * creation would just repeat the same failure. Only transient filesystem
+ * errors evict the cache, so a passing resource blip does not disable
+ * telemetry for the lifetime of the process.
+ */
+export async function getIntegrationVersion(): Promise<string> {
+	cachedIntegrationVersion ??= resolveIntegrationVersion();
+	const pending = cachedIntegrationVersion;
+	try {
+		return await pending;
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		// Identity-guarded, so a retry already started by another caller is kept.
+		if (code !== undefined && TRANSIENT_FS_CODES.has(code) && cachedIntegrationVersion === pending) {
+			cachedIntegrationVersion = undefined;
+		}
+		throw error;
+	}
 }
 
 /**
@@ -86,7 +127,7 @@ export async function registerIntegrationHeader(client: WeaviateClient): Promise
 		// The client only spreads object-form headers into requests, so only the
 		// `Record<string, string>` form can be augmented in place.
 		if (headers && !Array.isArray(headers)) {
-			headers[INTEGRATION_HEADER] = `${INTEGRATION_NAME}/${getIntegrationVersion()}`;
+			headers[INTEGRATION_HEADER] = `${INTEGRATION_NAME}/${await getIntegrationVersion()}`;
 		}
 	} catch {
 		// Best-effort telemetry: never let header registration break the node.

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/Weaviate.utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStoreWeaviate/Weaviate.utils.ts
@@ -1,6 +1,6 @@
-import { existsSync, readFileSync } from 'fs';
 import { jsonParse, OperationalError } from 'n8n-workflow';
-import { dirname, join } from 'path';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import type {
 	FilterValue,
 	GeoRangeFilter,
@@ -34,38 +34,38 @@ const INTEGRATION_NAME = 'n8n-langchain';
 const INTEGRATION_HEADER = 'X-Weaviate-Client-Integration';
 
 /**
- * Resolves the running n8n version, used as the integration version reported to
- * Weaviate. Prefers the `N8N_VERSION` env var (when a deployment sets it) and
- * otherwise reads the package version. All packages in the monorepo share the
- * same version, so the local `package.json` version matches the n8n version.
+ * Resolves the `@n8n/n8n-nodes-langchain` package version, reported alongside
+ * {@link INTEGRATION_NAME} to Weaviate telemetry. This is a single, consistent
+ * source — the package version — and all packages in the monorepo share the
+ * same version, so it also matches the n8n version.
  *
- * The package version is found by walking up from this module to the nearest
- * `package.json`, which is robust to the differing directory depth between the
- * compiled (`dist/nodes/...`) and source/test (`nodes/...`) layouts.
+ * The version is read from the nearest `package.json` by walking up from this
+ * module, which is robust to the differing directory depth between the compiled
+ * (`dist/nodes/...`) and source/test (`nodes/...`) layouts. `moduleResolution`
+ * is classic `node` here, so a direct `package.json` import is not an option.
+ *
+ * Memoized, since a client is created per node execution but the version cannot
+ * change while the process is running.
  */
-export function getN8nVersion(): string {
-	if (process.env.N8N_VERSION) {
-		return process.env.N8N_VERSION;
-	}
+let cachedIntegrationVersion: string | undefined;
 
-	try {
-		let dir = __dirname;
-		// Walk up until a package.json is found or the filesystem root is reached.
-		while (true) {
-			const packageJsonPath = join(dir, 'package.json');
-			if (existsSync(packageJsonPath)) {
-				const packageJson = jsonParse<{ version: string }>(readFileSync(packageJsonPath, 'utf8'));
-				return packageJson.version;
-			}
-			const parent = dirname(dir);
-			if (parent === dir) break;
-			dir = parent;
+export function getIntegrationVersion(): string {
+	if (cachedIntegrationVersion !== undefined) return cachedIntegrationVersion;
+
+	let dir = __dirname;
+	// Walk up until a package.json is found or the filesystem root is reached.
+	while (true) {
+		const packageJsonPath = join(dir, 'package.json');
+		if (existsSync(packageJsonPath)) {
+			const packageJson = jsonParse<{ version: string }>(readFileSync(packageJsonPath, 'utf8'));
+			cachedIntegrationVersion = packageJson.version;
+			return cachedIntegrationVersion;
 		}
-	} catch {
-		// Fall through to the default below.
+		const parent = dirname(dir);
+		if (parent === dir) break;
+		dir = parent;
 	}
-
-	return '0.0.0';
+	throw new OperationalError('Could not resolve the n8n-nodes-langchain package version');
 }
 
 /**
@@ -86,7 +86,7 @@ export async function registerIntegrationHeader(client: WeaviateClient): Promise
 		// The client only spreads object-form headers into requests, so only the
 		// `Record<string, string>` form can be augmented in place.
 		if (headers && !Array.isArray(headers)) {
-			headers[INTEGRATION_HEADER] = `${INTEGRATION_NAME}/${getN8nVersion()}`;
+			headers[INTEGRATION_HEADER] = `${INTEGRATION_NAME}/${getIntegrationVersion()}`;
 		}
 	} catch {
 		// Best-effort telemetry: never let header registration break the node.

--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -267,7 +267,7 @@
     "@langchain/qdrant": "1.0.1",
     "@langchain/redis": "1.0.1",
     "@langchain/textsplitters": "1.0.1",
-    "@langchain/weaviate": "1.0.1",
+    "@langchain/weaviate": "1.1.0",
     "@microsoft/agents-a365-notifications": "1.0.0",
     "@microsoft/agents-a365-observability": "1.0.0",
     "@microsoft/agents-a365-runtime": "1.0.0",
@@ -329,7 +329,7 @@
     "tmp-promise": "3.0.3",
     "uuid": "catalog:",
     "vm2": "catalog:",
-    "weaviate-client": "3.9.0",
+    "weaviate-client": "3.13.1",
     "zod": "catalog:",
     "zod-to-json-schema": "catalog:"
   },

--- a/packages/@n8n/nodes-langchain/package.json
+++ b/packages/@n8n/nodes-langchain/package.json
@@ -265,7 +265,7 @@
     "@langchain/qdrant": "1.0.1",
     "@langchain/redis": "1.0.1",
     "@langchain/textsplitters": "1.0.1",
-    "@langchain/weaviate": "1.0.1",
+    "@langchain/weaviate": "1.1.0",
     "@microsoft/agents-a365-notifications": "1.0.0",
     "@microsoft/agents-a365-observability": "1.0.0",
     "@microsoft/agents-a365-runtime": "1.0.0",
@@ -326,7 +326,7 @@
     "tmp-promise": "3.0.3",
     "uuid": "catalog:",
     "vm2": "catalog:",
-    "weaviate-client": "3.9.0",
+    "weaviate-client": "3.13.1",
     "zod": "catalog:",
     "zod-to-json-schema": "catalog:"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3151,7 +3151,7 @@ importers:
         version: 1.0.1(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.46.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(encoding@0.1.13)
       '@langchain/community':
         specifier: 'catalog:'
-        version: 1.1.27(58b3539f609126398d3a2334339488d1)
+        version: 1.1.27(c51bff64fc200464a6a0f9944297b5fe)
       '@langchain/core':
         specifier: 'catalog:'
         version: 1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.46.0(@smithy/signature-v4@5.3.5)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
@@ -3198,8 +3198,8 @@ importers:
         specifier: 1.0.1
         version: 1.0.1(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.46.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@langchain/weaviate':
-        specifier: 1.0.1
-        version: 1.0.1(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.46.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(encoding@0.1.13)
+        specifier: 1.1.0
+        version: 1.1.0(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.46.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(encoding@0.1.13)
       '@microsoft/agents-a365-notifications':
         specifier: 1.0.0
         version: 1.0.0(@opentelemetry/api-logs@0.217.0)(@opentelemetry/api@1.9.1)
@@ -3381,8 +3381,8 @@ importers:
         specifier: 'catalog:'
         version: 3.11.5
       weaviate-client:
-        specifier: 3.9.0
-        version: 3.9.0(encoding@0.1.13)
+        specifier: 3.13.1
+        version: 3.13.1(encoding@0.1.13)
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -8459,6 +8459,9 @@ packages:
     resolution: {integrity: sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw==}
     engines: {node: '>17.0.0'}
 
+  '@datastructures-js/deque@1.0.8':
+    resolution: {integrity: sha512-PSBhJ2/SmeRPRHuBv7i/fHWIdSC3JTyq56qb+Rq0wjOagi0/fdV5/B/3Md5zFZus/W6OkSPMaxMKKMNMrSmubg==}
+
   '@daytona/api-client@0.187.0':
     resolution: {integrity: sha512-riKOJ6eSuy67DL6iJlAa3Bfjnm4iQmkOdJk0B5hqrYMZeZmVDsgdiZtYvFpyoa+2KCZFNb0Gs5dQwO1d6NhGCw==}
 
@@ -9754,11 +9757,11 @@ packages:
     peerDependencies:
       '@langchain/core': ^1.0.0
 
-  '@langchain/weaviate@1.0.1':
-    resolution: {integrity: sha512-6FZxtJkFWwm1R985mW9VvRd+K70FKtIT5FS/P5KKnIaQkGDUYmteLzHoTi9w47Ry3PHwLWhI1Ps8DCoYRtsQhw==}
+  '@langchain/weaviate@1.1.0':
+    resolution: {integrity: sha512-PB6pY5seDwGf40j81yG50QjIlVpqlWJxKQOvXLT4AG9vK6PgUhY4lbCbzNdYdXOEkOBRUUJlTL3s0SCc6iREsQ==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': ^1.0.0
+      '@langchain/core': ^1.1.49
 
   '@lezer/common@1.2.1':
     resolution: {integrity: sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ==}
@@ -13742,8 +13745,8 @@ packages:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  abort-controller-x@0.4.3:
-    resolution: {integrity: sha512-VtUwTNU8fpMwvWGn4xE93ywbogTYsuT+AUxAXOeelbXuQVIwNmC5YLeho9sH4vZ4ITW8414TTAOG1nW6uIVHCA==}
+  abort-controller-x@0.5.0:
+    resolution: {integrity: sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ==}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -18943,14 +18946,17 @@ packages:
   next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
 
-  nice-grpc-client-middleware-retry@3.1.11:
-    resolution: {integrity: sha512-xW/imz/kNG2g0DwTfH2eYEGrg1chSLrXtvGp9fg2qkhTgGFfAS/Pq3+t+9G8KThcC4hK/xlEyKvZWKk++33S6A==}
+  nice-grpc-client-middleware-retry@3.1.15:
+    resolution: {integrity: sha512-fXfNNdtjCQzc3O/w3WsK1AOU+xdE1V7FCm4FEQWS/UUVsV1616S2oryvWqsZAF8aOvuMir8lFtNmgH3DeP+PBg==}
 
   nice-grpc-common@2.0.2:
     resolution: {integrity: sha512-7RNWbls5kAL1QVUOXvBsv1uO0wPQK3lHv+cY1gwkTzirnG1Nop4cBJZubpgziNbaVc/bl9QJcyvsf/NQxa3rjQ==}
 
-  nice-grpc@2.1.12:
-    resolution: {integrity: sha512-J1n4Wg+D3IhRhGQb+iqh2OpiM0GzTve/kf2lnlW4S+xczmIEd0aHUDV1OsJ5a3q8GSTqJf+s4Rgg1M8uJltarw==}
+  nice-grpc-common@2.0.3:
+    resolution: {integrity: sha512-MEhnD3JMah0mgyivpb9hpRDbOBuXBxI/TVO+OK1h6rC97WM42HsPMR+zzRNQ0C5BqYJTw1nyWiQRD0DucO+pjQ==}
+
+  nice-grpc@2.1.16:
+    resolution: {integrity: sha512-Cl3Pn00212Hl8/U6bpgMxmhZj5lyv3nWoJov4cd3FjWarktrMHP4DNvSjCnDwkMWYx4W1tyscEia4JX6Y4GVCQ==}
 
   nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
@@ -22258,6 +22264,10 @@ packages:
     resolution: {integrity: sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==}
     hasBin: true
 
+  uuid@14.0.1:
+    resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+    hasBin: true
+
   v-code-diff@1.13.1:
     resolution: {integrity: sha512-9LTV1dZhC1oYTntyB94vfumGgsfIX5u0fEDSI2Txx4vCE5sI5LkgeLJRRy2SsTVZmDcV+R73sBr0GpPn0TJxMw==}
     peerDependencies:
@@ -22593,9 +22603,9 @@ packages:
   weapon-regex@1.3.6:
     resolution: {integrity: sha512-wsf1m1jmMrso5nhwVFJJHSubEBf3+pereGd7+nBKtYJ18KoB/PWJOHS3WRkwS04VrOU0iJr2bZU+l1QaTJ+9nA==}
 
-  weaviate-client@3.9.0:
-    resolution: {integrity: sha512-7qwg7YONAaT4zWnohLrFdzky+rZegVe76J+Tky/+7tuyvjFpdKgSrdqI/wPDh8aji0ZGZrL4DdGwGfFnZ+uV4w==}
-    engines: {node: '>=18.0.0'}
+  weaviate-client@3.13.1:
+    resolution: {integrity: sha512-cimmwR8w8GnSKQsP7tyW3dT2fMxJA2Tj+WqGzaVVkTVOLH4bb4B4iY0SO3TJUM4L8bcHkL04+MY2RAWEWJpU6A==}
+    engines: {node: '>=22.0.0'}
 
   web-resource-inliner@6.0.1:
     resolution: {integrity: sha512-kfqDxt5dTB1JhqsCUQVFDj0rmY+4HLwGQIsLPbyrsN9y9WV/1oFDSx3BQ4GfCv9X+jVeQ7rouTqwK53rA/7t8A==}
@@ -25656,6 +25666,8 @@ snapshots:
 
   '@dagrejs/graphlib@2.2.4': {}
 
+  '@datastructures-js/deque@1.0.8': {}
+
   '@daytona/api-client@0.187.0':
     dependencies:
       axios: 1.18.0(patch_hash=149e256a2a7b632497650b32816716ced972ab02a5ab00fbd8a5158a51722c49)(debug@4.4.3)
@@ -26545,7 +26557,60 @@ snapshots:
       - aws-crt
       - encoding
 
-  '@langchain/community@1.1.27(58b3539f609126398d3a2334339488d1)':
+  '@langchain/community@1.1.27(b1822a993b35582954040a82820e4d06)':
+    dependencies:
+      '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.60.0)(bufferutil@4.0.9)(deepmerge@4.3.1)(dotenv@17.4.2)(encoding@0.1.13)(openai@6.46.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(utf-8-validate@5.0.10)(zod@3.25.76)
+      '@ibm-cloud/watsonx-ai': 1.1.2
+      '@langchain/classic': 1.0.27(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.46.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(cheerio@1.1.0)(openai@6.46.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@langchain/core': 1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.46.0(@smithy/signature-v4@5.3.5)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      '@langchain/openai': 1.4.1(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.46.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      binary-extensions: 2.2.0
+      flat: 5.0.2
+      ibm-cloud-sdk-core: 5.5.0
+      js-yaml: 4.3.0
+      langsmith: 0.6.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.46.0(@smithy/signature-v4@5.3.5)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
+      math-expression-evaluator: 2.0.7
+      openai: 6.46.0(@smithy/signature-v4@5.3.5)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
+      uuid: 13.0.1
+      zod: 3.25.76
+    optionalDependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@azure/storage-blob': 12.32.0
+      '@browserbasehq/sdk': 2.12.0(encoding@0.1.13)
+      '@getzep/zep-cloud': 1.0.6(40d462dc04f2b28317190740cba7d89c)
+      '@google-cloud/storage': 7.12.1(encoding@0.1.13)
+      '@libsql/client': 0.17.2(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
+      '@mozilla/readability': 0.6.0
+      '@smithy/eventstream-codec': 4.4.14
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/util-utf8': 4.4.14
+      '@supabase/supabase-js': 2.50.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      '@zilliz/milvus2-sdk-node': 2.5.7
+      chromadb: 3.2.0
+      crypto-js: 4.2.0
+      epub2: 3.0.2(ts-toolbelt@9.6.0)
+      fast-xml-parser: 5.7.2
+      google-auth-library: 10.1.0
+      html-to-text: 9.0.5
+      ignore: 7.0.5
+      ioredis: 5.3.2
+      jsdom: 23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      jsonwebtoken: 9.0.3
+      lodash: 4.18.1(patch_hash=81ead1b07fc8efda87bd2724dbd876ab49f4a0aa03f96c3770060b2ea47d9e0b)
+      mammoth: 1.12.0
+      pdf-parse: 2.4.5
+      pg: 8.21.0(pg-native@3.8.0)
+      playwright: 1.60.0
+      puppeteer: 24.41.0(bufferutil@4.0.9)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      ws: 8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+    transitivePeerDependencies:
+      - '@opentelemetry/api'
+      - '@opentelemetry/exporter-trace-otlp-proto'
+      - '@opentelemetry/sdk-trace-base'
+      - '@smithy/hash-node'
+      - peggy
+
+  '@langchain/community@1.1.27(c51bff64fc200464a6a0f9944297b5fe)':
     dependencies:
       '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.60.0)(bufferutil@4.0.9)(deepmerge@4.3.1)(dotenv@17.4.2)(encoding@0.1.13)(openai@6.46.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(utf-8-validate@5.0.10)(zod@3.25.76)
       '@ibm-cloud/watsonx-ai': 1.1.2
@@ -26602,60 +26667,7 @@ snapshots:
       playwright: 1.60.0
       puppeteer: 24.41.0(@typescript/typescript6@6.0.2)(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       redis: 4.6.14
-      weaviate-client: 3.9.0(encoding@0.1.13)
-      ws: 8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-    transitivePeerDependencies:
-      - '@opentelemetry/api'
-      - '@opentelemetry/exporter-trace-otlp-proto'
-      - '@opentelemetry/sdk-trace-base'
-      - '@smithy/hash-node'
-      - peggy
-
-  '@langchain/community@1.1.27(b1822a993b35582954040a82820e4d06)':
-    dependencies:
-      '@browserbasehq/stagehand': 1.14.0(@playwright/test@1.60.0)(bufferutil@4.0.9)(deepmerge@4.3.1)(dotenv@17.4.2)(encoding@0.1.13)(openai@6.46.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(utf-8-validate@5.0.10)(zod@3.25.76)
-      '@ibm-cloud/watsonx-ai': 1.1.2
-      '@langchain/classic': 1.0.27(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.46.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(cheerio@1.1.0)(openai@6.46.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@langchain/core': 1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.46.0(@smithy/signature-v4@5.3.5)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      '@langchain/openai': 1.4.1(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.46.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      binary-extensions: 2.2.0
-      flat: 5.0.2
-      ibm-cloud-sdk-core: 5.5.0
-      js-yaml: 4.3.0
-      langsmith: 0.6.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.46.0(@smithy/signature-v4@5.3.5)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      math-expression-evaluator: 2.0.7
-      openai: 6.46.0(@smithy/signature-v4@5.3.5)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76)
-      uuid: 13.0.1
-      zod: 3.25.76
-    optionalDependencies:
-      '@aws-crypto/sha256-js': 5.2.0
-      '@azure/storage-blob': 12.32.0
-      '@browserbasehq/sdk': 2.12.0(encoding@0.1.13)
-      '@getzep/zep-cloud': 1.0.6(40d462dc04f2b28317190740cba7d89c)
-      '@google-cloud/storage': 7.12.1(encoding@0.1.13)
-      '@libsql/client': 0.17.2(bufferutil@4.0.9)(encoding@0.1.13)(utf-8-validate@5.0.10)
-      '@mozilla/readability': 0.6.0
-      '@smithy/eventstream-codec': 4.4.14
-      '@smithy/protocol-http': 5.3.12
-      '@smithy/util-utf8': 4.4.14
-      '@supabase/supabase-js': 2.50.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      '@zilliz/milvus2-sdk-node': 2.5.7
-      chromadb: 3.2.0
-      crypto-js: 4.2.0
-      epub2: 3.0.2(ts-toolbelt@9.6.0)
-      fast-xml-parser: 5.7.2
-      google-auth-library: 10.1.0
-      html-to-text: 9.0.5
-      ignore: 7.0.5
-      ioredis: 5.3.2
-      jsdom: 23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      jsonwebtoken: 9.0.3
-      lodash: 4.18.1(patch_hash=81ead1b07fc8efda87bd2724dbd876ab49f4a0aa03f96c3770060b2ea47d9e0b)
-      mammoth: 1.12.0
-      pdf-parse: 2.4.5
-      pg: 8.21.0(pg-native@3.8.0)
-      playwright: 1.60.0
-      puppeteer: 24.41.0(bufferutil@4.0.9)(typescript@7.0.2)(utf-8-validate@5.0.10)
+      weaviate-client: 3.13.1(encoding@0.1.13)
       ws: 8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -26899,11 +26911,10 @@ snapshots:
       '@langchain/core': 1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.46.0(@smithy/signature-v4@5.3.5)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       js-tiktoken: 1.0.21
 
-  '@langchain/weaviate@1.0.1(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.46.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(encoding@0.1.13)':
+  '@langchain/weaviate@1.1.0(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.46.0(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(encoding@0.1.13)':
     dependencies:
       '@langchain/core': 1.2.0(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.217.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.7.1(@opentelemetry/api@1.9.1))(openai@6.46.0(@smithy/signature-v4@5.3.5)(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.0(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      uuid: 13.0.1
-      weaviate-client: 3.9.0(encoding@0.1.13)
+      weaviate-client: 3.13.1(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
 
@@ -31484,7 +31495,7 @@ snapshots:
 
   abbrev@4.0.0: {}
 
-  abort-controller-x@0.4.3: {}
+  abort-controller-x@0.5.0: {}
 
   abort-controller@3.0.0:
     dependencies:
@@ -37766,20 +37777,24 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  nice-grpc-client-middleware-retry@3.1.11:
+  nice-grpc-client-middleware-retry@3.1.15:
     dependencies:
-      abort-controller-x: 0.4.3
-      nice-grpc-common: 2.0.2
+      abort-controller-x: 0.5.0
+      nice-grpc-common: 2.0.3
 
   nice-grpc-common@2.0.2:
     dependencies:
       ts-error: 1.0.6
 
-  nice-grpc@2.1.12:
+  nice-grpc-common@2.0.3:
+    dependencies:
+      ts-error: 1.0.6
+
+  nice-grpc@2.1.16:
     dependencies:
       '@grpc/grpc-js': 1.14.4
-      abort-controller-x: 0.4.3
-      nice-grpc-common: 2.0.2
+      abort-controller-x: 0.5.0
+      nice-grpc-common: 2.0.3
 
   nice-try@1.0.5: {}
 
@@ -41842,6 +41857,8 @@ snapshots:
 
   uuid@13.0.1: {}
 
+  uuid@14.0.1: {}
+
   v-code-diff@1.13.1(patch_hash=21588de80e591bbc1e5a068d9bce311db5254686443652945d2c7887fdafe9d9)(vue@3.5.26(typescript@6.0.2)):
     dependencies:
       diff: 8.0.3
@@ -42216,16 +42233,17 @@ snapshots:
 
   weapon-regex@1.3.6: {}
 
-  weaviate-client@3.9.0(encoding@0.1.13):
+  weaviate-client@3.13.1(encoding@0.1.13):
     dependencies:
-      abort-controller-x: 0.4.3
+      '@datastructures-js/deque': 1.0.8
+      abort-controller-x: 0.5.0
       graphql: 16.11.0
       graphql-request: 6.1.0(encoding@0.1.13)(graphql@16.11.0)
       long: 5.3.2
-      nice-grpc: 2.1.12
-      nice-grpc-client-middleware-retry: 3.1.11
+      nice-grpc: 2.1.16
+      nice-grpc-client-middleware-retry: 3.1.15
       nice-grpc-common: 2.0.2
-      uuid: 13.0.1
+      uuid: 14.0.1
     transitivePeerDependencies:
       - encoding
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3404,8 +3404,8 @@ importers:
         specifier: 1.0.1
         version: 1.0.1(@langchain/core@1.2.8(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)))
       '@langchain/weaviate':
-        specifier: 1.0.1
-        version: 1.0.1(@langchain/core@1.2.8(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(encoding@0.1.13)
+        specifier: 1.1.0
+        version: 1.1.0(@langchain/core@1.2.8(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(encoding@0.1.13)
       '@microsoft/agents-a365-notifications':
         specifier: 1.0.0
         version: 1.0.0(@opentelemetry/api-logs@0.221.0)(@opentelemetry/api@1.9.1)(supports-color@8.1.1)
@@ -3590,8 +3590,8 @@ importers:
         specifier: 'catalog:'
         version: 3.11.6
       weaviate-client:
-        specifier: 3.9.0
-        version: 3.9.0(encoding@0.1.13)
+        specifier: 3.13.1
+        version: 3.13.1(encoding@0.1.13)
       zod:
         specifier: 3.25.76
         version: 3.25.76
@@ -9543,6 +9543,9 @@ packages:
     resolution: {integrity: sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw==}
     engines: {node: '>17.0.0'}
 
+  '@datastructures-js/deque@1.0.8':
+    resolution: {integrity: sha512-PSBhJ2/SmeRPRHuBv7i/fHWIdSC3JTyq56qb+Rq0wjOagi0/fdV5/B/3Md5zFZus/W6OkSPMaxMKKMNMrSmubg==}
+
   '@daytona/analytics-api-client@0.205.1':
     resolution: {integrity: sha512-/kGNw6RGI7psf5OYqOPTfyN2tDW/206XBMXFQxmD3Ljuor/xk17WrONRah35OJy62lk+BzvCRtnkGBNEL4EjhQ==}
 
@@ -10905,11 +10908,11 @@ packages:
     peerDependencies:
       '@langchain/core': ^1.0.0
 
-  '@langchain/weaviate@1.0.1':
-    resolution: {integrity: sha512-6FZxtJkFWwm1R985mW9VvRd+K70FKtIT5FS/P5KKnIaQkGDUYmteLzHoTi9w47Ry3PHwLWhI1Ps8DCoYRtsQhw==}
+  '@langchain/weaviate@1.1.0':
+    resolution: {integrity: sha512-PB6pY5seDwGf40j81yG50QjIlVpqlWJxKQOvXLT4AG9vK6PgUhY4lbCbzNdYdXOEkOBRUUJlTL3s0SCc6iREsQ==}
     engines: {node: '>=20'}
     peerDependencies:
-      '@langchain/core': ^1.0.0
+      '@langchain/core': ^1.1.49
 
   '@lezer/common@1.2.1':
     resolution: {integrity: sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ==}
@@ -15458,8 +15461,8 @@ packages:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  abort-controller-x@0.4.3:
-    resolution: {integrity: sha512-VtUwTNU8fpMwvWGn4xE93ywbogTYsuT+AUxAXOeelbXuQVIwNmC5YLeho9sH4vZ4ITW8414TTAOG1nW6uIVHCA==}
+  abort-controller-x@0.5.0:
+    resolution: {integrity: sha512-yTt9CI0x+nRfX6BFMenEGP8ooPvErGH6AbFz20C2IeOLIlDsrw/VHpgne3GsCEuTA410IiFiaLVFKmgM4bKEPQ==}
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -20768,14 +20771,17 @@ packages:
   next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
 
-  nice-grpc-client-middleware-retry@3.1.11:
-    resolution: {integrity: sha512-xW/imz/kNG2g0DwTfH2eYEGrg1chSLrXtvGp9fg2qkhTgGFfAS/Pq3+t+9G8KThcC4hK/xlEyKvZWKk++33S6A==}
+  nice-grpc-client-middleware-retry@3.1.16:
+    resolution: {integrity: sha512-8EbOCUZZ1Uq1pCfTD8dB2zMU1AYrilRvm9al5VSUi444eqhPhxElnI7iqP6ZY/ixb1NGsvMpfbU5FW/3L7DdFw==}
 
   nice-grpc-common@2.0.2:
     resolution: {integrity: sha512-7RNWbls5kAL1QVUOXvBsv1uO0wPQK3lHv+cY1gwkTzirnG1Nop4cBJZubpgziNbaVc/bl9QJcyvsf/NQxa3rjQ==}
 
-  nice-grpc@2.1.12:
-    resolution: {integrity: sha512-J1n4Wg+D3IhRhGQb+iqh2OpiM0GzTve/kf2lnlW4S+xczmIEd0aHUDV1OsJ5a3q8GSTqJf+s4Rgg1M8uJltarw==}
+  nice-grpc-common@2.0.4:
+    resolution: {integrity: sha512-gOEXlD6ShXZMZ8k+49wm/bA2j1+3IKbEFV9WYREJcvZV4kM5L1KkILYTX9VYBzZF2OuYCe1wp8c82bQkvR0fHw==}
+
+  nice-grpc@2.1.17:
+    resolution: {integrity: sha512-pu9xYPlWSeqoYQOCqb2ftQqZi/P2DaI70PSuwnxvoyIRiilaOVtktyPe6LmuXegWB4Ic1sPuDGCnCCASbwzK0w==}
 
   nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
@@ -24148,6 +24154,10 @@ packages:
     resolution: {integrity: sha512-9ezox2roIft6ExBVTVqibSd5dc5/47Sw/uY6b4SjQUT2TzQ0tltNquWA46y4xPQmdZYqvnio22SgWd41M86+jw==}
     hasBin: true
 
+  uuid@14.0.2:
+    resolution: {integrity: sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==}
+    hasBin: true
+
   v-code-diff@1.13.1:
     resolution: {integrity: sha512-9LTV1dZhC1oYTntyB94vfumGgsfIX5u0fEDSI2Txx4vCE5sI5LkgeLJRRy2SsTVZmDcV+R73sBr0GpPn0TJxMw==}
     peerDependencies:
@@ -24477,9 +24487,9 @@ packages:
   weapon-regex@2.0.4:
     resolution: {integrity: sha512-ubuhY5Lo4phWcMsJqe8j62m9uhsuo/VpfK5XsSgYGRGDSt10hwVwOBTriPRd0dac+KYbGNXOrfXjM6xCp2NUKg==}
 
-  weaviate-client@3.9.0:
-    resolution: {integrity: sha512-7qwg7YONAaT4zWnohLrFdzky+rZegVe76J+Tky/+7tuyvjFpdKgSrdqI/wPDh8aji0ZGZrL4DdGwGfFnZ+uV4w==}
-    engines: {node: '>=18.0.0'}
+  weaviate-client@3.13.1:
+    resolution: {integrity: sha512-cimmwR8w8GnSKQsP7tyW3dT2fMxJA2Tj+WqGzaVVkTVOLH4bb4B4iY0SO3TJUM4L8bcHkL04+MY2RAWEWJpU6A==}
+    engines: {node: '>=22.0.0'}
 
   web-resource-inliner@6.0.1:
     resolution: {integrity: sha512-kfqDxt5dTB1JhqsCUQVFDj0rmY+4HLwGQIsLPbyrsN9y9WV/1oFDSx3BQ4GfCv9X+jVeQ7rouTqwK53rA/7t8A==}
@@ -28682,6 +28692,8 @@ snapshots:
 
   '@dagrejs/graphlib@2.2.4': {}
 
+  '@datastructures-js/deque@1.0.8': {}
+
   '@daytona/analytics-api-client@0.205.1(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)':
     dependencies:
       axios: 1.18.0(patch_hash=149e256a2a7b632497650b32816716ced972ab02a5ab00fbd8a5158a51722c49)(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
@@ -29827,7 +29839,7 @@ snapshots:
       playwright: 1.62.1
       puppeteer: 24.41.0(@typescript/typescript6@6.0.2)(bufferutil@4.0.9)(supports-color@8.1.1)(utf-8-validate@5.0.10)
       redis: 4.6.14
-      weaviate-client: 3.9.0(encoding@0.1.13)
+      weaviate-client: 3.13.1(encoding@0.1.13)
       ws: 8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -29891,7 +29903,7 @@ snapshots:
       playwright: 1.62.1
       puppeteer: 24.41.0(bufferutil@4.0.9)(supports-color@8.1.1)(typescript@7.0.2)(utf-8-validate@5.0.10)
       redis: 4.6.14
-      weaviate-client: 3.9.0(encoding@0.1.13)
+      weaviate-client: 3.13.1(encoding@0.1.13)
       ws: 8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@opentelemetry/api'
@@ -30151,11 +30163,10 @@ snapshots:
       '@langchain/core': 1.2.8(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
       js-tiktoken: 1.0.21
 
-  '@langchain/weaviate@1.0.1(@langchain/core@1.2.8(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(encoding@0.1.13)':
+  '@langchain/weaviate@1.1.0(@langchain/core@1.2.8(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)))(encoding@0.1.13)':
     dependencies:
       '@langchain/core': 1.2.8(@opentelemetry/api@1.9.1)(@opentelemetry/exporter-trace-otlp-proto@0.221.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.10.0(@opentelemetry/api@1.9.1))(openai@6.46.0(@aws-sdk/credential-provider-node@3.972.80)(@smithy/signature-v4@5.7.2)(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.76))(ws@8.21.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      uuid: 13.0.1
-      weaviate-client: 3.9.0(encoding@0.1.13)
+      weaviate-client: 3.13.1(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
 
@@ -35287,7 +35298,7 @@ snapshots:
 
   abbrev@4.0.0: {}
 
-  abort-controller-x@0.4.3: {}
+  abort-controller-x@0.5.0: {}
 
   abort-controller@3.0.0:
     dependencies:
@@ -41856,20 +41867,24 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  nice-grpc-client-middleware-retry@3.1.11:
+  nice-grpc-client-middleware-retry@3.1.16:
     dependencies:
-      abort-controller-x: 0.4.3
-      nice-grpc-common: 2.0.2
+      abort-controller-x: 0.5.0
+      nice-grpc-common: 2.0.4
 
   nice-grpc-common@2.0.2:
     dependencies:
       ts-error: 1.0.6
 
-  nice-grpc@2.1.12:
+  nice-grpc-common@2.0.4:
+    dependencies:
+      ts-error: 1.0.6
+
+  nice-grpc@2.1.17:
     dependencies:
       '@grpc/grpc-js': 1.14.4
-      abort-controller-x: 0.4.3
-      nice-grpc-common: 2.0.2
+      abort-controller-x: 0.5.0
+      nice-grpc-common: 2.0.4
 
   nice-try@1.0.5: {}
 
@@ -46092,6 +46107,8 @@ snapshots:
 
   uuid@13.0.1: {}
 
+  uuid@14.0.2: {}
+
   v-code-diff@1.13.1(patch_hash=21588de80e591bbc1e5a068d9bce311db5254686443652945d2c7887fdafe9d9)(vue@3.5.26(typescript@6.0.2)):
     dependencies:
       diff: 8.0.3
@@ -46482,16 +46499,17 @@ snapshots:
 
   weapon-regex@2.0.4: {}
 
-  weaviate-client@3.9.0(encoding@0.1.13):
+  weaviate-client@3.13.1(encoding@0.1.13):
     dependencies:
-      abort-controller-x: 0.4.3
+      '@datastructures-js/deque': 1.0.8
+      abort-controller-x: 0.5.0
       graphql: 16.11.0
       graphql-request: 6.1.0(encoding@0.1.13)(graphql@16.11.0)
       long: 5.3.2
-      nice-grpc: 2.1.12
-      nice-grpc-client-middleware-retry: 3.1.11
+      nice-grpc: 2.1.17
+      nice-grpc-client-middleware-retry: 3.1.16
       nice-grpc-common: 2.0.2
-      uuid: 13.0.1
+      uuid: 14.0.2
     transitivePeerDependencies:
       - encoding
 


### PR DESCRIPTION
## Summary

Bump Weaviate Client version and implement fixes and new features.

- Fix: hybrid not passing filters over to Langchain stack
- Add feature: create custom collection
- Add: integration telemetry header so Weaviate can track n8n LangChain usage

### Integration telemetry header

Clients created by the Weaviate vector store node are now tagged with an
`X-Weaviate-Client-Integration: n8n-langchain/<n8n version>` header, so Weaviate
can identify traffic originating from the n8n LangChain nodes in its telemetry.
This mirrors the [`langchain-weaviate` JS integration](https://github.com/langchain-ai/langchainjs/pull/11088).

- The JS `weaviate-client` exposes no public `integrations.configure(...)` API
  (unlike the Python client), so we mutate the live `headers` object returned by
  `getConnectionDetails()`. The client spreads that same object into every
  request, so both the HTTP and gRPC transports get tagged without reaching into
  any private internals.
- Best-effort and non-blocking: registration never throws, so a future change to
  the client's shape silently skips tagging instead of breaking the node.
- The integration name is `n8n-langchain` and the version is the
  `@n8n/n8n-nodes-langchain` package version — the version of the integration
  itself, which is what the `n8n-langchain/<version>` header is meant to carry.
  `N8N_VERSION` is deliberately not used: it is only a build `ARG` and OCI label
  in the n8n Dockerfile, never a runtime `ENV`, so it is undefined in the
  official image, in `npm i -g n8n`, and in local dev. Reading it first would
  mean most installs report one value and a minority another — two semantics for
  one field.
- The version is resolved asynchronously (`node:fs/promises`) from the nearest
  `package.json`, memoized on the in-flight promise so concurrent first calls
  share a single read and never block the event loop.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/langchain-ai/langchainjs/pull/10785
https://github.com/langchain-ai/langchainjs/pull/11088
https://github.com/weaviate/weaviate/issues/11262


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

