### PR TITLE
fix(core): Coerce dynamic property keys before runtime denylist check (no-changelog)

### DIFF
--- a/packages/@n8n/expression-runtime/src/runtime/__tests__/safe-globals.test.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/__tests__/safe-globals.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { __sanitize, ExpressionError } from '../safe-globals';
+
+describe('__sanitize', () => {
+	it('throws for string keys in the unsafe-property set', () => {
+		expect(() => __sanitize('constructor')).toThrow(ExpressionError);
+		expect(() => __sanitize('__proto__')).toThrow(ExpressionError);
+		expect(() => __sanitize('prototype')).toThrow(ExpressionError);
+	});
+
+	it('returns string keys unchanged when they are not in the unsafe-property set', () => {
+		expect(__sanitize('foo')).toBe('foo');
+		expect(__sanitize('')).toBe('');
+		expect(__sanitize('0')).toBe('0');
+	});
+
+	it('coerces non-string values to a string before checking the unsafe-property set', () => {
+		// An object whose `toString` returns a denied name must be rejected:
+		// JavaScript invokes `toString` when the value is used as a property
+		// key (`obj[value]`), so a check that only handles strings is incomplete.
+		const coercingToConstructor = { toString: () => 'constructor' };
+		expect(() => __sanitize(coercingToConstructor)).toThrow(ExpressionError);
+
+		const coercingToProto = { toString: () => '__proto__' };
+		expect(() => __sanitize(coercingToProto)).toThrow(ExpressionError);
+
+		// `Symbol.toPrimitive` overrides `toString`; that path must also coerce.
+		const coercingViaSymbolToPrimitive = {
+			[Symbol.toPrimitive]: () => 'constructor',
+			toString: () => 'safe',
+		};
+		expect(() => __sanitize(coercingViaSymbolToPrimitive)).toThrow(ExpressionError);
+	});
+
+	it('returns the coerced key string so the caller cannot re-trigger toString', () => {
+		// If the function returned the original object, the property access
+		// `obj[__sanitize(x)]` would call `x.toString()` a second time and
+		// could resolve to a different string than the one we just checked.
+		// Returning the already-coerced string locks the result.
+		let calls = 0;
+		const k = {
+			toString: () => {
+				calls += 1;
+				return calls === 1 ? 'safe' : 'constructor';
+			},
+		};
+		const sanitized = __sanitize(k);
+		expect(typeof sanitized).toBe('string');
+		expect(sanitized).toBe('safe');
+		// Using the result as a property key must not invoke `k.toString` again.
+		const probe: Record<string, number> = { safe: 1, constructor: 2 };
+		expect(probe[sanitized as string]).toBe(1);
+		expect(calls).toBe(1);
+	});
+
+	it('passes symbols through unchanged', () => {
+		// `String(symbol)` throws, and symbol-keyed property access cannot
+		// reach the string-valued unsafe-property set, so symbols are passed
+		// through as-is.
+		const s = Symbol('arbitrary');
+		expect(__sanitize(s)).toBe(s);
+	});
+
+	it('coerces other primitives and returns the coerced string', () => {
+		expect(__sanitize(42)).toBe('42');
+		expect(__sanitize(null)).toBe('null');
+		expect(__sanitize(undefined)).toBe('undefined');
+		expect(__sanitize(true)).toBe('true');
+	});
+});

--- a/packages/@n8n/expression-runtime/src/runtime/__tests__/safe-globals.test.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/__tests__/safe-globals.test.ts
@@ -2,22 +2,21 @@ import { describe, it, expect } from 'vitest';
 import { __sanitize, ExpressionError } from '../safe-globals';
 
 describe('__sanitize', () => {
-	it('throws for string keys in the unsafe-property set', () => {
+	it('throws an ExpressionError for denied property names', () => {
 		expect(() => __sanitize('constructor')).toThrow(ExpressionError);
 		expect(() => __sanitize('__proto__')).toThrow(ExpressionError);
 		expect(() => __sanitize('prototype')).toThrow(ExpressionError);
 	});
 
-	it('returns string keys unchanged when they are not in the unsafe-property set', () => {
+	it('returns allowed string keys unchanged', () => {
 		expect(__sanitize('foo')).toBe('foo');
 		expect(__sanitize('')).toBe('');
 		expect(__sanitize('0')).toBe('0');
 	});
 
-	it('coerces non-string values to a string before checking the unsafe-property set', () => {
-		// An object whose `toString` returns a denied name must be rejected:
-		// JavaScript invokes `toString` when the value is used as a property
-		// key (`obj[value]`), so a check that only handles strings is incomplete.
+	it('coerces object values via toString before the denylist check', () => {
+		// JavaScript invokes `toString` when an object is used as a property key,
+		// so the denylist check must operate on the coerced string, not the raw value.
 		const coercingToConstructor = { toString: () => 'constructor' };
 		expect(() => __sanitize(coercingToConstructor)).toThrow(ExpressionError);
 
@@ -32,11 +31,9 @@ describe('__sanitize', () => {
 		expect(() => __sanitize(coercingViaSymbolToPrimitive)).toThrow(ExpressionError);
 	});
 
-	it('returns the coerced key string so the caller cannot re-trigger toString', () => {
-		// If the function returned the original object, the property access
-		// `obj[__sanitize(x)]` would call `x.toString()` a second time and
-		// could resolve to a different string than the one we just checked.
-		// Returning the already-coerced string locks the result.
+	it('returns the coerced string so subsequent property access uses the validated value', () => {
+		// Returning the already-coerced string ensures that `obj[__sanitize(x)]`
+		// uses exactly the string that was checked, not a second toString() call.
 		let calls = 0;
 		const k = {
 			toString: () => {
@@ -54,9 +51,8 @@ describe('__sanitize', () => {
 	});
 
 	it('passes symbols through unchanged', () => {
-		// `String(symbol)` throws, and symbol-keyed property access cannot
-		// reach the string-valued unsafe-property set, so symbols are passed
-		// through as-is.
+		// `String(symbol)` throws, and symbol keys are outside the string denylist,
+		// so symbols are returned as-is.
 		const s = Symbol('arbitrary');
 		expect(__sanitize(s)).toBe(s);
 	});

--- a/packages/@n8n/expression-runtime/src/runtime/safe-globals.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/safe-globals.ts
@@ -149,8 +149,15 @@ const unsafeObjectProperties = new Set([
 ]);
 
 export function __sanitize(value: unknown): unknown {
-	if (typeof value === 'string' && unsafeObjectProperties.has(value)) {
-		throw new ExpressionError(`Cannot access "${value}" due to security concerns`);
+	// Symbols cannot reach a string-valued denylist entry and `String(symbol)`
+	// throws, so we pass them through unchanged.
+	if (typeof value === 'symbol') return value;
+	// Coerce to string once so the check sees the same key the subsequent
+	// property access would see. Returning the coerced string locks it in,
+	// preventing a re-trigger of `toString` / `Symbol.toPrimitive` at use site.
+	const key = String(value);
+	if (unsafeObjectProperties.has(key)) {
+		throw new ExpressionError(`Cannot access "${key}" due to security concerns`);
 	}
-	return value;
+	return key;
 }

--- a/packages/@n8n/expression-runtime/src/runtime/safe-globals.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/safe-globals.ts
@@ -149,12 +149,9 @@ const unsafeObjectProperties = new Set([
 ]);
 
 export function __sanitize(value: unknown): unknown {
-	// Symbols cannot reach a string-valued denylist entry and `String(symbol)`
-	// throws, so we pass them through unchanged.
+	// Symbols are not string-coercible and fall outside the denylist; pass through.
 	if (typeof value === 'symbol') return value;
-	// Coerce to string once so the check sees the same key the subsequent
-	// property access would see. Returning the coerced string locks it in,
-	// preventing a re-trigger of `toString` / `Symbol.toPrimitive` at use site.
+	// Coerce once and return the string so the caller uses the already-checked key.
 	const key = String(value);
 	if (unsafeObjectProperties.has(key)) {
 		throw new ExpressionError(`Cannot access "${key}" due to security concerns`);


### PR DESCRIPTION
## Summary

`__sanitize` (the runtime guard generated by Tournament's
`PrototypeSanitizer` at `obj[expr] → obj[this.__sanitize(expr)]`)
previously only consulted the denylist when the input was a string and
returned non-string values unchanged. Because the property access at
the call site coerces its key via `ToPropertyKey`, the result the
denylist saw could differ from the result the access used.

This change matches the legacy `sanitizer` in
`packages/workflow/src/expression-sandboxing.ts:557-563`:

- Coerce via `String(value)` first.
- Check the coerced key against the denylist.
- Return the coerced string so the caller cannot trigger coercion a
  second time at use site.
- Symbols pass through unchanged — `String(symbol)` throws and a
  symbol-keyed access cannot land on a string-valued denylist entry,
  so any property access via a symbol is already outside the
  protected set.

### How to test

```bash
pnpm --filter=@n8n/expression-runtime test src/runtime/__tests__/safe-globals.test.ts
```

Six tests cover:

- string keys in the unsafe-property set throw
- string keys outside the set are returned unchanged
- non-string values are coerced and re-checked (including
  `Symbol.toPrimitive`-driven coercion)
- the coerced key is what's returned, so `toString` is not invoked
  again at use site
- symbols pass through unchanged
- other primitives (`42`, `null`, `undefined`, `true`) are coerced to
  their string forms

Full package suite (`pnpm --filter=@n8n/expression-runtime test`,
189 tests) is green; typecheck clean.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3129

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI