### PR TITLE
chore: claim Context7 ownership of n8n-io/n8n (DOC-1962)

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/n8n-io/n8n",
+  "public_key": "pk_njsfwAcAgfpxvLdUf5R7h"
+}


### PR DESCRIPTION
## Summary

Adds `context7.json` at the repo root to claim Context7 ownership of `n8n-io/n8n` via the `docs@n8n.io` account.

Context7 (context7.com) is the index that Cursor, Claude, Windsurf, and similar AI code editors query when a developer asks "how do I use n8n." This repo is currently unclaimed, meaning we have no control over parsing rules, excluded folders, or custom AI instructions.

This PR is the verification step in Context7's claim flow:
1. Merge this file.
2. Click "Claim Library" on context7.com/n8n-io/n8n.
3. Context7 verifies `context7.json` exists on `master` and grants ownership.

After the claim, no further changes to this file are required — config lives in the Context7 dashboard, accessible via `docs@n8n.io` (shared through Bitwarden).

## Context

- Part of our GEO/AEO docs experiments.
- We already claimed `n8n-io/n8n-docs` (same flow, same account).
- Linear: [DOC-1962](https://linear.app/n8n/issue/DOC-1962/claim-context7-ownership-of-n8n-ion8n-main-repo)
- Raised in the April 25 Slack thread on Context7.

## Notes

- The `public_key` is safe to commit — it's a verification token, not a secret.
- File is one-time-use; Context7 recommends keeping it so re-verification is automatic if the claim ever lapses.