### PR TITLE
ci: Stream pnpm install output via append-only reporter (no-changelog)

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -69,7 +69,7 @@ runs:
         INSTALL_COMMAND: ${{ inputs.install-command }}
         SAFE_CHAIN_LOGGING: verbose
       run: |
-        $INSTALL_COMMAND
+        $INSTALL_COMMAND --reporter=append-only
       shell: bash
 
     - name: Configure Turborepo Cache


### PR DESCRIPTION
## Summary

Append `--reporter=append-only` to the install command in the `setup-nodejs` composite action so pnpm streams lifecycle script output line-by-line instead of folding it.

**Why:** When a lifecycle script (preinstall/install/postinstall/prepare) of a dependency fails, pnpm's default reporter buffers script output and the GitHub Actions log only shows the terse summary:

```
 ELIFECYCLE  Command failed with exit code 1.
```

…with no preceding lines indicating which package or what error. This makes install failures (e.g. https://github.com/n8n-io/n8n/actions/runs/25992008217/job/76399835319) undiagnosable from the runner log alone. `--reporter=append-only` is pnpm's CI-friendly reporter that streams every line as it happens.

The flag is appended in the action's `run` step rather than baked into the default `install-command` input so all callers — including the ~9 workflows that pass a custom `install-command` for `--dir ./.github/scripts --ignore-workspace` installs — pick it up without each having to be touched.

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)