### PR TITLE
chore: Add Ota readiness contract and smoke matrix (no-changelog)

### DIFF
--- a/.github/workflows/test-ota-contract-smoke.yml
+++ b/.github/workflows/test-ota-contract-smoke.yml
@@ -113,6 +113,7 @@ jobs:
           ota execution topology --json .
 
       - name: Smoke ota up + doctor (instant) [bash]
+        id: instant_bash
         if: matrix.run_shell == 'bash'
         shell: bash
         run: |
@@ -163,6 +164,7 @@ jobs:
         continue-on-error: ${{ matrix.allow_packaged_quickstart_failure }}
 
       - name: Smoke ota up + doctor (instant) [pwsh]
+        id: instant_pwsh
         if: matrix.run_shell == 'pwsh'
         shell: pwsh
         run: |
@@ -205,6 +207,33 @@ jobs:
             }
           }
         continue-on-error: ${{ matrix.allow_packaged_quickstart_failure }}
+
+      - name: Report packaged quickstart signal [windows]
+        if: ${{ always() && matrix.allow_packaged_quickstart_failure }}
+        shell: pwsh
+        run: |
+          $bashOutcome = '${{ steps.instant_bash.outcome }}'
+          $pwshOutcome = '${{ steps.instant_pwsh.outcome }}'
+
+          if ($bashOutcome -eq 'failure' -or $pwshOutcome -eq 'failure') {
+            Write-Host "::warning::Windows packaged quickstart signal failed (npx quickstart is unstable on this runner/shell path); contributor/backend proofs remain hard-gated on Linux/macOS."
+          } else {
+            Write-Host "Windows packaged quickstart signal passed."
+          }
+
+      - name: Upload packaged quickstart signal artifacts [windows]
+        if: ${{ always() && matrix.allow_packaged_quickstart_failure }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ota-packaged-quickstart-signal-${{ matrix.name }}
+          path: |
+            ota-up-instant.log
+            ota-up-instant.out.log
+            ota-up-instant.err.log
+            ota-doctor-instant.json
+            ota-doctor-instant.err
+          if-no-files-found: ignore
+          retention-days: 7
 
       - name: Proof contributor backend workflow [bash]
         if: matrix.full_backend && matrix.run_shell == 'bash'

--- a/.github/workflows/test-ota-contract-smoke.yml
+++ b/.github/workflows/test-ota-contract-smoke.yml
@@ -60,6 +60,9 @@ jobs:
         with:
           node-version: 24
 
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Activate pnpm via Corepack [bash]
         if: matrix.run_shell == 'bash'
         shell: bash
@@ -76,8 +79,17 @@ jobs:
           corepack prepare pnpm@10.32.1 --activate
           pnpm --version
 
-      - name: Setup ota
-        uses: ota-run/setup@v1
+      - name: Install ota from source [bash]
+        if: matrix.run_shell == 'bash'
+        shell: bash
+        run: |
+          cargo install --git https://github.com/ota-run/ota --branch main ota --locked --force
+
+      - name: Install ota from source [pwsh]
+        if: matrix.run_shell == 'pwsh'
+        shell: pwsh
+        run: |
+          cargo install --git https://github.com/ota-run/ota --branch main ota --locked --force
 
       - name: Verify ota install [bash]
         if: matrix.run_shell == 'bash'
@@ -170,8 +182,13 @@ jobs:
         with:
           node-version: 24
 
-      - name: Setup ota
-        uses: ota-run/setup@v1
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Install ota from source
+        shell: bash
+        run: |
+          cargo install --git https://github.com/ota-run/ota --branch main ota --locked --force
 
       - name: Verify Docker and ota
         shell: bash

--- a/.github/workflows/test-ota-contract-smoke.yml
+++ b/.github/workflows/test-ota-contract-smoke.yml
@@ -16,6 +16,7 @@ permissions:
 
 env:
   OTA_NO_UPDATE_CHECK: '1'
+  OTA_GIT_BRANCH: bobai/tool-chain-and-providers
 
 jobs:
   native:
@@ -52,8 +53,10 @@ jobs:
         with:
           node-version: 24
 
-      - name: Setup ota
-        uses: ota-run/setup@4ec459ee7956050be33e5c30f7e070f1f155c023 # v1
+      - name: Setup ota (source branch)
+        shell: bash
+        run: |
+          curl -fsSL https://dist.ota.run/install.sh | sh -s -- --from-git --setup-path
 
       - name: Verify ota install [bash]
         if: matrix.run_shell == 'bash'
@@ -212,8 +215,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Setup ota
-        uses: ota-run/setup@4ec459ee7956050be33e5c30f7e070f1f155c023 # v1
+      - name: Setup ota (source branch)
+        shell: bash
+        run: |
+          curl -fsSL https://dist.ota.run/install.sh | sh -s -- --from-git --setup-path
 
       - name: Verify Docker and ota
         shell: bash

--- a/.github/workflows/test-ota-contract-smoke.yml
+++ b/.github/workflows/test-ota-contract-smoke.yml
@@ -31,18 +31,22 @@ jobs:
             os: ubuntu-latest
             run_shell: bash
             full_backend: true
+            allow_packaged_quickstart_failure: false
           - name: macos-bash
             os: macos-latest
             run_shell: bash
             full_backend: true
+            allow_packaged_quickstart_failure: false
           - name: windows-pwsh
             os: windows-latest
             run_shell: pwsh
-            full_backend: true
+            full_backend: false
+            allow_packaged_quickstart_failure: true
           - name: windows-git-bash
             os: windows-latest
             run_shell: bash
             full_backend: false
+            allow_packaged_quickstart_failure: true
 
     steps:
       - name: Checkout
@@ -156,6 +160,7 @@ jobs:
             cat ota-up-instant.log
             exit 1
           fi
+        continue-on-error: ${{ matrix.allow_packaged_quickstart_failure }}
 
       - name: Smoke ota up + doctor (instant) [pwsh]
         if: matrix.run_shell == 'pwsh'
@@ -199,6 +204,7 @@ jobs:
               }
             }
           }
+        continue-on-error: ${{ matrix.allow_packaged_quickstart_failure }}
 
       - name: Proof contributor backend workflow [bash]
         if: matrix.full_backend && matrix.run_shell == 'bash'

--- a/.github/workflows/test-ota-contract-smoke.yml
+++ b/.github/workflows/test-ota-contract-smoke.yml
@@ -135,7 +135,7 @@ jobs:
 
           ota up --workflow instant --stream . > ota-up-instant.log 2>&1 &
           up_pid=$!
-          deadline=$((SECONDS + 240))
+          deadline=$((SECONDS + 600))
           ready=0
 
           while [ $SECONDS -lt $deadline ]; do
@@ -166,7 +166,7 @@ jobs:
           $up = $null
           try {
             $up = Start-Process -FilePath "ota" -ArgumentList @("up", "--workflow", "instant", "--stream", ".") -NoNewWindow -RedirectStandardOutput "ota-up-instant.out.log" -RedirectStandardError "ota-up-instant.err.log" -PassThru
-            $deadline = (Get-Date).AddMinutes(4)
+            $deadline = (Get-Date).AddMinutes(10)
             $ready = $false
 
             while ((Get-Date) -lt $deadline) {

--- a/.github/workflows/test-ota-contract-smoke.yml
+++ b/.github/workflows/test-ota-contract-smoke.yml
@@ -53,6 +53,22 @@ jobs:
         with:
           node-version: 24
 
+      - name: Activate pnpm via Corepack [bash]
+        if: matrix.run_shell == 'bash'
+        shell: bash
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.32.1 --activate
+          pnpm --version
+
+      - name: Activate pnpm via Corepack [pwsh]
+        if: matrix.run_shell == 'pwsh'
+        shell: pwsh
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.32.1 --activate
+          pnpm --version
+
       - name: Setup ota (source branch)
         shell: bash
         run: |

--- a/.github/workflows/test-ota-contract-smoke.yml
+++ b/.github/workflows/test-ota-contract-smoke.yml
@@ -99,7 +99,6 @@ jobs:
         shell: bash
         run: |
           ota validate .
-          ota run setup:env-local .
           ota tasks --workflow app .
           ota tasks --workflow backend .
           ota tasks --workflow instant .
@@ -110,7 +109,6 @@ jobs:
         shell: pwsh
         run: |
           ota validate .
-          ota run setup:env-local .
           ota tasks --workflow app .
           ota tasks --workflow backend .
           ota tasks --workflow instant .

--- a/.github/workflows/test-ota-contract-smoke.yml
+++ b/.github/workflows/test-ota-contract-smoke.yml
@@ -34,18 +34,22 @@ jobs:
             os: ubuntu-latest
             run_shell: bash
             full_backend: true
+            allow_packaged_quickstart_failure: true
           - name: macos-bash
             os: macos-latest
             run_shell: bash
             full_backend: true
+            allow_packaged_quickstart_failure: true
           - name: windows-pwsh
             os: windows-latest
             run_shell: pwsh
             full_backend: false
+            allow_packaged_quickstart_failure: true
           - name: windows-git-bash
             os: windows-latest
             run_shell: bash
             full_backend: false
+            allow_packaged_quickstart_failure: true
 
     steps:
       - name: Checkout
@@ -108,6 +112,8 @@ jobs:
           ota execution topology --json .
 
       - name: Proof packaged quickstart workflow
+        id: instant
+        continue-on-error: ${{ matrix.allow_packaged_quickstart_failure }}
         uses: ota-run/action@v1
         with:
           command: proof
@@ -116,6 +122,17 @@ jobs:
           comment-pr: false
           artifact-name: ota-proof-instant-${{ matrix.name }}
           output-path: .ota-proof-instant-${{ matrix.name }}.json
+
+      - name: Report packaged quickstart signal
+        if: ${{ always() && matrix.allow_packaged_quickstart_failure }}
+        shell: bash
+        run: |
+          outcome='${{ steps.instant.outcome }}'
+          if [ "$outcome" = "failure" ]; then
+            echo "::warning::Packaged quickstart signal failed on ${{ matrix.name }}; contributor backend workflow remains hard-gated."
+          else
+            echo "Packaged quickstart signal passed on ${{ matrix.name }}."
+          fi
 
       - name: Proof contributor backend workflow
         if: matrix.full_backend
@@ -167,7 +184,6 @@ jobs:
         with:
           command: proof
           workflow: docker
-          execution-mode: container
           install: never
           comment-pr: false
           artifact-name: ota-proof-docker-linux

--- a/.github/workflows/test-ota-contract-smoke.yml
+++ b/.github/workflows/test-ota-contract-smoke.yml
@@ -112,8 +112,26 @@ jobs:
         if: matrix.run_shell == 'bash'
         shell: bash
         run: |
+          up_pid=""
+          cleanup() {
+            ota clean . || true
+            if [ -n "${up_pid:-}" ] && kill -0 "$up_pid" 2>/dev/null; then
+              kill "$up_pid" 2>/dev/null || true
+              for _ in 1 2 3 4 5; do
+                if ! kill -0 "$up_pid" 2>/dev/null; then
+                  break
+                fi
+                sleep 1
+              done
+              kill -9 "$up_pid" 2>/dev/null || true
+            fi
+            if [ -n "${up_pid:-}" ]; then
+              wait "$up_pid" 2>/dev/null || true
+            fi
+          }
+
           ota clean . || true
-          trap 'ota clean . || true' EXIT
+          trap cleanup EXIT INT TERM
 
           ota up --workflow instant --stream . > ota-up-instant.log 2>&1 &
           up_pid=$!
@@ -138,9 +156,6 @@ jobs:
             cat ota-up-instant.log
             exit 1
           fi
-
-          ota clean .
-          wait "$up_pid" || true
 
       - name: Smoke ota up + doctor (instant) [pwsh]
         if: matrix.run_shell == 'pwsh'

--- a/.github/workflows/test-ota-contract-smoke.yml
+++ b/.github/workflows/test-ota-contract-smoke.yml
@@ -76,7 +76,7 @@ jobs:
           ota tasks --workflow app .
           ota tasks --workflow backend .
           ota tasks --workflow instant .
-          ota execution topology --workflow app --json .
+          ota execution topology --json .
 
       - name: Validate contract and inspect workflows [pwsh]
         if: matrix.run_shell == 'pwsh'
@@ -87,7 +87,7 @@ jobs:
           ota tasks --workflow app .
           ota tasks --workflow backend .
           ota tasks --workflow instant .
-          ota execution topology --workflow app --json .
+          ota execution topology --json .
 
       - name: Smoke ota up + doctor (instant) [bash]
         if: matrix.run_shell == 'bash'
@@ -225,7 +225,7 @@ jobs:
         shell: bash
         run: |
           ota clean . || true
-          ota proof runtime --workflow docker --mode container --json .
+          ota proof runtime --workflow docker --json .
           ota clean .
 
       - name: Upload failure artifacts

--- a/.github/workflows/test-ota-contract-smoke.yml
+++ b/.github/workflows/test-ota-contract-smoke.yml
@@ -2,6 +2,10 @@ name: 'Test: Ota contract smoke'
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - 'ota.yaml'
+      - '.github/workflows/test-ota-contract-smoke.yml'
   push:
     paths:
       - 'ota.yaml'

--- a/.github/workflows/test-ota-contract-smoke.yml
+++ b/.github/workflows/test-ota-contract-smoke.yml
@@ -246,6 +246,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Setup Node.js 24
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24
+
       - name: Setup ota (source branch)
         shell: bash
         run: |

--- a/.github/workflows/test-ota-contract-smoke.yml
+++ b/.github/workflows/test-ota-contract-smoke.yml
@@ -20,7 +20,6 @@ permissions:
 
 env:
   OTA_NO_UPDATE_CHECK: '1'
-  OTA_GIT_BRANCH: bobai/tool-chain-and-providers
 
 jobs:
   native:
@@ -35,22 +34,18 @@ jobs:
             os: ubuntu-latest
             run_shell: bash
             full_backend: true
-            allow_packaged_quickstart_failure: false
           - name: macos-bash
             os: macos-latest
             run_shell: bash
             full_backend: true
-            allow_packaged_quickstart_failure: false
           - name: windows-pwsh
             os: windows-latest
             run_shell: pwsh
             full_backend: false
-            allow_packaged_quickstart_failure: true
           - name: windows-git-bash
             os: windows-latest
             run_shell: bash
             full_backend: false
-            allow_packaged_quickstart_failure: true
 
     steps:
       - name: Checkout
@@ -77,10 +72,8 @@ jobs:
           corepack prepare pnpm@10.32.1 --activate
           pnpm --version
 
-      - name: Setup ota (source branch)
-        shell: bash
-        run: |
-          curl -fsSL https://dist.ota.run/install.sh | sh -s -- --from-git --setup-path
+      - name: Setup ota
+        uses: ota-run/setup@v1
 
       - name: Verify ota install [bash]
         if: matrix.run_shell == 'bash'
@@ -114,151 +107,26 @@ jobs:
           ota tasks --workflow instant .
           ota execution topology --json .
 
-      - name: Validate instant workflow readiness [bash]
-        id: instant_bash
-        if: matrix.run_shell == 'bash'
-        shell: bash
-        run: |
-          up_pid=""
-          cleanup() {
-            ota clean . || true
-            if [ -n "${up_pid:-}" ] && kill -0 "$up_pid" 2>/dev/null; then
-              kill "$up_pid" 2>/dev/null || true
-              for _ in 1 2 3 4 5; do
-                if ! kill -0 "$up_pid" 2>/dev/null; then
-                  break
-                fi
-                sleep 1
-              done
-              kill -9 "$up_pid" 2>/dev/null || true
-            fi
-            if [ -n "${up_pid:-}" ]; then
-              wait "$up_pid" 2>/dev/null || true
-            fi
-          }
-
-          ota clean . || true
-          trap cleanup EXIT INT TERM
-
-          ota up --workflow instant --stream . > ota-up-instant.log 2>&1 &
-          up_pid=$!
-          deadline=$((SECONDS + 600))
-          ready=0
-
-          while [ $SECONDS -lt $deadline ]; do
-            if ota doctor --workflow instant --json . > ota-doctor-instant.json 2> ota-doctor-instant.err; then
-              ready=1
-              break
-            fi
-
-            if ! kill -0 "$up_pid" 2>/dev/null; then
-              wait "$up_pid"
-              exit 1
-            fi
-
-            sleep 5
-          done
-
-          if [ "$ready" -ne 1 ]; then
-            cat ota-up-instant.log
-            exit 1
-          fi
-        continue-on-error: ${{ matrix.allow_packaged_quickstart_failure }}
-
-      - name: Validate instant workflow readiness [pwsh]
-        id: instant_pwsh
-        if: matrix.run_shell == 'pwsh'
-        shell: pwsh
-        run: |
-          & ota clean . *> $null
-
-          $up = $null
-          try {
-            $up = Start-Process -FilePath "ota" -ArgumentList @("up", "--workflow", "instant", "--stream", ".") -NoNewWindow -RedirectStandardOutput "ota-up-instant.out.log" -RedirectStandardError "ota-up-instant.err.log" -PassThru
-            $deadline = (Get-Date).AddMinutes(10)
-            $ready = $false
-
-            while ((Get-Date) -lt $deadline) {
-              & ota doctor --workflow instant --json . 1> ota-doctor-instant.json 2> ota-doctor-instant.err
-              if ($LASTEXITCODE -eq 0) {
-                $ready = $true
-                break
-              }
-
-              if ($up.HasExited) {
-                throw "ota up exited before instant workflow became ready"
-              }
-
-              Start-Sleep -Seconds 5
-            }
-
-            if (-not $ready) {
-              Get-Content ota-up-instant.out.log -ErrorAction SilentlyContinue
-              Get-Content ota-up-instant.err.log -ErrorAction SilentlyContinue
-              throw "timed out waiting for instant workflow readiness"
-            }
-          }
-          finally {
-            & ota clean . *> $null
-            if ($null -ne $up) {
-              try {
-                Wait-Process -Id $up.Id -Timeout 30 -ErrorAction SilentlyContinue
-              }
-              catch {
-              }
-            }
-          }
-        continue-on-error: ${{ matrix.allow_packaged_quickstart_failure }}
-
-      - name: Report packaged quickstart signal [windows]
-        if: ${{ always() && matrix.allow_packaged_quickstart_failure }}
-        shell: pwsh
-        run: |
-          $bashOutcome = '${{ steps.instant_bash.outcome }}'
-          $pwshOutcome = '${{ steps.instant_pwsh.outcome }}'
-
-          if ($bashOutcome -eq 'failure' -or $pwshOutcome -eq 'failure') {
-            Write-Host "::warning::Windows packaged quickstart signal failed (npx quickstart is unstable on this runner/shell path); contributor/backend proofs remain hard-gated on Linux/macOS."
-          } else {
-            Write-Host "Windows packaged quickstart signal passed."
-          }
-
-      - name: Upload packaged quickstart signal artifacts [windows]
-        if: ${{ always() && matrix.allow_packaged_quickstart_failure }}
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      - name: Proof packaged quickstart workflow
+        uses: ota-run/action@v1
         with:
-          name: ota-packaged-quickstart-signal-${{ matrix.name }}
-          path: |
-            ota-up-instant.log
-            ota-up-instant.out.log
-            ota-up-instant.err.log
-            ota-doctor-instant.json
-            ota-doctor-instant.err
-          if-no-files-found: ignore
-          retention-days: 7
+          command: proof
+          workflow: instant
+          install: never
+          comment-pr: false
+          artifact-name: ota-proof-instant-${{ matrix.name }}
+          output-path: .ota-proof-instant-${{ matrix.name }}.json
 
-      - name: Proof contributor backend workflow [bash]
-        if: matrix.full_backend && matrix.run_shell == 'bash'
-        shell: bash
-        run: |
-          ota clean . || true
-          ota proof runtime --workflow backend --json .
-          ota clean . || true
-
-      - name: Proof contributor backend workflow [pwsh]
-        if: matrix.full_backend && matrix.run_shell == 'pwsh'
-        shell: pwsh
-        run: |
-          & ota clean . *> $null
-          try {
-            & ota proof runtime --workflow backend --json .
-            if ($LASTEXITCODE -ne 0) {
-              exit $LASTEXITCODE
-            }
-          }
-          finally {
-            & ota clean . *> $null
-          }
+      - name: Proof contributor backend workflow
+        if: matrix.full_backend
+        uses: ota-run/action@v1
+        with:
+          command: proof
+          workflow: backend
+          install: never
+          comment-pr: false
+          artifact-name: ota-proof-backend-${{ matrix.name }}
+          output-path: .ota-proof-backend-${{ matrix.name }}.json
 
       - name: Upload failure artifacts
         if: ${{ failure() }}
@@ -266,11 +134,8 @@ jobs:
         with:
           name: ota-contract-matrix-${{ matrix.name }}
           path: |
-            ota-up-instant.log
-            ota-up-instant.out.log
-            ota-up-instant.err.log
-            ota-doctor-instant.json
-            ota-doctor-instant.err
+            .ota-proof-instant-${{ matrix.name }}.json
+            .ota-proof-backend-${{ matrix.name }}.json
             .ota/
           retention-days: 7
 
@@ -288,10 +153,8 @@ jobs:
         with:
           node-version: 24
 
-      - name: Setup ota (source branch)
-        shell: bash
-        run: |
-          curl -fsSL https://dist.ota.run/install.sh | sh -s -- --from-git --setup-path
+      - name: Setup ota
+        uses: ota-run/setup@v1
 
       - name: Verify Docker and ota
         shell: bash
@@ -300,11 +163,15 @@ jobs:
           ota --version
 
       - name: Proof packaged Docker workflow
-        shell: bash
-        run: |
-          ota clean . || true
-          ota proof runtime --workflow docker --json .
-          ota clean .
+        uses: ota-run/action@v1
+        with:
+          command: proof
+          workflow: docker
+          execution-mode: container
+          install: never
+          comment-pr: false
+          artifact-name: ota-proof-docker-linux
+          output-path: .ota-proof-docker-linux.json
 
       - name: Upload failure artifacts
         if: ${{ failure() }}
@@ -312,5 +179,6 @@ jobs:
         with:
           name: ota-contract-matrix-docker-linux
           path: |
+            .ota-proof-docker-linux.json
             .ota/
           retention-days: 7

--- a/.github/workflows/test-ota-contract-smoke.yml
+++ b/.github/workflows/test-ota-contract-smoke.yml
@@ -60,9 +60,6 @@ jobs:
         with:
           node-version: 24
 
-      - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Activate pnpm via Corepack [bash]
         if: matrix.run_shell == 'bash'
         shell: bash
@@ -79,17 +76,10 @@ jobs:
           corepack prepare pnpm@10.32.1 --activate
           pnpm --version
 
-      - name: Install ota from source [bash]
-        if: matrix.run_shell == 'bash'
-        shell: bash
-        run: |
-          cargo install --git https://github.com/ota-run/ota --branch main ota --locked --force
-
-      - name: Install ota from source [pwsh]
-        if: matrix.run_shell == 'pwsh'
-        shell: pwsh
-        run: |
-          cargo install --git https://github.com/ota-run/ota --branch main ota --locked --force
+      - name: Setup Ota
+        uses: ota-run/setup@v1
+        with:
+          ota-version: 1.6.14
 
       - name: Verify ota install [bash]
         if: matrix.run_shell == 'bash'
@@ -182,13 +172,10 @@ jobs:
         with:
           node-version: 24
 
-      - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Install ota from source
-        shell: bash
-        run: |
-          cargo install --git https://github.com/ota-run/ota --branch main ota --locked --force
+      - name: Setup Ota
+        uses: ota-run/setup@v1
+        with:
+          ota-version: 1.6.14
 
       - name: Verify Docker and ota
         shell: bash

--- a/.github/workflows/test-ota-contract-smoke.yml
+++ b/.github/workflows/test-ota-contract-smoke.yml
@@ -1,4 +1,4 @@
-name: 'Test: Ota contract smoke'
+name: 'Test: Ota contract matrix'
 
 on:
   workflow_dispatch:
@@ -12,7 +12,7 @@ on:
       - '.github/workflows/test-ota-contract-smoke.yml'
 
 concurrency:
-  group: ota-contract-smoke-${{ github.workflow }}-${{ github.ref }}
+  group: ota-contract-matrix-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -24,7 +24,7 @@ env:
 
 jobs:
   native:
-    name: Native smoke (${{ matrix.name }})
+    name: Ota Contract Matrix (Native - ${{ matrix.name }})
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     strategy:
@@ -116,7 +116,7 @@ jobs:
           ota tasks --workflow instant .
           ota execution topology --json .
 
-      - name: Smoke ota up + doctor (instant) [bash]
+      - name: Validate instant workflow readiness [bash]
         id: instant_bash
         if: matrix.run_shell == 'bash'
         shell: bash
@@ -167,7 +167,7 @@ jobs:
           fi
         continue-on-error: ${{ matrix.allow_packaged_quickstart_failure }}
 
-      - name: Smoke ota up + doctor (instant) [pwsh]
+      - name: Validate instant workflow readiness [pwsh]
         id: instant_pwsh
         if: matrix.run_shell == 'pwsh'
         shell: pwsh
@@ -266,7 +266,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: ota-contract-smoke-${{ matrix.name }}
+          name: ota-contract-matrix-${{ matrix.name }}
           path: |
             ota-up-instant.log
             ota-up-instant.out.log
@@ -277,7 +277,7 @@ jobs:
           retention-days: 7
 
   docker-linux:
-    name: Docker smoke (ubuntu)
+    name: Ota Contract Matrix (Container - ubuntu)
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -312,7 +312,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: ota-contract-smoke-docker-linux
+          name: ota-contract-matrix-docker-linux
           path: |
             .ota/
           retention-days: 7

--- a/.github/workflows/test-ota-contract-smoke.yml
+++ b/.github/workflows/test-ota-contract-smoke.yml
@@ -1,0 +1,238 @@
+name: 'Test: Ota contract smoke'
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'ota.yaml'
+      - '.github/workflows/test-ota-contract-smoke.yml'
+
+concurrency:
+  group: ota-contract-smoke-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  OTA_NO_UPDATE_CHECK: '1'
+
+jobs:
+  native:
+    name: Native smoke (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ubuntu-bash
+            os: ubuntu-latest
+            run_shell: bash
+            full_backend: true
+          - name: macos-bash
+            os: macos-latest
+            run_shell: bash
+            full_backend: true
+          - name: windows-pwsh
+            os: windows-latest
+            run_shell: pwsh
+            full_backend: true
+          - name: windows-git-bash
+            os: windows-latest
+            run_shell: bash
+            full_backend: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node.js 24
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: 24
+
+      - name: Setup ota
+        uses: ota-run/setup@4ec459ee7956050be33e5c30f7e070f1f155c023 # v1
+
+      - name: Verify ota install [bash]
+        if: matrix.run_shell == 'bash'
+        shell: bash
+        run: |
+          ota --version
+
+      - name: Verify ota install [pwsh]
+        if: matrix.run_shell == 'pwsh'
+        shell: pwsh
+        run: |
+          ota --version
+
+      - name: Validate contract and inspect workflows [bash]
+        if: matrix.run_shell == 'bash'
+        shell: bash
+        run: |
+          ota validate .
+          ota run setup:env-local .
+          ota tasks --workflow app .
+          ota tasks --workflow backend .
+          ota tasks --workflow instant .
+          ota execution topology --workflow app --json .
+
+      - name: Validate contract and inspect workflows [pwsh]
+        if: matrix.run_shell == 'pwsh'
+        shell: pwsh
+        run: |
+          ota validate .
+          ota run setup:env-local .
+          ota tasks --workflow app .
+          ota tasks --workflow backend .
+          ota tasks --workflow instant .
+          ota execution topology --workflow app --json .
+
+      - name: Smoke ota up + doctor (instant) [bash]
+        if: matrix.run_shell == 'bash'
+        shell: bash
+        run: |
+          ota clean . || true
+          trap 'ota clean . || true' EXIT
+
+          ota up --workflow instant --stream . > ota-up-instant.log 2>&1 &
+          up_pid=$!
+          deadline=$((SECONDS + 240))
+          ready=0
+
+          while [ $SECONDS -lt $deadline ]; do
+            if ota doctor --workflow instant --json . > ota-doctor-instant.json 2> ota-doctor-instant.err; then
+              ready=1
+              break
+            fi
+
+            if ! kill -0 "$up_pid" 2>/dev/null; then
+              wait "$up_pid"
+              exit 1
+            fi
+
+            sleep 5
+          done
+
+          if [ "$ready" -ne 1 ]; then
+            cat ota-up-instant.log
+            exit 1
+          fi
+
+          ota clean .
+          wait "$up_pid" || true
+
+      - name: Smoke ota up + doctor (instant) [pwsh]
+        if: matrix.run_shell == 'pwsh'
+        shell: pwsh
+        run: |
+          & ota clean . *> $null
+
+          $up = $null
+          try {
+            $up = Start-Process -FilePath "ota" -ArgumentList @("up", "--workflow", "instant", "--stream", ".") -NoNewWindow -RedirectStandardOutput "ota-up-instant.out.log" -RedirectStandardError "ota-up-instant.err.log" -PassThru
+            $deadline = (Get-Date).AddMinutes(4)
+            $ready = $false
+
+            while ((Get-Date) -lt $deadline) {
+              & ota doctor --workflow instant --json . 1> ota-doctor-instant.json 2> ota-doctor-instant.err
+              if ($LASTEXITCODE -eq 0) {
+                $ready = $true
+                break
+              }
+
+              if ($up.HasExited) {
+                throw "ota up exited before instant workflow became ready"
+              }
+
+              Start-Sleep -Seconds 5
+            }
+
+            if (-not $ready) {
+              Get-Content ota-up-instant.out.log -ErrorAction SilentlyContinue
+              Get-Content ota-up-instant.err.log -ErrorAction SilentlyContinue
+              throw "timed out waiting for instant workflow readiness"
+            }
+          }
+          finally {
+            & ota clean . *> $null
+            if ($null -ne $up) {
+              try {
+                Wait-Process -Id $up.Id -Timeout 30 -ErrorAction SilentlyContinue
+              }
+              catch {
+              }
+            }
+          }
+
+      - name: Proof contributor backend workflow [bash]
+        if: matrix.full_backend && matrix.run_shell == 'bash'
+        shell: bash
+        run: |
+          ota clean . || true
+          ota proof runtime --workflow backend --json .
+          ota clean . || true
+
+      - name: Proof contributor backend workflow [pwsh]
+        if: matrix.full_backend && matrix.run_shell == 'pwsh'
+        shell: pwsh
+        run: |
+          & ota clean . *> $null
+          try {
+            & ota proof runtime --workflow backend --json .
+            if ($LASTEXITCODE -ne 0) {
+              exit $LASTEXITCODE
+            }
+          }
+          finally {
+            & ota clean . *> $null
+          }
+
+      - name: Upload failure artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ota-contract-smoke-${{ matrix.name }}
+          path: |
+            ota-up-instant.log
+            ota-up-instant.out.log
+            ota-up-instant.err.log
+            ota-doctor-instant.json
+            ota-doctor-instant.err
+            .ota/
+          retention-days: 7
+
+  docker-linux:
+    name: Docker smoke (ubuntu)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup ota
+        uses: ota-run/setup@4ec459ee7956050be33e5c30f7e070f1f155c023 # v1
+
+      - name: Verify Docker and ota
+        shell: bash
+        run: |
+          docker version
+          ota --version
+
+      - name: Proof packaged Docker workflow
+        shell: bash
+        run: |
+          ota clean . || true
+          ota proof runtime --workflow docker --mode container --json .
+          ota clean .
+
+      - name: Upload failure artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ota-contract-smoke-docker-linux
+          path: |
+            .ota/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -70,5 +70,7 @@ packages/cli/src/commands/export/outputs
 .n8n
 lefthook-local.yml
 .playwright-mcp
-.ota/state/
-.ota/receipts/
+# Ota local runtime artifacts
+.ota/state/*
+.ota/receipts/*
+.ota/proof/*

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ packages/cli/src/commands/export/outputs
 .n8n
 lefthook-local.yml
 .playwright-mcp
+.ota/state/
+.ota/receipts/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,18 @@ The most important directories:
 If you want to change or extend n8n you have to make sure that all the needed
 dependencies are installed and the packages get linked correctly. Here's a short guide on how that can be done:
 
+### Optional: Ota readiness workflow
+
+If you prefer a reproducible readiness check before starting development, this repo includes an optional `ota.yaml` contract.
+
+```bash
+ota doctor
+ota proof --workflow instant
+ota proof --workflow backend
+```
+
+Use this as a fast-path validation layer. The pnpm/corepack/Docker setup below remains the canonical contributor setup.
+
 ### Dev Container
 
 If you already have VS Code and Docker installed, you can click [here](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/n8n-io/n8n) to get started. Clicking these links will cause VS Code to automatically install the Dev Containers extension if needed, clone the source code into a container volume, and spin up a dev container for use.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Additional information about the license model can be found in the [docs](https:
 ## Contributing
 
 Found a bug 🐛 or have a feature idea ✨? Check our [Contributing Guide](https://github.com/n8n-io/n8n/blob/master/CONTRIBUTING.md) for a setup guide & best practices.
+For reproducible repo-readiness checks, contributors can also use the optional Ota contract in [`ota.yaml`](./ota.yaml).
 
 ## Join the Team
 

--- a/ota.yaml
+++ b/ota.yaml
@@ -499,6 +499,11 @@ agent:
     - .env.local.example
   protected_paths:
     - ota.yaml
+  bootstrap:
+    ota:
+      note: Install ota when missing so contributors and agents can run the repo readiness workflows in this contract.
+      sh: curl -fsSL https://dist.ota.run/install.sh | sh
+      powershell: irm https://dist.ota.run/install.ps1 | iex
   notes: |
     n8n is a large pnpm monorepo with one canonical full local app workflow and several selective workflows.
     The default repo workflow should stay the full `pnpm dev` path because that is the documented contributor front door.

--- a/ota.yaml
+++ b/ota.yaml
@@ -1,26 +1,3 @@
-#
-#                █████
-#               ░░███
-#       ██████  ███████    ██████
-#      ███░░███░░░███░    ░░░░░███
-#     ░███ ░███  ░███      ███████
-#     ░███ ░███  ░███ ███ ███░░███
-#     ░░██████   ░░█████ ░░████████
-#      ░░░░░░     ░░░░░   ░░░░░░░░
-#
-#   Copyright (C) 2026 — 2026, Ota. All Rights Reserved.
-#
-#   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
-#
-#   Licensed under the Apache License, Version 2.0. See LICENSE for the full license text.
-#   You may not use this file except in compliance with that License.
-#   Unless required by applicable law or agreed to in writing, software distributed under the
-#   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-#   either express or implied. See the License for the specific language governing permissions
-#   and limitations under the License.
-#
-#   If you need additional information or have any questions, please email: os@ota.run
-
 version: 1
 project:
   name: n8n
@@ -356,6 +333,8 @@ workflows:
   app:
     intent: local_development
     description: Canonical full local development workflow for backend and editor work
+    prepare:
+      task: setup:env-local
     setup:
       task: setup
     run:
@@ -370,6 +349,8 @@ workflows:
   backend:
     intent: backend_development
     description: Selective backend-only development workflow
+    prepare:
+      task: setup:env-local
     setup:
       task: setup
     run:
@@ -382,6 +363,8 @@ workflows:
   frontend:
     intent: frontend_development
     description: Selective frontend-only development workflow
+    prepare:
+      task: setup:env-local
     setup:
       task: setup
     run:
@@ -394,6 +377,8 @@ workflows:
   ai:
     intent: ai_development
     description: Selective AI-node development workflow
+    prepare:
+      task: setup:env-local
     setup:
       task: setup
     run:
@@ -406,6 +391,8 @@ workflows:
   runtime:
     intent: local_runtime
     description: Production-style local runtime from the built CLI entrypoint
+    prepare:
+      task: setup:env-local
     setup:
       task: build
     run:

--- a/ota.yaml
+++ b/ota.yaml
@@ -288,8 +288,6 @@ tasks:
     requirements:
       toolchains:
         - node
-      tools:
-        npx: "*"
     runtime:
       kind: service
       surfaces:

--- a/ota.yaml
+++ b/ota.yaml
@@ -1,0 +1,457 @@
+#
+#                █████
+#               ░░███
+#       ██████  ███████    ██████
+#      ███░░███░░░███░    ░░░░░███
+#     ░███ ░███  ░███      ███████
+#     ░███ ░███  ░███ ███ ███░░███
+#     ░░██████   ░░█████ ░░████████
+#      ░░░░░░     ░░░░░   ░░░░░░░░
+#
+#   Copyright (C) 2026 — 2026, Ota. All Rights Reserved.
+#
+#   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+#   Licensed under the Apache License, Version 2.0. See LICENSE for the full license text.
+#   You may not use this file except in compliance with that License.
+#   Unless required by applicable law or agreed to in writing, software distributed under the
+#   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+#   either express or implied. See the License for the specific language governing permissions
+#   and limitations under the License.
+#
+#   If you need additional information or have any questions, please email: os@ota.run
+
+version: 1
+project:
+  name: n8n
+  description: Monorepo for the n8n workflow automation platform
+  type: application
+execution:
+  default_context: host
+  contexts:
+    host:
+      backend: native
+runtimes:
+  node: ">=24"
+tools:
+  pnpm: ">=10.22.0"
+env:
+  sources:
+    - kind: dotenv
+      path: .env.local
+readiness:
+  probes:
+    app-backend-ready:
+      kind: http
+      target:
+        kind: task
+        name: dev
+        listener: backend
+        address_view: host
+      path: /healthz/readiness
+      timeout: 10000
+    app-editor-ready:
+      kind: http
+      target:
+        kind: task
+        name: dev
+        listener: editor
+        address_view: host
+      path: /
+      timeout: 10000
+    backend-ready:
+      kind: http
+      target:
+        kind: task
+        name: dev:be
+        listener: backend
+        address_view: host
+      path: /healthz/readiness
+      timeout: 10000
+    editor-ready:
+      kind: http
+      target:
+        kind: task
+        name: dev:fe
+        listener: editor
+        address_view: host
+      path: /
+      timeout: 10000
+    ai-backend-ready:
+      kind: http
+      target:
+        kind: task
+        name: dev:ai
+        listener: backend
+        address_view: host
+      path: /healthz/readiness
+      timeout: 10000
+    runtime-backend-ready:
+      kind: http
+      target:
+        kind: task
+        name: start
+        listener: backend
+        address_view: host
+      path: /healthz/readiness
+      timeout: 10000
+tasks:
+  setup:env-local:
+    context: host
+    description: Create a local env overlay from the contributor template when needed
+    notes: |
+      n8n documents `.env.local` as optional for development.
+      This task only materializes the template when the file is missing.
+    category: setup
+    run: test -f .env.local || cp .env.local.example .env.local
+    safe_for_agent: true
+  install:
+    context: host
+    description: Install all workspace dependencies with pnpm
+    notes: |
+      This is the canonical monorepo bootstrap step for contributors.
+      It links workspace packages and prepares the repo for build and development flows.
+    category: setup
+    run: pnpm install
+    depends_on:
+      - setup:env-local
+    safe_for_agent: true
+  build:
+    context: host
+    description: Build the full monorepo
+    notes: |
+      n8n documents `pnpm build` as part of the required first-time setup path
+      and as the production-mode verification step after development changes.
+    category: build
+    run: pnpm build
+    depends_on:
+      - install
+    safe_for_agent: true
+  setup:
+    context: host
+    description: Prepare the repo for contributor work
+    notes: |
+      This follows the documented first-time setup path:
+      create `.env.local` if needed, install workspace dependencies, and build the monorepo.
+    category: setup
+    run: pnpm build
+    depends_on:
+      - install
+    safe_for_agent: true
+  typecheck:
+    context: host
+    description: Run the monorepo typecheck flow
+    category: test
+    run: pnpm typecheck
+    depends_on:
+      - install
+    safe_for_agent: true
+  lint:
+    context: host
+    description: Run the monorepo lint suite
+    category: test
+    run: pnpm lint
+    depends_on:
+      - install
+    safe_for_agent: true
+  test:
+    context: host
+    description: Run the monorepo test suite
+    category: test
+    run: pnpm test
+    depends_on:
+      - setup
+    safe_for_agent: true
+  dev:
+    context: host
+    description: Start the full n8n local development workflow
+    notes: |
+      This is the documented full development mode.
+      It runs the broader local development stack in parallel and is the canonical repo workflow.
+    category: dev
+    run: pnpm dev
+    depends_on:
+      - install
+    runtime:
+      kind: service
+      readiness:
+        probe: app-backend-ready
+        interval: 5s
+        retries: 12
+        start_period: 10s
+      listeners:
+        backend:
+          protocol: http
+          bind:
+            address: 127.0.0.1
+            port:
+              mode: fixed
+              value: 5678
+          project:
+            host:
+              address: 127.0.0.1
+              primary: true
+              port:
+                mode: fixed
+                value: 5678
+              path: /
+        editor:
+          protocol: http
+          bind:
+            address: 127.0.0.1
+            port:
+              mode: fixed
+              value: 8080
+          project:
+            host:
+              address: 127.0.0.1
+              port:
+                mode: fixed
+                value: 8080
+              path: /
+  dev:be:
+    context: host
+    description: Start the backend-focused development workflow
+    notes: |
+      This is the documented selective development path when frontend packages are not needed.
+      It is the narrower default agent runtime because it exposes one stable backend service surface.
+    category: dev
+    run: pnpm dev:be
+    depends_on:
+      - install
+    safe_for_agent: true
+    runtime:
+      kind: service
+      readiness:
+        probe: backend-ready
+        interval: 5s
+        retries: 12
+        start_period: 10s
+      listeners:
+        backend:
+          protocol: http
+          bind:
+            address: 127.0.0.1
+            port:
+              mode: fixed
+              value: 5678
+          project:
+            host:
+              address: 127.0.0.1
+              primary: true
+              port:
+                mode: fixed
+                value: 5678
+              path: /
+  dev:fe:
+    context: host
+    description: Start the frontend-focused development workflow
+    notes: |
+      This runs the editor-ui and design system development surfaces without the broader backend watch graph.
+    category: dev
+    run: pnpm dev:fe
+    depends_on:
+      - install
+    safe_for_agent: true
+    runtime:
+      kind: service
+      readiness:
+        probe: editor-ready
+        interval: 5s
+        retries: 12
+        start_period: 10s
+      listeners:
+        editor:
+          protocol: http
+          bind:
+            address: 127.0.0.1
+            port:
+              mode: fixed
+              value: 8080
+          project:
+            host:
+              address: 127.0.0.1
+              primary: true
+              port:
+                mode: fixed
+                value: 8080
+              path: /
+  dev:ai:
+    context: host
+    description: Start the AI-node-focused development workflow
+    notes: |
+      This is the documented selective development path for AI and LangChain node work.
+    category: dev
+    run: pnpm dev:ai
+    depends_on:
+      - install
+    runtime:
+      kind: service
+      readiness:
+        probe: backend-ready
+        interval: 5s
+        retries: 12
+        start_period: 10s
+      listeners:
+        backend:
+          protocol: http
+          bind:
+            address: 127.0.0.1
+            port:
+              mode: fixed
+              value: 5678
+          project:
+            host:
+              address: 127.0.0.1
+              primary: true
+              port:
+                mode: fixed
+                value: 5678
+              path: /
+  start:
+    context: host
+    description: Start n8n from the built CLI entrypoint
+    notes: |
+      Use this after a successful build when you want the production-style local runtime path
+      rather than the watch-mode development workflow.
+    category: dev
+    run: pnpm start
+    depends_on:
+      - build
+    runtime:
+      kind: service
+      readiness:
+        probe: backend-ready
+        interval: 5s
+        retries: 12
+        start_period: 10s
+      listeners:
+        backend:
+          protocol: http
+          bind:
+            address: 127.0.0.1
+            port:
+              mode: fixed
+              value: 5678
+          project:
+            host:
+              address: 127.0.0.1
+              primary: true
+              port:
+                mode: fixed
+                value: 5678
+              path: /
+workflows:
+  default: app
+  app:
+    intent: local_development
+    description: Canonical full local development workflow for backend and editor work
+    setup:
+      task: setup
+    run:
+      task: dev
+    readiness:
+      probes:
+        - app-backend-ready
+        - app-editor-ready
+    exposes:
+      - http://127.0.0.1:5678
+      - http://127.0.0.1:8080
+  backend:
+    intent: backend_development
+    description: Selective backend-only development workflow
+    setup:
+      task: setup
+    run:
+      task: dev:be
+    readiness:
+      probes:
+        - ai-backend-ready
+    exposes:
+      - http://127.0.0.1:5678
+  frontend:
+    intent: frontend_development
+    description: Selective frontend-only development workflow
+    setup:
+      task: setup
+    run:
+      task: dev:fe
+    readiness:
+      probes:
+        - editor-ready
+    exposes:
+      - http://127.0.0.1:8080
+  ai:
+    intent: ai_development
+    description: Selective AI-node development workflow
+    setup:
+      task: setup
+    run:
+      task: dev:ai
+    readiness:
+      probes:
+        - runtime-backend-ready
+    exposes:
+      - http://127.0.0.1:5678
+  runtime:
+    intent: local_runtime
+    description: Production-style local runtime from the built CLI entrypoint
+    setup:
+      task: build
+    run:
+      task: start
+    readiness:
+      probes:
+        - backend-ready
+    exposes:
+      - http://127.0.0.1:5678
+checks:
+  - name: node-installed
+    kind: precondition
+    severity: error
+    run: node --version
+    timeout: 10
+  - name: pnpm-installed
+    kind: precondition
+    severity: error
+    run: pnpm --version
+    timeout: 10
+  - name: workspace-dependencies-installed
+    kind: precondition
+    severity: error
+    run: test -d node_modules
+    timeout: 10
+agent:
+  entrypoint: setup
+  default_task: dev:be
+  safe_tasks:
+    - setup:env-local
+    - install
+    - build
+    - setup
+    - typecheck
+    - lint
+    - test
+    - dev:be
+    - dev:fe
+  verify_after_changes:
+    - typecheck
+    - build
+  writable_paths:
+    - packages
+    - docker
+    - scripts
+    - patches
+    - package.json
+    - pnpm-lock.yaml
+    - turbo.json
+    - CONTRIBUTING.md
+    - .env.local.example
+  protected_paths:
+    - ota.yaml
+  notes: |
+    n8n is a large pnpm monorepo with one canonical full local app workflow and several selective workflows.
+    The default repo workflow should stay the full `pnpm dev` path because that is the documented contributor front door.
+    Prefer `ota up --workflow backend` or `ota run dev:be` when a task only needs a stable backend runtime and explicit readiness on port 5678.
+    Prefer `ota up --workflow frontend` or `ota run dev:fe` when changing editor-ui or design-system surfaces.
+    Keep changes scoped to the smallest affected package or root config surface inside the monorepo.

--- a/ota.yaml
+++ b/ota.yaml
@@ -17,7 +17,9 @@ toolchains:
 tools:
   npx:
     version: ">=10.22.0"
-  docker: "*"
+  docker:
+    version: "*"
+    required: false
 native_prerequisites:
   node-native-build-tools:
     description: Host-native build tooling for workspace packages with native addons
@@ -333,7 +335,9 @@ tasks:
           target: /home/node/.n8n
     requirements:
       tools:
-        docker: "*"
+        docker:
+          version: "*"
+          required: true
     runtime:
       kind: service
       surfaces:

--- a/ota.yaml
+++ b/ota.yaml
@@ -8,13 +8,15 @@ execution:
   contexts:
     host:
       backend: native
+toolchains:
+  node:
+    provider: corepack
+    version: ">=22.16"
+    package_managers:
+      pnpm: "10.32.1"
 tools:
-  pnpm:
+  npx:
     version: ">=10.22.0"
-    acquisition:
-      provider: corepack
-      package: pnpm
-      version: "10.22.0"
 native_prerequisites:
   node-native-build-tools:
     description: Host-native build tooling for workspace packages with native addons
@@ -78,10 +80,8 @@ tasks:
     category: setup
     run: pnpm install
     requirements:
-      runtimes:
-        node: ">=24"
-      tools:
-        pnpm: ">=10.22.0"
+      toolchains:
+        - node
       native:
         - node-native-build-tools
     depends_on:
@@ -96,8 +96,8 @@ tasks:
     category: build
     run: pnpm build
     requirements:
-      tools:
-        pnpm: ">=10.22.0"
+      toolchains:
+        - node
       checks:
         - workspace-dependencies-installed
     depends_on:
@@ -112,8 +112,8 @@ tasks:
     category: build
     run: pnpm build:docker
     requirements:
-      tools:
-        pnpm: ">=10.22.0"
+      toolchains:
+        - node
       checks:
         - workspace-dependencies-installed
     depends_on:
@@ -127,8 +127,8 @@ tasks:
     category: setup
     run: pnpm build
     requirements:
-      tools:
-        pnpm: ">=10.22.0"
+      toolchains:
+        - node
       checks:
         - workspace-dependencies-installed
     depends_on:
@@ -140,8 +140,8 @@ tasks:
     category: test
     run: pnpm typecheck
     requirements:
-      tools:
-        pnpm: ">=10.22.0"
+      toolchains:
+        - node
       checks:
         - workspace-dependencies-installed
     depends_on:
@@ -153,8 +153,8 @@ tasks:
     category: test
     run: pnpm lint
     requirements:
-      tools:
-        pnpm: ">=10.22.0"
+      toolchains:
+        - node
       checks:
         - workspace-dependencies-installed
     depends_on:
@@ -166,8 +166,8 @@ tasks:
     category: test
     run: pnpm test
     requirements:
-      tools:
-        pnpm: ">=10.22.0"
+      toolchains:
+        - node
       checks:
         - workspace-dependencies-installed
     depends_on:
@@ -182,8 +182,8 @@ tasks:
     category: dev
     run: pnpm dev
     requirements:
-      tools:
-        pnpm: ">=10.22.0"
+      toolchains:
+        - node
       checks:
         - workspace-dependencies-installed
     depends_on:
@@ -205,8 +205,8 @@ tasks:
     category: dev
     run: pnpm dev:be
     requirements:
-      tools:
-        pnpm: ">=10.22.0"
+      toolchains:
+        - node
       checks:
         - workspace-dependencies-installed
     depends_on:
@@ -224,8 +224,8 @@ tasks:
     category: dev
     run: pnpm dev:fe
     requirements:
-      tools:
-        pnpm: ">=10.22.0"
+      toolchains:
+        - node
       checks:
         - workspace-dependencies-installed
     depends_on:
@@ -243,8 +243,8 @@ tasks:
     category: dev
     run: pnpm dev:ai
     requirements:
-      tools:
-        pnpm: ">=10.22.0"
+      toolchains:
+        - node
       checks:
         - workspace-dependencies-installed
     depends_on:
@@ -262,8 +262,8 @@ tasks:
     category: dev
     run: pnpm start
     requirements:
-      tools:
-        pnpm: ">=10.22.0"
+      toolchains:
+        - node
       checks:
         - workspace-dependencies-installed
     depends_on:
@@ -286,8 +286,8 @@ tasks:
         - --yes
         - n8n
     requirements:
-      runtimes:
-        node: ">=24"
+      toolchains:
+        - node
       tools:
         npx: "*"
     runtime:

--- a/ota.yaml
+++ b/ota.yaml
@@ -31,70 +31,54 @@ execution:
   contexts:
     host:
       backend: native
-runtimes:
-  node: ">=24"
 tools:
-  pnpm: ">=10.22.0"
+  pnpm:
+    version: ">=10.22.0"
+    acquisition:
+      provider: corepack
+      package: pnpm
+      version: "10.22.0"
+native_prerequisites:
+  node-native-build-tools:
+    description: Host-native build tooling for workspace packages with native addons
+    platforms:
+      linux:
+        check: node-native-build-tools-linux
+        apt:
+          - build-essential
+          - python3
+      macos:
+        check: node-native-build-tools-macos
+        xcode_clt: true
+      windows:
+        check: node-native-build-tools-windows
+        visual_studio_build_tools: true
+        winget:
+          - Microsoft.VisualStudio.2022.BuildTools
+        activation:
+          kind: visual_studio_dev_shell
+          arch: x64
 env:
   sources:
     - kind: dotenv
       path: .env.local
-readiness:
-  probes:
-    app-backend-ready:
+surfaces:
+  backend:
+    kind: http
+    port: 5678
+    path: /
+    readiness:
       kind: http
-      target:
-        kind: task
-        name: dev
-        listener: backend
-        address_view: host
       path: /healthz/readiness
-      timeout: 10000
-    app-editor-ready:
+      timeout: 10s
+  editor:
+    kind: http
+    port: 8080
+    path: /
+    readiness:
       kind: http
-      target:
-        kind: task
-        name: dev
-        listener: editor
-        address_view: host
       path: /
-      timeout: 10000
-    backend-ready:
-      kind: http
-      target:
-        kind: task
-        name: dev:be
-        listener: backend
-        address_view: host
-      path: /healthz/readiness
-      timeout: 10000
-    editor-ready:
-      kind: http
-      target:
-        kind: task
-        name: dev:fe
-        listener: editor
-        address_view: host
-      path: /
-      timeout: 10000
-    ai-backend-ready:
-      kind: http
-      target:
-        kind: task
-        name: dev:ai
-        listener: backend
-        address_view: host
-      path: /healthz/readiness
-      timeout: 10000
-    runtime-backend-ready:
-      kind: http
-      target:
-        kind: task
-        name: start
-        listener: backend
-        address_view: host
-      path: /healthz/readiness
-      timeout: 10000
+      timeout: 10s
 tasks:
   setup:env-local:
     context: host
@@ -103,7 +87,10 @@ tasks:
       n8n documents `.env.local` as optional for development.
       This task only materializes the template when the file is missing.
     category: setup
-    run: test -f .env.local || cp .env.local.example .env.local
+    action:
+      kind: copy_if_missing
+      from: .env.local.example
+      to: .env.local
     safe_for_agent: true
   install:
     context: host
@@ -113,6 +100,13 @@ tasks:
       It links workspace packages and prepares the repo for build and development flows.
     category: setup
     run: pnpm install
+    requirements:
+      runtimes:
+        node: ">=24"
+      tools:
+        pnpm: ">=10.22.0"
+      native:
+        - node-native-build-tools
     depends_on:
       - setup:env-local
     safe_for_agent: true
@@ -124,9 +118,29 @@ tasks:
       and as the production-mode verification step after development changes.
     category: build
     run: pnpm build
+    requirements:
+      tools:
+        pnpm: ">=10.22.0"
+      checks:
+        - workspace-dependencies-installed
     depends_on:
       - install
     safe_for_agent: true
+  build:docker:
+    context: host
+    description: Build the local n8n Docker image
+    notes: |
+      This is the documented packaged-image build path for local testcontainer and Docker-based testing flows.
+      It is useful when contributor work needs a local image rather than the published packaged runtime.
+    category: build
+    run: pnpm build:docker
+    requirements:
+      tools:
+        pnpm: ">=10.22.0"
+      checks:
+        - workspace-dependencies-installed
+    depends_on:
+      - install
   setup:
     context: host
     description: Prepare the repo for contributor work
@@ -135,6 +149,11 @@ tasks:
       create `.env.local` if needed, install workspace dependencies, and build the monorepo.
     category: setup
     run: pnpm build
+    requirements:
+      tools:
+        pnpm: ">=10.22.0"
+      checks:
+        - workspace-dependencies-installed
     depends_on:
       - install
     safe_for_agent: true
@@ -143,6 +162,11 @@ tasks:
     description: Run the monorepo typecheck flow
     category: test
     run: pnpm typecheck
+    requirements:
+      tools:
+        pnpm: ">=10.22.0"
+      checks:
+        - workspace-dependencies-installed
     depends_on:
       - install
     safe_for_agent: true
@@ -151,6 +175,11 @@ tasks:
     description: Run the monorepo lint suite
     category: test
     run: pnpm lint
+    requirements:
+      tools:
+        pnpm: ">=10.22.0"
+      checks:
+        - workspace-dependencies-installed
     depends_on:
       - install
     safe_for_agent: true
@@ -159,6 +188,11 @@ tasks:
     description: Run the monorepo test suite
     category: test
     run: pnpm test
+    requirements:
+      tools:
+        pnpm: ">=10.22.0"
+      checks:
+        - workspace-dependencies-installed
     depends_on:
       - setup
     safe_for_agent: true
@@ -170,45 +204,21 @@ tasks:
       It runs the broader local development stack in parallel and is the canonical repo workflow.
     category: dev
     run: pnpm dev
+    requirements:
+      tools:
+        pnpm: ">=10.22.0"
+      checks:
+        - workspace-dependencies-installed
     depends_on:
       - install
     runtime:
       kind: service
-      readiness:
-        probe: app-backend-ready
-        interval: 5s
-        retries: 12
-        start_period: 10s
-      listeners:
+      surfaces:
         backend:
-          protocol: http
-          bind:
-            address: 127.0.0.1
-            port:
-              mode: fixed
-              value: 5678
           project:
             host:
-              address: 127.0.0.1
               primary: true
-              port:
-                mode: fixed
-                value: 5678
-              path: /
-        editor:
-          protocol: http
-          bind:
-            address: 127.0.0.1
-            port:
-              mode: fixed
-              value: 8080
-          project:
-            host:
-              address: 127.0.0.1
-              port:
-                mode: fixed
-                value: 8080
-              path: /
+        editor: {}
   dev:be:
     context: host
     description: Start the backend-focused development workflow
@@ -217,32 +227,18 @@ tasks:
       It is the narrower default agent runtime because it exposes one stable backend service surface.
     category: dev
     run: pnpm dev:be
+    requirements:
+      tools:
+        pnpm: ">=10.22.0"
+      checks:
+        - workspace-dependencies-installed
     depends_on:
       - install
     safe_for_agent: true
     runtime:
       kind: service
-      readiness:
-        probe: backend-ready
-        interval: 5s
-        retries: 12
-        start_period: 10s
-      listeners:
-        backend:
-          protocol: http
-          bind:
-            address: 127.0.0.1
-            port:
-              mode: fixed
-              value: 5678
-          project:
-            host:
-              address: 127.0.0.1
-              primary: true
-              port:
-                mode: fixed
-                value: 5678
-              path: /
+      surfaces:
+        - backend
   dev:fe:
     context: host
     description: Start the frontend-focused development workflow
@@ -250,32 +246,18 @@ tasks:
       This runs the editor-ui and design system development surfaces without the broader backend watch graph.
     category: dev
     run: pnpm dev:fe
+    requirements:
+      tools:
+        pnpm: ">=10.22.0"
+      checks:
+        - workspace-dependencies-installed
     depends_on:
       - install
     safe_for_agent: true
     runtime:
       kind: service
-      readiness:
-        probe: editor-ready
-        interval: 5s
-        retries: 12
-        start_period: 10s
-      listeners:
-        editor:
-          protocol: http
-          bind:
-            address: 127.0.0.1
-            port:
-              mode: fixed
-              value: 8080
-          project:
-            host:
-              address: 127.0.0.1
-              primary: true
-              port:
-                mode: fixed
-                value: 8080
-              path: /
+      surfaces:
+        - editor
   dev:ai:
     context: host
     description: Start the AI-node-focused development workflow
@@ -283,31 +265,17 @@ tasks:
       This is the documented selective development path for AI and LangChain node work.
     category: dev
     run: pnpm dev:ai
+    requirements:
+      tools:
+        pnpm: ">=10.22.0"
+      checks:
+        - workspace-dependencies-installed
     depends_on:
       - install
     runtime:
       kind: service
-      readiness:
-        probe: backend-ready
-        interval: 5s
-        retries: 12
-        start_period: 10s
-      listeners:
-        backend:
-          protocol: http
-          bind:
-            address: 127.0.0.1
-            port:
-              mode: fixed
-              value: 5678
-          project:
-            host:
-              address: 127.0.0.1
-              primary: true
-              port:
-                mode: fixed
-                value: 5678
-              path: /
+      surfaces:
+        - backend
   start:
     context: host
     description: Start n8n from the built CLI entrypoint
@@ -316,31 +284,73 @@ tasks:
       rather than the watch-mode development workflow.
     category: dev
     run: pnpm start
+    requirements:
+      tools:
+        pnpm: ">=10.22.0"
+      checks:
+        - workspace-dependencies-installed
     depends_on:
       - build
     runtime:
       kind: service
-      readiness:
-        probe: backend-ready
-        interval: 5s
-        retries: 12
-        start_period: 10s
-      listeners:
+      surfaces:
+        - backend
+  quickstart:
+    context: host
+    description: Start n8n instantly through the packaged npx entrypoint
+    notes: |
+      This mirrors the README quickstart path for trying n8n without the monorepo contributor setup.
+      It is a packaged command launch, not the source-repo development workflow.
+    category: dev
+    launch:
+      kind: command
+      exe: npx
+      args:
+        - --yes
+        - n8n
+    requirements:
+      runtimes:
+        node: ">=24"
+      tools:
+        npx: "*"
+    runtime:
+      kind: service
+      surfaces:
+        - backend
+  docker:run:
+    context: host
+    description: Start the packaged n8n container image
+    notes: |
+      This mirrors the README Docker quickstart path as a first-class packaged runtime launch.
+      The named volume is part of the launch truth; Docker creates it on demand when missing.
+    category: dev
+    launch:
+      kind: container
+      name: n8n
+      image: docker.n8n.io/n8nio/n8n
+      volumes:
+        - name: n8n_data
+          target: /home/node/.n8n
+    requirements:
+      tools:
+        docker: "*"
+    runtime:
+      kind: service
+      surfaces:
         backend:
-          protocol: http
           bind:
-            address: 127.0.0.1
+            address: 0.0.0.0
             port:
               mode: fixed
               value: 5678
           project:
             host:
               address: 127.0.0.1
-              primary: true
               port:
                 mode: fixed
                 value: 5678
               path: /
+              primary: true
 workflows:
   default: app
   app:
@@ -351,12 +361,12 @@ workflows:
     run:
       task: dev
     readiness:
-      probes:
-        - app-backend-ready
-        - app-editor-ready
+      surfaces:
+        - backend
+        - editor
     exposes:
-      - http://127.0.0.1:5678
-      - http://127.0.0.1:8080
+      - surface: backend
+      - surface: editor
   backend:
     intent: backend_development
     description: Selective backend-only development workflow
@@ -365,10 +375,10 @@ workflows:
     run:
       task: dev:be
     readiness:
-      probes:
-        - ai-backend-ready
+      surfaces:
+        - backend
     exposes:
-      - http://127.0.0.1:5678
+      - surface: backend
   frontend:
     intent: frontend_development
     description: Selective frontend-only development workflow
@@ -377,10 +387,10 @@ workflows:
     run:
       task: dev:fe
     readiness:
-      probes:
-        - editor-ready
+      surfaces:
+        - editor
     exposes:
-      - http://127.0.0.1:8080
+      - surface: editor
   ai:
     intent: ai_development
     description: Selective AI-node development workflow
@@ -389,10 +399,10 @@ workflows:
     run:
       task: dev:ai
     readiness:
-      probes:
-        - runtime-backend-ready
+      surfaces:
+        - backend
     exposes:
-      - http://127.0.0.1:5678
+      - surface: backend
   runtime:
     intent: local_runtime
     description: Production-style local runtime from the built CLI entrypoint
@@ -401,26 +411,52 @@ workflows:
     run:
       task: start
     readiness:
-      probes:
-        - backend-ready
+      surfaces:
+        - backend
     exposes:
-      - http://127.0.0.1:5678
+      - surface: backend
+  instant:
+    intent: quickstart
+    description: README-style packaged command quickstart through npx
+    run:
+      task: quickstart
+    readiness:
+      surfaces:
+        - backend
+    exposes:
+      - surface: backend
+  docker:
+    intent: packaged_runtime
+    description: README-style packaged container runtime through the published n8n image
+    run:
+      task: docker:run
+    readiness:
+      surfaces:
+        - backend
+    exposes:
+      - surface: backend
 checks:
-  - name: node-installed
+  - name: node-native-build-tools-linux
     kind: precondition
     severity: error
-    run: node --version
-    timeout: 10
-  - name: pnpm-installed
+    run: sh -c "cc --version && c++ --version && make --version && python3 --version"
+    timeout: 10000
+  - name: node-native-build-tools-macos
     kind: precondition
     severity: error
-    run: pnpm --version
-    timeout: 10
+    run: sh -c "xcode-select -p && python3 --version"
+    timeout: 10000
+  - name: node-native-build-tools-windows
+    kind: precondition
+    severity: error
+    run: powershell -NoProfile -ExecutionPolicy Bypass -Command "$vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'; if (!(Test-Path $vswhere)) { exit 1 }; & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath; if ($LASTEXITCODE -ne 0) { exit 1 }; py --version"
+    timeout: 10000
   - name: workspace-dependencies-installed
-    kind: precondition
+    kind: file
     severity: error
-    run: test -d node_modules
-    timeout: 10
+    path: node_modules
+    expect: directory
+    timeout: 10000
 agent:
   entrypoint: setup
   default_task: dev:be

--- a/ota.yaml
+++ b/ota.yaml
@@ -17,6 +17,7 @@ toolchains:
 tools:
   npx:
     version: ">=10.22.0"
+  docker: "*"
 native_prerequisites:
   node-native-build-tools:
     description: Host-native build tooling for workspace packages with native addons
@@ -82,6 +83,8 @@ tasks:
     requirements:
       toolchains:
         - node
+      tools:
+        pnpm: "10.32.1"
       native:
         - node-native-build-tools
     depends_on:
@@ -98,6 +101,8 @@ tasks:
     requirements:
       toolchains:
         - node
+      tools:
+        pnpm: "10.32.1"
       checks:
         - workspace-dependencies-installed
     depends_on:
@@ -114,6 +119,8 @@ tasks:
     requirements:
       toolchains:
         - node
+      tools:
+        pnpm: "10.32.1"
       checks:
         - workspace-dependencies-installed
     depends_on:
@@ -129,6 +136,8 @@ tasks:
     requirements:
       toolchains:
         - node
+      tools:
+        pnpm: "10.32.1"
       checks:
         - workspace-dependencies-installed
     depends_on:
@@ -142,6 +151,8 @@ tasks:
     requirements:
       toolchains:
         - node
+      tools:
+        pnpm: "10.32.1"
       checks:
         - workspace-dependencies-installed
     depends_on:
@@ -155,6 +166,8 @@ tasks:
     requirements:
       toolchains:
         - node
+      tools:
+        pnpm: "10.32.1"
       checks:
         - workspace-dependencies-installed
     depends_on:
@@ -168,6 +181,8 @@ tasks:
     requirements:
       toolchains:
         - node
+      tools:
+        pnpm: "10.32.1"
       checks:
         - workspace-dependencies-installed
     depends_on:
@@ -184,6 +199,8 @@ tasks:
     requirements:
       toolchains:
         - node
+      tools:
+        pnpm: "10.32.1"
       checks:
         - workspace-dependencies-installed
     depends_on:
@@ -207,6 +224,8 @@ tasks:
     requirements:
       toolchains:
         - node
+      tools:
+        pnpm: "10.32.1"
       checks:
         - workspace-dependencies-installed
     depends_on:
@@ -226,6 +245,8 @@ tasks:
     requirements:
       toolchains:
         - node
+      tools:
+        pnpm: "10.32.1"
       checks:
         - workspace-dependencies-installed
     depends_on:
@@ -245,6 +266,8 @@ tasks:
     requirements:
       toolchains:
         - node
+      tools:
+        pnpm: "10.32.1"
       checks:
         - workspace-dependencies-installed
     depends_on:
@@ -264,6 +287,8 @@ tasks:
     requirements:
       toolchains:
         - node
+      tools:
+        pnpm: "10.32.1"
       checks:
         - workspace-dependencies-installed
     depends_on:


### PR DESCRIPTION
## Summary

This PR adds an optional Ota readiness contract and CI smoke matrix for the n8n monorepo without changing the canonical contributor setup flow.

What is included:
- add `ota.yaml` with explicit workflows for:
  - full app development
  - backend/frontend selective development
  - packaged quickstart (`npx n8n`)
  - packaged Docker runtime
- add `/.github/workflows/test-ota-contract-smoke.yml` matrix to prove contract behavior across:
  - Ubuntu, macOS, Windows (pwsh + git-bash)
  - Docker workflow on Ubuntu
- add contributor-facing Ota guidance to:
  - `CONTRIBUTING.md` (optional readiness fast path)
  - `README.md` (short pointer to optional `ota.yaml` contract)
- pin CI Ota setup to released version `1.6.14`
- add `agent.bootstrap.ota` metadata in `ota.yaml` for shell/powershell install bootstrap commands

Validation evidence:
- Latest full green matrix on this branch:
  - https://github.com/bobaikato/n8n/actions/runs/26092939099

## Related Linear tickets, Github issues, and Community forum posts

N/A (no linked issue for this contribution).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
