### PR TITLE
test: Mark instance-ai timeouts test as fixme (no-changelog)

### DIFF
--- a/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-timeouts.spec.ts
+++ b/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-timeouts.spec.ts
@@ -3,34 +3,27 @@ import { test, expect, instanceAiTestConfig } from './fixtures';
 test.use(instanceAiTestConfig);
 
 test.describe('Instance AI timeouts', () => {
-	test.beforeEach(({}, testInfo) => {
-		test.skip(
-			testInfo.project.name.includes('multi-main'),
-			'Instance AI background-task state is per-main-process; the seed endpoint and the browser may land on different mains.',
-		);
-	});
+	test.fixme(
+		'should show a timeout message when a stuck background task times out',
+		async ({ api, n8n }) => {
+			const owner = await api.signin('owner');
+			const simulation = await api.startInstanceAiBackgroundTimeoutSimulation(owner.id);
 
-	test('should show a timeout message when a stuck background task times out', async ({
-		api,
-		n8n,
-	}) => {
-		const owner = await api.signin('owner');
-		const simulation = await api.startInstanceAiBackgroundTimeoutSimulation(owner.id);
+			await n8n.instanceAi.gotoThread(simulation.threadId);
+			await expect(n8n.instanceAi.getAssistantMessages().first()).toContainText(
+				'I started a background workflow-builder task.',
+				{ timeout: 15_000 },
+			);
+			await expect(n8n.instanceAi.getBackgroundTaskIndicator()).toBeVisible({ timeout: 15_000 });
 
-		await n8n.instanceAi.gotoThread(simulation.threadId);
-		await expect(n8n.instanceAi.getAssistantMessages().first()).toContainText(
-			'I started a background workflow-builder task.',
-			{ timeout: 15_000 },
-		);
-		await expect(n8n.instanceAi.getBackgroundTaskIndicator()).toBeVisible({ timeout: 15_000 });
+			await api.runInstanceAiLivenessSweep(simulation.timeoutAt);
 
-		await api.runInstanceAiLivenessSweep(simulation.timeoutAt);
-
-		await expect(
-			n8n.instanceAi.getAssistantMessageText(
-				/Background workflow-builder task timed out after \d+ms/,
-			),
-		).toBeVisible({ timeout: 15_000 });
-		await expect(n8n.instanceAi.getBackgroundTaskIndicator()).toBeHidden({ timeout: 15_000 });
-	});
+			await expect(
+				n8n.instanceAi.getAssistantMessageText(
+					/Background workflow-builder task timed out after \d+ms/,
+				),
+			).toBeVisible({ timeout: 15_000 });
+			await expect(n8n.instanceAi.getBackgroundTaskIndicator()).toBeHidden({ timeout: 15_000 });
+		},
+	);
 });


### PR DESCRIPTION
## Summary

Convert the single test in `instance-ai-timeouts.spec.ts` from a `multi-main`-only conditional skip to a full `test.fixme`.

The original guard only skipped on `multi-main:e2e` projects. Investigation of a Shard 3 failure on PR #17949 (an unrelated single-line tooltip change) showed the test fails 3-for-3 on `sqlite:e2e` as well — `getBackgroundTaskIndicator()` does not become visible after `startInstanceAiBackgroundTimeoutSimulation` seeds the task. Currents has 0 recorded passes across 245 executions of this spec, and `sqlite:e2e` isn't uploading to Currents at all, so flake tracking missed it entirely.

Marking as `fixme` until the indicator timing is fixed unblocks community PRs immediately.

## Related Linear tickets, Github issues, and Community forum posts

N/A — hotfix to unblock CI.

Follow-up work (separate tickets to be filed):
- Investigate why `getBackgroundTaskIndicator()` doesn't render after the seed endpoint
- Fix the Currents reporter gap so `sqlite:e2e` results upload

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included. <!-- N/A — this PR skips a broken test; the fix itself will need test coverage. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)