### PR TITLE
fix: Allow migration overrides at same timestamp (no-changelog)

### DIFF
--- a/packages/testing/code-health/src/rules/migration-timestamp.rule.test.ts
+++ b/packages/testing/code-health/src/rules/migration-timestamp.rule.test.ts
@@ -193,6 +193,67 @@ describe('MigrationTimestampRule', () => {
 		});
 	});
 
+	describe('dialect overrides', () => {
+		it('allows common/<ts>-<name>.ts paired with sqlite/<ts>-<name>.ts', async () => {
+			// SQLite override pattern: same timestamp + same suffix means same
+			// TypeORM class — the postgres index imports the common version,
+			// the sqlite index imports its own. One logical migration, two
+			// dialect-specific files. Both should be accepted as the head.
+			writeMigration(tmpDir, COMMON_DIR, '1700000000000-Pre-existing.ts');
+			const commonHead = writeMigration(
+				tmpDir,
+				COMMON_DIR,
+				'1777000000000-CreateAgentHistoryTable.ts',
+			);
+			const sqliteOverride = writeMigration(
+				tmpDir,
+				SQLITE_DIR,
+				'1777000000000-CreateAgentHistoryTable.ts',
+			);
+
+			const violations = await rule.analyze(context([commonHead, sqliteOverride]));
+
+			expect(violations).toEqual([]);
+		});
+
+		it('allows common/<ts>-<name>.ts paired with postgresdb/<ts>-<name>.ts', async () => {
+			writeMigration(tmpDir, COMMON_DIR, '1700000000000-Pre-existing.ts');
+			const commonHead = writeMigration(tmpDir, COMMON_DIR, '1777000000000-NewTable.ts');
+			const postgresOverride = writeMigration(tmpDir, POSTGRES_DIR, '1777000000000-NewTable.ts');
+
+			const violations = await rule.analyze(context([commonHead, postgresOverride]));
+
+			expect(violations).toEqual([]);
+		});
+
+		it('still flags two unrelated migrations colliding on the same timestamp', async () => {
+			// Same timestamp + DIFFERENT suffix = genuine collision. Override
+			// pairing must be by filename, not just by timestamp.
+			writeMigration(tmpDir, COMMON_DIR, '1700000000000-Pre-existing.ts');
+			const commonHead = writeMigration(tmpDir, COMMON_DIR, '1777000000000-Foo.ts');
+			const collision = writeMigration(tmpDir, SQLITE_DIR, '1777000000000-Bar.ts');
+
+			const violations = await rule.analyze(context([commonHead, collision]));
+
+			const files = violations.map((v) => path.basename(v.file)).sort();
+			expect(files).toEqual(['1777000000000-Bar.ts', '1777000000000-Foo.ts']);
+		});
+
+		it('still flags a sub-floor override file', async () => {
+			// An override pair below the head is still out of order — the
+			// floor is computed from non-self slots, so the pair shares one
+			// slot at the override timestamp but is still below the head.
+			writeMigration(tmpDir, COMMON_DIR, '1777000000000-Head.ts');
+			const commonLate = writeMigration(tmpDir, COMMON_DIR, '1700000000000-Override.ts');
+			const sqliteLate = writeMigration(tmpDir, SQLITE_DIR, '1700000000000-Override.ts');
+
+			const violations = await rule.analyze(context([commonLate, sqliteLate]));
+
+			const files = violations.map((v) => path.basename(v.file)).sort();
+			expect(files).toEqual(['1700000000000-Override.ts', '1700000000000-Override.ts']);
+		});
+	});
+
 	describe('ceiling configuration', () => {
 		it('respects a custom ceilingBufferMs option', async () => {
 			rule.configure({ options: { now: 1_800_000_000_000, ceilingBufferMs: 10 } });

--- a/packages/testing/code-health/src/rules/migration-timestamp.rule.ts
+++ b/packages/testing/code-health/src/rules/migration-timestamp.rule.ts
@@ -11,7 +11,7 @@ const DEFAULT_MIGRATION_GLOBS = [
 	'packages/@n8n/db/src/migrations/sqlite/*.ts',
 ];
 
-const MIGRATION_FILENAME = /^(\d{10,16})-.+\.ts$/;
+const MIGRATION_FILENAME = /^(\d{10,16})-(.+\.ts)$/;
 
 // Window above the ordering floor in which a new migration timestamp is
 // permitted. 1 second of headroom = 1000 unique slots — plenty for any
@@ -24,6 +24,9 @@ interface ParsedMigration {
 	relativePath: string;
 	fileName: string;
 	timestamp: number;
+	// Slot key groups dialect-override pairs (same timestamp + suffix across
+	// common/ and a dialect dir) into one logical ordering slot.
+	slotKey: string;
 }
 
 export class MigrationTimestampRule extends BaseRule<CodeHealthContext> {
@@ -53,11 +56,13 @@ export class MigrationTimestampRule extends BaseRule<CodeHealthContext> {
 			if (!match) continue;
 			const timestamp = Number(match[1]);
 			if (!Number.isFinite(timestamp)) continue;
+			const suffix = match[2];
 			parsed.push({
 				filePath,
 				relativePath: path.relative(rootDir, filePath),
 				fileName,
 				timestamp,
+				slotKey: `${timestamp}-${suffix}`,
 			});
 		}
 
@@ -74,14 +79,31 @@ export class MigrationTimestampRule extends BaseRule<CodeHealthContext> {
 				? new Set(changedFiles.map((p) => path.normalize(p)))
 				: undefined;
 
-		const sortedDesc = parsed.map((p) => p.timestamp).sort((a, b) => b - a);
-		const globalMax = sortedDesc[0] ?? 0;
-		const secondMax = sortedDesc[1] ?? 0;
+		// Dedupe to ordering slots: a `common/<ts>-<name>.ts` paired with a
+		// `postgresdb|sqlite/<ts>-<name>.ts` override is one logical migration
+		// (same TypeORM class name, only one runs per dialect) and occupies a
+		// single slot. Two files at the same timestamp with *different*
+		// suffixes remain distinct slots and still trip ordering.
+		const slotByKey = new Map<string, { timestamp: number; slotKey: string }>();
+		for (const m of parsed) {
+			if (!slotByKey.has(m.slotKey)) {
+				slotByKey.set(m.slotKey, { timestamp: m.timestamp, slotKey: m.slotKey });
+			}
+		}
+		const slotsDesc = Array.from(slotByKey.values()).sort((a, b) => {
+			if (b.timestamp !== a.timestamp) return b.timestamp - a.timestamp;
+			return a.slotKey.localeCompare(b.slotKey);
+		});
+		const globalMaxSlot = slotsDesc[0];
+		const secondMaxSlot = slotsDesc[1];
+		const globalMax = globalMaxSlot?.timestamp ?? 0;
+		const secondMax = secondMaxSlot?.timestamp ?? 0;
 
 		const violations: Violation[] = [];
 		for (const migration of parsed) {
-			const { filePath, relativePath, fileName, timestamp } = migration;
-			const floor = timestamp === globalMax ? secondMax : globalMax;
+			const { filePath, relativePath, fileName, timestamp, slotKey } = migration;
+			const isHeadSlot = globalMaxSlot?.slotKey === slotKey;
+			const floor = isHeadSlot ? secondMax : globalMax;
 			const ceiling = Math.max(now, floor + ceilingBuffer);
 
 			const isChanged = changedFilesSet?.has(path.normalize(relativePath)) ?? false;


### PR DESCRIPTION
## Summary

The `migration-timestamp` rule in `@n8n/code-health` flagged the dialect-override pattern — a single TypeORM migration class defined in `common/` and overridden in `sqlite/` (or `postgresdb/`) with the **same class name and timestamp** — as an ordering violation. The rule deduplicated by timestamp alone, so two files sharing `<ts>` both registered as the head slot and tripped the `timestamp <= floor` check, even though only one class runs per dialect.

**Fix:** group migrations by `timestamp + filename suffix` (e.g. `1784000000009-CreateAgentHistoryTable.ts`) so override pairs occupy a single ordering slot. Genuine same-timestamp collisions with **different** suffixes are still rejected.

**Verification**

- Vitest: 18/18 pass (14 pre-existing + 4 new dialect-override cases).
- Reproduced the failing CI run from https://github.com/n8n-io/n8n/pull/30828 (job 76995618329) locally: 2 violations before, 0 after.
- Negative case: same timestamp + different filename suffix across dirs still flags both files.
- `pnpm typecheck` and `pnpm lint` clean in `@n8n/code-health`.

**New test cases** (`migration-timestamp.rule.test.ts > dialect overrides`)

1. `common + sqlite` at same `<ts>-<name>.ts` → accepted
2. `common + postgresdb` at same `<ts>-<name>.ts` → accepted
3. `common + sqlite` at same timestamp, **different** name → both flagged
4. Override pair below the head → both flagged (sub-floor ordering preserved)

## How to test

```bash
cd packages/testing/code-health
pnpm test src/rules/migration-timestamp.rule.test.ts
pnpm typecheck
pnpm lint
```

To repro against a real PR-style scenario:

```bash
CODE_HEALTH_CHANGED_FILES="packages/@n8n/db/src/migrations/common/<ts>-Foo.ts
packages/@n8n/db/src/migrations/sqlite/<ts>-Foo.ts" \
  pnpm --filter=@n8n/code-health check
```

## Related Linear tickets, Github issues, and Community forum posts

Surfaced in https://github.com/n8n-io/n8n/pull/30828 (static analysis failure on the `agent_history` migration's SQLite FK-disable override).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)