### PR TITLE
fix(core): Move host Error details to a host-side side channel

### DIFF
--- a/packages/@n8n/expression-runtime/src/bridge/__tests__/isolated-vm-bridge.test.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/__tests__/isolated-vm-bridge.test.ts
@@ -1,6 +1,7 @@
-import { afterEach, describe, it, expect, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, it, expect, vi } from 'vitest';
 import { IsolatedVmBridge } from '../isolated-vm-bridge';
-import type { Logger } from '../../types';
+import { ExpressionEvaluator } from '../../evaluator/expression-evaluator';
+import { ExpressionError, type Logger } from '../../types';
 
 describe('IsolatedVmBridge', () => {
 	describe('logger integration', () => {
@@ -23,6 +24,120 @@ describe('IsolatedVmBridge', () => {
 
 			expect(logger.info).toHaveBeenCalledWith(expect.stringContaining('[IsolatedVmBridge]'));
 			expect(consoleSpy).not.toHaveBeenCalled();
+		});
+	});
+
+	// =========================================================================
+	// `serializeError` host→isolate boundary
+	//
+	// Intent: preserve host-side Error class identity and custom properties
+	// for the *host-side* reconstruction (since `ivm.copy: true` strips them),
+	// without bundling that rich data into the sentinel that travels through
+	// the isolate. The sentinel inside the isolate should expose `name` and
+	// `message` only; the rich data should be routed through a host-only
+	// side channel and re-attached by `reconstructError`.
+	// =========================================================================
+	describe('serializeError must not expose host Error internals inside the isolate', () => {
+		let evaluator: ExpressionEvaluator;
+		const caller = {};
+
+		beforeAll(async () => {
+			evaluator = new ExpressionEvaluator({
+				createBridge: () => new IsolatedVmBridge({ timeout: 5000 }),
+				maxCodeCacheSize: 64,
+			});
+			await evaluator.initialize();
+			await evaluator.acquire(caller);
+		});
+
+		afterAll(async () => {
+			await evaluator.release(caller);
+			await evaluator.dispose();
+		});
+
+		it('e.extra is undefined (or empty) for sentinels originating from host callbacks', () => {
+			const data: Record<string, unknown> = {
+				$json: new Proxy(
+					{},
+					{
+						get: () => {
+							const err = new Error('boom');
+							(err as Error & { internalCode?: string }).internalCode = 'INT-42';
+							(err as Error & { sensitive?: string }).sensitive = 'super-secret';
+							throw err;
+						},
+					},
+				),
+			};
+
+			const extraKeys = evaluator.evaluate(
+				'{{ (function(){ try { return $json.x; } catch(e) { return e && e.extra ? Object.keys(e.extra) : []; } })() }}',
+				data,
+				caller,
+			);
+
+			expect(extraKeys).toEqual([]);
+		});
+
+		it('host stack traces with absolute filesystem paths are NOT readable via e.stack inside the isolate', () => {
+			const data: Record<string, unknown> = {
+				$json: new Proxy(
+					{},
+					{
+						get: () => {
+							throw new Error('boom');
+						},
+					},
+				),
+			};
+
+			const stack = evaluator.evaluate(
+				'{{ (function(){ try { return $json.x; } catch(e) { return (e && e.stack) ? String(e.stack) : ""; } })() }}',
+				data,
+				caller,
+			);
+
+			expect(typeof stack).toBe('string');
+			expect(stack).toBe('');
+		});
+
+		it('host-side reconstruction preserves Error class identity, name, message, and custom properties when the sentinel reaches the host uncaught', () => {
+			// Guards the legitimate host-side use case: when the expression
+			// doesn't catch, the host receives the original Error with class
+			// identity and own props intact.
+			const data: Record<string, unknown> = {
+				$json: new Proxy(
+					{},
+					{
+						get: () => {
+							const err = new ExpressionError('upstream-failed', {
+								nodeCause: 'X',
+								itemIndex: 0,
+							});
+							(err as ExpressionError & { code?: string }).code = 'DB_TIMEOUT';
+							(err as ExpressionError & { level?: string }).level = 'warning';
+							throw err;
+						},
+					},
+				),
+			};
+
+			let caught: ExpressionError & { code?: string; level?: string } = new ExpressionError(
+				'no-op',
+				{},
+			);
+			try {
+				evaluator.evaluate('{{ $json.x }}', data, caller);
+			} catch (err) {
+				caught = err as typeof caught;
+			}
+
+			expect(caught).toBeInstanceOf(ExpressionError);
+			expect(caught.name).toBe('ExpressionError');
+			expect(caught.message).toBe('upstream-failed');
+			expect(caught.code).toBe('DB_TIMEOUT');
+			expect(caught.level).toBe('warning');
+			expect(caught.context).toEqual({ nodeCause: 'X', itemIndex: 0 });
 		});
 	});
 });

--- a/packages/@n8n/expression-runtime/src/bridge/__tests__/isolated-vm-bridge.test.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/__tests__/isolated-vm-bridge.test.ts
@@ -28,6 +28,78 @@ describe('IsolatedVmBridge', () => {
 	});
 
 	// =========================================================================
+	// `reconstructError` — poison-pill filtering
+	//
+	// Intent: when the in-isolate outer catch builds a sentinel with `extra`,
+	// blocked error properties (captureStackTrace, prepareStackTrace, etc.)
+	// and function-typed values must be stripped before being applied to the
+	// reconstructed Error on the host side. This prevents user expressions
+	// from injecting properties that abuse V8's stack trace API or smuggle
+	// callable values onto the error object.
+	// =========================================================================
+	describe('reconstructError filters dangerous properties from extra', () => {
+		let evaluator: ExpressionEvaluator;
+		const caller = {};
+
+		beforeAll(async () => {
+			evaluator = new ExpressionEvaluator({
+				createBridge: () => new IsolatedVmBridge({ timeout: 5000 }),
+				maxCodeCacheSize: 64,
+			});
+			await evaluator.initialize();
+			await evaluator.acquire(caller);
+		});
+
+		afterAll(async () => {
+			await evaluator.release(caller);
+			await evaluator.dispose();
+		});
+
+		it('strips blockedErrorProperties (captureStackTrace, prepareStackTrace, etc.) from extra', () => {
+			// Throw an ExpressionError inside the isolate with blocked properties
+			// set as own properties. E() re-throws ExpressionErrors, the outer catch
+			// captures them into a sentinel with extra, and reconstructError applies it.
+			let caught: Error & { safeProp?: string } = new Error('no-op');
+			try {
+				evaluator.evaluate(
+					'{{ (function() { var e = new Error("poisoned"); e.name = "ExpressionError"; e.captureStackTrace = "pwned"; e.prepareStackTrace = "pwned"; e.stackTraceLimit = 9999; e.safeProp = "allowed"; throw e; })() }}',
+					{},
+					caller,
+				);
+			} catch (err) {
+				caught = err as typeof caught;
+			}
+
+			expect(caught.message).toBe('poisoned');
+			expect(caught).not.toHaveProperty('captureStackTrace');
+			expect(caught).not.toHaveProperty('prepareStackTrace');
+			expect(caught).not.toHaveProperty('stackTraceLimit');
+			expect(caught.safeProp).toBe('allowed');
+		});
+
+		it('strips __defineGetter__/__defineSetter__/__lookupGetter__/__lookupSetter__ from extra', () => {
+			let caught: Error & { context?: string } = new Error('no-op');
+			try {
+				evaluator.evaluate(
+					'{{ (function() { var e = new Error("poisoned"); e.name = "ExpressionError"; e["__defineGetter__"] = "pwned"; e["__defineSetter__"] = "pwned"; e["__lookupGetter__"] = "pwned"; e["__lookupSetter__"] = "pwned"; e.context = "kept"; throw e; })() }}',
+					{},
+					caller,
+				);
+			} catch (err) {
+				caught = err as typeof caught;
+			}
+
+			expect(caught.message).toBe('poisoned');
+			// These exist on Object.prototype, so check own properties specifically
+			expect(Object.hasOwn(caught, '__defineGetter__')).toBe(false);
+			expect(Object.hasOwn(caught, '__defineSetter__')).toBe(false);
+			expect(Object.hasOwn(caught, '__lookupGetter__')).toBe(false);
+			expect(Object.hasOwn(caught, '__lookupSetter__')).toBe(false);
+			expect(caught.context).toBe('kept');
+		});
+	});
+
+	// =========================================================================
 	// `serializeError` host→isolate boundary
 	//
 	// Intent: preserve host-side Error class identity and custom properties

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -594,11 +594,12 @@ try {
 		error.name = data.name || 'Error';
 		if (data.stack) error.stack = data.stack;
 		if (data.extra) {
-			for (const [key, value] of Object.entries(data.extra)) {
-				if (!blockedErrorProperties.has(key) && typeof value !== 'function') {
-					(error as unknown as Record<string, unknown>)[key] = value;
-				}
-			}
+			const safeExtra = Object.fromEntries(
+				Object.entries(data.extra).filter(
+					([key, value]) => !blockedErrorProperties.has(key) && typeof value !== 'function',
+				),
+			);
+			Object.assign(error, safeExtra);
 		}
 		return error;
 	}

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import type { RuntimeBridge, BridgeConfig, ExecuteOptions } from '../types';
 import { DEFAULT_BRIDGE_CONFIG, TimeoutError, MemoryLimitError } from '../types';
 import type { ErrorSentinel } from '../runtime/lazy-proxy';
+import { blockedErrorProperties } from '../runtime/safe-globals';
 
 // Lazy-loaded isolated-vm — avoids loading the native binary when the barrel
 // file is statically imported (e.g. for error classes). The native module is
@@ -592,7 +593,13 @@ try {
 		const error = new Error(data.message);
 		error.name = data.name || 'Error';
 		if (data.stack) error.stack = data.stack;
-		if (data.extra) Object.assign(error, data.extra);
+		if (data.extra) {
+			for (const [key, value] of Object.entries(data.extra)) {
+				if (!blockedErrorProperties.has(key) && typeof value !== 'function') {
+					(error as unknown as Record<string, unknown>)[key] = value;
+				}
+			}
+		}
 		return error;
 	}
 

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -31,30 +31,6 @@ function isErrorSentinel(value: unknown): value is ErrorSentinel {
 }
 
 /**
- * Serialize an error into a transferable metadata object.
- *
- * Host-side callbacks (getValueAtPath, etc.) catch errors and return this
- * sentinel instead of letting the error cross the isolate boundary (which
- * strips custom class identity and properties). The isolate-side proxy
- * detects __isError and reconstructs a proper Error to throw.
- */
-function serializeError(err: unknown): ErrorSentinel {
-	if (err instanceof Error) {
-		const extra = Object.fromEntries(
-			Object.entries(err).filter(([key]) => key !== 'name' && key !== 'message' && key !== 'stack'),
-		);
-		return {
-			__isError: true,
-			name: err.name,
-			message: err.message,
-			stack: err.stack,
-			extra,
-		};
-	}
-	return { __isError: true, name: 'Error', message: String(err), extra: {} };
-}
-
-/**
  * Read the runtime IIFE bundle by walking up from `__dirname` until
  * `dist/bundle/runtime.iife.js` is found.
  *
@@ -93,6 +69,9 @@ export class IsolatedVmBridge implements RuntimeBridge {
 	private disposed = false;
 	private config: Required<BridgeConfig>;
 	private logger: Required<BridgeConfig>['logger'];
+	/** Host Errors keyed by sentinel token. Cleared at the end of every `execute()`. See `#serializeError`/`#reconstructError`. */
+	private errorSideChannel = new Map<string, Error>();
+	private errorTokenCounter = 0;
 
 	constructor(config: BridgeConfig = {}) {
 		this.config = {
@@ -343,7 +322,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 				// Primitive value
 				return value;
 			} catch (err) {
-				return serializeError(err);
+				return this.serializeError(err);
 			}
 		});
 	}
@@ -408,7 +387,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 				// Primitive element
 				return element;
 			} catch (err) {
-				return serializeError(err);
+				return this.serializeError(err);
 			}
 		});
 	}
@@ -450,7 +429,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 				// Execute function with parent as `this` to preserve method context
 				return (fn as (...fnArgs: unknown[]) => unknown).call(parent, ...args);
 			} catch (err) {
-				return serializeError(err);
+				return this.serializeError(err);
 			}
 		});
 	}
@@ -556,27 +535,64 @@ try {
 			getValueAtPath.release();
 			getArrayElement.release();
 			callFunctionAtPath.release();
+			// Drop any leftover side-channel entries from this execution so
+			// the next caller can't inherit them.
+			this.errorSideChannel.clear();
 		}
 	}
 
 	/**
-	 * Reconstruct an error from serialized isolate data.
+	 * Serialize a host-side error into a transferable sentinel.
 	 *
-	 * Maps error names back to their host-side classes and restores
-	 * custom properties that would otherwise be lost crossing the boundary.
+	 * Host-side callbacks (getValueAtPath, etc.) catch errors and return
+	 * this sentinel rather than letting the error cross the isolate boundary
+	 * (which would strip its class identity and own properties via
+	 * `ivm.copy: true`).
+	 *
+	 * The sentinel carries only `name`, `message`, and an opaque `__token`.
+	 * The original Error stays on the host in `this.errorSideChannel` and
+	 * is re-surfaced by `reconstructError` when the sentinel comes back.
+	 * The isolate never sees the stack or any own properties.
+	 *
+	 * This closes the leak that bundling stack/extra into the
+	 * sentinel produced — a `try { … } catch(e) { e.extra.password }` in
+	 * an expression would otherwise read whatever the host Error carried.
+	 */
+	private serializeError(err: unknown): ErrorSentinel {
+		if (err instanceof Error) {
+			const token = `__err_${this.errorTokenCounter++}`;
+			this.errorSideChannel.set(token, err);
+			return {
+				__isError: true,
+				__token: token,
+				name: err.name,
+				message: err.message,
+			};
+		}
+		return { __isError: true, name: 'Error', message: String(err) };
+	}
+
+	/**
+	 * Reconstruct an error from a sentinel returned by the isolate.
+	 *
+	 * Sentinels arrive in two shapes:
+	 *   - From the host's `serializeError`: carries `__token`; the original
+	 *     Error is in `this.errorSideChannel`. Returned directly, preserving
+	 *     class identity, stack, and own properties.
+	 *   - From the in-isolate `wrappedCode` outer catch: carries inline
+	 *     `stack` and `extra` (isolate-realm data — no host file paths or
+	 *     credentials). Rebuilt as a fresh Error here.
 	 */
 	private reconstructError(data: ErrorSentinel): Error {
+		if (data.__token !== undefined) {
+			const original = this.errorSideChannel.get(data.__token);
+			if (original) return original;
+		}
+
 		const error = new Error(data.message);
 		error.name = data.name || 'Error';
-		if (data.stack) {
-			error.stack = data.stack;
-		}
-
-		// Restore custom properties transferred via copy: true
-		if (data.extra) {
-			Object.assign(error, data.extra);
-		}
-
+		if (data.stack) error.stack = data.stack;
+		if (data.extra) Object.assign(error, data.extra);
 		return error;
 	}
 

--- a/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/lazy-proxy.ts
@@ -20,8 +20,12 @@ export interface ErrorSentinel {
 	__isError: true;
 	name: string;
 	message: string;
+	/** Present only on sentinels built by the in-isolate `wrappedCode` outer catch. */
 	stack?: string;
+	/** Present only on sentinels built by the in-isolate `wrappedCode` outer catch. */
 	extra?: Record<string, unknown>;
+	/** Opaque key into the host's side channel. Present only on sentinels from host-side `serializeError`. */
+	__token?: string;
 }
 
 interface ObjectMetadata {

--- a/packages/@n8n/expression-runtime/src/runtime/safe-globals.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/safe-globals.ts
@@ -53,7 +53,7 @@ export const SafeObject = new Proxy(Object, {
  * Properties blocked on Error and all Error subclasses.
  * These can be exploited for sandbox escape via V8's stack trace API.
  */
-const blockedErrorProperties = new Set([
+export const blockedErrorProperties = new Set([
 	'captureStackTrace',
 	'prepareStackTrace',
 	'stackTraceLimit',


### PR DESCRIPTION
## Summary

`serializeError` and `reconstructError` in the expression-runtime
bridge now route the rich data of host-thrown Errors through a
host-only side channel keyed by an opaque token. The sentinel that
crosses the isolate boundary carries only `name`, `message`, and that
token; the original Error stays on the host in a `Map` keyed by the
token and is cleared at the end of every `execute()`.

When the sentinel returns from the isolate, `reconstructError` resolves
the token against the side channel and returns the original Error
instance directly, preserving class identity, stack, and own
properties for the host caller. Sentinels that originate inside the
isolate (no token) fall through to the existing inline rebuild path.

Net effect for callers:

- `expression-runtime/src/runtime/lazy-proxy.ts`'s `ErrorSentinel`
  gains an optional `__token`; `stack` and `extra` are now declared as
  set only by the in-isolate `wrappedCode` catch.
- `packages/workflow/src/expression.ts:mapVmError` reaches its
  `isExpressionError` fast-path for host-thrown `ExpressionError`
  instances, bypassing the name-based rebuild at `:88-91`. The rebuild
  remains in place for sentinels that originate inside the isolate.

### How to test

```bash
pnpm --filter=@n8n/expression-runtime test src/bridge/__tests__/isolated-vm-bridge.test.ts
```

All four tests pass:

- `should use logger instead of console.log`
- `e.extra is undefined (or empty) for sentinels originating from host
  callbacks`
- `host stack traces with absolute filesystem paths are NOT readable
  via e.stack inside the isolate`
- `host-side reconstruction preserves Error class identity, name,
  message, and custom properties when the sentinel reaches the host
  uncaught`

Full package suite (`pnpm --filter=@n8n/expression-runtime test`) is
green; `pnpm --filter=@n8n/expression-runtime typecheck` is clean.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3129

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI