### PR TITLE
feat: Add ephemeralNode:read and ephemeralNode:execute scopes (no-changelog)

### DIFF
--- a/packages/@n8n/permissions/src/__tests__/__snapshots__/scope-information.test.ts.snap
+++ b/packages/@n8n/permissions/src/__tests__/__snapshots__/scope-information.test.ts.snap
@@ -204,6 +204,9 @@ exports[`Scope Information > ensure scopes are defined correctly 1`] = `
   "roleMappingRule:delete",
   "roleMappingRule:list",
   "roleMappingRule:*",
+  "ephemeralNode:read",
+  "ephemeralNode:execute",
+  "ephemeralNode:*",
   "*",
 ]
 `;

--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -70,6 +70,7 @@ export const RESOURCES = {
 	credentialResolver: [...DEFAULT_OPERATIONS] as const,
 	instanceAi: ['message', 'manage', 'gateway'] as const,
 	roleMappingRule: [...DEFAULT_OPERATIONS] as const,
+	ephemeralNode: ['read', 'execute'] as const,
 } as const;
 
 export const API_KEY_RESOURCES = {
@@ -90,6 +91,7 @@ export const API_KEY_RESOURCES = {
 	dataTableColumn: ['create', 'read', 'delete', 'update'] as const,
 	folder: ['create', 'delete', 'read', 'update', 'list'] as const,
 	insights: ['read'] as const,
+	ephemeralNode: ['read', 'execute'] as const,
 } as const;
 
 export const PROJECT_OWNER_ROLE_SLUG = 'project:personalOwner';

--- a/packages/@n8n/permissions/src/public-api-permissions.ee.ts
+++ b/packages/@n8n/permissions/src/public-api-permissions.ee.ts
@@ -70,6 +70,8 @@ export const OWNER_API_KEY_SCOPES: ApiKeyScope[] = [
 	'dataTableColumn:update',
 	'dataTableColumn:delete',
 	'insights:read',
+	'ephemeralNode:read',
+	'ephemeralNode:execute',
 ];
 
 export const ADMIN_API_KEY_SCOPES: ApiKeyScope[] = OWNER_API_KEY_SCOPES;
@@ -120,6 +122,8 @@ export const MEMBER_API_KEY_SCOPES: ApiKeyScope[] = [
 	'dataTableColumn:update',
 	'dataTableColumn:delete',
 	'insights:read',
+	'ephemeralNode:read',
+	'ephemeralNode:execute',
 ];
 
 export const CHAT_USER_API_KEY_SCOPES: ApiKeyScope[] = [];
@@ -167,6 +171,8 @@ export const API_KEY_SCOPES_FOR_IMPLICIT_PERSONAL_PROJECT: ApiKeyScope[] = [
 	'dataTableColumn:update',
 	'dataTableColumn:delete',
 	'insights:read',
+	'ephemeralNode:read',
+	'ephemeralNode:execute',
 ];
 
 const MAP_ROLE_SCOPES: Record<GlobalRole, ApiKeyScope[]> = {

--- a/packages/@n8n/permissions/src/roles/scopes/global-scopes.ee.ts
+++ b/packages/@n8n/permissions/src/roles/scopes/global-scopes.ee.ts
@@ -148,6 +148,8 @@ export const GLOBAL_OWNER_SCOPES: Scope[] = [
 	'roleMappingRule:update',
 	'roleMappingRule:delete',
 	'roleMappingRule:list',
+	'ephemeralNode:read',
+	'ephemeralNode:execute',
 ];
 
 export const GLOBAL_ADMIN_SCOPES = GLOBAL_OWNER_SCOPES.concat();
@@ -181,6 +183,7 @@ export const GLOBAL_MEMBER_SCOPES: Scope[] = [
 	'credentialResolver:list',
 	'instanceAi:message',
 	'instanceAi:gateway',
+	'ephemeralNode:read',
 ];
 
 export const GLOBAL_CHAT_USER_SCOPES: Scope[] = [

--- a/packages/@n8n/permissions/src/roles/scopes/project-scopes.ee.ts
+++ b/packages/@n8n/permissions/src/roles/scopes/project-scopes.ee.ts
@@ -60,6 +60,8 @@ export const REGULAR_PROJECT_ADMIN_SCOPES: Scope[] = [
 	'projectVariable:create',
 	'projectVariable:update',
 	'projectVariable:delete',
+	'ephemeralNode:read',
+	'ephemeralNode:execute',
 ];
 
 export const PERSONAL_PROJECT_OWNER_SCOPES: Scope[] = [
@@ -106,6 +108,8 @@ export const PERSONAL_PROJECT_OWNER_SCOPES: Scope[] = [
 	'dataTable:writeRow',
 	'dataTable:readColumn',
 	'dataTable:writeColumn',
+	'ephemeralNode:read',
+	'ephemeralNode:execute',
 ];
 
 export const PROJECT_EDITOR_SCOPES: Scope[] = [
@@ -152,6 +156,8 @@ export const PROJECT_EDITOR_SCOPES: Scope[] = [
 	'projectVariable:create',
 	'projectVariable:update',
 	'projectVariable:delete',
+	'ephemeralNode:read',
+	'ephemeralNode:execute',
 ];
 
 export const PROJECT_VIEWER_SCOPES: Scope[] = [
@@ -173,6 +179,7 @@ export const PROJECT_VIEWER_SCOPES: Scope[] = [
 	'dataTable:readColumn',
 	'projectVariable:list',
 	'projectVariable:read',
+	'ephemeralNode:read',
 ];
 
 export const PROJECT_CHAT_USER_SCOPES: Scope[] = ['agent:execute', 'workflow:execute-chat'];

--- a/packages/@n8n/permissions/src/scope-information.ts
+++ b/packages/@n8n/permissions/src/scope-information.ts
@@ -88,4 +88,12 @@ export const scopeInformation: Partial<Record<Scope, ScopeInformation>> = {
 		displayName: 'Read Insights',
 		description: 'Allows reading insights data.',
 	},
+	'ephemeralNode:read': {
+		displayName: 'Discover Ephemeral Nodes',
+		description: 'Allows discovering nodes available for ephemeral single-node execution.',
+	},
+	'ephemeralNode:execute': {
+		displayName: 'Execute Ephemeral Node',
+		description: 'Allows executing a single node inline without a saved workflow.',
+	},
 };

--- a/packages/@n8n/permissions/src/utilities/__tests__/get-resource-permissions.test.ts
+++ b/packages/@n8n/permissions/src/utilities/__tests__/get-resource-permissions.test.ts
@@ -50,6 +50,7 @@ describe('permissions', () => {
 			credentialResolver: {},
 			instanceAi: {},
 			roleMappingRule: {},
+			ephemeralNode: {},
 		});
 	});
 	it('getResourcePermissions', () => {
@@ -177,6 +178,7 @@ describe('permissions', () => {
 			credentialResolver: {},
 			instanceAi: {},
 			roleMappingRule: {},
+			ephemeralNode: {},
 		};
 
 		expect(getResourcePermissions(scopes)).toEqual(permissionRecord);

--- a/packages/frontend/editor-ui/src/app/stores/rbac.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/rbac.store.ts
@@ -56,6 +56,7 @@ export const useRBACStore = defineStore(STORES.RBAC, () => {
 		instanceAi: {},
 		securitySettings: {},
 		roleMappingRule: {},
+		ephemeralNode: {},
 	});
 
 	function addGlobalRole(role: Role) {


### PR DESCRIPTION
## Summary

Defines two new RBAC scopes — `ephemeralNode:read` and `ephemeralNode:execute` — that will gate the upcoming `GET /api/v1/ephemeral-nodes` discovery endpoint and the `POST /api/v1/ephemeral-nodes/execute` endpoint. This is the foundation slice (Engineer A) of the larger effort to expose `EphemeralNodeExecutor` over the public API so external AI systems (Claude, etc.) can discover and run individual nodes.

What this PR does *not* do: ship the endpoints themselves, change executor semantics, or affect any existing behaviour. The scopes exist but nothing checks them yet — downstream PRs from the same base branch will attach them to the new handlers.

Role coverage follows the `workflow:execute` precedent:

| Role | `ephemeralNode:read` | `ephemeralNode:execute` |
|---|---|---|
| Global owner / admin | ✅ | ✅ |
| Global member | ✅ | ❌ (granted via project) |
| Project admin / editor / personal-owner | ✅ | ✅ |
| Project viewer | ✅ | ❌ |
| Chat user | ❌ | ❌ |

API key support: both scopes are addable to API keys (owner/member arrays + the implicit-personal-project array), so external clients can be granted exactly the surface they need without overbroad permissions.

Files changed (8, +32 lines):
- `packages/@n8n/permissions/src/constants.ee.ts` — new `ephemeralNode` resource in `RESOURCES` and `API_KEY_RESOURCES`
- `packages/@n8n/permissions/src/scope-information.ts` — display names + descriptions
- `packages/@n8n/permissions/src/roles/scopes/global-scopes.ee.ts` — owner/admin/member assignments
- `packages/@n8n/permissions/src/roles/scopes/project-scopes.ee.ts` — admin/personal-owner/editor/viewer assignments
- `packages/@n8n/permissions/src/public-api-permissions.ee.ts` — owner/member/implicit-personal-project API key arrays
- `packages/@n8n/permissions/src/utilities/__tests__/get-resource-permissions.test.ts` — added `ephemeralNode: {}` to both empty- and non-empty-scope test cases
- `packages/@n8n/permissions/src/__tests__/__snapshots__/scope-information.test.ts.snap` — regenerated
- `packages/frontend/editor-ui/src/app/stores/rbac.store.ts` — added `ephemeralNode: {}` to `scopesByResourceId` so the frontend `Resource` type stays exhaustive

## Related Linear tickets, Github issues, and Community forum posts

<!-- Link the Linear ticket for this engineering stream when it's filed. -->

Part of the broader plan in `EPHEMERAL_NODES_PUBLIC_API_PLAN.md` (Engineer A stream).

## Manual testing steps

### 1. Verify the new scopes exist and are exhaustive

```bash
cd packages/@n8n/permissions
pnpm test        # 90/90 should pass, including the snapshot
pnpm lint
pnpm typecheck
```

Open `src/__tests__/__snapshots__/scope-information.test.ts.snap` and confirm the tail contains:

```
"ephemeralNode:read",
"ephemeralNode:execute",
"ephemeralNode:*",
"*",
```

### 2. Verify role-to-scope wiring

```bash
pnpm --filter=@n8n/permissions build

node -e "
const m = require('./packages/@n8n/permissions/dist');
console.log('Owner has read+execute:',
  m.GLOBAL_OWNER_SCOPES.includes('ephemeralNode:read') &&
  m.GLOBAL_OWNER_SCOPES.includes('ephemeralNode:execute'));
console.log('Member has read only:',
  m.GLOBAL_MEMBER_SCOPES.includes('ephemeralNode:read') &&
  !m.GLOBAL_MEMBER_SCOPES.includes('ephemeralNode:execute'));
console.log('Project viewer has read only:',
  m.PROJECT_VIEWER_SCOPES.includes('ephemeralNode:read') &&
  !m.PROJECT_VIEWER_SCOPES.includes('ephemeralNode:execute'));
"
```

All three lines should print `true`.

### 3. Verify API key surface

Boot n8n locally:

```bash
pnpm dev
```

- Sign in as the instance owner.
- Settings → API → **Create API key**.
- In the scope picker, confirm **Discover Ephemeral Nodes** and **Execute Ephemeral Node** appear as selectable options with the descriptions from `scope-information.ts`.
- Create the key, copy the JWT, then call:

  ```bash
  curl -H "X-N8N-API-KEY: $KEY" "$N8N/api/v1/discover" | jq '.scopes' | grep ephemeralNode
  ```

  Both scope strings should appear in the response — proving the `/discover` capability listing picks up the new resource without any other code changes.

### 4. Verify nothing existing is broken

```bash
pnpm --filter=@n8n/permissions test
pnpm --filter=n8n-editor-ui lint -- src/app/stores/rbac.store.ts
```

Run the permissions integration tests in `packages/cli/test/integration/public-api/` if you want extra confidence — they enumerate API key scopes for various roles and should continue passing because owner/member arrays only grew (never shrunk).

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. — N/A: scopes have no documented surface yet; doc PR will accompany the endpoint PRs (Engineers B/C)
- [x] Tests included. — `get-resource-permissions.test.ts` exercises the new resource in both empty- and populated-scope cases; the scope-information snapshot covers `ALL_SCOPES` enumeration
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported) — N/A: not a fix
