### PR TITLE
refactor(editor): Migrate workflowsStore.workflowId usages in stores and Vue components and composables

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/ActivationModal.vue
+++ b/packages/frontend/editor-ui/src/app/components/ActivationModal.vue
@@ -18,12 +18,10 @@ import {
 
 import { N8nButton, N8nCheckbox, N8nText } from '@n8n/design-system';
 import { injectWorkflowDocumentStore } from '../stores/workflowDocument.store';
-import { useWorkflowId } from '../composables/useWorkflowId';
 
 const checked = ref(false);
 
 const executionsStore = useExecutionsStore();
-const workflowId = useWorkflowId();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const nodeTypesStore = useNodeTypesStore();
 const uiStore = useUIStore();
@@ -72,7 +70,7 @@ const triggerContent = computed(() => {
 
 const showExecutionsList = async () => {
 	const activeExecution = executionsStore.activeExecution;
-	const currentWorkflow = workflowId.value;
+	const currentWorkflow = workflowDocumentStore.value.workflowId;
 
 	if (activeExecution) {
 		router

--- a/packages/frontend/editor-ui/src/app/components/ActivationModal.vue
+++ b/packages/frontend/editor-ui/src/app/components/ActivationModal.vue
@@ -5,7 +5,6 @@ import Modal from '@/app/components/Modal.vue';
 import { useStorage } from '@/app/composables/useStorage';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUIStore } from '@/app/stores/ui.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { getActivatableTriggerNodes, getTriggerNodeServiceName } from '@/app/utils/nodeTypesUtils';
 import { useExecutionsStore } from '@/features/execution/executions/executions.store';
 import { useI18n } from '@n8n/i18n';
@@ -19,11 +18,12 @@ import {
 
 import { N8nButton, N8nCheckbox, N8nText } from '@n8n/design-system';
 import { injectWorkflowDocumentStore } from '../stores/workflowDocument.store';
+import { useWorkflowId } from '../composables/useWorkflowId';
 
 const checked = ref(false);
 
 const executionsStore = useExecutionsStore();
-const workflowsStore = useWorkflowsStore();
+const workflowId = useWorkflowId();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const nodeTypesStore = useNodeTypesStore();
 const uiStore = useUIStore();
@@ -72,7 +72,7 @@ const triggerContent = computed(() => {
 
 const showExecutionsList = async () => {
 	const activeExecution = executionsStore.activeExecution;
-	const currentWorkflow = workflowsStore.workflowId;
+	const currentWorkflow = workflowId.value;
 
 	if (activeExecution) {
 		router

--- a/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.test.ts
@@ -21,6 +21,7 @@ const { mockWorkflowDocumentStore } = vi.hoisted(() => ({
 		allNodes: [] as Array<{ id: string; name: string; type: string }>,
 		workflowTriggerNodes: [] as Array<{ id: string; name: string; type: string }>,
 		name: '',
+		workflowId: 'test-workflow',
 		settings: {},
 		getPinDataSnapshot: () => ({}),
 	},

--- a/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.vue
+++ b/packages/frontend/editor-ui/src/app/components/FromAiParametersModal.vue
@@ -3,7 +3,6 @@ import Modal from '@/app/components/Modal.vue';
 import { useRunWorkflow } from '@/app/composables/useRunWorkflow';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { FROM_AI_PARAMETERS_MODAL_KEY } from '@/app/constants';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import type { FormFieldValueUpdate } from '@n8n/design-system';
@@ -37,7 +36,6 @@ const i18n = useI18n();
 const telemetry = useTelemetry();
 const ndvStore = useNDVStore();
 const modalBus = createEventBus();
-const workflowsStore = useWorkflowsStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const router = useRouter();
 const { runWorkflow } = useRunWorkflow({ router });
@@ -65,7 +63,7 @@ const onExecute = async () => {
 	const nodeName = node.value.name;
 	const inputValues = Object.values(inputs.value?.getValuesWithMetadata() ?? {});
 
-	agentRequestStore.clearAgentRequests(workflowsStore.workflowId, node.value.id);
+	agentRequestStore.clearAgentRequests(workflowDocumentStore.value.workflowId, node.value.id);
 	// check if there's a selected tool, e.g. HITL/MCP client tool selector
 	// findLast is used to get the last selected tool from the tool chain
 	const selectedToolName = inputValues.findLast((value) => value.metadata?.type === 'selector')
@@ -91,11 +89,15 @@ const onExecute = async () => {
 		}
 	}
 
-	agentRequestStore.setAgentRequestForNode(workflowsStore.workflowId, node.value.id, agentRequest);
+	agentRequestStore.setAgentRequestForNode(
+		workflowDocumentStore.value.workflowId,
+		node.value.id,
+		agentRequest,
+	);
 
 	const telemetryPayload = {
 		node_type: node.value.type,
-		workflow_id: workflowsStore.workflowId,
+		workflow_id: workflowDocumentStore.value.workflowId,
 		source: 'from-ai-parameters-modal',
 		push_ref: ndvStore.pushRef,
 	};

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowPublishModal.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowPublishModal.vue
@@ -173,7 +173,9 @@ const aiGatewayWarningNodeNames = computed(() =>
 async function displayActivationError() {
 	let errorMessage: string | VNode;
 	try {
-		const errorData = await workflowsStore.getActivationError(workflowsStore.workflowId);
+		const errorData = await workflowsStore.getActivationError(
+			workflowDocumentStore.value.workflowId,
+		);
 
 		if (errorData === undefined) {
 			errorMessage = i18n.baseText(
@@ -207,7 +209,7 @@ async function handlePublish() {
 
 	// Activate the workflow
 	const { success, errorHandled } = await workflowActivate.publishWorkflow(
-		workflowsStore.workflowId,
+		workflowDocumentStore.value.workflowId,
 		workflowDocumentStore.value?.versionId ?? '',
 		{
 			name: versionName.value,
@@ -233,7 +235,7 @@ async function handlePublish() {
 		}
 
 		telemetry.track('User published version from canvas', {
-			workflow_id: workflowsStore.workflowId,
+			workflow_id: workflowDocumentStore.value.workflowId,
 		});
 
 		// For now, just close the modal after successful activation
@@ -296,7 +298,7 @@ async function handlePublish() {
 						<li v-for="node in nodesWithValidationIssues" :key="node.id">
 							<N8nLink
 								size="small"
-								:to="`/workflow/${workflowsStore.workflowId}/${node.id}`"
+								:to="`/workflow/${workflowDocumentStore.workflowId}/${node.id}`"
 								@click="modalBus.emit('close')"
 								>{{ node.name }}</N8nLink
 							>

--- a/packages/frontend/editor-ui/src/app/components/MainSidebar.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebar.test.ts
@@ -19,7 +19,7 @@ vi.mock('vue-router', () => ({
 	useRouter: () => ({
 		resolve: vi.fn(() => ({ meta: {} })),
 	}),
-	useRoute: () => reactive({}),
+	useRoute: () => reactive({ params: {} }),
 	RouterLink: vi.fn(),
 }));
 

--- a/packages/frontend/editor-ui/src/app/components/MainSidebar.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebar.vue
@@ -12,7 +12,6 @@ import { useSettingsStore } from '@/app/stores/settings.store';
 import { useTemplatesStore } from '@/features/workflows/templates/templates.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useVersionsStore } from '@/app/stores/versions.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useBugReporting } from '@/app/composables/useBugReporting';
 import { usePageRedirectionHelper } from '@/app/composables/usePageRedirectionHelper';
@@ -28,6 +27,7 @@ import { useResourceCenterStore } from '@/experiments/resourceCenter/stores/reso
 import { LOCAL_STORAGE_SIDEBAR_WIDTH } from '@/app/constants';
 import { useSidebarExpandedExperiment } from '@/experiments/sidebarExpanded';
 import { trackTemplatesClick, TemplateClickSource } from '@/experiments/utils';
+import { useWorkflowId } from '../composables/useWorkflowId';
 
 const cloudPlanStore = useCloudPlanStore();
 const rootStore = useRootStore();
@@ -35,7 +35,7 @@ const settingsStore = useSettingsStore();
 const templatesStore = useTemplatesStore();
 const uiStore = useUIStore();
 const versionsStore = useVersionsStore();
-const workflowsStore = useWorkflowsStore();
+const workflowId = useWorkflowId();
 const resourceCenterStore = useResourceCenterStore();
 
 const i18n = useI18n();
@@ -263,7 +263,7 @@ onBeforeUnmount(() => {
 const trackHelpItemClick = (itemType: string) => {
 	telemetry.track('User clicked help resource', {
 		type: itemType,
-		workflow_id: workflowsStore.workflowId,
+		workflow_id: workflowId.value,
 	});
 };
 

--- a/packages/frontend/editor-ui/src/app/components/MainSidebar.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebar.vue
@@ -27,7 +27,7 @@ import { useResourceCenterStore } from '@/experiments/resourceCenter/stores/reso
 import { LOCAL_STORAGE_SIDEBAR_WIDTH } from '@/app/constants';
 import { useSidebarExpandedExperiment } from '@/experiments/sidebarExpanded';
 import { trackTemplatesClick, TemplateClickSource } from '@/experiments/utils';
-import { useWorkflowId } from '../composables/useWorkflowId';
+import { injectWorkflowDocumentStore } from '../stores/workflowDocument.store';
 
 const cloudPlanStore = useCloudPlanStore();
 const rootStore = useRootStore();
@@ -35,7 +35,7 @@ const settingsStore = useSettingsStore();
 const templatesStore = useTemplatesStore();
 const uiStore = useUIStore();
 const versionsStore = useVersionsStore();
-const workflowId = useWorkflowId();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const resourceCenterStore = useResourceCenterStore();
 
 const i18n = useI18n();
@@ -263,7 +263,7 @@ onBeforeUnmount(() => {
 const trackHelpItemClick = (itemType: string) => {
 	telemetry.track('User clicked help resource', {
 		type: itemType,
-		workflow_id: workflowId.value,
+		workflow_id: workflowDocumentStore.value.workflowId,
 	});
 };
 

--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
@@ -187,7 +187,7 @@ const readOnlyEnv = computed(
 	() => sourceControlStore.preferences.branchReadOnly || collaborationStore.shouldBeReadOnly,
 );
 const workflowName = computed(() => workflowDocumentStore.value.name);
-const workflowId = computed(() => workflowsStore.workflowId);
+const workflowId = computed(() => workflowDocumentStore.value.workflowId);
 const workflow = computed(() => workflowsListStore.getWorkflowById(workflowId.value));
 const isSharingEnabled = computed(
 	() => settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.Sharing],
@@ -621,7 +621,7 @@ const saveSettings = async () => {
 
 	void externalHooks.run('workflowSettings.saveSettings', { oldSettings: { ...oldSettings } });
 	telemetry.track('User updated workflow settings', {
-		workflow_id: workflowsStore.workflowId,
+		workflow_id: workflowDocumentStore.value.workflowId,
 		// null and undefined values are removed from the object, but we need the keys to be there
 		time_saved: workflowSettings.value.timeSavedPerExecution ?? '',
 		error_workflow: workflowSettings.value.errorWorkflow ?? '',
@@ -685,7 +685,7 @@ onMounted(async () => {
 	executionTimeout.value = rootStore.executionTimeout;
 	maxExecutionTimeout.value = rootStore.maxExecutionTimeout;
 
-	if (!workflowsStore.isWorkflowSaved[workflowsStore.workflowId]) {
+	if (!workflowsStore.isWorkflowSaved[workflowDocumentStore.value.workflowId]) {
 		toast.showMessage({
 			title: 'No workflow active',
 			message: 'No workflow active to display settings of.',
@@ -799,7 +799,7 @@ onMounted(async () => {
 		dialogVisible: true,
 	});
 	telemetry.track('User opened workflow settings', {
-		workflow_id: workflowsStore.workflowId,
+		workflow_id: workflowDocumentStore.value.workflowId,
 	});
 
 	// Register custom action for opening SavedTime node creator

--- a/packages/frontend/editor-ui/src/app/composables/useToolParameters.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useToolParameters.test.ts
@@ -19,6 +19,7 @@ const { mockWorkflowDocumentStore } = vi.hoisted(() => ({
 		getParentNodes: vi.fn().mockReturnValue([]),
 		allNodes: [],
 		workflowTriggerNodes: [],
+		workflowId: 'test-workflow',
 		name: '',
 		settings: {},
 		getPinDataSnapshot: () => ({}),

--- a/packages/frontend/editor-ui/src/app/composables/useToolParameters.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useToolParameters.ts
@@ -109,7 +109,7 @@ export function useToolParameters({ node }: GetToolParametersProps) {
 			currentNodeParameters: newNode.parameters,
 			credentials: newNode.credentials,
 			projectId: projectsStore.currentProjectId,
-			workflowId: workflowsStore.workflowId,
+			workflowId: workflowDocumentStore.value.workflowId,
 		});
 
 		// Load available tools
@@ -266,7 +266,7 @@ export function useToolParameters({ node }: GetToolParametersProps) {
 			const initialValue = inputQuery?.[value.key]
 				? inputQuery[value.key]
 				: (agentRequestStore.getQueryValue(
-						workflowsStore.workflowId,
+						workflowDocumentStore.value.workflowId,
 						toolNode.id,
 						toolNode.name,
 						value.key,
@@ -296,7 +296,7 @@ export function useToolParameters({ node }: GetToolParametersProps) {
 			const queryValue =
 				inputQuery ??
 				agentRequestStore.getQueryValue(
-					workflowsStore.workflowId,
+					workflowDocumentStore.value.workflowId,
 					toolNode.id,
 					toolNode.name,
 					key,

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/CanvasChatFloatingWindow.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/CanvasChatFloatingWindow.vue
@@ -4,12 +4,11 @@ import { useStorage } from '@vueuse/core';
 import { useI18n } from '@n8n/i18n';
 import { N8nFloatingWindow, N8nText } from '@n8n/design-system';
 import { LOCAL_STORAGE_FLOATING_CHAT_WINDOW } from '@/app/constants';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
-
 import { useChatHubPanelStore } from '@/features/ai/chatHub/chatHubPanel.store';
 import CanvasChatHubPanel from './CanvasChatHubPanel.vue';
 import CanvasChatFloatingMenu from './CanvasChatFloatingMenu.vue';
 import ChatAgentAvatar from './ChatAgentAvatar.vue';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 const CANVAS_MARGIN = 16;
 
@@ -19,7 +18,7 @@ const emit = defineEmits<{
 }>();
 
 const i18n = useI18n();
-const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const chatHubPanelStore = useChatHubPanelStore();
 const isPoppedOut = computed(() => chatHubPanelStore.isPoppedOut);
 
@@ -132,7 +131,7 @@ defineExpose({ focusInput, canvasChatHubRef });
 			<CanvasChatFloatingMenu
 				v-if="canvasChatHubRef?.sessionId"
 				:session-id="canvasChatHubRef.sessionId"
-				:workflow-id="workflowsStore.workflowId"
+				:workflow-id="workflowDocumentStore.workflowId"
 				:can-pop-out="canPopOut && !isPoppedOut"
 				@select-session="canvasChatHubRef.handleSelectSession"
 				@copy-session-id="canvasChatHubRef.copySessionId()"

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/CanvasChatHubPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/CanvasChatHubPanel.vue
@@ -16,7 +16,6 @@ import { CHAT_TRIGGER_NODE_TYPE } from '@/app/constants';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { flattenModel } from '@/features/ai/chatHub/chat.utils';
 import { useChatStore } from '../chat.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useChatHubPanelStore } from '@/features/ai/chatHub/chatHubPanel.store';
 import { useChatSession } from '../composables/useChatSession';
@@ -42,7 +41,6 @@ const emit = defineEmits<{
 
 const i18n = useI18n();
 const chatStore = useChatStore();
-const workflowsStore = useWorkflowsStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const chatHubPanelStore = useChatHubPanelStore();
 const telemetry = useTelemetry();
@@ -72,7 +70,7 @@ const agentDisplayName = computed(() => {
 });
 
 const workflowAgent = computed<ChatModelDto | null>(() => {
-	const workflowId = workflowsStore.workflowId;
+	const workflowId = workflowDocumentStore.value.workflowId;
 	if (!workflowId) return null;
 
 	const params = chatTriggerNode.value?.parameters;
@@ -174,7 +172,7 @@ async function handleSelectSession(selectedSessionId: ChatSessionId) {
 
 // Reset session when workflow changes
 watch(
-	() => workflowsStore.workflowId,
+	() => workflowDocumentStore.value.workflowId,
 	() => {
 		sessionId.value = uuidv4();
 	},
@@ -300,7 +298,7 @@ defineExpose({
 				<CanvasChatSessionDropdown
 					:session-id="sessionId"
 					:session-title="sessionIdText"
-					:workflow-id="workflowsStore.workflowId"
+					:workflow-id="workflowDocumentStore.workflowId"
 					@select-session="handleSelectSession"
 				/>
 				<N8nTooltip placement="bottom">

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/SetupWizard/SetupWizard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/SetupWizard/SetupWizard.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { useI18n } from '@n8n/i18n';
 import { ref, computed } from 'vue';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useEvaluationStore } from '../../evaluation.store';
 import { VIEWS } from '@/app/constants';
 import StepHeader from '../shared/StepHeader.vue';
@@ -11,19 +10,20 @@ import { usePageRedirectionHelper } from '@/app/composables/usePageRedirectionHe
 import { I18nT } from 'vue-i18n';
 
 import { N8nButton, N8nCallout, N8nText } from '@n8n/design-system';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 defineEmits<{
 	runTest: [];
 }>();
 
 const router = useRouter();
 const locale = useI18n();
-const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const evaluationStore = useEvaluationStore();
 const usageStore = useUsageStore();
 const pageRedirectionHelper = usePageRedirectionHelper();
 
 const hasRuns = computed(() => {
-	return evaluationStore.testRunsByWorkflowId[workflowsStore.workflowId]?.length > 0;
+	return evaluationStore.testRunsByWorkflowId[workflowDocumentStore.value.workflowId]?.length > 0;
 });
 
 const evaluationsAvailable = computed(() => {
@@ -74,7 +74,7 @@ const toggleStep = (index: number) => {
 function navigateToWorkflow(
 	action?: 'addEvaluationTrigger' | 'addEvaluationNode' | 'executeEvaluation',
 ) {
-	const routeWorkflowId = workflowsStore.workflowId || 'new';
+	const routeWorkflowId = workflowDocumentStore.value.workflowId || 'new';
 
 	void router.push({
 		name: VIEWS.WORKFLOW,

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.vue
@@ -26,7 +26,6 @@ import { useCredentialsStore } from '../../credentials.store';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useUIStore } from '@/app/stores/ui.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import Banner from '@/app/components/Banner.vue';
 import CopyInput from '@/app/components/CopyInput.vue';
 import CredentialInputs from './CredentialInputs.vue';
@@ -48,6 +47,7 @@ import { ElSwitch } from 'element-plus';
 import { useQuickConnect } from '../../quickConnect/composables/useQuickConnect';
 import QuickConnectButton from '../../quickConnect/components/QuickConnectButton.vue';
 import QuickConnectBanner from '../../quickConnect/components/QuickConnectBanner.vue';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 type Props = {
 	mode: string;
@@ -97,7 +97,7 @@ const credentialsStore = useCredentialsStore();
 const ndvStore = useNDVStore();
 const rootStore = useRootStore();
 const uiStore = useUIStore();
-const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const assistantStore = useAssistantStore();
 const chatPanelStore = useChatPanelStore();
 
@@ -243,7 +243,7 @@ function onDocumentationUrlClick(): void {
 		docs_link: documentationUrl.value,
 		credential_type: credentialTypeName.value,
 		source: 'modal',
-		workflow_id: workflowsStore.workflowId,
+		workflow_id: workflowDocumentStore.value.workflowId,
 	});
 }
 

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -32,7 +32,6 @@ import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import type { Project, ProjectSharingData } from '@/features/collaboration/projects/projects.types';
 import { getResourcePermissions } from '@n8n/permissions';
 import { assert } from '@n8n/utils/assert';
@@ -83,7 +82,6 @@ const credentialsStore = useCredentialsStore();
 const ndvStore = useNDVStore();
 const settingsStore = useSettingsStore();
 const uiStore = useUIStore();
-const workflowsStore = useWorkflowsStore();
 const nodeTypesStore = useNodeTypesStore();
 const projectsStore = useProjectsStore();
 const externalSecretsStore = useExternalSecretsStore();
@@ -684,7 +682,7 @@ function onTabSelect(tab: string) {
 		credential_type: credType,
 		node_type: activeNode ? activeNode.type : null,
 		tab,
-		workflow_id: workflowsStore.workflowId,
+		workflow_id: workflowDocumentStore.value.workflowId,
 		credential_id: credentialId.value,
 		sharing_enabled: EnterpriseEditionFeature.Sharing,
 	});
@@ -940,7 +938,7 @@ async function saveCredential(): Promise<ICredentialsResponse | null> {
 
 		const trackProperties: ITelemetryTrackProperties = {
 			credential_type: credentialDetails.type,
-			workflow_id: workflowsStore.workflowId,
+			workflow_id: workflowDocumentStore.value.workflowId,
 			credential_id: credential.id,
 			is_complete: !!requiredPropertiesFilled.value,
 			is_new: isNewCredential,
@@ -1077,7 +1075,7 @@ async function createCredential(
 	telemetry.track('User created credentials', {
 		credential_type: credentialDetails.type,
 		credential_id: credential.id,
-		workflow_id: workflowsStore.workflowId,
+		workflow_id: workflowDocumentStore.value.workflowId,
 	});
 
 	return credential;
@@ -1262,7 +1260,7 @@ async function oAuthCredentialAuthorize() {
 
 		const trackProperties: ITelemetryTrackProperties = {
 			credential_type: credentialTypeName.value,
-			workflow_id: workflowsStore.workflowId || null,
+			workflow_id: workflowDocumentStore.value.workflowId || null,
 			credential_id: credentialId.value,
 			is_complete: !!requiredPropertiesFilled.value,
 			is_new: props.mode === 'new' && !credentialId.value,

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialsSelectModal.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialsSelectModal.vue
@@ -3,7 +3,6 @@ import { useExternalHooks } from '@/app/composables/useExternalHooks';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useCredentialsStore } from '../credentials.store';
 import { useUIStore } from '@/app/stores/ui.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { createEventBus } from '@n8n/utils/event-bus';
 import { computed, onMounted, ref } from 'vue';
 import { CREDENTIAL_SELECT_MODAL_KEY } from '../credentials.constants';
@@ -11,6 +10,7 @@ import Modal from '@/app/components/Modal.vue';
 import { useI18n } from '@n8n/i18n';
 
 import { N8nButton, N8nIcon, N8nOption, N8nSelect } from '@n8n/design-system';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 const externalHooks = useExternalHooks();
 const telemetry = useTelemetry();
 const i18n = useI18n();
@@ -22,7 +22,7 @@ const selectRef = ref<HTMLSelectElement>();
 
 const credentialsStore = useCredentialsStore();
 const uiStore = useUIStore();
-const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 
 onMounted(async () => {
 	try {
@@ -55,7 +55,7 @@ function openCredentialType() {
 		credential_type: selected.value,
 		source: 'primary_menu',
 		new_credential: true,
-		workflow_id: workflowsStore.workflowId,
+		workflow_id: workflowDocumentStore.value.workflowId,
 	};
 
 	telemetry.track('User opened Credential modal', telemetryPayload);

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -571,7 +571,7 @@ function onAiGatewaySelector(credentialType: string, enable: boolean, isUserActi
 			credential_type: credentialType,
 			node_type: props.node.type,
 			mode: enable ? 'n8n_connect' : 'own',
-			workflow_id: props.standalone ? '' : workflowsStore.workflowId,
+			workflow_id: props.standalone ? '' : workflowDocumentStore?.value.workflowId,
 		});
 	}
 

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -32,7 +32,6 @@ import QuickConnectButton from '../quickConnect/components/QuickConnectButton.vu
 import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUIStore } from '@/app/stores/ui.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { assert } from '@n8n/utils/assert';
 import { isEmpty } from '@/app/utils/typesUtils';
@@ -98,7 +97,6 @@ const credentialsStore = useCredentialsStore();
 const nodeTypesStore = useNodeTypesStore();
 const ndvStore = injectNDVStore();
 const uiStore = useUIStore();
-const workflowsStore = useWorkflowsStore();
 const projectsStore = useProjectsStore();
 const workflowDocumentStore = props.standalone ? undefined : injectWorkflowDocumentStore();
 const { isEnabled: isDynamicCredentialsEnabled } = useDynamicCredentials();
@@ -408,7 +406,7 @@ function createNewCredential(
 		credential_type: credentialType,
 		source: 'node',
 		new_credential: true,
-		workflow_id: props.standalone ? '' : workflowsStore.workflowId,
+		workflow_id: props.standalone ? '' : workflowDocumentStore?.value.workflowId,
 	});
 }
 
@@ -437,7 +435,7 @@ function onCredentialSelected(
 		credential_type: credentialType,
 		node_type: props.node.type,
 		...(hasProxyAuth(props.node) ? { is_service_specific: true } : {}),
-		workflow_id: props.standalone ? '' : workflowsStore.workflowId,
+		workflow_id: props.standalone ? '' : workflowDocumentStore?.value.workflowId,
 		credential_id: credentialId,
 	});
 
@@ -607,7 +605,7 @@ function editCredential(credentialType: string): void {
 		credential_type: credentialType,
 		source: 'node',
 		new_credential: false,
-		workflow_id: props.standalone ? '' : workflowsStore.workflowId,
+		workflow_id: props.standalone ? '' : workflowDocumentStore?.value.workflowId,
 	});
 	subscribedToCredentialType.value = credentialType;
 }

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsList.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/global/GlobalExecutionsList.vue
@@ -6,7 +6,6 @@ import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useToast } from '@/app/composables/useToast';
 import { EnterpriseEditionFeature, MODAL_CONFIRM } from '@/app/constants';
 import { useSettingsStore } from '@/app/stores/settings.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import type { IWorkflowDb } from '@/Interface';
 import { useI18n } from '@n8n/i18n';
@@ -51,7 +50,6 @@ const emit = defineEmits<{
 
 const i18n = useI18n();
 const telemetry = useTelemetry();
-const workflowsStore = useWorkflowsStore();
 const workflowsListStore = useWorkflowsListStore();
 const executionsStore = useExecutionsStore();
 const agentSessionsStore = useAgentSessionsStore();
@@ -318,7 +316,7 @@ async function retryExecution(execution: ExecutionSummary, loadWorkflow?: boolea
 	}
 
 	telemetry.track('User clicked retry execution button', {
-		workflow_id: workflowsStore.workflowId,
+		workflow_id: '',
 		execution_id: execution.id,
 		retry_type: loadWorkflow ? 'current' : 'original',
 	});

--- a/packages/frontend/editor-ui/src/features/execution/executions/views/ExecutionsView.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/views/ExecutionsView.vue
@@ -16,6 +16,7 @@ import { useSettingsStore } from '@/app/stores/settings.store';
 import { storeToRefs } from 'pinia';
 import { onBeforeMount, onBeforeUnmount, onMounted, watch } from 'vue';
 import { useRoute } from 'vue-router';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 const route = useRoute();
 const i18n = useI18n();
@@ -27,6 +28,7 @@ const insightsStore = useInsightsStore();
 const settingsStore = useSettingsStore();
 const documentTitle = useDocumentTitle();
 const toast = useToast();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 
 const isAgentsView = () => settingsStore.isModuleActive('agents') && route.query.view === 'agents';
 const overview = useProjectPages();
@@ -43,7 +45,9 @@ onBeforeMount(async () => {
 	await loadWorkflows();
 
 	void externalHooks.run('executionsList.openDialog');
-	telemetry.track('User opened Executions log');
+	telemetry.track('User opened Executions log', {
+		workflow_id: workflowDocumentStore.value.workflowId,
+	});
 });
 
 onMounted(async () => {

--- a/packages/frontend/editor-ui/src/features/execution/executions/views/ExecutionsView.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/views/ExecutionsView.vue
@@ -11,7 +11,6 @@ import { useToast } from '@/app/composables/useToast';
 import InsightsSummary from '@/features/execution/insights/components/InsightsSummary.vue';
 import { useInsightsStore } from '@/features/execution/insights/insights.store';
 import { useExecutionsStore } from '../executions.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { storeToRefs } from 'pinia';
@@ -22,7 +21,6 @@ const route = useRoute();
 const i18n = useI18n();
 const telemetry = useTelemetry();
 const externalHooks = useExternalHooks();
-const workflowsStore = useWorkflowsStore();
 const workflowsListStore = useWorkflowsListStore();
 const executionsStore = useExecutionsStore();
 const insightsStore = useInsightsStore();
@@ -45,9 +43,7 @@ onBeforeMount(async () => {
 	await loadWorkflows();
 
 	void externalHooks.run('executionsList.openDialog');
-	telemetry.track('User opened Executions log', {
-		workflow_id: workflowsStore.workflowId,
-	});
+	telemetry.track('User opened Executions log');
 });
 
 onMounted(async () => {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ExpressionEditModal.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ExpressionEditModal.vue
@@ -93,7 +93,7 @@ const rootNode = computed(() => {
 
 const rootNodesParents = computed(() => {
 	if (!rootNode.value) return [];
-	return workflowDocumentStore?.value?.getParentNodesByDepth(rootNode.value) ?? [];
+	return workflowDocumentStore.value.getParentNodesByDepth(rootNode.value) ?? [];
 });
 
 watch(
@@ -112,7 +112,7 @@ watch(
 			const telemetryPayload = createExpressionTelemetryPayload(
 				segments.value,
 				props.modelValue.toString(),
-				workflowsStore.workflowId,
+				workflowDocumentStore.value.workflowId,
 				ndvStore.pushRef,
 				ndvStore.activeNode?.type ?? '',
 			);

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ExpressionParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ExpressionParameterInput.vue
@@ -7,7 +7,6 @@ import ExpressionFunctionIcon from './ExpressionFunctionIcon.vue';
 import InlineExpressionEditorInput from '@/features/shared/editors/components/InlineExpressionEditor/InlineExpressionEditorInput.vue';
 import InlineExpressionEditorOutput from '@/features/shared/editors/components/InlineExpressionEditor/InlineExpressionEditorOutput.vue';
 import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { createExpressionTelemetryPayload } from '@/app/utils/telemetryUtils';
 
 import { useTelemetry } from '@/app/composables/useTelemetry';
@@ -23,6 +22,7 @@ import { isEventTargetContainedBy } from '@/app/utils/htmlUtils';
 
 import { N8nButton } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 const i18n = useI18n();
 const isFocused = ref(false);
 const segments = ref<Segment[]>([]);
@@ -59,7 +59,7 @@ const emit = defineEmits<{
 
 const telemetry = useTelemetry();
 const ndvStore = injectNDVStore();
-const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 
 const canvas = inject(CanvasKey, undefined);
 const isInExperimentalNdv = useIsInExperimentalNdv();
@@ -108,7 +108,7 @@ function onBlur(event?: FocusEvent | KeyboardEvent) {
 		const telemetryPayload = createExpressionTelemetryPayload(
 			segments.value,
 			props.modelValue,
-			workflowsStore.workflowId,
+			workflowDocumentStore.value.workflowId,
 			ndvStore.pushRef,
 			ndvStore.activeNode?.type ?? '',
 		);

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterLegacy.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterLegacy.vue
@@ -16,7 +16,6 @@ import { computed, ref, watch, onBeforeMount } from 'vue';
 import { useI18n } from '@n8n/i18n';
 import ParameterInputList from '../ParameterInputList.vue';
 import Draggable from 'vuedraggable';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { storeToRefs } from 'pinia';
 import { telemetry } from '@/app/plugins/telemetry';
@@ -31,6 +30,7 @@ import {
 	N8nSelect,
 	N8nText,
 } from '@n8n/design-system';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 const locale = useI18n();
 const nodeHelpers = useNodeHelpers();
@@ -61,7 +61,7 @@ const emit = defineEmits<{
 	valueChanged: [value: ValueChangedEvent];
 }>();
 
-const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const ndvStore = injectNDVStore();
 
 const { activeNode } = storeToRefs(ndvStore);
@@ -407,14 +407,14 @@ const onDragChange = (optionName: string) => {
 const trackWorkflowInputFieldTypeChange = (parameterData: IUpdateInformation) => {
 	telemetry.track('User changed workflow input field type', {
 		type: parameterData.value,
-		workflow_id: workflowsStore.workflowId,
+		workflow_id: workflowDocumentStore.value.workflowId,
 		node_id: ndvStore.activeNode?.id,
 	});
 };
 
 const trackWorkflowInputFieldAdded = () => {
 	telemetry.track('User added workflow input field', {
-		workflow_id: workflowsStore.workflowId,
+		workflow_id: workflowDocumentStore.value.workflowId,
 		node_id: ndvStore.activeNode?.id,
 	});
 };

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.vue
@@ -2,7 +2,6 @@
 import { useFixedCollectionItemState } from '@/app/composables/useFixedCollectionItemState';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { telemetry } from '@/app/plugins/telemetry';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import type { IUpdateInformation } from '@/Interface';
 import type { DropdownMenuItemProps } from '@n8n/design-system';
@@ -29,10 +28,10 @@ import { storeToRefs } from 'pinia';
 import { computed, nextTick, onBeforeMount, ref, useTemplateRef, watch } from 'vue';
 import ParameterInputList from '../ParameterInputList.vue';
 import FixedCollectionItemList from './FixedCollectionItemList.vue';
+import { useWorkflowId } from '@/app/composables/useWorkflowId';
 
 const locale = useI18n();
 const ndvStore = injectNDVStore();
-const workflowsStore = useWorkflowsStore();
 const nodeHelpers = useNodeHelpers();
 const { activeNode } = storeToRefs(ndvStore);
 
@@ -66,6 +65,8 @@ const emit = defineEmits<{
 	valueChanged: [value: ValueChangedEvent];
 	delete: [];
 }>();
+
+const workflowId = useWorkflowId();
 
 const mutableValues = ref({} as Record<string, INodeParameters[] | INodeParameters>);
 const rootEl = useTemplateRef<HTMLElement>('rootEl');
@@ -414,7 +415,7 @@ const handleDelete = (optionName: string, index?: number) => {
 
 const trackFieldAdded = () => {
 	telemetry.track('User added workflow input field', {
-		workflow_id: workflowsStore.workflowId,
+		workflow_id: workflowId.value,
 		node_id: ndvStore.activeNode?.id,
 	});
 };
@@ -422,7 +423,7 @@ const trackFieldAdded = () => {
 const trackFieldTypeChange = (parameterData: IUpdateInformation) => {
 	telemetry.track('User changed workflow input field type', {
 		type: parameterData.value,
-		workflow_id: workflowsStore.workflowId,
+		workflow_id: workflowId.value,
 		node_id: ndvStore.activeNode?.id,
 	});
 };

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/FixedCollection/FixedCollectionParameterNew.vue
@@ -28,7 +28,7 @@ import { storeToRefs } from 'pinia';
 import { computed, nextTick, onBeforeMount, ref, useTemplateRef, watch } from 'vue';
 import ParameterInputList from '../ParameterInputList.vue';
 import FixedCollectionItemList from './FixedCollectionItemList.vue';
-import { useWorkflowId } from '@/app/composables/useWorkflowId';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 const locale = useI18n();
 const ndvStore = injectNDVStore();
@@ -66,7 +66,7 @@ const emit = defineEmits<{
 	delete: [];
 }>();
 
-const workflowId = useWorkflowId();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 
 const mutableValues = ref({} as Record<string, INodeParameters[] | INodeParameters>);
 const rootEl = useTemplateRef<HTMLElement>('rootEl');
@@ -415,7 +415,7 @@ const handleDelete = (optionName: string, index?: number) => {
 
 const trackFieldAdded = () => {
 	telemetry.track('User added workflow input field', {
-		workflow_id: workflowId.value,
+		workflow_id: workflowDocumentStore.value.workflowId,
 		node_id: ndvStore.activeNode?.id,
 	});
 };
@@ -423,7 +423,7 @@ const trackFieldAdded = () => {
 const trackFieldTypeChange = (parameterData: IUpdateInformation) => {
 	telemetry.track('User changed workflow input field type', {
 		type: parameterData.value,
-		workflow_id: workflowId.value,
+		workflow_id: workflowDocumentStore.value.workflowId,
 		node_id: ndvStore.activeNode?.id,
 	});
 };

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInput.vue
@@ -76,7 +76,6 @@ import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import type { EventBus } from '@n8n/utils/event-bus';
@@ -174,7 +173,6 @@ const telemetry = useTelemetry();
 
 const credentialsStore = useCredentialsStore();
 const ndvStore = injectNDVStore();
-const workflowsStore = useWorkflowsStore();
 const workflowsListStore = useWorkflowsListStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const settingsStore = useSettingsStore();
@@ -833,7 +831,7 @@ async function loadRemoteParameterOptions() {
 			currentNodeParameters: resolvedNodeParameters,
 			credentials: node.value.credentials,
 			projectId: projectsStore.currentProjectId,
-			workflowId: workflowsStore.workflowId,
+			workflowId: workflowDocumentStore.value.workflowId,
 		});
 
 		remoteParameterOptions.value = remoteParameterOptions.value.concat(options);
@@ -873,7 +871,7 @@ function trackExpressionEditOpen() {
 			parameter_name: props.parameter.displayName,
 			parameter_field_type: props.parameter.type,
 			new_expression: !isModelValueExpression.value,
-			workflow_id: workflowsStore.workflowId,
+			workflow_id: workflowDocumentStore.value.workflowId,
 			push_ref: ndvStore.pushRef,
 			source: props.eventSource ?? 'ndv',
 		});
@@ -1006,7 +1004,7 @@ function trackWorkflowInputModeEvent(value: string) {
 	};
 	telemetry.track('User chose input data mode', {
 		option: telemetryValuesMap[value],
-		workflow_id: workflowsStore.workflowId,
+		workflow_id: workflowDocumentStore.value.workflowId,
 		node_id: node.value?.id,
 	});
 }
@@ -1079,7 +1077,7 @@ function valueChanged(untypedValue: unknown) {
 
 	if (props.parameter.name === 'operation' || props.parameter.name === 'mode') {
 		telemetry.track('User set node operation or mode', {
-			workflow_id: workflowsStore.workflowId,
+			workflow_id: workflowDocumentStore.value.workflowId,
 			node_type: node.value?.type,
 			resource: node.value?.parameters.resource,
 			is_custom: value === CUSTOM_API_CALL_KEY,

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputExpanded.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputExpanded.vue
@@ -2,7 +2,6 @@
 import type { IUpdateInformation } from '@/Interface';
 import { useI18n } from '@n8n/i18n';
 import { useTelemetry } from '@/app/composables/useTelemetry';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { isValueExpression as isValueExpressionUtil } from '@/app/utils/nodeTypesUtils';
 import { createEventBus } from '@n8n/utils/event-bus';
 import {
@@ -20,6 +19,7 @@ import { useUIStore } from '@/app/stores/ui.store';
 import { storeToRefs } from 'pinia';
 
 import { N8nInputLabel, N8nLink, N8nText } from '@n8n/design-system';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 const LazyFixedCollectionParameter = defineAsyncComponent(
 	async () => await import('./FixedCollection/FixedCollectionParameter.vue'),
@@ -51,7 +51,7 @@ const menuExpanded = ref(false);
 const eventBus = ref(createEventBus());
 const uiStore = useUIStore();
 
-const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 
 const i18n = useI18n();
 const telemetry = useTelemetry();
@@ -160,7 +160,7 @@ function onDocumentationUrlClick(): void {
 	telemetry.track('User clicked credential modal docs link', {
 		docs_link: props.documentationUrl,
 		source: 'field',
-		workflow_id: workflowsStore.workflowId,
+		workflow_id: workflowDocumentStore.value.workflowId,
 	});
 }
 const param = useTemplateRef<{ displaysIssues?: ComputedRef<boolean> }>('param');

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceLocator/ResourceLocator.vue
@@ -13,7 +13,6 @@ import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useUIStore } from '@/app/stores/ui.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
 	getAppNameFromNodeName,
 	getMainAuthField,
@@ -160,7 +159,6 @@ const nodeTypesStore = useNodeTypesStore();
 const ndvStore = injectNDVStore();
 const rootStore = useRootStore();
 const uiStore = useUIStore();
-const workflowsStore = useWorkflowsStore();
 const projectsStore = useProjectsStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const expressionLocalResolveCtx = inject(ExpressionLocalResolveContextSymbol, undefined);
@@ -295,7 +293,7 @@ const currentRequestParams = computed(() => {
 		credentials: props.node?.credentials ?? {},
 		filter: searchFilter.value,
 		projectId: projectsStore.currentProjectId,
-		workflowId: workflowsStore.workflowId,
+		workflowId: workflowDocumentStore.value.workflowId,
 	};
 });
 
@@ -730,7 +728,7 @@ function onModeSelected(value: string): void {
 function trackEvent(event: string, params?: { [key: string]: string }): void {
 	telemetry.track(event, {
 		instance_id: rootStore.instanceId,
-		workflow_id: workflowsStore.workflowId,
+		workflow_id: workflowDocumentStore.value.workflowId,
 		node_type: props.node?.type,
 		resource: props.node?.parameters.resource,
 		operation: props.node?.parameters.operation,
@@ -837,7 +835,7 @@ async function loadResources() {
 			currentNodeParameters: resolvedNodeParameters,
 			credentials: props.node.credentials,
 			projectId: projectsStore.currentProjectId,
-			workflowId: workflowsStore.workflowId,
+			workflowId: workflowDocumentStore.value.workflowId,
 		};
 
 		if (params.filter) {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/ResourceMapper.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ResourceMapper/ResourceMapper.vue
@@ -348,7 +348,7 @@ const createRequestParams = async (methodName: string) => {
 		methodName,
 		credentials: props.node.credentials,
 		projectId: projectsStore.currentProjectId,
-		workflowId: workflowsStore.workflowId,
+		workflowId: workflowDocumentStore.value.workflowId,
 	};
 
 	return requestParams;

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettings.vue
@@ -44,7 +44,6 @@ import { useHistoryStore } from '@/app/stores/history.store';
 import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import type { NodeSettingsTab } from '@/app/types/nodeSettings';
 import {
@@ -123,7 +122,6 @@ const nodeValues = ref<INodeParameters>(getNodeSettingsInitialValues());
 
 const nodeTypesStore = useNodeTypesStore();
 const ndvStore = injectNDVStore();
-const workflowsStore = useWorkflowsStore();
 const workflowsListStore = useWorkflowsListStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const credentialsStore = useCredentialsStore();
@@ -162,7 +160,7 @@ const settingsStore = useSettingsStore();
 const { isPreviewMode } = settingsStore;
 const isDemoPreview = computed(() => isDemoRoute.value && isPreviewMode);
 const currentWorkflow = computed(() =>
-	workflowsListStore.getWorkflowById(workflowsStore.workflowId),
+	workflowsListStore.getWorkflowById(workflowDocumentStore.value.workflowId),
 );
 const hasForeignCredential = computed(() => props.foreignCredentials.length > 0);
 const isHomeProjectTeam = computed(
@@ -584,7 +582,7 @@ const onFeatureRequestClick = () => {
 	if (node.value) {
 		telemetry.track('User clicked ndv link', {
 			node_type: node.value.type,
-			workflow_id: workflowsStore.workflowId,
+			workflow_id: workflowDocumentStore.value.workflowId,
 			push_ref: props.pushRef,
 			pane: NodeConnectionTypes.Main,
 			type: 'i-wish-this-node-would',

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsTabs.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsTabs.vue
@@ -2,19 +2,18 @@
 import type { ITab } from '@/Interface';
 import { COMMUNITY_NODES_INSTALLATION_DOCS_URL } from '@/features/settings/communityNodes/communityNodes.constants';
 import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import type { INodeTypeDescription } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 import { computed } from 'vue';
-
 import { useExternalHooks } from '@/app/composables/useExternalHooks';
 import { useInstalledCommunityPackage } from '@/features/settings/communityNodes/composables/useInstalledCommunityPackage';
 import { useNodeDocsUrl } from '@/app/composables/useNodeDocsUrl';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import type { NodeSettingsTab } from '@/app/types/nodeSettings';
 import { useI18n } from '@n8n/i18n';
-
 import { N8nTabs } from '@n8n/design-system';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+
 type Props = {
 	modelValue?: NodeSettingsTab;
 	nodeType?: INodeTypeDescription | null;
@@ -40,7 +39,7 @@ const emit = defineEmits<{
 
 const externalHooks = useExternalHooks();
 const ndvStore = injectNDVStore();
-const workflowsStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const i18n = useI18n();
 const telemetry = useTelemetry();
 const { docsUrl } = useNodeDocsUrl({ nodeType: () => props.nodeType });
@@ -137,7 +136,7 @@ function onTabSelect(tab: NodeSettingsTab) {
 
 		telemetry.track('User clicked ndv link', {
 			node_type: activeNode.value?.type,
-			workflow_id: workflowsStore.workflowId,
+			workflow_id: workflowDocumentStore.value.workflowId,
 			push_ref: props.pushRef,
 			pane: NodeConnectionTypes.Main,
 			type: 'docs',
@@ -147,7 +146,7 @@ function onTabSelect(tab: NodeSettingsTab) {
 	if (tab === 'settings' && props.nodeType) {
 		telemetry.track('User viewed node settings', {
 			node_type: props.nodeType.name,
-			workflow_id: workflowsStore.workflowId,
+			workflow_id: workflowDocumentStore.value.workflowId,
 		});
 	}
 

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/cards/NodeGroupSetupCard.vue
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/cards/NodeGroupSetupCard.vue
@@ -14,7 +14,6 @@ import type {
 } from '@/features/setupPanel/setupPanel.types';
 import { isCardComplete } from '@/features/setupPanel/setupPanel.utils';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useSetupPanelStore } from '@/features/setupPanel/setupPanel.store';
 import {
@@ -34,7 +33,6 @@ const emit = defineEmits<{
 }>();
 
 const nodeHelpers = useNodeHelpers();
-const workflowsStore = useWorkflowsStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const setupPanelStore = useSetupPanelStore();
 
@@ -98,8 +96,8 @@ const hasParameters = computed(() => allSections.value.some(sectionHasParameters
 
 const telemetryPayload = computed(() => ({
 	type: ['node-group'],
-	template_id: workflowDocumentStore?.value?.meta?.templateId,
-	workflow_id: workflowsStore.workflowId,
+	template_id: workflowDocumentStore.value.meta?.templateId,
+	workflow_id: workflowDocumentStore.value.workflowId,
 	node_types: allSections.value.map((s) => s.node.type),
 	has_parameters: hasParameters.value,
 }));

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/cards/NodeSetupCard.vue
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/cards/NodeSetupCard.vue
@@ -17,7 +17,6 @@ import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import SetupCard from '@/features/setupPanel/components/cards/SetupCard.vue';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 const props = defineProps<{
@@ -36,7 +35,6 @@ const i18n = useI18n();
 const nodeTypesStore = useNodeTypesStore();
 const credentialsStore = useCredentialsStore();
 const nodeHelpers = useNodeHelpers();
-const workflowsStore = useWorkflowsStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 
 const setupCard = ref<InstanceType<typeof SetupCard> | null>(null);
@@ -96,8 +94,8 @@ const telemetryPayload = computed(() => {
 
 	return {
 		type: types,
-		template_id: workflowDocumentStore?.value?.meta?.templateId,
-		workflow_id: workflowsStore.workflowId,
+		template_id: workflowDocumentStore.value.meta?.templateId,
+		workflow_id: workflowDocumentStore.value.workflowId,
 		node_types: (props.state.allNodesUsingCredential ?? [props.state.node]).map((n) => n.type),
 		credential_type: props.state.credentialType,
 		has_parameters: hasParameters.value,

--- a/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/AskAI/AskAI.vue
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/AskAI/AskAI.vue
@@ -17,7 +17,6 @@ import { useMessage } from '@/app/composables/useMessage';
 import { useToast } from '@/app/composables/useToast';
 import { injectNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { executionDataToJson } from '@/app/utils/nodeTypesUtils';
 import {
 	ASK_AI_MAX_PROMPT_LENGTH,
@@ -91,9 +90,8 @@ function getErrorMessageByStatusCode(statusCode: number, message: string | undef
 
 function getParentNodes() {
 	const activeNode = ndvStore.activeNode;
-	const { workflowId } = useWorkflowsStore();
 
-	if (!activeNode || !workflowId) return [];
+	if (!activeNode) return [];
 
 	return workflowDocumentStore.value
 		.getParentNodesByDepth(activeNode?.name)

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Renderers/CategorizedItemsRenderer.vue
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/components/Renderers/CategorizedItemsRenderer.vue
@@ -1,9 +1,6 @@
 <script setup lang="ts">
 import { computed, watch, ref, useCssModule } from 'vue';
 import type { INodeCreateElement } from '@/Interface';
-
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
-
 import { useKeyboardNavigation } from '../../composables/useKeyboardNavigation';
 import { useViewStacks } from '../../composables/useViewStacks';
 import ItemsRenderer from './ItemsRenderer.vue';
@@ -27,13 +24,14 @@ export interface Props {
 import { useI18n } from '@n8n/i18n';
 
 import { N8nIcon, N8nTooltip } from '@n8n/design-system';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 const props = withDefaults(defineProps<Props>(), {
 	elements: () => [],
 });
 
 const { popViewStack, activeViewStack } = useViewStacks();
 const { registerKeyHook } = useKeyboardNavigation();
-const { workflowId } = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const nodeCreatorStore = useNodeCreatorStore();
 const i18n = useI18n();
 
@@ -55,7 +53,7 @@ function setExpanded(isExpanded: boolean) {
 	if (expanded.value && !prev) {
 		nodeCreatorStore.onCategoryExpanded({
 			category_name: props.category,
-			workflow_id: workflowId,
+			workflow_id: workflowDocumentStore.value.workflowId,
 		});
 	}
 }

--- a/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsModal.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsModal.vue
@@ -6,13 +6,13 @@ import AppsRequiringCredsNotice from './AppsRequiringCredsNotice.vue';
 import SetupTemplateFormStep from './SetupTemplateFormStep.vue';
 import { computed, onMounted, onUnmounted } from 'vue';
 import { useTelemetry } from '@/app/composables/useTelemetry';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useUIStore } from '@/app/stores/ui.store';
 
 import { N8nButton, N8nHeading } from '@n8n/design-system';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 const i18n = useI18n();
 const telemetry = useTelemetry();
-const workflowStore = useWorkflowsStore();
+const workflowDocumentStore = injectWorkflowDocumentStore();
 const uiStore = useUIStore();
 
 export type SetupCredentialsModalSource = 'template' | 'builder';
@@ -54,7 +54,7 @@ onUnmounted(() => {
 		completed: numFilledCredentials.value === credentialUsages.value.length,
 		creds_filled: numFilledCredentials.value,
 		creds_needed: credentialUsages.value.length,
-		workflow_id: workflowStore.workflowId,
+		workflow_id: workflowDocumentStore.value.workflowId,
 		source: props.data?.source ?? 'canvas',
 	});
 });


### PR DESCRIPTION
## Summary

This PR migrates usages of `workflowsStore.workflowId` in Vue components to workflow ID from `injectWorkflowDocument`. The change is meant to be safe because outside of setup context, it falls back to `workflowsStore.workflowId`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3034/migrate-workflowsstoreworkflowid-usages-in-stores-and-vue-components


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
