### PR TITLE
ci: Migrate from actions/attest-sbom to actions/attest

### DIFF
--- a/.github/workflows/sbom-generation-callable.yml
+++ b/.github/workflows/sbom-generation-callable.yml
@@ -56,7 +56,7 @@ jobs:
           output-file: sbom-source.cdx.json
 
       - name: Attest SBOM for source release
-        uses: actions/attest-sbom@07e74fc4e78d1aad915e867f9a094073a9f71527 # v4.0.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: './package.json'
           sbom-path: 'sbom-source.cdx.json'


### PR DESCRIPTION
## Summary

Release workflows were pushing warnings on deprecated sbom attestation workflow usage. Migrated to recommended [new package](https://github.com/actions/attest). Same API surface should work according to their docs.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3077

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
