### PR TITLE
ci: Add artifact prefix to e2e runs to prevent clashing

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -211,6 +211,7 @@ jobs:
       test-mode: docker-artifact
       test-command: pnpm --filter=n8n-playwright test:container:sqlite:e2e tests/e2e/building-blocks/workflow-entry-points.spec.ts
       workers: '1'
+      artifact-prefix: sanity
     secrets: inherit
 
   # Full e2e run. Internal PRs run multi-main (postgres + redis + caddy + 2 mains + 1 worker).
@@ -230,6 +231,7 @@ jobs:
       test-command: ${{ github.event.pull_request.head.repo.fork == true && 'pnpm --filter=n8n-playwright test:container:sqlite:e2e --grep-invert=@licensed' || 'pnpm --filter=n8n-playwright test:container:multi-main:e2e' }}
       workers: '1'
       pre-generated-matrix: ${{ needs.install-and-build.outputs.matrix }}
+      artifact-prefix: e2e
     secrets: inherit
 
   # Boots the editor-ui against the Vite dev server and fails on any console

--- a/.github/workflows/test-e2e-coverage-weekly.yml
+++ b/.github/workflows/test-e2e-coverage-weekly.yml
@@ -25,6 +25,7 @@ jobs:
       runner: blacksmith-4vcpu-ubuntu-2204
       timeout-minutes: 45
       pre-generated-matrix: '[{"shard":1,"images":""},{"shard":2,"images":""},{"shard":3,"images":""},{"shard":4,"images":""}]'
+      artifact-prefix: coverage
     secrets: inherit
 
   aggregate:
@@ -42,7 +43,7 @@ jobs:
       - name: Download shard artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          pattern: e2e-shard-*
+          pattern: coverage-shard-*
           path: /tmp/shards/
 
       - name: Collect coverage JSON

--- a/.github/workflows/test-e2e-infrastructure-reusable.yml
+++ b/.github/workflows/test-e2e-infrastructure-reusable.yml
@@ -38,4 +38,5 @@ jobs:
       workers: '1'
       runner: ${{ matrix.runner }}
       timeout-minutes: 120
+      artifact-prefix: benchmark
     secrets: inherit

--- a/.github/workflows/test-e2e-performance-reusable.yml
+++ b/.github/workflows/test-e2e-performance-reusable.yml
@@ -19,4 +19,5 @@ jobs:
       test-mode: docker-artifact
       test-command: pnpm --filter=n8n-playwright test:performance
       currents-project-id: 'O9BJaN'
+      artifact-prefix: performance
     secrets: inherit

--- a/.github/workflows/test-e2e-reusable.yml
+++ b/.github/workflows/test-e2e-reusable.yml
@@ -47,6 +47,11 @@ on:
         required: false
         default: ''
         type: string
+      artifact-prefix:
+        description: 'Prefix for uploaded shard artifacts'
+        required: false
+        default: 'e2e'
+        type: string
 
 env:
   NODE_OPTIONS: ${{ contains(inputs.runner, '2vcpu') && '--max-old-space-size=6144' || '' }}
@@ -120,7 +125,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: e2e-shard-${{ matrix.shard }}
+          name: ${{ inputs.artifact-prefix }}-shard-${{ matrix.shard }}
           path: |
             packages/testing/playwright/test-results/
             packages/testing/playwright/playwright-report/

--- a/.github/workflows/test-e2e-vm-expressions-nightly.yml
+++ b/.github/workflows/test-e2e-vm-expressions-nightly.yml
@@ -29,6 +29,7 @@ jobs:
       workers: '1'
       pre-generated-matrix: '[{"shard":1},{"shard":2},{"shard":3},{"shard":4},{"shard":5},{"shard":6},{"shard":7},{"shard":8},{"shard":9},{"shard":10},{"shard":11},{"shard":12},{"shard":13},{"shard":14},{"shard":15},{"shard":16}]'
       n8n-env: '{"N8N_EXPRESSION_ENGINE":"vm"}'
+      artifact-prefix: vm-expressions
     secrets: inherit
 
   notify-on-failure:


### PR DESCRIPTION
## Summary

CI Was breaking on Shard 1 due to a HTTP 409: Conflict caused due to an artifact with the same name already existing inside the given [workflow run](https://github.com/n8n-io/n8n/actions/runs/25700374514/job/75459751133?pr=30274#step:9:34).

This was caused by situations where `SQLite: Sanity Check` ran in the same workflow run as `E2E`. They both upload artifacts with the same name `e2e-shard-1`, causing a naming clash.

This PR adds a `artifact-prefix` input to the `test-e2e-reusable.yml` workflow that defaults to `e2e`.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/actions/runs/25700374514/job/75459751133?pr=30274#step:9:34


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
