### PR TITLE
feat(API): Allow ephemeral node execution to target any accessible project

### DIFF
--- a/packages/@n8n/api-types/src/dto/ephemeral-nodes/execute-ephemeral-node-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/ephemeral-nodes/execute-ephemeral-node-request.dto.ts
@@ -13,4 +13,5 @@ export class ExecuteEphemeralNodeRequestDto extends Z.class({
 	nodeParameters: z.record(z.string(), z.unknown()).default({}),
 	credentials: z.record(z.string(), credentialDetailSchema).optional(),
 	inputData: z.array(z.record(z.string(), z.unknown())).optional().default([]),
+	projectId: z.string().min(1).optional(),
 }) {}

--- a/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/ephemeral-nodes.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/ephemeral-nodes.handler.ts
@@ -5,9 +5,11 @@ import { Container } from '@n8n/di';
 import type { INodeParameters } from 'n8n-workflow';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import { EphemeralNodeExecutor } from '@/node-execution/ephemeral-node-executor';
 import type { PaginatedRequest } from '@/public-api/types';
+import { ProjectService } from '@/services/project.service.ee';
 
 import { isNodeTypeAllowlisted } from './ephemeral-nodes.allowlist';
 import {
@@ -48,9 +50,22 @@ const ephemeralNodesHandlers: EphemeralNodesHandlers = {
 				throw new BadRequestError(`Node type "${dto.nodeType}" is not available for execution`);
 			}
 
-			const projectId = (
-				await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(req.user.id)
-			).id;
+			let projectId: string;
+			if (dto.projectId) {
+				const project = await Container.get(ProjectService).getProjectWithScope(
+					req.user,
+					dto.projectId,
+					['workflow:execute'],
+				);
+				if (!project) {
+					throw new NotFoundError('Project not found');
+				}
+				projectId = project.id;
+			} else {
+				projectId = (
+					await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(req.user.id)
+				).id;
+			}
 
 			const executor = Container.get(EphemeralNodeExecutor);
 

--- a/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/spec/schemas/ephemeralNodeExecutionRequest.yml
+++ b/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/spec/schemas/ephemeralNodeExecutionRequest.yml
@@ -45,3 +45,10 @@ properties:
     example:
       - id: 1
         name: Alice
+  projectId:
+    type: string
+    description: >
+      ID of the project to execute the node in. The authenticated user must
+      have access to this project with the `workflow:execute` scope. If
+      omitted, the caller's personal project is used.
+    example: bcU7tnwBwoIO4MaP

--- a/packages/cli/test/integration/public-api/ephemeral-nodes-execute.test.ts
+++ b/packages/cli/test/integration/public-api/ephemeral-nodes-execute.test.ts
@@ -1,4 +1,9 @@
-import { mockInstance, getPersonalProject } from '@n8n/backend-test-utils';
+import {
+	mockInstance,
+	getPersonalProject,
+	createTeamProject,
+	linkUserToProject,
+} from '@n8n/backend-test-utils';
 import type { User } from '@n8n/db';
 import type { ApiKeyScope } from '@n8n/permissions';
 import { UserError } from 'n8n-workflow';
@@ -12,7 +17,11 @@ import * as utils from '../shared/utils/';
 
 const mockExecutor = mockInstance(EphemeralNodeExecutor);
 
-const testServer = utils.setupTestServer({ endpointGroups: ['publicApi'] });
+const testServer = utils.setupTestServer({
+	endpointGroups: ['publicApi'],
+	enabledFeatures: ['feat:projectRole:admin', 'feat:projectRole:editor', 'feat:projectRole:viewer'],
+	quotas: { 'quota:maxTeamProjects': -1 },
+});
 
 let owner: User;
 let member: User;
@@ -149,6 +158,52 @@ describe('POST /ephemeral-nodes/execute', () => {
 			expect(mockExecutor.executeInline).toHaveBeenCalledWith(
 				expect.objectContaining({ projectId: ownerPersonalProjectId }),
 			);
+		});
+
+		test('forwards an explicit projectId the caller has workflow:execute on', async () => {
+			const teamProject = await createTeamProject('Editable team');
+			await linkUserToProject(member, teamProject, 'project:editor');
+
+			await authMemberAgent
+				.post('/ephemeral-nodes/execute')
+				.send({ ...validPayload, projectId: teamProject.id })
+				.expect(200);
+
+			expect(mockExecutor.executeInline).toHaveBeenCalledWith(
+				expect.objectContaining({ projectId: teamProject.id }),
+			);
+		});
+
+		test('returns 404 when projectId points to a project the caller cannot access', async () => {
+			const otherTeamProject = await createTeamProject('Inaccessible team');
+
+			await authMemberAgent
+				.post('/ephemeral-nodes/execute')
+				.send({ ...validPayload, projectId: otherTeamProject.id })
+				.expect(404);
+
+			expect(mockExecutor.executeInline).not.toHaveBeenCalled();
+		});
+
+		test('returns 404 when caller has the project but lacks workflow:execute (viewer role)', async () => {
+			const teamProject = await createTeamProject('Viewer-only team');
+			await linkUserToProject(member, teamProject, 'project:viewer');
+
+			await authMemberAgent
+				.post('/ephemeral-nodes/execute')
+				.send({ ...validPayload, projectId: teamProject.id })
+				.expect(404);
+
+			expect(mockExecutor.executeInline).not.toHaveBeenCalled();
+		});
+
+		test('returns 404 when projectId does not exist', async () => {
+			await authOwnerAgent
+				.post('/ephemeral-nodes/execute')
+				.send({ ...validPayload, projectId: 'does-not-exist' })
+				.expect(404);
+
+			expect(mockExecutor.executeInline).not.toHaveBeenCalled();
 		});
 
 		test('returns 200 with status:error when node execution fails at runtime', async () => {


### PR DESCRIPTION
## Summary

Extends the public API ephemeral node execute endpoint to support a non-personal `projectId`. Previously the handler always resolved to the caller's personal project, so executions could only access credentials/resources shared into that project.

- Adds an optional `projectId` field to `ExecuteEphemeralNodeRequestDto`.
- When supplied, the handler verifies the caller has `workflow:execute` on that project via `ProjectService.getProjectWithScope`. Returns `404` if the project doesn't exist or the caller lacks access (matches the behavior of other public-API endpoints to avoid leaking project existence).
- When omitted, falls back to the caller's personal project (no behavior change for existing clients).
- Updates the OpenAPI schema (`ephemeralNodeExecutionRequest.yml`) to document the new field.
- Adds 4 new integration tests covering: explicit projectId for an editor, 404 for inaccessible project, 404 for viewer (lacks `workflow:execute`), 404 for non-existent project.

The downstream `EphemeralNodeExecutor` already scopes credential resolution and verification by `projectId`, so no executor changes were needed.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Add Linear ticket here, e.g. https://linear.app/n8n/issue/[TICKET-ID] -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)