### PR TITLE
feat(editor): Add message actions to Agent chat messages (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatMessageList.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentChatMessageList.test.ts
@@ -1,0 +1,134 @@
+import { flushPromises, mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import AgentChatMessageList from '../components/AgentChatMessageList.vue';
+import type { ChatMessage } from '../composables/agentChatMessages';
+
+const copySpy = vi.fn();
+
+vi.mock('@n8n/design-system', () => ({
+	N8nIcon: { template: '<i />' },
+	N8nIconButton: {
+		template:
+			'<button :data-test-id="$attrs[\'data-test-id\']" @click="$emit(\'click\')">{{ icon }}</button>',
+		props: ['icon'],
+		emits: ['click'],
+	},
+	N8nTooltip: { template: '<div><slot /><slot name="content" /></div>' },
+}));
+
+vi.mock('@/features/ai/chatHub/components/ChatMarkdownChunk.vue', () => ({
+	default: { template: '<div>{{ source.content }}</div>', props: ['source'] },
+}));
+
+vi.mock('@/features/ai/chatHub/components/ChatTypingIndicator.vue', () => ({
+	default: { template: '<div data-test-id="typing-indicator" />' },
+}));
+
+vi.mock('@/features/agents/components/AgentChatToolSteps.vue', () => ({
+	default: { template: '<div />', props: ['toolCalls'] },
+}));
+
+vi.mock('@/features/agents/components/interactive/InteractiveCard.vue', () => ({
+	default: { template: '<div />', props: ['payload', 'projectId', 'agentId'] },
+}));
+
+vi.mock('@/features/ai/chatHub/components/CopyButton.vue', () => ({
+	default: {
+		template:
+			'<button data-test-id="agent-chat-message-copy" @click="copySpy(content)">copy</button>',
+		props: ['content'],
+		setup() {
+			return { copySpy };
+		},
+	},
+}));
+
+vi.mock('@n8n/i18n', () => ({
+	useI18n: () => ({ baseText: (key: string) => key }),
+}));
+
+describe('AgentChatMessageList', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('shows copy and read-aloud actions for assistant text messages', async () => {
+		const speakSpy = vi.spyOn(window.speechSynthesis, 'speak');
+		const cancelSpy = vi.spyOn(window.speechSynthesis, 'cancel');
+
+		const wrapper = mount(AgentChatMessageList, {
+			props: {
+				messages: [
+					{
+						id: 'assistant-1',
+						role: 'assistant',
+						content: 'Agent reply',
+						status: 'success',
+					} satisfies ChatMessage,
+				],
+				messagingState: 'idle',
+			},
+		});
+
+		expect(wrapper.find('[data-test-id="agent-chat-message-actions"]').exists()).toBe(true);
+		expect(wrapper.find('[data-test-id="agent-chat-message-copy"]').exists()).toBe(true);
+		expect(wrapper.find('[data-test-id="agent-chat-message-read-aloud"]').exists()).toBe(true);
+
+		await wrapper.find('[data-test-id="agent-chat-message-read-aloud"]').trigger('click');
+		expect(cancelSpy).toHaveBeenCalled();
+		expect(speakSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it('does not render actions for user text messages', () => {
+		const wrapper = mount(AgentChatMessageList, {
+			props: {
+				messages: [
+					{
+						id: 'user-1',
+						role: 'user',
+						content: 'User prompt',
+						status: 'success',
+					} satisfies ChatMessage,
+				],
+				messagingState: 'idle',
+			},
+		});
+
+		expect(wrapper.find('[data-test-id="agent-chat-message-actions"]').exists()).toBe(false);
+		expect(wrapper.find('[data-test-id="agent-chat-message-read-aloud"]').exists()).toBe(false);
+	});
+
+	it('shows a single action row for consecutive assistant messages and copies the whole run', async () => {
+		const wrapper = mount(AgentChatMessageList, {
+			props: {
+				messages: [
+					{
+						id: 'assistant-1',
+						role: 'assistant',
+						content: 'First reply',
+						status: 'success',
+					} satisfies ChatMessage,
+					{
+						id: 'assistant-2',
+						role: 'assistant',
+						content: 'Second reply',
+						status: 'success',
+					} satisfies ChatMessage,
+					{
+						id: 'user-1',
+						role: 'user',
+						content: 'Next prompt',
+						status: 'success',
+					} satisfies ChatMessage,
+				],
+				messagingState: 'idle',
+			},
+		});
+
+		expect(wrapper.findAll('[data-test-id="agent-chat-message-actions"]')).toHaveLength(1);
+
+		await wrapper.find('[data-test-id="agent-chat-message-copy"]').trigger('click');
+		await flushPromises();
+		expect(copySpy).toHaveBeenCalledWith('First reply\n\nSecond reply');
+	});
+});

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChatMessageActions.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChatMessageActions.vue
@@ -5,7 +5,6 @@ import { useI18n } from '@n8n/i18n';
 
 defineProps<{
 	content: string;
-	canReadAloud: boolean;
 	isSpeechSynthesisAvailable: boolean;
 	isSpeaking: boolean;
 }>();
@@ -20,11 +19,7 @@ const i18n = useI18n();
 <template>
 	<div :class="$style.actions" data-test-id="agent-chat-message-actions">
 		<CopyButton :content="content" data-test-id="agent-chat-message-copy" />
-		<N8nTooltip
-			v-if="canReadAloud && isSpeechSynthesisAvailable"
-			placement="bottom"
-			:show-after="300"
-		>
+		<N8nTooltip v-if="isSpeechSynthesisAvailable" placement="bottom" :show-after="300">
 			<N8nIconButton
 				variant="ghost"
 				:icon="isSpeaking ? 'volume-x' : 'volume-2'"

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChatMessageActions.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChatMessageActions.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import CopyButton from '@/features/ai/chatHub/components/CopyButton.vue';
+import { N8nIconButton, N8nTooltip } from '@n8n/design-system';
+import { useI18n } from '@n8n/i18n';
+
+defineProps<{
+	content: string;
+	canReadAloud: boolean;
+	isSpeechSynthesisAvailable: boolean;
+	isSpeaking: boolean;
+}>();
+
+const emit = defineEmits<{
+	readAloud: [];
+}>();
+
+const i18n = useI18n();
+</script>
+
+<template>
+	<div :class="$style.actions" data-test-id="agent-chat-message-actions">
+		<CopyButton :content="content" data-test-id="agent-chat-message-copy" />
+		<N8nTooltip
+			v-if="canReadAloud && isSpeechSynthesisAvailable"
+			placement="bottom"
+			:show-after="300"
+		>
+			<N8nIconButton
+				variant="ghost"
+				:icon="isSpeaking ? 'volume-x' : 'volume-2'"
+				size="small"
+				icon-size="medium"
+				data-test-id="agent-chat-message-read-aloud"
+				@click="emit('readAloud')"
+			/>
+			<template #content>
+				{{
+					isSpeaking
+						? i18n.baseText('chatHub.message.actions.stopReading')
+						: i18n.baseText('chatHub.message.actions.readAloud')
+				}}
+			</template>
+		</N8nTooltip>
+	</div>
+</template>
+
+<style lang="scss" module>
+.actions {
+	display: flex;
+	align-items: center;
+	margin-top: var(--spacing--4xs);
+	margin-left: calc(var(--spacing--4xs) * -1);
+
+	& g,
+	& path {
+		color: var(--color--text--tint-1);
+		stroke-width: 2.5;
+	}
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChatMessageList.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChatMessageList.vue
@@ -255,7 +255,6 @@ onBeforeUnmount(() => {
 					<div v-if="shouldShowAssistantActions(group.id)" :class="$style.messageActions">
 						<AgentChatMessageActions
 							:content="getAssistantRunContent(group.id)"
-							:can-read-aloud="true"
 							:is-speech-synthesis-available="isSpeechSynthesisAvailable"
 							:is-speaking="isSpeakingMessage(group.id)"
 							@read-aloud="toggleReadAloud(group.id)"
@@ -311,7 +310,6 @@ onBeforeUnmount(() => {
 					<div v-if="shouldShowAssistantActions(group.id)" :class="$style.messageActions">
 						<AgentChatMessageActions
 							:content="getAssistantRunContent(group.id)"
-							:can-read-aloud="true"
 							:is-speech-synthesis-available="isSpeechSynthesisAvailable"
 							:is-speaking="isSpeakingMessage(group.id)"
 							@read-aloud="toggleReadAloud(group.id)"

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChatMessageList.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChatMessageList.vue
@@ -197,7 +197,7 @@ watch(
 watch(
 	() => speech.status.value,
 	(status) => {
-		if (status === 'end' || status === 'error') {
+		if (status === 'end') {
 			spokenMessageId.value = null;
 		}
 	},

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChatMessageList.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChatMessageList.vue
@@ -1,16 +1,19 @@
 <script setup lang="ts">
-import { computed, nextTick, onMounted, ref, useTemplateRef, watch } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useTemplateRef, watch } from 'vue';
 import { N8nIcon } from '@n8n/design-system';
+import { useSpeechSynthesis } from '@vueuse/core';
 import ChatMarkdownChunk from '@/features/ai/chatHub/components/ChatMarkdownChunk.vue';
 import ChatTypingIndicator from '@/features/ai/chatHub/components/ChatTypingIndicator.vue';
 import {
 	buildDisplayGroups,
+	type DisplayGroup,
 	type ChatMessage,
 	type InteractivePayload,
 } from '../composables/agentChatMessages';
 import AgentChatToolSteps from './AgentChatToolSteps.vue';
 import InteractiveCard from './interactive/InteractiveCard.vue';
 import { CHAT_MESSAGE_STATUS } from '../constants';
+import AgentChatMessageActions from './AgentChatMessageActions.vue';
 
 const props = defineProps<{
 	messages: ChatMessage[];
@@ -33,6 +36,59 @@ function onInteractiveSubmit(payload: InteractivePayload, resumeData: unknown) {
 const scrollRef = useTemplateRef<HTMLDivElement>('scrollRef');
 
 const displayGroups = computed(() => buildDisplayGroups(props.messages));
+
+function getAssistantGroupContent(group: DisplayGroup): string {
+	if (group.kind === 'toolRun') {
+		return group.finalMessage?.content ?? '';
+	}
+
+	return group.message.role === 'assistant' ? group.message.content : '';
+}
+
+function isAssistantGroup(group: DisplayGroup): boolean {
+	if (group.kind === 'toolRun') return true;
+	return group.message.role === 'assistant';
+}
+
+function getAssistantRunContent(groupId: string): string {
+	const index = displayGroups.value.findIndex((group) => group.id === groupId);
+	if (index === -1) return '';
+
+	const lines: string[] = [];
+	for (let i = index; i >= 0; i--) {
+		const group = displayGroups.value[i];
+		if (!isAssistantGroup(group)) break;
+
+		const content = getAssistantGroupContent(group).trim();
+		if (content) lines.unshift(content);
+	}
+
+	return lines.join('\n\n');
+}
+
+function shouldShowAssistantActions(groupId: string): boolean {
+	const index = displayGroups.value.findIndex((group) => group.id === groupId);
+	if (index === -1) return false;
+
+	const group = displayGroups.value[index];
+	if (!isAssistantGroup(group)) return false;
+	if (!getAssistantRunContent(groupId)) return false;
+
+	const nextGroup = displayGroups.value[index + 1];
+	return !nextGroup || !isAssistantGroup(nextGroup);
+}
+
+const spokenMessageId = ref<string | null>(null);
+const spokenText = computed(() => {
+	if (!spokenMessageId.value) return '';
+	return getAssistantRunContent(spokenMessageId.value);
+});
+const speech = useSpeechSynthesis(spokenText, {
+	pitch: 1,
+	rate: 1,
+	volume: 1,
+});
+const isSpeechSynthesisAvailable = computed(() => speech.isSupported.value);
 
 // How close to the bottom the user has to be for incoming chunks to keep
 // following them. Small enough that a deliberate scroll-up breaks the lock,
@@ -77,6 +133,24 @@ function autoScrollIfSticky(): void {
 	if (isStickToBottom.value) scrollToBottom();
 }
 
+function isSpeakingMessage(messageId: string): boolean {
+	return spokenMessageId.value === messageId && speech.status.value === 'play';
+}
+
+function toggleReadAloud(messageId: string): void {
+	if (!isSpeechSynthesisAvailable.value) return;
+
+	if (spokenMessageId.value === messageId && speech.status.value === 'play') {
+		speech.stop();
+		spokenMessageId.value = null;
+		return;
+	}
+
+	speech.stop();
+	spokenMessageId.value = messageId;
+	speech.speak();
+}
+
 // Snap to the bottom on initial render with a preloaded history. Two hooks on
 // purpose: the watcher with `immediate: true` fires after setup / initial
 // render, and `onMounted` covers cases where the post-flush scroll measured an
@@ -119,6 +193,26 @@ watch(
 	autoScrollIfSticky,
 	{ flush: 'post' },
 );
+
+watch(
+	() => speech.status.value,
+	(status) => {
+		if (status === 'end' || status === 'error') {
+			spokenMessageId.value = null;
+		}
+	},
+);
+
+watch(spokenText, (value) => {
+	if (!value && spokenMessageId.value) {
+		speech.stop();
+		spokenMessageId.value = null;
+	}
+});
+
+onBeforeUnmount(() => {
+	speech.stop();
+});
 </script>
 
 <template>
@@ -157,6 +251,15 @@ watch(
 								@open-artifact="() => {}"
 							/>
 						</div>
+					</div>
+					<div v-if="shouldShowAssistantActions(group.id)" :class="$style.messageActions">
+						<AgentChatMessageActions
+							:content="getAssistantRunContent(group.id)"
+							:can-read-aloud="true"
+							:is-speech-synthesis-available="isSpeechSynthesisAvailable"
+							:is-speaking="isSpeakingMessage(group.id)"
+							@read-aloud="toggleReadAloud(group.id)"
+						/>
 					</div>
 					<ChatTypingIndicator
 						v-if="
@@ -205,6 +308,15 @@ watch(
 							/>
 						</div>
 					</div>
+					<div v-if="shouldShowAssistantActions(group.id)" :class="$style.messageActions">
+						<AgentChatMessageActions
+							:content="getAssistantRunContent(group.id)"
+							:can-read-aloud="true"
+							:is-speech-synthesis-available="isSpeechSynthesisAvailable"
+							:is-speaking="isSpeakingMessage(group.id)"
+							@read-aloud="toggleReadAloud(group.id)"
+						/>
+					</div>
 
 					<div
 						v-if="group.message.interactive && !group.message.interactive.resolvedAt"
@@ -247,7 +359,7 @@ watch(
 	padding-bottom: var(--spacing--xl);
 	display: flex;
 	flex-direction: column;
-	gap: var(--spacing--lg);
+	gap: var(--spacing--sm);
 	scrollbar-width: none;
 
 	mask-image: linear-gradient(to bottom, transparent 0%, black 5%, black 95%, transparent 100%);
@@ -265,6 +377,18 @@ watch(
 	display: flex;
 	flex-direction: column;
 	align-items: stretch;
+}
+
+.messageActions {
+	opacity: 0;
+	pointer-events: none;
+	transition: opacity 0.15s ease;
+}
+
+.message.assistant:hover .messageActions,
+.message.assistant:focus-within .messageActions {
+	opacity: 1;
+	pointer-events: auto;
 }
 
 .message.user .content {

--- a/packages/frontend/editor-ui/src/features/ai/chatHub/components/CopyButton.vue
+++ b/packages/frontend/editor-ui/src/features/ai/chatHub/components/CopyButton.vue
@@ -27,7 +27,8 @@ async function handleCopy() {
 		<N8nIconButton
 			variant="ghost"
 			:icon="justCopied ? 'check' : 'copy'"
-			size="medium"
+			size="small"
+			icon-size="medium"
 			:class="$style.button"
 			tabindex="0"
 			:aria-label="copyTooltip"


### PR DESCRIPTION
## Summary

Adds copy and read-aloud actions to agent chat messages in the editor chat panel.

This PR:
- Adds a dedicated AgentChatMessageActions component for message-level actions
- Shows actions only on assistant messages, and only on hover/focus
- Groups consecutive assistant messages so actions appear once at the end of an assistant run

<img width="3022" height="1716" alt="CleanShot 2026-05-21 at 16 29 51@2x" src="https://github.com/user-attachments/assets/845efa75-4f44-4625-85c9-acb1ecdec011" />

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/AGENT-135/feature-copyread-aloud-actions

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. (See .github/pull_request_title_conventions.md)
- [ ] Docs updated in n8n-docs or follow-up ticket created.
- [x] Tests included.
- [ ] PR labeled with Backport to Beta, Backport to Stable, or Backport to v1 if needed.