### PR TITLE
ci: Use PR head ref in eval experiment names (no-changelog)

### DIFF
--- a/.github/workflows/test-evals-discovery.yml
+++ b/.github/workflows/test-evals-discovery.yml
@@ -82,7 +82,9 @@ jobs:
           pnpm eval:discovery "${EVAL_ARGS[@]}" 2>&1 | tee discovery-eval-output.txt
 
       - name: Post eval results to PR
-        if: ${{ always() && github.event_name == 'pull_request' && hashFiles('packages/@n8n/instance-ai/discovery-eval-output.txt') != '' }}
+        # Eval may be triggered by pull_request or pull_request_review; both
+        # expose github.event.pull_request.*, so the comment lookup works.
+        if: ${{ always() && github.event.pull_request.number && hashFiles('packages/@n8n/instance-ai/discovery-eval-output.txt') != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVAL_OUTCOME: ${{ steps.eval.outcome }}

--- a/.github/workflows/test-evals-discovery.yml
+++ b/.github/workflows/test-evals-discovery.yml
@@ -67,9 +67,6 @@ jobs:
           LANGSMITH_ENDPOINT: ${{ secrets.EVALS_LANGSMITH_ENDPOINT }}
           LANGSMITH_API_KEY: ${{ secrets.EVALS_LANGSMITH_API_KEY }}
           LANGSMITH_REVISION_ID: ${{ github.sha }}
-          # Prefer the PR's actual head ref so experiment names track the
-          # source branch on pull_request_review (where github.head_ref is
-          # empty and github.ref_name resolves to "<PR>/merge").
           LANGSMITH_BRANCH: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref_name }}
           FILTER: ${{ inputs.filter }}
           TRIALS: ${{ inputs.trials || 3 }}
@@ -82,8 +79,6 @@ jobs:
           pnpm eval:discovery "${EVAL_ARGS[@]}" 2>&1 | tee discovery-eval-output.txt
 
       - name: Post eval results to PR
-        # Eval may be triggered by pull_request or pull_request_review; both
-        # expose github.event.pull_request.*, so the comment lookup works.
         if: ${{ always() && github.event.pull_request.number && hashFiles('packages/@n8n/instance-ai/discovery-eval-output.txt') != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-evals-discovery.yml
+++ b/.github/workflows/test-evals-discovery.yml
@@ -67,7 +67,10 @@ jobs:
           LANGSMITH_ENDPOINT: ${{ secrets.EVALS_LANGSMITH_ENDPOINT }}
           LANGSMITH_API_KEY: ${{ secrets.EVALS_LANGSMITH_API_KEY }}
           LANGSMITH_REVISION_ID: ${{ github.sha }}
-          LANGSMITH_BRANCH: ${{ github.head_ref || github.ref_name }}
+          # Prefer the PR's actual head ref so experiment names track the
+          # source branch on pull_request_review (where github.head_ref is
+          # empty and github.ref_name resolves to "<PR>/merge").
+          LANGSMITH_BRANCH: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref_name }}
           FILTER: ${{ inputs.filter }}
           TRIALS: ${{ inputs.trials || 3 }}
         run: |
@@ -83,7 +86,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVAL_OUTCOME: ${{ steps.eval.outcome }}
-          HEAD_REF: ${{ github.head_ref || github.ref_name }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref_name }}
           COMMIT_SHA: ${{ github.sha }}
         run: |
           if [ "$EVAL_OUTCOME" = "success" ]; then

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -166,7 +166,10 @@ jobs:
           LANGSMITH_ENDPOINT: ${{ secrets.EVALS_LANGSMITH_ENDPOINT }}
           LANGSMITH_API_KEY: ${{ secrets.EVALS_LANGSMITH_API_KEY }}
           LANGSMITH_REVISION_ID: ${{ github.sha }}
-          LANGSMITH_BRANCH: ${{ github.head_ref || github.ref_name }}
+          # Prefer the PR's actual head ref so experiment names track the
+          # source branch on pull_request_review (where github.head_ref is
+          # empty and github.ref_name resolves to "<PR>/merge").
+          LANGSMITH_BRANCH: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref_name }}
           FILTER: ${{ inputs.filter }}
         run: |
           IFS=',' read -ra PORTS <<< "$LANE_PORTS"

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -166,9 +166,6 @@ jobs:
           LANGSMITH_ENDPOINT: ${{ secrets.EVALS_LANGSMITH_ENDPOINT }}
           LANGSMITH_API_KEY: ${{ secrets.EVALS_LANGSMITH_API_KEY }}
           LANGSMITH_REVISION_ID: ${{ github.sha }}
-          # Prefer the PR's actual head ref so experiment names track the
-          # source branch on pull_request_review (where github.head_ref is
-          # empty and github.ref_name resolves to "<PR>/merge").
           LANGSMITH_BRANCH: ${{ github.event.pull_request.head.ref || github.head_ref || github.ref_name }}
           FILTER: ${{ inputs.filter }}
         run: |
@@ -257,9 +254,6 @@ jobs:
           fi
 
       - name: Post eval results to PR
-        # Eval now fires on pull_request_review (see ci-instance-ai-evals.yml),
-        # which also exposes github.event.pull_request.*, so the comment lookup
-        # still works.
         if: ${{ always() && github.event.pull_request.number }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -257,7 +257,10 @@ jobs:
           fi
 
       - name: Post eval results to PR
-        if: ${{ always() && github.event_name == 'pull_request' }}
+        # Eval now fires on pull_request_review (see ci-instance-ai-evals.yml),
+        # which also exposes github.event.pull_request.*, so the comment lookup
+        # still works.
+        if: ${{ always() && github.event.pull_request.number }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/packages/@n8n/instance-ai/evaluations/__tests__/ci-metadata.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/ci-metadata.test.ts
@@ -1,0 +1,129 @@
+import { buildCIMetadata, computeExperimentPrefix } from '../cli/ci-metadata';
+
+const CI_ENV_VARS = [
+	'GITHUB_ACTIONS',
+	'GITHUB_HEAD_REF',
+	'GITHUB_REF_NAME',
+	'GITHUB_SHA',
+	'GITHUB_EVENT_NAME',
+	'GITHUB_RUN_ID',
+	'LANGSMITH_BRANCH',
+] as const;
+
+describe('computeExperimentPrefix', () => {
+	const originalEnv: Record<string, string | undefined> = {};
+
+	beforeEach(() => {
+		for (const key of CI_ENV_VARS) {
+			originalEnv[key] = process.env[key];
+			delete process.env[key];
+		}
+	});
+
+	afterEach(() => {
+		for (const key of CI_ENV_VARS) {
+			if (originalEnv[key] === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = originalEnv[key];
+			}
+		}
+	});
+
+	describe('CI mode', () => {
+		beforeEach(() => {
+			process.env.GITHUB_ACTIONS = 'true';
+			process.env.GITHUB_SHA = '357e949547671e2cd1c017eb4e7c809cd55bd121';
+		});
+
+		it('prefers LANGSMITH_BRANCH over GITHUB_HEAD_REF and GITHUB_REF_NAME', () => {
+			process.env.LANGSMITH_BRANCH = 'feature-branch';
+			process.env.GITHUB_HEAD_REF = 'should-not-be-used';
+			process.env.GITHUB_REF_NAME = '30711/merge';
+
+			expect(computeExperimentPrefix()).toBe('ci-feature-branch-357e949');
+		});
+
+		it('falls back to GITHUB_HEAD_REF when LANGSMITH_BRANCH is unset', () => {
+			process.env.GITHUB_HEAD_REF = 'feature-x';
+			process.env.GITHUB_REF_NAME = '30711/merge';
+
+			expect(computeExperimentPrefix()).toBe('ci-feature-x-357e949');
+		});
+
+		it('falls back to GITHUB_REF_NAME when LANGSMITH_BRANCH and GITHUB_HEAD_REF are unset', () => {
+			process.env.GITHUB_REF_NAME = 'master';
+
+			expect(computeExperimentPrefix()).toBe('ci-master-357e949');
+		});
+
+		it('sanitizes special characters in the branch name', () => {
+			process.env.LANGSMITH_BRANCH = '30711/merge';
+
+			expect(computeExperimentPrefix()).toBe('ci-30711_merge-357e949');
+		});
+
+		it('collapses consecutive sanitized underscores', () => {
+			process.env.LANGSMITH_BRANCH = 'feature//thing';
+
+			expect(computeExperimentPrefix()).toBe('ci-feature_thing-357e949');
+		});
+
+		it('returns local fallback when GITHUB_SHA is missing', () => {
+			delete process.env.GITHUB_SHA;
+			process.env.LANGSMITH_BRANCH = 'feature-x';
+
+			// In CI without SHA, computeCIExperimentName returns undefined; the
+			// local computation also fails outside a git context, so we land
+			// on the generic fallback.
+			const result = computeExperimentPrefix();
+			expect(result).not.toMatch(/^ci-/);
+		});
+	});
+
+	describe('local mode', () => {
+		it('does not use LANGSMITH_BRANCH when GITHUB_ACTIONS is unset', () => {
+			process.env.LANGSMITH_BRANCH = 'should-not-be-used';
+
+			expect(computeExperimentPrefix()).not.toContain('should-not-be-used');
+		});
+	});
+});
+
+describe('buildCIMetadata', () => {
+	const ENV_VARS = ['GITHUB_ACTIONS', 'GITHUB_EVENT_NAME', 'GITHUB_RUN_ID'] as const;
+	const originalEnv: Record<string, string | undefined> = {};
+
+	beforeEach(() => {
+		for (const key of ENV_VARS) {
+			originalEnv[key] = process.env[key];
+			delete process.env[key];
+		}
+	});
+
+	afterEach(() => {
+		for (const key of ENV_VARS) {
+			if (originalEnv[key] === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = originalEnv[key];
+			}
+		}
+	});
+
+	it('returns local source when not in CI', () => {
+		expect(buildCIMetadata()).toEqual({ source: 'local' });
+	});
+
+	it('returns ci source with trigger and runId when in CI', () => {
+		process.env.GITHUB_ACTIONS = 'true';
+		process.env.GITHUB_EVENT_NAME = 'pull_request_review';
+		process.env.GITHUB_RUN_ID = '12345';
+
+		expect(buildCIMetadata()).toEqual({
+			source: 'ci',
+			trigger: 'pull_request_review',
+			runId: '12345',
+		});
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/cli/ci-metadata.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/ci-metadata.ts
@@ -56,7 +56,11 @@ export function computeExperimentPrefix(): string {
 function computeCIExperimentName(): string | undefined {
 	if (process.env.GITHUB_ACTIONS !== 'true') return undefined;
 
-	const branch = process.env.GITHUB_HEAD_REF ?? process.env.GITHUB_REF_NAME;
+	// LANGSMITH_BRANCH is set explicitly by the eval workflows and resolves
+	// to the PR's head ref when available; GITHUB_HEAD_REF is empty on
+	// pull_request_review and GITHUB_REF_NAME falls back to "<PR>/merge".
+	const branch =
+		process.env.LANGSMITH_BRANCH ?? process.env.GITHUB_HEAD_REF ?? process.env.GITHUB_REF_NAME;
 	const sha = process.env.GITHUB_SHA;
 	if (!branch || !sha) return undefined;
 

--- a/packages/@n8n/instance-ai/evaluations/cli/ci-metadata.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/ci-metadata.ts
@@ -56,9 +56,6 @@ export function computeExperimentPrefix(): string {
 function computeCIExperimentName(): string | undefined {
 	if (process.env.GITHUB_ACTIONS !== 'true') return undefined;
 
-	// LANGSMITH_BRANCH is set explicitly by the eval workflows and resolves
-	// to the PR's head ref when available; GITHUB_HEAD_REF is empty on
-	// pull_request_review and GITHUB_REF_NAME falls back to "<PR>/merge".
 	const branch =
 		process.env.LANGSMITH_BRANCH ?? process.env.GITHUB_HEAD_REF ?? process.env.GITHUB_REF_NAME;
 	const sha = process.env.GITHUB_SHA;


### PR DESCRIPTION
## Summary

Follow-up to #30815. The split workflow now fires only on PR approval, but the LangSmith experiments were still landing with names like `ci-30711_merge-357e949-…`, which read like post-merge runs and made it hard to tell at a glance that the eval is review-triggered. Also restores the eval PR-comment step (gated on `event_name == 'pull_request'`, which silently skipped after the split moved the trigger to `pull_request_review`).

The misleading `<PR>_merge` came from a quirk of `pull_request_review` events: `github.head_ref` is empty for them, so `${{ github.head_ref || github.ref_name }}` fell through to `github.ref_name`, which resolves to `refs/pull/<N>/merge` (i.e., the simulated-merge ref name). The CLI's `sanitize()` then swapped `/` → `_`.

Verified from LangSmith metadata that every `_merge`-named experiment in the original screenshot has `trigger: pull_request_review` and `source: ci` — the gate is working; only the labels were wrong.

## Changes

- `test-evals-instance-ai.yml` / `test-evals-discovery.yml`: prefer `github.event.pull_request.head.ref` for `LANGSMITH_BRANCH` (and `HEAD_REF` in the discovery PR-comment step). Both `pull_request` and `pull_request_review` events expose the full PR payload, so `head.ref` is set; for `workflow_dispatch` / master pushes it falls through to the existing chain unchanged.
- `test-evals-instance-ai.yml` / `test-evals-discovery.yml`: swap the PR-comment guard from `event_name == 'pull_request'` to `github.event.pull_request.number` so it fires on both event types.
- `ci-metadata.ts`: prefer `process.env.LANGSMITH_BRANCH` when computing the experiment prefix so the workflow's explicit choice wins over the default GitHub refs.
- New unit tests for `computeExperimentPrefix` and `buildCIMetadata` covering priority order, sanitization, and local fallback.

## Safety

The user-controllable input here is the PR branch name. Mitigations:

1. The value flows only through `env:` blocks, never through direct `${{ }}` interpolation into a `run:` shell. GitHub Actions stores env values as literal strings — no shell parsing happens at assignment.
2. The CLI's `sanitize()` strips anything outside `[a-zA-Z0-9_.-]`, so an attacker-crafted branch name (e.g. with shell metacharacters) is neutered before it reaches the experiment name.
3. The discovery workflow's `${HEAD_REF}` is expanded inside double quotes in an `echo`; bash does not re-parse expanded values for command substitution, so `$(cmd)` in a branch name is printed verbatim rather than executed.

## Related

Follow-up to #30815.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)