### PR TITLE
feat(core): Add storage and cache layer for instance redaction enforcement setting (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -34,6 +34,7 @@ export {
 	type InteractiveResumeData,
 } from './agent-builder-interactive';
 export * from './instance-registry-types';
+export * from './redaction-enforcement';
 export {
 	chatHubConversationModelSchema,
 	type ChatModelDto,

--- a/packages/@n8n/api-types/src/redaction-enforcement.ts
+++ b/packages/@n8n/api-types/src/redaction-enforcement.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const redactionEnforcementSettingsSchema = z.object({
+	enforced: z.boolean(),
+	manual: z.boolean(),
+	production: z.boolean(),
+});
+
+export type RedactionEnforcementSettings = z.infer<typeof redactionEnforcementSettingsSchema>;
+
+export const REDACTION_ENFORCEMENT_DEFAULTS: RedactionEnforcementSettings = {
+	enforced: false,
+	manual: false,
+	production: true,
+};

--- a/packages/@n8n/api-types/src/redaction-enforcement.ts
+++ b/packages/@n8n/api-types/src/redaction-enforcement.ts
@@ -11,5 +11,5 @@ export type RedactionEnforcementSettings = z.infer<typeof redactionEnforcementSe
 export const REDACTION_ENFORCEMENT_DEFAULTS: RedactionEnforcementSettings = {
 	enforced: false,
 	manual: false,
-	production: true,
+	production: false,
 };

--- a/packages/cli/src/modules/redaction/__tests__/instance-redaction-enforcement.service.test.ts
+++ b/packages/cli/src/modules/redaction/__tests__/instance-redaction-enforcement.service.test.ts
@@ -1,7 +1,7 @@
 import type { Logger } from '@n8n/backend-common';
 import type { Settings, SettingsRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
-import { OperationalError } from 'n8n-workflow';
+import { OperationalError, UserError } from 'n8n-workflow';
 
 import type { CacheService } from '@/services/cache/cache.service';
 
@@ -58,16 +58,6 @@ describe('InstanceRedactionEnforcementService', () => {
 		} else {
 			process.env[N8N_ENV_FEAT_REDACTION_ENFORCEMENT] = originalFlag;
 		}
-	});
-
-	describe('isFeatureEnabled', () => {
-		it('reflects the env flag', () => {
-			disableFlag();
-			expect(service.isFeatureEnabled()).toBe(false);
-
-			enableFlag();
-			expect(service.isFeatureEnabled()).toBe(true);
-		});
 	});
 
 	describe('get', () => {
@@ -177,14 +167,18 @@ describe('InstanceRedactionEnforcementService', () => {
 				expect(cacheService.set).toHaveBeenCalledWith(KEY, JSON.stringify(next));
 			});
 
-			it('rejects invalid input without writing to repository or cache', async () => {
+			it('rejects invalid input with a UserError and logs validation issues', async () => {
 				const invalid = { enforced: true, manual: 'yes', production: true } as unknown as {
 					enforced: boolean;
 					manual: boolean;
 					production: boolean;
 				};
 
-				await expect(service.set(invalid)).rejects.toThrow();
+				await expect(service.set(invalid)).rejects.toThrow(UserError);
+				expect(logger.warn).toHaveBeenCalledWith(
+					'Invalid redaction enforcement settings payload',
+					expect.objectContaining({ issues: expect.any(Array) }),
+				);
 				expect(upsert).not.toHaveBeenCalled();
 				expect(cacheService.set).not.toHaveBeenCalled();
 			});

--- a/packages/cli/src/modules/redaction/__tests__/instance-redaction-enforcement.service.test.ts
+++ b/packages/cli/src/modules/redaction/__tests__/instance-redaction-enforcement.service.test.ts
@@ -1,0 +1,193 @@
+import type { Logger } from '@n8n/backend-common';
+import type { Settings, SettingsRepository } from '@n8n/db';
+import { mock } from 'jest-mock-extended';
+import { OperationalError } from 'n8n-workflow';
+
+import type { CacheService } from '@/services/cache/cache.service';
+
+import { InstanceRedactionEnforcementService } from '../instance-redaction-enforcement.service';
+import { N8N_ENV_FEAT_REDACTION_ENFORCEMENT } from '../redaction-enforcement.feature-flag';
+
+const KEY = 'redaction.enforcement';
+const DEFAULTS = { enforced: false, manual: false, production: true };
+
+describe('InstanceRedactionEnforcementService', () => {
+	const originalFlag = process.env[N8N_ENV_FEAT_REDACTION_ENFORCEMENT];
+
+	let service: InstanceRedactionEnforcementService;
+	let findByKey: jest.Mock<Promise<Settings | null>, [string]>;
+	let upsert: jest.Mock;
+	let settingsRepository: SettingsRepository;
+	const cacheService = mock<CacheService>();
+	const logger = mock<Logger>();
+
+	const enableFlag = () => {
+		process.env[N8N_ENV_FEAT_REDACTION_ENFORCEMENT] = 'true';
+	};
+
+	const disableFlag = () => {
+		delete process.env[N8N_ENV_FEAT_REDACTION_ENFORCEMENT];
+	};
+
+	// Mirrors the real CacheService.get refreshFn contract: on miss, invoke the
+	// refreshFn, write the result back via set(), and return it.
+	const simulateCacheMiss = () => {
+		cacheService.get.mockImplementationOnce(async (key, opts) => {
+			const refreshed = await opts!.refreshFn!(key);
+			await cacheService.set(key, refreshed);
+			return refreshed;
+		});
+	};
+
+	const simulateCacheHit = (value: string) => {
+		cacheService.get.mockResolvedValueOnce(value);
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		findByKey = jest.fn<Promise<Settings | null>, [string]>();
+		upsert = jest.fn();
+		settingsRepository = { findByKey, upsert } as unknown as SettingsRepository;
+
+		service = new InstanceRedactionEnforcementService(settingsRepository, cacheService, logger);
+	});
+
+	afterEach(() => {
+		if (originalFlag === undefined) {
+			delete process.env[N8N_ENV_FEAT_REDACTION_ENFORCEMENT];
+		} else {
+			process.env[N8N_ENV_FEAT_REDACTION_ENFORCEMENT] = originalFlag;
+		}
+	});
+
+	describe('isFeatureEnabled', () => {
+		it('reflects the env flag', () => {
+			disableFlag();
+			expect(service.isFeatureEnabled()).toBe(false);
+
+			enableFlag();
+			expect(service.isFeatureEnabled()).toBe(true);
+		});
+	});
+
+	describe('get', () => {
+		describe('with feature flag off', () => {
+			beforeEach(() => disableFlag());
+
+			it('returns defaults without touching cache or repository', async () => {
+				await expect(service.get()).resolves.toEqual(DEFAULTS);
+				expect(cacheService.get).not.toHaveBeenCalled();
+				expect(findByKey).not.toHaveBeenCalled();
+				expect(cacheService.set).not.toHaveBeenCalled();
+			});
+		});
+
+		describe('with feature flag on', () => {
+			beforeEach(() => enableFlag());
+
+			it('returns parsed value from cache on hit without reading DB', async () => {
+				const cached = { enforced: true, manual: true, production: true };
+				simulateCacheHit(JSON.stringify(cached));
+
+				await expect(service.get()).resolves.toEqual(cached);
+				expect(findByKey).not.toHaveBeenCalled();
+				expect(cacheService.set).not.toHaveBeenCalled();
+			});
+
+			it('falls back to DB, returns row, and backfills cache on cache miss', async () => {
+				const stored = { enforced: true, manual: false, production: true };
+				simulateCacheMiss();
+				findByKey.mockResolvedValueOnce(
+					mock<Settings>({
+						key: KEY,
+						value: JSON.stringify(stored),
+						loadOnStartup: true,
+					}),
+				);
+
+				await expect(service.get()).resolves.toEqual(stored);
+				expect(findByKey).toHaveBeenCalledWith(KEY);
+				expect(cacheService.set).toHaveBeenCalledWith(KEY, JSON.stringify(stored));
+			});
+
+			it('returns defaults and backfills cache when no DB row exists', async () => {
+				simulateCacheMiss();
+				findByKey.mockResolvedValueOnce(null);
+
+				await expect(service.get()).resolves.toEqual(DEFAULTS);
+				expect(cacheService.set).toHaveBeenCalledWith(KEY, JSON.stringify(DEFAULTS));
+			});
+
+			it('returns defaults when cache has invalid JSON, and logs a warning', async () => {
+				simulateCacheHit('not-json');
+
+				await expect(service.get()).resolves.toEqual(DEFAULTS);
+				expect(logger.warn).toHaveBeenCalledWith(
+					'Failed to parse redaction enforcement setting JSON',
+					expect.objectContaining({ source: 'cache' }),
+				);
+				expect(findByKey).not.toHaveBeenCalled();
+			});
+
+			it('returns defaults and backfills cache when DB value has an invalid shape, and logs a warning', async () => {
+				simulateCacheMiss();
+				findByKey.mockResolvedValueOnce(
+					mock<Settings>({
+						key: KEY,
+						value: JSON.stringify({ enforced: 'yes', manual: false, production: true }),
+						loadOnStartup: true,
+					}),
+				);
+
+				await expect(service.get()).resolves.toEqual(DEFAULTS);
+				expect(logger.warn).toHaveBeenCalledWith(
+					'Redaction enforcement setting has an invalid shape',
+					expect.objectContaining({ source: 'database' }),
+				);
+				expect(cacheService.set).toHaveBeenCalledWith(KEY, JSON.stringify(DEFAULTS));
+			});
+		});
+	});
+
+	describe('set', () => {
+		describe('with feature flag off', () => {
+			beforeEach(() => disableFlag());
+
+			it('throws OperationalError without touching cache or repository', async () => {
+				await expect(
+					service.set({ enforced: true, manual: true, production: true }),
+				).rejects.toThrow(OperationalError);
+				expect(upsert).not.toHaveBeenCalled();
+				expect(cacheService.set).not.toHaveBeenCalled();
+			});
+		});
+
+		describe('with feature flag on', () => {
+			beforeEach(() => enableFlag());
+
+			it('upserts the setting and writes the same serialized value to cache', async () => {
+				const next = { enforced: true, manual: false, production: true };
+
+				await service.set(next);
+
+				expect(upsert).toHaveBeenCalledWith(
+					{ key: KEY, value: JSON.stringify(next), loadOnStartup: true },
+					['key'],
+				);
+				expect(cacheService.set).toHaveBeenCalledWith(KEY, JSON.stringify(next));
+			});
+
+			it('rejects invalid input without writing to repository or cache', async () => {
+				const invalid = { enforced: true, manual: 'yes', production: true } as unknown as {
+					enforced: boolean;
+					manual: boolean;
+					production: boolean;
+				};
+
+				await expect(service.set(invalid)).rejects.toThrow();
+				expect(upsert).not.toHaveBeenCalled();
+				expect(cacheService.set).not.toHaveBeenCalled();
+			});
+		});
+	});
+});

--- a/packages/cli/src/modules/redaction/__tests__/instance-redaction-enforcement.service.test.ts
+++ b/packages/cli/src/modules/redaction/__tests__/instance-redaction-enforcement.service.test.ts
@@ -1,3 +1,4 @@
+import { REDACTION_ENFORCEMENT_DEFAULTS } from '@n8n/api-types';
 import type { Logger } from '@n8n/backend-common';
 import type { Settings, SettingsRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
@@ -9,7 +10,6 @@ import { InstanceRedactionEnforcementService } from '../instance-redaction-enfor
 import { N8N_ENV_FEAT_REDACTION_ENFORCEMENT } from '../redaction-enforcement.feature-flag';
 
 const KEY = 'redaction.enforcement';
-const DEFAULTS = { enforced: false, manual: false, production: true };
 
 describe('InstanceRedactionEnforcementService', () => {
 	const originalFlag = process.env[N8N_ENV_FEAT_REDACTION_ENFORCEMENT];
@@ -65,7 +65,7 @@ describe('InstanceRedactionEnforcementService', () => {
 			beforeEach(() => disableFlag());
 
 			it('returns defaults without touching cache or repository', async () => {
-				await expect(service.get()).resolves.toEqual(DEFAULTS);
+				await expect(service.get()).resolves.toEqual(REDACTION_ENFORCEMENT_DEFAULTS);
 				expect(cacheService.get).not.toHaveBeenCalled();
 				expect(findByKey).not.toHaveBeenCalled();
 				expect(cacheService.set).not.toHaveBeenCalled();
@@ -104,14 +104,17 @@ describe('InstanceRedactionEnforcementService', () => {
 				simulateCacheMiss();
 				findByKey.mockResolvedValueOnce(null);
 
-				await expect(service.get()).resolves.toEqual(DEFAULTS);
-				expect(cacheService.set).toHaveBeenCalledWith(KEY, JSON.stringify(DEFAULTS));
+				await expect(service.get()).resolves.toEqual(REDACTION_ENFORCEMENT_DEFAULTS);
+				expect(cacheService.set).toHaveBeenCalledWith(
+					KEY,
+					JSON.stringify(REDACTION_ENFORCEMENT_DEFAULTS),
+				);
 			});
 
 			it('returns defaults when cache has invalid JSON, and logs a warning', async () => {
 				simulateCacheHit('not-json');
 
-				await expect(service.get()).resolves.toEqual(DEFAULTS);
+				await expect(service.get()).resolves.toEqual(REDACTION_ENFORCEMENT_DEFAULTS);
 				expect(logger.warn).toHaveBeenCalledWith(
 					'Failed to parse redaction enforcement setting JSON',
 					expect.objectContaining({ source: 'cache' }),
@@ -129,12 +132,15 @@ describe('InstanceRedactionEnforcementService', () => {
 					}),
 				);
 
-				await expect(service.get()).resolves.toEqual(DEFAULTS);
+				await expect(service.get()).resolves.toEqual(REDACTION_ENFORCEMENT_DEFAULTS);
 				expect(logger.warn).toHaveBeenCalledWith(
 					'Redaction enforcement setting has an invalid shape',
 					expect.objectContaining({ source: 'database' }),
 				);
-				expect(cacheService.set).toHaveBeenCalledWith(KEY, JSON.stringify(DEFAULTS));
+				expect(cacheService.set).toHaveBeenCalledWith(
+					KEY,
+					JSON.stringify(REDACTION_ENFORCEMENT_DEFAULTS),
+				);
 			});
 		});
 	});

--- a/packages/cli/src/modules/redaction/instance-redaction-enforcement.service.ts
+++ b/packages/cli/src/modules/redaction/instance-redaction-enforcement.service.ts
@@ -6,7 +6,7 @@ import {
 import { Logger } from '@n8n/backend-common';
 import { SettingsRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { OperationalError } from 'n8n-workflow';
+import { OperationalError, UserError } from 'n8n-workflow';
 
 import { CacheService } from '@/services/cache/cache.service';
 
@@ -22,22 +22,11 @@ export class InstanceRedactionEnforcementService {
 		private readonly logger: Logger,
 	) {}
 
-	isFeatureEnabled(): boolean {
-		return isRedactionEnforcementEnabled();
-	}
-
 	async get(): Promise<RedactionEnforcementSettings> {
-		if (!this.isFeatureEnabled()) return REDACTION_ENFORCEMENT_DEFAULTS;
+		if (!isRedactionEnforcementEnabled()) return REDACTION_ENFORCEMENT_DEFAULTS;
 
 		const raw = await this.cacheService.get<string>(KEY, {
-			refreshFn: async () => {
-				const row = await this.settingsRepository.findByKey(KEY);
-				const value =
-					row?.value !== undefined
-						? (this.parseStoredValue(row.value, 'database') ?? REDACTION_ENFORCEMENT_DEFAULTS)
-						: REDACTION_ENFORCEMENT_DEFAULTS;
-				return JSON.stringify(value);
-			},
+			refreshFn: async () => await this.loadFromDatabase(),
 		});
 
 		if (raw === undefined) return REDACTION_ENFORCEMENT_DEFAULTS;
@@ -45,18 +34,34 @@ export class InstanceRedactionEnforcementService {
 	}
 
 	async set(next: RedactionEnforcementSettings): Promise<void> {
-		if (!this.isFeatureEnabled()) {
+		if (!isRedactionEnforcementEnabled()) {
 			throw new OperationalError('Redaction enforcement is not enabled on this instance');
 		}
 
-		const parsed = redactionEnforcementSettingsSchema.parse(next);
-		const serialized = JSON.stringify(parsed);
+		const result = redactionEnforcementSettingsSchema.safeParse(next);
+		if (!result.success) {
+			this.logger.warn('Invalid redaction enforcement settings payload', {
+				issues: result.error.issues,
+			});
+			throw new UserError('Invalid redaction enforcement settings');
+		}
+
+		const serialized = JSON.stringify(result.data);
 
 		await this.settingsRepository.upsert({ key: KEY, value: serialized, loadOnStartup: true }, [
 			'key',
 		]);
 
 		await this.cacheService.set(KEY, serialized);
+	}
+
+	private async loadFromDatabase(): Promise<string> {
+		const row = await this.settingsRepository.findByKey(KEY);
+		const value =
+			row?.value !== undefined
+				? (this.parseStoredValue(row.value, 'database') ?? REDACTION_ENFORCEMENT_DEFAULTS)
+				: REDACTION_ENFORCEMENT_DEFAULTS;
+		return JSON.stringify(value);
 	}
 
 	private parseStoredValue(

--- a/packages/cli/src/modules/redaction/instance-redaction-enforcement.service.ts
+++ b/packages/cli/src/modules/redaction/instance-redaction-enforcement.service.ts
@@ -1,0 +1,89 @@
+import {
+	REDACTION_ENFORCEMENT_DEFAULTS,
+	redactionEnforcementSettingsSchema,
+	type RedactionEnforcementSettings,
+} from '@n8n/api-types';
+import { Logger } from '@n8n/backend-common';
+import { SettingsRepository } from '@n8n/db';
+import { Service } from '@n8n/di';
+import { OperationalError } from 'n8n-workflow';
+
+import { CacheService } from '@/services/cache/cache.service';
+
+import { isRedactionEnforcementEnabled } from './redaction-enforcement.feature-flag';
+
+const KEY = 'redaction.enforcement';
+
+@Service()
+export class InstanceRedactionEnforcementService {
+	constructor(
+		private readonly settingsRepository: SettingsRepository,
+		private readonly cacheService: CacheService,
+		private readonly logger: Logger,
+	) {}
+
+	isFeatureEnabled(): boolean {
+		return isRedactionEnforcementEnabled();
+	}
+
+	async get(): Promise<RedactionEnforcementSettings> {
+		if (!this.isFeatureEnabled()) return REDACTION_ENFORCEMENT_DEFAULTS;
+
+		const raw = await this.cacheService.get<string>(KEY, {
+			refreshFn: async () => {
+				const row = await this.settingsRepository.findByKey(KEY);
+				const value =
+					row?.value !== undefined
+						? (this.parseStoredValue(row.value, 'database') ?? REDACTION_ENFORCEMENT_DEFAULTS)
+						: REDACTION_ENFORCEMENT_DEFAULTS;
+				return JSON.stringify(value);
+			},
+		});
+
+		if (raw === undefined) return REDACTION_ENFORCEMENT_DEFAULTS;
+		return this.parseStoredValue(raw, 'cache') ?? REDACTION_ENFORCEMENT_DEFAULTS;
+	}
+
+	async set(next: RedactionEnforcementSettings): Promise<void> {
+		if (!this.isFeatureEnabled()) {
+			throw new OperationalError('Redaction enforcement is not enabled on this instance');
+		}
+
+		const parsed = redactionEnforcementSettingsSchema.parse(next);
+		const serialized = JSON.stringify(parsed);
+
+		await this.settingsRepository.upsert(
+			{ key: KEY, value: serialized, loadOnStartup: true },
+			['key'],
+		);
+
+		await this.cacheService.set(KEY, serialized);
+	}
+
+	private parseStoredValue(
+		raw: string,
+		source: 'cache' | 'database',
+	): RedactionEnforcementSettings | undefined {
+		let parsedJson: unknown;
+		try {
+			parsedJson = JSON.parse(raw);
+		} catch (error) {
+			this.logger.warn('Failed to parse redaction enforcement setting JSON', {
+				source,
+				cause: error instanceof Error ? error.message : String(error),
+			});
+			return undefined;
+		}
+
+		const result = redactionEnforcementSettingsSchema.safeParse(parsedJson);
+		if (!result.success) {
+			this.logger.warn('Redaction enforcement setting has an invalid shape', {
+				source,
+				issues: result.error.issues,
+			});
+			return undefined;
+		}
+
+		return result.data;
+	}
+}

--- a/packages/cli/src/modules/redaction/instance-redaction-enforcement.service.ts
+++ b/packages/cli/src/modules/redaction/instance-redaction-enforcement.service.ts
@@ -52,10 +52,9 @@ export class InstanceRedactionEnforcementService {
 		const parsed = redactionEnforcementSettingsSchema.parse(next);
 		const serialized = JSON.stringify(parsed);
 
-		await this.settingsRepository.upsert(
-			{ key: KEY, value: serialized, loadOnStartup: true },
-			['key'],
-		);
+		await this.settingsRepository.upsert({ key: KEY, value: serialized, loadOnStartup: true }, [
+			'key',
+		]);
 
 		await this.cacheService.set(KEY, serialized);
 	}


### PR DESCRIPTION
## Summary

Introduces `InstanceRedactionEnforcementService` — the persistence and cache layer for the new instance-level redaction enforcement setting. The setting holds three booleans (`enforced`, `manual`, `production`) that govern whether redaction is automatically applied to executions and whether per-workflow redaction is locked.

This is the storage half of the feature. The public API surface (read/write endpoints) lands in IAM-619, and execution-path callers consume the value in sibling tickets. All paths remain dormant unless `N8N_ENV_FEAT_REDACTION_ENFORCEMENT=true`, the flag introduced in #30253.

**Why this shape:**
- **DB-backed + cache-first reads.** Execution paths will read this on every run, so the read path must be cheap. The setting lives in the `settings` table with `loadOnStartup: true` and is served from `CacheService`.
- **Multi-main consistency for free.** `CacheService` is Redis-backed in queue mode, so a `set()` on Main A is visible to Main B without explicit pub/sub.
- **Mirrors `McpSettingsService`.** Same DI style, same cache-first pattern, same `settingsRepository.upsert({...}, ['key'])` write. The DB-fallback uses `cacheService.get`'s built-in `refreshFn` so the service body is a single call.
- **Composite value, JSON-serialized.** `Settings.value` is `string`; we stringify on write and zod-validate on read. Invalid stored data → log warn + fall back to defaults rather than throwing.
- **Feature-flag gate inside the service.** When the flag is off, `get()` returns the documented defaults (`{ enforced: false, manual: false, production: true }`) without touching cache/DB, and `set()` throws `OperationalError`. Callers don't need to remember the gate.

The shared `RedactionEnforcementSettings` type and its zod schema live in `@n8n/api-types` so IAM-619's controller (and any future frontend code) consumes one source of truth.

## Key implementation decisions

- **`refreshFn` over manual fallback.** The service uses `cacheService.get(KEY, { refreshFn })` so the cache layer handles miss → DB read → backfill in one call. The service body stays declarative.
- **Bad cache JSON → defaults, no DB re-read.** From `CacheService`'s perspective a malformed string is still a cache hit, so `refreshFn` doesn't fire. The next legitimate `set()` overwrites the poisoned key. The alternative — manual fallthrough on cache parse failure — reintroduces the duplication this design avoids.
- **Defensive zod parse on writes** even though callers will validate at the controller (IAM-619). The storage layer is the last gate; the cost is one schema parse per write.
- **No bootstrap loader.** Env-var-driven config was descoped at the 2026-05-08 kickoff. Defaults are returned in-memory when the row is absent.

## Related Links

closes https://linear.app/n8n/issue/IAM-425

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
