### PR TITLE
feat(core): Persist episodic memory entries

### DIFF
--- a/packages/@n8n/agents/src/index.ts
+++ b/packages/@n8n/agents/src/index.ts
@@ -55,6 +55,8 @@ export type {
 	EpisodicMemoryScope,
 	EpisodicMemorySearchOptions,
 	EpisodicMemoryStatus,
+	EpisodicMemoryTaskLockHandle,
+	EpisodicMemoryTaskLockMethods,
 	NewEpisodicMemoryCursor,
 	NewEpisodicMemoryEntry,
 	NewEpisodicMemoryEntrySource,

--- a/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
@@ -2621,6 +2621,8 @@ describe('AgentRuntime — observation log jobs', () => {
 		embedMany.mockResolvedValue({ embeddings: [[1, 0]], usage: { tokens: 1 } });
 		const memory = new InMemoryMemory();
 		const fakeEmbedder = { specificationVersion: 'v2' } as never;
+		const observationLockSpy = jest.spyOn(memory, 'acquireObservationLogTaskLock');
+		const episodicLockSpy = jest.spyOn(memory.episodic.taskLock!, 'acquire');
 
 		const runtime = new AgentRuntime({
 			name: 'observing-agent',
@@ -2669,6 +2671,63 @@ describe('AgentRuntime — observation log jobs', () => {
 			scopeId: createObservationLogThreadScopeId('thread-1', 'resource-1'),
 		});
 		expect(typeof cursor?.lastIndexedObservationId).toBe('string');
+		const firstLockCall = episodicLockSpy.mock.calls.at(0);
+		if (!firstLockCall) throw new Error('Expected episodic memory lock acquisition');
+		const [lockedResourceId, lockOptions] = firstLockCall;
+		expect(lockedResourceId).toBe('resource-1');
+		expect(typeof lockOptions.holderId).toBe('string');
+		expect(typeof lockOptions.ttlMs).toBe('number');
+		const observationLockTaskKinds = observationLockSpy.mock.calls.map((call) => String(call[2]));
+		expect(observationLockTaskKinds).not.toContain('episodic-indexer');
+	});
+
+	it('skips episodic indexing when the episodic task lock is held', async () => {
+		generateText.mockResolvedValue(makeGenerateSuccess('Plain response'));
+		const memory = new InMemoryMemory();
+		const observationScope = {
+			scopeKind: 'thread' as const,
+			scopeId: createObservationLogThreadScopeId('thread-1', 'resource-1'),
+		};
+		const [observation] = await memory.appendObservationLogEntries([
+			{
+				...observationScope,
+				marker: 'critical',
+				text: 'User chose Postgres for memory storage.',
+				createdAt: new Date('2026-05-20T12:00:00Z'),
+			},
+		]);
+		const extract = jest.fn(async () => {
+			await Promise.resolve();
+
+			return {
+				entries: [
+					{
+						content: 'User chose Postgres for memory storage.',
+						sources: [{ observationId: observation.id, evidence: 'User chose Postgres' }],
+					},
+				],
+			};
+		});
+		jest.spyOn(memory.episodic.taskLock!, 'acquire').mockResolvedValue(null);
+
+		const runtime = new AgentRuntime({
+			name: 'observing-agent',
+			model: 'openai/gpt-4o-mini',
+			instructions: 'You are a test assistant.',
+			memory,
+			episodicMemory: {
+				embedder: { specificationVersion: 'v2' } as never,
+				extract,
+			},
+		});
+
+		await runtime.generate('Please remember this.', {
+			persistence: { threadId: 'thread-1', resourceId: 'resource-1' },
+		});
+		await runtime.dispose();
+
+		expect(extract).not.toHaveBeenCalled();
+		await expect(memory.episodic.getCursor(observationScope)).resolves.toBeNull();
 	});
 
 	it('does not inject episodic memory and exposes recall_memory for explicit recall', async () => {

--- a/packages/@n8n/agents/src/runtime/agent-runtime.ts
+++ b/packages/@n8n/agents/src/runtime/agent-runtime.ts
@@ -15,6 +15,8 @@ import type {
 	BuiltTool,
 	CheckpointStore,
 	EpisodicMemoryConfig,
+	EpisodicMemoryTaskLockHandle,
+	EpisodicMemoryTaskLockMethods,
 	FinishReason,
 	GenerateResult,
 	GoogleThinkingConfig,
@@ -206,6 +208,7 @@ export interface AgentRuntimeConfig {
 }
 
 const MAX_LOOP_ITERATIONS = 20;
+const DEFAULT_MEMORY_TASK_LOCK_TTL_MS = 30_000;
 const logger = createFilteredLogger();
 
 function getAiSdk(): ReturnType<typeof loadAi> {
@@ -357,6 +360,8 @@ export class AgentRuntime {
 	private backgroundTasks = new BackgroundTaskTracker();
 
 	private memoryTasks: ScopedMemoryTaskRunner | undefined;
+
+	private episodicMemoryTasksByResource = new Map<string, Promise<unknown>>();
 
 	private deferredToolManager: DeferredToolManager | undefined;
 
@@ -1483,62 +1488,74 @@ export class AgentRuntime {
 			);
 		}
 
-		this.scheduleObservationLogJobs(options.persistence);
-		this.scheduleEpisodicMemoryJob(options.persistence);
+		const observationTasks = this.scheduleObservationLogJobs(options.persistence);
+		this.scheduleEpisodicMemoryJob(options.persistence, observationTasks);
 	}
 
-	private scheduleObservationLogJobs(persistence: AgentPersistenceOptions): void {
+	private scheduleObservationLogJobs(
+		persistence: AgentPersistenceOptions,
+	): Array<Promise<unknown>> {
 		const { memory, observationalMemory } = this.config;
-		if (!memory || !observationalMemory || !hasObservationLogStore(memory)) return;
+		if (!memory || !observationalMemory || !hasObservationLogStore(memory)) return [];
 
 		const scope = this.getObservationLogScope(persistence);
 		const runner = this.getMemoryTaskRunner(memory, observationalMemory.lockTtlMs);
 		const observe = observationalMemory.observe;
 		const observerThresholdTokens = observationalMemory.observerThresholdTokens;
+		const tasks: Array<Promise<unknown>> = [];
 
 		if (
 			observe &&
 			observerThresholdTokens !== undefined &&
 			hasObservationLogObserverMemory(memory)
 		) {
-			this.scheduleMemoryTask(
-				runner,
-				scope,
-				'observer',
-				async () =>
-					await runObservationLogObserver({
-						memory,
-						...scope,
-						observerThresholdTokens,
-						observationLogTailLimit: observationalMemory.observationLogTailLimit ?? 0,
-						observe,
-						messageSource: {
-							threadId: persistence.threadId,
-							resourceId: persistence.resourceId,
-						},
-					}),
+			tasks.push(
+				this.scheduleMemoryTask(
+					runner,
+					scope,
+					'observer',
+					async () =>
+						await runObservationLogObserver({
+							memory,
+							...scope,
+							observerThresholdTokens,
+							observationLogTailLimit: observationalMemory.observationLogTailLimit ?? 0,
+							observe,
+							messageSource: {
+								threadId: persistence.threadId,
+								resourceId: persistence.resourceId,
+							},
+						}),
+				),
 			);
 		}
 
 		const reflect = observationalMemory.reflect;
 		const reflectorThresholdTokens = observationalMemory.reflectorThresholdTokens;
 		if (reflect && reflectorThresholdTokens !== undefined) {
-			this.scheduleMemoryTask(
-				runner,
-				scope,
-				'reflector',
-				async () =>
-					await runObservationLogReflector({
-						memory,
-						...scope,
-						reflectorThresholdTokens,
-						reflect,
-					}),
+			tasks.push(
+				this.scheduleMemoryTask(
+					runner,
+					scope,
+					'reflector',
+					async () =>
+						await runObservationLogReflector({
+							memory,
+							...scope,
+							reflectorThresholdTokens,
+							reflect,
+						}),
+				),
 			);
 		}
+
+		return tasks;
 	}
 
-	private scheduleEpisodicMemoryJob(persistence: AgentPersistenceOptions): void {
+	private scheduleEpisodicMemoryJob(
+		persistence: AgentPersistenceOptions,
+		observationTasks: Array<Promise<unknown>>,
+	): void {
 		const { memory, episodicMemory } = this.config;
 		if (
 			!memory ||
@@ -1554,29 +1571,84 @@ export class AgentRuntime {
 		if (!scope) return;
 
 		const observationScope = this.getObservationLogScope(persistence);
-		const runner = this.getMemoryTaskRunner(memory, this.config.observationalMemory?.lockTtlMs);
-		this.scheduleMemoryTask(
-			runner,
-			observationScope,
-			'episodic-indexer',
-			async () =>
-				await runEpisodicMemoryIndexer({
-					memory,
-					config: episodicMemory,
-					scope,
-					observationScope,
-					threadId: persistence.threadId,
-				}),
-		);
+		this.scheduleEpisodicMemoryTask(memory, scope.resourceId, async () => {
+			await Promise.allSettled(observationTasks);
+			await runEpisodicMemoryIndexer({
+				memory,
+				config: episodicMemory,
+				scope,
+				observationScope,
+				threadId: persistence.threadId,
+			});
+		});
 	}
 
-	private scheduleMemoryTask<T>(
+	private scheduleEpisodicMemoryTask(
+		memory: BuiltMemory,
+		resourceId: string,
+		task: () => Promise<void>,
+	): void {
+		const id = crypto.randomUUID();
+		const previous = this.episodicMemoryTasksByResource.get(resourceId) ?? Promise.resolve();
+		const done = previous
+			.catch(() => undefined)
+			.then(async () => await this.runEpisodicMemoryTask(memory, resourceId, id, task));
+		const queued = done.finally(() => {
+			if (this.episodicMemoryTasksByResource.get(resourceId) === queued) {
+				this.episodicMemoryTasksByResource.delete(resourceId);
+			}
+		});
+		this.episodicMemoryTasksByResource.set(resourceId, queued);
+		this.backgroundTasks.track(queued);
+	}
+
+	private async runEpisodicMemoryTask(
+		memory: BuiltMemory,
+		resourceId: string,
+		holderId: string,
+		task: () => Promise<void>,
+	): Promise<void> {
+		const taskLock = memory.episodic?.taskLock;
+		let lock: EpisodicMemoryTaskLockHandle | null = null;
+		try {
+			if (taskLock) {
+				lock = await taskLock.acquire(resourceId, {
+					holderId,
+					ttlMs: this.config.observationalMemory?.lockTtlMs ?? DEFAULT_MEMORY_TASK_LOCK_TTL_MS,
+				});
+				if (!lock) return;
+			}
+			await task();
+		} catch (error) {
+			const message = 'Episodic memory indexing task failed';
+			logger.warn(message, { error, resourceId });
+			this.eventBus.emit({ type: AgentEvent.Error, message, error, source: 'episodic-memory' });
+		} finally {
+			if (lock) {
+				await this.releaseEpisodicMemoryTaskLock(taskLock, lock, resourceId);
+			}
+		}
+	}
+
+	private async releaseEpisodicMemoryTaskLock(
+		taskLock: EpisodicMemoryTaskLockMethods | undefined,
+		lock: EpisodicMemoryTaskLockHandle,
+		resourceId: string,
+	): Promise<void> {
+		try {
+			await taskLock?.release(lock);
+		} catch (error) {
+			logger.warn('Episodic memory indexing lock release failed', { error, resourceId });
+		}
+	}
+
+	private async scheduleMemoryTask<T>(
 		runner: ScopedMemoryTaskRunner,
 		scope: ObservationLogScope,
 		taskKind: ObservationLogTaskKind,
 		task: () => Promise<T>,
-	): void {
-		runner.schedule({ ...scope, taskKind }, task);
+	): Promise<unknown> {
+		return await runner.schedule({ ...scope, taskKind }, task).done;
 	}
 
 	private getMemoryTaskRunner(memory: BuiltMemory, lockTtlMs?: number): ScopedMemoryTaskRunner {
@@ -1586,12 +1658,8 @@ export class AgentRuntime {
 			lockTtlMs,
 			onEvent: (event) => {
 				if (event.type !== 'failed') return;
-				const source =
-					event.task.taskKind === 'episodic-indexer' ? 'episodic-memory' : event.task.taskKind;
-				const message =
-					event.task.taskKind === 'episodic-indexer'
-						? 'Episodic memory indexing task failed'
-						: `Observation log ${source} task failed`;
+				const source = event.task.taskKind;
+				const message = `Observation log ${source} task failed`;
 				logger.warn(message, {
 					error: event.error,
 					scopeKind: event.task.scopeKind,

--- a/packages/@n8n/agents/src/runtime/memory-store.ts
+++ b/packages/@n8n/agents/src/runtime/memory-store.ts
@@ -19,6 +19,7 @@ import type {
 	EpisodicMemoryReflectionResult,
 	EpisodicMemoryScope,
 	EpisodicMemorySearchOptions,
+	EpisodicMemoryTaskLockHandle,
 	MemoryDescriptor,
 	NewEpisodicMemoryCursor,
 	NewEpisodicMemoryEntry,
@@ -108,6 +109,8 @@ export class InMemoryMemory
 
 	private episodicMemoryCursorsByScope = new Map<string, EpisodicMemoryCursor>();
 
+	private episodicMemoryLocksByResource = new Map<string, EpisodicMemoryTaskLockHandle>();
+
 	readonly episodic: EpisodicMemoryMethods = {
 		saveEntryWithSources: async (entry, sources) =>
 			await this.saveEpisodicMemoryEntryWithSources(entry, sources),
@@ -118,6 +121,11 @@ export class InMemoryMemory
 			await this.applyEpisodicMemoryReflection(scope, reflection),
 		getCursor: async (scope) => await this.getEpisodicMemoryCursor(scope),
 		setCursor: async (cursor) => await this.setEpisodicMemoryCursor(cursor),
+		taskLock: {
+			acquire: async (resourceId, opts) =>
+				await this.acquireEpisodicMemoryTaskLock(resourceId, opts),
+			release: async (handle) => await this.releaseEpisodicMemoryTaskLock(handle),
+		},
 	};
 
 	// eslint-disable-next-line @typescript-eslint/require-await
@@ -660,6 +668,33 @@ export class InMemoryMemory
 			lastIndexedObservationCreatedAt: new Date(cursor.lastIndexedObservationCreatedAt),
 			updatedAt: cursor.updatedAt ?? now,
 		});
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	private async acquireEpisodicMemoryTaskLock(
+		resourceId: string,
+		opts: { ttlMs: number; holderId: string },
+	): Promise<EpisodicMemoryTaskLockHandle | null> {
+		const existing = this.episodicMemoryLocksByResource.get(resourceId);
+		const now = Date.now();
+		if (existing && existing.holderId !== opts.holderId && existing.heldUntil.getTime() > now) {
+			return null;
+		}
+		const handle: EpisodicMemoryTaskLockHandle = {
+			resourceId,
+			holderId: opts.holderId,
+			heldUntil: new Date(now + opts.ttlMs),
+		};
+		this.episodicMemoryLocksByResource.set(resourceId, handle);
+		return { ...handle };
+	}
+
+	// eslint-disable-next-line @typescript-eslint/require-await
+	private async releaseEpisodicMemoryTaskLock(handle: EpisodicMemoryTaskLockHandle): Promise<void> {
+		const current = this.episodicMemoryLocksByResource.get(handle.resourceId);
+		if (current && current.holderId === handle.holderId) {
+			this.episodicMemoryLocksByResource.delete(handle.resourceId);
+		}
 	}
 }
 

--- a/packages/@n8n/agents/src/types/index.ts
+++ b/packages/@n8n/agents/src/types/index.ts
@@ -83,6 +83,8 @@ export type {
 	EpisodicMemoryScope,
 	EpisodicMemorySearchOptions,
 	EpisodicMemoryStatus,
+	EpisodicMemoryTaskLockHandle,
+	EpisodicMemoryTaskLockMethods,
 	NewEpisodicMemoryCursor,
 	NewEpisodicMemoryEntry,
 	NewEpisodicMemoryEntrySource,

--- a/packages/@n8n/agents/src/types/sdk/memory.ts
+++ b/packages/@n8n/agents/src/types/sdk/memory.ts
@@ -185,6 +185,20 @@ export interface EpisodicMemorySearchOptions {
 	includeStatuses?: EpisodicMemoryStatus[];
 }
 
+export interface EpisodicMemoryTaskLockHandle {
+	resourceId: string;
+	holderId: string;
+	heldUntil: Date;
+}
+
+export interface EpisodicMemoryTaskLockMethods {
+	acquire(
+		resourceId: string,
+		opts: { ttlMs: number; holderId: string },
+	): Promise<EpisodicMemoryTaskLockHandle | null>;
+	release(handle: EpisodicMemoryTaskLockHandle): Promise<void>;
+}
+
 export interface EpisodicMemoryMethods {
 	saveEntryWithSources(
 		entry: NewEpisodicMemoryEntry,
@@ -202,6 +216,7 @@ export interface EpisodicMemoryMethods {
 	): Promise<EpisodicMemoryReflectionResult>;
 	getCursor(scope: ObservationLogScope): Promise<EpisodicMemoryCursor | null>;
 	setCursor(cursor: NewEpisodicMemoryCursor): Promise<void>;
+	taskLock?: EpisodicMemoryTaskLockMethods;
 }
 
 export interface BuiltEpisodicMemoryStore {

--- a/packages/@n8n/agents/src/types/sdk/observation-log.ts
+++ b/packages/@n8n/agents/src/types/sdk/observation-log.ts
@@ -10,7 +10,7 @@ export type ObservationLogStatus = (typeof OBSERVATION_LOG_STATUSES)[number];
 
 export type ObservationLogScopeKind = 'thread' | 'resource';
 
-export type ObservationLogTaskKind = 'observer' | 'reflector' | 'episodic-indexer';
+export type ObservationLogTaskKind = 'observer' | 'reflector';
 
 const OBSERVATION_LOG_THREAD_SCOPE_PREFIX = 'thread';
 

--- a/packages/@n8n/db/src/migrations/common/1784000000009-CreateAgentMemoryEntryTables.ts
+++ b/packages/@n8n/db/src/migrations/common/1784000000009-CreateAgentMemoryEntryTables.ts
@@ -6,7 +6,7 @@ const MEMORY_ENTRY_STATUSES = ['active', 'superseded', 'dropped'];
 const OBSERVATION_SCOPE_KINDS = ['thread', 'resource'];
 const OBSERVATION_LOCKS_TABLE = 'agents_observation_locks';
 const OBSERVATION_LOCK_TASK_KIND_COLUMN = 'taskKind';
-const LEGACY_OBSERVATION_LOCK_TASK_KINDS = ['observer', 'reflector'];
+const LEGACY_OBSERVATION_LOCK_TASK_KIND_VALUES = "'observer', 'reflector'";
 
 export class CreateAgentMemoryEntryTables1784000000009 implements ReversibleMigration {
 	async up({
@@ -15,9 +15,6 @@ export class CreateAgentMemoryEntryTables1784000000009 implements ReversibleMigr
 		tablePrefix,
 	}: MigrationContext) {
 		await this.dropObservationLockTaskKindCheck(queryRunner, tablePrefix);
-		await dropTable('agents_memory_entry_cursors');
-		await dropTable('agents_memory_entry_sources');
-		await dropTable('agents_memory_entries');
 
 		await createTable('agents_memory_entries')
 			.withColumns(
@@ -84,6 +81,11 @@ export class CreateAgentMemoryEntryTables1784000000009 implements ReversibleMigr
 				tableName: 'agents_observations',
 				columnName: 'id',
 				onDelete: 'CASCADE',
+			})
+			.withForeignKey('threadId', {
+				tableName: 'agents_threads',
+				columnName: 'id',
+				onDelete: 'CASCADE',
 			}).withTimestamps;
 
 		await createTable('agents_memory_entry_cursors').withColumns(
@@ -147,20 +149,15 @@ export class CreateAgentMemoryEntryTables1784000000009 implements ReversibleMigr
 		const checkName = `CHK_${tablePrefix}${OBSERVATION_LOCKS_TABLE}_${OBSERVATION_LOCK_TASK_KIND_COLUMN}`;
 		if (table.checks.some((check) => check.name === checkName)) return;
 
-		const escapedColumnName = queryRunner.connection.driver.escape(
-			OBSERVATION_LOCK_TASK_KIND_COLUMN,
-		);
-		const escapedValues = LEGACY_OBSERVATION_LOCK_TASK_KINDS.map(
-			(value) => `'${value.replace(/'/g, "''")}'`,
-		).join(', ');
+		const escapedColumnName = escape.columnName(OBSERVATION_LOCK_TASK_KIND_COLUMN);
 		await runQuery(
-			`DELETE FROM ${escape.tableName(OBSERVATION_LOCKS_TABLE)} WHERE ${escape.columnName(OBSERVATION_LOCK_TASK_KIND_COLUMN)} NOT IN (${escapedValues})`,
+			`DELETE FROM ${escape.tableName(OBSERVATION_LOCKS_TABLE)} WHERE ${escape.columnName(OBSERVATION_LOCK_TASK_KIND_COLUMN)} NOT IN (${LEGACY_OBSERVATION_LOCK_TASK_KIND_VALUES})`,
 		);
 		await queryRunner.createCheckConstraint(
 			fullTableName,
 			new TableCheck({
 				name: checkName,
-				expression: `${escapedColumnName} IN (${escapedValues})`,
+				expression: `${escapedColumnName} IN (${LEGACY_OBSERVATION_LOCK_TASK_KIND_VALUES})`,
 			}),
 		);
 	}

--- a/packages/@n8n/db/src/migrations/common/1784000000009-CreateAgentMemoryEntryTables.ts
+++ b/packages/@n8n/db/src/migrations/common/1784000000009-CreateAgentMemoryEntryTables.ts
@@ -9,8 +9,8 @@ const OBSERVATION_LOCK_TASK_KIND_COLUMN = 'taskKind';
 const LEGACY_OBSERVATION_LOCK_TASK_KIND_VALUES = "'observer', 'reflector'";
 
 export class CreateAgentMemoryEntryTables1784000000009 implements ReversibleMigration {
-	async up({ schemaBuilder: { createTable, column }, queryRunner, tablePrefix }: MigrationContext) {
-		await this.dropObservationLockTaskKindCheck(queryRunner, tablePrefix);
+	async up({ schemaBuilder: { createTable, column, dropEnumCheck } }: MigrationContext) {
+		await dropEnumCheck(OBSERVATION_LOCKS_TABLE, OBSERVATION_LOCK_TASK_KIND_COLUMN);
 
 		await createTable('agents_memory_entries')
 			.withColumns(
@@ -114,24 +114,6 @@ export class CreateAgentMemoryEntryTables1784000000009 implements ReversibleMigr
 		await this.restoreObservationLockTaskKindCheck(queryRunner, tablePrefix, escape, runQuery);
 	}
 
-	private async dropObservationLockTaskKindCheck(
-		queryRunner: MigrationContext['queryRunner'],
-		tablePrefix: string,
-	) {
-		const fullTableName = `${tablePrefix}${OBSERVATION_LOCKS_TABLE}`;
-		const table = await queryRunner.getTable(fullTableName);
-		const check = table?.checks.find(
-			(item) =>
-				item.name ===
-					`CHK_${tablePrefix}${OBSERVATION_LOCKS_TABLE}_${OBSERVATION_LOCK_TASK_KIND_COLUMN}` ||
-				item.expression?.includes(OBSERVATION_LOCK_TASK_KIND_COLUMN),
-		);
-
-		if (check) {
-			await queryRunner.dropCheckConstraint(fullTableName, check);
-		}
-	}
-
 	private async restoreObservationLockTaskKindCheck(
 		queryRunner: MigrationContext['queryRunner'],
 		tablePrefix: string,
@@ -139,12 +121,7 @@ export class CreateAgentMemoryEntryTables1784000000009 implements ReversibleMigr
 		runQuery: MigrationContext['runQuery'],
 	) {
 		const fullTableName = `${tablePrefix}${OBSERVATION_LOCKS_TABLE}`;
-		const table = await queryRunner.getTable(fullTableName);
-		if (!table) return;
-
 		const checkName = `CHK_${tablePrefix}${OBSERVATION_LOCKS_TABLE}_${OBSERVATION_LOCK_TASK_KIND_COLUMN}`;
-		if (table.checks.some((check) => check.name === checkName)) return;
-
 		const escapedColumnName = escape.columnName(OBSERVATION_LOCK_TASK_KIND_COLUMN);
 		await runQuery(
 			`DELETE FROM ${escape.tableName(OBSERVATION_LOCKS_TABLE)} WHERE ${escape.columnName(OBSERVATION_LOCK_TASK_KIND_COLUMN)} NOT IN (${LEGACY_OBSERVATION_LOCK_TASK_KIND_VALUES})`,

--- a/packages/@n8n/db/src/migrations/common/1784000000009-CreateAgentMemoryEntryTables.ts
+++ b/packages/@n8n/db/src/migrations/common/1784000000009-CreateAgentMemoryEntryTables.ts
@@ -68,6 +68,9 @@ export class CreateAgentMemoryEntryTables1784000000009 implements ReversibleMigr
 		await createTable('agents_memory_entry_sources')
 			.withColumns(
 				column('id').varchar(36).primary.notNull,
+				column('agentId')
+					.varchar(36)
+					.notNull.comment('Agent that owns the linked episodic memory entry source'),
 				column('memoryEntryId').varchar(36).notNull,
 				column('observationId').varchar(36).notNull,
 				column('threadId')
@@ -82,7 +85,12 @@ export class CreateAgentMemoryEntryTables1784000000009 implements ReversibleMigr
 			)
 			.withIndexOn(['memoryEntryId', 'observationId', 'evidenceHash'], true)
 			.withIndexOn('observationId')
-			.withIndexOn('threadId')
+			.withIndexOn(['agentId', 'threadId'])
+			.withForeignKey('agentId', {
+				tableName: 'agents',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
 			.withForeignKey('memoryEntryId', {
 				tableName: 'agents_memory_entries',
 				columnName: 'id',

--- a/packages/@n8n/db/src/migrations/common/1784000000009-CreateAgentMemoryEntryTables.ts
+++ b/packages/@n8n/db/src/migrations/common/1784000000009-CreateAgentMemoryEntryTables.ts
@@ -9,11 +9,7 @@ const OBSERVATION_LOCK_TASK_KIND_COLUMN = 'taskKind';
 const LEGACY_OBSERVATION_LOCK_TASK_KIND_VALUES = "'observer', 'reflector'";
 
 export class CreateAgentMemoryEntryTables1784000000009 implements ReversibleMigration {
-	async up({
-		schemaBuilder: { createTable, dropTable, column },
-		queryRunner,
-		tablePrefix,
-	}: MigrationContext) {
+	async up({ schemaBuilder: { createTable, column }, queryRunner, tablePrefix }: MigrationContext) {
 		await this.dropObservationLockTaskKindCheck(queryRunner, tablePrefix);
 
 		await createTable('agents_memory_entries')

--- a/packages/@n8n/db/src/migrations/common/1784000000009-CreateAgentMemoryEntryTables.ts
+++ b/packages/@n8n/db/src/migrations/common/1784000000009-CreateAgentMemoryEntryTables.ts
@@ -1,17 +1,10 @@
-import { TableCheck } from '@n8n/typeorm';
-
 import type { MigrationContext, ReversibleMigration } from '../migration-types';
 
 const MEMORY_ENTRY_STATUSES = ['active', 'superseded', 'dropped'];
 const OBSERVATION_SCOPE_KINDS = ['thread', 'resource'];
-const OBSERVATION_LOCKS_TABLE = 'agents_observation_locks';
-const OBSERVATION_LOCK_TASK_KIND_COLUMN = 'taskKind';
-const LEGACY_OBSERVATION_LOCK_TASK_KIND_VALUES = "'observer', 'reflector'";
 
 export class CreateAgentMemoryEntryTables1784000000009 implements ReversibleMigration {
-	async up({ schemaBuilder: { createTable, column, dropEnumCheck } }: MigrationContext) {
-		await dropEnumCheck(OBSERVATION_LOCKS_TABLE, OBSERVATION_LOCK_TASK_KIND_COLUMN);
-
+	async up({ schemaBuilder: { createTable, column } }: MigrationContext) {
 		await createTable('agents_memory_entries')
 			.withColumns(
 				column('id').varchar(36).primary.notNull,
@@ -48,6 +41,28 @@ export class CreateAgentMemoryEntryTables1784000000009 implements ReversibleMigr
 			.withForeignKey('supersededBy', {
 				tableName: 'agents_memory_entries',
 				columnName: 'id',
+			}).withTimestamps;
+
+		await createTable('agents_memory_entry_locks')
+			.withColumns(
+				column('agentId').varchar(36).notNull.primary,
+				column('resourceId')
+					.varchar(255)
+					.notNull.primary.comment('agents_resources.id partition locked for episodic indexing'),
+				column('holderId')
+					.varchar(64)
+					.notNull.comment('Ephemeral background-task lock owner token'),
+				column('heldUntil').timestampTimezone(3).notNull,
+			)
+			.withForeignKey('agentId', {
+				tableName: 'agents',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withForeignKey('resourceId', {
+				tableName: 'agents_resources',
+				columnName: 'id',
+				onDelete: 'CASCADE',
 			}).withTimestamps;
 
 		await createTable('agents_memory_entry_sources')
@@ -101,37 +116,10 @@ export class CreateAgentMemoryEntryTables1784000000009 implements ReversibleMigr
 		).withTimestamps;
 	}
 
-	async down({
-		schemaBuilder: { dropTable },
-		queryRunner,
-		tablePrefix,
-		escape,
-		runQuery,
-	}: MigrationContext) {
+	async down({ schemaBuilder: { dropTable } }: MigrationContext) {
 		await dropTable('agents_memory_entry_cursors');
+		await dropTable('agents_memory_entry_locks');
 		await dropTable('agents_memory_entry_sources');
 		await dropTable('agents_memory_entries');
-		await this.restoreObservationLockTaskKindCheck(queryRunner, tablePrefix, escape, runQuery);
-	}
-
-	private async restoreObservationLockTaskKindCheck(
-		queryRunner: MigrationContext['queryRunner'],
-		tablePrefix: string,
-		escape: MigrationContext['escape'],
-		runQuery: MigrationContext['runQuery'],
-	) {
-		const fullTableName = `${tablePrefix}${OBSERVATION_LOCKS_TABLE}`;
-		const checkName = `CHK_${tablePrefix}${OBSERVATION_LOCKS_TABLE}_${OBSERVATION_LOCK_TASK_KIND_COLUMN}`;
-		const escapedColumnName = escape.columnName(OBSERVATION_LOCK_TASK_KIND_COLUMN);
-		await runQuery(
-			`DELETE FROM ${escape.tableName(OBSERVATION_LOCKS_TABLE)} WHERE ${escape.columnName(OBSERVATION_LOCK_TASK_KIND_COLUMN)} NOT IN (${LEGACY_OBSERVATION_LOCK_TASK_KIND_VALUES})`,
-		);
-		await queryRunner.createCheckConstraint(
-			fullTableName,
-			new TableCheck({
-				name: checkName,
-				expression: `${escapedColumnName} IN (${LEGACY_OBSERVATION_LOCK_TASK_KIND_VALUES})`,
-			}),
-		);
 	}
 }

--- a/packages/@n8n/db/src/migrations/common/1784000000009-CreateAgentMemoryEntryTables.ts
+++ b/packages/@n8n/db/src/migrations/common/1784000000009-CreateAgentMemoryEntryTables.ts
@@ -103,11 +103,17 @@ export class CreateAgentMemoryEntryTables1784000000009 implements ReversibleMigr
 		).withTimestamps;
 	}
 
-	async down({ schemaBuilder: { dropTable }, queryRunner, tablePrefix }: MigrationContext) {
+	async down({
+		schemaBuilder: { dropTable },
+		queryRunner,
+		tablePrefix,
+		escape,
+		runQuery,
+	}: MigrationContext) {
 		await dropTable('agents_memory_entry_cursors');
 		await dropTable('agents_memory_entry_sources');
 		await dropTable('agents_memory_entries');
-		await this.restoreObservationLockTaskKindCheck(queryRunner, tablePrefix);
+		await this.restoreObservationLockTaskKindCheck(queryRunner, tablePrefix, escape, runQuery);
 	}
 
 	private async dropObservationLockTaskKindCheck(
@@ -131,6 +137,8 @@ export class CreateAgentMemoryEntryTables1784000000009 implements ReversibleMigr
 	private async restoreObservationLockTaskKindCheck(
 		queryRunner: MigrationContext['queryRunner'],
 		tablePrefix: string,
+		escape: MigrationContext['escape'],
+		runQuery: MigrationContext['runQuery'],
 	) {
 		const fullTableName = `${tablePrefix}${OBSERVATION_LOCKS_TABLE}`;
 		const table = await queryRunner.getTable(fullTableName);
@@ -145,6 +153,9 @@ export class CreateAgentMemoryEntryTables1784000000009 implements ReversibleMigr
 		const escapedValues = LEGACY_OBSERVATION_LOCK_TASK_KINDS.map(
 			(value) => `'${value.replace(/'/g, "''")}'`,
 		).join(', ');
+		await runQuery(
+			`DELETE FROM ${escape.tableName(OBSERVATION_LOCKS_TABLE)} WHERE ${escape.columnName(OBSERVATION_LOCK_TASK_KIND_COLUMN)} NOT IN (${escapedValues})`,
+		);
 		await queryRunner.createCheckConstraint(
 			fullTableName,
 			new TableCheck({

--- a/packages/@n8n/db/src/migrations/common/1784000000009-CreateAgentMemoryEntryTables.ts
+++ b/packages/@n8n/db/src/migrations/common/1784000000009-CreateAgentMemoryEntryTables.ts
@@ -1,0 +1,156 @@
+import { TableCheck } from '@n8n/typeorm';
+
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+const MEMORY_ENTRY_STATUSES = ['active', 'superseded', 'dropped'];
+const OBSERVATION_SCOPE_KINDS = ['thread', 'resource'];
+const OBSERVATION_LOCKS_TABLE = 'agents_observation_locks';
+const OBSERVATION_LOCK_TASK_KIND_COLUMN = 'taskKind';
+const LEGACY_OBSERVATION_LOCK_TASK_KINDS = ['observer', 'reflector'];
+
+export class CreateAgentMemoryEntryTables1784000000009 implements ReversibleMigration {
+	async up({
+		schemaBuilder: { createTable, dropTable, column },
+		queryRunner,
+		tablePrefix,
+	}: MigrationContext) {
+		await this.dropObservationLockTaskKindCheck(queryRunner, tablePrefix);
+		await dropTable('agents_memory_entry_cursors');
+		await dropTable('agents_memory_entry_sources');
+		await dropTable('agents_memory_entries');
+
+		await createTable('agents_memory_entries')
+			.withColumns(
+				column('id').varchar(36).primary.notNull,
+				column('agentId').varchar(36).notNull,
+				column('resourceId')
+					.varchar(255)
+					.notNull.comment('agents_resources.id partition used for episodic recall scope'),
+				column('content').text.notNull,
+				column('contentHash').varchar(64).notNull,
+				column('status').varchar(16).notNull.withEnumCheck(MEMORY_ENTRY_STATUSES),
+				column('supersededBy').varchar(36).comment('Self-reference to replacement memory entry'),
+				column('embeddingModel').varchar(128).comment('Embedding model used to produce embedding'),
+				column('embedding').json.comment('Embedding vector for episodic recall'),
+				column('metadata').json.comment('Optional system metadata for ranking and debugging'),
+				column('lastSeenAt')
+					.timestampTimezone(3)
+					.notNull.comment(
+						'Last time equivalent content was observed; updatedAt tracks row mutation time',
+					),
+			)
+			.withIndexOn(['agentId', 'resourceId', 'status', 'createdAt', 'id'])
+			.withIndexOn(['agentId', 'resourceId', 'contentHash'], true)
+			.withIndexOn('supersededBy')
+			.withForeignKey('agentId', {
+				tableName: 'agents',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withForeignKey('resourceId', {
+				tableName: 'agents_resources',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withForeignKey('supersededBy', {
+				tableName: 'agents_memory_entries',
+				columnName: 'id',
+			}).withTimestamps;
+
+		await createTable('agents_memory_entry_sources')
+			.withColumns(
+				column('id').varchar(36).primary.notNull,
+				column('memoryEntryId').varchar(36).notNull,
+				column('observationId').varchar(36).notNull,
+				column('threadId')
+					.varchar(255)
+					.notNull.comment('Source conversation thread that produced the linked observation'),
+				column('evidenceHash')
+					.varchar(64)
+					.notNull.comment('Bounded hash used to deduplicate exact evidence links'),
+				column('evidenceText').text.notNull.comment(
+					'Exact source evidence text from the observation, not recall scope',
+				),
+			)
+			.withIndexOn(['memoryEntryId', 'observationId', 'evidenceHash'], true)
+			.withIndexOn('observationId')
+			.withIndexOn('threadId')
+			.withForeignKey('memoryEntryId', {
+				tableName: 'agents_memory_entries',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withForeignKey('observationId', {
+				tableName: 'agents_observations',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			}).withTimestamps;
+
+		await createTable('agents_memory_entry_cursors').withColumns(
+			column('scopeKind')
+				.varchar(20)
+				.notNull.primary.withEnumCheck(OBSERVATION_SCOPE_KINDS)
+				.comment('Observation-log scope kind being indexed into episodic memory'),
+			column('scopeId')
+				.varchar(255)
+				.notNull.primary.comment('Observation-log scope ID being indexed into episodic memory'),
+			column('lastIndexedObservationId')
+				.varchar(36)
+				.notNull.comment('Last observation-log row indexed into episodic memory'),
+			column('lastIndexedObservationCreatedAt')
+				.timestampTimezone(3)
+				.notNull.comment('Creation timestamp for the last indexed observation-log row'),
+		).withTimestamps;
+	}
+
+	async down({ schemaBuilder: { dropTable }, queryRunner, tablePrefix }: MigrationContext) {
+		await dropTable('agents_memory_entry_cursors');
+		await dropTable('agents_memory_entry_sources');
+		await dropTable('agents_memory_entries');
+		await this.restoreObservationLockTaskKindCheck(queryRunner, tablePrefix);
+	}
+
+	private async dropObservationLockTaskKindCheck(
+		queryRunner: MigrationContext['queryRunner'],
+		tablePrefix: string,
+	) {
+		const fullTableName = `${tablePrefix}${OBSERVATION_LOCKS_TABLE}`;
+		const table = await queryRunner.getTable(fullTableName);
+		const check = table?.checks.find(
+			(item) =>
+				item.name ===
+					`CHK_${tablePrefix}${OBSERVATION_LOCKS_TABLE}_${OBSERVATION_LOCK_TASK_KIND_COLUMN}` ||
+				item.expression?.includes(OBSERVATION_LOCK_TASK_KIND_COLUMN),
+		);
+
+		if (check) {
+			await queryRunner.dropCheckConstraint(fullTableName, check);
+		}
+	}
+
+	private async restoreObservationLockTaskKindCheck(
+		queryRunner: MigrationContext['queryRunner'],
+		tablePrefix: string,
+	) {
+		const fullTableName = `${tablePrefix}${OBSERVATION_LOCKS_TABLE}`;
+		const table = await queryRunner.getTable(fullTableName);
+		if (!table) return;
+
+		const checkName = `CHK_${tablePrefix}${OBSERVATION_LOCKS_TABLE}_${OBSERVATION_LOCK_TASK_KIND_COLUMN}`;
+		if (table.checks.some((check) => check.name === checkName)) return;
+
+		const escapedColumnName = queryRunner.connection.driver.escape(
+			OBSERVATION_LOCK_TASK_KIND_COLUMN,
+		);
+		const escapedValues = LEGACY_OBSERVATION_LOCK_TASK_KINDS.map(
+			(value) => `'${value.replace(/'/g, "''")}'`,
+		).join(', ');
+		await queryRunner.createCheckConstraint(
+			fullTableName,
+			new TableCheck({
+				name: checkName,
+				expression: `${escapedColumnName} IN (${escapedValues})`,
+			}),
+		);
+	}
+}

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -184,6 +184,7 @@ import { CreateMcpRegistryServerTable1784000000005 } from '../common/17840000000
 import { AddNodeGroupsColumnToWorkflowAndHistory1784000000006 } from '../common/1784000000006-AddNodeGroupsColumnToWorkflowAndHistory';
 import { CreateInstanceAiCheckpointTable1784000000007 } from '../common/1784000000007-CreateInstanceAiCheckpointTable';
 import { ResetInstanceAiNativePersistence1784000000008 } from '../common/1784000000008-ResetInstanceAiNativePersistence';
+import { CreateAgentMemoryEntryTables1784000000009 } from '../common/1784000000009-CreateAgentMemoryEntryTables';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -373,4 +374,5 @@ export const postgresMigrations: Migration[] = [
 	AddNodeGroupsColumnToWorkflowAndHistory1784000000006,
 	CreateInstanceAiCheckpointTable1784000000007,
 	ResetInstanceAiNativePersistence1784000000008,
+	CreateAgentMemoryEntryTables1784000000009,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -177,6 +177,7 @@ import { CreateMcpRegistryServerTable1784000000005 } from '../common/17840000000
 import { AddNodeGroupsColumnToWorkflowAndHistory1784000000006 } from '../common/1784000000006-AddNodeGroupsColumnToWorkflowAndHistory';
 import { CreateInstanceAiCheckpointTable1784000000007 } from '../common/1784000000007-CreateInstanceAiCheckpointTable';
 import { ResetInstanceAiNativePersistence1784000000008 } from '../common/1784000000008-ResetInstanceAiNativePersistence';
+import { CreateAgentMemoryEntryTables1784000000009 } from '../common/1784000000009-CreateAgentMemoryEntryTables';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -359,6 +360,7 @@ const sqliteMigrations: Migration[] = [
 	AddNodeGroupsColumnToWorkflowAndHistory1784000000006,
 	CreateInstanceAiCheckpointTable1784000000007,
 	ResetInstanceAiNativePersistence1784000000008,
+	CreateAgentMemoryEntryTables1784000000009,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/modules/agents/__tests__/agent-execution.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-execution.service.test.ts
@@ -4,7 +4,7 @@ import { mock } from 'jest-mock-extended';
 import { AgentExecutionService } from '../agent-execution.service';
 import type { AgentExecution } from '../entities/agent-execution.entity';
 import type { AgentExecutionThread } from '../entities/agent-execution-thread.entity';
-import type { N8nMemory } from '../integrations/n8n-memory';
+import type { N8nMemory, N8nMemoryImplementation } from '../integrations/n8n-memory';
 import type { AgentExecutionRepository } from '../repositories/agent-execution.repository';
 import type { AgentExecutionThreadRepository } from '../repositories/agent-execution-thread.repository';
 
@@ -32,6 +32,7 @@ describe('AgentExecutionService', () => {
 	let agentExecutionRepository: jest.Mocked<AgentExecutionRepository>;
 	let agentExecutionThreadRepository: jest.Mocked<AgentExecutionThreadRepository>;
 	let n8nMemory: jest.Mocked<N8nMemory>;
+	let memoryBackend: jest.Mocked<N8nMemoryImplementation>;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -39,6 +40,8 @@ describe('AgentExecutionService', () => {
 		agentExecutionRepository = mock<AgentExecutionRepository>();
 		agentExecutionThreadRepository = mock<AgentExecutionThreadRepository>();
 		n8nMemory = mock<N8nMemory>();
+		memoryBackend = mock<N8nMemoryImplementation>();
+		n8nMemory.getImplementation.mockReturnValue(memoryBackend);
 
 		service = new AgentExecutionService(
 			mockLogger(),
@@ -76,13 +79,15 @@ describe('AgentExecutionService', () => {
 		it('cleans SDK memory before deleting the execution thread', async () => {
 			agentExecutionThreadRepository.findOneBy.mockResolvedValue({
 				id: 'thread-1',
+				agentId: 'agent-1',
 				projectId: 'project-1',
 			} as AgentExecutionThread);
 
 			const result = await service.deleteThread('project-1', 'thread-1');
 
 			expect(result).toBe(true);
-			expect(n8nMemory.deleteThread).toHaveBeenCalledWith('thread-1');
+			expect(n8nMemory.getImplementation).toHaveBeenCalledWith('agent-1');
+			expect(memoryBackend.deleteThread).toHaveBeenCalledWith('thread-1');
 			expect(agentExecutionThreadRepository.delete).toHaveBeenCalledWith({ id: 'thread-1' });
 		});
 
@@ -92,7 +97,8 @@ describe('AgentExecutionService', () => {
 			const result = await service.deleteThread('project-1', 'thread-1');
 
 			expect(result).toBe(false);
-			expect(n8nMemory.deleteThread).not.toHaveBeenCalled();
+			expect(n8nMemory.getImplementation).not.toHaveBeenCalled();
+			expect(memoryBackend.deleteThread).not.toHaveBeenCalled();
 			expect(agentExecutionThreadRepository.delete).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/cli/src/modules/agents/__tests__/agent-execution.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-execution.service.test.ts
@@ -4,9 +4,11 @@ import { mock } from 'jest-mock-extended';
 import { AgentExecutionService } from '../agent-execution.service';
 import type { AgentExecution } from '../entities/agent-execution.entity';
 import type { AgentExecutionThread } from '../entities/agent-execution-thread.entity';
-import type { N8nMemory, N8nMemoryImplementation } from '../integrations/n8n-memory';
+import type { N8nMemory } from '../integrations/n8n-memory';
 import type { AgentExecutionRepository } from '../repositories/agent-execution.repository';
 import type { AgentExecutionThreadRepository } from '../repositories/agent-execution-thread.repository';
+
+type N8nMemoryImplementation = ReturnType<N8nMemory['getImplementation']>;
 
 function makeThread(overrides: Partial<AgentExecutionThread> = {}): AgentExecutionThread {
 	return {

--- a/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
@@ -27,7 +27,7 @@ import {
 	type AgentChatIntegrationContext,
 } from '../integrations/agent-chat-integration';
 import type { N8NCheckpointStorage } from '../integrations/n8n-checkpoint-storage';
-import type { N8nMemory } from '../integrations/n8n-memory';
+import type { N8nMemory, N8nMemoryImplementation } from '../integrations/n8n-memory';
 import type { AgentExecutionService } from '../agent-execution.service';
 import type { AgentPublishedVersionRepository } from '../repositories/agent-published-version.repository';
 import type { AgentRepository } from '../repositories/agent.repository';
@@ -76,6 +76,7 @@ describe('AgentsService', () => {
 	let agentRepository: jest.Mocked<AgentRepository>;
 	let agentPublishedVersionRepository: jest.Mocked<AgentPublishedVersionRepository>;
 	let n8nMemory: jest.Mocked<N8nMemory>;
+	let memoryBackend: jest.Mocked<N8nMemoryImplementation>;
 	let n8nCheckpointStorage: jest.Mocked<N8NCheckpointStorage>;
 	let agentExecutionService: jest.Mocked<AgentExecutionService>;
 	let scheduleService: jest.Mocked<AgentScheduleService>;
@@ -90,6 +91,8 @@ describe('AgentsService', () => {
 		agentRepository = mock<AgentRepository>();
 		agentPublishedVersionRepository = mock<AgentPublishedVersionRepository>();
 		n8nMemory = mock<N8nMemory>();
+		memoryBackend = mock<N8nMemoryImplementation>();
+		n8nMemory.getImplementation.mockReturnValue(memoryBackend);
 		n8nCheckpointStorage = mock<N8NCheckpointStorage>();
 		agentExecutionService = mock<AgentExecutionService>();
 		agentExecutionService.recordMessage.mockResolvedValue('exec-id');
@@ -986,7 +989,7 @@ describe('AgentsService', () => {
 				projectId,
 				agentId,
 			);
-			expect(n8nMemory.getMessages).not.toHaveBeenCalled();
+			expect(memoryBackend.getMessages).not.toHaveBeenCalled();
 			expect(result).toEqual([
 				{
 					id: 'execution-1:user',
@@ -1022,18 +1025,18 @@ describe('AgentsService', () => {
 		});
 
 		it('scopes the memory lookup to the caller via resourceId', async () => {
-			n8nMemory.getMessages.mockResolvedValue([]);
+			memoryBackend.getMessages.mockResolvedValue([]);
 
 			await service.getTestChatMessages(agentId, userId);
 
-			expect(n8nMemory.getMessages).toHaveBeenCalledWith(chatThreadId(agentId, userId), {
+			expect(memoryBackend.getMessages).toHaveBeenCalledWith(chatThreadId(agentId, userId), {
 				resourceId: userId,
 			});
 		});
 
 		it('returns whatever memory returns for this user', async () => {
 			const persisted = [{ id: 'm1' }, { id: 'm2' }];
-			n8nMemory.getMessages.mockResolvedValue(persisted as never);
+			memoryBackend.getMessages.mockResolvedValue(persisted as never);
 
 			const result = await service.getTestChatMessages(agentId, userId);
 
@@ -1045,11 +1048,11 @@ describe('AgentsService', () => {
 		it('deletes only the caller’s messages on their test-chat thread', async () => {
 			await service.clearTestChatMessages(agentId, userId);
 
-			expect(n8nMemory.deleteMessagesByThread).toHaveBeenCalledWith(
+			expect(memoryBackend.deleteMessagesByThread).toHaveBeenCalledWith(
 				chatThreadId(agentId, userId),
 				userId,
 			);
-			expect(n8nMemory.deleteThread).not.toHaveBeenCalled();
+			expect(memoryBackend.deleteThread).not.toHaveBeenCalled();
 		});
 	});
 
@@ -1057,11 +1060,11 @@ describe('AgentsService', () => {
 		it('deletes every message and the thread row itself', async () => {
 			await service.clearAllTestChatMessages(agentId);
 
-			expect(n8nMemory.deleteThreadsByPrefix).toHaveBeenCalledWith(chatThreadId(agentId));
-			expect(n8nMemory.deleteMessagesByThread).toHaveBeenCalledWith(chatThreadId(agentId));
+			expect(memoryBackend.deleteThreadsByPrefix).toHaveBeenCalledWith(chatThreadId(agentId));
+			expect(memoryBackend.deleteMessagesByThread).toHaveBeenCalledWith(chatThreadId(agentId));
 			// Second arg must be absent — undefined means "all users".
-			expect(n8nMemory.deleteMessagesByThread.mock.calls[0]).toHaveLength(1);
-			expect(n8nMemory.deleteThread).toHaveBeenCalledWith(chatThreadId(agentId));
+			expect(memoryBackend.deleteMessagesByThread.mock.calls[0]).toHaveLength(1);
+			expect(memoryBackend.deleteThread).toHaveBeenCalledWith(chatThreadId(agentId));
 		});
 	});
 
@@ -1295,9 +1298,9 @@ describe('AgentsService', () => {
 			await service.delete(agentId, projectId);
 
 			expect(agentRepository.remove).toHaveBeenCalledWith(agent);
-			expect(n8nMemory.deleteThreadsByPrefix).toHaveBeenCalledWith(chatThreadId(agentId));
-			expect(n8nMemory.deleteMessagesByThread).toHaveBeenCalledWith(chatThreadId(agentId));
-			expect(n8nMemory.deleteThread).toHaveBeenCalledWith(chatThreadId(agentId));
+			expect(memoryBackend.deleteThreadsByPrefix).toHaveBeenCalledWith(chatThreadId(agentId));
+			expect(memoryBackend.deleteMessagesByThread).toHaveBeenCalledWith(chatThreadId(agentId));
+			expect(memoryBackend.deleteThread).toHaveBeenCalledWith(chatThreadId(agentId));
 		});
 
 		it('stops the local schedule when deleting the agent', async () => {
@@ -1312,7 +1315,7 @@ describe('AgentsService', () => {
 		it('still returns true when chat cleanup fails — agent removal is the primary intent', async () => {
 			const agent = makeAgent();
 			agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
-			n8nMemory.deleteThreadsByPrefix.mockRejectedValueOnce(new Error('db down'));
+			memoryBackend.deleteThreadsByPrefix.mockRejectedValueOnce(new Error('db down'));
 
 			await expect(service.delete(agentId, projectId)).resolves.toBe(true);
 		});

--- a/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
@@ -27,7 +27,7 @@ import {
 	type AgentChatIntegrationContext,
 } from '../integrations/agent-chat-integration';
 import type { N8NCheckpointStorage } from '../integrations/n8n-checkpoint-storage';
-import type { N8nMemory, N8nMemoryImplementation } from '../integrations/n8n-memory';
+import type { N8nMemory } from '../integrations/n8n-memory';
 import type { AgentExecutionService } from '../agent-execution.service';
 import type { AgentPublishedVersionRepository } from '../repositories/agent-published-version.repository';
 import type { AgentRepository } from '../repositories/agent.repository';
@@ -36,6 +36,7 @@ const agentId = 'agent-1';
 const projectId = 'project-1';
 const userId = 'user-1';
 const versionId = 'v1';
+type N8nMemoryImplementation = ReturnType<N8nMemory['getImplementation']>;
 
 function makeAgent(overrides: Partial<Agent> = {}): Agent {
 	return {

--- a/packages/cli/src/modules/agents/agent-execution.service.ts
+++ b/packages/cli/src/modules/agents/agent-execution.service.ts
@@ -57,7 +57,7 @@ export class AgentExecutionService {
 			await this.agentExecutionThreadRepository.bumpUpdatedAt(threadId);
 			// Sync title from the SDK memory thread if we don't have one yet
 			if (!thread.title) {
-				await this.syncTitleFromMemory(threadId);
+				await this.syncTitleFromMemory(threadId, agentId);
 			}
 		}
 
@@ -122,7 +122,7 @@ export class AgentExecutionService {
 		// ends, so by this point the memory thread should have the title.
 		// Sync it to our execution thread on the first message.
 		if (created) {
-			await this.syncTitleFromMemory(threadId);
+			await this.syncTitleFromMemory(threadId, agentId);
 		}
 
 		return inserted.id;
@@ -147,9 +147,9 @@ export class AgentExecutionService {
 	 * The SDK's titleGeneration runs fire-and-forget after the first message,
 	 * so the title is typically available by the second message.
 	 */
-	private async syncTitleFromMemory(threadId: string): Promise<void> {
+	private async syncTitleFromMemory(threadId: string, agentId: string): Promise<void> {
 		try {
-			const memoryThread = await this.n8nMemory.getThread(threadId);
+			const memoryThread = await this.n8nMemory.getImplementation(agentId).getThread(threadId);
 			if (memoryThread?.title) {
 				const emoji =
 					memoryThread.metadata && typeof memoryThread.metadata.emoji === 'string'
@@ -177,7 +177,7 @@ export class AgentExecutionService {
 		});
 		if (!thread) return false;
 
-		await this.n8nMemory.deleteThread(threadId);
+		await this.n8nMemory.getImplementation(thread.agentId).deleteThread(threadId);
 		await this.agentExecutionThreadRepository.delete({ id: threadId });
 		return true;
 	}

--- a/packages/cli/src/modules/agents/agents.module.ts
+++ b/packages/cli/src/modules/agents/agents.module.ts
@@ -101,6 +101,9 @@ export class AgentsModule implements ModuleInterface {
 		);
 		const { AgentObservationLockEntity } = await import('./entities/agent-observation-lock.entity');
 		const { AgentMemoryEntryEntity } = await import('./entities/agent-memory-entry.entity');
+		const { AgentMemoryEntryLockEntity } = await import(
+			'./entities/agent-memory-entry-lock.entity'
+		);
 		const { AgentMemoryEntrySourceEntity } = await import(
 			'./entities/agent-memory-entry-source.entity'
 		);
@@ -121,6 +124,7 @@ export class AgentsModule implements ModuleInterface {
 			AgentObservationCursorEntity,
 			AgentObservationLockEntity,
 			AgentMemoryEntryEntity,
+			AgentMemoryEntryLockEntity,
 			AgentMemoryEntrySourceEntity,
 			AgentMemoryEntryCursorEntity,
 		];

--- a/packages/cli/src/modules/agents/agents.module.ts
+++ b/packages/cli/src/modules/agents/agents.module.ts
@@ -100,6 +100,13 @@ export class AgentsModule implements ModuleInterface {
 			'./entities/agent-observation-cursor.entity'
 		);
 		const { AgentObservationLockEntity } = await import('./entities/agent-observation-lock.entity');
+		const { AgentMemoryEntryEntity } = await import('./entities/agent-memory-entry.entity');
+		const { AgentMemoryEntrySourceEntity } = await import(
+			'./entities/agent-memory-entry-source.entity'
+		);
+		const { AgentMemoryEntryCursorEntity } = await import(
+			'./entities/agent-memory-entry-cursor.entity'
+		);
 
 		return [
 			Agent,
@@ -113,6 +120,9 @@ export class AgentsModule implements ModuleInterface {
 			AgentObservationEntity,
 			AgentObservationCursorEntity,
 			AgentObservationLockEntity,
+			AgentMemoryEntryEntity,
+			AgentMemoryEntrySourceEntity,
+			AgentMemoryEntryCursorEntity,
 		];
 	}
 

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -605,8 +605,8 @@ export class AgentsService {
 		return executionsToMessagesDto(detail.executions);
 	}
 
-	private getMemoryFactory(): MemoryFactory {
-		return (_params: AgentJsonMemoryConfig) => this.n8nMemory;
+	private getMemoryFactory(agentId: string): MemoryFactory {
+		return (_params: AgentJsonMemoryConfig) => this.n8nMemory.getImplementation(agentId);
 	}
 
 	/** Create a credential provider scoped to a project. */
@@ -947,24 +947,29 @@ export class AgentsService {
 	 * user. Test-chat threads are keyed by agent and user so memory stays isolated.
 	 */
 	async getTestChatMessages(agentId: string, userId: string) {
-		return await this.n8nMemory.getMessages(chatThreadId(agentId, userId), {
-			resourceId: userId,
-		});
+		return await this.n8nMemory
+			.getImplementation(agentId)
+			.getMessages(chatThreadId(agentId, userId), {
+				resourceId: userId,
+			});
 	}
 
 	/**
 	 * Clear the current user's test-chat messages for an agent.
 	 */
 	async clearTestChatMessages(agentId: string, userId: string) {
-		await this.n8nMemory.deleteMessagesByThread(chatThreadId(agentId, userId), userId);
+		await this.n8nMemory
+			.getImplementation(agentId)
+			.deleteMessagesByThread(chatThreadId(agentId, userId), userId);
 	}
 
 	/** Delete all test-chat messages + the thread row — used when the agent itself is deleted. */
 	async clearAllTestChatMessages(agentId: string) {
 		const threadId = chatThreadId(agentId);
-		await this.n8nMemory.deleteThreadsByPrefix(threadId);
-		await this.n8nMemory.deleteMessagesByThread(threadId);
-		await this.n8nMemory.deleteThread(threadId);
+		const memory = this.n8nMemory.getImplementation(agentId);
+		await memory.deleteThreadsByPrefix(threadId);
+		await memory.deleteMessagesByThread(threadId);
+		await memory.deleteThread(threadId);
 	}
 
 	/**
@@ -1760,7 +1765,7 @@ export class AgentsService {
 				return resolved;
 			},
 			skills: agentEntity.skills ?? {},
-			memoryFactory: this.getMemoryFactory(),
+			memoryFactory: this.getMemoryFactory(agentEntity.id),
 		});
 
 		await this.injectRuntimeDependencies({

--- a/packages/cli/src/modules/agents/builder/agents-builder.service.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder.service.ts
@@ -54,7 +54,7 @@ export class AgentsBuilderService {
 	 */
 	async getBuilderMessages(agentId: string) {
 		const threadId = builderThreadId(agentId);
-		return await this.n8nMemory.getMessages(threadId);
+		return await this.n8nMemory.getImplementation(agentId).getMessages(threadId);
 	}
 
 	/**
@@ -62,8 +62,9 @@ export class AgentsBuilderService {
 	 */
 	async clearBuilderMessages(agentId: string) {
 		const threadId = builderThreadId(agentId);
-		await this.n8nMemory.deleteMessagesByThread(threadId);
-		await this.n8nMemory.deleteThread(threadId);
+		const memory = this.n8nMemory.getImplementation(agentId);
+		await memory.deleteMessagesByThread(threadId);
+		await memory.deleteThread(threadId);
 	}
 	// ---------------------------------------------------------------------------
 	// Public — streaming
@@ -192,7 +193,9 @@ export class AgentsBuilderService {
 
 		const { Agent, Memory } = await import('@n8n/agents');
 
-		const builderMemory = new Memory().storage(this.n8nMemory).lastMessages(40);
+		const builderMemory = new Memory()
+			.storage(this.n8nMemory.getImplementation(agentId))
+			.lastMessages(40);
 
 		// Be careful with provider specific options, since user can change model to openai, grok, etc.
 		const builder = new Agent('agent-builder')

--- a/packages/cli/src/modules/agents/entities/agent-memory-entry-cursor.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-memory-entry-cursor.entity.ts
@@ -3,22 +3,17 @@ import { Column, Entity, PrimaryColumn } from '@n8n/typeorm';
 
 import type { ObservationScopeKind } from './agent-observation.entity';
 
-export type ObservationTaskKind = 'observer' | 'reflector' | 'episodic-indexer';
-
-@Entity({ name: 'agents_observation_locks' })
-export class AgentObservationLockEntity extends WithTimestamps {
+@Entity({ name: 'agents_memory_entry_cursors' })
+export class AgentMemoryEntryCursorEntity extends WithTimestamps {
 	@PrimaryColumn({ type: 'varchar', length: 20 })
 	scopeKind: ObservationScopeKind;
 
 	@PrimaryColumn({ type: 'varchar', length: 255 })
 	scopeId: string;
 
-	@PrimaryColumn({ type: 'varchar', length: 20 })
-	taskKind: ObservationTaskKind;
-
-	@Column({ type: 'varchar', length: 64 })
-	holderId: string;
+	@Column({ type: 'varchar', length: 36 })
+	lastIndexedObservationId: string;
 
 	@DateTimeColumn()
-	heldUntil: Date;
+	lastIndexedObservationCreatedAt: Date;
 }

--- a/packages/cli/src/modules/agents/entities/agent-memory-entry-lock.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-memory-entry-lock.entity.ts
@@ -1,0 +1,17 @@
+import { DateTimeColumn, WithTimestamps } from '@n8n/db';
+import { Column, Entity, PrimaryColumn } from '@n8n/typeorm';
+
+@Entity({ name: 'agents_memory_entry_locks' })
+export class AgentMemoryEntryLockEntity extends WithTimestamps {
+	@PrimaryColumn({ type: 'varchar', length: 36 })
+	agentId: string;
+
+	@PrimaryColumn({ type: 'varchar', length: 255 })
+	resourceId: string;
+
+	@Column({ type: 'varchar', length: 64 })
+	holderId: string;
+
+	@DateTimeColumn()
+	heldUntil: Date;
+}

--- a/packages/cli/src/modules/agents/entities/agent-memory-entry-source.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-memory-entry-source.entity.ts
@@ -1,0 +1,23 @@
+import { WithTimestampsAndStringId } from '@n8n/db';
+import { Column, Entity, Index } from '@n8n/typeorm';
+
+@Entity({ name: 'agents_memory_entry_sources' })
+@Index(['memoryEntryId', 'observationId', 'evidenceHash'], { unique: true })
+@Index(['observationId'])
+@Index(['threadId'])
+export class AgentMemoryEntrySourceEntity extends WithTimestampsAndStringId {
+	@Column({ type: 'varchar', length: 36 })
+	memoryEntryId: string;
+
+	@Column({ type: 'varchar', length: 36 })
+	observationId: string;
+
+	@Column({ type: 'varchar', length: 255 })
+	threadId: string;
+
+	@Column({ type: 'varchar', length: 64 })
+	evidenceHash: string;
+
+	@Column({ type: 'text' })
+	evidenceText: string;
+}

--- a/packages/cli/src/modules/agents/entities/agent-memory-entry-source.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-memory-entry-source.entity.ts
@@ -4,8 +4,11 @@ import { Column, Entity, Index } from '@n8n/typeorm';
 @Entity({ name: 'agents_memory_entry_sources' })
 @Index(['memoryEntryId', 'observationId', 'evidenceHash'], { unique: true })
 @Index(['observationId'])
-@Index(['threadId'])
+@Index(['agentId', 'threadId'])
 export class AgentMemoryEntrySourceEntity extends WithTimestampsAndStringId {
+	@Column({ type: 'varchar', length: 36 })
+	agentId: string;
+
 	@Column({ type: 'varchar', length: 36 })
 	memoryEntryId: string;
 

--- a/packages/cli/src/modules/agents/entities/agent-memory-entry.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-memory-entry.entity.ts
@@ -1,0 +1,41 @@
+import { DateTimeColumn, JsonColumn, WithTimestampsAndStringId } from '@n8n/db';
+import { Column, Entity, Index } from '@n8n/typeorm';
+import type { JSONObject } from '@n8n/agents';
+
+export type MemoryEntryStatus = 'active' | 'superseded' | 'dropped';
+
+@Entity({ name: 'agents_memory_entries' })
+@Index(['agentId', 'resourceId', 'status', 'createdAt', 'id'])
+@Index(['agentId', 'resourceId', 'contentHash'], { unique: true })
+@Index(['supersededBy'])
+export class AgentMemoryEntryEntity extends WithTimestampsAndStringId {
+	@Column({ type: 'varchar', length: 36 })
+	agentId: string;
+
+	@Column({ type: 'varchar', length: 255 })
+	resourceId: string;
+
+	@Column({ type: 'text' })
+	content: string;
+
+	@Column({ type: 'varchar', length: 64 })
+	contentHash: string;
+
+	@Column({ type: 'varchar', length: 16 })
+	status: MemoryEntryStatus;
+
+	@Column({ type: 'varchar', length: 36, nullable: true })
+	supersededBy: string | null;
+
+	@Column({ type: 'varchar', length: 128, nullable: true })
+	embeddingModel: string | null;
+
+	@JsonColumn({ nullable: true })
+	embedding: number[] | null;
+
+	@JsonColumn({ nullable: true })
+	metadata: JSONObject | null;
+
+	@DateTimeColumn()
+	lastSeenAt: Date;
+}

--- a/packages/cli/src/modules/agents/entities/agent-observation-lock.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-observation-lock.entity.ts
@@ -3,7 +3,7 @@ import { Column, Entity, PrimaryColumn } from '@n8n/typeorm';
 
 import type { ObservationScopeKind } from './agent-observation.entity';
 
-export type ObservationTaskKind = 'observer' | 'reflector' | 'episodic-indexer';
+export type ObservationTaskKind = 'observer' | 'reflector';
 
 @Entity({ name: 'agents_observation_locks' })
 export class AgentObservationLockEntity extends WithTimestamps {

--- a/packages/cli/src/modules/agents/integrations/__tests__/n8n-memory.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/n8n-memory.test.ts
@@ -1,13 +1,19 @@
-import type { NewObservationLogEntry } from '@n8n/agents';
+import { hashEpisodicMemoryEvidence, type NewObservationLogEntry } from '@n8n/agents';
 import { Equal, In, IsNull, LessThan, Like, MoreThan } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
 
+import { AgentMemoryEntryCursorEntity } from '../../entities/agent-memory-entry-cursor.entity';
+import { AgentMemoryEntryEntity } from '../../entities/agent-memory-entry.entity';
+import { AgentMemoryEntrySourceEntity } from '../../entities/agent-memory-entry-source.entity';
 import type { AgentMessageEntity } from '../../entities/agent-message.entity';
 import { AgentObservationCursorEntity } from '../../entities/agent-observation-cursor.entity';
 import { AgentObservationLockEntity } from '../../entities/agent-observation-lock.entity';
 import { AgentObservationEntity } from '../../entities/agent-observation.entity';
 import { AgentThreadEntity } from '../../entities/agent-thread.entity';
 import type { AgentMessageRepository } from '../../repositories/agent-message.repository';
+import type { AgentMemoryEntryCursorRepository } from '../../repositories/agent-memory-entry-cursor.repository';
+import type { AgentMemoryEntrySourceRepository } from '../../repositories/agent-memory-entry-source.repository';
+import type { AgentMemoryEntryRepository } from '../../repositories/agent-memory-entry.repository';
 import type { AgentObservationCursorRepository } from '../../repositories/agent-observation-cursor.repository';
 import type { AgentObservationLockRepository } from '../../repositories/agent-observation-lock.repository';
 import type { AgentObservationRepository } from '../../repositories/agent-observation.repository';
@@ -25,6 +31,9 @@ describe('N8nMemory', () => {
 	let observationRepository: jest.Mocked<AgentObservationRepository>;
 	let observationCursorRepository: jest.Mocked<AgentObservationCursorRepository>;
 	let observationLockRepository: jest.Mocked<AgentObservationLockRepository>;
+	let memoryEntryRepository: jest.Mocked<AgentMemoryEntryRepository>;
+	let memoryEntrySourceRepository: jest.Mocked<AgentMemoryEntrySourceRepository>;
+	let memoryEntryCursorRepository: jest.Mocked<AgentMemoryEntryCursorRepository>;
 	let runInTransaction: jest.Mock;
 	let transactionDelete: jest.Mock;
 	let observationRunInTransaction: jest.Mock;
@@ -32,6 +41,16 @@ describe('N8nMemory', () => {
 	let transactionObservationFind: jest.Mock;
 	let transactionObservationSave: jest.Mock;
 	let transactionObservationUpdate: jest.Mock;
+	let memoryEntryRunInTransaction: jest.Mock;
+	let transactionMemoryEntryCreate: jest.Mock;
+	let transactionMemoryEntryFind: jest.Mock;
+	let transactionMemoryEntryFindOneBy: jest.Mock;
+	let transactionMemoryEntrySave: jest.Mock;
+	let transactionMemoryEntryUpdate: jest.Mock;
+	let transactionMemoryEntrySourceCreate: jest.Mock;
+	let transactionMemoryEntrySourceFind: jest.Mock;
+	let transactionMemoryEntrySourceFindOneBy: jest.Mock;
+	let transactionMemoryEntrySourceSave: jest.Mock;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -42,16 +61,11 @@ describe('N8nMemory', () => {
 		observationRepository = mock<AgentObservationRepository>();
 		observationCursorRepository = mock<AgentObservationCursorRepository>();
 		observationLockRepository = mock<AgentObservationLockRepository>();
+		memoryEntryRepository = mock<AgentMemoryEntryRepository>();
+		memoryEntrySourceRepository = mock<AgentMemoryEntrySourceRepository>();
+		memoryEntryCursorRepository = mock<AgentMemoryEntryCursorRepository>();
+		resourceRepository.existsBy.mockResolvedValue(true);
 		transactionDelete = jest.fn().mockResolvedValue({ affected: 1, raw: {} });
-		runInTransaction = jest.fn(
-			async (callback: (trx: { delete: typeof transactionDelete }) => Promise<void>) => {
-				await callback({ delete: transactionDelete });
-			},
-		);
-		Object.defineProperty(threadRepository, 'manager', {
-			value: { transaction: runInTransaction },
-		});
-
 		transactionObservationCreate = jest.fn((input) => ({ ...input }) as AgentObservationEntity);
 		transactionObservationFind = jest.fn().mockResolvedValue([]);
 		transactionObservationSave = jest.fn(async (input: AgentObservationEntity[]) =>
@@ -78,6 +92,78 @@ describe('N8nMemory', () => {
 			value: { transaction: observationRunInTransaction },
 		});
 
+		transactionMemoryEntryCreate = jest.fn((input) => ({ ...input }) as AgentMemoryEntryEntity);
+		transactionMemoryEntryFind = jest.fn().mockResolvedValue([]);
+		transactionMemoryEntryFindOneBy = jest.fn().mockResolvedValue(null);
+		transactionMemoryEntrySave = jest.fn(async (input: AgentMemoryEntryEntity[]) =>
+			input.map((entity, index) => ({
+				...entity,
+				id: `merged-memory-${index + 1}`,
+				createdAt: entity.createdAt ?? new Date('2026-05-12T10:00:00Z'),
+				updatedAt: entity.updatedAt ?? new Date('2026-05-12T10:00:00Z'),
+			})),
+		);
+		transactionMemoryEntryUpdate = jest.fn().mockResolvedValue({ affected: 1, raw: {} });
+		transactionMemoryEntrySourceCreate = jest.fn(
+			(input) => ({ ...input }) as AgentMemoryEntrySourceEntity,
+		);
+		transactionMemoryEntrySourceFind = jest.fn().mockResolvedValue([]);
+		transactionMemoryEntrySourceFindOneBy = jest.fn().mockResolvedValue(null);
+		transactionMemoryEntrySourceSave = jest.fn(async (input: AgentMemoryEntrySourceEntity[]) =>
+			input.map((entity, index) => ({
+				...entity,
+				id: `merged-source-${index + 1}`,
+				createdAt: entity.createdAt ?? new Date('2026-05-12T10:00:00Z'),
+				updatedAt: entity.updatedAt ?? new Date('2026-05-12T10:00:00Z'),
+			})),
+		);
+		runInTransaction = jest.fn(
+			async (
+				callback: (trx: {
+					delete: typeof transactionDelete;
+					getRepository: jest.Mock;
+				}) => Promise<void>,
+			) => {
+				await callback({
+					delete: transactionDelete,
+					getRepository: jest.fn((entity) => {
+						if (entity === AgentMemoryEntryEntity) {
+							return { update: transactionMemoryEntryUpdate };
+						}
+						return { find: transactionMemoryEntrySourceFind };
+					}),
+				});
+			},
+		);
+		Object.defineProperty(threadRepository, 'manager', {
+			value: { transaction: runInTransaction },
+		});
+		memoryEntryRunInTransaction = jest.fn(
+			async (callback: (trx: { getRepository: jest.Mock }) => Promise<unknown>) =>
+				await callback({
+					getRepository: jest.fn((entity) => {
+						if (entity === AgentMemoryEntryEntity) {
+							return {
+								create: transactionMemoryEntryCreate,
+								find: transactionMemoryEntryFind,
+								findOneBy: transactionMemoryEntryFindOneBy,
+								save: transactionMemoryEntrySave,
+								update: transactionMemoryEntryUpdate,
+							};
+						}
+						return {
+							create: transactionMemoryEntrySourceCreate,
+							find: transactionMemoryEntrySourceFind,
+							findOneBy: transactionMemoryEntrySourceFindOneBy,
+							save: transactionMemoryEntrySourceSave,
+						};
+					}),
+				}),
+		);
+		Object.defineProperty(memoryEntryRepository, 'manager', {
+			value: { transaction: memoryEntryRunInTransaction },
+		});
+
 		memory = new N8nMemory(
 			threadRepository,
 			messageRepository,
@@ -85,6 +171,9 @@ describe('N8nMemory', () => {
 			observationRepository,
 			observationCursorRepository,
 			observationLockRepository,
+			memoryEntryRepository,
+			memoryEntrySourceRepository,
+			memoryEntryCursorRepository,
 		);
 	});
 
@@ -390,22 +479,70 @@ describe('N8nMemory', () => {
 				legacyScope,
 			);
 			expect(transactionDelete).toHaveBeenNthCalledWith(3, AgentObservationLockEntity, legacyScope);
-			expect(transactionDelete).toHaveBeenNthCalledWith(4, AgentObservationEntity, resourceScope);
 			expect(transactionDelete).toHaveBeenNthCalledWith(
-				5,
+				4,
+				AgentMemoryEntryCursorEntity,
+				legacyScope,
+			);
+			expect(transactionDelete).toHaveBeenNthCalledWith(5, AgentObservationEntity, resourceScope);
+			expect(transactionDelete).toHaveBeenNthCalledWith(
+				6,
 				AgentObservationCursorEntity,
 				resourceScope,
 			);
 			expect(transactionDelete).toHaveBeenNthCalledWith(
-				6,
+				7,
 				AgentObservationLockEntity,
 				resourceScope,
 			);
-			expect(transactionDelete).toHaveBeenNthCalledWith(7, AgentThreadEntity, { id: 'thread-1' });
+			expect(transactionDelete).toHaveBeenNthCalledWith(
+				8,
+				AgentMemoryEntryCursorEntity,
+				resourceScope,
+			);
+			expect(transactionDelete).toHaveBeenNthCalledWith(9, AgentThreadEntity, { id: 'thread-1' });
 			expect(observationRepository.delete).not.toHaveBeenCalled();
 			expect(observationCursorRepository.delete).not.toHaveBeenCalled();
 			expect(observationLockRepository.delete).not.toHaveBeenCalled();
 			expect(threadRepository.delete).not.toHaveBeenCalled();
+		});
+
+		it('drops active episodic entries that lose their last source when deleting a thread', async () => {
+			transactionMemoryEntrySourceFind
+				.mockResolvedValueOnce([
+					makeMemoryEntrySourceEntity({
+						memoryEntryId: 'orphaned-memory',
+						threadId: 'thread-1',
+					}),
+					makeMemoryEntrySourceEntity({
+						memoryEntryId: 'shared-memory',
+						threadId: 'thread-1',
+					}),
+				])
+				.mockResolvedValueOnce([
+					makeMemoryEntrySourceEntity({
+						memoryEntryId: 'shared-memory',
+						threadId: 'thread-2',
+					}),
+				]);
+
+			await memory.deleteThread('thread-1');
+
+			expect(transactionMemoryEntrySourceFind).toHaveBeenNthCalledWith(1, {
+				select: { memoryEntryId: true },
+				where: { threadId: 'thread-1' },
+			});
+			expect(transactionDelete).toHaveBeenCalledWith(AgentMemoryEntrySourceEntity, {
+				threadId: 'thread-1',
+			});
+			expect(transactionMemoryEntrySourceFind).toHaveBeenNthCalledWith(2, {
+				select: { memoryEntryId: true },
+				where: { memoryEntryId: In(['orphaned-memory', 'shared-memory']) },
+			});
+			expect(transactionMemoryEntryUpdate).toHaveBeenCalledWith(
+				{ id: In(['orphaned-memory']), status: 'active' },
+				{ status: 'dropped', supersededBy: null },
+			);
 		});
 
 		it('deletes thread-scoped observation state by thread id prefix in one transaction', async () => {
@@ -424,24 +561,58 @@ describe('N8nMemory', () => {
 				legacyScope,
 			);
 			expect(transactionDelete).toHaveBeenNthCalledWith(3, AgentObservationLockEntity, legacyScope);
-			expect(transactionDelete).toHaveBeenNthCalledWith(4, AgentObservationEntity, resourceScope);
 			expect(transactionDelete).toHaveBeenNthCalledWith(
-				5,
+				4,
+				AgentMemoryEntryCursorEntity,
+				legacyScope,
+			);
+			expect(transactionDelete).toHaveBeenNthCalledWith(5, AgentObservationEntity, resourceScope);
+			expect(transactionDelete).toHaveBeenNthCalledWith(
+				6,
 				AgentObservationCursorEntity,
 				resourceScope,
 			);
 			expect(transactionDelete).toHaveBeenNthCalledWith(
-				6,
+				7,
 				AgentObservationLockEntity,
 				resourceScope,
 			);
-			expect(transactionDelete).toHaveBeenNthCalledWith(7, AgentThreadEntity, {
+			expect(transactionDelete).toHaveBeenNthCalledWith(
+				8,
+				AgentMemoryEntryCursorEntity,
+				resourceScope,
+			);
+			expect(transactionDelete).toHaveBeenNthCalledWith(9, AgentThreadEntity, {
 				id: Like('test-agent-1%'),
 			});
 			expect(observationRepository.delete).not.toHaveBeenCalled();
 			expect(observationCursorRepository.delete).not.toHaveBeenCalled();
 			expect(observationLockRepository.delete).not.toHaveBeenCalled();
 			expect(threadRepository.delete).not.toHaveBeenCalled();
+		});
+
+		it('drops source-less episodic entries when deleting threads by prefix', async () => {
+			transactionMemoryEntrySourceFind
+				.mockResolvedValueOnce([
+					makeMemoryEntrySourceEntity({
+						memoryEntryId: 'prefix-orphaned-memory',
+						threadId: 'test-agent-1:run-1',
+					}),
+				])
+				.mockResolvedValueOnce([]);
+
+			await memory.deleteThreadsByPrefix('test-agent-1');
+
+			const threadId = Like('test-agent-1%');
+			expect(transactionMemoryEntrySourceFind).toHaveBeenNthCalledWith(1, {
+				select: { memoryEntryId: true },
+				where: { threadId },
+			});
+			expect(transactionDelete).toHaveBeenCalledWith(AgentMemoryEntrySourceEntity, { threadId });
+			expect(transactionMemoryEntryUpdate).toHaveBeenCalledWith(
+				{ id: In(['prefix-orphaned-memory']), status: 'active' },
+				{ status: 'dropped', supersededBy: null },
+			);
 		});
 	});
 
@@ -477,6 +648,46 @@ describe('N8nMemory', () => {
 			updatedAt: new Date('2026-05-05T00:00:00Z'),
 			...overrides,
 		} as AgentObservationEntity;
+	}
+
+	function makeMemoryEntryEntity(
+		overrides: Partial<AgentMemoryEntryEntity> = {},
+	): AgentMemoryEntryEntity {
+		const createdAt = new Date('2026-05-05T00:00:00Z');
+		return {
+			id: 'memory-1',
+			agentId: 'agent-1',
+			resourceId: 'resource-1',
+			content: 'User chose Postgres for the memory store.',
+			contentHash: 'hash-1',
+			status: 'active',
+			supersededBy: null,
+			embeddingModel: 'openai/text-embedding-3-small',
+			embedding: [1, 0],
+			metadata: null,
+			lastSeenAt: createdAt,
+			createdAt,
+			updatedAt: createdAt,
+			...overrides,
+		} as AgentMemoryEntryEntity;
+	}
+
+	function makeMemoryEntrySourceEntity(
+		overrides: Partial<AgentMemoryEntrySourceEntity> = {},
+	): AgentMemoryEntrySourceEntity {
+		const createdAt = new Date('2026-05-05T00:00:00Z');
+		const evidenceText = overrides.evidenceText ?? 'User chose Postgres';
+		return {
+			id: 'source-1',
+			memoryEntryId: 'memory-1',
+			observationId: 'obs-1',
+			threadId: 'thread-1',
+			evidenceHash: hashEpisodicMemoryEvidence(evidenceText),
+			evidenceText,
+			createdAt,
+			updatedAt: createdAt,
+			...overrides,
+		} as AgentMemoryEntrySourceEntity;
 	}
 
 	describe('appendObservationLogEntries', () => {
@@ -910,6 +1121,416 @@ describe('N8nMemory', () => {
 				taskKind: 'reflector',
 				holderId: 'A',
 			});
+		});
+	});
+
+	describe('episodic memory', () => {
+		beforeEach(() => {
+			memoryEntryRepository.create.mockImplementation(
+				(input) => ({ ...input }) as AgentMemoryEntryEntity,
+			);
+			memoryEntrySourceRepository.create.mockImplementation(
+				(input) => ({ ...input }) as AgentMemoryEntrySourceEntity,
+			);
+		});
+
+		it('stores active source-backed entries with a content hash', async () => {
+			memoryEntryRepository.save.mockImplementation(async (input) =>
+				makeMemoryEntryEntity({
+					...(input as AgentMemoryEntryEntity),
+					id: 'memory-1',
+					createdAt: new Date('2026-05-05T00:00:00Z'),
+					updatedAt: new Date('2026-05-05T00:00:00Z'),
+				}),
+			);
+
+			const [result] = await memory.saveEpisodicMemoryEntries([
+				{
+					agentId: 'agent-1',
+					resourceId: 'resource-1',
+					content: 'User chose Postgres for the memory store.',
+					embedding: [1, 0],
+					embeddingModel: 'openai/text-embedding-3-small',
+				},
+			]);
+
+			expect(memoryEntryRepository.create).toHaveBeenCalledWith(
+				expect.objectContaining({
+					agentId: 'agent-1',
+					resourceId: 'resource-1',
+					status: 'active',
+					supersededBy: null,
+					contentHash: expect.any(String),
+				}),
+			);
+			expect(result).toMatchObject({
+				id: 'memory-1',
+				content: 'User chose Postgres for the memory store.',
+				status: 'active',
+				embedding: [1, 0],
+			});
+		});
+
+		it('searches scoped active entries through hybrid ranking', async () => {
+			memoryEntryRepository.find.mockResolvedValue([
+				makeMemoryEntryEntity({
+					id: 'memory-1',
+					content: 'User chose Postgres for the memory store.',
+					embedding: [1, 0],
+				}),
+				makeMemoryEntryEntity({
+					id: 'memory-2',
+					content: 'User investigated a webhook timeout.',
+					embedding: [0, 1],
+				}),
+			]);
+
+			const results = await memory.searchEpisodicMemoryEntries(
+				{ agentId: 'agent-1', resourceId: 'resource-1' },
+				'Postgres memory store',
+				{ queryEmbedding: [1, 0], topK: 1 },
+			);
+
+			expect(memoryEntryRepository.find).toHaveBeenCalledWith({
+				where: {
+					agentId: 'agent-1',
+					resourceId: 'resource-1',
+					status: In(['active']),
+				},
+			});
+			expect(results.map((result) => result.id)).toEqual(['memory-1']);
+		});
+
+		it('links source observations without duplicating existing links', async () => {
+			const createdAt = new Date('2026-05-05T00:00:00Z');
+			memoryEntrySourceRepository.save.mockResolvedValue({
+				id: 'source-1',
+				memoryEntryId: 'memory-1',
+				observationId: 'obs-1',
+				threadId: 'thread-1',
+				evidenceHash: hashEpisodicMemoryEvidence('User chose Postgres'),
+				evidenceText: 'User chose Postgres',
+				createdAt,
+				updatedAt: createdAt,
+			} as AgentMemoryEntrySourceEntity);
+
+			const [source] = await memory.saveEpisodicMemoryEntrySources([
+				{
+					memoryEntryId: 'memory-1',
+					observationId: 'obs-1',
+					threadId: 'thread-1',
+					evidenceText: 'User chose Postgres',
+					createdAt,
+				},
+			]);
+
+			expect(source).toMatchObject({
+				id: 'source-1',
+				memoryEntryId: 'memory-1',
+				observationId: 'obs-1',
+			});
+		});
+
+		it('stores an episodic entry and its sources in one transaction', async () => {
+			transactionMemoryEntrySave.mockResolvedValueOnce([
+				makeMemoryEntryEntity({
+					id: 'memory-atomic',
+					content: 'User chose Postgres for durable memory storage.',
+				}),
+			]);
+			transactionMemoryEntrySourceSave.mockResolvedValueOnce([
+				makeMemoryEntrySourceEntity({
+					id: 'source-atomic',
+					memoryEntryId: 'memory-atomic',
+					observationId: 'obs-atomic',
+					evidenceText: 'User chose Postgres',
+				}),
+			]);
+
+			const result = await memory.saveEpisodicMemoryEntryWithSources(
+				{
+					agentId: 'agent-1',
+					resourceId: 'resource-1',
+					content: 'User chose Postgres for durable memory storage.',
+					embedding: [1, 0],
+					embeddingModel: 'openai/text-embedding-3-small',
+				},
+				[
+					{
+						observationId: 'obs-atomic',
+						threadId: 'thread-1',
+						evidenceText: 'User chose Postgres',
+					},
+				],
+			);
+
+			expect(memoryEntryRunInTransaction).toHaveBeenCalledWith(expect.any(Function));
+			expect(memoryEntryRepository.save).not.toHaveBeenCalled();
+			expect(memoryEntrySourceRepository.save).not.toHaveBeenCalled();
+			expect(transactionMemoryEntrySourceSave).toHaveBeenCalledWith([
+				expect.objectContaining({
+					memoryEntryId: 'memory-atomic',
+					observationId: 'obs-atomic',
+					evidenceHash: hashEpisodicMemoryEvidence('User chose Postgres'),
+					evidenceText: 'User chose Postgres',
+				}),
+			]);
+			expect(result).toEqual(expect.objectContaining({ id: 'memory-atomic' }));
+		});
+
+		it('rolls back the episodic entry transaction when source persistence fails', async () => {
+			transactionMemoryEntrySave.mockResolvedValueOnce([
+				makeMemoryEntryEntity({
+					id: 'memory-atomic',
+					content: 'User chose Postgres for durable memory storage.',
+				}),
+			]);
+			transactionMemoryEntrySourceSave.mockRejectedValueOnce(new Error('source write failed'));
+
+			await expect(
+				memory.saveEpisodicMemoryEntryWithSources(
+					{
+						agentId: 'agent-1',
+						resourceId: 'resource-1',
+						content: 'User chose Postgres for durable memory storage.',
+					},
+					[
+						{
+							observationId: 'obs-atomic',
+							threadId: 'thread-1',
+							evidenceText: 'User chose Postgres',
+						},
+					],
+				),
+			).rejects.toThrow('source write failed');
+
+			expect(memoryEntryRunInTransaction).toHaveBeenCalledWith(expect.any(Function));
+			expect(memoryEntryRepository.save).not.toHaveBeenCalled();
+			expect(memoryEntrySourceRepository.save).not.toHaveBeenCalled();
+		});
+
+		it('reads source links for episodic entries', async () => {
+			memoryEntrySourceRepository.find.mockResolvedValue([
+				makeMemoryEntrySourceEntity({ memoryEntryId: 'memory-1' }),
+			]);
+
+			const sources = await memory.getEpisodicMemoryEntrySources(['memory-1', 'memory-2']);
+
+			expect(memoryEntrySourceRepository.find).toHaveBeenCalledWith({
+				where: { memoryEntryId: In(['memory-1', 'memory-2']) },
+				order: { createdAt: 'ASC', id: 'ASC' },
+			});
+			expect(sources).toHaveLength(1);
+			expect(sources[0].memoryEntryId).toBe('memory-1');
+		});
+
+		it('applies episodic reflection transactionally and copies source links to replacements', async () => {
+			transactionMemoryEntryFind.mockResolvedValue([
+				makeMemoryEntryEntity({ id: 'memory-1', content: 'User planned SQLite.' }),
+				makeMemoryEntryEntity({ id: 'memory-2', content: 'User switched to Postgres.' }),
+				makeMemoryEntryEntity({ id: 'noise', content: 'Agent queried memory and found nothing.' }),
+			]);
+			transactionMemoryEntrySourceFind
+				.mockResolvedValueOnce([
+					makeMemoryEntrySourceEntity({
+						id: 'source-1',
+						memoryEntryId: 'memory-1',
+						observationId: 'obs-1',
+						evidenceText: 'User planned SQLite',
+					}),
+					makeMemoryEntrySourceEntity({
+						id: 'source-2',
+						memoryEntryId: 'memory-2',
+						observationId: 'obs-2',
+						evidenceText: 'User switched to Postgres',
+					}),
+				])
+				.mockResolvedValueOnce([]);
+
+			const result = await memory.applyEpisodicMemoryReflection(
+				{ agentId: 'agent-1', resourceId: 'resource-1' },
+				{
+					drop: ['noise'],
+					merge: [
+						{
+							supersedes: ['memory-1', 'memory-2'],
+							entry: {
+								agentId: 'agent-1',
+								resourceId: 'resource-1',
+								content: 'User switched memory store from SQLite to Postgres.',
+								embedding: [1, 0],
+								embeddingModel: 'openai/text-embedding-3-small',
+							},
+						},
+					],
+				},
+			);
+
+			expect(memoryEntryRunInTransaction).toHaveBeenCalledWith(expect.any(Function));
+			expect(transactionMemoryEntryUpdate).toHaveBeenCalledWith(
+				{ agentId: 'agent-1', resourceId: 'resource-1', id: In(['noise']), status: 'active' },
+				{ status: 'dropped', supersededBy: null },
+			);
+			expect(transactionMemoryEntrySave).toHaveBeenCalledWith([
+				expect.objectContaining({
+					content: 'User switched memory store from SQLite to Postgres.',
+					status: 'active',
+					supersededBy: null,
+				}),
+			]);
+			expect(transactionMemoryEntrySourceSave).toHaveBeenCalledWith([
+				expect.objectContaining({
+					memoryEntryId: 'merged-memory-1',
+					observationId: 'obs-1',
+					evidenceHash: hashEpisodicMemoryEvidence('User planned SQLite'),
+					evidenceText: 'User planned SQLite',
+				}),
+				expect.objectContaining({
+					memoryEntryId: 'merged-memory-1',
+					observationId: 'obs-2',
+					evidenceHash: hashEpisodicMemoryEvidence('User switched to Postgres'),
+					evidenceText: 'User switched to Postgres',
+				}),
+			]);
+			expect(transactionMemoryEntryUpdate).toHaveBeenCalledWith(
+				{
+					agentId: 'agent-1',
+					resourceId: 'resource-1',
+					id: In(['memory-1', 'memory-2']),
+					status: 'active',
+				},
+				{ status: 'superseded', supersededBy: 'merged-memory-1' },
+			);
+			expect(result).toEqual({
+				droppedIds: ['noise'],
+				supersededIds: ['memory-1', 'memory-2'],
+				inserted: [expect.objectContaining({ id: 'merged-memory-1' })],
+			});
+		});
+
+		it('reuses an existing replacement entry when reflection content already exists', async () => {
+			const replacementContent = 'User switched memory store from SQLite to Postgres.';
+			const replacementHash = 'replacement-hash';
+			transactionMemoryEntryFind
+				.mockResolvedValueOnce([
+					makeMemoryEntryEntity({ id: 'memory-1', content: 'User planned SQLite.' }),
+					makeMemoryEntryEntity({ id: 'memory-2', content: 'User switched to Postgres.' }),
+				])
+				.mockResolvedValueOnce([
+					makeMemoryEntryEntity({
+						id: 'existing-replacement',
+						content: replacementContent,
+						contentHash: replacementHash,
+						status: 'superseded',
+					}),
+				]);
+			transactionMemoryEntrySourceFind
+				.mockResolvedValueOnce([
+					makeMemoryEntrySourceEntity({
+						id: 'source-1',
+						memoryEntryId: 'memory-1',
+						observationId: 'obs-1',
+						evidenceText: 'User planned SQLite',
+					}),
+					makeMemoryEntrySourceEntity({
+						id: 'source-2',
+						memoryEntryId: 'memory-2',
+						observationId: 'obs-2',
+						evidenceText: 'User switched to Postgres',
+					}),
+				])
+				.mockResolvedValueOnce([]);
+
+			const result = await memory.applyEpisodicMemoryReflection(
+				{ agentId: 'agent-1', resourceId: 'resource-1' },
+				{
+					drop: [],
+					merge: [
+						{
+							supersedes: ['memory-1', 'memory-2'],
+							entry: {
+								agentId: 'agent-1',
+								resourceId: 'resource-1',
+								content: replacementContent,
+								contentHash: replacementHash,
+								embedding: [1, 0],
+								embeddingModel: 'openai/text-embedding-3-small',
+							},
+						},
+					],
+				},
+			);
+
+			expect(transactionMemoryEntrySave).not.toHaveBeenCalled();
+			expect(transactionMemoryEntryUpdate).toHaveBeenCalledWith(
+				{ agentId: 'agent-1', resourceId: 'resource-1', id: 'existing-replacement' },
+				expect.objectContaining({ status: 'active', supersededBy: null }),
+			);
+			expect(transactionMemoryEntrySourceSave).toHaveBeenCalledWith([
+				expect.objectContaining({
+					memoryEntryId: 'existing-replacement',
+					observationId: 'obs-1',
+				}),
+				expect.objectContaining({
+					memoryEntryId: 'existing-replacement',
+					observationId: 'obs-2',
+				}),
+			]);
+			expect(transactionMemoryEntryUpdate).toHaveBeenCalledWith(
+				{
+					agentId: 'agent-1',
+					resourceId: 'resource-1',
+					id: In(['memory-1', 'memory-2']),
+					status: 'active',
+				},
+				{ status: 'superseded', supersededBy: 'existing-replacement' },
+			);
+			expect(result).toEqual({
+				droppedIds: [],
+				supersededIds: ['memory-1', 'memory-2'],
+				inserted: [expect.objectContaining({ id: 'existing-replacement' })],
+			});
+		});
+
+		it('upserts the episodic cursor by observation scope', async () => {
+			const lastIndexedObservationCreatedAt = new Date('2026-05-05T00:00:00Z');
+
+			await memory.setEpisodicMemoryCursor({
+				scopeKind: 'thread',
+				scopeId: 'thread:thread-1:resource:resource-1',
+				lastIndexedObservationId: 'obs-1',
+				lastIndexedObservationCreatedAt,
+			});
+
+			expect(memoryEntryCursorRepository.upsert).toHaveBeenCalledWith(
+				expect.objectContaining({
+					scopeKind: 'thread',
+					scopeId: 'thread:thread-1:resource:resource-1',
+					lastIndexedObservationId: 'obs-1',
+					lastIndexedObservationCreatedAt,
+				}),
+				expect.objectContaining({ conflictPaths: ['scopeKind', 'scopeId'] }),
+			);
+		});
+
+		it('reads episodic cursors as dates', async () => {
+			const lastIndexedObservationCreatedAt = new Date('2026-05-05T00:00:00Z');
+			memoryEntryCursorRepository.findOneBy.mockResolvedValue({
+				scopeKind: 'thread',
+				scopeId: 'thread:thread-1:resource:resource-1',
+				lastIndexedObservationId: 'obs-1',
+				lastIndexedObservationCreatedAt,
+				createdAt: new Date('2026-05-05T00:00:00Z'),
+				updatedAt: new Date('2026-05-05T00:00:01Z'),
+			} as AgentMemoryEntryCursorEntity);
+
+			const cursor = await memory.getEpisodicMemoryCursor({
+				scopeKind: 'thread',
+				scopeId: 'thread:thread-1:resource:resource-1',
+			});
+
+			expect(cursor?.lastIndexedObservationId).toBe('obs-1');
+			expect(cursor?.lastIndexedObservationCreatedAt).toBe(lastIndexedObservationCreatedAt);
 		});
 	});
 });

--- a/packages/cli/src/modules/agents/integrations/__tests__/n8n-memory.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/n8n-memory.test.ts
@@ -19,12 +19,13 @@ import type { AgentObservationLockRepository } from '../../repositories/agent-ob
 import type { AgentObservationRepository } from '../../repositories/agent-observation.repository';
 import type { AgentResourceRepository } from '../../repositories/agent-resource.repository';
 import type { AgentThreadRepository } from '../../repositories/agent-thread.repository';
-import { N8nMemory } from '../n8n-memory';
+import { N8nMemory, type N8nMemoryImplementation } from '../n8n-memory';
 
 const estimateObservationTokens = (text: string) => Math.ceil(text.length / 4);
 
 describe('N8nMemory', () => {
-	let memory: N8nMemory;
+	let memory: N8nMemoryImplementation;
+	let memoryService: N8nMemory;
 	let messageRepository: jest.Mocked<AgentMessageRepository>;
 	let threadRepository: jest.Mocked<AgentThreadRepository>;
 	let resourceRepository: jest.Mocked<AgentResourceRepository>;
@@ -164,7 +165,7 @@ describe('N8nMemory', () => {
 			value: { transaction: memoryEntryRunInTransaction },
 		});
 
-		memory = new N8nMemory(
+		memoryService = new N8nMemory(
 			threadRepository,
 			messageRepository,
 			resourceRepository,
@@ -175,6 +176,7 @@ describe('N8nMemory', () => {
 			memoryEntrySourceRepository,
 			memoryEntryCursorRepository,
 		);
+		memory = memoryService.getImplementation('agent-1');
 	});
 
 	function makeMessageEntity(id: string, createdAt: Date, text: string): AgentMessageEntity {
@@ -1144,7 +1146,6 @@ describe('N8nMemory', () => {
 
 			const result = await memory.episodic.saveEntryWithSources(
 				{
-					namespace: 'agent-1',
 					resourceId: 'resource-1',
 					content: 'User chose Postgres for the memory store.',
 					embedding: [1, 0],
@@ -1199,7 +1200,7 @@ describe('N8nMemory', () => {
 			]);
 
 			const results = await memory.episodic.searchEntries(
-				{ namespace: 'agent-1', resourceId: 'resource-1' },
+				{ resourceId: 'resource-1' },
 				'Postgres memory store',
 				{ queryEmbedding: [1, 0], topK: 1 },
 			);
@@ -1232,7 +1233,6 @@ describe('N8nMemory', () => {
 
 			const result = await memory.episodic.saveEntryWithSources(
 				{
-					namespace: 'agent-1',
 					resourceId: 'resource-1',
 					content: 'User chose Postgres for durable memory storage.',
 					embedding: [1, 0],
@@ -1273,7 +1273,6 @@ describe('N8nMemory', () => {
 			await expect(
 				memory.episodic.saveEntryWithSources(
 					{
-						namespace: 'agent-1',
 						resourceId: 'resource-1',
 						content: 'User chose Postgres for durable memory storage.',
 					},
@@ -1331,14 +1330,13 @@ describe('N8nMemory', () => {
 				.mockResolvedValueOnce([]);
 
 			const result = await memory.episodic.applyReflection(
-				{ namespace: 'agent-1', resourceId: 'resource-1' },
+				{ resourceId: 'resource-1' },
 				{
 					drop: ['noise'],
 					merge: [
 						{
 							supersedes: ['memory-1', 'memory-2'],
 							entry: {
-								namespace: 'agent-1',
 								resourceId: 'resource-1',
 								content: 'User switched memory store from SQLite to Postgres.',
 								embedding: [1, 0],
@@ -1425,14 +1423,13 @@ describe('N8nMemory', () => {
 				.mockResolvedValueOnce([]);
 
 			const result = await memory.episodic.applyReflection(
-				{ namespace: 'agent-1', resourceId: 'resource-1' },
+				{ resourceId: 'resource-1' },
 				{
 					drop: [],
 					merge: [
 						{
 							supersedes: ['memory-1', 'memory-2'],
 							entry: {
-								namespace: 'agent-1',
 								resourceId: 'resource-1',
 								content: replacementContent,
 								contentHash: replacementHash,

--- a/packages/cli/src/modules/agents/integrations/__tests__/n8n-memory.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/n8n-memory.test.ts
@@ -1135,16 +1135,14 @@ describe('N8nMemory', () => {
 		});
 
 		it('stores active source-backed entries with a content hash', async () => {
-			memoryEntryRepository.save.mockImplementation(async (input) =>
+			transactionMemoryEntrySave.mockResolvedValueOnce([
 				makeMemoryEntryEntity({
-					...(input as AgentMemoryEntryEntity),
 					id: 'memory-1',
-					createdAt: new Date('2026-05-05T00:00:00Z'),
-					updatedAt: new Date('2026-05-05T00:00:00Z'),
+					content: 'User chose Postgres for the memory store.',
 				}),
-			);
+			]);
 
-			const [result] = await memory.saveEpisodicMemoryEntries([
+			const result = await memory.episodic.saveEntryWithSources(
 				{
 					namespace: 'agent-1',
 					resourceId: 'resource-1',
@@ -1152,9 +1150,16 @@ describe('N8nMemory', () => {
 					embedding: [1, 0],
 					embeddingModel: 'openai/text-embedding-3-small',
 				},
-			]);
+				[
+					{
+						observationId: 'obs-1',
+						threadId: 'thread-1',
+						evidenceText: 'User chose Postgres',
+					},
+				],
+			);
 
-			expect(memoryEntryRepository.create).toHaveBeenCalledWith(
+			expect(transactionMemoryEntryCreate).toHaveBeenCalledWith(
 				expect.objectContaining({
 					agentId: 'agent-1',
 					resourceId: 'resource-1',
@@ -1163,6 +1168,14 @@ describe('N8nMemory', () => {
 					contentHash: expect.any(String),
 				}),
 			);
+			expect(transactionMemoryEntrySourceSave).toHaveBeenCalledWith([
+				expect.objectContaining({
+					memoryEntryId: 'memory-1',
+					observationId: 'obs-1',
+					evidenceHash: hashEpisodicMemoryEvidence('User chose Postgres'),
+					evidenceText: 'User chose Postgres',
+				}),
+			]);
 			expect(result).toMatchObject({
 				id: 'memory-1',
 				content: 'User chose Postgres for the memory store.',
@@ -1185,7 +1198,7 @@ describe('N8nMemory', () => {
 				}),
 			]);
 
-			const results = await memory.searchEpisodicMemoryEntries(
+			const results = await memory.episodic.searchEntries(
 				{ namespace: 'agent-1', resourceId: 'resource-1' },
 				'Postgres memory store',
 				{ queryEmbedding: [1, 0], topK: 1 },
@@ -1199,36 +1212,6 @@ describe('N8nMemory', () => {
 				},
 			});
 			expect(results.map((result) => result.id)).toEqual(['memory-1']);
-		});
-
-		it('links source observations without duplicating existing links', async () => {
-			const createdAt = new Date('2026-05-05T00:00:00Z');
-			memoryEntrySourceRepository.save.mockResolvedValue({
-				id: 'source-1',
-				memoryEntryId: 'memory-1',
-				observationId: 'obs-1',
-				threadId: 'thread-1',
-				evidenceHash: hashEpisodicMemoryEvidence('User chose Postgres'),
-				evidenceText: 'User chose Postgres',
-				createdAt,
-				updatedAt: createdAt,
-			} as AgentMemoryEntrySourceEntity);
-
-			const [source] = await memory.saveEpisodicMemoryEntrySources([
-				{
-					memoryEntryId: 'memory-1',
-					observationId: 'obs-1',
-					threadId: 'thread-1',
-					evidenceText: 'User chose Postgres',
-					createdAt,
-				},
-			]);
-
-			expect(source).toMatchObject({
-				id: 'source-1',
-				memoryEntryId: 'memory-1',
-				observationId: 'obs-1',
-			});
 		});
 
 		it('stores an episodic entry and its sources in one transaction', async () => {
@@ -1247,7 +1230,7 @@ describe('N8nMemory', () => {
 				}),
 			]);
 
-			const result = await memory.saveEpisodicMemoryEntryWithSources(
+			const result = await memory.episodic.saveEntryWithSources(
 				{
 					namespace: 'agent-1',
 					resourceId: 'resource-1',
@@ -1288,7 +1271,7 @@ describe('N8nMemory', () => {
 			transactionMemoryEntrySourceSave.mockRejectedValueOnce(new Error('source write failed'));
 
 			await expect(
-				memory.saveEpisodicMemoryEntryWithSources(
+				memory.episodic.saveEntryWithSources(
 					{
 						namespace: 'agent-1',
 						resourceId: 'resource-1',
@@ -1314,7 +1297,7 @@ describe('N8nMemory', () => {
 				makeMemoryEntrySourceEntity({ memoryEntryId: 'memory-1' }),
 			]);
 
-			const sources = await memory.getEpisodicMemoryEntrySources(['memory-1', 'memory-2']);
+			const sources = await memory.episodic.getEntrySources(['memory-1', 'memory-2']);
 
 			expect(memoryEntrySourceRepository.find).toHaveBeenCalledWith({
 				where: { memoryEntryId: In(['memory-1', 'memory-2']) },
@@ -1347,7 +1330,7 @@ describe('N8nMemory', () => {
 				])
 				.mockResolvedValueOnce([]);
 
-			const result = await memory.applyEpisodicMemoryReflection(
+			const result = await memory.episodic.applyReflection(
 				{ namespace: 'agent-1', resourceId: 'resource-1' },
 				{
 					drop: ['noise'],
@@ -1441,7 +1424,7 @@ describe('N8nMemory', () => {
 				])
 				.mockResolvedValueOnce([]);
 
-			const result = await memory.applyEpisodicMemoryReflection(
+			const result = await memory.episodic.applyReflection(
 				{ namespace: 'agent-1', resourceId: 'resource-1' },
 				{
 					drop: [],
@@ -1495,7 +1478,7 @@ describe('N8nMemory', () => {
 		it('upserts the episodic cursor by observation scope', async () => {
 			const lastIndexedObservationCreatedAt = new Date('2026-05-05T00:00:00Z');
 
-			await memory.setEpisodicMemoryCursor({
+			await memory.episodic.setCursor({
 				scopeKind: 'thread',
 				scopeId: 'thread:thread-1:resource:resource-1',
 				lastIndexedObservationId: 'obs-1',
@@ -1524,7 +1507,7 @@ describe('N8nMemory', () => {
 				updatedAt: new Date('2026-05-05T00:00:01Z'),
 			} as AgentMemoryEntryCursorEntity);
 
-			const cursor = await memory.getEpisodicMemoryCursor({
+			const cursor = await memory.episodic.getCursor({
 				scopeKind: 'thread',
 				scopeId: 'thread:thread-1:resource:resource-1',
 			});

--- a/packages/cli/src/modules/agents/integrations/__tests__/n8n-memory.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/n8n-memory.test.ts
@@ -538,18 +538,38 @@ describe('N8nMemory', () => {
 
 			expect(transactionMemoryEntrySourceFind).toHaveBeenNthCalledWith(1, {
 				select: { memoryEntryId: true },
-				where: { threadId: 'thread-1' },
+				where: { agentId: 'agent-1', threadId: 'thread-1' },
 			});
 			expect(transactionDelete).toHaveBeenCalledWith(AgentMemoryEntrySourceEntity, {
 				threadId: 'thread-1',
+				agentId: 'agent-1',
 			});
 			expect(transactionMemoryEntrySourceFind).toHaveBeenNthCalledWith(2, {
 				select: { memoryEntryId: true },
-				where: { memoryEntryId: In(['orphaned-memory', 'shared-memory']) },
+				where: { agentId: 'agent-1', memoryEntryId: In(['orphaned-memory', 'shared-memory']) },
 			});
 			expect(transactionMemoryEntryUpdate).toHaveBeenCalledWith(
-				{ id: In(['orphaned-memory']), status: 'active' },
+				{ agentId: 'agent-1', id: In(['orphaned-memory']), status: 'active' },
 				{ status: 'dropped', supersededBy: null },
+			);
+		});
+
+		it('does not clean up episodic source rows owned by another agent', async () => {
+			transactionMemoryEntrySourceFind.mockResolvedValueOnce([]);
+
+			await memory.deleteThread('thread-1');
+
+			expect(transactionMemoryEntrySourceFind).toHaveBeenCalledWith({
+				select: { memoryEntryId: true },
+				where: { agentId: 'agent-1', threadId: 'thread-1' },
+			});
+			expect(transactionDelete).not.toHaveBeenCalledWith(
+				AgentMemoryEntrySourceEntity,
+				expect.objectContaining({ threadId: 'thread-1' }),
+			);
+			expect(transactionMemoryEntryUpdate).not.toHaveBeenCalledWith(
+				expect.objectContaining({ id: In(['other-agent-memory']) }),
+				expect.anything(),
 			);
 		});
 
@@ -614,11 +634,14 @@ describe('N8nMemory', () => {
 			const threadId = Like('test-agent-1%');
 			expect(transactionMemoryEntrySourceFind).toHaveBeenNthCalledWith(1, {
 				select: { memoryEntryId: true },
-				where: { threadId },
+				where: { agentId: 'agent-1', threadId },
 			});
-			expect(transactionDelete).toHaveBeenCalledWith(AgentMemoryEntrySourceEntity, { threadId });
+			expect(transactionDelete).toHaveBeenCalledWith(AgentMemoryEntrySourceEntity, {
+				threadId,
+				agentId: 'agent-1',
+			});
 			expect(transactionMemoryEntryUpdate).toHaveBeenCalledWith(
-				{ id: In(['prefix-orphaned-memory']), status: 'active' },
+				{ agentId: 'agent-1', id: In(['prefix-orphaned-memory']), status: 'active' },
 				{ status: 'dropped', supersededBy: null },
 			);
 		});
@@ -687,6 +710,7 @@ describe('N8nMemory', () => {
 		const evidenceText = overrides.evidenceText ?? 'User chose Postgres';
 		return {
 			id: 'source-1',
+			agentId: 'agent-1',
 			memoryEntryId: 'memory-1',
 			observationId: 'obs-1',
 			threadId: 'thread-1',
@@ -1271,6 +1295,7 @@ describe('N8nMemory', () => {
 			);
 			expect(transactionMemoryEntrySourceSave).toHaveBeenCalledWith([
 				expect.objectContaining({
+					agentId: 'agent-1',
 					memoryEntryId: 'memory-1',
 					observationId: 'obs-1',
 					evidenceHash: hashEpisodicMemoryEvidence('User chose Postgres'),
@@ -1352,6 +1377,7 @@ describe('N8nMemory', () => {
 			expect(memoryEntrySourceRepository.save).not.toHaveBeenCalled();
 			expect(transactionMemoryEntrySourceSave).toHaveBeenCalledWith([
 				expect.objectContaining({
+					agentId: 'agent-1',
 					memoryEntryId: 'memory-atomic',
 					observationId: 'obs-atomic',
 					evidenceHash: hashEpisodicMemoryEvidence('User chose Postgres'),
@@ -1399,7 +1425,7 @@ describe('N8nMemory', () => {
 			const sources = await memory.episodic.getEntrySources(['memory-1', 'memory-2']);
 
 			expect(memoryEntrySourceRepository.find).toHaveBeenCalledWith({
-				where: { memoryEntryId: In(['memory-1', 'memory-2']) },
+				where: { agentId: 'agent-1', memoryEntryId: In(['memory-1', 'memory-2']) },
 				order: { createdAt: 'ASC', id: 'ASC' },
 			});
 			expect(sources).toHaveLength(1);
@@ -1461,12 +1487,14 @@ describe('N8nMemory', () => {
 			]);
 			expect(transactionMemoryEntrySourceSave).toHaveBeenCalledWith([
 				expect.objectContaining({
+					agentId: 'agent-1',
 					memoryEntryId: 'merged-memory-1',
 					observationId: 'obs-1',
 					evidenceHash: hashEpisodicMemoryEvidence('User planned SQLite'),
 					evidenceText: 'User planned SQLite',
 				}),
 				expect.objectContaining({
+					agentId: 'agent-1',
 					memoryEntryId: 'merged-memory-1',
 					observationId: 'obs-2',
 					evidenceHash: hashEpisodicMemoryEvidence('User switched to Postgres'),
@@ -1548,10 +1576,12 @@ describe('N8nMemory', () => {
 			);
 			expect(transactionMemoryEntrySourceSave).toHaveBeenCalledWith([
 				expect.objectContaining({
+					agentId: 'agent-1',
 					memoryEntryId: 'existing-replacement',
 					observationId: 'obs-1',
 				}),
 				expect.objectContaining({
+					agentId: 'agent-1',
 					memoryEntryId: 'existing-replacement',
 					observationId: 'obs-2',
 				}),

--- a/packages/cli/src/modules/agents/integrations/__tests__/n8n-memory.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/n8n-memory.test.ts
@@ -19,9 +19,10 @@ import type { AgentObservationLockRepository } from '../../repositories/agent-ob
 import type { AgentObservationRepository } from '../../repositories/agent-observation.repository';
 import type { AgentResourceRepository } from '../../repositories/agent-resource.repository';
 import type { AgentThreadRepository } from '../../repositories/agent-thread.repository';
-import { N8nMemory, type N8nMemoryImplementation } from '../n8n-memory';
+import { N8nMemory } from '../n8n-memory';
 
 const estimateObservationTokens = (text: string) => Math.ceil(text.length / 4);
+type N8nMemoryImplementation = ReturnType<N8nMemory['getImplementation']>;
 
 describe('N8nMemory', () => {
 	let memory: N8nMemoryImplementation;

--- a/packages/cli/src/modules/agents/integrations/__tests__/n8n-memory.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/n8n-memory.test.ts
@@ -1146,7 +1146,7 @@ describe('N8nMemory', () => {
 
 			const [result] = await memory.saveEpisodicMemoryEntries([
 				{
-					agentId: 'agent-1',
+					namespace: 'agent-1',
 					resourceId: 'resource-1',
 					content: 'User chose Postgres for the memory store.',
 					embedding: [1, 0],
@@ -1186,7 +1186,7 @@ describe('N8nMemory', () => {
 			]);
 
 			const results = await memory.searchEpisodicMemoryEntries(
-				{ agentId: 'agent-1', resourceId: 'resource-1' },
+				{ namespace: 'agent-1', resourceId: 'resource-1' },
 				'Postgres memory store',
 				{ queryEmbedding: [1, 0], topK: 1 },
 			);
@@ -1249,7 +1249,7 @@ describe('N8nMemory', () => {
 
 			const result = await memory.saveEpisodicMemoryEntryWithSources(
 				{
-					agentId: 'agent-1',
+					namespace: 'agent-1',
 					resourceId: 'resource-1',
 					content: 'User chose Postgres for durable memory storage.',
 					embedding: [1, 0],
@@ -1290,7 +1290,7 @@ describe('N8nMemory', () => {
 			await expect(
 				memory.saveEpisodicMemoryEntryWithSources(
 					{
-						agentId: 'agent-1',
+						namespace: 'agent-1',
 						resourceId: 'resource-1',
 						content: 'User chose Postgres for durable memory storage.',
 					},
@@ -1348,14 +1348,14 @@ describe('N8nMemory', () => {
 				.mockResolvedValueOnce([]);
 
 			const result = await memory.applyEpisodicMemoryReflection(
-				{ agentId: 'agent-1', resourceId: 'resource-1' },
+				{ namespace: 'agent-1', resourceId: 'resource-1' },
 				{
 					drop: ['noise'],
 					merge: [
 						{
 							supersedes: ['memory-1', 'memory-2'],
 							entry: {
-								agentId: 'agent-1',
+								namespace: 'agent-1',
 								resourceId: 'resource-1',
 								content: 'User switched memory store from SQLite to Postgres.',
 								embedding: [1, 0],
@@ -1442,14 +1442,14 @@ describe('N8nMemory', () => {
 				.mockResolvedValueOnce([]);
 
 			const result = await memory.applyEpisodicMemoryReflection(
-				{ agentId: 'agent-1', resourceId: 'resource-1' },
+				{ namespace: 'agent-1', resourceId: 'resource-1' },
 				{
 					drop: [],
 					merge: [
 						{
 							supersedes: ['memory-1', 'memory-2'],
 							entry: {
-								agentId: 'agent-1',
+								namespace: 'agent-1',
 								resourceId: 'resource-1',
 								content: replacementContent,
 								contentHash: replacementHash,

--- a/packages/cli/src/modules/agents/integrations/__tests__/n8n-memory.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/n8n-memory.test.ts
@@ -1475,8 +1475,33 @@ describe('N8nMemory', () => {
 			});
 		});
 
-		it('upserts the episodic cursor by observation scope', async () => {
+		const mockEpisodicCursorWrite = () => {
+			const insertQueryBuilder = {
+				insert: jest.fn().mockReturnThis(),
+				into: jest.fn().mockReturnThis(),
+				values: jest.fn().mockReturnThis(),
+				orIgnore: jest.fn().mockReturnThis(),
+				execute: jest.fn().mockResolvedValue({ raw: {}, generatedMaps: [], identifiers: [] }),
+			};
+			const updateQueryBuilder = {
+				update: jest.fn().mockReturnThis(),
+				set: jest.fn().mockReturnThis(),
+				where: jest.fn().mockReturnThis(),
+				andWhere: jest.fn().mockReturnThis(),
+				setParameters: jest.fn().mockReturnThis(),
+				execute: jest.fn().mockResolvedValue({ affected: 1 }),
+			};
+
+			memoryEntryCursorRepository.createQueryBuilder
+				.mockReturnValueOnce(insertQueryBuilder as never)
+				.mockReturnValueOnce(updateQueryBuilder as never);
+
+			return { insertQueryBuilder, updateQueryBuilder };
+		};
+
+		it('only advances the episodic cursor by observation keyset', async () => {
 			const lastIndexedObservationCreatedAt = new Date('2026-05-05T00:00:00Z');
+			const { insertQueryBuilder, updateQueryBuilder } = mockEpisodicCursorWrite();
 
 			await memory.episodic.setCursor({
 				scopeKind: 'thread',
@@ -1485,15 +1510,32 @@ describe('N8nMemory', () => {
 				lastIndexedObservationCreatedAt,
 			});
 
-			expect(memoryEntryCursorRepository.upsert).toHaveBeenCalledWith(
+			expect(insertQueryBuilder.values).toHaveBeenCalledWith(
 				expect.objectContaining({
 					scopeKind: 'thread',
 					scopeId: 'thread:thread-1:resource:resource-1',
 					lastIndexedObservationId: 'obs-1',
 					lastIndexedObservationCreatedAt,
 				}),
-				expect.objectContaining({ conflictPaths: ['scopeKind', 'scopeId'] }),
 			);
+			expect(insertQueryBuilder.orIgnore).toHaveBeenCalled();
+			expect(updateQueryBuilder.where).toHaveBeenCalledWith('"scopeKind" = :scopeKind');
+			expect(updateQueryBuilder.andWhere).toHaveBeenCalledWith('"scopeId" = :scopeId');
+			expect(updateQueryBuilder.andWhere).toHaveBeenCalledWith(
+				expect.stringContaining(
+					'"lastIndexedObservationCreatedAt" < :lastIndexedObservationCreatedAt',
+				),
+			);
+			expect(updateQueryBuilder.andWhere).toHaveBeenCalledWith(
+				expect.stringContaining('"lastIndexedObservationId" < :lastIndexedObservationId'),
+			);
+			expect(updateQueryBuilder.setParameters).toHaveBeenCalledWith({
+				scopeKind: 'thread',
+				scopeId: 'thread:thread-1:resource:resource-1',
+				lastIndexedObservationId: 'obs-1',
+				lastIndexedObservationCreatedAt,
+			});
+			expect(memoryEntryCursorRepository.upsert).not.toHaveBeenCalled();
 		});
 
 		it('reads episodic cursors as dates', async () => {

--- a/packages/cli/src/modules/agents/integrations/__tests__/n8n-memory.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/n8n-memory.test.ts
@@ -4,6 +4,7 @@ import { mock } from 'jest-mock-extended';
 
 import { AgentMemoryEntryCursorEntity } from '../../entities/agent-memory-entry-cursor.entity';
 import { AgentMemoryEntryEntity } from '../../entities/agent-memory-entry.entity';
+import type { AgentMemoryEntryLockEntity } from '../../entities/agent-memory-entry-lock.entity';
 import { AgentMemoryEntrySourceEntity } from '../../entities/agent-memory-entry-source.entity';
 import type { AgentMessageEntity } from '../../entities/agent-message.entity';
 import { AgentObservationCursorEntity } from '../../entities/agent-observation-cursor.entity';
@@ -12,6 +13,7 @@ import { AgentObservationEntity } from '../../entities/agent-observation.entity'
 import { AgentThreadEntity } from '../../entities/agent-thread.entity';
 import type { AgentMessageRepository } from '../../repositories/agent-message.repository';
 import type { AgentMemoryEntryCursorRepository } from '../../repositories/agent-memory-entry-cursor.repository';
+import type { AgentMemoryEntryLockRepository } from '../../repositories/agent-memory-entry-lock.repository';
 import type { AgentMemoryEntrySourceRepository } from '../../repositories/agent-memory-entry-source.repository';
 import type { AgentMemoryEntryRepository } from '../../repositories/agent-memory-entry.repository';
 import type { AgentObservationCursorRepository } from '../../repositories/agent-observation-cursor.repository';
@@ -34,6 +36,7 @@ describe('N8nMemory', () => {
 	let observationCursorRepository: jest.Mocked<AgentObservationCursorRepository>;
 	let observationLockRepository: jest.Mocked<AgentObservationLockRepository>;
 	let memoryEntryRepository: jest.Mocked<AgentMemoryEntryRepository>;
+	let memoryEntryLockRepository: jest.Mocked<AgentMemoryEntryLockRepository>;
 	let memoryEntrySourceRepository: jest.Mocked<AgentMemoryEntrySourceRepository>;
 	let memoryEntryCursorRepository: jest.Mocked<AgentMemoryEntryCursorRepository>;
 	let runInTransaction: jest.Mock;
@@ -64,6 +67,7 @@ describe('N8nMemory', () => {
 		observationCursorRepository = mock<AgentObservationCursorRepository>();
 		observationLockRepository = mock<AgentObservationLockRepository>();
 		memoryEntryRepository = mock<AgentMemoryEntryRepository>();
+		memoryEntryLockRepository = mock<AgentMemoryEntryLockRepository>();
 		memoryEntrySourceRepository = mock<AgentMemoryEntrySourceRepository>();
 		memoryEntryCursorRepository = mock<AgentMemoryEntryCursorRepository>();
 		resourceRepository.existsBy.mockResolvedValue(true);
@@ -174,6 +178,7 @@ describe('N8nMemory', () => {
 			observationCursorRepository,
 			observationLockRepository,
 			memoryEntryRepository,
+			memoryEntryLockRepository,
 			memoryEntrySourceRepository,
 			memoryEntryCursorRepository,
 		);
@@ -1122,6 +1127,100 @@ describe('N8nMemory', () => {
 				scopeKind: 'resource',
 				scopeId: 't-1',
 				taskKind: 'reflector',
+				holderId: 'A',
+			});
+		});
+
+		const mockEpisodicLockWrite = ({
+			updateAffected,
+			claimed,
+		}: {
+			updateAffected: number;
+			claimed?: AgentMemoryEntryLockEntity | null;
+		}) => {
+			const updateQueryBuilder = {
+				update: jest.fn().mockReturnThis(),
+				set: jest.fn().mockReturnThis(),
+				where: jest.fn().mockReturnThis(),
+				andWhere: jest.fn().mockReturnThis(),
+				setParameters: jest.fn().mockReturnThis(),
+				execute: jest.fn().mockResolvedValue({ affected: updateAffected }),
+			};
+			const insertQueryBuilder = {
+				insert: jest.fn().mockReturnThis(),
+				into: jest.fn().mockReturnThis(),
+				values: jest.fn().mockReturnThis(),
+				orIgnore: jest.fn().mockReturnThis(),
+				execute: jest.fn().mockResolvedValue({ raw: {}, generatedMaps: [], identifiers: [] }),
+			};
+
+			memoryEntryLockRepository.createQueryBuilder
+				.mockReturnValueOnce(updateQueryBuilder as never)
+				.mockReturnValueOnce(insertQueryBuilder as never);
+			memoryEntryLockRepository.findOneBy.mockResolvedValue(claimed ?? null);
+
+			return { updateQueryBuilder, insertQueryBuilder };
+		};
+
+		it('acquires episodic task locks by bound agent and resource', async () => {
+			const { insertQueryBuilder } = mockEpisodicLockWrite({
+				updateAffected: 0,
+				claimed: {
+					agentId: 'agent-1',
+					resourceId: 'resource-1',
+					holderId: 'A',
+					heldUntil: new Date(Date.now() + 60_000),
+				} as AgentMemoryEntryLockEntity,
+			});
+
+			const handle = await memory.episodic.taskLock?.acquire('resource-1', {
+				ttlMs: 60_000,
+				holderId: 'A',
+			});
+
+			expect(handle).toMatchObject({ resourceId: 'resource-1', holderId: 'A' });
+			expect(insertQueryBuilder.values).toHaveBeenCalledWith(
+				expect.objectContaining({ agentId: 'agent-1', resourceId: 'resource-1', holderId: 'A' }),
+			);
+			expect(observationLockRepository.createQueryBuilder).not.toHaveBeenCalled();
+		});
+
+		it('uses the bound agent id for episodic task lock isolation', async () => {
+			const agentTwoMemory = memoryService.getImplementation('agent-2');
+			const { updateQueryBuilder } = mockEpisodicLockWrite({ updateAffected: 1 });
+
+			const handle = await agentTwoMemory.episodic.taskLock?.acquire('resource-1', {
+				ttlMs: 60_000,
+				holderId: 'B',
+			});
+
+			expect(handle).toMatchObject({ resourceId: 'resource-1', holderId: 'B' });
+			expect(updateQueryBuilder.setParameters).toHaveBeenCalledWith(
+				expect.objectContaining({ agentId: 'agent-2', resourceId: 'resource-1' }),
+			);
+		});
+
+		it('refuses episodic task locks held by another live holder', async () => {
+			mockEpisodicLockWrite({ updateAffected: 0 });
+
+			const handle = await memory.episodic.taskLock?.acquire('resource-1', {
+				ttlMs: 60_000,
+				holderId: 'B',
+			});
+
+			expect(handle).toBeNull();
+		});
+
+		it('releases episodic task locks by bound agent, resource, and holder', async () => {
+			await memory.episodic.taskLock?.release({
+				resourceId: 'resource-1',
+				holderId: 'A',
+				heldUntil: new Date(),
+			});
+
+			expect(memoryEntryLockRepository.delete).toHaveBeenCalledWith({
+				agentId: 'agent-1',
+				resourceId: 'resource-1',
 				holderId: 'A',
 			});
 		});

--- a/packages/cli/src/modules/agents/integrations/n8n-memory.ts
+++ b/packages/cli/src/modules/agents/integrations/n8n-memory.ts
@@ -72,7 +72,20 @@ const estimateObservationTokens = (text: string) => Math.ceil(text.length / 4);
 export type N8nMemoryImplementation = BuiltMemory &
 	BuiltObservationLogStore &
 	BuiltObservationLogTaskLockStore &
-	BuiltEpisodicMemoryStore;
+	BuiltEpisodicMemoryStore & {
+		deleteMessagesByThread(threadId: string, resourceId?: string): Promise<void>;
+		deleteThreadsByPrefix(threadIdPrefix: string): Promise<void>;
+		getMessagesForScope(
+			scopeKind: ObservationLogScopeKind,
+			scopeId: string,
+			opts?: { since?: { sinceCreatedAt: Date; sinceMessageId: string }; resourceId?: string },
+		): Promise<AgentDbMessage[]>;
+		getCursor(
+			scopeKind: ObservationLogScopeKind,
+			scopeId: string,
+		): Promise<ObservationCursor | null>;
+		setCursor(cursor: ObservationCursor & { scopeKind: ObservationLogScopeKind }): Promise<void>;
+	};
 
 @Service()
 export class N8nMemory {

--- a/packages/cli/src/modules/agents/integrations/n8n-memory.ts
+++ b/packages/cli/src/modules/agents/integrations/n8n-memory.ts
@@ -69,24 +69,6 @@ import { AgentThreadRepository } from '../repositories/agent-thread.repository';
 
 const estimateObservationTokens = (text: string) => Math.ceil(text.length / 4);
 
-export type N8nMemoryImplementation = BuiltMemory &
-	BuiltObservationLogStore &
-	BuiltObservationLogTaskLockStore &
-	BuiltEpisodicMemoryStore & {
-		deleteMessagesByThread(threadId: string, resourceId?: string): Promise<void>;
-		deleteThreadsByPrefix(threadIdPrefix: string): Promise<void>;
-		getMessagesForScope(
-			scopeKind: ObservationLogScopeKind,
-			scopeId: string,
-			opts?: { since?: { sinceCreatedAt: Date; sinceMessageId: string }; resourceId?: string },
-		): Promise<AgentDbMessage[]>;
-		getCursor(
-			scopeKind: ObservationLogScopeKind,
-			scopeId: string,
-		): Promise<ObservationCursor | null>;
-		setCursor(cursor: ObservationCursor & { scopeKind: ObservationLogScopeKind }): Promise<void>;
-	};
-
 @Service()
 export class N8nMemory {
 	constructor(
@@ -101,7 +83,7 @@ export class N8nMemory {
 		private readonly memoryEntryCursorRepository: AgentMemoryEntryCursorRepository,
 	) {}
 
-	getImplementation(agentId: string): N8nMemoryImplementation {
+	getImplementation(agentId: string) {
 		return new N8nMemoryImpl(
 			agentId,
 			this.threadRepository,

--- a/packages/cli/src/modules/agents/integrations/n8n-memory.ts
+++ b/packages/cli/src/modules/agents/integrations/n8n-memory.ts
@@ -18,6 +18,7 @@ import {
 	type EpisodicMemoryCursor,
 	type EpisodicMemoryEntry,
 	type EpisodicMemoryEntrySource,
+	type EpisodicMemoryMethods,
 	type EpisodicMemoryReflectionApply,
 	type EpisodicMemoryReflectionResult,
 	type EpisodicMemoryScope,
@@ -25,7 +26,6 @@ import {
 	type MemoryDescriptor,
 	type NewEpisodicMemoryCursor,
 	type NewEpisodicMemoryEntry,
-	type NewEpisodicMemoryEntrySource,
 	type NewEpisodicMemoryEntrySourceForEntry,
 	type NewObservationLogEntry,
 	type ObservationCursor,
@@ -81,6 +81,18 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 		private readonly memoryEntrySourceRepository: AgentMemoryEntrySourceRepository,
 		private readonly memoryEntryCursorRepository: AgentMemoryEntryCursorRepository,
 	) {}
+
+	readonly episodic: EpisodicMemoryMethods = {
+		saveEntryWithSources: async (entry, sources) =>
+			await this.saveEpisodicMemoryEntryWithSources(entry, sources),
+		searchEntries: async (scope, query, opts) =>
+			await this.searchEpisodicMemoryEntries(scope, query, opts),
+		getEntrySources: async (entryIds) => await this.getEpisodicMemoryEntrySources(entryIds),
+		applyReflection: async (scope, reflection) =>
+			await this.applyEpisodicMemoryReflection(scope, reflection),
+		getCursor: async (scope) => await this.getEpisodicMemoryCursor(scope),
+		setCursor: async (cursor) => await this.setEpisodicMemoryCursor(cursor),
+	};
 
 	// ── Thread management ────────────────────────────────────────────────
 
@@ -510,83 +522,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 
 	// ── Episodic memory ──────────────────────────────────────────────────
 
-	async saveEpisodicMemoryEntries(
-		entries: NewEpisodicMemoryEntry[],
-	): Promise<EpisodicMemoryEntry[]> {
-		const saved: EpisodicMemoryEntry[] = [];
-
-		for (const entry of entries) {
-			await this.ensureResource(entry.resourceId);
-			const contentHash = entry.contentHash ?? hashEpisodicMemoryContent(entry.content);
-			const now = new Date();
-			const entity = this.memoryEntryRepository.create({
-				agentId: entry.namespace,
-				resourceId: entry.resourceId,
-				content: entry.content,
-				contentHash,
-				...activeLifecycleState(),
-				embeddingModel: entry.embeddingModel ?? null,
-				embedding: entry.embedding ?? null,
-				metadata: entry.metadata ?? null,
-				createdAt: entry.createdAt ?? now,
-				lastSeenAt: entry.lastSeenAt ?? now,
-			});
-
-			try {
-				const persisted = await this.memoryEntryRepository.save(entity);
-				saved.push(this.toEpisodicMemoryEntry(persisted));
-			} catch (error) {
-				if (!(error instanceof Error) || !isUniqueConstraintError(error)) throw error;
-
-				const existing = await this.memoryEntryRepository.findOneBy({
-					agentId: entry.namespace,
-					resourceId: entry.resourceId,
-					contentHash,
-				});
-				if (!existing) throw error;
-				markLifecycleActive(existing);
-				existing.lastSeenAt = entry.lastSeenAt ?? now;
-				existing.updatedAt = now;
-				const updated = await this.memoryEntryRepository.save(existing);
-				saved.push(this.toEpisodicMemoryEntry(updated));
-			}
-		}
-
-		return saved;
-	}
-
-	async saveEpisodicMemoryEntrySources(
-		sources: NewEpisodicMemoryEntrySource[],
-	): Promise<EpisodicMemoryEntrySource[]> {
-		const saved: EpisodicMemoryEntrySource[] = [];
-		for (const source of sources) {
-			const evidenceHash = hashEpisodicMemoryEvidence(source.evidenceText);
-			const entity = this.memoryEntrySourceRepository.create({
-				memoryEntryId: source.memoryEntryId,
-				observationId: source.observationId,
-				threadId: source.threadId,
-				evidenceHash,
-				evidenceText: source.evidenceText,
-				createdAt: source.createdAt,
-			});
-			try {
-				const persisted = await this.memoryEntrySourceRepository.save(entity);
-				saved.push(this.toEpisodicMemoryEntrySource(persisted));
-			} catch (error) {
-				if (!(error instanceof Error) || !isUniqueConstraintError(error)) throw error;
-				const existing = await this.memoryEntrySourceRepository.findOneBy({
-					memoryEntryId: source.memoryEntryId,
-					observationId: source.observationId,
-					evidenceHash,
-				});
-				if (!existing) throw error;
-				saved.push(this.toEpisodicMemoryEntrySource(existing));
-			}
-		}
-		return saved;
-	}
-
-	async saveEpisodicMemoryEntryWithSources(
+	private async saveEpisodicMemoryEntryWithSources(
 		entry: NewEpisodicMemoryEntry,
 		sources: NewEpisodicMemoryEntrySourceForEntry[],
 	): Promise<EpisodicMemoryEntry | null> {
@@ -657,7 +593,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 		});
 	}
 
-	async searchEpisodicMemoryEntries(
+	private async searchEpisodicMemoryEntries(
 		scope: EpisodicMemoryScope,
 		query: string,
 		opts?: EpisodicMemorySearchOptions,
@@ -673,16 +609,9 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 		);
 	}
 
-	async supersedeEpisodicMemoryEntries(ids: string[], supersededBy: string): Promise<void> {
-		const filteredIds = ids.filter((id) => id !== supersededBy);
-		if (filteredIds.length === 0) return;
-		await this.memoryEntryRepository.update(
-			{ id: In(filteredIds), status: 'active' },
-			supersededLifecycleState(supersededBy),
-		);
-	}
-
-	async getEpisodicMemoryEntrySources(entryIds: string[]): Promise<EpisodicMemoryEntrySource[]> {
+	private async getEpisodicMemoryEntrySources(
+		entryIds: string[],
+	): Promise<EpisodicMemoryEntrySource[]> {
 		if (entryIds.length === 0) return [];
 		const entities = await this.memoryEntrySourceRepository.find({
 			where: { memoryEntryId: In(entryIds) },
@@ -691,7 +620,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 		return entities.map((entity) => this.toEpisodicMemoryEntrySource(entity));
 	}
 
-	async applyEpisodicMemoryReflection(
+	private async applyEpisodicMemoryReflection(
 		scope: EpisodicMemoryScope,
 		reflection: EpisodicMemoryReflectionApply,
 	): Promise<EpisodicMemoryReflectionResult> {
@@ -872,7 +801,9 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 		});
 	}
 
-	async getEpisodicMemoryCursor(scope: ObservationLogScope): Promise<EpisodicMemoryCursor | null> {
+	private async getEpisodicMemoryCursor(
+		scope: ObservationLogScope,
+	): Promise<EpisodicMemoryCursor | null> {
 		const entity = await this.memoryEntryCursorRepository.findOneBy(scope);
 		if (!entity) return null;
 		return {
@@ -884,7 +815,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 		};
 	}
 
-	async setEpisodicMemoryCursor(cursor: NewEpisodicMemoryCursor): Promise<void> {
+	private async setEpisodicMemoryCursor(cursor: NewEpisodicMemoryCursor): Promise<void> {
 		await this.memoryEntryCursorRepository.upsert(
 			{
 				scopeKind: cursor.scopeKind,

--- a/packages/cli/src/modules/agents/integrations/n8n-memory.ts
+++ b/packages/cli/src/modules/agents/integrations/n8n-memory.ts
@@ -228,26 +228,31 @@ export class N8nMemoryImpl
 		threadId: string | FindOperator<string>,
 	): Promise<void> {
 		const sourceRepo = trx.getRepository(AgentMemoryEntrySourceEntity);
+		const entryRepo = trx.getRepository(AgentMemoryEntryEntity);
 		const affectedSources = await sourceRepo.find({
 			select: { memoryEntryId: true },
-			where: { threadId },
+			where: { agentId: this.agentId, threadId },
 		});
 		const affectedEntryIds = uniqueStrings(affectedSources.map((source) => source.memoryEntryId));
 		if (affectedEntryIds.length === 0) return;
 
-		await trx.delete(AgentMemoryEntrySourceEntity, { threadId });
+		await trx.delete(AgentMemoryEntrySourceEntity, {
+			agentId: this.agentId,
+			threadId,
+		});
 
 		const remainingSources = await sourceRepo.find({
 			select: { memoryEntryId: true },
-			where: { memoryEntryId: In(affectedEntryIds) },
+			where: { agentId: this.agentId, memoryEntryId: In(affectedEntryIds) },
 		});
 		const entriesWithSources = new Set(remainingSources.map((source) => source.memoryEntryId));
 		const orphanedEntryIds = affectedEntryIds.filter((id) => !entriesWithSources.has(id));
 		if (orphanedEntryIds.length === 0) return;
 
-		await trx
-			.getRepository(AgentMemoryEntryEntity)
-			.update({ id: In(orphanedEntryIds), status: 'active' }, droppedLifecycleState());
+		await entryRepo.update(
+			{ agentId: this.agentId, id: In(orphanedEntryIds), status: 'active' },
+			droppedLifecycleState(),
+		);
 	}
 
 	// ── Message persistence ──────────────────────────────────────────────
@@ -672,6 +677,7 @@ export class N8nMemoryImpl
 			for (const source of sources) {
 				const evidenceHash = hashEpisodicMemoryEvidence(source.evidenceText);
 				const sourceEntity = sourceRepo.create({
+					agentId: this.agentId,
 					memoryEntryId: persisted.id,
 					observationId: source.observationId,
 					threadId: source.threadId,
@@ -684,6 +690,7 @@ export class N8nMemoryImpl
 				} catch (error) {
 					if (!(error instanceof Error) || !isUniqueConstraintError(error)) throw error;
 					const existing = await sourceRepo.findOneBy({
+						agentId: this.agentId,
 						memoryEntryId: persisted.id,
 						observationId: source.observationId,
 						evidenceHash,
@@ -717,7 +724,7 @@ export class N8nMemoryImpl
 	): Promise<EpisodicMemoryEntrySource[]> {
 		if (entryIds.length === 0) return [];
 		const entities = await this.memoryEntrySourceRepository.find({
-			where: { memoryEntryId: In(entryIds) },
+			where: { agentId: this.agentId, memoryEntryId: In(entryIds) },
 			order: { createdAt: 'ASC', id: 'ASC' },
 		});
 		return entities.map((entity) => this.toEpisodicMemoryEntrySource(entity));
@@ -854,11 +861,11 @@ export class N8nMemoryImpl
 				const replacement = replacements[index];
 				if (!replacement) continue;
 				const sourceRows = await sourceRepo.find({
-					where: { memoryEntryId: In(item.supersedes) },
+					where: { agentId: this.agentId, memoryEntryId: In(item.supersedes) },
 					order: { createdAt: 'ASC', id: 'ASC' },
 				});
 				const existingReplacementSources = await sourceRepo.find({
-					where: { memoryEntryId: replacement.id },
+					where: { agentId: this.agentId, memoryEntryId: replacement.id },
 				});
 				const existingKeys = new Set(
 					existingReplacementSources.map(
@@ -871,6 +878,7 @@ export class N8nMemoryImpl
 					existingKeys.add(key);
 					return [
 						sourceRepo.create({
+							agentId: this.agentId,
 							memoryEntryId: replacement.id,
 							observationId: source.observationId,
 							threadId: source.threadId,

--- a/packages/cli/src/modules/agents/integrations/n8n-memory.ts
+++ b/packages/cli/src/modules/agents/integrations/n8n-memory.ts
@@ -24,6 +24,7 @@ import {
 	type EpisodicMemoryReflectionResult,
 	type EpisodicMemoryScope,
 	type EpisodicMemorySearchOptions,
+	type EpisodicMemoryTaskLockHandle,
 	type MemoryDescriptor,
 	type NewEpisodicMemoryCursor,
 	type NewEpisodicMemoryEntry,
@@ -51,6 +52,7 @@ import { isUniqueConstraintError } from '@/response-helper';
 
 import { AgentMemoryEntryCursorEntity } from '../entities/agent-memory-entry-cursor.entity';
 import { AgentMemoryEntryEntity } from '../entities/agent-memory-entry.entity';
+import { AgentMemoryEntryLockEntity } from '../entities/agent-memory-entry-lock.entity';
 import { AgentMemoryEntrySourceEntity } from '../entities/agent-memory-entry-source.entity';
 import type { AgentMessageEntity } from '../entities/agent-message.entity';
 import { AgentObservationCursorEntity } from '../entities/agent-observation-cursor.entity';
@@ -59,6 +61,7 @@ import { AgentObservationEntity } from '../entities/agent-observation.entity';
 import { AgentThreadEntity } from '../entities/agent-thread.entity';
 import { AgentMessageRepository } from '../repositories/agent-message.repository';
 import { AgentMemoryEntryCursorRepository } from '../repositories/agent-memory-entry-cursor.repository';
+import { AgentMemoryEntryLockRepository } from '../repositories/agent-memory-entry-lock.repository';
 import { AgentMemoryEntrySourceRepository } from '../repositories/agent-memory-entry-source.repository';
 import { AgentMemoryEntryRepository } from '../repositories/agent-memory-entry.repository';
 import { AgentObservationCursorRepository } from '../repositories/agent-observation-cursor.repository';
@@ -79,6 +82,7 @@ export class N8nMemory {
 		private readonly observationCursorRepository: AgentObservationCursorRepository,
 		private readonly observationLockRepository: AgentObservationLockRepository,
 		private readonly memoryEntryRepository: AgentMemoryEntryRepository,
+		private readonly memoryEntryLockRepository: AgentMemoryEntryLockRepository,
 		private readonly memoryEntrySourceRepository: AgentMemoryEntrySourceRepository,
 		private readonly memoryEntryCursorRepository: AgentMemoryEntryCursorRepository,
 	) {}
@@ -93,6 +97,7 @@ export class N8nMemory {
 			this.observationCursorRepository,
 			this.observationLockRepository,
 			this.memoryEntryRepository,
+			this.memoryEntryLockRepository,
 			this.memoryEntrySourceRepository,
 			this.memoryEntryCursorRepository,
 		);
@@ -115,6 +120,7 @@ export class N8nMemoryImpl
 		private readonly observationCursorRepository: AgentObservationCursorRepository,
 		private readonly observationLockRepository: AgentObservationLockRepository,
 		private readonly memoryEntryRepository: AgentMemoryEntryRepository,
+		private readonly memoryEntryLockRepository: AgentMemoryEntryLockRepository,
 		private readonly memoryEntrySourceRepository: AgentMemoryEntrySourceRepository,
 		private readonly memoryEntryCursorRepository: AgentMemoryEntryCursorRepository,
 	) {}
@@ -129,6 +135,11 @@ export class N8nMemoryImpl
 			await this.applyEpisodicMemoryReflection(scope, reflection),
 		getCursor: async (scope) => await this.getEpisodicMemoryCursor(scope),
 		setCursor: async (cursor) => await this.setEpisodicMemoryCursor(cursor),
+		taskLock: {
+			acquire: async (resourceId, opts) =>
+				await this.acquireEpisodicMemoryTaskLock(resourceId, opts),
+			release: async (handle) => await this.releaseEpisodicMemoryTaskLock(handle),
+		},
 	};
 
 	// ── Thread management ────────────────────────────────────────────────
@@ -510,9 +521,8 @@ export class N8nMemoryImpl
 		const now = new Date();
 		const heldUntil = new Date(now.getTime() + opts.ttlMs);
 
-		// FIXME: This persisted lock is per task kind. In multi-main mode, different
-		// memory tasks for the same scope can still overlap across servers, so an
-		// episodic indexer could read while an observer is still writing observations.
+		// FIXME: This persisted lock is per task kind. In multi-main mode, observer
+		// and reflector tasks for the same scope can still overlap across servers.
 		const updateResult = await this.observationLockRepository
 			.createQueryBuilder()
 			.update(AgentObservationLockEntity)
@@ -561,6 +571,59 @@ export class N8nMemoryImpl
 	}
 
 	// ── Episodic memory ──────────────────────────────────────────────────
+
+	private async acquireEpisodicMemoryTaskLock(
+		resourceId: string,
+		opts: { ttlMs: number; holderId: string },
+	): Promise<EpisodicMemoryTaskLockHandle | null> {
+		await this.ensureResource(resourceId);
+
+		const now = new Date();
+		const heldUntil = new Date(now.getTime() + opts.ttlMs);
+		const updateResult = await this.memoryEntryLockRepository
+			.createQueryBuilder()
+			.update(AgentMemoryEntryLockEntity)
+			.set({ holderId: opts.holderId, heldUntil })
+			.where('"agentId" = :agentId')
+			.andWhere('"resourceId" = :resourceId')
+			.andWhere('("holderId" = :holderId OR "heldUntil" <= :now)')
+			.setParameters({
+				agentId: this.agentId,
+				resourceId,
+				holderId: opts.holderId,
+				now,
+			})
+			.execute();
+
+		if ((updateResult.affected ?? 0) > 0) {
+			return { resourceId, holderId: opts.holderId, heldUntil };
+		}
+
+		await this.memoryEntryLockRepository
+			.createQueryBuilder()
+			.insert()
+			.into(AgentMemoryEntryLockEntity)
+			.values({ agentId: this.agentId, resourceId, holderId: opts.holderId, heldUntil })
+			.orIgnore()
+			.execute();
+
+		const claimed = await this.memoryEntryLockRepository.findOneBy({
+			agentId: this.agentId,
+			resourceId,
+			holderId: opts.holderId,
+		});
+		if (!claimed) return null;
+
+		return { resourceId, holderId: opts.holderId, heldUntil };
+	}
+
+	private async releaseEpisodicMemoryTaskLock(handle: EpisodicMemoryTaskLockHandle): Promise<void> {
+		await this.memoryEntryLockRepository.delete({
+			agentId: this.agentId,
+			resourceId: handle.resourceId,
+			holderId: handle.holderId,
+		});
+	}
 
 	private async saveEpisodicMemoryEntryWithSources(
 		entry: NewEpisodicMemoryEntry,

--- a/packages/cli/src/modules/agents/integrations/n8n-memory.ts
+++ b/packages/cli/src/modules/agents/integrations/n8n-memory.ts
@@ -15,6 +15,7 @@ import {
 	type BuiltEpisodicMemoryStore,
 	type BuiltMemory,
 	type BuiltObservationLogStore,
+	type BuiltObservationLogTaskLockStore,
 	type EpisodicMemoryCursor,
 	type EpisodicMemoryEntry,
 	type EpisodicMemoryEntrySource,
@@ -68,9 +69,50 @@ import { AgentThreadRepository } from '../repositories/agent-thread.repository';
 
 const estimateObservationTokens = (text: string) => Math.ceil(text.length / 4);
 
+export type N8nMemoryImplementation = BuiltMemory &
+	BuiltObservationLogStore &
+	BuiltObservationLogTaskLockStore &
+	BuiltEpisodicMemoryStore;
+
 @Service()
-export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEpisodicMemoryStore {
+export class N8nMemory {
 	constructor(
+		private readonly threadRepository: AgentThreadRepository,
+		private readonly messageRepository: AgentMessageRepository,
+		private readonly resourceRepository: AgentResourceRepository,
+		private readonly observationRepository: AgentObservationRepository,
+		private readonly observationCursorRepository: AgentObservationCursorRepository,
+		private readonly observationLockRepository: AgentObservationLockRepository,
+		private readonly memoryEntryRepository: AgentMemoryEntryRepository,
+		private readonly memoryEntrySourceRepository: AgentMemoryEntrySourceRepository,
+		private readonly memoryEntryCursorRepository: AgentMemoryEntryCursorRepository,
+	) {}
+
+	getImplementation(agentId: string): N8nMemoryImplementation {
+		return new N8nMemoryImpl(
+			agentId,
+			this.threadRepository,
+			this.messageRepository,
+			this.resourceRepository,
+			this.observationRepository,
+			this.observationCursorRepository,
+			this.observationLockRepository,
+			this.memoryEntryRepository,
+			this.memoryEntrySourceRepository,
+			this.memoryEntryCursorRepository,
+		);
+	}
+}
+
+export class N8nMemoryImpl
+	implements
+		BuiltMemory,
+		BuiltObservationLogStore,
+		BuiltObservationLogTaskLockStore,
+		BuiltEpisodicMemoryStore
+{
+	constructor(
+		private readonly agentId: string,
 		private readonly threadRepository: AgentThreadRepository,
 		private readonly messageRepository: AgentMessageRepository,
 		private readonly resourceRepository: AgentResourceRepository,
@@ -536,7 +578,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 			const contentHash = entry.contentHash ?? hashEpisodicMemoryContent(entry.content);
 			const now = new Date();
 			const entity = entryRepo.create({
-				agentId: entry.namespace,
+				agentId: this.agentId,
 				resourceId: entry.resourceId,
 				content: entry.content,
 				contentHash,
@@ -555,7 +597,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 			} catch (error) {
 				if (!(error instanceof Error) || !isUniqueConstraintError(error)) throw error;
 				const existing = await entryRepo.findOneBy({
-					agentId: entry.namespace,
+					agentId: this.agentId,
 					resourceId: entry.resourceId,
 					contentHash,
 				});
@@ -603,7 +645,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 	): Promise<RetrievedEpisodicMemoryEntry[]> {
 		const statuses = opts?.includeStatuses ?? ['active'];
 		const entities = await this.memoryEntryRepository.find({
-			where: { agentId: scope.namespace, resourceId: scope.resourceId, status: In(statuses) },
+			where: { agentId: this.agentId, resourceId: scope.resourceId, status: In(statuses) },
 		});
 		return rankEpisodicMemoryEntries(
 			entities.map((entity) => this.toEpisodicMemoryEntry(entity)),
@@ -638,7 +680,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 
 			const activeEntries = await entryRepo.find({
 				where: {
-					agentId: scope.namespace,
+					agentId: this.agentId,
 					resourceId: scope.resourceId,
 					id: In(actionIds),
 					status: 'active',
@@ -661,7 +703,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 			const existingReplacements = replacementHashes.length
 				? await entryRepo.find({
 						where: {
-							agentId: scope.namespace,
+							agentId: this.agentId,
 							resourceId: scope.resourceId,
 							contentHash: In(replacementHashes),
 						},
@@ -687,7 +729,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 
 				if (existing) {
 					await entryRepo.update(
-						{ agentId: scope.namespace, resourceId: scope.resourceId, id: existing.id },
+						{ agentId: this.agentId, resourceId: scope.resourceId, id: existing.id },
 						update,
 					);
 					replacements.push({
@@ -698,7 +740,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 				}
 
 				const entity = entryRepo.create({
-					agentId: scope.namespace,
+					agentId: this.agentId,
 					resourceId: scope.resourceId,
 					content: item.entry.content,
 					contentHash,
@@ -718,13 +760,13 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 				} catch (error) {
 					if (!(error instanceof Error) || !isUniqueConstraintError(error)) throw error;
 					const persisted = await entryRepo.findOneBy({
-						agentId: scope.namespace,
+						agentId: this.agentId,
 						resourceId: scope.resourceId,
 						contentHash,
 					});
 					if (!persisted) throw error;
 					await entryRepo.update(
-						{ agentId: scope.namespace, resourceId: scope.resourceId, id: persisted.id },
+						{ agentId: this.agentId, resourceId: scope.resourceId, id: persisted.id },
 						update,
 					);
 					existingByHash.set(contentHash, persisted);
@@ -740,7 +782,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 			if (effectiveDrop.length > 0) {
 				await entryRepo.update(
 					{
-						agentId: scope.namespace,
+						agentId: this.agentId,
 						resourceId: scope.resourceId,
 						id: In(effectiveDrop),
 						status: 'active',
@@ -785,7 +827,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 				if (itemSupersededIds.length > 0) {
 					await entryRepo.update(
 						{
-							agentId: scope.namespace,
+							agentId: this.agentId,
 							resourceId: scope.resourceId,
 							id: In(itemSupersededIds),
 							status: 'active',
@@ -886,7 +928,6 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 	private toEpisodicMemoryEntry(entity: AgentMemoryEntryEntity): EpisodicMemoryEntry {
 		return {
 			id: entity.id,
-			namespace: entity.agentId,
 			resourceId: entity.resourceId,
 			content: entity.content,
 			contentHash: entity.contentHash,

--- a/packages/cli/src/modules/agents/integrations/n8n-memory.ts
+++ b/packages/cli/src/modules/agents/integrations/n8n-memory.ts
@@ -473,6 +473,9 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 		const now = new Date();
 		const heldUntil = new Date(now.getTime() + opts.ttlMs);
 
+		// FIXME: This persisted lock is per task kind. In multi-main mode, different
+		// memory tasks for the same scope can still overlap across servers, so an
+		// episodic indexer could read while an observer is still writing observations.
 		const updateResult = await this.observationLockRepository
 			.createQueryBuilder()
 			.update(AgentObservationLockEntity)
@@ -816,16 +819,38 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 	}
 
 	private async setEpisodicMemoryCursor(cursor: NewEpisodicMemoryCursor): Promise<void> {
-		await this.memoryEntryCursorRepository.upsert(
-			{
+		const cursorRow: QueryDeepPartialEntity<AgentMemoryEntryCursorEntity> = {
+			scopeKind: cursor.scopeKind,
+			scopeId: cursor.scopeId,
+			lastIndexedObservationId: cursor.lastIndexedObservationId,
+			lastIndexedObservationCreatedAt: cursor.lastIndexedObservationCreatedAt,
+			updatedAt: cursor.updatedAt ?? new Date(),
+		};
+
+		await this.memoryEntryCursorRepository
+			.createQueryBuilder()
+			.insert()
+			.into(AgentMemoryEntryCursorEntity)
+			.values(cursorRow)
+			.orIgnore()
+			.execute();
+
+		await this.memoryEntryCursorRepository
+			.createQueryBuilder()
+			.update(AgentMemoryEntryCursorEntity)
+			.set(cursorRow)
+			.where('"scopeKind" = :scopeKind')
+			.andWhere('"scopeId" = :scopeId')
+			.andWhere(
+				'("lastIndexedObservationCreatedAt" < :lastIndexedObservationCreatedAt OR ("lastIndexedObservationCreatedAt" = :lastIndexedObservationCreatedAt AND "lastIndexedObservationId" < :lastIndexedObservationId))',
+			)
+			.setParameters({
 				scopeKind: cursor.scopeKind,
 				scopeId: cursor.scopeId,
 				lastIndexedObservationId: cursor.lastIndexedObservationId,
 				lastIndexedObservationCreatedAt: cursor.lastIndexedObservationCreatedAt,
-				updatedAt: cursor.updatedAt ?? new Date(),
-			},
-			{ conflictPaths: ['scopeKind', 'scopeId'], skipUpdateIfNoValuesChanged: false },
-		);
+			})
+			.execute();
 	}
 
 	// ── Descriptor ───────────────────────────────────────────────────────

--- a/packages/cli/src/modules/agents/integrations/n8n-memory.ts
+++ b/packages/cli/src/modules/agents/integrations/n8n-memory.ts
@@ -1,11 +1,32 @@
 import {
+	activeLifecycleState,
+	droppedLifecycleState,
 	normalizeObservationLogReflection,
 	createObservationLogThreadScopePrefix,
+	hashEpisodicMemoryContent,
+	hashEpisodicMemoryEvidence,
+	markLifecycleActive,
+	normalizeFlatReflectionActions,
+	rankEpisodicMemoryEntries,
+	supersededLifecycleState,
+	uniqueStrings,
 	type AgentDbMessage,
 	type AgentMessage,
+	type BuiltEpisodicMemoryStore,
 	type BuiltMemory,
 	type BuiltObservationLogStore,
+	type EpisodicMemoryCursor,
+	type EpisodicMemoryEntry,
+	type EpisodicMemoryEntrySource,
+	type EpisodicMemoryReflectionApply,
+	type EpisodicMemoryReflectionResult,
+	type EpisodicMemoryScope,
+	type EpisodicMemorySearchOptions,
 	type MemoryDescriptor,
+	type NewEpisodicMemoryCursor,
+	type NewEpisodicMemoryEntry,
+	type NewEpisodicMemoryEntrySource,
+	type NewEpisodicMemoryEntrySourceForEntry,
 	type NewObservationLogEntry,
 	type ObservationCursor,
 	type ObservationLogEntry,
@@ -14,20 +35,31 @@ import {
 	type ObservationLogReflectionResult,
 	type ObservationLogScope,
 	type ObservationLogScopeKind,
+	type ObservationLogTaskKind,
+	type ObservationLogTaskLockHandle,
+	type RetrievedEpisodicMemoryEntry,
 	type Thread,
 } from '@n8n/agents';
 import { Service } from '@n8n/di';
-import type { FindOptionsWhere } from '@n8n/typeorm';
+import type { EntityManager, FindOperator, FindOptionsWhere } from '@n8n/typeorm';
 import { Equal, In, IsNull, LessThan, Like, MoreThan } from '@n8n/typeorm';
 import type { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
 import { UnexpectedError } from 'n8n-workflow';
 
+import { isUniqueConstraintError } from '@/response-helper';
+
+import { AgentMemoryEntryCursorEntity } from '../entities/agent-memory-entry-cursor.entity';
+import { AgentMemoryEntryEntity } from '../entities/agent-memory-entry.entity';
+import { AgentMemoryEntrySourceEntity } from '../entities/agent-memory-entry-source.entity';
 import type { AgentMessageEntity } from '../entities/agent-message.entity';
 import { AgentObservationCursorEntity } from '../entities/agent-observation-cursor.entity';
 import { AgentObservationLockEntity } from '../entities/agent-observation-lock.entity';
 import { AgentObservationEntity } from '../entities/agent-observation.entity';
 import { AgentThreadEntity } from '../entities/agent-thread.entity';
 import { AgentMessageRepository } from '../repositories/agent-message.repository';
+import { AgentMemoryEntryCursorRepository } from '../repositories/agent-memory-entry-cursor.repository';
+import { AgentMemoryEntrySourceRepository } from '../repositories/agent-memory-entry-source.repository';
+import { AgentMemoryEntryRepository } from '../repositories/agent-memory-entry.repository';
 import { AgentObservationCursorRepository } from '../repositories/agent-observation-cursor.repository';
 import { AgentObservationLockRepository } from '../repositories/agent-observation-lock.repository';
 import { AgentObservationRepository } from '../repositories/agent-observation.repository';
@@ -36,18 +68,8 @@ import { AgentThreadRepository } from '../repositories/agent-thread.repository';
 
 const estimateObservationTokens = (text: string) => Math.ceil(text.length / 4);
 
-type ObservationLogTaskKind = 'observer' | 'reflector';
-
-interface ObservationLogTaskLockHandle {
-	scopeKind: ObservationLogScopeKind;
-	scopeId: string;
-	taskKind: ObservationLogTaskKind;
-	holderId: string;
-	heldUntil: Date;
-}
-
 @Service()
-export class N8nMemory implements BuiltMemory, BuiltObservationLogStore {
+export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEpisodicMemoryStore {
 	constructor(
 		private readonly threadRepository: AgentThreadRepository,
 		private readonly messageRepository: AgentMessageRepository,
@@ -55,6 +77,9 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore {
 		private readonly observationRepository: AgentObservationRepository,
 		private readonly observationCursorRepository: AgentObservationCursorRepository,
 		private readonly observationLockRepository: AgentObservationLockRepository,
+		private readonly memoryEntryRepository: AgentMemoryEntryRepository,
+		private readonly memoryEntrySourceRepository: AgentMemoryEntrySourceRepository,
+		private readonly memoryEntryCursorRepository: AgentMemoryEntryCursorRepository,
 	) {}
 
 	// ── Thread management ────────────────────────────────────────────────
@@ -104,6 +129,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore {
 
 	async deleteThread(threadId: string): Promise<void> {
 		await this.threadRepository.manager.transaction(async (trx) => {
+			await this.dropEpisodicEntriesWithoutSources(trx, threadId);
 			const legacyScope = { scopeKind: 'thread' as const, scopeId: threadId };
 			const resourceScope = {
 				scopeKind: 'thread' as const,
@@ -113,6 +139,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore {
 				await trx.delete(AgentObservationEntity, scope);
 				await trx.delete(AgentObservationCursorEntity, scope);
 				await trx.delete(AgentObservationLockEntity, scope);
+				await trx.delete(AgentMemoryEntryCursorEntity, scope);
 			}
 			await trx.delete(AgentThreadEntity, { id: threadId });
 		});
@@ -122,6 +149,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore {
 		const scopeId = Like(`${threadIdPrefix}%`);
 		const resourceScopeId = Like(`${createObservationLogThreadScopePrefix(threadIdPrefix)}%`);
 		await this.threadRepository.manager.transaction(async (trx) => {
+			await this.dropEpisodicEntriesWithoutSources(trx, scopeId);
 			for (const scope of [
 				{ scopeKind: 'thread' as const, scopeId },
 				{ scopeKind: 'thread' as const, scopeId: resourceScopeId },
@@ -129,9 +157,37 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore {
 				await trx.delete(AgentObservationEntity, scope);
 				await trx.delete(AgentObservationCursorEntity, scope);
 				await trx.delete(AgentObservationLockEntity, scope);
+				await trx.delete(AgentMemoryEntryCursorEntity, scope);
 			}
 			await trx.delete(AgentThreadEntity, { id: scopeId });
 		});
+	}
+
+	private async dropEpisodicEntriesWithoutSources(
+		trx: EntityManager,
+		threadId: string | FindOperator<string>,
+	): Promise<void> {
+		const sourceRepo = trx.getRepository(AgentMemoryEntrySourceEntity);
+		const affectedSources = await sourceRepo.find({
+			select: { memoryEntryId: true },
+			where: { threadId },
+		});
+		const affectedEntryIds = uniqueStrings(affectedSources.map((source) => source.memoryEntryId));
+		if (affectedEntryIds.length === 0) return;
+
+		await trx.delete(AgentMemoryEntrySourceEntity, { threadId });
+
+		const remainingSources = await sourceRepo.find({
+			select: { memoryEntryId: true },
+			where: { memoryEntryId: In(affectedEntryIds) },
+		});
+		const entriesWithSources = new Set(remainingSources.map((source) => source.memoryEntryId));
+		const orphanedEntryIds = affectedEntryIds.filter((id) => !entriesWithSources.has(id));
+		if (orphanedEntryIds.length === 0) return;
+
+		await trx
+			.getRepository(AgentMemoryEntryEntity)
+			.update({ id: In(orphanedEntryIds), status: 'active' }, droppedLifecycleState());
 	}
 
 	// ── Message persistence ──────────────────────────────────────────────
@@ -222,8 +278,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore {
 				text: row.text,
 				parentId: row.parentId ?? null,
 				tokenCount: row.tokenCount ?? estimateObservationTokens(row.text),
-				status: 'active',
-				supersededBy: null,
+				...activeLifecycleState(),
 				createdAt: row.createdAt,
 			}),
 		);
@@ -292,17 +347,14 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore {
 
 	async dropObservationLogEntries(ids: string[]): Promise<void> {
 		if (ids.length === 0) return;
-		await this.observationRepository.update(
-			{ id: In(ids) },
-			{ status: 'dropped', supersededBy: null },
-		);
+		await this.observationRepository.update({ id: In(ids) }, droppedLifecycleState());
 	}
 
 	async supersedeObservationLogEntries(ids: string[], supersededBy: string): Promise<void> {
 		if (ids.length === 0) return;
 		await this.observationRepository.update(
 			{ id: In(ids) },
-			{ status: 'superseded', supersededBy },
+			supersededLifecycleState(supersededBy),
 		);
 	}
 
@@ -334,8 +386,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore {
 								text: entry.text,
 								parentId: entry.parentId ?? null,
 								tokenCount: entry.tokenCount ?? estimateObservationTokens(entry.text),
-								status: 'active',
-								supersededBy: null,
+								...activeLifecycleState(),
 								createdAt: entry.createdAt,
 							}),
 						),
@@ -345,7 +396,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore {
 			if (normalized.drop.length > 0) {
 				await repo.update(
 					{ scopeKind: scope.scopeKind, scopeId: scope.scopeId, id: In(normalized.drop) },
-					{ status: 'dropped', supersededBy: null },
+					droppedLifecycleState(),
 				);
 			}
 
@@ -354,7 +405,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore {
 				if (replacement && merge.supersedes.length > 0) {
 					await repo.update(
 						{ scopeKind: scope.scopeKind, scopeId: scope.scopeId, id: In(merge.supersedes) },
-						{ status: 'superseded', supersededBy: replacement.id },
+						supersededLifecycleState(replacement.id),
 					);
 				}
 			}
@@ -457,6 +508,395 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore {
 		});
 	}
 
+	// ── Episodic memory ──────────────────────────────────────────────────
+
+	async saveEpisodicMemoryEntries(
+		entries: NewEpisodicMemoryEntry[],
+	): Promise<EpisodicMemoryEntry[]> {
+		const saved: EpisodicMemoryEntry[] = [];
+
+		for (const entry of entries) {
+			await this.ensureResource(entry.resourceId);
+			const contentHash = entry.contentHash ?? hashEpisodicMemoryContent(entry.content);
+			const now = new Date();
+			const entity = this.memoryEntryRepository.create({
+				agentId: entry.agentId,
+				resourceId: entry.resourceId,
+				content: entry.content,
+				contentHash,
+				...activeLifecycleState(),
+				embeddingModel: entry.embeddingModel ?? null,
+				embedding: entry.embedding ?? null,
+				metadata: entry.metadata ?? null,
+				createdAt: entry.createdAt ?? now,
+				lastSeenAt: entry.lastSeenAt ?? now,
+			});
+
+			try {
+				const persisted = await this.memoryEntryRepository.save(entity);
+				saved.push(this.toEpisodicMemoryEntry(persisted));
+			} catch (error) {
+				if (!(error instanceof Error) || !isUniqueConstraintError(error)) throw error;
+
+				const existing = await this.memoryEntryRepository.findOneBy({
+					agentId: entry.agentId,
+					resourceId: entry.resourceId,
+					contentHash,
+				});
+				if (!existing) throw error;
+				markLifecycleActive(existing);
+				existing.lastSeenAt = entry.lastSeenAt ?? now;
+				existing.updatedAt = now;
+				const updated = await this.memoryEntryRepository.save(existing);
+				saved.push(this.toEpisodicMemoryEntry(updated));
+			}
+		}
+
+		return saved;
+	}
+
+	async saveEpisodicMemoryEntrySources(
+		sources: NewEpisodicMemoryEntrySource[],
+	): Promise<EpisodicMemoryEntrySource[]> {
+		const saved: EpisodicMemoryEntrySource[] = [];
+		for (const source of sources) {
+			const evidenceHash = hashEpisodicMemoryEvidence(source.evidenceText);
+			const entity = this.memoryEntrySourceRepository.create({
+				memoryEntryId: source.memoryEntryId,
+				observationId: source.observationId,
+				threadId: source.threadId,
+				evidenceHash,
+				evidenceText: source.evidenceText,
+				createdAt: source.createdAt,
+			});
+			try {
+				const persisted = await this.memoryEntrySourceRepository.save(entity);
+				saved.push(this.toEpisodicMemoryEntrySource(persisted));
+			} catch (error) {
+				if (!(error instanceof Error) || !isUniqueConstraintError(error)) throw error;
+				const existing = await this.memoryEntrySourceRepository.findOneBy({
+					memoryEntryId: source.memoryEntryId,
+					observationId: source.observationId,
+					evidenceHash,
+				});
+				if (!existing) throw error;
+				saved.push(this.toEpisodicMemoryEntrySource(existing));
+			}
+		}
+		return saved;
+	}
+
+	async saveEpisodicMemoryEntryWithSources(
+		entry: NewEpisodicMemoryEntry,
+		sources: NewEpisodicMemoryEntrySourceForEntry[],
+	): Promise<EpisodicMemoryEntry | null> {
+		await this.ensureResource(entry.resourceId);
+		return await this.memoryEntryRepository.manager.transaction(async (trx) => {
+			const entryRepo = trx.getRepository(AgentMemoryEntryEntity);
+			const sourceRepo = trx.getRepository(AgentMemoryEntrySourceEntity);
+			const contentHash = entry.contentHash ?? hashEpisodicMemoryContent(entry.content);
+			const now = new Date();
+			const entity = entryRepo.create({
+				agentId: entry.agentId,
+				resourceId: entry.resourceId,
+				content: entry.content,
+				contentHash,
+				...activeLifecycleState(),
+				embeddingModel: entry.embeddingModel ?? null,
+				embedding: entry.embedding ?? null,
+				metadata: entry.metadata ?? null,
+				createdAt: entry.createdAt ?? now,
+				lastSeenAt: entry.lastSeenAt ?? now,
+			});
+
+			let persisted: AgentMemoryEntryEntity | null = null;
+			try {
+				const [saved] = await entryRepo.save([entity]);
+				persisted = saved ?? null;
+			} catch (error) {
+				if (!(error instanceof Error) || !isUniqueConstraintError(error)) throw error;
+				const existing = await entryRepo.findOneBy({
+					agentId: entry.agentId,
+					resourceId: entry.resourceId,
+					contentHash,
+				});
+				if (!existing) throw error;
+				markLifecycleActive(existing);
+				existing.lastSeenAt = entry.lastSeenAt ?? now;
+				existing.updatedAt = now;
+				const [saved] = await entryRepo.save([existing]);
+				persisted = saved ?? existing;
+			}
+
+			if (!persisted) return null;
+
+			for (const source of sources) {
+				const evidenceHash = hashEpisodicMemoryEvidence(source.evidenceText);
+				const sourceEntity = sourceRepo.create({
+					memoryEntryId: persisted.id,
+					observationId: source.observationId,
+					threadId: source.threadId,
+					evidenceHash,
+					evidenceText: source.evidenceText,
+					createdAt: source.createdAt,
+				});
+				try {
+					await sourceRepo.save([sourceEntity]);
+				} catch (error) {
+					if (!(error instanceof Error) || !isUniqueConstraintError(error)) throw error;
+					const existing = await sourceRepo.findOneBy({
+						memoryEntryId: persisted.id,
+						observationId: source.observationId,
+						evidenceHash,
+					});
+					if (!existing) throw error;
+				}
+			}
+
+			return this.toEpisodicMemoryEntry(persisted);
+		});
+	}
+
+	async searchEpisodicMemoryEntries(
+		scope: EpisodicMemoryScope,
+		query: string,
+		opts?: EpisodicMemorySearchOptions,
+	): Promise<RetrievedEpisodicMemoryEntry[]> {
+		const statuses = opts?.includeStatuses ?? ['active'];
+		const entities = await this.memoryEntryRepository.find({
+			where: { agentId: scope.agentId, resourceId: scope.resourceId, status: In(statuses) },
+		});
+		return rankEpisodicMemoryEntries(
+			entities.map((entity) => this.toEpisodicMemoryEntry(entity)),
+			query,
+			opts,
+		);
+	}
+
+	async supersedeEpisodicMemoryEntries(ids: string[], supersededBy: string): Promise<void> {
+		const filteredIds = ids.filter((id) => id !== supersededBy);
+		if (filteredIds.length === 0) return;
+		await this.memoryEntryRepository.update(
+			{ id: In(filteredIds), status: 'active' },
+			supersededLifecycleState(supersededBy),
+		);
+	}
+
+	async getEpisodicMemoryEntrySources(entryIds: string[]): Promise<EpisodicMemoryEntrySource[]> {
+		if (entryIds.length === 0) return [];
+		const entities = await this.memoryEntrySourceRepository.find({
+			where: { memoryEntryId: In(entryIds) },
+			order: { createdAt: 'ASC', id: 'ASC' },
+		});
+		return entities.map((entity) => this.toEpisodicMemoryEntrySource(entity));
+	}
+
+	async applyEpisodicMemoryReflection(
+		scope: EpisodicMemoryScope,
+		reflection: EpisodicMemoryReflectionApply,
+	): Promise<EpisodicMemoryReflectionResult> {
+		return await this.memoryEntryRepository.manager.transaction(async (trx) => {
+			const entryRepo = trx.getRepository(AgentMemoryEntryEntity);
+			const sourceRepo = trx.getRepository(AgentMemoryEntrySourceEntity);
+			const actionIds = uniqueStrings([
+				...reflection.drop,
+				...reflection.merge.flatMap((merge) => merge.supersedes),
+			]);
+			if (actionIds.length === 0) return { droppedIds: [], supersededIds: [], inserted: [] };
+
+			const activeEntries = await entryRepo.find({
+				where: {
+					agentId: scope.agentId,
+					resourceId: scope.resourceId,
+					id: In(actionIds),
+					status: 'active',
+				},
+			});
+			const activeIds = new Set(activeEntries.map((entry) => entry.id));
+			const normalized = normalizeFlatReflectionActions({
+				activeIds,
+				drop: reflection.drop,
+				merge: reflection.merge,
+				normalizeMerge: (entry, supersedes) => ({ ...entry, supersedes }),
+			});
+
+			const now = new Date();
+			const replacementHashes = uniqueStrings(
+				normalized.merge.map(
+					(item) => item.entry.contentHash ?? hashEpisodicMemoryContent(item.entry.content),
+				),
+			);
+			const existingReplacements = replacementHashes.length
+				? await entryRepo.find({
+						where: {
+							agentId: scope.agentId,
+							resourceId: scope.resourceId,
+							contentHash: In(replacementHashes),
+						},
+					})
+				: [];
+			const existingByHash = new Map(
+				existingReplacements.map((entry) => [entry.contentHash, entry]),
+			);
+			const replacements: AgentMemoryEntryEntity[] = [];
+			for (const item of normalized.merge) {
+				const contentHash = item.entry.contentHash ?? hashEpisodicMemoryContent(item.entry.content);
+				const existing = existingByHash.get(contentHash);
+				const update: QueryDeepPartialEntity<AgentMemoryEntryEntity> = {
+					...activeLifecycleState(),
+					lastSeenAt: item.entry.lastSeenAt ?? now,
+					updatedAt: now,
+				};
+				if (item.entry.embedding !== undefined) update.embedding = item.entry.embedding;
+				if (item.entry.embeddingModel !== undefined) {
+					update.embeddingModel = item.entry.embeddingModel;
+				}
+				if (item.entry.metadata !== undefined) update.metadata = item.entry.metadata;
+
+				if (existing) {
+					await entryRepo.update(
+						{ agentId: scope.agentId, resourceId: scope.resourceId, id: existing.id },
+						update,
+					);
+					replacements.push({
+						...existing,
+						...update,
+					} as AgentMemoryEntryEntity);
+					continue;
+				}
+
+				const entity = entryRepo.create({
+					agentId: scope.agentId,
+					resourceId: scope.resourceId,
+					content: item.entry.content,
+					contentHash,
+					...activeLifecycleState(),
+					embeddingModel: item.entry.embeddingModel ?? null,
+					embedding: item.entry.embedding ?? null,
+					metadata: item.entry.metadata ?? null,
+					createdAt: item.entry.createdAt ?? now,
+					lastSeenAt: item.entry.lastSeenAt ?? now,
+				});
+				try {
+					const [persisted] = await entryRepo.save([entity]);
+					if (persisted) {
+						existingByHash.set(contentHash, persisted);
+						replacements.push(persisted);
+					}
+				} catch (error) {
+					if (!(error instanceof Error) || !isUniqueConstraintError(error)) throw error;
+					const persisted = await entryRepo.findOneBy({
+						agentId: scope.agentId,
+						resourceId: scope.resourceId,
+						contentHash,
+					});
+					if (!persisted) throw error;
+					await entryRepo.update(
+						{ agentId: scope.agentId, resourceId: scope.resourceId, id: persisted.id },
+						update,
+					);
+					existingByHash.set(contentHash, persisted);
+					replacements.push({
+						...persisted,
+						...update,
+					} as AgentMemoryEntryEntity);
+				}
+			}
+			const replacementIds = new Set(replacements.map((entry) => entry.id));
+			const effectiveDrop = normalized.drop.filter((id) => !replacementIds.has(id));
+
+			if (effectiveDrop.length > 0) {
+				await entryRepo.update(
+					{
+						agentId: scope.agentId,
+						resourceId: scope.resourceId,
+						id: In(effectiveDrop),
+						status: 'active',
+					},
+					droppedLifecycleState(),
+				);
+			}
+
+			const supersededIds: string[] = [];
+			for (const [index, item] of normalized.merge.entries()) {
+				const replacement = replacements[index];
+				if (!replacement) continue;
+				const sourceRows = await sourceRepo.find({
+					where: { memoryEntryId: In(item.supersedes) },
+					order: { createdAt: 'ASC', id: 'ASC' },
+				});
+				const existingReplacementSources = await sourceRepo.find({
+					where: { memoryEntryId: replacement.id },
+				});
+				const existingKeys = new Set(
+					existingReplacementSources.map(
+						(source) => `${source.observationId}\n${source.evidenceHash}`,
+					),
+				);
+				const copiedSources = sourceRows.flatMap((source) => {
+					const key = `${source.observationId}\n${source.evidenceHash}`;
+					if (existingKeys.has(key)) return [];
+					existingKeys.add(key);
+					return [
+						sourceRepo.create({
+							memoryEntryId: replacement.id,
+							observationId: source.observationId,
+							threadId: source.threadId,
+							evidenceHash: source.evidenceHash,
+							evidenceText: source.evidenceText,
+							createdAt: now,
+						}),
+					];
+				});
+				if (copiedSources.length > 0) await sourceRepo.save(copiedSources);
+				const itemSupersededIds = item.supersedes.filter((id) => id !== replacement.id);
+				if (itemSupersededIds.length > 0) {
+					await entryRepo.update(
+						{
+							agentId: scope.agentId,
+							resourceId: scope.resourceId,
+							id: In(itemSupersededIds),
+							status: 'active',
+						},
+						supersededLifecycleState(replacement.id),
+					);
+					supersededIds.push(...itemSupersededIds);
+				}
+			}
+
+			return {
+				droppedIds: effectiveDrop,
+				supersededIds,
+				inserted: replacements.map((entry) => this.toEpisodicMemoryEntry(entry)),
+			};
+		});
+	}
+
+	async getEpisodicMemoryCursor(scope: ObservationLogScope): Promise<EpisodicMemoryCursor | null> {
+		const entity = await this.memoryEntryCursorRepository.findOneBy(scope);
+		if (!entity) return null;
+		return {
+			scopeKind: entity.scopeKind,
+			scopeId: entity.scopeId,
+			lastIndexedObservationId: entity.lastIndexedObservationId,
+			lastIndexedObservationCreatedAt: entity.lastIndexedObservationCreatedAt,
+			updatedAt: entity.updatedAt,
+		};
+	}
+
+	async setEpisodicMemoryCursor(cursor: NewEpisodicMemoryCursor): Promise<void> {
+		await this.memoryEntryCursorRepository.upsert(
+			{
+				scopeKind: cursor.scopeKind,
+				scopeId: cursor.scopeId,
+				lastIndexedObservationId: cursor.lastIndexedObservationId,
+				lastIndexedObservationCreatedAt: cursor.lastIndexedObservationCreatedAt,
+				updatedAt: cursor.updatedAt ?? new Date(),
+			},
+			{ conflictPaths: ['scopeKind', 'scopeId'], skipUpdateIfNoValuesChanged: false },
+		);
+	}
+
 	// ── Descriptor ───────────────────────────────────────────────────────
 
 	describe(): MemoryDescriptor {
@@ -483,6 +923,37 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore {
 			tokenCount: Number(entity.tokenCount),
 			status: entity.status,
 			supersededBy: entity.supersededBy,
+			createdAt: entity.createdAt,
+		};
+	}
+
+	private toEpisodicMemoryEntry(entity: AgentMemoryEntryEntity): EpisodicMemoryEntry {
+		return {
+			id: entity.id,
+			agentId: entity.agentId,
+			resourceId: entity.resourceId,
+			content: entity.content,
+			contentHash: entity.contentHash,
+			status: entity.status,
+			supersededBy: entity.supersededBy,
+			...(entity.embedding ? { embedding: entity.embedding } : {}),
+			...(entity.embeddingModel ? { embeddingModel: entity.embeddingModel } : {}),
+			metadata: entity.metadata,
+			createdAt: entity.createdAt,
+			updatedAt: entity.updatedAt,
+			lastSeenAt: entity.lastSeenAt,
+		};
+	}
+
+	private toEpisodicMemoryEntrySource(
+		entity: AgentMemoryEntrySourceEntity,
+	): EpisodicMemoryEntrySource {
+		return {
+			id: entity.id,
+			memoryEntryId: entity.memoryEntryId,
+			observationId: entity.observationId,
+			threadId: entity.threadId,
+			evidenceText: entity.evidenceText,
 			createdAt: entity.createdAt,
 		};
 	}

--- a/packages/cli/src/modules/agents/integrations/n8n-memory.ts
+++ b/packages/cli/src/modules/agents/integrations/n8n-memory.ts
@@ -520,7 +520,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 			const contentHash = entry.contentHash ?? hashEpisodicMemoryContent(entry.content);
 			const now = new Date();
 			const entity = this.memoryEntryRepository.create({
-				agentId: entry.agentId,
+				agentId: entry.namespace,
 				resourceId: entry.resourceId,
 				content: entry.content,
 				contentHash,
@@ -539,7 +539,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 				if (!(error instanceof Error) || !isUniqueConstraintError(error)) throw error;
 
 				const existing = await this.memoryEntryRepository.findOneBy({
-					agentId: entry.agentId,
+					agentId: entry.namespace,
 					resourceId: entry.resourceId,
 					contentHash,
 				});
@@ -597,7 +597,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 			const contentHash = entry.contentHash ?? hashEpisodicMemoryContent(entry.content);
 			const now = new Date();
 			const entity = entryRepo.create({
-				agentId: entry.agentId,
+				agentId: entry.namespace,
 				resourceId: entry.resourceId,
 				content: entry.content,
 				contentHash,
@@ -616,7 +616,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 			} catch (error) {
 				if (!(error instanceof Error) || !isUniqueConstraintError(error)) throw error;
 				const existing = await entryRepo.findOneBy({
-					agentId: entry.agentId,
+					agentId: entry.namespace,
 					resourceId: entry.resourceId,
 					contentHash,
 				});
@@ -664,7 +664,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 	): Promise<RetrievedEpisodicMemoryEntry[]> {
 		const statuses = opts?.includeStatuses ?? ['active'];
 		const entities = await this.memoryEntryRepository.find({
-			where: { agentId: scope.agentId, resourceId: scope.resourceId, status: In(statuses) },
+			where: { agentId: scope.namespace, resourceId: scope.resourceId, status: In(statuses) },
 		});
 		return rankEpisodicMemoryEntries(
 			entities.map((entity) => this.toEpisodicMemoryEntry(entity)),
@@ -706,7 +706,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 
 			const activeEntries = await entryRepo.find({
 				where: {
-					agentId: scope.agentId,
+					agentId: scope.namespace,
 					resourceId: scope.resourceId,
 					id: In(actionIds),
 					status: 'active',
@@ -729,7 +729,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 			const existingReplacements = replacementHashes.length
 				? await entryRepo.find({
 						where: {
-							agentId: scope.agentId,
+							agentId: scope.namespace,
 							resourceId: scope.resourceId,
 							contentHash: In(replacementHashes),
 						},
@@ -755,7 +755,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 
 				if (existing) {
 					await entryRepo.update(
-						{ agentId: scope.agentId, resourceId: scope.resourceId, id: existing.id },
+						{ agentId: scope.namespace, resourceId: scope.resourceId, id: existing.id },
 						update,
 					);
 					replacements.push({
@@ -766,7 +766,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 				}
 
 				const entity = entryRepo.create({
-					agentId: scope.agentId,
+					agentId: scope.namespace,
 					resourceId: scope.resourceId,
 					content: item.entry.content,
 					contentHash,
@@ -786,13 +786,13 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 				} catch (error) {
 					if (!(error instanceof Error) || !isUniqueConstraintError(error)) throw error;
 					const persisted = await entryRepo.findOneBy({
-						agentId: scope.agentId,
+						agentId: scope.namespace,
 						resourceId: scope.resourceId,
 						contentHash,
 					});
 					if (!persisted) throw error;
 					await entryRepo.update(
-						{ agentId: scope.agentId, resourceId: scope.resourceId, id: persisted.id },
+						{ agentId: scope.namespace, resourceId: scope.resourceId, id: persisted.id },
 						update,
 					);
 					existingByHash.set(contentHash, persisted);
@@ -808,7 +808,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 			if (effectiveDrop.length > 0) {
 				await entryRepo.update(
 					{
-						agentId: scope.agentId,
+						agentId: scope.namespace,
 						resourceId: scope.resourceId,
 						id: In(effectiveDrop),
 						status: 'active',
@@ -853,7 +853,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 				if (itemSupersededIds.length > 0) {
 					await entryRepo.update(
 						{
-							agentId: scope.agentId,
+							agentId: scope.namespace,
 							resourceId: scope.resourceId,
 							id: In(itemSupersededIds),
 							status: 'active',
@@ -930,7 +930,7 @@ export class N8nMemory implements BuiltMemory, BuiltObservationLogStore, BuiltEp
 	private toEpisodicMemoryEntry(entity: AgentMemoryEntryEntity): EpisodicMemoryEntry {
 		return {
 			id: entity.id,
-			agentId: entity.agentId,
+			namespace: entity.agentId,
 			resourceId: entity.resourceId,
 			content: entity.content,
 			contentHash: entity.contentHash,

--- a/packages/cli/src/modules/agents/repositories/agent-memory-entry-cursor.repository.ts
+++ b/packages/cli/src/modules/agents/repositories/agent-memory-entry-cursor.repository.ts
@@ -1,0 +1,11 @@
+import { Service } from '@n8n/di';
+import { DataSource, Repository } from '@n8n/typeorm';
+
+import { AgentMemoryEntryCursorEntity } from '../entities/agent-memory-entry-cursor.entity';
+
+@Service()
+export class AgentMemoryEntryCursorRepository extends Repository<AgentMemoryEntryCursorEntity> {
+	constructor(dataSource: DataSource) {
+		super(AgentMemoryEntryCursorEntity, dataSource.manager);
+	}
+}

--- a/packages/cli/src/modules/agents/repositories/agent-memory-entry-lock.repository.ts
+++ b/packages/cli/src/modules/agents/repositories/agent-memory-entry-lock.repository.ts
@@ -1,0 +1,11 @@
+import { Service } from '@n8n/di';
+import { DataSource, Repository } from '@n8n/typeorm';
+
+import { AgentMemoryEntryLockEntity } from '../entities/agent-memory-entry-lock.entity';
+
+@Service()
+export class AgentMemoryEntryLockRepository extends Repository<AgentMemoryEntryLockEntity> {
+	constructor(dataSource: DataSource) {
+		super(AgentMemoryEntryLockEntity, dataSource.manager);
+	}
+}

--- a/packages/cli/src/modules/agents/repositories/agent-memory-entry-source.repository.ts
+++ b/packages/cli/src/modules/agents/repositories/agent-memory-entry-source.repository.ts
@@ -1,0 +1,11 @@
+import { Service } from '@n8n/di';
+import { DataSource, Repository } from '@n8n/typeorm';
+
+import { AgentMemoryEntrySourceEntity } from '../entities/agent-memory-entry-source.entity';
+
+@Service()
+export class AgentMemoryEntrySourceRepository extends Repository<AgentMemoryEntrySourceEntity> {
+	constructor(dataSource: DataSource) {
+		super(AgentMemoryEntrySourceEntity, dataSource.manager);
+	}
+}

--- a/packages/cli/src/modules/agents/repositories/agent-memory-entry.repository.ts
+++ b/packages/cli/src/modules/agents/repositories/agent-memory-entry.repository.ts
@@ -1,0 +1,11 @@
+import { Service } from '@n8n/di';
+import { DataSource, Repository } from '@n8n/typeorm';
+
+import { AgentMemoryEntryEntity } from '../entities/agent-memory-entry.entity';
+
+@Service()
+export class AgentMemoryEntryRepository extends Repository<AgentMemoryEntryEntity> {
+	constructor(dataSource: DataSource) {
+		super(AgentMemoryEntryEntity, dataSource.manager);
+	}
+}


### PR DESCRIPTION
## Summary

Adds entities, repositories, and N8nMemory persistence for episodic entries, sources, cursors, source cleanup, and reflection apply behavior. Entries stay source-backed and active search excludes dropped/superseded rows.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
