### PR TITLE
feat(API): Add per-user connection status to credential responses

### DIFF
--- a/packages/@n8n/api-types/src/dto/credentials/credential-connection-status.ts
+++ b/packages/@n8n/api-types/src/dto/credentials/credential-connection-status.ts
@@ -1,0 +1,8 @@
+/**
+ * Per-user connection state surfaced on credential responses. Set on private
+ * (resolvable) credentials only; omitted for static credentials whose
+ * connection is shared across everyone who can read them.
+ */
+export interface CredentialConnectionStatus {
+	connectedByMe?: boolean;
+}

--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -98,6 +98,7 @@ export { UpdateVariableRequestDto } from './variables/update-variable-request.dt
 export { CredentialsGetOneRequestQuery } from './credentials/credentials-get-one-request.dto';
 export { CredentialsGetManyRequestQuery } from './credentials/credentials-get-many-request.dto';
 export { GenerateCredentialNameRequestQuery } from './credentials/generate-credential-name.dto';
+export type { CredentialConnectionStatus } from './credentials/credential-connection-status';
 
 export {
 	MAX_PINNED_DATA_SIZE,

--- a/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
@@ -57,6 +57,7 @@ describe('CredentialsController', () => {
 		mock(), // credentialsHelper
 		mock(), // externalSecretsConfig
 		mock(), // externalSecretsProviderAccessCheckService
+		mock(), // connectionStatusProxy
 	);
 
 	// Spy on methods that need to be mocked in tests

--- a/packages/cli/src/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.service.test.ts
@@ -23,6 +23,7 @@ import { mockExistingCredential } from './credentials.test-data';
 
 import type { CredentialTypes } from '@/credential-types';
 import type { CredentialDependencyService } from '@/credentials/credential-dependency.service';
+import type { CredentialConnectionStatusProxy } from '@/credentials/credential-connection-status-proxy';
 import type { CredentialsFinderService } from '@/credentials/credentials-finder.service';
 import { CredentialsService } from '@/credentials/credentials.service';
 import * as validation from '@/credentials/validation';
@@ -76,6 +77,7 @@ describe('CredentialsService', () => {
 	const credentialsHelper = mock<CredentialsHelper>();
 	const externalSecretsConfig = mock<ExternalSecretsConfig>();
 	const externalSecretsProviderAccessCheckService = mock<SecretsProviderAccessCheckService>();
+	const connectionStatusProxy = mock<CredentialConnectionStatusProxy>();
 
 	const service = new CredentialsService(
 		credentialsRepository,
@@ -95,6 +97,7 @@ describe('CredentialsService', () => {
 		credentialsHelper,
 		externalSecretsConfig,
 		externalSecretsProviderAccessCheckService,
+		connectionStatusProxy,
 	);
 
 	beforeEach(() => {

--- a/packages/cli/src/credentials/credential-connection-status-provider.interface.ts
+++ b/packages/cli/src/credentials/credential-connection-status-provider.interface.ts
@@ -1,0 +1,22 @@
+/**
+ * Interface for per-user credential connection state providers.
+ *
+ * Implementations look up whether the current user has per-user storage
+ * associated with each given credential. Used by the credentials service to
+ * populate the `connectedByMe` field on credential responses and to mirror
+ * `data.oauthTokenData` per user on resolvable credentials.
+ *
+ * Modules register a concrete provider at init time; if no provider is
+ * registered, the {@link CredentialConnectionStatusProxy} degrades to a no-op
+ * (empty set), so read endpoints stay functional even when the
+ * dynamic-credentials feature is disabled.
+ */
+export interface ICredentialConnectionStatusProvider {
+	/**
+	 * Returns the subset of `credentialIds` for which the user has at least
+	 * one per-user storage entry.
+	 *
+	 * Implementations must execute a single bulk query (no N+1).
+	 */
+	findConnectedCredentialIds(userId: string, credentialIds: string[]): Promise<Set<string>>;
+}

--- a/packages/cli/src/credentials/credential-connection-status-proxy.ts
+++ b/packages/cli/src/credentials/credential-connection-status-proxy.ts
@@ -1,0 +1,23 @@
+import { Service } from '@n8n/di';
+
+import type { ICredentialConnectionStatusProvider } from './credential-connection-status-provider.interface';
+
+/**
+ * Proxy between the core credentials service and module-owned per-user
+ * connection state. When no provider is registered (feature disabled or
+ * module not loaded) every lookup degrades to "not connected" so read
+ * endpoints keep working.
+ */
+@Service()
+export class CredentialConnectionStatusProxy implements ICredentialConnectionStatusProvider {
+	private provider?: ICredentialConnectionStatusProvider;
+
+	setProvider(provider: ICredentialConnectionStatusProvider): void {
+		this.provider = provider;
+	}
+
+	async findConnectedCredentialIds(userId: string, credentialIds: string[]): Promise<Set<string>> {
+		if (!this.provider || credentialIds.length === 0) return new Set();
+		return await this.provider.findConnectedCredentialIds(userId, credentialIds);
+	}
+}

--- a/packages/cli/src/credentials/credentials.service.ee.ts
+++ b/packages/cli/src/credentials/credentials.service.ee.ts
@@ -126,16 +126,28 @@ export class EnterpriseCredentialsService {
 
 		const { data: _, ...rest } = credential;
 
+		const enriched: typeof rest & { connectedByMe?: boolean } = rest;
+		await this.credentialsService.populateConnectedByMe([enriched], user);
+
 		if (decryptedData) {
 			// We never want to expose the oauthTokenData to the frontend, but it
 			// expects it to check if the credential is already connected.
-			if (decryptedData?.oauthTokenData) {
+			if (credential.isResolvable) {
+				// For resolvable credentials, the "connected" signal lives in the
+				// per-user storage — mirror that into the existing oauthTokenData
+				// flag the frontend banner already reads.
+				if (enriched.connectedByMe) {
+					decryptedData.oauthTokenData = true;
+				} else {
+					delete decryptedData.oauthTokenData;
+				}
+			} else if (decryptedData?.oauthTokenData) {
 				decryptedData.oauthTokenData = true;
 			}
-			return { data: decryptedData, ...rest };
+			return { data: decryptedData, ...enriched };
 		}
 
-		return { ...rest };
+		return { ...enriched };
 	}
 
 	async transferOne(user: User, credentialId: string, destinationProjectId: string) {

--- a/packages/cli/src/credentials/credentials.service.ts
+++ b/packages/cli/src/credentials/credentials.service.ts
@@ -58,6 +58,7 @@ import { OwnershipService } from '@/services/ownership.service';
 import { ProjectService } from '@/services/project.service.ee';
 import { RoleService } from '@/services/role.service';
 
+import { CredentialConnectionStatusProxy } from './credential-connection-status-proxy';
 import {
 	CredentialDependencyService,
 	type CredentialDependencyFilter,
@@ -109,7 +110,33 @@ export class CredentialsService {
 		private readonly credentialsHelper: CredentialsHelper,
 		private readonly externalSecretsConfig: ExternalSecretsConfig,
 		private readonly externalSecretsProviderAccessCheckService: SecretsProviderAccessCheckService,
+		private readonly connectionStatusProxy: CredentialConnectionStatusProxy,
 	) {}
+
+	/**
+	 * Sets `connectedByMe` on every resolvable credential in `credentials`,
+	 * using a single bulk lookup against the per-user storage. Static
+	 * (non-resolvable) credentials are left untouched.
+	 *
+	 * Mutates in place; callers may pass entities, decrypted DTOs, or plain
+	 * object literals — any shape that carries `id` and `isResolvable`.
+	 */
+	async populateConnectedByMe<T extends { id: string; isResolvable?: boolean }>(
+		credentials: T[],
+		user: User,
+	): Promise<void> {
+		const resolvable = credentials.filter((c) => c.isResolvable === true);
+		if (resolvable.length === 0) return;
+
+		const connected = await this.connectionStatusProxy.findConnectedCredentialIds(
+			user.id,
+			resolvable.map((c) => c.id),
+		);
+
+		for (const c of resolvable) {
+			(c as T & { connectedByMe?: boolean }).connectedByMe = connected.has(c.id);
+		}
+	}
 
 	private async addGlobalCredentials(
 		credentials: CredentialsEntity[],
@@ -446,9 +473,12 @@ export class CredentialsService {
 		}
 
 		if (includeData) {
-			return await this.addDecryptedDataToCredentials(credentials);
+			const decrypted = await this.addDecryptedDataToCredentials(credentials);
+			await this.populateConnectedByMe(decrypted, user);
+			return decrypted;
 		}
 
+		await this.populateConnectedByMe(credentials, user);
 		return credentials;
 	}
 
@@ -537,7 +567,16 @@ export class CredentialsService {
 			(c) => allCredentialsForWorkflow.includes(c.id) || c.isGlobal,
 		);
 
-		return intersection
+		const result: Array<{
+			id: string;
+			name: string;
+			type: string;
+			scopes: Scope[];
+			isManaged: boolean;
+			isGlobal: boolean;
+			isResolvable: boolean;
+			connectedByMe?: boolean;
+		}> = intersection
 			.map((c) => this.roleService.addScopes(c, user, projectRelations))
 			.map((c) => ({
 				id: c.id,
@@ -548,6 +587,9 @@ export class CredentialsService {
 				isGlobal: c.isGlobal,
 				isResolvable: c.isResolvable,
 			}));
+
+		await this.populateConnectedByMe(result, user);
+		return result;
 	}
 
 	async findAllGlobalCredentialIds(includeData: boolean = false): Promise<CredentialsEntity[]> {
@@ -1110,15 +1152,27 @@ export class CredentialsService {
 
 		const { data: _, ...rest } = credential;
 
+		const enriched: typeof rest & { connectedByMe?: boolean } = rest;
+		await this.populateConnectedByMe([enriched], user);
+
 		if (decryptedData) {
 			// We never want to expose the oauthTokenData to the frontend, but it
 			// expects it to check if the credential is already connected.
-			if (decryptedData?.oauthTokenData) {
+			if (credential.isResolvable) {
+				// For resolvable credentials, the "connected" signal lives in the
+				// per-user storage — mirror that into the existing oauthTokenData
+				// flag the frontend banner already reads.
+				if (enriched.connectedByMe) {
+					decryptedData.oauthTokenData = true;
+				} else {
+					delete decryptedData.oauthTokenData;
+				}
+			} else if (decryptedData?.oauthTokenData) {
 				decryptedData.oauthTokenData = true;
 			}
-			return { data: decryptedData, ...rest };
+			return { data: decryptedData, ...enriched };
 		}
-		return { ...rest };
+		return { ...enriched };
 	}
 
 	async getCredentialScopes(user: User, credentialId: string): Promise<Scope[]> {

--- a/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.module.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.module.ts
@@ -22,6 +22,7 @@ export class DynamicCredentialsModule implements ModuleInterface {
 			DynamicCredentialStorageService,
 			DynamicCredentialService,
 			N8nResolverSeeder,
+			CredentialConnectionStatusService,
 		} = await import('./services');
 		await import('./workflow-status.controller');
 
@@ -35,6 +36,15 @@ export class DynamicCredentialsModule implements ModuleInterface {
 		const dynamicCredentialStorageService = Container.get(DynamicCredentialStorageService);
 		credentialsProxy.setResolverProvider(dynamicCredentialService);
 		credentialsProxy.setStorageProvider(dynamicCredentialStorageService);
+
+		// Register the per-user connection status provider so the credentials
+		// service can populate `connectedByMe` on responses.
+		const { CredentialConnectionStatusProxy } = await import(
+			'../../credentials/credential-connection-status-proxy'
+		);
+		Container.get(CredentialConnectionStatusProxy).setProvider(
+			Container.get(CredentialConnectionStatusService),
+		);
 	}
 
 	async entities() {

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/credential-connection-status.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/credential-connection-status.service.ts
@@ -1,0 +1,39 @@
+import { Service } from '@n8n/di';
+import { In } from '@n8n/db';
+
+import type { ICredentialConnectionStatusProvider } from '@/credentials/credential-connection-status-provider.interface';
+
+import { SYSTEM_RESOLVER_ID } from '../constants';
+import { DynamicCredentialUserEntryRepository } from '../database/repositories/dynamic-credential-user-entry.repository';
+
+/**
+ * Returns the set of credential ids for which a given user has a per-user
+ * storage entry under the system resolver. Existence is the signal — no
+ * decryption is performed.
+ *
+ * Scoped to the system resolver ({@link SYSTEM_RESOLVER_ID}) because that is
+ * the only resolver used to record per-user OAuth connections today. Entries
+ * from other resolvers do not count as a user-visible "connection".
+ *
+ * Backs {@link CredentialConnectionStatusProxy} which exposes the data to the
+ * core credentials service.
+ */
+@Service()
+export class CredentialConnectionStatusService implements ICredentialConnectionStatusProvider {
+	constructor(private readonly repository: DynamicCredentialUserEntryRepository) {}
+
+	async findConnectedCredentialIds(userId: string, credentialIds: string[]): Promise<Set<string>> {
+		if (credentialIds.length === 0) return new Set();
+
+		const rows = await this.repository.find({
+			select: ['credentialId'],
+			where: {
+				userId,
+				resolverId: SYSTEM_RESOLVER_ID,
+				credentialId: In(credentialIds),
+			},
+		});
+
+		return new Set(rows.map((row) => row.credentialId));
+	}
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/index.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/index.ts
@@ -5,3 +5,4 @@ export * from './dynamic-credential-storage.service';
 export * from './credential-resolver-workflow.service';
 export * from './credential-check-proxy.service';
 export * from './n8n-resolver-seeder.service';
+export * from './credential-connection-status.service';

--- a/packages/cli/src/public-api/v1/handlers/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/__tests__/credentials.service.test.ts
@@ -438,6 +438,7 @@ describe('CredentialsService', () => {
 			mock(), // credentialsHelper
 			mock(), // externalSecretsConfig
 			mock(), // externalSecretsProviderAccessCheckService
+			mock(), // connectionStatusProxy
 		);
 
 		jest.spyOn(credentialsService, 'decrypt');

--- a/packages/cli/test/integration/credentials/credentials.connected-by-me.api.test.ts
+++ b/packages/cli/test/integration/credentials/credentials.connected-by-me.api.test.ts
@@ -1,0 +1,269 @@
+import {
+	createTeamProject,
+	linkUserToProject,
+	mockInstance,
+	randomCredentialPayload,
+	randomCredentialPayloadWithOauthTokenData,
+	testDb,
+} from '@n8n/backend-test-utils';
+import type { Project, User } from '@n8n/db';
+import { Container } from '@n8n/di';
+
+import {
+	SYSTEM_RESOLVER_ID,
+	SYSTEM_RESOLVER_NAME,
+	SYSTEM_RESOLVER_TYPE,
+} from '@/modules/dynamic-credentials.ee/constants';
+import { DynamicCredentialUserEntryStorage } from '@/modules/dynamic-credentials.ee/credential-resolvers/storage/dynamic-credential-user-entry-storage';
+import { DynamicCredentialResolverRepository } from '@/modules/dynamic-credentials.ee/database/repositories/credential-resolver.repository';
+import { DynamicCredentialUserEntryRepository } from '@/modules/dynamic-credentials.ee/database/repositories/dynamic-credential-user-entry.repository';
+import { DynamicCredentialsConfig } from '@/modules/dynamic-credentials.ee/dynamic-credentials.config';
+import { Telemetry } from '@/telemetry';
+import { saveCredential } from '../shared/db/credentials';
+import { createMember } from '../shared/db/users';
+import { setupTestServer } from '../shared/utils';
+
+mockInstance(Telemetry);
+
+process.env.N8N_ENV_FEAT_DYNAMIC_CREDENTIALS = 'true';
+
+mockInstance(DynamicCredentialsConfig, {
+	endpointAuthToken: 'static-test-token',
+	corsOrigin: 'https://app.example.com',
+	corsAllowCredentials: false,
+});
+
+const testServer = setupTestServer({
+	endpointGroups: ['credentials'],
+	enabledFeatures: ['feat:sharing', 'feat:dynamicCredentials'],
+	modules: ['dynamic-credentials'],
+});
+
+let memberA: User;
+let memberB: User;
+let teamProject: Project;
+let storage: DynamicCredentialUserEntryStorage;
+
+beforeEach(async () => {
+	await testDb.truncate([
+		'DynamicCredentialUserEntry',
+		'DynamicCredentialResolver',
+		'SharedCredentials',
+		'CredentialsEntity',
+	]);
+
+	memberA = await createMember();
+	memberB = await createMember();
+
+	teamProject = await createTeamProject(undefined, memberA);
+	await linkUserToProject(memberB, teamProject, 'project:editor');
+
+	storage = Container.get(DynamicCredentialUserEntryStorage);
+
+	// Seed the system resolver — the connection-status lookup is scoped to it
+	// (see CredentialConnectionStatusService).
+	const resolverRepository = Container.get(DynamicCredentialResolverRepository);
+	await resolverRepository.save(
+		resolverRepository.create({
+			id: SYSTEM_RESOLVER_ID,
+			name: SYSTEM_RESOLVER_NAME,
+			type: SYSTEM_RESOLVER_TYPE,
+			config: '{}',
+		}),
+	);
+});
+
+const seedUserEntry = async (credentialId: string, userId: string) => {
+	await storage.setCredentialData(
+		credentialId,
+		userId,
+		SYSTEM_RESOLVER_ID,
+		'encrypted-payload',
+		{},
+	);
+};
+
+const saveResolvableCredential = async () =>
+	await saveCredential(randomCredentialPayload({ isResolvable: true }), {
+		project: teamProject,
+		role: 'credential:owner',
+	});
+
+const saveStaticCredential = async () =>
+	await saveCredential(randomCredentialPayload(), {
+		project: teamProject,
+		role: 'credential:owner',
+	});
+
+const saveStaticCredentialWithOauthTokenData = async () =>
+	await saveCredential(randomCredentialPayloadWithOauthTokenData(), {
+		project: teamProject,
+		role: 'credential:owner',
+	});
+
+type CredentialResponseFields = {
+	id: string;
+	isResolvable?: boolean;
+	connectedByMe?: boolean;
+	data?: { oauthTokenData?: unknown };
+};
+
+describe('GET /credentials — connectedByMe', () => {
+	test('returns connectedByMe=true for resolvable credential when user has a per-user entry', async () => {
+		const resolvable = await saveResolvableCredential();
+		await seedUserEntry(resolvable.id, memberA.id);
+
+		const response = await testServer.authAgentFor(memberA).get('/credentials').expect(200);
+
+		const cred = (response.body.data as CredentialResponseFields[]).find(
+			(c) => c.id === resolvable.id,
+		);
+		expect(cred).toBeDefined();
+		expect(cred?.connectedByMe).toBe(true);
+	});
+
+	test('returns connectedByMe=false for resolvable credential when user has no entry', async () => {
+		const resolvable = await saveResolvableCredential();
+		await seedUserEntry(resolvable.id, memberA.id);
+
+		const response = await testServer.authAgentFor(memberB).get('/credentials').expect(200);
+
+		const cred = (response.body.data as CredentialResponseFields[]).find(
+			(c) => c.id === resolvable.id,
+		);
+		expect(cred).toBeDefined();
+		expect(cred?.connectedByMe).toBe(false);
+	});
+
+	test('omits connectedByMe for static credentials', async () => {
+		const staticCred = await saveStaticCredential();
+
+		const response = await testServer.authAgentFor(memberA).get('/credentials').expect(200);
+
+		const cred = (response.body.data as CredentialResponseFields[]).find(
+			(c) => c.id === staticCred.id,
+		);
+		expect(cred).toBeDefined();
+		expect('connectedByMe' in (cred ?? {})).toBe(false);
+	});
+
+	test('uses a single bulk query for the connection lookup', async () => {
+		const [r1, _r2, r3] = await Promise.all([
+			saveResolvableCredential(),
+			saveResolvableCredential(),
+			saveResolvableCredential(),
+		]);
+		await seedUserEntry(r1.id, memberA.id);
+		await seedUserEntry(r3.id, memberA.id);
+
+		const repository = Container.get(DynamicCredentialUserEntryRepository);
+		const findSpy = jest.spyOn(repository, 'find');
+
+		try {
+			await testServer.authAgentFor(memberA).get('/credentials').expect(200);
+
+			expect(findSpy).toHaveBeenCalledTimes(1);
+			const firstCall = findSpy.mock.calls[0]?.[0];
+			expect(firstCall).toBeDefined();
+			const where = (firstCall as { where: { userId: string; credentialId: unknown } }).where;
+			expect(where.userId).toBe(memberA.id);
+			expect(where.credentialId).toBeDefined();
+		} finally {
+			findSpy.mockRestore();
+		}
+	});
+});
+
+describe('GET /credentials/for-workflow — connectedByMe', () => {
+	test('returns connectedByMe per user for the same resolvable credential', async () => {
+		const resolvable = await saveResolvableCredential();
+		await seedUserEntry(resolvable.id, memberA.id);
+
+		const responseA = await testServer
+			.authAgentFor(memberA)
+			.get('/credentials/for-workflow')
+			.query({ projectId: teamProject.id })
+			.expect(200);
+		const responseB = await testServer
+			.authAgentFor(memberB)
+			.get('/credentials/for-workflow')
+			.query({ projectId: teamProject.id })
+			.expect(200);
+
+		const credA = (responseA.body.data as CredentialResponseFields[]).find(
+			(c) => c.id === resolvable.id,
+		);
+		const credB = (responseB.body.data as CredentialResponseFields[]).find(
+			(c) => c.id === resolvable.id,
+		);
+
+		expect(credA?.connectedByMe).toBe(true);
+		expect(credB?.connectedByMe).toBe(false);
+	});
+
+	test('omits connectedByMe for static credentials in for-workflow response', async () => {
+		const staticCred = await saveStaticCredential();
+
+		const response = await testServer
+			.authAgentFor(memberA)
+			.get('/credentials/for-workflow')
+			.query({ projectId: teamProject.id })
+			.expect(200);
+
+		const cred = (response.body.data as CredentialResponseFields[]).find(
+			(c) => c.id === staticCred.id,
+		);
+		expect(cred).toBeDefined();
+		expect('connectedByMe' in (cred ?? {})).toBe(false);
+	});
+});
+
+describe('GET /credentials/:id — per-user oauthTokenData', () => {
+	test('reflects per-user storage for resolvable credentials (A connected, B not)', async () => {
+		const resolvable = await saveResolvableCredential();
+		await seedUserEntry(resolvable.id, memberA.id);
+
+		const responseA = await testServer
+			.authAgentFor(memberA)
+			.get(`/credentials/${resolvable.id}`)
+			.query({ includeData: true })
+			.expect(200);
+		const responseB = await testServer
+			.authAgentFor(memberB)
+			.get(`/credentials/${resolvable.id}`)
+			.query({ includeData: true })
+			.expect(200);
+
+		const bodyA = responseA.body.data as CredentialResponseFields;
+		const bodyB = responseB.body.data as CredentialResponseFields;
+
+		expect(bodyA.connectedByMe).toBe(true);
+		expect(bodyA.data?.oauthTokenData).toBe(true);
+
+		expect(bodyB.connectedByMe).toBe(false);
+		expect(bodyB.data?.oauthTokenData).toBeUndefined();
+	});
+
+	test('preserves static oauthTokenData behavior (shared across all readers)', async () => {
+		const staticCred = await saveStaticCredentialWithOauthTokenData();
+
+		const responseA = await testServer
+			.authAgentFor(memberA)
+			.get(`/credentials/${staticCred.id}`)
+			.query({ includeData: true })
+			.expect(200);
+		const responseB = await testServer
+			.authAgentFor(memberB)
+			.get(`/credentials/${staticCred.id}`)
+			.query({ includeData: true })
+			.expect(200);
+
+		const bodyA = responseA.body.data as CredentialResponseFields;
+		const bodyB = responseB.body.data as CredentialResponseFields;
+
+		expect(bodyA.data?.oauthTokenData).toBe(true);
+		expect(bodyB.data?.oauthTokenData).toBe(true);
+		expect('connectedByMe' in bodyA).toBe(false);
+		expect('connectedByMe' in bodyB).toBe(false);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/credentials/credentials.types.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/credentials.types.ts
@@ -16,6 +16,8 @@ export interface ICredentialsResponse extends ICredentialsEncrypted {
 	isManaged: boolean;
 	isGlobal?: boolean;
 	isResolvable?: boolean;
+	/** Whether the current user has personally connected this credential. Set on resolvable credentials only. */
+	connectedByMe?: boolean;
 }
 
 export interface IUsedCredential {
@@ -35,6 +37,8 @@ export interface ICredentialsBase {
 export interface ICredentialsDecryptedResponse extends ICredentialsBase, ICredentialsDecrypted {
 	id: string;
 	isResolvable?: boolean;
+	/** Whether the current user has personally connected this credential. Set on resolvable credentials only. */
+	connectedByMe?: boolean;
 }
 
 export interface ICredentialTypeMap {


### PR DESCRIPTION
## Summary

Adds a `connectedByMe?: boolean` field to credential responses on the three read endpoints (`GET /credentials`, `GET /credentials/for-workflow`, `GET /credentials/:id`) so the UI can tell whether the *current user* has personally connected each private (resolvable) credential. For private credentials, `data.oauthTokenData` — the signal the existing "Account connected" banner already reads — now reflects per-user storage instead of the shared static blob.

This is the foundational piece for the "Private Credentials – Manual Trigger MVP" milestone. The frontend tickets that consume the field (NDV badges, callouts, "Not connected yet" list states, edit-modal banner, user disconnect flow) all build on top of this.

### How to test manually

1. Run a local n8n with the dynamic-credentials feature on:
   ```
   N8N_ENV_FEAT_DYNAMIC_CREDENTIALS=true pnpm dev
   ```
2. As the instance owner, create a private (resolvable) OAuth credential and a regular (static) OAuth credential, then share them with a team project containing two members (A and B).
3. As member A, complete the OAuth flow against the private credential — this writes a per-user `DynamicCredentialUserEntry` row.
4. Hit each endpoint as member A and as member B; verify the response shape:

   | Endpoint | Member A | Member B |
   |---|---|---|
   | `GET /credentials` | private cred: `connectedByMe: true`; static cred: field absent | private cred: `connectedByMe: false`; static cred: field absent |
   | `GET /credentials/for-workflow?projectId=<team>` | same as list | same as list |
   | `GET /credentials/:id?includeData=true` (private) | `data.oauthTokenData === true`, `connectedByMe: true` | `data.oauthTokenData` absent, `connectedByMe: false` |
   | `GET /credentials/:id?includeData=true` (static with OAuth token) | `data.oauthTokenData === true`, no `connectedByMe` | `data.oauthTokenData === true`, no `connectedByMe` |

5. In the editor, opening the private credential in the modal as member B should show the "Not connected" banner state even though member A is connected.
6. Disable the feature flag and restart — resolvable credentials should still return `connectedByMe: false` (proxy degrades to no-op); static behavior is identical to today.

### Key implementation decisions

- **Module isolation preserved via the proxy + provider pattern.** `packages/cli/src/credentials/` defines a `CredentialConnectionStatusProxy` plus `ICredentialConnectionStatusProvider` interface. The `dynamic-credentials.ee` module registers a concrete `CredentialConnectionStatusService` in its `init()`. This mirrors the existing `DynamicCredentialsProxy` / `DynamicCredentialService` pair — the core credentials service never imports module internals.
- **Existence-only signal, no decryption on the read path.** "Connected" is defined as the existence of a `DynamicCredentialUserEntry` row for `(userId, credentialId)` under the system resolver. One bulk `IN(...)` query per request (verified by spy in the test suite) covers any list size with no N+1 risk.
- **Scoped to the system resolver (`SYSTEM_RESOLVER_ID = 'system-n8n'`).** Per-user entries from any other resolver do not count as a user-visible connection, since the system resolver is the only one writing per-user OAuth state today.
- **`data.oauthTokenData` override stays opt-in.** Static credentials keep the existing shared-blob behavior verbatim. Only `isResolvable: true` credentials get the per-user mirror — set when `connectedByMe`, deleted otherwise.
- **Module-not-loaded fallback is `connectedByMe: false`, never throw.** Read endpoints must work even when the feature flag is off — the proxy returns an empty `Set` and the UI sees a consistent, deterministic shape.

### Related Links

closes https://linear.app/n8n/issue/IAM-662

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
