### PR TITLE
fix(core): Bypass pubsub debounce for workflow activation display commands

### DIFF
--- a/packages/cli/src/scaling/constants.ts
+++ b/packages/cli/src/scaling/constants.ts
@@ -31,4 +31,7 @@ export const IMMEDIATE_COMMANDS = new Set<PubSub.Command['command']>([
 	'relay-execution-lifecycle-event',
 	'relay-chat-stream-event',
 	'cancel-test-run',
+	'display-workflow-activation',
+	'display-workflow-deactivation',
+	'display-workflow-activation-error',
 ]);

--- a/packages/cli/src/scaling/pubsub/__tests__/publisher.service.test.ts
+++ b/packages/cli/src/scaling/pubsub/__tests__/publisher.service.test.ts
@@ -141,6 +141,34 @@ describe('Publisher', () => {
 				}),
 			);
 		});
+
+		it.each([
+			'display-workflow-activation',
+			'display-workflow-deactivation',
+			'display-workflow-activation-error',
+		] as const)('should not debounce `%s`', async (command) => {
+			const publisher = new Publisher(
+				logger,
+				redisClientService,
+				instanceSettings,
+				executionsConfig,
+				globalConfig,
+			);
+			const msg = mock<PubSub.Command>({ command });
+
+			await publisher.publishCommand(msg);
+
+			expect(client.publish).toHaveBeenCalledWith(
+				'n8n:n8n.commands',
+				JSON.stringify({
+					...msg,
+					_isMockObject: true,
+					senderId: hostId,
+					selfSend: false,
+					debounce: false,
+				}),
+			);
+		});
 	});
 
 	describe('publishWorkerResponse', () => {

--- a/packages/cli/src/scaling/pubsub/__tests__/subscriber.service.test.ts
+++ b/packages/cli/src/scaling/pubsub/__tests__/subscriber.service.test.ts
@@ -202,6 +202,35 @@ describe('Subscriber', () => {
 			);
 			expect(pubsubEventBus.emit).toHaveBeenCalledTimes(1);
 		});
+
+		it('should deliver each display-workflow-activation immediately without coalescing', () => {
+			const pubsubEventBus = mock<PubSubEventBus>();
+			new Subscriber(
+				mockLogger(),
+				mock(),
+				pubsubEventBus,
+				redisClientService,
+				executionsConfig,
+				globalConfig,
+			);
+
+			const messageHandler = getMessageHandler();
+
+			const payload1 = { workflowId: 'wf-1', activeVersionId: 'v-1' };
+			const payload2 = { workflowId: 'wf-2', activeVersionId: 'v-2' };
+			messageHandler(
+				'n8n:n8n.commands',
+				makeCommandMsg('display-workflow-activation', false, payload1),
+			);
+			messageHandler(
+				'n8n:n8n.commands',
+				makeCommandMsg('display-workflow-activation', false, payload2),
+			);
+
+			expect(pubsubEventBus.emit).toHaveBeenCalledWith('display-workflow-activation', payload1);
+			expect(pubsubEventBus.emit).toHaveBeenCalledWith('display-workflow-activation', payload2);
+			expect(pubsubEventBus.emit).toHaveBeenCalledTimes(2);
+		});
 	});
 
 	describe('MCP relay handling', () => {


### PR DESCRIPTION
## Summary

Something I noticed when reviewing #27676 

In multi-main queue mode, `display-workflow-activation` commands are debounced by command name only (300ms window). When two workflows activate within that window, only the last confirmation reaches follower mains — causing the earlier workflow's UI to time out despite successful activation.

Do not debounce `display-workflow-activation`, `display-workflow-deactivation`, and `display-workflow-activation-error`.

- [x] I have seen this code, I have run this code, and I take responsibility for this code.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3199
