### PR TITLE
fix(core): Guide agent to not pass bogus workflow-id to submit-workflow tool

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/submit-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/submit-workflow.tool.test.ts
@@ -303,6 +303,20 @@ describe('classifySubmitFailure', () => {
 		expect(remediation.guidance).toContain('Stop editing');
 	});
 
+	it('treats a not-found workflowId as code-fixable so the agent can drop the id', () => {
+		const remediation = classifySubmitFailure(
+			['Workflow save failed: Workflow not found'],
+			'workflow_save_failed',
+		);
+
+		expect(remediation).toMatchObject({
+			category: 'code_fixable',
+			shouldEdit: true,
+			reason: 'workflow_save_failed',
+		});
+		expect(remediation.guidance).toContain('Omit the workflowId');
+	});
+
 	it('routes missing or inaccessible credential save failures to setup', () => {
 		const remediation = classifySubmitFailure(
 			['Workflow save failed: Credential "slackApi" is not accessible'],

--- a/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow.tool.ts
@@ -169,7 +169,12 @@ export const submitWorkflowInputSchema = z.object({
 		.string()
 		.optional()
 		.describe('Path to the TypeScript workflow file (default: ~/workspace/src/workflow.ts)'),
-	workflowId: z.string().optional().describe('Existing workflow ID to update (omit to create new)'),
+	workflowId: z
+		.string()
+		.optional()
+		.describe(
+			'Existing n8n workflow id to update (a 16-character nanoid returned by a previous submit-workflow call or workflows tool). OMIT this argument when creating a new workflow. Do NOT pass the local id from workflow(id, name) in your SDK code — that string is a local handle, not an n8n workflow id.',
+		),
 	projectId: z
 		.string()
 		.optional()
@@ -252,6 +257,16 @@ export function classifySubmitFailure(
 				shouldEdit: true,
 				reason,
 				guidance: 'Fix the workflow code in one batched edit, then call submit-workflow again.',
+			});
+		}
+
+		if (text.includes('workflow not found')) {
+			return createRemediation({
+				category: 'code_fixable',
+				shouldEdit: true,
+				reason,
+				guidance:
+					'The workflowId passed to submit-workflow does not exist. Omit the workflowId argument to create a new workflow, or pass an existing workflow id. Do not reuse the local id from workflow(id, name) in your SDK code — that is a local handle, not an n8n workflow id.',
 			});
 		}
 


### PR DESCRIPTION
## Summary

When the instance-ai builder agent submits a brand-new workflow it sometimes forwarded a fabricated string (e.g. `'wf-chat'`) as the `submit-workflow` tool's `workflowId` argument. The tool took the update branch with that bogus id, the DB threw `Workflow not found`, and `classifySubmitFailure` returned `category: 'blocked' / shouldEdit: false`. After that one failure `terminalRemediationFromState` in the identity wrapper short-circuited every subsequent submit in the same builder task — even submits where the agent had already corrected its code. Recovery only happened when the orchestrator spawned a fresh builder task.

This PR addresses both halves of the loop:

1. **Prevention** — rewrite the `workflowId` schema description so it spells out "16-character nanoid", "OMIT when creating new workflows", and explicitly warns not to pass the local id from `workflow(id, name)`. Across local repros (3 pre-fix failures vs 4 post-fix successes including a controlled ablation), this is the load-bearing change: the agent now consistently keeps the local SDK slug while correctly omitting `workflowId` from the tool call.
2. **Recovery** — extend `classifySubmitFailure` so a `'workflow not found'` save error returns `code_fixable / shouldEdit: true` with guidance to drop the `workflowId` argument. Defense-in-depth: if the agent ever still forwards a bogus id in future, it can self-correct within the same builder task instead of wedging the loop.

### Why the id appears at all

The `workflow(id, name)` SDK signature requires a positional string id. The builder's prompt examples model it as a kebab-slug. The LLM follows the pattern (`workflow('wf-chat', …)`) and then mirrors the same string into the tool's `workflowId` argument. The deeper SDK API smell (first arg has dual meaning — local hash salt for `generateDeterministicNodeId` when creating, real n8n id when round-tripping via `workflows(action="get-as-code")`) is worth a separate ticket; not blocking this fix.

### How to test

- Unit test: `pnpm --filter @n8n/instance-ai test src/tools/workflows/__tests__/submit-workflow.tool.test.ts` — new case `treats a not-found workflowId as code-fixable so the agent can drop the id`.
- End-to-end: in Instance AI, prompt the builder with something that exercises a new workflow (e.g., "build me a chat workflow that saves the conversations to a chat_logs data table. it should use anthropic"). Before the fix this reliably forwarded `'wf-chat'` as `workflowId` and wedged the task; after the fix the agent omits `workflowId`, the create branch runs, and the workflow saves on first attempt.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-277

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI