### PR TITLE
fix(core): Verify Telegram webhook secret token (no-changelog)

### DIFF
--- a/packages/cli/src/modules/agents/integrations/platforms/__tests__/telegram-integration.test.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/__tests__/telegram-integration.test.ts
@@ -10,13 +10,12 @@ import type { UrlService } from '@/services/url.service';
 import type { Agent } from '../../../entities/agent.entity';
 import type { AgentRepository } from '../../../repositories/agent.repository';
 import type { AgentChatIntegrationContext } from '../../agent-chat-integration';
+import { loadTelegramAdapter } from '../../esm-loader';
 import { TelegramIntegration } from '../telegram-integration';
 
 jest.mock('../../esm-loader', () => ({
 	loadTelegramAdapter: jest.fn(),
 }));
-
-import { loadTelegramAdapter } from '../../esm-loader';
 
 const mockedLoadTelegramAdapter = loadTelegramAdapter as jest.MockedFunction<
 	typeof loadTelegramAdapter
@@ -151,7 +150,7 @@ describe('TelegramIntegration.requiresLeader', () => {
 	});
 });
 
-describe('TelegramIntegration secret token (multi-main safe)', () => {
+describe('TelegramIntegration secret token', () => {
 	const createTelegramAdapter = jest.fn();
 
 	beforeEach(() => {
@@ -174,8 +173,6 @@ describe('TelegramIntegration secret token (multi-main safe)', () => {
 			mode: 'webhook',
 			secretToken: expected,
 		});
-		// Sanity: HMAC-SHA256 hex is always 64 chars, well under Telegram's 256 limit.
-		expect(expected).toMatch(/^[0-9a-f]{64}$/);
 	});
 
 	it('two service instances configured with the same encryption key produce identical secrets — the multi-main invariant', async () => {

--- a/packages/cli/src/modules/agents/integrations/platforms/__tests__/telegram-integration.test.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/__tests__/telegram-integration.test.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/unbound-method -- mock-based tests intentionally reference unbound methods */
 import type { Logger } from '@n8n/backend-common';
+import { createHmac } from 'crypto';
 import { mock } from 'jest-mock-extended';
+import type { InstanceSettings } from 'n8n-core';
 
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import type { UrlService } from '@/services/url.service';
@@ -9,6 +11,19 @@ import type { Agent } from '../../../entities/agent.entity';
 import type { AgentRepository } from '../../../repositories/agent.repository';
 import type { AgentChatIntegrationContext } from '../../agent-chat-integration';
 import { TelegramIntegration } from '../telegram-integration';
+
+jest.mock('../../esm-loader', () => ({
+	loadTelegramAdapter: jest.fn(),
+}));
+
+import { loadTelegramAdapter } from '../../esm-loader';
+
+const mockedLoadTelegramAdapter = loadTelegramAdapter as jest.MockedFunction<
+	typeof loadTelegramAdapter
+>;
+
+const expectedSecret = (encryptionKey: string, agentId: string, credentialId: string) =>
+	createHmac('sha256', encryptionKey).update(`telegram:${agentId}:${credentialId}`).digest('hex');
 
 const makeAgent = (
 	id: string,
@@ -28,18 +43,42 @@ const makeContext = (
 	...overrides,
 });
 
+const makeIntegration = (
+	opts: {
+		urlService?: jest.Mocked<UrlService>;
+		agentRepository?: jest.Mocked<AgentRepository>;
+		encryptionKey?: string;
+	} = {},
+) => {
+	const urlService =
+		opts.urlService ??
+		(() => {
+			const u = mock<UrlService>();
+			u.getWebhookBaseUrl.mockReturnValue('https://n8n.example.com/');
+			return u;
+		})();
+	const agentRepository = opts.agentRepository ?? mock<AgentRepository>();
+	const instanceSettings = mock<InstanceSettings>({
+		encryptionKey: opts.encryptionKey ?? 'test-encryption-key',
+	});
+	const integration = new TelegramIntegration(
+		mock<Logger>(),
+		urlService,
+		agentRepository,
+		instanceSettings,
+	);
+	return { integration, urlService, agentRepository, instanceSettings };
+};
+
 describe('TelegramIntegration.onBeforeConnect', () => {
-	let integration: TelegramIntegration;
 	let agentRepository: jest.Mocked<AgentRepository>;
-	let urlService: jest.Mocked<UrlService>;
+	let integration: TelegramIntegration;
 	let fetchSpy: jest.SpyInstance;
 
 	beforeEach(() => {
-		agentRepository = mock<AgentRepository>();
-		urlService = mock<UrlService>();
-		urlService.getWebhookBaseUrl.mockReturnValue('https://n8n.example.com/');
-
-		integration = new TelegramIntegration(mock<Logger>(), urlService, agentRepository);
+		const built = makeIntegration();
+		integration = built.integration;
+		agentRepository = built.agentRepository;
 
 		fetchSpy = jest.spyOn(globalThis, 'fetch');
 	});
@@ -97,11 +136,7 @@ describe('TelegramIntegration.requiresLeader', () => {
 		const urlService = mock<UrlService>();
 		urlService.getWebhookBaseUrl.mockReturnValue('http://localhost:5678/');
 
-		const integration = new TelegramIntegration(
-			mock<Logger>(),
-			urlService,
-			mock<AgentRepository>(),
-		);
+		const { integration } = makeIntegration({ urlService });
 
 		expect(integration.requiresLeader()).toBe(true);
 	});
@@ -110,12 +145,82 @@ describe('TelegramIntegration.requiresLeader', () => {
 		const urlService = mock<UrlService>();
 		urlService.getWebhookBaseUrl.mockReturnValue('https://n8n.example.com/');
 
-		const integration = new TelegramIntegration(
-			mock<Logger>(),
-			urlService,
-			mock<AgentRepository>(),
-		);
+		const { integration } = makeIntegration({ urlService });
 
 		expect(integration.requiresLeader()).toBe(false);
+	});
+});
+
+describe('TelegramIntegration secret token (multi-main safe)', () => {
+	const createTelegramAdapter = jest.fn();
+
+	beforeEach(() => {
+		createTelegramAdapter.mockReset();
+		createTelegramAdapter.mockReturnValue({ marker: 'adapter' });
+		mockedLoadTelegramAdapter.mockReset();
+		mockedLoadTelegramAdapter.mockResolvedValue({
+			createTelegramAdapter,
+		} as unknown as Awaited<ReturnType<typeof loadTelegramAdapter>>);
+	});
+
+	it('createAdapter passes a deterministic secretToken derived from encryptionKey + agentId + credentialId', async () => {
+		const { integration } = makeIntegration({ encryptionKey: 'super-secret-key' });
+
+		await integration.createAdapter(makeContext({ agentId: 'A', credentialId: 'C' }));
+
+		const expected = expectedSecret('super-secret-key', 'A', 'C');
+		expect(createTelegramAdapter).toHaveBeenCalledWith({
+			botToken: 'bot-token',
+			mode: 'webhook',
+			secretToken: expected,
+		});
+		// Sanity: HMAC-SHA256 hex is always 64 chars, well under Telegram's 256 limit.
+		expect(expected).toMatch(/^[0-9a-f]{64}$/);
+	});
+
+	it('two service instances configured with the same encryption key produce identical secrets — the multi-main invariant', async () => {
+		const a = makeIntegration({ encryptionKey: 'shared-cluster-key' });
+		const b = makeIntegration({ encryptionKey: 'shared-cluster-key' });
+
+		await a.integration.createAdapter(makeContext({ agentId: 'agent-X', credentialId: 'cred-Y' }));
+		await b.integration.createAdapter(makeContext({ agentId: 'agent-X', credentialId: 'cred-Y' }));
+
+		const firstSecret = createTelegramAdapter.mock.calls[0][0].secretToken;
+		const secondSecret = createTelegramAdapter.mock.calls[1][0].secretToken;
+		expect(firstSecret).toBe(secondSecret);
+	});
+
+	it('different (agentId, credentialId) pairs produce different secrets', async () => {
+		const { integration } = makeIntegration({ encryptionKey: 'k' });
+
+		await integration.createAdapter(makeContext({ agentId: 'A', credentialId: 'C1' }));
+		await integration.createAdapter(makeContext({ agentId: 'A', credentialId: 'C2' }));
+
+		expect(createTelegramAdapter.mock.calls[0][0].secretToken).not.toBe(
+			createTelegramAdapter.mock.calls[1][0].secretToken,
+		);
+	});
+
+	it('onAfterConnect sends secret_token to Telegram matching the secret used by the adapter', async () => {
+		const fetchSpy = jest
+			.spyOn(globalThis, 'fetch')
+			.mockResolvedValue({ ok: true, text: async () => 'ok' } as Response);
+
+		try {
+			const { integration } = makeIntegration({ encryptionKey: 'cluster-key' });
+
+			await integration.onAfterConnect(makeContext({ agentId: 'agent-Z', credentialId: 'cred-Z' }));
+
+			expect(fetchSpy).toHaveBeenCalledTimes(1);
+			const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe('https://api.telegram.org/botbot-token/setWebhook');
+			const body = JSON.parse(init.body as string) as { url: string; secret_token: string };
+			expect(body.url).toBe(
+				'https://n8n.example.com/rest/projects/proj-1/agents/v2/agent-1/webhooks/telegram',
+			);
+			expect(body.secret_token).toBe(expectedSecret('cluster-key', 'agent-Z', 'cred-Z'));
+		} finally {
+			fetchSpy.mockRestore();
+		}
 	});
 });

--- a/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
@@ -156,16 +156,10 @@ export class TelegramIntegration extends AgentChatIntegration {
 
 	/**
 	 * Per-integration webhook secret derived deterministically from the cluster
-	 * encryption key. Telegram's `setWebhook` accepts one `secret_token` per bot
-	 * and echoes it back in `X-Telegram-Bot-Api-Secret-Token` on every incoming
-	 * update. In multi-main mode the webhook is registered exactly once by the
-	 * leader, but every main must verify incoming POSTs (the load balancer
-	 * doesn't know which main "owns" the bot). HMAC over a domain-separated
+	 * encryption key. In multi-main mode the webhook is registered exactly once by the
+	 * leader, but every main must verify incoming POSTs. HMAC over an
 	 * `(agentId, credentialId)` lets every main reach the identical secret with
-	 * zero coordination — no DB write, no PubSub, no extra column. A rotation
-	 * of `N8N_ENCRYPTION_KEY` will invalidate the registered secret until the
-	 * next `onAfterConnect` re-registers it, same as it invalidates encrypted
-	 * credentials.
+	 * zero coordination.
 	 */
 	private deriveSecretToken(agentId: string, credentialId: string): string {
 		return createHmac('sha256', this.instanceSettings.encryptionKey)

--- a/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
@@ -1,6 +1,8 @@
 import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
 import type { Thread } from 'chat';
+import { createHmac } from 'crypto';
+import { InstanceSettings } from 'n8n-core';
 
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { UrlService } from '@/services/url.service';
@@ -63,6 +65,7 @@ export class TelegramIntegration extends AgentChatIntegration {
 		private readonly logger: Logger,
 		private readonly urlService: UrlService,
 		private readonly agentRepository: AgentRepository,
+		private readonly instanceSettings: InstanceSettings,
 	) {
 		super();
 	}
@@ -70,8 +73,9 @@ export class TelegramIntegration extends AgentChatIntegration {
 	async createAdapter(ctx: AgentChatIntegrationContext): Promise<unknown> {
 		const botToken = this.extractBotToken(ctx.credential);
 		const mode = this.getMode();
+		const secretToken = this.deriveSecretToken(ctx.agentId, ctx.credentialId);
 		const { createTelegramAdapter } = await loadTelegramAdapter();
-		return createTelegramAdapter({ botToken, mode });
+		return createTelegramAdapter({ botToken, mode, secretToken });
 	}
 
 	/**
@@ -107,10 +111,11 @@ export class TelegramIntegration extends AgentChatIntegration {
 		if (this.getMode() !== 'webhook') return;
 		const botToken = this.extractBotToken(ctx.credential);
 		const webhookUrl = ctx.webhookUrlFor('telegram');
+		const secretToken = this.deriveSecretToken(ctx.agentId, ctx.credentialId);
 		const resp = await fetch(`https://api.telegram.org/bot${botToken}/setWebhook`, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({ url: webhookUrl }),
+			body: JSON.stringify({ url: webhookUrl, secret_token: secretToken }),
 		});
 		if (!resp.ok) {
 			throw new Error(`Failed to register Telegram webhook: ${await resp.text()}`);
@@ -147,6 +152,25 @@ export class TelegramIntegration extends AgentChatIntegration {
 		const baseUrl = this.urlService.getWebhookBaseUrl();
 		const isPublic = baseUrl.startsWith('https://') && !baseUrl.includes('localhost');
 		return isPublic ? 'webhook' : 'polling';
+	}
+
+	/**
+	 * Per-integration webhook secret derived deterministically from the cluster
+	 * encryption key. Telegram's `setWebhook` accepts one `secret_token` per bot
+	 * and echoes it back in `X-Telegram-Bot-Api-Secret-Token` on every incoming
+	 * update. In multi-main mode the webhook is registered exactly once by the
+	 * leader, but every main must verify incoming POSTs (the load balancer
+	 * doesn't know which main "owns" the bot). HMAC over a domain-separated
+	 * `(agentId, credentialId)` lets every main reach the identical secret with
+	 * zero coordination — no DB write, no PubSub, no extra column. A rotation
+	 * of `N8N_ENCRYPTION_KEY` will invalidate the registered secret until the
+	 * next `onAfterConnect` re-registers it, same as it invalidates encrypted
+	 * credentials.
+	 */
+	private deriveSecretToken(agentId: string, credentialId: string): string {
+		return createHmac('sha256', this.instanceSettings.encryptionKey)
+			.update(`telegram:${agentId}:${credentialId}`)
+			.digest('hex');
 	}
 
 	private extractBotToken(credential: Record<string, unknown>): string {


### PR DESCRIPTION
## Summary

The Telegram integration in the new agents/messenger-platforms path now registers a `secret_token` with `setWebhook` and validates the `X-Telegram-Bot-Api-Secret-Token` header on every incoming update.

The secret is derived deterministically per agent integration:

```
HMAC-SHA256(N8N_ENCRYPTION_KEY, "telegram:<agentId>:<credentialId>").hex()
```

This makes the change **safe for multi-main mode**: every main computes the same secret independently in `createAdapter`. The leader still owns the single `setWebhook` call (existing `skipExternalHooks` plumbing in `ChatIntegrationService`); followers just need to reach the same value, which they do without DB writes, PubSub, or schema changes.

### Tradeoffs
- The secret follows `N8N_ENCRYPTION_KEY`. Rotating the encryption key invalidates the registered webhook secret until the next `onAfterConnect` re-registers it — same failure mode as encrypted credentials, no new operational concern.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AGENT-123/bug-no-telegram-webhook-signature-verification

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI