### PR TITLE
fix: Disable mcp-registry broken E2E test (no-changelog)

### DIFF
--- a/packages/testing/playwright/tests/e2e/mcp-registry/mcp-registry.spec.ts
+++ b/packages/testing/playwright/tests/e2e/mcp-registry/mcp-registry.spec.ts
@@ -16,7 +16,12 @@ test.describe(
 		annotation: [{ type: 'owner', description: 'AI' }],
 	},
 	() => {
-		test('exposes Notion MCP as a tool with hidden connection fields', async ({ n8n, api }) => {
+		// NODE-5089 - ticket to fix and enable this test again
+		// eslint-disable-next-line playwright/no-skipped-test
+		test.skip('exposes Notion MCP as a tool with hidden connection fields', async ({
+			n8n,
+			api,
+		}) => {
 			await api.seedMcpRegistry();
 			await n8n.start.fromBlankCanvas();
 


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Temporarily disable E2E test that's broken due to seeding issues

The fix will be pushed later separately

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
