### PR TITLE
feat(core): Add project.id to workflow.execute OTEL span

### DIFF
--- a/packages/cli/src/modules/otel/__tests__/execution-level-tracer.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/execution-level-tracer.test.ts
@@ -39,6 +39,7 @@ describe('ExecutionLevelTracer', () => {
 				executionId: 'exec-1',
 				tracingContext: inboundTracingContext,
 				workflow: defaultWorkflow,
+				project: { id: 'project-1' },
 			});
 			tracer.endWorkflow({
 				executionId: 'exec-1',
@@ -55,9 +56,26 @@ describe('ExecutionLevelTracer', () => {
 			expect(span.attributes['n8n.workflow.id']).toBe('wf-1');
 			expect(span.attributes['n8n.workflow.name']).toBe('Test');
 			expect(span.attributes['n8n.execution.id']).toBe('exec-1');
+			expect(span.attributes['n8n.project.id']).toBe('project-1');
 			expect(span.attributes['n8n.execution.mode']).toBe('manual');
 			expect(span.attributes['n8n.execution.status']).toBe('success');
 			expect(span.status.code).toBe(SpanStatusCode.OK);
+		});
+
+		it('should omit project id attribute when project is not provided', () => {
+			tracer.startWorkflow({
+				executionId: 'exec-no-project',
+				tracingContext: inboundTracingContext,
+				workflow: defaultWorkflow,
+			});
+			tracer.endWorkflow({
+				executionId: 'exec-no-project',
+				status: 'success',
+				mode: 'manual',
+				isRetry: false,
+			});
+
+			expect(otel.getFinishedSpans()[0].attributes['n8n.project.id']).toBeUndefined();
 		});
 
 		it('should set error status on failed executions', () => {

--- a/packages/cli/src/modules/otel/__tests__/otel-lifecycle-handler.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/otel-lifecycle-handler.test.ts
@@ -72,6 +72,17 @@ describe('OtelLifecycleHandler', () => {
 			);
 		});
 
+		it('should start workflow span without project if project lookup fails', async () => {
+			traceContextService.get.mockResolvedValueOnce(undefined);
+			ownershipService.getWorkflowProjectCached.mockRejectedValueOnce(new Error('DB error'));
+
+			await expect(handler.onWorkflowStart(baseCtx)).resolves.not.toThrow();
+
+			expect(tracer.startWorkflow).toHaveBeenCalledWith(
+				expect.objectContaining({ project: undefined }),
+			);
+		});
+
 		it('should use own tracingContext when present (webhook case)', async () => {
 			const ownContext: TracingContext = {
 				traceparent: '00-aaaa651916cd43dd8448eb211c80319c-aaaa67aa0ba902b7-01',
@@ -172,6 +183,24 @@ describe('OtelLifecycleHandler', () => {
 			expect(ownershipService.getWorkflowProjectCached).toHaveBeenCalledWith('wf-1');
 			expect(tracer.startWorkflow).toHaveBeenCalledWith(
 				expect.objectContaining({ project: { id: 'resume-proj' } }),
+			);
+		});
+
+		it('should start workflow span without project if project lookup fails on resume', async () => {
+			ownershipService.getWorkflowProjectCached.mockRejectedValueOnce(new Error('DB error'));
+
+			await expect(
+				handler.onWorkflowResume({
+					type: 'workflowExecuteResume',
+					workflow: { id: 'wf-1', name: 'Test', versionId: 'v1', nodes: [], connections: {} },
+					workflowInstance: undefined as never,
+					executionData: undefined as never,
+					executionId: 'exec-resume',
+				} as never),
+			).resolves.not.toThrow();
+
+			expect(tracer.startWorkflow).toHaveBeenCalledWith(
+				expect.objectContaining({ project: undefined }),
 			);
 		});
 

--- a/packages/cli/src/modules/otel/__tests__/otel-lifecycle-handler.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/otel-lifecycle-handler.test.ts
@@ -7,9 +7,11 @@ import type {
 import { mock } from 'jest-mock-extended';
 import type { IRun, IRunExecutionData } from 'n8n-workflow';
 
+import type { OwnershipService } from '@/services/ownership.service';
+
 import type { ExecutionLevelTracer } from '../execution-level-tracer';
-import type { OtelConfig } from '../otel.config';
 import { OtelLifecycleHandler, countInputItems, countOutputItems } from '../otel-lifecycle-handler';
+import type { OtelConfig } from '../otel.config';
 import type { TracingContext, TraceContextService } from '../tracing-context';
 
 const emptyExecutionData = {
@@ -22,6 +24,7 @@ describe('OtelLifecycleHandler', () => {
 		const tracer = mock<ExecutionLevelTracer>();
 		const traceContextService = mock<TraceContextService>();
 		const config = mock<OtelConfig>();
+		const ownershipService = mock<OwnershipService>();
 		let handler: OtelLifecycleHandler;
 
 		const parentTracingContext: TracingContext = {
@@ -52,8 +55,21 @@ describe('OtelLifecycleHandler', () => {
 
 		beforeEach(() => {
 			jest.clearAllMocks();
-			handler = new OtelLifecycleHandler(tracer, traceContextService, config);
+			handler = new OtelLifecycleHandler(tracer, traceContextService, config, ownershipService);
 			tracer.startWorkflow.mockReturnValue(generatedSpanContext);
+			ownershipService.getWorkflowProjectCached.mockResolvedValue({ id: 'proj-default' } as never);
+		});
+
+		it('should look up project via OwnershipService and pass id to the tracer', async () => {
+			traceContextService.get.mockResolvedValueOnce(undefined);
+			ownershipService.getWorkflowProjectCached.mockResolvedValueOnce({ id: 'proj-1' } as never);
+
+			await handler.onWorkflowStart(baseCtx);
+
+			expect(ownershipService.getWorkflowProjectCached).toHaveBeenCalledWith('wf-1');
+			expect(tracer.startWorkflow).toHaveBeenCalledWith(
+				expect.objectContaining({ project: { id: 'proj-1' } }),
+			);
 		});
 
 		it('should use own tracingContext when present (webhook case)', async () => {
@@ -122,6 +138,7 @@ describe('OtelLifecycleHandler', () => {
 		const tracer = mock<ExecutionLevelTracer>();
 		const traceContextService = mock<TraceContextService>();
 		const config = mock<OtelConfig>();
+		const ownershipService = mock<OwnershipService>();
 		let handler: OtelLifecycleHandler;
 
 		const prePauseContext: TracingContext = {
@@ -133,8 +150,29 @@ describe('OtelLifecycleHandler', () => {
 
 		beforeEach(() => {
 			jest.clearAllMocks();
-			handler = new OtelLifecycleHandler(tracer, traceContextService, config);
+			handler = new OtelLifecycleHandler(tracer, traceContextService, config, ownershipService);
 			tracer.startWorkflow.mockReturnValue(resumedSpanContext);
+			ownershipService.getWorkflowProjectCached.mockResolvedValue({ id: 'proj-default' } as never);
+		});
+
+		it('should look up project via OwnershipService on resume', async () => {
+			traceContextService.get.mockResolvedValueOnce(undefined);
+			ownershipService.getWorkflowProjectCached.mockResolvedValueOnce({
+				id: 'resume-proj',
+			} as never);
+
+			await handler.onWorkflowResume({
+				type: 'workflowExecuteResume',
+				workflow: { id: 'wf-1', name: 'Test', versionId: 'v1', nodes: [], connections: {} },
+				workflowInstance: undefined as never,
+				executionData: undefined as never,
+				executionId: 'exec-resume',
+			} as never);
+
+			expect(ownershipService.getWorkflowProjectCached).toHaveBeenCalledWith('wf-1');
+			expect(tracer.startWorkflow).toHaveBeenCalledWith(
+				expect.objectContaining({ project: { id: 'resume-proj' } }),
+			);
 		});
 
 		it('should start a new root span linked to the pre-wait origin and not overwrite the persisted origin', async () => {
@@ -168,11 +206,12 @@ describe('OtelLifecycleHandler', () => {
 		const tracer = mock<ExecutionLevelTracer>();
 		const traceContextService = mock<TraceContextService>();
 		const config = mock<OtelConfig>();
+		const ownershipService = mock<OwnershipService>();
 		let handler: OtelLifecycleHandler;
 
 		beforeEach(() => {
 			jest.clearAllMocks();
-			handler = new OtelLifecycleHandler(tracer, traceContextService, config);
+			handler = new OtelLifecycleHandler(tracer, traceContextService, config, ownershipService);
 		});
 
 		const makeCtx = (
@@ -234,6 +273,7 @@ describe('OtelLifecycleHandler', () => {
 		const tracer = mock<ExecutionLevelTracer>();
 		const traceContextService = mock<TraceContextService>();
 		const config = mock<OtelConfig>();
+		const ownershipService = mock<OwnershipService>();
 		let handler: OtelLifecycleHandler;
 
 		const node = { id: 'n1', name: 'Node1', type: 'test', typeVersion: 1 };
@@ -269,12 +309,12 @@ describe('OtelLifecycleHandler', () => {
 		beforeEach(() => {
 			jest.clearAllMocks();
 			config.includeNodeSpans = true;
-			handler = new OtelLifecycleHandler(tracer, traceContextService, config);
+			handler = new OtelLifecycleHandler(tracer, traceContextService, config, ownershipService);
 		});
 
 		it('should skip node spans when includeNodeSpans is false', () => {
 			config.includeNodeSpans = false;
-			handler = new OtelLifecycleHandler(tracer, traceContextService, config);
+			handler = new OtelLifecycleHandler(tracer, traceContextService, config, ownershipService);
 
 			handler.onNodeStart(makeStartCtx());
 			handler.onNodeEnd(makeEndCtx());

--- a/packages/cli/src/modules/otel/__tests__/otel-lifecycle-handler.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/otel-lifecycle-handler.test.ts
@@ -1,3 +1,4 @@
+import type { Logger } from '@n8n/backend-common';
 import type {
 	NodeExecuteAfterContext,
 	NodeExecuteBeforeContext,
@@ -25,6 +26,7 @@ describe('OtelLifecycleHandler', () => {
 		const traceContextService = mock<TraceContextService>();
 		const config = mock<OtelConfig>();
 		const ownershipService = mock<OwnershipService>();
+		const logger = mock<Logger>();
 		let handler: OtelLifecycleHandler;
 
 		const parentTracingContext: TracingContext = {
@@ -55,7 +57,13 @@ describe('OtelLifecycleHandler', () => {
 
 		beforeEach(() => {
 			jest.clearAllMocks();
-			handler = new OtelLifecycleHandler(tracer, traceContextService, config, ownershipService);
+			handler = new OtelLifecycleHandler(
+				tracer,
+				traceContextService,
+				config,
+				ownershipService,
+				logger,
+			);
 			tracer.startWorkflow.mockReturnValue(generatedSpanContext);
 			ownershipService.getWorkflowProjectCached.mockResolvedValue({ id: 'proj-default' } as never);
 		});
@@ -80,6 +88,10 @@ describe('OtelLifecycleHandler', () => {
 
 			expect(tracer.startWorkflow).toHaveBeenCalledWith(
 				expect.objectContaining({ project: undefined }),
+			);
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Failed to fetch project for OTEL span',
+				expect.objectContaining({ workflowId: 'wf-1', executionId: 'exec-sub' }),
 			);
 		});
 
@@ -150,6 +162,7 @@ describe('OtelLifecycleHandler', () => {
 		const traceContextService = mock<TraceContextService>();
 		const config = mock<OtelConfig>();
 		const ownershipService = mock<OwnershipService>();
+		const logger = mock<Logger>();
 		let handler: OtelLifecycleHandler;
 
 		const prePauseContext: TracingContext = {
@@ -161,7 +174,13 @@ describe('OtelLifecycleHandler', () => {
 
 		beforeEach(() => {
 			jest.clearAllMocks();
-			handler = new OtelLifecycleHandler(tracer, traceContextService, config, ownershipService);
+			handler = new OtelLifecycleHandler(
+				tracer,
+				traceContextService,
+				config,
+				ownershipService,
+				logger,
+			);
 			tracer.startWorkflow.mockReturnValue(resumedSpanContext);
 			ownershipService.getWorkflowProjectCached.mockResolvedValue({ id: 'proj-default' } as never);
 		});
@@ -202,6 +221,10 @@ describe('OtelLifecycleHandler', () => {
 			expect(tracer.startWorkflow).toHaveBeenCalledWith(
 				expect.objectContaining({ project: undefined }),
 			);
+			expect(logger.warn).toHaveBeenCalledWith(
+				'Failed to fetch project for OTEL span',
+				expect.objectContaining({ workflowId: 'wf-1', executionId: 'exec-resume' }),
+			);
 		});
 
 		it('should start a new root span linked to the pre-wait origin and not overwrite the persisted origin', async () => {
@@ -236,11 +259,18 @@ describe('OtelLifecycleHandler', () => {
 		const traceContextService = mock<TraceContextService>();
 		const config = mock<OtelConfig>();
 		const ownershipService = mock<OwnershipService>();
+		const logger = mock<Logger>();
 		let handler: OtelLifecycleHandler;
 
 		beforeEach(() => {
 			jest.clearAllMocks();
-			handler = new OtelLifecycleHandler(tracer, traceContextService, config, ownershipService);
+			handler = new OtelLifecycleHandler(
+				tracer,
+				traceContextService,
+				config,
+				ownershipService,
+				logger,
+			);
 		});
 
 		const makeCtx = (
@@ -303,6 +333,7 @@ describe('OtelLifecycleHandler', () => {
 		const traceContextService = mock<TraceContextService>();
 		const config = mock<OtelConfig>();
 		const ownershipService = mock<OwnershipService>();
+		const logger = mock<Logger>();
 		let handler: OtelLifecycleHandler;
 
 		const node = { id: 'n1', name: 'Node1', type: 'test', typeVersion: 1 };
@@ -338,12 +369,24 @@ describe('OtelLifecycleHandler', () => {
 		beforeEach(() => {
 			jest.clearAllMocks();
 			config.includeNodeSpans = true;
-			handler = new OtelLifecycleHandler(tracer, traceContextService, config, ownershipService);
+			handler = new OtelLifecycleHandler(
+				tracer,
+				traceContextService,
+				config,
+				ownershipService,
+				logger,
+			);
 		});
 
 		it('should skip node spans when includeNodeSpans is false', () => {
 			config.includeNodeSpans = false;
-			handler = new OtelLifecycleHandler(tracer, traceContextService, config, ownershipService);
+			handler = new OtelLifecycleHandler(
+				tracer,
+				traceContextService,
+				config,
+				ownershipService,
+				logger,
+			);
 
 			handler.onNodeStart(makeStartCtx());
 			handler.onNodeEnd(makeEndCtx());

--- a/packages/cli/src/modules/otel/__tests__/otel-workflow-tracing.integration.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/otel-workflow-tracing.integration.test.ts
@@ -1,4 +1,11 @@
+import { createTeamProject, createWorkflow, getPersonalProject } from '@n8n/backend-test-utils';
+import type { ExecutionRepository } from '@n8n/db';
 import { SpanStatusCode } from '@opentelemetry/api';
+import { NodeConnectionTypes } from 'n8n-workflow';
+import { v4 as uuid } from 'uuid';
+
+import type { WorkflowRunner } from '@/workflow-runner';
+import { createUser } from '@test-integration/db/users';
 
 import {
 	initOtelTestEnvironment,
@@ -8,16 +15,11 @@ import {
 	saveAndSetEnv,
 	restoreEnv,
 } from './support/otel-integration-utils';
+import type { OtelTestProvider } from './support/otel-test-provider';
 import {
 	createMultiNodeWorkflowFixture,
 	createFailingWorkflowFixture,
 } from './support/otel-workflow-fixtures';
-import type { OtelTestProvider } from './support/otel-test-provider';
-import type { WorkflowRunner } from '@/workflow-runner';
-import type { ExecutionRepository } from '@n8n/db';
-import { createTeamProject, createWorkflow } from '@n8n/backend-test-utils';
-import { NodeConnectionTypes } from 'n8n-workflow';
-import { v4 as uuid } from 'uuid';
 
 let otel: OtelTestProvider;
 let workflowRunner: WorkflowRunner;
@@ -60,9 +62,33 @@ describe('OTEL Workflow Tracing Integration', () => {
 		expect(nodeSpans).toHaveLength(workflow.nodes.length);
 	});
 
+	it('should emit n8n.project.id on workflow.execute for a team project', async () => {
+		const project = await createTeamProject();
+		const workflow = await createWorkflow(createMultiNodeWorkflowFixture(), project);
+		const executionId = await executeWorkflow(workflowRunner, workflow, project.id);
+		await waitForExecution(executionRepository, executionId);
+
+		const workflowSpan = otel.getFinishedSpans().find((s) => s.name === 'workflow.execute')!;
+		expect(workflowSpan).toBeDefined();
+		expect(workflowSpan.attributes['n8n.project.id']).toBe(project.id);
+	});
+
+	it('should emit n8n.project.id on workflow.execute for a personal project', async () => {
+		const owner = await createUser();
+		const personalProject = await getPersonalProject(owner);
+		const workflow = await createWorkflow(createMultiNodeWorkflowFixture(), personalProject);
+		const executionId = await executeWorkflow(workflowRunner, workflow, personalProject.id);
+		await waitForExecution(executionRepository, executionId);
+
+		const workflowSpan = otel.getFinishedSpans().find((s) => s.name === 'workflow.execute')!;
+		expect(workflowSpan).toBeDefined();
+		expect(workflowSpan.attributes['n8n.project.id']).toBe(personalProject.id);
+	});
+
 	it('should persist tracingContext to the execution entity after root span creation', async () => {
-		const workflow = await createWorkflow(createMultiNodeWorkflowFixture());
-		const executionId = await executeWorkflow(workflowRunner, workflow, 'test-project');
+		const project = await createTeamProject();
+		const workflow = await createWorkflow(createMultiNodeWorkflowFixture(), project);
+		const executionId = await executeWorkflow(workflowRunner, workflow, project.id);
 		await waitForExecution(executionRepository, executionId);
 
 		const execution = await executionRepository.findOneBy({ id: executionId });
@@ -71,8 +97,9 @@ describe('OTEL Workflow Tracing Integration', () => {
 	});
 
 	it('should set error status on failed executions', async () => {
-		const workflow = await createWorkflow(createFailingWorkflowFixture());
-		const executionId = await executeWorkflow(workflowRunner, workflow, 'test-project');
+		const project = await createTeamProject();
+		const workflow = await createWorkflow(createFailingWorkflowFixture(), project);
+		const executionId = await executeWorkflow(workflowRunner, workflow, project.id);
 		await waitForExecution(executionRepository, executionId);
 
 		const workflowSpan = otel.getFinishedSpans().find((s) => s.name === 'workflow.execute')!;
@@ -82,8 +109,9 @@ describe('OTEL Workflow Tracing Integration', () => {
 
 	it('should inherit traceId from inbound HTTP traceparent', async () => {
 		const inboundTraceId = '9bf2bd87b5053953e3fa08d8d889494b';
-		const workflow = await createWorkflow(createMultiNodeWorkflowFixture());
-		const executionId = await executeWorkflow(workflowRunner, workflow, 'test-project', {
+		const project = await createTeamProject();
+		const workflow = await createWorkflow(createMultiNodeWorkflowFixture(), project);
+		const executionId = await executeWorkflow(workflowRunner, workflow, project.id, {
 			mode: 'webhook',
 			tracingContext: {
 				traceparent: `00-${inboundTraceId}-b7ad6b7169203331-01`,

--- a/packages/cli/src/modules/otel/__tests__/support/otel-integration-utils.ts
+++ b/packages/cli/src/modules/otel/__tests__/support/otel-integration-utils.ts
@@ -126,7 +126,7 @@ export async function executeWorkflow(
 	return await workflowRunner.run(
 		{
 			workflowData: workflow,
-			userId: projectId,
+			projectId,
 			executionMode: mode,
 			executionData,
 			retryOf,

--- a/packages/cli/src/modules/otel/execution-level-tracer.ts
+++ b/packages/cli/src/modules/otel/execution-level-tracer.ts
@@ -46,6 +46,7 @@ export class ExecutionLevelTracer {
 						[ATTR.WORKFLOW_VERSION_ID]: params.workflow.versionId ?? '',
 						[ATTR.WORKFLOW_NODE_COUNT]: params.workflow.nodeCount,
 						[ATTR.EXECUTION_ID]: params.executionId,
+						...(params.project?.id && { [ATTR.PROJECT_ID]: params.project.id }),
 					},
 					links,
 				},

--- a/packages/cli/src/modules/otel/execution-level-tracer.types.ts
+++ b/packages/cli/src/modules/otel/execution-level-tracer.types.ts
@@ -3,6 +3,7 @@ import type { ExecutionStatus, WorkflowExecuteMode, INode } from 'n8n-workflow';
 import type { TracingContext } from './tracing-context';
 
 type ProjectContext = { id: string };
+type WorkflowContext = { id: string; name: string; versionId?: string; nodeCount: number };
 
 export type StartWorkflowParams = {
 	executionId: string;
@@ -13,7 +14,7 @@ export type StartWorkflowParams = {
 	 * workflow is resumed after a pause.
 	 */
 	linkTo?: TracingContext;
-	workflow: { id: string; name: string; versionId?: string; nodeCount: number };
+	workflow: WorkflowContext;
 	project?: ProjectContext;
 };
 

--- a/packages/cli/src/modules/otel/execution-level-tracer.types.ts
+++ b/packages/cli/src/modules/otel/execution-level-tracer.types.ts
@@ -2,6 +2,8 @@ import type { ExecutionStatus, WorkflowExecuteMode, INode } from 'n8n-workflow';
 
 import type { TracingContext } from './tracing-context';
 
+type ProjectContext = { id: string };
+
 export type StartWorkflowParams = {
 	executionId: string;
 	/** Parent context — incoming webhook traceparent or parent sub-workflow span. */
@@ -12,6 +14,7 @@ export type StartWorkflowParams = {
 	 */
 	linkTo?: TracingContext;
 	workflow: { id: string; name: string; versionId?: string; nodeCount: number };
+	project?: ProjectContext;
 };
 
 export type EndWorkflowParams = {

--- a/packages/cli/src/modules/otel/otel-lifecycle-handler.ts
+++ b/packages/cli/src/modules/otel/otel-lifecycle-handler.ts
@@ -8,6 +8,8 @@ import type {
 } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 
+import { OwnershipService } from '@/services/ownership.service';
+
 import { ExecutionLevelTracer } from './execution-level-tracer';
 import { OtelConfig } from './otel.config';
 import { TraceContextService } from './tracing-context';
@@ -18,6 +20,7 @@ export class OtelLifecycleHandler {
 		private readonly tracer: ExecutionLevelTracer,
 		private readonly traceContextService: TraceContextService,
 		private readonly config: OtelConfig,
+		private readonly ownershipService: OwnershipService,
 	) {}
 
 	@OnLifecycleEvent('workflowExecuteBefore')
@@ -29,9 +32,12 @@ export class OtelLifecycleHandler {
 			: // This will return "null" if there is no traceparent header in the trigger node. (e.g. webhook)
 				await this.traceContextService.get(ctx.executionId);
 
+		const project = await this.ownershipService.getWorkflowProjectCached(ctx.workflow.id);
+
 		const spanContext = this.tracer.startWorkflow({
 			executionId: ctx.executionId,
 			tracingContext,
+			project: { id: project.id },
 			workflow: {
 				id: ctx.workflow.id,
 				name: ctx.workflow.name,
@@ -49,9 +55,12 @@ export class OtelLifecycleHandler {
 	async onWorkflowResume(ctx: WorkflowExecuteResumeContext): Promise<void> {
 		const previousWorkflowExecution = await this.traceContextService.get(ctx.executionId);
 
+		const project = await this.ownershipService.getWorkflowProjectCached(ctx.workflow.id);
+
 		this.tracer.startWorkflow({
 			executionId: ctx.executionId,
 			linkTo: previousWorkflowExecution,
+			project: { id: project.id },
 			workflow: {
 				id: ctx.workflow.id,
 				name: ctx.workflow.name,

--- a/packages/cli/src/modules/otel/otel-lifecycle-handler.ts
+++ b/packages/cli/src/modules/otel/otel-lifecycle-handler.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@n8n/backend-common';
 import { OnLifecycleEvent } from '@n8n/decorators';
 import type {
 	WorkflowExecuteBeforeContext,
@@ -21,6 +22,7 @@ export class OtelLifecycleHandler {
 		private readonly traceContextService: TraceContextService,
 		private readonly config: OtelConfig,
 		private readonly ownershipService: OwnershipService,
+		private readonly logger: Logger,
 	) {}
 
 	@OnLifecycleEvent('workflowExecuteBefore')
@@ -34,7 +36,14 @@ export class OtelLifecycleHandler {
 
 		const project = await this.ownershipService
 			.getWorkflowProjectCached(ctx.workflow.id)
-			.catch(() => undefined);
+			.catch((error: unknown) => {
+				this.logger.warn('Failed to fetch project for OTEL span', {
+					workflowId: ctx.workflow.id,
+					executionId: ctx.executionId,
+					error: error instanceof Error ? error.message : String(error),
+				});
+				return undefined;
+			});
 
 		const spanContext = this.tracer.startWorkflow({
 			executionId: ctx.executionId,
@@ -59,7 +68,14 @@ export class OtelLifecycleHandler {
 
 		const project = await this.ownershipService
 			.getWorkflowProjectCached(ctx.workflow.id)
-			.catch(() => undefined);
+			.catch((error: unknown) => {
+				this.logger.warn('Failed to fetch project for OTEL span', {
+					workflowId: ctx.workflow.id,
+					executionId: ctx.executionId,
+					error: error instanceof Error ? error.message : String(error),
+				});
+				return undefined;
+			});
 
 		this.tracer.startWorkflow({
 			executionId: ctx.executionId,

--- a/packages/cli/src/modules/otel/otel-lifecycle-handler.ts
+++ b/packages/cli/src/modules/otel/otel-lifecycle-handler.ts
@@ -32,12 +32,14 @@ export class OtelLifecycleHandler {
 			: // This will return "null" if there is no traceparent header in the trigger node. (e.g. webhook)
 				await this.traceContextService.get(ctx.executionId);
 
-		const project = await this.ownershipService.getWorkflowProjectCached(ctx.workflow.id);
+		const project = await this.ownershipService
+			.getWorkflowProjectCached(ctx.workflow.id)
+			.catch(() => undefined);
 
 		const spanContext = this.tracer.startWorkflow({
 			executionId: ctx.executionId,
 			tracingContext,
-			project: { id: project.id },
+			project: project ? { id: project.id } : undefined,
 			workflow: {
 				id: ctx.workflow.id,
 				name: ctx.workflow.name,
@@ -55,12 +57,14 @@ export class OtelLifecycleHandler {
 	async onWorkflowResume(ctx: WorkflowExecuteResumeContext): Promise<void> {
 		const previousWorkflowExecution = await this.traceContextService.get(ctx.executionId);
 
-		const project = await this.ownershipService.getWorkflowProjectCached(ctx.workflow.id);
+		const project = await this.ownershipService
+			.getWorkflowProjectCached(ctx.workflow.id)
+			.catch(() => undefined);
 
 		this.tracer.startWorkflow({
 			executionId: ctx.executionId,
 			linkTo: previousWorkflowExecution,
-			project: { id: project.id },
+			project: project ? { id: project.id } : undefined,
 			workflow: {
 				id: ctx.workflow.id,
 				name: ctx.workflow.name,

--- a/packages/cli/src/modules/otel/otel.constants.ts
+++ b/packages/cli/src/modules/otel/otel.constants.ts
@@ -7,6 +7,8 @@ export const ATTR = {
 	INSTANCE_ID: 'n8n.instance.id',
 	INSTANCE_ROLE: 'n8n.instance.role',
 
+	PROJECT_ID: 'n8n.project.id',
+
 	WORKFLOW_ID: 'n8n.workflow.id',
 	WORKFLOW_VERSION_ID: 'n8n.workflow.version_id',
 	WORKFLOW_NAME: 'n8n.workflow.name',


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Adds `n8n.project.id` attribute to `workflow.execute` OTel spans. The attribute is resolved via `OwnershipService` directly in `OtelLifecycleHandler`.

<img width="533" height="384" alt="image" src="https://github.com/user-attachments/assets/27ac7754-03f1-4202-96f3-0e81cdb7846a" />

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/LIGO-578

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
