### PR TITLE
fix(core): Resolve empty expressions to empty string in VM evaluator

### DIFF
--- a/packages/@n8n/tournament/src/ExpressionSplitter.ts
+++ b/packages/@n8n/tournament/src/ExpressionSplitter.ts
@@ -25,6 +25,12 @@ const normalizeBackslashes = (text: string): string => {
 };
 
 export const splitExpression = (expression: string): ExpressionChunk[] => {
+	// Maintain the "always have an initial text chunk" invariant
+	// that ExpressionBuilder.getExpressionCode relies on.
+	if (expression === '') {
+		return [{ type: 'text', text: '' }];
+	}
+
 	const chunks: ExpressionChunk[] = [];
 	let searchingFor: 'open' | 'close' = 'open';
 	let activeRegex = OPEN_BRACKET;

--- a/packages/workflow/src/extensions/expression-parser.ts
+++ b/packages/workflow/src/extensions/expression-parser.ts
@@ -22,6 +22,12 @@ export const escapeCode = (text: string): string => {
 };
 
 export const splitExpression = (expression: string): ExpressionChunk[] => {
+	// Mirror @n8n/tournament's splitExpression: always emit an initial text
+	// chunk so downstream consumers can rely on chunks[0] being defined.
+	if (expression === '') {
+		return [{ type: 'text', text: '' }];
+	}
+
 	const chunks: ExpressionChunk[] = [];
 	let searchingFor: 'open' | 'close' = 'open';
 	let activeRegex = OPEN_BRACKET;

--- a/packages/workflow/test/ExpressionExtensions/expression-extension.test.ts
+++ b/packages/workflow/test/ExpressionExtensions/expression-extension.test.ts
@@ -69,6 +69,10 @@ describe('Expression Parser', () => {
 				{ type: 'code', text: ' code.test("}}") ', hasClosingBrackets: true },
 			]);
 		});
+
+		test('Empty input (CAT-3075)', () => {
+			expect(splitExpression('')).toEqual([{ type: 'text', text: '' }]);
+		});
 	});
 
 	describe('Compatible joining', () => {

--- a/packages/workflow/test/expression.test.ts
+++ b/packages/workflow/test/expression.test.ts
@@ -778,6 +778,14 @@ describe('Expression', () => {
 			});
 		});
 
+		// CAT-3075: feature parity between legacy and VM engines for empty expressions.
+		// The legacy engine returns "" via Tournament.execute's empty-input guard;
+		// the VM engine bypassed that guard and threw
+		// `TypeError: Cannot read properties of undefined (reading 'text')`.
+		it('should resolve "=" (empty expression marker) to "" (CAT-3075)', () => {
+			expect(evaluate('=')).toBe('');
+		});
+
 		describe('additionalKeys', () => {
 			const node = workflow.nodes.node;
 


### PR DESCRIPTION
## Summary

Under `N8N_EXPRESSION_ENGINE=vm` (the engine path active on n8n Cloud), evaluating a parameter whose value is `"="` (the expression-mode prefix with empty body — the natural state of an unfilled expression field) crashed with `TypeError: Cannot read properties of undefined (reading 'text')` instead of resolving to `""`.

The legacy engine handled this via `Tournament.execute`'s falsy-input short-circuit at `packages/@n8n/tournament/src/index.ts:36`, but the VM evaluator calls `Tournament.getExpressionCode` directly and bypassed that guard. Inside `getExpressionCode`, `splitExpression('')` returned `[]`, then `chunks[0].text` was read on `undefined` and threw.

This restores parity by fixing the documented invariant at the source: `splitExpression('')` now returns a single empty text chunk (`[{ type: 'text', text: '' }]`), which the existing builder branch at `ExpressionBuilder.ts:204-208` already knows how to emit as `return "";`. No changes needed elsewhere in the call chain.

### How to test

```bash
pnpm --filter @n8n/workflow test test/expression.test.ts
```

The new regression test `should resolve "=" (empty expression marker) to "" (CAT-3075)` runs under both `legacy-engine` and `vm-engine` vitest projects. Before this PR: passes under legacy, fails under VM with the customer's exact stack trace. After: passes under both.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/CAT-3075
- Closes duplicate https://linear.app/n8n/issue/CAT-3069

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<details>
<summary>Implementation plan</summary>

# CAT-3075 — VM expression evaluator crashes on empty expression (`rightValue: '='`)

**Linear:** https://linear.app/n8n/issue/CAT-3075
**Duplicate of:** CAT-3069 (marked as dup in Linear; same root cause, same fix)
**Branch:** `cat-3075-vm-expression-evaluator-crashes-on-empty-expression`

## Summary

Under `N8N_EXPRESSION_ENGINE=vm`, evaluating a parameter value of `"="` (the bare expression-mode prefix with empty body) crashes with `TypeError: Cannot read properties of undefined (reading 'text')` instead of resolving to `""`. The legacy engine handles this fine because `Tournament.execute` short-circuits on falsy input, but the VM evaluator goes through `Tournament.getExpressionCode` directly and the AST builder dereferences `chunks[0].text` without checking that `chunks` is non-empty. Fix is one guard in `@n8n/tournament` to restore the invariant the builder already documents.

## Root cause

- `packages/workflow/src/expression.ts` strips the leading `=` → calls into the evaluator with `""`.
- VM path: `ExpressionEvaluator.getTransformedCode` (`packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts:184`) calls `tournament.getExpressionCode("")` directly — it does **not** go through `Tournament.execute`, so the `if (!expr) return expr` guard at `packages/@n8n/tournament/src/index.ts:36` is bypassed.
- `getExpressionCode` (`packages/@n8n/tournament/src/ExpressionBuilder.ts:171`) calls `splitExpression("")` → returns `[]` (the `while` loop body never runs in `packages/@n8n/tournament/src/ExpressionSplitter.ts:36`).
- Line 206 reads `chunks[0].text` on `undefined` → TypeError.
- The comment at `ExpressionBuilder.ts:201` explicitly states the invariant `"we always have an initial text chunk"` — the splitter is what violates the invariant for empty input.

## Decisions

### Where to fix: `splitExpression`, not `getExpressionCode`

Two viable root-fix locations:

1. **`splitExpression`** — when given `""`, return `[{ type: 'text', text: '' }]` instead of `[]`. Restores the invariant documented in `ExpressionBuilder.ts:201`. The existing branch at line 204-271 already explicitly handles the single empty-text-chunk case (the `chunks[0].text === '' && chunks.length === 1` clause on line 208) and emits a clean `return "";`.
2. **`getExpressionCode`** — early-return on `chunks.length === 0` with a hand-rolled `['return "";', { has: { function: false, templateString: false } }]`.

Going with option 1. Reasons:

- It fixes the real invariant violation rather than papering over its consequence.
- It reuses the existing single-empty-chunk branch — no need to hand-construct an `ExpressionAnalysis` literal or speculate about the output shape.
- It's symmetric with `joinExpression`, which round-trips `""` ↔ `[{text:''}]` (the empty-chunk side of the round-trip is currently broken — `joinExpression([])` is also `""`, so adding the empty-text chunk preserves it).
- Any future caller of `splitExpression` (it's exported) benefits.

We are **not** also patching `getExpressionCode` (single source of truth) or guarding in `ExpressionEvaluator.getTransformedCode` (would mask any future regressions in the same class).

### `Tournament.getExpressionCode` wrapper

No additional guard needed. The wrapper at `index.ts:29-31` is a pass-through; the fix in `splitExpression` covers all consumers (the wrapper, `FunctionEvaluator` via `Tournament.execute`'s evaluator path, and the VM evaluator).

### IIFE bundle rebuild

Not required. `packages/@n8n/expression-runtime/esbuild.config.js` bundles `src/runtime/index.ts`, which contains only the in-isolate runtime (`context.ts`, `lazy-proxy.ts`, `safe-globals.ts`, `serialize.ts`). Grepping `packages/@n8n/expression-runtime/src/runtime/**` shows references to "tournament" are all comments — no `import` of `@n8n/tournament`. The fix lives entirely in host-side code that the bundle does not embed.

## Files to change

### `packages/@n8n/tournament/src/ExpressionSplitter.ts` — `splitExpression`

Add a single guard at the top of `splitExpression` (before the `while` loop, after the local-state declarations): when `expression === ''`, return `[{ type: 'text', text: '' }]`.

Rationale lives in a comment that points to `ExpressionBuilder.ts:201` (the documented "always have an initial text chunk" invariant) so the next reader doesn't strip the guard thinking it's dead code.

That's the entire production change.

## Files to leave alone

- `packages/@n8n/tournament/src/ExpressionBuilder.ts` — branch already handles `[{text:''}]` correctly; adding a redundant guard would be defense-in-depth no-op.
- `packages/@n8n/tournament/src/index.ts` — `Tournament.execute`'s falsy guard at line 36 stays as-is. Removing it would change legacy behavior; tightening `Tournament.getExpressionCode` would be redundant once `splitExpression` is fixed.
- `packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts` — no caller-side guard. The crash should be fixed at the source.
- `packages/@n8n/expression-runtime/dist/bundle/runtime.iife.js` — bundle does not include tournament; no rebuild needed.
- `packages/workflow/src/expression.ts` — does the right thing already (strips `=`, delegates).

## Test plan

### Keep the existing regression test (sufficient)

`packages/workflow/test/expression.test.ts` already contains the CAT-3075 test:

```ts
it('should resolve "=" (empty expression marker) to "" (CAT-3075)', () => {
    expect(evaluate('=')).toBe('');
});
```

This runs under both vitest projects (`legacy-engine` and `vm-engine`) per `packages/workflow/vitest.config.ts`. It exercises the full customer stack trace top-to-bottom: `WorkflowExpression.getParameterValue` → `Expression.resolveSimpleParameterValue` → `Expression.renderExpression` → `ExpressionEvaluator.evaluate` → `ExpressionEvaluator.getTransformedCode` → `Tournament.getExpressionCode` → `getExpressionCode` → `splitExpression`. That's the exact failure path from the ticket, and matching parity under both projects is the success criterion.

Currently: passes under `[legacy-engine]`, fails under `[vm-engine]` with the customer's TypeError. After the fix: passes under both.

### Do NOT add a unit test in `packages/@n8n/tournament/test/`

User preference is to keep this lean and the workflow-package test already covers the failure mode end-to-end. A `splitExpression('') === [{type:'text',text:''}]` test would be nice for documenting the invariant but is redundant for catching regressions — any regression in `splitExpression('')` immediately re-breaks the workflow-package CAT-3075 test in CI. Skipping.

### Manual verification

- Run `pnpm --filter @n8n/workflow test expression.test.ts` and confirm both projects pass (legacy + vm).
- Spot-check the rest of `packages/@n8n/tournament/test/` (`ExpressionSplitter.test.ts`, `Expression.test.ts`) still passes — none of them currently assert on `splitExpression('')`, and any non-empty input is unaffected.

## Risks and edge cases

- **Whitespace-only after `=` (`"= "` → `" "`)**: not affected. `splitExpression(' ')` already returns `[{type:'text', text:' '}]` (single non-empty text chunk) which hits the main branch and resolves to `" "`. Both engines already behave consistently here.
- **`"{{ }}"` / `"{{}}"`** (empty body inside `{{ }}`): explicitly **out of scope** per ticket. That's a separate bug affecting both engines (the parser, not the splitter) and not part of CAT-3075. Do not fix here.
- **Non-empty inputs**: completely unaffected — the new guard only fires on the exact-equals-empty-string path. The full `splitExpression` test suite (and the 363 workflow tests) should be unchanged.
- **`joinExpression` round-trip**: `joinExpression(splitExpression(''))` is `''` both before and after the fix (empty array joins to `''`; one empty-text chunk joins to `''`). No round-trip regression.
- **`FunctionEvaluator.evaluate('')`**: not reachable via `Tournament.execute('')` (short-circuits), but if called directly through `Tournament.getExpressionCode('')` + `new Function(...)` it would now produce `var ___n8n_data_global = {}; return "";` which is valid and correct. No behavior change for any currently-reachable code path.
- **Hooks (`before`/`after`)**: not invoked for a pure text chunk (hooks fire on `type === 'code'` parsed chunks). No hook-ordering risk.

## Open questions

- None blocking. One non-blocking observation: the comment at `ExpressionBuilder.ts:201-203` would be slightly clearer if it acknowledged that the invariant is now actually maintained by `splitExpression` (it currently reads like an aspirational claim). Not worth a separate change; could be folded in or left alone.

## Commit / PR

**Suggested commit title** (single line, conventional-commit, no security framing):

```
fix(core): resolve empty expressions to "" in VM evaluator (CAT-3075)
```

Alternative if reviewers prefer scope reflecting the actual touched package:

```
fix(tournament): return empty text chunk for empty input
```

Going with the first — the user-visible impact lives in `@n8n/workflow` / the VM evaluator, even though the file touched is in `@n8n/tournament`.

**PR body skeleton:**

```
## Summary

Under N8N_EXPRESSION_ENGINE=vm (the Cloud default), evaluating a parameter
whose value is "=" (the expression-mode prefix with empty body) crashed with
`TypeError: Cannot read properties of undefined (reading 'text')` instead of
resolving to "". The legacy engine handled this via Tournament.execute's
falsy-input short-circuit, but the VM evaluator calls getExpressionCode
directly and bypassed that guard.

This restores parity by fixing the documented invariant at the source:
`splitExpression('')` now returns a single empty text chunk, which the
existing builder branch already knows how to emit as `return "";`.

## Root cause

`splitExpression('')` returned `[]`, violating the "we always have an initial
text chunk" invariant noted in ExpressionBuilder.ts:201. Downstream code read
`chunks[0].text` and crashed.

## Changes

- `packages/@n8n/tournament/src/ExpressionSplitter.ts`: empty input now
  yields `[{ type: 'text', text: '' }]`.
- `packages/workflow/test/expression.test.ts`: regression test that runs
  under both `legacy-engine` and `vm-engine` vitest projects.

## Linear

- Closes https://linear.app/n8n/issue/CAT-3075
- Also closes CAT-3069 (marked as duplicate of CAT-3075)

## Test plan

- [ ] `pnpm --filter @n8n/workflow test expression.test.ts` passes under both
      legacy-engine and vm-engine projects.
- [ ] `pnpm --filter @n8n/tournament test` is green (no existing splitter
      assertions change).
- [ ] Manual: in a workflow with VM engine, an expression-mode parameter
      left empty (rightValue: "=") evaluates without throwing.
```

</details>

🤖 PR Summary generated by AI