### PR TITLE
refactor(core): Resolve $jmespath in-isolate for VM engine (no-changelog)

### DIFF
--- a/packages/@n8n/expression-runtime/package.json
+++ b/packages/@n8n/expression-runtime/package.json
@@ -34,6 +34,7 @@
     "@n8n/errors": "workspace:*",
     "@n8n/tournament": "workspace:*",
     "isolated-vm": "catalog:",
+    "jmespath": "0.16.0",
     "js-base64": "catalog:",
     "jssha": "3.3.1",
     "lodash": "catalog:",
@@ -45,6 +46,7 @@
   "devDependencies": {
     "@n8n/typescript-config": "workspace:*",
     "@n8n/vitest-config": "workspace:*",
+    "@types/jmespath": "^0.15.0",
     "@types/lodash": "catalog:",
     "@types/luxon": "3.2.0",
     "@types/md5": "^2.3.5",

--- a/packages/@n8n/expression-runtime/src/__tests__/host-fn-shadowing.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/host-fn-shadowing.test.ts
@@ -4,8 +4,8 @@
  * properties of the same name. Tournament's `VariablePolyfill` rewrites a
  * bare identifier `extend(...)` to `("extend" in this ? this : global).extend`
  * where `this` is the in-isolate context proxy. The proxy's `has` trap finds
- * `target.extend` (set in `runtime/context.ts:92-93`) and returns the
- * in-isolate copy before any host lookup happens.
+ * `target.<name>` (set in `runtime/context.ts`) and returns the in-isolate
+ * copy before any host lookup happens.
  *
  * Why this matters under the threat model: every host function reachable
  * from `data` becomes a callable target via the bridge's `callFunctionAtPath`.
@@ -16,7 +16,7 @@
  *
  * If this test ever fails, one of the following changed:
  *   - Tournament's polyfill no longer rewrites bare identifiers to context-first
- *   - `target.extend` / `target.extendOptional` were removed from `context.ts`
+ *   - The corresponding `target.<name>` was removed from `context.ts`
  *   - A new resolution path was added that prefers host `data` over context
  * Any of these is a meaningful security regression — investigate before
  * "fixing" the test.
@@ -110,5 +110,49 @@ describe('Host-fn shadowing: data.extend / data.extendOptional must not be invok
 
 		expect(result).toEqual([1, 2, 3]);
 		expect(hostExtendCalls).toBe(0);
+	});
+
+	it('does NOT invoke host-side data.$jmespath when expression calls $jmespath(...)', () => {
+		let hostJmespathCalls = 0;
+		const data: Record<string, unknown> = {
+			$json: { users: [{ name: 'a' }, { name: 'b' }] },
+			$jmespath: (...args: unknown[]) => {
+				hostJmespathCalls++;
+				throw new Error(`host-side data.$jmespath was invoked with: ${JSON.stringify(args)}`);
+			},
+			$jmesPath: (...args: unknown[]) => {
+				hostJmespathCalls++;
+				throw new Error(`host-side data.$jmesPath was invoked with: ${JSON.stringify(args)}`);
+			},
+		};
+
+		const result = evaluator.evaluate(
+			'{{ $jmespath({users: [{name: "a"}, {name: "b"}]}, "users[*].name") }}',
+			data,
+			caller,
+		);
+
+		expect(result).toEqual(['a', 'b']);
+		expect(hostJmespathCalls).toBe(0);
+	});
+
+	it('does NOT invoke host-side data.$jmesPath when expression calls $jmesPath (capital P)', () => {
+		let hostJmespathCalls = 0;
+		const data: Record<string, unknown> = {
+			$json: {},
+			$jmespath: (...args: unknown[]) => {
+				hostJmespathCalls++;
+				throw new Error(`host-side data.$jmespath was invoked with: ${JSON.stringify(args)}`);
+			},
+			$jmesPath: (...args: unknown[]) => {
+				hostJmespathCalls++;
+				throw new Error(`host-side data.$jmesPath was invoked with: ${JSON.stringify(args)}`);
+			},
+		};
+
+		const result = evaluator.evaluate('{{ $jmesPath({a: 1, b: 2}, "a") }}', data, caller);
+
+		expect(result).toBe(1);
+		expect(hostJmespathCalls).toBe(0);
 	});
 });

--- a/packages/@n8n/expression-runtime/src/runtime/context.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/context.ts
@@ -10,6 +10,7 @@ import {
 	isObjectMetadata,
 	throwIfErrorSentinel,
 } from './lazy-proxy';
+import { jmesPath } from './jmespath';
 
 // Pre-create safe error subclass wrappers (reused across evaluations)
 const SafeTypeError = createSafeErrorSubclass(TypeError);
@@ -96,6 +97,13 @@ export function buildContext(
 	// pattern resolves them correctly when the VM checks ctx first
 	target.extend = extend;
 	target.extendOptional = extendOptional;
+
+	// Expose jmespath helpers in-isolate so they shadow the host-side
+	// `data.$jmesPath` / `data.$jmespath` from WorkflowDataProxy. Same rationale
+	// as extend / extendOptional above: keeping these in-isolate removes them
+	// from the bridge's reachable host-callable surface.
+	target.$jmesPath = jmesPath;
+	target.$jmespath = jmesPath;
 
 	// Wire builtins so tournament's VariablePolyfill resolves them from ctx
 	initializeBuiltins(target);

--- a/packages/@n8n/expression-runtime/src/runtime/jmespath.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/jmespath.ts
@@ -1,0 +1,35 @@
+import * as jmespath from 'jmespath';
+
+import { ExpressionError } from './safe-globals';
+
+/**
+ * In-isolate `$jmespath` / `$jmesPath` implementation.
+ *
+ * Mirrors the host-side wrapper in `packages/workflow/src/workflow-data-proxy.ts`
+ * so that expressions resolve `$jmespath` from the in-isolate runtime via
+ * Tournament's polyfill, instead of falling through to the bridge's
+ * `callFunctionAtPath` channel. This shrinks the host-callable surface
+ * exposed by the data object.
+ *
+ * Behavioural parity with the host wrapper:
+ *   - Throws `ExpressionError` (same name) when args are wrong.
+ *   - Spreads non-array, non-null objects to drop proxies at the top level.
+ *
+ * Note on lazy proxies: when `data` is a lazy proxy (e.g. `$json`), each
+ * property access during `jmespath.search` triggers a synchronous host
+ * roundtrip via `getValueAtPath`. Functional but slow for deep traversals.
+ * Performance optimisation (e.g. bulk pre-fetch of the queried subtree) is
+ * a follow-up.
+ */
+export function jmesPath(data: unknown, query: string): unknown {
+	if (typeof data !== 'object' || typeof query !== 'string') {
+		throw new ExpressionError('expected two arguments (Object, string) for this function');
+	}
+
+	if (data !== null && !Array.isArray(data) && typeof data === 'object') {
+		return jmespath.search({ ...(data as Record<string, unknown>) }, query);
+	}
+
+	// Array or null — pass through to jmespath which accepts both
+	return jmespath.search(data as never, query);
+}

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -547,19 +547,32 @@ export class Expression {
 
 		Expression.initializeGlobalContext(data);
 
+		const usingVm = Expression.shouldUseVm();
+
 		// Expression extensions — only attached for the legacy engine.
 		//
 		// In the VM engine, every host function reachable from `data` becomes
 		// a callable target the isolate can reach via `callFunctionAtPath`.
-		// To minimise that attack surface we keep the VM-path data object as
-		// small as possible and let the in-isolate runtime resolve helpers
-		// itself (see packages/@n8n/expression-runtime/src/runtime/context.ts,
-		// where Tournament's polyfill rewrites bare `extend(...)` calls to the
-		// in-isolate copy on `target.extend`). Setting them here in VM mode
-		// would be dead code AND an unnecessary host-callable.
-		if (!Expression.shouldUseVm()) {
+		// To minimise that surface we keep the VM-path data object as small as
+		// possible and let the in-isolate runtime resolve helpers itself
+		// (see packages/@n8n/expression-runtime/src/runtime/context.ts, where
+		// Tournament's polyfill rewrites bare `extend(...)` calls to the
+		// in-isolate copy on `target.extend`). Setting them on `data` in VM
+		// mode would be dead code AND an unnecessary host-callable.
+		if (!usingVm) {
 			data.extend = extend;
 			data.extendOptional = extendOptional;
+		}
+
+		// In VM mode, strip `$jmesPath` / `$jmespath` from the data proxy.
+		// WorkflowDataProxy adds them, but the in-isolate `target.$jmespath`
+		// shadows them via Tournament's polyfill (see
+		// packages/@n8n/expression-runtime/src/runtime/context.ts). The delete
+		// makes them unreachable via direct path lookup through the bridge
+		// too, so the bridge can never invoke the host-side copies.
+		if (usingVm) {
+			delete data.$jmesPath;
+			delete data.$jmespath;
 		}
 
 		Object.defineProperty(data, sanitizerName, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1601,6 +1601,9 @@ importers:
       isolated-vm:
         specifier: 'catalog:'
         version: 6.1.2
+      jmespath:
+        specifier: 0.16.0
+        version: 0.16.0
       js-base64:
         specifier: 'catalog:'
         version: 3.7.8
@@ -1629,6 +1632,9 @@ importers:
       '@n8n/vitest-config':
         specifier: workspace:*
         version: link:../vitest-config
+      '@types/jmespath':
+        specifier: ^0.15.0
+        version: 0.15.0
       '@types/lodash':
         specifier: 'catalog:'
         version: 4.17.17
@@ -6747,17 +6753,8 @@ packages:
   '@daytona/toolbox-api-client@0.175.0':
     resolution: {integrity: sha512-wiSn1nTgROFkq4qtcYsDWuyZdtEBzb9mb3LkQmNm6ZB8crB9nIBwNxolziYPgS6DgGlXtsv4qEnWqUlDUva/Ew==}
 
-  '@daytonaio/api-client@0.143.0':
-    resolution: {integrity: sha512-LcrvExGcwyngt1JnVoxuBMD19fL9F+vwGnp18Hav5HJEbICM0pbrJc2FJ242sQJquNIF5mq+5jgznWg6wshZJA==}
-
-  '@daytonaio/sdk@0.143.0':
-    resolution: {integrity: sha512-itQ409W+WuuqLd8edIRVUWeRUyujSlOKInnN6GeC3OqyOWT27wyD/KzkesXDJtQ6HthGtqa4uRtHqnayd5wRCQ==}
-
   '@daytonaio/sdk@0.175.0':
     resolution: {integrity: sha512-2MR0sUAbyH7Z7Kay12XgVby5z5Vm/AECn/ELXNlFy1AKESE3VvglGuMq+ez1Ld+7r3Eylo4aiSt5msxqqQbQaw==}
-
-  '@daytonaio/toolbox-api-client@0.143.0':
-    resolution: {integrity: sha512-E6+yHPnFygNqRIctoDheISHCpzQkHydAU7fiBfsA5pnElfB/yLTOXQlnZfP8gfvOmUkRNU8QCXKzaualRTlI7w==}
 
   '@dependents/detective-less@5.0.1':
     resolution: {integrity: sha512-Y6+WUMsTFWE5jb20IFP4YGa5IrGY/+a/FbOSjDF/wz9gepU2hwCYSXRHP/vPwBvwcY3SVMASt4yXxbXNXigmZQ==}
@@ -8852,12 +8849,6 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/core@2.2.0':
-    resolution: {integrity: sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-
   '@opentelemetry/core@2.4.0':
     resolution: {integrity: sha512-KtcyFHssTn5ZgDu6SXmUznS80OFs/wN7y6MyFRRcKU6TOw8hNcGxKvt8hsdaLJfhzUszNSjURetq5Qpkad14Gw==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -8936,12 +8927,6 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/exporter-trace-otlp-http@0.207.0':
-    resolution: {integrity: sha512-HSRBzXHIC7C8UfPQdu15zEEoBGv0yWkhEwxqgPCHVUKUQ9NLHVGXkVrf65Uaj7UwmAkC1gQfkuVYvLlD//AnUQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
   '@opentelemetry/exporter-trace-otlp-http@0.213.0':
     resolution: {integrity: sha512-tnRmJD39aWrE/Sp7F6AbRNAjKHToDkAqBi6i0lESpGWz3G+f4bhVAV6mgSXH2o18lrDVJXo6jf9bAywQw43wRA==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -9010,12 +8995,6 @@ packages:
 
   '@opentelemetry/instrumentation-hapi@0.56.0':
     resolution: {integrity: sha512-HgLxgO0G8V9y/6yW2pS3Fv5M3hz9WtWUAdbuszQDZ8vXDQSd1sI9FYHLdZW+td/8xCLApm8Li4QIeCkRSpHVTg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/instrumentation-http@0.207.0':
-    resolution: {integrity: sha512-FC4i5hVixTzuhg4SV2ycTEAYx+0E2hm+GwbdoVPSA6kna0pPVI4etzaA9UkpJ9ussumQheFXP6rkGIaFJjMxsw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -9140,12 +9119,6 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
 
-  '@opentelemetry/otlp-exporter-base@0.207.0':
-    resolution: {integrity: sha512-4RQluMVVGMrHok/3SVeSJ6EnRNkA2MINcX88sh+d/7DjGUrewW/WT88IsMEci0wUM+5ykTpPPNbEOoW+jwHnbw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
   '@opentelemetry/otlp-exporter-base@0.213.0':
     resolution: {integrity: sha512-MegxAP1/n09Ob2dQvY5NBDVjAFkZRuKtWKxYev1R2M8hrsgXzQGkaMgoEKeUOyQ0FUyYcO29UOnYdQWmWa0PXg==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -9166,12 +9139,6 @@ packages:
 
   '@opentelemetry/otlp-transformer@0.205.0':
     resolution: {integrity: sha512-KmObgqPtk9k/XTlWPJHdMbGCylRAmMJNXIRh6VYJmvlRDMfe+DonH41G7eenG8t4FXn3fxOGh14o/WiMRR6vPg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-
-  '@opentelemetry/otlp-transformer@0.207.0':
-    resolution: {integrity: sha512-+6DRZLqM02uTIY5GASMZWUwr52sLfNiEe20+OEaZKhztCs3+2LxoTjb6JxFRd9q1qNqckXKYlUKjbH/AhG8/ZA==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': ^1.3.0
@@ -9216,12 +9183,6 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
 
-  '@opentelemetry/resources@2.2.0':
-    resolution: {integrity: sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
   '@opentelemetry/resources@2.5.0':
     resolution: {integrity: sha512-F8W52ApePshpoSrfsSk1H2yJn9aKjCrbpQF1M9Qii0GHzbfVeFUB+rc3X4aggyZD8x9Gu3Slua+s6krmq6Dt8g==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -9252,12 +9213,6 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.4.0 <1.10.0'
 
-  '@opentelemetry/sdk-logs@0.207.0':
-    resolution: {integrity: sha512-4MEQmn04y+WFe6cyzdrXf58hZxilvY59lzZj2AccuHW/+BxLn/rGVN/Irsi/F0qfBOpMOrrCLKTExoSL2zoQmg==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.4.0 <1.10.0'
-
   '@opentelemetry/sdk-logs@0.213.0':
     resolution: {integrity: sha512-00xlU3GZXo3kXKve4DLdrAL0NAFUaZ9appU/mn00S/5kSUdAvyYsORaDUfR04Mp2CLagAOhrzfUvYozY/EZX2g==}
     engines: {node: ^18.19.0 || >=20.6.0}
@@ -9272,12 +9227,6 @@ packages:
 
   '@opentelemetry/sdk-metrics@2.1.0':
     resolution: {integrity: sha512-J9QX459mzqHLL9Y6FZ4wQPRZG4TOpMCyPOh6mkr/humxE1W2S3Bvf4i75yiMW9uyed2Kf5rxmLhTm/UK8vNkAw==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.9.0 <1.10.0'
-
-  '@opentelemetry/sdk-metrics@2.2.0':
-    resolution: {integrity: sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.9.0 <1.10.0'
@@ -9302,12 +9251,6 @@ packages:
 
   '@opentelemetry/sdk-trace-base@2.1.0':
     resolution: {integrity: sha512-uTX9FBlVQm4S2gVQO1sb5qyBLq/FPjbp+tmGoxu4tIgtYGmBYB44+KX/725RFDe30yBSaA9Ml9fqphe1hbUyLQ==}
-    engines: {node: ^18.19.0 || >=20.6.0}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.3.0 <1.10.0'
-
-  '@opentelemetry/sdk-trace-base@2.2.0':
-    resolution: {integrity: sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.3.0 <1.10.0'
@@ -25912,43 +25855,6 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@daytonaio/api-client@0.143.0':
-    dependencies:
-      axios: 1.16.0
-    transitivePeerDependencies:
-      - debug
-
-  '@daytonaio/sdk@0.143.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
-    dependencies:
-      '@aws-sdk/client-s3': 3.808.0
-      '@aws-sdk/lib-storage': 3.1019.0(@aws-sdk/client-s3@3.808.0)
-      '@daytonaio/api-client': 0.143.0
-      '@daytonaio/toolbox-api-client': 0.143.0
-      '@iarna/toml': 2.2.5
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/exporter-trace-otlp-http': 0.207.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation-http': 0.207.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.207.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-node': 0.217.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.7.1(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.40.0
-      axios: 1.16.0
-      busboy: 1.6.0
-      dotenv: 17.2.3
-      expand-tilde: 2.0.2
-      fast-glob: 3.3.3
-      form-data: 4.0.4
-      isomorphic-ws: 5.0.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))
-      pathe: 2.0.3
-      shell-quote: 1.8.3
-      tar: 7.5.11
-    transitivePeerDependencies:
-      - aws-crt
-      - debug
-      - supports-color
-      - ws
-
   '@daytonaio/sdk@0.175.0(ws@8.18.3(bufferutil@4.0.9)(utf-8-validate@5.0.10))':
     dependencies:
       '@aws-sdk/client-s3': 3.808.0
@@ -25979,12 +25885,6 @@ snapshots:
       - debug
       - supports-color
       - ws
-
-  '@daytonaio/toolbox-api-client@0.143.0':
-    dependencies:
-      axios: 1.16.0
-    transitivePeerDependencies:
-      - debug
 
   '@dependents/detective-less@5.0.1':
     dependencies:
@@ -28272,11 +28172,6 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/semantic-conventions': 1.40.0
-
   '@opentelemetry/core@2.4.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -28386,15 +28281,6 @@ snapshots:
       '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.1.0(@opentelemetry/api@1.9.0)
 
-  '@opentelemetry/exporter-trace-otlp-http@0.207.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.207.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.207.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
-
   '@opentelemetry/exporter-trace-otlp-http@0.213.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -28493,16 +28379,6 @@ snapshots:
       '@opentelemetry/core': 2.7.1(@opentelemetry/api@1.9.0)
       '@opentelemetry/instrumentation': 0.210.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.40.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@opentelemetry/instrumentation-http@0.207.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/instrumentation': 0.207.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.40.0
-      forwarded-parse: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
@@ -28683,12 +28559,6 @@ snapshots:
       '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/otlp-transformer': 0.205.0(@opentelemetry/api@1.9.0)
 
-  '@opentelemetry/otlp-exporter-base@0.207.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.207.0(@opentelemetry/api@1.9.0)
-
   '@opentelemetry/otlp-exporter-base@0.213.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -28718,17 +28588,6 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.205.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-metrics': 2.1.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/sdk-trace-base': 2.1.0(@opentelemetry/api@1.9.0)
-      protobufjs: 7.5.6
-
-  '@opentelemetry/otlp-transformer@0.207.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.207.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-logs': 0.207.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
       protobufjs: 7.5.6
 
   '@opentelemetry/otlp-transformer@0.213.0(@opentelemetry/api@1.9.0)':
@@ -28777,12 +28636,6 @@ snapshots:
       '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.40.0
-
   '@opentelemetry/resources@2.5.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -28815,13 +28668,6 @@ snapshots:
       '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
 
-  '@opentelemetry/sdk-logs@0.207.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/api-logs': 0.207.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
-
   '@opentelemetry/sdk-logs@0.213.0(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -28843,12 +28689,6 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
-
-  '@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
 
   '@opentelemetry/sdk-metrics@2.6.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -28898,13 +28738,6 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.1.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/resources': 2.1.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/semantic-conventions': 1.40.0
-
-  '@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0)':
-    dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0)':


### PR DESCRIPTION
## Summary

In VM-engine mode, `$jmespath` / `$jmesPath` are now resolved from the in-isolate runtime instead of falling through to the host-side `WorkflowDataProxy`. The host-side copies are deleted from the data object passed to the bridge in VM mode, mirroring the Step 0 pattern previously applied to `extend` / `extendOptional`.

Three pieces make this work:

1. **New file** `packages/@n8n/expression-runtime/src/runtime/jmespath.ts` — in-isolate wrapper mirroring the host wrapper's behavior (validates args, throws `ExpressionError`, spreads non-array objects before search).
2. **`packages/@n8n/expression-runtime/src/runtime/context.ts`** — imports `jmesPath` and sets `target.$jmesPath` / `target.$jmespath` so Tournament's polyfill rewrites bare `$jmespath(...)` to the in-isolate copy via the context proxy's `has` trap before any host lookup happens.
3. **`packages/workflow/src/expression.ts`** — in VM mode, deletes `data.$jmesPath` and `data.$jmespath` from the data proxy before evaluation, so a direct path lookup through the bridge can't reach them either.

Motivation: every host function reachable from `data` becomes a callable target via the bridge's `callFunctionAtPath`. Trimming the data context shrinks the host-callable surface reachable from an expression — a structural reduction, not a fix for a known exploit. The legacy engine is unchanged.

A regression test in `packages/@n8n/expression-runtime/src/__tests__/host-fn-shadowing.test.ts` (2 new cases) locks in the in-isolate shadowing invariant for both `$jmespath` and `$jmesPath`.

### Bundle size note

`runtime.iife.js` grew ~22 KB (456 KB → 479 KB) to inline the `jmespath` library. This is in tension with CAT-2603 (bundle minimisation); decision deferred. If bundle pressure reasserts itself, the escape hatch is to revert this and expose `$jmespath` as a typed RPC instead.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2982

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- n/a — internal refactor, no docs surface -->
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported) <!-- n/a -->

## Test plan

- `pnpm --filter=n8n-workflow test test/expression.test.ts` — 362/362 pass (181 legacy + 181 VM)
- `pnpm --filter=n8n-workflow test test/workflow-data-proxy.test.ts` — 294/294 pass
- `pnpm --filter=@n8n/expression-runtime test` — full suite passes (incl. 5/5 in `host-fn-shadowing.test.ts` covering both `extend` and `$jmespath` shadowing)
- `pnpm --filter=n8n-workflow typecheck` — clean

🤖 PR Summary generated by AI