### PR TITLE
feat(core): Add agent evaluation setup APIs

### DIFF
--- a/packages/cli/src/modules/agents/__tests__/agent-evaluations.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-evaluations.controller.test.ts
@@ -1,0 +1,24 @@
+import { ControllerRegistryMetadata } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+
+import { AgentEvaluationsController } from '../agent-evaluations.controller';
+
+const metadata = Container.get(ControllerRegistryMetadata).getControllerMetadata(
+	AgentEvaluationsController as never,
+);
+
+const routeCases = Array.from(metadata.routes.entries()).map(([handlerName, route]) => ({
+	handlerName,
+	route,
+}));
+
+describe('AgentEvaluationsController route access scopes', () => {
+	it.each(routeCases)(
+		'$handlerName is gated by a project-scoped agent check',
+		({ handlerName, route }) => {
+			expect(route.accessScope).toBeDefined();
+			expect(route.accessScope?.globalOnly).toBe(false);
+			expect(route.accessScope?.scope).toBe('agent:read');
+		},
+	);
+});

--- a/packages/cli/src/modules/agents/agent-evaluations.controller.ts
+++ b/packages/cli/src/modules/agents/agent-evaluations.controller.ts
@@ -1,0 +1,43 @@
+import type {
+	AgentEvaluationSuiteSetupRequest,
+} from '@n8n/api-types';
+import { Body, Get, Post, ProjectScope, RestController } from '@n8n/decorators';
+import type { AuthenticatedRequest } from '@n8n/db';
+
+import { AgentEvaluationsService } from './agent-evaluations.service';
+
+@RestController('/projects/:projectId/agents/v2/:agentId/evaluations')
+export class AgentEvaluationsController {
+	constructor(private readonly agentEvaluationsService: AgentEvaluationsService) {}
+
+	@Get('/dataset')
+	@ProjectScope('agent:read')
+	async getDataset(
+		req: AuthenticatedRequest<
+			{ projectId: string; agentId: string },
+			{},
+			{},
+			{ agentVersionId?: string }
+		>,
+	) {
+		return await this.agentEvaluationsService.getDataset(
+			req.params.projectId,
+			req.params.agentId,
+			req.query.agentVersionId,
+		);
+	}
+
+	@Post('/suite')
+	@ProjectScope('agent:read')
+	async setupSuite(
+		req: AuthenticatedRequest<{ projectId: string; agentId: string }>,
+		_res: unknown,
+		@Body payload?: AgentEvaluationSuiteSetupRequest,
+	) {
+		return await this.agentEvaluationsService.setupSuite(
+			req.params.projectId,
+			req.params.agentId,
+			payload?.agentVersionId,
+		);
+	}
+}

--- a/packages/cli/src/modules/agents/agent-evaluations.service.ts
+++ b/packages/cli/src/modules/agents/agent-evaluations.service.ts
@@ -1,0 +1,304 @@
+import type {
+	AgentEvaluationDatasetReadiness,
+	AgentEvaluationDatasetResponse,
+	AgentEvaluationMetricSuggestion,
+	AgentEvaluationSuiteDraft,
+	AgentEvaluationSuiteRun,
+	AgentEvaluationSuiteSetupResponse,
+	AgentEvaluationVersionSummary,
+	AgentReviewCase,
+	AgentReviewSummary,
+} from '@n8n/api-types';
+import { AGENT_EVALUATION_MIN_REVIEWED_CASES } from '@n8n/api-types';
+import { Service } from '@n8n/di';
+
+import type { AgentEvaluationCase } from './entities/agent-evaluation-case.entity';
+import type { AgentEvaluationRun } from './entities/agent-evaluation-run.entity';
+import { AgentEvaluationCaseRepository } from './repositories/agent-evaluation-case.repository';
+import { AgentEvaluationRunRepository } from './repositories/agent-evaluation-run.repository';
+import { AgentRepository } from './repositories/agent.repository';
+import { getAgentCurrentVersionId } from './utils/agent-version.utils';
+
+const DATASET_PREVIEW_LIMIT = 10;
+const RECENT_RUNS_LIMIT = 20;
+const SUITE_CASE_LIMIT = 100;
+const ANSWER_CORRECTNESS_METRIC_ID = 'answer-correctness';
+const CALLED_TOOLS_METRIC_ID = 'called-tools-unordered';
+
+interface AgentEvaluationVersionContext {
+	currentAgentVersionId: string;
+	selectedAgentVersionId: string;
+	selectedVersionCanRun: boolean;
+	versions: AgentEvaluationVersionSummary[];
+}
+
+@Service()
+export class AgentEvaluationsService {
+	constructor(
+		private readonly agentEvaluationCaseRepository: AgentEvaluationCaseRepository,
+		private readonly agentEvaluationRunRepository: AgentEvaluationRunRepository,
+		private readonly agentRepository: AgentRepository,
+	) {}
+
+	async getDataset(
+		projectId: string,
+		agentId: string,
+		agentVersionId?: string,
+	): Promise<AgentEvaluationDatasetResponse> {
+		const summary = await this.agentEvaluationCaseRepository.countByStatus(projectId, agentId);
+		const versionContext = await this.resolveVersionContext(
+			projectId,
+			agentId,
+			summary,
+			agentVersionId,
+		);
+		if (!versionContext) return this.emptyDatasetResponse();
+
+		const [cases, recentRuns] = await Promise.all([
+			this.agentEvaluationCaseRepository.findByAgent(projectId, agentId, DATASET_PREVIEW_LIMIT),
+			this.agentEvaluationRunRepository.findRecentByAgent(projectId, agentId, RECENT_RUNS_LIMIT),
+		]);
+
+		return {
+			currentAgentVersionId: versionContext.currentAgentVersionId,
+			versions: versionContext.versions,
+			recentRuns: recentRuns.map((run) => this.toRunDto(run)),
+			cases: cases.map((evaluationCase) => this.toReviewDto(evaluationCase)),
+			summary,
+			nextCursor: null,
+			readiness: this.toReadiness(summary, versionContext),
+		};
+	}
+
+	async setupSuite(
+		projectId: string,
+		agentId: string,
+		_agentVersionId?: string,
+	): Promise<AgentEvaluationSuiteSetupResponse> {
+		const summary = await this.agentEvaluationCaseRepository.countByStatus(projectId, agentId);
+		const versionContext = await this.resolveVersionContext(projectId, agentId, summary);
+		if (!versionContext) return this.emptySuiteSetupResponse();
+
+		const cases = await this.agentEvaluationCaseRepository.findByAgent(
+			projectId,
+			agentId,
+			SUITE_CASE_LIMIT,
+		);
+		const readiness = this.toReadiness(summary, versionContext);
+
+		if (!readiness.isReady) {
+			return {
+				currentAgentVersionId: versionContext.currentAgentVersionId,
+				versions: versionContext.versions,
+				readiness,
+				suite: null,
+			};
+		}
+
+		return {
+			currentAgentVersionId: versionContext.currentAgentVersionId,
+			versions: versionContext.versions,
+			readiness,
+			suite: this.toSuiteDraft(agentId, versionContext.selectedAgentVersionId, summary, cases),
+		};
+	}
+
+	private emptySummary(): AgentReviewSummary {
+		return { total: 0, approved: 0, rejected: 0 };
+	}
+
+	private emptyReadiness(): AgentEvaluationDatasetReadiness {
+		return {
+			isReady: false,
+			agentVersionId: '',
+			agentVersionCanRun: false,
+			minimumReviewedCases: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+			reviewedCases: 0,
+			remainingCases: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+		};
+	}
+
+	private emptyDatasetResponse(): AgentEvaluationDatasetResponse {
+		return {
+			currentAgentVersionId: '',
+			versions: [],
+			recentRuns: [],
+			cases: [],
+			summary: this.emptySummary(),
+			nextCursor: null,
+			readiness: this.emptyReadiness(),
+		};
+	}
+
+	private emptySuiteSetupResponse(): AgentEvaluationSuiteSetupResponse {
+		return {
+			currentAgentVersionId: '',
+			versions: [],
+			readiness: this.emptyReadiness(),
+			suite: null,
+		};
+	}
+
+	private async resolveVersionContext(
+		projectId: string,
+		agentId: string,
+		summary: AgentReviewSummary,
+		requestedAgentVersionId?: string,
+	): Promise<AgentEvaluationVersionContext | null> {
+		const agent = await this.agentRepository.findByIdAndProjectId(agentId, projectId);
+		if (!agent) return null;
+
+		const currentAgentVersionId = getAgentCurrentVersionId(agent);
+		const publishedAgentVersionId = agent.publishedVersion?.publishedFromVersionId ?? null;
+		const summaries = await this.agentEvaluationCaseRepository.summarizeVersions(
+			projectId,
+			agentId,
+		);
+		const versionsById = new Map<string, AgentEvaluationVersionSummary>();
+
+		for (const versionSummary of summaries) {
+			versionsById.set(versionSummary.agentVersionId, {
+				agentVersionId: versionSummary.agentVersionId,
+				...this.withSharedDatasetSummary(versionSummary.updatedAt, summary),
+				isCurrent: versionSummary.agentVersionId === currentAgentVersionId,
+				isPublished: versionSummary.agentVersionId === publishedAgentVersionId,
+				canRun: versionSummary.agentVersionId === currentAgentVersionId,
+			});
+		}
+
+		for (const agentVersionId of [currentAgentVersionId, publishedAgentVersionId]) {
+			if (!agentVersionId || versionsById.has(agentVersionId)) continue;
+			versionsById.set(agentVersionId, {
+				agentVersionId,
+				isCurrent: agentVersionId === currentAgentVersionId,
+				isPublished: agentVersionId === publishedAgentVersionId,
+				canRun: agentVersionId === currentAgentVersionId,
+				...this.withSharedDatasetSummary(null, summary),
+			});
+		}
+
+		const selectedAgentVersionId =
+			requestedAgentVersionId && versionsById.has(requestedAgentVersionId)
+				? requestedAgentVersionId
+				: currentAgentVersionId;
+		const selectedVersion = versionsById.get(selectedAgentVersionId);
+
+		return {
+			currentAgentVersionId,
+			selectedAgentVersionId,
+			selectedVersionCanRun: selectedVersion?.canRun ?? false,
+			versions: [...versionsById.values()].sort((left, right) => {
+				if (left.isCurrent !== right.isCurrent) return left.isCurrent ? -1 : 1;
+				if (left.isPublished !== right.isPublished) return left.isPublished ? -1 : 1;
+				return (right.updatedAt ?? '').localeCompare(left.updatedAt ?? '');
+			}),
+		};
+	}
+
+	private withSharedDatasetSummary(
+		updatedAt: string | null,
+		summary: AgentReviewSummary,
+	): AgentReviewSummary & { updatedAt: string | null } {
+		return {
+			...summary,
+			updatedAt,
+		};
+	}
+
+	private toReadiness(
+		summary: AgentReviewSummary,
+		versionContext: Pick<
+			AgentEvaluationVersionContext,
+			'selectedAgentVersionId' | 'selectedVersionCanRun'
+		>,
+	): AgentEvaluationDatasetReadiness {
+		const remainingCases = Math.max(AGENT_EVALUATION_MIN_REVIEWED_CASES - summary.total, 0);
+
+		return {
+			isReady: remainingCases === 0,
+			agentVersionId: versionContext.selectedAgentVersionId,
+			agentVersionCanRun: versionContext.selectedVersionCanRun,
+			minimumReviewedCases: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+			reviewedCases: summary.total,
+			remainingCases,
+		};
+	}
+
+	private toSuiteId(agentId: string): string {
+		return `agent-${agentId}-reviewed-cases-v0`;
+	}
+
+	private toSuiteDraft(
+		agentId: string,
+		agentVersionId: string,
+		summary: AgentReviewSummary,
+		cases: AgentEvaluationCase[],
+	): AgentEvaluationSuiteDraft {
+		return {
+			id: this.toSuiteId(agentId),
+			agentVersionId,
+			name: 'Reviewed cases suite',
+			description: 'Draft evaluation suite generated from reviewed agent runs.',
+			caseCount: cases.length,
+			approvedCases: summary.approved,
+			rejectedCases: summary.rejected,
+			toolMocking: 'Recorded tool outputs from reviewed runs when available',
+			memoryMocking: 'Empty memory for the first evaluation run',
+			metrics: this.suggestMetrics(),
+		};
+	}
+
+	private suggestMetrics(): AgentEvaluationMetricSuggestion[] {
+		return [
+			{
+				id: ANSWER_CORRECTNESS_METRIC_ID,
+				name: 'Answer correctness',
+				type: 'judge',
+				description: 'Checks the agent response against the expected answer saved during review.',
+				enabled: true,
+			},
+			{
+				id: CALLED_TOOLS_METRIC_ID,
+				name: 'Called tools',
+				type: 'check',
+				description: 'Checks the unordered list of called tools against the reviewed expectation.',
+				enabled: true,
+			},
+		];
+	}
+
+	private toRunDto(run: AgentEvaluationRun): AgentEvaluationSuiteRun {
+		return {
+			id: run.id,
+			suiteId: run.suiteId,
+			agentVersionId: run.agentVersionId,
+			startedAt: run.startedAt.toISOString(),
+			completedAt: run.completedAt.toISOString(),
+			summary: run.summary,
+			cases: run.cases,
+			warnings: run.warnings,
+		};
+	}
+
+	private toReviewDto(evaluationCase: AgentEvaluationCase): AgentReviewCase {
+		return {
+			id: evaluationCase.id,
+			projectId: evaluationCase.projectId,
+			agentId: evaluationCase.agentId,
+			agentVersionId: evaluationCase.agentVersionId,
+			conversationId: evaluationCase.conversationId,
+			executionId: evaluationCase.executionId,
+			status: evaluationCase.status,
+			rejectionReason: evaluationCase.rejectionReason,
+			toolCallCorrection: evaluationCase.toolCallCorrection,
+			input: evaluationCase.input,
+			expectedOutput: evaluationCase.expectedOutput,
+			actualOutput: evaluationCase.actualOutput,
+			notes: evaluationCase.notes,
+			createdById: evaluationCase.createdById,
+			updatedById: evaluationCase.updatedById,
+			createdAt: evaluationCase.createdAt.toISOString(),
+			updatedAt: evaluationCase.updatedAt.toISOString(),
+		};
+	}
+}

--- a/packages/cli/src/modules/agents/agents.module.ts
+++ b/packages/cli/src/modules/agents/agents.module.ts
@@ -10,6 +10,7 @@ export class AgentsModule implements ModuleInterface {
 	async init() {
 		await import('./agents.controller');
 		await import('./agent-debug.controller');
+		await import('./agent-evaluations.controller');
 		await import('./builder/agents-builder-settings.controller');
 
 		const { AgentsService } = await import('./agents.service');
@@ -25,6 +26,9 @@ export class AgentsModule implements ModuleInterface {
 
 		const { AgentDebugService } = await import('./agent-debug.service');
 		Container.get(AgentDebugService);
+
+		const { AgentEvaluationsService } = await import('./agent-evaluations.service');
+		Container.get(AgentEvaluationsService);
 
 		const { AgentEvaluationCaseRepository } = await import(
 			'./repositories/agent-evaluation-case.repository'


### PR DESCRIPTION
## Summary

Adds backend APIs for preparing an evaluation suite from reviewed agent runs. This PR builds on the debug frontend PR and intentionally stops before executing evaluations.

The backend now exposes:

| Endpoint | Responsibility |
|---|---|
| evaluation dataset | Return reviewed cases, readiness, version summaries, and recent runs |
| suite setup | Generate a draft evaluation suite once the reviewed-case threshold is met |
| readiness model | Report how many reviewed cases are needed before the first evaluation can run |
| metric suggestions | Provide the first built-in metric suggestions for the generated suite |

### How to test

Targeted backend tests for the full stacked series were run from `packages/cli`:

```bash
pnpm test src/modules/agents/__tests__/agent-debug.controller.test.ts src/modules/agents/__tests__/agent-debug.service.test.ts src/modules/agents/__tests__/agent-evaluations.controller.test.ts src/modules/agents/__tests__/agent-evaluations.service.test.ts src/modules/agents/__tests__/agents.service.evaluation.test.ts
```

Result: 5 suites passed, 31 tests passed.

> **Note: this is part of a multi-step PR series delivering agent evaluations.**
>
> 1. persistence and shared contracts - `TRUST-12-agent-evals-01-persistence`
> 2. agent debug backend APIs - `TRUST-12-agent-evals-02-debug-backend`
> 3. agent debug frontend - `TRUST-12-agent-evals-03-debug-frontend`
> 4. <- **you are here** - evaluation setup backend APIs
> 5. evaluation execution backend - `TRUST-12-agent-evals-05-eval-execution`
> 6. evaluation frontend - `TRUST-12-agent-evals-06-eval-frontend`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-12

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
