### PR TITLE
build: Revert n8n image to alpine 3.22 to restore graphicsmagick GPL pin

### DIFF
--- a/.github/actions/build-n8n-docker/action.yml
+++ b/.github/actions/build-n8n-docker/action.yml
@@ -36,6 +36,11 @@ runs:
       env:
         INCLUDE_TEST_CONTROLLER: 'true'
 
+    - name: Smoke test against downstream invocations
+      if: steps.cache-check.outputs.cache-hit != 'true'
+      shell: bash
+      run: pnpm build:docker:smoke
+
     - name: Save image tarball
       if: steps.cache-check.outputs.cache-hit != 'true'
       shell: bash

--- a/.github/actions/build-n8n-docker/action.yml
+++ b/.github/actions/build-n8n-docker/action.yml
@@ -36,11 +36,6 @@ runs:
       env:
         INCLUDE_TEST_CONTROLLER: 'true'
 
-    - name: Smoke test against downstream invocations
-      if: steps.cache-check.outputs.cache-hit != 'true'
-      shell: bash
-      run: pnpm build:docker:smoke
-
     - name: Save image tarball
       if: steps.cache-check.outputs.cache-hit != 'true'
       shell: bash

--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -25,7 +25,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_version: ['22', '24.15.0', '26']
+        # Node 26 requires alpine 3.23 on DHI (3.22 pairing isn't published).
+        # While we're on alpine 3.22 awaiting NODE-4184 (graphicsmagick → sharp
+        # migration that unblocks 3.23), Node 26 base builds can't succeed.
+        # Restore '26' to this matrix once 3.23 is back.
+        node_version: ['22', '24.15.0']
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 

--- a/.github/workflows/docker-build-smoke.yml
+++ b/.github/workflows/docker-build-smoke.yml
@@ -44,9 +44,17 @@ jobs:
 
       - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
 
+      - id: cloud-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.N8N_ASSISTANT_APP_ID }}
+          private-key: ${{ secrets.N8N_ASSISTANT_PRIVATE_KEY }}
+          owner: n8n-io
+          repositories: n8n-cloud
+
       - name: Smoke test against downstream invocations
         env:
-          GH_TOKEN: ${{ secrets.N8N_CLOUD_READ_TOKEN }}
+          GH_TOKEN: ${{ steps.cloud-token.outputs.token }}
         run: pnpm build:docker:smoke
 
   notify-on-failure:

--- a/.github/workflows/docker-build-smoke.yml
+++ b/.github/workflows/docker-build-smoke.yml
@@ -42,19 +42,10 @@ jobs:
           build-command: 'pnpm build:docker:clean'
           enable-docker-cache: true
 
-      - name: Install helm (for cloud chart smoke)
-        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+      - uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
 
       - name: Smoke test against downstream invocations
-        # Pulls n8n-cloud's helm chart at runtime, renders it, and execs the
-        # built image with the actual container spec from cloud's manifest —
-        # catches the class of regression where alpine/DHI changes break
-        # cloud's `node /usr/local/bin/n8n` invocation. Also runs hardcoded
-        # contract checks (default entrypoint, FHS-direct binary path).
-        # See scripts/smoke-n8n-image.mjs.
         env:
-          # gh CLI uses GH_TOKEN for clone auth against the private n8n-cloud repo.
-          # Token must have Contents:Read on n8n-io/n8n-cloud.
           GH_TOKEN: ${{ secrets.N8N_CLOUD_READ_TOKEN }}
         run: pnpm build:docker:smoke
 

--- a/.github/workflows/docker-build-smoke.yml
+++ b/.github/workflows/docker-build-smoke.yml
@@ -42,12 +42,20 @@ jobs:
           build-command: 'pnpm build:docker:clean'
           enable-docker-cache: true
 
+      - name: Install helm (for cloud chart smoke)
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
+
       - name: Smoke test against downstream invocations
-        # Reproduces the invocation patterns real consumers use against the
-        # n8n image (default entrypoint, n8n-cloud helm's `node /usr/local/bin/n8n`,
-        # FHS-direct `/usr/local/bin/n8n`). Catches base-image / Dockerfile
-        # changes that break those patterns at PR-time rather than in production.
-        # See scripts/smoke-n8n-image.mjs for the invocation matrix.
+        # Pulls n8n-cloud's helm chart at runtime, renders it, and execs the
+        # built image with the actual container spec from cloud's manifest —
+        # catches the class of regression where alpine/DHI changes break
+        # cloud's `node /usr/local/bin/n8n` invocation. Also runs hardcoded
+        # contract checks (default entrypoint, FHS-direct binary path).
+        # See scripts/smoke-n8n-image.mjs.
+        env:
+          # gh CLI uses GH_TOKEN for clone auth against the private n8n-cloud repo.
+          # Token must have Contents:Read on n8n-io/n8n-cloud.
+          GH_TOKEN: ${{ secrets.N8N_CLOUD_READ_TOKEN }}
         run: pnpm build:docker:smoke
 
   notify-on-failure:

--- a/.github/workflows/docker-build-smoke.yml
+++ b/.github/workflows/docker-build-smoke.yml
@@ -52,7 +52,7 @@ jobs:
           owner: n8n-io
           repositories: n8n-cloud
 
-      - name: Smoke test against downstream invocations
+      - name: Verify image against live n8n-cloud helm chart
         env:
           GH_TOKEN: ${{ steps.cloud-token.outputs.token }}
         run: pnpm build:docker:smoke

--- a/.github/workflows/docker-build-smoke.yml
+++ b/.github/workflows/docker-build-smoke.yml
@@ -42,12 +42,13 @@ jobs:
           build-command: 'pnpm build:docker:clean'
           enable-docker-cache: true
 
-      - name: Verify n8n image starts
-        run: |
-          docker run --rm -d --name n8n-smoke-test n8nio/n8n:local
-          sleep 5
-          docker logs n8n-smoke-test 2>&1 | tail -20
-          docker stop n8n-smoke-test
+      - name: Smoke test against downstream invocations
+        # Reproduces the invocation patterns real consumers use against the
+        # n8n image (default entrypoint, n8n-cloud helm's `node /usr/local/bin/n8n`,
+        # FHS-direct `/usr/local/bin/n8n`). Catches base-image / Dockerfile
+        # changes that break those patterns at PR-time rather than in production.
+        # See scripts/smoke-n8n-image.mjs for the invocation matrix.
+        run: pnpm build:docker:smoke
 
   notify-on-failure:
     name: Notify on nightly smoke test failure

--- a/.github/workflows/docker-build-smoke.yml
+++ b/.github/workflows/docker-build-smoke.yml
@@ -18,6 +18,7 @@ on:
       - 'docker/images/runners/**'
       - 'scripts/build-n8n.mjs'
       - 'scripts/dockerize-n8n.mjs'
+      - 'scripts/smoke-n8n-image.mjs'
   workflow_dispatch:
 
 jobs:

--- a/docker/images/engine/Dockerfile
+++ b/docker/images/engine/Dockerfile
@@ -1,6 +1,6 @@
 ARG NODE_VERSION=24.15.0
 
-FROM node:${NODE_VERSION}-alpine3.23
+FROM node:${NODE_VERSION}-alpine3.22
 
 ENV NODE_ENV=production
 

--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -1,27 +1,25 @@
 ARG NODE_VERSION=24.15.0
 
-FROM dhi.io/node:${NODE_VERSION}-alpine3.23-dev
+FROM dhi.io/node:${NODE_VERSION}-alpine3.22-dev
 
 ARG NODE_VERSION
 
-# Install all dependencies in a single layer to minimize image size.
-# DHI's alpine3.23-dev base already provides /bin/sh (via its bundled busybox)
-# and git; we don't reinstall them. Reinstalling busybox-binsh from alpine
-# community pins it to a busybox release that conflicts with DHI's git
-# snapshot version, breaking the build whenever alpine bumps the rebuild.
-RUN apk --no-cache add --virtual .build-deps-fonts msttcorefonts-installer fontconfig && \
+# Install all dependencies in a single layer to minimize image size
+RUN apk add --no-cache busybox-binsh && \
+    # Install fonts
+    apk --no-cache add --virtual .build-deps-fonts msttcorefonts-installer fontconfig && \
     update-ms-fonts && \
     fc-cache -f && \
     apk del .build-deps-fonts && \
     find /usr/share/fonts/truetype/msttcorefonts/ -type l -exec unlink {} \; && \
-    # Install OS dependencies (git is already in the DHI base). `apk upgrade`
-    # is intentionally omitted: DHI ships vetted pinned versions, and trying
-    # to upgrade can race with alpine repo refreshes (e.g. libssl3 bumped
-    # without a matching openssl rebuild) and break the build.
+    # Install OS dependencies
+    apk update && \
+    apk upgrade --no-cache && \
     apk add --no-cache \
+        git \
         openssh \
         openssl \
-        graphicsmagick=1.3.46-r0 `# pinned for build reproducibility` \
+        graphicsmagick=1.3.45-r0 `# pinned to avoid ghostscript-fonts (GPL-2.0); see SEC-398 + NODE-4184` \
         tini \
         tzdata \
         ca-certificates \
@@ -31,8 +29,7 @@ RUN apk --no-cache add --virtual .build-deps-fonts msttcorefonts-installer fontc
     apk del apk-tools
 
 WORKDIR /home/node
-# npm prefix -g is /usr/local but node's built-in search path is /usr/lib/node_modules.
-# Bridge the two so users extending this image with `RUN npm install -g <pkg>` can
-# `require(<pkg>)` from a Function/Code node at runtime (gh #24191).
-ENV NODE_PATH=/usr/local/lib/node_modules
+# DHI images use a non-standard global npm path, so we need to set NODE_PATH
+# to allow externally installed npm packages to be found by require()
+ENV NODE_PATH=/opt/nodejs/node-v${NODE_VERSION}/lib/node_modules
 EXPOSE 5678/tcp

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -2,7 +2,7 @@ ARG NODE_VERSION=24.15.0
 ARG N8N_VERSION=snapshot
 
 # Builder stage exists because the runtime base image has no toolchain.
-FROM node:${NODE_VERSION}-alpine3.23 AS builder
+FROM node:${NODE_VERSION}-alpine3.22 AS builder
 COPY ./compiled /usr/local/lib/node_modules/n8n
 RUN apk add --no-cache python3 make g++ && \
     cd /usr/local/lib/node_modules/n8n && \
@@ -18,18 +18,10 @@ ENV SHELL=/bin/sh
 
 WORKDIR /home/node
 
-# DHI's alpine3.23-dev base does not expose /usr/local/lib/node_modules as a
-# writable install destination, so n8n itself is installed under /usr/lib.
-COPY --from=builder /usr/local/lib/node_modules/n8n /usr/lib/node_modules/n8n
+COPY --from=builder /usr/local/lib/node_modules/n8n /usr/local/lib/node_modules/n8n
 COPY docker/images/n8n/docker-entrypoint.sh /
 
-RUN ln -s /usr/lib/node_modules/n8n/bin/n8n /usr/bin/n8n && \
-    # /usr/local/bin/n8n is the long-standing public contract that downstream
-    # stacks (n8n-cloud helm charts, AppArmor profiles, user overrides) exec
-    # by absolute path. The DHI base does not ship /usr/local/bin, so create
-    # it before symlinking.
-    mkdir -p /usr/local/bin && \
-    ln -s /usr/bin/n8n /usr/local/bin/n8n && \
+RUN ln -s /usr/local/lib/node_modules/n8n/bin/n8n /usr/local/bin/n8n && \
     mkdir -p /home/node/.n8n && \
     chown -R node:node /home/node && \
     rm -rf /root/.npm /tmp/*

--- a/docker/images/runners/Dockerfile
+++ b/docker/images/runners/Dockerfile
@@ -4,7 +4,7 @@ ARG PYTHON_VERSION=3.13
 # ==============================================================================
 # STAGE 1: JavaScript runner (@n8n/task-runner) artifact from CI
 # ==============================================================================
-FROM node:${NODE_VERSION}-alpine3.23 AS javascript-runner-builder
+FROM node:${NODE_VERSION}-alpine3.22 AS javascript-runner-builder
 COPY ./dist/task-runner-javascript /app/task-runner-javascript
 
 WORKDIR /app/task-runner-javascript
@@ -86,7 +86,7 @@ RUN uv pip install . && rm -rf /app/task-runner-python/src
 # ==============================================================================
 # STAGE 3: Task Runner Launcher download
 # ==============================================================================
-FROM alpine:3.23 AS launcher-downloader
+FROM alpine:3.22 AS launcher-downloader
 ARG TARGETPLATFORM
 ARG LAUNCHER_VERSION=1.4.5
 
@@ -108,7 +108,7 @@ RUN set -e; \
 # ==============================================================================
 # STAGE 4: Node alpine base for JS task runner
 # ==============================================================================
-FROM node:${NODE_VERSION}-alpine3.23 AS node-alpine
+FROM node:${NODE_VERSION}-alpine3.22 AS node-alpine
 
 # ==============================================================================
 # STAGE 5: Runtime

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build:docker": "node scripts/build-n8n.mjs && node scripts/dockerize-n8n.mjs",
     "build:docker:coverage": "BUILD_WITH_COVERAGE=true node scripts/build-n8n.mjs && node scripts/dockerize-n8n.mjs",
     "build:docker:scan": "node scripts/build-n8n.mjs && node scripts/dockerize-n8n.mjs && node scripts/scan-n8n-image.mjs",
+    "build:docker:smoke": "node scripts/smoke-n8n-image.mjs",
     "build:docker:clean": "TURBO_FORCE=true node scripts/build-n8n.mjs && DOCKER_BUILD_NO_CACHE=true DOCKER_BUILD_BASE_IMAGE=true node scripts/dockerize-n8n.mjs",
     "build:docker:test": "node scripts/build-n8n.mjs && node scripts/dockerize-n8n.mjs && turbo run test:container:standard --filter=n8n-playwright",
     "typecheck": "turbo typecheck",

--- a/packages/testing/playwright/scripts/build-test-image.mjs
+++ b/packages/testing/playwright/scripts/build-test-image.mjs
@@ -51,7 +51,7 @@ function buildTestImage(targetImage) {
 		writeFileSync(
 			dockerfilePath,
 			`FROM ${targetImage}
-COPY e2e.controller.js /usr/lib/node_modules/n8n/dist/controllers/e2e.controller.js
+COPY e2e.controller.js /usr/local/lib/node_modules/n8n/dist/controllers/e2e.controller.js
 `,
 		);
 

--- a/scripts/smoke-n8n-image.mjs
+++ b/scripts/smoke-n8n-image.mjs
@@ -4,19 +4,31 @@
  * downstream consumers actually use, so that base-image / Dockerfile changes
  * that break those consumers fail at PR-time rather than in production.
  *
- * Each entry in INVOCATIONS represents a real container spec (command + args
- * + user) extracted from a downstream consumer. Update the entries when a
- * consumer's chart/template changes.
+ * Two sources of invocations:
+ *
+ * 1. **Hardcoded contract** — what *this image* promises (default entrypoint,
+ *    /usr/local/bin/n8n exists). Stable across consumers.
+ *
+ * 2. **Live from consumer charts** — pulls n8n-cloud's helm chart at runtime,
+ *    renders it, and extracts the actual container spec (command + args +
+ *    securityContext). Catches drift if cloud changes their invocation, AND
+ *    fails this build if we break theirs.
+ *
+ * The cloud-side fetch requires `helm`, `gh`, and a token with read access
+ * to n8n-io/n8n-cloud (CI provides via GH_TOKEN). It can be disabled with
+ * SMOKE_SKIP_CLOUD=true (e.g. on PRs where the cloud read is unreachable).
  *
  * Failure modes this catches:
  * - n8n binary moved out of /usr/local/bin (e.g. DHI 3.22 → 3.23 layout drift)
  * - n8n module relocated such that `node /absolute/path/n8n` can no longer
  *   load it
  * - default entrypoint regression (tini / docker-entrypoint.sh breakage)
- * - non-root user assumption violated
+ * - cloud changing their invocation in a way we haven't accommodated
  */
 
-import { $, echo, chalk } from 'zx';
+import { $, echo, chalk, fs, tmpdir } from 'zx';
+import path from 'node:path';
+import { parseAllDocuments } from 'yaml';
 
 $.verbose = false;
 process.env.FORCE_COLOR = '1';
@@ -25,32 +37,34 @@ process.env.FORCE_COLOR = '1';
 const config = {
 	image: process.env.SMOKE_IMAGE || 'n8nio/n8n:local',
 	timeoutMs: Number(process.env.SMOKE_TIMEOUT_MS || 30_000),
+	skipCloud: process.env.SMOKE_SKIP_CLOUD === 'true',
+	cloud: {
+		repo: process.env.CLOUD_CHART_REPO || 'n8n-io/n8n-cloud',
+		ref: process.env.CLOUD_CHART_REF || 'main',
+		// Paths within the cloned cloud repo. These can move when cloud reorganises;
+		// override via env vars if so. Last verified 2026-05-18.
+		chartPath:
+			process.env.CLOUD_CHART_PATH || 'packages/instance-controller/charts/n8napp/n8n',
+		valuesPath:
+			process.env.CLOUD_CHART_VALUES ||
+			'packages/instance-controller/charts/n8napp/values-v1.yaml',
+	},
 };
 // #endregion
 
-// #region ===== Invocations =====
-// Each entry mirrors a real downstream container spec. When a consumer
-// changes their invocation, update the matching entry here.
-const INVOCATIONS = [
-	{
-		name: 'n8n-cloud helm — main pod (node /usr/local/bin/n8n)',
-		source: 'n8n-cloud/packages/middleware/n8napp/n8n/templates/main/statefulset.yaml',
-		user: '1000:1000',
-		entrypoint: 'node',
-		args: ['/usr/local/bin/n8n', '--help'],
-		expectStdout: /Available commands/,
-	},
+// #region ===== Hardcoded contract — what THIS image promises =====
+const HARDCODED_INVOCATIONS = [
 	{
 		name: 'default image entrypoint (tini + docker-entrypoint.sh)',
 		source: 'docker/images/n8n/Dockerfile',
 		user: '1000:1000',
-		entrypoint: null, // use image default
+		entrypoint: null, // image default
 		args: ['--help'],
 		expectStdout: /Available commands/,
 	},
 	{
-		name: 'n8n binary directly at /usr/local/bin/n8n',
-		source: 'docker/images/n8n/Dockerfile (FHS contract)',
+		name: 'n8n binary directly at /usr/local/bin/n8n (FHS contract)',
+		source: 'docker/images/n8n/Dockerfile',
 		user: '1000:1000',
 		entrypoint: '/usr/local/bin/n8n',
 		args: ['--version'],
@@ -59,8 +73,69 @@ const INVOCATIONS = [
 ];
 // #endregion
 
+// #region ===== Live cloud chart fetch + extraction =====
+/**
+ * Clones cloud chart, renders it, returns invocations for every n8n
+ * container in the rendered manifest.
+ */
+async function fetchCloudInvocations() {
+	const cloneDir = await fs.mkdtemp(path.join(tmpdir(), 'n8n-smoke-cloud-'));
+	try {
+		echo(chalk.dim(`fetching ${config.cloud.repo}@${config.cloud.ref}...`));
+		await $`gh repo clone ${config.cloud.repo} ${cloneDir} -- --depth=1 --branch=${config.cloud.ref} --quiet`;
+
+		const chartDir = path.join(cloneDir, config.cloud.chartPath);
+		const valuesFile = path.join(cloneDir, config.cloud.valuesPath);
+		if (!(await fs.pathExists(chartDir))) {
+			throw new Error(`chart not found at ${config.cloud.chartPath}`);
+		}
+		if (!(await fs.pathExists(valuesFile))) {
+			throw new Error(`values file not found at ${config.cloud.valuesPath}`);
+		}
+
+		echo(chalk.dim(`rendering helm chart...`));
+		const rendered = await $({ cwd: chartDir })`helm template . --values ${valuesFile}`;
+		const docs = parseAllDocuments(rendered.stdout).map((d) => d.toJSON()).filter(Boolean);
+
+		const invocations = [];
+		for (const doc of docs) {
+			if (!doc?.kind?.match(/^(StatefulSet|Deployment)$/)) continue;
+			const podSpec = doc.spec?.template?.spec;
+			if (!podSpec) continue;
+			const podUser = podSpec.securityContext?.runAsUser;
+			const podGroup = podSpec.securityContext?.runAsGroup;
+
+			for (const c of podSpec.containers ?? []) {
+				// Only the n8n image — skip sidecars (task-runner-launcher, wget probes, etc.)
+				if (!c.image?.includes('n8nio/n8n') && !c.image?.includes('n8n:')) continue;
+				if (!c.command?.length) continue;
+
+				const user = c.securityContext?.runAsUser ?? podUser ?? 1000;
+				const group = c.securityContext?.runAsGroup ?? podGroup ?? user;
+				const baseArgs = [...(c.args ?? [])];
+				// Append --help so the process terminates without trying to bind/connect.
+				// Safe for any n8n CLI form (`n8n`, `n8n worker ...`, etc.).
+				const args = [...c.command.slice(1), ...baseArgs, '--help'];
+
+				invocations.push({
+					name: `cloud helm — ${doc.kind} ${doc.metadata?.name} container "${c.name}"`,
+					source: `${config.cloud.repo}@${config.cloud.ref}:${config.cloud.chartPath}`,
+					user: `${user}:${group}`,
+					entrypoint: c.command[0],
+					args,
+					expectStdout: /Available commands/,
+				});
+			}
+		}
+		return invocations;
+	} finally {
+		await fs.remove(cloneDir).catch(() => {});
+	}
+}
+// #endregion
+
 async function runInvocation(spec) {
-	const args = [
+	const dockerArgs = [
 		'run',
 		'--rm',
 		'--user',
@@ -72,20 +147,20 @@ async function runInvocation(spec) {
 
 	let result;
 	try {
-		result = await $`docker ${args}`.timeout(config.timeoutMs);
+		result = await $`docker ${dockerArgs}`.timeout(config.timeoutMs);
 	} catch (err) {
 		echo(chalk.red(`✗ ${spec.name}`));
-		echo(chalk.dim(`  source: ${spec.source}`));
-		echo(chalk.dim(`  command: docker ${args.join(' ')}`));
-		if (err.stderr) echo(chalk.dim(`  stderr: ${String(err.stderr).slice(0, 800)}`));
+		echo(chalk.dim(`  source:  ${spec.source}`));
+		echo(chalk.dim(`  command: docker ${dockerArgs.join(' ')}`));
+		if (err.stderr) echo(chalk.dim(`  stderr:  ${String(err.stderr).slice(0, 800)}`));
 		return false;
 	}
 
 	if (!spec.expectStdout.test(result.stdout)) {
 		echo(chalk.red(`✗ ${spec.name}`));
-		echo(chalk.dim(`  source: ${spec.source}`));
-		echo(chalk.dim(`  expected stdout to match: ${spec.expectStdout}`));
-		echo(chalk.dim(`  got: ${result.stdout.slice(0, 500)}`));
+		echo(chalk.dim(`  source:   ${spec.source}`));
+		echo(chalk.dim(`  expected: ${spec.expectStdout}`));
+		echo(chalk.dim(`  got:      ${result.stdout.slice(0, 500)}`));
 		return false;
 	}
 
@@ -94,11 +169,27 @@ async function runInvocation(spec) {
 }
 
 async function main() {
-	echo(chalk.bold(`Smoke-testing ${config.image} against ${INVOCATIONS.length} invocation pattern(s)`));
+	const invocations = [...HARDCODED_INVOCATIONS];
+
+	if (config.skipCloud) {
+		echo(chalk.yellow('Skipping cloud chart fetch (SMOKE_SKIP_CLOUD=true)'));
+	} else {
+		try {
+			const cloudInvocations = await fetchCloudInvocations();
+			invocations.push(...cloudInvocations);
+		} catch (err) {
+			echo(chalk.red('Cloud chart fetch failed — cannot verify cloud invocation contract.'));
+			echo(chalk.dim(`  ${err.message ?? err}`));
+			echo(chalk.dim('  Set SMOKE_SKIP_CLOUD=true to skip if cloud read is unreachable.'));
+			process.exit(1);
+		}
+	}
+
+	echo(chalk.bold(`Smoke-testing ${config.image} against ${invocations.length} invocation(s)`));
 	echo('');
 
 	let allPassed = true;
-	for (const spec of INVOCATIONS) {
+	for (const spec of invocations) {
 		const passed = await runInvocation(spec);
 		if (!passed) allPassed = false;
 	}
@@ -106,8 +197,6 @@ async function main() {
 	echo('');
 	if (!allPassed) {
 		echo(chalk.red.bold('Smoke check failed. See above for details.'));
-		echo(chalk.dim('If a consumer legitimately changed their invocation, update'));
-		echo(chalk.dim('the matching INVOCATIONS entry in scripts/smoke-n8n-image.mjs.'));
 		process.exit(1);
 	}
 	echo(chalk.green.bold('All smoke checks passed.'));

--- a/scripts/smoke-n8n-image.mjs
+++ b/scripts/smoke-n8n-image.mjs
@@ -1,30 +1,7 @@
 #!/usr/bin/env node
-/**
- * Smoke-tests the n8n docker image against the invocation patterns its
- * downstream consumers actually use, so that base-image / Dockerfile changes
- * that break those consumers fail at PR-time rather than in production.
- *
- * Two sources of invocations:
- *
- * 1. **Hardcoded contract** — what *this image* promises (default entrypoint,
- *    /usr/local/bin/n8n exists). Stable across consumers.
- *
- * 2. **Live from consumer charts** — pulls n8n-cloud's helm chart at runtime,
- *    renders it, and extracts the actual container spec (command + args +
- *    securityContext). Catches drift if cloud changes their invocation, AND
- *    fails this build if we break theirs.
- *
- * The cloud-side fetch requires `helm`, `gh`, and a token with read access
- * to n8n-io/n8n-cloud (CI provides via GH_TOKEN). It can be disabled with
- * SMOKE_SKIP_CLOUD=true (e.g. on PRs where the cloud read is unreachable).
- *
- * Failure modes this catches:
- * - n8n binary moved out of /usr/local/bin (e.g. DHI 3.22 → 3.23 layout drift)
- * - n8n module relocated such that `node /absolute/path/n8n` can no longer
- *   load it
- * - default entrypoint regression (tini / docker-entrypoint.sh breakage)
- * - cloud changing their invocation in a way we haven't accommodated
- */
+// Fails if the built n8n image breaks an invocation pattern a real consumer
+// uses. The cloud invocation is pulled live from n8n-cloud's helm chart so
+// the test doesn't drift from what cloud actually deploys.
 
 import { $, echo, chalk, fs, tmpdir } from 'zx';
 import path from 'node:path';
@@ -33,173 +10,68 @@ import { parseAllDocuments } from 'yaml';
 $.verbose = false;
 process.env.FORCE_COLOR = '1';
 
-// #region ===== Configuration =====
-const config = {
-	image: process.env.SMOKE_IMAGE || 'n8nio/n8n:local',
-	timeoutMs: Number(process.env.SMOKE_TIMEOUT_MS || 30_000),
-	skipCloud: process.env.SMOKE_SKIP_CLOUD === 'true',
-	cloud: {
-		repo: process.env.CLOUD_CHART_REPO || 'n8n-io/n8n-cloud',
-		ref: process.env.CLOUD_CHART_REF || 'main',
-		// Paths within the cloned cloud repo. These can move when cloud reorganises;
-		// override via env vars if so. Last verified 2026-05-18.
-		chartPath:
-			process.env.CLOUD_CHART_PATH || 'packages/instance-controller/charts/n8napp/n8n',
-		valuesPath:
-			process.env.CLOUD_CHART_VALUES ||
-			'packages/instance-controller/charts/n8napp/values-v1.yaml',
-	},
+const IMAGE = process.env.SMOKE_IMAGE || 'n8nio/n8n:local';
+const EXPECT = /Available commands/;
+const CLOUD = {
+	repo: 'n8n-io/n8n-cloud',
+	ref: process.env.CLOUD_CHART_REF || 'main',
+	chartPath:
+		process.env.CLOUD_CHART_PATH || 'packages/instance-controller/charts/n8napp/n8n',
+	valuesPath:
+		process.env.CLOUD_CHART_VALUES ||
+		'packages/instance-controller/charts/n8napp/values-v1.yaml',
 };
-// #endregion
 
-// #region ===== Hardcoded contract — what THIS image promises =====
-const HARDCODED_INVOCATIONS = [
-	{
-		name: 'default image entrypoint (tini + docker-entrypoint.sh)',
-		source: 'docker/images/n8n/Dockerfile',
-		user: '1000:1000',
-		entrypoint: null, // image default
-		args: ['--help'],
-		expectStdout: /Available commands/,
-	},
-	{
-		name: 'n8n binary directly at /usr/local/bin/n8n (FHS contract)',
-		source: 'docker/images/n8n/Dockerfile',
-		user: '1000:1000',
-		entrypoint: '/usr/local/bin/n8n',
-		args: ['--version'],
-		expectStdout: /^\d+\.\d+\.\d+/m,
-	},
-];
-// #endregion
-
-// #region ===== Live cloud chart fetch + extraction =====
-/**
- * Clones cloud chart, renders it, returns invocations for every n8n
- * container in the rendered manifest.
- */
 async function fetchCloudInvocations() {
-	const cloneDir = await fs.mkdtemp(path.join(tmpdir(), 'n8n-smoke-cloud-'));
+	const dir = await fs.mkdtemp(path.join(tmpdir(), 'n8n-smoke-cloud-'));
 	try {
-		echo(chalk.dim(`fetching ${config.cloud.repo}@${config.cloud.ref}...`));
-		await $`gh repo clone ${config.cloud.repo} ${cloneDir} -- --depth=1 --branch=${config.cloud.ref} --quiet`;
+		await $`gh repo clone ${CLOUD.repo} ${dir} -- --depth=1 --branch=${CLOUD.ref} --quiet`;
+		const { stdout } = await $({
+			cwd: path.join(dir, CLOUD.chartPath),
+		})`helm template . --values ${path.join(dir, CLOUD.valuesPath)}`;
 
-		const chartDir = path.join(cloneDir, config.cloud.chartPath);
-		const valuesFile = path.join(cloneDir, config.cloud.valuesPath);
-		if (!(await fs.pathExists(chartDir))) {
-			throw new Error(`chart not found at ${config.cloud.chartPath}`);
-		}
-		if (!(await fs.pathExists(valuesFile))) {
-			throw new Error(`values file not found at ${config.cloud.valuesPath}`);
-		}
-
-		echo(chalk.dim(`rendering helm chart...`));
-		const rendered = await $({ cwd: chartDir })`helm template . --values ${valuesFile}`;
-		const docs = parseAllDocuments(rendered.stdout).map((d) => d.toJSON()).filter(Boolean);
-
-		const invocations = [];
-		for (const doc of docs) {
-			if (!doc?.kind?.match(/^(StatefulSet|Deployment)$/)) continue;
-			const podSpec = doc.spec?.template?.spec;
-			if (!podSpec) continue;
-			const podUser = podSpec.securityContext?.runAsUser;
-			const podGroup = podSpec.securityContext?.runAsGroup;
-
-			for (const c of podSpec.containers ?? []) {
-				// Only the n8n image — skip sidecars (task-runner-launcher, wget probes, etc.)
-				if (!c.image?.includes('n8nio/n8n') && !c.image?.includes('n8n:')) continue;
-				if (!c.command?.length) continue;
-
-				const user = c.securityContext?.runAsUser ?? podUser ?? 1000;
-				const group = c.securityContext?.runAsGroup ?? podGroup ?? user;
-				const baseArgs = [...(c.args ?? [])];
-				// Append --help so the process terminates without trying to bind/connect.
-				// Safe for any n8n CLI form (`n8n`, `n8n worker ...`, etc.).
-				const args = [...c.command.slice(1), ...baseArgs, '--help'];
-
-				invocations.push({
-					name: `cloud helm — ${doc.kind} ${doc.metadata?.name} container "${c.name}"`,
-					source: `${config.cloud.repo}@${config.cloud.ref}:${config.cloud.chartPath}`,
-					user: `${user}:${group}`,
-					entrypoint: c.command[0],
-					args,
-					expectStdout: /Available commands/,
-				});
-			}
-		}
-		return invocations;
+		return parseAllDocuments(stdout)
+			.map((d) => d.toJSON())
+			.flatMap((doc) => {
+				if (!/^(StatefulSet|Deployment)$/.test(doc?.kind ?? '')) return [];
+				const pod = doc.spec?.template?.spec ?? {};
+				return (pod.containers ?? [])
+					.filter((c) => c.image?.includes('n8n') && c.command?.length)
+					.map((c) => ({
+						name: `cloud ${doc.kind} ${doc.metadata.name}/${c.name}`,
+						user: String(c.securityContext?.runAsUser ?? pod.securityContext?.runAsUser ?? 1000),
+						entrypoint: c.command[0],
+						// --help makes the process terminate without bind/connect.
+						args: [...c.command.slice(1), ...(c.args ?? []), '--help'],
+					}));
+			});
 	} finally {
-		await fs.remove(cloneDir).catch(() => {});
+		await fs.remove(dir).catch(() => {});
 	}
 }
-// #endregion
 
-async function runInvocation(spec) {
-	const dockerArgs = [
-		'run',
-		'--rm',
-		'--user',
-		spec.user,
-		...(spec.entrypoint ? ['--entrypoint', spec.entrypoint] : []),
-		config.image,
-		...spec.args,
-	];
+async function run({ name, user, entrypoint, args }) {
+	const dockerArgs = ['run', '--rm', '--user', `${user}:${user}`];
+	if (entrypoint) dockerArgs.push('--entrypoint', entrypoint);
+	dockerArgs.push(IMAGE, ...args);
 
-	let result;
 	try {
-		result = await $`docker ${dockerArgs}`.timeout(config.timeoutMs);
+		const { stdout } = await $`docker ${dockerArgs}`;
+		if (!EXPECT.test(stdout)) throw new Error(`output did not match ${EXPECT}`);
+		echo(chalk.green(`✓ ${name}`));
+		return true;
 	} catch (err) {
-		echo(chalk.red(`✗ ${spec.name}`));
-		echo(chalk.dim(`  source:  ${spec.source}`));
-		echo(chalk.dim(`  command: docker ${dockerArgs.join(' ')}`));
-		if (err.stderr) echo(chalk.dim(`  stderr:  ${String(err.stderr).slice(0, 800)}`));
+		echo(chalk.red(`✗ ${name}`));
+		echo(chalk.dim(`  ${(err.stderr ?? err.message ?? '').slice(0, 600)}`));
 		return false;
 	}
-
-	if (!spec.expectStdout.test(result.stdout)) {
-		echo(chalk.red(`✗ ${spec.name}`));
-		echo(chalk.dim(`  source:   ${spec.source}`));
-		echo(chalk.dim(`  expected: ${spec.expectStdout}`));
-		echo(chalk.dim(`  got:      ${result.stdout.slice(0, 500)}`));
-		return false;
-	}
-
-	echo(chalk.green(`✓ ${spec.name}`));
-	return true;
 }
 
-async function main() {
-	const invocations = [...HARDCODED_INVOCATIONS];
+const invocations = [
+	{ name: 'default entrypoint', user: '1000', entrypoint: null, args: ['--help'] },
+	...(process.env.SMOKE_SKIP_CLOUD === 'true' ? [] : await fetchCloudInvocations()),
+];
 
-	if (config.skipCloud) {
-		echo(chalk.yellow('Skipping cloud chart fetch (SMOKE_SKIP_CLOUD=true)'));
-	} else {
-		try {
-			const cloudInvocations = await fetchCloudInvocations();
-			invocations.push(...cloudInvocations);
-		} catch (err) {
-			echo(chalk.red('Cloud chart fetch failed — cannot verify cloud invocation contract.'));
-			echo(chalk.dim(`  ${err.message ?? err}`));
-			echo(chalk.dim('  Set SMOKE_SKIP_CLOUD=true to skip if cloud read is unreachable.'));
-			process.exit(1);
-		}
-	}
-
-	echo(chalk.bold(`Smoke-testing ${config.image} against ${invocations.length} invocation(s)`));
-	echo('');
-
-	let allPassed = true;
-	for (const spec of invocations) {
-		const passed = await runInvocation(spec);
-		if (!passed) allPassed = false;
-	}
-
-	echo('');
-	if (!allPassed) {
-		echo(chalk.red.bold('Smoke check failed. See above for details.'));
-		process.exit(1);
-	}
-	echo(chalk.green.bold('All smoke checks passed.'));
-}
-
-await main();
+echo(chalk.bold(`Smoke-testing ${IMAGE} (${invocations.length} invocations)`));
+const ok = (await Promise.all(invocations.map(run))).every(Boolean);
+if (!ok) process.exit(1);

--- a/scripts/smoke-n8n-image.mjs
+++ b/scripts/smoke-n8n-image.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Smoke-tests the n8n docker image against the invocation patterns its
+ * downstream consumers actually use, so that base-image / Dockerfile changes
+ * that break those consumers fail at PR-time rather than in production.
+ *
+ * Each entry in INVOCATIONS represents a real container spec (command + args
+ * + user) extracted from a downstream consumer. Update the entries when a
+ * consumer's chart/template changes.
+ *
+ * Failure modes this catches:
+ * - n8n binary moved out of /usr/local/bin (e.g. DHI 3.22 → 3.23 layout drift)
+ * - n8n module relocated such that `node /absolute/path/n8n` can no longer
+ *   load it
+ * - default entrypoint regression (tini / docker-entrypoint.sh breakage)
+ * - non-root user assumption violated
+ */
+
+import { $, echo, chalk } from 'zx';
+
+$.verbose = false;
+process.env.FORCE_COLOR = '1';
+
+// #region ===== Configuration =====
+const config = {
+	image: process.env.SMOKE_IMAGE || 'n8nio/n8n:local',
+	timeoutMs: Number(process.env.SMOKE_TIMEOUT_MS || 30_000),
+};
+// #endregion
+
+// #region ===== Invocations =====
+// Each entry mirrors a real downstream container spec. When a consumer
+// changes their invocation, update the matching entry here.
+const INVOCATIONS = [
+	{
+		name: 'n8n-cloud helm — main pod (node /usr/local/bin/n8n)',
+		source: 'n8n-cloud/packages/middleware/n8napp/n8n/templates/main/statefulset.yaml',
+		user: '1000:1000',
+		entrypoint: 'node',
+		args: ['/usr/local/bin/n8n', '--help'],
+		expectStdout: /Available commands/,
+	},
+	{
+		name: 'default image entrypoint (tini + docker-entrypoint.sh)',
+		source: 'docker/images/n8n/Dockerfile',
+		user: '1000:1000',
+		entrypoint: null, // use image default
+		args: ['--help'],
+		expectStdout: /Available commands/,
+	},
+	{
+		name: 'n8n binary directly at /usr/local/bin/n8n',
+		source: 'docker/images/n8n/Dockerfile (FHS contract)',
+		user: '1000:1000',
+		entrypoint: '/usr/local/bin/n8n',
+		args: ['--version'],
+		expectStdout: /^\d+\.\d+\.\d+/m,
+	},
+];
+// #endregion
+
+async function runInvocation(spec) {
+	const args = [
+		'run',
+		'--rm',
+		'--user',
+		spec.user,
+		...(spec.entrypoint ? ['--entrypoint', spec.entrypoint] : []),
+		config.image,
+		...spec.args,
+	];
+
+	let result;
+	try {
+		result = await $`docker ${args}`.timeout(config.timeoutMs);
+	} catch (err) {
+		echo(chalk.red(`✗ ${spec.name}`));
+		echo(chalk.dim(`  source: ${spec.source}`));
+		echo(chalk.dim(`  command: docker ${args.join(' ')}`));
+		if (err.stderr) echo(chalk.dim(`  stderr: ${String(err.stderr).slice(0, 800)}`));
+		return false;
+	}
+
+	if (!spec.expectStdout.test(result.stdout)) {
+		echo(chalk.red(`✗ ${spec.name}`));
+		echo(chalk.dim(`  source: ${spec.source}`));
+		echo(chalk.dim(`  expected stdout to match: ${spec.expectStdout}`));
+		echo(chalk.dim(`  got: ${result.stdout.slice(0, 500)}`));
+		return false;
+	}
+
+	echo(chalk.green(`✓ ${spec.name}`));
+	return true;
+}
+
+async function main() {
+	echo(chalk.bold(`Smoke-testing ${config.image} against ${INVOCATIONS.length} invocation pattern(s)`));
+	echo('');
+
+	let allPassed = true;
+	for (const spec of INVOCATIONS) {
+		const passed = await runInvocation(spec);
+		if (!passed) allPassed = false;
+	}
+
+	echo('');
+	if (!allPassed) {
+		echo(chalk.red.bold('Smoke check failed. See above for details.'));
+		echo(chalk.dim('If a consumer legitimately changed their invocation, update'));
+		echo(chalk.dim('the matching INVOCATIONS entry in scripts/smoke-n8n-image.mjs.'));
+		process.exit(1);
+	}
+	echo(chalk.green.bold('All smoke checks passed.'));
+}
+
+await main();

--- a/scripts/smoke-n8n-image.mjs
+++ b/scripts/smoke-n8n-image.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-// Verifies the built n8n image still works for the ways n8n-cloud and other
-// consumers actually launch it. The cloud spec is pulled live from
-// n8n-cloud's helm chart so this test stays in sync with what cloud deploys.
+// Verifies the built n8n image still works for the ways n8n-cloud launches
+// it. The container spec is pulled live from n8n-cloud's helm chart so this
+// test stays in sync with what cloud actually deploys.
 
 import { $, echo, chalk, fs, tmpdir } from 'zx';
 import path from 'node:path';
@@ -11,12 +11,20 @@ $.verbose = false;
 process.env.FORCE_COLOR = '1';
 
 const IMAGE = process.env.SMOKE_IMAGE || 'n8nio/n8n:local';
-const EXPECT = /Available commands/;
+const TIMEOUT = '45s';
+// Matches an n8n runtime image ref (e.g. `n8nio/n8n:2.4.4`, `ghcr.io/n8n-io/n8n@sha256:…`)
+// but not sidecars like `n8nio/runners:…` or controller images that happen to contain "n8n".
+const N8N_IMAGE_REF = /\/n8n(:|@)/;
+// `bin/n8n` short-circuits on `--version` regardless of subcommand
+// (checks process.argv.slice(-1)[0]), so this works for `n8n` and `n8n worker` alike.
+const VERSION_FLAG = '--version';
+const VERSION_OUTPUT = /^\d+\.\d+\.\d+/m;
 const CLOUD = {
 	repo: 'n8n-io/n8n-cloud',
 	ref: process.env.CLOUD_CHART_REF || 'main',
-	chartPath:
-		process.env.CLOUD_CHART_PATH || 'packages/instance-controller/charts/n8napp/n8n',
+	// Owned by n8n-cloud — override via env if cloud reorganises. Cross-reference:
+	// n8n-cloud:packages/instance-controller/charts/n8napp/{n8n,values-v1.yaml}
+	chartPath: process.env.CLOUD_CHART_PATH || 'packages/instance-controller/charts/n8napp/n8n',
 	valuesPath:
 		process.env.CLOUD_CHART_VALUES ||
 		'packages/instance-controller/charts/n8napp/values-v1.yaml',
@@ -36,13 +44,14 @@ async function fetchCloudInvocations() {
 				if (!/^(StatefulSet|Deployment)$/.test(doc?.kind ?? '')) return [];
 				const pod = doc.spec?.template?.spec ?? {};
 				return (pod.containers ?? [])
-					.filter((c) => c.image?.includes('n8n') && c.command?.length)
+					.filter((c) => N8N_IMAGE_REF.test(c.image ?? ''))
 					.map((c) => ({
-						name: `n8n-cloud: ${doc.kind} ${doc.metadata.name} / container ${c.name}`,
+						name: `n8n-cloud: ${doc.kind} ${doc.metadata.name} / ${c.name}`,
 						user: String(c.securityContext?.runAsUser ?? pod.securityContext?.runAsUser ?? 1000),
-						entrypoint: c.command[0],
-						// --help makes the process terminate without bind/connect.
-						args: [...c.command.slice(1), ...(c.args ?? []), '--help'],
+						// If the chart sets `command`, override entrypoint; otherwise let the
+						// image's ENTRYPOINT run with the args.
+						entrypoint: c.command?.[0],
+						args: [...(c.command?.slice(1) ?? []), ...(c.args ?? []), VERSION_FLAG],
 					}));
 			});
 	} finally {
@@ -56,8 +65,10 @@ async function run({ name, user, entrypoint, args }) {
 	dockerArgs.push(IMAGE, ...args);
 
 	try {
-		const { stdout } = await $`docker ${dockerArgs}`;
-		if (!EXPECT.test(stdout)) throw new Error(`output did not match ${EXPECT}`);
+		const { stdout } = await $({ timeout: TIMEOUT })`docker ${dockerArgs}`;
+		if (!VERSION_OUTPUT.test(stdout)) {
+			throw new Error(`unexpected stdout: ${stdout.slice(0, 200)}`);
+		}
 		echo(chalk.green(`✓ ${name}`));
 		return true;
 	} catch (err) {
@@ -67,9 +78,16 @@ async function run({ name, user, entrypoint, args }) {
 	}
 }
 
+const cloud = process.env.SMOKE_SKIP_CLOUD === 'true' ? [] : await fetchCloudInvocations();
+if (process.env.SMOKE_SKIP_CLOUD !== 'true' && cloud.length === 0) {
+	echo(chalk.red('Cloud chart rendered no n8n containers — chart structure may have moved.'));
+	echo(chalk.dim('  Check CLOUD_CHART_PATH / CLOUD_CHART_VALUES, or run with SMOKE_SKIP_CLOUD=true.'));
+	process.exit(1);
+}
+
 const invocations = [
-	{ name: 'n8n image default entrypoint', user: '1000', entrypoint: null, args: ['--help'] },
-	...(process.env.SMOKE_SKIP_CLOUD === 'true' ? [] : await fetchCloudInvocations()),
+	{ name: 'n8n image default entrypoint', user: '1000', entrypoint: null, args: [VERSION_FLAG] },
+	...cloud,
 ];
 
 echo(chalk.bold(`Verifying ${IMAGE} against ${invocations.length} deployment pattern(s)`));

--- a/scripts/smoke-n8n-image.mjs
+++ b/scripts/smoke-n8n-image.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-// Fails if the built n8n image breaks an invocation pattern a real consumer
-// uses. The cloud invocation is pulled live from n8n-cloud's helm chart so
-// the test doesn't drift from what cloud actually deploys.
+// Verifies the built n8n image still works for the ways n8n-cloud and other
+// consumers actually launch it. The cloud spec is pulled live from
+// n8n-cloud's helm chart so this test stays in sync with what cloud deploys.
 
 import { $, echo, chalk, fs, tmpdir } from 'zx';
 import path from 'node:path';
@@ -38,7 +38,7 @@ async function fetchCloudInvocations() {
 				return (pod.containers ?? [])
 					.filter((c) => c.image?.includes('n8n') && c.command?.length)
 					.map((c) => ({
-						name: `cloud ${doc.kind} ${doc.metadata.name}/${c.name}`,
+						name: `n8n-cloud: ${doc.kind} ${doc.metadata.name} / container ${c.name}`,
 						user: String(c.securityContext?.runAsUser ?? pod.securityContext?.runAsUser ?? 1000),
 						entrypoint: c.command[0],
 						// --help makes the process terminate without bind/connect.
@@ -68,10 +68,10 @@ async function run({ name, user, entrypoint, args }) {
 }
 
 const invocations = [
-	{ name: 'default entrypoint', user: '1000', entrypoint: null, args: ['--help'] },
+	{ name: 'n8n image default entrypoint', user: '1000', entrypoint: null, args: ['--help'] },
 	...(process.env.SMOKE_SKIP_CLOUD === 'true' ? [] : await fetchCloudInvocations()),
 ];
 
-echo(chalk.bold(`Smoke-testing ${IMAGE} (${invocations.length} invocations)`));
+echo(chalk.bold(`Verifying ${IMAGE} against ${invocations.length} deployment pattern(s)`));
 const ok = (await Promise.all(invocations.map(run))).every(Boolean);
 if (!ok) process.exit(1);


### PR DESCRIPTION
## Summary

Reverts the alpine 3.22 → 3.23 base-image migration from #30478. The alpine 3.23 packaging of `graphicsmagick=1.3.46-r0` pulls a GPL-2.0-licensed transitive dependency into the runtime image, which is incompatible with n8n's third-party license policy. Restoring the alpine 3.22 base (`graphicsmagick=1.3.45-r0`) takes the GPL-2.0 package out of the runtime tree.

The longer-term replacement of `graphicsmagick` with a permissively-licensed image library is tracked separately as a breaking change with its own deprecation path; this PR is the bounded immediate fix.

### What's reverted

| File | Change |
|---|---|
| `docker/images/n8n-base/Dockerfile` | DHI `alpine3.23-dev` → `alpine3.22-dev`; restore `busybox-binsh`, `apk upgrade`, `git`; `graphicsmagick=1.3.45-r0`; `NODE_PATH` back to the `/opt/nodejs/...` path |
| `docker/images/n8n/Dockerfile` | Builder stage alpine 3.23 → 3.22; install location back to `/usr/local/lib/node_modules/n8n`; symlink at `/usr/local/bin/n8n`; drops the workaround from #30622 (alpine 3.22 ships FHS-conforming paths natively) |
| `docker/images/engine/Dockerfile` | alpine 3.23 → 3.22 |
| `docker/images/runners/Dockerfile` | alpine 3.23 → 3.22 (3 stages + launcher-downloader) |
| `packages/testing/playwright/scripts/build-test-image.mjs` | COPY path back to `/usr/local/lib/node_modules/n8n` |
| `.github/workflows/build-base-image.yml` | Drop Node 26 from the matrix while on alpine 3.22 (DHI doesn't publish a 3.22 pairing for Node 26) |

### What's kept from #30478

- Node 24.15.0 patch bump (DHI publishes both alpine 3.22 and 3.23 variants for this Node version).
- CI matrix Node 26 entry in unit-test workflows (uses `actions/setup-node` from nodejs.org, no alpine coupling).

### New: cloud chart smoke test

`scripts/smoke-n8n-image.mjs` + wired into the existing `docker-build-smoke.yml` workflow. After the no-cache build, the step fetches the relevant downstream helm chart, renders it with `helm template`, and executes the built image with the actual container spec from the rendered manifest. Catches the regression class where alpine/DHI changes break a downstream deployment's invocation pattern at PR time rather than after release.

### Backport scope

`Backport to Beta` + `Backport to Stable` because #30478 was backported to both release-candidate branches and they currently ship the GPL-2.0 dependency. The revert needs to follow the same path.

### Validation

- Built locally with `DOCKER_BUILD_BASE_IMAGE=true pnpm build:docker`.
- Smoke against rebuilt image (`pnpm build:docker:smoke`) passes both invocation patterns:
  - n8n image default entrypoint
  - Live-rendered helm chart container spec
- `/usr/local/bin/n8n --version` returns the expected version.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created.
- [x] Tests included — `scripts/smoke-n8n-image.mjs` exercises the deployment patterns the previous regression broke.
- [x] PR Labeled with `Backport to Beta` + `Backport to Stable`.