### PR TITLE
ci: Apply Trivy ignore-policy to filter n8n self-CVEs

### DIFF
--- a/security/trivy.yaml
+++ b/security/trivy.yaml
@@ -3,4 +3,4 @@
 vulnerability:
   vex:
     - security/vex.openvex.json
-  ignore-policy: security/trivy-ignore-policy.rego
+ignore-policy: security/trivy-ignore-policy.rego


### PR DESCRIPTION
## Summary

Move `ignore-policy` to the top level in `security/trivy.yaml`. It was nested under `vulnerability:` but Trivy treats it as a top-level field — the config loads without error but Trivy silently drops the field. As a result, the rego at `security/trivy-ignore-policy.rego` (which intentionally excludes n8n's own published CVEs from internal scan results) has never been applied since the security/ directory was added.

**Impact:** Prior `#updates-security` Slack notifications from `.github/workflows/security-trivy-scan-callable.yml` included n8n self-CVE entries (e.g. `n8n@2.21.0`) that should have been filtered. The intent — per the rego comment — is that "vulnerabilities in the n8n package should be visible to anyone running an older version" (i.e. external scanners surface them so users upgrade), but they shouldn't appear in our own internal scan notifications because the fix is "release a newer version", which we already do.

**Diff is one line of indentation:**
```diff
 vulnerability:
   vex:
     - security/vex.openvex.json
-  ignore-policy: security/trivy-ignore-policy.rego
+ignore-policy: security/trivy-ignore-policy.rego
```

**Verification:** Local Trivy scan against `n8nio/n8n:local` with `trivy image --config security/trivy.yaml --severity CRITICAL,HIGH`:

| | CRITICAL/HIGH total | `PkgName == "n8n"` |
|---|---|---|
| Before | 19 | 5 |
| After | 14 | 0 |

The 5 filtered entries are CVE-2026-44789/44790/44791/44792 and CVE-2026-45732 — all flagged against `n8n@2.21.0` with fixes available in 1.123.43 / 2.20.7 / 2.21.1 / 2.22.1.

## Related Linear tickets, Github issues, and Community forum posts

n/a — discovered while investigating noisy `#updates-security` posts.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. — n/a (internal scan config)
- [ ] Tests included. — n/a (single-line config indentation; verified manually against a local image scan)
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)