### PR TITLE
fix: Improve browser_scroll description (no-changelog)

### DIFF
--- a/packages/@n8n/mcp-browser/src/tools/interaction.ts
+++ b/packages/@n8n/mcp-browser/src/tools/interaction.ts
@@ -256,7 +256,9 @@ const scrollByDirectionSchema = z.object({
 
 const browserScrollSchema = z
 	.discriminatedUnion('mode', [scrollToElementSchema, scrollByDirectionSchema])
-	.describe('Scroll an element into view, or scroll the page by direction/amount');
+	.describe(
+		'Scroll an element into view, or scroll the page by direction/amount in pixels. Always use an element if possible.',
+	);
 
 const browserScrollOutputSchema = withSnapshotEnvelope({
 	scrolled: z.boolean(),


### PR DESCRIPTION
## Summary

Improves the description of `browser_scroll` tool for a more reliable usage by AI Assistant. Before the change the AI would mostly execute the scroll tool with a `direction` and `amount` even if it wanted to click a button that was outside of the current scroll view. This often fails for two reasons:
1. AI often assumes that amount 1 is a full window height and not 1 pixel (fixed in the prompt)
2. Depending on the page layout it can have multiple scrollable elements - normal scroll binds to "document" (fixed by instructing to use a ref if possible)

To test:
- create a slack app
- ask AI to navigate to that app's url (looks like `https://api.slack.com/apps/xxx`)
- ask AI to click "Generate Token and Scopes" button - it will fail unless this element is visible on the screen - observe that the AI scrolls to the button after first click attempt

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5073/browser-scroll-works-unreliably


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
