### PR TITLE
fix(core): Warn MCP clients that removeNode disconnects sub-nodes

### DIFF
--- a/packages/cli/src/modules/mcp/tools/workflow-builder/mcp-instructions.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/mcp-instructions.ts
@@ -38,7 +38,7 @@ To build n8n workflows, follow these steps in order:
 
 7. Create: Call ${MCP_CREATE_WORKFLOW_FROM_CODE_TOOL.toolName} with the validated code to save the workflow to n8n. Include a short \`description\` (1-2 sentences) summarizing what the workflow does — this helps users find and understand their workflows.
 
-8. Update: Call ${MCP_UPDATE_WORKFLOW_TOOL.toolName} with the workflow ID and a list of operations (addNode, removeNode, updateNodeParameters, renameNode, addConnection, removeConnection, setNodeCredential, setNodePosition, setNodeDisabled, setWorkflowMetadata). The whole batch is atomic: if any op fails the workflow is unchanged. To modify an existing node's configuration, use updateNodeParameters or setNodeParameter — do NOT use removeNode followed by addNode for the same node, as this disconnects any attached sub-nodes (LLM models, memory, tools) and they will not be re-attached automatically.
+8. Update: Call ${MCP_UPDATE_WORKFLOW_TOOL.toolName} with the workflow ID and a list of operations (addNode, removeNode, updateNodeParameters, setNodeParameter, renameNode, addConnection, removeConnection, setNodeCredential, setNodePosition, setNodeDisabled, setWorkflowMetadata). The whole batch is atomic: if any op fails the workflow is unchanged. To modify an existing node's configuration, use updateNodeParameters or setNodeParameter — do NOT use removeNode followed by addNode for the same node, as this disconnects any attached sub-nodes (LLM models, memory, tools) and they will not be re-attached automatically.
 
 9. Archive: Call ${MCP_ARCHIVE_WORKFLOW_TOOL.toolName} with the workflow ID.`;
 

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/mcp-instructions.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/mcp-instructions.ts
@@ -38,7 +38,7 @@ To build n8n workflows, follow these steps in order:
 
 7. Create: Call ${MCP_CREATE_WORKFLOW_FROM_CODE_TOOL.toolName} with the validated code to save the workflow to n8n. Include a short \`description\` (1-2 sentences) summarizing what the workflow does — this helps users find and understand their workflows.
 
-8. Update: Call ${MCP_UPDATE_WORKFLOW_TOOL.toolName} with the workflow ID and a list of operations (addNode, removeNode, updateNodeParameters, renameNode, addConnection, removeConnection, setNodeCredential, setNodePosition, setNodeDisabled, setWorkflowMetadata). The whole batch is atomic: if any op fails the workflow is unchanged.
+8. Update: Call ${MCP_UPDATE_WORKFLOW_TOOL.toolName} with the workflow ID and a list of operations (addNode, removeNode, updateNodeParameters, renameNode, addConnection, removeConnection, setNodeCredential, setNodePosition, setNodeDisabled, setWorkflowMetadata). The whole batch is atomic: if any op fails the workflow is unchanged. To modify an existing node's configuration, use updateNodeParameters or setNodeParameter — do NOT use removeNode followed by addNode for the same node, as this disconnects any attached sub-nodes (LLM models, memory, tools) and they will not be re-attached automatically.
 
 9. Archive: Call ${MCP_ARCHIVE_WORKFLOW_TOOL.toolName} with the workflow ID.`;
 

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/workflow-operations.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/workflow-operations.ts
@@ -70,7 +70,9 @@ export const partialUpdateOperationSchema = z.discriminatedUnion('type', [
 		type: z.literal('removeNode'),
 		nodeName: z
 			.string()
-			.describe('Name of the node to remove. All inbound and outbound connections are removed.'),
+			.describe(
+				'Name of the node to remove. All inbound and outbound connections are removed, including any sub-node attachments (LLM models, memory, tools) — the sub-nodes themselves remain in the workflow but become disconnected and will not be re-attached automatically. To modify a node, use updateNodeParameters or setNodeParameter instead.',
+			),
 	}),
 	z.object({
 		type: z.literal('renameNode'),


### PR DESCRIPTION
## Summary

The n8n MCP workflow-update tool exposes a `removeNode` operation that removes inbound and outbound connections for the target node. Because sub-node attachments (LLM models, memory, tools) are stored as outbound connections from the sub-node's side, removing the parent strips the sub-node's connection entry entirely — the sub-node remains in `workflow.nodes` but its `connections` entry is gone, so it appears disconnected on the canvas.

Some MCP clients (e.g. Claude) sometimes implement "modify a node" as `removeNode` followed by `addNode` with the same name, which silently strips attached LLM models, memory, and tools. From the user's perspective, the model on their AI Agent disappears every time the LLM client edits the workflow.

This is a prompt-only mitigation that documents the cascade in two places the LLM client reads at call time:

- **`removeNode.nodeName` description** in the partial-update operation schema (`workflow-operations.ts`) — surfaces the sub-node cost when the LLM is choosing an operation.
- **Step 8 of the MCP server instructions** (`mcp-instructions.ts`) — explicitly directs clients to use `updateNodeParameters` / `setNodeParameter` for modifications.

No code logic changes. No behaviour change for clients that intentionally call `removeNode`.

## Verification

Confirmed empirically against `applyOperations` (in a local probe test) that:
- `updateNodeParameters` on any node — sub-node connection preserved ✓
- `renameNode` — sub-node connection preserved ✓
- `removeNode` — sub-node connection stripped (this is the documented cascade)
- `removeNode` + `addNode` with same name — sub-node stays stripped

Ruled out other server-side hypotheses (`ParseValidateHandler.validateJSON`, `resolveNodeWebhookIds`, `workflowService.update`) — none of them touch the connection graph.

## Follow-up (not in this PR)

Defense in depth: when `removeNode` orphans a sub-node, surface it as a `validationWarning` in the tool response so the LLM client can re-attach. Worth doing if the prompt mitigation alone doesn't move the needle.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-2462

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)