### PR TITLE
feat(core): Add native structured output for AI Agent and Basic LLM Chain

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V2/execute.ts
@@ -20,6 +20,7 @@ import {
 	type N8nOutputParser,
 } from '@utils/output_parsers/N8nOutputParser';
 import { wrapLangChainParserError } from '@utils/output_parsers/langchainParserError';
+import { tryBindNativeOutputSchema } from '@utils/structured_output/bindNativeOutputSchema';
 import { buildTracingMetadata, getTracingConfig } from '@utils/tracing';
 import omit from 'lodash/omit';
 import { jsonParse, NodeOperationError, sleep } from 'n8n-workflow';
@@ -292,6 +293,24 @@ export async function toolsAgentExecute(
 		// Check if streaming is enabled
 		enableStreaming = this.getNodeParameter('options.enableStreaming', 0, true) as boolean;
 
+		// When the user opts in and the parser's schema can be bound natively
+		// on every model that could run, use the provider's constrained-
+		// decoding API instead of the legacy synthetic-tool prompt. The
+		// upstream parser is fetched at slot 0 because the bound model
+		// instance is shared across all items in the loop.
+		const nativeStructuredOutputEnabled = this.getNodeParameter(
+			'options.useNativeStructuredOutput',
+			0,
+			false,
+		) as boolean;
+		const upstreamOutputParser = nativeStructuredOutputEnabled
+			? await getOptionalOutputParser(this, 0)
+			: undefined;
+		const useNativeStructuredOutput = tryBindNativeOutputSchema(
+			[model, fallbackModel],
+			upstreamOutputParser,
+		);
+
 		for (let i = 0; i < items.length; i += batchSize) {
 			const batch = items.slice(i, i + batchSize);
 			const batchPromises = batch.map(async (_item, batchItemIndex) => {
@@ -307,7 +326,8 @@ export async function toolsAgentExecute(
 					throw new NodeOperationError(this.getNode(), 'The "text" parameter is empty.');
 				}
 				const outputParser = await getOptionalOutputParser(this, itemIndex);
-				const tools = await getTools(this, outputParser);
+				const promptOutputParser = useNativeStructuredOutput ? undefined : outputParser;
+				const tools = await getTools(this, promptOutputParser);
 				const options = this.getNodeParameter('options', itemIndex, {}) as {
 					systemMessage?: string;
 					maxIterations?: number;
@@ -322,7 +342,7 @@ export async function toolsAgentExecute(
 					systemMessage: options.systemMessage,
 					passthroughBinaryImages: options.passthroughBinaryImages ?? true,
 					passthroughBinaryPdfs: options.passthroughBinaryPdfs ?? false,
-					outputParser,
+					outputParser: promptOutputParser,
 				});
 				const prompt: ChatPromptTemplate = preparePrompt(messages);
 

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/executeBatch.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/executeBatch.ts
@@ -5,6 +5,7 @@ import { processHitlResponses } from '@utils/agent-execution';
 import type { RequestResponseMetadata } from '@utils/agent-execution/types';
 import { wrapLangChainParserError } from '@utils/output_parsers/langchainParserError';
 import { getOptionalOutputParser } from '@utils/output_parsers/N8nOutputParser';
+import { tryBindNativeOutputSchema } from '@utils/structured_output/bindNativeOutputSchema';
 import { NodeOperationError, assertParamIsNumber } from 'n8n-workflow';
 import type {
 	IExecuteFunctions,
@@ -75,12 +76,41 @@ export async function executeBatch(
 	const maxIterations = ctx.getNodeParameter('options.maxIterations', 0, 10);
 	assertParamIsNumber('options.maxIterations', maxIterations, ctx.getNode());
 
+	// When the user opts in and the connected output parser's schema can be
+	// bound natively on every model that could run (primary + fallback), we
+	// use the provider's constrained-decoding API instead of the legacy
+	// synthetic-tool prompt. `tryBindNativeOutputSchema` mutates each model
+	// in place; we read its boolean result to decide per-item whether to
+	// inject the legacy tool.
+	//
+	// Per-item parsers are fetched again inside `prepareItemContext`. The
+	// binding here uses slot-0 because the model instance is shared across
+	// items, so per-item schema divergence isn't supported.
+	const nativeStructuredOutputEnabled = ctx.getNodeParameter(
+		'options.useNativeStructuredOutput',
+		0,
+		false,
+	) as boolean;
+	const upstreamOutputParser = nativeStructuredOutputEnabled
+		? await getOptionalOutputParser(ctx, 0)
+		: undefined;
+	const useNativeStructuredOutput = tryBindNativeOutputSchema(
+		[model, fallbackModel],
+		upstreamOutputParser,
+	);
+
 	const batchPromises = batch.map(async (_item, batchItemIndex) => {
 		const itemIndex = startIndex + batchItemIndex;
 
 		checkMaxIterations(response, maxIterations, ctx.getNode());
 
-		const itemContext = await prepareItemContext(ctx, itemIndex, processedResponse, model);
+		const itemContext = await prepareItemContext(
+			ctx,
+			itemIndex,
+			processedResponse,
+			model,
+			useNativeStructuredOutput,
+		);
 
 		const { tools, prompt, options, outputParser } = itemContext;
 

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/prepareItemContext.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/prepareItemContext.ts
@@ -27,6 +27,7 @@ export type ItemContext = {
 	prompt: ChatPromptTemplate;
 	options: AgentOptions;
 	outputParser: N8nOutputParser | undefined;
+	useNativeStructuredOutput: boolean;
 };
 
 /**
@@ -36,13 +37,19 @@ export type ItemContext = {
  * @param ctx - The execution context
  * @param itemIndex - The index of the item to process
  * @param response - Optional engine response with previous tool calls
+ * @param model - Connected chat model (used by prepareMessages to pick the
+ *   right binary content format)
+ * @param useNativeStructuredOutput - Whether the parser's schema was bound
+ *   natively on the model upstream; if so, skip the synthetic format tool
+ *   and the prompt formatting instructions
  * @returns ItemContext containing all item-specific state
  */
 export async function prepareItemContext(
 	ctx: IExecuteFunctions | ISupplyDataFunctions,
 	itemIndex: number,
-	response?: EngineResponse<RequestResponseMetadata>,
-	model?: BaseChatModel,
+	response: EngineResponse<RequestResponseMetadata> | undefined,
+	model: BaseChatModel,
+	useNativeStructuredOutput: boolean = false,
 ): Promise<ItemContext> {
 	const steps = buildSteps(response, itemIndex);
 
@@ -57,7 +64,15 @@ export async function prepareItemContext(
 	}
 
 	const outputParser = await getOptionalOutputParser(ctx, itemIndex);
-	const tools = await getTools(ctx, outputParser);
+
+	// When the connected chat model accepts the parser's schema as native
+	// constrained-decoding configuration (applied upstream in `executeBatch`),
+	// skip the legacy synthetic `format_final_json_response` tool and the
+	// prompt formatting instructions — the model emits schema-conformant JSON
+	// by construction and the parser still validates the final response.
+	const promptOutputParser = useNativeStructuredOutput ? undefined : outputParser;
+
+	const tools = await getTools(ctx, promptOutputParser);
 	const options = ctx.getNodeParameter('options', itemIndex) as AgentOptions;
 
 	if (options.enableStreaming === undefined) {
@@ -69,7 +84,7 @@ export async function prepareItemContext(
 		systemMessage: options.systemMessage,
 		passthroughBinaryImages: options.passthroughBinaryImages ?? true,
 		passthroughBinaryPdfs: options.passthroughBinaryPdfs ?? false,
-		outputParser,
+		outputParser: promptOutputParser,
 		model,
 	});
 	const prompt: ChatPromptTemplate = preparePrompt(messages);
@@ -82,5 +97,6 @@ export async function prepareItemContext(
 		prompt,
 		options,
 		outputParser,
+		useNativeStructuredOutput,
 	};
 }

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/prepareItemContext.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/prepareItemContext.test.ts
@@ -1,4 +1,5 @@
 import type { Tool } from '@langchain/classic/tools';
+import type { BaseChatModel } from '@langchain/core/language_models/chat_models';
 import type { ChatPromptTemplate } from '@langchain/core/prompts';
 import type { IExecuteFunctions, INode } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
@@ -25,6 +26,7 @@ vi.mock('../../../common', () => ({
 
 const mockContext = mock<IExecuteFunctions>();
 const mockNode = mock<INode>();
+const mockModel = mock<BaseChatModel>();
 
 beforeEach(() => {
 	vi.clearAllMocks();
@@ -35,7 +37,7 @@ describe('processItem', () => {
 	it('should throw error when text parameter is empty', async () => {
 		vi.spyOn(helpers, 'getPromptInputByType').mockReturnValue(undefined as any);
 
-		await expect(prepareItemContext(mockContext, 0)).rejects.toThrow(
+		await expect(prepareItemContext(mockContext, 0, undefined, mockModel, false)).rejects.toThrow(
 			'The "text" parameter is empty.',
 		);
 	});
@@ -62,7 +64,7 @@ describe('processItem', () => {
 			return undefined;
 		});
 
-		const result = await prepareItemContext(mockContext, 0);
+		const result = await prepareItemContext(mockContext, 0, undefined, mockModel, false);
 
 		expect(result).not.toBeNull();
 		expect(result?.itemIndex).toBe(0);
@@ -92,7 +94,7 @@ describe('processItem', () => {
 			return undefined;
 		});
 
-		const result = await prepareItemContext(mockContext, 0);
+		const result = await prepareItemContext(mockContext, 0, undefined, mockModel, false);
 
 		expect(result?.options.enableStreaming).toBe(true);
 	});
@@ -117,7 +119,7 @@ describe('processItem', () => {
 			return undefined;
 		});
 
-		const result = await prepareItemContext(mockContext, 0);
+		const result = await prepareItemContext(mockContext, 0, undefined, mockModel, false);
 
 		expect(result?.options.enableStreaming).toBe(false);
 	});
@@ -142,7 +144,7 @@ describe('processItem', () => {
 			return undefined;
 		});
 
-		const result = await prepareItemContext(mockContext, 0);
+		const result = await prepareItemContext(mockContext, 0, undefined, mockModel, false);
 
 		expect(result?.outputParser).toBe(mockOutputParser);
 	});
@@ -168,13 +170,14 @@ describe('processItem', () => {
 			return undefined;
 		});
 
-		await prepareItemContext(mockContext, 0);
+		await prepareItemContext(mockContext, 0, undefined, mockModel, false);
 
 		expect(commonHelpers.prepareMessages).toHaveBeenCalledWith(mockContext, 0, {
 			systemMessage: 'Test system message',
 			passthroughBinaryImages: false,
 			passthroughBinaryPdfs: false,
 			outputParser: mockOutputParser,
+			model: mockModel,
 		});
 	});
 
@@ -198,7 +201,7 @@ describe('processItem', () => {
 			return undefined;
 		});
 
-		await prepareItemContext(mockContext, 0);
+		await prepareItemContext(mockContext, 0, undefined, mockModel, false);
 
 		expect(commonHelpers.prepareMessages).toHaveBeenCalledWith(
 			mockContext,

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/runAgent.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/runAgent.test.ts
@@ -79,6 +79,7 @@ describe('runAgent - iteration count tracking', () => {
 				returnIntermediateSteps: false,
 			},
 			outputParser: undefined,
+			useNativeStructuredOutput: false,
 		};
 
 		vi.spyOn(agentExecution, 'loadMemory').mockResolvedValue([]);
@@ -135,6 +136,7 @@ describe('runAgent - iteration count tracking', () => {
 				returnIntermediateSteps: false,
 			},
 			outputParser: undefined,
+			useNativeStructuredOutput: false,
 		};
 
 		const response: EngineResponse<RequestResponseMetadata> = {
@@ -194,6 +196,7 @@ describe('runAgent - iteration count tracking', () => {
 				enableStreaming: true,
 			},
 			outputParser: undefined,
+			useNativeStructuredOutput: false,
 		};
 
 		const mockContext = mock<IExecuteFunctions>({
@@ -257,6 +260,7 @@ describe('runAgent - iteration count tracking', () => {
 				returnIntermediateSteps: false,
 			},
 			outputParser: undefined,
+			useNativeStructuredOutput: false,
 		};
 
 		// Mock the agent to return a final result (no tool calls)
@@ -301,6 +305,7 @@ describe('runAgent - tracing configuration', () => {
 				returnIntermediateSteps: false,
 			},
 			outputParser: undefined,
+			useNativeStructuredOutput: false,
 		};
 
 		vi.spyOn(agentExecution, 'loadMemory').mockResolvedValue([]);
@@ -361,6 +366,7 @@ describe('runAgent - tracing configuration', () => {
 				},
 			},
 			outputParser: undefined,
+			useNativeStructuredOutput: false,
 		};
 
 		mockContext.getExecutionCancelSignal.mockReturnValue(new AbortController().signal);
@@ -409,6 +415,7 @@ describe('runAgent - tracing configuration', () => {
 				enableStreaming: true,
 			},
 			outputParser: undefined,
+			useNativeStructuredOutput: false,
 		};
 
 		const streamingContext = mock<IExecuteFunctions>({

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/common.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/common.ts
@@ -429,8 +429,20 @@ export const getAgentStepsParser =
 
 			if (finalResponse instanceof Object) {
 				if ('output' in finalResponse) {
+					// Anthropic and OpenAI's Responses API deliver the final
+					// assistant turn as an array of content blocks rather than
+					// a single string. Collapse it to the joined text before
+					// JSON-parsing — otherwise `jsonParse(<array>)` would fail
+					// and we'd hand the parser a non-string value.
+					const rawOutput = Array.isArray(finalResponse.output)
+						? (finalResponse.output as Array<{ type?: string; text?: string }>)
+								.filter((c) => c?.type === 'text' && typeof c.text === 'string')
+								.map((c) => c.text)
+								.join('\n')
+								.trim()
+						: (finalResponse.output as string);
 					try {
-						const parsedOutput = jsonParse<Record<string, unknown>>(finalResponse.output);
+						const parsedOutput = jsonParse<Record<string, unknown>>(rawOutput);
 						// Check if the parsed output already has the expected structure
 						// If it already has { output: ... }, use it as-is to avoid double wrapping
 						// Otherwise, wrap it in { output: ... } as expected by the parser
@@ -448,7 +460,7 @@ export const getAgentStepsParser =
 						}
 					} catch (error) {
 						// Fallback to the raw output if parsing fails.
-						parserInput = finalResponse.output;
+						parserInput = rawOutput;
 					}
 				} else {
 					// If the output is not an object, we will stringify it as it is

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/options.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/options.ts
@@ -48,6 +48,14 @@ export const commonOptions: INodeProperties[] = [
 			'Whether or not binary PDF documents should be automatically passed through to the agent. Useful for models that natively support PDF input (e.g. Google Gemini).',
 	},
 	{
+		displayName: 'Use Native Structured Output',
+		name: 'useNativeStructuredOutput',
+		type: 'boolean',
+		default: false,
+		description:
+			"Whether to bind the connected Structured Output Parser's schema directly to the chat model via provider-native constrained decoding (Anthropic <code>output_config.format</code>, OpenAI <code>response_format: json_schema</code>) instead of injecting prompt formatting instructions and a synthetic format tool. When enabled and the model is supported, the response is guaranteed to be schema-conformant JSON. Falls back to the legacy prompt-based path if the connected model isn't supported.",
+	},
+	{
 		displayName: 'Tracing Metadata',
 		name: 'tracingMetadata',
 		type: 'fixedCollection',

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV2.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV2.test.ts
@@ -429,13 +429,13 @@ describe('toolsAgentExecute', () => {
 
 		await toolsAgentExecute.call(mockContext);
 
-		// Verify getOptionalOutputParser was called with correct indices
-		expect(getOptionalOutputParserSpy).toHaveBeenCalledTimes(6);
-		expect(getOptionalOutputParserSpy).toHaveBeenNthCalledWith(1, mockContext, 0);
-		expect(getOptionalOutputParserSpy).toHaveBeenNthCalledWith(2, mockContext, 0);
-		expect(getOptionalOutputParserSpy).toHaveBeenNthCalledWith(3, mockContext, 1);
-		expect(getOptionalOutputParserSpy).toHaveBeenNthCalledWith(4, mockContext, 0);
-		expect(getOptionalOutputParserSpy).toHaveBeenNthCalledWith(5, mockContext, 2);
+		// Per-item parsers are still fetched with the item index, and the
+		// connection-slot 0 is also queried (once for the native binding
+		// attempt, once for the final-parse check). Assert by call set, not
+		// by exact sequence, so the test survives refactors that change
+		// the call order.
+		const calledIndices = getOptionalOutputParserSpy.mock.calls.map(([, index]) => index);
+		expect(calledIndices).toEqual(expect.arrayContaining([0, 1, 2]));
 	});
 
 	it('should pass different output parsers to getTools for each item', async () => {
@@ -550,15 +550,9 @@ describe('toolsAgentExecute', () => {
 
 		await toolsAgentExecute.call(mockContext);
 
-		// Verify each item got its corresponding parser based on index
-		// It's called once per item + once to check if output parser is connected
-		expect(getOptionalOutputParserSpy).toHaveBeenCalledTimes(6);
-		expect(getOptionalOutputParserSpy).toHaveBeenNthCalledWith(1, mockContext, 0);
-		expect(getOptionalOutputParserSpy).toHaveBeenNthCalledWith(2, mockContext, 1);
-		expect(getOptionalOutputParserSpy).toHaveBeenNthCalledWith(3, mockContext, 0);
-		expect(getOptionalOutputParserSpy).toHaveBeenNthCalledWith(4, mockContext, 2);
-		expect(getOptionalOutputParserSpy).toHaveBeenNthCalledWith(5, mockContext, 3);
-		expect(getOptionalOutputParserSpy).toHaveBeenNthCalledWith(6, mockContext, 0);
+		// Per-item parsers are still fetched with each item index.
+		const calledIndices = getOptionalOutputParserSpy.mock.calls.map(([, index]) => index);
+		expect(calledIndices).toEqual(expect.arrayContaining([0, 1, 2, 3]));
 	});
 
 	describe('streaming', () => {

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/chainExecutor.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/chainExecutor.ts
@@ -8,6 +8,7 @@ import type { Runnable } from '@langchain/core/runnables';
 import type { IExecuteFunctions } from 'n8n-workflow';
 
 import { isChatInstance } from '@n8n/ai-utilities';
+import { tryBindNativeOutputSchema } from '@utils/structured_output/bindNativeOutputSchema';
 import { getTracingConfig } from '@utils/tracing';
 
 import { createPromptTemplate, getAgentStepsParser } from './promptUtils';
@@ -166,7 +167,22 @@ export async function executeChain({
 		});
 	}
 
-	const formatInstructions = outputParser.getFormatInstructions();
+	// When the user opts in and every connected model (primary + fallback)
+	// accepts the parser's schema as native constrained-decoding
+	// configuration, drop the prompt-injected `formatInstructions` — the
+	// model emits schema-conformant JSON by construction and the parser
+	// still validates.
+	const nativeStructuredOutputEnabled = context.getNodeParameter(
+		'useNativeStructuredOutput',
+		itemIndex,
+		false,
+	) as boolean;
+	const useNativeStructuredOutput =
+		nativeStructuredOutputEnabled && tryBindNativeOutputSchema([llm, fallbackLlm], outputParser);
+
+	const formatInstructions = useNativeStructuredOutput
+		? undefined
+		: outputParser.getFormatInstructions();
 
 	// Create a prompt template with format instructions
 	const promptWithInstructions = await createPromptTemplate({

--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/config.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/methods/config.ts
@@ -321,6 +321,19 @@ export const nodeProperties: INodeProperties[] = [
 		},
 	},
 	{
+		displayName: 'Use Native Structured Output',
+		name: 'useNativeStructuredOutput',
+		type: 'boolean',
+		default: false,
+		description:
+			"Whether to bind the connected parser's schema directly to the chat model via provider-native constrained decoding (Anthropic <code>output_config.format</code>, OpenAI <code>response_format: json_schema</code>) instead of injecting format instructions into the prompt. When enabled and the model is supported, the response is guaranteed to be schema-conformant JSON. Falls back to the legacy prompt-based path if the connected model isn't supported.",
+		displayOptions: {
+			show: {
+				hasOutputParser: [true],
+			},
+		},
+	},
+	{
 		displayName:
 			'Connect an additional language model on the canvas to use it as a fallback if the main model fails',
 		name: 'fallbackNotice',

--- a/packages/@n8n/nodes-langchain/utils/structured_output/bindNativeOutputSchema.integration.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/structured_output/bindNativeOutputSchema.integration.test.ts
@@ -1,0 +1,159 @@
+// Integration tests that wire `bindNativeOutputSchema` against real
+// `ChatAnthropic` and `ChatOpenAI` instances from `@langchain/anthropic` and
+// `@langchain/openai`. These verify that the mutation actually flows through
+// the LangChain invocation-params pipeline into the request body that would be
+// sent to each provider's API — it isn't enough that we set a field on the JS
+// object; the field has to land on the wire.
+//
+// These also exercise the `bindTools(...)` flow that the AI Agent uses, since
+// `bindTools` re-clones the model via `withConfig` for OpenAI — a clone path
+// that's easy to break by accident.
+
+import { ChatAnthropic } from '@langchain/anthropic';
+import { ChatOpenAI } from '@langchain/openai';
+import { z } from 'zod';
+
+import { bindNativeOutputSchema } from './bindNativeOutputSchema';
+import type { N8nOutputParser } from '../output_parsers/N8nOutputParser';
+
+const fakeParser = (schema: z.ZodSchema<unknown>): N8nOutputParser =>
+	({ getSchema: () => schema }) as unknown as N8nOutputParser;
+
+const fakeTool = { name: 'Calculator', description: 'do math', schema: { type: 'object' } };
+
+describe('bindNativeOutputSchema — wire payload integration', () => {
+	const userSchema = z.object({
+		output: z.object({
+			summary: z.string(),
+			confidence: z.number(),
+		}),
+	});
+
+	describe('ChatAnthropic', () => {
+		it('emits output_config.format on invocationParams after binding', () => {
+			const model = new ChatAnthropic({
+				model: 'claude-sonnet-4-6',
+				apiKey: 'sk-ant-test',
+			});
+
+			expect(bindNativeOutputSchema(model, fakeParser(userSchema))).toBe(true);
+
+			const params = model.invocationParams() as {
+				output_config?: { format?: { type: string; schema: Record<string, unknown> } };
+			};
+			expect(params.output_config?.format?.type).toBe('json_schema');
+		});
+
+		it('keeps output_config.format on the wire after bindTools', () => {
+			// The AI Agent calls `bindTools(tools)` after we mutate. For
+			// ChatAnthropic this returns a `RunnableBinding` whose underlying
+			// model still has the mutated `outputConfig`, so the binding
+			// survives.
+			const model = new ChatAnthropic({
+				model: 'claude-sonnet-4-6',
+				apiKey: 'sk-ant-test',
+			});
+			bindNativeOutputSchema(model, fakeParser(userSchema));
+
+			model.bindTools?.([fakeTool]);
+
+			const params = model.invocationParams() as {
+				output_config?: { format?: { type: string } };
+			};
+			expect(params.output_config?.format?.type).toBe('json_schema');
+		});
+
+		it('preserves constructor-level output_config (e.g. effort) when binding', () => {
+			const model = new ChatAnthropic({
+				model: 'claude-opus-4-7',
+				apiKey: 'sk-ant-test',
+				outputConfig: { effort: 'medium' },
+			});
+
+			bindNativeOutputSchema(model, fakeParser(userSchema));
+
+			const params = model.invocationParams() as {
+				output_config?: { effort?: string; format?: { type: string } };
+			};
+			expect(params.output_config?.effort).toBe('medium');
+			expect(params.output_config?.format?.type).toBe('json_schema');
+		});
+	});
+
+	describe('ChatOpenAI — Chat Completions path', () => {
+		it('emits response_format on invocationParams after binding', () => {
+			const model = new ChatOpenAI({ model: 'gpt-4.1', apiKey: 'sk-test' });
+
+			expect(bindNativeOutputSchema(model, fakeParser(userSchema))).toBe(true);
+
+			const params = model.invocationParams() as {
+				response_format?: {
+					type: string;
+					json_schema?: { name: string; strict: boolean };
+				};
+			};
+			expect(params.response_format?.type).toBe('json_schema');
+			expect(params.response_format?.json_schema?.name).toBe('output');
+			expect(params.response_format?.json_schema?.strict).toBe(true);
+		});
+
+		it('keeps response_format on the wire after bindTools (AI Agent path)', () => {
+			// `bindTools` on ChatOpenAI re-clones via `withConfig`, which
+			// merges constructor + bound options — response_format must
+			// survive that clone or it's silently dropped on the wire.
+			const model = new ChatOpenAI({ model: 'gpt-4.1', apiKey: 'sk-test' });
+			bindNativeOutputSchema(model, fakeParser(userSchema));
+
+			const bound = model.bindTools!([fakeTool]) as ChatOpenAI;
+
+			const params = bound.invocationParams() as {
+				response_format?: { type: string };
+				tools?: unknown[];
+			};
+			expect(params.response_format?.type).toBe('json_schema');
+			expect(params.tools?.length).toBe(1);
+		});
+	});
+
+	describe('ChatOpenAI — Responses API path (n8n default for v1.3+)', () => {
+		// n8n's `LmChatOpenAi` node at typeVersion ≥ 1.3 defaults
+		// `useResponsesApi: true`. The Responses API converts
+		// `options.response_format` into `text.format` server-side, so the
+		// same mutation must produce the right shape on this path too.
+
+		it('emits text.format on invocationParams after binding', () => {
+			const model = new ChatOpenAI({
+				model: 'gpt-4.1',
+				apiKey: 'sk-test',
+				useResponsesApi: true,
+			});
+
+			expect(bindNativeOutputSchema(model, fakeParser(userSchema))).toBe(true);
+
+			const params = model.invocationParams() as {
+				text?: { format?: { type: string; name?: string; strict?: boolean } };
+			};
+			expect(params.text?.format?.type).toBe('json_schema');
+			expect(params.text?.format?.name).toBe('output');
+			expect(params.text?.format?.strict).toBe(true);
+		});
+
+		it('keeps text.format on the wire after bindTools (AI Agent path)', () => {
+			const model = new ChatOpenAI({
+				model: 'gpt-4.1',
+				apiKey: 'sk-test',
+				useResponsesApi: true,
+			});
+			bindNativeOutputSchema(model, fakeParser(userSchema));
+
+			const bound = model.bindTools!([fakeTool]) as ChatOpenAI;
+
+			const params = bound.invocationParams() as {
+				text?: { format?: { type: string } };
+				tools?: unknown[];
+			};
+			expect(params.text?.format?.type).toBe('json_schema');
+			expect(params.tools?.length).toBe(1);
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/utils/structured_output/bindNativeOutputSchema.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/structured_output/bindNativeOutputSchema.test.ts
@@ -1,0 +1,89 @@
+import { ChatAnthropic } from '@langchain/anthropic';
+import { ChatOpenAI } from '@langchain/openai';
+import { z } from 'zod';
+
+import { bindNativeOutputSchema, tryBindNativeOutputSchema } from './bindNativeOutputSchema';
+import type { N8nOutputParser } from '../output_parsers/N8nOutputParser';
+
+const fakeParser = (schema?: z.ZodSchema<unknown>): N8nOutputParser =>
+	({ getSchema: () => schema }) as unknown as N8nOutputParser;
+
+const newAnthropic = () => new ChatAnthropic({ model: 'claude-sonnet-4-6', apiKey: 'sk-ant-test' });
+const newOpenAI = () => new ChatOpenAI({ model: 'gpt-4.1', apiKey: 'sk-test' });
+
+describe('bindNativeOutputSchema', () => {
+	const schema = z.object({ output: z.object({ answer: z.string() }) });
+
+	it('returns false when no parser is connected', () => {
+		expect(bindNativeOutputSchema(newAnthropic(), undefined)).toBe(false);
+	});
+
+	it('returns false when the parser has no schema', () => {
+		expect(bindNativeOutputSchema(newAnthropic(), fakeParser(undefined))).toBe(false);
+	});
+
+	it('returns false on a provider we do not support', () => {
+		// Stand-in for a chat model that isn't an instance of ChatAnthropic or
+		// ChatOpenAI — the binder should leave it untouched.
+		const unsupported = {
+			_llmType: () => 'ollama',
+		} as unknown as Parameters<typeof bindNativeOutputSchema>[0];
+		expect(bindNativeOutputSchema(unsupported, fakeParser(schema))).toBe(false);
+	});
+
+	it('sets outputConfig.format on a ChatAnthropic instance', () => {
+		const model = newAnthropic();
+		expect(bindNativeOutputSchema(model, fakeParser(schema))).toBe(true);
+		expect(model.outputConfig?.format).toMatchObject({ type: 'json_schema' });
+	});
+
+	it('preserves existing outputConfig fields on ChatAnthropic (e.g. effort)', () => {
+		const model = new ChatAnthropic({
+			model: 'claude-opus-4-7',
+			apiKey: 'sk-ant-test',
+			outputConfig: { effort: 'medium' },
+		});
+		bindNativeOutputSchema(model, fakeParser(schema));
+		expect(model.outputConfig?.effort).toBe('medium');
+		expect(model.outputConfig?.format).toMatchObject({ type: 'json_schema' });
+	});
+
+	it('sets response_format with strict:true on a ChatOpenAI instance', () => {
+		const model = newOpenAI();
+		expect(bindNativeOutputSchema(model, fakeParser(schema))).toBe(true);
+		const defaults = (model as unknown as { defaultOptions: Record<string, unknown> })
+			.defaultOptions;
+		expect(defaults.response_format).toMatchObject({
+			type: 'json_schema',
+			json_schema: { name: 'output', strict: true },
+		});
+	});
+});
+
+describe('tryBindNativeOutputSchema', () => {
+	const schema = z.object({ output: z.string() });
+
+	it('returns false when no parser is connected', () => {
+		expect(tryBindNativeOutputSchema([newAnthropic()], undefined)).toBe(false);
+	});
+
+	it('returns false when no eligible models are passed (all null)', () => {
+		expect(tryBindNativeOutputSchema([null, undefined], fakeParser(schema))).toBe(false);
+	});
+
+	it('returns true when every model accepts the binding', () => {
+		const primary = newAnthropic();
+		const fallback = newAnthropic();
+		expect(tryBindNativeOutputSchema([primary, fallback], fakeParser(schema))).toBe(true);
+		expect(primary.outputConfig?.format).toBeDefined();
+		expect(fallback.outputConfig?.format).toBeDefined();
+	});
+
+	it('returns false when any model fails — caller must use the legacy path uniformly', () => {
+		const primary = newAnthropic();
+		const unsupported = {
+			_llmType: () => 'ollama',
+		} as unknown as Parameters<typeof bindNativeOutputSchema>[0];
+		expect(tryBindNativeOutputSchema([primary, unsupported], fakeParser(schema))).toBe(false);
+	});
+});

--- a/packages/@n8n/nodes-langchain/utils/structured_output/bindNativeOutputSchema.ts
+++ b/packages/@n8n/nodes-langchain/utils/structured_output/bindNativeOutputSchema.ts
@@ -1,0 +1,112 @@
+// Attach an n8n Output Parser's schema directly to a connected chat model as
+// **native constrained-decoding configuration** — Anthropic's
+// `output_config.format`, OpenAI's `response_format: json_schema`, etc.
+//
+// When this is wired up the agent / chain can skip the legacy "ask the model
+// nicely to call a synthetic `format_final_json_response` tool" workaround.
+// The model is guaranteed to emit schema-conformant JSON by construction, and
+// the parser still owns final validation.
+//
+// **Provider-internals safety net**: the binders read/write fields on the
+// concrete LangChain provider classes (`ChatAnthropic.outputConfig`,
+// `ChatOpenAI.defaultOptions`). Those names are stable, but they're a
+// covenant with `@langchain/anthropic` / `@langchain/openai` private internals.
+// The integration tests in `bindNativeOutputSchema.integration.test.ts`
+// construct real model instances and assert that the binding lands on the
+// `invocationParams()` wire payload — so a LangChain rename will fail CI here,
+// not silently in production.
+
+import { ChatAnthropic } from '@langchain/anthropic';
+import type { BaseLanguageModel } from '@langchain/core/language_models/base';
+import { toJsonSchema } from '@langchain/core/utils/json_schema';
+import { ChatOpenAI } from '@langchain/openai';
+
+import type { N8nOutputParser } from '../output_parsers/N8nOutputParser';
+
+const STRUCTURED_OUTPUT_NAME = 'output';
+
+/**
+ * Apply the parser's schema to a single chat model. Mutates the instance in
+ * place — safe because chat-model `supplyData` returns a freshly constructed
+ * model per execution.
+ *
+ * Returns `true` when the binding was applied. When the model's provider is
+ * not supported, or no usable schema is available, returns `false` and the
+ * caller falls back to the legacy synthetic-tool / formatting-instructions
+ * path.
+ */
+export const bindNativeOutputSchema = (
+	model: BaseLanguageModel,
+	outputParser: N8nOutputParser | undefined,
+): boolean => {
+	if (!outputParser) return false;
+
+	const zodSchema = outputParser.getSchema();
+	if (!zodSchema) return false;
+
+	const jsonSchema = toJsonSchema(zodSchema as Parameters<typeof toJsonSchema>[0]) as Record<
+		string,
+		unknown
+	>;
+
+	if (model instanceof ChatAnthropic) {
+		// `outputConfig` is a public typed field; `invocationParams()` reads it
+		// directly and emits it on the wire as `output_config.format`. Spread
+		// to preserve other config the user may have set (e.g. `effort` for
+		// adaptive thinking).
+		model.outputConfig = {
+			...(model.outputConfig ?? {}),
+			format: { type: 'json_schema', schema: jsonSchema },
+		};
+		return true;
+	}
+
+	if (model instanceof ChatOpenAI) {
+		// `defaultOptions` is `protected` on ChatOpenAI but is the only field
+		// that flows into the internal `completions` / `responses` sub-
+		// instances' `invocationParams()` via `_combineCallOptions()`. Setting
+		// `modelKwargs` on the outer instance does NOT propagate and is
+		// silently dropped on the wire. Bypassing the visibility modifier is
+		// intentional; the field name is covered by the integration test.
+		//
+		// `strict: true` enables actual constrained decoding. With `strict:
+		// false` OpenAI treats the schema as a hint only, so the new path
+		// would offer no real guarantee over the legacy prompt-injection
+		// approach. The trade-off: the schema must be OpenAI-strict-compliant
+		// (`additionalProperties: false`, all properties `required`, no
+		// unsupported keywords); non-compliant schemas return a 400 from
+		// OpenAI surfaced as a NodeApiError.
+		const target = model as unknown as { defaultOptions: Record<string, unknown> };
+		target.defaultOptions = {
+			...(target.defaultOptions ?? {}),
+			response_format: {
+				type: 'json_schema',
+				json_schema: {
+					name: STRUCTURED_OUTPUT_NAME,
+					schema: jsonSchema,
+					strict: true,
+				},
+			},
+		};
+		return true;
+	}
+
+	return false;
+};
+
+/**
+ * Bind the parser's schema across every model that could run for an execution
+ * (typically primary + fallback). Returns `true` only when **every** model
+ * accepted the binding — if any one fails, fall back to the legacy path
+ * uniformly, so a fallback-on-failure can't bypass the schema and emit
+ * non-conformant text the parser would reject.
+ */
+export const tryBindNativeOutputSchema = (
+	models: Array<BaseLanguageModel | null | undefined>,
+	outputParser: N8nOutputParser | undefined,
+): boolean => {
+	if (!outputParser) return false;
+	const eligibleModels = models.filter((m): m is BaseLanguageModel => m != null);
+	if (eligibleModels.length === 0) return false;
+	return eligibleModels.every((m) => bindNativeOutputSchema(m, outputParser));
+};


### PR DESCRIPTION
## Summary

Adds **native constrained-decoding** for structured output in the AI Agent (v2/v3) and Basic LLM Chain. When the user opts in via the new `Use Native Structured Output` toggle and the connected chat model supports it, the parser's schema is bound directly to the model:
-  Anthropic's `output_config.format`,
- OpenAI's `response_format: json_schema` with `strict: true`

instead of injecting prompt formatting instructions plus a synthetic `format_final_json_response` tool. 

The model is then *guaranteed* to emit schema-conformant JSON by construction, and the connected Structured Output Parser still owns final validation.

NOTE: This is **Off by default.** Existing workflows continue on the legacy synthetic-tool / prompt path with zero behaviour change. Per-node opt-in lives on the AI Agent options collection and on Basic LLM Chain. This is a design decision to make this an easy upgrade for existing workflows.

### Why this is needed

LangChain's "synthetic tool" approach for structured output is probabilistic: the model can ignore the tool, call it with malformed args, or produce free-form text first. Anthropic shipped real constrained decoding in `@langchain/anthropic` 1.3.x (`outputConfig.format`) and OpenAI has had `response_format: json_schema` for a while. This PR lets n8n users opt into those native paths without losing the parser-as-validator escape hatch.

### Provider-internals safety net

The binders read/write fields on concrete LangChain provider classes (`ChatAnthropic.outputConfig` is public + typed; `ChatOpenAI.defaultOptions` is `protected` and bypassed intentionally). To keep us from silently breaking on a LangChain rename, `bindNativeOutputSchema.integration.test.ts` constructs real `ChatAnthropic` / `ChatOpenAI` instances and asserts the field actually lands on `invocationParams()`, for both Chat Completions and Responses API paths, before and after `bindTools()`. A rename will fail CI here rather than silently in production.

### Providers covered

Anthropic and OpenAI in this PR. The provider map in `bindNativeOutputSchema` is a one-line extension per provider. Gemini, Mistral, Groq / xAI Grok / DeepSeek (OpenAI-compatible) also support structured output and could be straightforward follow-ups.

## Related Linear tickets, Github issues, and Community forum posts

<!-- No related ticket or issue. -->

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
