### PR TITLE
feat(MCP): Add execute_ephemeral_node tool

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/execute-ephemeral-node.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/execute-ephemeral-node.tool.test.ts
@@ -1,0 +1,280 @@
+import { mockInstance } from '@n8n/backend-test-utils';
+import { User } from '@n8n/db';
+
+import { EphemeralNodeExecutor } from '@/node-execution';
+import { ProjectService } from '@/services/project.service.ee';
+import { Telemetry } from '@/telemetry';
+
+import { createExecuteEphemeralNodeTool } from '../tools/execute-ephemeral-node.tool';
+
+describe('execute-ephemeral-node MCP tool', () => {
+	const user = Object.assign(new User(), { id: 'user-1' });
+
+	const buildBaseInput = () => ({
+		projectId: 'proj-1',
+		nodeType: 'n8n-nodes-base.httpRequest',
+		nodeTypeVersion: 4.2,
+		nodeParameters: { method: 'GET', url: 'https://example.com' },
+		credentials: undefined as never,
+		inputData: undefined as never,
+	});
+
+	const createMocks = (overrides?: {
+		executeInline?: jest.Mock;
+		getProjectWithScope?: jest.Mock;
+	}) => {
+		const ephemeralNodeExecutor = mockInstance(EphemeralNodeExecutor, {
+			executeInline:
+				overrides?.executeInline ??
+				jest.fn().mockResolvedValue({ status: 'success', data: [{ json: { ok: true } }] }),
+		});
+		const projectService = mockInstance(ProjectService, {
+			getProjectWithScope:
+				overrides?.getProjectWithScope ?? jest.fn().mockResolvedValue({ id: 'proj-1' }),
+		});
+		const telemetry = mockInstance(Telemetry, { track: jest.fn() });
+		return { ephemeralNodeExecutor, projectService, telemetry };
+	};
+
+	describe('smoke tests', () => {
+		test('creates the tool correctly', () => {
+			const { ephemeralNodeExecutor, projectService, telemetry } = createMocks();
+
+			const tool = createExecuteEphemeralNodeTool(
+				user,
+				ephemeralNodeExecutor,
+				projectService,
+				telemetry,
+			);
+
+			expect(tool.name).toBe('execute_ephemeral_node');
+			expect(tool.config.description).toEqual(expect.any(String));
+			expect(tool.config.inputSchema).toBeDefined();
+			expect(tool.config.outputSchema).toBeDefined();
+			expect(tool.config.annotations).toMatchObject({
+				readOnlyHint: false,
+				destructiveHint: true,
+				idempotentHint: false,
+				openWorldHint: true,
+			});
+			expect(typeof tool.handler).toBe('function');
+		});
+	});
+
+	describe('handler', () => {
+		test('returns the executor result on success', async () => {
+			const { ephemeralNodeExecutor, projectService, telemetry } = createMocks();
+			const tool = createExecuteEphemeralNodeTool(
+				user,
+				ephemeralNodeExecutor,
+				projectService,
+				telemetry,
+			);
+
+			const result = await tool.handler(buildBaseInput(), {} as never);
+
+			expect(result.structuredContent).toEqual({
+				status: 'success',
+				data: [{ json: { ok: true } }],
+			});
+			expect(ephemeralNodeExecutor.executeInline).toHaveBeenCalledWith(
+				expect.objectContaining({
+					projectId: 'proj-1',
+					nodeType: 'n8n-nodes-base.httpRequest',
+					nodeTypeVersion: 4.2,
+					nodeParameters: { method: 'GET', url: 'https://example.com' },
+					// Defaults to one empty input item — see the comment in the tool
+					// about why [] is a silent footgun.
+					inputData: [{ json: {} }],
+				}),
+			);
+		});
+
+		test('defaults inputData to a single empty item when an empty array is passed', async () => {
+			const { ephemeralNodeExecutor, projectService, telemetry } = createMocks();
+			const tool = createExecuteEphemeralNodeTool(
+				user,
+				ephemeralNodeExecutor,
+				projectService,
+				telemetry,
+			);
+
+			await tool.handler({ ...buildBaseInput(), inputData: [] as never }, {} as never);
+
+			expect(ephemeralNodeExecutor.executeInline).toHaveBeenCalledWith(
+				expect.objectContaining({ inputData: [{ json: {} }] }),
+			);
+		});
+
+		test('passes through executor validation errors with status:error', async () => {
+			const { ephemeralNodeExecutor, projectService, telemetry } = createMocks({
+				executeInline: jest.fn().mockResolvedValue({
+					status: 'error',
+					data: [],
+					error:
+						'Cannot execute node "n8n-nodes-base.scheduleTrigger": Trigger nodes cannot be executed standalone',
+				}),
+			});
+			const tool = createExecuteEphemeralNodeTool(
+				user,
+				ephemeralNodeExecutor,
+				projectService,
+				telemetry,
+			);
+
+			const result = await tool.handler(buildBaseInput(), {} as never);
+
+			expect(result.structuredContent).toEqual({
+				status: 'error',
+				data: [],
+				error: expect.stringContaining('Trigger nodes cannot be executed standalone'),
+			});
+			// Tool result itself is not marked as isError — executor errors are part of the contract
+			expect((result as { isError?: boolean }).isError).toBeUndefined();
+		});
+
+		test('rejects calls when project access check fails', async () => {
+			const { ephemeralNodeExecutor, projectService, telemetry } = createMocks({
+				getProjectWithScope: jest.fn().mockResolvedValue(null),
+			});
+			const tool = createExecuteEphemeralNodeTool(
+				user,
+				ephemeralNodeExecutor,
+				projectService,
+				telemetry,
+			);
+
+			const result = await tool.handler(buildBaseInput(), {} as never);
+
+			expect(result.structuredContent).toMatchObject({
+				status: 'error',
+				data: [],
+				error: expect.stringContaining('ephemeralNode:execute'),
+			});
+			expect(ephemeralNodeExecutor.executeInline).not.toHaveBeenCalled();
+			expect(projectService.getProjectWithScope).toHaveBeenCalledWith(user, 'proj-1', [
+				'ephemeralNode:execute',
+			]);
+		});
+
+		test('passes credentials and inputData through to the executor', async () => {
+			const { ephemeralNodeExecutor, projectService, telemetry } = createMocks();
+			const tool = createExecuteEphemeralNodeTool(
+				user,
+				ephemeralNodeExecutor,
+				projectService,
+				telemetry,
+			);
+
+			await tool.handler(
+				{
+					...buildBaseInput(),
+					credentials: {
+						httpHeaderAuth: { id: 'cred-1', name: 'My Auth' },
+					} as never,
+					inputData: [{ json: { foo: 'bar' } }] as never,
+				},
+				{} as never,
+			);
+
+			expect(ephemeralNodeExecutor.executeInline).toHaveBeenCalledWith(
+				expect.objectContaining({
+					credentialDetails: { httpHeaderAuth: { id: 'cred-1', name: 'My Auth' } },
+					inputData: [{ json: { foo: 'bar' } }],
+				}),
+			);
+		});
+
+		test('tracks telemetry on success without leaking node parameters', async () => {
+			const { ephemeralNodeExecutor, projectService, telemetry } = createMocks();
+			const tool = createExecuteEphemeralNodeTool(
+				user,
+				ephemeralNodeExecutor,
+				projectService,
+				telemetry,
+			);
+
+			await tool.handler(
+				{
+					...buildBaseInput(),
+					credentials: { httpHeaderAuth: { id: 'cred-1', name: 'My Auth' } } as never,
+					inputData: [{ json: { secret: 'shhh' } }] as never,
+				},
+				{} as never,
+			);
+
+			expect(telemetry.track).toHaveBeenCalledWith(
+				'User called mcp tool',
+				expect.objectContaining({
+					user_id: 'user-1',
+					tool_name: 'execute_ephemeral_node',
+					parameters: {
+						nodeType: 'n8n-nodes-base.httpRequest',
+						nodeTypeVersion: 4.2,
+						projectId: 'proj-1',
+						hasCredentials: true,
+						hasInput: true,
+					},
+					results: { success: true, data: { status: 'success' } },
+				}),
+			);
+			// Parameters payload must not contain nodeParameters or inputData values
+			const trackedParams = (telemetry.track as jest.Mock).mock.calls[0][1].parameters;
+			expect(trackedParams).not.toHaveProperty('nodeParameters');
+			expect(trackedParams).not.toHaveProperty('inputData');
+			expect(trackedParams).not.toHaveProperty('credentials');
+		});
+
+		test('tracks telemetry on executor error', async () => {
+			const { ephemeralNodeExecutor, projectService, telemetry } = createMocks({
+				executeInline: jest
+					.fn()
+					.mockResolvedValue({ status: 'error', data: [], error: 'Node is not usable as a tool' }),
+			});
+			const tool = createExecuteEphemeralNodeTool(
+				user,
+				ephemeralNodeExecutor,
+				projectService,
+				telemetry,
+			);
+
+			await tool.handler(buildBaseInput(), {} as never);
+
+			expect(telemetry.track).toHaveBeenCalledWith(
+				'User called mcp tool',
+				expect.objectContaining({
+					results: expect.objectContaining({
+						success: false,
+						error: 'Node is not usable as a tool',
+					}),
+				}),
+			);
+		});
+
+		test('catches thrown executor errors and returns status:error', async () => {
+			const { ephemeralNodeExecutor, projectService, telemetry } = createMocks({
+				executeInline: jest.fn().mockRejectedValue(new Error('boom')),
+			});
+			const tool = createExecuteEphemeralNodeTool(
+				user,
+				ephemeralNodeExecutor,
+				projectService,
+				telemetry,
+			);
+
+			const result = await tool.handler(buildBaseInput(), {} as never);
+
+			expect(result.structuredContent).toMatchObject({
+				status: 'error',
+				data: [],
+				error: 'boom',
+			});
+			expect(telemetry.track).toHaveBeenCalledWith(
+				'User called mcp tool',
+				expect.objectContaining({
+					results: expect.objectContaining({ success: false }),
+				}),
+			);
+		});
+	});
+});

--- a/packages/cli/src/modules/mcp/__tests__/mcp.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.service.test.ts
@@ -20,6 +20,7 @@ import { CollaborationService } from '@/collaboration/collaboration.service';
 import { CredentialsService } from '@/credentials/credentials.service';
 import { ExecutionService } from '@/executions/execution.service';
 import { DataTableProxyService } from '@/modules/data-table/data-table-proxy.service';
+import { EphemeralNodeExecutor } from '@/node-execution';
 import { NodeTypes } from '@/node-types';
 import { ProjectService } from '@/services/project.service.ee';
 import { RoleService } from '@/services/role.service';
@@ -73,6 +74,7 @@ describe('McpService', () => {
 			mockInstance(ExecutionService),
 			mockInstance(DataTableProxyService),
 			mockInstance(CollaborationService),
+			mockInstance(EphemeralNodeExecutor),
 		);
 	});
 
@@ -113,6 +115,7 @@ describe('McpService', () => {
 				mockInstance(ExecutionService),
 				mockInstance(DataTableProxyService),
 				mockInstance(CollaborationService),
+				mockInstance(EphemeralNodeExecutor),
 			);
 
 			expect(queueMcpService.isQueueMode).toBe(true);
@@ -318,6 +321,7 @@ describe('McpService', () => {
 				mockInstance(ExecutionService),
 				mockInstance(DataTableProxyService),
 				mockInstance(CollaborationService),
+				mockInstance(EphemeralNodeExecutor),
 			);
 
 			const server = await service.getServer(user);
@@ -360,6 +364,7 @@ describe('McpService', () => {
 				mockInstance(ExecutionService),
 				mockInstance(DataTableProxyService),
 				mockInstance(CollaborationService),
+				mockInstance(EphemeralNodeExecutor),
 			);
 
 			const server = await service.getServer(user);

--- a/packages/cli/src/modules/mcp/mcp.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.service.ts
@@ -26,6 +26,7 @@ import {
 	createRenameDataTableTool,
 	createSearchDataTablesTool,
 } from './tools/data-table';
+import { createExecuteEphemeralNodeTool } from './tools/execute-ephemeral-node.tool';
 import { createExecuteWorkflowTool } from './tools/execute-workflow.tool';
 import { createGetExecutionTool } from './tools/get-execution.tool';
 import { createSearchExecutionsTool } from './tools/search-executions.tool';
@@ -52,6 +53,7 @@ import { ActiveExecutions } from '@/active-executions';
 import { CollaborationService } from '@/collaboration/collaboration.service';
 import { CredentialsService } from '@/credentials/credentials.service';
 import { DataTableProxyService } from '@/modules/data-table/data-table-proxy.service';
+import { EphemeralNodeExecutor } from '@/node-execution';
 import { NodeTypes } from '@/node-types';
 import { ProjectService } from '@/services/project.service.ee';
 import { RoleService } from '@/services/role.service';
@@ -106,6 +108,7 @@ export class McpService {
 		private readonly executionService: ExecutionService,
 		private readonly dataTableProxyService: DataTableProxyService,
 		private readonly collaborationService: CollaborationService,
+		private readonly ephemeralNodeExecutor: EphemeralNodeExecutor,
 	) {}
 
 	async getServer(user: User) {
@@ -245,6 +248,18 @@ export class McpService {
 			listCredentialsTool.name,
 			listCredentialsTool.config,
 			listCredentialsTool.handler,
+		);
+
+		const executeEphemeralNodeTool = createExecuteEphemeralNodeTool(
+			user,
+			this.ephemeralNodeExecutor,
+			this.projectService,
+			this.telemetry,
+		);
+		server.registerTool(
+			executeEphemeralNodeTool.name,
+			executeEphemeralNodeTool.config,
+			executeEphemeralNodeTool.handler,
 		);
 
 		// Data table tools

--- a/packages/cli/src/modules/mcp/tools/execute-ephemeral-node.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/execute-ephemeral-node.tool.ts
@@ -1,0 +1,185 @@
+import type { User } from '@n8n/db';
+import type { INodeCredentialsDetails, INodeExecutionData, INodeParameters } from 'n8n-workflow';
+import { ensureError, jsonStringify } from 'n8n-workflow';
+import { z } from 'zod';
+
+import type { EphemeralNodeExecutor } from '@/node-execution';
+import type { ProjectService } from '@/services/project.service.ee';
+import type { Telemetry } from '@/telemetry';
+
+import { USER_CALLED_MCP_TOOL_EVENT } from '../mcp.constants';
+import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../mcp.types';
+
+const credentialRefSchema = z.object({
+	id: z.string().describe('Credential ID from list_credentials.'),
+	name: z.string().describe('Credential name from list_credentials.'),
+});
+
+const inputDataItemSchema = z.object({
+	json: z
+		.record(z.unknown())
+		.describe('JSON payload exposed to the node as $json during execution.'),
+});
+
+const inputSchema = {
+	projectId: z
+		.string()
+		.describe(
+			'The n8n project that owns the credentials. Use the homeProject.id from list_credentials.',
+		),
+	nodeType: z
+		.string()
+		.describe(
+			'Canonical node id, e.g. "n8n-nodes-base.httpRequest". Get from search_workflow_nodes.',
+		),
+	nodeTypeVersion: z
+		.number()
+		.describe('Node type version to execute (e.g. 4.2). Get from search_workflow_nodes.'),
+	nodeParameters: z
+		.record(z.unknown())
+		.describe(
+			'Parameters block for the node — same shape as a workflow JSON. Use n8n expressions like ={{ $json.url }} to reference inputData.',
+		),
+	credentials: z
+		.record(credentialRefSchema)
+		.optional()
+		.describe(
+			'Credentials keyed by credential type (e.g. "httpHeaderAuth"). Each value is { id, name } from list_credentials. Omit for nodes that need no credential.',
+		),
+	inputData: z
+		.array(inputDataItemSchema)
+		.optional()
+		.describe(
+			'Items passed to the node as input. Each item drives one iteration of the node — passing an empty array short-circuits to no output. ' +
+				'For nodes that take no input (e.g. an HTTP request, a "getAll" call), omit this field and the tool will execute the node once with an empty item.',
+		),
+} satisfies z.ZodRawShape;
+
+const outputSchema = {
+	status: z
+		.enum(['success', 'error'])
+		.describe('"success" when the node ran, "error" when validation or execution failed.'),
+	data: z
+		.array(z.object({ json: z.unknown() }).passthrough())
+		.describe('Node output items. Empty array on error.'),
+	error: z.string().optional().describe('Error message when status is "error".'),
+} satisfies z.ZodRawShape;
+
+type ExecuteEphemeralNodeInput = z.infer<z.ZodObject<typeof inputSchema>>;
+type ExecuteEphemeralNodeOutput = {
+	status: 'success' | 'error';
+	data: INodeExecutionData[];
+	error?: string;
+};
+
+export const createExecuteEphemeralNodeTool = (
+	user: User,
+	ephemeralNodeExecutor: EphemeralNodeExecutor,
+	projectService: ProjectService,
+	telemetry: Telemetry,
+): ToolDefinition<typeof inputSchema> => ({
+	name: 'execute_ephemeral_node',
+	config: {
+		description:
+			'Run a single n8n node against real credentials without saving a workflow or execution. ' +
+			'Use this for one-shot calls — testing an HTTP request, sending a Slack message, querying a DB — ' +
+			'when the user does not have an existing workflow. ' +
+			'For invoking an existing workflow, use execute_workflow instead. ' +
+			'Always call list_credentials first to get credential id + name, and search_workflow_nodes to confirm nodeType + nodeTypeVersion. ' +
+			'Trigger nodes are not supported. ' +
+			'Operations that wait for human input (sendAndWait, dispatchAndWait) are not supported.',
+		inputSchema,
+		outputSchema,
+		annotations: {
+			title: 'Execute Single Node',
+			readOnlyHint: false,
+			destructiveHint: true,
+			idempotentHint: false,
+			openWorldHint: true,
+		},
+	},
+	handler: async ({
+		projectId,
+		nodeType,
+		nodeTypeVersion,
+		nodeParameters,
+		credentials,
+		inputData,
+	}: ExecuteEphemeralNodeInput) => {
+		const telemetryPayload: UserCalledMCPToolEventPayload = {
+			user_id: user.id,
+			tool_name: 'execute_ephemeral_node',
+			parameters: {
+				nodeType,
+				nodeTypeVersion,
+				projectId,
+				hasCredentials: credentials ? Object.keys(credentials).length > 0 : false,
+				hasInput: inputData ? inputData.length > 0 : false,
+			},
+		};
+
+		const respond = (output: ExecuteEphemeralNodeOutput) => ({
+			content: [{ type: 'text' as const, text: jsonStringify(output) }],
+			structuredContent: output,
+		});
+
+		try {
+			const project = await projectService.getProjectWithScope(user, projectId, [
+				'ephemeralNode:execute',
+			]);
+
+			if (!project) {
+				const output: ExecuteEphemeralNodeOutput = {
+					status: 'error',
+					data: [],
+					error: `Project "${projectId}" not found or you lack the ephemeralNode:execute scope on it.`,
+				};
+				telemetryPayload.results = {
+					success: false,
+					error: output.error,
+				};
+				telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
+				return respond(output);
+			}
+
+			// n8n nodes iterate once per input item. Passing [] makes the node
+			// short-circuit to empty output with no error — a silent footgun that
+			// looks like an auth/permissions issue. The internal agent runtime
+			// (agents-tools.service.ts) sidesteps this by always sending one item;
+			// mirror that here so omitting `inputData` Does The Right Thing.
+			const effectiveInputData: INodeExecutionData[] =
+				inputData && inputData.length > 0 ? (inputData as INodeExecutionData[]) : [{ json: {} }];
+
+			const result = await ephemeralNodeExecutor.executeInline({
+				projectId,
+				nodeType,
+				nodeTypeVersion,
+				nodeParameters: nodeParameters as INodeParameters,
+				credentialDetails: credentials as Record<string, INodeCredentialsDetails> | undefined,
+				inputData: effectiveInputData,
+			});
+
+			telemetryPayload.results = {
+				success: result.status === 'success',
+				data: { status: result.status },
+				...(result.status === 'error' ? { error: result.error ?? 'Unknown error' } : {}),
+			};
+			telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
+
+			return respond(result);
+		} catch (er) {
+			const error = ensureError(er);
+			const output: ExecuteEphemeralNodeOutput = {
+				status: 'error',
+				data: [],
+				error: error.message || `${error.constructor.name}: (no message)`,
+			};
+			telemetryPayload.results = {
+				success: false,
+				error: { message: error.message, name: error.constructor.name },
+			};
+			telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
+			return respond(output);
+		}
+	},
+});

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/mcp-instructions.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/mcp-instructions.ts
@@ -20,6 +20,9 @@ import {
 export function getMcpInstructions(isBuilderEnabled: boolean): string {
 	const INTRO = 'This is the official MCP server for n8n, a workflow automation platform.';
 
+	const EPHEMERAL_NODE_GUIDANCE =
+		'Single-node execution: when the user wants to run one node (test an HTTP request, send a Slack message, query a database) without a workflow, use execute_ephemeral_node. Call list_credentials first to get { id, name } and search_workflow_nodes to confirm nodeType + nodeTypeVersion. For invoking an existing workflow, use execute_workflow instead.';
+
 	const BUILDER_INSTRUCTIONS = `This MCP server provides tools to build n8n workflows programmatically using the n8n Workflow SDK.
 
 To build n8n workflows, follow these steps in order:
@@ -42,5 +45,6 @@ To build n8n workflows, follow these steps in order:
 
 9. Archive: Call ${MCP_ARCHIVE_WORKFLOW_TOOL.toolName} with the workflow ID.`;
 
-	return isBuilderEnabled ? `${INTRO}\n\n${BUILDER_INSTRUCTIONS}` : INTRO;
+	const base = `${INTRO}\n\n${EPHEMERAL_NODE_GUIDANCE}`;
+	return isBuilderEnabled ? `${base}\n\n${BUILDER_INSTRUCTIONS}` : base;
 }


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Adds the execute_ephemeral_node MCP tool, so external LLM clients (Claude Desktop and the rest of the n8n MCP audience) can run a single n8n node against real credentials without persisting a workflow or execution.

Builds on the public-API ephemeral-node work from #30385 (scopes), #30387 (list endpoint), #30395 (execute endpoint). The MCP tool calls EphemeralNodeExecutor.executeInline directly (in-process), bypassing HTTP — same executor, same safety rails.

### What’s in the tool:

- Thin wrapper over EphemeralNodeExecutor.executeInline, gated by ephemeralNode:execute via ProjectService.getProjectWithScope (global-scope fallback + project membership).
- Defaults inputData to [{ json: {} }] when omitted/empty. Without this, nodes silently short-circuit to empty output with no error — the failure mode looks like a permissions issue and is non-obvious. Mirrors the workaround the internal agent runtime applies at agents-tools.service.ts:234. Worth flagging to whoever owns the executor; the same footgun exists on the public API path.
- Telemetry scrubs nodeParameters, inputData, and credentials values — sends only presence booleans plus nodeType/nodeTypeVersion/projectId.
- Annotations: destructiveHint: true, openWorldHint: true (same as execute_workflow).
- One-paragraph guidance added to getMcpInstructions so LLMs pick between execute_ephemeral_node and execute_workflow.

### How to test:

- pnpm --filter=n8n test execute-ephemeral-node — 9 unit tests cover success, executor-error passthrough, scope denial, credential + inputData passthrough, the inputData: [] default, telemetry (success + error), and thrown-error catch.
- pnpm --filter=n8n test mcp.service — 16 existing tests still green (constructor signature widened by one).
Manual: hit tools/list on the MCP endpoint with a key that has ephemeralNode:execute, then tools/call with a payload matching the schema (e.g. HTTP Request to https://api.github.com/zen).

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
