### PR TITLE
fix: Fixes filtering session recordings based on group properties (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -96,6 +96,7 @@ declare global {
 				userPropertiesOnce?: Record<string, string>,
 			): void;
 			reset?(resetDeviceId?: boolean): void;
+			group?(groupType: string, groupKey: string, groupPropertiesToSet?: IDataObject): void;
 			onFeatureFlags?(callback: (keys: string[], map: FeatureFlags) => void): void;
 			reloadFeatureFlags?(): void;
 			capture?(event: string, properties: IDataObject): void;

--- a/packages/frontend/editor-ui/src/app/plugins/telemetry/index.ts
+++ b/packages/frontend/editor-ui/src/app/plugins/telemetry/index.ts
@@ -64,9 +64,14 @@ export class Telemetry {
 		});
 
 		this.identify({ instanceId, userId, versionCli, projectId, userRole });
+		this.groupIdentify({ instanceId });
 
 		this.flushPageEvents();
 		this.track('Session started', { session_id: rootStore.pushRef });
+	}
+
+	groupIdentify({ instanceId }: { instanceId: string }) {
+		usePostHog()?.groupIdentify?.('company', instanceId);
 	}
 
 	identify({ instanceId, userId, versionCli, projectId, userRole }: TelemetryIdentifyOptions) {

--- a/packages/frontend/editor-ui/src/app/stores/posthog.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/posthog.store.ts
@@ -114,6 +114,10 @@ export const usePostHog = defineStore('posthog', () => {
 		};
 	}
 
+	const groupIdentify = (groupKey: string, instanceId: string) => {
+		window.posthog?.group?.(groupKey, instanceId);
+	};
+
 	const identify = () => {
 		const instanceId = rootStore.instanceId;
 		const user = usersStore.currentUser;
@@ -233,6 +237,7 @@ export const usePostHog = defineStore('posthog', () => {
 		waitForFeatureFlags,
 		reset,
 		identify,
+		groupIdentify,
 		setMetadata,
 		capture,
 		overrides,


### PR DESCRIPTION
## Summary
As [suggested](https://n8nio.slack.com/archives/C08QATRERUH/p1778727793303439?thread_ts=1778686214.744889&cid=C08QATRERUH) by PostHog support, this PR implements a PostHog group identify calls alongside user identify calls to enable group-level properties filtering of session recordings.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
