### PR TITLE
ci: Match -exp for experimental/rc releases and mark semver as latest

### DIFF
--- a/.github/scripts/create-github-release.mjs
+++ b/.github/scripts/create-github-release.mjs
@@ -58,7 +58,7 @@ async function createGitHubRelease() {
 			body: BODY,
 			draft: false,
 			prerelease: IS_PRE_RELEASE === 'true',
-			make_latest: MAKE_LATEST === 'true' ? 'true' : 'false',
+			make_latest: MAKE_LATEST === 'true' && isReleaseTrackTag ? 'true' : 'false',
 			target_commitish: COMMIT,
 			owner,
 			repo,

--- a/.github/scripts/create-github-release.mjs
+++ b/.github/scripts/create-github-release.mjs
@@ -58,7 +58,7 @@ async function createGitHubRelease() {
 			body: BODY,
 			draft: false,
 			prerelease: IS_PRE_RELEASE === 'true',
-			make_latest: MAKE_LATEST === 'true' && isReleaseTrackTag ? 'true' : 'false',
+			make_latest: MAKE_LATEST === 'true' && !isReleaseTrackTag ? 'true' : 'false',
 			target_commitish: COMMIT,
 			owner,
 			repo,

--- a/.github/scripts/determine-version-info.mjs
+++ b/.github/scripts/determine-version-info.mjs
@@ -121,6 +121,9 @@ function determineReleaseType(currentVersion) {
 	if (currentVersion.includes('-rc.')) {
 		return 'rc';
 	}
+	if (currentVersion.includes('-exp')) {
+		return 'rc';
+	}
 	return 'stable';
 }
 

--- a/.github/scripts/determine-version-info.test.mjs
+++ b/.github/scripts/determine-version-info.test.mjs
@@ -104,4 +104,16 @@ describe('determine-tracks', () => {
 		assert.equal(output.release_type, 'rc');
 		assert.equal(output.rc_branch, 'release-candidate/2.10.x');
 	});
+
+	it('Set release_type accordingly on exp releases', () => {
+		const output = determineTrack('2.9.2-exp.0');
+
+		assert.equal(output.track, 'stable');
+		assert.equal(output.version, '2.9.2-exp.0');
+		assert.equal(output.previous_version, '2.9.2');
+		assert.equal(output.bump, 'patch');
+		assert.equal(output.new_stable_version, null);
+		assert.equal(output.release_type, 'rc');
+		assert.equal(output.rc_branch, 'release-candidate/2.9.x');
+	});
 });

--- a/.github/workflows/release-create-github-releases.yml
+++ b/.github/workflows/release-create-github-releases.yml
@@ -16,6 +16,9 @@ on:
       commit:
         required: true
         type: string
+      is_experimental:
+        required: true
+        type: boolean
   workflow_dispatch:
     inputs:
       track:
@@ -35,6 +38,9 @@ on:
         description: 'Commitish the release points to (e.g. branch name or SHA).'
         required: true
         type: string
+      is_experimental:
+        required: true
+        type: boolean
 
 permissions:
   contents: write
@@ -71,8 +77,8 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           RELEASE_TAG: ${{ inputs.version-tag }}
           BODY: ${{ inputs.body }}
-          IS_PRE_RELEASE: ${{ inputs.track == 'beta' }}
-          MAKE_LATEST: ${{ inputs.track == 'stable' }}
+          IS_PRE_RELEASE: ${{ inputs.track == 'beta' || inputs.is_experimental }}
+          MAKE_LATEST: ${{ inputs.track == 'stable' && !inputs.is_experimental }}
           COMMIT: ${{ inputs.commit }}
-          ADDITIONAL_TAGS: ${{ inputs.track }}
+          ADDITIONAL_TAGS: ${{ !inputs.is_experimental && inputs.track || '' }}
         run: node ./.github/scripts/create-github-release.mjs

--- a/.github/workflows/release-publish-post-release.yml
+++ b/.github/workflows/release-publish-post-release.yml
@@ -70,7 +70,7 @@ jobs:
     name: Ensure correct latest version on npm
     if: |
       inputs.bump == 'minor' ||
-      inputs.track == 'stable'
+      (inputs.track == 'stable' && inputs.release_type != 'rc')
     uses: ./.github/workflows/release-set-stable-npm-packages-to-latest.yml
     secrets: inherit
 

--- a/.github/workflows/release-publish-post-release.yml
+++ b/.github/workflows/release-publish-post-release.yml
@@ -85,6 +85,8 @@ jobs:
 
   send-version-release-notification:
     name: 'Send version release notifications'
+    if: |
+      inputs.release_type != 'rc'
     uses: ./.github/workflows/release-version-release-notification.yml
     with:
       previous-version: ${{ inputs.previous_version }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -128,12 +128,15 @@ jobs:
       version-tag: 'n8n@${{ needs.determine-version-info.outputs.version }}'
       body: ${{ github.event.pull_request.body }}
       commit: ${{ github.event.pull_request.base.ref }}
+      is_experimental: ${{ needs.determine-version-info.outputs.release_type == 'rc' }}
     secrets: inherit
 
   move-track-tag:
     name: Move track tag
     needs: [determine-version-info, create-github-release]
-    if: github.event.pull_request.merged == true
+    if: |
+      github.event.pull_request.merged == true &&
+      needs.determine-version-info.outputs.release_type != 'rc'
     uses: ./.github/workflows/release-update-pointer-tag.yml
     with:
       track: ${{ needs.determine-version-info.outputs.track }}


### PR DESCRIPTION
## Summary

[Experimental releases were falsely flagged](https://github.com/n8n-io/n8n/actions/runs/25801282139/job/75797043173#step:4:26) as `stable` instead of `rc`, causing release tracks, pointer tags and npm releases to get jumbled. 

Fixes the determination logic so `-exp` suffixes also get tagged as `rc`.

Also cleans up steps so experimental releases don't update what they're not supposed to.

On top of above changes, it makes sure that we only mark the semver version of releases as "Latest" on GitHub, instead of all stable track releases.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
