### PR TITLE
fix(ai-builder): Guide builder to prefer httpBearerAuth for Bearer flows

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/http-generic-auth-type-matches-prompt.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/http-generic-auth-type-matches-prompt.test.ts
@@ -1,0 +1,139 @@
+import { httpGenericAuthTypeMatchesPrompt } from './http-generic-auth-type-matches-prompt';
+import type { WorkflowResponse } from '../../clients/n8n-client';
+
+function workflowWithHttpRequest(parameters: Record<string, unknown>): WorkflowResponse {
+	return {
+		id: 'wf-1',
+		name: 'HTTP auth test',
+		active: false,
+		nodes: [
+			{
+				name: 'Manual Trigger',
+				type: 'n8n-nodes-base.manualTrigger',
+				parameters: {},
+			},
+			{
+				name: 'HTTP Request',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters,
+			},
+		],
+		connections: {
+			'Manual Trigger': {
+				main: [[{ node: 'HTTP Request', type: 'main', index: 0 }]],
+			},
+		},
+	};
+}
+
+describe('httpGenericAuthTypeMatchesPrompt', () => {
+	it('fails when prompt asks for Bearer but builder picks httpHeaderAuth', async () => {
+		const workflow = workflowWithHttpRequest({
+			authentication: 'genericCredentialType',
+			genericAuthType: 'httpHeaderAuth',
+		});
+
+		const result = await httpGenericAuthTypeMatchesPrompt.run(workflow, {
+			prompt: 'Call the GitHub API using a Bearer token',
+		});
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('HTTP Request');
+		expect(result.comment).toContain('httpBearerAuth');
+	});
+
+	it('fails when prompt mentions Authorization: Bearer header explicitly', async () => {
+		const workflow = workflowWithHttpRequest({
+			authentication: 'genericCredentialType',
+			genericAuthType: 'httpHeaderAuth',
+		});
+
+		const result = await httpGenericAuthTypeMatchesPrompt.run(workflow, {
+			prompt: 'Send a request with Authorization: Bearer <token>',
+		});
+
+		expect(result.pass).toBe(false);
+	});
+
+	it('passes when builder picks httpBearerAuth for a Bearer prompt', async () => {
+		const workflow = workflowWithHttpRequest({
+			authentication: 'genericCredentialType',
+			genericAuthType: 'httpBearerAuth',
+		});
+
+		const result = await httpGenericAuthTypeMatchesPrompt.run(workflow, {
+			prompt: 'Call the GitHub API using a Bearer token',
+		});
+
+		expect(result).toEqual({ pass: true });
+	});
+
+	it('passes when prompt specifies a custom header name and builder picks httpHeaderAuth', async () => {
+		const workflow = workflowWithHttpRequest({
+			authentication: 'genericCredentialType',
+			genericAuthType: 'httpHeaderAuth',
+		});
+
+		const result = await httpGenericAuthTypeMatchesPrompt.run(workflow, {
+			prompt: 'Call the Algolia API with an X-API-Key header',
+		});
+
+		expect(result).toEqual({ pass: true });
+	});
+
+	it('passes when the prompt has no auth signal at all', async () => {
+		const workflow = workflowWithHttpRequest({
+			authentication: 'genericCredentialType',
+			genericAuthType: 'httpHeaderAuth',
+		});
+
+		const result = await httpGenericAuthTypeMatchesPrompt.run(workflow, {
+			prompt: 'Fetch data from a public endpoint',
+		});
+
+		expect(result).toEqual({ pass: true });
+	});
+
+	it('ignores HTTP Request nodes that do not use generic credential type', async () => {
+		const workflow = workflowWithHttpRequest({
+			authentication: 'predefinedCredentialType',
+			nodeCredentialType: 'githubApi',
+		});
+
+		const result = await httpGenericAuthTypeMatchesPrompt.run(workflow, {
+			prompt: 'Call the GitHub API using a Bearer token',
+		});
+
+		expect(result).toEqual({ pass: true });
+	});
+
+	it('ignores non-HTTP-Request nodes', async () => {
+		const workflow: WorkflowResponse = {
+			id: 'wf-2',
+			name: 'Slack only',
+			active: false,
+			nodes: [
+				{
+					name: 'Manual Trigger',
+					type: 'n8n-nodes-base.manualTrigger',
+					parameters: {},
+				},
+				{
+					name: 'Slack',
+					type: 'n8n-nodes-base.slack',
+					parameters: {
+						authentication: 'genericCredentialType',
+						genericAuthType: 'httpHeaderAuth',
+					},
+				},
+			],
+			connections: {},
+		};
+
+		const result = await httpGenericAuthTypeMatchesPrompt.run(workflow, {
+			prompt: 'Send a Bearer-authenticated message',
+		});
+
+		expect(result).toEqual({ pass: true });
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/http-generic-auth-type-matches-prompt.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/http-generic-auth-type-matches-prompt.ts
@@ -1,0 +1,68 @@
+import type { WorkflowNodeResponse } from '../../clients/n8n-client';
+import type { BinaryCheck } from '../types';
+
+const HTTP_REQUEST_TYPE = 'n8n-nodes-base.httpRequest';
+
+const BEARER_PROMPT_PATTERNS = [
+	/\bbearer\s+(?:token|auth(?:entication)?)\b/i,
+	/\bauthorization\s*:\s*bearer\b/i,
+	/\b(?:use|with|via|using)\s+(?:a\s+|my\s+)?bearer\b/i,
+];
+
+const CUSTOM_HEADER_NAME_PATTERNS = [
+	/\bx-[a-z][a-z0-9-]*\b/i,
+	/\bheader\s+(?:named|called)\s+["'`]?[a-z][\w-]*["'`]?/i,
+	/\bcustom\s+header\b/i,
+	/\bheader\s+name\b/i,
+	/\bapikey\s+header\b/i,
+];
+
+function isHttpRequestWithGenericAuth(node: WorkflowNodeResponse): boolean {
+	return (
+		node.type === HTTP_REQUEST_TYPE && node.parameters?.authentication === 'genericCredentialType'
+	);
+}
+
+function getGenericAuthType(node: WorkflowNodeResponse): string {
+	const value = node.parameters?.genericAuthType;
+	return typeof value === 'string' ? value : '';
+}
+
+function promptAsksForBearer(prompt: string): boolean {
+	return BEARER_PROMPT_PATTERNS.some((p) => p.test(prompt));
+}
+
+function promptSpecifiesCustomHeaderName(prompt: string): boolean {
+	return CUSTOM_HEADER_NAME_PATTERNS.some((p) => p.test(prompt));
+}
+
+export const httpGenericAuthTypeMatchesPrompt: BinaryCheck = {
+	name: 'http_generic_auth_type_matches_prompt',
+	description:
+		'HTTP Request nodes pick a genericAuthType consistent with the prompt — prefer httpBearerAuth for Authorization: Bearer flows; reserve httpHeaderAuth for custom header names',
+	kind: 'deterministic',
+	run(workflow, ctx) {
+		const issues: string[] = [];
+
+		for (const node of workflow.nodes ?? []) {
+			if (!isHttpRequestWithGenericAuth(node)) continue;
+
+			const genericAuthType = getGenericAuthType(node);
+			if (genericAuthType !== 'httpHeaderAuth') continue;
+
+			const bearerIntent = promptAsksForBearer(ctx.prompt);
+			const customHeaderIntent = promptSpecifiesCustomHeaderName(ctx.prompt);
+
+			if (bearerIntent && !customHeaderIntent) {
+				issues.push(
+					`"${node.name}" uses httpHeaderAuth but the prompt asks for Bearer auth — should be httpBearerAuth`,
+				);
+			}
+		}
+
+		return {
+			pass: issues.length === 0,
+			...(issues.length > 0 ? { comment: issues.join('; ') } : {}),
+		};
+	},
+};

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/index.ts
@@ -14,6 +14,7 @@ import { handlesMultipleItems } from './handles-multiple-items';
 import { hasNodes } from './has-nodes';
 import { hasStartNode } from './has-start-node';
 import { hasTrigger } from './has-trigger';
+import { httpGenericAuthTypeMatchesPrompt } from './http-generic-auth-type-matches-prompt';
 import { inboundTriggerAuthDefaults } from './inbound-trigger-auth-defaults';
 import { memoryProperlyConnected } from './memory-properly-connected';
 import { memorySessionKeyExpression } from './memory-session-key-expression';
@@ -50,6 +51,7 @@ export const DETERMINISTIC_CHECKS: BinaryCheck[] = [
 	toolsHaveParameters,
 	noUnreachableNodes,
 	inboundTriggerAuthDefaults,
+	httpGenericAuthTypeMatchesPrompt,
 	validNodeConfig,
 ];
 

--- a/packages/@n8n/instance-ai/evaluations/data/subagent/http-bearer-auth.json
+++ b/packages/@n8n/instance-ai/evaluations/data/subagent/http-bearer-auth.json
@@ -1,0 +1,4 @@
+{
+	"id": "http-bearer-auth",
+	"prompt": "Build a workflow that runs manually, calls GET https://api.example.com/v1/items with a Bearer token, and writes the response to a file. Configure all nodes completely and don't ask me for credentials — I'll set them up later."
+}

--- a/packages/nodes-base/nodes/HttpRequest/V3/Description.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/Description.ts
@@ -117,6 +117,14 @@ export const mainProperties: INodeProperties[] = [
 				authentication: ['genericCredentialType'],
 			},
 		},
+		builderHint: {
+			propertyHint: `Pick by how the API authenticates, not by what the user calls it:
+- "Authorization: Bearer <token>" → httpBearerAuth (single token field, best UX). Use this for OpenAI, Anthropic, GitHub PATs, Stripe, Notion, and any service whose docs say "Bearer".
+- Custom header like X-API-Key, apikey, X-Auth-Token → httpHeaderAuth (user must enter the header name).
+- API key in the query string (?api_key=...) → httpQueryAuth.
+- username + password → httpBasicAuth.
+A user saying "API key" or "header auth" usually means Bearer if the docs use the Authorization header — prefer httpBearerAuth in that case. Only fall back to httpHeaderAuth when the header name is genuinely non-standard.`,
+		},
 	},
 	{
 		displayName: 'SSL Certificates',

--- a/packages/nodes-base/nodes/HttpRequest/V3/Description.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/Description.ts
@@ -120,10 +120,10 @@ export const mainProperties: INodeProperties[] = [
 		builderHint: {
 			propertyHint: `Pick by how the API authenticates, not by what the user calls it:
 - "Authorization: Bearer <token>" → httpBearerAuth (single token field, best UX). Use this for OpenAI, Anthropic, GitHub PATs, Stripe, Notion, and any service whose docs say "Bearer".
-- Custom header like X-API-Key, apikey, X-Auth-Token → httpHeaderAuth (user must enter the header name).
+- Custom header like X-API-Key, apikey, X-Auth-Token, or non-Bearer Authorization schemes → httpHeaderAuth (user must enter the header name and/or full value).
 - API key in the query string (?api_key=...) → httpQueryAuth.
 - username + password → httpBasicAuth.
-A user saying "API key" or "header auth" usually means Bearer if the docs use the Authorization header — prefer httpBearerAuth in that case. Only fall back to httpHeaderAuth when the header name is genuinely non-standard.`,
+A user saying "API key" or "header auth" usually means httpBearerAuth only when the docs use the Authorization: Bearer <token> scheme. Use httpHeaderAuth for custom header names or non-Bearer Authorization schemes where the full header value/prefix must be user-controlled.`,
 		},
 	},
 	{


### PR DESCRIPTION
## Summary

When the AI builder needs generic HTTP authentication for `Authorization: Bearer <token>` flows, it sometimes picks `httpHeaderAuth` (two fields: Name + Value) instead of `httpBearerAuth` (one field: Token). Users then have to know the header name (`Authorization`) and the value prefix (`Bearer `) — friction the Bearer credential was designed to remove.

The existing rule in the builder prompt (`build-workflow-agent.prompt.ts:364`) tells the agent to "prefer `httpBearerAuth`", but it's buried in the credentials syntax block and isn't followed reliably.

This PR moves the guidance closer to the actual decision and adds regression coverage:

- **`builderHint` on `genericAuthType`** (HTTP Request V3 Description) — the hint travels with the node's generated SDK types, so the LLM sees it inline next to the enum it's choosing. It tells the builder to prefer `httpBearerAuth` specifically for `Authorization: Bearer <token>` schemes, while keeping `httpHeaderAuth` for custom headers like `X-API-Key` or non-Bearer `Authorization` schemes where the full header value/prefix must be user-controlled.
- **Deterministic eval check** `http_generic_auth_type_matches_prompt` — fails when an HTTP Request node uses `httpHeaderAuth` while the prompt clearly asks for Bearer (and doesn't specify a custom header name like `X-API-Key`). Scoped tightly to avoid false positives on legitimate custom-header flows.
- **Subagent eval prompt** `http-bearer-auth.json` — exercises the path end-to-end so the check fires in CI.

### How to test

- Run the unit tests for the new check:
  ```bash
  cd packages/@n8n/instance-ai
  pnpm test evaluations/binaryChecks/checks/http-generic-auth-type-matches-prompt.test.ts
  ```
- Run the subagent eval against a live n8n with the new prompt: `pnpm eval:subagent --filter http-bearer-auth` (see `evaluations/README.md` for setup).
- Manual: build "fetch from api.example.com with a bearer token" via the AI Builder UI — the HTTP Request node should configure `genericAuthType: httpBearerAuth`. Build "call Algolia with an X-API-Key header" — should still be `httpHeaderAuth`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-6

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
