### PR TITLE
fix(core): Use TIMESTAMPTZ for Data Table date columns in Postgres

### DIFF
--- a/packages/cli/src/modules/data-table/__tests__/sql-utils.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/sql-utils.test.ts
@@ -96,6 +96,18 @@ describe('sql-utils', () => {
 			expect(result[0].updatedAt).toEqual(new Date('2024-01-15T10:30:00Z'));
 		});
 
+		it('should normalize date values from postgres TIMESTAMP strings with microseconds', () => {
+			const columns = [createColumn('birthday', 'date')];
+			const dateString = '2024-01-15 10:30:00.000000';
+			const rows = [{ id: 1, birthday: dateString, createdAt: dateString, updatedAt: dateString }];
+
+			const result = normalizeRows(rows, columns);
+
+			expect(result[0].birthday).toEqual(new Date('2024-01-15T10:30:00Z'));
+			expect(result[0].createdAt).toEqual(new Date('2024-01-15T10:30:00Z'));
+			expect(result[0].updatedAt).toEqual(new Date('2024-01-15T10:30:00Z'));
+		});
+
 		it('should normalize date values from timestamps', () => {
 			const columns = [createColumn('birthday', 'date')];
 			const timestamp = 1705318200000; // 2024-01-15T10:30:00Z
@@ -218,6 +230,24 @@ describe('sql-utils', () => {
 			const query = addColumnQuery(tableName, column, 'postgres');
 
 			expect(query).toBe('ALTER TABLE "data_table_user_abc" ADD "email" DOUBLE PRECISION');
+		});
+
+		it('should use TIMESTAMPTZ for date columns in postgres to preserve timezone info', () => {
+			const tableName = 'data_table_user_abc';
+			const column = { name: 'birthday', type: 'date' as const };
+
+			const query = addColumnQuery(tableName, column, 'postgres');
+
+			expect(query).toBe('ALTER TABLE "data_table_user_abc" ADD "birthday" TIMESTAMPTZ');
+		});
+
+		it('should use DATETIME for date columns in sqlite', () => {
+			const tableName = 'data_table_user_abc';
+			const column = { name: 'birthday', type: 'date' as const };
+
+			const query = addColumnQuery(tableName, column, 'sqlite');
+
+			expect(query).toBe('ALTER TABLE "data_table_user_abc" ADD "birthday" DATETIME');
 		});
 	});
 

--- a/packages/cli/src/modules/data-table/utils/sql-utils.ts
+++ b/packages/cli/src/modules/data-table/utils/sql-utils.ts
@@ -61,7 +61,7 @@ function dataTableColumnTypeToSql(
 			return 'BOOLEAN';
 		case 'date':
 			if (dbType === 'postgres') {
-				return 'TIMESTAMP';
+				return 'TIMESTAMPTZ';
 			}
 			return 'DATETIME';
 		default:
@@ -205,8 +205,15 @@ export function normalizeDate(value: unknown): Date | null {
 	if (value instanceof Date) return value;
 
 	if (typeof value === 'string') {
-		// sqlite returns date strings without timezone information, but we store them as UTC
-		const parsed = new Date(value.endsWith('Z') ? value : value + 'Z');
+		// SQLite returns date strings without timezone info; Postgres TIMESTAMP (legacy) returns
+		// space-separated strings like "2026-05-19 18:15:00.000000". Normalize both to valid ISO
+		// before appending 'Z' to treat as UTC, since we always store in UTC.
+		const normalized = value.includes('T') ? value : value.replace(' ', 'T');
+		const withZ =
+			normalized.endsWith('Z') || /[+-]\d{2}:\d{2}$/.test(normalized)
+				? normalized
+				: normalized + 'Z';
+		const parsed = new Date(withZ);
 		if (!isNaN(parsed.getTime())) return parsed;
 	}
 


### PR DESCRIPTION
## Summary

When adding a date column to an existing Data Table in Postgres, the column was                                                                                                                         
  created as `TIMESTAMP` (without timezone) instead of `TIMESTAMPTZ`. This caused
  a timezone-offset shift bug on every page refresh:                                                                                                                                                      
                                                                                                                                                                                                          
  - User enters `2026-05-19T15:15:00.000-03:00`                                                                                                                                                           
  - After refresh it becomes `2026-05-19T18:15:00.000-03:00` (+3h shifted)                                                                                                                                
  - The Get Row(s) node returns `2026-05-19T21:15:00.000Z` instead of `2026-05-19T18:15:00.000Z`                                                                                                          
                                                                                                                                                                                                          
  **Root cause:** The `pg` driver returns `TIMESTAMP` columns as raw strings (e.g.                                                                                                                        
  `"2026-05-19 18:15:00.000000"`) without timezone info. The browser treats these                                                                                                                         
  as local time instead of UTC, causing the repeated offset shift. `TIMESTAMPTZ`                                                                                                                          
  columns are returned as proper JS `Date` objects, which serialize correctly.                                                                                                                            
                                                                                                                                                                                                          
  **Fix:**                                                                                                                                                                                                
  - Changed `dataTableColumnTypeToSql()` to use `TIMESTAMPTZ` for Postgres date columns,                                                                                                                  
    making `addColumn` consistent with `createTableWithColumns` (which already used `TIMESTAMPTZ`)                                                                                                        
  - Hardened `normalizeDate()` to handle space-separated Postgres TIMESTAMP strings                                                                                                                       
    with microsecond precision as a fallback for legacy columns                                                                                                                                           
                                                                                                                                                                                                          
  **Note:** A database migration to convert existing `TIMESTAMP` date columns to                                                                                                                          
  `TIMESTAMPTZ` is still needed for deployments created before this fix. Happy to                                                                                                                         
  add it if the team can point me to the right migration pattern for dynamic user tables.                                                                                                                 
                                                                                                                                                                                                          
  ## Related Linear tickets, Github issues, and Community forum posts                                                                                                                                     
                                                                                                                                                                                                          
  fixes #30752                                                                                                                                                                              
                                                                                                                                                                                                        
  ## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.                                                                                                           
  - [x] PR title and summary are descriptive.                                                                                                                                                             
  - [ ] Docs updated or follow-up ticket created.
  - [x] Tests included.                                                                                                                                                                                   
  - [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` 