### PR TITLE
fix(editor): Remove 'no more sessions' from sessions list in Agents

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -1303,7 +1303,6 @@
 	"agentSessions.actions": "Actions",
 	"agentSessions.empty": "No agent sessions",
 	"agentSessions.loadMore": "Load more",
-	"agentSessions.loadedAll": "No more sessions to fetch",
 	"agentSessions.deleteConfirm.headline": "Delete Session?",
 	"agentSessions.deleteConfirm.message": "This will delete the session and all its executions. This cannot be undone.",
 	"agentSessions.deleteConfirm.confirmButtonText": "Yes, delete",

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentSessionsListView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentSessionsListView.vue
@@ -155,26 +155,29 @@ async function loadMore() {
 							</td>
 						</tr>
 					</template>
-					<tr>
-						<td colspan="6" style="text-align: center">
+					<tr
+						v-if="!sessionsStore.loading && !sessionsStore.threads.length"
+						:class="$style.lastRow"
+					>
+						<td :colspan="6" style="text-align: center; padding: var(--spacing--lg)">
 							<template v-if="!sessionsStore.threads.length && !sessionsStore.loading">
 								<span data-test-id="agent-sessions-empty">
 									{{ i18n.baseText('agentSessions.empty') }}
 								</span>
 							</template>
-							<template v-else-if="sessionsStore.nextCursor">
-								<N8nButton
-									icon="refresh-cw"
-									:title="i18n.baseText('agentSessions.loadMore')"
-									:label="i18n.baseText('agentSessions.loadMore')"
-									:loading="sessionsStore.loading"
-									data-test-id="agent-sessions-load-more"
-									@click="loadMore()"
-								/>
-							</template>
-							<template v-else-if="sessionsStore.threads.length">
-								{{ i18n.baseText('agentSessions.loadedAll') }}
-							</template>
+						</td>
+					</tr>
+					<tr :class="$style.lastRow" v-if="sessionsStore.nextCursor">
+						<td colspan="6">
+							<N8nButton
+								icon="refresh-cw"
+								variant="ghost"
+								:title="i18n.baseText('agentSessions.loadMore')"
+								:label="i18n.baseText('agentSessions.loadMore')"
+								:loading="sessionsStore.loading"
+								data-test-id="agent-sessions-load-more"
+								@click="loadMore()"
+							/>
 						</td>
 					</tr>
 				</tbody>
@@ -208,6 +211,20 @@ async function loadMore() {
 
 	&:hover {
 		background-color: var(--background--hover);
+	}
+}
+
+.lastRow {
+	td {
+		text-align: center;
+	}
+
+	td button {
+		margin: 0 auto;
+	}
+
+	&:hover {
+		background-color: var(--background--surface) !important;
 	}
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/global/AgentSessionsList.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/global/AgentSessionsList.vue
@@ -189,9 +189,6 @@ async function loadMore() {
 									@click="loadMore()"
 								/>
 							</template>
-							<template v-else-if="sessionsStore.threads.length">
-								{{ i18n.baseText('agentSessions.loadedAll') }}
-							</template>
 						</td>
 					</tr>
 				</tbody>


### PR DESCRIPTION
## Summary

This removes the “No more sessions to fetch” message from the Agent sessions list once all sessions have been loaded.

Changes made:
- Only render the empty-state row when there are no sessions and the list is not loading.
- Keep the “Load more” action visible only while another page is available.
- Change the “Load more” action to a ghost button and center it in the final table row.
- Remove the now-unused `agentSessions.loadedAll` i18n string.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created. Not needed, UI copy/behavior cleanup only.
- [ ] Tests included. Not included, visual/UI behavior cleanup covered by existing component behavior.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
