### PR TITLE
fix(core): Include node and field details in WorkflowHasIssuesError message

### DIFF
--- a/packages/core/src/errors/__tests__/workflow-has-issues.error.test.ts
+++ b/packages/core/src/errors/__tests__/workflow-has-issues.error.test.ts
@@ -1,91 +1,40 @@
 import type { INode, IWorkflowIssues } from 'n8n-workflow';
 
-import { WorkflowHasIssuesError } from '../workflow-has-issues.error';
+import { BASE_MESSAGE, WorkflowHasIssuesError } from '../workflow-has-issues.error';
 
 describe('WorkflowHasIssuesError', () => {
-	const baseMessage =
-		'The workflow has issues and cannot be executed for that reason. Please fix them first.';
-
-	it('uses the base message when no issues are provided', () => {
-		expect(new WorkflowHasIssuesError().message).toBe(baseMessage);
-	});
-
-	it('uses the base message when the issues map is empty', () => {
-		expect(new WorkflowHasIssuesError({}).message).toBe(baseMessage);
-	});
-
-	it('includes parameter and credential issues with node names', () => {
+	it('formats a single node with multiple issue types', () => {
 		const issues: IWorkflowIssues = {
 			'HTTP Request': {
-				credentials: { httpBasicAuth: ['Credentials for "httpBasicAuth" are not set.'] },
+				execution: true,
+				parameters: { url: ['Parameter "URL" is required.'] },
+				typeUnknown: true,
 			},
-			Set: {
-				parameters: { value: ['Parameter "value" is required.'] },
-			},
-		};
-
-		const message = new WorkflowHasIssuesError(issues).message;
-
-		expect(message).toContain(baseMessage);
-		expect(message).toContain('\'HTTP Request\': Credentials for "httpBasicAuth" are not set.');
-		expect(message).toContain('\'Set\': Parameter "value" is required.');
-	});
-
-	it('includes the node type in the typeUnknown message when nodes are provided', () => {
-		const issues: IWorkflowIssues = {
-			Custom: { typeUnknown: true },
 		};
 		const nodes: Record<string, INode> = {
-			Custom: {
+			'HTTP Request': {
 				id: '1',
-				name: 'Custom',
-				type: 'community.custom',
-				typeVersion: 1,
+				name: 'HTTP Request',
+				type: 'n8n-nodes-base.httpRequest',
+				typeVersion: 4.2,
 				position: [0, 0],
 				parameters: {},
 			},
 		};
 
-		expect(new WorkflowHasIssuesError(issues, nodes).message).toContain(
-			'\'Custom\': Node Type "community.custom" is not known.',
+		expect(new WorkflowHasIssuesError(issues, nodes).message).toBe(
+			`${BASE_MESSAGE} Issues: 'HTTP Request': Execution Error. Parameter "URL" is required. Node Type "n8n-nodes-base.httpRequest" is not known.`,
 		);
 	});
 
-	it('falls back to a generic typeUnknown message when the node is missing', () => {
-		const issues: IWorkflowIssues = {
-			Custom: { typeUnknown: true },
-		};
-
-		expect(new WorkflowHasIssuesError(issues).message).toContain(
-			"'Custom': Node Type is not known.",
-		);
-	});
-
-	it('flattens execution, parameters, credentials, and input issues for one node', () => {
-		const issues: IWorkflowIssues = {
-			Multi: {
-				execution: true,
-				parameters: { foo: ['Parameter "foo" is required.'] },
-				credentials: { api: ['API credentials missing.'] },
-				input: { in: ['Input is invalid.'] },
-			},
-		};
-
-		const message = new WorkflowHasIssuesError(issues).message;
-
-		expect(message).toContain(
-			'\'Multi\': Execution Error.; Parameter "foo" is required.; API credentials missing.; Input is invalid.',
-		);
-	});
-
-	it('joins multiple nodes with a separator', () => {
+	it('joins multiple nodes with a pipe separator', () => {
 		const issues: IWorkflowIssues = {
 			A: { parameters: { x: ['Parameter "x" is required.'] } },
 			B: { parameters: { y: ['Parameter "y" is required.'] } },
 		};
 
-		expect(new WorkflowHasIssuesError(issues).message).toContain(
-			'\'A\': Parameter "x" is required. | \'B\': Parameter "y" is required.',
+		expect(new WorkflowHasIssuesError(issues, {}).message).toBe(
+			`${BASE_MESSAGE} Issues: 'A': Parameter "x" is required. | 'B': Parameter "y" is required.`,
 		);
 	});
 
@@ -99,12 +48,8 @@ describe('WorkflowHasIssuesError', () => {
 			F: { parameters: { p: ['Parameter "p" is required.'] } },
 		};
 
-		const message = new WorkflowHasIssuesError(issues).message;
-
-		expect(message).toContain("'A':");
-		expect(message).toContain("'D':");
-		expect(message).not.toContain("'E':");
-		expect(message).not.toContain("'F':");
-		expect(message).toContain('(2 other issues)');
+		expect(new WorkflowHasIssuesError(issues, {}).message).toBe(
+			`${BASE_MESSAGE} Issues: 'A': Parameter "p" is required. | 'B': Parameter "p" is required. | 'C': Parameter "p" is required. | 'D': Parameter "p" is required. | (2 more)`,
+		);
 	});
 });

--- a/packages/core/src/errors/__tests__/workflow-has-issues.error.test.ts
+++ b/packages/core/src/errors/__tests__/workflow-has-issues.error.test.ts
@@ -88,4 +88,23 @@ describe('WorkflowHasIssuesError', () => {
 			'\'A\': Parameter "x" is required. | \'B\': Parameter "y" is required.',
 		);
 	});
+
+	it('caps at 4 nodes and appends a hint for the rest', () => {
+		const issues: IWorkflowIssues = {
+			A: { parameters: { p: ['Parameter "p" is required.'] } },
+			B: { parameters: { p: ['Parameter "p" is required.'] } },
+			C: { parameters: { p: ['Parameter "p" is required.'] } },
+			D: { parameters: { p: ['Parameter "p" is required.'] } },
+			E: { parameters: { p: ['Parameter "p" is required.'] } },
+			F: { parameters: { p: ['Parameter "p" is required.'] } },
+		};
+
+		const message = new WorkflowHasIssuesError(issues).message;
+
+		expect(message).toContain("'A':");
+		expect(message).toContain("'D':");
+		expect(message).not.toContain("'E':");
+		expect(message).not.toContain("'F':");
+		expect(message).toContain('(2 other issues)');
+	});
 });

--- a/packages/core/src/errors/__tests__/workflow-has-issues.error.test.ts
+++ b/packages/core/src/errors/__tests__/workflow-has-issues.error.test.ts
@@ -45,6 +45,24 @@ describe('WorkflowHasIssuesError', () => {
 		);
 	});
 
+	it("joins a node's multiple issues with a space within the multi-node format", () => {
+		const issues: IWorkflowIssues = {
+			A: { parameters: { x: ['Parameter "x" is required.'] } },
+			B: {
+				parameters: { url: ['Parameter "URL" is required.'] },
+				credentials: { httpBasicAuth: ['Credentials for "httpBasicAuth" are not set.'] },
+			},
+		};
+
+		expect(new WorkflowHasIssuesError(issues, {}).message).toBe(
+			[
+				'2 nodes have issues:',
+				'- \'A\': Parameter "x" is required.',
+				'- \'B\': Parameter "URL" is required. Credentials for "httpBasicAuth" are not set.',
+			].join('\n'),
+		);
+	});
+
 	it('caps at 4 nodes and appends a hint for the rest', () => {
 		const issues: IWorkflowIssues = {
 			A: { parameters: { p: ['Parameter "p" is required.'] } },

--- a/packages/core/src/errors/__tests__/workflow-has-issues.error.test.ts
+++ b/packages/core/src/errors/__tests__/workflow-has-issues.error.test.ts
@@ -1,12 +1,11 @@
 import type { INode, IWorkflowIssues } from 'n8n-workflow';
 
-import { BASE_MESSAGE, WorkflowHasIssuesError } from '../workflow-has-issues.error';
+import { WorkflowHasIssuesError } from '../workflow-has-issues.error';
 
 describe('WorkflowHasIssuesError', () => {
-	it('formats a single node with multiple issue types', () => {
+	it('formats a single node with multiple issues as bulleted lines', () => {
 		const issues: IWorkflowIssues = {
 			'HTTP Request': {
-				execution: true,
 				parameters: { url: ['Parameter "URL" is required.'] },
 				typeUnknown: true,
 			},
@@ -23,18 +22,26 @@ describe('WorkflowHasIssuesError', () => {
 		};
 
 		expect(new WorkflowHasIssuesError(issues, nodes).message).toBe(
-			`${BASE_MESSAGE} Issues: 'HTTP Request': Execution Error. Parameter "URL" is required. Node Type "n8n-nodes-base.httpRequest" is not known.`,
+			[
+				"The 'HTTP Request' node has issues:",
+				'- Parameter "URL" is required.',
+				'- Node Type "n8n-nodes-base.httpRequest" is not known.',
+			].join('\n'),
 		);
 	});
 
-	it('joins multiple nodes with a pipe separator', () => {
+	it('lists each node as its own bullet when multiple nodes have issues', () => {
 		const issues: IWorkflowIssues = {
 			A: { parameters: { x: ['Parameter "x" is required.'] } },
 			B: { parameters: { y: ['Parameter "y" is required.'] } },
 		};
 
 		expect(new WorkflowHasIssuesError(issues, {}).message).toBe(
-			`${BASE_MESSAGE} Issues: 'A': Parameter "x" is required. | 'B': Parameter "y" is required.`,
+			[
+				'2 nodes have issues:',
+				'- \'A\': Parameter "x" is required.',
+				'- \'B\': Parameter "y" is required.',
+			].join('\n'),
 		);
 	});
 
@@ -49,7 +56,14 @@ describe('WorkflowHasIssuesError', () => {
 		};
 
 		expect(new WorkflowHasIssuesError(issues, {}).message).toBe(
-			`${BASE_MESSAGE} Issues: 'A': Parameter "p" is required. | 'B': Parameter "p" is required. | 'C': Parameter "p" is required. | 'D': Parameter "p" is required. | (2 more)`,
+			[
+				'6 nodes have issues:',
+				'- \'A\': Parameter "p" is required.',
+				'- \'B\': Parameter "p" is required.',
+				'- \'C\': Parameter "p" is required.',
+				'- \'D\': Parameter "p" is required.',
+				'- (2 more)',
+			].join('\n'),
 		);
 	});
 });

--- a/packages/core/src/errors/__tests__/workflow-has-issues.error.test.ts
+++ b/packages/core/src/errors/__tests__/workflow-has-issues.error.test.ts
@@ -1,0 +1,91 @@
+import type { INode, IWorkflowIssues } from 'n8n-workflow';
+
+import { WorkflowHasIssuesError } from '../workflow-has-issues.error';
+
+describe('WorkflowHasIssuesError', () => {
+	const baseMessage =
+		'The workflow has issues and cannot be executed for that reason. Please fix them first.';
+
+	it('uses the base message when no issues are provided', () => {
+		expect(new WorkflowHasIssuesError().message).toBe(baseMessage);
+	});
+
+	it('uses the base message when the issues map is empty', () => {
+		expect(new WorkflowHasIssuesError({}).message).toBe(baseMessage);
+	});
+
+	it('includes parameter and credential issues with node names', () => {
+		const issues: IWorkflowIssues = {
+			'HTTP Request': {
+				credentials: { httpBasicAuth: ['Credentials for "httpBasicAuth" are not set.'] },
+			},
+			Set: {
+				parameters: { value: ['Parameter "value" is required.'] },
+			},
+		};
+
+		const message = new WorkflowHasIssuesError(issues).message;
+
+		expect(message).toContain(baseMessage);
+		expect(message).toContain('\'HTTP Request\': Credentials for "httpBasicAuth" are not set.');
+		expect(message).toContain('\'Set\': Parameter "value" is required.');
+	});
+
+	it('includes the node type in the typeUnknown message when nodes are provided', () => {
+		const issues: IWorkflowIssues = {
+			Custom: { typeUnknown: true },
+		};
+		const nodes: Record<string, INode> = {
+			Custom: {
+				id: '1',
+				name: 'Custom',
+				type: 'community.custom',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			},
+		};
+
+		expect(new WorkflowHasIssuesError(issues, nodes).message).toContain(
+			'\'Custom\': Node Type "community.custom" is not known.',
+		);
+	});
+
+	it('falls back to a generic typeUnknown message when the node is missing', () => {
+		const issues: IWorkflowIssues = {
+			Custom: { typeUnknown: true },
+		};
+
+		expect(new WorkflowHasIssuesError(issues).message).toContain(
+			"'Custom': Node Type is not known.",
+		);
+	});
+
+	it('flattens execution, parameters, credentials, and input issues for one node', () => {
+		const issues: IWorkflowIssues = {
+			Multi: {
+				execution: true,
+				parameters: { foo: ['Parameter "foo" is required.'] },
+				credentials: { api: ['API credentials missing.'] },
+				input: { in: ['Input is invalid.'] },
+			},
+		};
+
+		const message = new WorkflowHasIssuesError(issues).message;
+
+		expect(message).toContain(
+			'\'Multi\': Execution Error.; Parameter "foo" is required.; API credentials missing.; Input is invalid.',
+		);
+	});
+
+	it('joins multiple nodes with a separator', () => {
+		const issues: IWorkflowIssues = {
+			A: { parameters: { x: ['Parameter "x" is required.'] } },
+			B: { parameters: { y: ['Parameter "y" is required.'] } },
+		};
+
+		expect(new WorkflowHasIssuesError(issues).message).toContain(
+			'\'A\': Parameter "x" is required. | \'B\': Parameter "y" is required.',
+		);
+	});
+});

--- a/packages/core/src/errors/workflow-has-issues.error.ts
+++ b/packages/core/src/errors/workflow-has-issues.error.ts
@@ -1,64 +1,31 @@
-import type { INode, INodeIssues, IWorkflowIssues } from 'n8n-workflow';
-import { WorkflowOperationError } from 'n8n-workflow';
+import type { INode, IWorkflowIssues } from 'n8n-workflow';
+import { nodeIssuesToString, WorkflowOperationError } from 'n8n-workflow';
 
-const BASE_MESSAGE =
+export const BASE_MESSAGE =
 	'The workflow has issues and cannot be executed for that reason. Please fix them first.';
-
-const OBJECT_ISSUE_PROPERTIES = ['parameters', 'credentials', 'input'] as const;
 
 const MAX_NODES_IN_MESSAGE = 4;
 
-function nodeIssuesToMessages(issues: INodeIssues, node: INode | undefined): string[] {
-	const messages: string[] = [];
-
-	if (issues.execution !== undefined) {
-		messages.push('Execution Error.');
-	}
-
-	for (const propertyName of OBJECT_ISSUE_PROPERTIES) {
-		const propertyIssues = issues[propertyName];
-		if (propertyIssues === undefined || typeof propertyIssues === 'boolean') continue;
-
-		for (const parameterName of Object.keys(propertyIssues)) {
-			for (const issueText of propertyIssues[parameterName]) {
-				messages.push(issueText);
-			}
-		}
-	}
-
-	if (issues.typeUnknown !== undefined) {
-		messages.push(
-			node !== undefined ? `Node Type "${node.type}" is not known.` : 'Node Type is not known.',
-		);
-	}
-
-	return messages;
-}
-
 function formatWorkflowIssues(
 	workflowIssues: IWorkflowIssues,
-	nodes: Record<string, INode> | undefined,
+	nodes: Record<string, INode>,
 ): string {
 	const entries = Object.entries(workflowIssues);
-	const shown = entries.slice(0, MAX_NODES_IN_MESSAGE).map(([nodeName, nodeIssues]) => {
-		const messages = nodeIssuesToMessages(nodeIssues, nodes?.[nodeName]);
-		return `'${nodeName}': ${messages.join('; ')}`;
+	const segments = entries.slice(0, MAX_NODES_IN_MESSAGE).map(([nodeName, nodeIssues]) => {
+		const messages = nodeIssuesToString(nodeIssues, nodes[nodeName]);
+		return `'${nodeName}': ${messages.join(' ')}`;
 	});
 
-	const remaining = entries.length - shown.length;
+	const remaining = entries.length - segments.length;
 	if (remaining > 0) {
-		shown.push(`(${remaining} other issues)`);
+		segments.push(`(${remaining} more)`);
 	}
 
-	return shown.join(' | ');
+	return segments.join(' | ');
 }
 
 export class WorkflowHasIssuesError extends WorkflowOperationError {
-	constructor(workflowIssues?: IWorkflowIssues, nodes?: Record<string, INode>) {
-		let message = BASE_MESSAGE;
-		if (workflowIssues && Object.keys(workflowIssues).length > 0) {
-			message = `${BASE_MESSAGE} Issues: ${formatWorkflowIssues(workflowIssues, nodes)}`;
-		}
-		super(message);
+	constructor(workflowIssues: IWorkflowIssues, nodes: Record<string, INode>) {
+		super(`${BASE_MESSAGE} Issues: ${formatWorkflowIssues(workflowIssues, nodes)}`);
 	}
 }

--- a/packages/core/src/errors/workflow-has-issues.error.ts
+++ b/packages/core/src/errors/workflow-has-issues.error.ts
@@ -6,6 +6,8 @@ const BASE_MESSAGE =
 
 const OBJECT_ISSUE_PROPERTIES = ['parameters', 'credentials', 'input'] as const;
 
+const MAX_NODES_IN_MESSAGE = 4;
+
 function nodeIssuesToMessages(issues: INodeIssues, node: INode | undefined): string[] {
 	const messages: string[] = [];
 
@@ -37,12 +39,18 @@ function formatWorkflowIssues(
 	workflowIssues: IWorkflowIssues,
 	nodes: Record<string, INode> | undefined,
 ): string {
-	return Object.entries(workflowIssues)
-		.map(([nodeName, nodeIssues]) => {
-			const messages = nodeIssuesToMessages(nodeIssues, nodes?.[nodeName]);
-			return `'${nodeName}': ${messages.join('; ')}`;
-		})
-		.join(' | ');
+	const entries = Object.entries(workflowIssues);
+	const shown = entries.slice(0, MAX_NODES_IN_MESSAGE).map(([nodeName, nodeIssues]) => {
+		const messages = nodeIssuesToMessages(nodeIssues, nodes?.[nodeName]);
+		return `'${nodeName}': ${messages.join('; ')}`;
+	});
+
+	const remaining = entries.length - shown.length;
+	if (remaining > 0) {
+		shown.push(`(${remaining} other issues)`);
+	}
+
+	return shown.join(' | ');
 }
 
 export class WorkflowHasIssuesError extends WorkflowOperationError {

--- a/packages/core/src/errors/workflow-has-issues.error.ts
+++ b/packages/core/src/errors/workflow-has-issues.error.ts
@@ -1,31 +1,43 @@
 import type { INode, IWorkflowIssues } from 'n8n-workflow';
 import { nodeIssuesToString, WorkflowOperationError } from 'n8n-workflow';
 
-export const BASE_MESSAGE =
-	'The workflow has issues and cannot be executed for that reason. Please fix them first.';
-
 const MAX_NODES_IN_MESSAGE = 4;
 
-function formatWorkflowIssues(
+function formatSingleNode(
+	nodeName: string,
+	issues: NonNullable<IWorkflowIssues[string]>,
+	node: INode | undefined,
+): string {
+	const messages = nodeIssuesToString(issues, node);
+	const bullets = messages.map((m) => `- ${m}`).join('\n');
+	return `The '${nodeName}' node has issues:\n${bullets}`;
+}
+
+function formatMultipleNodes(
 	workflowIssues: IWorkflowIssues,
 	nodes: Record<string, INode>,
 ): string {
 	const entries = Object.entries(workflowIssues);
-	const segments = entries.slice(0, MAX_NODES_IN_MESSAGE).map(([nodeName, nodeIssues]) => {
-		const messages = nodeIssuesToString(nodeIssues, nodes[nodeName]);
-		return `'${nodeName}': ${messages.join(' ')}`;
+	const bullets = entries.slice(0, MAX_NODES_IN_MESSAGE).map(([nodeName, issues]) => {
+		const messages = nodeIssuesToString(issues, nodes[nodeName]);
+		return `- '${nodeName}': ${messages.join(' ')}`;
 	});
 
-	const remaining = entries.length - segments.length;
+	const remaining = entries.length - bullets.length;
 	if (remaining > 0) {
-		segments.push(`(${remaining} more)`);
+		bullets.push(`- (${remaining} more)`);
 	}
 
-	return segments.join(' | ');
+	return `${entries.length} nodes have issues:\n${bullets.join('\n')}`;
 }
 
 export class WorkflowHasIssuesError extends WorkflowOperationError {
 	constructor(workflowIssues: IWorkflowIssues, nodes: Record<string, INode>) {
-		super(`${BASE_MESSAGE} Issues: ${formatWorkflowIssues(workflowIssues, nodes)}`);
+		const entries = Object.entries(workflowIssues);
+		const message =
+			entries.length === 1
+				? formatSingleNode(entries[0][0], entries[0][1], nodes[entries[0][0]])
+				: formatMultipleNodes(workflowIssues, nodes);
+		super(message);
 	}
 }

--- a/packages/core/src/errors/workflow-has-issues.error.ts
+++ b/packages/core/src/errors/workflow-has-issues.error.ts
@@ -1,7 +1,56 @@
+import type { INode, INodeIssues, IWorkflowIssues } from 'n8n-workflow';
 import { WorkflowOperationError } from 'n8n-workflow';
 
+const BASE_MESSAGE =
+	'The workflow has issues and cannot be executed for that reason. Please fix them first.';
+
+const OBJECT_ISSUE_PROPERTIES = ['parameters', 'credentials', 'input'] as const;
+
+function nodeIssuesToMessages(issues: INodeIssues, node: INode | undefined): string[] {
+	const messages: string[] = [];
+
+	if (issues.execution !== undefined) {
+		messages.push('Execution Error.');
+	}
+
+	for (const propertyName of OBJECT_ISSUE_PROPERTIES) {
+		const propertyIssues = issues[propertyName];
+		if (propertyIssues === undefined || typeof propertyIssues === 'boolean') continue;
+
+		for (const parameterName of Object.keys(propertyIssues)) {
+			for (const issueText of propertyIssues[parameterName]) {
+				messages.push(issueText);
+			}
+		}
+	}
+
+	if (issues.typeUnknown !== undefined) {
+		messages.push(
+			node !== undefined ? `Node Type "${node.type}" is not known.` : 'Node Type is not known.',
+		);
+	}
+
+	return messages;
+}
+
+function formatWorkflowIssues(
+	workflowIssues: IWorkflowIssues,
+	nodes: Record<string, INode> | undefined,
+): string {
+	return Object.entries(workflowIssues)
+		.map(([nodeName, nodeIssues]) => {
+			const messages = nodeIssuesToMessages(nodeIssues, nodes?.[nodeName]);
+			return `'${nodeName}': ${messages.join('; ')}`;
+		})
+		.join(' | ');
+}
+
 export class WorkflowHasIssuesError extends WorkflowOperationError {
-	constructor() {
-		super('The workflow has issues and cannot be executed for that reason. Please fix them first.');
+	constructor(workflowIssues?: IWorkflowIssues, nodes?: Record<string, INode>) {
+		let message = BASE_MESSAGE;
+		if (workflowIssues && Object.keys(workflowIssues).length > 0) {
+			message = `${BASE_MESSAGE} Issues: ${formatWorkflowIssues(workflowIssues, nodes)}`;
+		}
+		super(message);
 	}
 }

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
@@ -256,7 +256,7 @@ describe('processRunExecutionData', () => {
 
 			expect(execution).toThrow(ApplicationError);
 			expect(execution).toThrow(
-				'The workflow has issues and cannot be executed for that reason. Please fix them first.',
+				/The workflow has issues and cannot be executed for that reason\. Please fix them first\. Issues: 'node': Parameter "Required Text" is required\./,
 			);
 		});
 

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
@@ -256,7 +256,7 @@ describe('processRunExecutionData', () => {
 
 			expect(execution).toThrow(ApplicationError);
 			expect(execution).toThrow(
-				/^The workflow has issues and cannot be executed for that reason\. Please fix them first\. Issues: 'node': Parameter "Required Text" is required\.$/,
+				/^The 'node' node has issues:\n- Parameter "Required Text" is required\.$/,
 			);
 		});
 

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
@@ -256,7 +256,7 @@ describe('processRunExecutionData', () => {
 
 			expect(execution).toThrow(ApplicationError);
 			expect(execution).toThrow(
-				/The workflow has issues and cannot be executed for that reason\. Please fix them first\. Issues: 'node': Parameter "Required Text" is required\./,
+				/^The workflow has issues and cannot be executed for that reason\. Please fix them first\. Issues: 'node': Parameter "Required Text" is required\.$/,
 			);
 		});
 

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1436,7 +1436,7 @@ export class WorkflowExecute {
 			pinDataNodeNames,
 		});
 		if (workflowIssues !== null) {
-			throw new WorkflowHasIssuesError();
+			throw new WorkflowHasIssuesError(workflowIssues, workflow.nodes);
 		}
 	}
 

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2575,6 +2575,7 @@
 	"pushConnection.executionError": "There was a problem executing the workflow{error}",
 	"pushConnection.executionError.openNode": "Open errored node",
 	"pushConnection.executionError.details": "<br /><strong>{details}</strong>",
+	"pushConnection.workflowHasIssues.title": "Workflow execution cannot start",
 	"prompts.npsSurvey.recommendationQuestion": "How likely are you to recommend n8n to a friend or colleague?",
 	"prompts.npsSurvey.greatFeedbackTitle": "Great to hear! Can we reach out to see how we can make n8n even better for you?",
 	"prompts.npsSurvey.defaultFeedbackTitle": "Thanks for your feedback! We'd love to understand how we can improve. Can we reach out?",

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
@@ -6,7 +6,12 @@ import {
 	PLACEHOLDER_FILLED_AT_EXECUTION_TIME,
 } from '@/app/constants';
 
-import { NodeHelpers, NodeConnectionTypes, MANUAL_TRIGGER_NODE_TYPES } from 'n8n-workflow';
+import {
+	NodeHelpers,
+	NodeConnectionTypes,
+	MANUAL_TRIGGER_NODE_TYPES,
+	nodeIssuesToString,
+} from 'n8n-workflow';
 import type {
 	INodeProperties,
 	INodeCredentialDescription,
@@ -1053,44 +1058,6 @@ export function useNodeHelpers() {
 		}
 
 		return hints;
-	}
-
-	/**
-	 * Returns the issues of the node as string
-	 *
-	 * @param {INodeIssues} issues The issues of the node
-	 * @param {INode} node The node
-	 */
-	function nodeIssuesToString(issues: INodeIssues, node?: INode): string[] {
-		const nodeIssues = [];
-
-		if (issues.execution !== undefined) {
-			nodeIssues.push('Execution Error.');
-		}
-
-		const objectProperties = ['parameters', 'credentials', 'input'];
-
-		let issueText: string;
-		let parameterName: string;
-		for (const propertyName of objectProperties) {
-			if (issues[propertyName] !== undefined) {
-				for (parameterName of Object.keys(issues[propertyName] as object)) {
-					for (issueText of (issues[propertyName] as INodeIssueObjectProperty)[parameterName]) {
-						nodeIssues.push(issueText);
-					}
-				}
-			}
-		}
-
-		if (issues.typeUnknown !== undefined) {
-			if (node !== undefined) {
-				nodeIssues.push(`Node Type "${node.type}" is not known.`);
-			} else {
-				nodeIssues.push('Node Type is not known.');
-			}
-		}
-
-		return nodeIssues;
 	}
 
 	function getDefaultNodeName(node: AddedNode | INode) {

--- a/packages/frontend/editor-ui/src/features/execution/executions/executions.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/executions.utils.test.ts
@@ -650,6 +650,23 @@ describe('getExecutionErrorToastConfiguration', () => {
 		});
 	});
 
+	it('returns config for WorkflowHasIssuesError with multi-line message preserved', () => {
+		const result = getExecutionErrorToastConfiguration({
+			error: executionErrorFactory({
+				name: 'WorkflowHasIssuesError',
+				message: 'The \'HTTP Request\' node has issues:\n- Parameter "URL" is required.',
+			}),
+			lastNodeExecuted: 'HTTP Request',
+		});
+
+		expect(result.title).toBe('pushConnection.workflowHasIssues.title');
+		const message = result.message as VNode;
+		expect(message.props?.style).toBe('white-space: pre-line');
+		expect(message.children).toBe(
+			'The \'HTTP Request\' node has issues:\n- Parameter "URL" is required.',
+		);
+	});
+
 	it('returns config for configuration-node error with node name', () => {
 		const result = getExecutionErrorToastConfiguration({
 			error: executionErrorFactory({

--- a/packages/frontend/editor-ui/src/features/execution/executions/executions.utils.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/executions.utils.ts
@@ -368,6 +368,13 @@ export function getExecutionErrorToastConfiguration({
 }) {
 	const message = getExecutionErrorMessage({ error, lastNodeExecuted });
 
+	if (error.name === 'WorkflowHasIssuesError') {
+		return {
+			title: i18n.baseText('pushConnection.workflowHasIssues.title'),
+			message: h('div', { style: 'white-space: pre-line' }, error.message),
+		};
+	}
+
 	if (error.name === 'SubworkflowOperationError') {
 		return { title: error.message, message: error.description ?? '' };
 	}

--- a/packages/workflow/src/node-helpers.ts
+++ b/packages/workflow/src/node-helpers.ts
@@ -1271,6 +1271,33 @@ export function getNodeParametersIssues(
 	return foundIssues;
 }
 
+/**
+ * Returns the node's issues as a flat list of human-readable strings,
+ * covering execution errors, parameter/credential/input issues, and unknown node types.
+ */
+export function nodeIssuesToString(issues: INodeIssues, node?: INode): string[] {
+	const messages: string[] = [];
+
+	if (issues.execution !== undefined) {
+		messages.push('Execution Error.');
+	}
+
+	for (const propertyIssues of [issues.parameters, issues.credentials, issues.input]) {
+		if (propertyIssues === undefined) continue;
+		for (const parameterName of Object.keys(propertyIssues)) {
+			messages.push(...propertyIssues[parameterName]);
+		}
+	}
+
+	if (issues.typeUnknown !== undefined) {
+		messages.push(
+			node !== undefined ? `Node Type "${node.type}" is not known.` : 'Node Type is not known.',
+		);
+	}
+
+	return messages;
+}
+
 /*
  * Validates resource locator node parameters based on validation ruled defined in each parameter mode
  */

--- a/packages/workflow/test/node-helpers.test.ts
+++ b/packages/workflow/test/node-helpers.test.ts
@@ -26,6 +26,7 @@ import {
 	isToolType,
 	isHitlToolType,
 	getNodeOutputs,
+	nodeIssuesToString,
 } from '../src/node-helpers';
 import type { Workflow } from '../src/workflow';
 import { mock } from 'vitest-mock-extended';
@@ -4392,6 +4393,47 @@ describe('NodeHelpers', () => {
 					testDateTime: ['Parameter "Date Time" is required.'],
 				},
 			});
+		});
+	});
+
+	describe('nodeIssuesToString', () => {
+		it('returns an empty list when no issues are set', () => {
+			expect(nodeIssuesToString({})).toEqual([]);
+		});
+
+		it('flattens every issue type in order (execution, parameters, credentials, input, typeUnknown)', () => {
+			const issues: INodeIssues = {
+				execution: true,
+				parameters: {
+					url: ['Parameter "URL" is required.', 'Parameter "URL" must be a string.'],
+					method: ['Parameter "Method" is required.'],
+				},
+				credentials: { api: ['Credentials for "api" are not set.'] },
+				input: { main: ['No node connected to required input "main"'] },
+				typeUnknown: true,
+			};
+			const node: INode = {
+				id: '1',
+				name: 'HTTP Request',
+				type: 'n8n-nodes-base.httpRequest',
+				typeVersion: 4.2,
+				position: [0, 0],
+				parameters: {},
+			};
+
+			expect(nodeIssuesToString(issues, node)).toEqual([
+				'Execution Error.',
+				'Parameter "URL" is required.',
+				'Parameter "URL" must be a string.',
+				'Parameter "Method" is required.',
+				'Credentials for "api" are not set.',
+				'No node connected to required input "main"',
+				'Node Type "n8n-nodes-base.httpRequest" is not known.',
+			]);
+		});
+
+		it('falls back to a generic typeUnknown message when no node is passed', () => {
+			expect(nodeIssuesToString({ typeUnknown: true })).toEqual(['Node Type is not known.']);
 		});
 	});
 


### PR DESCRIPTION
## Summary

When the workflow execution engine refuses to start a run due to validation issues (missing required parameters, unknown node types), `WorkflowHasIssuesError` now appends a per-node summary to its message instead of discarding the detail. Production and manual/test executions now report which node failed validation and why.

**Before**
```
WorkflowHasIssuesError: The workflow has issues and cannot be executed for that reason. Please fix them first.
```

**After**
```
Workflow execution cannot start
5 nodes have issues:
- 'Airtable E': Parameter "Base" is required. Parameter "Table" is required.
- 'Airtable D': Parameter "Base" is required. Parameter "Table" is required.
- 'Airtable C': Parameter "Base" is required. Parameter "Table" is required.
- 'Airtable B': Parameter "Base" is required. Parameter "Table" is required.
- (1 more)
```

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/CAT-3189
- closes #29608 (community report routed via CAT-3002)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI