### PR TITLE
fix(core): Scope source control data tables by project

### DIFF
--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-export.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-export.service.test.ts
@@ -64,7 +64,10 @@ describe('SourceControlExportService', () => {
 	const fsWriteFile = jest.spyOn(fsp, 'writeFile');
 	const fsReadFile = jest.spyOn(fsp, 'readFile');
 
-	beforeEach(() => jest.clearAllMocks());
+	beforeEach(() => {
+		jest.clearAllMocks();
+		sourceControlScopedService.getDataTablesInAdminProjectsFromContextFilter.mockReturnValue({});
+	});
 
 	describe('exportCredentialsToWorkFolder', () => {
 		const credentialData = {
@@ -786,6 +789,40 @@ describe('SourceControlExportService', () => {
 			expect(result.count).toBe(0);
 			expect(result.files).toHaveLength(0);
 			expect(fsWriteFile).not.toHaveBeenCalled();
+		});
+
+		it('should scope exported data tables to projects the user can push to', async () => {
+			// Arrange
+			const candidates = [
+				{
+					id: 'dt1',
+					name: 'Test Table 1',
+					type: 'datatable' as const,
+					status: 'created' as const,
+					file: '/mock/n8n/git/datatables/dt1.json',
+					location: 'local' as const,
+					conflict: false,
+					updatedAt: '2024-01-02T00:00:00.000Z',
+				},
+			];
+			const scopedFilter = { project: { id: 'authorized-project' } };
+			sourceControlScopedService.getDataTablesInAdminProjectsFromContextFilter.mockReturnValue(
+				scopedFilter as any,
+			);
+			dataTableRepository.find.mockResolvedValue([]);
+
+			// Act
+			await service.exportDataTablesToWorkFolder(candidates, globalAdminContext);
+
+			// Assert
+			expect(
+				sourceControlScopedService.getDataTablesInAdminProjectsFromContextFilter,
+			).toHaveBeenCalledWith(globalAdminContext);
+			expect(dataTableRepository.find).toHaveBeenCalledWith(
+				expect.objectContaining({
+					where: expect.objectContaining(scopedFilter),
+				}),
+			);
 		});
 
 		it('should handle export errors gracefully', async () => {

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -72,6 +72,11 @@ describe('SourceControlImportService', () => {
 		[],
 		[],
 	);
+	const globalMemberContext = new SourceControlContext(
+		Object.assign(new User(), { id: 'user1', role: GLOBAL_MEMBER_ROLE }),
+		[Object.assign(new Project(), { id: 'project1', name: 'Team Project 1', type: 'team' })],
+		[],
+	);
 
 	const service = new SourceControlImportService(
 		mockLogger,
@@ -104,7 +109,10 @@ describe('SourceControlImportService', () => {
 	const globMock = fastGlob.default as unknown as jest.Mock<Promise<string[]>, string[]>;
 	const fsReadFile = jest.spyOn(fsp, 'readFile');
 
-	beforeEach(() => jest.clearAllMocks());
+	beforeEach(() => {
+		jest.clearAllMocks();
+		sourceControlScopedService.getDataTablesInAdminProjectsFromContextFilter.mockReturnValue({});
+	});
 
 	describe('getRemoteVersionIdsFromFiles', () => {
 		const mockWorkflowFile = '/mock/workflow1.json';
@@ -2876,7 +2884,7 @@ describe('SourceControlImportService', () => {
 					.mockResolvedValueOnce(JSON.stringify(mockDataTable2) as any);
 
 				// Act
-				const result = await service.getRemoteDataTablesFromFiles();
+				const result = await service.getRemoteDataTablesFromFiles(globalAdminContext);
 
 				// Assert
 				expect(result).toEqual([mockDataTable1, mockDataTable2]);
@@ -2891,7 +2899,7 @@ describe('SourceControlImportService', () => {
 				globMock.mockResolvedValue([]);
 
 				// Act
-				const result = await service.getRemoteDataTablesFromFiles();
+				const result = await service.getRemoteDataTablesFromFiles(globalAdminContext);
 
 				// Assert
 				expect(result).toEqual([]);
@@ -2917,10 +2925,54 @@ describe('SourceControlImportService', () => {
 					.mockResolvedValueOnce('invalid json' as any);
 
 				// Act
-				const result = await service.getRemoteDataTablesFromFiles();
+				const result = await service.getRemoteDataTablesFromFiles(globalAdminContext);
 
 				// Assert
 				expect(result).toEqual([mockDataTable]);
+			});
+
+			it('should return only data tables from authorized projects', async () => {
+				// Arrange
+				const authorizedDataTable = {
+					id: 'dt1',
+					name: 'Authorized Table',
+					ownedBy: { type: 'team', teamId: 'project1', teamName: 'Team Project 1' },
+					columns: [],
+					createdAt: '2024-01-01T00:00:00.000Z',
+					updatedAt: '2024-01-02T00:00:00.000Z',
+				};
+				const unauthorizedDataTable = {
+					id: 'dt2',
+					name: 'Unauthorized Table',
+					ownedBy: { type: 'team', teamId: 'project2', teamName: 'Team Project 2' },
+					columns: [],
+					createdAt: '2024-01-03T00:00:00.000Z',
+					updatedAt: '2024-01-04T00:00:00.000Z',
+				};
+				const unownedDataTable = {
+					id: 'dt3',
+					name: 'Unowned Table',
+					ownedBy: null,
+					columns: [],
+					createdAt: '2024-01-05T00:00:00.000Z',
+					updatedAt: '2024-01-06T00:00:00.000Z',
+				};
+
+				globMock.mockResolvedValue([
+					'/mock/n8n/git/datatables/dt1.json',
+					'/mock/n8n/git/datatables/dt2.json',
+					'/mock/n8n/git/datatables/dt3.json',
+				]);
+				fsReadFile
+					.mockResolvedValueOnce(JSON.stringify(authorizedDataTable) as any)
+					.mockResolvedValueOnce(JSON.stringify(unauthorizedDataTable) as any)
+					.mockResolvedValueOnce(JSON.stringify(unownedDataTable) as any);
+
+				// Act
+				const result = await service.getRemoteDataTablesFromFiles(globalMemberContext);
+
+				// Assert
+				expect(result).toEqual([authorizedDataTable, unownedDataTable]);
 			});
 		});
 
@@ -2947,7 +2999,7 @@ describe('SourceControlImportService', () => {
 				dataTableRepository.find.mockResolvedValue(mockDataTables as any);
 
 				// Act
-				const result = await service.getLocalDataTablesFromDb();
+				const result = await service.getLocalDataTablesFromDb(globalAdminContext);
 
 				// Assert
 				expect(result).toHaveLength(1);
@@ -2971,6 +3023,34 @@ describe('SourceControlImportService', () => {
 						'project.projectRelations',
 						'project.projectRelations.role',
 					],
+					where: {},
+				});
+			});
+
+			it('should scope database query to data tables in authorized projects', async () => {
+				// Arrange
+				const where = { project: { id: 'project1' } };
+				sourceControlScopedService.getDataTablesInAdminProjectsFromContextFilter.mockReturnValue(
+					where as any,
+				);
+				dataTableRepository.find.mockResolvedValue([]);
+
+				// Act
+				const result = await service.getLocalDataTablesFromDb(globalMemberContext);
+
+				// Assert
+				expect(result).toEqual([]);
+				expect(
+					sourceControlScopedService.getDataTablesInAdminProjectsFromContextFilter,
+				).toHaveBeenCalledWith(globalMemberContext);
+				expect(dataTableRepository.find).toHaveBeenCalledWith({
+					relations: [
+						'columns',
+						'project',
+						'project.projectRelations',
+						'project.projectRelations.role',
+					],
+					where,
 				});
 			});
 
@@ -2979,7 +3059,7 @@ describe('SourceControlImportService', () => {
 				dataTableRepository.find.mockResolvedValue([]);
 
 				// Act
-				const result = await service.getLocalDataTablesFromDb();
+				const result = await service.getLocalDataTablesFromDb(globalAdminContext);
 
 				// Assert
 				expect(result).toEqual([]);
@@ -2991,7 +3071,7 @@ describe('SourceControlImportService', () => {
 				dataTableRepository.find.mockRejectedValue(error);
 
 				// Act
-				const result = await service.getLocalDataTablesFromDb();
+				const result = await service.getLocalDataTablesFromDb(globalAdminContext);
 
 				// Assert
 				expect(result).toEqual([]);
@@ -3003,7 +3083,7 @@ describe('SourceControlImportService', () => {
 				dataTableRepository.find.mockRejectedValue(error);
 
 				// Act & Assert
-				await expect(service.getLocalDataTablesFromDb()).rejects.toThrow(
+				await expect(service.getLocalDataTablesFromDb(globalAdminContext)).rejects.toThrow(
 					'Database connection failed',
 				);
 			});

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-status.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-status.service.test.ts
@@ -1728,6 +1728,24 @@ describe('getStatus', () => {
 	});
 
 	describe('data tables', () => {
+		it('should pass source control context when collecting data tables', async () => {
+			// ARRANGE
+			const user = globalAdminUserWithId;
+			const context = new SourceControlContext(user, [], []);
+			sourceControlContextFactory.createContext.mockResolvedValueOnce(context);
+
+			// ACT
+			await sourceControlStatusService.getStatus(user, {
+				direction: 'push',
+				verbose: true,
+				preferLocalVersion: false,
+			});
+
+			// ASSERT
+			expect(sourceControlImportService.getRemoteDataTablesFromFiles).toHaveBeenCalledWith(context);
+			expect(sourceControlImportService.getLocalDataTablesFromDb).toHaveBeenCalledWith(context);
+		});
+
 		it('should handle undefined data tables from remote (null safety)', async () => {
 			// ARRANGE
 			const user = globalAdminUserWithId;

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-status.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-status.service.test.ts
@@ -1728,24 +1728,6 @@ describe('getStatus', () => {
 	});
 
 	describe('data tables', () => {
-		it('should pass source control context when collecting data tables', async () => {
-			// ARRANGE
-			const user = globalAdminUserWithId;
-			const context = new SourceControlContext(user, [], []);
-			sourceControlContextFactory.createContext.mockResolvedValueOnce(context);
-
-			// ACT
-			await sourceControlStatusService.getStatus(user, {
-				direction: 'push',
-				verbose: true,
-				preferLocalVersion: false,
-			});
-
-			// ASSERT
-			expect(sourceControlImportService.getRemoteDataTablesFromFiles).toHaveBeenCalledWith(context);
-			expect(sourceControlImportService.getLocalDataTablesFromDb).toHaveBeenCalledWith(context);
-		});
-
 		it('should handle undefined data tables from remote (null safety)', async () => {
 			// ARRANGE
 			const user = globalAdminUserWithId;

--- a/packages/cli/src/modules/source-control.ee/source-control-export.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-export.service.ee.ts
@@ -255,7 +255,7 @@ export class SourceControlExportService {
 
 	async exportDataTablesToWorkFolder(
 		candidates: SourceControlledFile[],
-		_context: SourceControlContext,
+		context: SourceControlContext,
 	): Promise<ExportResult> {
 		try {
 			sourceControlFoldersExistCheck([this.gitFolder, this.dataTableExportFolder]);
@@ -275,6 +275,7 @@ export class SourceControlExportService {
 			const dataTables = await this.dataTableRepository.find({
 				where: {
 					id: In(candidateIds),
+					...this.sourceControlScopedService.getDataTablesInAdminProjectsFromContextFilter(context),
 				},
 				relations: [
 					'columns',

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -417,7 +417,9 @@ export class SourceControlImportService {
 		return await this.variablesService.getAllCached({ globalOnly: true });
 	}
 
-	async getRemoteDataTablesFromFiles(): Promise<ExportableDataTable[]> {
+	async getRemoteDataTablesFromFiles(
+		context: SourceControlContext,
+	): Promise<ExportableDataTable[]> {
 		const dataTableFiles = await glob('*.json', {
 			cwd: this.dataTableExportFolder,
 			absolute: true,
@@ -440,11 +442,25 @@ export class SourceControlImportService {
 			}),
 		);
 
-		// Filter out null/undefined values from failed parses
-		return remoteTables.filter((table): table is ExportableDataTable => !!table);
+		return remoteTables.filter((table): table is ExportableDataTable => {
+			// Filter out null/undefined values from failed parses
+			if (!table) {
+				return false;
+			}
+
+			// Unless data is corrupted, there should always be an owner.
+			// We keep tables without an owner because they can still be imported
+			// and assigned to the pulling user's personal project.
+			const owner = table.ownedBy;
+			return (
+				!owner || context.hasAccessToAllProjects() || !!context.findAuthorizedProjectByOwner(owner)
+			);
+		});
 	}
 
-	async getLocalDataTablesFromDb(): Promise<StatusExportableDataTable[]> {
+	async getLocalDataTablesFromDb(
+		context: SourceControlContext,
+	): Promise<StatusExportableDataTable[]> {
 		try {
 			const dataTables = await this.dataTableRepository.find({
 				relations: [
@@ -453,6 +469,8 @@ export class SourceControlImportService {
 					'project.projectRelations',
 					'project.projectRelations.role',
 				],
+				where:
+					this.sourceControlScopedService.getDataTablesInAdminProjectsFromContextFilter(context),
 			});
 			return dataTables.map((table) => {
 				let ownedBy: StatusResourceOwner | null = null;

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -451,10 +451,12 @@ export class SourceControlImportService {
 			// Unless data is corrupted, there should always be an owner.
 			// We keep tables without an owner because they can still be imported
 			// and assigned to the pulling user's personal project.
-			const owner = table.ownedBy;
-			return (
-				!owner || context.hasAccessToAllProjects() || !!context.findAuthorizedProjectByOwner(owner)
-			);
+			if (!table.ownedBy) {
+				return true;
+			}
+
+			const isOwnedByAuthorizedProject = !!context.findAuthorizedProjectByOwner(table.ownedBy);
+			return context.hasAccessToAllProjects() || isOwnedByAuthorizedProject;
 		});
 	}
 

--- a/packages/cli/src/modules/source-control.ee/source-control-status.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-status.service.ee.ts
@@ -202,7 +202,7 @@ export class SourceControlStatusService {
 			this.getStatusWorkflows(options, context, collectVerbose, remoteFolders),
 			this.getStatusCredentials(options, context, collectVerbose),
 			this.getStatusVariables(options, collectVerbose),
-			this.getStatusDataTables(options, collectVerbose),
+			this.getStatusDataTables(options, context, collectVerbose),
 			this.getStatusTagsMappings(options, context, collectVerbose),
 			this.getStatusFoldersMapping(options, context, collectVerbose, remoteFolders),
 			this.getStatusProjects(options, context, collectVerbose),
@@ -675,12 +675,16 @@ export class SourceControlStatusService {
 		};
 	}
 
-	private async getStatusDataTables(options: SourceControlGetStatus, collectVerbose: boolean) {
+	private async getStatusDataTables(
+		options: SourceControlGetStatus,
+		context: SourceControlContext,
+		collectVerbose: boolean,
+	) {
 		const sourceControlledFiles: SourceControlledFile[] = [];
 		const dataTablesRemote =
-			(await this.sourceControlImportService.getRemoteDataTablesFromFiles()) ?? [];
+			(await this.sourceControlImportService.getRemoteDataTablesFromFiles(context)) ?? [];
 		const dataTablesLocal =
-			(await this.sourceControlImportService.getLocalDataTablesFromDb()) ?? [];
+			(await this.sourceControlImportService.getLocalDataTablesFromDb(context)) ?? [];
 
 		const localById = new Map(dataTablesLocal.map((dt) => [dt.id, dt]));
 		const remoteById = new Map(dataTablesRemote.map((dt) => [dt.id, dt]));

--- a/packages/cli/test/integration/environments/source-control.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control.service.test.ts
@@ -1,5 +1,5 @@
 import type { SourceControlledFile } from '@n8n/api-types';
-import { createTeamProject, createWorkflow, testDb } from '@n8n/backend-test-utils';
+import { createTeamProject, createWorkflow, testDb, testModules } from '@n8n/backend-test-utils';
 import {
 	CredentialsEntity,
 	type Folder,
@@ -14,6 +14,7 @@ import {
 } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { createCredentials } from '@test-integration/db/credentials';
+import { createDataTable } from '@test-integration/db/data-tables';
 import { createFolder } from '@test-integration/db/folders';
 import { assignTagToWorkflow, createTag, updateTag } from '@test-integration/db/tags';
 import { createUser } from '@test-integration/db/users';
@@ -23,8 +24,10 @@ import { Cipher } from 'n8n-core';
 import fsp from 'node:fs/promises';
 import { basename, isAbsolute } from 'node:path';
 
+import type { DataTable } from '@/modules/data-table/data-table.entity';
 import {
 	SOURCE_CONTROL_CREDENTIAL_EXPORT_FOLDER,
+	SOURCE_CONTROL_DATATABLES_EXPORT_FOLDER,
 	SOURCE_CONTROL_FOLDERS_EXPORT_FILE,
 	SOURCE_CONTROL_TAGS_EXPORT_FILE,
 	SOURCE_CONTROL_WORKFLOW_EXPORT_FOLDER,
@@ -38,6 +41,7 @@ import { SourceControlScopedService } from '@/modules/source-control.ee/source-c
 import { SourceControlStatusService } from '@/modules/source-control.ee/source-control-status.service.ee';
 import { SourceControlService } from '@/modules/source-control.ee/source-control.service.ee';
 import type { ExportableCredential } from '@/modules/source-control.ee/types/exportable-credential';
+import type { ExportableDataTable } from '@/modules/source-control.ee/types/exportable-data-table';
 import type { ExportableFolder } from '@/modules/source-control.ee/types/exportable-folders';
 import type { ExportableWorkflow } from '@/modules/source-control.ee/types/exportable-workflow';
 import type { RemoteResourceOwner } from '@/modules/source-control.ee/types/resource-owner';
@@ -50,6 +54,7 @@ jest.mock('fast-glob');
 type Scope = {
 	workflows: WorkflowEntity[];
 	credentials: CredentialsEntity[];
+	dataTables: DataTable[];
 	folders: Folder[];
 };
 
@@ -128,6 +133,41 @@ function toExportableWorkflow(
 	};
 }
 
+function toExportableDataTable(table: DataTable, owner: Project | User): ExportableDataTable {
+	let resourceOwner: NonNullable<ExportableDataTable['ownedBy']>;
+
+	if (owner instanceof Project) {
+		resourceOwner = {
+			type: 'team',
+			teamId: owner.id,
+			teamName: owner.name,
+		};
+	} else {
+		resourceOwner = {
+			type: 'personal',
+			projectId: owner.id,
+			projectName: owner.createPersonalProjectName(),
+			personalEmail: owner.email,
+		};
+	}
+
+	return {
+		id: table.id,
+		name: table.name,
+		columns: (table.columns ?? [])
+			.sort((a, b) => a.index - b.index)
+			.map((column) => ({
+				id: column.id,
+				name: column.name,
+				type: column.type,
+				index: column.index,
+			})),
+		ownedBy: resourceOwner,
+		createdAt: table.createdAt.toISOString(),
+		updatedAt: table.updatedAt.toISOString(),
+	};
+}
+
 describe('SourceControlService', () => {
 	/*
 			Test scenarios (push):
@@ -178,6 +218,9 @@ describe('SourceControlService', () => {
 	let deletedOutOfScopeCredential: CredentialsEntity;
 	let deletedInScopeCredential: CredentialsEntity;
 
+	let remoteOutOfScopeDataTable: DataTable;
+	let remoteInScopeDataTable: DataTable;
+
 	let gitService: SourceControlGitService;
 	let service: SourceControlService;
 	let statusService: SourceControlStatusService;
@@ -192,6 +235,7 @@ describe('SourceControlService', () => {
 	const fsWriteFile = jest.spyOn(fsp, 'writeFile');
 
 	beforeAll(async () => {
+		await testModules.loadModules(['data-table']);
 		await testDb.init();
 
 		cipher = Container.get(Cipher);
@@ -353,6 +397,39 @@ describe('SourceControlService', () => {
 			]),
 		);
 
+		const [projectADataTables, projectBDataTables] = await Promise.all(
+			[projectA, projectB].map(async (project) => [
+				await createDataTable(project, {
+					name: `${project.name}-DataTableA`,
+					columns: [{ name: 'name', type: 'string' }],
+				}),
+				await createDataTable(project, {
+					name: `${project.name}-DataTableB`,
+					columns: [{ name: 'value', type: 'number' }],
+				}),
+			]),
+		);
+
+		const remoteDataTableDate = new Date('2024-01-01T00:00:00.000Z');
+		remoteInScopeDataTable = {
+			id: 'remoteInScopeDataTable',
+			name: 'Remote In Scope Data Table',
+			columns: [],
+			project: projectA,
+			projectId: projectA.id,
+			createdAt: remoteDataTableDate,
+			updatedAt: remoteDataTableDate,
+		} as DataTable;
+		remoteOutOfScopeDataTable = {
+			id: 'remoteOutOfScopeDataTable',
+			name: 'Remote Out Of Scope Data Table',
+			columns: [],
+			project: projectB,
+			projectId: projectB.id,
+			createdAt: remoteDataTableDate,
+			updatedAt: remoteDataTableDate,
+		} as DataTable;
+
 		tags = await Promise.all([
 			createTag({
 				name: 'testTag1',
@@ -396,36 +473,42 @@ describe('SourceControlService', () => {
 
 		globalAdminScope = {
 			credentials: [],
+			dataTables: [],
 			workflows: globalAdminWorkflows,
 			folders: [],
 		};
 
 		globalOwnerScope = {
 			credentials: [],
+			dataTables: [],
 			workflows: globalOwnerWorkflows,
 			folders: [],
 		};
 
 		globalMemberScope = {
 			credentials: [],
+			dataTables: [],
 			workflows: globalMemberWorkflows,
 			folders: [],
 		};
 
 		projectAdminScope = {
 			credentials: [],
+			dataTables: [],
 			workflows: projectAdminWorkflows,
 			folders: [],
 		};
 
 		projectAScope = {
 			credentials: projectACredentials,
+			dataTables: projectADataTables,
 			folders: projectAFolders,
 			workflows: projectAWorkflows,
 		};
 
 		projectBScope = {
 			credentials: projectBCredentials,
+			dataTables: projectBDataTables,
 			folders: projectBFolders,
 			workflows: projectBWorkflows,
 		};
@@ -491,6 +574,14 @@ describe('SourceControlService', () => {
 				deletedInScopeCredential,
 				projectA,
 			),
+			'datatables/remoteInScopeDataTable.json': toExportableDataTable(
+				remoteInScopeDataTable,
+				projectA,
+			),
+			'datatables/remoteOutOfScopeDataTable.json': toExportableDataTable(
+				remoteOutOfScopeDataTable,
+				projectB,
+			),
 			'folders.json': {
 				folders: [toExportableFolder(projectAFolders[0]), toExportableFolder(projectBFolders[0])],
 			},
@@ -522,6 +613,11 @@ describe('SourceControlService', () => {
 				// asking for credentials
 				return Object.keys(gitFiles).filter((file) =>
 					file.startsWith(SOURCE_CONTROL_CREDENTIAL_EXPORT_FOLDER),
+				);
+			} else if (opts.cwd?.endsWith(SOURCE_CONTROL_DATATABLES_EXPORT_FOLDER)) {
+				// asking for data tables
+				return Object.keys(gitFiles).filter((file) =>
+					file.startsWith(SOURCE_CONTROL_DATATABLES_EXPORT_FOLDER),
 				);
 			} else if (path === SOURCE_CONTROL_FOLDERS_EXPORT_FILE) {
 				// asking for folders
@@ -673,6 +769,29 @@ describe('SourceControlService', () => {
 						]),
 					);
 				});
+
+				it('should see all data tables', async () => {
+					const result = await service.getStatus(globalAdmin, {
+						direction: 'push',
+						preferLocalVersion: true,
+						verbose: false,
+					});
+
+					expect(Array.isArray(result)).toBe(true);
+
+					if (!Array.isArray(result)) {
+						throw new Error('Cannot reach this, only needed as type guard');
+					}
+
+					const dataTables = result.filter((r) => r.type === 'datatable' && r.status === 'created');
+
+					expect(new Set(dataTables.map((dataTable) => dataTable.id))).toEqual(
+						new Set([
+							...projectAScope.dataTables.map((dataTable) => dataTable.id),
+							...projectBScope.dataTables.map((dataTable) => dataTable.id),
+						]),
+					);
+				});
 			});
 
 			describe('global:member user', () => {
@@ -816,6 +935,73 @@ describe('SourceControlService', () => {
 						new Set([projectAScope.folders[1].id, projectAScope.folders[2].id]),
 					);
 				});
+
+				it('should see only data tables in correct scope', async () => {
+					const result = await service.getStatus(projectAdmin, {
+						direction: 'push',
+						preferLocalVersion: true,
+						verbose: false,
+					});
+
+					expect(Array.isArray(result)).toBe(true);
+
+					if (!Array.isArray(result)) {
+						throw new Error('Cannot reach this, only needed as type guard');
+					}
+
+					const dataTables = result.filter((r) => r.type === 'datatable');
+
+					expect(new Set(dataTables.map((dataTable) => dataTable.id))).toEqual(
+						new Set(projectAScope.dataTables.map((dataTable) => dataTable.id)),
+					);
+					expect(dataTables.every((dataTable) => dataTable.status === 'created')).toBe(true);
+					expect(
+						dataTables.some((dataTable) =>
+							projectBScope.dataTables.some((outOfScope) => outOfScope.id === dataTable.id),
+						),
+					).toBe(false);
+				});
+			});
+		});
+
+		describe('remote data tables', () => {
+			describe('project:Admin user', () => {
+				it('should see only tracked remote data tables in correct scope', async () => {
+					(gitService.getHistoricallyTrackedFiles as jest.Mock).mockResolvedValueOnce(
+						new Set([
+							`${SOURCE_CONTROL_DATATABLES_EXPORT_FOLDER}/${remoteInScopeDataTable.id}.json`,
+							`${SOURCE_CONTROL_DATATABLES_EXPORT_FOLDER}/${remoteOutOfScopeDataTable.id}.json`,
+						]),
+					);
+
+					const result = await service.getStatus(projectAdmin, {
+						direction: 'push',
+						preferLocalVersion: true,
+						verbose: false,
+					});
+
+					expect(Array.isArray(result)).toBe(true);
+
+					if (!Array.isArray(result)) {
+						throw new Error('Cannot reach this, only needed as type guard');
+					}
+
+					const dataTables = result.filter((r) => r.type === 'datatable');
+
+					expect(dataTables).toHaveLength(projectAScope.dataTables.length + 1);
+					expect(dataTables).toContainEqual(
+						expect.objectContaining({
+							id: remoteInScopeDataTable.id,
+							type: 'datatable',
+							status: 'deleted',
+						}),
+					);
+					expect(dataTables).not.toContainEqual(
+						expect.objectContaining({
+							id: remoteOutOfScopeDataTable.id,
+						}),
+					);
+				});
 			});
 		});
 	});
@@ -877,7 +1063,7 @@ describe('SourceControlService', () => {
 		});
 
 		describe('global:admin user', () => {
-			it('should update all workflows, credentials, tags and folder', async () => {
+			it('should update all workflows, credentials, data tables, tags and folder', async () => {
 				const allChanges = (await service.getStatus(globalAdmin, {
 					direction: 'push',
 					preferLocalVersion: true,
@@ -900,17 +1086,26 @@ describe('SourceControlService', () => {
 				const projectFiles = result.statusResult
 					.filter((change) => change.type === 'project' && change.status !== 'deleted')
 					.map((change) => change.file);
+				const dataTableFiles = result.statusResult
+					.filter((change) => change.type === 'datatable' && change.status !== 'deleted')
+					.map((change) => change.file);
 
 				expect(workflowFiles).toHaveLength(8);
 				expect(credentialFiles).toHaveLength(2);
 				expect(projectFiles).toHaveLength(2);
+				expect(dataTableFiles).toHaveLength(4);
 
 				expect(gitService.push).toBeCalled();
 				expect(fsWriteFile).toBeCalledTimes(
-					workflowFiles.length + credentialFiles.length + projectFiles.length + 2,
+					workflowFiles.length +
+						credentialFiles.length +
+						projectFiles.length +
+						dataTableFiles.length +
+						2,
 				); // folders + tags
 				expect(Object.keys(updatedFiles)).toEqual(expect.arrayContaining(workflowFiles));
 				expect(Object.keys(updatedFiles)).toEqual(expect.arrayContaining(credentialFiles));
+				expect(Object.keys(updatedFiles)).toEqual(expect.arrayContaining(dataTableFiles));
 				expect(Object.keys(updatedFiles)).toEqual(
 					expect.arrayContaining([expect.stringMatching(SOURCE_CONTROL_FOLDERS_EXPORT_FILE)]),
 				);
@@ -941,19 +1136,28 @@ describe('SourceControlService', () => {
 				const projectFiles = result.statusResult
 					.filter((change) => change.type === 'project' && change.status !== 'deleted')
 					.map((change) => change.file);
+				const dataTableFiles = result.statusResult
+					.filter((change) => change.type === 'datatable' && change.status !== 'deleted')
+					.map((change) => change.file);
 
 				expect(workflowFiles).toHaveLength(8);
 				expect(credentialFiles).toHaveLength(2);
 				expect(projectFiles).toHaveLength(2);
+				expect(dataTableFiles).toHaveLength(4);
 				const numberFilesToWrite =
-					workflowFiles.length + credentialFiles.length + projectFiles.length + 2; // folders + tags + projects
+					workflowFiles.length +
+					credentialFiles.length +
+					projectFiles.length +
+					dataTableFiles.length +
+					2; // folders + tags
 
 				const filesToWrite =
 					allChanges.filter(
 						(change) =>
 							(change.type === 'workflow' ||
 								change.type === 'credential' ||
-								change.type === 'project') &&
+								change.type === 'project' ||
+								change.type === 'datatable') &&
 							change.status !== 'deleted',
 					).length + 2; // folders + tags
 
@@ -963,6 +1167,7 @@ describe('SourceControlService', () => {
 				expect(Object.keys(updatedFiles)).toEqual(expect.arrayContaining(workflowFiles));
 				expect(Object.keys(updatedFiles)).toEqual(expect.arrayContaining(credentialFiles));
 				expect(Object.keys(updatedFiles)).toEqual(expect.arrayContaining(projectFiles));
+				expect(Object.keys(updatedFiles)).toEqual(expect.arrayContaining(dataTableFiles));
 				expect(Object.keys(updatedFiles)).toEqual(
 					expect.arrayContaining([expect.stringMatching(SOURCE_CONTROL_FOLDERS_EXPORT_FILE)]),
 				);
@@ -981,7 +1186,7 @@ describe('SourceControlService', () => {
 		});
 
 		describe('project:admin', () => {
-			it('should update selected workflows, credentials, tags and folders', async () => {
+			it('should update selected workflows, credentials, data tables, tags and folders', async () => {
 				const allChanges = (await service.getStatus(projectAdmin, {
 					direction: 'push',
 					preferLocalVersion: true,
@@ -1003,17 +1208,26 @@ describe('SourceControlService', () => {
 				const projectFiles = result.statusResult
 					.filter((change) => change.type === 'project' && change.status !== 'deleted')
 					.map((change) => change.file);
+				const dataTableFiles = result.statusResult
+					.filter((change) => change.type === 'datatable' && change.status !== 'deleted')
+					.map((change) => change.file);
 
 				expect(workflowFiles).toHaveLength(2);
 				expect(credentialFiles).toHaveLength(1);
 				expect(projectFiles).toHaveLength(1);
+				expect(dataTableFiles).toHaveLength(2);
 
-				// folders + tags + projects (1)
+				// folders + tags
 				expect(fsWriteFile).toBeCalledTimes(
-					workflowFiles.length + credentialFiles.length + projectFiles.length + 2,
+					workflowFiles.length +
+						credentialFiles.length +
+						projectFiles.length +
+						dataTableFiles.length +
+						2,
 				);
 				expect(Object.keys(updatedFiles)).toEqual(expect.arrayContaining(workflowFiles));
 				expect(Object.keys(updatedFiles)).toEqual(expect.arrayContaining(credentialFiles));
+				expect(Object.keys(updatedFiles)).toEqual(expect.arrayContaining(dataTableFiles));
 				expect(Object.keys(updatedFiles)).toEqual(
 					expect.arrayContaining([expect.stringMatching(SOURCE_CONTROL_FOLDERS_EXPORT_FILE)]),
 				);

--- a/packages/cli/test/integration/environments/source-control.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control.service.test.ts
@@ -24,7 +24,7 @@ import { Cipher } from 'n8n-core';
 import fsp from 'node:fs/promises';
 import { basename, isAbsolute } from 'node:path';
 
-import type { DataTable } from '@/modules/data-table/data-table.entity';
+import { DataTable } from '@/modules/data-table/data-table.entity';
 import {
 	SOURCE_CONTROL_CREDENTIAL_EXPORT_FOLDER,
 	SOURCE_CONTROL_DATATABLES_EXPORT_FOLDER,
@@ -411,7 +411,7 @@ describe('SourceControlService', () => {
 		);
 
 		const remoteDataTableDate = new Date('2024-01-01T00:00:00.000Z');
-		remoteInScopeDataTable = {
+		remoteInScopeDataTable = Object.assign(new DataTable(), {
 			id: 'remoteInScopeDataTable',
 			name: 'Remote In Scope Data Table',
 			columns: [],
@@ -419,8 +419,8 @@ describe('SourceControlService', () => {
 			projectId: projectA.id,
 			createdAt: remoteDataTableDate,
 			updatedAt: remoteDataTableDate,
-		} as DataTable;
-		remoteOutOfScopeDataTable = {
+		});
+		remoteOutOfScopeDataTable = Object.assign(new DataTable(), {
 			id: 'remoteOutOfScopeDataTable',
 			name: 'Remote Out Of Scope Data Table',
 			columns: [],
@@ -428,7 +428,7 @@ describe('SourceControlService', () => {
 			projectId: projectB.id,
 			createdAt: remoteDataTableDate,
 			updatedAt: remoteDataTableDate,
-		} as DataTable;
+		});
 
 		tags = await Promise.all([
 			createTag({


### PR DESCRIPTION
## Summary

Scopes source-control data table export/status/pull logic to projects available in the current source-control context.

Includes regression coverage for local and remote data table filtering, plus status context propagation.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-581

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI