### PR TITLE
feat(core): Wire episodic memory into agent runtime

### DIFF
--- a/packages/@n8n/agents/src/index.ts
+++ b/packages/@n8n/agents/src/index.ts
@@ -158,6 +158,28 @@ export { createModel } from './runtime/model-factory';
 export { createEmbeddingModel } from './runtime/model-factory';
 export { generateTitleFromMessage } from './runtime/title-generation';
 export {
+	activeLifecycleState,
+	droppedLifecycleState,
+	markLifecycleActive,
+	markLifecycleDropped,
+	markLifecycleSuperseded,
+	normalizeFlatReflectionActions,
+	supersededLifecycleState,
+	uniqueStrings,
+} from './runtime/memory-lifecycle';
+export {
+	RECALL_MEMORY_TOOL_NAME,
+	createRecallMemoryTool,
+	getEpisodicMemoryScope,
+	hashEpisodicMemoryContent,
+	hashEpisodicMemoryEvidence,
+	hasEpisodicMemoryStore,
+	isEpisodicMemoryEnabled,
+	rankEpisodicMemoryEntries,
+	runEpisodicMemoryIndexer,
+	withEpisodicMemoryDefaults,
+} from './runtime/episodic-memory';
+export {
 	DEFAULT_EPISODIC_MEMORY_EMBEDDING_MODEL,
 	DEFAULT_EPISODIC_MEMORY_EXTRACTION_PROMPT,
 	DEFAULT_EPISODIC_MEMORY_MAX_ENTRIES_PER_RUN,
@@ -173,6 +195,7 @@ export type {
 	CreateEpisodicMemoryExtractFnOptions,
 	CreateEpisodicMemoryReflectFnOptions,
 } from './runtime/episodic-memory-defaults';
+export type { MemoryLifecycleState, MemoryLifecycleStatus } from './runtime/memory-lifecycle';
 export {
 	parseObservationLogMarkdown,
 	renderObserverTranscript,

--- a/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
@@ -38,6 +38,8 @@ jest.mock('ai', () => {
 	const actual = jest.requireActual<AiImport>('ai');
 	return {
 		...actual,
+		embed: jest.fn(),
+		embedMany: jest.fn(),
 		generateText: jest.fn(),
 		streamText: jest.fn(),
 		tool: jest.fn((config: unknown) => config),
@@ -52,7 +54,9 @@ jest.mock('ai', () => {
 // ---------------------------------------------------------------------------
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const { generateText, streamText } = require('ai') as {
+const { embed, embedMany, generateText, streamText } = require('ai') as {
+	embed: jest.Mock;
+	embedMany: jest.Mock;
 	generateText: jest.Mock;
 	streamText: jest.Mock;
 };
@@ -2609,6 +2613,107 @@ describe('AgentRuntime — observation log jobs', () => {
 				text: 'User asked for generate observation memory.',
 			},
 		]);
+	});
+
+	it('indexes episodic memory after observation jobs complete', async () => {
+		generateText.mockResolvedValue(makeGenerateSuccess('Remembered response'));
+		embed.mockResolvedValue({ embedding: [1, 0], usage: { tokens: 1 } });
+		embedMany.mockResolvedValue({ embeddings: [[1, 0]], usage: { tokens: 1 } });
+		const memory = new InMemoryMemory();
+		const fakeEmbedder = { specificationVersion: 'v2' } as never;
+
+		const runtime = new AgentRuntime({
+			name: 'observing-agent',
+			model: 'openai/gpt-4o-mini',
+			instructions: 'You are a test assistant.',
+			memory,
+			observationalMemory: {
+				observerThresholdTokens: 1,
+				observationLogTailLimit: 20,
+				observe: async () =>
+					await Promise.resolve('* CRITICAL (14:30) User chose Postgres for memory storage.'),
+			},
+			episodicMemory: {
+				embedder: fakeEmbedder,
+				extract: async ({ observations }) =>
+					await Promise.resolve({
+						entries: [
+							{
+								content: 'User chose Postgres for memory storage.',
+								sources: [
+									{
+										observationId: observations[0].id,
+										evidence: 'User chose Postgres',
+									},
+								],
+							},
+						],
+					}),
+			},
+		});
+
+		await runtime.generate('Please remember the Postgres decision.', {
+			persistence: { agentId: 'agent-1', threadId: 'thread-1', resourceId: 'resource-1' },
+		});
+		await runtime.dispose();
+
+		const entries = await memory.searchEpisodicMemoryEntries(
+			{ agentId: 'agent-1', resourceId: 'resource-1' },
+			'Postgres storage',
+			{ queryEmbedding: [1, 0] },
+		);
+		expect(entries).toHaveLength(1);
+		expect(entries[0].content).toBe('User chose Postgres for memory storage.');
+		const cursor = await memory.getEpisodicMemoryCursor({
+			scopeKind: 'thread',
+			scopeId: createObservationLogThreadScopeId('thread-1', 'resource-1'),
+		});
+		expect(typeof cursor?.lastIndexedObservationId).toBe('string');
+	});
+
+	it('does not inject episodic memory and exposes recall_memory for explicit recall', async () => {
+		generateText.mockResolvedValue(makeGenerateSuccess('Scoped response'));
+		const memory = new InMemoryMemory();
+		const fakeEmbedder = { specificationVersion: 'v2' } as never;
+		await memory.saveEpisodicMemoryEntries([
+			{
+				agentId: 'agent-1',
+				resourceId: 'resource-1',
+				content: 'Earlier session: user chose Postgres for memory storage.',
+				embedding: [1, 0],
+			},
+		]);
+		await memory.saveEpisodicMemoryEntries([
+			{
+				agentId: 'agent-1',
+				resourceId: 'resource-2',
+				content: 'Earlier session: user chose SQLite for memory storage.',
+				embedding: [1, 0],
+			},
+		]);
+
+		const runtime = new AgentRuntime({
+			name: 'observing-agent',
+			model: 'openai/gpt-4o-mini',
+			instructions: 'You are a test assistant.',
+			memory,
+			episodicMemory: { embedder: fakeEmbedder },
+		});
+
+		await runtime.generate('What storage did we choose?', {
+			persistence: { agentId: 'agent-1', threadId: 'thread-1', resourceId: 'resource-1' },
+		});
+
+		const callArgs = (generateText.mock.calls[0] as [unknown])[0] as {
+			messages: Array<{ content: string }>;
+			tools: Record<string, unknown>;
+		};
+		const systemPrompt = callArgs.messages[0]?.content ?? '';
+		expect(systemPrompt).not.toContain('<episodic_memory>');
+		expect(systemPrompt).not.toContain('Postgres');
+		expect(systemPrompt).not.toContain('SQLite');
+		expect(callArgs.tools).toHaveProperty('recall_memory');
+		expect(embed).not.toHaveBeenCalled();
 	});
 
 	it('does not schedule observation jobs without policy callbacks', async () => {

--- a/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
@@ -2653,12 +2653,12 @@ describe('AgentRuntime — observation log jobs', () => {
 		});
 
 		await runtime.generate('Please remember the Postgres decision.', {
-			persistence: { agentId: 'agent-1', threadId: 'thread-1', resourceId: 'resource-1' },
+			persistence: { threadId: 'thread-1', resourceId: 'resource-1' },
 		});
 		await runtime.dispose();
 
 		const entries = await memory.searchEpisodicMemoryEntries(
-			{ agentId: 'agent-1', resourceId: 'resource-1' },
+			{ namespace: 'resource-1', resourceId: 'resource-1' },
 			'Postgres storage',
 			{ queryEmbedding: [1, 0] },
 		);
@@ -2677,7 +2677,7 @@ describe('AgentRuntime — observation log jobs', () => {
 		const fakeEmbedder = { specificationVersion: 'v2' } as never;
 		await memory.saveEpisodicMemoryEntries([
 			{
-				agentId: 'agent-1',
+				namespace: 'resource-1',
 				resourceId: 'resource-1',
 				content: 'Earlier session: user chose Postgres for memory storage.',
 				embedding: [1, 0],
@@ -2685,7 +2685,7 @@ describe('AgentRuntime — observation log jobs', () => {
 		]);
 		await memory.saveEpisodicMemoryEntries([
 			{
-				agentId: 'agent-1',
+				namespace: 'resource-2',
 				resourceId: 'resource-2',
 				content: 'Earlier session: user chose SQLite for memory storage.',
 				embedding: [1, 0],
@@ -2701,7 +2701,7 @@ describe('AgentRuntime — observation log jobs', () => {
 		});
 
 		await runtime.generate('What storage did we choose?', {
-			persistence: { agentId: 'agent-1', threadId: 'thread-1', resourceId: 'resource-1' },
+			persistence: { threadId: 'thread-1', resourceId: 'resource-1' },
 		});
 
 		const callArgs = (generateText.mock.calls[0] as [unknown])[0] as {

--- a/packages/@n8n/agents/src/runtime/__tests__/episodic-memory.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/episodic-memory.test.ts
@@ -27,7 +27,7 @@ function entry(overrides: Partial<EpisodicMemoryEntry> = {}): EpisodicMemoryEntr
 	const now = new Date('2026-05-12T10:00:00.000Z');
 	return {
 		id: overrides.id ?? crypto.randomUUID(),
-		agentId: overrides.agentId ?? 'agent-1',
+		namespace: overrides.namespace ?? 'agent-1',
 		resourceId: overrides.resourceId ?? 'user-1',
 		content: overrides.content ?? 'User chose Postgres for the memory store.',
 		contentHash: overrides.contentHash ?? crypto.randomUUID(),
@@ -152,7 +152,7 @@ describe('createRecallMemoryTool', () => {
 		const tool = createRecallMemoryTool({
 			memory,
 			config: { embedder: fakeEmbedder },
-			scope: { agentId: 'agent-1', resourceId: 'user-1' },
+			scope: { namespace: 'agent-1', resourceId: 'user-1' },
 		});
 
 		expect(tool.systemInstruction).toContain('Only call recall_memory');
@@ -173,13 +173,13 @@ describe('getEpisodicMemoryScope', () => {
 	it('uses the episodic-specific resource partition when provided', () => {
 		expect(
 			getEpisodicMemoryScope({
-				agentId: 'agent-1',
+				episodicMemoryNamespace: 'agent-1',
 				resourceId: 'chat-user-1',
 				threadId: 'thread-1',
 				episodicMemoryResourceId: 'integration:slack:thread-1',
 			}),
 		).toEqual({
-			agentId: 'agent-1',
+			namespace: 'agent-1',
 			resourceId: 'integration:slack:thread-1',
 		});
 	});
@@ -187,12 +187,11 @@ describe('getEpisodicMemoryScope', () => {
 	it('falls back to the persistence resourceId for existing SDK callers', () => {
 		expect(
 			getEpisodicMemoryScope({
-				agentId: 'agent-1',
 				resourceId: 'chat-user-1',
 				threadId: 'thread-1',
 			}),
 		).toEqual({
-			agentId: 'agent-1',
+			namespace: 'chat-user-1',
 			resourceId: 'chat-user-1',
 		});
 	});
@@ -203,12 +202,12 @@ describe('InMemoryMemory episodic source cleanup', () => {
 		const memory = new InMemoryMemory();
 		const [orphaned, shared] = await memory.saveEpisodicMemoryEntries([
 			{
-				agentId: 'agent-1',
+				namespace: 'agent-1',
 				resourceId: 'user-1',
 				content: 'User chose Postgres for durable memory storage.',
 			},
 			{
-				agentId: 'agent-1',
+				namespace: 'agent-1',
 				resourceId: 'user-1',
 				content: 'User prefers source-backed cross-session recall.',
 			},
@@ -238,14 +237,14 @@ describe('InMemoryMemory episodic source cleanup', () => {
 
 		await expect(
 			memory.searchEpisodicMemoryEntries(
-				{ agentId: 'agent-1', resourceId: 'user-1' },
+				{ namespace: 'agent-1', resourceId: 'user-1' },
 				'source-backed',
 				{ topK: 10 },
 			),
 		).resolves.toEqual([expect.objectContaining({ id: shared.id })]);
 		await expect(
 			memory.searchEpisodicMemoryEntries(
-				{ agentId: 'agent-1', resourceId: 'user-1' },
+				{ namespace: 'agent-1', resourceId: 'user-1' },
 				'Postgres storage',
 				{ includeStatuses: ['dropped'], topK: 10 },
 			),
@@ -290,7 +289,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		const result = await runEpisodicMemoryIndexer({
 			memory,
 			config: { embedder: fakeEmbedder, extract },
-			scope: { agentId: 'agent-1', resourceId: 'user-1' },
+			scope: { namespace: 'agent-1', resourceId: 'user-1' },
 			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
 			threadId: 'thread-1',
 			eventBus: new AgentEventBus(),
@@ -299,7 +298,7 @@ describe('runEpisodicMemoryIndexer', () => {
 
 		expect(result).toEqual({ status: 'ran', entriesWritten: 1, observationsIndexed: 1 });
 		const stored = await memory.searchEpisodicMemoryEntries(
-			{ agentId: 'agent-1', resourceId: 'user-1' },
+			{ namespace: 'agent-1', resourceId: 'user-1' },
 			'Postgres enterprise',
 			{ queryEmbedding: [1, 0] },
 		);
@@ -309,7 +308,7 @@ describe('runEpisodicMemoryIndexer', () => {
 			runEpisodicMemoryIndexer({
 				memory,
 				config: { embedder: fakeEmbedder, extract },
-				scope: { agentId: 'agent-1', resourceId: 'user-1' },
+				scope: { namespace: 'agent-1', resourceId: 'user-1' },
 				observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
 				threadId: 'thread-1',
 				eventBus: new AgentEventBus(),
@@ -344,7 +343,7 @@ describe('runEpisodicMemoryIndexer', () => {
 			runEpisodicMemoryIndexer({
 				memory,
 				config: { embedder: fakeEmbedder, extract },
-				scope: { agentId: 'agent-1', resourceId: 'user-1' },
+				scope: { namespace: 'agent-1', resourceId: 'user-1' },
 				observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
 				threadId: 'thread-1',
 				eventBus: new AgentEventBus(),
@@ -354,7 +353,7 @@ describe('runEpisodicMemoryIndexer', () => {
 
 		await expect(
 			memory.searchEpisodicMemoryEntries(
-				{ agentId: 'agent-1', resourceId: 'user-1' },
+				{ namespace: 'agent-1', resourceId: 'user-1' },
 				'Postgres memory',
 			),
 		).resolves.toEqual([]);
@@ -405,7 +404,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		await runEpisodicMemoryIndexer({
 			memory,
 			config: { embedder: fakeEmbedder, extract },
-			scope: { agentId: 'agent-1', resourceId: 'user-1' },
+			scope: { namespace: 'agent-1', resourceId: 'user-1' },
 			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
 			threadId: 'thread-1',
 			eventBus: new AgentEventBus(),
@@ -458,14 +457,14 @@ describe('runEpisodicMemoryIndexer', () => {
 		await runEpisodicMemoryIndexer({
 			memory,
 			config: { embedder: fakeEmbedder, extract },
-			scope: { agentId: 'agent-1', resourceId: 'user-1' },
+			scope: { namespace: 'agent-1', resourceId: 'user-1' },
 			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
 			threadId: 'thread-1',
 			eventBus: new AgentEventBus(),
 		});
 
 		const [stored] = await memory.searchEpisodicMemoryEntries(
-			{ agentId: 'agent-1', resourceId: 'user-1' },
+			{ namespace: 'agent-1', resourceId: 'user-1' },
 			'VENDORSTATUSCOMPLETE',
 			{ topK: 1 },
 		);
@@ -496,7 +495,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		const result = await runEpisodicMemoryIndexer({
 			memory,
 			config: { embedder: fakeEmbedder, extract },
-			scope: { agentId: 'agent-1', resourceId: 'user-1' },
+			scope: { namespace: 'agent-1', resourceId: 'user-1' },
 			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
 			threadId: 'thread-1',
 			eventBus: new AgentEventBus(),
@@ -504,7 +503,7 @@ describe('runEpisodicMemoryIndexer', () => {
 
 		expect(result).toEqual({ status: 'ran', entriesWritten: 0, observationsIndexed: 1 });
 		await expect(
-			memory.searchEpisodicMemoryEntries({ agentId: 'agent-1', resourceId: 'user-1' }, 'API key'),
+			memory.searchEpisodicMemoryEntries({ namespace: 'agent-1', resourceId: 'user-1' }, 'API key'),
 		).resolves.toEqual([]);
 	});
 
@@ -557,7 +556,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		const result = await runEpisodicMemoryIndexer({
 			memory,
 			config: { embedder: fakeEmbedder, extract },
-			scope: { agentId: 'agent-1', resourceId: 'user-1' },
+			scope: { namespace: 'agent-1', resourceId: 'user-1' },
 			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
 			threadId: 'thread-1',
 			eventBus: new AgentEventBus(),
@@ -566,7 +565,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		expect(result).toEqual({ status: 'ran', entriesWritten: 0, observationsIndexed: 3 });
 		await expect(
 			memory.searchEpisodicMemoryEntries(
-				{ agentId: 'agent-1', resourceId: 'user-1' },
+				{ namespace: 'agent-1', resourceId: 'user-1' },
 				'memory feature decisions',
 			),
 		).resolves.toEqual([]);
@@ -576,7 +575,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		const memory = new InMemoryMemory();
 		const [oldEntry] = await memory.saveEpisodicMemoryEntries([
 			{
-				agentId: 'agent-1',
+				namespace: 'agent-1',
 				resourceId: 'user-1',
 				content: 'User planned SQLite for local-first memory storage.',
 				embedding: [1, 0],
@@ -609,14 +608,14 @@ describe('runEpisodicMemoryIndexer', () => {
 		await runEpisodicMemoryIndexer({
 			memory,
 			config: { embedder: fakeEmbedder, extract },
-			scope: { agentId: 'agent-1', resourceId: 'user-1' },
+			scope: { namespace: 'agent-1', resourceId: 'user-1' },
 			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
 			threadId: 'thread-1',
 			eventBus: new AgentEventBus(),
 		});
 
 		const entries = await memory.searchEpisodicMemoryEntries(
-			{ agentId: 'agent-1', resourceId: 'user-1' },
+			{ namespace: 'agent-1', resourceId: 'user-1' },
 			'SQLite Postgres memory storage',
 			{ includeStatuses: ['active', 'superseded'], queryEmbedding: [1, 0], topK: 10 },
 		);
@@ -627,7 +626,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		const memory = new InMemoryMemory();
 		const [oldEntry] = await memory.saveEpisodicMemoryEntries([
 			{
-				agentId: 'agent-1',
+				namespace: 'agent-1',
 				resourceId: 'user-1',
 				content: 'User planned SQLite for local-first memory storage.',
 				embedding: [1, 0],
@@ -687,14 +686,14 @@ describe('runEpisodicMemoryIndexer', () => {
 		await runEpisodicMemoryIndexer({
 			memory,
 			config: { embedder: fakeEmbedder, extract, reflect },
-			scope: { agentId: 'agent-1', resourceId: 'user-1' },
+			scope: { namespace: 'agent-1', resourceId: 'user-1' },
 			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
 			threadId: 'thread-1',
 			eventBus: new AgentEventBus(),
 		});
 
 		const active = await memory.searchEpisodicMemoryEntries(
-			{ agentId: 'agent-1', resourceId: 'user-1' },
+			{ namespace: 'agent-1', resourceId: 'user-1' },
 			'Postgres enterprise constraints',
 			{ queryEmbedding: [1, 0], topK: 10 },
 		);
@@ -702,7 +701,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		expect(active[0].content).toContain('from SQLite to Postgres');
 
 		const inactive = await memory.searchEpisodicMemoryEntries(
-			{ agentId: 'agent-1', resourceId: 'user-1' },
+			{ namespace: 'agent-1', resourceId: 'user-1' },
 			'SQLite Postgres',
 			{ includeStatuses: ['superseded'], queryEmbedding: [1, 0], topK: 10 },
 		);
@@ -734,7 +733,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		const memory = new InMemoryMemory();
 		const [oldEntry] = await memory.saveEpisodicMemoryEntries([
 			{
-				agentId: 'agent-1',
+				namespace: 'agent-1',
 				resourceId: 'user-1',
 				content: 'User planned a Harborlight vendor intake pilot.',
 				embedding: [1, 0],
@@ -785,14 +784,14 @@ describe('runEpisodicMemoryIndexer', () => {
 		await runEpisodicMemoryIndexer({
 			memory,
 			config: { embedder: fakeEmbedder, extract, reflect },
-			scope: { agentId: 'agent-1', resourceId: 'user-1' },
+			scope: { namespace: 'agent-1', resourceId: 'user-1' },
 			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
 			threadId: 'thread-1',
 			eventBus: new AgentEventBus(),
 		});
 
 		const [stored] = await memory.searchEpisodicMemoryEntries(
-			{ agentId: 'agent-1', resourceId: 'user-1' },
+			{ namespace: 'agent-1', resourceId: 'user-1' },
 			'REFLECTEDVENDORSTATUSCOMPLETE',
 			{ topK: 1 },
 		);
@@ -804,7 +803,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		const memory = new InMemoryMemory();
 		const [noise] = await memory.saveEpisodicMemoryEntries([
 			{
-				agentId: 'agent-1',
+				namespace: 'agent-1',
 				resourceId: 'user-1',
 				content: 'Agent queried memory and no entries were found.',
 				embedding: [1, 0],
@@ -838,20 +837,20 @@ describe('runEpisodicMemoryIndexer', () => {
 		await runEpisodicMemoryIndexer({
 			memory,
 			config: { embedder: fakeEmbedder, extract, reflect },
-			scope: { agentId: 'agent-1', resourceId: 'user-1' },
+			scope: { namespace: 'agent-1', resourceId: 'user-1' },
 			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
 			threadId: 'thread-1',
 			eventBus: new AgentEventBus(),
 		});
 
 		const active = await memory.searchEpisodicMemoryEntries(
-			{ agentId: 'agent-1', resourceId: 'user-1' },
+			{ namespace: 'agent-1', resourceId: 'user-1' },
 			'no entries found',
 			{ queryEmbedding: [1, 0], topK: 10 },
 		);
 		expect(active.map((entry) => entry.id)).not.toContain(noise.id);
 		const [dropped] = await memory.searchEpisodicMemoryEntries(
-			{ agentId: 'agent-1', resourceId: 'user-1' },
+			{ namespace: 'agent-1', resourceId: 'user-1' },
 			'no entries found',
 			{ includeStatuses: ['dropped'], queryEmbedding: [1, 0] },
 		);
@@ -862,7 +861,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		const memory = new InMemoryMemory();
 		const [northstar] = await memory.saveEpisodicMemoryEntries([
 			{
-				agentId: 'agent-1',
+				namespace: 'agent-1',
 				resourceId: 'user-1',
 				content: 'Northstar routing issue was caused by stale manager email mappings.',
 				embedding: [1, 0],
@@ -902,14 +901,14 @@ describe('runEpisodicMemoryIndexer', () => {
 		await runEpisodicMemoryIndexer({
 			memory,
 			config: { embedder: fakeEmbedder, extract, reflect },
-			scope: { agentId: 'agent-1', resourceId: 'user-1' },
+			scope: { namespace: 'agent-1', resourceId: 'user-1' },
 			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
 			threadId: 'thread-1',
 			eventBus: new AgentEventBus(),
 		});
 
 		const active = await memory.searchEpisodicMemoryEntries(
-			{ agentId: 'agent-1', resourceId: 'user-1' },
+			{ namespace: 'agent-1', resourceId: 'user-1' },
 			'Northstar Southeast routing invoice',
 			{ queryEmbedding: [1, 0], topK: 10 },
 		);
@@ -952,7 +951,7 @@ describe('runEpisodicMemoryIndexer', () => {
 			runEpisodicMemoryIndexer({
 				memory,
 				config: { embedder: fakeEmbedder, extract, reflect },
-				scope: { agentId: 'agent-1', resourceId: 'user-1' },
+				scope: { namespace: 'agent-1', resourceId: 'user-1' },
 				observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
 				threadId: 'thread-1',
 				eventBus,
@@ -961,7 +960,7 @@ describe('runEpisodicMemoryIndexer', () => {
 
 		await expect(
 			memory.searchEpisodicMemoryEntries(
-				{ agentId: 'agent-1', resourceId: 'user-1' },
+				{ namespace: 'agent-1', resourceId: 'user-1' },
 				'Postgres memory store',
 				{ queryEmbedding: [1, 0] },
 			),

--- a/packages/@n8n/agents/src/runtime/__tests__/episodic-memory.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/episodic-memory.test.ts
@@ -1,0 +1,976 @@
+import { embed, embedMany } from 'ai';
+
+import type {
+	EpisodicMemoryEntry,
+	EpisodicMemoryExtractFn,
+	EpisodicMemoryReflectFn,
+} from '../../types';
+import {
+	createRecallMemoryTool,
+	getEpisodicMemoryScope,
+	rankEpisodicMemoryEntries,
+	runEpisodicMemoryIndexer,
+} from '../episodic-memory';
+import { AgentEventBus } from '../event-bus';
+import { InMemoryMemory } from '../memory-store';
+
+jest.mock('ai', () => ({
+	embed: jest.fn(),
+	embedMany: jest.fn(),
+}));
+
+const mockedEmbed = jest.mocked(embed);
+const mockedEmbedMany = jest.mocked(embedMany);
+const fakeEmbedder = { specificationVersion: 'v2' } as never;
+
+function entry(overrides: Partial<EpisodicMemoryEntry> = {}): EpisodicMemoryEntry {
+	const now = new Date('2026-05-12T10:00:00.000Z');
+	return {
+		id: overrides.id ?? crypto.randomUUID(),
+		agentId: overrides.agentId ?? 'agent-1',
+		resourceId: overrides.resourceId ?? 'user-1',
+		content: overrides.content ?? 'User chose Postgres for the memory store.',
+		contentHash: overrides.contentHash ?? crypto.randomUUID(),
+		status: overrides.status ?? 'active',
+		supersededBy: overrides.supersededBy ?? null,
+		embedding: overrides.embedding,
+		embeddingModel: overrides.embeddingModel,
+		metadata: overrides.metadata ?? null,
+		createdAt: overrides.createdAt ?? now,
+		updatedAt: overrides.updatedAt ?? now,
+		lastSeenAt: overrides.lastSeenAt ?? now,
+	};
+}
+
+describe('rankEpisodicMemoryEntries', () => {
+	it('combines lexical, vector, and recency while ignoring inactive entries by default', () => {
+		const newer = entry({
+			id: 'newer',
+			content: 'Acme webhook retries were caused by 429 responses.',
+			embedding: [1, 0],
+			createdAt: new Date(),
+		});
+		const oldDate = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000);
+		const older = entry({
+			id: 'older',
+			content: 'Acme webhook delay investigation ruled out queue lag.',
+			embedding: [0.9, 0.1],
+			createdAt: oldDate,
+			lastSeenAt: oldDate,
+		});
+		const superseded = entry({
+			id: 'superseded',
+			content: 'Acme webhook memory store was SQLite.',
+			status: 'superseded',
+		});
+
+		const results = rankEpisodicMemoryEntries([older, superseded, newer], 'Acme webhook 429', {
+			queryEmbedding: [1, 0],
+			topK: 5,
+		});
+
+		expect(results.map((result) => result.id)).toEqual(['newer', 'older']);
+		expect(results[0].vectorScore).toBeGreaterThan(results[1].vectorScore);
+		expect(results[0].finalScore).toBeGreaterThan(results[1].finalScore);
+	});
+
+	it('uses recency as a ranking signal when relevant entries are otherwise tied', () => {
+		const now = new Date();
+		const stalePlanning = entry({
+			id: 'stale-planning',
+			content: 'Midwest Southeast rollout current state manager mapping invoice review summary.',
+			embedding: [1, 0],
+			createdAt: new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000),
+			lastSeenAt: new Date(now.getTime() - 2 * 24 * 60 * 60 * 1000),
+		});
+		const currentState = entry({
+			id: 'current-state',
+			content: 'Midwest Southeast rollout current state manager mapping invoice review summary.',
+			embedding: [1, 0],
+			createdAt: now,
+			lastSeenAt: now,
+		});
+
+		const results = rankEpisodicMemoryEntries(
+			[stalePlanning, currentState],
+			'Midwest Southeast rollout current state manager mapping invoice review',
+			{ queryEmbedding: [1, 0], topK: 2 },
+		);
+
+		expect(results.map((result) => result.id)).toEqual(['current-state', 'stale-planning']);
+	});
+
+	it('returns no entries when the query has no lexical or vector match', () => {
+		const now = new Date();
+		const newest = entry({
+			id: 'newest-unrelated',
+			content: 'User chose Postgres for durable memory storage.',
+			createdAt: now,
+			lastSeenAt: now,
+		});
+		const older = entry({
+			id: 'older-unrelated',
+			content: 'User prefers concise answers in implementation reviews.',
+			createdAt: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+			lastSeenAt: new Date(now.getTime() - 24 * 60 * 60 * 1000),
+		});
+
+		const results = rankEpisodicMemoryEntries(
+			[older, newest],
+			'prior travel itinerary hotel booking',
+			{ topK: 5 },
+		);
+
+		expect(results).toEqual([]);
+	});
+
+	it('ignores low-positive vector scores without lexical relevance', () => {
+		const weakVector = entry({
+			id: 'weak-vector',
+			content: 'User chose Postgres for durable memory storage.',
+			embedding: [0.01, 1],
+		});
+		const strongVector = entry({
+			id: 'strong-vector',
+			content: 'Warehouse exception routing analysis used manager escalation history.',
+			embedding: [0.8, 0.6],
+		});
+
+		const results = rankEpisodicMemoryEntries(
+			[weakVector, strongVector],
+			'prior travel itinerary hotel booking',
+			{ queryEmbedding: [1, 0], topK: 5 },
+		);
+
+		expect(results.map((result) => result.id)).toEqual(['strong-vector']);
+	});
+});
+
+describe('createRecallMemoryTool', () => {
+	it('instructs the model to call recall_memory only for explicit prior-context asks', () => {
+		const memory = new InMemoryMemory();
+		const tool = createRecallMemoryTool({
+			memory,
+			config: { embedder: fakeEmbedder },
+			scope: { agentId: 'agent-1', resourceId: 'user-1' },
+		});
+
+		expect(tool.systemInstruction).toContain('Only call recall_memory');
+		expect(tool.systemInstruction).toContain('explicitly asks');
+		expect(tool.systemInstruction).not.toContain('<episodic_memory>');
+		expect(tool.systemInstruction).toContain('current user message');
+		expect(tool.systemInstruction).toContain('current thread history');
+		expect(tool.systemInstruction).toContain('current observations');
+		expect(tool.systemInstruction).toContain('find related prior entries');
+		expect(tool.systemInstruction).toContain('not answer from memory');
+		expect(tool.systemInstruction).toContain('complete lists');
+		expect(tool.systemInstruction).toContain('exact names');
+		expect(tool.description).toContain('prior artifacts');
+	});
+});
+
+describe('getEpisodicMemoryScope', () => {
+	it('uses the episodic-specific resource partition when provided', () => {
+		expect(
+			getEpisodicMemoryScope({
+				agentId: 'agent-1',
+				resourceId: 'chat-user-1',
+				threadId: 'thread-1',
+				episodicMemoryResourceId: 'integration:slack:thread-1',
+			}),
+		).toEqual({
+			agentId: 'agent-1',
+			resourceId: 'integration:slack:thread-1',
+		});
+	});
+
+	it('falls back to the persistence resourceId for existing SDK callers', () => {
+		expect(
+			getEpisodicMemoryScope({
+				agentId: 'agent-1',
+				resourceId: 'chat-user-1',
+				threadId: 'thread-1',
+			}),
+		).toEqual({
+			agentId: 'agent-1',
+			resourceId: 'chat-user-1',
+		});
+	});
+});
+
+describe('InMemoryMemory episodic source cleanup', () => {
+	it('drops active entries that lose their last source when deleting a thread', async () => {
+		const memory = new InMemoryMemory();
+		const [orphaned, shared] = await memory.saveEpisodicMemoryEntries([
+			{
+				agentId: 'agent-1',
+				resourceId: 'user-1',
+				content: 'User chose Postgres for durable memory storage.',
+			},
+			{
+				agentId: 'agent-1',
+				resourceId: 'user-1',
+				content: 'User prefers source-backed cross-session recall.',
+			},
+		]);
+		await memory.saveEpisodicMemoryEntrySources([
+			{
+				memoryEntryId: orphaned.id,
+				observationId: 'obs-orphaned',
+				threadId: 'thread-1',
+				evidenceText: 'User chose Postgres',
+			},
+			{
+				memoryEntryId: shared.id,
+				observationId: 'obs-shared-1',
+				threadId: 'thread-1',
+				evidenceText: 'source-backed',
+			},
+			{
+				memoryEntryId: shared.id,
+				observationId: 'obs-shared-2',
+				threadId: 'thread-2',
+				evidenceText: 'cross-session recall',
+			},
+		]);
+
+		await memory.deleteThread('thread-1');
+
+		await expect(
+			memory.searchEpisodicMemoryEntries(
+				{ agentId: 'agent-1', resourceId: 'user-1' },
+				'source-backed',
+				{ topK: 10 },
+			),
+		).resolves.toEqual([expect.objectContaining({ id: shared.id })]);
+		await expect(
+			memory.searchEpisodicMemoryEntries(
+				{ agentId: 'agent-1', resourceId: 'user-1' },
+				'Postgres storage',
+				{ includeStatuses: ['dropped'], topK: 10 },
+			),
+		).resolves.toEqual([expect.objectContaining({ id: orphaned.id, status: 'dropped' })]);
+	});
+});
+
+describe('runEpisodicMemoryIndexer', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockedEmbedMany.mockResolvedValue({ embeddings: [[1, 0]], usage: { tokens: 1 } } as never);
+		mockedEmbed.mockResolvedValue({ embedding: [1, 0], usage: { tokens: 1 } } as never);
+	});
+
+	it('indexes new active observations and advances the cursor', async () => {
+		const memory = new InMemoryMemory();
+		const [observation] = await memory.appendObservationLogEntries([
+			{
+				scopeKind: 'thread',
+				scopeId: 'thread:thread-1:resource:user-1',
+				marker: 'important',
+				text: 'User switched memory store to Postgres after ruling out SQLite for enterprise customers.',
+				createdAt: new Date('2026-05-12T10:00:00.000Z'),
+			},
+		]);
+		const extract: EpisodicMemoryExtractFn = async () =>
+			await Promise.resolve({
+				entries: [
+					{
+						content:
+							'User switched memory store to Postgres after ruling out SQLite for enterprise customers.',
+						sources: [
+							{
+								observationId: observation.id,
+								evidence: 'User switched memory store to Postgres',
+							},
+						],
+					},
+				],
+			});
+
+		const result = await runEpisodicMemoryIndexer({
+			memory,
+			config: { embedder: fakeEmbedder, extract },
+			scope: { agentId: 'agent-1', resourceId: 'user-1' },
+			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+			threadId: 'thread-1',
+			eventBus: new AgentEventBus(),
+			now: new Date('2026-05-12T10:01:00.000Z'),
+		});
+
+		expect(result).toEqual({ status: 'ran', entriesWritten: 1, observationsIndexed: 1 });
+		const stored = await memory.searchEpisodicMemoryEntries(
+			{ agentId: 'agent-1', resourceId: 'user-1' },
+			'Postgres enterprise',
+			{ queryEmbedding: [1, 0] },
+		);
+		expect(stored).toHaveLength(1);
+		expect(stored[0].content).toContain('Postgres');
+		await expect(
+			runEpisodicMemoryIndexer({
+				memory,
+				config: { embedder: fakeEmbedder, extract },
+				scope: { agentId: 'agent-1', resourceId: 'user-1' },
+				observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+				threadId: 'thread-1',
+				eventBus: new AgentEventBus(),
+			}),
+		).resolves.toEqual({ status: 'skipped', reason: 'no-observations' });
+	});
+
+	it('does not leave searchable entries behind when source persistence fails', async () => {
+		const memory = new InMemoryMemory();
+		const [observation] = await memory.appendObservationLogEntries([
+			{
+				scopeKind: 'thread',
+				scopeId: 'thread:thread-1:resource:user-1',
+				marker: 'important',
+				text: 'User chose Postgres for cross-session memory.',
+				createdAt: new Date('2026-05-12T10:00:00.000Z'),
+			},
+		]);
+		const sourceError = new Error('source write failed');
+		jest.spyOn(memory, 'saveEpisodicMemoryEntrySources').mockRejectedValueOnce(sourceError);
+		const extract: EpisodicMemoryExtractFn = async () =>
+			await Promise.resolve({
+				entries: [
+					{
+						content: 'User chose Postgres for cross-session memory.',
+						sources: [{ observationId: observation.id, evidence: 'User chose Postgres' }],
+					},
+				],
+			});
+
+		await expect(
+			runEpisodicMemoryIndexer({
+				memory,
+				config: { embedder: fakeEmbedder, extract },
+				scope: { agentId: 'agent-1', resourceId: 'user-1' },
+				observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+				threadId: 'thread-1',
+				eventBus: new AgentEventBus(),
+				now: new Date('2026-05-12T10:01:00.000Z'),
+			}),
+		).rejects.toThrow(sourceError);
+
+		await expect(
+			memory.searchEpisodicMemoryEntries(
+				{ agentId: 'agent-1', resourceId: 'user-1' },
+				'Postgres memory',
+			),
+		).resolves.toEqual([]);
+		await expect(
+			memory.getEpisodicMemoryCursor({
+				scopeKind: 'thread',
+				scopeId: 'thread:thread-1:resource:user-1',
+			}),
+		).resolves.toBeNull();
+	});
+
+	it('stores exact evidence for each source observation', async () => {
+		const memory = new InMemoryMemory();
+		const [decision, reason] = await memory.appendObservationLogEntries([
+			{
+				scopeKind: 'thread',
+				scopeId: 'thread:thread-1:resource:user-1',
+				marker: 'critical',
+				text: 'User chose Postgres for the memory store.',
+			},
+			{
+				scopeKind: 'thread',
+				scopeId: 'thread:thread-1:resource:user-1',
+				marker: 'important',
+				text: 'Enterprise customers will not run local storage.',
+			},
+		]);
+		const extract: EpisodicMemoryExtractFn = async () =>
+			await Promise.resolve({
+				entries: [
+					{
+						content:
+							'User chose Postgres for the memory store because enterprise customers will not run local storage.',
+						sources: [
+							{
+								observationId: decision.id,
+								evidence: 'User chose Postgres for the memory store',
+							},
+							{
+								observationId: reason.id,
+								evidence: 'Enterprise customers will not run local storage',
+							},
+						],
+					},
+				],
+			});
+
+		await runEpisodicMemoryIndexer({
+			memory,
+			config: { embedder: fakeEmbedder, extract },
+			scope: { agentId: 'agent-1', resourceId: 'user-1' },
+			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+			threadId: 'thread-1',
+			eventBus: new AgentEventBus(),
+		});
+
+		const sources = Reflect.get(memory, 'episodicMemorySources') as Array<{
+			observationId: string;
+			evidenceText: string;
+		}>;
+		expect(sources).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					observationId: decision.id,
+					evidenceText: 'User chose Postgres for the memory store',
+				}),
+				expect.objectContaining({
+					observationId: reason.id,
+					evidenceText: 'Enterprise customers will not run local storage',
+				}),
+			]),
+		);
+	});
+
+	it('stores extracted entries longer than 800 characters without truncating them', async () => {
+		const memory = new InMemoryMemory();
+		const [observation] = await memory.appendObservationLogEntries([
+			{
+				scopeKind: 'thread',
+				scopeId: 'thread:thread-1:resource:user-1',
+				marker: 'critical',
+				text: 'User settled the Harborlight vendor intake pilot details.',
+			},
+		]);
+		const longContent = `${'Harborlight vendor intake detail. '.repeat(30)}Final retained identifier VENDORSTATUSCOMPLETE`;
+		const extract: EpisodicMemoryExtractFn = async () =>
+			await Promise.resolve({
+				entries: [
+					{
+						content: longContent,
+						sources: [
+							{
+								observationId: observation.id,
+								evidence: 'Harborlight vendor intake pilot details',
+							},
+						],
+					},
+				],
+			});
+
+		await runEpisodicMemoryIndexer({
+			memory,
+			config: { embedder: fakeEmbedder, extract },
+			scope: { agentId: 'agent-1', resourceId: 'user-1' },
+			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+			threadId: 'thread-1',
+			eventBus: new AgentEventBus(),
+		});
+
+		const [stored] = await memory.searchEpisodicMemoryEntries(
+			{ agentId: 'agent-1', resourceId: 'user-1' },
+			'VENDORSTATUSCOMPLETE',
+			{ topK: 1 },
+		);
+		expect(stored.content).toBe(longContent);
+		expect(stored.content.length).toBeGreaterThan(800);
+	});
+
+	it('rejects extracted entries that are not backed by observation evidence', async () => {
+		const memory = new InMemoryMemory();
+		const [observation] = await memory.appendObservationLogEntries([
+			{
+				scopeKind: 'thread',
+				scopeId: 'thread:thread-1:resource:user-1',
+				marker: 'important',
+				text: 'User investigated webhook retries.',
+			},
+		]);
+		const extract: EpisodicMemoryExtractFn = async () =>
+			await Promise.resolve({
+				entries: [
+					{
+						content: 'Webhook retries were caused by a bad API key.',
+						sources: [{ observationId: observation.id, evidence: 'bad API key' }],
+					},
+				],
+			});
+
+		const result = await runEpisodicMemoryIndexer({
+			memory,
+			config: { embedder: fakeEmbedder, extract },
+			scope: { agentId: 'agent-1', resourceId: 'user-1' },
+			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+			threadId: 'thread-1',
+			eventBus: new AgentEventBus(),
+		});
+
+		expect(result).toEqual({ status: 'ran', entriesWritten: 0, observationsIndexed: 1 });
+		await expect(
+			memory.searchEpisodicMemoryEntries({ agentId: 'agent-1', resourceId: 'user-1' }, 'API key'),
+		).resolves.toEqual([]);
+	});
+
+	it('does not index failed recall attempts as episodic memories', async () => {
+		const memory = new InMemoryMemory();
+		const [request, toolResult, reply] = await memory.appendObservationLogEntries([
+			{
+				scopeKind: 'thread',
+				scopeId: 'thread:thread-1:resource:user-1',
+				marker: 'important',
+				text: 'User wants to continue an earlier memory feature discussion and recover prior decisions.',
+			},
+			{
+				scopeKind: 'thread',
+				scopeId: 'thread:thread-1:resource:user-1',
+				marker: 'info',
+				text: 'Agent queried memory; no entries were found.',
+			},
+			{
+				scopeKind: 'thread',
+				scopeId: 'thread:thread-1:resource:user-1',
+				marker: 'completion',
+				text: 'Agent told user it could not reliably recover finalized decisions.',
+			},
+		]);
+		const extract: EpisodicMemoryExtractFn = async () =>
+			await Promise.resolve({
+				entries: [
+					{
+						content:
+							'User tried to recover prior memory feature decisions, but memory lookup found no entries and the agent could not reliably recover finalized decisions.',
+						sources: [
+							{
+								observationId: request.id,
+								evidence: 'User wants to continue an earlier memory feature discussion',
+							},
+							{
+								observationId: toolResult.id,
+								evidence: 'Agent queried memory; no entries were found.',
+							},
+							{
+								observationId: reply.id,
+								evidence: 'could not reliably recover finalized decisions',
+							},
+						],
+					},
+				],
+			});
+
+		const result = await runEpisodicMemoryIndexer({
+			memory,
+			config: { embedder: fakeEmbedder, extract },
+			scope: { agentId: 'agent-1', resourceId: 'user-1' },
+			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+			threadId: 'thread-1',
+			eventBus: new AgentEventBus(),
+		});
+
+		expect(result).toEqual({ status: 'ran', entriesWritten: 0, observationsIndexed: 3 });
+		await expect(
+			memory.searchEpisodicMemoryEntries(
+				{ agentId: 'agent-1', resourceId: 'user-1' },
+				'memory feature decisions',
+			),
+		).resolves.toEqual([]);
+	});
+
+	it('ignores legacy extractor supersedes and keeps lifecycle decisions in reflection', async () => {
+		const memory = new InMemoryMemory();
+		const [oldEntry] = await memory.saveEpisodicMemoryEntries([
+			{
+				agentId: 'agent-1',
+				resourceId: 'user-1',
+				content: 'User planned SQLite for local-first memory storage.',
+				embedding: [1, 0],
+			},
+		]);
+		const [observation] = await memory.appendObservationLogEntries([
+			{
+				scopeKind: 'thread',
+				scopeId: 'thread:thread-1:resource:user-1',
+				marker: 'critical',
+				text: 'User switched memory store choice to Postgres.',
+			},
+		]);
+		const extract: EpisodicMemoryExtractFn = async () =>
+			await Promise.resolve({
+				entries: [
+					{
+						content: 'User switched memory store choice to Postgres.',
+						sources: [
+							{
+								observationId: observation.id,
+								evidence: 'User switched memory store choice to Postgres',
+							},
+						],
+						supersedes: [oldEntry.id],
+					} as never,
+				],
+			});
+
+		await runEpisodicMemoryIndexer({
+			memory,
+			config: { embedder: fakeEmbedder, extract },
+			scope: { agentId: 'agent-1', resourceId: 'user-1' },
+			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+			threadId: 'thread-1',
+			eventBus: new AgentEventBus(),
+		});
+
+		const entries = await memory.searchEpisodicMemoryEntries(
+			{ agentId: 'agent-1', resourceId: 'user-1' },
+			'SQLite Postgres memory storage',
+			{ includeStatuses: ['active', 'superseded'], queryEmbedding: [1, 0], topK: 10 },
+		);
+		expect(entries.find((entry) => entry.id === oldEntry.id)?.status).toBe('active');
+	});
+
+	it('reflects same-case entries into a replacement and copies source links', async () => {
+		const memory = new InMemoryMemory();
+		const [oldEntry] = await memory.saveEpisodicMemoryEntries([
+			{
+				agentId: 'agent-1',
+				resourceId: 'user-1',
+				content: 'User planned SQLite for local-first memory storage.',
+				embedding: [1, 0],
+			},
+		]);
+		await memory.saveEpisodicMemoryEntrySources([
+			{
+				memoryEntryId: oldEntry.id,
+				observationId: 'obs-old',
+				threadId: 'thread-old',
+				evidenceText: 'User planned SQLite',
+			},
+		]);
+		const [observation] = await memory.appendObservationLogEntries([
+			{
+				scopeKind: 'thread',
+				scopeId: 'thread:thread-1:resource:user-1',
+				marker: 'critical',
+				text: 'User switched memory store choice to Postgres after enterprise constraints.',
+			},
+		]);
+		const extract: EpisodicMemoryExtractFn = async () =>
+			await Promise.resolve({
+				entries: [
+					{
+						content: 'User switched memory store choice to Postgres after enterprise constraints.',
+						sources: [
+							{
+								observationId: observation.id,
+								evidence: 'User switched memory store choice to Postgres',
+							},
+						],
+					},
+				],
+			});
+		const reflect: EpisodicMemoryReflectFn = async (input) => {
+			const seedId = input.seedEntryIds[0];
+			return await Promise.resolve({
+				drop: [],
+				merge: [
+					{
+						supersedes: [oldEntry.id, seedId],
+						content:
+							'User switched memory store choice from SQLite to Postgres after enterprise constraints.',
+					},
+				],
+			});
+		};
+		mockedEmbedMany.mockResolvedValue({
+			embeddings: [
+				[1, 0],
+				[0.9, 0.1],
+			],
+			usage: { tokens: 2 },
+		} as never);
+
+		await runEpisodicMemoryIndexer({
+			memory,
+			config: { embedder: fakeEmbedder, extract, reflect },
+			scope: { agentId: 'agent-1', resourceId: 'user-1' },
+			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+			threadId: 'thread-1',
+			eventBus: new AgentEventBus(),
+		});
+
+		const active = await memory.searchEpisodicMemoryEntries(
+			{ agentId: 'agent-1', resourceId: 'user-1' },
+			'Postgres enterprise constraints',
+			{ queryEmbedding: [1, 0], topK: 10 },
+		);
+		expect(active).toHaveLength(1);
+		expect(active[0].content).toContain('from SQLite to Postgres');
+
+		const inactive = await memory.searchEpisodicMemoryEntries(
+			{ agentId: 'agent-1', resourceId: 'user-1' },
+			'SQLite Postgres',
+			{ includeStatuses: ['superseded'], queryEmbedding: [1, 0], topK: 10 },
+		);
+		expect(inactive).toHaveLength(2);
+		expect(new Set(inactive.map((entry) => entry.supersededBy))).toEqual(new Set([active[0].id]));
+
+		const sources = Reflect.get(memory, 'episodicMemorySources') as Array<{
+			memoryEntryId: string;
+			observationId: string;
+			evidenceText: string;
+		}>;
+		expect(sources).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					memoryEntryId: active[0].id,
+					observationId: 'obs-old',
+					evidenceText: 'User planned SQLite',
+				}),
+				expect.objectContaining({
+					memoryEntryId: active[0].id,
+					observationId: observation.id,
+					evidenceText: 'User switched memory store choice to Postgres',
+				}),
+			]),
+		);
+	});
+
+	it('stores reflection merge replacements longer than 800 characters without truncating them', async () => {
+		const memory = new InMemoryMemory();
+		const [oldEntry] = await memory.saveEpisodicMemoryEntries([
+			{
+				agentId: 'agent-1',
+				resourceId: 'user-1',
+				content: 'User planned a Harborlight vendor intake pilot.',
+				embedding: [1, 0],
+			},
+		]);
+		await memory.saveEpisodicMemoryEntrySources([
+			{
+				memoryEntryId: oldEntry.id,
+				observationId: 'obs-old',
+				threadId: 'thread-old',
+				evidenceText: 'Harborlight vendor intake pilot',
+			},
+		]);
+		const [observation] = await memory.appendObservationLogEntries([
+			{
+				scopeKind: 'thread',
+				scopeId: 'thread:thread-1:resource:user-1',
+				marker: 'critical',
+				text: 'User added final Harborlight ownership details.',
+			},
+		]);
+		const extract: EpisodicMemoryExtractFn = async () =>
+			await Promise.resolve({
+				entries: [
+					{
+						content: 'User added final Harborlight ownership details.',
+						sources: [
+							{
+								observationId: observation.id,
+								evidence: 'final Harborlight ownership details',
+							},
+						],
+					},
+				],
+			});
+		const longReplacement = `${'Harborlight reflected ownership detail. '.repeat(25)}Final reflected identifier REFLECTEDVENDORSTATUSCOMPLETE`;
+		const reflect: EpisodicMemoryReflectFn = async (input) =>
+			await Promise.resolve({
+				drop: [],
+				merge: [
+					{
+						supersedes: [oldEntry.id, input.seedEntryIds[0]],
+						content: longReplacement,
+					},
+				],
+			});
+
+		await runEpisodicMemoryIndexer({
+			memory,
+			config: { embedder: fakeEmbedder, extract, reflect },
+			scope: { agentId: 'agent-1', resourceId: 'user-1' },
+			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+			threadId: 'thread-1',
+			eventBus: new AgentEventBus(),
+		});
+
+		const [stored] = await memory.searchEpisodicMemoryEntries(
+			{ agentId: 'agent-1', resourceId: 'user-1' },
+			'REFLECTEDVENDORSTATUSCOMPLETE',
+			{ topK: 1 },
+		);
+		expect(stored.content).toBe(longReplacement);
+		expect(stored.content.length).toBeGreaterThan(800);
+	});
+
+	it('reflects obvious noise as dropped and excludes it from active search', async () => {
+		const memory = new InMemoryMemory();
+		const [noise] = await memory.saveEpisodicMemoryEntries([
+			{
+				agentId: 'agent-1',
+				resourceId: 'user-1',
+				content: 'Agent queried memory and no entries were found.',
+				embedding: [1, 0],
+			},
+		]);
+		const [observation] = await memory.appendObservationLogEntries([
+			{
+				scopeKind: 'thread',
+				scopeId: 'thread:thread-1:resource:user-1',
+				marker: 'important',
+				text: 'User confirmed the Postgres memory store decision.',
+			},
+		]);
+		const extract: EpisodicMemoryExtractFn = async () =>
+			await Promise.resolve({
+				entries: [
+					{
+						content: 'User confirmed the Postgres memory store decision.',
+						sources: [
+							{
+								observationId: observation.id,
+								evidence: 'User confirmed the Postgres memory store decision',
+							},
+						],
+					},
+				],
+			});
+		const reflect: EpisodicMemoryReflectFn = async () =>
+			await Promise.resolve({ drop: [noise.id], merge: [] });
+
+		await runEpisodicMemoryIndexer({
+			memory,
+			config: { embedder: fakeEmbedder, extract, reflect },
+			scope: { agentId: 'agent-1', resourceId: 'user-1' },
+			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+			threadId: 'thread-1',
+			eventBus: new AgentEventBus(),
+		});
+
+		const active = await memory.searchEpisodicMemoryEntries(
+			{ agentId: 'agent-1', resourceId: 'user-1' },
+			'no entries found',
+			{ queryEmbedding: [1, 0], topK: 10 },
+		);
+		expect(active.map((entry) => entry.id)).not.toContain(noise.id);
+		const [dropped] = await memory.searchEpisodicMemoryEntries(
+			{ agentId: 'agent-1', resourceId: 'user-1' },
+			'no entries found',
+			{ includeStatuses: ['dropped'], queryEmbedding: [1, 0] },
+		);
+		expect(dropped.id).toBe(noise.id);
+	});
+
+	it('ignores invalid reflection actions and keeps similar distinct cases active', async () => {
+		const memory = new InMemoryMemory();
+		const [northstar] = await memory.saveEpisodicMemoryEntries([
+			{
+				agentId: 'agent-1',
+				resourceId: 'user-1',
+				content: 'Northstar routing issue was caused by stale manager email mappings.',
+				embedding: [1, 0],
+			},
+		]);
+		const [observation] = await memory.appendObservationLogEntries([
+			{
+				scopeKind: 'thread',
+				scopeId: 'thread:thread-1:resource:user-1',
+				marker: 'important',
+				text: 'Southeast invoice requests are delayed before routing starts.',
+			},
+		]);
+		const extract: EpisodicMemoryExtractFn = async () =>
+			await Promise.resolve({
+				entries: [
+					{
+						content: 'Southeast invoice requests are delayed before routing starts.',
+						sources: [
+							{
+								observationId: observation.id,
+								evidence: 'Southeast invoice requests are delayed',
+							},
+						],
+					},
+				],
+			});
+		const reflect: EpisodicMemoryReflectFn = async () =>
+			await Promise.resolve({
+				drop: ['missing-entry'],
+				merge: [
+					{ supersedes: ['missing-entry'], content: 'Invalid replacement.' },
+					{ supersedes: [northstar.id], content: '   ' },
+				],
+			});
+
+		await runEpisodicMemoryIndexer({
+			memory,
+			config: { embedder: fakeEmbedder, extract, reflect },
+			scope: { agentId: 'agent-1', resourceId: 'user-1' },
+			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+			threadId: 'thread-1',
+			eventBus: new AgentEventBus(),
+		});
+
+		const active = await memory.searchEpisodicMemoryEntries(
+			{ agentId: 'agent-1', resourceId: 'user-1' },
+			'Northstar Southeast routing invoice',
+			{ queryEmbedding: [1, 0], topK: 10 },
+		);
+		expect(active.map((entry) => entry.id)).toEqual(expect.arrayContaining([northstar.id]));
+		expect(active.map((entry) => entry.content)).toEqual(
+			expect.arrayContaining([expect.stringContaining('Southeast invoice requests are delayed')]),
+		);
+	});
+
+	it('keeps saved entries and advances the cursor when reflection fails', async () => {
+		const memory = new InMemoryMemory();
+		const eventBus = new AgentEventBus();
+		const [observation] = await memory.appendObservationLogEntries([
+			{
+				scopeKind: 'thread',
+				scopeId: 'thread:thread-1:resource:user-1',
+				marker: 'important',
+				text: 'User confirmed the Postgres memory store decision.',
+			},
+		]);
+		const extract: EpisodicMemoryExtractFn = async () =>
+			await Promise.resolve({
+				entries: [
+					{
+						content: 'User confirmed the Postgres memory store decision.',
+						sources: [
+							{
+								observationId: observation.id,
+								evidence: 'User confirmed the Postgres memory store decision',
+							},
+						],
+					},
+				],
+			});
+		const reflect: EpisodicMemoryReflectFn = () => {
+			throw new Error('reflect failed');
+		};
+
+		await expect(
+			runEpisodicMemoryIndexer({
+				memory,
+				config: { embedder: fakeEmbedder, extract, reflect },
+				scope: { agentId: 'agent-1', resourceId: 'user-1' },
+				observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+				threadId: 'thread-1',
+				eventBus,
+			}),
+		).rejects.toThrow('reflect failed');
+
+		await expect(
+			memory.searchEpisodicMemoryEntries(
+				{ agentId: 'agent-1', resourceId: 'user-1' },
+				'Postgres memory store',
+				{ queryEmbedding: [1, 0] },
+			),
+		).resolves.toHaveLength(1);
+		await expect(
+			memory.getEpisodicMemoryCursor({
+				scopeKind: 'thread',
+				scopeId: 'thread:thread-1:resource:user-1',
+			}),
+		).resolves.toMatchObject({ lastIndexedObservationId: observation.id });
+	});
+});

--- a/packages/@n8n/agents/src/runtime/agent-runtime.ts
+++ b/packages/@n8n/agents/src/runtime/agent-runtime.ts
@@ -15,6 +15,7 @@ import type {
 	BuiltTelemetry,
 	BuiltTool,
 	CheckpointStore,
+	EpisodicMemoryConfig,
 	FinishReason,
 	GenerateResult,
 	GoogleThinkingConfig,
@@ -35,6 +36,14 @@ import type {
 } from '../types';
 import { BackgroundTaskTracker } from './background-task-tracker';
 import { DeferredToolManager } from './deferred-tool-manager';
+import {
+	createRecallMemoryTool,
+	getEpisodicMemoryScope,
+	hasEpisodicMemoryStore,
+	isEpisodicMemoryEnabled,
+	RECALL_MEMORY_TOOL_NAME,
+	runEpisodicMemoryIndexer,
+} from './episodic-memory';
 import { AgentEventBus } from './event-bus';
 import { toJsonValue } from './json-value';
 import { createFilteredLogger } from './logger';
@@ -80,7 +89,7 @@ import type {
 } from '../types/sdk/agent';
 import type { AgentDbMessage, AgentMessage, ContentToolCall, Message } from '../types/sdk/message';
 import { createObservationLogThreadScopeId } from '../types/sdk/observation-log';
-import type { ObservationLogScope } from '../types/sdk/observation-log';
+import type { ObservationLogScope, ObservationLogTaskKind } from '../types/sdk/observation-log';
 import type { JSONObject, JSONValue } from '../types/utils/json';
 import { parseWithSchema } from '../utils/parse';
 import { isZodSchema } from '../utils/zod';
@@ -183,6 +192,7 @@ export interface AgentRuntimeConfig {
 	lastMessages?: number;
 	observationLog?: ObservationLogMemoryConfig;
 	observationalMemory?: ObservationalMemoryConfig;
+	episodicMemory?: EpisodicMemoryConfig;
 	semanticRecall?: SemanticRecallConfig;
 	structuredOutput?: z.ZodType;
 	checkpointStorage?: 'memory' | CheckpointStore;
@@ -461,7 +471,7 @@ export class AgentRuntime {
 		const list = AgentMessageList.deserialize(state.messageList);
 		this.hydrateDeferredToolsFromList(list);
 
-		const tool = this.getCurrentTools().find((t) => t.name === toolCall.toolName);
+		const tool = this.getCurrentTools(state.persistence).find((t) => t.name === toolCall.toolName);
 		if (!tool) throw new Error(`Tool ${toolCall.toolName} not found`);
 
 		let resumeData: unknown = data;
@@ -935,7 +945,10 @@ export class AgentRuntime {
 			...options,
 			persistence: options?.persistence,
 		});
-		const pendingLoopContext = this.buildToolLoopContext(staticLoopContext.aiProviderTools);
+		const pendingLoopContext = this.buildToolLoopContext(
+			staticLoopContext.aiProviderTools,
+			options?.persistence,
+		);
 		const pendingToolCtx: ToolBatchContext = {
 			toolMap: pendingLoopContext.toolMap,
 			list,
@@ -991,6 +1004,7 @@ export class AgentRuntime {
 
 			const { toolMap, aiTools, hasTools, effectiveInstructions } = this.buildToolLoopContext(
 				staticLoopContext.aiProviderTools,
+				options?.persistence,
 			);
 
 			const result = await generateText({
@@ -1189,7 +1203,10 @@ export class AgentRuntime {
 			...options,
 			persistence: options?.persistence,
 		});
-		const pendingLoopContext = this.buildToolLoopContext(staticLoopContext.aiProviderTools);
+		const pendingLoopContext = this.buildToolLoopContext(
+			staticLoopContext.aiProviderTools,
+			options?.persistence,
+		);
 		const pendingToolCtx: ToolBatchContext = {
 			toolMap: pendingLoopContext.toolMap,
 			list,
@@ -1263,6 +1280,7 @@ export class AgentRuntime {
 			this.eventBus.emit({ type: AgentEvent.TurnStart });
 			const { toolMap, aiTools, hasTools, effectiveInstructions } = this.buildToolLoopContext(
 				staticLoopContext.aiProviderTools,
+				options?.persistence,
 			);
 			const messages = list.forLlm(effectiveInstructions, this.config.instructionProviderOptions);
 			const result = streamText({
@@ -1462,6 +1480,7 @@ export class AgentRuntime {
 		}
 
 		this.scheduleObservationLogJobs(options.persistence);
+		this.scheduleEpisodicMemoryJob(options.persistence);
 	}
 
 	private scheduleObservationLogJobs(persistence: AgentPersistenceOptions): void {
@@ -1469,7 +1488,7 @@ export class AgentRuntime {
 		if (!memory || !observationalMemory || !hasObservationLogStore(memory)) return;
 
 		const scope = this.getObservationLogScope(persistence);
-		const runner = this.getMemoryTaskRunner(memory, observationalMemory);
+		const runner = this.getMemoryTaskRunner(memory, observationalMemory.lockTtlMs);
 		const observe = observationalMemory.observe;
 		const observerThresholdTokens = observationalMemory.observerThresholdTokens;
 
@@ -1478,8 +1497,10 @@ export class AgentRuntime {
 			observerThresholdTokens !== undefined &&
 			hasObservationLogObserverMemory(memory)
 		) {
-			runner.schedule(
-				{ ...scope, taskKind: 'observer' },
+			this.scheduleMemoryTask(
+				runner,
+				scope,
+				'observer',
 				async () =>
 					await runObservationLogObserver({
 						memory,
@@ -1498,8 +1519,10 @@ export class AgentRuntime {
 		const reflect = observationalMemory.reflect;
 		const reflectorThresholdTokens = observationalMemory.reflectorThresholdTokens;
 		if (reflect && reflectorThresholdTokens !== undefined) {
-			runner.schedule(
-				{ ...scope, taskKind: 'reflector' },
+			this.scheduleMemoryTask(
+				runner,
+				scope,
+				'reflector',
 				async () =>
 					await runObservationLogReflector({
 						memory,
@@ -1511,18 +1534,61 @@ export class AgentRuntime {
 		}
 	}
 
-	private getMemoryTaskRunner(
-		memory: BuiltMemory,
-		observationalMemory: ObservationalMemoryConfig,
-	): ScopedMemoryTaskRunner {
+	private scheduleEpisodicMemoryJob(persistence: AgentPersistenceOptions): void {
+		const { memory, episodicMemory } = this.config;
+		if (
+			!memory ||
+			!episodicMemory ||
+			!isEpisodicMemoryEnabled(episodicMemory) ||
+			!hasEpisodicMemoryStore(memory) ||
+			!hasObservationLogStore(memory) ||
+			!episodicMemory.extract
+		) {
+			return;
+		}
+		const scope = getEpisodicMemoryScope(persistence);
+		if (!scope) return;
+
+		const observationScope = this.getObservationLogScope(persistence);
+		const runner = this.getMemoryTaskRunner(memory, this.config.observationalMemory?.lockTtlMs);
+		this.scheduleMemoryTask(
+			runner,
+			observationScope,
+			'episodic-indexer',
+			async () =>
+				await runEpisodicMemoryIndexer({
+					memory,
+					config: episodicMemory,
+					scope,
+					observationScope,
+					threadId: persistence.threadId,
+					eventBus: this.eventBus,
+				}),
+		);
+	}
+
+	private scheduleMemoryTask<T>(
+		runner: ScopedMemoryTaskRunner,
+		scope: ObservationLogScope,
+		taskKind: ObservationLogTaskKind,
+		task: () => Promise<T>,
+	): void {
+		runner.schedule({ ...scope, taskKind }, task);
+	}
+
+	private getMemoryTaskRunner(memory: BuiltMemory, lockTtlMs?: number): ScopedMemoryTaskRunner {
 		this.memoryTasks ??= new ScopedMemoryTaskRunner({
 			tracker: this.backgroundTasks,
 			lockStore: hasObservationLogTaskLockStore(memory) ? memory : undefined,
-			lockTtlMs: observationalMemory.lockTtlMs,
+			lockTtlMs,
 			onEvent: (event) => {
 				if (event.type !== 'failed') return;
-				const source = event.task.taskKind;
-				const message = `Observation log ${source} task failed`;
+				const source =
+					event.task.taskKind === 'episodic-indexer' ? 'episodic-memory' : event.task.taskKind;
+				const message =
+					event.task.taskKind === 'episodic-indexer'
+						? 'Episodic memory indexing task failed'
+						: `Observation log ${source} task failed`;
 				logger.warn(message, {
 					error: event.error,
 					scopeKind: event.task.scopeKind,
@@ -2102,8 +2168,11 @@ export class AgentRuntime {
 	}
 
 	/** Build the current local tool view; deferred loads can change this between iterations. */
-	private buildToolLoopContext(aiProviderTools: ReturnType<typeof toAiSdkProviderTools>) {
-		const allUserTools = this.getCurrentTools();
+	private buildToolLoopContext(
+		aiProviderTools: ReturnType<typeof toAiSdkProviderTools>,
+		persistence?: AgentPersistenceOptions,
+	) {
+		const allUserTools = this.getCurrentTools(persistence);
 		const aiTools = toAiSdkTools(allUserTools);
 		const allTools = { ...aiTools, ...aiProviderTools };
 		const aiToolCount = Object.keys(allTools).length;
@@ -2118,15 +2187,43 @@ export class AgentRuntime {
 		};
 	}
 
-	private getCurrentTools(): BuiltTool[] {
+	private getCurrentTools(persistence?: AgentPersistenceOptions): BuiltTool[] {
 		const baseTools = this.config.tools ?? [];
-		if (!this.deferredToolManager?.hasTools) return baseTools;
-
-		return [
+		const tools = [
 			...baseTools,
-			...this.deferredToolManager.getControllerTools(),
-			...this.deferredToolManager.getLoadedTools(),
+			...(this.deferredToolManager?.hasTools
+				? [
+						...this.deferredToolManager.getControllerTools(),
+						...this.deferredToolManager.getLoadedTools(),
+					]
+				: []),
 		];
+
+		const recallTool = this.createRecallMemoryToolForRun(persistence, tools);
+		return recallTool ? [...tools, recallTool] : tools;
+	}
+
+	private createRecallMemoryToolForRun(
+		persistence: AgentPersistenceOptions | undefined,
+		existingTools: BuiltTool[],
+	): BuiltTool | undefined {
+		const { memory, episodicMemory } = this.config;
+		if (
+			!memory ||
+			!episodicMemory ||
+			!isEpisodicMemoryEnabled(episodicMemory) ||
+			!hasEpisodicMemoryStore(memory)
+		) {
+			return undefined;
+		}
+		const scope = getEpisodicMemoryScope(persistence);
+		if (!scope) return undefined;
+		if (existingTools.some((tool) => tool.name === RECALL_MEMORY_TOOL_NAME)) {
+			throw new Error(
+				`Tool name "${RECALL_MEMORY_TOOL_NAME}" is reserved while episodic memory is enabled.`,
+			);
+		}
+		return createRecallMemoryTool({ memory, config: episodicMemory, scope });
 	}
 
 	private hydrateDeferredToolsFromList(list: AgentMessageList): void {

--- a/packages/@n8n/agents/src/runtime/episodic-memory.ts
+++ b/packages/@n8n/agents/src/runtime/episodic-memory.ts
@@ -1,0 +1,617 @@
+import { embed, embedMany } from 'ai';
+import { createHash } from 'crypto';
+import { z } from 'zod';
+
+import {
+	DEFAULT_EPISODIC_MEMORY_MAX_ENTRIES_PER_RUN,
+	DEFAULT_EPISODIC_MEMORY_RECALL_TOOL_INSTRUCTION,
+	DEFAULT_EPISODIC_MEMORY_TOP_K,
+} from './episodic-memory-defaults';
+import type { AgentEventBus } from './event-bus';
+import { normalizeFlatReflectionActions } from './memory-lifecycle';
+import { renderObservationLog } from './observation-log-renderer';
+import { Tool } from '../sdk/tool';
+import type {
+	BuiltEpisodicMemoryStore,
+	BuiltMemory,
+	EpisodicMemoryConfig,
+	EpisodicMemoryEntry,
+	EpisodicMemoryExtractionCandidate,
+	EpisodicMemoryReflection,
+	EpisodicMemoryReflectionMerge,
+	EpisodicMemoryScope,
+	EpisodicMemorySearchOptions,
+	RetrievedEpisodicMemoryEntry,
+} from '../types';
+import { AgentEvent } from '../types/runtime/event';
+import type { AgentPersistenceOptions } from '../types/sdk/agent';
+import type { ObservationLogEntry, ObservationLogScope } from '../types/sdk/observation-log';
+
+export const RECALL_MEMORY_TOOL_NAME = 'recall_memory';
+
+const RRF_K = 60;
+const RECENCY_RRF_WEIGHT = 1;
+const MIN_VECTOR_RELEVANCE_SCORE = 0.2;
+
+const RecallMemoryInputSchema = z.object({
+	query: z.string().min(1),
+});
+
+const RecallMemoryOutputSchema = z.object({
+	entries: z.array(
+		z.object({
+			id: z.string(),
+			content: z.string(),
+			createdAt: z.string(),
+			lexicalScore: z.number(),
+			vectorScore: z.number(),
+			rrfScore: z.number(),
+			finalScore: z.number(),
+		}),
+	),
+});
+
+type RecallMemoryOutput = z.infer<typeof RecallMemoryOutputSchema>;
+
+interface NormalizedEpisodicMemoryConfig {
+	topK: number;
+	maxEntriesPerRun: number;
+	embedder: NonNullable<EpisodicMemoryConfig['embedder']>;
+	embeddingModel: string;
+	extract: EpisodicMemoryConfig['extract'];
+	reflect: EpisodicMemoryConfig['reflect'];
+	recallToolInstruction: string;
+}
+
+export interface RunEpisodicMemoryIndexerOpts {
+	memory: BuiltMemory & BuiltEpisodicMemoryStore;
+	config: EpisodicMemoryConfig;
+	scope: EpisodicMemoryScope;
+	observationScope: ObservationLogScope;
+	threadId: string;
+	now?: Date;
+	eventBus: AgentEventBus;
+}
+
+export type RunEpisodicMemoryIndexerResult =
+	| { status: 'skipped'; reason: 'disabled' | 'no-extract' | 'no-observations' }
+	| { status: 'ran'; entriesWritten: number; observationsIndexed: number };
+
+export function isEpisodicMemoryEnabled(
+	config: EpisodicMemoryConfig | undefined,
+): config is EpisodicMemoryConfig {
+	return config !== undefined && config.enabled !== false;
+}
+
+export function hasEpisodicMemoryStore(
+	memory: BuiltMemory,
+): memory is BuiltMemory & BuiltEpisodicMemoryStore {
+	return (
+		typeof Reflect.get(memory, 'saveEpisodicMemoryEntries') === 'function' &&
+		typeof Reflect.get(memory, 'saveEpisodicMemoryEntrySources') === 'function' &&
+		typeof Reflect.get(memory, 'saveEpisodicMemoryEntryWithSources') === 'function' &&
+		typeof Reflect.get(memory, 'searchEpisodicMemoryEntries') === 'function' &&
+		typeof Reflect.get(memory, 'supersedeEpisodicMemoryEntries') === 'function' &&
+		typeof Reflect.get(memory, 'getEpisodicMemoryEntrySources') === 'function' &&
+		typeof Reflect.get(memory, 'applyEpisodicMemoryReflection') === 'function' &&
+		typeof Reflect.get(memory, 'getEpisodicMemoryCursor') === 'function' &&
+		typeof Reflect.get(memory, 'setEpisodicMemoryCursor') === 'function'
+	);
+}
+
+export function withEpisodicMemoryDefaults(
+	config: EpisodicMemoryConfig,
+): NormalizedEpisodicMemoryConfig {
+	if (!config.embedder) {
+		throw new Error('Episodic memory requires a resolved embedding model before runtime use.');
+	}
+
+	return {
+		topK: config.topK ?? DEFAULT_EPISODIC_MEMORY_TOP_K,
+		maxEntriesPerRun: config.maxEntriesPerRun ?? DEFAULT_EPISODIC_MEMORY_MAX_ENTRIES_PER_RUN,
+		embedder: config.embedder,
+		embeddingModel: config.embeddingModel ?? 'custom',
+		extract: config.extract,
+		reflect: config.reflect,
+		recallToolInstruction:
+			config.prompts?.recallToolInstruction ?? DEFAULT_EPISODIC_MEMORY_RECALL_TOOL_INSTRUCTION,
+	};
+}
+
+export async function runEpisodicMemoryIndexer(
+	opts: RunEpisodicMemoryIndexerOpts,
+): Promise<RunEpisodicMemoryIndexerResult> {
+	if (!isEpisodicMemoryEnabled(opts.config)) return { status: 'skipped', reason: 'disabled' };
+
+	try {
+		const normalized = withEpisodicMemoryDefaults(opts.config);
+		if (!normalized.extract) return { status: 'skipped', reason: 'no-extract' };
+
+		const observations = await getNewActiveObservations(opts.memory, opts.observationScope);
+		if (observations.length === 0) return { status: 'skipped', reason: 'no-observations' };
+
+		const renderedObservations = renderObservationLog(observations) ?? '';
+		const existingEntries = await opts.memory.searchEpisodicMemoryEntries(
+			opts.scope,
+			observations.map((entry) => entry.text).join('\n'),
+			{ topK: Math.max(normalized.topK, 20) },
+		);
+
+		const extraction = await normalized.extract({
+			scope: opts.scope,
+			observationScope: opts.observationScope,
+			now: opts.now ?? new Date(),
+			observations,
+			renderedObservations,
+			existingEntries,
+		});
+
+		const candidates = validateCandidates(extraction.entries, observations).slice(
+			0,
+			normalized.maxEntriesPerRun,
+		);
+
+		const savedEntries: EpisodicMemoryEntry[] = [];
+		if (candidates.length > 0) {
+			const { embeddings } = await embedMany({
+				model: normalized.embedder,
+				values: candidates.map((entry) => entry.content),
+			});
+			for (const [index, candidate] of candidates.entries()) {
+				const saved = await saveCandidate(opts, normalized, candidate, embeddings[index]);
+				if (saved) savedEntries.push(saved);
+			}
+		}
+
+		await advanceEpisodicCursor(opts.memory, opts.observationScope, observations);
+		if (savedEntries.length > 0 && normalized.reflect) {
+			await runEpisodicMemoryReflection(opts, normalized, savedEntries, observations);
+		}
+		return {
+			status: 'ran',
+			entriesWritten: savedEntries.length,
+			observationsIndexed: observations.length,
+		};
+	} catch (error) {
+		opts.eventBus.emit({
+			type: AgentEvent.Error,
+			message: 'Episodic memory indexing failed',
+			error,
+			source: 'episodic-memory',
+		});
+		throw error;
+	}
+}
+
+export function createRecallMemoryTool(opts: {
+	memory: BuiltMemory & BuiltEpisodicMemoryStore;
+	config: EpisodicMemoryConfig;
+	scope: EpisodicMemoryScope;
+}) {
+	const normalized = withEpisodicMemoryDefaults(opts.config);
+
+	return new Tool(RECALL_MEMORY_TOOL_NAME)
+		.description(
+			'Recall source-backed prior-session entries for explicit asks about previous conversations, earlier decisions, exact names, prior artifacts, remembered details, or similar historical situations.',
+		)
+		.systemInstruction(normalized.recallToolInstruction)
+		.input(RecallMemoryInputSchema)
+		.output(RecallMemoryOutputSchema)
+		.handler(async ({ query }): Promise<RecallMemoryOutput> => {
+			const { embedding: queryEmbedding } = await embed({
+				model: normalized.embedder,
+				value: query,
+			});
+			const entries = await opts.memory.searchEpisodicMemoryEntries(opts.scope, query, {
+				topK: normalized.topK,
+				queryEmbedding,
+			});
+			return { entries: entries.map(toRecallToolEntry) };
+		})
+		.toModelOutput((output) => ({
+			entries: output.entries.map((entry) => ({
+				...entry,
+				content: `Prior/historical entry: ${entry.content}`,
+			})),
+		}))
+		.build();
+}
+
+export function rankEpisodicMemoryEntries(
+	entries: EpisodicMemoryEntry[],
+	query: string,
+	opts: EpisodicMemorySearchOptions = {},
+): RetrievedEpisodicMemoryEntry[] {
+	const topK = opts.topK ?? DEFAULT_EPISODIC_MEMORY_TOP_K;
+	const statuses = new Set(opts.includeStatuses ?? ['active']);
+	const candidates = entries.filter((entry) => statuses.has(entry.status));
+	const queryTokens = tokenize(query);
+	const lexical = candidates
+		.map((entry) => ({ entry, score: lexicalScore(queryTokens, tokenize(entry.content)) }))
+		.filter((item) => item.score > 0)
+		.sort(compareScoredEntries);
+	const vector = candidates
+		.map((entry) => ({
+			entry,
+			score:
+				opts.queryEmbedding && entry.embedding
+					? cosineSimilarity(opts.queryEmbedding, entry.embedding)
+					: 0,
+		}))
+		.filter((item) => item.score >= MIN_VECTOR_RELEVANCE_SCORE)
+		.sort(compareScoredEntries);
+	const relevantIds = new Set([
+		...lexical.map((item) => item.entry.id),
+		...vector.map((item) => item.entry.id),
+	]);
+	const recency = candidates
+		.filter((entry) => relevantIds.has(entry.id))
+		.sort((a, b) => getEntryRecencyDate(b).getTime() - getEntryRecencyDate(a).getTime());
+	const scores = new Map<
+		string,
+		{ entry: EpisodicMemoryEntry; lexicalScore: number; vectorScore: number; rrfScore: number }
+	>();
+	for (const entry of candidates) {
+		scores.set(entry.id, { entry, lexicalScore: 0, vectorScore: 0, rrfScore: 0 });
+	}
+	for (let rank = 0; rank < lexical.length; rank++) {
+		const score = scores.get(lexical[rank].entry.id);
+		if (!score) continue;
+		score.lexicalScore = lexical[rank].score;
+		score.rrfScore += 1 / (RRF_K + rank + 1);
+	}
+	for (let rank = 0; rank < vector.length; rank++) {
+		const score = scores.get(vector[rank].entry.id);
+		if (!score) continue;
+		score.vectorScore = vector[rank].score;
+		score.rrfScore += 1 / (RRF_K + rank + 1);
+	}
+	for (let rank = 0; rank < recency.length; rank++) {
+		const score = scores.get(recency[rank].id);
+		if (!score) continue;
+		score.rrfScore += RECENCY_RRF_WEIGHT / (RRF_K + rank + 1);
+	}
+	return [...scores.values()]
+		.filter((score) => score.rrfScore > 0)
+		.map((score) => ({
+			...score.entry,
+			lexicalScore: score.lexicalScore,
+			vectorScore: score.vectorScore,
+			rrfScore: score.rrfScore,
+			finalScore: score.rrfScore,
+		}))
+		.sort(
+			(a, b) =>
+				b.finalScore - a.finalScore ||
+				getEntryRecencyDate(b).getTime() - getEntryRecencyDate(a).getTime(),
+		)
+		.slice(0, topK);
+}
+
+export function hashEpisodicMemoryContent(content: string): string {
+	return createHash('sha256').update(normalizeHashContent(content)).digest('hex');
+}
+
+export function hashEpisodicMemoryEvidence(evidenceText: string): string {
+	return createHash('sha256').update(normalizeHashContent(evidenceText)).digest('hex');
+}
+
+function requireEpisodicMemoryScope(
+	persistence: AgentPersistenceOptions | undefined,
+): EpisodicMemoryScope | null {
+	if (!persistence?.agentId || !persistence.resourceId) return null;
+	return {
+		agentId: persistence.agentId,
+		resourceId: persistence.episodicMemoryResourceId ?? persistence.resourceId,
+	};
+}
+
+export function getEpisodicMemoryScope(
+	persistence: AgentPersistenceOptions | undefined,
+): EpisodicMemoryScope | null {
+	return requireEpisodicMemoryScope(persistence);
+}
+
+async function getNewActiveObservations(
+	memory: BuiltMemory & BuiltEpisodicMemoryStore,
+	scope: ObservationLogScope,
+): Promise<ObservationLogEntry[]> {
+	if (
+		!('getActiveObservationLog' in memory) ||
+		typeof memory.getActiveObservationLog !== 'function'
+	) {
+		return [];
+	}
+	const observationMemory = memory as BuiltMemory &
+		BuiltEpisodicMemoryStore & {
+			getActiveObservationLog(
+				scope: ObservationLogScope & { limit?: number; order?: 'asc' | 'desc' },
+			): Promise<ObservationLogEntry[]>;
+		};
+	const [cursor, active] = await Promise.all([
+		memory.getEpisodicMemoryCursor(scope),
+		observationMemory.getActiveObservationLog({ ...scope, order: 'asc' }),
+	]);
+	if (!cursor) return active;
+	return active.filter(
+		(entry) =>
+			compareKeyset(
+				{ createdAt: entry.createdAt, id: entry.id },
+				{
+					createdAt: cursor.lastIndexedObservationCreatedAt,
+					id: cursor.lastIndexedObservationId,
+				},
+			) > 0,
+	);
+}
+
+async function saveCandidate(
+	opts: RunEpisodicMemoryIndexerOpts,
+	config: NormalizedEpisodicMemoryConfig,
+	candidate: ValidatedCandidate,
+	embedding: number[],
+): Promise<EpisodicMemoryEntry | null> {
+	const now = opts.now ?? new Date();
+	return await opts.memory.saveEpisodicMemoryEntryWithSources(
+		{
+			...opts.scope,
+			content: candidate.content,
+			contentHash: hashEpisodicMemoryContent(candidate.content),
+			embedding,
+			embeddingModel: config.embeddingModel,
+			createdAt: now,
+			lastSeenAt: now,
+		},
+		candidate.sources.map((source) => ({
+			observationId: source.observationId,
+			threadId: opts.threadId,
+			evidenceText: source.evidence,
+			createdAt: now,
+		})),
+	);
+}
+
+async function runEpisodicMemoryReflection(
+	opts: RunEpisodicMemoryIndexerOpts,
+	config: NormalizedEpisodicMemoryConfig,
+	savedEntries: EpisodicMemoryEntry[],
+	observations: ObservationLogEntry[],
+): Promise<void> {
+	if (!config.reflect) return;
+	const cluster = await buildReflectionCluster(opts, config, savedEntries, observations);
+	if (cluster.length === 0) return;
+
+	const sources = await opts.memory.getEpisodicMemoryEntrySources(cluster.map((entry) => entry.id));
+	const reflection = normalizeEpisodicMemoryReflection(
+		cluster,
+		await config.reflect({
+			scope: opts.scope,
+			now: opts.now ?? new Date(),
+			seedEntryIds: savedEntries.map((entry) => entry.id),
+			entries: cluster,
+			sources,
+		}),
+	);
+	if (reflection.drop.length === 0 && reflection.merge.length === 0) return;
+
+	const mergeContents = reflection.merge.map((entry) => entry.content);
+	const mergeEmbeddings =
+		mergeContents.length > 0
+			? (
+					await embedMany({
+						model: config.embedder,
+						values: mergeContents,
+					})
+				).embeddings
+			: [];
+	await opts.memory.applyEpisodicMemoryReflection(opts.scope, {
+		drop: reflection.drop,
+		merge: reflection.merge.map((merge, index) => ({
+			supersedes: merge.supersedes,
+			entry: {
+				...opts.scope,
+				content: merge.content,
+				contentHash: hashEpisodicMemoryContent(merge.content),
+				embedding: mergeEmbeddings[index],
+				embeddingModel: config.embeddingModel,
+				createdAt: opts.now ?? new Date(),
+				lastSeenAt: opts.now ?? new Date(),
+			},
+		})),
+	});
+}
+
+async function buildReflectionCluster(
+	opts: RunEpisodicMemoryIndexerOpts,
+	config: NormalizedEpisodicMemoryConfig,
+	savedEntries: EpisodicMemoryEntry[],
+	observations: ObservationLogEntry[],
+): Promise<RetrievedEpisodicMemoryEntry[]> {
+	const query = [
+		...savedEntries.map((entry) => entry.content),
+		...observations.map((entry) => entry.text),
+	].join('\n');
+	const related = await opts.memory.searchEpisodicMemoryEntries(opts.scope, query, {
+		topK: Math.max(config.topK, 20),
+	});
+	const relatedById = new Map(related.map((entry) => [entry.id, entry]));
+	for (const saved of savedEntries) {
+		if (saved.status !== 'active' || relatedById.has(saved.id)) continue;
+		relatedById.set(saved.id, toRetrievedEntry(saved));
+	}
+	return [...relatedById.values()];
+}
+
+function normalizeEpisodicMemoryReflection(
+	activeEntries: EpisodicMemoryEntry[],
+	reflection: EpisodicMemoryReflection,
+): EpisodicMemoryReflection {
+	const activeIds = new Set(
+		activeEntries.filter((entry) => entry.status === 'active').map((entry) => entry.id),
+	);
+	return normalizeFlatReflectionActions<
+		EpisodicMemoryReflectionMerge,
+		EpisodicMemoryReflectionMerge
+	>({
+		activeIds,
+		drop: reflection.drop,
+		merge: reflection.merge,
+		normalizeMerge: (entry, supersedes) => {
+			const content = normalizeEntryContent(entry.content);
+			return content ? { supersedes, content } : null;
+		},
+	});
+}
+
+async function advanceEpisodicCursor(
+	memory: BuiltMemory & BuiltEpisodicMemoryStore,
+	scope: ObservationLogScope,
+	observations: ObservationLogEntry[],
+): Promise<void> {
+	const last = observations.at(-1);
+	if (!last) return;
+	await memory.setEpisodicMemoryCursor({
+		...scope,
+		lastIndexedObservationId: last.id,
+		lastIndexedObservationCreatedAt: last.createdAt,
+	});
+}
+
+interface ValidatedCandidate {
+	content: string;
+	sources: Array<{
+		observationId: string;
+		evidence: string;
+	}>;
+}
+
+function validateCandidates(
+	candidates: EpisodicMemoryExtractionCandidate[],
+	observations: ObservationLogEntry[],
+): ValidatedCandidate[] {
+	const observationsById = new Map(observations.map((entry) => [entry.id, entry]));
+	const valid: ValidatedCandidate[] = [];
+	for (const candidate of candidates) {
+		const sourceKeys = new Set<string>();
+		const sources = candidate.sources.flatMap((source) => {
+			const evidence = source.evidence.trim();
+			if (!evidence) return [];
+			const observation = observationsById.get(source.observationId);
+			if (!observation?.text.includes(evidence)) return [];
+			const key = `${source.observationId}\n${evidence}`;
+			if (sourceKeys.has(key)) return [];
+			sourceKeys.add(key);
+			return [{ observationId: source.observationId, evidence }];
+		});
+		if (sources.length === 0) continue;
+		const content = normalizeEntryContent(candidate.content);
+		if (!content) continue;
+		const evidenceText = sources.map((source) => source.evidence).join('\n');
+		const sourceText = sources
+			.map((source) => observationsById.get(source.observationId)?.text ?? '')
+			.join('\n');
+		if (isFailedRecallCandidate(content, evidenceText, sourceText)) continue;
+		valid.push({
+			content,
+			sources,
+		});
+	}
+	return valid;
+}
+
+function isFailedRecallCandidate(content: string, evidence: string, sourceText: string): boolean {
+	const text = `${content}\n${evidence}\n${sourceText}`.toLowerCase();
+	if (!/\b(memory|recall|prior notes|saved decisions)\b/.test(text)) return false;
+
+	return [
+		/no (?:entries|memory entries|prior notes|saved decisions|matching memory entries) (?:were )?found/,
+		/queried memory[^.]*no entries/,
+		/memory lookup[^.]*no saved/,
+		/could not (?:reliably )?(?:recover|confirm|recall)/,
+		/re-establish(?:ing)? .* baseline/,
+	].some((pattern) => pattern.test(text));
+}
+
+function normalizeEntryContent(content: string): string {
+	return content.replace(/\s+/g, ' ').trim();
+}
+
+function normalizeHashContent(content: string): string {
+	return content.replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+function tokenize(text: string): string[] {
+	return text
+		.toLowerCase()
+		.split(/[^a-z0-9_@./-]+/i)
+		.map((token) => token.trim())
+		.filter((token) => token.length > 1);
+}
+
+function lexicalScore(queryTokens: string[], entryTokens: string[]): number {
+	if (queryTokens.length === 0 || entryTokens.length === 0) return 0;
+	const entryTokenSet = new Set(entryTokens);
+	const matches = queryTokens.filter((token) => entryTokenSet.has(token)).length;
+	return matches / Math.sqrt(entryTokens.length);
+}
+
+function cosineSimilarity(a: number[], b: number[]): number {
+	if (a.length !== b.length || a.length === 0) return 0;
+	let dot = 0;
+	let aMagnitude = 0;
+	let bMagnitude = 0;
+	for (let index = 0; index < a.length; index++) {
+		dot += a[index] * b[index];
+		aMagnitude += a[index] * a[index];
+		bMagnitude += b[index] * b[index];
+	}
+	if (aMagnitude === 0 || bMagnitude === 0) return 0;
+	return dot / (Math.sqrt(aMagnitude) * Math.sqrt(bMagnitude));
+}
+
+function getEntryRecencyDate(entry: Pick<EpisodicMemoryEntry, 'createdAt' | 'lastSeenAt'>): Date {
+	return entry.lastSeenAt ?? entry.createdAt;
+}
+
+function compareScoredEntries(
+	a: { entry: EpisodicMemoryEntry; score: number },
+	b: { entry: EpisodicMemoryEntry; score: number },
+): number {
+	return (
+		b.score - a.score ||
+		getEntryRecencyDate(b.entry).getTime() - getEntryRecencyDate(a.entry).getTime()
+	);
+}
+
+function compareKeyset(
+	a: { createdAt: Date; id: string },
+	b: { createdAt: Date; id: string },
+): number {
+	const t = a.createdAt.getTime() - b.createdAt.getTime();
+	if (t !== 0) return t;
+	return a.id.localeCompare(b.id);
+}
+
+function toRecallToolEntry(
+	entry: RetrievedEpisodicMemoryEntry,
+): RecallMemoryOutput['entries'][number] {
+	return {
+		id: entry.id,
+		content: entry.content,
+		createdAt: entry.createdAt.toISOString(),
+		lexicalScore: entry.lexicalScore,
+		vectorScore: entry.vectorScore,
+		rrfScore: entry.rrfScore,
+		finalScore: entry.finalScore,
+	};
+}
+
+function toRetrievedEntry(entry: EpisodicMemoryEntry): RetrievedEpisodicMemoryEntry {
+	return {
+		...entry,
+		lexicalScore: 0,
+		vectorScore: 0,
+		rrfScore: 0,
+		finalScore: 0,
+	};
+}

--- a/packages/@n8n/agents/src/runtime/episodic-memory.ts
+++ b/packages/@n8n/agents/src/runtime/episodic-memory.ts
@@ -299,9 +299,9 @@ export function hashEpisodicMemoryEvidence(evidenceText: string): string {
 function requireEpisodicMemoryScope(
 	persistence: AgentPersistenceOptions | undefined,
 ): EpisodicMemoryScope | null {
-	if (!persistence?.agentId || !persistence.resourceId) return null;
+	if (!persistence?.resourceId) return null;
 	return {
-		agentId: persistence.agentId,
+		namespace: persistence.episodicMemoryNamespace ?? persistence.resourceId,
 		resourceId: persistence.episodicMemoryResourceId ?? persistence.resourceId,
 	};
 }

--- a/packages/@n8n/agents/src/runtime/memory-lifecycle.ts
+++ b/packages/@n8n/agents/src/runtime/memory-lifecycle.ts
@@ -1,0 +1,79 @@
+export type MemoryLifecycleStatus = 'active' | 'superseded' | 'dropped';
+
+export interface MemoryLifecycleState {
+	status: MemoryLifecycleStatus;
+	supersededBy: string | null;
+}
+
+export function activeLifecycleState(): { status: 'active'; supersededBy: null } {
+	return { status: 'active', supersededBy: null };
+}
+
+export function droppedLifecycleState(): { status: 'dropped'; supersededBy: null } {
+	return { status: 'dropped', supersededBy: null };
+}
+
+export function supersededLifecycleState(supersededBy: string): {
+	status: 'superseded';
+	supersededBy: string;
+} {
+	return { status: 'superseded', supersededBy };
+}
+
+export function markLifecycleActive(entry: MemoryLifecycleState): void {
+	entry.status = 'active';
+	entry.supersededBy = null;
+}
+
+export function markLifecycleDropped(entry: MemoryLifecycleState): void {
+	entry.status = 'dropped';
+	entry.supersededBy = null;
+}
+
+export function markLifecycleSuperseded(entry: MemoryLifecycleState, supersededBy: string): void {
+	entry.status = 'superseded';
+	entry.supersededBy = supersededBy;
+}
+
+export function uniqueStrings(values: Iterable<string>): string[] {
+	const seen = new Set<string>();
+	const unique: string[] = [];
+	for (const value of values) {
+		if (seen.has(value)) continue;
+		seen.add(value);
+		unique.push(value);
+	}
+	return unique;
+}
+
+export function normalizeFlatReflectionActions<
+	TInput extends { supersedes: string[] },
+	TOutput extends { supersedes: string[] },
+>(opts: {
+	activeIds: Iterable<string>;
+	drop: string[];
+	merge: TInput[];
+	normalizeMerge: (entry: TInput, supersedes: string[]) => TOutput | null;
+}): { drop: string[]; merge: TOutput[] } {
+	const activeIds = new Set(opts.activeIds);
+	const claimedIds = new Set<string>();
+	const merge: TOutput[] = [];
+
+	for (const item of opts.merge) {
+		const supersedes = uniqueStrings(item.supersedes).filter(
+			(id) => activeIds.has(id) && !claimedIds.has(id),
+		);
+		if (supersedes.length === 0) continue;
+
+		const normalized = opts.normalizeMerge(item, supersedes);
+		if (!normalized) continue;
+
+		for (const id of supersedes) claimedIds.add(id);
+		merge.push(normalized);
+	}
+
+	return {
+		drop: uniqueStrings(opts.drop).filter((id) => activeIds.has(id) && !claimedIds.has(id)),
+		merge,
+	};
+}

--- a/packages/@n8n/agents/src/runtime/memory-store.ts
+++ b/packages/@n8n/agents/src/runtime/memory-store.ts
@@ -470,7 +470,7 @@ export class InMemoryMemory
 			const contentHash = entry.contentHash ?? hashEpisodicMemoryContent(entry.content);
 			const duplicate = this.episodicMemory.find(
 				(existing) =>
-					existing.agentId === entry.agentId &&
+					existing.namespace === entry.namespace &&
 					existing.resourceId === entry.resourceId &&
 					existing.contentHash === contentHash,
 			);
@@ -484,7 +484,7 @@ export class InMemoryMemory
 
 			const row: EpisodicMemoryEntry = {
 				id: crypto.randomUUID(),
-				agentId: entry.agentId,
+				namespace: entry.namespace,
 				resourceId: entry.resourceId,
 				content: entry.content,
 				contentHash,
@@ -559,7 +559,9 @@ export class InMemoryMemory
 		opts?: EpisodicMemorySearchOptions,
 	): Promise<RetrievedEpisodicMemoryEntry[]> {
 		const scoped = this.episodicMemory
-			.filter((entry) => entry.agentId === scope.agentId && entry.resourceId === scope.resourceId)
+			.filter(
+				(entry) => entry.namespace === scope.namespace && entry.resourceId === scope.resourceId,
+			)
 			.map(cloneEpisodicMemoryEntry);
 		return rankEpisodicMemoryEntries(scoped, query, opts);
 	}
@@ -591,7 +593,7 @@ export class InMemoryMemory
 			this.episodicMemory
 				.filter(
 					(entry) =>
-						entry.agentId === scope.agentId &&
+						entry.namespace === scope.namespace &&
 						entry.resourceId === scope.resourceId &&
 						entry.status === 'active',
 				)

--- a/packages/@n8n/agents/src/runtime/memory-store.ts
+++ b/packages/@n8n/agents/src/runtime/memory-store.ts
@@ -1,5 +1,31 @@
+import { hashEpisodicMemoryContent, rankEpisodicMemoryEntries } from './episodic-memory';
+import {
+	activeLifecycleState,
+	markLifecycleActive,
+	markLifecycleDropped,
+	markLifecycleSuperseded,
+	normalizeFlatReflectionActions,
+	uniqueStrings,
+} from './memory-lifecycle';
 import { normalizeObservationLogReflection } from './observation-log-reflector';
-import type { BuiltMemory, MemoryDescriptor, Thread } from '../types';
+import type {
+	BuiltEpisodicMemoryStore,
+	BuiltMemory,
+	EpisodicMemoryCursor,
+	EpisodicMemoryEntry,
+	EpisodicMemoryEntrySource,
+	EpisodicMemoryReflectionApply,
+	EpisodicMemoryReflectionResult,
+	EpisodicMemoryScope,
+	EpisodicMemorySearchOptions,
+	MemoryDescriptor,
+	NewEpisodicMemoryCursor,
+	NewEpisodicMemoryEntry,
+	NewEpisodicMemoryEntrySource,
+	NewEpisodicMemoryEntrySourceForEntry,
+	RetrievedEpisodicMemoryEntry,
+	Thread,
+} from '../types';
 import type { AgentDbMessage } from '../types/sdk/message';
 import type { ObservationCursor } from '../types/sdk/observation';
 import {
@@ -59,7 +85,11 @@ function compareKeyset(
  * The most recently saved thread is used when `saveMessages` is called.
  */
 export class InMemoryMemory
-	implements BuiltMemory, BuiltObservationLogStore, BuiltObservationLogTaskLockStore
+	implements
+		BuiltMemory,
+		BuiltObservationLogStore,
+		BuiltObservationLogTaskLockStore,
+		BuiltEpisodicMemoryStore
 {
 	private threads = new Map<string, Thread>();
 
@@ -70,6 +100,12 @@ export class InMemoryMemory
 	private cursorsByScope = new Map<string, ObservationCursor>();
 
 	private locksByScope = new Map<string, ObservationLogTaskLockHandle>();
+
+	private episodicMemory: EpisodicMemoryEntry[] = [];
+
+	private episodicMemorySources: EpisodicMemoryEntrySource[] = [];
+
+	private episodicMemoryCursorsByScope = new Map<string, EpisodicMemoryCursor>();
 
 	// eslint-disable-next-line @typescript-eslint/require-await
 	async getThread(threadId: string): Promise<Thread | null> {
@@ -110,6 +146,32 @@ export class InMemoryMemory
 		for (const key of this.locksByScope.keys()) {
 			if (key === legacyKey || key.startsWith(resourceScopePrefix)) {
 				this.locksByScope.delete(key);
+			}
+		}
+		const affectedEntryIds = uniqueStrings(
+			this.episodicMemorySources
+				.filter((source) => source.threadId === threadId)
+				.map((source) => source.memoryEntryId),
+		);
+		this.episodicMemorySources = this.episodicMemorySources.filter(
+			(source) => source.threadId !== threadId,
+		);
+		if (affectedEntryIds.length > 0) {
+			const entriesWithSources = new Set(
+				this.episodicMemorySources.map((source) => source.memoryEntryId),
+			);
+			for (const memoryEntry of this.episodicMemory) {
+				const hasLostLastSource =
+					affectedEntryIds.includes(memoryEntry.id) && !entriesWithSources.has(memoryEntry.id);
+				if (hasLostLastSource) {
+					markLifecycleDropped(memoryEntry);
+					memoryEntry.updatedAt = new Date();
+				}
+			}
+		}
+		for (const key of this.episodicMemoryCursorsByScope.keys()) {
+			if (key === legacyKey || key.startsWith(resourceScopePrefix)) {
+				this.episodicMemoryCursorsByScope.delete(key);
 			}
 		}
 	}
@@ -206,8 +268,7 @@ export class InMemoryMemory
 				text: row.text,
 				parentId: row.parentId ?? null,
 				tokenCount: row.tokenCount ?? estimateObservationTokens(row.text),
-				status: 'active',
-				supersededBy: null,
+				...activeLifecycleState(),
 				createdAt: row.createdAt ?? new Date(),
 			};
 			bucket.push(entry);
@@ -249,8 +310,7 @@ export class InMemoryMemory
 		for (const bucket of this.observationLogByScope.values()) {
 			for (const entry of bucket) {
 				if (idSet.has(entry.id)) {
-					entry.status = 'dropped';
-					entry.supersededBy = null;
+					markLifecycleDropped(entry);
 				}
 			}
 		}
@@ -263,8 +323,7 @@ export class InMemoryMemory
 		for (const bucket of this.observationLogByScope.values()) {
 			for (const entry of bucket) {
 				if (idSet.has(entry.id)) {
-					entry.status = 'superseded';
-					entry.supersededBy = supersededBy;
+					markLifecycleSuperseded(entry, supersededBy);
 				}
 			}
 		}
@@ -398,6 +457,201 @@ export class InMemoryMemory
 			this.locksByScope.delete(key);
 		}
 	}
+
+	// ── Episodic memory ──────────────────────────────────────────────────
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async saveEpisodicMemoryEntries(
+		entries: NewEpisodicMemoryEntry[],
+	): Promise<EpisodicMemoryEntry[]> {
+		const now = new Date();
+		const saved: EpisodicMemoryEntry[] = [];
+		for (const entry of entries) {
+			const contentHash = entry.contentHash ?? hashEpisodicMemoryContent(entry.content);
+			const duplicate = this.episodicMemory.find(
+				(existing) =>
+					existing.agentId === entry.agentId &&
+					existing.resourceId === entry.resourceId &&
+					existing.contentHash === contentHash,
+			);
+			if (duplicate) {
+				markLifecycleActive(duplicate);
+				duplicate.lastSeenAt = entry.lastSeenAt ?? now;
+				duplicate.updatedAt = now;
+				saved.push(cloneEpisodicMemoryEntry(duplicate));
+				continue;
+			}
+
+			const row: EpisodicMemoryEntry = {
+				id: crypto.randomUUID(),
+				agentId: entry.agentId,
+				resourceId: entry.resourceId,
+				content: entry.content,
+				contentHash,
+				...activeLifecycleState(),
+				...(entry.embedding ? { embedding: [...entry.embedding] } : {}),
+				...(entry.embeddingModel ? { embeddingModel: entry.embeddingModel } : {}),
+				metadata: entry.metadata ?? null,
+				createdAt: entry.createdAt ?? now,
+				updatedAt: now,
+				lastSeenAt: entry.lastSeenAt ?? now,
+			};
+			this.episodicMemory.push(row);
+			saved.push(cloneEpisodicMemoryEntry(row));
+		}
+		return saved;
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async saveEpisodicMemoryEntrySources(
+		sources: NewEpisodicMemoryEntrySource[],
+	): Promise<EpisodicMemoryEntrySource[]> {
+		const saved: EpisodicMemoryEntrySource[] = [];
+		for (const source of sources) {
+			const duplicate = this.episodicMemorySources.find(
+				(existing) =>
+					existing.memoryEntryId === source.memoryEntryId &&
+					existing.observationId === source.observationId &&
+					existing.evidenceText === source.evidenceText,
+			);
+			if (duplicate) {
+				saved.push(cloneEpisodicMemorySource(duplicate));
+				continue;
+			}
+			const row: EpisodicMemoryEntrySource = {
+				id: crypto.randomUUID(),
+				memoryEntryId: source.memoryEntryId,
+				observationId: source.observationId,
+				threadId: source.threadId,
+				evidenceText: source.evidenceText,
+				createdAt: source.createdAt ?? new Date(),
+			};
+			this.episodicMemorySources.push(row);
+			saved.push(cloneEpisodicMemorySource(row));
+		}
+		return saved;
+	}
+
+	async saveEpisodicMemoryEntryWithSources(
+		entry: NewEpisodicMemoryEntry,
+		sources: NewEpisodicMemoryEntrySourceForEntry[],
+	): Promise<EpisodicMemoryEntry | null> {
+		const memorySnapshot = this.episodicMemory.map(cloneEpisodicMemoryEntry);
+		const sourceSnapshot = this.episodicMemorySources.map(cloneEpisodicMemorySource);
+		try {
+			const [saved] = await this.saveEpisodicMemoryEntries([entry]);
+			if (!saved) return null;
+			await this.saveEpisodicMemoryEntrySources(
+				sources.map((source) => ({ ...source, memoryEntryId: saved.id })),
+			);
+			return saved;
+		} catch (error) {
+			this.episodicMemory = memorySnapshot;
+			this.episodicMemorySources = sourceSnapshot;
+			throw error;
+		}
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async searchEpisodicMemoryEntries(
+		scope: EpisodicMemoryScope,
+		query: string,
+		opts?: EpisodicMemorySearchOptions,
+	): Promise<RetrievedEpisodicMemoryEntry[]> {
+		const scoped = this.episodicMemory
+			.filter((entry) => entry.agentId === scope.agentId && entry.resourceId === scope.resourceId)
+			.map(cloneEpisodicMemoryEntry);
+		return rankEpisodicMemoryEntries(scoped, query, opts);
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async supersedeEpisodicMemoryEntries(ids: string[], supersededBy: string): Promise<void> {
+		const idSet = new Set(ids);
+		for (const entry of this.episodicMemory) {
+			if (!idSet.has(entry.id) || entry.id === supersededBy) continue;
+			markLifecycleSuperseded(entry, supersededBy);
+			entry.updatedAt = new Date();
+		}
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async getEpisodicMemoryEntrySources(entryIds: string[]): Promise<EpisodicMemoryEntrySource[]> {
+		const idSet = new Set(entryIds);
+		return this.episodicMemorySources
+			.filter((source) => idSet.has(source.memoryEntryId))
+			.sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime() || a.id.localeCompare(b.id))
+			.map(cloneEpisodicMemorySource);
+	}
+
+	async applyEpisodicMemoryReflection(
+		scope: EpisodicMemoryScope,
+		reflection: EpisodicMemoryReflectionApply,
+	): Promise<EpisodicMemoryReflectionResult> {
+		const activeIds = new Set(
+			this.episodicMemory
+				.filter(
+					(entry) =>
+						entry.agentId === scope.agentId &&
+						entry.resourceId === scope.resourceId &&
+						entry.status === 'active',
+				)
+				.map((entry) => entry.id),
+		);
+		const normalized = normalizeFlatReflectionActions({
+			activeIds,
+			drop: reflection.drop,
+			merge: reflection.merge,
+			normalizeMerge: (entry, supersedes) => ({ ...entry, supersedes }),
+		});
+		for (const entry of this.episodicMemory) {
+			if (!normalized.drop.includes(entry.id)) continue;
+			markLifecycleDropped(entry);
+			entry.updatedAt = new Date();
+		}
+
+		const inserted: EpisodicMemoryEntry[] = [];
+		const supersededIds: string[] = [];
+		for (const merge of normalized.merge) {
+			const { supersedes } = merge;
+			const [replacement] = await this.saveEpisodicMemoryEntries([merge.entry]);
+			if (!replacement) continue;
+			inserted.push(replacement);
+			const copiedSources = this.episodicMemorySources
+				.filter((source) => supersedes.includes(source.memoryEntryId))
+				.map((source) => ({
+					memoryEntryId: replacement.id,
+					observationId: source.observationId,
+					threadId: source.threadId,
+					evidenceText: source.evidenceText,
+					createdAt: merge.entry.createdAt ?? new Date(),
+				}));
+			await this.saveEpisodicMemoryEntrySources(copiedSources);
+			await this.supersedeEpisodicMemoryEntries(supersedes, replacement.id);
+			supersededIds.push(...supersedes.filter((id) => id !== replacement.id));
+		}
+
+		return {
+			droppedIds: normalized.drop,
+			supersededIds,
+			inserted,
+		};
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async getEpisodicMemoryCursor(scope: ObservationLogScope): Promise<EpisodicMemoryCursor | null> {
+		const cursor = this.episodicMemoryCursorsByScope.get(scopeKey(scope.scopeKind, scope.scopeId));
+		return cursor ? cloneEpisodicMemoryCursor(cursor) : null;
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	async setEpisodicMemoryCursor(cursor: NewEpisodicMemoryCursor): Promise<void> {
+		const now = new Date();
+		this.episodicMemoryCursorsByScope.set(scopeKey(cursor.scopeKind, cursor.scopeId), {
+			...cursor,
+			lastIndexedObservationCreatedAt: new Date(cursor.lastIndexedObservationCreatedAt),
+			updatedAt: cursor.updatedAt ?? now,
+		});
+	}
 }
 
 /**
@@ -413,4 +667,26 @@ export async function saveMessagesToThread(
 ): Promise<void> {
 	await memory.saveThread({ id: threadId, resourceId });
 	await memory.saveMessages({ threadId, resourceId, messages });
+}
+
+function cloneEpisodicMemoryEntry(entry: EpisodicMemoryEntry): EpisodicMemoryEntry {
+	return {
+		...entry,
+		...(entry.embedding ? { embedding: [...entry.embedding] } : {}),
+		createdAt: new Date(entry.createdAt),
+		updatedAt: new Date(entry.updatedAt),
+		lastSeenAt: new Date(entry.lastSeenAt),
+	};
+}
+
+function cloneEpisodicMemorySource(source: EpisodicMemoryEntrySource): EpisodicMemoryEntrySource {
+	return { ...source, createdAt: new Date(source.createdAt) };
+}
+
+function cloneEpisodicMemoryCursor(cursor: EpisodicMemoryCursor): EpisodicMemoryCursor {
+	return {
+		...cursor,
+		lastIndexedObservationCreatedAt: new Date(cursor.lastIndexedObservationCreatedAt),
+		updatedAt: new Date(cursor.updatedAt),
+	};
 }

--- a/packages/@n8n/agents/src/runtime/observation-log-reflector.ts
+++ b/packages/@n8n/agents/src/runtime/observation-log-reflector.ts
@@ -1,3 +1,4 @@
+import { uniqueStrings } from './memory-lifecycle';
 import type {
 	BuiltObservationLogStore,
 	ObservationLogEntry,
@@ -120,7 +121,7 @@ export function normalizeObservationLogReflection(
 	const merge = reflection.merge
 		.map((entry) => {
 			const ownSeeds = new Set(entry.supersedes.filter((id) => activeById.has(id)));
-			const supersedes = uniqueObservationIds(
+			const supersedes = uniqueStrings(
 				entry.supersedes
 					.filter((id) => activeById.has(id))
 					.filter((id) => !isChildOnlyRemoval(id, ownSeeds, allMergeSeeds, dropSeeds, activeById))
@@ -213,17 +214,6 @@ export async function runObservationLogReflector(
 		reflection,
 		result,
 	};
-}
-
-function uniqueObservationIds(ids: string[]): string[] {
-	const seen = new Set<string>();
-	const unique: string[] = [];
-	for (const id of ids) {
-		if (seen.has(id)) continue;
-		seen.add(id);
-		unique.push(id);
-	}
-	return unique;
 }
 
 function descendantIds(id: string, childrenByParent: Map<string, ObservationLogEntry[]>): string[] {

--- a/packages/@n8n/agents/src/sdk/__tests__/memory-builder-episodic.test.ts
+++ b/packages/@n8n/agents/src/sdk/__tests__/memory-builder-episodic.test.ts
@@ -1,0 +1,133 @@
+import type { AgentRuntime } from '../../runtime/agent-runtime';
+import {
+	DEFAULT_EPISODIC_MEMORY_EMBEDDING_MODEL,
+	DEFAULT_EPISODIC_MEMORY_MAX_ENTRIES_PER_RUN,
+	DEFAULT_EPISODIC_MEMORY_TOP_K,
+} from '../../runtime/episodic-memory-defaults';
+import { InMemoryMemory } from '../../runtime/memory-store';
+import type { EpisodicMemoryConfig } from '../../types';
+import { Agent } from '../agent';
+import { Memory, resolveEpisodicMemoryConfig } from '../memory';
+
+type EmbeddingProviderOpts = {
+	apiKey?: string;
+	baseURL?: string;
+};
+
+jest.mock('@ai-sdk/openai', () => ({
+	createOpenAI: (opts?: EmbeddingProviderOpts) =>
+		Object.assign(
+			(model: string) => ({
+				provider: 'openai',
+				modelId: model,
+				apiKey: opts?.apiKey,
+				baseURL: opts?.baseURL,
+				specificationVersion: 'v3',
+			}),
+			{
+				embeddingModel: (model: string) => ({
+					provider: 'openai',
+					modelId: model,
+					apiKey: opts?.apiKey,
+					baseURL: opts?.baseURL,
+					specificationVersion: 'v2',
+				}),
+			},
+		),
+}));
+
+describe('Memory builder — episodic memory', () => {
+	it('resolves episodic memory defaults from the agent model', async () => {
+		const memory = new Memory().storage(new InMemoryMemory()).episodicMemory({
+			embeddingProviderOptions: {
+				apiKey: 'embedding-key',
+				baseURL: 'https://custom.example/v1',
+			},
+		});
+		const agent = new Agent('a')
+			.model('openai/gpt-4o-mini')
+			.instructions('You are a test assistant.')
+			.memory(memory);
+
+		const runtime = await (agent as unknown as { build(): Promise<AgentRuntime> }).build();
+		const runtimeConfig = (
+			runtime as unknown as {
+				config: {
+					episodicMemory?: EpisodicMemoryConfig;
+				};
+			}
+		).config;
+		const embedder = runtimeConfig.episodicMemory?.embedder as unknown as Record<string, unknown>;
+
+		expect(runtimeConfig.episodicMemory).toMatchObject({
+			topK: DEFAULT_EPISODIC_MEMORY_TOP_K,
+			maxEntriesPerRun: DEFAULT_EPISODIC_MEMORY_MAX_ENTRIES_PER_RUN,
+			embeddingModel: DEFAULT_EPISODIC_MEMORY_EMBEDDING_MODEL,
+		});
+		expect(runtimeConfig.episodicMemory).not.toHaveProperty('halfLifeDays');
+		expect(runtimeConfig.episodicMemory).not.toHaveProperty('maxEntryLength');
+		expect(typeof runtimeConfig.episodicMemory?.extract).toBe('function');
+		expect(typeof runtimeConfig.episodicMemory?.reflect).toBe('function');
+		expect(embedder.provider).toBe('openai');
+		expect(embedder.modelId).toBe('text-embedding-3-small');
+		expect(embedder.apiKey).toBe('embedding-key');
+		expect(embedder.baseURL).toBe('https://custom.example/v1');
+	});
+
+	it('preserves episodic memory overrides when resolving defaults', () => {
+		const embedder = {
+			provider: 'custom',
+			modelId: 'embedding',
+			specificationVersion: 'v2',
+		} as unknown as NonNullable<EpisodicMemoryConfig['embedder']>;
+		const extract: NonNullable<EpisodicMemoryConfig['extract']> = async () =>
+			await Promise.resolve({ entries: [] });
+		const reflect: NonNullable<EpisodicMemoryConfig['reflect']> = async () =>
+			await Promise.resolve({
+				drop: [],
+				merge: [],
+			});
+		const prompts = {
+			extraction: 'extract prompt',
+			reflection: 'reflect prompt',
+			recallToolInstruction: 'recall prompt',
+		};
+
+		const resolved = resolveEpisodicMemoryConfig(
+			{
+				topK: 7,
+				maxEntriesPerRun: 2,
+				halfLifeDays: 14,
+				maxEntryLength: 400,
+				embedder,
+				embeddingModel: 'custom/model',
+				extract,
+				reflect,
+				prompts,
+			} as unknown as EpisodicMemoryConfig,
+			{ defaultModel: 'openai/gpt-4o-mini' },
+		);
+
+		expect(resolved).toMatchObject({
+			topK: 7,
+			maxEntriesPerRun: 2,
+			embeddingModel: 'custom/model',
+			prompts,
+		});
+		expect(resolved).not.toHaveProperty('halfLifeDays');
+		expect(resolved).not.toHaveProperty('maxEntryLength');
+		expect(resolved.embedder).toBe(embedder);
+		expect(resolved.extract).toBe(extract);
+		expect(resolved.reflect).toBe(reflect);
+	});
+
+	it('constructs the default embedder without provider options', () => {
+		const resolved = resolveEpisodicMemoryConfig({}, { defaultModel: 'openai/gpt-4o-mini' });
+		const embedder = resolved.embedder as unknown as Record<string, unknown>;
+
+		expect(embedder.provider).toBe('openai');
+		expect(embedder.modelId).toBe('text-embedding-3-small');
+		expect(embedder.apiKey).toBeUndefined();
+		expect(embedder.baseURL).toBeUndefined();
+	});
+});

--- a/packages/@n8n/agents/src/sdk/agent.ts
+++ b/packages/@n8n/agents/src/sdk/agent.ts
@@ -66,6 +66,8 @@ export interface AgentSnapshot {
 	hasMemory: boolean;
 	/** True when observation-log memory has been configured on the memory builder. */
 	hasObservationalMemory: boolean;
+	/** True when episodic memory has been configured on the memory builder. */
+	hasEpisodicMemory: boolean;
 	/** The thinking config if set, otherwise null. */
 	thinking: ThinkingConfig | null;
 	/** Tool-call concurrency limit if set, otherwise null. */
@@ -527,6 +529,7 @@ export class Agent implements BuiltAgent, AgentBuilder {
 			tools: this.tools.map((t) => ({ name: t.name, description: t.description })),
 			hasMemory: this.memoryConfig !== undefined,
 			hasObservationalMemory: this.memoryConfig?.observationalMemory !== undefined,
+			hasEpisodicMemory: this.memoryConfig?.episodicMemory !== undefined,
 			thinking: this.thinkingConfig ?? null,
 			toolCallConcurrency: this.concurrencyValue ?? null,
 			requireToolApproval: this.requireToolApprovalValue,
@@ -778,6 +781,7 @@ export class Agent implements BuiltAgent, AgentBuilder {
 			lastMessages: memoryConfig?.lastMessages,
 			observationLog: memoryConfig?.observationLog,
 			observationalMemory: memoryConfig?.observationalMemory,
+			episodicMemory: memoryConfig?.episodicMemory,
 			semanticRecall: memoryConfig?.semanticRecall,
 			structuredOutput: this.outputSchema,
 			checkpointStorage: this.checkpointStore,

--- a/packages/@n8n/agents/src/sdk/memory.ts
+++ b/packages/@n8n/agents/src/sdk/memory.ts
@@ -104,7 +104,7 @@ export function resolveMemoryConfigDefaults(
 
 	if (!hasObservationLogStore(config.memory)) {
 		throw new Error(
-			"Observational memory requires a storage backend that implements BuiltObservationLogStore (e.g. n8n's N8nMemory).",
+			'Observational memory requires a storage backend that implements BuiltObservationLogStore.',
 		);
 	}
 
@@ -133,7 +133,7 @@ export function normalizeMemoryConfig(config: MemoryConfig): MemoryConfig {
 
 	if (!hasObservationLogStore(config.memory)) {
 		throw new Error(
-			"Observational memory requires a storage backend that implements BuiltObservationLogStore (e.g. n8n's N8nMemory).",
+			'Observational memory requires a storage backend that implements BuiltObservationLogStore.',
 		);
 	}
 
@@ -183,7 +183,7 @@ export class Memory {
 	 * Set the storage backend for conversation history.
 	 *
 	 * - `'memory'` — in-process memory (default, lost on restart)
-	 * - A `BuiltMemory` instance — for a persistent backend (e.g. cli's `N8nMemory`)
+	 * - A `BuiltMemory` instance — for a persistent backend
 	 */
 	storage(backend: 'memory' | BuiltMemory): this {
 		if (backend === 'memory') {
@@ -285,7 +285,7 @@ export class Memory {
 
 		if (!hasObservationLogStore(memory)) {
 			throw new Error(
-				"Observational memory requires a storage backend that implements BuiltObservationLogStore (e.g. n8n's N8nMemory).",
+				'Observational memory requires a storage backend that implements BuiltObservationLogStore.',
 			);
 		}
 

--- a/packages/@n8n/agents/src/sdk/memory.ts
+++ b/packages/@n8n/agents/src/sdk/memory.ts
@@ -1,4 +1,13 @@
+import { hasEpisodicMemoryStore, isEpisodicMemoryEnabled } from '../runtime/episodic-memory';
+import {
+	DEFAULT_EPISODIC_MEMORY_EMBEDDING_MODEL,
+	DEFAULT_EPISODIC_MEMORY_MAX_ENTRIES_PER_RUN,
+	DEFAULT_EPISODIC_MEMORY_TOP_K,
+	createEpisodicMemoryExtractFn,
+	createEpisodicMemoryReflectFn,
+} from '../runtime/episodic-memory-defaults';
 import { InMemoryMemory } from '../runtime/memory-store';
+import { createEmbeddingModel } from '../runtime/model-factory';
 import {
 	createObservationLogObserveFn,
 	createObservationLogReflectFn,
@@ -11,6 +20,7 @@ import {
 import { hasObservationLogStore } from '../runtime/observation-log-store';
 import type {
 	BuiltMemory,
+	EpisodicMemoryConfig,
 	MemoryConfig,
 	ObservationalMemoryConfig,
 	SemanticRecallConfig,
@@ -25,6 +35,8 @@ export { DEFAULT_OBSERVATION_LOG_LOCK_TTL_MS, DEFAULT_OBSERVATION_LOG_RENDER_TOK
 export interface ResolveObservationalMemoryConfigOptions {
 	defaultModel: ModelConfig;
 }
+
+export type ResolveMemoryConfigDefaultsOptions = ResolveObservationalMemoryConfigOptions;
 
 export function resolveObservationalMemoryConfig(
 	config: ObservationalMemoryConfig,
@@ -46,12 +58,54 @@ export function resolveObservationalMemoryConfig(
 	};
 }
 
+export function resolveEpisodicMemoryConfig(
+	config: EpisodicMemoryConfig,
+	options: ResolveMemoryConfigDefaultsOptions,
+): EpisodicMemoryConfig {
+	const embeddingModel = config.embeddingModel ?? DEFAULT_EPISODIC_MEMORY_EMBEDDING_MODEL;
+	const extractorModel = options.defaultModel;
+	const reflectorModel = options.defaultModel;
+
+	return {
+		enabled: config.enabled,
+		topK: config.topK ?? DEFAULT_EPISODIC_MEMORY_TOP_K,
+		maxEntriesPerRun: config.maxEntriesPerRun ?? DEFAULT_EPISODIC_MEMORY_MAX_ENTRIES_PER_RUN,
+		embedder:
+			config.embedder ?? createEmbeddingModel(embeddingModel, config.embeddingProviderOptions),
+		embeddingModel,
+		extract:
+			config.extract ??
+			createEpisodicMemoryExtractFn(extractorModel, {
+				extractionPrompt: config.prompts?.extraction,
+			}),
+		reflect:
+			config.reflect ??
+			createEpisodicMemoryReflectFn(reflectorModel, {
+				reflectionPrompt: config.prompts?.reflection,
+			}),
+		prompts: config.prompts,
+	};
+}
+
 export function resolveMemoryConfigDefaults(
 	config: MemoryConfig,
-	options: ResolveObservationalMemoryConfigOptions,
+	options: ResolveMemoryConfigDefaultsOptions,
 ): MemoryConfig {
+	const episodicMemory = isEpisodicMemoryEnabled(config.episodicMemory)
+		? resolveEpisodicMemoryConfig(config.episodicMemory, options)
+		: config.episodicMemory;
+
 	if (!config.observationalMemory) {
-		return config;
+		return normalizeMemoryConfig({
+			...config,
+			episodicMemory,
+		});
+	}
+
+	if (!hasObservationLogStore(config.memory)) {
+		throw new Error(
+			"Observational memory requires a storage backend that implements BuiltObservationLogStore (e.g. n8n's N8nMemory).",
+		);
 	}
 
 	const observationalMemoryConfig =
@@ -66,7 +120,9 @@ export function resolveMemoryConfigDefaults(
 
 	return normalizeMemoryConfig({
 		...config,
+		memory: config.memory,
 		observationalMemory,
+		episodicMemory,
 	});
 }
 
@@ -110,6 +166,8 @@ export class Memory {
 
 	private semanticRecallConfig?: SemanticRecallConfig;
 
+	private episodicMemoryConfig?: EpisodicMemoryConfig;
+
 	private memoryBackend?: BuiltMemory;
 
 	private titleGenerationConfig?: TitleGenerationConfig;
@@ -145,6 +203,16 @@ export class Memory {
 	/** Enable semantic recall (RAG-based retrieval of relevant past messages). */
 	semanticRecall(config: SemanticRecallConfig): this {
 		this.semanticRecallConfig = config;
+		return this;
+	}
+
+	/** Enable source-backed cross-session episodic memory. */
+	episodicMemory(config: EpisodicMemoryConfig = {}): this {
+		if (config.enabled === false) {
+			this.episodicMemoryConfig = undefined;
+		} else {
+			this.episodicMemoryConfig = config;
+		}
 		return this;
 	}
 
@@ -195,10 +263,19 @@ export class Memory {
 			}
 		}
 
+		if (isEpisodicMemoryEnabled(this.episodicMemoryConfig)) {
+			if (!hasEpisodicMemoryStore(memory)) {
+				throw new Error(
+					'Episodic memory requires a storage backend that implements BuiltEpisodicMemoryStore.',
+				);
+			}
+		}
+
 		const baseConfig = {
 			memory,
 			lastMessages: this.lastMessagesValue,
 			semanticRecall: this.semanticRecallConfig,
+			episodicMemory: this.episodicMemoryConfig,
 			titleGeneration: this.titleGenerationConfig,
 		};
 

--- a/packages/@n8n/agents/src/types/runtime/event.ts
+++ b/packages/@n8n/agents/src/types/runtime/event.ts
@@ -27,7 +27,7 @@ export type AgentEventData =
 			type: AgentEvent.Error;
 			message: string;
 			error: unknown;
-			source?: 'observer' | 'reflector';
+			source?: 'observer' | 'reflector' | 'episodic-memory';
 	  };
 
 export type AgentEventHandler = (data: AgentEventData) => void;

--- a/packages/@n8n/agents/src/types/sdk/agent.ts
+++ b/packages/@n8n/agents/src/types/sdk/agent.ts
@@ -295,6 +295,6 @@ export interface SerializableAgentState {
 export type AgentPersistenceOptions = {
 	threadId: string;
 	resourceId: string;
-	agentId?: string;
+	episodicMemoryNamespace?: string;
 	episodicMemoryResourceId?: string;
 };

--- a/packages/@n8n/agents/src/types/sdk/agent.ts
+++ b/packages/@n8n/agents/src/types/sdk/agent.ts
@@ -295,4 +295,6 @@ export interface SerializableAgentState {
 export type AgentPersistenceOptions = {
 	threadId: string;
 	resourceId: string;
+	agentId?: string;
+	episodicMemoryResourceId?: string;
 };

--- a/packages/@n8n/agents/src/types/sdk/observation-log.ts
+++ b/packages/@n8n/agents/src/types/sdk/observation-log.ts
@@ -10,7 +10,7 @@ export type ObservationLogStatus = (typeof OBSERVATION_LOG_STATUSES)[number];
 
 export type ObservationLogScopeKind = 'thread' | 'resource';
 
-export type ObservationLogTaskKind = 'observer' | 'reflector';
+export type ObservationLogTaskKind = 'observer' | 'reflector' | 'episodic-indexer';
 
 const OBSERVATION_LOG_THREAD_SCOPE_PREFIX = 'thread';
 


### PR DESCRIPTION
## Summary

Wires Episodic Memory into AgentRuntime: resolved config defaults, recall_memory, background indexing, runtime task scheduling, and historical-context recall behavior. EM remains explicit recall only, with no passive prompt injection.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
