### PR TITLE
fix(Data Table Node): Prevent crash when name mode value is undefined

### DIFF
--- a/packages/nodes-base/nodes/DataTable/common/utils.ts
+++ b/packages/nodes-base/nodes/DataTable/common/utils.ts
@@ -27,10 +27,16 @@ function isDateLike(v: unknown): v is DateLike {
 // Helper function to resolve data table ID from resourceLocator
 export async function resolveDataTableId(
 	ctx: IExecuteFunctions | ILoadOptionsFunctions,
-	resourceLocator: { mode: 'list' | 'id' | 'name'; value: string },
+	resourceLocator: { mode: 'list' | 'id' | 'name'; value?: string },
 ): Promise<string> {
 	if (resourceLocator.mode === 'name') {
 		// Look up table by name
+		if (!resourceLocator.value) {
+			throw new NodeOperationError(
+				ctx.getNode(),
+				'Data table name is required when using "By Name" mode',
+			);
+		}
 		const aggregateProxy = await getDataTableAggregateProxy(ctx);
 		const response = await aggregateProxy.getManyAndCount({
 			filter: { name: resourceLocator.value.toLowerCase() },
@@ -47,6 +53,12 @@ export async function resolveDataTableId(
 		return response.data[0].id;
 	} else {
 		// For 'list' and 'id' modes, use the value from the resource locator
+		if (!resourceLocator.value) {
+			throw new NodeOperationError(
+				ctx.getNode(),
+				`Data table ID is required when using "${resourceLocator.mode}" mode`,
+			);
+		}
 		return resourceLocator.value;
 	}
 }

--- a/packages/nodes-base/nodes/DataTable/test/common/resolveDataTableId.test.ts
+++ b/packages/nodes-base/nodes/DataTable/test/common/resolveDataTableId.test.ts
@@ -132,6 +132,36 @@ describe('resolveDataTableId', () => {
 			});
 		});
 
+		it('should throw error when table name value is undefined', async () => {
+			const ctx = mock<IExecuteFunctions>();
+			ctx.getNode.mockReturnValue(mockNode);
+
+			const resourceLocator = {
+				mode: 'name' as const,
+				value: undefined,
+			};
+
+			await expect(resolveDataTableId(ctx, resourceLocator)).rejects.toThrow(NodeOperationError);
+			await expect(resolveDataTableId(ctx, resourceLocator)).rejects.toThrow(
+				'Data table name is required',
+			);
+		});
+
+		it('should throw error when table name value is empty string', async () => {
+			const ctx = mock<IExecuteFunctions>();
+			ctx.getNode.mockReturnValue(mockNode);
+
+			const resourceLocator = {
+				mode: 'name' as const,
+				value: '',
+			};
+
+			await expect(resolveDataTableId(ctx, resourceLocator)).rejects.toThrow(NodeOperationError);
+			await expect(resolveDataTableId(ctx, resourceLocator)).rejects.toThrow(
+				'Data table name is required',
+			);
+		});
+
 		it('should throw error when table name is not found', async () => {
 			const ctx = mock<IExecuteFunctions>();
 			ctx.getNode.mockReturnValue(mockNode);


### PR DESCRIPTION
## Summary

Fixes #30656 — DataTable node crash when using mode: "name" with a dynamic expression.

## Root Cause

In `resolveDataTableId()`, when `mode: "name"` is used with a dynamic expression that resolves to `undefined`, the code calls `resourceLocator.value.toLowerCase()` which throws `Cannot read properties of undefined (reading 'toLowerCase')`.

## Fix

Added validation in `resolveDataTableId()` to check that `resourceLocator.value` is not empty before accessing it:
- For `name` mode: throws a clear `NodeOperationError` when the name is missing
- For `id` and `list` modes: also validates the value is present (previously would silently pass `undefined`)

## Testing

- Added 2 new test cases for `resolveDataTableId`:
  - undefined value → throws clear error
  - empty string value → throws clear error
- All 10 tests pass
- Typecheck and lint pass