### PR TITLE
fix: include nodeGroups in source control push and CLI export

### DIFF
--- a/packages/cli/src/commands/export/workflow.ts
+++ b/packages/cli/src/commands/export/workflow.ts
@@ -252,6 +252,7 @@ function mergeHistoriesIntoWorkflows(
 					...workflow,
 					nodes: history.nodes,
 					connections: history.connections,
+					nodeGroups: history.nodeGroups,
 					versionId: history.versionId,
 					versionMetadata: {
 						name: history.name,

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-export.service.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-export.service.test.ts
@@ -15,7 +15,7 @@ import type {
 	WorkflowTagMappingRepository,
 	Variables,
 } from '@n8n/db';
-import { GLOBAL_ADMIN_ROLE, In, PROJECT_OWNER_ROLE, User } from '@n8n/db';
+import { GLOBAL_ADMIN_ROLE, In, PROJECT_OWNER_ROLE, User, WorkflowEntity } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { captor, mock } from 'jest-mock-extended';
 import { Cipher, type InstanceSettings } from 'n8n-core';
@@ -526,25 +526,72 @@ describe('SourceControlExportService', () => {
 	});
 
 	describe('exportWorkflowsToWorkFolder', () => {
-		it('should export workflows to work folder', async () => {
+		it('should export workflows with all required fields', async () => {
 			// Arrange
-			workflowRepository.findByIds.mockResolvedValue([mock()]);
+			const nodeGroups = [{ id: 'g1', name: 'Group 1', nodeIds: ['node-1'] }];
+			const workflowId = 'wf-1';
+			const nodes = [
+				{
+					id: 'node-1',
+					type: 'n8n-nodes-base.noOp',
+					name: 'NoOp',
+					typeVersion: 1,
+					position: [0, 0] as [number, number],
+					parameters: {},
+				},
+			];
+			workflowRepository.find.mockResolvedValue([
+				Object.assign(new WorkflowEntity(), {
+					id: workflowId,
+					name: 'Test Workflow',
+					nodes,
+					connections: {},
+					settings: {},
+					triggerCount: 1,
+					versionId: 'v1',
+					parentFolder: null,
+					isArchived: false,
+					nodeGroups,
+				}),
+			]);
 			sharedWorkflowRepository.findByWorkflowIds.mockResolvedValue([
 				mock<SharedWorkflow>({
+					workflowId,
 					project: mock({
 						type: 'personal',
-						projectRelations: [{ role: PROJECT_OWNER_ROLE, user: mock() }],
+						projectRelations: [
+							{ role: PROJECT_OWNER_ROLE, user: mock({ email: 'user@test.com' }) },
+						],
 					}),
 					workflow: mock(),
 				}),
 			]);
 
 			// Act
-			const result = await service.exportWorkflowsToWorkFolder([mock()]);
+			const result = await service.exportWorkflowsToWorkFolder([
+				mock<SourceControlledFile>({ id: workflowId }),
+			]);
 
 			// Assert
 			expect(result.count).toBe(1);
 			expect(result.files).toHaveLength(1);
+
+			const dataCaptor = captor<string>();
+			expect(fsWriteFile).toHaveBeenCalledWith(expect.stringContaining(workflowId), dataCaptor);
+			const exported = JSON.parse(dataCaptor.value);
+			expect(exported).toEqual({
+				id: workflowId,
+				name: 'Test Workflow',
+				nodes,
+				connections: {},
+				settings: {},
+				triggerCount: 1,
+				versionId: 'v1',
+				parentFolderId: null,
+				isArchived: false,
+				nodeGroups,
+				owner: { type: 'personal', personalEmail: 'user@test.com' },
+			});
 		});
 
 		it('should throw an error if workflow has no owner', async () => {

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -192,7 +192,16 @@ describe('SourceControlImportService', () => {
 				id: '1',
 				name: 'Workflow 1',
 				active: false,
-				nodes: [],
+				nodes: [
+					{
+						id: 'node-1',
+						name: 'Node 1',
+						type: 'n8n-nodes-base.noOp',
+						typeVersion: 1,
+						position: [0, 0],
+						parameters: {},
+					},
+				],
 				connections: {},
 				versionId: 'v1',
 				owner: {
@@ -200,6 +209,7 @@ describe('SourceControlImportService', () => {
 					personalEmail: 'user@example.com',
 				},
 				parentFolderId: null,
+				nodeGroups: [{ id: 'g1', name: 'Group 1', nodeIds: ['node-1'] }],
 			};
 			const mockWorkflowData2 = {
 				id: '2',
@@ -213,6 +223,7 @@ describe('SourceControlImportService', () => {
 					personalEmail: 'user@example.com',
 				},
 				parentFolderId: null,
+				nodeGroups: [],
 			};
 			const candidates = [
 				mock<SourceControlledFile>({ file: mockWorkflowFile1, id: mockWorkflowData1.id }),
@@ -242,6 +253,9 @@ describe('SourceControlImportService', () => {
 				expect.objectContaining({
 					id: mockWorkflowData1.id,
 					name: mockWorkflowData1.name,
+					nodes: mockWorkflowData1.nodes,
+					connections: mockWorkflowData1.connections,
+					nodeGroups: mockWorkflowData1.nodeGroups,
 				}),
 				['id'],
 			);
@@ -249,6 +263,9 @@ describe('SourceControlImportService', () => {
 				expect.objectContaining({
 					id: mockWorkflowData2.id,
 					name: mockWorkflowData2.name,
+					nodes: mockWorkflowData2.nodes,
+					connections: mockWorkflowData2.connections,
+					nodeGroups: mockWorkflowData2.nodeGroups,
 				}),
 				['id'],
 			);

--- a/packages/cli/src/modules/source-control.ee/source-control-export.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-export.service.ee.ts
@@ -140,6 +140,7 @@ export class SourceControlExportService {
 						owner: owners[workflow.id],
 						parentFolderId: workflow.parentFolder?.id ?? null,
 						isArchived: workflow.isArchived,
+						nodeGroups: workflow.nodeGroups ?? [],
 					};
 					this.logger.debug(`Writing workflow ${workflow.id} to ${fileName}`);
 					return await fsWriteFile(fileName, JSON.stringify(sanitizedWorkflow, null, 2));

--- a/packages/cli/src/modules/source-control.ee/types/exportable-workflow.ts
+++ b/packages/cli/src/modules/source-control.ee/types/exportable-workflow.ts
@@ -1,4 +1,4 @@
-import type { INode, IConnections, IWorkflowSettings } from 'n8n-workflow';
+import type { INode, IConnections, IWorkflowSettings, IWorkflowGroup } from 'n8n-workflow';
 
 import type { RemoteResourceOwner } from './resource-owner';
 
@@ -13,4 +13,5 @@ export interface ExportableWorkflow {
 	owner: RemoteResourceOwner;
 	parentFolderId: string | null;
 	isArchived: boolean;
+	nodeGroups: IWorkflowGroup[];
 }

--- a/packages/cli/test/integration/commands/export/workflow.test.ts
+++ b/packages/cli/test/integration/commands/export/workflow.test.ts
@@ -408,6 +408,50 @@ test('should include versionMetadata with historical name when set', async () =>
 	});
 });
 
+test('should export nodeGroups from historical version', async () => {
+	const nodeGroups = [{ id: 'g1', name: 'Group 1', nodeIds: ['uuid-v1'] }];
+	const workflow = await createWorkflowWithTriggerAndHistory({
+		name: 'Grouped Workflow',
+		nodes: [
+			{
+				id: 'uuid-v1',
+				parameters: {},
+				name: 'Version 1 Node',
+				type: 'n8n-nodes-base.manualTrigger',
+				typeVersion: 1,
+				position: [240, 300],
+			},
+		],
+		nodeGroups,
+	});
+
+	const version1Id = workflow.versionId;
+
+	const newVersionId = nanoid();
+	workflow.versionId = newVersionId;
+	workflow.nodes = [
+		{
+			id: 'uuid-v2',
+			parameters: {},
+			name: 'Version 2 Node',
+			type: 'n8n-nodes-base.manualTrigger',
+			typeVersion: 1,
+			position: [240, 300],
+		},
+	];
+	workflow.nodeGroups = [];
+	await Container.get(WorkflowRepository).save(workflow);
+	await createWorkflowHistory(workflow);
+
+	const outputFile = path.join(testOutputDir, 'output.json');
+	await command.run([`--id=${workflow.id}`, `--version=${version1Id}`, `--output=${outputFile}`]);
+
+	const exportedData = JSON.parse(fs.readFileSync(outputFile, 'utf-8'))[0];
+
+	expect(exportedData.versionId).toBe(version1Id);
+	expect(exportedData.nodeGroups).toEqual(nodeGroups);
+});
+
 test('should include versionMetadata with historical description when set', async () => {
 	const workflow = await createWorkflowWithTriggerAndHistory({
 		description: 'Original Description',

--- a/packages/cli/test/integration/environments/source-control.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control.service.test.ts
@@ -130,6 +130,7 @@ function toExportableWorkflow(
 		triggerCount: wf.triggerCount,
 		parentFolderId: null,
 		versionId: versionId ?? wf.versionId,
+		nodeGroups: wf.nodeGroups ?? [],
 	};
 }
 


### PR DESCRIPTION
## Summary

- Include `nodeGroups` in source control (environments) push so groups survive export to git
- Include `nodeGroups` in CLI `export:workflow` when exporting historical or published versions                                                       
- Add test coverage for nodeGroups in export, import, and CLI export

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
