### PR TITLE
refactor(editor): Stack tools and improve naming in Agents

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.prompt.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.prompt.ts
@@ -55,6 +55,15 @@ const NODE_CONFIGURATION_SAFETY_RULES = `## Node Configuration Safety Rules
 - Use live \`nodes(action="explore-resources")\` for resource locator, list, and model fields when credentials are available.
 - If a configuration is unclear after reading the definition, ask for clarification or use placeholders — do not guess.`;
 
+const TOOL_NAMING_RULES = `## Tool Naming Rules
+
+- Name tools by the action they perform, not by repeating the integration or tool family name.
+- Always set an explicit \`config.name\` on every \`tool(...)\` node you create. Do not rely on auto-generated names for tools.
+- Do NOT prefix a tool name with the service name when the tool already belongs to that service.
+- Prefer concise snake_case action names like \`get_email\`, \`add_labels\`, or \`mark_as_read\`.
+- Avoid redundant names like \`gmail_get_email\`, \`slack_send_message\`, or \`notion_create_page\` unless the user explicitly asked for that exact name.
+- Keep names specific enough to distinguish sibling tools, but remove repeated vendor/type prefixes first.`;
+
 // Node-specific configuration examples used to live here. They have moved
 // onto the nodes themselves as `@builderHint` annotations and `<patterns>...</patterns>`
 // blocks in the generated `.d.ts` — fetch them on-demand via `nodes(action="type-definition")`.
@@ -100,6 +109,7 @@ function composeSdkRulesAndPatterns(mode: 'tool' | 'sandbox'): string {
 	return [
 		SDK_CODE_RULES,
 		mode === 'sandbox' ? SANDBOX_WORKFLOW_RULES : WORKFLOW_RULES,
+		TOOL_NAMING_RULES,
 		'## SDK Patterns Reference\n\n' + WORKFLOW_SDK_PATTERNS,
 		'## Expression Reference\n\n' + EXPRESSION_REFERENCE,
 		'## Additional Functions\n\n' + ADDITIONAL_FUNCTIONS,

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -6135,6 +6135,8 @@
 	"agents.builder.tools.builtIn.title": "Built-in node tools",
 	"agents.builder.tools.builtIn.hint": "Let the agent search the n8n node catalog and execute nodes on demand.",
 	"agents.builder.tools.empty": "No tools added yet.",
+	"agents.builder.tools.type.workflow": "Workflow",
+	"agents.builder.tools.type.custom": "Custom tool",
 	"agents.builder.tools.workflows.title": "Workflows",
 	"agents.builder.tools.remove": "Remove tool",
 	"agents.builder.tools.back": "Back to tools",

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentCapabilitiesSection.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentCapabilitiesSection.test.ts
@@ -1,10 +1,29 @@
 import { mount } from '@vue/test-utils';
 import { describe, expect, it, vi } from 'vitest';
 
+import type { SimplifiedNodeType } from '@/Interface';
 import AgentCapabilitiesSection from '../components/AgentCapabilitiesSection.vue';
 import type { AgentJsonToolRef, CustomToolEntry } from '../types';
 
-const getNodeType = vi.fn(() => null);
+const getNodeType = vi.fn<(type: string, version?: number) => SimplifiedNodeType | null>(
+	() => null,
+);
+
+function createNodeType(name: string, displayName: string): SimplifiedNodeType {
+	return {
+		name,
+		displayName,
+		description: '',
+		group: [],
+		icon: 'file:placeholder.svg',
+		iconUrl: undefined,
+		iconColor: undefined,
+		badgeIconUrl: undefined,
+		codex: undefined,
+		defaults: {},
+		outputs: [],
+	};
+}
 
 vi.mock('@/app/stores/nodeTypes.store', () => ({
 	useNodeTypesStore: () => ({
@@ -104,10 +123,7 @@ describe('AgentCapabilitiesSection', () => {
 	it('keeps a single tool of the same type ungrouped', () => {
 		getNodeType.mockImplementation((type: string) => {
 			if (type === 'n8n-nodes-base.gmailTool') {
-				return {
-					name: 'n8n-nodes-base.gmailTool',
-					displayName: 'Gmail Tool',
-				};
+				return createNodeType('n8n-nodes-base.gmailTool', 'Gmail Tool');
 			}
 
 			return null;
@@ -132,10 +148,7 @@ describe('AgentCapabilitiesSection', () => {
 	it('groups tools once the same node type reaches the threshold', () => {
 		getNodeType.mockImplementation((type: string) => {
 			if (type === 'n8n-nodes-base.gmailTool') {
-				return {
-					name: 'n8n-nodes-base.gmailTool',
-					displayName: 'Gmail Tool',
-				};
+				return createNodeType('n8n-nodes-base.gmailTool', 'Gmail Tool');
 			}
 
 			return null;
@@ -170,10 +183,7 @@ describe('AgentCapabilitiesSection', () => {
 	it('groups more than two tools of the same node type', () => {
 		getNodeType.mockImplementation((type: string) => {
 			if (type === 'n8n-nodes-base.gmailTool') {
-				return {
-					name: 'n8n-nodes-base.gmailTool',
-					displayName: 'Gmail Tool',
-				};
+				return createNodeType('n8n-nodes-base.gmailTool', 'Gmail Tool');
 			}
 
 			return null;

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentCapabilitiesSection.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentCapabilitiesSection.test.ts
@@ -101,7 +101,35 @@ describe('AgentCapabilitiesSection', () => {
 		expect(text).not.toContain('tool_123');
 	});
 
-	it('groups duplicate node tool types into a dropdown chip and opens individual tools', async () => {
+	it('keeps a single tool of the same type ungrouped', () => {
+		getNodeType.mockImplementation((type: string) => {
+			if (type === 'n8n-nodes-base.gmailTool') {
+				return {
+					name: 'n8n-nodes-base.gmailTool',
+					displayName: 'Gmail Tool',
+				};
+			}
+
+			return null;
+		});
+
+		const wrapper = mountSection([
+			{
+				type: 'node',
+				name: 'inbox_triage',
+				node: {
+					nodeType: 'n8n-nodes-base.gmailTool',
+					nodeTypeVersion: 1,
+					nodeParameters: {},
+				},
+			},
+		]);
+
+		expect(wrapper.text()).not.toContain('2 Gmail');
+		expect(wrapper.text()).toContain('Inbox triage');
+	});
+
+	it('groups tools once the same node type reaches the threshold', () => {
 		getNodeType.mockImplementation((type: string) => {
 			if (type === 'n8n-nodes-base.gmailTool') {
 				return {
@@ -137,5 +165,53 @@ describe('AgentCapabilitiesSection', () => {
 		expect(wrapper.text()).toContain('2 Gmail');
 		expect(wrapper.text()).not.toContain('Inbox triage');
 		expect(wrapper.text()).not.toContain('Send follow up');
+	});
+
+	it('groups more than two tools of the same node type', () => {
+		getNodeType.mockImplementation((type: string) => {
+			if (type === 'n8n-nodes-base.gmailTool') {
+				return {
+					name: 'n8n-nodes-base.gmailTool',
+					displayName: 'Gmail Tool',
+				};
+			}
+
+			return null;
+		});
+
+		const wrapper = mountSection([
+			{
+				type: 'node',
+				name: 'inbox_triage',
+				node: {
+					nodeType: 'n8n-nodes-base.gmailTool',
+					nodeTypeVersion: 1,
+					nodeParameters: {},
+				},
+			},
+			{
+				type: 'node',
+				name: 'send_follow_up',
+				node: {
+					nodeType: 'n8n-nodes-base.gmailTool',
+					nodeTypeVersion: 1,
+					nodeParameters: {},
+				},
+			},
+			{
+				type: 'node',
+				name: 'archive_message',
+				node: {
+					nodeType: 'n8n-nodes-base.gmailTool',
+					nodeTypeVersion: 1,
+					nodeParameters: {},
+				},
+			},
+		]);
+
+		expect(wrapper.text()).toContain('3 Gmail');
+		expect(wrapper.text()).not.toContain('Inbox triage');
+		expect(wrapper.text()).not.toContain('Send follow up');
+		expect(wrapper.text()).not.toContain('Archive message');
 	});
 });

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentCapabilitiesSection.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentCapabilitiesSection.test.ts
@@ -4,9 +4,11 @@ import { describe, expect, it, vi } from 'vitest';
 import AgentCapabilitiesSection from '../components/AgentCapabilitiesSection.vue';
 import type { AgentJsonToolRef, CustomToolEntry } from '../types';
 
+const getNodeType = vi.fn(() => null);
+
 vi.mock('@/app/stores/nodeTypes.store', () => ({
 	useNodeTypesStore: () => ({
-		getNodeType: () => null,
+		getNodeType,
 	}),
 }));
 
@@ -41,6 +43,13 @@ function mountSection(
 			stubs: {
 				NodeIcon: { template: '<span />' },
 				N8nButton: { template: '<button><slot name="icon" /><slot /></button>' },
+				N8nDropdownMenu: {
+					name: 'N8nDropdownMenu',
+					props: ['items'],
+					emits: ['select'],
+					template:
+						'<div><slot name="trigger" /><button v-for="item in items" :key="item.id" @click="$emit(\'select\', item.id)">{{ item.label }}</button><slot /></div>',
+				},
 				N8nIcon: { template: '<span />' },
 				N8nText: { template: '<span><slot /></span>' },
 				N8nTooltip: { template: '<span><slot /></span>' },
@@ -51,6 +60,8 @@ function mountSection(
 
 describe('AgentCapabilitiesSection', () => {
 	it('formats node and custom tool chip labels for display', () => {
+		getNodeType.mockReturnValue(null);
+
 		const wrapper = mountSection(
 			[
 				{
@@ -88,5 +99,43 @@ describe('AgentCapabilitiesSection', () => {
 		expect(text).toContain('Seo analyzer');
 		expect(text).not.toContain('fetch_webpage');
 		expect(text).not.toContain('tool_123');
+	});
+
+	it('groups duplicate node tool types into a dropdown chip and opens individual tools', async () => {
+		getNodeType.mockImplementation((type: string) => {
+			if (type === 'n8n-nodes-base.gmailTool') {
+				return {
+					name: 'n8n-nodes-base.gmailTool',
+					displayName: 'Gmail Tool',
+				};
+			}
+
+			return null;
+		});
+
+		const wrapper = mountSection([
+			{
+				type: 'node',
+				name: 'inbox_triage',
+				node: {
+					nodeType: 'n8n-nodes-base.gmailTool',
+					nodeTypeVersion: 1,
+					nodeParameters: {},
+				},
+			},
+			{
+				type: 'node',
+				name: 'send_follow_up',
+				node: {
+					nodeType: 'n8n-nodes-base.gmailTool',
+					nodeTypeVersion: 1,
+					nodeParameters: {},
+				},
+			},
+		]);
+
+		expect(wrapper.text()).toContain('2 Gmail');
+		expect(wrapper.text()).not.toContain('Inbox triage');
+		expect(wrapper.text()).not.toContain('Send follow up');
 	});
 });

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.types.ts
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.types.ts
@@ -1,10 +1,8 @@
+import type { SimplifiedNodeType } from '@/Interface';
 import type { DropdownMenuItemProps } from '@n8n/design-system';
 import type { IconName } from '@n8n/design-system/components/N8nIcon';
 
-export type ToolRowNodeType = {
-	name: string;
-	displayName: string;
-} | null;
+export type ToolRowNodeType = SimplifiedNodeType | null;
 
 export type ToolRowItem = {
 	index: number;

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.types.ts
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.types.ts
@@ -1,0 +1,25 @@
+import type { DropdownMenuItemProps } from '@n8n/design-system';
+import type { IconName } from '@n8n/design-system/components/N8nIcon';
+
+export type ToolRowNodeType = {
+	name: string;
+	displayName: string;
+} | null;
+
+export type ToolRowItem = {
+	index: number;
+	label: string;
+	nodeType: ToolRowNodeType;
+};
+
+export type ToolRow = {
+	index: number;
+	label: string;
+	typeLabel: string;
+	nodeType: ToolRowNodeType;
+	fallbackIcon: IconName;
+	isGrouped: boolean;
+	items: ToolRowItem[];
+};
+
+export type ToolMenuItem = DropdownMenuItemProps<number, { nodeType: ToolRowNodeType }>;

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.utils.ts
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.utils.ts
@@ -1,0 +1,88 @@
+import type { IconName } from '@n8n/design-system/components/N8nIcon';
+
+import type { AgentJsonToolRef } from '../types';
+import type { ToolRow, ToolRowItem, ToolRowNodeType } from './AgentCapabilitiesSection.types';
+
+export const MIN_GROUPED_TOOLS_PER_TYPE = 2;
+
+type BaseToolRow = {
+	index: number;
+	label: string;
+	typeLabel: string;
+	nodeType: ToolRowNodeType;
+	fallbackIcon: IconName;
+	toolType: AgentJsonToolRef['type'];
+};
+
+function toUngroupedToolRow(row: BaseToolRow): ToolRow {
+	const item: ToolRowItem = {
+		index: row.index,
+		label: row.label,
+		nodeType: row.nodeType,
+	};
+
+	return {
+		index: row.index,
+		label: row.label,
+		typeLabel: row.typeLabel,
+		nodeType: row.nodeType,
+		fallbackIcon: row.fallbackIcon,
+		isGrouped: false,
+		items: [item],
+	};
+}
+
+function toGroupedToolRow(group: BaseToolRow[]): ToolRow {
+	const [first] = group;
+
+	return {
+		index: first.index,
+		label: `${group.length} ${first.typeLabel}`,
+		typeLabel: first.typeLabel,
+		nodeType: first.nodeType,
+		fallbackIcon: first.fallbackIcon,
+		isGrouped: true,
+		items: group.map((row) => ({
+			index: row.index,
+			label: row.label,
+			nodeType: row.nodeType,
+		})),
+	};
+}
+
+export function buildToolRows(rows: BaseToolRow[]): ToolRow[] {
+	const groupedRows: ToolRow[] = [];
+	const nodeGroups = new Map<string, BaseToolRow[]>();
+
+	for (const row of rows) {
+		/**
+		 * Only node tools with a resolved node type are eligible for grouping.
+		 * Workflow tools, custom tools, and unresolved node tools stay ungrouped
+		 * because this grouping logic relies on nodeType.name as the canonical key
+		 * and on the resolved node type for the grouped label/icon.
+		 */
+		if (row.toolType !== 'node' || !row.nodeType) {
+			groupedRows.push(toUngroupedToolRow(row));
+			continue;
+		}
+
+		const group = nodeGroups.get(row.nodeType.name);
+		if (group) {
+			group.push(row);
+			continue;
+		}
+
+		nodeGroups.set(row.nodeType.name, [row]);
+	}
+
+	for (const group of nodeGroups.values()) {
+		if (group.length >= MIN_GROUPED_TOOLS_PER_TYPE) {
+			groupedRows.push(toGroupedToolRow(group));
+			continue;
+		}
+
+		groupedRows.push(...group.map(toUngroupedToolRow));
+	}
+
+	return groupedRows.sort((left, right) => left.index - right.index);
+}

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.vue
@@ -2,7 +2,8 @@
 import NodeIcon from '@/app/components/NodeIcon.vue';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { AGENT_SCHEDULE_TRIGGER_TYPE } from '@n8n/api-types';
-import { N8nButton, N8nIcon, N8nText, N8nTooltip } from '@n8n/design-system';
+import { N8nButton, N8nDropdownMenu, N8nIcon, N8nText, N8nTooltip } from '@n8n/design-system';
+import type { DropdownMenuItemProps } from '@n8n/design-system';
 import { updatedIconSet, type IconName } from '@n8n/design-system/components/N8nIcon';
 import { useI18n } from '@n8n/i18n';
 import { computed } from 'vue';
@@ -103,14 +104,108 @@ function toolNodeType(tool: AgentJsonToolRef) {
 	return nodeTypesStore.getNodeType(node.type, node.typeVersion) ?? null;
 }
 
-const toolRows = computed(() =>
-	props.tools.map((tool, index) => ({
-		index,
-		label: toolLabel(tool, index),
-		nodeType: toolNodeType(tool),
-		fallbackIcon: toolIcon(tool),
-	})),
-);
+function toolTypeLabel(tool: AgentJsonToolRef, index: number, nodeType = toolNodeType(tool)) {
+	if (tool.type === 'node') {
+		return nodeType?.displayName.replace(/ Tool$/, '') ?? toolLabel(tool, index);
+	}
+
+	if (tool.type === 'workflow') return i18n.baseText('agents.builder.tools.type.workflow');
+	if (tool.type === 'custom') return i18n.baseText('agents.builder.tools.type.custom');
+	return toolLabel(tool, index);
+}
+
+type ToolRow = {
+	index: number;
+	label: string;
+	typeLabel: string;
+	nodeType: ReturnType<typeof toolNodeType>;
+	fallbackIcon: IconName;
+	isGrouped: boolean;
+	items: Array<{ index: number; label: string; nodeType: ReturnType<typeof toolNodeType> }>;
+};
+
+type ToolMenuItem = DropdownMenuItemProps<number, { nodeType: ReturnType<typeof toolNodeType> }>;
+
+const toolRows = computed<ToolRow[]>(() => {
+	const rows = props.tools.map((tool, index) => {
+		const nodeType = toolNodeType(tool);
+		return {
+			index,
+			label: toolLabel(tool, index),
+			typeLabel: toolTypeLabel(tool, index, nodeType),
+			nodeType,
+			fallbackIcon: toolIcon(tool),
+			raw: tool,
+		};
+	});
+
+	const groupedRows: ToolRow[] = [];
+	const nodeGroups = new Map<string, typeof rows>();
+
+	for (const row of rows) {
+		if (row.raw.type !== 'node' || !row.nodeType) {
+			groupedRows.push({
+				index: row.index,
+				label: row.label,
+				typeLabel: row.typeLabel,
+				nodeType: row.nodeType,
+				fallbackIcon: row.fallbackIcon,
+				isGrouped: false,
+				items: [{ index: row.index, label: row.label, nodeType: row.nodeType }],
+			});
+			continue;
+		}
+
+		const key = row.nodeType.name;
+		const group = nodeGroups.get(key);
+		if (group) {
+			group.push(row);
+		} else {
+			nodeGroups.set(key, [row]);
+		}
+	}
+
+	for (const group of nodeGroups.values()) {
+		if (group.length === 1) {
+			const [row] = group;
+			groupedRows.push({
+				index: row.index,
+				label: row.label,
+				typeLabel: row.typeLabel,
+				nodeType: row.nodeType,
+				fallbackIcon: row.fallbackIcon,
+				isGrouped: false,
+				items: [{ index: row.index, label: row.label, nodeType: row.nodeType }],
+			});
+			continue;
+		}
+
+		const [first] = group;
+		groupedRows.push({
+			index: first.index,
+			label: `${group.length} ${first.typeLabel}`,
+			typeLabel: first.typeLabel,
+			nodeType: first.nodeType,
+			fallbackIcon: first.fallbackIcon,
+			isGrouped: true,
+			items: group.map((row) => ({
+				index: row.index,
+				label: row.label,
+				nodeType: row.nodeType,
+			})),
+		});
+	}
+
+	return groupedRows.sort((left, right) => left.index - right.index);
+});
+
+function toolMenuItems(tool: ToolRow): ToolMenuItem[] {
+	return tool.items.map((item) => ({
+		id: item.index,
+		label: item.label,
+		data: { nodeType: item.nodeType },
+	}));
+}
 </script>
 
 <template>
@@ -164,8 +259,35 @@ const toolRows = computed(() =>
 
 			<div :class="$style.chips">
 				<template v-for="tool in toolRows" :key="`tool-${tool.index}`">
+					<N8nDropdownMenu
+						v-if="tool.isGrouped"
+						:items="toolMenuItems(tool)"
+						placement="bottom-start"
+						data-testid="agent-capabilities-tool-group"
+						@select="emit('open-tool', $event)"
+					>
+						<template #trigger>
+							<AgentChipButton data-testid="agent-capabilities-tool-row">
+								<template #icon>
+									<NodeIcon :node-type="tool.nodeType" :size="16" />
+								</template>
+								<span :class="$style.groupChipLabel">
+									{{ tool.label }}
+									<N8nIcon icon="chevron-down" :size="12" color="text-light" />
+								</span>
+							</AgentChipButton>
+						</template>
+						<template #item-leading="{ item, ui }">
+							<NodeIcon
+								v-if="item.data?.nodeType"
+								:node-type="item.data.nodeType"
+								:size="16"
+								:class="ui.class"
+							/>
+						</template>
+					</N8nDropdownMenu>
 					<AgentChipButton
-						v-if="tool.nodeType"
+						v-else-if="tool.nodeType"
 						data-testid="agent-capabilities-tool-row"
 						@click="emit('open-tool', tool.index)"
 					>
@@ -275,6 +397,12 @@ const toolRows = computed(() =>
 	gap: var(--spacing--2xs);
 	min-width: 0;
 	margin-top: var(--spacing--5xs);
+}
+
+.groupChipLabel {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--spacing--4xs);
 }
 
 .disabled {

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentCapabilitiesSection.vue
@@ -3,7 +3,6 @@ import NodeIcon from '@/app/components/NodeIcon.vue';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { AGENT_SCHEDULE_TRIGGER_TYPE } from '@n8n/api-types';
 import { N8nButton, N8nDropdownMenu, N8nIcon, N8nText, N8nTooltip } from '@n8n/design-system';
-import type { DropdownMenuItemProps } from '@n8n/design-system';
 import { updatedIconSet, type IconName } from '@n8n/design-system/components/N8nIcon';
 import { useI18n } from '@n8n/i18n';
 import { computed } from 'vue';
@@ -12,6 +11,8 @@ import type { AgentSkill, CustomToolEntry } from '../types';
 import { useAgentIntegrationsCatalog } from '../composables/useAgentIntegrationsCatalog';
 import { toolRefToNode } from '../composables/useAgentToolRefAdapter';
 import { formatToolNameForDisplay } from '../utils/toolDisplayName';
+import type { ToolMenuItem, ToolRow } from './AgentCapabilitiesSection.types';
+import { buildToolRows } from './AgentCapabilitiesSection.utils';
 import AgentChipButton from './AgentChipButton.vue';
 
 const props = withDefaults(
@@ -114,89 +115,20 @@ function toolTypeLabel(tool: AgentJsonToolRef, index: number, nodeType = toolNod
 	return toolLabel(tool, index);
 }
 
-type ToolRow = {
-	index: number;
-	label: string;
-	typeLabel: string;
-	nodeType: ReturnType<typeof toolNodeType>;
-	fallbackIcon: IconName;
-	isGrouped: boolean;
-	items: Array<{ index: number; label: string; nodeType: ReturnType<typeof toolNodeType> }>;
-};
-
-type ToolMenuItem = DropdownMenuItemProps<number, { nodeType: ReturnType<typeof toolNodeType> }>;
-
 const toolRows = computed<ToolRow[]>(() => {
-	const rows = props.tools.map((tool, index) => {
-		const nodeType = toolNodeType(tool);
-		return {
-			index,
-			label: toolLabel(tool, index),
-			typeLabel: toolTypeLabel(tool, index, nodeType),
-			nodeType,
-			fallbackIcon: toolIcon(tool),
-			raw: tool,
-		};
-	});
-
-	const groupedRows: ToolRow[] = [];
-	const nodeGroups = new Map<string, typeof rows>();
-
-	for (const row of rows) {
-		if (row.raw.type !== 'node' || !row.nodeType) {
-			groupedRows.push({
-				index: row.index,
-				label: row.label,
-				typeLabel: row.typeLabel,
-				nodeType: row.nodeType,
-				fallbackIcon: row.fallbackIcon,
-				isGrouped: false,
-				items: [{ index: row.index, label: row.label, nodeType: row.nodeType }],
-			});
-			continue;
-		}
-
-		const key = row.nodeType.name;
-		const group = nodeGroups.get(key);
-		if (group) {
-			group.push(row);
-		} else {
-			nodeGroups.set(key, [row]);
-		}
-	}
-
-	for (const group of nodeGroups.values()) {
-		if (group.length === 1) {
-			const [row] = group;
-			groupedRows.push({
-				index: row.index,
-				label: row.label,
-				typeLabel: row.typeLabel,
-				nodeType: row.nodeType,
-				fallbackIcon: row.fallbackIcon,
-				isGrouped: false,
-				items: [{ index: row.index, label: row.label, nodeType: row.nodeType }],
-			});
-			continue;
-		}
-
-		const [first] = group;
-		groupedRows.push({
-			index: first.index,
-			label: `${group.length} ${first.typeLabel}`,
-			typeLabel: first.typeLabel,
-			nodeType: first.nodeType,
-			fallbackIcon: first.fallbackIcon,
-			isGrouped: true,
-			items: group.map((row) => ({
-				index: row.index,
-				label: row.label,
-				nodeType: row.nodeType,
-			})),
-		});
-	}
-
-	return groupedRows.sort((left, right) => left.index - right.index);
+	return buildToolRows(
+		props.tools.map((tool, index) => {
+			const nodeType = toolNodeType(tool);
+			return {
+				index,
+				label: toolLabel(tool, index),
+				typeLabel: toolTypeLabel(tool, index, nodeType),
+				nodeType,
+				fallbackIcon: toolIcon(tool),
+				toolType: tool.type,
+			};
+		}),
+	);
 });
 
 function toolMenuItems(tool: ToolRow): ToolMenuItem[] {


### PR DESCRIPTION
## Summary

This PR improves how agent tools are presented and named.

* Stacks 2 or more tool chips of the same type (e.g Gmail) into a single dropdown chip such as `2 Gmail`, which reduces visual noise while preserving access to each underlying tool.
* Reuses the existing tool icon for grouped chips and shows a chevron so the dropdown affordance is clear.
* Opens the same tool modal flow when a specific tool is selected from the grouped dropdown.
* Adds builder prompt guidance to set explicit action-focused tool names for agent tools so generated names avoid redundant service prefixes like `gmail_get_all_messages`.
* Adds the supporting i18n entries and component test coverage for grouped tool rendering.

<img src="https://uploads.linear.app/1c35bbc6-9cd4-427e-8bc5-e5d370a9869f/bca1aee5-fde2-4139-b895-afeb09c381f7/7c46d425-4605-4588-a211-46e67f4f2cf4?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzFjMzViYmM2LTljZDQtNDI3ZS04YmM1LWU1ZDM3MGE5ODY5Zi9iY2ExYWVlNS1mZGUyLTQxMzktYjg5NS1hZmViMDljMzgxZjcvN2M0NmQ0MjUtNDYwNS00NTg4LWEyMTEtNDZlNjdmNGYyY2Y0IiwiaWF0IjoxNzc5MzgxNTg0LCJleHAiOjE4MTA5NTIxNDR9._2sOdIOnVJscgAUiOBCJI-RJJyQA11pOqHOVkWFl9Ug " alt="CleanShot 2026-05-21 at 17.38.46@2x.png" width="1254" data-linear-height="656" />

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](<../blob/master/.github/pull_request_title_conventions.md>))
- [ ] [Docs updated](<https://github.com/n8n-io/n8n-docs>) or follow-up ticket created.
- [X] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)