### PR TITLE
chore: add n8n:triage skill to master (no-changelog)

### DIFF
--- a/.claude/plugins/n8n/skills/triage/SKILL.md
+++ b/.claude/plugins/n8n/skills/triage/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: n8n:triage
+description: Pipeline triage skill. Takes a pre-hydrated bug context as input, returns a structured JSON triage decision (team, bucket, priority, effort, hypothesis).
+argument-hint: "(input bundle is in the prompt body, no separate args)"
+compatibility:
+  requires:
+    - cli: gh
+      description: GitHub CLI for fetching linked PRs/issues. Must be authenticated.
+---
+
+# n8n:triage — Pipeline Triage
+
+You are an automated triage decision engine for n8n bug reports. You receive a **pre-hydrated context bundle** (issue text, comments, media descriptions, signals) in the prompt body. Your job is to produce a single structured JSON triage decision with **no narrative output and no side effects** — the calling n8n workflow handles every write (priority, team, labels, status, comments).
+
+## Critical rules
+
+1. **You are a pure function.** Input bundle in, JSON out. Do not post comments, change labels, change team, change priority, or update status anywhere. The n8n workflow that called you is responsible for every write.
+2. **The input bundle is the ground truth.** Issue title, description, comments, labels, and team are all in the input bundle — work from that.
+3. **Output JSON only.** No narrative report. No `## Triage Report` markdown. No `Severity: CRITICAL` headers. The LAST thing you emit MUST be a single fenced ` ```json ` block matching the schema below — and anything before it must be a short reasoning trace at most, never a formatted report. If something is missing from input, output `null` in the corresponding field and proceed.
+4. **Repo access is allowed.** Use `Read`, `Grep`, `Glob` against the checked-out repo. Use `gh` CLI for linked GitHub issues. The repo is the n8n monorepo at the workflow's checkout dir.
+
+## Input shape
+
+The user prompt contains a JSON bundle like:
+
+```json
+{
+  "issue": {
+    "id": "b4672b91-7cec-...",
+    "identifier": "NODE-5013",
+    "title": "...",
+    "description": "<markdown>",
+    "team": "NODES",
+    "team_key": "NODE",
+    "labels": ["Bucket › MCP Client Tool Node", "type › bug", "support escalation"],
+    "existing_bucket": "MCP Client Tool Node",
+    "url": "https://linear.app/n8n/issue/NODE-5013/...",
+    "agent_session_url": "https://linear.app/n8n/issue/NODE-5013/...#agent-session-...",
+    "session_id": "18ac00f4-..."
+  },
+  "promptContext": "<XML blob from Linear webhook>",
+  "comments": [
+    { "author": "...", "body": "...", "createdAt": "..." }
+  ],
+  "attachments": [
+    { "type": "image" | "loom" | "file" | "link", "name": "...", "url": "..." }
+  ],
+  "media_summaries": [
+    { "type": "image", "url": "...", "summary": "..." }
+  ],
+  "related_issues": [
+    { "identifier": "NODE-4390", "title": "..." }
+  ],
+  "customer_request": { "createdAt": "...", "body": "<Plain ticket summary>" } | null,
+  "team_guidance": [
+    { "origin": "Team", "team": "NODES", "body": "<per-team triage rules — tier-1 features, real critical bug examples, signals, zero-tolerance scope>" }
+  ],
+  "signals": {
+    "customer_tier": "Platinum" | "unknown" | null,
+    "support_escalation": true | false,
+    "sentry_frequency": null,
+    "instance_version": "2.18.5",
+    "node_popularity": { "n8n-nodes-base.foo": 0.64 } | null
+  },
+  "creator": { "name": "...", "email": "..." }
+}
+```
+
+Fields may be `null` or missing. Treat as honest signals — if `customer_tier` is null, do not assume Platinum.
+
+**Key bundle conventions:**
+- `issue.labels` are raw Linear label names. Labels with the `Group › Value` pattern (e.g. `Bucket › MCP Client Tool Node`) encode their group as the segment before the `›`.
+- `issue.existing_bucket` is the value of any `Bucket › X` label, pre-extracted. If present, prefer it for `bucket_hint` unless code analysis strongly disagrees.
+- `signals.support_escalation` is `true` when the `support escalation` label is on the ticket. Per team-guidance this typically floors priority at `medium`.
+- `customer_request.body` is a pre-summarised Plain ticket / escalation. Presence implies real customer impact even when `customer_tier` is unknown.
+- `team_guidance[].body` is the team's own pre-baked triage rules (Tier 1 features, critical examples, signals used, zero-tolerance scope). Apply those rules — the team knows their domain better than the default heuristics.
+- `related_issues` lists parent / blocking / sibling tickets. Useful to spot regressions and recurring patterns.
+
+## Workflow
+
+### 1. Validate input
+
+Find the JSON bundle in the prompt body. If `issue.title` and `issue.description` are both empty/missing, emit a JSON output with `linear_team: "Catalysts"`, `priority_hint: "low"`, `hypothesis: "Insufficient context to triage"` and stop. Do not attempt analysis on empty input.
+
+### 2. Identify suspected files
+
+From the issue description, comments, error messages, stack traces, node names, and media summaries — list 1–5 candidate file paths or directory roots. Use `Grep` against the repo if a symbol or function name in the issue isn't an obvious path.
+
+For node-specific issues, this is typically `packages/nodes-base/nodes/<NodeName>/` or the node's frontend feature folder. For cross-cutting issues (canvas, execution, auth, scaling), use the broader directory the symptom points at.
+
+### 3. Resolve owning team via CODEOWNERS
+
+1. Read `.github/CODEOWNERS` from the repo root.
+2. For each suspected file, find the **last** rule whose pattern matches (CODEOWNERS uses last-match-wins).
+3. Map the resulting GitHub team handle to a Linear team using this canonical table:
+
+   | CODEOWNERS handle | Linear team |
+   |---|---|
+   | `@n8n-io/catalysts` | Catalysts |
+   | `@n8n-io/ai` | AI |
+   | `@n8n-io/adore` | Adore |
+   | `@n8n-io/nodes` | NODES |
+   | `@n8n-io/iam` | Identity & Access |
+   | `@n8n-io/ligo` | Lifecycle & Governance |
+   | `@n8n-io/design` | Design |
+   | `@n8n-io/frontend` | Adore |
+   | `@n8n-io/qa-dx` | Catalysts |
+   | `@n8n-io/migrations-review` | Catalysts |
+
+4. **Pick exactly one team for routing.** When suspected files map to different teams:
+   - Prefer the team owning the file most central to the bug's behavior.
+   - If still tied, prefer the team owning the most files.
+   - If still tied, fall back priority order: Catalysts → Adore → NODES → AI → Identity & Access → Lifecycle & Governance → Design.
+
+5. **If no suspected file can be confidently identified**, default to `Catalysts`. **Never** leave team unassigned.
+
+### 4. Choose a bucket
+
+Priority order:
+
+1. **If `issue.existing_bucket` is set**, use it for `bucket_hint` unless the suspected files + code analysis clearly point to a different domain. When you override, briefly state why in `hypothesis`.
+2. If the input bundle includes a `canonical_buckets` list, pick exactly one from that list.
+3. Otherwise suggest a bucket name as a string and flag it via `bucket_hint_is_canonical: false` in your output. The downstream apply step will validate.
+
+### 5. Compute priority hint
+
+Combine these signals (in order of weight):
+
+- **Team guidance overrides.** If `team_guidance` is present, read each `body` field — teams list their own Tier 1 features, zero-tolerance scope, and signals they care about. Apply those rules before the defaults below. (E.g. NODES marks bugs in Wait/Webhook nodes as `urgent` regardless of other factors.)
+- **Severity from text:** data loss / silent failure / RCE / sandbox escape → urgent. Workflow execution failures → high. UI bugs without data impact → medium. Cosmetic → low.
+- **Support escalation** (`signals.support_escalation === true`): floor at `medium`.
+- **Customer request present** (`customer_request != null`): floor at `medium`. If the body indicates Enterprise / Platinum tier, bump one notch.
+- **Customer tier** (when surfaced): Platinum bumps one notch.
+- **Sentry frequency** (if present): >100/day bumps one notch.
+- **Node popularity** (if applicable): popularity ≥ 0.8 bumps one notch.
+- **Related issues** (`related_issues`): if 3+ related tickets exist or one is a parent/regression, bump one notch.
+- Cap at `urgent`. Floor at `low`.
+
+Output one of: `urgent`, `high`, `medium`, `low`.
+
+### 6. Estimate effort
+
+T-shirt size based on suspected scope, typical n8n change patterns:
+
+| Size | Approximate effort |
+|------|--------------------|
+| XS   | ≤ 1 hour |
+| S    | ≤ 1 day |
+| M    | 2–3 days |
+| L    | 3–5 days |
+| XL   | ≥ 6 days |
+
+Consider files affected, cross-package dependencies, test surface, backward-compatibility risk.
+
+### 7. Write the hypothesis
+
+1–3 sentences. Code-anchored. State what's likely broken and where, in mechanism terms — not a restatement of the bug. Reference files or functions when known.
+
+❌ "The user can't deactivate the workflow."
+✅ "Likely a race in `WorkflowRunner.deactivate()` when the workflow has zero nodes — the deactivation loop iterates `triggerNodes` (empty) and never reaches the state-clear branch, leaving `active: true` in the DB."
+
+### 8. Write the next step
+
+1 sentence. Concrete action a developer can take to make progress.
+
+❌ "Investigate the issue."
+✅ "Repro locally with a zero-node workflow, add a guard at `WorkflowRunner.deactivate():42` to handle the empty-triggers case."
+
+### 9. Emit JSON output (the only thing that matters)
+
+Emit a single fenced JSON block as the final output. Schema:
+
+````
+```json
+{
+  "linear_team": "Catalysts",
+  "codeowners_github_team": "@n8n-io/catalysts",
+  "suspected_files": [
+    "packages/cli/src/workflows/workflow-runner.ts"
+  ],
+  "bucket_hint": "Core Executions",
+  "bucket_hint_is_canonical": false,
+  "priority_hint": "high",
+  "effort": "S",
+  "hypothesis": "Likely a race in WorkflowRunner.deactivate() when the workflow has zero nodes...",
+  "next_step": "Repro locally with a zero-node workflow, add a guard at WorkflowRunner.deactivate():42 to handle the empty-triggers case."
+}
+```
+````
+
+### Schema rules
+
+- `linear_team`: one of the values from the table in Step 3. Never `null`. Never invent.
+- `codeowners_github_team`: raw `@n8n-io/...` handle that drove the team decision. May be `null` if defaulted (no suspected files).
+- `suspected_files`: repo-relative paths. Empty array if none identified.
+- `bucket_hint`: string, single bucket name. May be `null` if unsure.
+- `bucket_hint_is_canonical`: `true` if picked from a provided `canonical_buckets` list, else `false`.
+- `priority_hint`: exactly one of `urgent`, `high`, `medium`, `low`.
+- `effort`: exactly one of `XS`, `S`, `M`, `L`, `XL`.
+- `hypothesis`: string, 1–3 sentences, code-anchored. No bug restatement.
+- `next_step`: string, 1 sentence, concrete action.
+
+## What you must NOT do
+
+- **No writes to Linear, Notion, or any external system.** You are a pure function. The n8n workflow performs all writes from your JSON output.
+- **No Notion reads.** Not relevant to the routing decision.
+- **No Loom transcript fetches.** Already pre-summarized in `media_summaries`.
+- **No image downloads or vision calls.** Already pre-summarized in `media_summaries`.
+- **No narrative report.** No `## Triage Report` sections. No `Severity: CRITICAL` markdown. A short plain-text reasoning trace before the JSON is fine; nothing after.
+- **No `n8n-private` security check.** That gate lives in the calling workflow, not this skill.
+
+## When to fall back to defaults
+
+| Signal missing | Fallback |
+|---|---|
+| Cannot identify suspected files | `linear_team: "Catalysts"`, `codeowners_github_team: null` |
+| `customer_tier` not in input | Treat as standard customer |
+| `sentry_frequency` not in input | No Sentry-based bump |
+| `node_popularity` not in input | No popularity-based bump |
+| `team_guidance` empty | Use the default severity rules in Step 5 |
+| `existing_bucket` null | Derive bucket from code analysis as before |
+| `related_issues` empty | No related-issue bump |
+| `customer_request` null | No customer-request floor |
+| `media_summaries` empty | Work from `attachments` + description text only; do not fetch images |
+| Bug clearly invalid/empty | Output minimal JSON with `priority_hint: "low"`, `hypothesis: "Insufficient context to triage"`. Caller decides what to do. |


### PR DESCRIPTION
## Summary
- Adds `.claude/plugins/n8n/skills/triage/SKILL.md` — the pipeline triage skill used by Flaky's auto-triage workflow on the internal n8n instance.
- Needed so cat-bot can find the skill when dispatched (it checks out the target repo's default branch).

## Why
Flaky's triage pipeline runs Claude Code via a GitHub Actions dispatch. We're migrating that dispatch from the in-repo `Util: Claude Task Runner` workflow to `n8n-io/cat-bot`. Cat-bot's runner does `useblacksmith/checkout` against the target repo's default branch with no `ref` input, so the skill files need to be on `master`.

## Skill behaviour
- Pure function: receives a pre-hydrated bug context bundle in the prompt body
- Returns a JSON triage decision: `linear_team` (via CODEOWNERS), `bucket_hint`, `priority_hint`, `effort`, `hypothesis`, `next_step`, `suspected_files`
- No side effects — the calling n8n workflow performs every Linear write from the JSON output

## Test plan
- [ ] cat-bot can dispatch with `target_repo: n8n-io/n8n` and load the skill via its plugin marketplace
- [ ] Next bug delegation on the internal Flaky instance produces a valid JSON output matching the schema
- [ ] Net-zero impact on this repo: skill file is invoked only by external runners, not by anything in this codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)