### PR TITLE
build(core): Use ES2023 in CLI tsconfig lib (no-changelog)

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -6,6 +6,7 @@
 	"compilerOptions": {
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
+		"lib": ["es2023", "dom"],
 		"paths": {
 			"@/*": ["./src/*"],
 			"@test/*": ["./test/shared/*"],


### PR DESCRIPTION
## Summary

Simplifies the `lib` array in `packages/cli/tsconfig.json` to `["es2023", "dom"]`, replacing the prior cherry-picked combination of `es2021`, `es2022.error`, and `es2023.array`.

`es2023` is a superset of the previously listed libs, so this preserves the existing types (including the ES2022 `Error.cause` constructor option and the ES2023 Array prototype methods like `findLast`, `findLastIndex`, `toSorted`, `toReversed`, `toSpliced`, `with`) and additionally exposes the rest of the ES2022/ES2023 standard library types (e.g. `Object.hasOwn`, `Array.from` improvements, `WeakRef`).

The Node.js runtime already supports these — this only updates TypeScript's type lib so they can be referenced in source code.

## Related Linear tickets, Github issues, and Community forum posts

n/a

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)