### PR TITLE
fix(editor): Render canvas context menu above workflow tabs

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useStyles.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useStyles.test.ts
@@ -9,7 +9,7 @@ describe('useStyles', () => {
 		setAppZIndexes();
 
 		expect(global.document.documentElement.style.setProperty).toHaveBeenNthCalledWith(
-			2,
+			1,
 			'--app-header--z',
 			'99',
 		);

--- a/packages/frontend/editor-ui/src/app/composables/useStyles.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useStyles.ts
@@ -1,11 +1,11 @@
 const APP_Z_INDEXES = {
-	CONTEXT_MENU: 10, // should be still in front of the logs panel
 	APP_HEADER: 99,
 	SELECT_BOX: 100,
 	CANVAS_ADD_BUTTON: 101,
 	APP_SIDEBAR: 999,
 	CANVAS_SELECT_BOX: 100,
 	TOP_BANNERS: 999,
+	CONTEXT_MENU: 1500, // above layout chrome (header, tabs, sidebar), below NDV/modals/toasts
 	NODE_CREATOR: 1700,
 	ASK_ASSISTANT_CHAT: 1750,
 	NDV: 1800,


### PR DESCRIPTION
## Summary

The canvas right-click context menu rendered underneath the workflow tabs (Edit / Executions / Evaluations) because `APP_Z_INDEXES.CONTEXT_MENU` was set to `10`, while the `TabBar` component hardcodes `z-index: 100`.

Raised `CONTEXT_MENU` to `1500` so the menu floats above all layout chrome (header `99`, tabs/select-box `100`, canvas add button `101`, sidebar/banners `999`) while staying below `NODE_CREATOR` (1700), `NDV` (1800), `DIALOGS` (1950), `MODALS` (2000), and `TOASTS` (2100).

### How to test

1. Open any workflow.
2. Right-click on the canvas near the top of the editor, so the menu would overlap the tabs.
3. Confirm the menu is fully visible and the tabs do not cover it.

<img width="1458" height="1376" alt="CleanShot 2026-05-16 at 14 29 35@2x" src="https://github.com/user-attachments/assets/9357f659-e956-45f0-996b-9f45d4e1d88e" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5212

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)