### PR TITLE
fix(Facebook Graph API Node): Clarify endpoints that accept binary uploads

### DIFF
--- a/packages/nodes-base/nodes/Facebook/FacebookGraphApi.node.ts
+++ b/packages/nodes-base/nodes/Facebook/FacebookGraphApi.node.ts
@@ -258,7 +258,8 @@ export class FacebookGraphApi implements INodeType {
 				},
 				default: false,
 				required: true,
-				description: 'Whether binary data should be sent as body',
+				hint: 'Page <code>/photos</code> and <code>/videos</code> edges accept binary uploads. Instagram container endpoints (e.g. <code>/media</code>) require <code>image_url</code> or <code>video_url</code> as Query Parameters instead.',
+				description: 'Whether to upload binary data as multipart/form-data',
 			},
 			{
 				displayName: 'Input Binary Field',
@@ -276,7 +277,7 @@ export class FacebookGraphApi implements INodeType {
 				},
 				hint: 'The name of the input binary field containing the file to be uploaded',
 				description:
-					'For Form-Data Multipart, they can be provided in the format: <code>"sendKey1:binaryProperty1,sendKey2:binaryProperty2</code>',
+					'For Form-Data Multipart, multiple files can be provided in the format: <code>sendKey1:binaryProperty1,sendKey2:binaryProperty2</code>',
 			},
 			{
 				displayName: 'Options',

--- a/packages/nodes-base/nodes/Facebook/__tests__/FacebookGraphApi.node.test.ts
+++ b/packages/nodes-base/nodes/Facebook/__tests__/FacebookGraphApi.node.test.ts
@@ -1,0 +1,109 @@
+import type { MockProxy } from 'jest-mock-extended';
+import { mock } from 'jest-mock-extended';
+import type { IBinaryData, IExecuteFunctions } from 'n8n-workflow';
+
+import { FacebookGraphApi } from '../FacebookGraphApi.node';
+
+describe('FacebookGraphApi node — binary upload', () => {
+	let mockExecuteFunctions: MockProxy<IExecuteFunctions>;
+	let node: FacebookGraphApi;
+
+	const binaryDataBuffer = Buffer.from('fake-image-bytes');
+	const binaryDescriptor: IBinaryData = {
+		data: 'base64data',
+		mimeType: 'image/png',
+		fileName: 'photo.png',
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockExecuteFunctions = mock<IExecuteFunctions>();
+		node = new FacebookGraphApi();
+
+		mockExecuteFunctions.getInputData.mockReturnValue([
+			{ json: {}, binary: { data: binaryDescriptor } },
+		]);
+		mockExecuteFunctions.getNode.mockReturnValue({
+			id: 'test-node-id',
+			name: 'Facebook Graph API',
+			type: 'n8n-nodes-base.facebookGraphApi',
+			typeVersion: 1,
+			position: [0, 0],
+			parameters: {},
+		});
+		mockExecuteFunctions.getCredentials.mockResolvedValue({ accessToken: 'TOKEN' });
+		mockExecuteFunctions.continueOnFail.mockReturnValue(false);
+		mockExecuteFunctions.helpers = {
+			request: jest.fn().mockResolvedValue({ id: 'photo-id' }),
+			requestWithAuthentication: jest.fn(),
+			assertBinaryData: jest.fn().mockReturnValue(binaryDescriptor),
+			getBinaryDataBuffer: jest.fn().mockResolvedValue(binaryDataBuffer),
+		} as any;
+	});
+
+	const setParams = (overrides: Record<string, unknown> = {}) => {
+		const defaults: Record<string, unknown> = {
+			authType: 'accessToken',
+			hostUrl: 'graph.facebook.com',
+			httpRequestMethod: 'POST',
+			graphApiVersion: 'v23.0',
+			node: '123456',
+			edge: 'photos',
+			options: {},
+			sendBinaryData: true,
+			binaryPropertyName: 'data',
+			allowUnauthorizedCerts: false,
+		};
+		const params = { ...defaults, ...overrides };
+		mockExecuteFunctions.getNodeParameter.mockImplementation(
+			(name: string) => params[name] as never,
+		);
+	};
+
+	it('builds a multipart/form-data request with the binary buffer when Send Binary File is enabled', async () => {
+		setParams();
+
+		await node.execute.call(mockExecuteFunctions);
+
+		const requestMock = mockExecuteFunctions.helpers.request as jest.Mock;
+		expect(requestMock).toHaveBeenCalledTimes(1);
+
+		const requestArg = requestMock.mock.calls[0][0];
+		expect(requestArg.method).toBe('POST');
+		expect(requestArg.uri).toBe('https://graph.facebook.com/v23.0/123456/photos');
+		expect(requestArg.formData).toEqual({
+			file: {
+				value: binaryDataBuffer,
+				options: {
+					filename: 'photo.png',
+					contentType: 'image/png',
+				},
+			},
+		});
+		// Buffer must NOT be JSON-serialized into the body.
+		expect(requestArg.body).toBeUndefined();
+		expect(requestArg.json).toBe(true);
+	});
+
+	it('respects the "<formField>:<binaryProperty>" syntax for the form field name', async () => {
+		setParams({ binaryPropertyName: 'source:data' });
+
+		await node.execute.call(mockExecuteFunctions);
+
+		const requestArg = (mockExecuteFunctions.helpers.request as jest.Mock).mock.calls[0][0];
+		expect(Object.keys(requestArg.formData)).toEqual(['source']);
+		expect(requestArg.formData.source.value).toBe(binaryDataBuffer);
+		expect(mockExecuteFunctions.helpers.getBinaryDataBuffer).toHaveBeenCalledWith(0, 'data');
+	});
+
+	it('does not attach formData when Send Binary File is disabled', async () => {
+		setParams({ sendBinaryData: false });
+
+		await node.execute.call(mockExecuteFunctions);
+
+		const requestArg = (mockExecuteFunctions.helpers.request as jest.Mock).mock.calls[0][0];
+		expect(requestArg.formData).toBeUndefined();
+		expect(mockExecuteFunctions.helpers.assertBinaryData).not.toHaveBeenCalled();
+		expect(mockExecuteFunctions.helpers.getBinaryDataBuffer).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Summary

The Facebook Graph API node's "Send Binary File" toggle implies binary uploads work everywhere, but Facebook's API only accepts multipart binary uploads on certain edges. Instagram container endpoints like `/media` require a `image_url` / `video_url` query parameter and reject multipart requests with `(#100) The parameter image_url is required` — leading to recurring community confusion (see GH #19432, ~8.8k active workflows touch this node).

**Investigation result:** the node's multipart upload code path is correct — Facebook's `/photos` and `/videos` edges accept it, and a community user [confirmed in the GH thread](https://github.com/n8n-io/n8n/issues/19432#issuecomment-4024262330) that switching to edge `photos` works with the existing implementation. The original Linear root-cause analysis pointing at `routing-node.ts` was a misdiagnosis: `FacebookGraphApi.node.ts` is a programmatic node and never touches the declarative routing engine. So this PR doesn't change runtime behaviour — it fixes the misleading UI copy that's responsible for the confusion, and adds regression tests pinning the (correct) multipart contract so it can't silently break later.

### Changes

- `sendBinaryData`: short `Whether to…` description (matches the convention of neighbouring boolean fields in this file), with the endpoint-support caveat moved into a `hint`.
- New `__tests__/FacebookGraphApi.node.test.ts` with 3 unit tests pinning:
  1. binary buffer is sent via `formData` (not JSON-serialised into `body`),
  2. the `<formField>:<binaryProperty>` syntax routes correctly,
  3. no `formData` is attached when the toggle is off.

### How to test

1. In a workflow, add the Facebook Graph API node.
2. Toggle **Send Binary File** — the field description and hint now mention which edges accept binary and what to use for Instagram `/media`.
3. Run the regression tests:
   ```
   cd packages/nodes-base && pnpm test -- nodes/Facebook
   ```

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-3628
- closes #19432

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI