### PR TITLE
ci: Split Instance AI evals to own workflow, fire on approval only (no-changelog)

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -184,11 +184,20 @@ These only run if specific files changed:
 
 ### On PR Review
 
-| Event                      | Workflow                    | Condition                    |
-|----------------------------|-----------------------------|------------------------------|
-| Review approved            | `test-visual-chromatic.yml` | + design files changed       |
-| Comment with `@claude`     | `util-claude.yml`           | mention in any comment       |
-| Any review                 | `util-notify-pr-status.yml` | not community-labeled        |
+| Event                      | Workflow                    | Condition                                            |
+|----------------------------|-----------------------------|------------------------------------------------------|
+| Review approved            | `test-visual-chromatic.yml` | + design files changed                               |
+| Review approved            | `ci-instance-ai-evals.yml`  | + Instance AI source/eval paths changed (see below)  |
+| Comment with `@claude`     | `util-claude.yml`           | mention in any comment                               |
+| Any review                 | `util-notify-pr-status.yml` | not community-labeled                                |
+
+**Why Instance AI evals fire on approval, not push:** the workflow eval is the most
+expensive job in PR CI (LLM-bound builds against ~70 unique scenarios). Running it
+on every push made cost untenable. With approval-only triggering, the eval acts as
+a merge gate — fires when the reviewer approves; if it fails, branch protection blocks
+the merge. `dismiss_stale_reviews_on_push: true` on master forces re-approval (and a
+fresh eval) if the author pushes between approval and merge, so the gate stays honest.
+The lighter `test-evals-discovery.yml` still runs on every push as part of ci-pull-requests.yml.
 
 ### On PR Close/Merge
 

--- a/.github/workflows/ci-instance-ai-evals.yml
+++ b/.github/workflows/ci-instance-ai-evals.yml
@@ -1,15 +1,16 @@
 name: 'CI: Instance AI Evals'
 
 # Triggers separately from ci-pull-requests.yml so build/tests/lint don't
-# re-run on review activity. Eval fires only at approval (gate before
-# merge) and on the merge queue (final check). Bare pushes don't fire it.
+# re-run on review activity. Eval fires only when a reviewer approves —
+# acts as the merge gate. Bare pushes don't fire it; `dismiss_stale_reviews_on_push`
+# on master forces a re-approval (and a fresh eval) if anything changes
+# between approval and merge.
 on:
   pull_request_review:
     types: [submitted]
-  merge_group:
 
 concurrency:
-  group: instance-ai-evals-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
+  group: instance-ai-evals-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -18,18 +19,16 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.repository == 'n8n-io/n8n' &&
-      (github.event_name == 'merge_group' ||
-        (github.event_name == 'pull_request_review' &&
-         github.event.review.state == 'approved' &&
-         !github.event.pull_request.head.repo.fork &&
-         github.event.pull_request.draft == false))
+      github.event.review.state == 'approved' &&
+      !github.event.pull_request.head.repo.fork &&
+      github.event.pull_request.draft == false
     outputs:
       should_run: ${{ steps.ci-filter.outputs.results && fromJSON(steps.ci-filter.outputs.results)['instance-ai-workflow-eval'] == true }}
       commit_sha: ${{ steps.commit-sha.outputs.sha }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || format('refs/pull/{0}/merge', github.event.pull_request.number) }}
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Capture commit SHA for cache consistency
         id: commit-sha

--- a/.github/workflows/ci-instance-ai-evals.yml
+++ b/.github/workflows/ci-instance-ai-evals.yml
@@ -1,0 +1,59 @@
+name: 'CI: Instance AI Evals'
+
+# Triggers separately from ci-pull-requests.yml so build/tests/lint don't
+# re-run on review activity. Eval fires only at approval (gate before
+# merge) and on the merge queue (final check). Bare pushes don't fire it.
+on:
+  pull_request_review:
+    types: [submitted]
+  merge_group:
+
+concurrency:
+  group: instance-ai-evals-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-paths:
+    name: Check Eval Should Run
+    runs-on: ubuntu-latest
+    if: >-
+      github.repository == 'n8n-io/n8n' &&
+      (github.event_name == 'merge_group' ||
+        (github.event_name == 'pull_request_review' &&
+         github.event.review.state == 'approved' &&
+         !github.event.pull_request.head.repo.fork &&
+         github.event.pull_request.draft == false))
+    outputs:
+      should_run: ${{ steps.ci-filter.outputs.results && fromJSON(steps.ci-filter.outputs.results)['instance-ai-workflow-eval'] == true }}
+      commit_sha: ${{ steps.commit-sha.outputs.sha }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || format('refs/pull/{0}/merge', github.event.pull_request.number) }}
+
+      - name: Capture commit SHA for cache consistency
+        id: commit-sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Check for relevant changes
+        id: ci-filter
+        uses: ./.github/actions/ci-filter
+        with:
+          mode: filter
+          filters: |
+            instance-ai-workflow-eval:
+              packages/@n8n/instance-ai/src/**
+              packages/@n8n/instance-ai/evaluations/**
+              packages/cli/src/modules/instance-ai/**
+              packages/core/src/execution-engine/eval-mock-helpers.ts
+              .github/workflows/test-evals-instance-ai*.yml
+              .github/workflows/ci-instance-ai-evals.yml
+
+  run-evals:
+    name: Instance AI Workflow Evals
+    needs: check-paths
+    if: needs.check-paths.outputs.should_run == 'true'
+    uses: ./.github/workflows/test-evals-instance-ai.yml
+    with:
+      branch: ${{ needs.check-paths.outputs.commit_sha }}
+    secrets: inherit

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -293,23 +293,6 @@ jobs:
       ref: ${{ needs.install-and-build.outputs.commit_sha }}
     secrets: inherit
 
-  # Depends on prepare-docker so the eval workflow can load the SHA-keyed image cache.
-  # prepare-docker may be skipped (its filter excludes .github/**); the eval falls back to a local build.
-  instance-ai-workflow-evals:
-    name: Instance AI Workflow Evals
-    needs: [install-and-build, prepare-docker]
-    if: >-
-      !cancelled() &&
-      needs.install-and-build.result == 'success' &&
-      (needs.prepare-docker.result == 'success' || needs.prepare-docker.result == 'skipped') &&
-      needs.install-and-build.outputs.instance_ai_workflow_eval == 'true' &&
-      github.repository == 'n8n-io/n8n' &&
-      (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
-    uses: ./.github/workflows/test-evals-instance-ai.yml
-    with:
-      branch: ${{ needs.install-and-build.outputs.commit_sha }}
-    secrets: inherit
-
   # In-process discovery eval — asserts the orchestrator reaches for browser/computer-use
   # tools at OAuth/screenshot moments. Lightweight (no Docker), runs in parallel with the
   # heavy workflow eval. Non-blocking initially; promote to required after stability.

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -91,7 +91,6 @@ jobs:
               packages/@n8n/instance-ai/evaluations/**
               packages/cli/src/modules/instance-ai/**
               packages/core/src/execution-engine/eval-mock-helpers.ts
-              .github/workflows/test-evals-instance-ai*.yml
               .github/workflows/test-evals-discovery.yml
             db:
               packages/cli/src/databases/**

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -180,14 +180,14 @@ jobs:
               --base-url "$BASE_URLS" \
               --concurrency 32 \
               --verbose \
-              --iterations 5 \
+              --iterations 3 \
               --filter "$FILTER"
           else
             pnpm eval:instance-ai \
               --base-url "$BASE_URLS" \
               --concurrency 32 \
               --verbose \
-              --iterations 5
+              --iterations 3
           fi
 
       # Captures sandbox/builder/Daytona signals that surface during the eval


### PR DESCRIPTION
## Summary

Cuts PR CI eval cost ~90% by restricting the Instance AI workflow eval to fire only on review approval — a pure merge gate — without affecting build/tests/lint, which keep running on every push as today.

### What changes

Three commits:

1. **Reduce iterations 5 → 3** in \`test-evals-instance-ai.yml\`. Per-run cost down ~40%. Trades some pass^k statistical confidence for cost.

2. **Split eval into its own workflow.** New file \`.github/workflows/ci-instance-ai-evals.yml\` triggers on \`pull_request_review: [submitted]\` (filtered to \`state == 'approved'\`, non-draft, non-fork). Removes the \`instance-ai-workflow-evals\` job from \`ci-pull-requests.yml\`. Each workflow has its own \`on:\` trigger surface and concurrency group, so the eval's trigger model doesn't pollute build/tests/lint.

3. **Drop \`merge_group\` trigger, document, clean up.** Eval no longer runs on the merge queue — \`dismiss_stale_reviews_on_push: true\` on master enforces fresh approval (and fresh eval) for any change between approval and merge, so the gate stays honest without re-running on merge_group. Adds an entry in \`.github/WORKFLOWS.md\` under "On PR Review". Trims a redundant path-filter entry in \`ci-pull-requests.yml\`.

### When the eval fires

| Event | Eval fires? | Notes |
|---|---|---|
| PR opened (draft or ready) | ❌ | |
| Author pushes commits | ❌ | build/tests/lint still run via ci-pull-requests.yml as today |
| Reviewer comments / requests changes | ❌ | |
| Draft → ready | ❌ | |
| **Reviewer approves** | ✅ | merge gate; required to pass before merging |
| Author pushes after approval | (dismisses approval) | next re-approval re-fires eval |
| Merge queue | ❌ | not needed — dismiss-stale-on-push gives us a fresh eval before any merge |

### Cost shape

Typical PR lifecycle:
- **Today**: ~10 evals per PR (every push + merge_group) × ~\$110 = **~\$1,000**
- **After this PR**: 1 eval per approval cycle × ~\$66 (N=3) = **~\$66–130**

~90% reduction. No author or reviewer behavior change required.

### Trade-offs

- Reviewers don't see eval results during code review — they see them after approving. If the eval fails, the approval cycle restarts. If anyone needs eval output mid-development, the existing \`workflow_dispatch\` on \`test-evals-instance-ai.yml\` is the escape hatch.
- No merge_group eval means no automatic cross-PR integration check. Low risk for our use case (eval tests agent reasoning on isolated scenarios, not deep code interactions), and \`dismiss_stale_reviews_on_push\` keeps the gate honest if approved PRs go stale.

### How to test

- Open this PR / push / comment → \`Instance AI Workflow Evals\` job should not appear. Other CI (build, tests, lint) runs normally.
- Approve the PR → \`Instance AI Workflow Evals\` job runs with 3 iterations against scenarios that touch instance-ai paths.
- Approval will be dismissed if I push another commit; re-approval will re-fire the eval.

### Architecture note

The new workflow runs the path filter inline against instance-ai paths (small duplication, ~10 lines, intentional). It calls the existing \`test-evals-instance-ai.yml\` reusable workflow unchanged. The reusable's docker-cache load-or-build step handles the case where the cache from the most recent push has expired.

## Related Linear tickets, Github issues, and Community forum posts

None — change driven from conversation.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI