### PR TITLE
chore(editor): Mark workflow setup parameter issue test as fixme (no-changelog)

### DIFF
--- a/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-workflow-setup.spec.ts
+++ b/packages/testing/playwright/tests/e2e/instance-ai/instance-ai-workflow-setup.spec.ts
@@ -774,6 +774,10 @@ test.describe(
 		test('should clear required parameter issue indicator when the field is filled', async ({
 			n8n,
 		}) => {
+			test.fixme(
+				true,
+				'Broken by ParameterInput node-resolution refactor in #30219 — issues are computed against the global workflow document store node instead of the wizard displayNode.',
+			);
 			await n8n.api.workflows.createWorkflow(
 				createParameterOnlyWorkflow(PARAMETER_ISSUE_WORKFLOW_NAME),
 			);


### PR DESCRIPTION
## Summary

- Mark the Playwright test `should clear required parameter issue indicator when the field is filled` as `test.fixme` with the root cause inline.
- The test broke after the refactor in #30219: `ParameterInput.node` now resolves the contextual node via `workflowDocumentStore.getNodeByName(...)` instead of the local workflow on `ExpressionLocalResolveContext`. The Instance AI workflow setup wizard keeps its in-progress credential/parameter edits in local refs (never touching the document store), so `getParameterIssues` is computed against the stale, unedited node and never reacts to wizard input.
- A follow-up will restore the wizard's ability to drive `ParameterInput`'s contextual node (e.g. by re-introducing a node accessor on the expression context, or by scoping a document store to the wizard).

## Test plan

- [x] I have seen this code, I have run this code, and I take responsibility for this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)