### PR TITLE
fix: Fixes PostHog group identify call site after init

### DIFF
--- a/packages/frontend/editor-ui/src/app/plugins/telemetry/index.ts
+++ b/packages/frontend/editor-ui/src/app/plugins/telemetry/index.ts
@@ -64,14 +64,9 @@ export class Telemetry {
 		});
 
 		this.identify({ instanceId, userId, versionCli, projectId, userRole });
-		this.groupIdentify({ instanceId });
 
 		this.flushPageEvents();
 		this.track('Session started', { session_id: rootStore.pushRef });
-	}
-
-	groupIdentify({ instanceId }: { instanceId: string }) {
-		usePostHog()?.groupIdentify?.('company', instanceId);
 	}
 
 	identify({ instanceId, userId, versionCli, projectId, userRole }: TelemetryIdentifyOptions) {

--- a/packages/frontend/editor-ui/src/app/stores/posthog.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/posthog.store.ts
@@ -187,6 +187,7 @@ export const usePostHog = defineStore('posthog', () => {
 
 		window.posthog?.init(config.apiKey, options);
 		identify();
+		groupIdentify('company', instanceId);
 
 		if (evaluatedFeatureFlags && Object.keys(evaluatedFeatureFlags).length) {
 			featureFlags.value = evaluatedFeatureFlags;


### PR DESCRIPTION
## Summary
Fixes site for PostHog group identify call to after init

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
