### PR TITLE
fix: Stabilize migration-timestamp rule message for baseline hashing (no-changelog)

### DIFF
--- a/.code-health-baseline.json
+++ b/.code-health-baseline.json
@@ -557,24 +557,24 @@
 			{
 				"rule": "migration-timestamp",
 				"line": 1,
-				"message": "1783000000000-CreateAgentTables.ts is prefixed with a future timestamp (1783000000000, ~50d ahead of now). Migration prefixes must be the exact Date.now() value at the time of creation — AI agents commonly fabricate future timestamps.",
-				"hash": "d81428d567aa"
+				"message": "1783000000000-CreateAgentTables.ts is prefixed with a future timestamp (1783000000000). Migration prefixes must be the exact Date.now() value at the time of creation — AI agents commonly fabricate future timestamps.",
+				"hash": "6599e9e66680"
 			}
 		],
 		"packages/@n8n/db/src/migrations/common/1783000000001-CreateAgentExecutionTables.ts": [
 			{
 				"rule": "migration-timestamp",
 				"line": 1,
-				"message": "1783000000001-CreateAgentExecutionTables.ts is prefixed with a future timestamp (1783000000001, ~50d ahead of now). Migration prefixes must be the exact Date.now() value at the time of creation — AI agents commonly fabricate future timestamps.",
-				"hash": "e33a8a794126"
+				"message": "1783000000001-CreateAgentExecutionTables.ts is prefixed with a future timestamp (1783000000001). Migration prefixes must be the exact Date.now() value at the time of creation — AI agents commonly fabricate future timestamps.",
+				"hash": "e55008535c0e"
 			}
 		],
 		"packages/@n8n/db/src/migrations/common/1784000000000-CreateAgentObservationTables.ts": [
 			{
 				"rule": "migration-timestamp",
 				"line": 1,
-				"message": "1784000000000-CreateAgentObservationTables.ts is prefixed with a future timestamp (1784000000000, ~61d ahead of now). Migration prefixes must be the exact Date.now() value at the time of creation — AI agents commonly fabricate future timestamps.",
-				"hash": "4bae5ef065ad"
+				"message": "1784000000000-CreateAgentObservationTables.ts is prefixed with a future timestamp (1784000000000). Migration prefixes must be the exact Date.now() value at the time of creation — AI agents commonly fabricate future timestamps.",
+				"hash": "5f4857aa8248"
 			}
 		]
 	}

--- a/packages/testing/code-health/src/rules/migration-timestamp.rule.ts
+++ b/packages/testing/code-health/src/rules/migration-timestamp.rule.ts
@@ -46,7 +46,7 @@ export class MigrationTimestampRule extends BaseRule<CodeHealthContext> {
 					filePath,
 					1,
 					1,
-					`${fileName} is prefixed with a future timestamp (${timestamp}, ${formatDelta(timestamp - now)} ahead of now). Migration prefixes must be the exact Date.now() value at the time of creation — AI agents commonly fabricate future timestamps.`,
+					`${fileName} is prefixed with a future timestamp (${timestamp}). Migration prefixes must be the exact Date.now() value at the time of creation — AI agents commonly fabricate future timestamps.`,
 					"Rename the file using the current millisecond timestamp from Date.now() (or 'date +%s%3N').",
 				),
 			);
@@ -54,14 +54,4 @@ export class MigrationTimestampRule extends BaseRule<CodeHealthContext> {
 
 		return violations;
 	}
-}
-
-function formatDelta(ms: number): string {
-	const abs = Math.abs(ms);
-	const days = Math.floor(abs / 86_400_000);
-	if (days >= 1) return `~${days}d`;
-	const hours = Math.floor(abs / 3_600_000);
-	if (hours >= 1) return `~${hours}h`;
-	const minutes = Math.floor(abs / 60_000);
-	return `~${minutes}m`;
 }


### PR DESCRIPTION
## Summary

The `migration-timestamp` code-health rule baked a live `~Nd ahead of now` delta into its violation message. Because `@n8n/rules-engine` derives the baseline match hash from `path + rule + message` (see `packages/testing/rules-engine/src/baseline.ts:23-27`), the hash drifted by one day every 24h. Result: the three baselined violations in `.code-health-baseline.json` silently stopped being recognised, and every PR went red on `migration-timestamp` until the calendar lined back up.

Fix:
- Drop the live `formatDelta(...) ahead of now` segment from the message in `packages/testing/code-health/src/rules/migration-timestamp.rule.ts` (and remove the now-unused helper).
- Refresh the three `migration-timestamp` entries in `.code-health-baseline.json` with the new stable hashes (`6599e9e66680`, `e55008535c0e`, `5f4857aa8248`).

Follow-up: the three fabricated-future-timestamp migration files on master (1783000000000, 1783000000001, 1784000000000) still need to be renamed to real `Date.now()` values. The baseline was papering over real violations — this PR only makes the receipt stop bleeding.

Verified:
- `pnpm test migration-timestamp` → 5/5 pass
- `pnpm typecheck` clean
- CLI run with baseline → 0 violations; with `--ignore-baseline` → 3 expected violations with stable messages.

## Related Linear tickets, Github issues, and Community forum posts

N/A — internal CI hygiene fix.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)