### PR TITLE
refactor(editor): Make useWorkflowDocumentRenderData a standalone composable

### DIFF
--- a/packages/frontend/editor-ui/src/app/stores/executionData.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/executionData.store.test.ts
@@ -564,4 +564,190 @@ describe('executionData.store', () => {
 			expect(recreated.executionStartedData).toBeUndefined();
 		});
 	});
+
+	describe('executionIssues', () => {
+		function setExecutionWithRunData(
+			store: ReturnType<typeof useExecutionDataStore>,
+			runData: Record<string, Array<Record<string, unknown>>>,
+		) {
+			store.setExecution(
+				createTestExecution({
+					data: {
+						resultData: { runData, lastNodeExecuted: '' },
+					} as never,
+				}),
+			);
+		}
+
+		it('starts empty when no execution is set', () => {
+			const store = useExecutionDataStore(createExecutionDataId('exec-1'));
+			expect(store.executionIssues.size).toBe(0);
+		});
+
+		it('adds an entry per node name present in runData on setExecution', async () => {
+			const store = useExecutionDataStore(createExecutionDataId('exec-1'));
+
+			setExecutionWithRunData(store, {
+				NodeA: [{ executionStatus: 'success' }],
+				NodeB: [{ executionStatus: 'error' }],
+			});
+			await flushPromises();
+
+			expect(store.executionIssues.has('NodeA')).toBe(true);
+			expect(store.executionIssues.has('NodeB')).toBe(true);
+		});
+
+		it('returns the formatted error message with description', async () => {
+			const store = useExecutionDataStore(createExecutionDataId('exec-1'));
+
+			setExecutionWithRunData(store, {
+				NodeA: [{ error: { message: 'msg', description: 'desc' } }],
+			});
+			await flushPromises();
+
+			expect(store.executionIssues.get('NodeA')?.value).toEqual(['msg (desc)']);
+		});
+
+		it('returns just the message when no description is provided', async () => {
+			const store = useExecutionDataStore(createExecutionDataId('exec-1'));
+
+			setExecutionWithRunData(store, {
+				NodeA: [{ error: { message: 'msg' } }],
+			});
+			await flushPromises();
+
+			expect(store.executionIssues.get('NodeA')?.value).toEqual(['msg']);
+		});
+
+		it('aggregates errors across multiple tasks', async () => {
+			const store = useExecutionDataStore(createExecutionDataId('exec-1'));
+
+			setExecutionWithRunData(store, {
+				NodeA: [
+					{ error: { message: 'e1', description: 'd1' } },
+					{ error: { message: 'e2', description: 'd2' } },
+				],
+			});
+			await flushPromises();
+
+			expect(store.executionIssues.get('NodeA')?.value).toEqual(['e1 (d1)', 'e2 (d2)']);
+		});
+
+		it('returns [] when a node has tasks but no errors', async () => {
+			const store = useExecutionDataStore(createExecutionDataId('exec-1'));
+
+			setExecutionWithRunData(store, {
+				NodeA: [{ executionStatus: 'success' }],
+			});
+			await flushPromises();
+
+			expect(store.executionIssues.get('NodeA')?.value).toEqual([]);
+		});
+
+		it('sanitises html in error messages', async () => {
+			const store = useExecutionDataStore(createExecutionDataId('exec-1'));
+
+			setExecutionWithRunData(store, {
+				NodeA: [{ error: { message: '<script>x</script>', description: 'd' } }],
+			});
+			await flushPromises();
+
+			const issues = store.executionIssues.get('NodeA')?.value ?? [];
+			expect(issues[0]).not.toContain('<script>');
+		});
+
+		it('removes entries that no longer appear in runData on subsequent setExecution', async () => {
+			const store = useExecutionDataStore(createExecutionDataId('exec-1'));
+
+			setExecutionWithRunData(store, {
+				NodeA: [{ executionStatus: 'success' }],
+				NodeB: [{ executionStatus: 'success' }],
+			});
+			await flushPromises();
+			expect(store.executionIssues.has('NodeA')).toBe(true);
+			expect(store.executionIssues.has('NodeB')).toBe(true);
+
+			setExecutionWithRunData(store, {
+				NodeB: [{ executionStatus: 'success' }],
+			});
+			await flushPromises();
+
+			expect(store.executionIssues.has('NodeA')).toBe(false);
+			expect(store.executionIssues.has('NodeB')).toBe(true);
+		});
+
+		it('removes an entry when clearNodeExecutionData empties a node', async () => {
+			const store = useExecutionDataStore(createExecutionDataId('exec-1'));
+
+			setExecutionWithRunData(store, {
+				NodeA: [{ executionStatus: 'success' }],
+			});
+			await flushPromises();
+			expect(store.executionIssues.has('NodeA')).toBe(true);
+
+			store.clearNodeExecutionData('NodeA');
+			await flushPromises();
+
+			expect(store.executionIssues.has('NodeA')).toBe(false);
+		});
+
+		it('clears all entries on resetExecutionData', async () => {
+			const store = useExecutionDataStore(createExecutionDataId('exec-1'));
+
+			setExecutionWithRunData(store, {
+				NodeA: [{ executionStatus: 'success' }],
+				NodeB: [{ executionStatus: 'success' }],
+			});
+			await flushPromises();
+			expect(store.executionIssues.size).toBe(2);
+
+			store.resetExecutionData();
+			await flushPromises();
+
+			expect(store.executionIssues.size).toBe(0);
+		});
+
+		it('migrates the entry from old to new name on renameExecutionDataNode', async () => {
+			const store = useExecutionDataStore(createExecutionDataId('exec-1'));
+
+			setExecutionWithRunData(store, {
+				OldName: [{ error: { message: 'boom' } }],
+			});
+			await flushPromises();
+			expect(store.executionIssues.has('OldName')).toBe(true);
+
+			store.renameExecutionDataNode('OldName', 'NewName');
+			await flushPromises();
+
+			expect(store.executionIssues.has('OldName')).toBe(false);
+			expect(store.executionIssues.get('NewName')?.value).toEqual(['boom']);
+		});
+
+		it('produces a stable ComputedRef value across unrelated runData mutations', async () => {
+			const store = useExecutionDataStore(createExecutionDataId('exec-1'));
+
+			setExecutionWithRunData(store, {
+				NodeA: [{ error: { message: 'a-err' } }],
+				NodeB: [{ error: { message: 'b-err' } }],
+			});
+			await flushPromises();
+
+			const nodeAEntry = store.executionIssues.get('NodeA');
+			const before = nodeAEntry?.value;
+
+			// Mutate NodeB only; structuralComputed + isEqual should keep NodeA's
+			// value reference stable.
+			setExecutionWithRunData(store, {
+				NodeA: [{ error: { message: 'a-err' } }],
+				NodeB: [{ error: { message: 'b-changed' } }],
+			});
+			await flushPromises();
+
+			expect(store.executionIssues.get('NodeA')?.value).toBe(before);
+		});
+	});
 });
+
+async function flushPromises() {
+	await new Promise((resolve) => setTimeout(resolve, 0));
+}

--- a/packages/frontend/editor-ui/src/app/stores/executionData.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/executionData.store.test.ts
@@ -565,7 +565,7 @@ describe('executionData.store', () => {
 		});
 	});
 
-	describe('executionIssues', () => {
+	describe('executionIssuesByNodeName', () => {
 		function setExecutionWithRunData(
 			store: ReturnType<typeof useExecutionDataStore>,
 			runData: Record<string, Array<Record<string, unknown>>>,
@@ -581,7 +581,7 @@ describe('executionData.store', () => {
 
 		it('starts empty when no execution is set', () => {
 			const store = useExecutionDataStore(createExecutionDataId('exec-1'));
-			expect(store.executionIssues.size).toBe(0);
+			expect(store.executionIssuesByNodeName.size).toBe(0);
 		});
 
 		it('adds an entry per node name present in runData on setExecution', async () => {
@@ -593,8 +593,8 @@ describe('executionData.store', () => {
 			});
 			await flushPromises();
 
-			expect(store.executionIssues.has('NodeA')).toBe(true);
-			expect(store.executionIssues.has('NodeB')).toBe(true);
+			expect(store.executionIssuesByNodeName.has('NodeA')).toBe(true);
+			expect(store.executionIssuesByNodeName.has('NodeB')).toBe(true);
 		});
 
 		it('returns the formatted error message with description', async () => {
@@ -605,7 +605,7 @@ describe('executionData.store', () => {
 			});
 			await flushPromises();
 
-			expect(store.executionIssues.get('NodeA')?.value).toEqual(['msg (desc)']);
+			expect(store.executionIssuesByNodeName.get('NodeA')?.value).toEqual(['msg (desc)']);
 		});
 
 		it('returns just the message when no description is provided', async () => {
@@ -616,7 +616,7 @@ describe('executionData.store', () => {
 			});
 			await flushPromises();
 
-			expect(store.executionIssues.get('NodeA')?.value).toEqual(['msg']);
+			expect(store.executionIssuesByNodeName.get('NodeA')?.value).toEqual(['msg']);
 		});
 
 		it('aggregates errors across multiple tasks', async () => {
@@ -630,7 +630,7 @@ describe('executionData.store', () => {
 			});
 			await flushPromises();
 
-			expect(store.executionIssues.get('NodeA')?.value).toEqual(['e1 (d1)', 'e2 (d2)']);
+			expect(store.executionIssuesByNodeName.get('NodeA')?.value).toEqual(['e1 (d1)', 'e2 (d2)']);
 		});
 
 		it('returns [] when a node has tasks but no errors', async () => {
@@ -641,7 +641,7 @@ describe('executionData.store', () => {
 			});
 			await flushPromises();
 
-			expect(store.executionIssues.get('NodeA')?.value).toEqual([]);
+			expect(store.executionIssuesByNodeName.get('NodeA')?.value).toEqual([]);
 		});
 
 		it('sanitises html in error messages', async () => {
@@ -652,7 +652,7 @@ describe('executionData.store', () => {
 			});
 			await flushPromises();
 
-			const issues = store.executionIssues.get('NodeA')?.value ?? [];
+			const issues = store.executionIssuesByNodeName.get('NodeA')?.value ?? [];
 			expect(issues[0]).not.toContain('<script>');
 		});
 
@@ -664,16 +664,16 @@ describe('executionData.store', () => {
 				NodeB: [{ executionStatus: 'success' }],
 			});
 			await flushPromises();
-			expect(store.executionIssues.has('NodeA')).toBe(true);
-			expect(store.executionIssues.has('NodeB')).toBe(true);
+			expect(store.executionIssuesByNodeName.has('NodeA')).toBe(true);
+			expect(store.executionIssuesByNodeName.has('NodeB')).toBe(true);
 
 			setExecutionWithRunData(store, {
 				NodeB: [{ executionStatus: 'success' }],
 			});
 			await flushPromises();
 
-			expect(store.executionIssues.has('NodeA')).toBe(false);
-			expect(store.executionIssues.has('NodeB')).toBe(true);
+			expect(store.executionIssuesByNodeName.has('NodeA')).toBe(false);
+			expect(store.executionIssuesByNodeName.has('NodeB')).toBe(true);
 		});
 
 		it('removes an entry when clearNodeExecutionData empties a node', async () => {
@@ -683,12 +683,12 @@ describe('executionData.store', () => {
 				NodeA: [{ executionStatus: 'success' }],
 			});
 			await flushPromises();
-			expect(store.executionIssues.has('NodeA')).toBe(true);
+			expect(store.executionIssuesByNodeName.has('NodeA')).toBe(true);
 
 			store.clearNodeExecutionData('NodeA');
 			await flushPromises();
 
-			expect(store.executionIssues.has('NodeA')).toBe(false);
+			expect(store.executionIssuesByNodeName.has('NodeA')).toBe(false);
 		});
 
 		it('clears all entries on resetExecutionData', async () => {
@@ -699,12 +699,12 @@ describe('executionData.store', () => {
 				NodeB: [{ executionStatus: 'success' }],
 			});
 			await flushPromises();
-			expect(store.executionIssues.size).toBe(2);
+			expect(store.executionIssuesByNodeName.size).toBe(2);
 
 			store.resetExecutionData();
 			await flushPromises();
 
-			expect(store.executionIssues.size).toBe(0);
+			expect(store.executionIssuesByNodeName.size).toBe(0);
 		});
 
 		it('migrates the entry from old to new name on renameExecutionDataNode', async () => {
@@ -714,13 +714,13 @@ describe('executionData.store', () => {
 				OldName: [{ error: { message: 'boom' } }],
 			});
 			await flushPromises();
-			expect(store.executionIssues.has('OldName')).toBe(true);
+			expect(store.executionIssuesByNodeName.has('OldName')).toBe(true);
 
 			store.renameExecutionDataNode('OldName', 'NewName');
 			await flushPromises();
 
-			expect(store.executionIssues.has('OldName')).toBe(false);
-			expect(store.executionIssues.get('NewName')?.value).toEqual(['boom']);
+			expect(store.executionIssuesByNodeName.has('OldName')).toBe(false);
+			expect(store.executionIssuesByNodeName.get('NewName')?.value).toEqual(['boom']);
 		});
 
 		it('produces a stable ComputedRef value across unrelated runData mutations', async () => {
@@ -732,7 +732,7 @@ describe('executionData.store', () => {
 			});
 			await flushPromises();
 
-			const nodeAEntry = store.executionIssues.get('NodeA');
+			const nodeAEntry = store.executionIssuesByNodeName.get('NodeA');
 			const before = nodeAEntry?.value;
 
 			// Mutate NodeB only; structuralComputed + isEqual should keep NodeA's
@@ -743,7 +743,7 @@ describe('executionData.store', () => {
 			});
 			await flushPromises();
 
-			expect(store.executionIssues.get('NodeA')?.value).toBe(before);
+			expect(store.executionIssuesByNodeName.get('NodeA')?.value).toBe(before);
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/stores/executionData.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/executionData.store.ts
@@ -1,13 +1,17 @@
 import { defineStore, getActivePinia } from 'pinia';
 import { STORES } from '@n8n/stores';
-import { computed, inject, readonly, ref } from 'vue';
+import { computed, effectScope, inject, readonly, ref, shallowReactive } from 'vue';
+import type { ComputedRef } from 'vue';
 import { createEventHook } from '@vueuse/core';
+import { structuralComputed } from '@n8n/composables/structuralComputed';
+import isEqual from 'lodash/isEqual';
 import type { ExecutionStatus, IRunData, IRunExecutionData, ITaskStartedData } from 'n8n-workflow';
 import type { PushPayload } from '@n8n/api-types';
 import type { NodeExecuteBefore } from '@n8n/api-types/push/execution';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
 import { ExecutionDataStoreKey } from '@/app/constants/injectionKeys';
 import { getPairedItemsMapping } from '@/app/utils/pairedItemUtils';
+import { sanitizeHtml } from '@/app/utils/htmlUtils';
 import { CHANGE_ACTION } from './workflowDocument/types';
 import type { ChangeAction, ChangeEvent } from './workflowDocument/types';
 
@@ -65,6 +69,69 @@ export function useExecutionDataStore(id: ExecutionDataId) {
 		);
 
 		const executedNode = computed(() => execution.value?.executedNode);
+
+		// Per-node-name execution-issues map with atomic per-name updates.
+		// Each entry is a structuralComputed in its own effectScope, so only
+		// the affected node re-evaluates on runData changes and isEqual
+		// short-circuits downstream propagation when the error array is
+		// structurally identical. Entries are added/removed by reconciling
+		// against executionRunData keys (driven by watch below).
+		// effectScopes are children of the store's setup-scope, so $dispose
+		// cascades cleanup — no explicit teardown needed.
+		const executionIssues = shallowReactive(new Map<string, ComputedRef<string[]>>());
+		const executionIssueScopes = new Map<string, () => void>();
+
+		function computeNodeExecutionIssues(nodeName: string): string[] {
+			const tasks = executionRunData.value?.[nodeName];
+			if (!tasks) return [];
+			const issues: string[] = [];
+			for (const task of tasks) {
+				if (task?.error) {
+					const { message, description } = task.error;
+					issues.push(sanitizeHtml(`${message}${description ? ` (${description})` : ''}`));
+				}
+			}
+			return issues;
+		}
+
+		function applyAddExecutionIssuesEntry(nodeName: string) {
+			if (executionIssueScopes.has(nodeName)) return;
+			const scope = effectScope();
+			scope.run(() => {
+				executionIssues.set(
+					nodeName,
+					structuralComputed(() => computeNodeExecutionIssues(nodeName), isEqual),
+				);
+			});
+			executionIssueScopes.set(nodeName, () => scope.stop());
+		}
+
+		function applyRemoveExecutionIssuesEntry(nodeName: string) {
+			executionIssueScopes.get(nodeName)?.();
+			executionIssueScopes.delete(nodeName);
+			executionIssues.delete(nodeName);
+		}
+
+		function applyReconcileExecutionIssuesEntries(nodeNames: string[]) {
+			const next = new Set(nodeNames);
+			for (const old of executionIssueScopes.keys()) {
+				if (!next.has(old)) applyRemoveExecutionIssuesEntry(old);
+			}
+			for (const name of nodeNames) applyAddExecutionIssuesEntry(name);
+		}
+
+		function reconcileExecutionIssuesFromRunData() {
+			const runData = executionRunData.value;
+			applyReconcileExecutionIssuesEntries(runData ? Object.keys(runData) : []);
+		}
+
+		// Subscribe to the event hook rather than watching `executionRunData` —
+		// renameExecutionDataNode mutates runData keys in place, leaving the
+		// computed's reference unchanged. The event hook fires on every
+		// mutation (including rename), so reconcile picks up key changes
+		// regardless of reference identity.
+		void onExecutionDataChange.on(reconcileExecutionIssuesFromRunData);
+		reconcileExecutionIssuesFromRunData();
 
 		function fireChange(action: ChangeAction, nodeName?: string) {
 			void onExecutionDataChange.trigger({
@@ -343,6 +410,7 @@ export function useExecutionDataStore(id: ExecutionDataId) {
 			executionResultDataLastUpdate: readonly(executionResultDataLastUpdate),
 			executionRunData,
 			executedNode,
+			executionIssues,
 			executionStartedData: readonly(executionStartedData),
 			executionPairedItemMappings: readonly(executionPairedItemMappings),
 			getExecutionRunDataByNodeName,

--- a/packages/frontend/editor-ui/src/app/stores/executionData.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/executionData.store.ts
@@ -78,7 +78,7 @@ export function useExecutionDataStore(id: ExecutionDataId) {
 		// against executionRunData keys (driven by watch below).
 		// effectScopes are children of the store's setup-scope, so $dispose
 		// cascades cleanup — no explicit teardown needed.
-		const executionIssues = shallowReactive(new Map<string, ComputedRef<string[]>>());
+		const executionIssuesByNodeName = shallowReactive(new Map<string, ComputedRef<string[]>>());
 		const executionIssueScopes = new Map<string, () => void>();
 
 		function computeNodeExecutionIssues(nodeName: string): string[] {
@@ -98,7 +98,7 @@ export function useExecutionDataStore(id: ExecutionDataId) {
 			if (executionIssueScopes.has(nodeName)) return;
 			const scope = effectScope();
 			scope.run(() => {
-				executionIssues.set(
+				executionIssuesByNodeName.set(
 					nodeName,
 					structuralComputed(() => computeNodeExecutionIssues(nodeName), isEqual),
 				);
@@ -109,7 +109,7 @@ export function useExecutionDataStore(id: ExecutionDataId) {
 		function applyRemoveExecutionIssuesEntry(nodeName: string) {
 			executionIssueScopes.get(nodeName)?.();
 			executionIssueScopes.delete(nodeName);
-			executionIssues.delete(nodeName);
+			executionIssuesByNodeName.delete(nodeName);
 		}
 
 		function applyReconcileExecutionIssuesEntries(nodeNames: string[]) {
@@ -410,7 +410,7 @@ export function useExecutionDataStore(id: ExecutionDataId) {
 			executionResultDataLastUpdate: readonly(executionResultDataLastUpdate),
 			executionRunData,
 			executedNode,
-			executionIssues,
+			executionIssuesByNodeName,
 			executionStartedData: readonly(executionStartedData),
 			executionPairedItemMappings: readonly(executionPairedItemMappings),
 			getExecutionRunDataByNodeName,

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -20,7 +20,6 @@ import { useWorkflowDocumentTimestamps } from './workflowDocument/useWorkflowDoc
 import { useWorkflowDocumentParentFolder } from './workflowDocument/useWorkflowDocumentParentFolder';
 import { useWorkflowDocumentUsedCredentials } from './workflowDocument/useWorkflowDocumentUsedCredentials';
 import { useWorkflowDocumentNodes } from './workflowDocument/useWorkflowDocumentNodes';
-import { useWorkflowDocumentRenderData } from './workflowDocument/useWorkflowDocumentRenderData';
 import { useWorkflowDocumentVersionData } from './workflowDocument/useWorkflowDocumentVersionData';
 import { useWorkflowDocumentViewport } from './workflowDocument/useWorkflowDocumentViewport';
 import { useWorkflowDocumentConnections } from './workflowDocument/useWorkflowDocumentConnections';
@@ -165,12 +164,7 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 		const workflowDocumentVersionData = useWorkflowDocumentVersionData();
 		const workflowDocumentViewport = useWorkflowDocumentViewport();
 		const workflowDocumentNodeMetadata = useWorkflowDocumentNodeMetadata();
-		const {
-			onStateDirty: onNodesStateDirty,
-			nodeInputsByNodeId,
-			nodeOutputsByNodeId,
-			...workflowDocumentNodes
-		} = useWorkflowDocumentNodes({
+		const { onStateDirty: onNodesStateDirty, ...workflowDocumentNodes } = useWorkflowDocumentNodes({
 			getNodeType: (typeName, version) => nodeTypesStore.getNodeType(typeName, version),
 			nodeMetadata: workflowDocumentNodeMetadata,
 			assignNodeId: (node) => nodeHelpers.assignNodeId(node),
@@ -194,10 +188,6 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 			allNodes: workflowDocumentNodes.allNodes,
 			outgoingConnectionsByNodeName: workflowDocumentConnections.outgoingConnectionsByNodeName,
 			incomingConnectionsByNodeName: workflowDocumentConnections.incomingConnectionsByNodeName,
-		});
-		const workflowDocumentRenderData = useWorkflowDocumentRenderData({
-			nodeInputsByNodeId,
-			nodeOutputsByNodeId,
 		});
 
 		// --- Cross-cut orchestration ---
@@ -406,7 +396,6 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 			...workflowDocumentExpression,
 			...workflowDocumentNodeMetadata,
 			...workflowDocumentNodesIssues,
-			...workflowDocumentRenderData,
 			removeAllNodes,
 			hydrate,
 			reset,

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.ts
@@ -214,8 +214,7 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 	// zero cost on node updates. The structuralComputed handles reactive
 	// re-evaluation (e.g. when workflowObject or node type changes) and
 	// isEqual gates downstream propagation. Exposed to canvas consumers via
-	// useWorkflowDocumentRenderData (a thin grouping façade keyed under
-	// `store.render`).
+	// `useWorkflowDocumentRenderData(documentId)`.
 	const nodeInputsByNodeId = shallowReactive(
 		new Map<string, ComputedRef<CanvasConnectionPort[]>>(),
 	);

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.test.ts
@@ -10,7 +10,7 @@ import { useWorkflowDocumentRenderData } from './useWorkflowDocumentRenderData';
 
 const nodeInputsByNodeId = shallowReactive(new Map<string, ComputedRef<CanvasConnectionPort[]>>());
 const nodeOutputsByNodeId = shallowReactive(new Map<string, ComputedRef<CanvasConnectionPort[]>>());
-const executionIssues = new Map<string, ComputedRef<string[]>>();
+const executionIssuesByNodeName = new Map<string, ComputedRef<string[]>>();
 
 vi.mock('@/app/stores/workflowDocument.store', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('@/app/stores/workflowDocument.store')>();
@@ -26,7 +26,7 @@ vi.mock('@/app/stores/workflowDocument.store', async (importOriginal) => {
 
 vi.mock('@/app/stores/workflowExecutionState.store', () => ({
 	useWorkflowExecutionStateStore: vi.fn(() => ({
-		getActiveExecutionIssues: () => executionIssues,
+		getActiveExecutionIssuesByNodeName: () => executionIssuesByNodeName,
 	})),
 	createWorkflowExecutionStateId: (id: string) => id,
 }));
@@ -44,9 +44,9 @@ describe('useWorkflowDocumentRenderData', () => {
 		expect(renderData.nodeOutputsByNodeId).toBe(nodeOutputsByNodeId);
 	});
 
-	it('exposes executionIssues resolved via the workflow execution state store', () => {
+	it('exposes executionIssuesByNodeName resolved via the workflow execution state store', () => {
 		const renderData = useWorkflowDocumentRenderData(createWorkflowDocumentId('wf-1'));
 
-		expect(renderData.executionIssues).toBe(executionIssues);
+		expect(renderData.executionIssuesByNodeName).toBe(executionIssuesByNodeName);
 	});
 });

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.test.ts
@@ -26,7 +26,7 @@ vi.mock('@/app/stores/workflowDocument.store', async (importOriginal) => {
 
 vi.mock('@/app/stores/workflowExecutionState.store', () => ({
 	useWorkflowExecutionStateStore: vi.fn(() => ({
-		getActiveExecutionIssuesByNodeName: () => executionIssuesByNodeName,
+		activeExecutionIssuesByNodeName: executionIssuesByNodeName,
 	})),
 	createWorkflowExecutionStateId: (id: string) => id,
 }));

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.test.ts
@@ -1,26 +1,52 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { shallowReactive, type ComputedRef } from 'vue';
+import { setActivePinia, createPinia } from 'pinia';
 import type { CanvasConnectionPort } from '@/features/workflows/canvas/canvas.types';
+import {
+	useWorkflowDocumentStore,
+	createWorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 import { useWorkflowDocumentRenderData } from './useWorkflowDocumentRenderData';
 
-describe('useWorkflowDocumentRenderData', () => {
-	it('exposes the injected port maps under render', () => {
-		const nodeInputsByNodeId = shallowReactive(
-			new Map<string, ComputedRef<CanvasConnectionPort[]>>(),
-		);
-		const nodeOutputsByNodeId = shallowReactive(
-			new Map<string, ComputedRef<CanvasConnectionPort[]>>(),
-		);
+const nodeInputsByNodeId = shallowReactive(new Map<string, ComputedRef<CanvasConnectionPort[]>>());
+const nodeOutputsByNodeId = shallowReactive(new Map<string, ComputedRef<CanvasConnectionPort[]>>());
+const executionIssues = new Map<string, ComputedRef<string[]>>();
 
-		const { render } = useWorkflowDocumentRenderData({
+vi.mock('@/app/stores/workflowDocument.store', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@/app/stores/workflowDocument.store')>();
+	return {
+		...actual,
+		useWorkflowDocumentStore: vi.fn(() => ({
+			workflowId: 'wf-1',
 			nodeInputsByNodeId,
 			nodeOutputsByNodeId,
-		});
+		})),
+	};
+});
 
-		// The façade exposes the same map references — no copies, no wrapping.
-		// Mutations to the underlying maps (done by useWorkflowDocumentNodes)
-		// are observable through `render` because they share identity.
-		expect(render.nodeInputsByNodeId).toBe(nodeInputsByNodeId);
-		expect(render.nodeOutputsByNodeId).toBe(nodeOutputsByNodeId);
+vi.mock('@/app/stores/workflowExecutionState.store', () => ({
+	useWorkflowExecutionStateStore: vi.fn(() => ({
+		getActiveExecutionIssues: () => executionIssues,
+	})),
+	createWorkflowExecutionStateId: (id: string) => id,
+}));
+
+describe('useWorkflowDocumentRenderData', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+		vi.mocked(useWorkflowDocumentStore).mockClear();
+	});
+
+	it('passes through nodeInputsByNodeId and nodeOutputsByNodeId by reference', () => {
+		const renderData = useWorkflowDocumentRenderData(createWorkflowDocumentId('wf-1'));
+
+		expect(renderData.nodeInputsByNodeId).toBe(nodeInputsByNodeId);
+		expect(renderData.nodeOutputsByNodeId).toBe(nodeOutputsByNodeId);
+	});
+
+	it('exposes executionIssues resolved via the workflow execution state store', () => {
+		const renderData = useWorkflowDocumentRenderData(createWorkflowDocumentId('wf-1'));
+
+		expect(renderData.executionIssues).toBe(executionIssues);
 	});
 });

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.ts
@@ -12,12 +12,12 @@ import {
  *
  * Thin façade that re-exposes the per-node port maps owned by
  * `useWorkflowDocumentNodes` and the active execution's per-node-name
- * `executionIssues` map (resolved via `useWorkflowExecutionStateStore`,
+ * `executionIssuesByNodeName` map (resolved via `useWorkflowExecutionStateStore`,
  * which in turn routes through the keyed `useExecutionDataStore`).
  *
  * Call inside a Vue reactive context (e.g. `computed`) — the resolver
  * reads `activeExecutionId` / `displayedExecutionId`, so identity of the
- * returned `executionIssues` map changes when the active or displayed
+ * returned `executionIssuesByNodeName` map changes when the active or displayed
  * execution swaps and the wrapping computed re-runs.
  */
 export function useWorkflowDocumentRenderData(workflowDocumentId: WorkflowDocumentId) {
@@ -29,6 +29,6 @@ export function useWorkflowDocumentRenderData(workflowDocumentId: WorkflowDocume
 	return {
 		nodeInputsByNodeId: workflowDocumentStore.nodeInputsByNodeId,
 		nodeOutputsByNodeId: workflowDocumentStore.nodeOutputsByNodeId,
-		executionIssues: executionStateStore.getActiveExecutionIssues(),
+		executionIssuesByNodeName: executionStateStore.getActiveExecutionIssuesByNodeName(),
 	};
 }

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.ts
@@ -1,36 +1,21 @@
-import type { ComputedRef, ShallowReactive } from 'vue';
-import type { CanvasConnectionPort } from '@/features/workflows/canvas/canvas.types';
-
-// --- Deps ---
-
-export interface WorkflowDocumentRenderDataDeps {
-	/**
-	 * Per-node port maps. State and lifecycle are owned by
-	 * useWorkflowDocumentNodes; this composable is a grouping façade that
-	 * exposes them under a single `render` key for canvas consumers.
-	 */
-	nodeInputsByNodeId: ShallowReactive<Map<string, ComputedRef<CanvasConnectionPort[]>>>;
-	nodeOutputsByNodeId: ShallowReactive<Map<string, ComputedRef<CanvasConnectionPort[]>>>;
-}
-
-// --- Composable ---
+import {
+	useWorkflowDocumentStore,
+	type WorkflowDocumentId,
+} from '@/app/stores/workflowDocument.store';
 
 /**
- * Canvas render data grouping façade.
+ * Canvas render data accessor for a workflow document.
  *
- * Takes the per-node input/output port maps owned by
- * `useWorkflowDocumentNodes` and exposes them under a single `render`
- * key. Spread into the workflow document store so canvas consumers
- * access port data via `store.render`.
- *
- * No state, no lifecycle, no computation — those all live with the maps
- * in `useWorkflowDocumentNodes`.
+ * Retrieves the workflow document store for the given id and exposes its
+ * per-node input/output port maps. The maps are owned by
+ * `useWorkflowDocumentNodes`; this composable is a thin read façade for
+ * canvas consumers.
  */
-export function useWorkflowDocumentRenderData(deps: WorkflowDocumentRenderDataDeps) {
+export function useWorkflowDocumentRenderData(workflowDocumentId: WorkflowDocumentId) {
+	const store = useWorkflowDocumentStore(workflowDocumentId);
+
 	return {
-		render: {
-			nodeInputsByNodeId: deps.nodeInputsByNodeId,
-			nodeOutputsByNodeId: deps.nodeOutputsByNodeId,
-		},
+		nodeInputsByNodeId: store.nodeInputsByNodeId,
+		nodeOutputsByNodeId: store.nodeOutputsByNodeId,
 	};
 }

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.ts
@@ -2,20 +2,33 @@ import {
 	useWorkflowDocumentStore,
 	type WorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
+import {
+	useWorkflowExecutionStateStore,
+	createWorkflowExecutionStateId,
+} from '@/app/stores/workflowExecutionState.store';
 
 /**
  * Canvas render data accessor for a workflow document.
  *
- * Retrieves the workflow document store for the given id and exposes its
- * per-node input/output port maps. The maps are owned by
- * `useWorkflowDocumentNodes`; this composable is a thin read façade for
- * canvas consumers.
+ * Thin façade that re-exposes the per-node port maps owned by
+ * `useWorkflowDocumentNodes` and the active execution's per-node-name
+ * `executionIssues` map (resolved via `useWorkflowExecutionStateStore`,
+ * which in turn routes through the keyed `useExecutionDataStore`).
+ *
+ * Call inside a Vue reactive context (e.g. `computed`) — the resolver
+ * reads `activeExecutionId` / `displayedExecutionId`, so identity of the
+ * returned `executionIssues` map changes when the active or displayed
+ * execution swaps and the wrapping computed re-runs.
  */
 export function useWorkflowDocumentRenderData(workflowDocumentId: WorkflowDocumentId) {
-	const store = useWorkflowDocumentStore(workflowDocumentId);
+	const workflowDocumentStore = useWorkflowDocumentStore(workflowDocumentId);
+	const executionStateStore = useWorkflowExecutionStateStore(
+		createWorkflowExecutionStateId(workflowDocumentStore.workflowId),
+	);
 
 	return {
-		nodeInputsByNodeId: store.nodeInputsByNodeId,
-		nodeOutputsByNodeId: store.nodeOutputsByNodeId,
+		nodeInputsByNodeId: workflowDocumentStore.nodeInputsByNodeId,
+		nodeOutputsByNodeId: workflowDocumentStore.nodeOutputsByNodeId,
+		executionIssues: executionStateStore.getActiveExecutionIssues(),
 	};
 }

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.ts
@@ -12,13 +12,11 @@ import {
  *
  * Thin façade that re-exposes the per-node port maps owned by
  * `useWorkflowDocumentNodes` and the active execution's per-node-name
- * `executionIssuesByNodeName` map (resolved via `useWorkflowExecutionStateStore`,
- * which in turn routes through the keyed `useExecutionDataStore`).
- *
- * Call inside a Vue reactive context (e.g. `computed`) — the resolver
- * reads `activeExecutionId` / `displayedExecutionId`, so identity of the
- * returned `executionIssuesByNodeName` map changes when the active or displayed
- * execution swaps and the wrapping computed re-runs.
+ * `executionIssuesByNodeName` map. Reactivity is owned by the underlying
+ * stores: the port maps are stable references on the workflow document
+ * store, and `executionIssuesByNodeName` resolves through a `computed`
+ * on the workflow execution state store that swaps between the active
+ * and displayed execution's per-execution maps.
  */
 export function useWorkflowDocumentRenderData(workflowDocumentId: WorkflowDocumentId) {
 	const workflowDocumentStore = useWorkflowDocumentStore(workflowDocumentId);
@@ -29,6 +27,6 @@ export function useWorkflowDocumentRenderData(workflowDocumentId: WorkflowDocume
 	return {
 		nodeInputsByNodeId: workflowDocumentStore.nodeInputsByNodeId,
 		nodeOutputsByNodeId: workflowDocumentStore.nodeOutputsByNodeId,
-		executionIssuesByNodeName: executionStateStore.getActiveExecutionIssuesByNodeName(),
+		executionIssuesByNodeName: executionStateStore.activeExecutionIssuesByNodeName,
 	};
 }

--- a/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.ts
@@ -1,6 +1,6 @@
 import { defineStore, getActivePinia } from 'pinia';
 import { STORES } from '@n8n/stores';
-import { computed, inject, readonly, ref } from 'vue';
+import { computed, inject, readonly, ref, type ComputedRef } from 'vue';
 import { createEventHook } from '@vueuse/core';
 import type { ExecutionSummary } from 'n8n-workflow';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
@@ -13,6 +13,8 @@ import {
 } from './executionData.store';
 import { CHANGE_ACTION } from './workflowDocument/types';
 import type { ChangeAction, ChangeEvent } from './workflowDocument/types';
+
+const EMPTY_EXECUTION_ISSUES = new Map<string, ComputedRef<string[]>>();
 
 export type WorkflowExecutionStateId = string;
 
@@ -167,6 +169,26 @@ export function useWorkflowExecutionStateStore(id: WorkflowExecutionStateId) {
 			if (runData === null) return null;
 			if (!runData.hasOwnProperty(nodeName)) return null;
 			return runData[nodeName];
+		}
+
+		/**
+		 * Resolves the per-node-name execution issues map for the active or
+		 * displayed execution. Mirrors the fallback chain in `activeExecution`
+		 * (active id → displayed id → empty). The returned Map identity changes
+		 * when the active/displayed execution swaps; callers that need this
+		 * reactivity should invoke inside a Vue reactive context (computed,
+		 * watchEffect) so the underlying ref reads are tracked.
+		 */
+		function getActiveExecutionIssues(): Map<string, ComputedRef<string[]>> {
+			if (typeof activeExecutionId.value === 'string') {
+				return useExecutionDataStore(createExecutionDataId(activeExecutionId.value))
+					.executionIssues;
+			}
+			if (typeof displayedExecutionId.value === 'string') {
+				return useExecutionDataStore(createExecutionDataId(displayedExecutionId.value))
+					.executionIssues;
+			}
+			return EMPTY_EXECUTION_ISSUES;
 		}
 
 		const lastSuccessfulExecution = computed(() => {
@@ -474,6 +496,7 @@ export function useWorkflowExecutionStateStore(id: WorkflowExecutionStateId) {
 			getAllLoadedFinishedExecutions,
 			getPastChatMessages,
 			getActiveExecutionRunDataByNodeName,
+			getActiveExecutionIssues,
 			resolveExecutionTriggerNodeName,
 			// Write API
 			trackExecutionId,

--- a/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.ts
@@ -172,14 +172,14 @@ export function useWorkflowExecutionStateStore(id: WorkflowExecutionStateId) {
 		}
 
 		/**
-		 * Resolves the per-node-name execution issues map for the active or
-		 * displayed execution. Mirrors the fallback chain in `activeExecution`
-		 * (active id → displayed id → empty). The returned Map identity changes
-		 * when the active/displayed execution swaps; callers that need this
-		 * reactivity should invoke inside a Vue reactive context (computed,
-		 * watchEffect) so the underlying ref reads are tracked.
+		 * Per-node-name execution issues map for the active or displayed
+		 * execution. Mirrors the fallback chain in `activeExecution`
+		 * (active id → displayed id → empty). Map identity changes when the
+		 * active/displayed execution swaps; per-name `ComputedRef` entries
+		 * inside each Map are owned by the per-execution data store and gate
+		 * downstream propagation via `isEqual`.
 		 */
-		function getActiveExecutionIssuesByNodeName(): Map<string, ComputedRef<string[]>> {
+		const activeExecutionIssuesByNodeName = computed(() => {
 			if (typeof activeExecutionId.value === 'string') {
 				return useExecutionDataStore(createExecutionDataId(activeExecutionId.value))
 					.executionIssuesByNodeName;
@@ -189,7 +189,7 @@ export function useWorkflowExecutionStateStore(id: WorkflowExecutionStateId) {
 					.executionIssuesByNodeName;
 			}
 			return EMPTY_EXECUTION_ISSUES_BY_NODE_NAME;
-		}
+		});
 
 		const lastSuccessfulExecution = computed(() => {
 			const lid = lastSuccessfulExecutionId.value;
@@ -496,7 +496,7 @@ export function useWorkflowExecutionStateStore(id: WorkflowExecutionStateId) {
 			getAllLoadedFinishedExecutions,
 			getPastChatMessages,
 			getActiveExecutionRunDataByNodeName,
-			getActiveExecutionIssuesByNodeName,
+			activeExecutionIssuesByNodeName,
 			resolveExecutionTriggerNodeName,
 			// Write API
 			trackExecutionId,

--- a/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.ts
@@ -14,7 +14,7 @@ import {
 import { CHANGE_ACTION } from './workflowDocument/types';
 import type { ChangeAction, ChangeEvent } from './workflowDocument/types';
 
-const EMPTY_EXECUTION_ISSUES = new Map<string, ComputedRef<string[]>>();
+const EMPTY_EXECUTION_ISSUES_BY_NODE_NAME = new Map<string, ComputedRef<string[]>>();
 
 export type WorkflowExecutionStateId = string;
 
@@ -179,16 +179,16 @@ export function useWorkflowExecutionStateStore(id: WorkflowExecutionStateId) {
 		 * reactivity should invoke inside a Vue reactive context (computed,
 		 * watchEffect) so the underlying ref reads are tracked.
 		 */
-		function getActiveExecutionIssues(): Map<string, ComputedRef<string[]>> {
+		function getActiveExecutionIssuesByNodeName(): Map<string, ComputedRef<string[]>> {
 			if (typeof activeExecutionId.value === 'string') {
 				return useExecutionDataStore(createExecutionDataId(activeExecutionId.value))
-					.executionIssues;
+					.executionIssuesByNodeName;
 			}
 			if (typeof displayedExecutionId.value === 'string') {
 				return useExecutionDataStore(createExecutionDataId(displayedExecutionId.value))
-					.executionIssues;
+					.executionIssuesByNodeName;
 			}
-			return EMPTY_EXECUTION_ISSUES;
+			return EMPTY_EXECUTION_ISSUES_BY_NODE_NAME;
 		}
 
 		const lastSuccessfulExecution = computed(() => {
@@ -496,7 +496,7 @@ export function useWorkflowExecutionStateStore(id: WorkflowExecutionStateId) {
 			getAllLoadedFinishedExecutions,
 			getPastChatMessages,
 			getActiveExecutionRunDataByNodeName,
-			getActiveExecutionIssues,
+			getActiveExecutionIssuesByNodeName,
 			resolveExecutionTriggerNodeName,
 			// Write API
 			trackExecutionId,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/__tests__/utils.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/__tests__/utils.ts
@@ -29,7 +29,7 @@ export function createCanvasNodeData({
 	disabled = false,
 	connections = { [CanvasConnectionMode.Input]: {}, [CanvasConnectionMode.Output]: {} },
 	execution = { running: false },
-	issues = { execution: [], validation: [], visible: false },
+	issues = { validation: [], visible: false },
 	pinnedData = { count: 0, visible: false },
 	runData = { outputMap: {}, iterations: 0, visible: false },
 	render = {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.types.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.types.ts
@@ -110,7 +110,6 @@ export interface CanvasNodeData {
 		[CanvasConnectionMode.Output]: INodeConnections;
 	};
 	issues: {
-		execution: string[];
 		validation: string[];
 		visible: boolean;
 	};

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.utils.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.utils.ts
@@ -23,10 +23,9 @@ import type { useWorkflowDocumentRenderData } from '@/app/stores/workflowDocumen
 
 /**
  * Per-node canvas render data (input/output port maps) shape, as produced by
- * the workflow document store's render composable and consumed by canvas
- * components.
+ * `useWorkflowDocumentRenderData` and consumed by canvas components.
  */
-export type CanvasRenderData = ReturnType<typeof useWorkflowDocumentRenderData>['render'];
+export type CanvasRenderData = ReturnType<typeof useWorkflowDocumentRenderData>;
 
 /**
  * Injects the canvas render data from the component tree. Provided by an

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.test.ts
@@ -30,7 +30,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
-			executionIssues: new Map(),
+			executionIssuesByNodeName: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.test.ts
@@ -30,6 +30,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
+			executionIssues: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/WorkflowCanvas.vue
@@ -11,6 +11,7 @@ import type { CanvasEventBusEvents } from '../canvas.types';
 import { useCanvasMapping } from '../composables/useCanvasMapping';
 import Canvas from './Canvas.vue';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import { useWorkflowDocumentRenderData } from '@/app/stores/workflowDocument/useWorkflowDocumentRenderData';
 
 defineOptions({
 	inheritAttrs: false,
@@ -40,7 +41,9 @@ const props = withDefaults(
 const canvasRef = useTemplateRef('canvas');
 const $style = useCssModule();
 const workflowDocumentStore = injectWorkflowDocumentStore();
-const renderData = computed(() => workflowDocumentStore.value.render);
+const renderData = computed(() =>
+	useWorkflowDocumentRenderData(workflowDocumentStore.value.documentId),
+);
 
 const { onNodesInitialized, viewport, viewportRef, getNodes, fitBounds } = useVueFlow(props.id);
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/CanvasHandleRenderer.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/CanvasHandleRenderer.test.ts
@@ -23,7 +23,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: renderNodeInputsMap,
 			nodeOutputsByNodeId: renderNodeOutputsMap,
-			executionIssues: new Map(),
+			executionIssuesByNodeName: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/CanvasHandleRenderer.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/CanvasHandleRenderer.test.ts
@@ -23,6 +23,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: renderNodeInputsMap,
 			nodeOutputsByNodeId: renderNodeOutputsMap,
+			executionIssues: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/render-types/CanvasHandleMainOutput.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/render-types/CanvasHandleMainOutput.test.ts
@@ -17,7 +17,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: renderNodeInputsMap,
 			nodeOutputsByNodeId: renderNodeOutputsMap,
-			executionIssues: new Map(),
+			executionIssuesByNodeName: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/render-types/CanvasHandleMainOutput.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/render-types/CanvasHandleMainOutput.test.ts
@@ -17,6 +17,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: renderNodeInputsMap,
 			nodeOutputsByNodeId: renderNodeOutputsMap,
+			executionIssues: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.test.ts
@@ -34,6 +34,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: renderNodeInputsMap,
 			nodeOutputsByNodeId: renderNodeOutputsMap,
+			executionIssues: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.test.ts
@@ -34,7 +34,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: renderNodeInputsMap,
 			nodeOutputsByNodeId: renderNodeOutputsMap,
-			executionIssues: new Map(),
+			executionIssuesByNodeName: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeRenderer.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeRenderer.test.ts
@@ -14,6 +14,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
+			executionIssues: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeRenderer.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeRenderer.test.ts
@@ -14,7 +14,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
-			executionIssues: new Map(),
+			executionIssuesByNodeName: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.test.ts
@@ -16,6 +16,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
+			executionIssues: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.test.ts
@@ -16,7 +16,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
-			executionIssues: new Map(),
+			executionIssuesByNodeName: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.test.ts
@@ -37,6 +37,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: renderNodeInputsMap,
 			nodeOutputsByNodeId: renderNodeOutputsMap,
+			executionIssues: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.test.ts
@@ -37,7 +37,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: renderNodeInputsMap,
 			nodeOutputsByNodeId: renderNodeOutputsMap,
-			executionIssues: new Map(),
+			executionIssuesByNodeName: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.vue
@@ -53,7 +53,7 @@ const renderData = injectCanvasRenderData();
 const inputs = computed(() => renderData.value.nodeInputsByNodeId.get(id.value)?.value ?? []);
 const outputs = computed(() => renderData.value.nodeOutputsByNodeId.get(id.value)?.value ?? []);
 const hasExecutionErrors = computed(
-	() => (renderData.value.executionIssues.get(name.value)?.value?.length ?? 0) > 0,
+	() => (renderData.value.executionIssuesByNodeName.get(name.value)?.value?.length ?? 0) > 0,
 );
 const { mainOutputs, mainOutputConnections, mainInputs, mainInputConnections, nonMainInputs } =
 	useNodeConnections({

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.vue
@@ -33,6 +33,7 @@ const { calculateNodeBorderOpacity } = useZoomAdjustedValues(viewport);
 const route = useRoute();
 const {
 	id,
+	name,
 	label,
 	subtitle,
 	connections,
@@ -45,13 +46,15 @@ const {
 	executionWaitingForNext,
 	executionRunning,
 	hasRunData,
-	hasExecutionErrors,
 	render,
 	isNotInstalledCommunityNode,
 } = useCanvasNode();
 const renderData = injectCanvasRenderData();
 const inputs = computed(() => renderData.value.nodeInputsByNodeId.get(id.value)?.value ?? []);
 const outputs = computed(() => renderData.value.nodeOutputsByNodeId.get(id.value)?.value ?? []);
+const hasExecutionErrors = computed(
+	() => (renderData.value.executionIssues.get(name.value)?.value?.length ?? 0) > 0,
+);
 const { mainOutputs, mainOutputConnections, mainInputs, mainInputConnections, nonMainInputs } =
 	useNodeConnections({
 		inputs,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeStickyNote.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeStickyNote.test.ts
@@ -11,7 +11,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
-			executionIssues: new Map(),
+			executionIssuesByNodeName: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeStickyNote.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeStickyNote.test.ts
@@ -11,6 +11,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
+			executionIssues: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeDisabledStrikeThrough.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeDisabledStrikeThrough.test.ts
@@ -7,6 +7,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
+			executionIssues: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeDisabledStrikeThrough.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeDisabledStrikeThrough.test.ts
@@ -7,7 +7,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
-			executionIssues: new Map(),
+			executionIssuesByNodeName: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeSettingsIcons.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeSettingsIcons.test.ts
@@ -27,7 +27,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
-			executionIssues: new Map(),
+			executionIssuesByNodeName: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeSettingsIcons.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeSettingsIcons.test.ts
@@ -27,6 +27,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
+			executionIssues: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeStatusIcons.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeStatusIcons.test.ts
@@ -26,6 +26,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
+			executionIssues: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeStatusIcons.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeStatusIcons.test.ts
@@ -26,7 +26,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
-			executionIssues: new Map(),
+			executionIssuesByNodeName: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeStatusIcons.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeStatusIcons.vue
@@ -38,7 +38,7 @@ const {
 } = useCanvasNode();
 const renderData = injectCanvasRenderData();
 const executionErrors = computed(
-	() => renderData.value.executionIssues.get(name.value)?.value ?? [],
+	() => renderData.value.executionIssuesByNodeName.get(name.value)?.value ?? [],
 );
 const hasExecutionErrors = computed(() => executionErrors.value.length > 0);
 const route = useRoute();

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeStatusIcons.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeStatusIcons.vue
@@ -3,6 +3,7 @@ import { computed, useCssModule } from 'vue';
 import TitledList from '@/app/components/TitledList.vue';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { useCanvasNode } from '../../../../../composables/useCanvasNode';
+import { injectCanvasRenderData } from '@/features/workflows/canvas/canvas.utils';
 import { useI18n } from '@n8n/i18n';
 import { CanvasNodeDirtiness, CanvasNodeRenderType } from '../../../../../canvas.types';
 import { useRoute } from 'vue-router';
@@ -24,10 +25,9 @@ const i18n = useI18n();
 const $style = useCssModule();
 
 const {
+	name,
 	hasPinnedData,
-	executionErrors,
 	validationErrors,
-	hasExecutionErrors,
 	hasValidationErrors,
 	executionStatus,
 	hasRunData,
@@ -36,6 +36,11 @@ const {
 	render,
 	isNotInstalledCommunityNode,
 } = useCanvasNode();
+const renderData = injectCanvasRenderData();
+const executionErrors = computed(
+	() => renderData.value.executionIssues.get(name.value)?.value ?? [],
+);
+const hasExecutionErrors = computed(() => executionErrors.value.length > 0);
 const route = useRoute();
 
 const hideNodeIssues = computed(() => false); // @TODO Implement this

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeTooltip.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeTooltip.test.ts
@@ -11,7 +11,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
-			executionIssues: new Map(),
+			executionIssuesByNodeName: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeTooltip.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeTooltip.test.ts
@@ -11,6 +11,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
+			executionIssues: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.test.ts
@@ -46,7 +46,7 @@ describe('useCanvasLayout', () => {
 			shallowRef<CanvasRenderData>({
 				nodeInputsByNodeId: new Map(),
 				nodeOutputsByNodeId: new Map(),
-				executionIssues: new Map(),
+				executionIssuesByNodeName: new Map(),
 			}),
 		);
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.test.ts
@@ -46,6 +46,7 @@ describe('useCanvasLayout', () => {
 			shallowRef<CanvasRenderData>({
 				nodeInputsByNodeId: new Map(),
 				nodeOutputsByNodeId: new Map(),
+				executionIssues: new Map(),
 			}),
 		);
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.test.ts
@@ -1,4 +1,4 @@
-import type { INode, NodeApiError, Workflow } from 'n8n-workflow';
+import type { INode, Workflow } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 import { setActivePinia } from 'pinia';
 import type { ComputedRef, Ref } from 'vue';
@@ -38,7 +38,6 @@ import { STORES } from '@n8n/stores';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { createTestingPinia } from '@pinia/testing';
 import { MarkerType } from '@vue-flow/core';
-import { mock } from 'vitest-mock-extended';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import {
 	injectWorkflowState,
@@ -71,12 +70,31 @@ const renderNodeOutputsMap = new Map<string, ComputedRef<CanvasConnectionPort[]>
 const testRenderData = shallowRef<CanvasRenderData>({
 	nodeInputsByNodeId: renderNodeInputsMap,
 	nodeOutputsByNodeId: renderNodeOutputsMap,
+	executionIssues: new Map(),
 });
 
 const emptyRenderData = shallowRef<CanvasRenderData>({
 	nodeInputsByNodeId: new Map(),
 	nodeOutputsByNodeId: new Map(),
+	executionIssues: new Map(),
 });
+
+function createRenderDataWithExecutionIssues(
+	executionIssuesByNodeName: Record<string, string[]> = {},
+): Ref<CanvasRenderData> {
+	const executionIssues = new Map<string, ComputedRef<string[]>>();
+	for (const [nodeName, issues] of Object.entries(executionIssuesByNodeName)) {
+		executionIssues.set(
+			nodeName,
+			computed(() => issues),
+		);
+	}
+	return shallowRef({
+		nodeInputsByNodeId: new Map(),
+		nodeOutputsByNodeId: new Map(),
+		executionIssues,
+	});
+}
 
 vi.mock('@/app/composables/useWorkflowState', async () => {
 	const actual = await vi.importActual('@/app/composables/useWorkflowState');
@@ -230,7 +248,6 @@ describe('useCanvasMapping', () => {
 							waitingForNext: false,
 						},
 						issues: {
-							execution: [],
 							validation: [],
 							visible: false,
 						},
@@ -252,10 +269,14 @@ describe('useCanvasMapping', () => {
 							options: {
 								configurable: false,
 								configuration: false,
+								dirtiness: undefined,
 								icon: {
+									badge: undefined,
 									src: '/nodes/test-node/icon.svg',
 									type: 'file',
 								},
+								placeholder: undefined,
+								tooltip: undefined,
 								trigger: true,
 							},
 						},
@@ -1096,14 +1117,11 @@ describe('useCanvasMapping', () => {
 		});
 
 		describe('node issues', () => {
-			it('should return empty arrays when node has no issues', () => {
-				const workflowsStore = mockedStore(useWorkflowsStore);
+			it('should return empty validation and not visible when node has no issues', () => {
 				const node = createTestNode({ name: 'Test Node' });
 				const nodes = [node];
 				const connections = {};
 				const workflowObject = createTestWorkflowObject({ nodes, connections });
-
-				workflowsStore.getWorkflowRunData = {};
 
 				const { nodes: mappedNodes } = useCanvasMapping({
 					nodes: ref(nodes),
@@ -1113,135 +1131,34 @@ describe('useCanvasMapping', () => {
 				});
 
 				expect(mappedNodes.value[0]?.data?.issues).toEqual({
-					execution: [],
 					validation: [],
 					visible: false,
 				});
 			});
 
-			it('should handle execution errors', () => {
-				const workflowsStore = mockedStore(useWorkflowsStore);
+			it('should mark issues.visible when renderData reports execution errors', () => {
 				const node = createTestNode({ name: 'Test Node' });
 				const nodes = [node];
 				const connections = {};
 				const workflowObject = createTestWorkflowObject({ nodes, connections });
-
-				const errorMessage = 'Test error message';
-				const errorDescription = 'Test error description';
-				workflowsStore.getWorkflowRunData = {
-					'Test Node': [
-						{
-							startTime: 0,
-							executionTime: 0,
-							executionIndex: 0,
-							source: [],
-							error: mock<NodeApiError>({
-								message: errorMessage,
-								description: errorDescription,
-							}),
-						},
-					],
-				};
+				const renderData = createRenderDataWithExecutionIssues({
+					[node.name]: ['Test error message (Test error description)'],
+				});
 
 				const { nodes: mappedNodes } = useCanvasMapping({
 					nodes: ref(nodes),
 					connections: ref(connections),
 					workflowObject: ref(workflowObject) as Ref<Workflow>,
-					renderData: emptyRenderData,
+					renderData,
 				});
 
 				expect(mappedNodes.value[0]?.data?.issues).toEqual({
-					execution: [`${errorMessage} (${errorDescription})`],
 					validation: [],
 					visible: true,
 				});
 			});
 
-			it('should handle execution error without description', () => {
-				const workflowsStore = mockedStore(useWorkflowsStore);
-				const node = createTestNode({ name: 'Test Node' });
-				const nodes = [node];
-				const connections = {};
-				const workflowObject = createTestWorkflowObject({ nodes, connections });
-
-				const errorMessage = 'Test error message';
-				workflowsStore.getWorkflowRunData = {
-					'Test Node': [
-						{
-							startTime: 0,
-							executionTime: 0,
-							executionIndex: 0,
-							source: [],
-							error: mock<NodeApiError>({
-								message: errorMessage,
-								description: null,
-							}),
-						},
-					],
-				};
-
-				const { nodes: mappedNodes } = useCanvasMapping({
-					nodes: ref(nodes),
-					connections: ref(connections),
-					workflowObject: ref(workflowObject) as Ref<Workflow>,
-					renderData: emptyRenderData,
-				});
-
-				expect(mappedNodes.value[0]?.data?.issues).toEqual({
-					execution: [errorMessage],
-					validation: [],
-					visible: true,
-				});
-			});
-
-			it('should handle multiple execution errors', () => {
-				const workflowsStore = mockedStore(useWorkflowsStore);
-				const node = createTestNode({ name: 'Test Node' });
-				const nodes = [node];
-				const connections = {};
-				const workflowObject = createTestWorkflowObject({ nodes, connections });
-
-				workflowsStore.getWorkflowRunData = {
-					'Test Node': [
-						{
-							startTime: 0,
-							executionTime: 0,
-							executionIndex: 0,
-							source: [],
-							error: mock<NodeApiError>({
-								message: 'Error 1',
-								description: 'Description 1',
-							}),
-						},
-						{
-							startTime: 0,
-							executionTime: 0,
-							executionIndex: 1,
-							source: [],
-							error: mock<NodeApiError>({
-								message: 'Error 2',
-								description: 'Description 2',
-							}),
-						},
-					],
-				};
-
-				const { nodes: mappedNodes } = useCanvasMapping({
-					nodes: ref(nodes),
-					connections: ref(connections),
-					workflowObject: ref(workflowObject) as Ref<Workflow>,
-					renderData: emptyRenderData,
-				});
-
-				expect(mappedNodes.value[0]?.data?.issues).toEqual({
-					execution: ['Error 1 (Description 1)', 'Error 2 (Description 2)'],
-					validation: [],
-					visible: true,
-				});
-			});
-
-			it('should handle node issues', () => {
-				const workflowsStore = mockedStore(useWorkflowsStore);
+			it('should expose validation errors from node.issues', () => {
 				const node = createTestNode({
 					name: 'Test Node',
 					issues: {
@@ -1252,8 +1169,6 @@ describe('useCanvasMapping', () => {
 				const connections = {};
 				const workflowObject = createTestWorkflowObject({ nodes, connections });
 
-				workflowsStore.getWorkflowRunData = {};
-
 				const { nodes: mappedNodes } = useCanvasMapping({
 					nodes: ref(nodes),
 					connections: ref(connections),
@@ -1262,14 +1177,12 @@ describe('useCanvasMapping', () => {
 				});
 
 				expect(mappedNodes.value[0]?.data?.issues).toEqual({
-					execution: [],
 					validation: ['Node Type "n8n-nodes-base.set" is not known.'],
 					visible: true,
 				});
 			});
 
-			it('should combine execution errors and node issues', () => {
-				const workflowsStore = mockedStore(useWorkflowsStore);
+			it('should mark issues.visible when both validation and execution errors are present', () => {
 				const node = createTestNode({
 					name: 'Test Node',
 					issues: {
@@ -1279,38 +1192,24 @@ describe('useCanvasMapping', () => {
 				const nodes = [node];
 				const connections = {};
 				const workflowObject = createTestWorkflowObject({ nodes, connections });
-
-				workflowsStore.getWorkflowRunData = {
-					'Test Node': [
-						{
-							startTime: 0,
-							executionTime: 0,
-							executionIndex: 0,
-							source: [],
-							error: mock<NodeApiError>({
-								message: 'Execution error',
-								description: 'Error description',
-							}),
-						},
-					],
-				};
+				const renderData = createRenderDataWithExecutionIssues({
+					[node.name]: ['Execution error (Error description)'],
+				});
 
 				const { nodes: mappedNodes } = useCanvasMapping({
 					nodes: ref(nodes),
 					connections: ref(connections),
 					workflowObject: ref(workflowObject) as Ref<Workflow>,
-					renderData: emptyRenderData,
+					renderData,
 				});
 
 				expect(mappedNodes.value[0]?.data?.issues).toEqual({
-					execution: ['Execution error (Error description)'],
 					validation: ['Node Type "n8n-nodes-base.set" is not known.'],
 					visible: true,
 				});
 			});
 
 			it('should handle multiple nodes with different issues', () => {
-				const workflowsStore = mockedStore(useWorkflowsStore);
 				const node1 = createTestNode({
 					name: 'Node 1',
 					issues: {
@@ -1321,36 +1220,22 @@ describe('useCanvasMapping', () => {
 				const nodes = [node1, node2];
 				const connections = {};
 				const workflowObject = createTestWorkflowObject({ nodes, connections });
-
-				workflowsStore.getWorkflowRunData = {
-					'Node 2': [
-						{
-							startTime: 0,
-							executionTime: 0,
-							executionIndex: 0,
-							source: [],
-							error: mock<NodeApiError>({
-								message: 'Execution error',
-								description: 'Error description',
-							}),
-						},
-					],
-				};
+				const renderData = createRenderDataWithExecutionIssues({
+					[node2.name]: ['Execution error (Error description)'],
+				});
 
 				const { nodes: mappedNodes } = useCanvasMapping({
 					nodes: ref(nodes),
 					connections: ref(connections),
 					workflowObject: ref(workflowObject) as Ref<Workflow>,
-					renderData: emptyRenderData,
+					renderData,
 				});
 
 				expect(mappedNodes.value[0]?.data?.issues).toEqual({
-					execution: [],
 					validation: ['Node Type "n8n-nodes-base.set" is not known.'],
 					visible: true,
 				});
 				expect(mappedNodes.value[1]?.data?.issues).toEqual({
-					execution: ['Execution error (Error description)'],
 					validation: [],
 					visible: true,
 				});
@@ -1752,40 +1637,21 @@ describe('useCanvasMapping', () => {
 				expect(nodeHasIssuesById.value[node.id]).toBe(true);
 			});
 
-			it('should return true for execution errors even with other issues', () => {
-				const workflowsStore = mockedStore(useWorkflowsStore);
-				const node = createTestNode({
-					name: 'Test Node',
-					issues: {
-						typeUnknown: true,
-					},
-				} as Partial<INode>);
+			it('should return true when renderData reports execution errors', () => {
+				const node = createTestNode({ name: 'Test Node' });
 				const nodes = [node];
 				const connections = {};
 				const workflowObject = createTestWorkflowObject({ nodes, connections });
-
-				workflowsStore.getWorkflowRunData = {
-					'Test Node': [
-						{
-							startTime: 0,
-							executionTime: 0,
-							executionIndex: 0,
-							source: [],
-							executionStatus: 'error',
-							error: mock<NodeApiError>({
-								message: 'Execution error',
-								description: 'Error description',
-							}),
-						},
-					],
-				};
+				const renderData = createRenderDataWithExecutionIssues({
+					[node.name]: ['Execution error (Error description)'],
+				});
 				setPinData({});
 
 				const { nodeHasIssuesById } = useCanvasMapping({
 					nodes: ref(nodes),
 					connections: ref(connections),
 					workflowObject: ref(workflowObject) as Ref<Workflow>,
-					renderData: emptyRenderData,
+					renderData,
 				});
 
 				expect(nodeHasIssuesById.value[node.id]).toBe(true);

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.test.ts
@@ -70,21 +70,21 @@ const renderNodeOutputsMap = new Map<string, ComputedRef<CanvasConnectionPort[]>
 const testRenderData = shallowRef<CanvasRenderData>({
 	nodeInputsByNodeId: renderNodeInputsMap,
 	nodeOutputsByNodeId: renderNodeOutputsMap,
-	executionIssues: new Map(),
+	executionIssuesByNodeName: new Map(),
 });
 
 const emptyRenderData = shallowRef<CanvasRenderData>({
 	nodeInputsByNodeId: new Map(),
 	nodeOutputsByNodeId: new Map(),
-	executionIssues: new Map(),
+	executionIssuesByNodeName: new Map(),
 });
 
-function createRenderDataWithExecutionIssues(
-	executionIssuesByNodeName: Record<string, string[]> = {},
+function createRenderDataWithExecutionIssuesByNodeName(
+	issuesByNodeName: Record<string, string[]> = {},
 ): Ref<CanvasRenderData> {
-	const executionIssues = new Map<string, ComputedRef<string[]>>();
-	for (const [nodeName, issues] of Object.entries(executionIssuesByNodeName)) {
-		executionIssues.set(
+	const executionIssuesByNodeName = new Map<string, ComputedRef<string[]>>();
+	for (const [nodeName, issues] of Object.entries(issuesByNodeName)) {
+		executionIssuesByNodeName.set(
 			nodeName,
 			computed(() => issues),
 		);
@@ -92,7 +92,7 @@ function createRenderDataWithExecutionIssues(
 	return shallowRef({
 		nodeInputsByNodeId: new Map(),
 		nodeOutputsByNodeId: new Map(),
-		executionIssues,
+		executionIssuesByNodeName,
 	});
 }
 
@@ -1141,7 +1141,7 @@ describe('useCanvasMapping', () => {
 				const nodes = [node];
 				const connections = {};
 				const workflowObject = createTestWorkflowObject({ nodes, connections });
-				const renderData = createRenderDataWithExecutionIssues({
+				const renderData = createRenderDataWithExecutionIssuesByNodeName({
 					[node.name]: ['Test error message (Test error description)'],
 				});
 
@@ -1192,7 +1192,7 @@ describe('useCanvasMapping', () => {
 				const nodes = [node];
 				const connections = {};
 				const workflowObject = createTestWorkflowObject({ nodes, connections });
-				const renderData = createRenderDataWithExecutionIssues({
+				const renderData = createRenderDataWithExecutionIssuesByNodeName({
 					[node.name]: ['Execution error (Error description)'],
 				});
 
@@ -1220,7 +1220,7 @@ describe('useCanvasMapping', () => {
 				const nodes = [node1, node2];
 				const connections = {};
 				const workflowObject = createTestWorkflowObject({ nodes, connections });
-				const renderData = createRenderDataWithExecutionIssues({
+				const renderData = createRenderDataWithExecutionIssuesByNodeName({
 					[node2.name]: ['Execution error (Error description)'],
 				});
 
@@ -1642,7 +1642,7 @@ describe('useCanvasMapping', () => {
 				const nodes = [node];
 				const connections = {};
 				const workflowObject = createTestWorkflowObject({ nodes, connections });
-				const renderData = createRenderDataWithExecutionIssues({
+				const renderData = createRenderDataWithExecutionIssuesByNodeName({
 					[node.name]: ['Execution error (Error description)'],
 				});
 				setPinData({});

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
@@ -390,7 +390,7 @@ export function useCanvasMapping({
 	const nodeHasIssuesById = computed(() =>
 		nodes.value.reduce<Record<string, boolean>>((acc, node) => {
 			const hasExecutionErrors =
-				(renderData.value.executionIssues.get(node.name)?.value?.length ?? 0) > 0;
+				(renderData.value.executionIssuesByNodeName.get(node.name)?.value?.length ?? 0) > 0;
 			const hasValidationErrors = nodeValidationErrorsById.value[node.id]?.length > 0;
 
 			if (['crashed', 'error'].includes(nodeExecutionStatusById.value[node.id])) {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
@@ -47,7 +47,6 @@ import {
 	STICKY_NODE_TYPE,
 	WAIT_NODE_TYPE,
 } from '@/app/constants';
-import { sanitizeHtml } from '@/app/utils/htmlUtils';
 import { MarkerType } from '@vue-flow/core';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { getTriggerNodeServiceName } from '@/app/utils/nodeTypesUtils';
@@ -374,26 +373,6 @@ export function useCanvasMapping({
 		{ throttle: CANVAS_EXECUTION_DATA_THROTTLE_DURATION, immediate: true },
 	);
 
-	const nodeExecutionErrorsById = computed(() =>
-		nodes.value.reduce<Record<string, string[]>>((acc, node) => {
-			const executionErrors: string[] = [];
-			const nodeExecutionRunData = workflowsStore.getWorkflowRunData?.[node.name];
-			if (nodeExecutionRunData) {
-				nodeExecutionRunData.forEach((executionRunData) => {
-					if (executionRunData?.error) {
-						const { message, description } = executionRunData.error;
-						const issue = `${message}${description ? ` (${description})` : ''}`;
-						executionErrors.push(sanitizeHtml(issue));
-					}
-				});
-			}
-
-			acc[node.id] = executionErrors;
-
-			return acc;
-		}, {}),
-	);
-
 	const nodeValidationErrorsById = computed(() =>
 		nodes.value.reduce<Record<string, string[]>>((acc, node) => {
 			const validationErrors: string[] = [];
@@ -410,7 +389,8 @@ export function useCanvasMapping({
 
 	const nodeHasIssuesById = computed(() =>
 		nodes.value.reduce<Record<string, boolean>>((acc, node) => {
-			const hasExecutionErrors = nodeExecutionErrorsById.value[node.id]?.length > 0;
+			const hasExecutionErrors =
+				(renderData.value.executionIssues.get(node.name)?.value?.length ?? 0) > 0;
 			const hasValidationErrors = nodeValidationErrorsById.value[node.id]?.length > 0;
 
 			if (['crashed', 'error'].includes(nodeExecutionStatusById.value[node.id])) {
@@ -604,7 +584,6 @@ export function useCanvasMapping({
 						[CanvasConnectionMode.Output]: outputConnections,
 					},
 					issues: {
-						execution: nodeExecutionErrorsById.value[node.id],
 						validation: nodeValidationErrorsById.value[node.id],
 						visible: nodeHasIssuesById.value[node.id],
 					},

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNode.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNode.test.ts
@@ -32,7 +32,6 @@ describe('useCanvasNode', () => {
 		expect(result.runDataOutputMap.value).toEqual({});
 		expect(result.runDataIterations.value).toBe(0);
 		expect(result.hasRunData.value).toBe(false);
-		expect(result.issues.value).toEqual([]);
 		expect(result.hasIssues.value).toBe(false);
 		expect(result.executionStatus.value).toBeUndefined();
 		expect(result.executionWaiting.value).toBeUndefined();
@@ -54,7 +53,6 @@ describe('useCanvasNode', () => {
 					[CanvasConnectionMode.Output]: {},
 				},
 				issues: {
-					execution: ['execution_error1'],
 					validation: ['validation_error1'],
 					visible: true,
 				},
@@ -92,7 +90,7 @@ describe('useCanvasNode', () => {
 		expect(result.runDataOutputMap.value).toEqual({});
 		expect(result.runDataIterations.value).toBe(1);
 		expect(result.hasRunData.value).toBe(true);
-		expect(result.issues.value).toEqual(['execution_error1', 'validation_error1']);
+		expect(result.validationErrors.value).toEqual(['validation_error1']);
 		expect(result.hasIssues.value).toBe(true);
 		expect(result.executionStatus.value).toBe('running');
 		expect(result.executionWaiting.value).toBe('waiting');

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNode.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNode.ts
@@ -18,7 +18,7 @@ export function useCanvasNode() {
 				typeVersion: 1,
 				disabled: false,
 				connections: { [CanvasConnectionMode.Input]: {}, [CanvasConnectionMode.Output]: {} },
-				issues: { execution: [], validation: [], visible: false },
+				issues: { validation: [], visible: false },
 				pinnedData: { count: 0, visible: false },
 				execution: {
 					running: false,
@@ -45,11 +45,8 @@ export function useCanvasNode() {
 	const pinnedDataCount = computed(() => data.value.pinnedData.count);
 	const hasPinnedData = computed(() => data.value.pinnedData.count > 0);
 
-	const issues = computed(() => [...data.value.issues.execution, ...data.value.issues.validation]);
-	const executionErrors = computed(() => data.value.issues.execution ?? []);
 	const validationErrors = computed(() => data.value.issues.validation ?? []);
 	const hasIssues = computed(() => data.value.issues.visible);
-	const hasExecutionErrors = computed(() => data.value.issues.execution.length > 0);
 	const hasValidationErrors = computed(() => data.value.issues.validation.length > 0);
 
 	const executionStatus = computed(() => data.value.execution.status);
@@ -88,11 +85,8 @@ export function useCanvasNode() {
 		runDataIterations,
 		runDataOutputMap,
 		hasRunData,
-		issues,
-		executionErrors,
 		validationErrors,
 		hasIssues,
-		hasExecutionErrors,
 		hasValidationErrors,
 		executionStatus,
 		executionWaiting,

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/SyncedWorkflowCanvas.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/SyncedWorkflowCanvas.test.ts
@@ -92,7 +92,11 @@ describe('SyncedWorkflowCanvas', () => {
 				id: 'test-canvas',
 				nodes: [],
 				connections: [],
-				renderData: { nodeInputsByNodeId: new Map(), nodeOutputsByNodeId: new Map() },
+				renderData: {
+					nodeInputsByNodeId: new Map(),
+					nodeOutputsByNodeId: new Map(),
+					executionIssues: new Map(),
+				},
 			},
 		});
 		expect(container).toBeTruthy();
@@ -106,7 +110,11 @@ describe('SyncedWorkflowCanvas', () => {
 					nodes: [],
 					connections: [],
 					applyLayout: true,
-					renderData: { nodeInputsByNodeId: new Map(), nodeOutputsByNodeId: new Map() },
+					renderData: {
+						nodeInputsByNodeId: new Map(),
+						nodeOutputsByNodeId: new Map(),
+						executionIssues: new Map(),
+					},
 				},
 			});
 
@@ -129,7 +137,11 @@ describe('SyncedWorkflowCanvas', () => {
 					nodes: [],
 					connections: [],
 					applyLayout: false,
-					renderData: { nodeInputsByNodeId: new Map(), nodeOutputsByNodeId: new Map() },
+					renderData: {
+						nodeInputsByNodeId: new Map(),
+						nodeOutputsByNodeId: new Map(),
+						executionIssues: new Map(),
+					},
 				},
 			});
 
@@ -148,7 +160,11 @@ describe('SyncedWorkflowCanvas', () => {
 					id: 'test-canvas',
 					nodes: [],
 					connections: [],
-					renderData: { nodeInputsByNodeId: new Map(), nodeOutputsByNodeId: new Map() },
+					renderData: {
+						nodeInputsByNodeId: new Map(),
+						nodeOutputsByNodeId: new Map(),
+						executionIssues: new Map(),
+					},
 				},
 			});
 
@@ -168,7 +184,11 @@ describe('SyncedWorkflowCanvas', () => {
 					nodes: [],
 					connections: [],
 					applyLayout: true,
-					renderData: { nodeInputsByNodeId: new Map(), nodeOutputsByNodeId: new Map() },
+					renderData: {
+						nodeInputsByNodeId: new Map(),
+						nodeOutputsByNodeId: new Map(),
+						executionIssues: new Map(),
+					},
 				},
 			});
 

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/SyncedWorkflowCanvas.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/SyncedWorkflowCanvas.test.ts
@@ -95,7 +95,7 @@ describe('SyncedWorkflowCanvas', () => {
 				renderData: {
 					nodeInputsByNodeId: new Map(),
 					nodeOutputsByNodeId: new Map(),
-					executionIssues: new Map(),
+					executionIssuesByNodeName: new Map(),
 				},
 			},
 		});
@@ -113,7 +113,7 @@ describe('SyncedWorkflowCanvas', () => {
 					renderData: {
 						nodeInputsByNodeId: new Map(),
 						nodeOutputsByNodeId: new Map(),
-						executionIssues: new Map(),
+						executionIssuesByNodeName: new Map(),
 					},
 				},
 			});
@@ -140,7 +140,7 @@ describe('SyncedWorkflowCanvas', () => {
 					renderData: {
 						nodeInputsByNodeId: new Map(),
 						nodeOutputsByNodeId: new Map(),
-						executionIssues: new Map(),
+						executionIssuesByNodeName: new Map(),
 					},
 				},
 			});
@@ -163,7 +163,7 @@ describe('SyncedWorkflowCanvas', () => {
 					renderData: {
 						nodeInputsByNodeId: new Map(),
 						nodeOutputsByNodeId: new Map(),
-						executionIssues: new Map(),
+						executionIssuesByNodeName: new Map(),
 					},
 				},
 			});
@@ -187,7 +187,7 @@ describe('SyncedWorkflowCanvas', () => {
 					renderData: {
 						nodeInputsByNodeId: new Map(),
 						nodeOutputsByNodeId: new Map(),
-						executionIssues: new Map(),
+						executionIssuesByNodeName: new Map(),
 					},
 				},
 			});

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffContent.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffContent.test.ts
@@ -105,12 +105,12 @@ describe('WorkflowDiffContent', () => {
 		sourceRenderData: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
-			executionIssues: new Map(),
+			executionIssuesByNodeName: new Map(),
 		},
 		targetRenderData: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
-			executionIssues: new Map(),
+			executionIssuesByNodeName: new Map(),
 		},
 	};
 

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffContent.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffContent.test.ts
@@ -102,8 +102,16 @@ describe('WorkflowDiffContent', () => {
 		isSourceWorkflowNew: false,
 		nodesDiff: new Map(),
 		connectionsDiff: new Map(),
-		sourceRenderData: { nodeInputsByNodeId: new Map(), nodeOutputsByNodeId: new Map() },
-		targetRenderData: { nodeInputsByNodeId: new Map(), nodeOutputsByNodeId: new Map() },
+		sourceRenderData: {
+			nodeInputsByNodeId: new Map(),
+			nodeOutputsByNodeId: new Map(),
+			executionIssues: new Map(),
+		},
+		targetRenderData: {
+			nodeInputsByNodeId: new Map(),
+			nodeOutputsByNodeId: new Map(),
+			executionIssues: new Map(),
+		},
 	};
 
 	describe('panels', () => {

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffModal.test.ts
@@ -63,7 +63,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
-			executionIssues: new Map(),
+			executionIssuesByNodeName: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffModal.test.ts
@@ -63,6 +63,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
+			executionIssues: new Map(),
 		},
 	})),
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiff.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiff.test.ts
@@ -27,6 +27,7 @@ const mockDocumentStore = vi.hoisted(() => ({
 	render: {
 		nodeInputsByNodeId: new Map(),
 		nodeOutputsByNodeId: new Map(),
+		executionIssues: new Map(),
 	},
 	$id: 'test-store',
 	$dispose: vi.fn(),
@@ -36,6 +37,13 @@ vi.mock('@/app/stores/workflowDocument.store', () => ({
 	createWorkflowDocumentId: vi.fn().mockReturnValue('test-id'),
 	injectWorkflowDocumentStore: () => ({ value: mockDocumentStore }),
 	disposeWorkflowDocumentStore: vi.fn(),
+}));
+
+vi.mock('@/app/stores/workflowExecutionState.store', () => ({
+	useWorkflowExecutionStateStore: () => ({
+		getActiveExecutionIssues: () => new Map(),
+	}),
+	createWorkflowExecutionStateId: (id: string) => id,
 }));
 
 vi.mock('@/app/stores/nodeTypes.store', () => ({

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiff.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiff.test.ts
@@ -41,7 +41,7 @@ vi.mock('@/app/stores/workflowDocument.store', () => ({
 
 vi.mock('@/app/stores/workflowExecutionState.store', () => ({
 	useWorkflowExecutionStateStore: () => ({
-		getActiveExecutionIssuesByNodeName: () => new Map(),
+		activeExecutionIssuesByNodeName: new Map(),
 	}),
 	createWorkflowExecutionStateId: (id: string) => id,
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiff.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiff.test.ts
@@ -27,7 +27,7 @@ const mockDocumentStore = vi.hoisted(() => ({
 	render: {
 		nodeInputsByNodeId: new Map(),
 		nodeOutputsByNodeId: new Map(),
-		executionIssues: new Map(),
+		executionIssuesByNodeName: new Map(),
 	},
 	$id: 'test-store',
 	$dispose: vi.fn(),
@@ -41,7 +41,7 @@ vi.mock('@/app/stores/workflowDocument.store', () => ({
 
 vi.mock('@/app/stores/workflowExecutionState.store', () => ({
 	useWorkflowExecutionStateStore: () => ({
-		getActiveExecutionIssues: () => new Map(),
+		getActiveExecutionIssuesByNodeName: () => new Map(),
 	}),
 	createWorkflowExecutionStateId: (id: string) => id,
 }));

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiff.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiff.ts
@@ -12,6 +12,7 @@ import {
 	createWorkflowDocumentId,
 	disposeWorkflowDocumentStore,
 } from '@/app/stores/workflowDocument.store';
+import { useWorkflowDocumentRenderData } from '@/app/stores/workflowDocument/useWorkflowDocumentRenderData';
 import type { CanvasRenderData } from '@/features/workflows/canvas/canvas.utils';
 
 export function mapConnections(connections: CanvasConnection[]) {
@@ -130,7 +131,7 @@ function createDiffRenderData(workflowRef: ComputedRef<IWorkflowDb | undefined>,
 
 		workflowDocumentStore = useWorkflowDocumentStore(docId);
 		workflowDocumentStore.hydrate({ ...wf, versionId } as IWorkflowDb);
-		renderData.value = workflowDocumentStore.render;
+		renderData.value = useWorkflowDocumentRenderData(docId);
 	});
 
 	function dispose() {

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiff.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiff.ts
@@ -115,6 +115,7 @@ function createDiffRenderData(workflowRef: ComputedRef<IWorkflowDb | undefined>,
 	const renderData = shallowRef<CanvasRenderData>({
 		nodeInputsByNodeId: new Map(),
 		nodeOutputsByNodeId: new Map(),
+		executionIssues: new Map(),
 	});
 	let workflowDocumentStore: ReturnType<typeof useWorkflowDocumentStore> | null = null;
 

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiff.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiff.ts
@@ -115,7 +115,7 @@ function createDiffRenderData(workflowRef: ComputedRef<IWorkflowDb | undefined>,
 	const renderData = shallowRef<CanvasRenderData>({
 		nodeInputsByNodeId: new Map(),
 		nodeOutputsByNodeId: new Map(),
-		executionIssues: new Map(),
+		executionIssuesByNodeName: new Map(),
 	});
 	let workflowDocumentStore: ReturnType<typeof useWorkflowDocumentStore> | null = null;
 


### PR DESCRIPTION
## Summary

Inverts ownership of the per-node canvas port maps. The `ShallowReactive`
`nodeInputsByNodeId` / `nodeOutputsByNodeId` maps stay owned by
`useWorkflowDocumentNodes` and are now exposed directly on the workflow
document store. `useWorkflowDocumentRenderData` becomes a standalone
consumer-facing composable that takes a `WorkflowDocumentId`, retrieves the
store internally, and returns the maps flat (no `render` wrapper).

`WorkflowCanvas.vue` and `useWorkflowDiff.ts` now call the composable
instead of reading `store.render`. Granular per-node reactivity is
preserved end-to-end: both maps are stable references on the store, the
outer `computed` only re-runs on document change, and consumer
`.get(nodeId).value` reads keep their per-entry `ComputedRef` dependencies.

**Test plan:** Load a workflow with multi-input nodes (e.g. Merge) and
open a workflow diff view — confirm ports render, connection handles
draw, and node sizing reflects port counts on both screens.

## Related Linear tickets, Github issues, and Community forum posts

_None._

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI