### PR TITLE
ci: Toggle jest verbosity off on package level

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -31,7 +31,7 @@ const esmDependenciesRegex = `node_modules/(${esmDependenciesPattern})/.+\\.m?js
 
 /** @type {import('jest').Config} */
 const config = {
-	verbose: true,
+	verbose: false,
 	testEnvironment: 'node',
 	testRegex: '\\.(test|spec)\\.(js|ts)$',
 	testPathIgnorePatterns: ['/dist/', '/node_modules/'],


### PR DESCRIPTION
## Summary

Jest's verbosity was burying actual test failures in the GitHub actions logs. Toggle verbosity off by default.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
