### PR TITLE
fix(editor): Fit workflow zoom into workflow artifact after animation correctly

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/WorkflowPreview.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowPreview.test.ts
@@ -547,6 +547,20 @@ describe('WorkflowPreview', () => {
 			});
 		});
 
+		it('requestFitView posts a fitView command to the iframe', async () => {
+			const wrapper = mount(WorkflowPreview, {
+				global: { plugins: [pinia] },
+				props: {},
+			});
+
+			sendPostMessageCommand('n8nReady');
+			postMessageSpy.mockClear();
+
+			(wrapper.vm as unknown as { requestFitView: () => void }).requestFitView();
+
+			expectIframePostMessage({ command: 'fitView' });
+		});
+
 		it('reloadExecution bypasses the executionId dedup so the same id is re-sent', async () => {
 			const wrapper = mount(WorkflowPreview, {
 				global: { plugins: [pinia] },

--- a/packages/frontend/editor-ui/src/app/components/WorkflowPreview.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowPreview.vue
@@ -290,7 +290,11 @@ const reloadExecution = () => {
 	loadExecution();
 };
 
-defineExpose({ iframeRef, reloadExecution });
+const requestFitView = () => {
+	iframeRef.value?.contentWindow?.postMessage?.(JSON.stringify({ command: 'fitView' }), '*');
+};
+
+defineExpose({ iframeRef, reloadExecution, requestFitView });
 </script>
 
 <template>

--- a/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.test.ts
@@ -746,6 +746,25 @@ describe('usePostMessageHandler', () => {
 		});
 	});
 
+	describe('fitView command', () => {
+		it('should emit fitView on canvasEventBus when fitView message is received', async () => {
+			const { setup, cleanup } = usePostMessageHandler({
+				workflowState,
+				currentWorkflowDocumentStore: shallowRef(null),
+				currentNDVStore: shallowRef(null),
+			});
+			setup();
+
+			dispatchPostMessage({ command: 'fitView' });
+
+			await vi.waitFor(() => {
+				expect(mockCanvasEventBusEmit).toHaveBeenCalledWith('fitView');
+			});
+
+			cleanup();
+		});
+	});
+
 	describe('message filtering', () => {
 		it('should ignore non-string messages', async () => {
 			const { setup, cleanup } = usePostMessageHandler({

--- a/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePostMessageHandler.ts
@@ -258,6 +258,8 @@ export function usePostMessageHandler({
 				executionsStore.activeExecution = (await executionsStore.fetchExecution(
 					json.executionId,
 				)) as ExecutionSummary;
+			} else if (json?.command === 'fitView') {
+				canvasEventBus.emit('fitView');
 			} else if (json?.command === 'executionEvent') {
 				// Relay execution push events from parent into the iframe's push pipeline.
 				// Uses onMessageReceivedHandlers (part of the store's public API) to dispatch

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
@@ -253,6 +253,10 @@ function handlePreviewResize({ width }: { width: number }) {
 
 function handlePreviewPanelAfterEnter() {
 	isPreviewPanelTransitioning.value = false;
+	// The slide-in animates the panel width from 0 to its target, so any
+	// fitView the iframe ran during the transition computed zoom against a
+	// near-zero viewport. Re-fit now that the iframe has its final size.
+	workflowPreviewRef.value?.requestFitView();
 }
 
 function handlePreviewPanelAfterLeave() {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowPreview.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowPreview.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
 import { createComponentRenderer } from '@/__tests__/render';
 import { createTestingPinia } from '@pinia/testing';
 import { waitFor } from '@testing-library/vue';
@@ -11,6 +12,8 @@ vi.mock('@/app/stores/workflowsList.store', () => ({
 		fetchWorkflow: mockFetchWorkflow,
 	})),
 }));
+
+const workflowPreviewRequestFitView = vi.fn();
 
 const renderComponent = createComponentRenderer(InstanceAiWorkflowPreview, {
 	global: {
@@ -28,6 +31,9 @@ const renderComponent = createComponentRenderer(InstanceAiWorkflowPreview, {
 					'allowErrorNotifications',
 					'loaderType',
 				],
+				setup(_props, { expose }) {
+					expose({ requestFitView: workflowPreviewRequestFitView });
+				},
 			},
 		},
 	},
@@ -141,6 +147,27 @@ describe('InstanceAiWorkflowPreview', () => {
 			expect(getByText('Could not load workflow')).toBeInTheDocument();
 		});
 		expect(emitted('workflow-loaded')).toBeUndefined();
+	});
+
+	it('forwards requestFitView to the inner WorkflowPreview', () => {
+		const wrapper = mount(InstanceAiWorkflowPreview, {
+			global: {
+				plugins: [createTestingPinia()],
+				stubs: {
+					WorkflowPreview: {
+						template: '<div data-test-id="workflow-preview" />',
+						setup(_props, { expose }) {
+							expose({ requestFitView: workflowPreviewRequestFitView });
+						},
+					},
+				},
+			},
+			props: { workflowId: null },
+		});
+
+		(wrapper.vm as unknown as { requestFitView: () => void }).requestFitView();
+
+		expect(workflowPreviewRequestFitView).toHaveBeenCalledTimes(1);
 	});
 
 	it('should emit iframe-ready even when n8nReady has no pushRef', async () => {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowPreview.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowPreview.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { mount } from '@vue/test-utils';
 import { createComponentRenderer } from '@/__tests__/render';
 import { createTestingPinia } from '@pinia/testing';
 import { waitFor } from '@testing-library/vue';
@@ -12,8 +11,6 @@ vi.mock('@/app/stores/workflowsList.store', () => ({
 		fetchWorkflow: mockFetchWorkflow,
 	})),
 }));
-
-const workflowPreviewRequestFitView = vi.fn();
 
 const renderComponent = createComponentRenderer(InstanceAiWorkflowPreview, {
 	global: {
@@ -31,9 +28,6 @@ const renderComponent = createComponentRenderer(InstanceAiWorkflowPreview, {
 					'allowErrorNotifications',
 					'loaderType',
 				],
-				setup(_props, { expose }) {
-					expose({ requestFitView: workflowPreviewRequestFitView });
-				},
 			},
 		},
 	},
@@ -147,27 +141,6 @@ describe('InstanceAiWorkflowPreview', () => {
 			expect(getByText('Could not load workflow')).toBeInTheDocument();
 		});
 		expect(emitted('workflow-loaded')).toBeUndefined();
-	});
-
-	it('forwards requestFitView to the inner WorkflowPreview', () => {
-		const wrapper = mount(InstanceAiWorkflowPreview, {
-			global: {
-				plugins: [createTestingPinia()],
-				stubs: {
-					WorkflowPreview: {
-						template: '<div data-test-id="workflow-preview" />',
-						setup(_props, { expose }) {
-							expose({ requestFitView: workflowPreviewRequestFitView });
-						},
-					},
-				},
-			},
-			props: { workflowId: null },
-		});
-
-		(wrapper.vm as unknown as { requestFitView: () => void }).requestFitView();
-
-		expect(workflowPreviewRequestFitView).toHaveBeenCalledTimes(1);
 	});
 
 	it('should emit iframe-ready even when n8nReady has no pushRef', async () => {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowPreview.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowPreview.vue
@@ -56,6 +56,10 @@ function relayPushEvent(event: PushMessage) {
 	);
 }
 
+function requestFitView() {
+	previewRef.value?.requestFitView();
+}
+
 function openWorkflowInEditor() {
 	const workflowId = workflow.value?.id ?? props.workflowId;
 	if (!workflowId) return;
@@ -114,7 +118,7 @@ onBeforeUnmount(() => {
 	window.removeEventListener('message', handleIframeMessage);
 });
 
-defineExpose({ relayPushEvent });
+defineExpose({ relayPushEvent, requestFitView });
 </script>
 
 <template>

--- a/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-workflow-preview.spec.ts
+++ b/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-workflow-preview.spec.ts
@@ -17,9 +17,16 @@ test.describe(
 			await n8n.instanceAi.approveBuildPlan();
 
 			// Preview should auto-open with canvas nodes visible (no confirmation for simple builds)
-			await expect(n8n.instanceAi.getPreviewCanvasNodes().first()).toBeVisible({
-				timeout: 120_000,
-			});
+			const firstNode = n8n.instanceAi.getPreviewCanvasNodes().first();
+			await expect(firstNode).toBeVisible({ timeout: 120_000 });
+
+			// Regression guard for INS-256: if fitView runs against a near-zero
+			// container (mid slide-in), nodes end up microscopic. The fix re-fits
+			// once the panel transition completes. Poll until the node settles to
+			// a reasonable on-screen width.
+			await expect
+				.poll(async () => (await firstNode.boundingBox())?.width ?? 0, { timeout: 5_000 })
+				.toBeGreaterThan(50);
 		});
 
 		test('should display canvas nodes in preview iframe', async ({ n8n }) => {


### PR DESCRIPTION
## Summary

After PR #30081 added the animation for the workflow artifact to open we broke the automatic zoom fit. This makes us fit the workflow to screen after the animation is complete, so that we don't end up doing this too early and end up with zoomed out workflow

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-256/workflow-artifacts-arent-zoomed-correctly

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
