### PR TITLE
ci: Resolve backport target branches via remote tags (no-changelog)

### DIFF
--- a/.github/scripts/github-helpers.mjs
+++ b/.github/scripts/github-helpers.mjs
@@ -105,6 +105,9 @@ export function resolveReleaseTagForTrack(track) {
  * release-candidate/<major>.<minor>.x branch, based on the n8n@<x.y.z> tag
  * pointing at the same commit.
  *
+ * Queries tags via `git ls-remote` so it works with shallow checkouts where
+ * the tags aren't present locally.
+ *
  * Returns null if the track tag or release tag is missing.
  *
  * @param { ReleaseTrack } track
@@ -114,15 +117,18 @@ export function resolveRcBranchForTrack(track) {
 		return '1.x';
 	}
 
-	const commit = getCommitForRef(track);
-	if (!commit) return null;
+	const tagToSha = listRemoteTagsWithCommits();
+	const trackSha = tagToSha.get(track);
+	if (!trackSha) return null;
 
-	const tagsAtCommit = listTagsPointingAt(commit);
+	const tagsAtCommit = [...tagToSha]
+		.filter(([, sha]) => sha === trackSha)
+		.map(([tag]) => tag);
+
 	const releaseTag = pickHighestReleaseTag(tagsAtCommit);
 	if (!releaseTag) return null;
 
-	const version = stripReleasePrefixes(releaseTag);
-	const parsed = semver.parse(version);
+	const parsed = semver.parse(stripReleasePrefixes(releaseTag));
 	if (!parsed) return null;
 
 	return `release-candidate/${parsed.major}.${parsed.minor}.x`;
@@ -264,6 +270,34 @@ export function writeGithubOutput(obj) {
 export function getCommitForRef(ref) {
 	const res = trySh('git', ['rev-parse', `${ref}^{}`]);
 	return res.ok && res.out ? res.out : null;
+}
+
+/**
+ * List every tag on `origin` together with the commit SHA it resolves to.
+ * Uses `git ls-remote --tags`, so it works without a deep local clone.
+ *
+ * Annotated tags appear twice in ls-remote output: once as the tag-object
+ * SHA, then again with a `^{}` suffix and the underlying commit SHA. We
+ * prefer the peeled `^{}` value so the map always points at commits.
+ *
+ * @returns { Map<string, string> } tag name → commit SHA
+ */
+export function listRemoteTagsWithCommits() {
+	const res = trySh('git', ['ls-remote', '--tags', 'origin']);
+	if (!res.ok || !res.out) return new Map();
+
+	const tagToSha = new Map();
+	for (const line of res.out.split('\n')) {
+		const match = line.match(/^([0-9a-f]+)\s+refs\/tags\/(.+)$/);
+		if (!match) continue;
+		const [, sha, ref] = match;
+		if (ref.endsWith('^{}')) {
+			tagToSha.set(ref.slice(0, -3), sha);
+		} else if (!tagToSha.has(ref)) {
+			tagToSha.set(ref, sha);
+		}
+	}
+	return tagToSha;
 }
 
 /**


### PR DESCRIPTION
## Summary

The backport workflow recently switched to `fetch-depth: 1` for its checkout, which means the `stable` and `beta` track tags (and the `n8n@x.y.z` tags they peel to) aren't present in the local repo. As a result `compute-backport-targets.mjs` was calling `git rev-parse stable^{}` against an empty tag set, leaking `fatal: ambiguous argument 'stable^{}'` into the action log and silently returning no backport branches.

This change rewrites `resolveRcBranchForTrack` to query tags through `git ls-remote --tags origin`, which works without any local objects:

- New helper `listRemoteTagsWithCommits()` parses `git ls-remote --tags origin` into a `tag → commit SHA` map. It prefers the peeled `^{}` entries so the SHAs always point at commits (not tag objects, for annotated tags).
- `resolveRcBranchForTrack` looks up the track's commit SHA, collects every tag pointing at the same commit, picks the highest `n8n@x.y.z`, and builds the `release-candidate/<major>.<minor>.x` name from it.
- Other callers (`get-release-versions.mjs`, `ensure-release-candidate-branches.mjs`) still use the local-repo helpers `getCommitForRef` / `listTagsPointingAt`; those workflows run with full clones, so their behavior is unchanged.

### How to test

- Re-run the **Util: Backport pull request changes** workflow against a recently merged PR that has a `Backport to Beta` or `Backport to Stable` label. The `Compute backport targets` step should emit the expected `release-candidate/<x>.<y>.x` branch instead of an empty value, with no `fatal: ambiguous argument` noise in the log.
- Existing tests still pass: `node --test --experimental-test-module-mocks ./.github/scripts/compute-backport-targets.test.mjs` (the unit tests mock `resolveRcBranchForTrack`, so they exercise the calling logic; the helper itself is best validated by re-running the workflow).

## Related Linear tickets, Github issues, and Community forum posts

_No ticket — follow-up fix for the backport workflow's recent shallow-clone change._

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI