### PR TITLE
test(editor): Prevent jsdom XHR leaks causing Node-22 shard-2 flake

### DIFF
--- a/packages/frontend/editor-ui/src/__tests__/server/index.ts
+++ b/packages/frontend/editor-ui/src/__tests__/server/index.ts
@@ -34,9 +34,10 @@ export function setupServer() {
 	// Handle undefined endpoints
 	server.post('/rest/:any', async () => ({}));
 
-	// Reset for everything else
 	server.namespace = '';
-	server.passthrough();
+	// Intentionally no `server.passthrough()` here: in tests we never want
+	// mirage to fall through to the real network. Unmatched requests return
+	// mirage's default 404 in-memory.
 
 	if (server.logging) {
 		console.log('Mirage database');

--- a/packages/frontend/editor-ui/src/__tests__/setup.ts
+++ b/packages/frontend/editor-ui/src/__tests__/setup.ts
@@ -413,3 +413,20 @@ Object.defineProperty(window, 'speechSynthesis', {
 });
 
 loadLanguage('en', englishBaseText as unknown as LocaleMessages);
+
+// Block jsdom XHRs from making real network requests in tests. Unmocked store
+// actions used to fire real /rest/* calls; on Node 22 the resulting dual-stack
+// DNS AggregateError emits via socketErrorListener AFTER the test has finished,
+// and vitest 4 promotes that to a test-run failure (~22% miss rate on shard 2).
+// Short-circuiting send() means any unmocked request fails synchronously during
+// the test instead of racing teardown.
+XMLHttpRequest.prototype.send = function (this: XMLHttpRequest) {
+	Object.defineProperty(this, 'readyState', { value: 4, configurable: true });
+	Object.defineProperty(this, 'status', { value: 0, configurable: true });
+	Object.defineProperty(this, 'statusText', { value: '', configurable: true });
+	queueMicrotask(() => {
+		this.dispatchEvent(new Event('readystatechange'));
+		this.dispatchEvent(new Event('error'));
+		this.dispatchEvent(new Event('loadend'));
+	});
+};

--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.test.ts
@@ -94,6 +94,8 @@ describe('WorkflowSettingsVue', () => {
 		// Mock specific store actions that tests assert on
 		workflowsStore.updateWorkflow = vi.fn();
 		workflowsListStore.fetchWorkflow = vi.fn();
+		// Component calls this on mount; avoid a real XHR with stubActions: false.
+		settingsStore.getTimezones = vi.fn().mockResolvedValue({});
 
 		// Create document store on the main pinia (same one the component uses).
 		// With stubActions: false, setSettings and getSettingsSnapshot work normally.

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -87,6 +87,19 @@ vi.mock('vue-router', async (importOriginal) => ({
 	}),
 }));
 
+vi.mock('@/app/api/workflows', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('@/app/api/workflows')>();
+	return {
+		...actual,
+		getNewWorkflow: vi.fn().mockResolvedValue({ name: 'New Workflow', settings: {} }),
+	};
+});
+
+vi.mock('@n8n/rest-api-client/api/workflowHistory', () => ({
+	getWorkflowHistory: vi.fn().mockResolvedValue([]),
+	getWorkflowVersion: vi.fn().mockResolvedValue({ workflow: { nodes: [], connections: {} } }),
+}));
+
 import { useCanvasOperations } from '@/app/composables/useCanvasOperations';
 import * as workflowHelpersModule from '@/app/composables/useWorkflowHelpers';
 import { GRID_SIZE, PUSH_NODES_OFFSET } from '@/app/utils/nodeViewUtils';

--- a/packages/frontend/editor-ui/src/features/core/dataTable/DataTableDetailsView.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/DataTableDetailsView.test.ts
@@ -11,6 +11,10 @@ import { sourceControlEventBus } from '@/features/integrations/sourceControl.ee/
 
 vi.mock('@/app/composables/useToast');
 vi.mock('vue-router');
+vi.mock('@/app/api/workflow-dependencies', () => ({
+	getResourceDependencyCounts: vi.fn().mockResolvedValue({}),
+	getResourceDependencies: vi.fn().mockResolvedValue({}),
+}));
 vi.mock('@/app/composables/useDocumentTitle', () => ({
 	useDocumentTitle: vi.fn(() => ({
 		set: vi.fn(),

--- a/packages/frontend/editor-ui/src/features/core/dataTable/DataTableView.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/dataTable/DataTableView.test.ts
@@ -20,6 +20,11 @@ vi.mock('@/features/collaboration/projects/composables/useProjectPages', () => (
 	}),
 }));
 
+vi.mock('@/app/api/workflow-dependencies', () => ({
+	getResourceDependencyCounts: vi.fn().mockResolvedValue({}),
+	getResourceDependencies: vi.fn().mockResolvedValue({}),
+}));
+
 vi.mock('@n8n/i18n', async (importOriginal) => {
 	const actual = await importOriginal();
 	const actualObj = typeof actual === 'object' && actual !== null ? actual : {};

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
@@ -186,6 +186,8 @@ describe('NodeCredentials', () => {
 		renderComponent = createComponentRenderer(NodeCredentials, defaultRenderOptions);
 
 		credentialsStore = mockedStore(useCredentialsStore);
+		// Component triggers this on mount; avoid a real XHR with stubActions: false.
+		credentialsStore.fetchAllCredentials = vi.fn().mockResolvedValue([]);
 		ndvStore = mockedStore(useNDVStore);
 		uiStore = mockedStore(useUIStore);
 		projectsStore = mockedStore(useProjectsStore);

--- a/packages/frontend/editor-ui/src/features/credentials/views/CredentialsView.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/views/CredentialsView.test.ts
@@ -25,6 +25,11 @@ vi.mock('@/features/collaboration/projects/projects.api', () => ({
 	getProject: vi.fn(),
 }));
 
+vi.mock('@/app/api/workflow-dependencies', () => ({
+	getResourceDependencyCounts: vi.fn().mockResolvedValue({}),
+	getResourceDependencies: vi.fn().mockResolvedValue({}),
+}));
+
 const router = createRouter({
 	history: createWebHistory(),
 	routes: [


### PR DESCRIPTION
## Summary

The frontend unit-test job (Node 22, Frontend 2/2) was failing ~22% of runs with `Error: AggregateError` emitted from jsdom's `xhr-utils.js:63` via `socketErrorListener` *after* the test had resolved. Vitest 4 promotes that unhandled error to a test-run failure.

**Root cause** (confirmed by instrumenting `XMLHttpRequest.prototype.open` with `expect.getState().testPath` and running shard 2 on Node 22.16.0):

Unmocked Pinia store actions and composables in 6 spec files fired real `/rest/*` XHRs that raced worker teardown. On Node 22 the dual-stack DNS lookup produces `AggregateError`; Node 24 swallows it, which is why CI runs on the 24.x matrix were green.

Attribution (instrumented shard-2 run, 141 leaks total):

| Spec | Leaks | URL |
|---|---|---|
| `WorkflowSettings.test.ts` | 55 | `GET /rest/options/timezones` |
| `NodeCredentials.test.ts` | 40 | `GET /rest/credentials?…` |
| `useCanvasOperations.test.ts` | 15 | `workflows/new`, `workflow-history/.../version/v1` |
| `DataTableView.test.ts` | 12 | `POST /rest/workflow-dependencies/counts` |
| `DataTableDetailsView.test.ts` | 8 | same |
| `CredentialsView.test.ts` | 7 | same |
| (one-off stragglers) | 4 | LogsOverviewPanel ×2, TestRunDetailView ×1, FocusPanel ×1 |

## Fix

Two-layer approach:

1. **Defensive net** (`__tests__/setup.ts`): stub `XMLHttpRequest.prototype.send` so any unmocked request fails synchronously inside the test instead of racing teardown.
2. **Root-cause mocks** in 6 spec files so the components don't even attempt the XHR. Mocking at the API layer (`@/app/api/workflow-dependencies`, `@/app/api/workflows`, `@n8n/rest-api-client/api/workflowHistory`) rather than the composable keeps real composable logic in the test path.

Also drops `server.passthrough()` from the mirage test server — in unit tests we never want unmatched routes to fall through to the network; mirage's in-memory 404 is the correct fallback.

## Verification

Editor-ui shard 2/2 on Node v22.16.0:

| Metric | Before | After |
|---|---|---|
| `AggregateError` count | 302 | 0 |
| XHR leaks | 141 | 4 (covered by defensive stub) |
| Test files | 391 pass | 391 pass |
| Tests | 5181 pass | 5181 pass |

Confirmed across 3 consecutive shard-2 runs. Shard-1 regression run also clean. `pnpm typecheck` and `pnpm lint` pass.

## Test plan
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] CI: `Unit tests (22.x) / Frontend (2/2)` passes consistently across re-runs
- [ ] CI: `Unit tests (22.x) / Frontend (1/2)` still passes (no regression from the global XHR stub)
- [ ] CI: Node 24.x frontend matrix still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)