### PR TITLE
fix(DataTable): Handle undefined name in resolveDataTableId

### DIFF
--- a/packages/nodes-base/nodes/DataTable/common/utils.ts
+++ b/packages/nodes-base/nodes/DataTable/common/utils.ts
@@ -31,9 +31,16 @@ export async function resolveDataTableId(
 ): Promise<string> {
 	if (resourceLocator.mode === 'name') {
 		// Look up table by name
+		const maybeName = resourceLocator.value;
+		if (!maybeName) {
+			throw new NodeOperationError(
+				ctx.getNode(),
+				'Data table name is empty or undefined',
+			);
+		}
 		const aggregateProxy = await getDataTableAggregateProxy(ctx);
 		const response = await aggregateProxy.getManyAndCount({
-			filter: { name: resourceLocator.value.toLowerCase() },
+			filter: { name: maybeName.toLowerCase() },
 			take: 1,
 		});
 

--- a/packages/nodes-base/nodes/DataTable/test/common/resolveDataTableId.test.ts
+++ b/packages/nodes-base/nodes/DataTable/test/common/resolveDataTableId.test.ts
@@ -186,5 +186,35 @@ describe('resolveDataTableId', () => {
 				take: 1,
 			});
 		});
+
+		it('should throw NodeOperationError when value is undefined in name mode', async () => {
+			const ctx = mock<IExecuteFunctions>();
+			ctx.getNode.mockReturnValue(mockNode);
+
+			const resourceLocator = {
+				mode: 'name' as const,
+				value: undefined as unknown as string,
+			};
+
+			await expect(resolveDataTableId(ctx, resourceLocator)).rejects.toThrow(NodeOperationError);
+			await expect(resolveDataTableId(ctx, resourceLocator)).rejects.toThrow(
+				'Data table name is empty or undefined',
+			);
+		});
+
+		it('should throw NodeOperationError when value is empty string in name mode', async () => {
+			const ctx = mock<IExecuteFunctions>();
+			ctx.getNode.mockReturnValue(mockNode);
+
+			const resourceLocator = {
+				mode: 'name' as const,
+				value: '',
+			};
+
+			await expect(resolveDataTableId(ctx, resourceLocator)).rejects.toThrow(NodeOperationError);
+			await expect(resolveDataTableId(ctx, resourceLocator)).rejects.toThrow(
+				'Data table name is empty or undefined',
+			);
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Fixes an issue where `resolveDataTableId` crashes with `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` when the DataTable node uses `mode: "name"` with a dynamic expression value.

The fix adds a null guard before calling `.toLowerCase()` on the `resourceLocator.value`, throwing a descriptive `NodeOperationError` when the value is undefined.

## Related Linear tickets, Github issues, and Community forum posts

- Fixes #30656

## Review / Merge checklist

- [x] PR title follows conventional commit format
- [x] Code changes are self-explanatory
- [x] Changes are covered by existing tests
- [x] Added unit tests for undefined/empty name branch
- [ ] All automated CI checks pass
