### PR TITLE
fix(core): Report scheduled-poll isolate acquisition failures via __emitError

### DIFF
--- a/packages/core/src/execution-engine/__tests__/active-workflows.test.ts
+++ b/packages/core/src/execution-engine/__tests__/active-workflows.test.ts
@@ -276,6 +276,31 @@ describe('ActiveWorkflows', () => {
 				expect(pollFunctions.__emitError).toHaveBeenCalledWith(emitError);
 			});
 
+			it('should route a failed acquireIsolate on a scheduled poll through __emitError', async () => {
+				// Without this routing, the rejection would escape the cron callback
+				// `() => void executeTrigger()` and become an unhandled rejection — the
+				// user would only see a process-level log line, not an error execution.
+				triggersAndPollers.runPoll.mockResolvedValueOnce(null); // initial activation test poll
+
+				await addWorkflow({ pollNodes: [pollNode] });
+
+				const acquireError = new Error('Failed to acquire isolate');
+				acquireIsolate.mockClear();
+				releaseIsolate.mockClear();
+				acquireIsolate.mockRejectedValueOnce(acquireError);
+				triggersAndPollers.runPoll.mockClear();
+
+				const registerCronCall = scheduledTaskManager.registerCron.mock.calls[0];
+				const executeScheduledPoll = registerCronCall[1] as () => Promise<void>;
+
+				await executeScheduledPoll();
+				await flushPromises();
+
+				expect(acquireIsolate).toHaveBeenCalledTimes(1);
+				expect(triggersAndPollers.runPoll).not.toHaveBeenCalled();
+				expect(pollFunctions.__emitError).toHaveBeenCalledWith(acquireError);
+			});
+
 			it('should release the isolate even when the scheduled poll throws', async () => {
 				const error = new Error('Poll function failed');
 				triggersAndPollers.runPoll

--- a/packages/core/src/execution-engine/active-workflows.ts
+++ b/packages/core/src/execution-engine/active-workflows.ts
@@ -272,9 +272,10 @@ export class ActiveWorkflows {
 					// polls fire from the cron scheduler's own async context outside
 					// that window and must acquire/release per tick — see CAT-3147.
 					const ownsIsolate = !testingTrigger;
-					if (ownsIsolate) await workflow.expression.acquireIsolate();
 
 					try {
+						if (ownsIsolate) await workflow.expression.acquireIsolate();
+
 						const pollResponse = await this.triggersAndPollers.runPoll(
 							workflow,
 							node,


### PR DESCRIPTION
## Summary

Follow-up to #30729. Addresses [a cubic-dev-ai review comment](https://github.com/n8n-io/n8n/pull/30729#discussion_r3267175732) on that PR.

In #30729 the `await workflow.expression.acquireIsolate()` call lived **outside** the surrounding `try { ... } catch` so that an acquire failure would surface up the call stack rather than being conflated with poll-execution errors. For the activation-time test poll this works as intended — the rejection propagates through `executeTrigger(true)` and `add()` catches it, surfacing a `WorkflowActivationError`.

For **scheduled** polls it's actually worse than the alternative: the cron callback is `() => void executeTrigger()` (fire-and-forget), so an acquire failure becomes an unhandled promise rejection — Node logs a process-level warning but no error execution shows up in the UI. The user has no way to see that the bridge pool is exhausted or the evaluator is misconfigured.

This PR moves the `acquireIsolate()` call **inside** the existing `try` block. Acquire failures on scheduled polls now flow through `pollFunctions.__emitError(error)` and become visible error executions, symmetric with how `runPoll` failures are handled. The `release` in `finally` is unchanged and is safe even if acquire never succeeded — `ExpressionEvaluator.release()` no-ops on an unknown caller (verified in `packages/@n8n/expression-runtime/src/evaluator/expression-evaluator.ts:144-146`).

For the activation-time test poll (`testingTrigger=true`), `ownsIsolate` is `false`, so the acquire is skipped entirely — no behavioral change there.

### How to test

`pnpm --filter n8n-core test active-workflows` — one new regression test (`should route a failed acquireIsolate on a scheduled poll through __emitError`) plus the existing 21 regression tests from #30729.

## Related Linear tickets, Github issues, and Community forum posts

- Linear: https://linear.app/n8n/issue/CAT-3147
- Follow-up to: #30729
- Review comment: https://github.com/n8n-io/n8n/pull/30729#discussion_r3267175732

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI