### PR TITLE
fix(core): Set HITL confirmation timeout default

### DIFF
--- a/packages/@n8n/config/src/configs/instance-ai.config.ts
+++ b/packages/@n8n/config/src/configs/instance-ai.config.ts
@@ -112,5 +112,5 @@ export class InstanceAiConfig {
 
 	/** Timeout in milliseconds for HITL confirmation requests. 0 = no timeout. */
 	@Env('N8N_INSTANCE_AI_CONFIRMATION_TIMEOUT')
-	confirmationTimeout: number = 0;
+	confirmationTimeout: number = 24 * 60 * 60 * 1000; // 24 hours
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -295,7 +295,7 @@ describe('GlobalConfig', () => {
 			threadTtlDays: 90,
 			snapshotPruneInterval: 3_600_000,
 			snapshotRetention: 86_400_000,
-			confirmationTimeout: 0,
+			confirmationTimeout: 86_400_000,
 		},
 		queue: {
 			health: {

--- a/packages/@n8n/instance-ai/docs/configuration.md
+++ b/packages/@n8n/instance-ai/docs/configuration.md
@@ -81,7 +81,7 @@ Sandbox workspaces persist per thread — the same container is reused across me
 | `N8N_INSTANCE_AI_THREAD_TTL_DAYS` | number | `90` | Conversation thread TTL in days. Threads older than this are auto-expired. 0 = no expiration. |
 | `N8N_INSTANCE_AI_SNAPSHOT_PRUNE_INTERVAL` | number | `3600000` | Interval in ms between snapshot pruning runs. 0 = disabled. |
 | `N8N_INSTANCE_AI_SNAPSHOT_RETENTION` | number | `86400000` | Retention period in ms for orphaned workflow snapshots before pruning. |
-| `N8N_INSTANCE_AI_CONFIRMATION_TIMEOUT` | number | `0` | Timeout in ms for HITL confirmation requests. 0 = no timeout. |
+| `N8N_INSTANCE_AI_CONFIRMATION_TIMEOUT` | number | `86400000` | Timeout in ms for HITL confirmation requests. 0 = no timeout. |
 
 ## Enabling / Disabling
 

--- a/packages/@n8n/instance-ai/src/runtime/__tests__/background-task-manager.test.ts
+++ b/packages/@n8n/instance-ai/src/runtime/__tests__/background-task-manager.test.ts
@@ -6,6 +6,8 @@ import type {
 } from '../background-task-manager';
 import { InstanceAiLivenessPolicy } from '../liveness-policy';
 
+const day = 24 * 60 * 60_000;
+
 function makeSpawnOptions(
 	overrides: Partial<SpawnManagedBackgroundTaskOptions> = {},
 ): SpawnManagedBackgroundTaskOptions {
@@ -29,7 +31,7 @@ describe('BackgroundTaskManager', () => {
 
 	describe('liveness timeouts', () => {
 		const policy = new InstanceAiLivenessPolicy({
-			confirmationTimeoutMs: 10_000,
+			confirmationTimeoutMs: day,
 			backgroundTaskIdleTimeoutMs: 10_000,
 			backgroundTaskMaxLifetimeMs: 30_000,
 			activeRunIdleTimeoutMs: 10_000,

--- a/packages/@n8n/instance-ai/src/runtime/__tests__/liveness-policy.test.ts
+++ b/packages/@n8n/instance-ai/src/runtime/__tests__/liveness-policy.test.ts
@@ -5,6 +5,7 @@ import {
 } from '../liveness-policy';
 
 const minute = 60_000;
+const day = 24 * 60 * minute;
 
 function createPolicy() {
 	return new InstanceAiLivenessPolicy(INSTANCE_AI_DEFAULT_LIVENESS_POLICY_CONFIG);
@@ -13,7 +14,7 @@ function createPolicy() {
 describe('InstanceAiLivenessPolicy', () => {
 	it('keeps default liveness limits centralized and allows the existing confirmation override', () => {
 		expect(INSTANCE_AI_DEFAULT_LIVENESS_POLICY_CONFIG).toEqual({
-			confirmationTimeoutMs: 0,
+			confirmationTimeoutMs: day,
 			backgroundTaskIdleTimeoutMs: 10 * minute,
 			backgroundTaskMaxLifetimeMs: 30 * minute,
 			activeRunIdleTimeoutMs: 10 * minute,
@@ -69,15 +70,16 @@ describe('InstanceAiLivenessPolicy', () => {
 		});
 	});
 
-	it('keeps suspended runs and pending confirmations alive by default', () => {
+	it('uses the one-day confirmation timeout for suspended runs and pending confirmations by default', () => {
 		const policy = createPolicy();
+		const shorterWorkTimeout = 30 * minute;
 
 		expect(
 			policy.evaluate({
 				surface: 'suspended-run',
 				startedAt: 0,
 				lastActivityAt: 0,
-				now: 10 * minute,
+				now: shorterWorkTimeout,
 			}),
 		).toEqual({ action: 'keep-alive' });
 
@@ -86,9 +88,27 @@ describe('InstanceAiLivenessPolicy', () => {
 				surface: 'pending-confirmation',
 				startedAt: 0,
 				lastActivityAt: 0,
-				now: 10 * minute,
+				now: shorterWorkTimeout,
 			}),
 		).toEqual({ action: 'keep-alive' });
+
+		expect(
+			policy.evaluate({
+				surface: 'suspended-run',
+				startedAt: 0,
+				lastActivityAt: 0,
+				now: day,
+			}),
+		).toMatchObject({ action: 'timeout', reason: 'idle_timeout', timeoutMs: day });
+
+		expect(
+			policy.evaluate({
+				surface: 'pending-confirmation',
+				startedAt: 0,
+				lastActivityAt: 0,
+				now: day,
+			}),
+		).toMatchObject({ action: 'timeout', reason: 'idle_timeout', timeoutMs: day });
 	});
 
 	it('uses a configured confirmation timeout for suspended runs and pending confirmations', () => {

--- a/packages/@n8n/instance-ai/src/runtime/__tests__/run-state-registry.test.ts
+++ b/packages/@n8n/instance-ai/src/runtime/__tests__/run-state-registry.test.ts
@@ -15,6 +15,7 @@ jest.mock('nanoid', () => ({
 }));
 
 const mockedNanoid = jest.mocked(nanoid);
+const day = 24 * 60 * 60_000;
 
 interface TestUser {
 	id: string;
@@ -1085,7 +1086,7 @@ describe('RunStateRegistry', () => {
 
 		it('does not time out an active run while a pending confirmation owns the wait', () => {
 			const confirmationPolicy = new InstanceAiLivenessPolicy({
-				confirmationTimeoutMs: 60_000,
+				confirmationTimeoutMs: day,
 				backgroundTaskIdleTimeoutMs: 0,
 				backgroundTaskMaxLifetimeMs: 0,
 				activeRunIdleTimeoutMs: 10_000,

--- a/packages/@n8n/instance-ai/src/runtime/liveness-policy.ts
+++ b/packages/@n8n/instance-ai/src/runtime/liveness-policy.ts
@@ -15,9 +15,10 @@ export interface InstanceAiLivenessPolicyConfig {
 }
 
 const MINUTE_MS = 60_000;
+const DAY_MS = 24 * 60 * MINUTE_MS;
 
 export const INSTANCE_AI_DEFAULT_LIVENESS_POLICY_CONFIG = {
-	confirmationTimeoutMs: 0,
+	confirmationTimeoutMs: DAY_MS,
 	backgroundTaskIdleTimeoutMs: 10 * MINUTE_MS,
 	backgroundTaskMaxLifetimeMs: 30 * MINUTE_MS,
 	activeRunIdleTimeoutMs: 10 * MINUTE_MS,


### PR DESCRIPTION
## Summary

Follow up on n8n-io/n8n#30722 by keeping Instance AI HITL confirmations time-bound by default without letting the shorter work liveness limits take over HITL waits.

What changes:

- Set the default `N8N_INSTANCE_AI_CONFIRMATION_TIMEOUT` to `86400000` ms (1 day) instead of `0` (unlimited).
- Update the centralized Instance AI liveness policy default to match.
- Keep explicit `0` as the opt-out value for no HITL confirmation timeout.
- Cover that suspended runs and pending confirmations use the one-day timeout rather than the shorter active/background work timeouts.
- Cover that active runs and background tasks do not time out via their shorter work limits while HITL confirmation is pending.
- Update the config snapshot and Instance AI configuration docs.

How to test:

- `pushd packages/@n8n/instance-ai && pnpm test src/runtime/__tests__/liveness-policy.test.ts src/runtime/__tests__/background-task-manager.test.ts src/runtime/__tests__/run-state-registry.test.ts; popd`
- `pushd packages/@n8n/config && pnpm test config.test.ts; popd`
- `pushd packages/@n8n/config && pnpm typecheck; popd`
- `pushd packages/@n8n/config && pnpm lint; popd`
- `pushd packages/@n8n/instance-ai && pnpm exec eslint src/runtime/liveness-policy.ts src/runtime/__tests__/liveness-policy.test.ts src/runtime/__tests__/background-task-manager.test.ts src/runtime/__tests__/run-state-registry.test.ts --quiet; popd`
- `git diff --check`

Known existing checks on this branch:

- `pushd packages/@n8n/instance-ai && pnpm typecheck; popd` currently fails in unchanged `src/agent/instance-agent.ts` at line 193: `Property 'deferredTool' does not exist on type 'Agent'`.
- `pushd packages/@n8n/instance-ai && pnpm lint; popd` currently fails in unchanged `src/agent/instance-agent.ts` at line 193: unsafe call of an error typed value.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-275

Follow-up to n8n-io/n8n#30722

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.