### PR TITLE
ci: Enable verbose SafeChain logging in CI dependency install (no-changelog)

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -67,6 +67,7 @@ runs:
       if: ${{ inputs.install-command != '' }}
       env:
         INSTALL_COMMAND: ${{ inputs.install-command }}
+        SAFE_CHAIN_LOGGING: verbose
       run: |
         $INSTALL_COMMAND
       shell: bash


### PR DESCRIPTION
## Summary

Set `SAFE_CHAIN_LOGGING=verbose` on the `Install Dependencies` step of the shared `setup-nodejs` composite action so Aikido SafeChain emits its diagnostic output directly to the GitHub Actions log.

**Why:** Intermittent install failures from the SafeChain pnpm shim currently surface as opaque non-zero exits with no indication of which package or check triggered the block. With verbose logging on, the next failure (running at ~15% rate) will tell us the actual block reason (e.g. minimum package age threshold, exclusion list miss) so we can decide whether to widen exclusions, lower the age threshold for renovate branches, or push back to Aikido about a soft-fail mode.

**Scope:** Single-line env var addition. No change to install command, exit handling, or shell flags — those can be layered on later if verbose alone is insufficient.

SafeChain has no warn-only mode; verbose logging is the minimum-friction diagnostic lever available.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Add Linear ticket link if applicable -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)