### PR TITLE
fix: Fix search_files computer use tool (no-changelog)

### DIFF
--- a/packages/@n8n/computer-use/package.json
+++ b/packages/@n8n/computer-use/package.json
@@ -45,6 +45,7 @@
     "@napi-rs/image": "^1.12.0",
     "@vscode/ripgrep": "^1.17.1",
     "eventsource": "^3.0.6",
+    "fast-glob": "catalog:",
     "node-screenshots": "^0.2.8",
     "picocolors": "catalog:",
     "yargs-parser": "21.1.1",

--- a/packages/@n8n/computer-use/src/tools/filesystem/search-files.test.ts
+++ b/packages/@n8n/computer-use/src/tools/filesystem/search-files.test.ts
@@ -1,39 +1,50 @@
-import type { Dirent, Stats } from 'node:fs';
 import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
 import { textOf } from '../test-utils';
 import { searchFilesTool } from './search-files';
 
-jest.mock('node:fs/promises');
+type FileMatch = { path: string };
+type ContentMatch = { path: string; lineNumber: number; line: string };
 
-const CONTEXT = { dir: '/base' };
+type NameOnlyResult = {
+	name: string;
+	matches: FileMatch[];
+	truncated: boolean;
+	totalMatches: number;
+};
 
-function dirent(name: string, isDir: boolean): Dirent {
-	return {
-		name,
-		parentPath: '',
-		path: '',
-		isDirectory: () => isDir,
-		isFile: () => !isDir,
-		isSymbolicLink: () => false,
-		isBlockDevice: () => false,
-		isCharacterDevice: () => false,
-		isFIFO: () => false,
-		isSocket: () => false,
-	} as unknown as Dirent;
+type ContentResult = {
+	name: string;
+	query: string;
+	matches: ContentMatch[];
+	truncated: boolean;
+	totalMatches: number;
+};
+
+async function writeFile(root: string, relPath: string, content = ''): Promise<void> {
+	const fullPath = path.join(root, relPath);
+	await fs.mkdir(path.dirname(fullPath), { recursive: true });
+	await fs.writeFile(fullPath, content);
 }
 
-function mockStat(size = 100): void {
-	jest.mocked(fs.stat).mockResolvedValue({ size } as unknown as Stats);
+function parseResult<T>(result: Awaited<ReturnType<typeof searchFilesTool.execute>>): T {
+	// eslint-disable-next-line n8n-local-rules/no-uncaught-json-parse
+	return JSON.parse(textOf(result)) as T;
 }
 
 describe('searchFilesTool', () => {
-	beforeEach(() => {
-		jest.resetAllMocks();
-		(fs.realpath as jest.Mock).mockImplementation(async (p: string) => {
-			if (p === '/base') return await Promise.resolve('/base');
-			throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
-		});
+	let baseDir: string;
+	let context: { dir: string };
+
+	beforeEach(async () => {
+		baseDir = await fs.mkdtemp(path.join(os.tmpdir(), 'search-files-'));
+		context = { dir: baseDir };
+	});
+
+	afterEach(async () => {
+		await fs.rm(baseDir, { recursive: true, force: true });
 	});
 
 	describe('metadata', () => {
@@ -41,212 +52,221 @@ describe('searchFilesTool', () => {
 			expect(searchFilesTool.name).toBe('search_files');
 		});
 
-		it('has a non-empty description', () => {
-			expect(searchFilesTool.description).toBe(
-				'Search for text patterns across files using a literal text query',
-			);
+		it('description steers AI towards the right usage pattern', () => {
+			const description = searchFilesTool.description;
+			expect(description).toContain('Find files by name');
+			expect(description).toContain('glob pattern');
+			expect(description).toContain('query');
 		});
 	});
 
 	describe('inputSchema validation', () => {
-		it('accepts a valid input with only required fields', () => {
-			expect(() => searchFilesTool.inputSchema.parse({ dirPath: '.', query: 'foo' })).not.toThrow();
+		it('accepts only required `name`', () => {
+			expect(() => searchFilesTool.inputSchema.parse({ name: '**/*.ts' })).not.toThrow();
 		});
 
-		it('accepts all optional fields with valid values', () => {
+		it('accepts all optional fields', () => {
 			expect(() =>
 				searchFilesTool.inputSchema.parse({
-					dirPath: 'src',
+					name: '**/*.ts',
 					query: 'TODO',
-					filePattern: '**/*.ts',
 					ignoreCase: true,
 					maxResults: 25,
 				}),
 			).not.toThrow();
 		});
 
-		it('throws when dirPath is missing', () => {
+		it('throws when `name` is missing', () => {
 			expect(() => searchFilesTool.inputSchema.parse({ query: 'foo' })).toThrow();
 		});
 
-		it('throws when query is missing', () => {
-			expect(() => searchFilesTool.inputSchema.parse({ dirPath: '.' })).toThrow();
+		it('throws when `name` is not a string', () => {
+			expect(() => searchFilesTool.inputSchema.parse({ name: 42 })).toThrow();
 		});
 
-		it('throws when dirPath is not a string', () => {
-			expect(() => searchFilesTool.inputSchema.parse({ dirPath: 0, query: 'foo' })).toThrow();
+		it('throws when `query` is not a string', () => {
+			expect(() => searchFilesTool.inputSchema.parse({ name: '**/*', query: true })).toThrow();
 		});
 
-		it('throws when query is not a string', () => {
-			expect(() => searchFilesTool.inputSchema.parse({ dirPath: '.', query: true })).toThrow();
-		});
-
-		it('throws when filePattern is not a string', () => {
+		it('throws when `ignoreCase` is not a boolean', () => {
 			expect(() =>
-				searchFilesTool.inputSchema.parse({ dirPath: '.', query: 'x', filePattern: 42 }),
+				searchFilesTool.inputSchema.parse({ name: '**/*', ignoreCase: 'yes' }),
 			).toThrow();
 		});
 
-		it('throws when ignoreCase is not a boolean', () => {
-			expect(() =>
-				searchFilesTool.inputSchema.parse({ dirPath: '.', query: 'x', ignoreCase: 'yes' }),
-			).toThrow();
+		it('throws when `maxResults` is not an integer', () => {
+			expect(() => searchFilesTool.inputSchema.parse({ name: '**/*', maxResults: 5.5 })).toThrow();
 		});
 
-		it('throws when maxResults is not an integer', () => {
-			expect(() =>
-				searchFilesTool.inputSchema.parse({ dirPath: '.', query: 'x', maxResults: 5.5 }),
-			).toThrow();
-		});
-
-		it('leaves optional fields undefined when not provided', () => {
-			const parsed = searchFilesTool.inputSchema.parse({ dirPath: '.', query: 'x' });
+		it('does not accept removed fields `dirPath` and `filePattern` (now stripped)', () => {
+			const parsed = searchFilesTool.inputSchema.parse({
+				name: '**/*',
+				dirPath: '.',
+				filePattern: '*.ts',
+			}) as Record<string, unknown>;
+			expect(parsed.dirPath).toBeUndefined();
 			expect(parsed.filePattern).toBeUndefined();
-			expect(parsed.ignoreCase).toBeUndefined();
-			expect(parsed.maxResults).toBeUndefined();
 		});
 	});
 
-	describe('execute', () => {
-		it('finds matches across multiple files', async () => {
-			// DFS: readdir('/base') → [src/], readdir('/base/src') → [index.ts, utils.ts]
-			(fs.readdir as jest.Mock)
-				.mockResolvedValueOnce([dirent('src', true)])
-				.mockResolvedValueOnce([dirent('index.ts', false), dirent('utils.ts', false)]);
-			mockStat();
-			(fs.readFile as jest.Mock).mockResolvedValue('const foo = 1;\nconst bar = 2;');
+	describe('execute — find by name', () => {
+		it('finds a file by exact name at any depth', async () => {
+			await writeFile(baseDir, 'joke.txt', 'why did the chicken');
+			await writeFile(baseDir, 'src/jokes/another-joke.txt');
+			await writeFile(baseDir, 'src/unrelated.ts');
 
-			const result = await searchFilesTool.execute({ dirPath: '.', query: 'foo' }, CONTEXT);
-			// eslint-disable-next-line n8n-local-rules/no-uncaught-json-parse
-			const data = JSON.parse(textOf(result)) as {
-				query: string;
-				matches: Array<{ path: string; lineNumber: number; line: string }>;
-				truncated: boolean;
-				totalMatches: number;
-			};
+			const result = await searchFilesTool.execute({ name: '**/joke.txt' }, context);
+			const data = parseResult<NameOnlyResult>(result);
 
-			expect(data.query).toBe('foo');
-			expect(data.matches.length).toBeGreaterThanOrEqual(2);
-			expect(data.matches.some((m) => m.path.includes('index.ts'))).toBe(true);
+			expect(data.matches.map((m) => m.path)).toEqual(['joke.txt']);
+			expect(data.totalMatches).toBe(1);
+			expect(data.truncated).toBe(false);
 		});
 
-		it('supports case-insensitive search', async () => {
-			(fs.readdir as jest.Mock).mockResolvedValue([dirent('test.ts', false)]);
-			mockStat();
-			(fs.readFile as jest.Mock).mockResolvedValue('Hello World\nhello world');
+		it('matches multiple files with a wildcard pattern', async () => {
+			await writeFile(baseDir, 'src/a.ts');
+			await writeFile(baseDir, 'src/nested/b.ts');
+			await writeFile(baseDir, 'src/c.js');
+
+			const result = await searchFilesTool.execute({ name: 'src/**/*.ts' }, context);
+			const data = parseResult<NameOnlyResult>(result);
+
+			expect(data.matches.map((m) => m.path).sort()).toEqual(['src/a.ts', 'src/nested/b.ts']);
+		});
+
+		it('returns each match as `{ path }` when `query` is not given', async () => {
+			await writeFile(baseDir, 'a.txt');
+			await writeFile(baseDir, 'b.txt');
+
+			const result = await searchFilesTool.execute({ name: '*.txt' }, context);
+			const data = parseResult<NameOnlyResult>(result);
+
+			expect(data.matches).toEqual(expect.arrayContaining([{ path: 'a.txt' }, { path: 'b.txt' }]));
+			expect(data.matches).toHaveLength(2);
+		});
+
+		it('returns empty matches when nothing matches', async () => {
+			await writeFile(baseDir, 'a.txt');
+
+			const result = await searchFilesTool.execute({ name: '**/nothing-here.xyz' }, context);
+			const data = parseResult<NameOnlyResult>(result);
+
+			expect(data.matches).toEqual([]);
+			expect(data.totalMatches).toBe(0);
+			expect(data.truncated).toBe(false);
+		});
+
+		it('respects `maxResults` and sets `truncated`', async () => {
+			for (let i = 0; i < 10; i++) {
+				await writeFile(baseDir, `file-${i}.txt`);
+			}
+
+			const result = await searchFilesTool.execute({ name: '*.txt', maxResults: 3 }, context);
+			const data = parseResult<NameOnlyResult>(result);
+
+			expect(data.matches).toHaveLength(3);
+			expect(data.totalMatches).toBe(10);
+			expect(data.truncated).toBe(true);
+		});
+
+		it('excludes node_modules, .git, dist and similar directories', async () => {
+			await writeFile(baseDir, 'src/index.ts', '');
+			await writeFile(baseDir, 'node_modules/foo/index.ts');
+			await writeFile(baseDir, '.git/HEAD');
+			await writeFile(baseDir, 'dist/index.ts');
+
+			const result = await searchFilesTool.execute({ name: '**/*' }, context);
+			const data = parseResult<NameOnlyResult>(result);
+
+			const paths = data.matches.map((m) => m.path);
+			expect(paths).toContain('src/index.ts');
+			expect(paths.some((p) => p.startsWith('node_modules/'))).toBe(false);
+			expect(paths.some((p) => p.startsWith('.git/'))).toBe(false);
+			expect(paths.some((p) => p.startsWith('dist/'))).toBe(false);
+		});
+	});
+
+	describe('execute — find by name + grep contents', () => {
+		it('returns line-level matches inside files matching `name`', async () => {
+			await writeFile(baseDir, 'src/a.ts', 'const foo = 1;\nconst bar = 2;');
+			await writeFile(baseDir, 'src/b.ts', 'no match here');
+			await writeFile(baseDir, 'src/c.js', 'const foo = 999;');
+
+			const result = await searchFilesTool.execute({ name: 'src/**/*.ts', query: 'foo' }, context);
+			const data = parseResult<ContentResult>(result);
+
+			expect(data.matches).toEqual([{ path: 'src/a.ts', lineNumber: 1, line: 'const foo = 1;' }]);
+			// c.js wasn't part of the name pattern → ignored even though it contains "foo"
+			expect(data.matches.every((m) => m.path.endsWith('.ts'))).toBe(true);
+		});
+
+		it('supports case-insensitive content search', async () => {
+			await writeFile(baseDir, 'a.txt', 'Hello World\nhello world');
 
 			const result = await searchFilesTool.execute(
-				{ dirPath: '.', query: 'hello', ignoreCase: true },
-				CONTEXT,
+				{ name: '**/*.txt', query: 'hello', ignoreCase: true },
+				context,
 			);
-			// eslint-disable-next-line n8n-local-rules/no-uncaught-json-parse
-			const data = JSON.parse(textOf(result)) as { matches: unknown[] };
+			const data = parseResult<ContentResult>(result);
 
 			expect(data.matches).toHaveLength(2);
 		});
 
-		it('respects maxResults and sets truncated=true', async () => {
-			(fs.readdir as jest.Mock).mockResolvedValue([dirent('many.txt', false)]);
-			mockStat();
-			const fileContent = Array.from({ length: 100 }, (_, i) => `match_${i}`).join('\n');
-			(fs.readFile as jest.Mock).mockResolvedValue(fileContent);
+		it('respects `maxResults` and sets `truncated` for content matches', async () => {
+			const content = Array.from({ length: 100 }, (_, i) => `match_${i}`).join('\n');
+			await writeFile(baseDir, 'many.txt', content);
 
 			const result = await searchFilesTool.execute(
-				{ dirPath: '.', query: 'match_', maxResults: 5 },
-				CONTEXT,
+				{ name: '**/many.txt', query: 'match_', maxResults: 5 },
+				context,
 			);
-			// eslint-disable-next-line n8n-local-rules/no-uncaught-json-parse
-			const data = JSON.parse(textOf(result)) as {
-				matches: unknown[];
-				truncated: boolean;
-			};
+			const data = parseResult<ContentResult>(result);
 
 			expect(data.matches).toHaveLength(5);
 			expect(data.truncated).toBe(true);
 		});
 
-		it('filters by filePattern — only .ts files are searched', async () => {
-			// DFS: readdir('/base') → [src/], readdir('/base/src') → [index.ts, style.css]
-			(fs.readdir as jest.Mock)
-				.mockResolvedValueOnce([dirent('src', true)])
-				.mockResolvedValueOnce([dirent('index.ts', false), dirent('style.css', false)]);
-			mockStat();
-			(fs.readFile as jest.Mock).mockResolvedValue('const needle = 1;');
+		it('skips likely binary files', async () => {
+			await writeFile(baseDir, 'binary.dat');
+			await fs.writeFile(path.join(baseDir, 'binary.dat'), Buffer.from([0xff, 0xfe, 0xfd, 0xfc]));
 
-			const result = await searchFilesTool.execute(
-				{ dirPath: '.', query: 'needle', filePattern: '**/*.ts' },
-				CONTEXT,
-			);
-			// eslint-disable-next-line n8n-local-rules/no-uncaught-json-parse
-			const data = JSON.parse(textOf(result)) as {
-				matches: Array<{ path: string }>;
-			};
-
-			expect(data.matches.every((m) => m.path.endsWith('.ts'))).toBe(true);
-			// style.css was excluded, readFile only called once (for index.ts)
-			expect(fs.readFile as jest.Mock).toHaveBeenCalledTimes(1);
-		});
-
-		it('returns zero matches when query is not found', async () => {
-			(fs.readdir as jest.Mock).mockResolvedValue([dirent('index.ts', false)]);
-			mockStat();
-			(fs.readFile as jest.Mock).mockResolvedValue('const x = 1;');
-
-			const result = await searchFilesTool.execute(
-				{ dirPath: '.', query: 'zzz_not_found' },
-				CONTEXT,
-			);
-			// eslint-disable-next-line n8n-local-rules/no-uncaught-json-parse
-			const data = JSON.parse(textOf(result)) as {
-				matches: unknown[];
-				totalMatches: number;
-			};
+			const result = await searchFilesTool.execute({ name: '**/*.dat', query: 'foo' }, context);
+			const data = parseResult<ContentResult>(result);
 
 			expect(data.matches).toHaveLength(0);
 			expect(data.totalMatches).toBe(0);
 		});
 
-		it('rejects path traversal', async () => {
-			await expect(
-				searchFilesTool.execute({ dirPath: '../../../etc', query: 'foo' }, CONTEXT),
-			).rejects.toThrow('escapes');
-		});
+		it('returns zero matches when `query` is not found in matched files', async () => {
+			await writeFile(baseDir, 'a.ts', 'const x = 1;');
 
-		it.each(['node_modules', 'Node_Modules', '.git', 'dist'])(
-			'rejects direct search roots under excluded directory %s',
-			async (dirPath) => {
-				await expect(searchFilesTool.execute({ dirPath, query: 'foo' }, CONTEXT)).rejects.toThrow(
-					'excluded from filesystem reads',
+			const result = await searchFilesTool.execute(
+				{ name: '**/*.ts', query: 'zzz_not_found' },
+				context,
+			);
+			const data = parseResult<ContentResult>(result);
+
+			expect(data.matches).toHaveLength(0);
+			expect(data.totalMatches).toBe(0);
+		});
+	});
+
+	describe('execute — security', () => {
+		it.each(['/etc/passwd', '../../etc/passwd', '../../../etc/**'])(
+			'rejects pattern that escapes the base directory: %s',
+			async (pattern) => {
+				await expect(searchFilesTool.execute({ name: pattern }, context)).rejects.toThrow(
+					'escapes the base directory',
 				);
 			},
 		);
+	});
 
-		it('skips likely binary files', async () => {
-			(fs.readdir as jest.Mock).mockResolvedValue([dirent('binary.dat', false)]);
-			mockStat();
-			(fs.readFile as jest.Mock).mockResolvedValue(Buffer.from([0xff, 0xfe, 0xfd, 0xfc]));
+	describe('CallToolResult shape', () => {
+		it('returns a content array of length 1', async () => {
+			await writeFile(baseDir, 'a.txt');
 
-			const result = await searchFilesTool.execute({ dirPath: '.', query: 'foo' }, CONTEXT);
-			// eslint-disable-next-line n8n-local-rules/no-uncaught-json-parse
-			const data = JSON.parse(textOf(result)) as {
-				matches: unknown[];
-				totalMatches: number;
-			};
-
-			expect(data.matches).toHaveLength(0);
-			expect(data.totalMatches).toBe(0);
-		});
-
-		it.each([
-			{ query: 'foo', ignoreCase: undefined, label: 'case-sensitive' },
-			{ query: 'foo', ignoreCase: true, label: 'case-insensitive' },
-			{ query: 'foo', ignoreCase: false, label: 'explicitly case-sensitive' },
-		])('returns content array of length 1 for $label search', async ({ query, ignoreCase }) => {
-			(fs.readdir as jest.Mock).mockResolvedValue([dirent('a.ts', false)]);
-			mockStat();
-			(fs.readFile as jest.Mock).mockResolvedValue('const foo = 1;');
-
-			const result = await searchFilesTool.execute({ dirPath: '.', query, ignoreCase }, CONTEXT);
+			const result = await searchFilesTool.execute({ name: '*.txt' }, context);
 
 			expect(result.content).toHaveLength(1);
 			expect(result.content[0].type).toBe('text');

--- a/packages/@n8n/computer-use/src/tools/filesystem/search-files.ts
+++ b/packages/@n8n/computer-use/src/tools/filesystem/search-files.ts
@@ -1,3 +1,4 @@
+import fastGlob from 'fast-glob';
 import * as fs from 'node:fs/promises';
 import * as path from 'node:path';
 import { z } from 'zod';
@@ -6,55 +7,96 @@ import type { ToolDefinition } from '../types';
 import { formatCallToolResult } from '../utils';
 import { MAX_FILE_SIZE } from './constants';
 import {
+	EXCLUDED_DIRS,
 	buildFilesystemResource,
-	isExcludedDirName,
 	isLikelyBinaryContent,
 	resolveReadablePath,
 } from './fs-utils';
 
-const inputSchema = z.object({
-	dirPath: z.string().describe('Directory to search in'),
-	query: z.string().describe('Text pattern to search for (literal match, not regex)'),
-	filePattern: z.string().optional().describe('Glob pattern to filter files (e.g. "**/*.ts")'),
-	ignoreCase: z.boolean().optional().describe('Case-insensitive search (default: false)'),
-	maxResults: z.number().int().optional().describe('Maximum number of results (default: 50)'),
-});
+const inputSchema = z
+	.object({
+		name: z
+			.string()
+			.describe(
+				'REQUIRED. Glob pattern for the file path(s) to find, relative to the base directory. ' +
+					'Use `**/` to match at any depth. ' +
+					'Examples: `**/joke.txt` finds joke.txt anywhere; ' +
+					'`src/**/*.ts` finds every .ts file under src/; ' +
+					'`README.md` matches only README.md at the root.',
+			),
+		query: z
+			.string()
+			.optional()
+			.describe(
+				'OPTIONAL. Literal text (not regex) to search for INSIDE the contents of the files matched by `name`. ' +
+					'Omit this to only list the matching files without opening them.',
+			),
+		ignoreCase: z
+			.boolean()
+			.optional()
+			.describe('Case-insensitive `query` search (default: false). Has no effect without `query`.'),
+		maxResults: z.number().int().optional().describe('Maximum number of results (default: 50)'),
+	})
+	.describe(
+		'Find files by name (glob pattern), and optionally grep inside their contents. ' +
+			'Pass `name` alone to locate a file by its name. ' +
+			'Pass `name` + `query` to also search for a literal text string inside the matching files.',
+	);
+
+const IGNORE_PATTERNS = [...EXCLUDED_DIRS].map((segment) => `**/${segment}/**`);
 
 export const searchFilesTool: ToolDefinition<typeof inputSchema> = {
 	name: 'search_files',
-	description: 'Search for text patterns across files using a literal text query',
+	description:
+		'Find files by name (glob pattern), and optionally search a literal text string inside the matched files. ' +
+		'To locate a file by name, pass only `name` (e.g. `{ name: "**/joke.txt" }`). ' +
+		'To grep file contents, pass `name` + `query` (e.g. `{ name: "**/*.ts", query: "TODO" }`).',
 	inputSchema,
 	annotations: { readOnlyHint: true },
-	async getAffectedResources({ dirPath }, { dir }) {
-		return [
-			await buildFilesystemResource(dir, dirPath, 'filesystemRead', `Search files in: ${dirPath}`),
-		];
+	async getAffectedResources(_args, { dir }) {
+		return [await buildFilesystemResource(dir, '.', 'filesystemRead', 'Search files')];
 	},
-	async execute({ dirPath, query, filePattern, ignoreCase, maxResults }, { dir }) {
-		const resolvedDir = await resolveReadablePath(dir, dirPath);
-		const limit = maxResults ?? 50;
-		const flags = ignoreCase ? 'gi' : 'g';
-		const regex = new RegExp(escapeRegex(query), flags);
+	async execute({ name, query, ignoreCase, maxResults }, { dir }) {
+		assertPatternStaysInside(name);
 
+		const resolvedDir = await resolveReadablePath(dir, '.');
+		const limit = maxResults ?? 50;
+
+		const files = await fastGlob(name, {
+			cwd: resolvedDir,
+			ignore: IGNORE_PATTERNS,
+			onlyFiles: true,
+			followSymbolicLinks: false,
+			suppressErrors: true,
+		});
+
+		if (!query) {
+			const matches = files.slice(0, limit).map((p) => ({ path: p }));
+			return formatCallToolResult({
+				name,
+				matches,
+				truncated: files.length > limit,
+				totalMatches: files.length,
+			});
+		}
+
+		const regex = new RegExp(escapeRegex(query), ignoreCase ? 'gi' : 'g');
 		const matches: Array<{ path: string; lineNumber: number; line: string }> = [];
 		let totalMatches = 0;
 
-		const filePaths = await collectFiles(resolvedDir, dir, filePattern);
-
-		for (const fp of filePaths) {
+		for (const fp of files) {
 			if (matches.length >= limit) break;
 
 			try {
-				const fullPath = path.join(dir, fp);
+				const fullPath = path.join(resolvedDir, fp);
 				const stat = await fs.stat(fullPath);
 				if (stat.size > MAX_FILE_SIZE) continue;
 
 				const fileContent = await fs.readFile(fullPath);
 				const buffer = Buffer.isBuffer(fileContent) ? fileContent : Buffer.from(fileContent);
 				if (isLikelyBinaryContent(buffer)) continue;
-				const content = buffer.toString('utf-8');
-				const lines = content.split('\n');
 
+				const lines = buffer.toString('utf-8').split('\n');
 				for (let i = 0; i < lines.length; i++) {
 					if (regex.test(lines[i])) {
 						totalMatches++;
@@ -69,52 +111,22 @@ export const searchFilesTool: ToolDefinition<typeof inputSchema> = {
 			}
 		}
 
-		return formatCallToolResult({ query, matches, truncated: totalMatches > limit, totalMatches });
+		return formatCallToolResult({
+			name,
+			query,
+			matches,
+			truncated: totalMatches > limit,
+			totalMatches,
+		});
 	},
 };
 
-async function collectFiles(
-	dir: string,
-	basePath: string,
-	pattern?: string,
-	collected: string[] = [],
-	depth = 0,
-): Promise<string[]> {
-	if (depth > 10 || collected.length > 5000) return collected;
-
-	const entries = await fs.readdir(dir, { withFileTypes: true });
-
-	for (const entry of entries) {
-		if (isExcludedDirName(entry.name) && entry.isDirectory()) continue;
-
-		const fullPath = path.join(dir, entry.name);
-		const relativePath = path.relative(basePath, fullPath);
-
-		if (entry.isDirectory()) {
-			await collectFiles(fullPath, basePath, pattern, collected, depth + 1);
-		} else if (entry.isFile()) {
-			if (pattern) {
-				const regex = globToRegex(pattern);
-				if (!regex.test(entry.name) && !regex.test(relativePath)) continue;
-			}
-			collected.push(relativePath);
-		}
+function assertPatternStaysInside(pattern: string): void {
+	if (pattern.startsWith('/') || pattern.split('/').includes('..')) {
+		throw new Error(`Pattern "${pattern}" escapes the base directory`);
 	}
-
-	return collected;
 }
 
 function escapeRegex(str: string): string {
 	return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function globToRegex(pattern: string): RegExp {
-	const escaped = pattern
-		.replace(/[.+^${}()|[\]\\]/g, '\\$&')
-		.replace(/\*\*\//g, '{{GLOBSTAR_SLASH}}')
-		.replace(/\*\*/g, '{{GLOBSTAR}}')
-		.replace(/\*/g, '[^/]*')
-		.replace(/\{\{GLOBSTAR_SLASH\}\}/g, '(.*/)?')
-		.replace(/\{\{GLOBSTAR\}\}/g, '.*');
-	return new RegExp(`^${escaped}$`);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1219,6 +1219,9 @@ importers:
       eventsource:
         specifier: ^3.0.6
         version: 3.0.6
+      fast-glob:
+        specifier: 'catalog:'
+        version: 3.2.12
       node-screenshots:
         specifier: ^0.2.8
         version: 0.2.8


### PR DESCRIPTION
## Summary

Fixes the `search_files` tool. The tool was intended to be used to search for content INSIDE the files, but the description did not make it explicit. I did iterate over the description and even if it says that it only searches inside the files the AI was using it when asked to search for files before using other tools - probably due to the name `search_files`. I did take a bit of a radical fix:

1. add `name` parameter accepting "glob" pattern to search for files with a specific name
2. make `query` optional, if not passed just return file names based on passed `name` pattern
3. simplify the too arguments, remove `dirPath` and `filePattern` since these are already covered by glob pattern matching via `name`
4. use `fast-glob` to find files instead of custom implementation - already used in our catalog
5. add tool description and made the argument description more explicit

to test:

1. connect to computer use via `npm start token` in `computer-use` package.
2. write to AI `find the joke file on my computer` - observe that it correctly finds the file (in the old version it does gibberish tool calls)
3. write to AI `find file with text "Local AI gateway for n8n AI Assistant" on my computer` - observe that it files the content in package.json with first tool call

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4904/find-file-tool-often-does-not-find-the-file


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
