### PR TITLE
fix(editor): Prevent evaluations tab crash on unsaved workflows

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.test.ts
@@ -18,6 +18,10 @@ import { EVALUATION_NODE_TYPE, EVALUATION_TRIGGER_NODE_TYPE, NodeHelpers } from 
 import { mockNodeTypeDescription } from '@/__tests__/mocks';
 import type { SourceControlPreferences } from '@/features/integrations/sourceControl.ee/sourceControl.types';
 
+const { showError } = vi.hoisted(() => ({
+	showError: vi.fn(),
+}));
+
 vi.mock('vue-router', () => ({
 	useRoute: () => ({
 		query: {},
@@ -38,7 +42,7 @@ vi.mock('@/app/composables/useTelemetry', () => {
 
 vi.mock('@/app/composables/useToast', () => ({
 	useToast: () => ({
-		showError: vi.fn(),
+		showError,
 		showMessage: vi.fn(),
 	}),
 }));
@@ -92,6 +96,8 @@ describe('EvaluationsRootView', () => {
 		createTestingPinia();
 		vi.clearAllMocks();
 
+		mockedStore(useWorkflowsStore).isWorkflowSaved = { [mockWorkflow.id]: true };
+
 		vi.spyOn(NodeHelpers, 'getNodeParameters').mockReturnValue({
 			assignments: {
 				assignments: [
@@ -123,6 +129,24 @@ describe('EvaluationsRootView', () => {
 		// Verify that evaluation-specific data is loaded
 		expect(usageStore.getLicenseInfo).toHaveBeenCalled();
 		expect(evaluationStore.fetchTestRuns).toHaveBeenCalledWith(mockWorkflow.id);
+	});
+
+	it('should not fetch test runs for an unsaved workflow', async () => {
+		const workflowsStore = mockedStore(useWorkflowsStore);
+		const usageStore = mockedStore(useUsageStore);
+		const evaluationStore = mockedStore(useEvaluationStore);
+
+		workflowsStore.isWorkflowSaved = {};
+		usageStore.getLicenseInfo.mockResolvedValue(undefined);
+		evaluationStore.fetchTestRuns.mockRejectedValue(new Error('Workflow not found'));
+
+		renderComponent({ props: { workflowId: mockWorkflow.id } });
+
+		await flushPromises();
+
+		expect(usageStore.getLicenseInfo).toHaveBeenCalled();
+		expect(evaluationStore.fetchTestRuns).not.toHaveBeenCalled();
+		expect(showError).not.toHaveBeenCalled();
 	});
 
 	it('should load test data', async () => {

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.vue
@@ -7,6 +7,7 @@ import { useToast } from '@/app/composables/useToast';
 import { useI18n } from '@n8n/i18n';
 import { useEvaluationStore } from '../evaluation.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
 
 import { computed, watch } from 'vue';
 import EvaluationsPaywall from '../components/Paywall/EvaluationsPaywall.vue';
@@ -19,6 +20,7 @@ const props = defineProps<{
 
 const usageStore = useUsageStore();
 const evaluationStore = useEvaluationStore();
+const workflowsStore = useWorkflowsStore();
 const telemetry = useTelemetry();
 const toast = useToast();
 const locale = useI18n();
@@ -31,6 +33,8 @@ const evaluationsLicensed = computed(() => {
 const isProtectedEnvironment = computed(() => {
 	return sourceControlStore.preferences.branchReadOnly;
 });
+
+const workflowIsSaved = computed(() => workflowsStore.isWorkflowSaved[props.workflowId] === true);
 
 const runs = computed(() => {
 	return Object.values(evaluationStore.testRunsById ?? {}).filter(
@@ -46,6 +50,8 @@ const showWizard = computed(() => !hasRuns.value);
 
 // Method to run a test - will be used by the SetupWizard component
 async function runTest() {
+	if (!workflowIsSaved.value) return;
+
 	try {
 		await evaluationStore.startTestRun(props.workflowId);
 	} catch (error) {
@@ -67,14 +73,31 @@ const evaluationsQuotaExceeded = computed(() => {
 	);
 });
 
-const { isReady } = useAsyncState(async () => {
+async function fetchTestRuns() {
+	if (!workflowIsSaved.value) return;
+
 	try {
-		await usageStore.getLicenseInfo();
 		await evaluationStore.fetchTestRuns(props.workflowId);
 	} catch (error) {
 		toast.showError(error, locale.baseText('evaluation.listRuns.error.cantFetchTestRuns'));
 	}
+}
+
+const { isReady } = useAsyncState(async () => {
+	try {
+		await usageStore.getLicenseInfo();
+	} catch (error) {
+		toast.showError(error, locale.baseText('evaluation.listRuns.error.cantFetchTestRuns'));
+	}
+
+	await fetchTestRuns();
 }, undefined);
+
+watch(workflowIsSaved, async (isSaved) => {
+	if (isSaved) {
+		await fetchTestRuns();
+	}
+});
 
 watch(
 	isReady,


### PR DESCRIPTION
## Summary

The evaluations tab attempted to fetch test runs for the current workflow even before the workflow had been saved, causing the request to fail and the tab to crash. This change gates the test runs fetch on the workflow being saved, and refetches once it transitions to a saved state.

### How to test

1. Create a new (unsaved) workflow.
2. Open the **Evaluations** tab — the tab should render without errors and no `fetchTestRuns` request should fire.
3. Save the workflow — the evaluations should fetch automatically once the workflow has an id and is persisted.
4. Reload an already-saved workflow and open the **Evaluations** tab — runs should load as before.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-82

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI