### PR TITLE
fix: Restore /usr/local/bin/n8n compat symlink in production image

### DIFF
--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -31,8 +31,8 @@ RUN apk --no-cache add --virtual .build-deps-fonts msttcorefonts-installer fontc
     apk del apk-tools
 
 WORKDIR /home/node
-# Point node's require() at npm's global install prefix so users extending this
-# image with `RUN npm install -g <pkg>` can `require(<pkg>)` from a Function/Code
-# node at runtime (gh #24191).
+# npm prefix -g is /usr/local but node's built-in search path is /usr/lib/node_modules.
+# Bridge the two so users extending this image with `RUN npm install -g <pkg>` can
+# `require(<pkg>)` from a Function/Code node at runtime (gh #24191).
 ENV NODE_PATH=/usr/local/lib/node_modules
 EXPOSE 5678/tcp

--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -31,8 +31,8 @@ RUN apk --no-cache add --virtual .build-deps-fonts msttcorefonts-installer fontc
     apk del apk-tools
 
 WORKDIR /home/node
-# npm prefix -g is /usr/local but node's built-in search path is /usr/lib/node_modules.
-# Bridge the two so users extending this image with `RUN npm install -g <pkg>` can
-# `require(<pkg>)` from a Function/Code node at runtime (gh #24191).
+# Point node's require() at npm's global install prefix so users extending this
+# image with `RUN npm install -g <pkg>` can `require(<pkg>)` from a Function/Code
+# node at runtime (gh #24191).
 ENV NODE_PATH=/usr/local/lib/node_modules
 EXPOSE 5678/tcp

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -19,10 +19,10 @@ ENV SHELL=/bin/sh
 
 WORKDIR /home/node
 
-COPY --from=builder /usr/local/lib/node_modules/n8n /usr/lib/node_modules/n8n
+COPY --from=builder /usr/local/lib/node_modules/n8n /usr/local/lib/node_modules/n8n
 COPY docker/images/n8n/docker-entrypoint.sh /
 
-RUN ln -s /usr/lib/node_modules/n8n/bin/n8n /usr/bin/n8n && \
+RUN ln -s /usr/local/lib/node_modules/n8n/bin/n8n /usr/local/bin/n8n && \
     mkdir -p /home/node/.n8n && \
     chown -R node:node /home/node && \
     rm -rf /root/.npm /tmp/*

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -19,10 +19,16 @@ ENV SHELL=/bin/sh
 
 WORKDIR /home/node
 
-COPY --from=builder /usr/local/lib/node_modules/n8n /usr/local/lib/node_modules/n8n
+# DHI's alpine3.23-dev base does not expose /usr/local/lib/node_modules as a
+# writable install destination, so n8n itself is installed under /usr/lib.
+COPY --from=builder /usr/local/lib/node_modules/n8n /usr/lib/node_modules/n8n
 COPY docker/images/n8n/docker-entrypoint.sh /
 
-RUN ln -s /usr/local/lib/node_modules/n8n/bin/n8n /usr/local/bin/n8n && \
+RUN ln -s /usr/lib/node_modules/n8n/bin/n8n /usr/bin/n8n && \
+    # /usr/local/bin/n8n is the long-standing public contract that downstream
+    # stacks (n8n-cloud helm charts, AppArmor profiles, user overrides) exec
+    # by absolute path. Keep it as a symlink to the real binary.
+    ln -s /usr/bin/n8n /usr/local/bin/n8n && \
     mkdir -p /home/node/.n8n && \
     chown -R node:node /home/node && \
     rm -rf /root/.npm /tmp/*

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -27,7 +27,9 @@ COPY docker/images/n8n/docker-entrypoint.sh /
 RUN ln -s /usr/lib/node_modules/n8n/bin/n8n /usr/bin/n8n && \
     # /usr/local/bin/n8n is the long-standing public contract that downstream
     # stacks (n8n-cloud helm charts, AppArmor profiles, user overrides) exec
-    # by absolute path. Keep it as a symlink to the real binary.
+    # by absolute path. The DHI base does not ship /usr/local/bin, so create
+    # it before symlinking.
+    mkdir -p /usr/local/bin && \
     ln -s /usr/bin/n8n /usr/local/bin/n8n && \
     mkdir -p /home/node/.n8n && \
     chown -R node:node /home/node && \


### PR DESCRIPTION
## Summary

The alpine 3.23 migration (#30478) moved the n8n binary symlink from `/usr/local/bin/n8n` to `/usr/bin/n8n`. This silently broke downstream stacks that exec the binary at its long-standing `/usr/local/bin/n8n` path — notably n8n-cloud helm charts (`runCommand: /usr/local/bin/n8n` in 8 values files + 2 statefulset templates) and an AppArmor profile in `n8n-cloud-infrastructure-next`.

Symptom on cloud test images:
```
Error: Cannot find module '/usr/local/bin/n8n'
  code: 'MODULE_NOT_FOUND',
```

Cloud's helm passes the binary path as `args: ["/usr/local/bin/n8n"]`, the entrypoint runs `exec n8n "$@"`, and node receives `/usr/local/bin/n8n` as a script path — bombing because the file no longer exists.

### Why a symlink rather than restoring the install location

The first iteration of this PR (commit 82575001e3) tried to revert the install location entirely (`/usr/lib/node_modules/n8n` → `/usr/local/lib/node_modules/n8n`). That **fails to build**: the DHI alpine3.23-dev base does not expose `/usr/local/lib/node_modules` as a writable install destination, so the COPY succeeds but the subsequent `ln -s` fails with `no such file or directory`. The install path move in #30478 was forced by the DHI base layout, not a stylistic choice — so the right fix is to keep n8n at `/usr/lib/node_modules/n8n` and restore the public `/usr/local/bin/n8n` path via a compat symlink.

Net change: one extra `ln -s /usr/bin/n8n /usr/local/bin/n8n` + an explanatory comment block.

## Related Linear tickets, Github issues, and Community forum posts

Regression of #30478. Surfaced via internal Slack from Jaakko Husso (cloud team). No Linear ticket.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created. — No docs change needed; restores prior published behaviour.
- [ ] Tests included. — Dockerfile-only change. Follow-up: there is no regression test today that exercises the cloud-style `args: [absolute-path]` invocation; this is a known coverage gap I'll file separately.
- [ ] Backport — needs `Backport to Stable` if #30478 has shipped in a release.