### PR TITLE
test: Restore updateExistingExecution spy in stopDuringRun test

### DIFF
--- a/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
@@ -405,28 +405,32 @@ describe('ExecutionRepository', () => {
 
 			const updateSpy = jest.spyOn(executionRepository, 'updateExistingExecution');
 
-			const result = await executionRepository.stopDuringRun(mockExecution as IExecutionResponse);
+			try {
+				const result = await executionRepository.stopDuringRun(mockExecution as IExecutionResponse);
 
-			// Verify updateExistingExecution was called with the execution
-			expect(updateSpy).toHaveBeenCalledWith(
-				'123',
-				expect.objectContaining({
-					status: 'canceled',
-					stoppedAt: expect.any(Date),
-					waitTill: null,
-					data: expect.objectContaining({
-						resultData: expect.objectContaining({
-							error: expect.objectContaining({
-								message: 'The execution was cancelled manually',
+				// Verify updateExistingExecution was called with the execution
+				expect(updateSpy).toHaveBeenCalledWith(
+					'123',
+					expect.objectContaining({
+						status: 'canceled',
+						stoppedAt: expect.any(Date),
+						waitTill: null,
+						data: expect.objectContaining({
+							resultData: expect.objectContaining({
+								error: expect.objectContaining({
+									message: 'The execution was cancelled manually',
+								}),
 							}),
 						}),
 					}),
-				}),
-			);
+				);
 
-			// Verify the execution was marked as canceled
-			expect(result.status).toBe('canceled');
-			expect(result.data.resultData.error?.message).toBe('The execution was cancelled manually');
+				// Verify the execution was marked as canceled
+				expect(result.status).toBe('canceled');
+				expect(result.data.resultData.error?.message).toBe('The execution was cancelled manually');
+			} finally {
+				updateSpy.mockRestore();
+			}
 		});
 	});
 


### PR DESCRIPTION
## Summary

The `stopDuringRun` test in `execution.repository.test.ts` installs a `jest.spyOn` on `executionRepository.updateExistingExecution` but never restores it. The top-level `beforeEach` only calls `jest.resetAllMocks()`, which clears mock state but does not restore spies, so the spy stays installed as a stub for the rest of the file.

The follow-up `updateExistingExecution` tests then call the stub instead of the real method, and assertions on `entityManager.transaction` never fire.

The bug was masked while `jest@29.6.2` was the hoisted version in the workspace. Once the pnpm dedupe in #cat-bot/run-26096466756 promoted `jest@29.7.0` to the hoist position, the stub behavior surfaced and two `updateExistingExecution` tests started failing:

- `ExecutionRepository > updateExistingExecution > should update execution and data in transaction on sqlite`
- `ExecutionRepository > updateExistingExecution > should update execution and data in transaction on postgresdb`

## Fix

Wrap the assertions in `try/finally` and call `updateSpy.mockRestore()` so the spy is cleaned up regardless of jest version.

This PR targets the dedupe PR branch (`cat-bot/run-26096466756`) so the test fix lands together with the lockfile changes that expose the regression.

## Test plan

- [x] `pnpm --filter @n8n/db test` passes (280/280)
- [x] `pnpm --filter @n8n/db lint` clean
- [x] `pnpm --filter @n8n/db typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)