### PR TITLE
test(ai-builder): Validate user-proxy tool outputs against api-types schemas (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/utils/user-proxy/tools.ts
+++ b/packages/@n8n/instance-ai/evaluations/utils/user-proxy/tools.ts
@@ -1,5 +1,6 @@
 // Decision schema (structured-output target) + encoders to InstanceAiConfirmRequest.
 
+import { domainAccessActionSchema, instanceGatewayResourceDecisionSchema } from '@n8n/api-types';
 import type { InstanceAiConfirmRequest } from '@n8n/api-types';
 import { z } from 'zod';
 
@@ -99,13 +100,22 @@ export function encodeConfirmationDecision(
 				...(decision.userInput ? { userInput: decision.userInput } : {}),
 			};
 
-		case 'respond_to_domain_access':
-			return decision.response === 'deny'
-				? { kind: 'domainAccessDeny' }
-				: { kind: 'domainAccessApprove', domainAccessAction: decision.response };
+		case 'respond_to_domain_access': {
+			if (decision.response === 'deny') return { kind: 'domainAccessDeny' };
+			const parsed = domainAccessActionSchema.safeParse(decision.response);
+			return {
+				kind: 'domainAccessApprove',
+				domainAccessAction: parsed.success ? parsed.data : 'allow_once',
+			};
+		}
 
-		case 'pick_resource_decision':
-			return { kind: 'resourceDecision', resourceDecision: decision.decision };
+		case 'pick_resource_decision': {
+			const parsed = instanceGatewayResourceDecisionSchema.safeParse(decision.decision);
+			return {
+				kind: 'resourceDecision',
+				resourceDecision: parsed.success ? parsed.data : 'allowOnce',
+			};
+		}
 
 		case 'send_follow_up_message':
 		case 'declare_done':


### PR DESCRIPTION
## Summary

- Mirror the schema-validation pattern from `confirmation-payload.ts` in the user-proxy tool encoder for `respond_to_domain_access` and `pick_resource_decision`.
- The Zod structured-output schema in the proxy already constrains the LLM's options to the enum values — this is defensive consistency so the project convention "Zod schemas as the runtime source of truth" holds at both the proxy emission point and the chat-loop infrastructure path.
- Falls back to a safe default (`allow_once` / `allowOnce`) on parse failure so an unexpected LLM string never short-circuits the build.

https://linear.app/n8n/issue/TRUST-117

Reviewer follow-up from #30586.

## Test plan

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] Eval test suite passes locally (`pnpm --filter @n8n/instance-ai test evaluations` — 347/347)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)