### PR TITLE
fix(core): Acquire expression isolate for scheduled polls

### DIFF
--- a/packages/core/src/execution-engine/__tests__/active-workflows.test.ts
+++ b/packages/core/src/execution-engine/__tests__/active-workflows.test.ts
@@ -42,9 +42,20 @@ describe('ActiveWorkflows', () => {
 	const pollNode = mock<INode>();
 
 	let activeWorkflows: ActiveWorkflows;
+	let acquireIsolate: jest.Mock;
+	let releaseIsolate: jest.Mock;
+
+	// The cron callback registered for scheduled polls is `() => void executeTrigger()` —
+	// fire-and-forget. A single `await callback()` returns immediately, so we yield to
+	// the event loop via setImmediate to let the full async chain settle.
+	const flushPromises = async () => await new Promise<void>((resolve) => setImmediate(resolve));
 
 	beforeEach(() => {
 		jest.clearAllMocks();
+		acquireIsolate = jest.fn().mockResolvedValue(undefined);
+		releaseIsolate = jest.fn().mockResolvedValue(undefined);
+		// @ts-expect-error -- assign minimal expression stub for isolate-acquisition tests
+		workflow.expression = { acquireIsolate, releaseIsolate };
 		activeWorkflows = new ActiveWorkflows(
 			mock(),
 			scheduledTaskManager,
@@ -194,6 +205,100 @@ describe('ActiveWorkflows', () => {
 			});
 		});
 
+		describe('should acquire expression isolate around scheduled polls', () => {
+			// Regression test for CAT-3147: scheduled cron-driven polls run outside
+			// the activation acquire/release window, so the expression bridge fails
+			// with "No bridge acquired for this context" on every tick.
+			it('should acquire and release the isolate when the scheduled poll fires', async () => {
+				triggersAndPollers.runPoll.mockResolvedValueOnce(null); // initial activation test poll
+				triggersAndPollers.runPoll.mockResolvedValueOnce(null); // scheduled poll
+
+				await addWorkflow({ pollNodes: [pollNode] });
+
+				acquireIsolate.mockClear();
+				releaseIsolate.mockClear();
+				triggersAndPollers.runPoll.mockClear();
+
+				const registerCronCall = scheduledTaskManager.registerCron.mock.calls[0];
+				const executeScheduledPoll = registerCronCall[1] as () => Promise<void>;
+
+				await executeScheduledPoll();
+				await flushPromises();
+
+				expect(acquireIsolate).toHaveBeenCalledTimes(1);
+				expect(releaseIsolate).toHaveBeenCalledTimes(1);
+				expect(triggersAndPollers.runPoll).toHaveBeenCalledTimes(1);
+
+				const [acquireOrder] = acquireIsolate.mock.invocationCallOrder;
+				const [runPollOrder] = triggersAndPollers.runPoll.mock.invocationCallOrder;
+				const [releaseOrder] = releaseIsolate.mock.invocationCallOrder;
+
+				expect(acquireOrder).toBeLessThan(runPollOrder);
+				expect(runPollOrder).toBeLessThan(releaseOrder);
+			});
+
+			it('should not acquire the isolate during the initial activation test poll', async () => {
+				// The outer ActiveWorkflowManager.add() acquire covers the test poll
+				// and the subsequent countTriggers call. Nested acquire/release would
+				// release the outer's bridge early and break countTriggers.
+				triggersAndPollers.runPoll.mockResolvedValueOnce(null);
+
+				await addWorkflow({ pollNodes: [pollNode] });
+
+				expect(triggersAndPollers.runPoll).toHaveBeenCalledTimes(1);
+				expect(acquireIsolate).not.toHaveBeenCalled();
+				expect(releaseIsolate).not.toHaveBeenCalled();
+			});
+
+			it('should release the isolate when __emit throws after a successful poll', async () => {
+				const pollData = [[{ json: { foo: 'bar' } }]];
+				triggersAndPollers.runPoll.mockResolvedValueOnce(null); // initial activation test poll
+				triggersAndPollers.runPoll.mockResolvedValueOnce(pollData); // scheduled poll returns data
+
+				const emitError = new Error('emit failed');
+				pollFunctions.__emit.mockImplementationOnce(() => {
+					throw emitError;
+				});
+
+				await addWorkflow({ pollNodes: [pollNode] });
+
+				acquireIsolate.mockClear();
+				releaseIsolate.mockClear();
+
+				const registerCronCall = scheduledTaskManager.registerCron.mock.calls[0];
+				const executeScheduledPoll = registerCronCall[1] as () => Promise<void>;
+
+				await executeScheduledPoll();
+				await flushPromises();
+
+				expect(acquireIsolate).toHaveBeenCalledTimes(1);
+				expect(releaseIsolate).toHaveBeenCalledTimes(1);
+				expect(pollFunctions.__emitError).toHaveBeenCalledWith(emitError);
+			});
+
+			it('should release the isolate even when the scheduled poll throws', async () => {
+				const error = new Error('Poll function failed');
+				triggersAndPollers.runPoll
+					.mockResolvedValueOnce(null) // initial activation test poll
+					.mockRejectedValueOnce(error); // scheduled poll fails
+
+				await addWorkflow({ pollNodes: [pollNode] });
+
+				acquireIsolate.mockClear();
+				releaseIsolate.mockClear();
+
+				const registerCronCall = scheduledTaskManager.registerCron.mock.calls[0];
+				const executeScheduledPoll = registerCronCall[1] as () => Promise<void>;
+
+				await executeScheduledPoll();
+				await flushPromises();
+
+				expect(acquireIsolate).toHaveBeenCalledTimes(1);
+				expect(releaseIsolate).toHaveBeenCalledTimes(1);
+				expect(pollFunctions.__emitError).toHaveBeenCalledWith(error);
+			});
+		});
+
 		describe('should handle polling errors', () => {
 			it('should throw error when poll fails during initial testing', async () => {
 				const error = new Error('Poll function failed');
@@ -221,6 +326,7 @@ describe('ActiveWorkflows', () => {
 
 				// Execute the trigger function to simulate a regular poll
 				await executeTrigger();
+				await flushPromises();
 
 				expect(triggersAndPollers.runPoll).toHaveBeenCalledTimes(2);
 				expect(pollFunctions.__emit).not.toHaveBeenCalled();

--- a/packages/core/src/execution-engine/active-workflows.ts
+++ b/packages/core/src/execution-engine/active-workflows.ts
@@ -275,28 +275,26 @@ export class ActiveWorkflows {
 					if (ownsIsolate) await workflow.expression.acquireIsolate();
 
 					try {
-						try {
-							const pollResponse = await this.triggersAndPollers.runPoll(
-								workflow,
-								node,
-								pollFunctions,
-							);
+						const pollResponse = await this.triggersAndPollers.runPoll(
+							workflow,
+							node,
+							pollFunctions,
+						);
 
-							if (pollResponse !== null) {
-								pollFunctions.__emit(pollResponse);
-							}
-
-							span.setStatus({ code: SpanStatus.ok });
-						} catch (error) {
-							span.setStatus({ code: SpanStatus.error });
-							// If the poll function fails in the first activation
-							// throw the error back so we let the user know there is
-							// an issue with the trigger.
-							if (testingTrigger) {
-								throw error;
-							}
-							pollFunctions.__emitError(error as Error);
+						if (pollResponse !== null) {
+							pollFunctions.__emit(pollResponse);
 						}
+
+						span.setStatus({ code: SpanStatus.ok });
+					} catch (error) {
+						span.setStatus({ code: SpanStatus.error });
+						// If the poll function fails in the first activation
+						// throw the error back so we let the user know there is
+						// an issue with the trigger.
+						if (testingTrigger) {
+							throw error;
+						}
+						pollFunctions.__emitError(error as Error);
 					} finally {
 						if (ownsIsolate) await workflow.expression.releaseIsolate();
 					}

--- a/packages/core/src/execution-engine/active-workflows.ts
+++ b/packages/core/src/execution-engine/active-workflows.ts
@@ -265,27 +265,40 @@ export class ActiveWorkflows {
 						workflowId: workflow.id,
 					});
 
+					// The initial activation poll runs inside ActiveWorkflowManager's
+					// outer acquireIsolate window, which also covers countTriggers
+					// afterwards. Acquiring here would release the outer bridge early
+					// (acquire is idempotent per caller; release deletes it). Scheduled
+					// polls fire from the cron scheduler's own async context outside
+					// that window and must acquire/release per tick — see CAT-3147.
+					const ownsIsolate = !testingTrigger;
+					if (ownsIsolate) await workflow.expression.acquireIsolate();
+
 					try {
-						const pollResponse = await this.triggersAndPollers.runPoll(
-							workflow,
-							node,
-							pollFunctions,
-						);
+						try {
+							const pollResponse = await this.triggersAndPollers.runPoll(
+								workflow,
+								node,
+								pollFunctions,
+							);
 
-						if (pollResponse !== null) {
-							pollFunctions.__emit(pollResponse);
-						}
+							if (pollResponse !== null) {
+								pollFunctions.__emit(pollResponse);
+							}
 
-						span.setStatus({ code: SpanStatus.ok });
-					} catch (error) {
-						span.setStatus({ code: SpanStatus.error });
-						// If the poll function fails in the first activation
-						// throw the error back so we let the user know there is
-						// an issue with the trigger.
-						if (testingTrigger) {
-							throw error;
+							span.setStatus({ code: SpanStatus.ok });
+						} catch (error) {
+							span.setStatus({ code: SpanStatus.error });
+							// If the poll function fails in the first activation
+							// throw the error back so we let the user know there is
+							// an issue with the trigger.
+							if (testingTrigger) {
+								throw error;
+							}
+							pollFunctions.__emitError(error as Error);
 						}
-						pollFunctions.__emitError(error as Error);
+					} finally {
+						if (ownsIsolate) await workflow.expression.releaseIsolate();
 					}
 				},
 			);


### PR DESCRIPTION
## Summary

Polling triggers (Airtable, RSS, Gmail Trigger, etc.) crashed on every scheduled tick with `No bridge acquired for this context. Call acquire() first.` when running under `N8N_EXPRESSION_ENGINE=vm`. Manual execution worked because it goes through `WorkflowExecute`, which has its own acquire path.

The activation-time acquire in `ActiveWorkflowManager.add()` (CAT-2725) wraps `addWebhooks` + `addTriggersAndPollers` + `countTriggers`, and it also covers the initial `executeTrigger(true)` test poll. But the cron callback registered for subsequent ticks (`active-workflows.ts` → `void executeTrigger()`) fires from the scheduler's own async context, outside that window. Every scheduled poll then evaluates user expressions without an acquired bridge.

This PR moves the lifetime contract one level down: `createPollExecuteFn` now acquires/releases per invocation, gated on `!testingTrigger` so the initial activation poll doesn't double-acquire (`ExpressionEvaluator.acquire` is idempotent-by-caller, but `release` is destructive — a nested release would yank the bridge out from under `countTriggers`).

### How to test

1. Start n8n with `N8N_EXPRESSION_ENGINE=vm`.
2. Build an Airtable Trigger (polling) workflow, `pollTimes: everyMinute`. Activate.
3. Pre-fix: every tick logs `No bridge acquired for this context.` and no execution runs.
4. Post-fix: each tick executes and creates an execution.
5. Sanity: verify the legacy engine still works (`unset N8N_EXPRESSION_ENGINE`); verify a second polling trigger (e.g. RSS Feed Read) too.

Unit coverage: `pnpm --filter n8n-core test active-workflows` — 4 regression tests added under `should acquire expression isolate around scheduled polls`.

## Related Linear tickets, Github issues, and Community forum posts

- Linear: https://linear.app/n8n/issue/CAT-3147
- Related: CAT-2725 (activation acquire), RLY-36 / #29671 (dynamic node parameters acquire), CAT-2849 (sibling)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<details>
<summary>Implementation plan</summary>

# CAT-3147 — Airtable polling trigger fails at runtime with "No bridge acquired for this context" under vm expression engine

- **Linear:** https://linear.app/n8n/issue/CAT-3147/airtable-polling-trigger-fails-at-runtime-with-no-bridge-acquired-for
- **Branch:** `cat-3147-airtable-polling-trigger-fails-at-runtime-with-no-bridge`

## Ticket summary

With `N8N_EXPRESSION_ENGINE=vm`, every scheduled tick of an Airtable (or any other) polling trigger throws `No bridge acquired for this context. Call acquire() first.` The activation-time acquire in `ActiveWorkflowManager.add()` covers the initial test poll but not subsequent cron-fired polls, because the cron callback runs from the scheduler's own async context. The fix is to acquire/release the isolate inside the poll-execution function itself so it covers both the initial activation poll and every scheduled invocation.

## Root cause

Activation today only acquires the isolate once, around the **synchronous** activation block:

- `packages/cli/src/active-workflow-manager.ts:731-753` — outer `await workflow.expression.acquireIsolate(); try { addWebhooks(); addTriggersAndPollers(); countTriggers(); } finally { releaseIsolate(); }`.
- `addTriggersAndPollers` eventually calls `ActiveWorkflows.add()` → `activatePolling()` in `packages/core/src/execution-engine/active-workflows.ts:141-183`.
- The initial test poll fires at line 161 (`await executeTrigger(true)`) **inside** the outer acquire — works.
- Line 179-181 registers a cron callback: `this.scheduledTaskManager.registerCron(ctx, () => { void executeTrigger(); })`. By the time that callback fires (next cron tick), the outer `try { … } finally { releaseIsolate(); }` has long since completed. The closure captures `executeTrigger`, not the acquire context.
- Inside `createPollExecuteFn` (`active-workflows.ts:247-293`), `this.triggersAndPollers.runPoll(workflow, node, pollFunctions)` triggers expression evaluation on the shared `Workflow` instance. With `N8N_EXPRESSION_ENGINE=vm` (see `packages/workflow/src/expression.ts:283-289`), `vmEvaluator.acquire(this)` was never called for the workflow instance in the current async context → throws "No bridge acquired for this context."
- `acquireIsolate()` / `releaseIsolate()` are confirmed no-ops when `vmEvaluator` is unset, so wrapping is safe under the legacy engine too.

## Design decisions

### Where to wrap — chosen: inside `createPollExecuteFn`'s returned function

Three candidate sites; only one is correct.

**(A) Inside `createPollExecuteFn`'s returned async function (CHOSEN).** Place `await workflow.expression.acquireIsolate()` near the top of the returned function (around the `tracing.startSpan` callback body) and `releaseIsolate()` in a `finally`. Single, obvious home for the lifetime contract: "any execution of this poll function holds the isolate." Symmetric `try/finally` so a thrown poll still releases.

**(B) In the cron callback at line 179-181 only.** Rejected — leaves the initial test poll dependent on the outer activation acquire (fragile if anyone reorders activation).

**(C) Duplicate the wrap inside `ActiveWorkflowManager` around a hypothetical cron-side hook.** Rejected — `ActiveWorkflowManager` is in `packages/cli`, the cron callback is owned by `ActiveWorkflows` in `packages/core`. Inverts layering.

### Nested-acquire gate

During implementation we verified `ExpressionEvaluator.acquire/release` (`packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts:86-147`): `acquire(caller)` is idempotent-by-caller (no-op if already present), but `release(caller)` deletes the entry and returns the bridge to the pool. A nested release would therefore release the outer activation's bridge early — `countTriggers` (which runs after `addTriggersAndPollers`) would lose its bridge.

So the inner wrap skips itself for the initial activation test poll: `const ownsIsolate = !testingTrigger`. Outer activation acquire owns the test poll's lifetime; the inner wrap owns every scheduled tick.

### Should we remove the outer activation acquire?

**No.** `addWebhooks` and `countTriggers` still evaluate expressions during activation and need it. The outer wrap protects activation-time evaluation; the new inner wrap protects each runtime poll. Independent lifetimes.

### `withIsolate(workflow, fn)` helper?

Considered. Would unify CAT-2725, RLY-36, and CAT-3147 call sites. **Follow-up refactor, not part of this fix** — keeps the diff small and back-portable.

## Files changed

### `packages/core/src/execution-engine/active-workflows.ts`

`createPollExecuteFn` now acquires the isolate before `runPoll` and releases in `finally`, gated on `!testingTrigger`:

```
return async (testingTrigger = false) => {
  return await this.tracing.startSpan({…}, async (span) => {
    this.logger.debug(…);
    const ownsIsolate = !testingTrigger;
    if (ownsIsolate) await workflow.expression.acquireIsolate();
    try {
      try {
        const pollResponse = await this.triggersAndPollers.runPoll(...);
        if (pollResponse !== null) pollFunctions.__emit(pollResponse);
        span.setStatus({ code: SpanStatus.ok });
      } catch (error) {
        span.setStatus({ code: SpanStatus.error });
        if (testingTrigger) throw error;
        pollFunctions.__emitError(error as Error);
      }
    } finally {
      if (ownsIsolate) await workflow.expression.releaseIsolate();
    }
  });
};
```

Notes:
- Acquire is **outside** the outer try. If acquire throws, there is nothing to release — and `ExpressionEvaluator.release` no-ops for unknown callers anyway.
- Release in `finally` guarantees balance even if `runPoll` throws or `__emit` throws.

### `packages/core/src/execution-engine/__tests__/active-workflows.test.ts`

Four regression tests under `should acquire expression isolate around scheduled polls`:

1. acquires + releases around scheduled poll (with `invocationCallOrder` ordering assertion)
2. does NOT acquire/release during the initial activation test poll (covers the nested-acquire gate)
3. releases the isolate when `__emit` throws after a successful poll
4. releases the isolate even when the scheduled poll throws

Plus a `flushPromises()` helper (the cron callback is `() => void executeTrigger()`, fire-and-forget; the longer await chain needs `setImmediate` to settle). Updated one existing test (`should emit error when poll fails during regular polling`) to use it.

## Files left alone

- `packages/cli/src/active-workflow-manager.ts` outer activation acquire (lines 731-753) — still needed for `addWebhooks` / `countTriggers`. Removing it would regress CAT-2725.
- `packages/cli/src/active-workflow-manager.ts` `getExecuteTriggerFunctions` (lines 357-410) — runtime trigger emits go through `WorkflowExecute.runWorkflow` which has its own acquire path. Open question / out of scope.
- `packages/core/src/execution-engine/triggers-and-pollers.ts` `runPoll` — lifetime concern stays at the owner (the poll-execute closure), not the utility method.
- `packages/workflow/src/expression.ts` — `acquireIsolate`/`releaseIsolate` already correctly no-op when `vmEvaluator` is unset.
- `ScheduledTaskManager.registerCron` — generic scheduler; should not know about expression engines.

## Risks & open questions

### Risks

- **Isolate held for the duration of each poll body** (incl. HTTP latency) — same shape as activation today. Real concern only if pool size < concurrent active polling workflows. Worth measuring with `N8N_VM_POOL_SIZE` if it bites.
- **Pool contention with many active polling workflows** — N workflows polling every minute = N concurrent acquires every minute. Tune pool size if needed.

### Open question (NOT addressed here)

- **Trigger-node async emit parity.** Push-style triggers (RabbitMQ, MQTT, Kafka, Webhook receive, etc.) emit asynchronously *after* activation. Their emit closures call `workflowExecutionService.runWorkflow`, which goes through `WorkflowExecute`'s own acquire path — believed safe, but not verified end-to-end as part of this PR. File a sibling ticket if a repro is found.
- **`Expression.prototype.withIsolate` helper** — strong follow-up to unify the growing list of acquire call sites.

</details>

🤖 PR Summary generated by AI