### PR TITLE
feat(MCP Client Tool Node): Filter exposed tools by MCP annotation hints

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/McpClientTool.node.ts
@@ -10,7 +10,7 @@ import {
 } from 'n8n-workflow';
 
 import { getTools } from './loadOptions';
-import type { McpToolIncludeMode } from './types';
+import type { McpToolHint, McpToolIncludeMode } from './types';
 import { credentials, transportSelect } from '../shared/descriptions';
 import { buildMcpToolkit, executeMcpTool, type ResolvedMcpConfig } from '../shared/runtime';
 import type { McpAuthenticationOption, McpServerTransport } from '../shared/types';
@@ -45,6 +45,7 @@ function resolveConfigFromNodeParameters(
 			mode: ctx.getNodeParameter('include', itemIndex) as McpToolIncludeMode,
 			includeTools: ctx.getNodeParameter('includeTools', itemIndex, []) as string[],
 			excludeTools: ctx.getNodeParameter('excludeTools', itemIndex, []) as string[],
+			hints: ctx.getNodeParameter('hints', itemIndex, []) as McpToolHint[],
 		},
 	};
 }
@@ -220,6 +221,12 @@ export class McpClientTool implements INodeType {
 						value: 'except',
 						description: 'Exclude the tools listed in the parameter "Tools to Exclude"',
 					},
+					{
+						name: 'With Hints',
+						value: 'hints',
+						description:
+							'Only expose tools whose MCP annotations declare any of the selected hints as true',
+					},
 				],
 			},
 			{
@@ -252,6 +259,41 @@ export class McpClientTool implements INodeType {
 				displayOptions: {
 					show: {
 						include: ['except'],
+					},
+				},
+			},
+			{
+				displayName: 'Tool Hints',
+				name: 'hints',
+				type: 'multiOptions',
+				default: [],
+				description:
+					'Expose tools whose <a href="https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool-annotations">MCP annotations</a> declare any of the selected hints as true',
+				options: [
+					{
+						name: 'Read-Only',
+						value: 'readOnlyHint',
+						description: 'The tool does not modify its environment',
+					},
+					{
+						name: 'Destructive',
+						value: 'destructiveHint',
+						description: 'The tool may perform destructive updates',
+					},
+					{
+						name: 'Idempotent',
+						value: 'idempotentHint',
+						description: 'Repeated calls with the same arguments have no additional effect',
+					},
+					{
+						name: 'Open-World',
+						value: 'openWorldHint',
+						description: 'The tool interacts with an open world of external entities',
+					},
+				],
+				displayOptions: {
+					show: {
+						include: ['hints'],
 					},
 				},
 			},

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/__test__/McpClientTool.node.test.ts
@@ -260,6 +260,63 @@ describe('McpClientTool', () => {
 			expect(tools[0].name).toBe(buildMcpToolName('MCP Client', 'MyTool1'));
 		});
 
+		it('should support filtering tools by hint annotations', async () => {
+			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
+			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({
+				tools: [
+					{
+						name: 'ReadTool',
+						description: 'Reads things',
+						inputSchema: { type: 'object', properties: {} },
+						annotations: { readOnlyHint: true },
+					},
+					{
+						name: 'DestructiveTool',
+						description: 'Wipes things',
+						inputSchema: { type: 'object', properties: {} },
+						annotations: { destructiveHint: true },
+					},
+					{
+						name: 'WriteTool',
+						description: 'Writes things',
+						inputSchema: { type: 'object', properties: {} },
+						annotations: { readOnlyHint: false },
+					},
+					{
+						name: 'UnannotatedTool',
+						description: 'No annotations',
+						inputSchema: { type: 'object', properties: {} },
+					},
+				],
+			});
+
+			const supplyDataResult = await new McpClientTool().supplyData.call(
+				mock<ISupplyDataFunctions>({
+					getNode: vi.fn(() => mock<INode>({ typeVersion: 1, name: 'MCP Client' })),
+					getNodeParameter: vi.fn((key, _index) => {
+						const parameters: Record<string, any> = {
+							include: 'hints',
+							hints: ['readOnlyHint', 'destructiveHint'],
+							authentication: 'none',
+						};
+						return parameters[key];
+					}),
+					logger: { debug: vi.fn(), error: vi.fn() },
+					addInputData: vi.fn(() => ({ index: 0 })),
+				}),
+				0,
+			);
+
+			const tools = (supplyDataResult.response as StructuredToolkit).getTools();
+			const toolNames = tools.map((t) => t.name).sort();
+			expect(toolNames).toEqual(
+				[
+					buildMcpToolName('MCP Client', 'DestructiveTool'),
+					buildMcpToolName('MCP Client', 'ReadTool'),
+				].sort(),
+			);
+		});
+
 		it('should support header auth', async () => {
 			vi.spyOn(Client.prototype, 'connect').mockResolvedValue();
 			vi.spyOn(Client.prototype, 'listTools').mockResolvedValue({

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/types.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/types.ts
@@ -1,1 +1,7 @@
-export type McpToolIncludeMode = 'all' | 'selected' | 'except';
+export type McpToolIncludeMode = 'all' | 'selected' | 'except' | 'hints';
+
+export type McpToolHint =
+	| 'readOnlyHint'
+	| 'destructiveHint'
+	| 'idempotentHint'
+	| 'openWorldHint';

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpClientTool/utils.ts
@@ -6,7 +6,7 @@ import { z } from 'zod';
 
 import { convertJsonSchemaToZod } from '@utils/schemaParsing';
 
-import type { McpToolIncludeMode } from './types';
+import type { McpToolHint, McpToolIncludeMode } from './types';
 import type { McpTool } from '../shared/types';
 import { isStructuredContent } from '../shared/utils';
 
@@ -14,11 +14,13 @@ export function getSelectedTools({
 	mode,
 	includeTools,
 	excludeTools,
+	hints,
 	tools,
 }: {
 	mode: McpToolIncludeMode;
 	includeTools?: string[];
 	excludeTools?: string[];
+	hints?: McpToolHint[];
 	tools: McpTool[];
 }) {
 	switch (mode) {
@@ -30,6 +32,12 @@ export function getSelectedTools({
 		case 'except': {
 			const except = new Set(excludeTools ?? []);
 			return tools.filter((tool) => !except.has(tool.name));
+		}
+		case 'hints': {
+			if (!hints?.length) return tools;
+			return tools.filter((tool) =>
+				hints.some((hint) => tool.annotations?.[hint] === true),
+			);
 		}
 		case 'all':
 		default:

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpRegistryClientTool/McpRegistryClientTool.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpRegistryClientTool/McpRegistryClientTool.node.test.ts
@@ -166,6 +166,7 @@ describe('McpRegistryClientTool', () => {
 					mode: 'selected',
 					includeTools: ['notion-search'],
 					excludeTools: [],
+					hints: [],
 				},
 			};
 			expect(buildMcpToolkitMock).toHaveBeenCalledWith(ctx, 0, expectedConfig);
@@ -188,7 +189,7 @@ describe('McpRegistryClientTool', () => {
 				0,
 				expect.objectContaining({
 					timeout: 60000,
-					toolFilter: { mode: 'all', includeTools: [], excludeTools: [] },
+					toolFilter: { mode: 'all', includeTools: [], excludeTools: [], hints: [] },
 				}),
 			);
 		});
@@ -236,7 +237,7 @@ describe('McpRegistryClientTool', () => {
 				transport: 'httpStreamable',
 				endpointUrl: 'https://mcp.notion.com/mcp',
 				timeout: 60000,
-				toolFilter: { mode: 'all', includeTools: [], excludeTools: [] },
+				toolFilter: { mode: 'all', includeTools: [], excludeTools: [], hints: [] },
 			});
 		});
 

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpRegistryClientTool/McpRegistryClientTool.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpRegistryClientTool/McpRegistryClientTool.node.ts
@@ -11,7 +11,7 @@ import {
 	NodeOperationError,
 } from 'n8n-workflow';
 
-import type { McpToolIncludeMode } from '../McpClientTool/types';
+import type { McpToolHint, McpToolIncludeMode } from '../McpClientTool/types';
 import {
 	buildMcpToolkit,
 	executeMcpTool,
@@ -90,6 +90,12 @@ export class McpRegistryClientTool implements INodeType {
 						value: 'except',
 						description: 'Expose all tools except those listed in "Tools to Exclude"',
 					},
+					{
+						name: 'With Hints',
+						value: 'hints',
+						description:
+							'Only expose tools whose MCP annotations declare any of the selected hints as true',
+					},
 				],
 			},
 			{
@@ -121,6 +127,41 @@ export class McpRegistryClientTool implements INodeType {
 				displayOptions: {
 					show: {
 						include: ['except'],
+					},
+				},
+			},
+			{
+				displayName: 'Tool Hints',
+				name: 'hints',
+				type: 'multiOptions',
+				default: [],
+				description:
+					'Expose tools whose <a href="https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool-annotations">MCP annotations</a> declare any of the selected hints as true',
+				options: [
+					{
+						name: 'Read-Only',
+						value: 'readOnlyHint',
+						description: 'The tool does not modify its environment',
+					},
+					{
+						name: 'Destructive',
+						value: 'destructiveHint',
+						description: 'The tool may perform destructive updates',
+					},
+					{
+						name: 'Idempotent',
+						value: 'idempotentHint',
+						description: 'Repeated calls with the same arguments have no additional effect',
+					},
+					{
+						name: 'Open-World',
+						value: 'openWorldHint',
+						description: 'The tool interacts with an open world of external entities',
+					},
+				],
+				displayOptions: {
+					show: {
+						include: ['hints'],
 					},
 				},
 			},
@@ -184,6 +225,7 @@ function resolveConfig(
 			mode: ctx.getNodeParameter('include', itemIndex) as McpToolIncludeMode,
 			includeTools: ctx.getNodeParameter('includeTools', itemIndex, []) as string[],
 			excludeTools: ctx.getNodeParameter('excludeTools', itemIndex, []) as string[],
+			hints: ctx.getNodeParameter('hints', itemIndex, []) as McpToolHint[],
 		},
 	};
 }

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/runtime.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/runtime.test.ts
@@ -27,7 +27,7 @@ const baseConfig: ResolvedMcpConfig = {
 	transport: 'httpStreamable',
 	endpointUrl: 'https://mcp.example.com/mcp',
 	timeout: 60000,
-	toolFilter: { mode: 'all', includeTools: [], excludeTools: [] },
+	toolFilter: { mode: 'all', includeTools: [], excludeTools: [], hints: [] },
 };
 
 const baseConnectionConfig: McpConnectionConfig = {
@@ -135,7 +135,12 @@ describe('runtime', () => {
 
 			const result = await buildMcpToolkit(ctx, 0, {
 				...baseConfig,
-				toolFilter: { mode: 'selected', includeTools: ['search'], excludeTools: [] },
+				toolFilter: {
+					mode: 'selected',
+					includeTools: ['search'],
+					excludeTools: [],
+					hints: [],
+				},
 			});
 
 			const tools = (result.response as StructuredToolkit).getTools();

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/runtime.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/runtime.ts
@@ -22,7 +22,7 @@ import {
 	getSelectedTools,
 	mcpToolToDynamicTool,
 } from '../McpClientTool/utils';
-import type { McpToolIncludeMode } from '../McpClientTool/types';
+import type { McpToolHint, McpToolIncludeMode } from '../McpClientTool/types';
 import type { McpAuthenticationOption, McpServerTransport } from './types';
 import {
 	connectMcpClient,
@@ -55,6 +55,7 @@ export type ResolvedMcpConfig = McpConnectionConfig & {
 		mode: McpToolIncludeMode;
 		includeTools: string[];
 		excludeTools: string[];
+		hints: McpToolHint[];
 	};
 };
 
@@ -85,6 +86,7 @@ async function connectAndGetTools(
 			mode: config.toolFilter.mode,
 			includeTools: config.toolFilter.includeTools,
 			excludeTools: config.toolFilter.excludeTools,
+			hints: config.toolFilter.hints,
 		});
 		return { client: client.result, mcpTools, error: null };
 	} catch (error) {

--- a/packages/@n8n/nodes-langchain/nodes/mcp/shared/types.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/shared/types.ts
@@ -1,6 +1,19 @@
 import type { JSONSchema7 } from 'json-schema';
 
-export type McpTool = { name: string; description?: string; inputSchema: JSONSchema7 };
+export type McpToolAnnotations = {
+	title?: string;
+	readOnlyHint?: boolean;
+	destructiveHint?: boolean;
+	idempotentHint?: boolean;
+	openWorldHint?: boolean;
+};
+
+export type McpTool = {
+	name: string;
+	description?: string;
+	inputSchema: JSONSchema7;
+	annotations?: McpToolAnnotations;
+};
 
 export type McpServerTransport = 'sse' | 'httpStreamable';
 


### PR DESCRIPTION
## Summary

This PR allows filtering MCP Client tools by their hints:

<img width="458" height="462" alt="image" src="https://github.com/user-attachments/assets/79e27f01-34d7-4589-9ceb-48806adcba11" />

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
