### PR TITLE
test: Clean up dead code and selector-purity violations (no-changelog)

### DIFF
--- a/packages/testing/playwright/.janitor-baseline.json
+++ b/packages/testing/playwright/.janitor-baseline.json
@@ -1,7 +1,7 @@
 {
 	"version": 1,
-	"generated": "2026-05-12T08:06:17.170Z",
-	"totalViolations": 416,
+	"generated": "2026-05-12T11:24:54.376Z",
+	"totalViolations": 410,
 	"violations": {
 		"pages/AIAssistantPage.ts": [
 			{
@@ -82,13 +82,7 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 274,
-				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "4087a9cf20cb"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 323,
+				"line": 278,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
@@ -106,7 +100,7 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 351,
+				"line": 335,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
@@ -136,31 +130,25 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 373,
+				"line": 371,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 399,
+				"line": 377,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 435,
+				"line": 403,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 463,
-				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "4087a9cf20cb"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 467,
+				"line": 439,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
@@ -178,13 +166,19 @@
 			},
 			{
 				"rule": "scope-lockdown",
+				"line": 471,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "4087a9cf20cb"
+			},
+			{
+				"rule": "scope-lockdown",
 				"line": 475,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 493,
+				"line": 479,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
@@ -196,49 +190,43 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 497,
+				"line": 501,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 508,
+				"line": 501,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 517,
+				"line": 512,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 579,
+				"line": 521,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 624,
+				"line": 583,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 630,
+				"line": 628,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 654,
-				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
-				"hash": "4087a9cf20cb"
-			},
-			{
-				"rule": "scope-lockdown",
-				"line": 654,
+				"line": 634,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
@@ -250,19 +238,25 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 765,
+				"line": 658,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 810,
+				"line": 662,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 864,
+				"line": 769,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "4087a9cf20cb"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 814,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
@@ -274,13 +268,19 @@
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 877,
+				"line": 872,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			},
 			{
 				"rule": "scope-lockdown",
-				"line": 883,
+				"line": 885,
+				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
+				"hash": "4087a9cf20cb"
+			},
+			{
+				"rule": "scope-lockdown",
+				"line": 891,
 				"message": "NodeDetailsViewPage: Unscoped locator - use this.container instead of this.page",
 				"hash": "4087a9cf20cb"
 			}
@@ -1547,20 +1547,6 @@
 				"hash": "e286b40da00e"
 			}
 		],
-		"tests/e2e/workflows/editor/expressions/transformation.spec.ts": [
-			{
-				"rule": "selector-purity",
-				"line": 114,
-				"message": "Chained locator call in test: n8n.ndv.getOutputDataContainer().locator('[class*=value_]')",
-				"hash": "5ce9a307e353"
-			},
-			{
-				"rule": "selector-purity",
-				"line": 134,
-				"message": "Chained locator call in test: n8n.ndv.getOutputDataContainer().locator('[class*=value_]')",
-				"hash": "5ce9a307e353"
-			}
-		],
 		"tests/e2e/workflows/editor/ndv/io-filter.spec.ts": [
 			{
 				"rule": "selector-purity",
@@ -1851,14 +1837,6 @@
 				"line": 145,
 				"message": "Chained locator call in test: visiblePopperAfter.getByTestId('rlc-item')",
 				"hash": "6ccf615ddb0b"
-			}
-		],
-		"tests/e2e/workflows/editor/subworkflows/workflow-selector.spec.ts": [
-			{
-				"rule": "selector-purity",
-				"line": 92,
-				"message": "Chained locator call in test: addResourceItem.getByText(/Create a/)",
-				"hash": "46294c103c93"
 			}
 		],
 		"tests/e2e/workflows/editor/tags.spec.ts": [
@@ -2469,26 +2447,6 @@
 				"line": 299,
 				"message": "Raw API call detected: request.patch(",
 				"hash": "0acea681877b"
-			}
-		],
-		"utils/benchmark/instance-ai-driver.ts": [
-			{
-				"rule": "dead-code",
-				"line": 263,
-				"message": "Unused method: InstanceAiDriver.deleteAllThreads()",
-				"hash": "84fa4accc8fa"
-			},
-			{
-				"rule": "dead-code",
-				"line": 302,
-				"message": "Unused method: InstanceAiDriver.measureHeap()",
-				"hash": "40ed597f87ba"
-			},
-			{
-				"rule": "dead-code",
-				"line": 307,
-				"message": "Unused method: InstanceAiDriver.snapshot()",
-				"hash": "70bd4d633512"
 			}
 		],
 		"pages/ChatHubSettingsPage.ts": [

--- a/packages/testing/playwright/pages/NodeDetailsViewPage.ts
+++ b/packages/testing/playwright/pages/NodeDetailsViewPage.ts
@@ -143,6 +143,10 @@ export class NodeDetailsViewPage extends BasePage {
 		return this.getOutputPanel().getByTestId('ndv-data-container');
 	}
 
+	getOutputDataValues() {
+		return this.getOutputDataContainer().locator('[class*=value_]');
+	}
+
 	async setPinnedData(data: object | string) {
 		const pinnedData = typeof data === 'string' ? data : JSON.stringify(data);
 		await this.getEditPinnedDataButton().click();
@@ -866,6 +870,10 @@ export class NodeDetailsViewPage extends BasePage {
 
 	getAddResourceItem() {
 		return this.page.getByTestId('rlc-item-add-resource');
+	}
+
+	getAddResourceCreateOption() {
+		return this.getAddResourceItem().getByText(/Create a/);
 	}
 
 	getExpressionModeToggle(index: number = 1) {

--- a/packages/testing/playwright/tests/e2e/workflows/editor/expressions/transformation.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/expressions/transformation.spec.ts
@@ -111,7 +111,7 @@ test.describe(
 			await expect(n8n.ndv.getInlineExpressionEditorOutput()).toContainText(output);
 
 			await n8n.ndv.execute();
-			const valueElements = n8n.ndv.getOutputDataContainer().locator('[class*=value_]');
+			const valueElements = n8n.ndv.getOutputDataValues();
 			await expect(valueElements).toBeVisible();
 			await expect(valueElements).toContainText(output);
 		});
@@ -131,7 +131,7 @@ test.describe(
 			await expect(n8n.ndv.getInlineExpressionEditorOutput()).toContainText(output);
 
 			await n8n.ndv.execute();
-			const valueElements = n8n.ndv.getOutputDataContainer().locator('[class*=value_]');
+			const valueElements = n8n.ndv.getOutputDataValues();
 			await expect(valueElements).toBeVisible();
 			await expect(valueElements).toContainText(output);
 		});

--- a/packages/testing/playwright/tests/e2e/workflows/editor/subworkflows/workflow-selector.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/subworkflows/workflow-selector.spec.ts
@@ -89,7 +89,7 @@ test.describe(
 
 			const addResourceItem = n8n.ndv.getAddResourceItem();
 			await expect(addResourceItem).toHaveCount(1);
-			await expect(addResourceItem.getByText(/Create a/)).toBeVisible();
+			await expect(n8n.ndv.getAddResourceCreateOption()).toBeVisible();
 
 			const secondPage = await n8n.start.fromNewPage(async () => {
 				await n8n.ndvComposer.createNewSubworkflow('workflowId');

--- a/packages/testing/playwright/tests/infrastructure/benchmarks-local/instance-ai/fixtures.ts
+++ b/packages/testing/playwright/tests/infrastructure/benchmarks-local/instance-ai/fixtures.ts
@@ -17,11 +17,10 @@ export const instanceAiTestConfig = {
 } as const;
 
 export const test = base.extend<InstanceAiMemoryFixtures>({
-	instanceAiDriver: async ({ n8n, backendUrl, services }, use) => {
+	instanceAiDriver: async ({ n8n, backendUrl }, use) => {
 		const config: InstanceAiDriverConfig = {
 			n8n,
 			baseUrl: backendUrl,
-			metrics: services.observability.metrics,
 		};
 
 		const driver = new InstanceAiDriver(config);

--- a/packages/testing/playwright/utils/benchmark/instance-ai-driver.ts
+++ b/packages/testing/playwright/utils/benchmark/instance-ai-driver.ts
@@ -1,14 +1,7 @@
-import type { Page, TestInfo } from '@playwright/test';
-import type { MetricsHelper } from 'n8n-containers';
+import type { Page } from '@playwright/test';
 
 import { InstanceAiPage } from '../../pages/InstanceAiPage';
 import type { n8nPage } from '../../pages/n8nPage';
-import {
-	getStableHeap,
-	takeHeapSnapshot,
-	type StableHeapOptions,
-	type StableHeapResult,
-} from '../performance-helper';
 
 /** Lightweight prompt for warmup — exercises the instance-ai path without building a workflow. */
 export const WARMUP_PROMPT = 'List my current credentials.';
@@ -42,8 +35,6 @@ export interface InstanceAiDriverConfig {
 	n8n: n8nPage;
 	/** Backend base URL for REST API calls (GC, snapshots, thread management) */
 	baseUrl: string;
-	/** VictoriaMetrics helper for heap queries */
-	metrics: MetricsHelper;
 }
 
 export interface RunParallelOptions {
@@ -74,14 +65,12 @@ export interface TabRunResult {
 export class InstanceAiDriver {
 	private readonly n8n: n8nPage;
 	private readonly baseUrl: string;
-	private readonly metrics: MetricsHelper;
 	private createdThreadIds: string[] = [];
 	private openedPages: Page[] = [];
 
 	constructor(config: InstanceAiDriverConfig) {
 		this.n8n = config.n8n;
 		this.baseUrl = config.baseUrl;
-		this.metrics = config.metrics;
 	}
 
 	/**
@@ -259,14 +248,6 @@ export class InstanceAiDriver {
 		this.createdThreadIds = this.createdThreadIds.filter((id) => id !== threadId);
 	}
 
-	/** Delete all threads created by this driver instance. */
-	async deleteAllThreads(): Promise<void> {
-		const threadIds = [...this.createdThreadIds];
-		for (const threadId of threadIds) {
-			await this.deleteThread(threadId);
-		}
-	}
-
 	/** Delete all workflows via the REST API to prevent cross-round interference. */
 	async deleteAllWorkflows(): Promise<void> {
 		const cookies = await this.n8n.page.context().cookies();
@@ -296,16 +277,6 @@ export class InstanceAiDriver {
 	async cleanup(): Promise<void> {
 		await this.closeAllTabs();
 		await this.deleteAllWorkflows();
-	}
-
-	/** Take a stable server-side heap measurement (triggers GC + polls VictoriaMetrics). */
-	async measureHeap(options?: StableHeapOptions): Promise<StableHeapResult> {
-		return await getStableHeap(this.baseUrl, this.metrics, options);
-	}
-
-	/** Trigger a V8 heap snapshot on the server. */
-	async snapshot(testInfo: TestInfo, label: string): Promise<void> {
-		await takeHeapSnapshot(this.baseUrl, testInfo, label);
 	}
 
 	private extractThreadId(page: Page): string {


### PR DESCRIPTION
## Summary

Small janitor baseline cleanup for the Playwright test suite — 5 fixes, all TCR-verified:

- Remove 3 unused methods on `InstanceAiDriver` (`deleteAllThreads`, `measureHeap`, `snapshot`) flagged by the `dead-code` rule, plus knock-on cleanup of the now-unused `metrics` field and imports.
- Resolve `selector-purity` violation in `tests/e2e/workflows/editor/subworkflows/workflow-selector.spec.ts` by extracting `NodeDetailsViewPage.getAddResourceCreateOption()`.
- Resolve `selector-purity` violations in `tests/e2e/workflows/editor/expressions/transformation.spec.ts` (2 spots, same selector) by extracting `NodeDetailsViewPage.getOutputDataValues()`.

Janitor baseline refreshed: 416 → 410 tracked violations.

## Related Linear tickets, Github issues, and Community forum posts

n/a — incremental test-infrastructure cleanup.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included. (Affected tests run via TCR — `transformation.spec.ts` + `workflow-selector.spec.ts` all green.)
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. — n/a
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`. — n/a