### PR TITLE
feat(editor): Add HoverCard to design-system

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nHoverCard/HoverCard.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nHoverCard/HoverCard.stories.ts
@@ -42,9 +42,6 @@ const WorkflowPreviewTemplate: StoryFn = (args) => ({
 					<section style="width: 360px; padding: var(--spacing--sm); display: flex; flex-direction: column; gap: var(--spacing--sm);">
 						<header style="display: flex; align-items: flex-start; justify-content: space-between; gap: var(--spacing--sm);">
 							<div style="display: flex; gap: var(--spacing--xs); align-items: flex-start;">
-								<div style="height: 32px; width: 32px; border-radius: var(--radius--sm); display: grid; place-items: center; background: var(--color--foreground--base); color: var(--color--text--xlight);">
-									<N8nIcon icon="workflow" size="medium" />
-								</div>
 								<div style="display: flex; flex-direction: column; gap: var(--spacing--5xs);">
 									<N8nText bold>Customer onboarding</N8nText>
 									<N8nText size="small" color="text-light">Assigns setup tasks, enriches CRM data, and notifies account owners.</N8nText>
@@ -54,15 +51,15 @@ const WorkflowPreviewTemplate: StoryFn = (args) => ({
 						</header>
 
 						<div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--spacing--2xs);">
-							<div style="padding: var(--spacing--2xs); border: var(--border); border-radius: var(--radius--xs);">
+							<div style="padding: var(--spacing--2xs); border: var(--border); border-radius: var(--radius--xs); display:flex; flex-direction:column;">
 								<N8nText size="xsmall" color="text-light">Success rate</N8nText>
 								<N8nText bold>99.2%</N8nText>
 							</div>
-							<div style="padding: var(--spacing--2xs); border: var(--border); border-radius: var(--radius--xs);">
+							<div style="padding: var(--spacing--2xs); border: var(--border); border-radius: var(--radius--xs); display:flex; flex-direction:column;">
 								<N8nText size="xsmall" color="text-light">Avg. runtime</N8nText>
 								<N8nText bold>42s</N8nText>
 							</div>
-							<div style="padding: var(--spacing--2xs); border: var(--border); border-radius: var(--radius--xs);">
+							<div style="padding: var(--spacing--2xs); border: var(--border); border-radius: var(--radius--xs); display:flex; flex-direction:column;">
 								<N8nText size="xsmall" color="text-light">Runs today</N8nText>
 								<N8nText bold>184</N8nText>
 							</div>

--- a/packages/frontend/@n8n/design-system/src/components/N8nHoverCard/HoverCard.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nHoverCard/HoverCard.stories.ts
@@ -1,0 +1,371 @@
+import type { StoryFn } from '@storybook/vue3-vite';
+import { computed, ref } from 'vue';
+
+import N8nHoverCard from './HoverCard.vue';
+import N8nBadge from '../N8nBadge/Badge.vue';
+import N8nButton from '../N8nButton/Button.vue';
+import N8nIcon from '../N8nIcon/Icon.vue';
+import N8nTag from '../N8nTag/Tag.vue';
+import N8nText from '../N8nText/Text.vue';
+
+export default {
+	title: 'Core/Hover Card',
+	component: N8nHoverCard,
+	argTypes: {
+		openDelay: { control: 'number' },
+		closeDelay: { control: 'number' },
+		side: { control: 'select', options: ['top', 'right', 'bottom', 'left'] },
+		align: { control: 'select', options: ['start', 'center', 'end'] },
+		maxWidth: { control: 'text' },
+		disabled: { control: 'boolean' },
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'A hover/focus-triggered floating card for lightweight contextual previews and structured metadata.',
+			},
+		},
+	},
+};
+
+const WorkflowPreviewTemplate: StoryFn = (args) => ({
+	setup: () => ({ args }),
+	components: { N8nHoverCard, N8nButton, N8nIcon, N8nText, N8nBadge },
+	template: `
+		<div style="padding: 96px; display: flex; justify-content: center;">
+			<N8nHoverCard v-bind="args">
+				<template #trigger>
+					<N8nButton type="secondary">Customer onboarding</N8nButton>
+				</template>
+				<template #content>
+					<section style="width: 360px; padding: var(--spacing--sm); display: flex; flex-direction: column; gap: var(--spacing--sm);">
+						<header style="display: flex; align-items: flex-start; justify-content: space-between; gap: var(--spacing--sm);">
+							<div style="display: flex; gap: var(--spacing--xs); align-items: flex-start;">
+								<div style="height: 32px; width: 32px; border-radius: var(--radius--sm); display: grid; place-items: center; background: var(--color--foreground--base); color: var(--color--text--xlight);">
+									<N8nIcon icon="workflow" size="medium" />
+								</div>
+								<div style="display: flex; flex-direction: column; gap: var(--spacing--5xs);">
+									<N8nText bold>Customer onboarding</N8nText>
+									<N8nText size="small" color="text-light">Assigns setup tasks, enriches CRM data, and notifies account owners.</N8nText>
+								</div>
+							</div>
+							<N8nBadge theme="secondary" size="small">Active</N8nBadge>
+						</header>
+
+						<div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--spacing--2xs);">
+							<div style="padding: var(--spacing--2xs); border: var(--border); border-radius: var(--radius--xs);">
+								<N8nText size="xsmall" color="text-light">Success rate</N8nText>
+								<N8nText bold>99.2%</N8nText>
+							</div>
+							<div style="padding: var(--spacing--2xs); border: var(--border); border-radius: var(--radius--xs);">
+								<N8nText size="xsmall" color="text-light">Avg. runtime</N8nText>
+								<N8nText bold>42s</N8nText>
+							</div>
+							<div style="padding: var(--spacing--2xs); border: var(--border); border-radius: var(--radius--xs);">
+								<N8nText size="xsmall" color="text-light">Runs today</N8nText>
+								<N8nText bold>184</N8nText>
+							</div>
+						</div>
+
+						<div style="display: flex; flex-direction: column; gap: var(--spacing--2xs);">
+							<div style="display: flex; justify-content: space-between; gap: var(--spacing--sm);">
+								<N8nText size="small" color="text-light">Last failed node</N8nText>
+								<N8nText size="small">HubSpot: Update company</N8nText>
+							</div>
+							<div style="display: flex; justify-content: space-between; gap: var(--spacing--sm);">
+								<N8nText size="small" color="text-light">Owner</N8nText>
+								<N8nText size="small">Growth Ops</N8nText>
+							</div>
+							<div style="display: flex; justify-content: space-between; gap: var(--spacing--sm);">
+								<N8nText size="small" color="text-light">Last edited</N8nText>
+								<N8nText size="small">Yesterday by Maya Chen</N8nText>
+							</div>
+						</div>
+					</section>
+				</template>
+			</N8nHoverCard>
+		</div>
+	`,
+});
+
+export const WorkflowPreview = WorkflowPreviewTemplate.bind({});
+WorkflowPreview.args = {
+	maxWidth: '380px',
+	side: 'right',
+	align: 'center',
+};
+
+const EnvironmentTemplate: StoryFn = (args) => ({
+	setup() {
+		const isOpen = ref(false);
+		return { args, isOpen };
+	},
+	components: { N8nHoverCard, N8nTag, N8nText, N8nBadge },
+	template: `
+		<div style="padding: 96px; display: flex; flex-direction: column; align-items: center; gap: var(--spacing--sm);">
+			<N8nText size="small" color="text-light">Open: {{ isOpen }}</N8nText>
+			<N8nHoverCard v-model:open="isOpen" v-bind="args">
+				<template #trigger>
+					<N8nTag text="Production" type="success" />
+				</template>
+				<template #content>
+					<section style="width: 340px; padding: var(--spacing--sm); display: flex; flex-direction: column; gap: var(--spacing--sm);">
+						<header style="display: flex; justify-content: space-between; gap: var(--spacing--sm); align-items: flex-start;">
+							<div>
+								<N8nText bold>Production environment</N8nText>
+								<N8nText size="small" color="text-light">Webhook traffic is routed to this workflow version.</N8nText>
+							</div>
+							<N8nBadge theme="secondary" size="small">Healthy</N8nBadge>
+						</header>
+
+						<div style="padding: var(--spacing--xs); border-radius: var(--radius--xs); background: var(--color--background--light); display: flex; flex-direction: column; gap: var(--spacing--2xs);">
+							<div style="display: flex; justify-content: space-between; gap: var(--spacing--sm);">
+								<N8nText size="small" color="text-light">Deployed version</N8nText>
+								<N8nText size="small" bold>v42</N8nText>
+							</div>
+							<div style="display: flex; justify-content: space-between; gap: var(--spacing--sm);">
+								<N8nText size="small" color="text-light">Last deploy</N8nText>
+								<N8nText size="small">14 minutes ago</N8nText>
+							</div>
+							<div style="display: flex; justify-content: space-between; gap: var(--spacing--sm);">
+								<N8nText size="small" color="text-light">Deploy author</N8nText>
+								<N8nText size="small">Maya Chen</N8nText>
+							</div>
+						</div>
+
+						<div style="display: flex; flex-direction: column; gap: var(--spacing--2xs);">
+							<N8nText size="small" bold>Recent checks</N8nText>
+							<div style="display: flex; justify-content: space-between; gap: var(--spacing--sm);">
+								<N8nText size="small">Credential validation</N8nText>
+								<N8nText size="small" color="success">Passed</N8nText>
+							</div>
+							<div style="display: flex; justify-content: space-between; gap: var(--spacing--sm);">
+								<N8nText size="small">Webhook response time</N8nText>
+								<N8nText size="small">218ms p95</N8nText>
+							</div>
+						</div>
+					</section>
+				</template>
+			</N8nHoverCard>
+		</div>
+	`,
+});
+
+export const ControlledEnvironment = EnvironmentTemplate.bind({});
+ControlledEnvironment.args = {
+	side: 'top',
+	closeDelay: 600,
+	maxWidth: '360px',
+};
+
+const SharedReferenceTemplate: StoryFn = (args) => ({
+	setup() {
+		const open = ref(false);
+		const activeReference = ref<HTMLElement | undefined>();
+		const activeStepId = ref('webhook');
+		const steps = [
+			{
+				id: 'webhook',
+				label: 'Webhook received',
+				duration: '12ms',
+				status: 'Success',
+				detail: 'POST /lead-created matched the production webhook URL.',
+				input: 'Lead payload, 18 fields',
+				output: 'Execution started',
+			},
+			{
+				id: 'agent',
+				label: 'AI agent planned',
+				duration: '5.8s',
+				status: 'Success',
+				detail: 'Selected CRM enrichment and owner assignment tools.',
+				input: 'Lead profile + account context',
+				output: '3-step action plan',
+			},
+			{
+				id: 'http',
+				label: 'HTTP request sent',
+				duration: '640ms',
+				status: 'Retried',
+				detail: 'First HubSpot request timed out; retry succeeded.',
+				input: 'Company enrichment request',
+				output: 'Company size and domain',
+			},
+			{
+				id: 'slack',
+				label: 'Slack notified',
+				duration: '210ms',
+				status: 'Success',
+				detail: 'Sent account handoff summary to #growth-ops.',
+				input: 'Owner, score, next task',
+				output: 'Message timestamp',
+			},
+		];
+		const activeStep = computed(
+			() => steps.find((step) => step.id === activeStepId.value) ?? steps[0],
+		);
+
+		function showCard(event: MouseEvent, stepId: string) {
+			if (!(event.currentTarget instanceof HTMLElement)) return;
+			activeReference.value = event.currentTarget;
+			activeStepId.value = stepId;
+			open.value = true;
+		}
+
+		function hideCard() {
+			open.value = false;
+			activeReference.value = undefined;
+		}
+
+		return { args, open, activeReference, activeStep, steps, showCard, hideCard };
+	},
+	components: { N8nHoverCard, N8nText, N8nBadge },
+	template: `
+		<div style="padding: 112px;">
+			<N8nHoverCard
+				v-model:open="open"
+				hide-trigger
+				:reference="activeReference"
+				v-bind="args"
+			>
+				<template #content>
+					<section style="width: 360px; padding: var(--spacing--sm); display: flex; flex-direction: column; gap: var(--spacing--sm);">
+						<header style="display: flex; justify-content: space-between; gap: var(--spacing--sm); align-items: flex-start;">
+							<div>
+								<N8nText bold>{{ activeStep.label }}</N8nText>
+								<N8nText size="small" color="text-light">{{ activeStep.detail }}</N8nText>
+							</div>
+							<N8nBadge size="small" theme="secondary">{{ activeStep.status }}</N8nBadge>
+						</header>
+
+						<div style="display: grid; grid-template-columns: auto 1fr; gap: var(--spacing--2xs) var(--spacing--sm);">
+							<N8nText size="small" color="text-light">Duration</N8nText>
+							<N8nText size="small">{{ activeStep.duration }}</N8nText>
+							<N8nText size="small" color="text-light">Input</N8nText>
+							<N8nText size="small">{{ activeStep.input }}</N8nText>
+							<N8nText size="small" color="text-light">Output</N8nText>
+							<N8nText size="small">{{ activeStep.output }}</N8nText>
+						</div>
+					</section>
+				</template>
+			</N8nHoverCard>
+
+			<div style="display: flex; gap: 1px; height: 36px;">
+				<button
+					v-for="(step, index) in steps"
+					:key="step.id"
+					type="button"
+					style="border: 0; min-width: 112px; padding: 0 var(--spacing--xs); border-radius: var(--radius--sm); background: var(--color--foreground--base); color: var(--color--text--xlight); cursor: pointer;"
+					@mouseenter="showCard($event, step.id)"
+					@mouseleave="hideCard"
+					@focus="showCard($event, step.id)"
+					@blur="hideCard"
+				>
+					{{ index + 1 }}. {{ step.label.split(' ')[0] }}
+				</button>
+			</div>
+		</div>
+	`,
+});
+
+export const SharedReference = SharedReferenceTemplate.bind({});
+SharedReference.args = {
+	side: 'top',
+	align: 'center',
+	sideOffset: 8,
+	closeDelay: 0,
+	maxWidth: '380px',
+};
+
+const ScrollableTemplate: StoryFn = (args) => ({
+	setup: () => ({
+		args,
+		executions: [
+			{
+				id: 1852,
+				status: 'Success',
+				workflowName: 'New trial signup',
+				duration: '34s',
+				started: '2 min ago',
+			},
+			{
+				id: 1851,
+				status: 'Success',
+				workflowName: 'Demo booked',
+				duration: '41s',
+				started: '9 min ago',
+			},
+			{
+				id: 1850,
+				status: 'Warning',
+				workflowName: 'Lead enriched',
+				duration: '1m 12s',
+				started: '18 min ago',
+			},
+			{
+				id: 1849,
+				status: 'Success',
+				workflowName: 'Account owner assigned',
+				duration: '29s',
+				started: '26 min ago',
+			},
+			{
+				id: 1848,
+				status: 'Success',
+				workflowName: 'Lifecycle updated',
+				duration: '38s',
+				started: '33 min ago',
+			},
+			{
+				id: 1847,
+				status: 'Error',
+				workflowName: 'CRM sync',
+				duration: '7s',
+				started: '41 min ago',
+			},
+			{
+				id: 1846,
+				status: 'Success',
+				workflowName: 'Welcome email queued',
+				duration: '23s',
+				started: '48 min ago',
+			},
+		],
+	}),
+	components: { N8nHoverCard, N8nButton, N8nText, N8nBadge },
+	template: `
+		<div style="padding: 96px; display: flex; justify-content: center;">
+			<N8nHoverCard v-bind="args">
+				<template #trigger>
+					<N8nButton type="secondary">Recent executions</N8nButton>
+				</template>
+				<template #content>
+					<section style="width: 380px; padding: var(--spacing--sm); display: flex; flex-direction: column; gap: var(--spacing--sm);">
+						<header>
+							<N8nText bold>Recent executions</N8nText>
+							<N8nText size="small" color="text-light">Last hour of production runs for this workflow.</N8nText>
+						</header>
+
+						<div style="display: flex; flex-direction: column; gap: var(--spacing--2xs);">
+							<div v-for="execution in executions" :key="execution.id" style="display: grid; grid-template-columns: 1fr auto; gap: var(--spacing--3xs) var(--spacing--sm); padding: var(--spacing--2xs); border: var(--border); border-radius: var(--radius--xs);">
+								<div style="display: flex; flex-direction: column; gap: var(--spacing--5xs);">
+									<N8nText size="small" bold>#{{ execution.id }} · {{ execution.workflowName }}</N8nText>
+									<N8nText size="xsmall" color="text-light">Started {{ execution.started }} · Runtime {{ execution.duration }}</N8nText>
+								</div>
+								<N8nBadge size="small" theme="secondary">{{ execution.status }}</N8nBadge>
+							</div>
+						</div>
+					</section>
+				</template>
+			</N8nHoverCard>
+		</div>
+	`,
+});
+
+export const ScrollableContent = ScrollableTemplate.bind({});
+ScrollableContent.args = {
+	maxWidth: '400px',
+	maxHeight: '320px',
+	enableScrolling: true,
+};

--- a/packages/frontend/@n8n/design-system/src/components/N8nHoverCard/HoverCard.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nHoverCard/HoverCard.test.ts
@@ -1,0 +1,131 @@
+import { render } from '@testing-library/vue';
+import { mount } from '@vue/test-utils';
+
+import N8nHoverCard from './HoverCard.vue';
+
+const defaultStubs = {
+	HoverCardContent: {
+		template:
+			'<mock-hover-card-content v-bind="$attrs" :style="$attrs.style" :data-reference="reference ? String(reference) : undefined"><slot /></mock-hover-card-content>',
+		props: ['side', 'align', 'sideOffset', 'class', 'style', 'reference'],
+	},
+	HoverCardPortal: { template: '<mock-hover-card-portal><slot /></mock-hover-card-portal>' },
+	HoverCardRoot: {
+		template:
+			'<mock-hover-card-root v-bind="$attrs" :data-open="String(open)" @click="$emit(\'update:open\', true)"><slot /></mock-hover-card-root>',
+		props: ['open', 'defaultOpen', 'openDelay', 'closeDelay'],
+		emits: ['update:open'],
+	},
+	HoverCardTrigger: {
+		template: '<mock-hover-card-trigger v-bind="$attrs"><slot /></mock-hover-card-trigger>',
+		props: ['asChild'],
+	},
+};
+
+describe('N8nHoverCard', () => {
+	it('should render correctly with default props', () => {
+		const wrapper = render(N8nHoverCard, {
+			global: { stubs: defaultStubs },
+			slots: {
+				trigger: '<button>Trigger</button>',
+				content: '<div>Hover content</div>',
+			},
+		});
+
+		expect(wrapper.html()).toMatchSnapshot();
+		expect(wrapper.html()).toContain('Trigger');
+		expect(wrapper.html()).toContain('Hover content');
+	});
+
+	it('should emit update:open with false when close function is called', () => {
+		let closeFunction: (() => void) | undefined;
+
+		const wrapper = render(N8nHoverCard, {
+			global: { stubs: defaultStubs },
+			slots: {
+				trigger: '<button>Trigger</button>',
+				content: ({ close }: { close: () => void }) => {
+					closeFunction = close;
+					return '<button>Close</button>';
+				},
+			},
+		});
+
+		closeFunction?.();
+
+		expect(wrapper.emitted()).toHaveProperty('update:open');
+		expect(wrapper.emitted()['update:open']).toContainEqual([false]);
+	});
+
+	it('should render a hidden trigger for reference-based usage', () => {
+		const reference = document.createElement('button');
+		const wrapper = mount(N8nHoverCard, {
+			props: { hideTrigger: true, reference },
+			global: { stubs: defaultStubs },
+			slots: { content: '<div>Shared content</div>' },
+		});
+
+		expect(wrapper.find('mock-hover-card-trigger').classes()).toContain('hiddenTrigger');
+		expect(wrapper.find('mock-hover-card-content').attributes('data-reference')).toBe(
+			'[object HTMLButtonElement]',
+		);
+	});
+
+	it('should wrap content in scroll area when enableScrolling is true', () => {
+		const wrapper = render(N8nHoverCard, {
+			props: { enableScrolling: true, maxHeight: '240px' },
+			global: { stubs: defaultStubs },
+			slots: {
+				trigger: '<button>Trigger</button>',
+				content: '<div>Scrollable content</div>',
+			},
+		});
+
+		expect(wrapper.html()).toContain('Scrollable content');
+		expect(wrapper.html()).toContain('data-reka-scroll-area-viewport');
+	});
+
+	it('should emit lifecycle events when controlled open state changes', async () => {
+		const wrapper = mount(N8nHoverCard, {
+			props: { open: false },
+			global: { stubs: defaultStubs },
+			slots: {
+				trigger: '<button>Trigger</button>',
+				content: '<div>Hover content</div>',
+			},
+		});
+
+		await wrapper.setProps({ open: true });
+		await wrapper.setProps({ open: false });
+
+		expect(wrapper.emitted('before-enter')).toHaveLength(1);
+		expect(wrapper.emitted('after-leave')).toHaveLength(1);
+	});
+
+	it('should force controlled open state to false when disabled', () => {
+		const wrapper = mount(N8nHoverCard, {
+			props: { open: true, disabled: true },
+			global: { stubs: defaultStubs },
+			slots: {
+				trigger: '<button>Trigger</button>',
+				content: '<div>Hover content</div>',
+			},
+		});
+
+		expect(wrapper.find('mock-hover-card-root').attributes('data-open')).toBe('false');
+	});
+
+	it('should pass update:open events through from reka root', async () => {
+		const wrapper = mount(N8nHoverCard, {
+			global: { stubs: defaultStubs },
+			slots: {
+				trigger: '<button>Trigger</button>',
+				content: '<div>Hover content</div>',
+			},
+		});
+
+		await wrapper.find('mock-hover-card-root').trigger('click');
+
+		expect(wrapper.emitted('update:open')).toContainEqual([true]);
+	});
+});

--- a/packages/frontend/@n8n/design-system/src/components/N8nHoverCard/HoverCard.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nHoverCard/HoverCard.vue
@@ -1,0 +1,234 @@
+<script setup lang="ts">
+import {
+	HoverCardContent,
+	type HoverCardContentProps,
+	HoverCardPortal,
+	HoverCardRoot,
+	type HoverCardRootProps,
+	HoverCardTrigger,
+	type ReferenceElement,
+} from 'reka-ui';
+import { computed, watch } from 'vue';
+
+import N8nScrollArea from '../N8nScrollArea/N8nScrollArea.vue';
+
+defineOptions({ name: 'N8nHoverCard' });
+
+interface Props
+	extends Pick<HoverCardRootProps, 'open' | 'defaultOpen' | 'openDelay' | 'closeDelay'>,
+		Pick<
+			HoverCardContentProps,
+			| 'side'
+			| 'align'
+			| 'sideOffset'
+			| 'alignOffset'
+			| 'avoidCollisions'
+			| 'collisionPadding'
+			| 'sideFlip'
+			| 'forceMount'
+		> {
+	/** Disables opening the hover card. */
+	disabled?: boolean;
+	/** Custom reference element for shared/virtual positioning patterns. */
+	reference?: ReferenceElement;
+	/** Hover card max content width. */
+	maxWidth?: string;
+	/** Hover card max content height. */
+	maxHeight?: string;
+	/** Whether to wrap content in N8nScrollArea. */
+	enableScrolling?: boolean;
+	/** Whether to teleport the hover card to the body element. */
+	teleported?: boolean;
+	/** Additional class name set on HoverCardContent. */
+	contentClass?: string;
+	/** Additional class name set on HoverCardTrigger. */
+	triggerClass?: string;
+	/** Whether to render the trigger slot as the trigger element. */
+	triggerAsChild?: boolean;
+	/** Renders an inert hidden trigger for reference-based/shared patterns. */
+	hideTrigger?: boolean;
+}
+
+interface Emits {
+	(event: 'update:open', value: boolean): void;
+	(event: 'before-enter'): void;
+	(event: 'after-leave'): void;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+	open: undefined,
+	defaultOpen: undefined,
+	openDelay: 600,
+	closeDelay: 0,
+	disabled: false,
+	side: 'bottom',
+	align: 'center',
+	sideOffset: 4,
+	alignOffset: undefined,
+	avoidCollisions: true,
+	collisionPadding: 5,
+	sideFlip: undefined,
+	reference: undefined,
+	maxWidth: undefined,
+	maxHeight: undefined,
+	enableScrolling: false,
+	forceMount: false,
+	teleported: true,
+	contentClass: undefined,
+	triggerClass: undefined,
+	triggerAsChild: true,
+	hideTrigger: false,
+});
+
+const emit = defineEmits<Emits>();
+
+const rootOpen = computed(() => (props.disabled ? false : props.open));
+
+const contentStyle = computed(() => ({
+	maxWidth: props.maxWidth,
+	zIndex: 999,
+}));
+
+function handleOpenUpdate(open: boolean) {
+	if (props.disabled && open) return;
+	emit('update:open', open);
+}
+
+function close() {
+	emit('update:open', false);
+}
+
+watch(
+	() => rootOpen.value,
+	(newOpen, oldOpen) => {
+		if (newOpen && !oldOpen) {
+			emit('before-enter');
+		} else if (!newOpen && oldOpen) {
+			emit('after-leave');
+		}
+	},
+);
+</script>
+
+<template>
+	<HoverCardRoot
+		:open="rootOpen"
+		:default-open="defaultOpen"
+		:open-delay="openDelay"
+		:close-delay="closeDelay"
+		@update:open="handleOpenUpdate"
+	>
+		<HoverCardTrigger
+			:as-child="triggerAsChild && !hideTrigger"
+			:class="[triggerClass, { [$style.hiddenTrigger]: hideTrigger }]"
+		>
+			<span v-if="hideTrigger" aria-hidden="true" />
+			<slot v-else name="trigger" />
+		</HoverCardTrigger>
+		<HoverCardPortal :disabled="!teleported">
+			<HoverCardContent
+				:side="side"
+				:align="align"
+				:side-offset="sideOffset"
+				:align-offset="alignOffset"
+				:avoid-collisions="avoidCollisions"
+				:collision-padding="collisionPadding"
+				:side-flip="sideFlip"
+				:reference="reference"
+				:force-mount="forceMount"
+				:class="[$style.hoverCardContent, contentClass]"
+				:style="contentStyle"
+			>
+				<N8nScrollArea
+					v-if="enableScrolling"
+					:max-height="maxHeight"
+					type="hover"
+					:enable-vertical-scroll="true"
+					:enable-horizontal-scroll="false"
+				>
+					<slot name="content" :close="close" />
+				</N8nScrollArea>
+				<template v-else>
+					<slot name="content" :close="close" />
+				</template>
+			</HoverCardContent>
+		</HoverCardPortal>
+	</HoverCardRoot>
+</template>
+
+<style lang="scss" module>
+@use '../../css/mixins/motion';
+
+.hiddenTrigger {
+	display: none;
+}
+
+.hoverCardContent {
+	--hover-card--offset--slide-x: 0;
+	--hover-card--offset--slide-y: 0;
+	--hover-card--offset--origin-x: center;
+	--hover-card--offset--origin-y: center;
+	--animation--popover-in--translate-x: var(--hover-card--offset--slide-x);
+	--animation--popover-in--translate-y: var(--hover-card--offset--slide-y);
+
+	border-radius: var(--radius--xs);
+	background-color: var(--background--surface);
+	box-shadow:
+		var(--shadow--md),
+		inset var(--shadow--outline);
+	will-change: transform, opacity;
+	transform-origin: var(--hover-card--offset--origin-x) var(--hover-card--offset--origin-y);
+
+	&[data-state='open'] {
+		@include motion.popover-in;
+	}
+
+	&[data-state='closed'] {
+		display: none;
+	}
+}
+
+.hoverCardContent[data-state='open'][data-side='top'] {
+	--hover-card--offset--slide-y: -2px;
+	--hover-card--offset--origin-y: bottom;
+}
+
+.hoverCardContent[data-state='open'][data-side='right'] {
+	--hover-card--offset--slide-x: 2px;
+	--hover-card--offset--origin-x: left;
+}
+
+.hoverCardContent[data-state='open'][data-side='bottom'] {
+	--hover-card--offset--slide-y: 2px;
+	--hover-card--offset--origin-y: top;
+}
+
+.hoverCardContent[data-state='open'][data-side='left'] {
+	--hover-card--offset--slide-x: -2px;
+	--hover-card--offset--origin-x: right;
+}
+
+.hoverCardContent[data-state='open'][data-side='top'][data-align='start'],
+.hoverCardContent[data-state='open'][data-side='bottom'][data-align='start'] {
+	--hover-card--offset--slide-x: -2px;
+	--hover-card--offset--origin-x: left;
+}
+
+.hoverCardContent[data-state='open'][data-side='top'][data-align='end'],
+.hoverCardContent[data-state='open'][data-side='bottom'][data-align='end'] {
+	--hover-card--offset--slide-x: 2px;
+	--hover-card--offset--origin-x: right;
+}
+
+.hoverCardContent[data-state='open'][data-side='left'][data-align='start'],
+.hoverCardContent[data-state='open'][data-side='right'][data-align='start'] {
+	--hover-card--offset--slide-y: -2px;
+	--hover-card--offset--origin-y: top;
+}
+
+.hoverCardContent[data-state='open'][data-side='left'][data-align='end'],
+.hoverCardContent[data-state='open'][data-side='right'][data-align='end'] {
+	--hover-card--offset--slide-y: 2px;
+	--hover-card--offset--origin-y: bottom;
+}
+</style>

--- a/packages/frontend/@n8n/design-system/src/components/N8nHoverCard/__snapshots__/HoverCard.test.ts.snap
+++ b/packages/frontend/@n8n/design-system/src/components/N8nHoverCard/__snapshots__/HoverCard.test.ts.snap
@@ -1,0 +1,12 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`N8nHoverCard > should render correctly with default props 1`] = `
+"<mock-hover-card-root data-open="undefined">
+  <mock-hover-card-trigger class=""><button>Trigger</button></mock-hover-card-trigger>
+  <mock-hover-card-portal disabled="false">
+    <mock-hover-card-content avoid-collisions="true" collision-padding="5" force-mount="false">
+      <div>Hover content</div>
+    </mock-hover-card-content>
+  </mock-hover-card-portal>
+</mock-hover-card-root>"
+`;

--- a/packages/frontend/@n8n/design-system/src/components/N8nHoverCard/component-hover-card.md
+++ b/packages/frontend/@n8n/design-system/src/components/N8nHoverCard/component-hover-card.md
@@ -1,0 +1,211 @@
+# Component specification
+
+Displays contextual information when a user hovers or focuses a trigger. Hover cards are for lightweight preview/details content that benefits from richer layout than `N8nTooltip`, but should not require a click or modal interaction.
+
+- **Component Name:** N8nHoverCard
+- **Figma Component:** TBD
+- **Reka UI Component:** [Hover Card](https://reka-ui.com/docs/components/hover-card)
+- **Related Component:** `N8nPopover` for click-triggered overlays and shared floating-surface styling
+
+## Current usage research
+
+`editor-ui` currently has one direct Reka HoverCard usage:
+
+- `packages/frontend/editor-ui/src/features/agents/components/SessionTimelineChart.vue`
+
+That implementation uses:
+
+- A controlled `open` state bound to `HoverCardRoot`.
+- `closeDelay={0}` on `HoverCardRoot`.
+- A hidden `HoverCardTrigger` because the chart uses one shared hover card instead of one card per timeline segment.
+- `HoverCardContent.reference` to anchor content to the currently hovered/focused timeline segment element.
+- `side="top"`, `align="center"`, and `sideOffset={8}`.
+- `HoverCardPortal` with default teleport behavior.
+- Custom content class for compact, single-line, popover-like surface styling.
+
+The design-system wrapper must therefore support both normal trigger-slot usage and advanced reference-based usage for shared hover cards.
+
+## Public API definition
+
+### Props
+
+- `open?: boolean` - Controlled visibility state. Supports two-way binding via `v-model:open`.
+- `defaultOpen?: boolean` - Initial uncontrolled visibility state.
+- `openDelay?: number` - Delay in milliseconds before opening on hover/focus. Default: `600`.
+- `closeDelay?: number` - Delay in milliseconds before closing after hover/focus leaves. Default: `0`.
+- `disabled?: boolean` - Disables opening the hover card.
+- `side?: 'top' | 'right' | 'bottom' | 'left'` - Preferred side of the trigger/reference. Default: `'bottom'`.
+- `align?: 'start' | 'center' | 'end'` - Alignment along the side axis. Default: `'center'`.
+- `sideOffset?: number` - Offset from the trigger/reference in pixels. Default: `4`, matching `N8nPopover`.
+- `alignOffset?: number` - Offset along the alignment axis.
+- `avoidCollisions?: boolean` - Whether to avoid viewport collisions. Default: `true`.
+- `collisionPadding?: number | Partial<Record<'top' | 'right' | 'bottom' | 'left', number>>` - Padding from collision boundaries. Default: `5`, matching `N8nPopover`.
+- `sideFlip?: boolean` - Whether to flip to the opposite side when there is not enough space.
+- `reference?: Element | VirtualElement` - Custom reference element for positioning. Required for shared/virtual hover card patterns where the trigger slot is hidden or not the positioning anchor.
+- `maxWidth?: string` - Hover card max content width, for example `'280px'` or `'auto'`.
+- `maxHeight?: string` - Maximum height for scrollable content.
+- `enableScrolling?: boolean` - Whether to wrap content in `N8nScrollArea`. Default: `false` because hover cards are expected to be compact.
+- `forceMount?: boolean` - Whether to force mount the content even when closed.
+- `teleported?: boolean` - Whether to render content in a portal. Default: `true`.
+- `contentClass?: string` - Additional class for the content element.
+- `triggerClass?: string` - Additional class for the trigger wrapper.
+- `triggerAsChild?: boolean` - Whether to render the trigger slot as the trigger element. Default: `true`.
+- `hideTrigger?: boolean` - Renders an inert hidden trigger for reference-based/shared patterns. Default: `false`.
+
+`VirtualElement` should use the compatible Floating UI shape accepted by Reka `HoverCardContent.reference`.
+
+### Events
+
+- `update:open` - Emitted when visibility changes. Payload: `boolean`. Used with `v-model:open`.
+- `before-enter` - Emitted when the hover card transitions from closed to open.
+- `after-leave` - Emitted when the hover card transitions from open to closed.
+
+### Slots
+
+- `trigger` - Element that activates the hover card. Optional only when `hideTrigger` and `reference` are used for a shared/virtual hover card pattern.
+- `content` - Hover card content. Receives `{ close: () => void }` scope for programmatic closing.
+
+## Styling
+
+The content surface should reuse `N8nPopover`'s visual language:
+
+- `border-radius: var(--radius--xs)`
+- `background-color: var(--background--surface)`
+- `box-shadow: var(--shadow--md), inset var(--shadow--outline)`
+- `transform-origin` derived from Reka/Floating data attributes
+- `motion.popover-in` for the open-state entrance animation
+- `[data-state='closed'] { display: none; }`
+- Add the entrance animation from `_motion.scss`; it should be origin-aware like `N8nPopover` and `N8nDropdownMenu`. Do not animate on exit.
+
+The wrapper should not use `N8nTooltip`'s dark tooltip surface. Hover cards can contain structured content and should adapt to light/dark mode like popovers.
+
+## Template usage examples
+
+### Basic preview card
+
+```vue
+<script setup lang="ts">
+import { N8nHoverCard, N8nButton, N8nText } from '@n8n/design-system';
+</script>
+
+<template>
+	<N8nHoverCard side="right" max-width="280px">
+		<template #trigger>
+			<N8nButton type="secondary">View workflow details</N8nButton>
+		</template>
+		<template #content>
+			<div class="workflow-preview">
+				<N8nText bold>Customer onboarding</N8nText>
+				<N8nText size="small" color="text-light">
+					Runs when a new account is created and sends setup tasks to the owner.
+				</N8nText>
+			</div>
+		</template>
+	</N8nHoverCard>
+</template>
+```
+
+### Controlled open state
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+import { N8nHoverCard, N8nTag } from '@n8n/design-system';
+
+const isOpen = ref(false);
+</script>
+
+<template>
+	<N8nHoverCard v-model:open="isOpen" side="top" :close-delay="600">
+		<template #trigger>
+			<N8nTag text="Production" />
+		</template>
+		<template #content>
+			<div class="environment-card">Last deployed 14 minutes ago</div>
+		</template>
+	</N8nHoverCard>
+</template>
+```
+
+### Shared reference-based hover card
+
+This is the API shape needed to replace the manual Reka usage in `SessionTimelineChart.vue`.
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue';
+import { N8nHoverCard } from '@n8n/design-system';
+
+const open = ref(false);
+const activeReference = ref<HTMLElement | null>(null);
+const activeLabel = ref('');
+
+function showCard(event: MouseEvent, label: string) {
+	if (!(event.currentTarget instanceof HTMLElement)) return;
+	activeReference.value = event.currentTarget;
+	activeLabel.value = label;
+	open.value = true;
+}
+
+function hideCard() {
+	open.value = false;
+	activeReference.value = null;
+}
+</script>
+
+<template>
+	<N8nHoverCard
+		v-model:open="open"
+		hide-trigger
+		:reference="activeReference ?? undefined"
+		side="top"
+		align="center"
+		:side-offset="8"
+		:close-delay="0"
+		content-class="timeline-hover-card"
+	>
+		<template #content>
+			<span>{{ activeLabel }}</span>
+		</template>
+	</N8nHoverCard>
+
+	<button @mouseenter="showCard($event, 'Agent step')" @mouseleave="hideCard">
+		Timeline segment
+	</button>
+</template>
+```
+
+### With scrollable content
+
+```vue
+<script setup lang="ts">
+import { N8nHoverCard } from '@n8n/design-system';
+</script>
+
+<template>
+	<N8nHoverCard max-width="320px" max-height="240px" enable-scrolling>
+		<template #trigger>
+			<span>Show recent executions</span>
+		</template>
+		<template #content>
+			<ul class="execution-list">
+				<li v-for="execution in recentExecutions" :key="execution.id">
+					{{ execution.workflowName }}
+				</li>
+			</ul>
+		</template>
+	</N8nHoverCard>
+</template>
+```
+
+## Migration plan
+
+1. Add `N8nHoverCard/HoverCard.vue`, `index.ts`, stories, and tests in `@n8n/design-system`.
+2. Export `N8nHoverCard` from `packages/frontend/@n8n/design-system/src/components/index.ts`.
+3. Replace the direct Reka imports in `SessionTimelineChart.vue` with `N8nHoverCard`.
+4. Keep the timeline's delayed-open timer because it is domain behavior tied to active segment state, not generic hover-card behavior.
+5. Remove duplicated popover-like surface styles from `SessionTimelineChart.vue` once the wrapper provides the shared base surface.
+
+## PR summary draft
+
+Added an API specification for a new `N8nHoverCard` design-system component. The spec is based on the existing direct Reka HoverCard usage in `SessionTimelineChart.vue` and defines the wrapper props, events, slots, styling direction, examples, and migration plan needed before implementing the component.

--- a/packages/frontend/@n8n/design-system/src/components/N8nHoverCard/index.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nHoverCard/index.ts
@@ -1,0 +1,3 @@
+import N8nHoverCard from './HoverCard.vue';
+
+export default N8nHoverCard;

--- a/packages/frontend/@n8n/design-system/src/components/index.ts
+++ b/packages/frontend/@n8n/design-system/src/components/index.ts
@@ -41,6 +41,7 @@ export { default as N8nFormInputs } from './N8nFormInputs';
 export { default as N8nFormInput } from './N8nFormInput';
 export { default as N8nHeading } from './N8nHeading';
 export { default as N8nHeaderAction } from './N8nHeaderAction';
+export { default as N8nHoverCard } from './N8nHoverCard';
 export {
 	default as N8nIcon,
 	type IconName,

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineChart.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionTimelineChart.vue
@@ -2,7 +2,7 @@
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue';
 import { truncate } from '@n8n/utils';
 import { useI18n } from '@n8n/i18n';
-import { HoverCardContent, HoverCardPortal, HoverCardRoot, HoverCardTrigger } from 'reka-ui';
+import { N8nHoverCard } from '@n8n/design-system';
 import { convertToDisplayDate } from '@/app/utils/formatters/dateFormatter';
 import type { CSSProperties } from 'vue';
 import type { IdleRange, TimelineItem } from '../session-timeline.types';
@@ -231,40 +231,41 @@ onBeforeUnmount(clearShowPopoverTimer);
 
 <template>
 	<div ref="chartRef" :class="$style.chart">
-		<HoverCardRoot :open="popoverOpen" :close-delay="0">
+		<N8nHoverCard
+			:open="popoverOpen"
+			hide-trigger
+			:reference="activePopover?.reference"
+			side="top"
+			align="center"
+			:side-offset="8"
+			:close-delay="0"
+			max-width="none"
+			:content-class="$style.hoverCardContent"
+		>
 			<!-- One shared HoverCard avoids hundreds of tooltip instances; segment handlers set content and reference. -->
-			<HoverCardTrigger as="span" :class="$style.popoverTrigger" />
-			<HoverCardPortal>
-				<HoverCardContent
-					:reference="activePopover?.reference"
-					side="top"
-					align="center"
-					:side-offset="8"
-					:class="$style.tooltipContent"
-				>
-					<div v-if="activePopover?.segment.kind === 'idle'" :class="$style.popoverInner">
-						<SessionTimelinePill
-							kind="idle"
-							:label="i18n.baseText('agentSessions.timeline.idle')"
-							show-label
-						/>
-						<span :class="$style.popoverMeta">{{ idleDuration(activePopover.segment.range) }}</span>
-					</div>
-					<div v-else-if="activePopover" :class="$style.popoverInner">
-						<SessionTimelinePill
-							:kind="activePopover.segment.item.kind"
-							:label="popoverLabel(activePopover.segment.item)"
-							show-label
-						/>
-						<span :class="$style.popoverName">{{ popoverName(activePopover.segment.item) }}</span>
-						<span v-if="popoverDuration(activePopover.segment.item)" :class="$style.popoverMeta">
-							{{ popoverDuration(activePopover.segment.item) }}
-						</span>
-						<span :class="$style.popoverMeta">{{ popoverTime(activePopover.segment.item) }}</span>
-					</div>
-				</HoverCardContent>
-			</HoverCardPortal>
-		</HoverCardRoot>
+			<template #content>
+				<div v-if="activePopover?.segment.kind === 'idle'" :class="$style.popoverInner">
+					<SessionTimelinePill
+						kind="idle"
+						:label="i18n.baseText('agentSessions.timeline.idle')"
+						show-label
+					/>
+					<span :class="$style.popoverMeta">{{ idleDuration(activePopover.segment.range) }}</span>
+				</div>
+				<div v-else-if="activePopover" :class="$style.popoverInner">
+					<SessionTimelinePill
+						:kind="activePopover.segment.item.kind"
+						:label="popoverLabel(activePopover.segment.item)"
+						show-label
+					/>
+					<span :class="$style.popoverName">{{ popoverName(activePopover.segment.item) }}</span>
+					<span v-if="popoverDuration(activePopover.segment.item)" :class="$style.popoverMeta">
+						{{ popoverDuration(activePopover.segment.item) }}
+					</span>
+					<span :class="$style.popoverMeta">{{ popoverTime(activePopover.segment.item) }}</span>
+				</div>
+			</template>
+		</N8nHoverCard>
 		<div
 			v-for="(seg, segIdx) in segments"
 			:key="segIdx"
@@ -384,30 +385,19 @@ onBeforeUnmount(clearShowPopoverTimer);
 }
 
 /*
- * Override the design-system tooltip's fixed dark background with the page
- * background + a border so the tooltip adapts correctly to light and dark
- * mode. Also remove the 180px max-width so our single-line row layout
+ * Keep the shared hover card compact so the single-line row layout
  * (pill · name · duration · time) doesn't wrap.
  */
-.popoverTrigger {
-	display: none;
-}
-
-.tooltipContent {
+.hoverCardContent {
 	max-width: none;
 	min-height: var(--height--sm);
 	font-size: var(--font-size--xs);
 	font-weight: var(--font-weight--medium);
 	line-height: var(--line-height--md);
-	border-radius: var(--radius--xs);
-	box-shadow: var(--shadow--sm);
 	word-wrap: break-word;
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	z-index: 999;
-	background: var(--background--surface);
-	border: var(--border);
 	color: var(--color--text);
 }
 


### PR DESCRIPTION
## Summary

Adds `N8nHoverCard` to the design system as a Reka UI-backed component for rich hover/focus previews that need more structure than a tooltip.

<img width="1366" height="708" alt="CleanShot 2026-05-18 at 16 33 18@2x" src="https://github.com/user-attachments/assets/2e7bdd68-481a-4ece-981a-ef7bef3fb194" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DS-513

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)