### PR TITLE
ci: Disable Instance AI eval auto-trigger on PR review (no-changelog)

### DIFF
--- a/.github/workflows/ci-instance-ai-evals.yml
+++ b/.github/workflows/ci-instance-ai-evals.yml
@@ -1,58 +1,23 @@
 name: 'CI: Instance AI Evals'
 
-# Triggers separately from ci-pull-requests.yml so build/tests/lint don't
-# re-run on review activity. Eval fires only when a reviewer approves —
-# acts as the merge gate. Bare pushes don't fire it; `dismiss_stale_reviews_on_push`
-# on master forces a re-approval (and a fresh eval) if anything changes
-# between approval and merge.
+# Auto-trigger disabled — run manually via workflow_dispatch.
 on:
-  pull_request_review:
-    types: [submitted]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'GitHub branch to test'
+        required: false
+        default: 'master'
 
 concurrency:
-  group: instance-ai-evals-${{ github.event.pull_request.number || github.ref }}
+  group: instance-ai-evals-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  check-paths:
-    name: Check Eval Should Run
-    runs-on: ubuntu-latest
-    if: >-
-      github.repository == 'n8n-io/n8n' &&
-      github.event.review.state == 'approved' &&
-      !github.event.pull_request.head.repo.fork &&
-      github.event.pull_request.draft == false
-    outputs:
-      should_run: ${{ steps.ci-filter.outputs.results && fromJSON(steps.ci-filter.outputs.results)['instance-ai-workflow-eval'] == true }}
-      commit_sha: ${{ steps.commit-sha.outputs.sha }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
-
-      - name: Capture commit SHA for cache consistency
-        id: commit-sha
-        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-      - name: Check for relevant changes
-        id: ci-filter
-        uses: ./.github/actions/ci-filter
-        with:
-          mode: filter
-          filters: |
-            instance-ai-workflow-eval:
-              packages/@n8n/instance-ai/src/**
-              packages/@n8n/instance-ai/evaluations/**
-              packages/cli/src/modules/instance-ai/**
-              packages/core/src/execution-engine/eval-mock-helpers.ts
-              .github/workflows/test-evals-instance-ai*.yml
-              .github/workflows/ci-instance-ai-evals.yml
-
   run-evals:
     name: Instance AI Workflow Evals
-    needs: check-paths
-    if: needs.check-paths.outputs.should_run == 'true'
+    if: github.repository == 'n8n-io/n8n'
     uses: ./.github/workflows/test-evals-instance-ai.yml
     with:
-      branch: ${{ needs.check-paths.outputs.commit_sha }}
+      branch: ${{ inputs.branch }}
     secrets: inherit


### PR DESCRIPTION
## Summary

Disables the auto-trigger on \`ci-instance-ai-evals.yml\`. The workflow file is kept; the \`pull_request_review\` trigger is replaced with \`workflow_dispatch\` so it can still be run manually from the Actions tab.

After this lands, eval results will no longer be posted to PRs on review approval. To run evals on demand, dispatch either:
- \`CI: Instance AI Evals\` (this workflow) — runs against the chosen branch
- \`Test: Instance AI Exec Evals\` (the underlying reusable workflow, also \`workflow_dispatch\`-enabled)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.