### PR TITLE
fix: security issue - pin timeago.js to exact version to prevent future supply-chain attacks

### DIFF
--- a/package.json
+++ b/package.json
@@ -179,7 +179,8 @@
       "brace-expansion@5": "5.0.6",
       "@opentelemetry/exporter-prometheus@<=0.217.0": "0.217.0",
       "@opentelemetry/sdk-node@<=0.217.0": "0.217.0",
-      "langsmith": "0.6.0"
+      "langsmith": "0.6.0",
+      "timeago.js": "4.0.2"
     },
     "patchedDependencies": {
       "bull@4.16.4": "patches/bull@4.16.4.patch",

--- a/packages/frontend/editor-ui/package.json
+++ b/packages/frontend/editor-ui/package.json
@@ -93,7 +93,7 @@
     "qrcode.vue": "^3.3.4",
     "semver": "^7.5.4",
     "stream-browserify": "^3.0.0",
-    "timeago.js": "^4.0.2",
+    "timeago.js": "4.0.2",
     "typescript": "catalog:",
     "uuid": "catalog:",
     "v-code-diff": "^1.13.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -544,6 +544,7 @@ overrides:
   '@opentelemetry/exporter-prometheus@<=0.217.0': 0.217.0
   '@opentelemetry/sdk-node@<=0.217.0': 0.217.0
   langsmith: 0.6.0
+  timeago.js: 4.0.2
 
 patchedDependencies:
   '@lezer/highlight':
@@ -4238,7 +4239,7 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       timeago.js:
-        specifier: ^4.0.2
+        specifier: 4.0.2
         version: 4.0.2
       typescript:
         specifier: 6.0.2


### PR DESCRIPTION
## Summary

Pins `timeago.js` to an exact version (`4.0.2`) instead of the floating `^4.0.2` range:

- `packages/frontend/editor-ui/package.json` — caret removed.
- Root `package.json` `pnpm.overrides` — added `"timeago.js": "4.0.2"` so any future transitive use is also pinned (matches the existing pattern used for ~30 other deps in this repo).
- `pnpm-lock.yaml` — specifier updated; resolved version unchanged (`4.0.2`, same integrity hash). Pnpm also pruned a handful of unreferenced stale entries (`@daytonaio/*@0.143.0`, `@opentelemetry/*@2.2.0`) — incidental housekeeping.

## Background — Mini Shai-Hulud supply-chain attack

On **May 19, 2026**, the **Mini Shai-Hulud** npm worm (attributed to the threat group **TeamPCP**) compromised ~160 npm packages in the AntV / G2 ecosystem and beyond, including TanStack, Mistral AI, UiPath, and SAP. The campaign published 373 malicious package-version entries — several of them with valid **SLSA Build Level 3 provenance attestations**, making naive provenance verification ineffective.

Two `timeago.js` versions were published as part of this wave:

- **`timeago.js@4.1.2`** (published May 19, 2026, since unpublished)
- **`timeago.js@4.2.2`** (published May 19, 2026, since unpublished)

Both shipped a malicious `optionalDependencies` entry pointing at a GitHub-hosted package whose `prepare` script ran during `pnpm install` / `npm install`, exfiltrating npm tokens, GitHub credentials, SSH keys, and cloud secrets from developer machines and CI runners, then using those credentials to publish further malicious packages — i.e. a self-propagating worm.

References:

- Aikido Security: *Mini Shai-Hulud Is Back: npm Worm Hits over 160 Packages, including Mistral and Tanstack* — https://www.aikido.dev/blog/mini-shai-hulud-is-back-tanstack-compromised
- Snyk: *TanStack npm Packages Hit by Mini Shai-Hulud* — https://snyk.io/blog/tanstack-npm-packages-compromised/
- Endor Labs: *Mini Shai-Hulud Returns: 42 Malicious npm Packages Fake Sigstore Badges in AntV Ecosystem Attack* — https://www.endorlabs.com/learn/mini-shai-hulud-returns-42-malicious-npm-packages-fake-sigstore-badges-in-antv-ecosystem-attack

## Current exposure (and why this PR is still warranted)

- The malicious `4.1.2` and `4.2.2` versions **have been unpublished from npm**. `pnpm view timeago.js@latest` currently returns `4.0.2`.
- n8n's current `pnpm-lock.yaml` already pins `4.0.2`, so any install today resolves to the known-good version.
- **However**, the `^4.0.2` spec in `editor-ui/package.json` allows the package manager to resolve to any `4.x.y` at install time. Specifically:
  - A fresh `pnpm install` in an environment without the lockfile.
  - A `pnpm update`.
  - A lockfile regeneration triggered by any unrelated PR.
  Any of these would have pulled `4.1.2` / `4.2.2` during the window those versions were live, and would pull any **future** maliciously re-published version that falls inside the `^4.0.2` range (e.g. `4.0.3`, `4.1.3`, …).
- The underlying maintainer-account compromise pattern that produced this wave is still active — researchers continue to discover newly compromised package-versions days after the initial wave. The credentials that enabled the original publish may still be in attacker hands until rotated.

In short: the lockfile protects us today, but the floating spec leaves a future window. This PR closes it.

## Why pin this one specifically

- The library is **~1 KB, no transitive deps, no functional release for years**. Locking to an exact version costs nothing in maintenance — there is nothing to chase upstream.
- It executes in the browser bundle shipped to n8n operators via `n8n-editor-ui`, so the blast radius of a compromised version is larger than a backend-only dev dependency.
- There is already a confirmed compromise of a version inside our allowed range.

### Why both the spec change *and* the `pnpm.overrides`

- The spec change (`"timeago.js": "4.0.2"` in `editor-ui/package.json`) removes the caret from the only place `timeago.js` is declared today.
- The `pnpm.overrides` entry at the root is belt-and-suspenders — if anything in the dependency tree later starts depending on `timeago.js` transitively with its own range, the override forces it to `4.0.2` across the whole workspace. This mirrors the existing pattern used for ~30 other dependencies in the same `overrides` block.

### Cost / scope

- No application code changes, no public API changes, no behavior changes.
- Build, lint, and editor-ui still compile against the same resolved version (`4.0.2`).
- Future legitimate updates to `timeago.js` will require a deliberate one-line bump — acceptable for a library of this size and release cadence.

## How to test

1. `pnpm install` — completes without surprises (existing peer warnings only).
2. `pnpm --filter n8n-editor-ui why timeago.js` reports a single resolution at `4.0.2`.
3. Editor-ui build (`pnpm --filter n8n-editor-ui build`) succeeds — no consumer code touched.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included. <!-- N/A for a pure dependency pin; covered by existing install + build CI -->
- [ ] Docs updated or follow-up ticket created. <!-- N/A -->
- [ ] PR Labeled with ``Backport to Beta``, ``Backport to Stable``, or ``Backport to v1``