### PR TITLE
feat(API): Add ephemeral node execution endpoint

### DIFF
--- a/packages/@n8n/api-types/src/dto/ephemeral-nodes/execute-ephemeral-node-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/ephemeral-nodes/execute-ephemeral-node-request.dto.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+
+const credentialDetailSchema = z.object({
+	id: z.string(),
+	name: z.string(),
+});
+
+export class ExecuteEphemeralNodeRequestDto extends Z.class({
+	nodeType: z.string().min(1),
+	nodeTypeVersion: z.number(),
+	nodeParameters: z.record(z.string(), z.unknown()).default({}),
+	credentials: z.record(z.string(), credentialDetailSchema).optional(),
+	inputData: z.array(z.record(z.string(), z.unknown())).optional().default([]),
+}) {}

--- a/packages/@n8n/api-types/src/dto/ephemeral-nodes/execute-ephemeral-node-response.dto.ts
+++ b/packages/@n8n/api-types/src/dto/ephemeral-nodes/execute-ephemeral-node-response.dto.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const executeEphemeralNodeResponseSchema = z.object({
+	status: z.enum(['success', 'error']),
+	data: z.array(z.unknown()),
+	error: z.string().optional(),
+});
+
+export type ExecuteEphemeralNodeResponse = z.infer<typeof executeEphemeralNodeResponseSchema>;

--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -238,6 +238,12 @@ export {
 export { VersionSinceDateQueryDto } from './instance-version-history/version-since-date-query.dto';
 export { VersionQueryDto } from './instance-version-history/version-query.dto';
 
+export { ExecuteEphemeralNodeRequestDto } from './ephemeral-nodes/execute-ephemeral-node-request.dto';
+export {
+	executeEphemeralNodeResponseSchema,
+	type ExecuteEphemeralNodeResponse,
+} from './ephemeral-nodes/execute-ephemeral-node-response.dto';
+
 export { CreateAgentDto } from './agents/create-agent.dto';
 export { UpdateAgentDto } from './agents/update-agent.dto';
 export { UpdateAgentConfigDto } from './agents/update-agent-config.dto';

--- a/packages/cli/src/node-execution/ephemeral-node-executor.ts
+++ b/packages/cli/src/node-execution/ephemeral-node-executor.ts
@@ -206,7 +206,7 @@ export class EphemeralNodeExecutor {
 		return verified;
 	}
 
-	private validateNodeForExecution(
+	validateNodeForExecution(
 		nodeType: string,
 		typeVersion: number,
 		nodeParameters: INodeParameters,

--- a/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/ephemeral-nodes.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/ephemeral-nodes.handler.ts
@@ -1,22 +1,59 @@
-// TODO(scope): swap to `apiKeyHasScopeWithGlobalScopeFallback({ scope: 'node:read' })`
-// once the permissions PR adds `node:read` to the ApiKeyScope union and the role
-// scope sets.
-
+import { ExecuteEphemeralNodeRequestDto } from '@n8n/api-types';
 import type { AuthenticatedRequest } from '@n8n/db';
+import { ProjectRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+import type { INodeParameters } from 'n8n-workflow';
 
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { EphemeralNodeExecutor } from '@/node-execution/ephemeral-node-executor';
 import type { PaginatedRequest } from '@/public-api/types';
 
+import { toInlineRequest, toPublicResponse } from './ephemeral-nodes.mapper';
 import type { PublicAPIEndpoint } from '../../shared/handler.types';
-import { validCursor } from '../../shared/middlewares/global.middleware';
+import {
+	apiKeyHasScopeWithGlobalScopeFallback,
+	validCursor,
+} from '../../shared/middlewares/global.middleware';
+
+type EphemeralNodesHandlers = {
+	executeEphemeralNode: PublicAPIEndpoint<AuthenticatedRequest>;
+	listEphemeralNodes: PublicAPIEndpoint<ListEphemeralNodesRequest>;
+};
 
 type ListEphemeralNodesRequest = AuthenticatedRequest<{}, {}, {}, { nodeType?: string }> &
 	PaginatedRequest;
 
-type EphemeralNodesHandlers = {
-	listEphemeralNodes: PublicAPIEndpoint<ListEphemeralNodesRequest>;
-};
-
 const ephemeralNodesHandlers: EphemeralNodesHandlers = {
+	executeEphemeralNode: [
+		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'ephemeralNode:execute' }),
+		async (req, res) => {
+			const parsed = ExecuteEphemeralNodeRequestDto.safeParse(req.body);
+			if (!parsed.success) {
+				throw new BadRequestError(parsed.error.errors[0].message);
+			}
+			const dto = parsed.data;
+
+			const projectId = (
+				await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(req.user.id)
+			).id;
+
+			const executor = Container.get(EphemeralNodeExecutor);
+
+			try {
+				executor.validateNodeForExecution(
+					dto.nodeType,
+					dto.nodeTypeVersion,
+					dto.nodeParameters as INodeParameters,
+				);
+			} catch (error) {
+				throw new BadRequestError(error instanceof Error ? error.message : String(error));
+			}
+
+			const result = await executor.executeInline(toInlineRequest(dto, projectId));
+
+			return res.json(toPublicResponse(result));
+		},
+	],
 	listEphemeralNodes: [
 		validCursor,
 		async (_req, res) => {

--- a/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/ephemeral-nodes.mapper.ts
+++ b/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/ephemeral-nodes.mapper.ts
@@ -1,0 +1,60 @@
+import {
+	type ExecuteEphemeralNodeResponse,
+	executeEphemeralNodeResponseSchema,
+	type ExecuteEphemeralNodeRequestDto,
+} from '@n8n/api-types';
+import { UnexpectedError } from 'n8n-workflow';
+import type {
+	IDataObject,
+	INodeCredentialsDetails,
+	INodeExecutionData,
+	INodeParameters,
+} from 'n8n-workflow';
+
+import type {
+	InlineNodeExecutionRequest,
+	NodeExecutionResult,
+} from '@/node-execution/ephemeral-node-executor';
+
+export function toInlineRequest(
+	dto: ExecuteEphemeralNodeRequestDto,
+	projectId: string,
+): InlineNodeExecutionRequest {
+	const credentialDetails: Record<string, INodeCredentialsDetails> | undefined = dto.credentials
+		? Object.fromEntries(
+				Object.entries(dto.credentials).map(([credType, detail]) => [
+					credType,
+					{ id: detail.id, name: detail.name },
+				]),
+			)
+		: undefined;
+
+	const inputData: INodeExecutionData[] = (dto.inputData ?? []).map((item) => ({
+		json: item as IDataObject,
+	}));
+
+	return {
+		nodeType: dto.nodeType,
+		nodeTypeVersion: dto.nodeTypeVersion,
+		nodeParameters: dto.nodeParameters as INodeParameters,
+		credentialDetails,
+		inputData,
+		projectId,
+	};
+}
+
+export function toPublicResponse(result: NodeExecutionResult): ExecuteEphemeralNodeResponse {
+	const parsed = executeEphemeralNodeResponseSchema.safeParse({
+		status: result.status,
+		data: result.data.map((item) => item.json),
+		error: result.error,
+	});
+
+	if (!parsed.success) {
+		throw new UnexpectedError('Failed to serialize ephemeral node execution response', {
+			cause: parsed.error,
+		});
+	}
+
+	return parsed.data;
+}

--- a/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/spec/paths/ephemeral-nodes-execute.yml
+++ b/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/spec/paths/ephemeral-nodes-execute.yml
@@ -1,0 +1,34 @@
+post:
+  operationId: executeEphemeralNode
+  x-eov-operation-id: executeEphemeralNode
+  x-eov-operation-handler: v1/handlers/ephemeral-nodes/ephemeral-nodes.handler
+  tags:
+    - EphemeralNode
+  summary: Execute a node
+  description: >
+    Execute a single node inline without persisting a workflow or execution record.
+    The node runs in the caller's personal project context.
+    Only nodes that are usable as agent tools are supported; trigger nodes and
+    sendAndWait/dispatchAndWait operations are rejected with 400.
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../schemas/ephemeralNodeExecutionRequest.yml'
+  responses:
+    '200':
+      description: >
+        Execution completed. Check the status field — "success" or "error".
+        An "error" status means the node ran but failed (e.g. a remote API returned an error);
+        it is not an HTTP-level error.
+      content:
+        application/json:
+          schema:
+            $ref: '../schemas/ephemeralNodeExecutionResponse.yml'
+    '400':
+      $ref: '../../../../shared/spec/responses/badRequest.yml'
+    '401':
+      $ref: '../../../../shared/spec/responses/unauthorized.yml'
+    '403':
+      $ref: '../../../../shared/spec/responses/forbidden.yml'

--- a/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/spec/schemas/ephemeralNodeExecutionRequest.yml
+++ b/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/spec/schemas/ephemeralNodeExecutionRequest.yml
@@ -1,0 +1,47 @@
+type: object
+required:
+  - nodeType
+  - nodeTypeVersion
+  - nodeParameters
+properties:
+  nodeType:
+    type: string
+    description: The node type identifier.
+    example: n8n-nodes-base.httpRequest
+  nodeTypeVersion:
+    type: number
+    description: The version of the node type to execute.
+    example: 4.2
+  nodeParameters:
+    type: object
+    description: Node-specific parameters as key-value pairs.
+    additionalProperties: true
+    example:
+      url: https://api.example.com/data
+      method: GET
+  credentials:
+    type: object
+    description: >
+      Map of credential type name to a resolved credential { id, name }.
+      Use GET /credentials to discover available credential ids and names.
+    additionalProperties:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+          example: R2DjclaysHbqn778
+        name:
+          type: string
+          example: My HTTP credential
+  inputData:
+    type: array
+    description: Items to pass as input to the node. Each item is a plain JSON object.
+    items:
+      type: object
+      additionalProperties: true
+    example:
+      - id: 1
+        name: Alice

--- a/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/spec/schemas/ephemeralNodeExecutionResponse.yml
+++ b/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/spec/schemas/ephemeralNodeExecutionResponse.yml
@@ -1,0 +1,26 @@
+type: object
+required:
+  - status
+  - data
+properties:
+  status:
+    type: string
+    enum:
+      - success
+      - error
+    description: >
+      Indicates whether the node executed successfully. A value of "error"
+      means the node ran but produced an error (e.g. a remote API call failed).
+      HTTP 400 is returned instead for invalid node types or blacklisted operations.
+    example: success
+  data:
+    type: array
+    description: Output items produced by the node. Each item is the JSON payload of one output row.
+    items: {}
+    example:
+      - statusCode: 200
+        body: '{"ok":true}'
+  error:
+    type: string
+    description: Error message when status is "error".
+    example: Request failed with status code 404

--- a/packages/cli/src/public-api/v1/openapi.yml
+++ b/packages/cli/src/public-api/v1/openapi.yml
@@ -46,6 +46,8 @@ tags:
     description: Operations about folders
   - name: EphemeralNode
     description: Operations about nodes runnable via single-node ephemeral execution
+  - name: EphemeralNodeExecution
+    description: Operations about ephemeral node execution
 
 paths:
   /audit:
@@ -144,6 +146,8 @@ paths:
     $ref: './handlers/folders/spec/paths/folders.folderId.yml'
   /ephemeral-nodes:
     $ref: './handlers/ephemeral-nodes/spec/paths/ephemeral-nodes-list.yml'
+  /ephemeral-nodes/execute:
+    $ref: './handlers/ephemeral-nodes/spec/paths/ephemeral-nodes-execute.yml'
 components:
   schemas:
     $ref: './shared/spec/schemas/_index.yml'

--- a/packages/cli/test/integration/public-api/ephemeral-nodes-execute.test.ts
+++ b/packages/cli/test/integration/public-api/ephemeral-nodes-execute.test.ts
@@ -1,0 +1,178 @@
+
+import { mockInstance, getPersonalProject } from '@n8n/backend-test-utils';
+import type { User } from '@n8n/db';
+import type { ApiKeyScope } from '@n8n/permissions';
+import { UserError } from 'n8n-workflow';
+
+import { EphemeralNodeExecutor } from '@/node-execution/ephemeral-node-executor';
+import handlers from '@/public-api/v1/handlers/ephemeral-nodes/ephemeral-nodes.handler';
+
+import { createMemberWithApiKey, createOwnerWithApiKey } from '../shared/db/users';
+import type { SuperAgentTest } from '../shared/types';
+import * as utils from '../shared/utils/';
+
+const mockExecutor = mockInstance(EphemeralNodeExecutor);
+
+const testServer = utils.setupTestServer({ endpointGroups: ['publicApi'] });
+
+let owner: User;
+let member: User;
+
+let unscopedOwner: User;
+let authOwnerAgent: SuperAgentTest;
+let authMemberAgent: SuperAgentTest;
+let authUnscopedAgent: SuperAgentTest;
+let ownerPersonalProjectId: string;
+
+const EPHEMERAL_NODE_SCOPES: ApiKeyScope[] = ['ephemeralNode:execute'];
+
+const validPayload = {
+	nodeType: 'n8n-nodes-base.httpRequest',
+	nodeTypeVersion: 4,
+	nodeParameters: { url: 'https://api.example.com' },
+};
+
+beforeAll(async () => {
+	owner = await createOwnerWithApiKey({ scopes: EPHEMERAL_NODE_SCOPES });
+	member = await createMemberWithApiKey({ scopes: EPHEMERAL_NODE_SCOPES });
+	// Holds a non-ephemeralNode scope so the key lacks ephemeralNode:execute
+	unscopedOwner = await createOwnerWithApiKey({ scopes: ['workflow:list' as ApiKeyScope] });
+
+	ownerPersonalProjectId = (await getPersonalProject(owner)).id;
+
+	// Default executor behaviour — individual tests override with mockImplementationOnce
+	mockExecutor.validateNodeForExecution.mockReturnValue(undefined);
+	mockExecutor.executeInline.mockResolvedValue({ status: 'success', data: [] });
+});
+
+beforeEach(() => {
+	// Clears call history while preserving the default implementations set in beforeAll
+	jest.clearAllMocks();
+
+	authOwnerAgent = testServer.publicApiAgentFor(owner);
+	authMemberAgent = testServer.publicApiAgentFor(member);
+	authUnscopedAgent = testServer.publicApiAgentFor(unscopedOwner);
+});
+
+describe('POST /ephemeral-nodes/execute', () => {
+	describe('authorization', () => {
+		test('returns 401 without API key', async () => {
+			await testServer
+				.publicApiAgentWithoutApiKey()
+				.post('/ephemeral-nodes/execute')
+				.send(validPayload)
+				.expect(401);
+		});
+
+		test('returns 403 when API key lacks ephemeralNode:execute scope', async () => {
+			await authUnscopedAgent.post('/ephemeral-nodes/execute').send(validPayload).expect(403);
+
+			expect(mockExecutor.executeInline).not.toHaveBeenCalled();
+		});
+
+		test('owner with ephemeralNode:execute scope is allowed', async () => {
+			await authOwnerAgent.post('/ephemeral-nodes/execute').send(validPayload).expect(200);
+		});
+
+		test('member with ephemeralNode:execute scope is allowed', async () => {
+			await authMemberAgent.post('/ephemeral-nodes/execute').send(validPayload).expect(200);
+		});
+	});
+
+	describe('request validation — HTTP 400', () => {
+		test('rejects malformed body missing required fields', async () => {
+			await authOwnerAgent
+				.post('/ephemeral-nodes/execute')
+				.send({ nodeParameters: {} })
+				.expect(400);
+
+			expect(mockExecutor.validateNodeForExecution).not.toHaveBeenCalled();
+			expect(mockExecutor.executeInline).not.toHaveBeenCalled();
+		});
+
+		test('rejects trigger nodes with 400', async () => {
+			mockExecutor.validateNodeForExecution.mockImplementationOnce(() => {
+				throw new UserError('Trigger nodes cannot be executed standalone');
+			});
+
+			await authOwnerAgent
+				.post('/ephemeral-nodes/execute')
+				.send({ ...validPayload, nodeType: 'n8n-nodes-base.webhook' })
+				.expect(400);
+
+			expect(mockExecutor.executeInline).not.toHaveBeenCalled();
+		});
+
+		test('rejects blacklisted operations with 400', async () => {
+			mockExecutor.validateNodeForExecution.mockImplementationOnce(() => {
+				throw new UserError('The "sendAndWait" is not supported for agent tool execution.');
+			});
+
+			await authOwnerAgent
+				.post('/ephemeral-nodes/execute')
+				.send({ ...validPayload, nodeParameters: { operation: 'sendAndWait' } })
+				.expect(400);
+
+			expect(mockExecutor.executeInline).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('execution', () => {
+		test('returns 200 with status:success and mapped output data', async () => {
+			mockExecutor.executeInline.mockResolvedValueOnce({
+				status: 'success',
+				data: [{ json: { statusCode: 200, body: 'ok' } }],
+			});
+
+			const response = await authOwnerAgent
+				.post('/ephemeral-nodes/execute')
+				.send(validPayload)
+				.expect(200);
+
+			expect(response.body).toMatchObject({
+				status: 'success',
+				data: [{ statusCode: 200, body: 'ok' }],
+			});
+		});
+
+		test("forwards the caller's personal projectId to executeInline", async () => {
+			await authOwnerAgent.post('/ephemeral-nodes/execute').send(validPayload).expect(200);
+
+			expect(mockExecutor.executeInline).toHaveBeenCalledWith(
+				expect.objectContaining({ projectId: ownerPersonalProjectId }),
+			);
+		});
+
+		test('returns 200 with status:error when node execution fails at runtime', async () => {
+			mockExecutor.executeInline.mockResolvedValueOnce({
+				status: 'error',
+				data: [],
+				error: 'Request failed with status code 404',
+			});
+
+			const response = await authOwnerAgent
+				.post('/ephemeral-nodes/execute')
+				.send(validPayload)
+				.expect(200);
+
+			expect(response.body).toMatchObject({
+				status: 'error',
+				data: [],
+				error: 'Request failed with status code 404',
+			});
+		});
+	});
+
+	describe('executeEphemeralNode handler middleware', () => {
+		test('handler is scope-gated with ephemeralNode:execute', () => {
+			const middlewareChain = handlers.executeEphemeralNode as unknown as Array<
+				Record<string, unknown>
+			>;
+			const hasScopedMiddleware = middlewareChain.some(
+				(mw) => typeof mw === 'function' && '__apiKeyScope' in mw,
+			);
+
+			expect(hasScopedMiddleware).toBe(true);
+		});
+	});
+});

--- a/packages/cli/test/integration/public-api/ephemeral-nodes.test.ts
+++ b/packages/cli/test/integration/public-api/ephemeral-nodes.test.ts
@@ -4,7 +4,7 @@ import handlers from '@/public-api/v1/handlers/ephemeral-nodes/ephemeral-nodes.h
 
 import { createMemberWithApiKey, createOwnerWithApiKey } from '../shared/db/users';
 import type { SuperAgentTest } from '../shared/types';
-import * as utils from '../shared/utils';
+import * as utils from '../shared/utils/';
 
 const testServer = utils.setupTestServer({ endpointGroups: ['publicApi'] });
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Adds `POST /api/v1/ephemeral-nodes/execute`, a thin public-API wrapper around `EphemeralNodeExecutor.executeInline`. The endpoint runs a single node inline against the caller's personal project — no workflow, no execution record — and returns the node's output items (or a runtime error envelope) as JSON.
This is the third piece of the public ephemeral-nodes surface, on top of:
- #30385 — scopes (`ephemeralNode:read`, `ephemeralNode:execute`)
- #30387 — list endpoint (`GET /ephemeral-nodes`)
### What it does
- New endpoint: `POST /api/v1/ephemeral-nodes/execute`
- Auth: gated by `ephemeralNode:execute` (with global-scope fallback)
- Project context: always resolves the authenticated user's personal project — no `projectId` in the body, no per-request access checks
- Response shape:
  - `200 { status: "success", data: [...] }` — node executed successfully
  - `200 { status: "error", data: [], error: "..." }` — node ran but failed at runtime (e.g. upstream HTTP 4xx); semantically a successful API call
  - `400` — validation failures (malformed body, trigger node, blacklisted operation like `sendAndWait`)
  - `401` / `403` — missing API key / missing scope

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
