### PR TITLE
refactor(editor): Migrate push handlers to workflowExecutionState store

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.test.ts
@@ -27,6 +27,12 @@ import { mockedStore } from '@/__tests__/utils';
 import { useReadyToRunStore } from '@/features/workflows/readyToRun/stores/readyToRun.store';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+import {
+	useWorkflowExecutionStateStore,
+	createWorkflowExecutionStateId,
+} from '@/app/stores/workflowExecutionState.store';
+import { useExecutionDataStore, createExecutionDataId } from '@/app/stores/executionData.store';
+import { createTestWorkflowExecutionResponse } from '@/__tests__/mocks';
 
 const opts = {
 	workflowState: mock<WorkflowState>(),
@@ -244,16 +250,16 @@ describe('getRunExecutionData()', () => {
 
 describe('executionFinished', () => {
 	beforeEach(() => {
-		const pinia = createTestingPinia();
+		const pinia = createTestingPinia({ stubActions: false });
 		setActivePinia(pinia);
 	});
 
 	it('should clear lastAddedExecutingNode when execution is finished', async () => {
-		const workflowState = mock<WorkflowState>({
-			executingNode: {
-				lastAddedExecutingNode: 'test-node',
-			},
-		});
+		const workflowExecutionStateStore = useWorkflowExecutionStateStore(
+			createWorkflowExecutionStateId(''),
+		);
+		workflowExecutionStateStore.addExecutingNode('test-node');
+
 		await executionFinished(
 			{
 				type: 'executionFinished',
@@ -265,23 +271,25 @@ describe('executionFinished', () => {
 			},
 			{
 				router: mock<Router>(),
-				workflowState,
+				workflowState: mock<WorkflowState>(),
 			},
 		);
 
-		expect(workflowState.executingNode.lastAddedExecutingNode).toBeNull();
+		expect(workflowExecutionStateStore.lastAddedExecutingNode).toBeNull();
+		expect(workflowExecutionStateStore.executingNode).toEqual([]);
 	});
 
 	describe('ready-to-run AI workflow tracking', () => {
 		it('should track successful execution of ready-to-run-ai-workflow', async () => {
-			const pinia = createTestingPinia();
+			const pinia = createTestingPinia({ stubActions: false });
 			setActivePinia(pinia);
 
-			const workflowsStore = useWorkflowsStore();
 			const workflowsListStore = useWorkflowsListStore();
 			const readyToRunStore = useReadyToRunStore();
 
-			vi.spyOn(workflowsStore, 'activeExecutionId', 'get').mockReturnValue('123');
+			useWorkflowExecutionStateStore(createWorkflowExecutionStateId('')).setActiveExecutionId(
+				'123',
+			);
 			vi.spyOn(workflowsListStore, 'getWorkflowById').mockReturnValue({
 				id: '1',
 				name: 'Test Workflow',
@@ -318,14 +326,15 @@ describe('executionFinished', () => {
 		});
 
 		it('should track failed execution of ready-to-run-ai-workflow', async () => {
-			const pinia = createTestingPinia();
+			const pinia = createTestingPinia({ stubActions: false });
 			setActivePinia(pinia);
 
-			const workflowsStore = useWorkflowsStore();
 			const workflowsListStore = useWorkflowsListStore();
 			const readyToRunStore = useReadyToRunStore();
 
-			vi.spyOn(workflowsStore, 'activeExecutionId', 'get').mockReturnValue('123');
+			useWorkflowExecutionStateStore(createWorkflowExecutionStateId('')).setActiveExecutionId(
+				'123',
+			);
 			vi.spyOn(workflowsListStore, 'getWorkflowById').mockReturnValue({
 				id: '1',
 				name: 'Test Workflow',
@@ -359,14 +368,15 @@ describe('executionFinished', () => {
 		});
 
 		it('should track execution of ready-to-run-ai-workflow-v5', async () => {
-			const pinia = createTestingPinia();
+			const pinia = createTestingPinia({ stubActions: false });
 			setActivePinia(pinia);
 
-			const workflowsStore = useWorkflowsStore();
 			const workflowsListStore = useWorkflowsListStore();
 			const readyToRunStore = useReadyToRunStore();
 
-			vi.spyOn(workflowsStore, 'activeExecutionId', 'get').mockReturnValue('123');
+			useWorkflowExecutionStateStore(createWorkflowExecutionStateId('')).setActiveExecutionId(
+				'123',
+			);
 			vi.spyOn(workflowsListStore, 'getWorkflowById').mockReturnValue({
 				id: '1',
 				name: 'Test Workflow',
@@ -403,14 +413,15 @@ describe('executionFinished', () => {
 		});
 
 		it('should track execution of ready-to-run-ai-workflow-v6', async () => {
-			const pinia = createTestingPinia();
+			const pinia = createTestingPinia({ stubActions: false });
 			setActivePinia(pinia);
 
-			const workflowsStore = useWorkflowsStore();
 			const workflowsListStore = useWorkflowsListStore();
 			const readyToRunStore = useReadyToRunStore();
 
-			vi.spyOn(workflowsStore, 'activeExecutionId', 'get').mockReturnValue('123');
+			useWorkflowExecutionStateStore(createWorkflowExecutionStateId('')).setActiveExecutionId(
+				'123',
+			);
 			vi.spyOn(workflowsListStore, 'getWorkflowById').mockReturnValue({
 				id: '1',
 				name: 'Test Workflow',
@@ -444,14 +455,15 @@ describe('executionFinished', () => {
 		});
 
 		it('should not track execution for non-ready-to-run workflows', async () => {
-			const pinia = createTestingPinia();
+			const pinia = createTestingPinia({ stubActions: false });
 			setActivePinia(pinia);
 
-			const workflowsStore = useWorkflowsStore();
 			const workflowsListStore = useWorkflowsListStore();
 			const readyToRunStore = useReadyToRunStore();
 
-			vi.spyOn(workflowsStore, 'activeExecutionId', 'get').mockReturnValue('123');
+			useWorkflowExecutionStateStore(createWorkflowExecutionStateId('')).setActiveExecutionId(
+				'123',
+			);
 			vi.spyOn(workflowsListStore, 'getWorkflowById').mockReturnValue({
 				id: '1',
 				name: 'Test Workflow',
@@ -491,24 +503,18 @@ describe('executionFinished', () => {
 	});
 
 	it('should return early and clear active execution when fetchExecutionData returns undefined', async () => {
-		const pinia = createTestingPinia({
-			initialState: {
-				workflows: {
-					activeExecutionId: '123',
-				},
-			},
-		});
-
+		const pinia = createTestingPinia({ stubActions: false });
 		setActivePinia(pinia);
 
 		const workflowsStore = mockedStore(useWorkflowsStore);
 		const workflowsListStore = mockedStore(useWorkflowsListStore);
 		const uiStore = mockedStore(useUIStore);
+		const workflowExecutionStateStore = useWorkflowExecutionStateStore(
+			createWorkflowExecutionStateId(''),
+		);
 
-		// Set activeExecutionId directly on the store
-		workflowsStore.activeExecutionId = '123';
+		workflowExecutionStateStore.setActiveExecutionId('123');
 
-		// Mock getWorkflowById to return a workflow
 		vi.spyOn(workflowsListStore, 'getWorkflowById').mockReturnValue({
 			id: '1',
 			name: 'Test Workflow',
@@ -522,13 +528,6 @@ describe('executionFinished', () => {
 
 		const setProcessingExecutionResultsSpy = vi.spyOn(uiStore, 'setProcessingExecutionResults');
 
-		const workflowState = mock<WorkflowState>({
-			executingNode: {
-				lastAddedExecutingNode: 'test-node',
-			},
-			setActiveExecutionId: vi.fn(),
-		});
-
 		await executionFinished(
 			{
 				type: 'executionFinished',
@@ -540,12 +539,12 @@ describe('executionFinished', () => {
 			},
 			{
 				router: mock<Router>(),
-				workflowState,
+				workflowState: mock<WorkflowState>(),
 			},
 		);
 
-		// Verify that setActiveExecutionId was called with undefined
-		expect(workflowState.setActiveExecutionId).toHaveBeenCalledWith(undefined);
+		// Active execution id is cleared on the per-workflow state store.
+		expect(workflowExecutionStateStore.activeExecutionId).toBeUndefined();
 
 		// Verify that processing was set to false
 		expect(setProcessingExecutionResultsSpy).toHaveBeenCalledWith(false);
@@ -554,20 +553,17 @@ describe('executionFinished', () => {
 	});
 
 	it('should clear executing node queue even when fetchExecutionData returns undefined', async () => {
-		const pinia = createTestingPinia({
-			initialState: {
-				workflows: {
-					activeExecutionId: '123',
-				},
-			},
-		});
-
+		const pinia = createTestingPinia({ stubActions: false });
 		setActivePinia(pinia);
 
 		const workflowsStore = mockedStore(useWorkflowsStore);
 		const workflowsListStore = mockedStore(useWorkflowsListStore);
+		const workflowExecutionStateStore = useWorkflowExecutionStateStore(
+			createWorkflowExecutionStateId(''),
+		);
 
-		workflowsStore.activeExecutionId = '123';
+		workflowExecutionStateStore.setActiveExecutionId('123');
+		workflowExecutionStateStore.addExecutingNode('LastNode');
 
 		vi.spyOn(workflowsListStore, 'getWorkflowById').mockReturnValue({
 			id: '1',
@@ -581,15 +577,6 @@ describe('executionFinished', () => {
 		// Simulate the iframe scenario: fetch returns no data
 		vi.spyOn(workflowsStore, 'fetchExecutionDataById').mockResolvedValue(null);
 
-		const clearNodeExecutionQueue = vi.fn();
-		const workflowState = mock<WorkflowState>({
-			executingNode: {
-				lastAddedExecutingNode: 'LastNode',
-				clearNodeExecutionQueue,
-			},
-			setActiveExecutionId: vi.fn(),
-		});
-
 		await executionFinished(
 			{
 				type: 'executionFinished',
@@ -601,30 +588,24 @@ describe('executionFinished', () => {
 			},
 			{
 				router: mock<Router>(),
-				workflowState,
+				workflowState: mock<WorkflowState>(),
 			},
 		);
 
 		// The executing node queue must be cleared so nodes don't stay stuck
 		// with a spinner after the execution finishes.
-		expect(clearNodeExecutionQueue).toHaveBeenCalled();
+		expect(workflowExecutionStateStore.executingNode).toEqual([]);
 	});
 
 	it('should clear executing node queue when activeExecutionId is undefined (iframe preview)', async () => {
-		const pinia = createTestingPinia();
+		const pinia = createTestingPinia({ stubActions: false });
 		setActivePinia(pinia);
 
-		const workflowsStore = mockedStore(useWorkflowsStore);
-		// In iframe preview after resetWorkspace, activeExecutionId can be undefined
-		workflowsStore.activeExecutionId = undefined;
-
-		const clearNodeExecutionQueue = vi.fn();
-		const workflowState = mock<WorkflowState>({
-			executingNode: {
-				lastAddedExecutingNode: 'LastNode',
-				clearNodeExecutionQueue,
-			},
-		});
+		const workflowExecutionStateStore = useWorkflowExecutionStateStore(
+			createWorkflowExecutionStateId(''),
+		);
+		// In iframe preview after resetWorkspace, activeExecutionId is undefined.
+		workflowExecutionStateStore.addExecutingNode('LastNode');
 
 		await executionFinished(
 			{
@@ -637,13 +618,13 @@ describe('executionFinished', () => {
 			},
 			{
 				router: mock<Router>(),
-				workflowState,
+				workflowState: mock<WorkflowState>(),
 			},
 		);
 
 		// Even when activeExecutionId is undefined (iframe early return),
 		// the executing node queue must be cleared.
-		expect(clearNodeExecutionQueue).toHaveBeenCalled();
+		expect(workflowExecutionStateStore.executingNode).toEqual([]);
 	});
 });
 
@@ -654,37 +635,37 @@ describe('manual execution stats tracking', () => {
 
 	describe('handleExecutionFinishedWithSuccessOrOther', () => {
 		it('increments success stats on successful execution', () => {
-			const pinia = createTestingPinia();
+			const pinia = createTestingPinia({ stubActions: false });
 			setActivePinia(pinia);
 
 			const builderStore = mockedStore(useBuilderStore);
 			const incrementSpy = vi.spyOn(builderStore, 'incrementManualExecutionStats');
 
-			handleExecutionFinishedWithSuccessOrOther(mock<WorkflowState>(), 'success', false);
+			handleExecutionFinishedWithSuccessOrOther('success', false);
 
 			expect(incrementSpy).toHaveBeenCalledWith('success');
 		});
 
 		it('does not increment success stats when successToastAlreadyShown is true', () => {
-			const pinia = createTestingPinia();
+			const pinia = createTestingPinia({ stubActions: false });
 			setActivePinia(pinia);
 
 			const builderStore = mockedStore(useBuilderStore);
 			const incrementSpy = vi.spyOn(builderStore, 'incrementManualExecutionStats');
 
-			handleExecutionFinishedWithSuccessOrOther(mock<WorkflowState>(), 'success', true);
+			handleExecutionFinishedWithSuccessOrOther('success', true);
 
 			expect(incrementSpy).not.toHaveBeenCalled();
 		});
 
 		it('does not increment stats for non-success status', () => {
-			const pinia = createTestingPinia();
+			const pinia = createTestingPinia({ stubActions: false });
 			setActivePinia(pinia);
 
 			const builderStore = mockedStore(useBuilderStore);
 			const incrementSpy = vi.spyOn(builderStore, 'incrementManualExecutionStats');
 
-			handleExecutionFinishedWithSuccessOrOther(mock<WorkflowState>(), 'error', false);
+			handleExecutionFinishedWithSuccessOrOther('error', false);
 
 			expect(incrementSpy).not.toHaveBeenCalled();
 		});
@@ -696,23 +677,38 @@ describe('manual execution stats tracking', () => {
 		});
 
 		it('shows success toast when executed node has run data', () => {
-			const pinia = createTestingPinia();
+			const pinia = createTestingPinia({ stubActions: false });
 			setActivePinia(pinia);
 
-			const workflowsStore = mockedStore(useWorkflowsStore);
 			const nodeTypesStore = mockedStore(useNodeTypesStore);
+			const workflowExecutionStateStore = useWorkflowExecutionStateStore(
+				createWorkflowExecutionStateId(''),
+			);
 
 			const nodeName = 'Send Telegram';
-			vi.spyOn(workflowsStore, 'getWorkflowExecution', 'get').mockReturnValue({
-				executedNode: nodeName,
-				data: {
-					resultData: {
-						runData: {
-							[nodeName]: [mock<ITaskData>()],
+			const executionId = 'exec-success';
+			useExecutionDataStore(createExecutionDataId(executionId)).setExecution(
+				createTestWorkflowExecutionResponse({
+					id: executionId,
+					executedNode: nodeName,
+					data: {
+						resultData: {
+							runData: {
+								[nodeName]: [
+									{
+										executionTime: 0,
+										startTime: 0,
+										executionIndex: 0,
+										source: [],
+										data: { main: [[]] },
+									},
+								],
+							},
 						},
-					},
-				},
-			} as unknown as IExecutionResponse);
+					} as unknown as IExecutionResponse['data'],
+				}),
+			);
+			workflowExecutionStateStore.setActiveExecutionId(executionId);
 
 			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(''));
 			workflowDocumentStore.setNodes([
@@ -722,27 +718,32 @@ describe('manual execution stats tracking', () => {
 			nodeTypesStore.getNodeType = () =>
 				mock<INodeTypeDescription>({ polling: undefined, group: [] });
 
-			handleExecutionFinishedWithSuccessOrOther(mock<WorkflowState>(), 'success', false);
+			handleExecutionFinishedWithSuccessOrOther('success', false);
 
 			expect(mockShowMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'success' }));
 		});
 
 		it('shows warning toast when executed node was not reached', () => {
-			const pinia = createTestingPinia();
+			const pinia = createTestingPinia({ stubActions: false });
 			setActivePinia(pinia);
 
-			const workflowsStore = mockedStore(useWorkflowsStore);
 			const nodeTypesStore = mockedStore(useNodeTypesStore);
+			const workflowExecutionStateStore = useWorkflowExecutionStateStore(
+				createWorkflowExecutionStateId(''),
+			);
 
 			const nodeName = 'Send a text message';
-			vi.spyOn(workflowsStore, 'getWorkflowExecution', 'get').mockReturnValue({
-				executedNode: nodeName,
-				data: {
-					resultData: {
-						runData: {},
-					},
-				},
-			} as unknown as IExecutionResponse);
+			const executionId = 'exec-warn';
+			useExecutionDataStore(createExecutionDataId(executionId)).setExecution(
+				createTestWorkflowExecutionResponse({
+					id: executionId,
+					executedNode: nodeName,
+					data: {
+						resultData: { runData: {} },
+					} as unknown as IExecutionResponse['data'],
+				}),
+			);
+			workflowExecutionStateStore.setActiveExecutionId(executionId);
 
 			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(''));
 			workflowDocumentStore.setNodes([
@@ -752,27 +753,32 @@ describe('manual execution stats tracking', () => {
 			nodeTypesStore.getNodeType = () =>
 				mock<INodeTypeDescription>({ polling: undefined, group: [] });
 
-			handleExecutionFinishedWithSuccessOrOther(mock<WorkflowState>(), 'success', false);
+			handleExecutionFinishedWithSuccessOrOther('success', false);
 
 			expect(mockShowMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'warning' }));
 		});
 
 		it('does not show warning toast when successToastAlreadyShown is true', () => {
-			const pinia = createTestingPinia();
+			const pinia = createTestingPinia({ stubActions: false });
 			setActivePinia(pinia);
 
-			const workflowsStore = mockedStore(useWorkflowsStore);
 			const nodeTypesStore = mockedStore(useNodeTypesStore);
+			const workflowExecutionStateStore = useWorkflowExecutionStateStore(
+				createWorkflowExecutionStateId(''),
+			);
 
 			const nodeName = 'Send a text message';
-			vi.spyOn(workflowsStore, 'getWorkflowExecution', 'get').mockReturnValue({
-				executedNode: nodeName,
-				data: {
-					resultData: {
-						runData: {},
-					},
-				},
-			} as unknown as IExecutionResponse);
+			const executionId = 'exec-skip';
+			useExecutionDataStore(createExecutionDataId(executionId)).setExecution(
+				createTestWorkflowExecutionResponse({
+					id: executionId,
+					executedNode: nodeName,
+					data: {
+						resultData: { runData: {} },
+					} as unknown as IExecutionResponse['data'],
+				}),
+			);
+			workflowExecutionStateStore.setActiveExecutionId(executionId);
 
 			const docStore2 = useWorkflowDocumentStore(createWorkflowDocumentId(''));
 			docStore2.setNodes([
@@ -782,7 +788,7 @@ describe('manual execution stats tracking', () => {
 			nodeTypesStore.getNodeType = () =>
 				mock<INodeTypeDescription>({ polling: undefined, group: [] });
 
-			handleExecutionFinishedWithSuccessOrOther(mock<WorkflowState>(), 'success', true);
+			handleExecutionFinishedWithSuccessOrOther('success', true);
 
 			expect(mockShowMessage).not.toHaveBeenCalled();
 		});
@@ -790,7 +796,7 @@ describe('manual execution stats tracking', () => {
 
 	describe('handleExecutionFinishedWithErrorOrCanceled', () => {
 		it('increments error stats on execution error', () => {
-			const pinia = createTestingPinia();
+			const pinia = createTestingPinia({ stubActions: false });
 			setActivePinia(pinia);
 
 			const builderStore = mockedStore(useBuilderStore);
@@ -814,7 +820,7 @@ describe('manual execution stats tracking', () => {
 		});
 
 		it('does not increment stats for canceled executions', () => {
-			const pinia = createTestingPinia();
+			const pinia = createTestingPinia({ stubActions: false });
 			setActivePinia(pinia);
 
 			const builderStore = mockedStore(useBuilderStore);

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -71,16 +71,18 @@ export async function executionFinished(
 	options: ExecutionFinishedOptions,
 ) {
 	const workflowsStore = useWorkflowsStore();
+	const workflowExecutionStateStore = useWorkflowExecutionStateStore(
+		createWorkflowExecutionStateId(workflowsStore.workflowId),
+	);
 	const workflowsListStore = useWorkflowsListStore();
 	const uiStore = useUIStore();
 	const aiTemplatesStarterCollectionStore = useAITemplatesStarterCollectionStore();
 	const readyToRunStore = useReadyToRunStore();
 
-	options.workflowState.executingNode.lastAddedExecutingNode = null;
-	options.workflowState.executingNode.clearNodeExecutionQueue();
+	workflowExecutionStateStore.clearNodeExecutionQueue();
 
 	// No workflow is actively running, therefore we ignore this event
-	if (typeof workflowsStore.activeExecutionId === 'undefined') {
+	if (typeof workflowExecutionStateStore.activeExecutionId === 'undefined') {
 		return;
 	}
 
@@ -125,11 +127,7 @@ export async function executionFinished(
 	let successToastAlreadyShown = false;
 
 	if (data.status === 'success') {
-		handleExecutionFinishedWithSuccessOrOther(
-			options.workflowState,
-			data.status,
-			successToastAlreadyShown,
-		);
+		handleExecutionFinishedWithSuccessOrOther(data.status, successToastAlreadyShown);
 		successToastAlreadyShown = true;
 	}
 
@@ -141,7 +139,7 @@ export async function executionFinished(
 	 * Returning early presists existing run data up to this point.
 	 */
 	if (!execution) {
-		options.workflowState.setActiveExecutionId(undefined);
+		workflowExecutionStateStore.setActiveExecutionId(undefined);
 		uiStore.setProcessingExecutionResults(false);
 		return;
 	}
@@ -154,14 +152,10 @@ export async function executionFinished(
 	} else if (execution.status === 'error' || execution.status === 'canceled') {
 		handleExecutionFinishedWithErrorOrCanceled(execution, runExecutionData);
 	} else {
-		handleExecutionFinishedWithSuccessOrOther(
-			options.workflowState,
-			execution.status,
-			successToastAlreadyShown,
-		);
+		handleExecutionFinishedWithSuccessOrOther(execution.status, successToastAlreadyShown);
 	}
 
-	setRunExecutionData(execution, runExecutionData, options.workflowState);
+	setRunExecutionData(execution, runExecutionData);
 
 	continueEvaluationLoop(execution, options);
 }
@@ -215,6 +209,9 @@ export async function fetchExecutionData(
 	const workflowDocumentStore = useWorkflowDocumentStore(
 		createWorkflowDocumentId(workflowsStore.workflowId),
 	);
+	const workflowExecutionStateStore = useWorkflowExecutionStateStore(
+		createWorkflowExecutionStateId(workflowsStore.workflowId),
+	);
 
 	try {
 		const executionResponse = await workflowsStore.fetchExecutionDataById(executionId);
@@ -228,7 +225,7 @@ export async function fetchExecutionData(
 			workflowData: workflowDocumentStore.getSnapshot(),
 			data: executionResponse.data,
 			status: executionResponse.status,
-			startedAt: workflowsStore.workflowExecutionData?.startedAt as Date,
+			startedAt: workflowExecutionStateStore.activeExecution?.startedAt as Date,
 			stoppedAt: new Date(),
 		};
 	} catch {
@@ -259,9 +256,12 @@ export function getRunDataExecutedErrorMessage(execution: SimplifiedExecution) {
 		return i18n.baseText('pushConnection.executionFailed.message');
 	} else if (execution.status === 'canceled') {
 		const workflowsStore = useWorkflowsStore();
+		const workflowExecutionStateStore = useWorkflowExecutionStateStore(
+			createWorkflowExecutionStateId(workflowsStore.workflowId),
+		);
 
 		return i18n.baseText('executionsList.showMessage.stopExecution.message', {
-			interpolate: { activeExecutionId: workflowsStore.activeExecutionId ?? '' },
+			interpolate: { activeExecutionId: workflowExecutionStateStore.activeExecutionId ?? '' },
 		});
 	}
 
@@ -390,15 +390,15 @@ export function handleExecutionFinishedWithErrorOrCanceled(
  * immediately, even though we still need to fetch and deserialize the
  * full execution data, to minimize perceived latency.
  */
-function handleExecutionFinishedSuccessfully(
-	workflowName: string,
-	message: string,
-	workflowState: WorkflowState,
-) {
+function handleExecutionFinishedSuccessfully(workflowName: string, message: string) {
 	const toast = useToast();
+	const workflowsStore = useWorkflowsStore();
+	const workflowExecutionStateStore = useWorkflowExecutionStateStore(
+		createWorkflowExecutionStateId(workflowsStore.workflowId),
+	);
 
 	useDocumentTitle().setDocumentTitle(workflowName, 'IDLE');
-	workflowState.setActiveExecutionId(undefined);
+	workflowExecutionStateStore.setActiveExecutionId(undefined);
 	toast.showMessage({
 		title: message,
 		type: 'success',
@@ -409,11 +409,13 @@ function handleExecutionFinishedSuccessfully(
  * Handle the case when the workflow execution finished successfully.
  */
 export function handleExecutionFinishedWithSuccessOrOther(
-	workflowState: WorkflowState,
 	executionStatus: ExecutionStatus,
 	successToastAlreadyShown: boolean,
 ) {
 	const workflowsStore = useWorkflowsStore();
+	const workflowExecutionStateStore = useWorkflowExecutionStateStore(
+		createWorkflowExecutionStateId(workflowsStore.workflowId),
+	);
 	const toast = useToast();
 	const i18n = useI18n();
 	const nodeTypesStore = useNodeTypesStore();
@@ -425,7 +427,7 @@ export function handleExecutionFinishedWithSuccessOrOther(
 
 	useDocumentTitle().setDocumentTitle(workflowName, 'IDLE');
 
-	const workflowExecution = workflowsStore.getWorkflowExecution;
+	const workflowExecution = workflowExecutionStateStore.activeExecution;
 	if (workflowExecution?.executedNode) {
 		const node = workflowDocumentStore.getNodeByName(workflowExecution.executedNode) ?? null;
 		const nodeType = node && nodeTypesStore.getNodeType(node.type, node.typeVersion);
@@ -456,14 +458,12 @@ export function handleExecutionFinishedWithSuccessOrOther(
 			handleExecutionFinishedSuccessfully(
 				workflowName,
 				i18n.baseText('pushConnection.nodeExecutedSuccessfully'),
-				workflowState,
 			);
 		}
 	} else if (!successToastAlreadyShown) {
 		handleExecutionFinishedSuccessfully(
 			workflowName,
 			i18n.baseText('pushConnection.workflowExecutedSuccessfully'),
-			workflowState,
 		);
 	}
 
@@ -477,16 +477,15 @@ export function handleExecutionFinishedWithSuccessOrOther(
 export function setRunExecutionData(
 	execution: SimplifiedExecution,
 	runExecutionData: IRunExecutionData,
-	workflowState: WorkflowState,
 ) {
 	const workflowsStore = useWorkflowsStore();
-	const stateStore = useWorkflowExecutionStateStore(
+	const workflowExecutionStateStore = useWorkflowExecutionStateStore(
 		createWorkflowExecutionStateId(workflowsStore.workflowId),
 	);
 	const nodeHelpers = useNodeHelpers();
 	const runDataExecutedErrorMessage = getRunDataExecutedErrorMessage(execution);
 
-	workflowState.executingNode.clearNodeExecutionQueue();
+	workflowExecutionStateStore.clearNodeExecutionQueue();
 
 	const executionDataStore = useExecutionDataStore(createExecutionDataId(execution.id));
 	const workflowExecution = executionDataStore.getExecutionSnapshot();
@@ -502,7 +501,7 @@ export function setRunExecutionData(
 		stoppedAt: execution.stoppedAt,
 	});
 	executionDataStore.setExecutionRunData(runExecutionData);
-	stateStore.setActiveExecutionId(undefined);
+	workflowExecutionStateStore.setActiveExecutionId(undefined);
 
 	// Set the node execution issues on all the nodes which produced an error so that
 	// it can be displayed in the node-view
@@ -519,7 +518,7 @@ export function setRunExecutionData(
 			runExecutionData.resultData.runData[lastNodeExecuted][0].data?.main[0]?.length ?? 0;
 	}
 
-	stateStore.setActiveExecutionId(undefined);
+	workflowExecutionStateStore.setActiveExecutionId(undefined);
 
 	void useExternalHooks().run('pushConnection.executionFinished', {
 		itemsCount,

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionRecovered.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionRecovered.ts
@@ -21,13 +21,13 @@ export async function executionRecovered(
 	options: { router: ReturnType<typeof useRouter>; workflowState: WorkflowState },
 ) {
 	const workflowsStore = useWorkflowsStore();
-	const stateStore = useWorkflowExecutionStateStore(
+	const workflowExecutionStateStore = useWorkflowExecutionStateStore(
 		createWorkflowExecutionStateId(workflowsStore.workflowId),
 	);
 	const uiStore = useUIStore();
 
 	// No workflow is actively running, therefore we ignore this event
-	if (typeof stateStore.activeExecutionId === 'undefined') {
+	if (typeof workflowExecutionStateStore.activeExecutionId === 'undefined') {
 		return;
 	}
 
@@ -47,8 +47,8 @@ export async function executionRecovered(
 	} else if (execution.status === 'error' || execution.status === 'canceled') {
 		handleExecutionFinishedWithErrorOrCanceled(execution, runExecutionData);
 	} else {
-		handleExecutionFinishedWithSuccessOrOther(options.workflowState, execution.status, false);
+		handleExecutionFinishedWithSuccessOrOther(execution.status, false);
 	}
 
-	setRunExecutionData(execution, runExecutionData, options.workflowState);
+	setRunExecutionData(execution, runExecutionData);
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionStarted.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionStarted.test.ts
@@ -14,7 +14,7 @@ import { createExecutionDataId, useExecutionDataStore } from '@/app/stores/execu
 
 describe('executionStarted', () => {
 	let workflowsStore: ReturnType<typeof useWorkflowsStore>;
-	let stateStore: ReturnType<typeof useWorkflowExecutionStateStore>;
+	let workflowExecutionStateStore: ReturnType<typeof useWorkflowExecutionStateStore>;
 
 	function makeEvent(executionId = 'exec-1'): ExecutionStarted {
 		return {
@@ -32,15 +32,17 @@ describe('executionStarted', () => {
 		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId('wf-123'));
 		workflowDocumentStore.setName('My Workflow');
 
-		stateStore = useWorkflowExecutionStateStore(createWorkflowExecutionStateId('wf-123'));
+		workflowExecutionStateStore = useWorkflowExecutionStateStore(
+			createWorkflowExecutionStateId('wf-123'),
+		);
 	});
 
 	it('should skip when activeExecutionId is undefined', async () => {
 		// activeExecutionId defaults to undefined, no need to set it
 		await executionStarted(makeEvent());
 
-		// stateStore.activeExecutionId should remain undefined
-		expect(stateStore.activeExecutionId).toBeUndefined();
+		// workflowExecutionStateStore.activeExecutionId should remain undefined
+		expect(workflowExecutionStateStore.activeExecutionId).toBeUndefined();
 
 		// No execution data store should have been created for exec-1
 		const executionDataStore = useExecutionDataStore(createExecutionDataId('exec-1'));
@@ -48,11 +50,11 @@ describe('executionStarted', () => {
 	});
 
 	it('should accept execution when activeExecutionId is null and populate workflowData from store', async () => {
-		stateStore.setActiveExecutionId(null);
+		workflowExecutionStateStore.setActiveExecutionId(null);
 
 		await executionStarted(makeEvent('exec-1'));
 
-		expect(stateStore.activeExecutionId).toBe('exec-1');
+		expect(workflowExecutionStateStore.activeExecutionId).toBe('exec-1');
 
 		const executionDataStore = useExecutionDataStore(createExecutionDataId('exec-1'));
 		expect(executionDataStore.execution).toMatchObject({
@@ -64,7 +66,7 @@ describe('executionStarted', () => {
 
 	it('should not reinitialize when same execution ID arrives', async () => {
 		// Set up an active execution with existing data
-		stateStore.promotePendingExecution('exec-1');
+		workflowExecutionStateStore.promotePendingExecution('exec-1');
 		const executionDataStore = useExecutionDataStore(createExecutionDataId('exec-1'));
 		executionDataStore.setExecution({
 			id: 'exec-1',
@@ -81,8 +83,8 @@ describe('executionStarted', () => {
 
 		await executionStarted(makeEvent('exec-1'));
 
-		// stateStore.activeExecutionId should remain 'exec-1' without change
-		expect(stateStore.activeExecutionId).toBe('exec-1');
+		// workflowExecutionStateStore.activeExecutionId should remain 'exec-1' without change
+		expect(workflowExecutionStateStore.activeExecutionId).toBe('exec-1');
 
 		// execution data should not have been overwritten (same reference or same id)
 		expect(executionDataStore.execution?.id).toBe('exec-1');
@@ -114,7 +116,7 @@ describe('executionStarted', () => {
 			// activeExecutionId defaults to undefined; in iframe context this should still accept
 			await executionStarted(makeEvent('exec-2'));
 
-			expect(stateStore.activeExecutionId).toBe('exec-2');
+			expect(workflowExecutionStateStore.activeExecutionId).toBe('exec-2');
 
 			const executionDataStore = useExecutionDataStore(createExecutionDataId('exec-2'));
 			expect(executionDataStore.execution).toMatchObject({
@@ -125,7 +127,7 @@ describe('executionStarted', () => {
 
 		it('should accept new execution and reset state when re-executing in iframe', async () => {
 			// Set up an existing active execution
-			stateStore.promotePendingExecution('exec-1');
+			workflowExecutionStateStore.promotePendingExecution('exec-1');
 			const oldExecStore = useExecutionDataStore(createExecutionDataId('exec-1'));
 			oldExecStore.setExecution({
 				id: 'exec-1',
@@ -142,7 +144,7 @@ describe('executionStarted', () => {
 
 			await executionStarted(makeEvent('exec-2'));
 
-			expect(stateStore.activeExecutionId).toBe('exec-2');
+			expect(workflowExecutionStateStore.activeExecutionId).toBe('exec-2');
 
 			const newExecStore = useExecutionDataStore(createExecutionDataId('exec-2'));
 			expect(newExecStore.execution).toMatchObject({
@@ -153,7 +155,7 @@ describe('executionStarted', () => {
 
 		it('should not reset when same execution ID arrives in iframe', async () => {
 			// Set up an existing active execution with data
-			stateStore.promotePendingExecution('exec-1');
+			workflowExecutionStateStore.promotePendingExecution('exec-1');
 			const executionDataStore = useExecutionDataStore(createExecutionDataId('exec-1'));
 			executionDataStore.setExecution({
 				id: 'exec-1',
@@ -169,7 +171,7 @@ describe('executionStarted', () => {
 			await executionStarted(makeEvent('exec-1'));
 
 			// Should remain exec-1 without reinitializing
-			expect(stateStore.activeExecutionId).toBe('exec-1');
+			expect(workflowExecutionStateStore.activeExecutionId).toBe('exec-1');
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionStarted.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionStarted.ts
@@ -18,7 +18,7 @@ import type { IRunExecutionData } from 'n8n-workflow';
  */
 export async function executionStarted({ data }: ExecutionStarted) {
 	const workflowsStore = useWorkflowsStore();
-	const stateStore = useWorkflowExecutionStateStore(
+	const workflowExecutionStateStore = useWorkflowExecutionStateStore(
 		createWorkflowExecutionStateId(workflowsStore.workflowId),
 	);
 	const isIframe = window !== window.parent;
@@ -26,18 +26,18 @@ export async function executionStarted({ data }: ExecutionStarted) {
 	// In non-iframe context, undefined means "not tracking executions" → skip.
 	// In iframe context, executionFinished resets activeExecutionId to undefined,
 	// but we still want to accept new executions (re-execution scenario).
-	if (typeof stateStore.activeExecutionId === 'undefined' && !isIframe) {
+	if (typeof workflowExecutionStateStore.activeExecutionId === 'undefined' && !isIframe) {
 		return;
 	}
 
 	// Determine if we need to (re)initialize execution tracking state
 	const needsInit =
-		stateStore.activeExecutionId === null ||
-		typeof stateStore.activeExecutionId === 'undefined' ||
-		(isIframe && stateStore.activeExecutionId !== data.executionId);
+		workflowExecutionStateStore.activeExecutionId === null ||
+		typeof workflowExecutionStateStore.activeExecutionId === 'undefined' ||
+		(isIframe && workflowExecutionStateStore.activeExecutionId !== data.executionId);
 
 	if (needsInit) {
-		stateStore.promotePendingExecution(data.executionId);
+		workflowExecutionStateStore.promotePendingExecution(data.executionId);
 	}
 
 	const executionDataStore = useExecutionDataStore(createExecutionDataId(data.executionId));

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.test.ts
@@ -4,9 +4,6 @@ import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useAssistantStore } from '@/features/ai/assistant/assistant.store';
 import type { NodeExecuteAfter } from '@n8n/api-types/push/execution';
 import { TRIMMED_TASK_DATA_CONNECTIONS_KEY } from 'n8n-workflow';
-import type { WorkflowState } from '@/app/composables/useWorkflowState';
-import { mock } from 'vitest-mock-extended';
-import type { Mocked } from 'vitest';
 import {
 	createWorkflowExecutionStateId,
 	useWorkflowExecutionStateStore,
@@ -29,9 +26,8 @@ vi.mock('@/features/execution/executions/executions.utils', async (importOrigina
 import { openFormPopupWindow } from '@/features/execution/executions/executions.utils';
 
 describe('nodeExecuteAfter', () => {
-	let mockOptions: { workflowState: Mocked<WorkflowState> };
 	let workflowsStore: ReturnType<typeof useWorkflowsStore>;
-	let stateStore: ReturnType<typeof useWorkflowExecutionStateStore>;
+	let workflowExecutionStateStore: ReturnType<typeof useWorkflowExecutionStateStore>;
 	let executionDataStore: ReturnType<typeof useExecutionDataStore>;
 
 	beforeEach(() => {
@@ -41,7 +37,9 @@ describe('nodeExecuteAfter', () => {
 		workflowsStore = useWorkflowsStore();
 		workflowsStore.setWorkflowId('test-wf');
 
-		stateStore = useWorkflowExecutionStateStore(createWorkflowExecutionStateId('test-wf'));
+		workflowExecutionStateStore = useWorkflowExecutionStateStore(
+			createWorkflowExecutionStateId('test-wf'),
+		);
 
 		executionDataStore = useExecutionDataStore(createExecutionDataId('exec-1'));
 		executionDataStore.setExecution(
@@ -53,19 +51,12 @@ describe('nodeExecuteAfter', () => {
 			}),
 		);
 
-		stateStore.setActiveExecutionId('exec-1');
-
-		mockOptions = {
-			workflowState: mock<WorkflowState>({
-				executingNode: {
-					removeExecutingNode: vi.fn(),
-				},
-			}),
-		};
+		workflowExecutionStateStore.setActiveExecutionId('exec-1');
 	});
 
 	it('should update node execution data with placeholder and remove executing node', async () => {
 		const assistantStore = useAssistantStore();
+		workflowExecutionStateStore.addExecutingNode('Test Node');
 
 		const event: NodeExecuteAfter = {
 			type: 'nodeExecuteAfter',
@@ -82,12 +73,9 @@ describe('nodeExecuteAfter', () => {
 			},
 		};
 
-		await nodeExecuteAfter(event, mockOptions);
+		await nodeExecuteAfter(event);
 
-		expect(mockOptions.workflowState.executingNode.removeExecutingNode).toHaveBeenCalledTimes(1);
-		expect(mockOptions.workflowState.executingNode.removeExecutingNode).toHaveBeenCalledWith(
-			'Test Node',
-		);
+		expect(workflowExecutionStateStore.executingNode).toEqual([]);
 		expect(assistantStore.onNodeExecution).toHaveBeenCalledTimes(1);
 		expect(assistantStore.onNodeExecution).toHaveBeenCalledWith(event.data);
 
@@ -122,7 +110,7 @@ describe('nodeExecuteAfter', () => {
 			},
 		};
 
-		await nodeExecuteAfter(event, mockOptions);
+		await nodeExecuteAfter(event);
 
 		const runData = executionDataStore.execution?.data?.resultData.runData;
 		expect(runData?.['Test Node'][0].data).toEqual({
@@ -155,7 +143,7 @@ describe('nodeExecuteAfter', () => {
 			},
 		};
 
-		await nodeExecuteAfter(event, mockOptions);
+		await nodeExecuteAfter(event);
 
 		const runData = executionDataStore.execution?.data?.resultData.runData;
 		expect(runData?.['Test Node'][0].data).toEqual({
@@ -179,7 +167,7 @@ describe('nodeExecuteAfter', () => {
 			},
 		};
 
-		await nodeExecuteAfter(event, mockOptions);
+		await nodeExecuteAfter(event);
 
 		const runData = executionDataStore.execution?.data?.resultData.runData;
 		const taskData = runData?.['Test Node'][0];
@@ -216,7 +204,7 @@ describe('nodeExecuteAfter', () => {
 			},
 		};
 
-		await nodeExecuteAfter(event, mockOptions);
+		await nodeExecuteAfter(event);
 
 		const runData = executionDataStore.execution?.data?.resultData.runData;
 		// Should only contain main connection, invalid_connection should be filtered out
@@ -247,7 +235,7 @@ describe('nodeExecuteAfter', () => {
 			},
 		};
 
-		await nodeExecuteAfter(event, mockOptions);
+		await nodeExecuteAfter(event);
 
 		expect(openFormPopupWindow).toHaveBeenCalledWith(formUrl);
 	});
@@ -269,7 +257,7 @@ describe('nodeExecuteAfter', () => {
 			},
 		};
 
-		await nodeExecuteAfter(event, mockOptions);
+		await nodeExecuteAfter(event);
 
 		expect(openFormPopupWindow).not.toHaveBeenCalled();
 	});

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfter.ts
@@ -12,17 +12,13 @@ import type { PushPayload } from '@n8n/api-types';
 import { isValidNodeConnectionType } from '@/app/utils/typeGuards';
 import { openFormPopupWindow } from '@/features/execution/executions/executions.utils';
 import { trackNodeExecution } from './trackNodeExecution';
-import type { WorkflowState } from '@/app/composables/useWorkflowState';
 
 /**
  * Handles the 'nodeExecuteAfter' event, which happens after a node is executed.
  */
-export async function nodeExecuteAfter(
-	{ data: pushData }: NodeExecuteAfter,
-	{ workflowState }: { workflowState: WorkflowState },
-) {
+export async function nodeExecuteAfter({ data: pushData }: NodeExecuteAfter) {
 	const workflowsStore = useWorkflowsStore();
-	const stateStore = useWorkflowExecutionStateStore(
+	const workflowExecutionStateStore = useWorkflowExecutionStateStore(
 		createWorkflowExecutionStateId(workflowsStore.workflowId),
 	);
 	const assistantStore = useAssistantStore();
@@ -60,7 +56,7 @@ export async function nodeExecuteAfter(
 		},
 	};
 
-	const activeExecutionId = stateStore.activeExecutionId;
+	const activeExecutionId = workflowExecutionStateStore.activeExecutionId;
 	if (typeof activeExecutionId === 'string') {
 		useExecutionDataStore(createExecutionDataId(activeExecutionId)).updateNodeExecutionStatus(
 			pushDataWithPlaceholderOutputData,
@@ -71,7 +67,7 @@ export async function nodeExecuteAfter(
 		}
 	}
 
-	workflowState.executingNode.removeExecutingNode(pushData.nodeName);
+	workflowExecutionStateStore.removeExecutingNode(pushData.nodeName);
 
 	// Side effects
 	if (pushData.data.executionStatus === 'waiting' && pushData.data.metadata?.resumeFormUrl) {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfterData.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfterData.test.ts
@@ -12,7 +12,7 @@ import { createExecutionDataId, useExecutionDataStore } from '@/app/stores/execu
 
 describe('nodeExecuteAfterData', () => {
 	let workflowsStore: ReturnType<typeof useWorkflowsStore>;
-	let stateStore: ReturnType<typeof useWorkflowExecutionStateStore>;
+	let workflowExecutionStateStore: ReturnType<typeof useWorkflowExecutionStateStore>;
 	let executionDataStore: ReturnType<typeof useExecutionDataStore>;
 
 	beforeEach(() => {
@@ -21,7 +21,9 @@ describe('nodeExecuteAfterData', () => {
 		workflowsStore = useWorkflowsStore();
 		workflowsStore.setWorkflowId('test-wf');
 
-		stateStore = useWorkflowExecutionStateStore(createWorkflowExecutionStateId('test-wf'));
+		workflowExecutionStateStore = useWorkflowExecutionStateStore(
+			createWorkflowExecutionStateId('test-wf'),
+		);
 
 		executionDataStore = useExecutionDataStore(createExecutionDataId('exec-1'));
 		executionDataStore.setExecution(
@@ -49,7 +51,7 @@ describe('nodeExecuteAfterData', () => {
 			}),
 		);
 
-		stateStore.setActiveExecutionId('exec-1');
+		workflowExecutionStateStore.setActiveExecutionId('exec-1');
 	});
 
 	it('should update node execution data with incoming payload', async () => {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfterData.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteAfterData.ts
@@ -17,7 +17,7 @@ import {
  */
 export async function nodeExecuteAfterData({ data: pushData }: NodeExecuteAfterData) {
 	const workflowsStore = useWorkflowsStore();
-	const stateStore = useWorkflowExecutionStateStore(
+	const workflowExecutionStateStore = useWorkflowExecutionStateStore(
 		createWorkflowExecutionStateId(workflowsStore.workflowId),
 	);
 	const workflowDocumentStore = computed(() =>
@@ -25,7 +25,7 @@ export async function nodeExecuteAfterData({ data: pushData }: NodeExecuteAfterD
 	);
 	const schemaPreviewStore = useSchemaPreviewStore();
 
-	const activeExecutionId = stateStore.activeExecutionId;
+	const activeExecutionId = workflowExecutionStateStore.activeExecutionId;
 	if (typeof activeExecutionId === 'string') {
 		useExecutionDataStore(createExecutionDataId(activeExecutionId)).updateNodeExecutionRunData(
 			pushData,

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteBefore.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/nodeExecuteBefore.ts
@@ -5,23 +5,19 @@ import {
 	useWorkflowExecutionStateStore,
 } from '@/app/stores/workflowExecutionState.store';
 import { createExecutionDataId, useExecutionDataStore } from '@/app/stores/executionData.store';
-import type { WorkflowState } from '@/app/composables/useWorkflowState';
 
 /**
  * Handles the 'nodeExecuteBefore' event, which happens before a node is executed.
  */
-export async function nodeExecuteBefore(
-	{ data }: NodeExecuteBefore,
-	{ workflowState }: { workflowState: WorkflowState },
-) {
+export async function nodeExecuteBefore({ data }: NodeExecuteBefore) {
 	const workflowsStore = useWorkflowsStore();
-	const stateStore = useWorkflowExecutionStateStore(
+	const workflowExecutionStateStore = useWorkflowExecutionStateStore(
 		createWorkflowExecutionStateId(workflowsStore.workflowId),
 	);
 
-	workflowState.executingNode.addExecutingNode(data.nodeName);
+	workflowExecutionStateStore.addExecutingNode(data.nodeName);
 
-	const activeExecutionId = stateStore.activeExecutionId;
+	const activeExecutionId = workflowExecutionStateStore.activeExecutionId;
 	if (typeof activeExecutionId === 'string') {
 		useExecutionDataStore(createExecutionDataId(activeExecutionId)).addNodeExecutionStartedData(
 			data,

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/testWebhookDeleted.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/testWebhookDeleted.ts
@@ -1,18 +1,21 @@
 import type { TestWebhookDeleted } from '@n8n/api-types/push/webhook';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import type { WorkflowState } from '@/app/composables/useWorkflowState';
+import {
+	createWorkflowExecutionStateId,
+	useWorkflowExecutionStateStore,
+} from '@/app/stores/workflowExecutionState.store';
 
 /**
  * Handles the 'testWebhookDeleted' push message, which is sent when a test webhook is deleted.
  */
-export async function testWebhookDeleted(
-	{ data }: TestWebhookDeleted,
-	options: { workflowState: WorkflowState },
-) {
+export async function testWebhookDeleted({ data }: TestWebhookDeleted) {
 	const workflowsStore = useWorkflowsStore();
 
 	if (data.workflowId === workflowsStore.workflowId) {
-		workflowsStore.setExecutionWaitingForWebhook(false);
-		options.workflowState.setActiveExecutionId(undefined);
+		const workflowExecutionStateStore = useWorkflowExecutionStateStore(
+			createWorkflowExecutionStateId(workflowsStore.workflowId),
+		);
+		workflowExecutionStateStore.setExecutionWaitingForWebhook(false);
+		workflowExecutionStateStore.setActiveExecutionId(undefined);
 	}
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/testWebhookReceived.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/testWebhookReceived.ts
@@ -1,18 +1,21 @@
 import type { TestWebhookReceived } from '@n8n/api-types/push/webhook';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
-import type { WorkflowState } from '@/app/composables/useWorkflowState';
+import {
+	createWorkflowExecutionStateId,
+	useWorkflowExecutionStateStore,
+} from '@/app/stores/workflowExecutionState.store';
 
 /**
  * Handles the 'testWebhookReceived' push message, which is sent when a test webhook is received.
  */
-export async function testWebhookReceived(
-	{ data }: TestWebhookReceived,
-	options: { workflowState: WorkflowState },
-) {
+export async function testWebhookReceived({ data }: TestWebhookReceived) {
 	const workflowsStore = useWorkflowsStore();
 
 	if (data.workflowId === workflowsStore.workflowId) {
-		workflowsStore.setExecutionWaitingForWebhook(false);
-		options.workflowState.setActiveExecutionId(data.executionId ?? null);
+		const workflowExecutionStateStore = useWorkflowExecutionStateStore(
+			createWorkflowExecutionStateId(workflowsStore.workflowId),
+		);
+		workflowExecutionStateStore.setExecutionWaitingForWebhook(false);
+		workflowExecutionStateStore.setActiveExecutionId(data.executionId ?? null);
 	}
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.test.ts
@@ -92,7 +92,7 @@ describe('usePushConnection composable', () => {
 
 		// Verify that the correct handler was called.
 		expect(testWebhookReceived).toHaveBeenCalledTimes(1);
-		expect(testWebhookReceived).toHaveBeenCalledWith(testEvent, expect.any(Object));
+		expect(testWebhookReceived).toHaveBeenCalledWith(testEvent);
 	});
 
 	it('should call removeEventListener when terminate is called', () => {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.ts
@@ -62,9 +62,9 @@ export function usePushConnection({
 	async function processEvent(event: PushMessage) {
 		switch (event.type) {
 			case 'testWebhookDeleted':
-				return await testWebhookDeleted(event, options);
+				return await testWebhookDeleted(event);
 			case 'testWebhookReceived':
-				return await testWebhookReceived(event, options);
+				return await testWebhookReceived(event);
 			case 'reloadNodeType':
 				return await reloadNodeType(event);
 			case 'removeNodeType':
@@ -72,9 +72,9 @@ export function usePushConnection({
 			case 'nodeDescriptionUpdated':
 				return await nodeDescriptionUpdated(event);
 			case 'nodeExecuteBefore':
-				return await nodeExecuteBefore(event, options);
+				return await nodeExecuteBefore(event);
 			case 'nodeExecuteAfter':
-				return await nodeExecuteAfter(event, options);
+				return await nodeExecuteAfter(event);
 			case 'nodeExecuteAfterData':
 				return await nodeExecuteAfterData(event);
 			case 'executionStarted':

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowInitialization.ts
@@ -30,6 +30,11 @@ import {
 	createWorkflowDocumentId,
 	disposeWorkflowDocumentStore,
 } from '@/app/stores/workflowDocument.store';
+import {
+	useWorkflowExecutionStateStore,
+	createWorkflowExecutionStateId,
+	disposeWorkflowExecutionStateStore,
+} from '@/app/stores/workflowExecutionState.store';
 import { useNDVStore, disposeNDVStore } from '@/features/ndv/shared/ndv.store';
 import { WorkflowDocumentStoreKey } from '@/app/constants/injectionKeys';
 import { injectStrict } from '@/app/utils/injectStrict';
@@ -78,7 +83,7 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 
 	const { fetchParentFolder } = useParentFolder();
 
-	function disposeCurrentWorkflowDocumentStore() {
+	function disposeCurrentWorkflowStores() {
 		const ndvStore = currentNDVStore.value;
 		const workflowDocumentStore = currentWorkflowDocumentStore.value;
 
@@ -87,6 +92,14 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 		}
 
 		if (workflowDocumentStore) {
+			// Execution state store is derived from the document store's workflow id
+			// (see injectWorkflowExecutionStateStore); dispose alongside the document
+			// store so per-workflow Pinia state doesn't leak across workflow switches.
+			disposeWorkflowExecutionStateStore(
+				useWorkflowExecutionStateStore(
+					createWorkflowExecutionStateId(workflowDocumentStore.workflowId),
+				),
+			);
 			disposeWorkflowDocumentStore(workflowDocumentStore);
 		}
 
@@ -131,7 +144,7 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 		const templateId = route.params.id;
 		if (!templateId) return false;
 
-		disposeCurrentWorkflowDocumentStore();
+		disposeCurrentWorkflowStores();
 
 		// Load credentials and credential types for template import
 		try {
@@ -257,7 +270,7 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 			);
 		}
 
-		disposeCurrentWorkflowDocumentStore();
+		disposeCurrentWorkflowStores();
 		resetWorkspace();
 
 		if (builderStore.streaming) {
@@ -303,7 +316,7 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 	}
 
 	async function initializeWorkspaceForNewWorkflow() {
-		disposeCurrentWorkflowDocumentStore();
+		disposeCurrentWorkflowStores();
 		resetWorkspace();
 
 		const parentFolderId = route.query.parentFolderId as string | undefined;
@@ -471,7 +484,7 @@ export function useWorkflowInitialization(workflowState: WorkflowState) {
 	}
 
 	function cleanup() {
-		disposeCurrentWorkflowDocumentStore();
+		disposeCurrentWorkflowStores();
 		resetWorkspace();
 		uiStore.nodeViewInitialized = false;
 	}

--- a/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
+++ b/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
@@ -10,7 +10,6 @@ import type { WorkflowState } from '@/app/composables/useWorkflowState';
 import type { useExecutionDataStore } from '@/app/stores/executionData.store';
 import type { WorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import type { CanvasRenderData } from '@/features/workflows/canvas/canvas.utils';
-import type { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
 import type { useNDVStore } from '@/features/ndv/shared/ndv.store';
 
 export const WorkflowIdKey = 'workflowId' as unknown as InjectionKey<ComputedRef<string>>;
@@ -29,9 +28,6 @@ export const WorkflowDocumentStoreKey: InjectionKey<ShallowRef<WorkflowDocumentS
 export const ExecutionDataStoreKey: InjectionKey<
 	ShallowRef<ReturnType<typeof useExecutionDataStore> | null>
 > = Symbol('ExecutionDataStore');
-export const WorkflowExecutionStateStoreKey: InjectionKey<
-	ShallowRef<ReturnType<typeof useWorkflowExecutionStateStore> | null>
-> = Symbol('WorkflowExecutionStateStore');
 export const NDVStoreKey: InjectionKey<ShallowRef<ReturnType<typeof useNDVStore> | null>> =
 	Symbol('NDVStore');
 export const CanvasRenderDataKey: InjectionKey<Ref<CanvasRenderData>> = Symbol('CanvasRenderData');

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.ts
@@ -20,13 +20,13 @@ import {
  */
 export function useWorkflowDocumentRenderData(workflowDocumentId: WorkflowDocumentId) {
 	const workflowDocumentStore = useWorkflowDocumentStore(workflowDocumentId);
-	const executionStateStore = useWorkflowExecutionStateStore(
+	const workflowExecutionStateStore = useWorkflowExecutionStateStore(
 		createWorkflowExecutionStateId(workflowDocumentStore.workflowId),
 	);
 
 	return {
 		nodeInputsByNodeId: workflowDocumentStore.nodeInputsByNodeId,
 		nodeOutputsByNodeId: workflowDocumentStore.nodeOutputsByNodeId,
-		executionIssuesByNodeName: executionStateStore.activeExecutionIssuesByNodeName,
+		executionIssuesByNodeName: workflowExecutionStateStore.activeExecutionIssuesByNodeName,
 	};
 }

--- a/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.test.ts
@@ -16,7 +16,10 @@ import {
 } from '@/app/stores/workflowExecutionState.store';
 import { useExecutionDataStore, createExecutionDataId } from '@/app/stores/executionData.store';
 import { createTestWorkflowExecutionResponse } from '@/__tests__/mocks';
-import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
+import type {
+	IExecutionResponse,
+	IExecutionsStopData,
+} from '@/features/execution/executions/executions.types';
 import type { ExecutionSummary } from 'n8n-workflow';
 import { IN_PROGRESS_EXECUTION_ID } from '@/app/constants/placeholders';
 
@@ -39,6 +42,16 @@ function makeExecutionSummary(overrides: Partial<ExecutionSummary> = {}): Execut
 		startedAt: new Date(),
 		...overrides,
 	} as ExecutionSummary;
+}
+
+function makeStopData(overrides: Partial<IExecutionsStopData> = {}): IExecutionsStopData {
+	return {
+		mode: 'manual',
+		startedAt: new Date('2024-01-01T00:00:00Z'),
+		stoppedAt: new Date('2024-01-01T00:00:05Z'),
+		status: 'canceled',
+		...overrides,
+	};
 }
 
 describe('workflowExecutionState.store', () => {
@@ -490,6 +503,8 @@ describe('workflowExecutionState.store', () => {
 			stateStore.setSelectedTriggerNodeName('Trigger');
 			stateStore.setCurrentWorkflowExecutions([makeExecutionSummary({ id: '1' })]);
 			stateStore.setLastSuccessfulExecutionId('last-1');
+			stateStore.addExecutingNode('NodeA');
+			stateStore.addExecutingNode('NodeB');
 
 			stateStore.resetExecutionState();
 
@@ -504,6 +519,8 @@ describe('workflowExecutionState.store', () => {
 			expect(stateStore.selectedTriggerNodeName).toBeUndefined();
 			expect(stateStore.currentWorkflowExecutions).toEqual([]);
 			expect(stateStore.lastSuccessfulExecutionId).toBeNull();
+			expect(stateStore.executingNode).toEqual([]);
+			expect(stateStore.lastAddedExecutingNode).toBeNull();
 		});
 
 		it('disposes per-execution data stores for every tracked id', () => {
@@ -641,6 +658,217 @@ describe('workflowExecutionState.store', () => {
 			stateStore.setPendingExecution(null);
 
 			expect(spy.mock.calls.some((c) => c[0].action === 'delete')).toBe(true);
+		});
+	});
+
+	describe('loadExecution', () => {
+		it('clears pending and displayed when execution is null', () => {
+			const stateStore = useWorkflowExecutionStateStore(createWorkflowExecutionStateId('wf-1'));
+			stateStore.setPendingExecution(makeExecution({ id: IN_PROGRESS_EXECUTION_ID }));
+			stateStore.setDisplayedExecutionId('exec-prev');
+
+			stateStore.loadExecution(null);
+
+			expect(stateStore.pendingExecution).toBeNull();
+			expect(stateStore.displayedExecutionId).toBeUndefined();
+		});
+
+		it('stages IN_PROGRESS payload as pending scaffold and writes placeholder executionData', () => {
+			const stateStore = useWorkflowExecutionStateStore(createWorkflowExecutionStateId('wf-1'));
+			const scaffold = makeExecution({ id: IN_PROGRESS_EXECUTION_ID });
+
+			stateStore.loadExecution(scaffold);
+
+			expect(stateStore.activeExecutionId).toBeNull();
+			expect(stateStore.pendingExecution?.id).toBe(IN_PROGRESS_EXECUTION_ID);
+			expect(
+				useExecutionDataStore(createExecutionDataId(IN_PROGRESS_EXECUTION_ID)).execution?.id,
+			).toBe(IN_PROGRESS_EXECUTION_ID);
+		});
+
+		it('writes to id-keyed executionData and sets displayedExecutionId when no active id is tracked', () => {
+			const stateStore = useWorkflowExecutionStateStore(createWorkflowExecutionStateId('wf-1'));
+			const execution = makeExecution({ id: 'exec-real' });
+
+			stateStore.loadExecution(execution);
+
+			expect(stateStore.activeExecutionId).toBeUndefined();
+			expect(stateStore.displayedExecutionId).toBe('exec-real');
+			expect(stateStore.pendingExecution).toBeNull();
+			expect(useExecutionDataStore(createExecutionDataId('exec-real')).execution?.id).toBe(
+				'exec-real',
+			);
+		});
+
+		it('only writes executionData when an active execution id is already tracked', () => {
+			const stateStore = useWorkflowExecutionStateStore(createWorkflowExecutionStateId('wf-1'));
+			useExecutionDataStore(createExecutionDataId('active-1')).setExecution(
+				makeExecution({ id: 'active-1' }),
+			);
+			stateStore.setActiveExecutionId('active-1');
+
+			stateStore.loadExecution(makeExecution({ id: 'other', executedNode: 'X' }));
+
+			// activeExecutionId untouched, displayedExecutionId stays at the active id.
+			expect(stateStore.activeExecutionId).toBe('active-1');
+			expect(stateStore.displayedExecutionId).toBe('active-1');
+			// But the new execution's data lands in its own store.
+			expect(useExecutionDataStore(createExecutionDataId('other')).execution?.executedNode).toBe(
+				'X',
+			);
+		});
+	});
+
+	describe('markExecutionAsStopped', () => {
+		it('clears active id, executing-node queue, and webhook flag', () => {
+			const stateStore = useWorkflowExecutionStateStore(createWorkflowExecutionStateId('wf-1'));
+			useExecutionDataStore(createExecutionDataId('exec-1')).setExecution(
+				makeExecution({ id: 'exec-1' }),
+			);
+			stateStore.setActiveExecutionId('exec-1');
+			stateStore.setExecutionWaitingForWebhook(true);
+			stateStore.addExecutingNode('NodeA');
+
+			stateStore.markExecutionAsStopped();
+
+			expect(stateStore.activeExecutionId).toBeUndefined();
+			expect(stateStore.executingNode).toEqual([]);
+			expect(stateStore.executionWaitingForWebhook).toBe(false);
+		});
+
+		it('applies stopData to executionData when active id is a string', () => {
+			const stateStore = useWorkflowExecutionStateStore(createWorkflowExecutionStateId('wf-1'));
+			useExecutionDataStore(createExecutionDataId('exec-1')).setExecution(
+				makeExecution({ id: 'exec-1', status: 'running' }),
+			);
+			stateStore.setActiveExecutionId('exec-1');
+
+			const stopData = makeStopData({ status: 'canceled' });
+			stateStore.markExecutionAsStopped(stopData);
+
+			const dataStore = useExecutionDataStore(createExecutionDataId('exec-1'));
+			expect(dataStore.execution?.status).toBe('canceled');
+			expect(dataStore.execution?.stoppedAt).toEqual(stopData.stoppedAt);
+		});
+
+		it('targets IN_PROGRESS placeholder and mirrors stopData onto pending scaffold when active id is null', () => {
+			const stateStore = useWorkflowExecutionStateStore(createWorkflowExecutionStateId('wf-1'));
+			stateStore.loadExecution(makeExecution({ id: IN_PROGRESS_EXECUTION_ID, status: 'running' }));
+
+			const stopData = makeStopData({ status: 'canceled' });
+			stateStore.markExecutionAsStopped(stopData);
+
+			// Pending scaffold receives the stop metadata.
+			expect(stateStore.pendingExecution?.status).toBe('canceled');
+			expect(stateStore.pendingExecution?.stoppedAt).toEqual(stopData.stoppedAt);
+			// Placeholder executionData store is also stopped.
+			expect(
+				useExecutionDataStore(createExecutionDataId(IN_PROGRESS_EXECUTION_ID)).execution?.status,
+			).toBe('canceled');
+		});
+
+		it('falls back to displayedExecutionId when active id is undefined (stop-race-with-finished)', () => {
+			const stateStore = useWorkflowExecutionStateStore(createWorkflowExecutionStateId('wf-1'));
+			useExecutionDataStore(createExecutionDataId('exec-1')).setExecution(
+				makeExecution({ id: 'exec-1', status: 'running' }),
+			);
+			stateStore.setActiveExecutionId('exec-1');
+			stateStore.setActiveExecutionId(undefined); // displayedExecutionId still 'exec-1'
+
+			stateStore.markExecutionAsStopped(makeStopData({ status: 'canceled' }));
+
+			expect(stateStore.displayedExecutionId).toBe('exec-1');
+			expect(useExecutionDataStore(createExecutionDataId('exec-1')).execution?.status).toBe(
+				'canceled',
+			);
+		});
+
+		it('is a no-op on executionData stores when neither active nor displayed id is set', () => {
+			const stateStore = useWorkflowExecutionStateStore(createWorkflowExecutionStateId('wf-1'));
+			stateStore.addExecutingNode('NodeA');
+
+			expect(() => stateStore.markExecutionAsStopped()).not.toThrow();
+
+			// Side-effect state still clears.
+			expect(stateStore.executingNode).toEqual([]);
+			expect(stateStore.executionWaitingForWebhook).toBe(false);
+		});
+	});
+
+	describe('executingNode queue', () => {
+		it('addExecutingNode pushes name and updates lastAddedExecutingNode', () => {
+			const stateStore = useWorkflowExecutionStateStore(createWorkflowExecutionStateId('wf-1'));
+			stateStore.addExecutingNode('NodeA');
+			stateStore.addExecutingNode('NodeB');
+
+			expect(stateStore.executingNode).toEqual(['NodeA', 'NodeB']);
+			expect(stateStore.lastAddedExecutingNode).toBe('NodeB');
+		});
+
+		it('removeExecutingNode removes a single occurrence', () => {
+			const stateStore = useWorkflowExecutionStateStore(createWorkflowExecutionStateId('wf-1'));
+			stateStore.addExecutingNode('NodeA');
+			stateStore.addExecutingNode('NodeA');
+			stateStore.addExecutingNode('NodeB');
+
+			stateStore.removeExecutingNode('NodeA');
+
+			// One NodeA remains; sub-node parallel runs rely on multi-presence semantics.
+			expect(stateStore.executingNode).toEqual(['NodeA', 'NodeB']);
+		});
+
+		it('removeExecutingNode is a no-op for names not in the queue', () => {
+			const stateStore = useWorkflowExecutionStateStore(createWorkflowExecutionStateId('wf-1'));
+			stateStore.addExecutingNode('NodeA');
+
+			stateStore.removeExecutingNode('NodeX');
+
+			expect(stateStore.executingNode).toEqual(['NodeA']);
+		});
+
+		it('isNodeExecuting reflects queue membership', () => {
+			const stateStore = useWorkflowExecutionStateStore(createWorkflowExecutionStateId('wf-1'));
+			stateStore.addExecutingNode('NodeA');
+
+			expect(stateStore.isNodeExecuting('NodeA')).toBe(true);
+			expect(stateStore.isNodeExecuting('NodeB')).toBe(false);
+		});
+
+		it('clearNodeExecutionQueue empties the queue and clears lastAddedExecutingNode', () => {
+			const stateStore = useWorkflowExecutionStateStore(createWorkflowExecutionStateId('wf-1'));
+			stateStore.addExecutingNode('NodeA');
+			stateStore.addExecutingNode('NodeB');
+
+			stateStore.clearNodeExecutionQueue();
+
+			expect(stateStore.executingNode).toEqual([]);
+			expect(stateStore.lastAddedExecutingNode).toBeNull();
+		});
+
+		it('different workflowIds have isolated queues', () => {
+			const a = useWorkflowExecutionStateStore(createWorkflowExecutionStateId('wf-a'));
+			const b = useWorkflowExecutionStateStore(createWorkflowExecutionStateId('wf-b'));
+
+			a.addExecutingNode('A1');
+			b.addExecutingNode('B1');
+
+			expect(a.executingNode).toEqual(['A1']);
+			expect(b.executingNode).toEqual(['B1']);
+		});
+
+		it('markExecutionAsStopped clears the queue', () => {
+			const stateStore = useWorkflowExecutionStateStore(createWorkflowExecutionStateId('wf-1'));
+			useExecutionDataStore(createExecutionDataId('exec-1')).setExecution(
+				makeExecution({ id: 'exec-1' }),
+			);
+			stateStore.setActiveExecutionId('exec-1');
+			stateStore.addExecutingNode('NodeA');
+			stateStore.addExecutingNode('NodeB');
+
+			stateStore.markExecutionAsStopped();
+
+			expect(stateStore.executingNode).toEqual([]);
+			expect(stateStore.lastAddedExecutingNode).toBeNull();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.ts
@@ -1,11 +1,14 @@
 import { defineStore, getActivePinia } from 'pinia';
 import { STORES } from '@n8n/stores';
-import { computed, inject, readonly, ref, type ComputedRef } from 'vue';
+import { computed, readonly, ref, type ComputedRef, type ShallowRef } from 'vue';
 import { createEventHook } from '@vueuse/core';
 import type { ExecutionSummary } from 'n8n-workflow';
-import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
-import { WorkflowExecutionStateStoreKey } from '@/app/constants/injectionKeys';
+import type {
+	IExecutionResponse,
+	IExecutionsStopData,
+} from '@/features/execution/executions/executions.types';
 import { IN_PROGRESS_EXECUTION_ID } from '@/app/constants/placeholders';
+import { injectWorkflowDocumentStore } from './workflowDocument.store';
 import {
 	createExecutionDataId,
 	disposeExecutionDataStore,
@@ -35,6 +38,7 @@ export type WorkflowExecutionStateField =
 	| 'selectedTriggerNodeName'
 	| 'currentWorkflowExecutions'
 	| 'lastSuccessfulExecutionId'
+	| 'executingNode'
 	| 'state';
 
 export type WorkflowExecutionStateChangeEvent = ChangeEvent<WorkflowExecutionStateChangePayload>;
@@ -88,6 +92,19 @@ export function useWorkflowExecutionStateStore(id: WorkflowExecutionStateId) {
 		const selectedTriggerNodeName = ref<string | undefined>();
 		const currentWorkflowExecutions = ref<ExecutionSummary[]>([]);
 		const lastSuccessfulExecutionId = ref<string | null>(null);
+		/**
+		 * Per-workflow queue of currently executing node names. A node can
+		 * appear multiple times — push handlers add on `nodeExecuteBefore`
+		 * and remove on `nodeExecuteAfter`, and parallel sub-node runs can
+		 * stack the same name. Used by the UI to show running spinners.
+		 */
+		const executingNode = ref<string[]>([]);
+		/**
+		 * Last node name added to the `executingNode` queue. Drives
+		 * spinner animation timing — UI keeps the spinner visible for a
+		 * minimum duration based on this signal.
+		 */
+		const lastAddedExecutingNode = ref<string | null>(null);
 		/**
 		 * Every execution id ever bound to this workflow's state. Used at
 		 * `resetExecutionState` time to dispose all per-execution data stores
@@ -318,6 +335,113 @@ export function useWorkflowExecutionStateStore(id: WorkflowExecutionStateId) {
 			);
 		}
 
+		// --- Executing-node queue ---
+
+		function addExecutingNode(nodeName: string) {
+			executingNode.value.push(nodeName);
+			lastAddedExecutingNode.value = nodeName;
+			fireChange(CHANGE_ACTION.ADD, 'executingNode');
+		}
+
+		function removeExecutingNode(nodeName: string) {
+			const executionIndex = executingNode.value.indexOf(nodeName);
+			if (executionIndex === -1) return;
+			executingNode.value.splice(executionIndex, 1);
+			fireChange(CHANGE_ACTION.DELETE, 'executingNode');
+		}
+
+		function isNodeExecuting(nodeName: string): boolean {
+			return executingNode.value.includes(nodeName);
+		}
+
+		function clearNodeExecutionQueue() {
+			if (executingNode.value.length === 0 && lastAddedExecutingNode.value === null) return;
+			executingNode.value = [];
+			lastAddedExecutingNode.value = null;
+			fireChange(CHANGE_ACTION.DELETE, 'executingNode');
+		}
+
+		// --- Execution lifecycle (cross-store orchestration) ---
+
+		/**
+		 * Routes an execution payload to the correct location based on its id.
+		 *  - `null`                       -> clears pending + displayed
+		 *  - `IN_PROGRESS_EXECUTION_ID`   -> stages as pending scaffold + sets activeExecutionId(null) + writes to placeholder executionData store
+		 *  - real id                      -> writes to the id-keyed executionData store, and (if no active id) sets displayedExecutionId for read fallback
+		 *
+		 * Replaces the legacy `useWorkflowState.setWorkflowExecutionData`.
+		 */
+		function loadExecution(execution: IExecutionResponse | null) {
+			if (execution === null) {
+				setPendingExecution(null);
+				clearDisplayedExecution();
+				return;
+			}
+			if (execution.id === IN_PROGRESS_EXECUTION_ID) {
+				setPendingExecution(execution);
+				setActiveExecutionId(null);
+				useExecutionDataStore(createExecutionDataId(IN_PROGRESS_EXECUTION_ID)).setExecution(
+					execution,
+				);
+				return;
+			}
+			trackExecutionId(execution.id);
+			useExecutionDataStore(createExecutionDataId(execution.id)).setExecution(execution);
+			// When an active execution id is already tracked, the read path resolves
+			// via activeExecutionId — leave pending/displayed alone. Only when there
+			// is no active id do we clear pending and surface this execution as the
+			// displayed fallback so `activeExecution` resolves to it.
+			if (typeof activeExecutionId.value !== 'string') {
+				setPendingExecution(null);
+				setActiveExecutionId(undefined);
+				setDisplayedExecutionId(execution.id);
+			}
+		}
+
+		/**
+		 * Pure state mutation for "execution stopped." Clears active id, the
+		 * executing-node queue, and the webhook-wait flag, then routes the stop
+		 * payload to the appropriate executionData store based on the tri-state
+		 * activeExecutionId. Caller-side side effects (document title, popup
+		 * cleanup) stay with the caller — this method touches only store state.
+		 *
+		 * Replaces the state portion of legacy `useWorkflowState.markExecutionAsStopped`.
+		 */
+		function markExecutionAsStopped(stopData?: IExecutionsStopData) {
+			const previousActiveId = activeExecutionId.value;
+
+			setActiveExecutionId(undefined);
+			clearNodeExecutionQueue();
+			setExecutionWaitingForWebhook(false);
+
+			if (typeof previousActiveId === 'string') {
+				const executionDataStore = useExecutionDataStore(createExecutionDataId(previousActiveId));
+				executionDataStore.clearExecutionStartedData();
+				executionDataStore.markAsStopped(stopData);
+				return;
+			}
+
+			if (previousActiveId === null) {
+				const executionDataStore = useExecutionDataStore(
+					createExecutionDataId(IN_PROGRESS_EXECUTION_ID),
+				);
+				executionDataStore.clearExecutionStartedData();
+				executionDataStore.markAsStopped(stopData);
+				if (stopData) applyStopDataToPendingExecution(stopData);
+				return;
+			}
+
+			// previousActiveId === undefined: stop-race-with-finished case where active
+			// was just cleared but the displayed execution still needs the stop applied.
+			if (typeof displayedExecutionId.value === 'string') {
+				const executionDataStore = useExecutionDataStore(
+					createExecutionDataId(displayedExecutionId.value),
+				);
+				executionDataStore.clearExecutionStartedData();
+				executionDataStore.markAsStopped(stopData);
+			}
+		}
+
 		function setExecutionWaitingForWebhook(value: boolean) {
 			executionWaitingForWebhook.value = value;
 			fireChange(CHANGE_ACTION.UPDATE, 'executionWaitingForWebhook');
@@ -469,6 +593,8 @@ export function useWorkflowExecutionStateStore(id: WorkflowExecutionStateId) {
 			selectedTriggerNodeName.value = undefined;
 			currentWorkflowExecutions.value = [];
 			lastSuccessfulExecutionId.value = null;
+			executingNode.value = [];
+			lastAddedExecutingNode.value = null;
 			fireChange(CHANGE_ACTION.DELETE, 'state');
 		}
 
@@ -486,6 +612,8 @@ export function useWorkflowExecutionStateStore(id: WorkflowExecutionStateId) {
 			selectedTriggerNodeName: readonly(selectedTriggerNodeName),
 			currentWorkflowExecutions: readonly(currentWorkflowExecutions),
 			lastSuccessfulExecutionId: readonly(lastSuccessfulExecutionId),
+			executingNode: readonly(executingNode),
+			lastAddedExecutingNode: readonly(lastAddedExecutingNode),
 			activeExecution,
 			activeExecutionRunData,
 			activeExecutionStartedData,
@@ -498,6 +626,7 @@ export function useWorkflowExecutionStateStore(id: WorkflowExecutionStateId) {
 			getActiveExecutionRunDataByNodeName,
 			activeExecutionIssuesByNodeName,
 			resolveExecutionTriggerNodeName,
+			isNodeExecuting,
 			// Write API
 			trackExecutionId,
 			setActiveExecutionId,
@@ -522,6 +651,11 @@ export function useWorkflowExecutionStateStore(id: WorkflowExecutionStateId) {
 			appendChatMessage,
 			setSelectedTriggerNodeName,
 			renameExecutionStateNode,
+			addExecutingNode,
+			removeExecutingNode,
+			clearNodeExecutionQueue,
+			loadExecution,
+			markExecutionAsStopped,
 			resetExecutionState,
 			// Events
 			onWorkflowExecutionStateChange: onWorkflowExecutionStateChange.on,
@@ -529,13 +663,13 @@ export function useWorkflowExecutionStateStore(id: WorkflowExecutionStateId) {
 	})();
 }
 
+export type WorkflowExecutionStateStore = ReturnType<typeof useWorkflowExecutionStateStore>;
+
 /**
  * Disposes a workflow-execution-state store. Call when navigating between
  * workflows. Mirrors `disposeWorkflowDocumentStore`.
  */
-export function disposeWorkflowExecutionStateStore(
-	store: ReturnType<typeof useWorkflowExecutionStateStore>,
-) {
+export function disposeWorkflowExecutionStateStore(store: WorkflowExecutionStateStore) {
 	const pinia = getActivePinia();
 	store.$dispose();
 
@@ -545,9 +679,17 @@ export function disposeWorkflowExecutionStateStore(
 }
 
 /**
- * Injects the active workflow-execution-state store from the component tree.
- * Returns null when not within a context that has provided the store.
+ * Returns the workflow-execution-state store for the workflow that the current
+ * `WorkflowDocumentStore` injection resolves to. Derives from
+ * `injectWorkflowDocumentStore` (no separate provider) — the two stores are 1:1
+ * by workflow id, so one source of truth for "current workflow" is enough.
+ *
+ * Inherits the document-store injection's fallback chain (legacy
+ * `workflowsStore.workflowId`) transitively.
  */
-export function injectWorkflowExecutionStateStore() {
-	return inject(WorkflowExecutionStateStoreKey, null);
+export function injectWorkflowExecutionStateStore(): ShallowRef<WorkflowExecutionStateStore> {
+	const documentStore = injectWorkflowDocumentStore();
+	return computed(() =>
+		useWorkflowExecutionStateStore(createWorkflowExecutionStateId(documentStore.value.workflowId)),
+	);
 }


### PR DESCRIPTION
## Summary

Wires the per-workflow `workflowExecutionState` Pinia store as the source of truth for execution state in push handlers. Adds `loadExecution`, `markExecutionAsStopped` (pure state mutation), and an `executingNode` queue to the store, and migrates every push handler (`testWebhook{Deleted,Received}`, `nodeExecute{Before,After,AfterData}`, `executionStarted`, `executionRecovered`, `executionFinished`) to read/write it directly instead of routing through the legacy `workflows.store` adapter or the `useWorkflowState` composable. Simplifies `injectWorkflowExecutionStateStore` to derive from `injectWorkflowDocumentStore` (no separate provider) and disposes the per-workflow store alongside the document store in `useWorkflowInitialization`. Tests rewritten to seed via stores and assert on observable state instead of mock-call recording.

**Test:** from `packages/frontend/editor-ui` run `pnpm typecheck && pnpm vitest run src/app/stores src/app/composables` — 1769/1770 pass (1 todo).

## Related Linear tickets, Github issues, and Community forum posts

_Phases 1, 2 and 3a of the editor-ui execution-state migration (in-progress, multi-PR series)._

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI