### PR TITLE
fix(core): Use coerced name for all expression-extension property lookups (no-changelog)

### DIFF
--- a/packages/@n8n/expression-runtime/src/extensions/__tests__/extend.test.ts
+++ b/packages/@n8n/expression-runtime/src/extensions/__tests__/extend.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+
+import { extend, extendOptional, UNSAFE_PROPERTY_NAMES } from '../extend';
+import { ExpressionExtensionError } from '../expression-extension-error';
+
+/** Returns a safe name on the first toString() call, then `payload` thereafter. */
+function statefulName(payload: string, safeFirstReturn = 'totallyFineName') {
+	let calls = 0;
+	const obj = Object.create(null) as { toString: () => string; calls: () => number };
+	obj.toString = () => {
+		calls += 1;
+		return calls === 1 ? safeFirstReturn : payload;
+	};
+	obj.calls = () => calls;
+	return obj;
+}
+
+describe('extend', () => {
+	describe('property-name resolution is stable across lookup branches', () => {
+		it('does not resolve a callable when functionName.toString() returns different values on successive calls', () => {
+			const k = statefulName('constructor', 'x');
+			const body = 'return "value"';
+
+			let result: unknown;
+			try {
+				result = extend(function () {}, k as unknown as string, [body]);
+			} catch (err) {
+				expect(err).toBeInstanceOf(ExpressionExtensionError);
+				return;
+			}
+
+			expect(typeof result).not.toBe('function');
+		});
+
+		// One case per typed-lookup branch in findExtendedFunction.
+		it.each([
+			['array input', [] as unknown],
+			['string input', 'hello' as unknown],
+			['number input', 42 as unknown],
+			['boolean input', true as unknown],
+			['plain object input', {} as unknown],
+			['ISO-date string input', '2024-01-02T03:04:05.000Z' as unknown],
+			['Date input', new Date() as unknown],
+			['function input', function () {} as unknown],
+		])('returns no callable for stateful functionName across %s', (_label, input) => {
+			const k = statefulName('constructor');
+
+			let returned: unknown;
+			try {
+				returned = extend(input, k as unknown as string, ['return "value"']);
+			} catch (err) {
+				expect(err).toBeInstanceOf(ExpressionExtensionError);
+				return;
+			}
+
+			if (typeof returned === 'function') {
+				let invokeResult: unknown;
+				try {
+					invokeResult = (returned as (...a: unknown[]) => unknown)();
+				} catch {
+					return;
+				}
+				expect(invokeResult).not.toBe('value');
+			}
+		});
+
+		it('extendOptional() returns undefined for stateful functionName', () => {
+			const k = statefulName('constructor', 'x');
+			const found = extendOptional(function () {}, k as unknown as string);
+
+			expect(found).toBeUndefined();
+		});
+	});
+
+	describe('UNSAFE_PROPERTY_NAMES upfront denylist', () => {
+		it.each([...UNSAFE_PROPERTY_NAMES])('rejects direct string property name %s', (badName) => {
+			expect(() => extend([], badName, [])).toThrowError(ExpressionExtensionError);
+			expect(() => extend({}, badName, [])).toThrowError(ExpressionExtensionError);
+			expect(() => extend('s', badName, [])).toThrowError(ExpressionExtensionError);
+		});
+
+		it.each([...UNSAFE_PROPERTY_NAMES])(
+			'rejects name returned on first toString() call: %s',
+			(badName) => {
+				const k = { toString: () => badName };
+				expect(() => extend([], k as unknown as string, [])).toThrowError(ExpressionExtensionError);
+			},
+		);
+	});
+
+	describe('legitimate behaviour preserved', () => {
+		it('still resolves Array.first on real arrays', () => {
+			expect(extend([10, 20, 30], 'first', [])).toBe(10);
+		});
+
+		it('still resolves String.toSnakeCase on real strings', () => {
+			expect(extend('hello world', 'toSnakeCase', [])).toBe('hello_world');
+		});
+
+		it('still resolves the generic isEmpty extension', () => {
+			expect(extend([], 'isEmpty', [])).toBe(true);
+			expect(extend([1], 'isEmpty', [])).toBe(false);
+		});
+	});
+
+	describe('single-evaluation of functionName', () => {
+		// If a lookup branch re-coerced, the second toString() call would
+		// return 'CHANGED_ON_SECOND_CALL' and miss the real `first` extension.
+		it('resolves an extension once and does not re-coerce functionName along the lookup path', () => {
+			const k = statefulName('CHANGED_ON_SECOND_CALL', 'first');
+
+			const result = extend([1, 2, 3], k as unknown as string, []);
+
+			expect(result).toBe(1);
+			expect(k.calls()).toBe(1);
+		});
+	});
+});

--- a/packages/@n8n/expression-runtime/src/extensions/extend.ts
+++ b/packages/@n8n/expression-runtime/src/extensions/extend.ts
@@ -54,7 +54,7 @@ interface FoundFunction {
  * Property names that must never be accessed via expression extensions.
  * Matches the host-side blocklist in packages/workflow/src/utils.ts.
  */
-const UNSAFE_PROPERTY_NAMES = new Set([
+export const UNSAFE_PROPERTY_NAMES = new Set([
 	'__proto__',
 	'prototype',
 	'constructor',
@@ -87,23 +87,23 @@ function findExtendedFunction(input: unknown, functionName: string): FoundFuncti
 	// eslint-disable-next-line @typescript-eslint/no-restricted-types
 	let foundFunction: Function | undefined;
 	if (Array.isArray(input)) {
-		foundFunction = arrayExtensions.functions[functionName];
-	} else if (isDate(input) && functionName !== 'toDate' && functionName !== 'toDateTime') {
+		foundFunction = arrayExtensions.functions[name];
+	} else if (isDate(input) && name !== 'toDate' && name !== 'toDateTime') {
 		// If it's a string date (from $json), convert it to a Date object,
 		// unless that function is `toDate`, since `toDate` does something
 		// very different on date objects
 		input = new Date(input as string);
-		foundFunction = dateExtensions.functions[functionName];
+		foundFunction = dateExtensions.functions[name];
 	} else if (typeof input === 'string') {
-		foundFunction = stringExtensions.functions[functionName];
+		foundFunction = stringExtensions.functions[name];
 	} else if (typeof input === 'number') {
-		foundFunction = numberExtensions.functions[functionName];
+		foundFunction = numberExtensions.functions[name];
 	} else if (input && (DateTime.isDateTime(input) || input instanceof Date)) {
-		foundFunction = dateExtensions.functions[functionName];
+		foundFunction = dateExtensions.functions[name];
 	} else if (input !== null && typeof input === 'object') {
-		foundFunction = objectExtensions.functions[functionName];
+		foundFunction = objectExtensions.functions[name];
 	} else if (typeof input === 'boolean') {
-		foundFunction = booleanExtensions.functions[functionName];
+		foundFunction = booleanExtensions.functions[name];
 	}
 
 	// Look for generic or builtin
@@ -112,13 +112,13 @@ function findExtendedFunction(input: unknown, functionName: string): FoundFuncti
 		const inputAny: any = input;
 		// This is likely a builtin we're implementing for another type
 		// (e.g. toLocaleString). We'll return that instead
-		if (inputAny && functionName && typeof inputAny[functionName] === 'function') {
+		if (inputAny && name && typeof inputAny[name] === 'function') {
 			// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-			return { type: 'native', function: inputAny[functionName] };
+			return { type: 'native', function: inputAny[name] };
 		}
 
 		// Use a generic version if available
-		foundFunction = genericExtensions[functionName];
+		foundFunction = genericExtensions[name];
 	}
 
 	if (!foundFunction) {


### PR DESCRIPTION
## Summary

In `packages/@n8n/expression-runtime/src/extensions/extend.ts`,
`findExtendedFunction` now uses the up-front coerced `name` value for every
property lookup and predicate (array/date/string/number/object/boolean/Date
extensions, the native fallback, and the generic-extension fallback). The
new runtime copy was using the coerced `name` only for the
`UNSAFE_PROPERTY_NAMES` check; every other lookup used the raw `functionName`
argument. Aligning all sites on the single coerced value matches the legacy
implementation in `packages/workflow/src/extensions/expression-extension.ts`
and keeps property-name handling consistent across the lookup chain.

Also exports `UNSAFE_PROPERTY_NAMES` so the denylist is a single source of
truth and can be iterated by tests.

### How to test

```bash
pnpm --filter=@n8n/expression-runtime test src/extensions/__tests__/extend.test.ts
pnpm --filter=@n8n/expression-runtime typecheck
```

52 unit tests added in `extend.test.ts` cover property-lookup behavior,
the `UNSAFE_PROPERTY_NAMES` denylist (both direct string names and names
returned via `toString()`), and confirm legitimate extension calls still
resolve correctly.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3129

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI