### PR TITLE
fix(core): Return defaultSettings with timezone from GET /workflows/new

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -112,6 +112,10 @@ export { DeactivateWorkflowDto } from './workflows/deactivate-workflow.dto';
 export { ArchiveWorkflowDto } from './workflows/archive-workflow.dto';
 export { GetResourceDependencyCountsDto } from './workflows/get-resource-dependency-counts.dto';
 export { GetResourceDependenciesDto } from './workflows/get-resource-dependencies.dto';
+export type {
+	GetNewWorkflowResponse,
+	NewWorkflowDefaultSettings,
+} from './workflows/get-new-workflow-response.dto';
 
 export { CreateOrUpdateTagRequestDto } from './tag/create-or-update-tag-request.dto';
 export { RetrieveTagQueryDto } from './tag/retrieve-tag-query.dto';

--- a/packages/@n8n/api-types/src/dto/workflows/get-new-workflow-response.dto.ts
+++ b/packages/@n8n/api-types/src/dto/workflows/get-new-workflow-response.dto.ts
@@ -1,0 +1,8 @@
+import type { IWorkflowSettings } from 'n8n-workflow';
+
+export type NewWorkflowDefaultSettings = Pick<IWorkflowSettings, 'executionOrder' | 'timezone'>;
+
+export type GetNewWorkflowResponse = {
+	name: string;
+	defaultSettings: NewWorkflowDefaultSettings;
+};

--- a/packages/cli/src/workflows/__tests__/workflows.controller.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflows.controller.test.ts
@@ -1,6 +1,6 @@
 import type { ImportWorkflowFromUrlDto } from '@n8n/api-types';
 import type { Logger } from '@n8n/backend-common';
-import type { SsrfProtectionConfig } from '@n8n/config';
+import type { GlobalConfig, SsrfProtectionConfig } from '@n8n/config';
 import type { AuthenticatedRequest, IExecutionResponse } from '@n8n/db';
 import axios from 'axios';
 import type { Response } from 'express';
@@ -12,6 +12,7 @@ import { WorkflowsController } from '../workflows.controller';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import type { ExecutionService } from '@/executions/execution.service';
+import type { NamingService } from '@/services/naming.service';
 import type { ProjectService } from '@/services/project.service.ee';
 import { SsrfBlockedIpError } from '@/services/ssrf/ssrf-blocked-ip.error';
 import type { SsrfProtectionService } from '@/services/ssrf/ssrf-protection.service';
@@ -210,6 +211,56 @@ describe('WorkflowsController', () => {
 				expect(ssrfProtectionService.validateUrl).not.toHaveBeenCalled();
 				expect(ssrfProtectionService.createSecureLookup).not.toHaveBeenCalled();
 			});
+		});
+	});
+
+	describe('getNewName', () => {
+		const namingService = mock<NamingService>();
+		const globalConfig = mock<GlobalConfig>({
+			workflows: { defaultName: 'My workflow' },
+			generic: { timezone: 'Europe/Berlin' },
+		});
+
+		beforeEach(() => {
+			controller.namingService = namingService;
+			controller.globalConfig = globalConfig;
+		});
+
+		it('should return name and defaultSettings with timezone from config', async () => {
+			const req = mock<AuthenticatedRequest>({ query: { projectId: 'project-1' } });
+			projectService.getProjectWithScope.mockResolvedValue({} as never);
+			namingService.getUniqueWorkflowName.mockResolvedValue('My workflow');
+
+			const result = await controller.getNewName(req);
+
+			expect(result).toEqual({
+				name: 'My workflow',
+				defaultSettings: {
+					executionOrder: 'v1',
+					timezone: 'Europe/Berlin',
+				},
+			});
+		});
+
+		it('should throw ForbiddenError when user lacks workflow:create scope', async () => {
+			const req = mock<AuthenticatedRequest>({ query: { projectId: 'project-1' } });
+			projectService.getProjectWithScope.mockResolvedValue(null);
+
+			await expect(controller.getNewName(req)).rejects.toThrow(ForbiddenError);
+			expect(namingService.getUniqueWorkflowName).not.toHaveBeenCalled();
+		});
+
+		it('should use requested name when provided', async () => {
+			const req = mock<AuthenticatedRequest>({
+				query: { projectId: 'project-1', name: 'Custom Name' },
+			});
+			projectService.getProjectWithScope.mockResolvedValue({} as never);
+			namingService.getUniqueWorkflowName.mockResolvedValue('Custom Name');
+
+			const result = await controller.getNewName(req);
+
+			expect(namingService.getUniqueWorkflowName).toHaveBeenCalledWith('Custom Name');
+			expect(result.name).toBe('Custom Name');
 		});
 	});
 

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -163,7 +163,11 @@ export class WorkflowsController {
 		const requestedName = req.query.name ?? this.globalConfig.workflows.defaultName;
 
 		const name = await this.namingService.getUniqueWorkflowName(requestedName);
-		return { name };
+		const defaultSettings = {
+			executionOrder: 'v1' as const,
+			timezone: this.globalConfig.generic.timezone,
+		};
+		return { name, defaultSettings };
 	}
 
 	@Get('/from-url')

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -8,6 +8,7 @@ import {
 	ROLE,
 	TransferWorkflowBodyDto,
 	UpdateWorkflowDto,
+	type GetNewWorkflowResponse,
 } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import { GlobalConfig, SsrfProtectionConfig } from '@n8n/config';
@@ -163,11 +164,14 @@ export class WorkflowsController {
 		const requestedName = req.query.name ?? this.globalConfig.workflows.defaultName;
 
 		const name = await this.namingService.getUniqueWorkflowName(requestedName);
-		const defaultSettings = {
-			executionOrder: 'v1' as const,
-			timezone: this.globalConfig.generic.timezone,
+		const response: GetNewWorkflowResponse = {
+			name,
+			defaultSettings: {
+				executionOrder: 'v1',
+				timezone: this.globalConfig.generic.timezone,
+			},
 		};
-		return { name, defaultSettings };
+		return response;
 	}
 
 	@Get('/from-url')

--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -235,6 +235,7 @@ export interface NewWorkflowResponse {
 
 export interface INewWorkflowData {
 	name: string;
+	settings?: IWorkflowSettingsWorkflow;
 }
 
 // Almost identical to cli.Interfaces.ts

--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -1,6 +1,7 @@
 import type { NotificationOptions as ElementNotificationOptions } from 'element-plus';
 import type {
 	FrontendSettings,
+	GetNewWorkflowResponse,
 	IUserManagementSettings,
 	IVersionNotificationSettings,
 	Role,
@@ -228,10 +229,7 @@ export interface IWorkflowToShare extends WorkflowDataUpdate {
 	meta: WorkflowMetadata;
 }
 
-export interface NewWorkflowResponse {
-	name: string;
-	defaultSettings: IWorkflowSettings;
-}
+export type { GetNewWorkflowResponse as NewWorkflowResponse };
 
 export interface INewWorkflowData {
 	name: string;

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -324,6 +324,9 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 			parentFolderId,
 		);
 		currentWorkflowDocumentStore.value.setName(workflowData.name);
+		if (workflowData.settings) {
+			currentWorkflowDocumentStore.value.mergeSettings(workflowData.settings);
+		}
 		const homeProject = projectsStore.currentProject ?? projectsStore.personalProject ?? null;
 		currentWorkflowDocumentStore.value.setHomeProject(homeProject);
 


### PR DESCRIPTION
## Summary

`GET /workflows/new` only returned the generated workflow name. New workflows never inherited the instance timezone from `GENERIC_TIMEZONE` - they always defaulted to `America/New_York` on the frontend, regardless of instance config.

This PR adds `defaultSettings` to the response (`executionOrder` + `timezone` pulled from global config). The frontend merges those settings into the new workflow document at creation, so the timezone matches the instance default right away.

### Changes

- **`workflows.controller.ts`:** `getNewName` now returns `defaultSettings` with `executionOrder: 'v1'` and `timezone` from `globalConfig.generic.timezone`, alongside the workflow name.
- **`Interface.ts`:** `INewWorkflowData` has a new optional `settings` field to carry the API response through to initialization.
- **`useWorkflowInitialization.ts`:** Merges returned settings into the workflow document store after fetching, if present.

### How to test
-  Set `GENERIC_TIMEZONE` to a non-default value (e.g. `Europe/Berlin`).
- Start n8n and create a new workflow.
- Open **Workflow Settings** — should show `Europe/Berlin`, not `America/New_York`.
- Without `GENERIC_TIMEZONE` set, new workflows should still default to `America/New_York`.

## Related Linear tickets, Github issues, and Community forum posts
- [GHC-8395](https://linear.app/n8n/issue/GHC-8395) - Linear ticket
- [#30583 — GENERIC_TIMEZONE has no effect](https://github.com/n8n-io/n8n/issues/30583) - GitHub issue

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([[conventions](https://claude.ai/blob/master/.github/pull_request_title_conventions.md)](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [[Docs updated](https://github.com/n8n-io/n8n-docs)](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)