### PR TITLE
fix(core): Populate manual user id on webhook execution data path

### DIFF
--- a/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts
@@ -503,6 +503,54 @@ describe('prepareExecutionData', () => {
 		expect(runExecutionData.resultData.pinData).toBeUndefined();
 	});
 
+	test('should populate manualData.userId for manual executions when userId is provided', () => {
+		const { runExecutionData } = prepareExecutionData(
+			'manual',
+			workflowStartNode,
+			webhookResultData,
+			undefined,
+			{},
+			undefined,
+			undefined,
+			workflowData,
+			'user-abc',
+		);
+
+		expect(runExecutionData.manualData).toEqual({ userId: 'user-abc' });
+	});
+
+	test('should not populate manualData when userId is undefined', () => {
+		const { runExecutionData } = prepareExecutionData(
+			'manual',
+			workflowStartNode,
+			webhookResultData,
+			undefined,
+			{},
+			undefined,
+			undefined,
+			workflowData,
+			undefined,
+		);
+
+		expect(runExecutionData.manualData).toBeUndefined();
+	});
+
+	test('should not populate manualData for non-manual execution modes', () => {
+		const { runExecutionData } = prepareExecutionData(
+			'webhook',
+			workflowStartNode,
+			webhookResultData,
+			undefined,
+			{},
+			undefined,
+			undefined,
+			workflowData,
+			'user-abc',
+		);
+
+		expect(runExecutionData.manualData).toBeUndefined();
+	});
+
 	describe('MICROSOFT_AGENT365_TRIGGER_NODE_TYPE merge condition', () => {
 		test('should merge nodeExecutionStack when node type is MICROSOFT_AGENT365_TRIGGER_NODE_TYPE and runExecutionData exists', () => {
 			const microsoftAgentNode = mock<INode>({

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -356,6 +356,7 @@ export function prepareExecutionData(
 	destinationNode?: IDestinationNode,
 	executionId?: string,
 	workflowData?: IWorkflowBase,
+	userId?: string,
 ): { runExecutionData: IRunExecutionData; pinData: IPinData | undefined } {
 	// Initialize the data of the webhook node
 	const nodeExecutionStack: IExecuteData[] = [
@@ -381,6 +382,7 @@ export function prepareExecutionData(
 		executionData: {
 			nodeExecutionStack,
 		},
+		...(executionMode === 'manual' && userId ? { manualData: { userId } } : {}),
 	});
 
 	if (destinationNode && runExecutionData.startData) {
@@ -535,6 +537,9 @@ export async function executeWebhook(
 					executionData: {
 						nodeExecutionStack,
 					},
+					...(executionMode === 'manual' && webhookData.userId
+						? { manualData: { userId: webhookData.userId } }
+						: {}),
 				});
 		}
 
@@ -647,6 +652,7 @@ export async function executeWebhook(
 			destinationNode,
 			executionId,
 			workflowData,
+			webhookData.userId,
 		);
 		runExecutionData = preparedRunExecutionData;
 


### PR DESCRIPTION
## Summary

Manual workflow executions started via Form Trigger or Webhook node failed to deliver
node input/output data to the editor when running with
`OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS=true` and
`EXECUTIONS_DATA_SAVE_MANUAL_EXECUTIONS=false`. Editor panels would spin indefinitely
with no error surfaced. This PR threads the manual user identity through the webhook
execution data path so the worker can resolve the running user when preparing
real-time push events.

### What changed

`packages/cli/src/webhooks/webhook-helpers.ts`:

- `prepareExecutionData()` takes a new optional `userId` parameter and, for manual
  executions, writes it onto the freshly created `runExecutionData.manualData`.
- `executeWebhook()` threads `webhookData.userId` into that call.
- The MCP / Chat trigger early-init `createRunExecutionData()` call gets the same
  conditional `manualData` block to avoid the same latent gap on those triggers.

This brings the webhook entry path in line with the existing "Run from this node"
path (`workflow-execution.service.ts`), which already populates `manualData.userId`.

### Why

The worker's `nodeExecuteAfter` hook
(`packages/cli/src/execution-lifecycle/execution-lifecycle-hooks.ts`) resolves a
`User` from `execution.data.manualData.userId` before sending `nodeExecuteAfterData`,
and skips the data push when the user cannot be resolved. The two
`createRunExecutionData()` call sites in `webhook-helpers.ts` previously omitted any
`manualData` block, so the worker always received `userId: undefined` for webhook
manual runs and skipped the data frame. With
`EXECUTIONS_DATA_SAVE_MANUAL_EXECUTIONS=false` the REST fallback also returned `{}`
(execution soft-deleted on completion), so neither delivery channel produced data.

### How to test manually

Prerequisites — run in queue mode with:

```
EXECUTIONS_MODE=queue
OFFLOAD_MANUAL_EXECUTIONS_TO_WORKERS=true
EXECUTIONS_DATA_SAVE_MANUAL_EXECUTIONS=false
```

(Main + worker + Postgres + Redis.)

1. Build a workflow: Form Trigger (one field, e.g. `email`) → any second node.
2. Save the workflow.
3. Click **Test workflow**, submit the form when it opens.
4. Observe the editor's node input/output panels.

**Expected:** panels populate with execution data in real time. Worker log contains
no `Skipping execution data push: unable to resolve user for redaction` warnings.

**Before this fix:** spinner forever; worker log shows the skip warning.

Worth also verifying:

- Production (non-manual) webhook executions are unaffected — the new `manualData`
  block is gated on `executionMode === 'manual'`.
- A manual webhook execution with `EXECUTIONS_DATA_SAVE_MANUAL_EXECUTIONS=true`
  continues to work (REST fallback path).

### Key implementation decisions

- **Gated on `executionMode === 'manual'`.** Mirrors `executeManually()` semantics;
  production webhook executions don't go through the offload-to-worker path and
  don't need `manualData`.
- **Only `userId` is populated.** `dirtyNodeNames` and `triggerToStartFrom` belong
  to the "Run from this node" path, not the webhook entry path.
- **`userId` threaded as an explicit `prepareExecutionData()` parameter** rather
  than accessed via `webhookData` inside the helper. Keeps the contract typed and
  visible; the helper is exported and already directly unit-tested.
- **Skipped when `userId` is undefined.** Webhook runs without a resolvable user
  still fail-close on the worker — that's the intended redaction safety behavior
  and a separate concern.

### Tests

Three unit tests added inside the existing `describe('prepareExecutionData', …)`
block in `packages/cli/src/webhooks/__tests__/webhook-helpers.test.ts`:

- Populates `manualData.userId` for manual executions when `userId` is provided.
- Omits `manualData` when `userId` is undefined.
- Omits `manualData` for non-manual execution modes.

The consumer-side fail-closed contract is already covered by existing tests at
`packages/cli/src/execution-lifecycle/__tests__/execution-lifecycle-hooks.test.ts:692–756`
(verified still green).

## Related Links

closes https://linear.app/n8n/issue/IAM-678
- Fixes #21185

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
