### PR TITLE
feat(core): Add SSO chat module foundation (no-changelog)

### DIFF
--- a/packages/@n8n/backend-common/src/modules/module-registry.ts
+++ b/packages/@n8n/backend-common/src/modules/module-registry.ts
@@ -43,6 +43,7 @@ export class ModuleRegistry {
 		'chat-hub',
 		'sso-oidc',
 		'sso-saml',
+		'sso-chat',
 		'log-streaming',
 		'ldap',
 		'quick-connect',

--- a/packages/@n8n/backend-common/src/modules/modules.config.ts
+++ b/packages/@n8n/backend-common/src/modules/modules.config.ts
@@ -16,6 +16,7 @@ export const MODULE_NAMES = [
 	'chat-hub',
 	'sso-oidc',
 	'sso-saml',
+	'sso-chat',
 	'log-streaming',
 	'ldap',
 	'quick-connect',

--- a/packages/@n8n/db/src/migrations/common/1784000000001-ChatSSOTable.ts
+++ b/packages/@n8n/db/src/migrations/common/1784000000001-ChatSSOTable.ts
@@ -1,0 +1,32 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+const chatAuthIdentityTable = 'chat_auth_identity';
+const chatClientCodeTable = 'chat_client_code';
+
+export class ChatSSOTable1784000000001 implements ReversibleMigration {
+	async up({ schemaBuilder: { createTable, column } }: MigrationContext) {
+		await createTable(chatAuthIdentityTable)
+			.withColumns(
+				column('userId').uuid.notNull,
+				column('providerId').varchar(255).primary.notNull,
+				column('providerType').varchar().primary.notNull,
+			)
+			.withForeignKey('userId', {
+				tableName: 'user',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			}).withTimestamps;
+
+		await createTable(chatClientCodeTable).withColumns(
+			column('providerId').varchar(255).primary.notNull,
+			column('providerType').varchar().primary.notNull,
+			column('codeHash').varchar().notNull,
+			column('expiresAt').timestamp().notNull,
+		).withTimestamps;
+	}
+
+	async down({ schemaBuilder: { dropTable } }: MigrationContext) {
+		await dropTable(chatClientCodeTable);
+		await dropTable(chatAuthIdentityTable);
+	}
+}

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -176,6 +176,7 @@ import { CreateEvaluationCollection1778496086558 } from '../common/1778496086558
 import { CreateAgentTables1783000000000 } from '../common/1783000000000-CreateAgentTables';
 import { CreateAgentExecutionTables1783000000001 } from '../common/1783000000001-CreateAgentExecutionTables';
 import { CreateAgentObservationTables1784000000000 } from '../common/1784000000000-CreateAgentObservationTables';
+import { ChatSSOTable1784000000001 } from '../common/1784000000001-ChatSSOTable';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -357,4 +358,5 @@ export const postgresMigrations: Migration[] = [
 	CreateAgentTables1783000000000,
 	CreateAgentExecutionTables1783000000001,
 	CreateAgentObservationTables1784000000000,
+	ChatSSOTable1784000000001,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -169,6 +169,7 @@ import { CreateEvaluationCollection1778496086558 } from '../common/1778496086558
 import { CreateAgentTables1783000000000 } from '../common/1783000000000-CreateAgentTables';
 import { CreateAgentExecutionTables1783000000001 } from '../common/1783000000001-CreateAgentExecutionTables';
 import { CreateAgentObservationTables1784000000000 } from '../common/1784000000000-CreateAgentObservationTables';
+import { ChatSSOTable1784000000001 } from '../common/1784000000001-ChatSSOTable';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -343,6 +344,7 @@ const sqliteMigrations: Migration[] = [
 	CreateAgentTables1783000000000,
 	CreateAgentExecutionTables1783000000001,
 	CreateAgentObservationTables1784000000000,
+	ChatSSOTable1784000000001,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/modules/sso-chat/entities/chat-auth-identity.ts
+++ b/packages/cli/src/modules/sso-chat/entities/chat-auth-identity.ts
@@ -1,0 +1,16 @@
+import { ChatProviderType } from '@/services/chat-authentication-proxy.service';
+import { WithTimestamps } from '@n8n/db';
+import { Column, Entity, PrimaryColumn, Unique } from '@n8n/typeorm';
+
+@Entity()
+@Unique(['providerId', 'providerType'])
+export class ChatAuthIdentity extends WithTimestamps {
+	@Column()
+	userId: string;
+
+	@PrimaryColumn({ length: 255 })
+	providerId: string;
+
+	@PrimaryColumn({ type: 'varchar' })
+	providerType: ChatProviderType;
+}

--- a/packages/cli/src/modules/sso-chat/entities/chat-client-code.ts
+++ b/packages/cli/src/modules/sso-chat/entities/chat-client-code.ts
@@ -1,0 +1,18 @@
+import { ChatProviderType } from '@/services/chat-authentication-proxy.service';
+import { WithTimestamps } from '@n8n/db';
+import { Column, Entity, PrimaryColumn } from '@n8n/typeorm';
+
+@Entity()
+export class ChatClientCode extends WithTimestamps {
+	@Column()
+	expiresAt: Date;
+
+	@Column()
+	codeHash: string;
+
+	@PrimaryColumn({ length: 255 })
+	providerId: string;
+
+	@PrimaryColumn({ type: 'varchar' })
+	providerType: ChatProviderType;
+}

--- a/packages/cli/src/modules/sso-chat/repositories/chat-auth-identity.repository.ts
+++ b/packages/cli/src/modules/sso-chat/repositories/chat-auth-identity.repository.ts
@@ -1,0 +1,11 @@
+import { Service } from '@n8n/di';
+import { DataSource, Repository } from '@n8n/typeorm';
+
+import { ChatAuthIdentity } from '../entities/chat-auth-identity';
+
+@Service()
+export class ChatAuthIdentityRepository extends Repository<ChatAuthIdentity> {
+	constructor(dataSource: DataSource) {
+		super(ChatAuthIdentity, dataSource.manager);
+	}
+}

--- a/packages/cli/src/modules/sso-chat/repositories/chat-client-code.repository.ts
+++ b/packages/cli/src/modules/sso-chat/repositories/chat-client-code.repository.ts
@@ -1,0 +1,11 @@
+import { Service } from '@n8n/di';
+import { DataSource, Repository } from '@n8n/typeorm';
+
+import { ChatClientCode } from '../entities/chat-client-code';
+
+@Service()
+export class ChatClientCodeRepository extends Repository<ChatClientCode> {
+	constructor(dataSource: DataSource) {
+		super(ChatClientCode, dataSource.manager);
+	}
+}

--- a/packages/cli/src/modules/sso-chat/services/chat-auth.service.ts
+++ b/packages/cli/src/modules/sso-chat/services/chat-auth.service.ts
@@ -1,0 +1,150 @@
+import {
+	ChatProviderType,
+	IChatAuthenticationService,
+} from '@/services/chat-authentication-proxy.service';
+import { UserRepository } from '@n8n/db';
+import type { EntityManager, User } from '@n8n/db';
+import { Service } from '@n8n/di';
+import { OperationalError, randomInt } from 'n8n-workflow';
+import { createHash } from 'node:crypto';
+
+import { ChatAuthIdentity } from '../entities/chat-auth-identity';
+import { ChatClientCode } from '../entities/chat-client-code';
+import { ChatAuthIdentityRepository } from '../repositories/chat-auth-identity.repository';
+import { ChatClientCodeRepository } from '../repositories/chat-client-code.repository';
+
+@Service()
+export class ChatAuthenticationService implements IChatAuthenticationService {
+	constructor(
+		private readonly chatAuthIdentityRepository: ChatAuthIdentityRepository,
+		private readonly chatClientCodeRepository: ChatClientCodeRepository,
+		private readonly userRepository: UserRepository,
+	) {}
+
+	/**
+	 * Store a user code for a chat user id and provider
+	 */
+	async createVerificationCode(
+		chatUserId: string,
+		chatProvider: ChatProviderType,
+		validForSeconds: number = 300,
+	): Promise<string> {
+		const identity = await this.chatAuthIdentityRepository.findOneBy({
+			providerType: chatProvider,
+			providerId: chatUserId,
+		});
+
+		if (identity !== null) {
+			throw new OperationalError('Chat userid is already linked');
+		}
+
+		const randomCode = `${randomInt(100_000_000, 1_000_000_000)}`;
+
+		const randomCodeHash = createHash('sha256').update(randomCode).digest().toString('base64');
+
+		const milliseconds = validForSeconds * 1000;
+
+		await this.chatClientCodeRepository.save({
+			codeHash: randomCodeHash,
+			providerId: chatUserId,
+			providerType: chatProvider,
+			expiresAt: new Date(Date.now() + milliseconds),
+		});
+
+		return randomCode;
+	}
+
+	/**
+	 * Validate and link an n8n user, based on a chat code.
+	 * if the code is still valid, the user will be linked,
+	 * to the chat user that the code was created for.
+	 */
+	async validateUserCodeAndLink(
+		n8nUserId: string,
+		chatProvider: ChatProviderType,
+		code: string,
+	): Promise<void> {
+		const randomCodeHash = createHash('sha256').update(code).digest().toString('base64');
+
+		const exchangeCodeAndLinkUser = async (tx: EntityManager) => {
+			const clientCodeRepository = tx.getRepository(ChatClientCode);
+			const clientCode = await clientCodeRepository.findOneBy({
+				codeHash: randomCodeHash,
+				providerType: chatProvider,
+			});
+
+			if (!clientCode) {
+				throw new OperationalError('No valid code found');
+			}
+
+			await clientCodeRepository.delete({
+				providerId: clientCode.providerId,
+				providerType: clientCode.providerType,
+			});
+
+			if (clientCode.expiresAt <= new Date()) {
+				throw new OperationalError('Code is already expired');
+			}
+
+			const chatAuthIdentityRepository = tx.getRepository(ChatAuthIdentity);
+
+			await chatAuthIdentityRepository.save({
+				providerId: clientCode.providerId,
+				providerType: clientCode.providerType,
+				userId: n8nUserId,
+			});
+		};
+
+		await this.chatClientCodeRepository.manager.transaction(exchangeCodeAndLinkUser);
+	}
+
+	/**
+	 * Get an n8n User by a chat user id and provider
+	 */
+	async getUserByChatUserId(
+		chatUserId: string,
+		chatProvider: ChatProviderType,
+	): Promise<User | null> {
+		const userIdentity = await this.chatAuthIdentityRepository.findOne({
+			select: ['userId'],
+			where: {
+				providerType: chatProvider,
+				providerId: chatUserId,
+			},
+		});
+
+		if (userIdentity) {
+			return await this.userRepository.findOneBy({ id: userIdentity.userId });
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get all linked chat providers for a user.
+	 */
+	async getChatProvidersForUser(n8nUserId: string): Promise<ChatProviderType[]> {
+		const providers = await this.chatAuthIdentityRepository.find({
+			where: {
+				userId: n8nUserId,
+			},
+			select: ['providerType'],
+		});
+
+		return providers
+			.map((p) => p.providerType)
+			.filter((value, index, array) => {
+				return array.indexOf(value) === index;
+			});
+	}
+
+	/**
+	 * Remove link for chat provider for the given n8n user id
+	 */
+	async unlinkUserFromProvider(n8nUserId: string, chatProvider: ChatProviderType): Promise<void> {
+		await this.chatAuthIdentityRepository.delete({
+			userId: n8nUserId,
+			providerType: chatProvider,
+		});
+	}
+}

--- a/packages/cli/src/modules/sso-chat/sso-chat.module.ts
+++ b/packages/cli/src/modules/sso-chat/sso-chat.module.ts
@@ -1,0 +1,20 @@
+import { ChatAuthenticationProxyService } from '@/services/chat-authentication-proxy.service';
+import type { ModuleInterface } from '@n8n/decorators';
+import { BackendModule } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+
+@BackendModule({ name: 'sso-chat' })
+export class SSOChatModule implements ModuleInterface {
+	async init() {
+		const { ChatAuthenticationService } = await import('./services/chat-auth.service');
+		Container.get(ChatAuthenticationProxyService).setProvider(
+			Container.get(ChatAuthenticationService),
+		);
+	}
+
+	async entities() {
+		const { ChatAuthIdentity } = await import('./entities/chat-auth-identity');
+		const { ChatClientCode } = await import('./entities/chat-client-code');
+		return [ChatAuthIdentity, ChatClientCode];
+	}
+}

--- a/packages/cli/src/services/chat-authentication-proxy.service.ts
+++ b/packages/cli/src/services/chat-authentication-proxy.service.ts
@@ -1,0 +1,118 @@
+import { User } from '@n8n/db';
+import { Service } from '@n8n/di';
+import { UserError } from 'n8n-workflow';
+
+export type ChatProviderType = 'telegram' | 'slack';
+
+export interface IChatAuthenticationService {
+	/**
+	 * Store a user code for a chat user id and provider
+	 */
+	createVerificationCode(
+		chatUserId: string,
+		chatProvider: ChatProviderType,
+		validForSeconds?: number,
+	): Promise<string>;
+
+	/**
+	 * Validate and link an n8n user, based on a chat code.
+	 * if the code is still valid, the user will be linked,
+	 * to the chat user that the code was created for.
+	 */
+	validateUserCodeAndLink(
+		n8nUserId: string,
+		chatProvider: ChatProviderType,
+		code: string,
+	): Promise<void>;
+
+	/**
+	 * Get an n8n User by a chat user id and provider
+	 */
+	getUserByChatUserId(chatUserId: string, chatProvider: ChatProviderType): Promise<User | null>;
+
+	/**
+	 * Get all linked chat providers for a user.
+	 */
+	getChatProvidersForUser(n8nUserId: string): Promise<ChatProviderType[]>;
+
+	/**
+	 * Remove link for chat provider for the given n8n user id
+	 */
+	unlinkUserFromProvider(n8nUserId: string, chatProvider: ChatProviderType): Promise<void>;
+}
+
+@Service()
+export class ChatAuthenticationProxyService implements IChatAuthenticationService {
+	private provider: IChatAuthenticationService | null = null;
+
+	setProvider(provider: IChatAuthenticationService) {
+		this.provider = provider;
+	}
+
+	/**
+	 * Returns true when a chat authentication module has registered itself as the provider.
+	 * Callers can use this to gate behavior without catching {@link UserError}.
+	 */
+	hasProvider(): boolean {
+		return this.provider !== null;
+	}
+
+	private requireProvider(): IChatAuthenticationService {
+		if (!this.provider) {
+			throw new UserError('No chat authentication module available');
+		}
+		return this.provider;
+	}
+
+	/**
+	 * Store a user code for a chat user id and provider
+	 */
+	async createVerificationCode(
+		chatUserId: string,
+		chatProvider: ChatProviderType,
+		validForSeconds: number = 300,
+	): Promise<string> {
+		return await this.requireProvider().createVerificationCode(
+			chatUserId,
+			chatProvider,
+			validForSeconds,
+		);
+	}
+
+	/**
+	 * Validate and link an n8n user, based on a chat code.
+	 * if the code is still valid, the user will be linked,
+	 * to the chat user that the code was created for.
+	 */
+	async validateUserCodeAndLink(
+		n8nUserId: string,
+		chatProvider: ChatProviderType,
+		code: string,
+	): Promise<void> {
+		return await this.requireProvider().validateUserCodeAndLink(n8nUserId, chatProvider, code);
+	}
+
+	/**
+	 * Get an n8n User by a chat user id and provider
+	 */
+	async getUserByChatUserId(
+		chatUserId: string,
+		chatProvider: ChatProviderType,
+	): Promise<User | null> {
+		return await this.requireProvider().getUserByChatUserId(chatUserId, chatProvider);
+	}
+
+	/**
+	 * Get all linked chat providers for a user.
+	 */
+	async getChatProvidersForUser(n8nUserId: string): Promise<ChatProviderType[]> {
+		return await this.requireProvider().getChatProvidersForUser(n8nUserId);
+	}
+
+	/**
+	 * Remove link for chat provider for the given n8n user id
+	 */
+	async unlinkUserFromProvider(n8nUserId: string, chatProvider: ChatProviderType): Promise<void> {
+		return await this.requireProvider().unlinkUserFromProvider(n8nUserId, chatProvider);
+	}
+}

--- a/packages/cli/test/integration/sso-chat/chat-auth.service.integration.test.ts
+++ b/packages/cli/test/integration/sso-chat/chat-auth.service.integration.test.ts
@@ -1,0 +1,364 @@
+import { testDb, testModules } from '@n8n/backend-test-utils';
+import { UserRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { OperationalError } from 'n8n-workflow';
+import { createHash } from 'node:crypto';
+
+import { ChatAuthIdentityRepository } from '@/modules/sso-chat/repositories/chat-auth-identity.repository';
+import { ChatClientCodeRepository } from '@/modules/sso-chat/repositories/chat-client-code.repository';
+import { ChatAuthenticationService } from '@/modules/sso-chat/services/chat-auth.service';
+
+import { createUser } from '../shared/db/users';
+
+const hashCode = (code: string) => createHash('sha256').update(code).digest().toString('base64');
+
+describe('ChatAuthenticationService', () => {
+	let service: ChatAuthenticationService;
+	let authIdentityRepo: ChatAuthIdentityRepository;
+	let clientCodeRepo: ChatClientCodeRepository;
+	let userRepo: UserRepository;
+
+	beforeAll(async () => {
+		await testModules.loadModules(['sso-chat']);
+		await testDb.init();
+		service = Container.get(ChatAuthenticationService);
+		authIdentityRepo = Container.get(ChatAuthIdentityRepository);
+		clientCodeRepo = Container.get(ChatClientCodeRepository);
+		userRepo = Container.get(UserRepository);
+	});
+
+	afterEach(async () => {
+		await authIdentityRepo.delete({});
+		await clientCodeRepo.delete({});
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	describe('createVerificationCode', () => {
+		it('returns a 9-digit numeric code and persists its hash', async () => {
+			const code = await service.createVerificationCode('tg-123', 'telegram');
+
+			expect(code).toMatch(/^\d{9}$/);
+
+			const row = await clientCodeRepo.findOneBy({
+				providerId: 'tg-123',
+				providerType: 'telegram',
+			});
+			expect(row).not.toBeNull();
+			expect(row!.codeHash).toBe(hashCode(code));
+		});
+
+		it('sets expiresAt approximately at now + validForSeconds', async () => {
+			const before = Date.now();
+			await service.createVerificationCode('tg-123', 'telegram', 120);
+			const after = Date.now();
+
+			const row = await clientCodeRepo.findOneBy({
+				providerId: 'tg-123',
+				providerType: 'telegram',
+			});
+			const expiresMs = row!.expiresAt.getTime();
+			expect(expiresMs).toBeGreaterThanOrEqual(before + 120_000);
+			expect(expiresMs).toBeLessThanOrEqual(after + 120_000);
+		});
+
+		it('defaults validForSeconds to 300 when omitted', async () => {
+			const before = Date.now();
+			await service.createVerificationCode('tg-default', 'telegram');
+			const after = Date.now();
+
+			const row = await clientCodeRepo.findOneBy({
+				providerId: 'tg-default',
+				providerType: 'telegram',
+			});
+			const expiresMs = row!.expiresAt.getTime();
+			expect(expiresMs).toBeGreaterThanOrEqual(before + 300_000);
+			expect(expiresMs).toBeLessThanOrEqual(after + 300_000);
+		});
+
+		it('throws OperationalError when the chat user is already linked', async () => {
+			const user = await createUser();
+			await authIdentityRepo.save({
+				userId: user.id,
+				providerId: 'tg-linked',
+				providerType: 'telegram',
+			});
+
+			await expect(service.createVerificationCode('tg-linked', 'telegram')).rejects.toThrow(
+				OperationalError,
+			);
+
+			const codeRow = await clientCodeRepo.findOneBy({
+				providerId: 'tg-linked',
+				providerType: 'telegram',
+			});
+			expect(codeRow).toBeNull();
+		});
+
+		it('replaces a previous pending code for the same (providerId, providerType)', async () => {
+			const firstCode = await service.createVerificationCode('tg-reissue', 'telegram');
+			const secondCode = await service.createVerificationCode('tg-reissue', 'telegram');
+
+			expect(secondCode).not.toBe(firstCode);
+
+			const rows = await clientCodeRepo.findBy({
+				providerId: 'tg-reissue',
+				providerType: 'telegram',
+			});
+			expect(rows).toHaveLength(1);
+			expect(rows[0].codeHash).toBe(hashCode(secondCode));
+			expect(rows[0].codeHash).not.toBe(hashCode(firstCode));
+		});
+
+		it('produces distinct codes across calls', async () => {
+			const codes = new Set<string>();
+			for (let i = 0; i < 5; i++) {
+				codes.add(await service.createVerificationCode(`tg-${i}`, 'telegram'));
+			}
+			expect(codes.size).toBe(5);
+		});
+
+		it('scopes codes per provider — telegram and slack can have separate pending codes for the same id', async () => {
+			const tgCode = await service.createVerificationCode('shared-id', 'telegram');
+			const slCode = await service.createVerificationCode('shared-id', 'slack');
+
+			expect(tgCode).not.toBe(slCode);
+
+			const allRows = await clientCodeRepo.findBy({ providerId: 'shared-id' });
+			expect(allRows).toHaveLength(2);
+		});
+	});
+
+	describe('validateUserCodeAndLink', () => {
+		it('links the n8n user, removes the code, and persists the identity', async () => {
+			const user = await createUser();
+			const code = await service.createVerificationCode('tg-happy', 'telegram');
+
+			await service.validateUserCodeAndLink(user.id, 'telegram', code);
+
+			const identity = await authIdentityRepo.findOneBy({
+				providerId: 'tg-happy',
+				providerType: 'telegram',
+			});
+			expect(identity).not.toBeNull();
+			expect(identity!.userId).toBe(user.id);
+
+			const codeRow = await clientCodeRepo.findOneBy({
+				providerId: 'tg-happy',
+				providerType: 'telegram',
+			});
+			expect(codeRow).toBeNull();
+		});
+
+		it('throws OperationalError when the code is unknown', async () => {
+			const user = await createUser();
+
+			await expect(
+				service.validateUserCodeAndLink(user.id, 'telegram', '999999999'),
+			).rejects.toThrow(OperationalError);
+
+			const identities = await authIdentityRepo.find();
+			expect(identities).toHaveLength(0);
+		});
+
+		it('rejects a code issued for a different provider', async () => {
+			const user = await createUser();
+			const code = await service.createVerificationCode('shared-id', 'telegram');
+
+			await expect(service.validateUserCodeAndLink(user.id, 'slack', code)).rejects.toThrow(
+				OperationalError,
+			);
+
+			const identities = await authIdentityRepo.find();
+			expect(identities).toHaveLength(0);
+			const codeRow = await clientCodeRepo.findOneBy({
+				providerId: 'shared-id',
+				providerType: 'telegram',
+			});
+			expect(codeRow).not.toBeNull();
+		});
+
+		// The service calls delete() then throws on expiry inside the same transaction,
+		// so the throw rolls the delete back. The code row persists until an external
+		// sweeper removes it. This test pins that behavior so a refactor cannot quietly
+		// strip the transaction wrapper.
+		it('throws on an expired code and rolls back the delete (no identity created)', async () => {
+			const user = await createUser();
+			await clientCodeRepo.save({
+				providerId: 'tg-expired',
+				providerType: 'telegram',
+				codeHash: hashCode('123456789'),
+				expiresAt: new Date(Date.now() - 1000),
+			});
+
+			await expect(
+				service.validateUserCodeAndLink(user.id, 'telegram', '123456789'),
+			).rejects.toThrow(OperationalError);
+
+			const codeRow = await clientCodeRepo.findOneBy({
+				providerId: 'tg-expired',
+				providerType: 'telegram',
+			});
+			expect(codeRow).not.toBeNull();
+			const identity = await authIdentityRepo.findOneBy({
+				providerId: 'tg-expired',
+				providerType: 'telegram',
+			});
+			expect(identity).toBeNull();
+		});
+
+		it('cannot be replayed — a consumed code is rejected on the second call', async () => {
+			const user = await createUser();
+			const code = await service.createVerificationCode('tg-replay', 'telegram');
+
+			await service.validateUserCodeAndLink(user.id, 'telegram', code);
+			await expect(service.validateUserCodeAndLink(user.id, 'telegram', code)).rejects.toThrow(
+				OperationalError,
+			);
+		});
+	});
+
+	describe('getUserByChatUserId', () => {
+		it('returns the linked user', async () => {
+			const user = await createUser();
+			const code = await service.createVerificationCode('tg-lookup', 'telegram');
+			await service.validateUserCodeAndLink(user.id, 'telegram', code);
+
+			const found = await service.getUserByChatUserId('tg-lookup', 'telegram');
+			expect(found).not.toBeNull();
+			expect(found!.id).toBe(user.id);
+		});
+
+		it('returns null when no identity exists', async () => {
+			const found = await service.getUserByChatUserId('tg-unknown', 'telegram');
+			expect(found).toBeNull();
+		});
+
+		it('returns null when the chat id is linked under a different provider', async () => {
+			const user = await createUser();
+			await authIdentityRepo.save({
+				userId: user.id,
+				providerId: 'shared-id',
+				providerType: 'telegram',
+			});
+
+			const found = await service.getUserByChatUserId('shared-id', 'slack');
+			expect(found).toBeNull();
+		});
+
+		it('returns null after the linked user has been deleted (FK cascade wipes the identity)', async () => {
+			const user = await createUser();
+			await authIdentityRepo.save({
+				userId: user.id,
+				providerId: 'tg-cascade',
+				providerType: 'telegram',
+			});
+
+			await userRepo.delete({ id: user.id });
+
+			const found = await service.getUserByChatUserId('tg-cascade', 'telegram');
+			expect(found).toBeNull();
+		});
+	});
+
+	describe('getChatProvidersForUser', () => {
+		it('returns an empty array when the user has no linked chat identities', async () => {
+			const user = await createUser();
+			expect(await service.getChatProvidersForUser(user.id)).toEqual([]);
+		});
+
+		it('returns deduped providers for a user linked to telegram and slack', async () => {
+			const user = await createUser();
+			await authIdentityRepo.save([
+				{ userId: user.id, providerId: 'tg-1', providerType: 'telegram' },
+				{ userId: user.id, providerId: 'sl-1', providerType: 'slack' },
+			]);
+
+			const providers = await service.getChatProvidersForUser(user.id);
+			expect(providers.sort()).toEqual(['slack', 'telegram']);
+		});
+
+		it('dedupes when the user has multiple identities under the same provider', async () => {
+			const user = await createUser();
+			await authIdentityRepo.save([
+				{ userId: user.id, providerId: 'tg-a', providerType: 'telegram' },
+				{ userId: user.id, providerId: 'tg-b', providerType: 'telegram' },
+			]);
+
+			expect(await service.getChatProvidersForUser(user.id)).toEqual(['telegram']);
+		});
+
+		it('only returns providers belonging to the requested user', async () => {
+			const userA = await createUser();
+			const userB = await createUser();
+			await authIdentityRepo.save([
+				{ userId: userA.id, providerId: 'tg-a', providerType: 'telegram' },
+				{ userId: userB.id, providerId: 'sl-b', providerType: 'slack' },
+			]);
+
+			expect(await service.getChatProvidersForUser(userA.id)).toEqual(['telegram']);
+			expect(await service.getChatProvidersForUser(userB.id)).toEqual(['slack']);
+		});
+	});
+
+	describe('unlinkUserFromProvider', () => {
+		it('removes the matching (userId, providerType) identity', async () => {
+			const user = await createUser();
+			await authIdentityRepo.save({
+				userId: user.id,
+				providerId: 'tg-unlink',
+				providerType: 'telegram',
+			});
+
+			await service.unlinkUserFromProvider(user.id, 'telegram');
+
+			const remaining = await authIdentityRepo.findOneBy({
+				providerId: 'tg-unlink',
+				providerType: 'telegram',
+			});
+			expect(remaining).toBeNull();
+		});
+
+		it('leaves identities for other provider types intact', async () => {
+			const user = await createUser();
+			await authIdentityRepo.save([
+				{ userId: user.id, providerId: 'tg-keep', providerType: 'telegram' },
+				{ userId: user.id, providerId: 'sl-keep', providerType: 'slack' },
+			]);
+
+			await service.unlinkUserFromProvider(user.id, 'telegram');
+
+			expect(
+				await authIdentityRepo.findOneBy({
+					providerId: 'sl-keep',
+					providerType: 'slack',
+				}),
+			).not.toBeNull();
+		});
+
+		it('is idempotent for a non-existent link', async () => {
+			const user = await createUser();
+			await expect(service.unlinkUserFromProvider(user.id, 'telegram')).resolves.toBeUndefined();
+		});
+
+		it('does not affect another user with the same provider type', async () => {
+			const userA = await createUser();
+			const userB = await createUser();
+			await authIdentityRepo.save([
+				{ userId: userA.id, providerId: 'tg-a', providerType: 'telegram' },
+				{ userId: userB.id, providerId: 'tg-b', providerType: 'telegram' },
+			]);
+
+			await service.unlinkUserFromProvider(userA.id, 'telegram');
+
+			expect(
+				await authIdentityRepo.findOneBy({
+					providerId: 'tg-b',
+					providerType: 'telegram',
+				}),
+			).not.toBeNull();
+		});
+	});
+});

--- a/packages/cli/test/integration/sso-chat/chat-sso.repository.integration.test.ts
+++ b/packages/cli/test/integration/sso-chat/chat-sso.repository.integration.test.ts
@@ -1,0 +1,286 @@
+import { testDb, testModules } from '@n8n/backend-test-utils';
+import { UserRepository } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { v4 as uuid } from 'uuid';
+
+import { ChatAuthIdentity } from '@/modules/sso-chat/entities/chat-auth-identity';
+import { ChatClientCode } from '@/modules/sso-chat/entities/chat-client-code';
+import { ChatAuthIdentityRepository } from '@/modules/sso-chat/repositories/chat-auth-identity.repository';
+import { ChatClientCodeRepository } from '@/modules/sso-chat/repositories/chat-client-code.repository';
+
+import { createUser } from '../shared/db/users';
+
+describe('sso-chat repositories', () => {
+	let authIdentityRepo: ChatAuthIdentityRepository;
+	let clientCodeRepo: ChatClientCodeRepository;
+
+	beforeAll(async () => {
+		await testModules.loadModules(['sso-chat']);
+		await testDb.init();
+		authIdentityRepo = Container.get(ChatAuthIdentityRepository);
+		clientCodeRepo = Container.get(ChatClientCodeRepository);
+	});
+
+	afterEach(async () => {
+		await authIdentityRepo.delete({});
+		await clientCodeRepo.delete({});
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	describe('ChatAuthIdentityRepository', () => {
+		it('persists and retrieves an identity by its composite key', async () => {
+			const user = await createUser();
+
+			await authIdentityRepo.save(
+				authIdentityRepo.create({
+					userId: user.id,
+					providerId: 'tg-12345',
+					providerType: 'telegram',
+				}),
+			);
+
+			const found = await authIdentityRepo.findOneBy({
+				providerId: 'tg-12345',
+				providerType: 'telegram',
+			});
+
+			expect(found).not.toBeNull();
+			expect(found!.userId).toBe(user.id);
+			expect(found!.providerId).toBe('tg-12345');
+			expect(found!.providerType).toBe('telegram');
+			expect(found!.createdAt).toBeInstanceOf(Date);
+			expect(found!.updatedAt).toBeInstanceOf(Date);
+		});
+
+		it('allows the same user to link multiple providers', async () => {
+			const user = await createUser();
+
+			await authIdentityRepo.save([
+				authIdentityRepo.create({
+					userId: user.id,
+					providerId: 'tg-1',
+					providerType: 'telegram',
+				}),
+				authIdentityRepo.create({
+					userId: user.id,
+					providerId: 'sl-1',
+					providerType: 'slack',
+				}),
+			]);
+
+			const identities = await authIdentityRepo.findBy({ userId: user.id });
+			expect(identities).toHaveLength(2);
+			expect(identities.map((i) => i.providerType).sort()).toEqual(['slack', 'telegram']);
+		});
+
+		it('allows the same providerId across different providerTypes', async () => {
+			const user = await createUser();
+
+			await authIdentityRepo.save([
+				authIdentityRepo.create({
+					userId: user.id,
+					providerId: 'shared-id',
+					providerType: 'telegram',
+				}),
+				authIdentityRepo.create({
+					userId: user.id,
+					providerId: 'shared-id',
+					providerType: 'slack',
+				}),
+			]);
+
+			const all = await authIdentityRepo.findBy({ providerId: 'shared-id' });
+			expect(all).toHaveLength(2);
+		});
+
+		it('rejects duplicate (providerId, providerType) pairs', async () => {
+			const userA = await createUser();
+			const userB = await createUser();
+
+			await authIdentityRepo.save(
+				authIdentityRepo.create({
+					userId: userA.id,
+					providerId: 'tg-conflict',
+					providerType: 'telegram',
+				}),
+			);
+
+			await expect(
+				authIdentityRepo.insert({
+					userId: userB.id,
+					providerId: 'tg-conflict',
+					providerType: 'telegram',
+				}),
+			).rejects.toThrow();
+		});
+
+		it('rejects identities referencing a non-existent user', async () => {
+			await expect(
+				authIdentityRepo.insert({
+					userId: uuid(),
+					providerId: 'tg-orphan',
+					providerType: 'telegram',
+				}),
+			).rejects.toThrow();
+		});
+
+		it('cascades deletes when the linked user is removed', async () => {
+			const user = await createUser();
+
+			await authIdentityRepo.save(
+				authIdentityRepo.create({
+					userId: user.id,
+					providerId: 'tg-cascade',
+					providerType: 'telegram',
+				}),
+			);
+
+			await Container.get(UserRepository).delete({ id: user.id });
+
+			const remaining = await authIdentityRepo.findOneBy({
+				providerId: 'tg-cascade',
+				providerType: 'telegram',
+			});
+			expect(remaining).toBeNull();
+		});
+
+		it('looks up by userId and providerType', async () => {
+			const user = await createUser();
+
+			await authIdentityRepo.save(
+				authIdentityRepo.create({
+					userId: user.id,
+					providerId: 'tg-lookup',
+					providerType: 'telegram',
+				}),
+			);
+
+			const found = await authIdentityRepo.findOneBy({
+				userId: user.id,
+				providerType: 'telegram',
+			});
+
+			expect(found).not.toBeNull();
+			expect(found).toBeInstanceOf(ChatAuthIdentity);
+			expect(found!.providerId).toBe('tg-lookup');
+		});
+	});
+
+	describe('ChatClientCodeRepository', () => {
+		const futureDate = () => new Date(Date.now() + 60 * 60 * 1000);
+
+		it('persists and retrieves a client code by its composite key', async () => {
+			const expiresAt = futureDate();
+			await clientCodeRepo.save(
+				clientCodeRepo.create({
+					providerId: 'tg-12345',
+					providerType: 'telegram',
+					codeHash: 'hashed-code-1',
+					expiresAt,
+				}),
+			);
+
+			const found = await clientCodeRepo.findOneBy({
+				providerId: 'tg-12345',
+				providerType: 'telegram',
+			});
+
+			expect(found).not.toBeNull();
+			expect(found).toBeInstanceOf(ChatClientCode);
+			expect(found!.codeHash).toBe('hashed-code-1');
+			expect(found!.expiresAt.getTime()).toBe(expiresAt.getTime());
+			expect(found!.createdAt).toBeInstanceOf(Date);
+			expect(found!.updatedAt).toBeInstanceOf(Date);
+		});
+
+		it('allows the same providerId across different providerTypes', async () => {
+			const expiresAt = futureDate();
+			await clientCodeRepo.save([
+				clientCodeRepo.create({
+					providerId: 'shared-id',
+					providerType: 'telegram',
+					codeHash: 'hash-tg',
+					expiresAt,
+				}),
+				clientCodeRepo.create({
+					providerId: 'shared-id',
+					providerType: 'slack',
+					codeHash: 'hash-sl',
+					expiresAt,
+				}),
+			]);
+
+			const all = await clientCodeRepo.findBy({ providerId: 'shared-id' });
+			expect(all).toHaveLength(2);
+		});
+
+		it('rejects duplicate (providerId, providerType) pairs', async () => {
+			const expiresAt = futureDate();
+			await clientCodeRepo.save(
+				clientCodeRepo.create({
+					providerId: 'tg-dup',
+					providerType: 'telegram',
+					codeHash: 'hash-1',
+					expiresAt,
+				}),
+			);
+
+			await expect(
+				clientCodeRepo.insert({
+					providerId: 'tg-dup',
+					providerType: 'telegram',
+					codeHash: 'hash-2',
+					expiresAt,
+				}),
+			).rejects.toThrow();
+		});
+
+		it('updates codeHash and expiresAt on an existing row', async () => {
+			const initialExpiry = futureDate();
+			await clientCodeRepo.save(
+				clientCodeRepo.create({
+					providerId: 'tg-update',
+					providerType: 'telegram',
+					codeHash: 'original-hash',
+					expiresAt: initialExpiry,
+				}),
+			);
+
+			const newExpiry = new Date(Date.now() + 2 * 60 * 60 * 1000);
+			await clientCodeRepo.update(
+				{ providerId: 'tg-update', providerType: 'telegram' },
+				{ codeHash: 'rotated-hash', expiresAt: newExpiry },
+			);
+
+			const found = await clientCodeRepo.findOneBy({
+				providerId: 'tg-update',
+				providerType: 'telegram',
+			});
+			expect(found!.codeHash).toBe('rotated-hash');
+			expect(found!.expiresAt.getTime()).toBe(newExpiry.getTime());
+		});
+
+		it('deletes by composite key', async () => {
+			const expiresAt = futureDate();
+			await clientCodeRepo.save(
+				clientCodeRepo.create({
+					providerId: 'tg-delete',
+					providerType: 'telegram',
+					codeHash: 'to-delete',
+					expiresAt,
+				}),
+			);
+
+			await clientCodeRepo.delete({ providerId: 'tg-delete', providerType: 'telegram' });
+
+			const found = await clientCodeRepo.findOneBy({
+				providerId: 'tg-delete',
+				providerType: 'telegram',
+			});
+			expect(found).toBeNull();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds the foundation for an `sso-chat` backend module that lets external chat
users (Telegram, Slack) link themselves to an n8n user via a short-lived
verification code. This PR is **scaffolding only**: schema, entities,
repositories, the authentication service, and a CLI-level proxy. There is no
controller, API endpoint, UI, or actual chat-platform integration yet.

### What this PR contains

- **Migration** `1784000000001-ChatSSOTable` (Postgres + SQLite indexes
  registered) creating two tables:
  - `chat_auth_identity` — links an n8n user to a chat identity
    (`userId`, composite PK `(providerId, providerType)`, FK to `user.id` with
    `ON DELETE CASCADE`).
  - `chat_client_code` — stores hashed, short-lived verification codes keyed
    on `(providerId, providerType)`.
- **Entities** (`ChatAuthIdentity`, `ChatClientCode`) and matching
  TypeORM repositories.
- **Module** `sso-chat` registered in `module-registry` and `modules.config`,
  with an `init()` that wires the proxy at startup.
- **`ChatAuthenticationService`** (inside the module) implementing:
  `createVerificationCode`, `validateUserCodeAndLink`, `getUserByChatUserId`,
  `getChatProvidersForUser`, `unlinkUserFromProvider`.
- **`ChatAuthenticationProxyService`** (CLI-level) exposing
  `IChatAuthenticationService` to non-module code; throws `UserError` when
  the module is disabled and offers `hasProvider()` to gate callers.
- **36 integration tests** (real DB):
  - 12 repository tests covering the migration, composite PKs, the FK
    cascade, and basic CRUD.
  - 24 service tests covering code generation, expiry, replay rejection,
    provider scoping, link/unlink, and FK-cascade behavior through the
    service.

### Key design decisions

- **Crypto-secure verification codes**: `randomInt(1e8, 1e9)` from
  `n8n-workflow` (uses `crypto.getRandomValues`). Plaintext code is returned
  to the caller once; only its SHA-256 hash is persisted.
- **Provider-scoped redemption**: `validateUserCodeAndLink` takes
  `chatProvider` and matches on `(codeHash, providerType)` so a code issued
  for Telegram cannot be claimed via a Slack flow.
- **Transactional redemption**: code lookup + delete + identity insert run in
  one TypeORM transaction. On expiry the throw rolls the delete back — the
  expired row is preserved (a sweeper is left as follow-up work).
- **Proxy + module wiring** mirrors how OIDC/SAML modules are exposed: the
  proxy lives in CLI and is always injectable; the real implementation is
  registered when the module is enabled.
- **`ChatProviderType`** is defined once at the proxy module
  (`"telegram" | "slack"`) and re-used by entities and the service.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
