### PR TITLE
fix: Improve AI builder reliability for Sheets and workflow lookups

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
@@ -291,7 +291,29 @@ async function handleList(context: InstanceAiContext, input: Extract<Input, { ac
 }
 
 async function handleGet(context: InstanceAiContext, input: Extract<Input, { action: 'get' }>) {
-	return await context.workflowService.get(input.workflowId);
+	// Hallucinated workflow IDs (e.g. `wf-foo`, `telegram-chatbot`) come back as
+	// unhandled tool errors otherwise, which the agent then retries with another
+	// invented id. Convert the error into a structured "not found" response
+	// surfacing the list of accessible workflows so the agent can self-correct
+	// without burning more turns guessing.
+	try {
+		return await context.workflowService.get(input.workflowId);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : 'Failed to fetch workflow';
+		const available = await context.workflowService
+			.list({ limit: 25 })
+			.then((items) => items.map((w) => ({ id: w.id, name: w.name })))
+			.catch(() => [] as Array<{ id: string; name: string }>);
+		return {
+			workflowId: input.workflowId,
+			found: false as const,
+			error: message,
+			availableWorkflows: available,
+			hint:
+				'No workflow exists with that id. Pick one from `availableWorkflows` or call `workflows(action="list")` for the current set. ' +
+				'Do not retry with a guessed id — if the user did not provide one, you are building a new workflow.',
+		};
+	}
 }
 
 async function handleGetAsCode(

--- a/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
@@ -291,11 +291,7 @@ async function handleList(context: InstanceAiContext, input: Extract<Input, { ac
 }
 
 async function handleGet(context: InstanceAiContext, input: Extract<Input, { action: 'get' }>) {
-	// Hallucinated workflow IDs (e.g. `wf-foo`, `telegram-chatbot`) come back as
-	// unhandled tool errors otherwise, which the agent then retries with another
-	// invented id. Convert the error into a structured "not found" response
-	// surfacing the list of accessible workflows so the agent can self-correct
-	// without burning more turns guessing.
+	// Convert hallucinated-id errors into structured not-found responses so the agent stops guessing.
 	try {
 		return await context.workflowService.get(input.workflowId);
 	} catch (error) {

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/appendOrUpdate.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/appendOrUpdate.operation.ts
@@ -8,9 +8,9 @@ import { NodeOperationError } from 'n8n-workflow';
 
 import {
 	cellFormat,
-	columnsResourceMapperBuilderHint,
 	handlingExtraData,
 	locationDefine,
+	upsertColumnsResourceMapperBuilderHint,
 	useAppendOption,
 } from './commonDescription';
 import type { GoogleSheet } from '../../helpers/GoogleSheet';
@@ -172,7 +172,7 @@ export const description: SheetProperties = [
 			value: null,
 		},
 		required: true,
-		builderHint: columnsResourceMapperBuilderHint,
+		builderHint: upsertColumnsResourceMapperBuilderHint,
 		typeOptions: {
 			loadOptionsDependsOn: ['sheetName.value'],
 			resourceMapper: {
@@ -208,7 +208,7 @@ export const description: SheetProperties = [
 			value: null,
 		},
 		required: true,
-		builderHint: columnsResourceMapperBuilderHint,
+		builderHint: upsertColumnsResourceMapperBuilderHint,
 		typeOptions: {
 			loadOptionsDependsOn: ['sheetName.value'],
 			resourceMapper: {

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/commonDescription.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/commonDescription.ts
@@ -1,29 +1,10 @@
 import type { INodeProperties, IParameterBuilderHint } from 'n8n-workflow';
 
-/**
- * Builder hint for the Google Sheets `columns` resourceMapper on the `append`
- * operation. The full resourceMapper object shape is non-obvious, and a bare
- * string like `'autoMapInputData'` silently fails validation. The matching
- * `<patterns>` example lives on the node-level `builderHint.extraTypeDefContent`
- * in `Google/Sheet/GoogleSheets.node.ts`.
- *
- * `append` is plain insert — it does NOT need `matchingColumns`; that field is
- * specific to `appendOrUpdate` / `update` (see `upsertColumnsResourceMapperBuilderHint`).
- */
 export const columnsResourceMapperBuilderHint: IParameterBuilderHint = {
 	propertyHint:
 		"Pass the full resourceMapper object: { mappingMode, value, schema }. A bare string like 'autoMapInputData' fails validation. `append` is plain insert \u2014 do NOT add `matchingColumns` here (that is for the `appendOrUpdate` and `update` operations).",
 };
 
-/**
- * Builder hint for the `columns` resourceMapper on the `appendOrUpdate` and
- * `update` operations. These read `columns.matchingColumns` at execution time
- * (see `appendOrUpdate.operation.ts` and `update.operation.ts`); when the
- * array is missing or empty the node throws `Could not get parameter` mid-run
- * with no recovery. The agent regularly omits `matchingColumns` because the
- * generated TypeScript type marks it as optional, so we surface the
- * requirement here.
- */
 export const upsertColumnsResourceMapperBuilderHint: IParameterBuilderHint = {
 	propertyHint:
 		"Pass the full resourceMapper object: { mappingMode, value, schema, matchingColumns }. `matchingColumns` is REQUIRED for this operation \u2014 it must be a non-empty `string[]` of header names that uniquely identify the row to update; without it the node throws 'Could not get parameter' at runtime. Use the `append` operation instead if there is no key column to match on. A bare string like 'autoMapInputData' silently fails validation; always send the full resourceMapper object.",

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/commonDescription.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/commonDescription.ts
@@ -1,16 +1,32 @@
 import type { INodeProperties, IParameterBuilderHint } from 'n8n-workflow';
 
 /**
- * Builder hint shared by every Google Sheets `columns` resourceMapper parameter
- * (append, appendOrUpdate, update). The full resourceMapper object shape is
- * non-obvious, and a bare string like `'autoMapInputData'` silently fails
- * validation. The matching `<patterns>` example lives on the node-level
- * `builderHint.extraTypeDefContent` in `Google/Sheet/GoogleSheets.node.ts`,
- * gated by `displayOptions: { show: { resource: ['sheet'], operation: [...] } }`.
+ * Builder hint for the Google Sheets `columns` resourceMapper on the `append`
+ * operation. The full resourceMapper object shape is non-obvious, and a bare
+ * string like `'autoMapInputData'` silently fails validation. The matching
+ * `<patterns>` example lives on the node-level `builderHint.extraTypeDefContent`
+ * in `Google/Sheet/GoogleSheets.node.ts`.
+ *
+ * `append` is plain insert — it does NOT need `matchingColumns`; that field is
+ * specific to `appendOrUpdate` / `update` (see `upsertColumnsResourceMapperBuilderHint`).
  */
 export const columnsResourceMapperBuilderHint: IParameterBuilderHint = {
 	propertyHint:
-		"Pass the full resourceMapper object: { mappingMode, value, schema }. A bare string like 'autoMapInputData' fails validation.",
+		"Pass the full resourceMapper object: { mappingMode, value, schema }. A bare string like 'autoMapInputData' fails validation. `append` is plain insert \u2014 do NOT add `matchingColumns` here (that is for the `appendOrUpdate` and `update` operations).",
+};
+
+/**
+ * Builder hint for the `columns` resourceMapper on the `appendOrUpdate` and
+ * `update` operations. These read `columns.matchingColumns` at execution time
+ * (see `appendOrUpdate.operation.ts` and `update.operation.ts`); when the
+ * array is missing or empty the node throws `Could not get parameter` mid-run
+ * with no recovery. The agent regularly omits `matchingColumns` because the
+ * generated TypeScript type marks it as optional, so we surface the
+ * requirement here.
+ */
+export const upsertColumnsResourceMapperBuilderHint: IParameterBuilderHint = {
+	propertyHint:
+		"Pass the full resourceMapper object: { mappingMode, value, schema, matchingColumns }. `matchingColumns` is REQUIRED for this operation \u2014 it must be a non-empty `string[]` of header names that uniquely identify the row to update; without it the node throws 'Could not get parameter' at runtime. Use the `append` operation instead if there is no key column to match on. A bare string like 'autoMapInputData' silently fails validation; always send the full resourceMapper object.",
 };
 
 export const dataLocationOnSheet: INodeProperties = {

--- a/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/update.operation.ts
+++ b/packages/nodes-base/nodes/Google/Sheet/v2/actions/sheet/update.operation.ts
@@ -3,9 +3,9 @@ import { NodeOperationError, UserError } from 'n8n-workflow';
 
 import {
 	cellFormat,
-	columnsResourceMapperBuilderHint,
 	handlingExtraData,
 	locationDefine,
+	upsertColumnsResourceMapperBuilderHint,
 } from './commonDescription';
 import type { GoogleSheet } from '../../helpers/GoogleSheet';
 import {
@@ -162,7 +162,7 @@ export const description: SheetProperties = [
 			value: null,
 		},
 		required: true,
-		builderHint: columnsResourceMapperBuilderHint,
+		builderHint: upsertColumnsResourceMapperBuilderHint,
 		typeOptions: {
 			loadOptionsDependsOn: ['sheetName.value'],
 			resourceMapper: {
@@ -198,7 +198,7 @@ export const description: SheetProperties = [
 			value: null,
 		},
 		required: true,
-		builderHint: columnsResourceMapperBuilderHint,
+		builderHint: upsertColumnsResourceMapperBuilderHint,
 		typeOptions: {
 			loadOptionsDependsOn: ['sheetName.value'],
 			resourceMapper: {


### PR DESCRIPTION
## Summary

Two small, narrowly-scoped fixes that came out of an autoresearch experiment as the most defensible mechanism-aligned wins: independent of the broader pre-submit validator layer that loop also produced. Both target concrete, reproducible runtime failures the AI workflow builder kept hitting on real evals.

### 1. Google Sheets `columns` builderHint split

The shared `columnsResourceMapperBuilderHint` was reused by `append`, `appendOrUpdate`, and `update`. The hint never mentioned `matchingColumns`, so when the agent built `appendOrUpdate`/`update` it consistently omitted the field — and the node then threw `Could not get parameter` mid-execution with no recovery path.

- `append` now gets a tightened hint explicitly stating `matchingColumns` must **not** be set (it's not part of the operation).
- `appendOrUpdate` and `update` use a new `upsertColumnsResourceMapperBuilderHint` that states `matchingColumns` is **required** and must be a non-empty `string[]` of header names.
- The hint surfaces via `nodes(action="type-definition")`, so any builder benefits — not just Instance AI.

### 2. `workflows(action="get")` not-found recovery

Hallucinated workflow IDs (`wf-foo`, `telegram-chatbot`, …) used to raise an unhandled tool exception. The agent would react by retrying with another invented ID. Turn after turn was wasted; in some scenarios the run timed out before the agent recovered.

- Now returns a structured `{ workflowId, found: false, error, availableWorkflows, hint }` with up to 25 accessible workflows the agent can choose from and a hint to stop guessing.
- A real lookup still returns the workflow unchanged — strictly-better tool response.

## Data backing the changes

From the autoresearch loop (20 runs on a 6-case × 3-iter golden suite). Honest aggregates use the mean of 3 same-commit reruns at the kept state; the per-scenario evidence is more defensible than the suite-level metric (`pass_hat_3` has a ~16pp stdev on this suite size).

| metric | baseline (n=1) | with these fixes + validator layer (n=3) |
|---|---|---|
| `pass@3` (credible band, ±5pp) | 73.33 | ~80 |
| `pass_hat_3` (±16pp) | 23.70 | ~30 |

**Per-scenario, attributable to these two specific changes:**

- **Google Sheets matchingColumns hint** — `contact-form` `missing-fields` and `empty-message`: 1/3 → 2-3/3 each, reproduced across runs since iter #3. Mechanism: the agent reads the per-operation hint when calling `nodes(action="type-definition")` for `appendOrUpdate` and supplies `matchingColumns` on the first try.
- **`workflows.get` recovery** — eliminates the turn-burning retry loop on hallucinated IDs; lets the agent recover in one turn instead of N. Direct contribution to several full-suite scenario completions where the agent now lists existing workflows instead of timing out.

Full report and per-iteration log: `autoresearch.report.md` on the [autoresearch worktree branch](https://github.com/n8n-io/n8n/tree/autoresearch/optimise-instance-ai-loop).


## Related Linear tickets, Github issues, and Community forum posts

_None directly._ This work originated from the internal autoresearch loop on workflow-builder reliability.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.