### PR TITLE
fix: Correct misleading credential notice in Bearer Auth

### DIFF
--- a/packages/nodes-base/credentials/HttpBearerAuth.credentials.ts
+++ b/packages/nodes-base/credentials/HttpBearerAuth.credentials.ts
@@ -26,7 +26,7 @@ export class HttpBearerAuth implements ICredentialType {
 		},
 		{
 			displayName:
-				'This credential uses the "Authorization" header. To use a custom header, use a "Custom Auth" credential instead',
+				'This credential uses the "Authorization" header. To use a custom header, use a "Header Auth" credential instead',
 			name: 'useCustomAuth',
 			type: 'notice',
 			default: '',


### PR DESCRIPTION
## Summary

The Bearer Auth credential notice tells users to use "Custom Auth" for custom headers, but that credential type isn't available in all node contexts (e.g. MCP Client Tool only supports Bearer Auth, Header Auth, Multiple Headers Auth, and MCP OAuth2). This changes the reference to "Header Auth" which is the correct and universally available alternative.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5009
closes https://github.com/n8n-io/n8n/issues/30076

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

🤖 PR Summary generated by AI