### PR TITLE
feat(core): Route executions to project-level worker pool defaults (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/repositories/index.ts
+++ b/packages/@n8n/db/src/repositories/index.ts
@@ -31,6 +31,7 @@ export { FolderTagMappingRepository } from './folder-tag-mapping.repository';
 export { ScopeRepository } from './scope.repository';
 export { InvalidAuthTokenRepository } from './invalid-auth-token.repository';
 export { LicenseMetricsRepository } from './license-metrics.repository';
+export { ProjectPoolSettingsRepository } from './project-pool-settings.repository';
 export { ProjectRelationRepository } from './project-relation.repository';
 export { ProjectRepository, type ProjectListOptions } from './project.repository';
 export { RoleRepository } from './role.repository';

--- a/packages/@n8n/db/src/repositories/project-pool-settings.repository.ts
+++ b/packages/@n8n/db/src/repositories/project-pool-settings.repository.ts
@@ -1,0 +1,11 @@
+import { Service } from '@n8n/di';
+import { DataSource, Repository } from '@n8n/typeorm';
+
+import { ProjectPoolSettings } from '../entities';
+
+@Service()
+export class ProjectPoolSettingsRepository extends Repository<ProjectPoolSettings> {
+	constructor(dataSource: DataSource) {
+		super(ProjectPoolSettings, dataSource.manager);
+	}
+}

--- a/packages/@n8n/db/src/repositories/project-pool-settings.repository.ts
+++ b/packages/@n8n/db/src/repositories/project-pool-settings.repository.ts
@@ -3,9 +3,27 @@ import { DataSource, Repository } from '@n8n/typeorm';
 
 import { ProjectPoolSettings } from '../entities';
 
+const CATEGORY_COLUMN = {
+	production: 'productionPool',
+	manual: 'manualPool',
+	evaluation: 'evaluationPool',
+} as const satisfies Record<string, keyof ProjectPoolSettings>;
+
 @Service()
 export class ProjectPoolSettingsRepository extends Repository<ProjectPoolSettings> {
 	constructor(dataSource: DataSource) {
 		super(ProjectPoolSettings, dataSource.manager);
+	}
+
+	async getPoolForCategory(
+		projectId: string,
+		category: 'production' | 'manual' | 'evaluation',
+	): Promise<string | undefined> {
+		const column = CATEGORY_COLUMN[category];
+		const row = await this.findOne({
+			where: { projectId },
+			select: [column],
+		});
+		return row?.[column] ?? undefined;
 	}
 }

--- a/packages/cli/src/scaling/__tests__/pool-config.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/pool-config.service.test.ts
@@ -1,4 +1,4 @@
-import type { SettingsRepository } from '@n8n/db';
+import type { ProjectPoolSettingsRepository, SettingsRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 
 import { PoolConfigService } from '@/scaling/pool-config.service';
@@ -6,8 +6,13 @@ import type { CacheService } from '@/services/cache/cache.service';
 
 describe('PoolConfigService', () => {
 	const settingsRepository = mock<SettingsRepository>();
+	const projectPoolSettingsRepository = mock<ProjectPoolSettingsRepository>();
 	const cacheService = mock<CacheService>();
-	const service = new PoolConfigService(settingsRepository, cacheService);
+	const service = new PoolConfigService(
+		settingsRepository,
+		projectPoolSettingsRepository,
+		cacheService,
+	);
 
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -62,6 +67,77 @@ describe('PoolConfigService', () => {
 
 			expect(settingsRepository.upsert).toHaveBeenCalledTimes(1);
 			expect(cacheService.set).toHaveBeenCalledTimes(1);
+		});
+	});
+
+	describe('getProjectPool', () => {
+		const projectId = 'project-123';
+		const cacheKey = `projectPool:${projectId}`;
+
+		it('should return pool from DB on cache miss', async () => {
+			cacheService.get.mockResolvedValue(undefined);
+			projectPoolSettingsRepository.findOneBy.mockResolvedValue({
+				projectId,
+				productionPool: 'gpu',
+				manualPool: null,
+				evaluationPool: 'eval',
+				allowedPools: [],
+			} as never);
+
+			const result = await service.getProjectPool(projectId, 'production');
+
+			expect(result).toBe('gpu');
+			expect(projectPoolSettingsRepository.findOneBy).toHaveBeenCalledWith({ projectId });
+			expect(cacheService.set).toHaveBeenCalledWith(
+				cacheKey,
+				JSON.stringify({ productionPool: 'gpu', manualPool: null, evaluationPool: 'eval' }),
+			);
+		});
+
+		it('should return pool from cache on cache hit', async () => {
+			cacheService.get.mockResolvedValue(
+				JSON.stringify({ productionPool: 'gpu', manualPool: null, evaluationPool: 'eval' }),
+			);
+
+			const result = await service.getProjectPool(projectId, 'production');
+
+			expect(result).toBe('gpu');
+			expect(projectPoolSettingsRepository.findOneBy).not.toHaveBeenCalled();
+		});
+
+		it('should return undefined when no settings row exists', async () => {
+			cacheService.get.mockResolvedValue(undefined);
+			projectPoolSettingsRepository.findOneBy.mockResolvedValue(null);
+
+			const result = await service.getProjectPool(projectId, 'production');
+
+			expect(result).toBeUndefined();
+			expect(cacheService.set).toHaveBeenCalledWith(cacheKey, JSON.stringify({}));
+		});
+
+		it('should return undefined when category column is null', async () => {
+			cacheService.get.mockResolvedValue(undefined);
+			projectPoolSettingsRepository.findOneBy.mockResolvedValue({
+				projectId,
+				productionPool: null,
+				manualPool: 'cpu',
+				evaluationPool: null,
+				allowedPools: [],
+			} as never);
+
+			const result = await service.getProjectPool(projectId, 'production');
+
+			expect(result).toBeUndefined();
+		});
+
+		it('should return correct pool per category', async () => {
+			cacheService.get.mockResolvedValue(
+				JSON.stringify({ productionPool: 'gpu', manualPool: 'cpu', evaluationPool: 'eval' }),
+			);
+
+			expect(await service.getProjectPool(projectId, 'production')).toBe('gpu');
+			expect(await service.getProjectPool(projectId, 'manual')).toBe('cpu');
+			expect(await service.getProjectPool(projectId, 'evaluation')).toBe('eval');
 		});
 	});
 });

--- a/packages/cli/src/scaling/__tests__/pool-config.service.test.ts
+++ b/packages/cli/src/scaling/__tests__/pool-config.service.test.ts
@@ -72,72 +72,60 @@ describe('PoolConfigService', () => {
 
 	describe('getProjectPool', () => {
 		const projectId = 'project-123';
-		const cacheKey = `projectPool:${projectId}`;
 
 		it('should return pool from DB on cache miss', async () => {
 			cacheService.get.mockResolvedValue(undefined);
-			projectPoolSettingsRepository.findOneBy.mockResolvedValue({
-				projectId,
-				productionPool: 'gpu',
-				manualPool: null,
-				evaluationPool: 'eval',
-				allowedPools: [],
-			} as never);
+			projectPoolSettingsRepository.getPoolForCategory.mockResolvedValue('gpu');
 
 			const result = await service.getProjectPool(projectId, 'production');
 
 			expect(result).toBe('gpu');
-			expect(projectPoolSettingsRepository.findOneBy).toHaveBeenCalledWith({ projectId });
-			expect(cacheService.set).toHaveBeenCalledWith(
-				cacheKey,
-				JSON.stringify({ productionPool: 'gpu', manualPool: null, evaluationPool: 'eval' }),
+			expect(projectPoolSettingsRepository.getPoolForCategory).toHaveBeenCalledWith(
+				projectId,
+				'production',
 			);
+			expect(cacheService.set).toHaveBeenCalledWith(`projectPool:${projectId}:production`, 'gpu');
 		});
 
 		it('should return pool from cache on cache hit', async () => {
-			cacheService.get.mockResolvedValue(
-				JSON.stringify({ productionPool: 'gpu', manualPool: null, evaluationPool: 'eval' }),
-			);
+			cacheService.get.mockResolvedValue('gpu');
 
 			const result = await service.getProjectPool(projectId, 'production');
 
 			expect(result).toBe('gpu');
-			expect(projectPoolSettingsRepository.findOneBy).not.toHaveBeenCalled();
+			expect(projectPoolSettingsRepository.getPoolForCategory).not.toHaveBeenCalled();
 		});
 
 		it('should return undefined when no settings row exists', async () => {
 			cacheService.get.mockResolvedValue(undefined);
-			projectPoolSettingsRepository.findOneBy.mockResolvedValue(null);
+			projectPoolSettingsRepository.getPoolForCategory.mockResolvedValue(undefined);
 
 			const result = await service.getProjectPool(projectId, 'production');
 
 			expect(result).toBeUndefined();
-			expect(cacheService.set).toHaveBeenCalledWith(cacheKey, JSON.stringify({}));
+			expect(cacheService.set).toHaveBeenCalledWith(`projectPool:${projectId}:production`, '');
 		});
 
-		it('should return undefined when category column is null', async () => {
+		it('should return undefined when cached value is empty string', async () => {
+			cacheService.get.mockResolvedValue('');
+
+			const result = await service.getProjectPool(projectId, 'production');
+
+			expect(result).toBeUndefined();
+			expect(projectPoolSettingsRepository.getPoolForCategory).not.toHaveBeenCalled();
+		});
+
+		it('should cache per category', async () => {
 			cacheService.get.mockResolvedValue(undefined);
-			projectPoolSettingsRepository.findOneBy.mockResolvedValue({
-				projectId,
-				productionPool: null,
-				manualPool: 'cpu',
-				evaluationPool: null,
-				allowedPools: [],
-			} as never);
+			projectPoolSettingsRepository.getPoolForCategory
+				.mockResolvedValueOnce('gpu')
+				.mockResolvedValueOnce('cpu');
 
-			const result = await service.getProjectPool(projectId, 'production');
+			await service.getProjectPool(projectId, 'production');
+			await service.getProjectPool(projectId, 'manual');
 
-			expect(result).toBeUndefined();
-		});
-
-		it('should return correct pool per category', async () => {
-			cacheService.get.mockResolvedValue(
-				JSON.stringify({ productionPool: 'gpu', manualPool: 'cpu', evaluationPool: 'eval' }),
-			);
-
-			expect(await service.getProjectPool(projectId, 'production')).toBe('gpu');
-			expect(await service.getProjectPool(projectId, 'manual')).toBe('cpu');
-			expect(await service.getProjectPool(projectId, 'evaluation')).toBe('eval');
+			expect(cacheService.set).toHaveBeenCalledWith(`projectPool:${projectId}:production`, 'gpu');
+			expect(cacheService.set).toHaveBeenCalledWith(`projectPool:${projectId}:manual`, 'cpu');
 		});
 	});
 });

--- a/packages/cli/src/scaling/pool-config.service.ts
+++ b/packages/cli/src/scaling/pool-config.service.ts
@@ -65,44 +65,17 @@ export class PoolConfigService {
 		projectId: string,
 		category: ExecutionCategory,
 	): Promise<string | undefined> {
-		const cacheKey = `projectPool:${projectId}`;
+		const cacheKey = `projectPool:${projectId}:${category}`;
 
 		const cached = await this.cacheService.get<string>(cacheKey);
-		if (cached !== undefined) {
-			const settings = jsonParse<ProjectPoolColumns>(cached, { fallbackValue: {} });
-			return pickPool(settings, category) ?? undefined;
-		}
+		if (cached !== undefined) return cached || undefined;
 
-		const row = await this.projectPoolSettingsRepository.findOneBy({ projectId });
+		const poolName = await this.projectPoolSettingsRepository.getPoolForCategory(
+			projectId,
+			category,
+		);
 
-		const toCache = row
-			? JSON.stringify({
-					productionPool: row.productionPool,
-					manualPool: row.manualPool,
-					evaluationPool: row.evaluationPool,
-				})
-			: JSON.stringify({});
-		await this.cacheService.set(cacheKey, toCache);
-
-		if (!row) return undefined;
-		return pickPool(row, category) ?? undefined;
-	}
-}
-
-type ProjectPoolColumns = Partial<
-	Pick<import('@n8n/db').ProjectPoolSettings, 'productionPool' | 'manualPool' | 'evaluationPool'>
->;
-
-function pickPool(
-	settings: ProjectPoolColumns,
-	category: ExecutionCategory,
-): string | null | undefined {
-	switch (category) {
-		case 'production':
-			return settings.productionPool;
-		case 'manual':
-			return settings.manualPool;
-		case 'evaluation':
-			return settings.evaluationPool;
+		void this.cacheService.set(cacheKey, poolName ?? '');
+		return poolName;
 	}
 }

--- a/packages/cli/src/scaling/pool-config.service.ts
+++ b/packages/cli/src/scaling/pool-config.service.ts
@@ -1,4 +1,4 @@
-import { SettingsRepository } from '@n8n/db';
+import { ProjectPoolSettingsRepository, SettingsRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { jsonParse } from 'n8n-workflow';
 
@@ -14,6 +14,7 @@ const SETTINGS_KEY = 'workerPools.assignment';
 export class PoolConfigService {
 	constructor(
 		private readonly settingsRepository: SettingsRepository,
+		private readonly projectPoolSettingsRepository: ProjectPoolSettingsRepository,
 		private readonly cacheService: CacheService,
 	) {}
 
@@ -58,5 +59,50 @@ export class PoolConfigService {
 		await this.cacheService.set(SETTINGS_KEY, serialized);
 
 		return next;
+	}
+
+	async getProjectPool(
+		projectId: string,
+		category: ExecutionCategory,
+	): Promise<string | undefined> {
+		const cacheKey = `projectPool:${projectId}`;
+
+		const cached = await this.cacheService.get<string>(cacheKey);
+		if (cached !== undefined) {
+			const settings = jsonParse<ProjectPoolColumns>(cached, { fallbackValue: {} });
+			return pickPool(settings, category) ?? undefined;
+		}
+
+		const row = await this.projectPoolSettingsRepository.findOneBy({ projectId });
+
+		const toCache = row
+			? JSON.stringify({
+					productionPool: row.productionPool,
+					manualPool: row.manualPool,
+					evaluationPool: row.evaluationPool,
+				})
+			: JSON.stringify({});
+		await this.cacheService.set(cacheKey, toCache);
+
+		if (!row) return undefined;
+		return pickPool(row, category) ?? undefined;
+	}
+}
+
+type ProjectPoolColumns = Partial<
+	Pick<import('@n8n/db').ProjectPoolSettings, 'productionPool' | 'manualPool' | 'evaluationPool'>
+>;
+
+function pickPool(
+	settings: ProjectPoolColumns,
+	category: ExecutionCategory,
+): string | null | undefined {
+	switch (category) {
+		case 'production':
+			return settings.productionPool;
+		case 'manual':
+			return settings.manualPool;
+		case 'evaluation':
+			return settings.evaluationPool;
 	}
 }

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -696,6 +696,13 @@ export class WorkflowRunner {
 			return { queueName: poolQueueName(overridePoolName), poolName: overridePoolName };
 		}
 
+		if (category && data.projectId) {
+			const projectPool = await this.poolConfigService.getProjectPool(data.projectId, category);
+			if (projectPool) {
+				return { queueName: poolQueueName(projectPool), poolName: projectPool };
+			}
+		}
+
 		const poolAssignment = await this.poolConfigService.getPoolAssignment();
 		const poolName = category ? poolAssignment[category] : undefined;
 

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -678,22 +678,10 @@ export class WorkflowRunner {
 		data: IWorkflowExecutionDataProcess,
 	): Promise<{ queueName: string; poolName: string | undefined }> {
 		const category = getExecutionCategory(data.executionMode);
-		let overridePoolName: string | undefined;
 
-		switch (category) {
-			case 'production':
-				overridePoolName = data.workflowData.settings?.workerPoolOverrideProduction;
-				break;
-			case 'manual':
-				overridePoolName = data.workflowData.settings?.workerPoolOverrideManual;
-				break;
-			case 'evaluation':
-				overridePoolName = data.workflowData.settings?.workerPoolOverrideEvaluation;
-				break;
-		}
-
-		if (overridePoolName) {
-			return { queueName: poolQueueName(overridePoolName), poolName: overridePoolName };
+		const workflowPool = this.getWorkflowPool(data, category);
+		if (workflowPool) {
+			return { queueName: poolQueueName(workflowPool), poolName: workflowPool };
 		}
 
 		if (category && data.projectId) {
@@ -707,6 +695,22 @@ export class WorkflowRunner {
 		const poolName = category ? poolAssignment[category] : undefined;
 
 		return { queueName: poolQueueName(poolName), poolName };
+	}
+
+	private getWorkflowPool(
+		data: IWorkflowExecutionDataProcess,
+		category: ReturnType<typeof getExecutionCategory>,
+	): string | undefined {
+		switch (category) {
+			case 'production':
+				return data.workflowData.settings?.workerPoolOverrideProduction;
+			case 'manual':
+				return data.workflowData.settings?.workerPoolOverrideManual;
+			case 'evaluation':
+				return data.workflowData.settings?.workerPoolOverrideEvaluation;
+			default:
+				return undefined;
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Adds project-level pool settings as a middle tier in the worker pool routing hierarchy. When determining which queue an execution should be routed to, the system now checks:

1. **Workflow-level override** — per-workflow pool settings
2. **Project-level default** — from the new `ProjectPoolSettings` entity (new tier)
3. **Instance-level default** — global pool assignment

Changes:
- Created `ProjectPoolSettingsRepository` for the existing `ProjectPoolSettings` entity
- Extended `PoolConfigService` with `getProjectPool()` method (cached via `CacheService`)
- Inserted project-level lookup in `WorkflowRunner.getQueueForWorkflow()` between the workflow override and instance fallback
- Added 5 unit tests covering cache hit/miss, missing rows, null columns, and per-category mapping

## Related Linear tickets, Github issues, and Community forum posts

Part of the worker pools feature branch (`hackmation/worker-pools`).

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI