### PR TITLE
feat(core): Fetch templates matching the bundled SDK minor

### DIFF
--- a/packages/@n8n/instance-ai/src/workspace/__tests__/builder-templates-service.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/builder-templates-service.test.ts
@@ -25,7 +25,12 @@ interface MockState {
 	/** Opaque archive bytes — the service treats these as a black box, no extraction. */
 	archive: Buffer;
 	etag: string | null;
+	/** Default status for an archive fetch (used by both channels when not overridden). */
 	archiveStatus?: number;
+	/** Per-channel status override for the `/v<minor>/` URL. */
+	exactStatus?: number;
+	/** Per-channel status override for the `/latest/` URL. */
+	latestStatus?: number;
 	respondNotModified?: boolean;
 	/** When `null`, sidecar returns 404; when a string, that body is served; default = correct sha. */
 	sha256Override?: string | null;
@@ -33,7 +38,21 @@ interface MockState {
 	transientFailuresBeforeSuccess?: number;
 	/** When true, the archive 200 response omits its ETag header. */
 	omitEtagHeader?: boolean;
-	calls: { fetch: number; archiveFetches: number; lastIfNoneMatch: string | null };
+	calls: {
+		fetch: number;
+		archiveFetches: number;
+		exactFetches: number;
+		latestFetches: number;
+		lastIfNoneMatch: string | null;
+	};
+}
+
+function isExactArchiveUrl(url: string): boolean {
+	return /\/v\d+\.\d+\/templates\.tar\.gz$/.test(url);
+}
+
+function isLatestArchiveUrl(url: string): boolean {
+	return url.endsWith('/latest/templates.tar.gz');
 }
 
 function installMockFetch(state: MockState): jest.Mock {
@@ -51,11 +70,15 @@ function installMockFetch(state: MockState): jest.Mock {
 			});
 		}
 
-		if (!url.endsWith('/templates.tar.gz')) {
+		const exact = isExactArchiveUrl(url);
+		const latest = isLatestArchiveUrl(url);
+		if (!exact && !latest) {
 			return new Response('unhandled', { status: 500 });
 		}
 
 		state.calls.archiveFetches++;
+		if (exact) state.calls.exactFetches++;
+		else state.calls.latestFetches++;
 		state.calls.lastIfNoneMatch = headers.get('if-none-match');
 
 		if (state.respondNotModified) {
@@ -67,7 +90,8 @@ function installMockFetch(state: MockState): jest.Mock {
 			return new Response('temporarily unavailable', { status: 503 });
 		}
 
-		const status = state.archiveStatus ?? 200;
+		const channelStatus = exact ? state.exactStatus : state.latestStatus;
+		const status = channelStatus ?? state.archiveStatus ?? 200;
 		if (status >= 400) return new Response('error', { status });
 		const etag = state.omitEtagHeader ? null : state.etag;
 		return archiveResponse(state.archive, etag, status);
@@ -85,7 +109,8 @@ function makeOptions(
 	overrides: Partial<BuilderTemplatesServiceOptions> = {},
 ): BuilderTemplatesServiceOptions {
 	return {
-		cdnBaseUrl: 'https://cdn.example/n8n-sdk-templates/v1',
+		cdnBaseUrl: 'https://cdn.example/n8n-sdk-templates',
+		sdkVersion: '0.15.0',
 		cacheDir,
 		refreshIntervalMs: 60_000,
 		fetchTimeoutMs: 1_000,
@@ -99,7 +124,13 @@ function makeState(): MockState {
 	return {
 		archive: Buffer.from('opaque-archive-bytes-v1'),
 		etag: '"sha-1"',
-		calls: { fetch: 0, archiveFetches: 0, lastIfNoneMatch: null },
+		calls: {
+			fetch: 0,
+			archiveFetches: 0,
+			exactFetches: 0,
+			latestFetches: 0,
+			lastIfNoneMatch: null,
+		},
 	};
 }
 
@@ -192,6 +223,7 @@ describe('BuilderTemplatesService', () => {
 		const archive = Buffer.from('opaque-archive-bytes-pre-existing');
 		await fsp.writeFile(path.join(cacheDir, 'templates.tar.gz'), archive);
 		await fsp.writeFile(path.join(cacheDir, 'etag.txt'), '"pre-existing"');
+		await fsp.writeFile(path.join(cacheDir, 'channel.txt'), 'exact');
 
 		// Block any network call so we know hydration came from disk.
 		globalThis.fetch = jest.fn(
@@ -203,8 +235,8 @@ describe('BuilderTemplatesService', () => {
 
 		expect(bundle.version).toBe('"pre-existing"');
 		expect(bundle.archive?.equals(archive)).toBe(true);
-		// getVersion() strips the quotes for telemetry use; raw etag stays on bundle.version.
-		expect(svc.getVersion()).toBe('pre-existing');
+		// getVersion() prefixes with the channel + strips quotes for telemetry use; raw etag stays on bundle.version.
+		expect(svc.getVersion()).toBe('v0.15:pre-existing');
 	});
 
 	it('keeps the existing bundle when the refresh fetch errors', async () => {
@@ -361,6 +393,7 @@ describe('BuilderTemplatesService', () => {
 		const corruptArchive = Buffer.from('this-is-the-corrupt-archive-on-disk');
 		await fsp.writeFile(path.join(cacheDir, 'templates.tar.gz'), corruptArchive);
 		await fsp.writeFile(path.join(cacheDir, 'etag.txt'), '"stale"');
+		await fsp.writeFile(path.join(cacheDir, 'channel.txt'), 'exact');
 		// Sha that does NOT match the archive on disk
 		await fsp.writeFile(path.join(cacheDir, 'templates.tar.gz.sha256'), 'deadbeef'.repeat(8));
 
@@ -378,6 +411,132 @@ describe('BuilderTemplatesService', () => {
 		expect(state.calls.lastIfNoneMatch).toBeNull();
 	});
 
+	describe('versioned URLs', () => {
+		it('fetches /v<major>.<minor>/templates.tar.gz when SDK version is set', async () => {
+			const cacheDir = await makeTempDir();
+			const state = makeState();
+			const fetchMock = installMockFetch(state);
+
+			const svc = new BuilderTemplatesService(makeOptions(cacheDir, { sdkVersion: '0.15.0' }));
+			const bundle = await svc.getBundle();
+
+			expect(bundle.archive?.equals(state.archive)).toBe(true);
+			expect(fetchMock).toHaveBeenCalledWith(
+				'https://cdn.example/n8n-sdk-templates/v0.15/templates.tar.gz',
+				expect.any(Object),
+			);
+		});
+
+		it('prefixes getVersion with the exact channel (v<major>.<minor>:<etag>)', async () => {
+			const cacheDir = await makeTempDir();
+			const state = makeState();
+			installMockFetch(state);
+
+			const svc = new BuilderTemplatesService(makeOptions(cacheDir, { sdkVersion: '0.15.0' }));
+			await svc.getBundle();
+			expect(svc.getVersion()).toBe('v0.15:sha-1');
+		});
+
+		it('returns an empty bundle when both /v<minor>/ and /latest/ return 404', async () => {
+			const cacheDir = await makeTempDir();
+			const state = makeState();
+			state.exactStatus = 404;
+			state.latestStatus = 404;
+			installMockFetch(state);
+
+			const svc = new BuilderTemplatesService(makeOptions(cacheDir, { sdkVersion: '0.17.0' }));
+			const bundle = await svc.getBundle();
+
+			expect(bundle.archive).toBeNull();
+			expect(bundle.version).toBeNull();
+			expect(state.calls.exactFetches).toBe(1);
+			expect(state.calls.latestFetches).toBe(1);
+		});
+
+		it('does not fall back to /latest/ when the exact channel returns 500 (transport error)', async () => {
+			const cacheDir = await makeTempDir();
+			const state = makeState();
+			state.exactStatus = 500;
+			installMockFetch(state);
+
+			const svc = new BuilderTemplatesService(
+				makeOptions(cacheDir, { sdkVersion: '0.15.0', maxAttempts: 1 }),
+			);
+			const bundle = await svc.getBundle();
+
+			expect(bundle.archive).toBeNull();
+			expect(state.calls.latestFetches).toBe(0);
+		});
+
+		it('drops legacy disk cache when channel.txt is missing and refetches fresh', async () => {
+			const cacheDir = await makeTempDir();
+			await fsp.mkdir(cacheDir, { recursive: true });
+			const legacyArchive = Buffer.from('opaque-archive-legacy');
+			await fsp.writeFile(path.join(cacheDir, 'templates.tar.gz'), legacyArchive);
+			await fsp.writeFile(path.join(cacheDir, 'etag.txt'), '"legacy-etag"');
+			await fsp.writeFile(path.join(cacheDir, 'templates.tar.gz.sha256'), sha256Hex(legacyArchive));
+			// Note: no channel.txt — represents a pre-versioned cache layout.
+
+			const state = makeState();
+			installMockFetch(state);
+
+			const svc = new BuilderTemplatesService(makeOptions(cacheDir, { sdkVersion: '0.15.0' }));
+			const bundle = await svc.getBundle();
+
+			// Came from the network, not the legacy disk archive.
+			expect(bundle.archive?.equals(state.archive)).toBe(true);
+			expect(svc.getVersion()).toBe('v0.15:sha-1');
+			expect(state.calls.lastIfNoneMatch).toBeNull();
+
+			const channelOnDisk = await fsp.readFile(path.join(cacheDir, 'channel.txt'), 'utf-8');
+			expect(channelOnDisk).toBe('exact');
+		});
+
+		it('honours channel.txt on warm restart so getVersion keeps the latest: prefix', async () => {
+			const cacheDir = await makeTempDir();
+			await fsp.mkdir(cacheDir, { recursive: true });
+			const archive = Buffer.from('opaque-archive-bytes-from-latest');
+			await fsp.writeFile(path.join(cacheDir, 'templates.tar.gz'), archive);
+			await fsp.writeFile(path.join(cacheDir, 'etag.txt'), '"latest-etag"');
+			await fsp.writeFile(path.join(cacheDir, 'templates.tar.gz.sha256'), sha256Hex(archive));
+			await fsp.writeFile(path.join(cacheDir, 'channel.txt'), 'latest');
+
+			globalThis.fetch = jest.fn(
+				() => new Response('', { status: 500 }),
+			) as unknown as typeof globalThis.fetch;
+
+			const svc = new BuilderTemplatesService(
+				makeOptions(cacheDir, { sdkVersion: '0.17.0', refreshIntervalMs: 60_000 }),
+			);
+			const bundle = await svc.getBundle();
+
+			expect(bundle.archive?.equals(archive)).toBe(true);
+			expect(svc.getVersion()).toBe('latest:latest-etag');
+		});
+
+		it('falls back to /latest/ when /v<minor>/ returns 404', async () => {
+			const cacheDir = await makeTempDir();
+			const state = makeState();
+			state.exactStatus = 404;
+			const logger = { warn: jest.fn(), info: jest.fn(), error: jest.fn(), debug: jest.fn() };
+			installMockFetch(state);
+
+			const svc = new BuilderTemplatesService(
+				makeOptions(cacheDir, { sdkVersion: '0.17.0', logger }),
+			);
+			const bundle = await svc.getBundle();
+
+			expect(bundle.archive?.equals(state.archive)).toBe(true);
+			expect(svc.getVersion()).toBe('latest:sha-1');
+			expect(state.calls.exactFetches).toBeGreaterThan(0);
+			expect(state.calls.latestFetches).toBeGreaterThan(0);
+			expect(logger.warn).toHaveBeenCalledWith(
+				expect.stringContaining('falling back to /latest/'),
+				expect.any(Object),
+			);
+		});
+	});
+
 	it('getVersion strips the W/ prefix and surrounding quotes for telemetry', async () => {
 		const cacheDir = await makeTempDir();
 		const state = makeState();
@@ -386,7 +545,7 @@ describe('BuilderTemplatesService', () => {
 
 		const svc = new BuilderTemplatesService(makeOptions(cacheDir));
 		await svc.getBundle();
-		expect(svc.getVersion()).toBe('abc-123');
+		expect(svc.getVersion()).toBe('v0.15:abc-123');
 	});
 });
 

--- a/packages/@n8n/instance-ai/src/workspace/builder-templates-service.ts
+++ b/packages/@n8n/instance-ai/src/workspace/builder-templates-service.ts
@@ -31,6 +31,7 @@
  *
  * Never throws.
  */
+import workflowSdkPackage from '@n8n/workflow-sdk/package.json';
 import { createHash } from 'node:crypto';
 import * as fsp from 'node:fs/promises';
 import * as os from 'node:os';
@@ -38,7 +39,8 @@ import * as path from 'node:path';
 
 import type { Logger } from '../logger';
 
-const DEFAULT_CDN_BASE_URL = 'https://sdk-templates.n8n.io/v1';
+const DEFAULT_CDN_BASE_URL = 'https://sdk-templates.n8n.io';
+const WORKFLOW_SDK_VERSION = (workflowSdkPackage as { version: string }).version;
 const DEFAULT_REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_ATTEMPTS = 3;
@@ -48,10 +50,20 @@ const DEFAULT_CACHE_SUBDIR = 'n8n-sdk-templates';
 const ARCHIVE_FILENAME = 'templates.tar.gz';
 const ETAG_FILENAME = 'etag.txt';
 const SHA256_FILENAME = 'templates.tar.gz.sha256';
+const CHANNEL_FILENAME = 'channel.txt';
 
 export interface BuilderTemplatesServiceOptions {
-	/** Base URL hosting `templates.tar.gz` and `templates.tar.gz.sha256`. */
+	/**
+	 * CDN root. The service appends a channel prefix:
+	 *   - `<base>/v<major>.<minor>/templates.tar.gz` (matched to `sdkVersion`)
+	 *   - `<base>/latest/templates.tar.gz` (404-fallback)
+	 */
 	cdnBaseUrl?: string;
+	/**
+	 * SDK version the instance is running, used to build `/v<major>.<minor>/`.
+	 * Defaults to the version of `@n8n/workflow-sdk` resolved at module load.
+	 */
+	sdkVersion?: string;
 	/** Directory where the service persists the archive + ETag + sha sidecar between runs. */
 	cacheDir?: string;
 	/** Time-to-live before a refresh fires in the background. Default 24h. */
@@ -77,11 +89,15 @@ export interface BuilderTemplatesBundle {
 
 const EMPTY_BUNDLE: BuilderTemplatesBundle = { archive: null, version: null };
 
+type Channel = 'exact' | 'latest';
+
 interface CacheState {
 	bundle: BuilderTemplatesBundle;
 	lastFetched: number;
 	/** sha256 hex of the archive currently in `bundle`, when known. */
 	sha256: string | null;
+	/** Which CDN folder the cached bundle came from. */
+	channel: Channel;
 }
 
 interface FetchedBundle {
@@ -90,8 +106,9 @@ interface FetchedBundle {
 }
 
 export class BuilderTemplatesService {
-	private readonly archiveUrl: string;
-	private readonly sha256Url: string;
+	private readonly cdnBase: string;
+	private readonly versionPrefix: string;
+	private readonly sdkVersion: string;
 	private readonly cacheDir: string;
 	private readonly refreshIntervalMs: number;
 	private readonly fetchTimeoutMs: number;
@@ -105,9 +122,9 @@ export class BuilderTemplatesService {
 	private backgroundRefresh: Promise<void> | null = null;
 
 	constructor(opts: BuilderTemplatesServiceOptions = {}) {
-		const base = (opts.cdnBaseUrl ?? DEFAULT_CDN_BASE_URL).replace(/\/+$/, '');
-		this.archiveUrl = `${base}/${ARCHIVE_FILENAME}`;
-		this.sha256Url = `${base}/${SHA256_FILENAME}`;
+		this.cdnBase = (opts.cdnBaseUrl ?? DEFAULT_CDN_BASE_URL).replace(/\/+$/, '');
+		this.sdkVersion = opts.sdkVersion ?? WORKFLOW_SDK_VERSION;
+		this.versionPrefix = sdkVersionToPrefix(this.sdkVersion);
 		this.cacheDir = opts.cacheDir ?? path.join(os.homedir(), '.n8n', DEFAULT_CACHE_SUBDIR);
 		this.refreshIntervalMs = opts.refreshIntervalMs ?? DEFAULT_REFRESH_INTERVAL_MS;
 		this.fetchTimeoutMs = opts.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS;
@@ -115,6 +132,18 @@ export class BuilderTemplatesService {
 		this.retryBackoffBaseMs = opts.retryBackoffBaseMs ?? DEFAULT_RETRY_BACKOFF_BASE_MS;
 		this.disabled = opts.disabled ?? false;
 		this.logger = opts.logger;
+	}
+
+	private channelPrefix(channel: Channel): string {
+		return channel === 'exact' ? this.versionPrefix : 'latest';
+	}
+
+	private archiveUrlFor(channel: Channel): string {
+		return `${this.cdnBase}/${this.channelPrefix(channel)}/${ARCHIVE_FILENAME}`;
+	}
+
+	private sha256UrlFor(channel: Channel): string {
+		return `${this.cdnBase}/${this.channelPrefix(channel)}/${SHA256_FILENAME}`;
 	}
 
 	/** Return the memoised bundle, hydrating from disk or network on first call. */
@@ -145,9 +174,11 @@ export class BuilderTemplatesService {
 	 * exact token.
 	 */
 	getVersion(): string | null {
-		const raw = this.state?.bundle.version ?? null;
-		if (!raw) return null;
-		return raw.replace(/^W\//, '').replace(/^"|"$/g, '');
+		const state = this.state;
+		const raw = state?.bundle.version ?? null;
+		if (!raw || !state) return null;
+		const normalised = raw.replace(/^W\//, '').replace(/^"|"$/g, '');
+		return `${this.channelPrefix(state.channel)}:${normalised}`;
 	}
 
 	private async hydrate(): Promise<void> {
@@ -180,11 +211,24 @@ export class BuilderTemplatesService {
 				return null;
 			}
 
+			const channel = await this.readChannelFromDisk();
+			if (!channel) {
+				// Pre-versioned cache layout (no channel.txt). We can't tell which
+				// CDN folder this archive came from, so its etag is unsafe to echo
+				// back in If-None-Match. Drop the cache and let the next refresh
+				// repopulate from scratch.
+				this.logger?.debug(
+					'[builder-templates] disk cache missing channel.txt, treating as legacy and refetching',
+				);
+				return null;
+			}
+
 			const etag = await this.readEtagFromDisk();
 			return {
 				bundle: { archive: buffer, version: etag },
 				lastFetched: stat.mtimeMs,
 				sha256: actualSha,
+				channel,
 			};
 		} catch (error) {
 			if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
@@ -214,55 +258,97 @@ export class BuilderTemplatesService {
 		}
 	}
 
+	private async readChannelFromDisk(): Promise<Channel | null> {
+		try {
+			const raw = (await fsp.readFile(path.join(this.cacheDir, CHANNEL_FILENAME), 'utf-8')).trim();
+			if (raw === 'exact' || raw === 'latest') return raw;
+			return null;
+		} catch {
+			return null;
+		}
+	}
+
 	private async refresh({ isInitial }: { isInitial: boolean }): Promise<void> {
 		try {
 			const maxAttempts = isInitial ? this.maxAttempts : 1;
-			const fetched = await this.fetchBundleWithRetries(maxAttempts);
-			if (!fetched) return;
 
-			await this.persist(fetched.bundle.archive, fetched.bundle.version, fetched.sha256);
+			let outcome = await this.fetchBundleWithRetries('exact', maxAttempts);
+			let channel: Channel = 'exact';
+
+			if (outcome.kind === 'not-found') {
+				this.logger?.warn(
+					'[builder-templates] no archive at /v<minor>/, falling back to /latest/',
+					{ sdkVersion: this.sdkVersion },
+				);
+				outcome = await this.fetchBundleWithRetries('latest', maxAttempts);
+				channel = 'latest';
+			}
+
+			if (outcome.kind !== 'fetched') return;
+
+			await this.persist(
+				outcome.bundle.bundle.archive,
+				outcome.bundle.bundle.version,
+				outcome.bundle.sha256,
+				channel,
+			);
 			this.state = {
-				bundle: fetched.bundle,
+				bundle: outcome.bundle.bundle,
 				lastFetched: Date.now(),
-				sha256: fetched.sha256,
+				sha256: outcome.bundle.sha256,
+				channel,
 			};
 		} catch (error) {
 			this.logger?.warn('[builder-templates] refresh failed', {
 				error: error instanceof Error ? error.message : String(error),
-				url: this.archiveUrl,
 			});
 		}
 	}
 
-	private async fetchBundleWithRetries(maxAttempts: number): Promise<FetchedBundle | null> {
+	private async fetchBundleWithRetries(
+		channel: Channel,
+		maxAttempts: number,
+	): Promise<
+		| { kind: 'fetched'; bundle: FetchedBundle }
+		| { kind: 'not-modified' }
+		| { kind: 'not-found' }
+		| { kind: 'failed' }
+	> {
 		for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-			const outcome = await this.tryFetchBundleOnce();
-			if (outcome.kind === 'fetched') return outcome.bundle;
-			if (outcome.kind === 'not-modified') return null;
-			if (!outcome.retryable || attempt === maxAttempts) return null;
+			const outcome = await this.tryFetchBundleOnce(channel);
+			if (outcome.kind === 'fetched') return outcome;
+			if (outcome.kind === 'not-modified') return outcome;
+			if (outcome.kind === 'not-found') return outcome;
+			if (!outcome.retryable || attempt === maxAttempts) return { kind: 'failed' };
 
 			const delay = Math.min(this.retryBackoffBaseMs * 2 ** (attempt - 1), RETRY_BACKOFF_CAP_MS);
 			await sleep(delay);
 		}
-		return null;
+		return { kind: 'failed' };
 	}
 
-	private async tryFetchBundleOnce(): Promise<
+	private async tryFetchBundleOnce(
+		channel: Channel,
+	): Promise<
 		| { kind: 'fetched'; bundle: FetchedBundle }
 		| { kind: 'not-modified' }
+		| { kind: 'not-found' }
 		| { kind: 'failed'; retryable: boolean }
 	> {
+		const archiveUrl = this.archiveUrlFor(channel);
+
 		// Only send a conditional request when we already have a bundle in
-		// memory to fall back to. Sending If-None-Match with an orphan etag
-		// (e.g. archive missing/corrupt but etag.txt present) could return 304
-		// and leave the service permanently empty for this process.
+		// memory from the SAME channel — etags from /v<minor>/ don't match
+		// /latest/ even when the file is byte-identical, since R2 hashes per
+		// path. Sending If-None-Match with an orphan etag would also risk a
+		// stale 304 that leaves the service empty for the process.
 		const headers: Record<string, string> = {};
-		const cachedEtag = this.state?.bundle.version ?? null;
+		const cachedEtag = this.state?.channel === channel ? (this.state.bundle.version ?? null) : null;
 		if (cachedEtag) headers['If-None-Match'] = cachedEtag;
 
 		let response: Response;
 		try {
-			response = await fetch(this.archiveUrl, {
+			response = await fetch(archiveUrl, {
 				headers,
 				signal: AbortSignal.timeout(this.fetchTimeoutMs),
 			});
@@ -270,34 +356,40 @@ export class BuilderTemplatesService {
 			// Network / abort errors — assume transient.
 			this.logger?.warn('[builder-templates] archive fetch threw', {
 				error: error instanceof Error ? error.message : String(error),
-				url: this.archiveUrl,
+				url: archiveUrl,
 			});
 			return { kind: 'failed', retryable: true };
 		}
 
-		if (response.status === 304 && this.state) {
+		if (response.status === 304 && this.state?.channel === channel) {
 			await touchArchiveFile(path.join(this.cacheDir, ARCHIVE_FILENAME));
 			this.state = { ...this.state, lastFetched: Date.now() };
 			return { kind: 'not-modified' };
 		}
 
+		if (response.status === 404) {
+			// 404 is the unique trigger for fallback — the folder simply isn't
+			// published. Other non-OK statuses are transport-level failures.
+			return { kind: 'not-found' };
+		}
+
 		if (!response.ok) {
 			this.logger?.warn('[builder-templates] archive fetch returned non-OK', {
 				status: response.status,
-				url: this.archiveUrl,
+				url: archiveUrl,
 			});
 			return { kind: 'failed', retryable: isRetryableStatus(response.status) };
 		}
 
 		const buffer = Buffer.from(await response.arrayBuffer());
 		const actualSha = sha256Hex(buffer);
-		const expectedSha = await this.fetchSha256Sidecar();
+		const expectedSha = await this.fetchSha256Sidecar(channel);
 
 		if (expectedSha && expectedSha !== actualSha) {
 			this.logger?.warn('[builder-templates] sha256 mismatch on downloaded archive, rejecting', {
 				expected: expectedSha,
 				actual: actualSha,
-				url: this.archiveUrl,
+				url: archiveUrl,
 			});
 			// Treat as a hard failure that isn't worth retrying — the sidecar
 			// and archive come from the same origin, so a retry will almost
@@ -315,22 +407,23 @@ export class BuilderTemplatesService {
 		};
 	}
 
-	private async fetchSha256Sidecar(): Promise<string | null> {
+	private async fetchSha256Sidecar(channel: Channel): Promise<string | null> {
+		const sha256Url = this.sha256UrlFor(channel);
 		try {
-			const response = await fetch(this.sha256Url, {
+			const response = await fetch(sha256Url, {
 				signal: AbortSignal.timeout(this.fetchTimeoutMs),
 			});
 			if (response.status === 404) {
 				this.logger?.warn(
 					'[builder-templates] sha256 sidecar missing — proceeding without integrity check',
-					{ url: this.sha256Url },
+					{ url: sha256Url },
 				);
 				return null;
 			}
 			if (!response.ok) {
 				this.logger?.warn(
 					'[builder-templates] sha256 sidecar fetch returned non-OK — proceeding without integrity check',
-					{ status: response.status, url: this.sha256Url },
+					{ status: response.status, url: sha256Url },
 				);
 				return null;
 			}
@@ -340,7 +433,7 @@ export class BuilderTemplatesService {
 				'[builder-templates] sha256 sidecar fetch threw — proceeding without integrity check',
 				{
 					error: error instanceof Error ? error.message : String(error),
-					url: this.sha256Url,
+					url: sha256Url,
 				},
 			);
 			return null;
@@ -351,6 +444,7 @@ export class BuilderTemplatesService {
 		buffer: Buffer | null,
 		etag: string | null,
 		sha256: string | null,
+		channel: Channel,
 	): Promise<void> {
 		if (!buffer) return;
 		await fsp.mkdir(this.cacheDir, { recursive: true });
@@ -368,8 +462,20 @@ export class BuilderTemplatesService {
 		} else {
 			await unlinkIfExists(path.join(this.cacheDir, SHA256_FILENAME));
 		}
+		await atomicWriteFile(path.join(this.cacheDir, CHANNEL_FILENAME), channel);
 		await atomicWriteFile(path.join(this.cacheDir, ARCHIVE_FILENAME), buffer);
 	}
+}
+
+/**
+ * Turn an SDK version like `0.15.0` (or `0.15.0-beta.3`) into the `v0.15`
+ * channel prefix used in the CDN URL. Falls back to `latest` if the version
+ * can't be parsed — defensive against unexpected pkg.json shapes at boot.
+ */
+function sdkVersionToPrefix(sdkVersion: string): string {
+	const match = sdkVersion.match(/^(\d+)\.(\d+)/);
+	if (!match) return 'latest';
+	return `v${match[1]}.${match[2]}`;
 }
 
 function normaliseEtag(raw: string | null): string | null {

--- a/packages/@n8n/instance-ai/src/workspace/builder-templates-service.ts
+++ b/packages/@n8n/instance-ai/src/workspace/builder-templates-service.ts
@@ -8,6 +8,18 @@
  *   - `index.txt`        — pipe-delimited catalog used for grep-style lookup
  *   - `<slug>.ts`        — one pre-rendered SDK file per publishable template
  *
+ * Versioning:
+ *   - The companion repo emits one archive per supported SDK minor and
+ *     uploads it to `/v<major>.<minor>/templates.tar.gz`. The newest minor
+ *     is mirrored to `/latest/templates.tar.gz`.
+ *   - The instance derives its CDN path from the bundled `@n8n/workflow-sdk`
+ *     version and prefers that exact path. On 404 (no archive published for
+ *     this minor yet) the service falls back to `/latest/`. Other transport
+ *     failures keep the existing cached bundle and do not trigger fallback.
+ *   - The current channel (`exact` or `latest`) is persisted on disk so warm
+ *     restarts pick the same URL on refresh and the cached ETag is only
+ *     echoed back to its originating path.
+ *
  * Behaviour:
  *   - First call: read disk cache if present; otherwise do a blocking fetch
  *     with a hard timeout. On any fetch error, return an empty bundle.
@@ -26,8 +38,9 @@
  *     against transport corruption and accidental CDN inconsistency — not
  *     against tampering, since the sidecar shares the archive's trust root.
  *
- * The HTTP ETag doubles as the bundle version — surfaced via telemetry so we
- * can correlate template-set revisions with usage events.
+ * The HTTP ETag is exposed via `getVersion()` prefixed with the channel
+ * (`v0.15:<etag>` or `latest:<etag>`) so telemetry can track template-set
+ * revisions and fallback rate.
  *
  * Never throws.
  */


### PR DESCRIPTION
## Summary

Makes `BuilderTemplatesService` SDK-aware so each instance pulls a template archive that was emitted against its own bundled `@n8n/workflow-sdk` minor.

- URL now derived from `@n8n/workflow-sdk/package.json`: `https://sdk-templates.n8n.io/v<major>.<minor>/templates.tar.gz`.
- On 404 (companion repo hasn't published this minor yet), falls back to `https://sdk-templates.n8n.io/latest/templates.tar.gz`. Logs a warning. Other transport failures keep the existing cached bundle and do NOT trigger fallback — fallback is a "version not published" signal, not a "CDN is down" signal.
- `getVersion()` is now channel-prefixed: `v0.15:<etag>` vs `latest:<etag>` so Posthog can monitor fallback rate.
- Channel is persisted on disk as `channel.txt`. Warm restarts pick the same URL on refresh, and the cached ETag is only sent in `If-None-Match` when hitting its originating path.
- Legacy caches (archive present, no `channel.txt`) are dropped and refetched — their etag is unsafe to echo because we can't tell which CDN path it came from.

## Why

Companion repo PR https://github.com/n8n-io/n8n-sdk-templates/pull/8 (merged) publishes a `/v<minor>/templates.tar.gz` for each of the latest 5 SDK minors on npm + a `/latest/` mirror. Without this PR, instances pulling that CDN don't pick a versioned archive — they'd 404 on the old `/v1/` path or get a random minor. After this PR, each instance gets templates emitted against the SDK it actually runs, with a safe forward-fallback on `/latest/`.

## Test plan

- [x] `pnpm jest builder-templates-service` — 28/28 tests pass (21 existing + 7 new: exact 200, version prefix, both 404 empty, exact-500 no fallback, exact-404 → latest, legacy cache drop, warm-restart channel persistence).
- [x] `pnpm jest` (full `@n8n/instance-ai` suite) — 2029 / 2029.
- [x] `pnpm jest instance-ai` in `packages/cli` — 669 / 669.
- [x] `pnpm typecheck` clean in `@n8n/instance-ai`.
- [x] `pnpm lint` clean in `@n8n/instance-ai`.
- [ ] Smoke test against the live `https://sdk-templates.n8n.io` deployment with a dev instance — verify cold start populates from `/v<minor>/` and `templates_version` shows up in Posthog with the channel prefix.

## Rollout

Stacked on top of #30537 (`move-templates-impl`). The companion-side PR is merged and the CDN now serves `/v0.11/.../v0.15/` and `/latest/`. No flag, no migration step — the previous behavior never shipped to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)