### PR TITLE
fix(editor): Render fallback icon for projects without one in sidebar

### DIFF
--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectNavigation.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectNavigation.test.ts
@@ -176,6 +176,23 @@ describe('ProjectsNavigation', () => {
 		expect(getByText('Projects')).toBeVisible();
 	});
 
+	it('should render a fallback icon for projects with no icon set', async () => {
+		projectsStore.teamProjectsLimit = -1;
+		const projectWithoutIcon = createProjectListItem('team');
+		projectWithoutIcon.icon = null;
+		projectsStore.myProjects = [projectWithoutIcon];
+
+		const { getAllByTestId } = renderComponent({
+			props: {
+				collapsed: false,
+			},
+		});
+
+		const items = getAllByTestId('project-menu-item');
+		expect(items).toHaveLength(1);
+		expect(items[0].querySelector('svg')).toBeInTheDocument();
+	});
+
 	it('should not render shared menu item when only one verified user', async () => {
 		// Only one verified user
 		usersStore.allUsers = [

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectNavigation.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/components/ProjectNavigation.vue
@@ -9,6 +9,7 @@ import type { IMenuItem } from '@n8n/design-system/types';
 import { useI18n } from '@n8n/i18n';
 import { computed, onBeforeMount, onBeforeUnmount, ref, watch } from 'vue';
 import { useProjectsStore } from '../projects.store';
+import { DEFAULT_PROJECT_ICON } from '../projects.constants';
 import type { ProjectListItem } from '../projects.types';
 import { CHAT_VIEW } from '@/features/ai/chatHub/constants';
 import { useFavoritesStore } from '@/app/stores/favorites.store';
@@ -91,7 +92,7 @@ const shared = computed<IMenuItem>(() => ({
 const getProjectMenuItem = (project: ProjectListItem): IMenuItem => ({
 	id: project.id,
 	label: project.name ?? '',
-	icon: project.icon as IMenuItem['icon'],
+	icon: (project.icon as IMenuItem['icon']) ?? DEFAULT_PROJECT_ICON,
 	route: {
 		to: {
 			name: VIEWS.PROJECTS_WORKFLOWS,

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/composables/useFavoriteNavItems.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/composables/useFavoriteNavItems.test.ts
@@ -99,7 +99,10 @@ describe('useFavoriteNavItems', () => {
 
 			const { favoriteProjectItems } = useFavoriteNavItems();
 
-			expect(favoriteProjectItems.value[0].menuItem.icon).toBe('layers');
+			expect(favoriteProjectItems.value[0].menuItem.icon).toEqual({
+				type: 'icon',
+				value: 'layers',
+			});
 		});
 
 		it('should use raw resourceId as item id (no prefix)', () => {

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/composables/useFavoriteNavItems.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/composables/useFavoriteNavItems.ts
@@ -3,6 +3,7 @@ import type { IMenuItem } from '@n8n/design-system/types';
 import { VIEWS } from '@/app/constants';
 import { useFavoritesStore } from '@/app/stores/favorites.store';
 import { useProjectsStore } from '../projects.store';
+import { DEFAULT_PROJECT_ICON } from '../projects.constants';
 import type { Project } from '../projects.types';
 import { DATA_TABLE_DETAILS } from '@/features/core/dataTable/constants';
 import type { FavoriteResourceType } from '@/app/api/favorites';
@@ -46,7 +47,7 @@ export function useFavoriteNavItems() {
 					menuItem: {
 						id: f.resourceId,
 						label: f.resourceName,
-						icon: (project?.icon as IMenuItem['icon']) ?? ('layers' as IMenuItem['icon']),
+						icon: (project?.icon as IMenuItem['icon']) ?? DEFAULT_PROJECT_ICON,
 						route: { to: { name: VIEWS.PROJECTS_WORKFLOWS, params: { projectId: f.resourceId } } },
 					},
 					resourceId: f.resourceId,

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/projects.constants.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/projects.constants.ts
@@ -1,1 +1,5 @@
+import type { IconOrEmoji } from '@n8n/design-system/components/N8nIconPicker/types';
+
 export const PROJECT_MOVE_RESOURCE_MODAL = 'projectMoveResourceModal';
+
+export const DEFAULT_PROJECT_ICON: IconOrEmoji = { type: 'icon', value: 'layers' };

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/views/ProjectSettings.vue
@@ -7,6 +7,7 @@ import { useDebounceFn } from '@vueuse/core';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { useI18n } from '@n8n/i18n';
 import { type ResourceCounts, useProjectsStore } from '../projects.store';
+import { DEFAULT_PROJECT_ICON } from '../projects.constants';
 import type { Project, ProjectRelation, ProjectMemberData } from '../projects.types';
 import { useToast } from '@/app/composables/useToast';
 import { DEBOUNCE_TIME, getDebounceTime, VIEWS } from '@/app/constants';
@@ -84,10 +85,7 @@ const suppressNextSync = ref(false);
 
 const nameInput = ref<InstanceType<typeof N8nFormInput> | null>(null);
 
-const projectIcon = ref<IconOrEmoji>({
-	type: 'icon',
-	value: 'layers',
-});
+const projectIcon = ref<IconOrEmoji>({ ...DEFAULT_PROJECT_ICON });
 
 const search = ref('');
 const membersTableState = ref<TableOptions>({


### PR DESCRIPTION
## Summary

Projects whose `icon` is `null` (typically created before the project icon feature shipped) were rendering without any glyph in the sidebar — making them look like section titles and breaking list alignment.

This adds a render-time fallback: when a project has no icon, the sidebar shows the same `layers` icon that's already used as the default for new projects and for favorited projects whose data isn't loaded yet. The literal is moved to a shared `DEFAULT_PROJECT_ICON` constant and reused from `ProjectNavigation.vue`, `ProjectSettings.vue`, and `useFavoriteNavItems.ts`.

No DB backfill — new projects already pick up `layers` on first edit, and the render-time fallback covers legacy rows plus any future state where `icon` is null.

**How to test**
1. Set a team project's `icon` to `null` in the DB (`UPDATE project SET icon = NULL WHERE id = '<id>'`).
2. Reload the sidebar — the project should render with the `layers` icon and proper alignment instead of looking like a section header.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5214

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI