### PR TITLE
feat(core): Add agent evaluation execution

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/filesystem/create-tools-from-mcp-server.ts
+++ b/packages/@n8n/instance-ai/src/tools/filesystem/create-tools-from-mcp-server.ts
@@ -12,7 +12,7 @@ import {
 	type GatewayConfirmationRequiredPayload,
 	type McpToolCallResult,
 } from '@n8n/api-types';
-import { browserCreateCredentialSchema } from '@n8n/mcp-browser/dist/tools/credential';
+import { browserCreateCredentialSchema } from '@n8n/mcp-browser';
 import { nanoid } from 'nanoid';
 import { z } from 'zod';
 import { convertJsonSchemaToZod } from 'zod-from-json-schema-v3';

--- a/packages/@n8n/mcp-browser/src/index.ts
+++ b/packages/@n8n/mcp-browser/src/index.ts
@@ -1,5 +1,6 @@
 export { BrowserConnection } from './connection';
 export { createBrowserTools } from './tools/index';
+export { browserCreateCredentialSchema } from './tools/credential';
 export { configureLogger } from './logger';
 export type { LogLevel } from './logger';
 export { parseServerOptions } from './server-config';

--- a/packages/cli/src/modules/agents/__tests__/agent-evaluations.controller.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-evaluations.controller.test.ts
@@ -18,7 +18,9 @@ describe('AgentEvaluationsController route access scopes', () => {
 		({ handlerName, route }) => {
 			expect(route.accessScope).toBeDefined();
 			expect(route.accessScope?.globalOnly).toBe(false);
-			expect(route.accessScope?.scope).toBe('agent:read');
+			expect(route.accessScope?.scope).toBe(
+				handlerName === 'runSuite' ? 'agent:execute' : 'agent:read',
+			);
 		},
 	);
 });

--- a/packages/cli/src/modules/agents/__tests__/agent-evaluations.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-evaluations.service.test.ts
@@ -1,0 +1,563 @@
+import { AGENT_EVALUATION_MIN_REVIEWED_CASES } from '@n8n/api-types';
+import { mock } from 'jest-mock-extended';
+
+import { AgentEvaluationsService } from '../agent-evaluations.service';
+import type { AgentsService } from '../agents.service';
+import type { AgentEvaluationCase } from '../entities/agent-evaluation-case.entity';
+import type { AgentEvaluationRun } from '../entities/agent-evaluation-run.entity';
+import type { AgentExecution } from '../entities/agent-execution.entity';
+import type { AgentEvaluationCaseRepository } from '../repositories/agent-evaluation-case.repository';
+import type { AgentEvaluationRunRepository } from '../repositories/agent-evaluation-run.repository';
+import type { AgentExecutionRepository } from '../repositories/agent-execution.repository';
+import type { AgentRepository } from '../repositories/agent.repository';
+
+describe('AgentEvaluationsService', () => {
+	const now = new Date('2026-05-18T12:00:00.000Z');
+	let agentEvaluationCaseRepository: jest.Mocked<AgentEvaluationCaseRepository>;
+	let agentEvaluationRunRepository: jest.Mocked<AgentEvaluationRunRepository>;
+	let agentExecutionRepository: jest.Mocked<AgentExecutionRepository>;
+	let agentsService: jest.Mocked<AgentsService>;
+	let agentRepository: jest.Mocked<AgentRepository>;
+	let queryBuilder: {
+		innerJoin: jest.Mock;
+		where: jest.Mock;
+		andWhere: jest.Mock;
+		orderBy: jest.Mock;
+		getMany: jest.Mock;
+	};
+	let service: AgentEvaluationsService;
+
+	beforeEach(() => {
+		agentEvaluationCaseRepository = mock<AgentEvaluationCaseRepository>();
+		agentEvaluationRunRepository = mock<AgentEvaluationRunRepository>();
+		agentExecutionRepository = mock<AgentExecutionRepository>();
+		agentsService = mock<AgentsService>();
+		agentRepository = mock<AgentRepository>();
+		agentRepository.findByIdAndProjectId.mockResolvedValue({
+			id: 'agent-1',
+			versionId: 'version-1',
+			updatedAt: now,
+			publishedVersion: null,
+		} as never);
+		agentEvaluationCaseRepository.summarizeVersions.mockResolvedValue([]);
+		agentEvaluationRunRepository.findRecentByAgent.mockResolvedValue([]);
+		queryBuilder = {
+			innerJoin: jest.fn().mockReturnThis(),
+			where: jest.fn().mockReturnThis(),
+			andWhere: jest.fn().mockReturnThis(),
+			orderBy: jest.fn().mockReturnThis(),
+			getMany: jest.fn().mockResolvedValue([]),
+		};
+		agentExecutionRepository.createQueryBuilder.mockReturnValue(queryBuilder as never);
+		service = new AgentEvaluationsService(
+			agentEvaluationCaseRepository,
+			agentEvaluationRunRepository,
+			agentExecutionRepository,
+			agentsService,
+			agentRepository,
+		);
+	});
+
+	function reviewFixture(overrides: Partial<AgentEvaluationCase> = {}): AgentEvaluationCase {
+		return {
+			id: 'review-1',
+			projectId: 'project-1',
+			agentId: 'agent-1',
+			agentVersionId: 'version-1',
+			conversationId: 'thread-1',
+			executionId: 'execution-1',
+			status: 'approved',
+			rejectionReason: null,
+			toolCallCorrection: null,
+			input: 'Question',
+			expectedOutput: 'Expected answer',
+			actualOutput: 'Actual answer',
+			notes: null,
+			createdById: 'user-1',
+			updatedById: 'user-1',
+			createdAt: now,
+			updatedAt: now,
+			...overrides,
+		} as AgentEvaluationCase;
+	}
+
+	function runFixture(overrides: Partial<AgentEvaluationRun> = {}): AgentEvaluationRun {
+		return {
+			id: 'run-1',
+			projectId: 'project-1',
+			agentId: 'agent-1',
+			agentVersionId: 'version-1',
+			suiteId: 'agent-agent-1-reviewed-cases-v0',
+			startedAt: now,
+			completedAt: now,
+			summary: {
+				totalCases: 1,
+				passedCases: 1,
+				failedCases: 0,
+				errorCases: 0,
+				averageScore: 1,
+			},
+			cases: [],
+			warnings: [],
+			createdById: 'user-1',
+			createdAt: now,
+			updatedAt: now,
+			...overrides,
+		} as AgentEvaluationRun;
+	}
+
+	it('requires more reviewed cases when the dataset is below the threshold', async () => {
+		agentEvaluationCaseRepository.countByStatus.mockResolvedValue({
+			total: 4,
+			approved: 3,
+			rejected: 1,
+		});
+		agentEvaluationCaseRepository.findByAgent.mockResolvedValue([reviewFixture()]);
+
+		const dataset = await service.getDataset('project-1', 'agent-1');
+
+		expect(agentEvaluationCaseRepository.findByAgent).toHaveBeenCalledWith(
+			'project-1',
+			'agent-1',
+			10,
+		);
+		expect(dataset.readiness).toEqual({
+			isReady: false,
+			agentVersionId: 'version-1',
+			agentVersionCanRun: true,
+			minimumReviewedCases: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+			reviewedCases: 4,
+			remainingCases: AGENT_EVALUATION_MIN_REVIEWED_CASES - 4,
+		});
+		expect(dataset.summary).toEqual({ total: 4, approved: 3, rejected: 1 });
+		expect(dataset.cases).toEqual([
+			expect.objectContaining({ id: 'review-1', updatedAt: now.toISOString() }),
+		]);
+	});
+
+	it('marks the dataset as ready at the reviewed-case threshold', async () => {
+		agentEvaluationCaseRepository.countByStatus.mockResolvedValue({
+			total: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+			approved: 4,
+			rejected: 1,
+		});
+		agentEvaluationCaseRepository.findByAgent.mockResolvedValue([]);
+
+		const dataset = await service.getDataset('project-1', 'agent-1');
+
+		expect(dataset.readiness).toEqual({
+			isReady: true,
+			agentVersionId: 'version-1',
+			agentVersionCanRun: true,
+			minimumReviewedCases: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+			reviewedCases: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+			remainingCases: 0,
+		});
+	});
+
+	it('loads recent evaluation runs with the dataset', async () => {
+		agentEvaluationCaseRepository.countByStatus.mockResolvedValue({
+			total: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+			approved: 4,
+			rejected: 1,
+		});
+		agentEvaluationCaseRepository.findByAgent.mockResolvedValue([]);
+		agentEvaluationRunRepository.findRecentByAgent.mockResolvedValue([
+			runFixture({ id: 'run-1', agentVersionId: 'version-1' }),
+			runFixture({ id: 'run-2', agentVersionId: 'version-2' }),
+		]);
+
+		const dataset = await service.getDataset('project-1', 'agent-1');
+
+		expect(agentEvaluationRunRepository.findRecentByAgent).toHaveBeenCalledWith(
+			'project-1',
+			'agent-1',
+			20,
+		);
+		expect(dataset.recentRuns).toEqual([
+			expect.objectContaining({
+				id: 'run-1',
+				agentVersionId: 'version-1',
+				completedAt: now.toISOString(),
+			}),
+			expect.objectContaining({
+				id: 'run-2',
+				agentVersionId: 'version-2',
+				completedAt: now.toISOString(),
+			}),
+		]);
+	});
+
+	it('loads a requested reviewed version for dataset context only', async () => {
+		agentRepository.findByIdAndProjectId.mockResolvedValue({
+			id: 'agent-1',
+			versionId: 'version-2',
+			updatedAt: now,
+			publishedVersion: {
+				publishedFromVersionId: 'version-1',
+			},
+		} as never);
+		agentEvaluationCaseRepository.summarizeVersions.mockResolvedValue([
+			{
+				agentVersionId: 'version-1',
+				total: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+				approved: 4,
+				rejected: 1,
+				updatedAt: now.toISOString(),
+			},
+		]);
+		agentEvaluationCaseRepository.countByStatus.mockResolvedValue({
+			total: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+			approved: 4,
+			rejected: 1,
+		});
+		agentEvaluationCaseRepository.findByAgent.mockResolvedValue([
+			reviewFixture({ agentVersionId: 'version-1' }),
+		]);
+
+		const dataset = await service.getDataset('project-1', 'agent-1', 'version-1');
+
+		expect(agentEvaluationCaseRepository.findByAgent).toHaveBeenCalledWith(
+			'project-1',
+			'agent-1',
+			10,
+		);
+		expect(dataset.currentAgentVersionId).toBe('version-2');
+		expect(dataset.readiness).toEqual({
+			isReady: true,
+			agentVersionId: 'version-1',
+			agentVersionCanRun: false,
+			minimumReviewedCases: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+			reviewedCases: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+			remainingCases: 0,
+		});
+		expect(dataset.versions).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					agentVersionId: 'version-2',
+					isCurrent: true,
+					canRun: true,
+				}),
+				expect.objectContaining({
+					agentVersionId: 'version-1',
+					isPublished: true,
+					canRun: false,
+				}),
+			]),
+		);
+	});
+
+	it('does not set up a suite below the reviewed-case threshold', async () => {
+		agentEvaluationCaseRepository.countByStatus.mockResolvedValue({
+			total: 3,
+			approved: 2,
+			rejected: 1,
+		});
+		agentEvaluationCaseRepository.findByAgent.mockResolvedValue([reviewFixture()]);
+
+		const response = await service.setupSuite('project-1', 'agent-1');
+
+		expect(response.suite).toBeNull();
+		expect(response.readiness).toEqual({
+			isReady: false,
+			agentVersionId: 'version-1',
+			agentVersionCanRun: true,
+			minimumReviewedCases: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+			reviewedCases: 3,
+			remainingCases: AGENT_EVALUATION_MIN_REVIEWED_CASES - 3,
+		});
+	});
+
+	it('sets up a draft suite with suggested metrics from reviewed cases', async () => {
+		agentEvaluationCaseRepository.countByStatus.mockResolvedValue({
+			total: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+			approved: 4,
+			rejected: 1,
+		});
+		agentEvaluationCaseRepository.findByAgent.mockResolvedValue([
+			reviewFixture(),
+			reviewFixture({ id: 'review-2', executionId: 'execution-2', status: 'rejected' }),
+		]);
+
+		const response = await service.setupSuite('project-1', 'agent-1');
+
+		expect(agentEvaluationCaseRepository.findByAgent).toHaveBeenCalledWith(
+			'project-1',
+			'agent-1',
+			100,
+		);
+		expect(response.suite).toEqual(
+			expect.objectContaining({
+				id: 'agent-agent-1-reviewed-cases-v0',
+				agentVersionId: 'version-1',
+				name: 'Reviewed cases suite',
+				caseCount: 2,
+				approvedCases: 4,
+				rejectedCases: 1,
+				memoryMocking: 'Empty memory for the first evaluation run',
+				toolMocking: 'Recorded tool outputs from reviewed runs when available',
+				metrics: [
+					expect.objectContaining({ id: 'answer-correctness', enabled: true }),
+					expect.objectContaining({ id: 'called-tools-unordered', enabled: true }),
+				],
+			}),
+		);
+	});
+
+	it('does not run a suite below the reviewed-case threshold', async () => {
+		agentEvaluationCaseRepository.countByStatus.mockResolvedValue({
+			total: 3,
+			approved: 2,
+			rejected: 1,
+		});
+		agentEvaluationCaseRepository.findByAgent.mockResolvedValue([reviewFixture()]);
+
+		const response = await service.runSuite('project-1', 'agent-1', 'user-1');
+
+		expect(response.run).toBeNull();
+		expect(agentExecutionRepository.createQueryBuilder).not.toHaveBeenCalled();
+		expect(agentsService.executeEvaluationCase).not.toHaveBeenCalled();
+		expect(agentEvaluationRunRepository.saveRun).not.toHaveBeenCalled();
+	});
+
+	it('runs the current version even when an older reviewed version is requested', async () => {
+		agentRepository.findByIdAndProjectId.mockResolvedValue({
+			id: 'agent-1',
+			versionId: 'version-2',
+			updatedAt: now,
+			publishedVersion: null,
+		} as never);
+		agentEvaluationCaseRepository.summarizeVersions.mockResolvedValue([
+			{
+				agentVersionId: 'version-1',
+				total: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+				approved: 4,
+				rejected: 1,
+				updatedAt: now.toISOString(),
+			},
+		]);
+		agentEvaluationCaseRepository.countByStatus.mockResolvedValue({
+			total: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+			approved: 4,
+			rejected: 1,
+		});
+		agentEvaluationCaseRepository.findByAgent.mockResolvedValue([
+			reviewFixture({ agentVersionId: 'version-1' }),
+		]);
+		agentsService.executeEvaluationCase.mockResolvedValue({
+			output: 'Expected answer',
+			error: null,
+			finishReason: 'stop',
+			durationMs: 125,
+			toolCalls: [],
+			missingToolMocks: [],
+			warnings: [],
+		});
+
+		const response = await service.runSuite('project-1', 'agent-1', 'user-1', {
+			agentVersionId: 'version-1',
+		});
+
+		expect(response.readiness).toEqual({
+			isReady: true,
+			agentVersionId: 'version-2',
+			agentVersionCanRun: true,
+			minimumReviewedCases: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+			reviewedCases: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+			remainingCases: 0,
+		});
+		expect(agentsService.executeEvaluationCase).toHaveBeenCalledWith(
+			expect.objectContaining({
+				agentVersionId: 'version-2',
+			}),
+		);
+		expect(agentEvaluationRunRepository.saveRun).toHaveBeenCalledWith(
+			'project-1',
+			'agent-1',
+			'user-1',
+			expect.objectContaining({
+				agentVersionId: 'version-2',
+			}),
+		);
+		expect(response.run).toEqual(expect.objectContaining({ agentVersionId: 'version-2' }));
+	});
+
+	it('runs the first evaluation with reviewed cases and recorded tool mocks', async () => {
+		const review = reviewFixture({
+			expectedOutput: 'Expected answer',
+			actualOutput: 'Old answer',
+		});
+		agentEvaluationCaseRepository.countByStatus.mockResolvedValue({
+			total: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+			approved: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+			rejected: 0,
+		});
+		agentEvaluationCaseRepository.findByAgent.mockResolvedValue([review]);
+		queryBuilder.getMany.mockResolvedValueOnce([
+			{
+				id: review.executionId,
+				threadId: 'thread-1',
+				createdAt: now,
+				userMessage: 'Question',
+				assistantResponse: 'Old answer',
+				error: null,
+				timeline: [
+					{
+						type: 'tool-call',
+						name: 'lookup',
+						output: { answer: 42 },
+					},
+				],
+				toolCalls: null,
+			} as AgentExecution,
+		]);
+		queryBuilder.getMany.mockResolvedValueOnce([
+			{
+				id: 'execution-0',
+				threadId: 'thread-1',
+				createdAt: new Date('2026-05-18T11:00:00.000Z'),
+				userMessage: 'Earlier question',
+				assistantResponse: 'Earlier answer',
+				error: null,
+				timeline: null,
+				toolCalls: null,
+			} as AgentExecution,
+		]);
+		agentsService.executeEvaluationCase.mockResolvedValue({
+			output: 'Expected answer',
+			error: null,
+			finishReason: 'stop',
+			durationMs: 125,
+			toolCalls: [{ name: 'lookup', input: { query: 'Question' }, output: { answer: 42 } }],
+			missingToolMocks: [],
+			warnings: [],
+		});
+
+		const response = await service.runSuite('project-1', 'agent-1', 'user-1');
+
+		expect(agentEvaluationCaseRepository.findByAgent).toHaveBeenCalledWith(
+			'project-1',
+			'agent-1',
+			AGENT_EVALUATION_MIN_REVIEWED_CASES,
+		);
+		expect(agentsService.executeEvaluationCase).toHaveBeenCalledWith({
+			agentId: 'agent-1',
+			agentVersionId: 'version-1',
+			projectId: 'project-1',
+			userId: 'user-1',
+			message: 'Question',
+			conversationHistory: [
+				{ role: 'user', text: 'Earlier question' },
+				{ role: 'assistant', text: 'Earlier answer' },
+			],
+			toolMocks: [{ toolName: 'lookup', outputs: [{ answer: 42 }] }],
+		});
+		expect(agentEvaluationRunRepository.saveRun).toHaveBeenCalledWith(
+			'project-1',
+			'agent-1',
+			'user-1',
+			expect.objectContaining({
+				suiteId: 'agent-agent-1-reviewed-cases-v0',
+				agentVersionId: 'version-1',
+			}),
+		);
+		expect(response.run).toEqual(
+			expect.objectContaining({
+				suiteId: 'agent-agent-1-reviewed-cases-v0',
+				agentVersionId: 'version-1',
+				summary: {
+					totalCases: 1,
+					passedCases: 1,
+					failedCases: 0,
+					errorCases: 0,
+					averageScore: 1,
+				},
+				cases: [
+					expect.objectContaining({
+						caseId: review.id,
+						status: 'passed',
+						output: 'Expected answer',
+						toolCalls: [
+							{
+								name: 'lookup',
+								input: { query: 'Question' },
+								output: { answer: 42 },
+								mocked: true,
+								missingMock: false,
+							},
+						],
+					}),
+				],
+			}),
+		);
+	});
+
+	it('runs only the metrics selected for the suite', async () => {
+		const review = reviewFixture({
+			expectedOutput: 'Expected answer',
+			actualOutput: 'Old answer',
+		});
+		agentEvaluationCaseRepository.countByStatus.mockResolvedValue({
+			total: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+			approved: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+			rejected: 0,
+		});
+		agentEvaluationCaseRepository.findByAgent.mockResolvedValue([review]);
+		agentsService.executeEvaluationCase.mockResolvedValue({
+			output: 'Expected answer',
+			error: null,
+			finishReason: 'stop',
+			durationMs: 125,
+			toolCalls: [],
+			missingToolMocks: [],
+			warnings: [],
+		});
+
+		const response = await service.runSuite('project-1', 'agent-1', 'user-1', {
+			enabledMetricIds: ['answer-correctness'],
+		});
+
+		expect(response.run?.cases[0].metrics).toEqual([
+			expect.objectContaining({ id: 'answer-correctness', pass: true }),
+		]);
+	});
+
+	it('does not pass different non-Latin answers as empty-token matches', async () => {
+		const review = reviewFixture({
+			expectedOutput: '猫です',
+			actualOutput: '猫です',
+		});
+		agentEvaluationCaseRepository.countByStatus.mockResolvedValue({
+			total: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+			approved: AGENT_EVALUATION_MIN_REVIEWED_CASES,
+			rejected: 0,
+		});
+		agentEvaluationCaseRepository.findByAgent.mockResolvedValue([review]);
+		agentsService.executeEvaluationCase.mockResolvedValue({
+			output: '犬です',
+			error: null,
+			finishReason: 'stop',
+			durationMs: 125,
+			toolCalls: [],
+			missingToolMocks: [],
+			warnings: [],
+		});
+
+		const response = await service.runSuite('project-1', 'agent-1', 'user-1', {
+			enabledMetricIds: ['answer-correctness'],
+		});
+
+		expect(response.run?.cases[0]).toEqual(
+			expect.objectContaining({
+				status: 'failed',
+				metrics: [
+					expect.objectContaining({
+						id: 'answer-correctness',
+						score: 0,
+						pass: false,
+					}),
+				],
+			}),
+		);
+	});
+});

--- a/packages/cli/src/modules/agents/__tests__/agents.service.evaluation.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.service.evaluation.test.ts
@@ -1,0 +1,252 @@
+import type {
+	Agent as RuntimeAgent,
+	BuiltAgent,
+	BuiltTool,
+	CredentialProvider,
+	StreamChunk,
+} from '@n8n/agents';
+import type { AgentJsonConfig } from '@n8n/api-types';
+import { mockLogger } from '@n8n/backend-test-utils';
+import type { AgentsConfig, GlobalConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
+import { mock } from 'jest-mock-extended';
+
+import { CredentialsService } from '@/credentials/credentials.service';
+import type { Publisher } from '@/scaling/pubsub/publisher.service';
+import type { Telemetry } from '@/telemetry';
+
+import type { AgentExecutionService } from '../agent-execution.service';
+import { AgentSkillsService } from '../agent-skills.service';
+import type { AgentsToolsService } from '../agents-tools.service';
+import { AgentsService } from '../agents.service';
+import type { AgentPublishedVersion } from '../entities/agent-published-version.entity';
+import type { Agent } from '../entities/agent.entity';
+import type { N8NCheckpointStorage } from '../integrations/n8n-checkpoint-storage';
+import type { N8nMemory } from '../integrations/n8n-memory';
+import { buildFromJson } from '../json-config/from-json-config';
+import type { AgentPublishedVersionRepository } from '../repositories/agent-published-version.repository';
+import type { AgentRepository } from '../repositories/agent.repository';
+
+jest.mock('../json-config/from-json-config', () => ({
+	buildFromJson: jest.fn(),
+}));
+
+const agentId = 'agent-1';
+const projectId = 'project-1';
+const userId = 'user-1';
+
+type MockRuntimeAgent = RuntimeAgent & {
+	tool: jest.Mock;
+	stream: jest.Mock;
+};
+
+function makeAgent(overrides: Partial<Agent> = {}): Agent {
+	return {
+		id: agentId,
+		projectId,
+		versionId: 'version-1',
+		schema: null,
+		model: 'claude-3',
+		provider: 'anthropic',
+		credentialId: 'cred-1',
+		publishedVersion: null,
+		integrations: [],
+		tools: {},
+		skills: {},
+		updatedAt: new Date('2026-05-20T10:00:00.000Z'),
+		...overrides,
+	} as unknown as Agent;
+}
+
+function makePublishedVersion(
+	overrides: Partial<AgentPublishedVersion> = {},
+): AgentPublishedVersion {
+	return {
+		agentId,
+		publishedFromVersionId: 'version-1',
+		schema: null,
+		model: null,
+		provider: null,
+		credentialId: null,
+		tools: null,
+		skills: null,
+		publishedById: userId,
+		...overrides,
+	} as unknown as AgentPublishedVersion;
+}
+
+function streamFromChunks(chunks: StreamChunk[]) {
+	return {
+		runId: 'run-1',
+		stream: new ReadableStream<StreamChunk>({
+			start(controller) {
+				for (const chunk of chunks) controller.enqueue(chunk);
+				controller.close();
+			},
+		}),
+	};
+}
+
+function makeRuntimeAgent(chunks: StreamChunk[]): MockRuntimeAgent {
+	return {
+		name: 'Test Agent',
+		tool: jest.fn().mockReturnThis(),
+		stream: jest.fn().mockResolvedValue(streamFromChunks(chunks)),
+	} as unknown as MockRuntimeAgent;
+}
+
+function makeTool(name: string): BuiltTool {
+	return {
+		name,
+		description: `Replay ${name}`,
+		handler: async () => undefined,
+		editable: false,
+	};
+}
+
+describe('AgentsService evaluation and workflow execution', () => {
+	const buildFromJsonMock = jest.mocked(buildFromJson);
+	let service: AgentsService;
+	let agentRepository: jest.Mocked<AgentRepository>;
+	let agentExecutionService: jest.Mocked<AgentExecutionService>;
+	let agentsToolsService: jest.Mocked<AgentsToolsService>;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		Container.set(CredentialsService, mock<CredentialsService>());
+
+		agentRepository = mock<AgentRepository>();
+		agentExecutionService = mock<AgentExecutionService>();
+		agentExecutionService.recordMessage.mockResolvedValue('exec-id');
+		agentsToolsService = mock<AgentsToolsService>();
+
+		const logger = mockLogger();
+		service = new AgentsService(
+			logger,
+			agentRepository,
+			mock(),
+			mock(),
+			mock(),
+			mock(),
+			mock(),
+			mock(),
+			mock(),
+			mock(),
+			mock<N8NCheckpointStorage>(),
+			mock(),
+			mock(),
+			agentsToolsService,
+			mock<N8nMemory>(),
+			agentExecutionService,
+			mock<AgentPublishedVersionRepository>(),
+			new AgentSkillsService(logger, agentRepository),
+			mock<Publisher>(),
+			{ modules: ['node-tools-searcher'] } as unknown as AgentsConfig,
+			mock<GlobalConfig>({
+				multiMainSetup: { enabled: false },
+			} as Partial<GlobalConfig>),
+			mock<Telemetry>(),
+			mock(),
+		);
+	});
+
+	afterEach(() => {
+		Container.reset();
+	});
+
+	it('attaches evaluation mocks for runtime-injected environment and node tools', async () => {
+		const schema: AgentJsonConfig = {
+			name: 'Test Agent',
+			model: 'anthropic/claude-sonnet-4-5',
+			instructions: 'Be helpful',
+			config: { nodeTools: { enabled: true } },
+		};
+		agentRepository.findByIdAndProjectId.mockResolvedValue(makeAgent({ schema }));
+		agentsToolsService.getRuntimeTools.mockReturnValue([
+			makeTool('search_nodes'),
+			makeTool('get_node_types'),
+			makeTool('list_credentials'),
+			makeTool('run_node_tool'),
+		]);
+		const credentialProvider = mock<CredentialProvider>();
+		jest
+			.spyOn(service as never, 'createCredentialProvider')
+			.mockReturnValue(credentialProvider as never);
+		const runtimeAgent = makeRuntimeAgent([{ type: 'finish', finishReason: 'stop' }]);
+		buildFromJsonMock.mockResolvedValue(runtimeAgent);
+
+		await service.executeEvaluationCase({
+			agentId,
+			projectId,
+			userId,
+			message: 'What day is it?',
+			toolMocks: [
+				{ toolName: 'get_environment', outputs: [{ timezone: 'UTC' }] },
+				{ toolName: 'run_node_tool', outputs: [{ ok: true }] },
+			],
+		});
+
+		expect(agentsToolsService.getRuntimeTools).toHaveBeenCalledWith(credentialProvider, projectId);
+
+		const runtimeTools = runtimeAgent.tool.mock.calls.flatMap(([tools]) =>
+			Array.isArray(tools) ? tools : [tools],
+		) as BuiltTool[];
+		expect(runtimeTools.map((tool) => tool.name)).toEqual([
+			'get_environment',
+			'search_nodes',
+			'get_node_types',
+			'list_credentials',
+			'run_node_tool',
+		]);
+
+		await expect(
+			runtimeTools.find((tool) => tool.name === 'get_environment')?.handler?.({}, {}),
+		).resolves.toEqual({ timezone: 'UTC' });
+		await expect(
+			runtimeTools
+				.find((tool) => tool.name === 'run_node_tool')
+				?.handler?.({ nodeType: 'n8n-nodes-base.httpRequestTool' }, {}),
+		).resolves.toEqual({ ok: true });
+	});
+
+	it('records workflow executions against the version that was compiled', async () => {
+		const schema: AgentJsonConfig = {
+			name: 'Draft Agent',
+			model: 'anthropic/claude-sonnet-4-5',
+			instructions: 'Be helpful',
+		};
+		const agent = makeAgent({
+			versionId: 'draft-version-id',
+			schema,
+			publishedVersion: makePublishedVersion({
+				publishedFromVersionId: 'published-version-id',
+				schema,
+			}),
+		});
+		agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
+		const runtimeAgent = makeRuntimeAgent([
+			{ type: 'text-delta', id: 'text-1', delta: 'Done' },
+			{ type: 'finish', finishReason: 'stop' },
+		]);
+		jest
+			.spyOn(service as never, 'compileIsolated')
+			.mockResolvedValue({ ok: true, agent: runtimeAgent as BuiltAgent } as never);
+
+		await service.executeForWorkflow(
+			agentId,
+			'Run this',
+			'execution-1',
+			'thread-1',
+			userId,
+			projectId,
+		);
+
+		expect(agentExecutionService.recordMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				agentId,
+				agentVersionId: 'draft-version-id',
+				source: 'workflow',
+			}),
+		);
+	});
+});

--- a/packages/cli/src/modules/agents/agent-evaluations.controller.ts
+++ b/packages/cli/src/modules/agents/agent-evaluations.controller.ts
@@ -1,4 +1,5 @@
 import type {
+	AgentEvaluationSuiteRunRequest,
 	AgentEvaluationSuiteSetupRequest,
 } from '@n8n/api-types';
 import { Body, Get, Post, ProjectScope, RestController } from '@n8n/decorators';
@@ -38,6 +39,20 @@ export class AgentEvaluationsController {
 			req.params.projectId,
 			req.params.agentId,
 			payload?.agentVersionId,
+		);
+	}
+
+	@Post('/suite/run')
+	@ProjectScope('agent:execute')
+	async runSuite(
+		req: AuthenticatedRequest<{ projectId: string; agentId: string }>,
+		@Body payload?: AgentEvaluationSuiteRunRequest,
+	) {
+		return await this.agentEvaluationsService.runSuite(
+			req.params.projectId,
+			req.params.agentId,
+			req.user.id,
+			payload,
 		);
 	}
 }

--- a/packages/cli/src/modules/agents/agent-evaluations.service.ts
+++ b/packages/cli/src/modules/agents/agent-evaluations.service.ts
@@ -2,8 +2,13 @@ import type {
 	AgentEvaluationDatasetReadiness,
 	AgentEvaluationDatasetResponse,
 	AgentEvaluationMetricSuggestion,
+	AgentEvaluationRunCaseResult,
+	AgentEvaluationRunMetricResult,
+	AgentEvaluationRunSummary,
 	AgentEvaluationSuiteDraft,
 	AgentEvaluationSuiteRun,
+	AgentEvaluationSuiteRunRequest,
+	AgentEvaluationSuiteRunResponse,
 	AgentEvaluationSuiteSetupResponse,
 	AgentEvaluationVersionSummary,
 	AgentReviewCase,
@@ -11,17 +16,28 @@ import type {
 } from '@n8n/api-types';
 import { AGENT_EVALUATION_MIN_REVIEWED_CASES } from '@n8n/api-types';
 import { Service } from '@n8n/di';
+import { randomUUID } from 'crypto';
 
+import {
+	AgentsService,
+	type AgentEvaluationConversationMessage,
+	type AgentEvaluationToolMock,
+} from './agents.service';
 import type { AgentEvaluationCase } from './entities/agent-evaluation-case.entity';
 import type { AgentEvaluationRun } from './entities/agent-evaluation-run.entity';
+import type { AgentExecution } from './entities/agent-execution.entity';
+import type { TimelineEvent } from './execution-recorder';
 import { AgentEvaluationCaseRepository } from './repositories/agent-evaluation-case.repository';
 import { AgentEvaluationRunRepository } from './repositories/agent-evaluation-run.repository';
+import { AgentExecutionRepository } from './repositories/agent-execution.repository';
 import { AgentRepository } from './repositories/agent.repository';
 import { getAgentCurrentVersionId } from './utils/agent-version.utils';
 
 const DATASET_PREVIEW_LIMIT = 10;
 const RECENT_RUNS_LIMIT = 20;
 const SUITE_CASE_LIMIT = 100;
+const FIRST_RUN_CASE_LIMIT = AGENT_EVALUATION_MIN_REVIEWED_CASES;
+const SIMILARITY_PASS_THRESHOLD = 0.65;
 const ANSWER_CORRECTNESS_METRIC_ID = 'answer-correctness';
 const CALLED_TOOLS_METRIC_ID = 'called-tools-unordered';
 
@@ -32,11 +48,18 @@ interface AgentEvaluationVersionContext {
 	versions: AgentEvaluationVersionSummary[];
 }
 
+interface ExpectedToolCall {
+	id: string;
+	name: string;
+}
+
 @Service()
 export class AgentEvaluationsService {
 	constructor(
 		private readonly agentEvaluationCaseRepository: AgentEvaluationCaseRepository,
 		private readonly agentEvaluationRunRepository: AgentEvaluationRunRepository,
+		private readonly agentExecutionRepository: AgentExecutionRepository,
+		private readonly agentsService: AgentsService,
 		private readonly agentRepository: AgentRepository,
 	) {}
 
@@ -103,6 +126,152 @@ export class AgentEvaluationsService {
 		};
 	}
 
+	async runSuite(
+		projectId: string,
+		agentId: string,
+		userId: string,
+		options: AgentEvaluationSuiteRunRequest = {},
+	): Promise<AgentEvaluationSuiteRunResponse> {
+		const summary = await this.agentEvaluationCaseRepository.countByStatus(projectId, agentId);
+		const versionContext = await this.resolveVersionContext(projectId, agentId, summary);
+		if (!versionContext) return this.emptySuiteRunResponse();
+
+		const cases = await this.agentEvaluationCaseRepository.findByAgent(
+			projectId,
+			agentId,
+			FIRST_RUN_CASE_LIMIT,
+		);
+		const readiness = this.toReadiness(summary, versionContext);
+
+		if (!readiness.isReady || !readiness.agentVersionCanRun) {
+			return {
+				currentAgentVersionId: versionContext.currentAgentVersionId,
+				versions: versionContext.versions,
+				readiness,
+				run: null,
+			};
+		}
+
+		const startedAt = new Date();
+		const warnings = new Set<string>();
+		const executionsById = await this.findExecutionsById(
+			projectId,
+			agentId,
+			cases.map((evaluationCase) => evaluationCase.executionId),
+		);
+		const results: AgentEvaluationRunCaseResult[] = [];
+		const metrics = this.selectMetrics(options.enabledMetricIds);
+
+		for (const evaluationCase of cases) {
+			const execution = executionsById.get(evaluationCase.executionId) ?? null;
+			if (!execution) {
+				warnings.add('Some reviewed cases no longer have recorded run data.');
+			}
+
+			const toolMocks = execution ? this.toToolMocks(execution) : [];
+			const conversationHistory = execution
+				? this.toConversationHistory(
+						await this.findConversationHistoryBefore(projectId, agentId, execution),
+					)
+				: [];
+			try {
+				const executionResult = await this.agentsService.executeEvaluationCase({
+					agentId,
+					agentVersionId: versionContext.selectedAgentVersionId,
+					projectId,
+					userId,
+					message: evaluationCase.input,
+					conversationHistory,
+					toolMocks,
+				});
+				for (const warning of executionResult.warnings) warnings.add(warning);
+				if (executionResult.missingToolMocks.length > 0) {
+					warnings.add('Some tool calls did not have recorded outputs.');
+				}
+
+				const expectedToolNames = execution
+					? this.toExpectedToolNames(execution, evaluationCase)
+					: [];
+				const actualToolNames = executionResult.toolCalls.map((toolCall) => toolCall.name);
+				const metricResults = metrics.map((metric) =>
+					this.scoreMetric(
+						metric,
+						evaluationCase,
+						executionResult.output,
+						executionResult.error,
+						expectedToolNames,
+						actualToolNames,
+					),
+				);
+				const status =
+					executionResult.error !== null
+						? 'error'
+						: metricResults.every((metric) => metric.pass)
+							? 'passed'
+							: 'failed';
+
+				results.push({
+					caseId: evaluationCase.id,
+					input: evaluationCase.input,
+					expectedOutput: evaluationCase.expectedOutput,
+					output: executionResult.output,
+					status,
+					durationMs: executionResult.durationMs,
+					error: executionResult.error,
+					metrics: metricResults,
+					toolCalls: executionResult.toolCalls.map((toolCall) => ({
+						name: toolCall.name,
+						input: toolCall.input,
+						output: toolCall.output,
+						mocked: !executionResult.missingToolMocks.includes(toolCall.name),
+						missingMock: executionResult.missingToolMocks.includes(toolCall.name),
+					})),
+					missingToolMocks: executionResult.missingToolMocks,
+				});
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				results.push({
+					caseId: evaluationCase.id,
+					input: evaluationCase.input,
+					expectedOutput: evaluationCase.expectedOutput,
+					output: '',
+					status: 'error',
+					durationMs: 0,
+					error: message,
+					metrics: metrics.map((metric) => ({
+						id: metric.id,
+						name: metric.name,
+						score: 0,
+						pass: false,
+						reason: 'The evaluation case could not run.',
+					})),
+					toolCalls: [],
+					missingToolMocks: [],
+				});
+			}
+		}
+
+		const completedAt = new Date();
+		const run: AgentEvaluationSuiteRun = {
+			id: randomUUID(),
+			suiteId: this.toSuiteId(agentId),
+			agentVersionId: versionContext.selectedAgentVersionId,
+			startedAt: startedAt.toISOString(),
+			completedAt: completedAt.toISOString(),
+			summary: this.toRunSummary(results),
+			cases: results,
+			warnings: [...warnings],
+		};
+		await this.agentEvaluationRunRepository.saveRun(projectId, agentId, userId, run);
+
+		return {
+			currentAgentVersionId: versionContext.currentAgentVersionId,
+			versions: versionContext.versions,
+			readiness,
+			run,
+		};
+	}
+
 	private emptySummary(): AgentReviewSummary {
 		return { total: 0, approved: 0, rejected: 0 };
 	}
@@ -136,6 +305,15 @@ export class AgentEvaluationsService {
 			versions: [],
 			readiness: this.emptyReadiness(),
 			suite: null,
+		};
+	}
+
+	private emptySuiteRunResponse(): AgentEvaluationSuiteRunResponse {
+		return {
+			currentAgentVersionId: '',
+			versions: [],
+			readiness: this.emptyReadiness(),
+			run: null,
 		};
 	}
 
@@ -265,6 +443,275 @@ export class AgentEvaluationsService {
 				enabled: true,
 			},
 		];
+	}
+
+	private selectMetrics(enabledMetricIds: string[] | undefined): AgentEvaluationMetricSuggestion[] {
+		const metrics = this.suggestMetrics();
+		if (!enabledMetricIds || enabledMetricIds.length === 0) return metrics;
+
+		const enabled = new Set(enabledMetricIds);
+		return metrics.filter((metric) => enabled.has(metric.id));
+	}
+
+	private async findExecutionsById(
+		projectId: string,
+		agentId: string,
+		executionIds: string[],
+	): Promise<Map<string, AgentExecution>> {
+		if (executionIds.length === 0) return new Map();
+
+		const executions = await this.agentExecutionRepository
+			.createQueryBuilder('execution')
+			.innerJoin('execution.thread', 'thread')
+			.where('execution.id IN (:...executionIds)', { executionIds })
+			.andWhere('thread.projectId = :projectId', { projectId })
+			.andWhere('thread.agentId = :agentId', { agentId })
+			.getMany();
+
+		return new Map(executions.map((execution) => [execution.id, execution]));
+	}
+
+	private async findConversationHistoryBefore(
+		projectId: string,
+		agentId: string,
+		execution: AgentExecution,
+	): Promise<AgentExecution[]> {
+		return await this.agentExecutionRepository
+			.createQueryBuilder('execution')
+			.innerJoin('execution.thread', 'thread')
+			.where('execution.threadId = :threadId', { threadId: execution.threadId })
+			.andWhere('execution.createdAt < :createdAt', { createdAt: execution.createdAt })
+			.andWhere('thread.projectId = :projectId', { projectId })
+			.andWhere('thread.agentId = :agentId', { agentId })
+			.orderBy('execution.createdAt', 'ASC')
+			.getMany();
+	}
+
+	private toConversationHistory(
+		executions: AgentExecution[],
+	): AgentEvaluationConversationMessage[] {
+		return executions.flatMap((execution) => {
+			const messages: AgentEvaluationConversationMessage[] = [];
+			if (execution.userMessage?.trim()) {
+				messages.push({ role: 'user', text: execution.userMessage });
+			}
+			const assistantText =
+				execution.assistantResponse?.trim() ||
+				(execution.error?.trim() ? `Error: ${execution.error}` : '');
+			if (assistantText) {
+				messages.push({ role: 'assistant', text: assistantText });
+			}
+			return messages;
+		});
+	}
+
+	private toToolMocks(execution: AgentExecution): AgentEvaluationToolMock[] {
+		const outputsByToolName = new Map<string, unknown[]>();
+
+		for (const event of execution.timeline ?? []) {
+			if (!this.isToolCallEvent(event)) continue;
+			if (event.output === undefined) continue;
+			this.addToolMockOutput(outputsByToolName, event.name, event.output);
+		}
+
+		if (outputsByToolName.size === 0) {
+			for (const toolCall of execution.toolCalls ?? []) {
+				if (toolCall.output === undefined) continue;
+				this.addToolMockOutput(outputsByToolName, toolCall.name, toolCall.output);
+			}
+		}
+
+		return [...outputsByToolName.entries()].map(([toolName, outputs]) => ({
+			toolName,
+			outputs,
+		}));
+	}
+
+	private addToolMockOutput(
+		outputsByToolName: Map<string, unknown[]>,
+		toolName: string,
+		output: unknown,
+	): void {
+		const outputs = outputsByToolName.get(toolName) ?? [];
+		outputs.push(output);
+		outputsByToolName.set(toolName, outputs);
+	}
+
+	private isToolCallEvent(
+		event: TimelineEvent,
+	): event is Extract<TimelineEvent, { type: 'tool-call' }> {
+		return event.type === 'tool-call';
+	}
+
+	private toExpectedToolNames(
+		execution: AgentExecution,
+		evaluationCase: AgentEvaluationCase,
+	): string[] {
+		const expectedCalls = this.toExpectedToolCalls(execution);
+		if (
+			evaluationCase.status !== 'rejected' ||
+			evaluationCase.rejectionReason !== 'wrong_tool_calling' ||
+			!evaluationCase.toolCallCorrection
+		) {
+			return expectedCalls.map((toolCall) => toolCall.name);
+		}
+
+		const correctedCalls = [...expectedCalls];
+		for (const toolCallToRemove of evaluationCase.toolCallCorrection.removeToolCalls) {
+			const indexById = correctedCalls.findIndex((toolCall) => toolCall.id === toolCallToRemove.id);
+			if (indexById !== -1) {
+				correctedCalls.splice(indexById, 1);
+				continue;
+			}
+
+			const indexByName = correctedCalls.findIndex(
+				(toolCall) => toolCall.name === toolCallToRemove.name,
+			);
+			if (indexByName !== -1) correctedCalls.splice(indexByName, 1);
+		}
+
+		return [
+			...correctedCalls.map((toolCall) => toolCall.name),
+			...evaluationCase.toolCallCorrection.addToolNames,
+		];
+	}
+
+	private toExpectedToolCalls(execution: AgentExecution): ExpectedToolCall[] {
+		const timelineToolCalls = (execution.timeline ?? [])
+			.filter((event) => this.isToolCallEvent(event))
+			.map((event, index) => ({
+				id: event.toolCallId ?? `${execution.id}:tool:${index}`,
+				name: event.name,
+			}));
+
+		if (timelineToolCalls.length > 0) return timelineToolCalls;
+
+		return (execution.toolCalls ?? []).map((toolCall, index) => ({
+			id: `${execution.id}:tool:${index}`,
+			name: toolCall.name,
+		}));
+	}
+
+	private scoreMetric(
+		metric: AgentEvaluationMetricSuggestion,
+		evaluationCase: AgentEvaluationCase,
+		output: string,
+		error: string | null,
+		expectedToolNames: string[],
+		actualToolNames: string[],
+	): AgentEvaluationRunMetricResult {
+		if (metric.id === CALLED_TOOLS_METRIC_ID) {
+			return this.scoreCalledToolsMetric(metric, expectedToolNames, actualToolNames, error);
+		}
+
+		const score = this.scoreTextSimilarity(output, evaluationCase.expectedOutput);
+		const pass = error === null && score >= SIMILARITY_PASS_THRESHOLD;
+		return {
+			id: metric.id,
+			name: metric.name,
+			score,
+			pass,
+			reason: pass
+				? 'The answer matches the expected answer.'
+				: 'The answer differs from the expected answer.',
+		};
+	}
+
+	private scoreCalledToolsMetric(
+		metric: AgentEvaluationMetricSuggestion,
+		expectedToolNames: string[],
+		actualToolNames: string[],
+		error: string | null,
+	): AgentEvaluationRunMetricResult {
+		const expected = this.toSortedToolNames(expectedToolNames);
+		const actual = this.toSortedToolNames(actualToolNames);
+		const pass = error === null && this.sameStringList(expected, actual);
+		const score = error === null ? this.scoreToolListOverlap(expected, actual) : 0;
+
+		return {
+			id: metric.id,
+			name: metric.name,
+			score,
+			pass,
+			reason: pass
+				? 'The called tools match the reviewed expectation.'
+				: `Expected tools: ${this.formatToolList(expected)}. Called tools: ${this.formatToolList(actual)}.`,
+		};
+	}
+
+	private toSortedToolNames(toolNames: string[]): string[] {
+		return toolNames
+			.map((toolName) => toolName.trim())
+			.filter(Boolean)
+			.sort();
+	}
+
+	private sameStringList(left: string[], right: string[]): boolean {
+		return left.length === right.length && left.every((value, index) => value === right[index]);
+	}
+
+	private scoreToolListOverlap(expected: string[], actual: string[]): number {
+		if (expected.length === 0 && actual.length === 0) return 1;
+		if (expected.length === 0 || actual.length === 0) return 0;
+
+		const actualCounts = new Map<string, number>();
+		for (const toolName of actual) {
+			actualCounts.set(toolName, (actualCounts.get(toolName) ?? 0) + 1);
+		}
+
+		let overlap = 0;
+		for (const toolName of expected) {
+			const count = actualCounts.get(toolName) ?? 0;
+			if (count === 0) continue;
+			overlap += 1;
+			actualCounts.set(toolName, count - 1);
+		}
+
+		return overlap / Math.max(expected.length, actual.length);
+	}
+
+	private formatToolList(toolNames: string[]): string {
+		return toolNames.length > 0 ? toolNames.join(', ') : 'none';
+	}
+
+	private scoreTextSimilarity(left: string, right: string): number {
+		const leftTokens = new Set(this.toTokens(left));
+		const rightTokens = new Set(this.toTokens(right));
+		if (leftTokens.size === 0 && rightTokens.size === 0) return 1;
+		if (leftTokens.size === 0 || rightTokens.size === 0) return 0;
+
+		let overlap = 0;
+		for (const token of leftTokens) {
+			if (rightTokens.has(token)) overlap += 1;
+		}
+		return overlap / new Set([...leftTokens, ...rightTokens]).size;
+	}
+
+	private toTokens(value: string): string[] {
+		return (
+			value
+				.normalize('NFKC')
+				.toLocaleLowerCase()
+				.match(/[\p{L}\p{N}]+/gu) ?? []
+		);
+	}
+
+	private toRunSummary(results: AgentEvaluationRunCaseResult[]): AgentEvaluationRunSummary {
+		const totalCases = results.length;
+		const passedCases = results.filter((result) => result.status === 'passed').length;
+		const errorCases = results.filter((result) => result.status === 'error').length;
+		const failedCases = totalCases - passedCases - errorCases;
+		const scores = results.flatMap((result) => result.metrics.map((metric) => metric.score));
+		const averageScore =
+			scores.length === 0 ? 0 : scores.reduce((total, score) => total + score, 0) / scores.length;
+
+		return {
+			totalCases,
+			passedCases,
+			failedCases,
+			errorCases,
+			averageScore,
+		};
 	}
 
 	private toRunDto(run: AgentEvaluationRun): AgentEvaluationSuiteRun {

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -1,5 +1,6 @@
 import type {
 	Agent as RuntimeAgent,
+	AgentMessage,
 	AgentExecutionCounter,
 	BuiltAgent,
 	BuiltTool,
@@ -41,12 +42,14 @@ import { OnPubSubEvent } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
 import {
 	deepCopy,
+	nodeNameToToolName,
 	OperationalError,
 	UserError,
 	type ExecuteAgentData,
 	type INodeParameters,
 } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
+import { z } from 'zod';
 
 import { ActiveExecutions } from '@/active-executions';
 import { CredentialsService } from '@/credentials/credentials.service';
@@ -72,12 +75,16 @@ import { AgentSkillsService } from './agent-skills.service';
 import { AgentsToolsService } from './agents-tools.service';
 import { AGENT_THREAD_PREFIX } from './builder/builder-tool-names';
 import { Agent } from './entities/agent.entity';
-import { ExecutionRecorder } from './execution-recorder';
+import { ExecutionRecorder, type RecordedToolCall } from './execution-recorder';
 import { ChatIntegrationRegistry } from './integrations/agent-chat-integration';
 import { syncAgentIntegrations } from './integrations/integrations-sync';
 import { N8NCheckpointStorage } from './integrations/n8n-checkpoint-storage';
 import { N8nMemory } from './integrations/n8n-memory';
-import { composeJsonConfig, decomposeJsonConfig } from './json-config/agent-config-composition';
+import {
+	composeJsonConfig,
+	decomposeJsonConfig,
+	sanitizeToolName,
+} from './json-config/agent-config-composition';
 import {
 	buildFromJson,
 	type MemoryFactory,
@@ -173,6 +180,36 @@ interface GetRuntimeParams {
 	integrationType?: string;
 	/** When true, load the published snapshot; n8nUserId is derived from publishedById when omitted. */
 	usePublishedVersion?: boolean;
+}
+
+export interface AgentEvaluationToolMock {
+	toolName: string;
+	outputs: unknown[];
+}
+
+export interface AgentEvaluationConversationMessage {
+	role: 'user' | 'assistant';
+	text: string;
+}
+
+export interface ExecuteEvaluationCaseConfig {
+	agentId: string;
+	agentVersionId?: string;
+	projectId: string;
+	userId: string;
+	message: string;
+	conversationHistory?: AgentEvaluationConversationMessage[];
+	toolMocks: AgentEvaluationToolMock[];
+}
+
+export interface AgentEvaluationExecutionResult {
+	output: string;
+	error: string | null;
+	finishReason: string;
+	durationMs: number;
+	toolCalls: RecordedToolCall[];
+	missingToolMocks: string[];
+	warnings: string[];
 }
 
 @Service()
@@ -978,6 +1015,256 @@ export class AgentsService {
 	 */
 	async clearTestChatMessages(agentId: string, userId: string) {
 		await this.n8nMemory.deleteMessagesByThread(chatThreadId(agentId, userId), userId);
+	}
+
+	async executeEvaluationCase(
+		config: ExecuteEvaluationCaseConfig,
+	): Promise<AgentEvaluationExecutionResult> {
+		const {
+			agentId,
+			agentVersionId,
+			projectId,
+			message,
+			conversationHistory = [],
+			toolMocks,
+		} = config;
+		const agentEntity = await this.agentRepository.findByIdAndProjectId(agentId, projectId);
+		if (!agentEntity) throw new NotFoundError(`Agent ${agentId} not found`);
+
+		const currentAgentVersionId = getAgentCurrentVersionId(agentEntity);
+		const publishedAgentVersionId = agentEntity.publishedVersion?.publishedFromVersionId ?? null;
+		const shouldUsePublishedVersion =
+			agentVersionId !== undefined &&
+			agentVersionId !== currentAgentVersionId &&
+			agentVersionId === publishedAgentVersionId;
+		if (
+			agentVersionId !== undefined &&
+			agentVersionId !== currentAgentVersionId &&
+			!shouldUsePublishedVersion
+		) {
+			throw new UserError('Agent version is no longer available to run.');
+		}
+
+		const sourceSchema = shouldUsePublishedVersion
+			? agentEntity.publishedVersion?.schema
+			: agentEntity.schema;
+		if (!sourceSchema) throw new UserError('Agent has no JSON config.');
+
+		const sourceTools = shouldUsePublishedVersion
+			? (agentEntity.publishedVersion?.tools ?? {})
+			: (agentEntity.tools ?? {});
+		const sourceSkills = shouldUsePublishedVersion
+			? (agentEntity.publishedVersion?.skills ?? {})
+			: (agentEntity.skills ?? {});
+
+		const evaluationConfig = this.toEvaluationRunConfig(sourceSchema);
+		const providerToolsDisabled =
+			sourceSchema.providerTools !== undefined &&
+			Object.keys(sourceSchema.providerTools).length > 0;
+		const warnings = providerToolsDisabled
+			? ['Provider tools are disabled in v0 evaluation runs.']
+			: [];
+
+		const toolDescriptors: Record<string, ToolDescriptor> = {};
+		for (const [toolId, toolEntry] of Object.entries(sourceTools)) {
+			toolDescriptors[toolId] = toolEntry.descriptor;
+		}
+
+		const outputsByToolName = new Map(
+			toolMocks.map(({ toolName, outputs }) => [toolName, [...outputs]]),
+		);
+		const missingToolMocks = new Set<string>();
+		const takeMockOutput = (toolName: string, input: unknown): unknown => {
+			const outputs = outputsByToolName.get(toolName);
+			if (outputs && outputs.length > 0) {
+				return outputs.shift();
+			}
+			missingToolMocks.add(toolName);
+			return {
+				mocked: false,
+				toolName,
+				input,
+				message: `No recorded output is available for "${toolName}".`,
+			};
+		};
+
+		const toolExecutor = {
+			executeTool: async (toolName: string, input: unknown) => takeMockOutput(toolName, input),
+		};
+		const resolvedTools: BuiltTool[] = [];
+		const credentialProvider = this.createCredentialProvider(projectId);
+
+		const agentInstance = await buildFromJson(evaluationConfig, toolDescriptors, {
+			toolExecutor,
+			credentialProvider,
+			resolveTool: async (ref) => {
+				const resolved = this.createEvaluationMockTool(ref, takeMockOutput);
+				resolvedTools.push(resolved);
+				return resolved;
+			},
+			skills: sourceSkills,
+			memoryFactory: this.getMemoryFactory(),
+		});
+		const runtimeTools = await this.injectEvaluationRuntimeMocks({
+			agent: agentInstance,
+			config: evaluationConfig,
+			credentialProvider,
+			projectId,
+			takeMockOutput,
+			warnings,
+		});
+		resolvedTools.push(...runtimeTools);
+
+		const recorder = new ExecutionRecorder(buildToolRegistry(resolvedTools));
+		const input = this.toEvaluationInput(message, conversationHistory);
+		const resultStream = await agentInstance.stream(input, {
+			executionCounter: this.createAgentExecutionCounter(agentId),
+		});
+
+		const reader = resultStream.stream.getReader();
+		try {
+			while (true) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				recorder.record(value);
+			}
+		} finally {
+			reader.releaseLock();
+		}
+
+		const record = recorder.getMessageRecord();
+		return {
+			output: record.assistantResponse,
+			error: record.error,
+			finishReason: record.finishReason,
+			durationMs: record.duration,
+			toolCalls: record.toolCalls,
+			missingToolMocks: [...missingToolMocks],
+			warnings,
+		};
+	}
+
+	private toEvaluationInput(
+		message: string,
+		conversationHistory: AgentEvaluationConversationMessage[],
+	): string | AgentMessage[] {
+		if (conversationHistory.length === 0) return message;
+
+		return [
+			...conversationHistory.map((historyMessage) => this.toAgentTextMessage(historyMessage)),
+			this.toAgentTextMessage({ role: 'user', text: message }),
+		];
+	}
+
+	private toAgentTextMessage(message: AgentEvaluationConversationMessage): AgentMessage {
+		return {
+			role: message.role,
+			content: [{ type: 'text', text: message.text }],
+		};
+	}
+
+	private toEvaluationRunConfig(config: AgentJsonConfig): AgentJsonConfig {
+		const evaluationConfig = { ...config };
+		delete evaluationConfig.memory;
+		delete evaluationConfig.providerTools;
+		if (evaluationConfig.tools) {
+			evaluationConfig.tools = evaluationConfig.tools.map((tool) => ({
+				...tool,
+				requireApproval: false,
+			}));
+		}
+		return evaluationConfig;
+	}
+
+	private createEvaluationMockTool(
+		ref: AgentJsonToolConfig,
+		takeMockOutput: (toolName: string, input: unknown) => unknown,
+	): BuiltTool {
+		if (ref.type === 'workflow') {
+			const toolName = sanitizeToolName(ref.name ?? ref.workflow);
+			return {
+				name: toolName,
+				description: ref.description ?? `Replay the recorded output for "${ref.workflow}"`,
+				inputSchema: z.object({}).catchall(z.unknown()),
+				handler: async (input) => takeMockOutput(toolName, input),
+				editable: false,
+				metadata: {
+					kind: 'workflow',
+					workflowId: ref.workflow,
+					workflowName: ref.workflow,
+				},
+			};
+		}
+
+		if (ref.type !== 'node') {
+			throw new UserError(`Tool type "${ref.type}" cannot be mocked through resolveTool`);
+		}
+
+		const toolName = nodeNameToToolName(ref.name);
+		return {
+			name: toolName,
+			description: ref.description ?? `Replay the recorded output for "${ref.name}"`,
+			inputSchema: z.object({}).catchall(z.unknown()),
+			handler: async (input) => takeMockOutput(toolName, input),
+			editable: false,
+			metadata: {
+				kind: 'node',
+				nodeType: ref.node.nodeType,
+				nodeTypeVersion: ref.node.nodeTypeVersion,
+				displayName: ref.name,
+				nodeParameters: ref.node.nodeParameters,
+			},
+		};
+	}
+
+	private async injectEvaluationRuntimeMocks(params: {
+		agent: RuntimeAgent;
+		config: AgentJsonConfig;
+		credentialProvider: CredentialProvider;
+		projectId: string;
+		takeMockOutput: (toolName: string, input: unknown) => unknown;
+		warnings: string[];
+	}): Promise<BuiltTool[]> {
+		const { agent, config, credentialProvider, projectId, takeMockOutput, warnings } = params;
+		const tools: BuiltTool[] = [];
+
+		try {
+			const { createGetEnvironmentTool } = await import('./tools/environment-tool');
+			tools.push(
+				this.toEvaluationRuntimeMockTool(createGetEnvironmentTool().build(), takeMockOutput),
+			);
+		} catch (toolError) {
+			this.logger.warn('Failed to inject get_environment mock tool for evaluation', {
+				error: toolError instanceof Error ? toolError.message : String(toolError),
+			});
+			warnings.push('The get_environment tool is unavailable in this evaluation run.');
+		}
+
+		if (this.shouldAttachNodeTools(config.config)) {
+			tools.push(
+				...this.agentsToolsService
+					.getRuntimeTools(credentialProvider, projectId)
+					.map((tool) => this.toEvaluationRuntimeMockTool(tool, takeMockOutput)),
+			);
+		}
+
+		if (tools.length > 0) agent.tool(tools);
+		return tools;
+	}
+
+	private toEvaluationRuntimeMockTool(
+		tool: BuiltTool,
+		takeMockOutput: (toolName: string, input: unknown) => unknown,
+	): BuiltTool {
+		return {
+			...tool,
+			handler: async (input) => takeMockOutput(tool.name, input),
+			editable: false,
+			metadata: {
+				...tool.metadata,
+				evaluationRuntimeTool: true,
+			},
+		};
 	}
 
 	/** Delete all test-chat messages + the thread row — used when the agent itself is deleted. */


### PR DESCRIPTION
## Summary

Adds backend execution for agent evaluation suites. This PR builds on the setup API PR and adds the runtime path that replays reviewed cases against the current agent version.

The execution path covers:

| Area | Responsibility |
|---|---|
| suite run endpoint | Run the first evaluation over the minimum reviewed-case set |
| evaluation runtime | Execute an agent without memory/provider tools and with recorded tool outputs |
| tool mocks | Replay recorded workflow/node/runtime tool outputs where available |
| scoring | Score answer correctness and unordered tool-calling expectations |
| persistence | Save completed evaluation runs for later viewing and comparison |

### How to test

Targeted backend tests were run from `packages/cli`:

```bash
pnpm test src/modules/agents/__tests__/agent-debug.controller.test.ts src/modules/agents/__tests__/agent-debug.service.test.ts src/modules/agents/__tests__/agent-evaluations.controller.test.ts src/modules/agents/__tests__/agent-evaluations.service.test.ts src/modules/agents/__tests__/agents.service.evaluation.test.ts
```

Result: 5 suites passed, 31 tests passed.

> **Note: this is part of a multi-step PR series delivering agent evaluations.**
>
> 1. persistence and shared contracts - `TRUST-12-agent-evals-01-persistence`
> 2. agent debug backend APIs - `TRUST-12-agent-evals-02-debug-backend`
> 3. agent debug frontend - `TRUST-12-agent-evals-03-debug-frontend`
> 4. evaluation setup backend APIs - `TRUST-12-agent-evals-04-eval-setup-backend`
> 5. <- **you are here** - evaluation execution backend
> 6. evaluation frontend - `TRUST-12-agent-evals-06-eval-frontend`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-12

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
