### PR TITLE
fix(core): Pre-create examples dir in sandbox workspace (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
+++ b/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
@@ -224,7 +224,7 @@ export function formatNodeCatalogLine(node: SearchableNodeDescription): string {
 }
 
 /** Dirs the agent's `list_files` may probe; some providers 404 on missing dirs. */
-const ALWAYS_PRESENT_DIRS: readonly string[] = ['src', 'chunks', 'workflows'];
+const ALWAYS_PRESENT_DIRS: readonly string[] = ['src', 'chunks', 'workflows', 'examples'];
 
 /**
  * Build a shell script that writes all files at once.


### PR DESCRIPTION
## Summary

`writeCuratedExamples` calls `filesystem.writeFile(...examples/<file>, { recursive: true })` for each of the 107 example files in parallel. On Daytona, `recursive: true` issues a parent-dir `createFolder` per file — 107 concurrent calls against the same `examples/` path.

Adding `examples` to `ALWAYS_PRESENT_DIRS` lets the existing upfront-mkdir loop create the directory once, before the parallel writes fan out.

Defensive change — does not directly address any confirmed root cause. Filed because we're investigating CI eval failures whose only visible symptom is a (possibly hallucinated) 'filesystem permission error' in agent output, and this is the cheapest known-good improvement to the post-creation write fan-out.

## Test plan
- [ ] Existing `sandbox-setup.test.ts` still passes.
- [ ] CI eval pass rate.
