### PR TITLE
refactor(editor): Refactor push connection handlers to call composables in setup context

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/MainHeader.vue
@@ -30,7 +30,7 @@ import { useToast } from '@/app/composables/useToast';
 const router = useRouter();
 const route = useRoute();
 const locale = useI18n();
-const pushConnection = usePushConnection({ router });
+const pushConnection = usePushConnection();
 const toast = useToast();
 const ndvStore = injectNDVStore();
 const uiStore = useUIStore();

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/builderCreditsUpdated.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/builderCreditsUpdated.test.ts
@@ -1,4 +1,4 @@
-import { builderCreditsUpdated } from './builderCreditsUpdated';
+import { useBuilderCreditsUpdated } from './builderCreditsUpdated';
 import type { BuilderCreditsPushMessage } from '@n8n/api-types/push/builder-credits';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 
@@ -14,6 +14,8 @@ describe('builderCreditsUpdated', () => {
 		} as unknown as ReturnType<typeof useBuilderStore>;
 
 		vi.mocked(useBuilderStore).mockReturnValue(mockStore);
+
+		const { builderCreditsUpdated } = useBuilderCreditsUpdated();
 
 		const event: BuilderCreditsPushMessage = {
 			type: 'updateBuilderCredits',

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/builderCreditsUpdated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/builderCreditsUpdated.ts
@@ -1,9 +1,13 @@
 import type { BuilderCreditsPushMessage } from '@n8n/api-types/push/builder-credits';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 
-export async function builderCreditsUpdated(event: BuilderCreditsPushMessage): Promise<void> {
+export function useBuilderCreditsUpdated() {
 	const builderStore = useBuilderStore();
 
-	// Update the builder store with new credits values
-	builderStore.updateBuilderCredits(event.data.creditsQuota, event.data.creditsClaimed);
+	async function builderCreditsUpdated(event: BuilderCreditsPushMessage): Promise<void> {
+		// Update the builder store with new credits values
+		builderStore.updateBuilderCredits(event.data.creditsQuota, event.data.creditsClaimed);
+	}
+
+	return { builderCreditsUpdated };
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 import { useExecutionFinished, type SimplifiedExecution } from './executionFinished';
 import type { IRunExecutionData, ITaskData, INodeTypeDescription } from 'n8n-workflow';
@@ -84,16 +84,31 @@ vi.mock('@/app/composables/useExternalHooks', () => ({
 	})),
 }));
 
+let executionFinished: ReturnType<typeof useExecutionFinished>['executionFinished'];
+let continueEvaluationLoop: ReturnType<typeof useExecutionFinished>['continueEvaluationLoop'];
+let getRunExecutionData: ReturnType<typeof useExecutionFinished>['getRunExecutionData'];
+let handleExecutionFinishedWithSuccessOrOther: ReturnType<
+	typeof useExecutionFinished
+>['handleExecutionFinishedWithSuccessOrOther'];
+let handleExecutionFinishedWithErrorOrCanceled: ReturnType<
+	typeof useExecutionFinished
+>['handleExecutionFinishedWithErrorOrCanceled'];
+
+beforeEach(() => {
+	vi.resetAllMocks();
+	setActivePinia(createTestingPinia());
+
+	({
+		executionFinished,
+		continueEvaluationLoop,
+		getRunExecutionData,
+		handleExecutionFinishedWithSuccessOrOther,
+		handleExecutionFinishedWithErrorOrCanceled,
+	} = useExecutionFinished());
+});
+
 describe('continueEvaluationLoop()', () => {
-	beforeEach(() => {
-		vi.resetAllMocks();
-	});
-
 	it('should call runWorkflow() if workflow has eval trigger that executed successfully with rows left', () => {
-		const pinia = createTestingPinia();
-		setActivePinia(pinia);
-
-		const { continueEvaluationLoop } = useExecutionFinished();
 		const evalTriggerNodeName = 'eval-trigger';
 		const evalTriggerNodeData = mock<ITaskData>({
 			data: {
@@ -139,10 +154,6 @@ describe('continueEvaluationLoop()', () => {
 	});
 
 	it('should not call runWorkflow() if workflow execution status is not success', () => {
-		const pinia = createTestingPinia();
-		setActivePinia(pinia);
-
-		const { continueEvaluationLoop } = useExecutionFinished();
 		const execution = mock<SimplifiedExecution>({
 			status: 'error',
 			workflowData: {
@@ -166,10 +177,6 @@ describe('continueEvaluationLoop()', () => {
 	});
 
 	it('should not call runWorkflow() if eval trigger node does not exist in workflow', () => {
-		const pinia = createTestingPinia();
-		setActivePinia(pinia);
-
-		const { continueEvaluationLoop } = useExecutionFinished();
 		const execution = mock<SimplifiedExecution>({
 			status: 'success',
 			workflowData: {
@@ -188,10 +195,6 @@ describe('continueEvaluationLoop()', () => {
 	});
 
 	it('should not call runWorkflow() if eval trigger node exists but has no run data', () => {
-		const pinia = createTestingPinia();
-		setActivePinia(pinia);
-
-		const { continueEvaluationLoop } = useExecutionFinished();
 		const evalTriggerNodeName = 'eval-trigger';
 		const execution = mock<SimplifiedExecution>({
 			status: 'success',
@@ -216,10 +219,6 @@ describe('continueEvaluationLoop()', () => {
 	});
 
 	it('should not call runWorkflow() if eval trigger node run data has no rows left', () => {
-		const pinia = createTestingPinia();
-		setActivePinia(pinia);
-
-		const { continueEvaluationLoop } = useExecutionFinished();
 		const evalTriggerNodeName = 'eval-trigger';
 		const evalTriggerNodeData = mock<ITaskData>({
 			data: {
@@ -263,7 +262,6 @@ describe('continueEvaluationLoop()', () => {
 
 describe('getRunExecutionData()', () => {
 	it('should preserve pushRef from execution data', () => {
-		const { getRunExecutionData } = useExecutionFinished();
 		const execution = mock<SimplifiedExecution>({
 			data: {
 				pushRef: 'test-push-ref-12345',
@@ -279,7 +277,6 @@ describe('getRunExecutionData()', () => {
 	});
 
 	it('should handle missing pushRef gracefully', () => {
-		const { getRunExecutionData } = useExecutionFinished();
 		const execution = mock<SimplifiedExecution>({
 			data: {
 				resultData: {
@@ -295,13 +292,7 @@ describe('getRunExecutionData()', () => {
 });
 
 describe('executionFinished', () => {
-	beforeEach(() => {
-		const pinia = createTestingPinia();
-		setActivePinia(pinia);
-	});
-
 	it('should clear lastAddedExecutingNode when execution is finished', async () => {
-		const { executionFinished } = useExecutionFinished();
 		mockWorkflowState.executingNode.lastAddedExecutingNode = 'test-node';
 
 		await executionFinished({
@@ -318,10 +309,6 @@ describe('executionFinished', () => {
 
 	describe('ready-to-run AI workflow tracking', () => {
 		it('should track successful execution of ready-to-run-ai-workflow', async () => {
-			const pinia = createTestingPinia();
-			setActivePinia(pinia);
-			const { executionFinished } = useExecutionFinished();
-
 			const workflowsStore = useWorkflowsStore();
 			const workflowsListStore = useWorkflowsListStore();
 			const readyToRunStore = useReadyToRunStore();
@@ -351,10 +338,6 @@ describe('executionFinished', () => {
 		});
 
 		it('should track failed execution of ready-to-run-ai-workflow', async () => {
-			const pinia = createTestingPinia();
-			setActivePinia(pinia);
-			const { executionFinished } = useExecutionFinished();
-
 			const workflowsStore = useWorkflowsStore();
 			const workflowsListStore = useWorkflowsListStore();
 			const readyToRunStore = useReadyToRunStore();
@@ -381,10 +364,6 @@ describe('executionFinished', () => {
 		});
 
 		it('should track execution of ready-to-run-ai-workflow-v5', async () => {
-			const pinia = createTestingPinia();
-			setActivePinia(pinia);
-			const { executionFinished } = useExecutionFinished();
-
 			const workflowsStore = useWorkflowsStore();
 			const workflowsListStore = useWorkflowsListStore();
 			const readyToRunStore = useReadyToRunStore();
@@ -414,10 +393,6 @@ describe('executionFinished', () => {
 		});
 
 		it('should track execution of ready-to-run-ai-workflow-v6', async () => {
-			const pinia = createTestingPinia();
-			setActivePinia(pinia);
-			const { executionFinished } = useExecutionFinished();
-
 			const workflowsStore = useWorkflowsStore();
 			const workflowsListStore = useWorkflowsListStore();
 			const readyToRunStore = useReadyToRunStore();
@@ -444,10 +419,6 @@ describe('executionFinished', () => {
 		});
 
 		it('should not track execution for non-ready-to-run workflows', async () => {
-			const pinia = createTestingPinia();
-			setActivePinia(pinia);
-			const { executionFinished } = useExecutionFinished();
-
 			const workflowsStore = useWorkflowsStore();
 			const workflowsListStore = useWorkflowsListStore();
 			const readyToRunStore = useReadyToRunStore();
@@ -480,17 +451,6 @@ describe('executionFinished', () => {
 	});
 
 	it('should return early and clear active execution when fetchExecutionData returns undefined', async () => {
-		const pinia = createTestingPinia({
-			initialState: {
-				workflows: {
-					activeExecutionId: '123',
-				},
-			},
-		});
-
-		setActivePinia(pinia);
-		const { executionFinished } = useExecutionFinished();
-
 		const workflowsStore = mockedStore(useWorkflowsStore);
 		const workflowsListStore = mockedStore(useWorkflowsListStore);
 		const uiStore = mockedStore(useUIStore);
@@ -525,17 +485,6 @@ describe('executionFinished', () => {
 	});
 
 	it('should clear executing node queue even when fetchExecutionData returns undefined', async () => {
-		const pinia = createTestingPinia({
-			initialState: {
-				workflows: {
-					activeExecutionId: '123',
-				},
-			},
-		});
-
-		setActivePinia(pinia);
-		const { executionFinished } = useExecutionFinished();
-
 		const workflowsStore = mockedStore(useWorkflowsStore);
 		const workflowsListStore = mockedStore(useWorkflowsListStore);
 
@@ -565,10 +514,6 @@ describe('executionFinished', () => {
 	});
 
 	it('should clear executing node queue when activeExecutionId is undefined (iframe preview)', async () => {
-		const pinia = createTestingPinia();
-		setActivePinia(pinia);
-		const { executionFinished } = useExecutionFinished();
-
 		const workflowsStore = mockedStore(useWorkflowsStore);
 		workflowsStore.activeExecutionId = undefined;
 
@@ -586,16 +531,8 @@ describe('executionFinished', () => {
 });
 
 describe('manual execution stats tracking', () => {
-	beforeEach(() => {
-		vi.resetAllMocks();
-	});
-
 	describe('handleExecutionFinishedWithSuccessOrOther', () => {
 		it('increments success stats on successful execution', () => {
-			const pinia = createTestingPinia();
-			setActivePinia(pinia);
-			const { handleExecutionFinishedWithSuccessOrOther } = useExecutionFinished();
-
 			const builderStore = mockedStore(useBuilderStore);
 			const incrementSpy = vi.spyOn(builderStore, 'incrementManualExecutionStats');
 
@@ -605,10 +542,6 @@ describe('manual execution stats tracking', () => {
 		});
 
 		it('does not increment success stats when successToastAlreadyShown is true', () => {
-			const pinia = createTestingPinia();
-			setActivePinia(pinia);
-			const { handleExecutionFinishedWithSuccessOrOther } = useExecutionFinished();
-
 			const builderStore = mockedStore(useBuilderStore);
 			const incrementSpy = vi.spyOn(builderStore, 'incrementManualExecutionStats');
 
@@ -618,10 +551,6 @@ describe('manual execution stats tracking', () => {
 		});
 
 		it('does not increment stats for non-success status', () => {
-			const pinia = createTestingPinia();
-			setActivePinia(pinia);
-			const { handleExecutionFinishedWithSuccessOrOther } = useExecutionFinished();
-
 			const builderStore = mockedStore(useBuilderStore);
 			const incrementSpy = vi.spyOn(builderStore, 'incrementManualExecutionStats');
 
@@ -632,15 +561,7 @@ describe('manual execution stats tracking', () => {
 	});
 
 	describe('toast messages', () => {
-		beforeEach(() => {
-			mockShowMessage.mockClear();
-		});
-
 		it('shows success toast when executed node has run data', () => {
-			const pinia = createTestingPinia();
-			setActivePinia(pinia);
-			const { handleExecutionFinishedWithSuccessOrOther } = useExecutionFinished();
-
 			const workflowsStore = mockedStore(useWorkflowsStore);
 			const nodeTypesStore = mockedStore(useNodeTypesStore);
 
@@ -670,10 +591,6 @@ describe('manual execution stats tracking', () => {
 		});
 
 		it('shows warning toast when executed node was not reached', () => {
-			const pinia = createTestingPinia();
-			setActivePinia(pinia);
-			const { handleExecutionFinishedWithSuccessOrOther } = useExecutionFinished();
-
 			const workflowsStore = mockedStore(useWorkflowsStore);
 			const nodeTypesStore = mockedStore(useNodeTypesStore);
 
@@ -701,10 +618,6 @@ describe('manual execution stats tracking', () => {
 		});
 
 		it('does not show warning toast when successToastAlreadyShown is true', () => {
-			const pinia = createTestingPinia();
-			setActivePinia(pinia);
-			const { handleExecutionFinishedWithSuccessOrOther } = useExecutionFinished();
-
 			const workflowsStore = mockedStore(useWorkflowsStore);
 			const nodeTypesStore = mockedStore(useNodeTypesStore);
 
@@ -718,8 +631,8 @@ describe('manual execution stats tracking', () => {
 				},
 			} as unknown as IExecutionResponse);
 
-			const docStore2 = useWorkflowDocumentStore(createWorkflowDocumentId(''));
-			docStore2.setNodes([
+			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(''));
+			workflowDocumentStore.setNodes([
 				mock<INodeUi>({ name: nodeName, type: 'n8n-nodes-base.vonage', typeVersion: 1 }),
 			]);
 
@@ -734,10 +647,6 @@ describe('manual execution stats tracking', () => {
 
 	describe('handleExecutionFinishedWithErrorOrCanceled', () => {
 		it('increments error stats on execution error', () => {
-			const pinia = createTestingPinia();
-			setActivePinia(pinia);
-			const { handleExecutionFinishedWithErrorOrCanceled } = useExecutionFinished();
-
 			const builderStore = mockedStore(useBuilderStore);
 			const incrementSpy = vi.spyOn(builderStore, 'incrementManualExecutionStats');
 
@@ -759,10 +668,6 @@ describe('manual execution stats tracking', () => {
 		});
 
 		it('does not increment stats for canceled executions', () => {
-			const pinia = createTestingPinia();
-			setActivePinia(pinia);
-			const { handleExecutionFinishedWithErrorOrCanceled } = useExecutionFinished();
-
 			const builderStore = mockedStore(useBuilderStore);
 			const incrementSpy = vi.spyOn(builderStore, 'incrementManualExecutionStats');
 

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.test.ts
@@ -1,18 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
 import { mock } from 'vitest-mock-extended';
-import {
-	continueEvaluationLoop,
-	executionFinished,
-	getRunExecutionData,
-	handleExecutionFinishedWithSuccessOrOther,
-	handleExecutionFinishedWithErrorOrCanceled,
-	type SimplifiedExecution,
-} from './executionFinished';
+import { useExecutionFinished, type SimplifiedExecution } from './executionFinished';
 import type { IRunExecutionData, ITaskData, INodeTypeDescription } from 'n8n-workflow';
 import { EVALUATION_TRIGGER_NODE_TYPE } from 'n8n-workflow';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
 import type { INodeUi, IWorkflowDb } from '@/Interface';
-import type { Router } from 'vue-router';
 import type { WorkflowState } from '@/app/composables/useWorkflowState';
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
@@ -28,10 +20,24 @@ import { useReadyToRunStore } from '@/features/workflows/readyToRun/stores/ready
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 
-const opts = {
-	workflowState: mock<WorkflowState>(),
-	router: mock<Router>(),
-};
+const mockWorkflowState = mock<WorkflowState>({
+	executingNode: {
+		lastAddedExecutingNode: null,
+	},
+});
+
+vi.mock('vue-router', async (importOriginal) => ({
+	...(await importOriginal()),
+	useRouter: vi.fn(() => ({
+		push: vi.fn(),
+		replace: vi.fn(),
+		currentRoute: { value: {} },
+	})),
+}));
+
+vi.mock('@/app/composables/useWorkflowState', () => ({
+	injectWorkflowState: vi.fn(() => mockWorkflowState),
+}));
 
 const mockShowMessage = vi.fn();
 vi.mock('@/app/composables/useToast', () => ({
@@ -54,12 +60,40 @@ vi.mock('@/app/composables/useRunWorkflow', () => ({
 	})),
 }));
 
+vi.mock('@/app/composables/useNodeHelpers', () => ({
+	useNodeHelpers: vi.fn(() => ({
+		updateNodesExecutionIssues: vi.fn(),
+	})),
+}));
+
+vi.mock('@/app/composables/useWorkflowHelpers', () => ({
+	useWorkflowHelpers: vi.fn(() => ({
+		getNodeTypes: vi.fn(() => ({})),
+	})),
+}));
+
+vi.mock('@/app/composables/useWorkflowSaving', () => ({
+	useWorkflowSaving: vi.fn(() => ({
+		saveAsNewWorkflow: vi.fn(),
+	})),
+}));
+
+vi.mock('@/app/composables/useExternalHooks', () => ({
+	useExternalHooks: vi.fn(() => ({
+		run: vi.fn(),
+	})),
+}));
+
 describe('continueEvaluationLoop()', () => {
 	beforeEach(() => {
 		vi.resetAllMocks();
 	});
 
 	it('should call runWorkflow() if workflow has eval trigger that executed successfully with rows left', () => {
+		const pinia = createTestingPinia();
+		setActivePinia(pinia);
+
+		const { continueEvaluationLoop } = useExecutionFinished();
 		const evalTriggerNodeName = 'eval-trigger';
 		const evalTriggerNodeData = mock<ITaskData>({
 			data: {
@@ -95,7 +129,7 @@ describe('continueEvaluationLoop()', () => {
 			},
 		});
 
-		continueEvaluationLoop(execution, opts);
+		continueEvaluationLoop(execution);
 
 		expect(runWorkflow).toHaveBeenCalledWith({
 			triggerNode: evalTriggerNodeName,
@@ -105,6 +139,10 @@ describe('continueEvaluationLoop()', () => {
 	});
 
 	it('should not call runWorkflow() if workflow execution status is not success', () => {
+		const pinia = createTestingPinia();
+		setActivePinia(pinia);
+
+		const { continueEvaluationLoop } = useExecutionFinished();
 		const execution = mock<SimplifiedExecution>({
 			status: 'error',
 			workflowData: {
@@ -122,12 +160,16 @@ describe('continueEvaluationLoop()', () => {
 			},
 		});
 
-		continueEvaluationLoop(execution, opts);
+		continueEvaluationLoop(execution);
 
 		expect(runWorkflow).not.toHaveBeenCalled();
 	});
 
 	it('should not call runWorkflow() if eval trigger node does not exist in workflow', () => {
+		const pinia = createTestingPinia();
+		setActivePinia(pinia);
+
+		const { continueEvaluationLoop } = useExecutionFinished();
 		const execution = mock<SimplifiedExecution>({
 			status: 'success',
 			workflowData: {
@@ -140,12 +182,16 @@ describe('continueEvaluationLoop()', () => {
 			},
 		});
 
-		continueEvaluationLoop(execution, opts);
+		continueEvaluationLoop(execution);
 
 		expect(runWorkflow).not.toHaveBeenCalled();
 	});
 
 	it('should not call runWorkflow() if eval trigger node exists but has no run data', () => {
+		const pinia = createTestingPinia();
+		setActivePinia(pinia);
+
+		const { continueEvaluationLoop } = useExecutionFinished();
 		const evalTriggerNodeName = 'eval-trigger';
 		const execution = mock<SimplifiedExecution>({
 			status: 'success',
@@ -164,12 +210,16 @@ describe('continueEvaluationLoop()', () => {
 			},
 		});
 
-		continueEvaluationLoop(execution, opts);
+		continueEvaluationLoop(execution);
 
 		expect(runWorkflow).not.toHaveBeenCalled();
 	});
 
 	it('should not call runWorkflow() if eval trigger node run data has no rows left', () => {
+		const pinia = createTestingPinia();
+		setActivePinia(pinia);
+
+		const { continueEvaluationLoop } = useExecutionFinished();
 		const evalTriggerNodeName = 'eval-trigger';
 		const evalTriggerNodeData = mock<ITaskData>({
 			data: {
@@ -205,7 +255,7 @@ describe('continueEvaluationLoop()', () => {
 			},
 		});
 
-		continueEvaluationLoop(execution, opts);
+		continueEvaluationLoop(execution);
 
 		expect(runWorkflow).not.toHaveBeenCalled();
 	});
@@ -213,6 +263,7 @@ describe('continueEvaluationLoop()', () => {
 
 describe('getRunExecutionData()', () => {
 	it('should preserve pushRef from execution data', () => {
+		const { getRunExecutionData } = useExecutionFinished();
 		const execution = mock<SimplifiedExecution>({
 			data: {
 				pushRef: 'test-push-ref-12345',
@@ -228,6 +279,7 @@ describe('getRunExecutionData()', () => {
 	});
 
 	it('should handle missing pushRef gracefully', () => {
+		const { getRunExecutionData } = useExecutionFinished();
 		const execution = mock<SimplifiedExecution>({
 			data: {
 				resultData: {
@@ -249,33 +301,26 @@ describe('executionFinished', () => {
 	});
 
 	it('should clear lastAddedExecutingNode when execution is finished', async () => {
-		const workflowState = mock<WorkflowState>({
-			executingNode: {
-				lastAddedExecutingNode: 'test-node',
+		const { executionFinished } = useExecutionFinished();
+		mockWorkflowState.executingNode.lastAddedExecutingNode = 'test-node';
+
+		await executionFinished({
+			type: 'executionFinished',
+			data: {
+				executionId: '1',
+				workflowId: '1',
+				status: 'success',
 			},
 		});
-		await executionFinished(
-			{
-				type: 'executionFinished',
-				data: {
-					executionId: '1',
-					workflowId: '1',
-					status: 'success',
-				},
-			},
-			{
-				router: mock<Router>(),
-				workflowState,
-			},
-		);
 
-		expect(workflowState.executingNode.lastAddedExecutingNode).toBeNull();
+		expect(mockWorkflowState.executingNode.lastAddedExecutingNode).toBeNull();
 	});
 
 	describe('ready-to-run AI workflow tracking', () => {
 		it('should track successful execution of ready-to-run-ai-workflow', async () => {
 			const pinia = createTestingPinia();
 			setActivePinia(pinia);
+			const { executionFinished } = useExecutionFinished();
 
 			const workflowsStore = useWorkflowsStore();
 			const workflowsListStore = useWorkflowsListStore();
@@ -293,26 +338,14 @@ describe('executionFinished', () => {
 				'trackExecuteAiWorkflowSuccess',
 			);
 
-			const workflowState = mock<WorkflowState>({
-				executingNode: {
-					lastAddedExecutingNode: null,
+			await executionFinished({
+				type: 'executionFinished',
+				data: {
+					executionId: '123',
+					workflowId: '1',
+					status: 'success',
 				},
 			});
-
-			await executionFinished(
-				{
-					type: 'executionFinished',
-					data: {
-						executionId: '123',
-						workflowId: '1',
-						status: 'success',
-					},
-				},
-				{
-					router: mock<Router>(),
-					workflowState,
-				},
-			);
 
 			expect(trackExecuteAiWorkflowSuccess).toHaveBeenCalled();
 		});
@@ -320,6 +353,7 @@ describe('executionFinished', () => {
 		it('should track failed execution of ready-to-run-ai-workflow', async () => {
 			const pinia = createTestingPinia();
 			setActivePinia(pinia);
+			const { executionFinished } = useExecutionFinished();
 
 			const workflowsStore = useWorkflowsStore();
 			const workflowsListStore = useWorkflowsListStore();
@@ -334,26 +368,14 @@ describe('executionFinished', () => {
 
 			const trackExecuteAiWorkflow = vi.spyOn(readyToRunStore, 'trackExecuteAiWorkflow');
 
-			const workflowState = mock<WorkflowState>({
-				executingNode: {
-					lastAddedExecutingNode: null,
+			await executionFinished({
+				type: 'executionFinished',
+				data: {
+					executionId: '123',
+					workflowId: '1',
+					status: 'error',
 				},
 			});
-
-			await executionFinished(
-				{
-					type: 'executionFinished',
-					data: {
-						executionId: '123',
-						workflowId: '1',
-						status: 'error',
-					},
-				},
-				{
-					router: mock<Router>(),
-					workflowState,
-				},
-			);
 
 			expect(trackExecuteAiWorkflow).toHaveBeenCalledWith('error');
 		});
@@ -361,6 +383,7 @@ describe('executionFinished', () => {
 		it('should track execution of ready-to-run-ai-workflow-v5', async () => {
 			const pinia = createTestingPinia();
 			setActivePinia(pinia);
+			const { executionFinished } = useExecutionFinished();
 
 			const workflowsStore = useWorkflowsStore();
 			const workflowsListStore = useWorkflowsListStore();
@@ -378,26 +401,14 @@ describe('executionFinished', () => {
 				'trackExecuteAiWorkflowSuccess',
 			);
 
-			const workflowState = mock<WorkflowState>({
-				executingNode: {
-					lastAddedExecutingNode: null,
+			await executionFinished({
+				type: 'executionFinished',
+				data: {
+					executionId: '123',
+					workflowId: '1',
+					status: 'success',
 				},
 			});
-
-			await executionFinished(
-				{
-					type: 'executionFinished',
-					data: {
-						executionId: '123',
-						workflowId: '1',
-						status: 'success',
-					},
-				},
-				{
-					router: mock<Router>(),
-					workflowState,
-				},
-			);
 
 			expect(trackExecuteAiWorkflowSuccess).toHaveBeenCalled();
 		});
@@ -405,6 +416,7 @@ describe('executionFinished', () => {
 		it('should track execution of ready-to-run-ai-workflow-v6', async () => {
 			const pinia = createTestingPinia();
 			setActivePinia(pinia);
+			const { executionFinished } = useExecutionFinished();
 
 			const workflowsStore = useWorkflowsStore();
 			const workflowsListStore = useWorkflowsListStore();
@@ -419,26 +431,14 @@ describe('executionFinished', () => {
 
 			const trackExecuteAiWorkflow = vi.spyOn(readyToRunStore, 'trackExecuteAiWorkflow');
 
-			const workflowState = mock<WorkflowState>({
-				executingNode: {
-					lastAddedExecutingNode: null,
+			await executionFinished({
+				type: 'executionFinished',
+				data: {
+					executionId: '123',
+					workflowId: '1',
+					status: 'canceled',
 				},
 			});
-
-			await executionFinished(
-				{
-					type: 'executionFinished',
-					data: {
-						executionId: '123',
-						workflowId: '1',
-						status: 'canceled',
-					},
-				},
-				{
-					router: mock<Router>(),
-					workflowState,
-				},
-			);
 
 			expect(trackExecuteAiWorkflow).toHaveBeenCalledWith('canceled');
 		});
@@ -446,6 +446,7 @@ describe('executionFinished', () => {
 		it('should not track execution for non-ready-to-run workflows', async () => {
 			const pinia = createTestingPinia();
 			setActivePinia(pinia);
+			const { executionFinished } = useExecutionFinished();
 
 			const workflowsStore = useWorkflowsStore();
 			const workflowsListStore = useWorkflowsListStore();
@@ -464,26 +465,14 @@ describe('executionFinished', () => {
 			);
 			const trackExecuteAiWorkflow = vi.spyOn(readyToRunStore, 'trackExecuteAiWorkflow');
 
-			const workflowState = mock<WorkflowState>({
-				executingNode: {
-					lastAddedExecutingNode: null,
+			await executionFinished({
+				type: 'executionFinished',
+				data: {
+					executionId: '123',
+					workflowId: '1',
+					status: 'success',
 				},
 			});
-
-			await executionFinished(
-				{
-					type: 'executionFinished',
-					data: {
-						executionId: '123',
-						workflowId: '1',
-						status: 'success',
-					},
-				},
-				{
-					router: mock<Router>(),
-					workflowState,
-				},
-			);
 
 			expect(trackExecuteAiWorkflowSuccess).not.toHaveBeenCalled();
 			expect(trackExecuteAiWorkflow).not.toHaveBeenCalled();
@@ -500,15 +489,14 @@ describe('executionFinished', () => {
 		});
 
 		setActivePinia(pinia);
+		const { executionFinished } = useExecutionFinished();
 
 		const workflowsStore = mockedStore(useWorkflowsStore);
 		const workflowsListStore = mockedStore(useWorkflowsListStore);
 		const uiStore = mockedStore(useUIStore);
 
-		// Set activeExecutionId directly on the store
 		workflowsStore.activeExecutionId = '123';
 
-		// Mock getWorkflowById to return a workflow
 		vi.spyOn(workflowsListStore, 'getWorkflowById').mockReturnValue({
 			id: '1',
 			name: 'Test Workflow',
@@ -522,34 +510,17 @@ describe('executionFinished', () => {
 
 		const setProcessingExecutionResultsSpy = vi.spyOn(uiStore, 'setProcessingExecutionResults');
 
-		const workflowState = mock<WorkflowState>({
-			executingNode: {
-				lastAddedExecutingNode: 'test-node',
+		await executionFinished({
+			type: 'executionFinished',
+			data: {
+				executionId: '123',
+				workflowId: '1',
+				status: 'error',
 			},
-			setActiveExecutionId: vi.fn(),
 		});
 
-		await executionFinished(
-			{
-				type: 'executionFinished',
-				data: {
-					executionId: '123',
-					workflowId: '1',
-					status: 'error',
-				},
-			},
-			{
-				router: mock<Router>(),
-				workflowState,
-			},
-		);
-
-		// Verify that setActiveExecutionId was called with undefined
-		expect(workflowState.setActiveExecutionId).toHaveBeenCalledWith(undefined);
-
-		// Verify that processing was set to false
+		expect(mockWorkflowState.setActiveExecutionId).toHaveBeenCalledWith(undefined);
 		expect(setProcessingExecutionResultsSpy).toHaveBeenCalledWith(false);
-
 		expect(runWorkflow).not.toHaveBeenCalled();
 	});
 
@@ -563,6 +534,7 @@ describe('executionFinished', () => {
 		});
 
 		setActivePinia(pinia);
+		const { executionFinished } = useExecutionFinished();
 
 		const workflowsStore = mockedStore(useWorkflowsStore);
 		const workflowsListStore = mockedStore(useWorkflowsListStore);
@@ -578,72 +550,38 @@ describe('executionFinished', () => {
 			settings: {},
 		} as unknown as ReturnType<typeof workflowsListStore.getWorkflowById>);
 
-		// Simulate the iframe scenario: fetch returns no data
 		vi.spyOn(workflowsStore, 'fetchExecutionDataById').mockResolvedValue(null);
 
-		const clearNodeExecutionQueue = vi.fn();
-		const workflowState = mock<WorkflowState>({
-			executingNode: {
-				lastAddedExecutingNode: 'LastNode',
-				clearNodeExecutionQueue,
+		await executionFinished({
+			type: 'executionFinished',
+			data: {
+				executionId: '123',
+				workflowId: '1',
+				status: 'success',
 			},
-			setActiveExecutionId: vi.fn(),
 		});
 
-		await executionFinished(
-			{
-				type: 'executionFinished',
-				data: {
-					executionId: '123',
-					workflowId: '1',
-					status: 'success',
-				},
-			},
-			{
-				router: mock<Router>(),
-				workflowState,
-			},
-		);
-
-		// The executing node queue must be cleared so nodes don't stay stuck
-		// with a spinner after the execution finishes.
-		expect(clearNodeExecutionQueue).toHaveBeenCalled();
+		expect(mockWorkflowState.executingNode.clearNodeExecutionQueue).toHaveBeenCalled();
 	});
 
 	it('should clear executing node queue when activeExecutionId is undefined (iframe preview)', async () => {
 		const pinia = createTestingPinia();
 		setActivePinia(pinia);
+		const { executionFinished } = useExecutionFinished();
 
 		const workflowsStore = mockedStore(useWorkflowsStore);
-		// In iframe preview after resetWorkspace, activeExecutionId can be undefined
 		workflowsStore.activeExecutionId = undefined;
 
-		const clearNodeExecutionQueue = vi.fn();
-		const workflowState = mock<WorkflowState>({
-			executingNode: {
-				lastAddedExecutingNode: 'LastNode',
-				clearNodeExecutionQueue,
+		await executionFinished({
+			type: 'executionFinished',
+			data: {
+				executionId: '123',
+				workflowId: '1',
+				status: 'success',
 			},
 		});
 
-		await executionFinished(
-			{
-				type: 'executionFinished',
-				data: {
-					executionId: '123',
-					workflowId: '1',
-					status: 'success',
-				},
-			},
-			{
-				router: mock<Router>(),
-				workflowState,
-			},
-		);
-
-		// Even when activeExecutionId is undefined (iframe early return),
-		// the executing node queue must be cleared.
-		expect(clearNodeExecutionQueue).toHaveBeenCalled();
+		expect(mockWorkflowState.executingNode.clearNodeExecutionQueue).toHaveBeenCalled();
 	});
 });
 
@@ -656,11 +594,12 @@ describe('manual execution stats tracking', () => {
 		it('increments success stats on successful execution', () => {
 			const pinia = createTestingPinia();
 			setActivePinia(pinia);
+			const { handleExecutionFinishedWithSuccessOrOther } = useExecutionFinished();
 
 			const builderStore = mockedStore(useBuilderStore);
 			const incrementSpy = vi.spyOn(builderStore, 'incrementManualExecutionStats');
 
-			handleExecutionFinishedWithSuccessOrOther(mock<WorkflowState>(), 'success', false);
+			handleExecutionFinishedWithSuccessOrOther('success', false);
 
 			expect(incrementSpy).toHaveBeenCalledWith('success');
 		});
@@ -668,11 +607,12 @@ describe('manual execution stats tracking', () => {
 		it('does not increment success stats when successToastAlreadyShown is true', () => {
 			const pinia = createTestingPinia();
 			setActivePinia(pinia);
+			const { handleExecutionFinishedWithSuccessOrOther } = useExecutionFinished();
 
 			const builderStore = mockedStore(useBuilderStore);
 			const incrementSpy = vi.spyOn(builderStore, 'incrementManualExecutionStats');
 
-			handleExecutionFinishedWithSuccessOrOther(mock<WorkflowState>(), 'success', true);
+			handleExecutionFinishedWithSuccessOrOther('success', true);
 
 			expect(incrementSpy).not.toHaveBeenCalled();
 		});
@@ -680,11 +620,12 @@ describe('manual execution stats tracking', () => {
 		it('does not increment stats for non-success status', () => {
 			const pinia = createTestingPinia();
 			setActivePinia(pinia);
+			const { handleExecutionFinishedWithSuccessOrOther } = useExecutionFinished();
 
 			const builderStore = mockedStore(useBuilderStore);
 			const incrementSpy = vi.spyOn(builderStore, 'incrementManualExecutionStats');
 
-			handleExecutionFinishedWithSuccessOrOther(mock<WorkflowState>(), 'error', false);
+			handleExecutionFinishedWithSuccessOrOther('error', false);
 
 			expect(incrementSpy).not.toHaveBeenCalled();
 		});
@@ -698,6 +639,7 @@ describe('manual execution stats tracking', () => {
 		it('shows success toast when executed node has run data', () => {
 			const pinia = createTestingPinia();
 			setActivePinia(pinia);
+			const { handleExecutionFinishedWithSuccessOrOther } = useExecutionFinished();
 
 			const workflowsStore = mockedStore(useWorkflowsStore);
 			const nodeTypesStore = mockedStore(useNodeTypesStore);
@@ -722,7 +664,7 @@ describe('manual execution stats tracking', () => {
 			nodeTypesStore.getNodeType = () =>
 				mock<INodeTypeDescription>({ polling: undefined, group: [] });
 
-			handleExecutionFinishedWithSuccessOrOther(mock<WorkflowState>(), 'success', false);
+			handleExecutionFinishedWithSuccessOrOther('success', false);
 
 			expect(mockShowMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
 		});
@@ -730,6 +672,7 @@ describe('manual execution stats tracking', () => {
 		it('shows warning toast when executed node was not reached', () => {
 			const pinia = createTestingPinia();
 			setActivePinia(pinia);
+			const { handleExecutionFinishedWithSuccessOrOther } = useExecutionFinished();
 
 			const workflowsStore = mockedStore(useWorkflowsStore);
 			const nodeTypesStore = mockedStore(useNodeTypesStore);
@@ -752,7 +695,7 @@ describe('manual execution stats tracking', () => {
 			nodeTypesStore.getNodeType = () =>
 				mock<INodeTypeDescription>({ polling: undefined, group: [] });
 
-			handleExecutionFinishedWithSuccessOrOther(mock<WorkflowState>(), 'success', false);
+			handleExecutionFinishedWithSuccessOrOther('success', false);
 
 			expect(mockShowMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' }));
 		});
@@ -760,6 +703,7 @@ describe('manual execution stats tracking', () => {
 		it('does not show warning toast when successToastAlreadyShown is true', () => {
 			const pinia = createTestingPinia();
 			setActivePinia(pinia);
+			const { handleExecutionFinishedWithSuccessOrOther } = useExecutionFinished();
 
 			const workflowsStore = mockedStore(useWorkflowsStore);
 			const nodeTypesStore = mockedStore(useNodeTypesStore);
@@ -782,7 +726,7 @@ describe('manual execution stats tracking', () => {
 			nodeTypesStore.getNodeType = () =>
 				mock<INodeTypeDescription>({ polling: undefined, group: [] });
 
-			handleExecutionFinishedWithSuccessOrOther(mock<WorkflowState>(), 'success', true);
+			handleExecutionFinishedWithSuccessOrOther('success', true);
 
 			expect(mockShowMessage).not.toHaveBeenCalled();
 		});
@@ -792,6 +736,7 @@ describe('manual execution stats tracking', () => {
 		it('increments error stats on execution error', () => {
 			const pinia = createTestingPinia();
 			setActivePinia(pinia);
+			const { handleExecutionFinishedWithErrorOrCanceled } = useExecutionFinished();
 
 			const builderStore = mockedStore(useBuilderStore);
 			const incrementSpy = vi.spyOn(builderStore, 'incrementManualExecutionStats');
@@ -816,6 +761,7 @@ describe('manual execution stats tracking', () => {
 		it('does not increment stats for canceled executions', () => {
 			const pinia = createTestingPinia();
 			setActivePinia(pinia);
+			const { handleExecutionFinishedWithErrorOrCanceled } = useExecutionFinished();
 
 			const builderStore = mockedStore(useBuilderStore);
 			const incrementSpy = vi.spyOn(builderStore, 'incrementManualExecutionStats');

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -17,6 +17,7 @@ import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
+	injectWorkflowDocumentStore,
 } from '@/app/stores/workflowDocument.store';
 import {
 	createWorkflowExecutionStateId,
@@ -49,8 +50,8 @@ import {
 	TelemetryHelpers,
 	createRunExecutionData,
 } from 'n8n-workflow';
-import type { useRouter } from 'vue-router';
-import { type WorkflowState } from '@/app/composables/useWorkflowState';
+import { useRouter } from 'vue-router';
+import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
 
 export type SimplifiedExecution = Pick<
@@ -58,477 +59,416 @@ export type SimplifiedExecution = Pick<
 	'workflowId' | 'workflowData' | 'data' | 'status' | 'startedAt' | 'stoppedAt' | 'id'
 >;
 
-export type ExecutionFinishedOptions = {
-	router: ReturnType<typeof useRouter>;
-	workflowState: WorkflowState;
-};
-
-/**
- * Handles the 'executionFinished' event, which happens when a workflow execution is finished.
- */
-export async function executionFinished(
-	{ data }: ExecutionFinished,
-	options: ExecutionFinishedOptions,
-) {
+export function useExecutionFinished() {
 	const workflowsStore = useWorkflowsStore();
 	const workflowsListStore = useWorkflowsListStore();
 	const uiStore = useUIStore();
+	const settingsStore = useSettingsStore();
+	const nodeTypesStore = useNodeTypesStore();
 	const aiTemplatesStarterCollectionStore = useAITemplatesStarterCollectionStore();
 	const readyToRunStore = useReadyToRunStore();
+	const builderStore = useBuilderStore();
 
-	options.workflowState.executingNode.lastAddedExecutingNode = null;
-	options.workflowState.executingNode.clearNodeExecutionQueue();
+	const workflowDocumentStore = injectWorkflowDocumentStore();
 
-	// No workflow is actively running, therefore we ignore this event
-	if (typeof workflowsStore.activeExecutionId === 'undefined') {
-		return;
-	}
+	const router = useRouter();
+	const workflowState = injectWorkflowState();
 
+	const toast = useToast();
+	const i18n = useI18n();
 	const telemetry = useTelemetry();
+	const documentTitle = useDocumentTitle();
+	const externalHooks = useExternalHooks();
+	const nodeHelpers = useNodeHelpers();
+	const workflowHelpers = useWorkflowHelpers();
+	const workflowSaving = useWorkflowSaving({ router });
+	const { runWorkflow } = useRunWorkflow({ router });
 
-	clearPopupWindowState();
+	async function executionFinished({ data }: ExecutionFinished) {
+		workflowState.executingNode.lastAddedExecutingNode = null;
+		workflowState.executingNode.clearNodeExecutionQueue();
 
-	const workflow = workflowsListStore.getWorkflowById(data.workflowId);
-	const templateId = workflow?.meta?.templateId;
-
-	if (templateId) {
-		const isEasyAIWorkflow = templateId === SampleTemplates.EasyAiTemplate;
-		if (isEasyAIWorkflow) {
-			telemetry.track('User executed test AI workflow', {
-				status: data.status,
-			});
-		} else if (templateId.startsWith('035_template_onboarding')) {
-			aiTemplatesStarterCollectionStore.trackUserExecutedWorkflow(
-				templateId.split('-').pop() ?? '',
-				data.status,
-			);
-		} else if (
-			templateId === 'ready-to-run-ai-workflow' ||
-			templateId === 'ready-to-run-ai-workflow-v5' ||
-			templateId === 'ready-to-run-ai-workflow-v6'
-		) {
-			if (data.status === 'success') {
-				readyToRunStore.trackExecuteAiWorkflowSuccess();
-			} else {
-				readyToRunStore.trackExecuteAiWorkflow(data.status);
-			}
-		} else if (isTutorialTemplateId(templateId)) {
-			telemetry.track('User executed tutorial template', {
-				template: templateId,
-				status: data.status,
-			});
-		}
-	}
-
-	uiStore.setProcessingExecutionResults(true);
-
-	let successToastAlreadyShown = false;
-
-	if (data.status === 'success') {
-		handleExecutionFinishedWithSuccessOrOther(
-			options.workflowState,
-			data.status,
-			successToastAlreadyShown,
-		);
-		successToastAlreadyShown = true;
-	}
-
-	const execution = await fetchExecutionData(data.executionId);
-
-	/**
-	 * This accounts for the case where the execution is not stored.
-	 * We clear the active execution id and set processing to false and return early.
-	 * Returning early presists existing run data up to this point.
-	 */
-	if (!execution) {
-		options.workflowState.setActiveExecutionId(undefined);
-		uiStore.setProcessingExecutionResults(false);
-		return;
-	}
-
-	const runExecutionData = getRunExecutionData(execution);
-	uiStore.setProcessingExecutionResults(false);
-
-	if (execution.data?.waitTill !== undefined) {
-		handleExecutionFinishedWithWaitTill(data.workflowId, options);
-	} else if (execution.status === 'error' || execution.status === 'canceled') {
-		handleExecutionFinishedWithErrorOrCanceled(execution, runExecutionData);
-	} else {
-		handleExecutionFinishedWithSuccessOrOther(
-			options.workflowState,
-			execution.status,
-			successToastAlreadyShown,
-		);
-	}
-
-	setRunExecutionData(execution, runExecutionData, options.workflowState);
-
-	continueEvaluationLoop(execution, options);
-}
-
-/**
- * Implicit looping: This will re-trigger the evaluation trigger if it exists on a successful execution of the workflow.
- * @param execution
- * @param router
- */
-export function continueEvaluationLoop(
-	execution: SimplifiedExecution,
-	opts: ExecutionFinishedOptions,
-) {
-	if (execution.status !== 'success' || execution.data?.startData?.destinationNode !== undefined) {
-		return;
-	}
-
-	// check if we have an evaluation trigger in our workflow and whether it has any run data
-	const evaluationTrigger = execution.workflowData.nodes.find(
-		(node) => node.type === EVALUATION_TRIGGER_NODE_TYPE,
-	);
-	const triggerRunData = evaluationTrigger
-		? execution?.data?.resultData?.runData[evaluationTrigger.name]
-		: undefined;
-
-	if (!evaluationTrigger || triggerRunData === undefined) {
-		return;
-	}
-
-	const mainData = triggerRunData[0]?.data?.main[0];
-	const rowsLeft = mainData ? (mainData[0]?.json?._rowsLeft as number) : 0;
-
-	if (rowsLeft && rowsLeft > 0) {
-		const { runWorkflow } = useRunWorkflow(opts);
-		void runWorkflow({
-			triggerNode: evaluationTrigger.name,
-			// pass output of previous node run to trigger next run
-			nodeData: triggerRunData[0],
-			rerunTriggerNode: true,
-		});
-	}
-}
-
-/**
- * Fetches the execution data from the server and returns a simplified execution object
- */
-export async function fetchExecutionData(
-	executionId: string,
-): Promise<SimplifiedExecution | undefined> {
-	const workflowsStore = useWorkflowsStore();
-	const workflowDocumentStore = useWorkflowDocumentStore(
-		createWorkflowDocumentId(workflowsStore.workflowId),
-	);
-
-	try {
-		const executionResponse = await workflowsStore.fetchExecutionDataById(executionId);
-		if (!executionResponse?.data) {
+		// No workflow is actively running, therefore we ignore this event
+		if (typeof workflowsStore.activeExecutionId === 'undefined') {
 			return;
 		}
 
-		return {
-			id: executionId,
-			workflowId: executionResponse.workflowId,
-			workflowData: workflowDocumentStore.getSnapshot(),
-			data: executionResponse.data,
-			status: executionResponse.status,
-			startedAt: workflowsStore.workflowExecutionData?.startedAt as Date,
-			stoppedAt: new Date(),
-		};
-	} catch {
-		return;
-	}
-}
+		clearPopupWindowState();
 
-/**
- * Returns the run execution data from the execution object in a normalized format
- */
-export function getRunExecutionData(execution: SimplifiedExecution): IRunExecutionData {
-	return createRunExecutionData({
-		...execution.data,
-		startData: execution.data?.startData,
-		resultData: execution.data?.resultData ?? { runData: {} },
-		executionData: execution.data?.executionData,
-	});
-}
+		const workflow = workflowsListStore.getWorkflowById(data.workflowId);
+		const templateId = workflow?.meta?.templateId;
 
-/**
- * Returns the error message for the execution run data if the execution status is crashed or canceled,
- * or a fallback error message otherwise
- */
-export function getRunDataExecutedErrorMessage(execution: SimplifiedExecution) {
-	const i18n = useI18n();
-
-	if (execution.status === 'crashed') {
-		return i18n.baseText('pushConnection.executionFailed.message');
-	} else if (execution.status === 'canceled') {
-		const workflowsStore = useWorkflowsStore();
-
-		return i18n.baseText('executionsList.showMessage.stopExecution.message', {
-			interpolate: { activeExecutionId: workflowsStore.activeExecutionId ?? '' },
-		});
-	}
-
-	return getExecutionErrorMessage({
-		error: execution.data?.resultData.error,
-		lastNodeExecuted: execution.data?.resultData.lastNodeExecuted,
-	});
-}
-
-/**
- * Handle the case when the workflow execution finished with `waitTill`,
- * meaning that it's in a waiting state.
- */
-export function handleExecutionFinishedWithWaitTill(
-	workflowId: string,
-	options: {
-		router: ReturnType<typeof useRouter>;
-	},
-) {
-	const workflowsStore = useWorkflowsStore();
-	const settingsStore = useSettingsStore();
-	const workflowSaving = useWorkflowSaving(options);
-
-	const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
-	const workflowSettings = workflowDocumentStore.settings;
-	const saveManualExecutions =
-		workflowSettings.saveManualExecutions ?? settingsStore.saveManualExecutions;
-
-	if (!saveManualExecutions) {
-		const uiStore = useUIStore();
-
-		globalLinkActionsEventBus.emit('registerGlobalLinkAction', {
-			key: 'open-settings',
-			action: async () => {
-				if (!workflowsStore.isWorkflowSaved[workflowsStore.workflowId])
-					await workflowSaving.saveAsNewWorkflow();
-				uiStore.openModal(WORKFLOW_SETTINGS_MODAL_KEY);
-			},
-		});
-	}
-
-	// Workflow did start but had been put to wait
-	useDocumentTitle().setDocumentTitle(workflowDocumentStore.name, 'IDLE');
-}
-
-/**
- * Handle the case when the workflow execution finished with an `error` or `canceled` status.
- */
-export function handleExecutionFinishedWithErrorOrCanceled(
-	execution: SimplifiedExecution,
-	runExecutionData: IRunExecutionData,
-) {
-	const toast = useToast();
-	const i18n = useI18n();
-	const telemetry = useTelemetry();
-	const workflowsStore = useWorkflowsStore();
-	const workflowDocumentStore = useWorkflowDocumentStore(
-		createWorkflowDocumentId(workflowsStore.workflowId),
-	);
-	const documentTitle = useDocumentTitle();
-	const workflowHelpers = useWorkflowHelpers();
-
-	documentTitle.setDocumentTitle(workflowDocumentStore.name, 'ERROR');
-
-	if (
-		runExecutionData.resultData.error?.name === 'ExpressionError' &&
-		(runExecutionData.resultData.error as ExpressionError).functionality === 'pairedItem'
-	) {
-		const error = runExecutionData.resultData.error as ExpressionError;
-
-		const workflowData = workflowDocumentStore.serialize();
-		const eventData: IDataObject = {
-			caused_by_credential: false,
-			error_message: error.description,
-			error_title: error.message,
-			error_type: error.context.type,
-			node_graph_string: JSON.stringify(
-				TelemetryHelpers.generateNodesGraph(
-					workflowData as IWorkflowBase,
-					workflowHelpers.getNodeTypes(),
-				).nodeGraph,
-			),
-			workflow_id: workflowsStore.workflowId,
-		};
-
-		if (
-			error.context.nodeCause &&
-			['paired_item_no_info', 'paired_item_invalid_info'].includes(error.context.type as string)
-		) {
-			const node = workflowDocumentStore.getNodeByName(error.context.nodeCause as string);
-
-			if (node) {
-				eventData.is_pinned = !!workflowDocumentStore.pinData?.[node.name];
-				eventData.mode = node.parameters.mode;
-				eventData.node_type = node.type;
-				eventData.operation = node.parameters.operation;
-				eventData.resource = node.parameters.resource;
+		if (templateId) {
+			const isEasyAIWorkflow = templateId === SampleTemplates.EasyAiTemplate;
+			if (isEasyAIWorkflow) {
+				telemetry.track('User executed test AI workflow', {
+					status: data.status,
+				});
+			} else if (templateId.startsWith('035_template_onboarding')) {
+				aiTemplatesStarterCollectionStore.trackUserExecutedWorkflow(
+					templateId.split('-').pop() ?? '',
+					data.status,
+				);
+			} else if (
+				templateId === 'ready-to-run-ai-workflow' ||
+				templateId === 'ready-to-run-ai-workflow-v5' ||
+				templateId === 'ready-to-run-ai-workflow-v6'
+			) {
+				if (data.status === 'success') {
+					readyToRunStore.trackExecuteAiWorkflowSuccess();
+				} else {
+					readyToRunStore.trackExecuteAiWorkflow(data.status);
+				}
+			} else if (isTutorialTemplateId(templateId)) {
+				telemetry.track('User executed tutorial template', {
+					template: templateId,
+					status: data.status,
+				});
 			}
 		}
 
-		telemetry.track('Instance FE emitted paired item error', eventData);
+		uiStore.setProcessingExecutionResults(true);
+
+		let successToastAlreadyShown = false;
+
+		if (data.status === 'success') {
+			handleExecutionFinishedWithSuccessOrOther(data.status, successToastAlreadyShown);
+			successToastAlreadyShown = true;
+		}
+
+		const execution = await fetchExecutionData(data.executionId);
+
+		/**
+		 * This accounts for the case where the execution is not stored.
+		 * We clear the active execution id and set processing to false and return early.
+		 * Returning early presists existing run data up to this point.
+		 */
+		if (!execution) {
+			workflowState.setActiveExecutionId(undefined);
+			uiStore.setProcessingExecutionResults(false);
+			return;
+		}
+
+		const runExecutionData = getRunExecutionData(execution);
+		uiStore.setProcessingExecutionResults(false);
+
+		if (execution.data?.waitTill !== undefined) {
+			handleExecutionFinishedWithWaitTill(data.workflowId);
+		} else if (execution.status === 'error' || execution.status === 'canceled') {
+			handleExecutionFinishedWithErrorOrCanceled(execution, runExecutionData);
+		} else {
+			handleExecutionFinishedWithSuccessOrOther(execution.status, successToastAlreadyShown);
+		}
+
+		setRunExecutionData(execution, runExecutionData);
+
+		continueEvaluationLoop(execution);
 	}
 
-	if (execution.status === 'canceled') {
-		// Do not show the error message if the workflow got canceled
-		toast.showMessage({
-			title: i18n.baseText('nodeView.showMessage.stopExecutionTry.title'),
-			type: 'success',
+	// check if we have an evaluation trigger in our workflow and whether it has any run data
+	function continueEvaluationLoop(execution: SimplifiedExecution) {
+		if (
+			execution.status !== 'success' ||
+			execution.data?.startData?.destinationNode !== undefined
+		) {
+			return;
+		}
+
+		const evaluationTrigger = execution.workflowData.nodes.find(
+			(node) => node.type === EVALUATION_TRIGGER_NODE_TYPE,
+		);
+		const triggerRunData = evaluationTrigger
+			? execution?.data?.resultData?.runData[evaluationTrigger.name]
+			: undefined;
+
+		if (!evaluationTrigger || triggerRunData === undefined) {
+			return;
+		}
+
+		const mainData = triggerRunData[0]?.data?.main[0];
+		const rowsLeft = mainData ? (mainData[0]?.json?._rowsLeft as number) : 0;
+
+		if (rowsLeft && rowsLeft > 0) {
+			// pass output of previous node run to trigger next run
+			void runWorkflow({
+				triggerNode: evaluationTrigger.name,
+				nodeData: triggerRunData[0],
+				rerunTriggerNode: true,
+			});
+		}
+	}
+
+	async function fetchExecutionData(executionId: string): Promise<SimplifiedExecution | undefined> {
+		try {
+			const executionResponse = await workflowsStore.fetchExecutionDataById(executionId);
+			if (!executionResponse?.data) {
+				return;
+			}
+
+			return {
+				id: executionId,
+				workflowId: executionResponse.workflowId,
+				workflowData: workflowDocumentStore.value.getSnapshot(),
+				data: executionResponse.data,
+				status: executionResponse.status,
+				startedAt: workflowsStore.workflowExecutionData?.startedAt as Date,
+				stoppedAt: new Date(),
+			};
+		} catch {
+			return;
+		}
+	}
+
+	/**
+	 * Returns the run execution data from the execution object in a normalized format
+	 */
+	function getRunExecutionData(execution: SimplifiedExecution): IRunExecutionData {
+		return createRunExecutionData({
+			...execution.data,
+			startData: execution.data?.startData,
+			resultData: execution.data?.resultData ?? { runData: {} },
+			executionData: execution.data?.executionData,
 		});
-	} else if (execution.data?.resultData.error) {
-		const { message, title } = getExecutionErrorToastConfiguration({
-			error: execution.data.resultData.error,
+	}
+
+	/**
+	 * Returns the error message for the execution run data if the execution status is crashed or canceled,
+	 * or a fallback error message otherwise
+	 */
+	function getRunDataExecutedErrorMessage(execution: SimplifiedExecution) {
+		if (execution.status === 'crashed') {
+			return i18n.baseText('pushConnection.executionFailed.message');
+		} else if (execution.status === 'canceled') {
+			return i18n.baseText('executionsList.showMessage.stopExecution.message', {
+				interpolate: { activeExecutionId: workflowsStore.activeExecutionId ?? '' },
+			});
+		}
+
+		return getExecutionErrorMessage({
+			error: execution.data?.resultData.error,
 			lastNodeExecuted: execution.data?.resultData.lastNodeExecuted,
 		});
-
-		toast.showMessage({ title, message, type: 'error', duration: 0 });
-
-		useBuilderStore().incrementManualExecutionStats('error');
 	}
-}
 
-/**
- * Handle the case when the workflow execution finished successfully.
- *
- * On successful completion without data, we show a success toast
- * immediately, even though we still need to fetch and deserialize the
- * full execution data, to minimize perceived latency.
- */
-function handleExecutionFinishedSuccessfully(
-	workflowName: string,
-	message: string,
-	workflowState: WorkflowState,
-) {
-	const toast = useToast();
+	/**
+	 * Handle the case when the workflow execution finished with `waitTill`,
+	 * meaning that it's in a waiting state.
+	 */
+	function handleExecutionFinishedWithWaitTill(eventWorkflowId: string) {
+		const docStore = useWorkflowDocumentStore(createWorkflowDocumentId(eventWorkflowId));
+		const workflowSettings = docStore.settings;
+		const saveManualExecutions =
+			workflowSettings.saveManualExecutions ?? settingsStore.saveManualExecutions;
 
-	useDocumentTitle().setDocumentTitle(workflowName, 'IDLE');
-	workflowState.setActiveExecutionId(undefined);
-	toast.showMessage({
-		title: message,
-		type: 'success',
-	});
-}
+		if (!saveManualExecutions) {
+			globalLinkActionsEventBus.emit('registerGlobalLinkAction', {
+				key: 'open-settings',
+				action: async () => {
+					if (!workflowsStore.isWorkflowSaved[workflowsStore.workflowId]) {
+						await workflowSaving.saveAsNewWorkflow();
+					}
+					uiStore.openModal(WORKFLOW_SETTINGS_MODAL_KEY);
+				},
+			});
+		}
 
-/**
- * Handle the case when the workflow execution finished successfully.
- */
-export function handleExecutionFinishedWithSuccessOrOther(
-	workflowState: WorkflowState,
-	executionStatus: ExecutionStatus,
-	successToastAlreadyShown: boolean,
-) {
-	const workflowsStore = useWorkflowsStore();
-	const toast = useToast();
-	const i18n = useI18n();
-	const nodeTypesStore = useNodeTypesStore();
+		// Workflow did start but had been put to wait
+		documentTitle.setDocumentTitle(docStore.name, 'IDLE');
+	}
 
-	const workflowDocumentStore = useWorkflowDocumentStore(
-		createWorkflowDocumentId(workflowsStore.workflowId),
-	);
-	const workflowName = workflowDocumentStore.name;
+	function handleExecutionFinishedWithErrorOrCanceled(
+		execution: SimplifiedExecution,
+		runExecutionData: IRunExecutionData,
+	) {
+		documentTitle.setDocumentTitle(workflowDocumentStore.value.name, 'ERROR');
 
-	useDocumentTitle().setDocumentTitle(workflowName, 'IDLE');
+		if (
+			runExecutionData.resultData.error?.name === 'ExpressionError' &&
+			(runExecutionData.resultData.error as ExpressionError).functionality === 'pairedItem'
+		) {
+			const error = runExecutionData.resultData.error as ExpressionError;
 
-	const workflowExecution = workflowsStore.getWorkflowExecution;
-	if (workflowExecution?.executedNode) {
-		const node = workflowDocumentStore.getNodeByName(workflowExecution.executedNode) ?? null;
-		const nodeType = node && nodeTypesStore.getNodeType(node.type, node.typeVersion);
-		const nodeOutput =
-			workflowExecution.data?.resultData?.runData?.[workflowExecution.executedNode];
+			const workflowData = workflowDocumentStore.value.serialize();
+			const eventData: IDataObject = {
+				caused_by_credential: false,
+				error_message: error.description,
+				error_title: error.message,
+				error_type: error.context.type,
+				node_graph_string: JSON.stringify(
+					TelemetryHelpers.generateNodesGraph(
+						workflowData as IWorkflowBase,
+						workflowHelpers.getNodeTypes(),
+					).nodeGraph,
+				),
+				workflow_id: workflowsStore.workflowId,
+			};
 
-		if (nodeType?.polling && !nodeOutput) {
+			if (
+				error.context.nodeCause &&
+				['paired_item_no_info', 'paired_item_invalid_info'].includes(error.context.type as string)
+			) {
+				const node = workflowDocumentStore.value.getNodeByName(error.context.nodeCause as string);
+
+				if (node) {
+					eventData.is_pinned = !!workflowDocumentStore.value.pinData?.[node.name];
+					eventData.mode = node.parameters.mode;
+					eventData.node_type = node.type;
+					eventData.operation = node.parameters.operation;
+					eventData.resource = node.parameters.resource;
+				}
+			}
+
+			telemetry.track('Instance FE emitted paired item error', eventData);
+		}
+
+		// Do not show the error message if the workflow got canceled
+		if (execution.status === 'canceled') {
 			toast.showMessage({
-				title: i18n.baseText('pushConnection.pollingNode.dataNotFound', {
-					interpolate: {
-						service: getTriggerNodeServiceName(nodeType),
-					},
-				}),
-				message: i18n.baseText('pushConnection.pollingNode.dataNotFound.message', {
-					interpolate: {
-						service: getTriggerNodeServiceName(nodeType),
-					},
-				}),
+				title: i18n.baseText('nodeView.showMessage.stopExecutionTry.title'),
 				type: 'success',
 			});
-		} else if (!nodeOutput && !successToastAlreadyShown) {
-			toast.showMessage({
-				title: i18n.baseText('pushConnection.nodeNotExecuted'),
-				message: i18n.baseText('pushConnection.nodeNotExecuted.message'),
-				type: 'warning',
+		} else if (execution.data?.resultData.error) {
+			const { message, title } = getExecutionErrorToastConfiguration({
+				error: execution.data.resultData.error,
+				lastNodeExecuted: execution.data?.resultData.lastNodeExecuted,
 			});
-		} else if (!successToastAlreadyShown) {
-			handleExecutionFinishedSuccessfully(
-				workflowName,
-				i18n.baseText('pushConnection.nodeExecutedSuccessfully'),
-				workflowState,
-			);
+
+			toast.showMessage({ title, message, type: 'error', duration: 0 });
+
+			builderStore.incrementManualExecutionStats('error');
 		}
-	} else if (!successToastAlreadyShown) {
-		handleExecutionFinishedSuccessfully(
-			workflowName,
-			i18n.baseText('pushConnection.workflowExecutedSuccessfully'),
-			workflowState,
-		);
 	}
 
 	// Execution finished is triggered multiple times
 	// use "successToastAlreadyShown" flag to avoid double counting executions
-	if (executionStatus === 'success' && !successToastAlreadyShown) {
-		useBuilderStore().incrementManualExecutionStats('success');
-	}
-}
-
-export function setRunExecutionData(
-	execution: SimplifiedExecution,
-	runExecutionData: IRunExecutionData,
-	workflowState: WorkflowState,
-) {
-	const workflowsStore = useWorkflowsStore();
-	const stateStore = useWorkflowExecutionStateStore(
-		createWorkflowExecutionStateId(workflowsStore.workflowId),
-	);
-	const nodeHelpers = useNodeHelpers();
-	const runDataExecutedErrorMessage = getRunDataExecutedErrorMessage(execution);
-
-	workflowState.executingNode.clearNodeExecutionQueue();
-
-	const executionDataStore = useExecutionDataStore(createExecutionDataId(execution.id));
-	const workflowExecution = executionDataStore.getExecutionSnapshot();
-
-	if (workflowExecution === null) {
-		return;
-	}
-
-	executionDataStore.setExecution({
-		...workflowExecution,
-		status: execution.status,
-		id: execution.id,
-		stoppedAt: execution.stoppedAt,
-	});
-	executionDataStore.setExecutionRunData(runExecutionData);
-	stateStore.setActiveExecutionId(undefined);
-
-	// Set the node execution issues on all the nodes which produced an error so that
-	// it can be displayed in the node-view
-	nodeHelpers.updateNodesExecutionIssues();
-
-	const lastNodeExecuted: string | undefined = runExecutionData.resultData.lastNodeExecuted;
-	let itemsCount = 0;
-	if (
-		lastNodeExecuted &&
-		runExecutionData.resultData.runData[lastNodeExecuted] &&
-		!runDataExecutedErrorMessage
+	function handleExecutionFinishedWithSuccessOrOther(
+		executionStatus: ExecutionStatus,
+		successToastAlreadyShown: boolean,
 	) {
-		itemsCount =
-			runExecutionData.resultData.runData[lastNodeExecuted][0].data?.main[0]?.length ?? 0;
+		const workflowName = workflowDocumentStore.value.name;
+
+		documentTitle.setDocumentTitle(workflowName, 'IDLE');
+
+		const workflowExecution = workflowsStore.getWorkflowExecution;
+		if (workflowExecution?.executedNode) {
+			const node =
+				workflowDocumentStore.value.getNodeByName(workflowExecution.executedNode) ?? null;
+			const nodeType = node && nodeTypesStore.getNodeType(node.type, node.typeVersion);
+			const nodeOutput =
+				workflowExecution.data?.resultData?.runData?.[workflowExecution.executedNode];
+
+			if (nodeType?.polling && !nodeOutput) {
+				toast.showMessage({
+					title: i18n.baseText('pushConnection.pollingNode.dataNotFound', {
+						interpolate: {
+							service: getTriggerNodeServiceName(nodeType),
+						},
+					}),
+					message: i18n.baseText('pushConnection.pollingNode.dataNotFound.message', {
+						interpolate: {
+							service: getTriggerNodeServiceName(nodeType),
+						},
+					}),
+					type: 'success',
+				});
+			} else if (!nodeOutput && !successToastAlreadyShown) {
+				toast.showMessage({
+					title: i18n.baseText('pushConnection.nodeNotExecuted'),
+					message: i18n.baseText('pushConnection.nodeNotExecuted.message'),
+					type: 'warning',
+				});
+			} else if (!successToastAlreadyShown) {
+				handleExecutionFinishedSuccessfully(
+					workflowName,
+					i18n.baseText('pushConnection.nodeExecutedSuccessfully'),
+				);
+			}
+		} else if (!successToastAlreadyShown) {
+			handleExecutionFinishedSuccessfully(
+				workflowName,
+				i18n.baseText('pushConnection.workflowExecutedSuccessfully'),
+			);
+		}
+
+		if (executionStatus === 'success' && !successToastAlreadyShown) {
+			builderStore.incrementManualExecutionStats('success');
+		}
 	}
 
-	stateStore.setActiveExecutionId(undefined);
+	function handleExecutionFinishedSuccessfully(workflowName: string, message: string) {
+		documentTitle.setDocumentTitle(workflowName, 'IDLE');
+		workflowState.setActiveExecutionId(undefined);
+		toast.showMessage({
+			title: message,
+			type: 'success',
+		});
+	}
 
-	void useExternalHooks().run('pushConnection.executionFinished', {
-		itemsCount,
-		nodeName: runExecutionData.resultData.lastNodeExecuted,
-		errorMessage: runDataExecutedErrorMessage,
-		runDataExecutedStartData: runExecutionData.startData,
-		resultDataError: runExecutionData.resultData.error,
-	});
+	function setRunExecutionData(
+		execution: SimplifiedExecution,
+		runExecutionData: IRunExecutionData,
+	) {
+		const stateStore = useWorkflowExecutionStateStore(
+			createWorkflowExecutionStateId(workflowsStore.workflowId),
+		);
+		const runDataExecutedErrorMessage = getRunDataExecutedErrorMessage(execution);
 
-	const lineNumber = runExecutionData.resultData?.error?.lineNumber;
-	codeNodeEditorEventBus.emit('highlightLine', lineNumber ?? 'last');
+		workflowState.executingNode.clearNodeExecutionQueue();
+
+		const executionDataStore = useExecutionDataStore(createExecutionDataId(execution.id));
+		const workflowExecution = executionDataStore.getExecutionSnapshot();
+
+		if (workflowExecution === null) {
+			return;
+		}
+
+		executionDataStore.setExecution({
+			...workflowExecution,
+			status: execution.status,
+			id: execution.id,
+			stoppedAt: execution.stoppedAt,
+		});
+		executionDataStore.setExecutionRunData(runExecutionData);
+		stateStore.setActiveExecutionId(undefined);
+
+		// Set the node execution issues on all the nodes which produced an error so that
+		// it can be displayed in the node-view
+		nodeHelpers.updateNodesExecutionIssues();
+
+		const lastNodeExecuted: string | undefined = runExecutionData.resultData.lastNodeExecuted;
+		let itemsCount = 0;
+		if (
+			lastNodeExecuted &&
+			runExecutionData.resultData.runData[lastNodeExecuted] &&
+			!runDataExecutedErrorMessage
+		) {
+			itemsCount =
+				runExecutionData.resultData.runData[lastNodeExecuted][0].data?.main[0]?.length ?? 0;
+		}
+
+		stateStore.setActiveExecutionId(undefined);
+
+		void externalHooks.run('pushConnection.executionFinished', {
+			itemsCount,
+			nodeName: runExecutionData.resultData.lastNodeExecuted,
+			errorMessage: runDataExecutedErrorMessage,
+			runDataExecutedStartData: runExecutionData.startData,
+			resultDataError: runExecutionData.resultData.error,
+		});
+
+		const lineNumber = runExecutionData.resultData?.error?.lineNumber;
+		codeNodeEditorEventBus.emit('highlightLine', lineNumber ?? 'last');
+	}
+
+	return {
+		executionFinished,
+		continueEvaluationLoop,
+		fetchExecutionData,
+		getRunDataExecutedErrorMessage,
+		handleExecutionFinishedWithWaitTill,
+		handleExecutionFinishedWithErrorOrCanceled,
+		handleExecutionFinishedWithSuccessOrOther,
+		setRunExecutionData,
+		getRunExecutionData,
+	};
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -264,7 +264,7 @@ export function useExecutionFinished() {
 			globalLinkActionsEventBus.emit('registerGlobalLinkAction', {
 				key: 'open-settings',
 				action: async () => {
-					if (!workflowsStore.isWorkflowSaved[workflowsStore.workflowId]) {
+					if (!workflowsStore.isWorkflowSaved[workflowDocumentStore.value.workflowId]) {
 						await workflowSaving.saveAsNewWorkflow();
 					}
 					uiStore.openModal(WORKFLOW_SETTINGS_MODAL_KEY);
@@ -300,7 +300,7 @@ export function useExecutionFinished() {
 						workflowHelpers.getNodeTypes(),
 					).nodeGraph,
 				),
-				workflow_id: workflowsStore.workflowId,
+				workflow_id: workflowDocumentStore.value.workflowId,
 			};
 
 			if (
@@ -409,7 +409,7 @@ export function useExecutionFinished() {
 		runExecutionData: IRunExecutionData,
 	) {
 		const stateStore = useWorkflowExecutionStateStore(
-			createWorkflowExecutionStateId(workflowsStore.workflowId),
+			createWorkflowExecutionStateId(workflowDocumentStore.value.workflowId),
 		);
 		const runDataExecutedErrorMessage = getRunDataExecutedErrorMessage(execution);
 

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionRecovered.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionRecovered.ts
@@ -1,54 +1,55 @@
 import type { ExecutionRecovered } from '@n8n/api-types/push/execution';
 import { useUIStore } from '@/app/stores/ui.store';
-import {
-	fetchExecutionData,
-	getRunExecutionData,
-	handleExecutionFinishedWithSuccessOrOther,
-	handleExecutionFinishedWithErrorOrCanceled,
-	handleExecutionFinishedWithWaitTill,
-	setRunExecutionData,
-} from './executionFinished';
+import { useExecutionFinished } from './executionFinished';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
 	createWorkflowExecutionStateId,
 	useWorkflowExecutionStateStore,
 } from '@/app/stores/workflowExecutionState.store';
-import type { useRouter } from 'vue-router';
-import type { WorkflowState } from '@/app/composables/useWorkflowState';
 
-export async function executionRecovered(
-	{ data }: ExecutionRecovered,
-	options: { router: ReturnType<typeof useRouter>; workflowState: WorkflowState },
-) {
+export function useExecutionRecovered() {
 	const workflowsStore = useWorkflowsStore();
-	const stateStore = useWorkflowExecutionStateStore(
-		createWorkflowExecutionStateId(workflowsStore.workflowId),
-	);
 	const uiStore = useUIStore();
+	const {
+		fetchExecutionData,
+		handleExecutionFinishedWithWaitTill,
+		handleExecutionFinishedWithErrorOrCanceled,
+		handleExecutionFinishedWithSuccessOrOther,
+		setRunExecutionData,
+		getRunExecutionData,
+	} = useExecutionFinished();
 
-	// No workflow is actively running, therefore we ignore this event
-	if (typeof stateStore.activeExecutionId === 'undefined') {
-		return;
-	}
+	async function executionRecovered({ data }: ExecutionRecovered) {
+		const stateStore = useWorkflowExecutionStateStore(
+			createWorkflowExecutionStateId(workflowsStore.workflowId),
+		);
 
-	uiStore.setProcessingExecutionResults(true);
+		// No workflow is actively running, therefore we ignore this event
+		if (typeof stateStore.activeExecutionId === 'undefined') {
+			return;
+		}
 
-	const execution = await fetchExecutionData(data.executionId);
-	if (!execution) {
+		uiStore.setProcessingExecutionResults(true);
+
+		const execution = await fetchExecutionData(data.executionId);
+		if (!execution) {
+			uiStore.setProcessingExecutionResults(false);
+			return;
+		}
+
+		const runExecutionData = getRunExecutionData(execution);
 		uiStore.setProcessingExecutionResults(false);
-		return;
+
+		if (execution.data?.waitTill !== undefined) {
+			handleExecutionFinishedWithWaitTill(execution.workflowId ?? '');
+		} else if (execution.status === 'error' || execution.status === 'canceled') {
+			handleExecutionFinishedWithErrorOrCanceled(execution, runExecutionData);
+		} else {
+			handleExecutionFinishedWithSuccessOrOther(execution.status, false);
+		}
+
+		setRunExecutionData(execution, runExecutionData);
 	}
 
-	const runExecutionData = getRunExecutionData(execution);
-	uiStore.setProcessingExecutionResults(false);
-
-	if (execution.data?.waitTill !== undefined) {
-		handleExecutionFinishedWithWaitTill(execution.workflowId ?? '', options);
-	} else if (execution.status === 'error' || execution.status === 'canceled') {
-		handleExecutionFinishedWithErrorOrCanceled(execution, runExecutionData);
-	} else {
-		handleExecutionFinishedWithSuccessOrOther(options.workflowState, execution.status, false);
-	}
-
-	setRunExecutionData(execution, runExecutionData, options.workflowState);
+	return { executionRecovered };
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionRecovered.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionRecovered.ts
@@ -1,15 +1,19 @@
 import type { ExecutionRecovered } from '@n8n/api-types/push/execution';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useExecutionFinished } from './executionFinished';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
 	createWorkflowExecutionStateId,
 	useWorkflowExecutionStateStore,
 } from '@/app/stores/workflowExecutionState.store';
+import { computed } from 'vue';
+import { useWorkflowId } from '../../useWorkflowId';
 
 export function useExecutionRecovered() {
-	const workflowsStore = useWorkflowsStore();
+	const workflowId = useWorkflowId();
 	const uiStore = useUIStore();
+	const stateStore = computed(() =>
+		useWorkflowExecutionStateStore(createWorkflowExecutionStateId(workflowId.value)),
+	);
 	const {
 		fetchExecutionData,
 		handleExecutionFinishedWithWaitTill,
@@ -20,12 +24,8 @@ export function useExecutionRecovered() {
 	} = useExecutionFinished();
 
 	async function executionRecovered({ data }: ExecutionRecovered) {
-		const stateStore = useWorkflowExecutionStateStore(
-			createWorkflowExecutionStateId(workflowsStore.workflowId),
-		);
-
 		// No workflow is actively running, therefore we ignore this event
-		if (typeof stateStore.activeExecutionId === 'undefined') {
+		if (typeof stateStore.value.activeExecutionId === 'undefined') {
 			return;
 		}
 

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionStarted.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionStarted.test.ts
@@ -1,6 +1,6 @@
+import { ref } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
-import { executionStarted } from './executionStarted';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useExecutionStarted } from './executionStarted';
 import {
 	createWorkflowDocumentId,
 	useWorkflowDocumentStore,
@@ -12,9 +12,13 @@ import {
 } from '@/app/stores/workflowExecutionState.store';
 import { createExecutionDataId, useExecutionDataStore } from '@/app/stores/executionData.store';
 
+vi.mock('../../useWorkflowId', () => ({
+	useWorkflowId: vi.fn(() => ref('wf-123')),
+}));
+
 describe('executionStarted', () => {
-	let workflowsStore: ReturnType<typeof useWorkflowsStore>;
 	let stateStore: ReturnType<typeof useWorkflowExecutionStateStore>;
+	let executionStarted: ReturnType<typeof useExecutionStarted>['executionStarted'];
 
 	function makeEvent(executionId = 'exec-1'): ExecutionStarted {
 		return {
@@ -26,13 +30,12 @@ describe('executionStarted', () => {
 	beforeEach(() => {
 		setActivePinia(createPinia());
 
-		workflowsStore = useWorkflowsStore();
-		workflowsStore.setWorkflowId('wf-123');
-
 		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId('wf-123'));
 		workflowDocumentStore.setName('My Workflow');
 
 		stateStore = useWorkflowExecutionStateStore(createWorkflowExecutionStateId('wf-123'));
+
+		({ executionStarted } = useExecutionStarted());
 	});
 
 	it('should skip when activeExecutionId is undefined', async () => {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionStarted.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionStarted.ts
@@ -1,5 +1,4 @@
 import type { ExecutionStarted } from '@n8n/api-types/push/execution';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
 	createWorkflowDocumentId,
 	useWorkflowDocumentStore,
@@ -12,62 +11,68 @@ import { createExecutionDataId, useExecutionDataStore } from '@/app/stores/execu
 import { parse } from 'flatted';
 import { createRunExecutionData } from 'n8n-workflow';
 import type { IRunExecutionData } from 'n8n-workflow';
+import { useWorkflowId } from '../../useWorkflowId';
+import { computed } from 'vue';
 
 /**
  * Handles the 'executionStarted' event, which happens when a workflow is executed.
  */
-export async function executionStarted({ data }: ExecutionStarted) {
-	const workflowsStore = useWorkflowsStore();
-	const stateStore = useWorkflowExecutionStateStore(
-		createWorkflowExecutionStateId(workflowsStore.workflowId),
+export function useExecutionStarted() {
+	const workflowId = useWorkflowId();
+	const workflowDocumentStore = computed(() =>
+		useWorkflowDocumentStore(createWorkflowDocumentId(workflowId.value)),
 	);
-	const isIframe = window !== window.parent;
 
-	// In non-iframe context, undefined means "not tracking executions" → skip.
-	// In iframe context, executionFinished resets activeExecutionId to undefined,
-	// but we still want to accept new executions (re-execution scenario).
-	if (typeof stateStore.activeExecutionId === 'undefined' && !isIframe) {
-		return;
-	}
-
-	// Determine if we need to (re)initialize execution tracking state
-	const needsInit =
-		stateStore.activeExecutionId === null ||
-		typeof stateStore.activeExecutionId === 'undefined' ||
-		(isIframe && stateStore.activeExecutionId !== data.executionId);
-
-	if (needsInit) {
-		stateStore.promotePendingExecution(data.executionId);
-	}
-
-	const executionDataStore = useExecutionDataStore(createExecutionDataId(data.executionId));
-
-	// Initialize or reinitialize execution data to clear previous execution's
-	// node status (e.g. DemoLayout iframe receiving push events for a new execution).
-	if (!executionDataStore.execution?.data || needsInit) {
-		const workflowDocumentStore = useWorkflowDocumentStore(
-			createWorkflowDocumentId(workflowsStore.workflowId),
+	async function executionStarted({ data }: ExecutionStarted) {
+		const stateStore = useWorkflowExecutionStateStore(
+			createWorkflowExecutionStateId(workflowId.value),
 		);
+		const isIframe = window !== window.parent;
 
-		executionDataStore.setExecution({
-			id: data.executionId,
-			finished: false,
-			mode: 'manual',
-			status: 'running',
-			createdAt: new Date(),
-			startedAt: new Date(),
-			workflowData: workflowDocumentStore.getSnapshot(),
-			data: createRunExecutionData(),
-		});
+		// In non-iframe context, undefined means "not tracking executions" → skip.
+		// In iframe context, executionFinished resets activeExecutionId to undefined,
+		// but we still want to accept new executions (re-execution scenario).
+		if (typeof stateStore.activeExecutionId === 'undefined' && !isIframe) {
+			return;
+		}
+
+		// Determine if we need to (re)initialize execution tracking state
+		const needsInit =
+			stateStore.activeExecutionId === null ||
+			typeof stateStore.activeExecutionId === 'undefined' ||
+			(isIframe && stateStore.activeExecutionId !== data.executionId);
+
+		if (needsInit) {
+			stateStore.promotePendingExecution(data.executionId);
+		}
+
+		const executionDataStore = useExecutionDataStore(createExecutionDataId(data.executionId));
+
+		// Initialize or reinitialize execution data to clear previous execution's
+		// node status (e.g. DemoLayout iframe receiving push events for a new execution).
+		if (!executionDataStore.execution?.data || needsInit) {
+			executionDataStore.setExecution({
+				id: data.executionId,
+				finished: false,
+				mode: 'manual',
+				status: 'running',
+				createdAt: new Date(),
+				startedAt: new Date(),
+				workflowData: workflowDocumentStore.value.getSnapshot(),
+				data: createRunExecutionData(),
+			});
+		}
+
+		if (executionDataStore.execution?.data && data.flattedRunData) {
+			executionDataStore.setExecutionRunData({
+				...executionDataStore.execution.data,
+				resultData: {
+					...executionDataStore.execution.data.resultData,
+					runData: parse(data.flattedRunData),
+				},
+			} as IRunExecutionData);
+		}
 	}
 
-	if (executionDataStore.execution?.data && data.flattedRunData) {
-		executionDataStore.setExecutionRunData({
-			...executionDataStore.execution.data,
-			resultData: {
-				...executionDataStore.execution.data.resultData,
-				runData: parse(data.flattedRunData),
-			},
-		} as IRunExecutionData);
-	}
+	return { executionStarted };
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/index.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/index.ts
@@ -12,6 +12,7 @@ export * from './sendConsoleMessage';
 export * from './sendWorkerStatusMessage';
 export * from './testWebhookDeleted';
 export * from './testWebhookReceived';
+export * from './trackNodeExecution';
 export * from './workflowActivated';
 export * from './workflowAutoDeactivated';
 export * from './workflowDeactivated';

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeDescriptionUpdated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeDescriptionUpdated.ts
@@ -6,11 +6,15 @@ import { useCredentialsStore } from '@/features/credentials/credentials.store';
  * Handles the 'nodeDescriptionUpdated' event from the push connection, which indicates
  * that a node description has been updated.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export async function nodeDescriptionUpdated(_event: NodeDescriptionUpdated) {
+export function useNodeDescriptionUpdated() {
 	const nodeTypesStore = useNodeTypesStore();
 	const credentialsStore = useCredentialsStore();
 
-	await nodeTypesStore.getNodeTypes();
-	await credentialsStore.fetchCredentialTypes(true);
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	async function nodeDescriptionUpdated(_event: NodeDescriptionUpdated) {
+		await nodeTypesStore.getNodeTypes();
+		await credentialsStore.fetchCredentialTypes(true);
+	}
+
+	return { nodeDescriptionUpdated };
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.test.ts
@@ -1,6 +1,6 @@
+import { ref } from 'vue';
 import { createPinia, setActivePinia } from 'pinia';
 import { useNodeExecuteAfter } from './nodeExecuteAfter';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useAssistantStore } from '@/features/ai/assistant/assistant.store';
 import type { NodeExecuteAfter } from '@n8n/api-types/push/execution';
 import { TRIMMED_TASK_DATA_CONNECTIONS_KEY } from 'n8n-workflow';
@@ -31,6 +31,10 @@ vi.mock('./trackNodeExecution', () => ({
 	})),
 }));
 
+vi.mock('../../useWorkflowId', () => ({
+	useWorkflowId: vi.fn(() => ref('test-wf')),
+}));
+
 const mockWorkflowState = mock<WorkflowState>({
 	executingNode: {
 		removeExecutingNode: vi.fn(),
@@ -44,7 +48,6 @@ vi.mock('@/app/composables/useWorkflowState', () => ({
 import { openFormPopupWindow } from '@/features/execution/executions/executions.utils';
 
 describe('nodeExecuteAfter', () => {
-	let workflowsStore: ReturnType<typeof useWorkflowsStore>;
 	let stateStore: ReturnType<typeof useWorkflowExecutionStateStore>;
 	let executionDataStore: ReturnType<typeof useExecutionDataStore>;
 	let nodeExecuteAfter: ReturnType<typeof useNodeExecuteAfter>['nodeExecuteAfter'];
@@ -54,9 +57,6 @@ describe('nodeExecuteAfter', () => {
 		setActivePinia(createPinia());
 
 		({ nodeExecuteAfter } = useNodeExecuteAfter());
-
-		workflowsStore = useWorkflowsStore();
-		workflowsStore.setWorkflowId('test-wf');
 
 		stateStore = useWorkflowExecutionStateStore(createWorkflowExecutionStateId('test-wf'));
 

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.test.ts
@@ -1,12 +1,11 @@
 import { createPinia, setActivePinia } from 'pinia';
-import { nodeExecuteAfter } from './nodeExecuteAfter';
+import { useNodeExecuteAfter } from './nodeExecuteAfter';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useAssistantStore } from '@/features/ai/assistant/assistant.store';
 import type { NodeExecuteAfter } from '@n8n/api-types/push/execution';
 import { TRIMMED_TASK_DATA_CONNECTIONS_KEY } from 'n8n-workflow';
 import type { WorkflowState } from '@/app/composables/useWorkflowState';
 import { mock } from 'vitest-mock-extended';
-import type { Mocked } from 'vitest';
 import {
 	createWorkflowExecutionStateId,
 	useWorkflowExecutionStateStore,
@@ -26,17 +25,35 @@ vi.mock('@/features/execution/executions/executions.utils', async (importOrigina
 	return { ...actual, openFormPopupWindow: vi.fn() };
 });
 
+vi.mock('./trackNodeExecution', () => ({
+	useTrackNodeExecution: vi.fn(() => ({
+		trackNodeExecution: vi.fn(),
+	})),
+}));
+
+const mockWorkflowState = mock<WorkflowState>({
+	executingNode: {
+		removeExecutingNode: vi.fn(),
+	},
+});
+
+vi.mock('@/app/composables/useWorkflowState', () => ({
+	injectWorkflowState: vi.fn(() => mockWorkflowState),
+}));
+
 import { openFormPopupWindow } from '@/features/execution/executions/executions.utils';
 
 describe('nodeExecuteAfter', () => {
-	let mockOptions: { workflowState: Mocked<WorkflowState> };
 	let workflowsStore: ReturnType<typeof useWorkflowsStore>;
 	let stateStore: ReturnType<typeof useWorkflowExecutionStateStore>;
 	let executionDataStore: ReturnType<typeof useExecutionDataStore>;
+	let nodeExecuteAfter: ReturnType<typeof useNodeExecuteAfter>['nodeExecuteAfter'];
 
 	beforeEach(() => {
 		vi.mocked(openFormPopupWindow).mockClear();
 		setActivePinia(createPinia());
+
+		({ nodeExecuteAfter } = useNodeExecuteAfter());
 
 		workflowsStore = useWorkflowsStore();
 		workflowsStore.setWorkflowId('test-wf');
@@ -54,14 +71,6 @@ describe('nodeExecuteAfter', () => {
 		);
 
 		stateStore.setActiveExecutionId('exec-1');
-
-		mockOptions = {
-			workflowState: mock<WorkflowState>({
-				executingNode: {
-					removeExecutingNode: vi.fn(),
-				},
-			}),
-		};
 	});
 
 	it('should update node execution data with placeholder and remove executing node', async () => {
@@ -82,12 +91,10 @@ describe('nodeExecuteAfter', () => {
 			},
 		};
 
-		await nodeExecuteAfter(event, mockOptions);
+		await nodeExecuteAfter(event);
 
-		expect(mockOptions.workflowState.executingNode.removeExecutingNode).toHaveBeenCalledTimes(1);
-		expect(mockOptions.workflowState.executingNode.removeExecutingNode).toHaveBeenCalledWith(
-			'Test Node',
-		);
+		expect(mockWorkflowState.executingNode.removeExecutingNode).toHaveBeenCalledTimes(1);
+		expect(mockWorkflowState.executingNode.removeExecutingNode).toHaveBeenCalledWith('Test Node');
 		expect(assistantStore.onNodeExecution).toHaveBeenCalledTimes(1);
 		expect(assistantStore.onNodeExecution).toHaveBeenCalledWith(event.data);
 
@@ -122,7 +129,7 @@ describe('nodeExecuteAfter', () => {
 			},
 		};
 
-		await nodeExecuteAfter(event, mockOptions);
+		await nodeExecuteAfter(event);
 
 		const runData = executionDataStore.execution?.data?.resultData.runData;
 		expect(runData?.['Test Node'][0].data).toEqual({
@@ -155,7 +162,7 @@ describe('nodeExecuteAfter', () => {
 			},
 		};
 
-		await nodeExecuteAfter(event, mockOptions);
+		await nodeExecuteAfter(event);
 
 		const runData = executionDataStore.execution?.data?.resultData.runData;
 		expect(runData?.['Test Node'][0].data).toEqual({
@@ -179,7 +186,7 @@ describe('nodeExecuteAfter', () => {
 			},
 		};
 
-		await nodeExecuteAfter(event, mockOptions);
+		await nodeExecuteAfter(event);
 
 		const runData = executionDataStore.execution?.data?.resultData.runData;
 		const taskData = runData?.['Test Node'][0];
@@ -216,7 +223,7 @@ describe('nodeExecuteAfter', () => {
 			},
 		};
 
-		await nodeExecuteAfter(event, mockOptions);
+		await nodeExecuteAfter(event);
 
 		const runData = executionDataStore.execution?.data?.resultData.runData;
 		// Should only contain main connection, invalid_connection should be filtered out
@@ -247,7 +254,7 @@ describe('nodeExecuteAfter', () => {
 			},
 		};
 
-		await nodeExecuteAfter(event, mockOptions);
+		await nodeExecuteAfter(event);
 
 		expect(openFormPopupWindow).toHaveBeenCalledWith(formUrl);
 	});
@@ -269,7 +276,7 @@ describe('nodeExecuteAfter', () => {
 			},
 		};
 
-		await nodeExecuteAfter(event, mockOptions);
+		await nodeExecuteAfter(event);
 
 		expect(openFormPopupWindow).not.toHaveBeenCalled();
 	});

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.ts
@@ -1,6 +1,5 @@
 import type { NodeExecuteAfter } from '@n8n/api-types/push/execution';
 import { useAssistantStore } from '@/features/ai/assistant/assistant.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
 	createWorkflowExecutionStateId,
 	useWorkflowExecutionStateStore,
@@ -13,18 +12,19 @@ import { isValidNodeConnectionType } from '@/app/utils/typeGuards';
 import { openFormPopupWindow } from '@/features/execution/executions/executions.utils';
 import { useTrackNodeExecution } from './trackNodeExecution';
 import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import { useWorkflowId } from '../../useWorkflowId';
+import { computed } from 'vue';
 
 export function useNodeExecuteAfter() {
 	const { trackNodeExecution } = useTrackNodeExecution();
-	const workflowsStore = useWorkflowsStore();
+	const workflowId = useWorkflowId();
 	const assistantStore = useAssistantStore();
 	const workflowState = injectWorkflowState();
+	const stateStore = computed(() =>
+		useWorkflowExecutionStateStore(createWorkflowExecutionStateId(workflowId.value)),
+	);
 
 	async function nodeExecuteAfter({ data: pushData }: NodeExecuteAfter) {
-		const stateStore = useWorkflowExecutionStateStore(
-			createWorkflowExecutionStateId(workflowsStore.workflowId),
-		);
-
 		const placeholderOutputData: ITaskData['data'] = {
 			main: [],
 		};
@@ -53,7 +53,7 @@ export function useNodeExecuteAfter() {
 			},
 		};
 
-		const activeExecutionId = stateStore.activeExecutionId;
+		const activeExecutionId = stateStore.value.activeExecutionId;
 		if (typeof activeExecutionId === 'string') {
 			useExecutionDataStore(createExecutionDataId(activeExecutionId)).updateNodeExecutionStatus(
 				pushDataWithPlaceholderOutputData,

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.ts
@@ -11,74 +11,69 @@ import { TRIMMED_TASK_DATA_CONNECTIONS_KEY } from 'n8n-workflow';
 import type { PushPayload } from '@n8n/api-types';
 import { isValidNodeConnectionType } from '@/app/utils/typeGuards';
 import { openFormPopupWindow } from '@/features/execution/executions/executions.utils';
-import { trackNodeExecution } from './trackNodeExecution';
-import type { WorkflowState } from '@/app/composables/useWorkflowState';
+import { useTrackNodeExecution } from './trackNodeExecution';
+import { injectWorkflowState } from '@/app/composables/useWorkflowState';
 
-/**
- * Handles the 'nodeExecuteAfter' event, which happens after a node is executed.
- */
-export async function nodeExecuteAfter(
-	{ data: pushData }: NodeExecuteAfter,
-	{ workflowState }: { workflowState: WorkflowState },
-) {
+export function useNodeExecuteAfter() {
+	const { trackNodeExecution } = useTrackNodeExecution();
 	const workflowsStore = useWorkflowsStore();
-	const stateStore = useWorkflowExecutionStateStore(
-		createWorkflowExecutionStateId(workflowsStore.workflowId),
-	);
 	const assistantStore = useAssistantStore();
+	const workflowState = injectWorkflowState();
 
-	/**
-	 * We trim the actual data returned from the node execution to avoid performance issues
-	 * when dealing with large datasets. Instead of storing the actual data, we initially store
-	 * a placeholder object indicating that the data has been trimmed until the
-	 * `nodeExecuteAfterData` event comes in.
-	 */
-
-	const placeholderOutputData: ITaskData['data'] = {
-		main: [],
-	};
-
-	if (
-		pushData.itemCountByConnectionType &&
-		typeof pushData.itemCountByConnectionType === 'object'
-	) {
-		const fillObject: INodeExecutionData = { json: { [TRIMMED_TASK_DATA_CONNECTIONS_KEY]: true } };
-		for (const [connectionType, outputs] of Object.entries(pushData.itemCountByConnectionType)) {
-			if (isValidNodeConnectionType(connectionType)) {
-				placeholderOutputData[connectionType] = outputs.map((count) =>
-					Array.from({ length: count }, () => fillObject),
-				);
-			}
-		}
-	}
-
-	const pushDataWithPlaceholderOutputData: PushPayload<'nodeExecuteAfterData'> = {
-		...pushData,
-		data: {
-			...pushData.data,
-			data: placeholderOutputData,
-		},
-	};
-
-	const activeExecutionId = stateStore.activeExecutionId;
-	if (typeof activeExecutionId === 'string') {
-		useExecutionDataStore(createExecutionDataId(activeExecutionId)).updateNodeExecutionStatus(
-			pushDataWithPlaceholderOutputData,
+	async function nodeExecuteAfter({ data: pushData }: NodeExecuteAfter) {
+		const stateStore = useWorkflowExecutionStateStore(
+			createWorkflowExecutionStateId(workflowsStore.workflowId),
 		);
 
-		if (pushDataWithPlaceholderOutputData.data.executionStatus !== 'waiting') {
-			void trackNodeExecution(pushDataWithPlaceholderOutputData, workflowsStore.workflowId);
+		const placeholderOutputData: ITaskData['data'] = {
+			main: [],
+		};
+
+		if (
+			pushData.itemCountByConnectionType &&
+			typeof pushData.itemCountByConnectionType === 'object'
+		) {
+			const fillObject: INodeExecutionData = {
+				json: { [TRIMMED_TASK_DATA_CONNECTIONS_KEY]: true },
+			};
+			for (const [connectionType, outputs] of Object.entries(pushData.itemCountByConnectionType)) {
+				if (isValidNodeConnectionType(connectionType)) {
+					placeholderOutputData[connectionType] = outputs.map((count) =>
+						Array.from({ length: count }, () => fillObject),
+					);
+				}
+			}
 		}
+
+		const pushDataWithPlaceholderOutputData: PushPayload<'nodeExecuteAfterData'> = {
+			...pushData,
+			data: {
+				...pushData.data,
+				data: placeholderOutputData,
+			},
+		};
+
+		const activeExecutionId = stateStore.activeExecutionId;
+		if (typeof activeExecutionId === 'string') {
+			useExecutionDataStore(createExecutionDataId(activeExecutionId)).updateNodeExecutionStatus(
+				pushDataWithPlaceholderOutputData,
+			);
+
+			if (pushDataWithPlaceholderOutputData.data.executionStatus !== 'waiting') {
+				void trackNodeExecution(pushDataWithPlaceholderOutputData);
+			}
+		}
+
+		workflowState.executingNode.removeExecutingNode(pushData.nodeName);
+
+		if (pushData.data.executionStatus === 'waiting' && pushData.data.metadata?.resumeFormUrl) {
+			openFormPopupWindow(pushData.data.metadata.resumeFormUrl);
+		} else if (pushData.data.executionStatus !== 'waiting') {
+			void trackNodeExecution(pushData);
+		}
+
+		void assistantStore.onNodeExecution(pushData);
 	}
 
-	workflowState.executingNode.removeExecutingNode(pushData.nodeName);
-
-	// Side effects
-	if (pushData.data.executionStatus === 'waiting' && pushData.data.metadata?.resumeFormUrl) {
-		openFormPopupWindow(pushData.data.metadata.resumeFormUrl);
-	} else if (pushData.data.executionStatus !== 'waiting') {
-		void trackNodeExecution(pushData, workflowsStore.workflowId);
-	}
-
-	void assistantStore.onNodeExecution(pushData);
+	return { nodeExecuteAfter };
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfterData.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfterData.test.ts
@@ -1,5 +1,5 @@
 import { createPinia, setActivePinia } from 'pinia';
-import { nodeExecuteAfterData } from './nodeExecuteAfterData';
+import { useNodeExecuteAfterData } from './nodeExecuteAfterData';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import type { NodeExecuteAfterData } from '@n8n/api-types/push/execution';
 import { createRunExecutionData } from 'n8n-workflow';
@@ -14,6 +14,7 @@ describe('nodeExecuteAfterData', () => {
 	let workflowsStore: ReturnType<typeof useWorkflowsStore>;
 	let stateStore: ReturnType<typeof useWorkflowExecutionStateStore>;
 	let executionDataStore: ReturnType<typeof useExecutionDataStore>;
+	let nodeExecuteAfterData: ReturnType<typeof useNodeExecuteAfterData>['nodeExecuteAfterData'];
 
 	beforeEach(() => {
 		setActivePinia(createPinia());
@@ -50,6 +51,8 @@ describe('nodeExecuteAfterData', () => {
 		);
 
 		stateStore.setActiveExecutionId('exec-1');
+
+		({ nodeExecuteAfterData } = useNodeExecuteAfterData());
 	});
 
 	it('should update node execution data with incoming payload', async () => {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfterData.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfterData.ts
@@ -1,42 +1,45 @@
 import type { NodeExecuteAfterData } from '@n8n/api-types/push/execution';
 import { useSchemaPreviewStore } from '@/features/ndv/runData/schemaPreview.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import { computed } from 'vue';
 import {
 	createWorkflowExecutionStateId,
 	useWorkflowExecutionStateStore,
 } from '@/app/stores/workflowExecutionState.store';
 import { createExecutionDataId, useExecutionDataStore } from '@/app/stores/executionData.store';
-import {
-	createWorkflowDocumentId,
-	useWorkflowDocumentStore,
-} from '@/app/stores/workflowDocument.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import { computed } from 'vue';
 
 /**
  * Handles the 'nodeExecuteAfterData' event, which is sent after a node has executed and contains the resulting data.
  */
-export async function nodeExecuteAfterData({ data: pushData }: NodeExecuteAfterData) {
-	const workflowsStore = useWorkflowsStore();
-	const stateStore = useWorkflowExecutionStateStore(
-		createWorkflowExecutionStateId(workflowsStore.workflowId),
-	);
-	const workflowDocumentStore = computed(() =>
-		useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId)),
-	);
+export function useNodeExecuteAfterData() {
 	const schemaPreviewStore = useSchemaPreviewStore();
+	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const stateStore = computed(() =>
+		useWorkflowExecutionStateStore(
+			createWorkflowExecutionStateId(workflowDocumentStore.value.workflowId),
+		),
+	);
 
-	const activeExecutionId = stateStore.activeExecutionId;
-	if (typeof activeExecutionId === 'string') {
-		useExecutionDataStore(createExecutionDataId(activeExecutionId)).updateNodeExecutionRunData(
+	async function nodeExecuteAfterData({ data: pushData }: NodeExecuteAfterData) {
+		const activeExecutionId = stateStore.value.activeExecutionId;
+		if (typeof activeExecutionId === 'string') {
+			useExecutionDataStore(createExecutionDataId(activeExecutionId)).updateNodeExecutionRunData(
+				pushData,
+			);
+		}
+
+		const node = workflowDocumentStore.value.getNodeByName(pushData.nodeName);
+
+		if (!node) {
+			return;
+		}
+
+		void schemaPreviewStore.trackSchemaPreviewExecution(
+			workflowDocumentStore.value.workflowId,
+			node,
 			pushData,
 		);
 	}
 
-	const node = workflowDocumentStore.value.getNodeByName(pushData.nodeName);
-
-	if (!node) {
-		return;
-	}
-
-	void schemaPreviewStore.trackSchemaPreviewExecution(workflowsStore.workflowId, node, pushData);
+	return { nodeExecuteAfterData };
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteBefore.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteBefore.ts
@@ -1,30 +1,33 @@
 import type { NodeExecuteBefore } from '@n8n/api-types/push/execution';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
 	createWorkflowExecutionStateId,
 	useWorkflowExecutionStateStore,
 } from '@/app/stores/workflowExecutionState.store';
 import { createExecutionDataId, useExecutionDataStore } from '@/app/stores/executionData.store';
-import type { WorkflowState } from '@/app/composables/useWorkflowState';
+import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import { computed } from 'vue';
+import { useWorkflowId } from '../../useWorkflowId';
 
 /**
  * Handles the 'nodeExecuteBefore' event, which happens before a node is executed.
  */
-export async function nodeExecuteBefore(
-	{ data }: NodeExecuteBefore,
-	{ workflowState }: { workflowState: WorkflowState },
-) {
-	const workflowsStore = useWorkflowsStore();
-	const stateStore = useWorkflowExecutionStateStore(
-		createWorkflowExecutionStateId(workflowsStore.workflowId),
+export function useNodeExecuteBefore() {
+	const workflowState = injectWorkflowState();
+	const workflowId = useWorkflowId();
+	const stateStore = computed(() =>
+		useWorkflowExecutionStateStore(createWorkflowExecutionStateId(workflowId.value)),
 	);
 
-	workflowState.executingNode.addExecutingNode(data.nodeName);
+	async function nodeExecuteBefore({ data }: NodeExecuteBefore) {
+		workflowState.executingNode.addExecutingNode(data.nodeName);
 
-	const activeExecutionId = stateStore.activeExecutionId;
-	if (typeof activeExecutionId === 'string') {
-		useExecutionDataStore(createExecutionDataId(activeExecutionId)).addNodeExecutionStartedData(
-			data,
-		);
+		const activeExecutionId = stateStore?.value?.activeExecutionId;
+		if (typeof activeExecutionId === 'string') {
+			useExecutionDataStore(createExecutionDataId(activeExecutionId)).addNodeExecutionStartedData(
+				data,
+			);
+		}
 	}
+
+	return { nodeExecuteBefore };
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/reloadNodeType.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/reloadNodeType.ts
@@ -6,10 +6,14 @@ import { isCommunityPackageName } from 'n8n-workflow';
  * Handles the 'reloadNodeType' event from the push connection, which indicates
  * that a node type needs to be reloaded.
  */
-export async function reloadNodeType({ data }: ReloadNodeType) {
+export function useReloadNodeType() {
 	const nodeTypesStore = useNodeTypesStore();
 
-	await nodeTypesStore.getNodeTypes();
-	const isCommunityNode = isCommunityPackageName(data.name);
-	await nodeTypesStore.getFullNodesProperties([data], !isCommunityNode);
+	async function reloadNodeType({ data }: ReloadNodeType) {
+		await nodeTypesStore.getNodeTypes();
+		const isCommunityNode = isCommunityPackageName(data.name);
+		await nodeTypesStore.getFullNodesProperties([data], !isCommunityNode);
+	}
+
+	return { reloadNodeType };
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/removeNodeType.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/removeNodeType.ts
@@ -7,14 +7,18 @@ import { useCredentialsStore } from '@/features/credentials/credentials.store';
  * Handles the 'removeNodeType' event from the push connection, which indicates
  * that a node type needs to be removed
  */
-export async function removeNodeType({ data }: RemoveNodeType) {
+export function useRemoveNodeType() {
 	const nodeTypesStore = useNodeTypesStore();
 	const credentialsStore = useCredentialsStore();
 
-	const nodesToBeRemoved: INodeTypeNameVersion[] = [data];
+	async function removeNodeType({ data }: RemoveNodeType) {
+		const nodesToBeRemoved: INodeTypeNameVersion[] = [data];
 
-	// Force reload of all credential types
-	await credentialsStore.fetchCredentialTypes(false).then(() => {
-		nodeTypesStore.removeNodeTypes(nodesToBeRemoved as INodeTypeDescription[]);
-	});
+		// Force reload of all credential types
+		await credentialsStore.fetchCredentialTypes(false).then(() => {
+			nodeTypesStore.removeNodeTypes(nodesToBeRemoved as INodeTypeDescription[]);
+		});
+	}
+
+	return { removeNodeType };
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/sendConsoleMessage.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/sendConsoleMessage.ts
@@ -4,6 +4,10 @@ import type { SendConsoleMessage } from '@n8n/api-types/push/debug';
  * Handles the 'sendConsoleMessage' event from the push connection, which indicates
  * that a console message should be sent.
  */
-export async function sendConsoleMessage({ data }: SendConsoleMessage) {
-	console.log(data.source, ...data.messages);
+export function useSendConsoleMessage() {
+	async function sendConsoleMessage({ data }: SendConsoleMessage) {
+		console.log(data.source, ...data.messages);
+	}
+
+	return { sendConsoleMessage };
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/sendWorkerStatusMessage.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/sendWorkerStatusMessage.ts
@@ -5,7 +5,12 @@ import { useOrchestrationStore } from '@/features/settings/orchestration.ee/orch
  * Handles the 'sendWorkerStatusMessage' event from the push connection, which indicates
  * that a worker status message should be sent.
  */
-export async function sendWorkerStatusMessage({ data }: SendWorkerStatusMessage) {
+export function useSendWorkerStatusMessage() {
 	const orchestrationStore = useOrchestrationStore();
-	orchestrationStore.updateWorkerStatus(data.status);
+
+	async function sendWorkerStatusMessage({ data }: SendWorkerStatusMessage) {
+		orchestrationStore.updateWorkerStatus(data.status);
+	}
+
+	return { sendWorkerStatusMessage };
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/testWebhookDeleted.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/testWebhookDeleted.ts
@@ -1,18 +1,22 @@
 import type { TestWebhookDeleted } from '@n8n/api-types/push/webhook';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import type { WorkflowState } from '@/app/composables/useWorkflowState';
+import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 /**
  * Handles the 'testWebhookDeleted' push message, which is sent when a test webhook is deleted.
  */
-export async function testWebhookDeleted(
-	{ data }: TestWebhookDeleted,
-	options: { workflowState: WorkflowState },
-) {
+export function useTestWebhookDeleted() {
 	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const workflowState = injectWorkflowState();
 
-	if (data.workflowId === workflowsStore.workflowId) {
-		workflowsStore.setExecutionWaitingForWebhook(false);
-		options.workflowState.setActiveExecutionId(undefined);
+	async function testWebhookDeleted({ data }: TestWebhookDeleted) {
+		if (data.workflowId === workflowDocumentStore.value.workflowId) {
+			workflowsStore.setExecutionWaitingForWebhook(false);
+			workflowState.setActiveExecutionId(undefined);
+		}
 	}
+
+	return { testWebhookDeleted };
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/testWebhookReceived.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/testWebhookReceived.ts
@@ -1,18 +1,22 @@
 import type { TestWebhookReceived } from '@n8n/api-types/push/webhook';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import type { WorkflowState } from '@/app/composables/useWorkflowState';
+import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
 /**
  * Handles the 'testWebhookReceived' push message, which is sent when a test webhook is received.
  */
-export async function testWebhookReceived(
-	{ data }: TestWebhookReceived,
-	options: { workflowState: WorkflowState },
-) {
+export function useTestWebhookReceived() {
 	const workflowsStore = useWorkflowsStore();
+	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const workflowState = injectWorkflowState();
 
-	if (data.workflowId === workflowsStore.workflowId) {
-		workflowsStore.setExecutionWaitingForWebhook(false);
-		options.workflowState.setActiveExecutionId(data.executionId ?? null);
+	async function testWebhookReceived({ data }: TestWebhookReceived) {
+		if (data.workflowId === workflowDocumentStore.value.workflowId) {
+			workflowsStore.setExecutionWaitingForWebhook(false);
+			workflowState.setActiveExecutionId(data.executionId ?? null);
+		}
 	}
+
+	return { testWebhookReceived };
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/trackNodeExecution.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/trackNodeExecution.ts
@@ -1,25 +1,25 @@
-import type { PushPayload } from '@n8n/api-types';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useWorkflowHelpers } from '@/app/composables/useWorkflowHelpers';
 import { useSettingsStore } from '@/app/stores/settings.store';
-import {
-	createWorkflowDocumentId,
-	useWorkflowDocumentStore,
-} from '@/app/stores/workflowDocument.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import type { PushPayload } from '@n8n/api-types';
 import { TelemetryHelpers } from 'n8n-workflow';
 
-export async function trackNodeExecution(
-	pushData: PushPayload<'nodeExecuteAfter'>,
-	workflowId: string,
-): Promise<void> {
-	const nodeName = pushData.nodeName;
+export function useTrackNodeExecution() {
+	const telemetry = useTelemetry();
+	const workflowHelpers = useWorkflowHelpers();
+	const settingsStore = useSettingsStore();
+	const workflowDocumentStore = injectWorkflowDocumentStore();
 
-	if (pushData.data.error) {
-		const telemetry = useTelemetry();
-		const workflowHelpers = useWorkflowHelpers();
-		const settingsStore = useSettingsStore();
-		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
-		const node = workflowDocumentStore.getNodeByName(nodeName);
+	async function trackNodeExecution(pushData: PushPayload<'nodeExecuteAfter'>): Promise<void> {
+		const nodeName = pushData.nodeName;
+
+		if (!pushData.data.error) {
+			return;
+		}
+
+		const node = workflowDocumentStore.value.getNodeByName(nodeName);
+
 		telemetry.track('Manual exec errored', {
 			error_title: pushData.data.error.message,
 			node_type: node?.type,
@@ -27,7 +27,7 @@ export async function trackNodeExecution(
 			node_id: node?.id,
 			node_graph_string: JSON.stringify(
 				TelemetryHelpers.generateNodesGraph(
-					workflowDocumentStore.serialize(),
+					workflowDocumentStore.value.serialize(),
 					workflowHelpers.getNodeTypes(),
 					{
 						isCloudDeployment: settingsStore.isCloudDeployment,
@@ -36,4 +36,6 @@ export async function trackNodeExecution(
 			),
 		});
 	}
+
+	return { trackNodeExecution };
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowActivated.ts
@@ -1,36 +1,38 @@
 import type { WorkflowActivated } from '@n8n/api-types/push/workflow';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useBannersStore } from '@/features/shared/banners/banners.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 
-export async function workflowActivated({ data }: WorkflowActivated) {
+export function useWorkflowActivated() {
 	const { initializeWorkspace } = useCanvasOperations();
-	const workflowsStore = useWorkflowsStore();
-	const workflowsListStore = useWorkflowsListStore();
 	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const workflowsListStore = useWorkflowsListStore();
 	const bannersStore = useBannersStore();
 	const uiStore = useUIStore();
 
-	const { workflowId, activeVersionId } = data;
+	async function workflowActivated({ data }: WorkflowActivated) {
+		const { workflowId, activeVersionId } = data;
 
-	const workflowIsBeingViewed = workflowsStore.workflowId === workflowId;
-	const activeVersionChanged = workflowDocumentStore?.value?.activeVersionId !== activeVersionId;
-	if (workflowIsBeingViewed && activeVersionChanged) {
-		// Only update workflow if there are no unsaved changes
-		if (!uiStore.stateIsDirty) {
-			const updatedWorkflow = await workflowsListStore.fetchWorkflow(workflowId);
-			if (!updatedWorkflow.checksum) {
-				throw new Error('Failed to fetch workflow');
-			}
-			await initializeWorkspace(updatedWorkflow);
+		if (workflowDocumentStore.value.workflowId !== workflowId) {
+			return;
 		}
-	}
 
-	// Remove auto-deactivated banner if viewing this workflow
-	if (workflowIsBeingViewed) {
+		const activeVersionChanged = workflowDocumentStore?.value?.activeVersionId !== activeVersionId;
+
+		if (activeVersionChanged) {
+			if (!uiStore.stateIsDirty) {
+				const updatedWorkflow = await workflowsListStore.fetchWorkflow(workflowId);
+				if (!updatedWorkflow.checksum) {
+					throw new Error('Failed to fetch workflow');
+				}
+				await initializeWorkspace(updatedWorkflow);
+			}
+		}
+
 		bannersStore.removeBannerFromStack('WORKFLOW_AUTO_DEACTIVATED');
 	}
+
+	return { workflowActivated };
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowAutoDeactivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowAutoDeactivated.ts
@@ -6,29 +6,36 @@ import { useBannersStore } from '@/features/shared/banners/banners.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 
-export async function workflowAutoDeactivated({ data }: WorkflowAutoDeactivated) {
-	const workflowsStore = useWorkflowsStore();
-	const workflowsListStore = useWorkflowsListStore();
+export function useWorkflowAutoDeactivated() {
 	const workflowDocumentStore = injectWorkflowDocumentStore();
 	const { initializeWorkspace } = useCanvasOperations();
+	const workflowsStore = useWorkflowsStore();
+	const workflowsListStore = useWorkflowsListStore();
 	const bannersStore = useBannersStore();
 	const uiStore = useUIStore();
 
-	workflowsStore.setWorkflowInactive(data.workflowId);
+	async function workflowAutoDeactivated({ data }: WorkflowAutoDeactivated) {
+		workflowsStore.setWorkflowInactive(data.workflowId);
 
-	if (workflowsStore.workflowId === data.workflowId) {
-		// Only update workflow if there are no unsaved changes
+		if (workflowDocumentStore.value.workflowId !== data.workflowId) {
+			return;
+		}
+
 		if (!uiStore.stateIsDirty) {
 			const updatedWorkflow = await workflowsListStore.fetchWorkflow(data.workflowId);
 			if (!updatedWorkflow.checksum) {
 				throw new Error('Failed to fetch workflow');
 			}
-			// initializeWorkspace calls initState which sets the document store
 			await initializeWorkspace(updatedWorkflow);
 		} else {
-			workflowDocumentStore?.value?.setActiveState({ activeVersionId: null, activeVersion: null });
+			workflowDocumentStore.value.setActiveState({
+				activeVersionId: null,
+				activeVersion: null,
+			});
 		}
 
 		bannersStore.pushBannerToStack('WORKFLOW_AUTO_DEACTIVATED');
 	}
+
+	return { workflowAutoDeactivated };
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowDeactivated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowDeactivated.ts
@@ -1,28 +1,33 @@
 import type { WorkflowDeactivated } from '@n8n/api-types/push/workflow';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 
-export async function workflowDeactivated({ data }: WorkflowDeactivated) {
+export function useWorkflowDeactivated() {
 	const { initializeWorkspace } = useCanvasOperations();
-	const workflowsStore = useWorkflowsStore();
-	const workflowsListStore = useWorkflowsListStore();
 	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const workflowsListStore = useWorkflowsListStore();
 	const uiStore = useUIStore();
 
-	if (workflowsStore.workflowId === data.workflowId) {
-		// Only update workflow if there are no unsaved changes
+	async function workflowDeactivated({ data }: WorkflowDeactivated) {
+		if (workflowDocumentStore.value.workflowId !== data.workflowId) {
+			return;
+		}
+
 		if (!uiStore.stateIsDirty) {
 			const updatedWorkflow = await workflowsListStore.fetchWorkflow(data.workflowId);
 			if (!updatedWorkflow.checksum) {
 				throw new Error('Failed to fetch workflow');
 			}
-			// initializeWorkspace calls initState which sets the document store
 			await initializeWorkspace(updatedWorkflow);
 		} else {
-			workflowDocumentStore?.value?.setActiveState({ activeVersionId: null, activeVersion: null });
+			workflowDocumentStore?.value?.setActiveState({
+				activeVersionId: null,
+				activeVersion: null,
+			});
 		}
 	}
+
+	return { workflowDeactivated };
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowFailedToActivate.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowFailedToActivate.ts
@@ -1,29 +1,38 @@
 import type { WorkflowFailedToActivate } from '@n8n/api-types/push/workflow';
 import { useToast } from '@/app/composables/useToast';
-import { useActivationError } from '@/app/composables/useActivationError';
 import { useI18n } from '@n8n/i18n';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
-export async function workflowFailedToActivate({ data }: WorkflowFailedToActivate) {
-	const workflowsStore = useWorkflowsStore();
+export function useWorkflowFailedToActivate() {
 	const workflowDocumentStore = injectWorkflowDocumentStore();
-
-	if (workflowsStore.workflowId !== data.workflowId) {
-		return;
-	}
-
-	workflowsStore.setWorkflowInactive(data.workflowId);
-	workflowDocumentStore?.value?.setActiveState({ activeVersionId: null, activeVersion: null });
-
+	const workflowsStore = useWorkflowsStore();
 	const toast = useToast();
 	const i18n = useI18n();
-	const { errorMessage } = useActivationError(() => data.nodeId);
-	const title = i18n.baseText('workflowActivator.showError.title', {
-		interpolate: { newStateName: 'activated' },
-	});
-	toast.showError(new Error(data.errorMessage), title, {
-		message: errorMessage.value,
-		description: data.errorDescription,
-	});
+
+	async function workflowFailedToActivate({ data }: WorkflowFailedToActivate) {
+		if (workflowDocumentStore.value.workflowId !== data.workflowId) {
+			return;
+		}
+
+		workflowsStore.setWorkflowInactive(data.workflowId);
+		workflowDocumentStore.value.setActiveState({ activeVersionId: null, activeVersion: null });
+
+		const node = data.nodeId ? workflowDocumentStore.value.getNodeById(data.nodeId) : undefined;
+		const errorMessage = node
+			? i18n.baseText('workflowActivator.showError.nodeError', {
+					interpolate: { nodeName: node.name },
+				})
+			: undefined;
+
+		const title = i18n.baseText('workflowActivator.showError.title', {
+			interpolate: { newStateName: 'activated' },
+		});
+		toast.showError(new Error(data.errorMessage), title, {
+			message: errorMessage,
+			description: data.errorDescription,
+		});
+	}
+
+	return { workflowFailedToActivate };
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowSettingsUpdated.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowSettingsUpdated.test.ts
@@ -4,13 +4,13 @@ import { setActivePinia } from 'pinia';
 import type { IWorkflowSettings } from 'n8n-workflow';
 import type { WorkflowSettingsUpdated } from '@n8n/api-types/push/workflow';
 
-import { workflowSettingsUpdated } from './workflowSettingsUpdated';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useWorkflowSettingsUpdated } from './workflowSettingsUpdated';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { mockedStore } from '@/__tests__/utils';
 
 const { mockWorkflowDocumentStore } = vi.hoisted(() => ({
 	mockWorkflowDocumentStore: {
+		workflowId: '',
 		allNodes: [],
 		name: '',
 		settings: {},
@@ -38,14 +38,16 @@ const makeEvent = (
 });
 
 describe('workflowSettingsUpdated', () => {
-	let workflowsStore: ReturnType<typeof mockedStore<typeof useWorkflowsStore>>;
 	let workflowsListStore: ReturnType<typeof mockedStore<typeof useWorkflowsListStore>>;
+	let workflowSettingsUpdated: ReturnType<
+		typeof useWorkflowSettingsUpdated
+	>['workflowSettingsUpdated'];
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 		setActivePinia(createTestingPinia({ stubActions: false }));
-		workflowsStore = mockedStore(useWorkflowsStore);
 		workflowsListStore = mockedStore(useWorkflowsListStore);
+		({ workflowSettingsUpdated } = useWorkflowSettingsUpdated());
 	});
 
 	it('merges partial settings into an existing list entry', async () => {
@@ -78,7 +80,7 @@ describe('workflowSettingsUpdated', () => {
 	});
 
 	it('does nothing for the document store when the workflow is not the active one', async () => {
-		workflowsStore.setWorkflowId('other-workflow');
+		mockWorkflowDocumentStore.workflowId = 'other-workflow';
 
 		await workflowSettingsUpdated(makeEvent('wf-1', { availableInMCP: true }));
 
@@ -87,7 +89,7 @@ describe('workflowSettingsUpdated', () => {
 	});
 
 	it('merges settings and uses payload checksum for the active document', async () => {
-		workflowsStore.setWorkflowId('wf-current');
+		mockWorkflowDocumentStore.workflowId = 'wf-current';
 		workflowsListStore.workflowsById = {
 			'wf-current': {
 				id: 'wf-current',
@@ -107,7 +109,7 @@ describe('workflowSettingsUpdated', () => {
 	});
 
 	it('applies settings but skips checksum refresh when none is provided', async () => {
-		workflowsStore.setWorkflowId('wf-current');
+		mockWorkflowDocumentStore.workflowId = 'wf-current';
 		workflowsListStore.workflowsById = {
 			'wf-current': {
 				id: 'wf-current',
@@ -125,7 +127,7 @@ describe('workflowSettingsUpdated', () => {
 	});
 
 	it('merges multiple settings keys in one event', async () => {
-		workflowsStore.setWorkflowId('wf-current');
+		mockWorkflowDocumentStore.workflowId = 'wf-current';
 		workflowsListStore.workflowsById = {
 			'wf-current': {
 				id: 'wf-current',

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowSettingsUpdated.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/workflowSettingsUpdated.ts
@@ -1,41 +1,40 @@
 import type { WorkflowSettingsUpdated } from '@n8n/api-types/push/workflow';
 import type { IWorkflowSettings } from '@/Interface';
 
-import {
-	createWorkflowDocumentId,
-	useWorkflowDocumentStore,
-} from '@/app/stores/workflowDocument.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 
-export async function workflowSettingsUpdated({
-	data: { workflowId, settings, checksum },
-}: WorkflowSettingsUpdated) {
-	const workflowsStore = useWorkflowsStore();
+export function useWorkflowSettingsUpdated() {
 	const workflowsListStore = useWorkflowsListStore();
+	const workflowDocumentStore = injectWorkflowDocumentStore();
 
-	// Keep the list entry in sync so other views (workflow cards, MCP
-	// settings table) reflect the new state without a full list re-fetch.
-	const listEntry = workflowsListStore.workflowsById[workflowId];
-	if (listEntry) {
-		if (listEntry.settings) {
-			Object.assign(listEntry.settings, settings);
-		} else {
-			listEntry.settings = { ...settings } as IWorkflowSettings;
+	async function workflowSettingsUpdated({
+		data: { workflowId, settings, checksum },
+	}: WorkflowSettingsUpdated) {
+		// Keep the list entry in sync so other views (workflow cards, MCP
+		// settings table) reflect the new state without a full list re-fetch.
+		const listEntry = workflowsListStore.workflowsById[workflowId];
+		if (listEntry) {
+			if (listEntry.settings) {
+				Object.assign(listEntry.settings, settings);
+			} else {
+				listEntry.settings = { ...settings } as IWorkflowSettings;
+			}
+			if (checksum) {
+				listEntry.checksum = checksum;
+			}
 		}
+
+		// Only the editor tab needs to resync the document store + checksum.
+		if (workflowId !== workflowDocumentStore.value.workflowId) return;
+
+		workflowDocumentStore.value.mergeSettings(settings);
+
 		if (checksum) {
-			listEntry.checksum = checksum;
+			// Refresh the expectedChecksum so the next normal save doesn't 409.
+			workflowDocumentStore.value.setChecksum(checksum);
 		}
 	}
 
-	// Only the editor tab needs to resync the document store + checksum.
-	if (workflowId !== workflowsStore.workflowId) return;
-
-	const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
-	workflowDocumentStore.mergeSettings(settings);
-
-	if (checksum) {
-		// Refresh the expectedChecksum so the next normal save doesn't 409.
-		workflowDocumentStore.setChecksum(checksum);
-	}
+	return { workflowSettingsUpdated };
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.test.ts
@@ -1,5 +1,4 @@
 import { usePushConnection } from '@/app/composables/usePushConnection';
-import { builderCreditsUpdated } from '@/app/composables/usePushConnection/handlers';
 import type { TestWebhookReceived } from '@n8n/api-types/push/webhook';
 import type { BuilderCreditsPushMessage } from '@n8n/api-types/push/builder-credits';
 import type { OnPushMessageHandler } from '@/app/stores/pushConnection.store';
@@ -16,27 +15,28 @@ vi.mock('@/app/stores/pushConnection.store', () => ({
 }));
 
 const mockTestWebhookReceived = vi.fn();
+const mockBuilderCreditsUpdated = vi.fn();
 
 vi.mock('@/app/composables/usePushConnection/handlers', () => ({
 	useTestWebhookDeleted: vi.fn(() => ({ testWebhookDeleted: vi.fn() })),
 	useTestWebhookReceived: vi.fn(() => ({ testWebhookReceived: mockTestWebhookReceived })),
-	reloadNodeType: vi.fn(),
-	removeNodeType: vi.fn(),
-	nodeDescriptionUpdated: vi.fn(),
+	useReloadNodeType: vi.fn(() => ({ reloadNodeType: vi.fn() })),
+	useRemoveNodeType: vi.fn(() => ({ removeNodeType: vi.fn() })),
+	useNodeDescriptionUpdated: vi.fn(() => ({ nodeDescriptionUpdated: vi.fn() })),
 	useNodeExecuteBefore: vi.fn(() => ({ nodeExecuteBefore: vi.fn() })),
 	useNodeExecuteAfter: vi.fn(() => ({ nodeExecuteAfter: vi.fn() })),
-	nodeExecuteAfterData: vi.fn(),
-	executionStarted: vi.fn(),
-	sendWorkerStatusMessage: vi.fn(),
-	sendConsoleMessage: vi.fn(),
+	useNodeExecuteAfterData: vi.fn(() => ({ nodeExecuteAfterData: vi.fn() })),
+	useExecutionStarted: vi.fn(() => ({ executionStarted: vi.fn() })),
+	useSendWorkerStatusMessage: vi.fn(() => ({ sendWorkerStatusMessage: vi.fn() })),
+	useSendConsoleMessage: vi.fn(() => ({ sendConsoleMessage: vi.fn() })),
 	useWorkflowFailedToActivate: vi.fn(() => ({ workflowFailedToActivate: vi.fn() })),
 	useExecutionFinished: vi.fn(() => ({ executionFinished: vi.fn() })),
 	useExecutionRecovered: vi.fn(() => ({ executionRecovered: vi.fn() })),
 	useWorkflowActivated: vi.fn(() => ({ workflowActivated: vi.fn() })),
 	useWorkflowDeactivated: vi.fn(() => ({ workflowDeactivated: vi.fn() })),
 	useWorkflowAutoDeactivated: vi.fn(() => ({ workflowAutoDeactivated: vi.fn() })),
-	workflowSettingsUpdated: vi.fn(),
-	builderCreditsUpdated: vi.fn(),
+	useWorkflowSettingsUpdated: vi.fn(() => ({ workflowSettingsUpdated: vi.fn() })),
+	useBuilderCreditsUpdated: vi.fn(() => ({ builderCreditsUpdated: mockBuilderCreditsUpdated })),
 }));
 
 vi.mock('vue-router', async (importOriginal) => {
@@ -120,7 +120,7 @@ describe('usePushConnection composable', () => {
 		await Promise.resolve();
 
 		// Verify that the correct handler was called.
-		expect(builderCreditsUpdated).toHaveBeenCalledTimes(1);
-		expect(builderCreditsUpdated).toHaveBeenCalledWith(testEvent);
+		expect(mockBuilderCreditsUpdated).toHaveBeenCalledTimes(1);
+		expect(mockBuilderCreditsUpdated).toHaveBeenCalledWith(testEvent);
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.test.ts
@@ -1,11 +1,7 @@
 import { usePushConnection } from '@/app/composables/usePushConnection';
-import {
-	testWebhookReceived,
-	builderCreditsUpdated,
-} from '@/app/composables/usePushConnection/handlers';
+import { builderCreditsUpdated } from '@/app/composables/usePushConnection/handlers';
 import type { TestWebhookReceived } from '@n8n/api-types/push/webhook';
 import type { BuilderCreditsPushMessage } from '@n8n/api-types/push/builder-credits';
-import { useRouter } from 'vue-router';
 import type { OnPushMessageHandler } from '@/app/stores/pushConnection.store';
 import { createPinia, setActivePinia } from 'pinia';
 
@@ -19,25 +15,27 @@ vi.mock('@/app/stores/pushConnection.store', () => ({
 	}),
 }));
 
+const mockTestWebhookReceived = vi.fn();
+
 vi.mock('@/app/composables/usePushConnection/handlers', () => ({
-	testWebhookDeleted: vi.fn(),
-	testWebhookReceived: vi.fn(),
+	useTestWebhookDeleted: vi.fn(() => ({ testWebhookDeleted: vi.fn() })),
+	useTestWebhookReceived: vi.fn(() => ({ testWebhookReceived: mockTestWebhookReceived })),
 	reloadNodeType: vi.fn(),
 	removeNodeType: vi.fn(),
 	nodeDescriptionUpdated: vi.fn(),
-	nodeExecuteBefore: vi.fn(),
-	nodeExecuteAfter: vi.fn(),
+	useNodeExecuteBefore: vi.fn(() => ({ nodeExecuteBefore: vi.fn() })),
+	useNodeExecuteAfter: vi.fn(() => ({ nodeExecuteAfter: vi.fn() })),
 	nodeExecuteAfterData: vi.fn(),
 	executionStarted: vi.fn(),
-	executionWaiting: vi.fn(),
 	sendWorkerStatusMessage: vi.fn(),
 	sendConsoleMessage: vi.fn(),
-	workflowFailedToActivate: vi.fn(),
-	executionFinished: vi.fn(),
-	executionRecovered: vi.fn(),
-	workflowActivated: vi.fn(),
-	workflowDeactivated: vi.fn(),
-	collaboratorsChanged: vi.fn(),
+	useWorkflowFailedToActivate: vi.fn(() => ({ workflowFailedToActivate: vi.fn() })),
+	useExecutionFinished: vi.fn(() => ({ executionFinished: vi.fn() })),
+	useExecutionRecovered: vi.fn(() => ({ executionRecovered: vi.fn() })),
+	useWorkflowActivated: vi.fn(() => ({ workflowActivated: vi.fn() })),
+	useWorkflowDeactivated: vi.fn(() => ({ workflowDeactivated: vi.fn() })),
+	useWorkflowAutoDeactivated: vi.fn(() => ({ workflowAutoDeactivated: vi.fn() })),
+	workflowSettingsUpdated: vi.fn(),
 	builderCreditsUpdated: vi.fn(),
 }));
 
@@ -59,8 +57,7 @@ describe('usePushConnection composable', () => {
 
 		setActivePinia(createPinia());
 
-		const router = useRouter();
-		pushConnection = usePushConnection({ router });
+		pushConnection = usePushConnection();
 	});
 
 	it('should register an event listener on initialize', () => {
@@ -75,7 +72,6 @@ describe('usePushConnection composable', () => {
 		const handler = addEventListener.mock.calls[0][0];
 
 		// Create a test event for one of the handled types.
-		// In this test, we simulate the event type 'testWebhookReceived'.
 		const testEvent: TestWebhookReceived = {
 			type: 'testWebhookReceived',
 			data: {
@@ -91,8 +87,8 @@ describe('usePushConnection composable', () => {
 		await Promise.resolve();
 
 		// Verify that the correct handler was called.
-		expect(testWebhookReceived).toHaveBeenCalledTimes(1);
-		expect(testWebhookReceived).toHaveBeenCalledWith(testEvent, expect.any(Object));
+		expect(mockTestWebhookReceived).toHaveBeenCalledTimes(1);
+		expect(mockTestWebhookReceived).toHaveBeenCalledWith(testEvent);
 	});
 
 	it('should call removeEventListener when terminate is called', () => {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.ts
@@ -4,41 +4,40 @@ import type { PushMessage } from '@n8n/api-types';
 import { usePushConnectionStore } from '@/app/stores/pushConnection.store';
 import {
 	builderCreditsUpdated,
-	testWebhookDeleted,
-	testWebhookReceived,
+	useTestWebhookDeleted,
+	useTestWebhookReceived,
 	reloadNodeType,
 	removeNodeType,
 	nodeDescriptionUpdated,
-	nodeExecuteBefore,
-	nodeExecuteAfter,
+	useNodeExecuteBefore,
+	useNodeExecuteAfter,
 	nodeExecuteAfterData,
 	executionStarted,
 	sendWorkerStatusMessage,
 	sendConsoleMessage,
-	workflowFailedToActivate,
-	executionFinished,
-	executionRecovered,
-	workflowActivated,
-	workflowDeactivated,
-	workflowAutoDeactivated,
+	useWorkflowFailedToActivate,
+	useExecutionFinished,
+	useExecutionRecovered,
+	useWorkflowActivated,
+	useWorkflowDeactivated,
+	useWorkflowAutoDeactivated,
 	workflowSettingsUpdated,
 } from '@/app/composables/usePushConnection/handlers';
-import { injectWorkflowState, type WorkflowState } from '@/app/composables/useWorkflowState';
 import { createEventQueue } from '@n8n/utils/event-queue';
-import type { useRouter } from 'vue-router';
 
-export function usePushConnection({
-	router,
-	workflowState,
-}: {
-	router: ReturnType<typeof useRouter>;
-	workflowState?: WorkflowState;
-}) {
+export function usePushConnection() {
 	const pushStore = usePushConnectionStore();
-	const options = {
-		router,
-		workflowState: workflowState ?? injectWorkflowState(),
-	};
+
+	const { testWebhookDeleted } = useTestWebhookDeleted();
+	const { testWebhookReceived } = useTestWebhookReceived();
+	const { nodeExecuteBefore } = useNodeExecuteBefore();
+	const { nodeExecuteAfter } = useNodeExecuteAfter();
+	const { workflowActivated } = useWorkflowActivated();
+	const { workflowDeactivated } = useWorkflowDeactivated();
+	const { workflowAutoDeactivated } = useWorkflowAutoDeactivated();
+	const { workflowFailedToActivate } = useWorkflowFailedToActivate();
+	const { executionFinished } = useExecutionFinished();
+	const { executionRecovered } = useExecutionRecovered();
 
 	const { enqueue } = createEventQueue<PushMessage>(processEvent);
 
@@ -62,9 +61,9 @@ export function usePushConnection({
 	async function processEvent(event: PushMessage) {
 		switch (event.type) {
 			case 'testWebhookDeleted':
-				return await testWebhookDeleted(event, options);
+				return await testWebhookDeleted(event);
 			case 'testWebhookReceived':
-				return await testWebhookReceived(event, options);
+				return await testWebhookReceived(event);
 			case 'reloadNodeType':
 				return await reloadNodeType(event);
 			case 'removeNodeType':
@@ -72,9 +71,9 @@ export function usePushConnection({
 			case 'nodeDescriptionUpdated':
 				return await nodeDescriptionUpdated(event);
 			case 'nodeExecuteBefore':
-				return await nodeExecuteBefore(event, options);
+				return await nodeExecuteBefore(event);
 			case 'nodeExecuteAfter':
-				return await nodeExecuteAfter(event, options);
+				return await nodeExecuteAfter(event);
 			case 'nodeExecuteAfterData':
 				return await nodeExecuteAfterData(event);
 			case 'executionStarted':
@@ -86,9 +85,9 @@ export function usePushConnection({
 			case 'workflowFailedToActivate':
 				return await workflowFailedToActivate(event);
 			case 'executionFinished':
-				return await executionFinished(event, options);
+				return await executionFinished(event);
 			case 'executionRecovered':
-				return await executionRecovered(event, options);
+				return await executionRecovered(event);
 			case 'workflowActivated':
 				return await workflowActivated(event);
 			case 'workflowDeactivated':

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.ts
@@ -3,25 +3,25 @@ import type { PushMessage } from '@n8n/api-types';
 
 import { usePushConnectionStore } from '@/app/stores/pushConnection.store';
 import {
-	builderCreditsUpdated,
+	useBuilderCreditsUpdated,
 	useTestWebhookDeleted,
 	useTestWebhookReceived,
-	reloadNodeType,
-	removeNodeType,
-	nodeDescriptionUpdated,
+	useReloadNodeType,
+	useRemoveNodeType,
+	useNodeDescriptionUpdated,
 	useNodeExecuteBefore,
 	useNodeExecuteAfter,
-	nodeExecuteAfterData,
-	executionStarted,
-	sendWorkerStatusMessage,
-	sendConsoleMessage,
+	useNodeExecuteAfterData,
+	useExecutionStarted,
+	useSendWorkerStatusMessage,
+	useSendConsoleMessage,
 	useWorkflowFailedToActivate,
 	useExecutionFinished,
 	useExecutionRecovered,
 	useWorkflowActivated,
 	useWorkflowDeactivated,
 	useWorkflowAutoDeactivated,
-	workflowSettingsUpdated,
+	useWorkflowSettingsUpdated,
 } from '@/app/composables/usePushConnection/handlers';
 import { createEventQueue } from '@n8n/utils/event-queue';
 
@@ -32,12 +32,21 @@ export function usePushConnection() {
 	const { testWebhookReceived } = useTestWebhookReceived();
 	const { nodeExecuteBefore } = useNodeExecuteBefore();
 	const { nodeExecuteAfter } = useNodeExecuteAfter();
+	const { nodeExecuteAfterData } = useNodeExecuteAfterData();
+	const { executionStarted } = useExecutionStarted();
+	const { reloadNodeType } = useReloadNodeType();
+	const { removeNodeType } = useRemoveNodeType();
+	const { nodeDescriptionUpdated } = useNodeDescriptionUpdated();
+	const { sendWorkerStatusMessage } = useSendWorkerStatusMessage();
+	const { sendConsoleMessage } = useSendConsoleMessage();
 	const { workflowActivated } = useWorkflowActivated();
 	const { workflowDeactivated } = useWorkflowDeactivated();
 	const { workflowAutoDeactivated } = useWorkflowAutoDeactivated();
 	const { workflowFailedToActivate } = useWorkflowFailedToActivate();
 	const { executionFinished } = useExecutionFinished();
 	const { executionRecovered } = useExecutionRecovered();
+	const { workflowSettingsUpdated } = useWorkflowSettingsUpdated();
+	const { builderCreditsUpdated } = useBuilderCreditsUpdated();
 
 	const { enqueue } = createEventQueue<PushMessage>(processEvent);
 

--- a/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
+++ b/packages/frontend/editor-ui/src/app/layouts/DemoLayout.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { computed, provide, onBeforeUnmount, onMounted } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
+import { useRoute } from 'vue-router';
 import BaseLayout from './BaseLayout.vue';
 import DemoFooter from '@/features/execution/logs/components/DemoFooter.vue';
 import { NDVStoreKey, WorkflowStateKey } from '@/app/constants/injectionKeys';
@@ -46,7 +46,7 @@ const { setup: setupPostMessages, cleanup: cleanupPostMessages } = usePostMessag
 // from the parent) are processed for node highlighting, execution state, etc.
 // When canExecute is enabled, the iframe also establishes its own WebSocket
 // connection for user-triggered executions (pushConnect below).
-const pushConnection = usePushConnection({ router: useRouter(), workflowState });
+const pushConnection = usePushConnection();
 const pushConnectionStore = usePushConnectionStore();
 
 // When canExecute is disabled (read-only preview), set activeExecutionId to null

--- a/packages/frontend/editor-ui/src/features/settings/communityNodes/views/SettingsCommunityNodesView.vue
+++ b/packages/frontend/editor-ui/src/features/settings/communityNodes/views/SettingsCommunityNodesView.vue
@@ -12,7 +12,6 @@ import { useCommunityNodesStore } from '../communityNodes.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { onBeforeUnmount, ref, computed, onBeforeMount, onMounted } from 'vue';
 import { useExternalHooks } from '@/app/composables/useExternalHooks';
-import { useRouter } from 'vue-router';
 import { usePushConnection } from '@/app/composables/usePushConnection';
 import { usePushConnectionStore } from '@/app/stores/pushConnection.store';
 import { useI18n } from '@n8n/i18n';
@@ -24,8 +23,7 @@ const PACKAGE_COUNT_THRESHOLD = 31;
 
 const loading = ref(false);
 
-const router = useRouter();
-const pushConnection = usePushConnection({ router });
+const pushConnection = usePushConnection();
 const pushStore = usePushConnectionStore();
 const externalHooks = useExternalHooks();
 const i18n = useI18n();

--- a/packages/frontend/editor-ui/src/features/settings/orchestration.ee/components/WorkerList.vue
+++ b/packages/frontend/editor-ui/src/features/settings/orchestration.ee/components/WorkerList.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { computed, onBeforeMount, onBeforeUnmount, onMounted } from 'vue';
-import { useRouter } from 'vue-router';
 
 import { useI18n } from '@n8n/i18n';
 import { useOrchestrationStore } from '../orchestration.store';
@@ -22,9 +21,8 @@ withDefaults(
 	},
 );
 
-const router = useRouter();
 const i18n = useI18n();
-const pushConnection = usePushConnection({ router });
+const pushConnection = usePushConnection();
 const documentTitle = useDocumentTitle();
 const telemetry = useTelemetry();
 


### PR DESCRIPTION
## Summary

This PR converts push connection event handlers into composable that returns the handler itself, so that the provide/inject pattern works as intended. This makes it safe to call `useRouter()` `useWorkflowState()` in these composables and makes it redundant to pass them down as arguments. It also refactors `workflowsStore.workflowId` usages in handlers.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3033/migrate-workflowsstoreworkflowid-usages-in-push-handlers


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
