### PR TITLE
fix(core): Make MCP registry nodes discoverable in Agent Builder

### DIFF
--- a/packages/cli/src/modules/agents/__tests__/agents-tools.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents-tools.service.test.ts
@@ -172,6 +172,11 @@ describe('AgentsToolsService', () => {
 			expect(isAgentToolNodeType('@n8n/n8n-nodes-langchain.lmChatOpenAi')).toBe(false);
 			expect(isAgentToolNodeType('@n8n/n8n-nodes-langchain.agent')).toBe(false);
 		});
+
+		it('admits MCP registry nodes despite the missing Tool suffix', () => {
+			expect(isAgentToolNodeType('@n8n/mcp-registry.notion')).toBe(true);
+			expect(isAgentToolNodeType('@n8n/mcp-registry.linear')).toBe(true);
+		});
 	});
 
 	describe('get_node_types handler', () => {

--- a/packages/cli/src/modules/agents/agents-tools.service.ts
+++ b/packages/cli/src/modules/agents/agents-tools.service.ts
@@ -9,6 +9,7 @@ import { z } from 'zod';
 
 import { EphemeralNodeExecutor, isAgentProviderNode } from '@/node-execution';
 import { NodeCatalogService } from '@/node-catalog';
+import { MCP_REGISTRY_PACKAGE_NAME } from '@/modules/mcp-registry/node-description-transform';
 
 type NodeRequest =
 	| string
@@ -27,6 +28,15 @@ type NodeRequest =
 export const isExecutableNodeType = (nodeId: string): boolean => !isTriggerNodeType(nodeId);
 
 /**
+ * Nodes from the MCP registry package are synthesised at runtime from the
+ * curated catalog and are purpose-built for agent tool use, but their bare
+ * names don't follow the `*Tool` suffix convention `isToolType` checks for —
+ * they're admitted by package id instead.
+ */
+const isMcpRegistryNode = (nodeId: string): boolean =>
+	nodeId.startsWith(`${MCP_REGISTRY_PACKAGE_NAME}.`);
+
+/**
  * Node IDs the agent builder should surface when configuring node-backed
  * tools. For regular nodes marked `usableAsTool`, the loader creates a
  * mirrored `*Tool` node type; native tool nodes already follow this shape.
@@ -40,7 +50,9 @@ export const isExecutableNodeType = (nodeId: string): boolean => !isTriggerNodeT
  */
 export const isAgentToolNodeType = (nodeId: string): boolean =>
 	isExecutableNodeType(nodeId) &&
-	(isToolType(nodeId, { includeHitl: false }) || isAgentProviderNode(nodeId));
+	(isToolType(nodeId, { includeHitl: false }) ||
+		isAgentProviderNode(nodeId) ||
+		isMcpRegistryNode(nodeId));
 
 const searchNodesInputSchema = z.object({
 	queries: z.array(z.string()).min(1).describe('Search queries (e.g., ["gmail", "slack", "http"])'),

--- a/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
+++ b/packages/cli/src/modules/agents/builder/agents-builder-prompts.ts
@@ -104,6 +104,7 @@ Rules for node tools:
 - For every credential slot the node requires, you MUST first call ask_credential. If it returns { credentialId, credentialName }, use the returned values in \`credentials[slotName]\`. Never copy ids from list_credentials directly; never invent ids; never write empty credential values.
 - Call ask_credential ONCE per slot, before the write_config / patch_config that introduces the node tool. If it returns { skipped: true }, DO NOT abort and DO NOT refuse to add the tool. Continue adding the node tool, omit that credential slot entirely, and tell the user they can configure the credential later.
 - Use search_nodes first, never guess node type names
+- When search_nodes returns both an \`@n8n/mcp-registry.*\` node and a native \`n8n-nodes-base.*Tool\` node for the same service (e.g. \`@n8n/mcp-registry.notion\` and \`n8n-nodes-base.notionTool\`), pick the MCP registry variant. It is purpose-built for agent tool use, ships pre-configured connection details, and exposes the service's tools in the shape an agent expects. The result's \`<builder_hint>\` will flag it as the agent-optimised variant. Fall back to the native \`*Tool\` node only when no MCP variant is returned.
 
 ### Custom tools
 Write TypeScript using the Tool builder, validate via build_custom_tool, then register the returned id.

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -109,6 +109,8 @@ import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
 import { NodeTypes } from '@/node-types';
 import { DataTableRepository } from '@/modules/data-table/data-table.repository';
 import { DataTableService } from '@/modules/data-table/data-table.service';
+import { MCP_REGISTRY_PACKAGE_NAME } from '@/modules/mcp-registry/node-description-transform';
+import { synthesizeMcpRegistryTypeDef } from '@/modules/mcp-registry/synthesize-type-def';
 import { SourceControlPreferencesService } from '@/modules/source-control.ee/source-control-preferences.service.ee';
 import { userHasScopes } from '@/permissions.ee/check-access';
 import { DynamicNodeParametersService } from '@/services/dynamic-node-parameters.service';
@@ -1883,13 +1885,31 @@ export class InstanceAiAdapterService {
 			},
 
 			getNodeTypeDefinition: async (nodeType, options) => {
+				const nodes = await getNodes();
+
+				// Synthetic MCP registry nodes have no on-disk type-def, so the
+				// standard resolver would 404 on them. Match either the bare slug
+				// (e.g. `notion`) or the package-prefixed form, then synthesise
+				// the TypeScript content from the in-memory description.
+				const registryNode =
+					nodes.find((n) => n.name === `${MCP_REGISTRY_PACKAGE_NAME}.${nodeType}`) ??
+					(nodeType.startsWith(`${MCP_REGISTRY_PACKAGE_NAME}.`)
+						? nodes.find((n) => n.name === nodeType)
+						: undefined);
+				if (registryNode) {
+					const builderHint = registryNode.builderHint?.searchHint;
+					return {
+						content: synthesizeMcpRegistryTypeDef(registryNode),
+						...(builderHint ? { builderHint } : {}),
+					};
+				}
+
 				const result = resolveNodeTypeDefinition(nodeType, this.getNodeDefinitionDirs(), options);
 
 				if (result.error) {
 					return { content: '', error: result.error };
 				}
 
-				const nodes = await getNodes();
 				const nodeDesc = findNodeByVersion(
 					nodes,
 					nodeType,

--- a/packages/cli/src/modules/mcp-registry/__tests__/synthesize-type-def.test.ts
+++ b/packages/cli/src/modules/mcp-registry/__tests__/synthesize-type-def.test.ts
@@ -1,0 +1,69 @@
+import type { INodeTypeDescription } from 'n8n-workflow';
+
+import { serverToNodeDescription } from '../node-description-transform';
+import { notionMockServer, linearMockServer } from '../registry/mock-servers';
+import { synthesizeMcpRegistryTypeDef } from '../synthesize-type-def';
+
+const baseDescription: INodeTypeDescription = {
+	displayName: 'MCP Registry Client Tool',
+	name: 'mcpRegistryClientTool',
+	icon: 'fa:server',
+	group: ['output'],
+	version: 1,
+	description: 'Connect to a registry-backed MCP server',
+	defaults: { name: 'MCP Registry Client Tool' },
+	inputs: [],
+	outputs: [],
+	codex: {
+		alias: ['MCP', 'Model Context Protocol'],
+		categories: ['AI'],
+		subcategories: { AI: ['Model Context Protocol'] },
+	},
+	credentials: [],
+	properties: [
+		{
+			displayName: 'Endpoint URL',
+			name: 'endpointUrl',
+			type: 'hidden',
+			default: '',
+		},
+		{
+			displayName: 'Server Transport',
+			name: 'serverTransport',
+			type: 'hidden',
+			default: 'httpStreamable',
+		},
+		{
+			displayName: 'Tools to Include',
+			name: 'include',
+			type: 'options',
+			default: 'all',
+			options: [],
+		},
+	],
+};
+
+describe('synthesizeMcpRegistryTypeDef', () => {
+	it('produces TypeScript content for the Notion registry node', () => {
+		const description = serverToNodeDescription(notionMockServer, baseDescription);
+		expect(description).not.toBeNull();
+
+		const content = synthesizeMcpRegistryTypeDef(description!);
+
+		expect(content).toContain('notionMcpOAuth2Api');
+		expect(content).toContain('export');
+		// Hidden fields should not leak into the agent-facing schema.
+		expect(content).not.toContain('endpointUrl');
+		expect(content).not.toContain('serverTransport');
+	});
+
+	it('produces TypeScript content for the Linear registry node', () => {
+		const description = serverToNodeDescription(linearMockServer, baseDescription);
+		expect(description).not.toBeNull();
+
+		const content = synthesizeMcpRegistryTypeDef(description!);
+
+		expect(content).toContain('linearMcpOAuth2Api');
+		expect(content).toContain('export');
+	});
+});

--- a/packages/cli/src/modules/mcp-registry/synthesize-type-def.ts
+++ b/packages/cli/src/modules/mcp-registry/synthesize-type-def.ts
@@ -1,0 +1,70 @@
+import { generateNodeTypeFile } from '@n8n/workflow-sdk';
+import type { NodeTypeDescription as SdkNodeTypeDescription } from '@n8n/workflow-sdk';
+import type { INodeTypeDescription } from 'n8n-workflow';
+
+/**
+ * Generate TypeScript type-definition content for a synthetic MCP registry
+ * node by running its in-memory description through the SDK's standard
+ * generator. The output shape matches the on-disk `dist/node-definitions/`
+ * files produced for native nodes at build time, so consumers
+ * (Agent Builder's `get_node_types`, Instance AI's `type-definition`) can
+ * treat it identically.
+ *
+ * Hidden properties (pre-configured connection details like the endpoint
+ * URL and server transport) are stripped before generation so the agent's
+ * schema only surfaces parameters the agent is meant to set.
+ */
+export function synthesizeMcpRegistryTypeDef(description: INodeTypeDescription): string {
+	const visibleDescription = {
+		...description,
+		properties: description.properties.filter((property) => property.type !== 'hidden'),
+	};
+
+	if (!isSdkNodeTypeDescription(visibleDescription)) {
+		throw new Error(`Cannot synthesize MCP registry type definition for ${description.name}`);
+	}
+
+	return generateNodeTypeFile(visibleDescription);
+}
+
+function isSdkNodeTypeDescription(
+	description: INodeTypeDescription,
+): description is INodeTypeDescription & SdkNodeTypeDescription {
+	return (
+		Array.isArray(description.group) &&
+		Array.isArray(description.properties) &&
+		typeof description.inputs !== 'string' &&
+		typeof description.outputs !== 'string' &&
+		hasSdkConnections(description.inputs) &&
+		hasSdkConnections(description.outputs) &&
+		hasSdkCredentials(description.credentials)
+	);
+}
+
+function hasSdkConnections(
+	connections: INodeTypeDescription['inputs'] | INodeTypeDescription['outputs'],
+): connections is (INodeTypeDescription['inputs'] | INodeTypeDescription['outputs']) &
+	SdkNodeTypeDescription['inputs'] {
+	return (
+		Array.isArray(connections) &&
+		connections.every(
+			(connection) =>
+				typeof connection === 'string' ||
+				(typeof connection.type === 'string' &&
+					(connection.displayName === undefined || typeof connection.displayName === 'string')),
+		)
+	);
+}
+
+function hasSdkCredentials(
+	credentials: INodeTypeDescription['credentials'],
+): credentials is SdkNodeTypeDescription['credentials'] {
+	return (
+		credentials === undefined ||
+		credentials.every(
+			(credential) =>
+				typeof credential.name === 'string' &&
+				(credential.required === undefined || typeof credential.required === 'boolean'),
+		)
+	);
+}

--- a/packages/cli/src/node-catalog/node-catalog.service.ts
+++ b/packages/cli/src/node-catalog/node-catalog.service.ts
@@ -6,9 +6,12 @@ import type {
 import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
 import * as fs from 'fs/promises';
+import type { INodeTypeDescription } from 'n8n-workflow';
 import * as path from 'path';
 
 import { LoadNodesAndCredentials } from '@/load-nodes-and-credentials';
+import { MCP_REGISTRY_PACKAGE_NAME } from '@/modules/mcp-registry/node-description-transform';
+import { synthesizeMcpRegistryTypeDef } from '@/modules/mcp-registry/synthesize-type-def';
 
 export type NodeFilter = (nodeId: string) => boolean;
 
@@ -41,6 +44,13 @@ export class NodeCatalogService {
 	private nodeTypeParser: NodeTypeParser | undefined;
 
 	private nodeDefinitionDirs: string[] = [];
+
+	/**
+	 * Synthetic MCP registry node descriptions indexed by their prefixed name
+	 * (e.g. `@n8n/mcp-registry.notion`). Used by `getNodeTypes` to synthesise
+	 * type-def content for registry slugs, which have no on-disk artifact.
+	 */
+	private mcpRegistryDescriptions = new Map<string, INodeTypeDescription>();
 
 	private initPromise: Promise<void> | undefined;
 
@@ -126,8 +136,33 @@ export class NodeCatalogService {
 		const cached = this.getCache.get(cacheKey);
 		if (cached) return cached;
 
-		const { getNodeTypes } = await import('@n8n/ai-utilities/node-catalog');
-		const result = getNodeTypes(nodeIds, { nodeDefinitionDirs: this.nodeDefinitionDirs });
+		const registryIds: NodeRequest[] = [];
+		const onDiskIds: NodeRequest[] = [];
+		for (const id of nodeIds) {
+			const nodeId = typeof id === 'string' ? id : id.nodeId;
+			if (nodeId.startsWith(`${MCP_REGISTRY_PACKAGE_NAME}.`)) {
+				registryIds.push(id);
+			} else {
+				onDiskIds.push(id);
+			}
+		}
+
+		const parts: string[] = [];
+
+		for (const id of registryIds) {
+			const nodeId = typeof id === 'string' ? id : id.nodeId;
+			const description = this.mcpRegistryDescriptions.get(nodeId);
+			if (description) {
+				parts.push(synthesizeMcpRegistryTypeDef(description));
+			}
+		}
+
+		if (onDiskIds.length > 0) {
+			const { getNodeTypes } = await import('@n8n/ai-utilities/node-catalog');
+			parts.push(getNodeTypes(onDiskIds, { nodeDefinitionDirs: this.nodeDefinitionDirs }));
+		}
+
+		const result = parts.join('\n\n');
 		this.getCache.set(cacheKey, result);
 		return result;
 	}
@@ -152,6 +187,7 @@ export class NodeCatalogService {
 		const { nodes: nodeTypeDescriptions } = await this.loadNodesAndCredentials.collectTypes();
 
 		this.nodeTypeParser = new NodeTypeParserClass(nodeTypeDescriptions);
+		this.indexMcpRegistryDescriptions(nodeTypeDescriptions);
 		this.nodeDefinitionDirs = await this.resolveBuiltinNodeDefinitionDirs();
 
 		setSchemaBaseDirs(this.nodeDefinitionDirs);
@@ -168,6 +204,7 @@ export class NodeCatalogService {
 		const { NodeTypeParser: NodeTypeParserClass } = await import('@n8n/ai-utilities/node-catalog');
 		const { nodes: nodeTypeDescriptions } = await this.loadNodesAndCredentials.collectTypes();
 		this.nodeTypeParser = new NodeTypeParserClass(nodeTypeDescriptions);
+		this.indexMcpRegistryDescriptions(nodeTypeDescriptions);
 
 		this.searchStates.clear();
 
@@ -177,6 +214,16 @@ export class NodeCatalogService {
 		this.logger.debug('NodeCatalogService refreshed node types', {
 			nodeTypeCount: nodeTypeDescriptions.length,
 		});
+	}
+
+	private indexMcpRegistryDescriptions(descriptions: INodeTypeDescription[]): void {
+		this.mcpRegistryDescriptions.clear();
+		const prefix = `${MCP_REGISTRY_PACKAGE_NAME}.`;
+		for (const description of descriptions) {
+			if (description.name.startsWith(prefix)) {
+				this.mcpRegistryDescriptions.set(description.name, description);
+			}
+		}
 	}
 
 	private async resolveBuiltinNodeDefinitionDirs(): Promise<string[]> {


### PR DESCRIPTION
## Summary

> ⚠️ **Stacked PR** — based on [#30887 (Synthesize type-defs for MCP registry nodes)](https://github.com/n8n-io/n8n/pull/30887). Review/merge that one first, then this PR will retarget to `master` automatically. The diff shown here is only the two commits on top of #30887.

Makes Agent Builder aware of MCP-registry nodes (`@n8n/mcp-registry.notion`, `@n8n/mcp-registry.linear`, …) during tool discovery. Two changes:

1. **Admit registry nodes through the agent-tool filter.** `isAgentToolNodeType` in `agents-tools.service.ts` required either an `*Tool` suffix (per `isToolType`) or the agent-provider whitelist. Synthetic registry nodes are bare names (`notion`, `linear`, …) and matched neither, so they were stripped before the search engine could rank them — Agent Builder's `search_nodes` was blind to them. Admit anything under the `@n8n/mcp-registry` package by package id.
2. **Prefer registry variants in the prompt.** When `search_nodes` returns both a registry variant and a native `*Tool` variant for the same service, the registry variant is the right pick — it is purpose-built for agent tool use with pre-configured connection details. Mirrors the equivalent rule already present in Instance AI's workflow-builder prompt.


### How to test

1. Check out this branch (which already includes #30887).
2. Boot with `E2E_TESTS=true pnpm dev:ai` and seed the registry:
   ```bash
   curl -X POST http://localhost:5678/rest/mcp-registry/test/seed
   ```
3. In Agent Builder chat, ask:
   > Create an agent that can read my Notion pages.
4. Expect: `search_nodes` returns `@n8n/mcp-registry.notion`, and the agent picks it over `n8n-nodes-base.notionTool`. Before this PR, `search_nodes` returned nothing for `notion`/`linear` because the filter stripped them upstream of the ranker.

Unit coverage: `packages/cli/src/modules/agents/__tests__/agents-tools.service.test.ts` — new cases assert `isAgentToolNodeType` admits MCP-registry nodes.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4930

Stacked on: #30887

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
