### PR TITLE
fix(editor): Use i18n heading for insights chart granularity title

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -5285,6 +5285,7 @@
 	"insights.banner.title.timeSaved": "Time saved",
 	"insights.banner.title.timeSavedDailyAverage": "Time saved daily avg.",
 	"insights.banner.title.averageRunTime": "Run time (avg.)",
+	"insights.dashboard.chart.title": "Breakdown by {granularity}",
 	"insights.dashboard.table.projectName": "Project name",
 	"insights.dashboard.table.title": "Breakdown by workflow",
 	"insights.dashboard.table.estimate": "Estimate",

--- a/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.vue
+++ b/packages/frontend/editor-ui/src/features/execution/insights/components/InsightsDashboard.vue
@@ -262,7 +262,9 @@ onBeforeMount(async () => {
 						<span>{{ i18n.baseText('insights.chart.loading') }}</span>
 					</div>
 					<div :class="$style.insightsChartWrapper">
-						{{ granularity }}
+						<N8nHeading bold tag="h3" size="medium" class="mb-s">{{
+							i18n.baseText('insights.dashboard.chart.title', { interpolate: { granularity } })
+						}}</N8nHeading>
 						<component
 							:is="chartComponents[props.insightType]"
 							:type="props.insightType"


### PR DESCRIPTION
## Summary

The insights dashboard chart was displaying a bare granularity value ("day", "hour", or "week") as its title, a debug placeholder left over from #20952. This replaces it with a properly localised heading that renders "Breakdown by day/hour/week", matching the styling of the existing "Breakdown by workflow" table heading.

### Before:
<img width="1472" height="1252" alt="CleanShot 2026-05-20 at 17 57 15@2x" src="https://github.com/user-attachments/assets/ee077cc4-de44-4397-aaca-43d0d28485ff" />

### After:
<img width="1418" height="988" alt="CleanShot 2026-05-20 at 17 58 07@2x" src="https://github.com/user-attachments/assets/9136b7e8-9120-4167-8b0e-9518d6b6dac0" />


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-615

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- ~[ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.~
- ~[ ] Tests included.~ <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] ~PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)~