### PR TITLE
fix: Show friendly message in computer use cli when connection token is invalid (no-changelog)

### DIFF
--- a/packages/@n8n/computer-use/src/cli.ts
+++ b/packages/@n8n/computer-use/src/cli.ts
@@ -5,13 +5,14 @@ import * as fs from 'node:fs/promises';
 
 import { isOriginAllowed, parseConfig } from './config';
 import { cliConfirmResourceAccess, sanitizeForTerminal } from './confirm-resource-cli';
-import { GatewayClient } from './gateway-client';
+import { GatewayAuthError, GatewayClient } from './gateway-client';
 import { GatewaySession } from './gateway-session';
 import {
 	configure,
 	logger,
 	printBanner,
 	printConnected,
+	printInvalidToken,
 	printModuleStatus,
 	printToolList,
 } from './logger';
@@ -223,7 +224,15 @@ async function main(
 	process.on('SIGINT', shutdown);
 	process.on('SIGTERM', shutdown);
 
-	await client.start();
+	try {
+		await client.start();
+	} catch (error) {
+		if (error instanceof GatewayAuthError) {
+			printInvalidToken(origin);
+			process.exit(1);
+		}
+		throw error;
+	}
 
 	printConnected(url);
 	printToolList(client.tools);

--- a/packages/@n8n/computer-use/src/gateway-client.test.ts
+++ b/packages/@n8n/computer-use/src/gateway-client.test.ts
@@ -41,7 +41,7 @@ jest.mock('./tools/browser', () => ({
 }));
 
 import type { GatewayConfig } from './config';
-import { GatewayClient } from './gateway-client';
+import { GatewayAuthError, GatewayClient } from './gateway-client';
 import type { GatewaySession } from './gateway-session';
 import type { AffectedResource, ConfirmResourceAccess, ToolDefinition } from './tools/types';
 import { INSTANCE_RESOURCE_DECISION_KEYS } from './tools/types';
@@ -255,5 +255,67 @@ describe('GatewayClient.checkPermissions', () => {
 			expect(session.allowForSession).toHaveBeenCalledWith('shell', 'npm install');
 			expect(confirmResourceAccess).not.toHaveBeenCalled();
 		});
+	});
+});
+
+describe('GatewayClient.uploadCapabilities', () => {
+	const originalFetch = global.fetch;
+
+	beforeEach(() => {
+		global.fetch = jest.fn();
+	});
+
+	afterEach(() => {
+		global.fetch = originalFetch;
+	});
+
+	function makeMinimalClient(): GatewayClient {
+		const client = new GatewayClient({
+			url: 'http://localhost:5678',
+			apiKey: 'tok',
+			config: makeConfig(),
+			session: makeSession(),
+			confirmResourceAccess: jest.fn(),
+		});
+
+		// Bypass tool discovery — uploadCapabilities only needs definitions to exist.
+		// @ts-expect-error — accessing private field for testing
+		client.allDefinitions = [];
+		// @ts-expect-error — accessing private field for testing
+		client.activeToolCategories = [];
+
+		return client;
+	}
+
+	function mockFetchResponse(status: number, body = ''): void {
+		(global.fetch as jest.Mock).mockResolvedValueOnce({
+			ok: status >= 200 && status < 300,
+			status,
+			text: jest.fn().mockResolvedValue(body),
+			json: jest.fn().mockResolvedValue({ data: { ok: true } }),
+		});
+	}
+
+	it('throws GatewayAuthError on 401', async () => {
+		mockFetchResponse(401, 'invalid token');
+		const client = makeMinimalClient();
+
+		await expect(client['uploadCapabilities']()).rejects.toBeInstanceOf(GatewayAuthError);
+	});
+
+	it('throws GatewayAuthError on 403', async () => {
+		mockFetchResponse(403, 'forbidden');
+		const client = makeMinimalClient();
+
+		await expect(client['uploadCapabilities']()).rejects.toBeInstanceOf(GatewayAuthError);
+	});
+
+	it('throws plain Error on non-auth failure (500)', async () => {
+		mockFetchResponse(500, 'server exploded');
+		const client = makeMinimalClient();
+
+		const promise = client['uploadCapabilities']();
+		await expect(promise).rejects.not.toBeInstanceOf(GatewayAuthError);
+		await expect(promise).rejects.toThrow(/Failed to upload capabilities: 500/);
 	});
 });

--- a/packages/@n8n/computer-use/src/gateway-client.ts
+++ b/packages/@n8n/computer-use/src/gateway-client.ts
@@ -32,6 +32,17 @@ import { formatErrorResult } from './tools/utils';
 const MAX_RECONNECT_DELAY_MS = 30_000;
 const MAX_AUTH_RETRIES = 5;
 
+/** Thrown when the gateway rejects our pairing token with 401/403. */
+export class GatewayAuthError extends Error {
+	constructor(
+		readonly status: number,
+		readonly body: string,
+	) {
+		super(`Gateway rejected token: ${status} ${body}`);
+		this.name = 'GatewayAuthError';
+	}
+}
+
 /** Tag tool definitions with a category annotation (mutates in place for efficiency). */
 function tagCategory(defs: ToolDefinition[], category: string): ToolDefinition[] {
 	for (const def of defs) {
@@ -301,6 +312,9 @@ export class GatewayClient {
 
 		if (!response.ok) {
 			const text = await response.text();
+			if (response.status === 401 || response.status === 403) {
+				throw new GatewayAuthError(response.status, text);
+			}
 			throw new Error(`Failed to upload capabilities: ${response.status} ${text}`);
 		}
 

--- a/packages/@n8n/computer-use/src/logger.ts
+++ b/packages/@n8n/computer-use/src/logger.ts
@@ -259,6 +259,13 @@ export function printAuthFailure(): void {
 	logger.error(`  ${pc.red('✗')} Authentication failed — waiting for new pairing token`);
 }
 
+export function printInvalidToken(url: string): void {
+	logger.error(`  ${pc.red('✗')} Connection token invalid`);
+	logger.error(
+		`    ${pc.dim(`Go to ${url} and reconnect n8n Computer Use using a new connection token`)}`,
+	);
+}
+
 export function printReinitializing(): void {
 	logger.info(`  ${pc.magenta('▸')} Re-initializing gateway connection`);
 }


### PR DESCRIPTION
## Summary

When the n8n Computer Use CLI started with an invalid/expired connection token, the gateway returned 401/403 and the CLI surfaced an unhelpful "Fatal error" message. This change distinguishes auth failures from other startup errors and prints a clear, actionable message instead.

- Introduces a `GatewayAuthError` thrown from `uploadCapabilities` on 401/403.
- The CLI catches it on initial `start()` and prints a friendly message directing the user to reconnect with a new token, then exits.
- Other (non-auth) startup failures continue to surface as fatal errors.
- The SSE reconnect path is unchanged: `reInitialize` still treats the new error generically and retries up to `MAX_AUTH_RETRIES`.

### How to test

1. Run the CLI with an invalid token: `npx @n8n/computer-use <url> invalid-token`
2. Expect a red "Connection token invalid" message and a dim hint pointing back to the instance URL.
3. Repeat with a valid token to confirm normal startup is unaffected.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4985

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI