### PR TITLE
ci: Optimize .github/scripts runs via caching and reduced checkout depth

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: 'Command to execute for installing project dependencies. Leave empty to skip install step.'
     required: false
     default: 'pnpm install --frozen-lockfile'
+  cache-dependency-path:
+    description: 'Path(s) to the lockfile(s) used to compute the pnpm-store cache key. Scope this down (e.g. to `.github/scripts/pnpm-lock.yaml`) when only installing a subset, to avoid restoring the full workspace store.'
+    required: false
+    default: 'pnpm-lock.yaml'
 
 runs:
   using: 'composite'
@@ -34,6 +38,7 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
         cache: 'pnpm'
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
 
     # To avoid setup-node cache failure.
     # see: https://github.com/actions/setup-node/issues/1137

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           build-command: ''
           install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
+          cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Compute backport targets
         id: targets

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           token: ${{ steps.generate-token.outputs.token }}
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-nodejs

--- a/.github/workflows/ci-detect-new-packages.yml
+++ b/.github/workflows/ci-detect-new-packages.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           build-command: ''
           install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
+          cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Check for new unpublished packages
         id: detect

--- a/.github/workflows/ci-pr-quality.yml
+++ b/.github/workflows/ci-pr-quality.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           build-command: ''
           install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
+          cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Re-request PR Size Limit check
         env:
@@ -69,6 +70,7 @@ jobs:
         with:
           build-command: ''
           install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
+          cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Check ownership checkbox
         env:
@@ -101,6 +103,7 @@ jobs:
         with:
           build-command: ''
           install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
+          cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Check PR size
         env:

--- a/.github/workflows/release-create-github-releases.yml
+++ b/.github/workflows/release-create-github-releases.yml
@@ -71,6 +71,7 @@ jobs:
         with:
           build-command: ''
           install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
+          cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Create GitHub releases
         env:

--- a/.github/workflows/release-create-patch-pr.yml
+++ b/.github/workflows/release-create-patch-pr.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           build-command: ''
           install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
+          cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Determine release candidate branch from track
         id: determine-branch

--- a/.github/workflows/release-create-pr.yml
+++ b/.github/workflows/release-create-pr.yml
@@ -80,6 +80,7 @@ jobs:
         with:
           build-command: ''
           install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
+          cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Setup corepack and pnpm
         run: |

--- a/.github/workflows/release-populate-cloud-with-releases.yml
+++ b/.github/workflows/release-populate-cloud-with-releases.yml
@@ -49,6 +49,7 @@ jobs:
         with:
           build-command: ''
           install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
+          cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Extract changes
         id: get-changes

--- a/.github/workflows/release-promote-github-release.yml
+++ b/.github/workflows/release-promote-github-release.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           build-command: ''
           install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
+          cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Promote GitHub releases
         env:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-nodejs

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           build-command: ''
           install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
+          cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Determine track from package version number
         id: determine-info

--- a/.github/workflows/release-set-stable-npm-packages-to-latest.yml
+++ b/.github/workflows/release-set-stable-npm-packages-to-latest.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           build-command: ''
           install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
+          cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Set npm packages to latest
         run: node ./.github/scripts/set-latest-for-monorepo-packages.mjs

--- a/.github/workflows/release-update-pointer-tag.yml
+++ b/.github/workflows/release-update-pointer-tag.yml
@@ -53,6 +53,7 @@ jobs:
         with:
           build-command: ''
           install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
+          cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Configure git author
         run: |

--- a/.github/workflows/release-version-release-notification.yml
+++ b/.github/workflows/release-version-release-notification.yml
@@ -31,13 +31,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-nodejs
         with:
           build-command: ''
           install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
+          cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Send release notification
         env:

--- a/.github/workflows/test-workflow-scripts-reusable.yml
+++ b/.github/workflows/test-workflow-scripts-reusable.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           build-command: ''
           install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
+          cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Run tests
         id: run-tests

--- a/.github/workflows/util-cleanup-abandoned-release-branches.yml
+++ b/.github/workflows/util-cleanup-abandoned-release-branches.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           build-command: ''
           install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
+          cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Cleanup release branch if PR qualifies
         run: node .github/scripts/cleanup-release-branch.mjs

--- a/.github/workflows/util-determine-current-version.yml
+++ b/.github/workflows/util-determine-current-version.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           build-command: ''
           install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
+          cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Extract release versions
         id: get-tags

--- a/.github/workflows/util-determine-current-version.yml
+++ b/.github/workflows/util-determine-current-version.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
+          fetch-tags: true
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-nodejs

--- a/.github/workflows/util-ensure-release-candidate-branches.yml
+++ b/.github/workflows/util-ensure-release-candidate-branches.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           fetch-tags: true
 
       - name: Setup NodeJS

--- a/.github/workflows/util-ensure-release-candidate-branches.yml
+++ b/.github/workflows/util-ensure-release-candidate-branches.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           build-command: ''
           install-command: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace
+          cache-dependency-path: .github/scripts/pnpm-lock.yaml
 
       - name: Ensure release-candidate branches
         env:


### PR DESCRIPTION
## Summary

- Add pnpm caching for the `.github/scripts` node modules
- Don't overfetch with actions/checkout if not needed

Should speed up the often-running scripts like backports and other CI checks by a large margin.

## Related Linear tickets, Github issues, and Community forum posts


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
