### PR TITLE
ci: Scope unit tests to affected packages on merge_group runs

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -135,6 +135,7 @@ jobs:
     with:
       ref: ${{ needs.install-and-build.outputs.commit_sha }}
       collectCoverage: ${{ github.event_name != 'merge_group' }}
+      merge-base: ${{ needs.install-and-build.outputs.merge_base }}
     secrets: inherit
 
   typecheck:

--- a/.github/workflows/test-unit-reusable.yml
+++ b/.github/workflows/test-unit-reusable.yml
@@ -215,7 +215,7 @@ jobs:
       - name: Test
         run: |
           if [ "${{ github.event_name }}" = "merge_group" ] && [ -n "$MERGE_BASE" ]; then
-            pnpm turbo run test --continue --filter="./packages/frontend/**[$MERGE_BASE]" --summarize -- --shard=${{ matrix.shard }}/2
+            pnpm turbo run test --continue --filter="{./packages/frontend/**}[$MERGE_BASE]" --summarize -- --shard=${{ matrix.shard }}/2
           else
             pnpm test:ci:frontend --summarize -- --shard=${{ matrix.shard }}/2
           fi

--- a/.github/workflows/test-unit-reusable.yml
+++ b/.github/workflows/test-unit-reusable.yml
@@ -17,6 +17,14 @@ on:
         required: false
         default: false
         type: boolean
+      merge-base:
+        description: |
+          Optional base SHA from ci-filter. When set and the caller event is
+          merge_group, test jobs scope to packages affected since this SHA
+          (turbo `[<sha>]` filter) instead of running the full suite.
+        required: false
+        default: ''
+        type: string
 env:
   NODE_OPTIONS: --max-old-space-size=7168
 
@@ -26,6 +34,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
     env:
       COVERAGE_ENABLED: ${{ inputs.collectCoverage }} # Coverage collected when true
+      MERGE_BASE: ${{ inputs.merge-base }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -36,8 +45,17 @@ jobs:
         with:
           node-version: ${{ inputs.nodeVersion }}
 
+      - name: Fetch merge base for affected detection
+        if: github.event_name == 'merge_group' && env.MERGE_BASE != ''
+        run: git fetch --depth=1 origin "$MERGE_BASE"
+
       - name: Test Unit
-        run: pnpm test:ci:backend:unit --summarize
+        run: |
+          if [ "${{ github.event_name }}" = "merge_group" ] && [ -n "$MERGE_BASE" ]; then
+            pnpm turbo run test:unit --continue --filter="[$MERGE_BASE]" --summarize
+          else
+            pnpm test:ci:backend:unit --summarize
+          fi
 
       - name: Send Test Stats
         if: ${{ !cancelled() }}
@@ -69,6 +87,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
     env:
       COVERAGE_ENABLED: ${{ inputs.collectCoverage }} # Coverage collected when true
+      MERGE_BASE: ${{ inputs.merge-base }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -79,8 +98,17 @@ jobs:
         with:
           node-version: ${{ inputs.nodeVersion }}
 
+      - name: Fetch merge base for affected detection
+        if: github.event_name == 'merge_group' && env.MERGE_BASE != ''
+        run: git fetch --depth=1 origin "$MERGE_BASE"
+
       - name: Test Integration
-        run: pnpm test:ci:backend:integration --summarize
+        run: |
+          if [ "${{ github.event_name }}" = "merge_group" ] && [ -n "$MERGE_BASE" ]; then
+            pnpm turbo run test:integration --continue --concurrency=1 --filter="[$MERGE_BASE]" --summarize
+          else
+            pnpm test:ci:backend:integration --summarize
+          fi
 
       - name: Send Test Stats
         if: ${{ !cancelled() }}
@@ -112,6 +140,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
     env:
       COVERAGE_ENABLED: ${{ inputs.collectCoverage }} # Coverage collected when true
+      MERGE_BASE: ${{ inputs.merge-base }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -122,8 +151,17 @@ jobs:
         with:
           node-version: ${{ inputs.nodeVersion }}
 
+      - name: Fetch merge base for affected detection
+        if: github.event_name == 'merge_group' && env.MERGE_BASE != ''
+        run: git fetch --depth=1 origin "$MERGE_BASE"
+
       - name: Test Nodes
-        run: pnpm turbo test --filter=n8n-nodes-base --summarize
+        run: |
+          if [ "${{ github.event_name }}" = "merge_group" ] && [ -n "$MERGE_BASE" ]; then
+            pnpm turbo run test --filter="n8n-nodes-base[$MERGE_BASE]" --summarize
+          else
+            pnpm turbo test --filter=n8n-nodes-base --summarize
+          fi
 
       - name: Send Test Stats
         if: ${{ !cancelled() }}
@@ -159,6 +197,7 @@ jobs:
         shard: [1, 2]
     env:
       COVERAGE_ENABLED: ${{ inputs.collectCoverage }}
+      MERGE_BASE: ${{ inputs.merge-base }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -169,8 +208,17 @@ jobs:
         with:
           node-version: ${{ inputs.nodeVersion }}
 
+      - name: Fetch merge base for affected detection
+        if: github.event_name == 'merge_group' && env.MERGE_BASE != ''
+        run: git fetch --depth=1 origin "$MERGE_BASE"
+
       - name: Test
-        run: pnpm test:ci:frontend --summarize -- --shard=${{ matrix.shard }}/2
+        run: |
+          if [ "${{ github.event_name }}" = "merge_group" ] && [ -n "$MERGE_BASE" ]; then
+            pnpm turbo run test --continue --filter="./packages/frontend/**[$MERGE_BASE]" --summarize -- --shard=${{ matrix.shard }}/2
+          else
+            pnpm test:ci:frontend --summarize -- --shard=${{ matrix.shard }}/2
+          fi
         env:
           VITEST_SHARD: ${{ matrix.shard }}/2
 


### PR DESCRIPTION
## Summary
- Reuse `ci-filter`'s computed `merge-base` SHA to scope unit-test jobs to affected packages in `merge_group` events
- Each of the four unit-test jobs (Backend Unit, Backend Integration, Nodes, Frontend ×2 shards) now branches on event: pull_request runs full-suite as today, merge_group runs `turbo run <task> --filter='[<sha>]'`
- Backend unit/integration drop the explicit `!./packages/frontend/**` exclusion because `test:unit` and `test:integration` tasks are only defined in backend packages (verified — no frontend package declares those scripts)

## Why
Throughput-side companion to DEVP-170. Backend Unit Tests is the heaviest merge_group job (596s p50, ~10,102 median-minutes/month). Cross-package interactions PRs miss are still guarded by typecheck, lint, and DB tests — all of which stay full in merge_group.

Capacity context: at current ~11min p50 critical path, queue ceiling is ~5.45 builds/h × 264h working window = ~1,400 PRs/month. DEVP-170 + this should move the floor meaningfully without touching infra.

Linear: https://linear.app/n8n/issue/DEVP-171

## Mechanism
1. `ci-filter` (in `install-and-build`) already computes a `merge-base` SHA and exposes it as `outputs.merge_base`
2. Caller (`ci-pull-requests.yml`) passes that SHA into the reusable workflow as a new `merge-base` input
3. Each test job adds a conditional `git fetch --depth=1 origin "$MERGE_BASE"` so the SHA is locally resolvable for turbo
4. Each test step's `run:` becomes a bash `if` — full command for `pull_request`, affected-only for `merge_group`

The fetch is `--depth=1` so it's cheap (~1-3s) and only runs in merge_group.

## What I want to confirm in CI
- [ ] Turbo `[<sha>]` filter resolves correctly with the shallow-fetched ref
- [ ] Frontend `./packages/frontend/**[<sha>]` filter syntax works (path + change-ref combined)
- [ ] Nodes `n8n-nodes-base[<sha>]` filter syntax works (package + change-ref combined)
- [ ] Backend Unit Tests p50 drops vs current baseline on merge_group events (~596s → expected significantly lower when no backend packages changed)
- [ ] Pull-request behaviour unchanged

## Rollback
Single revert. The change is additive (new input defaults to empty string → falls through to existing command). Reverting either file restores prior behaviour.

## Test plan
- [ ] Push, observe CI passes on the PR itself (pull_request event path)
- [ ] Once merged + cycled through merge queue once, inspect the unit-test job logs to confirm the affected-only path fired
- [ ] Compare Backend Unit Tests p50/p95 from BigQuery `qa_github_action_jobs` over the next ~7 days against the pre-merge baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)