### PR TITLE
fix(editor): Open update CTA docs in a new tab on self-hosted instances

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/usePageRedirectionHelper.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePageRedirectionHelper.test.ts
@@ -138,54 +138,56 @@ describe('usePageRedirectionHelper', () => {
 		},
 	);
 
-	test.each([
-		[
-			'cloud',
-			'production',
-			ROLE.Owner,
-			`https://app.n8n.cloud/login?code=123&returnPath=${encodeURIComponent('/manage')}`,
-		],
-		[
-			'cloud',
-			'production',
-			ROLE.Member,
-			'https://docs.n8n.io/release-notes/#n8n1652?utm_source=n8n_app&utm_medium=instance_upgrade_releases',
-		],
-	])(
-		'"goToVersions" should generate the correct URL for "%s" deployment and "%s" license environment and user role "%s"',
-		async (type, environment, role, expectation) => {
-			// Arrange
-
-			usersStore.addUsers([
-				{
-					id: '1',
-					isPending: false,
-					role,
-				},
-			]);
-
+	describe('goToVersions', () => {
+		test('redirects in the same tab for cloud instance owners', async () => {
+			usersStore.addUsers([{ id: '1', isPending: false, role: ROLE.Owner }]);
 			usersStore.currentUserId = '1';
 
 			settingsStore.setSettings(
 				merge({}, defaultSettings, {
-					deployment: {
-						type,
-					},
-					license: {
-						environment,
-					},
+					deployment: { type: 'cloud' },
+					license: { environment: 'production' },
 				}),
 			);
 
-			// Act
+			const windowOpenSpy = vi.spyOn(window, 'open').mockReturnValue(null);
 
 			await pageRedirectionHelper.goToVersions();
 
-			// Assert
+			expect(location.href).toBe(
+				`https://app.n8n.cloud/login?code=123&returnPath=${encodeURIComponent('/manage')}`,
+			);
+			expect(windowOpenSpy).not.toHaveBeenCalled();
+		});
 
-			expect(location.href).toBe(expectation);
-		},
-	);
+		test.each([
+			['cloud', ROLE.Member],
+			['default', ROLE.Owner],
+			['default', ROLE.Member],
+		])('opens the docs URL in a new tab for "%s" deployment with role "%s"', async (type, role) => {
+			usersStore.addUsers([{ id: '1', isPending: false, role }]);
+			usersStore.currentUserId = '1';
+
+			settingsStore.setSettings(
+				merge({}, defaultSettings, {
+					deployment: { type },
+					license: { environment: 'production' },
+				}),
+			);
+
+			const initialHref = location.href;
+			const windowOpenSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+
+			await pageRedirectionHelper.goToVersions();
+
+			expect(windowOpenSpy).toHaveBeenCalledWith(
+				'https://docs.n8n.io/release-notes/#n8n1652?utm_source=n8n_app&utm_medium=instance_upgrade_releases',
+				'_blank',
+				'noopener',
+			);
+			expect(location.href).toBe(initialHref);
+		});
+	});
 
 	test.each([
 		[

--- a/packages/frontend/editor-ui/src/app/composables/usePageRedirectionHelper.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePageRedirectionHelper.ts
@@ -20,15 +20,14 @@ export function usePageRedirectionHelper() {
 	 * Otherwise, it redirect them to our docs.
 	 */
 	const goToVersions = async () => {
-		let versionsLink = versionsStore.infoUrl;
-
 		if (usersStore.isInstanceOwner && settingsStore.isCloudDeployment) {
-			versionsLink = await cloudPlanStore.generateCloudDashboardAutoLoginLink({
+			location.href = await cloudPlanStore.generateCloudDashboardAutoLoginLink({
 				redirectionPath: '/manage',
 			});
+			return;
 		}
 
-		location.href = versionsLink;
+		window.open(versionsStore.infoUrl, '_blank', 'noopener');
 	};
 
 	const goToDashboard = async () => {


### PR DESCRIPTION
## Summary

The "Update (N versions behind)" CTA in the help menu sent self-hosted users to the release-notes docs via `location.href`, replacing their active n8n tab and forcing them to lose their workflow context.

`goToVersions` is now branched:

- **Cloud + Owner** → `location.href` to cloud dashboard `/manage` (unchanged — the URL carries a one-shot auth code and is meant to consume the tab).
- **Cloud Member, Self-hosted Owner, Self-hosted Member** → `window.open(versionsStore.infoUrl, '_blank', 'noopener')` — docs open in a new tab, current tab untouched.

### Behavior matrix

| Deployment    | Role  | Destination               | Tab      |
|---------------|-------|---------------------------|----------|
| Cloud         | Owner | Cloud dashboard `/manage` | Same     |
| Cloud         | Member| Release-notes docs        | New      |
| Self-hosted   | Owner | Release-notes docs        | New      |
| Self-hosted   | Member| Release-notes docs        | New      |

### How to test

- Self-hosted instance: click "Update (N versions behind)" in the help menu → docs open in a new tab, n8n tab unchanged.
- Cloud member: same as above.
- Cloud owner: click "Update" → same tab navigates to cloud `/manage` page (unchanged).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5233

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI