### PR TITLE
ci: Scope prepare-test-image docker build context to temp dir

### DIFF
--- a/packages/testing/playwright/scripts/build-test-image.mjs
+++ b/packages/testing/playwright/scripts/build-test-image.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execSync } from 'child_process';
-import { writeFileSync, unlinkSync, existsSync, mkdirSync, copyFileSync, rmSync } from 'fs';
+import { writeFileSync, existsSync, mkdirSync, copyFileSync, rmSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -13,21 +13,17 @@ function execCommand(command, options = {}) {
 	return execSync(command, { cwd: repoRoot, stdio: 'inherit', ...options });
 }
 
-function cleanup(files = []) {
-	files.forEach((file) => {
+function cleanup(paths = []) {
+	paths.forEach((p) => {
 		try {
-			if (file.endsWith('/')) {
-				rmSync(file, { recursive: true, force: true });
-			} else {
-				unlinkSync(file);
-			}
+			rmSync(p, { recursive: true, force: true });
 		} catch {}
 	});
 }
 
 function buildTestImage(targetImage) {
 	const tempBuildDir = path.join(repoRoot, 'temp-build-e2e');
-	const dockerfilePath = path.join(repoRoot, 'Dockerfile.test');
+	const dockerfilePath = path.join(tempBuildDir, 'Dockerfile');
 	const tempTag = `${targetImage}-temp-${Date.now()}`;
 
 	try {
@@ -47,27 +43,27 @@ function buildTestImage(targetImage) {
 			throw new Error(`E2E controller not found. Build may have failed.`);
 		}
 
-		// Setup temp files
-		cleanup([tempBuildDir, dockerfilePath]);
+		// Setup temp build context (self-contained, decoupled from repo .dockerignore)
+		cleanup([tempBuildDir]);
 		mkdirSync(tempBuildDir, { recursive: true });
 		copyFileSync(controllerPath, path.join(tempBuildDir, 'e2e.controller.js'));
 
-		// Create Dockerfile
 		writeFileSync(
 			dockerfilePath,
 			`FROM ${targetImage}
-COPY temp-build-e2e/e2e.controller.js /usr/local/lib/node_modules/n8n/dist/controllers/e2e.controller.js`,
+COPY e2e.controller.js /usr/local/lib/node_modules/n8n/dist/controllers/e2e.controller.js
+`,
 		);
 
-		// Build and replace image
-		execCommand(`docker build -f Dockerfile.test -t ${tempTag} .`);
+		// Build with the temp dir as the build context — avoids repo-root .dockerignore whitelist
+		execCommand(`docker build -f ${dockerfilePath} -t ${tempTag} ${tempBuildDir}`);
 		execCommand(`docker rmi ${targetImage}`);
 		execCommand(`docker tag ${tempTag} ${targetImage}`);
 		execCommand(`docker rmi ${tempTag}`);
 
 		console.log(`✅ Modified ${targetImage} with e2e controller`);
 	} finally {
-		cleanup([tempBuildDir, dockerfilePath]);
+		cleanup([tempBuildDir]);
 	}
 }
 


### PR DESCRIPTION
## Summary

`pnpm prepare-test-image` was broken: the repo `.dockerignore` switched to a whitelist (`*` then `!entries`) to shrink the build context, and `temp-build-e2e/` is not whitelisted. Running `docker build` from repo root therefore produced an empty context (`transferring context: 2B`) and the `COPY temp-build-e2e/e2e.controller.js …` step failed with `not found`. Not stable-specific — it happens for any target image.

This PR:

- Writes the generated `Dockerfile` inside `temp-build-e2e/` and passes that directory as the build context. The script is now decoupled from the repo-root `.dockerignore`.
- Fixes a cleanup bug: `unlinkSync` was being called on the `temp-build-e2e/` directory (path didn't end in `/`), silently failing inside the empty `catch` and leaving the directory behind. Cleanup now uses `rmSync(path, { recursive: true, force: true })` for every path.
- Removes the now-unused `unlinkSync` import and the root `Dockerfile.test` path.

### Verified locally against `n8nio/n8n:stable`

- `docker build` succeeded: build context `22.60kB`, `COPY` step DONE, image tagged.
- Final image present: `n8nio/n8n:stable` (2.25 GB).
- `e2e.controller.js` is in the image at `/usr/local/lib/node_modules/n8n/dist/controllers/e2e.controller.js` (22556 bytes).
- Cleanup runs to completion — no `temp-build-e2e/` or `Dockerfile.test` left at repo root.

## Related Linear tickets, Github issues, and Community forum posts

n/a — internal test-tooling fix.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!-- Script is exercised end-to-end by `pnpm prepare-test-image` itself; no separate unit test added. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)