### PR TITLE
fix(editor): Make focus parameter textarea fill full sidebar height

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/FocusPanel.vue
+++ b/packages/frontend/editor-ui/src/app/components/FocusPanel.vue
@@ -699,8 +699,12 @@ function onRenameNode(value: string) {
 				display: flex;
 				height: 100%;
 				width: 100%;
-				align-items: normal;
+				align-items: stretch;
 				font-size: var(--font-size--2xs);
+
+				:global(.n8n-input__wrapper) {
+					height: 100%;
+				}
 
 				textarea {
 					height: 100%;


### PR DESCRIPTION
## Summary

The string-parameter textarea in the Focus Parameter sidebar (e.g. AI Agent System Message) was rendering at its default 2-row height with a draggable resize handle, leaving most of the sidebar empty. It now fills the full available height and is non-resizable.

**Cause:** `N8nInput` with `type="textarea"` adds `.isTextarea` to its container with `align-items: flex-start`, so the inner `.n8n-input__wrapper` did not stretch vertically. The textarea's `height: 100%` was relative to that short wrapper.

**Fix:** In `FocusPanel.vue`, set `align-items: stretch` on `.editor` and force `:global(.n8n-input__wrapper) { height: 100% }` so the wrapper fills its container, giving the textarea something to stretch into.

<img width="800" height="440" alt="CleanShot 2026-05-16 at 14 33 08" src="https://github.com/user-attachments/assets/ae1f3c27-fdab-42f1-93d5-42375017f71b" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5211

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Tests included.