### PR TITLE
refactor(editor): Migrate workflowsStore.workflowId usages in stores

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/WorkflowProductionChecklist.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowProductionChecklist.test.ts
@@ -57,6 +57,16 @@ vi.mock('@/app/composables/useTelemetry', () => ({
 
 vi.mock('@/features/ai/mcpAccess/composables/useMcp', () => ({}));
 
+const mockEvaluationSetOutputsNodeExist = ref(false);
+vi.mock('@/features/ai/evaluation.ee/composables/useWorkflowEvaluationState', () => ({
+	useWorkflowEvaluationState: () => ({
+		evaluationTriggerExists: ref(false),
+		evaluationSetMetricsNodeExist: ref(false),
+		evaluationSetOutputsNodeExist: mockEvaluationSetOutputsNodeExist,
+		metricSourceByKey: ref({}),
+	}),
+}));
+
 vi.mock('@n8n/i18n', async (importOriginal) => {
 	const actual = await importOriginal<typeof import('@n8n/i18n')>();
 	return {
@@ -193,6 +203,7 @@ describe('WorkflowProductionChecklist', () => {
 		vi.clearAllMocks();
 		mockN8nSuggestedActionsProps = {};
 		mockN8nSuggestedActionsEmits = {};
+		mockEvaluationSetOutputsNodeExist.value = false;
 	});
 
 	describe('Action visibility', () => {
@@ -225,7 +236,7 @@ describe('WorkflowProductionChecklist', () => {
 			nodeTypesStore = useNodeTypesStore(pinia);
 
 			vi.spyOn(evaluationStore, 'isEvaluationEnabled', 'get').mockReturnValue(true);
-			vi.spyOn(evaluationStore, 'evaluationSetOutputsNodeExist', 'get').mockReturnValue(false);
+			mockEvaluationSetOutputsNodeExist.value = false;
 			// @ts-expect-error - mocking readonly property
 			nodeTypesStore.getNodeType = vi.fn().mockReturnValue(mockAINodeType as INodeTypeDescription);
 
@@ -655,7 +666,7 @@ describe('WorkflowProductionChecklist', () => {
 			nodeTypesStore = useNodeTypesStore(pinia);
 
 			vi.spyOn(evaluationStore, 'isEvaluationEnabled', 'get').mockReturnValue(true);
-			vi.spyOn(evaluationStore, 'evaluationSetOutputsNodeExist', 'get').mockReturnValue(true);
+			mockEvaluationSetOutputsNodeExist.value = true;
 			// @ts-expect-error - mocking readonly property
 			nodeTypesStore.getNodeType = vi.fn().mockReturnValue(mockAINodeType as INodeTypeDescription);
 

--- a/packages/frontend/editor-ui/src/app/components/WorkflowProductionChecklist.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowProductionChecklist.vue
@@ -27,10 +27,12 @@ import { N8nSuggestedActions } from '@n8n/design-system';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
+import { useWorkflowEvaluationState } from '@/features/ai/evaluation.ee/composables/useWorkflowEvaluationState';
 
 const i18n = useI18n();
 const router = useRouter();
 const evaluationStore = useEvaluationStore();
+const evaluationState = useWorkflowEvaluationState();
 const nodeTypesStore = useNodeTypesStore();
 const workflowsCache = useWorkflowSettingsCache();
 const uiStore = useUIStore();
@@ -53,7 +55,7 @@ const hasAINode = computed(() => {
 });
 
 const hasEvaluationSetOutputsNode = computed((): boolean => {
-	return evaluationStore.evaluationSetOutputsNodeExist;
+	return evaluationState.evaluationSetOutputsNodeExist.value;
 });
 
 const hasErrorWorkflow = computed(() => {

--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
@@ -810,6 +810,7 @@ onMounted(async () => {
 			closeDialog();
 			// Open node creator for regular nodes
 			nodeCreatorStore.openNodeCreatorForRegularNodes(
+				workflowDocumentStore.value.workflowId,
 				NODE_CREATOR_OPEN_SOURCES.NODE_CONNECTION_ACTION,
 			);
 		},

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -452,7 +452,8 @@ describe('useCanvasOperations', () => {
 			const node = createTestNode({ id: '0' });
 			const nodeTypeDescription = mockNodeTypeDescription();
 
-			vi.spyOn(uiStore, 'lastInteractedWithNode', 'get').mockReturnValue(node);
+			uiStore.lastInteractedWithNodeId = node.id;
+			vi.spyOn(workflowDocumentStoreInstance, 'getNodeById').mockReturnValue(node as INodeUi);
 			nodeTypesStore.getNodeType = vi.fn().mockReturnValue(nodeTypeDescription);
 
 			uiStore.lastInteractedWithNodeHandle = 'inputs/main/0';
@@ -477,7 +478,10 @@ describe('useCanvasOperations', () => {
 				type: 'test',
 				typeVersion: 1,
 			});
-			uiStore.lastInteractedWithNode = lastInteracted;
+			uiStore.lastInteractedWithNodeId = lastInteracted.id;
+			vi.spyOn(workflowDocumentStoreInstance, 'getNodeById').mockReturnValue(
+				lastInteracted as INodeUi,
+			);
 			nodeTypesStore.getNodeType = vi.fn().mockReturnValue(nodeTypeDescription);
 			vi.spyOn(workflowDocumentStoreInstance, 'getNodeByName').mockReturnValue(
 				lastInteracted as INodeUi,
@@ -501,7 +505,10 @@ describe('useCanvasOperations', () => {
 				type: 'test',
 				typeVersion: 1,
 			});
-			uiStore.lastInteractedWithNode = lastInteracted;
+			uiStore.lastInteractedWithNodeId = lastInteracted.id;
+			vi.spyOn(workflowDocumentStoreInstance, 'getNodeById').mockReturnValue(
+				lastInteracted as INodeUi,
+			);
 			nodeTypesStore.getNodeType = vi.fn().mockReturnValue(nodeTypeDescription);
 			vi.spyOn(workflowDocumentStoreInstance, 'getNodeByName').mockReturnValue(
 				lastInteracted as INodeUi,
@@ -558,7 +565,10 @@ describe('useCanvasOperations', () => {
 				type: 'test',
 				typeVersion: 1,
 			});
-			uiStore.lastInteractedWithNode = lastInteracted;
+			uiStore.lastInteractedWithNodeId = lastInteracted.id;
+			vi.spyOn(workflowDocumentStoreInstance, 'getNodeById').mockReturnValue(
+				lastInteracted as INodeUi,
+			);
 			uiStore.lastInteractedWithNodeHandle = `outputs/${NodeConnectionTypes.AiLanguageModel}/0`;
 			nodeTypesStore.getNodeType = vi.fn().mockReturnValue(nodeTypeDescription);
 			vi.spyOn(workflowDocumentStoreInstance, 'getNodeByName').mockReturnValue(
@@ -594,7 +604,10 @@ describe('useCanvasOperations', () => {
 				type: 'test',
 				typeVersion: 1,
 			});
-			uiStore.lastInteractedWithNode = lastInteracted;
+			uiStore.lastInteractedWithNodeId = lastInteracted.id;
+			vi.spyOn(workflowDocumentStoreInstance, 'getNodeById').mockReturnValue(
+				lastInteracted as INodeUi,
+			);
 			uiStore.lastInteractedWithNodeHandle = `outputs/${NodeConnectionTypes.AiMemory}/0`;
 			nodeTypesStore.getNodeType = vi.fn().mockReturnValue(nodeTypeDescription);
 			vi.spyOn(workflowDocumentStoreInstance, 'getNodeByName').mockReturnValue(
@@ -628,7 +641,10 @@ describe('useCanvasOperations', () => {
 				type: 'test',
 				typeVersion: 1,
 			});
-			uiStore.lastInteractedWithNode = lastInteracted;
+			uiStore.lastInteractedWithNodeId = lastInteracted.id;
+			vi.spyOn(workflowDocumentStoreInstance, 'getNodeById').mockReturnValue(
+				lastInteracted as INodeUi,
+			);
 			uiStore.lastInteractedWithNodeHandle = `outputs/${NodeConnectionTypes.AiTool}/0`;
 			nodeTypesStore.getNodeType = vi.fn().mockReturnValue(nodeTypeDescription);
 			vi.spyOn(workflowDocumentStoreInstance, 'getNodeByName').mockReturnValue(
@@ -664,7 +680,10 @@ describe('useCanvasOperations', () => {
 				type: 'test',
 				typeVersion: 1,
 			});
-			uiStore.lastInteractedWithNode = lastInteracted;
+			uiStore.lastInteractedWithNodeId = lastInteracted.id;
+			vi.spyOn(workflowDocumentStoreInstance, 'getNodeById').mockReturnValue(
+				lastInteracted as INodeUi,
+			);
 			// No lastInteractedWithNodeHandle set
 			nodeTypesStore.getNodeType = vi.fn().mockReturnValue(nodeTypeDescription);
 			vi.spyOn(workflowDocumentStoreInstance, 'getNodeByName').mockReturnValue(
@@ -714,7 +733,7 @@ describe('useCanvasOperations', () => {
 			const nodeTypeDescription = mockNodeTypeDescription();
 
 			// Mock the tool node as lastInteractedWithNode
-			uiStore.lastInteractedWithNode = toolNode;
+			uiStore.lastInteractedWithNodeId = toolNode.id;
 			uiStore.lastInteractedWithNodeConnection = {
 				source: mainNode.id,
 				target: mainNode.id,
@@ -725,7 +744,11 @@ describe('useCanvasOperations', () => {
 
 			nodeTypesStore.getNodeType = vi.fn().mockReturnValue(nodeTypeDescription);
 			vi.spyOn(workflowDocumentStoreInstance, 'getNodeByName').mockReturnValue(toolNode as INodeUi);
-			vi.spyOn(workflowDocumentStoreInstance, 'getNodeById').mockReturnValue(mainNode as INodeUi);
+			vi.spyOn(workflowDocumentStoreInstance, 'getNodeById').mockImplementation((id: string) => {
+				if (id === toolNode.id) return toolNode as INodeUi;
+				if (id === mainNode.id) return mainNode as INodeUi;
+				return undefined;
+			});
 
 			const { resolveNodePosition } = useCanvasOperations();
 			const position = resolveNodePosition(
@@ -767,7 +790,7 @@ describe('useCanvasOperations', () => {
 
 			const nodeTypeDescription = mockNodeTypeDescription();
 
-			uiStore.lastInteractedWithNode = toolNode;
+			uiStore.lastInteractedWithNodeId = toolNode.id;
 			uiStore.lastInteractedWithNodeConnection = {
 				source: mainNode.id,
 				target: mainNode.id,
@@ -778,7 +801,11 @@ describe('useCanvasOperations', () => {
 
 			nodeTypesStore.getNodeType = vi.fn().mockReturnValue(nodeTypeDescription);
 			vi.spyOn(workflowDocumentStoreInstance, 'getNodeByName').mockReturnValue(toolNode as INodeUi);
-			vi.spyOn(workflowDocumentStoreInstance, 'getNodeById').mockReturnValue(mainNode as INodeUi);
+			vi.spyOn(workflowDocumentStoreInstance, 'getNodeById').mockImplementation((id: string) => {
+				if (id === toolNode.id) return toolNode as INodeUi;
+				if (id === mainNode.id) return mainNode as INodeUi;
+				return undefined;
+			});
 
 			const setNodePositionByIdSpy = vi.spyOn(workflowDocumentStoreInstance, 'setNodePositionById');
 
@@ -822,7 +849,12 @@ describe('useCanvasOperations', () => {
 
 			const nodeTypeDescription = mockNodeTypeDescription();
 
-			uiStore.lastInteractedWithNode = toolNode;
+			uiStore.lastInteractedWithNodeId = toolNode.id;
+			vi.spyOn(workflowDocumentStoreInstance, 'getNodeById').mockImplementation((id: string) => {
+				if (id === toolNode.id) return toolNode as INodeUi;
+				if (id === mainNode.id) return mainNode as INodeUi;
+				return undefined;
+			});
 			uiStore.lastInteractedWithNodeConnection = {
 				source: mainNode.id,
 				target: mainNode.id,
@@ -832,7 +864,6 @@ describe('useCanvasOperations', () => {
 			uiStore.lastInteractedWithNodeHandle = `outputs/${NodeConnectionTypes.AiTool}/0`;
 
 			nodeTypesStore.getNodeType = vi.fn().mockReturnValue(nodeTypeDescription);
-			vi.spyOn(workflowDocumentStoreInstance, 'getNodeById').mockReturnValue(mainNode);
 
 			const { resolveNodePosition } = useCanvasOperations();
 			const position = resolveNodePosition(
@@ -871,7 +902,12 @@ describe('useCanvasOperations', () => {
 
 			const nodeTypeDescription = mockNodeTypeDescription();
 
-			uiStore.lastInteractedWithNode = regularNode;
+			uiStore.lastInteractedWithNodeId = regularNode.id;
+			vi.spyOn(workflowDocumentStoreInstance, 'getNodeById').mockImplementation((id: string) => {
+				if (id === regularNode.id) return regularNode as INodeUi;
+				if (id === mainNode.id) return mainNode as INodeUi;
+				return undefined;
+			});
 			uiStore.lastInteractedWithNodeConnection = {
 				source: mainNode.id,
 				target: mainNode.id,
@@ -881,7 +917,6 @@ describe('useCanvasOperations', () => {
 			uiStore.lastInteractedWithNodeHandle = `outputs/${NodeConnectionTypes.AiTool}/0`;
 
 			nodeTypesStore.getNodeType = vi.fn().mockReturnValue(nodeTypeDescription);
-			vi.spyOn(workflowDocumentStoreInstance, 'getNodeById').mockReturnValue(mainNode);
 
 			const { resolveNodePosition } = useCanvasOperations();
 			const position = resolveNodePosition(
@@ -3999,6 +4034,7 @@ describe('useCanvasOperations', () => {
 			resetWorkspace();
 
 			expect(nodeCreatorStore.setNodeCreatorState).toHaveBeenCalledWith({
+				workflowId: 'workflow-id',
 				createNodeActive: false,
 			});
 			expect(workflowsStore.removeTestWebhook).toHaveBeenCalledWith('workflow-id');
@@ -6571,7 +6607,7 @@ describe('useCanvasOperations', () => {
 			);
 
 			// Mock the last interacted node as the tool node with an existing connection
-			uiStore.lastInteractedWithNode = toolNode;
+			uiStore.lastInteractedWithNodeId = toolNode.id;
 			uiStore.lastInteractedWithNodeConnection = {
 				source: agentNode.id,
 				target: toolNode.id,

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -219,6 +219,12 @@ export function useCanvasOperations() {
 		return workflowDocumentStore.value.workflowTriggerNodes;
 	});
 
+	const lastInteractedWithNode = computed(() =>
+		uiStore.lastInteractedWithNodeId
+			? workflowDocumentStore.value.getNodeById(uiStore.lastInteractedWithNodeId)
+			: null,
+	);
+
 	/**
 	 * Node operations
 	 */
@@ -939,12 +945,11 @@ export function useCanvasOperations() {
 	}
 
 	function createConnectionToLastInteractedWithNode(node: INodeUi, options: AddNodeOptions = {}) {
-		const lastInteractedWithNode = uiStore.lastInteractedWithNode;
-		if (!lastInteractedWithNode) {
+		if (!lastInteractedWithNode.value) {
 			return;
 		}
 		const isNewHitlToolNode = isHitlToolType(node.type);
-		const lastInteractedWithNodeId = lastInteractedWithNode.id;
+		const lastInteractedWithNodeId = lastInteractedWithNode.value.id;
 		const lastInteractedWithNodeConnection = uiStore.lastInteractedWithNodeConnection;
 		const lastInteractedWithNodeHandle = uiStore.lastInteractedWithNodeHandle;
 		if (isNewHitlToolNode && lastInteractedWithNodeConnection) {
@@ -1100,9 +1105,7 @@ export function useCanvasOperations() {
 			is_auto_add: options.isAutoAdd,
 			workflow_id: workflowsStore.workflowId,
 			drag_and_drop: options.dragAndDrop,
-			input_node_type: uiStore.lastInteractedWithNode
-				? uiStore.lastInteractedWithNode.type
-				: undefined,
+			input_node_type: lastInteractedWithNode.value?.type,
 			resource,
 			operation,
 			action: options.actionName,
@@ -1220,7 +1223,6 @@ export function useCanvasOperations() {
 		// - clicking the plus button of a node handle
 		// - dragging an edge / connection of a node handle
 		// - selecting a node, adding a node via the node creator
-		const lastInteractedWithNode = uiStore.lastInteractedWithNode;
 		// Available when clicking the plus button of a node edge / connection
 		const lastInteractedWithNodeConnection = uiStore.lastInteractedWithNodeConnection;
 		// Available when dragging an edge / connection from a node
@@ -1244,13 +1246,13 @@ export function useCanvasOperations() {
 			});
 		}
 
-		if (lastInteractedWithNode) {
+		if (lastInteractedWithNode.value) {
 			const lastInteractedWithNodeTypeDescription = nodeTypesStore.getNodeType(
-				lastInteractedWithNode.type,
-				lastInteractedWithNode.typeVersion,
+				lastInteractedWithNode.value.type,
+				lastInteractedWithNode.value.typeVersion,
 			);
 			const lastInteractedWithNodeObject = workflowDocumentStore.value.getNodeByName(
-				lastInteractedWithNode.name,
+				lastInteractedWithNode.value.name,
 			);
 
 			const newNodeInsertPosition = uiStore.lastCancelledConnectionPosition;
@@ -1287,12 +1289,12 @@ export function useCanvasOperations() {
 						// X position: same as the tool node, slightly shifted to the left because of the size difference
 						// Y position: halfway between source and target nodes
 						const sourceY = toolUserNode.position[1];
-						const targetY = lastInteractedWithNode.position[1];
+						const targetY = lastInteractedWithNode.value.position[1];
 						const yDiff = (targetY - sourceY) / 2;
 						const middleY = sourceY + yDiff;
 
 						position = [
-							lastInteractedWithNode.position[0] - CONFIGURABLE_NODE_SIZE[0] / 2,
+							lastInteractedWithNode.value.position[0] - CONFIGURABLE_NODE_SIZE[0] / 2,
 							middleY,
 						];
 
@@ -1301,11 +1303,11 @@ export function useCanvasOperations() {
 							// slightly move the tool node vertically
 							const verticalOffset = PUSH_NODES_OFFSET / 2;
 							updateNodePosition(
-								lastInteractedWithNode.id,
+								lastInteractedWithNode.value.id,
 								{
-									x: lastInteractedWithNode.position[0],
+									x: lastInteractedWithNode.value.position[0],
 									y:
-										lastInteractedWithNode.position[1] +
+										lastInteractedWithNode.value.position[1] +
 										(yDiff > 0 ? verticalOffset : -verticalOffset),
 								},
 								{ trackHistory: true },
@@ -1385,7 +1387,7 @@ export function useCanvasOperations() {
 						: 0;
 					const shiftMargin = PUSH_NODES_OFFSET + extraWidth;
 
-					shiftDownstreamNodesPosition(lastInteractedWithNode.name, shiftMargin, {
+					shiftDownstreamNodesPosition(lastInteractedWithNode.value.name, shiftMargin, {
 						trackHistory: true,
 						nodeSize: newNodeSize,
 					});
@@ -1443,12 +1445,12 @@ export function useCanvasOperations() {
 					);
 
 					position = [
-						lastInteractedWithNode.position[0] +
+						lastInteractedWithNode.value.position[0] +
 							(CONFIGURABLE_NODE_SIZE[0] / lastInteractedWithNodeWidthDivisions) *
 								(scopedConnectionIndex + 1) -
 							nodeSize[0] / 2 -
 							customOffset,
-						lastInteractedWithNode.position[1] + PUSH_NODES_OFFSET,
+						lastInteractedWithNode.value.position[1] + PUSH_NODES_OFFSET,
 					];
 				} else {
 					// When the node has only main outputs, mixed outputs, or no outputs at all
@@ -1464,13 +1466,13 @@ export function useCanvasOperations() {
 
 					// If a node is active then add the new node directly after the current one
 					position = [
-						lastInteractedWithNode.position[0] + pushOffset,
-						lastInteractedWithNode.position[1] + yOffset,
+						lastInteractedWithNode.value.position[0] + pushOffset,
+						lastInteractedWithNode.value.position[1] + yOffset,
 					];
 
 					// When inserting via edge plus button, keep Y aligned to preserve vertical line
 					if (lastInteractedWithNodeConnection) {
-						position = [position[0], lastInteractedWithNode.position[1]];
+						position = [position[0], lastInteractedWithNode.value.position[1]];
 					}
 				}
 			}
@@ -2302,7 +2304,10 @@ export function useCanvasOperations() {
 
 	function resetWorkspace() {
 		// Reset node creator
-		nodeCreatorStore.setNodeCreatorState({ createNodeActive: false });
+		nodeCreatorStore.setNodeCreatorState({
+			workflowId: workflowDocumentStore.value.workflowId,
+			createNodeActive: false,
+		});
 
 		// Make sure that if there is a waiting test-webhook, it gets removed
 		if (workflowsStore.executionWaitingForWebhook) {

--- a/packages/frontend/editor-ui/src/app/stores/ui.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/ui.store.ts
@@ -91,11 +91,6 @@ import type {
 	INodeUi,
 } from '@/Interface';
 import { defineStore } from 'pinia';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import {
-	useWorkflowDocumentStore,
-	createWorkflowDocumentId,
-} from '@/app/stores/workflowDocument.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { applyThemeToBody, getThemeOverride, isValidTheme } from './ui.utils';
 import { computed, ref } from 'vue';
@@ -346,10 +341,6 @@ export const useUIStore = defineStore(STORES.UI, () => {
 	const lastCancelledConnectionPosition = ref<XYPosition | undefined>();
 
 	const settingsStore = useSettingsStore();
-	const workflowsStore = useWorkflowsStore();
-	const workflowDocumentStore = computed(() =>
-		useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId)),
-	);
 
 	const isDarkThemePreferred = useMediaQuery('(prefers-color-scheme: dark)');
 	const preferredSystemTheme = computed<AppliedThemeOption>(() =>
@@ -416,14 +407,6 @@ export const useUIStore = defineStore(STORES.UI, () => {
 				},
 			},
 		} as const;
-	});
-
-	const lastInteractedWithNode = computed(() => {
-		if (lastInteractedWithNodeId.value) {
-			return workflowDocumentStore.value.getNodeById(lastInteractedWithNodeId.value) ?? null;
-		}
-
-		return null;
 	});
 
 	const isModalActiveById = computed(() =>
@@ -754,7 +737,6 @@ export const useUIStore = defineStore(STORES.UI, () => {
 		lastInteractedWithNodeConnection,
 		lastInteractedWithNodeHandle,
 		lastInteractedWithNodeId,
-		lastInteractedWithNode,
 		lastCancelledConnectionPosition,
 		nodeViewOffsetPosition,
 		nodeViewInitialized,

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -327,6 +327,7 @@ function initializeRoute() {
 	// Open node panel if the route has a corresponding action
 	if (route.query.action === 'addEvaluationTrigger') {
 		nodeCreatorStore.openNodeCreatorForTriggerNodes(
+			workflowId.value,
 			NODE_CREATOR_OPEN_SOURCES.ADD_EVALUATION_TRIGGER_BUTTON,
 		);
 	} else if (route.query.action === 'addEvaluationNode') {
@@ -721,6 +722,7 @@ function onUpdateNodeOutputs(id: string) {
 
 function onClickNodeAdd(source: string, sourceHandle: string) {
 	nodeCreatorStore.openNodeCreatorForConnectingNode({
+		workflowId: workflowId.value,
 		connection: {
 			source,
 			sourceHandle,
@@ -784,6 +786,7 @@ function onCreateConnectionCancelled(
 		if (!event.nodeId) return;
 
 		nodeCreatorStore.openNodeCreatorForConnectingNode({
+			workflowId: workflowId.value,
 			connection: {
 				source: event.nodeId,
 				sourceHandle: event.handleId,
@@ -919,11 +922,16 @@ function onOpenSelectiveNodeCreator(
 	connectionType: NodeConnectionType,
 	connectionIndex: number = 0,
 ) {
-	nodeCreatorStore.openSelectiveNodeCreator({ node, connectionType, connectionIndex });
+	nodeCreatorStore.openSelectiveNodeCreator({
+		workflowId: workflowId.value,
+		node,
+		connectionType,
+		connectionIndex,
+	});
 }
 
 function onToggleNodeCreator(options: ToggleNodeCreatorOptions) {
-	nodeCreatorStore.setNodeCreatorState(options);
+	nodeCreatorStore.setNodeCreatorState({ ...options, workflowId: workflowId.value });
 
 	if (!options.createNodeActive) {
 		nodeCreatorReplaceTargetId.value = undefined;
@@ -936,7 +944,7 @@ function onOpenNodeCreatorFromCanvas(source: NodeCreatorOpenSource) {
 }
 
 function onOpenNodeCreatorForTriggerNodes(source: NodeCreatorOpenSource) {
-	nodeCreatorStore.openNodeCreatorForTriggerNodes(source);
+	nodeCreatorStore.openNodeCreatorForTriggerNodes(workflowId.value, source);
 }
 
 function onToggleFocusPanel() {
@@ -964,12 +972,14 @@ function onClickConnectionAdd(connection: Connection) {
 		type === NodeConnectionTypes.AiTool && mode === CanvasConnectionMode.Output;
 	if (isAddBetwenTool) {
 		nodeCreatorStore.openNodeCreatorForConnectingNode({
+			workflowId: workflowId.value,
 			connection,
 			eventSource: NODE_CREATOR_OPEN_SOURCES.NODE_CONNECTION_ACTION,
 			nodeCreatorView: HUMAN_IN_THE_LOOP_CATEGORY,
 		});
 	} else {
 		nodeCreatorStore.openNodeCreatorForConnectingNode({
+			workflowId: workflowId.value,
 			connection,
 			eventSource: NODE_CREATOR_OPEN_SOURCES.NODE_CONNECTION_ACTION,
 		});
@@ -986,7 +996,10 @@ function onClickReplaceNode(nodeId: string) {
 	nodeCreatorReplaceTargetId.value = nodeId;
 	nodeCreatorStore.openingContext = 'replacement';
 	if (isTriggerNode(nodeType)) {
-		nodeCreatorStore.openNodeCreatorForTriggerNodes(NODE_CREATOR_OPEN_SOURCES.REPLACE_NODE_ACTION);
+		nodeCreatorStore.openNodeCreatorForTriggerNodes(
+			workflowId.value,
+			NODE_CREATOR_OPEN_SOURCES.REPLACE_NODE_ACTION,
+		);
 	} else {
 		const inputs = NodeHelpers.getNodeInputs({ expression }, node, nodeType).map((output) =>
 			typeof output === 'string' ? output : output.type,
@@ -1001,10 +1014,12 @@ function onClickReplaceNode(nodeId: string) {
 		// back to showing all nodes in edge cases
 		if (inputs[0] && outputs[0] && inputs[0] !== outputs[0]) {
 			nodeCreatorStore.openNodeCreatorForRegularNodes(
+				workflowId.value,
 				NODE_CREATOR_OPEN_SOURCES.REPLACE_NODE_ACTION,
 			);
 		} else {
 			nodeCreatorStore.openSelectiveNodeCreator({
+				workflowId: workflowId.value,
 				connectionType: inputs[0] ?? outputs[0],
 				node: node.name,
 			});
@@ -1516,7 +1531,12 @@ function registerCustomActions() {
 			connectiontype: NodeConnectionType;
 			node: string;
 		}) => {
-			nodeCreatorStore.openSelectiveNodeCreator({ node, connectionType, creatorView });
+			nodeCreatorStore.openSelectiveNodeCreator({
+				workflowId: workflowId.value,
+				node,
+				connectionType,
+				creatorView,
+			});
 		},
 	});
 

--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.test.ts
@@ -427,6 +427,7 @@ describe('AI Assistant store', () => {
 		expect(assistantStore.currentSessionId).toEqual(mockSessionId);
 
 		assistantStore.trackUserOpenedAssistant({
+			workflowId: 'test-workflow',
 			task: 'error',
 			source: 'error',
 			has_existing_session: true,
@@ -449,7 +450,7 @@ describe('AI Assistant store', () => {
 			node_type: 'n8n-nodes-base.stopAndError',
 			source: 'error',
 			task: 'error',
-			workflow_id: '',
+			workflow_id: 'test-workflow',
 			instance_id: '',
 			canvas_status: 'empty',
 		});
@@ -462,6 +463,7 @@ describe('AI Assistant store', () => {
 		mockWorkflowDocumentStore.allNodes = [];
 
 		assistantStore.trackUserOpenedAssistant({
+			workflowId: '',
 			task: 'placeholder',
 			source: 'build_with_ai',
 			has_existing_session: false,
@@ -500,6 +502,7 @@ describe('AI Assistant store', () => {
 		] as INodeUi[];
 
 		assistantStore.trackUserOpenedAssistant({
+			workflowId: 'test-wf',
 			task: 'placeholder',
 			source: 'canvas',
 			has_existing_session: false,

--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
@@ -40,9 +40,6 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 	const usersStore = useUsersStore();
 	const uiStore = useUIStore();
 	const workflowsStore = useWorkflowsStore();
-	const workflowDocumentStore = computed(() =>
-		useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId)),
-	);
 	const route = useRoute();
 	const streaming = ref<boolean>();
 	const streamingAbortController = ref<AbortController | null>(null);
@@ -314,6 +311,7 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 		await initSupportChat(workflowId, question, credType);
 
 		trackUserOpenedAssistant({
+			workflowId,
 			source: 'credential',
 			task: 'credentials',
 			has_existing_session: hasExistingSession,
@@ -324,6 +322,7 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 	 * Gets information about the current view and active node to provide context to the assistant
 	 */
 	async function getVisualContext(
+		workflowId: string,
 		nodeInfo?: ChatRequest.NodeInfo,
 	): Promise<ChatRequest.AssistantContext | undefined> {
 		if (chatSessionTask.value === 'error') {
@@ -389,7 +388,7 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 				: undefined,
 			currentWorkflow: workflowDataStale.value
 				? await assistantHelpers.simplifyWorkflowForAssistant(
-						workflowDocumentStore.value.getSnapshot(),
+						useWorkflowDocumentStore(createWorkflowDocumentId(workflowId)).getSnapshot(),
 						{
 							excludeParameterValues: !allowSendingParameterValues.value,
 						},
@@ -418,7 +417,7 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 		// For the initial message, only provide visual context if the task is support
 		const visualContext =
 			chatSessionTask.value === 'support'
-				? await getVisualContext(nodeInfo)
+				? await getVisualContext(workflowId, nodeInfo)
 				: {
 						aiUsageSettings: {
 							allowSendingParameterValues: allowSendingParameterValues.value,
@@ -641,7 +640,7 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 			const nodeInfo = assistantHelpers.getNodeInfoForAssistant(workflowId, activeNode, {
 				excludeParameterValues: !allowSendingParameterValues.value,
 			});
-			const userContext = await getVisualContext(nodeInfo);
+			const userContext = await getVisualContext(workflowId, nodeInfo);
 
 			if (streamingAbortController.value) {
 				streamingAbortController.value.abort();
@@ -688,10 +687,11 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 	}
 
 	function trackUserOpenedAssistant({
+		workflowId,
 		source,
 		task,
 		has_existing_session,
-	}: { has_existing_session: boolean } & (
+	}: { has_existing_session: boolean; workflowId: string } & (
 		| {
 				source: 'error';
 				task: 'error';
@@ -710,13 +710,15 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 		  }
 	)) {
 		const canvasStatus =
-			workflowDocumentStore.value.allNodes.length === 0 ? 'empty' : 'existing_workflow';
+			useWorkflowDocumentStore(createWorkflowDocumentId(workflowId)).allNodes.length === 0
+				? 'empty'
+				: 'existing_workflow';
 		telemetry.track('User opened assistant', {
 			source,
 			task,
 			has_existing_session,
 			instance_id: rootStore.instanceId,
-			workflow_id: workflowsStore.workflowId,
+			workflow_id: workflowId,
 			canvas_status: canvasStatus,
 			node_type: chatSessionError.value?.node?.type,
 			error: chatSessionError.value?.error,

--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
@@ -726,18 +726,6 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 		});
 	}
 
-	watch(route, () => {
-		const activeWorkflowId = workflowsStore.workflowId;
-		if (
-			!currentSessionId.value ||
-			!currentSessionWorkflowId.value ||
-			currentSessionWorkflowId.value === activeWorkflowId
-		) {
-			return;
-		}
-		resetAssistantChat(activeWorkflowId);
-	});
-
 	watch(
 		() => uiStore.stateIsDirty,
 		() => {
@@ -760,6 +748,7 @@ export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 		unreadCount,
 		streaming,
 		currentSessionId,
+		currentSessionWorkflowId,
 		lastUnread,
 		isSessionEnded,
 		isFloatingButtonShown,

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/AssistantsHub.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/AssistantsHub.vue
@@ -13,11 +13,15 @@ import { useAskModeCoachmark } from '../composables/useAskModeCoachmark';
 
 import { N8nResizeWrapper } from '@n8n/design-system';
 import HubSwitcher from '@/features/ai/assistant/components/HubSwitcher.vue';
+import { useRoute } from 'vue-router';
+import { useWorkflowId } from '@/app/composables/useWorkflowId';
 
 const builderStore = useBuilderStore();
 const assistantStore = useAssistantStore();
 const chatPanelStore = useChatPanelStore();
 const settingsStore = useSettingsStore();
+const route = useRoute();
+const workflowId = useWorkflowId();
 
 const {
 	isBuildMode,
@@ -103,6 +107,17 @@ const unsubscribeBuilderStore = builderStore.$onAction(({ name }) => {
 	if (['sendChatMessage'].includes(name)) {
 		chatPanelStore.switchMode('builder');
 	}
+});
+
+watch(route, () => {
+	if (
+		!assistantStore.currentSessionId ||
+		!assistantStore.currentSessionWorkflowId ||
+		assistantStore.currentSessionWorkflowId === workflowId.value
+	) {
+		return;
+	}
+	assistantStore.resetAssistantChat(workflowId.value);
 });
 
 // Set default mode based on which flags are enabled

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Chat/AskAssistantFloatingButton.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Chat/AskAssistantFloatingButton.vue
@@ -8,11 +8,13 @@ import { computed } from 'vue';
 
 import { N8nAskAssistantButton, N8nAssistantAvatar, N8nTooltip } from '@n8n/design-system';
 import { useSettingsStore } from '@/app/stores/settings.store';
+import { useWorkflowId } from '@/app/composables/useWorkflowId';
 
 const assistantStore = useAssistantStore();
 const builderStore = useBuilderStore();
 const chatPanelStore = useChatPanelStore();
 const settingsStore = useSettingsStore();
+const workflowId = useWorkflowId();
 const i18n = useI18n();
 const { APP_Z_INDEXES } = useStyles();
 
@@ -52,6 +54,7 @@ const onClick = async () => {
 			source: 'canvas',
 			task: 'placeholder',
 			has_existing_session: !assistantStore.isSessionEnded,
+			workflowId: workflowId.value,
 		});
 	}
 };

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Chat/NewAssistantSessionModal.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Chat/NewAssistantSessionModal.vue
@@ -9,11 +9,13 @@ import { useAssistantStore } from '@/features/ai/assistant/assistant.store';
 import type { ICredentialType } from 'n8n-workflow';
 
 import { N8nAssistantIcon, N8nAssistantText, N8nButton, N8nText } from '@n8n/design-system';
+import { useWorkflowId } from '@/app/composables/useWorkflowId';
 
 const i18n = useI18n();
 const uiStore = useUIStore();
 const assistantStore = useAssistantStore();
 const chatPanelStore = useChatPanelStore();
+const workflowId = useWorkflowId();
 
 const props = defineProps<{
 	name: string;
@@ -33,6 +35,7 @@ const startNewSession = async () => {
 			source: 'error',
 			task: 'error',
 			has_existing_session: true,
+			workflowId: workflowId.value,
 		});
 	} else if ('credHelp' in props.data.context) {
 		await chatPanelStore.openWithCredHelp(props.data.context.credHelp.credType);

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
@@ -539,14 +539,16 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 	 * 2. The workflow is currently open on the canvas
 	 * 3. The workflow has a chat trigger with availableInChat enabled
 	 */
-	function isCanvasManualExecution(model: ChatHubConversationModel): boolean {
+	function isCanvasManualExecution(
+		model: ChatHubConversationModel,
+		canvasWorkflowId?: string,
+	): boolean {
 		if (model.provider !== 'n8n') return false;
 
-		const workflowsStore = useWorkflowsStore();
-		if (workflowsStore.workflowId !== model.workflowId) return false;
+		if (canvasWorkflowId !== model.workflowId) return false;
 
 		const workflowDocumentStore = useWorkflowDocumentStore(
-			createWorkflowDocumentId(workflowsStore.workflowId),
+			createWorkflowDocumentId(canvasWorkflowId),
 		);
 		const chatTrigger = workflowDocumentStore.allNodes.find(
 			(node) => node.type === CHAT_TRIGGER_NODE_TYPE,
@@ -592,6 +594,7 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 		agent: ChatModelDto,
 		credentials: ChatHubSendMessageRequest['credentials'],
 		files: File[] = [],
+		canvasWorkflowId?: string,
 	) {
 		const messageId = uuidv4();
 		const conversation = ensureConversation(sessionId);
@@ -617,7 +620,7 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 			agent,
 		};
 
-		const useManualMode = isCanvasManualExecution(agent.model);
+		const useManualMode = isCanvasManualExecution(agent.model, canvasWorkflowId);
 		const mode = useManualMode ? 'manual' : 'production';
 		const source = useManualMode ? 'canvas' : 'chat_hub';
 
@@ -688,6 +691,7 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 		credentials: ChatHubSendMessageRequest['credentials'],
 		keepAttachmentIndices: number[] = [],
 		newFiles: File[] = [],
+		canvasWorkflowId?: string,
 	) {
 		const promptId = uuidv4();
 
@@ -737,7 +741,7 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 			attachments: [...keptExistingAttachments, ...binaryData],
 		};
 
-		const useManualMode = isCanvasManualExecution(agent.model);
+		const useManualMode = isCanvasManualExecution(agent.model, canvasWorkflowId);
 		const mode = useManualMode ? 'manual' : 'production';
 		const source = useManualMode ? 'canvas' : 'chat_hub';
 
@@ -786,6 +790,7 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 		retryId: ChatMessageId,
 		agent: ChatModelDto,
 		credentials: ChatHubSendMessageRequest['credentials'],
+		canvasWorkflowId?: string,
 	) {
 		const conversation = ensureConversation(sessionId);
 		const previousMessageId = conversation.messages[retryId]?.previousMessageId ?? null;
@@ -810,7 +815,7 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 			attachments: [],
 		};
 
-		const useManualMode = isCanvasManualExecution(agent.model);
+		const useManualMode = isCanvasManualExecution(agent.model, canvasWorkflowId);
 		const mode = useManualMode ? 'manual' : 'production';
 		const source = useManualMode ? 'canvas' : 'chat_hub';
 

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
@@ -541,7 +541,7 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 	 */
 	function isCanvasManualExecution(
 		model: ChatHubConversationModel,
-		canvasWorkflowId?: string,
+		canvasWorkflowId: string,
 	): boolean {
 		if (model.provider !== 'n8n') return false;
 
@@ -563,11 +563,9 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 	 * Initialize workflowExecutionData scaffold so canvas push handlers can write
 	 * node results (makes nodes turn green during manual execution).
 	 */
-	function initManualExecutionScaffold() {
+	function initManualExecutionScaffold(workflowId: string) {
 		const workflowsStore = useWorkflowsStore();
-		const workflowDocumentStore = useWorkflowDocumentStore(
-			createWorkflowDocumentId(workflowsStore.workflowId),
-		);
+		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
 
 		workflowsStore.setWorkflowExecutionData({
 			id: IN_PROGRESS_EXECUTION_ID,
@@ -577,7 +575,7 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 			createdAt: new Date(),
 			startedAt: new Date(),
 			stoppedAt: undefined,
-			workflowId: workflowsStore.workflowId,
+			workflowId: workflowId,
 			data: createRunExecutionData({
 				resultData: { runData: {} },
 			}),
@@ -620,7 +618,8 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 			agent,
 		};
 
-		const useManualMode = isCanvasManualExecution(agent.model, canvasWorkflowId);
+		const useManualMode =
+			!!canvasWorkflowId && isCanvasManualExecution(agent.model, canvasWorkflowId);
 		const mode = useManualMode ? 'manual' : 'production';
 		const source = useManualMode ? 'canvas' : 'chat_hub';
 
@@ -657,19 +656,22 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 			}
 
 			if (useManualMode) {
-				initManualExecutionScaffold();
+				initManualExecutionScaffold(canvasWorkflowId);
 
 				// model is guaranteed to be n8n type here (checked in isCanvasManualMode)
-				const { workflowId } = agent.model as ChatHubN8nModel;
-				await sendMessageManualApi(rootStore.restApiContext, workflowId, {
-					messageId,
-					sessionId,
-					message,
-					previousMessageId,
-					attachments,
-					agentName: agent.name,
-					timeZone: payload.timeZone,
-				});
+				await sendMessageManualApi(
+					rootStore.restApiContext,
+					(agent.model as ChatHubN8nModel).workflowId,
+					{
+						messageId,
+						sessionId,
+						message,
+						previousMessageId,
+						attachments,
+						agentName: agent.name,
+						timeZone: payload.timeZone,
+					},
+				);
 			} else {
 				await sendMessageApi(rootStore.restApiContext, payload);
 			}
@@ -741,7 +743,8 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 			attachments: [...keptExistingAttachments, ...binaryData],
 		};
 
-		const useManualMode = isCanvasManualExecution(agent.model, canvasWorkflowId);
+		const useManualMode =
+			!!canvasWorkflowId && isCanvasManualExecution(agent.model, canvasWorkflowId);
 		const mode = useManualMode ? 'manual' : 'production';
 		const source = useManualMode ? 'canvas' : 'chat_hub';
 
@@ -756,7 +759,7 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 
 		try {
 			if (useManualMode) {
-				initManualExecutionScaffold();
+				initManualExecutionScaffold(canvasWorkflowId);
 
 				await editMessageManualApi(rootStore.restApiContext, {
 					workflowId: (agent.model as ChatHubN8nModel).workflowId,
@@ -815,7 +818,8 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 			attachments: [],
 		};
 
-		const useManualMode = isCanvasManualExecution(agent.model, canvasWorkflowId);
+		const useManualMode =
+			!!canvasWorkflowId && isCanvasManualExecution(agent.model, canvasWorkflowId);
 		const mode = useManualMode ? 'manual' : 'production';
 		const source = useManualMode ? 'canvas' : 'chat_hub';
 
@@ -830,7 +834,7 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 
 		try {
 			if (useManualMode) {
-				initManualExecutionScaffold();
+				initManualExecutionScaffold(canvasWorkflowId);
 
 				await regenerateMessageManualApi(rootStore.restApiContext, {
 					workflowId: (agent.model as ChatHubN8nModel).workflowId,

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/chat.store.ts
@@ -575,7 +575,7 @@ export const useChatStore = defineStore(STORES.CHAT_HUB, () => {
 			createdAt: new Date(),
 			startedAt: new Date(),
 			stoppedAt: undefined,
-			workflowId: workflowId,
+			workflowId,
 			data: createRunExecutionData({
 				resultData: { runData: {} },
 			}),

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/CanvasChatHubPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/CanvasChatHubPanel.vue
@@ -187,6 +187,7 @@ async function onSubmit(message: string, attachments: File[]) {
 		workflowAgent.value,
 		{} as ChatHubSendMessageRequest['credentials'],
 		attachments,
+		workflowDocumentStore.value.workflowId,
 	);
 
 	inputRef.value?.reset();
@@ -206,6 +207,7 @@ async function handleRegenerateMessage(message: ChatMessageType) {
 		message.id,
 		workflowAgent.value,
 		{} as ChatHubSendMessageRequest['credentials'],
+		workflowDocumentStore.value.workflowId,
 	);
 }
 
@@ -232,6 +234,7 @@ async function handleEditMessage(
 		{} as ChatHubSendMessageRequest['credentials'],
 		keptAttachmentIndices,
 		newFiles,
+		workflowDocumentStore.value.workflowId,
 	);
 
 	editingMessageId.value = undefined;

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/SetupWizard/SetupWizard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/SetupWizard/SetupWizard.vue
@@ -11,6 +11,7 @@ import { I18nT } from 'vue-i18n';
 
 import { N8nButton, N8nCallout, N8nText } from '@n8n/design-system';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import { useWorkflowEvaluationState } from '../../composables/useWorkflowEvaluationState';
 defineEmits<{
 	runTest: [];
 }>();
@@ -19,6 +20,7 @@ const router = useRouter();
 const locale = useI18n();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const evaluationStore = useEvaluationStore();
+const evaluationState = useWorkflowEvaluationState();
 const usageStore = useUsageStore();
 const pageRedirectionHelper = usePageRedirectionHelper();
 
@@ -50,14 +52,17 @@ const initializeActiveStep = () => {
 		return;
 	}
 
-	if (evaluationStore.evaluationTriggerExists && evaluationStore.evaluationSetMetricsNodeExist) {
+	if (
+		evaluationState.evaluationTriggerExists.value &&
+		evaluationState.evaluationSetMetricsNodeExist.value
+	) {
 		activeStepIndex.value = 3;
 	} else if (
-		evaluationStore.evaluationTriggerExists &&
-		evaluationStore.evaluationSetOutputsNodeExist
+		evaluationState.evaluationTriggerExists.value &&
+		evaluationState.evaluationSetOutputsNodeExist.value
 	) {
 		activeStepIndex.value = 2;
-	} else if (evaluationStore.evaluationTriggerExists) {
+	} else if (evaluationState.evaluationTriggerExists.value) {
 		activeStepIndex.value = 1;
 	} else {
 		activeStepIndex.value = 0;
@@ -96,7 +101,7 @@ function onSeePlans() {
 				<StepHeader
 					:step-number="1"
 					:title="locale.baseText('evaluations.setupWizard.step1.title')"
-					:is-completed="evaluationStore.evaluationTriggerExists"
+					:is-completed="evaluationState.evaluationTriggerExists.value"
 					:is-active="activeStepIndex === 0"
 					@click="toggleStep(0)"
 				/>
@@ -131,7 +136,7 @@ function onSeePlans() {
 				<StepHeader
 					:step-number="2"
 					:title="locale.baseText('evaluations.setupWizard.step2.title')"
-					:is-completed="evaluationStore.evaluationSetOutputsNodeExist"
+					:is-completed="evaluationState.evaluationSetOutputsNodeExist.value"
 					:is-active="activeStepIndex === 1"
 					@click="toggleStep(1)"
 				/>
@@ -160,7 +165,7 @@ function onSeePlans() {
 				<StepHeader
 					:step-number="3"
 					:title="locale.baseText('evaluations.setupWizard.step3.title')"
-					:is-completed="evaluationStore.evaluationSetMetricsNodeExist"
+					:is-completed="evaluationState.evaluationSetMetricsNodeExist.value"
 					:is-active="activeStepIndex === 2"
 					:is-optional="true"
 					@click="toggleStep(2)"
@@ -231,12 +236,14 @@ function onSeePlans() {
 					<div :class="[$style.actionButton, $style.actionButtonInline]">
 						<N8nButton
 							variant="subtle"
-							v-if="evaluationStore.evaluationSetMetricsNodeExist && !evaluationsQuotaExceeded"
+							v-if="
+								evaluationState.evaluationSetMetricsNodeExist.value && !evaluationsQuotaExceeded
+							"
 							size="medium"
 							:disabled="
-								!evaluationStore.evaluationTriggerExists ||
-								(!evaluationStore.evaluationSetOutputsNodeExist &&
-									!evaluationStore.evaluationSetMetricsNodeExist)
+								!evaluationState.evaluationTriggerExists.value ||
+								(!evaluationState.evaluationSetOutputsNodeExist.value &&
+									!evaluationState.evaluationSetMetricsNodeExist.value)
 							"
 							@click="$emit('runTest')"
 						>
@@ -247,9 +254,9 @@ function onSeePlans() {
 							v-else
 							size="medium"
 							:disabled="
-								!evaluationStore.evaluationTriggerExists ||
-								(!evaluationStore.evaluationSetOutputsNodeExist &&
-									!evaluationStore.evaluationSetMetricsNodeExist)
+								!evaluationState.evaluationTriggerExists.value ||
+								(!evaluationState.evaluationSetOutputsNodeExist.value &&
+									!evaluationState.evaluationSetMetricsNodeExist.value)
 							"
 							@click="navigateToWorkflow('executeEvaluation')"
 						>

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/composables/useWorkflowEvaluationState.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/composables/useWorkflowEvaluationState.ts
@@ -1,0 +1,116 @@
+import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import { EVALUATION_NODE_TYPE, EVALUATION_TRIGGER_NODE_TYPE, NodeHelpers } from 'n8n-workflow';
+import { computed } from 'vue';
+import { getMetricCategory, type MetricSource } from '../evaluation.utils';
+
+const BUILTIN_METRIC_DEFAULT_NAMES: Record<string, string> = {
+	correctness: 'Correctness',
+	helpfulness: 'Helpfulness',
+	stringSimilarity: 'String similarity',
+	categorization: 'Categorization',
+	toolsUsed: 'Tools Used',
+};
+
+export function useWorkflowEvaluationState() {
+	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const nodeTypesStore = useNodeTypesStore();
+
+	const evaluationTriggerExists = computed(() => {
+		return workflowDocumentStore.value.allNodes.some(
+			(node) => node.type === EVALUATION_TRIGGER_NODE_TYPE,
+		);
+	});
+
+	function evaluationNodeExist(operation: string) {
+		return workflowDocumentStore.value.allNodes.some((node) => {
+			if (node.type !== EVALUATION_NODE_TYPE) {
+				return false;
+			}
+
+			const nodeType = nodeTypesStore.getNodeType(node.type, node.typeVersion);
+			if (!nodeType) return false;
+
+			const nodeParameters = NodeHelpers.getNodeParameters(
+				nodeType.properties,
+				node.parameters,
+				true,
+				false,
+				node,
+				nodeType,
+			);
+
+			return nodeParameters?.operation === operation;
+		});
+	}
+
+	const evaluationSetMetricsNodeExist = computed(() => {
+		return evaluationNodeExist('setMetrics');
+	});
+
+	const evaluationSetOutputsNodeExist = computed(() => {
+		return evaluationNodeExist('setOutputs');
+	});
+
+	// Per-metric category + source-node name, keyed by metric name as it
+	// appears in the run output. Built-in nodes emit one key (overridable
+	// via `options.metricName`); customMetrics emits one key per assignment.
+	const metricSourceByKey = computed<Record<string, MetricSource>>(() => {
+		const map: Record<string, MetricSource> = {};
+
+		for (const node of workflowDocumentStore.value.allNodes) {
+			if (node.type !== EVALUATION_NODE_TYPE) continue;
+
+			const nodeType = nodeTypesStore.getNodeType(node.type, node.typeVersion);
+			if (!nodeType) continue;
+
+			const resolved = NodeHelpers.getNodeParameters(
+				nodeType.properties,
+				node.parameters,
+				true,
+				false,
+				node,
+				nodeType,
+			);
+			if (resolved?.operation !== 'setMetrics') continue;
+
+			const metricType =
+				typeof resolved.metric === 'string' && resolved.metric.length > 0
+					? resolved.metric
+					: 'customMetrics';
+
+			if (metricType === 'customMetrics') {
+				const assignments = (
+					resolved.metrics as { assignments?: Array<{ name?: string }> } | undefined
+				)?.assignments;
+				if (!Array.isArray(assignments)) continue;
+
+				for (const assignment of assignments) {
+					const key = assignment?.name;
+					if (typeof key !== 'string' || key.length === 0) continue;
+					if (map[key]) continue;
+					map[key] = { category: 'custom', nodeName: node.name };
+				}
+			} else {
+				const overriddenName = (resolved.options as { metricName?: string } | undefined)
+					?.metricName;
+				const key =
+					typeof overriddenName === 'string' && overriddenName.length > 0
+						? overriddenName
+						: BUILTIN_METRIC_DEFAULT_NAMES[metricType];
+				if (!key || map[key]) continue;
+				map[key] = { category: getMetricCategory(metricType), nodeName: node.name };
+			}
+		}
+
+		return map;
+	});
+
+	return {
+		// computed
+		evaluationTriggerExists,
+		evaluationSetMetricsNodeExist,
+		evaluationSetOutputsNodeExist,
+		metricSourceByKey,
+	};
+}

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/evaluation.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/evaluation.store.ts
@@ -4,23 +4,7 @@ import { useRootStore } from '@n8n/stores/useRootStore';
 import * as evaluationsApi from './evaluation.api';
 import type { TestCaseExecutionRecord, TestRunRecord } from './evaluation.api';
 import { STORES } from '@n8n/stores';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import {
-	useWorkflowDocumentStore,
-	createWorkflowDocumentId,
-} from '@/app/stores/workflowDocument.store';
-import { EVALUATION_NODE_TYPE, EVALUATION_TRIGGER_NODE_TYPE, NodeHelpers } from 'n8n-workflow';
-import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
-import { getMetricCategory, type MetricSource } from './evaluation.utils';
-
-const BUILTIN_METRIC_DEFAULT_NAMES: Record<string, string> = {
-	correctness: 'Correctness',
-	helpfulness: 'Helpfulness',
-	stringSimilarity: 'String similarity',
-	categorization: 'Categorization',
-	toolsUsed: 'Tools Used',
-};
 
 export const useEvaluationStore = defineStore(
 	STORES.EVALUATION,
@@ -33,11 +17,6 @@ export const useEvaluationStore = defineStore(
 
 		// Store instances
 		const rootStore = useRootStore();
-		const workflowsStore = useWorkflowsStore();
-		const workflowDocumentStore = computed(() =>
-			useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId)),
-		);
-		const nodeTypesStore = useNodeTypesStore();
 		const settingsStore = useSettingsStore();
 
 		// Computed
@@ -57,96 +36,6 @@ export const useEvaluationStore = defineStore(
 				},
 				{},
 			);
-		});
-
-		const evaluationTriggerExists = computed(() => {
-			return workflowDocumentStore.value.allNodes.some(
-				(node) => node.type === EVALUATION_TRIGGER_NODE_TYPE,
-			);
-		});
-
-		function evaluationNodeExist(operation: string) {
-			return workflowDocumentStore.value.allNodes.some((node) => {
-				if (node.type !== EVALUATION_NODE_TYPE) {
-					return false;
-				}
-
-				const nodeType = nodeTypesStore.getNodeType(node.type, node.typeVersion);
-				if (!nodeType) return false;
-
-				const nodeParameters = NodeHelpers.getNodeParameters(
-					nodeType.properties,
-					node.parameters,
-					true,
-					false,
-					node,
-					nodeType,
-				);
-
-				return nodeParameters?.operation === operation;
-			});
-		}
-
-		const evaluationSetMetricsNodeExist = computed(() => {
-			return evaluationNodeExist('setMetrics');
-		});
-
-		const evaluationSetOutputsNodeExist = computed(() => {
-			return evaluationNodeExist('setOutputs');
-		});
-
-		// Per-metric category + source-node name, keyed by metric name as it
-		// appears in the run output. Built-in nodes emit one key (overridable
-		// via `options.metricName`); customMetrics emits one key per assignment.
-		const metricSourceByKey = computed<Record<string, MetricSource>>(() => {
-			const map: Record<string, MetricSource> = {};
-
-			for (const node of workflowDocumentStore.value.allNodes) {
-				if (node.type !== EVALUATION_NODE_TYPE) continue;
-
-				const nodeType = nodeTypesStore.getNodeType(node.type, node.typeVersion);
-				if (!nodeType) continue;
-
-				const resolved = NodeHelpers.getNodeParameters(
-					nodeType.properties,
-					node.parameters,
-					true,
-					false,
-					node,
-					nodeType,
-				);
-				if (resolved?.operation !== 'setMetrics') continue;
-
-				const metricType =
-					typeof resolved.metric === 'string' && resolved.metric.length > 0
-						? resolved.metric
-						: 'customMetrics';
-
-				if (metricType === 'customMetrics') {
-					const assignments = (
-						resolved.metrics as { assignments?: Array<{ name?: string }> } | undefined
-					)?.assignments;
-					if (!Array.isArray(assignments)) continue;
-
-					for (const assignment of assignments) {
-						const key = assignment?.name;
-						if (typeof key !== 'string' || key.length === 0) continue;
-						if (map[key]) continue;
-						map[key] = { category: 'custom', nodeName: node.name };
-					}
-				} else {
-					const overriddenName = (resolved.options as { metricName?: string } | undefined)
-						?.metricName;
-					const key =
-						typeof overriddenName === 'string' && overriddenName.length > 0
-							? overriddenName
-							: BUILTIN_METRIC_DEFAULT_NAMES[metricType];
-					if (!key || map[key]) continue;
-					map[key] = { category: getMetricCategory(metricType), nodeName: node.name };
-				}
-			}
-
-			return map;
 		});
 
 		// Methods
@@ -283,10 +172,6 @@ export const useEvaluationStore = defineStore(
 			isLoading,
 			isEvaluationEnabled,
 			testRunsByWorkflowId,
-			evaluationTriggerExists,
-			evaluationSetMetricsNodeExist,
-			evaluationSetOutputsNodeExist,
-			metricSourceByKey,
 
 			// Methods
 			fetchTestCaseExecutions,

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.test.ts
@@ -10,6 +10,7 @@ import { useUsageStore } from '@/features/settings/usage/usage.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { mockedStore } from '@/__tests__/utils';
 import type { IWorkflowDb } from '@/Interface';
+import { ref } from 'vue';
 import { waitFor } from '@testing-library/vue';
 import { flushPromises } from '@vue/test-utils';
 import type { TestRunRecord } from '../evaluation.api';
@@ -59,6 +60,18 @@ vi.mock('@/app/stores/nodeTypes.store', () => ({
 	})),
 }));
 
+const mockEvaluationTriggerExists = ref(false);
+const mockEvaluationSetOutputsNodeExist = ref(false);
+const mockEvaluationSetMetricsNodeExist = ref(false);
+vi.mock('../composables/useWorkflowEvaluationState', () => ({
+	useWorkflowEvaluationState: () => ({
+		evaluationTriggerExists: mockEvaluationTriggerExists,
+		evaluationSetOutputsNodeExist: mockEvaluationSetOutputsNodeExist,
+		evaluationSetMetricsNodeExist: mockEvaluationSetMetricsNodeExist,
+		metricSourceByKey: ref({}),
+	}),
+}));
+
 vi.mock('@n8n/i18n', async (importOriginal) => {
 	return {
 		...(await importOriginal()),
@@ -95,6 +108,9 @@ describe('EvaluationsRootView', () => {
 	beforeEach(() => {
 		createTestingPinia();
 		vi.clearAllMocks();
+		mockEvaluationTriggerExists.value = false;
+		mockEvaluationSetOutputsNodeExist.value = false;
+		mockEvaluationSetMetricsNodeExist.value = false;
 
 		mockedStore(useWorkflowsStore).isWorkflowSaved = { [mockWorkflow.id]: true };
 
@@ -283,9 +299,7 @@ describe('EvaluationsRootView', () => {
 
 			workflowsStore.workflow = workflowWithTrigger;
 			evaluationStore.testRunsById = {};
-			// Override the computed property directly since createTestingPinia stubs actions
-			// and the document store's setNodes is a no-op
-			evaluationStore.evaluationTriggerExists = true;
+			mockEvaluationTriggerExists.value = true;
 			usageStore.workflowsWithEvaluationsLimit = 10;
 			usageStore.workflowsWithEvaluationsCount = 0;
 
@@ -338,8 +352,7 @@ describe('EvaluationsRootView', () => {
 
 			workflowsStore.workflow = workflowWithOutputNode;
 			evaluationStore.testRunsById = {};
-			// Override the computed property directly since createTestingPinia stubs actions
-			evaluationStore.evaluationSetOutputsNodeExist = true;
+			mockEvaluationSetOutputsNodeExist.value = true;
 			usageStore.workflowsWithEvaluationsLimit = 10;
 			usageStore.workflowsWithEvaluationsCount = 0;
 
@@ -392,8 +405,7 @@ describe('EvaluationsRootView', () => {
 
 			workflowsStore.workflow = workflowWithMetricsNode;
 			evaluationStore.testRunsById = {};
-			// Override the computed property directly since createTestingPinia stubs actions
-			evaluationStore.evaluationSetMetricsNodeExist = true;
+			mockEvaluationSetMetricsNodeExist.value = true;
 			usageStore.workflowsWithEvaluationsLimit = 10;
 			usageStore.workflowsWithEvaluationsCount = 0;
 

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.vue
@@ -14,12 +14,14 @@ import EvaluationsPaywall from '../components/Paywall/EvaluationsPaywall.vue';
 import SetupWizard from '../components/SetupWizard/SetupWizard.vue';
 
 import { N8nCallout, N8nLink, N8nText } from '@n8n/design-system';
+import { useWorkflowEvaluationState } from '../composables/useWorkflowEvaluationState';
 const props = defineProps<{
 	workflowId: string;
 }>();
 
 const usageStore = useUsageStore();
 const evaluationStore = useEvaluationStore();
+const evaluationState = useWorkflowEvaluationState();
 const workflowsStore = useWorkflowsStore();
 const telemetry = useTelemetry();
 const toast = useToast();
@@ -108,9 +110,9 @@ watch(
 					workflow_id: props.workflowId,
 					test_type: 'evaluation',
 					view: 'setup',
-					trigger_set_up: evaluationStore.evaluationTriggerExists,
-					output_set_up: evaluationStore.evaluationSetOutputsNodeExist,
-					metrics_set_up: evaluationStore.evaluationSetMetricsNodeExist,
+					trigger_set_up: evaluationState.evaluationTriggerExists.value,
+					output_set_up: evaluationState.evaluationSetOutputsNodeExist.value,
+					metrics_set_up: evaluationState.evaluationSetMetricsNodeExist.value,
 					quota_reached: evaluationsQuotaExceeded.value,
 				});
 			} else {

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/TestRunDetailView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/TestRunDetailView.vue
@@ -14,10 +14,12 @@ import { getUserDefinedMetricNames } from '../evaluation.utils';
 import MetricSummaryStrip from '../components/RunDetail/MetricSummaryStrip.vue';
 import RunStatusPill from '../components/RunDetail/RunStatusPill.vue';
 import TestCaseCard from '../components/RunDetail/TestCaseCard.vue';
+import { useWorkflowEvaluationState } from '../composables/useWorkflowEvaluationState';
 
 const router = useRouter();
 const toast = useToast();
 const evaluationStore = useEvaluationStore();
+const evaluationState = useWorkflowEvaluationState();
 const locale = useI18n();
 const telemetry = useTelemetry();
 
@@ -72,7 +74,7 @@ const orderedTestCases = computed(() =>
 	),
 );
 
-const metricSources = computed(() => evaluationStore.metricSourceByKey);
+const metricSources = computed(() => evaluationState.metricSourceByKey.value);
 
 const caseValuesByKey = computed(() => {
 	const result: Record<string, Array<number | undefined>> = {};

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/mcp.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/mcp.store.test.ts
@@ -3,7 +3,6 @@ import { setActivePinia, createPinia } from 'pinia';
 
 import * as mcpApi from './mcp.api';
 import { useMCPStore } from './mcp.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 
 const { mockWorkflowDocumentStore } = vi.hoisted(() => ({
@@ -29,14 +28,12 @@ vi.mock('@/app/stores/workflowDocument.store', () => ({
 
 describe('mcp.store', () => {
 	let store: ReturnType<typeof useMCPStore>;
-	let workflowsStore: ReturnType<typeof useWorkflowsStore>;
 	let workflowsListStore: ReturnType<typeof useWorkflowsListStore>;
 
 	beforeEach(() => {
 		vi.clearAllMocks();
 		setActivePinia(createPinia());
 		store = useMCPStore();
-		workflowsStore = useWorkflowsStore();
 		workflowsListStore = useWorkflowsListStore();
 	});
 
@@ -85,8 +82,6 @@ describe('mcp.store', () => {
 		});
 
 		it('merges settings into the active workflow document when toggling its own id', async () => {
-			workflowsStore.workflowId = 'wf-current';
-
 			vi.spyOn(mcpApi, 'toggleWorkflowsMcpAccessApi').mockResolvedValue({
 				updatedCount: 1,
 				updatedIds: ['wf-current'],

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/mcp.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/mcp.store.ts
@@ -1,6 +1,5 @@
 import { defineStore } from 'pinia';
 import { MCP_STORE } from './mcp.constants';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import {
 	useWorkflowDocumentStore,
@@ -32,7 +31,6 @@ import type {
 import { i18n } from '@n8n/i18n';
 
 export const useMCPStore = defineStore(MCP_STORE, () => {
-	const workflowsStore = useWorkflowsStore();
 	const workflowsListStore = useWorkflowsListStore();
 	const rootStore = useRootStore();
 	const settingsStore = useSettingsStore();
@@ -84,10 +82,8 @@ export const useMCPStore = defineStore(MCP_STORE, () => {
 			}
 		}
 
-		if (workflowId === workflowsStore.workflowId) {
-			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
-			workflowDocumentStore.mergeSettings({ availableInMCP });
-		}
+		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+		workflowDocumentStore.mergeSettings({ availableInMCP });
 	}
 
 	// Toggle MCP access for a single workflow

--- a/packages/frontend/editor-ui/src/features/collaboration/collaboration/collaboration.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/collaboration/collaboration.store.test.ts
@@ -123,7 +123,7 @@ describe('useCollaborationStore', () => {
 			const store = useCollaborationStore();
 
 			// Initialize collaboration on workflow-1
-			await store.initialize();
+			await store.initialize('workflow-1');
 
 			// Clear any calls from initialization
 			mockPushStore.send.mockClear();
@@ -147,7 +147,7 @@ describe('useCollaborationStore', () => {
 			mockShowMessage.mockReturnValue({ close });
 			const store = useCollaborationStore();
 
-			await store.initialize();
+			await store.initialize('workflow-1');
 			const handler = mockPushStore.addEventListener.mock.calls[0][0] as (event: {
 				type: string;
 				data: { workflowId: string };

--- a/packages/frontend/editor-ui/src/features/collaboration/collaboration/collaboration.store.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/collaboration/collaboration.store.ts
@@ -360,13 +360,13 @@ export const useCollaborationStore = defineStore(STORES.COLLABORATION, () => {
 		}
 	}
 
-	async function initialize() {
+	async function initialize(workflowId: string) {
 		if (pushStoreEventListenerRemovalFn.value) {
 			return;
 		}
 
 		// Store the workflowId we're collaborating on
-		collaboratingWorkflowId.value = workflowsStore.workflowId;
+		collaboratingWorkflowId.value = workflowId;
 
 		// Fetch current write-lock state from backend to restore state after page refresh
 		const writeLock = await fetchWriteLockState();

--- a/packages/frontend/editor-ui/src/features/collaboration/collaboration/collaboration.store.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/collaboration/collaboration.store.ts
@@ -187,7 +187,7 @@ export const useCollaborationStore = defineStore(STORES.COLLABORATION, () => {
 	const startLockStatePolling = (workflowId: string) => {
 		stopLockStatePolling();
 		lockStatePollTimer.value = window.setInterval(
-			() => pollLockState(workflowId),
+			async () => await pollLockState(workflowId),
 			LOCK_STATE_POLL_INTERVAL,
 		);
 	};

--- a/packages/frontend/editor-ui/src/features/collaboration/collaboration/collaboration.store.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/collaboration/collaboration.store.ts
@@ -87,9 +87,10 @@ export const useCollaborationStore = defineStore(STORES.COLLABORATION, () => {
 		return isAnyoneWriting.value && !isCurrentTabWriter.value;
 	});
 
-	async function fetchWriteLockState(): Promise<{ clientId: string; userId: string } | null> {
+	async function fetchWriteLockState(
+		workflowId: string,
+	): Promise<{ clientId: string; userId: string } | null> {
 		try {
-			const { workflowId } = workflowsStore;
 			if (!workflowsStore.isWorkflowSaved[workflowId]) {
 				return null;
 			}
@@ -168,13 +169,13 @@ export const useCollaborationStore = defineStore(STORES.COLLABORATION, () => {
 	 * Poll lock state from backend to detect if lock has expired.
 	 * Only runs when in read-only mode (someone else has the lock).
 	 */
-	const pollLockState = async () => {
+	const pollLockState = async (workflowId: string) => {
 		if (!shouldBeReadOnly.value) {
 			stopLockStatePolling();
 			return;
 		}
 
-		const writeLock = await fetchWriteLockState();
+		const writeLock = await fetchWriteLockState(workflowId);
 
 		// If lock is gone on backend but still exists in frontend, clear it
 		if (!writeLock && currentWriterLock.value) {
@@ -183,9 +184,12 @@ export const useCollaborationStore = defineStore(STORES.COLLABORATION, () => {
 		}
 	};
 
-	const startLockStatePolling = () => {
+	const startLockStatePolling = (workflowId: string) => {
 		stopLockStatePolling();
-		lockStatePollTimer.value = window.setInterval(pollLockState, LOCK_STATE_POLL_INTERVAL);
+		lockStatePollTimer.value = window.setInterval(
+			() => pollLockState(workflowId),
+			LOCK_STATE_POLL_INTERVAL,
+		);
 	};
 
 	addBeforeUnloadHandler(() => {
@@ -369,7 +373,7 @@ export const useCollaborationStore = defineStore(STORES.COLLABORATION, () => {
 		collaboratingWorkflowId.value = workflowId;
 
 		// Fetch current write-lock state from backend to restore state after page refresh
-		const writeLock = await fetchWriteLockState();
+		const writeLock = await fetchWriteLockState(workflowId);
 		if (writeLock) {
 			currentWriterLock.value = writeLock;
 
@@ -378,7 +382,7 @@ export const useCollaborationStore = defineStore(STORES.COLLABORATION, () => {
 				startWriteLockHeartbeat();
 			} else {
 				// If someone else has the lock, start polling
-				startLockStatePolling();
+				startLockStatePolling(workflowId);
 			}
 		}
 
@@ -408,7 +412,7 @@ export const useCollaborationStore = defineStore(STORES.COLLABORATION, () => {
 					stopLockStatePolling();
 				} else {
 					// Start polling if someone else has the lock
-					startLockStatePolling();
+					startLockStatePolling(workflowId);
 				}
 				return;
 			}

--- a/packages/frontend/editor-ui/src/features/collaboration/collaboration/components/CollaborationPane.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/collaboration/components/CollaborationPane.test.ts
@@ -3,6 +3,17 @@ import { mock } from 'vitest-mock-extended';
 
 import { STORES } from '@n8n/stores';
 import CollaborationPane from './CollaborationPane.vue';
+
+vi.mock('vue-router', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('vue-router')>();
+	return {
+		...actual,
+		useRoute: () => ({
+			name: 'NodeView',
+			params: { workflowId: 'test-workflow-id' },
+		}),
+	};
+});
 import type { IUser } from '@n8n/rest-api-client/api/users';
 
 import type { RenderOptions } from '@/__tests__/render';

--- a/packages/frontend/editor-ui/src/features/collaboration/collaboration/components/CollaborationPane.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/collaboration/components/CollaborationPane.vue
@@ -6,8 +6,11 @@ import { useUsersStore } from '@/features/settings/users/users.store';
 import { useCollaborationStore } from '../collaboration.store';
 
 import { N8nUserStack } from '@n8n/design-system';
+import { useWorkflowId } from '@/app/composables/useWorkflowId';
+
 const collaborationStore = useCollaborationStore();
 const usersStore = useUsersStore();
+const workflowId = useWorkflowId();
 
 const visibility = useDocumentVisibility();
 watch(visibility, (visibilityState) => {
@@ -32,7 +35,7 @@ const collaboratorsSorted = computed(() => {
 const currentUserEmail = computed(() => usersStore.currentUser?.email);
 
 onMounted(() => {
-	void collaborationStore.initialize();
+	void collaborationStore.initialize(workflowId.value);
 });
 
 onBeforeUnmount(() => {

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/error/NodeErrorView.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/error/NodeErrorView.vue
@@ -453,6 +453,7 @@ async function onAskAssistantClick() {
 		source: 'error',
 		task: 'error',
 		has_existing_session: false,
+		workflowId: workflowId.value,
 	});
 }
 </script>

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsInvalidNodeWarning.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsInvalidNodeWarning.test.ts
@@ -22,6 +22,16 @@ vi.mock('@/app/composables/useTelemetry', () => ({
 		track: vi.fn(),
 	}),
 }));
+vi.mock('vue-router', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('vue-router')>();
+	return {
+		...actual,
+		useRoute: () => ({
+			name: 'NodeView',
+			params: { workflowId: 'test-workflow-id' },
+		}),
+	};
+});
 
 const mockInstallNode = vi.fn();
 const mockUseInstallNode = useInstallNode as MockedFunction<typeof useInstallNode>;
@@ -110,7 +120,7 @@ describe('NodeSettingsInvalidNodeWarning', () => {
 			const viewDetailsButton = getByRole('button', { name: 'View details' });
 			viewDetailsButton.click();
 
-			expect(mockOpenNodeCreatorWithNode).toHaveBeenCalledWith('Test Node');
+			expect(mockOpenNodeCreatorWithNode).toHaveBeenCalledWith('test-workflow-id', 'Test Node');
 		});
 
 		it('should open NPM page when node is not verified community node', async () => {

--- a/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsInvalidNodeWarning.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/settings/components/NodeSettingsInvalidNodeWarning.vue
@@ -17,6 +17,7 @@ import { I18nT } from 'vue-i18n';
 import ContactAdministratorToInstall from '@/features/settings/communityNodes/components/ContactAdministratorToInstall.vue';
 import { removePreviewToken } from '@/features/shared/nodeCreator/nodeCreator.utils';
 import { useQuickConnect } from '@/features/credentials/quickConnect/composables/useQuickConnect';
+import { useWorkflowId } from '@/app/composables/useWorkflowId';
 
 const { node, previewMode = false } = defineProps<{ node: INodeUi; previewMode?: boolean }>();
 
@@ -27,6 +28,7 @@ const uiStore = useUIStore();
 const ndvStore = injectNDVStore();
 const nodeCreatorStore = useNodeCreatorStore();
 const usersStore = useUsersStore();
+const workflowId = useWorkflowId();
 
 const isCommunityNode = computed(() => isCommunityPackageName(node.type));
 const isVerifiedCommunityNode = computed(
@@ -50,7 +52,7 @@ async function onViewDetailsClick() {
 		node_type: node.type,
 	});
 	if (isVerifiedCommunityNode.value) {
-		await nodeCreatorStore.openNodeCreatorWithNode(node.name);
+		await nodeCreatorStore.openNodeCreatorWithNode(workflowId.value, node.name);
 	} else if (npmPackage.value) {
 		window.open(`https://www.npmjs.com/package/${npmPackage.value}`, '_blank');
 	}

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.store.test.ts
@@ -328,6 +328,7 @@ describe('useNodeCreatorStore', () => {
 			nodeCreatorStore.openNodeCreatorForConnectingNode({
 				connection,
 				eventSource: 'plus_endpoint',
+				workflowId: 'test-wf-id',
 			});
 
 			expect(nodeCreatorStore.selectedView).toEqual(AI_UNCATEGORIZED_CATEGORY);
@@ -349,6 +350,7 @@ describe('useNodeCreatorStore', () => {
 				connection,
 				eventSource: 'plus_endpoint',
 				nodeCreatorView: REGULAR_NODE_CREATOR_VIEW,
+				workflowId: 'test-wf-id',
 			});
 
 			expect(nodeCreatorStore.selectedView).toEqual(REGULAR_NODE_CREATOR_VIEW);
@@ -370,6 +372,7 @@ describe('useNodeCreatorStore', () => {
 				connection,
 				eventSource: 'plus_endpoint',
 				nodeCreatorView: REGULAR_NODE_CREATOR_VIEW,
+				workflowId: 'test-wf-id',
 			});
 
 			expect(nodeCreatorStore.selectedView).toEqual(REGULAR_NODE_CREATOR_VIEW);
@@ -385,6 +388,7 @@ describe('useNodeCreatorStore', () => {
 				connection,
 				eventSource: 'plus_endpoint',
 				nodeCreatorView: REGULAR_NODE_CREATOR_VIEW,
+				workflowId: 'test-wf-id',
 			});
 
 			expect(nodeCreatorStore.selectedView).not.toEqual(REGULAR_NODE_CREATOR_VIEW);
@@ -434,7 +438,7 @@ describe('useNodeCreatorStore', () => {
 			mockUseNodeTypesStore.getNodeType = vi.fn();
 			mockUseNodeTypesStore.communityNodeType = vi.fn();
 
-			await nodeCreatorStore.openNodeCreatorWithNode(nodeName);
+			await nodeCreatorStore.openNodeCreatorWithNode('test-wf-id', nodeName);
 
 			expect(mockUseNDVStore.unsetActiveNodeName).not.toHaveBeenCalled();
 			expect(mockUseNodeTypesStore.getNodeType).not.toHaveBeenCalled();
@@ -450,7 +454,7 @@ describe('useNodeCreatorStore', () => {
 			mockUseNodeTypesStore.getNodeType = vi.fn(() => null);
 			mockUseNodeTypesStore.communityNodeType = vi.fn(() => undefined);
 
-			await nodeCreatorStore.openNodeCreatorWithNode(nodeName);
+			await nodeCreatorStore.openNodeCreatorWithNode('test-wf-id', nodeName);
 
 			expect(mockUseNDVStore.unsetActiveNodeName).toHaveBeenCalled();
 			expect(mockUseNodeTypesStore.getNodeType).toHaveBeenCalledWith('test-type');
@@ -476,7 +480,7 @@ describe('useNodeCreatorStore', () => {
 				],
 			} as ActionsRecord<SimplifiedNodeType[]>;
 
-			await nodeCreatorStore.openNodeCreatorWithNode(nodeName);
+			await nodeCreatorStore.openNodeCreatorWithNode('test-wf-id', nodeName);
 			expect(mockUseNDVStore.unsetActiveNodeName).toHaveBeenCalled();
 			expect(mockUseNodeTypesStore.getNodeType).toHaveBeenCalledWith('test-type');
 			expect(nodeCreatorStore.isCreateNodeActive).toBe(true);
@@ -524,7 +528,7 @@ describe('useNodeCreatorStore', () => {
 				[nodeType.name]: [],
 			};
 
-			await nodeCreatorStore.openNodeCreatorWithNode(nodeName);
+			await nodeCreatorStore.openNodeCreatorWithNode('test-wf-id', nodeName);
 
 			expect(mockUseNDVStore.unsetActiveNodeName).toHaveBeenCalled();
 			expect(mockUseNodeTypesStore.getNodeType).toHaveBeenCalledWith('test-type');
@@ -562,7 +566,7 @@ describe('useNodeCreatorStore', () => {
 
 			nodeCreatorStore.actions = {};
 
-			await nodeCreatorStore.openNodeCreatorWithNode(nodeName);
+			await nodeCreatorStore.openNodeCreatorWithNode('test-wf-id', nodeName);
 
 			expect(mockedPrepareCommunityNodeDetailsViewStack).toHaveBeenCalledWith(
 				{

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.store.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/nodeCreator.store.ts
@@ -22,8 +22,6 @@ import { useExternalHooks } from '@/app/composables/useExternalHooks';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useUIStore } from '@/app/stores/ui.store';
-import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import type { TelemetryNdvType } from '@/app/types/telemetry';
 import { getNodeIconSource } from '@/app/utils/nodeIcon';
 import { isVueFlowConnection } from '@/app/utils/typeGuards';
@@ -42,10 +40,12 @@ import { computed, nextTick, ref } from 'vue';
 import { useGetNodeCreatorFilter } from './composables/useGetNodeCreatorFilter';
 import { useViewStacks } from './composables/useViewStacks';
 import { prepareCommunityNodeDetailsViewStack, transformNodeType } from './nodeCreator.utils';
+import {
+	createWorkflowDocumentId,
+	useWorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
 
 export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
-	const workflowsStore = useWorkflowsStore();
-	const workflowDocumentStore = injectWorkflowDocumentStore();
 	const ndvStore = useNDVStore();
 	const uiStore = useUIStore();
 	const nodeTypesStore = useNodeTypesStore();
@@ -94,15 +94,18 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 		node,
 		creatorView,
 		connectionIndex = 0,
+		workflowId,
 	}: {
 		connectionType: NodeConnectionType;
 		node: string;
 		creatorView?: NodeFilterType;
 		connectionIndex?: number;
+		workflowId: string;
 	}) {
 		const nodeName = node ?? ndvStore.activeNodeName;
 		const nodeData = nodeName
-			? (workflowDocumentStore.value.getNodeByName(nodeName) ?? null)
+			? (useWorkflowDocumentStore(createWorkflowDocumentId(workflowId)).getNodeByName(nodeName) ??
+				null)
 			: null;
 
 		ndvStore.unsetActiveNodeName();
@@ -113,6 +116,7 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 					createNodeActive: true,
 					nodeCreatorView: creatorView,
 					connectionType,
+					workflowId,
 				});
 			} else if (connectionType && nodeData) {
 				openNodeCreatorForConnectingNode({
@@ -125,6 +129,7 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 						}),
 					},
 					eventSource: NODE_CREATOR_OPEN_SOURCES.NOTICE_ERROR_MESSAGE,
+					workflowId,
 				});
 			}
 		});
@@ -135,10 +140,12 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 		createNodeActive,
 		nodeCreatorView,
 		connectionType,
-	}: ToggleNodeCreatorOptions) {
+		workflowId,
+	}: ToggleNodeCreatorOptions & { workflowId: string }) {
 		if (!nodeCreatorView) {
 			nodeCreatorView =
-				workflowDocumentStore.value.workflowTriggerNodes.length > 0
+				useWorkflowDocumentStore(createWorkflowDocumentId(workflowId)).workflowTriggerNodes.length >
+				0
 					? REGULAR_NODE_CREATOR_VIEW
 					: TRIGGER_NODE_CREATOR_VIEW;
 		}
@@ -162,7 +169,7 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 				source,
 				mode: getMode(nodeCreatorView),
 				connectionType,
-				workflow_id: workflowsStore.workflowId,
+				workflow_id: workflowId,
 			});
 		}
 	}
@@ -171,15 +178,19 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 		connection,
 		eventSource,
 		nodeCreatorView,
+		workflowId,
 	}: {
 		connection: PartialBy<Connection, 'target' | 'targetHandle'>;
 		eventSource?: NodeCreatorOpenSource;
 		nodeCreatorView?: NodeFilterType;
+		workflowId: string;
 	}) {
 		// Get the node and set it as active that new nodes
 		// which get created get automatically connected
 		// to it.
-		const sourceNode = workflowDocumentStore.value.getNodeById(connection.source);
+		const sourceNode = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId)).getNodeById(
+			connection.source,
+		);
 		if (!sourceNode) {
 			return;
 		}
@@ -202,6 +213,7 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 			createNodeActive: true,
 			nodeCreatorView: view,
 			connectionType: type,
+			workflowId,
 		});
 
 		// TODO: The animation is a bit glitchy because we're updating view stack immediately
@@ -217,10 +229,9 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 		}
 	}
 
-	async function openNodeCreatorWithNode(nodeName: string) {
-		const nodeData = nodeName
-			? (workflowDocumentStore.value.getNodeByName(nodeName) ?? null)
-			: null;
+	async function openNodeCreatorWithNode(workflowId: string, nodeName: string) {
+		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+		const nodeData = nodeName ? (workflowDocumentStore.getNodeByName(nodeName) ?? null) : null;
 		if (!nodeData) {
 			return;
 		}
@@ -232,6 +243,7 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 			return;
 		}
 		setNodeCreatorState({
+			workflowId,
 			createNodeActive: true,
 		});
 		// wait for the node creator state to be set
@@ -244,34 +256,40 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 				type: 'node',
 				subcategory: '*',
 			},
-			getNodeIconSource(nodeType.name, null, workflowDocumentStore.value.getExpressionHandler()),
+			getNodeIconSource(nodeType.name, null, workflowDocumentStore.getExpressionHandler()),
 			'Regular',
 			nodeActions ?? [],
 		);
 		useViewStacks().pushViewStack(viewStack, { resetStacks: true });
 	}
 
-	function openNodeCreatorForTriggerNodes(source: NodeCreatorOpenSource) {
+	function openNodeCreatorForTriggerNodes(workflowId: string, source: NodeCreatorOpenSource) {
 		ndvStore.unsetActiveNodeName();
 		setSelectedView(TRIGGER_NODE_CREATOR_VIEW);
 		setNodeCreatorState({
+			workflowId,
 			source,
 			createNodeActive: true,
 			nodeCreatorView: TRIGGER_NODE_CREATOR_VIEW,
 		});
 	}
 
-	function openNodeCreatorForRegularNodes(source: NodeCreatorOpenSource) {
+	function openNodeCreatorForRegularNodes(workflowId: string, source: NodeCreatorOpenSource) {
 		ndvStore.unsetActiveNodeName();
 		setSelectedView(REGULAR_NODE_CREATOR_VIEW);
 		setNodeCreatorState({
+			workflowId,
 			source,
 			createNodeActive: true,
 			nodeCreatorView: REGULAR_NODE_CREATOR_VIEW,
 		});
 	}
 
-	function openNodeCreatorForActions(node: string, eventSource?: NodeCreatorOpenSource) {
+	function openNodeCreatorForActions(
+		workflowId: string,
+		node: string,
+		eventSource?: NodeCreatorOpenSource,
+	) {
 		const actionNode = allNodeCreatorNodes.value.find((i) => i.key === node);
 
 		if (!actionNode) {
@@ -287,6 +305,7 @@ export const useNodeCreatorStore = defineStore(STORES.NODE_CREATOR, () => {
 		ndvStore.unsetActiveNodeName();
 		setSelectedView(REGULAR_NODE_CREATOR_VIEW);
 		setNodeCreatorState({
+			workflowId,
 			source: eventSource,
 			createNodeActive: true,
 			nodeCreatorView: REGULAR_NODE_CREATOR_VIEW,

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/NodeCreation.vue
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/views/NodeCreation.vue
@@ -27,6 +27,7 @@ import { useChatPanelStore } from '@/features/ai/assistant/chatPanel.store';
 
 import { N8nAssistantIcon, N8nButton, N8nIconButton, N8nTooltip } from '@n8n/design-system';
 import { useSetupPanelStore } from '@/features/setupPanel/setupPanel.store';
+import { useWorkflowId } from '@/app/composables/useWorkflowId';
 
 type Props = {
 	nodeViewScale: number;
@@ -57,6 +58,7 @@ const telemetry = useTelemetry();
 const assistantStore = useAssistantStore();
 const builderStore = useBuilderStore();
 const chatPanelStore = useChatPanelStore();
+const workflowId = useWorkflowId();
 
 const { getAddedNodesAndConnections } = useActions();
 const { shouldShowCoachmark, onDismissCoachmark } = useNodeCreatorShortcutCoachmark();
@@ -125,6 +127,7 @@ async function onAskAssistantButtonClick() {
 			source: 'canvas',
 			task: 'placeholder',
 			has_existing_session: !assistantStore.isSessionEnded,
+			workflowId: workflowId.value,
 		});
 	}
 }

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeAddNodes.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeAddNodes.vue
@@ -13,12 +13,15 @@ import { useI18n } from '@n8n/i18n';
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue';
 import { useRouter } from 'vue-router';
 import { N8nIcon, N8nLink, N8nTooltip } from '@n8n/design-system';
+import { useWorkflowId } from '@/app/composables/useWorkflowId';
+
 const nodeCreatorStore = useNodeCreatorStore();
 const i18n = useI18n();
 const settingsStore = useSettingsStore();
 const templatesStore = useTemplatesStore();
 const router = useRouter();
 const isTooltipVisible = ref(false);
+const workflowId = useWorkflowId();
 
 const templatesLinkEnabled = computed(() => {
 	return isExtraTemplateLinksExperimentEnabled() && settingsStore.isTemplatesEnabled;
@@ -44,6 +47,7 @@ function onHideTooltip() {
 
 function onClick() {
 	nodeCreatorStore.openNodeCreatorForTriggerNodes(
+		workflowId.value,
 		NODE_CREATOR_OPEN_SOURCES.TRIGGER_PLACEHOLDER_BUTTON,
 	);
 }

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeChoicePrompt.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeChoicePrompt.vue
@@ -14,6 +14,7 @@ import { computed } from 'vue';
 import { useRouter } from 'vue-router';
 import { N8nIcon, N8nLink } from '@n8n/design-system';
 import { useAssistantStore } from '@/features/ai/assistant/assistant.store';
+import { useWorkflowId } from '@/app/composables/useWorkflowId';
 
 const nodeCreatorStore = useNodeCreatorStore();
 const chatPanelStore = useChatPanelStore();
@@ -22,6 +23,7 @@ const settingsStore = useSettingsStore();
 const templatesStore = useTemplatesStore();
 const router = useRouter();
 const assistantStore = useAssistantStore();
+const workflowId = useWorkflowId();
 
 const isChatWindowOpen = computed(
 	() => chatPanelStore.isOpen && chatPanelStore.isBuilderModeActive,
@@ -36,6 +38,7 @@ const onAddFirstStepClick = () => {
 		nodeCreatorStore.isCreateNodeActive = false;
 	} else {
 		nodeCreatorStore.openNodeCreatorForTriggerNodes(
+			workflowId.value,
 			NODE_CREATOR_OPEN_SOURCES.TRIGGER_PLACEHOLDER_BUTTON,
 		);
 	}
@@ -46,6 +49,7 @@ async function onBuildWithAIClick() {
 		source: 'build_with_ai',
 		task: 'placeholder',
 		has_existing_session: !assistantStore.isSessionEnded,
+		workflowId: workflowId.value,
 	});
 	await chatPanelStore.toggle({ mode: 'builder' });
 }


### PR DESCRIPTION
## Summary

This PR migrates usages of `workflowsStore.workflowId` in other stores to prepare for its eventual removal.

- `ui.store.ts` – Move dependent computed value to a composable
- `assistant.store.ts` `chat.store.ts` `collaboration.store.ts` `nodeCreator.store.ts` – Pass down `workflowId` from components
-  `evaluation.store.ts` – Move dependent computed values into a new composable
- `mcp.store.ts` – Remove unnecessary guard that depends on `workflowsStore.workflowId`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3034/migrate-workflowsstoreworkflowid-usages-in-stores-and-vue-components


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
