### PR TITLE
ci: Message slack on failed release pipeline run

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -75,7 +75,7 @@ jobs:
     name: Build App, then Build and Push Docker Image (${{ matrix.platform }})
     needs: determine-build-context
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 25
+    timeout-minutes: 35
     strategy:
       matrix: ${{ fromJSON(needs.determine-build-context.outputs.build_matrix) }}
     outputs:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -247,8 +247,8 @@ jobs:
           sparse-checkout-cone-mode: false
       - name: Notify Slack
         env:
-          SLACK_TOKEN: ${{ secrets.QBOT_SLACK_TOKEN }}
+          SLACK_TOKEN: ${{ secrets.RELEASE_HELPER_SLACK_TOKEN }}
         run: |
           node .github/scripts/slack/notify.mjs \
-            --channel '#updates-and-product-releases' \
+            --channel C036AELNMV0 \
             --text '<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Release publish failed for n8n@${{ needs.determine-version-info.outputs.version }}>. Please Go to the actions page and retry failed runs to recover a flake in the release pipeline.'

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -217,3 +217,38 @@ jobs:
       new_stable_version: ${{ needs.determine-version-info.outputs.new_stable_version }}
       release_type: ${{ needs.determine-version-info.outputs.release_type }}
     secrets: inherit
+
+  notify-on-failure:
+    name: Notify Slack on failure
+    needs:
+      [
+        determine-version-info,
+        publish-to-npm,
+        publish-to-docker-hub,
+        build-daytona-snapshot,
+        create-github-release,
+        move-track-tag,
+        promote-stable-tag,
+        generate-and-attach-sbom,
+        merge-release-tag-to-master,
+        merge-release-tag-to-rc-branch,
+        post-release,
+      ]
+    if: |
+      always() &&
+      github.event.pull_request.merged == true &&
+      (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: master
+          sparse-checkout: .github/scripts/slack
+          sparse-checkout-cone-mode: false
+      - name: Notify Slack
+        env:
+          SLACK_TOKEN: ${{ secrets.QBOT_SLACK_TOKEN }}
+        run: |
+          node .github/scripts/slack/notify.mjs \
+            --channel '#updates-and-product-releases' \
+            --text '<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Release publish failed for n8n@${{ needs.determine-version-info.outputs.version }}>. Please Go to the actions page and retry failed runs to recover a flake in the release pipeline.'


### PR DESCRIPTION
## Summary

The release pipeline sometimes fails due to external factors. These can be npm outages, GitHub being GitHub or just a slowness in the runner. 

These failed runs can sometimes get lost in the noise and forgotten. This PR introduces a ping to our slack for anyone with write access to go retry the run.

Also bumps the docker build push timeout to 35 minutes as it is the usual culprit.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
