### PR TITLE
fix(core): Require admin push when migrating legacy environments to projects folder

### DIFF
--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-git.service.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-git.service.test.ts
@@ -19,6 +19,8 @@ const MOCK_BRANCHES = {
 const mockGitInstance = {
 	branch: jest.fn().mockResolvedValue(MOCK_BRANCHES),
 	env: jest.fn().mockReturnThis(),
+	fetch: jest.fn().mockResolvedValue(undefined),
+	raw: jest.fn().mockResolvedValue(''),
 };
 
 jest.mock('simple-git', () => {
@@ -505,6 +507,50 @@ describe('SourceControlGitService', () => {
 					expect.not.stringContaining('Test"User'), // No unescaped quote in final command
 				);
 			});
+		});
+	});
+
+	describe('requiresAdminPushForProjectsMigration', () => {
+		beforeEach(() => {
+			mockSourceControlPreferencesService.getPreferences.mockReturnValue({
+				branchName: 'main',
+			} as SourceControlPreferences);
+		});
+
+		it('should return true when workflows exist on remote but projects do not', async () => {
+			mockGitInstance.raw.mockImplementation(async (args: string[]) => {
+				const path = args[2];
+				if (path === 'workflows') {
+					return '040000 tree abc\tworkflows\n';
+				}
+				throw new Error('path not found');
+			});
+
+			await expect(sourceControlGitService.requiresAdminPushForProjectsMigration()).resolves.toBe(
+				true,
+			);
+		});
+
+		it('should return false when both workflows and projects exist on remote', async () => {
+			mockGitInstance.raw.mockImplementation(async (args: string[]) => {
+				const path = args[2];
+				if (path === 'workflows' || path === 'projects') {
+					return `040000 tree abc\t${path}\n`;
+				}
+				throw new Error('path not found');
+			});
+
+			await expect(sourceControlGitService.requiresAdminPushForProjectsMigration()).resolves.toBe(
+				false,
+			);
+		});
+
+		it('should return false when workflows do not exist on remote', async () => {
+			mockGitInstance.raw.mockRejectedValue(new Error('path not found'));
+
+			await expect(sourceControlGitService.requiresAdminPushForProjectsMigration()).resolves.toBe(
+				false,
+			);
 		});
 	});
 });

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control-git.service.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control-git.service.test.ts
@@ -4,8 +4,8 @@ import { simpleGit } from 'simple-git';
 import type { SimpleGit } from 'simple-git';
 
 import { SourceControlGitService } from '../source-control-git.service.ee';
-import type { SourceControlPreferences } from '../types/source-control-preferences';
 import type { SourceControlPreferencesService } from '../source-control-preferences.service.ee';
+import type { SourceControlPreferences } from '../types/source-control-preferences';
 
 const MOCK_BRANCHES = {
 	all: ['origin/master', 'origin/feature/branch'],
@@ -523,7 +523,10 @@ describe('SourceControlGitService', () => {
 				if (path === 'workflows') {
 					return '040000 tree abc\tworkflows\n';
 				}
-				throw new Error('path not found');
+				if (path === 'projects') {
+					return '';
+				}
+				return '';
 			});
 
 			await expect(sourceControlGitService.requiresAdminPushForProjectsMigration()).resolves.toBe(
@@ -537,7 +540,7 @@ describe('SourceControlGitService', () => {
 				if (path === 'workflows' || path === 'projects') {
 					return `040000 tree abc\t${path}\n`;
 				}
-				throw new Error('path not found');
+				return '';
 			});
 
 			await expect(sourceControlGitService.requiresAdminPushForProjectsMigration()).resolves.toBe(
@@ -546,10 +549,18 @@ describe('SourceControlGitService', () => {
 		});
 
 		it('should return false when workflows do not exist on remote', async () => {
-			mockGitInstance.raw.mockRejectedValue(new Error('path not found'));
+			mockGitInstance.raw.mockResolvedValue('');
 
 			await expect(sourceControlGitService.requiresAdminPushForProjectsMigration()).resolves.toBe(
 				false,
+			);
+		});
+
+		it('should reject when remote directory check fails (fail closed for migration guard)', async () => {
+			mockGitInstance.raw.mockRejectedValue(new Error('network error'));
+
+			await expect(sourceControlGitService.requiresAdminPushForProjectsMigration()).rejects.toThrow(
+				'network error',
 			);
 		});
 	});

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control.controller.ee.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control.controller.ee.test.ts
@@ -7,6 +7,7 @@ import type { EventService } from '@/events/event.service';
 
 import type { SourceControlPreferencesService } from '../source-control-preferences.service.ee';
 import { SourceControlController } from '../source-control.controller.ee';
+import type { SourceControlScopedService } from '../source-control-scoped.service';
 import type { SourceControlService } from '../source-control.service.ee';
 import type { SourceControlRequest } from '../types/requests';
 import type { SourceControlGetStatus } from '../types/source-control-get-status';
@@ -15,6 +16,7 @@ describe('SourceControlController', () => {
 	let controller: SourceControlController;
 	let sourceControlService: SourceControlService;
 	let sourceControlPreferencesService: SourceControlPreferencesService;
+	let sourceControlScopedService: SourceControlScopedService;
 	let eventService: EventService;
 
 	beforeEach(() => {
@@ -23,15 +25,19 @@ describe('SourceControlController', () => {
 			pullWorkfolder: jest.fn().mockResolvedValue({ statusCode: 200 }),
 			getStatus: jest.fn().mockResolvedValue([]),
 			setGitUserDetails: jest.fn(),
+			sanityCheck: jest.fn().mockResolvedValue(undefined),
 		} as unknown as SourceControlService;
 
 		sourceControlPreferencesService = mock<SourceControlPreferencesService>();
+		sourceControlScopedService = {
+			ensureIsAllowedToPush: jest.fn().mockResolvedValue(undefined),
+		} as unknown as SourceControlScopedService;
 		eventService = mock<EventService>();
 
 		controller = new SourceControlController(
 			sourceControlService,
 			sourceControlPreferencesService,
-			mock(),
+			sourceControlScopedService,
 			eventService,
 		);
 	});

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control.service.test.ts
@@ -6,6 +6,7 @@ import { mock } from 'jest-mock-extended';
 import { InstanceSettings } from 'n8n-core';
 import type { PushResult } from 'simple-git';
 
+import { SOURCE_CONTROL_ADMIN_PUSH_REQUIRED_MESSAGE } from '@/environments.ee/source-control/constants';
 import { SourceControlPreferencesService } from '@/environments.ee/source-control/source-control-preferences.service.ee';
 import { SourceControlService } from '@/environments.ee/source-control/source-control.service.ee';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
@@ -59,6 +60,7 @@ describe('SourceControlService', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
 		jest.spyOn(sourceControlService, 'sanityCheck').mockResolvedValue(undefined);
+		gitService.requiresAdminPushForProjectsMigration.mockResolvedValue(false);
 		// Reset mock implementations
 		mockStatusService.getStatus.mockReset();
 	});
@@ -266,6 +268,56 @@ describe('SourceControlService', () => {
 			expect(result).toMatchObject({
 				statusCode: 200,
 			});
+		});
+
+		it('should throw ForbiddenError when projects migration requires admin push', async () => {
+			const user = Object.assign(new User(), {
+				role: GLOBAL_MEMBER_ROLE,
+			});
+			gitService.requiresAdminPushForProjectsMigration.mockResolvedValueOnce(true);
+
+			await expect(sourceControlService.ensureCanPushWorkfolder(user)).rejects.toThrow(
+				new ForbiddenError(SOURCE_CONTROL_ADMIN_PUSH_REQUIRED_MESSAGE),
+			);
+		});
+
+		it('should throw ForbiddenError from pushWorkfolder when projects migration requires admin push', async () => {
+			const user = Object.assign(new User(), {
+				role: GLOBAL_MEMBER_ROLE,
+			});
+			gitService.requiresAdminPushForProjectsMigration.mockResolvedValueOnce(true);
+
+			await expect(
+				sourceControlService.pushWorkfolder(user, {
+					fileNames: [],
+					commitMessage: 'Test',
+				}),
+			).rejects.toThrow(new ForbiddenError(SOURCE_CONTROL_ADMIN_PUSH_REQUIRED_MESSAGE));
+
+			expect(mockStatusService.getStatus).not.toHaveBeenCalled();
+		});
+
+		it('should allow instance admin to push when projects migration requires admin push', async () => {
+			const user = Object.assign(new User(), {
+				role: GLOBAL_ADMIN_ROLE,
+			});
+			gitService.requiresAdminPushForProjectsMigration.mockResolvedValueOnce(true);
+			mockStatusService.getStatus.mockResolvedValueOnce([]);
+			sourceControlExportService.exportCredentialsToWorkFolder.mockResolvedValueOnce({
+				count: 0,
+				missingIds: [],
+				folder: '',
+				files: [],
+			});
+			gitService.push.mockResolvedValueOnce(mock<PushResult>());
+
+			await sourceControlService.pushWorkfolder(user, {
+				fileNames: [],
+				commitMessage: 'Test',
+			});
+
+			expect(gitService.requiresAdminPushForProjectsMigration).toHaveBeenCalled();
+			expect(mockStatusService.getStatus).toHaveBeenCalled();
 		});
 
 		it('should throw an error if file path validation fails', async () => {

--- a/packages/cli/src/environments.ee/source-control/__tests__/source-control.service.test.ts
+++ b/packages/cli/src/environments.ee/source-control/__tests__/source-control.service.test.ts
@@ -276,17 +276,6 @@ describe('SourceControlService', () => {
 			});
 			gitService.requiresAdminPushForProjectsMigration.mockResolvedValueOnce(true);
 
-			await expect(sourceControlService.ensureCanPushWorkfolder(user)).rejects.toThrow(
-				new ForbiddenError(SOURCE_CONTROL_ADMIN_PUSH_REQUIRED_MESSAGE),
-			);
-		});
-
-		it('should throw ForbiddenError from pushWorkfolder when projects migration requires admin push', async () => {
-			const user = Object.assign(new User(), {
-				role: GLOBAL_MEMBER_ROLE,
-			});
-			gitService.requiresAdminPushForProjectsMigration.mockResolvedValueOnce(true);
-
 			await expect(
 				sourceControlService.pushWorkfolder(user, {
 					fileNames: [],

--- a/packages/cli/src/environments.ee/source-control/constants.ts
+++ b/packages/cli/src/environments.ee/source-control/constants.ts
@@ -17,3 +17,5 @@ export const SOURCE_CONTROL_README = `
 `;
 export const SOURCE_CONTROL_DEFAULT_NAME = 'n8n user';
 export const SOURCE_CONTROL_DEFAULT_EMAIL = 'n8n@example.com';
+export const SOURCE_CONTROL_ADMIN_PUSH_REQUIRED_MESSAGE =
+	'The connected Git repository is missing the projects folder. An instance owner or instance admin must perform the next push so that projects are synced correctly with environments.';

--- a/packages/cli/src/environments.ee/source-control/source-control-git.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-git.service.ee.ts
@@ -510,6 +510,8 @@ export class SourceControlGitService {
 
 	/**
 	 * Checks whether a directory exists on the remote tracking branch of the connected repository.
+	 * On git or network failure, throws — callers must not treat errors as "directory absent", or
+	 * non-admins could bypass the legacy migration admin push requirement (see LIGO-326).
 	 */
 	private async remoteDirectoryExists(directory: string): Promise<boolean> {
 		if (!this.git) {
@@ -521,16 +523,9 @@ export class SourceControlGitService {
 			return false;
 		}
 
-		try {
-			await this.fetch();
-			const remoteRef = `${SOURCE_CONTROL_ORIGIN}/${branchName}`;
-			const result = await this.git.raw(['ls-tree', remoteRef, directory]);
-			return result.trim().length > 0;
-		} catch (error) {
-			this.logger.debug(`Remote directory "${directory}" not found on connected repository`, {
-				error,
-			});
-			return false;
-		}
+		await this.fetch();
+		const remoteRef = `${SOURCE_CONTROL_ORIGIN}/${branchName}`;
+		const result = await this.git.raw(['ls-tree', remoteRef, directory]);
+		return result.trim().length > 0;
 	}
 }

--- a/packages/cli/src/environments.ee/source-control/source-control-git.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control-git.service.ee.ts
@@ -22,6 +22,8 @@ import {
 	SOURCE_CONTROL_DEFAULT_EMAIL,
 	SOURCE_CONTROL_DEFAULT_NAME,
 	SOURCE_CONTROL_ORIGIN,
+	SOURCE_CONTROL_PROJECT_EXPORT_FOLDER,
+	SOURCE_CONTROL_WORKFLOW_EXPORT_FOLDER,
 } from './constants';
 import { sourceControlFoldersExistCheck } from './source-control-helper.ee';
 import { SourceControlPreferencesService } from './source-control-preferences.service.ee';
@@ -489,6 +491,46 @@ export class SourceControlGitService {
 				`Could not get content for file: ${filePath}: ${(error as Error)?.message}`,
 				{ cause: error },
 			);
+		}
+	}
+
+	/**
+	 * Instances that used environments before n8n 1.118.0 have workflows on the remote repository
+	 * but no projects directory yet. The first push after upgrading must be done by an instance admin.
+	 */
+	async requiresAdminPushForProjectsMigration(): Promise<boolean> {
+		const workflowsExist = await this.remoteDirectoryExists(SOURCE_CONTROL_WORKFLOW_EXPORT_FOLDER);
+		if (!workflowsExist) {
+			return false;
+		}
+
+		const projectsExist = await this.remoteDirectoryExists(SOURCE_CONTROL_PROJECT_EXPORT_FOLDER);
+		return !projectsExist;
+	}
+
+	/**
+	 * Checks whether a directory exists on the remote tracking branch of the connected repository.
+	 */
+	private async remoteDirectoryExists(directory: string): Promise<boolean> {
+		if (!this.git) {
+			throw new UnexpectedError('Git is not initialized (remoteDirectoryExists)');
+		}
+
+		const branchName = this.sourceControlPreferencesService.getPreferences().branchName;
+		if (!branchName) {
+			return false;
+		}
+
+		try {
+			await this.fetch();
+			const remoteRef = `${SOURCE_CONTROL_ORIGIN}/${branchName}`;
+			const result = await this.git.raw(['ls-tree', remoteRef, directory]);
+			return result.trim().length > 0;
+		} catch (error) {
+			this.logger.debug(`Remote directory "${directory}" not found on connected repository`, {
+				error,
+			});
+			return false;
 		}
 	}
 }

--- a/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
@@ -245,16 +245,11 @@ export class SourceControlService {
 		return await this.gitService.setBranch(branch);
 	}
 
-	// will reset the branch to the remote branch and pull
-	// this will discard all local changes
-	async ensureCanPushWorkfolder(user: User): Promise<void> {
-		if (await this.gitService.requiresAdminPushForProjectsMigration()) {
-			if (!hasGlobalScope(user, 'sourceControl:push')) {
-				throw new ForbiddenError(SOURCE_CONTROL_ADMIN_PUSH_REQUIRED_MESSAGE);
-			}
-		}
-	}
-
+	/**
+	 * Resets the current local branch to match its remote counterpart, discarding all local changes.
+	 * This operation overwrites any uncommitted or divergent local changes with the state from the remote branch.
+	 * Use with caution, as this action cannot be undone.
+	 */
 	async resetWorkfolder(): Promise<ImportResult | undefined> {
 		if (!this.gitService.git) {
 			await this.initGitService();
@@ -557,6 +552,14 @@ export class SourceControlService {
 			}
 			default:
 				throw new BadRequestError(`Unsupported file type: ${type}`);
+		}
+	}
+
+	private async ensureCanPushWorkfolder(user: User): Promise<void> {
+		if (await this.gitService.requiresAdminPushForProjectsMigration()) {
+			if (!hasGlobalScope(user, 'sourceControl:push')) {
+				throw new ForbiddenError(SOURCE_CONTROL_ADMIN_PUSH_REQUIRED_MESSAGE);
+			}
 		}
 	}
 }

--- a/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
+++ b/packages/cli/src/environments.ee/source-control/source-control.service.ee.ts
@@ -7,12 +7,14 @@ import { Logger } from '@n8n/backend-common';
 import { type User } from '@n8n/db';
 import { OnPubSubEvent } from '@n8n/decorators';
 import { Service } from '@n8n/di';
+import { hasGlobalScope } from '@n8n/permissions';
 import { writeFileSync } from 'fs';
 import { UnexpectedError, UserError, jsonParse } from 'n8n-workflow';
 import * as path from 'path';
 import type { PushResult } from 'simple-git';
 
 import {
+	SOURCE_CONTROL_ADMIN_PUSH_REQUIRED_MESSAGE,
 	SOURCE_CONTROL_DEFAULT_EMAIL,
 	SOURCE_CONTROL_DEFAULT_NAME,
 	SOURCE_CONTROL_README,
@@ -245,6 +247,14 @@ export class SourceControlService {
 
 	// will reset the branch to the remote branch and pull
 	// this will discard all local changes
+	async ensureCanPushWorkfolder(user: User): Promise<void> {
+		if (await this.gitService.requiresAdminPushForProjectsMigration()) {
+			if (!hasGlobalScope(user, 'sourceControl:push')) {
+				throw new ForbiddenError(SOURCE_CONTROL_ADMIN_PUSH_REQUIRED_MESSAGE);
+			}
+		}
+	}
+
 	async resetWorkfolder(): Promise<ImportResult | undefined> {
 		if (!this.gitService.git) {
 			await this.initGitService();
@@ -274,6 +284,8 @@ export class SourceControlService {
 		if (this.sourceControlPreferencesService.isBranchReadOnly()) {
 			throw new BadRequestError('Cannot push onto read-only branch.');
 		}
+
+		await this.ensureCanPushWorkfolder(user);
 
 		const context = new SourceControlContext(user);
 
@@ -497,6 +509,11 @@ export class SourceControlService {
 
 	async getStatus(user: User, options: SourceControlGetStatus) {
 		await this.sanityCheck();
+
+		if (options.direction === 'push') {
+			await this.ensureCanPushWorkfolder(user);
+		}
+
 		return await this.sourceControlStatusService.getStatus(user, options);
 	}
 

--- a/packages/cli/test/integration/environments/source-control.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control.service.test.ts
@@ -23,6 +23,7 @@ import fsp from 'node:fs/promises';
 import { basename, isAbsolute } from 'node:path';
 
 import {
+	SOURCE_CONTROL_ADMIN_PUSH_REQUIRED_MESSAGE,
 	SOURCE_CONTROL_CREDENTIAL_EXPORT_FOLDER,
 	SOURCE_CONTROL_FOLDERS_EXPORT_FILE,
 	SOURCE_CONTROL_TAGS_EXPORT_FILE,
@@ -425,7 +426,9 @@ describe('SourceControlService', () => {
 			workflows: projectBWorkflows,
 		};
 
-		gitService = mock<SourceControlGitService>();
+		gitService = mock<SourceControlGitService>({
+			requiresAdminPushForProjectsMigration: jest.fn().mockResolvedValue(false),
+		});
 		statusService = Container.get(SourceControlStatusService);
 
 		service = new SourceControlService(
@@ -1127,6 +1130,49 @@ describe('SourceControlService', () => {
 				expect(foldersFileContent.folders.map((f: any) => f.id)).toEqual(
 					expect.arrayContaining(projectAScope.folders.map((f) => f.id)),
 				);
+			});
+		});
+
+		describe('legacy environments repository without projects folder', () => {
+			beforeEach(() => {
+				gitService.requiresAdminPushForProjectsMigration.mockResolvedValue(true);
+			});
+
+			afterEach(() => {
+				gitService.requiresAdminPushForProjectsMigration.mockResolvedValue(false);
+			});
+
+			it('should deny push for project admin', async () => {
+				const allChanges = (await service.getStatus(projectAdmin, {
+					direction: 'push',
+					preferLocalVersion: true,
+					verbose: false,
+				})) as SourceControlledFile[];
+
+				await expect(
+					service.pushWorkfolder(projectAdmin, {
+						fileNames: allChanges,
+						commitMessage: 'Test',
+						force: true,
+					}),
+				).rejects.toThrow(new ForbiddenError(SOURCE_CONTROL_ADMIN_PUSH_REQUIRED_MESSAGE));
+			});
+
+			it('should allow push for global admin', async () => {
+				const allChanges = (await service.getStatus(globalAdmin, {
+					direction: 'push',
+					preferLocalVersion: true,
+					verbose: false,
+				})) as SourceControlledFile[];
+
+				const result = await service.pushWorkfolder(globalAdmin, {
+					fileNames: allChanges,
+					commitMessage: 'Test',
+					force: true,
+				});
+
+				expect(result.statusCode).toBe(200);
+				expect(gitService.push).toBeCalled();
 			});
 		});
 

--- a/packages/cli/test/integration/environments/source-control.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control.service.test.ts
@@ -12,12 +12,8 @@ import {
 	WorkflowEntity,
 } from '@n8n/db';
 import { Container } from '@n8n/di';
-import { createCredentials } from '@test-integration/db/credentials';
-import { createFolder } from '@test-integration/db/folders';
-import { assignTagToWorkflow, createTag, updateTag } from '@test-integration/db/tags';
-import { createUser } from '@test-integration/db/users';
 import * as fastGlob from 'fast-glob';
-import { mock } from 'jest-mock-extended';
+import { mock, type MockProxy } from 'jest-mock-extended';
 import { Cipher } from 'n8n-core';
 import fsp from 'node:fs/promises';
 import { basename, isAbsolute } from 'node:path';
@@ -43,6 +39,10 @@ import type { RemoteResourceOwner } from '@/environments.ee/source-control/types
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { EventService } from '@/events/event.service';
+import { createCredentials } from '@test-integration/db/credentials';
+import { createFolder } from '@test-integration/db/folders';
+import { assignTagToWorkflow, createTag, updateTag } from '@test-integration/db/tags';
+import { createUser } from '@test-integration/db/users';
 
 jest.mock('fast-glob');
 
@@ -176,7 +176,7 @@ describe('SourceControlService', () => {
 	let deletedOutOfScopeCredential: CredentialsEntity;
 	let deletedInScopeCredential: CredentialsEntity;
 
-	let gitService: SourceControlGitService;
+	let gitService: MockProxy<SourceControlGitService>;
 	let service: SourceControlService;
 	let statusService: SourceControlStatusService;
 
@@ -426,9 +426,8 @@ describe('SourceControlService', () => {
 			workflows: projectBWorkflows,
 		};
 
-		gitService = mock<SourceControlGitService>({
-			requiresAdminPushForProjectsMigration: jest.fn().mockResolvedValue(false),
-		});
+		gitService = mock<SourceControlGitService>();
+		gitService.requiresAdminPushForProjectsMigration.mockResolvedValue(false);
 		statusService = Container.get(SourceControlStatusService);
 
 		service = new SourceControlService(
@@ -813,6 +812,7 @@ describe('SourceControlService', () => {
 		});
 
 		beforeEach(() => {
+			gitService.requiresAdminPushForProjectsMigration.mockResolvedValue(false);
 			fsWriteFile.mockImplementation(async (path, data) => {
 				updatedFiles[path as string] = data as string;
 			});
@@ -1143,11 +1143,14 @@ describe('SourceControlService', () => {
 			});
 
 			it('should deny push for project admin', async () => {
+				// getStatus(direction: 'push') also enforces migration; load changes without that guard first
+				gitService.requiresAdminPushForProjectsMigration.mockResolvedValue(false);
 				const allChanges = (await service.getStatus(projectAdmin, {
 					direction: 'push',
 					preferLocalVersion: true,
 					verbose: false,
 				})) as SourceControlledFile[];
+				gitService.requiresAdminPushForProjectsMigration.mockResolvedValue(true);
 
 				await expect(
 					service.pushWorkfolder(projectAdmin, {

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.vue
@@ -617,9 +617,18 @@ async function onWorkflowMenuSelect(action: WORKFLOW_MENU_ACTIONS): Promise<void
 		case WORKFLOW_MENU_ACTIONS.PUSH: {
 			try {
 				await onSaveButtonClick();
+				const status = await sourceControlStore.prefetchPushStatus();
+				if (!status.length) {
+					toast.showMessage({
+						title: locale.baseText('settings.sourceControl.modals.push.everythingIsUpToDate'),
+						message: '',
+						type: 'info',
+					});
+					break;
+				}
 
 				// Navigate to route with sourceControl param - modal will handle data loading and loading states
-				void router.push({
+				await router.push({
 					query: {
 						...route.query,
 						sourceControl: 'push',

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.vue
@@ -28,6 +28,7 @@ import { ResourceType } from '@/features/collaboration/projects/projects.utils';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
+import { useSourceControlModalRouting } from '@/features/integrations/sourceControl.ee/useSourceControlModalRouting';
 import { useTagsStore } from '@/features/shared/tags/tags.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
@@ -117,6 +118,7 @@ const i18n = useI18n();
 
 const router = useRouter();
 const route = useRoute();
+const { openPushModal } = useSourceControlModalRouting();
 
 const locale = useI18n();
 const telemetry = useTelemetry();
@@ -617,36 +619,9 @@ async function onWorkflowMenuSelect(action: WORKFLOW_MENU_ACTIONS): Promise<void
 		case WORKFLOW_MENU_ACTIONS.PUSH: {
 			try {
 				await onSaveButtonClick();
-				const status = await sourceControlStore.prefetchPushStatus();
-				if (!status.length) {
-					toast.showMessage({
-						title: locale.baseText('settings.sourceControl.modals.push.everythingIsUpToDate'),
-						message: '',
-						type: 'info',
-					});
-					break;
-				}
-
-				// Navigate to route with sourceControl param - modal will handle data loading and loading states
-				await router.push({
-					query: {
-						...route.query,
-						sourceControl: 'push',
-					},
-				});
+				await openPushModal();
 			} catch (error) {
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				switch (error.message) {
-					case 'source_control_not_connected':
-						toast.showError(
-							{ ...error, message: '' },
-							locale.baseText('settings.sourceControl.error.not.connected.title'),
-							locale.baseText('settings.sourceControl.error.not.connected.message'),
-						);
-						break;
-					default:
-						toast.showError(error, locale.baseText('error'));
-				}
+				toast.showError(error, locale.baseText('error'));
 			}
 
 			break;

--- a/packages/frontend/editor-ui/src/app/components/MainSidebarSourceControl.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebarSourceControl.test.ts
@@ -65,19 +65,6 @@ describe('MainSidebarSourceControl', () => {
 
 		sourceControlStore = useSourceControlStore();
 		vi.spyOn(sourceControlStore, 'isEnterpriseSourceControlEnabled', 'get').mockReturnValue(true);
-		vi.spyOn(sourceControlStore, 'prefetchPushStatus').mockResolvedValue([
-			{
-				id: 'workflow-1',
-				name: 'Workflow 1',
-				type: 'workflow',
-				status: 'modified',
-				location: 'local',
-				conflict: false,
-				file: 'workflows/workflow-1.json',
-				updatedAt: '2024-01-01T00:00:00.000Z',
-				pushed: false,
-			},
-		]);
 		mockShowError.mockReset();
 	});
 
@@ -228,7 +215,6 @@ describe('MainSidebarSourceControl', () => {
 			});
 
 			await userEvent.click(getAllByRole('button')[1]);
-			await waitFor(() => expect(sourceControlStore.prefetchPushStatus).toHaveBeenCalled());
 			await waitFor(() =>
 				expect(mockRouterPush).toHaveBeenCalledWith({
 					query: {
@@ -236,19 +222,6 @@ describe('MainSidebarSourceControl', () => {
 					},
 				}),
 			);
-		});
-
-		it('should not navigate to push route when prefetching push status fails', async () => {
-			vi.spyOn(sourceControlStore, 'prefetchPushStatus').mockRejectedValue(new Error('Forbidden'));
-
-			const { getAllByRole } = renderComponent({
-				pinia,
-				props: { isCollapsed: false },
-			});
-
-			await userEvent.click(getAllByRole('button')[1]);
-			await waitFor(() => expect(sourceControlStore.prefetchPushStatus).toHaveBeenCalled());
-			expect(mockRouterPush).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/components/MainSidebarSourceControl.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebarSourceControl.test.ts
@@ -31,6 +31,14 @@ vi.mock('vue-router', () => ({
 	RouterLink: vi.fn(),
 }));
 
+const mockShowError = vi.fn();
+
+vi.mock('@/app/composables/useToast', () => ({
+	useToast: () => ({
+		showError: mockShowError,
+	}),
+}));
+
 const renderComponent = createComponentRenderer(MainSidebarSourceControl);
 
 describe('MainSidebarSourceControl', () => {
@@ -57,6 +65,20 @@ describe('MainSidebarSourceControl', () => {
 
 		sourceControlStore = useSourceControlStore();
 		vi.spyOn(sourceControlStore, 'isEnterpriseSourceControlEnabled', 'get').mockReturnValue(true);
+		vi.spyOn(sourceControlStore, 'prefetchPushStatus').mockResolvedValue([
+			{
+				id: 'workflow-1',
+				name: 'Workflow 1',
+				type: 'workflow',
+				status: 'modified',
+				location: 'local',
+				conflict: false,
+				file: 'workflows/workflow-1.json',
+				updatedAt: '2024-01-01T00:00:00.000Z',
+				pushed: false,
+			},
+		]);
+		mockShowError.mockReset();
 	});
 
 	it('should render nothing when not instance owner', async () => {
@@ -206,6 +228,7 @@ describe('MainSidebarSourceControl', () => {
 			});
 
 			await userEvent.click(getAllByRole('button')[1]);
+			await waitFor(() => expect(sourceControlStore.prefetchPushStatus).toHaveBeenCalled());
 			await waitFor(() =>
 				expect(mockRouterPush).toHaveBeenCalledWith({
 					query: {
@@ -213,6 +236,19 @@ describe('MainSidebarSourceControl', () => {
 					},
 				}),
 			);
+		});
+
+		it('should not navigate to push route when prefetching push status fails', async () => {
+			vi.spyOn(sourceControlStore, 'prefetchPushStatus').mockRejectedValue(new Error('Forbidden'));
+
+			const { getAllByRole } = renderComponent({
+				pinia,
+				props: { isCollapsed: false },
+			});
+
+			await userEvent.click(getAllByRole('button')[1]);
+			await waitFor(() => expect(sourceControlStore.prefetchPushStatus).toHaveBeenCalled());
+			expect(mockRouterPush).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/components/MainSidebarSourceControl.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebarSourceControl.vue
@@ -3,6 +3,7 @@ import { computed, ref } from 'vue';
 import { useI18n } from '@n8n/i18n';
 import { hasPermission } from '@/app/utils/rbac/permissions';
 import { getResourcePermissions } from '@n8n/permissions';
+import { useToast } from '@/app/composables/useToast';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import { useRoute, useRouter } from 'vue-router';
@@ -15,9 +16,11 @@ defineProps<{
 const sourceControlStore = useSourceControlStore();
 const projectStore = useProjectsStore();
 const i18n = useI18n();
+const toast = useToast();
 const route = useRoute();
 const router = useRouter();
 const tooltipOpenDelay = ref(300);
+const isLoadingPushStatus = ref(false);
 
 const currentBranch = computed(() => {
 	return sourceControlStore.preferences.branchName;
@@ -45,13 +48,34 @@ const sourceControlAvailable = computed(
 );
 
 async function pushWorkfolder() {
-	// Navigate to route with sourceControl param - modal will handle data loading and loading states
-	void router.push({
-		query: {
-			...route.query,
-			sourceControl: 'push',
-		},
-	});
+	if (isLoadingPushStatus.value) {
+		return;
+	}
+
+	isLoadingPushStatus.value = true;
+	try {
+		const status = await sourceControlStore.prefetchPushStatus();
+
+		if (!status.length) {
+			toast.showMessage({
+				title: i18n.baseText('settings.sourceControl.modals.push.everythingIsUpToDate'),
+				message: '',
+				type: 'info',
+			});
+			return;
+		}
+
+		await router.push({
+			query: {
+				...route.query,
+				sourceControl: 'push',
+			},
+		});
+	} catch (error) {
+		toast.showError(error, i18n.baseText('error'));
+	} finally {
+		isLoadingPushStatus.value = false;
+	}
 }
 
 function pullWorkfolder() {
@@ -134,7 +158,12 @@ function pullWorkfolder() {
 					<N8nButton
 						:square="isCollapsed"
 						:label="isCollapsed ? '' : i18n.baseText('settings.sourceControl.button.push')"
-						:disabled="sourceControlStore.preferences.branchReadOnly || !hasPushPermission"
+						:disabled="
+							sourceControlStore.preferences.branchReadOnly ||
+							!hasPushPermission ||
+							isLoadingPushStatus
+						"
+						:loading="isLoadingPushStatus"
 						data-test-id="main-sidebar-source-control-push"
 						icon="arrow-up"
 						type="tertiary"

--- a/packages/frontend/editor-ui/src/app/components/MainSidebarSourceControl.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebarSourceControl.vue
@@ -3,10 +3,9 @@ import { computed, ref } from 'vue';
 import { useI18n } from '@n8n/i18n';
 import { hasPermission } from '@/app/utils/rbac/permissions';
 import { getResourcePermissions } from '@n8n/permissions';
-import { useToast } from '@/app/composables/useToast';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
+import { useSourceControlModalRouting } from '@/features/integrations/sourceControl.ee/useSourceControlModalRouting';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
-import { useRoute, useRouter } from 'vue-router';
 
 import { N8nButton, N8nIcon, N8nTooltip } from '@n8n/design-system';
 defineProps<{
@@ -16,9 +15,7 @@ defineProps<{
 const sourceControlStore = useSourceControlStore();
 const projectStore = useProjectsStore();
 const i18n = useI18n();
-const toast = useToast();
-const route = useRoute();
-const router = useRouter();
+const { openPushModal, openPullModal } = useSourceControlModalRouting();
 const tooltipOpenDelay = ref(300);
 const isLoadingPushStatus = ref(false);
 
@@ -54,38 +51,10 @@ async function pushWorkfolder() {
 
 	isLoadingPushStatus.value = true;
 	try {
-		const status = await sourceControlStore.prefetchPushStatus();
-
-		if (!status.length) {
-			toast.showMessage({
-				title: i18n.baseText('settings.sourceControl.modals.push.everythingIsUpToDate'),
-				message: '',
-				type: 'info',
-			});
-			return;
-		}
-
-		await router.push({
-			query: {
-				...route.query,
-				sourceControl: 'push',
-			},
-		});
-	} catch (error) {
-		toast.showError(error, i18n.baseText('error'));
+		await openPushModal();
 	} finally {
 		isLoadingPushStatus.value = false;
 	}
-}
-
-function pullWorkfolder() {
-	// Navigate to route with sourceControl param - modal will handle the pull operation
-	void router.push({
-		query: {
-			...route.query,
-			sourceControl: 'pull',
-		},
-	});
 }
 </script>
 
@@ -136,7 +105,7 @@ function pullWorkfolder() {
 						size="mini"
 						:square="isCollapsed"
 						:label="isCollapsed ? '' : i18n.baseText('settings.sourceControl.button.pull')"
-						@click="pullWorkfolder"
+						@click="openPullModal"
 					/>
 				</N8nTooltip>
 				<N8nTooltip

--- a/packages/frontend/editor-ui/src/app/components/MainSidebarSourceControl.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainSidebarSourceControl.vue
@@ -17,7 +17,6 @@ const projectStore = useProjectsStore();
 const i18n = useI18n();
 const { openPushModal, openPullModal } = useSourceControlModalRouting();
 const tooltipOpenDelay = ref(300);
-const isLoadingPushStatus = ref(false);
 
 const currentBranch = computed(() => {
 	return sourceControlStore.preferences.branchName;
@@ -43,19 +42,6 @@ const sourceControlAvailable = computed(
 		sourceControlStore.isEnterpriseSourceControlEnabled &&
 		(hasPullPermission.value || hasPushPermission.value),
 );
-
-async function pushWorkfolder() {
-	if (isLoadingPushStatus.value) {
-		return;
-	}
-
-	isLoadingPushStatus.value = true;
-	try {
-		await openPushModal();
-	} finally {
-		isLoadingPushStatus.value = false;
-	}
-}
 </script>
 
 <template>
@@ -127,17 +113,12 @@ async function pushWorkfolder() {
 					<N8nButton
 						:square="isCollapsed"
 						:label="isCollapsed ? '' : i18n.baseText('settings.sourceControl.button.push')"
-						:disabled="
-							sourceControlStore.preferences.branchReadOnly ||
-							!hasPushPermission ||
-							isLoadingPushStatus
-						"
-						:loading="isLoadingPushStatus"
+						:disabled="sourceControlStore.preferences.branchReadOnly || !hasPushPermission"
 						data-test-id="main-sidebar-source-control-push"
 						icon="arrow-up"
 						type="tertiary"
 						size="mini"
-						@click="pushWorkfolder"
+						@click="openPushModal"
 					/>
 				</N8nTooltip>
 			</div>

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/components/SourceControlPushModal.vue
@@ -83,7 +83,9 @@ async function loadSourceControlStatus() {
 	loadingService.setLoadingText(i18n.baseText('settings.sourceControl.loading.checkingForChanges'));
 
 	try {
-		const freshStatus = await sourceControlStore.getAggregatedStatus();
+		const freshStatus =
+			sourceControlStore.takePrefetchedPushStatus() ??
+			(await sourceControlStore.getAggregatedStatus());
 
 		if (!freshStatus.length) {
 			toast.showMessage({

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.store.test.ts
@@ -180,6 +180,33 @@ describe('useSourceControlStore', () => {
 		});
 	});
 
+	describe('prefetchPushStatus', () => {
+		it('should fetch push status and cache it for the modal', async () => {
+			const mockStatus: SourceControlledFile[] = [
+				{
+					id: 'workflow1',
+					name: 'Test Workflow',
+					type: 'workflow' as const,
+					status: 'modified' as const,
+					location: 'local' as const,
+					conflict: false,
+					file: '/path/to/workflow.json',
+					updatedAt: '2024-01-01T00:00:00.000Z',
+					pushed: false,
+				},
+			];
+
+			const mockGetAggregatedStatus = vi.mocked(vcApi.getAggregatedStatus);
+			mockGetAggregatedStatus.mockResolvedValue(mockStatus);
+
+			const result = await sourceControlStore.prefetchPushStatus();
+
+			expect(mockGetAggregatedStatus).toHaveBeenCalledWith({});
+			expect(result).toEqual(mockStatus);
+			expect(sourceControlStore.takePrefetchedPushStatus()).toEqual(mockStatus);
+		});
+	});
+
 	describe('pushWorkfolder', () => {
 		it('should call API with correct parameters', async () => {
 			const data = {

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.store.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/sourceControl.store.ts
@@ -1,4 +1,4 @@
-import { computed, reactive } from 'vue';
+import { computed, reactive, ref } from 'vue';
 import { defineStore } from 'pinia';
 import { EnterpriseEditionFeature } from '@/app/constants';
 import { useSettingsStore } from '@/app/stores/settings.store';
@@ -103,6 +103,20 @@ export const useSourceControlStore = defineStore('sourceControl', () => {
 		return await vcApi.getAggregatedStatus(rootStore.restApiContext);
 	};
 
+	const prefetchedPushStatus = ref<SourceControlledFile[] | null>(null);
+
+	const prefetchPushStatus = async () => {
+		const status = await getAggregatedStatus();
+		prefetchedPushStatus.value = status;
+		return status;
+	};
+
+	const takePrefetchedPushStatus = () => {
+		const status = prefetchedPushStatus.value;
+		prefetchedPushStatus.value = null;
+		return status;
+	};
+
 	const getRemoteWorkflow = async (workflowId: string) => {
 		return await vcApi.getRemoteWorkflow(rootStore.restApiContext, workflowId);
 	};
@@ -111,6 +125,8 @@ export const useSourceControlStore = defineStore('sourceControl', () => {
 		isEnterpriseSourceControlEnabled,
 		state,
 		preferences,
+		prefetchPushStatus,
+		takePrefetchedPushStatus,
 		pushWorkfolder,
 		pullWorkfolder,
 		getPreferences,

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/useSourceControlModalRouting.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/useSourceControlModalRouting.ts
@@ -1,6 +1,3 @@
-import { useToast } from '@/app/composables/useToast';
-import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
-import { useI18n } from '@n8n/i18n';
 import { useRoute, useRouter } from 'vue-router';
 
 type SourceControlModalDirection = 'push' | 'pull';
@@ -8,12 +5,10 @@ type SourceControlModalDirection = 'push' | 'pull';
 export function useSourceControlModalRouting() {
 	const route = useRoute();
 	const router = useRouter();
-	const sourceControlStore = useSourceControlStore();
-	const i18n = useI18n();
-	const toast = useToast();
 
 	async function navigateToSourceControlModal(direction: SourceControlModalDirection) {
-		// Navigate to route with sourceControl param - modal will handle data loading and loading states
+		// Navigate to route with sourceControl param - modal will handle data loading,
+		// loading states, and backend errors (e.g. admin push required for legacy repos).
 		return await router.push({
 			query: {
 				...route.query,
@@ -22,44 +17,12 @@ export function useSourceControlModalRouting() {
 		});
 	}
 
-	function handlePushError(error: unknown) {
-		if (error instanceof Error && error.message === 'source_control_not_connected') {
-			toast.showError(
-				{ ...error, message: '' },
-				i18n.baseText('settings.sourceControl.error.not.connected.title'),
-				i18n.baseText('settings.sourceControl.error.not.connected.message'),
-			);
-			return;
-		}
-
-		toast.showError(error, i18n.baseText('error'));
-	}
-
 	async function openPullModal(): Promise<void> {
 		await navigateToSourceControlModal('pull');
 	}
 
-	/**
-	 * Prefetches push status and opens the push modal when there are changes to push.
-	 * Shows an info toast when everything is already up to date.
-	 */
 	async function openPushModal(): Promise<void> {
-		try {
-			const status = await sourceControlStore.prefetchPushStatus();
-
-			if (!status.length) {
-				toast.showMessage({
-					title: i18n.baseText('settings.sourceControl.modals.push.everythingIsUpToDate'),
-					message: '',
-					type: 'info',
-				});
-				return;
-			}
-
-			await navigateToSourceControlModal('push');
-		} catch (error) {
-			handlePushError(error);
-		}
+		await navigateToSourceControlModal('push');
 	}
 
 	return { openPushModal, openPullModal };

--- a/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/useSourceControlModalRouting.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/sourceControl.ee/useSourceControlModalRouting.ts
@@ -1,0 +1,66 @@
+import { useToast } from '@/app/composables/useToast';
+import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
+import { useI18n } from '@n8n/i18n';
+import { useRoute, useRouter } from 'vue-router';
+
+type SourceControlModalDirection = 'push' | 'pull';
+
+export function useSourceControlModalRouting() {
+	const route = useRoute();
+	const router = useRouter();
+	const sourceControlStore = useSourceControlStore();
+	const i18n = useI18n();
+	const toast = useToast();
+
+	async function navigateToSourceControlModal(direction: SourceControlModalDirection) {
+		// Navigate to route with sourceControl param - modal will handle data loading and loading states
+		return await router.push({
+			query: {
+				...route.query,
+				sourceControl: direction,
+			},
+		});
+	}
+
+	function handlePushError(error: unknown) {
+		if (error instanceof Error && error.message === 'source_control_not_connected') {
+			toast.showError(
+				{ ...error, message: '' },
+				i18n.baseText('settings.sourceControl.error.not.connected.title'),
+				i18n.baseText('settings.sourceControl.error.not.connected.message'),
+			);
+			return;
+		}
+
+		toast.showError(error, i18n.baseText('error'));
+	}
+
+	async function openPullModal(): Promise<void> {
+		await navigateToSourceControlModal('pull');
+	}
+
+	/**
+	 * Prefetches push status and opens the push modal when there are changes to push.
+	 * Shows an info toast when everything is already up to date.
+	 */
+	async function openPushModal(): Promise<void> {
+		try {
+			const status = await sourceControlStore.prefetchPushStatus();
+
+			if (!status.length) {
+				toast.showMessage({
+					title: i18n.baseText('settings.sourceControl.modals.push.everythingIsUpToDate'),
+					message: '',
+					type: 'info',
+				});
+				return;
+			}
+
+			await navigateToSourceControlModal('push');
+		} catch (error) {
+			handlePushError(error);
+		}
+	}
+
+	return { openPushModal, openPullModal };
+}


### PR DESCRIPTION
## Summary

https://www.loom.com/share/a5a717d7c2484c269d26da4c7dfa768e

Instances upgraded from a version below 1.118.0 have workflows in the connected git repository but no `projects` directory. If a non-admin pushes first after the upgrade, only their accessible project is committed, and all other projects are then deleted from the instance on the next pull.

This PR adds a guard that detects the legacy state (workflows folder present, projects folder missing on the remote tracking branch) and rejects pushes from non-admin users with a clear error message until an instance owner or admin performs the initial migration push.

As a small UX defense, the editor also now prefetches the push status when the user clicks Push and shows an "Everything is up to date" toast instead of opening an empty modal when there are no changes.

### How to test

1. Connect an instance running < 1.118.0 to a git repository and push so the remote contains a `workflows/` folder but no `projects/` folder.
2. Upgrade to a build that includes this PR.
3. Sign in as a non-admin user and attempt to push — the request should fail with a message asking for an instance owner or admin to perform the next push.
4. Sign in as an instance owner/admin and push — the initial migration should succeed and the `projects/` folder should appear on the remote.
5. After the first admin push, non-admin pushes should be allowed again as normal.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-326

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI