### PR TITLE
feat(ai-builder): Add binary checks to exec evals (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -454,7 +454,8 @@ Test cases live in `evaluations/data/workflows/*.json`. Drop a file in, the CLI 
       "name": "happy-path",
       "description": "Normal operation",
       "dataSetup": "The webhook receives a submission from Jane (jane@example.com)...",
-      "successCriteria": "The workflow executes without errors. An email is sent to jane@example.com..."
+      "successCriteria": "The workflow executes without errors. An email is sent to jane@example.com...",
+      "binaryChecks": ["has_trigger", "all_nodes_connected", "no_empty_set_nodes"]
     }
   ]
 }
@@ -481,6 +482,29 @@ Test cases live in `evaluations/data/workflows/*.json`. Drop a file in, the CLI 
 - Edge cases — empty data, missing fields, single vs multiple items
 - Error scenarios only if the workflow is expected to handle them gracefully. Most agent-built workflows don't include error handling, so "the workflow crashes on invalid input" is a legitimate finding, not a test-case failure.
 
+### Binary checks per scenario
+
+Scenarios can opt into deterministic pass/fail checks on the built workflow JSON via `binaryChecks: string[]`. Each name resolves against the registry in `binaryChecks/checks/index.ts`. Unknown names are rejected at fixture-load time, before the harness spins up any containers.
+
+A binary-check failure is **authoritative** — it overrides the LLM verifier's verdict, flips the scenario to `success: false`, sets `failureCategory: 'binary_check_failure'`, and prefixes the verifier's reasoning with the failed check names. The verifier still runs; it just doesn't get to declare success on a structurally broken workflow.
+
+Both **deterministic** and **LLM-based** checks (e.g. `fulfills_user_request`, `valid_data_flow`) work — LLM checks reuse the same Sonnet model the verifier already uses, so no extra configuration is needed. Cost is bounded by per-scenario opt-in: an LLM check only runs when its name appears in `binaryChecks`.
+
+Pick the subset that matters for the workflow you're testing. A reasonable default for new fixtures:
+
+```json
+"binaryChecks": [
+  "has_nodes",
+  "has_trigger",
+  "all_nodes_connected",
+  "no_empty_set_nodes",
+  "no_hardcoded_credentials",
+  "valid_field_references"
+]
+```
+
+The full list of available checks lives next to the implementations in `binaryChecks/checks/`.
+
 ### Adding a new credential type
 
 `credentials/seeder.ts` seeds generic creds (HTTP Header, HTTP Basic) on every run, plus env-gated creds (GitHub, Gmail, Teams, Linear…) when the matching env var is set. If your scenario needs a credential type that isn't there, add it to the appropriate list in `seeder.ts` — env-gated if it requires a real token, generic if a placeholder is fine.
@@ -494,6 +518,7 @@ When a scenario fails, the verifier categorizes the root cause:
 - **framework_issue** — Phase 1 failed (empty trigger content) or the eval framework itself cascaded an error.
 - **verification_failure** — the verifier couldn't produce a valid result.
 - **build_failure** — Instance AI failed to build the workflow or a scenario timed out.
+- **binary_check_failure** — a deterministic check listed in `scenario.binaryChecks` returned `pass: false`. Distinct from `builder_issue` (assigned by the LLM verifier).
 
 Suite pass rates typically sit between 40–65%; most failures are `builder_issue` on scenarios that require error handling the agent doesn't produce by default.
 

--- a/packages/@n8n/instance-ai/evaluations/__tests__/data-workflows-binary-checks.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/data-workflows-binary-checks.test.ts
@@ -1,0 +1,69 @@
+jest.mock('fs', () => ({
+	readdirSync: jest.fn(),
+	readFileSync: jest.fn(),
+}));
+
+import { readdirSync, readFileSync } from 'fs';
+
+import { loadWorkflowTestCasesWithFiles } from '../data/workflows';
+
+const mockedReaddir = jest.mocked(readdirSync);
+const mockedReadFile = jest.mocked(readFileSync);
+
+function makeTestCaseJson(binaryChecks?: unknown): string {
+	return JSON.stringify({
+		prompt: 'build it',
+		complexity: 'simple',
+		tags: ['t'],
+		scenarios: [
+			{
+				name: 'happy-path',
+				description: 'normal',
+				dataSetup: 'webhook gets a submission',
+				successCriteria: 'all good',
+				...(binaryChecks !== undefined ? { binaryChecks } : {}),
+			},
+		],
+	});
+}
+
+beforeEach(() => {
+	jest.clearAllMocks();
+	mockedReaddir.mockReturnValue(['contact.json'] as unknown as ReturnType<typeof readdirSync>);
+});
+
+describe('loadWorkflowTestCasesWithFiles binary-check validation', () => {
+	it('loads a fixture with no binaryChecks unchanged', () => {
+		mockedReadFile.mockReturnValue(makeTestCaseJson());
+		const result = loadWorkflowTestCasesWithFiles();
+		expect(result).toHaveLength(1);
+		expect(result[0].testCase.scenarios[0].binaryChecks).toBeUndefined();
+	});
+
+	it('loads a fixture with known binaryChecks', () => {
+		// Pick names that are definitely in the registry.
+		mockedReadFile.mockReturnValue(makeTestCaseJson(['has_nodes', 'all_nodes_connected']));
+		const result = loadWorkflowTestCasesWithFiles();
+		expect(result[0].testCase.scenarios[0].binaryChecks).toEqual([
+			'has_nodes',
+			'all_nodes_connected',
+		]);
+	});
+
+	it('throws with file slug and scenario name when an unknown binary check is requested', () => {
+		mockedReadFile.mockReturnValue(makeTestCaseJson(['this_check_does_not_exist']));
+		expect(() => loadWorkflowTestCasesWithFiles()).toThrow(/contact\.json/);
+		expect(() => loadWorkflowTestCasesWithFiles()).toThrow(/happy-path/);
+		expect(() => loadWorkflowTestCasesWithFiles()).toThrow(/this_check_does_not_exist/);
+	});
+
+	it('throws when binaryChecks is not an array of strings', () => {
+		mockedReadFile.mockReturnValue(makeTestCaseJson(42 as unknown));
+		expect(() => loadWorkflowTestCasesWithFiles()).toThrow(/Invalid test case/);
+	});
+
+	it('throws with the offending file path on malformed JSON', () => {
+		mockedReadFile.mockReturnValue('{ not json');
+		expect(() => loadWorkflowTestCasesWithFiles()).toThrow(/contact\.json/);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/__tests__/data-workflows.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/data-workflows.test.ts
@@ -25,7 +25,14 @@ const STUB_TEST_CASE = JSON.stringify({
 	prompt: 'stub',
 	complexity: 'simple',
 	tags: [],
-	scenarios: [],
+	scenarios: [
+		{
+			name: 'happy-path',
+			description: 'stub',
+			dataSetup: 'stub',
+			successCriteria: 'stub',
+		},
+	],
 });
 
 beforeEach(() => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/runner-binary-checks.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/runner-binary-checks.test.ts
@@ -1,0 +1,236 @@
+jest.mock('../checklist/verifier', () => ({
+	verifyChecklist: jest.fn(),
+}));
+
+jest.mock('../binaryChecks/index', () => ({
+	runBinaryChecks: jest.fn(),
+}));
+
+import { SONNET_MODEL } from '../../src/utils/eval-agents';
+import { runBinaryChecks } from '../binaryChecks/index';
+import { verifyChecklist } from '../checklist/verifier';
+import type { N8nClient, WorkflowResponse } from '../clients/n8n-client';
+import type { EvalLogger } from '../harness/logger';
+import { executeScenario } from '../harness/runner';
+import type { TestScenario } from '../types';
+
+const mockedRunBinaryChecks = jest.mocked(runBinaryChecks);
+const mockedVerifyChecklist = jest.mocked(verifyChecklist);
+
+const silentLogger: EvalLogger = {
+	info: jest.fn(),
+	verbose: jest.fn(),
+	success: jest.fn(),
+	warn: jest.fn(),
+	error: jest.fn(),
+	isVerbose: false,
+};
+
+function makeClient(): N8nClient {
+	return {
+		executeWithLlmMock: jest.fn().mockResolvedValue({
+			success: true,
+			errors: [],
+			hints: { warnings: [], triggerContent: { foo: 'bar' }, globalContext: '', nodeHints: {} },
+			nodeResults: {},
+		}),
+	} as unknown as N8nClient;
+}
+
+function makeScenario(overrides: Partial<TestScenario> = {}): TestScenario {
+	return {
+		name: 'happy-path',
+		description: 'normal',
+		dataSetup: 'webhook gets a submission',
+		successCriteria: 'all good',
+		...overrides,
+	};
+}
+
+const fakeWorkflow = {
+	id: 'W1',
+	name: 'Test Workflow',
+	nodes: [],
+	connections: {},
+} as unknown as WorkflowResponse;
+
+beforeEach(() => {
+	jest.clearAllMocks();
+});
+
+describe('executeScenario binary check integration', () => {
+	it('does not call runBinaryChecks when scenario.binaryChecks is undefined', async () => {
+		mockedVerifyChecklist.mockResolvedValue([
+			{ id: 1, pass: true, reasoning: 'ok', strategy: 'llm' },
+		]);
+
+		const result = await executeScenario(
+			makeClient(),
+			'W1',
+			makeScenario(),
+			[fakeWorkflow],
+			'user prompt',
+			silentLogger,
+		);
+
+		expect(mockedRunBinaryChecks).not.toHaveBeenCalled();
+		expect(result.success).toBe(true);
+		expect(result.binaryCheckResults).toBeUndefined();
+	});
+
+	it('does not call runBinaryChecks when binaryChecks is empty', async () => {
+		mockedVerifyChecklist.mockResolvedValue([
+			{ id: 1, pass: true, reasoning: 'ok', strategy: 'llm' },
+		]);
+
+		await executeScenario(
+			makeClient(),
+			'W1',
+			makeScenario({ binaryChecks: [] }),
+			[fakeWorkflow],
+			'user prompt',
+			silentLogger,
+		);
+
+		expect(mockedRunBinaryChecks).not.toHaveBeenCalled();
+	});
+
+	it('calls runBinaryChecks with the user prompt, model, requested checks, and annotations', async () => {
+		mockedVerifyChecklist.mockResolvedValue([
+			{ id: 1, pass: true, reasoning: 'ok', strategy: 'llm' },
+		]);
+		mockedRunBinaryChecks.mockResolvedValue([
+			{ evaluator: 'binary-checks', metric: 'has_nodes', kind: 'metric', score: 1 },
+			{ evaluator: 'binary-checks', metric: 'pass_rate', kind: 'score', score: 1 },
+		]);
+
+		await executeScenario(
+			makeClient(),
+			'W1',
+			makeScenario({
+				binaryChecks: ['has_nodes'],
+				annotations: { code_necessary: true },
+			}),
+			[fakeWorkflow],
+			'user prompt',
+			silentLogger,
+		);
+
+		expect(mockedRunBinaryChecks).toHaveBeenCalledTimes(1);
+		const [workflow, ctx, options] = mockedRunBinaryChecks.mock.calls[0];
+		expect(workflow).toBe(fakeWorkflow);
+		expect(ctx).toEqual({
+			prompt: 'user prompt',
+			modelId: SONNET_MODEL,
+			annotations: { code_necessary: true },
+		});
+		expect(options).toEqual({ only: ['has_nodes'] });
+	});
+
+	it('strips the pass_rate aggregate from binaryCheckResults', async () => {
+		mockedVerifyChecklist.mockResolvedValue([
+			{ id: 1, pass: true, reasoning: 'ok', strategy: 'llm' },
+		]);
+		mockedRunBinaryChecks.mockResolvedValue([
+			{ evaluator: 'binary-checks', metric: 'has_nodes', kind: 'metric', score: 1 },
+			{
+				evaluator: 'binary-checks',
+				metric: 'has_trigger',
+				kind: 'metric',
+				score: 0,
+				comment: 'no trigger',
+			},
+			{ evaluator: 'binary-checks', metric: 'pass_rate', kind: 'score', score: 0.5 },
+		]);
+
+		const result = await executeScenario(
+			makeClient(),
+			'W1',
+			makeScenario({ binaryChecks: ['has_nodes', 'has_trigger'] }),
+			[fakeWorkflow],
+			'user prompt',
+			silentLogger,
+		);
+
+		expect(result.binaryCheckResults).toEqual([
+			{ name: 'has_nodes', pass: true },
+			{ name: 'has_trigger', pass: false, comment: 'no trigger' },
+		]);
+	});
+
+	it('flips a verifier-passing scenario to failure when a binary check fails', async () => {
+		mockedVerifyChecklist.mockResolvedValue([
+			{ id: 1, pass: true, reasoning: 'verifier said ok', strategy: 'llm' },
+		]);
+		mockedRunBinaryChecks.mockResolvedValue([
+			{
+				evaluator: 'binary-checks',
+				metric: 'all_nodes_connected',
+				kind: 'metric',
+				score: 0,
+				comment: 'Disconnected: Set',
+			},
+		]);
+
+		const result = await executeScenario(
+			makeClient(),
+			'W1',
+			makeScenario({ binaryChecks: ['all_nodes_connected'] }),
+			[fakeWorkflow],
+			'user prompt',
+			silentLogger,
+		);
+
+		expect(result.success).toBe(false);
+		expect(result.score).toBe(0);
+		expect(result.failureCategory).toBe('binary_check_failure');
+		expect(result.reasoning).toContain('all_nodes_connected');
+		expect(result.reasoning).toContain('verifier said ok');
+	});
+
+	it('marks every requested check failed when runBinaryChecks throws', async () => {
+		mockedVerifyChecklist.mockResolvedValue([
+			{ id: 1, pass: true, reasoning: 'ok', strategy: 'llm' },
+		]);
+		mockedRunBinaryChecks.mockRejectedValue(new Error('registry exploded'));
+
+		const result = await executeScenario(
+			makeClient(),
+			'W1',
+			makeScenario({ binaryChecks: ['has_nodes', 'has_trigger'] }),
+			[fakeWorkflow],
+			'user prompt',
+			silentLogger,
+		);
+
+		expect(result.binaryCheckResults).toEqual([
+			{ name: 'has_nodes', pass: false, comment: 'Runner error: registry exploded' },
+			{ name: 'has_trigger', pass: false, comment: 'Runner error: registry exploded' },
+		]);
+		expect(result.success).toBe(false);
+		expect(result.failureCategory).toBe('binary_check_failure');
+	});
+
+	it('preserves verifier success when all binary checks pass', async () => {
+		mockedVerifyChecklist.mockResolvedValue([
+			{ id: 1, pass: true, reasoning: 'ok', strategy: 'llm' },
+		]);
+		mockedRunBinaryChecks.mockResolvedValue([
+			{ evaluator: 'binary-checks', metric: 'has_nodes', kind: 'metric', score: 1 },
+		]);
+
+		const result = await executeScenario(
+			makeClient(),
+			'W1',
+			makeScenario({ binaryChecks: ['has_nodes'] }),
+			[fakeWorkflow],
+			'user prompt',
+			silentLogger,
+		);
+
+		expect(result.success).toBe(true);
+		expect(result.score).toBe(1);
+		expect(result.failureCategory).toBeUndefined();
+		expect(result.binaryCheckResults).toEqual([{ name: 'has_nodes', pass: true }]);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/__tests__/schema.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/schema.test.ts
@@ -1,0 +1,75 @@
+import { TestScenarioSchema, WorkflowTestCaseSchema } from '../data/workflows/schema';
+
+const minimalScenario = {
+	name: 'happy-path',
+	description: 'normal',
+	dataSetup: 'webhook gets a submission',
+	successCriteria: 'all good',
+};
+
+const minimalTestCase = {
+	prompt: 'build me a thing',
+	complexity: 'simple' as const,
+	tags: ['test'],
+	scenarios: [minimalScenario],
+};
+
+describe('TestScenarioSchema', () => {
+	it('accepts a minimal scenario without binaryChecks', () => {
+		expect(TestScenarioSchema.parse(minimalScenario)).toEqual(minimalScenario);
+	});
+
+	it('accepts binaryChecks as a string array', () => {
+		const sc = { ...minimalScenario, binaryChecks: ['has_nodes', 'has_trigger'] };
+		expect(TestScenarioSchema.parse(sc).binaryChecks).toEqual(['has_nodes', 'has_trigger']);
+	});
+
+	it('rejects binaryChecks of the wrong type', () => {
+		const sc = { ...minimalScenario, binaryChecks: 42 };
+		expect(() => TestScenarioSchema.parse(sc)).toThrow();
+	});
+
+	it('rejects binaryChecks whose entries are not strings', () => {
+		const sc = { ...minimalScenario, binaryChecks: ['has_nodes', 7] };
+		expect(() => TestScenarioSchema.parse(sc)).toThrow();
+	});
+
+	it('accepts annotations as an arbitrary record', () => {
+		const sc = { ...minimalScenario, annotations: { code_necessary: true } };
+		expect(TestScenarioSchema.parse(sc).annotations).toEqual({ code_necessary: true });
+	});
+
+	it('accepts the informational requires field', () => {
+		const sc = { ...minimalScenario, requires: 'mock-server' };
+		expect(TestScenarioSchema.parse(sc).requires).toBe('mock-server');
+	});
+
+	it('rejects scenarios missing required fields', () => {
+		const bad = { ...minimalScenario, name: '' };
+		expect(() => TestScenarioSchema.parse(bad)).toThrow();
+	});
+});
+
+describe('WorkflowTestCaseSchema', () => {
+	it('accepts a minimal valid case', () => {
+		expect(WorkflowTestCaseSchema.parse(minimalTestCase)).toEqual(minimalTestCase);
+	});
+
+	it('rejects an empty scenarios array', () => {
+		expect(() => WorkflowTestCaseSchema.parse({ ...minimalTestCase, scenarios: [] })).toThrow();
+	});
+
+	it('rejects unknown complexity values', () => {
+		expect(() =>
+			WorkflowTestCaseSchema.parse({ ...minimalTestCase, complexity: 'gigantic' }),
+		).toThrow();
+	});
+
+	it('propagates binaryChecks from nested scenarios', () => {
+		const tc = {
+			...minimalTestCase,
+			scenarios: [{ ...minimalScenario, binaryChecks: ['has_trigger'] }],
+		};
+		expect(WorkflowTestCaseSchema.parse(tc).scenarios[0].binaryChecks).toEqual(['has_trigger']);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/__tests__/score-folder.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/score-folder.test.ts
@@ -1,0 +1,56 @@
+import { applyBinaryCheckResults, BINARY_CHECK_FAILURE_CATEGORY } from '../harness/score-folder';
+import type { BinaryCheckOutcome } from '../types';
+
+const passing: BinaryCheckOutcome = { name: 'has_nodes', pass: true };
+const failingA: BinaryCheckOutcome = { name: 'has_trigger', pass: false, comment: 'no trigger' };
+const failingB: BinaryCheckOutcome = { name: 'all_nodes_connected', pass: false };
+
+const verifierPass = {
+	success: true,
+	score: 1,
+	reasoning: 'looks fine',
+	failureCategory: undefined,
+};
+
+const verifierFail = {
+	success: false,
+	score: 0,
+	reasoning: 'missing email send',
+	failureCategory: 'builder_issue',
+};
+
+describe('applyBinaryCheckResults', () => {
+	it('returns base unchanged when no binary checks were run', () => {
+		expect(applyBinaryCheckResults(verifierPass, undefined)).toEqual(verifierPass);
+		expect(applyBinaryCheckResults(verifierFail, undefined)).toEqual(verifierFail);
+	});
+
+	it('returns base unchanged when the binary array is empty', () => {
+		expect(applyBinaryCheckResults(verifierPass, [])).toEqual(verifierPass);
+	});
+
+	it('returns base unchanged when every binary check passed', () => {
+		expect(applyBinaryCheckResults(verifierPass, [passing, passing])).toEqual(verifierPass);
+	});
+
+	it('flips a verifier-passing scenario to failure when any binary check failed', () => {
+		const folded = applyBinaryCheckResults(verifierPass, [passing, failingA]);
+		expect(folded.success).toBe(false);
+		expect(folded.score).toBe(0);
+		expect(folded.failureCategory).toBe(BINARY_CHECK_FAILURE_CATEGORY);
+		expect(folded.reasoning).toContain('has_trigger');
+		expect(folded.reasoning).toContain('Verifier: looks fine');
+	});
+
+	it('lists every failing check name in the reasoning prefix', () => {
+		const folded = applyBinaryCheckResults(verifierPass, [failingA, failingB, passing]);
+		expect(folded.reasoning).toContain('has_trigger');
+		expect(folded.reasoning).toContain('all_nodes_connected');
+	});
+
+	it('overrides an existing failureCategory when binary checks fail', () => {
+		const folded = applyBinaryCheckResults(verifierFail, [failingA]);
+		expect(folded.failureCategory).toBe(BINARY_CHECK_FAILURE_CATEGORY);
+		expect(folded.reasoning).toContain('Verifier: missing email send');
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -65,6 +65,12 @@ import type {
 // n8n degrades above ~4 concurrent builds.
 const MAX_CONCURRENT_BUILDS = 4;
 
+const binaryCheckOutcomeSchema = z.object({
+	name: z.string(),
+	pass: z.boolean(),
+	comment: z.string().optional(),
+});
+
 const targetOutputSchema = z.object({
 	buildSuccess: z.boolean().default(false),
 	passed: z.boolean().default(false),
@@ -75,6 +81,7 @@ const targetOutputSchema = z.object({
 	rootCause: z.string().optional(),
 	execErrors: z.array(z.string()).default([]),
 	evalResult: z.unknown().optional(),
+	binaryCheckResults: z.array(binaryCheckOutcomeSchema).optional(),
 	/** Only set on the scenario that initiated the build. */
 	buildDurationMs: z.number().optional(),
 	execDurationMs: z.number().default(0),
@@ -279,6 +286,7 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 			workflowId: string;
 			scenario: TestScenario;
 			workflowJsons: BuildResult['workflowJsons'];
+			prompt: string;
 		}) => Promise<Awaited<ReturnType<typeof executeScenario>>>;
 	}
 
@@ -312,12 +320,14 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 					workflowId: string;
 					scenario: TestScenario;
 					workflowJsons: BuildResult['workflowJsons'];
+					prompt: string;
 				}) =>
 					await executeScenario(
 						lane.client,
 						execArgs.workflowId,
 						execArgs.scenario,
 						execArgs.workflowJsons,
+						execArgs.prompt,
 						logger,
 						args.timeoutMs,
 					),
@@ -421,6 +431,7 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 				workflowId: build.workflowId,
 				scenario,
 				workflowJsons: build.workflowJsons,
+				prompt: inputs.prompt,
 			});
 		} catch (error: unknown) {
 			// Mirror direct mode's per-scenario guard — without this, n8n API errors
@@ -459,6 +470,7 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 			rootCause,
 			execErrors: result.evalResult?.errors ?? [],
 			evalResult: result.evalResult,
+			binaryCheckResults: result.binaryCheckResults,
 			buildDurationMs,
 			execDurationMs,
 			nodeCount,
@@ -788,6 +800,7 @@ function reshapeLangSmithRuns(
 					reasoning: output.reasoning,
 					failureCategory: output.failureCategory,
 					rootCause: output.rootCause,
+					...(output.binaryCheckResults ? { binaryCheckResults: output.binaryCheckResults } : {}),
 				});
 			}
 
@@ -933,6 +946,45 @@ function computeAggregateMetrics(evaluation: MultiRunEvaluation): AggregateMetri
 	};
 }
 
+/**
+ * Aggregate binary-check pass/fail across every scenario run. Returns
+ * `undefined` when no scenario in the run requested any binary checks — keeps
+ * older results consistent and lets PR-comment / report renderers skip the
+ * section entirely.
+ */
+function computeBinaryCheckSummary(
+	evaluation: MultiRunEvaluation,
+):
+	| {
+			totalChecksRun: number;
+			totalChecksPassed: number;
+			perCheck: Record<string, { runs: number; passes: number }>;
+	  }
+	| undefined {
+	const perCheck: Record<string, { runs: number; passes: number }> = {};
+	let totalChecksRun = 0;
+	let totalChecksPassed = 0;
+
+	for (const tc of evaluation.testCases) {
+		for (const sa of tc.scenarios) {
+			for (const sr of sa.runs) {
+				if (!sr.binaryCheckResults) continue;
+				for (const r of sr.binaryCheckResults) {
+					const entry = perCheck[r.name] ?? { runs: 0, passes: 0 };
+					entry.runs++;
+					if (r.pass) entry.passes++;
+					perCheck[r.name] = entry;
+					totalChecksRun++;
+					if (r.pass) totalChecksPassed++;
+				}
+			}
+		}
+	}
+
+	if (totalChecksRun === 0) return undefined;
+	return { totalChecksRun, totalChecksPassed, perCheck };
+}
+
 /** Pass rate of each iteration formatted as e.g. "37% / 37% / 37%". */
 function computePassRatePerIter(evaluation: MultiRunEvaluation): string {
 	const { totalRuns, testCases } = evaluation;
@@ -959,6 +1011,7 @@ function writeEvalResults(
 	const metrics = computeAggregateMetrics(evaluation);
 
 	const result = outcome?.kind === 'ok' ? outcome.result : undefined;
+	const binaryChecksSummary = computeBinaryCheckSummary(evaluation);
 
 	const report = {
 		timestamp: new Date().toISOString(),
@@ -972,6 +1025,7 @@ function writeEvalResults(
 			passAtK: metrics.passAtK,
 			passHatK: metrics.passHatK,
 			passRatePerIter: metrics.passRatePerIter,
+			...(binaryChecksSummary ? { binaryChecks: binaryChecksSummary } : {}),
 		},
 		// Structured comparison payload only — the rendered markdown lives in
 		// the sibling `eval-pr-comment.md` file so consumers can pick the format
@@ -1004,6 +1058,7 @@ function writeEvalResults(
 					rootCause: sr.rootCause,
 					execErrors: sr.evalResult?.errors ?? [],
 					evalResult: sr.evalResult,
+					...(sr.binaryCheckResults ? { binaryChecks: sr.binaryCheckResults } : {}),
 				})),
 			})),
 		})),

--- a/packages/@n8n/instance-ai/evaluations/comparison/format.ts
+++ b/packages/@n8n/instance-ai/evaluations/comparison/format.ts
@@ -126,6 +126,9 @@ export function formatComparisonMarkdown(
 
 	lines.push(...renderPerTestCaseDetails(evaluation, options.slugByTestCase));
 
+	const binaryChecksSection = renderBinaryChecksSection(evaluation);
+	if (binaryChecksSection.length > 0) lines.push(...binaryChecksSection);
+
 	if (comparison) {
 		const otherFindings = renderOtherFindings(comparison);
 		if (otherFindings.length > 0) lines.push(...otherFindings);
@@ -407,6 +410,45 @@ function renderPerTestCaseDetails(
 	}
 	lines.push('');
 	lines.push('</details>');
+	lines.push('');
+	return lines;
+}
+
+/**
+ * Pass-rate breakdown per binary check across every scenario run that requested
+ * one. Returns empty when no scenario asked for binary checks, so older runs
+ * and runs whose fixtures opted out don't show a blank section.
+ */
+function renderBinaryChecksSection(evaluation: MultiRunEvaluation): string[] {
+	const perCheck = new Map<string, { runs: number; passes: number }>();
+	for (const tc of evaluation.testCases) {
+		for (const sa of tc.scenarios) {
+			for (const sr of sa.runs) {
+				if (!sr.binaryCheckResults) continue;
+				for (const r of sr.binaryCheckResults) {
+					const entry = perCheck.get(r.name) ?? { runs: 0, passes: 0 };
+					entry.runs++;
+					if (r.pass) entry.passes++;
+					perCheck.set(r.name, entry);
+				}
+			}
+		}
+	}
+	if (perCheck.size === 0) return [];
+
+	const lines: string[] = [
+		'#### Binary checks',
+		'',
+		'| Check | Runs | Pass rate |',
+		'|---|---|---|',
+	];
+	const sortedNames = [...perCheck.keys()].sort();
+	for (const name of sortedNames) {
+		const entry = perCheck.get(name);
+		if (!entry) continue;
+		const pct = entry.runs > 0 ? Math.round((entry.passes / entry.runs) * 100) : 0;
+		lines.push(`| ${name} | ${String(entry.runs)} | ${String(pct)}% |`);
+	}
 	lines.push('');
 	return lines;
 }

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/contact-form-automation.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/contact-form-automation.json
@@ -8,7 +8,16 @@
 			"name": "happy-path",
 			"description": "A valid contact form submission triggers all 3 actions",
 			"dataSetup": "The webhook receives a contact form submission from Jane Smith (jane@example.com) with the message 'I am interested in your enterprise plan, can you send me more details?'. The Gmail, Telegram, and Google Sheets nodes return success responses.",
-			"successCriteria": "The workflow executes without errors. The webhook returns a response acknowledging the submission. An auto-reply email is sent to jane@example.com. A Telegram notification is sent containing the submission details (name, email, message). The submission is logged to Google Sheets with the form fields. All 3 actions receive the data from the webhook trigger."
+			"successCriteria": "The workflow executes without errors. The webhook returns a response acknowledging the submission. An auto-reply email is sent to jane@example.com. A Telegram notification is sent containing the submission details (name, email, message). The submission is logged to Google Sheets with the form fields. All 3 actions receive the data from the webhook trigger.",
+			"binaryChecks": [
+				"has_nodes",
+				"has_trigger",
+				"all_nodes_connected",
+				"no_empty_set_nodes",
+				"no_hardcoded_credentials",
+				"no_invalid_from_ai",
+				"valid_field_references"
+			]
 		},
 		{
 			"name": "missing-fields",

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/index.ts
@@ -1,6 +1,8 @@
 import { readFileSync, readdirSync } from 'fs';
 import { basename, join } from 'path';
 
+import { WorkflowTestCaseSchema } from './schema';
+import { DETERMINISTIC_CHECKS, LLM_CHECKS } from '../../binaryChecks/checks';
 import type { WorkflowTestCase } from '../../types';
 
 export interface WorkflowTestCaseWithFile {
@@ -9,15 +11,42 @@ export interface WorkflowTestCaseWithFile {
 	fileSlug: string;
 }
 
+const KNOWN_BINARY_CHECK_NAMES = new Set(
+	[...DETERMINISTIC_CHECKS, ...LLM_CHECKS].map((c) => c.name),
+);
+
 function parseTestCaseFile(filePath: string): WorkflowTestCase {
 	const content = readFileSync(filePath, 'utf-8');
+
+	let raw: unknown;
 	try {
-		return JSON.parse(content) as WorkflowTestCase;
+		raw = JSON.parse(content);
 	} catch (error) {
 		throw new Error(
 			`Failed to parse test case ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
 		);
 	}
+
+	const parsed = WorkflowTestCaseSchema.safeParse(raw);
+	if (!parsed.success) {
+		const issues = parsed.error.issues
+			.map((i) => `  - ${i.path.join('.')}: ${i.message}`)
+			.join('\n');
+		throw new Error(`Invalid test case ${filePath}:\n${issues}`);
+	}
+
+	for (const sc of parsed.data.scenarios) {
+		const requested = sc.binaryChecks ?? [];
+		const unknown = requested.filter((name) => !KNOWN_BINARY_CHECK_NAMES.has(name));
+		if (unknown.length > 0) {
+			throw new Error(
+				`${filePath}: scenario "${sc.name}" requests unknown binary check(s): ${unknown.join(', ')}. ` +
+					`Available: ${[...KNOWN_BINARY_CHECK_NAMES].sort().join(', ')}`,
+			);
+		}
+	}
+
+	return parsed.data as WorkflowTestCase;
 }
 
 /** Split a comma-separated CLI value into a normalized list of substring tokens. */

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/schema.ts
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/schema.ts
@@ -1,0 +1,33 @@
+// ---------------------------------------------------------------------------
+// Zod schemas for workflow test case fixtures.
+//
+// Fixtures are JSON files under `data/workflows/*.json`. Until now they were
+// parsed with `JSON.parse() as WorkflowTestCase`, which silently accepts
+// malformed shapes. The schema catches typos and missing fields at load time,
+// before the harness spends time on builds or container setup.
+// ---------------------------------------------------------------------------
+
+import { z } from 'zod';
+
+export const TestScenarioSchema = z.object({
+	name: z.string().min(1),
+	description: z.string(),
+	dataSetup: z.string(),
+	successCriteria: z.string(),
+	binaryChecks: z.array(z.string()).optional(),
+	annotations: z.record(z.unknown()).optional(),
+	// `requires: "mock-server"` appears in some fixtures as an informational hint.
+	// Nothing reads it today; accept it so fixtures keep parsing.
+	requires: z.string().optional(),
+});
+
+export const WorkflowTestCaseSchema = z.object({
+	prompt: z.string().min(1),
+	complexity: z.enum(['simple', 'medium', 'complex']),
+	tags: z.array(z.string()),
+	triggerType: z.enum(['manual', 'webhook', 'schedule', 'form']).optional(),
+	scenarios: z.array(TestScenarioSchema).min(1),
+});
+
+export type TestScenarioInput = z.infer<typeof TestScenarioSchema>;
+export type WorkflowTestCaseInput = z.infer<typeof WorkflowTestCaseSchema>;

--- a/packages/@n8n/instance-ai/evaluations/harness/runner.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/runner.ts
@@ -13,11 +13,16 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { SSE_SETTLE_DELAY_MS, startSseConnection, waitForAllActivity } from './chat-loop';
 import { type EvalLogger } from './logger';
 import { fetchPrebuiltBuild } from './prebuilt-workflows';
+import { applyBinaryCheckResults } from './score-folder';
+import { SONNET_MODEL } from '../../src/utils/eval-agents';
+import { runBinaryChecks } from '../binaryChecks/index';
+import type { BinaryCheckContext } from '../binaryChecks/types';
 import { verifyChecklist } from '../checklist/verifier';
 import type { N8nClient, WorkflowResponse } from '../clients/n8n-client';
 import { extractOutcomeFromEvents } from '../outcome/event-parser';
 import { buildAgentOutcome, extractWorkflowIdsFromMessages } from '../outcome/workflow-discovery';
 import type {
+	BinaryCheckOutcome,
 	ChecklistItem,
 	CapturedEvent,
 	ScenarioResult,
@@ -103,6 +108,7 @@ export async function runWorkflowTestCase(
 					build.workflowId!,
 					scenario,
 					build.workflowJsons,
+					testCase.prompt,
 					logger,
 					timeoutMs,
 				);
@@ -288,16 +294,21 @@ export async function buildWorkflow(config: BuildWorkflowConfig): Promise<BuildR
 
 /**
  * Execute a single scenario against a pre-built workflow and verify the result.
+ *
+ * `prompt` is the user-facing prompt the orchestrator received. It is forwarded
+ * to binary checks via `ctx.prompt` so checks that compare workflow against user
+ * intent (e.g. `inbound_trigger_auth_defaults`) can evaluate correctly.
  */
 export async function executeScenario(
 	client: N8nClient,
 	workflowId: string,
 	scenario: TestScenario,
 	workflowJsons: WorkflowResponse[],
+	prompt: string,
 	logger: EvalLogger,
 	timeoutMs?: number,
 ): Promise<ScenarioResult> {
-	return await runScenario(client, scenario, workflowId, workflowJsons, logger, timeoutMs);
+	return await runScenario(client, scenario, workflowId, workflowJsons, prompt, logger, timeoutMs);
 }
 
 /**
@@ -342,6 +353,7 @@ async function runScenario(
 	scenario: TestScenario,
 	workflowId: string,
 	workflowJsons: WorkflowResponse[],
+	prompt: string,
 	logger: EvalLogger,
 	timeoutMs?: number,
 ): Promise<ScenarioResult> {
@@ -353,8 +365,20 @@ async function runScenario(
 		`    [${scenario.name}] exec=${String(Math.round(execMs / 1000))}s (${Object.keys(evalResult.nodeResults).length} nodes)`,
 	);
 
+	const binaryCheckResults = await runScenarioBinaryChecks(
+		scenario,
+		workflowJsons[0],
+		prompt,
+		logger,
+	);
+
 	const verifyStart = Date.now();
-	const verificationArtifact = buildVerificationArtifact(scenario, evalResult, workflowJsons);
+	const verificationArtifact = buildVerificationArtifact(
+		scenario,
+		evalResult,
+		workflowJsons,
+		binaryCheckResults,
+	);
 
 	const scenarioChecklist: ChecklistItem[] = [
 		{
@@ -378,23 +402,90 @@ async function runScenario(
 	const failureCategory = result?.failureCategory ?? (result ? undefined : 'verification_failure');
 	const rootCause = result?.rootCause;
 
-	const categoryLabel = failureCategory ? ` [${failureCategory}]` : '';
-	logger.info(
-		`    [${scenario.name}] ${passed ? 'PASS' : 'FAIL'}${categoryLabel} verify=${String(Math.round(verifyMs / 1000))}s`,
+	const folded = applyBinaryCheckResults(
+		{
+			success: passed,
+			score: passed ? 1 : 0,
+			reasoning,
+			failureCategory,
+		},
+		binaryCheckResults,
 	);
-	if (!passed) {
-		logger.info(`    [${scenario.name}] ${reasoning}`);
+
+	const categoryLabel = folded.failureCategory ? ` [${folded.failureCategory}]` : '';
+	logger.info(
+		`    [${scenario.name}] ${folded.success ? 'PASS' : 'FAIL'}${categoryLabel} verify=${String(Math.round(verifyMs / 1000))}s`,
+	);
+	if (!folded.success) {
+		logger.info(`    [${scenario.name}] ${folded.reasoning}`);
 	}
 
 	return {
 		scenario,
-		success: passed,
+		success: folded.success,
 		evalResult,
-		score: passed ? 1 : 0,
-		reasoning,
-		failureCategory,
+		score: folded.score,
+		reasoning: folded.reasoning,
+		failureCategory: folded.failureCategory,
 		rootCause,
+		...(binaryCheckResults ? { binaryCheckResults } : {}),
 	};
+}
+
+/**
+ * Run the binary checks configured on the scenario, if any. Returns `undefined`
+ * when the scenario doesn't request any so downstream code can distinguish
+ * "didn't ask" from "asked, all passed".
+ *
+ * LLM checks become eligible because we pass the same Sonnet model the verifier
+ * uses; they only fire when listed in `scenario.binaryChecks`, so per-scenario
+ * opt-in keeps the cost bounded.
+ */
+async function runScenarioBinaryChecks(
+	scenario: TestScenario,
+	workflow: WorkflowResponse | undefined,
+	prompt: string,
+	logger: EvalLogger,
+): Promise<BinaryCheckOutcome[] | undefined> {
+	if (!scenario.binaryChecks || scenario.binaryChecks.length === 0) return undefined;
+	if (!workflow) return undefined;
+
+	const ctx: BinaryCheckContext = {
+		prompt,
+		modelId: SONNET_MODEL,
+		...(scenario.annotations ? { annotations: scenario.annotations } : {}),
+	};
+
+	let outcomes: BinaryCheckOutcome[];
+	try {
+		const feedback = await runBinaryChecks(workflow, ctx, { only: scenario.binaryChecks });
+		outcomes = feedback
+			.filter((f) => f.kind === 'metric')
+			.map((f) => ({
+				name: f.metric,
+				pass: f.score === 1,
+				...(f.comment ? { comment: f.comment } : {}),
+			}));
+	} catch (error) {
+		// Defense in depth — unknown names are rejected at fixture load time,
+		// but if `runBinaryChecks` throws anyway, mark every requested check failed.
+		const msg = error instanceof Error ? error.message : String(error);
+		logger.error(`    [${scenario.name}] binary checks errored: ${msg}`);
+		outcomes = scenario.binaryChecks.map((name) => ({
+			name,
+			pass: false,
+			comment: `Runner error: ${msg}`,
+		}));
+	}
+
+	const failed = outcomes.filter((r) => !r.pass);
+	if (failed.length > 0) {
+		logger.info(
+			`    [${scenario.name}] binary checks failed: ${failed.map((f) => f.name).join(', ')}`,
+		);
+	}
+
+	return outcomes;
 }
 
 // ---------------------------------------------------------------------------
@@ -410,6 +501,7 @@ function buildVerificationArtifact(
 	scenario: TestScenario,
 	evalResult: InstanceAiEvalExecutionResult,
 	workflowJsons: WorkflowResponse[],
+	binaryCheckResults?: BinaryCheckOutcome[],
 ): string {
 	const sections: string[] = [];
 
@@ -421,6 +513,18 @@ function buildVerificationArtifact(
 		`**Data setup:** ${scenario.dataSetup}`,
 		'',
 	);
+
+	// --- Binary checks (deterministic ground truth, shown to the verifier as
+	//     informational context — its verdict is still LLM-driven). ---
+	if (binaryCheckResults && binaryCheckResults.length > 0) {
+		sections.push('## Binary checks (deterministic)', '');
+		for (const r of binaryCheckResults) {
+			const status = r.pass ? 'PASS' : 'FAIL';
+			const comment = r.comment ? ` — ${r.comment}` : '';
+			sections.push(`- ${r.name}: ${status}${comment}`);
+		}
+		sections.push('');
+	}
 
 	// --- Pre-analysis: flag known issues programmatically ---
 	const preAnalysis: string[] = [];

--- a/packages/@n8n/instance-ai/evaluations/harness/score-folder.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/score-folder.ts
@@ -1,0 +1,31 @@
+// ---------------------------------------------------------------------------
+// Pure helper: fold binary check results into the scenario state produced by
+// the LLM verifier. Deterministic ground truth wins — any binary failure
+// overrides a verifier PASS verdict.
+// ---------------------------------------------------------------------------
+
+import type { BinaryCheckOutcome, ScenarioResult } from '../types';
+
+export type FoldableScenarioState = Pick<
+	ScenarioResult,
+	'success' | 'score' | 'reasoning' | 'failureCategory'
+>;
+
+export const BINARY_CHECK_FAILURE_CATEGORY = 'binary_check_failure';
+
+export function applyBinaryCheckResults(
+	base: FoldableScenarioState,
+	binaryCheckResults: BinaryCheckOutcome[] | undefined,
+): FoldableScenarioState {
+	if (!binaryCheckResults || binaryCheckResults.length === 0) return base;
+
+	const failed = binaryCheckResults.filter((r) => !r.pass);
+	if (failed.length === 0) return base;
+
+	return {
+		success: false,
+		score: 0,
+		reasoning: `Binary checks failed (${failed.map((f) => f.name).join(', ')}). Verifier: ${base.reasoning}`,
+		failureCategory: BINARY_CHECK_FAILURE_CATEGORY,
+	};
+}

--- a/packages/@n8n/instance-ai/evaluations/report/workflow-report.ts
+++ b/packages/@n8n/instance-ai/evaluations/report/workflow-report.ts
@@ -68,6 +68,7 @@ function renderScenarioDetail(sr: ScenarioResult): string {
 		if (sr.reasoning) {
 			html += `<div class="diagnosis">${escapeHtml(sr.reasoning)}</div>`;
 		}
+		html += renderBinaryChecks(sr);
 		return html;
 	}
 
@@ -78,9 +79,13 @@ function renderScenarioDetail(sr: ScenarioResult): string {
 				? 'warn'
 				: sr.failureCategory === 'mock_issue'
 					? 'fail'
-					: 'info';
+					: sr.failureCategory === 'binary_check_failure'
+						? 'fail'
+						: 'info';
 		html += `<div class="category-badge category-${catClass}">${escapeHtml(sr.failureCategory)}${sr.rootCause ? ': ' + escapeHtml(sr.rootCause) : ''}</div>`;
 	}
+
+	html += renderBinaryChecks(sr);
 
 	// 1. Error — what broke
 	if (sr.evalResult.errors.length > 0) {
@@ -183,6 +188,26 @@ function renderScenarioDetail(sr: ScenarioResult): string {
 		html += '</details>';
 	}
 
+	return html;
+}
+
+function renderBinaryChecks(sr: ScenarioResult): string {
+	if (!sr.binaryCheckResults || sr.binaryCheckResults.length === 0) return '';
+
+	const passCount = sr.binaryCheckResults.filter((r) => r.pass).length;
+	const totalCount = sr.binaryCheckResults.length;
+	const headerCls = passCount === totalCount ? 'pass' : 'fail';
+
+	let html = `<details class="section" ${passCount < totalCount ? 'open' : ''}>`;
+	html += `<summary>Binary checks <span class="${headerCls}">${String(passCount)}/${String(totalCount)} passed</span></summary>`;
+	html += '<ul class="binary-checks">';
+	for (const r of sr.binaryCheckResults) {
+		const icon = r.pass ? '&#10003;' : '&#10007;';
+		const cls = r.pass ? 'pass' : 'fail';
+		const comment = r.comment ? ` — ${escapeHtml(r.comment)}` : '';
+		html += `<li class="${cls}"><span class="scenario-icon ${cls}">${icon}</span> <code>${escapeHtml(r.name)}</code>${comment}</li>`;
+	}
+	html += '</ul></details>';
 	return html;
 }
 

--- a/packages/@n8n/instance-ai/evaluations/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/types.ts
@@ -136,6 +136,19 @@ export interface TestScenario {
 	dataSetup: string;
 	/** Criteria the LLM verifier checks against the execution result */
 	successCriteria: string;
+	/**
+	 * Names of binary checks (see `binaryChecks/checks/index.ts`) to run against the
+	 * built workflow. Each must pass for the scenario to pass; failures override
+	 * the LLM verifier verdict. Unknown names are rejected at fixture load time.
+	 */
+	binaryChecks?: string[];
+	/**
+	 * Per-scenario annotations forwarded as `ctx.annotations` to binary checks.
+	 * Lets fixture authors flag false-positive scenarios (e.g. `code_necessary: true`
+	 * suppresses `no_unnecessary_code_nodes` for prompts where a Code node is the
+	 * right answer).
+	 */
+	annotations?: Record<string, unknown>;
 }
 
 export interface WorkflowTestCase {
@@ -150,6 +163,12 @@ export interface WorkflowTestCase {
 // Workflow test case results
 // ---------------------------------------------------------------------------
 
+export interface BinaryCheckOutcome {
+	name: string;
+	pass: boolean;
+	comment?: string;
+}
+
 export interface ScenarioResult {
 	scenario: TestScenario;
 	success: boolean;
@@ -160,6 +179,8 @@ export interface ScenarioResult {
 	failureCategory?: string;
 	/** Detailed root cause explanation */
 	rootCause?: string;
+	/** Per-check pass/fail; absent when the scenario didn't request any binary checks. */
+	binaryCheckResults?: BinaryCheckOutcome[];
 }
 
 export interface WorkflowTestCaseResult {


### PR DESCRIPTION
## Summary

Wires the existing binary-check suite (`@n8n/instance-ai/evaluations/binaryChecks/`) into the **exec-eval** harness, so checks now run on every scenario in `pnpm eval:instance-ai` — not just in the sub-agent harness.

What changed:

- **Per-scenario opt-in** via a new optional `binaryChecks: string[]` field on `TestScenario`, plus optional `annotations` to flag false-positive cases (e.g. `code_necessary: true`).
- **Fixtures validated with zod** at load time (`data/workflows/schema.ts`) — typos in check names are rejected before the harness spins up containers.
- **Authoritative failure semantics:** any failing check flips the scenario to `success: false`, sets `failureCategory: 'binary_check_failure'`, and prefixes the verifier's reasoning. Folding lives in a pure helper (`harness/score-folder.ts`) for testability.
- **Verifier sees the deterministic ground truth** — the binary results are also injected into the verification artifact under a `## Binary checks` section.
- **Reporting** — per-check results land in `eval-results.json`, the PR comment table, and the HTML report.
- **LLM checks reuse the eval Sonnet model**, so no extra config — but only fire when listed per-scenario, keeping cost bounded.
- **Docs** updated in `evaluations/README.md` with the new field, the failure category, and a sensible default set.
- **Fixture example** added: `contact-form-automation.json` `happy-path` opts into 7 checks as documentation.

### How to test

```bash
# From packages/@n8n/instance-ai/
dotenvx run -f ../../../.env.local -- pnpm eval:instance-ai --filter contact-form --verbose
```

The happy-path scenario should report binary check results in the console and in `.data/workflow-eval-report.html`. To trigger a binary-check failure, add an unknown check name to a fixture — fixture loading should reject it with a clear file + scenario reference.

Unit coverage:

```bash
cd packages/@n8n/instance-ai
pnpm test evaluations/__tests__/schema.test.ts
pnpm test evaluations/__tests__/score-folder.test.ts
pnpm test evaluations/__tests__/runner-binary-checks.test.ts
pnpm test evaluations/__tests__/data-workflows-binary-checks.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

_None — feature driven from conversation._

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI