### PR TITLE
chore: Fix mcp-registry test seeding flake

### DIFF
--- a/packages/cli/src/modules/mcp-registry/__tests__/mcp-registry-test.controller.test.ts
+++ b/packages/cli/src/modules/mcp-registry/__tests__/mcp-registry-test.controller.test.ts
@@ -3,13 +3,34 @@ import { mock } from 'jest-mock-extended';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 
 import { McpRegistryTestController } from '../mcp-registry-test.controller';
+import { McpRegistryServerEntity } from '../registry/mcp-registry-server.entity';
 import type { McpRegistryServerRepository } from '../registry/mcp-registry-server.repository';
 import type { McpRegistryService } from '../registry/mcp-registry.service';
 import { toEntity } from '../registry/mcp-registry.types';
 import { notionMockServer, linearMockServer } from '../registry/mock-servers';
 
 describe('McpRegistryTestController', () => {
+	const deleteQueryBuilder = {
+		delete: jest.fn().mockReturnThis(),
+		from: jest.fn().mockReturnThis(),
+		execute: jest.fn().mockResolvedValue({}),
+	};
+
+	const transactionManager = {
+		createQueryBuilder: jest.fn().mockReturnValue(deleteQueryBuilder),
+		insert: jest.fn().mockResolvedValue({}),
+	};
+
+	const manager = {
+		transaction: jest.fn(
+			async (runInTransaction: (m: typeof transactionManager) => Promise<unknown>) =>
+				await runInTransaction(transactionManager),
+		),
+	};
+
 	const repository = mock<McpRegistryServerRepository>();
+	Object.assign(repository, { manager });
+
 	const service = mock<McpRegistryService>();
 	const controller = new McpRegistryTestController(repository, service);
 
@@ -25,15 +46,17 @@ describe('McpRegistryTestController', () => {
 	});
 
 	describe('seed', () => {
-		it('should upsert mock servers and trigger registry reload', async () => {
-			repository.upsert.mockResolvedValue({} as never);
+		it('should replace mock servers and trigger registry reload', async () => {
 			service.handleReloadMcpRegistry.mockResolvedValue();
 
 			const result = await controller.seed();
 
-			expect(repository.upsert).toHaveBeenCalledWith(
+			expect(manager.transaction).toHaveBeenCalled();
+			expect(deleteQueryBuilder.from).toHaveBeenCalledWith(McpRegistryServerEntity);
+			expect(deleteQueryBuilder.execute).toHaveBeenCalled();
+			expect(transactionManager.insert).toHaveBeenCalledWith(
+				McpRegistryServerEntity,
 				[notionMockServer, linearMockServer].map(toEntity),
-				['id'],
 			);
 			expect(service.handleReloadMcpRegistry).toHaveBeenCalled();
 			expect(result).toEqual({ ok: true, count: 2 });

--- a/packages/cli/src/modules/mcp-registry/mcp-registry-test.controller.ts
+++ b/packages/cli/src/modules/mcp-registry/mcp-registry-test.controller.ts
@@ -2,6 +2,7 @@ import { Post, RestController } from '@n8n/decorators';
 
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 
+import { McpRegistryServerEntity } from './registry/mcp-registry-server.entity';
 import { McpRegistryServerRepository } from './registry/mcp-registry-server.repository';
 import { McpRegistryService } from './registry/mcp-registry.service';
 import { toEntity } from './registry/mcp-registry.types';
@@ -23,7 +24,12 @@ export class McpRegistryTestController {
 		this.assertE2ETestsEnabled();
 
 		const entities = [notionMockServer, linearMockServer].map(toEntity);
-		await this.repository.upsert(entities, ['id']);
+
+		// Replace rather than upsert: a startup refresh can leave rows whose slug collides with our mocks at a different id, which `ON CONFLICT (id) DO UPDATE` does not cover.
+		await this.repository.manager.transaction(async (manager) => {
+			await manager.createQueryBuilder().delete().from(McpRegistryServerEntity).execute();
+			await manager.insert(McpRegistryServerEntity, entities);
+		});
 		await this.service.handleReloadMcpRegistry();
 
 		return { ok: true, count: entities.length };


### PR DESCRIPTION
## Summary

> [!NOTE] 
> This fix was investigated and implemented by Claude 🤖 

The seed's upsert(entities, ['id']) only catches id conflicts but a startup refresh can leave rows with the same slug at a different id, blowing up the unique slug index — fixed by replacing the upsert with a transactional delete-then-insert.

## Related Linear tickets, Github issues, and Community forum posts

Found from investigating flakes in e.g. https://github.com/n8n-io/n8n/actions/runs/26147465234/job/76910683408


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
