### PR TITLE
chore: Bump fast-uri override to 3.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,8 @@
       "fast-xml-parser": "5.7.2",
       "hono": "4.12.18",
       "@anthropic-ai/sdk@<=0.91.1": "0.91.1",
-      "uuid@<=13.0.1": "13.0.1"
+      "uuid@<=13.0.1": "13.0.1",
+      "fast-uri": "3.1.2"
     },
     "patchedDependencies": {
       "bull@4.16.4": "patches/bull@4.16.4.patch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,6 +465,7 @@ overrides:
   hono: 4.12.18
   '@anthropic-ai/sdk@<=0.91.1': 0.91.1
   uuid@<=13.0.1: 13.0.1
+  fast-uri: 3.1.2
 
 patchedDependencies:
   '@lezer/highlight':
@@ -39216,7 +39217,7 @@ snapshots:
   langsmith@0.5.19(@opentelemetry/api@1.9.0)(@opentelemetry/exporter-trace-otlp-proto@0.213.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0))(openai@6.34.0(ws@8.17.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(zod@3.25.67))(ws@8.17.1(bufferutil@4.0.9)(utf-8-validate@5.0.10)):
     dependencies:
       p-queue: 6.6.2
-      uuid: 10.0.0
+      uuid: 13.0.1
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/exporter-trace-otlp-proto': 0.213.0(@opentelemetry/api@1.9.0)


### PR DESCRIPTION
## Summary

Our dependency [ajv](https://github.com/ajv-validator/ajv) hasn't yet released a new version with the [bumped fast-uri version](https://github.com/ajv-validator/ajv/pull/2612) so we'll override it ourselves for now.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/SEC-641

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
