### PR TITLE
build: Pin n8nio/base by revision SHA on release-candidate/2.20.x (no-changelog)

### DIFF
--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -1,6 +1,14 @@
 ARG NODE_VERSION=24.15.0
 ARG N8N_VERSION=snapshot
 
+# Pinned revision of n8nio/base. The base image is rebuilt from master's
+# n8n-base/Dockerfile and republished under the floating `n8nio/base:<NODE_VERSION>`
+# tag, so any upstream-layout shift (alpine/DHI/Node bumps) on master is
+# otherwise forced through to this release lane on the next build.
+# Bump deliberately; do not let a floating tag move us silently.
+# Advance via: chore: Advance n8nio/base pin on release-candidate/2.20.x
+ARG BASE_IMAGE_REVISION=82575001e322fb0286069812b735a7a640d5bc48
+
 # Rebuild native addons for the container platform. The base image has no
 # package manager or build tools, so we compile in a throwaway builder stage.
 FROM node:${NODE_VERSION}-alpine3.23 AS builder
@@ -9,7 +17,7 @@ RUN apk add --no-cache python3 make g++ && \
     cd /usr/local/lib/node_modules/n8n && \
     npm rebuild sqlite3 isolated-vm
 
-FROM n8nio/base:${NODE_VERSION}
+FROM n8nio/base:${NODE_VERSION}-${BASE_IMAGE_REVISION}
 
 ARG N8N_VERSION
 ARG N8N_RELEASE_TYPE=dev


### PR DESCRIPTION
## Summary

Pin the `n8nio/base` `FROM` reference in `docker/images/n8n/Dockerfile` from the floating `n8nio/base:${NODE_VERSION}` tag to the SHA-suffixed `n8nio/base:${NODE_VERSION}-${BASE_IMAGE_REVISION}` variant that the base-image-build workflow already publishes alongside it.

### Why

`n8nio/base:24.15.0` is a single mutable tag, rebuilt from master's `docker/images/n8n-base/Dockerfile` whenever the base-image-build workflow runs. Any upstream-layout shift on master — alpine major, DHI base restructure, Node bump — is force-pushed under every release lane's feet on the next docker build.

The recent DHI alpine 3.22 → 3.23 migration (#30478) is a concrete example: it moved npm globals from `/usr/local/lib/node_modules` to `/usr/lib/node_modules` and dropped `/usr/local/bin` from the base layout. Once master republished `n8nio/base:24.15.0` against that base, this lane's `n8n/Dockerfile` could no longer build (`COPY ... /usr/local/lib/node_modules/n8n` against a directory that no longer exists), forcing the layout-matching changes through as #30624. Side effects of that forced migration included moving the public `/usr/local/bin/n8n` path, which downstream stacks pinned to (#30622 was needed to restore it via compat symlink).

Pinning by revision SHA removes the forcing function: master's base-image rebuilds only land on this lane via a deliberate bump PR, not as a CI side-effect.

### What changed

- Added `ARG BASE_IMAGE_REVISION=82575001e322fb0286069812b735a7a640d5bc48` (current `n8nio/base:24.15.0` head of master — same digest as the floating `24.15.0` tag right now, so functionally a no-op for the next build).
- `FROM n8nio/base:${NODE_VERSION}` → `FROM n8nio/base:${NODE_VERSION}-${BASE_IMAGE_REVISION}`.

### Sequencing

This PR is independent of #30622's backport (which adds the `/usr/local/bin/n8n` compat symlink). They touch different lines; either order of merge is fine. Suggested order:

1. **First:** the `Backport to Stable` of #30622 to `release-candidate/2.20.x`.
2. **Then:** this PR — protects the lane from the next forced-bump.

### Out of scope (follow-ups)

- Apply the same pattern to `release-candidate/2.21.x` and `1.x` (1.x is incidentally safe right now because `n8nio/base:24.13.1` wasn't included in the alpine 3.23 rebuild matrix — luck, not architecture).
- Pin the upstream `FROM node:${NODE_VERSION}-alpine3.23 AS builder` stage by digest for fully hermetic builds.
- Pin `dhi.io/node:${NODE_VERSION}-alpine3.23-dev` by digest inside `n8n-base/Dockerfile` on master, so master's own base rebuilds are also deliberate rather than DHI-driven.
- Renovate-style automation to bump `BASE_IMAGE_REVISION` as a routine reviewable action.

## Related Linear tickets, Github issues, and Community forum posts

- Mechanism: #30478 (alpine 3.23 migration) → #30624 (backport that demonstrated the forcing function)
- Tactical fix that restored the `/usr/local/bin/n8n` contract: #30622

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created. — No docs change; internal Dockerfile pin.
- [ ] Tests included. — Dockerfile-only change. The CI Docker build job is the test; passing on this PR proves the pinned tag resolves and builds end-to-end.
- [ ] Backport — N/A; this PR *is* the stable-lane change. Equivalent PRs for 2.21.x and 1.x should be filed separately so each lane's pin can advance on its own cadence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)