### PR TITLE
fix(core): Handle null pinData column at executions, save empty object as pinData on instanceAI

### DIFF
--- a/packages/cli/src/__tests__/workflow-helpers.test.ts
+++ b/packages/cli/src/__tests__/workflow-helpers.test.ts
@@ -4,9 +4,12 @@ import type { CredentialsEntity, Project, Variables } from '@n8n/db';
 import { CredentialsRepository } from '@n8n/db';
 import type { ITaskData, IWorkflowBase, IWorkflowSettings } from 'n8n-workflow';
 
+import type { IRun } from 'n8n-workflow';
+
 import { VariablesService } from '@/environments.ee/variables/variables.service.ee';
 import { OwnershipService } from '@/services/ownership.service';
 import {
+	getDataLastExecutedNodeData,
 	getVariables,
 	preserveInputOverride,
 	removeDefaultValues,
@@ -438,5 +441,45 @@ describe('validatePinDataSize', () => {
 		).toThrow(
 			`Workflow with pinned data exceeds the maximum allowed size of ${Math.floor(limit / (1024 * 1024))} MB`,
 		);
+	});
+});
+
+describe('getDataLastExecutedNodeData', () => {
+	const lastNodeTaskData: ITaskData = {
+		startTime: 0,
+		executionIndex: 0,
+		executionTime: 0,
+		executionStatus: 'success',
+		source: [],
+		data: { main: [[{ json: { ok: true } }]] },
+	};
+
+	function buildRun(pinData: unknown): IRun {
+		return {
+			mode: 'webhook',
+			startedAt: new Date(),
+			status: 'success',
+			storedAt: 'db',
+			data: {
+				resultData: {
+					runData: { 'Log Assistant Message': [lastNodeTaskData] },
+					lastNodeExecuted: 'Log Assistant Message',
+					// Persisted execution data can contain `pinData: null` for workflows
+					// created without a pinData column (e.g. older AI-built workflows).
+					pinData,
+				},
+			},
+		} as unknown as IRun;
+	}
+
+	it('returns last node run data when pinData is null', () => {
+		// Regression: destructure default `pinData = {}` only applies to undefined,
+		// so a null value used to throw `Cannot read properties of null`.
+		expect(() => getDataLastExecutedNodeData(buildRun(null))).not.toThrow();
+		expect(getDataLastExecutedNodeData(buildRun(null))).toBe(lastNodeTaskData);
+	});
+
+	it('returns last node run data when pinData is undefined', () => {
+		expect(getDataLastExecutedNodeData(buildRun(undefined))).toBe(lastNodeTaskData);
 	});
 });

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -1658,6 +1658,22 @@ describe('createWorkflowAdapter', () => {
 		);
 	});
 
+	it('persists pinData as an empty object (not undefined) when the SDK workflow has no pinData', async () => {
+		// Regression: explicit `pinData: undefined` round-tripped as SQL NULL,
+		// which then crashed `getDataLastExecutedNodeData` on test-webhook runs.
+		// Match the manual UI path, which stores `{}`.
+		const { adapter, mockWorkflowService } = createWorkflowAdapterForTests();
+
+		await adapter.createFromWorkflowJSON(minimalWorkflowJSON);
+
+		expect(mockWorkflowService.update).toHaveBeenCalledWith(
+			expect.anything(),
+			expect.objectContaining({ pinData: {} }),
+			expect.anything(),
+			expect.anything(),
+		);
+	});
+
 	it('clears the AI-builder temporary marker when promoting the main workflow', async () => {
 		const { adapter, mockAiBuilderTemporaryWorkflowRepository, mockWorkflowRepository } =
 			createWorkflowAdapterForTests();

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -526,6 +526,11 @@ export class InstanceAiAdapterService {
 						source: 'n8n-ai',
 					});
 				} catch (error) {
+					logger.warn('AI-builder workflow save failed', {
+						threadId,
+						workflowId: saved.id,
+						error: error instanceof Error ? error.message : String(error),
+					});
 					try {
 						const archived = await workflowService.archive(user, saved.id, { skipArchived: true });
 						if (archived && options?.markAsAiTemporary) {
@@ -580,19 +585,29 @@ export class InstanceAiAdapterService {
 					pinData: sdkPinDataToRuntime(json.pinData),
 				} as Partial<WorkflowEntity>);
 
-				// Enforce credential tamper protection — same guard as the
-				// REST controller (workflows.controller PATCH /:workflowId).
-				if (license.isSharingEnabled()) {
-					updateData = await enterpriseWorkflowService.preventTampering(
-						updateData,
-						workflowId,
-						user,
-					);
-				}
+				let updated: WorkflowEntity;
+				try {
+					// Enforce credential tamper protection — same guard as the
+					// REST controller (workflows.controller PATCH /:workflowId).
+					if (license.isSharingEnabled()) {
+						updateData = await enterpriseWorkflowService.preventTampering(
+							updateData,
+							workflowId,
+							user,
+						);
+					}
 
-				const updated = await workflowService.update(user, updateData, workflowId, {
-					source: 'n8n-ai',
-				});
+					updated = await workflowService.update(user, updateData, workflowId, {
+						source: 'n8n-ai',
+					});
+				} catch (error) {
+					logger.warn('AI-builder workflow save failed', {
+						threadId,
+						workflowId,
+						error: error instanceof Error ? error.message : String(error),
+					});
+					throw error;
+				}
 
 				if (threadId) {
 					telemetry.track('Builder modified workflow', {
@@ -3012,9 +3027,9 @@ export async function extractExecutionDebugInfo(
  * Convert SDK pinData (Record<string, IDataObject[]>) to runtime format (IPinData).
  * SDK stores plain objects; runtime wraps each item in { json: item }.
  */
-function sdkPinDataToRuntime(pinData: Record<string, unknown[]> | undefined): IPinData | undefined {
-	if (!pinData || Object.keys(pinData).length === 0) return undefined;
+function sdkPinDataToRuntime(pinData: Record<string, unknown[]> | undefined): IPinData {
 	const result: IPinData = {};
+	if (!pinData) return result;
 	for (const [nodeName, items] of Object.entries(pinData)) {
 		result[nodeName] = items.map((item) => ({ json: (item ?? {}) as IDataObject }));
 	}

--- a/packages/cli/src/workflow-helpers.ts
+++ b/packages/cli/src/workflow-helpers.ts
@@ -58,8 +58,8 @@ export function validatePinDataSize(workflow: IWorkflowBase): void {
  * Returns the data of the last executed node
  */
 export function getDataLastExecutedNodeData(inputData: IRun): ITaskData | undefined {
-	const { runData, pinData = {} } = inputData.data.resultData;
-	const { lastNodeExecuted } = inputData.data.resultData;
+	const { runData, lastNodeExecuted } = inputData.data.resultData;
+	const pinData = inputData.data.resultData.pinData ?? {};
 
 	if (lastNodeExecuted === undefined) {
 		return undefined;


### PR DESCRIPTION
## Summary

Turns out if `pinData` column (json data) contains `null` as its value we failed to use it at workflow-helpers.ts `getDataLastExecutedNodeData`, when accessed via `inputData.data.resultData` could actually resolve to a null, which would then error at

```
let lastNodePinData = pinData[lastNodeExecuted]
```

when pinData was actually `null`. Our types believe it to be `IPindata | undefined` but that's not true it seems like.

I fixed workflow-helpers to fall back to an empty object instead so that this line wouldn't error even if pinData is set to null, and I made instance AI workflow generation to save empty objects instead of null as the pinData value when it doesn't set it.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
