### PR TITLE
feat(core): Support choosing which credential type to use on credential tool

### DIFF
--- a/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/instance-ai.schema.ts
@@ -183,6 +183,7 @@ export const toolErrorPayloadSchema = z.object({
 
 export const credentialRequestSchema = z.object({
 	credentialType: z.string(),
+	nodeType: z.string().optional(),
 	reason: z.string(),
 	existingCredentials: z.array(z.object({ id: z.string(), name: z.string() })),
 	suggestedName: z.string().optional(),

--- a/packages/@n8n/instance-ai/src/tools/__tests__/credentials.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/credentials.tool.test.ts
@@ -861,6 +861,242 @@ describe('credentials tool', () => {
 			expect(suspendFn).not.toHaveBeenCalled();
 		});
 
+		describe('node-bound credentials', () => {
+			const notionDescription = {
+				name: 'n8n-nodes-base.notion',
+				displayName: 'Notion',
+				description: '',
+				group: [],
+				version: 2.2,
+				inputs: ['main'],
+				outputs: ['main'],
+				credentials: [
+					{
+						name: 'notionApi',
+						required: true,
+						displayOptions: { show: { authentication: ['apiKey'] } },
+					},
+					{
+						name: 'notionOAuth2Api',
+						required: true,
+						displayOptions: { show: { authentication: ['oAuth2'] } },
+					},
+				],
+				properties: [
+					{
+						displayName: 'Authentication',
+						name: 'authentication',
+						type: 'options',
+						options: [
+							{ name: 'API Key', value: 'apiKey' },
+							{ name: 'OAuth2', value: 'oAuth2' },
+						],
+						default: 'apiKey',
+					},
+				],
+			};
+
+			function createNodeContext(description: typeof notionDescription) {
+				const context = createMockContext();
+				(context.nodeService as unknown as { getDescription: jest.Mock }).getDescription = jest
+					.fn()
+					.mockResolvedValue(description);
+				return context;
+			}
+
+			it('resolves credentialType from nodeType and prefers the OAuth2 variant', async () => {
+				const context = createNodeContext(notionDescription);
+				const suspendFn = jest.fn();
+
+				const tool = createCredentialsTool(context);
+				await executeTool(
+					tool,
+					{
+						action: 'setup' as const,
+						credentials: [{ nodeType: 'n8n-nodes-base.notion' }],
+					},
+					suspendCtx(suspendFn),
+				);
+
+				expect(context.credentialService.list).toHaveBeenCalledWith({
+					type: 'notionOAuth2Api',
+				});
+				expect(suspendFn).toHaveBeenCalledTimes(1);
+				expect(suspendFn.mock.calls[0][0]).toEqual(
+					expect.objectContaining({
+						credentialRequests: [
+							expect.objectContaining({
+								credentialType: 'notionOAuth2Api',
+								nodeType: 'n8n-nodes-base.notion',
+							}),
+						],
+					}),
+				);
+			});
+
+			it('honors a preferred credentialType when both are provided', async () => {
+				const context = createNodeContext(notionDescription);
+				const suspendFn = jest.fn();
+
+				const tool = createCredentialsTool(context);
+				await executeTool(
+					tool,
+					{
+						action: 'setup' as const,
+						credentials: [{ nodeType: 'n8n-nodes-base.notion', credentialType: 'notionApi' }],
+					},
+					suspendCtx(suspendFn),
+				);
+
+				expect(suspendFn.mock.calls[0][0]).toEqual(
+					expect.objectContaining({
+						credentialRequests: [
+							expect.objectContaining({
+								credentialType: 'notionApi',
+								nodeType: 'n8n-nodes-base.notion',
+							}),
+						],
+					}),
+				);
+			});
+
+			it('ignores an unsupported preferred credentialType and falls back to OAuth2', async () => {
+				const context = createNodeContext(notionDescription);
+				const suspendFn = jest.fn();
+
+				const tool = createCredentialsTool(context);
+				await executeTool(
+					tool,
+					{
+						action: 'setup' as const,
+						credentials: [{ nodeType: 'n8n-nodes-base.notion', credentialType: 'slackApi' }],
+					},
+					suspendCtx(suspendFn),
+				);
+
+				expect(suspendFn.mock.calls[0][0]).toEqual(
+					expect.objectContaining({
+						credentialRequests: [
+							expect.objectContaining({
+								credentialType: 'notionOAuth2Api',
+								nodeType: 'n8n-nodes-base.notion',
+							}),
+						],
+					}),
+				);
+			});
+
+			it('falls back to the default authentication value when no OAuth variant exists', async () => {
+				const apiKeyOnlyDescription = {
+					...notionDescription,
+					credentials: [
+						{
+							name: 'slackApi',
+							required: true,
+							displayOptions: { show: { authentication: ['accessToken'] } },
+						},
+						{
+							name: 'slackBotApi',
+							required: true,
+							displayOptions: { show: { authentication: ['botToken'] } },
+						},
+					],
+					properties: [
+						{
+							displayName: 'Authentication',
+							name: 'authentication',
+							type: 'options',
+							options: [
+								{ name: 'Access Token', value: 'accessToken' },
+								{ name: 'Bot Token', value: 'botToken' },
+							],
+							default: 'botToken',
+						},
+					],
+				};
+				const context = createNodeContext(apiKeyOnlyDescription);
+				const suspendFn = jest.fn();
+
+				const tool = createCredentialsTool(context);
+				await executeTool(
+					tool,
+					{
+						action: 'setup' as const,
+						credentials: [{ nodeType: 'n8n-nodes-base.slack' }],
+					},
+					suspendCtx(suspendFn),
+				);
+
+				expect(suspendFn.mock.calls[0][0]).toEqual(
+					expect.objectContaining({
+						credentialRequests: [
+							expect.objectContaining({
+								credentialType: 'slackBotApi',
+							}),
+						],
+					}),
+				);
+			});
+
+			it('returns an error when nodeType lookup fails', async () => {
+				const context = createMockContext();
+				(context.nodeService as unknown as { getDescription: jest.Mock }).getDescription = jest
+					.fn()
+					.mockRejectedValue(new Error('not found'));
+
+				const tool = createCredentialsTool(context);
+				const result = await tool.handler!(
+					{
+						action: 'setup',
+						credentials: [{ nodeType: 'n8n-nodes-base.unknown' }],
+					},
+					noSuspendCtx(),
+				);
+
+				expect(result).toEqual({
+					error: 'node_not_found',
+					message: expect.stringContaining('n8n-nodes-base.unknown'),
+				});
+			});
+
+			it('returns an error when the node declares no credentials', async () => {
+				const noCredsDescription = { ...notionDescription, credentials: [] };
+				const context = createNodeContext(noCredsDescription);
+
+				const tool = createCredentialsTool(context);
+				const result = await tool.handler!(
+					{
+						action: 'setup',
+						credentials: [{ nodeType: 'n8n-nodes-base.notion' }],
+					},
+					noSuspendCtx(),
+				);
+
+				expect(result).toEqual({
+					error: 'no_credentials_for_node',
+					message: expect.stringContaining('n8n-nodes-base.notion'),
+				});
+			});
+
+			it('returns invalid_request when neither nodeType nor credentialType is provided', async () => {
+				const context = createMockContext();
+				const tool = createCredentialsTool(context);
+
+				const result = await tool.handler!(
+					{
+						action: 'setup',
+						credentials: [{ reason: 'just because' }],
+					},
+					noSuspendCtx(),
+				);
+
+				expect(result).toEqual({
+					error: 'invalid_request',
+					message: expect.stringContaining('nodeType or credentialType'),
+				});
+			});
+		});
+
 		it('should default reason when not provided in credential requests', async () => {
 			const context = createMockContext();
 			(context.credentialService.list as jest.Mock).mockResolvedValue([]);

--- a/packages/@n8n/instance-ai/src/tools/credentials.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/credentials.tool.ts
@@ -3,6 +3,7 @@
  */
 import { Tool } from '@n8n/agents';
 import { instanceAiConfirmationSeveritySchema } from '@n8n/api-types';
+import type { NodeParameterValue } from 'n8n-workflow';
 import { nanoid } from 'nanoid';
 import { z } from 'zod';
 
@@ -91,9 +92,18 @@ const setupAction = z.object({
 	credentials: z
 		.array(
 			z.object({
+				nodeType: z
+					.string()
+					.optional()
+					.describe(
+						'n8n node type this credential is for (e.g. "n8n-nodes-base.notion"). Prefer passing this whenever the credential is for a known workflow node — the backend resolves a sensible auth option (preferring OAuth2 when supported) and the user can switch between supported auth types in the setup modal.',
+					),
 				credentialType: z
 					.string()
-					.describe('n8n credential type name (e.g. "slackApi", "gmailOAuth2Api")'),
+					.optional()
+					.describe(
+						'Specific n8n credential type name (e.g. "daytonaApi"). Required when nodeType is not provided (e.g. instance-level credentials not tied to a node). When both are provided, this is the preferred starting auth option.',
+					),
 				reason: z.string().optional().describe('Why this credential is needed (shown to user)'),
 				suggestedName: z
 					.string()
@@ -103,7 +113,9 @@ const setupAction = z.object({
 					),
 			}),
 		)
-		.describe('List of credentials to set up'),
+		.describe(
+			'List of credentials to set up. Each entry must include nodeType or credentialType (or both).',
+		),
 	projectId: z
 		.string()
 		.optional()
@@ -230,6 +242,7 @@ const suspendSchema = z.object({
 		.array(
 			z.object({
 				credentialType: z.string(),
+				nodeType: z.string().optional(),
 				reason: z.string(),
 				existingCredentials: z.array(z.object({ id: z.string(), name: z.string() })),
 				suggestedName: z.string().optional(),
@@ -334,6 +347,85 @@ async function handleSearchTypes(
 	return { results };
 }
 
+/**
+ * The `authentication` property's default is always a primitive at runtime (it's
+ * an `options` field). Narrow from the wide `NodeParameterValueType` so `.includes`
+ * on `NodeParameterValue[]` typechecks.
+ */
+function isParameterValue(value: unknown): value is NodeParameterValue {
+	return (
+		value === null ||
+		typeof value === 'string' ||
+		typeof value === 'number' ||
+		typeof value === 'boolean'
+	);
+}
+
+/**
+ * Resolve a concrete credential type for a node. Reads the node description and
+ * picks the preferred credential from `credentials[]` using these rules in order:
+ *   1. If `preferred` matches a declared credential name, use it.
+ *   2. Prefer the credential whose name matches /oauth2?/i (Notion → notionOAuth2Api).
+ *   3. Fall back to the credential gated by the node's default `authentication` value.
+ *   4. Fall back to the first declared credential.
+ */
+async function resolveCredentialTypeForNode(
+	nodeService: InstanceAiContext['nodeService'],
+	nodeType: string,
+	preferred?: string,
+): Promise<{ credentialType: string } | { error: string; message: string }> {
+	let desc;
+	try {
+		desc = await nodeService.getDescription(nodeType);
+	} catch {
+		return {
+			error: 'node_not_found',
+			message: `Could not look up node "${nodeType}". Pass a credentialType directly, or check the nodeType spelling.`,
+		};
+	}
+
+	const credentials = desc.credentials ?? [];
+	if (credentials.length === 0) {
+		return {
+			error: 'no_credentials_for_node',
+			message: `Node "${nodeType}" does not declare any credentials. Pass a credentialType directly if this is intentional.`,
+		};
+	}
+
+	// 1. Preferred match
+	if (preferred && credentials.some((c) => c.name === preferred)) {
+		return { credentialType: preferred };
+	}
+
+	// 2. OAuth2 preference — substring match on credential name
+	const oauthCred = credentials.find((c) => /oauth2?/i.test(c.name));
+	if (oauthCred) {
+		return { credentialType: oauthCred.name };
+	}
+
+	// 3. Default-auth-value fallback. Find the auth field (first key referenced in any
+	//    credential's `displayOptions.show`), look up its default on `properties[]`,
+	//    then pick the credential whose displayOptions.show[authField] contains it.
+	const authField = credentials
+		.flatMap((c) => (c.displayOptions?.show ? Object.keys(c.displayOptions.show) : []))
+		.find(Boolean);
+
+	if (authField) {
+		const defaultValue = desc.properties.find((p) => p.name === authField)?.default;
+		if (isParameterValue(defaultValue)) {
+			const defaultCred = credentials.find((c) =>
+				c.displayOptions?.show?.[authField]?.includes(defaultValue),
+			);
+			if (defaultCred) {
+				return { credentialType: defaultCred.name };
+			}
+		}
+	}
+
+	// 4. First credential
+	return { credentialType: credentials[0].name };
+}
+
 async function handleSetup(
 	context: InstanceAiContext,
 	input: Extract<Input, { action: 'setup' }>,
@@ -346,37 +438,77 @@ async function handleSetup(
 		return {
 			error: 'missing_credentials',
 			message:
-				'The `credentials` array is required for the setup action. Pass an array of { credentialType, reason?, suggestedName? } entries describing each credential to set up.',
+				'The `credentials` array is required for the setup action. Pass an array of { nodeType?, credentialType?, reason?, suggestedName? } entries. Each entry must include nodeType or credentialType (or both).',
 		};
 	}
 
-	// State 1: First call — look up existing credentials per type and suspend
+	// State 1: First call — resolve each entry, look up existing credentials, suspend
 	if (resumeData === undefined || resumeData === null) {
+		interface ResolvedRequest {
+			credentialType: string;
+			nodeType?: string;
+			reason?: string;
+			suggestedName?: string;
+		}
+
+		const resolved: ResolvedRequest[] = [];
+		for (const req of input.credentials) {
+			if (!req.nodeType && !req.credentialType) {
+				return {
+					error: 'invalid_request',
+					message: 'Each credentials entry must include nodeType or credentialType (or both).',
+				};
+			}
+
+			let credentialType = req.credentialType;
+			if (req.nodeType) {
+				const result = await resolveCredentialTypeForNode(
+					context.nodeService,
+					req.nodeType,
+					req.credentialType,
+				);
+				if ('error' in result) return result;
+				credentialType = result.credentialType;
+			}
+
+			// Unreachable given the validation above, but narrow for the type checker.
+			if (!credentialType) {
+				return {
+					error: 'invalid_request',
+					message: 'Could not determine credentialType for entry.',
+				};
+			}
+
+			resolved.push({
+				credentialType,
+				...(req.nodeType ? { nodeType: req.nodeType } : {}),
+				...(req.reason ? { reason: req.reason } : {}),
+				...(req.suggestedName ? { suggestedName: req.suggestedName } : {}),
+			});
+		}
+
 		const credentialRequests = await Promise.all(
-			input.credentials.map(
-				async (req: { credentialType: string; reason?: string; suggestedName?: string }) => {
-					const existing = await context.credentialService.list({
-						type: req.credentialType,
-						...(input.projectId ? { projectId: input.projectId } : {}),
-					});
-					return {
-						credentialType: req.credentialType,
-						reason: req.reason ?? `Required for ${req.credentialType}`,
-						existingCredentials: existing.map((c) => ({ id: c.id, name: c.name })),
-						...(req.suggestedName ? { suggestedName: req.suggestedName } : {}),
-					};
-				},
-			),
+			resolved.map(async (req) => {
+				const existing = await context.credentialService.list({
+					type: req.credentialType,
+					...(input.projectId ? { projectId: input.projectId } : {}),
+				});
+				return {
+					credentialType: req.credentialType,
+					...(req.nodeType ? { nodeType: req.nodeType } : {}),
+					reason: req.reason ?? `Required for ${req.credentialType}`,
+					existingCredentials: existing.map((c) => ({ id: c.id, name: c.name })),
+					...(req.suggestedName ? { suggestedName: req.suggestedName } : {}),
+				};
+			}),
 		);
 
-		const typeNames = input.credentials
-			.map((c: { credentialType: string }) => c.credentialType)
-			.join(', ');
+		const typeNames = resolved.map((r) => r.credentialType).join(', ');
 		return await ctx.suspend({
 			requestId: nanoid(),
 			message: isFinalize
 				? `Your workflow is verified. Add credentials to make it production-ready: ${typeNames}`
-				: input.credentials.length === 1
+				: resolved.length === 1
 					? `Select or create a ${typeNames} credential`
 					: `Select or create credentials: ${typeNames}`,
 			severity: 'info' as const,

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -17,7 +17,12 @@ import type {
 	McpToolCallResult,
 } from '@n8n/api-types';
 import type { WorkflowJSON } from '@n8n/workflow-sdk';
-import type { GenericValue, INodeTypes } from 'n8n-workflow';
+import type {
+	GenericValue,
+	ICredentialsDisplayOptions,
+	INodeTypes,
+	NodeParameterValueType,
+} from 'n8n-workflow';
 
 // Service interfaces — dependency inversion so the package stays decoupled from n8n internals.
 // The backend module provides concrete implementations via InstanceAiAdapterService.
@@ -124,13 +129,13 @@ export interface NodeDescription extends NodeSummary {
 		type: string;
 		required?: boolean;
 		description?: string;
-		default?: unknown;
+		default?: NodeParameterValueType;
 		options?: Array<{ name: string; value: string | number | boolean }>;
 	}>;
 	credentials?: Array<{
 		name: string;
 		required?: boolean;
-		displayOptions?: Record<string, unknown>;
+		displayOptions?: ICredentialsDisplayOptions;
 	}>;
 	inputs: string[];
 	outputs: string[];

--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -652,6 +652,13 @@ export interface NewCredentialsModal extends ModalState {
 	nodeName?: string;
 	contextNode?: INodeUi;
 	hideAskAssistant?: boolean;
+	/**
+	 * When true, the modal opens with the explicitly requested credential type
+	 * (the `type` arg to `openNewCredential`) instead of auto-defaulting to the
+	 * node's recommended auth option. Set by callers that have already resolved
+	 * which credential type to use (e.g. Instance AI's credential setup flow).
+	 */
+	respectActiveCredentialType?: boolean;
 }
 
 export type IRunDataDisplayMode = 'table' | 'json' | 'binary' | 'schema' | 'html' | 'ai';

--- a/packages/frontend/editor-ui/src/app/stores/ui.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/ui.store.ts
@@ -556,7 +556,7 @@ export const useUIStore = defineStore(STORES.UI, () => {
 		suggestedName?: string,
 		nodeName?: string,
 		contextNode?: INodeUi,
-		options: { hideAskAssistant?: boolean } = {},
+		options: { hideAskAssistant?: boolean; respectActiveCredentialType?: boolean } = {},
 	) => {
 		setActiveId(CREDENTIAL_EDIT_MODAL_KEY, type);
 		setShowAuthSelector(CREDENTIAL_EDIT_MODAL_KEY, showAuthOptions);
@@ -568,6 +568,7 @@ export const useUIStore = defineStore(STORES.UI, () => {
 			nodeName,
 			contextNode,
 			hideAskAssistant: options.hideAskAssistant,
+			respectActiveCredentialType: options.respectActiveCredentialType,
 		} as NewCredentialsModal;
 		setMode(CREDENTIAL_EDIT_MODAL_KEY, 'new');
 		openModal(CREDENTIAL_EDIT_MODAL_KEY);

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiCredentialSetup.test.ts
@@ -7,7 +7,9 @@ import type { InstanceAiCredentialRequest } from '@n8n/api-types';
 import InstanceAiCredentialSetup from '../components/InstanceAiCredentialSetup.vue';
 import { useInstanceAiStore, type ThreadRuntime } from '../instanceAi.store';
 import { useCredentialsStore } from '@/features/credentials/credentials.store';
+import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUIStore } from '@/app/stores/ui.store';
+import { mockedStore } from '@/__tests__/utils';
 
 vi.mock('@n8n/i18n', async (importOriginal) => ({
 	...(await importOriginal()),
@@ -85,6 +87,9 @@ describe('InstanceAiCredentialSetup', () => {
 		const credentialsStore = useCredentialsStore();
 		vi.spyOn(credentialsStore, 'fetchAllCredentials').mockResolvedValue([]);
 		vi.spyOn(credentialsStore, 'fetchCredentialTypes').mockResolvedValue(undefined);
+
+		const nodeTypesStore = useNodeTypesStore();
+		vi.spyOn(nodeTypesStore, 'loadNodeTypesIfNotLoaded').mockResolvedValue(undefined);
 	});
 
 	describe('credential list', () => {
@@ -341,6 +346,95 @@ describe('InstanceAiCredentialSetup', () => {
 			expect(resolveSpy).not.toHaveBeenCalled();
 			// Should show the form again (not deferred state)
 			expect(getByText('instanceAi.credential.deny')).toBeTruthy();
+		});
+	});
+
+	describe('node-bound credential flow', () => {
+		const notionNodeDescription = {
+			name: 'n8n-nodes-base.notion',
+			displayName: 'Notion',
+			version: 2.2,
+			credentials: [
+				{
+					name: 'notionApi',
+					required: true,
+					displayOptions: { show: { authentication: ['apiKey'] } },
+				},
+				{
+					name: 'notionOAuth2Api',
+					required: true,
+					displayOptions: { show: { authentication: ['oAuth2'] } },
+				},
+			],
+			properties: [
+				{
+					displayName: 'Authentication',
+					name: 'authentication',
+					type: 'options',
+					options: [
+						{ name: 'API Key', value: 'apiKey' },
+						{ name: 'OAuth2', value: 'oAuth2' },
+					],
+					default: 'apiKey',
+				},
+			],
+		};
+
+		function makeNotionRequest(
+			credentialType: 'notionApi' | 'notionOAuth2Api' = 'notionOAuth2Api',
+		): InstanceAiCredentialRequest {
+			return {
+				credentialType,
+				nodeType: 'n8n-nodes-base.notion',
+				reason: 'Required for Notion',
+				existingCredentials: [],
+			};
+		}
+
+		it('opens the credential modal with auth-options enabled and a Notion contextNode', async () => {
+			const uiStore = useUIStore();
+			const openNewCredSpy = vi.spyOn(uiStore, 'openNewCredential');
+
+			const nodeTypesStore = mockedStore(useNodeTypesStore);
+			nodeTypesStore.getNodeType = vi.fn().mockReturnValue(notionNodeDescription);
+
+			const { getByTestId } = renderComponent({
+				props: {
+					requestId: 'req-1',
+					credentialRequests: [makeNotionRequest()],
+					message: 'Set up credentials',
+				},
+			});
+
+			await userEvent.click(getByTestId('instance-ai-credential-setup-button'));
+
+			expect(openNewCredSpy).toHaveBeenCalledTimes(1);
+			const args = openNewCredSpy.mock.calls[0];
+			expect(args[0]).toBe('notionOAuth2Api');
+			expect(args[1]).toBe(true); // showAuthOptions
+			expect(args[2]).toBe(false); // forceManualMode
+			expect(args[5]).toBe('n8n-nodes-base.notion'); // nodeName
+			expect(args[6]).toMatchObject({
+				type: 'n8n-nodes-base.notion',
+				typeVersion: 2.2,
+			});
+		});
+
+		it('falls back to the 5-arg call when nodeType is absent', async () => {
+			const uiStore = useUIStore();
+			const openNewCredSpy = vi.spyOn(uiStore, 'openNewCredential');
+
+			const { getByTestId } = renderComponent({
+				props: {
+					requestId: 'req-1',
+					credentialRequests: makeCredentialRequests(1),
+					message: 'Set up credentials',
+				},
+			});
+
+			await userEvent.click(getByTestId('instance-ai-credential-setup-button'));
+
+			expect(openNewCredSpy).toHaveBeenCalledWith('type1', false, false, undefined, undefined);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
@@ -258,7 +258,7 @@ function openNewCredentialModal() {
 
 	if (req.nodeType) {
 		// Pass a synthetic node as contextNode + showAuthOptions=true so the modal
-		// renders the auth-type dropdown (e.g. "API Key / OAuth2" for Notion).
+		// renders the auth-type dropdown (e.g. "API Key / OAuth2").
 		uiStore.openNewCredential(
 			req.credentialType,
 			true,
@@ -267,6 +267,7 @@ function openNewCredentialModal() {
 			req.suggestedName,
 			req.nodeType,
 			syntheticNodeUi(req),
+			{ respectActiveCredentialType: true },
 		);
 		return;
 	}

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiCredentialSetup.vue
@@ -1,6 +1,11 @@
 <script lang="ts" setup>
+import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUIStore } from '@/app/stores/ui.store';
-import { getAppNameFromCredType } from '@/app/utils/nodeTypesUtils';
+import {
+	getAppNameFromCredType,
+	getNodeAuthOptions,
+	getNodeCredentialForSelectedAuthType,
+} from '@/app/utils/nodeTypesUtils';
 import { useWizardNavigation } from '@/features/ai/shared/composables/useWizardNavigation';
 import CredentialIcon from '@/features/credentials/components/CredentialIcon.vue';
 import NodeCredentials from '@/features/credentials/components/NodeCredentials.vue';
@@ -28,6 +33,7 @@ const telemetry = useTelemetry();
 const rootStore = useRootStore();
 const thread = useThread();
 const credentialsStore = useCredentialsStore();
+const nodeTypesStore = useNodeTypesStore();
 const uiStore = useUIStore();
 
 // ---------------------------------------------------------------------------
@@ -50,7 +56,43 @@ const isFinalize = computed(() => props.credentialFlow?.stage === 'finalize');
 const isSubmitted = ref(false);
 const isDeferred = ref(false);
 
-const selections = ref<Record<string, string | null>>({});
+// Keyed by the request's credentialType. The value's `credentialType` carries the
+// *actual* type of the chosen credential — equal to the key in the common case,
+// or different when the user swapped auth types in the modal (e.g. a request for
+// `notionApi` fulfilled by a `notionOAuth2Api` credential the user just created).
+const selections = ref<Record<string, { credentialId: string; credentialType: string } | null>>({});
+
+// ---------------------------------------------------------------------------
+// Acceptable credential types per request
+// ---------------------------------------------------------------------------
+
+/**
+ * Credential types this request will accept. When `nodeType` is provided the
+ * set includes every credential supported by the node's `authentication`
+ * options (e.g. notionApi + notionOAuth2Api for the Notion node); otherwise
+ * only the originally-requested type.
+ */
+function getAcceptableTypes(req: InstanceAiCredentialRequest): string[] {
+	const types = new Set<string>([req.credentialType]);
+	if (!req.nodeType) return [...types];
+
+	const nodeType = nodeTypesStore.getNodeType(req.nodeType);
+	if (!nodeType) return [...types];
+
+	const authOptions = getNodeAuthOptions(nodeType);
+	for (const option of authOptions) {
+		const cred = getNodeCredentialForSelectedAuthType(nodeType, option.value);
+		if (cred) types.add(cred.name);
+	}
+	// Single-credential nodes have no `authentication` option but still declare
+	// the credential in `credentials[]`.
+	if (authOptions.length === 0) {
+		for (const cred of nodeType.credentials ?? []) {
+			types.add(cred.name);
+		}
+	}
+	return [...types];
+}
 
 // ---------------------------------------------------------------------------
 // Auto-select from existing credentials
@@ -62,7 +104,10 @@ function initSelections() {
 
 		if (req.existingCredentials?.length === 1) {
 			// Auto-select when exactly one credential available
-			selections.value[req.credentialType] = req.existingCredentials[0].id;
+			selections.value[req.credentialType] = {
+				credentialId: req.existingCredentials[0].id,
+				credentialType: req.credentialType,
+			};
 		} else {
 			selections.value[req.credentialType] = null;
 		}
@@ -75,16 +120,17 @@ const stopDeleteListener = credentialsStore.$onAction(({ name, after, args }) =>
 	if (name !== 'deleteCredential') return;
 	after(() => {
 		const deletedId = (args[0] as { id: string }).id;
-		for (const [credType, selectedId] of Object.entries(selections.value)) {
-			if (selectedId === deletedId) {
+		for (const [credType, sel] of Object.entries(selections.value)) {
+			if (sel?.credentialId === deletedId) {
 				selections.value[credType] = null;
 			}
 		}
 	});
 });
 
-// Listen for credential creation to auto-select newly created credentials
-// when using the button path (no NodeCredentials rendered)
+// Listen for credential creation to auto-select newly created credentials.
+// Accepts any credential whose type is valid for the current request's node —
+// so the user swapping auth types in the modal still binds the new cred.
 const stopCreateListener = credentialsStore.$onAction(({ name, after }) => {
 	if (name !== 'createNewCredential') return;
 	after((newCred) => {
@@ -92,8 +138,11 @@ const stopCreateListener = credentialsStore.$onAction(({ name, after }) => {
 		const req = currentRequest.value;
 		if (!req) return;
 		const cred = newCred as { id: string; type: string };
-		if (cred.type === req.credentialType) {
-			selections.value[req.credentialType] = cred.id;
+		if (getAcceptableTypes(req).includes(cred.type)) {
+			selections.value[req.credentialType] = {
+				credentialId: cred.id,
+				credentialType: cred.type,
+			};
 		}
 	});
 });
@@ -108,7 +157,8 @@ onBeforeUnmount(() => {
 // ---------------------------------------------------------------------------
 
 function isStepComplete(credentialType: string): boolean {
-	return selections.value[credentialType] !== null;
+	const sel = selections.value[credentialType];
+	return sel !== null && sel !== undefined;
 }
 
 const allSelected = computed(() =>
@@ -144,7 +194,7 @@ watch(
 			return;
 		}
 		const nextIncomplete = props.credentialRequests.findIndex(
-			(r, idx) => idx > currentStepIndex.value && !isStepComplete(r.credentialType),
+			(req, idx) => idx > currentStepIndex.value && !isStepComplete(req.credentialType),
 		);
 		if (nextIncomplete >= 0) {
 			goToStep(nextIncomplete);
@@ -161,20 +211,21 @@ watch(allSelected, async (nowComplete, wasComplete) => {
 });
 
 onMounted(async () => {
-	// Ensure the credentials store is populated so NodeCredentials can show
-	// existing credentials in the dropdown. The Instance AI page may not have
-	// fetched them yet.
+	// Ensure the credentials and node-types stores are populated. The credential
+	// dropdown needs the cred list; the auth-type swap UI in the credential modal
+	// needs the node description so it can enumerate the node's auth options.
 	try {
 		await Promise.all([
 			credentialsStore.fetchAllCredentials(),
 			credentialsStore.fetchCredentialTypes(false),
+			nodeTypesStore.loadNodeTypesIfNotLoaded(),
 		]);
 	} catch (error) {
 		console.warn('Failed to preload credentials for Instance AI setup', error);
 	}
 
 	const firstIncomplete = props.credentialRequests.findIndex(
-		(r) => !isStepComplete(r.credentialType),
+		(req) => !isStepComplete(req.credentialType),
 	);
 	if (firstIncomplete > 0) {
 		goToStep(firstIncomplete);
@@ -204,26 +255,51 @@ const hasExistingCredentials = computed(() => {
 function openNewCredentialModal() {
 	const req = currentRequest.value;
 	if (!req) return;
+
+	if (req.nodeType) {
+		// Pass a synthetic node as contextNode + showAuthOptions=true so the modal
+		// renders the auth-type dropdown (e.g. "API Key / OAuth2" for Notion).
+		uiStore.openNewCredential(
+			req.credentialType,
+			true,
+			false,
+			props.projectId,
+			req.suggestedName,
+			req.nodeType,
+			syntheticNodeUi(req),
+		);
+		return;
+	}
+
 	uiStore.openNewCredential(req.credentialType, false, false, props.projectId, req.suggestedName);
 }
 
 /** Build a minimal synthetic INodeUi so NodeCredentials can render in standalone mode. */
 function syntheticNodeUi(req: InstanceAiCredentialRequest): INodeUi {
-	const selectedId = selections.value[req.credentialType];
-	const selectedCred = selectedId
-		? (req.existingCredentials?.find((c) => c.id === selectedId) ??
-			credentialsStore.getCredentialById(selectedId))
+	const sel = selections.value[req.credentialType];
+	const selectedCred = sel
+		? (req.existingCredentials?.find((c) => c.id === sel.credentialId) ??
+			credentialsStore.getCredentialById(sel.credentialId))
 		: undefined;
+
+	const nodeType = req.nodeType ? nodeTypesStore.getNodeType(req.nodeType) : null;
+	const typeVersion = nodeType
+		? Array.isArray(nodeType.version)
+			? nodeType.version[nodeType.version.length - 1]
+			: nodeType.version
+		: 1;
+
+	const selectedType = sel?.credentialType ?? req.credentialType;
 
 	return {
 		id: req.credentialType,
 		name: req.credentialType,
-		type: 'n8n-nodes-base.noOp',
-		typeVersion: 1,
+		type: req.nodeType ?? 'n8n-nodes-base.noOp',
+		typeVersion,
 		position: [0, 0],
 		parameters: {},
 		credentials: selectedCred
-			? { [req.credentialType]: { id: selectedCred.id, name: selectedCred.name } }
+			? { [selectedType]: { id: selectedCred.id, name: selectedCred.name } }
 			: {},
 	} as INodeUi;
 }
@@ -232,16 +308,18 @@ function syntheticNodeUi(req: InstanceAiCredentialRequest): INodeUi {
 // Event handlers
 // ---------------------------------------------------------------------------
 
-function onCredentialSelected(
-	credentialType: string,
-	updateInfo: INodeUpdatePropertiesInformation,
-) {
-	const credentialData = updateInfo.properties.credentials?.[credentialType];
+function onCredentialSelected(updateInfo: INodeUpdatePropertiesInformation) {
+	const req = currentRequest.value;
+	if (!req) return;
+	const credentialData = updateInfo.properties.credentials?.[req.credentialType];
 	const credentialId = typeof credentialData === 'string' ? undefined : credentialData?.id;
 	if (credentialId) {
-		selections.value[credentialType] = credentialId;
+		selections.value[req.credentialType] = {
+			credentialId,
+			credentialType: req.credentialType,
+		};
 	} else {
-		selections.value[credentialType] = null;
+		selections.value[req.credentialType] = null;
 	}
 }
 
@@ -251,9 +329,13 @@ function trackCredentialInput() {
 	const provided: Array<{ label: string; options: string[]; option_chosen: string }> = [];
 	const skipped: Array<{ label: string; options: string[] }> = [];
 	for (const req of props.credentialRequests) {
-		const selected = selections.value[req.credentialType];
-		if (selected) {
-			provided.push({ label: req.credentialType, options: [], option_chosen: selected });
+		const sel = selections.value[req.credentialType];
+		if (sel) {
+			provided.push({
+				label: req.credentialType,
+				options: [],
+				option_chosen: sel.credentialId,
+			});
 		} else {
 			skipped.push({ label: req.credentialType, options: [] });
 		}
@@ -271,8 +353,8 @@ function trackCredentialInput() {
 
 async function handleContinue() {
 	const credentials: Record<string, string> = {};
-	for (const [type, id] of Object.entries(selections.value)) {
-		if (id) credentials[type] = id;
+	for (const sel of Object.values(selections.value)) {
+		if (sel) credentials[sel.credentialType] = sel.credentialId;
 	}
 
 	trackCredentialInput();
@@ -348,7 +430,7 @@ async function handleLater() {
 							standalone
 							hide-issues
 							hide-ask-assistant
-							@credential-selected="onCredentialSelected(currentRequest.credentialType, $event)"
+							@credential-selected="onCredentialSelected($event)"
 						/>
 						<N8nButton
 							v-else

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/composables/useWorkflowSetupSections.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/workflowSetup/composables/useWorkflowSetupSections.ts
@@ -62,11 +62,16 @@ export function useWorkflowSetupSections(
 		const nodeType = nodeTypesStore.getNodeType(node.type, node.typeVersion);
 		if (!nodeType) return node.parameters as INodeParameters;
 
+		// returnNoneDisplayed=false: only resolve defaults for currently-displayed
+		// parameters. The setup UI doesn't render hidden parameters, and processing
+		// them walks duplicate definitions whose `typeOptions.multipleValues` may
+		// disagree with the runtime shape (e.g. Notion `options.sort.sortValue`),
+		// which crashes the resolver in `getNodeParameters`.
 		return (NodeHelpers.getNodeParameters(
 			nodeType.properties,
 			node.parameters as INodeParameters,
 			true,
-			true,
+			false,
 			node,
 			nodeType,
 		) ?? node.parameters) as INodeParameters;

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -168,12 +168,8 @@ const selectedCredentialType = computed(() => {
 	if (selectedCredential.value !== '') {
 		return credentialsStore.getCredentialTypeByName(selectedCredential.value) ?? null;
 	} else if (requiredCredentials.value) {
-		// Use the recommended auth option (managed OAuth sorts first) or the first available
-		const nodeAuthOptions = getNodeAuthOptions(activeNodeType.value);
-		if (nodeAuthOptions.length > 0 && activeNodeType.value?.credentials) {
-			return getNodeCredentialForSelectedAuthType(activeNodeType.value, nodeAuthOptions[0].value);
-		}
-		// No auth options — fall back to the explicitly requested type or the first credential
+		// Honor an explicitly requested credential type when it matches a declared
+		// credential of the node — the caller has signalled their intent.
 		if (props.activeId) {
 			const nodeCredential = activeNodeType.value?.credentials?.find(
 				(c) => c.name === props.activeId,
@@ -181,6 +177,12 @@ const selectedCredentialType = computed(() => {
 			if (nodeCredential) {
 				return nodeCredential;
 			}
+		}
+		// Otherwise fall back to the recommended auth option (managed OAuth sorts first)
+		// or the first declared credential.
+		const nodeAuthOptions = getNodeAuthOptions(activeNodeType.value);
+		if (nodeAuthOptions.length > 0 && activeNodeType.value?.credentials) {
+			return getNodeCredentialForSelectedAuthType(activeNodeType.value, nodeAuthOptions[0].value);
 		}
 		return activeNodeType.value?.credentials?.[0] ?? null;
 	}

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -150,6 +150,14 @@ const hideAskAssistant = computed<boolean>(() => {
 	return isCredentialModalState(modalState) && modalState.hideAskAssistant === true;
 });
 
+// When true, the caller explicitly chose `activeId` and the modal should not
+// override it with the node's "recommended" auth option. Used by Instance AI's
+// credential setup flow where the AI has already resolved the desired type.
+const respectActiveCredentialType = computed<boolean>(() => {
+	const modalState = uiStore.modalsById[CREDENTIAL_EDIT_MODAL_KEY];
+	return isCredentialModalState(modalState) && modalState.respectActiveCredentialType === true;
+});
+
 const activeNodeType = computed(() => {
 	const activeNode = contextNode.value;
 
@@ -168,9 +176,10 @@ const selectedCredentialType = computed(() => {
 	if (selectedCredential.value !== '') {
 		return credentialsStore.getCredentialTypeByName(selectedCredential.value) ?? null;
 	} else if (requiredCredentials.value) {
-		// Honor an explicitly requested credential type when it matches a declared
-		// credential of the node — the caller has signalled their intent.
-		if (props.activeId) {
+		// When the caller explicitly locked the credential type (e.g. Instance AI's
+		// setup flow has already resolved which type to use), honor `activeId` over
+		// the node's recommended auth default.
+		if (respectActiveCredentialType.value && props.activeId) {
 			const nodeCredential = activeNodeType.value?.credentials?.find(
 				(c) => c.name === props.activeId,
 			);
@@ -178,11 +187,19 @@ const selectedCredentialType = computed(() => {
 				return nodeCredential;
 			}
 		}
-		// Otherwise fall back to the recommended auth option (managed OAuth sorts first)
-		// or the first declared credential.
+		// Use the recommended auth option (managed OAuth sorts first) or the first available
 		const nodeAuthOptions = getNodeAuthOptions(activeNodeType.value);
 		if (nodeAuthOptions.length > 0 && activeNodeType.value?.credentials) {
 			return getNodeCredentialForSelectedAuthType(activeNodeType.value, nodeAuthOptions[0].value);
+		}
+		// No auth options — fall back to the explicitly requested type or the first credential
+		if (props.activeId) {
+			const nodeCredential = activeNodeType.value?.credentials?.find(
+				(c) => c.name === props.activeId,
+			);
+			if (nodeCredential) {
+				return nodeCredential;
+			}
 		}
 		return activeNodeType.value?.credentials?.[0] ?? null;
 	}


### PR DESCRIPTION
## Summary

Make the credential tool support passing it node type, which when passed opens the credential modal in a mode where the credential type can be chosen, instead of forcing it in the mode where only a single credential type is supported, even if the node in question would support multiple types of credentials.

<img width="1295" height="820" alt="image" src="https://github.com/user-attachments/assets/355c0e1a-10ab-4ceb-b705-d6a37923ab04" />

Here the agent correctly opened this in the Oauth2 credential mode, matching user's intent.

Notably this `InstanceAiCredentialSetup` widget is separate from the `WorkflowSetupSectionBody` widget that is used on the regular workflow setup flow, this only comes up if the agent calls the credential tool - the widget used on the regular workflow setup already handled the case of multiple credential types correctly.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-252/setting-up-notion-creds-via-instanceai-default-to-api-key-with-no-way

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
