### PR TITLE
feat(core): Add agent execution count telemetry (no-changelog)

### DIFF
--- a/packages/@n8n/agents/src/index.ts
+++ b/packages/@n8n/agents/src/index.ts
@@ -38,6 +38,7 @@ export type {
 	McpVerifyResult,
 	ModelConfig,
 	ExecutionOptions,
+	AgentExecutionCounter,
 	PersistedExecutionOptions,
 	BuiltTelemetry,
 	AttributeValue,

--- a/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
@@ -101,6 +101,14 @@ function makeErrorStream(error: Error) {
 	});
 }
 
+function makeExecutionCounter() {
+	return {
+		incrementMessageCount: jest.fn(),
+		incrementToolCallCount: jest.fn(),
+		incrementTokenCount: jest.fn(),
+	};
+}
+
 /** Collect all chunks from a ReadableStream. */
 async function collectChunks(stream: ReadableStream<unknown>): Promise<StreamChunk[]> {
 	const chunks: StreamChunk[] = [];
@@ -198,6 +206,90 @@ function makeInterruptibleTool(): BuiltTool {
 		},
 	};
 }
+
+// ---------------------------------------------------------------------------
+// execution counters
+// ---------------------------------------------------------------------------
+
+describe('AgentRuntime — execution counters', () => {
+	beforeEach(() => {
+		generateText.mockReset();
+		streamText.mockReset();
+	});
+
+	it('counts one fresh generate turn and token usage', async () => {
+		generateText.mockResolvedValue(makeGenerateSuccess());
+		const counter = makeExecutionCounter();
+
+		const { runtime } = createRuntime();
+		await runtime.generate('hi', { executionCounter: counter });
+
+		expect(counter.incrementMessageCount).toHaveBeenCalledTimes(1);
+		expect(counter.incrementToolCallCount).not.toHaveBeenCalled();
+		expect(counter.incrementTokenCount).toHaveBeenCalledWith(15);
+	});
+
+	it('counts one fresh stream turn and streamed token usage', async () => {
+		streamText.mockReturnValue(makeStreamSuccess());
+		const counter = makeExecutionCounter();
+
+		const { runtime } = createRuntime();
+		const result = await runtime.stream('hi', { executionCounter: counter });
+		await collectChunks(result.stream);
+
+		expect(counter.incrementMessageCount).toHaveBeenCalledTimes(1);
+		expect(counter.incrementToolCallCount).not.toHaveBeenCalled();
+		expect(counter.incrementTokenCount).toHaveBeenCalledWith(15);
+	});
+
+	it('counts provider-executed tool calls when surfaced by the model', async () => {
+		generateText
+			.mockResolvedValueOnce({
+				...makeGenerateWithToolCall('tc-provider', 'openai.web_search', { query: 'n8n' }),
+				toolCalls: [
+					{
+						toolCallId: 'tc-provider',
+						toolName: 'openai.web_search',
+						input: { query: 'n8n' },
+						providerExecuted: true,
+					},
+				],
+			})
+			.mockResolvedValueOnce(makeGenerateSuccess('Done'));
+		const counter = makeExecutionCounter();
+
+		const { runtime } = createRuntime();
+		await runtime.generate('search', { executionCounter: counter });
+
+		expect(counter.incrementToolCallCount).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not count a resumed suspended tool call as a new tool invocation', async () => {
+		const suspendTool = makeInterruptibleTool();
+		const counter = makeExecutionCounter();
+		const { runtime } = createRuntimeWithTools([suspendTool], 1);
+
+		generateText.mockResolvedValueOnce(
+			makeGenerateWithToolCalls([
+				{ toolCallId: 'tc-1', toolName: 'approve', args: { question: 'continue?' } },
+			]),
+		);
+
+		const first = await runtime.generate('needs approval', { executionCounter: counter });
+		const { runId, toolCallId } = first.pendingSuspend![0];
+
+		generateText.mockResolvedValueOnce(makeGenerateSuccess('approved'));
+		await runtime.resume(
+			'generate',
+			{ approved: true },
+			{ runId, toolCallId, executionCounter: counter },
+		);
+
+		expect(counter.incrementMessageCount).toHaveBeenCalledTimes(1);
+		expect(counter.incrementToolCallCount).toHaveBeenCalledTimes(1);
+		expect(counter.incrementTokenCount).toHaveBeenCalledTimes(2);
+	});
+});
 
 // ---------------------------------------------------------------------------
 // generate() — graceful error contract

--- a/packages/@n8n/agents/src/runtime/agent-runtime.ts
+++ b/packages/@n8n/agents/src/runtime/agent-runtime.ts
@@ -6,6 +6,7 @@ import { zodToJsonSchema, type JsonSchema7Type } from 'zod-to-json-schema';
 import { computeCost, getModelCost, type ModelCost } from '../sdk/catalog';
 import { isLlmMessage } from '../sdk/message';
 import type {
+	AgentExecutionCounter,
 	AgentRunState,
 	AnthropicThinkingConfig,
 	AttributeValue,
@@ -277,6 +278,13 @@ interface ToolBatchContext {
 	list: AgentMessageList;
 	runId: string;
 	telemetry?: BuiltTelemetry;
+	executionCounter?: AgentExecutionCounter;
+}
+
+interface RawTokenUsage {
+	inputTokens?: number | undefined;
+	outputTokens?: number | undefined;
+	totalTokens?: number | undefined;
 }
 
 /**
@@ -700,6 +708,7 @@ export class AgentRuntime {
 		this.eventBus.emit({ type: AgentEvent.AgentStart });
 		await this.ensureModelCost();
 		const normalizedInput = normalizeInput(input);
+		this.incrementMessageCount(options?.executionCounter);
 		return await this.buildMessageList(normalizedInput, options);
 	}
 
@@ -800,6 +809,34 @@ export class AgentRuntime {
 		};
 	}
 
+	private recordExecutionCounter(fn: () => void): void {
+		try {
+			fn();
+		} catch {
+			// Aggregate counters are best-effort and must never affect agent execution.
+		}
+	}
+
+	private incrementMessageCount(counter: AgentExecutionCounter | undefined): void {
+		if (!counter) return;
+		this.recordExecutionCounter(() => counter.incrementMessageCount());
+	}
+
+	private incrementToolCallCount(counter: AgentExecutionCounter | undefined): void {
+		if (!counter) return;
+		this.recordExecutionCounter(() => counter.incrementToolCallCount());
+	}
+
+	private incrementTokenCount(
+		counter: AgentExecutionCounter | undefined,
+		usage: RawTokenUsage | undefined,
+	): void {
+		if (!counter || !usage) return;
+		const tokenCount = usage.totalTokens ?? (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0);
+		if (tokenCount <= 0) return;
+		this.recordExecutionCounter(() => counter.incrementTokenCount(tokenCount));
+	}
+
 	private async withTelemetryRootSpan<T>(
 		operation: 'generate' | 'stream',
 		options: ExecutionOptions | undefined,
@@ -894,7 +931,13 @@ export class AgentRuntime {
 
 		// Resolve pending tool calls from a resumed run before the first LLM call.
 		const runTelemetry = this.resolveTelemetry(options);
-		const toolCtx: ToolBatchContext = { toolMap, list, runId, telemetry: runTelemetry };
+		const toolCtx: ToolBatchContext = {
+			toolMap,
+			list,
+			runId,
+			telemetry: runTelemetry,
+			executionCounter: options?.executionCounter,
+		};
 
 		if (pendingResume) {
 			const batch = await this.iteratePendingToolCallsConcurrent({ ...toolCtx, pendingResume });
@@ -954,6 +997,7 @@ export class AgentRuntime {
 			lastFinishReason = fromAiFinishReason(aiFinishReason);
 
 			totalUsage = accumulateUsage(totalUsage, result.usage);
+			this.incrementTokenCount(options?.executionCounter, result.usage);
 
 			const responseMessages = result.response.messages;
 			const newMessages = fromAiMessages(responseMessages);
@@ -1133,7 +1177,13 @@ export class AgentRuntime {
 
 		// Resolve pending tool calls from a resumed run before the first LLM call.
 		const runTelemetry = this.resolveTelemetry(options);
-		const toolCtx: ToolBatchContext = { toolMap, list, runId, telemetry: runTelemetry };
+		const toolCtx: ToolBatchContext = {
+			toolMap,
+			list,
+			runId,
+			telemetry: runTelemetry,
+			executionCounter: options?.executionCounter,
+		};
 		if (pendingResume) {
 			try {
 				const batch = await this.iteratePendingToolCallsConcurrent({
@@ -1244,6 +1294,7 @@ export class AgentRuntime {
 			lastFinishReason = fromAiFinishReason(aiFinishReason);
 
 			totalUsage = accumulateUsage(totalUsage, usage);
+			this.incrementTokenCount(options?.executionCounter, usage);
 
 			const responseMessages = response.messages;
 			const newMessages = fromAiMessages(responseMessages);
@@ -1523,8 +1574,12 @@ export class AgentRuntime {
 			}>;
 		},
 	): Promise<ToolCallBatchResult> {
-		const { toolCalls, toolMap, list, runId, telemetry: resolvedTelemetry } = ctx;
+		const { toolCalls, toolMap, list, runId, telemetry: resolvedTelemetry, executionCounter } = ctx;
 		const executableCalls = toolCalls.filter((tc) => !tc.providerExecuted);
+		const providerExecutedCount = toolCalls.length - executableCalls.length;
+		for (let i = 0; i < providerExecutedCount; i++) {
+			this.incrementToolCallCount(executionCounter);
+		}
 		const executableCallsById = new Map(executableCalls.map((tc) => [tc.toolCallId, tc]));
 		const unexecutedIds = new Set(executableCalls.map((tc) => tc.toolCallId));
 		const batchSize = this.concurrency;
@@ -1552,6 +1607,8 @@ export class AgentRuntime {
 							list,
 							undefined,
 							resolvedTelemetry,
+							executionCounter,
+							true,
 						),
 				),
 			);
@@ -1645,7 +1702,14 @@ export class AgentRuntime {
 	private async iteratePendingToolCallsConcurrent(
 		ctx: ToolBatchContext & { pendingResume: PendingResume },
 	): Promise<ToolCallBatchResult> {
-		const { pendingResume, toolMap, list, runId, telemetry: resolvedTelemetry } = ctx;
+		const {
+			pendingResume,
+			toolMap,
+			list,
+			runId,
+			telemetry: resolvedTelemetry,
+			executionCounter,
+		} = ctx;
 		const resumedId = pendingResume.resumeToolCallId;
 		const resumedEntry = pendingResume.pendingToolCalls[resumedId];
 		if (!resumedEntry) {
@@ -1667,6 +1731,8 @@ export class AgentRuntime {
 			list,
 			pendingResume.resumeData,
 			resolvedTelemetry,
+			executionCounter,
+			false,
 		);
 
 		if (processResult.outcome === 'suspended') {
@@ -1741,6 +1807,7 @@ export class AgentRuntime {
 				list,
 				runId,
 				telemetry: resolvedTelemetry,
+				executionCounter,
 			});
 			results.push(...batch.results);
 			suspensions.push(...batch.suspensions);
@@ -1769,6 +1836,8 @@ export class AgentRuntime {
 		list: AgentMessageList,
 		resumeData?: unknown,
 		resolvedTelemetry?: BuiltTelemetry,
+		executionCounter?: AgentExecutionCounter,
+		countToolCall = true,
 	): Promise<ToolCallOutcome> {
 		const builtTool = toolMap.get(toolName);
 
@@ -1821,6 +1890,10 @@ export class AgentRuntime {
 				isError: settledBlock.state === 'rejected',
 			});
 			return { outcome: 'noop' };
+		}
+
+		if (countToolCall) {
+			this.incrementToolCallCount(executionCounter);
 		}
 
 		if (builtTool.inputSchema) {

--- a/packages/@n8n/agents/src/types/index.ts
+++ b/packages/@n8n/agents/src/types/index.ts
@@ -36,6 +36,7 @@ export type {
 	ModelConfig,
 	RunOptions,
 	ExecutionOptions,
+	AgentExecutionCounter,
 	PersistedExecutionOptions,
 	ResumeOptions,
 	GenerateResult,

--- a/packages/@n8n/agents/src/types/sdk/agent.ts
+++ b/packages/@n8n/agents/src/types/sdk/agent.ts
@@ -119,12 +119,20 @@ export interface RunOptions {
 	persistence?: AgentPersistenceOptions;
 }
 
+export interface AgentExecutionCounter {
+	incrementMessageCount(): void;
+	incrementToolCallCount(): void;
+	incrementTokenCount(tokenCount: number): void;
+}
+
 export interface ExecutionOptions {
 	maxIterations?: number;
 	abortSignal?: AbortSignal;
 	providerOptions?: ProviderOptions;
 	/** Inherited telemetry from a parent agent. Used internally by asTool(). */
 	telemetry?: BuiltTelemetry;
+	/** Inherited execution counter from the host runtime. Used for aggregate heartbeat telemetry. */
+	executionCounter?: AgentExecutionCounter;
 }
 
 export interface PersistedExecutionOptions {

--- a/packages/cli/src/interfaces.ts
+++ b/packages/cli/src/interfaces.ts
@@ -187,6 +187,13 @@ export interface IExecutionTrackProperties extends ITelemetryTrackProperties {
 	used_dynamic_credentials?: boolean;
 }
 
+export interface IAgentExecutionTrackProperties extends ITelemetryTrackProperties {
+	agent_id: string;
+	message_count?: number;
+	token_count?: number;
+	tool_call_count?: number;
+}
+
 // ----------------------------------
 //               license
 // ----------------------------------

--- a/packages/cli/src/modules/agents/__tests__/agents-service-reconstruct-gating.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-service-reconstruct-gating.test.ts
@@ -15,6 +15,7 @@ import { mock } from 'jest-mock-extended';
 import type { ActiveExecutions } from '@/active-executions';
 import type { EphemeralNodeExecutor } from '@/node-execution';
 import type { UrlService } from '@/services/url.service';
+import type { Telemetry } from '@/telemetry';
 import type { WorkflowRunner } from '@/workflow-runner';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
@@ -69,6 +70,7 @@ function makeService(
 		mock(),
 		{ modules } as unknown as AgentsConfig,
 		mock(),
+		mock<Telemetry>(),
 	);
 }
 

--- a/packages/cli/src/modules/agents/__tests__/agents-service-sync.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-service-sync.test.ts
@@ -12,6 +12,7 @@ import { mock } from 'jest-mock-extended';
 import type { ActiveExecutions } from '@/active-executions';
 import type { EphemeralNodeExecutor } from '@/node-execution';
 import type { UrlService } from '@/services/url.service';
+import type { Telemetry } from '@/telemetry';
 import type { WorkflowRunner } from '@/workflow-runner';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
@@ -78,6 +79,7 @@ describe('AgentsService — updateName / updateDescription schema sync', () => {
 			mock(),
 			{ modules: [] } as unknown as AgentsConfig,
 			mock(),
+			mock<Telemetry>(),
 		);
 	});
 

--- a/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
@@ -6,6 +6,7 @@ import { mockLogger } from '@n8n/backend-test-utils';
 import { mock } from 'jest-mock-extended';
 
 import type { Publisher } from '@/scaling/pubsub/publisher.service';
+import type { Telemetry } from '@/telemetry';
 
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
@@ -119,6 +120,7 @@ describe('AgentsService', () => {
 			publisher,
 			agentsConfig,
 			globalConfig,
+			mock<Telemetry>(),
 		);
 	});
 
@@ -1142,10 +1144,16 @@ describe('AgentsService', () => {
 			expect(mockAgentInstance.resume).toHaveBeenCalledWith(
 				'stream',
 				{ value: 'yes' },
-				{ runId, toolCallId },
+				expect.objectContaining({
+					runId,
+					toolCallId,
+					executionCounter: expect.any(Object),
+				}),
 			);
 			// The n8n publisher ID must not appear in the resume args
 			const resumeArgs = mockAgentInstance.resume.mock.calls[0];
+			const resumeOptions = resumeArgs[2] as Record<string, unknown>;
+			expect(resumeOptions).not.toHaveProperty('resourceId');
 			expect(JSON.stringify(resumeArgs)).not.toContain(n8nPublisherId);
 		});
 	});

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -22,13 +22,13 @@ import { Time } from '@n8n/constants';
 import {
 	CredentialsRepository,
 	ExecutionRepository,
+	In,
 	ProjectRelationRepository,
 	UserRepository,
 	WorkflowRepository,
 } from '@n8n/db';
 import { OnPubSubEvent } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
-import { In } from '@n8n/typeorm';
 import {
 	deepCopy,
 	OperationalError,
@@ -47,6 +47,7 @@ import { EphemeralNodeExecutor } from '@/node-execution';
 import type { PubSubCommandMap } from '@/scaling/pubsub/pubsub.event-map';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
 import { UrlService } from '@/services/url.service';
+import { Telemetry } from '@/telemetry';
 import { TtlMap } from '@/utils/ttl-map';
 import { WorkflowRunner } from '@/workflow-runner';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
@@ -260,10 +261,22 @@ export class AgentsService {
 		private readonly publisher: Publisher,
 		private readonly agentsConfig: AgentsConfig,
 		private readonly globalConfig: GlobalConfig,
+		private readonly telemetry: Telemetry,
 	) {}
 
 	private isNodeToolsModuleEnabled(): boolean {
 		return this.agentsConfig.modules.includes('node-tools-searcher');
+	}
+
+	private createAgentExecutionCounter(agentId: string): agents.AgentExecutionCounter {
+		return {
+			incrementMessageCount: () =>
+				this.telemetry.trackAgentExecution({ agent_id: agentId, message_count: 1 }),
+			incrementTokenCount: (tokenCount) =>
+				this.telemetry.trackAgentExecution({ agent_id: agentId, token_count: tokenCount }),
+			incrementToolCallCount: () =>
+				this.telemetry.trackAgentExecution({ agent_id: agentId, tool_call_count: 1 }),
+		};
 	}
 
 	private shouldAttachNodeTools(config: AgentJsonConfig['config']): boolean {
@@ -800,6 +813,7 @@ export class AgentsService {
 		const resultStream = await agentInstance.resume('stream', resumeData, {
 			runId,
 			toolCallId,
+			executionCounter: this.createAgentExecutionCounter(agentId),
 		});
 
 		const reader = resultStream.stream.getReader();
@@ -1018,6 +1032,7 @@ export class AgentsService {
 
 		const resultStream = await agentInstance.stream(message, {
 			persistence: { threadId, resourceId },
+			executionCounter: this.createAgentExecutionCounter(agentId),
 		});
 
 		const reader = resultStream.stream.getReader();
@@ -1144,6 +1159,7 @@ export class AgentsService {
 
 		const resultStream = await agentInstance.stream(message, {
 			persistence: { resourceId: executionId, threadId },
+			executionCounter: this.createAgentExecutionCounter(agentId),
 		});
 
 		const reader = resultStream.stream.getReader();

--- a/packages/cli/src/telemetry/__tests__/telemetry.test.ts
+++ b/packages/cli/src/telemetry/__tests__/telemetry.test.ts
@@ -348,6 +348,56 @@ describe('Telemetry', () => {
 		});
 	});
 
+	describe('trackAgentExecution', () => {
+		test('should aggregate agent execution counters by agent ID', () => {
+			telemetry.trackAgentExecution({ agent_id: 'agent-1', message_count: 1 });
+			telemetry.trackAgentExecution({ agent_id: 'agent-1', token_count: 15 });
+			telemetry.trackAgentExecution({ agent_id: 'agent-1', tool_call_count: 2 });
+			telemetry.trackAgentExecution({ agent_id: 'agent-2', message_count: 1 });
+
+			expect(spyTrack).toHaveBeenCalledTimes(0);
+			expect(telemetry.getAgentExecutionCountsBuffer()).toEqual({
+				'agent-1': {
+					message_count: 1,
+					token_count: 15,
+					tool_call_count: 2,
+				},
+				'agent-2': {
+					message_count: 1,
+					token_count: 0,
+					tool_call_count: 0,
+				},
+			});
+		});
+
+		test('should flush agent execution counters and reset the buffer', () => {
+			telemetry.trackAgentExecution({ agent_id: 'agent-1', message_count: 1 });
+			telemetry.trackAgentExecution({ agent_id: 'agent-1', token_count: 15 });
+			telemetry.trackAgentExecution({ agent_id: 'agent-1', tool_call_count: 2 });
+
+			// @ts-expect-error Calling private method
+			telemetry.flushAgentExecutionCounts();
+
+			expect(spyTrack).toHaveBeenCalledWith('Agent execution count', {
+				event_version: '1',
+				agent_id: 'agent-1',
+				message_count: 1,
+				token_count: 15,
+				tool_call_count: 2,
+			});
+			expect(telemetry.getAgentExecutionCountsBuffer()).toEqual({});
+		});
+
+		test('should not buffer when rudderStack is not initialized', () => {
+			// @ts-expect-error Assigning to private property
+			telemetry.rudderStack = undefined;
+
+			telemetry.trackAgentExecution({ agent_id: 'agent-1', message_count: 1 });
+
+			expect(telemetry.getAgentExecutionCountsBuffer()).toEqual({});
+		});
+	});
+
 	describe('trackApiInvocation', () => {
 		beforeEach(() => {
 			jest.setSystemTime(testDateTime);

--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -14,7 +14,7 @@ import { ErrorReporter, InstanceSettings } from 'n8n-core';
 import type { ITelemetryTrackProperties } from 'n8n-workflow';
 
 import { LOWEST_SHUTDOWN_PRIORITY, N8N_VERSION } from '@/constants';
-import type { IExecutionTrackProperties } from '@/interfaces';
+import type { IAgentExecutionTrackProperties, IExecutionTrackProperties } from '@/interfaces';
 import { License } from '@/license';
 import { PostHogClient } from '@/posthog';
 
@@ -64,6 +64,14 @@ interface IApiInvocationsBuffer {
 	[userId: string]: IApiInvocationsBufferEntry;
 }
 
+interface IAgentExecutionCountsBuffer {
+	[agentId: string]: {
+		message_count: number;
+		token_count: number;
+		tool_call_count: number;
+	};
+}
+
 @Service()
 export class Telemetry {
 	private rudderStack?: RudderStack;
@@ -73,6 +81,8 @@ export class Telemetry {
 	private executionCountsBuffer: IExecutionsBuffer = {};
 
 	private apiInvocationsBuffer: IApiInvocationsBuffer = {};
+
+	private agentExecutionCountsBuffer: IAgentExecutionCountsBuffer = {};
 
 	constructor(
 		private readonly logger: Logger,
@@ -176,28 +186,8 @@ export class Telemetry {
 			return;
 		}
 
-		const workflowIdsToReport = Object.keys(this.executionCountsBuffer).filter((workflowId) => {
-			const data = this.executionCountsBuffer[workflowId];
-			const sum =
-				(data.manual_error?.count ?? 0) +
-				(data.manual_success?.count ?? 0) +
-				(data.prod_error?.count ?? 0) +
-				(data.prod_success?.count ?? 0) +
-				(data.manual_crashed?.count ?? 0) +
-				(data.prod_crashed?.count ?? 0);
-
-			return sum > 0;
-		});
-
-		for (const workflowId of workflowIdsToReport) {
-			this.track('Workflow execution count', {
-				event_version: '2',
-				workflow_id: workflowId,
-				...this.executionCountsBuffer[workflowId],
-			});
-		}
-
-		this.executionCountsBuffer = {};
+		this.flushWorkflowExecutionCounts();
+		this.flushAgentExecutionCounts();
 
 		// Flush API invocation counts
 		for (const userId of Object.keys(this.apiInvocationsBuffer)) {
@@ -232,6 +222,48 @@ export class Telemetry {
 		};
 
 		this.track('pulse', pulsePacket);
+	}
+
+	private flushWorkflowExecutionCounts() {
+		const workflowIdsToReport = Object.keys(this.executionCountsBuffer).filter((workflowId) => {
+			const data = this.executionCountsBuffer[workflowId];
+			const sum =
+				(data.manual_error?.count ?? 0) +
+				(data.manual_success?.count ?? 0) +
+				(data.prod_error?.count ?? 0) +
+				(data.prod_success?.count ?? 0) +
+				(data.manual_crashed?.count ?? 0) +
+				(data.prod_crashed?.count ?? 0);
+
+			return sum > 0;
+		});
+
+		for (const workflowId of workflowIdsToReport) {
+			this.track('Workflow execution count', {
+				event_version: '2',
+				workflow_id: workflowId,
+				...this.executionCountsBuffer[workflowId],
+			});
+		}
+
+		this.executionCountsBuffer = {};
+	}
+
+	private flushAgentExecutionCounts() {
+		const agentIdsToReport = Object.keys(this.agentExecutionCountsBuffer).filter((agentId) => {
+			const data = this.agentExecutionCountsBuffer[agentId];
+			return data.message_count + data.token_count + data.tool_call_count > 0;
+		});
+
+		for (const agentId of agentIdsToReport) {
+			this.track('Agent execution count', {
+				event_version: '1',
+				agent_id: agentId,
+				...this.agentExecutionCountsBuffer[agentId],
+			});
+		}
+
+		this.agentExecutionCountsBuffer = {};
 	}
 
 	trackWorkflowExecution(properties: IExecutionTrackProperties) {
@@ -275,6 +307,23 @@ export class Telemetry {
 				this.track('Workflow execution errored', properties);
 			}
 		}
+	}
+
+	trackAgentExecution(properties: IAgentExecutionTrackProperties) {
+		if (!this.rudderStack) return;
+
+		const { agent_id, message_count = 0, token_count = 0, tool_call_count = 0 } = properties;
+
+		this.agentExecutionCountsBuffer[agent_id] = this.agentExecutionCountsBuffer[agent_id] ?? {
+			message_count: 0,
+			token_count: 0,
+			tool_call_count: 0,
+		};
+
+		const agentExecutionCounts = this.agentExecutionCountsBuffer[agent_id];
+		agentExecutionCounts.message_count += message_count;
+		agentExecutionCounts.token_count += token_count;
+		agentExecutionCounts.tool_call_count += tool_call_count;
 	}
 
 	trackApiInvocation(properties: IApiInvocationProperties) {
@@ -412,5 +461,9 @@ export class Telemetry {
 
 	getApiInvocationsBuffer(): IApiInvocationsBuffer {
 		return this.apiInvocationsBuffer;
+	}
+
+	getAgentExecutionCountsBuffer(): IAgentExecutionCountsBuffer {
+		return this.agentExecutionCountsBuffer;
 	}
 }


### PR DESCRIPTION
## Summary

This adds periodic agent execution heartbeat telemetry, mirroring the existing workflow execution count pattern. The new telemetry buffers per-agent counters in memory and flushes them during the existing 6-hour telemetry pulse as Agent execution count.

The implementation adds an AgentExecutionCounter execution option to @n8n/agents, wires it through fresh agent runs and resumed runs, and records only the requested aggregate counters: message count, token count, and tool call count. Fresh generate() and stream() calls count one user turn, LLM responses contribute token totals, local tool executions count as tool calls, and provider-executed tool calls are counted when surfaced by the model. Resumed suspended tool calls do not count as new turns or duplicate tool invocations.

On the CLI side, AgentsService creates an agent_id-scoped counter for chat, resume, and workflow-triggered agent executions. Telemetry now maintains an in-memory agentExecutionCountsBuffer, flushes it alongside workflow execution counts, and emits payloads with event_version, agent_id, message_count, token_count, and tool_call_count.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
