### PR TITLE
feat(Bitbucket Trigger Node): Add OAuth2 authentication support

### DIFF
--- a/packages/cli/src/constants.ts
+++ b/packages/cli/src/constants.ts
@@ -112,6 +112,7 @@ export const GENERIC_OAUTH2_CREDENTIALS_WITH_EDITABLE_SCOPE = [
 	'wordpressOAuth2Api',
 	'figmaOAuth2Api',
 	'gumroadOAuth2Api',
+	'bitbucketOAuth2Api',
 ];
 
 export const ARTIFICIAL_TASK_DATA = {

--- a/packages/nodes-base/credentials/BitbucketOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/BitbucketOAuth2Api.credentials.ts
@@ -1,0 +1,87 @@
+import type { ICredentialType, INodeProperties } from 'n8n-workflow';
+
+const defaultScopes = [
+	'account',
+	'repository',
+	'repository:write',
+	'pullrequest',
+	'pullrequest:write',
+	'webhook',
+];
+
+export class BitbucketOAuth2Api implements ICredentialType {
+	name = 'bitbucketOAuth2Api';
+
+	extends = ['oAuth2Api'];
+
+	displayName = 'Bitbucket OAuth2 API';
+
+	documentationUrl = 'bitbucket';
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'Grant Type',
+			name: 'grantType',
+			type: 'hidden',
+			default: 'authorizationCode',
+		},
+		{
+			displayName: 'Authorization URL',
+			name: 'authUrl',
+			type: 'hidden',
+			default: 'https://bitbucket.org/site/oauth2/authorize',
+			required: true,
+		},
+		{
+			displayName: 'Access Token URL',
+			name: 'accessTokenUrl',
+			type: 'hidden',
+			default: 'https://bitbucket.org/site/oauth2/access_token',
+			required: true,
+		},
+		{
+			displayName: 'Authentication',
+			name: 'authentication',
+			type: 'hidden',
+			default: 'header',
+		},
+		{
+			displayName: 'Custom Scopes',
+			name: 'customScopes',
+			type: 'boolean',
+			default: false,
+			description: 'Define custom scopes',
+		},
+		{
+			displayName:
+				'The default scopes needed for the node to work are already set. If you change these the node may not function correctly.',
+			name: 'customScopesNotice',
+			type: 'notice',
+			default: '',
+			displayOptions: {
+				show: {
+					customScopes: [true],
+				},
+			},
+		},
+		{
+			displayName: 'Enabled Scopes',
+			name: 'enabledScopes',
+			type: 'string',
+			displayOptions: {
+				show: {
+					customScopes: [true],
+				},
+			},
+			default: defaultScopes.join(' '),
+			description: 'Scopes that should be enabled',
+		},
+		{
+			displayName: 'Scope',
+			name: 'scope',
+			type: 'hidden',
+			default:
+				'={{$self["customScopes"] ? $self["enabledScopes"] : "' + defaultScopes.join(' ') + '"}}',
+		},
+	];
+}

--- a/packages/nodes-base/credentials/test/BitbucketOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/BitbucketOAuth2Api.credentials.test.ts
@@ -1,0 +1,53 @@
+import { BitbucketOAuth2Api } from '../BitbucketOAuth2Api.credentials';
+
+describe('BitbucketOAuth2Api Credential', () => {
+	const credential = new BitbucketOAuth2Api();
+	const defaultScopes = 'account repository repository:write pullrequest pullrequest:write webhook';
+
+	it('should have correct credential metadata', () => {
+		expect(credential.name).toBe('bitbucketOAuth2Api');
+		expect(credential.extends).toEqual(['oAuth2Api']);
+
+		const authUrlProperty = credential.properties.find((p) => p.name === 'authUrl');
+		expect(authUrlProperty?.default).toBe('https://bitbucket.org/site/oauth2/authorize');
+
+		const accessTokenUrlProperty = credential.properties.find((p) => p.name === 'accessTokenUrl');
+		expect(accessTokenUrlProperty?.default).toBe('https://bitbucket.org/site/oauth2/access_token');
+	});
+
+	it('should use the authorization code grant', () => {
+		const grantTypeProperty = credential.properties.find((p) => p.name === 'grantType');
+		expect(grantTypeProperty?.type).toBe('hidden');
+		expect(grantTypeProperty?.default).toBe('authorizationCode');
+	});
+
+	it('should use header authentication', () => {
+		const authenticationProperty = credential.properties.find((p) => p.name === 'authentication');
+		expect(authenticationProperty?.type).toBe('hidden');
+		expect(authenticationProperty?.default).toBe('header');
+	});
+
+	it('should have custom scopes toggle defaulting to false', () => {
+		const customScopesProperty = credential.properties.find((p) => p.name === 'customScopes');
+		expect(customScopesProperty?.type).toBe('boolean');
+		expect(customScopesProperty?.default).toBe(false);
+	});
+
+	it('should have enabledScopes defaulting to the current default scope list', () => {
+		const enabledScopesProperty = credential.properties.find((p) => p.name === 'enabledScopes');
+		expect(enabledScopesProperty?.default).toBe(defaultScopes);
+	});
+
+	it('should only show enabledScopes when customScopes is true', () => {
+		const enabledScopesProperty = credential.properties.find((p) => p.name === 'enabledScopes');
+		expect(enabledScopesProperty?.displayOptions?.show?.customScopes).toEqual([true]);
+	});
+
+	it('should use enabledScopes when customScopes is true, otherwise fall back to defaults', () => {
+		const scopeProperty = credential.properties.find((p) => p.name === 'scope');
+		expect(scopeProperty?.type).toBe('hidden');
+		expect(scopeProperty?.default).toBe(
+			`={{$self["customScopes"] ? $self["enabledScopes"] : "${defaultScopes}"}}`,
+		);
+	});
+});

--- a/packages/nodes-base/nodes/Bitbucket/BitbucketTrigger.node.ts
+++ b/packages/nodes-base/nodes/Bitbucket/BitbucketTrigger.node.ts
@@ -50,6 +50,16 @@ export class BitbucketTrigger implements INodeType {
 					},
 				},
 			},
+			{
+				name: 'bitbucketOAuth2Api',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['oAuth2'],
+						'@version': [1.1],
+					},
+				},
+			},
 		],
 		webhooks: [
 			{
@@ -93,6 +103,10 @@ export class BitbucketTrigger implements INodeType {
 					{
 						name: 'Access Token',
 						value: 'accessToken',
+					},
+					{
+						name: 'OAuth2',
+						value: 'oAuth2',
 					},
 				],
 				default: 'accessToken',

--- a/packages/nodes-base/nodes/Bitbucket/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Bitbucket/GenericFunctions.ts
@@ -19,9 +19,12 @@ export async function bitbucketApiRequest(
 	uri?: string,
 ): Promise<any> {
 	try {
-		const authentication = this.getNodeParameter('authentication', 0) as 'password' | 'accessToken';
+		const authentication = this.getNodeParameter('authentication', 0) as
+			| 'password'
+			| 'accessToken'
+			| 'oAuth2';
 
-		if (authentication === 'accessToken') {
+		if (authentication === 'accessToken' || authentication === 'oAuth2') {
 			const httpRequestOptions: IHttpRequestOptions = {
 				method,
 				qs,
@@ -34,9 +37,12 @@ export async function bitbucketApiRequest(
 				delete httpRequestOptions.body;
 			}
 
+			const credentialType =
+				authentication === 'oAuth2' ? 'bitbucketOAuth2Api' : 'bitbucketAccessTokenApi';
+
 			return await this.helpers.httpRequestWithAuthentication.call(
 				this,
-				'bitbucketAccessTokenApi',
+				credentialType,
 				httpRequestOptions,
 			);
 		}

--- a/packages/nodes-base/nodes/Bitbucket/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Bitbucket/test/GenericFunctions.test.ts
@@ -152,6 +152,101 @@ describe('Bitbucket GenericFunctions', () => {
 			});
 		});
 
+		describe('with OAuth2 authentication', () => {
+			beforeEach(() => {
+				mockExecuteFunctions.getNodeParameter.mockReturnValue('oAuth2');
+				mockHookFunctions.getNodeParameter.mockReturnValue('oAuth2');
+				mockLoadOptionsFunctions.getNodeParameter.mockReturnValue('oAuth2');
+			});
+
+			it('should call httpRequestWithAuthentication with bitbucketOAuth2Api', async () => {
+				const mockResponse = { data: 'test response' };
+				mockExecuteFunctions.helpers.httpRequestWithAuthentication.mockResolvedValue(mockResponse);
+
+				const result = await bitbucketApiRequest.call(
+					mockExecuteFunctions,
+					'GET',
+					'/repositories',
+					{},
+					{},
+				);
+
+				expect(mockExecuteFunctions.helpers.httpRequestWithAuthentication).toHaveBeenCalledWith(
+					'bitbucketOAuth2Api',
+					{
+						method: 'GET',
+						qs: {},
+						url: 'https://api.bitbucket.org/2.0/repositories',
+						json: true,
+					},
+				);
+				expect(result).toEqual(mockResponse);
+			});
+
+			it('should handle custom URI with OAuth2', async () => {
+				const mockResponse = { data: 'test response' };
+				const customUri = 'https://custom.api.bitbucket.org/2.0/custom';
+				mockExecuteFunctions.helpers.httpRequestWithAuthentication.mockResolvedValue(mockResponse);
+
+				await bitbucketApiRequest.call(
+					mockExecuteFunctions,
+					'POST',
+					'/repositories',
+					{ name: 'test' },
+					{ page: 1 },
+					customUri,
+				);
+
+				expect(mockExecuteFunctions.helpers.httpRequestWithAuthentication).toHaveBeenCalledWith(
+					'bitbucketOAuth2Api',
+					{
+						method: 'POST',
+						qs: { page: 1 },
+						body: { name: 'test' },
+						url: customUri,
+						json: true,
+					},
+				);
+			});
+
+			it('should remove empty body with OAuth2', async () => {
+				const mockResponse = { data: 'test response' };
+				mockExecuteFunctions.helpers.httpRequestWithAuthentication.mockResolvedValue(mockResponse);
+
+				await bitbucketApiRequest.call(mockExecuteFunctions, 'GET', '/repositories');
+
+				const expectedOptions: IHttpRequestOptions = {
+					method: 'GET',
+					qs: {},
+					url: 'https://api.bitbucket.org/2.0/repositories',
+					json: true,
+				};
+
+				expect(mockExecuteFunctions.helpers.httpRequestWithAuthentication).toHaveBeenCalledWith(
+					'bitbucketOAuth2Api',
+					expectedOptions,
+				);
+			});
+
+			it('should work with hook functions using OAuth2', async () => {
+				const mockResponse = { values: [] };
+				mockHookFunctions.helpers.httpRequestWithAuthentication.mockResolvedValue(mockResponse);
+
+				const result = await bitbucketApiRequest.call(mockHookFunctions, 'GET', '/workspaces');
+
+				expect(mockHookFunctions.helpers.httpRequestWithAuthentication).toHaveBeenCalledWith(
+					'bitbucketOAuth2Api',
+					{
+						method: 'GET',
+						qs: {},
+						url: 'https://api.bitbucket.org/2.0/workspaces',
+						json: true,
+					},
+				);
+				expect(result).toEqual(mockResponse);
+			});
+		});
+
 		describe('with password authentication', () => {
 			beforeEach(() => {
 				mockExecuteFunctions.getNodeParameter.mockReturnValue('password');

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -54,6 +54,7 @@
       "dist/credentials/BeeminderOAuth2Api.credentials.js",
       "dist/credentials/BitbucketAccessTokenApi.credentials.js",
       "dist/credentials/BitbucketApi.credentials.js",
+      "dist/credentials/BitbucketOAuth2Api.credentials.js",
       "dist/credentials/BitlyApi.credentials.js",
       "dist/credentials/BitlyOAuth2Api.credentials.js",
       "dist/credentials/BitwardenApi.credentials.js",


### PR DESCRIPTION
## Summary

Adds `bitbucketOAuth2Api` as a third authentication option on the Bitbucket Trigger node (v1.1 only) using the standard Bitbucket Cloud OAuth 2.0 authorization-code flow. The credential supports custom scopes via the standard toggle, defaulting to `account repository repository:write pullrequest pullrequest:write webhook`. v1 of the trigger is untouched.

**How to test:**
1. Create a Bitbucket OAuth Consumer in your workspace settings with callback URL `<n8n base URL>/rest/oauth2-credential/callback` and the six default scopes.
2. In n8n, create a Bitbucket OAuth2 API credential, paste the Client ID/Secret, and complete the OAuth dance.
3. Add a Bitbucket Trigger node (v1.1), set Authentication = OAuth2, pick the credential, choose a workspace/repo, activate the workflow.
4. Trigger the chosen event (e.g. push to repo) and confirm the workflow fires.
5. Toggle Custom Scopes on the credential, remove `webhook`, reconnect — webhook registration should fail with a permission error.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CE-897

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI