### PR TITLE
refactor(editor): Migrate pin data to render data (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -238,7 +238,7 @@ describe('useCanvasOperations', () => {
 		vi.mocked(workflowDocumentStoreInstance.getWorkflowObjectAccessorSnapshot).mockReturnValue({
 			id: workflowDocumentStoreInstance.workflowId,
 			connectionsBySourceNode: workflowDocumentStoreInstance.connectionsBySourceNode,
-			pinData: workflowDocumentStoreInstance.pinData as IPinData,
+			pinData: workflowDocumentStoreInstance.pinnedDataByNodeName as IPinData,
 			expression: workflowDocumentStoreInstance.getExpressionHandler(),
 			getNode: workflowDocumentStoreInstance.getNodeByName,
 			getParentNodes: workflowDocumentStoreInstance.getParentNodes,

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -2864,7 +2864,9 @@ export function useCanvasOperations() {
 
 		for (const node of nodes) {
 			const nodeSaveData = serializeNode(nodeTypesStore, node);
-			const pinDataForNode = pinDataToExecutionData(workflowDocumentStore.value.pinData)[node.name];
+			const pinDataForNode = pinDataToExecutionData(
+				workflowDocumentStore.value.pinnedDataByNodeName,
+			)[node.name];
 
 			if (pinDataForNode) {
 				data.pinData[node.name] = pinDataForNode as IPinData[string];

--- a/packages/frontend/editor-ui/src/app/composables/useNodeExecution.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeExecution.ts
@@ -342,7 +342,7 @@ export function useNodeExecution(
 		const startNode = workflowDocumentStore.value.getStartNode(nodeRef.value.name);
 		if (!startNode || startNode.type !== CHAT_TRIGGER_NODE_TYPE) return false;
 		const hasRunData = nodeHelpers.getNodeInputData(startNode, 0, 0, 'input')?.length > 0;
-		const hasPinData = !!workflowDocumentStore.value.pinData?.[startNode.name];
+		const hasPinData = !!workflowDocumentStore.value.pinnedDataByNodeName?.[startNode.name];
 		return hasRunData || hasPinData;
 	}
 

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
@@ -26,7 +26,7 @@ const mockDocumentStoreUsedCredentials: Record<string, IUsedCredential> = {};
 const mockDocumentStore = {
 	name: '',
 	settings: {},
-	pinData: {},
+	pinnedDataByNodeName: {},
 	usedCredentials: mockDocumentStoreUsedCredentials,
 	allNodes: [],
 	workflowTriggerNodes: [],

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
@@ -184,7 +184,7 @@ export function useNodeHelpers() {
 		workflow: WorkflowObjectAccessors,
 		ignoreIssues?: string[],
 	): INodeIssues | null {
-		const pinDataNodeNames = Object.keys(workflowDocumentStore.value.pinData);
+		const pinDataNodeNames = Object.keys(workflowDocumentStore.value.pinnedDataByNodeName);
 
 		let nodeIssues: INodeIssues | null = null;
 		ignoreIssues = ignoreIssues ?? [];

--- a/packages/frontend/editor-ui/src/app/composables/usePinnedData.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePinnedData.test.ts
@@ -95,7 +95,7 @@ describe('usePinnedData', () => {
 
 			expect(() => setData(testData, 'pin-icon-click')).not.toThrow();
 			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(''));
-			expect(workflowDocumentStore.pinData?.[node.value.name]).toEqual(testData);
+			expect(workflowDocumentStore.pinnedDataByNodeName?.[node.value.name]).toEqual(testData);
 		});
 
 		it('should throw and not pin data when input contains the trimmed-execution-data marker', () => {
@@ -117,7 +117,7 @@ describe('usePinnedData', () => {
 			const workflowDocumentStore = useWorkflowDocumentStore(
 				createWorkflowDocumentId(workflowsStore.workflowId),
 			);
-			expect(workflowDocumentStore.pinData?.[node.value.name]).toBeUndefined();
+			expect(workflowDocumentStore.pinnedDataByNodeName?.[node.value.name]).toBeUndefined();
 			expect(trackSpy).toHaveBeenCalledWith(
 				'Ndv data pinning failure',
 				expect.objectContaining({ error_type: 'trimmed-data' }),
@@ -135,7 +135,7 @@ describe('usePinnedData', () => {
 			unsetData('context-menu');
 
 			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(''));
-			expect(workflowDocumentStore.pinData?.[node.value.name]).toBeUndefined();
+			expect(workflowDocumentStore.pinnedDataByNodeName?.[node.value.name]).toBeUndefined();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/composables/usePinnedData.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePinnedData.ts
@@ -72,7 +72,9 @@ export function usePinnedData(
 	const data = computed<IDataObject[] | undefined>(() => {
 		const targetNode = unref(node);
 		if (!targetNode || !workflowDocumentStore.value) return undefined;
-		return pinDataToExecutionData(workflowDocumentStore.value.pinData)[targetNode.name];
+		return pinDataToExecutionData(workflowDocumentStore.value.pinnedDataByNodeName)[
+			targetNode.name
+		];
 	});
 
 	const hasData = computed<boolean>(() => {
@@ -182,7 +184,7 @@ export function usePinnedData(
 
 		const { pinData: _pinData, ...workflowObjectWithoutPinData } =
 			workflowDocumentStore.value?.getSnapshot() ?? {};
-		const currentPinData = (workflowDocumentStore.value?.pinData ?? {}) as IPinData;
+		const currentPinData = (workflowDocumentStore.value?.pinnedDataByNodeName ?? {}) as IPinData;
 		const workflowJson = jsonStringify(workflowObjectWithoutPinData, { replaceCircularRefs: true });
 
 		const newPinData = { ...currentPinData, [targetNode.name]: data };
@@ -291,7 +293,7 @@ export function usePinnedData(
 		if (workflowDocumentStore.value) {
 			const nodeName = targetNode.name;
 			// Update metadata timestamp for existing pinned data
-			if ((workflowDocumentStore.value.pinData[nodeName] ?? []).length > 0) {
+			if ((workflowDocumentStore.value.pinnedDataByNodeName[nodeName] ?? []).length > 0) {
 				workflowDocumentStore.value.touchPinnedDataLastUpdatedAt(nodeName);
 			}
 			workflowDocumentStore.value.pinNodeData(nodeName, data as INodeExecutionData[]);

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -354,7 +354,7 @@ export function handleExecutionFinishedWithErrorOrCanceled(
 			const node = workflowDocumentStore.getNodeByName(error.context.nodeCause as string);
 
 			if (node) {
-				eventData.is_pinned = !!workflowDocumentStore.pinData?.[node.name];
+				eventData.is_pinned = !!workflowDocumentStore.pinnedDataByNodeName?.[node.name];
 				eventData.mode = node.parameters.mode;
 				eventData.node_type = node.type;
 				eventData.operation = node.parameters.operation;

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
@@ -83,7 +83,7 @@ const { mockDocumentStore } = vi.hoisted(() => {
 		getParentNodes: store.getParentNodes,
 		getChildNodes: store.getChildNodes,
 		connectionsBySourceNode: store.connectionsBySourceNode,
-		pinData: store.pinData as IPinData,
+		pinData: store.pinnedDataByNodeName as IPinData,
 	} as Partial<WorkflowObjectAccessors> as WorkflowObjectAccessors);
 	return { mockDocumentStore: store };
 });
@@ -301,7 +301,7 @@ describe('useRunWorkflow({ router })', () => {
 		mockDocumentStore.workflowId = '123';
 		mockDocumentStore.name = 'Test Workflow';
 		mockDocumentStore.connectionsBySourceNode = {};
-		mockDocumentStore.pinData = {};
+		mockDocumentStore.pinnedDataByNodeName = {};
 		mockDocumentStore.getNodeByName = vi.fn();
 		mockDocumentStore.getParentNodes = vi.fn().mockReturnValue([]);
 		mockDocumentStore.getChildNodes = vi.fn().mockReturnValue([]);

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.test.ts
@@ -370,7 +370,7 @@ describe('workflowDocument.store orchestration', () => {
 			});
 			expect(store.allNodes).toHaveLength(2);
 			expect(store.connectionsBySourceNode).toHaveProperty('A');
-			expect(store.pinData).toEqual({ A: [{ json: { foo: 'bar' } }] });
+			expect(store.pinnedDataByNodeName).toEqual({ A: [{ json: { foo: 'bar' } }] });
 		});
 
 		it('applies safe defaults for missing optional fields', () => {
@@ -411,7 +411,7 @@ describe('workflowDocument.store orchestration', () => {
 			});
 			expect(store.allNodes).toHaveLength(0);
 			expect(store.connectionsBySourceNode).toEqual({});
-			expect(store.pinData).toEqual({});
+			expect(store.pinnedDataByNodeName).toEqual({});
 		});
 
 		it('normalizes ITag[] tags to string[]', () => {
@@ -451,7 +451,7 @@ describe('workflowDocument.store orchestration', () => {
 				tags: [...store.tags],
 				checksum: store.checksum,
 				allNodes: store.allNodes.map((n) => n.name),
-				pinData: { ...store.pinData },
+				pinData: { ...store.pinnedDataByNodeName },
 			};
 
 			store.hydrate(workflow);
@@ -463,7 +463,7 @@ describe('workflowDocument.store orchestration', () => {
 			expect([...store.tags]).toEqual(firstSnapshot.tags);
 			expect(store.checksum).toBe(firstSnapshot.checksum);
 			expect(store.allNodes.map((n) => n.name)).toEqual(firstSnapshot.allNodes);
-			expect({ ...store.pinData }).toEqual(firstSnapshot.pinData);
+			expect({ ...store.pinnedDataByNodeName }).toEqual(firstSnapshot.pinData);
 		});
 
 		describe('identity guards', () => {
@@ -579,11 +579,11 @@ describe('workflowDocument.store orchestration', () => {
 			const node = createNode({ name: 'A' });
 			store.setNodes([node]);
 			store.setPinData({ A: [{ json: { value: 1 } }] });
-			expect(store.pinData).toHaveProperty('A');
+			expect(store.pinnedDataByNodeName).toHaveProperty('A');
 
 			store.removeNode(node);
 
-			expect(store.pinData).not.toHaveProperty('A');
+			expect(store.pinnedDataByNodeName).not.toHaveProperty('A');
 		});
 
 		it('removeNodeById unpins node data', () => {
@@ -591,11 +591,11 @@ describe('workflowDocument.store orchestration', () => {
 			const node = createNode({ name: 'A' });
 			store.setNodes([node]);
 			store.setPinData({ A: [{ json: { value: 1 } }] });
-			expect(store.pinData).toHaveProperty('A');
+			expect(store.pinnedDataByNodeName).toHaveProperty('A');
 
 			store.removeNodeById(node.id);
 
-			expect(store.pinData).not.toHaveProperty('A');
+			expect(store.pinnedDataByNodeName).not.toHaveProperty('A');
 		});
 	});
 
@@ -661,7 +661,7 @@ describe('workflowDocument.store orchestration', () => {
 			expect(store.versionData).toEqual({ versionId: '', name: null, description: null });
 			expect(store.allNodes).toHaveLength(0);
 			expect(store.connectionsBySourceNode).toEqual({});
-			expect(store.pinData).toEqual({});
+			expect(store.pinnedDataByNodeName).toEqual({});
 			expect(store.viewport).toBeNull();
 		});
 	});

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.test.ts
@@ -62,14 +62,14 @@ describe('workflowDocument.store orchestration', () => {
 		// Verify all are populated
 		expect(workflowDocumentStore.allNodes).toHaveLength(2);
 		expect(workflowDocumentStore.connectionsBySourceNode).toHaveProperty('A');
-		expect(workflowDocumentStore.pinData).toHaveProperty('A');
+		expect(workflowDocumentStore.pinnedDataByNodeName).toHaveProperty('A');
 
 		// removeAllNodes should clear all three
 		workflowDocumentStore.removeAllNodes();
 
 		expect(workflowDocumentStore.allNodes).toHaveLength(0);
 		expect(workflowDocumentStore.connectionsBySourceNode).toEqual({});
-		expect(workflowDocumentStore.pinData).toEqual({});
+		expect(workflowDocumentStore.pinnedDataByNodeName).toEqual({});
 	});
 
 	it('disposeWorkflowDocumentStore disposes the instance and clears scoped state', () => {

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -35,7 +35,7 @@ import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
 import { serializeNode } from '@/app/utils/nodes/nodeTransforms';
 import type { WorkflowObjectAccessors } from '../types';
 import type { IWorkflowDb } from '@/Interface';
-import type { INode, IPinData, ProjectSharingData } from 'n8n-workflow';
+import type { INode, ProjectSharingData } from 'n8n-workflow';
 import { deepCopy } from 'n8n-workflow';
 import type { WorkflowData } from '@n8n/rest-api-client/api/workflows';
 import type { Scope } from '@n8n/permissions';
@@ -219,7 +219,7 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 			const data: WorkflowData = {
 				name: workflowDocumentName.name.value,
 				nodes,
-				pinData: workflowDocumentPinData.getPinDataSnapshot() as IPinData,
+				pinData: workflowDocumentPinData.getPinDataSnapshot(),
 				connections,
 				active: workflowDocumentActive.active.value,
 				settings: workflowDocumentSettings.settings.value,
@@ -329,7 +329,7 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 			return {
 				id: workflowId,
 				connectionsBySourceNode: workflowDocumentConnections.connectionsBySourceNode.value,
-				pinData: workflowDocumentPinData.pinData.value as IPinData,
+				pinData: workflowDocumentPinData.getPinDataSnapshot(),
 				expression: workflowDocumentExpression.getExpressionHandler(),
 				getNode: workflowDocumentNodes.getNodeByName,
 				getParentNodes: workflowDocumentGraph.getParentNodes,
@@ -354,7 +354,7 @@ export function useWorkflowDocumentStore(id: WorkflowDocumentId) {
 				connections: workflowDocumentConnections.connectionsBySourceNode.value,
 				settings: { ...DEFAULT_SETTINGS, ...workflowDocumentSettings.settings.value },
 				tags: [...workflowDocumentTags.tags.value],
-				pinData: workflowDocumentPinData.pinData.value as IPinData,
+				pinData: workflowDocumentPinData.getPinDataSnapshot(),
 				sharedWithProjects: (workflowDocumentSharedWithProjects.sharedWithProjects.value ??
 					[]) as ProjectSharingData[],
 				homeProject: workflowDocumentHomeProject.homeProject.value ?? undefined,

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { computed, effectScope } from 'vue';
+import { effectScope, watchEffect } from 'vue';
 import type { INodeExecutionData, IPinData } from 'n8n-workflow';
 import {
 	useWorkflowDocumentPinData,
@@ -306,18 +306,18 @@ describe('useWorkflowDocumentPinData', () => {
 			let evaluations = 0;
 
 			scope.run(() => {
-				const nodeA = computed(() => {
-					evaluations += 1;
-					return pinnedDataByNodeName.A;
-				});
-				// Prime the computed
-				void nodeA.value;
+				watchEffect(
+					() => {
+						evaluations += 1;
+						void pinnedDataByNodeName.A;
+					},
+					{ flush: 'sync' },
+				);
 			});
 
 			expect(evaluations).toBe(1);
 
 			pinNodeData('B', [{ json: { value: 1 } }]);
-			// Force a re-read; without per-key reactivity this would re-evaluate
 			expect(evaluations).toBe(1);
 
 			pinNodeData('A', [{ json: { value: 1 } }]);

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { effectScope, watchEffect } from 'vue';
 import type { INodeExecutionData, IPinData } from 'n8n-workflow';
 import {
 	useWorkflowDocumentPinData,
@@ -19,7 +18,7 @@ describe('useWorkflowDocumentPinData', () => {
 	describe('initial state', () => {
 		it('should start with empty pin data', () => {
 			const { pinnedDataByNodeName } = createPinData();
-			expect(pinnedDataByNodeName).toEqual({});
+			expect(pinnedDataByNodeName.value).toEqual({});
 		});
 	});
 
@@ -32,7 +31,7 @@ describe('useWorkflowDocumentPinData', () => {
 
 			setPinData(data);
 
-			expect(pinnedDataByNodeName).toEqual({ Node1: [{ json: { key: 'value' } }] });
+			expect(pinnedDataByNodeName.value).toEqual({ Node1: [{ json: { key: 'value' } }] });
 		});
 
 		it('should fire event hook with bulk payload', () => {
@@ -57,7 +56,7 @@ describe('useWorkflowDocumentPinData', () => {
 
 			setPinData(data);
 
-			expect(pinnedDataByNodeName).toEqual({ Node1: [{ json: { key: 'value' } }] });
+			expect(pinnedDataByNodeName.value).toEqual({ Node1: [{ json: { key: 'value' } }] });
 		});
 
 		it('should replace existing pin data entirely', () => {
@@ -65,8 +64,8 @@ describe('useWorkflowDocumentPinData', () => {
 			setPinData({ Node1: [{ json: { a: 1 } }] });
 			setPinData({ Node2: [{ json: { b: 2 } }] });
 
-			expect(pinnedDataByNodeName).toEqual({ Node2: [{ json: { b: 2 } }] });
-			expect(pinnedDataByNodeName).not.toHaveProperty('Node1');
+			expect(pinnedDataByNodeName.value).toEqual({ Node2: [{ json: { b: 2 } }] });
+			expect(pinnedDataByNodeName.value).not.toHaveProperty('Node1');
 		});
 	});
 
@@ -76,7 +75,7 @@ describe('useWorkflowDocumentPinData', () => {
 
 			pinNodeData('Node1', [{ json: { key: 'value' } }]);
 
-			expect(pinnedDataByNodeName).toEqual({ Node1: [{ json: { key: 'value' } }] });
+			expect(pinnedDataByNodeName.value).toEqual({ Node1: [{ json: { key: 'value' } }] });
 		});
 
 		it('should fire event hook with add action for new node', () => {
@@ -121,13 +120,13 @@ describe('useWorkflowDocumentPinData', () => {
 
 			pinNodeData('Node1', data);
 
-			expect(pinnedDataByNodeName.Node1[0]).toEqual({
+			expect(pinnedDataByNodeName.value.Node1[0]).toEqual({
 				json: { key: 'value' },
 				binary: { file: { mimeType: 'text/plain', data: 'abc' } },
 				pairedItem: { item: 0 },
 			});
-			expect(pinnedDataByNodeName.Node1[0]).not.toHaveProperty('index');
-			expect(pinnedDataByNodeName.Node1[0]).not.toHaveProperty('executionIndex');
+			expect(pinnedDataByNodeName.value.Node1[0]).not.toHaveProperty('index');
+			expect(pinnedDataByNodeName.value.Node1[0]).not.toHaveProperty('executionIndex');
 		});
 
 		it('should wrap items without json key in { json: item }', () => {
@@ -136,7 +135,7 @@ describe('useWorkflowDocumentPinData', () => {
 
 			pinNodeData('Node1', data);
 
-			expect(pinnedDataByNodeName).toEqual({
+			expect(pinnedDataByNodeName.value).toEqual({
 				Node1: [{ json: { key: 'value' } }],
 			});
 		});
@@ -146,7 +145,7 @@ describe('useWorkflowDocumentPinData', () => {
 			pinNodeData('Node1', [{ json: { a: 1 } }]);
 			pinNodeData('Node2', [{ json: { b: 2 } }]);
 
-			expect(pinnedDataByNodeName).toEqual({
+			expect(pinnedDataByNodeName.value).toEqual({
 				Node1: [{ json: { a: 1 } }],
 				Node2: [{ json: { b: 2 } }],
 			});
@@ -157,7 +156,7 @@ describe('useWorkflowDocumentPinData', () => {
 			pinNodeData('Node1', [{ json: { a: 1 } }]);
 			pinNodeData('Node1', [{ json: { a: 2 } }]);
 
-			expect(pinnedDataByNodeName).toEqual({ Node1: [{ json: { a: 2 } }] });
+			expect(pinnedDataByNodeName.value).toEqual({ Node1: [{ json: { a: 2 } }] });
 		});
 
 		it('should handle non-array input by wrapping in array', () => {
@@ -166,7 +165,7 @@ describe('useWorkflowDocumentPinData', () => {
 
 			pinNodeData('Node1', data);
 
-			expect(pinnedDataByNodeName).toEqual({ Node1: [{ json: { key: 'value' } }] });
+			expect(pinnedDataByNodeName.value).toEqual({ Node1: [{ json: { key: 'value' } }] });
 		});
 	});
 
@@ -178,7 +177,7 @@ describe('useWorkflowDocumentPinData', () => {
 
 			unpinNodeData('Node1');
 
-			expect(pinnedDataByNodeName).toEqual({ Node2: [{ json: { b: 2 } }] });
+			expect(pinnedDataByNodeName.value).toEqual({ Node2: [{ json: { b: 2 } }] });
 		});
 
 		it('should fire event hook with delete action', () => {
@@ -200,7 +199,7 @@ describe('useWorkflowDocumentPinData', () => {
 
 			unpinNodeData('NonExistent');
 
-			expect(pinnedDataByNodeName).toEqual({});
+			expect(pinnedDataByNodeName.value).toEqual({});
 		});
 	});
 
@@ -214,8 +213,8 @@ describe('useWorkflowDocumentPinData', () => {
 
 			renamePinDataNode('OldName', 'NewName');
 
-			expect(pinnedDataByNodeName).not.toHaveProperty('OldName');
-			expect(pinnedDataByNodeName).toEqual({ NewName: [{ json: { key: 'value' } }] });
+			expect(pinnedDataByNodeName.value).not.toHaveProperty('OldName');
+			expect(pinnedDataByNodeName.value).toEqual({ NewName: [{ json: { key: 'value' } }] });
 			expect(hookSpy).toHaveBeenCalledWith({
 				action: 'update',
 				payload: { nodeName: 'NewName', data: [{ json: { key: 'value' } }] },
@@ -228,8 +227,8 @@ describe('useWorkflowDocumentPinData', () => {
 
 			renamePinDataNode('NonExistent', 'NewName');
 
-			expect(pinnedDataByNodeName).toEqual({ Node1: [{ json: { key: 'value' } }] });
-			expect(pinnedDataByNodeName).not.toHaveProperty('NewName');
+			expect(pinnedDataByNodeName.value).toEqual({ Node1: [{ json: { key: 'value' } }] });
+			expect(pinnedDataByNodeName.value).not.toHaveProperty('NewName');
 		});
 
 		it('should update pairedItem sourceOverwrite references', () => {
@@ -248,7 +247,7 @@ describe('useWorkflowDocumentPinData', () => {
 
 			renamePinDataNode('OldName', 'NewName');
 
-			const pairedItem = pinnedDataByNodeName.Node2[0].pairedItem as unknown as {
+			const pairedItem = pinnedDataByNodeName.value.Node2[0].pairedItem as unknown as {
 				sourceOverwrite: { previousNode: string };
 			};
 			expect(pairedItem.sourceOverwrite.previousNode).toBe('NewName');
@@ -276,7 +275,7 @@ describe('useWorkflowDocumentPinData', () => {
 
 			renamePinDataNode('OldName', 'NewName');
 
-			const pairedItems = pinnedDataByNodeName.Node2[0].pairedItem as unknown as Array<{
+			const pairedItems = pinnedDataByNodeName.value.Node2[0].pairedItem as unknown as Array<{
 				sourceOverwrite: { previousNode: string };
 			}>;
 			expect(pairedItems[0].sourceOverwrite.previousNode).toBe('NewName');
@@ -295,35 +294,7 @@ describe('useWorkflowDocumentPinData', () => {
 			});
 
 			expect(() => renamePinDataNode('OldName', 'NewName')).not.toThrow();
-			expect(pinnedDataByNodeName.Node2[0].pairedItem).toBe(0);
-		});
-	});
-
-	describe('per-key reactivity', () => {
-		it('should not invalidate a key-A subscriber when key B changes', () => {
-			const { pinnedDataByNodeName, pinNodeData } = createPinData();
-			const scope = effectScope();
-			let evaluations = 0;
-
-			scope.run(() => {
-				watchEffect(
-					() => {
-						evaluations += 1;
-						void pinnedDataByNodeName.A;
-					},
-					{ flush: 'sync' },
-				);
-			});
-
-			expect(evaluations).toBe(1);
-
-			pinNodeData('B', [{ json: { value: 1 } }]);
-			expect(evaluations).toBe(1);
-
-			pinNodeData('A', [{ json: { value: 1 } }]);
-			expect(evaluations).toBe(2);
-
-			scope.stop();
+			expect(pinnedDataByNodeName.value.Node2[0].pairedItem).toBe(0);
 		});
 	});
 
@@ -335,7 +306,7 @@ describe('useWorkflowDocumentPinData', () => {
 		it('should return undefined when indexing a non-existent node', () => {
 			const { pinnedDataByNodeName } = createPinData();
 
-			expect(pinDataToExecutionData(pinnedDataByNodeName).NonExistent).toBeUndefined();
+			expect(pinDataToExecutionData(pinnedDataByNodeName.value).NonExistent).toBeUndefined();
 		});
 
 		it('should return unwrapped json values for all nodes', () => {
@@ -343,7 +314,7 @@ describe('useWorkflowDocumentPinData', () => {
 			pinNodeData('Node1', [{ json: { key: 'value1' } }, { json: { key: 'value2' } }]);
 			pinNodeData('Node2', [{ json: { key: 'value3' } }]);
 
-			const result = pinDataToExecutionData(pinnedDataByNodeName);
+			const result = pinDataToExecutionData(pinnedDataByNodeName.value);
 
 			expect(result).toEqual({
 				Node1: [{ key: 'value1' }, { key: 'value2' }],
@@ -359,9 +330,9 @@ describe('useWorkflowDocumentPinData', () => {
 
 			const snapshot = getPinDataSnapshot();
 
-			expect(snapshot).toEqual(pinnedDataByNodeName);
+			expect(snapshot).toEqual(pinnedDataByNodeName.value);
 			snapshot.Node2 = [{ json: { key: 'new' } }];
-			expect(pinnedDataByNodeName).not.toHaveProperty('Node2');
+			expect(pinnedDataByNodeName.value).not.toHaveProperty('Node2');
 
 			pinNodeData('Node3', [{ json: { key: 'later' } }]);
 			expect(snapshot).not.toHaveProperty('Node3');

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { computed, effectScope } from 'vue';
 import type { INodeExecutionData, IPinData } from 'n8n-workflow';
 import {
 	useWorkflowDocumentPinData,
@@ -17,21 +18,21 @@ describe('useWorkflowDocumentPinData', () => {
 
 	describe('initial state', () => {
 		it('should start with empty pin data', () => {
-			const { pinData } = createPinData();
-			expect(pinData.value).toEqual({});
+			const { pinnedDataByNodeName } = createPinData();
+			expect(pinnedDataByNodeName).toEqual({});
 		});
 	});
 
 	describe('setPinData', () => {
 		it('should set pin data with json-key objects', () => {
-			const { pinData, setPinData } = createPinData();
+			const { pinnedDataByNodeName, setPinData } = createPinData();
 			const data: IPinData = {
 				Node1: [{ json: { key: 'value' } }],
 			};
 
 			setPinData(data);
 
-			expect(pinData.value).toEqual({ Node1: [{ json: { key: 'value' } }] });
+			expect(pinnedDataByNodeName).toEqual({ Node1: [{ json: { key: 'value' } }] });
 		});
 
 		it('should fire event hook with bulk payload', () => {
@@ -49,33 +50,33 @@ describe('useWorkflowDocumentPinData', () => {
 		});
 
 		it('should normalize items without json key wrapper', () => {
-			const { pinData, setPinData } = createPinData();
+			const { pinnedDataByNodeName, setPinData } = createPinData();
 			const data = {
 				Node1: [{ key: 'value' } as unknown as INodeExecutionData],
 			};
 
 			setPinData(data);
 
-			expect(pinData.value).toEqual({ Node1: [{ json: { key: 'value' } }] });
+			expect(pinnedDataByNodeName).toEqual({ Node1: [{ json: { key: 'value' } }] });
 		});
 
 		it('should replace existing pin data entirely', () => {
-			const { pinData, setPinData } = createPinData();
+			const { pinnedDataByNodeName, setPinData } = createPinData();
 			setPinData({ Node1: [{ json: { a: 1 } }] });
 			setPinData({ Node2: [{ json: { b: 2 } }] });
 
-			expect(pinData.value).toEqual({ Node2: [{ json: { b: 2 } }] });
-			expect(pinData.value).not.toHaveProperty('Node1');
+			expect(pinnedDataByNodeName).toEqual({ Node2: [{ json: { b: 2 } }] });
+			expect(pinnedDataByNodeName).not.toHaveProperty('Node1');
 		});
 	});
 
 	describe('pinNodeData', () => {
 		it('should pin data for a specific node', () => {
-			const { pinData, pinNodeData } = createPinData();
+			const { pinnedDataByNodeName, pinNodeData } = createPinData();
 
 			pinNodeData('Node1', [{ json: { key: 'value' } }]);
 
-			expect(pinData.value).toEqual({ Node1: [{ json: { key: 'value' } }] });
+			expect(pinnedDataByNodeName).toEqual({ Node1: [{ json: { key: 'value' } }] });
 		});
 
 		it('should fire event hook with add action for new node', () => {
@@ -106,7 +107,7 @@ describe('useWorkflowDocumentPinData', () => {
 		});
 
 		it('should normalize data by stripping runtime properties', () => {
-			const { pinData, pinNodeData } = createPinData();
+			const { pinnedDataByNodeName, pinNodeData } = createPinData();
 			const data = [
 				{
 					json: { key: 'value' },
@@ -120,64 +121,64 @@ describe('useWorkflowDocumentPinData', () => {
 
 			pinNodeData('Node1', data);
 
-			expect(pinData.value.Node1[0]).toEqual({
+			expect(pinnedDataByNodeName.Node1[0]).toEqual({
 				json: { key: 'value' },
 				binary: { file: { mimeType: 'text/plain', data: 'abc' } },
 				pairedItem: { item: 0 },
 			});
-			expect(pinData.value.Node1[0]).not.toHaveProperty('index');
-			expect(pinData.value.Node1[0]).not.toHaveProperty('executionIndex');
+			expect(pinnedDataByNodeName.Node1[0]).not.toHaveProperty('index');
+			expect(pinnedDataByNodeName.Node1[0]).not.toHaveProperty('executionIndex');
 		});
 
 		it('should wrap items without json key in { json: item }', () => {
-			const { pinData, pinNodeData } = createPinData();
+			const { pinnedDataByNodeName, pinNodeData } = createPinData();
 			const data = [{ key: 'value' } as unknown as INodeExecutionData];
 
 			pinNodeData('Node1', data);
 
-			expect(pinData.value).toEqual({
+			expect(pinnedDataByNodeName).toEqual({
 				Node1: [{ json: { key: 'value' } }],
 			});
 		});
 
 		it('should preserve existing nodes when pinning a new one', () => {
-			const { pinData, pinNodeData } = createPinData();
+			const { pinnedDataByNodeName, pinNodeData } = createPinData();
 			pinNodeData('Node1', [{ json: { a: 1 } }]);
 			pinNodeData('Node2', [{ json: { b: 2 } }]);
 
-			expect(pinData.value).toEqual({
+			expect(pinnedDataByNodeName).toEqual({
 				Node1: [{ json: { a: 1 } }],
 				Node2: [{ json: { b: 2 } }],
 			});
 		});
 
 		it('should overwrite existing pin data for the same node', () => {
-			const { pinData, pinNodeData } = createPinData();
+			const { pinnedDataByNodeName, pinNodeData } = createPinData();
 			pinNodeData('Node1', [{ json: { a: 1 } }]);
 			pinNodeData('Node1', [{ json: { a: 2 } }]);
 
-			expect(pinData.value).toEqual({ Node1: [{ json: { a: 2 } }] });
+			expect(pinnedDataByNodeName).toEqual({ Node1: [{ json: { a: 2 } }] });
 		});
 
 		it('should handle non-array input by wrapping in array', () => {
-			const { pinData, pinNodeData } = createPinData();
+			const { pinnedDataByNodeName, pinNodeData } = createPinData();
 			const data = { json: { key: 'value' } } as unknown as INodeExecutionData[];
 
 			pinNodeData('Node1', data);
 
-			expect(pinData.value).toEqual({ Node1: [{ json: { key: 'value' } }] });
+			expect(pinnedDataByNodeName).toEqual({ Node1: [{ json: { key: 'value' } }] });
 		});
 	});
 
 	describe('unpinNodeData', () => {
 		it('should remove pin data for a specific node', () => {
-			const { pinData, pinNodeData, unpinNodeData } = createPinData();
+			const { pinnedDataByNodeName, pinNodeData, unpinNodeData } = createPinData();
 			pinNodeData('Node1', [{ json: { a: 1 } }]);
 			pinNodeData('Node2', [{ json: { b: 2 } }]);
 
 			unpinNodeData('Node1');
 
-			expect(pinData.value).toEqual({ Node2: [{ json: { b: 2 } }] });
+			expect(pinnedDataByNodeName).toEqual({ Node2: [{ json: { b: 2 } }] });
 		});
 
 		it('should fire event hook with delete action', () => {
@@ -195,25 +196,26 @@ describe('useWorkflowDocumentPinData', () => {
 		});
 
 		it('should handle unpinning a non-existent node gracefully', () => {
-			const { pinData, unpinNodeData } = createPinData();
+			const { pinnedDataByNodeName, unpinNodeData } = createPinData();
 
 			unpinNodeData('NonExistent');
 
-			expect(pinData.value).toEqual({});
+			expect(pinnedDataByNodeName).toEqual({});
 		});
 	});
 
 	describe('renamePinDataNode', () => {
 		it('should rename a node key in pin data and fire event hook', () => {
-			const { pinData, pinNodeData, renamePinDataNode, onPinnedDataChange } = createPinData();
+			const { pinnedDataByNodeName, pinNodeData, renamePinDataNode, onPinnedDataChange } =
+				createPinData();
 			pinNodeData('OldName', [{ json: { key: 'value' } }]);
 			const hookSpy = vi.fn();
 			onPinnedDataChange(hookSpy);
 
 			renamePinDataNode('OldName', 'NewName');
 
-			expect(pinData.value).not.toHaveProperty('OldName');
-			expect(pinData.value).toEqual({ NewName: [{ json: { key: 'value' } }] });
+			expect(pinnedDataByNodeName).not.toHaveProperty('OldName');
+			expect(pinnedDataByNodeName).toEqual({ NewName: [{ json: { key: 'value' } }] });
 			expect(hookSpy).toHaveBeenCalledWith({
 				action: 'update',
 				payload: { nodeName: 'NewName', data: [{ json: { key: 'value' } }] },
@@ -221,17 +223,17 @@ describe('useWorkflowDocumentPinData', () => {
 		});
 
 		it('should not modify pin data if old name does not exist', () => {
-			const { pinData, pinNodeData, renamePinDataNode } = createPinData();
+			const { pinnedDataByNodeName, pinNodeData, renamePinDataNode } = createPinData();
 			pinNodeData('Node1', [{ json: { key: 'value' } }]);
 
 			renamePinDataNode('NonExistent', 'NewName');
 
-			expect(pinData.value).toEqual({ Node1: [{ json: { key: 'value' } }] });
-			expect(pinData.value).not.toHaveProperty('NewName');
+			expect(pinnedDataByNodeName).toEqual({ Node1: [{ json: { key: 'value' } }] });
+			expect(pinnedDataByNodeName).not.toHaveProperty('NewName');
 		});
 
 		it('should update pairedItem sourceOverwrite references', () => {
-			const { pinData, setPinData, renamePinDataNode } = createPinData();
+			const { pinnedDataByNodeName, setPinData, renamePinDataNode } = createPinData();
 			setPinData({
 				Node2: [
 					{
@@ -246,14 +248,14 @@ describe('useWorkflowDocumentPinData', () => {
 
 			renamePinDataNode('OldName', 'NewName');
 
-			const pairedItem = pinData.value.Node2[0].pairedItem as unknown as {
+			const pairedItem = pinnedDataByNodeName.Node2[0].pairedItem as unknown as {
 				sourceOverwrite: { previousNode: string };
 			};
 			expect(pairedItem.sourceOverwrite.previousNode).toBe('NewName');
 		});
 
 		it('should update pairedItem array sourceOverwrite references', () => {
-			const { pinData, setPinData, renamePinDataNode } = createPinData();
+			const { pinnedDataByNodeName, setPinData, renamePinDataNode } = createPinData();
 			setPinData({
 				Node2: [
 					{
@@ -274,7 +276,7 @@ describe('useWorkflowDocumentPinData', () => {
 
 			renamePinDataNode('OldName', 'NewName');
 
-			const pairedItems = pinData.value.Node2[0].pairedItem as unknown as Array<{
+			const pairedItems = pinnedDataByNodeName.Node2[0].pairedItem as unknown as Array<{
 				sourceOverwrite: { previousNode: string };
 			}>;
 			expect(pairedItems[0].sourceOverwrite.previousNode).toBe('NewName');
@@ -282,7 +284,7 @@ describe('useWorkflowDocumentPinData', () => {
 		});
 
 		it('should skip numeric pairedItem values', () => {
-			const { pinData, setPinData, renamePinDataNode } = createPinData();
+			const { pinnedDataByNodeName, setPinData, renamePinDataNode } = createPinData();
 			setPinData({
 				Node2: [
 					{
@@ -293,7 +295,35 @@ describe('useWorkflowDocumentPinData', () => {
 			});
 
 			expect(() => renamePinDataNode('OldName', 'NewName')).not.toThrow();
-			expect(pinData.value.Node2[0].pairedItem).toBe(0);
+			expect(pinnedDataByNodeName.Node2[0].pairedItem).toBe(0);
+		});
+	});
+
+	describe('per-key reactivity', () => {
+		it('should not invalidate a key-A subscriber when key B changes', () => {
+			const { pinnedDataByNodeName, pinNodeData } = createPinData();
+			const scope = effectScope();
+			let evaluations = 0;
+
+			scope.run(() => {
+				const nodeA = computed(() => {
+					evaluations += 1;
+					return pinnedDataByNodeName.A;
+				});
+				// Prime the computed
+				void nodeA.value;
+			});
+
+			expect(evaluations).toBe(1);
+
+			pinNodeData('B', [{ json: { value: 1 } }]);
+			// Force a re-read; without per-key reactivity this would re-evaluate
+			expect(evaluations).toBe(1);
+
+			pinNodeData('A', [{ json: { value: 1 } }]);
+			expect(evaluations).toBe(2);
+
+			scope.stop();
 		});
 	});
 
@@ -303,17 +333,17 @@ describe('useWorkflowDocumentPinData', () => {
 		});
 
 		it('should return undefined when indexing a non-existent node', () => {
-			const { pinData } = createPinData();
+			const { pinnedDataByNodeName } = createPinData();
 
-			expect(pinDataToExecutionData(pinData.value).NonExistent).toBeUndefined();
+			expect(pinDataToExecutionData(pinnedDataByNodeName).NonExistent).toBeUndefined();
 		});
 
 		it('should return unwrapped json values for all nodes', () => {
-			const { pinData, pinNodeData } = createPinData();
+			const { pinnedDataByNodeName, pinNodeData } = createPinData();
 			pinNodeData('Node1', [{ json: { key: 'value1' } }, { json: { key: 'value2' } }]);
 			pinNodeData('Node2', [{ json: { key: 'value3' } }]);
 
-			const result = pinDataToExecutionData(pinData.value);
+			const result = pinDataToExecutionData(pinnedDataByNodeName);
 
 			expect(result).toEqual({
 				Node1: [{ key: 'value1' }, { key: 'value2' }],
@@ -323,16 +353,18 @@ describe('useWorkflowDocumentPinData', () => {
 	});
 
 	describe('getPinDataSnapshot', () => {
-		it('should return a mutable shallow copy', () => {
-			const { pinData, pinNodeData, getPinDataSnapshot } = createPinData();
+		it('should return a mutable shallow copy disconnected from later mutations', () => {
+			const { pinnedDataByNodeName, pinNodeData, getPinDataSnapshot } = createPinData();
 			pinNodeData('Node1', [{ json: { key: 'value' } }]);
 
 			const snapshot = getPinDataSnapshot();
 
-			expect(snapshot).toEqual(pinData.value);
-			// Should be a different object reference
+			expect(snapshot).toEqual(pinnedDataByNodeName);
 			snapshot.Node2 = [{ json: { key: 'new' } }];
-			expect(pinData.value).not.toHaveProperty('Node2');
+			expect(pinnedDataByNodeName).not.toHaveProperty('Node2');
+
+			pinNodeData('Node3', [{ json: { key: 'later' } }]);
+			expect(snapshot).not.toHaveProperty('Node3');
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.ts
@@ -1,4 +1,4 @@
-import { shallowReactive } from 'vue';
+import { ref, readonly } from 'vue';
 import { createEventHook } from '@vueuse/core';
 import type { INodeExecutionData, IDataObject, IPinData } from 'n8n-workflow';
 import { isJsonKeyObject, stringSizeInBytes } from '@/app/utils/typesUtils';
@@ -67,31 +67,26 @@ export function getPinDataSize(
 }
 
 export function useWorkflowDocumentPinData() {
-	// shallowReactive keeps per-key reactivity for `pinnedDataByNodeName[name]`
-	// reads while leaving nested arrays as plain JS — so getPinDataSnapshot()
-	// returns a clean IPinData suitable for JSON serialization.
-	const pinnedDataByNodeName = shallowReactive<IPinData>({});
+	const pinnedDataByNodeName = ref<IPinData>({});
 
 	const onPinnedDataChange = createEventHook<PinDataChangeEvent>();
 
 	function applyPinData(data: IPinData, action: ChangeAction = CHANGE_ACTION.UPDATE) {
-		for (const key of Object.keys(pinnedDataByNodeName)) {
-			delete pinnedDataByNodeName[key];
-		}
-		Object.assign(pinnedDataByNodeName, data);
+		pinnedDataByNodeName.value = data;
 		void onPinnedDataChange.trigger({ action, payload: { pinData: data } });
 	}
 
 	function applyNodePinData(nodeName: string, data: INodeExecutionData[]) {
-		const action: ChangeAction = pinnedDataByNodeName[nodeName]
+		const action: ChangeAction = pinnedDataByNodeName.value[nodeName]
 			? CHANGE_ACTION.UPDATE
 			: CHANGE_ACTION.ADD;
-		pinnedDataByNodeName[nodeName] = data;
+		pinnedDataByNodeName.value = { ...pinnedDataByNodeName.value, [nodeName]: data };
 		void onPinnedDataChange.trigger({ action, payload: { nodeName, data } });
 	}
 
 	function applyUnpin(nodeName: string) {
-		delete pinnedDataByNodeName[nodeName];
+		const { [nodeName]: _, ...rest } = pinnedDataByNodeName.value;
+		pinnedDataByNodeName.value = rest;
 		void onPinnedDataChange.trigger({
 			action: CHANGE_ACTION.DELETE,
 			payload: { nodeName, data: undefined },
@@ -99,11 +94,11 @@ export function useWorkflowDocumentPinData() {
 	}
 
 	function applyRenamePinDataNode(oldName: string, newName: string) {
-		if (pinnedDataByNodeName[oldName]) {
-			pinnedDataByNodeName[newName] = pinnedDataByNodeName[oldName];
-			delete pinnedDataByNodeName[oldName];
+		if (pinnedDataByNodeName.value[oldName]) {
+			const { [oldName]: renamed, ...rest } = pinnedDataByNodeName.value;
+			pinnedDataByNodeName.value = { ...rest, [newName]: renamed };
 		}
-		Object.values(pinnedDataByNodeName)
+		Object.values(pinnedDataByNodeName.value)
 			.flatMap((executionData) =>
 				executionData.flatMap((nodeExecution) =>
 					Array.isArray(nodeExecution.pairedItem)
@@ -118,7 +113,7 @@ export function useWorkflowDocumentPinData() {
 			});
 		void onPinnedDataChange.trigger({
 			action: CHANGE_ACTION.UPDATE,
-			payload: { nodeName: newName, data: pinnedDataByNodeName[newName] },
+			payload: { nodeName: newName, data: pinnedDataByNodeName.value[newName] },
 		});
 	}
 
@@ -139,15 +134,15 @@ export function useWorkflowDocumentPinData() {
 	}
 
 	function getPinDataSnapshot(): IPinData {
-		return { ...pinnedDataByNodeName };
+		return { ...pinnedDataByNodeName.value };
 	}
 
 	function getNodePinData(nodeName: string): INodeExecutionData[] | undefined {
-		return pinnedDataByNodeName[nodeName];
+		return pinnedDataByNodeName.value[nodeName];
 	}
 
 	return {
-		pinnedDataByNodeName,
+		pinnedDataByNodeName: readonly(pinnedDataByNodeName),
 		setPinData,
 		pinNodeData,
 		unpinNodeData,

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.ts
@@ -1,4 +1,4 @@
-import { ref, readonly } from 'vue';
+import { shallowReactive } from 'vue';
 import { createEventHook } from '@vueuse/core';
 import type { INodeExecutionData, IDataObject, IPinData } from 'n8n-workflow';
 import { isJsonKeyObject, stringSizeInBytes } from '@/app/utils/typesUtils';
@@ -66,27 +66,32 @@ export function getPinDataSize(
 	}, 0);
 }
 
-// TODO: Consider replacing the plain object ref with a reactive Map for per-node
-// reactivity and a more natural fit with CRDT Y.Map when collaborative editing lands.
 export function useWorkflowDocumentPinData() {
-	const pinData = ref<IPinData>({});
+	// shallowReactive keeps per-key reactivity for `pinnedDataByNodeName[name]`
+	// reads while leaving nested arrays as plain JS — so getPinDataSnapshot()
+	// returns a clean IPinData suitable for JSON serialization.
+	const pinnedDataByNodeName = shallowReactive<IPinData>({});
 
 	const onPinnedDataChange = createEventHook<PinDataChangeEvent>();
 
 	function applyPinData(data: IPinData, action: ChangeAction = CHANGE_ACTION.UPDATE) {
-		pinData.value = data;
+		for (const key of Object.keys(pinnedDataByNodeName)) {
+			delete pinnedDataByNodeName[key];
+		}
+		Object.assign(pinnedDataByNodeName, data);
 		void onPinnedDataChange.trigger({ action, payload: { pinData: data } });
 	}
 
 	function applyNodePinData(nodeName: string, data: INodeExecutionData[]) {
-		const action: ChangeAction = pinData.value[nodeName] ? CHANGE_ACTION.UPDATE : CHANGE_ACTION.ADD;
-		pinData.value = { ...pinData.value, [nodeName]: data };
+		const action: ChangeAction = pinnedDataByNodeName[nodeName]
+			? CHANGE_ACTION.UPDATE
+			: CHANGE_ACTION.ADD;
+		pinnedDataByNodeName[nodeName] = data;
 		void onPinnedDataChange.trigger({ action, payload: { nodeName, data } });
 	}
 
 	function applyUnpin(nodeName: string) {
-		const { [nodeName]: _, ...rest } = pinData.value;
-		pinData.value = rest;
+		delete pinnedDataByNodeName[nodeName];
 		void onPinnedDataChange.trigger({
 			action: CHANGE_ACTION.DELETE,
 			payload: { nodeName, data: undefined },
@@ -94,11 +99,11 @@ export function useWorkflowDocumentPinData() {
 	}
 
 	function applyRenamePinDataNode(oldName: string, newName: string) {
-		if (pinData.value[oldName]) {
-			const { [oldName]: renamed, ...rest } = pinData.value;
-			pinData.value = { ...rest, [newName]: renamed };
+		if (pinnedDataByNodeName[oldName]) {
+			pinnedDataByNodeName[newName] = pinnedDataByNodeName[oldName];
+			delete pinnedDataByNodeName[oldName];
 		}
-		Object.values(pinData.value)
+		Object.values(pinnedDataByNodeName)
 			.flatMap((executionData) =>
 				executionData.flatMap((nodeExecution) =>
 					Array.isArray(nodeExecution.pairedItem)
@@ -113,7 +118,7 @@ export function useWorkflowDocumentPinData() {
 			});
 		void onPinnedDataChange.trigger({
 			action: CHANGE_ACTION.UPDATE,
-			payload: { nodeName: newName, data: pinData.value[newName] },
+			payload: { nodeName: newName, data: pinnedDataByNodeName[newName] },
 		});
 	}
 
@@ -134,15 +139,15 @@ export function useWorkflowDocumentPinData() {
 	}
 
 	function getPinDataSnapshot(): IPinData {
-		return { ...pinData.value };
+		return { ...pinnedDataByNodeName };
 	}
 
 	function getNodePinData(nodeName: string): INodeExecutionData[] | undefined {
-		return pinData.value[nodeName];
+		return pinnedDataByNodeName[nodeName];
 	}
 
 	return {
-		pinData: readonly(pinData),
+		pinnedDataByNodeName,
 		setPinData,
 		pinNodeData,
 		unpinNodeData,

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { shallowReactive, type ComputedRef } from 'vue';
 import { setActivePinia, createPinia } from 'pinia';
+import type { IPinData } from 'n8n-workflow';
 import type { CanvasConnectionPort } from '@/features/workflows/canvas/canvas.types';
 import {
 	useWorkflowDocumentStore,
@@ -10,6 +11,7 @@ import { useWorkflowDocumentRenderData } from './useWorkflowDocumentRenderData';
 
 const nodeInputsByNodeId = shallowReactive(new Map<string, ComputedRef<CanvasConnectionPort[]>>());
 const nodeOutputsByNodeId = shallowReactive(new Map<string, ComputedRef<CanvasConnectionPort[]>>());
+const pinnedDataByNodeName = shallowReactive<IPinData>({});
 const executionIssuesByNodeName = new Map<string, ComputedRef<string[]>>();
 
 vi.mock('@/app/stores/workflowDocument.store', async (importOriginal) => {
@@ -20,6 +22,7 @@ vi.mock('@/app/stores/workflowDocument.store', async (importOriginal) => {
 			workflowId: 'wf-1',
 			nodeInputsByNodeId,
 			nodeOutputsByNodeId,
+			pinnedDataByNodeName,
 		})),
 	};
 });
@@ -42,6 +45,12 @@ describe('useWorkflowDocumentRenderData', () => {
 
 		expect(renderData.nodeInputsByNodeId).toBe(nodeInputsByNodeId);
 		expect(renderData.nodeOutputsByNodeId).toBe(nodeOutputsByNodeId);
+	});
+
+	it('passes through pinnedDataByNodeName by reference', () => {
+		const renderData = useWorkflowDocumentRenderData(createWorkflowDocumentId('wf-1'));
+
+		expect(renderData.pinnedDataByNodeName).toBe(pinnedDataByNodeName);
 	});
 
 	it('exposes executionIssuesByNodeName resolved via the workflow execution state store', () => {

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.ts
@@ -10,13 +10,18 @@ import {
 /**
  * Canvas render data accessor for a workflow document.
  *
- * Thin façade that re-exposes the per-node port maps owned by
- * `useWorkflowDocumentNodes` and the active execution's per-node-name
- * `executionIssuesByNodeName` map. Reactivity is owned by the underlying
- * stores: the port maps are stable references on the workflow document
- * store, and `executionIssuesByNodeName` resolves through a `computed`
- * on the workflow execution state store that swaps between the active
- * and displayed execution's per-execution maps.
+ * Thin façade that re-exposes:
+ * - the per-node port maps (`nodeInputsByNodeId`, `nodeOutputsByNodeId`)
+ *   owned by `useWorkflowDocumentNodes`,
+ * - the pin data map (`pinnedDataByNodeName`) owned by
+ *   `useWorkflowDocumentPinData`, and
+ * - the active execution's `executionIssuesByNodeName` map.
+ *
+ * Reactivity is owned by the underlying stores: the port maps are stable
+ * references on the workflow document store, `pinnedDataByNodeName` is a
+ * `shallowReactive` with per-key reactivity, and `executionIssuesByNodeName`
+ * resolves through a `computed` on the workflow execution state store that
+ * swaps between the active and displayed execution's per-execution maps.
  */
 export function useWorkflowDocumentRenderData(workflowDocumentId: WorkflowDocumentId) {
 	const workflowDocumentStore = useWorkflowDocumentStore(workflowDocumentId);
@@ -27,6 +32,7 @@ export function useWorkflowDocumentRenderData(workflowDocumentId: WorkflowDocume
 	return {
 		nodeInputsByNodeId: workflowDocumentStore.nodeInputsByNodeId,
 		nodeOutputsByNodeId: workflowDocumentStore.nodeOutputsByNodeId,
+		pinnedDataByNodeName: workflowDocumentStore.pinnedDataByNodeName,
 		executionIssuesByNodeName: executionStateStore.activeExecutionIssuesByNodeName,
 	};
 }

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.test.ts
@@ -962,9 +962,9 @@ describe('useWorkflowsStore', () => {
 				},
 			});
 
-			expect(workflowDocumentStore.pinData?.[nodeName]).not.toBeDefined();
-			expect(workflowDocumentStore.pinData?.[newName]).toBeDefined();
-			expect(workflowDocumentStore.pinData?.['Edit Fields'][0].pairedItem).toEqual([
+			expect(workflowDocumentStore.pinnedDataByNodeName?.[nodeName]).not.toBeDefined();
+			expect(workflowDocumentStore.pinnedDataByNodeName?.[newName]).toBeDefined();
+			expect(workflowDocumentStore.pinnedDataByNodeName?.['Edit Fields'][0].pairedItem).toEqual([
 				{
 					item: 3,
 					sourceOverwrite: {

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -1242,7 +1242,7 @@ const isOnlyChatTriggerNodeActive = computed(() => {
 const chatTriggerNodePinnedData = computed(() => {
 	if (!chatTriggerNode.value) return null;
 
-	return workflowDocumentStore?.value?.pinData?.[chatTriggerNode.value.name];
+	return workflowDocumentStore?.value?.pinnedDataByNodeName?.[chatTriggerNode.value.name];
 });
 
 const isChatHubAvailable = computed(() => {

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
@@ -4089,7 +4089,7 @@ describe('AI Builder store', () => {
 			const workflowDocumentStore = useWorkflowDocumentStore(
 				createWorkflowDocumentId(workflowsStore.workflowId),
 			);
-			expect(workflowDocumentStore.pinData).toEqual({});
+			expect(workflowDocumentStore.pinnedDataByNodeName).toEqual({});
 		});
 
 		it('storeGeneratedPinData merges multiple calls', () => {
@@ -4117,7 +4117,7 @@ describe('AI Builder store', () => {
 			const workflowDocumentStore = useWorkflowDocumentStore(
 				createWorkflowDocumentId(workflowsStore.workflowId),
 			);
-			expect(workflowDocumentStore.pinData).toEqual(pinData);
+			expect(workflowDocumentStore.pinnedDataByNodeName).toEqual(pinData);
 			expect(uiStore.stateIsDirty).toBe(true);
 			expect(builderStore.hasDeferredPinData).toBe(false);
 			expect(builderStore.pinDataApplied).toBe(true);

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
@@ -1393,7 +1393,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 	}
 
 	function unpinAllNodes() {
-		const pinData = workflowDocumentStore.value.pinData;
+		const pinData = workflowDocumentStore.value.pinnedDataByNodeName;
 		if (!pinData) return;
 		for (const nodeName of Object.keys(pinData)) {
 			workflowDocumentStore.value.unpinNodeData(nodeName);

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/ExecuteMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/ExecuteMessage.vue
@@ -138,7 +138,7 @@ const isExecutionBlocked = computed(
 );
 
 const hasPinDataApplied = computed(
-	() => Object.keys(workflowDocumentStore.value.pinData).length > 0,
+	() => Object.keys(workflowDocumentStore.value.pinnedDataByNodeName).length > 0,
 );
 
 const showPostExecutionFollowUps = computed(

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useAIAssistantHelpers.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useAIAssistantHelpers.ts
@@ -312,7 +312,7 @@ export const useAIAssistantHelpers = () => {
 			if (!node) {
 				continue;
 			}
-			if (workflowDocumentStore.pinData?.[node.name]) {
+			if (workflowDocumentStore.pinnedDataByNodeName?.[node.name]) {
 				pinnedNodeNames.push(node.name);
 			}
 			const { getSchemaForExecutionData, getInputDataWithPinned } = useDataSchema();

--- a/packages/frontend/editor-ui/src/features/ai/assistant/composables/useBuilderTodos.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/composables/useBuilderTodos.ts
@@ -93,7 +93,7 @@ export function useBuilderTodos() {
 		}
 		visited.add(nodeName);
 
-		const pinData = workflowDocumentStore.value.pinData;
+		const pinData = workflowDocumentStore.value.pinnedDataByNodeName;
 
 		// Check if node has direct pinned data
 		if (pinData?.[nodeName]?.length) {
@@ -130,7 +130,7 @@ export function useBuilderTodos() {
 		// Explicit dependencies to ensure reactivity when parent node state changes.
 		// Vue's computed may not track dependencies accessed in recursive helper functions,
 		// so we access pinData and nodes here to register them as dependencies.
-		const _pinData = workflowDocumentStore.value.pinData;
+		const _pinData = workflowDocumentStore.value.pinnedDataByNodeName;
 		const _nodes = workflowDocumentStore.value.allNodes;
 		void _pinData;
 		void _nodes;
@@ -151,7 +151,7 @@ export function useBuilderTodos() {
 	const placeholderIssues = computed(() => {
 		// Explicit dependency to ensure reactivity when parent node state changes.
 		// Vue's computed may not track pinData accessed in recursive helper functions.
-		const _pinData = workflowDocumentStore.value.pinData;
+		const _pinData = workflowDocumentStore.value.pinnedDataByNodeName;
 		void _pinData;
 
 		const issues: WorkflowValidationIssue[] = [];
@@ -214,7 +214,7 @@ export function useBuilderTodos() {
 		if (workflowTodos.value.length > 0) return false;
 
 		// Check if any pinned data exists
-		const pinData = workflowDocumentStore.value.pinData;
+		const pinData = workflowDocumentStore.value.pinnedDataByNodeName;
 		if (!pinData || Object.keys(pinData).length === 0) return false;
 
 		// Check base workflow issues that would show if not for pinned data

--- a/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionDebugging.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionDebugging.test.ts
@@ -40,7 +40,7 @@ const { mockWorkflowDocumentStore } = vi.hoisted(() => ({
 		clearPinnedDataTimestamps: vi.fn(),
 		resetAllNodesIssues: vi.fn(),
 		getPinDataSnapshot: vi.fn().mockReturnValue({}),
-		pinData: {},
+		pinnedDataByNodeName: {},
 		settings: {},
 	} satisfies Partial<ReturnType<typeof useWorkflowDocumentStore>>,
 }));

--- a/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionDebugging.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionDebugging.ts
@@ -60,7 +60,7 @@ export const useExecutionDebugging = (providedWorkflowState?: WorkflowState) => 
 
 		// Using the pinned data of the workflow to check if the node is pinned
 		// because workflowsStore.getCurrentWorkflow() returns a cached workflow without the updated pinned data
-		const workflowPinnedNodeNames = Object.keys(workflowDocumentStore.value.pinData);
+		const workflowPinnedNodeNames = Object.keys(workflowDocumentStore.value.pinnedDataByNodeName);
 		const matchingPinnedNodeNames = executionNodeNames.filter((name) =>
 			workflowPinnedNodeNames.includes(name),
 		);

--- a/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewPanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/logs/components/LogsOverviewPanel.test.ts
@@ -44,7 +44,7 @@ const { mockDocumentStore } = vi.hoisted(() => ({
 			getParentNodesByDepth: vi.fn().mockReturnValue([]),
 		}),
 		connectionsBySourceNode: {},
-		pinData: {},
+		pinnedDataByNodeName: {},
 		incomingConnectionsByNodeName: vi.fn().mockReturnValue({}),
 		outgoingConnectionsByNodeName: vi.fn().mockReturnValue({}),
 		settings: {},

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
@@ -620,7 +620,7 @@ const parentNodeOutputData = computed(() => {
 
 const parentNodePinnedData = computed(() => {
 	const parentNode = props.workflowObject.getParentNodesByDepth(node.value?.name ?? '')[0];
-	return workflowDocumentStore?.value?.pinData?.[parentNode?.name || ''] ?? [];
+	return workflowDocumentStore?.value?.pinnedDataByNodeName?.[parentNode?.name || ''] ?? [];
 });
 
 const showPinButton = computed(

--- a/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/ndv.store.ts
@@ -144,7 +144,7 @@ function defineNDVStore(id: NDVStoreId, useCurrentWorkflowDocument = false) {
 		const ndvInputDataWithPinnedData = computed(() => {
 			const data = ndvInputData.value;
 			return ndvInputNodeName.value
-				? (workflowDocumentStore.value.pinData?.[ndvInputNodeName.value] ?? data)
+				? (workflowDocumentStore.value.pinnedDataByNodeName?.[ndvInputNodeName.value] ?? data)
 				: data;
 		});
 

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsView.vue
@@ -141,7 +141,7 @@ const parentNodes = computed(() => {
 
 const parentNode = computed<IConnectedNode | undefined>(() => {
 	for (const parent of parentNodes.value) {
-		if (workflowDocumentStore?.value?.pinData?.[parent.name]) {
+		if (workflowDocumentStore?.value?.pinnedDataByNodeName?.[parent.name]) {
 			return parent;
 		}
 

--- a/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/shared/views/NodeDetailsViewV2.vue
@@ -145,7 +145,7 @@ const parentNodes = computed(() => {
 
 const parentNode = computed(() => {
 	for (const parentNodeName of parentNodes.value) {
-		if (workflowDocumentStore?.value?.pinData?.[parentNodeName]) {
+		if (workflowDocumentStore?.value?.pinnedDataByNodeName?.[parentNodeName]) {
 			return parentNodeName;
 		}
 

--- a/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenuItems.ts
+++ b/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenuItems.ts
@@ -98,7 +98,7 @@ export function useContextMenuItems(targetNodeIds: ComputedRef<string[]>): Compu
 	};
 
 	const hasPinData = (node: INode): boolean => {
-		return !!workflowDocumentStore?.value?.pinData?.[node.name];
+		return !!workflowDocumentStore?.value?.pinnedDataByNodeName?.[node.name];
 	};
 
 	const isExecutable = (node: INodeUi) => {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/__tests__/utils.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/__tests__/utils.ts
@@ -30,7 +30,6 @@ export function createCanvasNodeData({
 	connections = { [CanvasConnectionMode.Input]: {}, [CanvasConnectionMode.Output]: {} },
 	execution = { running: false },
 	issues = { validation: [], visible: false },
-	pinnedData = { count: 0, visible: false },
 	runData = { outputMap: {}, iterations: 0, visible: false },
 	render = {
 		type: CanvasNodeRenderType.Default,
@@ -45,7 +44,6 @@ export function createCanvasNodeData({
 		typeVersion,
 		execution,
 		issues,
-		pinnedData,
 		runData,
 		disabled,
 		connections,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.types.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/canvas.types.ts
@@ -113,10 +113,6 @@ export interface CanvasNodeData {
 		validation: string[];
 		visible: boolean;
 	};
-	pinnedData: {
-		count: number;
-		visible: boolean;
-	};
 	execution: {
 		status?: ExecutionStatus;
 		waiting?: string;

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.test.ts
@@ -30,6 +30,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
+			pinnedDataByNodeName: {},
 			executionIssuesByNodeName: new Map(),
 		},
 	})),

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/CanvasHandleRenderer.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/CanvasHandleRenderer.test.ts
@@ -23,6 +23,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: renderNodeInputsMap,
 			nodeOutputsByNodeId: renderNodeOutputsMap,
+			pinnedDataByNodeName: {},
 			executionIssuesByNodeName: new Map(),
 		},
 	})),

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/render-types/CanvasHandleMainOutput.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/handles/render-types/CanvasHandleMainOutput.test.ts
@@ -17,6 +17,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: renderNodeInputsMap,
 			nodeOutputsByNodeId: renderNodeOutputsMap,
+			pinnedDataByNodeName: {},
 			executionIssuesByNodeName: new Map(),
 		},
 	})),

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNode.test.ts
@@ -34,6 +34,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: renderNodeInputsMap,
 			nodeOutputsByNodeId: renderNodeOutputsMap,
+			pinnedDataByNodeName: {},
 			executionIssuesByNodeName: new Map(),
 		},
 	})),

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeRenderer.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeRenderer.test.ts
@@ -14,6 +14,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
+			pinnedDataByNodeName: {},
 			executionIssuesByNodeName: new Map(),
 		},
 	})),

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.test.ts
@@ -16,6 +16,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
+			pinnedDataByNodeName: {},
 			executionIssuesByNodeName: new Map(),
 		},
 	})),

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.test.ts
@@ -37,6 +37,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: renderNodeInputsMap,
 			nodeOutputsByNodeId: renderNodeOutputsMap,
+			pinnedDataByNodeName: {},
 			executionIssuesByNodeName: new Map(),
 		},
 	})),

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.vue
@@ -40,7 +40,6 @@ const {
 	isDisabled,
 	isReadOnly,
 	isSelected,
-	hasPinnedData,
 	executionStatus,
 	executionWaiting,
 	executionWaitingForNext,
@@ -55,6 +54,7 @@ const outputs = computed(() => renderData.value.nodeOutputsByNodeId.get(id.value
 const hasExecutionErrors = computed(
 	() => (renderData.value.executionIssuesByNodeName.get(name.value)?.value?.length ?? 0) > 0,
 );
+const hasPinnedData = computed(() => !!renderData.value.pinnedDataByNodeName[name.value]);
 const { mainOutputs, mainOutputConnections, mainInputs, mainInputConnections, nonMainInputs } =
 	useNodeConnections({
 		inputs,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeStickyNote.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeStickyNote.test.ts
@@ -11,6 +11,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
+			pinnedDataByNodeName: {},
 			executionIssuesByNodeName: new Map(),
 		},
 	})),

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeDisabledStrikeThrough.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeDisabledStrikeThrough.test.ts
@@ -7,6 +7,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
+			pinnedDataByNodeName: {},
 			executionIssuesByNodeName: new Map(),
 		},
 	})),

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeSettingsIcons.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeSettingsIcons.test.ts
@@ -27,6 +27,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
+			pinnedDataByNodeName: {},
 			executionIssuesByNodeName: new Map(),
 		},
 	})),

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeStatusIcons.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeStatusIcons.test.ts
@@ -8,6 +8,7 @@ import { VIEWS } from '@/app/constants';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { CanvasNodeDirtiness, CanvasNodeRenderType } from '../../../../../canvas.types';
 import { createTestingPinia } from '@pinia/testing';
+import type { IPinData } from 'n8n-workflow';
 import type * as actualVueRouter from 'vue-router';
 import { type RouteLocationNormalizedLoadedGeneric, useRoute } from 'vue-router';
 import CanvasNodeStatusIcons from './CanvasNodeStatusIcons.vue';
@@ -20,12 +21,15 @@ vi.mock('vue-router', async (importOriginal) => {
 	};
 });
 
+const pinnedDataByNodeName: IPinData = {};
+
 vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 	...(await importOriginal<typeof import('@/features/workflows/canvas/canvas.utils')>()),
 	injectCanvasRenderData: vi.fn(() => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
+			pinnedDataByNodeName,
 			executionIssuesByNodeName: new Map(),
 		},
 	})),
@@ -43,14 +47,19 @@ describe('CanvasNodeStatusIcons', () => {
 	beforeEach(() => {
 		nodeTypesStore = mockedStore(useNodeTypesStore);
 		mockedUseRoute.mockReturnValue({} as RouteLocationNormalizedLoadedGeneric);
+		for (const key of Object.keys(pinnedDataByNodeName)) {
+			delete pinnedDataByNodeName[key];
+		}
 	});
 
 	it('should render correctly for a pinned node', () => {
+		pinnedDataByNodeName['Test Node'] = [{ json: { key: 'value' } }];
+
 		const { getByTestId } = renderComponent({
 			global: {
 				provide: {
 					...createCanvasProvide(),
-					...createCanvasNodeProvide({ data: { pinnedData: { count: 5, visible: true } } }),
+					...createCanvasNodeProvide(),
 				},
 			},
 		});
@@ -59,12 +68,14 @@ describe('CanvasNodeStatusIcons', () => {
 	});
 
 	it('should not render pinned icon when disabled', () => {
+		pinnedDataByNodeName['Test Node'] = [{ json: { key: 'value' } }];
+
 		const { queryByTestId } = renderComponent({
 			global: {
 				provide: {
 					...createCanvasProvide(),
 					...createCanvasNodeProvide({
-						data: { disabled: true, pinnedData: { count: 5, visible: true } },
+						data: { disabled: true },
 					}),
 				},
 			},

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeStatusIcons.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeStatusIcons.vue
@@ -26,7 +26,6 @@ const $style = useCssModule();
 
 const {
 	name,
-	hasPinnedData,
 	validationErrors,
 	hasValidationErrors,
 	executionStatus,
@@ -41,6 +40,7 @@ const executionErrors = computed(
 	() => renderData.value.executionIssuesByNodeName.get(name.value)?.value ?? [],
 );
 const hasExecutionErrors = computed(() => executionErrors.value.length > 0);
+const hasPinnedData = computed(() => !!renderData.value.pinnedDataByNodeName[name.value]);
 const route = useRoute();
 
 const hideNodeIssues = computed(() => false); // @TODO Implement this

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeTooltip.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/parts/CanvasNodeTooltip.test.ts
@@ -11,6 +11,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
+			pinnedDataByNodeName: {},
 			executionIssuesByNodeName: new Map(),
 		},
 	})),

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasLayout.test.ts
@@ -46,6 +46,7 @@ describe('useCanvasLayout', () => {
 			shallowRef<CanvasRenderData>({
 				nodeInputsByNodeId: new Map(),
 				nodeOutputsByNodeId: new Map(),
+				pinnedDataByNodeName: {},
 				executionIssuesByNodeName: new Map(),
 			}),
 		);

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.test.ts
@@ -70,12 +70,14 @@ const renderNodeOutputsMap = new Map<string, ComputedRef<CanvasConnectionPort[]>
 const testRenderData = shallowRef<CanvasRenderData>({
 	nodeInputsByNodeId: renderNodeInputsMap,
 	nodeOutputsByNodeId: renderNodeOutputsMap,
+	pinnedDataByNodeName: {},
 	executionIssuesByNodeName: new Map(),
 });
 
 const emptyRenderData = shallowRef<CanvasRenderData>({
 	nodeInputsByNodeId: new Map(),
 	nodeOutputsByNodeId: new Map(),
+	pinnedDataByNodeName: {},
 	executionIssuesByNodeName: new Map(),
 });
 
@@ -92,6 +94,7 @@ function createRenderDataWithExecutionIssuesByNodeName(
 	return shallowRef({
 		nodeInputsByNodeId: new Map(),
 		nodeOutputsByNodeId: new Map(),
+		pinnedDataByNodeName: {},
 		executionIssuesByNodeName,
 	});
 }
@@ -249,10 +252,6 @@ describe('useCanvasMapping', () => {
 						},
 						issues: {
 							validation: [],
-							visible: false,
-						},
-						pinnedData: {
-							count: 0,
 							visible: false,
 						},
 						runData: {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasMapping.ts
@@ -587,10 +587,6 @@ export function useCanvasMapping({
 						validation: nodeValidationErrorsById.value[node.id],
 						visible: nodeHasIssuesById.value[node.id],
 					},
-					pinnedData: {
-						count: nodePinnedDataById.value[node.id]?.length ?? 0,
-						visible: !!nodePinnedDataById.value[node.id],
-					},
 					execution: {
 						status: nodeExecutionStatusById.value[node.id],
 						waiting: nodeExecutionWaitingById.value[node.id],

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNode.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNode.test.ts
@@ -27,8 +27,6 @@ describe('useCanvasNode', () => {
 		});
 		expect(result.isDisabled.value).toBe(false);
 		expect(result.isSelected.value).toBeUndefined();
-		expect(result.pinnedDataCount.value).toBe(0);
-		expect(result.hasPinnedData.value).toBe(false);
 		expect(result.runDataOutputMap.value).toEqual({});
 		expect(result.runDataIterations.value).toBe(0);
 		expect(result.hasRunData.value).toBe(false);
@@ -58,7 +56,6 @@ describe('useCanvasNode', () => {
 				},
 				execution: { status: 'running', waiting: 'waiting', running: true },
 				runData: { outputMap: {}, iterations: 1, visible: true },
-				pinnedData: { count: 1, visible: true },
 				render: {
 					type: CanvasNodeRenderType.Default,
 					options: {
@@ -85,8 +82,6 @@ describe('useCanvasNode', () => {
 		});
 		expect(result.isDisabled.value).toBe(true);
 		expect(result.isSelected.value).toBe(true);
-		expect(result.pinnedDataCount.value).toBe(1);
-		expect(result.hasPinnedData.value).toBe(true);
 		expect(result.runDataOutputMap.value).toEqual({});
 		expect(result.runDataIterations.value).toBe(1);
 		expect(result.hasRunData.value).toBe(true);

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNode.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNode.ts
@@ -19,7 +19,6 @@ export function useCanvasNode() {
 				disabled: false,
 				connections: { [CanvasConnectionMode.Input]: {}, [CanvasConnectionMode.Output]: {} },
 				issues: { validation: [], visible: false },
-				pinnedData: { count: 0, visible: false },
 				execution: {
 					running: false,
 				},
@@ -41,9 +40,6 @@ export function useCanvasNode() {
 	const isDisabled = computed(() => data.value.disabled);
 	const isReadOnly = computed(() => node?.readOnly.value);
 	const isSelected = computed(() => node?.selected.value);
-
-	const pinnedDataCount = computed(() => data.value.pinnedData.count);
-	const hasPinnedData = computed(() => data.value.pinnedData.count > 0);
 
 	const validationErrors = computed(() => data.value.issues.validation ?? []);
 	const hasIssues = computed(() => data.value.issues.visible);
@@ -80,8 +76,6 @@ export function useCanvasNode() {
 		isDisabled,
 		isReadOnly,
 		isSelected,
-		pinnedDataCount,
-		hasPinnedData,
 		runDataIterations,
 		runDataOutputMap,
 		hasRunData,

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/SyncedWorkflowCanvas.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/SyncedWorkflowCanvas.test.ts
@@ -95,6 +95,7 @@ describe('SyncedWorkflowCanvas', () => {
 				renderData: {
 					nodeInputsByNodeId: new Map(),
 					nodeOutputsByNodeId: new Map(),
+					pinnedDataByNodeName: {},
 					executionIssuesByNodeName: new Map(),
 				},
 			},
@@ -113,6 +114,7 @@ describe('SyncedWorkflowCanvas', () => {
 					renderData: {
 						nodeInputsByNodeId: new Map(),
 						nodeOutputsByNodeId: new Map(),
+						pinnedDataByNodeName: {},
 						executionIssuesByNodeName: new Map(),
 					},
 				},
@@ -140,6 +142,7 @@ describe('SyncedWorkflowCanvas', () => {
 					renderData: {
 						nodeInputsByNodeId: new Map(),
 						nodeOutputsByNodeId: new Map(),
+						pinnedDataByNodeName: {},
 						executionIssuesByNodeName: new Map(),
 					},
 				},
@@ -163,6 +166,7 @@ describe('SyncedWorkflowCanvas', () => {
 					renderData: {
 						nodeInputsByNodeId: new Map(),
 						nodeOutputsByNodeId: new Map(),
+						pinnedDataByNodeName: {},
 						executionIssuesByNodeName: new Map(),
 					},
 				},
@@ -187,6 +191,7 @@ describe('SyncedWorkflowCanvas', () => {
 					renderData: {
 						nodeInputsByNodeId: new Map(),
 						nodeOutputsByNodeId: new Map(),
+						pinnedDataByNodeName: {},
 						executionIssuesByNodeName: new Map(),
 					},
 				},

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffContent.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffContent.test.ts
@@ -105,11 +105,13 @@ describe('WorkflowDiffContent', () => {
 		sourceRenderData: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
+			pinnedDataByNodeName: {},
 			executionIssuesByNodeName: new Map(),
 		},
 		targetRenderData: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
+			pinnedDataByNodeName: {},
 			executionIssuesByNodeName: new Map(),
 		},
 	};

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/WorkflowDiffModal.test.ts
@@ -63,6 +63,7 @@ vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 		value: {
 			nodeInputsByNodeId: new Map(),
 			nodeOutputsByNodeId: new Map(),
+			pinnedDataByNodeName: {},
 			executionIssuesByNodeName: new Map(),
 		},
 	})),

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiff.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiff.test.ts
@@ -27,6 +27,7 @@ const mockDocumentStore = vi.hoisted(() => ({
 	render: {
 		nodeInputsByNodeId: new Map(),
 		nodeOutputsByNodeId: new Map(),
+		pinnedDataByNodeName: {},
 		executionIssuesByNodeName: new Map(),
 	},
 	$id: 'test-store',

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiff.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiff.ts
@@ -115,6 +115,7 @@ function createDiffRenderData(workflowRef: ComputedRef<IWorkflowDb | undefined>,
 	const renderData = shallowRef<CanvasRenderData>({
 		nodeInputsByNodeId: new Map(),
 		nodeOutputsByNodeId: new Map(),
+		pinnedDataByNodeName: {},
 		executionIssuesByNodeName: new Map(),
 	});
 	let workflowDocumentStore: ReturnType<typeof useWorkflowDocumentStore> | null = null;


### PR DESCRIPTION
## Summary

Migrates pin data from a wholesale-replaced `ref<IPinData>` to a per-key reactive `shallowReactive<IPinData>` renamed `pinnedDataByNodeName`, exposed through `useWorkflowDocumentRenderData`. Removes the `pinnedData: { count, visible }` field from `CanvasNodeData` and inlines `hasPinnedData` derivation in `CanvasNodeDefault.vue` and `CanvasNodeStatusIcons.vue` so pinning one node no longer rerenders pin visuals on other nodes. `serialize()` / `getSnapshot()` / `getWorkflowObjectAccessorSnapshot()` are standardized on `getPinDataSnapshot()` so the reactive storage never leaks outside the composable.

How to test: open a workflow, pin a node, save and reload — pin data round-trips correctly; pin a second node and observe that the first node's border/icon does not re-render. Vitest covers per-key reactivity, the new render-data passthrough, and the renamed field across store/composable tests.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Add Linear ticket URL here if applicable -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI