### PR TITLE
feat: ephemeral node executor public api eng c list nodes endpoint impl

### DIFF
--- a/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/__tests__/ephemeral-nodes.mapper.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/__tests__/ephemeral-nodes.mapper.test.ts
@@ -82,13 +82,25 @@ describe('toInlineRequest', () => {
 		expect(result.inputData).toEqual([{ json: { foo: 'bar' } }, { json: { baz: 1 } }]);
 	});
 
-	it('returns an empty inputData array when the DTO omits it', () => {
+	it('fires the node once with an empty item when the DTO omits inputData', () => {
+		// Action nodes iterate input items to produce output items, so zero
+		// input means zero output. We mirror n8n's Manual Trigger convention:
+		// missing `inputData` becomes a single empty item to make the call
+		// meaningful for one-shot callers.
 		const result = toInlineRequest(
 			makeDto({ inputData: undefined as unknown as ExecuteEphemeralNodeRequestDto['inputData'] }),
 			'project-1',
 		);
 
-		expect(result.inputData).toEqual([]);
+		expect(result.inputData).toEqual([{ json: {} }]);
+	});
+
+	it('preserves an explicitly empty inputData array as a single empty item', () => {
+		// Same reasoning as the `undefined` case — an explicit `[]` from the
+		// caller is treated as "no upstream data" rather than "do nothing".
+		const result = toInlineRequest(makeDto({ inputData: [] }), 'project-1');
+
+		expect(result.inputData).toEqual([{ json: {} }]);
 	});
 });
 

--- a/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/__tests__/ephemeral-nodes.mapper.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/__tests__/ephemeral-nodes.mapper.test.ts
@@ -1,0 +1,254 @@
+import type { ExecuteEphemeralNodeRequestDto } from '@n8n/api-types';
+import { UnexpectedError } from 'n8n-workflow';
+import type { INodeTypeDescription, IWebhookDescription } from 'n8n-workflow';
+import { ZodError } from 'zod';
+
+import {
+	mapToEphemeralNodeList,
+	toInlineRequest,
+	toPublicResponse,
+} from '../ephemeral-nodes.mapper';
+
+const makeDto = (
+	overrides: Partial<ExecuteEphemeralNodeRequestDto> = {},
+): ExecuteEphemeralNodeRequestDto =>
+	({
+		nodeType: 'n8n-nodes-base.httpRequest',
+		nodeTypeVersion: 4.2,
+		nodeParameters: {},
+		inputData: [],
+		...overrides,
+	}) as ExecuteEphemeralNodeRequestDto;
+
+const makeNode = (overrides: Partial<INodeTypeDescription> = {}): INodeTypeDescription =>
+	({
+		name: 'n8n-nodes-base.httpRequest',
+		displayName: 'HTTP Request',
+		description: 'Makes an HTTP request',
+		group: ['input'],
+		version: 4.2,
+		defaultVersion: 4.2,
+		...overrides,
+	}) as INodeTypeDescription;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Execute mapping
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('toInlineRequest', () => {
+	it('passes through nodeType, version, parameters, and projectId', () => {
+		const result = toInlineRequest(
+			makeDto({
+				nodeType: 'n8n-nodes-base.httpRequest',
+				nodeTypeVersion: 4.2,
+				nodeParameters: { url: 'https://example.com' },
+			}),
+			'project-123',
+		);
+
+		expect(result).toMatchObject({
+			nodeType: 'n8n-nodes-base.httpRequest',
+			nodeTypeVersion: 4.2,
+			nodeParameters: { url: 'https://example.com' },
+			projectId: 'project-123',
+		});
+	});
+
+	it('maps `credentials` to `credentialDetails` when provided', () => {
+		const result = toInlineRequest(
+			makeDto({
+				credentials: { httpBearerAuth: { id: 'cred-1', name: 'My Token' } },
+			}),
+			'project-1',
+		);
+
+		expect(result.credentialDetails).toEqual({
+			httpBearerAuth: { id: 'cred-1', name: 'My Token' },
+		});
+	});
+
+	it('leaves `credentialDetails` undefined when no credentials are supplied', () => {
+		const result = toInlineRequest(makeDto(), 'project-1');
+
+		expect(result.credentialDetails).toBeUndefined();
+	});
+
+	it('wraps each inputData item in a `{ json }` envelope', () => {
+		const result = toInlineRequest(
+			makeDto({ inputData: [{ foo: 'bar' }, { baz: 1 }] }),
+			'project-1',
+		);
+
+		expect(result.inputData).toEqual([{ json: { foo: 'bar' } }, { json: { baz: 1 } }]);
+	});
+
+	it('returns an empty inputData array when the DTO omits it', () => {
+		const result = toInlineRequest(
+			makeDto({ inputData: undefined as unknown as ExecuteEphemeralNodeRequestDto['inputData'] }),
+			'project-1',
+		);
+
+		expect(result.inputData).toEqual([]);
+	});
+});
+
+describe('toPublicResponse', () => {
+	it('serialises a successful result with `json` payloads extracted', () => {
+		const response = toPublicResponse({
+			status: 'success',
+			data: [{ json: { ok: true } }, { json: { count: 2 } }],
+		});
+
+		expect(response).toEqual({
+			status: 'success',
+			data: [{ ok: true }, { count: 2 }],
+		});
+	});
+
+	it('preserves the error message for failed executions', () => {
+		const response = toPublicResponse({
+			status: 'error',
+			data: [],
+			error: 'boom',
+		});
+
+		expect(response).toEqual({ status: 'error', data: [], error: 'boom' });
+	});
+
+	it('throws UnexpectedError with ZodError cause when the result shape is invalid', () => {
+		const invalidResult = {
+			status: 'weird' as unknown as 'success',
+			data: [],
+		};
+
+		expect(() => toPublicResponse(invalidResult)).toThrow(UnexpectedError);
+
+		try {
+			toPublicResponse(invalidResult);
+		} catch (error) {
+			expect(error).toBeInstanceOf(UnexpectedError);
+			expect((error as UnexpectedError).message).toBe(
+				'Failed to serialize ephemeral node execution response',
+			);
+			expect((error as UnexpectedError).cause).toBeInstanceOf(ZodError);
+		}
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// List mapping
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('mapToEphemeralNodeList', () => {
+	it('drops non-allowlisted nodes', () => {
+		const result = mapToEphemeralNodeList([
+			makeNode({ name: 'n8n-nodes-base.slack', displayName: 'Slack' }),
+		]);
+
+		expect(result).toEqual([]);
+	});
+
+	it('drops hidden, trigger, polling, and webhook nodes', () => {
+		const result = mapToEphemeralNodeList([
+			makeNode({ hidden: true }),
+			makeNode({ group: ['trigger'] }),
+			makeNode({ polling: true }),
+			makeNode({ webhooks: [{ name: 'default' } as IWebhookDescription] }),
+		]);
+
+		expect(result).toEqual([]);
+	});
+
+	it('collapses VersionedNodeType variants to the `version === defaultVersion` entry', () => {
+		const result = mapToEphemeralNodeList([
+			makeNode({ version: 1, defaultVersion: 4.2 }),
+			makeNode({ version: 4, defaultVersion: 4.2 }),
+			makeNode({
+				version: 4.2,
+				defaultVersion: 4.2,
+				codex: { categories: ['Core Nodes'] },
+			}),
+		]);
+
+		expect(result).toEqual([
+			{
+				nodeType: 'n8n-nodes-base.httpRequest',
+				nodeTypeVersion: 4.2,
+				displayName: 'HTTP Request',
+				description: 'Makes an HTTP request',
+				category: 'Core Nodes',
+				supportedCredentialTypes: ['httpBearerAuth'],
+			},
+		]);
+	});
+
+	it('falls back to the highest version when no variant matches `defaultVersion`', () => {
+		const result = mapToEphemeralNodeList([
+			makeNode({ version: 1, defaultVersion: undefined }),
+			makeNode({ version: 3, defaultVersion: undefined }),
+			makeNode({ version: 2, defaultVersion: undefined }),
+		]);
+
+		expect(result).toHaveLength(1);
+		expect(result[0].nodeTypeVersion).toBe(3);
+	});
+
+	it('handles array-valued `version` via maxVersion', () => {
+		const result = mapToEphemeralNodeList([
+			makeNode({
+				version: [1, 2, 3] as unknown as INodeTypeDescription['version'],
+				defaultVersion: undefined,
+			}),
+		]);
+
+		expect(result[0].nodeTypeVersion).toBe(3);
+	});
+
+	it('uses `codex.categories[0]` as category when present', () => {
+		const result = mapToEphemeralNodeList([
+			makeNode({ codex: { categories: ['Core Nodes', 'Other'] } }),
+		]);
+
+		expect(result[0].category).toBe('Core Nodes');
+	});
+
+	it('falls back to `group[0]` when codex categories are missing', () => {
+		const result = mapToEphemeralNodeList([makeNode({ group: ['input'] })]);
+
+		expect(result[0].category).toBe('input');
+	});
+
+	it('omits `category` entirely when neither codex nor group can supply one', () => {
+		const result = mapToEphemeralNodeList([makeNode({ group: [] })]);
+
+		expect(result[0]).not.toHaveProperty('category');
+	});
+
+	it('reads `supportedCredentialTypes` from the allowlist, ignoring the descriptor', () => {
+		const result = mapToEphemeralNodeList([
+			makeNode({
+				credentials: [{ name: 'somethingElse' }],
+			}),
+		]);
+
+		expect(result[0].supportedCredentialTypes).toEqual(['httpBearerAuth']);
+	});
+
+	it('filters by `nodeType` query parameter', () => {
+		const result = mapToEphemeralNodeList([makeNode()], { nodeType: 'does-not-match' });
+
+		expect(result).toEqual([]);
+	});
+
+	it('sorts results alphabetically by node name', () => {
+		const result = mapToEphemeralNodeList([
+			makeNode({ name: 'n8n-nodes-base.linear', displayName: 'Linear' }),
+			makeNode(),
+		]);
+
+		expect(result.map((n) => n.nodeType)).toEqual([
+			'n8n-nodes-base.httpRequest',
+			'n8n-nodes-base.linear',
+		]);
+	});
+});

--- a/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/ephemeral-nodes.allowlist.ts
+++ b/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/ephemeral-nodes.allowlist.ts
@@ -1,0 +1,22 @@
+import type { INodeTypeDescription } from 'n8n-workflow';
+
+// Allowlist of node types exposed via the public ephemeral-execution API.
+//
+// Each entry carries a curated `supportedCredentialTypes` list that defines
+// the credential surface clients see for that node.
+//
+// To add a node: confirm it can run safely as a single-shot
+export type EphemeralNodeAllowlistEntry = {
+	supportedCredentialTypes: string[];
+};
+
+export const EPHEMERAL_NODE_ALLOWLIST: ReadonlyMap<string, EphemeralNodeAllowlistEntry> = new Map([
+	['n8n-nodes-base.httpRequest', { supportedCredentialTypes: ['httpBearerAuth'] }],
+	['n8n-nodes-base.linear', { supportedCredentialTypes: ['linearApi'] }],
+]);
+
+export const isAllowlisted = (n: INodeTypeDescription): boolean =>
+	EPHEMERAL_NODE_ALLOWLIST.has(n.name);
+
+export const isNodeTypeAllowlisted = (nodeType: string): boolean =>
+	EPHEMERAL_NODE_ALLOWLIST.has(nodeType);

--- a/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/ephemeral-nodes.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/ephemeral-nodes.handler.ts
@@ -5,15 +5,22 @@ import { Container } from '@n8n/di';
 import type { INodeParameters } from 'n8n-workflow';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import { EphemeralNodeExecutor } from '@/node-execution/ephemeral-node-executor';
 import type { PaginatedRequest } from '@/public-api/types';
 
-import { toInlineRequest, toPublicResponse } from './ephemeral-nodes.mapper';
+import { isNodeTypeAllowlisted } from './ephemeral-nodes.allowlist';
+import {
+	mapToEphemeralNodeList,
+	toInlineRequest,
+	toPublicResponse,
+} from './ephemeral-nodes.mapper';
 import type { PublicAPIEndpoint } from '../../shared/handler.types';
 import {
 	apiKeyHasScopeWithGlobalScopeFallback,
 	validCursor,
 } from '../../shared/middlewares/global.middleware';
+import { paginateArray } from '../../shared/services/pagination.service';
 
 type EphemeralNodesHandlers = {
 	executeEphemeralNode: PublicAPIEndpoint<AuthenticatedRequest>;
@@ -32,6 +39,14 @@ const ephemeralNodesHandlers: EphemeralNodesHandlers = {
 				throw new BadRequestError(parsed.error.errors[0].message);
 			}
 			const dto = parsed.data;
+
+			// The public API only exposes a curated subset of nodes; refuse
+			// anything outside that set before doing project lookups or hitting
+			// the shared executor (which is also used by the agent runtime and
+			// applies looser, tool-oriented criteria).
+			if (!isNodeTypeAllowlisted(dto.nodeType)) {
+				throw new BadRequestError(`Node type "${dto.nodeType}" is not available for execution`);
+			}
 
 			const projectId = (
 				await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(req.user.id)
@@ -55,9 +70,15 @@ const ephemeralNodesHandlers: EphemeralNodesHandlers = {
 		},
 	],
 	listEphemeralNodes: [
+		apiKeyHasScopeWithGlobalScopeFallback({ scope: 'ephemeralNode:read' }),
 		validCursor,
-		async (_req, res) => {
-			return res.json({ data: [], nextCursor: null });
+		async (req, res) => {
+			const { offset = 0, limit = 100, nodeType } = req.query;
+
+			const { nodes } = await Container.get(LoadNodesAndCredentials).collectTypes();
+			const catalogue = mapToEphemeralNodeList(nodes, { nodeType });
+
+			return res.json(paginateArray(catalogue, { offset, limit }));
 		},
 	],
 };

--- a/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/ephemeral-nodes.mapper.ts
+++ b/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/ephemeral-nodes.mapper.ts
@@ -65,7 +65,13 @@ function toCredentialDetails(
 }
 
 function toInputData(items: ExecuteEphemeralNodeRequestDto['inputData']): INodeExecutionData[] {
-	return (items ?? []).map((item) => ({ json: item as IDataObject }));
+	// Action nodes (HTTP Request, Linear, etc.) iterate input items to produce
+	// output items — zero input means zero output. Match n8n's "Manual Trigger"
+	// convention: when no input is supplied, fire the node once with one empty
+	// item so callers omitting `inputData` get a meaningful response instead of
+	// a misleading `{status: success, data: []}`.
+	const provided = (items ?? []).map((item) => ({ json: item as IDataObject }));
+	return provided.length > 0 ? provided : [{ json: {} }];
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/ephemeral-nodes.mapper.ts
+++ b/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/ephemeral-nodes.mapper.ts
@@ -9,6 +9,7 @@ import type {
 	INodeCredentialsDetails,
 	INodeExecutionData,
 	INodeParameters,
+	INodeTypeDescription,
 } from 'n8n-workflow';
 
 import type {
@@ -16,29 +17,22 @@ import type {
 	NodeExecutionResult,
 } from '@/node-execution/ephemeral-node-executor';
 
+import { EPHEMERAL_NODE_ALLOWLIST, isAllowlisted } from './ephemeral-nodes.allowlist';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Execute mapping — DTO ↔ inline executor
+// ─────────────────────────────────────────────────────────────────────────────
+
 export function toInlineRequest(
 	dto: ExecuteEphemeralNodeRequestDto,
 	projectId: string,
 ): InlineNodeExecutionRequest {
-	const credentialDetails: Record<string, INodeCredentialsDetails> | undefined = dto.credentials
-		? Object.fromEntries(
-				Object.entries(dto.credentials).map(([credType, detail]) => [
-					credType,
-					{ id: detail.id, name: detail.name },
-				]),
-			)
-		: undefined;
-
-	const inputData: INodeExecutionData[] = (dto.inputData ?? []).map((item) => ({
-		json: item as IDataObject,
-	}));
-
 	return {
 		nodeType: dto.nodeType,
 		nodeTypeVersion: dto.nodeTypeVersion,
 		nodeParameters: dto.nodeParameters as INodeParameters,
-		credentialDetails,
-		inputData,
+		credentialDetails: toCredentialDetails(dto.credentials),
+		inputData: toInputData(dto.inputData),
 		projectId,
 	};
 }
@@ -58,3 +52,98 @@ export function toPublicResponse(result: NodeExecutionResult): ExecuteEphemeralN
 
 	return parsed.data;
 }
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function toCredentialDetails(
+	credentials: ExecuteEphemeralNodeRequestDto['credentials'],
+): Record<string, INodeCredentialsDetails> | undefined {
+	if (!credentials) return undefined;
+	return Object.fromEntries(
+		Object.entries(credentials).map(([type, { id, name }]) => [type, { id, name }]),
+	);
+}
+
+function toInputData(items: ExecuteEphemeralNodeRequestDto['inputData']): INodeExecutionData[] {
+	return (items ?? []).map((item) => ({ json: item as IDataObject }));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// List mapping — node catalogue → public listing entries
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type EphemeralNode = {
+	nodeType: string;
+	nodeTypeVersion: number;
+	displayName: string;
+	description: string;
+	category?: string;
+	supportedCredentialTypes: string[];
+};
+
+export function mapToEphemeralNodeList(
+	nodes: INodeTypeDescription[],
+	filter: { nodeType?: string } = {},
+): EphemeralNode[] {
+	const allowlisted = nodes.filter(isAllowlisted).filter(isExecutableNode);
+	const canonical = collapseToOneEntryPerName(allowlisted);
+	const matchesFilter = (n: INodeTypeDescription) => !filter.nodeType || n.name === filter.nodeType;
+
+	return canonical
+		.filter(matchesFilter)
+		.sort((a, b) => a.name.localeCompare(b.name))
+		.map(toEphemeralNode);
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const isExecutableNode = (n: INodeTypeDescription): boolean =>
+	!n.hidden && !n.group.includes('trigger') && !n.polling && !n.webhooks?.length;
+
+const maxVersion = (n: INodeTypeDescription): number => {
+	if (!Array.isArray(n.version)) return n.version;
+	return n.version.length > 0 ? Math.max(...n.version) : 0;
+};
+
+// `types.nodes` carries one entry per *version* for `VersionedNodeType` nodes
+// (see `directory-loader.ts` — `getVersionedNodeTypeAll(...).forEach(... push)`).
+// Collapse those down to one entry per node name, preferring the description
+// whose `version` equals its declared `defaultVersion`; fall back to the
+// highest-numbered version when no default is set.
+const collapseToOneEntryPerName = (nodes: INodeTypeDescription[]): INodeTypeDescription[] => {
+	const variantsByName = new Map<string, INodeTypeDescription[]>();
+	for (const node of nodes) {
+		const variants = variantsByName.get(node.name) ?? [];
+		variants.push(node);
+		variantsByName.set(node.name, variants);
+	}
+
+	return Array.from(variantsByName.values()).map(pickCanonicalVersion);
+};
+
+const pickCanonicalVersion = (variants: INodeTypeDescription[]): INodeTypeDescription => {
+	const defaultVariant = variants.find((n) => n.version === n.defaultVersion);
+	if (defaultVariant) return defaultVariant;
+
+	return variants.reduce((best, candidate) =>
+		maxVersion(candidate) > maxVersion(best) ? candidate : best,
+	);
+};
+
+const toEphemeralNode = (n: INodeTypeDescription): EphemeralNode => {
+	const nodeTypeVersion = n.defaultVersion ?? maxVersion(n);
+	const category = n.codex?.categories?.[0] ?? n.group[0];
+	// `n` reached this point only via `isAllowlisted`, so the lookup is total
+	// in practice. Default to `[]` to keep the type honest.
+	const supportedCredentialTypes =
+		EPHEMERAL_NODE_ALLOWLIST.get(n.name)?.supportedCredentialTypes ?? [];
+
+	return {
+		nodeType: n.name,
+		nodeTypeVersion,
+		displayName: n.displayName,
+		description: n.description,
+		...(category ? { category } : {}),
+		supportedCredentialTypes,
+	};
+};

--- a/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/spec/schemas/ephemeralNode.yml
+++ b/packages/cli/src/public-api/v1/handlers/ephemeral-nodes/spec/schemas/ephemeralNode.yml
@@ -1,13 +1,11 @@
 type: object
-description: >
-  A single node in the ephemeral-execution catalogue. Field values are
-  illustrative; the catalogue currently returns an empty list (population
-  tracked in follow-up).
+description: A single node in the ephemeral-execution catalogue. One entry per node type, reflecting its `defaultVersion` (or highest version when no default is set).
 required:
   - nodeType
   - nodeTypeVersion
   - displayName
   - description
+  - supportedCredentialTypes
 properties:
   nodeType:
     type: string
@@ -15,7 +13,7 @@ properties:
     example: n8n-nodes-base.httpRequest
   nodeTypeVersion:
     type: number
-    description: Version of the node type to execute.
+    description: Version of the node type to execute (the node's `defaultVersion` when set, otherwise the highest supported version).
     example: 4.2
   displayName:
     type: string
@@ -26,21 +24,13 @@ properties:
     description: Short description of what the node does.
   category:
     type: string
-    description: Top-level node category (e.g. `Core Nodes`, `Communication`).
-  exampleParameters:
-    type: object
-    additionalProperties: true
-    description: An example `nodeParameters` payload demonstrating the minimum viable invocation.
-  requiredCredentialTypes:
+    description: Top-level node category (e.g. `Core Nodes`, `Communication`). Sourced from the node's codex categories; falls back to the first group entry. Omitted when neither is set.
+  supportedCredentialTypes:
     type: array
     items:
       type: string
     description: >
-      Credential type names this node accepts (matches the `type` field of
-      `GET /credentials` entries). Empty if the node needs no credential.
-  inputDataShape:
-    type: object
-    additionalProperties: true
-    description: >
-      Optional JSON-Schema-like description of the input data the node expects.
-      Present when the node has a strong input contract; omitted otherwise.
+      Credential type names the node can authenticate with (matches the
+      `type` field of `GET /credentials` entries). The node typically uses
+      one of these at a time — selection depends on its configuration.
+      Empty if the node needs no credential.

--- a/packages/cli/test/integration/public-api/ephemeral-nodes-discovery.test.ts
+++ b/packages/cli/test/integration/public-api/ephemeral-nodes-discovery.test.ts
@@ -4,17 +4,18 @@
  *
  *   1. GET /credentials   → needs id, name, type per item
  *   2. GET /projects      → needs id, name per item
- *   3. GET /ephemeral-nodes → contract-only stub today
+ *   3. GET /ephemeral-nodes → needs nodeType, nodeTypeVersion, displayName, description per item
  *   4. GET /discover      → must list all three resources for the caller
  *
  * If a field drops out of any of the response shapes this test catches it.
- *
- * NOTE: /ephemeral-nodes is currently auth-only (no scope gate) pending
- * Engineer A's permissions PR. See `ephemeral-nodes.handler.ts` for context.
  */
 
 import { createTeamProject, testDb } from '@n8n/backend-test-utils';
 import type { User } from '@n8n/db';
+import { Container } from '@n8n/di';
+import type { INodeTypeDescription } from 'n8n-workflow';
+
+import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 
 import { saveCredential } from '../shared/db/credentials';
 import { createOwnerWithApiKey } from '../shared/db/users';
@@ -33,8 +34,23 @@ let authAgent: SuperAgentTest;
 beforeAll(async () => {
 	await utils.initCredentialsTypes();
 	owner = await createOwnerWithApiKey({
-		scopes: ['credential:list', 'project:list'],
+		scopes: ['credential:list', 'project:list', 'ephemeralNode:read'],
 	});
+
+	// One executable fixture is enough to exercise the response shape this
+	// contract test guards. See `ephemeral-nodes.test.ts` for the full
+	// filter/pagination/mapping coverage.
+	Container.get(LoadNodesAndCredentials).types.nodes = [
+		{
+			name: 'n8n-nodes-base.httpRequest',
+			displayName: 'HTTP Request',
+			description: 'Makes an HTTP request and returns the response',
+			group: ['input'],
+			version: 4.2,
+			codex: { categories: ['Core Nodes'] },
+			credentials: [{ name: 'httpBasicAuth' }],
+		} as INodeTypeDescription,
+	];
 });
 
 beforeEach(async () => {
@@ -75,10 +91,19 @@ describe('Ephemeral nodes discovery flow contract', () => {
 		}
 	});
 
-	test('GET /ephemeral-nodes returns the documented stub shape', async () => {
+	test('GET /ephemeral-nodes returns nodeType, nodeTypeVersion, and displayName for every item', async () => {
 		const response = await authAgent.get('/ephemeral-nodes').expect(200);
 
-		expect(response.body).toEqual({ data: [], nextCursor: null });
+		expect(Array.isArray(response.body.data)).toBe(true);
+		expect(response.body.data.length).toBeGreaterThan(0);
+
+		for (const node of response.body.data) {
+			expect(typeof node.nodeType).toBe('string');
+			expect(typeof node.nodeTypeVersion).toBe('number');
+			expect(typeof node.displayName).toBe('string');
+			expect(typeof node.description).toBe('string');
+			expect(Array.isArray(node.supportedCredentialTypes)).toBe(true);
+		}
 	});
 
 	test('GET /discover surfaces credentials, projects, and ephemeralnode for the same API key', async () => {
@@ -90,14 +115,12 @@ describe('Ephemeral nodes discovery flow contract', () => {
 		);
 	});
 
-	// Skipped: flip to `test(...)` when Engineer A's permissions PR lands.
-	// Also add `'node:read'` to the `createOwnerWithApiKey` scopes in `beforeAll`.
-	// Sanity check that one API key can hold all three scopes Claude needs.
-	test.skip('A single API key can carry credential:list + project:list + node:read', async () => {
+	// Sanity check that one API key can hold all three scopes an LLM client needs.
+	test('A single API key can carry credential:list + project:list + ephemeralNode:read', async () => {
 		const response = await authAgent.get('/discover').expect(200);
 
 		expect(response.body.data.scopes).toEqual(
-			expect.arrayContaining(['credential:list', 'project:list', 'node:read']),
+			expect.arrayContaining(['credential:list', 'project:list', 'ephemeralNode:read']),
 		);
 	});
 });

--- a/packages/cli/test/integration/public-api/ephemeral-nodes-execute.test.ts
+++ b/packages/cli/test/integration/public-api/ephemeral-nodes-execute.test.ts
@@ -89,15 +89,24 @@ describe('POST /ephemeral-nodes/execute', () => {
 			expect(mockExecutor.executeInline).not.toHaveBeenCalled();
 		});
 
-		test('rejects trigger nodes with 400', async () => {
+		test('rejects non-allowlisted node types with 400 before hitting the executor', async () => {
+			await authOwnerAgent
+				.post('/ephemeral-nodes/execute')
+				.send({ ...validPayload, nodeType: 'n8n-nodes-base.slack' })
+				.expect(400);
+
+			expect(mockExecutor.validateNodeForExecution).not.toHaveBeenCalled();
+			expect(mockExecutor.executeInline).not.toHaveBeenCalled();
+		});
+
+		test('maps a trigger-node validation error from the executor to 400', async () => {
+			// Use an allowlisted nodeType so the request reaches the executor; the
+			// executor's UserError is what we're verifying gets surfaced as 400.
 			mockExecutor.validateNodeForExecution.mockImplementationOnce(() => {
 				throw new UserError('Trigger nodes cannot be executed standalone');
 			});
 
-			await authOwnerAgent
-				.post('/ephemeral-nodes/execute')
-				.send({ ...validPayload, nodeType: 'n8n-nodes-base.webhook' })
-				.expect(400);
+			await authOwnerAgent.post('/ephemeral-nodes/execute').send(validPayload).expect(400);
 
 			expect(mockExecutor.executeInline).not.toHaveBeenCalled();
 		});

--- a/packages/cli/test/integration/public-api/ephemeral-nodes.test.ts
+++ b/packages/cli/test/integration/public-api/ephemeral-nodes.test.ts
@@ -1,5 +1,8 @@
 import type { User } from '@n8n/db';
+import { Container } from '@n8n/di';
+import type { INodeTypeDescription } from 'n8n-workflow';
 
+import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import handlers from '@/public-api/v1/handlers/ephemeral-nodes/ephemeral-nodes.handler';
 
 import { createMemberWithApiKey, createOwnerWithApiKey } from '../shared/db/users';
@@ -14,19 +17,75 @@ let authOwnerAgent: SuperAgentTest;
 let authMemberAgent: SuperAgentTest;
 let authUnscopedAgent: SuperAgentTest;
 
+// Fixtures cover the two cases the active tests need to distinguish:
+//   - VersionedNodeType nodes (multiple entries sharing a `name`, each with a
+//     scalar `version` and a shared `defaultVersion`) — modelling how
+//     `directory-loader.ts` actually populates `types.nodes`. HTTP Request
+//     appears 3× to exercise the collapse-to-`defaultVersion` path.
+//   - A non-allowlisted node (Slack) that would otherwise pass structural
+//     filters — proves `EPHEMERAL_NODE_ALLOWLIST` is the gate.
+const nodeFixtures: INodeTypeDescription[] = [
+	{
+		name: 'n8n-nodes-base.httpRequest',
+		displayName: 'HTTP Request',
+		description: 'Makes an HTTP request and returns the response',
+		group: ['input'],
+		version: 1,
+		defaultVersion: 4.2,
+		codex: { categories: ['Core Nodes'] },
+		credentials: [{ name: 'legacyHttpAuth' }],
+	} as INodeTypeDescription,
+	{
+		name: 'n8n-nodes-base.httpRequest',
+		displayName: 'HTTP Request',
+		description: 'Makes an HTTP request and returns the response',
+		group: ['input'],
+		version: 4,
+		defaultVersion: 4.2,
+		codex: { categories: ['Core Nodes'] },
+		credentials: [{ name: 'httpBasicAuth' }, { name: 'httpHeaderAuth' }],
+	} as INodeTypeDescription,
+	{
+		name: 'n8n-nodes-base.httpRequest',
+		displayName: 'HTTP Request',
+		description: 'Makes an HTTP request and returns the response',
+		group: ['input'],
+		version: 4.2,
+		defaultVersion: 4.2,
+		codex: { categories: ['Core Nodes'] },
+		credentials: [{ name: 'httpBasicAuth' }, { name: 'httpHeaderAuth' }, { name: 'oAuth2Api' }],
+	} as INodeTypeDescription,
+	{
+		name: 'n8n-nodes-base.slack',
+		displayName: 'Slack',
+		description: 'Consume Slack API',
+		group: ['output'],
+		version: 2,
+		codex: { categories: ['Communication'] },
+		credentials: [{ name: 'slackApi' }],
+	} as INodeTypeDescription,
+];
+
+let unscopedMember: User;
+
 beforeAll(async () => {
 	owner = await createOwnerWithApiKey();
 	member = await createMemberWithApiKey();
+	// A member API key that explicitly does NOT carry `ephemeralNode:read` —
+	// used to assert 403 on the gated list endpoint and the discover hide.
+	unscopedMember = await createMemberWithApiKey({ scopes: ['user:read'] });
+
+	// The handler reads from `LoadNodesAndCredentials.types.nodes` via
+	// `collectTypes()`. In production this is populated by `postProcessLoaders`;
+	// the test harness's `initNodeTypes` only populates `loaded.nodes`, so we
+	// seed `types.nodes` directly with the fixtures above.
+	Container.get(LoadNodesAndCredentials).types.nodes = nodeFixtures;
 });
 
 beforeEach(() => {
 	authOwnerAgent = testServer.publicApiAgentFor(owner);
 	authMemberAgent = testServer.publicApiAgentFor(member);
-	// Skipped tests below reference an "unscoped" agent (an API key that does
-	// not hold `node:read`). Wire it up here so type-checking stays green and
-	// the body is ready to re-enable. Today it's the same as the member agent
-	// because there's no scope to lack.
-	authUnscopedAgent = testServer.publicApiAgentFor(member);
+	authUnscopedAgent = testServer.publicApiAgentFor(unscopedMember);
 });
 
 describe('GET /ephemeral-nodes', () => {
@@ -34,41 +93,98 @@ describe('GET /ephemeral-nodes', () => {
 		await testServer.publicApiAgentWithoutApiKey().get('/ephemeral-nodes').expect(401);
 	});
 
-	test('returns 200 with stub catalogue for any authenticated owner', async () => {
+	test('returns only the allowlisted subset of the catalogue', async () => {
 		const response = await authOwnerAgent.get('/ephemeral-nodes').expect(200);
 
-		expect(response.body).toEqual({ data: [], nextCursor: null });
+		expect(response.body.nextCursor).toBeNull();
+
+		const names = response.body.data.map((n: { nodeType: string }) => n.nodeType);
+		// Fixture seeds httpRequest + slack; only allowlisted entries surface.
+		// v1 ships with `httpRequest` only.
+		expect(names).toEqual(['n8n-nodes-base.httpRequest']);
 	});
 
-	test('returns 200 with stub catalogue for any authenticated member', async () => {
+	test('returns the same catalogue for any authenticated member', async () => {
 		const response = await authMemberAgent.get('/ephemeral-nodes').expect(200);
 
-		expect(response.body).toEqual({ data: [], nextCursor: null });
+		const names = response.body.data.map((n: { nodeType: string }) => n.nodeType);
+		expect(names).toEqual(['n8n-nodes-base.httpRequest']);
 	});
 
-	test('accepts the documented query params without rejecting', async () => {
-		// Validation only — the stub returns an empty list regardless.
+	test('collapses VersionedNodeType entries to the `defaultVersion` row', async () => {
 		const response = await authOwnerAgent
 			.get('/ephemeral-nodes')
-			.query({ nodeType: 'n8n-nodes-base.httpRequest', limit: 50 })
+			.query({ nodeType: 'n8n-nodes-base.httpRequest' })
+			.expect(200);
+
+		// The fixture seeds 3 HTTP Request rows (v1, v4, v4.2); only the
+		// `defaultVersion: 4.2` row should surface. `supportedCredentialTypes`
+		// comes from EPHEMERAL_NODE_ALLOWLIST (curated), not from the
+		// descriptor's `credentials[]`.
+		expect(response.body.data).toEqual([
+			{
+				nodeType: 'n8n-nodes-base.httpRequest',
+				nodeTypeVersion: 4.2,
+				displayName: 'HTTP Request',
+				description: 'Makes an HTTP request and returns the response',
+				category: 'Core Nodes',
+				supportedCredentialTypes: ['httpBearerAuth'],
+			},
+		]);
+	});
+
+	test('filters by `nodeType` query parameter', async () => {
+		const response = await authOwnerAgent
+			.get('/ephemeral-nodes')
+			.query({ nodeType: 'n8n-nodes-base.httpRequest' })
+			.expect(200);
+
+		expect(response.body.data).toHaveLength(1);
+		expect(response.body.data[0].nodeType).toBe('n8n-nodes-base.httpRequest');
+	});
+
+	test('returns an empty array for a non-allowlisted `nodeType`', async () => {
+		// Slack exists in the fixture and would pass structural filters, but
+		// it's not in EPHEMERAL_NODE_ALLOWLIST, so the API treats it the same
+		// as an unknown node.
+		const response = await authOwnerAgent
+			.get('/ephemeral-nodes')
+			.query({ nodeType: 'n8n-nodes-base.slack' })
 			.expect(200);
 
 		expect(response.body).toEqual({ data: [], nextCursor: null });
 	});
 
-	// Skipped: flip to `test(...)` when Engineer A's permissions PR lands and
-	// the handler gates with `apiKeyHasScopeWithGlobalScopeFallback({ scope: 'node:read' })`.
-	// The owner/member fixtures will need explicit `{ scopes: [...] }` then — one
-	// holding `node:read`, one without.
-	test.skip('returns 403 without node:read scope', async () => {
+	test('returns an empty array for an unknown `nodeType`', async () => {
+		const response = await authOwnerAgent
+			.get('/ephemeral-nodes')
+			.query({ nodeType: 'does-not-exist' })
+			.expect(200);
+
+		expect(response.body).toEqual({ data: [], nextCursor: null });
+	});
+
+	test('paginates with limit + cursor (single-entry allowlist)', async () => {
+		// With only `httpRequest` allowlisted, the catalogue has one entry —
+		// limit=1 returns it with no further cursor. Multi-page pagination is
+		// covered by the shared paginateArray() utility's own tests.
+		const response = await authOwnerAgent.get('/ephemeral-nodes').query({ limit: 1 }).expect(200);
+
+		expect(response.body.data.map((n: { nodeType: string }) => n.nodeType)).toEqual([
+			'n8n-nodes-base.httpRequest',
+		]);
+		expect(response.body.nextCursor).toBeNull();
+	});
+
+	test('returns 403 without ephemeralNode:read scope', async () => {
 		await authUnscopedAgent.get('/ephemeral-nodes').expect(403);
 	});
 });
 
 describe('GET /discover lists ephemeral-nodes', () => {
-	// Discover treats `scope: null` endpoints as visible to everyone (see
+	// Discover filters endpoints by the caller's scope set (see
 	// discover.service.ts — `ep.scope === null || scopeSet.has(ep.scope)`).
-	test('any authenticated owner sees the ephemeralnode resource', async () => {
+	test('any owner with ephemeralNode:read sees the ephemeralnode resource', async () => {
 		const response = await authOwnerAgent.get('/discover').expect(200);
 
 		const resourceKeys = Object.keys(response.body.data.resources);
@@ -83,16 +199,14 @@ describe('GET /discover lists ephemeral-nodes', () => {
 		expect(operationIds).toContain('listEphemeralNodes');
 	});
 
-	test('any authenticated member also sees the ephemeralnode resource', async () => {
+	test('any member with ephemeralNode:read also sees the ephemeralnode resource', async () => {
 		const response = await authMemberAgent.get('/discover').expect(200);
 
 		const resourceKeys = Object.keys(response.body.data.resources);
 		expect(resourceKeys).toContain('ephemeralnode');
 	});
 
-	// Skipped: flip to `test(...)` when the handler is scope-gated. Discover
-	// will then hide the resource from callers without `node:read`.
-	test.skip('owner without node:read does not see the ephemeralnode resource', async () => {
+	test('caller without ephemeralNode:read does not see the ephemeralnode resource', async () => {
 		const response = await authUnscopedAgent.get('/discover').expect(200);
 
 		const resourceKeys = Object.keys(response.body.data.resources);
@@ -101,23 +215,15 @@ describe('GET /discover lists ephemeral-nodes', () => {
 });
 
 describe('listEphemeralNodes handler middleware', () => {
-	// Swap-back guard: when the permissions PR adds `node:read`,
-	// this handler MUST be updated to gate with
-	// `apiKeyHasScopeWithGlobalScopeFallback({ scope: 'node:read' })`. That
-	// At that point this assertion flips and you need to:
-	//   1. Replace this test body with `expect(hasScopedMiddleware).toBe(true)`
-	//      (or just delete this suite — the 401/403 coverage proves auth+scope).
-	//   2. Uncomment the 403 case in the `GET /ephemeral-nodes` suite for callers
-	//      lacking `node:read`.
-	//   3. Uncomment the "without node:read does not see…" case in the discover suite.
-	test('handler is currently auth-only (no scope middleware) — swap when permissions PR lands', () => {
+	test('handler is gated by ephemeralNode:read scope', () => {
 		const middlewareChain = handlers.listEphemeralNodes as unknown as Array<
 			Record<string, unknown>
 		>;
-		const hasScopedMiddleware = middlewareChain.some(
+		const scopedMiddleware = middlewareChain.find(
 			(mw) => typeof mw === 'function' && '__apiKeyScope' in mw,
-		);
+		) as { __apiKeyScope: string } | undefined;
 
-		expect(hasScopedMiddleware).toBe(false);
+		expect(scopedMiddleware).toBeDefined();
+		expect(scopedMiddleware?.__apiKeyScope).toBe('ephemeralNode:read');
 	});
 });


### PR DESCRIPTION
## Summary

Implements the `GET /ephemeral-nodes` list endpoint (which landed as a stub returning `[]` in #30387) and tightens `POST /ephemeral-nodes/execute`.

**List endpoint (`GET /ephemeral-nodes`)**
- Drives the catalogue from `EPHEMERAL_NODE_ALLOWLIST` (currently `httpRequest`, `linear`), with curated `supportedCredentialTypes` per node.
- Filters out hidden / trigger / polling / webhook nodes.
- Collapses `VersionedNodeType` variants to one entry per node name, preferring the `defaultVersion` row (falls back to the highest version when no default is set).
- Optional `?nodeType=` query-parameter filter; results sorted alphabetically.
- OpenAPI schema rewritten — `supportedCredentialTypes` replaces the stub `requiredCredentialTypes` / `exampleParameters` / `inputDataShape` fields.

**Execute endpoint (`POST /ephemeral-nodes/execute`)**
- Now gated by the same allowlist before the executor runs. `EphemeralNodeExecutor` is shared with the agent runtime (which applies looser `usableAsTool` criteria), so the public-API restriction lives at the handler layer to avoid over-restricting agents.
- Empty `inputData` now defaults to a single `{}` item — matching n8n's Manual Trigger convention — so callers that omit the field still get meaningful output instead of `{ status: 'success', data: [] }`.

**Testing**

```bash
pnpm --filter=n8n jest src/public-api/v1/handlers/ephemeral-nodes
pnpm --filter=n8n jest test/integration/public-api/ephemeral-nodes