### PR TITLE
feat(core): Add migration, entity + repo for iAi OM (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/migrations/common/1784000000012-CreateInstanceAiObservationTables.ts
+++ b/packages/@n8n/db/src/migrations/common/1784000000012-CreateInstanceAiObservationTables.ts
@@ -27,7 +27,7 @@ export class CreateInstanceAiObservationTables1784000000012 implements Reversibl
 				column('status').varchar(16).notNull.withEnumCheck(OBSERVATION_STATUSES),
 				column('supersededBy').varchar(36),
 			)
-			.withIndexOn(['observationScopeId', 'status'])
+			.withIndexOn(['observationScopeId', 'status', 'createdAt', 'id'])
 			.withIndexOn('parentId')
 			.withIndexOn('supersededBy')
 			.withForeignKey('observationScopeId', {

--- a/packages/@n8n/db/src/migrations/common/1784000000012-CreateInstanceAiObservationTables.ts
+++ b/packages/@n8n/db/src/migrations/common/1784000000012-CreateInstanceAiObservationTables.ts
@@ -1,0 +1,84 @@
+import type { MigrationContext, ReversibleMigration } from '../migration-types';
+
+const OBSERVATION_MARKERS = ['critical', 'important', 'info', 'completion'];
+const OBSERVATION_STATUSES = ['active', 'superseded', 'dropped'];
+const OBSERVATION_TASK_KINDS = ['observer', 'reflector'];
+
+const table = {
+	observations: 'instance_ai_observations',
+	observationCursors: 'instance_ai_observation_cursors',
+	observationLocks: 'instance_ai_observation_locks',
+} as const;
+
+export class CreateInstanceAiObservationTables1784000000012 implements ReversibleMigration {
+	async up({ schemaBuilder: { createTable, column } }: MigrationContext) {
+		await createTable(table.observations)
+			.withColumns(
+				column('id')
+					.varchar(36)
+					.primary.notNull.comment('Application-generated n8n string ID, not a database UUID'),
+				column('observationScopeId').uuid.notNull.comment(
+					'instance_ai_threads.id source stream for this observation log',
+				),
+				column('marker').varchar(16).notNull.withEnumCheck(OBSERVATION_MARKERS),
+				column('text').text.notNull,
+				column('parentId').varchar(36),
+				column('tokenCount').int.notNull.default(0),
+				column('status').varchar(16).notNull.withEnumCheck(OBSERVATION_STATUSES),
+				column('supersededBy').varchar(36),
+			)
+			.withIndexOn(['observationScopeId', 'status'])
+			.withIndexOn('parentId')
+			.withIndexOn('supersededBy')
+			.withForeignKey('observationScopeId', {
+				tableName: 'instance_ai_threads',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			})
+			.withForeignKey('parentId', {
+				tableName: table.observations,
+				columnName: 'id',
+			})
+			.withForeignKey('supersededBy', {
+				tableName: table.observations,
+				columnName: 'id',
+			}).withTimestamps;
+
+		await createTable(table.observationCursors)
+			.withColumns(
+				column('observationScopeId').uuid.notNull.primary.comment(
+					'instance_ai_threads.id source stream checkpointed by this cursor',
+				),
+				column('lastObservedMessageId').varchar(36).notNull,
+				column('lastObservedAt').timestampTimezone(3).notNull,
+			)
+			.withForeignKey('observationScopeId', {
+				tableName: 'instance_ai_threads',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			}).withTimestamps;
+
+		await createTable(table.observationLocks)
+			.withColumns(
+				column('observationScopeId').uuid.notNull.primary.comment(
+					'instance_ai_threads.id source stream locked for observation tasks',
+				),
+				column('taskKind').varchar(20).notNull.primary.withEnumCheck(OBSERVATION_TASK_KINDS),
+				column('holderId')
+					.varchar(64)
+					.notNull.comment('Ephemeral background-task lock owner token, not a user ID'),
+				column('heldUntil').timestampTimezone(3).notNull,
+			)
+			.withForeignKey('observationScopeId', {
+				tableName: 'instance_ai_threads',
+				columnName: 'id',
+				onDelete: 'CASCADE',
+			}).withTimestamps;
+	}
+
+	async down({ schemaBuilder: { dropTable } }: MigrationContext) {
+		await dropTable(table.observationLocks);
+		await dropTable(table.observationCursors);
+		await dropTable(table.observations);
+	}
+}

--- a/packages/@n8n/db/src/migrations/postgresdb/index.ts
+++ b/packages/@n8n/db/src/migrations/postgresdb/index.ts
@@ -187,6 +187,7 @@ import { ResetInstanceAiNativePersistence1784000000008 } from '../common/1784000
 import { CreateAgentMemoryEntryTables1784000000009 } from '../common/1784000000009-CreateAgentMemoryEntryTables';
 import { RefactorAgentObservationScope1784000000010 } from '../common/1784000000010-RefactorAgentObservationScope';
 import { CreateAgentHistoryTable1784000000011 } from '../common/1784000000011-CreateAgentHistoryTable';
+import { CreateInstanceAiObservationTables1784000000012 } from '../common/1784000000012-CreateInstanceAiObservationTables';
 import type { Migration } from '../migration-types';
 
 export const postgresMigrations: Migration[] = [
@@ -379,4 +380,5 @@ export const postgresMigrations: Migration[] = [
 	CreateAgentMemoryEntryTables1784000000009,
 	RefactorAgentObservationScope1784000000010,
 	CreateAgentHistoryTable1784000000011,
+	CreateInstanceAiObservationTables1784000000012,
 ];

--- a/packages/@n8n/db/src/migrations/sqlite/index.ts
+++ b/packages/@n8n/db/src/migrations/sqlite/index.ts
@@ -180,6 +180,7 @@ import { CreateInstanceAiCheckpointTable1784000000007 } from '../common/17840000
 import { ResetInstanceAiNativePersistence1784000000008 } from '../common/1784000000008-ResetInstanceAiNativePersistence';
 import { CreateAgentMemoryEntryTables1784000000009 } from '../common/1784000000009-CreateAgentMemoryEntryTables';
 import { RefactorAgentObservationScope1784000000010 } from '../common/1784000000010-RefactorAgentObservationScope';
+import { CreateInstanceAiObservationTables1784000000012 } from '../common/1784000000012-CreateInstanceAiObservationTables';
 import type { Migration } from '../migration-types';
 
 const sqliteMigrations: Migration[] = [
@@ -365,6 +366,7 @@ const sqliteMigrations: Migration[] = [
 	CreateAgentMemoryEntryTables1784000000009,
 	RefactorAgentObservationScope1784000000010,
 	CreateAgentHistoryTable1784000000011,
+	CreateInstanceAiObservationTables1784000000012,
 ];
 
 export { sqliteMigrations };

--- a/packages/cli/src/modules/instance-ai/entities/index.ts
+++ b/packages/cli/src/modules/instance-ai/entities/index.ts
@@ -4,3 +4,11 @@ export { InstanceAiResource } from './instance-ai-resource.entity';
 export { InstanceAiRunSnapshot } from './instance-ai-run-snapshot.entity';
 export { InstanceAiIterationLog } from './instance-ai-iteration-log.entity';
 export { InstanceAiCheckpoint } from './instance-ai-checkpoint.entity';
+export { InstanceAiObservation } from './instance-ai-observation.entity';
+export { InstanceAiObservationCursor } from './instance-ai-observation-cursor.entity';
+export { InstanceAiObservationLock } from './instance-ai-observation-lock.entity';
+export type {
+	InstanceAiObservationMarker,
+	InstanceAiObservationStatus,
+} from './instance-ai-observation.entity';
+export type { InstanceAiObservationTaskKind } from './instance-ai-observation-lock.entity';

--- a/packages/cli/src/modules/instance-ai/entities/instance-ai-observation-cursor.entity.ts
+++ b/packages/cli/src/modules/instance-ai/entities/instance-ai-observation-cursor.entity.ts
@@ -1,0 +1,14 @@
+import { DateTimeColumn, WithTimestamps } from '@n8n/db';
+import { Column, Entity, PrimaryColumn } from '@n8n/typeorm';
+
+@Entity({ name: 'instance_ai_observation_cursors' })
+export class InstanceAiObservationCursor extends WithTimestamps {
+	@PrimaryColumn({ type: 'uuid' })
+	observationScopeId: string;
+
+	@Column({ type: 'varchar', length: 36 })
+	lastObservedMessageId: string;
+
+	@DateTimeColumn()
+	lastObservedAt: Date;
+}

--- a/packages/cli/src/modules/instance-ai/entities/instance-ai-observation-lock.entity.ts
+++ b/packages/cli/src/modules/instance-ai/entities/instance-ai-observation-lock.entity.ts
@@ -1,0 +1,19 @@
+import { DateTimeColumn, WithTimestamps } from '@n8n/db';
+import { Column, Entity, PrimaryColumn } from '@n8n/typeorm';
+
+export type InstanceAiObservationTaskKind = 'observer' | 'reflector';
+
+@Entity({ name: 'instance_ai_observation_locks' })
+export class InstanceAiObservationLock extends WithTimestamps {
+	@PrimaryColumn({ type: 'uuid' })
+	observationScopeId: string;
+
+	@PrimaryColumn({ type: 'varchar', length: 20 })
+	taskKind: InstanceAiObservationTaskKind;
+
+	@Column({ type: 'varchar', length: 64 })
+	holderId: string;
+
+	@DateTimeColumn()
+	heldUntil: Date;
+}

--- a/packages/cli/src/modules/instance-ai/entities/instance-ai-observation.entity.ts
+++ b/packages/cli/src/modules/instance-ai/entities/instance-ai-observation.entity.ts
@@ -5,7 +5,7 @@ export type InstanceAiObservationMarker = 'critical' | 'important' | 'info' | 'c
 export type InstanceAiObservationStatus = 'active' | 'superseded' | 'dropped';
 
 @Entity({ name: 'instance_ai_observations' })
-@Index(['observationScopeId', 'status'])
+@Index(['observationScopeId', 'status', 'createdAt', 'id'])
 @Index(['parentId'])
 @Index(['supersededBy'])
 export class InstanceAiObservation extends WithTimestampsAndStringId {

--- a/packages/cli/src/modules/instance-ai/entities/instance-ai-observation.entity.ts
+++ b/packages/cli/src/modules/instance-ai/entities/instance-ai-observation.entity.ts
@@ -1,0 +1,32 @@
+import { WithTimestampsAndStringId } from '@n8n/db';
+import { Column, Entity, Index } from '@n8n/typeorm';
+
+export type InstanceAiObservationMarker = 'critical' | 'important' | 'info' | 'completion';
+export type InstanceAiObservationStatus = 'active' | 'superseded' | 'dropped';
+
+@Entity({ name: 'instance_ai_observations' })
+@Index(['observationScopeId', 'status'])
+@Index(['parentId'])
+@Index(['supersededBy'])
+export class InstanceAiObservation extends WithTimestampsAndStringId {
+	@Column({ type: 'uuid' })
+	observationScopeId: string;
+
+	@Column({ type: 'varchar', length: 16 })
+	marker: InstanceAiObservationMarker;
+
+	@Column({ type: 'text' })
+	text: string;
+
+	@Column({ type: 'varchar', length: 36, nullable: true })
+	parentId: string | null;
+
+	@Column({ type: 'int', default: 0 })
+	tokenCount: number;
+
+	@Column({ type: 'varchar', length: 16 })
+	status: InstanceAiObservationStatus;
+
+	@Column({ type: 'varchar', length: 36, nullable: true })
+	supersededBy: string | null;
+}

--- a/packages/cli/src/modules/instance-ai/instance-ai.module.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.module.ts
@@ -57,6 +57,13 @@ export class InstanceAiModule implements ModuleInterface {
 		const { InstanceAiRunSnapshot } = await import('./entities/instance-ai-run-snapshot.entity');
 		const { InstanceAiIterationLog } = await import('./entities/instance-ai-iteration-log.entity');
 		const { InstanceAiCheckpoint } = await import('./entities/instance-ai-checkpoint.entity');
+		const { InstanceAiObservation } = await import('./entities/instance-ai-observation.entity');
+		const { InstanceAiObservationCursor } = await import(
+			'./entities/instance-ai-observation-cursor.entity'
+		);
+		const { InstanceAiObservationLock } = await import(
+			'./entities/instance-ai-observation-lock.entity'
+		);
 
 		return [
 			InstanceAiThread,
@@ -65,6 +72,9 @@ export class InstanceAiModule implements ModuleInterface {
 			InstanceAiRunSnapshot,
 			InstanceAiIterationLog,
 			InstanceAiCheckpoint,
+			InstanceAiObservation,
+			InstanceAiObservationCursor,
+			InstanceAiObservationLock,
 		];
 	}
 

--- a/packages/cli/src/modules/instance-ai/repositories/index.ts
+++ b/packages/cli/src/modules/instance-ai/repositories/index.ts
@@ -4,3 +4,6 @@ export { InstanceAiResourceRepository } from './instance-ai-resource.repository'
 export { InstanceAiRunSnapshotRepository } from './instance-ai-run-snapshot.repository';
 export { InstanceAiIterationLogRepository } from './instance-ai-iteration-log.repository';
 export { InstanceAiCheckpointRepository } from './instance-ai-checkpoint.repository';
+export { InstanceAiObservationRepository } from './instance-ai-observation.repository';
+export { InstanceAiObservationCursorRepository } from './instance-ai-observation-cursor.repository';
+export { InstanceAiObservationLockRepository } from './instance-ai-observation-lock.repository';

--- a/packages/cli/src/modules/instance-ai/repositories/instance-ai-observation-cursor.repository.ts
+++ b/packages/cli/src/modules/instance-ai/repositories/instance-ai-observation-cursor.repository.ts
@@ -1,0 +1,11 @@
+import { Service } from '@n8n/di';
+import { DataSource, Repository } from '@n8n/typeorm';
+
+import { InstanceAiObservationCursor } from '../entities/instance-ai-observation-cursor.entity';
+
+@Service()
+export class InstanceAiObservationCursorRepository extends Repository<InstanceAiObservationCursor> {
+	constructor(dataSource: DataSource) {
+		super(InstanceAiObservationCursor, dataSource.manager);
+	}
+}

--- a/packages/cli/src/modules/instance-ai/repositories/instance-ai-observation-lock.repository.ts
+++ b/packages/cli/src/modules/instance-ai/repositories/instance-ai-observation-lock.repository.ts
@@ -1,0 +1,11 @@
+import { Service } from '@n8n/di';
+import { DataSource, Repository } from '@n8n/typeorm';
+
+import { InstanceAiObservationLock } from '../entities/instance-ai-observation-lock.entity';
+
+@Service()
+export class InstanceAiObservationLockRepository extends Repository<InstanceAiObservationLock> {
+	constructor(dataSource: DataSource) {
+		super(InstanceAiObservationLock, dataSource.manager);
+	}
+}

--- a/packages/cli/src/modules/instance-ai/repositories/instance-ai-observation.repository.ts
+++ b/packages/cli/src/modules/instance-ai/repositories/instance-ai-observation.repository.ts
@@ -1,0 +1,11 @@
+import { Service } from '@n8n/di';
+import { DataSource, Repository } from '@n8n/typeorm';
+
+import { InstanceAiObservation } from '../entities/instance-ai-observation.entity';
+
+@Service()
+export class InstanceAiObservationRepository extends Repository<InstanceAiObservation> {
+	constructor(dataSource: DataSource) {
+		super(InstanceAiObservation, dataSource.manager);
+	}
+}


### PR DESCRIPTION
## Summary

Part of adding OM to instance AI agent. 

This PR adds the migrations and entities necessary for the integration of agent sdk's implementation of observational memory.

## Related Linear tickets, Github issues, and Community forum posts

Closes https://linear.app/n8n/issue/INS-323/create-pr-with-migrations-and-type-orm-entities-repository

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
