### PR TITLE
chore: Migrate @n8n/config and @n8n/backend-common from jest to vitest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,7 @@ const children = getChildNodes(workflow.connections, 'NodeName', 'main', 1);
 - **Confirm test cases with user** before writing unit tests
 - **Typecheck is critical before committing** - always run `pnpm typecheck`
 - **When modifying pinia stores**, check for unused computed properties
+- **For Vitest packages that use `@n8n/di` decorators**, use `createVitestConfigWithDecorators` from `@n8n/vitest-config/node-decorators`. It enables SWC `decoratorMetadata` (esbuild doesn't emit it) and externalizes workspace packages that register services (`@n8n/di`, `@n8n/config`, `@n8n/constants`, `n8n-workflow`) so a single DI `Container` instance is shared across the runtime. Loading them through Vitest's pipeline alongside their CJS dist produces two `Container`s and `Container.get(...)` returns `undefined`.
 
 What we use for testing and writing tests:
 - For testing nodes and other backend components, we use Jest for unit tests. Examples can be found in `packages/nodes-base/nodes/**/*test*`.

--- a/packages/@n8n/backend-common/jest.config.js
+++ b/packages/@n8n/backend-common/jest.config.js
@@ -1,7 +1,0 @@
-/** @type {import('jest').Config} */
-module.exports = {
-	...require('../../../jest.config'),
-	transform: {
-		'^.+\\.ts$': ['ts-jest', { isolatedModules: false }],
-	},
-};

--- a/packages/@n8n/backend-common/package.json
+++ b/packages/@n8n/backend-common/package.json
@@ -11,9 +11,9 @@
     "lint": "eslint . --quiet",
     "lint:fix": "eslint . --fix",
     "watch": "tsc -p tsconfig.build.json --watch",
-    "test": "jest",
-    "test:unit": "jest",
-    "test:dev": "jest --watch"
+    "test": "vitest run",
+    "test:unit": "vitest run",
+    "test:dev": "vitest --silent=false"
   },
   "main": "dist/index.js",
   "module": "src/index.ts",
@@ -39,6 +39,10 @@
     "@n8n/typescript-config": "workspace:*",
     "@types/stream-json": "1.7.8",
     "@types/yargs-parser": "21.0.0",
+    "@n8n/vitest-config": "workspace:*",
+    "@vitest/coverage-v8": "catalog:",
+    "vitest": "catalog:",
+    "vitest-mock-extended": "catalog:",
     "zod": "catalog:"
   }
 }

--- a/packages/@n8n/backend-common/src/__tests__/cli-parser.test.ts
+++ b/packages/@n8n/backend-common/src/__tests__/cli-parser.test.ts
@@ -1,4 +1,4 @@
-import { mock } from 'jest-mock-extended';
+import { mock } from 'vitest-mock-extended';
 import z from 'zod';
 
 import { CliParser } from '../cli-parser';

--- a/packages/@n8n/backend-common/src/logging/__tests__/logger.test.ts
+++ b/packages/@n8n/backend-common/src/logging/__tests__/logger.test.ts
@@ -78,7 +78,7 @@ describe('Logger', () => {
 
 			const output = stdoutSpy.mock.lastCall?.[0];
 			if (typeof output !== 'string') {
-				fail(`expected 'output' to be of type 'string', got ${typeof output}`);
+				assert.fail(`expected 'output' to be of type 'string', got ${typeof output}`);
 			}
 
 			expect(output).toEqual(`${testMessage}\n`);
@@ -105,7 +105,7 @@ describe('Logger', () => {
 			expect(stdoutSpy).toHaveBeenCalledTimes(1);
 			const output = stdoutSpy.mock.lastCall?.[0];
 			if (typeof output !== 'string') {
-				fail(`expected 'output' to be of type 'string', got ${typeof output}`);
+				assert.fail(`expected 'output' to be of type 'string', got ${typeof output}`);
 			}
 
 			expect(() => JSON.parse(output)).not.toThrow();
@@ -168,7 +168,7 @@ describe('Logger', () => {
 			expect(stdoutSpy).toHaveBeenCalledTimes(1);
 			const output = stdoutSpy.mock.lastCall?.[0];
 			if (typeof output !== 'string') {
-				fail(`expected 'output' to be of type 'string', got ${typeof output}`);
+				assert.fail(`expected 'output' to be of type 'string', got ${typeof output}`);
 			}
 
 			expect(() => JSON.parse(output)).not.toThrow();
@@ -216,7 +216,7 @@ describe('Logger', () => {
 			expect(stdoutSpy).toHaveBeenCalledTimes(1);
 			const output = stdoutSpy.mock.lastCall?.[0];
 			if (typeof output !== 'string') {
-				fail(`expected 'output' to be of type 'string', got ${typeof output}`);
+				assert.fail(`expected 'output' to be of type 'string', got ${typeof output}`);
 			}
 
 			expect(() => JSON.parse(output)).not.toThrow();
@@ -265,7 +265,7 @@ describe('Logger', () => {
 			expect(stdoutSpy).toHaveBeenCalledTimes(1);
 			const output = stdoutSpy.mock.lastCall?.[0];
 			if (typeof output !== 'string') {
-				fail(`expected 'output' to be of type 'string', got ${typeof output}`);
+				assert.fail(`expected 'output' to be of type 'string', got ${typeof output}`);
 			}
 
 			const parsedOutput = JSON.parse(output) as { metadata: Record<string, unknown> };
@@ -292,7 +292,7 @@ describe('Logger', () => {
 			expect(stdoutSpy).toHaveBeenCalledTimes(1);
 			const output = stdoutSpy.mock.lastCall?.[0];
 			if (typeof output !== 'string') {
-				fail(`expected 'output' to be of type 'string', got ${typeof output}`);
+				assert.fail(`expected 'output' to be of type 'string', got ${typeof output}`);
 			}
 
 			const parsedOutput = JSON.parse(output) as { metadata: Record<string, unknown> };
@@ -550,7 +550,7 @@ describe('Logger', () => {
 			expect(stdoutSpy).toHaveBeenCalled();
 			const output = stdoutSpy.mock.lastCall?.[0];
 			if (typeof output !== 'string') {
-				fail(`expected 'output' to be of type 'string', got ${typeof output}`);
+				assert.fail(`expected 'output' to be of type 'string', got ${typeof output}`);
 			}
 
 			// JSON logs should be parseable and not contain ANSI codes
@@ -579,7 +579,7 @@ describe('Logger', () => {
 			expect(stdoutSpy).toHaveBeenCalled();
 			const output = stdoutSpy.mock.lastCall?.[0];
 			if (typeof output !== 'string') {
-				fail(`expected 'output' to be of type 'string', got ${typeof output}`);
+				assert.fail(`expected 'output' to be of type 'string', got ${typeof output}`);
 			}
 
 			// Should not contain ANSI color codes even with colorize in dev format
@@ -615,7 +615,7 @@ describe('Logger', () => {
 			expect(stdoutSpy).toHaveBeenCalled();
 			const output = stdoutSpy.mock.lastCall?.[0];
 			if (typeof output !== 'string') {
-				fail(`expected 'output' to be of type 'string', got ${typeof output}`);
+				assert.fail(`expected 'output' to be of type 'string', got ${typeof output}`);
 			}
 
 			// Verify output is valid JSON (our format configuration)
@@ -665,7 +665,7 @@ describe('Logger', () => {
 			const debugOutput = stdoutSpy.mock.calls[1]?.[0];
 
 			if (typeof infoOutput !== 'string' || typeof debugOutput !== 'string') {
-				fail('expected both outputs to be strings');
+				assert.fail('expected both outputs to be strings');
 			}
 
 			expect(ANSI_COLOR_PATTERN.test(infoOutput)).toBe(false);

--- a/packages/@n8n/backend-common/src/logging/__tests__/logger.test.ts
+++ b/packages/@n8n/backend-common/src/logging/__tests__/logger.test.ts
@@ -1,18 +1,32 @@
-jest.mock('n8n-workflow', () => ({
-	...jest.requireActual('n8n-workflow'),
-	LoggerProxy: { init: jest.fn() },
-}));
+vi.mock('n8n-workflow', async () => {
+	const original = await vi.importActual('n8n-workflow');
+	return {
+		...original,
+		LoggerProxy: { init: vi.fn() },
+	};
+});
 
 import type { GlobalConfig, InstanceSettingsConfig } from '@n8n/config';
-import { mock, captor } from 'jest-mock-extended';
 import { LoggerProxy } from 'n8n-workflow';
+import type { MockInstance } from 'vitest';
+import { mock, captor } from 'vitest-mock-extended';
 import winston from 'winston';
 
 import { Logger } from '../logger';
 
+let stdoutSpy: MockInstance;
+
 describe('Logger', () => {
 	beforeEach(() => {
-		jest.resetAllMocks();
+		vi.clearAllMocks();
+		// Winston's Console transport writes to `console._stdout`, which Vitest
+		// replaces with its own intercepted stream — not the same object as `process.stdout`.
+		const consoleStdout = (console as unknown as { _stdout: NodeJS.WriteStream })._stdout;
+		stdoutSpy = vi.spyOn(consoleStdout, 'write').mockImplementation(() => true);
+	});
+
+	afterEach(() => {
+		stdoutSpy.mockRestore();
 	});
 
 	describe('constructor', () => {
@@ -39,12 +53,11 @@ describe('Logger', () => {
 
 	describe('formats', () => {
 		afterEach(() => {
-			jest.resetAllMocks();
+			vi.resetAllMocks();
 		});
 
 		test('log text, if `config.logging.format` is set to `text`', () => {
 			// ARRANGE
-			const stdoutSpy = jest.spyOn(process.stdout, 'write').mockReturnValue(true);
 			const globalConfig = mock<GlobalConfig>({
 				logging: {
 					format: 'text',
@@ -73,7 +86,6 @@ describe('Logger', () => {
 
 		test('log json, if `config.logging.format` is set to `json`', () => {
 			// ARRANGE
-			const stdoutSpy = jest.spyOn(process.stdout, 'write').mockReturnValue(true);
 			const globalConfig = mock<GlobalConfig>({
 				logging: {
 					format: 'json',
@@ -111,7 +123,6 @@ describe('Logger', () => {
 
 		test('apply scope filters, if `config.logging.format` is set to `json`', () => {
 			// ARRANGE
-			const stdoutSpy = jest.spyOn(process.stdout, 'write').mockReturnValue(true);
 			const globalConfig = mock<GlobalConfig>({
 				logging: {
 					format: 'json',
@@ -136,7 +147,6 @@ describe('Logger', () => {
 
 		test('log errors in metadata with stack trace, if `config.logging.format` is set to `json`', () => {
 			// ARRANGE
-			const stdoutSpy = jest.spyOn(process.stdout, 'write').mockReturnValue(true);
 			const globalConfig = mock<GlobalConfig>({
 				logging: {
 					format: 'json',
@@ -184,7 +194,6 @@ describe('Logger', () => {
 
 		test('do not recurse indefinitely when `cause` contains circular references', () => {
 			// ARRANGE
-			const stdoutSpy = jest.spyOn(process.stdout, 'write').mockReturnValue(true);
 			const globalConfig = mock<GlobalConfig>({
 				logging: {
 					format: 'json',
@@ -233,11 +242,10 @@ describe('Logger', () => {
 
 	describe('optional metadata fields', () => {
 		afterEach(() => {
-			jest.resetAllMocks();
+			vi.resetAllMocks();
 		});
 
 		test('should include optional metadata fields in JSON output when defined', () => {
-			const stdoutSpy = jest.spyOn(process.stdout, 'write').mockReturnValue(true);
 			const globalConfig = mock<GlobalConfig>({
 				logging: {
 					format: 'json',
@@ -269,7 +277,6 @@ describe('Logger', () => {
 		});
 
 		test('should omit undefined metadata fields from JSON output', () => {
-			const stdoutSpy = jest.spyOn(process.stdout, 'write').mockReturnValue(true);
 			const globalConfig = mock<GlobalConfig>({
 				logging: {
 					format: 'json',
@@ -297,7 +304,7 @@ describe('Logger', () => {
 
 	describe('transports', () => {
 		afterEach(() => {
-			jest.restoreAllMocks();
+			vi.restoreAllMocks();
 		});
 
 		test('if `console` selected, should set console transport', () => {
@@ -361,9 +368,11 @@ describe('Logger', () => {
 					},
 				});
 				const OriginalFile = winston.transports.File;
-				const FileSpy = jest.spyOn(winston.transports, 'File').mockImplementation((...args) => {
+				const FileSpy = vi.spyOn(winston.transports, 'File').mockImplementation(function (
+					...args: ConstructorParameters<typeof OriginalFile>
+				) {
 					return new OriginalFile(...args);
-				});
+				} as unknown as typeof OriginalFile);
 
 				// ACT
 				new Logger(globalConfig, mock<InstanceSettingsConfig>({ n8nFolder: '/tmp' }));
@@ -393,9 +402,11 @@ describe('Logger', () => {
 					},
 				});
 				const OriginalFile = winston.transports.File;
-				const FileSpy = jest.spyOn(winston.transports, 'File').mockImplementation((...args) => {
+				const FileSpy = vi.spyOn(winston.transports, 'File').mockImplementation(function (
+					...args: ConstructorParameters<typeof OriginalFile>
+				) {
 					return new OriginalFile(...args);
-				});
+				} as unknown as typeof OriginalFile);
 
 				// ACT
 				new Logger(globalConfig, mock<InstanceSettingsConfig>({ n8nFolder }));
@@ -513,13 +524,12 @@ describe('Logger', () => {
 		const ANSI_COLOR_PATTERN = /\x1b\[\d+m/g; // Pattern to match ANSI color escape codes
 
 		afterEach(() => {
-			jest.resetAllMocks();
+			vi.resetAllMocks();
 			delete process.env.NO_COLOR;
 		});
 
 		test('production debug logs default to no colors (NO_COLOR not set)', () => {
 			// ARRANGE
-			const stdoutSpy = jest.spyOn(process.stdout, 'write').mockReturnValue(true);
 			const globalConfig = mock<GlobalConfig>({
 				logging: {
 					format: 'json', // Use json format so we can check the format property directly
@@ -552,7 +562,6 @@ describe('Logger', () => {
 		test('NO_COLOR environment variable is respected and prevents colors', () => {
 			// ARRANGE
 			process.env.NO_COLOR = '1';
-			const stdoutSpy = jest.spyOn(process.stdout, 'write').mockReturnValue(true);
 			const globalConfig = mock<GlobalConfig>({
 				logging: {
 					format: 'json',
@@ -586,7 +595,6 @@ describe('Logger', () => {
 			// Note: This test inspects the actual formatter method signature
 			// We verify that when level is debug in production mode,
 			// the output doesn't include color codes
-			const stdoutSpy = jest.spyOn(process.stdout, 'write').mockReturnValue(true);
 			const globalConfig = mock<GlobalConfig>({
 				logging: {
 					format: 'json', // Using json to ensure we test the basic behavior
@@ -623,7 +631,6 @@ describe('Logger', () => {
 		test('logger format selection respects environment and level', () => {
 			// ARRANGE
 			// Create two loggers with different configurations
-			const stdoutSpy = jest.spyOn(process.stdout, 'write').mockReturnValue(true);
 
 			const infoProdConfig = mock<GlobalConfig>({
 				logging: {

--- a/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
+++ b/packages/@n8n/backend-common/src/modules/__tests__/module-registry.test.ts
@@ -1,13 +1,13 @@
 import type { ModuleInterface, ModuleMetadata } from '@n8n/decorators';
 import { Container } from '@n8n/di';
-import { mock } from 'jest-mock-extended';
+import { mock } from 'vitest-mock-extended';
 
 import type { LicenseState } from '../../license-state';
 import { ModuleConfusionError } from '../errors/module-confusion.error';
 import { ModuleRegistry } from '../module-registry';
 
 beforeEach(() => {
-	jest.resetAllMocks();
+	vi.resetAllMocks();
 	process.env = {};
 	Container.reset();
 });
@@ -93,13 +93,13 @@ describe('loadModules', () => {
 		const SecondEntity = class SecondEntityClass {};
 
 		const ModuleClass = {
-			entities: jest.fn().mockReturnValue([FirstEntity, SecondEntity]),
+			entities: vi.fn().mockReturnValue([FirstEntity, SecondEntity]),
 		};
 		const moduleMetadata = mock<ModuleMetadata>({
-			getClasses: jest.fn().mockReturnValue([ModuleClass]),
+			getClasses: vi.fn().mockReturnValue([ModuleClass]),
 		});
 
-		Container.get = jest.fn().mockReturnValue(ModuleClass);
+		Container.get = vi.fn().mockReturnValue(ModuleClass);
 		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
 
 		await moduleRegistry.loadModules([]);
@@ -108,12 +108,12 @@ describe('loadModules', () => {
 	});
 
 	it('should load no entities if none are defined by modules', async () => {
-		const ModuleClass = { entities: jest.fn().mockReturnValue([]) };
+		const ModuleClass = { entities: vi.fn().mockReturnValue([]) };
 		const moduleMetadata = mock<ModuleMetadata>({
-			getClasses: jest.fn().mockReturnValue([ModuleClass]),
+			getClasses: vi.fn().mockReturnValue([ModuleClass]),
 		});
 
-		Container.get = jest.fn().mockReturnValue(ModuleClass);
+		Container.get = vi.fn().mockReturnValue(ModuleClass);
 		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
 
 		await moduleRegistry.loadModules([]);
@@ -124,13 +124,13 @@ describe('loadModules', () => {
 
 describe('initModules', () => {
 	it('should init module if it has no feature flag', async () => {
-		const ModuleClass = { init: jest.fn() };
+		const ModuleClass = { init: vi.fn() };
 		const moduleMetadata = mock<ModuleMetadata>({
-			getEntries: jest
+			getEntries: vi
 				.fn()
 				.mockReturnValue([['test-module', { licenseFlag: undefined, class: ModuleClass }]]),
 		});
-		Container.get = jest.fn().mockReturnValue(ModuleClass);
+		Container.get = vi.fn().mockReturnValue(ModuleClass);
 
 		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
 
@@ -140,16 +140,16 @@ describe('initModules', () => {
 	});
 
 	it('should init module if it is licensed', async () => {
-		const ModuleClass = { init: jest.fn() };
+		const ModuleClass = { init: vi.fn() };
 		const moduleMetadata = mock<ModuleMetadata>({
-			getEntries: jest
+			getEntries: vi
 				.fn()
 				.mockReturnValue([
 					['test-module', { licenseFlag: 'feat:testFeature', class: ModuleClass }],
 				]),
 		});
-		const licenseState = mock<LicenseState>({ isLicensed: jest.fn().mockReturnValue(true) });
-		Container.get = jest.fn().mockReturnValue(ModuleClass);
+		const licenseState = mock<LicenseState>({ isLicensed: vi.fn().mockReturnValue(true) });
+		Container.get = vi.fn().mockReturnValue(ModuleClass);
 
 		const moduleRegistry = new ModuleRegistry(moduleMetadata, licenseState, mock(), mock());
 
@@ -159,16 +159,16 @@ describe('initModules', () => {
 	});
 
 	it('should skip init for unlicensed module', async () => {
-		const ModuleClass = { init: jest.fn() };
+		const ModuleClass = { init: vi.fn() };
 		const moduleMetadata = mock<ModuleMetadata>({
-			getEntries: jest
+			getEntries: vi
 				.fn()
 				.mockReturnValue([
 					['test-module', { licenseFlag: 'feat:testFeature', class: ModuleClass }],
 				]),
 		});
-		const licenseState = mock<LicenseState>({ isLicensed: jest.fn().mockReturnValue(false) });
-		Container.get = jest.fn().mockReturnValue(ModuleClass);
+		const licenseState = mock<LicenseState>({ isLicensed: vi.fn().mockReturnValue(false) });
+		Container.get = vi.fn().mockReturnValue(ModuleClass);
 
 		const moduleRegistry = new ModuleRegistry(moduleMetadata, licenseState, mock(), mock());
 
@@ -180,12 +180,12 @@ describe('initModules', () => {
 	it('should accept module without `init` method', async () => {
 		const ModuleClass = {};
 		const moduleMetadata = mock<ModuleMetadata>({
-			getEntries: jest
+			getEntries: vi
 				.fn()
 				.mockReturnValue([['test-module', { licenseFlag: undefined, class: ModuleClass }]]),
 		});
 
-		Container.get = jest.fn().mockReturnValue(ModuleClass);
+		Container.get = vi.fn().mockReturnValue(ModuleClass);
 
 		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
 
@@ -199,13 +199,13 @@ describe('initModules', () => {
 		const moduleName = 'test-module';
 		const moduleSettings = { foo: 1 };
 		const ModuleClass: ModuleInterface = {
-			init: jest.fn(),
-			settings: jest.fn().mockReturnValue(moduleSettings),
+			init: vi.fn(),
+			settings: vi.fn().mockReturnValue(moduleSettings),
 		};
 		const moduleMetadata = mock<ModuleMetadata>({
-			getEntries: jest.fn().mockReturnValue([[moduleName, { class: ModuleClass }]]),
+			getEntries: vi.fn().mockReturnValue([[moduleName, { class: ModuleClass }]]),
 		});
-		Container.get = jest.fn().mockReturnValue(ModuleClass);
+		Container.get = vi.fn().mockReturnValue(ModuleClass);
 
 		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
 
@@ -223,13 +223,13 @@ describe('initModules', () => {
 		const moduleName = 'test-module';
 		const moduleSettings = { foo: 1 };
 		const ModuleClass: ModuleInterface = {
-			init: jest.fn(),
-			settings: jest.fn().mockReturnValue(moduleSettings),
+			init: vi.fn(),
+			settings: vi.fn().mockReturnValue(moduleSettings),
 		};
 		const moduleMetadata = mock<ModuleMetadata>({
-			getEntries: jest.fn().mockReturnValue([[moduleName, { class: ModuleClass }]]),
+			getEntries: vi.fn().mockReturnValue([[moduleName, { class: ModuleClass }]]),
 		});
-		Container.get = jest.fn().mockReturnValue(ModuleClass);
+		Container.get = vi.fn().mockReturnValue(ModuleClass);
 
 		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
 
@@ -246,12 +246,12 @@ describe('initModules', () => {
 		// ARRANGE
 		const moduleName = 'test-module';
 		const ModuleClass: ModuleInterface = {
-			init: jest.fn(),
+			init: vi.fn(),
 		};
 		const moduleMetadata = mock<ModuleMetadata>({
-			getEntries: jest.fn().mockReturnValue([[moduleName, { class: ModuleClass }]]),
+			getEntries: vi.fn().mockReturnValue([[moduleName, { class: ModuleClass }]]),
 		});
-		Container.get = jest.fn().mockReturnValue(ModuleClass);
+		Container.get = vi.fn().mockReturnValue(ModuleClass);
 
 		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
 
@@ -269,13 +269,13 @@ describe('initModules', () => {
 		const moduleName = 'test-module';
 		const moduleContext = { proxy: 'test-proxy', config: { enabled: true } };
 		const ModuleClass: ModuleInterface = {
-			init: jest.fn(),
-			context: jest.fn().mockReturnValue(moduleContext),
+			init: vi.fn(),
+			context: vi.fn().mockReturnValue(moduleContext),
 		};
 		const moduleMetadata = mock<ModuleMetadata>({
-			getEntries: jest.fn().mockReturnValue([[moduleName, { class: ModuleClass }]]),
+			getEntries: vi.fn().mockReturnValue([[moduleName, { class: ModuleClass }]]),
 		});
-		Container.get = jest.fn().mockReturnValue(ModuleClass);
+		Container.get = vi.fn().mockReturnValue(ModuleClass);
 
 		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
 
@@ -291,11 +291,11 @@ describe('initModules', () => {
 	it('does not register context for module without `context` method', async () => {
 		// ARRANGE
 		const moduleName = 'test-module';
-		const ModuleClass: ModuleInterface = { init: jest.fn() };
+		const ModuleClass: ModuleInterface = { init: vi.fn() };
 		const moduleMetadata = mock<ModuleMetadata>({
-			getEntries: jest.fn().mockReturnValue([[moduleName, { class: ModuleClass }]]),
+			getEntries: vi.fn().mockReturnValue([[moduleName, { class: ModuleClass }]]),
 		});
-		Container.get = jest.fn().mockReturnValue(ModuleClass);
+		Container.get = vi.fn().mockReturnValue(ModuleClass);
 
 		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
 
@@ -307,15 +307,15 @@ describe('initModules', () => {
 	});
 
 	it('should init module with matching instance type', async () => {
-		const ModuleClass = { init: jest.fn() };
+		const ModuleClass = { init: vi.fn() };
 		const moduleMetadata = mock<ModuleMetadata>({
-			getEntries: jest
+			getEntries: vi
 				.fn()
 				.mockReturnValue([
 					['test-module', { instanceTypes: ['main', 'worker'], class: ModuleClass }],
 				]),
 		});
-		Container.get = jest.fn().mockReturnValue(ModuleClass);
+		Container.get = vi.fn().mockReturnValue(ModuleClass);
 
 		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
 
@@ -325,13 +325,13 @@ describe('initModules', () => {
 	});
 
 	it('should skip init for module with non-matching instance type', async () => {
-		const ModuleClass = { init: jest.fn() };
+		const ModuleClass = { init: vi.fn() };
 		const moduleMetadata = mock<ModuleMetadata>({
-			getEntries: jest
+			getEntries: vi
 				.fn()
 				.mockReturnValue([['test-module', { instanceTypes: ['worker'], class: ModuleClass }]]),
 		});
-		Container.get = jest.fn().mockReturnValue(ModuleClass);
+		Container.get = vi.fn().mockReturnValue(ModuleClass);
 
 		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
 
@@ -345,13 +345,13 @@ describe('nodeLoaders', () => {
 	it('should collect node loaders defined by modules', async () => {
 		const TEST_LOADER = { packageName: 'test-loader' };
 		const ModuleClass = {
-			entities: jest.fn().mockReturnValue([]),
-			nodeLoaders: jest.fn().mockResolvedValue([TEST_LOADER]),
+			entities: vi.fn().mockReturnValue([]),
+			nodeLoaders: vi.fn().mockResolvedValue([TEST_LOADER]),
 		};
 		const moduleMetadata = mock<ModuleMetadata>({
-			getClasses: jest.fn().mockReturnValue([ModuleClass]),
+			getClasses: vi.fn().mockReturnValue([ModuleClass]),
 		});
-		Container.get = jest.fn().mockReturnValue(ModuleClass);
+		Container.get = vi.fn().mockReturnValue(ModuleClass);
 		const moduleRegistry = new ModuleRegistry(moduleMetadata, mock(), mock(), mock());
 
 		await moduleRegistry.loadModules([]); // empty to skip dynamic imports

--- a/packages/@n8n/backend-common/src/modules/__tests__/modules.config.test.ts
+++ b/packages/@n8n/backend-common/src/modules/__tests__/modules.config.test.ts
@@ -4,7 +4,7 @@ import { UnknownModuleError } from '../errors/unknown-module.error';
 import { ModulesConfig } from '../modules.config';
 
 beforeEach(() => {
-	jest.resetAllMocks();
+	vi.resetAllMocks();
 	process.env = {};
 	Container.reset();
 });

--- a/packages/@n8n/backend-common/src/utils/__tests__/parse-flatted.test.ts
+++ b/packages/@n8n/backend-common/src/utils/__tests__/parse-flatted.test.ts
@@ -3,13 +3,13 @@ import { stringify } from 'flatted';
 import * as flattedAsync from '../flatted-async';
 import { parseFlatted, SIZE_THRESHOLD } from '../parse-flatted';
 
-jest.mock('../flatted-async');
+vi.mock('../flatted-async');
 
 describe('parseFlatted', () => {
-	const parseFlattedAsyncMock = jest.mocked(flattedAsync.parseFlattedAsync);
+	const parseFlattedAsyncMock = vi.mocked(flattedAsync.parseFlattedAsync);
 
 	beforeEach(() => {
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	});
 
 	it('should use sync flatted.parse for small data', async () => {

--- a/packages/@n8n/backend-common/tsconfig.json
+++ b/packages/@n8n/backend-common/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"types": ["node", "jest"],
+		"types": ["node", "vitest/globals"],
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"experimentalDecorators": true,
 		"emitDecoratorMetadata": true

--- a/packages/@n8n/backend-common/vite.config.ts
+++ b/packages/@n8n/backend-common/vite.config.ts
@@ -1,18 +1,3 @@
-import { mergeConfig } from 'vite';
-import { defineConfig } from 'vitest/config';
-import { vitestConfig } from '@n8n/vitest-config/node';
+import { createVitestConfigWithDecorators } from '@n8n/vitest-config/node-decorators';
 
-export default mergeConfig(
-	defineConfig({
-		test: {
-			server: {
-				deps: {
-					// Load workspace packages from their built dist so decorators
-					// share a single DI Container instance across packages.
-					external: [/@n8n\/(di|config|decorators|constants)/, /n8n-workflow/],
-				},
-			},
-		},
-	}),
-	vitestConfig,
-);
+export default createVitestConfigWithDecorators();

--- a/packages/@n8n/backend-common/vite.config.ts
+++ b/packages/@n8n/backend-common/vite.config.ts
@@ -1,0 +1,18 @@
+import { mergeConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
+import { vitestConfig } from '@n8n/vitest-config/node';
+
+export default mergeConfig(
+	defineConfig({
+		test: {
+			server: {
+				deps: {
+					// Load workspace packages from their built dist so decorators
+					// share a single DI Container instance across packages.
+					external: [/@n8n\/(di|config|decorators|constants)/, /n8n-workflow/],
+				},
+			},
+		},
+	}),
+	vitestConfig,
+);

--- a/packages/@n8n/config/jest.config.js
+++ b/packages/@n8n/config/jest.config.js
@@ -1,2 +1,0 @@
-/** @type {import('jest').Config} */
-module.exports = require('../../../jest.config');

--- a/packages/@n8n/config/package.json
+++ b/packages/@n8n/config/package.json
@@ -11,9 +11,9 @@
     "lint": "eslint . --quiet",
     "lint:fix": "eslint . --fix",
     "watch": "tsc -p tsconfig.build.json --watch",
-    "test": "jest",
-    "test:unit": "jest",
-    "test:dev": "jest --watch"
+    "test": "vitest run",
+    "test:unit": "vitest run",
+    "test:dev": "vitest --silent=false"
   },
   "main": "dist/index.js",
   "module": "src/index.ts",
@@ -27,6 +27,10 @@
     "zod": "catalog:"
   },
   "devDependencies": {
-    "@n8n/typescript-config": "workspace:*"
+    "@n8n/typescript-config": "workspace:*",
+    "@n8n/vitest-config": "workspace:*",
+    "@vitest/coverage-v8": "catalog:",
+    "vitest": "catalog:",
+    "vitest-mock-extended": "catalog:"
   }
 }

--- a/packages/@n8n/config/src/configs/__tests__/ai.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/ai.config.test.ts
@@ -5,7 +5,7 @@ import { AiConfig } from '../ai.config';
 describe('AiConfig', () => {
 	beforeEach(() => {
 		Container.reset();
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	});
 
 	it('should not poison openAiDefaultHeaders object globally when modified', () => {

--- a/packages/@n8n/config/src/configs/__tests__/expression-engine.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/expression-engine.config.test.ts
@@ -5,30 +5,29 @@ import { ExpressionEngineConfig } from '../expression-engine.config';
 describe('ExpressionEngineConfig', () => {
 	beforeEach(() => {
 		Container.reset();
-		jest.resetAllMocks();
+		vi.resetAllMocks();
+		vi.unstubAllEnvs();
 	});
 
 	describe('defaults', () => {
 		test('bridgeTimeout defaults to 5000', () => {
-			jest.replaceProperty(process, 'env', {});
 			expect(Container.get(ExpressionEngineConfig).bridgeTimeout).toBe(5000);
 		});
 
 		test('bridgeMemoryLimit defaults to 128', () => {
-			jest.replaceProperty(process, 'env', {});
 			expect(Container.get(ExpressionEngineConfig).bridgeMemoryLimit).toBe(128);
 		});
 	});
 
 	describe('N8N_EXPRESSION_ENGINE_IDLE_TIMEOUT', () => {
 		test('overrides idleTimeout', () => {
-			jest.replaceProperty(process, 'env', { N8N_EXPRESSION_ENGINE_IDLE_TIMEOUT: '60' });
+			vi.stubEnv('N8N_EXPRESSION_ENGINE_IDLE_TIMEOUT', '60');
 			const config = Container.get(ExpressionEngineConfig);
 			expect(config.idleTimeout).toBe(60);
 		});
 
 		test('parses "0" as the number 0 (distinct from undefined/unset)', () => {
-			jest.replaceProperty(process, 'env', { N8N_EXPRESSION_ENGINE_IDLE_TIMEOUT: '0' });
+			vi.stubEnv('N8N_EXPRESSION_ENGINE_IDLE_TIMEOUT', '0');
 			const config = Container.get(ExpressionEngineConfig);
 			expect(config.idleTimeout).toBe(0);
 			expect(config.idleTimeout).not.toBeUndefined();
@@ -37,14 +36,14 @@ describe('ExpressionEngineConfig', () => {
 
 	describe('N8N_EXPRESSION_ENGINE_TIMEOUT', () => {
 		test('overrides bridgeTimeout', () => {
-			jest.replaceProperty(process, 'env', { N8N_EXPRESSION_ENGINE_TIMEOUT: '1000' });
+			vi.stubEnv('N8N_EXPRESSION_ENGINE_TIMEOUT', '1000');
 			expect(Container.get(ExpressionEngineConfig).bridgeTimeout).toBe(1000);
 		});
 
 		test('falls back to default on non-numeric value', () => {
-			const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+			const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-			jest.replaceProperty(process, 'env', { N8N_EXPRESSION_ENGINE_TIMEOUT: 'not-a-number' });
+			vi.stubEnv('N8N_EXPRESSION_ENGINE_TIMEOUT', 'not-a-number');
 			expect(Container.get(ExpressionEngineConfig).bridgeTimeout).toBe(5000);
 			expect(consoleWarnSpy).toHaveBeenCalled();
 		});
@@ -52,14 +51,14 @@ describe('ExpressionEngineConfig', () => {
 
 	describe('N8N_EXPRESSION_ENGINE_MEMORY_LIMIT', () => {
 		test('overrides bridgeMemoryLimit', () => {
-			jest.replaceProperty(process, 'env', { N8N_EXPRESSION_ENGINE_MEMORY_LIMIT: '64' });
+			vi.stubEnv('N8N_EXPRESSION_ENGINE_MEMORY_LIMIT', '64');
 			expect(Container.get(ExpressionEngineConfig).bridgeMemoryLimit).toBe(64);
 		});
 
 		test('falls back to default on non-numeric value', () => {
-			const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+			const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-			jest.replaceProperty(process, 'env', { N8N_EXPRESSION_ENGINE_MEMORY_LIMIT: 'not-a-number' });
+			vi.stubEnv('N8N_EXPRESSION_ENGINE_MEMORY_LIMIT', 'not-a-number');
 			expect(Container.get(ExpressionEngineConfig).bridgeMemoryLimit).toBe(128);
 			expect(consoleWarnSpy).toHaveBeenCalled();
 		});
@@ -67,64 +66,50 @@ describe('ExpressionEngineConfig', () => {
 
 	describe('observability defaults', () => {
 		test('observabilityEnabled defaults to true', () => {
-			jest.replaceProperty(process, 'env', {});
 			expect(Container.get(ExpressionEngineConfig).observabilityEnabled).toBe(true);
 		});
 
 		test('tracesEnabled defaults to true', () => {
-			jest.replaceProperty(process, 'env', {});
 			expect(Container.get(ExpressionEngineConfig).tracesEnabled).toBe(true);
 		});
 
 		test('slowEvaluationThresholdMs defaults to 50', () => {
-			jest.replaceProperty(process, 'env', {});
 			expect(Container.get(ExpressionEngineConfig).slowEvaluationThresholdMs).toBe(50);
 		});
 
 		test('tracesSampleRate defaults to 0', () => {
-			jest.replaceProperty(process, 'env', {});
 			expect(Container.get(ExpressionEngineConfig).tracesSampleRate).toBe(0);
 		});
 	});
 
 	describe('observability overrides', () => {
 		test('N8N_EXPRESSION_ENGINE_OBSERVABILITY_ENABLED disables observability', () => {
-			jest.replaceProperty(process, 'env', {
-				N8N_EXPRESSION_ENGINE_OBSERVABILITY_ENABLED: 'false',
-			});
+			vi.stubEnv('N8N_EXPRESSION_ENGINE_OBSERVABILITY_ENABLED', 'false');
 			expect(Container.get(ExpressionEngineConfig).observabilityEnabled).toBe(false);
 		});
 
 		test('N8N_EXPRESSION_ENGINE_SLOW_EVAL_THRESHOLD_MS overrides threshold', () => {
-			jest.replaceProperty(process, 'env', {
-				N8N_EXPRESSION_ENGINE_SLOW_EVAL_THRESHOLD_MS: '100',
-			});
+			vi.stubEnv('N8N_EXPRESSION_ENGINE_SLOW_EVAL_THRESHOLD_MS', '100');
 			expect(Container.get(ExpressionEngineConfig).slowEvaluationThresholdMs).toBe(100);
 		});
 
 		test('N8N_EXPRESSION_ENGINE_SLOW_EVAL_THRESHOLD_MS falls back to default on non-positive value', () => {
-			const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+			const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-			jest.replaceProperty(process, 'env', {
-				N8N_EXPRESSION_ENGINE_SLOW_EVAL_THRESHOLD_MS: '0',
-			});
+			vi.stubEnv('N8N_EXPRESSION_ENGINE_SLOW_EVAL_THRESHOLD_MS', '0');
 			expect(Container.get(ExpressionEngineConfig).slowEvaluationThresholdMs).toBe(50);
 			expect(consoleWarnSpy).toHaveBeenCalled();
 		});
 
 		test('N8N_EXPRESSION_ENGINE_TRACES_SAMPLE_RATE overrides sample rate', () => {
-			jest.replaceProperty(process, 'env', {
-				N8N_EXPRESSION_ENGINE_TRACES_SAMPLE_RATE: '0.25',
-			});
+			vi.stubEnv('N8N_EXPRESSION_ENGINE_TRACES_SAMPLE_RATE', '0.25');
 			expect(Container.get(ExpressionEngineConfig).tracesSampleRate).toBe(0.25);
 		});
 
 		test('N8N_EXPRESSION_ENGINE_TRACES_SAMPLE_RATE falls back to default on out-of-range value', () => {
-			const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+			const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
-			jest.replaceProperty(process, 'env', {
-				N8N_EXPRESSION_ENGINE_TRACES_SAMPLE_RATE: '1.5',
-			});
+			vi.stubEnv('N8N_EXPRESSION_ENGINE_TRACES_SAMPLE_RATE', '1.5');
 			expect(Container.get(ExpressionEngineConfig).tracesSampleRate).toBe(0);
 			expect(consoleWarnSpy).toHaveBeenCalled();
 		});

--- a/packages/@n8n/config/src/configs/__tests__/external-hooks.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/external-hooks.config.test.ts
@@ -3,17 +3,20 @@ import { Container } from '@n8n/di';
 import { GlobalConfig } from '../../index';
 
 const getExternalHookFiles = (env: Record<string, string> = {}) => {
-	jest.replaceProperty(process, 'env', env);
+	Object.entries(env).forEach(([key, val]) => {
+		vi.stubEnv(key, val);
+	});
 	return Container.get(GlobalConfig).externalHooks.files;
 };
 
 describe('ExternalHooksConfig', () => {
 	beforeEach(() => {
 		Container.reset();
+		vi.unstubAllEnvs();
 	});
 
 	afterEach(() => {
-		jest.restoreAllMocks();
+		vi.restoreAllMocks();
 	});
 
 	it('should split by colon separator by default', () => {

--- a/packages/@n8n/config/src/configs/__tests__/ssrf-protection.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/ssrf-protection.config.test.ts
@@ -5,7 +5,7 @@ import { SsrfProtectionConfig, SSRF_DEFAULT_BLOCKED_IP_RANGES } from '../ssrf-pr
 describe('SsrfProtectionConfig', () => {
 	beforeEach(() => {
 		Container.reset();
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	});
 
 	const originalEnv = process.env;
@@ -133,7 +133,7 @@ describe('SsrfProtectionConfig', () => {
 		});
 
 		test('falls back to default for invalid dnsCacheMaxSize', () => {
-			const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+			const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation();
 
 			process.env = { N8N_SSRF_DNS_CACHE_MAX_SIZE: 'invalid' };
 			expect(Container.get(SsrfProtectionConfig).dnsCacheMaxSize).toBe(1048576);

--- a/packages/@n8n/config/src/configs/__tests__/ssrf-protection.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/ssrf-protection.config.test.ts
@@ -133,7 +133,7 @@ describe('SsrfProtectionConfig', () => {
 		});
 
 		test('falls back to default for invalid dnsCacheMaxSize', () => {
-			const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation();
+			const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 			process.env = { N8N_SSRF_DNS_CACHE_MAX_SIZE: 'invalid' };
 			expect(Container.get(SsrfProtectionConfig).dnsCacheMaxSize).toBe(1048576);

--- a/packages/@n8n/config/src/configs/__tests__/user-management.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/user-management.config.test.ts
@@ -14,7 +14,7 @@ describe('UserManagementConfig', () => {
 	});
 
 	test('with refresh timout > session, sets refresh timout to `0`', () => {
-		const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation();
+		const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 		process.env = {
 			N8N_USER_MANAGEMENT_JWT_DURATION_HOURS: '1',
@@ -32,7 +32,7 @@ describe('UserManagementConfig', () => {
 	});
 
 	test('with refresh timout == session, sets refresh timout to `0`', () => {
-		const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation();
+		const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 		process.env = {
 			N8N_USER_MANAGEMENT_JWT_DURATION_HOURS: '1',
@@ -50,7 +50,7 @@ describe('UserManagementConfig', () => {
 	});
 
 	test('with refresh timout < session, keeps refresh timout intact', () => {
-		const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation();
+		const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 		process.env = {
 			N8N_USER_MANAGEMENT_JWT_DURATION_HOURS: '10',

--- a/packages/@n8n/config/src/configs/__tests__/user-management.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/user-management.config.test.ts
@@ -5,7 +5,7 @@ import { UserManagementConfig } from '../user-management.config';
 describe('UserManagementConfig', () => {
 	beforeEach(() => {
 		Container.reset();
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	});
 
 	const originalEnv = process.env;
@@ -14,7 +14,7 @@ describe('UserManagementConfig', () => {
 	});
 
 	test('with refresh timout > session, sets refresh timout to `0`', () => {
-		const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+		const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation();
 
 		process.env = {
 			N8N_USER_MANAGEMENT_JWT_DURATION_HOURS: '1',
@@ -32,7 +32,7 @@ describe('UserManagementConfig', () => {
 	});
 
 	test('with refresh timout == session, sets refresh timout to `0`', () => {
-		const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+		const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation();
 
 		process.env = {
 			N8N_USER_MANAGEMENT_JWT_DURATION_HOURS: '1',
@@ -50,7 +50,7 @@ describe('UserManagementConfig', () => {
 	});
 
 	test('with refresh timout < session, keeps refresh timout intact', () => {
-		const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+		const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation();
 
 		process.env = {
 			N8N_USER_MANAGEMENT_JWT_DURATION_HOURS: '10',

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -634,7 +634,9 @@ describe('GlobalConfig', () => {
 
 	it('should read values from files using _FILE env variables', () => {
 		const passwordFile = '/path/to/postgres/password';
-		vi.stubEnv('DB_POSTGRESDB_PASSWORD_FILE', passwordFile);
+		process.env = {
+			DB_POSTGRESDB_PASSWORD_FILE: passwordFile,
+		};
 		readFileSyncMock.mockReturnValueOnce('password-from-file');
 
 		const config = Container.get(GlobalConfig);

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -1,17 +1,19 @@
 import { Container } from '@n8n/di';
-import fs from 'fs';
-import { mock } from 'jest-mock-extended';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
 import type { DatabaseConfig } from '../src/index';
 import { ExecutionsConfig, GlobalConfig, SSRF_DEFAULT_BLOCKED_IP_RANGES } from '../src/index';
 
-jest.mock('fs');
-const mockFs = mock<typeof fs>();
-fs.readFileSync = mockFs.readFileSync;
+const { readFileSyncMock } = vi.hoisted(() => ({
+	readFileSyncMock: vi.fn(),
+}));
 
-const consoleWarnMock = jest.spyOn(console, 'warn').mockImplementation(() => {});
+vi.mock('node:fs', () => ({
+	readFileSync: readFileSyncMock,
+}));
+
+const consoleWarnMock = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 // Ignore the sanitize function from the GlobalConfig nested types
 type ConfigShape<T> = T extends ReadonlyArray<infer U>
@@ -31,7 +33,7 @@ type GlobalConfigShape = ConfigShape<GlobalConfig>;
 describe('GlobalConfig', () => {
 	beforeEach(() => {
 		Container.reset();
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	});
 
 	const originalEnv = process.env;
@@ -560,7 +562,7 @@ describe('GlobalConfig', () => {
 		// which `toEqual` and `toBe` does not do.
 		expect(defaultConfig).toMatchObject(config);
 		expect(config).toMatchObject(defaultConfig);
-		expect(mockFs.readFileSync).not.toHaveBeenCalled();
+		expect(readFileSyncMock).not.toHaveBeenCalled();
 	});
 
 	it('should use values from env variables when defined', () => {
@@ -627,15 +629,13 @@ describe('GlobalConfig', () => {
 				globalUserAgentValue: 'AcmeCorp/1.0',
 			},
 		});
-		expect(mockFs.readFileSync).not.toHaveBeenCalled();
+		expect(readFileSyncMock).not.toHaveBeenCalled();
 	});
 
 	it('should read values from files using _FILE env variables', () => {
 		const passwordFile = '/path/to/postgres/password';
-		process.env = {
-			DB_POSTGRESDB_PASSWORD_FILE: passwordFile,
-		};
-		mockFs.readFileSync.calledWith(passwordFile, 'utf8').mockReturnValueOnce('password-from-file');
+		vi.stubEnv('DB_POSTGRESDB_PASSWORD_FILE', passwordFile);
+		readFileSyncMock.mockReturnValueOnce('password-from-file');
 
 		const config = Container.get(GlobalConfig);
 		const expected = {
@@ -652,7 +652,7 @@ describe('GlobalConfig', () => {
 		// which `toEqual` and `toBe` does not do.
 		expect(config).toMatchObject(expected);
 		expect(expected).toMatchObject(config);
-		expect(mockFs.readFileSync).toHaveBeenCalled();
+		expect(readFileSyncMock).toHaveBeenCalled();
 	});
 
 	it('should warn when _FILE env variable value contains whitespace', () => {
@@ -660,9 +660,7 @@ describe('GlobalConfig', () => {
 		process.env = {
 			DB_POSTGRESDB_PASSWORD_FILE: passwordFile,
 		};
-		mockFs.readFileSync
-			.calledWith(passwordFile, 'utf8')
-			.mockReturnValueOnce('password-from-file\n');
+		readFileSyncMock.mockReturnValueOnce('password-from-file\n');
 
 		const config = Container.get(GlobalConfig);
 		expect(config.database.postgresdb.password).toBe('password-from-file');

--- a/packages/@n8n/config/test/decorators.test.ts
+++ b/packages/@n8n/config/test/decorators.test.ts
@@ -3,8 +3,8 @@ import fs from 'fs';
 
 import { Config, Env } from '../src/decorators';
 
-jest.mock('fs');
-const mockFs = jest.mocked(fs);
+vi.mock('fs');
+const mockFs = vi.mocked(fs);
 
 describe('decorators', () => {
 	const originalEnv = process.env;
@@ -12,7 +12,7 @@ describe('decorators', () => {
 	beforeEach(() => {
 		Container.reset();
 		process.env = {};
-		jest.clearAllMocks();
+		vi.clearAllMocks();
 	});
 
 	afterEach(() => {
@@ -52,7 +52,7 @@ describe('decorators', () => {
 		const filePath = '/path/to/secret';
 		process.env.TEST_VALUE_FILE = filePath;
 		mockFs.readFileSync.mockReturnValueOnce('secret-value\n');
-		const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+		const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation();
 
 		@Config
 		class TestConfig {

--- a/packages/@n8n/config/test/decorators.test.ts
+++ b/packages/@n8n/config/test/decorators.test.ts
@@ -52,7 +52,7 @@ describe('decorators', () => {
 		const filePath = '/path/to/secret';
 		process.env.TEST_VALUE_FILE = filePath;
 		mockFs.readFileSync.mockReturnValueOnce('secret-value\n');
-		const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation();
+		const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
 		@Config
 		class TestConfig {

--- a/packages/@n8n/config/test/string-normalization.test.ts
+++ b/packages/@n8n/config/test/string-normalization.test.ts
@@ -4,7 +4,7 @@ import { GlobalConfig } from '../src/index';
 
 beforeEach(() => {
 	Container.reset();
-	jest.clearAllMocks();
+	vi.clearAllMocks();
 });
 
 const originalEnv = process.env;

--- a/packages/@n8n/config/tsconfig.json
+++ b/packages/@n8n/config/tsconfig.json
@@ -4,7 +4,7 @@
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
 		"strictPropertyInitialization": false,
-		"types": ["node", "jest"],
+		"types": ["node", "vitest/globals"],
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
 	},
 	"include": ["src/**/*.ts", "test/**/*.ts"],

--- a/packages/@n8n/config/vite.config.ts
+++ b/packages/@n8n/config/vite.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig, mergeConfig } from 'vite';
+import { vitestConfig } from '@n8n/vitest-config/node';
+
+export default mergeConfig(defineConfig({}), vitestConfig);

--- a/packages/@n8n/vitest-config/node-decorators.ts
+++ b/packages/@n8n/vitest-config/node-decorators.ts
@@ -26,8 +26,21 @@ export const createVitestConfigWithDecorators = (options: InlineConfig = {}) => 
 		esbuild: false, // Disable esbuild - it doesn't support decoratorMetadata
 		server: {
 			deps: {
-				// Inline all dependencies so SWC can transform them (including TypeScript in node_modules)
+				// Inline all dependencies so SWC can transform TypeScript in node_modules
+				// (e.g. `@n8n/tournament`).
 				inline: [/.*/],
+			},
+		},
+		test: {
+			server: {
+				deps: {
+					// Load workspace packages that own the DI container or register services
+					// from their built dist instead of source. Otherwise Vitest's pipeline loads
+					// them as TS while CJS dist gets loaded via require, producing two `Container`
+					// instances — one where `@Config`/`@Service` decorators registered, one used
+					// by the test — and `Container.get(...)` returns undefined for everything.
+					external: [/@n8n\/(di|config|constants)/, /n8n-workflow/],
+				},
 			},
 		},
 	});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1245,6 +1245,18 @@ importers:
       '@n8n/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+      '@n8n/vitest-config':
+        specifier: workspace:*
+        version: link:../vitest-config
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.1(vitest@4.1.1)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(@vitest/browser-playwright@4.0.16)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
+      vitest-mock-extended:
+        specifier: 'catalog:'
+        version: 3.1.0(typescript@6.0.2)(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
 
   packages/@n8n/constants:
     devDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -944,12 +944,24 @@ importers:
       '@n8n/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
+      '@n8n/vitest-config':
+        specifier: workspace:*
+        version: link:../vitest-config
       '@types/stream-json':
         specifier: 1.7.8
         version: 1.7.8
       '@types/yargs-parser':
         specifier: 21.0.0
         version: 21.0.0
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.1(vitest@4.1.1)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(@vitest/browser-playwright@4.0.16)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
+      vitest-mock-extended:
+        specifier: 'catalog:'
+        version: 3.1.0(typescript@6.0.2)(vitest@4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.21)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.21)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3)))
       zod:
         specifier: 3.25.67
         version: 3.25.67
@@ -22179,8 +22191,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.2.8:
-    resolution: {integrity: sha512-9689efAXhN/EV86plgkL/XFiJSXhGtWPG6JDboZ+QnjlUWUUQrQ0ILKQtw4iQsuwIwu5k6Aw+JnehDe7161e7A==}
+  vue-component-type-helpers@3.2.9:
+    resolution: {integrity: sha512-S3BiWYaLSzHxTpln665ELSrMR9UYmrIDUmhik7nVZxmJjTKL2/a+ew1hvGxksKelivm0ujjWfG1fYOiU/2e8rA==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -31621,7 +31633,7 @@ snapshots:
       storybook: 10.1.11(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.6.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(utf-8-validate@5.0.10)
       type-fest: 2.19.0
       vue: 3.5.26(typescript@6.0.2)
-      vue-component-type-helpers: 3.2.8
+      vue-component-type-helpers: 3.2.9
 
   '@stylistic/eslint-plugin@5.0.0(eslint@9.29.0(jiti@2.6.1))':
     dependencies:
@@ -45284,7 +45296,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.2.8: {}
+  vue-component-type-helpers@3.2.9: {}
 
   vue-demi@0.14.10(vue@3.5.26(typescript@6.0.2)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -88,7 +88,6 @@ catalog:
   langsmith: 0.5.19
   lodash: 4.18.1
   luxon: 3.7.2
-  memfs: ^4.57.2
   mime-types: 3.0.2
   mysql2: 3.17.0
   nanoid: 3.3.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -88,6 +88,7 @@ catalog:
   langsmith: 0.5.19
   lodash: 4.18.1
   luxon: 3.7.2
+  memfs: ^4.57.2
   mime-types: 3.0.2
   mysql2: 3.17.0
   nanoid: 3.3.8


### PR DESCRIPTION
## Summary

Migrate @n8n/config and @n8n/backend-common from jest to vitest. Combined backend-common to this PR due to surfaced issues with backend-common jest tests.


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-96

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
