### PR TITLE
fix(core): Stop classifying AI sub-tool nodes as triggers in generated types

### DIFF
--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-types.test.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-types.test.ts
@@ -2289,6 +2289,26 @@ describe('generate-types', () => {
 			expect(result).toContain('isTrigger: true');
 		});
 
+		it('should not mark AI sub-tool nodes as triggers', () => {
+			// AI sub-tool nodes (mcpClientTool, *Tool variants, etc.) have no main
+			// input — but they emit on `ai_tool`, not `main`. Earlier the heuristic
+			// classified them as triggers because it only checked inputs.
+			const subToolNode: NodeTypeDescription = {
+				name: 'n8n-nodes-langchain.mcpClientTool',
+				displayName: 'MCP Client Tool',
+				description: 'Use MCP-server tools as agent tools',
+				group: ['output'],
+				version: 1,
+				inputs: [],
+				outputs: [{ type: 'ai_tool', displayName: 'Tools' }],
+				properties: [],
+			};
+
+			const result = generateTypes.generateNodeTypeFile(subToolNode);
+
+			expect(result).not.toContain('isTrigger: true');
+		});
+
 		it('should emit helper type for resourceMapper properties', () => {
 			const sheetsLikeNode: NodeTypeDescription = {
 				name: 'n8n-nodes-base.googleSheets',

--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-types.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-types.ts
@@ -2965,18 +2965,23 @@ export function planSplitVersionFiles(
 }
 
 /**
- * Check if node is a trigger (no main input)
+ * Check if node is a trigger.
+ *
+ * Triggers produce main data without consuming any: they emit on the `main`
+ * output and have no `main` input. AI sub-tool nodes (mcpClientTool,
+ * `*Tool` variants, etc.) also have no `main` input, but they emit on
+ * `ai_tool` rather than `main` — so a heuristic that only inspects inputs
+ * misclassifies them. Check outputs explicitly.
  */
 function isTriggerNode(node: NodeTypeDescription): boolean {
-	const inputs = node.inputs;
-	if (Array.isArray(inputs)) {
-		if (inputs.length === 0) return true;
-		if (typeof inputs[0] === 'string') {
-			return !(inputs as string[]).includes('main');
-		}
-		return !inputs.some((i) => typeof i === 'object' && i.type === 'main');
-	}
-	return false;
+	return hasMainConnection(node.outputs) && !hasMainConnection(node.inputs);
+}
+
+function hasMainConnection(connections: NodeTypeDescription['inputs']): boolean {
+	if (!Array.isArray(connections)) return false;
+	return connections.some((connection) =>
+		typeof connection === 'string' ? connection === 'main' : connection.type === 'main',
+	);
 }
 
 /**


### PR DESCRIPTION
## Summary

`isTriggerNode` in the workflow-sdk type generator only inspected `inputs`: any node with no `main` input was flagged as a trigger. AI sub-tool nodes — `mcpClientTool`, `*Tool` variants, and anything else that connects to an AI Agent via `ai_tool`, intentionally have no `main` input. They emit on `ai_tool`, not `main`. The heuristic misclassified them, so they were being marked `isTrigger: true` in their generated `.ts` type wrappers.

Visible on disk for every native ai-tool subnode currently shipped, e.g.:

```bash
$ grep -l "isTrigger: true" packages/@n8n/nodes-langchain/dist/node-definitions/nodes/n8n-nodes-langchain/mcpClientTool/*.ts
v1.ts
v11.ts
v12.ts
```

These wrapper types are consumed by the AI builders (Instance AI, Agent Builder, the EE workflow builder) when reading node schemas via `get_node_types` / `type-definition`. A bogus `isTrigger: true` on the wrapper invites the agent to wire a tool node as a trigger or treat it as one in its reasoning, neither of which is what we want.

Why is this important: We will reuse the workflow-sdk to generate the node-definitions for the tools from the mcp registry soon, and they would all get classified as triggers.

### The fix

Tighten the heuristic: a node is a trigger only if it emits `main` output AND has no `main` input. Sub-tool nodes (no `main` on either side) now correctly fall through.

The bogus `isTrigger: true` will clear from `dist/node-definitions/` on the next `pnpm build` that regenerates type-defs for affected packages — primarily `@n8n/n8n-nodes-langchain` and `n8n-nodes-base`. No other code change required.

### How to test

Run `pnpm build` to rebuild the type-definitions, then run the grep command above again or look at the resulting type-definitions.

## Related Linear tickets, Github issues, and Community forum posts

- NODE-5104

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI