### PR TITLE
fix(core): Prevent multi-main crash loop from expired license certificate on restart

### DIFF
--- a/packages/@n8n/constants/src/time.ts
+++ b/packages/@n8n/constants/src/time.ts
@@ -15,9 +15,11 @@ export const Time = {
 	},
 	hours: {
 		toMilliseconds: 60 * 60 * 1000,
+		toMinutes: 60,
 		toSeconds: 60 * 60,
 	},
 	days: {
+		toMinutes: 24 * 60,
 		toSeconds: 24 * 60 * 60,
 		toMilliseconds: 24 * 60 * 60 * 1000,
 	},

--- a/packages/cli/src/__tests__/license.test.ts
+++ b/packages/cli/src/__tests__/license.test.ts
@@ -233,30 +233,39 @@ describe('License', () => {
 			{
 				instanceType: 'main' as const,
 				isLeader: true,
-				shouldReload: false,
-				description: 'Leader main should not reload',
+				expectedAction: 'log' as const,
+				expectedOffset: 24 * 60,
+				description: 'Leader main should log critical warning 24h before expiry',
 			},
 			{
 				instanceType: 'main' as const,
 				isLeader: false,
-				shouldReload: true,
-				description: 'Follower main should reload',
+				expectedAction: 'reload' as const,
+				expectedOffset: 120,
+				description: 'Follower main should reload 2h before expiry',
 			},
 			{
 				instanceType: 'worker' as const,
 				isLeader: false,
-				shouldReload: true,
-				description: 'Worker should reload',
+				expectedAction: 'reload' as const,
+				expectedOffset: 120,
+				description: 'Worker should reload 2h before expiry',
 			},
 			{
 				instanceType: 'webhook' as const,
 				isLeader: false,
-				shouldReload: true,
-				description: 'Webhook should reload',
+				expectedAction: 'reload' as const,
+				expectedOffset: 120,
+				description: 'Webhook should reload 2h before expiry',
 			},
-		])('$description', async ({ instanceType, isLeader, shouldReload }) => {
+		])('$description', async ({ instanceType, isLeader, expectedAction, expectedOffset }) => {
 			const logger = mockLogger();
 			const reloadSpy = jest.spyOn(License.prototype, 'reload').mockResolvedValueOnce();
+			if (expectedAction === 'log') {
+				jest
+					.spyOn(License.prototype, 'getExpiryDate')
+					.mockReturnValueOnce(new Date('2026-05-15T00:00:00.000Z'));
+			}
 			const instanceSettings = mock<InstanceSettings>({ instanceType });
 			Object.defineProperty(instanceSettings, 'isLeader', { get: () => isLeader });
 
@@ -275,13 +284,19 @@ describe('License', () => {
 			const licenseManagerCall = calls[calls.length - 1][0];
 			const onExpirySoon = licenseManagerCall.onExpirySoon;
 
-			if (shouldReload) {
-				expect(onExpirySoon).toBeDefined();
-				onExpirySoon!();
-				expect(reloadSpy).toHaveBeenCalled();
-			} else {
-				expect(onExpirySoon).toBeUndefined();
+			expect(onExpirySoon).toBeDefined();
+			expect(licenseManagerCall.expirySoonOffsetMins).toBe(expectedOffset);
+
+			onExpirySoon!();
+
+			if (expectedAction === 'log') {
+				expect(logger.scoped('license').error).toHaveBeenCalledWith(
+					'License is expiring within 24h.',
+					{ expiryDate: '2026-05-15T00:00:00.000Z' },
+				);
 				expect(reloadSpy).not.toHaveBeenCalled();
+			} else {
+				expect(reloadSpy).toHaveBeenCalled();
 			}
 		});
 	});

--- a/packages/cli/src/__tests__/license.test.ts
+++ b/packages/cli/src/__tests__/license.test.ts
@@ -291,7 +291,7 @@ describe('License', () => {
 
 			if (expectedAction === 'log') {
 				expect(logger.scoped('license').error).toHaveBeenCalledWith(
-					'License is expiring within 24h.',
+					expect.stringContaining('License is expiring'),
 					{ expiryDate: '2026-05-15T00:00:00.000Z' },
 				);
 				expect(reloadSpy).not.toHaveBeenCalled();

--- a/packages/cli/src/commands/__tests__/start.test.ts
+++ b/packages/cli/src/commands/__tests__/start.test.ts
@@ -355,5 +355,38 @@ describe('Start - AuthRolesService initialization', () => {
 			// Followers only retry via reload; leaders should fail immediately
 			expect(license.reload).not.toHaveBeenCalled();
 		});
+
+		it('should attempt to renew license before throwing when leader fails the license check', async () => {
+			setupInstanceSettings('main', true, true);
+			// @ts-expect-error - Accessing protected property for testing
+			start.globalConfig = multiMainConfig;
+
+			license.isMultiMainLicensed = jest
+				.fn()
+				.mockReturnValueOnce(false)
+				.mockReturnValue(true) as unknown as typeof license.isMultiMainLicensed;
+
+			await expect(start.init()).resolves.not.toThrow();
+			expect(license.renew).toHaveBeenCalled();
+		});
+
+		it('should throw FeatureNotLicensedError when leader renewal rejects', async () => {
+			setupInstanceSettings('main', true, true);
+			// @ts-expect-error - Accessing protected property for testing
+			start.globalConfig = multiMainConfig;
+
+			license.isMultiMainLicensed = jest
+				.fn()
+				.mockReturnValue(false) as unknown as typeof license.isMultiMainLicensed;
+			license.renew = jest
+				.fn()
+				.mockRejectedValue(
+					new Error('license server unreachable'),
+				) as unknown as typeof license.renew;
+
+			await expect(start.init()).rejects.toThrow(FeatureNotLicensedError);
+			expect(license.renew).toHaveBeenCalled();
+			expect(license.reload).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -14,7 +14,7 @@ import glob from 'fast-glob';
 import { createReadStream, createWriteStream, existsSync } from 'fs';
 import { mkdir } from 'fs/promises';
 import { BinaryDataConfig } from 'n8n-core';
-import { jsonParse, sleep, type IWorkflowExecutionDataProcess } from 'n8n-workflow';
+import { ensureError, jsonParse, sleep, type IWorkflowExecutionDataProcess } from 'n8n-workflow';
 import path from 'path';
 import replaceStream from 'replacestream';
 import { pipeline } from 'stream/promises';
@@ -351,7 +351,7 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 			} catch (error) {
 				this.logger.error(
 					'Failed to renew multi-main license during boot; license check will likely fail',
-					{ error: error instanceof Error ? error.message : error },
+					{ error: ensureError(error) },
 				);
 			}
 			if (this.license.isMultiMainLicensed()) return;

--- a/packages/cli/src/commands/start.ts
+++ b/packages/cli/src/commands/start.ts
@@ -345,6 +345,18 @@ export class Start extends BaseCommand<z.infer<typeof flagsSchema>> {
 	private async ensureMultiMainLicensed() {
 		if (this.license.isMultiMainLicensed()) return;
 
+		if (this.instanceSettings.isLeader) {
+			try {
+				await this.license.renew();
+			} catch (error) {
+				this.logger.error(
+					'Failed to renew multi-main license during boot; license check will likely fail',
+					{ error: error instanceof Error ? error.message : error },
+				);
+			}
+			if (this.license.isMultiMainLicensed()) return;
+		}
+
 		if (!this.instanceSettings.isLeader) {
 			const maxRetries = 5;
 			for (let attempt = 1; attempt <= maxRetries; attempt++) {

--- a/packages/cli/src/license.ts
+++ b/packages/cli/src/license.ts
@@ -83,8 +83,7 @@ export class License implements LicenseProvider {
 		const collectPassthroughData = isMainInstance
 			? async () => await this.licenseMetricsService.collectPassthroughData()
 			: async () => ({});
-		const onExpirySoon = !this.instanceSettings.isLeader ? () => this.onExpirySoon() : undefined;
-		const expirySoonOffsetMins = !this.instanceSettings.isLeader ? 120 : undefined;
+		const expirySoonOffsetMins = this.instanceSettings.isLeader ? 24 * 60 : 120;
 
 		const { isLeader } = this.instanceSettings;
 		const { autoRenewalEnabled } = this.globalConfig.license;
@@ -114,7 +113,7 @@ export class License implements LicenseProvider {
 				collectPassthroughData,
 				onFeatureChange,
 				onLicenseRenewed,
-				onExpirySoon,
+				onExpirySoon: () => this.onExpirySoon(),
 				expirySoonOffsetMins,
 			});
 
@@ -518,18 +517,24 @@ export class License implements LicenseProvider {
 	}
 
 	private onExpirySoon() {
-		this.logger.info('License is about to expire soon, reloading license...');
-
-		// reload in background to avoid blocking SDK
-
-		void this.reload()
-			.then(() => {
-				this.logger.info('Reloaded license on expiry soon');
-			})
-			.catch((error) => {
-				this.logger.error('Failed to reload license on expiry soon', {
-					error: error instanceof Error ? error.message : error,
-				});
+		if (this.instanceSettings.isLeader) {
+			this.logger.error('License is expiring within 24h.', {
+				expiryDate: this.getExpiryDate()?.toISOString() ?? null,
 			});
+		} else {
+			this.logger.info('License is about to expire soon, reloading license...');
+
+			// reload in background to avoid blocking SDK
+
+			void this.reload()
+				.then(() => {
+					this.logger.info('Reloaded license on expiry soon');
+				})
+				.catch((error) => {
+					this.logger.error('Failed to reload license on expiry soon', {
+						error: error instanceof Error ? error.message : error,
+					});
+				});
+		}
 	}
 }

--- a/packages/cli/src/license.ts
+++ b/packages/cli/src/license.ts
@@ -83,7 +83,9 @@ export class License implements LicenseProvider {
 		const collectPassthroughData = isMainInstance
 			? async () => await this.licenseMetricsService.collectPassthroughData()
 			: async () => ({});
-		const expirySoonOffsetMins = this.instanceSettings.isLeader ? 24 * 60 : 120;
+		const expirySoonOffsetMins = this.instanceSettings.isLeader
+			? Time.days.toMinutes
+			: 2 * Time.hours.toMinutes;
 
 		const { isLeader } = this.instanceSettings;
 		const { autoRenewalEnabled } = this.globalConfig.license;
@@ -518,9 +520,10 @@ export class License implements LicenseProvider {
 
 	private onExpirySoon() {
 		if (this.instanceSettings.isLeader) {
-			this.logger.error('License is expiring within 24h.', {
-				expiryDate: this.getExpiryDate()?.toISOString() ?? null,
-			});
+			this.logger.error(
+				'License is expiring within 24h and automatic renewal has not yet succeeded. Verify network connectivity to the license server and that license.autoRenewalEnabled is true.',
+				{ expiryDate: this.getExpiryDate()?.toISOString() ?? null },
+			);
 		} else {
 			this.logger.info('License is about to expire soon, reloading license...');
 


### PR DESCRIPTION
## Summary

When a multi-main leader's license cert expires (e.g. the instance was offline at renewal time), the boot-time multi-main license check fails and the instance crashes without ever attempting to recover. This PR makes recovery possible:

- **Renew on boot:** if the leader fails the multi-main license check on startup, it now attempts `license.renew()` once before throwing `FeatureNotLicensedError`. If the renewal succeeds, boot continues normally.
- **Early warning on the leader:** previously, only followers got an `onExpirySoon` callback (2h before expiry, triggering a reload). The leader now also subscribes to `onExpirySoon` with a 24h offset and logs a critical-level message so operators have a full day's heads-up to investigate before the cert lapses.

### How to test

- Unit tests cover the new behavior in `packages/cli/src/__tests__/license.test.ts` and `packages/cli/src/commands/__tests__/start.test.ts`:
  - Leader renew-on-boot succeeds → no throw.
  - Leader renew-on-boot rejects → `FeatureNotLicensedError`, no reload attempted.
  - Leader gets `onExpirySoon` at 24h offset and logs (does not reload).
  - Followers/workers/webhooks keep the existing 2h reload behavior.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2794

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI