### PR TITLE
feat(core): Add `dropEnumCheck` helper to migration DSL (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/migrations/dsl/__tests__/enum-check.test.ts
+++ b/packages/@n8n/db/src/migrations/dsl/__tests__/enum-check.test.ts
@@ -2,7 +2,7 @@ import type { Driver, QueryRunner, Table } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
 
 import { Column } from '../column';
-import { AddColumns, CreateTable } from '../table';
+import { AddColumns, CreateTable, DropEnumCheck } from '../table';
 
 const createMocks = (escapeChar = '"') => {
 	const driver = mock<Driver>();
@@ -118,6 +118,30 @@ describe('CreateTable with column-level enum checks', () => {
 
 		const tableArg: Table = queryRunner.createTable.mock.calls[0][0];
 		expect(tableArg.checks).toHaveLength(0);
+	});
+});
+
+describe('DropEnumCheck', () => {
+	it('should drop the check constraint with correct name', async () => {
+		const { queryRunner } = createMocks();
+
+		await new DropEnumCheck('test_table', 'status', 'n8n_', queryRunner);
+
+		expect(queryRunner.dropCheckConstraint).toHaveBeenCalledWith(
+			'n8n_test_table',
+			'CHK_n8n_test_table_status',
+		);
+	});
+
+	it('should work without a table prefix', async () => {
+		const { queryRunner } = createMocks();
+
+		await new DropEnumCheck('test_table', 'role', '', queryRunner);
+
+		expect(queryRunner.dropCheckConstraint).toHaveBeenCalledWith(
+			'test_table',
+			'CHK_test_table_role',
+		);
 	});
 });
 

--- a/packages/@n8n/db/src/migrations/dsl/index.ts
+++ b/packages/@n8n/db/src/migrations/dsl/index.ts
@@ -8,6 +8,7 @@ import {
 	AddNotNull,
 	CreateTable,
 	DropColumns,
+	DropEnumCheck,
 	DropForeignKey,
 	DropNotNull,
 	DropTable,
@@ -93,6 +94,9 @@ export const createSchemaBuilder = (tablePrefix: string, queryRunner: QueryRunne
 		new AddNotNull(tableName, columnName, tablePrefix, queryRunner),
 	dropNotNull: (tableName: string, columnName: string) =>
 		new DropNotNull(tableName, columnName, tablePrefix, queryRunner),
+
+	dropEnumCheck: (tableName: string, columnName: string) =>
+		new DropEnumCheck(tableName, columnName, tablePrefix, queryRunner),
 
 	/* eslint-enable */
 });

--- a/packages/@n8n/db/src/migrations/dsl/table.ts
+++ b/packages/@n8n/db/src/migrations/dsl/table.ts
@@ -268,3 +268,21 @@ export class DropNotNull extends ModifyNotNull {
 		super(tableName, columnName, true, prefix, queryRunner);
 	}
 }
+
+export class DropEnumCheck extends TableOperation {
+	constructor(
+		tableName: string,
+		protected columnName: string,
+		prefix: string,
+		queryRunner: QueryRunner,
+	) {
+		super(tableName, prefix, queryRunner);
+	}
+
+	async execute(queryRunner: QueryRunner) {
+		const { tableName, prefix, columnName } = this;
+		const fullTableName = `${prefix}${tableName}`;
+		const checkName = `CHK_${prefix}${tableName}_${columnName}`;
+		return await queryRunner.dropCheckConstraint(fullTableName, checkName);
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `DropEnumCheck` operation class and `schemaBuilder.dropEnumCheck(tableName, columnName)` factory method to the migration DSL. This allows migrations to drop enum CHECK constraints using the same DSL abstraction used to create them, instead of manually constructing constraint names and calling `queryRunner.dropCheckConstraint()` directly.

**How to test:** Run `pnpm test src/migrations/dsl/__tests__/enum-check.test.ts` in `packages/@n8n/db`.

- [x] I have seen this code, I have run this code, and I take responsibility for this code.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3179

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI