### PR TITLE
ci: Restore Codecov session count and weekly E2E coverage uploads

### DIFF
--- a/.github/actions/build-n8n-docker/action.yml
+++ b/.github/actions/build-n8n-docker/action.yml
@@ -23,7 +23,7 @@ runs:
       id: cache-check
       uses: actions/cache/restore@640a1c2554105b57832a23eea0b4672fc7a790d5 # v4.2.3
       with:
-        key: n8n-docker-image-${{ github.sha }}
+        key: n8n-docker-image-${{ inputs.build-variant }}-${{ github.sha }}
         path: /tmp/n8n-image.tar.zst
         lookup-only: true
 
@@ -47,5 +47,5 @@ runs:
       if: steps.cache-check.outputs.cache-hit != 'true'
       uses: actions/cache/save@640a1c2554105b57832a23eea0b4672fc7a790d5 # v4.2.3
       with:
-        key: n8n-docker-image-${{ github.sha }}
+        key: n8n-docker-image-${{ inputs.build-variant }}-${{ github.sha }}
         path: /tmp/n8n-image.tar.zst

--- a/.github/actions/load-n8n-docker/action.yml
+++ b/.github/actions/load-n8n-docker/action.yml
@@ -1,12 +1,18 @@
 # Restores the n8n + runners image tarball (produced by build-n8n-docker
-# under the SHA-derived cache key) and loads both images into the local
-# docker daemon.
+# under the variant+SHA-derived cache key) and loads both images into the
+# local docker daemon.
 #
 # After this action runs, `n8nio/n8n:local` and `n8nio/runners:local` are
 # present on the runner.
 
 name: 'Load n8n Docker images from cache'
-description: 'Restores the zstd-compressed n8n + runners image tarball from the SHA-keyed GHA cache and loads both images into the local docker daemon.'
+description: 'Restores the zstd-compressed n8n + runners image tarball from the variant+SHA-keyed GHA cache and loads both images into the local docker daemon.'
+
+inputs:
+  build-variant:
+    description: 'Variant of the image to load. Must match what build-n8n-docker used (standard or coverage).'
+    required: false
+    default: 'standard'
 
 runs:
   using: 'composite'
@@ -14,7 +20,7 @@ runs:
     - name: Restore image tarball from cache
       uses: actions/cache/restore@640a1c2554105b57832a23eea0b4672fc7a790d5 # v4.2.3
       with:
-        key: n8n-docker-image-${{ github.sha }}
+        key: n8n-docker-image-${{ inputs.build-variant }}-${{ github.sha }}
         path: /tmp/n8n-image.tar.zst
         fail-on-cache-miss: true
 

--- a/.github/workflows/test-e2e-coverage-weekly.yml
+++ b/.github/workflows/test-e2e-coverage-weekly.yml
@@ -26,6 +26,7 @@ jobs:
       timeout-minutes: 45
       pre-generated-matrix: '[{"shard":1,"images":""},{"shard":2,"images":""},{"shard":3,"images":""},{"shard":4,"images":""}]'
       artifact-prefix: coverage
+      build-variant: coverage
     secrets: inherit
 
   aggregate:

--- a/.github/workflows/test-e2e-reusable.yml
+++ b/.github/workflows/test-e2e-reusable.yml
@@ -52,6 +52,11 @@ on:
         required: false
         default: 'e2e'
         type: string
+      build-variant:
+        description: 'Build variant for docker-artifact mode. Must match the variant used by prepare-docker (standard or coverage).'
+        required: false
+        default: 'standard'
+        type: string
 
 env:
   NODE_OPTIONS: ${{ contains(inputs.runner, '2vcpu') && '--max-old-space-size=6144' || '' }}
@@ -96,6 +101,8 @@ jobs:
       - name: Load n8n image from cache
         if: ${{ inputs.test-mode == 'docker-artifact' }}
         uses: ./.github/actions/load-n8n-docker
+        with:
+          build-variant: ${{ inputs.build-variant }}
 
       - name: Pre-pull Test Container Images
         if: ${{ !contains(inputs.test-command, 'test:local') }}

--- a/.github/workflows/test-unit-reusable.yml
+++ b/.github/workflows/test-unit-reusable.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
-          name: backend-unit
+          name: backend-unit-tests
 
       - name: Upload coverage to Codecov
         if: env.COVERAGE_ENABLED == 'true'
@@ -96,7 +96,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
-          name: backend-integration
+          name: backend-integration-tests
 
       - name: Upload coverage to Codecov
         if: env.COVERAGE_ENABLED == 'true'
@@ -139,7 +139,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
-          name: nodes-unit
+          name: nodes-unit-tests
 
       - name: Upload coverage to Codecov
         if: env.COVERAGE_ENABLED == 'true'
@@ -188,7 +188,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           report_type: test_results
-          name: frontend-shard-${{ matrix.shard }}
+          name: frontend-shard-${{ matrix.shard }}-tests
 
       - name: Upload coverage to Codecov
         if: env.COVERAGE_ENABLED == 'true'


### PR DESCRIPTION
## Summary

Two independent bugs distorting Codecov's coverage reporting on master, both fixed here.

- **Session dedupe**: `test_results` and `coverage` uploads in `test-unit-reusable.yml` shared the same `name:` field, which `codecov/codecov-action@v5` treats as a session key. Sessions per master commit collapsed from ~14 to ~7 after the Apr 7 migration to the unified action; the aggregate dropped ~7–10pp. Adding a `-tests` suffix to the test-results name restores distinct sessions.
- **Docker image cache collision**: `build-n8n-docker` and `load-n8n-docker` keyed the image tarball cache on `${{ github.sha }}` only. The standard variant cached by master CI was reused by the weekly E2E coverage workflow, so `editor-ui` was never istanbul-instrumented, `window.__coverage__` was undefined, the Currents fixture wrote nothing, and the weekly run's aggregate step failed with `❌ No coverage data found in .nyc_output/coverage/`. Cache key is now `n8n-docker-image-<variant>-<sha>`; `load-n8n-docker` and `test-e2e-reusable.yml` accept a `build-variant` input (default `standard`); `test-e2e-coverage-weekly.yml` passes `coverage`.

Linear: https://linear.app/n8n/issue/DEVP-104

## Test plan
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] Codecov comment on this PR shows session count back to ~14 on the merge-base commit and aggregate coverage climbing toward the pre-Apr 7 baseline.
- [ ] Manually dispatch `Test: E2E Coverage Weekly` against this branch; shard artifacts (`coverage-shard-*`) contain a non-empty `.nyc_output/coverage/` directory and the aggregate step succeeds.
- [ ] After merge, the `frontend-e2e` flag on `master` in Codecov becomes non-zero.
- [ ] First PR after merge gets one extra cache miss on Docker image build (expected; old SHA-only key is orphaned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)