### PR TITLE
feat(API): Add list endpoint for ephemeral nodes

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/ephemeral-nodes.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/ephemeral-nodes.handler.ts
@@ -1,0 +1,28 @@
+// TODO(scope): swap to `apiKeyHasScopeWithGlobalScopeFallback({ scope: 'node:read' })`
+// once the permissions PR adds `node:read` to the ApiKeyScope union and the role
+// scope sets.
+
+import type { AuthenticatedRequest } from '@n8n/db';
+
+import type { PaginatedRequest } from '@/public-api/types';
+
+import type { PublicAPIEndpoint } from '../../shared/handler.types';
+import { validCursor } from '../../shared/middlewares/global.middleware';
+
+type ListEphemeralNodesRequest = AuthenticatedRequest<{}, {}, {}, { nodeType?: string }> &
+	PaginatedRequest;
+
+type EphemeralNodesHandlers = {
+	listEphemeralNodes: PublicAPIEndpoint<ListEphemeralNodesRequest>;
+};
+
+const ephemeralNodesHandlers: EphemeralNodesHandlers = {
+	listEphemeralNodes: [
+		validCursor,
+		async (_req, res) => {
+			return res.json({ data: [], nextCursor: null });
+		},
+	],
+};
+
+export = ephemeralNodesHandlers;

--- a/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/spec/paths/ephemeral-nodes-list.yml
+++ b/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/spec/paths/ephemeral-nodes-list.yml
@@ -1,0 +1,29 @@
+get:
+  x-eov-operation-id: listEphemeralNodes
+  x-eov-operation-handler: v1/handlers/ephemeral-nodes/ephemeral-nodes.handler
+  tags:
+    - EphemeralNode
+  summary: List nodes that can be executed inline.
+  description: >
+    Returns the catalogue of nodes that can be executed via
+    `POST /ephemeral-nodes/execute`.
+  parameters:
+    - $ref: '../../../../shared/spec/parameters/limit.yml'
+    - $ref: '../../../../shared/spec/parameters/cursor.yml'
+    - name: nodeType
+      in: query
+      required: false
+      description: Filter to a single node type (e.g. `n8n-nodes-base.httpRequest`).
+      schema:
+        type: string
+  responses:
+    '200':
+      description: Operation successful.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ephemeralNodeList.yml'
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
+    '403':
+      $ref: '../../../../shared/spec/responses/forbidden.yml'

--- a/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/spec/schemas/ephemeralNode.yml
+++ b/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/spec/schemas/ephemeralNode.yml
@@ -1,0 +1,46 @@
+type: object
+description: >
+  A single node in the ephemeral-execution catalogue. Field values are
+  illustrative; the catalogue currently returns an empty list (population
+  tracked in follow-up).
+required:
+  - nodeType
+  - nodeTypeVersion
+  - displayName
+  - description
+properties:
+  nodeType:
+    type: string
+    description: The canonical node identifier passed to `/ephemeral-nodes/execute`.
+    example: n8n-nodes-base.httpRequest
+  nodeTypeVersion:
+    type: number
+    description: Version of the node type to execute.
+    example: 4.2
+  displayName:
+    type: string
+    description: Human-readable node name.
+    example: HTTP Request
+  description:
+    type: string
+    description: Short description of what the node does.
+  category:
+    type: string
+    description: Top-level node category (e.g. `Core Nodes`, `Communication`).
+  exampleParameters:
+    type: object
+    additionalProperties: true
+    description: An example `nodeParameters` payload demonstrating the minimum viable invocation.
+  requiredCredentialTypes:
+    type: array
+    items:
+      type: string
+    description: >
+      Credential type names this node accepts (matches the `type` field of
+      `GET /credentials` entries). Empty if the node needs no credential.
+  inputDataShape:
+    type: object
+    additionalProperties: true
+    description: >
+      Optional JSON-Schema-like description of the input data the node expects.
+      Present when the node has a strong input contract; omitted otherwise.

--- a/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/spec/schemas/ephemeralNodeList.yml
+++ b/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/spec/schemas/ephemeralNodeList.yml
@@ -1,0 +1,15 @@
+type: object
+required:
+  - data
+properties:
+  data:
+    type: array
+    items:
+      $ref: './ephemeralNode.yml'
+  nextCursor:
+    type: string
+    description: >
+      Paginate by setting the `cursor` parameter to this value on the next
+      request. `null` when there are no further pages.
+    nullable: true
+    example: MTIzZTQ1NjctZTg5Yi0xMmQzLWE0NTYtNDI2NjE0MTc0MDA

--- a/packages/cli/src/public-api/v1/openapi.yml
+++ b/packages/cli/src/public-api/v1/openapi.yml
@@ -44,6 +44,8 @@ tags:
     description: Operations about insights
   - name: Folders
     description: Operations about folders
+  - name: EphemeralNode
+    description: Operations about nodes runnable via single-node ephemeral execution
 
 paths:
   /audit:
@@ -140,6 +142,8 @@ paths:
     $ref: './handlers/folders/spec/paths/folders.yml'
   /projects/{projectId}/folders/{folderId}:
     $ref: './handlers/folders/spec/paths/folders.folderId.yml'
+  /ephemeral-nodes:
+    $ref: './handlers/ephemeral-nodes/spec/paths/ephemeral-nodes-list.yml'
 components:
   schemas:
     $ref: './shared/spec/schemas/_index.yml'

--- a/packages/cli/test/integration/public-api/ephemeral-nodes-discovery.test.ts
+++ b/packages/cli/test/integration/public-api/ephemeral-nodes-discovery.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Locks in the four-call discovery flow an external client (e.g. Claude) walks
+ * to drive `POST /ephemeral-nodes/execute`:
+ *
+ *   1. GET /credentials   → needs id, name, type per item
+ *   2. GET /projects      → needs id, name per item
+ *   3. GET /ephemeral-nodes → contract-only stub today
+ *   4. GET /discover      → must list all three resources for the caller
+ *
+ * If a field drops out of any of the response shapes this test catches it.
+ *
+ * NOTE: /ephemeral-nodes is currently auth-only (no scope gate) pending
+ * Engineer A's permissions PR. See `ephemeral-nodes.handler.ts` for context.
+ */
+
+import { createTeamProject, testDb } from '@n8n/backend-test-utils';
+import type { User } from '@n8n/db';
+
+import { saveCredential } from '../shared/db/credentials';
+import { createOwnerWithApiKey } from '../shared/db/users';
+import type { SuperAgentTest } from '../shared/types';
+import * as utils from '../shared/utils';
+
+const testServer = utils.setupTestServer({
+	endpointGroups: ['publicApi'],
+	enabledFeatures: ['feat:projectRole:admin'],
+	quotas: { 'quota:maxTeamProjects': -1 },
+});
+
+let owner: User;
+let authAgent: SuperAgentTest;
+
+beforeAll(async () => {
+	await utils.initCredentialsTypes();
+	owner = await createOwnerWithApiKey({
+		scopes: ['credential:list', 'project:list'],
+	});
+});
+
+beforeEach(async () => {
+	await testDb.truncate(['SharedCredentials', 'CredentialsEntity']);
+	authAgent = testServer.publicApiAgentFor(owner);
+});
+
+describe('Ephemeral nodes discovery flow contract', () => {
+	test('GET /credentials returns id, name, type for every item', async () => {
+		await saveCredential(
+			{ name: 'My GitHub', type: 'githubApi', data: { accessToken: 'x' } },
+			{ user: owner, role: 'credential:owner' },
+		);
+
+		const response = await authAgent.get('/credentials').expect(200);
+
+		expect(Array.isArray(response.body.data)).toBe(true);
+		expect(response.body.data.length).toBeGreaterThan(0);
+
+		for (const credential of response.body.data) {
+			expect(typeof credential.id).toBe('string');
+			expect(typeof credential.name).toBe('string');
+			expect(typeof credential.type).toBe('string');
+		}
+	});
+
+	test('GET /projects returns id, name for every item', async () => {
+		await createTeamProject();
+
+		const response = await authAgent.get('/projects').expect(200);
+
+		expect(Array.isArray(response.body.data)).toBe(true);
+		expect(response.body.data.length).toBeGreaterThan(0);
+
+		for (const project of response.body.data) {
+			expect(typeof project.id).toBe('string');
+			expect(typeof project.name).toBe('string');
+		}
+	});
+
+	test('GET /ephemeral-nodes returns the documented stub shape', async () => {
+		const response = await authAgent.get('/ephemeral-nodes').expect(200);
+
+		expect(response.body).toEqual({ data: [], nextCursor: null });
+	});
+
+	test('GET /discover surfaces credentials, projects, and ephemeralnode for the same API key', async () => {
+		const response = await authAgent.get('/discover').expect(200);
+
+		const resourceKeys = Object.keys(response.body.data.resources);
+		expect(resourceKeys).toEqual(
+			expect.arrayContaining(['credential', 'projects', 'ephemeralnode']),
+		);
+	});
+
+	// Skipped: flip to `test(...)` when Engineer A's permissions PR lands.
+	// Also add `'node:read'` to the `createOwnerWithApiKey` scopes in `beforeAll`.
+	// Sanity check that one API key can hold all three scopes Claude needs.
+	test.skip('A single API key can carry credential:list + project:list + node:read', async () => {
+		const response = await authAgent.get('/discover').expect(200);
+
+		expect(response.body.data.scopes).toEqual(
+			expect.arrayContaining(['credential:list', 'project:list', 'node:read']),
+		);
+	});
+});

--- a/packages/cli/test/integration/public-api/ephemeral-nodes.test.ts
+++ b/packages/cli/test/integration/public-api/ephemeral-nodes.test.ts
@@ -1,0 +1,123 @@
+import type { User } from '@n8n/db';
+
+import handlers from '@/public-api/v1/handlers/ephemeral-nodes/ephemeral-nodes.handler';
+
+import { createMemberWithApiKey, createOwnerWithApiKey } from '../shared/db/users';
+import type { SuperAgentTest } from '../shared/types';
+import * as utils from '../shared/utils';
+
+const testServer = utils.setupTestServer({ endpointGroups: ['publicApi'] });
+
+let owner: User;
+let member: User;
+let authOwnerAgent: SuperAgentTest;
+let authMemberAgent: SuperAgentTest;
+let authUnscopedAgent: SuperAgentTest;
+
+beforeAll(async () => {
+	owner = await createOwnerWithApiKey();
+	member = await createMemberWithApiKey();
+});
+
+beforeEach(() => {
+	authOwnerAgent = testServer.publicApiAgentFor(owner);
+	authMemberAgent = testServer.publicApiAgentFor(member);
+	// Skipped tests below reference an "unscoped" agent (an API key that does
+	// not hold `node:read`). Wire it up here so type-checking stays green and
+	// the body is ready to re-enable. Today it's the same as the member agent
+	// because there's no scope to lack.
+	authUnscopedAgent = testServer.publicApiAgentFor(member);
+});
+
+describe('GET /ephemeral-nodes', () => {
+	test('returns 401 without API key', async () => {
+		await testServer.publicApiAgentWithoutApiKey().get('/ephemeral-nodes').expect(401);
+	});
+
+	test('returns 200 with stub catalogue for any authenticated owner', async () => {
+		const response = await authOwnerAgent.get('/ephemeral-nodes').expect(200);
+
+		expect(response.body).toEqual({ data: [], nextCursor: null });
+	});
+
+	test('returns 200 with stub catalogue for any authenticated member', async () => {
+		const response = await authMemberAgent.get('/ephemeral-nodes').expect(200);
+
+		expect(response.body).toEqual({ data: [], nextCursor: null });
+	});
+
+	test('accepts the documented query params without rejecting', async () => {
+		// Validation only — the stub returns an empty list regardless.
+		const response = await authOwnerAgent
+			.get('/ephemeral-nodes')
+			.query({ nodeType: 'n8n-nodes-base.httpRequest', limit: 50 })
+			.expect(200);
+
+		expect(response.body).toEqual({ data: [], nextCursor: null });
+	});
+
+	// Skipped: flip to `test(...)` when Engineer A's permissions PR lands and
+	// the handler gates with `apiKeyHasScopeWithGlobalScopeFallback({ scope: 'node:read' })`.
+	// The owner/member fixtures will need explicit `{ scopes: [...] }` then — one
+	// holding `node:read`, one without.
+	test.skip('returns 403 without node:read scope', async () => {
+		await authUnscopedAgent.get('/ephemeral-nodes').expect(403);
+	});
+});
+
+describe('GET /discover lists ephemeral-nodes', () => {
+	// Discover treats `scope: null` endpoints as visible to everyone (see
+	// discover.service.ts — `ep.scope === null || scopeSet.has(ep.scope)`).
+	test('any authenticated owner sees the ephemeralnode resource', async () => {
+		const response = await authOwnerAgent.get('/discover').expect(200);
+
+		const resourceKeys = Object.keys(response.body.data.resources);
+		// Resource key derives from the OpenAPI `tags` entry (lower-cased).
+		// `EphemeralNode` → `ephemeralnode`.
+		expect(resourceKeys).toContain('ephemeralnode');
+
+		const ephemeralNodeResource = response.body.data.resources.ephemeralnode;
+		const operationIds = ephemeralNodeResource.endpoints.map(
+			(e: { operationId: string }) => e.operationId,
+		);
+		expect(operationIds).toContain('listEphemeralNodes');
+	});
+
+	test('any authenticated member also sees the ephemeralnode resource', async () => {
+		const response = await authMemberAgent.get('/discover').expect(200);
+
+		const resourceKeys = Object.keys(response.body.data.resources);
+		expect(resourceKeys).toContain('ephemeralnode');
+	});
+
+	// Skipped: flip to `test(...)` when the handler is scope-gated. Discover
+	// will then hide the resource from callers without `node:read`.
+	test.skip('owner without node:read does not see the ephemeralnode resource', async () => {
+		const response = await authUnscopedAgent.get('/discover').expect(200);
+
+		const resourceKeys = Object.keys(response.body.data.resources);
+		expect(resourceKeys).not.toContain('ephemeralnode');
+	});
+});
+
+describe('listEphemeralNodes handler middleware', () => {
+	// Swap-back guard: when the permissions PR adds `node:read`,
+	// this handler MUST be updated to gate with
+	// `apiKeyHasScopeWithGlobalScopeFallback({ scope: 'node:read' })`. That
+	// At that point this assertion flips and you need to:
+	//   1. Replace this test body with `expect(hasScopedMiddleware).toBe(true)`
+	//      (or just delete this suite — the 401/403 coverage proves auth+scope).
+	//   2. Uncomment the 403 case in the `GET /ephemeral-nodes` suite for callers
+	//      lacking `node:read`.
+	//   3. Uncomment the "without node:read does not see…" case in the discover suite.
+	test('handler is currently auth-only (no scope middleware) — swap when permissions PR lands', () => {
+		const middlewareChain = handlers.listEphemeralNodes as unknown as Array<
+			Record<string, unknown>
+		>;
+		const hasScopedMiddleware = middlewareChain.some(
+			(mw) => typeof mw === 'function' && '__apiKeyScope' in mw,
+		);
+
+		expect(hasScopedMiddleware).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Adds a new `GET /ephemeral-nodes` endpoint to the public API. This is the first piece of the ephemeral-node-executor public API surface,it returns the catalogue of nodes that external clients can later execute via `POST /ephemeral-nodes/execute`.

This PR ships the **contract only**: the handler returns an empty list. Populating the catalogue is tracked as a follow-up.

 What's included:
  - New handler at `packages/cli/src/public-api/v1/handlers/ephemeral-nodes/ephemeral-nodes.handler.ts`
  - OpenAPI path (`ephemeral-nodes-list.yml`) and two schemas (`ephemeralNode.yml`, `ephemeralNodeList.yml`)
  - New `EphemeralNode` tag registered in `openapi.yml`
  - Cursor + `nodeType` query parameter wired up via the existing `validCursor` middleware
  - Integration tests covering the endpoint itself and a discovery-flow contract test that locks the shapes of `/credentials`, `/projects`,
  `/ephemeral-nodes`, and `/discover` together

  Notes for reviewers:
  - The endpoint is currently **auth-only, no scope gate**. The handler has a `TODO(scope)` comment 
  `apiKeyHasScopeWithGlobalScopeFallback({ scope: 'node:read' })` once the permissions PR adds `node:read` to the `ApiKeyScope` union and role scope sets.
  - Response shape returns `{ data: [], nextCursor: null }` today; field definitions in the schema are the agreed-upon contract for population.

  How to test:
  ```bash
  curl -H "X-N8N-API-KEY: <key>" http://localhost:5678/api/v1/ephemeral-nodes
  # → { "data": [], "nextCursor": null }
  ``

  ## Review / Merge checklist

  - [x] I have seen this code, I have run this code, and I take responsibility for this code.
  - [x] PR title and summary are descriptive.
  - [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
  - [x] Tests included.
  - [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)