### PR TITLE
fix(odoo): pass database name as X-Odoo-Database header

### DIFF
--- a/packages/nodes-base/nodes/Odoo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Odoo/GenericFunctions.ts
@@ -82,6 +82,18 @@ export function odooGetDBName(databaseName: string | undefined, url: string) {
 	return odooURL.hostname.split('.')[0];
 }
 
+function getOdooDatabaseNameFromJsonRpcBody(body: IDataObject): string | undefined {
+	const params = body.params as IDataObject | undefined;
+	const args = params?.args as unknown[] | undefined;
+	const db = args?.[0];
+
+	if (typeof db !== 'string') return undefined;
+
+	const trimmedDb = db.trim();
+
+	return trimmedDb.length > 0 ? trimmedDb : undefined;
+}
+
 function processFilters(value: IOdooFilterOperations) {
 	return value.filter?.map((item) => {
 		const operator = item.operator as FilterOperation;
@@ -108,11 +120,14 @@ export async function odooJSONRPCRequest(
 	url: string,
 ): Promise<IDataObject | IDataObject[]> {
 	try {
+		const db = getOdooDatabaseNameFromJsonRpcBody(body);
+
 		const options: IRequestOptions = {
 			headers: {
 				Connection: 'keep-alive',
 				Accept: '*/*',
 				'Content-Type': 'application/json',
+				...(db ? { 'X-Odoo-Database': db } : {}),
 			},
 			method: 'POST',
 			body,

--- a/packages/nodes-base/nodes/Odoo/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Odoo/GenericFunctions.ts
@@ -82,7 +82,7 @@ export function odooGetDBName(databaseName: string | undefined, url: string) {
 	return odooURL.hostname.split('.')[0];
 }
 
-function getOdooDatabaseNameFromJsonRpcBody(body: IDataObject): string | undefined {
+export function getOdooDatabaseNameFromJsonRpcBody(body: IDataObject): string | undefined {
 	const params = body.params as IDataObject | undefined;
 	const args = params?.args as unknown[] | undefined;
 	const db = args?.[0];
@@ -92,6 +92,17 @@ function getOdooDatabaseNameFromJsonRpcBody(body: IDataObject): string | undefin
 	const trimmedDb = db.trim();
 
 	return trimmedDb.length > 0 ? trimmedDb : undefined;
+}
+
+export function getOdooJsonRpcRequestHeaders(body: IDataObject) {
+	const db = getOdooDatabaseNameFromJsonRpcBody(body);
+
+	return {
+		Connection: 'keep-alive',
+		Accept: '*/*',
+		'Content-Type': 'application/json',
+		...(db ? { 'X-Odoo-Database': db } : {}),
+	};
 }
 
 function processFilters(value: IOdooFilterOperations) {
@@ -120,15 +131,8 @@ export async function odooJSONRPCRequest(
 	url: string,
 ): Promise<IDataObject | IDataObject[]> {
 	try {
-		const db = getOdooDatabaseNameFromJsonRpcBody(body);
-
 		const options: IRequestOptions = {
-			headers: {
-				Connection: 'keep-alive',
-				Accept: '*/*',
-				'Content-Type': 'application/json',
-				...(db ? { 'X-Odoo-Database': db } : {}),
-			},
+			headers: getOdooJsonRpcRequestHeaders(body),
 			method: 'POST',
 			body,
 			uri: `${url}/jsonrpc`,

--- a/packages/nodes-base/nodes/Odoo/Odoo.node.ts
+++ b/packages/nodes-base/nodes/Odoo/Odoo.node.ts
@@ -229,6 +229,7 @@ export class Odoo implements INodeType {
 				credential: ICredentialsDecrypted,
 			): Promise<INodeCredentialTestResult> {
 				const credentials = credential.data;
+				const db = odooGetDBName(credentials?.db as string, credentials?.url as string);
 
 				try {
 					const body = {
@@ -237,11 +238,7 @@ export class Odoo implements INodeType {
 						params: {
 							service: 'common',
 							method: 'login',
-							args: [
-								odooGetDBName(credentials?.db as string, credentials?.url as string),
-								credentials?.username,
-								credentials?.password,
-							],
+							args: [db, credentials?.username, credentials?.password],
 						},
 						id: randomInt(100),
 					};
@@ -251,6 +248,7 @@ export class Odoo implements INodeType {
 							Connection: 'keep-alive',
 							Accept: '*/*',
 							'Content-Type': 'application/json',
+							...(db ? { 'X-Odoo-Database': db } : {}),
 						},
 						method: 'POST',
 						body,

--- a/packages/nodes-base/nodes/Odoo/Odoo.node.ts
+++ b/packages/nodes-base/nodes/Odoo/Odoo.node.ts
@@ -26,6 +26,7 @@ import {
 } from './descriptions';
 import type { IOdooFilterOperations } from './GenericFunctions';
 import {
+	getOdooJsonRpcRequestHeaders,
 	odooCreate,
 	odooDelete,
 	odooGet,
@@ -244,12 +245,7 @@ export class Odoo implements INodeType {
 					};
 
 					const options: IRequestOptions = {
-						headers: {
-							Connection: 'keep-alive',
-							Accept: '*/*',
-							'Content-Type': 'application/json',
-							...(db ? { 'X-Odoo-Database': db } : {}),
-						},
+						headers: getOdooJsonRpcRequestHeaders(body),
 						method: 'POST',
 						body,
 						uri: `${(credentials?.url as string).replace(/\/$/, '')}/jsonrpc`,

--- a/packages/nodes-base/nodes/Odoo/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Odoo/test/GenericFunctions.test.ts
@@ -1,0 +1,160 @@
+import type {
+	ICredentialTestFunctions,
+	ICredentialsDecrypted,
+	IDataObject,
+	IExecuteFunctions,
+	IRequestOptions,
+} from 'n8n-workflow';
+
+jest.mock(
+	'n8n-workflow',
+	() => ({
+		NodeApiError: class NodeApiError extends Error {},
+		NodeConnectionTypes: {
+			Main: 'main',
+		},
+		deepCopy: jest.fn((data) => data),
+		randomInt: jest.fn(() => 1),
+	}),
+	{ virtual: true },
+);
+
+import { Odoo } from '../Odoo.node';
+import {
+	getOdooDatabaseNameFromJsonRpcBody,
+	odooJSONRPCRequest,
+} from '../GenericFunctions';
+
+const getLastRequestOptions = (request: jest.Mock): IRequestOptions => {
+	return request.mock.calls[request.mock.calls.length - 1][0] as IRequestOptions;
+};
+
+const getRequestHeaders = (request: jest.Mock): IDataObject => {
+	return getLastRequestOptions(request).headers as IDataObject;
+};
+
+const createMockExecuteFunctions = () => {
+	const request = jest.fn().mockResolvedValue({ result: { success: true } });
+	const executeFunctions = {
+		helpers: {
+			request,
+		},
+		getNode: jest.fn().mockReturnValue({ name: 'Odoo' }),
+	} as unknown as IExecuteFunctions;
+
+	return { executeFunctions, request };
+};
+
+const createJsonRpcBody = (db: unknown): IDataObject => ({
+	jsonrpc: '2.0',
+	method: 'call',
+	params: {
+		service: 'object',
+		method: 'execute',
+		args: [db, 1, 'password', 'res.partner', 'search_read', [], ['id', 'name']],
+	},
+	id: 1,
+});
+
+const runCredentialTest = async (data: IDataObject) => {
+	const request = jest.fn().mockResolvedValue({ result: 1 });
+	const credentialTestFunctions = {
+		helpers: {
+			request,
+		},
+	} as unknown as ICredentialTestFunctions;
+	const odoo = new Odoo();
+
+	const result = await odoo.methods.credentialTest.odooApiTest.call(credentialTestFunctions, {
+		data,
+	} as ICredentialsDecrypted);
+
+	return { request, result };
+};
+
+describe('Odoo GenericFunctions', () => {
+	describe('getOdooDatabaseNameFromJsonRpcBody', () => {
+		it('returns the database name when body.params.args[0] is a non-empty string', () => {
+			expect(getOdooDatabaseNameFromJsonRpcBody(createJsonRpcBody('odoo'))).toBe('odoo');
+		});
+
+		it.each([
+			['params are missing', {}],
+			['args are missing', { params: {} }],
+			['database value is missing', { params: { args: [] } }],
+			['database value is empty', createJsonRpcBody('')],
+			['database value is only whitespace', createJsonRpcBody('   ')],
+			['database value is not a string', createJsonRpcBody(123)],
+		])('returns undefined when %s', (_, body) => {
+			expect(getOdooDatabaseNameFromJsonRpcBody(body as IDataObject)).toBeUndefined();
+		});
+	});
+
+	describe('odooJSONRPCRequest', () => {
+		it('sets the X-Odoo-Database header when body.params.args[0] is a non-empty string', async () => {
+			const { executeFunctions, request } = createMockExecuteFunctions();
+
+			await odooJSONRPCRequest.call(executeFunctions, createJsonRpcBody('odoo'), 'https://odoo.test');
+
+			expect(getRequestHeaders(request)).toEqual(
+				expect.objectContaining({
+					'X-Odoo-Database': 'odoo',
+				}),
+			);
+		});
+
+		it.each([
+			['params are missing', {}],
+			['args are missing', { params: {} }],
+			['database value is missing', { params: { args: [] } }],
+			['database value is empty', createJsonRpcBody('')],
+			['database value is only whitespace', createJsonRpcBody('   ')],
+			['database value is not a string', createJsonRpcBody(123)],
+		])('omits the X-Odoo-Database header when %s', async (_, body) => {
+			const { executeFunctions, request } = createMockExecuteFunctions();
+
+			await odooJSONRPCRequest.call(executeFunctions, body as IDataObject, 'https://odoo.test');
+
+			expect(getRequestHeaders(request)).not.toHaveProperty('X-Odoo-Database');
+		});
+	});
+
+	describe('credential test', () => {
+		it('sets the X-Odoo-Database header when the credential database resolves to a non-empty string', async () => {
+			const { request, result } = await runCredentialTest({
+				db: 'odoo',
+				url: 'https://odoo.test',
+				username: 'admin',
+				password: 'password',
+			});
+
+			expect(result).toEqual({
+				status: 'OK',
+				message: 'Authentication successful!',
+			});
+			expect(getRequestHeaders(request)).toEqual(
+				expect.objectContaining({
+					'X-Odoo-Database': 'odoo',
+				}),
+			);
+		});
+
+		it.each([
+			['database value is missing', { url: 'file:///tmp' }],
+			['database value is empty', { db: '', url: 'file:///tmp' }],
+			['database value is not a string', { db: 123, url: 'https://odoo.test' }],
+		])('omits the X-Odoo-Database header when the credential %s', async (_, credentials) => {
+			const { request, result } = await runCredentialTest({
+				...credentials,
+				username: 'admin',
+				password: 'password',
+			});
+
+			expect(result).toEqual({
+				status: 'OK',
+				message: 'Authentication successful!',
+			});
+			expect(getRequestHeaders(request)).not.toHaveProperty('X-Odoo-Database');
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Add the Odoo database name as the `X-Odoo-Database` HTTP header on Odoo JSON-RPC requests when a database can be resolved.

Odoo requires this header when an instance hosts multiple databases and `dbfilter` does not select the database from the Host header. n8n already sends the database as the first JSON-RPC argument, and this change reuses that same value for the routing header.

## Changes

- Derive the Odoo database name from `body.params.args[0]` in the shared JSON-RPC helper.
- Add `X-Odoo-Database` to JSON-RPC request headers when the resolved database is a non-empty string.
- Add the same header to the Odoo credential test request, which constructs its own request options.
- Preserve existing behavior when no database can be resolved.
- Add unit tests for the JSON-RPC helper, conditional request header, and credential test request header.

## Validation

- Verified locally against an Odoo 19 instance that requires `X-Odoo-Database`.
- Confirmed the patched n8n Odoo credential test succeeds with:

```text
Site URL: http://192.168.72.44:8069
Database Name: fl_staging
```

- Confirmed the header appears in both Odoo request paths:

```bash
grep -R "X-Odoo-Database" packages/nodes-base/nodes/Odoo
```

- Added and ran targeted unit tests:

```bash
node <jest-bin> --config packages/nodes-base/jest.config.js packages/nodes-base/nodes/Odoo/test/GenericFunctions.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. N/A: code-only Odoo request header fix.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
