### PR TITLE
fix(editor): Reserve options-bar space in stacked InputTriple rows

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/InputTriple/InputTriple.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/InputTriple/InputTriple.vue
@@ -241,6 +241,10 @@ const isStacked = computed(() => bp.value !== 'default');
 	}
 
 	.item:last-of-type {
+		// Reserve space for the absolutely-positioned options bar (bottom: -22px)
+		// so it stays within this triple instead of overlapping the next row.
+		padding-bottom: var(--parameter-input-options--height, 22px);
+
 		--input--radius--top-left: 0;
 		--input--radius--top-right: 0;
 		--input-triple--radius--top-right: 0;


### PR DESCRIPTION
## Summary

In stacked-mode `InputTriple` (Edit Fields and Filter Condition rows when narrow), the value field's options bar — which holds the fixed/expression toggle — is absolutely positioned at `bottom: -22px` of its wrapper. With only a 4 px gap between rows in `AssignmentCollection`, the bar overflowed into the next row, making the third field's toggle uninteractable (clicks/hover hit the row below).

Reserve `var(--parameter-input-options--height, 22px)` of `padding-bottom` on the last item in stacked mode so the options bar stays within its own triple's bounding box.

**How to test:** Open Edit Fields with ≥3 triples; narrow the NDV so triples stack vertically; hover/click the fixed/expression toggle on each row's value field — it should respond on its own row. Same check works for Filter conditions in stacked mode.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5220

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI