### PR TITLE
fix(editor): Remove 'Build Agent' button from EmptyStateBuilderPrompt (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/experiments/emptyStateBuilderPrompt/components/EmptyStateBuilderPrompt.vue
+++ b/packages/frontend/editor-ui/src/experiments/emptyStateBuilderPrompt/components/EmptyStateBuilderPrompt.vue
@@ -15,7 +15,6 @@ import { useEmptyStateBuilderPromptStore } from '../stores/emptyStateBuilderProm
 const props = defineProps<{
 	projectId?: string;
 	parentFolderId?: string;
-	showBuildAgentButton?: boolean;
 }>();
 
 const router = useRouter();
@@ -27,7 +26,6 @@ const emptyStateBuilderPromptStore = useEmptyStateBuilderPromptStore();
 const emit = defineEmits<{
 	submit: [prompt: string];
 	startFromScratch: [];
-	buildAgent: [];
 }>();
 
 const textInputValue = ref<string>('');
@@ -59,10 +57,6 @@ function onTemplate() {
 
 function onImportFromFile() {
 	importFileRef.value?.click();
-}
-
-function onBuildAgent() {
-	emit('buildAgent');
 }
 
 function handleFileImport() {
@@ -142,16 +136,6 @@ function handleFileImport() {
 						{{ i18n.baseText('emptyStateBuilderPrompt.fromScratch') }}
 					</N8nButton>
 				</N8nTooltip>
-				<N8nButton
-					v-if="props.showBuildAgentButton"
-					variant="subtle"
-					size="small"
-					icon="robot"
-					data-test-id="build-agent-button"
-					@click="onBuildAgent"
-				>
-					{{ i18n.baseText('workflows.empty.buildAgent') }}
-				</N8nButton>
 				<N8nTooltip :content="i18n.baseText('emptyStateBuilderPrompt.templateTooltip')">
 					<N8nButton variant="subtle" size="small" icon="layout-template" @click="onTemplate">
 						{{ i18n.baseText('emptyStateBuilderPrompt.template') }}


### PR DESCRIPTION
## Summary
Remove the secondary "Build agent" action and its unused wiring from the component as we don't have Agents/IAI in the same experiment -  so it's not needed.


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)