### PR TITLE
ci: Drop Node 26 from ci-master matrix

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [22.x, 24.15.0, 26.x]
+        node-version: [22.x, 24.15.0]
     with:
       ref: ${{ github.sha }}
       nodeVersion: ${{ matrix.node-version }}


### PR DESCRIPTION
## Summary
- Drop Node 26 from the `ci-master` unit-test matrix so master CI stops failing.
- Keeps Node 22.x and 24.15.0 (coverage stays on 24.15.0).

## Why
The `ci-master` workflow is currently red on Node 26. Root cause is `sqlite3@5.x`, which has no prebuilt binaries for Node 26 and fails to build from source against Node 26's headers. The fix is to upgrade `sqlite3` to `6.x`, which is a larger change that needs to be tackled separately.

Node 25 is not a viable interim version either — it is reaching EOL imminently and there are no maintained Alpine images we can rely on.

So this PR just removes Node 26 from the matrix to unblock master. We'll re-add it once the `sqlite3` upgrade lands.

## Test plan
- [ ] CI runs successfully on this PR (only Node 22.x and 24.15.0 in matrix)
- [ ] Master is green after merge
- [x] I have seen this code, I have run this code, and I take responsibility for this code.