### PR TITLE
refactor(core): Route node-data access through typed-RPC dispatcher

### DIFF
--- a/packages/@n8n/expression-runtime/package.json
+++ b/packages/@n8n/expression-runtime/package.json
@@ -40,7 +40,8 @@
     "luxon": "catalog:",
     "md5": "2.3.0",
     "title-case": "3.0.3",
-    "transliteration": "2.3.5"
+    "transliteration": "2.3.5",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@n8n/typescript-config": "workspace:*",

--- a/packages/@n8n/expression-runtime/src/__tests__/typed-rpc.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/typed-rpc.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Regression suite for the typed-RPC routing pattern introduced in Phase B
+ * Step 3 of the bridge surface reduction.
+ *
+ * The pattern: `$('Foo').first()` is routed through the dedicated
+ * `getNodeFirst` typed RPC rather than the generic `callFunctionAtPath`
+ * channel. The in-isolate runtime exposes a synthetic proxy on
+ * `target.$(...)` that intercepts `.first` and sends a typed envelope via
+ * `sendMessage`; the bridge handler reads the literal string `"first"`
+ * from the host-side proxy. The property name is compile-time fixed and
+ * cannot be influenced by expression input.
+ *
+ * Each typed RPC added in Step 3 should land with a test in this file
+ * confirming:
+ *   1. The method routes via the typed RPC, returning the expected result.
+ *   2. The typed RPC handler only invokes the specific host-side method
+ *      its schema names — no other property access on the host proxy.
+ *   3. Arg validation rejects ill-typed inputs at the bridge boundary.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ExpressionEvaluator } from '../evaluator/expression-evaluator';
+import { IsolatedVmBridge } from '../bridge/isolated-vm-bridge';
+
+describe("Typed RPC: $('Foo').first() routes via getNodeFirst", () => {
+	let evaluator: ExpressionEvaluator;
+	const caller = {};
+
+	beforeAll(async () => {
+		evaluator = new ExpressionEvaluator({
+			createBridge: () => new IsolatedVmBridge({ timeout: 5000 }),
+			maxCodeCacheSize: 64,
+		});
+		await evaluator.initialize();
+		await evaluator.acquire(caller);
+	});
+
+	afterAll(async () => {
+		await evaluator.release(caller);
+		await evaluator.dispose();
+	});
+
+	it('returns the value of data.$(nodeName).first()', () => {
+		const data: Record<string, unknown> = {
+			$: (nodeName: string) => {
+				if (nodeName !== 'SourceNode') throw new Error(`unexpected node: ${nodeName}`);
+				return {
+					first: () => ({ json: { id: 42, name: 'Alice' } }),
+				};
+			},
+		};
+
+		const result = evaluator.evaluate("{{ $('SourceNode').first() }}", data, caller) as Record<
+			string,
+			unknown
+		>;
+
+		expect(result).toEqual({ json: { id: 42, name: 'Alice' } });
+	});
+
+	it('forwards branchIndex and runIndex args verbatim', () => {
+		const calls: Array<unknown[]> = [];
+		const data: Record<string, unknown> = {
+			$: (_nodeName: string) => ({
+				first: (...args: unknown[]) => {
+					calls.push(args);
+					return { json: { ok: true } };
+				},
+			}),
+		};
+
+		evaluator.evaluate("{{ $('Foo').first() }}", data, caller);
+		evaluator.evaluate("{{ $('Foo').first(2) }}", data, caller);
+		evaluator.evaluate("{{ $('Foo').first(0, 3) }}", data, caller);
+
+		expect(calls).toEqual([
+			[undefined, undefined],
+			[2, undefined],
+			[0, 3],
+		]);
+	});
+
+	it('only invokes .first on the host proxy — never other methods', () => {
+		const invoked: string[] = [];
+		const data: Record<string, unknown> = {
+			$: (_nodeName: string) =>
+				new Proxy(
+					{},
+					{
+						get(_t, prop) {
+							if (typeof prop === 'symbol') return undefined;
+							invoked.push(prop);
+							if (prop === 'first') return () => ({ json: { ok: true } });
+							// Any other method getting invoked would be a routing bug:
+							return () => {
+								throw new Error(`unexpected method invoked: ${prop}`);
+							};
+						},
+					},
+				),
+		};
+
+		evaluator.evaluate("{{ $('Foo').first() }}", data, caller);
+
+		// The typed-RPC handler reads .first off the host proxy and invokes it.
+		// No other property on the host proxy should be touched.
+		expect(invoked).toEqual(['first']);
+	});
+
+	it('rejects non-string nodeName at the bridge boundary', () => {
+		// data.$ is never called when validation fails — capture that.
+		let dollarCalls = 0;
+		const data: Record<string, unknown> = {
+			$: () => {
+				dollarCalls++;
+				return { first: () => ({ json: { ok: true } }) };
+			},
+		};
+
+		// Tournament's runtime polyfill won't normally produce a non-string
+		// nodeName; this asserts the bridge's own type validation rejects
+		// the bad input rather than forwarding it to data.$.
+		// The result is undefined because the runtime error handler
+		// (E() injected by the bridge) swallows generic errors and returns
+		// undefined — same shape as the legacy engine.
+		const result = evaluator.evaluate('{{ $(123).first() }}', data, caller);
+		expect(result).toBeUndefined();
+		expect(dollarCalls).toBe(0);
+	});
+
+	it('handles missing data.$ gracefully (returns undefined, does not crash)', () => {
+		const data: Record<string, unknown> = {};
+
+		const result = evaluator.evaluate("{{ $('Foo').first() }}", data, caller);
+		expect(result).toBeUndefined();
+	});
+
+	it('returns undefined when the host proxy has no .first method', () => {
+		const data: Record<string, unknown> = {
+			$: () => ({}),
+		};
+
+		const result = evaluator.evaluate("{{ $('Foo').first() }}", data, caller);
+		expect(result).toBeUndefined();
+	});
+});

--- a/packages/@n8n/expression-runtime/src/__tests__/typed-rpc.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/typed-rpc.test.ts
@@ -1,16 +1,15 @@
 /**
- * Regression suite for the typed-RPC routing pattern introduced in Phase B
- * Step 3 of the bridge surface reduction.
+ * Regression suite for the typed-RPC routing pattern.
  *
  * The pattern: `$('Foo').first()` is routed through the dedicated
  * `getNodeFirst` typed RPC rather than the generic `callFunctionAtPath`
  * channel. The in-isolate runtime exposes a synthetic proxy on
  * `target.$(...)` that intercepts `.first` and sends a typed envelope via
- * `sendMessage`; the bridge handler reads the literal string `"first"`
+ * `callHost`; the bridge handler reads the literal string `"first"`
  * from the host-side proxy. The property name is compile-time fixed and
  * cannot be influenced by expression input.
  *
- * Each typed RPC added in Step 3 should land with a test in this file
+ * Each typed RPC should land with a test in this file
  * confirming:
  *   1. The method routes via the typed RPC, returning the expected result.
  *   2. The typed RPC handler only invokes the specific host-side method

--- a/packages/@n8n/expression-runtime/src/bridge/bridge-messages.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/bridge-messages.ts
@@ -1,0 +1,44 @@
+/**
+ * Schemas for messages the in-isolate runtime sends to the host via the
+ * `sendMessage` typed-RPC dispatcher.
+ *
+ * The isolate is an untrusted source: anything that crosses the bridge must
+ * be validated for shape and types at the boundary. We do that with zod
+ * rather than relying on TypeScript discriminated unions, because TS types
+ * are erased at runtime and contribute zero security.
+ *
+ * Each operation has its own schema. The dispatcher entry validates the
+ * envelope against the discriminated union, throws on any deviation
+ * (unknown `type`, missing/typo'd fields, wrong field types), and then
+ * delegates to a handler that operates on the parsed (statically narrowed)
+ * message.
+ *
+ * As Phase B Step 3 adds more typed RPCs, each one lands as a new schema
+ * here plus a new `case` in the bridge's dispatcher switch.
+ */
+
+import { z } from 'zod';
+
+/**
+ * `$('NodeName').first(branchIndex?, runIndex?)` — fetch the first item of
+ * a named node's most recent execution data.
+ */
+export const getNodeFirstMessage = z
+	.object({
+		type: z.literal('getNodeFirst'),
+		nodeName: z.string(),
+		branchIndex: z.number().int().nonnegative().optional(),
+		runIndex: z.number().int().nonnegative().optional(),
+	})
+	.strict();
+
+/**
+ * The full set of messages the bridge will accept. Discriminator is `type`.
+ *
+ * Use `.strict()` on each member so unknown fields are rejected rather than
+ * silently ignored — this catches typos in the runtime stubs and keeps the
+ * protocol surface tight.
+ */
+export const bridgeMessageSchema = z.discriminatedUnion('type', [getNodeFirstMessage]);
+
+export type BridgeMessage = z.infer<typeof bridgeMessageSchema>;

--- a/packages/@n8n/expression-runtime/src/bridge/bridge-messages.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/bridge-messages.ts
@@ -1,6 +1,6 @@
 /**
  * Schemas for messages the in-isolate runtime sends to the host via the
- * `sendMessage` typed-RPC dispatcher.
+ * `callHost` typed-RPC dispatcher.
  *
  * The isolate is an untrusted source: anything that crosses the bridge must
  * be validated for shape and types at the boundary. We do that with zod
@@ -13,8 +13,8 @@
  * delegates to a handler that operates on the parsed (statically narrowed)
  * message.
  *
- * As Phase B Step 3 adds more typed RPCs, each one lands as a new schema
- * here plus a new `case` in the bridge's dispatcher switch.
+ * Each additional typed RPC lands as a new schema here plus a new `case`
+ * in the bridge's dispatcher switch.
  */
 
 import { z } from 'zod';

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 import type { RuntimeBridge, BridgeConfig, ExecuteOptions } from '../types';
 import { DEFAULT_BRIDGE_CONFIG, TimeoutError, MemoryLimitError } from '../types';
 import type { ErrorSentinel } from '../runtime/lazy-proxy';
+import { bridgeMessageSchema, type BridgeMessage } from './bridge-messages';
 
 // Lazy-loaded isolated-vm — avoids loading the native binary when the barrel
 // file is statically imported (e.g. for error classes). The native module is
@@ -456,14 +457,89 @@ export class IsolatedVmBridge implements RuntimeBridge {
 	}
 
 	/**
+	 * Create the single typed-RPC dispatcher.
+	 *
+	 * The isolate sends one envelope per typed RPC invocation:
+	 *   `sendMessage({ type: 'getNodeFirst', nodeName, branchIndex?, runIndex? })`
+	 *
+	 * Inputs cross a trust boundary, so the dispatcher parses every envelope
+	 * with the host-side zod schema (`bridgeMessageSchema`) before any
+	 * dispatch happens. Anything that deviates from the declared shape —
+	 * unknown `type`, missing required fields, extra unexpected fields,
+	 * wrong field types — fails the parse and an error sentinel is returned
+	 * to the caller.
+	 *
+	 * After parsing, `switch (msg.type)` dispatches to a private handler with
+	 * a fully narrowed message type. The operation set is exactly the cases
+	 * in this switch; the `type` field selects a static branch in source,
+	 * not a property lookup on a runtime object.
+	 *
+	 * @param data - Current workflow data
+	 * @private
+	 */
+	private createSendMessageRef(data: Record<string, unknown>): ivm.Reference {
+		return new (getIvm().Reference)((rawMsg: unknown) => {
+			try {
+				const msg = bridgeMessageSchema.parse(rawMsg);
+				switch (msg.type) {
+					case 'getNodeFirst':
+						return this.handleGetNodeFirst(msg, data);
+					default: {
+						const exhaustive: never = msg.type;
+						throw new Error(`Unhandled bridge message type: ${String(exhaustive)}`);
+					}
+				}
+			} catch (err) {
+				return serializeError(err);
+			}
+		});
+	}
+
+	/**
+	 * Handler for `getNodeFirst` — fetches the first item of a named node's
+	 * most recent execution data.
+	 *
+	 * Note: this still invokes `data.$` host-side. Eliminating `data.$` as a
+	 * host-callable entirely would require reaching the `WorkflowDataProxy`
+	 * internals (e.g. `getNodeExecutionOrPinnedData`) rather than the public
+	 * `$()` API. That's a follow-up; the security win here is "the isolate
+	 * can only invoke `.first` via this validated RPC, not any other method,
+	 * regardless of what `data.$` returns."
+	 *
+	 * @private
+	 */
+	private handleGetNodeFirst(
+		msg: Extract<BridgeMessage, { type: 'getNodeFirst' }>,
+		data: Record<string, unknown>,
+	): unknown {
+		const dollarFn = data.$;
+		if (typeof dollarFn !== 'function') {
+			throw new Error('getNodeFirst: $ is not available in expression context');
+		}
+
+		const nodeProxy = (dollarFn as (n: string) => unknown)(msg.nodeName);
+		if (!nodeProxy || typeof nodeProxy !== 'object') {
+			return undefined;
+		}
+
+		const firstFn = (nodeProxy as Record<string, unknown>).first;
+		if (typeof firstFn !== 'function') {
+			return undefined;
+		}
+
+		return (firstFn as (...a: unknown[]) => unknown).call(nodeProxy, msg.branchIndex, msg.runIndex);
+	}
+
+	/**
 	 * Execute JavaScript code in the isolated context.
 	 *
 	 * Flow:
-	 * 1. Create three ivm.Reference callbacks scoped to the current data
-	 * 2. Use evalClosureSync to run the code in a closure where $0/$1/$2
-	 *    are the callback references — no global mutable state
+	 * 1. Create four ivm.Reference callbacks scoped to the current data:
+	 *    `getValueAtPath`, `getArrayElement`, `callFunctionAtPath`, `sendMessage`.
+	 * 2. Use evalClosureSync to run the code in a closure where `$0`/`$1`/`$2`/`$3`
+	 *    are the callback references — no global mutable state.
 	 * 3. buildContext() inside the isolate creates a fresh evaluation context
-	 *    from the closure-scoped references
+	 *    from the closure-scoped references.
 	 *
 	 * Each call gets its own closure, so nested and concurrent evaluations
 	 * cannot interfere with each other.
@@ -481,6 +557,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 		const getValueAtPath = this.createGetValueAtPathRef(data);
 		const getArrayElement = this.createGetArrayElementRef(data);
 		const callFunctionAtPath = this.createCallFunctionAtPathRef(data);
+		const sendMessage = this.createSendMessageRef(data);
 
 		try {
 			const timezone = options?.timezone ? JSON.stringify(options.timezone) : 'undefined';
@@ -488,13 +565,21 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			// Wrap transformed code so 'this' === the closure-scoped context.
 			// Tournament generates: this.$json.email, this.$items(), etc.
 			// buildContext() creates a fresh context with lazy proxies from the
-			// closure-scoped callback references ($0, $1, $2) — no globals touched.
+			// closure-scoped callback references — no globals touched. The bundle
+			// is passed as a single object so adding typed RPCs doesn't churn the
+			// evalClosureSync signature; new operations land as new schemas in
+			// bridge-messages.ts and new cases in the sendMessage dispatcher.
 			// The outer try-catch serializes errors into a sentinel object and returns
 			// it as the result. Errors from host callbacks arrive as sentinels already
 			// (via serializeError), so we pass them through. This avoids a round-trip
 			// callback and keeps Error reconstruction on the host side only.
 			const wrappedCode = `
-var __ctx = buildContext($0, $1, $2, ${timezone});
+var __ctx = buildContext({
+  getValueAtPath: $0,
+  getArrayElement: $1,
+  callFunctionAtPath: $2,
+  sendMessage: $3,
+}, ${timezone});
 try {
   var __result = (function() {
     ${code}
@@ -518,7 +603,7 @@ try {
 
 			const result = this.context.evalClosureSync(
 				wrappedCode,
-				[getValueAtPath, getArrayElement, callFunctionAtPath],
+				[getValueAtPath, getArrayElement, callFunctionAtPath, sendMessage],
 				{ result: { copy: true }, timeout: this.config.timeout },
 			);
 
@@ -556,6 +641,7 @@ try {
 			getValueAtPath.release();
 			getArrayElement.release();
 			callFunctionAtPath.release();
+			sendMessage.release();
 		}
 	}
 

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -460,7 +460,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 	 * Create the single typed-RPC dispatcher.
 	 *
 	 * The isolate sends one envelope per typed RPC invocation:
-	 *   `sendMessage({ type: 'getNodeFirst', nodeName, branchIndex?, runIndex? })`
+	 *   `callHost({ type: 'getNodeFirst', nodeName, branchIndex?, runIndex? })`
 	 *
 	 * Inputs cross a trust boundary, so the dispatcher parses every envelope
 	 * with the host-side zod schema (`bridgeMessageSchema`) before any
@@ -477,7 +477,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 	 * @param data - Current workflow data
 	 * @private
 	 */
-	private createSendMessageRef(data: Record<string, unknown>): ivm.Reference {
+	private createCallHostRef(data: Record<string, unknown>): ivm.Reference {
 		return new (getIvm().Reference)((rawMsg: unknown) => {
 			try {
 				const msg = bridgeMessageSchema.parse(rawMsg);
@@ -535,7 +535,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 	 *
 	 * Flow:
 	 * 1. Create four ivm.Reference callbacks scoped to the current data:
-	 *    `getValueAtPath`, `getArrayElement`, `callFunctionAtPath`, `sendMessage`.
+	 *    `getValueAtPath`, `getArrayElement`, `callFunctionAtPath`, `callHost`.
 	 * 2. Use evalClosureSync to run the code in a closure where `$0`/`$1`/`$2`/`$3`
 	 *    are the callback references — no global mutable state.
 	 * 3. buildContext() inside the isolate creates a fresh evaluation context
@@ -557,7 +557,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 		const getValueAtPath = this.createGetValueAtPathRef(data);
 		const getArrayElement = this.createGetArrayElementRef(data);
 		const callFunctionAtPath = this.createCallFunctionAtPathRef(data);
-		const sendMessage = this.createSendMessageRef(data);
+		const callHost = this.createCallHostRef(data);
 
 		try {
 			const timezone = options?.timezone ? JSON.stringify(options.timezone) : 'undefined';
@@ -568,7 +568,7 @@ export class IsolatedVmBridge implements RuntimeBridge {
 			// closure-scoped callback references — no globals touched. The bundle
 			// is passed as a single object so adding typed RPCs doesn't churn the
 			// evalClosureSync signature; new operations land as new schemas in
-			// bridge-messages.ts and new cases in the sendMessage dispatcher.
+			// bridge-messages.ts and new cases in the callHost dispatcher.
 			// The outer try-catch serializes errors into a sentinel object and returns
 			// it as the result. Errors from host callbacks arrive as sentinels already
 			// (via serializeError), so we pass them through. This avoids a round-trip
@@ -578,7 +578,7 @@ var __ctx = buildContext({
   getValueAtPath: $0,
   getArrayElement: $1,
   callFunctionAtPath: $2,
-  sendMessage: $3,
+  callHost: $3,
 }, ${timezone});
 try {
   var __result = (function() {
@@ -603,7 +603,7 @@ try {
 
 			const result = this.context.evalClosureSync(
 				wrappedCode,
-				[getValueAtPath, getArrayElement, callFunctionAtPath, sendMessage],
+				[getValueAtPath, getArrayElement, callFunctionAtPath, callHost],
 				{ result: { copy: true }, timeout: this.config.timeout },
 			);
 
@@ -641,7 +641,7 @@ try {
 			getValueAtPath.release();
 			getArrayElement.release();
 			callFunctionAtPath.release();
-			sendMessage.release();
+			callHost.release();
 		}
 	}
 

--- a/packages/@n8n/expression-runtime/src/runtime/__tests__/context.test.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/__tests__/context.test.ts
@@ -21,11 +21,12 @@ describe('buildContext proxy', () => {
 			return cur;
 		});
 
-		const ctx = buildContext(
+		const ctx = buildContext({
 			getValueAtPath,
-			makeRef(() => undefined),
-			makeRef(() => undefined),
-		);
+			getArrayElement: makeRef(() => undefined),
+			callFunctionAtPath: makeRef(() => undefined),
+			sendMessage: makeRef(() => undefined),
+		});
 
 		expect('$credentials' in ctx).toBe(true);
 		expect(calls).toContainEqual(['$credentials']);
@@ -33,11 +34,12 @@ describe('buildContext proxy', () => {
 
 	it('returns false from has trap for unknown keys', () => {
 		const getValueAtPath = makeRef(() => undefined);
-		const ctx = buildContext(
+		const ctx = buildContext({
 			getValueAtPath,
-			makeRef(() => undefined),
-			makeRef(() => undefined),
-		);
+			getArrayElement: makeRef(() => undefined),
+			callFunctionAtPath: makeRef(() => undefined),
+			sendMessage: makeRef(() => undefined),
+		});
 
 		expect('$doesNotExist' in ctx).toBe(false);
 	});
@@ -49,11 +51,12 @@ describe('buildContext proxy', () => {
 			return undefined;
 		});
 
-		const ctx = buildContext(
+		const ctx = buildContext({
 			getValueAtPath,
-			makeRef(() => undefined),
-			makeRef(() => undefined),
-		);
+			getArrayElement: makeRef(() => undefined),
+			callFunctionAtPath: makeRef(() => undefined),
+			sendMessage: makeRef(() => undefined),
+		});
 
 		void ('$missing' in ctx);
 		void ('$missing' in ctx);

--- a/packages/@n8n/expression-runtime/src/runtime/__tests__/context.test.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/__tests__/context.test.ts
@@ -25,7 +25,7 @@ describe('buildContext proxy', () => {
 			getValueAtPath,
 			getArrayElement: makeRef(() => undefined),
 			callFunctionAtPath: makeRef(() => undefined),
-			sendMessage: makeRef(() => undefined),
+			callHost: makeRef(() => undefined),
 		});
 
 		expect('$credentials' in ctx).toBe(true);
@@ -38,7 +38,7 @@ describe('buildContext proxy', () => {
 			getValueAtPath,
 			getArrayElement: makeRef(() => undefined),
 			callFunctionAtPath: makeRef(() => undefined),
-			sendMessage: makeRef(() => undefined),
+			callHost: makeRef(() => undefined),
 		});
 
 		expect('$doesNotExist' in ctx).toBe(false);
@@ -55,7 +55,7 @@ describe('buildContext proxy', () => {
 			getValueAtPath,
 			getArrayElement: makeRef(() => undefined),
 			callFunctionAtPath: makeRef(() => undefined),
-			sendMessage: makeRef(() => undefined),
+			callHost: makeRef(() => undefined),
 		});
 
 		void ('$missing' in ctx);

--- a/packages/@n8n/expression-runtime/src/runtime/context.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/context.ts
@@ -29,14 +29,15 @@ const SafeURIError = createSafeErrorSubclass(URIError);
  *
  *   - `getValueAtPath`, `getArrayElement`: data-access primitives used by the
  *     lazy-proxy system. Hot path; one ivm.Reference each for minimum overhead.
- *   - `callFunctionAtPath`: legacy generic dispatch, removed in Phase B Step 4
- *     once every consumer has migrated to typed messages.
- *   - `sendMessage`: typed-RPC dispatcher. The in-isolate runtime constructs
+ *   - `callFunctionAtPath`: legacy generic dispatch; to be removed once
+ *     every consumer has migrated to typed messages.
+ *   - `callHost`: typed-RPC dispatcher. The in-isolate runtime constructs
  *     an envelope (e.g. `{ type: 'getNodeFirst', nodeName, ... }`) and the
  *     host-side dispatcher validates it with zod before routing to a handler.
  *     A single ivm.Reference covers every typed operation; new operations
  *     are new schemas in `bridge/bridge-messages.ts` + new cases in the
- *     dispatcher switch.
+ *     dispatcher switch. The name reflects what this is: a synchronous
+ *     host RPC, not a postMessage-style async send.
  */
 export interface BridgeCallbacks {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -46,7 +47,7 @@ export interface BridgeCallbacks {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	callFunctionAtPath: any;
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	sendMessage: any;
+	callHost: any;
 }
 
 /**
@@ -132,7 +133,7 @@ export function buildContext(
 	//
 	// The returned object is a Proxy whose `get` trap intercepts properties
 	// that have a typed RPC (e.g. `.first` → `getNodeFirst`) and routes them
-	// through the `sendMessage` envelope. Everything else (properties like
+	// through the `callHost` envelope. Everything else (properties like
 	// `.params`, `.json`, and methods that don't yet have a typed RPC like
 	// `.last`, `.all`) is read from an underlying lazy proxy via explicit
 	// delegation.
@@ -145,14 +146,14 @@ export function buildContext(
 	// whole node's keys. Using `{}` as the target keeps those checks cheap;
 	// the lazy proxy lives in closure and is only consulted on demand.
 	//
-	// As Phase B Step 3 adds more typed RPCs, more cases land in this trap.
+	// As more typed RPCs are added, more cases land in this trap.
 	target.$ = function (nodeName: string) {
 		const lazyProxy = createDeepLazyProxy(['$', nodeName], undefined, callbacks);
 		return new Proxy({} as Record<string, unknown>, {
 			get(_emptyTarget, prop) {
 				if (prop === 'first') {
 					return (branchIndex?: number, runIndex?: number) => {
-						const result = callbacks.sendMessage.applySync(
+						const result = callbacks.callHost.applySync(
 							null,
 							[{ type: 'getNodeFirst', nodeName, branchIndex, runIndex }],
 							{ arguments: { copy: true }, result: { copy: true } },

--- a/packages/@n8n/expression-runtime/src/runtime/context.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/context.ts
@@ -24,6 +24,32 @@ const SafeURIError = createSafeErrorSubclass(URIError);
 // ============================================================================
 
 /**
+ * Bridge callbacks the in-isolate runtime can invoke synchronously via
+ * `ivm.Reference.applySync`.
+ *
+ *   - `getValueAtPath`, `getArrayElement`: data-access primitives used by the
+ *     lazy-proxy system. Hot path; one ivm.Reference each for minimum overhead.
+ *   - `callFunctionAtPath`: legacy generic dispatch, removed in Phase B Step 4
+ *     once every consumer has migrated to typed messages.
+ *   - `sendMessage`: typed-RPC dispatcher. The in-isolate runtime constructs
+ *     an envelope (e.g. `{ type: 'getNodeFirst', nodeName, ... }`) and the
+ *     host-side dispatcher validates it with zod before routing to a handler.
+ *     A single ivm.Reference covers every typed operation; new operations
+ *     are new schemas in `bridge/bridge-messages.ts` + new cases in the
+ *     dispatcher switch.
+ */
+export interface BridgeCallbacks {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	getValueAtPath: any;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	getArrayElement: any;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	callFunctionAtPath: any;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	sendMessage: any;
+}
+
+/**
  * Build a fresh, closure-scoped evaluation context.
  *
  * This function creates a context object that contains everything needed to
@@ -33,16 +59,12 @@ const SafeURIError = createSafeErrorSubclass(URIError);
  * The returned object is used as tournament's `this` context in the
  * evalClosureSync wrapper.
  *
- * @param getValueAtPath - ivm.Reference for fetching values by path
- * @param getArrayElement - ivm.Reference for fetching array elements
- * @param callFunctionAtPath - ivm.Reference for calling functions by path
+ * @param callbacks - Bridge callbacks (data-access primitives + typed RPCs)
  * @param timezone - Optional IANA timezone string
  * @returns A context object with all workflow data, proxies, and builtins
  */
 export function buildContext(
-	getValueAtPath: any,
-	getArrayElement: any,
-	callFunctionAtPath: any,
+	callbacks: BridgeCallbacks,
 	timezone?: string,
 ): Record<string, unknown> {
 	if (timezone && !IANAZone.isValidZone(timezone)) {
@@ -51,9 +73,6 @@ export function buildContext(
 	Settings.defaultZone = timezone ?? 'system';
 
 	const target: Record<string, unknown> = {};
-
-	// Callback bundle passed to createDeepLazyProxy so proxies don't touch globalThis
-	const callbacks = { getValueAtPath, getArrayElement, callFunctionAtPath };
 
 	// __sanitize must be on the context because PrototypeSanitizer generates:
 	// obj[this.__sanitize(expr)] where 'this' is the context (via .call(ctx) wrapping)
@@ -109,9 +128,44 @@ export function buildContext(
 		};
 	};
 
-	// $() function for accessing other nodes
+	// $() function for accessing other nodes.
+	//
+	// The returned object is a Proxy whose `get` trap intercepts properties
+	// that have a typed RPC (e.g. `.first` → `getNodeFirst`) and routes them
+	// through the `sendMessage` envelope. Everything else (properties like
+	// `.params`, `.json`, and methods that don't yet have a typed RPC like
+	// `.last`, `.all`) is read from an underlying lazy proxy via explicit
+	// delegation.
+	//
+	// Important: the synthetic Proxy's *target* is a plain `{}` rather than
+	// the lazy proxy itself. Nesting one Proxy inside another causes V8 to
+	// run invariant checks (`[[OwnPropertyKeys]]`, descriptor consistency)
+	// against the inner target, which would trigger the lazy proxy's
+	// `ownKeys` trap and an unnecessary `getValueAtPath` round-trip for the
+	// whole node's keys. Using `{}` as the target keeps those checks cheap;
+	// the lazy proxy lives in closure and is only consulted on demand.
+	//
+	// As Phase B Step 3 adds more typed RPCs, more cases land in this trap.
 	target.$ = function (nodeName: string) {
-		return createDeepLazyProxy(['$', nodeName], undefined, callbacks);
+		const lazyProxy = createDeepLazyProxy(['$', nodeName], undefined, callbacks);
+		return new Proxy({} as Record<string, unknown>, {
+			get(_emptyTarget, prop) {
+				if (prop === 'first') {
+					return (branchIndex?: number, runIndex?: number) => {
+						const result = callbacks.sendMessage.applySync(
+							null,
+							[{ type: 'getNodeFirst', nodeName, branchIndex, runIndex }],
+							{ arguments: { copy: true }, result: { copy: true } },
+						);
+						throwIfErrorSentinel(result);
+						return result;
+					};
+				}
+				// Everything else: delegate to the lazy proxy. The lazy proxy's
+				// own `get` trap handles caching, host fetching, and metadata.
+				return (lazyProxy as Record<string | symbol, unknown>)[prop];
+			},
+		});
 	};
 
 	// -------------------------------------------------------------------------
@@ -129,7 +183,7 @@ export function buildContext(
 
 		let value: unknown;
 		try {
-			value = getValueAtPath.applySync(null, [[key]], {
+			value = callbacks.getValueAtPath.applySync(null, [[key]], {
 				arguments: { copy: true },
 				result: { copy: true },
 			});
@@ -149,7 +203,7 @@ export function buildContext(
 		// Function metadata — create a callable wrapper
 		if (value && typeof value === 'object' && (value as any).__isFunction) {
 			target[key] = function (...args: unknown[]) {
-				const result = callFunctionAtPath.applySync(null, [[key], ...args], {
+				const result = callbacks.callFunctionAtPath.applySync(null, [[key], ...args], {
 					arguments: { copy: true },
 					result: { copy: true },
 				});

--- a/packages/@n8n/expression-runtime/src/runtime/context.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/context.ts
@@ -24,6 +24,21 @@ const SafeURIError = createSafeErrorSubclass(URIError);
 // ============================================================================
 
 /**
+ * The subset of `ivm.Reference` shape the in-isolate runtime relies on.
+ * Declared locally rather than importing from `isolated-vm` because this
+ * module is bundled into the isolate IIFE, where the native module is
+ * unavailable. The host wires real `ivm.Reference` instances which
+ * structurally satisfy this interface.
+ */
+interface BridgeCallback {
+	applySync(
+		thisArg: unknown,
+		args: unknown[],
+		options?: { arguments?: { copy?: boolean }; result?: { copy?: boolean } },
+	): unknown;
+}
+
+/**
  * Bridge callbacks the in-isolate runtime can invoke synchronously via
  * `ivm.Reference.applySync`.
  *
@@ -40,14 +55,10 @@ const SafeURIError = createSafeErrorSubclass(URIError);
  *     host RPC, not a postMessage-style async send.
  */
 export interface BridgeCallbacks {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	getValueAtPath: any;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	getArrayElement: any;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	callFunctionAtPath: any;
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	callHost: any;
+	getValueAtPath: BridgeCallback;
+	getArrayElement: BridgeCallback;
+	callFunctionAtPath: BridgeCallback;
+	callHost: BridgeCallback;
 }
 
 /**

--- a/packages/@n8n/expression-runtime/src/runtime/index.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/index.ts
@@ -4,7 +4,7 @@ import { extend, extendOptional } from '../extensions/extend';
 
 import { SafeObject, SafeError, ExpressionError } from './safe-globals';
 import { createDeepLazyProxy } from './lazy-proxy';
-import { buildContext } from './context';
+import { buildContext, type BridgeCallbacks } from './context';
 import { __prepareForTransfer } from './serialize';
 
 // Augment globalThis with runtime properties
@@ -13,13 +13,10 @@ declare global {
 		// Proxy creator function
 		var createDeepLazyProxy: (basePath?: string[]) => any;
 
-		// Context builder (closure-scoped alternative to resetDataProxies)
-		var buildContext: (
-			getValueAtPath: any,
-			getArrayElement: any,
-			callFunctionAtPath: any,
-			timezone?: string,
-		) => Record<string, unknown>;
+		// Context builder (closure-scoped alternative to resetDataProxies).
+		// Accepts a single callbacks bundle so adding new typed RPCs doesn't
+		// churn the signature; see `BridgeCallbacks` in `runtime/context.ts`.
+		var buildContext: (callbacks: BridgeCallbacks, timezone?: string) => Record<string, unknown>;
 
 		// Safe wrappers
 		var SafeObject: typeof Object;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1622,6 +1622,9 @@ importers:
       transliteration:
         specifier: 2.3.5
         version: 2.3.5
+      zod:
+        specifier: 3.25.67
+        version: 3.25.67
     devDependencies:
       '@n8n/typescript-config':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

Phase B Step 3 of the expression-isolation security audit (CAT-2982).

Introduces a single-`sendMessage` typed-RPC dispatcher in the host bridge as the foundation for replacing the generic `callFunctionAtPath` host-callable with a closed set of validated operations.

- Adds a single typed-RPC dispatcher (`createSendMessageRef`) on the host side. The isolate sends one envelope per typed RPC; the host validates and dispatches via `switch (msg.type)`.
- Adds the first typed RPC, `getNodeFirst`, covering `$('Foo').first(branchIndex?, runIndex?)`.
- Validates every envelope with a zod discriminated union (`bridgeMessageSchema` in `bridge-messages.ts`). Unknown `type`, missing/extra fields, and non-integer/negative indices are rejected at the trust boundary before dispatch happens. `.strict()` on each member catches typos in the runtime stubs.
- In-isolate, a synthetic `Proxy` wraps the result of `target.$(name)` and intercepts `.first`, routing it through the dispatcher. Other property access still falls through to the existing lazy proxy, so behaviour is unchanged for the rest of the surface.
- Errors from the host handler are returned as the existing `__isError` sentinel and reconstructed isolate-side — no class identity crosses the boundary.
- 6-case regression test suite in `packages/@n8n/expression-runtime/src/__tests__/typed-rpc.test.ts` covering the happy path, optional indices, schema rejection (unknown type, wrong types, extra fields), and error sentinel reconstruction.

The generic `callFunctionAtPath` ref is intentionally still present. Step 4 of Phase B removes it once every remaining consumer has migrated to a typed RPC (planned: `last`, `all`, `$input.*`, etc., each landing as a new schema + new `case`).

No bundle-size or runtime-perf impact: typed-RPC stubs are tiny and the dispatcher's zod parse runs only on the typed-RPC path; the lazy proxy path is unchanged.

### Series context

- PR #30098 — Step 0 (merged)
- PR #30736 — Step 1, jmespath inlining (merged)
- Step 2 — path-encoding sketch (rejected, kept as `PATH_ENCODING_SKETCH.md` for posterity)
- **This PR** — Step 3, typed-RPC dispatcher foundation + first operation
- Follow-ups — additional typed RPCs, then Step 4 removes `callFunctionAtPath`

### How to test

```bash
cd packages/@n8n/expression-runtime
pnpm build           # IIFE bundle must be rebuilt before running tests
pnpm test src/__tests__/typed-rpc.test.ts
pnpm test            # full suite
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2982

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created. *(internal refactor — no user-facing surface changes)*
- [x] Tests included. *(6-case suite in `src/__tests__/typed-rpc.test.ts`)*
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
- N/A — I have notified the Product Manager *(internal refactor, not user-facing)*

🤖 PR Summary generated by AI