### PR TITLE
chore: Quarantine submitted-workflow mocked credential setup test (no-changelog)

### DIFF
--- a/.github/test-metrics/quarantine.json
+++ b/.github/test-metrics/quarantine.json
@@ -1,5 +1,5 @@
 {
-  "updatedAt": "2026-05-14T15:02:35Z",
+  "updatedAt": "2026-05-22T00:00:00Z",
   "source": "currents",
   "projectId": "LRxcNt",
   "quarantined": [
@@ -31,6 +31,7 @@
     "should not send workflow context if nothing changed",
     "should open executions tab",
     "should populate logs as manual execution progresses",
+    "should preserve a submitted workflow when mocked credential verification needs setup",
     "should preserve resource mapper values when navigating between connected nodes via floating nodes",
     "should render runItems for sub-nodes and allow switching between them",
     "should reset filter and remove badge",


### PR DESCRIPTION
## Summary

- Adds the `should preserve a submitted workflow when mocked credential verification needs setup` Playwright test to `.github/test-metrics/quarantine.json` while a flake is investigated.
- Bumps `updatedAt` to reflect the change.

## Test plan
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] JSON remains valid and alphabetically ordered alongside neighbouring entries.