### PR TITLE
fix(editor): Clear workflow worker pool overrides on save (no-changelog)

### DIFF
--- a/packages/cli/src/__tests__/workflow-helpers.test.ts
+++ b/packages/cli/src/__tests__/workflow-helpers.test.ts
@@ -368,6 +368,29 @@ describe('removeDefaultValues', () => {
 		});
 	});
 
+	it('should remove worker pool overrides when cleared (empty string)', () => {
+		const settings: IWorkflowSettings = {
+			workerPoolOverrideProduction: '',
+			workerPoolOverrideManual: '',
+			workerPoolOverrideEvaluation: '',
+			timezone: 'America/New_York',
+		};
+		const result = removeDefaultValues(settings, DEFAULT_EXECUTION_TIMEOUT);
+		expect(result).toEqual({ timezone: 'America/New_York' });
+	});
+
+	it('should keep worker pool overrides when set to a pool name', () => {
+		const settings: IWorkflowSettings = {
+			workerPoolOverrideProduction: 'gpu',
+			workerPoolOverrideManual: 'cpu',
+		};
+		const result = removeDefaultValues(settings, DEFAULT_EXECUTION_TIMEOUT);
+		expect(result).toEqual({
+			workerPoolOverrideProduction: 'gpu',
+			workerPoolOverrideManual: 'cpu',
+		});
+	});
+
 	it('should not mutate the original settings object', () => {
 		const settings = {
 			errorWorkflow: DEFAULT,

--- a/packages/cli/src/workflow-helpers.ts
+++ b/packages/cli/src/workflow-helpers.ts
@@ -183,6 +183,18 @@ export function removeDefaultValues(
 		delete cleanedSettings.credentialResolverId;
 	}
 
+	// Remove worker pool overrides if they were cleared (empty string / falsy values from UI clear action).
+	const poolOverrideKeys = [
+		'workerPoolOverrideProduction',
+		'workerPoolOverrideManual',
+		'workerPoolOverrideEvaluation',
+	] as const;
+	for (const key of poolOverrideKeys) {
+		if (!cleanedSettings[key]) {
+			delete cleanedSettings[key];
+		}
+	}
+
 	return cleanedSettings;
 }
 

--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
@@ -223,17 +223,16 @@ const workerPoolOptionsForCategory = (category: WorkerPoolCategory) => {
 };
 
 const selectedWorkerPool = (category: WorkerPoolCategory) => {
-	return workflowSettings.value[workerPoolSettingKeys[category]] ?? 'DEFAULT';
+	return workflowSettings.value[workerPoolSettingKeys[category]] || 'DEFAULT';
 };
 
 const onWorkerPoolChange = (category: WorkerPoolCategory, value: string) => {
 	const settingKey = workerPoolSettingKeys[category];
 
-	if (value === 'DEFAULT') {
-		delete workflowSettings.value[settingKey];
-	} else {
-		workflowSettings.value[settingKey] = value;
-	}
+	// Send empty string (not `delete`) so the backend's PATCH-merge of `settings`
+	// actually overwrites any previously-stored override. `removeDefaultValues`
+	// strips empty-string overrides before persisting to keep the JSON tidy.
+	workflowSettings.value[settingKey] = value === 'DEFAULT' ? '' : value;
 };
 
 const isSelectedResolverEditable = computed(() => {


### PR DESCRIPTION
## Summary

Fixes a bug in the Workflow Settings form where setting any of the **Production / Manual / Evaluation execution pool** dropdowns back to "Default" did not actually clear the previously-stored override at the API/database level.

### Root cause

\`onWorkerPoolChange\` used \`delete workflowSettings.value[settingKey]\` when the user picked "DEFAULT". The settings object was then sent to \`PATCH /rest/workflows/:id\`, but the backend (\`workflow.service.ts\` \`updateWorkflow\`) PATCH-merges \`settings\`:

\`\`\`ts
workflowUpdateData.settings = { ...workflow.settings, ...workflowUpdateData.settings };
\`\`\`

A locally-\`delete\`-d key is simply absent from the spread → the previously-stored override survives the merge → cleared-in-UI but not cleared-in-DB. Subsequent executions kept using the stale override.

### Fix

Mirrors the existing \`credentialResolverId\` clear-action convention:

1. **\`WorkflowSettings.vue\`**
   - \`onWorkerPoolChange\` now writes \`''\` (empty string) instead of \`delete\`-ing the key — empty string survives JSON serialization and overwrites the stored value on backend merge.
   - \`selectedWorkerPool\` uses \`||\` (falsy-coalesce) instead of \`??\` so a stored empty string displays as "Default" in the dropdown on reload.

2. **\`workflow-helpers.ts\` \`removeDefaultValues\`** strips empty-string \`workerPoolOverrideProduction\` / \`workerPoolOverrideManual\` / \`workerPoolOverrideEvaluation\` before persisting, matching how \`credentialResolverId\` and the other "DEFAULT"-allowing keys are cleaned up — keeps the \`workflow.settings\` JSON column tidy.

Runtime cascade (\`workflow-runner.ts:706-710\`) already truthy-checks the override (\`if (workflowPool)\`), so empty-string values correctly fall through to project/instance defaults even before the cleanup runs.

### How to test

1. As a project admin, open a workflow's Settings dialog.
2. Set Production executions to a specific pool (e.g. \`gpu\`). Save → reload page → dropdown still shows \`gpu\`. Confirm \`workflow.settings.workerPoolOverrideProduction === 'gpu'\` in DB.
3. Reopen Settings, switch Production back to "Default". Save.
4. Reload → dropdown shows "Default". Inspect DB: \`workerPoolOverrideProduction\` key should be **absent** from \`settings\`.
5. Repeat for Manual + Evaluation independently.
6. Run the workflow in production mode and verify cascade falls through to project default (or instance default).

### Stack

Targets \`hackmation/project-pool-settings-ui\` (#30424). Once that lands, retarget via GitHub UI — no code changes needed.

## Related Linear tickets, Github issues, and Community forum posts

Part of the worker pools Hackmation project. Bug surfaced after #30393 added the workflow-level override UI.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI