### PR TITLE
fix(core): Deregister Telegram webhook on agent integration disconnect (no-changelog)

### DIFF
--- a/packages/cli/src/modules/agents/integrations/__tests__/chat-integration.service.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/chat-integration.service.test.ts
@@ -409,9 +409,8 @@ describe('ChatIntegrationService — multi-main role-aware behavior', () => {
 			await service.reconnectAll();
 
 			expect(connectSpy).toHaveBeenCalledTimes(1);
-			// Followers must not run external hooks during startup reconnect — the
-			// leader owns Telegram setWebhook etc., so a follower racing it would
-			// just trip Telegram's 1/sec rate limit.
+			// Followers must not run external hooks during startup reconnect. The
+			// leader owns external setup; followers only build local runtime state.
 			expect(connectSpy).toHaveBeenCalledWith(
 				'agent-1',
 				{ type: 'linear', credentialId: 'c2' },
@@ -517,9 +516,8 @@ describe('ChatIntegrationService — multi-main role-aware behavior', () => {
 			await service.disconnectLeaderOnlyIntegrations();
 
 			expect(disconnectOneSpy).toHaveBeenCalledTimes(1);
-			// Leader stepdown is a role transition, not a user-initiated disconnect —
-			// another main is about to take over, so remote-side state (e.g.
-			// Telegram webhooks) must not be released here.
+			// Leader stepdown is a role transition, not a user-initiated disconnect.
+			// Only local runtime state should be cleared here.
 			expect(disconnectOneSpy).toHaveBeenCalledWith('agent-1:telegram:c1', {
 				skipExternalHooks: true,
 			});
@@ -537,9 +535,8 @@ describe('ChatIntegrationService — multi-main role-aware behavior', () => {
 				action: 'disconnect',
 			});
 
-			// External teardown (Telegram deleteWebhook etc.) already ran on the
-			// originator — the peer must skip it so cluster-wide remote state is
-			// released exactly once.
+			// External teardown already ran on the originator. The peer must skip it
+			// so cluster-wide remote state is released exactly once.
 			expect(disconnectSpy).toHaveBeenCalledWith(
 				'a1',
 				{ type: 'linear', credentialId: 'c1' },
@@ -589,9 +586,8 @@ describe('ChatIntegrationService — multi-main role-aware behavior', () => {
 				action: 'connect',
 			});
 
-			// External hooks (Telegram setWebhook, DB validation) already ran on
-			// the originator — the peer must skip them to avoid duplicate API
-			// calls and the resulting 429 rate-limit failure.
+			// External hooks already ran on the originator. The peer must skip them
+			// to avoid duplicate external side effects.
 			expect(connectSpy).toHaveBeenCalledWith(
 				'a1',
 				{ type: 'linear', credentialId: 'c1' },

--- a/packages/cli/src/modules/agents/integrations/__tests__/chat-integration.service.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/chat-integration.service.test.ts
@@ -233,6 +233,145 @@ describe('ChatIntegrationService', () => {
 	});
 });
 
+describe('ChatIntegrationService — onBeforeDisconnect plumbing', () => {
+	type ConnectionStub = {
+		chat: {
+			shutdown: jest.Mock;
+			webhooks: Record<string, unknown>;
+			onAction: jest.Mock;
+			onNewMention: jest.Mock;
+			onSubscribedMessage: jest.Mock;
+			initialize: jest.Mock;
+		};
+		bridge: { dispose: jest.Mock };
+		context: AgentChatIntegrationContext;
+	};
+
+	const seedConnection = (
+		service: ChatIntegrationService,
+		key: string,
+		ctx: AgentChatIntegrationContext,
+	): ConnectionStub => {
+		const stub: ConnectionStub = {
+			chat: {
+				shutdown: jest.fn().mockResolvedValue(undefined),
+				webhooks: {},
+				onAction: jest.fn(),
+				onNewMention: jest.fn(),
+				onSubscribedMessage: jest.fn(),
+				initialize: jest.fn(),
+			},
+			bridge: { dispose: jest.fn() },
+			context: ctx,
+		};
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		(service as any).connections.set(key, stub);
+		return stub;
+	};
+
+	const makeCtx = (
+		overrides: Partial<AgentChatIntegrationContext> = {},
+	): AgentChatIntegrationContext => ({
+		agentId: 'agent-1',
+		projectId: 'project-1',
+		credentialId: 'cred-1',
+		credential: { accessToken: 'bot-token' },
+		webhookUrlFor: () => 'https://n8n.example.com/wh',
+		...overrides,
+	});
+
+	beforeEach(() => {
+		Container.reset();
+	});
+
+	it('invokes the integration onBeforeDisconnect hook with the captured context on user-initiated disconnect', async () => {
+		const onBeforeDisconnect = jest.fn().mockResolvedValue(undefined);
+		const telegram = new FakeIntegration('telegram', false);
+		(telegram as unknown as { onBeforeDisconnect: typeof onBeforeDisconnect }).onBeforeDisconnect =
+			onBeforeDisconnect;
+
+		const registry = new ChatIntegrationRegistry();
+		registry.register(telegram);
+
+		const { service } = buildServiceWith({ registry });
+		const ctx = makeCtx();
+		const stub = seedConnection(service, 'agent-1:telegram:cred-1', ctx);
+
+		await service.disconnect('agent-1', { type: 'telegram', credentialId: 'cred-1' });
+
+		expect(onBeforeDisconnect).toHaveBeenCalledTimes(1);
+		expect(onBeforeDisconnect).toHaveBeenCalledWith(ctx);
+		// Order: external teardown → local shutdown → dispose
+		expect(onBeforeDisconnect.mock.invocationCallOrder[0]).toBeLessThan(
+			stub.chat.shutdown.mock.invocationCallOrder[0],
+		);
+		expect(stub.bridge.dispose).toHaveBeenCalledTimes(1);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		expect((service as any).connections.size).toBe(0);
+	});
+
+	it('swallows errors from onBeforeDisconnect and still tears down local state', async () => {
+		const onBeforeDisconnect = jest.fn().mockRejectedValue(new Error('telegram 500'));
+		const telegram = new FakeIntegration('telegram', false);
+		(telegram as unknown as { onBeforeDisconnect: typeof onBeforeDisconnect }).onBeforeDisconnect =
+			onBeforeDisconnect;
+
+		const registry = new ChatIntegrationRegistry();
+		registry.register(telegram);
+
+		const { service } = buildServiceWith({ registry });
+		const stub = seedConnection(service, 'agent-1:telegram:cred-1', makeCtx());
+
+		await expect(
+			service.disconnect('agent-1', { type: 'telegram', credentialId: 'cred-1' }),
+		).resolves.toBeUndefined();
+
+		expect(onBeforeDisconnect).toHaveBeenCalledTimes(1);
+		expect(stub.chat.shutdown).toHaveBeenCalledTimes(1);
+		expect(stub.bridge.dispose).toHaveBeenCalledTimes(1);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		expect((service as any).connections.size).toBe(0);
+	});
+
+	it('skips onBeforeDisconnect when caller passes skipExternalHooks: true', async () => {
+		const onBeforeDisconnect = jest.fn().mockResolvedValue(undefined);
+		const telegram = new FakeIntegration('telegram', false);
+		(telegram as unknown as { onBeforeDisconnect: typeof onBeforeDisconnect }).onBeforeDisconnect =
+			onBeforeDisconnect;
+
+		const registry = new ChatIntegrationRegistry();
+		registry.register(telegram);
+
+		const { service } = buildServiceWith({ registry });
+		seedConnection(service, 'agent-1:telegram:cred-1', makeCtx());
+
+		await service.disconnect(
+			'agent-1',
+			{ type: 'telegram', credentialId: 'cred-1' },
+			{ skipExternalHooks: true },
+		);
+
+		expect(onBeforeDisconnect).not.toHaveBeenCalled();
+	});
+
+	it('disconnectAll never runs onBeforeDisconnect — graceful shutdown must not release remote state', async () => {
+		const onBeforeDisconnect = jest.fn().mockResolvedValue(undefined);
+		const telegram = new FakeIntegration('telegram', false);
+		(telegram as unknown as { onBeforeDisconnect: typeof onBeforeDisconnect }).onBeforeDisconnect =
+			onBeforeDisconnect;
+
+		const registry = new ChatIntegrationRegistry();
+		registry.register(telegram);
+
+		const { service } = buildServiceWith({ registry });
+		seedConnection(service, 'agent-1:telegram:cred-1', makeCtx());
+
+		await service.disconnectAll();
+
+		expect(onBeforeDisconnect).not.toHaveBeenCalled();
+	});
+});
+
 describe('ChatIntegrationService — multi-main role-aware behavior', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -368,7 +507,9 @@ describe('ChatIntegrationService — multi-main role-aware behavior', () => {
 
 			const disconnectOneSpy = jest
 				.spyOn(
-					service as unknown as { disconnectOne: (k: string) => Promise<void> },
+					service as unknown as {
+						disconnectOne: (k: string, options?: { skipExternalHooks?: boolean }) => Promise<void>;
+					},
 					'disconnectOne',
 				)
 				.mockImplementation(async () => undefined);
@@ -376,12 +517,17 @@ describe('ChatIntegrationService — multi-main role-aware behavior', () => {
 			await service.disconnectLeaderOnlyIntegrations();
 
 			expect(disconnectOneSpy).toHaveBeenCalledTimes(1);
-			expect(disconnectOneSpy).toHaveBeenCalledWith('agent-1:telegram:c1');
+			// Leader stepdown is a role transition, not a user-initiated disconnect —
+			// another main is about to take over, so remote-side state (e.g.
+			// Telegram webhooks) must not be released here.
+			expect(disconnectOneSpy).toHaveBeenCalledWith('agent-1:telegram:c1', {
+				skipExternalHooks: true,
+			});
 		});
 	});
 
 	describe('handleIntegrationChanged', () => {
-		it('routes disconnect actions to disconnect()', async () => {
+		it('routes disconnect actions to disconnect() and skips external hooks on the peer', async () => {
 			const { service } = buildServiceWith();
 			const disconnectSpy = jest.spyOn(service, 'disconnect').mockResolvedValue();
 
@@ -391,10 +537,14 @@ describe('ChatIntegrationService — multi-main role-aware behavior', () => {
 				action: 'disconnect',
 			});
 
-			expect(disconnectSpy).toHaveBeenCalledWith('a1', {
-				type: 'linear',
-				credentialId: 'c1',
-			});
+			// External teardown (Telegram deleteWebhook etc.) already ran on the
+			// originator — the peer must skip it so cluster-wide remote state is
+			// released exactly once.
+			expect(disconnectSpy).toHaveBeenCalledWith(
+				'a1',
+				{ type: 'linear', credentialId: 'c1' },
+				{ skipExternalHooks: true },
+			);
 		});
 
 		it('skips connect for a leader-only integration on a follower', async () => {

--- a/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
@@ -112,6 +112,19 @@ export abstract class AgentChatIntegration {
 	onAfterConnect?(ctx: AgentChatIntegrationContext): Promise<void>;
 
 	/**
+	 * Optional hook run BEFORE `chat.shutdown()` — use it to release any
+	 * external state owned by this integration (e.g. Telegram `deleteWebhook`
+	 * to free the bot for other applications). Runs only when the disconnect
+	 * is user-initiated; peer mains reacting to a multi-main PubSub broadcast,
+	 * graceful shutdowns, and leader-stepdown teardown all skip this hook so
+	 * the cluster-wide state isn't released by every main in turn.
+	 *
+	 * Errors are logged by the caller and swallowed — local teardown always
+	 * proceeds so a transient remote failure can't leak in-process resources.
+	 */
+	onBeforeDisconnect?(ctx: AgentChatIntegrationContext): Promise<void>;
+
+	/**
 	 * Optional per-platform component normalization (applied before toCard).
 	 * Convert unsupported types into close-enough equivalents — e.g. Telegram
 	 * turns select options into individual buttons.

--- a/packages/cli/src/modules/agents/integrations/chat-integration.service.ts
+++ b/packages/cli/src/modules/agents/integrations/chat-integration.service.ts
@@ -54,9 +54,9 @@ interface ChatAgentConnection {
 	bridge: AgentChatBridge;
 	/**
 	 * Context captured at connect time. Used by `disconnectOne` to invoke
-	 * `onBeforeDisconnect` hooks (e.g. Telegram `deleteWebhook`) with the same
-	 * decrypted credential the connect ran with — re-decrypting at disconnect
-	 * time would fail if the credential was rotated or deleted in between.
+	 * `onBeforeDisconnect` hooks with the same decrypted credential the connect
+	 * ran with — re-decrypting at disconnect time would fail if the credential
+	 * was rotated or deleted in between.
 	 */
 	context: AgentChatIntegrationContext;
 }
@@ -68,7 +68,7 @@ interface ConnectOptions {
 
 interface DisconnectOptions {
 	/**
-	 * Skip integration-defined external teardown (e.g. Telegram `deleteWebhook`).
+	 * Skip integration-defined external teardown.
 	 * Mirror of `ConnectOptions.skipExternalHooks` — set true on peer mains
 	 * reacting to a PubSub broadcast, in graceful-shutdown paths, and during
 	 * leader-stepdown so the cluster-wide remote release happens exactly once.
@@ -143,12 +143,10 @@ export class ChatIntegrationService {
 	 * and wires up the AgentChatBridge for event handling.
 	 *
 	 * `options.skipExternalHooks` skips `onBeforeConnect` and `onAfterConnect`.
-	 * These hooks touch external services (DB validation, Telegram `setWebhook`)
-	 * and must run exactly once per cluster — by the originator on a
-	 * user-initiated connect, or by the leader on startup. Peer mains reacting
-	 * to a PubSub broadcast pass `true` so we don't, for example, race two
-	 * `setWebhook` calls into Telegram's 1/sec rate limit and 429 ourselves out
-	 * of a healthy connection.
+	 * These hooks can touch external services and must run exactly once per
+	 * cluster — by the originator on a user-initiated connect, or by the leader
+	 * on startup. Peer mains reacting to a PubSub broadcast pass `true` so they
+	 * only build local runtime state.
 	 */
 	async connect(
 		agentId: string,
@@ -258,7 +256,7 @@ export class ChatIntegrationService {
 	 *
 	 * `options.skipExternalHooks` skips `onBeforeDisconnect` — set this on peer
 	 * mains reacting to a PubSub broadcast so the cluster-wide remote release
-	 * (e.g. Telegram `deleteWebhook`) happens exactly once.
+	 * happens exactly once.
 	 */
 	async disconnect(
 		agentId: string,
@@ -287,9 +285,8 @@ export class ChatIntegrationService {
 	async disconnectAll(): Promise<void> {
 		const keys = [...this.connections.keys()];
 		for (const key of keys) {
-			// Graceful shutdown: don't release cluster-wide remote state (e.g.
-			// Telegram webhooks) — we want the bot to keep receiving when this
-			// main restarts.
+			// Graceful shutdown should only clear local runtime state. Cluster-wide
+			// remote state must survive so another main can keep receiving events.
 			await this.disconnectOne(key, { skipExternalHooks: true });
 		}
 	}
@@ -307,9 +304,6 @@ export class ChatIntegrationService {
 			if (!type) continue;
 			const integration = this.integrationRegistry.get(type);
 			if (integration?.requiresLeader()) {
-				// Leader stepdown is a role transition, not a user-initiated
-				// disconnect — another main is about to take over polling, so we
-				// must not release any remote-side state.
 				await this.disconnectOne(key, { skipExternalHooks: true });
 			}
 		}
@@ -496,10 +490,8 @@ export class ChatIntegrationService {
 					continue;
 				}
 
-				// External setup (Telegram setWebhook, etc.) runs once per cluster —
-				// the leader claims that role on startup; followers only build local
-				// state so a stampede of reconnecting mains doesn't trip remote rate
-				// limits.
+				// External setup runs once per cluster — the leader claims that role
+				// on startup; followers only build local runtime state.
 				const skipExternalHooks = !this.instanceSettings.isLeader;
 				const options = this.connectOptionsFor(integration, skipExternalHooks);
 
@@ -545,10 +537,8 @@ export class ChatIntegrationService {
 		const { type, credentialId } = integration;
 
 		if (action === 'disconnect') {
-			// The originating main already ran external teardown (Telegram
-			// deleteWebhook etc.). Peers only need to clear local state —
-			// skipping the hook also avoids racing the originator into Telegram's
-			// 1/sec rate limit and 429 ourselves out of a clean release.
+			// The originating main already ran integration-defined external teardown.
+			// Peers only clear local runtime state to avoid duplicate external side effects.
 			await this.disconnect(agentId, integration, { skipExternalHooks: true });
 			return;
 		}
@@ -577,10 +567,9 @@ export class ChatIntegrationService {
 		);
 		for (const userId of userIds) {
 			try {
-				// The originating main already ran external setup (DB validation,
-				// Telegram setWebhook). We only need local state here — skipping
-				// the hooks also avoids racing the originator into Telegram's 1/sec
-				// rate limit.
+				// The originating main already ran integration-defined external setup.
+				// Peers only build local runtime state to avoid duplicate external
+				// side effects.
 				const options: ConnectOptions = { skipExternalHooks: true };
 				await this.connect(agentId, integration, userId, agent.projectId, options);
 				return;

--- a/packages/cli/src/modules/agents/integrations/chat-integration.service.ts
+++ b/packages/cli/src/modules/agents/integrations/chat-integration.service.ts
@@ -52,11 +52,28 @@ interface ChatInstance {
 interface ChatAgentConnection {
 	chat: ChatInstance;
 	bridge: AgentChatBridge;
+	/**
+	 * Context captured at connect time. Used by `disconnectOne` to invoke
+	 * `onBeforeDisconnect` hooks (e.g. Telegram `deleteWebhook`) with the same
+	 * decrypted credential the connect ran with — re-decrypting at disconnect
+	 * time would fail if the credential was rotated or deleted in between.
+	 */
+	context: AgentChatIntegrationContext;
 }
 
 interface ConnectOptions {
 	skipExternalHooks?: boolean;
 	settings?: AgentIntegrationSettings;
+}
+
+interface DisconnectOptions {
+	/**
+	 * Skip integration-defined external teardown (e.g. Telegram `deleteWebhook`).
+	 * Mirror of `ConnectOptions.skipExternalHooks` — set true on peer mains
+	 * reacting to a PubSub broadcast, in graceful-shutdown paths, and during
+	 * leader-stepdown so the cluster-wide remote release happens exactly once.
+	 */
+	skipExternalHooks?: boolean;
 }
 
 /**
@@ -229,6 +246,7 @@ export class ChatIntegrationService {
 		this.connections.set(key, {
 			chat: chatInstance,
 			bridge,
+			context: ctx,
 		});
 		this.logger.info(`[ChatIntegrationService] Connected: ${key}`);
 	}
@@ -237,19 +255,25 @@ export class ChatIntegrationService {
 	 * Disconnect one or all integrations for an agent.
 	 * If `type` and `credentialId` are provided, disconnects only that integration.
 	 * Otherwise disconnects all integrations for the agent.
+	 *
+	 * `options.skipExternalHooks` skips `onBeforeDisconnect` — set this on peer
+	 * mains reacting to a PubSub broadcast so the cluster-wide remote release
+	 * (e.g. Telegram `deleteWebhook`) happens exactly once.
 	 */
 	async disconnect(
 		agentId: string,
 		integration?: { credentialId: string; type: string },
+		options: DisconnectOptions = {},
 	): Promise<void> {
 		if (integration) {
 			await this.disconnectOne(
 				this.connectionKey(agentId, integration.type, integration.credentialId),
+				options,
 			);
 		} else {
 			const keysToRemove = [...this.connections.keys()].filter((k) => k.startsWith(`${agentId}:`));
 			for (const k of keysToRemove) {
-				await this.disconnectOne(k);
+				await this.disconnectOne(k, options);
 			}
 		}
 	}
@@ -263,7 +287,10 @@ export class ChatIntegrationService {
 	async disconnectAll(): Promise<void> {
 		const keys = [...this.connections.keys()];
 		for (const key of keys) {
-			await this.disconnectOne(key);
+			// Graceful shutdown: don't release cluster-wide remote state (e.g.
+			// Telegram webhooks) — we want the bot to keep receiving when this
+			// main restarts.
+			await this.disconnectOne(key, { skipExternalHooks: true });
 		}
 	}
 
@@ -280,7 +307,10 @@ export class ChatIntegrationService {
 			if (!type) continue;
 			const integration = this.integrationRegistry.get(type);
 			if (integration?.requiresLeader()) {
-				await this.disconnectOne(key);
+				// Leader stepdown is a role transition, not a user-initiated
+				// disconnect — another main is about to take over polling, so we
+				// must not release any remote-side state.
+				await this.disconnectOne(key, { skipExternalHooks: true });
 			}
 		}
 	}
@@ -515,7 +545,11 @@ export class ChatIntegrationService {
 		const { type, credentialId } = integration;
 
 		if (action === 'disconnect') {
-			await this.disconnect(agentId, integration);
+			// The originating main already ran external teardown (Telegram
+			// deleteWebhook etc.). Peers only need to clear local state —
+			// skipping the hook also avoids racing the originator into Telegram's
+			// 1/sec rate limit and 429 ourselves out of a clean release.
+			await this.disconnect(agentId, integration, { skipExternalHooks: true });
 			return;
 		}
 
@@ -565,9 +599,27 @@ export class ChatIntegrationService {
 	// Private helpers
 	// ---------------------------------------------------------------------------
 
-	private async disconnectOne(key: string): Promise<void> {
+	private async disconnectOne(key: string, options: DisconnectOptions = {}): Promise<void> {
 		const conn = this.connections.get(key);
 		if (!conn) return;
+
+		// External teardown runs while the chat is still live — symmetric with
+		// `onAfterConnect`, which runs after `chat.initialize()`. Errors are
+		// logged but never re-thrown: local teardown must always complete so a
+		// transient remote failure can't leak in-process resources.
+		if (!options.skipExternalHooks) {
+			const type = this.connectionTypeFromKey(key);
+			const integration = type ? this.integrationRegistry.get(type) : undefined;
+			if (integration?.onBeforeDisconnect) {
+				try {
+					await integration.onBeforeDisconnect(conn.context);
+				} catch (error) {
+					this.logger.warn(
+						`[ChatIntegrationService] onBeforeDisconnect failed for ${key}: ${error instanceof Error ? error.message : String(error)}`,
+					);
+				}
+			}
+		}
 
 		try {
 			await conn.chat.shutdown();

--- a/packages/cli/src/modules/agents/integrations/platforms/__tests__/telegram-integration.test.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/__tests__/telegram-integration.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/unbound-method -- mock-based tests intentionally reference unbound methods */
 import type { Logger } from '@n8n/backend-common';
+import type { Author } from 'chat';
 import { createHmac } from 'crypto';
 import { mock } from 'jest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
@@ -12,7 +13,6 @@ import type { AgentRepository } from '../../../repositories/agent.repository';
 import type { AgentChatIntegrationContext } from '../../agent-chat-integration';
 import { loadTelegramAdapter } from '../../esm-loader';
 import { TelegramIntegration } from '../telegram-integration';
-import type { Author } from 'chat';
 
 jest.mock('../../esm-loader', () => ({
 	loadTelegramAdapter: jest.fn(),
@@ -295,6 +295,30 @@ describe('TelegramIntegration secret token', () => {
 			fetchSpy.mockRestore();
 		}
 	});
+
+	it('onAfterConnect honors a custom baseUrl from the credential (self-hosted Bot API)', async () => {
+		const fetchSpy = jest
+			.spyOn(globalThis, 'fetch')
+			.mockResolvedValue({ ok: true, text: async () => 'ok' } as Response);
+
+		try {
+			const { integration } = makeIntegration();
+
+			await integration.onAfterConnect(
+				makeContext({
+					credential: {
+						accessToken: 'bot-token',
+						baseUrl: 'https://bot-api.self-hosted.example.com/',
+					},
+				}),
+			);
+
+			const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe('https://bot-api.self-hosted.example.com/botbot-token/setWebhook');
+		} finally {
+			fetchSpy.mockRestore();
+		}
+	});
 });
 
 describe('TelegramIntegration.onBeforeDisconnect', () => {
@@ -343,5 +367,25 @@ describe('TelegramIntegration.onBeforeDisconnect', () => {
 		await expect(integration.onBeforeDisconnect(makeContext())).rejects.toThrow(
 			'Failed to deregister Telegram webhook: invalid token',
 		);
+	});
+
+	it('honors a custom baseUrl from the credential (self-hosted Bot API)', async () => {
+		fetchSpy.mockResolvedValue({ ok: true, text: async () => 'ok' } as Response);
+
+		const urlService = mock<UrlService>();
+		urlService.getWebhookBaseUrl.mockReturnValue('https://n8n.example.com/');
+		const { integration } = makeIntegration({ urlService });
+
+		await integration.onBeforeDisconnect(
+			makeContext({
+				credential: {
+					accessToken: 'bot-token',
+					baseUrl: 'https://bot-api.self-hosted.example.com',
+				},
+			}),
+		);
+
+		const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+		expect(url).toBe('https://bot-api.self-hosted.example.com/botbot-token/deleteWebhook');
 	});
 });

--- a/packages/cli/src/modules/agents/integrations/platforms/__tests__/telegram-integration.test.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/__tests__/telegram-integration.test.ts
@@ -296,3 +296,52 @@ describe('TelegramIntegration secret token', () => {
 		}
 	});
 });
+
+describe('TelegramIntegration.onBeforeDisconnect', () => {
+	let fetchSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		fetchSpy = jest.spyOn(globalThis, 'fetch');
+	});
+
+	afterEach(() => {
+		fetchSpy.mockRestore();
+	});
+
+	it('calls deleteWebhook on Telegram with the bot token in webhook mode', async () => {
+		fetchSpy.mockResolvedValue({ ok: true, text: async () => 'ok' } as Response);
+
+		const urlService = mock<UrlService>();
+		urlService.getWebhookBaseUrl.mockReturnValue('https://n8n.example.com/');
+		const { integration } = makeIntegration({ urlService });
+
+		await integration.onBeforeDisconnect(makeContext());
+
+		expect(fetchSpy).toHaveBeenCalledTimes(1);
+		const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+		expect(url).toBe('https://api.telegram.org/botbot-token/deleteWebhook');
+		expect(init.method).toBe('POST');
+	});
+
+	it('skips the API call entirely in polling mode (localhost / non-public URL)', async () => {
+		const urlService = mock<UrlService>();
+		urlService.getWebhookBaseUrl.mockReturnValue('http://localhost:5678/');
+		const { integration } = makeIntegration({ urlService });
+
+		await integration.onBeforeDisconnect(makeContext());
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it('throws when Telegram rejects deleteWebhook so the caller can log it', async () => {
+		fetchSpy.mockResolvedValue({ ok: false, text: async () => 'invalid token' } as Response);
+
+		const urlService = mock<UrlService>();
+		urlService.getWebhookBaseUrl.mockReturnValue('https://n8n.example.com/');
+		const { integration } = makeIntegration({ urlService });
+
+		await expect(integration.onBeforeDisconnect(makeContext())).rejects.toThrow(
+			'Failed to deregister Telegram webhook: invalid token',
+		);
+	});
+});

--- a/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
@@ -126,6 +126,25 @@ export class TelegramIntegration extends AgentChatIntegration {
 	}
 
 	/**
+	 * Mirror of `onAfterConnect`: clear the webhook we registered on Telegram so
+	 * the bot is free for another agent or another application. Polling-mode
+	 * connections never registered a webhook with Telegram, so skip.
+	 */
+	async onBeforeDisconnect(ctx: AgentChatIntegrationContext): Promise<void> {
+		if (this.getMode() !== 'webhook') return;
+		const botToken = this.extractBotToken(ctx.credential);
+		const resp = await fetch(`https://api.telegram.org/bot${botToken}/deleteWebhook`, {
+			method: 'POST',
+		});
+		if (!resp.ok) {
+			throw new Error(`Failed to deregister Telegram webhook: ${await resp.text()}`);
+		}
+		this.logger.info(
+			`[TelegramIntegration] Webhook deregistered for agent ${ctx.agentId}, credential ${ctx.credentialId}`,
+		);
+	}
+
+	/**
 	 * Enforce the Private-mode allowlist. Public mode (or legacy connections
 	 * without saved settings) accepts every Telegram user; Private mode only
 	 * accepts senders whose numeric user ID or username appears in `allowedUsers`.

--- a/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
@@ -1,3 +1,4 @@
+import { AgentCredentialIntegrationConfig } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
 import type { Thread, Author } from 'chat';
@@ -8,7 +9,6 @@ import { UnexpectedError } from 'n8n-workflow';
 import { ConflictError } from '@/errors/response-errors/conflict.error';
 import { UrlService } from '@/services/url.service';
 
-import { AgentCredentialIntegrationConfig } from '@n8n/api-types';
 import { AgentRepository } from '../../repositories/agent.repository';
 import { AgentChatIntegration, type AgentChatIntegrationContext } from '../agent-chat-integration';
 import type { SuspendComponent } from '../component-mapper';
@@ -111,10 +111,9 @@ export class TelegramIntegration extends AgentChatIntegration {
 
 	async onAfterConnect(ctx: AgentChatIntegrationContext): Promise<void> {
 		if (this.getMode() !== 'webhook') return;
-		const botToken = this.extractBotToken(ctx.credential);
 		const webhookUrl = ctx.webhookUrlFor('telegram');
 		const secretToken = this.deriveSecretToken(ctx.agentId, ctx.credentialId);
-		const resp = await fetch(`https://api.telegram.org/bot${botToken}/setWebhook`, {
+		const resp = await fetch(this.botApiUrl(ctx.credential, 'setWebhook'), {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({ url: webhookUrl, secret_token: secretToken }),
@@ -132,8 +131,7 @@ export class TelegramIntegration extends AgentChatIntegration {
 	 */
 	async onBeforeDisconnect(ctx: AgentChatIntegrationContext): Promise<void> {
 		if (this.getMode() !== 'webhook') return;
-		const botToken = this.extractBotToken(ctx.credential);
-		const resp = await fetch(`https://api.telegram.org/bot${botToken}/deleteWebhook`, {
+		const resp = await fetch(this.botApiUrl(ctx.credential, 'deleteWebhook'), {
 			method: 'POST',
 		});
 		if (!resp.ok) {
@@ -224,5 +222,20 @@ export class TelegramIntegration extends AgentChatIntegration {
 			'Could not extract a bot token from the Telegram credential. ' +
 				'Please ensure the credential has a valid access token from BotFather.',
 		);
+	}
+
+	/**
+	 * Build a Bot API URL honoring the credential's `baseUrl` (defaults to
+	 * `https://api.telegram.org`). Lets users on a self-hosted Bot API server
+	 * register/deregister webhooks against their own endpoint.
+	 */
+	private botApiUrl(credential: Record<string, unknown>, method: string): string {
+		const botToken = this.extractBotToken(credential);
+		const raw = credential.baseUrl;
+		const baseUrl =
+			typeof raw === 'string' && raw.trim()
+				? raw.trim().replace(/\/+$/, '')
+				: 'https://api.telegram.org';
+		return `${baseUrl}/bot${botToken}/${method}`;
 	}
 }


### PR DESCRIPTION
## Summary

When an agent's Telegram integration was disconnected, the webhook registered on Telegram was left in place. Telegram only allows one webhook per bot at a time, so the bot stayed bound to this n8n instance and could not be reused by another agent, another n8n instance, or another application until the user manually called `deleteWebhook`.

This PR adds a generic `onBeforeDisconnect` lifecycle hook to `AgentChatIntegration` (mirror of the existing `onAfterConnect`) and implements it for Telegram by calling `https://api.telegram.org/bot<token>/deleteWebhook`.

### Multi-main correctness

The hook only runs on **user-initiated** disconnects. Three teardown paths explicitly skip it via a new `skipExternalHooks` option so the cluster-wide remote release happens exactly once:

- **Peer mains reacting to a PubSub `disconnect` broadcast** — the originating main already ran the external teardown; peers only clear local state. Skipping also avoids racing the originator into Telegram's 1/sec rate limit.
- **Graceful shutdown (`disconnectAll`)** — we want the bot to keep receiving when this main restarts.
- **Leader stepdown (`disconnectLeaderOnlyIntegrations`)** — a role transition where another main is about to take over polling; remote state must not be released.

Errors from `onBeforeDisconnect` are logged and swallowed so a transient remote failure can't leak in-process resources (the chat instance and bridge still shut down).

### How to test

1. Connect an agent's Telegram integration in webhook mode (public n8n URL).
2. Verify Telegram has the webhook: `curl https://api.telegram.org/bot<TOKEN>/getWebhookInfo` — `url` should point to your n8n instance.
3. Disconnect the integration from the agent UI.
4. Call `getWebhookInfo` again — `url` should now be empty.
5. Reconnect the same bot to a different agent or n8n instance — it should succeed without a manual `deleteWebhook` call.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-131

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI