### PR TITLE
chore: test impact of removing SafeChain from install step (no-changelog)

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -3,7 +3,7 @@
 # GitHub-hosted runners use standard GitHub Actions caching.
 
 name: 'Node.js Build Setup'
-description: 'Configures Node.js with pnpm, installs Aikido SafeChain for supply chain protection, installs dependencies, enables Turborepo caching, (optional) sets up Docker layer caching, and builds the project or an optional command.'
+description: 'Configures Node.js with pnpm, installs dependencies, enables Turborepo caching, (optional) sets up Docker layer caching, and builds the project or an optional command.'
 
 inputs:
   node-version:
@@ -50,29 +50,10 @@ runs:
             mkdir -p "$PNPM_STORE_PATH"
         fi
 
-    - name: Configure SafeChain
-      shell: bash
-      run: |
-        # SafeChain only reads configs from this directory https://github.com/AikidoSec/safe-chain#configuration-options-1
-        mkdir -p "$HOME/.safe-chain"
-        cp "${{ github.action_path }}/safe-chain.config.json" "$HOME/.safe-chain/config.json"
-
-    - name: Install Aikido SafeChain
-      run: |
-        VERSION="1.5.3"
-        EXPECTED_SHA256="0107cbbbf90159379756157e902acae512d62ffbd174307e42c5fe9f266792d3"
-        node .github/scripts/retry.mjs --attempts 3 --delay 10 -- \
-          curl -fsSL -o install-safe-chain.sh "https://github.com/AikidoSec/safe-chain/releases/download/${VERSION}/install-safe-chain.sh"
-        echo "${EXPECTED_SHA256}  install-safe-chain.sh" | sha256sum -c -
-        sh install-safe-chain.sh --ci
-        rm install-safe-chain.sh
-      shell: bash
-
     - name: Install Dependencies
       if: ${{ inputs.install-command != '' }}
       env:
         INSTALL_COMMAND: ${{ inputs.install-command }}
-        SAFE_CHAIN_LOGGING: verbose
       run: |
         timeout --kill-after=30s 300s $INSTALL_COMMAND --reporter=append-only
       shell: bash

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<!-- ci-trigger: setup-nodejs install-time experiment (do not merge) -->
 ![Banner image](https://user-images.githubusercontent.com/10284570/173569848-c624317f-42b1-45a6-ab09-f0ea3c247648.png)
 
 # n8n - Secure Workflow Automation for Technical Teams


### PR DESCRIPTION
## Summary

- Temporarily removes the **Configure SafeChain** + **Install Aikido SafeChain** steps from `.github/actions/setup-nodejs/action.yml`
- Drops `SAFE_CHAIN_LOGGING` from the **Install Dependencies** step env
- Purely to measure SafeChain's impact on install time — install duration jumped from ~10s to ~30s after SafeChain was introduced

**Not for merge.** This PR exists so we can compare CI install timings against `master` runs that still include SafeChain.

## What to compare

Look at the `Install Dependencies` step:
```
Run timeout --kill-after=30s 300s $INSTALL_COMMAND --reporter=append-only
```
…and the surrounding `Configure Turborepo Cache` step (`rharkor/caching-for-turbo@5d14fba`) across a handful of jobs vs. recent `master` runs.

## Test plan

- [ ] Wait for CI to complete on this PR
- [ ] Compare `Install Dependencies` step duration on this branch vs. a recent master run
- [ ] Capture findings, then close without merging (or revert before any accidental merge)