### PR TITLE
feat(core): Add unpinNodes opt-in field to eval execution (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -395,6 +395,7 @@ export type {
 	InstanceAiEvalNodeResult,
 	InstanceAiEvalMockHints,
 	InstanceAiEvalMockedCredential,
+	InstanceAiEvalRewrittenCredential,
 	InstanceAiEvalExecutionResult,
 	InstanceAiEvalToolCall,
 	InstanceAiEvalToolResult,

--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -1115,6 +1115,20 @@ export interface InstanceAiEvalMockedCredential {
 	credentialId?: string;
 }
 
+/**
+ * Records a credential field that was rewritten (e.g. routed to the eval wire
+ * server) during evaluation. Populated when the caller opts into the unpin
+ * path via `InstanceAiEvalExecutionRequest.unpinNodes`. Field added in the
+ * foundation PR; the rewrite path itself is wired up in a later PR and stays
+ * empty until then.
+ */
+export interface InstanceAiEvalRewrittenCredential {
+	nodeName: string;
+	credentialType: string;
+	credentialId?: string;
+	field: string;
+}
+
 export interface InstanceAiEvalExecutionResult {
 	executionId: string;
 	success: boolean;
@@ -1122,10 +1136,19 @@ export interface InstanceAiEvalExecutionResult {
 	errors: string[];
 	hints: InstanceAiEvalMockHints;
 	mockedCredentials: InstanceAiEvalMockedCredential[];
+	rewrittenCredentials?: InstanceAiEvalRewrittenCredential[];
 }
 
 export class InstanceAiEvalExecutionRequest extends Z.class({
 	scenarioHints: z.string().max(2000).optional(),
+	/**
+	 * AI root node names (Agent, Chain, etc.) whose sub-nodes should run their
+	 * real vendor SDK code instead of being pinned. The eval pipeline rewrites
+	 * matching credentials so vendor traffic lands on the eval wire server.
+	 * Refused if any sub-node uses a protocol-binary client (e.g. Postgres
+	 * memory) — those cannot be intercepted via HTTP.
+	 */
+	unpinNodes: z.array(z.string().min(1).max(200)).max(50).optional(),
 }) {}
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/execution.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/execution.service.test.ts
@@ -82,6 +82,7 @@ import {
 } from '../workflow-analysis';
 import { createLlmMockHandler } from '../mock-handler';
 import type { MockHints } from '../workflow-analysis';
+import { UserError } from 'n8n-workflow';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -309,16 +310,41 @@ describe('EvalExecutionService', () => {
 		// must not run until TRUST-113 wires the credential rewrite + wire
 		// server, or the workflow would hit real provider APIs.
 		describe('safety gate (no rewriter wired)', () => {
-			it('returns an error result for non-empty unpinNodes without invoking the workflow', async () => {
+			it('runs the compatibility guard, then refuses with the gate error when the guard passes', async () => {
 				const result = await service.executeWithLlmMock('wf-1', makeUser(), {
 					unpinNodes: ['Agent'],
 				});
 
 				expect(result.success).toBe(false);
 				expect(result.errors).toEqual([expect.stringContaining('not yet enabled')]);
-				expect(assertUnpinCompatibilityMock).not.toHaveBeenCalled();
+				// Guard runs first so the user gets actionable diagnostics when their
+				// workflow has a permanent compatibility issue. When the guard passes,
+				// the gate fires with the generic "not yet enabled" message.
+				expect(assertUnpinCompatibilityMock).toHaveBeenCalledWith(
+					expect.objectContaining({ id: 'wf-1' }),
+					['Agent'],
+				);
 				expect(generateMockHintsMock).not.toHaveBeenCalled();
 				expect(mockProcessRunExecutionData).not.toHaveBeenCalled();
+			});
+
+			it("surfaces the guard's error when the workflow has a permanent compatibility issue", async () => {
+				assertUnpinCompatibilityMock.mockImplementation(() => {
+					throw new UserError(
+						'Cannot unpin AI root nodes — protocol-binary sub-nodes ' +
+							'(cannot be intercepted via HTTP): "Mem" (memoryPostgresChat) → "Agent"',
+					);
+				});
+
+				const result = await service.executeWithLlmMock('wf-1', makeUser(), {
+					unpinNodes: ['Agent'],
+				});
+
+				expect(result.success).toBe(false);
+				// Guard's protocol-binary message wins over the generic gate message —
+				// the user needs to fix the workflow regardless of when the feature ships.
+				expect(result.errors).toEqual([expect.stringContaining('memoryPostgresChat')]);
+				expect(result.errors[0]).not.toContain('not yet enabled');
 			});
 
 			it('refuses regardless of how many roots are requested', async () => {

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/execution.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/execution.service.test.ts
@@ -27,6 +27,7 @@ jest.mock('../mock-handler', () => ({
 	createLlmMockHandler: jest.fn(),
 }));
 jest.mock('../workflow-analysis', () => ({
+	assertUnpinCompatibility: jest.fn(),
 	generateMockHints: jest.fn(),
 	identifyNodesForHints: jest.fn(),
 	identifyNodesForPinData: jest.fn(),
@@ -74,12 +75,14 @@ jest.mock('n8n-workflow', () => {
 
 import { EvalExecutionService } from '../execution.service';
 import {
+	assertUnpinCompatibility,
 	generateMockHints,
 	identifyNodesForHints,
 	identifyNodesForPinData,
 } from '../workflow-analysis';
 import { createLlmMockHandler } from '../mock-handler';
 import type { MockHints } from '../workflow-analysis';
+import { UserError } from 'n8n-workflow';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -88,6 +91,7 @@ import type { MockHints } from '../workflow-analysis';
 const generateMockHintsMock = jest.mocked(generateMockHints);
 const identifyNodesForHintsMock = jest.mocked(identifyNodesForHints);
 const identifyNodesForPinDataMock = jest.mocked(identifyNodesForPinData);
+const assertUnpinCompatibilityMock = jest.mocked(assertUnpinCompatibility);
 const createLlmMockHandlerMock = jest.mocked(createLlmMockHandler);
 
 function makeWorkflowEntity(overrides: Partial<IWorkflowBase> = {}) {
@@ -177,6 +181,7 @@ describe('EvalExecutionService', () => {
 		// Default mock returns — happy path
 		identifyNodesForHintsMock.mockReturnValue([]);
 		identifyNodesForPinDataMock.mockReturnValue([]);
+		assertUnpinCompatibilityMock.mockImplementation(() => undefined);
 		generateMockHintsMock.mockResolvedValue(makeEmptyHints());
 		createLlmMockHandlerMock.mockReturnValue(jest.fn());
 		mockGetStartNode.mockReturnValue(makeStartNode());
@@ -276,6 +281,72 @@ describe('EvalExecutionService', () => {
 			expect(result.executionId).toBeDefined();
 			expect(typeof result.executionId).toBe('string');
 			expect(result.executionId.length).toBeGreaterThan(0);
+		});
+	});
+
+	// ── unpinNodes handling ──────────────────────────────────────────
+
+	describe('unpinNodes', () => {
+		beforeEach(() => {
+			workflowFinderService.findWorkflowForUser.mockResolvedValue(makeWorkflowEntity() as never);
+		});
+
+		it('calls assertUnpinCompatibility with an empty list when unpinNodes is omitted', async () => {
+			await service.executeWithLlmMock('wf-1', makeUser());
+
+			expect(assertUnpinCompatibilityMock).toHaveBeenCalledWith(expect.anything(), []);
+		});
+
+		it('forwards unpinNodes to assertUnpinCompatibility', async () => {
+			await service.executeWithLlmMock('wf-1', makeUser(), { unpinNodes: ['Agent'] });
+
+			expect(assertUnpinCompatibilityMock).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 'wf-1' }),
+				['Agent'],
+			);
+		});
+
+		it('forwards an exclusion set to identifyNodesForPinData when unpinNodes is non-empty', async () => {
+			await service.executeWithLlmMock('wf-1', makeUser(), { unpinNodes: ['Agent'] });
+
+			expect(identifyNodesForPinDataMock).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 'wf-1' }),
+				new Set(['Agent']),
+			);
+		});
+
+		it('omits the exclusion set when unpinNodes is empty', async () => {
+			await service.executeWithLlmMock('wf-1', makeUser(), { unpinNodes: [] });
+
+			expect(identifyNodesForPinDataMock).toHaveBeenCalledWith(
+				expect.objectContaining({ id: 'wf-1' }),
+				undefined,
+			);
+		});
+
+		it('returns an error result and skips workflow execution when the guard refuses', async () => {
+			assertUnpinCompatibilityMock.mockImplementation(() => {
+				throw new UserError('Cannot unpin "Agent" — incompatible memory backend');
+			});
+
+			const result = await service.executeWithLlmMock('wf-1', makeUser(), {
+				unpinNodes: ['Agent'],
+			});
+
+			expect(result.success).toBe(false);
+			expect(result.errors).toEqual([expect.stringContaining('Cannot unpin "Agent"')]);
+			expect(generateMockHintsMock).not.toHaveBeenCalled();
+			expect(mockProcessRunExecutionData).not.toHaveBeenCalled();
+		});
+
+		it('rethrows non-UserError failures from the guard', async () => {
+			assertUnpinCompatibilityMock.mockImplementation(() => {
+				throw new Error('boom');
+			});
+
+			await expect(
+				service.executeWithLlmMock('wf-1', makeUser(), { unpinNodes: ['Agent'] }),
+			).rejects.toThrow('boom');
 		});
 	});
 

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/execution.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/execution.service.test.ts
@@ -82,7 +82,6 @@ import {
 } from '../workflow-analysis';
 import { createLlmMockHandler } from '../mock-handler';
 import type { MockHints } from '../workflow-analysis';
-import { UserError } from 'n8n-workflow';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -297,24 +296,6 @@ describe('EvalExecutionService', () => {
 			expect(assertUnpinCompatibilityMock).toHaveBeenCalledWith(expect.anything(), []);
 		});
 
-		it('forwards unpinNodes to assertUnpinCompatibility', async () => {
-			await service.executeWithLlmMock('wf-1', makeUser(), { unpinNodes: ['Agent'] });
-
-			expect(assertUnpinCompatibilityMock).toHaveBeenCalledWith(
-				expect.objectContaining({ id: 'wf-1' }),
-				['Agent'],
-			);
-		});
-
-		it('forwards an exclusion set to identifyNodesForPinData when unpinNodes is non-empty', async () => {
-			await service.executeWithLlmMock('wf-1', makeUser(), { unpinNodes: ['Agent'] });
-
-			expect(identifyNodesForPinDataMock).toHaveBeenCalledWith(
-				expect.objectContaining({ id: 'wf-1' }),
-				new Set(['Agent']),
-			);
-		});
-
 		it('omits the exclusion set when unpinNodes is empty', async () => {
 			await service.executeWithLlmMock('wf-1', makeUser(), { unpinNodes: [] });
 
@@ -324,29 +305,37 @@ describe('EvalExecutionService', () => {
 			);
 		});
 
-		it('returns an error result and skips workflow execution when the guard refuses', async () => {
-			assertUnpinCompatibilityMock.mockImplementation(() => {
-				throw new UserError('Cannot unpin "Agent" — incompatible memory backend');
+		// Safety gate: this PR ships the surface only. Non-empty `unpinNodes`
+		// must not run until TRUST-113 wires the credential rewrite + wire
+		// server, or the workflow would hit real provider APIs.
+		describe('safety gate (no rewriter wired)', () => {
+			it('returns an error result for non-empty unpinNodes without invoking the workflow', async () => {
+				const result = await service.executeWithLlmMock('wf-1', makeUser(), {
+					unpinNodes: ['Agent'],
+				});
+
+				expect(result.success).toBe(false);
+				expect(result.errors).toEqual([expect.stringContaining('not yet enabled')]);
+				expect(assertUnpinCompatibilityMock).not.toHaveBeenCalled();
+				expect(generateMockHintsMock).not.toHaveBeenCalled();
+				expect(mockProcessRunExecutionData).not.toHaveBeenCalled();
 			});
 
-			const result = await service.executeWithLlmMock('wf-1', makeUser(), {
-				unpinNodes: ['Agent'],
+			it('refuses regardless of how many roots are requested', async () => {
+				const result = await service.executeWithLlmMock('wf-1', makeUser(), {
+					unpinNodes: ['A', 'B', 'C'],
+				});
+
+				expect(result.success).toBe(false);
+				expect(result.errors[0]).toContain('unpinNodes');
 			});
 
-			expect(result.success).toBe(false);
-			expect(result.errors).toEqual([expect.stringContaining('Cannot unpin "Agent"')]);
-			expect(generateMockHintsMock).not.toHaveBeenCalled();
-			expect(mockProcessRunExecutionData).not.toHaveBeenCalled();
-		});
+			it('still runs the workflow when unpinNodes is omitted', async () => {
+				await service.executeWithLlmMock('wf-1', makeUser());
 
-		it('rethrows non-UserError failures from the guard', async () => {
-			assertUnpinCompatibilityMock.mockImplementation(() => {
-				throw new Error('boom');
+				expect(generateMockHintsMock).toHaveBeenCalled();
+				expect(mockProcessRunExecutionData).toHaveBeenCalled();
 			});
-
-			await expect(
-				service.executeWithLlmMock('wf-1', makeUser(), { unpinNodes: ['Agent'] }),
-			).rejects.toThrow('boom');
 		});
 	});
 

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/workflow-analysis.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/workflow-analysis.test.ts
@@ -11,10 +11,12 @@ import { createEvalAgent, extractText } from '@n8n/instance-ai';
 import type { IConnections, INode, IWorkflowBase } from 'n8n-workflow';
 
 import {
+	assertUnpinCompatibility,
 	generateMockHints,
 	identifyNodesForHints,
 	identifyNodesForPinData,
 } from '../workflow-analysis';
+import { UserError } from 'n8n-workflow';
 
 const mockedCreateEvalAgent = jest.mocked(createEvalAgent);
 const mockedExtractText = jest.mocked(extractText);
@@ -150,6 +152,166 @@ describe('identifyNodesForPinData', () => {
 		const result = identifyNodesForPinData(makeWorkflow(nodes));
 
 		expect(result).toHaveLength(bypassTypes.length);
+	});
+
+	describe('exclusionSet', () => {
+		const agentNodes = [
+			makeNode({ name: 'OpenAI', type: '@n8n/n8n-nodes-langchain.lmChatOpenAi' }),
+			makeNode({ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+		];
+		const agentConnections: IConnections = {
+			OpenAI: { ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 0 }]] },
+		};
+
+		it('treats an empty exclusion set the same as omitting it', () => {
+			const result = identifyNodesForPinData(makeWorkflow(agentNodes, agentConnections), new Set());
+			expect(result.map((n) => n.name)).toEqual(['Agent']);
+		});
+
+		it('ignores names not present in the workflow', () => {
+			const result = identifyNodesForPinData(
+				makeWorkflow(agentNodes, agentConnections),
+				new Set(['NotAWorkflowNode']),
+			);
+			expect(result.map((n) => n.name)).toEqual(['Agent']);
+		});
+
+		it('ignores names not in the pin set (regular logic nodes)', () => {
+			const nodes = [...agentNodes, makeNode({ name: 'Set', type: 'n8n-nodes-base.set' })];
+			const result = identifyNodesForPinData(
+				makeWorkflow(nodes, agentConnections),
+				new Set(['Set']),
+			);
+			expect(result.map((n) => n.name)).toEqual(['Agent']);
+		});
+
+		it('drops AI root names from the pin set', () => {
+			const result = identifyNodesForPinData(
+				makeWorkflow(agentNodes, agentConnections),
+				new Set(['Agent']),
+			);
+			expect(result.map((n) => n.name)).toEqual([]);
+		});
+
+		it('keeps protocol-binary bypass nodes pinned even when present in the exclusion set', () => {
+			const nodes = [...agentNodes, makeNode({ name: 'Cache', type: 'n8n-nodes-base.redis' })];
+			const result = identifyNodesForPinData(
+				makeWorkflow(nodes, agentConnections),
+				new Set(['Agent', 'Cache']),
+			);
+			expect(result.map((n) => n.name)).toEqual(['Cache']);
+		});
+	});
+});
+
+describe('assertUnpinCompatibility', () => {
+	function agentWithMemory(memoryType: string) {
+		const nodes = [
+			makeNode({ name: 'OpenAI', type: '@n8n/n8n-nodes-langchain.lmChatOpenAi' }),
+			makeNode({ name: 'Memory', type: memoryType }),
+			makeNode({ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+		];
+		const connections: IConnections = {
+			OpenAI: { ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 0 }]] },
+			Memory: { ai_memory: [[{ node: 'Agent', type: 'ai_memory', index: 0 }]] },
+		};
+		return makeWorkflow(nodes, connections);
+	}
+
+	it('is a no-op when unpinNodes is empty', () => {
+		const workflow = agentWithMemory('@n8n/n8n-nodes-langchain.memoryPostgresChat');
+		expect(() => assertUnpinCompatibility(workflow, [])).not.toThrow();
+	});
+
+	it('allows unpinning an Agent backed by MemoryBufferWindow', () => {
+		const workflow = agentWithMemory('@n8n/n8n-nodes-langchain.memoryBufferWindow');
+		expect(() => assertUnpinCompatibility(workflow, ['Agent'])).not.toThrow();
+	});
+
+	it('allows unpinning an Agent with no sub-nodes attached', () => {
+		const nodes = [makeNode({ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' })];
+		expect(() => assertUnpinCompatibility(makeWorkflow(nodes), ['Agent'])).not.toThrow();
+	});
+
+	it('ignores disabled sub-nodes when checking compatibility', () => {
+		const nodes = [
+			makeNode({ name: 'OpenAI', type: '@n8n/n8n-nodes-langchain.lmChatOpenAi' }),
+			makeNode({
+				name: 'PgMem',
+				type: '@n8n/n8n-nodes-langchain.memoryPostgresChat',
+				disabled: true,
+			}),
+			makeNode({ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+		];
+		const connections: IConnections = {
+			OpenAI: { ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 0 }]] },
+			PgMem: { ai_memory: [[{ node: 'Agent', type: 'ai_memory', index: 0 }]] },
+		};
+		expect(() =>
+			assertUnpinCompatibility(makeWorkflow(nodes, connections), ['Agent']),
+		).not.toThrow();
+	});
+
+	it('ignores roots that do not exist in the workflow', () => {
+		const workflow = agentWithMemory('@n8n/n8n-nodes-langchain.memoryBufferWindow');
+		expect(() => assertUnpinCompatibility(workflow, ['Ghost'])).not.toThrow();
+	});
+
+	it.each([
+		['Postgres memory', '@n8n/n8n-nodes-langchain.memoryPostgresChat'],
+		['Redis memory', '@n8n/n8n-nodes-langchain.memoryRedisChat'],
+		['MongoDB memory', '@n8n/n8n-nodes-langchain.memoryMongoDbChat'],
+	])('refuses unpinning an Agent backed by %s', (_label, memoryType) => {
+		const workflow = agentWithMemory(memoryType);
+		expect(() => assertUnpinCompatibility(workflow, ['Agent'])).toThrow(UserError);
+	});
+
+	it.each([
+		'@n8n/n8n-nodes-langchain.vectorStorePGVector',
+		'@n8n/n8n-nodes-langchain.vectorStoreMongoDBAtlas',
+		'@n8n/n8n-nodes-langchain.vectorStoreRedis',
+		'@n8n/n8n-nodes-langchain.chatHubVectorStorePGVector',
+	])('refuses unpinning an Agent backed by protocol-binary vector store %s', (vectorStoreType) => {
+		const nodes = [
+			makeNode({ name: 'OpenAI', type: '@n8n/n8n-nodes-langchain.lmChatOpenAi' }),
+			makeNode({ name: 'Store', type: vectorStoreType }),
+			makeNode({ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+		];
+		const connections: IConnections = {
+			OpenAI: { ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 0 }]] },
+			Store: { ai_vectorStore: [[{ node: 'Agent', type: 'ai_vectorStore', index: 0 }]] },
+		};
+		expect(() => assertUnpinCompatibility(makeWorkflow(nodes, connections), ['Agent'])).toThrow(
+			UserError,
+		);
+	});
+
+	it('reports all offending roots when multiple unpin targets are mixed', () => {
+		const nodes = [
+			makeNode({ name: 'OpenAI', type: '@n8n/n8n-nodes-langchain.lmChatOpenAi' }),
+			makeNode({ name: 'PgMem', type: '@n8n/n8n-nodes-langchain.memoryPostgresChat' }),
+			makeNode({ name: 'BufMem', type: '@n8n/n8n-nodes-langchain.memoryBufferWindow' }),
+			makeNode({ name: 'AgentA', type: '@n8n/n8n-nodes-langchain.agent' }),
+			makeNode({ name: 'AgentB', type: '@n8n/n8n-nodes-langchain.agent' }),
+		];
+		const connections: IConnections = {
+			PgMem: { ai_memory: [[{ node: 'AgentA', type: 'ai_memory', index: 0 }]] },
+			BufMem: { ai_memory: [[{ node: 'AgentB', type: 'ai_memory', index: 0 }]] },
+		};
+
+		let thrown: unknown;
+		try {
+			assertUnpinCompatibility(makeWorkflow(nodes, connections), ['AgentA', 'AgentB']);
+		} catch (e) {
+			thrown = e;
+		}
+
+		expect(thrown).toBeInstanceOf(UserError);
+		const message = (thrown as UserError).message;
+		expect(message).toContain('AgentA');
+		expect(message).toContain('PgMem');
+		expect(message).not.toContain('AgentB');
+		expect(message).not.toContain('BufMem');
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/workflow-analysis.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/workflow-analysis.test.ts
@@ -270,6 +270,7 @@ describe('assertUnpinCompatibility', () => {
 		'@n8n/n8n-nodes-langchain.vectorStorePGVector',
 		'@n8n/n8n-nodes-langchain.vectorStoreMongoDBAtlas',
 		'@n8n/n8n-nodes-langchain.vectorStoreRedis',
+		'@n8n/n8n-nodes-langchain.vectorStoreMilvus',
 		'@n8n/n8n-nodes-langchain.chatHubVectorStorePGVector',
 	])('refuses unpinning an Agent backed by protocol-binary vector store %s', (vectorStoreType) => {
 		const nodes = [

--- a/packages/cli/src/modules/instance-ai/eval/execution.service.ts
+++ b/packages/cli/src/modules/instance-ai/eval/execution.service.ts
@@ -95,6 +95,20 @@ export class EvalExecutionService {
 
 		const unpinNodes = options.unpinNodes ?? [];
 
+		// Run the compatibility guard FIRST — protocol-binary or unmapped-vendor
+		// errors are actionable ("replace this Postgres memory") and the user
+		// needs them whether or not the feature is enabled. The gate below
+		// only kicks in when the workflow IS otherwise compatible, so the guard
+		// never gets shadowed by a more generic refusal.
+		try {
+			assertUnpinCompatibility(workflowEntity, unpinNodes);
+		} catch (error) {
+			if (error instanceof UserError) {
+				return this.errorResult(executionId, error.message);
+			}
+			throw error;
+		}
+
 		// Safety gate: this PR ships only the API surface for `unpinNodes`. The
 		// credential rewrite + eval wire server that route vendor SDK traffic
 		// through localhost land in TRUST-113. Without them, unpinning would let
@@ -107,15 +121,6 @@ export class EvalExecutionService {
 				'`unpinNodes` is reserved — vendor SDK interception is not yet enabled in this build. ' +
 					'Submit the request without `unpinNodes` to use the existing pinned path.',
 			);
-		}
-
-		try {
-			assertUnpinCompatibility(workflowEntity, unpinNodes);
-		} catch (error) {
-			if (error instanceof UserError) {
-				return this.errorResult(executionId, error.message);
-			}
-			throw error;
 		}
 
 		const unpinSet = unpinNodes.length > 0 ? new Set(unpinNodes) : undefined;

--- a/packages/cli/src/modules/instance-ai/eval/execution.service.ts
+++ b/packages/cli/src/modules/instance-ai/eval/execution.service.ts
@@ -23,6 +23,7 @@ import {
 	type IWorkflowExecuteAdditionalData,
 	createRunExecutionData,
 	NodeHelpers,
+	UserError,
 	Workflow,
 } from 'n8n-workflow';
 import { randomUUID } from 'node:crypto';
@@ -37,6 +38,7 @@ import { normalizePinData } from '@n8n/workflow-sdk';
 import { generatePinData } from './pin-data-generator';
 
 import {
+	assertUnpinCompatibility,
 	generateMockHints,
 	identifyNodesForHints,
 	identifyNodesForPinData,
@@ -91,7 +93,18 @@ export class EvalExecutionService {
 			return this.errorResult(executionId, `Workflow ${workflowId} not found or not accessible`);
 		}
 
-		const hints = await this.analyzeWorkflow(workflowEntity, options.scenarioHints);
+		const unpinNodes = options.unpinNodes ?? [];
+		try {
+			assertUnpinCompatibility(workflowEntity, unpinNodes);
+		} catch (error) {
+			if (error instanceof UserError) {
+				return this.errorResult(executionId, error.message);
+			}
+			throw error;
+		}
+
+		const unpinSet = unpinNodes.length > 0 ? new Set(unpinNodes) : undefined;
+		const hints = await this.analyzeWorkflow(workflowEntity, options.scenarioHints, unpinSet);
 
 		return await this.execute(workflowEntity, user, executionId, hints, options.scenarioHints);
 	}
@@ -101,6 +114,7 @@ export class EvalExecutionService {
 	private async analyzeWorkflow(
 		workflowEntity: IWorkflowBase,
 		scenarioHints?: string,
+		unpinSet?: Set<string>,
 	): Promise<MockHints> {
 		// Phase 1: Generate mock hints for HTTP-interceptible nodes
 		const hintNodes = identifyNodesForHints(workflowEntity);
@@ -127,7 +141,7 @@ export class EvalExecutionService {
 		);
 
 		// Phase 1.5: Generate pin data for nodes that bypass the HTTP mock layer
-		const bypassNodes = identifyNodesForPinData(workflowEntity);
+		const bypassNodes = identifyNodesForPinData(workflowEntity, unpinSet);
 		const bypassNodeNames = bypassNodes.map((n) => n.name);
 
 		if (bypassNodeNames.length > 0) {
@@ -484,6 +498,7 @@ export class EvalExecutionService {
 				bypassPinData: {},
 			},
 			mockedCredentials: [],
+			rewrittenCredentials: [],
 		};
 	}
 }

--- a/packages/cli/src/modules/instance-ai/eval/execution.service.ts
+++ b/packages/cli/src/modules/instance-ai/eval/execution.service.ts
@@ -94,6 +94,21 @@ export class EvalExecutionService {
 		}
 
 		const unpinNodes = options.unpinNodes ?? [];
+
+		// Safety gate: this PR ships only the API surface for `unpinNodes`. The
+		// credential rewrite + eval wire server that route vendor SDK traffic
+		// through localhost land in TRUST-113. Without them, unpinning would let
+		// AI sub-nodes execute their real SDK code against real credentials,
+		// leaking traffic to the actual provider. Refuse the request until the
+		// rewrite path is wired up — TRUST-113 removes this gate.
+		if (unpinNodes.length > 0) {
+			return this.errorResult(
+				executionId,
+				'`unpinNodes` is reserved — vendor SDK interception is not yet enabled in this build. ' +
+					'Submit the request without `unpinNodes` to use the existing pinned path.',
+			);
+		}
+
 		try {
 			assertUnpinCompatibility(workflowEntity, unpinNodes);
 		} catch (error) {

--- a/packages/cli/src/modules/instance-ai/eval/workflow-analysis.ts
+++ b/packages/cli/src/modules/instance-ai/eval/workflow-analysis.ts
@@ -12,7 +12,14 @@
 
 import { Logger } from '@n8n/backend-common';
 import { Container } from '@n8n/di';
-import { type INode, type IPinData, type IWorkflowBase, jsonParse } from 'n8n-workflow';
+import {
+	type INode,
+	type IPinData,
+	type IWorkflowBase,
+	jsonParse,
+	mapConnectionsByDestination,
+	UserError,
+} from 'n8n-workflow';
 
 import { createEvalAgent, extractText } from '@n8n/instance-ai';
 import { extractNodeConfig } from './node-config';
@@ -94,18 +101,91 @@ const BYPASS_NODE_TYPES = new Set([
 ]);
 
 /**
+ * AI sub-node types that use a protocol-binary client (TCP, native driver, etc.).
+ * These cannot be intercepted via the HTTP wire server, so the root they hang off
+ * cannot be unpinned safely. `assertUnpinCompatibility` refuses unpin requests
+ * for roots whose sub-nodes match this set.
+ */
+const PROTOCOL_BINARY_SUB_NODE_TYPES = new Set([
+	// Memory backends
+	'@n8n/n8n-nodes-langchain.memoryPostgresChat',
+	'@n8n/n8n-nodes-langchain.memoryRedisChat',
+	'@n8n/n8n-nodes-langchain.memoryMongoDbChat',
+	// Vector stores
+	'@n8n/n8n-nodes-langchain.vectorStorePGVector',
+	'@n8n/n8n-nodes-langchain.vectorStoreMongoDBAtlas',
+	'@n8n/n8n-nodes-langchain.vectorStoreRedis',
+	'@n8n/n8n-nodes-langchain.chatHubVectorStorePGVector',
+]);
+
+/**
  * Identify nodes that bypass the HTTP mock layer and need pin data instead.
  * Returns AI root nodes (Agent, Chain) and protocol/bypass nodes.
+ *
+ * `exclusionSet` opts AI root names out of pinning so their sub-nodes run real
+ * vendor SDK code (routed through the eval wire server). `BYPASS_NODE_TYPES`
+ * nodes ignore the exclusion set — they use protocol-binary clients and have
+ * no HTTP interception path, so they must always be pinned.
  */
-export function identifyNodesForPinData(workflow: IWorkflowBase): INode[] {
+export function identifyNodesForPinData(
+	workflow: IWorkflowBase,
+	exclusionSet?: Set<string>,
+): INode[] {
 	const aiRootNodes = findAiRootNodeNames(workflow);
 
 	return workflow.nodes.filter((node) => {
 		if (node.disabled) return false;
-		if (aiRootNodes.has(node.name)) return true;
+		if (aiRootNodes.has(node.name) && !exclusionSet?.has(node.name)) return true;
 		if (BYPASS_NODE_TYPES.has(node.type)) return true;
 		return false;
 	});
+}
+
+/**
+ * Refuse unpinning AI roots whose inbound `ai_*` sub-nodes can't be intercepted
+ * over HTTP. Walks the workflow's destination-indexed connections once per
+ * call and throws a `UserError` listing every offending root → sub-node pair.
+ */
+export function assertUnpinCompatibility(workflow: IWorkflowBase, unpinNodes: string[]): void {
+	if (unpinNodes.length === 0) return;
+
+	const nodesByName = new Map(workflow.nodes.map((n) => [n.name, n]));
+	const connectionsByDestination = mapConnectionsByDestination(workflow.connections);
+
+	const refusals: Array<{ root: string; subNode: string; subNodeType: string }> = [];
+
+	for (const rootName of unpinNodes) {
+		const inbound = connectionsByDestination[rootName];
+		if (!inbound) continue;
+
+		for (const [connType, groups] of Object.entries(inbound)) {
+			if (!connType.startsWith('ai_') || !Array.isArray(groups)) continue;
+			for (const group of groups) {
+				if (!Array.isArray(group)) continue;
+				for (const conn of group) {
+					const sourceNode = nodesByName.get(conn.node);
+					if (!sourceNode || sourceNode.disabled) continue;
+					if (PROTOCOL_BINARY_SUB_NODE_TYPES.has(sourceNode.type)) {
+						refusals.push({
+							root: rootName,
+							subNode: sourceNode.name,
+							subNodeType: sourceNode.type,
+						});
+					}
+				}
+			}
+		}
+	}
+
+	if (refusals.length > 0) {
+		const detail = refusals
+			.map((r) => `"${r.subNode}" (${r.subNodeType}) → "${r.root}"`)
+			.join(', ');
+		throw new UserError(
+			`Cannot unpin AI root nodes whose sub-nodes use a protocol-binary client: ${detail}. ` +
+				'These sub-nodes cannot be intercepted via HTTP — leave the root pinned or replace the sub-node with an HTTP-based alternative.',
+		);
+	}
 }
 
 /**

--- a/packages/cli/src/modules/instance-ai/eval/workflow-analysis.ts
+++ b/packages/cli/src/modules/instance-ai/eval/workflow-analysis.ts
@@ -115,6 +115,7 @@ const PROTOCOL_BINARY_SUB_NODE_TYPES = new Set([
 	'@n8n/n8n-nodes-langchain.vectorStorePGVector',
 	'@n8n/n8n-nodes-langchain.vectorStoreMongoDBAtlas',
 	'@n8n/n8n-nodes-langchain.vectorStoreRedis',
+	'@n8n/n8n-nodes-langchain.vectorStoreMilvus',
 	'@n8n/n8n-nodes-langchain.chatHubVectorStorePGVector',
 ]);
 


### PR DESCRIPTION
## Summary

Foundation PR (1 of 4) for vendor SDK interception during evals (parent: [TRUST-101](https://linear.app/n8n/issue/TRUST-101)). Adds the API surface and refuse-unpin guard so later PRs can wire the rewrite path. **No runtime behaviour change** — `unpinNodes` is opt-in and defaults to undefined, so existing eval callers see no difference.

- Add `unpinNodes?: string[]` to `InstanceAiEvalExecutionRequest`.
- Add `assertUnpinCompatibility(workflow, unpinNodes)` — walks inbound `ai_*` connections and refuses unpinning roots whose sub-nodes use a protocol-binary client (Postgres/Redis/Mongo memory; PGVector / MongoDBAtlas / Redis vector stores). Skips disabled sub-nodes.
- Extend `identifyNodesForPinData(workflow, exclusionSet?)` so AI root names in the exclusion set drop out of the pin set. `BYPASS_NODE_TYPES` always pinned regardless.
- Add `rewrittenCredentials?: InstanceAiEvalRewrittenCredential[]` diagnostic field on the result (dormant — populated by PR 2's rewrite path).
- Thread the field through `EvalExecutionService.executeWithLlmMock()`. Guard runs before any other work; refusals return an error-shaped result and skip `runWorkflow`.

### Why this is split

Master spec lays out four phased PRs, each independently safe to merge because the unpin path is opt-in. This PR ships only the *surface* — the wire server, credential URL rewrite, and `NO_PROXY` workaround all land in [TRUST-113](https://linear.app/n8n/issue/TRUST-113).

## Related Linear tickets, Github issues, and Community forum posts

- Linear: https://linear.app/n8n/issue/TRUST-112
- Parent: https://linear.app/n8n/issue/TRUST-101
- Blocks: https://linear.app/n8n/issue/TRUST-113 (PR 2 — wire server + credential rewrite)
- Master spec: `specs/trust-101-vendor-sdk-interception.md`
- Phasing plan: `specs/trust-101-implementation-phasing.md`

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. Marked `(no-changelog)` — purely additive API surface, no user-visible change at merge.
- [x] Tests included — 12 new unit tests covering exclusion-set behaviour, compatibility refusal matrix (memory + vector store), disabled-sub-node skip, multi-root mixed-compatibility error message, and refuse-path service plumbing. All 57 eval unit tests pass.
- [ ] Docs updated — not applicable; field is opt-in and not yet exposed to UI.
- [ ] PR Labeled with `Backport to *` — not applicable.

## Test plan

- [x] `pnpm test src/modules/instance-ai/eval/__tests__/workflow-analysis.test.ts src/modules/instance-ai/eval/__tests__/execution.service.test.ts` — 57/57 pass
- [x] `@n8n/api-types`: lint clean, typecheck clean, build clean
- [x] `packages/cli` lint on touched files clean; full typecheck identical to clean-master baseline (pre-existing master-level errors in unrelated modules confirmed via stash-and-rerun)