### PR TITLE
refactor(core): Scope observation memory by agent thread

### DIFF
--- a/packages/@n8n/agents/src/__tests__/integration/memory/memory-episodic.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/memory/memory-episodic.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, expect, it } from 'vitest';
 
-import { Agent, createObservationLogThreadScopeId, Memory } from '../../../index';
+import { Agent, Memory } from '../../../index';
 import {
 	createInMemoryAgentMemory,
 	describeIf,
@@ -244,8 +244,7 @@ describe('episodic memory integration', () => {
 		await agent.close();
 
 		const observations = await memory.getActiveObservationLog({
-			scopeKind: 'thread',
-			scopeId: createObservationLogThreadScopeId(threadId, resourceId),
+			observationScopeId: threadId,
 		});
 		expect(observations.length).toBeGreaterThan(0);
 

--- a/packages/@n8n/agents/src/index.ts
+++ b/packages/@n8n/agents/src/index.ts
@@ -74,7 +74,6 @@ export type {
 	AttributeValue,
 	ObservationCursor,
 	ObservationalMemoryConfig,
-	ScopeKind,
 	BuiltObservationLogStore,
 	BuiltObservationLogTaskLockStore,
 	NewObservationLogEntry,
@@ -85,7 +84,6 @@ export type {
 	ObservationLogReflection,
 	ObservationLogReflectionResult,
 	ObservationLogScope,
-	ObservationLogScopeKind,
 	ObservationLogStatus,
 	ObservationLogTaskKind,
 	ObservationLogTaskLockHandle,
@@ -95,8 +93,6 @@ export type { ProviderOptions } from '@ai-sdk/provider-utils';
 export { AgentEvent } from './types';
 export type { AgentEventData, AgentEventHandler } from './types';
 export {
-	createObservationLogThreadScopeId,
-	createObservationLogThreadScopePrefix,
 	estimateObservationTokens,
 	OBSERVATION_LOG_MARKERS,
 	OBSERVATION_LOG_STATUSES,

--- a/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
@@ -6,7 +6,6 @@ import { AgentEvent } from '../../types/runtime/event';
 import type { AgentEventData } from '../../types/runtime/event';
 import type { StreamChunk } from '../../types/sdk/agent';
 import type { ContentToolCall, Message } from '../../types/sdk/message';
-import { createObservationLogThreadScopeId } from '../../types/sdk/observation-log';
 import type { BuiltTool, InterruptibleToolContext } from '../../types/sdk/tool';
 import type { BuiltTelemetry } from '../../types/telemetry';
 import { AgentRuntime } from '../agent-runtime';
@@ -2561,8 +2560,7 @@ describe('AgentRuntime — observation log jobs', () => {
 		await runtime.dispose();
 
 		const observations = await memory.getActiveObservationLog({
-			scopeKind: 'thread',
-			scopeId: createObservationLogThreadScopeId('thread-1', 'resource-1'),
+			observationScopeId: 'thread-1',
 		});
 		expect(observations).toMatchObject([
 			{
@@ -2571,10 +2569,7 @@ describe('AgentRuntime — observation log jobs', () => {
 				parentId: null,
 			},
 		]);
-		const cursor = await memory.getCursor(
-			'thread',
-			createObservationLogThreadScopeId('thread-1', 'resource-1'),
-		);
+		const cursor = await memory.getCursor('thread-1');
 		expect(typeof cursor?.lastObservedMessageId).toBe('string');
 	});
 
@@ -2604,8 +2599,7 @@ describe('AgentRuntime — observation log jobs', () => {
 		await runtime.dispose();
 
 		const observations = await memory.getActiveObservationLog({
-			scopeKind: 'thread',
-			scopeId: createObservationLogThreadScopeId('thread-1', 'resource-1'),
+			observationScopeId: 'thread-1',
 		});
 		expect(observations).toMatchObject([
 			{
@@ -2667,8 +2661,7 @@ describe('AgentRuntime — observation log jobs', () => {
 		expect(entries).toHaveLength(1);
 		expect(entries[0].content).toBe('User chose Postgres for memory storage.');
 		const cursor = await memory.episodic.getCursor({
-			scopeKind: 'thread',
-			scopeId: createObservationLogThreadScopeId('thread-1', 'resource-1'),
+			observationScopeId: 'thread-1',
 		});
 		expect(typeof cursor?.lastIndexedObservationId).toBe('string');
 		const firstLockCall = episodicLockSpy.mock.calls.at(0);
@@ -2677,7 +2670,7 @@ describe('AgentRuntime — observation log jobs', () => {
 		expect(lockedResourceId).toBe('resource-1');
 		expect(typeof lockOptions.holderId).toBe('string');
 		expect(typeof lockOptions.ttlMs).toBe('number');
-		const observationLockTaskKinds = observationLockSpy.mock.calls.map((call) => String(call[2]));
+		const observationLockTaskKinds = observationLockSpy.mock.calls.map((call) => String(call[1]));
 		expect(observationLockTaskKinds).not.toContain('episodic-indexer');
 	});
 
@@ -2685,8 +2678,7 @@ describe('AgentRuntime — observation log jobs', () => {
 		generateText.mockResolvedValue(makeGenerateSuccess('Plain response'));
 		const memory = new InMemoryMemory();
 		const observationScope = {
-			scopeKind: 'thread' as const,
-			scopeId: createObservationLogThreadScopeId('thread-1', 'resource-1'),
+			observationScopeId: 'thread-1',
 		};
 		const [observation] = await memory.appendObservationLogEntries([
 			{
@@ -2811,14 +2803,13 @@ describe('AgentRuntime — observation log jobs', () => {
 
 		expect(
 			await memory.getActiveObservationLog({
-				scopeKind: 'thread',
-				scopeId: 'thread-1',
+				observationScopeId: 'thread-1',
 			}),
 		).toEqual([]);
-		expect(await memory.getCursor('thread', 'thread-1')).toBeNull();
+		expect(await memory.getCursor('thread-1')).toBeNull();
 	});
 
-	it('isolates history and observation-log memory by resource on shared threads', async () => {
+	it('keeps history resource-filtered while observation-log memory is thread-local', async () => {
 		generateText.mockResolvedValue(makeGenerateSuccess('Remembered response'));
 		const memory = new InMemoryMemory();
 		const runtime = new AgentRuntime({
@@ -2866,8 +2857,8 @@ describe('AgentRuntime — observation log jobs', () => {
 		>;
 		const [{ messages }] = generateTextMock.mock.calls[0];
 		const systemPrompt = messages[0].content;
+		expect(systemPrompt).toContain('Resource one memory.');
 		expect(systemPrompt).toContain('Resource two memory.');
-		expect(systemPrompt).not.toContain('Resource one memory.');
 		expect(JSON.stringify(messages)).toContain('remember resource-two preference');
 		expect(JSON.stringify(messages)).not.toContain('remember resource-one preference');
 

--- a/packages/@n8n/agents/src/runtime/__tests__/episodic-memory-defaults.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/episodic-memory-defaults.test.ts
@@ -73,15 +73,13 @@ describe('episodic memory defaults', () => {
 		const extractorPrompt = buildEpisodicMemoryExtractorPrompt({
 			scope: { resourceId: 'user-1' },
 			observationScope: {
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:user-1',
+				observationScopeId: 'thread-1',
 			},
 			now,
 			observations: [
 				{
 					id: 'obs-1',
-					scopeKind: 'thread',
-					scopeId: 'thread:thread-1:resource:user-1',
+					observationScopeId: 'thread-1',
 					marker: 'critical',
 					text: 'User switched memory store choice to Postgres.',
 					parentId: null,
@@ -138,8 +136,7 @@ describe('episodic memory defaults', () => {
 			createEpisodicMemoryExtractFn(fakeModel)({
 				scope: { resourceId: 'user-1' },
 				observationScope: {
-					scopeKind: 'thread',
-					scopeId: 'thread:thread-1:resource:user-1',
+					observationScopeId: 'thread-1',
 				},
 				now: new Date('2026-05-12T15:00:00.000Z'),
 				observations: [],

--- a/packages/@n8n/agents/src/runtime/__tests__/episodic-memory.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/episodic-memory.test.ts
@@ -292,8 +292,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		const memory = new InMemoryMemory();
 		const [observation] = await memory.appendObservationLogEntries([
 			{
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:user-1',
+				observationScopeId: 'thread-1',
 				marker: 'important',
 				text: 'User switched memory store to Postgres after ruling out SQLite for enterprise customers.',
 				createdAt: new Date('2026-05-12T10:00:00.000Z'),
@@ -319,7 +318,7 @@ describe('runEpisodicMemoryIndexer', () => {
 			memory,
 			config: { embedder: fakeEmbedder, extract },
 			scope: { resourceId: 'user-1' },
-			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+			observationScope: { observationScopeId: 'thread-1' },
 			threadId: 'thread-1',
 			now: new Date('2026-05-12T10:01:00.000Z'),
 		});
@@ -337,7 +336,7 @@ describe('runEpisodicMemoryIndexer', () => {
 				memory,
 				config: { embedder: fakeEmbedder, extract },
 				scope: { resourceId: 'user-1' },
-				observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+				observationScope: { observationScopeId: 'thread-1' },
 				threadId: 'thread-1',
 			}),
 		).resolves.toEqual({ status: 'skipped', reason: 'no-observations' });
@@ -347,8 +346,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		const memory = new InMemoryMemory();
 		const [observation] = await memory.appendObservationLogEntries([
 			{
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:user-1',
+				observationScopeId: 'thread-1',
 				marker: 'important',
 				text: 'User chose Postgres for cross-session memory.',
 				createdAt: new Date('2026-05-12T10:00:00.000Z'),
@@ -371,7 +369,7 @@ describe('runEpisodicMemoryIndexer', () => {
 				memory,
 				config: { embedder: fakeEmbedder, extract },
 				scope: { resourceId: 'user-1' },
-				observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+				observationScope: { observationScopeId: 'thread-1' },
 				threadId: 'thread-1',
 				now: new Date('2026-05-12T10:01:00.000Z'),
 			}),
@@ -382,8 +380,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		).resolves.toEqual([]);
 		await expect(
 			memory.episodic.getCursor({
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:user-1',
+				observationScopeId: 'thread-1',
 			}),
 		).resolves.toBeNull();
 	});
@@ -392,14 +389,12 @@ describe('runEpisodicMemoryIndexer', () => {
 		const memory = new InMemoryMemory();
 		const [decision, reason] = await memory.appendObservationLogEntries([
 			{
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:user-1',
+				observationScopeId: 'thread-1',
 				marker: 'critical',
 				text: 'User chose Postgres for the memory store.',
 			},
 			{
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:user-1',
+				observationScopeId: 'thread-1',
 				marker: 'important',
 				text: 'Enterprise customers will not run local storage.',
 			},
@@ -428,7 +423,7 @@ describe('runEpisodicMemoryIndexer', () => {
 			memory,
 			config: { embedder: fakeEmbedder, extract },
 			scope: { resourceId: 'user-1' },
-			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+			observationScope: { observationScopeId: 'thread-1' },
 			threadId: 'thread-1',
 		});
 
@@ -454,8 +449,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		const memory = new InMemoryMemory();
 		const [observation] = await memory.appendObservationLogEntries([
 			{
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:user-1',
+				observationScopeId: 'thread-1',
 				marker: 'critical',
 				text: 'User settled the Harborlight vendor intake pilot details.',
 			},
@@ -480,7 +474,7 @@ describe('runEpisodicMemoryIndexer', () => {
 			memory,
 			config: { embedder: fakeEmbedder, extract },
 			scope: { resourceId: 'user-1' },
-			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+			observationScope: { observationScopeId: 'thread-1' },
 			threadId: 'thread-1',
 		});
 
@@ -497,8 +491,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		const memory = new InMemoryMemory();
 		const [observation] = await memory.appendObservationLogEntries([
 			{
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:user-1',
+				observationScopeId: 'thread-1',
 				marker: 'important',
 				text: 'User investigated webhook retries.',
 			},
@@ -517,7 +510,7 @@ describe('runEpisodicMemoryIndexer', () => {
 			memory,
 			config: { embedder: fakeEmbedder, extract },
 			scope: { resourceId: 'user-1' },
-			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+			observationScope: { observationScopeId: 'thread-1' },
 			threadId: 'thread-1',
 		});
 
@@ -531,20 +524,17 @@ describe('runEpisodicMemoryIndexer', () => {
 		const memory = new InMemoryMemory();
 		const [request, toolResult, reply] = await memory.appendObservationLogEntries([
 			{
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:user-1',
+				observationScopeId: 'thread-1',
 				marker: 'important',
 				text: 'User wants to continue an earlier memory feature discussion and recover prior decisions.',
 			},
 			{
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:user-1',
+				observationScopeId: 'thread-1',
 				marker: 'info',
 				text: 'Agent queried memory; no entries were found.',
 			},
 			{
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:user-1',
+				observationScopeId: 'thread-1',
 				marker: 'completion',
 				text: 'Agent told user it could not reliably recover finalized decisions.',
 			},
@@ -577,7 +567,7 @@ describe('runEpisodicMemoryIndexer', () => {
 			memory,
 			config: { embedder: fakeEmbedder, extract },
 			scope: { resourceId: 'user-1' },
-			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+			observationScope: { observationScopeId: 'thread-1' },
 			threadId: 'thread-1',
 		});
 
@@ -596,8 +586,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		});
 		const [observation] = await memory.appendObservationLogEntries([
 			{
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:user-1',
+				observationScopeId: 'thread-1',
 				marker: 'critical',
 				text: 'User switched memory store choice to Postgres.',
 			},
@@ -622,7 +611,7 @@ describe('runEpisodicMemoryIndexer', () => {
 			memory,
 			config: { embedder: fakeEmbedder, extract },
 			scope: { resourceId: 'user-1' },
-			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+			observationScope: { observationScopeId: 'thread-1' },
 			threadId: 'thread-1',
 		});
 
@@ -647,8 +636,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		);
 		const [observation] = await memory.appendObservationLogEntries([
 			{
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:user-1',
+				observationScopeId: 'thread-1',
 				marker: 'critical',
 				text: 'User switched memory store choice to Postgres after enterprise constraints.',
 			},
@@ -692,7 +680,7 @@ describe('runEpisodicMemoryIndexer', () => {
 			memory,
 			config: { embedder: fakeEmbedder, extract, reflect },
 			scope: { resourceId: 'user-1' },
-			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+			observationScope: { observationScopeId: 'thread-1' },
 			threadId: 'thread-1',
 		});
 
@@ -752,8 +740,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		);
 		const [observation] = await memory.appendObservationLogEntries([
 			{
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:user-1',
+				observationScopeId: 'thread-1',
 				marker: 'critical',
 				text: 'User added final Harborlight ownership details.',
 			},
@@ -788,7 +775,7 @@ describe('runEpisodicMemoryIndexer', () => {
 			memory,
 			config: { embedder: fakeEmbedder, extract, reflect },
 			scope: { resourceId: 'user-1' },
-			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+			observationScope: { observationScopeId: 'thread-1' },
 			threadId: 'thread-1',
 		});
 
@@ -810,8 +797,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		});
 		const [observation] = await memory.appendObservationLogEntries([
 			{
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:user-1',
+				observationScopeId: 'thread-1',
 				marker: 'important',
 				text: 'User confirmed the Postgres memory store decision.',
 			},
@@ -837,7 +823,7 @@ describe('runEpisodicMemoryIndexer', () => {
 			memory,
 			config: { embedder: fakeEmbedder, extract, reflect },
 			scope: { resourceId: 'user-1' },
-			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+			observationScope: { observationScopeId: 'thread-1' },
 			threadId: 'thread-1',
 		});
 
@@ -864,8 +850,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		});
 		const [observation] = await memory.appendObservationLogEntries([
 			{
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:user-1',
+				observationScopeId: 'thread-1',
 				marker: 'important',
 				text: 'Southeast invoice requests are delayed before routing starts.',
 			},
@@ -897,7 +882,7 @@ describe('runEpisodicMemoryIndexer', () => {
 			memory,
 			config: { embedder: fakeEmbedder, extract, reflect },
 			scope: { resourceId: 'user-1' },
-			observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+			observationScope: { observationScopeId: 'thread-1' },
 			threadId: 'thread-1',
 		});
 
@@ -916,8 +901,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		const memory = new InMemoryMemory();
 		const [observation] = await memory.appendObservationLogEntries([
 			{
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:user-1',
+				observationScopeId: 'thread-1',
 				marker: 'important',
 				text: 'User confirmed the Postgres memory store decision.',
 			},
@@ -948,7 +932,7 @@ describe('runEpisodicMemoryIndexer', () => {
 				memory,
 				config: { embedder: fakeEmbedder, extract, reflect },
 				scope: { resourceId: 'user-1' },
-				observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+				observationScope: { observationScopeId: 'thread-1' },
 				threadId: 'thread-1',
 			}),
 		).rejects.toThrow('reflect failed');
@@ -960,8 +944,7 @@ describe('runEpisodicMemoryIndexer', () => {
 		).resolves.toHaveLength(1);
 		await expect(
 			memory.episodic.getCursor({
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:user-1',
+				observationScopeId: 'thread-1',
 			}),
 		).resolves.toBeNull();
 
@@ -970,15 +953,14 @@ describe('runEpisodicMemoryIndexer', () => {
 				memory,
 				config: { embedder: fakeEmbedder, extract, reflect },
 				scope: { resourceId: 'user-1' },
-				observationScope: { scopeKind: 'thread', scopeId: 'thread:thread-1:resource:user-1' },
+				observationScope: { observationScopeId: 'thread-1' },
 				threadId: 'thread-1',
 			}),
 		).resolves.toMatchObject({ status: 'ran' });
 
 		await expect(
 			memory.episodic.getCursor({
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:user-1',
+				observationScopeId: 'thread-1',
 			}),
 		).resolves.toMatchObject({ lastIndexedObservationId: observation.id });
 	});

--- a/packages/@n8n/agents/src/runtime/__tests__/inmemory-messages.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/inmemory-messages.test.ts
@@ -85,12 +85,12 @@ describe('InMemoryMemory — message keyset reads', () => {
 
 		const all = await mem.getMessages('t-1');
 
-		const tail = await mem.getMessagesForScope('thread', 't-1', {
+		const tail = await mem.getMessagesForObservationScope('t-1', {
 			since: { sinceCreatedAt: all[0].createdAt, sinceMessageId: all[0].id },
 		});
 		expect(tail.map(textOf)).toEqual(['b', 'c']);
 
-		const empty = await mem.getMessagesForScope('thread', 't-1', {
+		const empty = await mem.getMessagesForObservationScope('t-1', {
 			since: { sinceCreatedAt: all[2].createdAt, sinceMessageId: all[2].id },
 		});
 		expect(empty).toEqual([]);
@@ -104,14 +104,14 @@ describe('InMemoryMemory — message keyset reads', () => {
 		await mem.saveMessages({ threadId: 't-1', resourceId: 'u-1', messages: [m1, m2] });
 
 		const [low, high] = [m1, m2].sort((a, b) => (a.id < b.id ? -1 : 1));
-		const tail = await mem.getMessagesForScope('thread', 't-1', {
+		const tail = await mem.getMessagesForObservationScope('t-1', {
 			since: { sinceCreatedAt: low.createdAt, sinceMessageId: low.id },
 		});
 		expect(tail).toHaveLength(1);
 		expect(tail[0].id).toBe(high.id);
 	});
 
-	it('filters observation-scope messages by resourceId when provided', async () => {
+	it('reads all messages in the observation source thread', async () => {
 		const mem = new InMemoryMemory();
 		await mem.saveMessages({
 			threadId: 't-1',
@@ -124,8 +124,9 @@ describe('InMemoryMemory — message keyset reads', () => {
 			messages: [makeMsg('user', 'two')],
 		});
 
-		const messages = await mem.getMessagesForScope('thread', 't-1', { resourceId: 'u-2' });
+		const messages = await mem.getMessagesForObservationScope('t-1');
 
-		expect(messages.map(textOf)).toEqual(['two']);
+		expect(messages.map(textOf)).toEqual(expect.arrayContaining(['one', 'two']));
+		expect(messages).toHaveLength(2);
 	});
 });

--- a/packages/@n8n/agents/src/runtime/__tests__/observation-log-observer.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/observation-log-observer.test.ts
@@ -41,8 +41,7 @@ describe('observation-log observer defaults', () => {
 
 	it('builds the default observer prompt from log tail and transcript delta', () => {
 		const prompt = buildObservationLogObserverPrompt({
-			scopeKind: 'thread',
-			scopeId: 'thread-1',
+			observationScopeId: 'thread-1',
 			now: new Date('2026-05-12T14:30:00.000Z'),
 			deltaMessages: [],
 			transcript: '[2026-05-12T14:29:00.000Z] user:\nRemember daily-report-prod.',
@@ -205,8 +204,7 @@ describe('runObservationLogObserver', () => {
 
 		const result = await runObservationLogObserver({
 			memory: store,
-			scopeKind: 'thread',
-			scopeId: 'thread-1',
+			observationScopeId: 'thread-1',
 			observerThresholdTokens: 999,
 			observationLogTailLimit: 20,
 			tokenCounter: () => 1,
@@ -215,7 +213,7 @@ describe('runObservationLogObserver', () => {
 
 		expect(result).toEqual({ status: 'skipped', reason: 'below-threshold', tokenCount: 1 });
 		expect(observe).not.toHaveBeenCalled();
-		expect(await store.getCursor('thread', 'thread-1')).toBeNull();
+		expect(await store.getCursor('thread-1')).toBeNull();
 	});
 
 	it('writes parsed observations and advances the cursor after observing', async () => {
@@ -229,8 +227,7 @@ describe('runObservationLogObserver', () => {
 
 		const result = await runObservationLogObserver({
 			memory: store,
-			scopeKind: 'thread',
-			scopeId: 'thread-1',
+			observationScopeId: 'thread-1',
 			observerThresholdTokens: 1,
 			observationLogTailLimit: 20,
 			tokenCounter: () => 10,
@@ -246,8 +243,7 @@ describe('runObservationLogObserver', () => {
 
 		expect(result).toMatchObject({ status: 'ran', observationsWritten: 2 });
 		const observations = await store.getActiveObservationLog({
-			scopeKind: 'thread',
-			scopeId: 'thread-1',
+			observationScopeId: 'thread-1',
 		});
 		expect(observations).toMatchObject([
 			{
@@ -261,7 +257,7 @@ describe('runObservationLogObserver', () => {
 				parentId: observations[0]?.id,
 			},
 		]);
-		expect(await store.getCursor('thread', 'thread-1')).toMatchObject({
+		expect(await store.getCursor('thread-1')).toMatchObject({
 			lastObservedMessageId: 'm1',
 		});
 	});

--- a/packages/@n8n/agents/src/runtime/__tests__/observation-log-reflector.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/observation-log-reflector.test.ts
@@ -15,8 +15,7 @@ import {
 function observation(overrides: Partial<ObservationLogEntry> = {}): ObservationLogEntry {
 	return {
 		id: overrides.id ?? crypto.randomUUID(),
-		scopeKind: overrides.scopeKind ?? 'thread',
-		scopeId: overrides.scopeId ?? 'thread-1',
+		observationScopeId: overrides.observationScopeId ?? 'thread-1',
 		marker: overrides.marker ?? 'important',
 		text: overrides.text ?? 'Observation',
 		parentId: overrides.parentId ?? null,
@@ -38,8 +37,7 @@ describe('observation-log reflector defaults', () => {
 
 	it('builds the default reflector prompt from active log and token budget', () => {
 		const prompt = buildObservationLogReflectorPrompt({
-			scopeKind: 'thread',
-			scopeId: 'thread-1',
+			observationScopeId: 'thread-1',
 			now: new Date('2026-05-12T15:00:00.000Z'),
 			activeObservationLog: [],
 			renderedObservationLog:
@@ -49,7 +47,7 @@ describe('observation-log reflector defaults', () => {
 		});
 
 		expect(prompt).toContain('Current timestamp: 2026-05-12T15:00:00.000Z');
-		expect(prompt).toContain('Scope: thread:thread-1');
+		expect(prompt).not.toContain('Scope:');
 		expect(prompt).toContain('Active observation log tokens: 42');
 		expect(prompt).toContain('Token budget: 8000');
 		expect(prompt).toContain('[obs-1] CRITICAL');
@@ -89,8 +87,7 @@ describe('renderObservationLogForReflection', () => {
 		const rendered = renderObservationLogForReflection([
 			{
 				id: 'parent',
-				scopeKind: 'thread',
-				scopeId: 'thread-1',
+				observationScopeId: 'thread-1',
 				marker: 'critical',
 				text: 'User chose the observation-log model.',
 				parentId: null,
@@ -101,8 +98,7 @@ describe('renderObservationLogForReflection', () => {
 			},
 			{
 				id: 'child',
-				scopeKind: 'thread',
-				scopeId: 'thread-1',
+				observationScopeId: 'thread-1',
 				marker: 'completion',
 				text: 'Plan 7 finished.',
 				parentId: 'parent',
@@ -121,8 +117,7 @@ describe('renderObservationLogForReflection', () => {
 		const rendered = renderObservationLogForReflection([
 			{
 				id: 'orphan',
-				scopeKind: 'thread',
-				scopeId: 'thread-1',
+				observationScopeId: 'thread-1',
 				marker: 'important',
 				text: 'Orphaned active observation remains relevant.',
 				parentId: 'missing-parent',
@@ -219,8 +214,7 @@ describe('runObservationLogReflector', () => {
 		const store = new InMemoryMemory();
 		await store.appendObservationLogEntries([
 			{
-				scopeKind: 'thread',
-				scopeId: 'thread-1',
+				observationScopeId: 'thread-1',
 				marker: 'info',
 				text: 'Small detail',
 				tokenCount: 2,
@@ -230,8 +224,7 @@ describe('runObservationLogReflector', () => {
 
 		const result = await runObservationLogReflector({
 			memory: store,
-			scopeKind: 'thread',
-			scopeId: 'thread-1',
+			observationScopeId: 'thread-1',
 			reflectorThresholdTokens: 10,
 			reflect,
 		});
@@ -244,22 +237,19 @@ describe('runObservationLogReflector', () => {
 		const store = new InMemoryMemory();
 		const [stale, oldA, oldB] = await store.appendObservationLogEntries([
 			{
-				scopeKind: 'resource',
-				scopeId: 'user-1',
+				observationScopeId: 'thread-1',
 				marker: 'info',
 				text: 'Tiny aside',
 				tokenCount: 9,
 			},
 			{
-				scopeKind: 'resource',
-				scopeId: 'user-1',
+				observationScopeId: 'thread-1',
 				marker: 'important',
 				text: 'Old plan A',
 				tokenCount: 9,
 			},
 			{
-				scopeKind: 'resource',
-				scopeId: 'user-1',
+				observationScopeId: 'thread-1',
 				marker: 'important',
 				text: 'Old plan B',
 				tokenCount: 9,
@@ -268,8 +258,7 @@ describe('runObservationLogReflector', () => {
 
 		const result = await runObservationLogReflector({
 			memory: store,
-			scopeKind: 'resource',
-			scopeId: 'user-1',
+			observationScopeId: 'thread-1',
 			reflectorThresholdTokens: 10,
 			now: new Date('2026-05-12T15:00:00.000Z'),
 			reflect: async (input) => {
@@ -306,10 +295,10 @@ describe('runObservationLogReflector', () => {
 			overBudgetAfterReflection: false,
 		});
 		await expect(
-			store.getObservationLog({ scopeKind: 'resource', scopeId: 'user-1', status: 'dropped' }),
+			store.getObservationLog({ observationScopeId: 'thread-1', status: 'dropped' }),
 		).resolves.toMatchObject([{ id: stale.id, status: 'dropped' }]);
 		await expect(
-			store.getObservationLog({ scopeKind: 'resource', scopeId: 'user-1', status: 'superseded' }),
+			store.getObservationLog({ observationScopeId: 'thread-1', status: 'superseded' }),
 		).resolves.toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({ id: oldA.id, status: 'superseded' }),
@@ -322,15 +311,13 @@ describe('runObservationLogReflector', () => {
 		const store = new InMemoryMemory();
 		const [critical, stale] = await store.appendObservationLogEntries([
 			{
-				scopeKind: 'thread',
-				scopeId: 'thread-1',
+				observationScopeId: 'thread-1',
 				marker: 'critical',
 				text: 'Large critical fact',
 				tokenCount: 20,
 			},
 			{
-				scopeKind: 'thread',
-				scopeId: 'thread-1',
+				observationScopeId: 'thread-1',
 				marker: 'info',
 				text: 'Small aside',
 				tokenCount: 20,
@@ -340,8 +327,7 @@ describe('runObservationLogReflector', () => {
 
 		const result = await runObservationLogReflector({
 			memory: store,
-			scopeKind: 'thread',
-			scopeId: 'thread-1',
+			observationScopeId: 'thread-1',
 			reflectorThresholdTokens: 10,
 			reflect: async () => await Promise.resolve(JSON.stringify({ drop: [stale.id], merge: [] })),
 			onWarning: (warning) => warnings.push(warning.message),
@@ -354,7 +340,7 @@ describe('runObservationLogReflector', () => {
 		});
 		expect(warnings).toEqual(['Observation log remains over reflector budget after reflection']);
 		await expect(
-			store.getActiveObservationLog({ scopeKind: 'thread', scopeId: 'thread-1' }),
+			store.getActiveObservationLog({ observationScopeId: 'thread-1' }),
 		).resolves.toMatchObject([{ id: critical.id }]);
 	});
 });

--- a/packages/@n8n/agents/src/runtime/__tests__/observation-log-renderer.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/observation-log-renderer.test.ts
@@ -5,8 +5,7 @@ function entry(overrides: Partial<ObservationLogEntry> = {}): ObservationLogEntr
 	const marker: ObservationLogMarker = overrides.marker ?? 'important';
 	return {
 		id: overrides.id ?? crypto.randomUUID(),
-		scopeKind: overrides.scopeKind ?? 'thread',
-		scopeId: overrides.scopeId ?? 'thread-1',
+		observationScopeId: overrides.observationScopeId ?? 'thread-1',
 		marker,
 		text: overrides.text ?? 'User chose the observation log model.',
 		parentId: overrides.parentId ?? null,

--- a/packages/@n8n/agents/src/runtime/__tests__/observation-log-store.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/observation-log-store.test.ts
@@ -8,8 +8,7 @@ describe('observation log store', () => {
 
 		const [entry] = await store.appendObservationLogEntries([
 			{
-				scopeKind: 'thread',
-				scopeId: 'thread-1',
+				observationScopeId: 'thread-1',
 				marker: 'critical',
 				text: 'User chose the observation log model.',
 				createdAt,
@@ -17,8 +16,7 @@ describe('observation log store', () => {
 		]);
 
 		expect(entry).toMatchObject({
-			scopeKind: 'thread',
-			scopeId: 'thread-1',
+			observationScopeId: 'thread-1',
 			marker: 'critical',
 			text: 'User chose the observation log model.',
 			parentId: null,
@@ -29,29 +27,29 @@ describe('observation log store', () => {
 		});
 
 		await expect(
-			store.getActiveObservationLog({ scopeKind: 'thread', scopeId: 'thread-1' }),
+			store.getActiveObservationLog({ observationScopeId: 'thread-1' }),
 		).resolves.toEqual([entry]);
 	});
 
 	it('keeps dropped and superseded observations out of the active read path', async () => {
 		const store = new InMemoryMemory();
 		const [dropped, superseded, replacement] = await store.appendObservationLogEntries([
-			{ scopeKind: 'thread', scopeId: 'thread-1', marker: 'info', text: 'Small detail' },
-			{ scopeKind: 'thread', scopeId: 'thread-1', marker: 'important', text: 'Old plan' },
-			{ scopeKind: 'thread', scopeId: 'thread-1', marker: 'important', text: 'New plan' },
+			{ observationScopeId: 'thread-1', marker: 'info', text: 'Small detail' },
+			{ observationScopeId: 'thread-1', marker: 'important', text: 'Old plan' },
+			{ observationScopeId: 'thread-1', marker: 'important', text: 'New plan' },
 		]);
 
 		await store.dropObservationLogEntries([dropped.id]);
 		await store.supersedeObservationLogEntries([superseded.id], replacement.id);
 
 		await expect(
-			store.getActiveObservationLog({ scopeKind: 'thread', scopeId: 'thread-1' }),
+			store.getActiveObservationLog({ observationScopeId: 'thread-1' }),
 		).resolves.toEqual([replacement]);
 		await expect(
-			store.getObservationLog({ scopeKind: 'thread', scopeId: 'thread-1', status: 'dropped' }),
+			store.getObservationLog({ observationScopeId: 'thread-1', status: 'dropped' }),
 		).resolves.toMatchObject([{ id: dropped.id, status: 'dropped', supersededBy: null }]);
 		await expect(
-			store.getObservationLog({ scopeKind: 'thread', scopeId: 'thread-1', status: 'superseded' }),
+			store.getObservationLog({ observationScopeId: 'thread-1', status: 'superseded' }),
 		).resolves.toMatchObject([
 			{ id: superseded.id, status: 'superseded', supersededBy: replacement.id },
 		]);
@@ -60,13 +58,13 @@ describe('observation log store', () => {
 	it('applies reflection as drops plus merged replacements', async () => {
 		const store = new InMemoryMemory();
 		const [stale, oldA, oldB] = await store.appendObservationLogEntries([
-			{ scopeKind: 'resource', scopeId: 'user-1', marker: 'info', text: 'Tiny aside' },
-			{ scopeKind: 'resource', scopeId: 'user-1', marker: 'important', text: 'Plan A' },
-			{ scopeKind: 'resource', scopeId: 'user-1', marker: 'important', text: 'Plan B' },
+			{ observationScopeId: 'thread-1', marker: 'info', text: 'Tiny aside' },
+			{ observationScopeId: 'thread-1', marker: 'important', text: 'Plan A' },
+			{ observationScopeId: 'thread-1', marker: 'important', text: 'Plan B' },
 		]);
 
 		const result = await store.applyObservationLogReflection(
-			{ scopeKind: 'resource', scopeId: 'user-1' },
+			{ observationScopeId: 'thread-1' },
 			{
 				drop: [stale.id],
 				merge: [
@@ -83,19 +81,18 @@ describe('observation log store', () => {
 		expect(result.supersededIds).toEqual([oldA.id, oldB.id]);
 		expect(result.inserted).toHaveLength(1);
 		await expect(
-			store.getActiveObservationLog({ scopeKind: 'resource', scopeId: 'user-1' }),
+			store.getActiveObservationLog({ observationScopeId: 'thread-1' }),
 		).resolves.toEqual(result.inserted);
 	});
 
 	it('ignores child-only drops while the parent remains active', async () => {
 		const store = new InMemoryMemory();
 		const [parent] = await store.appendObservationLogEntries([
-			{ scopeKind: 'thread', scopeId: 'thread-1', marker: 'important', text: 'Open case' },
+			{ observationScopeId: 'thread-1', marker: 'important', text: 'Open case' },
 		]);
 		const [child] = await store.appendObservationLogEntries([
 			{
-				scopeKind: 'thread',
-				scopeId: 'thread-1',
+				observationScopeId: 'thread-1',
 				marker: 'completion',
 				text: 'Case closed',
 				parentId: parent.id,
@@ -103,14 +100,13 @@ describe('observation log store', () => {
 		]);
 
 		const result = await store.applyObservationLogReflection(
-			{ scopeKind: 'thread', scopeId: 'thread-1' },
+			{ observationScopeId: 'thread-1' },
 			{ drop: [child.id], merge: [] },
 		);
 
 		expect(result.droppedIds).toEqual([]);
 		const active = await store.getActiveObservationLog({
-			scopeKind: 'thread',
-			scopeId: 'thread-1',
+			observationScopeId: 'thread-1',
 		});
 		expect(active).toHaveLength(2);
 		expect(active).toEqual(expect.arrayContaining([parent, child]));
@@ -119,12 +115,11 @@ describe('observation log store', () => {
 	it('supersedes children when their parent is merged', async () => {
 		const store = new InMemoryMemory();
 		const [parent] = await store.appendObservationLogEntries([
-			{ scopeKind: 'thread', scopeId: 'thread-1', marker: 'important', text: 'Open case' },
+			{ observationScopeId: 'thread-1', marker: 'important', text: 'Open case' },
 		]);
 		const [child] = await store.appendObservationLogEntries([
 			{
-				scopeKind: 'thread',
-				scopeId: 'thread-1',
+				observationScopeId: 'thread-1',
 				marker: 'completion',
 				text: 'Case closed',
 				parentId: parent.id,
@@ -132,7 +127,7 @@ describe('observation log store', () => {
 		]);
 
 		const result = await store.applyObservationLogReflection(
-			{ scopeKind: 'thread', scopeId: 'thread-1' },
+			{ observationScopeId: 'thread-1' },
 			{
 				drop: [],
 				merge: [
@@ -147,7 +142,7 @@ describe('observation log store', () => {
 
 		expect(result.supersededIds).toEqual([parent.id, child.id]);
 		await expect(
-			store.getObservationLog({ scopeKind: 'thread', scopeId: 'thread-1', status: 'superseded' }),
+			store.getObservationLog({ observationScopeId: 'thread-1', status: 'superseded' }),
 		).resolves.toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({ id: parent.id, status: 'superseded' }),

--- a/packages/@n8n/agents/src/runtime/__tests__/scoped-memory-task-runner.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/scoped-memory-task-runner.test.ts
@@ -2,7 +2,6 @@ import type {
 	BuiltObservationLogTaskLockStore,
 	ObservationLogTaskKind,
 	ObservationLogTaskLockHandle,
-	ObservationLogScopeKind,
 } from '../../types/sdk/observation-log';
 import { ScopedMemoryTaskRunner } from '../scoped-memory-task-runner';
 
@@ -24,14 +23,12 @@ function lockStore(
 }
 
 function lockHandle(
-	scopeKind: ObservationLogScopeKind,
-	scopeId: string,
+	observationScopeId: string,
 	taskKind: ObservationLogTaskKind,
 	holderId: string,
 ): ObservationLogTaskLockHandle {
 	return {
-		scopeKind,
-		scopeId,
+		observationScopeId,
 		taskKind,
 		holderId,
 		heldUntil: new Date(Date.now() + 30_000),
@@ -45,7 +42,7 @@ describe('ScopedMemoryTaskRunner', () => {
 		const events: string[] = [];
 
 		const observer = runner.schedule(
-			{ taskKind: 'observer', scopeKind: 'thread', scopeId: 'thread-1' },
+			{ taskKind: 'observer', observationScopeId: 'thread-1' },
 			async () => {
 				events.push('observer:start');
 				await first.promise;
@@ -53,7 +50,7 @@ describe('ScopedMemoryTaskRunner', () => {
 			},
 		);
 		const reflector = runner.schedule(
-			{ taskKind: 'reflector', scopeKind: 'thread', scopeId: 'thread-1' },
+			{ taskKind: 'reflector', observationScopeId: 'thread-1' },
 			async () => {
 				events.push('reflector:start');
 				await Promise.resolve();
@@ -78,10 +75,7 @@ describe('ScopedMemoryTaskRunner', () => {
 		const runner = new ScopedMemoryTaskRunner({ lockStore: lockStore(acquire) });
 		const task = jest.fn().mockResolvedValue(undefined);
 
-		const handle = runner.schedule(
-			{ taskKind: 'observer', scopeKind: 'thread', scopeId: 'thread-1' },
-			task,
-		);
+		const handle = runner.schedule({ taskKind: 'observer', observationScopeId: 'thread-1' }, task);
 
 		await expect(handle.done).resolves.toMatchObject({
 			status: 'skipped',
@@ -99,7 +93,7 @@ describe('ScopedMemoryTaskRunner', () => {
 		});
 
 		const handle = runner.schedule(
-			{ taskKind: 'observer', scopeKind: 'thread', scopeId: 'thread-1' },
+			{ taskKind: 'observer', observationScopeId: 'thread-1' },
 			async () => {
 				await Promise.reject(error);
 			},
@@ -115,7 +109,7 @@ describe('ScopedMemoryTaskRunner', () => {
 		const runner = new ScopedMemoryTaskRunner({ maxCapturedErrors: -1 });
 
 		const handle = runner.schedule(
-			{ taskKind: 'observer', scopeKind: 'thread', scopeId: 'thread-1' },
+			{ taskKind: 'observer', observationScopeId: 'thread-1' },
 			async () => {
 				await Promise.reject(new Error('observer failed'));
 			},
@@ -129,7 +123,7 @@ describe('ScopedMemoryTaskRunner', () => {
 		const runner = new ScopedMemoryTaskRunner({ maxCapturedErrors: Number.NaN });
 
 		const handle = runner.schedule(
-			{ taskKind: 'observer', scopeKind: 'thread', scopeId: 'thread-1' },
+			{ taskKind: 'observer', observationScopeId: 'thread-1' },
 			async () => {
 				await Promise.reject(new Error('observer failed'));
 			},
@@ -148,10 +142,7 @@ describe('ScopedMemoryTaskRunner', () => {
 			},
 		});
 
-		const handle = runner.schedule(
-			{ taskKind: 'reflector', scopeKind: 'thread', scopeId: 'thread-1' },
-			task,
-		);
+		const handle = runner.schedule({ taskKind: 'reflector', observationScopeId: 'thread-1' }, task);
 
 		await expect(handle.done).resolves.toMatchObject({ status: 'completed', value: 'done' });
 		expect(task).toHaveBeenCalled();
@@ -165,7 +156,7 @@ describe('ScopedMemoryTaskRunner', () => {
 		const runner = new ScopedMemoryTaskRunner();
 
 		const handle = runner.schedule(
-			{ taskKind: 'observer', scopeKind: 'thread', scopeId: 'thread-1' },
+			{ taskKind: 'observer', observationScopeId: 'thread-1' },
 			async () => await Promise.resolve('done'),
 		);
 
@@ -180,19 +171,19 @@ describe('ScopedMemoryTaskRunner', () => {
 			ReturnType<BuiltObservationLogTaskLockStore['acquireObservationLogTaskLock']>,
 			Parameters<BuiltObservationLogTaskLockStore['acquireObservationLogTaskLock']>
 		>(
-			async (scopeKind, scopeId, taskKind, opts) =>
-				await Promise.resolve(lockHandle(scopeKind, scopeId, taskKind, opts.holderId)),
+			async (observationScopeId, taskKind, opts) =>
+				await Promise.resolve(lockHandle(observationScopeId, taskKind, opts.holderId)),
 		);
 		const store = lockStore(acquire);
 		const runner = new ScopedMemoryTaskRunner({ lockStore: store, lockTtlMs: 15_000 });
 
 		const handle = runner.schedule(
-			{ taskKind: 'reflector', scopeKind: 'resource', scopeId: 'user-1' },
+			{ taskKind: 'reflector', observationScopeId: 'user-1' },
 			async () => await Promise.resolve('done'),
 		);
 
 		await expect(handle.done).resolves.toMatchObject({ status: 'completed', value: 'done' });
-		expect(acquire).toHaveBeenCalledWith('resource', 'user-1', 'reflector', {
+		expect(acquire).toHaveBeenCalledWith('user-1', 'reflector', {
 			holderId: handle.id,
 			ttlMs: 15_000,
 		});

--- a/packages/@n8n/agents/src/runtime/agent-runtime.ts
+++ b/packages/@n8n/agents/src/runtime/agent-runtime.ts
@@ -91,7 +91,6 @@ import type {
 	ToolResultEntry,
 } from '../types/sdk/agent';
 import type { AgentDbMessage, AgentMessage, ContentToolCall, Message } from '../types/sdk/message';
-import { createObservationLogThreadScopeId } from '../types/sdk/observation-log';
 import type { ObservationLogScope, ObservationLogTaskKind } from '../types/sdk/observation-log';
 import type { JSONObject, JSONValue } from '../types/utils/json';
 import { parseWithSchema } from '../utils/parse';
@@ -234,7 +233,7 @@ function hasObservationLogObserverMemory(
 ): memory is ObservationLogObserverMemory {
 	return (
 		hasObservationLogStore(memory) &&
-		hasFunctionProperty(memory, 'getMessagesForScope') &&
+		hasFunctionProperty(memory, 'getMessagesForObservationScope') &&
 		hasFunctionProperty(memory, 'getCursor') &&
 		hasFunctionProperty(memory, 'setCursor')
 	);
@@ -1521,10 +1520,6 @@ export class AgentRuntime {
 							observerThresholdTokens,
 							observationLogTailLimit: observationalMemory.observationLogTailLimit ?? 0,
 							observe,
-							messageSource: {
-								threadId: persistence.threadId,
-								resourceId: persistence.resourceId,
-							},
 						}),
 				),
 			);
@@ -1662,8 +1657,7 @@ export class AgentRuntime {
 				const message = `Observation log ${source} task failed`;
 				logger.warn(message, {
 					error: event.error,
-					scopeKind: event.task.scopeKind,
-					scopeId: event.task.scopeId,
+					observationScopeId: event.task.observationScopeId,
 				});
 				this.eventBus.emit({ type: AgentEvent.Error, message, error: event.error, source });
 			},
@@ -1673,8 +1667,7 @@ export class AgentRuntime {
 
 	private getObservationLogScope(persistence: AgentPersistenceOptions): ObservationLogScope {
 		return {
-			scopeKind: 'thread',
-			scopeId: createObservationLogThreadScopeId(persistence.threadId, persistence.resourceId),
+			observationScopeId: persistence.threadId,
 		};
 	}
 

--- a/packages/@n8n/agents/src/runtime/episodic-memory-defaults.ts
+++ b/packages/@n8n/agents/src/runtime/episodic-memory-defaults.ts
@@ -524,7 +524,6 @@ export function buildEpisodicMemoryExtractorPrompt(input: EpisodicMemoryExtracto
 	return [
 		`Current timestamp: ${input.now.toISOString()}`,
 		`Scope: resource:${input.scope.resourceId}`,
-		`Observation scope: ${input.observationScope.scopeKind}:${input.observationScope.scopeId}`,
 		`Active observation batch:\n${renderObservationsWithIds(input.observations)}`,
 		`Existing episodic entries for duplicate-awareness context:\n${renderExistingEntries(input.existingEntries)}`,
 	].join('\n\n');

--- a/packages/@n8n/agents/src/runtime/memory-store.ts
+++ b/packages/@n8n/agents/src/runtime/memory-store.ts
@@ -30,10 +30,7 @@ import type {
 } from '../types';
 import type { AgentDbMessage } from '../types/sdk/message';
 import type { ObservationCursor } from '../types/sdk/observation';
-import {
-	createObservationLogThreadScopePrefix,
-	estimateObservationTokens,
-} from '../types/sdk/observation-log';
+import { estimateObservationTokens } from '../types/sdk/observation-log';
 import type {
 	BuiltObservationLogStore,
 	BuiltObservationLogTaskLockStore,
@@ -43,7 +40,6 @@ import type {
 	ObservationLogReflection,
 	ObservationLogReflectionResult,
 	ObservationLogScope,
-	ObservationLogScopeKind,
 	ObservationLogTaskKind,
 	ObservationLogTaskLockHandle,
 } from '../types/sdk/observation-log';
@@ -52,10 +48,6 @@ interface StoredMessage {
 	message: AgentDbMessage;
 	createdAt: Date;
 	resourceId: string;
-}
-
-function scopeKey(scopeKind: ObservationLogScopeKind, scopeId: string): string {
-	return `${scopeKind}:${scopeId}`;
 }
 
 function cloneCursor(cursor: ObservationCursor): ObservationCursor {
@@ -152,23 +144,9 @@ export class InMemoryMemory
 	async deleteThread(threadId: string): Promise<void> {
 		this.threads.delete(threadId);
 		this.messagesByThread.delete(threadId);
-		const legacyKey = scopeKey('thread', threadId);
-		const resourceScopePrefix = scopeKey('thread', createObservationLogThreadScopePrefix(threadId));
-		for (const key of this.observationLogByScope.keys()) {
-			if (key === legacyKey || key.startsWith(resourceScopePrefix)) {
-				this.observationLogByScope.delete(key);
-			}
-		}
-		for (const key of this.cursorsByScope.keys()) {
-			if (key === legacyKey || key.startsWith(resourceScopePrefix)) {
-				this.cursorsByScope.delete(key);
-			}
-		}
-		for (const key of this.locksByScope.keys()) {
-			if (key === legacyKey || key.startsWith(resourceScopePrefix)) {
-				this.locksByScope.delete(key);
-			}
-		}
+		this.observationLogByScope.delete(threadId);
+		this.cursorsByScope.delete(threadId);
+		this.locksByScope.delete(threadId);
 		const affectedEntryIds = uniqueStrings(
 			this.episodicMemorySources
 				.filter((source) => source.threadId === threadId)
@@ -190,11 +168,7 @@ export class InMemoryMemory
 				}
 			}
 		}
-		for (const key of this.episodicMemoryCursorsByScope.keys()) {
-			if (key === legacyKey || key.startsWith(resourceScopePrefix)) {
-				this.episodicMemoryCursorsByScope.delete(key);
-			}
-		}
+		this.episodicMemoryCursorsByScope.delete(threadId);
 	}
 
 	// eslint-disable-next-line @typescript-eslint/require-await
@@ -279,12 +253,11 @@ export class InMemoryMemory
 	): Promise<ObservationLogEntry[]> {
 		const persisted: ObservationLogEntry[] = [];
 		for (const row of rows) {
-			const key = scopeKey(row.scopeKind, row.scopeId);
+			const key = row.observationScopeId;
 			const bucket = this.observationLogByScope.get(key) ?? [];
 			const entry: ObservationLogEntry = {
 				id: crypto.randomUUID(),
-				scopeKind: row.scopeKind,
-				scopeId: row.scopeId,
+				observationScopeId: row.observationScopeId,
 				marker: row.marker,
 				text: row.text,
 				parentId: row.parentId ?? null,
@@ -307,7 +280,7 @@ export class InMemoryMemory
 
 	// eslint-disable-next-line @typescript-eslint/require-await
 	async getObservationLog(opts: ObservationLogReadOptions): Promise<ObservationLogEntry[]> {
-		const bucket = this.observationLogByScope.get(scopeKey(opts.scopeKind, opts.scopeId)) ?? [];
+		const bucket = this.observationLogByScope.get(opts.observationScopeId) ?? [];
 		let rows = [...bucket].sort((a, b) =>
 			compareKeyset({ createdAt: a.createdAt, id: a.id }, { createdAt: b.createdAt, id: b.id }),
 		);
@@ -360,8 +333,7 @@ export class InMemoryMemory
 		);
 		const inserted = await this.appendObservationLogEntries(
 			normalized.merge.map((entry) => ({
-				scopeKind: scope.scopeKind,
-				scopeId: scope.scopeId,
+				observationScopeId: scope.observationScopeId,
 				marker: entry.marker,
 				text: entry.text,
 				parentId: entry.parentId,
@@ -386,23 +358,17 @@ export class InMemoryMemory
 	}
 
 	// eslint-disable-next-line @typescript-eslint/require-await
-	async getMessagesForScope(
-		scopeKind: ObservationLogScopeKind,
-		scopeId: string,
-		opts?: { since?: { sinceCreatedAt: Date; sinceMessageId: string }; resourceId?: string },
+	async getMessagesForObservationScope(
+		observationScopeId: string,
+		opts?: { since?: { sinceCreatedAt: Date; sinceMessageId: string } },
 	): Promise<AgentDbMessage[]> {
-		if (scopeKind !== 'thread') {
-			throw new Error(`getMessagesForScope: scopeKind='${scopeKind}' is not supported in v1`);
-		}
-		const candidates = this.messagesByThread.get(scopeId) ?? [];
-		let rows = candidates
-			.filter((s) => opts?.resourceId === undefined || s.resourceId === opts.resourceId)
-			.sort((a, b) =>
-				compareKeyset(
-					{ createdAt: a.createdAt, id: a.message.id },
-					{ createdAt: b.createdAt, id: b.message.id },
-				),
-			);
+		const candidates = this.messagesByThread.get(observationScopeId) ?? [];
+		let rows = candidates.sort((a, b) =>
+			compareKeyset(
+				{ createdAt: a.createdAt, id: a.message.id },
+				{ createdAt: b.createdAt, id: b.message.id },
+			),
+		);
 		if (opts?.since) {
 			const { sinceCreatedAt, sinceMessageId } = opts.since;
 			rows = rows.filter(
@@ -417,47 +383,40 @@ export class InMemoryMemory
 	}
 
 	// eslint-disable-next-line @typescript-eslint/require-await
-	async getCursor(
-		scopeKind: ObservationLogScopeKind,
-		scopeId: string,
-	): Promise<ObservationCursor | null> {
-		const cursor = this.cursorsByScope.get(scopeKey(scopeKind, scopeId));
+	async getCursor(observationScopeId: string): Promise<ObservationCursor | null> {
+		const cursor = this.cursorsByScope.get(observationScopeId);
 		return cursor ? cloneCursor(cursor) : null;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/require-await
 	async setCursor(cursor: ObservationCursor): Promise<void> {
-		const key = scopeKey(cursor.scopeKind, cursor.scopeId);
-		this.cursorsByScope.set(key, cloneCursor(cursor));
+		this.cursorsByScope.set(cursor.observationScopeId, cloneCursor(cursor));
 	}
 
 	async acquireObservationLogTaskLock(
-		scopeKind: ObservationLogScopeKind,
-		scopeId: string,
+		observationScopeId: string,
 		taskKind: ObservationLogTaskKind,
 		opts: { ttlMs: number; holderId: string },
 	): Promise<ObservationLogTaskLockHandle | null> {
-		const handle = await this.acquireScopeLock(scopeKind, scopeId, opts, taskKind);
+		const handle = await this.acquireScopeLock(observationScopeId, opts, taskKind);
 		if (!handle) return null;
-		return { scopeKind, scopeId, taskKind, holderId: handle.holderId, heldUntil: handle.heldUntil };
+		return { observationScopeId, taskKind, holderId: handle.holderId, heldUntil: handle.heldUntil };
 	}
 
 	// eslint-disable-next-line @typescript-eslint/require-await
 	private async acquireScopeLock(
-		scopeKind: ObservationLogScopeKind,
-		scopeId: string,
+		observationScopeId: string,
 		opts: { ttlMs: number; holderId: string },
 		taskKind: ObservationLogTaskKind,
 	): Promise<ObservationLogTaskLockHandle | null> {
-		const key = scopeKey(scopeKind, scopeId);
+		const key = observationScopeId;
 		const existing = this.locksByScope.get(key);
 		const now = Date.now();
 		if (existing && existing.holderId !== opts.holderId && existing.heldUntil.getTime() > now) {
 			return null;
 		}
 		const handle: ObservationLogTaskLockHandle = {
-			scopeKind,
-			scopeId,
+			observationScopeId,
 			taskKind,
 			holderId: opts.holderId,
 			heldUntil: new Date(now + opts.ttlMs),
@@ -472,7 +431,7 @@ export class InMemoryMemory
 
 	// eslint-disable-next-line @typescript-eslint/require-await
 	private async releaseScopeLock(handle: ObservationLogTaskLockHandle): Promise<void> {
-		const key = scopeKey(handle.scopeKind, handle.scopeId);
+		const key = handle.observationScopeId;
 		const current = this.locksByScope.get(key);
 		if (current && current.holderId === handle.holderId) {
 			this.locksByScope.delete(key);
@@ -656,14 +615,14 @@ export class InMemoryMemory
 	private async getEpisodicMemoryCursor(
 		scope: ObservationLogScope,
 	): Promise<EpisodicMemoryCursor | null> {
-		const cursor = this.episodicMemoryCursorsByScope.get(scopeKey(scope.scopeKind, scope.scopeId));
+		const cursor = this.episodicMemoryCursorsByScope.get(scope.observationScopeId);
 		return cursor ? cloneEpisodicMemoryCursor(cursor) : null;
 	}
 
 	// eslint-disable-next-line @typescript-eslint/require-await
 	private async setEpisodicMemoryCursor(cursor: NewEpisodicMemoryCursor): Promise<void> {
 		const now = new Date();
-		this.episodicMemoryCursorsByScope.set(scopeKey(cursor.scopeKind, cursor.scopeId), {
+		this.episodicMemoryCursorsByScope.set(cursor.observationScopeId, {
 			...cursor,
 			lastIndexedObservationCreatedAt: new Date(cursor.lastIndexedObservationCreatedAt),
 			updatedAt: cursor.updatedAt ?? now,

--- a/packages/@n8n/agents/src/runtime/observation-log-defaults.ts
+++ b/packages/@n8n/agents/src/runtime/observation-log-defaults.ts
@@ -291,7 +291,6 @@ export function buildObservationLogObserverPrompt(input: ObservationLogObserverI
 
 	return [
 		`Current timestamp: ${input.now.toISOString()}`,
-		`Scope: ${input.scopeKind}:${input.scopeId}`,
 		`Unobserved transcript tokens: ${input.transcriptTokenCount}`,
 		`Current observation log tail:\n${renderedLogTail}`,
 		`New transcript delta since the last observation:\n${transcript}`,
@@ -529,7 +528,6 @@ export function buildObservationLogReflectorPrompt(input: ObservationLogReflecto
 
 	return [
 		`Current timestamp: ${input.now.toISOString()}`,
-		`Scope: ${input.scopeKind}:${input.scopeId}`,
 		`Active observation log tokens: ${input.tokenCount}`,
 		`Token budget: ${input.tokenBudget}`,
 		`Current active observation log:\n${renderedLog}`,

--- a/packages/@n8n/agents/src/runtime/observation-log-observer.ts
+++ b/packages/@n8n/agents/src/runtime/observation-log-observer.ts
@@ -8,7 +8,6 @@ import type {
 	ObservationLogMarker,
 	ObservationLogObserveFn,
 	ObservationLogObserverInput,
-	ObservationLogScopeKind,
 	TokenCounter,
 } from '../types/sdk/observation-log';
 import { estimateObservationTokens } from '../types/sdk/observation-log';
@@ -54,25 +53,22 @@ export interface RenderObserverTranscriptOptions {
 }
 
 export interface ObservationLogObserverMemory extends BuiltMemory, BuiltObservationLogStore {
-	getMessagesForScope(
-		scopeKind: ObservationLogScopeKind,
-		scopeId: string,
-		opts?: { since?: { sinceCreatedAt: Date; sinceMessageId: string }; resourceId?: string },
+	getMessagesForObservationScope(
+		observationScopeId: string,
+		opts?: { since?: { sinceCreatedAt: Date; sinceMessageId: string } },
 	): Promise<AgentDbMessage[]>;
-	getCursor(scopeKind: ObservationLogScopeKind, scopeId: string): Promise<ObservationCursor | null>;
-	setCursor(cursor: ObservationCursor & { scopeKind: ObservationLogScopeKind }): Promise<void>;
+	getCursor(observationScopeId: string): Promise<ObservationCursor | null>;
+	setCursor(cursor: ObservationCursor): Promise<void>;
 }
 
 export interface RunObservationLogObserverOpts {
 	memory: ObservationLogObserverMemory;
-	scopeKind: ObservationLogScopeKind;
-	scopeId: string;
+	observationScopeId: string;
 	observerThresholdTokens: number;
 	observationLogTailLimit: number;
 	observe: ObservationLogObserveFn;
 	tokenCounter?: TokenCounter;
 	now?: Date;
-	messageSource?: { threadId: string; resourceId?: string };
 	onMalformedLine?: (line: string) => void;
 }
 
@@ -158,26 +154,18 @@ export function renderObserverTranscript(
 export async function runObservationLogObserver(
 	opts: RunObservationLogObserverOpts,
 ): Promise<RunObservationLogObserverResult> {
-	const { memory, scopeKind, scopeId } = opts;
-	const cursor = await memory.getCursor(scopeKind, scopeId);
-	const messageScopeKind = opts.messageSource ? 'thread' : scopeKind;
-	const messageScopeId = opts.messageSource?.threadId ?? scopeId;
-	const deltaMessages = await memory.getMessagesForScope(
-		messageScopeKind,
-		messageScopeId,
+	const { memory, observationScopeId } = opts;
+	const cursor = await memory.getCursor(observationScopeId);
+	const deltaMessages = await memory.getMessagesForObservationScope(
+		observationScopeId,
 		cursor
 			? {
-					...(opts.messageSource?.resourceId !== undefined && {
-						resourceId: opts.messageSource.resourceId,
-					}),
 					since: {
 						sinceCreatedAt: cursor.lastObservedAt,
 						sinceMessageId: cursor.lastObservedMessageId,
 					},
 				}
-			: opts.messageSource?.resourceId !== undefined
-				? { resourceId: opts.messageSource.resourceId }
-				: undefined,
+			: undefined,
 	);
 	if (deltaMessages.length === 0) return { status: 'skipped', reason: 'no-delta' };
 
@@ -190,8 +178,7 @@ export async function runObservationLogObserver(
 
 	const observationLogTail = (
 		await memory.getActiveObservationLog({
-			scopeKind,
-			scopeId,
+			observationScopeId,
 			limit: opts.observationLogTailLimit,
 			order: 'desc',
 		})
@@ -199,8 +186,7 @@ export async function runObservationLogObserver(
 	const now = opts.now ?? new Date();
 	const renderedObservationLogTail = renderObservationLog(observationLogTail);
 	const markdown = await opts.observe({
-		scopeKind,
-		scopeId,
+		observationScopeId,
 		now,
 		deltaMessages,
 		transcript,
@@ -219,8 +205,7 @@ export async function runObservationLogObserver(
 		const parentId = entry.parentIndex === null ? null : (inserted[entry.parentIndex]?.id ?? null);
 		const [row] = await memory.appendObservationLogEntries([
 			{
-				scopeKind,
-				scopeId,
+				observationScopeId,
 				marker: entry.marker,
 				text: entry.text,
 				parentId,
@@ -232,8 +217,7 @@ export async function runObservationLogObserver(
 
 	await advanceObserverCursor(
 		memory,
-		scopeKind,
-		scopeId,
+		observationScopeId,
 		deltaMessages[deltaMessages.length - 1],
 		now,
 	);
@@ -349,14 +333,12 @@ function safeJsonStringify(value: unknown): string {
 
 async function advanceObserverCursor(
 	memory: ObservationLogObserverMemory,
-	scopeKind: ObservationLogScopeKind,
-	scopeId: string,
+	observationScopeId: string,
 	lastMessage: AgentDbMessage,
 	now: Date,
 ): Promise<void> {
 	await memory.setCursor({
-		scopeKind,
-		scopeId,
+		observationScopeId,
 		lastObservedMessageId: lastMessage.id,
 		lastObservedAt: lastMessage.createdAt,
 		updatedAt: now,

--- a/packages/@n8n/agents/src/runtime/observation-log-reflector.ts
+++ b/packages/@n8n/agents/src/runtime/observation-log-reflector.ts
@@ -8,7 +8,6 @@ import type {
 	ObservationLogMerge,
 	ObservationLogReflection,
 	ObservationLogReflectionResult,
-	ObservationLogScopeKind,
 	TokenCounter,
 } from '../types/sdk/observation-log';
 import { estimateObservationTokens } from '../types/sdk/observation-log';
@@ -29,16 +28,14 @@ export type ObservationLogReflectorMemory = BuiltObservationLogStore;
 
 export interface ObservationLogReflectorWarning {
 	message: string;
-	scopeKind: ObservationLogScopeKind;
-	scopeId: string;
+	observationScopeId: string;
 	tokenCount: number;
 	tokenBudget: number;
 }
 
 export interface RunObservationLogReflectorOpts {
 	memory: ObservationLogReflectorMemory;
-	scopeKind: ObservationLogScopeKind;
-	scopeId: string;
+	observationScopeId: string;
 	reflectorThresholdTokens: number;
 	reflect: ObservationLogReflectFn;
 	tokenCounter?: TokenCounter;
@@ -162,11 +159,10 @@ export function normalizeObservationLogReflection(
 export async function runObservationLogReflector(
 	opts: RunObservationLogReflectorOpts,
 ): Promise<RunObservationLogReflectorResult> {
-	const { memory, scopeKind, scopeId, reflectorThresholdTokens } = opts;
+	const { memory, observationScopeId, reflectorThresholdTokens } = opts;
 	const tokenCounter = opts.tokenCounter ?? estimateObservationTokens;
 	const activeObservationLog = await memory.getActiveObservationLog({
-		scopeKind,
-		scopeId,
+		observationScopeId,
 		order: 'asc',
 	});
 	const tokenCount = countObservationTokens(activeObservationLog, tokenCounter);
@@ -177,8 +173,7 @@ export async function runObservationLogReflector(
 	const now = opts.now ?? new Date();
 	const renderedObservationLog = renderObservationLogForReflection(activeObservationLog);
 	const output = await opts.reflect({
-		scopeKind,
-		scopeId,
+		observationScopeId,
 		now,
 		activeObservationLog,
 		renderedObservationLog,
@@ -189,18 +184,17 @@ export async function runObservationLogReflector(
 		activeObservationLog,
 		withCreatedAt(parseObservationLogReflectionJson(output), now),
 	);
-	const result = await memory.applyObservationLogReflection({ scopeKind, scopeId }, reflection);
+	const result = await memory.applyObservationLogReflection({ observationScopeId }, reflection);
 
 	const remainingTokenCount = countObservationTokens(
-		await memory.getActiveObservationLog({ scopeKind, scopeId }),
+		await memory.getActiveObservationLog({ observationScopeId }),
 		tokenCounter,
 	);
 	const overBudgetAfterReflection = remainingTokenCount > reflectorThresholdTokens;
 	if (overBudgetAfterReflection) {
 		opts.onWarning?.({
 			message: REFLECTOR_OVER_BUDGET_WARNING,
-			scopeKind,
-			scopeId,
+			observationScopeId,
 			tokenCount: remainingTokenCount,
 			tokenBudget: reflectorThresholdTokens,
 		});

--- a/packages/@n8n/agents/src/runtime/scoped-memory-task-runner.ts
+++ b/packages/@n8n/agents/src/runtime/scoped-memory-task-runner.ts
@@ -1,7 +1,6 @@
 import { BackgroundTaskTracker } from './background-task-tracker';
 import type {
 	BuiltObservationLogTaskLockStore,
-	ObservationLogScopeKind,
 	ObservationLogTaskKind,
 	ObservationLogTaskLockHandle,
 } from '../types/sdk/observation-log';
@@ -11,8 +10,7 @@ const DEFAULT_MAX_CAPTURED_ERRORS = 50;
 
 export interface ScopedMemoryTaskDescriptor {
 	taskKind: ObservationLogTaskKind;
-	scopeKind: ObservationLogScopeKind;
-	scopeId: string;
+	observationScopeId: string;
 }
 
 export type ScopedMemoryTaskStatus = 'queued' | 'running';
@@ -118,7 +116,7 @@ export class ScopedMemoryTaskRunner {
 		};
 		this.inFlightTasks.set(id, info);
 
-		const scopeKey = this.scopeKey(descriptor.scopeKind, descriptor.scopeId);
+		const scopeKey = descriptor.observationScopeId;
 		const previous = this.queuesByScope.get(scopeKey) ?? Promise.resolve();
 		const done = previous.catch(() => undefined).then(async () => await this.runTask(info, task));
 		const queued = done.finally(() => {
@@ -167,8 +165,7 @@ export class ScopedMemoryTaskRunner {
 	): Promise<ObservationLogTaskLockHandle | null> {
 		if (!this.lockStore) return null;
 		return await this.lockStore.acquireObservationLogTaskLock(
-			info.scopeKind,
-			info.scopeId,
+			info.observationScopeId,
 			info.taskKind,
 			{ holderId: info.id, ttlMs: this.lockTtlMs },
 		);
@@ -189,8 +186,7 @@ export class ScopedMemoryTaskRunner {
 		this.capturedErrors.push({
 			id: info.id,
 			taskKind: info.taskKind,
-			scopeKind: info.scopeKind,
-			scopeId: info.scopeId,
+			observationScopeId: info.observationScopeId,
 			error,
 			createdAt: new Date(),
 		});
@@ -213,9 +209,5 @@ export class ScopedMemoryTaskRunner {
 			queuedAt: new Date(info.queuedAt),
 			...(info.startedAt ? { startedAt: new Date(info.startedAt) } : {}),
 		};
-	}
-
-	private scopeKey(scopeKind: ObservationLogScopeKind, scopeId: string): string {
-		return `${scopeKind}:${scopeId}`;
 	}
 }

--- a/packages/@n8n/agents/src/types/index.ts
+++ b/packages/@n8n/agents/src/types/index.ts
@@ -100,10 +100,7 @@ export type {
 	TitleGenerationConfig,
 } from './sdk/memory';
 
-export type {
-	ObservationCursor,
-	ScopeKind,
-} from './sdk/observation';
+export type { ObservationCursor } from './sdk/observation';
 
 export type {
 	BuiltObservationLogStore,
@@ -120,15 +117,12 @@ export type {
 	ObservationLogReflection,
 	ObservationLogReflectionResult,
 	ObservationLogScope,
-	ObservationLogScopeKind,
 	ObservationLogStatus,
 	ObservationLogTaskKind,
 	ObservationLogTaskLockHandle,
 	TokenCounter,
 } from './sdk/observation-log';
 export {
-	createObservationLogThreadScopeId,
-	createObservationLogThreadScopePrefix,
 	estimateObservationTokens,
 	OBSERVATION_LOG_MARKERS,
 	OBSERVATION_LOG_STATUSES,

--- a/packages/@n8n/agents/src/types/sdk/observation-log.ts
+++ b/packages/@n8n/agents/src/types/sdk/observation-log.ts
@@ -8,23 +8,10 @@ export const OBSERVATION_LOG_STATUSES = ['active', 'superseded', 'dropped'] as c
 
 export type ObservationLogStatus = (typeof OBSERVATION_LOG_STATUSES)[number];
 
-export type ObservationLogScopeKind = 'thread' | 'resource';
-
 export type ObservationLogTaskKind = 'observer' | 'reflector';
 
-const OBSERVATION_LOG_THREAD_SCOPE_PREFIX = 'thread';
-
-export function createObservationLogThreadScopeId(threadId: string, resourceId: string): string {
-	return `${OBSERVATION_LOG_THREAD_SCOPE_PREFIX}:${encodeURIComponent(threadId)}:resource:${encodeURIComponent(resourceId)}`;
-}
-
-export function createObservationLogThreadScopePrefix(threadId: string): string {
-	return `${OBSERVATION_LOG_THREAD_SCOPE_PREFIX}:${encodeURIComponent(threadId)}:resource:`;
-}
-
 export interface ObservationLogScope {
-	scopeKind: ObservationLogScopeKind;
-	scopeId: string;
+	observationScopeId: string;
 }
 
 export interface ObservationLogTaskLockHandle extends ObservationLogScope {
@@ -84,8 +71,7 @@ export type TokenCounter = (text: string) => number;
 export const estimateObservationTokens: TokenCounter = (text) => Math.ceil(text.length / 4);
 
 export interface ObservationLogObserverInput {
-	scopeKind: ObservationLogScopeKind;
-	scopeId: string;
+	observationScopeId: string;
 	now: Date;
 	deltaMessages: AgentDbMessage[];
 	transcript: string;
@@ -97,8 +83,7 @@ export interface ObservationLogObserverInput {
 export type ObservationLogObserveFn = (input: ObservationLogObserverInput) => Promise<string>;
 
 export interface ObservationLogReflectorInput {
-	scopeKind: ObservationLogScopeKind;
-	scopeId: string;
+	observationScopeId: string;
 	now: Date;
 	activeObservationLog: ObservationLogEntry[];
 	renderedObservationLog: string;
@@ -124,8 +109,7 @@ export interface BuiltObservationLogStore {
 
 export interface BuiltObservationLogTaskLockStore {
 	acquireObservationLogTaskLock(
-		scopeKind: ObservationLogScopeKind,
-		scopeId: string,
+		observationScopeId: string,
 		taskKind: ObservationLogTaskKind,
 		opts: { ttlMs: number; holderId: string },
 	): Promise<ObservationLogTaskLockHandle | null>;

--- a/packages/@n8n/agents/src/types/sdk/observation.ts
+++ b/packages/@n8n/agents/src/types/sdk/observation.ts
@@ -1,10 +1,5 @@
-import type { ObservationLogScopeKind } from './observation-log';
-
-export type ScopeKind = ObservationLogScopeKind;
-
 export interface ObservationCursor {
-	scopeKind: ObservationLogScopeKind;
-	scopeId: string;
+	observationScopeId: string;
 	lastObservedMessageId: string;
 	lastObservedAt: Date;
 	updatedAt: Date;

--- a/packages/@n8n/db/src/migrations/common/1784000000010-RefactorAgentObservationScope.ts
+++ b/packages/@n8n/db/src/migrations/common/1784000000010-RefactorAgentObservationScope.ts
@@ -1,0 +1,318 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+const OBSERVATION_MARKERS = ['critical', 'important', 'info', 'completion'];
+const OBSERVATION_STATUSES = ['active', 'superseded', 'dropped'];
+const OBSERVATION_TASK_KINDS = ['observer', 'reflector'];
+const MEMORY_ENTRY_STATUSES = ['active', 'superseded', 'dropped'];
+const OBSERVATION_SCOPE_KINDS = ['thread', 'resource'];
+
+export class RefactorAgentObservationScope1784000000010 implements ReversibleMigration {
+	async up({
+		escape,
+		isPostgres,
+		runQuery,
+		schemaBuilder: { createTable, column },
+	}: MigrationContext) {
+		await this.dropDerivedMemoryTables(runQuery, escape, isPostgres);
+		await this.createObservationLogTables(createTable, column);
+		await this.createEpisodicMemoryTables(createTable, column, 'agent-bound');
+	}
+
+	async down({
+		escape,
+		isPostgres,
+		runQuery,
+		schemaBuilder: { createTable, column },
+	}: MigrationContext) {
+		await this.dropDerivedMemoryTables(runQuery, escape, isPostgres);
+		await this.createLegacyObservationLogTables(createTable, column);
+		await this.createEpisodicMemoryTables(createTable, column, 'legacy-observation-scope');
+	}
+
+	private async dropDerivedMemoryTables(
+		runQuery: MigrationContext['runQuery'],
+		escape: MigrationContext['escape'],
+		isPostgres: boolean,
+	) {
+		const cascade = isPostgres ? ' CASCADE' : '';
+
+		await runQuery(
+			`DROP TABLE IF EXISTS ${escape.tableName('agents_memory_entry_cursors')}${cascade}`,
+		);
+		await runQuery(
+			`DROP TABLE IF EXISTS ${escape.tableName('agents_memory_entry_sources')}${cascade}`,
+		);
+		await runQuery(
+			`DROP TABLE IF EXISTS ${escape.tableName('agents_memory_entry_locks')}${cascade}`,
+		);
+		await runQuery(`DROP TABLE IF EXISTS ${escape.tableName('agents_memory_entries')}${cascade}`);
+		await runQuery(
+			`DROP TABLE IF EXISTS ${escape.tableName('agents_observation_locks')}${cascade}`,
+		);
+		await runQuery(
+			`DROP TABLE IF EXISTS ${escape.tableName('agents_observation_cursors')}${cascade}`,
+		);
+		await runQuery(`DROP TABLE IF EXISTS ${escape.tableName('agents_observations')}${cascade}`);
+	}
+
+	private async createObservationLogTables(
+		createTable: MigrationContext['schemaBuilder']['createTable'],
+		column: MigrationContext['schemaBuilder']['column'],
+	) {
+		await createTable('agents_observations')
+			.withColumns(
+				column('id')
+					.varchar(36)
+					.primary.notNull.comment('Application-generated n8n string ID, not a database UUID'),
+				column('agentId').varchar(36).notNull,
+				column('observationScopeId').varchar(255).notNull,
+				column('marker').varchar(16).notNull.withEnumCheck(OBSERVATION_MARKERS),
+				column('text').text.notNull,
+				column('parentId').varchar(36),
+				column('tokenCount').int.notNull.default(0),
+				column('status').varchar(16).notNull.withEnumCheck(OBSERVATION_STATUSES),
+				column('supersededBy').varchar(36),
+			)
+			.withIndexOn(['agentId', 'observationScopeId', 'status', 'createdAt', 'id'])
+			.withIndexOn(['agentId', 'observationScopeId', 'createdAt', 'id'])
+			.withIndexOn('parentId')
+			.withIndexOn('supersededBy')
+			.withForeignKey('agentId', {
+				tableName: 'agents',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withForeignKey('parentId', {
+				tableName: 'agents_observations',
+				columnName: 'id',
+			})
+			.withForeignKey('supersededBy', {
+				tableName: 'agents_observations',
+				columnName: 'id',
+			}).withTimestamps;
+
+		await createTable('agents_observation_cursors')
+			.withColumns(
+				column('agentId').varchar(36).notNull.primary,
+				column('observationScopeId').varchar(255).notNull.primary,
+				column('lastObservedMessageId').varchar(36).notNull,
+				column('lastObservedAt').timestampTimezone(3).notNull,
+			)
+			.withForeignKey('agentId', {
+				tableName: 'agents',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			}).withTimestamps;
+
+		await createTable('agents_observation_locks')
+			.withColumns(
+				column('agentId').varchar(36).notNull.primary,
+				column('observationScopeId').varchar(255).notNull.primary,
+				column('taskKind').varchar(20).notNull.primary.withEnumCheck(OBSERVATION_TASK_KINDS),
+				column('holderId')
+					.varchar(64)
+					.notNull.comment('Ephemeral background-task lock owner token, not a user ID'),
+				column('heldUntil').timestampTimezone(3).notNull,
+			)
+			.withForeignKey('agentId', {
+				tableName: 'agents',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			}).withTimestamps;
+	}
+
+	private async createLegacyObservationLogTables(
+		createTable: MigrationContext['schemaBuilder']['createTable'],
+		column: MigrationContext['schemaBuilder']['column'],
+	) {
+		await createTable('agents_observations')
+			.withColumns(
+				column('id')
+					.varchar(36)
+					.primary.notNull.comment('Application-generated n8n string ID, not a database UUID'),
+				column('scopeKind').varchar(20).notNull.withEnumCheck(OBSERVATION_SCOPE_KINDS),
+				column('scopeId').varchar(255).notNull,
+				column('marker').varchar(16).notNull.withEnumCheck(OBSERVATION_MARKERS),
+				column('text').text.notNull,
+				column('parentId').varchar(36),
+				column('tokenCount').int.notNull.default(0),
+				column('status').varchar(16).notNull.withEnumCheck(OBSERVATION_STATUSES),
+				column('supersededBy').varchar(36),
+			)
+			.withIndexOn(['scopeKind', 'scopeId', 'status', 'createdAt', 'id'])
+			.withIndexOn(['scopeKind', 'scopeId', 'createdAt', 'id'])
+			.withIndexOn('parentId')
+			.withIndexOn('supersededBy')
+			.withForeignKey('parentId', {
+				tableName: 'agents_observations',
+				columnName: 'id',
+			})
+			.withForeignKey('supersededBy', {
+				tableName: 'agents_observations',
+				columnName: 'id',
+			}).withTimestamps;
+
+		await createTable('agents_observation_cursors').withColumns(
+			column('scopeKind').varchar(20).notNull.primary.withEnumCheck(OBSERVATION_SCOPE_KINDS),
+			column('scopeId').varchar(255).notNull.primary,
+			column('lastObservedMessageId').varchar(36).notNull,
+			column('lastObservedAt').timestampTimezone(3).notNull,
+		).withTimestamps;
+
+		await createTable('agents_observation_locks').withColumns(
+			column('scopeKind').varchar(20).notNull.primary.withEnumCheck(OBSERVATION_SCOPE_KINDS),
+			column('scopeId').varchar(255).notNull.primary,
+			column('taskKind').varchar(20).notNull.primary.withEnumCheck(OBSERVATION_TASK_KINDS),
+			column('holderId')
+				.varchar(64)
+				.notNull.comment('Ephemeral background-task lock owner token, not a user ID'),
+			column('heldUntil').timestampTimezone(3).notNull,
+		).withTimestamps;
+	}
+
+	private async createEpisodicMemoryTables(
+		createTable: MigrationContext['schemaBuilder']['createTable'],
+		column: MigrationContext['schemaBuilder']['column'],
+		cursorScope: 'agent-bound' | 'legacy-observation-scope',
+	) {
+		await createTable('agents_memory_entries')
+			.withColumns(
+				column('id').varchar(36).primary.notNull,
+				column('agentId').varchar(36).notNull,
+				column('resourceId')
+					.varchar(255)
+					.notNull.comment('agents_resources.id partition used for episodic recall scope'),
+				column('content').text.notNull,
+				column('contentHash').varchar(64).notNull,
+				column('status').varchar(16).notNull.withEnumCheck(MEMORY_ENTRY_STATUSES),
+				column('supersededBy').varchar(36).comment('Self-reference to replacement memory entry'),
+				column('embeddingModel').varchar(128).comment('Embedding model used to produce embedding'),
+				column('embedding').json.comment('Embedding vector for episodic recall'),
+				column('metadata').json.comment('Optional system metadata for ranking and debugging'),
+				column('lastSeenAt')
+					.timestampTimezone(3)
+					.notNull.comment(
+						'Last time equivalent content was observed; updatedAt tracks row mutation time',
+					),
+			)
+			.withIndexOn(['agentId', 'resourceId', 'status', 'createdAt', 'id'])
+			.withIndexOn(['agentId', 'resourceId', 'contentHash'], true)
+			.withIndexOn('supersededBy')
+			.withForeignKey('agentId', {
+				tableName: 'agents',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withForeignKey('resourceId', {
+				tableName: 'agents_resources',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withForeignKey('supersededBy', {
+				tableName: 'agents_memory_entries',
+				columnName: 'id',
+			}).withTimestamps;
+
+		await createTable('agents_memory_entry_locks')
+			.withColumns(
+				column('agentId').varchar(36).notNull.primary,
+				column('resourceId')
+					.varchar(255)
+					.notNull.primary.comment('agents_resources.id partition locked for episodic indexing'),
+				column('holderId')
+					.varchar(64)
+					.notNull.comment('Ephemeral background-task lock owner token'),
+				column('heldUntil').timestampTimezone(3).notNull,
+			)
+			.withForeignKey('agentId', {
+				tableName: 'agents',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withForeignKey('resourceId', {
+				tableName: 'agents_resources',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			}).withTimestamps;
+
+		await createTable('agents_memory_entry_sources')
+			.withColumns(
+				column('id').varchar(36).primary.notNull,
+				column('agentId')
+					.varchar(36)
+					.notNull.comment('Agent that owns the linked episodic memory entry source'),
+				column('memoryEntryId').varchar(36).notNull,
+				column('observationId').varchar(36).notNull,
+				column('threadId')
+					.varchar(255)
+					.notNull.comment('Source conversation thread that produced the linked observation'),
+				column('evidenceHash')
+					.varchar(64)
+					.notNull.comment('Bounded hash used to deduplicate exact evidence links'),
+				column('evidenceText').text.notNull.comment(
+					'Exact source evidence text from the observation, not recall scope',
+				),
+			)
+			.withIndexOn(['memoryEntryId', 'observationId', 'evidenceHash'], true)
+			.withIndexOn('observationId')
+			.withIndexOn(['agentId', 'threadId'])
+			.withForeignKey('agentId', {
+				tableName: 'agents',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withForeignKey('memoryEntryId', {
+				tableName: 'agents_memory_entries',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withForeignKey('observationId', {
+				tableName: 'agents_observations',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withForeignKey('threadId', {
+				tableName: 'agents_threads',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			}).withTimestamps;
+
+		if (cursorScope === 'agent-bound') {
+			await createTable('agents_memory_entry_cursors')
+				.withColumns(
+					column('agentId').varchar(36).notNull.primary,
+					column('observationScopeId')
+						.varchar(255)
+						.notNull.primary.comment('Source observation stream indexed into episodic memory'),
+					column('lastIndexedObservationId')
+						.varchar(36)
+						.notNull.comment('Last observation-log row indexed into episodic memory'),
+					column('lastIndexedObservationCreatedAt')
+						.timestampTimezone(3)
+						.notNull.comment('Creation timestamp for the last indexed observation-log row'),
+				)
+				.withForeignKey('agentId', {
+					tableName: 'agents',
+					columnName: 'id',
+					onDelete: 'CASCADE',
+				}).withTimestamps;
+			return;
+		}
+
+		await createTable('agents_memory_entry_cursors').withColumns(
+			column('scopeKind')
+				.varchar(20)
+				.notNull.primary.withEnumCheck(OBSERVATION_SCOPE_KINDS)
+				.comment('Observation-log scope kind being indexed into episodic memory'),
+			column('scopeId')
+				.varchar(255)
+				.notNull.primary.comment('Observation-log scope ID being indexed into episodic memory'),
+			column('lastIndexedObservationId')
+				.varchar(36)
+				.notNull.comment('Last observation-log row indexed into episodic memory'),
+			column('lastIndexedObservationCreatedAt')
+				.timestampTimezone(3)
+				.notNull.comment('Creation timestamp for the last indexed observation-log row'),
+		).withTimestamps;
+	}
+}

--- a/packages/@n8n/db/src/migrations/common/1784000000010-RefactorAgentObservationScope.ts
+++ b/packages/@n8n/db/src/migrations/common/1784000000010-RefactorAgentObservationScope.ts
@@ -15,7 +15,8 @@ export class RefactorAgentObservationScope1784000000010 implements ReversibleMig
 	}: MigrationContext) {
 		await this.dropDerivedMemoryTables(runQuery, escape, isPostgres);
 		await this.createObservationLogTables(createTable, column);
-		await this.createEpisodicMemoryTables(createTable, column, 'agent-bound');
+		await this.createEpisodicMemoryTables(createTable, column);
+		await this.createAgentBoundMemoryEntryCursorTable(createTable, column);
 	}
 
 	async down({
@@ -26,7 +27,8 @@ export class RefactorAgentObservationScope1784000000010 implements ReversibleMig
 	}: MigrationContext) {
 		await this.dropDerivedMemoryTables(runQuery, escape, isPostgres);
 		await this.createLegacyObservationLogTables(createTable, column);
-		await this.createEpisodicMemoryTables(createTable, column, 'legacy-observation-scope');
+		await this.createEpisodicMemoryTables(createTable, column);
+		await this.createLegacyMemoryEntryCursorTable(createTable, column);
 	}
 
 	private async dropDerivedMemoryTables(
@@ -173,7 +175,6 @@ export class RefactorAgentObservationScope1784000000010 implements ReversibleMig
 	private async createEpisodicMemoryTables(
 		createTable: MigrationContext['schemaBuilder']['createTable'],
 		column: MigrationContext['schemaBuilder']['column'],
-		cursorScope: 'agent-bound' | 'legacy-observation-scope',
 	) {
 		await createTable('agents_memory_entries')
 			.withColumns(
@@ -276,29 +277,36 @@ export class RefactorAgentObservationScope1784000000010 implements ReversibleMig
 				columnName: 'id',
 				onDelete: 'CASCADE',
 			}).withTimestamps;
+	}
 
-		if (cursorScope === 'agent-bound') {
-			await createTable('agents_memory_entry_cursors')
-				.withColumns(
-					column('agentId').varchar(36).notNull.primary,
-					column('observationScopeId')
-						.varchar(255)
-						.notNull.primary.comment('Source observation stream indexed into episodic memory'),
-					column('lastIndexedObservationId')
-						.varchar(36)
-						.notNull.comment('Last observation-log row indexed into episodic memory'),
-					column('lastIndexedObservationCreatedAt')
-						.timestampTimezone(3)
-						.notNull.comment('Creation timestamp for the last indexed observation-log row'),
-				)
-				.withForeignKey('agentId', {
-					tableName: 'agents',
-					columnName: 'id',
-					onDelete: 'CASCADE',
-				}).withTimestamps;
-			return;
-		}
+	private async createAgentBoundMemoryEntryCursorTable(
+		createTable: MigrationContext['schemaBuilder']['createTable'],
+		column: MigrationContext['schemaBuilder']['column'],
+	) {
+		await createTable('agents_memory_entry_cursors')
+			.withColumns(
+				column('agentId').varchar(36).notNull.primary,
+				column('observationScopeId')
+					.varchar(255)
+					.notNull.primary.comment('Source observation stream indexed into episodic memory'),
+				column('lastIndexedObservationId')
+					.varchar(36)
+					.notNull.comment('Last observation-log row indexed into episodic memory'),
+				column('lastIndexedObservationCreatedAt')
+					.timestampTimezone(3)
+					.notNull.comment('Creation timestamp for the last indexed observation-log row'),
+			)
+			.withForeignKey('agentId', {
+				tableName: 'agents',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			}).withTimestamps;
+	}
 
+	private async createLegacyMemoryEntryCursorTable(
+		createTable: MigrationContext['schemaBuilder']['createTable'],
+		column: MigrationContext['schemaBuilder']['column'],
+	) {
 		await createTable('agents_memory_entry_cursors').withColumns(
 			column('scopeKind')
 				.varchar(20)

--- a/packages/@n8n/db/src/migrations/common/1784000000010-RefactorAgentObservationScope.ts
+++ b/packages/@n8n/db/src/migrations/common/1784000000010-RefactorAgentObservationScope.ts
@@ -77,8 +77,7 @@ export class RefactorAgentObservationScope1784000000010 implements ReversibleMig
 				column('status').varchar(16).notNull.withEnumCheck(OBSERVATION_STATUSES),
 				column('supersededBy').varchar(36),
 			)
-			.withIndexOn(['agentId', 'observationScopeId', 'status', 'createdAt', 'id'])
-			.withIndexOn(['agentId', 'observationScopeId', 'createdAt', 'id'])
+			.withIndexOn(['agentId', 'observationScopeId', 'status'])
 			.withIndexOn('observationScopeId')
 			.withIndexOn('parentId')
 			.withIndexOn('supersededBy')

--- a/packages/@n8n/db/src/migrations/common/1784000000010-RefactorAgentObservationScope.ts
+++ b/packages/@n8n/db/src/migrations/common/1784000000010-RefactorAgentObservationScope.ts
@@ -66,8 +66,10 @@ export class RefactorAgentObservationScope1784000000010 implements ReversibleMig
 				column('id')
 					.varchar(36)
 					.primary.notNull.comment('Application-generated n8n string ID, not a database UUID'),
-				column('agentId').varchar(36).notNull,
-				column('observationScopeId').varchar(255).notNull,
+				column('agentId').varchar(36).notNull.comment('Agent that owns this observation row'),
+				column('observationScopeId')
+					.varchar(255)
+					.notNull.comment('agents_threads.id source stream for this observation log'),
 				column('marker').varchar(16).notNull.withEnumCheck(OBSERVATION_MARKERS),
 				column('text').text.notNull,
 				column('parentId').varchar(36),
@@ -77,10 +79,16 @@ export class RefactorAgentObservationScope1784000000010 implements ReversibleMig
 			)
 			.withIndexOn(['agentId', 'observationScopeId', 'status', 'createdAt', 'id'])
 			.withIndexOn(['agentId', 'observationScopeId', 'createdAt', 'id'])
+			.withIndexOn('observationScopeId')
 			.withIndexOn('parentId')
 			.withIndexOn('supersededBy')
 			.withForeignKey('agentId', {
 				tableName: 'agents',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withForeignKey('observationScopeId', {
+				tableName: 'agents_threads',
 				columnName: 'id',
 				onDelete: 'CASCADE',
 			})
@@ -95,29 +103,45 @@ export class RefactorAgentObservationScope1784000000010 implements ReversibleMig
 
 		await createTable('agents_observation_cursors')
 			.withColumns(
-				column('agentId').varchar(36).notNull.primary,
-				column('observationScopeId').varchar(255).notNull.primary,
+				column('agentId').varchar(36).notNull.primary.comment('Agent that owns this cursor'),
+				column('observationScopeId')
+					.varchar(255)
+					.notNull.primary.comment('agents_threads.id source stream checkpointed by this cursor'),
 				column('lastObservedMessageId').varchar(36).notNull,
 				column('lastObservedAt').timestampTimezone(3).notNull,
 			)
+			.withIndexOn('observationScopeId')
 			.withForeignKey('agentId', {
 				tableName: 'agents',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withForeignKey('observationScopeId', {
+				tableName: 'agents_threads',
 				columnName: 'id',
 				onDelete: 'CASCADE',
 			}).withTimestamps;
 
 		await createTable('agents_observation_locks')
 			.withColumns(
-				column('agentId').varchar(36).notNull.primary,
-				column('observationScopeId').varchar(255).notNull.primary,
+				column('agentId').varchar(36).notNull.primary.comment('Agent that owns this lock'),
+				column('observationScopeId')
+					.varchar(255)
+					.notNull.primary.comment('agents_threads.id source stream locked for observation tasks'),
 				column('taskKind').varchar(20).notNull.primary.withEnumCheck(OBSERVATION_TASK_KINDS),
 				column('holderId')
 					.varchar(64)
 					.notNull.comment('Ephemeral background-task lock owner token, not a user ID'),
 				column('heldUntil').timestampTimezone(3).notNull,
 			)
+			.withIndexOn('observationScopeId')
 			.withForeignKey('agentId', {
 				tableName: 'agents',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withForeignKey('observationScopeId', {
+				tableName: 'agents_threads',
 				columnName: 'id',
 				onDelete: 'CASCADE',
 			}).withTimestamps;
@@ -179,7 +203,7 @@ export class RefactorAgentObservationScope1784000000010 implements ReversibleMig
 		await createTable('agents_memory_entries')
 			.withColumns(
 				column('id').varchar(36).primary.notNull,
-				column('agentId').varchar(36).notNull,
+				column('agentId').varchar(36).notNull.comment('Agent that owns this episodic memory entry'),
 				column('resourceId')
 					.varchar(255)
 					.notNull.comment('agents_resources.id partition used for episodic recall scope'),
@@ -198,6 +222,7 @@ export class RefactorAgentObservationScope1784000000010 implements ReversibleMig
 			)
 			.withIndexOn(['agentId', 'resourceId', 'status', 'createdAt', 'id'])
 			.withIndexOn(['agentId', 'resourceId', 'contentHash'], true)
+			.withIndexOn('resourceId')
 			.withIndexOn('supersededBy')
 			.withForeignKey('agentId', {
 				tableName: 'agents',
@@ -216,7 +241,7 @@ export class RefactorAgentObservationScope1784000000010 implements ReversibleMig
 
 		await createTable('agents_memory_entry_locks')
 			.withColumns(
-				column('agentId').varchar(36).notNull.primary,
+				column('agentId').varchar(36).notNull.primary.comment('Agent that owns this lock'),
 				column('resourceId')
 					.varchar(255)
 					.notNull.primary.comment('agents_resources.id partition locked for episodic indexing'),
@@ -225,6 +250,7 @@ export class RefactorAgentObservationScope1784000000010 implements ReversibleMig
 					.notNull.comment('Ephemeral background-task lock owner token'),
 				column('heldUntil').timestampTimezone(3).notNull,
 			)
+			.withIndexOn('resourceId')
 			.withForeignKey('agentId', {
 				tableName: 'agents',
 				columnName: 'id',
@@ -242,8 +268,12 @@ export class RefactorAgentObservationScope1784000000010 implements ReversibleMig
 				column('agentId')
 					.varchar(36)
 					.notNull.comment('Agent that owns the linked episodic memory entry source'),
-				column('memoryEntryId').varchar(36).notNull,
-				column('observationId').varchar(36).notNull,
+				column('memoryEntryId')
+					.varchar(36)
+					.notNull.comment('Episodic memory entry linked to this source evidence'),
+				column('observationId')
+					.varchar(36)
+					.notNull.comment('Observation-log row used as source evidence'),
 				column('threadId')
 					.varchar(255)
 					.notNull.comment('Source conversation thread that produced the linked observation'),
@@ -257,6 +287,7 @@ export class RefactorAgentObservationScope1784000000010 implements ReversibleMig
 			.withIndexOn(['memoryEntryId', 'observationId', 'evidenceHash'], true)
 			.withIndexOn('observationId')
 			.withIndexOn(['agentId', 'threadId'])
+			.withIndexOn('threadId')
 			.withForeignKey('agentId', {
 				tableName: 'agents',
 				columnName: 'id',
@@ -285,10 +316,10 @@ export class RefactorAgentObservationScope1784000000010 implements ReversibleMig
 	) {
 		await createTable('agents_memory_entry_cursors')
 			.withColumns(
-				column('agentId').varchar(36).notNull.primary,
+				column('agentId').varchar(36).notNull.primary.comment('Agent that owns this cursor'),
 				column('observationScopeId')
 					.varchar(255)
-					.notNull.primary.comment('Source observation stream indexed into episodic memory'),
+					.notNull.primary.comment('agents_threads.id source stream indexed into episodic memory'),
 				column('lastIndexedObservationId')
 					.varchar(36)
 					.notNull.comment('Last observation-log row indexed into episodic memory'),
@@ -296,8 +327,14 @@ export class RefactorAgentObservationScope1784000000010 implements ReversibleMig
 					.timestampTimezone(3)
 					.notNull.comment('Creation timestamp for the last indexed observation-log row'),
 			)
+			.withIndexOn('observationScopeId')
 			.withForeignKey('agentId', {
 				tableName: 'agents',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withForeignKey('observationScopeId', {
+				tableName: 'agents_threads',
 				columnName: 'id',
 				onDelete: 'CASCADE',
 			}).withTimestamps;

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -185,6 +185,7 @@ import { AddNodeGroupsColumnToWorkflowAndHistory1784000000006 } from '../common/
 import { CreateInstanceAiCheckpointTable1784000000007 } from '../common/1784000000007-CreateInstanceAiCheckpointTable';
 import { ResetInstanceAiNativePersistence1784000000008 } from '../common/1784000000008-ResetInstanceAiNativePersistence';
 import { CreateAgentMemoryEntryTables1784000000009 } from '../common/1784000000009-CreateAgentMemoryEntryTables';
+import { RefactorAgentObservationScope1784000000010 } from '../common/1784000000010-RefactorAgentObservationScope';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -375,4 +376,5 @@ export const postgresMigrations: Migration[] = [
 	CreateInstanceAiCheckpointTable1784000000007,
 	ResetInstanceAiNativePersistence1784000000008,
 	CreateAgentMemoryEntryTables1784000000009,
+	RefactorAgentObservationScope1784000000010,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -178,6 +178,7 @@ import { AddNodeGroupsColumnToWorkflowAndHistory1784000000006 } from '../common/
 import { CreateInstanceAiCheckpointTable1784000000007 } from '../common/1784000000007-CreateInstanceAiCheckpointTable';
 import { ResetInstanceAiNativePersistence1784000000008 } from '../common/1784000000008-ResetInstanceAiNativePersistence';
 import { CreateAgentMemoryEntryTables1784000000009 } from '../common/1784000000009-CreateAgentMemoryEntryTables';
+import { RefactorAgentObservationScope1784000000010 } from '../common/1784000000010-RefactorAgentObservationScope';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -361,6 +362,7 @@ const sqliteMigrations: Migration[] = [
 	CreateInstanceAiCheckpointTable1784000000007,
 	ResetInstanceAiNativePersistence1784000000008,
 	CreateAgentMemoryEntryTables1784000000009,
+	RefactorAgentObservationScope1784000000010,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/modules/agents/__tests__/episodic-memory.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/episodic-memory.test.ts
@@ -33,15 +33,13 @@ describe('n8n episodic memory policy', () => {
 		const prompt = buildN8nEpisodicMemoryExtractorPrompt({
 			scope: { resourceId: 'user-1' },
 			observationScope: {
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:user-1',
+				observationScopeId: 'thread-1',
 			},
 			now: new Date('2026-05-12T15:00:00.000Z'),
 			observations: [
 				{
 					id: 'obs-1',
-					scopeKind: 'thread',
-					scopeId: 'thread:thread-1:resource:user-1',
+					observationScopeId: 'thread-1',
 					marker: 'critical',
 					text: 'User switched memory store choice to Postgres.',
 					parentId: null,

--- a/packages/cli/src/modules/agents/__tests__/from-json-config.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/from-json-config.test.ts
@@ -119,7 +119,7 @@ describe('buildFromJson()', () => {
 		dropObservationLogEntries: jest.fn(),
 		supersedeObservationLogEntries: jest.fn(),
 		applyObservationLogReflection: jest.fn(),
-		getMessagesForScope: jest.fn(),
+		getMessagesForObservationScope: jest.fn(),
 		getCursor: jest.fn(),
 		setCursor: jest.fn(),
 		acquireObservationLogTaskLock: jest.fn(),

--- a/packages/cli/src/modules/agents/__tests__/observation-log-observer.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/observation-log-observer.test.ts
@@ -21,8 +21,7 @@ describe('n8n observation-log observer policy', () => {
 
 	it('builds the observer prompt from log tail and transcript delta', () => {
 		const prompt = buildN8nObservationLogObserverPrompt({
-			scopeKind: 'thread',
-			scopeId: 'thread-1',
+			observationScopeId: 'thread-1',
 			now: new Date('2026-05-12T14:30:00.000Z'),
 			deltaMessages: [],
 			transcript: '[2026-05-12T14:29:00.000Z] user:\nRemember daily-report-prod.',

--- a/packages/cli/src/modules/agents/__tests__/observation-log-reflector.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/observation-log-reflector.test.ts
@@ -13,8 +13,7 @@ describe('n8n observation-log reflector policy', () => {
 
 	it('builds the reflector prompt from active log and token budget', () => {
 		const prompt = buildN8nObservationLogReflectorPrompt({
-			scopeKind: 'thread',
-			scopeId: 'thread-1',
+			observationScopeId: 'thread-1',
 			now: new Date('2026-05-12T15:00:00.000Z'),
 			activeObservationLog: [],
 			renderedObservationLog:
@@ -24,7 +23,7 @@ describe('n8n observation-log reflector policy', () => {
 		});
 
 		expect(prompt).toContain('Current timestamp: 2026-05-12T15:00:00.000Z');
-		expect(prompt).toContain('Scope: thread:thread-1');
+		expect(prompt).not.toContain('Scope:');
 		expect(prompt).toContain('Active observation log tokens: 42');
 		expect(prompt).toContain('Token budget: 8000');
 		expect(prompt).toContain('[obs-1] CRITICAL');

--- a/packages/cli/src/modules/agents/entities/agent-memory-entry-cursor.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-memory-entry-cursor.entity.ts
@@ -1,7 +1,8 @@
 import { DateTimeColumn, WithTimestamps } from '@n8n/db';
-import { Column, Entity, PrimaryColumn } from '@n8n/typeorm';
+import { Column, Entity, Index, PrimaryColumn } from '@n8n/typeorm';
 
 @Entity({ name: 'agents_memory_entry_cursors' })
+@Index(['observationScopeId'])
 export class AgentMemoryEntryCursorEntity extends WithTimestamps {
 	@PrimaryColumn({ type: 'varchar', length: 36 })
 	agentId: string;

--- a/packages/cli/src/modules/agents/entities/agent-memory-entry-cursor.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-memory-entry-cursor.entity.ts
@@ -1,15 +1,13 @@
 import { DateTimeColumn, WithTimestamps } from '@n8n/db';
 import { Column, Entity, PrimaryColumn } from '@n8n/typeorm';
 
-import type { ObservationScopeKind } from './agent-observation.entity';
-
 @Entity({ name: 'agents_memory_entry_cursors' })
 export class AgentMemoryEntryCursorEntity extends WithTimestamps {
-	@PrimaryColumn({ type: 'varchar', length: 20 })
-	scopeKind: ObservationScopeKind;
+	@PrimaryColumn({ type: 'varchar', length: 36 })
+	agentId: string;
 
 	@PrimaryColumn({ type: 'varchar', length: 255 })
-	scopeId: string;
+	observationScopeId: string;
 
 	@Column({ type: 'varchar', length: 36 })
 	lastIndexedObservationId: string;

--- a/packages/cli/src/modules/agents/entities/agent-memory-entry-lock.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-memory-entry-lock.entity.ts
@@ -1,7 +1,8 @@
 import { DateTimeColumn, WithTimestamps } from '@n8n/db';
-import { Column, Entity, PrimaryColumn } from '@n8n/typeorm';
+import { Column, Entity, Index, PrimaryColumn } from '@n8n/typeorm';
 
 @Entity({ name: 'agents_memory_entry_locks' })
+@Index(['resourceId'])
 export class AgentMemoryEntryLockEntity extends WithTimestamps {
 	@PrimaryColumn({ type: 'varchar', length: 36 })
 	agentId: string;

--- a/packages/cli/src/modules/agents/entities/agent-memory-entry-source.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-memory-entry-source.entity.ts
@@ -5,6 +5,7 @@ import { Column, Entity, Index } from '@n8n/typeorm';
 @Index(['memoryEntryId', 'observationId', 'evidenceHash'], { unique: true })
 @Index(['observationId'])
 @Index(['agentId', 'threadId'])
+@Index(['threadId'])
 export class AgentMemoryEntrySourceEntity extends WithTimestampsAndStringId {
 	@Column({ type: 'varchar', length: 36 })
 	agentId: string;

--- a/packages/cli/src/modules/agents/entities/agent-memory-entry.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-memory-entry.entity.ts
@@ -7,6 +7,7 @@ export type MemoryEntryStatus = 'active' | 'superseded' | 'dropped';
 @Entity({ name: 'agents_memory_entries' })
 @Index(['agentId', 'resourceId', 'status', 'createdAt', 'id'])
 @Index(['agentId', 'resourceId', 'contentHash'], { unique: true })
+@Index(['resourceId'])
 @Index(['supersededBy'])
 export class AgentMemoryEntryEntity extends WithTimestampsAndStringId {
 	@Column({ type: 'varchar', length: 36 })

--- a/packages/cli/src/modules/agents/entities/agent-observation-cursor.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-observation-cursor.entity.ts
@@ -1,7 +1,8 @@
 import { DateTimeColumn, WithTimestamps } from '@n8n/db';
-import { Column, Entity, PrimaryColumn } from '@n8n/typeorm';
+import { Column, Entity, Index, PrimaryColumn } from '@n8n/typeorm';
 
 @Entity({ name: 'agents_observation_cursors' })
+@Index(['observationScopeId'])
 export class AgentObservationCursorEntity extends WithTimestamps {
 	@PrimaryColumn({ type: 'varchar', length: 36 })
 	agentId: string;

--- a/packages/cli/src/modules/agents/entities/agent-observation-cursor.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-observation-cursor.entity.ts
@@ -1,15 +1,13 @@
 import { DateTimeColumn, WithTimestamps } from '@n8n/db';
 import { Column, Entity, PrimaryColumn } from '@n8n/typeorm';
 
-import type { ObservationScopeKind } from './agent-observation.entity';
-
 @Entity({ name: 'agents_observation_cursors' })
 export class AgentObservationCursorEntity extends WithTimestamps {
-	@PrimaryColumn({ type: 'varchar', length: 20 })
-	scopeKind: ObservationScopeKind;
+	@PrimaryColumn({ type: 'varchar', length: 36 })
+	agentId: string;
 
 	@PrimaryColumn({ type: 'varchar', length: 255 })
-	scopeId: string;
+	observationScopeId: string;
 
 	@Column({ type: 'varchar', length: 36 })
 	lastObservedMessageId: string;

--- a/packages/cli/src/modules/agents/entities/agent-observation-lock.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-observation-lock.entity.ts
@@ -1,9 +1,10 @@
 import { DateTimeColumn, WithTimestamps } from '@n8n/db';
-import { Column, Entity, PrimaryColumn } from '@n8n/typeorm';
+import { Column, Entity, Index, PrimaryColumn } from '@n8n/typeorm';
 
 export type ObservationTaskKind = 'observer' | 'reflector';
 
 @Entity({ name: 'agents_observation_locks' })
+@Index(['observationScopeId'])
 export class AgentObservationLockEntity extends WithTimestamps {
 	@PrimaryColumn({ type: 'varchar', length: 36 })
 	agentId: string;

--- a/packages/cli/src/modules/agents/entities/agent-observation-lock.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-observation-lock.entity.ts
@@ -1,17 +1,15 @@
 import { DateTimeColumn, WithTimestamps } from '@n8n/db';
 import { Column, Entity, PrimaryColumn } from '@n8n/typeorm';
 
-import type { ObservationScopeKind } from './agent-observation.entity';
-
 export type ObservationTaskKind = 'observer' | 'reflector';
 
 @Entity({ name: 'agents_observation_locks' })
 export class AgentObservationLockEntity extends WithTimestamps {
-	@PrimaryColumn({ type: 'varchar', length: 20 })
-	scopeKind: ObservationScopeKind;
+	@PrimaryColumn({ type: 'varchar', length: 36 })
+	agentId: string;
 
 	@PrimaryColumn({ type: 'varchar', length: 255 })
-	scopeId: string;
+	observationScopeId: string;
 
 	@PrimaryColumn({ type: 'varchar', length: 20 })
 	taskKind: ObservationTaskKind;

--- a/packages/cli/src/modules/agents/entities/agent-observation.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-observation.entity.ts
@@ -1,21 +1,20 @@
 import { WithTimestampsAndStringId } from '@n8n/db';
 import { Column, Entity, Index } from '@n8n/typeorm';
 
-export type ObservationScopeKind = 'thread' | 'resource';
 export type ObservationMarker = 'critical' | 'important' | 'info' | 'completion';
 export type ObservationStatus = 'active' | 'superseded' | 'dropped';
 
 @Entity({ name: 'agents_observations' })
-@Index(['scopeKind', 'scopeId', 'status', 'createdAt', 'id'])
-@Index(['scopeKind', 'scopeId', 'createdAt', 'id'])
+@Index(['agentId', 'observationScopeId', 'status', 'createdAt', 'id'])
+@Index(['agentId', 'observationScopeId', 'createdAt', 'id'])
 @Index(['parentId'])
 @Index(['supersededBy'])
 export class AgentObservationEntity extends WithTimestampsAndStringId {
-	@Column({ type: 'varchar', length: 20 })
-	scopeKind: ObservationScopeKind;
+	@Column({ type: 'varchar', length: 36 })
+	agentId: string;
 
 	@Column({ type: 'varchar', length: 255 })
-	scopeId: string;
+	observationScopeId: string;
 
 	@Column({ type: 'varchar', length: 16 })
 	marker: ObservationMarker;

--- a/packages/cli/src/modules/agents/entities/agent-observation.entity.ts
+++ b/packages/cli/src/modules/agents/entities/agent-observation.entity.ts
@@ -7,6 +7,7 @@ export type ObservationStatus = 'active' | 'superseded' | 'dropped';
 @Entity({ name: 'agents_observations' })
 @Index(['agentId', 'observationScopeId', 'status', 'createdAt', 'id'])
 @Index(['agentId', 'observationScopeId', 'createdAt', 'id'])
+@Index(['observationScopeId'])
 @Index(['parentId'])
 @Index(['supersededBy'])
 export class AgentObservationEntity extends WithTimestampsAndStringId {

--- a/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
@@ -233,6 +233,7 @@ describe('AgentChatBridge — consumeStream', () => {
 			expect(agentExecutor.executeForChatPublished).toHaveBeenCalledWith(
 				expect.objectContaining({
 					memory: expect.objectContaining({
+						threadId: expect.objectContaining({ id: 'agent-1:thread-1' }),
 						resourceId: 'integration:test-streaming:thread-1',
 					}),
 				}),

--- a/packages/cli/src/modules/agents/integrations/__tests__/n8n-memory.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/n8n-memory.test.ts
@@ -315,12 +315,12 @@ describe('N8nMemory', () => {
 		});
 	});
 
-	describe('getMessagesForScope', () => {
-		it('queries thread-scoped messages by thread id', async () => {
+	describe('getMessagesForObservationScope', () => {
+		it('queries source messages by observation scope id', async () => {
 			const createdAt = new Date('2026-01-01T00:00:02.000Z');
 			messageRepository.find.mockResolvedValue([makeMessageEntity('m2', createdAt, 'middle')]);
 
-			const result = await memory.getMessagesForScope('thread', 'thread-1');
+			const result = await memory.getMessagesForObservationScope('thread-1');
 
 			expect(messageRepository.find).toHaveBeenCalledWith(
 				expect.objectContaining({
@@ -331,47 +331,38 @@ describe('N8nMemory', () => {
 			expect(result.map((m) => m.id)).toEqual(['m2']);
 		});
 
-		it('filters thread-scoped messages by resourceId when provided', async () => {
+		it('does not filter source messages by resourceId', async () => {
 			messageRepository.find.mockResolvedValue([]);
 
-			await memory.getMessagesForScope('thread', 'thread-1', { resourceId: 'user-2' });
+			await memory.getMessagesForObservationScope('thread-1');
 
 			expect(messageRepository.find).toHaveBeenCalledWith(
 				expect.objectContaining({
-					where: [{ threadId: 'thread-1', resourceId: 'user-2' }],
+					where: [{ threadId: 'thread-1' }],
 				}),
 			);
 		});
 
-		it('applies the cursor keyset for thread scopes', async () => {
+		it('applies the cursor keyset for observation scopes', async () => {
 			const sinceCreatedAt = new Date('2026-01-01T00:00:01.000Z');
 			messageRepository.find.mockResolvedValue([]);
 
-			await memory.getMessagesForScope('thread', 'thread-1', {
-				resourceId: 'user-2',
+			await memory.getMessagesForObservationScope('thread-1', {
 				since: { sinceCreatedAt, sinceMessageId: 'm1' },
 			});
 
 			expect(messageRepository.find).toHaveBeenCalledWith(
 				expect.objectContaining({
 					where: [
-						{ threadId: 'thread-1', resourceId: 'user-2', createdAt: MoreThan(sinceCreatedAt) },
+						{ threadId: 'thread-1', createdAt: MoreThan(sinceCreatedAt) },
 						{
 							threadId: 'thread-1',
-							resourceId: 'user-2',
 							createdAt: Equal(sinceCreatedAt),
 							id: MoreThan('m1'),
 						},
 					],
 				}),
 			);
-		});
-
-		it('rejects non-thread scopes in v1', async () => {
-			await expect(memory.getMessagesForScope('resource', 'agent-1:user-1')).rejects.toThrow(
-				/not supported/,
-			);
-			expect(messageRepository.find).not.toHaveBeenCalled();
 		});
 
 		it('returns createdAt as a Date when the content JSON stores it as an ISO string', async () => {
@@ -383,7 +374,7 @@ describe('N8nMemory', () => {
 			};
 			messageRepository.find.mockResolvedValue([entity]);
 
-			const [result] = await memory.getMessagesForScope('thread', 'thread-1');
+			const [result] = await memory.getMessagesForObservationScope('thread-1');
 
 			expect(result.createdAt).toBeInstanceOf(Date);
 			expect(result.createdAt.toISOString()).toBe(createdAt.toISOString());
@@ -474,41 +465,29 @@ describe('N8nMemory', () => {
 		it('deletes thread-scoped observation state and the thread row in one transaction', async () => {
 			await memory.deleteThread('thread-1');
 
-			const legacyScope = { scopeKind: 'thread' as const, scopeId: 'thread-1' };
-			const resourceScope = {
-				scopeKind: 'thread' as const,
-				scopeId: Like('thread:thread-1:resource:%'),
-			};
+			const observationScope = { agentId: 'agent-1', observationScopeId: 'thread-1' };
 			expect(runInTransaction).toHaveBeenCalledWith(expect.any(Function));
-			expect(transactionDelete).toHaveBeenNthCalledWith(1, AgentObservationEntity, legacyScope);
+			expect(transactionDelete).toHaveBeenNthCalledWith(
+				1,
+				AgentObservationEntity,
+				observationScope,
+			);
 			expect(transactionDelete).toHaveBeenNthCalledWith(
 				2,
 				AgentObservationCursorEntity,
-				legacyScope,
+				observationScope,
 			);
-			expect(transactionDelete).toHaveBeenNthCalledWith(3, AgentObservationLockEntity, legacyScope);
+			expect(transactionDelete).toHaveBeenNthCalledWith(
+				3,
+				AgentObservationLockEntity,
+				observationScope,
+			);
 			expect(transactionDelete).toHaveBeenNthCalledWith(
 				4,
 				AgentMemoryEntryCursorEntity,
-				legacyScope,
+				observationScope,
 			);
-			expect(transactionDelete).toHaveBeenNthCalledWith(5, AgentObservationEntity, resourceScope);
-			expect(transactionDelete).toHaveBeenNthCalledWith(
-				6,
-				AgentObservationCursorEntity,
-				resourceScope,
-			);
-			expect(transactionDelete).toHaveBeenNthCalledWith(
-				7,
-				AgentObservationLockEntity,
-				resourceScope,
-			);
-			expect(transactionDelete).toHaveBeenNthCalledWith(
-				8,
-				AgentMemoryEntryCursorEntity,
-				resourceScope,
-			);
-			expect(transactionDelete).toHaveBeenNthCalledWith(9, AgentThreadEntity, { id: 'thread-1' });
+			expect(transactionDelete).toHaveBeenNthCalledWith(5, AgentThreadEntity, { id: 'thread-1' });
 			expect(observationRepository.delete).not.toHaveBeenCalled();
 			expect(observationCursorRepository.delete).not.toHaveBeenCalled();
 			expect(observationLockRepository.delete).not.toHaveBeenCalled();
@@ -576,41 +555,32 @@ describe('N8nMemory', () => {
 		it('deletes thread-scoped observation state by thread id prefix in one transaction', async () => {
 			await memory.deleteThreadsByPrefix('test-agent-1');
 
-			const legacyScope = { scopeKind: 'thread' as const, scopeId: Like('test-agent-1%') };
-			const resourceScope = {
-				scopeKind: 'thread' as const,
-				scopeId: Like('thread:test-agent-1:resource:%'),
+			const observationScope = {
+				agentId: 'agent-1',
+				observationScopeId: Like('test-agent-1%'),
 			};
 			expect(runInTransaction).toHaveBeenCalledWith(expect.any(Function));
-			expect(transactionDelete).toHaveBeenNthCalledWith(1, AgentObservationEntity, legacyScope);
+			expect(transactionDelete).toHaveBeenNthCalledWith(
+				1,
+				AgentObservationEntity,
+				observationScope,
+			);
 			expect(transactionDelete).toHaveBeenNthCalledWith(
 				2,
 				AgentObservationCursorEntity,
-				legacyScope,
+				observationScope,
 			);
-			expect(transactionDelete).toHaveBeenNthCalledWith(3, AgentObservationLockEntity, legacyScope);
+			expect(transactionDelete).toHaveBeenNthCalledWith(
+				3,
+				AgentObservationLockEntity,
+				observationScope,
+			);
 			expect(transactionDelete).toHaveBeenNthCalledWith(
 				4,
 				AgentMemoryEntryCursorEntity,
-				legacyScope,
+				observationScope,
 			);
-			expect(transactionDelete).toHaveBeenNthCalledWith(5, AgentObservationEntity, resourceScope);
-			expect(transactionDelete).toHaveBeenNthCalledWith(
-				6,
-				AgentObservationCursorEntity,
-				resourceScope,
-			);
-			expect(transactionDelete).toHaveBeenNthCalledWith(
-				7,
-				AgentObservationLockEntity,
-				resourceScope,
-			);
-			expect(transactionDelete).toHaveBeenNthCalledWith(
-				8,
-				AgentMemoryEntryCursorEntity,
-				resourceScope,
-			);
-			expect(transactionDelete).toHaveBeenNthCalledWith(9, AgentThreadEntity, {
+			expect(transactionDelete).toHaveBeenNthCalledWith(5, AgentThreadEntity, {
 				id: Like('test-agent-1%'),
 			});
 			expect(observationRepository.delete).not.toHaveBeenCalled();
@@ -653,8 +623,7 @@ describe('N8nMemory', () => {
 		overrides: Partial<NewObservationLogEntry> = {},
 	): NewObservationLogEntry {
 		return {
-			scopeKind: 'resource',
-			scopeId: 't-1',
+			observationScopeId: 't-1',
 			marker: 'important',
 			text: 'hello',
 			createdAt: new Date('2026-05-05T00:00:00Z'),
@@ -667,8 +636,8 @@ describe('N8nMemory', () => {
 	): AgentObservationEntity {
 		return {
 			id: 'obs-1',
-			scopeKind: 'thread',
-			scopeId: 't-1',
+			agentId: 'agent-1',
+			observationScopeId: 't-1',
 			marker: 'important',
 			text: 'Observation',
 			parentId: null,
@@ -774,8 +743,7 @@ describe('N8nMemory', () => {
 
 		it('passes filters through to find()', async () => {
 			await memory.getObservationLog({
-				scopeKind: 'resource',
-				scopeId: 't-1',
+				observationScopeId: 't-1',
 				status: 'active',
 				parentId: null,
 				limit: 10,
@@ -785,8 +753,8 @@ describe('N8nMemory', () => {
 			expect(observationRepository.find).toHaveBeenCalledWith({
 				where: [
 					{
-						scopeKind: 'resource',
-						scopeId: 't-1',
+						agentId: 'agent-1',
+						observationScopeId: 't-1',
 						status: 'active',
 						parentId: IsNull(),
 					},
@@ -797,10 +765,10 @@ describe('N8nMemory', () => {
 		});
 
 		it('active read filters out non-active rows', async () => {
-			await memory.getActiveObservationLog({ scopeKind: 'resource', scopeId: 't-1' });
+			await memory.getActiveObservationLog({ observationScopeId: 't-1' });
 
 			expect(observationRepository.find).toHaveBeenCalledWith({
-				where: [{ scopeKind: 'resource', scopeId: 't-1', status: 'active' }],
+				where: [{ agentId: 'agent-1', observationScopeId: 't-1', status: 'active' }],
 				order: { createdAt: 'ASC', id: 'ASC' },
 			});
 		});
@@ -809,8 +777,8 @@ describe('N8nMemory', () => {
 			observationRepository.find.mockResolvedValue([
 				{
 					id: 'obs-1',
-					scopeKind: 'resource',
-					scopeId: 't-1',
+					agentId: 'agent-1',
+					observationScopeId: 't-1',
 					marker: 'important',
 					text: 'hi',
 					parentId: null,
@@ -822,7 +790,7 @@ describe('N8nMemory', () => {
 				} as AgentObservationEntity,
 			]);
 
-			const [row] = await memory.getObservationLog({ scopeKind: 'resource', scopeId: 't-1' });
+			const [row] = await memory.getObservationLog({ observationScopeId: 't-1' });
 			expect(row).toMatchObject({
 				id: 'obs-1',
 				marker: 'important',
@@ -868,7 +836,7 @@ describe('N8nMemory', () => {
 			]);
 
 			const result = await memory.applyObservationLogReflection(
-				{ scopeKind: 'thread', scopeId: 't-1' },
+				{ observationScopeId: 't-1' },
 				{
 					drop: ['drop-1'],
 					merge: [
@@ -883,13 +851,13 @@ describe('N8nMemory', () => {
 
 			expect(observationRunInTransaction).toHaveBeenCalledWith(expect.any(Function));
 			expect(transactionObservationFind).toHaveBeenCalledWith({
-				where: { scopeKind: 'thread', scopeId: 't-1', status: 'active' },
+				where: { agentId: 'agent-1', observationScopeId: 't-1', status: 'active' },
 				order: { createdAt: 'ASC', id: 'ASC' },
 			});
 			expect(transactionObservationCreate).toHaveBeenCalledWith(
 				expect.objectContaining({
-					scopeKind: 'thread',
-					scopeId: 't-1',
+					agentId: 'agent-1',
+					observationScopeId: 't-1',
 					marker: 'important',
 					text: 'Merged observation',
 					parentId: null,
@@ -900,12 +868,12 @@ describe('N8nMemory', () => {
 			);
 			expect(transactionObservationUpdate).toHaveBeenNthCalledWith(
 				1,
-				{ scopeKind: 'thread', scopeId: 't-1', id: In(['drop-1']) },
+				{ agentId: 'agent-1', observationScopeId: 't-1', id: In(['drop-1']) },
 				{ status: 'dropped', supersededBy: null },
 			);
 			expect(transactionObservationUpdate).toHaveBeenNthCalledWith(
 				2,
-				{ scopeKind: 'thread', scopeId: 't-1', id: In(['old-1', 'old-2']) },
+				{ agentId: 'agent-1', observationScopeId: 't-1', id: In(['old-1', 'old-2']) },
 				{ status: 'superseded', supersededBy: 'merged-1' },
 			);
 			expect(result).toMatchObject({
@@ -927,7 +895,7 @@ describe('N8nMemory', () => {
 			]);
 
 			const result = await memory.applyObservationLogReflection(
-				{ scopeKind: 'thread', scopeId: 't-1' },
+				{ observationScopeId: 't-1' },
 				{
 					drop: ['child'],
 					merge: [{ supersedes: ['parent'], marker: 'important', text: 'Case resolved' }],
@@ -936,7 +904,7 @@ describe('N8nMemory', () => {
 
 			expect(transactionObservationUpdate).toHaveBeenCalledTimes(1);
 			expect(transactionObservationUpdate).toHaveBeenCalledWith(
-				{ scopeKind: 'thread', scopeId: 't-1', id: In(['parent', 'child']) },
+				{ agentId: 'agent-1', observationScopeId: 't-1', id: In(['parent', 'child']) },
 				{ status: 'superseded', supersededBy: 'merged-1' },
 			);
 			expect(result).toMatchObject({
@@ -949,30 +917,29 @@ describe('N8nMemory', () => {
 	describe('cursors', () => {
 		it('returns null when no cursor row exists', async () => {
 			observationCursorRepository.findOneBy.mockResolvedValue(null);
-			expect(await memory.getCursor('thread', 't-1')).toBeNull();
+			expect(await memory.getCursor('t-1')).toBeNull();
 		});
 
 		it('reads lastObservedAt and lastObservedMessageId', async () => {
 			const lastObservedAt = new Date('2026-05-05T00:00:00.250Z');
 			observationCursorRepository.findOneBy.mockResolvedValue({
-				scopeKind: 'thread',
-				scopeId: 't-1',
+				agentId: 'agent-1',
+				observationScopeId: 't-1',
 				lastObservedMessageId: 'm-7',
 				lastObservedAt,
 				createdAt: new Date(),
 				updatedAt: new Date('2026-05-05T00:00:00Z'),
 			} as AgentObservationCursorEntity);
 
-			const cursor = await memory.getCursor('thread', 't-1');
+			const cursor = await memory.getCursor('t-1');
 			expect(cursor?.lastObservedAt.getTime()).toBe(lastObservedAt.getTime());
 			expect(cursor?.lastObservedMessageId).toBe('m-7');
 		});
 
-		it('upserts on setCursor with cursor-advance fields keyed by (scopeKind, scopeId)', async () => {
+		it('upserts on setCursor with cursor-advance fields keyed by agent and observation scope', async () => {
 			const lastObservedAt = new Date('2026-05-05T00:00:00.500Z');
 			await memory.setCursor({
-				scopeKind: 'thread',
-				scopeId: 't-1',
+				observationScopeId: 't-1',
 				lastObservedMessageId: 'm-9',
 				lastObservedAt,
 				updatedAt: new Date('2026-05-05T00:00:00Z'),
@@ -980,12 +947,12 @@ describe('N8nMemory', () => {
 
 			expect(observationCursorRepository.upsert).toHaveBeenCalledWith(
 				expect.objectContaining({
-					scopeKind: 'thread',
-					scopeId: 't-1',
+					agentId: 'agent-1',
+					observationScopeId: 't-1',
 					lastObservedMessageId: 'm-9',
 					lastObservedAt,
 				}),
-				expect.objectContaining({ conflictPaths: ['scopeKind', 'scopeId'] }),
+				expect.objectContaining({ conflictPaths: ['agentId', 'observationScopeId'] }),
 			);
 			const call = observationCursorRepository.upsert.mock.calls[0][0] as Record<string, unknown>;
 			expect(call).not.toHaveProperty('summary');
@@ -1038,15 +1005,15 @@ describe('N8nMemory', () => {
 			const { insertQueryBuilder } = mockLockWrite({
 				updateAffected: 0,
 				claimed: {
-					scopeKind: 'thread',
-					scopeId: 't-1',
+					agentId: 'agent-1',
+					observationScopeId: 't-1',
 					taskKind: 'observer',
 					holderId: 'A',
 					heldUntil: new Date(Date.now() + 60_000),
 				} as AgentObservationLockEntity,
 			});
 
-			const handle = await memory.acquireObservationLogTaskLock('thread', 't-1', 'observer', {
+			const handle = await memory.acquireObservationLogTaskLock('t-1', 'observer', {
 				ttlMs: 60_000,
 				holderId: 'A',
 			});
@@ -1060,7 +1027,7 @@ describe('N8nMemory', () => {
 		it('attempts a conditional write before reading the lock row', async () => {
 			mockLockWrite({ updateAffected: 1 });
 
-			const handle = await memory.acquireObservationLogTaskLock('thread', 't-1', 'observer', {
+			const handle = await memory.acquireObservationLogTaskLock('t-1', 'observer', {
 				ttlMs: 60_000,
 				holderId: 'A',
 			});
@@ -1072,7 +1039,7 @@ describe('N8nMemory', () => {
 		it('stores the task kind for scoped observation-log task locks', async () => {
 			const { updateQueryBuilder } = mockLockWrite({ updateAffected: 1 });
 
-			const handle = await memory.acquireObservationLogTaskLock('thread', 't-1', 'reflector', {
+			const handle = await memory.acquireObservationLogTaskLock('t-1', 'reflector', {
 				ttlMs: 60_000,
 				holderId: 'A',
 			});
@@ -1086,7 +1053,7 @@ describe('N8nMemory', () => {
 		it('refuses a different holder while the lock is live', async () => {
 			mockLockWrite({ updateAffected: 0 });
 
-			const handle = await memory.acquireObservationLogTaskLock('thread', 't-1', 'observer', {
+			const handle = await memory.acquireObservationLogTaskLock('t-1', 'observer', {
 				ttlMs: 60_000,
 				holderId: 'B',
 			});
@@ -1097,7 +1064,7 @@ describe('N8nMemory', () => {
 		it('reclaims the lock for a new holder once the prior one has expired', async () => {
 			const { updateQueryBuilder } = mockLockWrite({ updateAffected: 1 });
 
-			const handle = await memory.acquireObservationLogTaskLock('thread', 't-1', 'observer', {
+			const handle = await memory.acquireObservationLogTaskLock('t-1', 'observer', {
 				ttlMs: 60_000,
 				holderId: 'B',
 			});
@@ -1115,7 +1082,7 @@ describe('N8nMemory', () => {
 		it('lets the same holder refresh the TTL while still held', async () => {
 			mockLockWrite({ updateAffected: 1 });
 
-			const handle = await memory.acquireObservationLogTaskLock('thread', 't-1', 'observer', {
+			const handle = await memory.acquireObservationLogTaskLock('t-1', 'observer', {
 				ttlMs: 60_000,
 				holderId: 'A',
 			});
@@ -1125,15 +1092,14 @@ describe('N8nMemory', () => {
 
 		it('release deletes only the matching holder', async () => {
 			await memory.releaseObservationLogTaskLock({
-				scopeKind: 'resource',
-				scopeId: 't-1',
+				observationScopeId: 't-1',
 				taskKind: 'observer',
 				holderId: 'A',
 				heldUntil: new Date(),
 			});
 			expect(observationLockRepository.delete).toHaveBeenCalledWith({
-				scopeKind: 'resource',
-				scopeId: 't-1',
+				agentId: 'agent-1',
+				observationScopeId: 't-1',
 				taskKind: 'observer',
 				holderId: 'A',
 			});
@@ -1141,15 +1107,14 @@ describe('N8nMemory', () => {
 
 		it('releases observation-log task locks by scope and holder', async () => {
 			await memory.releaseObservationLogTaskLock({
-				scopeKind: 'resource',
-				scopeId: 't-1',
+				observationScopeId: 't-1',
 				taskKind: 'reflector',
 				holderId: 'A',
 				heldUntil: new Date(),
 			});
 			expect(observationLockRepository.delete).toHaveBeenCalledWith({
-				scopeKind: 'resource',
-				scopeId: 't-1',
+				agentId: 'agent-1',
+				observationScopeId: 't-1',
 				taskKind: 'reflector',
 				holderId: 'A',
 			});
@@ -1631,23 +1596,24 @@ describe('N8nMemory', () => {
 			const { insertQueryBuilder, updateQueryBuilder } = mockEpisodicCursorWrite();
 
 			await memory.episodic.setCursor({
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:resource-1',
+				observationScopeId: 'thread-1',
 				lastIndexedObservationId: 'obs-1',
 				lastIndexedObservationCreatedAt,
 			});
 
 			expect(insertQueryBuilder.values).toHaveBeenCalledWith(
 				expect.objectContaining({
-					scopeKind: 'thread',
-					scopeId: 'thread:thread-1:resource:resource-1',
+					agentId: 'agent-1',
+					observationScopeId: 'thread-1',
 					lastIndexedObservationId: 'obs-1',
 					lastIndexedObservationCreatedAt,
 				}),
 			);
 			expect(insertQueryBuilder.orIgnore).toHaveBeenCalled();
-			expect(updateQueryBuilder.where).toHaveBeenCalledWith('"scopeKind" = :scopeKind');
-			expect(updateQueryBuilder.andWhere).toHaveBeenCalledWith('"scopeId" = :scopeId');
+			expect(updateQueryBuilder.where).toHaveBeenCalledWith('"agentId" = :agentId');
+			expect(updateQueryBuilder.andWhere).toHaveBeenCalledWith(
+				'"observationScopeId" = :observationScopeId',
+			);
 			expect(updateQueryBuilder.andWhere).toHaveBeenCalledWith(
 				expect.stringContaining(
 					'"lastIndexedObservationCreatedAt" < :lastIndexedObservationCreatedAt',
@@ -1657,8 +1623,8 @@ describe('N8nMemory', () => {
 				expect.stringContaining('"lastIndexedObservationId" < :lastIndexedObservationId'),
 			);
 			expect(updateQueryBuilder.setParameters).toHaveBeenCalledWith({
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:resource-1',
+				agentId: 'agent-1',
+				observationScopeId: 'thread-1',
 				lastIndexedObservationId: 'obs-1',
 				lastIndexedObservationCreatedAt,
 			});
@@ -1668,8 +1634,8 @@ describe('N8nMemory', () => {
 		it('reads episodic cursors as dates', async () => {
 			const lastIndexedObservationCreatedAt = new Date('2026-05-05T00:00:00Z');
 			memoryEntryCursorRepository.findOneBy.mockResolvedValue({
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:resource-1',
+				agentId: 'agent-1',
+				observationScopeId: 'thread-1',
 				lastIndexedObservationId: 'obs-1',
 				lastIndexedObservationCreatedAt,
 				createdAt: new Date('2026-05-05T00:00:00Z'),
@@ -1677,8 +1643,7 @@ describe('N8nMemory', () => {
 			} as AgentMemoryEntryCursorEntity);
 
 			const cursor = await memory.episodic.getCursor({
-				scopeKind: 'thread',
-				scopeId: 'thread:thread-1:resource:resource-1',
+				observationScopeId: 'thread-1',
 			});
 
 			expect(cursor?.lastIndexedObservationId).toBe('obs-1');

--- a/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
@@ -187,18 +187,12 @@ export class AgentChatBridge {
 	// Thread ID resolution — single place to apply per-platform formatting
 	// ---------------------------------------------------------------------------
 
-	/**
-	 * Resolve the thread ID to pass to the agents service.
-	 *
-	 * Delegates to `integration.formatThreadId.fromSdk` when the platform
-	 * provides one (e.g. Slack encodes channel + ts), otherwise falls back
-	 * to the raw Chat SDK `thread.id`.
-	 *
-	 * Every call site that hands a threadId to `AgentExecutor` MUST use this
-	 * helper so platform-specific formatting is never accidentally skipped.
-	 */
-	private resolveThreadId(thread: Thread<unknown, unknown>) {
-		return toInternalThreadId(this.integrationImpl?.formatThreadId?.fromSdk(thread) ?? thread.id);
+	private resolvePlatformThreadId(thread: Thread<unknown, unknown>) {
+		return this.integrationImpl?.formatThreadId?.fromSdk(thread) ?? thread.id;
+	}
+
+	private toAgentThreadId(platformThreadId: string) {
+		return toInternalThreadId(`${this.agentId}:${platformThreadId}`);
 	}
 
 	/**
@@ -224,10 +218,10 @@ export class AgentChatBridge {
 		const text = message.text?.trim();
 		if (!text) return;
 
-		const threadId = this.resolveThreadId(thread);
-		// threadId.id already encodes platform + user identity (e.g. Telegram:
-		// "chat:botId-userId") so it partitions Episodic Memory for this
-		// integration context without leaking the n8n user identity.
+		const platformThreadId = this.resolvePlatformThreadId(thread);
+		const threadId = this.toAgentThreadId(platformThreadId);
+		// threadId.id is agent-prefixed for observation storage; resourceId keeps
+		// the platform identity so episodic recall remains agent + resource scoped.
 		// Always run the published snapshot — integrations are production traffic.
 		const stream = this.agentService.executeForChatPublished({
 			agentId: this.agentId,
@@ -235,7 +229,7 @@ export class AgentChatBridge {
 			message: text,
 			memory: {
 				threadId,
-				resourceId: integrationMemoryResourceId(this.integration.type, threadId.id),
+				resourceId: integrationMemoryResourceId(this.integration.type, platformThreadId),
 			},
 			integrationType: this.integration.type,
 		});

--- a/packages/cli/src/modules/agents/integrations/n8n-memory.ts
+++ b/packages/cli/src/modules/agents/integrations/n8n-memory.ts
@@ -2,7 +2,6 @@ import {
 	activeLifecycleState,
 	droppedLifecycleState,
 	normalizeObservationLogReflection,
-	createObservationLogThreadScopePrefix,
 	hashEpisodicMemoryContent,
 	hashEpisodicMemoryEvidence,
 	markLifecycleActive,
@@ -36,7 +35,6 @@ import {
 	type ObservationLogReflection,
 	type ObservationLogReflectionResult,
 	type ObservationLogScope,
-	type ObservationLogScopeKind,
 	type ObservationLogTaskKind,
 	type ObservationLogTaskLockHandle,
 	type RetrievedEpisodicMemoryEntry,
@@ -46,7 +44,6 @@ import { Service } from '@n8n/di';
 import type { EntityManager, FindOperator, FindOptionsWhere } from '@n8n/typeorm';
 import { Equal, In, IsNull, LessThan, Like, MoreThan } from '@n8n/typeorm';
 import type { QueryDeepPartialEntity } from '@n8n/typeorm/query-builder/QueryPartialEntity';
-import { UnexpectedError } from 'n8n-workflow';
 
 import { isUniqueConstraintError } from '@/response-helper';
 
@@ -190,36 +187,25 @@ export class N8nMemoryImpl
 	async deleteThread(threadId: string): Promise<void> {
 		await this.threadRepository.manager.transaction(async (trx) => {
 			await this.dropEpisodicEntriesWithoutSources(trx, threadId);
-			const legacyScope = { scopeKind: 'thread' as const, scopeId: threadId };
-			const resourceScope = {
-				scopeKind: 'thread' as const,
-				scopeId: Like(`${createObservationLogThreadScopePrefix(threadId)}%`),
-			};
-			for (const scope of [legacyScope, resourceScope]) {
-				await trx.delete(AgentObservationEntity, scope);
-				await trx.delete(AgentObservationCursorEntity, scope);
-				await trx.delete(AgentObservationLockEntity, scope);
-				await trx.delete(AgentMemoryEntryCursorEntity, scope);
-			}
+			const observationScope = { agentId: this.agentId, observationScopeId: threadId };
+			await trx.delete(AgentObservationEntity, observationScope);
+			await trx.delete(AgentObservationCursorEntity, observationScope);
+			await trx.delete(AgentObservationLockEntity, observationScope);
+			await trx.delete(AgentMemoryEntryCursorEntity, observationScope);
 			await trx.delete(AgentThreadEntity, { id: threadId });
 		});
 	}
 
 	async deleteThreadsByPrefix(threadIdPrefix: string): Promise<void> {
-		const scopeId = Like(`${threadIdPrefix}%`);
-		const resourceScopeId = Like(`${createObservationLogThreadScopePrefix(threadIdPrefix)}%`);
+		const observationScopeId = Like(`${threadIdPrefix}%`);
 		await this.threadRepository.manager.transaction(async (trx) => {
-			await this.dropEpisodicEntriesWithoutSources(trx, scopeId);
-			for (const scope of [
-				{ scopeKind: 'thread' as const, scopeId },
-				{ scopeKind: 'thread' as const, scopeId: resourceScopeId },
-			]) {
-				await trx.delete(AgentObservationEntity, scope);
-				await trx.delete(AgentObservationCursorEntity, scope);
-				await trx.delete(AgentObservationLockEntity, scope);
-				await trx.delete(AgentMemoryEntryCursorEntity, scope);
-			}
-			await trx.delete(AgentThreadEntity, { id: scopeId });
+			await this.dropEpisodicEntriesWithoutSources(trx, observationScopeId);
+			const observationScope = { agentId: this.agentId, observationScopeId };
+			await trx.delete(AgentObservationEntity, observationScope);
+			await trx.delete(AgentObservationCursorEntity, observationScope);
+			await trx.delete(AgentObservationLockEntity, observationScope);
+			await trx.delete(AgentMemoryEntryCursorEntity, observationScope);
+			await trx.delete(AgentThreadEntity, { id: observationScopeId });
 		});
 	}
 
@@ -337,8 +323,8 @@ export class N8nMemoryImpl
 
 		const entities: AgentObservationEntity[] = rows.map((row) =>
 			this.observationRepository.create({
-				scopeKind: row.scopeKind,
-				scopeId: row.scopeId,
+				agentId: this.agentId,
+				observationScopeId: row.observationScopeId,
 				marker: row.marker,
 				text: row.text,
 				parentId: row.parentId ?? null,
@@ -360,8 +346,8 @@ export class N8nMemoryImpl
 
 	async getObservationLog(opts: ObservationLogReadOptions): Promise<ObservationLogEntry[]> {
 		const baseWhere: FindOptionsWhere<AgentObservationEntity> = {
-			scopeKind: opts.scopeKind,
-			scopeId: opts.scopeId,
+			agentId: this.agentId,
+			observationScopeId: opts.observationScopeId,
 			...(opts.status !== undefined && { status: opts.status }),
 			...(opts.parentId !== undefined && { parentId: opts.parentId ?? IsNull() }),
 		};
@@ -377,20 +363,12 @@ export class N8nMemoryImpl
 		return entities.map((e) => this.toObservationLogEntry(e));
 	}
 
-	async getMessagesForScope(
-		scopeKind: ObservationLogScopeKind,
-		scopeId: string,
-		opts?: { since?: { sinceCreatedAt: Date; sinceMessageId: string }; resourceId?: string },
+	async getMessagesForObservationScope(
+		observationScopeId: string,
+		opts?: { since?: { sinceCreatedAt: Date; sinceMessageId: string } },
 	): Promise<AgentDbMessage[]> {
-		if (scopeKind !== 'thread') {
-			throw new UnexpectedError(
-				`getMessagesForScope: scopeKind='${scopeKind}' is not supported in observational memory v1`,
-			);
-		}
-
 		const baseWhere: FindOptionsWhere<AgentMessageEntity> = {
-			threadId: scopeId,
-			...(opts?.resourceId !== undefined && { resourceId: opts.resourceId }),
+			threadId: observationScopeId,
 		};
 		const where: FindOptionsWhere<AgentMessageEntity>[] = opts?.since
 			? [
@@ -431,8 +409,8 @@ export class N8nMemoryImpl
 			const repo = trx.getRepository(AgentObservationEntity);
 			const activeEntries = await repo.find({
 				where: {
-					scopeKind: scope.scopeKind,
-					scopeId: scope.scopeId,
+					agentId: this.agentId,
+					observationScopeId: scope.observationScopeId,
 					status: 'active',
 				},
 				order: { createdAt: 'ASC', id: 'ASC' },
@@ -445,8 +423,8 @@ export class N8nMemoryImpl
 				? await repo.save(
 						normalized.merge.map((entry) =>
 							repo.create({
-								scopeKind: scope.scopeKind,
-								scopeId: scope.scopeId,
+								agentId: this.agentId,
+								observationScopeId: scope.observationScopeId,
 								marker: entry.marker,
 								text: entry.text,
 								parentId: entry.parentId ?? null,
@@ -460,7 +438,11 @@ export class N8nMemoryImpl
 
 			if (normalized.drop.length > 0) {
 				await repo.update(
-					{ scopeKind: scope.scopeKind, scopeId: scope.scopeId, id: In(normalized.drop) },
+					{
+						agentId: this.agentId,
+						observationScopeId: scope.observationScopeId,
+						id: In(normalized.drop),
+					},
 					droppedLifecycleState(),
 				);
 			}
@@ -469,7 +451,11 @@ export class N8nMemoryImpl
 				const replacement = inserted[index];
 				if (replacement && merge.supersedes.length > 0) {
 					await repo.update(
-						{ scopeKind: scope.scopeKind, scopeId: scope.scopeId, id: In(merge.supersedes) },
+						{
+							agentId: this.agentId,
+							observationScopeId: scope.observationScopeId,
+							id: In(merge.supersedes),
+						},
 						supersededLifecycleState(replacement.id),
 					);
 				}
@@ -485,41 +471,40 @@ export class N8nMemoryImpl
 
 	// ── Observational memory: cursors ────────────────────────────────────
 
-	async getCursor(
-		scopeKind: ObservationLogScopeKind,
-		scopeId: string,
-	): Promise<ObservationCursor | null> {
-		const entity = await this.observationCursorRepository.findOneBy({ scopeKind, scopeId });
+	async getCursor(observationScopeId: string): Promise<ObservationCursor | null> {
+		const entity = await this.observationCursorRepository.findOneBy({
+			agentId: this.agentId,
+			observationScopeId,
+		});
 		if (!entity) return null;
 		return {
-			scopeKind: entity.scopeKind,
-			scopeId: entity.scopeId,
+			observationScopeId: entity.observationScopeId,
 			lastObservedMessageId: entity.lastObservedMessageId,
 			lastObservedAt: entity.lastObservedAt,
 			updatedAt: entity.updatedAt,
 		};
 	}
 
-	async setCursor(
-		cursor: ObservationCursor & { scopeKind: ObservationLogScopeKind },
-	): Promise<void> {
+	async setCursor(cursor: ObservationCursor): Promise<void> {
 		await this.observationCursorRepository.upsert(
 			{
-				scopeKind: cursor.scopeKind,
-				scopeId: cursor.scopeId,
+				agentId: this.agentId,
+				observationScopeId: cursor.observationScopeId,
 				lastObservedMessageId: cursor.lastObservedMessageId,
 				lastObservedAt: cursor.lastObservedAt,
 				updatedAt: cursor.updatedAt,
 			},
-			{ conflictPaths: ['scopeKind', 'scopeId'], skipUpdateIfNoValuesChanged: false },
+			{
+				conflictPaths: ['agentId', 'observationScopeId'],
+				skipUpdateIfNoValuesChanged: false,
+			},
 		);
 	}
 
 	// ── Observation log: locks ───────────────────────────────────────────
 
 	async acquireObservationLogTaskLock(
-		scopeKind: ObservationLogScopeKind,
-		scopeId: string,
+		observationScopeId: string,
 		taskKind: ObservationLogTaskKind,
 		opts: { ttlMs: number; holderId: string },
 	): Promise<ObservationLogTaskLockHandle | null> {
@@ -532,34 +517,46 @@ export class N8nMemoryImpl
 			.createQueryBuilder()
 			.update(AgentObservationLockEntity)
 			.set({ taskKind, holderId: opts.holderId, heldUntil })
-			.where('"scopeKind" = :scopeKind')
-			.andWhere('"scopeId" = :scopeId')
+			.where('"agentId" = :agentId')
+			.andWhere('"observationScopeId" = :observationScopeId')
 			.andWhere('"taskKind" = :taskKind')
 			.andWhere('("holderId" = :holderId OR "heldUntil" <= :now)')
-			.setParameters({ scopeKind, scopeId, taskKind, holderId: opts.holderId, now })
+			.setParameters({
+				agentId: this.agentId,
+				observationScopeId,
+				taskKind,
+				holderId: opts.holderId,
+				now,
+			})
 			.execute();
 
 		if ((updateResult.affected ?? 0) > 0) {
-			return { scopeKind, scopeId, taskKind, holderId: opts.holderId, heldUntil };
+			return { observationScopeId, taskKind, holderId: opts.holderId, heldUntil };
 		}
 
 		await this.observationLockRepository
 			.createQueryBuilder()
 			.insert()
 			.into(AgentObservationLockEntity)
-			.values({ scopeKind, scopeId, taskKind, holderId: opts.holderId, heldUntil })
+			.values({
+				agentId: this.agentId,
+				observationScopeId,
+				taskKind,
+				holderId: opts.holderId,
+				heldUntil,
+			})
 			.orIgnore()
 			.execute();
 
 		const claimed = await this.observationLockRepository.findOneBy({
-			scopeKind,
-			scopeId,
+			agentId: this.agentId,
+			observationScopeId,
 			taskKind,
 			holderId: opts.holderId,
 		});
 		if (!claimed) return null;
 
-		return { scopeKind, scopeId, taskKind, holderId: opts.holderId, heldUntil };
+		return { observationScopeId, taskKind, holderId: opts.holderId, heldUntil };
 	}
 
 	async releaseObservationLogTaskLock(handle: ObservationLogTaskLockHandle): Promise<void> {
@@ -568,8 +565,8 @@ export class N8nMemoryImpl
 
 	private async releaseScopeLock(handle: ObservationLogTaskLockHandle): Promise<void> {
 		await this.observationLockRepository.delete({
-			scopeKind: handle.scopeKind,
-			scopeId: handle.scopeId,
+			agentId: this.agentId,
+			observationScopeId: handle.observationScopeId,
 			taskKind: handle.taskKind,
 			holderId: handle.holderId,
 		});
@@ -915,11 +912,13 @@ export class N8nMemoryImpl
 	private async getEpisodicMemoryCursor(
 		scope: ObservationLogScope,
 	): Promise<EpisodicMemoryCursor | null> {
-		const entity = await this.memoryEntryCursorRepository.findOneBy(scope);
+		const entity = await this.memoryEntryCursorRepository.findOneBy({
+			agentId: this.agentId,
+			observationScopeId: scope.observationScopeId,
+		});
 		if (!entity) return null;
 		return {
-			scopeKind: entity.scopeKind,
-			scopeId: entity.scopeId,
+			observationScopeId: entity.observationScopeId,
 			lastIndexedObservationId: entity.lastIndexedObservationId,
 			lastIndexedObservationCreatedAt: entity.lastIndexedObservationCreatedAt,
 			updatedAt: entity.updatedAt,
@@ -928,8 +927,8 @@ export class N8nMemoryImpl
 
 	private async setEpisodicMemoryCursor(cursor: NewEpisodicMemoryCursor): Promise<void> {
 		const cursorRow: QueryDeepPartialEntity<AgentMemoryEntryCursorEntity> = {
-			scopeKind: cursor.scopeKind,
-			scopeId: cursor.scopeId,
+			agentId: this.agentId,
+			observationScopeId: cursor.observationScopeId,
 			lastIndexedObservationId: cursor.lastIndexedObservationId,
 			lastIndexedObservationCreatedAt: cursor.lastIndexedObservationCreatedAt,
 			updatedAt: cursor.updatedAt ?? new Date(),
@@ -947,14 +946,14 @@ export class N8nMemoryImpl
 			.createQueryBuilder()
 			.update(AgentMemoryEntryCursorEntity)
 			.set(cursorRow)
-			.where('"scopeKind" = :scopeKind')
-			.andWhere('"scopeId" = :scopeId')
+			.where('"agentId" = :agentId')
+			.andWhere('"observationScopeId" = :observationScopeId')
 			.andWhere(
 				'("lastIndexedObservationCreatedAt" < :lastIndexedObservationCreatedAt OR ("lastIndexedObservationCreatedAt" = :lastIndexedObservationCreatedAt AND "lastIndexedObservationId" < :lastIndexedObservationId))',
 			)
 			.setParameters({
-				scopeKind: cursor.scopeKind,
-				scopeId: cursor.scopeId,
+				agentId: this.agentId,
+				observationScopeId: cursor.observationScopeId,
 				lastIndexedObservationId: cursor.lastIndexedObservationId,
 				lastIndexedObservationCreatedAt: cursor.lastIndexedObservationCreatedAt,
 			})
@@ -979,8 +978,7 @@ export class N8nMemoryImpl
 	private toObservationLogEntry(entity: AgentObservationEntity): ObservationLogEntry {
 		return {
 			id: entity.id,
-			scopeKind: entity.scopeKind,
-			scopeId: entity.scopeId,
+			observationScopeId: entity.observationScopeId,
 			marker: entity.marker,
 			text: entity.text,
 			parentId: entity.parentId,


### PR DESCRIPTION
## Summary

- Refactor observational memory scope from `scopeKind + scopeId` to a single opaque `observationScopeId`.
- Keep n8n agent identity at the adapter boundary by scoping persisted OM rows with `agentId + observationScopeId`.
- Update OM observations, cursors, locks, task runner keys, in-memory store APIs, observer/reflector inputs, and SDK-facing types to use the new scope shape.
- Update EM indexing cursors to checkpoint source observation streams with `agentId + observationScopeId`, while keeping EM recall partitioned by `agentId + resourceId`.
- Add a migration that clears derived OM/EM memory tables and recreates them with the new agent-bound observation scope schema.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-156/tech-debt-om-scoping

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
