### PR TITLE
fix(editor): Soften read-only canvas stripe contrast (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/background/CanvasBackgroundStripedPattern.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/background/CanvasBackgroundStripedPattern.vue
@@ -31,5 +31,6 @@ const patternOffset = computed(() => scaledGap.value / 2);
 <style scoped>
 path {
 	stroke: var(--canvas--read-only-line--color);
+	opacity: 0.5;
 }
 </style>


### PR DESCRIPTION
## Summary
Reduce the visual intensity of the diagonal read-only stripes so they remain perceptible but do not compete with workflow content (Linear DS-533: https://linear.app/n8n/issue/DS-533).

| Before | After |
|:---:|:---:|
| <img src="https://github.com/user-attachments/assets/1c9deb32-cdb2-4b9a-8aec-e1262d3a356f" width="960px" alt="Before image" /> | <img src="https://github.com/user-attachments/assets/c71c420b-60a3-4351-aaa3-07f1e5283b19" width="960px" alt="After image" /> |

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DS-533

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
