### PR TITLE
fix(editor): Continue manually triggered evaluation runs

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
@@ -326,6 +326,22 @@ describe('useRunWorkflow({ router })', () => {
 			);
 		});
 
+		it('should use the passed-in workflowState when injection is unavailable', async () => {
+			vi.mocked(injectWorkflowState).mockReturnValue(undefined as unknown as WorkflowState);
+
+			const setActiveExecutionId = vi.spyOn(workflowState, 'setActiveExecutionId');
+			const { runWorkflowApi } = useRunWorkflow({ router, workflowState });
+
+			vi.mocked(pushConnectionStore).isConnected = true;
+			vi.mocked(workflowsStore).runWorkflow.mockResolvedValue({
+				executionId: '123',
+				waitingForWebhook: false,
+			});
+
+			await expect(runWorkflowApi({} as IStartRunData)).resolves.not.toThrow();
+			expect(setActiveExecutionId).toHaveBeenCalled();
+		});
+
 		it('should successfully run a workflow', async () => {
 			const setActiveExecutionId = vi.spyOn(workflowState, 'setActiveExecutionId');
 			const { runWorkflowApi } = useRunWorkflow({ router });

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
@@ -55,13 +55,14 @@ import { useCanvasOperations } from './useCanvasOperations';
 import { chatEventBus } from '@n8n/chat/event-buses';
 import { useAgentRequestStore } from '@n8n/stores/useAgentRequestStore';
 import { useWorkflowSaving } from './useWorkflowSaving';
-import { injectWorkflowState } from '@/app/composables/useWorkflowState';
+import { injectWorkflowState, type WorkflowState } from '@/app/composables/useWorkflowState';
 import { useDocumentTitle } from './useDocumentTitle';
 import { useChat } from '@n8n/chat/composables';
 import type { WorkflowObjectAccessors } from '../types';
 
 export function useRunWorkflow(useRunWorkflowOpts: {
 	router: ReturnType<typeof useRouter>;
+	workflowState?: WorkflowState;
 }) {
 	const workflowHelpers = useWorkflowHelpers();
 	const i18n = useI18n();
@@ -75,7 +76,9 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 	const rootStore = useRootStore();
 	const pushConnectionStore = usePushConnectionStore();
 	const workflowsStore = useWorkflowsStore();
-	const workflowState = injectWorkflowState();
+	// `inject()` only resolves inside a setup context; callers from async event
+	// handlers must pass `workflowState` in.
+	const workflowState = useRunWorkflowOpts.workflowState ?? injectWorkflowState();
 
 	const workflowDocumentStore = injectWorkflowDocumentStore();
 


### PR DESCRIPTION
## Summary

When the EvaluationTrigger node is run manually from the canvas (rather than via the "Run evaluation" tab), it should loop through the dataset rows. Currently it executes once and stops.

Root cause: `continueEvaluationLoop` (`executionFinished.ts`) fires from the async push-event handler and calls `useRunWorkflow(opts)`. `useRunWorkflow` then calls `injectWorkflowState()`, but Vue's `inject()` only resolves inside a synchronous setup context, so it returns `undefined`. The eventual `workflowState.setWorkflowExecutionData(...)` call crashes, taking the loop down with it:

```
TypeError: Cannot read properties of undefined (reading 'setWorkflowExecutionData')
    at runWorkflow (useRunWorkflow.ts:406:18)
    at continueEvaluationLoop (executionFinished.ts:199:8)
```

`usePushConnection` already worked around this by capturing `workflowState` eagerly and threading it through `options`, but `useRunWorkflow` was throwing that away and re-injecting.

Fix: `useRunWorkflow` now accepts an optional `workflowState` and prefers it over the inject call. The existing `continueEvaluationLoop` call site already passes `opts` containing the captured state, so no caller change is needed.

### How to test
1. Open or create a workflow with an `EvaluationTrigger` node and a dataset with multiple rows (e.g. `EvaluationTrigger` → `Set`).
2. Click "Execute workflow" on the canvas.
3. Verify every dataset row is processed (the trigger node should re-run for each row), not just the first.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-105

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI