### PR TITLE
test(core): Strengthen workflow-checksum assertions

### DIFF
--- a/packages/workflow/test/workflow-checksum.test.ts
+++ b/packages/workflow/test/workflow-checksum.test.ts
@@ -177,4 +177,60 @@ describe('calculateWorkflowChecksum', () => {
 
 		expect(checksum1).not.toBe(checksum2);
 	});
+
+	it('should generate the same checksum when object keys are in different insertion order', async () => {
+		const workflow1: WorkflowSnapshot = {
+			name: 'Test Workflow',
+			settings: {
+				executionOrder: 'v1',
+				timezone: 'America/New_York',
+			},
+			meta: {
+				nested: { foo: 'bar', baz: 'qux' },
+			},
+		};
+
+		const workflow2: WorkflowSnapshot = {
+			meta: {
+				nested: { baz: 'qux', foo: 'bar' },
+			},
+			settings: {
+				timezone: 'America/New_York',
+				executionOrder: 'v1',
+			},
+			name: 'Test Workflow',
+		};
+
+		const checksum1 = await calculateWorkflowChecksum(workflow1);
+		const checksum2 = await calculateWorkflowChecksum(workflow2);
+
+		expect(checksum1).toBe(checksum2);
+	});
+
+	it('should return a 64-character lowercase hex string matching a pinned reference hash', async () => {
+		const canonicalWorkflow: WorkflowSnapshot = {
+			name: 'Canonical',
+			nodes: [],
+			connections: {},
+		};
+
+		const checksum = await calculateWorkflowChecksum(canonicalWorkflow);
+
+		expect(checksum).toMatch(/^[0-9a-f]{64}$/);
+		expect(checksum).toBe('11020572b14a9e257c93b4c971cc6fd85e390305548f029e3277422fb5678e33');
+	});
+
+	it('should produce the same checksum via the jsSHA fallback as WebCrypto', async () => {
+		const webCryptoChecksum = await calculateWorkflowChecksum(baseWorkflow);
+
+		const originalCrypto = globalThis.crypto;
+		Object.defineProperty(globalThis, 'crypto', { value: undefined, configurable: true });
+		try {
+			const fallbackChecksum = await calculateWorkflowChecksum(baseWorkflow);
+			expect(fallbackChecksum).toBe(webCryptoChecksum);
+			expect(fallbackChecksum).toMatch(/^[0-9a-f]{64}$/);
+		} finally {
+			Object.defineProperty(globalThis, 'crypto', { value: originalCrypto, configurable: true });
+		}
+	});
 });


### PR DESCRIPTION
## Summary

Demo PR for #30956. Drives the `n8n:strengthen-tests` loop against `packages/workflow/src/workflow-checksum.ts` to show the trial loop end-to-end.

**Before**: 38.64% mutation score, 21 survivors + 6 no-coverage
**After**:  72.73% mutation score, 12 survivors,   0 no-coverage  (+34.09 points, 15 mutants killed)

5 survivors were explicitly targeted; the three test additions killed 15 mutants total (3× leverage from bystander kills). The 6 no-coverage mutants on the jsSHA fallback path are now all covered.

### Survivors addressed (with rationale)

1. **`#15` BlockStatement at `src/workflow-checksum.ts:53:23`** — strips the `isObject(value)` branch so objects are returned unsorted. Killed by the new **order-invariance test**: two workflows with the same data but reversed key insertion order must produce identical checksums.

2. **`#16` MethodExpression at `src/workflow-checksum.ts:54:22`** — drops `.sort()` from `Object.keys(value).sort()`. Same fix as `#15` (insertion-order JSON diverges between the two workflows).

3. **`#36` StringLiteral at `src/workflow-checksum.ts:101:18`** — `let hexString = ''` mutated to `"Stryker was here!"`. Killed by the new **pinned-hash + lowercase-hex regex** test against a canonical workflow; mutated prefix breaks both regex and the pinned hash.

4. **`#43` StringLiteral at `src/workflow-checksum.ts:104:54`** — `padStart(2, '0')` → `padStart(2, '')`. Same fix as `#36`; missing padding breaks both regex (length ≠ 64) and the pinned hash.

5. **`#33` MethodExpression at `src/workflow-checksum.ts:96:9`** — `.toLowerCase()` swapped to `.toUpperCase()` on the jsSHA fallback. Killed by the new **fallback-path equivalence test** that removes `globalThis.crypto`, runs the fallback, and asserts it matches the WebCrypto output (and the lowercase-hex regex). This single test also killed all 5 sibling no-coverage mutants on the same fallback line.

### Survivors deliberately skipped as low-leverage / equivalent

- `#24` (`crypto?.subtle` optional-chaining removal) — `globalThis.crypto` exists in the test env, so the mutation is observationally equivalent.
- `#25 / #26 / #27` (`if (subtle)` branch mutations) — both WebCrypto and jsSHA produce identical SHA-256 output for the same input; swapping implementations doesn't change the observed hash.
- `#20` (`value !== undefined` → `true` on line 79) — `JSON.stringify` already drops `undefined` values, so the mutation is observationally equivalent.

### What this PR demonstrates

- The loop produces a real, surgical diff (three new `it()` blocks; no rewrites).
- The before/after numbers are reproducible by anyone running `pnpm --filter=n8n-workflow mutate src/workflow-checksum.ts`.
- The skill declined to fabricate or split low-leverage survivors into separate edits.
- Stacked on the WIP branch from #30956 (`devp-stryker-mvp-spike`) so the Stryker config is already in place — reviewers don't need a separate setup.

## Test plan
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] `pnpm --filter=n8n-workflow mutate src/workflow-checksum.ts` reproduces 72.73% locally
- [ ] `pnpm --filter=n8n-workflow test test/workflow-checksum.test.ts` passes (22 tests across both VM engines)
- [ ] Each new assertion has a clear "this would have caught X mutant" justification (see survivor list above)
- [ ] Pinned hash `1102…8e33` independently reproducible (Node `crypto.createHash('sha256')` over the canonical serialized payload `{"connections":{},"name":"Canonical","nodes":[]}`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)