### PR TITLE
ci: Bump Aikido SafeChain to 1.5.3, add install timeout (no-changelog)

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -54,8 +54,8 @@ runs:
 
     - name: Install Aikido SafeChain
       run: |
-        VERSION="1.5.1"
-        EXPECTED_SHA256="7c910fff717649c86cc8ca960e6c054d3734da2d660050e3bcfc54029e3b485b"
+        VERSION="1.5.3"
+        EXPECTED_SHA256="0107cbbbf90159379756157e902acae512d62ffbd174307e42c5fe9f266792d3"
         node .github/scripts/retry.mjs --attempts 3 --delay 10 -- \
           curl -fsSL -o install-safe-chain.sh "https://github.com/AikidoSec/safe-chain/releases/download/${VERSION}/install-safe-chain.sh"
         echo "${EXPECTED_SHA256}  install-safe-chain.sh" | sha256sum -c -
@@ -69,7 +69,7 @@ runs:
         INSTALL_COMMAND: ${{ inputs.install-command }}
         SAFE_CHAIN_LOGGING: verbose
       run: |
-        $INSTALL_COMMAND --reporter=append-only
+        timeout --kill-after=30s 300s $INSTALL_COMMAND --reporter=append-only
       shell: bash
 
     - name: Configure Turborepo Cache


### PR DESCRIPTION
## Summary

- Bump pinned Aikido SafeChain from `1.5.1` to `1.5.3` in `.github/actions/setup-nodejs/action.yml`. SHA256 `0107cbbbf90159379756157e902acae512d62ffbd174307e42c5fe9f266792d3` computed fresh from the [1.5.3 GitHub release asset](https://github.com/AikidoSec/safe-chain/releases/download/1.5.3/install-safe-chain.sh).
- Wrap the install step in `timeout --kill-after=30s 300s` so silent stalls fail loud with exit 124 instead of consuming the GHA step ceiling.

## Motivation

The `Performance / Benchmarks` job in [run 26047187407](https://github.com/n8n-io/n8n/actions/runs/26047187407/job/76574353099) spent 2m20s in `pnpm install --frozen-lockfile --reporter=append-only` on a **warm** pnpm store and died with `ELIFECYCLE` and zero output, despite `SAFE_CHAIN_LOGGING: verbose`. All other jobs in the same run passed.

The Blacksmith host had serviced 8 jobs through the same agent process (`Host Agent PID: 542515`) — the same class of host-reuse problem #30604 addressed for the Turborepo cache server via `server-port: 0`.

Two leverage points:

- **safe-chain [1.5.2 changelog](https://github.com/AikidoSec/safe-chain/releases/tag/1.5.2)** introduced *"Bind registry proxy to loopback only"* — same shape of fix as the rharkor bump, hardening how a localhost service binds on a shared host. We were on 1.5.1, missing this. 1.5.3 is stabilisation on top.
- **5-minute timeout** makes future silent stalls visible (exit 124) instead of invisible. A warm `pnpm install` on this monorepo runs in 60–90s, so 300s is generous.

## Related

- Failing run: https://github.com/n8n-io/n8n/actions/runs/26047187407
- Same class of bug, prior fix: #30604

## Review / Merge checklist
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] CI passes on this PR (the bumped composite action is the standard CI entry point, so this validates repo-wide).