### PR TITLE
feat(editor): Periodically refresh worker pools on settings page (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/settings/orchestration.ee/components/WorkerList.vue
+++ b/packages/frontend/editor-ui/src/features/settings/orchestration.ee/components/WorkerList.vue
@@ -51,10 +51,12 @@ onBeforeMount(() => {
 	pushConnection.initialize();
 	pushStore.pushConnect();
 	orchestrationManagerStore.startWorkerStatusPolling();
+	orchestrationManagerStore.startWorkerPoolsPolling();
 });
 
 onBeforeUnmount(() => {
 	orchestrationManagerStore.stopWorkerStatusPolling();
+	orchestrationManagerStore.stopWorkerPoolsPolling();
 	pushStore.pushDisconnect();
 	pushConnection.terminate();
 });

--- a/packages/frontend/editor-ui/src/features/settings/orchestration.ee/orchestration.store.ts
+++ b/packages/frontend/editor-ui/src/features/settings/orchestration.ee/orchestration.store.ts
@@ -10,6 +10,7 @@ import {
 
 export const WORKER_HISTORY_LENGTH = 100;
 const STALE_SECONDS = 120 * 1000;
+const WORKER_POOLS_POLL_INTERVAL_MS = 10_000;
 
 export interface IOrchestrationStoreState {
 	initialStatusReceived: boolean;
@@ -21,6 +22,7 @@ export interface IOrchestrationStoreState {
 	statusInterval: NodeJS.Timeout | null;
 	availablePools: string[];
 	poolAssignment: PoolAssignment | null;
+	workerPoolsInterval: NodeJS.Timeout | null;
 }
 
 export interface IWorkerHistoryItem {
@@ -37,6 +39,7 @@ export const useOrchestrationStore = defineStore('orchestrationManager', {
 		statusInterval: null,
 		availablePools: [],
 		poolAssignment: null,
+		workerPoolsInterval: null,
 	}),
 	actions: {
 		updateWorkerStatus(data: WorkerStatus) {
@@ -90,6 +93,23 @@ export const useOrchestrationStore = defineStore('orchestrationManager', {
 			const response = await getWorkerPools(rootStore.restApiContext);
 			this.availablePools = response.pools;
 			this.poolAssignment = response.assignment;
+		},
+		startWorkerPoolsPolling() {
+			if (this.workerPoolsInterval) return;
+			this.workerPoolsInterval = setInterval(async () => {
+				try {
+					await this.fetchWorkerPools();
+				} catch {
+					// Swallow errors during polling — surfacing a toast every 10s would be noisy.
+					// The initial fetch on mount surfaces errors to the user.
+				}
+			}, WORKER_POOLS_POLL_INTERVAL_MS);
+		},
+		stopWorkerPoolsPolling() {
+			if (this.workerPoolsInterval) {
+				clearInterval(this.workerPoolsInterval);
+				this.workerPoolsInterval = null;
+			}
 		},
 		async updateWorkerPoolAssignment(dto: UpdateWorkerPoolAssignmentDto) {
 			const rootStore = useRootStore();


### PR DESCRIPTION
## Summary

Makes the **Worker pools** section on `/settings/workers` reactive to changes in pool membership without requiring a page reload. Mirrors the existing worker-status polling lifecycle but at a slower cadence since pool composition changes are rare.

- Adds `startWorkerPoolsPolling` / `stopWorkerPoolsPolling` actions to the orchestration store, polling `GET /rest/orchestration/worker/pools` every **10s**.
- Started/stopped from `WorkerList.vue` alongside the existing worker-status polling.
- Errors during polling are swallowed — the initial fetch in `WorkerPoolsCard` already surfaces loading errors to the user; surfacing a toast every 10s would be noisy.
- The user's in-progress form draft is **not** clobbered — only the underlying `availablePools` and `poolAssignment` store state updates, and Pinia reactivity propagates new pool options into the dropdowns.

### How to test

1. Start n8n in queue mode with a worker view license, navigate to `/settings/workers`.
2. With the page open, spin up a new worker via `N8N_WORKER_POOL_NAME=gpu`.
3. Within ~10s, the new pool appears as a badge in the "Available pools" section and as a selectable option in the three default-routing dropdowns — without reloading.
4. Stop the worker; within ~10s + cluster cleanup, the pool disappears from the list.

## Related Linear tickets, Github issues, and Community forum posts

Part of the worker pools Hackmation project. Follow-up to #30386.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI