### PR TITLE
fix(editor): Change the title of plan review panel after approved and collapsed, fix cursor on hover (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -5570,6 +5570,7 @@
 	"instanceAi.backgroundTask.completed": "Background task finished",
 	"instanceAi.backgroundTask.failed": "Background task failed",
 	"instanceAi.planReview.title": "Review before building",
+	"instanceAi.planReview.titleResolved": "Plan",
 	"instanceAi.planReview.building": "Building plan...",
 	"instanceAi.planReview.awaitingApproval": "Awaiting approval",
 	"instanceAi.planReview.description": "Review the plan, then approve it to start building or request changes to revise it.",

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/PlanReviewPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/PlanReviewPanel.vue
@@ -43,6 +43,11 @@ const resolvedAction = ref<'approved' | 'changes-requested' | null>(null);
 
 const hasFeedback = computed(() => feedback.value.trim().length > 0);
 const isExpanded = ref(!props.readOnly);
+const titleKey = computed(() =>
+	isResolved.value || props.readOnly
+		? 'instanceAi.planReview.titleResolved'
+		: 'instanceAi.planReview.title',
+);
 
 function getDescription(task: PlannedTaskArg): string {
 	let text = task.spec;
@@ -81,7 +86,7 @@ function handleRequestChanges() {
 			<!-- Header -->
 			<div :class="$style.header">
 				<N8nText bold>
-					{{ i18n.baseText('instanceAi.planReview.title') }}
+					{{ i18n.baseText(titleKey) }}
 				</N8nText>
 			</div>
 		</CollapsibleTrigger>
@@ -152,6 +157,7 @@ function handleRequestChanges() {
 	gap: var(--spacing--3xs);
 	padding: var(--spacing--xs) var(--spacing--sm);
 	border-bottom: var(--border);
+	cursor: pointer;
 }
 
 .tasks {


### PR DESCRIPTION
## Summary

<img width="504" height="416" alt="image" src="https://github.com/user-attachments/assets/d236a03d-14d6-4965-bda0-8399ec11ae26" />

Change the title so that the plan panel shows up as "Plan" once user approves the plan and it gets collapsed, like we spoke today.

On hover show a cursor indicating that the plan can be clicked and expanded.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
