### PR TITLE
fix(core): Allow shadowing dangerous globals as variable names in workflow SDK

### DIFF
--- a/packages/@n8n/workflow-sdk/src/ast-interpreter/interpreter.test.ts
+++ b/packages/@n8n/workflow-sdk/src/ast-interpreter/interpreter.test.ts
@@ -869,6 +869,69 @@ describe('AST Interpreter', () => {
 			const code = 'export default WebAssembly;';
 			expect(() => interpretSDKCode(code, sdkFunctions)).toThrow(SecurityError);
 		});
+
+		it('should report SecurityError with a clean (non-doubled) message', () => {
+			const code = 'export default fetch;';
+			expect(() => interpretSDKCode(code, sdkFunctions)).toThrow(
+				/Security violation: 'fetch' is not allowed/,
+			);
+		});
+	});
+
+	describe('Security - dangerous globals shadowed by declared variables', () => {
+		let sdkFunctions: SDKFunctions;
+
+		beforeEach(() => {
+			sdkFunctions = createMockSDKFunctions();
+		});
+
+		const shadowable = [
+			'fetch',
+			'process',
+			'require',
+			'console',
+			'Object',
+			'Array',
+			'Math',
+			'Date',
+			'Error',
+			'Promise',
+			'Buffer',
+		];
+
+		for (const name of shadowable) {
+			it(`should allow '${name}' as a node variable name`, () => {
+				const code = `
+					const ${name} = node({ name: 'X', type: 'n8n-nodes-base.set' });
+					export default workflow('id', 'name').add(${name});
+				`;
+				const result = interpretSDKCode(code, sdkFunctions) as { nodes: unknown[] };
+				expect(result.nodes).toHaveLength(1);
+			});
+		}
+
+		it('should still reject undeclared fetch reference', () => {
+			const code = 'export default fetch;';
+			expect(() => interpretSDKCode(code, sdkFunctions)).toThrow(SecurityError);
+		});
+
+		it('should still reject member access on undeclared process', () => {
+			const code = 'export default process.env.PATH;';
+			expect(() => interpretSDKCode(code, sdkFunctions)).toThrow(SecurityError);
+		});
+
+		it('should still reject member access on undeclared Math', () => {
+			const code = 'export default Math.PI;';
+			expect(() => interpretSDKCode(code, sdkFunctions)).toThrow(SecurityError);
+		});
+
+		it('should resolve member access against the user-declared shadow', () => {
+			const code = `
+				const Math = { custom: 42 };
+				export default Math.custom;
+			`;
+			expect(interpretSDKCode(code, sdkFunctions)).toBe(42);
+		});
 	});
 
 	describe('JSON.stringify', () => {

--- a/packages/@n8n/workflow-sdk/src/ast-interpreter/interpreter.ts
+++ b/packages/@n8n/workflow-sdk/src/ast-interpreter/interpreter.ts
@@ -411,14 +411,16 @@ class SDKInterpreter {
 	private visitIdentifier(node: ESTree.Identifier): unknown {
 		const name = node.name;
 
-		// Check for dangerous globals
-		validateIdentifier(name, this.getVariableNames(), node, this.sourceCode);
-
-		// Check if it's a declared variable (including auto-renamed ones)
+		// Locally declared variables shadow the dangerous-globals blocklist,
+		// so a user-declared `const fetch = node(...)` resolves to their value
+		// rather than being rejected as access to the real `fetch` global.
 		const resolvedName = this.renamedVariables.get(name) ?? name;
 		if (this.variables.has(resolvedName)) {
 			return this.variables.get(resolvedName);
 		}
+
+		// Check for dangerous globals (only when not shadowed by a local)
+		validateIdentifier(name, this.getVariableNames(), node, this.sourceCode);
 
 		// Check if it's an SDK function
 		if (this.sdkFunctions.has(name)) {

--- a/packages/@n8n/workflow-sdk/src/ast-interpreter/validators.ts
+++ b/packages/@n8n/workflow-sdk/src/ast-interpreter/validators.ts
@@ -264,11 +264,7 @@ export function validateIdentifier(
 	sourceCode: string,
 ): void {
 	if (DANGEROUS_GLOBALS.has(name)) {
-		throw new SecurityError(
-			`Access to '${name}' is not allowed`,
-			node.loc ?? undefined,
-			sourceCode,
-		);
+		throw new SecurityError(name, node.loc ?? undefined, sourceCode);
 	}
 }
 
@@ -330,11 +326,7 @@ export function validateMemberExpression(node: MemberExpression, sourceCode: str
 		propName !== undefined &&
 		(propName === '__proto__' || propName === 'prototype' || propName === 'constructor')
 	) {
-		throw new SecurityError(
-			`Access to '${propName}' is not allowed`,
-			node.loc ?? undefined,
-			sourceCode,
-		);
+		throw new SecurityError(propName, node.loc ?? undefined, sourceCode);
 	}
 }
 


### PR DESCRIPTION
## Summary

The workflow SDK's AST interpreter rejected any reference to identifiers in its `DANGEROUS_GLOBALS` blocklist (`fetch`, `process`, `require`, `console`, `Object`, `Math`, `Date`, `Promise`, `Buffer`, ...) — even when the user had declared a local `const` with that name. This caused `validate_workflow` to fail on otherwise valid SDK code such as:

```js
const fetch = node({ name: 'Fetch', type: 'n8n-nodes-base.httpRequest' });
const wf = workflow('id', 'name').add(fetch);
export default wf;
```

with `Security violation: 'Access to 'fetch' is not allowed' is not allowed`.

The cause: `visitIdentifier` ran the dangerous-globals check **before** looking up the local variables map, so a shadowed name never resolved.

### Changes

- `interpreter.ts`: in `visitIdentifier`, look up declared variables (and auto-renamed ones) before consulting the dangerous-globals blocklist. Locals now shadow globals, matching normal JS scoping semantics.
- `validators.ts`: pass just the identifier/property name to `SecurityError` instead of a full sentence, so the wrapped message reads `Security violation: 'fetch' is not allowed` instead of the doubled `Security violation: 'Access to 'fetch' is not allowed' is not allowed`.
- Tests: added coverage for declared/undeclared cases across the blocklist, plus a regression for the cleaned-up error message.

### Still rejected (verified by tests)

- Free reference to undeclared dangerous globals (`export default fetch;`)
- Member access on undeclared globals (`process.env.PATH`, `Math.PI`)
- Calling `eval()` / `Function()` / `require()` directly (separate guard in `validateCallExpression`)
- `__proto__`, `prototype`, `constructor` access

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5172

External report: https://github.com/czlonkowski/n8n-mcp/blob/main/docs/competitive-analysis-may-2026.md#54-what-the-official-server-gives-up

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)