### PR TITLE
feat(core): Add agent debug APIs

### DIFF
--- a/packages/cli/src/modules/agents/__tests__/agent-debug.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-debug.controller.test.ts
@@ -1,0 +1,28 @@
+import { ControllerRegistryMetadata } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+
+import { AgentDebugController } from '../agent-debug.controller';
+
+const metadata = Container.get(ControllerRegistryMetadata).getControllerMetadata(
+	AgentDebugController as never,
+);
+
+const routeCases = Array.from(metadata.routes.entries()).map(([handlerName, route]) => ({
+	handlerName,
+	route,
+}));
+
+const writeHandlers = new Set(['upsertRunReview', 'deleteRunReview']);
+
+describe('AgentDebugController route access scopes', () => {
+	it.each(routeCases)(
+		'$handlerName is gated by the expected project-scoped agent check',
+		({ handlerName, route }) => {
+			expect(route.accessScope).toBeDefined();
+			expect(route.accessScope?.globalOnly).toBe(false);
+			expect(route.accessScope?.scope).toBe(
+				writeHandlers.has(handlerName) ? 'agent:update' : 'agent:read',
+			);
+		},
+	);
+});

--- a/packages/cli/src/modules/agents/__tests__/agent-debug.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-debug.service.test.ts
@@ -1,0 +1,439 @@
+import {
+	DEFAULT_AGENT_REVIEW_REJECTION_REASON,
+	type UpsertAgentReviewCaseDto,
+} from '@n8n/api-types';
+import { mock } from 'jest-mock-extended';
+
+import { AgentDebugService, computeAgentDebugSignals } from '../agent-debug.service';
+import type { AgentEvaluationCase } from '../entities/agent-evaluation-case.entity';
+import type { AgentExecution } from '../entities/agent-execution.entity';
+import type { AgentExecutionThread } from '../entities/agent-execution-thread.entity';
+import type { AgentEvaluationCaseRepository } from '../repositories/agent-evaluation-case.repository';
+import type { AgentExecutionRepository } from '../repositories/agent-execution.repository';
+import type { AgentRepository } from '../repositories/agent.repository';
+
+type SignalInput = Parameters<typeof computeAgentDebugSignals>[0];
+
+const baseExecution = {
+	status: 'success',
+	duration: 1200,
+	cost: null,
+	totalTokens: null,
+	timeline: null,
+	toolCalls: null,
+	hitlStatus: null,
+	assistantResponse: 'Done',
+	error: null,
+} satisfies SignalInput;
+
+describe('computeAgentDebugSignals', () => {
+	it('flags failed runs, slow runs, high-cost runs, and empty responses', () => {
+		const signals = computeAgentDebugSignals({
+			...baseExecution,
+			status: 'error',
+			duration: 45_000,
+			cost: 0.2,
+			assistantResponse: '',
+			error: 'Model request failed',
+		});
+
+		expect(signals.map((signal) => signal.type)).toEqual(['failed_run', 'slow_run', 'high_cost']);
+		expect(signals[0].description).toBe('Model request failed');
+	});
+
+	it('flags failed and empty tool outputs from timeline events', () => {
+		const signals = computeAgentDebugSignals({
+			...baseExecution,
+			timeline: [
+				{
+					type: 'tool-call',
+					kind: 'tool',
+					name: 'search',
+					toolCallId: 'tool-1',
+					input: {},
+					output: { error: 'Unavailable' },
+					startTime: 1,
+					endTime: 2,
+					success: false,
+				},
+				{
+					type: 'tool-call',
+					kind: 'tool',
+					name: 'lookup',
+					toolCallId: 'tool-2',
+					input: {},
+					output: '',
+					startTime: 3,
+					endTime: 4,
+					success: true,
+				},
+			],
+		} satisfies SignalInput);
+
+		expect(signals).toEqual([
+			expect.objectContaining({ type: 'tool_failure', count: 1 }),
+			expect.objectContaining({ type: 'empty_tool_output', count: 1 }),
+		]);
+	});
+
+	it('uses recorded tool calls for empty output only when timeline tool calls are absent', () => {
+		const toolCalls: AgentExecution['toolCalls'] = [
+			{ name: 'lookup', input: {}, output: null },
+			{ name: 'search', input: {}, output: ['result'] },
+		];
+
+		const signals = computeAgentDebugSignals({
+			...baseExecution,
+			toolCalls,
+		});
+
+		expect(signals).toEqual([expect.objectContaining({ type: 'empty_tool_output', count: 1 })]);
+	});
+
+	it('flags human input handoff from status or suspension events', () => {
+		const statusSignals = computeAgentDebugSignals({
+			...baseExecution,
+			hitlStatus: 'suspended',
+		});
+		const timelineSignals = computeAgentDebugSignals({
+			...baseExecution,
+			timeline: [{ type: 'suspension', toolName: 'approval', toolCallId: 'tool-1', timestamp: 1 }],
+		});
+
+		expect(statusSignals.map((signal) => signal.type)).toContain('human_input_required');
+		expect(timelineSignals.map((signal) => signal.type)).toContain('human_input_required');
+	});
+});
+
+describe('AgentDebugService', () => {
+	const now = new Date('2026-05-18T12:00:00.000Z');
+	let agentExecutionRepository: jest.Mocked<AgentExecutionRepository>;
+	let agentEvaluationCaseRepository: jest.Mocked<AgentEvaluationCaseRepository>;
+	let agentRepository: jest.Mocked<AgentRepository>;
+	let service: AgentDebugService;
+
+	beforeEach(() => {
+		agentExecutionRepository = mock<AgentExecutionRepository>();
+		agentEvaluationCaseRepository = mock<AgentEvaluationCaseRepository>();
+		agentRepository = mock<AgentRepository>();
+		agentRepository.findByIdAndProjectId.mockResolvedValue({
+			id: 'agent-1',
+			versionId: 'version-1',
+			updatedAt: now,
+		} as never);
+		service = new AgentDebugService(
+			agentExecutionRepository,
+			agentEvaluationCaseRepository,
+			agentRepository,
+		);
+	});
+
+	function executionFixture(): AgentExecution & { thread: AgentExecutionThread } {
+		return {
+			id: 'execution-1',
+			threadId: 'thread-1',
+			agentVersionId: 'version-1',
+			thread: {
+				id: 'thread-1',
+				agentId: 'agent-1',
+				agentName: 'Support agent',
+				projectId: 'project-1',
+				sessionNumber: 7,
+				totalPromptTokens: 0,
+				totalCompletionTokens: 0,
+				totalCost: 0,
+				totalDuration: 0,
+				title: 'Support session',
+				emoji: null,
+				createdAt: now,
+				updatedAt: now,
+			},
+			status: 'success',
+			startedAt: now,
+			stoppedAt: now,
+			duration: 1200,
+			userMessage: 'Can you summarize this?',
+			assistantResponse: 'Summary',
+			model: 'gpt-test',
+			promptTokens: 12,
+			completionTokens: 8,
+			totalTokens: 20,
+			cost: 0.001,
+			toolCalls: null,
+			timeline: null,
+			error: null,
+			hitlStatus: null,
+			workingMemory: null,
+			source: 'chat',
+			createdAt: now,
+			updatedAt: now,
+		} as unknown as AgentExecution & { thread: AgentExecutionThread };
+	}
+
+	function mockRunLookup(execution: (AgentExecution & { thread: AgentExecutionThread }) | null) {
+		const queryBuilder = {
+			innerJoinAndSelect: jest.fn().mockReturnThis(),
+			select: jest.fn().mockReturnThis(),
+			addSelect: jest.fn().mockReturnThis(),
+			where: jest.fn().mockReturnThis(),
+			getOne: jest.fn().mockResolvedValue(execution),
+		};
+
+		agentExecutionRepository.createQueryBuilder.mockReturnValue(queryBuilder as never);
+		return queryBuilder;
+	}
+
+	function reviewFixture(overrides: Partial<AgentEvaluationCase> = {}): AgentEvaluationCase {
+		return {
+			id: 'review-1',
+			projectId: 'project-1',
+			agentId: 'agent-1',
+			agentVersionId: 'version-1',
+			conversationId: 'thread-1',
+			executionId: 'execution-1',
+			status: 'approved',
+			rejectionReason: null,
+			toolCallCorrection: null,
+			input: 'Question',
+			expectedOutput: 'Expected answer',
+			actualOutput: 'Actual answer',
+			notes: null,
+			createdById: 'user-1',
+			updatedById: 'user-1',
+			createdAt: now,
+			updatedAt: now,
+			...overrides,
+		} as AgentEvaluationCase;
+	}
+
+	it('lists review cases with summary and pagination', async () => {
+		const updatedAt = new Date('2026-05-18T12:00:00.000Z');
+		const nextUpdatedAt = new Date('2026-05-18T11:00:00.000Z');
+		agentEvaluationCaseRepository.findByAgent.mockResolvedValue([
+			reviewFixture({ updatedAt }),
+			reviewFixture({
+				id: 'review-2',
+				executionId: 'execution-2',
+				status: 'rejected',
+				updatedAt: nextUpdatedAt,
+			}),
+		]);
+		agentEvaluationCaseRepository.countByStatus.mockResolvedValue({
+			total: 2,
+			approved: 1,
+			rejected: 1,
+		});
+
+		const response = await service.listReviewCases('project-1', 'agent-1', 1);
+
+		expect(agentEvaluationCaseRepository.findByAgent).toHaveBeenCalledWith(
+			'project-1',
+			'agent-1',
+			2,
+			undefined,
+		);
+		expect(response).toEqual({
+			cases: [
+				expect.objectContaining({
+					id: 'review-1',
+					status: 'approved',
+					updatedAt: updatedAt.toISOString(),
+				}),
+			],
+			summary: { total: 2, approved: 1, rejected: 1 },
+			nextCursor: updatedAt.toISOString(),
+		});
+	});
+
+	it('creates a review case from an existing run', async () => {
+		const execution = executionFixture();
+		const queryBuilder = mockRunLookup(execution);
+		agentEvaluationCaseRepository.findByExecutionId.mockResolvedValue(null);
+		agentEvaluationCaseRepository.create.mockReturnValue({
+			id: 'review-1',
+			projectId: 'project-1',
+			agentId: 'agent-1',
+			agentVersionId: 'version-1',
+			conversationId: 'thread-1',
+			executionId: 'execution-1',
+			status: 'approved',
+			rejectionReason: null,
+			toolCallCorrection: null,
+			input: execution.userMessage,
+			expectedOutput: '',
+			actualOutput: '',
+			notes: null,
+			createdById: 'user-1',
+			updatedById: null,
+			createdAt: now,
+			updatedAt: now,
+		} as AgentEvaluationCase);
+		agentEvaluationCaseRepository.save.mockImplementation(
+			async (review) =>
+				({
+					...review,
+					id: 'review-1',
+					createdAt: now,
+					updatedAt: now,
+				}) as AgentEvaluationCase,
+		);
+
+		const payload: UpsertAgentReviewCaseDto = {
+			status: 'approved',
+			expectedOutput: 'Expected summary',
+			notes: ' Looks good ',
+		};
+
+		const review = await service.upsertRunReview(
+			'project-1',
+			'agent-1',
+			'execution-1',
+			payload,
+			'user-1',
+		);
+
+		expect(agentEvaluationCaseRepository.save).toHaveBeenCalledWith(
+			expect.objectContaining({
+				projectId: 'project-1',
+				agentId: 'agent-1',
+				agentVersionId: 'version-1',
+				conversationId: 'thread-1',
+				executionId: 'execution-1',
+				status: 'approved',
+				rejectionReason: null,
+				toolCallCorrection: null,
+				input: execution.userMessage,
+				expectedOutput: 'Expected summary',
+				actualOutput: execution.assistantResponse,
+				notes: 'Looks good',
+				createdById: 'user-1',
+				updatedById: 'user-1',
+			}),
+		);
+		const selectedExecutionColumns = queryBuilder.select.mock.calls[0][0] as string[];
+		expect(selectedExecutionColumns).not.toContain('execution.workingMemory');
+		expect(review).toEqual(
+			expect.objectContaining({
+				id: 'review-1',
+				status: 'approved',
+				rejectionReason: null,
+				expectedOutput: 'Expected summary',
+				actualOutput: execution.assistantResponse,
+				createdAt: now.toISOString(),
+			}),
+		);
+	});
+
+	it('stores a rejection reason for rejected review cases', async () => {
+		const execution = executionFixture();
+		mockRunLookup(execution);
+		agentEvaluationCaseRepository.findByExecutionId.mockResolvedValue(null);
+		agentEvaluationCaseRepository.create.mockReturnValue({
+			id: 'review-1',
+			projectId: 'project-1',
+			agentId: 'agent-1',
+			agentVersionId: 'version-1',
+			conversationId: 'thread-1',
+			executionId: 'execution-1',
+			status: 'approved',
+			rejectionReason: null,
+			toolCallCorrection: null,
+			input: execution.userMessage,
+			expectedOutput: '',
+			actualOutput: '',
+			notes: null,
+			createdById: 'user-1',
+			updatedById: null,
+			createdAt: now,
+			updatedAt: now,
+		} as AgentEvaluationCase);
+		agentEvaluationCaseRepository.save.mockImplementation(
+			async (review) =>
+				({
+					...review,
+					id: 'review-1',
+					createdAt: now,
+					updatedAt: now,
+				}) as AgentEvaluationCase,
+		);
+
+		const review = await service.upsertRunReview(
+			'project-1',
+			'agent-1',
+			'execution-1',
+			{
+				status: 'rejected',
+				rejectionReason: 'wrong_tool_calling',
+				toolCallCorrection: {
+					removeToolCalls: [{ id: 'tool-1', name: 'search' }],
+					addToolNames: ['lookup'],
+				},
+			},
+			'user-1',
+		);
+
+		expect(agentEvaluationCaseRepository.save).toHaveBeenCalledWith(
+			expect.objectContaining({
+				status: 'rejected',
+				rejectionReason: 'wrong_tool_calling',
+				toolCallCorrection: {
+					removeToolCalls: [{ id: 'tool-1', name: 'search' }],
+					addToolNames: ['lookup'],
+				},
+			}),
+		);
+		expect(review).toEqual(
+			expect.objectContaining({
+				status: 'rejected',
+				rejectionReason: 'wrong_tool_calling',
+				toolCallCorrection: {
+					removeToolCalls: [{ id: 'tool-1', name: 'search' }],
+					addToolNames: ['lookup'],
+				},
+			}),
+		);
+	});
+
+	it('defaults missing rejection reasons for rejected review cases', async () => {
+		const execution = executionFixture();
+		mockRunLookup(execution);
+		agentEvaluationCaseRepository.findByExecutionId.mockResolvedValue(reviewFixture());
+		agentEvaluationCaseRepository.save.mockImplementation(
+			async (review) =>
+				({
+					...review,
+					updatedAt: now,
+				}) as AgentEvaluationCase,
+		);
+
+		await service.upsertRunReview(
+			'project-1',
+			'agent-1',
+			'execution-1',
+			{ status: 'rejected' },
+			'user-1',
+		);
+
+		expect(agentEvaluationCaseRepository.save).toHaveBeenCalledWith(
+			expect.objectContaining({
+				status: 'rejected',
+				rejectionReason: DEFAULT_AGENT_REVIEW_REJECTION_REASON,
+			}),
+		);
+	});
+
+	it('does not create a review case for a run outside the agent project', async () => {
+		mockRunLookup(null);
+
+		const review = await service.upsertRunReview(
+			'project-1',
+			'agent-1',
+			'execution-1',
+			{ status: 'rejected' },
+			'user-1',
+		);
+
+		expect(review).toBeNull();
+		expect(agentEvaluationCaseRepository.save).not.toHaveBeenCalled();
+	});
+});

--- a/packages/cli/src/modules/agents/agent-debug.controller.ts
+++ b/packages/cli/src/modules/agents/agent-debug.controller.ts
@@ -1,0 +1,109 @@
+import { UpsertAgentReviewCaseDto } from '@n8n/api-types';
+import { Body, Delete, Get, ProjectScope, Put, RestController } from '@n8n/decorators';
+import type { AuthenticatedRequest } from '@n8n/db';
+
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+
+import { AgentDebugService } from './agent-debug.service';
+
+@RestController('/projects/:projectId/agents/v2/:agentId/debug')
+export class AgentDebugController {
+	constructor(private readonly agentDebugService: AgentDebugService) {}
+
+	@Get('/runs')
+	@ProjectScope('agent:read')
+	async listRuns(
+		req: AuthenticatedRequest<
+			{ projectId: string; agentId: string },
+			{},
+			{},
+			{ cursor?: string; limit?: string; agentVersionId?: string }
+		>,
+	) {
+		const limit = Number(req.query.limit) || undefined;
+		return await this.agentDebugService.listRuns(
+			req.params.projectId,
+			req.params.agentId,
+			limit,
+			req.query.cursor,
+			req.query.agentVersionId,
+		);
+	}
+
+	@Get('/runs/:executionId')
+	@ProjectScope('agent:read')
+	async getRun(
+		req: AuthenticatedRequest<{ projectId: string; agentId: string; executionId: string }>,
+	) {
+		const run = await this.agentDebugService.getRunDetail(
+			req.params.projectId,
+			req.params.agentId,
+			req.params.executionId,
+		);
+		if (!run) {
+			throw new NotFoundError(`Agent execution "${req.params.executionId}" not found`);
+		}
+		return run;
+	}
+
+	@Get('/insights')
+	@ProjectScope('agent:read')
+	async getInsights(req: AuthenticatedRequest<{ projectId: string; agentId: string }>) {
+		return await this.agentDebugService.getInsights(req.params.projectId, req.params.agentId);
+	}
+
+	@Get('/reviews')
+	@ProjectScope('agent:read')
+	async listReviewCases(
+		req: AuthenticatedRequest<
+			{ projectId: string; agentId: string },
+			{},
+			{},
+			{ cursor?: string; limit?: string }
+		>,
+	) {
+		const limit = Number(req.query.limit) || undefined;
+		return await this.agentDebugService.listReviewCases(
+			req.params.projectId,
+			req.params.agentId,
+			limit,
+			req.query.cursor,
+		);
+	}
+
+	@Put('/runs/:executionId/review')
+	@ProjectScope('agent:update')
+	async upsertRunReview(
+		req: AuthenticatedRequest<{ projectId: string; agentId: string; executionId: string }>,
+		_res: unknown,
+		@Body payload: UpsertAgentReviewCaseDto,
+	) {
+		const review = await this.agentDebugService.upsertRunReview(
+			req.params.projectId,
+			req.params.agentId,
+			req.params.executionId,
+			payload,
+			req.user.id,
+		);
+		if (!review) {
+			throw new NotFoundError(`Agent execution "${req.params.executionId}" not found`);
+		}
+		return review;
+	}
+
+	@Delete('/runs/:executionId/review')
+	@ProjectScope('agent:update')
+	async deleteRunReview(
+		req: AuthenticatedRequest<{ projectId: string; agentId: string; executionId: string }>,
+	) {
+		const deleted = await this.agentDebugService.deleteRunReview(
+			req.params.projectId,
+			req.params.agentId,
+			req.params.executionId,
+		);
+		if (!deleted) {
+			throw new NotFoundError(`Agent execution "${req.params.executionId}" not found`);
+		}
+		return { ok: true };
+	}
+}

--- a/packages/cli/src/modules/agents/agent-debug.service.ts
+++ b/packages/cli/src/modules/agents/agent-debug.service.ts
@@ -1,0 +1,518 @@
+import {
+	DEFAULT_AGENT_REVIEW_REJECTION_REASON,
+	type AgentDebugInsight,
+	type AgentDebugInsightsResponse,
+	type AgentDebugRun,
+	type AgentDebugRunDetail,
+	type AgentDebugRunsResponse,
+	type AgentDebugRunVersionSummary,
+	type AgentDebugSignal,
+	type AgentDebugSignalType,
+	type AgentReviewCase,
+	type AgentReviewCasesResponse,
+	type UpsertAgentReviewCaseDto,
+} from '@n8n/api-types';
+import { Service } from '@n8n/di';
+
+import type { AgentEvaluationCase } from './entities/agent-evaluation-case.entity';
+import type { AgentExecution } from './entities/agent-execution.entity';
+import type { AgentExecutionThread } from './entities/agent-execution-thread.entity';
+import type { TimelineEvent } from './execution-recorder';
+import { AgentEvaluationCaseRepository } from './repositories/agent-evaluation-case.repository';
+import { AgentExecutionRepository } from './repositories/agent-execution.repository';
+import { AgentRepository } from './repositories/agent.repository';
+
+const DEFAULT_RUNS_LIMIT = 20;
+const MAX_RUNS_LIMIT = 100;
+const DEFAULT_REVIEW_CASES_LIMIT = 20;
+const MAX_REVIEW_CASES_LIMIT = 100;
+const INSIGHTS_RUN_LIMIT = 200;
+const SLOW_RUN_MS = 30_000;
+const HIGH_COST_USD = 0.1;
+const HIGH_TOKEN_COUNT = 10_000;
+const AGENT_EXECUTION_DEBUG_COLUMNS = [
+	'execution.id',
+	'execution.threadId',
+	'execution.agentVersionId',
+	'execution.status',
+	'execution.startedAt',
+	'execution.stoppedAt',
+	'execution.duration',
+	'execution.userMessage',
+	'execution.assistantResponse',
+	'execution.model',
+	'execution.promptTokens',
+	'execution.completionTokens',
+	'execution.totalTokens',
+	'execution.cost',
+	'execution.toolCalls',
+	'execution.timeline',
+	'execution.error',
+	'execution.hitlStatus',
+	'execution.source',
+	'execution.createdAt',
+	'execution.updatedAt',
+];
+const AGENT_EXECUTION_THREAD_DEBUG_COLUMNS = ['thread.id', 'thread.sessionNumber', 'thread.title'];
+
+type AgentExecutionWithThread = AgentExecution & { thread: AgentExecutionThread };
+type ToolCallTimelineEvent = Extract<TimelineEvent, { type: 'tool-call' }>;
+
+function toIsoString(date: Date | null): string | null {
+	return date?.toISOString() ?? null;
+}
+
+function isEmptyOutput(output: unknown): boolean {
+	if (output === null || output === undefined) return true;
+	if (typeof output === 'string') return output.trim().length === 0;
+	if (Array.isArray(output)) return output.length === 0;
+	if (typeof output === 'object') return Object.keys(output).length === 0;
+	return false;
+}
+
+function toolCallEvents(execution: Pick<AgentExecution, 'timeline'>): ToolCallTimelineEvent[] {
+	return (execution.timeline ?? []).filter((event): event is ToolCallTimelineEvent => {
+		return event.type === 'tool-call';
+	});
+}
+
+function signal(
+	type: AgentDebugSignalType,
+	severity: AgentDebugSignal['severity'],
+	label: string,
+	description: string,
+	count = 1,
+): AgentDebugSignal {
+	return { type, severity, label, description, count };
+}
+
+export function computeAgentDebugSignals(
+	execution: Pick<
+		AgentExecution,
+		| 'status'
+		| 'duration'
+		| 'cost'
+		| 'totalTokens'
+		| 'timeline'
+		| 'toolCalls'
+		| 'hitlStatus'
+		| 'assistantResponse'
+		| 'error'
+	>,
+): AgentDebugSignal[] {
+	const signals: AgentDebugSignal[] = [];
+
+	if (execution.status === 'error') {
+		signals.push(
+			signal(
+				'failed_run',
+				'error',
+				'Failed run',
+				execution.error?.trim() || 'The agent run ended with an error.',
+			),
+		);
+	}
+
+	if (execution.duration >= SLOW_RUN_MS) {
+		signals.push(
+			signal(
+				'slow_run',
+				'warning',
+				'Slow run',
+				`The run took ${(execution.duration / 1000).toFixed(1)}s to complete.`,
+			),
+		);
+	}
+
+	const totalTokens = execution.totalTokens ?? 0;
+	const cost = execution.cost ?? 0;
+	if (cost >= HIGH_COST_USD || totalTokens >= HIGH_TOKEN_COUNT) {
+		signals.push(
+			signal(
+				'high_cost',
+				'warning',
+				'High cost',
+				'The run used more tokens or estimated cost than the debug threshold.',
+			),
+		);
+	}
+
+	const timelineToolCalls = toolCallEvents(execution);
+	const failedToolCalls = timelineToolCalls.filter((event) => !event.success);
+	if (failedToolCalls.length > 0) {
+		signals.push(
+			signal(
+				'tool_failure',
+				'error',
+				'Tool failure',
+				'One or more tools failed during the run.',
+				failedToolCalls.length,
+			),
+		);
+	}
+
+	const emptyTimelineOutputs = timelineToolCalls.filter(
+		(event) => event.success && isEmptyOutput(event.output),
+	);
+	const emptyRecordedOutputs =
+		timelineToolCalls.length === 0
+			? (execution.toolCalls ?? []).filter((toolCall) => isEmptyOutput(toolCall.output))
+			: [];
+	const emptyToolOutputCount = emptyTimelineOutputs.length + emptyRecordedOutputs.length;
+	if (emptyToolOutputCount > 0) {
+		signals.push(
+			signal(
+				'empty_tool_output',
+				'info',
+				'Empty tool output',
+				'One or more tools returned no output.',
+				emptyToolOutputCount,
+			),
+		);
+	}
+
+	const hasSuspension = execution.hitlStatus === 'suspended' || execution.hitlStatus === 'resumed';
+	if (hasSuspension || (execution.timeline ?? []).some((event) => event.type === 'suspension')) {
+		signals.push(
+			signal(
+				'human_input_required',
+				'info',
+				'Human input required',
+				'The run paused or resumed around a human-in-the-loop tool call.',
+			),
+		);
+	}
+
+	if (execution.status === 'success' && execution.assistantResponse.trim().length === 0) {
+		signals.push(
+			signal(
+				'empty_response',
+				'warning',
+				'Empty response',
+				'The run succeeded but did not record an assistant response.',
+			),
+		);
+	}
+
+	return signals;
+}
+
+@Service()
+export class AgentDebugService {
+	constructor(
+		private readonly agentExecutionRepository: AgentExecutionRepository,
+		private readonly agentEvaluationCaseRepository: AgentEvaluationCaseRepository,
+		private readonly agentRepository: AgentRepository,
+	) {}
+
+	async listRuns(
+		projectId: string,
+		agentId: string,
+		limit = DEFAULT_RUNS_LIMIT,
+		cursor?: string,
+		agentVersionId?: string,
+	): Promise<AgentDebugRunsResponse> {
+		const agent = await this.agentRepository.findByIdAndProjectId(agentId, projectId);
+		if (!agent) return { runs: [], versions: [], nextCursor: null };
+
+		const pageSize = Math.min(Math.max(limit, 1), MAX_RUNS_LIMIT);
+		const [executions, versions] = await Promise.all([
+			this.findRuns(projectId, agentId, pageSize + 1, cursor, agentVersionId),
+			this.summarizeRunVersions(projectId, agentId),
+		]);
+		const hasMore = executions.length > pageSize;
+		if (hasMore) executions.pop();
+		const reviewsByExecutionId = await this.findReviewsByExecutionIds(
+			executions.map((execution) => execution.id),
+		);
+
+		return {
+			runs: executions.map((execution) =>
+				this.toRunDto(execution, reviewsByExecutionId.get(execution.id) ?? null),
+			),
+			versions,
+			nextCursor: hasMore ? toIsoString(executions[executions.length - 1].createdAt) : null,
+		};
+	}
+
+	async getRunDetail(
+		projectId: string,
+		agentId: string,
+		executionId: string,
+	): Promise<AgentDebugRunDetail | null> {
+		const execution = await this.findRun(projectId, agentId, executionId);
+
+		if (!execution) return null;
+
+		const review = await this.agentEvaluationCaseRepository.findByExecutionId(
+			projectId,
+			agentId,
+			executionId,
+		);
+
+		return {
+			...this.toRunDto(execution, review),
+			toolCalls: execution.toolCalls,
+			timeline: execution.timeline,
+			workingMemory: null,
+		};
+	}
+
+	async listReviewCases(
+		projectId: string,
+		agentId: string,
+		limit = DEFAULT_REVIEW_CASES_LIMIT,
+		cursor?: string,
+	): Promise<AgentReviewCasesResponse> {
+		const pageSize = Math.min(Math.max(limit, 1), MAX_REVIEW_CASES_LIMIT);
+		const [reviews, summary] = await Promise.all([
+			this.agentEvaluationCaseRepository.findByAgent(projectId, agentId, pageSize + 1, cursor),
+			this.agentEvaluationCaseRepository.countByStatus(projectId, agentId),
+		]);
+		const hasMore = reviews.length > pageSize;
+		if (hasMore) reviews.pop();
+
+		return {
+			cases: reviews.map((review) => this.toReviewDto(review)),
+			summary,
+			nextCursor: hasMore ? reviews[reviews.length - 1].updatedAt.toISOString() : null,
+		};
+	}
+
+	async upsertRunReview(
+		projectId: string,
+		agentId: string,
+		executionId: string,
+		payload: UpsertAgentReviewCaseDto,
+		userId: string,
+	): Promise<AgentReviewCase | null> {
+		const execution = await this.findRun(projectId, agentId, executionId);
+		if (!execution) return null;
+
+		const existing = await this.agentEvaluationCaseRepository.findByExecutionId(
+			projectId,
+			agentId,
+			executionId,
+		);
+		const review =
+			existing ??
+			this.agentEvaluationCaseRepository.create({
+				projectId,
+				agentId,
+				agentVersionId: execution.agentVersionId,
+				conversationId: execution.threadId,
+				executionId,
+				input: execution.userMessage,
+				createdById: userId,
+			});
+
+		review.status = payload.status;
+		review.agentVersionId = execution.agentVersionId;
+		review.conversationId = execution.threadId;
+		review.rejectionReason =
+			payload.status === 'rejected'
+				? (payload.rejectionReason ?? DEFAULT_AGENT_REVIEW_REJECTION_REASON)
+				: null;
+		review.toolCallCorrection =
+			payload.status === 'rejected' && review.rejectionReason === 'wrong_tool_calling'
+				? (payload.toolCallCorrection ?? { removeToolCalls: [], addToolNames: [] })
+				: null;
+		review.input = execution.userMessage;
+		review.expectedOutput = payload.expectedOutput ?? execution.assistantResponse;
+		review.actualOutput = execution.assistantResponse;
+		review.notes = payload.notes?.trim() || null;
+		review.updatedById = userId;
+
+		const savedReview = await this.agentEvaluationCaseRepository.save(review);
+		return this.toReviewDto(savedReview);
+	}
+
+	async deleteRunReview(projectId: string, agentId: string, executionId: string): Promise<boolean> {
+		const execution = await this.findRun(projectId, agentId, executionId);
+		if (!execution) return false;
+
+		await this.agentEvaluationCaseRepository.deleteByExecutionId(projectId, agentId, executionId);
+		return true;
+	}
+
+	async getInsights(projectId: string, agentId: string): Promise<AgentDebugInsightsResponse> {
+		const executions = await this.findRuns(projectId, agentId, INSIGHTS_RUN_LIMIT);
+		const signalCounts = new Map<AgentDebugSignalType, AgentDebugInsight>();
+		let totalSignals = 0;
+		let totalDuration = 0;
+		let totalCost = 0;
+		let errorCount = 0;
+
+		for (const execution of executions) {
+			totalDuration += execution.duration;
+			totalCost += execution.cost ?? 0;
+			if (execution.status === 'error') errorCount++;
+
+			for (const currentSignal of computeAgentDebugSignals(execution)) {
+				totalSignals += currentSignal.count;
+				const existing = signalCounts.get(currentSignal.type);
+				if (existing) {
+					existing.count += currentSignal.count;
+					continue;
+				}
+
+				signalCounts.set(currentSignal.type, {
+					type: currentSignal.type,
+					severity: currentSignal.severity,
+					label: currentSignal.label,
+					description: currentSignal.description,
+					count: currentSignal.count,
+					latestRunId: execution.id,
+				});
+			}
+		}
+
+		const totalRuns = executions.length;
+
+		return {
+			totalRuns,
+			totalSignals,
+			errorRate: totalRuns === 0 ? 0 : errorCount / totalRuns,
+			averageDuration: totalRuns === 0 ? 0 : Math.round(totalDuration / totalRuns),
+			totalCost,
+			insights: Array.from(signalCounts.values()).sort((a, b) => b.count - a.count),
+		};
+	}
+
+	private async findRuns(
+		projectId: string,
+		agentId: string,
+		limit: number,
+		cursor?: string,
+		agentVersionId?: string,
+	): Promise<AgentExecutionWithThread[]> {
+		const query = this.agentExecutionRepository
+			.createQueryBuilder('execution')
+			.innerJoinAndSelect(
+				'execution.thread',
+				'thread',
+				'thread.projectId = :projectId AND thread.agentId = :agentId',
+				{ projectId, agentId },
+			)
+			.select(AGENT_EXECUTION_DEBUG_COLUMNS)
+			.addSelect(AGENT_EXECUTION_THREAD_DEBUG_COLUMNS)
+			.orderBy('execution.createdAt', 'DESC')
+			.take(limit);
+
+		if (cursor) {
+			query.andWhere('execution.createdAt < :cursor', { cursor: new Date(cursor) });
+		}
+
+		if (agentVersionId) {
+			query.andWhere('execution.agentVersionId = :agentVersionId', { agentVersionId });
+		}
+
+		return await query.getMany();
+	}
+
+	private async summarizeRunVersions(
+		projectId: string,
+		agentId: string,
+	): Promise<AgentDebugRunVersionSummary[]> {
+		const rows = await this.agentExecutionRepository
+			.createQueryBuilder('execution')
+			.innerJoin('execution.thread', 'thread')
+			.select('execution.agentVersionId', 'agentVersionId')
+			.addSelect('COUNT(*)', 'total')
+			.addSelect('MAX(execution.createdAt)', 'latestRunAt')
+			.where('thread.projectId = :projectId', { projectId })
+			.andWhere('thread.agentId = :agentId', { agentId })
+			.groupBy('execution.agentVersionId')
+			.orderBy('MAX(execution.createdAt)', 'DESC')
+			.getRawMany<{
+				agentVersionId: string;
+				total: string | number;
+				latestRunAt: Date | string | null;
+			}>();
+
+		return rows.map((row) => ({
+			agentVersionId: row.agentVersionId,
+			total: Number(row.total),
+			latestRunAt:
+				row.latestRunAt instanceof Date ? row.latestRunAt.toISOString() : (row.latestRunAt ?? null),
+		}));
+	}
+
+	private async findRun(
+		projectId: string,
+		agentId: string,
+		executionId: string,
+	): Promise<AgentExecutionWithThread | null> {
+		return await this.agentExecutionRepository
+			.createQueryBuilder('execution')
+			.innerJoinAndSelect(
+				'execution.thread',
+				'thread',
+				'thread.projectId = :projectId AND thread.agentId = :agentId',
+				{ projectId, agentId },
+			)
+			.select(AGENT_EXECUTION_DEBUG_COLUMNS)
+			.addSelect(AGENT_EXECUTION_THREAD_DEBUG_COLUMNS)
+			.where('execution.id = :executionId', { executionId })
+			.getOne();
+	}
+
+	private async findReviewsByExecutionIds(
+		executionIds: string[],
+	): Promise<Map<string, AgentEvaluationCase>> {
+		const reviews = await this.agentEvaluationCaseRepository.findByExecutionIds(executionIds);
+		return new Map(reviews.map((review) => [review.executionId, review]));
+	}
+
+	private toRunDto(
+		execution: AgentExecutionWithThread,
+		review: AgentEvaluationCase | null,
+	): AgentDebugRun {
+		return {
+			id: execution.id,
+			threadId: execution.threadId,
+			sessionNumber: execution.thread.sessionNumber,
+			sessionTitle: execution.thread.title,
+			agentVersionId: execution.agentVersionId,
+			status: execution.status,
+			createdAt: execution.createdAt.toISOString(),
+			startedAt: toIsoString(execution.startedAt),
+			stoppedAt: toIsoString(execution.stoppedAt),
+			duration: execution.duration,
+			userMessage: execution.userMessage,
+			assistantResponse: execution.assistantResponse,
+			model: execution.model,
+			promptTokens: execution.promptTokens,
+			completionTokens: execution.completionTokens,
+			totalTokens: execution.totalTokens,
+			cost: execution.cost,
+			error: execution.error,
+			hitlStatus: execution.hitlStatus,
+			source: execution.source,
+			signals: computeAgentDebugSignals(execution),
+			review: review ? this.toReviewDto(review) : null,
+		};
+	}
+
+	private toReviewDto(review: AgentEvaluationCase): AgentReviewCase {
+		return {
+			id: review.id,
+			projectId: review.projectId,
+			agentId: review.agentId,
+			agentVersionId: review.agentVersionId,
+			conversationId: review.conversationId,
+			executionId: review.executionId,
+			status: review.status,
+			rejectionReason: review.rejectionReason,
+			toolCallCorrection: review.toolCallCorrection,
+			input: review.input,
+			expectedOutput: review.expectedOutput,
+			actualOutput: review.actualOutput,
+			notes: review.notes,
+			createdById: review.createdById,
+			updatedById: review.updatedById,
+			createdAt: review.createdAt.toISOString(),
+			updatedAt: review.updatedAt.toISOString(),
+		};
+	}
+}

--- a/packages/cli/src/modules/agents/agents.module.ts
+++ b/packages/cli/src/modules/agents/agents.module.ts
@@ -9,6 +9,7 @@ import { InstanceSettings } from 'n8n-core';
 export class AgentsModule implements ModuleInterface {
 	async init() {
 		await import('./agents.controller');
+		await import('./agent-debug.controller');
 		await import('./builder/agents-builder-settings.controller');
 
 		const { AgentsService } = await import('./agents.service');
@@ -21,6 +22,9 @@ export class AgentsModule implements ModuleInterface {
 
 		const { AgentExecutionService } = await import('./agent-execution.service');
 		Container.get(AgentExecutionService);
+
+		const { AgentDebugService } = await import('./agent-debug.service');
+		Container.get(AgentDebugService);
 
 		const { AgentEvaluationCaseRepository } = await import(
 			'./repositories/agent-evaluation-case.repository'


### PR DESCRIPTION
## Summary

Adds backend APIs for inspecting and reviewing recorded agent runs. This PR builds on the persistence/contracts PR and keeps the frontend out of scope.

The endpoints introduced here support:

| Endpoint group | Responsibility |
|---|---|
| debug runs | List recent agent runs with version, status, cost, token, and signal metadata |
| debug run detail | Load a single run with timeline/tool-call data for review |
| insights | Summarize run health signals for the agent debug tab |
| reviews | Create, update, list, and clear reviewed evaluation cases |

### How to test

Targeted backend tests for the full stacked series were run from `packages/cli`:

```bash
pnpm test src/modules/agents/__tests__/agent-debug.controller.test.ts src/modules/agents/__tests__/agent-debug.service.test.ts src/modules/agents/__tests__/agent-evaluations.controller.test.ts src/modules/agents/__tests__/agent-evaluations.service.test.ts src/modules/agents/__tests__/agents.service.evaluation.test.ts
```

Result: 5 suites passed, 31 tests passed.

> **Note: this is part of a multi-step PR series delivering agent evaluations.**
>
> 1. persistence and shared contracts - `TRUST-12-agent-evals-01-persistence`
> 2. <- **you are here** - agent debug backend APIs
> 3. agent debug frontend - `TRUST-12-agent-evals-03-debug-frontend`
> 4. evaluation setup backend APIs - `TRUST-12-agent-evals-04-eval-setup-backend`
> 5. evaluation execution backend - `TRUST-12-agent-evals-05-eval-execution`
> 6. evaluation frontend - `TRUST-12-agent-evals-06-eval-frontend`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-12

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
