### PR TITLE
feat(core): Route executions to dedicated worker pool queues (no-changelog)

### DIFF
--- a/packages/cli/src/scaling/constants.ts
+++ b/packages/cli/src/scaling/constants.ts
@@ -1,13 +1,6 @@
 import type { PubSub } from './pubsub/pubsub.types';
 
-export const DEFAULT_QUEUE_NAME = 'jobs';
-
 export const JOB_TYPE_NAME = 'job';
-
-export function poolQueueName(poolName: string | undefined): string {
-	if (!poolName) return DEFAULT_QUEUE_NAME;
-	return `${DEFAULT_QUEUE_NAME}-${poolName}`;
-}
 
 /** Pubsub channel for commands sent by a main process to workers or to other main processes. */
 export const COMMAND_PUBSUB_CHANNEL = 'n8n.commands';

--- a/packages/cli/src/scaling/constants.ts
+++ b/packages/cli/src/scaling/constants.ts
@@ -1,6 +1,13 @@
 import type { PubSub } from './pubsub/pubsub.types';
 
+export const DEFAULT_QUEUE_NAME = 'jobs';
+
 export const JOB_TYPE_NAME = 'job';
+
+export function poolQueueName(poolName: string | undefined): string {
+	if (!poolName) return DEFAULT_QUEUE_NAME;
+	return `${DEFAULT_QUEUE_NAME}-${poolName}`;
+}
 
 /** Pubsub channel for commands sent by a main process to workers or to other main processes. */
 export const COMMAND_PUBSUB_CHANNEL = 'n8n.commands';

--- a/packages/cli/src/scaling/execution-category.ts
+++ b/packages/cli/src/scaling/execution-category.ts
@@ -1,0 +1,20 @@
+import type { WorkflowExecuteMode } from 'n8n-workflow';
+
+import type { ExecutionCategory } from './scaling.types';
+
+/** Map an execution mode to its pool category. Returns `undefined` for modes that run locally. */
+export function getExecutionCategory(mode: WorkflowExecuteMode): ExecutionCategory | undefined {
+	switch (mode) {
+		case 'webhook':
+		case 'trigger':
+		case 'chat':
+			return 'production';
+		case 'manual':
+		case 'retry':
+			return 'manual';
+		case 'evaluation':
+			return 'evaluation';
+		default:
+			return undefined;
+	}
+}

--- a/packages/cli/src/scaling/pool-config.service.ts
+++ b/packages/cli/src/scaling/pool-config.service.ts
@@ -1,0 +1,39 @@
+import { SettingsRepository } from '@n8n/db';
+import { Service } from '@n8n/di';
+import { jsonParse } from 'n8n-workflow';
+
+import { CacheService } from '@/services/cache/cache.service';
+
+import { poolQueueName } from './constants';
+import type { ExecutionCategory, PoolAssignment } from './scaling.types';
+
+const SETTINGS_KEY = 'workerPools.assignment';
+
+/** Resolves execution categories to worker pool queue names using DB-backed settings with cache. */
+@Service()
+export class PoolConfigService {
+	constructor(
+		private readonly settingsRepository: SettingsRepository,
+		private readonly cacheService: CacheService,
+	) {}
+
+	async getQueueNameForCategory(category: ExecutionCategory): Promise<string> {
+		const assignment = await this.getPoolAssignment();
+		return poolQueueName(assignment[category]);
+	}
+
+	async getPoolAssignment(): Promise<PoolAssignment> {
+		const cached = await this.cacheService.get<string>(SETTINGS_KEY);
+		if (cached !== undefined) {
+			return jsonParse<PoolAssignment>(cached, { fallbackValue: {} });
+		}
+
+		const row = await this.settingsRepository.findByKey(SETTINGS_KEY);
+		const assignment = row?.value
+			? jsonParse<PoolAssignment>(row.value, { fallbackValue: {} })
+			: {};
+
+		await this.cacheService.set(SETTINGS_KEY, JSON.stringify(assignment));
+		return assignment;
+	}
+}

--- a/packages/cli/src/scaling/pool-config.service.ts
+++ b/packages/cli/src/scaling/pool-config.service.ts
@@ -4,7 +4,7 @@ import { jsonParse } from 'n8n-workflow';
 
 import { CacheService } from '@/services/cache/cache.service';
 
-import { poolQueueName } from './constants';
+import { poolQueueName } from './queue-name';
 import type { ExecutionCategory, PoolAssignment } from './scaling.types';
 
 const SETTINGS_KEY = 'workerPools.assignment';

--- a/packages/cli/src/scaling/queue-name.ts
+++ b/packages/cli/src/scaling/queue-name.ts
@@ -1,8 +1,8 @@
 import type { InstanceSettings } from 'n8n-core';
 
-type InstanceType = InstanceSettings['instanceType'];
+import { DEFAULT_QUEUE_NAME } from './constants';
 
-const DEFAULT_QUEUE_NAME = 'jobs';
+type InstanceType = InstanceSettings['instanceType'];
 
 export function resolveQueueName(instanceType: InstanceType, poolName: string): string {
 	if (instanceType !== 'worker' || poolName === '') return DEFAULT_QUEUE_NAME;

--- a/packages/cli/src/scaling/queue-name.ts
+++ b/packages/cli/src/scaling/queue-name.ts
@@ -1,10 +1,15 @@
 import type { InstanceSettings } from 'n8n-core';
 
-import { DEFAULT_QUEUE_NAME } from './constants';
+export const DEFAULT_QUEUE_NAME = 'jobs';
 
 type InstanceType = InstanceSettings['instanceType'];
 
 export function resolveQueueName(instanceType: InstanceType, poolName: string): string {
 	if (instanceType !== 'worker' || poolName === '') return DEFAULT_QUEUE_NAME;
+	return `${DEFAULT_QUEUE_NAME}-${poolName}`;
+}
+
+export function poolQueueName(poolName: string | undefined): string {
+	if (!poolName) return DEFAULT_QUEUE_NAME;
 	return `${DEFAULT_QUEUE_NAME}-${poolName}`;
 }

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -14,7 +14,7 @@ import { HIGHEST_SHUTDOWN_PRIORITY } from '@/constants';
 import { EventService } from '@/events/event.service';
 import { assertNever } from '@/utils';
 
-import { JOB_TYPE_NAME } from './constants';
+import { DEFAULT_QUEUE_NAME, JOB_TYPE_NAME } from './constants';
 import { JobProcessor } from './job-processor';
 import { resolveQueueName } from './queue-name';
 import type {
@@ -32,7 +32,12 @@ import type {
 
 @Service()
 export class ScalingService {
-	private queue: JobQueue;
+	/** Bull queues keyed by queue name. Pool queues are created lazily. */
+	private readonly queueByName = new Map<string, JobQueue>();
+
+	private initialQueueName = DEFAULT_QUEUE_NAME;
+
+	private createBullQueue?: (name: string) => JobQueue;
 
 	private jobResults = new Map<string, JobFinishedProps>();
 
@@ -49,35 +54,62 @@ export class ScalingService {
 		this.logger = this.logger.scoped('scaling');
 	}
 
+	private get defaultQueue(): JobQueue {
+		const queue = this.queueByName.get(this.initialQueueName);
+		if (!queue) throw new UnexpectedError('This method must be called after `setupQueue`');
+		return queue;
+	}
+
+	/** Return an existing queue or lazily create a new Bull queue for the given name. */
+	async getOrCreateQueue(queueName: string): Promise<JobQueue> {
+		const existing = this.queueByName.get(queueName);
+		if (existing) return existing;
+
+		if (!this.createBullQueue) {
+			throw new UnexpectedError('This method must be called after `setupQueue`');
+		}
+
+		const queue = this.createBullQueue(queueName);
+		this.registerListenersForQueue(queue);
+		this.queueByName.set(queueName, queue);
+		this.logger.debug(`Created queue "${queueName}"`);
+		return queue;
+	}
+
 	// #region Lifecycle
 
 	async setupQueue() {
+		if (this.queueByName.size > 0) return;
+
 		const { default: BullQueue } = await import('bull');
 		const { RedisClientService } = await import('@/services/redis-client.service');
-
-		if (this.queue) return;
 
 		const service = Container.get(RedisClientService);
 
 		const bullPrefix = this.globalConfig.queue.bull.prefix;
 		const prefix = service.toValidPrefix(bullPrefix);
+		const settings = { ...this.globalConfig.queue.bull.settings, maxStalledCount: 0 };
+
+		this.createBullQueue = (name: string) =>
+			new BullQueue(name, {
+				prefix,
+				settings,
+				createClient: (type) => service.createClient({ type: `${type}(bull)` }),
+			});
 
 		const poolName = this.globalConfig.queue.workerPool.name;
 		const queueName = resolveQueueName(this.instanceSettings.instanceType, poolName);
 
-		this.queue = new BullQueue(queueName, {
-			prefix,
-			settings: { ...this.globalConfig.queue.bull.settings, maxStalledCount: 0 },
-			createClient: (type) => service.createClient({ type: `${type}(bull)` }),
-		});
+		const queue = this.createBullQueue(queueName);
+		this.registerListenersForQueue(queue);
+		this.queueByName.set(queueName, queue);
+		this.initialQueueName = queueName;
 
 		this.logger.debug('Queue setup', {
 			queueName,
 			poolName,
 			instanceType: this.instanceSettings.instanceType,
 		});
-
-		this.registerListeners();
 
 		if (this.instanceSettings.isLeader) this.scheduleQueueRecovery(0);
 
@@ -115,7 +147,7 @@ export class ScalingService {
 		this.assertWorker();
 		this.assertQueue();
 
-		void this.queue.process(JOB_TYPE_NAME, concurrency, async (job: Job) => {
+		void this.defaultQueue.process(JOB_TYPE_NAME, concurrency, async (job: Job) => {
 			try {
 				this.eventService.emit('job-dequeued', {
 					executionId: job.data.executionId,
@@ -171,20 +203,22 @@ export class ScalingService {
 		else if (instanceType === 'worker') await this.stopWorker();
 	}
 
-	private async pauseQueue() {
-		await this.queue.pause(true, true); // no more jobs will be enqueued or picked up
-		this.logger.debug('Paused queue');
+	private async pauseAllQueues() {
+		await Promise.all(
+			[...this.queueByName.values()].map(async (queue) => await queue.pause(true, true)),
+		);
+		this.logger.debug('Paused all queues');
 	}
 
 	private async stopMain() {
-		if (this.instanceSettings.isSingleMain) await this.pauseQueue();
+		if (this.instanceSettings.isSingleMain) await this.pauseAllQueues();
 
 		if (this.queueRecoveryContext.timeout) this.stopQueueRecovery();
 		if (this.isQueueMetricsEnabled) this.stopQueueMetrics();
 	}
 
 	private async stopWorker() {
-		await this.pauseQueue();
+		await this.pauseAllQueues();
 
 		let count = 0;
 
@@ -200,7 +234,7 @@ export class ScalingService {
 	}
 
 	async pingQueue() {
-		await this.queue.client.ping();
+		await this.defaultQueue.client.ping();
 	}
 
 	// #endregion
@@ -215,18 +249,18 @@ export class ScalingService {
 	}
 
 	async getPendingJobCounts() {
-		const { active, waiting } = await this.queue.getJobCounts();
-
+		let active = 0;
+		let waiting = 0;
+		for (const queue of this.queueByName.values()) {
+			const counts = await queue.getJobCounts();
+			active += counts.active;
+			waiting += counts.waiting;
+		}
 		return { active, waiting };
 	}
 
-	/**
-	 * Add a job to the queue.
-	 *
-	 * @param jobData Data of the job to add to the queue.
-	 * @param priority Priority of the job, from `1` (highest) to `MAX_SAFE_INTEGER` (lowest).
-	 */
-	async addJob(jobData: JobData, { priority }: { priority: number }) {
+	/** Add a job to the given queue (or the default queue). Priority: `1` (highest) to `MAX_SAFE_INTEGER` (lowest). */
+	async addJob(jobData: JobData, { priority, queueName }: { priority: number; queueName?: string }) {
 		strict(priority > 0 && priority <= Number.MAX_SAFE_INTEGER);
 
 		const jobOptions: JobOptions = {
@@ -235,12 +269,20 @@ export class ScalingService {
 			removeOnFail: true,
 		};
 
-		const job = await this.queue.add(JOB_TYPE_NAME, jobData, jobOptions);
+		const targetQueue = queueName
+			? await this.getOrCreateQueue(queueName)
+			: this.defaultQueue;
+
+		const job = await targetQueue.add(JOB_TYPE_NAME, jobData, jobOptions);
 
 		const { executionId } = jobData;
 		const jobId = job.id;
 
-		this.logger.info(`Enqueued execution ${executionId} (job ${jobId})`, { executionId, jobId });
+		this.logger.info(`Enqueued execution ${executionId} (job ${jobId})`, {
+			executionId,
+			jobId,
+			...(queueName && queueName !== DEFAULT_QUEUE_NAME ? { queueName } : {}),
+		});
 		this.eventService.emit('job-enqueued', {
 			executionId,
 			workflowId: jobData.workflowId,
@@ -252,13 +294,20 @@ export class ScalingService {
 	}
 
 	async getJob(jobId: JobId) {
-		return await this.queue.getJob(jobId);
+		for (const queue of this.queueByName.values()) {
+			const job = await queue.getJob(jobId);
+			if (job) return job;
+		}
+		return null;
 	}
 
 	async findJobsByStatus(statuses: JobStatus[]) {
-		const jobs = await this.queue.getJobs(statuses);
-
-		return jobs.filter((job) => job !== null);
+		const allJobs: Job[] = [];
+		for (const queue of this.queueByName.values()) {
+			const jobs = await queue.getJobs(statuses);
+			allJobs.push(...jobs.filter((job): job is Job => job !== null));
+		}
+		return allJobs;
 	}
 
 	async stopJob(job: Job) {
@@ -296,26 +345,26 @@ export class ScalingService {
 
 	// #region Listeners
 
-	private registerListeners() {
+	private registerListenersForQueue(queue: JobQueue) {
 		const { instanceType } = this.instanceSettings;
 		if (instanceType === 'main' || instanceType === 'webhook') {
-			this.registerMainOrWebhookListeners();
+			this.registerMainOrWebhookListeners(queue);
 		} else if (instanceType === 'worker') {
-			this.registerWorkerListeners();
+			this.registerWorkerListeners(queue);
 		}
 	}
 
 	/**
 	 * Register listeners on a `worker` process for Bull queue events.
 	 */
-	private registerWorkerListeners() {
-		this.queue.on('global:progress', (jobId: JobId, msg: unknown) => {
+	private registerWorkerListeners(queue: JobQueue) {
+		queue.on('global:progress', (jobId: JobId, msg: unknown) => {
 			if (!this.isJobMessage(msg)) return;
 
 			if (msg.kind === 'abort-job') this.jobProcessor.stopJob(jobId);
 		});
 
-		this.queue.on('error', (error: Error) => {
+		queue.on('error', (error: Error) => {
 			if ('code' in error && error.code === 'ECONNREFUSED') return; // handled by RedisClientService.retryStrategy
 
 			/**
@@ -337,8 +386,8 @@ export class ScalingService {
 	/**
 	 * Register listeners on a `main` or `webhook` process for Bull queue events.
 	 */
-	private registerMainOrWebhookListeners() {
-		this.queue.on('error', (error: Error) => {
+	private registerMainOrWebhookListeners(queue: JobQueue) {
+		queue.on('error', (error: Error) => {
 			if ('code' in error && error.code === 'ECONNREFUSED') return; // handled by RedisClientService.retryStrategy
 
 			this.logger.error('Queue errored', { error });
@@ -346,7 +395,7 @@ export class ScalingService {
 			throw error;
 		});
 
-		this.queue.on('global:progress', (jobId: JobId, msg: unknown) => {
+		queue.on('global:progress', (jobId: JobId, msg: unknown) => {
 			if (!this.isJobMessage(msg)) return;
 
 			// completion and failure are reported via `global:progress` to convey more details
@@ -430,8 +479,8 @@ export class ScalingService {
 		});
 
 		if (this.isQueueMetricsEnabled) {
-			this.queue.on('global:completed', () => this.jobCounters.completed++);
-			this.queue.on('global:failed', () => this.jobCounters.failed++);
+			queue.on('global:completed', () => this.jobCounters.completed++);
+			queue.on('global:failed', () => this.jobCounters.failed++);
 		}
 	}
 
@@ -512,7 +561,7 @@ export class ScalingService {
 	}
 
 	private assertQueue() {
-		if (this.queue) return;
+		if (this.queueByName.size > 0) return;
 
 		throw new UnexpectedError('This method must be called after `setupQueue`');
 	}

--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -14,9 +14,9 @@ import { HIGHEST_SHUTDOWN_PRIORITY } from '@/constants';
 import { EventService } from '@/events/event.service';
 import { assertNever } from '@/utils';
 
-import { DEFAULT_QUEUE_NAME, JOB_TYPE_NAME } from './constants';
+import { JOB_TYPE_NAME } from './constants';
 import { JobProcessor } from './job-processor';
-import { resolveQueueName } from './queue-name';
+import { DEFAULT_QUEUE_NAME, resolveQueueName } from './queue-name';
 import type {
 	JobQueue,
 	Job,
@@ -260,7 +260,10 @@ export class ScalingService {
 	}
 
 	/** Add a job to the given queue (or the default queue). Priority: `1` (highest) to `MAX_SAFE_INTEGER` (lowest). */
-	async addJob(jobData: JobData, { priority, queueName }: { priority: number; queueName?: string }) {
+	async addJob(
+		jobData: JobData,
+		{ priority, queueName }: { priority: number; queueName?: string },
+	) {
 		strict(priority > 0 && priority <= Number.MAX_SAFE_INTEGER);
 
 		const jobOptions: JobOptions = {
@@ -269,9 +272,7 @@ export class ScalingService {
 			removeOnFail: true,
 		};
 
-		const targetQueue = queueName
-			? await this.getOrCreateQueue(queueName)
-			: this.defaultQueue;
+		const targetQueue = queueName ? await this.getOrCreateQueue(queueName) : this.defaultQueue;
 
 		const job = await targetQueue.add(JOB_TYPE_NAME, jobData, jobOptions);
 

--- a/packages/cli/src/scaling/scaling.types.ts
+++ b/packages/cli/src/scaling/scaling.types.ts
@@ -15,6 +15,10 @@ export type Job = Bull.Job<JobData>;
 
 export type JobId = Job['id'];
 
+export type ExecutionCategory = 'production' | 'manual' | 'evaluation';
+
+export type PoolAssignment = Partial<Record<ExecutionCategory, string>>;
+
 export type JobData = {
 	workflowId: string;
 	executionId: string;
@@ -24,6 +28,7 @@ export type JobData = {
 	restartExecutionId?: string;
 	projectId?: string;
 	projectName?: string;
+	poolName?: string;
 
 	// MCP-specific fields for queue mode support
 	/** Whether this execution was triggered by an MCP tool call. */

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -47,6 +47,9 @@ import { CredentialsPermissionChecker } from '@/executions/pre-execution-checks'
 import { ExternalHooks } from '@/external-hooks';
 import { ManualExecutionService } from '@/manual-execution.service';
 import { NodeTypes } from '@/node-types';
+import { poolQueueName } from '@/scaling/constants';
+import { getExecutionCategory } from '@/scaling/execution-category';
+import type { PoolConfigService } from '@/scaling/pool-config.service';
 import type { ScalingService } from '@/scaling/scaling.service';
 import type { Job, JobData } from '@/scaling/scaling.types';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
@@ -73,6 +76,8 @@ function flushResponse(res: { flush?: () => void }) {
 @Service()
 export class WorkflowRunner {
 	private scalingService: ScalingService;
+
+	private poolConfigService: PoolConfigService;
 
 	constructor(
 		private readonly logger: Logger,
@@ -493,6 +498,22 @@ export class WorkflowRunner {
 		realtime?: boolean,
 		restartExecutionId?: string,
 	): Promise<void> {
+		if (!this.scalingService) {
+			const { ScalingService } = await import('@/scaling/scaling.service');
+			this.scalingService = Container.get(ScalingService);
+			await this.scalingService.setupQueue();
+		}
+
+		if (!this.poolConfigService) {
+			const { PoolConfigService } = await import('@/scaling/pool-config.service');
+			this.poolConfigService = Container.get(PoolConfigService);
+		}
+
+		const category = getExecutionCategory(data.executionMode);
+		const poolAssignment = await this.poolConfigService.getPoolAssignment();
+		const poolName = category ? poolAssignment[category] : undefined;
+		const queueName = poolQueueName(poolName);
+
 		const jobData: JobData = {
 			workflowId,
 			executionId,
@@ -502,6 +523,7 @@ export class WorkflowRunner {
 			restartExecutionId,
 			projectId: data.projectId,
 			projectName: data.projectName,
+			poolName,
 			// MCP-specific fields for queue mode support
 			isMcpExecution: data.isMcpExecution,
 			mcpType: data.mcpType,
@@ -510,18 +532,12 @@ export class WorkflowRunner {
 			mcpToolCall: data.mcpToolCall,
 		};
 
-		if (!this.scalingService) {
-			const { ScalingService } = await import('@/scaling/scaling.service');
-			this.scalingService = Container.get(ScalingService);
-			await this.scalingService.setupQueue();
-		}
-
 		// TODO: For realtime jobs should probably also not do retry or not retry if they are older than x seconds.
 		//       Check if they get retried by default and how often.
 		let job: Job;
 		let lifecycleHooks: ExecutionLifecycleHooks;
 		try {
-			job = await this.scalingService.addJob(jobData, { priority: realtime ? 50 : 100 });
+			job = await this.scalingService.addJob(jobData, { priority: realtime ? 50 : 100, queueName });
 
 			lifecycleHooks = getLifecycleHooksForScalingMain(data, executionId);
 

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -509,10 +509,7 @@ export class WorkflowRunner {
 			this.poolConfigService = Container.get(PoolConfigService);
 		}
 
-		const category = getExecutionCategory(data.executionMode);
-		const poolAssignment = await this.poolConfigService.getPoolAssignment();
-		const poolName = category ? poolAssignment[category] : undefined;
-		const queueName = poolQueueName(poolName);
+		const { queueName, poolName } = await this.getQueueForWorkflow(data);
 
 		const jobData: JobData = {
 			workflowId,
@@ -675,6 +672,16 @@ export class WorkflowRunner {
 		});
 
 		this.activeExecutions.attachWorkflowExecution(executionId, workflowExecution);
+	}
+
+	private async getQueueForWorkflow(
+		data: IWorkflowExecutionDataProcess,
+	): Promise<{ queueName: string; poolName: string | undefined }> {
+		const category = getExecutionCategory(data.executionMode);
+		const poolAssignment = await this.poolConfigService.getPoolAssignment();
+		const poolName = category ? poolAssignment[category] : undefined;
+
+		return { queueName: poolQueueName(poolName), poolName };
 	}
 
 	/**

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -47,7 +47,7 @@ import { CredentialsPermissionChecker } from '@/executions/pre-execution-checks'
 import { ExternalHooks } from '@/external-hooks';
 import { ManualExecutionService } from '@/manual-execution.service';
 import { NodeTypes } from '@/node-types';
-import { poolQueueName } from '@/scaling/constants';
+import { poolQueueName } from '@/scaling/queue-name';
 import { getExecutionCategory } from '@/scaling/execution-category';
 import type { PoolConfigService } from '@/scaling/pool-config.service';
 import type { ScalingService } from '@/scaling/scaling.service';


### PR DESCRIPTION
## Summary

Adds execution-to-pool routing on the main process side (step 3 of dedicated worker pools). When a workflow execution is enqueued, the system now determines which worker pool queue to target based on the execution category (production, manual, or evaluation) and a DB-backed pool assignment setting.

**Key changes:**

- `ScalingService` manages multiple Bull queues via a `Map`, creating pool queues lazily on first use. Listeners, shutdown, recovery, and metrics all operate across all queues.
- `WorkflowRunner.enqueueExecution()` resolves the target pool from `PoolConfigService` and passes the queue name to `ScalingService.addJob()`.
- New `PoolConfigService` reads pool assignments from the settings table with a cache layer.
- New `getExecutionCategory()` utility maps `WorkflowExecuteMode` to `ExecutionCategory` (production/manual/evaluation).
- `DEFAULT_QUEUE_NAME` and `poolQueueName()` consolidated in `queue-name.ts`.
- Fully backward compatible: when no pools are configured, all jobs route to the default `'jobs'` queue.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Part of the dedicated worker pools feature -->

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI