### PR TITLE
fix(core): Agent sessions present tool errors correctly and inputs to tools when error occurs (no-changelog)

### DIFF
--- a/packages/cli/src/modules/agents/__tests__/execution-recorder.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/execution-recorder.test.ts
@@ -498,10 +498,9 @@ describe('ExecutionRecorder — tool-result error normalization', () => {
 
 		const tc = rec.getMessageRecord().timeline.find((e) => e.type === 'tool-call')!;
 		expect(tc.success).toBe(false);
-		// Serializing an Error directly produces "{}" because name/message/stack are
-		// non-enumerable. The recorder must normalise so the persisted timeline
-		// carries the message that the UI can render.
-		expect(JSON.parse(JSON.stringify(tc.output))).toEqual({
+		// `tc.output` must be a plain enumerable object — a raw Error would serialize
+		// to "{}" via TypeORM's JSON column, losing the diagnostic the UI needs.
+		expect(tc.output).toEqual({
 			error: 'Credential "Telegram acc" is not accessible or does not exist.',
 		});
 	});
@@ -552,7 +551,7 @@ describe('ExecutionRecorder — tool-result error normalization', () => {
 
 		const tc = rec.getMessageRecord().timeline.find((e) => e.type === 'tool-call')!;
 		expect(tc.success).toBe(false);
-		expect(JSON.parse(JSON.stringify(tc.output))).toEqual({ error: 'still bad' });
+		expect(tc.output).toEqual({ error: 'still bad' });
 	});
 
 	it('leaves a successful tool result untouched', () => {

--- a/packages/cli/src/modules/agents/__tests__/execution-recorder.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/execution-recorder.test.ts
@@ -478,3 +478,210 @@ describe('ExecutionRecorder — workflow-tool timeline tags', () => {
 		expect(tc.success).toBe(false);
 	});
 });
+
+describe('ExecutionRecorder — tool-result error normalization', () => {
+	it('captures the Error message when a tool throws (instead of storing a non-serializable Error)', () => {
+		const rec = new ExecutionRecorder();
+		rec.record({
+			type: 'tool-call',
+			toolCallId: 't1',
+			toolName: 'send_telegram_message',
+			input: { chatId: '1', text: 'hi' },
+		} as never);
+		rec.record({
+			type: 'tool-result',
+			toolCallId: 't1',
+			toolName: 'send_telegram_message',
+			output: new Error('Credential "Telegram acc" is not accessible or does not exist.'),
+			isError: true,
+		} as never);
+
+		const tc = rec.getMessageRecord().timeline.find((e) => e.type === 'tool-call')!;
+		expect(tc.success).toBe(false);
+		// Serializing an Error directly produces "{}" because name/message/stack are
+		// non-enumerable. The recorder must normalise so the persisted timeline
+		// carries the message that the UI can render.
+		expect(JSON.parse(JSON.stringify(tc.output))).toEqual({
+			error: 'Credential "Telegram acc" is not accessible or does not exist.',
+		});
+	});
+
+	it('wraps a string error output in { error } so the shape stays consistent', () => {
+		const rec = new ExecutionRecorder();
+		rec.record({ type: 'tool-call', toolCallId: 't1', toolName: 'x', input: {} } as never);
+		rec.record({
+			type: 'tool-result',
+			toolCallId: 't1',
+			toolName: 'x',
+			output: 'boom',
+			isError: true,
+		} as never);
+
+		const tc = rec.getMessageRecord().timeline.find((e) => e.type === 'tool-call')!;
+		expect(tc.output).toEqual({ error: 'boom' });
+	});
+
+	it('preserves an already-enumerable error object', () => {
+		const rec = new ExecutionRecorder();
+		rec.record({ type: 'tool-call', toolCallId: 't1', toolName: 'x', input: {} } as never);
+		rec.record({
+			type: 'tool-result',
+			toolCallId: 't1',
+			toolName: 'x',
+			output: { error: 'already shaped', code: 'E_BAD' },
+			isError: true,
+		} as never);
+
+		const tc = rec.getMessageRecord().timeline.find((e) => e.type === 'tool-call')!;
+		expect(tc.output).toEqual({ error: 'already shaped', code: 'E_BAD' });
+	});
+
+	it('normalises Error in the synthesised entry path too', () => {
+		// HITL/approval resume path: tool-result arrives without a preceding
+		// tool-call chunk, so the recorder synthesises a timeline entry. That
+		// path must apply the same normalisation.
+		const rec = new ExecutionRecorder();
+		rec.record({
+			type: 'tool-result',
+			toolCallId: 't-resume',
+			toolName: 'x',
+			output: new Error('still bad'),
+			isError: true,
+		} as never);
+		rec.record({ type: 'finish', finishReason: 'stop' } as StreamChunk);
+
+		const tc = rec.getMessageRecord().timeline.find((e) => e.type === 'tool-call')!;
+		expect(tc.success).toBe(false);
+		expect(JSON.parse(JSON.stringify(tc.output))).toEqual({ error: 'still bad' });
+	});
+
+	it('leaves a successful tool result untouched', () => {
+		const rec = new ExecutionRecorder();
+		rec.record({ type: 'tool-call', toolCallId: 't1', toolName: 'x', input: {} } as never);
+		rec.record({
+			type: 'tool-result',
+			toolCallId: 't1',
+			toolName: 'x',
+			output: { status: 'ok', data: [1, 2, 3] },
+			isError: false,
+		} as never);
+
+		const tc = rec.getMessageRecord().timeline.find((e) => e.type === 'tool-call')!;
+		expect(tc.success).toBe(true);
+		expect(tc.output).toEqual({ status: 'ok', data: [1, 2, 3] });
+	});
+});
+
+describe('ExecutionRecorder — node-tool {{$json.x}} resolution', () => {
+	it('resolves a full-string {{$json.path}} expression using the LLM args', () => {
+		const registry = buildToolRegistry([
+			nodeTool('send_message', 'n8n-nodes-base.telegramTool', {
+				resource: 'message',
+				operation: 'sendMessage',
+				chatId: '={{$json.chat_id}}',
+				text: '={{ $json.text }}',
+			}),
+		]);
+		const rec = new ExecutionRecorder(registry);
+
+		rec.record({
+			type: 'tool-call',
+			toolCallId: 't1',
+			toolName: 'send_message',
+			input: { chat_id: '12345', text: 'hello there' },
+		} as never);
+		rec.record({
+			type: 'tool-result',
+			toolCallId: 't1',
+			toolName: 'send_message',
+			output: { ok: true },
+		} as never);
+
+		const tc = rec.getMessageRecord().timeline.find((e) => e.type === 'tool-call')!;
+		expect(tc.nodeParameters).toEqual({
+			resource: 'message',
+			operation: 'sendMessage',
+			chatId: '12345',
+			text: 'hello there',
+		});
+	});
+
+	it('resolves a nested {{$json.path.sub}} lookup', () => {
+		const registry = buildToolRegistry([
+			nodeTool('post', 'n8n-nodes-base.http', {
+				url: '={{ $json.target.url }}',
+			}),
+		]);
+		const rec = new ExecutionRecorder(registry);
+
+		rec.record({
+			type: 'tool-call',
+			toolCallId: 't1',
+			toolName: 'post',
+			input: { target: { url: 'https://example.com/api' } },
+		} as never);
+		rec.record({
+			type: 'tool-result',
+			toolCallId: 't1',
+			toolName: 'post',
+			output: { ok: true },
+		} as never);
+
+		const tc = rec.getMessageRecord().timeline.find((e) => e.type === 'tool-call')!;
+		expect((tc.nodeParameters as Record<string, unknown>).url).toBe('https://example.com/api');
+	});
+
+	it('leaves the raw template in place when the path is missing', () => {
+		const registry = buildToolRegistry([
+			nodeTool('post', 'n8n-nodes-base.http', {
+				url: '={{ $json.target.url }}',
+			}),
+		]);
+		const rec = new ExecutionRecorder(registry);
+
+		rec.record({
+			type: 'tool-call',
+			toolCallId: 't1',
+			toolName: 'post',
+			input: { target: {} },
+		} as never);
+		rec.record({
+			type: 'tool-result',
+			toolCallId: 't1',
+			toolName: 'post',
+			output: { ok: true },
+		} as never);
+
+		const tc = rec.getMessageRecord().timeline.find((e) => e.type === 'tool-call')!;
+		expect((tc.nodeParameters as Record<string, unknown>).url).toBe('={{ $json.target.url }}');
+	});
+
+	it('still resolves $fromAI calls when both styles are mixed', () => {
+		const registry = buildToolRegistry([
+			nodeTool('post', 'n8n-nodes-base.http', {
+				url: "={{ $fromAI('endpoint', 'API endpoint', 'string') }}",
+				body: '={{ $json.payload }}',
+			}),
+		]);
+		const rec = new ExecutionRecorder(registry);
+
+		rec.record({
+			type: 'tool-call',
+			toolCallId: 't1',
+			toolName: 'post',
+			input: { endpoint: 'https://api/x', payload: 'hi' },
+		} as never);
+		rec.record({
+			type: 'tool-result',
+			toolCallId: 't1',
+			toolName: 'post',
+			output: { ok: true },
+		} as never);
+
+		const tc = rec.getMessageRecord().timeline.find((e) => e.type === 'tool-call')!;
+		expect(tc.nodeParameters).toEqual({
+			url: 'https://api/x',
+			body: 'hi',
+		});
+	});
+});

--- a/packages/cli/src/modules/agents/execution-recorder.ts
+++ b/packages/cli/src/modules/agents/execution-recorder.ts
@@ -4,27 +4,34 @@ import { extractFromAICalls, isFromAIOnlyExpression } from 'n8n-workflow';
 import type { ToolRegistry } from './tool-registry';
 
 /**
- * Walk a nodeParameters tree and substitute every `$fromAI('key', ...)`
- * expression with the value the LLM passed for that key (or the call's
- * default when the LLM didn't provide one). Used when recording a
- * `kind: 'node'` tool call so the timeline shows the resolved values the
- * node would have run with — not the raw template strings the user
+ * Walk a nodeParameters tree and substitute templated values with what the
+ * LLM passed: both `$fromAI('key', ...)` placeholders and `={{ $json.path }}`
+ * lookups (the LLM's structured input is the node's `$json` at runtime — see
+ * `node-tool-factory.ts` where input flows in as `[{ json: input }]`). Used
+ * when recording a `kind: 'node'` tool call so the timeline shows the values
+ * the node would have run with, not the raw template strings the user
  * configured.
  *
  * Pure best-effort: parsing failures fall through to the raw string. The
  * goal is a clearer log entry, not exact expression-engine fidelity.
  */
-function resolveFromAIInValue(value: unknown, llmArgs: Record<string, unknown>): unknown {
-	if (typeof value === 'string') return resolveFromAIInString(value, llmArgs);
-	if (Array.isArray(value)) return value.map((v) => resolveFromAIInValue(v, llmArgs));
+function resolveTemplatesInValue(value: unknown, llmArgs: Record<string, unknown>): unknown {
+	if (typeof value === 'string') return resolveTemplatesInString(value, llmArgs);
+	if (Array.isArray(value)) return value.map((v) => resolveTemplatesInValue(v, llmArgs));
 	if (value !== null && typeof value === 'object') {
 		const out: Record<string, unknown> = {};
 		for (const [k, v] of Object.entries(value)) {
-			out[k] = resolveFromAIInValue(v, llmArgs);
+			out[k] = resolveTemplatesInValue(v, llmArgs);
 		}
 		return out;
 	}
 	return value;
+}
+
+function resolveTemplatesInString(str: string, llmArgs: Record<string, unknown>): unknown {
+	const afterFromAI = resolveFromAIInString(str, llmArgs);
+	if (typeof afterFromAI !== 'string') return afterFromAI;
+	return resolveJsonRefsInString(afterFromAI, llmArgs);
 }
 
 function resolveFromAIInString(str: string, llmArgs: Record<string, unknown>): unknown {
@@ -70,6 +77,65 @@ function resolveFromAIInString(str: string, llmArgs: Record<string, unknown>): u
 			return match;
 		}
 	});
+}
+
+// Single full-string expression like `={{ $json.foo.bar }}`. Captures the
+// dotted path after `$json`. Bracket access and JS expressions are out of
+// scope here — this resolver is for display only, not for actual node
+// execution.
+const FULL_JSON_REF_PATTERN = /^=\s*\{\{\s*\$json((?:\s*\.\s*[a-zA-Z_$][\w$]*)+)\s*\}\}\s*$/;
+const INLINE_JSON_REF_PATTERN = /\{\{\s*\$json((?:\s*\.\s*[a-zA-Z_$][\w$]*)+)\s*\}\}/g;
+
+function resolveJsonRefsInString(str: string, llmArgs: Record<string, unknown>): unknown {
+	if (!str.startsWith('=') || !str.includes('$json')) return str;
+
+	const fullMatch = str.match(FULL_JSON_REF_PATTERN);
+	if (fullMatch) {
+		const resolved = lookupJsonPath(llmArgs, fullMatch[1]);
+		return resolved === undefined ? str : resolved;
+	}
+
+	let replaced = false;
+	const out = str.replace(INLINE_JSON_REF_PATTERN, (match, path: string) => {
+		const resolved = lookupJsonPath(llmArgs, path);
+		if (resolved === undefined) return match;
+		replaced = true;
+		if (typeof resolved === 'object') return JSON.stringify(resolved);
+		return String(resolved);
+	});
+	return replaced ? out : str;
+}
+
+function lookupJsonPath(root: Record<string, unknown>, dottedPath: string): unknown {
+	const segments = dottedPath
+		.split('.')
+		.map((s) => s.trim())
+		.filter((s) => s.length > 0);
+	let cur: unknown = root;
+	for (const seg of segments) {
+		if (cur === null || cur === undefined) return undefined;
+		if (typeof cur !== 'object') return undefined;
+		cur = (cur as Record<string, unknown>)[seg];
+	}
+	return cur;
+}
+
+/**
+ * Tool errors arrive on the `tool-result` chunk as raw `Error` instances
+ * (see `agent-runtime.ts` → `tool-result` write on `batch.errors`). Persisting
+ * those directly produces `"output": {}` because `Error.name`/`message`/`stack`
+ * are non-enumerable, so the timeline drops the diagnostic the UI needs. Wrap
+ * Errors and bare strings into an enumerable `{ error }` shape; pass through
+ * objects that already carry their own shape.
+ */
+function normaliseToolErrorOutput(output: unknown): unknown {
+	if (output instanceof Error) {
+		return { error: output.message || output.name || 'Tool execution failed' };
+	}
+	if (typeof output === 'string') {
+		return { error: output };
+	}
+	return output;
 }
 
 export interface RecordedUsage {
@@ -274,14 +340,15 @@ export class ExecutionRecorder {
 		this.toolCalls.push({ name, input, output: undefined });
 
 		const entry = this.registry.get(name);
-		// Resolve `$fromAI(...)` expressions in nodeParameters using the LLM's
-		// args so the timeline shows the values the node would have run with
-		// (e.g. the actual prompt text) rather than raw template strings.
+		// Resolve both `$fromAI(...)` placeholders and simple `={{ $json.x }}`
+		// references in nodeParameters using the LLM's args, so the timeline
+		// shows the values the node would have run with (e.g. the actual
+		// prompt text) rather than raw template strings.
 		const llmArgs =
 			input !== null && typeof input === 'object' ? (input as Record<string, unknown>) : {};
 		const resolvedNodeParameters =
 			entry?.nodeParameters !== undefined
-				? (resolveFromAIInValue(entry.nodeParameters, llmArgs) as Record<string, unknown>)
+				? (resolveTemplatesInValue(entry.nodeParameters, llmArgs) as Record<string, unknown>)
 				: undefined;
 		this.timeline.push({
 			type: 'tool-call',
@@ -319,13 +386,15 @@ export class ExecutionRecorder {
 		output: unknown,
 		isError: boolean,
 	): void {
+		const recordedOutput = isError ? normaliseToolErrorOutput(output) : output;
+
 		const pendingFlat = [...this.toolCalls]
 			.reverse()
 			.find((tc) => tc.name === name && tc.output === undefined);
 		if (pendingFlat) {
-			pendingFlat.output = output;
+			pendingFlat.output = recordedOutput;
 		} else {
-			this.toolCalls.push({ name, input: undefined, output });
+			this.toolCalls.push({ name, input: undefined, output: recordedOutput });
 		}
 
 		const pendingTimeline = [...this.timeline]
@@ -337,12 +406,12 @@ export class ExecutionRecorder {
 					e.endTime === 0,
 			);
 		if (pendingTimeline) {
-			pendingTimeline.output = output;
+			pendingTimeline.output = recordedOutput;
 			pendingTimeline.endTime = Date.now();
 			pendingTimeline.success = !isError;
 
-			if (pendingTimeline.kind === 'workflow' && isRecord(output)) {
-				const execId = output.executionId;
+			if (pendingTimeline.kind === 'workflow' && isRecord(recordedOutput)) {
+				const execId = recordedOutput.executionId;
 				if (typeof execId === 'string') {
 					pendingTimeline.workflowExecutionId = execId;
 				}
@@ -359,7 +428,7 @@ export class ExecutionRecorder {
 			name,
 			toolCallId,
 			input: undefined,
-			output,
+			output: recordedOutput,
 			startTime: now,
 			endTime: now,
 			success: !isError,
@@ -371,8 +440,8 @@ export class ExecutionRecorder {
 			nodeDisplayName: entry?.nodeDisplayName,
 			nodeParameters: entry?.nodeParameters,
 		};
-		if (synthesized.kind === 'workflow' && isRecord(output)) {
-			const execId = output.executionId;
+		if (synthesized.kind === 'workflow' && isRecord(recordedOutput)) {
+			const execId = recordedOutput.executionId;
 			if (typeof execId === 'string') {
 				synthesized.workflowExecutionId = execId;
 			}

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1356,6 +1356,7 @@
 	"agentSessions.timeline.memoryUpdated": "Memory updated",
 	"agentSessions.timeline.openForm": "Open form",
 	"agentSessions.timeline.workflowError": "Workflow call did not produce an execution",
+	"agentSessions.timeline.nodeError": "Tool experienced an error",
 	"agentSessions.timeline.filter": "Filter",
 	"agentSessions.timeline.clearFilter": "Clear",
 	"agentSessions.timeline.suspended": "Suspended",

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/SessionDetailPanel.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/SessionDetailPanel.spec.ts
@@ -156,6 +156,61 @@ describe('SessionDetailPanel — other kinds', () => {
 		expect(w.find('[data-test-id="tool-io-view"]').exists()).toBe(true);
 	});
 
+	it('shows the error callout with the output message when a node tool call fails', () => {
+		const w = mountIt({
+			kind: 'node',
+			executionId: 'e1',
+			timestamp: 0,
+			toolName: 'telegram-tool',
+			nodeType: 'n8n-nodes-base.telegramTool',
+			nodeTypeVersion: 1.2,
+			nodeDisplayName: 'Telegram',
+			toolInput: { chatId: '1' },
+			toolOutput: { error: 'Node does not have any credentials set' },
+			toolSuccess: false,
+		});
+		const callout = w.find('[data-test-id="node-error-callout"]');
+		expect(callout.exists()).toBe(true);
+		expect(callout.text()).toContain(
+			'Tool experienced an error: Node does not have any credentials set',
+		);
+	});
+
+	it('falls back to the prefix-only message when the failed node output has no error string', () => {
+		const w = mountIt({
+			kind: 'node',
+			executionId: 'e1',
+			timestamp: 0,
+			toolName: 'telegram-tool',
+			nodeType: 'n8n-nodes-base.telegramTool',
+			nodeTypeVersion: 1.2,
+			nodeDisplayName: 'Telegram',
+			toolInput: { chatId: '1' },
+			toolOutput: {},
+			toolSuccess: false,
+		});
+		const callout = w.find('[data-test-id="node-error-callout"]');
+		expect(callout.exists()).toBe(true);
+		expect(callout.text()).toContain('Tool experienced an error');
+		expect(callout.text()).not.toContain(':');
+	});
+
+	it('does not show the error callout when the node tool call succeeded', () => {
+		const w = mountIt({
+			kind: 'node',
+			executionId: 'e1',
+			timestamp: 0,
+			toolName: 'http-tool',
+			nodeType: 'n8n-nodes-base.httpRequest',
+			nodeTypeVersion: 4.2,
+			nodeDisplayName: 'HTTP Request',
+			toolInput: { url: 'https://x' },
+			toolOutput: { status: 200 },
+			toolSuccess: true,
+		});
+		expect(w.find('[data-test-id="node-error-callout"]').exists()).toBe(false);
+	});
+
 	it('renders markdown for user messages', () => {
 		const w = mountIt({ kind: 'user', executionId: 'e1', timestamp: 0, content: 'hi' });
 		expect(w.find('[data-test-id="markdown"]').exists()).toBe(true);

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionDetailPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionDetailPanel.vue
@@ -325,9 +325,8 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 							:name="(item.nodeDisplayName ?? formatToolNameForDisplay(item.toolName)) || 'node'"
 							:input="item.toolInput"
 							:output="item.toolOutput"
-							:node-type="item.nodeType"
-							:node-type-version="item.nodeTypeVersion"
 							:node-parameters="item.nodeParameters"
+							:success="item.toolSuccess"
 						/>
 					</template>
 

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionDetailPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionDetailPanel.vue
@@ -5,6 +5,7 @@ import { useI18n } from '@n8n/i18n';
 import VueMarkdown from 'vue-markdown-render';
 import {
 	N8nButton,
+	N8nCallout,
 	N8nIconButton,
 	N8nText,
 	N8nCard,
@@ -148,6 +149,18 @@ const headerIcon = computed((): IconName => {
 	if (item.kind === 'user') return 'user';
 	if (item.kind === 'agent') return 'bot';
 	return 'clock';
+});
+
+const nodeErrorMessage = computed((): string => {
+	const item = props.item;
+	if (!item || item.kind !== 'node' || item.toolSuccess !== false) return '';
+	const prefix = i18n.baseText('agentSessions.timeline.nodeError');
+	const output = item.toolOutput;
+	if (output && typeof output === 'object' && 'error' in output) {
+		const err = (output as { error: unknown }).error;
+		if (typeof err === 'string' && err.length > 0) return `${prefix}: ${err}`;
+	}
+	return prefix;
 });
 
 const workflowFormOutput = computed((): { formUrl: string; message: string } | null => {
@@ -321,6 +334,9 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 					</template>
 
 					<template v-else-if="item.kind === 'node'">
+						<N8nCallout v-if="nodeErrorMessage" theme="danger" data-test-id="node-error-callout">
+							{{ nodeErrorMessage }}
+						</N8nCallout>
 						<ToolIoView
 							:name="(item.nodeDisplayName ?? formatToolNameForDisplay(item.toolName)) || 'node'"
 							:input="item.toolInput"

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineTable.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineTable.vue
@@ -267,6 +267,7 @@ watch(
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	width: 100%;
 	height: var(--height--xl);
 	padding: var(--spacing--2xs) var(--spacing--sm);
 	font-size: var(--font-size--2xs);

--- a/packages/frontend/editor-ui/src/features/agents/components/ToolIoView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/ToolIoView.vue
@@ -25,21 +25,28 @@ import type { WorkflowObjectAccessors } from '@/app/types/workflow';
  * workflows store with the synthesized execution, and tears it all down on
  * unmount.
  */
-const props = defineProps<{
-	name: string;
-	input: unknown;
-	output: unknown;
-	nodeType?: string;
-	nodeTypeVersion?: number;
-	/**
-	 * Configured node parameters from the agent's JSON config (channel,
-	 * operation, `$fromAI(...)` templates, etc.). Set on the synthesised tool
-	 * node so the IO viewer can render the actual node config — without this
-	 * the synthetic execution shows an empty parameters block, which makes a
-	 * failed node call read as "input == output".
-	 */
-	nodeParameters?: Record<string, unknown>;
-}>();
+const props = withDefaults(
+	defineProps<{
+		name: string;
+		input: unknown;
+		output: unknown;
+		/**
+		 * Configured node parameters from the agent's JSON config (channel,
+		 * operation, `$fromAI(...)` templates, etc.). Set on the synthesised tool
+		 * node so the IO viewer can render the actual node config — without this
+		 * the synthetic execution shows an empty parameters block, which makes a
+		 * failed node call read as "input == output".
+		 */
+		nodeParameters?: Record<string, unknown>;
+		/**
+		 * Whether the underlying tool call succeeded. Drives the synthesised
+		 * execution status so RunData can show error styling for a failed call
+		 * rather than rendering as if the call had completed cleanly.
+		 */
+		success?: boolean;
+	}>(),
+	{ success: true },
+);
 
 const i18n = useI18n();
 const workflowsStore = useWorkflowsStore();
@@ -91,11 +98,23 @@ const synthExecution = computed<IExecutionResponse>(() => {
 		position: [0, 0],
 		parameters: {},
 	};
+	// The synth tool node deliberately uses `set` (a plain main-IO node) rather
+	// than the real tool variant (`...telegramTool` etc.). Two reasons:
+	//   1. `RunData` derives its `connectionType` from the synth node's
+	//      *outputs* (see `RunData.vue:init`). Tool variants expose `AiTool`
+	//      outputs, so it would look for data under `inputOverride.AiTool`
+	//      while we always populate `inputOverride.main` — leaving both
+	//      panes empty.
+	//   2. `nodeViewUtils.getGenericHints` fires a "No parameters set up by AI"
+	//      hint whenever the node type contains "tool" and the stringified
+	//      parameters lack `$fromAI`. After we resolve `$fromAI` placeholders
+	//      into their LLM values, that substring is gone, so the hint always
+	//      fires falsely. Stripping the tool-variant type sidesteps it.
 	const toolNode: INodeUi = {
 		id: props.name,
 		name: props.name,
-		type: props.nodeType ?? 'n8n-nodes-base.set',
-		typeVersion: props.nodeTypeVersion ?? 1,
+		type: 'n8n-nodes-base.set',
+		typeVersion: 1,
 		position: [220, 0],
 		// `nodeParameters` is typed loosely on the wire (Record<string, unknown>)
 		// because it round-trips through JSON storage, but at this point it
@@ -142,7 +161,7 @@ const synthExecution = computed<IExecutionResponse>(() => {
 				startTime: 0,
 				executionIndex: 0,
 				executionTime: 0,
-				executionStatus: 'success',
+				executionStatus: props.success ? 'success' : 'error',
 				source: [{ previousNode: INPUT_NODE_NAME, previousNodeOutput: 0, previousNodeRun: 0 }],
 				data: { main: [outputItems] },
 				// `RunData` reads the input pane from `inputOverride` (see


### PR DESCRIPTION
## Summary

Prior to this PR the input/output of tool nodes was not always presented correctly if an error occurred in the tool.

The persisted timeline lost the error message (TypeORM JSON-serializing a raw `Error` instance produced `{}`), the input pane rendered empty because the recorder didn't resolve `$fromAI(...)` or `={{$json.x}}` templates, the output pane was identical to input because of a connection-type mismatch on the synthetic tool node, and a misleading "No parameters set up by AI" hint appeared on every node tool call. Even after fixing the underlying data, the UI gave no visible signal that a tool call had failed.

This PR fixes the data path end-to-end and adds an explicit failure callout in the session detail view.

Screenshot:
<img width="691" height="736" alt="image" src="https://github.com/user-attachments/assets/2fafb427-0164-49e2-8b8e-98096f698f96" />

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
