### PR TITLE
fix(nodes-base): Duplicated "the" in Zulip and Taiga user-visible descriptions

### DIFF
--- a/packages/nodes-base/nodes/Taiga/descriptions/UserStoryDescription.ts
+++ b/packages/nodes-base/nodes/Taiga/descriptions/UserStoryDescription.ts
@@ -455,7 +455,7 @@ export const userStoryFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the user to assign the the user story to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user to assign the user story to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Backlog Order',

--- a/packages/nodes-base/nodes/Zulip/StreamDescription.ts
+++ b/packages/nodes-base/nodes/Zulip/StreamDescription.ts
@@ -94,7 +94,7 @@ export const streamFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'A list of dictionaries containing the the key name and value specifying the name of the stream to subscribe. If the stream does not exist a new stream is created.',
+			'A list of dictionaries containing the key name and value specifying the name of the stream to subscribe. If the stream does not exist a new stream is created.',
 		typeOptions: {
 			multipleValues: true,
 		},


### PR DESCRIPTION
Two one-line typo fixes for duplicated "the" in node parameter descriptions:
- `packages/nodes-base/nodes/Zulip/StreamDescription.ts` — "A list of dictionaries containing the the key name and value" → "...containing the key name and value"
- `packages/nodes-base/nodes/Taiga/descriptions/UserStoryDescription.ts` — "ID of the user to assign the the user story to" → "ID of the user to assign the user story to"

No code/behavior change.