### PR TITLE
feat(core): Wire LLM eval server + credential URL rewrite (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -299,6 +299,7 @@ export {
 	isSafeObjectKey,
 	DEFAULT_INSTANCE_AI_PERMISSIONS,
 	UNLIMITED_CREDITS,
+	EVAL_VENDOR_SDK_INTERCEPTION_FLAG,
 	domainAccessActionSchema,
 	domainAccessMetaSchema,
 	webSearchMetaSchema,

--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -1108,6 +1108,16 @@ export interface InstanceAiEvalMockedCredential {
 }
 
 /**
+ * PostHog kill-switch flag for the eval vendor SDK interception code path.
+ * Defaults to true (rewrite enabled for every caller that opts in via
+ * `unpinNodes`). Flipping to false in PostHog disables the credential URL
+ * rewrite so `EvalMockedCredentialsHelper` reverts to today's behaviour —
+ * the wire server keeps booting but never receives traffic. Fail-open on
+ * PostHog outage: if the flag can't be resolved, treat as enabled.
+ */
+export const EVAL_VENDOR_SDK_INTERCEPTION_FLAG = '085_eval_vendor_sdk_interception';
+
+/**
  * Records a credential field that was rewritten (e.g. routed to the eval wire
  * server) during evaluation. Populated when the caller opts into the unpin
  * path via `InstanceAiEvalExecutionRequest.unpinNodes`. Field added in the

--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -1109,11 +1109,19 @@ export interface InstanceAiEvalMockedCredential {
 
 /**
  * PostHog kill-switch flag for the eval vendor SDK interception code path.
- * Defaults to true (rewrite enabled for every caller that opts in via
- * `unpinNodes`). Flipping to false in PostHog disables the credential URL
- * rewrite so `EvalMockedCredentialsHelper` reverts to today's behaviour —
- * the wire server keeps booting but never receives traffic. Fail-open on
- * PostHog outage: if the flag can't be resolved, treat as enabled.
+ *
+ * Resolution semantics (consult `EvalExecutionService.isInterceptionEnabled`
+ * for the implementation):
+ *   - **Flag set to `true`**, or **unset** (no rule configured in PostHog):
+ *     interception is ENABLED. The flag is default-on; operators flip it to
+ *     `false` to kill the feature in an emergency.
+ *   - **Flag set to `false`**: interception is DISABLED. Requests with
+ *     `unpinNodes` are refused with a clear error so vendor traffic can
+ *     never reach the real provider — the wire server never boots.
+ *   - **Resolution error** (PostHog unreachable/unhealthy): treated as
+ *     DISABLED (fail-closed). A kill-switch must work when the flag plane
+ *     itself is degraded; an outage is the moment to refuse rather than
+ *     silently run the rewrite.
  */
 export const EVAL_VENDOR_SDK_INTERCEPTION_FLAG = '085_eval_vendor_sdk_interception';
 

--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -1155,8 +1155,24 @@ export class InstanceAiEvalExecutionRequest extends Z.class({
 	 * AI root node names (Agent, Chain, etc.) whose sub-nodes should run their
 	 * real vendor SDK code instead of being pinned. The eval pipeline rewrites
 	 * matching credentials so vendor traffic lands on the eval wire server.
-	 * Refused if any sub-node uses a protocol-binary client (e.g. Postgres
-	 * memory) — those cannot be intercepted via HTTP.
+	 *
+	 * The compatibility guard refuses the request up front (no execution
+	 * attempted) when any inbound `ai_*` sub-node of a requested root falls
+	 * into one of these categories:
+	 *   - **Protocol-binary client**: Postgres/Redis/MongoDB memory, native
+	 *     vector stores (PGVector / Mongo / Redis / Milvus). These don't
+	 *     speak HTTP and can't be intercepted by the wire server.
+	 *   - **Unsupported vendor LLM**: any `@n8n/n8n-nodes-langchain.lm*` node
+	 *     not yet on the supported list (currently `lmChatOpenAi` only).
+	 *     These would call the real provider with real credentials because
+	 *     there's no eval URL-rewrite mapping for them.
+	 *   - **Unsafe `options.baseURL` override**: a supported vendor LLM
+	 *     configured with a non-empty `options.baseURL` parameter. The SDK
+	 *     prefers that over the rewritten credential URL, so the override
+	 *     would bypass the wire server.
+	 *
+	 * Refused requests come back as an error-shaped `InstanceAiEvalExecutionResult`
+	 * with the offending root → sub-node pairs listed in `errors`.
 	 */
 	unpinNodes: z.array(z.string().min(1)).max(50).optional(),
 }) {}

--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -1158,7 +1158,7 @@ export class InstanceAiEvalExecutionRequest extends Z.class({
 	 * Refused if any sub-node uses a protocol-binary client (e.g. Postgres
 	 * memory) — those cannot be intercepted via HTTP.
 	 */
-	unpinNodes: z.array(z.string().min(1).max(200)).max(50).optional(),
+	unpinNodes: z.array(z.string().min(1)).max(50).optional(),
 }) {}
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/eval-mocked-credentials-helper.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/eval-mocked-credentials-helper.test.ts
@@ -1,3 +1,4 @@
+import type { Logger } from '@n8n/backend-common';
 import type {
 	ICredentialDataDecryptedObject,
 	ICredentials,
@@ -163,36 +164,33 @@ describe('EvalMockedCredentialsHelper', () => {
 				expect(helper.rewrittenCredentials).toEqual([]);
 			});
 
-			it('logs a warning when serverUrl is set but the credential type is unmapped', async () => {
-				// Spy on the Logger via DI Container so we don't have to mock
-				// the import. Restored in the afterEach via jest.restoreAllMocks.
-				// eslint-disable-next-line @typescript-eslint/no-var-requires
-				const { Container } = require('@n8n/di');
-				// eslint-disable-next-line @typescript-eslint/no-var-requires
-				const { Logger } = require('@n8n/backend-common');
+			it('logs a warning via the injected logger when the credential type is unmapped', async () => {
 				const warn = jest.fn();
-				const originalGet = Container.get.bind(Container);
-				const spy = jest.spyOn(Container, 'get').mockImplementation((token: unknown) => {
-					if (token === Logger) return { warn } as never;
-					return originalGet(token);
+				const inner = makeInner({
+					getDecrypted: jest.fn().mockResolvedValue({ accessToken: 'real-token' }),
 				});
+				const helper = new EvalMockedCredentialsHelper(inner, serverUrl, {
+					warn,
+				} as unknown as Logger);
 
-				try {
-					const inner = makeInner({
-						getDecrypted: jest.fn().mockResolvedValue({ accessToken: 'real-token' }),
-					});
-					const helper = new EvalMockedCredentialsHelper(inner, serverUrl);
+				await helper.getDecrypted(fakeAdditionalData, fakeNodeCreds, 'claudeApi', 'manual', {
+					node: { name: 'Anthropic Chat Model', id: 'a' } as INode,
+				} as IExecuteData);
 
-					await helper.getDecrypted(fakeAdditionalData, fakeNodeCreds, 'claudeApi', 'manual', {
-						node: { name: 'Anthropic Chat Model', id: 'a' } as INode,
-					} as IExecuteData);
+				expect(warn).toHaveBeenCalledTimes(1);
+				expect(warn.mock.calls[0][0]).toContain('claudeApi');
+				expect(warn.mock.calls[0][0]).toContain('Anthropic Chat Model');
+			});
 
-					expect(warn).toHaveBeenCalledTimes(1);
-					expect(warn.mock.calls[0][0]).toContain('claudeApi');
-					expect(warn.mock.calls[0][0]).toContain('Anthropic Chat Model');
-				} finally {
-					spy.mockRestore();
-				}
+			it('is silent on unmapped types when no logger was passed', async () => {
+				const inner = makeInner({
+					getDecrypted: jest.fn().mockResolvedValue({ accessToken: 'real-token' }),
+				});
+				const helper = new EvalMockedCredentialsHelper(inner, serverUrl);
+
+				await expect(
+					helper.getDecrypted(fakeAdditionalData, fakeNodeCreds, 'claudeApi', 'manual'),
+				).resolves.toEqual({ accessToken: 'real-token' });
 			});
 
 			it('is a no-op when serverUrl is undefined (today’s default path)', async () => {

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/eval-mocked-credentials-helper.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/eval-mocked-credentials-helper.test.ts
@@ -97,6 +97,160 @@ describe('EvalMockedCredentialsHelper', () => {
 
 			expect(helper.mockedCredentials[0].nodeName).toBe('unknown');
 		});
+
+		describe('server URL rewrite', () => {
+			const serverUrl = 'http://127.0.0.1:55555';
+			const openAiCreds: INodeCredentialsDetails = { id: 'cred-1', name: 'OpenAI cred' };
+			const openAiNode = { name: 'OpenAI Chat Model', id: 'node-9' } as INode;
+
+			it('rewrites the URL field on openAiApi credentials when serverUrl is set', async () => {
+				const inner = makeInner({
+					getDecrypted: jest
+						.fn()
+						.mockResolvedValue({ apiKey: 'sk-real', url: 'https://api.openai.com/v1' }),
+				});
+				const helper = new EvalMockedCredentialsHelper(inner, serverUrl);
+
+				const result = await helper.getDecrypted(
+					fakeAdditionalData,
+					openAiCreds,
+					'openAiApi',
+					'manual',
+					{ node: openAiNode } as IExecuteData,
+				);
+
+				expect(result).toEqual({ apiKey: 'sk-real', url: serverUrl });
+				expect(helper.rewrittenCredentials).toEqual([
+					{
+						nodeName: 'OpenAI Chat Model',
+						credentialType: 'openAiApi',
+						credentialId: 'cred-1',
+						field: 'url',
+					},
+				]);
+			});
+
+			it('does not mutate the credential returned by the inner helper', async () => {
+				const original = { apiKey: 'sk-real', url: 'https://api.openai.com/v1' };
+				const inner = makeInner({ getDecrypted: jest.fn().mockResolvedValue(original) });
+				const helper = new EvalMockedCredentialsHelper(inner, serverUrl);
+
+				const result = await helper.getDecrypted(
+					fakeAdditionalData,
+					openAiCreds,
+					'openAiApi',
+					'manual',
+				);
+
+				expect(original).toEqual({ apiKey: 'sk-real', url: 'https://api.openai.com/v1' });
+				expect(result).not.toBe(original);
+			});
+
+			it('does not rewrite credentials of an unmapped type', async () => {
+				const inner = makeInner({
+					getDecrypted: jest.fn().mockResolvedValue({ accessToken: 'real-token' }),
+				});
+				const helper = new EvalMockedCredentialsHelper(inner, serverUrl);
+
+				const result = await helper.getDecrypted(
+					fakeAdditionalData,
+					fakeNodeCreds,
+					'telegramApi',
+					'manual',
+				);
+
+				expect(result).toEqual({ accessToken: 'real-token' });
+				expect(helper.rewrittenCredentials).toEqual([]);
+			});
+
+			it('logs a warning when serverUrl is set but the credential type is unmapped', async () => {
+				// Spy on the Logger via DI Container so we don't have to mock
+				// the import. Restored in the afterEach via jest.restoreAllMocks.
+				// eslint-disable-next-line @typescript-eslint/no-var-requires
+				const { Container } = require('@n8n/di');
+				// eslint-disable-next-line @typescript-eslint/no-var-requires
+				const { Logger } = require('@n8n/backend-common');
+				const warn = jest.fn();
+				const originalGet = Container.get.bind(Container);
+				const spy = jest.spyOn(Container, 'get').mockImplementation((token: unknown) => {
+					if (token === Logger) return { warn } as never;
+					return originalGet(token);
+				});
+
+				try {
+					const inner = makeInner({
+						getDecrypted: jest.fn().mockResolvedValue({ accessToken: 'real-token' }),
+					});
+					const helper = new EvalMockedCredentialsHelper(inner, serverUrl);
+
+					await helper.getDecrypted(fakeAdditionalData, fakeNodeCreds, 'claudeApi', 'manual', {
+						node: { name: 'Anthropic Chat Model', id: 'a' } as INode,
+					} as IExecuteData);
+
+					expect(warn).toHaveBeenCalledTimes(1);
+					expect(warn.mock.calls[0][0]).toContain('claudeApi');
+					expect(warn.mock.calls[0][0]).toContain('Anthropic Chat Model');
+				} finally {
+					spy.mockRestore();
+				}
+			});
+
+			it('is a no-op when serverUrl is undefined (today’s default path)', async () => {
+				const inner = makeInner({
+					getDecrypted: jest
+						.fn()
+						.mockResolvedValue({ apiKey: 'sk-real', url: 'https://api.openai.com/v1' }),
+				});
+				const helper = new EvalMockedCredentialsHelper(inner);
+
+				const result = await helper.getDecrypted(
+					fakeAdditionalData,
+					openAiCreds,
+					'openAiApi',
+					'manual',
+				);
+
+				expect(result).toEqual({ apiKey: 'sk-real', url: 'https://api.openai.com/v1' });
+				expect(helper.rewrittenCredentials).toEqual([]);
+			});
+
+			it('rewrites the URL on the marker stub when the credential is missing', async () => {
+				const inner = makeInner({
+					getDecrypted: jest
+						.fn()
+						.mockRejectedValue(new CredentialNotFoundError('cred-1', 'openAiApi')),
+				});
+				const helper = new EvalMockedCredentialsHelper(inner, serverUrl);
+
+				const result = await helper.getDecrypted(
+					fakeAdditionalData,
+					openAiCreds,
+					'openAiApi',
+					'manual',
+					{ node: openAiNode } as IExecuteData,
+				);
+
+				expect(result).toEqual({ __evalMockedCredential: true, url: serverUrl });
+				expect(helper.mockedCredentials).toHaveLength(1);
+				expect(helper.rewrittenCredentials).toHaveLength(1);
+			});
+
+			it('records each rewrite in order across multiple calls', async () => {
+				const inner = makeInner({
+					getDecrypted: jest.fn().mockResolvedValue({ apiKey: 'sk-real', url: 'real' }),
+				});
+				const helper = new EvalMockedCredentialsHelper(inner, serverUrl);
+
+				await helper.getDecrypted(fakeAdditionalData, openAiCreds, 'openAiApi', 'manual', {
+					node: { name: 'A', id: 'a' } as INode,
+				} as IExecuteData);
+				await helper.getDecrypted(fakeAdditionalData, openAiCreds, 'openAiApi', 'manual', {
+					node: { name: 'B', id: 'b' } as INode,
+				} as IExecuteData);
+
+				expect(helper.rewrittenCredentials.map((r) => r.nodeName)).toEqual(['A', 'B']);
+			});
+		});
 	});
 
 	describe('authenticate', () => {

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/eval-mocked-credentials-helper.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/eval-mocked-credentials-helper.test.ts
@@ -120,7 +120,11 @@ describe('EvalMockedCredentialsHelper', () => {
 					{ node: openAiNode } as IExecuteData,
 				);
 
-				expect(result).toEqual({ apiKey: 'sk-real', url: serverUrl });
+				// /v1 must stay on the rewritten URL — the LangChain OpenAI node
+				// uses this verbatim as the SDK's `baseURL`, and the SDK appends
+				// `/chat/completions`. A bare server URL would miss the wire-server
+				// route. See LmChatOpenAi.node.ts:765.
+				expect(result).toEqual({ apiKey: 'sk-real', url: `${serverUrl}/v1` });
 				expect(helper.rewrittenCredentials).toEqual([
 					{
 						nodeName: 'OpenAI Chat Model',
@@ -228,7 +232,7 @@ describe('EvalMockedCredentialsHelper', () => {
 					{ node: openAiNode } as IExecuteData,
 				);
 
-				expect(result).toEqual({ __evalMockedCredential: true, url: serverUrl });
+				expect(result).toEqual({ __evalMockedCredential: true, url: `${serverUrl}/v1` });
 				expect(helper.mockedCredentials).toHaveLength(1);
 				expect(helper.rewrittenCredentials).toHaveLength(1);
 			});

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/execution.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/execution.service.test.ts
@@ -11,6 +11,7 @@ import type {
 
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import type { NodeTypes } from '@/node-types';
+import type { PostHogClient } from '@/posthog';
 
 // ---------------------------------------------------------------------------
 // Mocks — must be before the import of the class under test
@@ -31,6 +32,19 @@ jest.mock('../workflow-analysis', () => ({
 	generateMockHints: jest.fn(),
 	identifyNodesForHints: jest.fn(),
 	identifyNodesForPinData: jest.fn(),
+}));
+const mockWireServerStart = jest.fn();
+const mockWireServerStop = jest.fn();
+jest.mock('../llm-wire-server', () => ({
+	LlmWireServer: jest.fn().mockImplementation(() => ({
+		start: mockWireServerStart,
+		stop: mockWireServerStop,
+		url: 'http://127.0.0.1:54321',
+	})),
+}));
+const mockRestoreNoProxy = jest.fn();
+jest.mock('../proxy-loopback', () => ({
+	patchNoProxyForLoopback: jest.fn(() => mockRestoreNoProxy),
 }));
 jest.mock('@n8n/workflow-sdk', () => ({
 	normalizePinData: jest.fn((pd: unknown) => pd),
@@ -172,11 +186,12 @@ describe('EvalExecutionService', () => {
 	const workflowFinderService = mock<WorkflowFinderService>();
 	const nodeTypes = mock<NodeTypes>();
 	const logger = mock<Logger>();
+	const postHogClient = mock<PostHogClient>();
 
 	beforeEach(() => {
 		jest.clearAllMocks();
 
-		service = new EvalExecutionService(workflowFinderService, nodeTypes, logger);
+		service = new EvalExecutionService(workflowFinderService, nodeTypes, logger, postHogClient);
 
 		// Default mock returns — happy path
 		identifyNodesForHintsMock.mockReturnValue([]);
@@ -186,6 +201,10 @@ describe('EvalExecutionService', () => {
 		createLlmMockHandlerMock.mockReturnValue(jest.fn());
 		mockGetStartNode.mockReturnValue(makeStartNode());
 		mockProcessRunExecutionData.mockResolvedValue(makeIRun());
+		mockWireServerStart.mockResolvedValue('http://127.0.0.1:54321');
+		mockWireServerStop.mockResolvedValue(undefined);
+		// Default: kill-switch enabled. Tests that need it off flip this.
+		postHogClient.getFeatureFlags.mockResolvedValue({});
 
 		// NodeTypes.getByNameAndVersion returns a minimal node type with no webhook
 		nodeTypes.getByNameAndVersion.mockReturnValue({
@@ -306,20 +325,26 @@ describe('EvalExecutionService', () => {
 			);
 		});
 
-		// Safety gate: this PR ships the surface only. Non-empty `unpinNodes`
-		// must not run until TRUST-113 wires the credential rewrite + wire
-		// server, or the workflow would hit real provider APIs.
-		describe('safety gate (no rewriter wired)', () => {
-			it('runs the compatibility guard, then refuses with the gate error when the guard passes', async () => {
+		// PostHog kill-switch: non-empty unpinNodes only runs when the flag
+		// resolves to ON. Flag OFF refuses the request before any other work
+		// so vendor traffic can never reach the real provider.
+		describe('PostHog kill-switch (flag off)', () => {
+			beforeEach(() => {
+				postHogClient.getFeatureFlags.mockResolvedValue({
+					'085_eval_vendor_sdk_interception': false,
+				});
+			});
+
+			it('runs the compatibility guard first, then refuses with the gate error when the guard passes', async () => {
 				const result = await service.executeWithLlmMock('wf-1', makeUser(), {
 					unpinNodes: ['Agent'],
 				});
 
 				expect(result.success).toBe(false);
-				expect(result.errors).toEqual([expect.stringContaining('not yet enabled')]);
+				expect(result.errors).toEqual([expect.stringContaining('currently disabled')]);
 				// Guard runs first so the user gets actionable diagnostics when their
 				// workflow has a permanent compatibility issue. When the guard passes,
-				// the gate fires with the generic "not yet enabled" message.
+				// the gate fires with the generic "currently disabled" message.
 				expect(assertUnpinCompatibilityMock).toHaveBeenCalledWith(
 					expect.objectContaining({ id: 'wf-1' }),
 					['Agent'],
@@ -344,23 +369,113 @@ describe('EvalExecutionService', () => {
 				// Guard's protocol-binary message wins over the generic gate message —
 				// the user needs to fix the workflow regardless of when the feature ships.
 				expect(result.errors).toEqual([expect.stringContaining('memoryPostgresChat')]);
-				expect(result.errors[0]).not.toContain('not yet enabled');
+				expect(result.errors[0]).not.toContain('currently disabled');
+				// Guard refused before the PostHog check fires.
+				expect(postHogClient.getFeatureFlags).not.toHaveBeenCalled();
 			});
 
-			it('refuses regardless of how many roots are requested', async () => {
+			it('still runs the normal pinned path when unpinNodes is omitted (no flag check)', async () => {
+				await service.executeWithLlmMock('wf-1', makeUser());
+
+				expect(postHogClient.getFeatureFlags).not.toHaveBeenCalled();
+				expect(generateMockHintsMock).toHaveBeenCalled();
+				expect(mockProcessRunExecutionData).toHaveBeenCalled();
+			});
+		});
+
+		// Flag ON (or unset — fail-open default): non-empty unpinNodes proceeds
+		// into the rewrite path and boots the wire server.
+		describe('PostHog kill-switch (flag on)', () => {
+			it('forwards unpinNodes to assertUnpinCompatibility', async () => {
+				await service.executeWithLlmMock('wf-1', makeUser(), { unpinNodes: ['Agent'] });
+
+				expect(assertUnpinCompatibilityMock).toHaveBeenCalledWith(
+					expect.objectContaining({ id: 'wf-1' }),
+					['Agent'],
+				);
+			});
+
+			it('forwards the exclusion set to identifyNodesForPinData', async () => {
+				await service.executeWithLlmMock('wf-1', makeUser(), { unpinNodes: ['Agent'] });
+
+				expect(identifyNodesForPinDataMock).toHaveBeenCalledWith(
+					expect.objectContaining({ id: 'wf-1' }),
+					new Set(['Agent']),
+				);
+			});
+
+			it('boots and tears down the wire server around the workflow run', async () => {
+				await service.executeWithLlmMock('wf-1', makeUser(), { unpinNodes: ['Agent'] });
+
+				expect(mockWireServerStart).toHaveBeenCalledTimes(1);
+				expect(mockProcessRunExecutionData).toHaveBeenCalledTimes(1);
+				expect(mockWireServerStop).toHaveBeenCalledTimes(1);
+				expect(mockRestoreNoProxy).toHaveBeenCalledTimes(1);
+			});
+
+			it('tears down the wire server even if the workflow run throws', async () => {
+				mockProcessRunExecutionData.mockRejectedValue(new Error('explode'));
+
 				const result = await service.executeWithLlmMock('wf-1', makeUser(), {
-					unpinNodes: ['A', 'B', 'C'],
+					unpinNodes: ['Agent'],
 				});
 
 				expect(result.success).toBe(false);
-				expect(result.errors[0]).toContain('unpinNodes');
+				expect(mockWireServerStop).toHaveBeenCalledTimes(1);
+				expect(mockRestoreNoProxy).toHaveBeenCalledTimes(1);
 			});
 
-			it('still runs the workflow when unpinNodes is omitted', async () => {
-				await service.executeWithLlmMock('wf-1', makeUser());
+			it('does not boot the wire server when unpinNodes is empty', async () => {
+				await service.executeWithLlmMock('wf-1', makeUser(), { unpinNodes: [] });
 
-				expect(generateMockHintsMock).toHaveBeenCalled();
-				expect(mockProcessRunExecutionData).toHaveBeenCalled();
+				expect(mockWireServerStart).not.toHaveBeenCalled();
+				expect(mockWireServerStop).not.toHaveBeenCalled();
+			});
+
+			it('fails closed when PostHog rejects (treats flag as off and refuses the request)', async () => {
+				postHogClient.getFeatureFlags.mockRejectedValue(new Error('PostHog down'));
+
+				const result = await service.executeWithLlmMock('wf-1', makeUser(), {
+					unpinNodes: ['Agent'],
+				});
+
+				expect(result.success).toBe(false);
+				expect(result.errors).toEqual([expect.stringContaining('currently disabled')]);
+				expect(mockWireServerStart).not.toHaveBeenCalled();
+			});
+
+			it('tears down the wire server when NO_PROXY patching throws after boot', async () => {
+				const proxyLoopback = require('../proxy-loopback');
+				proxyLoopback.patchNoProxyForLoopback.mockImplementationOnce(() => {
+					throw new Error('env mutation blocked');
+				});
+
+				const result = await service.executeWithLlmMock('wf-1', makeUser(), {
+					unpinNodes: ['Agent'],
+				});
+
+				expect(result.success).toBe(false);
+				expect(result.errors).toEqual([expect.stringContaining('env mutation blocked')]);
+				expect(mockWireServerStart).toHaveBeenCalledTimes(1);
+				expect(mockWireServerStop).toHaveBeenCalledTimes(1);
+			});
+
+			it('returns an error result and skips workflow execution when the compatibility guard refuses', async () => {
+				assertUnpinCompatibilityMock.mockImplementation(() => {
+					throw new (require('n8n-workflow').UserError)(
+						'Cannot unpin "Agent" — incompatible memory backend',
+					);
+				});
+
+				const result = await service.executeWithLlmMock('wf-1', makeUser(), {
+					unpinNodes: ['Agent'],
+				});
+
+				expect(result.success).toBe(false);
+				expect(result.errors).toEqual([expect.stringContaining('Cannot unpin "Agent"')]);
+				expect(mockProcessRunExecutionData).not.toHaveBeenCalled();
+				// Server was never started — guard runs before boot.
+				expect(mockWireServerStart).not.toHaveBeenCalled();
 			});
 		});
 	});

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/llm-wire-server.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/llm-wire-server.test.ts
@@ -1,0 +1,118 @@
+import { LlmWireServer } from '../llm-wire-server';
+
+async function postChatCompletion(url: string, body: unknown): Promise<Response> {
+	return await fetch(`${url}/v1/chat/completions`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(body),
+	});
+}
+
+describe('LlmWireServer', () => {
+	let server: LlmWireServer;
+
+	beforeEach(() => {
+		server = new LlmWireServer();
+	});
+
+	afterEach(async () => {
+		await server.stop();
+	});
+
+	describe('lifecycle', () => {
+		it('binds to 127.0.0.1 on an OS-assigned port', async () => {
+			const url = await server.start();
+			expect(url).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+			expect(server.url).toBe(url);
+		});
+
+		it('start() is idempotent — second call returns the same URL', async () => {
+			const url1 = await server.start();
+			const url2 = await server.start();
+			expect(url2).toBe(url1);
+		});
+
+		it('stop() is a no-op when the server was never started', async () => {
+			await expect(server.stop()).resolves.toBeUndefined();
+		});
+
+		it('throws when url is accessed before start() resolves', () => {
+			expect(() => server.url).toThrow('start() resolved');
+		});
+
+		it('binds two independent instances to different ports', async () => {
+			const second = new LlmWireServer();
+			try {
+				const urlA = await server.start();
+				const urlB = await second.start();
+				expect(urlA).not.toBe(urlB);
+			} finally {
+				await second.stop();
+			}
+		});
+	});
+
+	describe('POST /v1/chat/completions', () => {
+		it('returns a 200 with a chat.completion envelope', async () => {
+			const url = await server.start();
+
+			const response = await postChatCompletion(url, {
+				model: 'gpt-4o-mini',
+				messages: [{ role: 'user', content: 'hello' }],
+			});
+			const body = (await response.json()) as Record<string, unknown>;
+
+			expect(response.status).toBe(200);
+			expect(body.object).toBe('chat.completion');
+			expect(body.model).toBe('gpt-4o-mini');
+			expect(typeof body.id).toBe('string');
+			expect(Array.isArray(body.choices)).toBe(true);
+		});
+
+		it('echoes the request model in the response', async () => {
+			const url = await server.start();
+
+			const response = await postChatCompletion(url, {
+				model: 'gpt-5',
+				messages: [],
+			});
+			const body = (await response.json()) as Record<string, unknown>;
+
+			expect(body.model).toBe('gpt-5');
+		});
+
+		it('falls back to a default model when the body omits one', async () => {
+			const url = await server.start();
+
+			const response = await postChatCompletion(url, { messages: [] });
+			const body = (await response.json()) as Record<string, unknown>;
+
+			expect(body.model).toBe('gpt-4o-mini');
+		});
+
+		it('includes a single assistant choice with finish_reason="stop"', async () => {
+			const url = await server.start();
+
+			const response = await postChatCompletion(url, {
+				model: 'gpt-4o',
+				messages: [{ role: 'user', content: 'ping' }],
+			});
+			const body = (await response.json()) as {
+				choices: Array<{
+					index: number;
+					message: { role: string; content: string };
+					finish_reason: string;
+				}>;
+			};
+
+			expect(body.choices).toHaveLength(1);
+			expect(body.choices[0]).toEqual(
+				expect.objectContaining({
+					index: 0,
+					message: expect.objectContaining({ role: 'assistant' }),
+					finish_reason: 'stop',
+				}),
+			);
+		});
+	});
+});

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/m1-rewrite-roundtrip.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/m1-rewrite-roundtrip.test.ts
@@ -47,7 +47,7 @@ describe('TRUST-113 M1: helper + wire server end-to-end rewrite', () => {
 		} as ICredentialsHelper;
 	}
 
-	it('rewrites the openAiApi base URL to the running wire server', async () => {
+	it('rewrites the openAiApi base URL to the wire server with the /v1 path', async () => {
 		const realCreds: ICredentialDataDecryptedObject = {
 			apiKey: 'sk-real-secret',
 			url: 'https://api.openai.com/v1',
@@ -63,7 +63,7 @@ describe('TRUST-113 M1: helper + wire server end-to-end rewrite', () => {
 			{ node: { name: 'OpenAI Chat Model', id: 'node-1' } as INode } as IExecuteData,
 		);
 
-		expect(result.url).toBe(server.url);
+		expect(result.url).toBe(`${server.url}/v1`);
 		expect(result.apiKey).toBe('sk-real-secret');
 		expect(helper.rewrittenCredentials).toEqual([
 			{
@@ -75,7 +75,7 @@ describe('TRUST-113 M1: helper + wire server end-to-end rewrite', () => {
 		]);
 	});
 
-	it('a POST to the rewritten URL returns a usable chat-completion envelope', async () => {
+	it('mirrors the OpenAI SDK baseURL contract — appending /chat/completions reaches the wire server', async () => {
 		const realCreds: ICredentialDataDecryptedObject = {
 			apiKey: 'sk-real-secret',
 			url: 'https://api.openai.com/v1',
@@ -91,7 +91,12 @@ describe('TRUST-113 M1: helper + wire server end-to-end rewrite', () => {
 			{ node: { name: 'OpenAI Chat Model', id: 'node-1' } as INode } as IExecuteData,
 		);
 
-		const response = await fetch(`${String(rewritten.url)}/v1/chat/completions`, {
+		// Mirror the LangChain OpenAI node behaviour: `credentials.url` becomes
+		// the SDK's `baseURL` verbatim (LmChatOpenAi.node.ts:765), and the SDK
+		// appends `/chat/completions`. So this is the exact URL the SDK would
+		// post to — if the rewrite were missing `/v1`, this would 404.
+		const baseUrl = String(rewritten.url);
+		const response = await fetch(`${baseUrl}/chat/completions`, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/m1-rewrite-roundtrip.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/m1-rewrite-roundtrip.test.ts
@@ -1,0 +1,127 @@
+import type {
+	ICredentialDataDecryptedObject,
+	ICredentialsHelper,
+	IExecuteData,
+	INode,
+	INodeCredentialsDetails,
+	IWorkflowExecuteAdditionalData,
+} from 'n8n-workflow';
+
+import { EvalMockedCredentialsHelper } from '../eval-mocked-credentials-helper';
+import { LlmWireServer } from '../llm-wire-server';
+
+/**
+ * M1 acceptance fixture (mechanism). Proves end-to-end that:
+ *   1. `LlmWireServer` boots on a real loopback port.
+ *   2. `EvalMockedCredentialsHelper` rewrites the resolved `openAiApi`
+ *      credential's `url` field to that exact URL.
+ *   3. A POST against the rewritten URL hits the live server and gets back a
+ *      well-formed OpenAI chat-completion envelope.
+ *
+ * The full LangChain SDK round-trip (vendor SDK as the caller, not raw fetch)
+ * lands in TRUST-115's M3 fixture — see the master spec.
+ */
+describe('TRUST-113 M1: helper + wire server end-to-end rewrite', () => {
+	let server: LlmWireServer;
+
+	beforeEach(async () => {
+		server = new LlmWireServer();
+		await server.start();
+	});
+
+	afterEach(async () => {
+		await server.stop();
+	});
+
+	function makeInner(credentials: ICredentialDataDecryptedObject): ICredentialsHelper {
+		return {
+			getParentTypes: jest.fn().mockReturnValue([]),
+			authenticate: jest.fn(),
+			preAuthentication: jest.fn(),
+			runPreAuthentication: jest.fn(),
+			getCredentials: jest.fn(),
+			getDecrypted: jest.fn().mockResolvedValue(credentials),
+			updateCredentials: jest.fn(),
+			updateCredentialsOauthTokenData: jest.fn(),
+			getCredentialsProperties: jest.fn().mockReturnValue([]),
+		} as ICredentialsHelper;
+	}
+
+	it('rewrites the openAiApi base URL to the running wire server', async () => {
+		const realCreds: ICredentialDataDecryptedObject = {
+			apiKey: 'sk-real-secret',
+			url: 'https://api.openai.com/v1',
+		};
+		const helper = new EvalMockedCredentialsHelper(makeInner(realCreds), server.url);
+		const nodeCreds: INodeCredentialsDetails = { id: 'cred-1', name: 'OpenAI' };
+
+		const result = await helper.getDecrypted(
+			{} as IWorkflowExecuteAdditionalData,
+			nodeCreds,
+			'openAiApi',
+			'manual',
+			{ node: { name: 'OpenAI Chat Model', id: 'node-1' } as INode } as IExecuteData,
+		);
+
+		expect(result.url).toBe(server.url);
+		expect(result.apiKey).toBe('sk-real-secret');
+		expect(helper.rewrittenCredentials).toEqual([
+			{
+				nodeName: 'OpenAI Chat Model',
+				credentialType: 'openAiApi',
+				credentialId: 'cred-1',
+				field: 'url',
+			},
+		]);
+	});
+
+	it('a POST to the rewritten URL returns a usable chat-completion envelope', async () => {
+		const realCreds: ICredentialDataDecryptedObject = {
+			apiKey: 'sk-real-secret',
+			url: 'https://api.openai.com/v1',
+		};
+		const helper = new EvalMockedCredentialsHelper(makeInner(realCreds), server.url);
+		const nodeCreds: INodeCredentialsDetails = { id: 'cred-1', name: 'OpenAI' };
+
+		const rewritten = await helper.getDecrypted(
+			{} as IWorkflowExecuteAdditionalData,
+			nodeCreds,
+			'openAiApi',
+			'manual',
+			{ node: { name: 'OpenAI Chat Model', id: 'node-1' } as INode } as IExecuteData,
+		);
+
+		const response = await fetch(`${String(rewritten.url)}/v1/chat/completions`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({
+				model: 'gpt-4o-mini',
+				messages: [{ role: 'user', content: 'M1 mechanism check' }],
+			}),
+		});
+		const body = (await response.json()) as {
+			object: string;
+			model: string;
+			choices: Array<{ message: { role: string; content: string }; finish_reason: string }>;
+		};
+
+		expect(response.status).toBe(200);
+		expect(body.object).toBe('chat.completion');
+		expect(body.choices[0].message.role).toBe('assistant');
+	});
+
+	it('leaves the URL alone for credential types not in the provider map', async () => {
+		const realCreds: ICredentialDataDecryptedObject = { accessToken: 'real-token' };
+		const helper = new EvalMockedCredentialsHelper(makeInner(realCreds), server.url);
+
+		const result = await helper.getDecrypted(
+			{} as IWorkflowExecuteAdditionalData,
+			{ id: 'cred-2', name: 'Telegram' },
+			'telegramApi',
+			'manual',
+		);
+
+		expect(result).toEqual({ accessToken: 'real-token' });
+		expect(helper.rewrittenCredentials).toEqual([]);
+	});
+});

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/proxy-loopback.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/proxy-loopback.test.ts
@@ -1,0 +1,77 @@
+import { patchNoProxyForLoopback } from '../proxy-loopback';
+
+describe('patchNoProxyForLoopback', () => {
+	const originalNoProxy = process.env.NO_PROXY;
+
+	afterEach(() => {
+		if (originalNoProxy === undefined) {
+			delete process.env.NO_PROXY;
+		} else {
+			process.env.NO_PROXY = originalNoProxy;
+		}
+	});
+
+	it('sets NO_PROXY to the loopback entries when previously undefined', () => {
+		delete process.env.NO_PROXY;
+
+		const restore = patchNoProxyForLoopback();
+
+		expect(process.env.NO_PROXY).toBe('127.0.0.1,localhost');
+
+		restore();
+		expect(process.env.NO_PROXY).toBeUndefined();
+	});
+
+	it('sets NO_PROXY to the loopback entries when previously empty', () => {
+		process.env.NO_PROXY = '';
+
+		const restore = patchNoProxyForLoopback();
+
+		expect(process.env.NO_PROXY).toBe('127.0.0.1,localhost');
+
+		restore();
+		expect(process.env.NO_PROXY).toBe('');
+	});
+
+	it('prepends loopback entries while preserving existing entries', () => {
+		process.env.NO_PROXY = 'example.com,internal.net';
+
+		const restore = patchNoProxyForLoopback();
+
+		expect(process.env.NO_PROXY).toBe('127.0.0.1,localhost,example.com,internal.net');
+
+		restore();
+		expect(process.env.NO_PROXY).toBe('example.com,internal.net');
+	});
+
+	it('leaves NO_PROXY unchanged when both loopback entries are already present', () => {
+		process.env.NO_PROXY = '127.0.0.1, localhost, example.com';
+
+		const restore = patchNoProxyForLoopback();
+
+		expect(process.env.NO_PROXY).toBe('127.0.0.1, localhost, example.com');
+
+		restore();
+		expect(process.env.NO_PROXY).toBe('127.0.0.1, localhost, example.com');
+	});
+
+	it('prepends if only one of the loopback entries is present', () => {
+		process.env.NO_PROXY = '127.0.0.1';
+
+		const restore = patchNoProxyForLoopback();
+
+		expect(process.env.NO_PROXY).toBe('127.0.0.1,localhost,127.0.0.1');
+
+		restore();
+		expect(process.env.NO_PROXY).toBe('127.0.0.1');
+	});
+
+	it('restore closure resets to undefined when env var was unset', () => {
+		delete process.env.NO_PROXY;
+
+		const restore = patchNoProxyForLoopback();
+		restore();
+
+		expect(Object.prototype.hasOwnProperty.call(process.env, 'NO_PROXY')).toBe(false);
+	});
+});

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/proxy-loopback.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/proxy-loopback.test.ts
@@ -74,4 +74,70 @@ describe('patchNoProxyForLoopback', () => {
 
 		expect(Object.prototype.hasOwnProperty.call(process.env, 'NO_PROXY')).toBe(false);
 	});
+
+	describe('overlapping (reference-counted) patches', () => {
+		it('keeps the loopback exemption in place until every overlapping caller restores', () => {
+			process.env.NO_PROXY = 'example.com';
+
+			const restoreA = patchNoProxyForLoopback();
+			expect(process.env.NO_PROXY).toBe('127.0.0.1,localhost,example.com');
+
+			const restoreB = patchNoProxyForLoopback();
+			// Second call must not snapshot the *already patched* value, otherwise
+			// restoring would leave the loopback entries permanently.
+			expect(process.env.NO_PROXY).toBe('127.0.0.1,localhost,example.com');
+
+			restoreA();
+			// A is done, but B is still running — env must stay patched.
+			expect(process.env.NO_PROXY).toBe('127.0.0.1,localhost,example.com');
+
+			restoreB();
+			// All overlapping evals done — env reverts to the operator's value.
+			expect(process.env.NO_PROXY).toBe('example.com');
+		});
+
+		it('each restore closure is idempotent', () => {
+			process.env.NO_PROXY = 'example.com';
+
+			const restoreA = patchNoProxyForLoopback();
+			const restoreB = patchNoProxyForLoopback();
+
+			restoreA();
+			restoreA(); // duplicate call must not double-decrement
+			expect(process.env.NO_PROXY).toBe('127.0.0.1,localhost,example.com');
+
+			restoreB();
+			expect(process.env.NO_PROXY).toBe('example.com');
+		});
+
+		it('handles undefined original across overlapping patches', () => {
+			delete process.env.NO_PROXY;
+
+			const restoreA = patchNoProxyForLoopback();
+			const restoreB = patchNoProxyForLoopback();
+			expect(process.env.NO_PROXY).toBe('127.0.0.1,localhost');
+
+			restoreB();
+			expect(process.env.NO_PROXY).toBe('127.0.0.1,localhost');
+
+			restoreA();
+			expect(Object.prototype.hasOwnProperty.call(process.env, 'NO_PROXY')).toBe(false);
+		});
+
+		it('after every closure fires, a fresh patch starts a new snapshot', () => {
+			process.env.NO_PROXY = 'first.example.com';
+			const restore1 = patchNoProxyForLoopback();
+			restore1();
+			expect(process.env.NO_PROXY).toBe('first.example.com');
+
+			// Operator changes NO_PROXY between eval runs — the next patch should
+			// snapshot the new value, not the original from the previous cycle.
+			process.env.NO_PROXY = 'second.example.com';
+			const restore2 = patchNoProxyForLoopback();
+			expect(process.env.NO_PROXY).toBe('127.0.0.1,localhost,second.example.com');
+
+			restore2();
+			expect(process.env.NO_PROXY).toBe('second.example.com');
+		});
+	});
 });

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/workflow-analysis.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/workflow-analysis.test.ts
@@ -8,7 +8,7 @@ jest.mock('../node-config', () => ({
 }));
 
 import { createEvalAgent, extractText } from '@n8n/instance-ai';
-import type { IConnections, INode, IWorkflowBase } from 'n8n-workflow';
+import type { IConnections, INode, INodeParameters, IWorkflowBase } from 'n8n-workflow';
 
 import {
 	assertUnpinCompatibility,
@@ -427,7 +427,7 @@ describe('assertUnpinCompatibility', () => {
 		});
 
 		describe('lmChatOpenAi options.baseURL override', () => {
-			function agentWithOpenAi(parameters: Record<string, unknown>) {
+			function agentWithOpenAi(parameters: INodeParameters) {
 				const nodes = [
 					makeNode({
 						name: 'OpenAI',

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/workflow-analysis.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/workflow-analysis.test.ts
@@ -425,6 +425,109 @@ describe('assertUnpinCompatibility', () => {
 				assertUnpinCompatibility(makeWorkflow(nodes, connections), ['Agent']),
 			).not.toThrow();
 		});
+
+		describe('lmChatOpenAi options.baseURL override', () => {
+			function agentWithOpenAi(parameters: Record<string, unknown>) {
+				const nodes = [
+					makeNode({
+						name: 'OpenAI',
+						type: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+						parameters,
+					}),
+					makeNode({ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+				];
+				const connections: IConnections = {
+					OpenAI: { ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 0 }]] },
+				};
+				return makeWorkflow(nodes, connections);
+			}
+
+			it('allows lmChatOpenAi with no options', () => {
+				const workflow = agentWithOpenAi({});
+				expect(() => assertUnpinCompatibility(workflow, ['Agent'])).not.toThrow();
+			});
+
+			it('allows lmChatOpenAi with empty options.baseURL', () => {
+				const workflow = agentWithOpenAi({ options: { baseURL: '' } });
+				expect(() => assertUnpinCompatibility(workflow, ['Agent'])).not.toThrow();
+			});
+
+			it('allows lmChatOpenAi when options.baseURL is whitespace-only', () => {
+				const workflow = agentWithOpenAi({ options: { baseURL: '   ' } });
+				expect(() => assertUnpinCompatibility(workflow, ['Agent'])).not.toThrow();
+			});
+
+			it('refuses lmChatOpenAi when options.baseURL is set — credential rewrite would be bypassed', () => {
+				const workflow = agentWithOpenAi({
+					options: { baseURL: 'https://my-proxy.example.com/v1' },
+				});
+
+				let thrown: unknown;
+				try {
+					assertUnpinCompatibility(workflow, ['Agent']);
+				} catch (e) {
+					thrown = e;
+				}
+
+				expect(thrown).toBeInstanceOf(UserError);
+				const message = (thrown as UserError).message;
+				expect(message).toContain('options.baseURL');
+				expect(message).toContain('"OpenAI"');
+				expect(message).not.toContain('unsupported vendor LLM');
+			});
+
+			it('groups baseURL-override refusals alongside protocol-binary refusals', () => {
+				const nodes = [
+					makeNode({
+						name: 'OpenAI',
+						type: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+						parameters: { options: { baseURL: 'https://my-proxy.example.com/v1' } },
+					}),
+					makeNode({
+						name: 'PgMem',
+						type: '@n8n/n8n-nodes-langchain.memoryPostgresChat',
+					}),
+					makeNode({ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+				];
+				const connections: IConnections = {
+					OpenAI: { ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 0 }]] },
+					PgMem: { ai_memory: [[{ node: 'Agent', type: 'ai_memory', index: 0 }]] },
+				};
+
+				let thrown: unknown;
+				try {
+					assertUnpinCompatibility(makeWorkflow(nodes, connections), ['Agent']);
+				} catch (e) {
+					thrown = e;
+				}
+
+				expect(thrown).toBeInstanceOf(UserError);
+				const message = (thrown as UserError).message;
+				expect(message).toContain('protocol-binary');
+				expect(message).toContain('PgMem');
+				expect(message).toContain('options.baseURL');
+				expect(message).toContain('OpenAI');
+			});
+
+			it('skips the baseURL check when the OpenAI sub-node is disabled', () => {
+				const nodes = [
+					makeNode({
+						name: 'OpenAI',
+						type: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+						parameters: { options: { baseURL: 'https://my-proxy.example.com/v1' } },
+						disabled: true,
+					}),
+					makeNode({ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+				];
+				const connections: IConnections = {
+					OpenAI: { ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 0 }]] },
+				};
+
+				expect(() =>
+					assertUnpinCompatibility(makeWorkflow(nodes, connections), ['Agent']),
+				).not.toThrow();
+			});
+		});
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/workflow-analysis.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/workflow-analysis.test.ts
@@ -296,6 +296,7 @@ describe('assertUnpinCompatibility', () => {
 			makeNode({ name: 'AgentB', type: '@n8n/n8n-nodes-langchain.agent' }),
 		];
 		const connections: IConnections = {
+			OpenAI: { ai_languageModel: [[{ node: 'AgentB', type: 'ai_languageModel', index: 0 }]] },
 			PgMem: { ai_memory: [[{ node: 'AgentA', type: 'ai_memory', index: 0 }]] },
 			BufMem: { ai_memory: [[{ node: 'AgentB', type: 'ai_memory', index: 0 }]] },
 		};
@@ -313,6 +314,100 @@ describe('assertUnpinCompatibility', () => {
 		expect(message).toContain('PgMem');
 		expect(message).not.toContain('AgentB');
 		expect(message).not.toContain('BufMem');
+	});
+
+	describe('vendor LLM mapping', () => {
+		function agentWithLlm(llmType: string) {
+			const nodes = [
+				makeNode({ name: 'Llm', type: llmType }),
+				makeNode({ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+			];
+			const connections: IConnections = {
+				Llm: { ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 0 }]] },
+			};
+			return makeWorkflow(nodes, connections);
+		}
+
+		it('allows unpinning an Agent backed by lmChatOpenAi (the only mapped vendor for M1)', () => {
+			const workflow = agentWithLlm('@n8n/n8n-nodes-langchain.lmChatOpenAi');
+			expect(() => assertUnpinCompatibility(workflow, ['Agent'])).not.toThrow();
+		});
+
+		it.each([
+			'@n8n/n8n-nodes-langchain.lmChatAnthropic',
+			'@n8n/n8n-nodes-langchain.lmChatGoogleGemini',
+			'@n8n/n8n-nodes-langchain.lmChatCohere',
+			'@n8n/n8n-nodes-langchain.lmChatGroq',
+			'@n8n/n8n-nodes-langchain.lmChatMistralCloud',
+			'@n8n/n8n-nodes-langchain.lmChatAzureOpenAi',
+			'@n8n/n8n-nodes-langchain.lmChatOpenRouter',
+			'@n8n/n8n-nodes-langchain.lmChatXAiGrok',
+			'@n8n/n8n-nodes-langchain.lmChatDeepSeek',
+			'@n8n/n8n-nodes-langchain.lmChatOllama',
+			'@n8n/n8n-nodes-langchain.lmOpenAi',
+		])('refuses unpinning an Agent backed by unmapped vendor LLM %s', (llmType) => {
+			const workflow = agentWithLlm(llmType);
+
+			let thrown: unknown;
+			try {
+				assertUnpinCompatibility(workflow, ['Agent']);
+			} catch (e) {
+				thrown = e;
+			}
+
+			expect(thrown).toBeInstanceOf(UserError);
+			const message = (thrown as UserError).message;
+			expect(message).toContain('unsupported vendor LLM');
+			expect(message).toContain(llmType);
+		});
+
+		it('groups protocol-binary and unsupported-vendor refusals into the same error', () => {
+			const nodes = [
+				makeNode({ name: 'Anthropic', type: '@n8n/n8n-nodes-langchain.lmChatAnthropic' }),
+				makeNode({ name: 'PgMem', type: '@n8n/n8n-nodes-langchain.memoryPostgresChat' }),
+				makeNode({ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+			];
+			const connections: IConnections = {
+				Anthropic: {
+					ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 0 }]],
+				},
+				PgMem: { ai_memory: [[{ node: 'Agent', type: 'ai_memory', index: 0 }]] },
+			};
+
+			let thrown: unknown;
+			try {
+				assertUnpinCompatibility(makeWorkflow(nodes, connections), ['Agent']);
+			} catch (e) {
+				thrown = e;
+			}
+
+			expect(thrown).toBeInstanceOf(UserError);
+			const message = (thrown as UserError).message;
+			expect(message).toContain('protocol-binary');
+			expect(message).toContain('PgMem');
+			expect(message).toContain('unsupported vendor LLM');
+			expect(message).toContain('Anthropic');
+		});
+
+		it('ignores disabled vendor LLM sub-nodes when checking compatibility', () => {
+			const nodes = [
+				makeNode({
+					name: 'Anthropic',
+					type: '@n8n/n8n-nodes-langchain.lmChatAnthropic',
+					disabled: true,
+				}),
+				makeNode({ name: 'Agent', type: '@n8n/n8n-nodes-langchain.agent' }),
+			];
+			const connections: IConnections = {
+				Anthropic: {
+					ai_languageModel: [[{ node: 'Agent', type: 'ai_languageModel', index: 0 }]],
+				},
+			};
+
+			expect(() =>
+				assertUnpinCompatibility(makeWorkflow(nodes, connections), ['Agent']),
+			).not.toThrow();
+		});
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/eval/__tests__/workflow-analysis.test.ts
+++ b/packages/cli/src/modules/instance-ai/eval/__tests__/workflow-analysis.test.ts
@@ -257,6 +257,23 @@ describe('assertUnpinCompatibility', () => {
 		expect(() => assertUnpinCompatibility(workflow, ['Ghost'])).not.toThrow();
 	});
 
+	it('ignores disabled roots even when their sub-nodes would otherwise be refused', () => {
+		const nodes = [
+			makeNode({ name: 'PgMem', type: '@n8n/n8n-nodes-langchain.memoryPostgresChat' }),
+			makeNode({
+				name: 'Agent',
+				type: '@n8n/n8n-nodes-langchain.agent',
+				disabled: true,
+			}),
+		];
+		const connections: IConnections = {
+			PgMem: { ai_memory: [[{ node: 'Agent', type: 'ai_memory', index: 0 }]] },
+		};
+		expect(() =>
+			assertUnpinCompatibility(makeWorkflow(nodes, connections), ['Agent']),
+		).not.toThrow();
+	});
+
 	it.each([
 		['Postgres memory', '@n8n/n8n-nodes-langchain.memoryPostgresChat'],
 		['Redis memory', '@n8n/n8n-nodes-langchain.memoryRedisChat'],

--- a/packages/cli/src/modules/instance-ai/eval/eval-mocked-credentials-helper.ts
+++ b/packages/cli/src/modules/instance-ai/eval/eval-mocked-credentials-helper.ts
@@ -25,15 +25,21 @@ import { CredentialNotFoundError } from '@/errors/credential-not-found.error';
 const MOCK_MARKER = '__evalMockedCredential' as const;
 
 /**
- * Maps credential type → the property on the decrypted credential that holds
- * the vendor base URL. When the eval wire server is running, the matched
- * property gets rewritten so the vendor SDK posts to the local server.
+ * Maps credential type → which field holds the vendor base URL and the path
+ * prefix the rewritten URL needs to carry so the vendor SDK lands on the
+ * correct wire-server route.
+ *
+ * The LangChain OpenAI node passes `credentials.url` straight into the SDK's
+ * `baseURL`. The SDK then appends `/chat/completions`. So the rewritten URL
+ * **must** include `/v1` — otherwise the SDK calls `/chat/completions` and
+ * misses the wire server's `/v1/chat/completions` route. See LmChatOpenAi
+ * `LmChatOpenAi.node.ts:765` (`configuration.baseURL = credentials.url`).
  *
  * Only OpenAI for now — Anthropic, Azure, OpenAI-compat providers, embeddings,
  * vector stores land in the Tier 1–3 follow-up tickets after TRUST-115.
  */
-const EVAL_PROVIDER_URL_FIELD: Record<string, string> = {
-	openAiApi: 'url',
+export const EVAL_PROVIDER_URL_FIELD: Record<string, { field: string; pathPrefix: string }> = {
+	openAiApi: { field: 'url', pathPrefix: '/v1' },
 };
 
 /**
@@ -178,13 +184,17 @@ export class EvalMockedCredentialsHelper extends ICredentialsHelper {
 		executeData: IExecuteData | undefined,
 	): ICredentialDataDecryptedObject {
 		if (!this.serverUrl) return credentials;
-		const field = EVAL_PROVIDER_URL_FIELD[type];
-		if (!field) {
+		const mapping = EVAL_PROVIDER_URL_FIELD[type];
+		if (!mapping) {
 			// Wire server is up (caller opted in) but this credential type has no
 			// URL field mapping yet. The vendor SDK will use its built-in default
 			// URL, which means traffic for this provider escapes interception and
 			// hits the real API. Surface this loudly so the gap is visible until
 			// the Tier 1 follow-up tickets extend `EVAL_PROVIDER_URL_FIELD`.
+			// `assertUnpinCompatibility` should refuse this case for vendor LLM
+			// sub-node types — this branch survives for non-LLM credentials
+			// that legitimately go through n8n's HTTP helpers (eval mock layer
+			// intercepts those separately).
 			this.logger?.warn(
 				`[EvalMock] No URL rewrite mapping for credential type "${type}" — ` +
 					`vendor traffic from "${executeData?.node?.name ?? 'unknown'}" will hit the real provider.`,
@@ -192,6 +202,7 @@ export class EvalMockedCredentialsHelper extends ICredentialsHelper {
 			return credentials;
 		}
 
+		const { field, pathPrefix } = mapping;
 		this.rewrittenCredentials.push({
 			nodeName: executeData?.node?.name ?? 'unknown',
 			credentialType: type,
@@ -199,7 +210,7 @@ export class EvalMockedCredentialsHelper extends ICredentialsHelper {
 			field,
 		});
 
-		return { ...credentials, [field]: this.serverUrl };
+		return { ...credentials, [field]: `${this.serverUrl}${pathPrefix}` };
 	}
 
 	async updateCredentials(

--- a/packages/cli/src/modules/instance-ai/eval/eval-mocked-credentials-helper.ts
+++ b/packages/cli/src/modules/instance-ai/eval/eval-mocked-credentials-helper.ts
@@ -2,8 +2,7 @@ import type {
 	InstanceAiEvalMockedCredential,
 	InstanceAiEvalRewrittenCredential,
 } from '@n8n/api-types';
-import { Logger } from '@n8n/backend-common';
-import { Container } from '@n8n/di';
+import type { Logger } from '@n8n/backend-common';
 import type {
 	ICredentialDataDecryptedObject,
 	ICredentials,
@@ -66,10 +65,15 @@ export class EvalMockedCredentialsHelper extends ICredentialsHelper {
 	 *   vendor SDK posts to the wire server instead of the real provider.
 	 *   Leaving this undefined keeps the helper's pre-rewrite behaviour for
 	 *   callers that don't opt into the unpin path.
+	 * @param logger Optional logger. When provided, the helper warns on each
+	 *   resolved credential whose type is unmapped (so unmapped HTTP providers
+	 *   like Anthropic don't silently escape interception). Optional so this
+	 *   helper stays usable in tests/sites that don't construct it from DI.
 	 */
 	constructor(
 		private readonly inner: ICredentialsHelper,
 		private readonly serverUrl?: string,
+		private readonly logger?: Logger,
 	) {
 		super();
 	}
@@ -181,7 +185,7 @@ export class EvalMockedCredentialsHelper extends ICredentialsHelper {
 			// URL, which means traffic for this provider escapes interception and
 			// hits the real API. Surface this loudly so the gap is visible until
 			// the Tier 1 follow-up tickets extend `EVAL_PROVIDER_URL_FIELD`.
-			Container.get(Logger).warn(
+			this.logger?.warn(
 				`[EvalMock] No URL rewrite mapping for credential type "${type}" — ` +
 					`vendor traffic from "${executeData?.node?.name ?? 'unknown'}" will hit the real provider.`,
 			);

--- a/packages/cli/src/modules/instance-ai/eval/eval-mocked-credentials-helper.ts
+++ b/packages/cli/src/modules/instance-ai/eval/eval-mocked-credentials-helper.ts
@@ -1,4 +1,9 @@
-import type { InstanceAiEvalMockedCredential } from '@n8n/api-types';
+import type {
+	InstanceAiEvalMockedCredential,
+	InstanceAiEvalRewrittenCredential,
+} from '@n8n/api-types';
+import { Logger } from '@n8n/backend-common';
+import { Container } from '@n8n/di';
 import type {
 	ICredentialDataDecryptedObject,
 	ICredentials,
@@ -21,6 +26,18 @@ import { CredentialNotFoundError } from '@/errors/credential-not-found.error';
 const MOCK_MARKER = '__evalMockedCredential' as const;
 
 /**
+ * Maps credential type → the property on the decrypted credential that holds
+ * the vendor base URL. When the eval wire server is running, the matched
+ * property gets rewritten so the vendor SDK posts to the local server.
+ *
+ * Only OpenAI for now — Anthropic, Azure, OpenAI-compat providers, embeddings,
+ * vector stores land in the Tier 1–3 follow-up tickets after TRUST-115.
+ */
+const EVAL_PROVIDER_URL_FIELD: Record<string, string> = {
+	openAiApi: 'url',
+};
+
+/**
  * CredentialsHelper proxy for evaluation runs. Delegates everything to the
  * wrapped real helper, except:
  *
@@ -39,8 +56,21 @@ const MOCK_MARKER = '__evalMockedCredential' as const;
  */
 export class EvalMockedCredentialsHelper extends ICredentialsHelper {
 	readonly mockedCredentials: InstanceAiEvalMockedCredential[] = [];
+	readonly rewrittenCredentials: InstanceAiEvalRewrittenCredential[] = [];
 
-	constructor(private readonly inner: ICredentialsHelper) {
+	/**
+	 * @param inner The real credentials helper to delegate to.
+	 * @param serverUrl Optional base URL of the running eval wire server. When
+	 *   set, decrypted credentials of a type listed in `EVAL_PROVIDER_URL_FIELD`
+	 *   get their URL field rewritten to this value (copy-on-write), so the
+	 *   vendor SDK posts to the wire server instead of the real provider.
+	 *   Leaving this undefined keeps the helper's pre-rewrite behaviour for
+	 *   callers that don't opt into the unpin path.
+	 */
+	constructor(
+		private readonly inner: ICredentialsHelper,
+		private readonly serverUrl?: string,
+	) {
 		super();
 	}
 
@@ -103,8 +133,9 @@ export class EvalMockedCredentialsHelper extends ICredentialsHelper {
 		raw?: boolean,
 		expressionResolveValues?: ICredentialsExpressionResolveValues,
 	): Promise<ICredentialDataDecryptedObject> {
+		let credentials: ICredentialDataDecryptedObject;
 		try {
-			return await this.inner.getDecrypted(
+			credentials = await this.inner.getDecrypted(
 				additionalData,
 				nodeCredentials,
 				type,
@@ -122,8 +153,49 @@ export class EvalMockedCredentialsHelper extends ICredentialsHelper {
 				credentialId: nodeCredentials.id ?? undefined,
 			});
 
-			return { [MOCK_MARKER]: true };
+			credentials = { [MOCK_MARKER]: true };
 		}
+
+		return this.applyServerUrlRewrite(credentials, type, nodeCredentials, executeData);
+	}
+
+	/**
+	 * Routes the vendor base URL on the resolved credential to the eval wire
+	 * server. Copy-on-write — never mutates the caller's object — and records
+	 * the rewrite on `rewrittenCredentials` so the eval result can surface it.
+	 * No-op when `serverUrl` is unset or the credential type isn't in the
+	 * provider map; this is what keeps the existing (non-unpin) eval path
+	 * unchanged.
+	 */
+	private applyServerUrlRewrite(
+		credentials: ICredentialDataDecryptedObject,
+		type: string,
+		nodeCredentials: INodeCredentialsDetails,
+		executeData: IExecuteData | undefined,
+	): ICredentialDataDecryptedObject {
+		if (!this.serverUrl) return credentials;
+		const field = EVAL_PROVIDER_URL_FIELD[type];
+		if (!field) {
+			// Wire server is up (caller opted in) but this credential type has no
+			// URL field mapping yet. The vendor SDK will use its built-in default
+			// URL, which means traffic for this provider escapes interception and
+			// hits the real API. Surface this loudly so the gap is visible until
+			// the Tier 1 follow-up tickets extend `EVAL_PROVIDER_URL_FIELD`.
+			Container.get(Logger).warn(
+				`[EvalMock] No URL rewrite mapping for credential type "${type}" — ` +
+					`vendor traffic from "${executeData?.node?.name ?? 'unknown'}" will hit the real provider.`,
+			);
+			return credentials;
+		}
+
+		this.rewrittenCredentials.push({
+			nodeName: executeData?.node?.name ?? 'unknown',
+			credentialType: type,
+			credentialId: nodeCredentials.id ?? undefined,
+			field,
+		});
+
+		return { ...credentials, [field]: this.serverUrl };
 	}
 
 	async updateCredentials(

--- a/packages/cli/src/modules/instance-ai/eval/eval-mocked-credentials-helper.ts
+++ b/packages/cli/src/modules/instance-ai/eval/eval-mocked-credentials-helper.ts
@@ -24,58 +24,17 @@ import { CredentialNotFoundError } from '@/errors/credential-not-found.error';
 
 const MOCK_MARKER = '__evalMockedCredential' as const;
 
-/**
- * Maps credential type → which field holds the vendor base URL and the path
- * prefix the rewritten URL needs to carry so the vendor SDK lands on the
- * correct wire-server route.
- *
- * The LangChain OpenAI node passes `credentials.url` straight into the SDK's
- * `baseURL`. The SDK then appends `/chat/completions`. So the rewritten URL
- * **must** include `/v1` — otherwise the SDK calls `/chat/completions` and
- * misses the wire server's `/v1/chat/completions` route. See LmChatOpenAi
- * `LmChatOpenAi.node.ts:765` (`configuration.baseURL = credentials.url`).
- *
- * Only OpenAI for now — Anthropic, Azure, OpenAI-compat providers, embeddings,
- * vector stores land in the Tier 1–3 follow-up tickets after TRUST-115.
- */
+// `pathPrefix` must match what the vendor SDK appends to `baseURL`. OpenAI SDK appends
+// `/chat/completions`, so credentials.url must include `/v1` for the wire server route to match.
 export const EVAL_PROVIDER_URL_FIELD: Record<string, { field: string; pathPrefix: string }> = {
 	openAiApi: { field: 'url', pathPrefix: '/v1' },
 };
 
-/**
- * CredentialsHelper proxy for evaluation runs. Delegates everything to the
- * wrapped real helper, except:
- *
- *   - `getDecrypted`: when a credential ID cannot be resolved, returns a
- *     marker-only payload instead of throwing. This stops the credential
- *     lookup from halting the workflow before the LLM mock layer can run.
- *
- *   - `authenticate` / `preAuthentication` / `runPreAuthentication`: when
- *     called with a marker payload, return the input unchanged so the
- *     unauthed request flows into `helpers.httpRequest`, where the LLM
- *     mock handler intercepts and synthesizes a response.
- *
- * Eval-mode HTTP never reaches real services, so credential data shape is
- * irrelevant — the only contract we preserve is that the auth path doesn't
- * throw on missing data.
- */
+/** CredentialsHelper proxy for eval: tolerates missing credentials and (optionally) rewrites vendor URLs to the wire server. */
 export class EvalMockedCredentialsHelper extends ICredentialsHelper {
 	readonly mockedCredentials: InstanceAiEvalMockedCredential[] = [];
 	readonly rewrittenCredentials: InstanceAiEvalRewrittenCredential[] = [];
 
-	/**
-	 * @param inner The real credentials helper to delegate to.
-	 * @param serverUrl Optional base URL of the running eval wire server. When
-	 *   set, decrypted credentials of a type listed in `EVAL_PROVIDER_URL_FIELD`
-	 *   get their URL field rewritten to this value (copy-on-write), so the
-	 *   vendor SDK posts to the wire server instead of the real provider.
-	 *   Leaving this undefined keeps the helper's pre-rewrite behaviour for
-	 *   callers that don't opt into the unpin path.
-	 * @param logger Optional logger. When provided, the helper warns on each
-	 *   resolved credential whose type is unmapped (so unmapped HTTP providers
-	 *   like Anthropic don't silently escape interception). Optional so this
-	 *   helper stays usable in tests/sites that don't construct it from DI.
-	 */
 	constructor(
 		private readonly inner: ICredentialsHelper,
 		private readonly serverUrl?: string,
@@ -169,14 +128,6 @@ export class EvalMockedCredentialsHelper extends ICredentialsHelper {
 		return this.applyServerUrlRewrite(credentials, type, nodeCredentials, executeData);
 	}
 
-	/**
-	 * Routes the vendor base URL on the resolved credential to the eval wire
-	 * server. Copy-on-write — never mutates the caller's object — and records
-	 * the rewrite on `rewrittenCredentials` so the eval result can surface it.
-	 * No-op when `serverUrl` is unset or the credential type isn't in the
-	 * provider map; this is what keeps the existing (non-unpin) eval path
-	 * unchanged.
-	 */
 	private applyServerUrlRewrite(
 		credentials: ICredentialDataDecryptedObject,
 		type: string,
@@ -186,15 +137,8 @@ export class EvalMockedCredentialsHelper extends ICredentialsHelper {
 		if (!this.serverUrl) return credentials;
 		const mapping = EVAL_PROVIDER_URL_FIELD[type];
 		if (!mapping) {
-			// Wire server is up (caller opted in) but this credential type has no
-			// URL field mapping yet. The vendor SDK will use its built-in default
-			// URL, which means traffic for this provider escapes interception and
-			// hits the real API. Surface this loudly so the gap is visible until
-			// the Tier 1 follow-up tickets extend `EVAL_PROVIDER_URL_FIELD`.
-			// `assertUnpinCompatibility` should refuse this case for vendor LLM
-			// sub-node types — this branch survives for non-LLM credentials
-			// that legitimately go through n8n's HTTP helpers (eval mock layer
-			// intercepts those separately).
+			// No rewrite mapping — vendor SDK will hit its default URL. Refused upfront
+			// by assertUnpinCompatibility for LLM sub-nodes; this branch is for non-LLM HTTP creds.
 			this.logger?.warn(
 				`[EvalMock] No URL rewrite mapping for credential type "${type}" — ` +
 					`vendor traffic from "${executeData?.node?.name ?? 'unknown'}" will hit the real provider.`,

--- a/packages/cli/src/modules/instance-ai/eval/execution.service.ts
+++ b/packages/cli/src/modules/instance-ai/eval/execution.service.ts
@@ -114,23 +114,21 @@ export class EvalExecutionService {
 			throw error;
 		}
 
-		// Resolve the PostHog kill-switch only after the guard has cleared.
-		// `unpinNodes` is only safe when the credential rewrite + wire server
-		// are running; if the flag is off, vendor SDKs would execute against
-		// real credentials. For the empty case, today's pinned path runs and
-		// no flag check is needed.
-		const interceptionEnabled =
-			unpinNodes.length > 0 ? await this.isInterceptionEnabled(user) : false;
-
-		// Safety gate: refuse opt-in requests when the kill-switch is off.
-		// Without interception the request would leak vendor traffic to the
-		// real provider.
-		if (unpinNodes.length > 0 && !interceptionEnabled) {
-			return this.errorResult(
-				executionId,
-				'`unpinNodes` is reserved — vendor SDK interception is currently disabled. ' +
-					'Submit the request without `unpinNodes` to use the existing pinned path.',
-			);
+		// Resolve the PostHog kill-switch and apply the safety gate only when
+		// the caller opted in. For empty `unpinNodes`, today's pinned path
+		// runs unchanged — no flag check, no gate. When opt-in is requested,
+		// flag-off refuses the request so vendor SDKs can't execute against
+		// real credentials.
+		let interceptionEnabled = false;
+		if (unpinNodes.length > 0) {
+			interceptionEnabled = await this.isInterceptionEnabled(user);
+			if (!interceptionEnabled) {
+				return this.errorResult(
+					executionId,
+					'`unpinNodes` is reserved — vendor SDK interception is currently disabled. ' +
+						'Submit the request without `unpinNodes` to use the existing pinned path.',
+				);
+			}
 		}
 
 		const unpinSet = unpinNodes.length > 0 ? new Set(unpinNodes) : undefined;

--- a/packages/cli/src/modules/instance-ai/eval/execution.service.ts
+++ b/packages/cli/src/modules/instance-ai/eval/execution.service.ts
@@ -1,7 +1,8 @@
-import type {
-	InstanceAiEvalExecutionRequest,
-	InstanceAiEvalNodeResult,
-	InstanceAiEvalExecutionResult,
+import {
+	EVAL_VENDOR_SDK_INTERCEPTION_FLAG,
+	type InstanceAiEvalExecutionRequest,
+	type InstanceAiEvalNodeResult,
+	type InstanceAiEvalExecutionResult,
 } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
 import type { User } from '@n8n/db';
@@ -29,6 +30,7 @@ import {
 import { randomUUID } from 'node:crypto';
 
 import { NodeTypes } from '@/node-types';
+import { PostHogClient } from '@/posthog';
 import { getBase } from '@/workflow-execute-additional-data';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
@@ -46,6 +48,8 @@ import {
 } from './workflow-analysis';
 import { createLlmMockHandler } from './mock-handler';
 import { EvalMockedCredentialsHelper } from './eval-mocked-credentials-helper';
+import { LlmWireServer } from './llm-wire-server';
+import { patchNoProxyForLoopback } from './proxy-loopback';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -76,6 +80,7 @@ export class EvalExecutionService {
 		private readonly workflowFinderService: WorkflowFinderService,
 		private readonly nodeTypes: NodeTypes,
 		private readonly logger: Logger,
+		private readonly postHogClient: PostHogClient,
 	) {}
 
 	async executeWithLlmMock(
@@ -97,9 +102,9 @@ export class EvalExecutionService {
 
 		// Run the compatibility guard FIRST — protocol-binary or unmapped-vendor
 		// errors are actionable ("replace this Postgres memory") and the user
-		// needs them whether or not the feature is enabled. The gate below
-		// only kicks in when the workflow IS otherwise compatible, so the guard
-		// never gets shadowed by a more generic refusal.
+		// needs them whether or not the feature is enabled. The PostHog gate
+		// below only kicks in when the workflow IS otherwise compatible, so
+		// the guard never gets shadowed by a more generic refusal.
 		try {
 			assertUnpinCompatibility(workflowEntity, unpinNodes);
 		} catch (error) {
@@ -109,16 +114,21 @@ export class EvalExecutionService {
 			throw error;
 		}
 
-		// Safety gate: this PR ships only the API surface for `unpinNodes`. The
-		// credential rewrite + eval wire server that route vendor SDK traffic
-		// through localhost land in TRUST-113. Without them, unpinning would let
-		// AI sub-nodes execute their real SDK code against real credentials,
-		// leaking traffic to the actual provider. Refuse the request until the
-		// rewrite path is wired up — TRUST-113 removes this gate.
-		if (unpinNodes.length > 0) {
+		// Resolve the PostHog kill-switch only after the guard has cleared.
+		// `unpinNodes` is only safe when the credential rewrite + wire server
+		// are running; if the flag is off, vendor SDKs would execute against
+		// real credentials. For the empty case, today's pinned path runs and
+		// no flag check is needed.
+		const interceptionEnabled =
+			unpinNodes.length > 0 ? await this.isInterceptionEnabled(user) : false;
+
+		// Safety gate: refuse opt-in requests when the kill-switch is off.
+		// Without interception the request would leak vendor traffic to the
+		// real provider.
+		if (unpinNodes.length > 0 && !interceptionEnabled) {
 			return this.errorResult(
 				executionId,
-				'`unpinNodes` is reserved — vendor SDK interception is not yet enabled in this build. ' +
+				'`unpinNodes` is reserved — vendor SDK interception is currently disabled. ' +
 					'Submit the request without `unpinNodes` to use the existing pinned path.',
 			);
 		}
@@ -126,7 +136,33 @@ export class EvalExecutionService {
 		const unpinSet = unpinNodes.length > 0 ? new Set(unpinNodes) : undefined;
 		const hints = await this.analyzeWorkflow(workflowEntity, options.scenarioHints, unpinSet);
 
-		return await this.execute(workflowEntity, user, executionId, hints, options.scenarioHints);
+		return await this.execute(
+			workflowEntity,
+			user,
+			executionId,
+			hints,
+			options.scenarioHints,
+			interceptionEnabled,
+		);
+	}
+
+	/**
+	 * Resolves the PostHog kill-switch for the credential-rewrite code path.
+	 * Fail-closed: any error reading the flag treats it as OFF. The whole
+	 * point of the kill-switch is to disable the feature in an emergency, so
+	 * a PostHog outage must NOT let the rewrite run silently — the user's
+	 * request is refused (with a clear error) until the flag can be resolved.
+	 */
+	private async isInterceptionEnabled(user: User): Promise<boolean> {
+		try {
+			const flags = await this.postHogClient.getFeatureFlags(user);
+			return flags?.[EVAL_VENDOR_SDK_INTERCEPTION_FLAG] !== false;
+		} catch (error) {
+			this.logger.warn('[EvalMock] Failed to resolve vendor-SDK interception flag', {
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return false;
+		}
 	}
 
 	// ── Phase 1: Workflow analysis ─────────────────────────────────────────
@@ -225,6 +261,7 @@ export class EvalExecutionService {
 		executionId: string,
 		hints: MockHints,
 		scenarioHints?: string,
+		interceptionEnabled = false,
 	): Promise<InstanceAiEvalExecutionResult> {
 		const nodeResults: Record<string, InstanceAiEvalNodeResult> = {};
 
@@ -246,43 +283,63 @@ export class EvalExecutionService {
 			workflowId: workflowEntity.id,
 			workflowSettings: workflowEntity.settings ?? {},
 		});
-		const credentialsHelper = new EvalMockedCredentialsHelper(additionalData.credentialsHelper);
-		additionalData.credentialsHelper = credentialsHelper;
-		additionalData.evalLlmMockHandler = this.createInterceptingHandler(mockHandler, nodeResults);
-		additionalData.hooks = new ExecutionLifecycleHooks('evaluation', executionId, workflowEntity);
 
-		const triggerPinData = this.buildTriggerPinData(startNode, hints.triggerContent);
-		const pinData: IPinData = { ...triggerPinData, ...hints.bypassPinData };
-		const pinDataNodeNames = Object.keys(pinData);
-
-		// Check config completeness before execution — detect missing required parameters
-		this.checkNodeConfig(workflow, nodeResults, pinDataNodeNames);
-		const executionData = this.buildExecutionData(startNode, pinData);
-
-		// Mark the trigger node as pinned (it gets its output from pin data, not execution)
-		// Preserve any configIssues that checkNodeConfig may have already recorded.
-		if (Object.keys(triggerPinData).length > 0) {
-			const existing = nodeResults[startNode.name];
-			nodeResults[startNode.name] = {
-				output: null,
-				interceptedRequests: [],
-				executionMode: 'pinned',
-				...(existing?.configIssues ? { configIssues: existing.configIssues } : {}),
-			};
-		}
-
-		// Mark bypass nodes as pinned
-		for (const nodeName of Object.keys(hints.bypassPinData)) {
-			const existing = nodeResults[nodeName];
-			nodeResults[nodeName] = {
-				output: null,
-				interceptedRequests: [],
-				executionMode: 'pinned',
-				...(existing?.configIssues ? { configIssues: existing.configIssues } : {}),
-			};
-		}
-
+		// Single try/finally wraps boot, setup, and run so a throw anywhere
+		// after `wireServer.start()` still tears the server + NO_PROXY patch
+		// back down. The boot has to be guarded too — a thrown
+		// `patchNoProxyForLoopback()` or helper construction would otherwise
+		// leak the live server.
+		let wireServer: LlmWireServer | undefined;
+		let restoreNoProxy: (() => void) | undefined;
+		let credentialsHelper: EvalMockedCredentialsHelper | undefined;
 		try {
+			let serverUrl: string | undefined;
+			if (interceptionEnabled) {
+				wireServer = new LlmWireServer();
+				serverUrl = await wireServer.start();
+				restoreNoProxy = patchNoProxyForLoopback();
+				this.logger.debug(`[EvalMock] Wire server listening at ${serverUrl}`);
+			}
+
+			credentialsHelper = new EvalMockedCredentialsHelper(
+				additionalData.credentialsHelper,
+				serverUrl,
+			);
+			additionalData.credentialsHelper = credentialsHelper;
+			additionalData.evalLlmMockHandler = this.createInterceptingHandler(mockHandler, nodeResults);
+			additionalData.hooks = new ExecutionLifecycleHooks('evaluation', executionId, workflowEntity);
+
+			const triggerPinData = this.buildTriggerPinData(startNode, hints.triggerContent);
+			const pinData: IPinData = { ...triggerPinData, ...hints.bypassPinData };
+			const pinDataNodeNames = Object.keys(pinData);
+
+			// Check config completeness before execution — detect missing required parameters
+			this.checkNodeConfig(workflow, nodeResults, pinDataNodeNames);
+			const executionData = this.buildExecutionData(startNode, pinData);
+
+			// Mark the trigger node as pinned (it gets its output from pin data, not execution)
+			// Preserve any configIssues that checkNodeConfig may have already recorded.
+			if (Object.keys(triggerPinData).length > 0) {
+				const existing = nodeResults[startNode.name];
+				nodeResults[startNode.name] = {
+					output: null,
+					interceptedRequests: [],
+					executionMode: 'pinned',
+					...(existing?.configIssues ? { configIssues: existing.configIssues } : {}),
+				};
+			}
+
+			// Mark bypass nodes as pinned
+			for (const nodeName of Object.keys(hints.bypassPinData)) {
+				const existing = nodeResults[nodeName];
+				nodeResults[nodeName] = {
+					output: null,
+					interceptedRequests: [],
+					executionMode: 'pinned',
+					...(existing?.configIssues ? { configIssues: existing.configIssues } : {}),
+				};
+			}
+
 			const result = await this.runWorkflow(workflow, additionalData, executionData);
 			return this.buildResult(executionId, result, nodeResults, hints, credentialsHelper);
 		} catch (error: unknown) {
@@ -294,8 +351,20 @@ export class EvalExecutionService {
 				nodeResults,
 				errors: [`Execution failed: ${message}`],
 				hints,
-				mockedCredentials: credentialsHelper.mockedCredentials,
+				mockedCredentials: credentialsHelper?.mockedCredentials ?? [],
+				rewrittenCredentials: credentialsHelper?.rewrittenCredentials ?? [],
 			};
+		} finally {
+			if (restoreNoProxy) restoreNoProxy();
+			if (wireServer) {
+				try {
+					await wireServer.stop();
+				} catch (error) {
+					this.logger.warn('[EvalMock] Wire server teardown failed', {
+						error: error instanceof Error ? error.message : String(error),
+					});
+				}
+			}
 		}
 	}
 
@@ -501,6 +570,7 @@ export class EvalExecutionService {
 			errors,
 			hints,
 			mockedCredentials: credentialsHelper.mockedCredentials,
+			rewrittenCredentials: credentialsHelper.rewrittenCredentials,
 		};
 	}
 

--- a/packages/cli/src/modules/instance-ai/eval/execution.service.ts
+++ b/packages/cli/src/modules/instance-ai/eval/execution.service.ts
@@ -148,10 +148,16 @@ export class EvalExecutionService {
 
 	/**
 	 * Resolves the PostHog kill-switch for the credential-rewrite code path.
-	 * Fail-closed: any error reading the flag treats it as OFF. The whole
-	 * point of the kill-switch is to disable the feature in an emergency, so
-	 * a PostHog outage must NOT let the rewrite run silently — the user's
-	 * request is refused (with a clear error) until the flag can be resolved.
+	 *
+	 * Two distinct cases:
+	 *   - **Unset flag (`undefined`)**: treated as ENABLED. The flag is a
+	 *     default-on kill-switch — operators flip it to `false` to disable.
+	 *     Until an explicit rule is configured in PostHog the rewrite path
+	 *     stays active for any caller that opts in via `unpinNodes`.
+	 *   - **Flag resolution error**: treated as DISABLED. A kill-switch's job
+	 *     is to disable the feature in emergencies, including when the flag
+	 *     plane itself is degraded — the user's request is refused (with a
+	 *     clear error) rather than silently running the rewrite.
 	 */
 	private async isInterceptionEnabled(user: User): Promise<boolean> {
 		try {
@@ -304,6 +310,7 @@ export class EvalExecutionService {
 			credentialsHelper = new EvalMockedCredentialsHelper(
 				additionalData.credentialsHelper,
 				serverUrl,
+				this.logger,
 			);
 			additionalData.credentialsHelper = credentialsHelper;
 			additionalData.evalLlmMockHandler = this.createInterceptingHandler(mockHandler, nodeResults);

--- a/packages/cli/src/modules/instance-ai/eval/execution.service.ts
+++ b/packages/cli/src/modules/instance-ai/eval/execution.service.ts
@@ -100,11 +100,7 @@ export class EvalExecutionService {
 
 		const unpinNodes = options.unpinNodes ?? [];
 
-		// Run the compatibility guard FIRST — protocol-binary or unmapped-vendor
-		// errors are actionable ("replace this Postgres memory") and the user
-		// needs them whether or not the feature is enabled. The PostHog gate
-		// below only kicks in when the workflow IS otherwise compatible, so
-		// the guard never gets shadowed by a more generic refusal.
+		// Compatibility guard runs before the kill-switch so actionable errors aren't shadowed.
 		try {
 			assertUnpinCompatibility(workflowEntity, unpinNodes);
 		} catch (error) {
@@ -114,11 +110,6 @@ export class EvalExecutionService {
 			throw error;
 		}
 
-		// Resolve the PostHog kill-switch and apply the safety gate only when
-		// the caller opted in. For empty `unpinNodes`, today's pinned path
-		// runs unchanged — no flag check, no gate. When opt-in is requested,
-		// flag-off refuses the request so vendor SDKs can't execute against
-		// real credentials.
 		let interceptionEnabled = false;
 		if (unpinNodes.length > 0) {
 			interceptionEnabled = await this.isInterceptionEnabled(user);
@@ -144,19 +135,7 @@ export class EvalExecutionService {
 		);
 	}
 
-	/**
-	 * Resolves the PostHog kill-switch for the credential-rewrite code path.
-	 *
-	 * Two distinct cases:
-	 *   - **Unset flag (`undefined`)**: treated as ENABLED. The flag is a
-	 *     default-on kill-switch — operators flip it to `false` to disable.
-	 *     Until an explicit rule is configured in PostHog the rewrite path
-	 *     stays active for any caller that opts in via `unpinNodes`.
-	 *   - **Flag resolution error**: treated as DISABLED. A kill-switch's job
-	 *     is to disable the feature in emergencies, including when the flag
-	 *     plane itself is degraded — the user's request is refused (with a
-	 *     clear error) rather than silently running the rewrite.
-	 */
+	// Default-on kill-switch: unset → enabled, explicit `false` → disabled, resolution error → disabled.
 	private async isInterceptionEnabled(user: User): Promise<boolean> {
 		try {
 			const flags = await this.postHogClient.getFeatureFlags(user);
@@ -288,11 +267,7 @@ export class EvalExecutionService {
 			workflowSettings: workflowEntity.settings ?? {},
 		});
 
-		// Single try/finally wraps boot, setup, and run so a throw anywhere
-		// after `wireServer.start()` still tears the server + NO_PROXY patch
-		// back down. The boot has to be guarded too — a thrown
-		// `patchNoProxyForLoopback()` or helper construction would otherwise
-		// leak the live server.
+		// try/finally wraps boot so a throw never leaks the server or NO_PROXY patch.
 		let wireServer: LlmWireServer | undefined;
 		let restoreNoProxy: (() => void) | undefined;
 		let credentialsHelper: EvalMockedCredentialsHelper | undefined;

--- a/packages/cli/src/modules/instance-ai/eval/llm-wire-server.ts
+++ b/packages/cli/src/modules/instance-ai/eval/llm-wire-server.ts
@@ -2,19 +2,7 @@ import express, { type Express, type Request, type Response } from 'express';
 import { type Server } from 'node:http';
 import { randomUUID } from 'node:crypto';
 
-/**
- * Local-only HTTP server that intercepts vendor SDK calls during evaluation.
- * Vendor credentials are rewritten by {@link EvalMockedCredentialsHelper} to
- * point at this server's URL, so e.g. the OpenAI SDK posts to
- * `127.0.0.1:<port>/v1/chat/completions` instead of `api.openai.com`.
- *
- * This PR (TRUST-113) ships the lifecycle + a hardcoded OpenAI envelope. The
- * mock-handler integration that returns scenario-specific content lands in
- * TRUST-114; SSE streaming + tool-call envelopes in TRUST-115.
- *
- * Bound to `127.0.0.1:0` so the OS assigns a free port — `url` is populated
- * after `start()` resolves.
- */
+/** Loopback HTTP server that intercepts vendor SDK calls during eval. Binds to an OS-assigned port. */
 export class LlmWireServer {
 	private server: Server | undefined;
 	private resolvedUrl: string | undefined;
@@ -50,6 +38,8 @@ export class LlmWireServer {
 		this.server = undefined;
 		this.resolvedUrl = undefined;
 
+		server.closeAllConnections();
+
 		await new Promise<void>((resolve, reject) => {
 			server.close((error) => (error ? reject(error) : resolve()));
 		});
@@ -65,12 +55,6 @@ export class LlmWireServer {
 	}
 }
 
-/**
- * Hardcoded OpenAI chat-completion envelope. Returned for every POST to
- * `/v1/chat/completions` until TRUST-114 wires the eval mock handler in.
- * The shape matches OpenAI's `chat.completion` response so the SDK accepts it
- * without quirks.
- */
 function buildOpenAiChatCompletionStub(requestBody: unknown): Record<string, unknown> {
 	const model =
 		typeof requestBody === 'object' && requestBody !== null && 'model' in requestBody

--- a/packages/cli/src/modules/instance-ai/eval/llm-wire-server.ts
+++ b/packages/cli/src/modules/instance-ai/eval/llm-wire-server.ts
@@ -1,0 +1,101 @@
+import express, { type Express, type Request, type Response } from 'express';
+import { type Server } from 'node:http';
+import { randomUUID } from 'node:crypto';
+
+/**
+ * Local-only HTTP server that intercepts vendor SDK calls during evaluation.
+ * Vendor credentials are rewritten by {@link EvalMockedCredentialsHelper} to
+ * point at this server's URL, so e.g. the OpenAI SDK posts to
+ * `127.0.0.1:<port>/v1/chat/completions` instead of `api.openai.com`.
+ *
+ * This PR (TRUST-113) ships the lifecycle + a hardcoded OpenAI envelope. The
+ * mock-handler integration that returns scenario-specific content lands in
+ * TRUST-114; SSE streaming + tool-call envelopes in TRUST-115.
+ *
+ * Bound to `127.0.0.1:0` so the OS assigns a free port — `url` is populated
+ * after `start()` resolves.
+ */
+export class LlmWireServer {
+	private server: Server | undefined;
+	private resolvedUrl: string | undefined;
+
+	get url(): string {
+		if (!this.resolvedUrl) {
+			throw new Error('LlmWireServer.url accessed before start() resolved');
+		}
+		return this.resolvedUrl;
+	}
+
+	async start(): Promise<string> {
+		if (this.server) return this.url;
+
+		const app = this.buildApp();
+
+		this.server = await new Promise<Server>((resolve, reject) => {
+			const s = app.listen(0, '127.0.0.1', () => resolve(s));
+			s.once('error', reject);
+		});
+
+		const address = this.server.address();
+		if (!address || typeof address === 'string') {
+			throw new Error('LlmWireServer failed to bind a TCP port');
+		}
+		this.resolvedUrl = `http://127.0.0.1:${address.port}`;
+		return this.resolvedUrl;
+	}
+
+	async stop(): Promise<void> {
+		const server = this.server;
+		if (!server) return;
+		this.server = undefined;
+		this.resolvedUrl = undefined;
+
+		await new Promise<void>((resolve, reject) => {
+			server.close((error) => (error ? reject(error) : resolve()));
+		});
+	}
+
+	private buildApp(): Express {
+		const app = express();
+		app.use(express.json({ limit: '4mb' }));
+		app.post('/v1/chat/completions', (req: Request, res: Response) => {
+			res.status(200).json(buildOpenAiChatCompletionStub(req.body));
+		});
+		return app;
+	}
+}
+
+/**
+ * Hardcoded OpenAI chat-completion envelope. Returned for every POST to
+ * `/v1/chat/completions` until TRUST-114 wires the eval mock handler in.
+ * The shape matches OpenAI's `chat.completion` response so the SDK accepts it
+ * without quirks.
+ */
+function buildOpenAiChatCompletionStub(requestBody: unknown): Record<string, unknown> {
+	const model =
+		typeof requestBody === 'object' && requestBody !== null && 'model' in requestBody
+			? String((requestBody as { model: unknown }).model)
+			: 'gpt-4o-mini';
+
+	return {
+		id: `chatcmpl-${randomUUID()}`,
+		object: 'chat.completion',
+		created: Math.floor(Date.now() / 1000),
+		model,
+		choices: [
+			{
+				index: 0,
+				message: {
+					role: 'assistant',
+					content: '[eval wire server stub] — mock-handler integration ships in TRUST-114.',
+				},
+				finish_reason: 'stop',
+			},
+		],
+		usage: {
+			prompt_tokens: 1,
+			completion_tokens: 1,
+			total_tokens: 2,
+		},
+	};
+}

--- a/packages/cli/src/modules/instance-ai/eval/proxy-loopback.ts
+++ b/packages/cli/src/modules/instance-ai/eval/proxy-loopback.ts
@@ -1,0 +1,34 @@
+/**
+ * Workaround for the M0 finding: when `HTTP_PROXY` is set and `NO_PROXY` does
+ * not include `127.0.0.1`/`localhost`, n8n's `getProxyAgent` routes loopback
+ * traffic through the configured proxy. The eval wire server lives on
+ * `127.0.0.1:<port>`, so vendor SDK calls would never reach it.
+ *
+ * `patchNoProxyForLoopback()` prepends the loopback entries to `NO_PROXY`
+ * (preserving anything the operator already configured) and returns a restore
+ * closure that resets the env var to its prior value — including the case
+ * where it was undefined to begin with. Call the closure inside `finally` so
+ * the patch never outlives the eval execution that needed it.
+ */
+export function patchNoProxyForLoopback(): () => void {
+	const previous = process.env.NO_PROXY;
+	const loopback = '127.0.0.1,localhost';
+
+	if (previous === undefined || previous.length === 0) {
+		process.env.NO_PROXY = loopback;
+	} else {
+		const entries = previous.split(',').map((s) => s.trim());
+		const already = entries.includes('127.0.0.1') && entries.includes('localhost');
+		if (!already) {
+			process.env.NO_PROXY = `${loopback},${previous}`;
+		}
+	}
+
+	return () => {
+		if (previous === undefined) {
+			delete process.env.NO_PROXY;
+		} else {
+			process.env.NO_PROXY = previous;
+		}
+	};
+}

--- a/packages/cli/src/modules/instance-ai/eval/proxy-loopback.ts
+++ b/packages/cli/src/modules/instance-ai/eval/proxy-loopback.ts
@@ -9,26 +9,56 @@
  * closure that resets the env var to its prior value — including the case
  * where it was undefined to begin with. Call the closure inside `finally` so
  * the patch never outlives the eval execution that needed it.
+ *
+ * The patch is **reference-counted**. `process.env` is shared process-wide,
+ * so overlapping eval executions would otherwise stomp on each other: eval A
+ * snapshots, eval B sees A's patched state, A restores → B's loopback
+ * exemption vanishes mid-flight. The counter keeps the patch in place until
+ * the last active restore closure fires. Each closure is idempotent.
  */
+
+// Module-level state. The first concurrent caller snapshots the operator's
+// original NO_PROXY value here; subsequent overlapping callers just increment
+// the counter. When `activeCount` returns to zero the snapshot is restored
+// and these fields reset.
+let activeCount = 0;
+let originalValue: string | undefined;
+let hadOriginal = false;
+
 export function patchNoProxyForLoopback(): () => void {
-	const previous = process.env.NO_PROXY;
-	const loopback = '127.0.0.1,localhost';
-
-	if (previous === undefined || previous.length === 0) {
-		process.env.NO_PROXY = loopback;
-	} else {
-		const entries = previous.split(',').map((s) => s.trim());
-		const already = entries.includes('127.0.0.1') && entries.includes('localhost');
-		if (!already) {
-			process.env.NO_PROXY = `${loopback},${previous}`;
-		}
+	if (activeCount === 0) {
+		hadOriginal = Object.prototype.hasOwnProperty.call(process.env, 'NO_PROXY');
+		originalValue = process.env.NO_PROXY;
+		applyLoopbackPatch(originalValue);
 	}
+	activeCount++;
 
+	let restored = false;
 	return () => {
-		if (previous === undefined) {
-			delete process.env.NO_PROXY;
-		} else {
-			process.env.NO_PROXY = previous;
+		if (restored) return;
+		restored = true;
+		activeCount--;
+		if (activeCount === 0) {
+			if (!hadOriginal) {
+				delete process.env.NO_PROXY;
+			} else {
+				process.env.NO_PROXY = originalValue;
+			}
+			originalValue = undefined;
+			hadOriginal = false;
 		}
 	};
+}
+
+function applyLoopbackPatch(previous: string | undefined): void {
+	const loopback = '127.0.0.1,localhost';
+	if (previous === undefined || previous.length === 0) {
+		process.env.NO_PROXY = loopback;
+		return;
+	}
+	const entries = previous.split(',').map((s) => s.trim());
+	const alreadyPresent = entries.includes('127.0.0.1') && entries.includes('localhost');
+	if (!alreadyPresent) {
+		process.env.NO_PROXY = `${loopback},${previous}`;
+	}
 }

--- a/packages/cli/src/modules/instance-ai/eval/proxy-loopback.ts
+++ b/packages/cli/src/modules/instance-ai/eval/proxy-loopback.ts
@@ -1,26 +1,5 @@
-/**
- * Workaround for the M0 finding: when `HTTP_PROXY` is set and `NO_PROXY` does
- * not include `127.0.0.1`/`localhost`, n8n's `getProxyAgent` routes loopback
- * traffic through the configured proxy. The eval wire server lives on
- * `127.0.0.1:<port>`, so vendor SDK calls would never reach it.
- *
- * `patchNoProxyForLoopback()` prepends the loopback entries to `NO_PROXY`
- * (preserving anything the operator already configured) and returns a restore
- * closure that resets the env var to its prior value — including the case
- * where it was undefined to begin with. Call the closure inside `finally` so
- * the patch never outlives the eval execution that needed it.
- *
- * The patch is **reference-counted**. `process.env` is shared process-wide,
- * so overlapping eval executions would otherwise stomp on each other: eval A
- * snapshots, eval B sees A's patched state, A restores → B's loopback
- * exemption vanishes mid-flight. The counter keeps the patch in place until
- * the last active restore closure fires. Each closure is idempotent.
- */
-
-// Module-level state. The first concurrent caller snapshots the operator's
-// original NO_PROXY value here; subsequent overlapping callers just increment
-// the counter. When `activeCount` returns to zero the snapshot is restored
-// and these fields reset.
+// Ensures NO_PROXY includes loopback so HTTP_PROXY doesn't route the wire server through a proxy.
+// Reference-counted: process.env is shared, so overlapping eval runs must not stomp on each other.
 let activeCount = 0;
 let originalValue: string | undefined;
 let hadOriginal = false;

--- a/packages/cli/src/modules/instance-ai/eval/workflow-analysis.ts
+++ b/packages/cli/src/modules/instance-ai/eval/workflow-analysis.ts
@@ -1,15 +1,3 @@
-/**
- * Workflow analysis utilities for evaluation mock execution.
- *
- * Identifies which nodes should receive mock hints and generates consistent
- * per-node hints + trigger data via a single LLM call.
- *
- * Adapted from @n8n/instance-ai/evaluations/support/ — this copy lives
- * in the CLI package because it runs in-process during workflow execution.
- * TODO: Extract to a shared @n8n/eval-utils package for reuse by
- * the eval CLI, MCP, and other consumers.
- */
-
 import { Logger } from '@n8n/backend-common';
 import { Container } from '@n8n/di';
 import {
@@ -24,17 +12,7 @@ import {
 import { createEvalAgent, extractText } from '@n8n/instance-ai';
 import { extractNodeConfig } from './node-config';
 
-// ---------------------------------------------------------------------------
-// Node classification
-// ---------------------------------------------------------------------------
-
-/**
- * Find node names that are targets of ai_* connections (Agent, Chain nodes).
- * These are "root" AI nodes whose sub-nodes use vendor SDKs. Pinning the root
- * prevents supplyData() on all connected sub-nodes, avoiding SDK calls entirely.
- *
- * Ported from @n8n/instance-ai/evaluations/support/service-node-classifier.ts
- */
+/** Targets of `ai_*` connections — Agent/Chain root nodes. Pinning these short-circuits sub-node SDK calls. */
 function findAiRootNodeNames(workflow: IWorkflowBase): Set<string> {
 	const roots = new Set<string>();
 	for (const nodeConns of Object.values(workflow.connections)) {
@@ -53,13 +31,7 @@ function findAiRootNodeNames(workflow: IWorkflowBase): Set<string> {
 	return roots;
 }
 
-/**
- * Find node names that are sources of ai_* connections (LLM models, tools, memory).
- * These are sub-nodes handled via their root — they should not be pinned individually
- * or receive mock hints.
- *
- * Ported from @n8n/instance-ai/evaluations/support/service-node-classifier.ts
- */
+/** Sources of `ai_*` connections — LLM/tool/memory sub-nodes. Handled via their root, never pinned individually. */
 function findAiSubNodeNames(workflow: IWorkflowBase): Set<string> {
 	const subNodes = new Set<string>();
 	for (const [sourceName, nodeConns] of Object.entries(workflow.connections)) {
@@ -72,71 +44,35 @@ function findAiSubNodeNames(workflow: IWorkflowBase): Set<string> {
 	return subNodes;
 }
 
-// ---------------------------------------------------------------------------
-// Bypass node types — nodes that use non-HTTP protocols or bypass n8n's
-// request helper functions. These can't be intercepted by the eval mock handler.
-// ---------------------------------------------------------------------------
-
+/** Node types that bypass the HTTP mock handler (non-HTTP protocols or non-helper HTTP). */
 const BYPASS_NODE_TYPES = new Set([
-	// Databases (TCP/binary protocol)
 	'n8n-nodes-base.redis',
 	'n8n-nodes-base.mongoDb',
 	'n8n-nodes-base.mySql',
 	'n8n-nodes-base.postgres',
 	'n8n-nodes-base.microsoftSql',
 	'n8n-nodes-base.snowflake',
-	// Message queues (TCP/binary protocol)
 	'n8n-nodes-base.kafka',
 	'n8n-nodes-base.rabbitmq',
 	'n8n-nodes-base.mqtt',
 	'n8n-nodes-base.amqp',
-	// File/network protocols
 	'n8n-nodes-base.ftp',
 	'n8n-nodes-base.ssh',
 	'n8n-nodes-base.ldap',
 	'n8n-nodes-base.emailSend',
-	// Non-helper HTTP
 	'n8n-nodes-base.rssFeedRead',
 	'n8n-nodes-base.git',
 ]);
 
-/**
- * AI sub-node types that **are** supported by the eval wire-server rewrite
- * path. The compatibility guard refuses unpinning when an inbound `ai_*`
- * sub-node uses a vendor SDK that isn't on this list — its vendor traffic
- * would escape interception and hit the real provider with real credentials.
- *
- * Currently OpenAI only; Tier 1 follow-ups (Anthropic, Azure, Cohere/Groq,
- * Google Gemini/Vertex, etc.) will extend this set together with the
- * matching entries in `EVAL_PROVIDER_URL_FIELD`.
- */
+/** LLM sub-node types whose vendor URL can be rewritten to the wire server (must match `EVAL_PROVIDER_URL_FIELD`). */
 const SUPPORTED_VENDOR_LLM_SUB_NODE_TYPES = new Set(['@n8n/n8n-nodes-langchain.lmChatOpenAi']);
 
-/**
- * Heuristic for "this sub-node bakes a vendor base URL into its SDK at
- * construction time, so the only way to intercept its traffic is to rewrite
- * the credential URL". All `@n8n/n8n-nodes-langchain.lm*` nodes match — both
- * the chat (`lmChat*`) and legacy completion (`lmOpenAi`, `lmOllama`, etc.)
- * variants. The compatibility guard pairs this with
- * `SUPPORTED_VENDOR_LLM_SUB_NODE_TYPES` to refuse unsupported vendors.
- */
+/** `lm*` nodes bake the vendor base URL into the SDK; only credential URL rewrite can intercept them. */
 function isVendorLlmSubNode(nodeType: string): boolean {
 	return nodeType.startsWith('@n8n/n8n-nodes-langchain.lm');
 }
 
-/**
- * Detects parameter overrides on supported vendor LLM sub-nodes that bypass
- * the credential-URL rewrite. The LangChain OpenAI node, for example, prefers
- * `options.baseURL` over `credentials.url` when building the SDK client
- * (`LmChatOpenAi.node.ts:761-765`):
- *
- *     if (options.baseURL) { configuration.baseURL = options.baseURL; }
- *     else if (credentials.url) { configuration.baseURL = credentials.url; }
- *
- * So a sub-node configured with a non-empty `options.baseURL` would talk to
- * the operator's override URL even after we rewrite the credential. Refuse
- * the unpin until parameter-level rewriting exists.
- */
+/** Non-empty `options.baseURL` on the LangChain OpenAI node beats credentials.url — credential rewrite isn't enough. */
 function hasUnsafeBaseUrlOverride(node: INode): boolean {
 	if (node.type === '@n8n/n8n-nodes-langchain.lmChatOpenAi') {
 		const options = (node.parameters?.options ?? {}) as Record<string, unknown>;
@@ -146,12 +82,7 @@ function hasUnsafeBaseUrlOverride(node: INode): boolean {
 	return false;
 }
 
-/**
- * AI sub-node types that use a protocol-binary client (TCP, native driver, etc.).
- * These cannot be intercepted via the HTTP wire server, so the root they hang off
- * cannot be unpinned safely. `assertUnpinCompatibility` refuses unpin requests
- * for roots whose sub-nodes match this set.
- */
+/** AI sub-nodes that speak non-HTTP protocols — can't be intercepted, so their root must stay pinned. */
 const PROTOCOL_BINARY_SUB_NODE_TYPES = new Set([
 	// Memory backends
 	'@n8n/n8n-nodes-langchain.memoryPostgresChat',
@@ -165,15 +96,7 @@ const PROTOCOL_BINARY_SUB_NODE_TYPES = new Set([
 	'@n8n/n8n-nodes-langchain.chatHubVectorStorePGVector',
 ]);
 
-/**
- * Identify nodes that bypass the HTTP mock layer and need pin data instead.
- * Returns AI root nodes (Agent, Chain) and protocol/bypass nodes.
- *
- * `exclusionSet` opts AI root names out of pinning so their sub-nodes run real
- * vendor SDK code (routed through the eval wire server). `BYPASS_NODE_TYPES`
- * nodes ignore the exclusion set — they use protocol-binary clients and have
- * no HTTP interception path, so they must always be pinned.
- */
+/** Returns nodes that need pin data — AI roots (unless in `exclusionSet`) and bypass-protocol nodes. */
 export function identifyNodesForPinData(
 	workflow: IWorkflowBase,
 	exclusionSet?: Set<string>,
@@ -195,27 +118,7 @@ type UnpinRefusal = {
 	reason: 'protocol_binary' | 'unsupported_vendor_llm' | 'unsafe_baseurl_override';
 };
 
-/**
- * Refuse unpinning AI roots whose inbound `ai_*` sub-nodes can't be intercepted
- * over HTTP. Three categories are refused:
- *   - **Protocol-binary** sub-nodes (Postgres memory, Redis memory, native
- *     vector stores) — they don't speak HTTP at all.
- *   - **Unsupported vendor LLM** sub-nodes (anything matching
- *     `@n8n/n8n-nodes-langchain.lm*` that isn't on
- *     `SUPPORTED_VENDOR_LLM_SUB_NODE_TYPES`) — they bake their vendor base
- *     URL into the SDK and would call the real provider with real
- *     credentials, because `EVAL_PROVIDER_URL_FIELD` has no rewrite mapping
- *     for them yet.
- *   - **Unsafe baseURL override** on a supported vendor LLM — the SDK
- *     prefers a configured `options.baseURL` over `credentials.url`, so
- *     rewriting the credential isn't enough. Refused until parameter-level
- *     rewriting exists.
- *
- * Walks destination-indexed connections once per call and throws a `UserError`
- * listing every offending root → sub-node pair grouped by reason. Refusing up
- * front (before any execution) keeps the safety story unambiguous — the only
- * way to opt into an unmapped vendor is to extend the support set.
- */
+/** Throws if any unpinned AI root has a sub-node we can't intercept: protocol-binary, unmapped vendor LLM, or unsafe baseURL override. */
 export function assertUnpinCompatibility(workflow: IWorkflowBase, unpinNodes: string[]): void {
 	if (unpinNodes.length === 0) return;
 
@@ -299,11 +202,7 @@ export function assertUnpinCompatibility(workflow: IWorkflowBase, unpinNodes: st
 	);
 }
 
-/**
- * Identify which nodes in a workflow should receive mock hints.
- * Excludes AI sub-nodes (handled via their root) and nodes that will be
- * pinned (they don't execute, so hints are irrelevant for them).
- */
+/** Nodes that should receive mock hints — excludes AI sub-nodes (handled via root) and pinned nodes. */
 export function identifyNodesForHints(workflow: IWorkflowBase): INode[] {
 	const aiSubNodes = findAiSubNodeNames(workflow);
 	const aiRootNodes = findAiRootNodeNames(workflow);
@@ -414,11 +313,7 @@ function buildUserPrompt(
 
 const MAX_HINT_ATTEMPTS = 2;
 
-/**
- * Generate consistent mock hints for service nodes in a workflow. One Sonnet
- * call produces globalContext, triggerContent, and per-node hints — retried
- * once if the LLM returns an empty triggerContent or any structural issue.
- */
+/** One LLM call → globalContext + triggerContent + per-node hints. Retried once on structural issues. */
 export async function generateMockHints(options: GenerateMockHintsOptions): Promise<MockHints> {
 	const { workflow, nodeNames, scenarioHints } = options;
 	const emptyResult: MockHints = {

--- a/packages/cli/src/modules/instance-ai/eval/workflow-analysis.ts
+++ b/packages/cli/src/modules/instance-ai/eval/workflow-analysis.ts
@@ -101,6 +101,30 @@ const BYPASS_NODE_TYPES = new Set([
 ]);
 
 /**
+ * AI sub-node types that **are** supported by the eval wire-server rewrite
+ * path. The compatibility guard refuses unpinning when an inbound `ai_*`
+ * sub-node uses a vendor SDK that isn't on this list — its vendor traffic
+ * would escape interception and hit the real provider with real credentials.
+ *
+ * Currently OpenAI only; Tier 1 follow-ups (Anthropic, Azure, Cohere/Groq,
+ * Google Gemini/Vertex, etc.) will extend this set together with the
+ * matching entries in `EVAL_PROVIDER_URL_FIELD`.
+ */
+const SUPPORTED_VENDOR_LLM_SUB_NODE_TYPES = new Set(['@n8n/n8n-nodes-langchain.lmChatOpenAi']);
+
+/**
+ * Heuristic for "this sub-node bakes a vendor base URL into its SDK at
+ * construction time, so the only way to intercept its traffic is to rewrite
+ * the credential URL". All `@n8n/n8n-nodes-langchain.lm*` nodes match — both
+ * the chat (`lmChat*`) and legacy completion (`lmOpenAi`, `lmOllama`, etc.)
+ * variants. The compatibility guard pairs this with
+ * `SUPPORTED_VENDOR_LLM_SUB_NODE_TYPES` to refuse unsupported vendors.
+ */
+function isVendorLlmSubNode(nodeType: string): boolean {
+	return nodeType.startsWith('@n8n/n8n-nodes-langchain.lm');
+}
+
+/**
  * AI sub-node types that use a protocol-binary client (TCP, native driver, etc.).
  * These cannot be intercepted via the HTTP wire server, so the root they hang off
  * cannot be unpinned safely. `assertUnpinCompatibility` refuses unpin requests
@@ -142,10 +166,29 @@ export function identifyNodesForPinData(
 	});
 }
 
+type UnpinRefusal = {
+	root: string;
+	subNode: string;
+	subNodeType: string;
+	reason: 'protocol_binary' | 'unsupported_vendor_llm';
+};
+
 /**
  * Refuse unpinning AI roots whose inbound `ai_*` sub-nodes can't be intercepted
- * over HTTP. Walks the workflow's destination-indexed connections once per
- * call and throws a `UserError` listing every offending root → sub-node pair.
+ * over HTTP. Two categories are refused:
+ *   - **Protocol-binary** sub-nodes (Postgres memory, Redis memory, native
+ *     vector stores) — they don't speak HTTP at all.
+ *   - **Unsupported vendor LLM** sub-nodes (anything matching
+ *     `@n8n/n8n-nodes-langchain.lm*` that isn't on
+ *     `SUPPORTED_VENDOR_LLM_SUB_NODE_TYPES`) — they bake their vendor base
+ *     URL into the SDK and would call the real provider with real
+ *     credentials, because `EVAL_PROVIDER_URL_FIELD` has no rewrite mapping
+ *     for them yet.
+ *
+ * Walks destination-indexed connections once per call and throws a `UserError`
+ * listing every offending root → sub-node pair grouped by reason. Refusing up
+ * front (before any execution) keeps the safety story unambiguous — the only
+ * way to opt into an unmapped vendor is to extend the support set.
  */
 export function assertUnpinCompatibility(workflow: IWorkflowBase, unpinNodes: string[]): void {
 	if (unpinNodes.length === 0) return;
@@ -153,7 +196,7 @@ export function assertUnpinCompatibility(workflow: IWorkflowBase, unpinNodes: st
 	const nodesByName = new Map(workflow.nodes.map((n) => [n.name, n]));
 	const connectionsByDestination = mapConnectionsByDestination(workflow.connections);
 
-	const refusals: Array<{ root: string; subNode: string; subNodeType: string }> = [];
+	const refusals: UnpinRefusal[] = [];
 
 	for (const rootName of unpinNodes) {
 		const inbound = connectionsByDestination[rootName];
@@ -166,11 +209,23 @@ export function assertUnpinCompatibility(workflow: IWorkflowBase, unpinNodes: st
 				for (const conn of group) {
 					const sourceNode = nodesByName.get(conn.node);
 					if (!sourceNode || sourceNode.disabled) continue;
+
 					if (PROTOCOL_BINARY_SUB_NODE_TYPES.has(sourceNode.type)) {
 						refusals.push({
 							root: rootName,
 							subNode: sourceNode.name,
 							subNodeType: sourceNode.type,
+							reason: 'protocol_binary',
+						});
+					} else if (
+						isVendorLlmSubNode(sourceNode.type) &&
+						!SUPPORTED_VENDOR_LLM_SUB_NODE_TYPES.has(sourceNode.type)
+					) {
+						refusals.push({
+							root: rootName,
+							subNode: sourceNode.name,
+							subNodeType: sourceNode.type,
+							reason: 'unsupported_vendor_llm',
 						});
 					}
 				}
@@ -178,15 +233,30 @@ export function assertUnpinCompatibility(workflow: IWorkflowBase, unpinNodes: st
 		}
 	}
 
-	if (refusals.length > 0) {
-		const detail = refusals
-			.map((r) => `"${r.subNode}" (${r.subNodeType}) → "${r.root}"`)
-			.join(', ');
-		throw new UserError(
-			`Cannot unpin AI root nodes whose sub-nodes use a protocol-binary client: ${detail}. ` +
-				'These sub-nodes cannot be intercepted via HTTP — leave the root pinned or replace the sub-node with an HTTP-based alternative.',
+	if (refusals.length === 0) return;
+
+	const formatPairs = (list: UnpinRefusal[]) =>
+		list.map((r) => `"${r.subNode}" (${r.subNodeType}) → "${r.root}"`).join(', ');
+
+	const protocolBinary = refusals.filter((r) => r.reason === 'protocol_binary');
+	const unsupportedVendor = refusals.filter((r) => r.reason === 'unsupported_vendor_llm');
+
+	const segments: string[] = [];
+	if (protocolBinary.length > 0) {
+		segments.push(
+			`protocol-binary sub-nodes (cannot be intercepted via HTTP): ${formatPairs(protocolBinary)}`,
 		);
 	}
+	if (unsupportedVendor.length > 0) {
+		segments.push(
+			`unsupported vendor LLM sub-nodes (no eval URL-rewrite mapping yet): ${formatPairs(unsupportedVendor)}`,
+		);
+	}
+
+	throw new UserError(
+		`Cannot unpin AI root nodes — ${segments.join('; ')}. ` +
+			'Leave these roots pinned, or replace the sub-node with one that has interception support.',
+	);
 }
 
 /**

--- a/packages/cli/src/modules/instance-ai/eval/workflow-analysis.ts
+++ b/packages/cli/src/modules/instance-ai/eval/workflow-analysis.ts
@@ -125,6 +125,28 @@ function isVendorLlmSubNode(nodeType: string): boolean {
 }
 
 /**
+ * Detects parameter overrides on supported vendor LLM sub-nodes that bypass
+ * the credential-URL rewrite. The LangChain OpenAI node, for example, prefers
+ * `options.baseURL` over `credentials.url` when building the SDK client
+ * (`LmChatOpenAi.node.ts:761-765`):
+ *
+ *     if (options.baseURL) { configuration.baseURL = options.baseURL; }
+ *     else if (credentials.url) { configuration.baseURL = credentials.url; }
+ *
+ * So a sub-node configured with a non-empty `options.baseURL` would talk to
+ * the operator's override URL even after we rewrite the credential. Refuse
+ * the unpin until parameter-level rewriting exists.
+ */
+function hasUnsafeBaseUrlOverride(node: INode): boolean {
+	if (node.type === '@n8n/n8n-nodes-langchain.lmChatOpenAi') {
+		const options = (node.parameters?.options ?? {}) as Record<string, unknown>;
+		const baseURL = options.baseURL;
+		return typeof baseURL === 'string' && baseURL.trim().length > 0;
+	}
+	return false;
+}
+
+/**
  * AI sub-node types that use a protocol-binary client (TCP, native driver, etc.).
  * These cannot be intercepted via the HTTP wire server, so the root they hang off
  * cannot be unpinned safely. `assertUnpinCompatibility` refuses unpin requests
@@ -170,12 +192,12 @@ type UnpinRefusal = {
 	root: string;
 	subNode: string;
 	subNodeType: string;
-	reason: 'protocol_binary' | 'unsupported_vendor_llm';
+	reason: 'protocol_binary' | 'unsupported_vendor_llm' | 'unsafe_baseurl_override';
 };
 
 /**
  * Refuse unpinning AI roots whose inbound `ai_*` sub-nodes can't be intercepted
- * over HTTP. Two categories are refused:
+ * over HTTP. Three categories are refused:
  *   - **Protocol-binary** sub-nodes (Postgres memory, Redis memory, native
  *     vector stores) — they don't speak HTTP at all.
  *   - **Unsupported vendor LLM** sub-nodes (anything matching
@@ -184,6 +206,10 @@ type UnpinRefusal = {
  *     URL into the SDK and would call the real provider with real
  *     credentials, because `EVAL_PROVIDER_URL_FIELD` has no rewrite mapping
  *     for them yet.
+ *   - **Unsafe baseURL override** on a supported vendor LLM — the SDK
+ *     prefers a configured `options.baseURL` over `credentials.url`, so
+ *     rewriting the credential isn't enough. Refused until parameter-level
+ *     rewriting exists.
  *
  * Walks destination-indexed connections once per call and throws a `UserError`
  * listing every offending root → sub-node pair grouped by reason. Refusing up
@@ -219,10 +245,16 @@ export function assertUnpinCompatibility(workflow: IWorkflowBase, unpinNodes: st
 							subNodeType: sourceNode.type,
 							reason: 'protocol_binary',
 						});
-					} else if (
-						isVendorLlmSubNode(sourceNode.type) &&
-						!SUPPORTED_VENDOR_LLM_SUB_NODE_TYPES.has(sourceNode.type)
-					) {
+					} else if (SUPPORTED_VENDOR_LLM_SUB_NODE_TYPES.has(sourceNode.type)) {
+						if (hasUnsafeBaseUrlOverride(sourceNode)) {
+							refusals.push({
+								root: rootName,
+								subNode: sourceNode.name,
+								subNodeType: sourceNode.type,
+								reason: 'unsafe_baseurl_override',
+							});
+						}
+					} else if (isVendorLlmSubNode(sourceNode.type)) {
 						refusals.push({
 							root: rootName,
 							subNode: sourceNode.name,
@@ -242,6 +274,7 @@ export function assertUnpinCompatibility(workflow: IWorkflowBase, unpinNodes: st
 
 	const protocolBinary = refusals.filter((r) => r.reason === 'protocol_binary');
 	const unsupportedVendor = refusals.filter((r) => r.reason === 'unsupported_vendor_llm');
+	const baseUrlOverride = refusals.filter((r) => r.reason === 'unsafe_baseurl_override');
 
 	const segments: string[] = [];
 	if (protocolBinary.length > 0) {
@@ -254,10 +287,15 @@ export function assertUnpinCompatibility(workflow: IWorkflowBase, unpinNodes: st
 			`unsupported vendor LLM sub-nodes (no eval URL-rewrite mapping yet): ${formatPairs(unsupportedVendor)}`,
 		);
 	}
+	if (baseUrlOverride.length > 0) {
+		segments.push(
+			`vendor LLM sub-nodes with a configured options.baseURL that bypasses the credential rewrite: ${formatPairs(baseUrlOverride)}`,
+		);
+	}
 
 	throw new UserError(
 		`Cannot unpin AI root nodes — ${segments.join('; ')}. ` +
-			'Leave these roots pinned, or replace the sub-node with one that has interception support.',
+			'Leave these roots pinned, remove the parameter override, or replace the sub-node with one that has interception support.',
 	);
 }
 

--- a/packages/cli/src/modules/instance-ai/eval/workflow-analysis.ts
+++ b/packages/cli/src/modules/instance-ai/eval/workflow-analysis.ts
@@ -199,6 +199,8 @@ export function assertUnpinCompatibility(workflow: IWorkflowBase, unpinNodes: st
 	const refusals: UnpinRefusal[] = [];
 
 	for (const rootName of unpinNodes) {
+		const rootNode = nodesByName.get(rootName);
+		if (!rootNode || rootNode.disabled) continue;
 		const inbound = connectionsByDestination[rootName];
 		if (!inbound) continue;
 


### PR DESCRIPTION
## Summary

PR 2 of 4 for vendor SDK interception during evals (parent: [TRUST-101](https://linear.app/n8n/issue/TRUST-101)). Stands up the localhost wire server and routes vendor credentials through it via `EvalMockedCredentialsHelper`. **Default eval path is untouched** — the wire server only boots when `unpinNodes` is non-empty AND the PostHog kill-switch is on.

**Stacked on top of [PR #30737](https://github.com/n8n-io/n8n/pull/30737) (TRUST-112).** Will be rebased onto master when #30737 merges.

### New files
- `eval/proxy-loopback.ts` — `patchNoProxyForLoopback()` prepends `127.0.0.1,localhost` to `NO_PROXY`, returns a restore closure. Codifies M0 finding 2 (loopback can be shadowed by an operator-configured HTTP_PROXY without this).
- `eval/llm-wire-server.ts` — `LlmWireServer` class. Express app bound to `127.0.0.1:0`, single `POST /v1/chat/completions` route returning a hardcoded OpenAI chat-completion envelope. Dynamic responses land in TRUST-114; SSE + tool-calls in TRUST-115.

### Wiring
- `EVAL_VENDOR_SDK_INTERCEPTION_FLAG = '085_eval_vendor_sdk_interception'` exported from `@n8n/api-types` and used as the kill-switch. **Fail-closed** — a PostHog outage treats the flag as OFF and refuses the request. The whole point of the kill-switch is to disable the feature in an emergency, including when the flag plane itself is degraded.
- `EvalMockedCredentialsHelper` takes optional `serverUrl`; new `EVAL_PROVIDER_URL_FIELD = { openAiApi: 'url' }` map. `getDecrypted()` does copy-on-write rewrite + records `rewrittenCredentials[]`. Logs a warning when interception is wired but the credential type has no URL mapping (visibility for the Tier-1 follow-up gap — Anthropic, Cohere/Groq, etc.).
- `EvalExecutionService` injects `PostHogClient`. Replaces TRUST-112's unconditional gate with a flag-conditional one. Boot + setup + run all live inside a single try/finally so a throw between `start()` and the run can't leak the server.

### M1 acceptance (mechanism)
`__tests__/m1-rewrite-roundtrip.test.ts` spins a real `LlmWireServer`, runs the helper, posts to the rewritten URL via fetch, and verifies the chat-completion envelope returns. Full LangChain SDK round-trip remains TRUST-115's M3 fixture.

### Out of scope
- Mock-handler integration (dynamic responses) → TRUST-114
- SSE streaming, tool-call envelope → TRUST-115
- Anthropic / Azure / OpenAI-compat URL rewrite mappings → Tier 1 follow-ups after TRUST-115

## Related Linear tickets, Github issues, and Community forum posts

- Linear: https://linear.app/n8n/issue/TRUST-113
- Parent: https://linear.app/n8n/issue/TRUST-101
- Blocked by: https://linear.app/n8n/issue/TRUST-112 ([PR #30737](https://github.com/n8n-io/n8n/pull/30737))
- Blocks: https://linear.app/n8n/issue/TRUST-114 (PR 3 — mock-handler integration)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. Marked \`(no-changelog)\` — opt-in feature behind PostHog kill-switch, no user-visible change at merge.
- [x] Tests included — 19 new cases across proxy round-trip, server lifecycle + real chat-completion POST, helper rewrite matrix, service flag-on/off paths, teardown-on-throw, M1 mechanism end-to-end. All 241 eval tests pass.
- [ ] Docs updated — not applicable; field is opt-in and not yet exposed to UI.
- [ ] PR Labeled with \`Backport to *\` — not applicable.

## Test plan

- [x] \`pnpm test src/modules/instance-ai/eval/__tests__/\` — 241/241 pass (12 suites)
- [x] M1 integration fixture proves end-to-end mechanism: real server boots, helper rewrites \`openAiApi.url\` to the live URL, POST to that URL returns a chat-completion envelope.
- [x] \`@n8n/api-types\` lint + typecheck + build clean
- [x] \`packages/cli\` lint on touched files clean; full typecheck unchanged from clean-master baseline (pre-existing unrelated errors confirmed via stash-and-rerun)
- [ ] Manual smoke when the rewrite path is exercised by an actual LangChain workflow — deferred to TRUST-115's M3 fixture