### PR TITLE
fix(core): Handle null pinData in getDataLastExecutedNodeData

### DIFF
--- a/packages/cli/src/__tests__/workflow-helpers.test.ts
+++ b/packages/cli/src/__tests__/workflow-helpers.test.ts
@@ -7,6 +7,7 @@ import type { ITaskData, IWorkflowBase, IWorkflowSettings } from 'n8n-workflow';
 import { VariablesService } from '@/environments.ee/variables/variables.service.ee';
 import { OwnershipService } from '@/services/ownership.service';
 import {
+	getDataLastExecutedNodeData,
 	getVariables,
 	preserveInputOverride,
 	removeDefaultValues,
@@ -438,5 +439,45 @@ describe('validatePinDataSize', () => {
 		).toThrow(
 			`Workflow with pinned data exceeds the maximum allowed size of ${Math.floor(limit / (1024 * 1024))} MB`,
 		);
+	});
+});
+
+describe('getDataLastExecutedNodeData', () => {
+	const taskData = {
+		startTime: 0,
+		executionIndex: 0,
+		executionTime: 0,
+		source: [],
+		data: { main: [[{ json: { ok: true } }]] },
+	} as unknown as ITaskData;
+
+	const buildRun = (resultData: object) =>
+		({ data: { resultData }, mode: 'manual' }) as unknown as Parameters<
+			typeof getDataLastExecutedNodeData
+		>[0];
+
+	it('returns the last node task data when pinData is an empty object', () => {
+		const result = getDataLastExecutedNodeData(
+			buildRun({
+				runData: { 'AI Agent': [taskData] },
+				pinData: {},
+				lastNodeExecuted: 'AI Agent',
+			}),
+		);
+		expect(result).toBe(taskData);
+	});
+
+	it('returns the last node task data when pinData is null', () => {
+		// Persisted execution data stores pinData as `null` when no data is pinned.
+		// The destructuring default `pinData = {}` only fires for undefined, so a
+		// null value used to slip through and crash on `pinData[lastNodeExecuted]`.
+		const result = getDataLastExecutedNodeData(
+			buildRun({
+				runData: { 'AI Agent': [taskData] },
+				pinData: null,
+				lastNodeExecuted: 'AI Agent',
+			}),
+		);
+		expect(result).toBe(taskData);
 	});
 });

--- a/packages/cli/src/workflow-helpers.ts
+++ b/packages/cli/src/workflow-helpers.ts
@@ -71,7 +71,7 @@ export function getDataLastExecutedNodeData(inputData: IRun): ITaskData | undefi
 
 	const lastNodeRunData = runData[lastNodeExecuted][runData[lastNodeExecuted].length - 1];
 
-	let lastNodePinData = pinData[lastNodeExecuted];
+	let lastNodePinData = pinData ? pinData[lastNodeExecuted] : undefined;
 
 	if (lastNodePinData && inputData.mode === 'manual') {
 		if (!Array.isArray(lastNodePinData)) lastNodePinData = [lastNodePinData];


### PR DESCRIPTION
## Summary

`getDataLastExecutedNodeData` (`packages/cli/src/workflow-helpers.ts`) destructures `pinData` with a default of `{}`. JavaScript destructuring defaults only apply when the property is `undefined`, so when an execution stores `pinData` as **`null`** the default silently does not apply and the subsequent `pinData[lastNodeExecuted]` throws:

```
TypeError: Cannot read properties of null (reading 'AI Agent')
    at Object.getDataLastExecutedNodeData (packages/cli/src/workflow-helpers.ts:74:23)
    at packages/cli/src/webhooks/webhook-helpers.ts (the response handler for test webhooks)
```

The crash is wrapped into a generic `ResponseError: There was a problem executing the workflow`. In the editor UI this surfaces as the **chat panel of any Chat Trigger workflow showing "There was a problem executing the workflow"** while the workflow itself completes successfully — the Logs panel shows `Success in <N>ms`, the AI node output is correct, only the chat panel is broken.

### Reproduction (n8n 2.20.9 / current `master`)

1. Create a workflow: `Chat Trigger → AI Agent (with any Chat Model + Memory)`.
2. Open the editor chat panel and send a message.
3. The workflow runs fine but the chat panel displays "There was a problem executing the workflow".

Internally, `inputData.data.resultData` looks like `{ runData, pinData: null, lastNodeExecuted, ... }` — `pinData` is explicitly `null`, so the destructuring default does not kick in.

### Fix

Guard the property access (one-line change):

\`\`\`ts
- let lastNodePinData = pinData[lastNodeExecuted];
+ let lastNodePinData = pinData ? pinData[lastNodeExecuted] : undefined;
\`\`\`

This treats \`null\` the same way an empty pinData map would be treated, matching the intent of the destructuring default.

A unit test in \`packages/cli/src/__tests__/workflow-helpers.test.ts\` covers both the empty-object and null cases.

## Related Linear tickets, Github issues, and Community forum posts

No tracked Linear ticket — community-reported workaround for self-hosted users running workflows with AI Agent + Chat Trigger.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\`.