### PR TITLE
feat(core): Encrypt running user's auth cookie into manual execution credential context

### DIFF
--- a/packages/cli/src/auth/__tests__/auth.service.test.ts
+++ b/packages/cli/src/auth/__tests__/auth.service.test.ts
@@ -1367,4 +1367,91 @@ describe('AuthService', () => {
 			});
 		});
 	});
+
+	describe('authenticateUserByCookie', () => {
+		beforeEach(() => {
+			jest.resetAllMocks();
+		});
+
+		describe('token validation failures', () => {
+			it('should throw when token is blocklisted', async () => {
+				const token = authService.issueJWT(user, true, browserId);
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(true);
+
+				await expect(authService.authenticateUserByCookie(token)).rejects.toThrow('Unauthorized');
+				expect(userRepository.findOne).not.toHaveBeenCalled();
+			});
+
+			it('should throw when JWT is expired', async () => {
+				const token = authService.issueJWT(user, true, browserId);
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				jest.advanceTimersByTime(365 * Time.days.toMilliseconds);
+
+				await expect(authService.authenticateUserByCookie(token)).rejects.toThrow('jwt expired');
+			});
+
+			it('should throw when JWT is malformed', async () => {
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+
+				await expect(authService.authenticateUserByCookie('not-a-jwt')).rejects.toThrow(
+					'jwt malformed',
+				);
+			});
+
+			it('should throw when user is not found', async () => {
+				const token = authService.issueJWT(user, true, browserId);
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				userRepository.findOne.mockResolvedValue(null);
+
+				await expect(authService.authenticateUserByCookie(token)).rejects.toThrow('Unauthorized');
+			});
+
+			it('should throw when user is disabled', async () => {
+				const token = authService.issueJWT(user, true, browserId);
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				userRepository.findOne.mockResolvedValue(mock<User>({ ...userData, disabled: true }));
+
+				await expect(authService.authenticateUserByCookie(token)).rejects.toThrow('Unauthorized');
+			});
+
+			it('should throw when user password hash changed', async () => {
+				const token = authService.issueJWT(user, true, browserId);
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				userRepository.findOne.mockResolvedValue(
+					mock<User>({ ...userData, password: 'newPasswordHash' }),
+				);
+
+				await expect(authService.authenticateUserByCookie(token)).rejects.toThrow('Unauthorized');
+			});
+		});
+
+		describe('MFA gate', () => {
+			it('should throw when MFA is enforced and token was issued without MFA', async () => {
+				const tokenWithoutMfa = authService.issueJWT(user, false, browserId);
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				userRepository.findOne.mockResolvedValue(user);
+				mfaService.isMFAEnforced.mockResolvedValue(true);
+
+				await expect(authService.authenticateUserByCookie(tokenWithoutMfa)).rejects.toThrow(
+					'Unauthorized',
+				);
+			});
+
+			it('should throw when user has MFA enabled and token was issued without MFA', async () => {
+				const userWithMfa = mock<User>({
+					...userData,
+					mfaEnabled: true,
+					mfaSecret: 'secret',
+				});
+				const tokenForMfaUser = authService.issueJWT(userWithMfa, false, browserId);
+				invalidAuthTokenRepository.existsBy.mockResolvedValue(false);
+				userRepository.findOne.mockResolvedValue(userWithMfa);
+				mfaService.isMFAEnforced.mockResolvedValue(false);
+
+				await expect(authService.authenticateUserByCookie(tokenForMfaUser)).rejects.toThrow(
+					'Unauthorized',
+				);
+			});
+		});
+	});
 });

--- a/packages/cli/src/auth/auth.service.ts
+++ b/packages/cli/src/auth/auth.service.ts
@@ -268,18 +268,39 @@ export class AuthService {
 
 		this.validateBrowserId(jwtPayload, browserId, endpoint, method);
 
-		const usedMfa = jwtPayload.usedMfa ?? false;
+		await this.checkMfaGate(user, jwtPayload);
 
-		// MFA was used, we are good either way.
-		if (usedMfa) {
-			return user;
+		return user;
+	}
+
+	/**
+	 * Validates an n8n auth cookie (JWT) without request-bound checks (browserId / endpoint / method).
+	 *
+	 * Use when the cookie was captured at the controller boundary and must be re-validated
+	 * later in the execution lifecycle, after the original HTTP request is no longer available.
+	 *
+	 * @param cookie - The JWT string extracted from the `n8n-auth` browser cookie.
+	 */
+	async authenticateUserByCookie(cookie: string): Promise<User> {
+		const isInvalid = await this.invalidAuthTokenRepository.existsBy({ token: cookie });
+		if (isInvalid) throw new AuthError('Unauthorized');
+
+		const { user, jwtPayload } = await this.validateToken(cookie);
+
+		await this.checkMfaGate(user, jwtPayload);
+		return user;
+	}
+
+	private async checkMfaGate(user: User, jwtPayload: IssuedJWT): Promise<void> {
+		if (jwtPayload.usedMfa ?? false) {
+			return;
 		}
-		const mfaEnforced = await this.mfaService.isMFAEnforced();
 
+		const mfaEnforced = await this.mfaService.isMFAEnforced();
 		if (!mfaEnforced && !user.mfaEnabled) {
 			// MFA is not enforced and the user has MFA not enabled
 			// we are good
-			return user;
+			return;
 		}
 
 		// either MFA is enforced or user has MFA enabled

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/n8n-identifier.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/n8n-identifier.test.ts
@@ -173,5 +173,79 @@ describe('N8NIdentifier', () => {
 				await expect(identifier.resolve(context, {})).rejects.toThrow('Database connection failed');
 			});
 		});
+
+		describe('chat-hub branch with explicit source', () => {
+			it('should call authenticateUserBasedOnToken when source is chat-hub-injected', async () => {
+				mockAuthService.authenticateUserBasedOnToken.mockResolvedValue(mockUser);
+
+				const context = {
+					identity: 'cookie-jwt',
+					version: 1 as const,
+					metadata: {
+						source: 'chat-hub-injected' as const,
+						method: 'POST',
+						endpoint: '/chat',
+						browserId: 'browser-abc',
+					},
+				};
+
+				const result = await identifier.resolve(context, {});
+
+				expect(result).toBe('user-123');
+				expect(mockAuthService.authenticateUserBasedOnToken).toHaveBeenCalledWith(
+					'cookie-jwt',
+					'POST',
+					'/chat',
+					'browser-abc',
+				);
+				expect(mockAuthService.authenticateUserByCookie).not.toHaveBeenCalled();
+			});
+		});
+
+		describe('manual-execution branch', () => {
+			it('should resolve user via authenticateUserByCookie and skip the request-bound path', async () => {
+				mockAuthService.authenticateUserByCookie.mockResolvedValue(mockUser);
+
+				const context = {
+					identity: 'n8n-auth-cookie-jwt',
+					version: 1 as const,
+					metadata: { source: 'manual-execution' as const },
+				};
+
+				const result = await identifier.resolve(context, {});
+
+				expect(result).toBe('user-123');
+				expect(mockAuthService.authenticateUserByCookie).toHaveBeenCalledWith(
+					'n8n-auth-cookie-jwt',
+				);
+				expect(mockAuthService.authenticateUserBasedOnToken).not.toHaveBeenCalled();
+			});
+
+			it('should propagate AuthError from authenticateUserByCookie', async () => {
+				mockAuthService.authenticateUserByCookie.mockRejectedValue(new AuthError('Unauthorized'));
+
+				const context = {
+					identity: 'expired-cookie',
+					version: 1 as const,
+					metadata: { source: 'manual-execution' as const },
+				};
+
+				await expect(identifier.resolve(context, {})).rejects.toThrow('Unauthorized');
+			});
+
+			it('should propagate generic errors from authenticateUserByCookie', async () => {
+				mockAuthService.authenticateUserByCookie.mockRejectedValue(
+					new Error('Database connection failed'),
+				);
+
+				const context = {
+					identity: 'cookie-jwt',
+					version: 1 as const,
+					metadata: { source: 'manual-execution' as const },
+				};
+
+				await expect(identifier.resolve(context, {})).rejects.toThrow('Database connection failed');
+			});
+		});
 	});
 });

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/n8n-identifier.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/n8n-identifier.test.ts
@@ -39,6 +39,7 @@ describe('N8NIdentifier', () => {
 					identity: 'valid-jwt-token',
 					version: 1 as const,
 					metadata: {
+						source: 'chat-hub-injected' as const,
 						method: 'GET',
 						endpoint: '/api/users',
 						browserId: 'browser-abc',
@@ -63,6 +64,7 @@ describe('N8NIdentifier', () => {
 					identity: 'valid-jwt-token',
 					version: 1 as const,
 					metadata: {
+						source: 'chat-hub-injected' as const,
 						method: 'POST',
 						endpoint: '/api/workflows',
 						browserId: undefined,
@@ -87,6 +89,7 @@ describe('N8NIdentifier', () => {
 					identity: 'valid-jwt-token',
 					version: 1 as const,
 					metadata: {
+						source: 'chat-hub-injected' as const,
 						method: 'DELETE',
 						endpoint: '/api/credentials',
 					},
@@ -123,6 +126,7 @@ describe('N8NIdentifier', () => {
 					identity: 'valid-jwt-token',
 					version: 1 as const,
 					metadata: {
+						source: 'chat-hub-injected' as const,
 						method: 'GET',
 						endpoint: '/api/users',
 						browserId: 123, // Number instead of string
@@ -148,6 +152,7 @@ describe('N8NIdentifier', () => {
 					identity: 'invalid-token',
 					version: 1 as const,
 					metadata: {
+						source: 'chat-hub-injected' as const,
 						method: 'GET',
 						endpoint: '/api/users',
 						browserId: 'browser-abc',
@@ -165,6 +170,7 @@ describe('N8NIdentifier', () => {
 					identity: 'valid-token',
 					version: 1 as const,
 					metadata: {
+						source: 'chat-hub-injected' as const,
 						method: 'POST',
 						endpoint: '/api/workflows',
 					},
@@ -198,6 +204,68 @@ describe('N8NIdentifier', () => {
 					'/chat',
 					'browser-abc',
 				);
+				expect(mockAuthService.authenticateUserByCookie).not.toHaveBeenCalled();
+			});
+		});
+
+		describe('cookie-source branch', () => {
+			it('should call authenticateUserBasedOnToken when source is cookie-source', async () => {
+				mockAuthService.authenticateUserBasedOnToken.mockResolvedValue(mockUser);
+
+				const context = {
+					identity: 'cookie-jwt',
+					version: 1 as const,
+					metadata: {
+						source: 'cookie-source' as const,
+						method: 'GET',
+						endpoint: '/api/data',
+						browserId: 'browser-xyz',
+					},
+				};
+
+				const result = await identifier.resolve(context, {});
+
+				expect(result).toBe('user-123');
+				expect(mockAuthService.authenticateUserBasedOnToken).toHaveBeenCalledWith(
+					'cookie-jwt',
+					'GET',
+					'/api/data',
+					'browser-xyz',
+				);
+				expect(mockAuthService.authenticateUserByCookie).not.toHaveBeenCalled();
+			});
+		});
+
+		describe('discriminator validation', () => {
+			it('should reject metadata without a source field', async () => {
+				const context = {
+					identity: 'valid-jwt-token',
+					version: 1 as const,
+					metadata: {
+						method: 'GET',
+						endpoint: '/api/users',
+						browserId: 'browser-abc',
+					},
+				};
+
+				await expect(identifier.resolve(context, {})).rejects.toThrow(CredentialResolverError);
+				expect(mockAuthService.authenticateUserBasedOnToken).not.toHaveBeenCalled();
+				expect(mockAuthService.authenticateUserByCookie).not.toHaveBeenCalled();
+			});
+
+			it('should reject metadata with an unknown source value', async () => {
+				const context = {
+					identity: 'valid-jwt-token',
+					version: 1 as const,
+					metadata: {
+						source: 'unknown-source',
+						method: 'GET',
+						endpoint: '/api/users',
+					},
+				};
+
+				await expect(identifier.resolve(context, {})).rejects.toThrow(CredentialResolverError);
+				expect(mockAuthService.authenticateUserBasedOnToken).not.toHaveBeenCalled();
 				expect(mockAuthService.authenticateUserByCookie).not.toHaveBeenCalled();
 			});
 		});

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/n8n-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/n8n-identifier.ts
@@ -9,14 +9,17 @@ const ManualExecutionMetadataSchema = z.object({
 	source: z.literal('manual-execution'),
 });
 
-const ChatHubMetadataSchema = z.object({
-	source: z.enum(['chat-hub-injected', 'cookie-source']).optional(),
+const RequestBoundMetadataSchema = z.object({
+	source: z.enum(['chat-hub-injected', 'cookie-source']),
 	method: z.string(),
 	endpoint: z.string(),
 	browserId: z.string().optional(),
 });
 
-const N8NIdentifierMetadataSchema = z.union([ManualExecutionMetadataSchema, ChatHubMetadataSchema]);
+const N8NIdentifierMetadataSchema = z.discriminatedUnion('source', [
+	ManualExecutionMetadataSchema,
+	RequestBoundMetadataSchema,
+]);
 
 /**
  * N8N JWT token identifier.
@@ -24,11 +27,13 @@ const N8NIdentifierMetadataSchema = z.union([ManualExecutionMetadataSchema, Chat
  * Used by the N8N credential resolver to authenticate users via n8n's
  * built-in JWT authentication and store credentials per user.
  *
- * Supports two metadata sources:
+ * Supports two metadata shapes, discriminated by `source`:
  * - `manual-execution`: editor-triggered run; identity is the n8n auth cookie (JWT).
  *   Validated cryptographically without request-bound checks (browserId / endpoint).
- * - `chat-hub-injected` (or no source): chat-hub / webhook run; identity is the
- *   n8n auth cookie captured from the HTTP request, validated with full request context.
+ * - `chat-hub-injected` / `cookie-source`: request-bound run (chat-hub or
+ *   web/cookie-based dynamic-credential resolution); identity is the n8n auth
+ *   cookie captured from the HTTP request, validated with full request context
+ *   (method, endpoint, browserId).
  */
 @Service()
 export class N8NIdentifier implements ITokenIdentifier {

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/n8n-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/n8n-identifier.ts
@@ -5,17 +5,30 @@ import { AuthService } from '@/auth/auth.service';
 import { z } from 'zod';
 import { CredentialResolverError } from '@n8n/decorators';
 
-const ChatHubExtractorMetadataSchema = z.object({
+const ManualExecutionMetadataSchema = z.object({
+	source: z.literal('manual-execution'),
+});
+
+const ChatHubMetadataSchema = z.object({
+	source: z.enum(['chat-hub-injected', 'cookie-source']).optional(),
 	method: z.string(),
 	endpoint: z.string(),
 	browserId: z.string().optional(),
 });
+
+const N8NIdentifierMetadataSchema = z.union([ManualExecutionMetadataSchema, ChatHubMetadataSchema]);
 
 /**
  * N8N JWT token identifier.
  * Validates n8n authentication tokens and resolves them to user IDs.
  * Used by the N8N credential resolver to authenticate users via n8n's
  * built-in JWT authentication and store credentials per user.
+ *
+ * Supports two metadata sources:
+ * - `manual-execution`: editor-triggered run; identity is the n8n auth cookie (JWT).
+ *   Validated cryptographically without request-bound checks (browserId / endpoint).
+ * - `chat-hub-injected` (or no source): chat-hub / webhook run; identity is the
+ *   n8n auth cookie captured from the HTTP request, validated with full request context.
  */
 @Service()
 export class N8NIdentifier implements ITokenIdentifier {
@@ -26,13 +39,21 @@ export class N8NIdentifier implements ITokenIdentifier {
 	}
 
 	async resolve(context: ICredentialContext, _: Record<string, unknown>): Promise<string> {
-		const metadataResult = ChatHubExtractorMetadataSchema.safeParse(context.metadata);
+		const metadataResult = N8NIdentifierMetadataSchema.safeParse(context.metadata);
 		if (!metadataResult.success) {
 			throw new CredentialResolverError(
 				`Invalid context metadata: ${metadataResult.error.message}`,
 			);
 		}
 
+		if (metadataResult.data.source === 'manual-execution') {
+			// No HTTP request context at credential-resolution time; skip browserId/endpoint checks.
+			const user = await this.authService.authenticateUserByCookie(context.identity);
+			return user.id;
+		}
+
+		// Chat-hub / webhook run: validate the JWT together with the request-bound metadata
+		// (browserId, endpoint, method) captured from the originating HTTP request.
 		const user = await this.authService.authenticateUserBasedOnToken(
 			context.identity,
 			metadataResult.data.method,

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -21,6 +21,7 @@ import type {
 	INode,
 	IPinData,
 	IRun,
+	IWorkflowExecuteAdditionalData,
 	WorkflowExecuteMode,
 	IWorkflowExecutionDataProcess,
 } from 'n8n-workflow';
@@ -220,7 +221,7 @@ export class WorkflowRunner {
 				await establishExecutionContext(
 					contextWorkflow,
 					data.executionData,
-					undefined,
+					{ n8nAuthCookie: data.n8nAuthCookie } as IWorkflowExecuteAdditionalData,
 					data.executionMode,
 				);
 			} catch (error) {
@@ -373,6 +374,7 @@ export class WorkflowRunner {
 		});
 		additionalData.restartExecutionId = restartExecutionId;
 		additionalData.streamingEnabled = data.streamingEnabled;
+		additionalData.n8nAuthCookie = data.n8nAuthCookie;
 
 		additionalData.executionId = executionId;
 

--- a/packages/cli/src/workflow-runner.ts
+++ b/packages/cli/src/workflow-runner.ts
@@ -21,7 +21,6 @@ import type {
 	INode,
 	IPinData,
 	IRun,
-	IWorkflowExecuteAdditionalData,
 	WorkflowExecuteMode,
 	IWorkflowExecutionDataProcess,
 } from 'n8n-workflow';
@@ -221,7 +220,7 @@ export class WorkflowRunner {
 				await establishExecutionContext(
 					contextWorkflow,
 					data.executionData,
-					{ n8nAuthCookie: data.n8nAuthCookie } as IWorkflowExecuteAdditionalData,
+					{ encryptedRunnerIdentity: data.encryptedRunnerIdentity },
 					data.executionMode,
 				);
 			} catch (error) {
@@ -374,7 +373,7 @@ export class WorkflowRunner {
 		});
 		additionalData.restartExecutionId = restartExecutionId;
 		additionalData.streamingEnabled = data.streamingEnabled;
-		additionalData.n8nAuthCookie = data.n8nAuthCookie;
+		additionalData.encryptedRunnerIdentity = data.encryptedRunnerIdentity;
 
 		additionalData.executionId = executionId;
 

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -100,6 +100,7 @@ describe('WorkflowExecutionService', () => {
 		mock(),
 		mock(),
 		mockOwnershipService(),
+		mock(),
 	);
 
 	const additionalData = mock<IWorkflowExecuteAdditionalData>({});
@@ -457,6 +458,7 @@ describe('WorkflowExecutionService', () => {
 				mock(),
 				mock(),
 				mockOwnershipService(),
+				mock(),
 			);
 
 			const runPayload: WorkflowRequest.FullManualExecutionFromKnownTriggerPayload = {
@@ -526,6 +528,7 @@ describe('WorkflowExecutionService', () => {
 				mock(),
 				mock(),
 				mockOwnershipService(),
+				mock(),
 			);
 
 			const result = await service.executeManually(workflowData, runPayload, user);
@@ -694,6 +697,7 @@ describe('WorkflowExecutionService', () => {
 				mock(),
 				mock(),
 				mockOwnershipService(),
+				mock(),
 			);
 		});
 
@@ -846,6 +850,7 @@ describe('WorkflowExecutionService', () => {
 				mock(),
 				mock(),
 				mockOwnershipService(),
+				mock(),
 			);
 
 			await service.executeErrorWorkflow(
@@ -975,6 +980,7 @@ describe('WorkflowExecutionService', () => {
 				mock(),
 				workflowRunnerMock,
 				globalConfig,
+				mock(),
 				mock(),
 				mock(),
 				mock(),

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -108,6 +108,7 @@ export class WorkflowExecutionService {
 		payload: WorkflowRequest.ManualRunPayload,
 		user: User,
 		pushRef?: string,
+		n8nAuthCookie?: string,
 	): Promise<{ executionId: string } | { waitingForWebhook: boolean }> {
 		// Check whether this workflow is active.
 		const workflowIsActive = await this.workflowRepository.isActive(workflowData.id);
@@ -218,6 +219,7 @@ export class WorkflowExecutionService {
 			const project = await this.ownershipService.getWorkflowProjectCached(workflowData.id);
 			data.projectId = project.id;
 			data.projectName = project.name;
+			data.n8nAuthCookie = n8nAuthCookie;
 
 			const offloadingManualExecutionsInQueueMode =
 				this.globalConfig.executions.mode === 'queue' &&

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -4,7 +4,12 @@ import type { Project, User, CreateExecutionPayload } from '@n8n/db';
 import { WorkflowRepository } from '@n8n/db';
 import { Service } from '@n8n/di';
 import type { Response } from 'express';
-import { DirectedGraph, ErrorReporter, anyReachableRootHasRunData } from 'n8n-core';
+import {
+	DirectedGraph,
+	ErrorReporter,
+	ExecutionContextService,
+	anyReachableRootHasRunData,
+} from 'n8n-core';
 import type {
 	IDeferredPromise,
 	IExecuteData,
@@ -52,6 +57,7 @@ export class WorkflowExecutionService {
 		private readonly failedRunFactory: FailedRunFactory,
 		private readonly eventService: EventService,
 		private readonly ownershipService: OwnershipService,
+		private readonly executionContextService: ExecutionContextService,
 	) {}
 
 	async runWorkflow(
@@ -219,7 +225,10 @@ export class WorkflowExecutionService {
 			const project = await this.ownershipService.getWorkflowProjectCached(workflowData.id);
 			data.projectId = project.id;
 			data.projectName = project.name;
-			data.n8nAuthCookie = n8nAuthCookie;
+
+			data.encryptedRunnerIdentity = n8nAuthCookie
+				? await this.executionContextService.buildManualExecutionCredentials(n8nAuthCookie)
+				: undefined;
 
 			const offloadingManualExecutionsInQueueMode =
 				this.globalConfig.executions.mode === 'queue' &&

--- a/packages/cli/src/workflows/workflows.controller.ts
+++ b/packages/cli/src/workflows/workflows.controller.ts
@@ -56,6 +56,7 @@ import type { IWorkflowResponse } from '@/interfaces';
 import { License } from '@/license';
 import { listQueryMiddleware } from '@/middlewares';
 import { userHasScopes } from '@/permissions.ee/check-access';
+import { AuthService } from '@/auth/auth.service';
 import * as ResponseHelper from '@/response-helper';
 import { NamingService } from '@/services/naming.service';
 import { ProjectService } from '@/services/project.service.ee';
@@ -68,6 +69,7 @@ import * as utils from '@/utils';
 export class WorkflowsController {
 	constructor(
 		private readonly logger: Logger,
+		private readonly authService: AuthService,
 		private readonly enterpriseWorkflowService: EnterpriseWorkflowService,
 		private readonly namingService: NamingService,
 		private readonly workflowRepository: WorkflowRepository,
@@ -523,11 +525,14 @@ export class WorkflowsController {
 			throw new NotFoundError(`Workflow with ID "${workflowId}" not found`);
 		}
 
+		const n8nAuthCookie = this.authService.getCookieToken(req);
+
 		const result = await this.workflowExecutionService.executeManually(
 			dbWorkflow,
 			req.body,
 			req.user,
 			req.headers['push-ref'],
+			n8nAuthCookie,
 		);
 
 		if ('executionId' in result) {

--- a/packages/cli/test/integration/execution-context-propagation.test.ts
+++ b/packages/cli/test/integration/execution-context-propagation.test.ts
@@ -7,15 +7,13 @@
 import { testDb, createWorkflow, createActiveWorkflow } from '@n8n/backend-test-utils';
 import { ExecutionRepository, type IWorkflowDb } from '@n8n/db';
 import { Container } from '@n8n/di';
-import { readFileSync } from 'fs';
-import { UnrecognizedNodeTypeError } from 'n8n-core';
-import type { IExecutionContext, INodeType, INodeTypeData, NodeLoadingDetails } from 'n8n-workflow';
-import path from 'path';
+import type { IExecutionContext } from 'n8n-workflow';
 
 import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
 
 import { createOwner } from './shared/db/users';
 import * as utils from './shared/utils';
+import { loadNodesFromDist } from './shared/utils/node-types-data';
 import {
 	createSubWorkflowFixture,
 	createParentWorkflowFixture,
@@ -28,36 +26,6 @@ import {
 	validateContextInheritanceChain,
 	validateBasicContextStructure,
 } from './shared/execution-context-helpers';
-
-// ============================================================
-// Helper to load nodes from dist folder
-// ============================================================
-
-const BASE_DIR = path.resolve(__dirname, '../../..');
-
-function loadNodesFromDist(nodeNames: string[]): INodeTypeData {
-	const nodeTypes: INodeTypeData = {};
-
-	const knownNodes = JSON.parse(
-		readFileSync(path.join(BASE_DIR, 'nodes-base/dist/known/nodes.json'), 'utf-8'),
-	) as Record<string, NodeLoadingDetails>;
-
-	for (const nodeName of nodeNames) {
-		const loadInfo = knownNodes[nodeName.replace('n8n-nodes-base.', '')];
-		if (!loadInfo) {
-			throw new UnrecognizedNodeTypeError('n8n-nodes-base', nodeName);
-		}
-		// Load from dist .js files (sourcePath already includes 'dist/')
-		const nodeDistPath = path.join(BASE_DIR, 'nodes-base', loadInfo.sourcePath);
-		const node = new (require(nodeDistPath)[loadInfo.className])() as INodeType;
-		nodeTypes[nodeName] = {
-			sourcePath: '',
-			type: node,
-		};
-	}
-
-	return nodeTypes;
-}
 
 // Fixtures are now imported from './shared/workflow-fixtures'
 

--- a/packages/cli/test/integration/insights/insights-vs-workflow-statistics.integration.test.ts
+++ b/packages/cli/test/integration/insights/insights-vs-workflow-statistics.integration.test.ts
@@ -11,11 +11,8 @@ import { createTeamProject, createWorkflow, testDb, testModules } from '@n8n/bac
 import type { Project, WorkflowEntity } from '@n8n/db';
 import { ExecutionRepository, StatisticsNames, WorkflowStatisticsRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
-import { readFileSync } from 'fs';
-import { InstanceSettings, UnrecognizedNodeTypeError } from 'n8n-core';
-import type { INodeType, INodeTypeData, NodeLoadingDetails } from 'n8n-workflow';
+import { InstanceSettings } from 'n8n-core';
 import { createRunExecutionData } from 'n8n-workflow';
-import path from 'path';
 
 import { InsightsByPeriodRepository } from '@/modules/insights/database/repositories/insights-by-period.repository';
 import { InsightsRawRepository } from '@/modules/insights/database/repositories/insights-raw.repository';
@@ -25,37 +22,8 @@ import { WorkflowStatisticsService } from '@/services/workflow-statistics.servic
 import { WorkflowRunner } from '@/workflow-runner';
 
 import * as utils from '../shared/utils';
+import { loadNodesFromDist } from '../shared/utils/node-types-data';
 import { createSimpleWorkflowFixture } from '../shared/workflow-fixtures';
-
-// ============================================================
-// Helper to load nodes from dist folder
-// ============================================================
-
-const BASE_DIR = path.resolve(__dirname, '../../../..');
-
-function loadNodesFromDist(nodeNames: string[]): INodeTypeData {
-	const nodeTypes: INodeTypeData = {};
-
-	const knownNodes = JSON.parse(
-		readFileSync(path.join(BASE_DIR, 'nodes-base/dist/known/nodes.json'), 'utf-8'),
-	) as Record<string, NodeLoadingDetails>;
-
-	for (const nodeName of nodeNames) {
-		const loadInfo = knownNodes[nodeName.replace('n8n-nodes-base.', '')];
-		if (!loadInfo) {
-			throw new UnrecognizedNodeTypeError('n8n-nodes-base', nodeName);
-		}
-		// Load from dist .js files (sourcePath already includes 'dist/')
-		const nodeDistPath = path.join(BASE_DIR, 'nodes-base', loadInfo.sourcePath);
-		const node = new (require(nodeDistPath)[loadInfo.className])() as INodeType;
-		nodeTypes[nodeName] = {
-			sourcePath: '',
-			type: node,
-		};
-	}
-
-	return nodeTypes;
-}
 
 describe('Insights vs Workflow Statistics Integration', () => {
 	beforeAll(async () => {

--- a/packages/cli/test/integration/manual-execution-credential-context.test.ts
+++ b/packages/cli/test/integration/manual-execution-credential-context.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Integration tests for the manual-execution credential context.
+ *
+ * Verifies that when a workflow is run manually from the editor:
+ *  - The auth cookie passed to `executeManually` is encrypted into
+ *    `runtimeData.credentials` of the persisted execution.
+ *  - `N8NIdentifier.resolve` can decrypt that context, validate the cookie
+ *    via `AuthService.authenticateUserByCookie`, and return the running
+ *    user's id — without any request-bound (browserId / endpoint) data.
+ *  - A blocklisted cookie (simulating logout) makes the resolver fail.
+ */
+
+import { LicenseState } from '@n8n/backend-common';
+import { testDb, createWorkflow } from '@n8n/backend-test-utils';
+import { ExecutionRepository, InvalidAuthTokenRepository, type IWorkflowDb } from '@n8n/db';
+import { Container } from '@n8n/di';
+import { mock } from 'jest-mock-extended';
+import { Cipher } from 'n8n-core';
+import { toCredentialContext, toExecutionContext, type IExecutionContext } from 'n8n-workflow';
+
+import { AuthService } from '@/auth/auth.service';
+import { N8NIdentifier } from '@/modules/dynamic-credentials.ee/credential-resolvers/identifiers/n8n-identifier';
+import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
+
+import { createOwner, createMember } from './shared/db/users';
+import * as utils from './shared/utils';
+import { loadNodesFromDist } from './shared/utils/node-types-data';
+import { createSimpleWorkflowFixture } from './shared/workflow-fixtures';
+
+// MFA enforcement gates inside AuthService.authenticateUserByCookie call into the
+// license state; stub it so any feature check returns "not licensed".
+const licenseMock = mock<LicenseState>();
+licenseMock.isLicensed.mockReturnValue(false);
+Container.set(LicenseState, licenseMock);
+
+describe('Manual execution credential context (integration)', () => {
+	let owner: Awaited<ReturnType<typeof createOwner>>;
+	let member: Awaited<ReturnType<typeof createMember>>;
+	let workflowExecutionService: WorkflowExecutionService;
+	let executionRepository: ExecutionRepository;
+	let authService: AuthService;
+	let cipher: Cipher;
+	let identifier: N8NIdentifier;
+	let invalidAuthTokenRepository: InvalidAuthTokenRepository;
+
+	beforeAll(async () => {
+		await testDb.init();
+
+		const nodeTypes = loadNodesFromDist(['n8n-nodes-base.manualTrigger']);
+		await utils.initNodeTypes(nodeTypes);
+		await utils.initBinaryDataService();
+
+		owner = await createOwner();
+		member = await createMember();
+
+		workflowExecutionService = Container.get(WorkflowExecutionService);
+		executionRepository = Container.get(ExecutionRepository);
+		authService = Container.get(AuthService);
+		cipher = Container.get(Cipher);
+		identifier = Container.get(N8NIdentifier);
+		invalidAuthTokenRepository = Container.get(InvalidAuthTokenRepository);
+	});
+
+	afterEach(async () => {
+		await testDb.truncate(['ExecutionEntity', 'WorkflowEntity', 'InvalidAuthToken']);
+	});
+
+	afterAll(async () => {
+		await testDb.terminate();
+	});
+
+	/** Wait until the manual run is persisted with `finished: true`. */
+	async function waitForExecution(executionId: string, timeout = 10000): Promise<void> {
+		const start = Date.now();
+		while (Date.now() - start < timeout) {
+			const execution = await executionRepository.findOneBy({ id: executionId });
+			if (execution?.finished) return;
+			await new Promise((resolve) => setTimeout(resolve, 100));
+		}
+		throw new Error(`Execution ${executionId} did not complete within ${timeout}ms`);
+	}
+
+	async function getExecutionContext(executionId: string): Promise<IExecutionContext> {
+		const executionWithData = await executionRepository.findSingleExecution(executionId, {
+			includeData: true,
+			unflattenData: true,
+		});
+		if (!executionWithData) {
+			throw new Error(`Execution ${executionId} not found`);
+		}
+		return executionWithData.data.executionData?.runtimeData as IExecutionContext;
+	}
+
+	async function runManually(user: typeof owner, cookie?: string) {
+		const workflow = await createWorkflow(
+			{
+				name: 'Manual Test Workflow',
+				...createSimpleWorkflowFixture(),
+			} as unknown as IWorkflowDb,
+			user,
+		);
+
+		const result = await workflowExecutionService.executeManually(
+			workflow,
+			{ triggerToStartFrom: { name: 'Trigger' } },
+			user,
+			undefined,
+			cookie,
+		);
+
+		if (!('executionId' in result)) {
+			throw new Error(`Expected an executionId, got ${JSON.stringify(result)}`);
+		}
+
+		await waitForExecution(result.executionId);
+		return result.executionId;
+	}
+
+	describe('credential context injection', () => {
+		it('encrypts the running user’s auth cookie into runtimeData.credentials', async () => {
+			const cookie = authService.issueJWT(owner, owner.mfaEnabled, 'browser-1');
+
+			const executionId = await runManually(owner, cookie);
+			const ctx = await getExecutionContext(executionId);
+
+			expect(ctx.source).toBe('manual');
+			expect(typeof ctx.credentials).toBe('string');
+			expect(ctx.credentials).not.toBe(cookie); // never persisted in plaintext
+
+			const decrypted = await cipher.decryptV2(ctx.credentials!);
+			expect(toCredentialContext(decrypted)).toEqual({
+				version: 1,
+				identity: cookie,
+				metadata: { source: 'manual-execution' },
+			});
+
+			// The persisted context itself must still validate against the schema.
+			expect(() => toExecutionContext(ctx as unknown as object)).not.toThrow();
+		});
+
+		it('does not inject credentials when no cookie is passed', async () => {
+			const executionId = await runManually(owner, undefined);
+			const ctx = await getExecutionContext(executionId);
+
+			expect(ctx.source).toBe('manual');
+			expect(ctx.credentials).toBeUndefined();
+		});
+	});
+
+	describe('N8NIdentifier end-to-end resolution', () => {
+		it('resolves a manual-execution context to the running user via real AuthService', async () => {
+			const cookie = authService.issueJWT(owner, owner.mfaEnabled, 'browser-1');
+			const executionId = await runManually(owner, cookie);
+			const ctx = await getExecutionContext(executionId);
+
+			// Decrypt the persisted credential context and feed it into the identifier
+			// exactly as the credential resolver would at runtime.
+			const decrypted = await cipher.decryptV2(ctx.credentials!);
+			const credentialContext = toCredentialContext(decrypted);
+
+			const resolvedUserId = await identifier.resolve(credentialContext, {});
+
+			expect(resolvedUserId).toBe(owner.id);
+		});
+
+		it('routes the right secret to the right user across two members', async () => {
+			const ownerCookie = authService.issueJWT(owner, owner.mfaEnabled, 'browser-owner');
+			const memberCookie = authService.issueJWT(member, member.mfaEnabled, 'browser-member');
+
+			const ownerExecutionId = await runManually(owner, ownerCookie);
+			const memberExecutionId = await runManually(member, memberCookie);
+
+			const ownerCtx = await getExecutionContext(ownerExecutionId);
+			const memberCtx = await getExecutionContext(memberExecutionId);
+
+			const ownerResolved = await identifier.resolve(
+				toCredentialContext(await cipher.decryptV2(ownerCtx.credentials!)),
+				{},
+			);
+			const memberResolved = await identifier.resolve(
+				toCredentialContext(await cipher.decryptV2(memberCtx.credentials!)),
+				{},
+			);
+
+			expect(ownerResolved).toBe(owner.id);
+			expect(memberResolved).toBe(member.id);
+			expect(ownerResolved).not.toBe(memberResolved);
+		});
+
+		it('rejects a blocklisted cookie (logout mid-run scenario)', async () => {
+			const cookie = authService.issueJWT(owner, owner.mfaEnabled, 'browser-1');
+			const executionId = await runManually(owner, cookie);
+			const ctx = await getExecutionContext(executionId);
+
+			// Simulate the user logging out between execution start and resolver invocation.
+			await invalidAuthTokenRepository.insert({
+				token: cookie,
+				expiresAt: Math.floor(Date.now() / 1000) + 60 * 60,
+			});
+
+			const credentialContext = toCredentialContext(await cipher.decryptV2(ctx.credentials!));
+
+			await expect(identifier.resolve(credentialContext, {})).rejects.toThrow('Unauthorized');
+		});
+	});
+});

--- a/packages/cli/test/integration/manual-execution-credential-context.test.ts
+++ b/packages/cli/test/integration/manual-execution-credential-context.test.ts
@@ -195,7 +195,7 @@ describe('Manual execution credential context (integration)', () => {
 			// Simulate the user logging out between execution start and resolver invocation.
 			await invalidAuthTokenRepository.insert({
 				token: cookie,
-				expiresAt: Math.floor(Date.now() / 1000) + 60 * 60,
+				expiresAt: new Date(Date.now() + 60 * 60 * 1000),
 			});
 
 			const credentialContext = toCredentialContext(await cipher.decryptV2(ctx.credentials!));

--- a/packages/cli/test/integration/shared/utils/node-types-data.ts
+++ b/packages/cli/test/integration/shared/utils/node-types-data.ts
@@ -1,4 +1,29 @@
-import type { INodeTypeData } from 'n8n-workflow';
+import { readFileSync } from 'fs';
+import { UnrecognizedNodeTypeError } from 'n8n-core';
+import type { INodeType, INodeTypeData, NodeLoadingDetails } from 'n8n-workflow';
+import path from 'path';
+
+// Resolves to packages/
+const BASE_DIR = path.resolve(__dirname, '../../../../..');
+
+export function loadNodesFromDist(nodeNames: string[]): INodeTypeData {
+	const nodeTypes: INodeTypeData = {};
+	const knownNodes = JSON.parse(
+		readFileSync(path.join(BASE_DIR, 'nodes-base/dist/known/nodes.json'), 'utf-8'),
+	) as Record<string, NodeLoadingDetails>;
+
+	for (const nodeName of nodeNames) {
+		const loadInfo = knownNodes[nodeName.replace('n8n-nodes-base.', '')];
+		if (!loadInfo) {
+			throw new UnrecognizedNodeTypeError('n8n-nodes-base', nodeName);
+		}
+		const nodeDistPath = path.join(BASE_DIR, 'nodes-base', loadInfo.sourcePath);
+		const node = new (require(nodeDistPath)[loadInfo.className])() as INodeType;
+		nodeTypes[nodeName] = { sourcePath: '', type: node };
+	}
+
+	return nodeTypes;
+}
 
 export function mockNodeTypesData(
 	nodeNames: string[],

--- a/packages/core/nodes-testing/node-test-harness.ts
+++ b/packages/core/nodes-testing/node-test-harness.ts
@@ -236,6 +236,7 @@ export class NodeTestHarness {
 			currentNodeParameters: undefined,
 			parentCallbackManager: undefined,
 			ssrfBridge: undefined,
+			encryptedRunnerIdentity: undefined,
 		});
 		additionalData.credentialsHelper = credentialsHelper;
 

--- a/packages/core/src/execution-engine/__tests__/execution-context.service.test.ts
+++ b/packages/core/src/execution-engine/__tests__/execution-context.service.test.ts
@@ -298,6 +298,29 @@ describe('ExecutionContextService', () => {
 		});
 	});
 
+	describe('buildManualExecutionCredentials()', () => {
+		it('should encrypt the credential context with the cookie as identity', async () => {
+			mockCipher.encryptV2.mockResolvedValue('encrypted-credential-blob');
+
+			const result = await service.buildManualExecutionCredentials('n8n-auth-cookie-jwt');
+
+			expect(mockCipher.encryptV2).toHaveBeenCalledWith({
+				version: 1,
+				identity: 'n8n-auth-cookie-jwt',
+				metadata: { source: 'manual-execution' },
+			});
+			expect(result).toBe('encrypted-credential-blob');
+		});
+
+		it('should propagate errors raised by the cipher', async () => {
+			mockCipher.encryptV2.mockRejectedValue(new Error('encryption key missing'));
+
+			await expect(service.buildManualExecutionCredentials('cookie')).rejects.toThrow(
+				'encryption key missing',
+			);
+		});
+	});
+
 	describe('encrypt → decrypt round-trip', () => {
 		it('should preserve secureArtifacts through a full round-trip', async () => {
 			// JSON-stringify on encrypt, identity on decrypt — simulates a symmetric cipher

--- a/packages/core/src/execution-engine/__tests__/execution-context.test.ts
+++ b/packages/core/src/execution-engine/__tests__/execution-context.test.ts
@@ -1,3 +1,4 @@
+import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 import {
 	createEmptyRunExecutionData,
@@ -12,6 +13,7 @@ import {
 } from 'n8n-workflow';
 
 import { establishExecutionContext } from '../execution-context';
+import { ExecutionContextService } from '../execution-context.service';
 
 describe('establishExecutionContext', () => {
 	const mockWorkflow = mock<Workflow>({ id: 'test-workflow-id' });
@@ -1204,6 +1206,130 @@ describe('establishExecutionContext', () => {
 				version: 1,
 				policy: 'all',
 			});
+		});
+	});
+
+	describe('manual execution credential context', () => {
+		let mockExecutionContextService: jest.Mocked<ExecutionContextService>;
+
+		const buildRunDataWithManualTrigger = () =>
+			createRunExecutionData({
+				startData: {},
+				resultData: { runData: {} },
+				executionData: {
+					contextData: {},
+					nodeExecutionStack: [
+						{
+							node: mock<INode>({ name: 'Manual', type: 'n8n-nodes-base.manualTrigger' }),
+							data: { main: [[{ json: {} }]] },
+							source: null,
+						},
+					],
+					metadata: {},
+					waitingExecution: {},
+					waitingExecutionSource: {},
+				},
+			});
+
+		beforeEach(() => {
+			mockExecutionContextService = mock<ExecutionContextService>();
+			mockExecutionContextService.buildManualExecutionCredentials.mockResolvedValue(
+				'encrypted-credential-blob',
+			);
+			// The end of establishExecutionContext calls augmentExecutionContextWithHooks for any
+			// start item that isn't gated by an early return. Stub it to a no-op pass-through so the
+			// tests below only assert the manual-injection branch.
+			mockExecutionContextService.augmentExecutionContextWithHooks.mockImplementation(
+				async (_workflow, _startItem, context) => ({
+					context,
+					triggerItems: null,
+				}),
+			);
+			Container.set(ExecutionContextService, mockExecutionContextService);
+		});
+
+		afterEach(() => {
+			Container.reset();
+		});
+
+		it('should encrypt the n8nAuthCookie into credentials for manual runs', async () => {
+			const runExecutionData = buildRunDataWithManualTrigger();
+			const additionalData = mock<IWorkflowExecuteAdditionalData>({
+				n8nAuthCookie: 'cookie-jwt',
+			});
+
+			await establishExecutionContext(mockWorkflow, runExecutionData, additionalData, 'manual');
+
+			expect(mockExecutionContextService.buildManualExecutionCredentials).toHaveBeenCalledWith(
+				'cookie-jwt',
+			);
+			expect(runExecutionData.executionData!.runtimeData!.credentials).toBe(
+				'encrypted-credential-blob',
+			);
+		});
+
+		it('should NOT inject credentials when n8nAuthCookie is missing', async () => {
+			const runExecutionData = buildRunDataWithManualTrigger();
+			const additionalData = mock<IWorkflowExecuteAdditionalData>({
+				n8nAuthCookie: undefined,
+			});
+
+			await establishExecutionContext(mockWorkflow, runExecutionData, additionalData, 'manual');
+
+			expect(mockExecutionContextService.buildManualExecutionCredentials).not.toHaveBeenCalled();
+			expect(runExecutionData.executionData!.runtimeData!.credentials).toBeUndefined();
+		});
+
+		it('should NOT inject credentials when additionalData is undefined', async () => {
+			const runExecutionData = buildRunDataWithManualTrigger();
+
+			await establishExecutionContext(mockWorkflow, runExecutionData, undefined, 'manual');
+
+			expect(mockExecutionContextService.buildManualExecutionCredentials).not.toHaveBeenCalled();
+			expect(runExecutionData.executionData!.runtimeData!.credentials).toBeUndefined();
+		});
+
+		it('should NOT inject credentials for webhook mode even when cookie is present', async () => {
+			const runExecutionData = buildRunDataWithManualTrigger();
+			const additionalData = mock<IWorkflowExecuteAdditionalData>({
+				n8nAuthCookie: 'cookie-jwt',
+			});
+
+			await establishExecutionContext(mockWorkflow, runExecutionData, additionalData, 'webhook');
+
+			expect(mockExecutionContextService.buildManualExecutionCredentials).not.toHaveBeenCalled();
+			expect(runExecutionData.executionData!.runtimeData!.credentials).toBeUndefined();
+		});
+
+		it('should NOT inject credentials for trigger mode even when cookie is present', async () => {
+			const runExecutionData = buildRunDataWithManualTrigger();
+			const additionalData = mock<IWorkflowExecuteAdditionalData>({
+				n8nAuthCookie: 'cookie-jwt',
+			});
+
+			await establishExecutionContext(mockWorkflow, runExecutionData, additionalData, 'trigger');
+
+			expect(mockExecutionContextService.buildManualExecutionCredentials).not.toHaveBeenCalled();
+			expect(runExecutionData.executionData!.runtimeData!.credentials).toBeUndefined();
+		});
+
+		it('should not overwrite existing runtimeData when it is already established', async () => {
+			const runExecutionData = buildRunDataWithManualTrigger();
+			const existingContext: IExecutionContext = {
+				version: 1,
+				establishedAt: 12345,
+				source: 'manual',
+				credentials: 'pre-existing-credentials',
+			};
+			runExecutionData.executionData!.runtimeData = existingContext;
+			const additionalData = mock<IWorkflowExecuteAdditionalData>({
+				n8nAuthCookie: 'cookie-jwt',
+			});
+
+			await establishExecutionContext(mockWorkflow, runExecutionData, additionalData, 'manual');
+
+			expect(mockExecutionContextService.buildManualExecutionCredentials).not.toHaveBeenCalled();
+			expect(runExecutionData.executionData!.runtimeData).toEqual(existingContext);
 		});
 	});
 });

--- a/packages/core/src/execution-engine/__tests__/execution-context.test.ts
+++ b/packages/core/src/execution-engine/__tests__/execution-context.test.ts
@@ -20,6 +20,7 @@ describe('establishExecutionContext', () => {
 	const mockAdditionalData = mock<IWorkflowExecuteAdditionalData>({
 		webhookWaitingBaseUrl: 'http://localhost:5678/webhook-waiting',
 		formWaitingBaseUrl: 'http://localhost:5678/form-waiting',
+		encryptedRunnerIdentity: undefined,
 	});
 	const mockMode: WorkflowExecuteMode = 'manual';
 
@@ -1233,9 +1234,6 @@ describe('establishExecutionContext', () => {
 
 		beforeEach(() => {
 			mockExecutionContextService = mock<ExecutionContextService>();
-			mockExecutionContextService.buildManualExecutionCredentials.mockResolvedValue(
-				'encrypted-credential-blob',
-			);
 			// The end of establishExecutionContext calls augmentExecutionContextWithHooks for any
 			// start item that isn't gated by an early return. Stub it to a no-op pass-through so the
 			// tests below only assert the manual-injection branch.
@@ -1252,26 +1250,24 @@ describe('establishExecutionContext', () => {
 			Container.reset();
 		});
 
-		it('should encrypt the n8nAuthCookie into credentials for manual runs', async () => {
+		it('should assign the pre-built encryptedRunnerIdentity to credentials for manual runs', async () => {
 			const runExecutionData = buildRunDataWithManualTrigger();
 			const additionalData = mock<IWorkflowExecuteAdditionalData>({
-				n8nAuthCookie: 'cookie-jwt',
+				encryptedRunnerIdentity: 'encrypted-credential-blob',
 			});
 
 			await establishExecutionContext(mockWorkflow, runExecutionData, additionalData, 'manual');
 
-			expect(mockExecutionContextService.buildManualExecutionCredentials).toHaveBeenCalledWith(
-				'cookie-jwt',
-			);
+			expect(mockExecutionContextService.buildManualExecutionCredentials).not.toHaveBeenCalled();
 			expect(runExecutionData.executionData!.runtimeData!.credentials).toBe(
 				'encrypted-credential-blob',
 			);
 		});
 
-		it('should NOT inject credentials when n8nAuthCookie is missing', async () => {
+		it('should NOT inject credentials when encryptedRunnerIdentity is missing', async () => {
 			const runExecutionData = buildRunDataWithManualTrigger();
 			const additionalData = mock<IWorkflowExecuteAdditionalData>({
-				n8nAuthCookie: undefined,
+				encryptedRunnerIdentity: undefined,
 			});
 
 			await establishExecutionContext(mockWorkflow, runExecutionData, additionalData, 'manual');
@@ -1289,10 +1285,10 @@ describe('establishExecutionContext', () => {
 			expect(runExecutionData.executionData!.runtimeData!.credentials).toBeUndefined();
 		});
 
-		it('should NOT inject credentials for webhook mode even when cookie is present', async () => {
+		it('should NOT inject credentials for webhook mode even when ciphertext is present', async () => {
 			const runExecutionData = buildRunDataWithManualTrigger();
 			const additionalData = mock<IWorkflowExecuteAdditionalData>({
-				n8nAuthCookie: 'cookie-jwt',
+				encryptedRunnerIdentity: 'encrypted-credential-blob',
 			});
 
 			await establishExecutionContext(mockWorkflow, runExecutionData, additionalData, 'webhook');
@@ -1301,10 +1297,10 @@ describe('establishExecutionContext', () => {
 			expect(runExecutionData.executionData!.runtimeData!.credentials).toBeUndefined();
 		});
 
-		it('should NOT inject credentials for trigger mode even when cookie is present', async () => {
+		it('should NOT inject credentials for trigger mode even when ciphertext is present', async () => {
 			const runExecutionData = buildRunDataWithManualTrigger();
 			const additionalData = mock<IWorkflowExecuteAdditionalData>({
-				n8nAuthCookie: 'cookie-jwt',
+				encryptedRunnerIdentity: 'encrypted-credential-blob',
 			});
 
 			await establishExecutionContext(mockWorkflow, runExecutionData, additionalData, 'trigger');
@@ -1323,7 +1319,7 @@ describe('establishExecutionContext', () => {
 			};
 			runExecutionData.executionData!.runtimeData = existingContext;
 			const additionalData = mock<IWorkflowExecuteAdditionalData>({
-				n8nAuthCookie: 'cookie-jwt',
+				encryptedRunnerIdentity: 'encrypted-credential-blob',
 			});
 
 			await establishExecutionContext(mockWorkflow, runExecutionData, additionalData, 'manual');

--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -2635,6 +2635,7 @@ describe('WorkflowExecute', () => {
 			additionalData = mock<IWorkflowExecuteAdditionalData>({
 				webhookWaitingBaseUrl: 'http://localhost:5678/webhook-waiting',
 				formWaitingBaseUrl: 'http://localhost:5678/form-waiting',
+				encryptedRunnerIdentity: undefined,
 			});
 			additionalData.hooks = mockHooks;
 			additionalData.currentNodeExecutionIndex = 0;

--- a/packages/core/src/execution-engine/execution-context.service.ts
+++ b/packages/core/src/execution-engine/execution-context.service.ts
@@ -1,6 +1,7 @@
 import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
 import {
+	ICredentialContext,
 	IExecuteData,
 	IExecutionContext,
 	INodeExecutionData,
@@ -36,6 +37,21 @@ export class ExecutionContextService {
 			result.secureArtifacts = toSecureArtifacts(decrypted);
 		}
 		return result;
+	}
+
+	/**
+	 * Builds and encrypts a credential context for a manual editor-triggered execution.
+	 *
+	 * @param n8nAuthCookie - The JWT string extracted from the `n8n-auth` browser cookie.
+	 * @returns Encrypted credential context string for storage in `IExecutionContext.credentials`.
+	 */
+	async buildManualExecutionCredentials(n8nAuthCookie: string): Promise<string> {
+		const payload: ICredentialContext = {
+			version: 1,
+			identity: n8nAuthCookie,
+			metadata: { source: 'manual-execution' },
+		};
+		return await this.cipher.encryptV2(payload);
 	}
 
 	async encryptExecutionContext(context: PlaintextExecutionContext): Promise<IExecutionContext> {

--- a/packages/core/src/execution-engine/execution-context.ts
+++ b/packages/core/src/execution-engine/execution-context.ts
@@ -1,13 +1,8 @@
 import { Logger } from '@n8n/backend-common';
 import { Container } from '@n8n/di';
-import {
-	type IWorkflowExecuteAdditionalData,
-	type WorkflowExecuteMode,
-	type IRunExecutionData,
-	type Workflow,
-} from 'n8n-workflow';
+import { type WorkflowExecuteMode, type IRunExecutionData, type Workflow } from 'n8n-workflow';
 
-import { assertExecutionDataExists } from '@/utils/assertions';
+import { assertExecutionDataExists, type PreExecutionAdditionalData } from '@/utils/assertions';
 
 import { ExecutionContextService } from './execution-context.service';
 
@@ -109,7 +104,7 @@ import { ExecutionContextService } from './execution-context.service';
 export const establishExecutionContext = async (
 	workflow: Workflow,
 	runExecutionData: IRunExecutionData,
-	additionalData: IWorkflowExecuteAdditionalData | undefined,
+	additionalData: PreExecutionAdditionalData | undefined,
 	mode: WorkflowExecuteMode,
 ): Promise<void> => {
 	assertExecutionDataExists(runExecutionData.executionData, workflow, additionalData, mode);
@@ -135,12 +130,8 @@ export const establishExecutionContext = async (
 		},
 	};
 
-	// Manual runs have no live request at credential-resolution time; encrypt the JWT now.
-	const n8nAuthCookie = additionalData?.n8nAuthCookie;
-	if (mode === 'manual' && n8nAuthCookie) {
-		const executionContextService = Container.get(ExecutionContextService);
-		executionData.runtimeData.credentials =
-			await executionContextService.buildManualExecutionCredentials(n8nAuthCookie);
+	if (mode === 'manual' && additionalData?.encryptedRunnerIdentity) {
+		executionData.runtimeData.credentials = additionalData.encryptedRunnerIdentity;
 	}
 
 	if (runExecutionData.parentExecution) {

--- a/packages/core/src/execution-engine/execution-context.ts
+++ b/packages/core/src/execution-engine/execution-context.ts
@@ -135,6 +135,14 @@ export const establishExecutionContext = async (
 		},
 	};
 
+	// Manual runs have no live request at credential-resolution time; encrypt the JWT now.
+	const n8nAuthCookie = additionalData?.n8nAuthCookie;
+	if (mode === 'manual' && n8nAuthCookie) {
+		const executionContextService = Container.get(ExecutionContextService);
+		executionData.runtimeData.credentials =
+			await executionContextService.buildManualExecutionCredentials(n8nAuthCookie);
+	}
+
 	if (runExecutionData.parentExecution) {
 		// Create a new context by inheriting everything from the parent execution context,
 		// except for the establishedAt timestamp which we set to now and the source which we set to the current mode.

--- a/packages/core/src/execution-engine/index.ts
+++ b/packages/core/src/execution-engine/index.ts
@@ -79,6 +79,8 @@ declare module 'n8n-workflow' {
 		 * Contains workflow-level configuration including credential resolver ID.
 		 */
 		workflowSettings?: IWorkflowSettings;
+		/** n8n auth JWT of the user who triggered this manual execution. */
+		n8nAuthCookie?: string;
 	}
 }
 

--- a/packages/core/src/execution-engine/index.ts
+++ b/packages/core/src/execution-engine/index.ts
@@ -79,8 +79,8 @@ declare module 'n8n-workflow' {
 		 * Contains workflow-level configuration including credential resolver ID.
 		 */
 		workflowSettings?: IWorkflowSettings;
-		/** n8n auth JWT of the user who triggered this manual execution. */
-		n8nAuthCookie?: string;
+		/** Encrypted credential context for a manual editor-triggered execution. */
+		encryptedRunnerIdentity?: string;
 	}
 }
 

--- a/packages/core/src/utils/assertions.ts
+++ b/packages/core/src/utils/assertions.ts
@@ -6,10 +6,15 @@ import {
 	type WorkflowExecuteMode,
 } from 'n8n-workflow';
 
+export type PreExecutionAdditionalData = Pick<
+	IWorkflowExecuteAdditionalData,
+	'executionId' | 'encryptedRunnerIdentity'
+>;
+
 export function assertExecutionDataExists(
 	executionData: IRunExecutionData['executionData'],
 	workflow: Workflow,
-	additionalData: IWorkflowExecuteAdditionalData | undefined,
+	additionalData: PreExecutionAdditionalData | undefined,
 	mode: WorkflowExecuteMode,
 ): asserts executionData is NonNullable<IRunExecutionData['executionData']> {
 	if (!executionData) {

--- a/packages/core/test/helpers/index.ts
+++ b/packages/core/test/helpers/index.ts
@@ -64,6 +64,7 @@ export function WorkflowExecuteAdditionalData(
 		// e.g. `if (!this.additionalData.restartExecutionId)`. This would for
 		// example skip running the `workflowExecuteBefore` hook in the tests.
 		restartExecutionId: undefined,
+		encryptedRunnerIdentity: undefined,
 	});
 }
 

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -3142,8 +3142,8 @@ export interface IWorkflowExecutionDataProcess {
 	deduplicationKey?: string;
 	/** W3C trace context extracted from inbound webhook headers. */
 	tracingContext?: { traceparent: string; tracestate?: string };
-	/** n8n auth JWT of the user who triggered this manual execution. */
-	n8nAuthCookie?: string;
+	/** Encrypted credential context for a manual editor-triggered execution. */
+	encryptedRunnerIdentity?: string;
 }
 
 export interface ExecuteWorkflowOptions {

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -3142,6 +3142,8 @@ export interface IWorkflowExecutionDataProcess {
 	deduplicationKey?: string;
 	/** W3C trace context extracted from inbound webhook headers. */
 	tracingContext?: { traceparent: string; tracestate?: string };
+	/** n8n auth JWT of the user who triggered this manual execution. */
+	n8nAuthCookie?: string;
 }
 
 export interface ExecuteWorkflowOptions {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

When a workflow is run manually from the editor, the running user's n8n auth
cookie (JWT) is now encrypted into the execution's `runtimeData.credentials`.
This allows the N8N dynamic credential resolver to identify the running user at
credential-resolution time — even though the original HTTP request is no longer
available when the node executes.

**Before:** The `N8NIdentifier` only supported the `chat-hub-injected` /
`cookie-source` metadata source. Manual editor runs had no credential context,
so private credentials could not be resolved and the execution failed.

**After:** `N8NIdentifier` now handles a `manual-execution` metadata source.
The resolver decrypts the context, validates the JWT (signature, expiry,
blocklist, MFA gate) without request-bound checks (browserId / endpoint), and
resolves the user ID for credential lookup.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-652/

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
