### PR TITLE
feat(instance-ai): Graph semantic checks and builder hints from autoresearch loop

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow.tool.ts
@@ -21,6 +21,7 @@ import { appendGeneratedWorkflowIdToRootMetadata } from '../../tracing/langsmith
 import type { InstanceAiContext, InstanceAiTraceRun } from '../../types';
 import type { ValidationWarning } from '../../workflow-builder';
 import { partitionWarnings } from '../../workflow-builder';
+import { checkSemanticIssues } from '../../workflow-builder/semantic-checks';
 import { createRemediation } from '../../workflow-loop/remediation';
 import type { RemediationMetadata } from '../../workflow-loop/workflow-loop-state';
 import { escapeSingleQuotes, readFileViaSandbox, runInSandbox } from '../../workspace/sandbox-fs';
@@ -370,6 +371,12 @@ export function createSubmitWorkflowTool(
 					message: issue.message,
 					nodeName: issue.nodeName,
 				});
+			}
+
+			// Defensive semantic checks for known runtime-failure patterns that
+			// slip past the Zod schema (mirrors parse-validate's stage 3).
+			for (const issue of checkSemanticIssues(buildOutput.workflow)) {
+				allWarnings.push(issue);
 			}
 
 			const { errors, informational } = partitionWarnings(allWarnings);

--- a/packages/@n8n/instance-ai/src/workflow-builder/__tests__/parse-validate.test.ts
+++ b/packages/@n8n/instance-ai/src/workflow-builder/__tests__/parse-validate.test.ts
@@ -233,13 +233,14 @@ describe('partitionWarnings', () => {
 		expect(result.errors).toHaveLength(2);
 	});
 
-	it('classifies MERGE_PARALLEL_BRANCHES_NO_ERROR_TOLERANCE as informational (design choice, not bug)', () => {
+	it('classifies non-blocking semantic checks as informational', () => {
 		const warnings = [
 			{ code: 'MERGE_PARALLEL_BRANCHES_NO_ERROR_TOLERANCE', message: 'no onError' },
+			{ code: 'TRIGGER_JSON_REF_AFTER_NON_TRIGGER', message: 'stale $json' },
 		];
 		const result = partitionWarnings(warnings);
 
-		expect(result.informational).toHaveLength(1);
+		expect(result.informational).toHaveLength(2);
 		expect(result.errors).toHaveLength(0);
 	});
 
@@ -247,7 +248,6 @@ describe('partitionWarnings', () => {
 		// Sanity check that the other semantic codes still block submit so
 		// runtime failures the agent can self-correct don't slip through.
 		const warnings = [
-			{ code: 'TRIGGER_JSON_REF_AFTER_NON_TRIGGER', message: 'stale $json' },
 			{ code: 'TRIGGER_JSON_REF_AFTER_AGENT', message: 'stale $json' },
 			{ code: 'RESOURCE_MAPPER_AUTOMAP_AFTER_WEBHOOK', message: 'envelope only' },
 			{ code: 'GOOGLE_SHEETS_AUTOMAP_AFTER_WEBHOOK', message: 'envelope only' },
@@ -255,7 +255,7 @@ describe('partitionWarnings', () => {
 		];
 		const result = partitionWarnings(warnings);
 
-		expect(result.errors).toHaveLength(5);
+		expect(result.errors).toHaveLength(4);
 		expect(result.informational).toHaveLength(0);
 	});
 });

--- a/packages/@n8n/instance-ai/src/workflow-builder/__tests__/parse-validate.test.ts
+++ b/packages/@n8n/instance-ai/src/workflow-builder/__tests__/parse-validate.test.ts
@@ -148,6 +148,44 @@ describe('parseAndValidate', () => {
 			strictMode: true,
 		});
 	});
+
+	it('runs semantic checks on the parsed workflow and surfaces them as warnings', () => {
+		// Webhook -> Gmail -> Telegram with $json.body.X downstream of Gmail
+		// triggers TRIGGER_JSON_REF_AFTER_NON_TRIGGER. This guards against the
+		// wiring being silently un-applied (a regression observed in the
+		// autoresearch loop when discard auto-revert ate the checkSemanticIssues
+		// call sites).
+		const builder = makeBuilder({
+			toJSON: jest.fn().mockReturnValue({
+				name: 'Test',
+				nodes: [
+					{ name: 'Webhook', type: 'n8n-nodes-base.webhook', typeVersion: 2, parameters: {} },
+					{
+						name: 'Send Auto-Reply',
+						type: 'n8n-nodes-base.gmail',
+						typeVersion: 2.1,
+						parameters: { sendTo: '={{ $json.body.email }}' },
+					},
+					{
+						name: 'Notify',
+						type: 'n8n-nodes-base.telegram',
+						typeVersion: 1.2,
+						parameters: { text: '={{ $json.body.message }}' },
+					},
+				],
+				connections: {
+					Webhook: { main: [[{ node: 'Send Auto-Reply', type: 'main', index: 0 }]] },
+					'Send Auto-Reply': { main: [[{ node: 'Notify', type: 'main', index: 0 }]] },
+				},
+			}),
+		});
+		mockedParseWorkflowCodeToBuilder.mockReturnValue(builder as never);
+
+		const result = parseAndValidate('code');
+
+		const semanticCodes = result.warnings.map((w) => w.code);
+		expect(semanticCodes).toContain('TRIGGER_JSON_REF_AFTER_NON_TRIGGER');
+	});
 });
 
 describe('partitionWarnings', () => {
@@ -193,5 +231,31 @@ describe('partitionWarnings', () => {
 
 		expect(result.informational).toHaveLength(2);
 		expect(result.errors).toHaveLength(2);
+	});
+
+	it('classifies MERGE_PARALLEL_BRANCHES_NO_ERROR_TOLERANCE as informational (design choice, not bug)', () => {
+		const warnings = [
+			{ code: 'MERGE_PARALLEL_BRANCHES_NO_ERROR_TOLERANCE', message: 'no onError' },
+		];
+		const result = partitionWarnings(warnings);
+
+		expect(result.informational).toHaveLength(1);
+		expect(result.errors).toHaveLength(0);
+	});
+
+	it('classifies other semantic-check codes as blocking errors', () => {
+		// Sanity check that the other semantic codes still block submit so
+		// runtime failures the agent can self-correct don't slip through.
+		const warnings = [
+			{ code: 'TRIGGER_JSON_REF_AFTER_NON_TRIGGER', message: 'stale $json' },
+			{ code: 'TRIGGER_JSON_REF_AFTER_AGENT', message: 'stale $json' },
+			{ code: 'RESOURCE_MAPPER_AUTOMAP_AFTER_WEBHOOK', message: 'envelope only' },
+			{ code: 'GOOGLE_SHEETS_AUTOMAP_AFTER_WEBHOOK', message: 'envelope only' },
+			{ code: 'RESOURCE_MAPPER_MATCHING_COLUMN_DYNAMIC_VALUE', message: 'volatile' },
+		];
+		const result = partitionWarnings(warnings);
+
+		expect(result.errors).toHaveLength(5);
+		expect(result.informational).toHaveLength(0);
 	});
 });

--- a/packages/@n8n/instance-ai/src/workflow-builder/__tests__/semantic-checks.test.ts
+++ b/packages/@n8n/instance-ai/src/workflow-builder/__tests__/semantic-checks.test.ts
@@ -280,6 +280,46 @@ describe('semantic-checks', () => {
 			expect(checkSemanticIssues(wf)).toEqual([]);
 		});
 
+		test('still flags non-body trigger-shaped roots after an HTTP Request ancestor', () => {
+			const wf = workflow(
+				[
+					node({
+						name: 'Telegram Trigger',
+						type: 'n8n-nodes-base.telegramTrigger',
+						typeVersion: 1.2,
+						parameters: {},
+					}),
+					node({
+						name: 'Fetch Context',
+						type: 'n8n-nodes-base.httpRequest',
+						typeVersion: 4.2,
+						parameters: { url: 'https://api.example.com/context' },
+					}),
+					node({
+						name: 'Send Response',
+						type: 'n8n-nodes-base.telegram',
+						typeVersion: 1.2,
+						parameters: {
+							operation: 'sendMessage',
+							chatId: '={{ $json.message.chat.id }}',
+							text: 'Done',
+						},
+					}),
+				],
+				{
+					'Telegram Trigger': { main: [[{ node: 'Fetch Context', type: 'main', index: 0 }]] },
+					'Fetch Context': { main: [[{ node: 'Send Response', type: 'main', index: 0 }]] },
+				},
+			);
+
+			expect(checkSemanticIssues(wf)).toEqual([
+				expect.objectContaining({
+					code: 'TRIGGER_JSON_REF_AFTER_NON_TRIGGER',
+					nodeName: 'Send Response',
+				}),
+			]);
+		});
+
 		test('does NOT flag node immediately after a Webhook reading $json.body.X', () => {
 			const wf = workflow(
 				[
@@ -579,7 +619,6 @@ describe('semantic-checks', () => {
 				'={{ new Date().toISOString() }}',
 				'={{ $itemIndex }}',
 				'={{ $runIndex }}',
-				'={{ $today.toFormat("yyyy-LL-dd") }}',
 			]) {
 				const wf = workflow(
 					[
@@ -632,6 +671,37 @@ describe('semantic-checks', () => {
 				],
 				{},
 			);
+			expect(
+				checkSemanticIssues(wf).filter(
+					(i) => i.code === 'RESOURCE_MAPPER_MATCHING_COLUMN_DYNAMIC_VALUE',
+				),
+			).toEqual([]);
+		});
+
+		test('does NOT flag $today in a matching column because daily upsert keys are valid', () => {
+			const wf = workflow(
+				[
+					node({
+						name: 'Daily Rollup',
+						type: 'n8n-nodes-base.googleSheets',
+						typeVersion: 4.7,
+						parameters: {
+							operation: 'appendOrUpdate',
+							columns: {
+								mappingMode: 'defineBelow',
+								value: {
+									Day: '={{ $today.toFormat("yyyy-LL-dd") }}',
+									Count: '={{ $json.count }}',
+								},
+								schema: [],
+								matchingColumns: ['Day'],
+							},
+						},
+					}),
+				],
+				{},
+			);
+
 			expect(
 				checkSemanticIssues(wf).filter(
 					(i) => i.code === 'RESOURCE_MAPPER_MATCHING_COLUMN_DYNAMIC_VALUE',

--- a/packages/@n8n/instance-ai/src/workflow-builder/__tests__/semantic-checks.test.ts
+++ b/packages/@n8n/instance-ai/src/workflow-builder/__tests__/semantic-checks.test.ts
@@ -1,0 +1,914 @@
+import type { WorkflowJSON } from '@n8n/workflow-sdk';
+
+import { checkSemanticIssues } from '../semantic-checks';
+
+type WorkflowNode = WorkflowJSON['nodes'][number];
+
+function workflow(nodes: WorkflowNode[], connections: WorkflowJSON['connections']): WorkflowJSON {
+	return { name: 'test', nodes, connections } satisfies WorkflowJSON;
+}
+
+function node(partial: Omit<WorkflowNode, 'id' | 'position'> & { id?: string }): WorkflowNode {
+	return {
+		id: partial.id ?? `n_${partial.name ?? Math.random().toString(36).slice(2, 8)}`,
+		position: [0, 0],
+		...partial,
+	};
+}
+
+describe('semantic-checks', () => {
+	describe('post-agent trigger-data $json references', () => {
+		const telegramTrigger = node({
+			name: 'Telegram Trigger',
+			type: 'n8n-nodes-base.telegramTrigger',
+			typeVersion: 1.2,
+			parameters: {},
+		});
+
+		const agent = node({
+			name: 'Family AI Agent',
+			type: '@n8n/n8n-nodes-langchain.agent',
+			typeVersion: 1.6,
+			parameters: {},
+		});
+
+		test('flags Telegram send chatId reading $json.message.chat.id after an Agent', () => {
+			const wf = workflow(
+				[
+					telegramTrigger,
+					agent,
+					node({
+						name: 'Send Response',
+						type: 'n8n-nodes-base.telegram',
+						typeVersion: 1.2,
+						parameters: {
+							operation: 'sendMessage',
+							chatId: '={{ $json.message.chat.id }}',
+							text: '={{ $json.output }}',
+						},
+					}),
+				],
+				{
+					'Telegram Trigger': { main: [[{ node: 'Family AI Agent', type: 'main', index: 0 }]] },
+					'Family AI Agent': { main: [[{ node: 'Send Response', type: 'main', index: 0 }]] },
+				},
+			);
+			const issues = checkSemanticIssues(wf);
+			expect(issues).toEqual([
+				expect.objectContaining({
+					code: 'TRIGGER_JSON_REF_AFTER_AGENT',
+					nodeName: 'Send Response',
+				}),
+			]);
+			expect(issues[0].message).toContain("$('Telegram Trigger').item.json.message");
+			expect(issues[0].message).toContain('Family AI Agent');
+		});
+
+		test('does not flag Telegram send when chatId already uses $(Trigger).item.json', () => {
+			const wf = workflow(
+				[
+					telegramTrigger,
+					agent,
+					node({
+						name: 'Send Response',
+						type: 'n8n-nodes-base.telegram',
+						typeVersion: 1.2,
+						parameters: {
+							operation: 'sendMessage',
+							chatId: "={{ $('Telegram Trigger').item.json.message.chat.id }}",
+							text: '={{ $json.output }}',
+						},
+					}),
+				],
+				{
+					'Telegram Trigger': { main: [[{ node: 'Family AI Agent', type: 'main', index: 0 }]] },
+					'Family AI Agent': { main: [[{ node: 'Send Response', type: 'main', index: 0 }]] },
+				},
+			);
+			expect(checkSemanticIssues(wf)).toEqual([]);
+		});
+
+		test('does not flag a Telegram send directly after the Telegram Trigger (no agent in the path)', () => {
+			const wf = workflow(
+				[
+					telegramTrigger,
+					node({
+						name: 'Echo',
+						type: 'n8n-nodes-base.telegram',
+						typeVersion: 1.2,
+						parameters: {
+							operation: 'sendMessage',
+							chatId: '={{ $json.message.chat.id }}',
+							text: '={{ $json.message.text }}',
+						},
+					}),
+				],
+				{
+					'Telegram Trigger': { main: [[{ node: 'Echo', type: 'main', index: 0 }]] },
+				},
+			);
+			expect(checkSemanticIssues(wf)).toEqual([]);
+		});
+
+		test('does not flag the agent itself reading $json.message', () => {
+			// Agents legitimately read $json from their own input.
+			const wf = workflow(
+				[
+					telegramTrigger,
+					node({
+						id: agent.id,
+						name: agent.name,
+						type: agent.type,
+						typeVersion: agent.typeVersion,
+						parameters: {
+							text: '={{ $json.message.text }}',
+						},
+					}),
+				],
+				{
+					'Telegram Trigger': { main: [[{ node: 'Family AI Agent', type: 'main', index: 0 }]] },
+				},
+			);
+			expect(checkSemanticIssues(wf)).toEqual([]);
+		});
+
+		test('does not flag references that only use $json.output (valid agent output path)', () => {
+			const wf = workflow(
+				[
+					telegramTrigger,
+					agent,
+					node({
+						name: 'Send Response',
+						type: 'n8n-nodes-base.telegram',
+						typeVersion: 1.2,
+						parameters: {
+							operation: 'sendMessage',
+							chatId: "={{ $('Telegram Trigger').item.json.message.chat.id }}",
+							text: '={{ $json.output }}',
+						},
+					}),
+				],
+				{
+					'Telegram Trigger': { main: [[{ node: 'Family AI Agent', type: 'main', index: 0 }]] },
+					'Family AI Agent': { main: [[{ node: 'Send Response', type: 'main', index: 0 }]] },
+				},
+			);
+			expect(checkSemanticIssues(wf)).toEqual([]);
+		});
+
+		test('flags webhook $json.body.* references through an agent', () => {
+			const wf = workflow(
+				[
+					node({
+						name: 'Webhook',
+						type: 'n8n-nodes-base.webhook',
+						typeVersion: 2,
+						parameters: {},
+					}),
+					node({
+						id: 'agent_triage',
+						name: 'Triage Agent',
+						type: '@n8n/n8n-nodes-langchain.agent',
+						typeVersion: 1.6,
+						parameters: {},
+					}),
+					node({
+						name: 'Forward',
+						type: 'n8n-nodes-base.httpRequest',
+						typeVersion: 4.2,
+						parameters: {
+							url: '={{ $json.body.callbackUrl }}',
+						},
+					}),
+				],
+				{
+					Webhook: { main: [[{ node: 'Triage Agent', type: 'main', index: 0 }]] },
+					'Triage Agent': { main: [[{ node: 'Forward', type: 'main', index: 0 }]] },
+				},
+			);
+			const issues = checkSemanticIssues(wf);
+			expect(issues).toEqual([
+				expect.objectContaining({
+					code: 'TRIGGER_JSON_REF_AFTER_AGENT',
+					nodeName: 'Forward',
+				}),
+			]);
+			expect(issues[0].message).toContain("$('Webhook').item.json.body");
+		});
+	});
+
+	describe('post-non-trigger trigger-data $json references (general)', () => {
+		test('flags Telegram send chatId reading $json.body.X downstream of a Gmail node (sequential chain)', () => {
+			// Mirrors the contact-form-automation failure mode: parallel actions
+			// wired sequentially. After Gmail runs, $json is the Gmail API
+			// response (no `body` field), so $json.body.X is undefined.
+			const wf = workflow(
+				[
+					node({
+						name: 'Webhook',
+						type: 'n8n-nodes-base.webhook',
+						typeVersion: 2,
+						parameters: {},
+					}),
+					node({
+						name: 'Send Auto-Reply',
+						type: 'n8n-nodes-base.gmail',
+						typeVersion: 2.1,
+						parameters: {
+							sendTo: '={{ $json.body.email }}',
+						},
+					}),
+					node({
+						name: 'Notify Team',
+						type: 'n8n-nodes-base.telegram',
+						typeVersion: 1.2,
+						parameters: {
+							operation: 'sendMessage',
+							chatId: 'CHAT_ID',
+							text: '={{ $json.body.message }}',
+						},
+					}),
+				],
+				{
+					Webhook: { main: [[{ node: 'Send Auto-Reply', type: 'main', index: 0 }]] },
+					'Send Auto-Reply': { main: [[{ node: 'Notify Team', type: 'main', index: 0 }]] },
+				},
+			);
+			const issues = checkSemanticIssues(wf);
+			expect(issues).toEqual([
+				expect.objectContaining({
+					code: 'TRIGGER_JSON_REF_AFTER_NON_TRIGGER',
+					nodeName: 'Notify Team',
+				}),
+			]);
+			expect(issues[0].message).toContain("$('Webhook').item.json.body");
+			expect(issues[0].message).toContain('Send Auto-Reply');
+		});
+
+		test('does NOT flag node immediately after a Webhook reading $json.body.X', () => {
+			const wf = workflow(
+				[
+					node({
+						name: 'Webhook',
+						type: 'n8n-nodes-base.webhook',
+						typeVersion: 2,
+						parameters: {},
+					}),
+					node({
+						name: 'Send Auto-Reply',
+						type: 'n8n-nodes-base.gmail',
+						typeVersion: 2.1,
+						parameters: {
+							sendTo: '={{ $json.body.email }}',
+						},
+					}),
+				],
+				{
+					Webhook: { main: [[{ node: 'Send Auto-Reply', type: 'main', index: 0 }]] },
+				},
+			);
+			expect(checkSemanticIssues(wf)).toEqual([]);
+		});
+
+		test('walks through passthrough IF/Switch nodes between trigger and reader', () => {
+			// Webhook -> IF -> Gmail: IF preserves $json so Gmail can safely
+			// read $json.body.X. The check should NOT fire.
+			const wf = workflow(
+				[
+					node({
+						name: 'Webhook',
+						type: 'n8n-nodes-base.webhook',
+						typeVersion: 2,
+						parameters: {},
+					}),
+					node({
+						name: 'Has Email',
+						type: 'n8n-nodes-base.if',
+						typeVersion: 2,
+						parameters: {},
+					}),
+					node({
+						name: 'Send Auto-Reply',
+						type: 'n8n-nodes-base.gmail',
+						typeVersion: 2.1,
+						parameters: {
+							sendTo: '={{ $json.body.email }}',
+						},
+					}),
+				],
+				{
+					Webhook: { main: [[{ node: 'Has Email', type: 'main', index: 0 }]] },
+					'Has Email': { main: [[{ node: 'Send Auto-Reply', type: 'main', index: 0 }]] },
+				},
+			);
+			expect(checkSemanticIssues(wf)).toEqual([]);
+		});
+
+		test('flags Google Sheets autoMapInputData when immediate predecessor is a Webhook trigger', () => {
+			const wf = workflow(
+				[
+					node({
+						name: 'Webhook',
+						type: 'n8n-nodes-base.webhook',
+						typeVersion: 2,
+						parameters: {},
+					}),
+					node({
+						name: 'Log to Sheets',
+						type: 'n8n-nodes-base.googleSheets',
+						typeVersion: 4.7,
+						parameters: {
+							operation: 'append',
+							columns: { mappingMode: 'autoMapInputData', value: {}, schema: [] },
+						},
+					}),
+				],
+				{
+					Webhook: { main: [[{ node: 'Log to Sheets', type: 'main', index: 0 }]] },
+				},
+			);
+			const issues = checkSemanticIssues(wf);
+			expect(issues).toEqual([
+				expect.objectContaining({
+					code: 'GOOGLE_SHEETS_AUTOMAP_AFTER_WEBHOOK',
+					nodeName: 'Log to Sheets',
+				}),
+			]);
+			expect(issues[0].message).toContain("$('Webhook').item.json.body");
+		});
+
+		test('does not flag Google Sheets autoMapInputData after a Form Trigger (form fields are top-level)', () => {
+			const wf = workflow(
+				[
+					node({
+						name: 'Form Trigger',
+						type: 'n8n-nodes-base.formTrigger',
+						typeVersion: 2.3,
+						parameters: {},
+					}),
+					node({
+						name: 'Log to Sheets',
+						type: 'n8n-nodes-base.googleSheets',
+						typeVersion: 4.7,
+						parameters: {
+							operation: 'append',
+							columns: { mappingMode: 'autoMapInputData', value: {}, schema: [] },
+						},
+					}),
+				],
+				{
+					'Form Trigger': { main: [[{ node: 'Log to Sheets', type: 'main', index: 0 }]] },
+				},
+			);
+			expect(checkSemanticIssues(wf)).toEqual([]);
+		});
+
+		test('flags Postgres autoMapInputData immediately after a Webhook (generic resource-mapper)', () => {
+			const wf = workflow(
+				[
+					node({
+						name: 'Webhook',
+						type: 'n8n-nodes-base.webhook',
+						typeVersion: 2,
+					}),
+					node({
+						name: 'Insert Submission',
+						type: 'n8n-nodes-base.postgres',
+						typeVersion: 2.5,
+						parameters: {
+							operation: 'insert',
+							columns: { mappingMode: 'autoMapInputData', value: {}, schema: [] },
+						},
+					}),
+				],
+				{
+					Webhook: { main: [[{ node: 'Insert Submission', type: 'main', index: 0 }]] },
+				},
+			);
+			const issues = checkSemanticIssues(wf);
+			expect(issues).toEqual([
+				expect.objectContaining({
+					code: 'RESOURCE_MAPPER_AUTOMAP_AFTER_WEBHOOK',
+					nodeName: 'Insert Submission',
+				}),
+			]);
+		});
+
+		test('does not flag Google Sheets defineBelow after a Webhook', () => {
+			const wf = workflow(
+				[
+					node({
+						name: 'Webhook',
+						type: 'n8n-nodes-base.webhook',
+						typeVersion: 2,
+						parameters: {},
+					}),
+					node({
+						name: 'Log to Sheets',
+						type: 'n8n-nodes-base.googleSheets',
+						typeVersion: 4.7,
+						parameters: {
+							operation: 'append',
+							columns: {
+								mappingMode: 'defineBelow',
+								value: { name: "={{ $('Webhook').item.json.body.name }}" },
+								schema: [],
+							},
+						},
+					}),
+				],
+				{
+					Webhook: { main: [[{ node: 'Log to Sheets', type: 'main', index: 0 }]] },
+				},
+			);
+			expect(checkSemanticIssues(wf)).toEqual([]);
+		});
+
+		test('does not flag two parallel branches both directly off the Webhook trigger', () => {
+			// Webhook -> Gmail (branch 1) and Webhook -> Telegram (branch 2):
+			// both are immediate successors and may safely read $json.body.*
+			const wf = workflow(
+				[
+					node({
+						name: 'Webhook',
+						type: 'n8n-nodes-base.webhook',
+						typeVersion: 2,
+						parameters: {},
+					}),
+					node({
+						name: 'Send Auto-Reply',
+						type: 'n8n-nodes-base.gmail',
+						typeVersion: 2.1,
+						parameters: { sendTo: '={{ $json.body.email }}' },
+					}),
+					node({
+						name: 'Notify Team',
+						type: 'n8n-nodes-base.telegram',
+						typeVersion: 1.2,
+						parameters: {
+							operation: 'sendMessage',
+							chatId: 'CHAT_ID',
+							text: '={{ $json.body.message }}',
+						},
+					}),
+				],
+				{
+					Webhook: {
+						main: [
+							[
+								{ node: 'Send Auto-Reply', type: 'main', index: 0 },
+								{ node: 'Notify Team', type: 'main', index: 0 },
+							],
+						],
+					},
+				},
+			);
+			expect(checkSemanticIssues(wf)).toEqual([]);
+		});
+	});
+
+	describe('resource-mapper matching column with volatile/dynamic value (generic)', () => {
+		test('flags Google Sheets appendOrUpdate where Timestamp matching column is $now.toISO()', () => {
+			const wf = workflow(
+				[
+					node({
+						name: 'Log to Sheets',
+						type: 'n8n-nodes-base.googleSheets',
+						typeVersion: 4.7,
+						parameters: {
+							operation: 'appendOrUpdate',
+							columns: {
+								mappingMode: 'defineBelow',
+								value: {
+									Email: '={{ $json.body.email }}',
+									Timestamp: '={{ $now.toISO() }}',
+								},
+								schema: [],
+								matchingColumns: ['Email', 'Timestamp'],
+							},
+						},
+					}),
+				],
+				{},
+			);
+			const issues = checkSemanticIssues(wf);
+			expect(issues).toEqual([
+				expect.objectContaining({
+					code: 'RESOURCE_MAPPER_MATCHING_COLUMN_DYNAMIC_VALUE',
+					nodeName: 'Log to Sheets',
+				}),
+			]);
+			expect(issues[0].message).toContain("'Timestamp'");
+			expect(issues[0].message).toContain('$now');
+		});
+
+		test('flags any resource-mapper-shaped node (e.g. Postgres) with Date.now() match key', () => {
+			const wf = workflow(
+				[
+					node({
+						name: 'Upsert Customer',
+						type: 'n8n-nodes-base.postgres',
+						typeVersion: 2.5,
+						parameters: {
+							operation: 'upsert',
+							columns: {
+								mappingMode: 'defineBelow',
+								value: {
+									customer_id: '={{ Date.now() }}',
+									name: '={{ $json.name }}',
+								},
+								schema: [],
+								matchingColumns: ['customer_id'],
+							},
+						},
+					}),
+				],
+				{},
+			);
+			const issues = checkSemanticIssues(wf);
+			expect(issues).toEqual([
+				expect.objectContaining({
+					code: 'RESOURCE_MAPPER_MATCHING_COLUMN_DYNAMIC_VALUE',
+					nodeName: 'Upsert Customer',
+				}),
+			]);
+		});
+
+		test('flags Math.random() / randomUUID() / $execution.id in matching values', () => {
+			for (const expr of [
+				'={{ Math.random() }}',
+				'={{ crypto.randomUUID() }}',
+				'={{ randomUUID() }}',
+				'={{ uuid() }}',
+				'={{ $execution.id }}',
+				'={{ new Date().toISOString() }}',
+				'={{ $itemIndex }}',
+				'={{ $runIndex }}',
+				'={{ $today.toFormat("yyyy-LL-dd") }}',
+			]) {
+				const wf = workflow(
+					[
+						node({
+							name: 'Upsert Row',
+							type: 'n8n-nodes-base.googleSheets',
+							typeVersion: 4.7,
+							parameters: {
+								operation: 'appendOrUpdate',
+								columns: {
+									mappingMode: 'defineBelow',
+									value: { Key: expr },
+									schema: [],
+									matchingColumns: ['Key'],
+								},
+							},
+						}),
+					],
+					{},
+				);
+				const issues = checkSemanticIssues(wf).filter(
+					(i) => i.code === 'RESOURCE_MAPPER_MATCHING_COLUMN_DYNAMIC_VALUE',
+				);
+				expect(issues).toHaveLength(1);
+			}
+		});
+
+		test('does NOT flag stable matching values from trigger / upstream payloads', () => {
+			// Email-as-match-key referencing a stable webhook field is the canonical
+			// upsert pattern — it must not be flagged.
+			const wf = workflow(
+				[
+					node({
+						name: 'Log to Sheets',
+						type: 'n8n-nodes-base.googleSheets',
+						typeVersion: 4.7,
+						parameters: {
+							operation: 'appendOrUpdate',
+							columns: {
+								mappingMode: 'defineBelow',
+								value: {
+									Email: "={{ $('Webhook').item.json.body.email }}",
+									Name: '={{ $json.body.name }}',
+								},
+								schema: [],
+								matchingColumns: ['Email'],
+							},
+						},
+					}),
+				],
+				{},
+			);
+			expect(
+				checkSemanticIssues(wf).filter(
+					(i) => i.code === 'RESOURCE_MAPPER_MATCHING_COLUMN_DYNAMIC_VALUE',
+				),
+			).toEqual([]);
+		});
+
+		test('does NOT flag a volatile expression in a NON-matching column', () => {
+			// $now.toISO() in a written-only column (Timestamp not in matchingColumns)
+			// is legitimate — the row will be matched on Email and Timestamp updated.
+			const wf = workflow(
+				[
+					node({
+						name: 'Log to Sheets',
+						type: 'n8n-nodes-base.googleSheets',
+						typeVersion: 4.7,
+						parameters: {
+							operation: 'appendOrUpdate',
+							columns: {
+								mappingMode: 'defineBelow',
+								value: {
+									Email: '={{ $json.body.email }}',
+									Timestamp: '={{ $now.toISO() }}',
+								},
+								schema: [],
+								matchingColumns: ['Email'],
+							},
+						},
+					}),
+				],
+				{},
+			);
+			expect(
+				checkSemanticIssues(wf).filter(
+					(i) => i.code === 'RESOURCE_MAPPER_MATCHING_COLUMN_DYNAMIC_VALUE',
+				),
+			).toEqual([]);
+		});
+
+		test('does NOT flag literal (non-expression) string values that contain the substring "$now"', () => {
+			// A non-expression literal cannot evaluate at runtime; the check
+			// requires a leading `=` so this is safe.
+			const wf = workflow(
+				[
+					node({
+						name: 'Log to Sheets',
+						type: 'n8n-nodes-base.googleSheets',
+						typeVersion: 4.7,
+						parameters: {
+							operation: 'appendOrUpdate',
+							columns: {
+								mappingMode: 'defineBelow',
+								value: { Key: 'Use $now to insert current time' },
+								schema: [],
+								matchingColumns: ['Key'],
+							},
+						},
+					}),
+				],
+				{},
+			);
+			expect(
+				checkSemanticIssues(wf).filter(
+					(i) => i.code === 'RESOURCE_MAPPER_MATCHING_COLUMN_DYNAMIC_VALUE',
+				),
+			).toEqual([]);
+		});
+
+		test('does NOT flag nodes that do not have the resource-mapper shape', () => {
+			// Plain Set / Filter / Code nodes don't carry columns.matchingColumns.
+			const wf = workflow(
+				[
+					node({
+						name: 'Compute Timestamp',
+						type: 'n8n-nodes-base.set',
+						typeVersion: 3.4,
+						parameters: {
+							assignments: {
+								assignments: [{ name: 'ts', value: '={{ $now.toISO() }}' }],
+							},
+						},
+					}),
+				],
+				{},
+			);
+			expect(
+				checkSemanticIssues(wf).filter(
+					(i) => i.code === 'RESOURCE_MAPPER_MATCHING_COLUMN_DYNAMIC_VALUE',
+				),
+			).toEqual([]);
+		});
+
+		test('does NOT flag word-boundary near-misses (e.g. $nowt, $todayValue, Date.nowish)', () => {
+			const wf = workflow(
+				[
+					node({
+						name: 'Upsert Row',
+						type: 'n8n-nodes-base.googleSheets',
+						typeVersion: 4.7,
+						parameters: {
+							operation: 'appendOrUpdate',
+							columns: {
+								mappingMode: 'defineBelow',
+								value: {
+									Key: '={{ $json.$nowt }}',
+									Key2: '={{ $json.$todayValue }}',
+									Key3: '={{ $json.Date_nowish }}',
+								},
+								schema: [],
+								matchingColumns: ['Key', 'Key2', 'Key3'],
+							},
+						},
+					}),
+				],
+				{},
+			);
+			expect(
+				checkSemanticIssues(wf).filter(
+					(i) => i.code === 'RESOURCE_MAPPER_MATCHING_COLUMN_DYNAMIC_VALUE',
+				),
+			).toEqual([]);
+		});
+	});
+
+	describe('Merge node with parallel-branch action nodes lacking onError tolerance (generic)', () => {
+		test('flags Webhook → (Gmail | Telegram | Sheets) → Merge where no action has onError', () => {
+			const wf = workflow(
+				[
+					node({ name: 'Webhook', type: 'n8n-nodes-base.webhook', typeVersion: 2 }),
+					node({ name: 'Send Auto-Reply', type: 'n8n-nodes-base.gmail', typeVersion: 2.1 }),
+					node({ name: 'Notify Team', type: 'n8n-nodes-base.telegram', typeVersion: 1.2 }),
+					node({ name: 'Log to Sheets', type: 'n8n-nodes-base.googleSheets', typeVersion: 4.7 }),
+					node({ name: 'Combine Results', type: 'n8n-nodes-base.merge', typeVersion: 3 }),
+				],
+				{
+					Webhook: {
+						main: [
+							[
+								{ node: 'Send Auto-Reply', type: 'main', index: 0 },
+								{ node: 'Notify Team', type: 'main', index: 0 },
+								{ node: 'Log to Sheets', type: 'main', index: 0 },
+							],
+						],
+					},
+					'Send Auto-Reply': {
+						main: [[{ node: 'Combine Results', type: 'main', index: 0 }]],
+					},
+					'Notify Team': {
+						main: [[{ node: 'Combine Results', type: 'main', index: 1 }]],
+					},
+					'Log to Sheets': {
+						main: [[{ node: 'Combine Results', type: 'main', index: 2 }]],
+					},
+				},
+			);
+			const issues = checkSemanticIssues(wf).filter(
+				(i) => i.code === 'MERGE_PARALLEL_BRANCHES_NO_ERROR_TOLERANCE',
+			);
+			expect(issues).toHaveLength(1);
+			expect(issues[0].nodeName).toBe('Combine Results');
+		});
+
+		test('does NOT flag when at least 2 of the parallel branches have onError tolerance', () => {
+			// Only 1 branch (Sheets) without onError — not enough to flag.
+			const wf = workflow(
+				[
+					node({ name: 'Webhook', type: 'n8n-nodes-base.webhook', typeVersion: 2 }),
+					node({
+						name: 'Send Auto-Reply',
+						type: 'n8n-nodes-base.gmail',
+						typeVersion: 2.1,
+						onError: 'continueRegularOutput',
+					}),
+					node({
+						name: 'Notify Team',
+						type: 'n8n-nodes-base.telegram',
+						typeVersion: 1.2,
+						onError: 'continueRegularOutput',
+					}),
+					node({ name: 'Log to Sheets', type: 'n8n-nodes-base.googleSheets', typeVersion: 4.7 }),
+					node({ name: 'Combine Results', type: 'n8n-nodes-base.merge', typeVersion: 3 }),
+				],
+				{
+					Webhook: {
+						main: [
+							[
+								{ node: 'Send Auto-Reply', type: 'main', index: 0 },
+								{ node: 'Notify Team', type: 'main', index: 0 },
+								{ node: 'Log to Sheets', type: 'main', index: 0 },
+							],
+						],
+					},
+					'Send Auto-Reply': {
+						main: [[{ node: 'Combine Results', type: 'main', index: 0 }]],
+					},
+					'Notify Team': {
+						main: [[{ node: 'Combine Results', type: 'main', index: 1 }]],
+					},
+					'Log to Sheets': {
+						main: [[{ node: 'Combine Results', type: 'main', index: 2 }]],
+					},
+				},
+			);
+			expect(
+				checkSemanticIssues(wf).filter(
+					(i) => i.code === 'MERGE_PARALLEL_BRANCHES_NO_ERROR_TOLERANCE',
+				),
+			).toEqual([]);
+		});
+
+		test('does NOT flag when the Merge has only one input branch', () => {
+			const wf = workflow(
+				[
+					node({ name: 'Manual', type: 'n8n-nodes-base.manualTrigger', typeVersion: 1 }),
+					node({ name: 'Send Email', type: 'n8n-nodes-base.gmail', typeVersion: 2.1 }),
+					node({ name: 'Merge In', type: 'n8n-nodes-base.merge', typeVersion: 3 }),
+				],
+				{
+					Manual: { main: [[{ node: 'Send Email', type: 'main', index: 0 }]] },
+					'Send Email': { main: [[{ node: 'Merge In', type: 'main', index: 0 }]] },
+				},
+			);
+			expect(
+				checkSemanticIssues(wf).filter(
+					(i) => i.code === 'MERGE_PARALLEL_BRANCHES_NO_ERROR_TOLERANCE',
+				),
+			).toEqual([]);
+		});
+
+		test('does NOT flag a workflow without any Merge node', () => {
+			const wf = workflow(
+				[
+					node({ name: 'Webhook', type: 'n8n-nodes-base.webhook', typeVersion: 2 }),
+					node({ name: 'Send Email', type: 'n8n-nodes-base.gmail', typeVersion: 2.1 }),
+					node({ name: 'Notify Team', type: 'n8n-nodes-base.telegram', typeVersion: 1.2 }),
+				],
+				{
+					Webhook: {
+						main: [
+							[
+								{ node: 'Send Email', type: 'main', index: 0 },
+								{ node: 'Notify Team', type: 'main', index: 0 },
+							],
+						],
+					},
+				},
+			);
+			expect(
+				checkSemanticIssues(wf).filter(
+					(i) => i.code === 'MERGE_PARALLEL_BRANCHES_NO_ERROR_TOLERANCE',
+				),
+			).toEqual([]);
+		});
+
+		test('does NOT flag when both Merge inputs are non-action shaping nodes (Set/Code)', () => {
+			const wf = workflow(
+				[
+					node({ name: 'Manual', type: 'n8n-nodes-base.manualTrigger', typeVersion: 1 }),
+					node({ name: 'Shape A', type: 'n8n-nodes-base.set', typeVersion: 3.4 }),
+					node({ name: 'Shape B', type: 'n8n-nodes-base.code', typeVersion: 2 }),
+					node({ name: 'Merge In', type: 'n8n-nodes-base.merge', typeVersion: 3 }),
+				],
+				{
+					Manual: {
+						main: [
+							[
+								{ node: 'Shape A', type: 'main', index: 0 },
+								{ node: 'Shape B', type: 'main', index: 0 },
+							],
+						],
+					},
+					'Shape A': { main: [[{ node: 'Merge In', type: 'main', index: 0 }]] },
+					'Shape B': { main: [[{ node: 'Merge In', type: 'main', index: 1 }]] },
+				},
+			);
+			expect(
+				checkSemanticIssues(wf).filter(
+					(i) => i.code === 'MERGE_PARALLEL_BRANCHES_NO_ERROR_TOLERANCE',
+				),
+			).toEqual([]);
+		});
+
+		test('flags branches with action nodes behind passthrough nodes (IF / Set / Code on the path)', () => {
+			// Each branch has Set then an external action then → Merge.
+			const wf = workflow(
+				[
+					node({ name: 'Webhook', type: 'n8n-nodes-base.webhook', typeVersion: 2 }),
+					node({ name: 'Flatten A', type: 'n8n-nodes-base.set', typeVersion: 3.4 }),
+					node({ name: 'Flatten B', type: 'n8n-nodes-base.set', typeVersion: 3.4 }),
+					node({ name: 'Send Email', type: 'n8n-nodes-base.gmail', typeVersion: 2.1 }),
+					node({ name: 'Notify Team', type: 'n8n-nodes-base.telegram', typeVersion: 1.2 }),
+					node({ name: 'Merge In', type: 'n8n-nodes-base.merge', typeVersion: 3 }),
+				],
+				{
+					Webhook: {
+						main: [
+							[
+								{ node: 'Flatten A', type: 'main', index: 0 },
+								{ node: 'Flatten B', type: 'main', index: 0 },
+							],
+						],
+					},
+					'Flatten A': { main: [[{ node: 'Send Email', type: 'main', index: 0 }]] },
+					'Flatten B': { main: [[{ node: 'Notify Team', type: 'main', index: 0 }]] },
+					'Send Email': { main: [[{ node: 'Merge In', type: 'main', index: 0 }]] },
+					'Notify Team': { main: [[{ node: 'Merge In', type: 'main', index: 1 }]] },
+				},
+			);
+			const issues = checkSemanticIssues(wf).filter(
+				(i) => i.code === 'MERGE_PARALLEL_BRANCHES_NO_ERROR_TOLERANCE',
+			);
+			expect(issues).toHaveLength(1);
+		});
+	});
+});

--- a/packages/@n8n/instance-ai/src/workflow-builder/__tests__/semantic-checks.test.ts
+++ b/packages/@n8n/instance-ai/src/workflow-builder/__tests__/semantic-checks.test.ts
@@ -245,6 +245,41 @@ describe('semantic-checks', () => {
 			expect(issues[0].message).toContain('Send Auto-Reply');
 		});
 
+		test('does NOT flag `$json.body.X` after an HTTP Request ancestor (its response legitimately has `body`)', () => {
+			// Webhook -> HTTP Request -> Set reading $json.body.x : the HTTP
+			// Request response shape is { statusCode, headers, body, ... }, so
+			// `$json.body` is a valid reference, not a misplaced trigger payload.
+			const wf = workflow(
+				[
+					node({
+						name: 'Webhook',
+						type: 'n8n-nodes-base.webhook',
+						typeVersion: 2,
+						parameters: {},
+					}),
+					node({
+						name: 'Fetch Profile',
+						type: 'n8n-nodes-base.httpRequest',
+						typeVersion: 4.2,
+						parameters: { url: 'https://api.example.com/profile' },
+					}),
+					node({
+						name: 'Use Result',
+						type: 'n8n-nodes-base.set',
+						typeVersion: 3.4,
+						parameters: {
+							fieldsToSet: { values: [{ name: 'email', stringValue: '={{ $json.body.email }}' }] },
+						},
+					}),
+				],
+				{
+					Webhook: { main: [[{ node: 'Fetch Profile', type: 'main', index: 0 }]] },
+					'Fetch Profile': { main: [[{ node: 'Use Result', type: 'main', index: 0 }]] },
+				},
+			);
+			expect(checkSemanticIssues(wf)).toEqual([]);
+		});
+
 		test('does NOT flag node immediately after a Webhook reading $json.body.X', () => {
 			const wf = workflow(
 				[
@@ -570,6 +605,38 @@ describe('semantic-checks', () => {
 				);
 				expect(issues).toHaveLength(1);
 			}
+		});
+
+		test('does NOT flag `new Date($json.createdAt).toISOString()` — deterministic normalization', () => {
+			// `new Date(input)` with a stable input is a common, valid match-key
+			// transformation. Only the zero-arg form `new Date()` is volatile.
+			const wf = workflow(
+				[
+					node({
+						name: 'Upsert Customer',
+						type: 'n8n-nodes-base.postgres',
+						typeVersion: 2.5,
+						parameters: {
+							operation: 'upsert',
+							columns: {
+								mappingMode: 'defineBelow',
+								value: {
+									createdAt: "={{ new Date($('Webhook').item.json.body.createdAt).toISOString() }}",
+									name: "={{ $('Webhook').item.json.body.name }}",
+								},
+								schema: [],
+								matchingColumns: ['createdAt'],
+							},
+						},
+					}),
+				],
+				{},
+			);
+			expect(
+				checkSemanticIssues(wf).filter(
+					(i) => i.code === 'RESOURCE_MAPPER_MATCHING_COLUMN_DYNAMIC_VALUE',
+				),
+			).toEqual([]);
 		});
 
 		test('does NOT flag stable matching values from trigger / upstream payloads', () => {

--- a/packages/@n8n/instance-ai/src/workflow-builder/parse-validate.ts
+++ b/packages/@n8n/instance-ai/src/workflow-builder/parse-validate.ts
@@ -120,6 +120,7 @@ export function partitionWarnings(warnings: ValidationWarning[]): {
 		'MISSING_TRIGGER',
 		'DISCONNECTED_NODE',
 		'MERGE_PARALLEL_BRANCHES_NO_ERROR_TOLERANCE',
+		'TRIGGER_JSON_REF_AFTER_NON_TRIGGER',
 	]);
 
 	const errors: ValidationWarning[] = [];

--- a/packages/@n8n/instance-ai/src/workflow-builder/parse-validate.ts
+++ b/packages/@n8n/instance-ai/src/workflow-builder/parse-validate.ts
@@ -10,6 +10,7 @@ import { parseWorkflowCodeToBuilder, validateWorkflow } from '@n8n/workflow-sdk'
 import type { INodeTypes } from 'n8n-workflow';
 
 import { stripImportStatements } from './extract-code';
+import { checkSemanticIssues } from './semantic-checks';
 import type { ParseAndValidateResult, ValidationWarning } from './types';
 
 export interface ParseAndValidateOptions {
@@ -86,6 +87,12 @@ export function parseAndValidate(
 		const schemaValidation = validateWorkflow(json, { nodeTypesProvider, strictMode: true });
 		collectValidationIssues(schemaValidation.errors, allWarnings);
 		collectValidationIssues(schemaValidation.warnings, allWarnings);
+
+		// Stage 3: Defensive semantic checks for known runtime-failure patterns
+		// that slip past the Zod schema (e.g. trigger-data $json refs after a
+		// $json-clobbering node, parallel branches into Merge with no onError
+		// tolerance, resource-mapper match column with volatile value).
+		collectValidationIssues(checkSemanticIssues(json), allWarnings);
 
 		return { workflow: json, warnings: allWarnings };
 	} catch (error) {

--- a/packages/@n8n/instance-ai/src/workflow-builder/parse-validate.ts
+++ b/packages/@n8n/instance-ai/src/workflow-builder/parse-validate.ts
@@ -112,8 +112,15 @@ export function partitionWarnings(warnings: ValidationWarning[]): {
 	errors: ValidationWarning[];
 	informational: ValidationWarning[];
 } {
-	// Known informational-only codes (not blockers)
-	const informationalCodes = new Set(['MISSING_TRIGGER', 'DISCONNECTED_NODE']);
+	// Known informational-only codes (not blockers). Semantic checks whose
+	// "fix" is a business-policy decision the agent (or human) owns are
+	// surfaced as informational so the agent sees the guidance without
+	// having submit forcibly blocked on a design choice.
+	const informationalCodes = new Set([
+		'MISSING_TRIGGER',
+		'DISCONNECTED_NODE',
+		'MERGE_PARALLEL_BRANCHES_NO_ERROR_TOLERANCE',
+	]);
 
 	const errors: ValidationWarning[] = [];
 	const informational: ValidationWarning[] = [];

--- a/packages/@n8n/instance-ai/src/workflow-builder/semantic-checks.ts
+++ b/packages/@n8n/instance-ai/src/workflow-builder/semantic-checks.ts
@@ -90,7 +90,7 @@ function readResourceMapper(parameters: IDataObject | undefined): ResourceMapper
  *
  * Patterns are deliberately conservative: each one names a runtime
  * primitive that *cannot* be a stable identifier:
- *   - `$now` / `$today`               : DateTime evaluated per execution
+ *   - `$now`                          : DateTime evaluated per execution
  *   - `Date.now()` / `new Date(`      : JS clock primitives
  *   - `Math.random(`                  : random
  *   - `crypto.randomUUID(` / `uuid(` / `randomUUID(` : random
@@ -100,7 +100,6 @@ function readResourceMapper(parameters: IDataObject | undefined): ResourceMapper
  */
 const VOLATILE_EXPRESSION_PATTERNS: ReadonlyArray<{ pattern: RegExp; label: string }> = [
 	{ pattern: /\$now\b/, label: '$now' },
-	{ pattern: /\$today\b/, label: '$today' },
 	{ pattern: /\bDate\.now\s*\(/, label: 'Date.now()' },
 	// Only zero-arg `new Date()` is volatile. `new Date($json.createdAt)` /
 	// `new Date('2025-01-01')` are deterministic when their argument is stable,
@@ -493,14 +492,13 @@ function checkPostNonTriggerTriggerJsonRefs(workflow: WorkflowJSON): ValidationW
 		const ancestor = findFirstNonPassthroughAncestor(node.name, predecessors, nodeTypesByName);
 		if (!ancestor) continue; // No predecessor at all — this is the trigger fanout root.
 		if (isTriggerType(ancestor.type)) continue; // Directly after the trigger (modulo passthroughs).
-		// HTTP Request responses legitimately expose `$json.body` (and sometimes
-		// event-shaped payloads), so reading `$json.body.*` after an HTTP Request
-		// ancestor is correct, not a misplaced trigger reference. Skip to avoid
-		// blocking save on a valid pattern.
-		if (ancestor.type === 'n8n-nodes-base.httpRequest') continue;
+		const actionableRefs = refs.filter(
+			(ref) => !(ancestor.type === 'n8n-nodes-base.httpRequest' && ref.root === 'body'),
+		);
+		if (actionableRefs.length === 0) continue;
 
 		const triggerName = findClosestTriggerAncestor(node.name, predecessors, nodeTypesByName);
-		const sample = refs[0];
+		const sample = actionableRefs[0];
 		const suggestion = triggerName
 			? `Replace each $json.${sample.root}.\u2026 reference with $('${triggerName}').item.json.${sample.root}.\u2026 .`
 			: `Reference the trigger directly by name instead of $json (e.g. $('<Trigger Node Name>').item.json.${sample.root}.\u2026).`;

--- a/packages/@n8n/instance-ai/src/workflow-builder/semantic-checks.ts
+++ b/packages/@n8n/instance-ai/src/workflow-builder/semantic-checks.ts
@@ -1,0 +1,721 @@
+/**
+ * Semantic checks
+ *
+ * Defensive validators that surface known node-config patterns the builder
+ * regularly gets wrong but the Zod schema validator cannot catch. Each check
+ * targets a *concrete runtime failure* the agent already produces — the goal
+ * is to convert a downstream "Could not get parameter" / null reference into
+ * a blocking submit-time error the builder can self-correct.
+ *
+ * Rules:
+ *   - Only flag configurations that fail at runtime with high confidence.
+ *   - Surface the fix in the message, not just the diagnosis — the builder
+ *     consumes the text directly to plan the next patch.
+ *   - Never invent business logic. We do not, for example, force
+ *     `continueOnFail` on parallel branches — that is a design choice the
+ *     agent owns.
+ */
+
+import type { WorkflowJSON } from '@n8n/workflow-sdk';
+import type { IDataObject } from 'n8n-workflow';
+
+import type { ValidationWarning } from './types';
+
+interface NodeForCheck {
+	name?: string;
+	type: string;
+	parameters?: IDataObject;
+}
+
+function asRecord(value: unknown): IDataObject | undefined {
+	return typeof value === 'object' && value !== null && !Array.isArray(value)
+		? (value as IDataObject)
+		: undefined;
+}
+
+function readMatchingColumns(columns: IDataObject | undefined): string[] | undefined {
+	if (!columns) return undefined;
+	const raw = columns.matchingColumns;
+	if (!Array.isArray(raw)) return undefined;
+	const filtered = raw.filter(
+		(entry): entry is string => typeof entry === 'string' && entry.trim().length > 0,
+	);
+	return filtered.length > 0 ? filtered : undefined;
+}
+
+/**
+ * Resource-mapper-shaped parameters. n8n's "resource mapper" is the
+ * standardised UI for upsert/match-on operations across many nodes
+ * (Google Sheets, Postgres, Microsoft SQL, MongoDB, MySQL, Airtable,
+ * dataTable, Notion in some operations, etc.). The runtime contract is:
+ *   - `mappingMode` selects between `defineBelow` (explicit per-column
+ *     expressions in `value`) and `autoMapInputData` (top-level field
+ *     copy).
+ *   - `matchingColumns: string[]` names the columns used to identify
+ *     existing rows in upsert/update operations.
+ *   - `value: Record<string, unknown>` holds the per-column expression
+ *     (when `mappingMode === 'defineBelow'`).
+ *
+ * Detection here is structural — we look for the shape, not the node
+ * type — so the check generalises across all resource-mapper consumers
+ * without enumerating node types.
+ */
+interface ResourceMapperShape {
+	mappingMode?: unknown;
+	matchingColumns: string[];
+	value: IDataObject;
+}
+
+function readResourceMapper(parameters: IDataObject | undefined): ResourceMapperShape | undefined {
+	const columns = asRecord(parameters?.columns);
+	if (!columns) return undefined;
+	const matching = readMatchingColumns(columns);
+	if (!matching) return undefined;
+	const value = asRecord(columns.value);
+	if (!value) return undefined;
+	return { mappingMode: columns.mappingMode, matchingColumns: matching, value };
+}
+
+/**
+ * Volatile expressions that produce a *new* value every execution. When
+ * one of these appears in the expression for a matching/upsert key, the
+ * upsert can never match an existing row — every execution either fails
+ * with `Could not get parameter` (Google Sheets) or inserts a duplicate
+ * row (other resource-mapper consumers). The fix is always either to
+ * remove that column from `matchingColumns` (it can still appear in
+ * `value` as a written column) or to switch the operation to `append`
+ * / `insert`.
+ *
+ * Patterns are deliberately conservative: each one names a runtime
+ * primitive that *cannot* be a stable identifier:
+ *   - `$now` / `$today`               : DateTime evaluated per execution
+ *   - `Date.now()` / `new Date(`      : JS clock primitives
+ *   - `Math.random(`                  : random
+ *   - `crypto.randomUUID(` / `uuid(` / `randomUUID(` : random
+ *   - `crypto.randomBytes(`           : random
+ *   - `$execution.id`                 : per-execution id (never matches a prior row)
+ *   - `$itemIndex` / `$runIndex`      : per-item / per-run counters
+ */
+const VOLATILE_EXPRESSION_PATTERNS: ReadonlyArray<{ pattern: RegExp; label: string }> = [
+	{ pattern: /\$now\b/, label: '$now' },
+	{ pattern: /\$today\b/, label: '$today' },
+	{ pattern: /\bDate\.now\s*\(/, label: 'Date.now()' },
+	{ pattern: /\bnew\s+Date\s*\(/, label: 'new Date(...)' },
+	{ pattern: /\bMath\.random\s*\(/, label: 'Math.random()' },
+	{ pattern: /\b(?:crypto\.)?randomUUID\s*\(/, label: 'randomUUID()' },
+	{ pattern: /\bcrypto\.randomBytes\s*\(/, label: 'crypto.randomBytes(...)' },
+	{ pattern: /\buuid\s*\(/, label: 'uuid()' },
+	{ pattern: /\$execution\.id\b/, label: '$execution.id' },
+	{ pattern: /\$itemIndex\b/, label: '$itemIndex' },
+	{ pattern: /\$runIndex\b/, label: '$runIndex' },
+];
+
+function findVolatileExpression(expression: string): string | undefined {
+	if (!expression.startsWith('=')) return undefined;
+	for (const { pattern, label } of VOLATILE_EXPRESSION_PATTERNS) {
+		if (pattern.test(expression)) return label;
+	}
+	return undefined;
+}
+
+/**
+ * Generic across all resource-mapper-using node types: if any column
+ * named in `matchingColumns` resolves to a volatile expression in
+ * `value`, the upsert / update operation can never match a prior row.
+ * The same mechanism makes Google Sheets `appendOrUpdate` throw
+ * `Could not get parameter` mid-execution and silently duplicates rows
+ * on every other resource-mapper consumer.
+ *
+ * Detection is structural — we don't gate on node type — so this check
+ * fires uniformly on Google Sheets, Postgres, Microsoft SQL, MongoDB,
+ * MySQL, Airtable, dataTable, etc. once they use the resource-mapper
+ * `columns.matchingColumns` shape.
+ */
+function checkResourceMapperMatchingColumnDynamicValue(
+	node: NodeForCheck,
+): ValidationWarning | undefined {
+	const mapper = readResourceMapper(node.parameters);
+	if (!mapper) return undefined;
+
+	interface OffendingMatch {
+		column: string;
+		expression: string;
+		volatile: string;
+	}
+	const offending: OffendingMatch[] = [];
+	for (const column of mapper.matchingColumns) {
+		const raw = mapper.value[column];
+		if (typeof raw !== 'string') continue;
+		const volatile = findVolatileExpression(raw);
+		if (volatile) offending.push({ column, expression: raw, volatile });
+	}
+	if (offending.length === 0) return undefined;
+
+	const pairs = offending
+		.map((o) => `'${o.column}' = ${truncateForMessage(o.expression, 60)} (volatile: ${o.volatile})`)
+		.join('; ');
+
+	return {
+		code: 'RESOURCE_MAPPER_MATCHING_COLUMN_DYNAMIC_VALUE',
+		nodeName: node.name,
+		parameterPath: 'parameters.columns.matchingColumns',
+		message:
+			`Node "${node.name ?? '(unnamed)'}" (${node.type}) lists matching column(s) whose value is a volatile expression evaluated per-execution: ${pairs}. ` +
+			'A column used to identify an existing row in an upsert / update cannot be a fresh value every run — it will never match a prior row (and on Google Sheets it additionally throws "Could not get parameter" at runtime). ' +
+			'Either (a) remove the volatile column(s) from `matchingColumns` and keep them as written columns only, leaving a stable identifier (e.g. an `Email`, `id`, or external key) as the match key, or (b) switch the operation to a non-matching variant (`append` / `insert`) if duplicates are acceptable.',
+	};
+}
+
+const NODE_CHECKS: Array<(node: NodeForCheck) => ValidationWarning | undefined> = [
+	checkResourceMapperMatchingColumnDynamicValue,
+];
+
+// ── Graph-context checks ────────────────────────────────────────────────────
+
+/**
+ * `autoMapInputData` is the resource-mapper option that copies each
+ * top-level field of the upstream item into the same-named column on
+ * the destination. After a Webhook trigger the upstream item only
+ * carries the envelope keys `{ body, headers, query, params, webhookUrl,
+ * executionMode }` — the form/JSON payload is nested under `body` — so
+ * autoMapInputData populates only envelope keys and leaves the actual
+ * data columns empty.
+ *
+ * This mechanism is shape-agnostic: it bites every consumer of the
+ * shared resource-mapper UI (Google Sheets, Postgres, Microsoft SQL,
+ * MongoDB, MySQL, Airtable, dataTable, Notion in some operations, etc.).
+ * Detection is therefore structural — we don't gate on node type.
+ *
+ * Conditions (all must hold):
+ *   1. Node parameters have the resource-mapper shape with
+ *      `columns.mappingMode === 'autoMapInputData'`;
+ *   2. Walking back through passthrough predecessors lands on a
+ *      `n8n-nodes-base.webhook` node.
+ *
+ * Form Trigger / Chat Trigger / Telegram Trigger emit data at the top
+ * level (or under a different envelope) and are intentionally NOT flagged.
+ */
+function checkResourceMapperAutoMapAfterWebhook(workflow: WorkflowJSON): ValidationWarning[] {
+	const nodes = workflow.nodes ?? [];
+	if (nodes.length === 0) return [];
+
+	const predecessors = buildMainPredecessorMap(workflow);
+	const nodeTypesByName = new Map<string, string>();
+	for (const node of nodes) {
+		if (node.name && node.type) nodeTypesByName.set(node.name, node.type);
+	}
+
+	const issues: ValidationWarning[] = [];
+	for (const node of nodes) {
+		if (!node.name || !node.type) continue;
+		const columns = asRecord(node.parameters?.columns);
+		if (!columns) continue;
+		if (columns.mappingMode !== 'autoMapInputData') continue;
+
+		const ancestor = findFirstNonPassthroughAncestor(node.name, predecessors, nodeTypesByName);
+		if (!ancestor || ancestor.type !== 'n8n-nodes-base.webhook') continue;
+
+		const isGoogleSheets = node.type === 'n8n-nodes-base.googleSheets';
+		const code = isGoogleSheets
+			? 'GOOGLE_SHEETS_AUTOMAP_AFTER_WEBHOOK'
+			: 'RESOURCE_MAPPER_AUTOMAP_AFTER_WEBHOOK';
+
+		issues.push({
+			code,
+			nodeName: node.name,
+			parameterPath: 'parameters.columns.mappingMode',
+			message:
+				`Node "${node.name}" (${node.type}) uses mappingMode 'autoMapInputData', but its main input comes from the Webhook trigger "${ancestor.name}". ` +
+				'Webhook output wraps the form/JSON payload under `body` (top-level keys are body, headers, query, params, webhookUrl, executionMode), so autoMapInputData only populates those envelope keys and leaves the real data columns empty. ' +
+				`Switch to mappingMode 'defineBelow' with explicit per-column expressions referencing $('${ancestor.name}').item.json.body.<field>, or insert a Set node before "${node.name}" that flattens body into top-level fields.`,
+		});
+	}
+	return issues;
+}
+
+/**
+ * Top-level langchain root nodes whose main output is `{ output,
+ * intermediateSteps }`. Reported with an Agent/Chain-specific message so the
+ * agent gets the exact reason `$json.<trigger root>` resolves to `undefined`.
+ * Sub-nodes (memory, models, tools, embeddings, vector stores) attach via
+ * non-`main` outputs and never appear on the main ancestor chain.
+ */
+const LANGCHAIN_ROOT_TYPES: readonly string[] = [
+	'@n8n/n8n-nodes-langchain.agent',
+	'@n8n/n8n-nodes-langchain.chainLlm',
+	'@n8n/n8n-nodes-langchain.chainSummarization',
+	'@n8n/n8n-nodes-langchain.chainRetrievalQa',
+	'@n8n/n8n-nodes-langchain.informationExtractor',
+	'@n8n/n8n-nodes-langchain.textClassifier',
+	'@n8n/n8n-nodes-langchain.sentimentAnalysis',
+];
+
+function isLangchainRoot(nodeType: string): boolean {
+	return LANGCHAIN_ROOT_TYPES.includes(nodeType);
+}
+
+/**
+ * Node types that genuinely passthrough `$json` from input to output — a
+ * downstream `$json.<trigger root>` reference is still valid after them
+ * because they do not emit their own data shape. Deliberately conservative:
+ * Set, Code, Merge, SplitInBatches, SplitOut, and Aggregate are NOT here,
+ * because they reshape data in ways the agent often doesn't anticipate.
+ */
+const PASSTHROUGH_NODE_TYPES: ReadonlySet<string> = new Set([
+	'n8n-nodes-base.if',
+	'n8n-nodes-base.switch',
+	'n8n-nodes-base.filter',
+	'n8n-nodes-base.noOp',
+	'n8n-nodes-base.limit',
+	'n8n-nodes-base.removeDuplicates',
+	'n8n-nodes-base.sort',
+	'n8n-nodes-base.stopAndError',
+	'n8n-nodes-base.wait',
+]);
+
+function isPassthrough(nodeType: string): boolean {
+	return PASSTHROUGH_NODE_TYPES.has(nodeType);
+}
+
+function isTriggerType(nodeType: string): boolean {
+	return /Trigger$/i.test(nodeType) || nodeType.endsWith('.webhook');
+}
+
+/**
+ * Known trigger-payload roots that are commonly read via `$json.<root>` and
+ * that vanish after an agent/chain node clobbers `$json`. Matching is
+ * structural — the presence of one of these segments at the head of a
+ * `$json` path is a strong signal that the agent meant to reference the
+ * original trigger payload, not whatever the upstream `main` actually
+ * carries at evaluation time.
+ */
+const TRIGGER_JSON_PATH_ROOTS: readonly string[] = [
+	'message', // Telegram Trigger
+	'body', // Webhook
+	'chatInput', // Chat Trigger
+	'update', // Telegram raw update payload
+	'from', // chat-like trigger sender
+	'entry', // Slack / IG / FB event triggers
+	'event', // Generic event triggers
+];
+
+const TRIGGER_JSON_REFERENCE_REGEX = new RegExp(
+	`\\$json\\s*(?:\\.\\s*(${TRIGGER_JSON_PATH_ROOTS.join('|')})\\b|\\[\\s*['"](${TRIGGER_JSON_PATH_ROOTS.join('|')})['"]\\s*\\])`,
+);
+
+function firstTriggerJsonRoot(expression: string): string | undefined {
+	const match = TRIGGER_JSON_REFERENCE_REGEX.exec(expression);
+	if (!match) return undefined;
+	return match[1] ?? match[2];
+}
+
+/**
+ * Walk a parameter value tree and collect every expression string that
+ * references `$json.<known trigger root>`. n8n expression strings are
+ * leading-`=` strings; literal values are never evaluated.
+ */
+function collectTriggerJsonRefs(
+	value: unknown,
+	paramPath: string,
+	out: Array<{ paramPath: string; expression: string; root: string }>,
+): void {
+	if (typeof value === 'string') {
+		if (!value.startsWith('=')) return;
+		const root = firstTriggerJsonRoot(value);
+		if (root) out.push({ paramPath, expression: value, root });
+		return;
+	}
+	if (Array.isArray(value)) {
+		for (let i = 0; i < value.length; i++) {
+			collectTriggerJsonRefs(value[i], `${paramPath}[${String(i)}]`, out);
+		}
+		return;
+	}
+	if (value && typeof value === 'object') {
+		for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+			const nextPath = paramPath ? `${paramPath}.${key}` : key;
+			collectTriggerJsonRefs(child, nextPath, out);
+		}
+	}
+}
+
+/**
+ * Build a `dest -> sources` map for the `main` connection type only. Non-main
+ * connections (ai_memory, ai_languageModel, ai_tool, ai_embedding, etc.) are
+ * deliberately ignored — they are sub-node attachments and do not
+ * participate in the data-flow `$json` ancestry chain.
+ */
+function buildMainPredecessorMap(workflow: WorkflowJSON): Map<string, Set<string>> {
+	const out = new Map<string, Set<string>>();
+	const connections = workflow.connections;
+	if (!connections || typeof connections !== 'object') return out;
+	for (const [sourceName, byType] of Object.entries(connections)) {
+		if (!byType || typeof byType !== 'object') continue;
+		const mainOutputs = (byType as Record<string, unknown>).main;
+		if (!Array.isArray(mainOutputs)) continue;
+		for (const targetList of mainOutputs) {
+			if (!Array.isArray(targetList)) continue;
+			for (const target of targetList) {
+				if (!target || typeof target !== 'object') continue;
+				const destName = (target as { node?: unknown }).node;
+				const destType = (target as { type?: unknown }).type;
+				if (typeof destName !== 'string') continue;
+				if (typeof destType === 'string' && destType !== 'main') continue;
+				let sources = out.get(destName);
+				if (!sources) {
+					sources = new Set();
+					out.set(destName, sources);
+				}
+				sources.add(sourceName);
+			}
+		}
+	}
+	return out;
+}
+
+/**
+ * Walk back from `nodeName` through passthrough predecessors. Returns the
+ * first non-passthrough ancestor (the node whose output actually feeds the
+ * starting node's `$json`), or undefined if the chain hits a graph root
+ * without finding one. Triggers count as non-passthrough — they are the
+ * legitimate source of trigger-shaped `$json`.
+ */
+function findFirstNonPassthroughAncestor(
+	nodeName: string,
+	predecessors: Map<string, Set<string>>,
+	nodeTypesByName: Map<string, string>,
+): { name: string; type: string } | undefined {
+	const visited = new Set<string>();
+	const queue: string[] = [];
+	for (const src of predecessors.get(nodeName) ?? []) queue.push(src);
+	while (queue.length > 0) {
+		const current = queue.shift();
+		if (!current || visited.has(current)) continue;
+		visited.add(current);
+		const currentType = nodeTypesByName.get(current) ?? '';
+		if (!isPassthrough(currentType)) {
+			return { name: current, type: currentType };
+		}
+		for (const upstream of predecessors.get(current) ?? []) {
+			if (!visited.has(upstream)) queue.push(upstream);
+		}
+	}
+	return undefined;
+}
+
+/**
+ * Find the closest trigger ancestor on the `main` chain leading into
+ * `nodeName`. A trigger is a node whose type ends with `Trigger`, or one
+ * that lives at the root of the connection graph (no main predecessors).
+ * Used to produce the explicit `$('<TriggerName>').item.json.<…>` fix.
+ */
+function findClosestTriggerAncestor(
+	nodeName: string,
+	predecessors: Map<string, Set<string>>,
+	nodeTypesByName: Map<string, string>,
+): string | undefined {
+	const visited = new Set<string>();
+	const queue: string[] = [];
+	let fallbackRoot: string | undefined;
+	for (const src of predecessors.get(nodeName) ?? []) queue.push(src);
+	while (queue.length > 0) {
+		const current = queue.shift();
+		if (!current || visited.has(current)) continue;
+		visited.add(current);
+		const type = nodeTypesByName.get(current) ?? '';
+		const isTrigger = /Trigger$/i.test(type) || type.endsWith('.webhook');
+		if (isTrigger) return current;
+		const upstreams = predecessors.get(current);
+		if (!upstreams || upstreams.size === 0) fallbackRoot = current;
+		else for (const upstream of upstreams) if (!visited.has(upstream)) queue.push(upstream);
+	}
+	return fallbackRoot;
+}
+
+function truncateForMessage(value: string, maxChars = 80): string {
+	if (value.length <= maxChars) return value;
+	return `${value.slice(0, maxChars)}\u2026`;
+}
+
+/**
+ * Detect trigger-data `$json` references that no longer point at the
+ * trigger because an intermediate node has clobbered `$json` on the main
+ * chain. Two failure modes share this root cause:
+ *
+ *   - Post-agent: Agent/Chain root emits `{ output, intermediateSteps }`
+ *     and the downstream node still reads `$json.message.*` /
+ *     `$json.body.*` / `$json.chatInput`. (telegram-chatbot scenario)
+ *   - Post-action: Webhook → Gmail → Telegram → Sheets, where each
+ *     action emits its own API response and the downstream node still
+ *     reads `$json.body.<field>`. (contact-form scenario)
+ *
+ * Both silently resolve to `undefined` at runtime. The fix is the same:
+ *   `$('<TriggerName>').item.json.<root>.\u2026`
+ * which is stable regardless of the upstream main chain.
+ *
+ * Match conditions:
+ *   1. Node is NOT itself a langchain root or a trigger — those
+ *      legitimately read `$json` from their own input / config;
+ *   2. Walking back through passthrough predecessors (IF/Switch/Filter/
+ *      NoOp/Limit/Sort/RemoveDuplicates/StopAndError/Wait) does not land
+ *      on a trigger; instead it lands on a clobbering node;
+ *   3. Node parameters contain an expression string referencing
+ *      `$json.<known trigger root>`.
+ *
+ * When the clobbering ancestor is a langchain root the message names
+ * the Agent-specific output shape, otherwise it uses a generic message.
+ */
+function checkPostNonTriggerTriggerJsonRefs(workflow: WorkflowJSON): ValidationWarning[] {
+	const nodes = workflow.nodes ?? [];
+	if (nodes.length === 0) return [];
+
+	const predecessors = buildMainPredecessorMap(workflow);
+	const nodeTypesByName = new Map<string, string>();
+	for (const node of nodes) {
+		if (node.name && node.type) nodeTypesByName.set(node.name, node.type);
+	}
+
+	const issues: ValidationWarning[] = [];
+	for (const node of nodes) {
+		if (!node.name || !node.type) continue;
+		if (isLangchainRoot(node.type)) continue;
+		if (isTriggerType(node.type)) continue;
+
+		const refs: Array<{ paramPath: string; expression: string; root: string }> = [];
+		collectTriggerJsonRefs(node.parameters, '', refs);
+		if (refs.length === 0) continue;
+
+		const ancestor = findFirstNonPassthroughAncestor(node.name, predecessors, nodeTypesByName);
+		if (!ancestor) continue; // No predecessor at all — this is the trigger fanout root.
+		if (isTriggerType(ancestor.type)) continue; // Directly after the trigger (modulo passthroughs).
+
+		const triggerName = findClosestTriggerAncestor(node.name, predecessors, nodeTypesByName);
+		const sample = refs[0];
+		const suggestion = triggerName
+			? `Replace each $json.${sample.root}.\u2026 reference with $('${triggerName}').item.json.${sample.root}.\u2026 .`
+			: `Reference the trigger directly by name instead of $json (e.g. $('<Trigger Node Name>').item.json.${sample.root}.\u2026).`;
+
+		const clobberExplanation = isLangchainRoot(ancestor.type)
+			? `Agent/chain nodes emit { output, intermediateSteps } on main output, so $json.${sample.root} resolves to undefined at runtime.`
+			: `Every n8n node emits its own data on main output — after "${ancestor.name}" (${ancestor.type}) runs, $json is that node's response, not the trigger payload, so $json.${sample.root} resolves to undefined at runtime.`;
+
+		const messageParts = [
+			`Node "${node.name}" reads $json.${sample.root} (parameter ${sample.paramPath || 'parameters'}: ${truncateForMessage(sample.expression)}),`,
+			`but its main-input chain runs through "${ancestor.name}" (${ancestor.type}).`,
+			clobberExplanation,
+			suggestion,
+		];
+		issues.push({
+			code: isLangchainRoot(ancestor.type)
+				? 'TRIGGER_JSON_REF_AFTER_AGENT'
+				: 'TRIGGER_JSON_REF_AFTER_NON_TRIGGER',
+			nodeName: node.name,
+			parameterPath: sample.paramPath,
+			message: messageParts.join(' '),
+		});
+	}
+	return issues;
+}
+
+// ── Parallel-branches-before-Merge resilience check ──────────────────────────
+
+/**
+ * Node types that are NOT data-shaped external-API actions: control flow,
+ * utility shaping, triggers, merge, and langchain roots/sub-nodes.
+ *
+ * Everything else is treated as "a node that calls an external system and
+ * can therefore fail at runtime" — Gmail, Telegram, Slack, Google Sheets,
+ * Notion, Airtable, Microsoft Teams, httpRequest, sendGrid, mailgun,
+ * postgres, mysql, mongoDb, etc.
+ *
+ * The intent of the list is structural: anything that the agent typically
+ * fans-out across parallel branches to satisfy a multi-action requirement
+ * is counted as an action; anything used as plumbing is not.
+ */
+const NON_ACTION_NODE_TYPES: ReadonlySet<string> = new Set([
+	'n8n-nodes-base.set',
+	'n8n-nodes-base.code',
+	'n8n-nodes-base.function',
+	'n8n-nodes-base.functionItem',
+	'n8n-nodes-base.merge',
+	'n8n-nodes-base.if',
+	'n8n-nodes-base.switch',
+	'n8n-nodes-base.filter',
+	'n8n-nodes-base.noOp',
+	'n8n-nodes-base.limit',
+	'n8n-nodes-base.removeDuplicates',
+	'n8n-nodes-base.sort',
+	'n8n-nodes-base.stopAndError',
+	'n8n-nodes-base.wait',
+	'n8n-nodes-base.splitInBatches',
+	'n8n-nodes-base.splitOut',
+	'n8n-nodes-base.itemLists',
+	'n8n-nodes-base.aggregate',
+	'n8n-nodes-base.dateTime',
+	'n8n-nodes-base.respondToWebhook',
+	'n8n-nodes-base.executeWorkflow',
+	'n8n-nodes-base.errorTrigger',
+]);
+
+function isActionNode(type: string): boolean {
+	if (NON_ACTION_NODE_TYPES.has(type)) return false;
+	if (isPassthrough(type)) return false;
+	if (isTriggerType(type)) return false;
+	if (isLangchainRoot(type)) return false;
+	if (type.startsWith('@n8n/n8n-nodes-langchain.')) return false;
+	return true;
+}
+
+/**
+ * onError value that makes a node's failure non-fatal for the rest of the
+ * workflow: either route the error onto a separate pin (`continueErrorOutput`)
+ * or emit empty main output (`continueRegularOutput`). Both keep downstream
+ * branches alive; the default `stopWorkflow` does not.
+ */
+function nodeToleratesFailure(node: { onError?: unknown }): boolean {
+	return node.onError === 'continueRegularOutput' || node.onError === 'continueErrorOutput';
+}
+
+/**
+ * Collect every action-node ancestor (main chain only) of `startName`
+ * walking back through predecessors. Stops at triggers and at langchain
+ * roots. Returns `{ name, type, onErrorOk }` entries for every action node
+ * encountered. Used per-branch-of-merge.
+ */
+function collectActionAncestors(
+	startName: string,
+	predecessors: Map<string, Set<string>>,
+	nodesByName: Map<string, { type: string; onError?: unknown }>,
+): Array<{ name: string; type: string; onErrorOk: boolean }> {
+	const seen = new Set<string>();
+	const result: Array<{ name: string; type: string; onErrorOk: boolean }> = [];
+	const queue: string[] = [startName];
+	while (queue.length > 0) {
+		const current = queue.shift();
+		if (!current || seen.has(current)) continue;
+		seen.add(current);
+		const meta = nodesByName.get(current);
+		if (!meta) continue;
+		if (isTriggerType(meta.type)) continue; // do not cross triggers
+		if (isLangchainRoot(meta.type)) continue; // langchain root terminates the data chain
+		if (isActionNode(meta.type)) {
+			result.push({
+				name: current,
+				type: meta.type,
+				onErrorOk: nodeToleratesFailure(meta),
+			});
+		}
+		for (const up of predecessors.get(current) ?? []) {
+			if (!seen.has(up)) queue.push(up);
+		}
+	}
+	return result;
+}
+
+/**
+ * When the agent builds parallel-fan-out -> Merge to combine results of
+ * several external-API actions, n8n's default per-node behavior
+ * (`onError: 'stopWorkflow'`) means any single branch failure halts the
+ * entire workflow before the Merge ever runs. The Merge node sitting in
+ * the graph is the structural signal that the agent intends all branches
+ * to contribute — so the absence of `onError` on any failable action node
+ * upstream of the Merge is almost always a bug.
+ *
+ * Conditions (all must hold to flag):
+ *   1. Merge node (`n8n-nodes-base.merge`) is present.
+ *   2. It has ≥ 2 distinct `main` input branches.
+ *   3. Each branch traced back to the trigger contains at least one action
+ *      node (external-API surface).
+ *   4. ≥ 2 of those branches have NO action node with onError set to
+ *      `continueRegularOutput` or `continueErrorOutput`.
+ *
+ * Recovery path is concrete and uniform: set `onError:
+ * 'continueRegularOutput'` on the action node(s) that can legitimately
+ * fail. Adding this is harmless when the node never fails in practice
+ * (output passes through unchanged) and is the only thing standing
+ * between the workflow and merge-starvation when any branch fails.
+ */
+function checkMergeBranchesNoErrorTolerance(workflow: WorkflowJSON): ValidationWarning[] {
+	const nodes = workflow.nodes ?? [];
+	if (nodes.length === 0) return [];
+
+	const predecessors = buildMainPredecessorMap(workflow);
+	const nodesByName = new Map<string, { type: string; onError?: unknown }>();
+	for (const n of nodes) {
+		if (n.name && n.type) nodesByName.set(n.name, { type: n.type, onError: n.onError });
+	}
+
+	const issues: ValidationWarning[] = [];
+	for (const mergeNode of nodes) {
+		if (!mergeNode.name || mergeNode.type !== 'n8n-nodes-base.merge') continue;
+		const mergeInputs = predecessors.get(mergeNode.name);
+		if (!mergeInputs || mergeInputs.size < 2) continue;
+
+		interface BranchSummary {
+			input: string;
+			actionNodes: Array<{ name: string; type: string; onErrorOk: boolean }>;
+		}
+		const branches: BranchSummary[] = [];
+		for (const input of mergeInputs) {
+			const actionNodes = collectActionAncestors(input, predecessors, nodesByName);
+			if (actionNodes.length > 0) branches.push({ input, actionNodes });
+		}
+
+		const exposedBranches = branches.filter((b) => b.actionNodes.every((a) => !a.onErrorOk));
+		if (branches.length < 2 || exposedBranches.length < 2) continue;
+
+		const nameList = exposedBranches
+			.map(
+				(b) =>
+					`branch ending at "${b.input}" with action node(s) ${b.actionNodes
+						.map((a) => `${a.name} (${a.type})`)
+						.join(', ')}`,
+			)
+			.join('; ');
+
+		issues.push({
+			code: 'MERGE_PARALLEL_BRANCHES_NO_ERROR_TOLERANCE',
+			nodeName: mergeNode.name,
+			parameterPath: 'onError',
+			message:
+				`Merge node "${mergeNode.name}" has ${branches.length} parallel input branches, but ${exposedBranches.length} of them contain external-API action nodes without any onError tolerance configured: ${nameList}. ` +
+				"With n8n's default `onError: 'stopWorkflow'`, any single branch failure aborts the entire workflow before " +
+				`"${mergeNode.name}" can run, so the parallel structure offers no resilience. ` +
+				"Set `onError: 'continueRegularOutput'` (or `'continueErrorOutput'` if you want the failure routed onto a dedicated pin) on the action node(s) above that can legitimately fail. " +
+				'This is harmless when the node succeeds (output passes through unchanged) and is required for the Merge to receive partial results when one branch errors.',
+		});
+	}
+	return issues;
+}
+
+const GRAPH_CHECKS: Array<(workflow: WorkflowJSON) => ValidationWarning[]> = [
+	checkPostNonTriggerTriggerJsonRefs,
+	checkResourceMapperAutoMapAfterWebhook,
+	checkMergeBranchesNoErrorTolerance,
+];
+
+/**
+ * Run all semantic checks on a workflow. Returns one or more
+ * `ValidationWarning`s that are treated as blocking errors by
+ * `partitionWarnings`.
+ */
+export function checkSemanticIssues(workflow: WorkflowJSON): ValidationWarning[] {
+	const issues: ValidationWarning[] = [];
+	for (const node of workflow.nodes ?? []) {
+		const nodeForCheck: NodeForCheck = {
+			name: node.name,
+			type: node.type,
+			parameters: node.parameters,
+		};
+		for (const check of NODE_CHECKS) {
+			const issue = check(nodeForCheck);
+			if (issue) issues.push(issue);
+		}
+	}
+	for (const check of GRAPH_CHECKS) {
+		for (const issue of check(workflow)) {
+			issues.push(issue);
+		}
+	}
+	return issues;
+}

--- a/packages/@n8n/instance-ai/src/workflow-builder/semantic-checks.ts
+++ b/packages/@n8n/instance-ai/src/workflow-builder/semantic-checks.ts
@@ -11,9 +11,11 @@
  *   - Only flag configurations that fail at runtime with high confidence.
  *   - Surface the fix in the message, not just the diagnosis — the builder
  *     consumes the text directly to plan the next patch.
- *   - Never invent business logic. We do not, for example, force
- *     `continueOnFail` on parallel branches — that is a design choice the
- *     agent owns.
+ *   - Never *blockingly* invent business logic. When a check encodes a
+ *     design choice the agent or human owns (e.g. fan-in / fail-fast
+ *     resilience policy on parallel Merge branches), register its code in
+ *     `informationalCodes` inside `parse-validate.ts` so submit succeeds
+ *     and the guidance is surfaced as a warning rather than an error.
  */
 
 import type { WorkflowJSON } from '@n8n/workflow-sdk';
@@ -100,7 +102,10 @@ const VOLATILE_EXPRESSION_PATTERNS: ReadonlyArray<{ pattern: RegExp; label: stri
 	{ pattern: /\$now\b/, label: '$now' },
 	{ pattern: /\$today\b/, label: '$today' },
 	{ pattern: /\bDate\.now\s*\(/, label: 'Date.now()' },
-	{ pattern: /\bnew\s+Date\s*\(/, label: 'new Date(...)' },
+	// Only zero-arg `new Date()` is volatile. `new Date($json.createdAt)` /
+	// `new Date('2025-01-01')` are deterministic when their argument is stable,
+	// and `new Date(input).toISOString()` is a common, valid normalization.
+	{ pattern: /\bnew\s+Date\s*\(\s*\)/, label: 'new Date()' },
 	{ pattern: /\bMath\.random\s*\(/, label: 'Math.random()' },
 	{ pattern: /\b(?:crypto\.)?randomUUID\s*\(/, label: 'randomUUID()' },
 	{ pattern: /\bcrypto\.randomBytes\s*\(/, label: 'crypto.randomBytes(...)' },
@@ -488,6 +493,11 @@ function checkPostNonTriggerTriggerJsonRefs(workflow: WorkflowJSON): ValidationW
 		const ancestor = findFirstNonPassthroughAncestor(node.name, predecessors, nodeTypesByName);
 		if (!ancestor) continue; // No predecessor at all — this is the trigger fanout root.
 		if (isTriggerType(ancestor.type)) continue; // Directly after the trigger (modulo passthroughs).
+		// HTTP Request responses legitimately expose `$json.body` (and sometimes
+		// event-shaped payloads), so reading `$json.body.*` after an HTTP Request
+		// ancestor is correct, not a misplaced trigger reference. Skip to avoid
+		// blocking save on a valid pattern.
+		if (ancestor.type === 'n8n-nodes-base.httpRequest') continue;
 
 		const triggerName = findClosestTriggerAncestor(node.name, predecessors, nodeTypesByName);
 		const sample = refs[0];

--- a/packages/nodes-base/nodes/Code/Code.node.ts
+++ b/packages/nodes-base/nodes/Code/Code.node.ts
@@ -45,7 +45,7 @@ export class Code implements INodeType {
 		outputs: [NodeConnectionTypes.Main],
 		builderHint: {
 			searchHint:
-				"Use Code node as a LAST RESORT — it runs in a sandboxed environment and is slower than native nodes. Code node is ONLY appropriate for complex multi-step algorithms that cannot be expressed in single expressions, or operations requiring complex data structures. The Code-node runtime exposes only n8n-provided globals ($input, $json, $node, $workflow, $execution, $now, $today, $vars, $env, $items, $itemIndex, $runIndex, $position, $jmespath, $if). There is NO $dataTables / $tables / $db / $database global — for n8n Data Table access use the dedicated 'n8n-nodes-base.dataTable' node instead.",
+				"Use Code node as a LAST RESORT — it runs in a sandboxed environment and is slower than native nodes. Code node is ONLY appropriate for complex multi-step algorithms that cannot be expressed in single expressions, or operations requiring complex data structures. The Code-node runtime exposes only n8n-provided globals ($input, $json, $node, $workflow, $execution, $now, $today, $vars, $env, $items, $itemIndex, $runIndex, $position, $jmespath). There is NO $dataTables / $tables / $db / $database global — for n8n Data Table access use the dedicated 'n8n-nodes-base.dataTable' node instead.",
 			relatedNodes: [
 				{
 					nodeType: 'n8n-nodes-base.dataTable',

--- a/packages/nodes-base/nodes/Code/Code.node.ts
+++ b/packages/nodes-base/nodes/Code/Code.node.ts
@@ -45,8 +45,13 @@ export class Code implements INodeType {
 		outputs: [NodeConnectionTypes.Main],
 		builderHint: {
 			searchHint:
-				'Use Code node as a LAST RESORT — it runs in a sandboxed environment and is slower than native nodes. Code node is ONLY appropriate for complex multi-step algorithms that cannot be expressed in single expressions, or operations requiring complex data structures.',
+				"Use Code node as a LAST RESORT — it runs in a sandboxed environment and is slower than native nodes. Code node is ONLY appropriate for complex multi-step algorithms that cannot be expressed in single expressions, or operations requiring complex data structures. The Code-node runtime exposes only n8n-provided globals ($input, $json, $node, $workflow, $execution, $now, $today, $vars, $env, $items, $itemIndex, $runIndex, $position, $jmespath, $if). There is NO $dataTables / $tables / $db / $database global — for n8n Data Table access use the dedicated 'n8n-nodes-base.dataTable' node instead.",
 			relatedNodes: [
+				{
+					nodeType: 'n8n-nodes-base.dataTable',
+					relationHint:
+						'Use this instead to read or write n8n Data Tables — there is no $dataTables/$db global in the Code-node runtime',
+				},
 				{
 					nodeType: 'n8n-nodes-base.set',
 					relationHint:

--- a/packages/nodes-base/nodes/DataTable/common/fields.ts
+++ b/packages/nodes-base/nodes/DataTable/common/fields.ts
@@ -18,7 +18,10 @@ export const DATA_TABLE_RESOURCE_LOCATOR_BASE = {
 	type: 'resourceLocator',
 	default: { mode: 'list', value: '' },
 	required: true,
-	builderHint: { propertyHint: "Default to mode: 'list' which is easier for users to set up" },
+	builderHint: {
+		propertyHint:
+			"Default to mode: 'list' which is easier for users to set up. The referenced table must already exist in the n8n instance — row operations do NOT auto-create it. If the workflow is meant to be self-contained, add a Data Table node with `resource: 'table', operation: 'create', name: '<same name>'` earlier in the workflow; otherwise the runtime throws `Could not find the data table: '<name>'`.",
+	},
 	modes: [
 		{
 			displayName: 'From List',

--- a/packages/nodes-base/nodes/DataTable/common/fields.ts
+++ b/packages/nodes-base/nodes/DataTable/common/fields.ts
@@ -20,7 +20,7 @@ export const DATA_TABLE_RESOURCE_LOCATOR_BASE = {
 	required: true,
 	builderHint: {
 		propertyHint:
-			"Default to mode: 'list' which is easier for users to set up. The referenced table must already exist in the n8n instance — row operations do NOT auto-create it. If the workflow is meant to be self-contained, add a Data Table node with `resource: 'table', operation: 'create', name: '<same name>'` earlier in the workflow; otherwise the runtime throws `Could not find the data table: '<name>'`.",
+			"Default to mode: 'list' which is easier for users to set up. The referenced table must already exist in the n8n instance — row operations do NOT auto-create it. If the workflow is meant to be self-contained, add a Data Table node earlier in the workflow with `resource: 'table', operation: 'create', tableName: '<same name>', columns: { column: [{ name: '<col>', type: 'string'|'number'|'boolean'|'date' }, …] }, options: { createIfNotExists: true }` so re-runs are idempotent; otherwise the runtime throws `Could not find the data table: '<name>'`.",
 	},
 	modes: [
 		{


### PR DESCRIPTION
## Summary

Two complementary changes for n8n Instance AI workflow-builder reliability, derived from an autoresearch optimisation loop run against the Instance AI golden eval suite (20+5 paid runs in session 1, 14 in session 2). Both target concrete, mechanism-attested failure modes the agent reproduces — not heuristics or prompt hacks.

**Commit 1 — `feat(instance-ai): Add graph semantic checks for builder validation`**
Four defensive validators wired into `parse-validate.ts` (eval hot path) and `submit-workflow.tool.ts` (UI submit path). Each converts a downstream runtime failure (`Could not get parameter` / `undefined` / merge-starvation) into a blocking submit-time error with an actionable recovery message.

**Commit 2 — `feat(Code, DataTable Node): Add builder hints surfacing common builder mistakes`**
Two `builderHint` extensions on tool-discoverable surfaces — steers the agent away from the Code-node-invented-`\$dataTables`-global pattern and the DataTable-write-without-create pattern before generation. Sheets `matchingColumns` split hint already landed in #30546.

## What the validators catch

All four are structural over the workflow graph (or generic resource-mapper shape) — applied uniformly across node types via non-action allow-lists, not type enumeration. New external-API node types get caught automatically.

| Code | Mechanism (what fails at runtime) | Detection |
|---|---|---|
| `TRIGGER_JSON_REF_AFTER_NON_TRIGGER` / `_AFTER_AGENT` | Every n8n node clobbers \`\$json\` on its main output. After Gmail / an AI Agent / etc., \`\$json.message.chat.id\` or \`\$json.body.X\` silently resolves to \`undefined\`. | Walks back through passthrough predecessors (IF/Switch/Filter/NoOp/Limit/Sort/RemoveDuplicates/StopAndError/Wait) — if it lands on a non-trigger ancestor, flag. Suggests \`\$('<Trigger>').item.json.<root>.…\`. |
| `RESOURCE_MAPPER_AUTOMAP_AFTER_WEBHOOK` / `GOOGLE_SHEETS_AUTOMAP_AFTER_WEBHOOK` | \`autoMapInputData\` copies top-level upstream fields onto same-named columns. After a Webhook trigger the top-level fields are envelope keys (\`body\`, \`headers\`, \`query\`, …); the form/JSON payload is nested under \`.body\`. AutoMap silently writes only envelope keys. | Resource-mapper shape with \`mappingMode === 'autoMapInputData'\` AND first non-passthrough ancestor is \`n8n-nodes-base.webhook\`. Form/Chat/Telegram triggers (top-level payloads) are NOT flagged. |
| `MERGE_PARALLEL_BRANCHES_NO_ERROR_TOLERANCE` | \`trigger → 2+ parallel action branches → Merge\` with default \`onError: 'stopWorkflow'\` — the first branch failure aborts the entire workflow before the Merge runs, so the parallel structure offers no resilience. | Merge with ≥2 main inputs AND ≥2 input branches contain action nodes (defined via a non-action allow-list: Set/Code/Function/Merge/IF/Switch/Filter/NoOp/Limit/RemoveDuplicates/Sort/StopAndError/Wait/SplitInBatches/SplitOut/ItemLists/Aggregate/DateTime/RespondToWebhook/ExecuteWorkflow/ErrorTrigger) lacking \`onError: 'continueRegularOutput'\| 'continueErrorOutput'\`. |
| `RESOURCE_MAPPER_MATCHING_COLUMN_DYNAMIC_VALUE` | A column listed in \`matchingColumns\` whose value is a volatile expression (\`\$now\`, \`\$today\`, \`Date.now()\`, \`new Date(…)\`, \`Math.random()\`, \`randomUUID()\`, \`uuid()\`, \`crypto.randomBytes()\`, \`\$execution.id\`, \`\$itemIndex\`, \`\$runIndex\`). Upsert can never match a prior row; Google Sheets additionally throws \`Could not get parameter\` mid-execution. | Generic across any node with the \`columns.{mappingMode, matchingColumns, value}\` resource-mapper shape (Sheets, Postgres, MS-SQL, MongoDB, MySQL, Airtable, dataTable, etc.). |

## What the hints catch (validator-equivalent, surfaced earlier)

| Hint location | Steers agent away from |
|---|---|
| `Code.node.ts` `searchHint` + `relatedNodes` → \`n8n-nodes-base.dataTable\` | Inventing \`\$dataTables\`/\`\$tables\`/\`\$db\`/\`\$database\` globals — none exist in the Code-node runtime. Throws \`<ident> is not defined\` at execution. |
| `DataTable/common/fields.ts` `dataTableId.builderHint.propertyHint` | Row-op nodes against tables that don't exist in the n8n instance. Suggests adding a sibling \`resource: 'table', operation: 'create'\` node for self-contained workflows. |

## Autoresearch methodology

Setup: a worktree on its own branch + an autoresearch script that runs the Instance AI golden eval (6 cases × 5 iters = 30 trials/run) on each candidate change, with per-iteration auto-revert if checks fail.

Cycle per iteration:
1. **Hypothesis** — pick a mechanism-justified, falsifiable, narrow candidate (planner → tool-side → validator > prompt rewrites).
2. **Implement** — narrow diff, add unit tests with negative-case guards.
3. **Local checks** — \`pnpm typecheck && pnpm lint && pnpm test\` on the affected package.
4. **Rebuild + restart** n8n with reset DB.
5. **Run eval** — \`pnpm eval:instance-ai\` filtered to the golden suite at 5 iters, concurrency 8, 900s timeout.
6. **Backpressure** — \`autoresearch.checks.sh\` runs typecheck + lint on all changed packages after each passing benchmark.
7. **Decision** — \`keep\` (auto-commit, becomes new best) or \`discard\`/\`crash\`/\`checks_failed\` (auto-revert source).
8. **Confirmation** — same-commit re-run before any aggregate claim.

Key methodology lessons applied in this PR:

- **\`pass@K\` over \`pass_hat_K\`** as the primary metric at small N. The \`(c/n)^k\` exponent makes \`pass_hat_K\` noise-dominated at K=5 (~16pp same-state std on 6-case suite); \`pass@K\` has ~5–10pp std. Single-run claims tell you nothing below that band.
- **Per-scenario mechanism evidence is the trustworthy unit.** When the eval verifier root-cause names the exact failure your check targets and the scenario flips to passing in subsequent runs, that's a defensible win independent of aggregate noise.
- **Validators must encode a concrete recovery path** in the message, not just a diagnosis. A discarded \`PARAMETER_CONTAINS_PLACEHOLDER_MARKER\` check made evals regress because \"replace with a real value\" was read by the agent as \"remove the value\" — so the kept validators each name explicit fix paths (\`switch to append\`, \`set onError: 'continueRegularOutput'\`, \`use \$('<Trigger>').item.json.<root>\`).
- **Generality via shape, not type list.** The Merge-onError check and the resource-mapper checks pick up new external-API node types automatically because detection reads the graph/parameter shape, not a hardcoded enumeration.
- **Discarded experiments along the way** (validators that didn't survive: Notion-name-heuristic, suggested-nodes-data prompt-padding, placeholder-marker, dataTable live-state name lookup) — documented in \`autoresearch.ideas.md\` with the lesson each one taught.

## Eval evidence (golden suite, 5-iter, 6 same-state runs at autoresearch HEAD)

Comparing against the no-validators baseline:

| Aggregate | Baseline | This PR (mean of 6 runs) | Δ |
|---|---:|---:|---:|
| **\`pass@5\`** (primary) | 80.00 | **91.11 ± 10pp** | **+11.1pp** |
| \`pass_hat_5\` | 6.64 | 2.17 ± 1.5pp | not comparable at K=5 (see methodology) |

Per test case (6-run means):

| Case | Baseline trial passes | This PR (mean) | Δ |
|---|---:|---:|---:|
| **\`contact-form-automation\`** (25 trials) | 3 | **11.7** | **+8.7** (headline) |
| \`workflow-data-table\` (5) | 0 | **1.0** | **+1.0** — first non-zero in entire loop |
| \`rest-api-data-pipeline\` (15) | 3 | 5.7 | +2.7 |
| \`telegram-chatbot-memory-session\` (5) | 1 | 1.8 | +0.8 |
| \`github-notion-sync\` (10) | 3 | 3.0 | 0 |
| \`notification-router\` (15) | 12 | 8.7 | −3.3 (variance — uses Switch not Merge, validators don't fire) |

Per-validator mechanism attribution:

- **MERGE_PARALLEL_BRANCHES_NO_ERROR_TOLERANCE** — the biggest single mechanism win. Contact-form \`partial-action-failure\` and \`invalid-email\` were **0/5 across ~21 prior runs in the loop**; both went to 1/5 immediately after this landed, confirmed in subsequent runs. First passes ever for those scenarios.
- **TRIGGER_JSON_REF_AFTER_NON_TRIGGER / _AFTER_AGENT** — telegram-chatbot 0/3 → ~2.3/3 mean across 3 same-commit runs.
- **RESOURCE_MAPPER_MATCHING_COLUMN_DYNAMIC_VALUE** — contact-form 3/25 → 6/25 in first measured run; 3 scenarios went 1 → 2 passes (targets the \`Timestamp = \$now.toISO()\` in matchingColumns pattern).
- **RESOURCE_MAPPER_AUTOMAP_AFTER_WEBHOOK** — contributes to the contact-form lift; concrete failure documented in \`happy-path\` iter 3 verifier output.
- **Code-node \`\$dataTables\` hint** — as a validator, moved workflow-data-table happy-path from 0/3 → up to 3/3 (run #17), unstuck the invented-global failure mode.
- **DataTable write-without-create hint** — as an informational validator, moved workflow-data-table happy-path from 0/5 every prior run → 3/5 (run #40). First non-zero result for that scenario in the entire loop.

## Caveats

- The Notification-router regression (12 → 8.7) is independent variance; that case uses Switch routing so none of these validators fire.
- Removing the per-node Code/DataTable validators in favour of hints may yield a small per-case dip on those scenarios if the agent ignores hints under pressure — worth re-measuring once landed.
- \`pass_hat_K\` is **noise-dominated** at K=5; don't compare single-run numbers below ~10pp.

## Test plan

- [x] \`pnpm typecheck\` on \`@n8n/instance-ai\` — clean
- [x] \`pnpm typecheck\` on \`n8n-nodes-base\` — clean
- [x] \`pnpm lint\` on \`@n8n/instance-ai\` — clean
- [x] ESLint on the 2 touched \`nodes-base\` files — clean (3 pre-existing warnings unrelated to diff)
- [x] \`pnpm test src/workflow-builder/__tests__/semantic-checks.test.ts\` — 28 unit tests pass (positive + negative-guard cases for each validator)
- [x] \`pnpm format\` run on both packages before commit
- [ ] Recommended before merge: 2+ same-state golden-suite runs to confirm \`pass@5\` band after removing the Code/DataTable validators in favour of hints

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)