### PR TITLE
perf(core): Cache allowed domain normalization

### DIFF
--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -420,6 +420,46 @@ export function sanitizeXmlName(name: string) {
 	return name;
 }
 
+type NormalizedAllowedDomains = {
+	exact: Set<string>;
+	wildcards: string[];
+};
+
+const ALLOWED_DOMAINS_CACHE_LIMIT = 128;
+const normalizedAllowedDomainsCache = new Map<string, NormalizedAllowedDomains>();
+
+function stripTrailingDot(value: string) {
+	return value.endsWith('.') ? value.slice(0, -1) : value;
+}
+
+function getNormalizedAllowedDomains(allowedDomains: string) {
+	const cached = normalizedAllowedDomainsCache.get(allowedDomains);
+	if (cached) return cached;
+
+	const normalized: NormalizedAllowedDomains = {
+		exact: new Set(),
+		wildcards: [],
+	};
+	for (const rawDomain of allowedDomains.split(',')) {
+		const domain = stripTrailingDot(rawDomain.trim().toLowerCase());
+		if (!domain) continue;
+
+		if (domain.startsWith('*.')) {
+			normalized.wildcards.push(domain.substring(2));
+		} else {
+			normalized.exact.add(domain);
+		}
+	}
+
+	if (normalizedAllowedDomainsCache.size >= ALLOWED_DOMAINS_CACHE_LIMIT) {
+		const oldestKey = normalizedAllowedDomainsCache.keys().next().value;
+		if (oldestKey !== undefined) normalizedAllowedDomainsCache.delete(oldestKey);
+	}
+
+	normalizedAllowedDomainsCache.set(allowedDomains, normalized);
+	return normalized;
+}
+
 export function isDomainAllowed(
 	urlString: string,
 	options: {
@@ -434,33 +474,26 @@ export function isDomainAllowed(
 		const url = new URL(urlString);
 
 		// Normalize hostname: lowercase and remove trailing dot
-		const hostname = url.hostname.toLowerCase().replace(/\.$/, '');
+		const hostname = stripTrailingDot(url.hostname.toLowerCase());
 
 		// Reject empty hostnames
 		if (!hostname) {
 			return false;
 		}
 
-		const allowedDomainsList = options.allowedDomains
-			.split(',')
-			.map((domain) => domain.trim().toLowerCase().replace(/\.$/, ''))
-			.filter(Boolean);
+		const allowedDomainsList = getNormalizedAllowedDomains(options.allowedDomains);
 
-		for (const allowedDomain of allowedDomainsList) {
-			// Handle wildcard domains (*.example.com)
-			if (allowedDomain.startsWith('*.')) {
-				const domainSuffix = allowedDomain.substring(2);
-				// Ensure the suffix itself is valid
-				if (!domainSuffix) continue;
+		if (allowedDomainsList.exact.has(hostname)) {
+			return true;
+		}
 
-				// Wildcard matches only subdomains, not the base domain itself
-				// *.example.com matches sub.example.com but NOT example.com
-				if (hostname.endsWith('.' + domainSuffix)) {
-					return true;
-				}
-			}
-			// Exact match
-			else if (hostname === allowedDomain) {
+		for (const domainSuffix of allowedDomainsList.wildcards) {
+			// Ensure the suffix itself is valid
+			if (!domainSuffix) continue;
+
+			// Wildcard matches only subdomains, not the base domain itself
+			// *.example.com matches sub.example.com but NOT example.com
+			if (hostname.endsWith('.' + domainSuffix)) {
 				return true;
 			}
 		}

--- a/packages/workflow/test/utils.test.ts
+++ b/packages/workflow/test/utils.test.ts
@@ -700,6 +700,26 @@ describe('isDomainAllowed', () => {
 			).toBe(true);
 		});
 
+		it('should keep matching after repeated allow-list normalization', () => {
+			const allowedDomains = 'api.example.com,*.example.org';
+
+			expect(isDomainAllowed('https://api.example.com', { allowedDomains })).toBe(true);
+			expect(isDomainAllowed('https://sub.example.org', { allowedDomains })).toBe(true);
+			expect(isDomainAllowed('https://example.org', { allowedDomains })).toBe(false);
+
+			for (let i = 0; i < 130; i++) {
+				expect(
+					isDomainAllowed(`https://site-${i}.example.com`, {
+						allowedDomains: `site-${i}.example.com`,
+					}),
+				).toBe(true);
+			}
+
+			expect(isDomainAllowed('https://api.example.com', { allowedDomains })).toBe(true);
+			expect(isDomainAllowed('https://sub.example.org', { allowedDomains })).toBe(true);
+			expect(isDomainAllowed('https://example.org', { allowedDomains })).toBe(false);
+		});
+
 		it('should block non-matching domains', () => {
 			expect(
 				isDomainAllowed('https://malicious.com', {


### PR DESCRIPTION
## Summary

Cache the normalized representation of `allowedDomains` in `isDomainAllowed()` and keep exact domains in a `Set` so repeated restricted HTTP requests do not split, trim, lowercase, and classify the same allow-list on every check.

This keeps the same matching behavior for exact domains, wildcard subdomains, trailing dots, empty wildcard suffixes, invalid URLs, and empty allow-lists. The cache is bounded to 128 distinct allow-list strings.

Local microbenchmark over a mixed allow-list with exact and wildcard domains:

```text
old:     per_call_us min/med/max=72.324/93.007/107.564
patched: per_call_us min/med/max=6.700/11.293/16.843
patched_speedup_vs_old=8.24x
```

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created. N/A, no user-facing behavior change.
- [x] Tests included. Added coverage for repeated allow-list checks after cache churn.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

Local checks run:

```bash
git diff --check
```

A local microbenchmark script was used to compare this implementation against the previous logic. `pnpm --filter n8n-workflow test -- test/utils.test.ts` was not runnable in this local checkout because dependencies are not installed (`vitest: command not found`).
