### PR TITLE
fix(editor): Align Referenced resources chip tooltip placement

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/DependencyPill.vue
+++ b/packages/frontend/editor-ui/src/app/components/DependencyPill.vue
@@ -201,7 +201,7 @@ async function onDropdownToggle(open: boolean) {
 </script>
 
 <template>
-	<N8nTooltip :content="tooltipText" placement="bottom" :show-after="300">
+	<N8nTooltip :content="tooltipText" placement="top" :show-after="300">
 		<N8nDropdownMenu
 			:items="menuItems"
 			placement="bottom-end"


### PR DESCRIPTION
## Summary

Set the `DependencyPill` tooltip `placement` to `top` so it matches the adjacent Owner chip on workflow / credential / data-table cards. With `avoidCollisions` (default), it still flips to bottom when there isn't room above.

**Test:** Open Home / Workflows, hover the Owner chip and the Referenced resources chip on the same row — both tooltips should now appear above.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5239

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI