### PR TITLE
fix: Extend Browser mcp secret redaction patterns

### DIFF
--- a/packages/@n8n/mcp-browser/src/redaction/__tests__/redact.test.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/__tests__/redact.test.ts
@@ -42,6 +42,67 @@ const FIXTURES: Array<{ slug: string; secret: string }> = [
 	{ slug: 'sentry_user_token', secret: `sntryu_${'s'.repeat(64)}` },
 	{ slug: 'grafana_api_key', secret: `eyJrIjoi${'t'.repeat(70)}` },
 	{ slug: 'jwt', secret: `eyJ${'u'.repeat(10)}.eyJ${'v'.repeat(10)}.${'w'.repeat(10)}` },
+
+	// AI providers
+	{ slug: 'openai_service_account_key', secret: `sk-svcacct-${'a'.repeat(40)}` },
+	{ slug: 'groq_api_key', secret: `gsk_${'b'.repeat(52)}` },
+	{ slug: 'perplexity_api_key', secret: `pplx-${'c'.repeat(48)}` },
+	{ slug: 'xai_api_key', secret: `xai-${'d'.repeat(80)}` },
+	{ slug: 'fireworks_api_key', secret: `fw_${'e'.repeat(24)}` },
+	{ slug: 'replicate_api_token', secret: `r8_${'f'.repeat(37)}` },
+	{ slug: 'langsmith_api_key_v1', secret: `ls__${'a'.repeat(32)}` },
+	{
+		slug: 'langsmith_api_key_v2',
+		secret: `lsv2_pt_${'a'.repeat(40)}_${'b'.repeat(16)}`,
+	},
+
+	// Cloud / infra
+	{ slug: 'google_oauth_client_secret', secret: `GOCSPX-${'g'.repeat(30)}` },
+	{ slug: 'digitalocean_pat', secret: `dop_v1_${'a'.repeat(64)}` },
+	{ slug: 'digitalocean_oauth_token', secret: `doo_v1_${'b'.repeat(64)}` },
+	{ slug: 'digitalocean_refresh_token', secret: `dor_v1_${'c'.repeat(64)}` },
+	{ slug: 'hashicorp_vault_service_token', secret: `hvs.${'h'.repeat(95)}` },
+	{ slug: 'hashicorp_vault_batch_token', secret: `hvb.${'i'.repeat(95)}` },
+	{ slug: 'pulumi_access_token', secret: `pul-${'a'.repeat(40)}` },
+	{
+		slug: 'terraform_cloud_api_token',
+		secret: `${'a'.repeat(14)}.atlasv1.${'b'.repeat(65)}`,
+	},
+	{ slug: 'databricks_pat', secret: `dapi${'a'.repeat(32)}` },
+	{ slug: 'doppler_token', secret: `dp.pt.${'z'.repeat(43)}` },
+
+	// Source / CI
+	{ slug: 'gitlab_pipeline_trigger_token', secret: `glptt-${'a'.repeat(40)}` },
+	{ slug: 'gitlab_runner_registration_token', secret: `GR1348941${'b'.repeat(25)}` },
+	{ slug: 'gitlab_feed_token', secret: `glft-${'c'.repeat(25)}` },
+	{ slug: 'clojars_token', secret: `CLOJARS_${'d'.repeat(60)}` },
+	{ slug: 'readme_api_key', secret: `rdme_${'e'.repeat(70)}` },
+
+	// Messaging / social
+	{
+		slug: 'discord_bot_token',
+		secret: `M${'a'.repeat(23)}.${'b'.repeat(6)}.${'c'.repeat(30)}`,
+	},
+	{ slug: 'telegram_bot_token', secret: `123456789:A${'a'.repeat(34)}` },
+	{ slug: 'twitter_bearer_token', secret: `${'A'.repeat(21)}${'b'.repeat(80)}` },
+	{ slug: 'facebook_access_token', secret: `EAACEdEose0cBA${'x'.repeat(40)}` },
+
+	// Payments / commerce
+	{ slug: 'shopify_access_token', secret: `shpat_${'a'.repeat(32)}` },
+	{ slug: 'shopify_custom_access_token', secret: `shpca_${'b'.repeat(32)}` },
+	{ slug: 'shopify_private_app_token', secret: `shppa_${'c'.repeat(32)}` },
+	{ slug: 'shopify_shared_secret', secret: `shpss_${'d'.repeat(32)}` },
+
+	// SaaS / dev tools
+	{ slug: 'atlassian_api_token', secret: `ATATT3x${'a'.repeat(185)}` },
+	{ slug: 'sendgrid_api_key', secret: `SG.${'a'.repeat(22)}.${'b'.repeat(43)}` },
+	{ slug: 'mailgun_api_key', secret: `key-${'a'.repeat(32)}` },
+	{ slug: 'mailchimp_api_key', secret: `${'a'.repeat(32)}-us12` },
+	{ slug: 'postman_api_key', secret: `PMAK-${'a'.repeat(24)}-${'b'.repeat(34)}` },
+	{ slug: 'linear_api_key', secret: `lin_api_${'a'.repeat(40)}` },
+	{ slug: 'notion_integration_token', secret: `secret_${'a'.repeat(43)}` },
+	{ slug: 'figma_pat', secret: `figd_${'a'.repeat(40)}` },
+	{ slug: 'dropbox_long_lived_token', secret: `sl.${'a'.repeat(135)}` },
 ];
 
 describe('BUILTIN_PATTERNS coverage', () => {
@@ -95,6 +156,13 @@ describe('redactString', () => {
 		'https://example.com/?utm_source=newsletter&fbclid=IwAR0xQ8mN1kJyZpQrStUvWxYzAbCdEf',
 		'Press the Enter key to submit',
 		'group "Account" [ref=e1]\n  text "Bernhard" [ref=e2]\n  link "Sign out" [ref=e3]',
+		// Bare 32-char hex string (no recognisable provider prefix) must not
+		// be redacted by any of the new rules.
+		'hash=0123456789abcdef0123456789abcdef',
+		// UUID shape — Heroku/Cloudflare-like — intentionally not matched.
+		'request-id: 550e8400-e29b-41d4-a716-446655440000',
+		// Long base64 chunk inside a data URL preview — must remain intact.
+		'src="data:application/octet-stream;base64,QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVowMTIzNDU2Nzg5Kys="',
 	])('does not falsely redact %j', (input) => {
 		expect(redactString(input)).toBe(input);
 	});

--- a/packages/@n8n/mcp-browser/src/redaction/patterns.ts
+++ b/packages/@n8n/mcp-browser/src/redaction/patterns.ts
@@ -1,3 +1,14 @@
+// Secret-redaction regexes for MCP browser tool output.
+//
+// Patterns are adapted from the gitleaks default ruleset
+// (https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml).
+// We only port rules that match a distinctive, prefix-anchored token shape so
+// each regex is precise on its own — gitleaks' two-stage "keyword + regex"
+// matcher is not reproduced here. Rules that rely on keyword proximity
+// (Datadog, Cloudflare global key, Algolia, Heroku, CircleCI, generic
+// 32-hex/UUID shapes) are intentionally omitted to avoid false positives on
+// arbitrary page content.
+
 export interface SecretPattern {
 	slug: string;
 	pattern: RegExp;
@@ -7,39 +18,102 @@ const PEM_PRIVATE_KEY =
 	/-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----[\s\S]*?-----END [A-Z0-9 ]*PRIVATE KEY-----|-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----/;
 
 export const BUILTIN_PATTERNS: SecretPattern[] = [
+	// --- Keys / certificates ---
 	{
 		slug: 'openssh_private_key',
 		pattern:
 			/-----BEGIN OPENSSH PRIVATE KEY-----[\s\S]*?-----END OPENSSH PRIVATE KEY-----|-----BEGIN OPENSSH PRIVATE KEY-----/,
 	},
 	{ slug: 'pem_private_key', pattern: PEM_PRIVATE_KEY },
+
+	// --- AI providers ---
 	{ slug: 'anthropic_api_key', pattern: /sk-ant-api\d{2}-[A-Za-z0-9_-]{80,}/ },
 	{ slug: 'anthropic_admin_key', pattern: /sk-ant-admin\d{2}-[A-Za-z0-9_-]{80,}/ },
 	{ slug: 'openai_api_key', pattern: /sk-proj-[A-Za-z0-9_-]{40,}/ },
+	{ slug: 'openai_service_account_key', pattern: /sk-svcacct-[A-Za-z0-9_-]{20,}/ },
 	{ slug: 'openai_legacy_api_key', pattern: /sk-[A-Za-z0-9]{48}/ },
 	{ slug: 'huggingface_token', pattern: /hf_[A-Za-z0-9]{34,}/ },
+	{ slug: 'groq_api_key', pattern: /gsk_[A-Za-z0-9]{52}/ },
+	{ slug: 'perplexity_api_key', pattern: /pplx-[A-Za-z0-9]{48,}/ },
+	{ slug: 'xai_api_key', pattern: /xai-[A-Za-z0-9]{80}/ },
+	{ slug: 'fireworks_api_key', pattern: /fw_[A-Za-z0-9]{24,}/ },
+	{ slug: 'replicate_api_token', pattern: /r8_[A-Za-z0-9]{37,}/ },
+	{ slug: 'langsmith_api_key_v1', pattern: /ls__[a-f0-9]{32}/ },
+	{ slug: 'langsmith_api_key_v2', pattern: /lsv2_(?:pt|sk)_[a-f0-9]{40}_[a-f0-9]{16}/ },
+
+	// --- Cloud / infra ---
 	{ slug: 'google_api_key', pattern: /AIza[0-9A-Za-z_-]{35}/ },
+	{ slug: 'google_oauth_client_secret', pattern: /GOCSPX-[A-Za-z0-9_-]{28,}/ },
 	{ slug: 'aws_access_key_id', pattern: /(?:AKIA|ASIA)[A-Z0-9]{16}/ },
 	{ slug: 'azure_ad_client_secret', pattern: /[A-Za-z0-9_-]{3,}~[A-Za-z0-9_-]{31,}/ },
+	{ slug: 'digitalocean_pat', pattern: /dop_v1_[a-f0-9]{64}/ },
+	{ slug: 'digitalocean_oauth_token', pattern: /doo_v1_[a-f0-9]{64}/ },
+	{ slug: 'digitalocean_refresh_token', pattern: /dor_v1_[a-f0-9]{64}/ },
+	{ slug: 'hashicorp_vault_service_token', pattern: /hvs\.[A-Za-z0-9_-]{90,}/ },
+	{ slug: 'hashicorp_vault_batch_token', pattern: /hvb\.[A-Za-z0-9_-]{90,}/ },
+	{ slug: 'pulumi_access_token', pattern: /pul-[a-f0-9]{40}/ },
+	{ slug: 'terraform_cloud_api_token', pattern: /[A-Za-z0-9]{14}\.atlasv1\.[A-Za-z0-9_-]{60,}/ },
+	{ slug: 'databricks_pat', pattern: /dapi[a-h0-9]{32}(?:-\d)?/ },
+	{ slug: 'doppler_token', pattern: /dp\.pt\.[A-Za-z0-9]{43}/ },
+
+	// --- Source / CI ---
 	{ slug: 'github_pat', pattern: /ghp_[A-Za-z0-9]{36}/ },
 	{ slug: 'github_fine_grained_pat', pattern: /github_pat_[A-Za-z0-9_]{22,}/ },
 	{ slug: 'github_oauth', pattern: /gho_[A-Za-z0-9]{36}/ },
 	{ slug: 'github_app_token', pattern: /ghu_[A-Za-z0-9]{36}/ },
 	{ slug: 'github_refresh_token', pattern: /ghr_[A-Za-z0-9]{36}/ },
 	{ slug: 'gitlab_pat', pattern: /glpat-[A-Za-z0-9_-]{20,}/ },
+	{ slug: 'gitlab_pipeline_trigger_token', pattern: /glptt-[0-9a-f]{40}/ },
+	{ slug: 'gitlab_runner_registration_token', pattern: /GR1348941[A-Za-z0-9_-]{20,}/ },
+	{ slug: 'gitlab_feed_token', pattern: /glft-[A-Za-z0-9_-]{20,}/ },
+	{ slug: 'clojars_token', pattern: /CLOJARS_[A-Za-z0-9]{60}/ },
+	{ slug: 'readme_api_key', pattern: /rdme_[A-Za-z0-9]{70}/ },
+
+	// --- Messaging / social ---
 	{ slug: 'slack_bot_token', pattern: /xoxb-\d{10,13}-\d{10,13}-[A-Za-z0-9]{20,}/ },
 	{ slug: 'slack_user_token', pattern: /xoxp-\d{10,13}-\d{10,13}-\d{10,13}-[A-Za-z0-9]{10,}/ },
 	{
 		slug: 'slack_webhook_url',
 		pattern: /https:\/\/hooks\.slack\.com\/services\/[A-Za-z0-9/_-]{30,}/,
 	},
+	// `discord_bot_token` must precede `jwt`: both shapes can match the same
+	// string (three base64url segments separated by `.`), and we want the more
+	// specific provider slug to win when both apply.
+	{
+		slug: 'discord_bot_token',
+		pattern: /[MN][A-Za-z0-9_-]{23}\.[A-Za-z0-9_-]{6,7}\.[A-Za-z0-9_-]{27,38}/,
+	},
+	{ slug: 'telegram_bot_token', pattern: /\b\d{5,16}:A[A-Za-z0-9_-]{34}\b/ },
+	{ slug: 'twitter_bearer_token', pattern: /AAAAAAAAAAAAAAAAAAAAA[A-Za-z0-9%]{35,}/ },
+	{ slug: 'facebook_access_token', pattern: /EAACEdEose0cBA[A-Za-z0-9]+/ },
+
+	// --- Payments / commerce ---
 	{ slug: 'twilio_api_key_sid', pattern: /SK[0-9a-fA-F]{32}/ },
 	{ slug: 'twilio_account_sid', pattern: /AC[0-9a-fA-F]{32}/ },
 	{ slug: 'stripe_secret_key', pattern: /sk_(?:live|test)_[A-Za-z0-9]{20,}/ },
 	{ slug: 'square_access_token', pattern: /sq0atp-[A-Za-z0-9_-]{22,}/ },
+	{ slug: 'shopify_access_token', pattern: /shpat_[a-fA-F0-9]{32}/ },
+	{ slug: 'shopify_custom_access_token', pattern: /shpca_[a-fA-F0-9]{32}/ },
+	{ slug: 'shopify_private_app_token', pattern: /shppa_[a-fA-F0-9]{32}/ },
+	{ slug: 'shopify_shared_secret', pattern: /shpss_[a-fA-F0-9]{32}/ },
+
+	// --- SaaS / dev tools ---
 	{ slug: 'npm_token', pattern: /npm_[A-Za-z0-9]{36,}/ },
 	{ slug: 'pypi_token', pattern: /pypi-AgEIcHlwaS5vcmc[A-Za-z0-9_-]{20,}/ },
 	{ slug: 'sentry_user_token', pattern: /sntryu_[A-Za-z0-9_-]{32,}/ },
 	{ slug: 'grafana_api_key', pattern: /eyJrIjoi[A-Za-z0-9_-]{30,}/ },
+	{ slug: 'atlassian_api_token', pattern: /ATATT3x[A-Za-z0-9_=-]{180,}/ },
+	{ slug: 'sendgrid_api_key', pattern: /SG\.[A-Za-z0-9_-]{16,32}\.[A-Za-z0-9_-]{16,64}/ },
+	{ slug: 'mailgun_api_key', pattern: /key-[a-f0-9]{32}/ },
+	{ slug: 'mailchimp_api_key', pattern: /[a-f0-9]{32}-us\d{1,2}/ },
+	{ slug: 'postman_api_key', pattern: /PMAK-[a-f0-9]{24}-[a-f0-9]{34}/ },
+	{ slug: 'linear_api_key', pattern: /lin_api_[A-Za-z0-9]{40}/ },
+	{ slug: 'notion_integration_token', pattern: /secret_[A-Za-z0-9]{43}/ },
+	{ slug: 'figma_pat', pattern: /figd_[A-Za-z0-9_-]{40,}/ },
+	{ slug: 'dropbox_long_lived_token', pattern: /sl\.[A-Za-z0-9_-]{130,}/ },
+
+	// --- Generic ---
+	// Must come after `discord_bot_token` so that token shape is labelled with
+	// the more specific provider slug.
 	{ slug: 'jwt', pattern: /eyJ[A-Za-z0-9_-]{8,}\.eyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/ },
 ];


### PR DESCRIPTION
## Summary

Extends the MCP browser tool's secret-redaction regex set with additional gitleaks-derived patterns. Coverage now includes more AI provider keys, cloud/infra credentials, and other common token shapes so that secrets accidentally surfaced in tool output are scrubbed before being returned.

Changes:
- `packages/@n8n/mcp-browser/src/redaction/patterns.ts` — adds new regex patterns.
- `packages/@n8n/mcp-browser/src/redaction/__tests__/redact.test.ts` — adds coverage for each new pattern.

### How to test

```bash
cd packages/@n8n/mcp-browser
pnpm test redact
```

All redaction unit tests should pass; new tests verify that the added token shapes are redacted from sample outputs.

## Related Linear tickets, Github issues, and Community forum posts

_None._

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
