### PR TITLE
fix(core): Keep Instance AI HITL confirmations waiting

### DIFF
--- a/packages/@n8n/config/src/configs/instance-ai.config.ts
+++ b/packages/@n8n/config/src/configs/instance-ai.config.ts
@@ -112,5 +112,5 @@ export class InstanceAiConfig {
 
 	/** Timeout in milliseconds for HITL confirmation requests. 0 = no timeout. */
 	@Env('N8N_INSTANCE_AI_CONFIRMATION_TIMEOUT')
-	confirmationTimeout: number = 10 * 60 * 1000; // 10 minutes
+	confirmationTimeout: number = 0;
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -295,7 +295,7 @@ describe('GlobalConfig', () => {
 			threadTtlDays: 90,
 			snapshotPruneInterval: 3_600_000,
 			snapshotRetention: 86_400_000,
-			confirmationTimeout: 600_000,
+			confirmationTimeout: 0,
 		},
 		queue: {
 			health: {

--- a/packages/@n8n/instance-ai/docs/configuration.md
+++ b/packages/@n8n/instance-ai/docs/configuration.md
@@ -81,7 +81,7 @@ Sandbox workspaces persist per thread — the same container is reused across me
 | `N8N_INSTANCE_AI_THREAD_TTL_DAYS` | number | `90` | Conversation thread TTL in days. Threads older than this are auto-expired. 0 = no expiration. |
 | `N8N_INSTANCE_AI_SNAPSHOT_PRUNE_INTERVAL` | number | `3600000` | Interval in ms between snapshot pruning runs. 0 = disabled. |
 | `N8N_INSTANCE_AI_SNAPSHOT_RETENTION` | number | `86400000` | Retention period in ms for orphaned workflow snapshots before pruning. |
-| `N8N_INSTANCE_AI_CONFIRMATION_TIMEOUT` | number | `600000` | Timeout in ms for HITL confirmation requests. 0 = no timeout. |
+| `N8N_INSTANCE_AI_CONFIRMATION_TIMEOUT` | number | `0` | Timeout in ms for HITL confirmation requests. 0 = no timeout. |
 
 ## Enabling / Disabling
 

--- a/packages/@n8n/instance-ai/src/runtime/__tests__/background-task-manager.test.ts
+++ b/packages/@n8n/instance-ai/src/runtime/__tests__/background-task-manager.test.ts
@@ -100,6 +100,24 @@ describe('BackgroundTaskManager', () => {
 			expect(timedOut).toEqual([]);
 			expect(manager.getRunningTasks('thread-1')).toHaveLength(1);
 		});
+
+		it('skips timeout checks for tasks currently waiting on HITL', async () => {
+			manager.spawn(
+				makeSpawnOptions({
+					run: async () => await new Promise(() => {}),
+				}),
+			);
+			const task = manager.getRunningTasks('thread-1')[0];
+			task.startedAt = 0;
+			task.lastActivityAt = 0;
+
+			const timedOut = await manager.timeoutTimedOutTasks(policy, 30_000, {
+				shouldSkipTask: (candidate) => candidate.threadId === 'thread-1',
+			});
+
+			expect(timedOut).toEqual([]);
+			expect(manager.getRunningTasks('thread-1')).toHaveLength(1);
+		});
 	});
 
 	describe('spawn', () => {

--- a/packages/@n8n/instance-ai/src/runtime/__tests__/liveness-policy.test.ts
+++ b/packages/@n8n/instance-ai/src/runtime/__tests__/liveness-policy.test.ts
@@ -13,7 +13,7 @@ function createPolicy() {
 describe('InstanceAiLivenessPolicy', () => {
 	it('keeps default liveness limits centralized and allows the existing confirmation override', () => {
 		expect(INSTANCE_AI_DEFAULT_LIVENESS_POLICY_CONFIG).toEqual({
-			confirmationTimeoutMs: 10 * minute,
+			confirmationTimeoutMs: 0,
 			backgroundTaskIdleTimeoutMs: 10 * minute,
 			backgroundTaskMaxLifetimeMs: 30 * minute,
 			activeRunIdleTimeoutMs: 10 * minute,
@@ -69,8 +69,32 @@ describe('InstanceAiLivenessPolicy', () => {
 		});
 	});
 
-	it('uses the confirmation timeout for suspended runs and pending confirmations', () => {
+	it('keeps suspended runs and pending confirmations alive by default', () => {
 		const policy = createPolicy();
+
+		expect(
+			policy.evaluate({
+				surface: 'suspended-run',
+				startedAt: 0,
+				lastActivityAt: 0,
+				now: 10 * minute,
+			}),
+		).toEqual({ action: 'keep-alive' });
+
+		expect(
+			policy.evaluate({
+				surface: 'pending-confirmation',
+				startedAt: 0,
+				lastActivityAt: 0,
+				now: 10 * minute,
+			}),
+		).toEqual({ action: 'keep-alive' });
+	});
+
+	it('uses a configured confirmation timeout for suspended runs and pending confirmations', () => {
+		const policy = new InstanceAiLivenessPolicy(
+			createInstanceAiLivenessPolicyConfig({ confirmationTimeoutMs: 10 * minute }),
+		);
 
 		expect(
 			policy.evaluate({

--- a/packages/@n8n/instance-ai/src/runtime/background-task-manager.ts
+++ b/packages/@n8n/instance-ai/src/runtime/background-task-manager.ts
@@ -91,6 +91,10 @@ export type SpawnManagedBackgroundTaskResult =
 	| { status: 'limit-reached' }
 	| { status: 'duplicate'; existing: ManagedBackgroundTask };
 
+export interface BackgroundTaskTimeoutOptions {
+	shouldSkipTask?: (task: ManagedBackgroundTask) => boolean;
+}
+
 export interface BackgroundTaskMessageOptions<
 	TTask extends ManagedBackgroundTask = ManagedBackgroundTask,
 > {
@@ -242,10 +246,12 @@ export class BackgroundTaskManager {
 	async timeoutTimedOutTasks(
 		policy: InstanceAiLivenessPolicy,
 		now = Date.now(),
+		options: BackgroundTaskTimeoutOptions = {},
 	): Promise<ManagedBackgroundTask[]> {
 		const timedOut: ManagedBackgroundTask[] = [];
 		for (const task of [...this.tasks.values()]) {
 			if (task.status !== 'running') continue;
+			if (options.shouldSkipTask?.(task)) continue;
 			const decision = policy.evaluate({
 				surface: 'background-task',
 				startedAt: task.startedAt,

--- a/packages/@n8n/instance-ai/src/runtime/liveness-policy.ts
+++ b/packages/@n8n/instance-ai/src/runtime/liveness-policy.ts
@@ -17,7 +17,7 @@ export interface InstanceAiLivenessPolicyConfig {
 const MINUTE_MS = 60_000;
 
 export const INSTANCE_AI_DEFAULT_LIVENESS_POLICY_CONFIG = {
-	confirmationTimeoutMs: 10 * MINUTE_MS,
+	confirmationTimeoutMs: 0,
 	backgroundTaskIdleTimeoutMs: 10 * MINUTE_MS,
 	backgroundTaskMaxLifetimeMs: 30 * MINUTE_MS,
 	activeRunIdleTimeoutMs: 10 * MINUTE_MS,

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-liveness.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-liveness.service.test.ts
@@ -43,11 +43,23 @@ function createLivenessService() {
 		getPendingConfirmation: jest.fn(
 			(_requestId: string): { threadId: string } | undefined => undefined,
 		),
+		hasPendingConfirmationForThread: jest.fn((_threadId: string) => false),
 		rejectPendingConfirmation: jest.fn((_requestId: string) => true),
 	};
 	const backgroundTasks = {
 		timeoutTimedOutTasks: jest.fn(
-			async (_policy: InstanceAiLivenessPolicy, _now?: number) =>
+			async (
+				_policy: InstanceAiLivenessPolicy,
+				_now?: number,
+				_options?: {
+					shouldSkipTask?: (task: {
+						threadId: string;
+						taskId: string;
+						role: string;
+						timeoutReason?: InstanceAiLivenessTimeoutReason;
+					}) => boolean;
+				},
+			) =>
 				[] as Array<{
 					threadId: string;
 					taskId: string;
@@ -150,7 +162,21 @@ describe('InstanceAiLivenessService', () => {
 			INSTANCE_AI_RUN_TIMEOUT_REASON,
 		);
 		expect(runState.rejectPendingConfirmation).toHaveBeenCalledWith('request-1');
-		expect(backgroundTasks.timeoutTimedOutTasks).toHaveBeenCalledWith(policy, 123_456);
+		expect(backgroundTasks.timeoutTimedOutTasks).toHaveBeenCalledWith(
+			policy,
+			123_456,
+			expect.objectContaining({ shouldSkipTask: expect.any(Function) }),
+		);
+		const timeoutOptions = backgroundTasks.timeoutTimedOutTasks.mock.calls[0]?.[2];
+		runState.hasPendingConfirmationForThread.mockReturnValueOnce(true);
+		expect(
+			timeoutOptions?.shouldSkipTask?.({
+				threadId: 'thread-bg',
+				taskId: 'task-1',
+				role: 'workflow-builder',
+			}),
+		).toBe(true);
+		expect(runState.hasPendingConfirmationForThread).toHaveBeenCalledWith('thread-bg');
 		expect(eventBus.publish).toHaveBeenCalledWith(
 			'thread-active',
 			expect.objectContaining({ responseId: 'run-timeout:run-active' }),

--- a/packages/cli/src/modules/instance-ai/liveness/instance-ai-liveness.service.ts
+++ b/packages/cli/src/modules/instance-ai/liveness/instance-ai-liveness.service.ts
@@ -59,6 +59,7 @@ export type InstanceAiLivenessRunState<
 	cancelSuspendedRun: (threadId: string) => TSuspendedRun | undefined;
 	getActiveRunId: (threadId: string) => string | undefined;
 	getPendingConfirmation: (requestId: string) => InstanceAiLivenessPendingConfirmation | undefined;
+	hasPendingConfirmationForThread: (threadId: string) => boolean;
 	rejectPendingConfirmation: (requestId: string) => boolean;
 };
 
@@ -66,6 +67,9 @@ export type InstanceAiLivenessBackgroundTasks = {
 	timeoutTimedOutTasks: (
 		policy: InstanceAiLivenessPolicy,
 		now?: number,
+		options?: {
+			shouldSkipTask?: (task: InstanceAiLivenessTimedOutTask) => boolean;
+		},
 	) => Promise<InstanceAiLivenessTimedOutTask[]>;
 };
 
@@ -189,6 +193,10 @@ export class InstanceAiLivenessService<
 			const timedOutTasks = await this.options.backgroundTasks.timeoutTimedOutTasks(
 				this.options.policy,
 				now,
+				{
+					shouldSkipTask: (task) =>
+						this.options.runState.hasPendingConfirmationForThread(task.threadId),
+				},
 			);
 			for (const task of timedOutTasks) {
 				this.options.logger.debug('Timed out background task', {


### PR DESCRIPTION
## Summary

This PR changes Instance AI HITL waits so they are not cancelled just because the user steps away from the generation.

What changes:

- `suspended-run` and `pending-confirmation` now default to no confirmation timeout.
- `0` for `N8N_INSTANCE_AI_CONFIRMATION_TIMEOUT` means no HITL timeout, not instant timeout.
- Active-run liveness still exists, but it already skips active runs while the same thread has a pending confirmation.
- Background-task liveness still exists, but now also skips background tasks while their thread has a pending confirmation.

What still has timeouts:

- Background tasks still idle-timeout after 10 minutes when they are not waiting on HITL.
- Background tasks still have a 30 minute max lifetime when they are not waiting on HITL.
- Active runs still idle-timeout after 10 minutes when they are not waiting on HITL.
- Active runs still have a 30 minute max lifetime when they are not waiting on HITL.
- A configured non-zero `N8N_INSTANCE_AI_CONFIRMATION_TIMEOUT` still applies to HITL confirmations.

So the run/task safeguards remain in place for unattended work, but they do not cancel HITL while the user confirmation is pending.

How to test:

- `pnpm test src/runtime/__tests__/liveness-policy.test.ts src/runtime/__tests__/background-task-manager.test.ts` from `packages/@n8n/instance-ai`
- `pnpm typecheck` from `packages/@n8n/instance-ai`
- `pnpm lint` from `packages/@n8n/instance-ai`
- `pnpm test instance-ai-liveness.service.test.ts` from `packages/cli`
- `pnpm exec eslint src/modules/instance-ai/liveness/instance-ai-liveness.service.ts src/modules/instance-ai/__tests__/instance-ai-liveness.service.test.ts --quiet` from `packages/cli`
- `pnpm test config.test.ts` from `packages/@n8n/config`
- `pnpm typecheck` from `packages/@n8n/config`
- `pnpm lint` from `packages/@n8n/config`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-275

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
