### PR TITLE
fix(core): Use expression isolate for ephemeral node executor (no-changelog)

### DIFF
--- a/packages/cli/src/node-execution/ephemeral-node-executor.ts
+++ b/packages/cli/src/node-execution/ephemeral-node-executor.ts
@@ -25,6 +25,7 @@ import {
 import { v4 as uuid } from 'uuid';
 
 import { NodeTypes } from '@/node-types';
+import { withExpressionIsolate } from '@/utils';
 import { getBase } from '@/workflow-execute-additional-data';
 
 /** Minimal tool shape for constructing an in-memory single-node execution. */
@@ -296,26 +297,34 @@ export class EphemeralNodeExecutor {
 
 		const nodeType = this.nodeTypes.getByNameAndVersion(tool.nodeType, tool.nodeTypeVersion);
 
-		if (!nodeType.execute) {
-			return { status: 'error', data: [], error: 'Node type does not have an execute method' };
-		}
-
-		let output: NodeOutput;
+		let output: NodeOutput | undefined;
 		try {
-			output =
-				nodeType instanceof Node
-					? await nodeType.execute(context)
-					: await nodeType.execute.call(context);
+			const executionResult = await withExpressionIsolate(
+				parts.workflow,
+				async (): Promise<NodeExecutionResult> => {
+					if (!nodeType.execute) {
+						return {
+							status: 'error',
+							data: [],
+							error: 'Node type does not have an execute method',
+						};
+					}
+					output =
+						nodeType instanceof Node
+							? await nodeType.execute(context)
+							: await nodeType.execute.call(context);
+					if (!Array.isArray(output) || !output[0]) {
+						return { status: 'error', data: [], error: 'No output data' };
+					}
+					return { status: 'success', data: output[0] };
+				},
+			);
+			return executionResult;
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			this.logger.debug('Node execution failed', { nodeType: tool.nodeType, error: message });
 			return { status: 'error', data: [], error: message };
 		}
-
-		if (!Array.isArray(output) || !output[0]) {
-			return { status: 'error', data: [], error: 'No output data' };
-		}
-		return { status: 'success', data: output[0] };
 	}
 
 	async executeInline(request: InlineNodeExecutionRequest): Promise<NodeExecutionResult> {

--- a/packages/cli/src/services/dynamic-node-parameters.service.ts
+++ b/packages/cli/src/services/dynamic-node-parameters.service.ts
@@ -30,6 +30,7 @@ import { WorkflowLoaderService } from './workflow-loader.service';
 import { SharedWorkflowRepository, User } from '@n8n/db';
 import { userHasScopes } from '@/permissions.ee/check-access';
 import { Logger } from '@n8n/backend-common';
+import { withExpressionIsolate } from '@/utils';
 
 type LocalResourceMappingMethod = (
 	this: ILocalLoadOptionsFunctions,
@@ -134,7 +135,7 @@ export class DynamicNodeParametersService {
 		const method = this.getMethod('loadOptions', methodName, nodeType);
 		const workflow = this.getWorkflow(nodeTypeAndVersion, currentNodeParameters, credentials);
 		const thisArgs = this.getThisArg(path, additionalData, workflow);
-		return await this.withExpressionIsolate(workflow, async () => {
+		return await withExpressionIsolate(workflow, async () => {
 			// Need to use untyped call since `this` usage is widespread and we don't have `strictBindCallApply`
 			// enabled in `tsconfig.json`
 			return await method.call(thisArgs);
@@ -211,7 +212,7 @@ export class DynamicNodeParametersService {
 			[],
 		);
 		const routingNode = new RoutingNode(executeFunctions, tempNodeType);
-		return await this.withExpressionIsolate(workflow, async () => {
+		return await withExpressionIsolate(workflow, async () => {
 			const optionsData = await routingNode.runNode();
 
 			if (optionsData?.length === 0) {
@@ -240,7 +241,7 @@ export class DynamicNodeParametersService {
 		const method = this.getMethod('listSearch', methodName, nodeType);
 		const workflow = this.getWorkflow(nodeTypeAndVersion, currentNodeParameters, credentials);
 		const thisArgs = this.getThisArg(path, additionalData, workflow);
-		return await this.withExpressionIsolate(workflow, async () => {
+		return await withExpressionIsolate(workflow, async () => {
 			return await method.call(thisArgs, filter, paginationToken);
 		});
 	}
@@ -258,7 +259,7 @@ export class DynamicNodeParametersService {
 		const method = this.getMethod('resourceMapping', methodName, nodeType);
 		const workflow = this.getWorkflow(nodeTypeAndVersion, currentNodeParameters, credentials);
 		const thisArgs = this.getThisArg(path, additionalData, workflow);
-		return await this.withExpressionIsolate(workflow, async () =>
+		return await withExpressionIsolate(workflow, async () =>
 			this.removeDuplicateResourceMappingFields(await method.call(thisArgs)),
 		);
 	}
@@ -290,22 +291,9 @@ export class DynamicNodeParametersService {
 		const method = this.getMethod('actionHandler', handler, nodeType);
 		const workflow = this.getWorkflow(nodeTypeAndVersion, currentNodeParameters, credentials);
 		const thisArgs = this.getThisArg(path, additionalData, workflow);
-		return await this.withExpressionIsolate(workflow, async () => {
+		return await withExpressionIsolate(workflow, async () => {
 			return await method.call(thisArgs, payload);
 		});
-	}
-
-	/**
-	 * When N8N_EXPRESSION_ENGINE=vm, expressions run in an isolate that must be acquired
-	 * for this workflow before any code resolves {{ }} in parameters or credentials.
-	 */
-	private async withExpressionIsolate<T>(workflow: Workflow, fn: () => Promise<T>): Promise<T> {
-		await workflow.expression.acquireIsolate();
-		try {
-			return await fn();
-		} finally {
-			await workflow.expression.releaseIsolate();
-		}
 	}
 
 	private getMethod(

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,5 +1,5 @@
 import { CliWorkflowOperationError, SubworkflowOperationError } from 'n8n-workflow';
-import type { INode, INodeType } from 'n8n-workflow';
+import type { INode, INodeType, Workflow } from 'n8n-workflow';
 
 import { STARTING_NODES } from '@/constants';
 
@@ -146,4 +146,20 @@ export function containsExpression(testString: string): boolean {
 
 export function isObject(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * When N8N_EXPRESSION_ENGINE=vm, expressions run in an isolate that must be acquired
+ * for this workflow before any code resolves {{ }} in parameters or credentials.
+ */
+export async function withExpressionIsolate<T>(
+	workflow: Workflow,
+	fn: () => Promise<T>,
+): Promise<T> {
+	await workflow.expression.acquireIsolate();
+	try {
+		return await fn();
+	} finally {
+		await workflow.expression.releaseIsolate();
+	}
 }

--- a/packages/frontend/editor-ui/src/features/agents/agentSessions.store.ts
+++ b/packages/frontend/editor-ui/src/features/agents/agentSessions.store.ts
@@ -10,7 +10,7 @@ import {
 } from './composables/useAgentThreadsApi';
 
 const ITEMS_PER_PAGE = 20;
-const AUTO_REFRESH_INTERVAL_MS = 2_000;
+const AUTO_REFRESH_INTERVAL_MS = 5_000;
 
 export const useAgentSessionsStore = defineStore('agentSessions', () => {
 	const threads = ref<AgentExecutionThread[]>([]);


### PR DESCRIPTION
## Summary

This PR fixes error that leads to agent tool execution being incompatible with new expression execution engine.
Also, changed refresh timer for sessions on frontend, as it was too aggressive

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-154/bug-http-tool-fails-with-bridge-error-in-agents

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
