### PR TITLE
fix(nodes-base): Duplicated words in Postgres/Filter/If comments

### DIFF
--- a/packages/nodes-base/nodes/Filter/V1/FilterV1.node.ts
+++ b/packages/nodes-base/nodes/Filter/V1/FilterV1.node.ts
@@ -364,7 +364,7 @@ export class FilterV1 implements INodeType {
 			if (combineConditions === 'AND') {
 				returnDataTrue.push(item);
 			} else {
-				// If the operation is "OR" it means the the item did not match any condition.
+				// If the operation is "OR" it means the item did not match any condition.
 				returnDataFalse.push(item);
 			}
 		}

--- a/packages/nodes-base/nodes/If/V1/IfV1.node.ts
+++ b/packages/nodes-base/nodes/If/V1/IfV1.node.ts
@@ -476,7 +476,7 @@ export class IfV1 implements INodeType {
 				// so it passes.
 				returnDataTrue.push(item);
 			} else {
-				// If the operation is "any" it means the the item did not match any condition.
+				// If the operation is "any" it means the item did not match any condition.
 				returnDataFalse.push(item);
 			}
 		}

--- a/packages/nodes-base/nodes/Postgres/v1/PostgresV1.node.ts
+++ b/packages/nodes-base/nodes/Postgres/v1/PostgresV1.node.ts
@@ -305,7 +305,7 @@ export class PostgresV1 implements INodeType {
 				try {
 					const { db } = await configurePostgres.call(this, credentials, {});
 
-					// Acquires a new connection that can be used to to run multiple
+					// Acquires a new connection that can be used to run multiple
 					// queries on the same connection and must be released again
 					// manually.
 					connection = await db.connect();


### PR DESCRIPTION
Three one-line typo fixes for duplicated words in source comments:
- `packages/nodes-base/nodes/Postgres/v1/PostgresV1.node.ts` — "Acquires a new connection that can be used to to run multiple" → "...to run multiple"
- `packages/nodes-base/nodes/Filter/V1/FilterV1.node.ts` — "it means the the item did not match any condition." → "it means the item did not match any condition."
- `packages/nodes-base/nodes/If/V1/IfV1.node.ts` — same fix as Filter

No code/behavior change.