### PR TITLE
fix(core): Loading agents test sessions again correctly (no-changelog)

### DIFF
--- a/packages/cli/src/modules/agents/__tests__/agents.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.controller.test.ts
@@ -110,3 +110,97 @@ describe('AgentsController integration credentials', () => {
 		expect(chatIntegrationService.connect).not.toHaveBeenCalled();
 	});
 });
+
+describe('AgentsController chat message history', () => {
+	function makeController() {
+		const agentsService = mock<AgentsService>();
+		const agentExecutionService = mock<AgentExecutionService>();
+		const controller = new AgentsController(
+			agentsService,
+			mock<AgentsBuilderService>(),
+			mock<CredentialsService>(),
+			mock<ChatIntegrationService>(),
+			mock<AgentScheduleService>(),
+			mock<AgentRepository>(),
+			agentExecutionService,
+			mock<ChatIntegrationRegistry>(),
+		);
+
+		return { controller, agentsService, agentExecutionService };
+	}
+
+	it('falls back to execution transcript when memory history is empty', async () => {
+		const { controller, agentsService, agentExecutionService } = makeController();
+		const thread = {
+			id: 'thread-1',
+			projectId: 'project-1',
+			agentId: 'agent-1',
+		};
+		agentsService.findById.mockResolvedValue({ id: 'agent-1' } as never);
+		agentsService.getChatMessages.mockResolvedValue([]);
+		agentExecutionService.findThreadById.mockResolvedValue(thread as never);
+		agentExecutionService.getThreadDetail.mockResolvedValue({
+			thread,
+			executions: [
+				{
+					id: 'execution-1',
+					userMessage: 'Hello',
+					assistantResponse: 'Hi there',
+					error: null,
+				},
+			],
+		} as never);
+
+		const messages = await controller.getChatMessages({
+			params: { projectId: 'project-1', agentId: 'agent-1', threadId: 'thread-1' },
+		} as never);
+
+		expect(messages).toEqual([
+			{
+				id: 'execution-1:user',
+				role: 'user',
+				content: [{ type: 'text', text: 'Hello' }],
+			},
+			{
+				id: 'execution-1:assistant',
+				role: 'assistant',
+				content: [{ type: 'text', text: 'Hi there' }],
+			},
+		]);
+		expect(agentExecutionService.getThreadDetail).toHaveBeenCalledWith(
+			'thread-1',
+			'project-1',
+			'agent-1',
+		);
+	});
+
+	it('uses memory history when available', async () => {
+		const { controller, agentsService, agentExecutionService } = makeController();
+		agentsService.findById.mockResolvedValue({ id: 'agent-1' } as never);
+		agentsService.getChatMessages.mockResolvedValue([
+			{
+				id: 'message-1',
+				role: 'user',
+				content: [{ type: 'text', text: 'From memory' }],
+			},
+		] as never);
+		agentExecutionService.findThreadById.mockResolvedValue({
+			id: 'thread-1',
+			projectId: 'project-1',
+			agentId: 'agent-1',
+		} as never);
+
+		const messages = await controller.getChatMessages({
+			params: { projectId: 'project-1', agentId: 'agent-1', threadId: 'thread-1' },
+		} as never);
+
+		expect(messages).toEqual([
+			{
+				id: 'message-1',
+				role: 'user',
+				content: [{ type: 'text', text: 'From memory' }],
+			},
+		]);
+		expect(agentExecutionService.getThreadDetail).not.toHaveBeenCalled();
+	});
+});

--- a/packages/cli/src/modules/agents/__tests__/agents.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.controller.test.ts
@@ -114,7 +114,6 @@ describe('AgentsController integration credentials', () => {
 describe('AgentsController chat message history', () => {
 	function makeController() {
 		const agentsService = mock<AgentsService>();
-		const agentExecutionService = mock<AgentExecutionService>();
 		const controller = new AgentsController(
 			agentsService,
 			mock<AgentsBuilderService>(),
@@ -122,34 +121,28 @@ describe('AgentsController chat message history', () => {
 			mock<ChatIntegrationService>(),
 			mock<AgentScheduleService>(),
 			mock<AgentRepository>(),
-			agentExecutionService,
+			mock<AgentExecutionService>(),
 			mock<ChatIntegrationRegistry>(),
 		);
 
-		return { controller, agentsService, agentExecutionService };
+		return { controller, agentsService };
 	}
 
-	it('falls back to execution transcript when memory history is empty', async () => {
-		const { controller, agentsService, agentExecutionService } = makeController();
-		const thread = {
-			id: 'thread-1',
-			projectId: 'project-1',
-			agentId: 'agent-1',
-		};
+	it('returns conversation history from the agents service', async () => {
+		const { controller, agentsService } = makeController();
 		agentsService.findById.mockResolvedValue({ id: 'agent-1' } as never);
-		agentsService.getChatMessages.mockResolvedValue([]);
-		agentExecutionService.findThreadById.mockResolvedValue(thread as never);
-		agentExecutionService.getThreadDetail.mockResolvedValue({
-			thread,
-			executions: [
-				{
-					id: 'execution-1',
-					userMessage: 'Hello',
-					assistantResponse: 'Hi there',
-					error: null,
-				},
-			],
-		} as never);
+		agentsService.getConversationHistory.mockResolvedValue([
+			{
+				id: 'execution-1:user',
+				role: 'user',
+				content: [{ type: 'text', text: 'Hello' }],
+			},
+			{
+				id: 'execution-1:assistant',
+				role: 'assistant',
+				content: [{ type: 'text', text: 'Hi there' }],
+			},
+		]);
 
 		const messages = await controller.getChatMessages({
 			params: { projectId: 'project-1', agentId: 'agent-1', threadId: 'thread-1' },
@@ -167,40 +160,22 @@ describe('AgentsController chat message history', () => {
 				content: [{ type: 'text', text: 'Hi there' }],
 			},
 		]);
-		expect(agentExecutionService.getThreadDetail).toHaveBeenCalledWith(
-			'thread-1',
-			'project-1',
-			'agent-1',
-		);
-	});
-
-	it('uses memory history when available', async () => {
-		const { controller, agentsService, agentExecutionService } = makeController();
-		agentsService.findById.mockResolvedValue({ id: 'agent-1' } as never);
-		agentsService.getChatMessages.mockResolvedValue([
-			{
-				id: 'message-1',
-				role: 'user',
-				content: [{ type: 'text', text: 'From memory' }],
-			},
-		] as never);
-		agentExecutionService.findThreadById.mockResolvedValue({
-			id: 'thread-1',
+		expect(agentsService.getConversationHistory).toHaveBeenCalledWith({
+			threadId: 'thread-1',
 			projectId: 'project-1',
 			agentId: 'agent-1',
-		} as never);
+		});
+	});
 
-		const messages = await controller.getChatMessages({
-			params: { projectId: 'project-1', agentId: 'agent-1', threadId: 'thread-1' },
-		} as never);
+	it('rejects missing conversation history', async () => {
+		const { controller, agentsService } = makeController();
+		agentsService.findById.mockResolvedValue({ id: 'agent-1' } as never);
+		agentsService.getConversationHistory.mockResolvedValue(null);
 
-		expect(messages).toEqual([
-			{
-				id: 'message-1',
-				role: 'user',
-				content: [{ type: 'text', text: 'From memory' }],
-			},
-		]);
-		expect(agentExecutionService.getThreadDetail).not.toHaveBeenCalled();
+		await expect(
+			controller.getChatMessages({
+				params: { projectId: 'project-1', agentId: 'agent-1', threadId: 'thread-1' },
+			} as never),
+		).rejects.toThrow(NotFoundError);
 	});
 });

--- a/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
@@ -939,6 +939,59 @@ describe('AgentsService', () => {
 		});
 	});
 
+	describe('getConversationHistory', () => {
+		it('returns the user-visible transcript from execution history', async () => {
+			agentExecutionService.getThreadDetail.mockResolvedValue({
+				thread: { id: 'thread-1' },
+				executions: [
+					{
+						id: 'execution-1',
+						userMessage: 'Hello',
+						assistantResponse: 'Hi there',
+						error: null,
+					},
+				],
+			} as never);
+
+			const result = await service.getConversationHistory({
+				threadId: 'thread-1',
+				projectId,
+				agentId,
+			});
+
+			expect(agentExecutionService.getThreadDetail).toHaveBeenCalledWith(
+				'thread-1',
+				projectId,
+				agentId,
+			);
+			expect(n8nMemory.getMessages).not.toHaveBeenCalled();
+			expect(result).toEqual([
+				{
+					id: 'execution-1:user',
+					role: 'user',
+					content: [{ type: 'text', text: 'Hello' }],
+				},
+				{
+					id: 'execution-1:assistant',
+					role: 'assistant',
+					content: [{ type: 'text', text: 'Hi there' }],
+				},
+			]);
+		});
+
+		it('returns null when the requested thread is not in the agent project', async () => {
+			agentExecutionService.getThreadDetail.mockResolvedValue(null);
+
+			const result = await service.getConversationHistory({
+				threadId: 'thread-1',
+				projectId,
+				agentId,
+			});
+
+			expect(result).toBeNull();
+		});
+	});
+
 	describe('getTestChatMessages', () => {
 		it('derives user-scoped fallback test-chat thread ids', () => {
 			expect(chatThreadId(agentId, 'user-1')).toBe('test-agent-1:user-1');

--- a/packages/cli/src/modules/agents/__tests__/execution-to-message-mapper.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/execution-to-message-mapper.test.ts
@@ -1,0 +1,178 @@
+import type { AgentExecution } from '../entities/agent-execution.entity';
+import {
+	executionToMessagesDto,
+	executionsToMessagesDto,
+} from '../utils/execution-to-message-mapper';
+
+function execution(overrides: Partial<AgentExecution> = {}): AgentExecution {
+	return {
+		id: 'execution-1',
+		userMessage: 'Hello',
+		assistantResponse: '',
+		toolCalls: null,
+		timeline: null,
+		error: null,
+		...overrides,
+	} as unknown as AgentExecution;
+}
+
+describe('execution-to-message-mapper', () => {
+	it('maps execution timeline text and tool calls into assistant message content', () => {
+		const result = executionToMessagesDto(
+			execution({
+				assistantResponse: 'Let me check.Done.',
+				timeline: [
+					{ type: 'text', content: 'Let me check.', timestamp: 100, endTime: 110 },
+					{
+						type: 'tool-call',
+						kind: 'workflow',
+						name: 'search_tool',
+						toolCallId: 'call-1',
+						input: { query: 'n8n' },
+						output: { items: [1] },
+						startTime: 111,
+						endTime: 120,
+						success: true,
+						workflowId: 'workflow-1',
+						workflowName: 'Search workflow',
+					},
+					{ type: 'text', content: 'Done.', timestamp: 121, endTime: 130 },
+				],
+			}),
+		);
+
+		expect(result).toEqual([
+			{
+				id: 'execution-1:user',
+				role: 'user',
+				content: [{ type: 'text', text: 'Hello' }],
+			},
+			{
+				id: 'execution-1:assistant',
+				role: 'assistant',
+				content: [
+					{ type: 'text', text: 'Let me check.' },
+					{
+						type: 'tool-call',
+						toolName: 'search_tool',
+						toolCallId: 'call-1',
+						input: { query: 'n8n' },
+						state: 'resolved',
+						output: { items: [1] },
+					},
+					{ type: 'text', text: 'Done.' },
+				],
+			},
+		]);
+	});
+
+	it('maps failed timeline tool calls as rejected content parts', () => {
+		const result = executionToMessagesDto(
+			execution({
+				timeline: [
+					{
+						type: 'tool-call',
+						kind: 'tool',
+						name: 'failing_tool',
+						toolCallId: 'call-1',
+						input: { id: '123' },
+						output: { message: 'Tool failed' },
+						startTime: 100,
+						endTime: 120,
+						success: false,
+					},
+				],
+			}),
+		);
+
+		expect(result).toEqual([
+			{
+				id: 'execution-1:user',
+				role: 'user',
+				content: [{ type: 'text', text: 'Hello' }],
+			},
+			{
+				id: 'execution-1:assistant',
+				role: 'assistant',
+				content: [
+					{
+						type: 'tool-call',
+						toolName: 'failing_tool',
+						toolCallId: 'call-1',
+						input: { id: '123' },
+						state: 'rejected',
+						error: 'Tool failed',
+					},
+				],
+			},
+		]);
+	});
+
+	it('falls back to recorded tool calls when execution timeline is unavailable', () => {
+		const result = executionToMessagesDto(
+			execution({
+				assistantResponse: 'Legacy done.',
+				toolCalls: [{ name: 'legacy_tool', input: { id: '123' }, output: 'ok' }],
+			}),
+		);
+
+		expect(result).toEqual([
+			{
+				id: 'execution-1:user',
+				role: 'user',
+				content: [{ type: 'text', text: 'Hello' }],
+			},
+			{
+				id: 'execution-1:assistant',
+				role: 'assistant',
+				content: [
+					{
+						type: 'tool-call',
+						toolName: 'legacy_tool',
+						toolCallId: 'execution-1:tool:0',
+						input: { id: '123' },
+						state: 'resolved',
+						output: 'ok',
+					},
+					{ type: 'text', text: 'Legacy done.' },
+				],
+			},
+		]);
+	});
+
+	it('does not expose raw working-memory timeline events as chat message content', () => {
+		const result = executionToMessagesDto(
+			execution({
+				assistantResponse: 'Done.',
+				timeline: [{ type: 'working-memory', content: 'private memory', timestamp: 100 }],
+			}),
+		);
+
+		expect(result).toEqual([
+			{
+				id: 'execution-1:user',
+				role: 'user',
+				content: [{ type: 'text', text: 'Hello' }],
+			},
+			{
+				id: 'execution-1:assistant',
+				role: 'assistant',
+				content: [{ type: 'text', text: 'Done.' }],
+			},
+		]);
+	});
+
+	it('flattens multiple executions into a single message list', () => {
+		const result = executionsToMessagesDto([
+			execution({ id: 'execution-1', userMessage: 'Hello', assistantResponse: 'Hi' }),
+			execution({ id: 'execution-2', userMessage: 'Again', assistantResponse: 'There' }),
+		]);
+
+		expect(result.map((message) => message.id)).toEqual([
+			'execution-1:user',
+			'execution-1:assistant',
+			'execution-2:user',
+			'execution-2:assistant',
+		]);
+	});
+});

--- a/packages/cli/src/modules/agents/__tests__/execution-to-message-mapper.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/execution-to-message-mapper.test.ts
@@ -131,10 +131,44 @@ describe('execution-to-message-mapper', () => {
 						toolName: 'legacy_tool',
 						toolCallId: 'execution-1:tool:0',
 						input: { id: '123' },
-						state: 'resolved',
 						output: 'ok',
 					},
 					{ type: 'text', text: 'Legacy done.' },
+				],
+			},
+		]);
+	});
+
+	it('does not infer resolved state from legacy recorded tool call output', () => {
+		const result = executionToMessagesDto(
+			execution({
+				toolCalls: [
+					{
+						name: 'legacy_tool',
+						input: { id: '123' },
+						output: { message: 'Tool failed before timeline recording was available' },
+					},
+				],
+			}),
+		);
+
+		expect(result).toEqual([
+			{
+				id: 'execution-1:user',
+				role: 'user',
+				content: [{ type: 'text', text: 'Hello' }],
+			},
+			{
+				id: 'execution-1:assistant',
+				role: 'assistant',
+				content: [
+					{
+						type: 'tool-call',
+						toolName: 'legacy_tool',
+						toolCallId: 'execution-1:tool:0',
+						input: { id: '123' },
+						output: { message: 'Tool failed before timeline recording was available' },
+					},
 				],
 			},
 		]);

--- a/packages/cli/src/modules/agents/agent-message-mapper.ts
+++ b/packages/cli/src/modules/agents/agent-message-mapper.ts
@@ -1,6 +1,8 @@
 import type { AgentDbMessage, MessageContent } from '@n8n/agents';
 import type { AgentPersistedMessageContentPart, AgentPersistedMessageDto } from '@n8n/api-types';
 
+import type { AgentExecution } from './entities/agent-execution.entity';
+
 export function contentPartToDto(part: MessageContent): AgentPersistedMessageContentPart {
 	const dto: AgentPersistedMessageContentPart = { type: part.type };
 	if ('text' in part && typeof part.text === 'string') dto.text = part.text;
@@ -31,4 +33,37 @@ export function messagesToDto(msgs: AgentDbMessage[]): AgentPersistedMessageDto[
 		if (dto) out.push(dto);
 	}
 	return out;
+}
+
+function textMessageDto(
+	id: string,
+	role: AgentPersistedMessageDto['role'],
+	text: string,
+): AgentPersistedMessageDto | null {
+	if (!text.trim()) return null;
+	return {
+		id,
+		role,
+		content: [{ type: 'text', text }],
+	};
+}
+
+export function executionsToMessagesDto(executions: AgentExecution[]): AgentPersistedMessageDto[] {
+	const messages: AgentPersistedMessageDto[] = [];
+
+	for (const execution of executions) {
+		const userMessage = textMessageDto(`${execution.id}:user`, 'user', execution.userMessage);
+		if (userMessage) messages.push(userMessage);
+
+		const assistantText =
+			execution.assistantResponse || (execution.error ? `Error: ${execution.error}` : '');
+		const assistantMessage = textMessageDto(
+			`${execution.id}:assistant`,
+			'assistant',
+			assistantText,
+		);
+		if (assistantMessage) messages.push(assistantMessage);
+	}
+
+	return messages;
 }

--- a/packages/cli/src/modules/agents/agent-message-mapper.ts
+++ b/packages/cli/src/modules/agents/agent-message-mapper.ts
@@ -1,8 +1,6 @@
 import type { AgentDbMessage, MessageContent } from '@n8n/agents';
 import type { AgentPersistedMessageContentPart, AgentPersistedMessageDto } from '@n8n/api-types';
 
-import type { AgentExecution } from './entities/agent-execution.entity';
-
 export function contentPartToDto(part: MessageContent): AgentPersistedMessageContentPart {
 	const dto: AgentPersistedMessageContentPart = { type: part.type };
 	if ('text' in part && typeof part.text === 'string') dto.text = part.text;
@@ -33,37 +31,4 @@ export function messagesToDto(msgs: AgentDbMessage[]): AgentPersistedMessageDto[
 		if (dto) out.push(dto);
 	}
 	return out;
-}
-
-function textMessageDto(
-	id: string,
-	role: AgentPersistedMessageDto['role'],
-	text: string,
-): AgentPersistedMessageDto | null {
-	if (!text.trim()) return null;
-	return {
-		id,
-		role,
-		content: [{ type: 'text', text }],
-	};
-}
-
-export function executionsToMessagesDto(executions: AgentExecution[]): AgentPersistedMessageDto[] {
-	const messages: AgentPersistedMessageDto[] = [];
-
-	for (const execution of executions) {
-		const userMessage = textMessageDto(`${execution.id}:user`, 'user', execution.userMessage);
-		if (userMessage) messages.push(userMessage);
-
-		const assistantText =
-			execution.assistantResponse || (execution.error ? `Error: ${execution.error}` : '');
-		const assistantMessage = textMessageDto(
-			`${execution.id}:assistant`,
-			'assistant',
-			assistantText,
-		);
-		if (assistantMessage) messages.push(assistantMessage);
-	}
-
-	return messages;
 }

--- a/packages/cli/src/modules/agents/agents.controller.ts
+++ b/packages/cli/src/modules/agents/agents.controller.ts
@@ -39,7 +39,7 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
 import { AgentsCredentialProvider } from './adapters/agents-credential-provider';
 import { AgentExecutionService, threadBelongsTo } from './agent-execution.service';
-import { messagesToDto } from './agent-message-mapper';
+import { executionsToMessagesDto, messagesToDto } from './agent-message-mapper';
 import {
 	type FlushableResponse,
 	initSseStream,
@@ -464,7 +464,12 @@ export class AgentsController {
 		if (!thread || !threadBelongsTo(thread, projectId, agentId)) {
 			throw new NotFoundError(`Thread "${threadId}" not found`);
 		}
-		return await this.agentsService.getChatMessages(threadId);
+		const memoryMessages = messagesToDto(await this.agentsService.getChatMessages(threadId));
+		if (memoryMessages.length > 0) return memoryMessages;
+
+		const detail = await this.agentExecutionService.getThreadDetail(threadId, projectId, agentId);
+		if (!detail) throw new NotFoundError(`Thread "${threadId}" not found`);
+		return executionsToMessagesDto(detail.executions);
 	}
 
 	@Get('/:agentId/build/messages')

--- a/packages/cli/src/modules/agents/agents.controller.ts
+++ b/packages/cli/src/modules/agents/agents.controller.ts
@@ -460,6 +460,9 @@ export class AgentsController {
 		const { projectId, agentId, threadId } = req.params;
 		const agent = await this.agentsService.findById(agentId, projectId);
 		if (!agent) throw new NotFoundError(`Agent "${agentId}" not found`);
+		// getConversationHistory delegates to getThreadDetail, which validates
+		// thread ownership against both projectId and agentId before returning
+		// execution transcript data.
 		const history = await this.agentsService.getConversationHistory({
 			threadId,
 			projectId,

--- a/packages/cli/src/modules/agents/agents.controller.ts
+++ b/packages/cli/src/modules/agents/agents.controller.ts
@@ -39,7 +39,7 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
 import { AgentsCredentialProvider } from './adapters/agents-credential-provider';
 import { AgentExecutionService, threadBelongsTo } from './agent-execution.service';
-import { executionsToMessagesDto, messagesToDto } from './agent-message-mapper';
+import { messagesToDto } from './agent-message-mapper';
 import {
 	type FlushableResponse,
 	initSseStream,
@@ -460,16 +460,15 @@ export class AgentsController {
 		const { projectId, agentId, threadId } = req.params;
 		const agent = await this.agentsService.findById(agentId, projectId);
 		if (!agent) throw new NotFoundError(`Agent "${agentId}" not found`);
-		const thread = await this.agentExecutionService.findThreadById(threadId);
-		if (!thread || !threadBelongsTo(thread, projectId, agentId)) {
+		const history = await this.agentsService.getConversationHistory({
+			threadId,
+			projectId,
+			agentId,
+		});
+		if (!history) {
 			throw new NotFoundError(`Thread "${threadId}" not found`);
 		}
-		const memoryMessages = messagesToDto(await this.agentsService.getChatMessages(threadId));
-		if (memoryMessages.length > 0) return memoryMessages;
-
-		const detail = await this.agentExecutionService.getThreadDetail(threadId, projectId, agentId);
-		if (!detail) throw new NotFoundError(`Thread "${threadId}" not found`);
-		return executionsToMessagesDto(detail.executions);
+		return history;
 	}
 
 	@Get('/:agentId/build/messages')

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -55,9 +55,9 @@ import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 import { AgentsCredentialProvider } from './adapters/agents-credential-provider';
 import { markAgentDraftDirty } from './utils/agent-draft.utils';
+import { executionsToMessagesDto } from './utils/execution-to-message-mapper';
 import { generateAgentResourceId } from './utils/agent-resource-id';
 import { AgentExecutionService } from './agent-execution.service';
-import { executionsToMessagesDto } from './agent-message-mapper';
 import { AgentSkillsService } from './agent-skills.service';
 import { AgentsToolsService } from './agents-tools.service';
 import { AGENT_THREAD_PREFIX } from './builder/builder-tool-names';

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -8,6 +8,7 @@ import type {
 import {
 	AGENT_SCHEDULE_TRIGGER_TYPE,
 	AGENT_WORKFLOW_TRIGGER_TYPE,
+	type AgentPersistedMessageDto,
 	isAgentCredentialIntegration,
 	isAgentScheduleIntegration,
 	type AgentSkill,
@@ -56,6 +57,7 @@ import { AgentsCredentialProvider } from './adapters/agents-credential-provider'
 import { markAgentDraftDirty } from './utils/agent-draft.utils';
 import { generateAgentResourceId } from './utils/agent-resource-id';
 import { AgentExecutionService } from './agent-execution.service';
+import { executionsToMessagesDto } from './agent-message-mapper';
 import { AgentSkillsService } from './agent-skills.service';
 import { AgentsToolsService } from './agents-tools.service';
 import { AGENT_THREAD_PREFIX } from './builder/builder-tool-names';
@@ -582,9 +584,22 @@ export class AgentsService {
 		return true;
 	}
 
-	/** Return persisted chat messages for a given session/thread. */
-	async getChatMessages(threadId: string) {
-		return await this.n8nMemory.getMessages(threadId);
+	/**
+	 * Return user-visible conversation history for a persisted chat thread.
+	 *
+	 * Execution records are the source of truth for the UI transcript. SDK
+	 * memory is runtime context for the agent: it can be disabled, windowed, or
+	 * shaped for model input rather than for user-facing history.
+	 */
+	async getConversationHistory(params: {
+		threadId: string;
+		projectId: string;
+		agentId: string;
+	}): Promise<AgentPersistedMessageDto[] | null> {
+		const { threadId, projectId, agentId } = params;
+		const detail = await this.agentExecutionService.getThreadDetail(threadId, projectId, agentId);
+		if (!detail) return null;
+		return executionsToMessagesDto(detail.executions);
 	}
 
 	private getMemoryFactory(): MemoryFactory {

--- a/packages/cli/src/modules/agents/utils/execution-to-message-mapper.ts
+++ b/packages/cli/src/modules/agents/utils/execution-to-message-mapper.ts
@@ -1,0 +1,166 @@
+import type { AgentPersistedMessageContentPart, AgentPersistedMessageDto } from '@n8n/api-types';
+
+import type { AgentExecution } from '../entities/agent-execution.entity';
+import type { RecordedToolCall, TimelineEvent } from '../execution-recorder';
+
+type ExecutionTranscript = Pick<
+	AgentExecution,
+	'id' | 'userMessage' | 'assistantResponse' | 'toolCalls' | 'timeline' | 'error'
+>;
+
+type ToolCallTimelineEvent = Extract<TimelineEvent, { type: 'tool-call' }>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
+function textPart(text: string): AgentPersistedMessageContentPart | null {
+	if (!text.trim()) return null;
+	return { type: 'text', text };
+}
+
+function textMessageDto(
+	id: string,
+	role: AgentPersistedMessageDto['role'],
+	text: string,
+): AgentPersistedMessageDto | null {
+	const contentPart = textPart(text);
+	if (!contentPart) return null;
+
+	return {
+		id,
+		role,
+		content: [contentPart],
+	};
+}
+
+function toolCallState(event: ToolCallTimelineEvent): 'resolved' | 'rejected' | undefined {
+	if (typeof event.endTime !== 'number' || event.endTime <= 0) return undefined;
+	return event.success ? 'resolved' : 'rejected';
+}
+
+function toolErrorMessage(output: unknown): string | undefined {
+	if (typeof output === 'string' && output.trim()) return output;
+
+	if (isRecord(output)) {
+		const message = output.message;
+		if (typeof message === 'string' && message.trim()) return message;
+
+		const error = output.error;
+		if (typeof error === 'string' && error.trim()) return error;
+	}
+
+	if (output === undefined || output === null) return undefined;
+
+	try {
+		return JSON.stringify(output);
+	} catch {
+		return String(output);
+	}
+}
+
+function timelineToolCallToPart(event: ToolCallTimelineEvent): AgentPersistedMessageContentPart {
+	const state = toolCallState(event);
+	const base: AgentPersistedMessageContentPart = {
+		type: 'tool-call',
+		toolName: event.name,
+		toolCallId: event.toolCallId,
+		input: event.input,
+	};
+
+	if (state === undefined) return base;
+	if (state === 'resolved') {
+		return {
+			...base,
+			state,
+			output: event.output,
+		};
+	}
+
+	return {
+		...base,
+		state,
+		error: toolErrorMessage(event.output) ?? `Tool "${event.name}" failed`,
+	};
+}
+
+function recordedToolCallToPart(
+	executionId: string,
+	index: number,
+	toolCall: RecordedToolCall,
+): AgentPersistedMessageContentPart {
+	const base: AgentPersistedMessageContentPart = {
+		type: 'tool-call',
+		toolName: toolCall.name,
+		toolCallId: `${executionId}:tool:${index}`,
+		input: toolCall.input,
+	};
+
+	if (toolCall.output === undefined) return base;
+
+	return {
+		...base,
+		state: 'resolved',
+		output: toolCall.output,
+	};
+}
+
+function assistantContentFromExecution(
+	execution: ExecutionTranscript,
+): AgentPersistedMessageContentPart[] {
+	const content: AgentPersistedMessageContentPart[] = [];
+	let hasTimelineText = false;
+	let hasTimelineToolCalls = false;
+
+	for (const event of execution.timeline ?? []) {
+		if (event.type === 'text') {
+			const part = textPart(event.content);
+			if (!part) continue;
+
+			hasTimelineText = true;
+			content.push(part);
+		} else if (event.type === 'tool-call') {
+			hasTimelineToolCalls = true;
+			content.push(timelineToolCallToPart(event));
+		}
+	}
+
+	if (!hasTimelineToolCalls) {
+		for (const [index, toolCall] of (execution.toolCalls ?? []).entries()) {
+			content.push(recordedToolCallToPart(execution.id, index, toolCall));
+		}
+	}
+
+	if (!hasTimelineText) {
+		const fallbackText =
+			execution.assistantResponse || (execution.error ? `Error: ${execution.error}` : '');
+		const part = textPart(fallbackText);
+		if (part) content.push(part);
+	}
+
+	return content;
+}
+
+export function executionToMessagesDto(execution: ExecutionTranscript): AgentPersistedMessageDto[] {
+	const messages: AgentPersistedMessageDto[] = [];
+
+	const userMessage = textMessageDto(`${execution.id}:user`, 'user', execution.userMessage);
+	if (userMessage) messages.push(userMessage);
+
+	const assistantContent = assistantContentFromExecution(execution);
+	if (assistantContent.length > 0) {
+		messages.push({
+			id: `${execution.id}:assistant`,
+			role: 'assistant',
+			content: assistantContent,
+		});
+	}
+
+	return messages;
+}
+
+export function executionsToMessagesDto(
+	executions: ExecutionTranscript[],
+): AgentPersistedMessageDto[] {
+	return executions.flatMap(executionToMessagesDto);
+}

--- a/packages/cli/src/modules/agents/utils/execution-to-message-mapper.ts
+++ b/packages/cli/src/modules/agents/utils/execution-to-message-mapper.ts
@@ -100,7 +100,6 @@ function recordedToolCallToPart(
 
 	return {
 		...base,
-		state: 'resolved',
 		output: toolCall.output,
 	};
 }


### PR DESCRIPTION
## Summary

Fixes test chat session reloads for agents.

Previously, the session picker listed sessions from `agent_execution`, but opening a selected session loaded messages only from SDK memory. For agents without n8n memory configured, the session existed but the memory transcript was empty, so the chat panel showed no messages.

This PR:
- Uses execution transcript consistently in the UI for chat.
- Converts execution records into the same persisted message DTO shape used by the chat UI.
- Makes a clear separation between memory and chat history, chat history is for the UI and the user, memory is for the agent.

Sessions loaded:
<img width="1231" height="812" alt="image" src="https://github.com/user-attachments/assets/3090bfa8-c7c3-4421-96aa-d779a1f07006" />

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
