### PR TITLE
fix(core): Member role getting read permissions for insights

### DIFF
--- a/packages/@n8n/permissions/src/roles/scopes/global-scopes.ee.ts
+++ b/packages/@n8n/permissions/src/roles/scopes/global-scopes.ee.ts
@@ -167,7 +167,6 @@ export const GLOBAL_MEMBER_SCOPES: Scope[] = [
 	'user:list',
 	'variable:list',
 	'variable:read',
-	'insights:read',
 	'dataTable:list',
 	'mcp:oauth',
 	'mcpApiKey:create',


### PR DESCRIPTION

## Summary

This scope was added to the member role by mistake. Members also can't access the insights page in n8n. So giving them the insights:read scope is inconsistent. There is no security impact, as insights data does not contain sensitive information.


## Related Linear tickets, Github issues, and Community forum posts

Relates to https://linear.app/n8n/issue/LIGO-496
Relates to https://linear.app/n8n/issue/LIGO-550
Relates to https://linear.app/n8n/project/make-insights-accessible-via-public-api-0cc0c3245493/overview


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
