### PR TITLE
fix(editor): Snap tidy-up node positions to grid

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/__snapshots__/useCanvasLayout.test.ts.snap
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/__snapshots__/useCanvasLayout.test.ts.snap
@@ -135,7 +135,7 @@ exports[`useCanvasLayout > should layout a workflow with sticky notes 1`] = `
     },
     {
       "id": "sticky",
-      "x": 134,
+      "x": 128,
       "y": -240,
     },
   ],

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.ts
@@ -565,15 +565,19 @@ export function useCanvasLayout(canvasId: string, isEmbeddedNdvActive: ComputedR
 			})
 			.filter(isPresent);
 
+		const snapToGrid = (value: number) => Math.round(value / GRID_SIZE) * GRID_SIZE;
+
+		const finalNodes = positionedNodes.concat(positionedStickies).map(({ id, boundingBox }) => {
+			return {
+				id,
+				x: snapToGrid(boundingBox.x - anchor.x),
+				y: snapToGrid(boundingBox.y - anchor.y),
+			};
+		});
+
 		return {
 			boundingBox: boundingBoxAfter,
-			nodes: positionedNodes.concat(positionedStickies).map(({ id, boundingBox }) => {
-				return {
-					id,
-					x: boundingBox.x - anchor.x,
-					y: boundingBox.y - anchor.y,
-				};
-			}),
+			nodes: finalNodes,
 		};
 	}
 


### PR DESCRIPTION
## Summary

The "tidy up" feature positions nodes off-grid (offset by 8px — half the 16px grid size), making it impossible to manually align nodes afterwards. This happens because Dagre's layout engine produces positions that aren't multiples of `GRID_SIZE`, and the anchor offset (which preserves the workflow's original position) compounds the misalignment.

The fix snaps all final node positions to the nearest `GRID_SIZE` (16px) multiple before returning them from the layout function.

**How to test:**
1. Create a workflow with 3+ rows of connected nodes (e.g., triggers → processing → output)
2. Click "tidy up" in the canvas
3. Try to align any node using the alignment tools
4. Verify nodes snap correctly and alignment works as expected

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4158

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

---
🤖 PR Summary generated by AI

Made with [Cursor](https://cursor.com)