### PR TITLE
refactor(core): Replace typed-RPC method ladder with NODE_RPC_TYPES registry

### DIFF
--- a/packages/@n8n/expression-runtime/src/runtime/__tests__/utils.test.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/__tests__/utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+
+import { isKeyOf } from '../utils';
+
+describe('isKeyOf', () => {
+	const registry = { first: 'getNodeFirst', last: 'getNodeLast', all: 'getNodeAll' } as const;
+
+	it('returns true for own string keys', () => {
+		expect(isKeyOf(registry, 'first')).toBe(true);
+		expect(isKeyOf(registry, 'last')).toBe(true);
+		expect(isKeyOf(registry, 'all')).toBe(true);
+	});
+
+	it('returns false for prototype-chain keys (toString, constructor, ...)', () => {
+		// Critical: `in` would return true here because these live on
+		// `Object.prototype`. `Object.hasOwn` correctly rejects them.
+		expect(isKeyOf(registry, 'toString')).toBe(false);
+		expect(isKeyOf(registry, 'constructor')).toBe(false);
+		expect(isKeyOf(registry, 'hasOwnProperty')).toBe(false);
+		expect(isKeyOf(registry, '__proto__')).toBe(false);
+		expect(isKeyOf(registry, 'valueOf')).toBe(false);
+	});
+
+	it('returns false for own keys that are not in the registry', () => {
+		expect(isKeyOf(registry, 'unknown')).toBe(false);
+	});
+
+	it('returns false for symbol keys', () => {
+		expect(isKeyOf(registry, Symbol.iterator)).toBe(false);
+		expect(isKeyOf(registry, Symbol('arbitrary'))).toBe(false);
+	});
+});

--- a/packages/@n8n/expression-runtime/src/runtime/context.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/context.ts
@@ -11,6 +11,8 @@ import {
 	throwIfErrorSentinel,
 } from './lazy-proxy';
 import { jmesPath } from './jmespath';
+import { isKeyOf } from './utils';
+import type { BridgeMessage } from '../bridge/bridge-messages';
 
 // Pre-create safe error subclass wrappers (reused across evaluations)
 const SafeTypeError = createSafeErrorSubclass(TypeError);
@@ -19,6 +21,12 @@ const SafeEvalError = createSafeErrorSubclass(EvalError);
 const SafeRangeError = createSafeErrorSubclass(RangeError);
 const SafeReferenceError = createSafeErrorSubclass(ReferenceError);
 const SafeURIError = createSafeErrorSubclass(URIError);
+
+const NODE_RPC_TYPES = {
+	first: 'getNodeFirst',
+	last: 'getNodeLast',
+	all: 'getNodeAll',
+} as const satisfies Record<string, BridgeMessage['type']>;
 
 // ============================================================================
 // Build Context Function
@@ -187,16 +195,17 @@ export function buildContext(
 		};
 		return new Proxy({} as Record<string, unknown>, {
 			get(_emptyTarget, prop) {
-				if (prop === 'first') return sendNodeMethod('getNodeFirst');
-				if (prop === 'last') return sendNodeMethod('getNodeLast');
-				if (prop === 'all') return sendNodeMethod('getNodeAll');
+				if (isKeyOf(NODE_RPC_TYPES, prop)) {
+					return sendNodeMethod(NODE_RPC_TYPES[prop]);
+				}
 				// Everything else: delegate to the lazy proxy. The lazy proxy's
 				// own `get` trap handles caching, host fetching, and metadata.
 				return (lazyProxy as Record<string | symbol, unknown>)[prop];
 			},
 			has(_emptyTarget, prop) {
-				if (prop === 'first' || prop === 'last' || prop === 'all') return true;
-				return prop in (lazyProxy as Record<string | symbol, unknown>);
+				return (
+					isKeyOf(NODE_RPC_TYPES, prop) || prop in (lazyProxy as Record<string | symbol, unknown>)
+				);
 			},
 		});
 	};

--- a/packages/@n8n/expression-runtime/src/runtime/context.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/context.ts
@@ -22,11 +22,19 @@ const SafeRangeError = createSafeErrorSubclass(RangeError);
 const SafeReferenceError = createSafeErrorSubclass(ReferenceError);
 const SafeURIError = createSafeErrorSubclass(URIError);
 
+/**
+ * Maps proxy property names on `$('NodeName')` to the typed-RPC discriminator
+ * the bridge dispatches on. Single source of truth for the synthetic proxy's
+ * `get`/`has` traps and the `sendNodeMethod` envelope builder. Adding a new
+ * `getNode*` schema to `BridgeMessage` lets you wire a new method here in
+ * one place; `satisfies` catches typos in the discriminator string.
+ */
 const NODE_RPC_TYPES = {
 	first: 'getNodeFirst',
 	last: 'getNodeLast',
 	all: 'getNodeAll',
 } as const satisfies Record<string, BridgeMessage['type']>;
+type NodeRpcType = (typeof NODE_RPC_TYPES)[keyof typeof NODE_RPC_TYPES];
 
 // ============================================================================
 // Build Context Function
@@ -182,7 +190,7 @@ export function buildContext(
 	// the inner target is empty.
 	target.$ = function (nodeName: string) {
 		const lazyProxy = createDeepLazyProxy(['$', nodeName], undefined, callbacks);
-		const sendNodeMethod = (type: 'getNodeFirst' | 'getNodeLast' | 'getNodeAll') => {
+		const sendNodeMethod = (type: NodeRpcType) => {
 			return (branchIndex?: number, runIndex?: number) => {
 				const result = callbacks.callHost.applySync(
 					null,

--- a/packages/@n8n/expression-runtime/src/runtime/utils.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/utils.ts
@@ -1,11 +1,17 @@
 /**
- * Type guard: narrows `key` to `keyof T` when it is a real own/inherited
+ * Type guard: narrows `key` to `keyof T` when it is a real own (non-inherited)
  * string key of `object`. Used in `Proxy` `get`/`has` traps to route on a
  * registry of known property names without resorting to `as keyof T` casts.
+ *
+ * Uses `Object.hasOwn` rather than the `in` operator so prototype-chain
+ * properties (`toString`, `constructor`, `hasOwnProperty`, ...) do NOT pass
+ * the guard. Otherwise a synthetic `Proxy` would treat `obj.toString` as a
+ * registered method and route it through whatever the trap dispatches on,
+ * producing a malformed envelope and breaking the user-visible fallthrough.
  *
  * Parameter order matches the `Object.hasOwn(obj, key)` / `Reflect.has(obj, key)`
  * convention from the standard library.
  */
 export function isKeyOf<T extends object>(object: T, key: PropertyKey): key is keyof T {
-	return typeof key !== 'symbol' && key in object;
+	return typeof key !== 'symbol' && Object.hasOwn(object, key);
 }

--- a/packages/@n8n/expression-runtime/src/runtime/utils.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/utils.ts
@@ -1,0 +1,11 @@
+/**
+ * Type guard: narrows `key` to `keyof T` when it is a real own/inherited
+ * string key of `object`. Used in `Proxy` `get`/`has` traps to route on a
+ * registry of known property names without resorting to `as keyof T` casts.
+ *
+ * Parameter order matches the `Object.hasOwn(obj, key)` / `Reflect.has(obj, key)`
+ * convention from the standard library.
+ */
+export function isKeyOf<T extends object>(object: T, key: PropertyKey): key is keyof T {
+	return typeof key !== 'symbol' && key in object;
+}


### PR DESCRIPTION
## Summary

Pure-types refactor of the `$('NodeName')` synthetic proxy in the in-isolate
expression runtime. Addresses [this review thread on #30825](https://github.com/n8n-io/n8n/pull/30825#discussion_r3279795716)
asking whether typing can guarantee all typed-RPC method props are handled.

**This PR does NOT add new RPCs.** No new schemas, no new handlers — purely
a type-tightening response to the review. The existing `getNodeFirst` /
`getNodeLast` / `getNodeAll` dispatch is unchanged behaviourally.

### What changes

Today, the `target.$()` proxy hardcodes the property-name ladder in three
places:

- the `get` trap (`if (prop === 'first') …`)
- the `has` trap (`prop === 'first' || prop === 'last' || …`)
- the `sendNodeMethod` parameter union (`'getNodeFirst' | 'getNodeLast' | …`)

Adding a new typed-RPC method requires touching all three, and the reviewer
correctly flagged that nothing in the type system catches a missed update.

This PR centralises the mapping in a single registry:

```ts
const NODE_RPC_TYPES = {
  first: 'getNodeFirst',
  last:  'getNodeLast',
  all:   'getNodeAll',
} as const satisfies Record<string, BridgeMessage['type']>;
type NodeRpcType = (typeof NODE_RPC_TYPES)[keyof typeof NODE_RPC_TYPES];
```

- `as const satisfies Record<string, BridgeMessage['type']>` turns a typo in
  any discriminator string into a compile error — the registry can only hold
  literals that exist on `BridgeMessage['type']`.
- The `get` / `has` traps now route via a small reusable `isKeyOf(object, key)`
  type guard (new `runtime/utils.ts`, 11 lines), avoiding `as keyof typeof`
  casts.
- `sendNodeMethod`'s parameter type is derived from the registry
  (`NodeRpcType = (typeof NODE_RPC_TYPES)[keyof typeof NODE_RPC_TYPES]`), so
  adding a registry entry automatically widens the accepted closure
  parameter.

Net result: adding a typed-RPC method becomes a one-line addition to
`NODE_RPC_TYPES`. The proxy traps and `sendNodeMethod` pick it up for free.

### How to test

Existing unit/integration tests for `$('NodeName').first/last/all` should
pass unchanged — this is a pure refactor with no runtime behaviour change.
`pnpm typecheck` in `packages/@n8n/expression-runtime` is the primary signal.

### Origin

Originally drafted as a stacked follow-up to #30825; that PR has since merged
so this targets `master` directly.

## Related Linear tickets, Github issues, and Community forum posts

- Linear: https://linear.app/n8n/issue/CAT-2982
- Parent (merged): #30825
- Review thread: https://github.com/n8n-io/n8n/pull/30825#discussion_r3279795716

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. N/A — internal refactor, no user-facing change.
- [x] Tests included. N/A — pure-types refactor; covered by existing tests and `pnpm typecheck`.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
- [x] I have notified the Product Manager. N/A — internal refactor.

🤖 PR Summary generated by AI