### PR TITLE
ci(core): Add baseline-refresh inputs to Instance AI eval workflow

### DIFF
--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -13,6 +13,21 @@ on:
         required: false
         type: string
         default: ''
+      iterations:
+        description: 'Iterations per scenario (5 for PR runs, 10 for baseline refresh)'
+        required: false
+        type: number
+        default: 5
+      experiment_name:
+        description: 'LangSmith experiment prefix. Leave blank to auto-generate; use "instance-ai-baseline" to refresh the comparison baseline (matched by `findLatestBaseline()`).'
+        required: false
+        type: string
+        default: ''
+      timeout_minutes:
+        description: 'Job timeout in minutes (45 for PR runs, 90 for N=10 baseline)'
+        required: false
+        type: number
+        default: 45
   workflow_dispatch:
     inputs:
       branch:
@@ -23,12 +38,26 @@ on:
         description: 'Filter test cases by name (e.g. "contact-form")'
         required: false
         default: ''
+      iterations:
+        description: 'Iterations per scenario (5 for PR runs, 10 for baseline refresh)'
+        required: false
+        type: number
+        default: 5
+      experiment_name:
+        description: 'LangSmith experiment prefix. Leave blank to auto-generate; use "instance-ai-baseline" to refresh the comparison baseline.'
+        required: false
+        default: ''
+      timeout_minutes:
+        description: 'Job timeout in minutes (45 for PR runs, 90 for N=10 baseline)'
+        required: false
+        type: number
+        default: 45
 
 jobs:
   run-evals:
     name: 'Run Evals'
     runs-on: blacksmith-4vcpu-ubuntu-2204
-    timeout-minutes: 45
+    timeout-minutes: ${{ inputs.timeout_minutes }}
     env:
       # Each port hosts an independent n8n container. The eval CLI's
       # work-stealing allocator dispatches builds across them, capped per-lane.
@@ -178,8 +207,9 @@ jobs:
             --base-url "$BASE_URLS" \
             --concurrency 32 \
             --verbose \
-            --iterations 5 \
-            ${{ inputs.filter && format('--filter "{0}"', inputs.filter) || '' }}
+            --iterations ${{ inputs.iterations }} \
+            ${{ inputs.filter && format('--filter "{0}"', inputs.filter) || '' }} \
+            ${{ inputs.experiment_name && format('--experiment-name "{0}"', inputs.experiment_name) || '' }}
 
       # Captures sandbox/builder/Daytona signals that surface during the eval
       # (after migrations finish). Two layers of secret-leak defense:

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -57,7 +57,7 @@ jobs:
   run-evals:
     name: 'Run Evals'
     runs-on: blacksmith-4vcpu-ubuntu-2204
-    timeout-minutes: ${{ inputs.timeout_minutes }}
+    timeout-minutes: ${{ fromJSON(inputs.timeout_minutes) }}
     env:
       # Each port hosts an independent n8n container. The eval CLI's
       # work-stealing allocator dispatches builds across them, capped per-lane.


### PR DESCRIPTION
## Summary

Adds three `workflow_dispatch` + `workflow_call` inputs to `test-evals-instance-ai.yml`:

- `iterations` (default `5`) — bump to `10` for baseline refresh
- `experiment_name` (default `''`) — set to `instance-ai-baseline` to refresh the comparison baseline (matched by `findLatestBaseline()` in `evaluations/comparison/fetch-baseline.ts`)
- `timeout_minutes` (default `45`) — bump to `90` for N=10

Defaults preserve current PR behaviour. The reusable caller in `ci-pull-requests.yml` only passes `branch`, so existing PR runs are unaffected.

## Why

We haven't refreshed the Instance AI workflow-eval baseline since the April 22 N=10 run, which only had 8 test cases / 27 scenarios. The project is now at 14 test cases / 35 scenarios — new scenarios end up in `prOnly` and don't count toward aggregate or regression detection, biasing PR signal toward stale data.

This change exposes the knobs needed to dispatch a refresh on demand without touching the rest of the eval pipeline.

## How to refresh the baseline (after this lands or via `--ref` from this branch)

\`\`\`
gh workflow run \"Test: Instance AI Exec Evals\" --ref <branch> \\
  -f branch=master \\
  -f experiment_name=instance-ai-baseline \\
  -f iterations=10 \\
  -f timeout_minutes=90
\`\`\`

LangSmith appends a random suffix, producing \`instance-ai-baseline-<suffix>\` which subsequent PR runs auto-detect.

## Test plan

- [ ] This PR's own eval run (triggered via the path filter) completes in ~22 min at N=5 — confirms defaults are preserved
- [ ] Manual dispatch with \`experiment_name=baseline-pretest iterations=10\` produces a LangSmith project named \`baseline-pretest-<suffix>\` (not \`instance-ai-baseline-*\` so it doesn't displace the existing baseline)
- [ ] Manual dispatch with \`experiment_name=instance-ai-baseline iterations=10\` produces \`instance-ai-baseline-<suffix>\` and \`findLatestBaseline()\` resolves to it on subsequent PR runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)