### PR TITLE
feat(lmChatAzureOpenAi): Add reasoning effort option

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/LmChatAzureOpenAi.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/LmChatAzureOpenAi.node.ts
@@ -101,6 +101,15 @@ export class LmChatAzureOpenAi implements INodeType {
 			this.logger.info(`Instantiating AzureChatOpenAI model with deployment: ${modelName}`);
 
 			const timeout = options.timeout;
+
+			const modelKwargs: Record<string, unknown> = {};
+			if (options.responseFormat) {
+				modelKwargs.response_format = { type: options.responseFormat };
+			}
+			if (options.reasoningEffort && ['low', 'medium', 'high'].includes(options.reasoningEffort)) {
+				modelKwargs.reasoning_effort = options.reasoningEffort;
+			}
+
 			const model = new AzureChatOpenAI({
 				// Force completions API — Azure's SDK doesn't rewrite the /responses path,
 				// so the Responses API hits an invalid endpoint and causes a connection error.
@@ -123,11 +132,7 @@ export class LmChatAzureOpenAi implements INodeType {
 						}),
 					},
 				},
-				modelKwargs: options.responseFormat
-					? {
-							response_format: { type: options.responseFormat },
-						}
-					: undefined,
+				modelKwargs: Object.keys(modelKwargs).length > 0 ? modelKwargs : undefined,
 				onFailedAttempt: makeN8nLlmFailedAttemptHandler(this),
 			});
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/properties.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/properties.ts
@@ -92,6 +92,32 @@ export const properties: INodeProperties[] = [
 				],
 			},
 			{
+				displayName: 'Reasoning Effort',
+				name: 'reasoningEffort',
+				default: 'medium',
+				description:
+					'Controls the amount of reasoning tokens to use. A value of "low" will favor speed and economical token usage, "high" will favor more complete reasoning at the cost of more tokens generated and slower responses. Only applies to reasoning-capable deployments (e.g., o1, o3, gpt-5).',
+				type: 'options',
+				options: [
+					{
+						name: 'Low',
+						value: 'low',
+						description: 'Favors speed and economical token usage',
+					},
+					{
+						name: 'Medium',
+						value: 'medium',
+						description: 'Balance between speed and reasoning accuracy',
+					},
+					{
+						name: 'High',
+						value: 'high',
+						description:
+							'Favors more complete reasoning at the cost of more tokens generated and slower responses',
+					},
+				],
+			},
+			{
 				displayName: 'Presence Penalty',
 				name: 'presencePenalty',
 				default: 0,

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/types.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatAzureOpenAi/types.ts
@@ -31,6 +31,7 @@ export interface AzureOpenAIOptions {
 	temperature?: number;
 	topP?: number;
 	responseFormat?: 'text' | 'json_object';
+	reasoningEffort?: 'low' | 'medium' | 'high';
 }
 
 /**

--- a/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatAzureOpenAi.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/test/LmChatAzureOpenAi.test.ts
@@ -1,0 +1,173 @@
+import { AzureChatOpenAI } from '@langchain/openai';
+import { makeN8nLlmFailedAttemptHandler, N8nLlmTracing, getProxyAgent } from '@n8n/ai-utilities';
+import { createMockExecuteFunction } from 'n8n-nodes-base/test/nodes/Helpers';
+import type { INode, ISupplyDataFunctions } from 'n8n-workflow';
+import type { Mocked } from 'vitest';
+
+import { setupApiKeyAuthentication } from '../LmChatAzureOpenAi/credentials/api-key';
+import { LmChatAzureOpenAi } from '../LmChatAzureOpenAi/LmChatAzureOpenAi.node';
+
+vi.mock('@langchain/openai');
+vi.mock('@n8n/ai-utilities');
+vi.mock('../LmChatAzureOpenAi/credentials/api-key');
+vi.mock('../LmChatAzureOpenAi/credentials/oauth2');
+
+const MockedAzureChatOpenAI = vi.mocked(AzureChatOpenAI);
+const mockedMakeN8nLlmFailedAttemptHandler = vi.mocked(makeN8nLlmFailedAttemptHandler);
+const mockedGetProxyAgent = vi.mocked(getProxyAgent);
+const mockedSetupApiKeyAuthentication = vi.mocked(setupApiKeyAuthentication);
+
+describe('LmChatAzureOpenAi', () => {
+	let lmChatAzureOpenAi: LmChatAzureOpenAi;
+	let mockContext: Mocked<ISupplyDataFunctions>;
+
+	const mockNode: INode = {
+		id: '1',
+		name: 'Azure OpenAI Chat Model',
+		typeVersion: 1,
+		type: 'n8n-nodes-langchain.lmChatAzureOpenAi',
+		position: [0, 0],
+		parameters: {},
+	};
+
+	const setupMockContext = (options: Record<string, unknown> = {}) => {
+		mockContext = createMockExecuteFunction<ISupplyDataFunctions>(
+			{},
+			mockNode,
+		) as Mocked<ISupplyDataFunctions>;
+
+		mockContext.getNode = vi.fn().mockReturnValue(mockNode);
+		mockContext.logger = {
+			info: vi.fn(),
+			error: vi.fn(),
+			debug: vi.fn(),
+			warn: vi.fn(),
+		} as unknown as ISupplyDataFunctions['logger'];
+
+		const getNodeParameter = vi.fn((paramName: string) => {
+			if (paramName === 'authentication') return 'azureOpenAiApi';
+			if (paramName === 'model') return 'gpt-5';
+			if (paramName === 'options') return options;
+			return undefined;
+		});
+		mockContext.getNodeParameter =
+			getNodeParameter as unknown as typeof mockContext.getNodeParameter;
+
+		mockedSetupApiKeyAuthentication.mockResolvedValue({
+			azureOpenAIApiKey: 'test-api-key',
+			azureOpenAIApiInstanceName: 'test-resource',
+			azureOpenAIApiVersion: '2024-02-01',
+			azureOpenAIEndpoint: undefined,
+		});
+		mockedMakeN8nLlmFailedAttemptHandler.mockReturnValue(vi.fn());
+		mockedGetProxyAgent.mockReturnValue({} as never);
+		vi.mocked(N8nLlmTracing).mockClear();
+
+		return mockContext;
+	};
+
+	beforeEach(() => {
+		lmChatAzureOpenAi = new LmChatAzureOpenAi();
+		vi.clearAllMocks();
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	describe('node description', () => {
+		it('should expose a Reasoning Effort option', () => {
+			const optionsCollection = lmChatAzureOpenAi.description.properties.find(
+				(property) => property?.name === 'options',
+			);
+			const reasoningEffort = optionsCollection?.options?.find(
+				(option) => 'name' in option && option.name === 'reasoningEffort',
+			);
+
+			expect(reasoningEffort).toMatchObject({
+				name: 'reasoningEffort',
+				type: 'options',
+				default: 'medium',
+			});
+		});
+	});
+
+	describe('supplyData', () => {
+		it('should not set modelKwargs when no relevant options are provided', async () => {
+			const mockContext = setupMockContext({});
+
+			await lmChatAzureOpenAi.supplyData.call(mockContext, 0);
+
+			expect(MockedAzureChatOpenAI).toHaveBeenCalledWith(
+				expect.objectContaining({
+					model: 'gpt-5',
+					modelKwargs: undefined,
+				}),
+			);
+		});
+
+		it('should pass reasoning_effort to modelKwargs when set', async () => {
+			const mockContext = setupMockContext({ reasoningEffort: 'high' });
+
+			await lmChatAzureOpenAi.supplyData.call(mockContext, 0);
+
+			expect(MockedAzureChatOpenAI).toHaveBeenCalledWith(
+				expect.objectContaining({
+					modelKwargs: {
+						reasoning_effort: 'high',
+					},
+				}),
+			);
+		});
+
+		it('should pass both response_format and reasoning_effort when both are set', async () => {
+			const mockContext = setupMockContext({
+				responseFormat: 'json_object',
+				reasoningEffort: 'low',
+			});
+
+			await lmChatAzureOpenAi.supplyData.call(mockContext, 0);
+
+			expect(MockedAzureChatOpenAI).toHaveBeenCalledWith(
+				expect.objectContaining({
+					modelKwargs: {
+						response_format: { type: 'json_object' },
+						reasoning_effort: 'low',
+					},
+				}),
+			);
+		});
+
+		it('should ignore an invalid reasoning effort value', async () => {
+			const mockContext = setupMockContext({ reasoningEffort: 'invalid' });
+
+			await lmChatAzureOpenAi.supplyData.call(mockContext, 0);
+
+			expect(MockedAzureChatOpenAI).toHaveBeenCalledWith(
+				expect.objectContaining({
+					modelKwargs: undefined,
+				}),
+			);
+		});
+
+		it('should accept all valid reasoning effort values', async () => {
+			const reasoningEffortValues = ['low', 'medium', 'high'] as const;
+
+			for (const effort of reasoningEffortValues) {
+				const mockContext = setupMockContext({ reasoningEffort: effort });
+
+				await lmChatAzureOpenAi.supplyData.call(mockContext, 0);
+
+				expect(MockedAzureChatOpenAI).toHaveBeenCalledWith(
+					expect.objectContaining({
+						modelKwargs: {
+							reasoning_effort: effort,
+						},
+					}),
+				);
+
+				vi.clearAllMocks();
+			}
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds a **Reasoning Effort** option (`Low` / `Medium` / `High`) to the **Azure OpenAI Chat Model** node. The selected value is sent to the model as the `reasoning_effort` parameter.

Previously the node exposed no way to set this, so requests to reasoning-capable Azure deployments (o-series, GPT-5) always used Azure's default effort. Users can now trade response latency and token usage against reasoning depth, matching the capability already available through Azure's API.

**Design note — divergence from the OpenAI Chat Model node:** the OpenAI node gates its Reasoning Effort field behind a model-name regex. The Azure node intentionally does **not**: its model field is a free-text *deployment name* chosen by the user (e.g. `my-prod-reasoner`), which doesn't reliably match OpenAI's model naming, so regex gating would wrongly hide the option for valid reasoning deployments. The option is therefore always visible. The value is passed via `modelKwargs.reasoning_effort` (snake_case), consistent with `LmChatOpenAi`'s non-Responses-API path — correct here since the Azure node forces `useResponsesApi: false`.

### How to test

1. Add an **Azure OpenAI Chat Model** sub-node to a workflow with a reasoning-capable deployment (o1 / o3 / GPT-5 family).
2. Open **Options → Add Option → Reasoning Effort** and pick a level.
3. Run the workflow.

Verified manually against a live `gpt-5-mini` Azure deployment with an identical prompt — completion tokens scale with effort (reasoning tokens are billed as completion tokens), confirming the parameter reaches and affects the model:

| Reasoning Effort | completionTokens | totalTokens |
|---|---|---|
| Low | 20 | 28 |
| Medium | 37 | 45 |
| High | 247 | 255 |

The serialized model config also shows `model_kwargs: { reasoning_effort: "high" }`, confirming the value is passed end-to-end.

Unit tests (`packages/@n8n/nodes-langchain/nodes/llms/test/LmChatAzureOpenAi.test.ts`) cover: the property is exposed; each valid value lands in `modelKwargs`; `response_format` and `reasoning_effort` coexist when both are set; invalid values are ignored; nothing is sent when unset.

## Related Linear tickets, Github issues, and Community forum posts

Community feature request: https://community.n8n.io/t/add-reasoning-effort-parameter-to-azure-openai-chat-model-node/162624

Companion docs PR: https://github.com/n8n-io/n8n-docs/pull/4648

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- Documented in companion docs PR n8n-io/n8n-docs#4648. -->
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
