### PR TITLE
ci: Capture actual task durations under turbo 2.x summary schema

### DIFF
--- a/.github/scripts/send-build-stats.mjs
+++ b/.github/scripts/send-build-stats.mjs
@@ -37,10 +37,16 @@ const summary = JSON.parse(readFileSync(join(runsDir, files.at(-1)), 'utf-8'));
 
 const metrics = [];
 
+// turbo 2.x emits start/end timestamps rather than a `durationMs` field.
+// For cache hits, the execution window measures only restore overhead (~ms),
+// so we use `cache.timeSaved` — the duration of the run we avoided — instead.
+const elapsedMs = ({ startTime, endTime } = {}) =>
+	startTime && endTime ? endTime - startTime : 0;
+
 for (const task of summary.tasks ?? []) {
 	if (task.execution?.exitCode !== 0) continue;
-	const durationMs = task.execution.durationMs ?? 0;
 	const cacheHit = task.cache?.status === 'HIT';
+	const durationMs = cacheHit ? (task.cache.timeSaved ?? 0) : elapsedMs(task.execution);
 	// taskId format: "package-name#task-name"
 	const [pkg, taskName] = task.taskId?.split('#') ?? [task.package, task.task];
 
@@ -53,7 +59,7 @@ for (const task of summary.tasks ?? []) {
 	);
 }
 
-const totalMs = summary.durationMs ?? 0;
+const totalMs = elapsedMs(summary.execution);
 const totalTasks = summary.tasks?.length ?? 0;
 const cachedTasks = summary.tasks?.filter((t) => t.cache?.status === 'HIT').length ?? 0;
 


### PR DESCRIPTION
## Summary

- `.github/scripts/send-build-stats.mjs` was reading `task.execution.durationMs` and `summary.durationMs` — neither exist in turbo 2.x summaries
- Every row written to `qa_performance_metrics` therefore had `value = 0`, silently breaking all duration-based queries against the table
- Fix derives durations from `execution.startTime` / `endTime` for misses, and uses `cache.timeSaved` for hits (the duration of the run that was avoided — more useful than the ~ms cache-restore window)

Linear: https://linear.app/n8n/issue/DEVP-173

## Root cause

Turbo 2.x summary schema (confirmed against an actual `.turbo/runs/*.json` from 2.9.4):

```json
"execution": {
  "startTime": 1779132055452,
  "endTime": 1779132058010,
  "exitCode": 0
}
```

No `durationMs` field. The `?? 0` fallback in the script null-coalesced every row to 0. Counts (hit/miss) survived because they come from `task.cache.status`, but no timing data ever reached BigQuery under this turbo version.

## Bonus capture: `cache.timeSaved`

Cache hits include `cache.timeSaved` — the duration of the task whose execution turbo skipped. Far more useful for analytics than the cache-restore time (typically <5 ms). Now captured as the hit-side duration.

## Smoke test

Patched logic verified locally against a real summary file (build run, 59 tasks):

- 32/32 cache hits → non-zero duration (avg 2.77 s, from `cache.timeSaved`)
- 27/27 cache misses → non-zero duration (avg 4.38 s, from `endTime − startTime`)
- Total run duration: 63.66 s (was 0 before)

## Impact

- Going-forward `qa_performance_metrics` rows have correct durations
- Unblocks timing columns in CI cache dashboard (`avg_miss_s`, `p95_miss_s`, `avg_hit_s`, `total_miss_hours`)
- Required for measuring DEVP-171 (affected-only filter) impact — without this fix, hit/miss rate changes would be visible but the cost-saved signal wouldn't be
- Historical 0-value rows stay 0 (no backfill — turbo summaries aren't archived)

Expect `MAX(value) > 0` for both `hit` and `miss` rows.

## Test plan
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] Merge and watch a CI run land
- [ ] Run the verification query 1 hour after merge — confirm non-zero values
- [ ] Open `qa-ci-cache-hit-dashboard.md` queries in Hex against the fresh data — timing columns should populate

🤖 Generated with [Claude Code](https://claude.com/claude-code)