### PR TITLE
ci: Run migration-timestamp rule on pre-commit (no-changelog)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -32,6 +32,14 @@ pre-commit:
       skip:
         - merge
         - rebase
+    migration_timestamp_check:
+      glob: 'packages/@n8n/db/src/migrations/{common,postgresdb,sqlite}/*.ts'
+      run: |
+        files=$(echo "{staged_files}" | tr ' ' ',')
+        CODE_HEALTH_CHANGED_FILES="$files" pnpm --filter=@n8n/code-health check --rule=migration-timestamp
+      skip:
+        - merge
+        - rebase
     playwright_janitor:
       glob: 'packages/testing/playwright/**/*.ts'
       run: |


### PR DESCRIPTION
## Summary

Wire the existing `@n8n/code-health` `migration-timestamp` rule into lefthook so migration-ordering violations surface locally on `git commit` instead of after a CI round-trip.

- Glob-scoped to `packages/@n8n/db/src/migrations/{common,postgresdb,sqlite}/*.ts`, so the hook is a no-op unless a migration file is staged.
- Passes `{staged_files}` through `CODE_HEALTH_CHANGED_FILES` (comma-joined, matching the CLI's parser) so only the staged files are checked for ordering — pre-existing violations are not re-flagged.
- Runs `--rule=migration-timestamp` only, keeping execution well under a second.
- Skips on merge/rebase, matching the other pre-commit entries.

This is a friction reduction, not a correctness fix — the merge queue still catches collisions between concurrent PRs. The motivating case is the "master moved while I wasn't looking" loop, where a stale local floor causes a CI failure that's only visible after push.

### How to test
1. `git checkout` this branch.
2. Stage a new migration file under `packages/@n8n/db/src/migrations/common/` with a timestamp at or below the current max (e.g. `1784000000003-Foo.ts`).
3. `git commit` — lefthook should block the commit with the `migration-timestamp` violation message and a suggested timestamp.
4. Bump the filename to a higher timestamp and re-stage — commit should pass.

## Related Linear tickets, Github issues, and Community forum posts

_None — direct response to repeated in-flight collisions on `1784000000003`._

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)