### PR TITLE
test(benchmark): Add sizing-matrix aggregator for DEVP-185 schema

### DIFF
--- a/packages/testing/playwright/scripts/sizing-matrix-aggregate.ts
+++ b/packages/testing/playwright/scripts/sizing-matrix-aggregate.ts
@@ -4,17 +4,25 @@
  *   # Local directory of downloaded reports
  *   npx tsx packages/testing/playwright/scripts/sizing-matrix-aggregate.ts \
  *     --input <dir> [--mapping <file>] [--out <file>] \
- *     [--n8n-version <ver>] [--commit-sha <sha>]
+ *     [--n8n-version <ver>] [--commit-sha <sha>] \
+ *     [--hardware-runner <name>] [--hardware-vcpu <n>] [--hardware-ram-gb <n>]
  *
  *   # Or pull straight from a Currents run (requires CURRENTS_API_KEY env)
  *   CURRENTS_API_KEY=… npx tsx packages/testing/playwright/scripts/sizing-matrix-aggregate.ts \
  *     --currents-run <runId> [--out <file>]
  *
+ *   # Hardware can also be set via env: SIZING_MATRIX_RUNNER, SIZING_MATRIX_VCPU,
+ *   # SIZING_MATRIX_RAM_GB. Local-dev runs that don't override produce metadata
+ *   # claiming the Blacksmith CI runner — wrong number is silently misleading,
+ *   # so override when running outside CI.
+ *
  * Default mapping is inlined below — moves to JSON once stable.
  *
- * Hardware baseline: blacksmith-8vcpu-ubuntu-2204 (8 vCPU / 16 GB), the
- * runner that hosts `benchmarking:infrastructure` jobs. Cell topologies
- * are containers-on-that-host with the CPU/memory caps each spec sets.
+ * Hardware default: blacksmith-8vcpu-ubuntu-2204 (8 vCPU / 16 GB), the runner
+ * that hosts `benchmarking:infrastructure` jobs. Cell topologies are
+ * containers-on-that-host with the CPU/memory caps each spec sets. Local
+ * Mac runs MUST override via `--hardware-runner my-mac --hardware-vcpu 12
+ * --hardware-ram-gb 32` or the matrix will mis-attribute the source.
  */
 
 import { readdirSync, readFileSync, writeFileSync, statSync, mkdirSync } from 'node:fs';
@@ -145,6 +153,7 @@ interface CliArgs {
 	markdownOut?: string;
 	n8nVersion: string;
 	commitSha: string;
+	hardware: HardwareInfo;
 }
 
 function parseArgs(argv: string[]): CliArgs {
@@ -172,7 +181,36 @@ function parseArgs(argv: string[]): CliArgs {
 		markdownOut: args['markdown-out'] ? resolve(args['markdown-out']) : undefined,
 		n8nVersion: args['n8n-version'] ?? readN8nVersion(),
 		commitSha: args['commit-sha'] ?? readGitSha(),
+		hardware: resolveHardware(args),
 	};
+}
+
+/**
+ * Hardware metadata stamped into the matrix output. Defaults to the Blacksmith
+ * CI runner but can be overridden via CLI for local development or alternative
+ * runners. Setting the wrong runner here silently produces a misleading matrix —
+ * the absolute exec/sec numbers are tied to the host that ran the bench.
+ */
+function resolveHardware(args: Record<string, string>): HardwareInfo {
+	const runner =
+		args['hardware-runner'] ?? process.env.SIZING_MATRIX_RUNNER ?? DEFAULT_HARDWARE.runner;
+	const vcpu = args['hardware-vcpu']
+		? Number(args['hardware-vcpu'])
+		: process.env.SIZING_MATRIX_VCPU
+			? Number(process.env.SIZING_MATRIX_VCPU)
+			: DEFAULT_HARDWARE.vcpu;
+	const ramGb = args['hardware-ram-gb']
+		? Number(args['hardware-ram-gb'])
+		: process.env.SIZING_MATRIX_RAM_GB
+			? Number(process.env.SIZING_MATRIX_RAM_GB)
+			: DEFAULT_HARDWARE.ramGb;
+	if (!Number.isFinite(vcpu) || vcpu <= 0) {
+		throw new Error(`--hardware-vcpu must be a positive number, got ${args['hardware-vcpu']}`);
+	}
+	if (!Number.isFinite(ramGb) || ramGb <= 0) {
+		throw new Error(`--hardware-ram-gb must be a positive number, got ${args['hardware-ram-gb']}`);
+	}
+	return { runner, vcpu, ramGb };
 }
 
 function readN8nVersion(): string {
@@ -354,7 +392,7 @@ async function main(): Promise<void> {
 	const input: AggregateInput = {
 		reports,
 		mapping,
-		hardware: DEFAULT_HARDWARE,
+		hardware: args.hardware,
 		n8nVersion: args.n8nVersion,
 		commitSha,
 		runDate: new Date().toISOString(),

--- a/packages/testing/playwright/scripts/sizing-matrix-aggregate.ts
+++ b/packages/testing/playwright/scripts/sizing-matrix-aggregate.ts
@@ -1,0 +1,397 @@
+/**
+ * Aggregates N `run-report.json` files into a `sizing-matrix.json`.
+ *
+ *   # Local directory of downloaded reports
+ *   npx tsx packages/testing/playwright/scripts/sizing-matrix-aggregate.ts \
+ *     --input <dir> [--mapping <file>] [--out <file>] \
+ *     [--n8n-version <ver>] [--commit-sha <sha>]
+ *
+ *   # Or pull straight from a Currents run (requires CURRENTS_API_KEY env)
+ *   CURRENTS_API_KEY=… npx tsx packages/testing/playwright/scripts/sizing-matrix-aggregate.ts \
+ *     --currents-run <runId> [--out <file>]
+ *
+ * Default mapping is inlined below — moves to JSON once stable.
+ *
+ * Hardware baseline: blacksmith-8vcpu-ubuntu-2204 (8 vCPU / 16 GB), the
+ * runner that hosts `benchmarking:infrastructure` jobs. Cell topologies
+ * are containers-on-that-host with the CPU/memory caps each spec sets.
+ */
+
+import { readdirSync, readFileSync, writeFileSync, statSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+
+const CURRENTS_API = 'https://api.currents.dev/v1';
+
+import type { RunReport } from '../utils/benchmark/run-report';
+import {
+	aggregate,
+	renderMarkdown,
+	type AggregateInput,
+	type HardwareInfo,
+	type SpecMapping,
+	type Topology,
+} from '../utils/benchmark/sizing-matrix';
+
+const DEFAULT_HARDWARE: HardwareInfo = {
+	runner: 'blacksmith-8vcpu-ubuntu-2204',
+	vcpu: 8,
+	ramGb: 16,
+};
+
+// S0 single-instance topology: 1 main, no workers, no dedicated webhook procs.
+// Mirrors the spec setup for webhook-single-instance.spec.ts on the 8vcpu runner.
+const S0_SINGLE_MAIN: Topology = {
+	mains: 1,
+	webhookProcs: 0,
+	workers: 0,
+	mainVcpu: 2,
+	mainRamGb: 4,
+	pgVcpu: 2,
+	pgRamGb: 4,
+	redisVcpu: 1,
+	redisRamGb: 1,
+};
+
+const S1_QUEUE_BASELINE: Topology = {
+	...S0_SINGLE_MAIN,
+	workers: 1,
+	workerVcpu: 2,
+	workerRamGb: 4,
+};
+
+const S1_QUEUE_TWO_WORKERS: Topology = {
+	...S0_SINGLE_MAIN,
+	workers: 2,
+	workerVcpu: 2,
+	workerRamGb: 4,
+};
+
+/**
+ * Bridge from current free-form `scenario.spec` to DEVP-185 cell coordinates.
+ * Inline for now — extract to JSON once we have ≥10 specs mapped.
+ *
+ * Trigger axis (webhook vs kafka) collapses into the same cell — shape is
+ * about workload archetype, not ingress protocol.
+ */
+const DEFAULT_MAPPING: SpecMapping = {
+	// --- webhook-driven ---
+	'webhook/webhook-single-instance.spec.ts': {
+		scale: 'S0',
+		shape: 'L',
+		topology: S0_SINGLE_MAIN,
+	},
+	'webhook/webhook-queue-baseline.spec.ts': {
+		scale: 'S1',
+		shape: 'L',
+		topology: S1_QUEUE_BASELINE,
+	},
+	'webhook/webhook-main-scaling.spec.ts': {
+		scale: 'S1',
+		shape: 'L',
+		topology: S1_QUEUE_TWO_WORKERS,
+	},
+	'webhook/webhook-save-data-overhead.spec.ts': {
+		scale: 'S1',
+		shape: 'D',
+		topology: S1_QUEUE_BASELINE,
+	},
+	'webhook/webhook-sync-latency-floor.spec.ts': {
+		scale: 'S1',
+		shape: 'L',
+		topology: S1_QUEUE_BASELINE,
+	},
+	// --- kafka-driven (same workflow shape, different trigger) ---
+	'kafka/single-instance-ceiling.spec.ts': {
+		scale: 'S0',
+		shape: 'L',
+		topology: S0_SINGLE_MAIN,
+	},
+	'kafka/queue-mode-sustained-rate.spec.ts': {
+		scale: 'S1',
+		shape: 'L',
+		topology: S1_QUEUE_BASELINE,
+	},
+	'kafka/burst-drain-capacity.spec.ts': {
+		scale: 'S1',
+		shape: 'L',
+		topology: S1_QUEUE_BASELINE,
+	},
+	'kafka/node-count-scaling.spec.ts': {
+		// Ramps node count — closest to X-shape (deep-execution) variant
+		scale: 'S1',
+		shape: 'X',
+		topology: S1_QUEUE_BASELINE,
+	},
+	'kafka/output-size-impact.spec.ts': {
+		// Ramps output payload size — D-shape variant
+		scale: 'S1',
+		shape: 'D',
+		topology: S1_QUEUE_BASELINE,
+	},
+	'kafka/steady-rate-breaking-point.spec.ts': {
+		// 30 nodes per workflow + 10KB payload + direct mode (no workers) — X-shape under saturation
+		scale: 'S0',
+		shape: 'X',
+		topology: S0_SINGLE_MAIN,
+	},
+};
+
+interface CliArgs {
+	input?: string;
+	currentsRun?: string;
+	mapping?: string;
+	out: string;
+	markdownOut?: string;
+	n8nVersion: string;
+	commitSha: string;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+	const args: Record<string, string> = {};
+	for (let i = 0; i < argv.length; i++) {
+		const token = argv[i];
+		if (!token?.startsWith('--')) continue;
+		const key = token.slice(2);
+		const value = argv[i + 1];
+		if (value && !value.startsWith('--')) {
+			args[key] = value;
+			i++;
+		} else {
+			args[key] = 'true';
+		}
+	}
+	if (!args.input && !args['currents-run']) {
+		throw new Error('Either --input <dir> or --currents-run <runId> is required');
+	}
+	return {
+		input: args.input ? resolve(args.input) : undefined,
+		currentsRun: args['currents-run'],
+		mapping: args.mapping ? resolve(args.mapping) : undefined,
+		out: resolve(args.out ?? 'sizing-matrix.json'),
+		markdownOut: args['markdown-out'] ? resolve(args['markdown-out']) : undefined,
+		n8nVersion: args['n8n-version'] ?? readN8nVersion(),
+		commitSha: args['commit-sha'] ?? readGitSha(),
+	};
+}
+
+function readN8nVersion(): string {
+	try {
+		const pkg = JSON.parse(
+			readFileSync(join(process.cwd(), 'packages/cli/package.json'), 'utf8'),
+		) as { version?: string };
+		return pkg.version ?? 'unknown';
+	} catch {
+		return 'unknown';
+	}
+}
+
+function readGitSha(): string {
+	try {
+		const head = readFileSync(join(process.cwd(), '.git/HEAD'), 'utf8').trim();
+		if (head.startsWith('ref: ')) {
+			const refPath = head.slice(5);
+			return readFileSync(join(process.cwd(), '.git', refPath), 'utf8')
+				.trim()
+				.slice(0, 12);
+		}
+		return head.slice(0, 12);
+	} catch {
+		return 'unknown';
+	}
+}
+
+function loadMapping(path?: string): SpecMapping {
+	if (!path) return DEFAULT_MAPPING;
+	const overrides = JSON.parse(readFileSync(path, 'utf8')) as SpecMapping;
+	return { ...DEFAULT_MAPPING, ...overrides };
+}
+
+interface CurrentsAttachment {
+	name: string;
+	readUrl: string;
+	contentType: string;
+}
+
+interface CurrentsRunSpec {
+	instanceId: string;
+	spec: string;
+}
+
+interface CurrentsRunDetails {
+	commit?: { sha?: string };
+	specs?: CurrentsRunSpec[];
+}
+
+interface CurrentsInstanceDetails {
+	spec?: string;
+	commit?: { sha?: string };
+	results?: { attachments?: CurrentsAttachment[] };
+}
+
+async function currentsGet<T>(apiKey: string, path: string): Promise<T> {
+	const res = await fetch(`${CURRENTS_API}${path}`, {
+		headers: { Authorization: `Bearer ${apiKey}` },
+	});
+	if (!res.ok) {
+		throw new Error(`Currents API ${path} failed: ${res.status} ${res.statusText}`);
+	}
+	const json = (await res.json()) as { data?: T };
+	if (!json.data) throw new Error(`Currents API ${path} returned no data field`);
+	return json.data;
+}
+
+async function fetchCurrentsRun(
+	runId: string,
+	cacheDir: string,
+): Promise<{ reportPaths: string[]; commitSha?: string }> {
+	const apiKey = process.env.CURRENTS_API_KEY;
+	if (!apiKey) throw new Error('CURRENTS_API_KEY env var required for --currents-run');
+
+	console.log(`[sizing-matrix] Fetching Currents run ${runId}…`);
+	const run = await currentsGet<CurrentsRunDetails>(apiKey, `/runs/${runId}`);
+	const specs = run.specs ?? [];
+	if (specs.length === 0) {
+		throw new Error(`Currents run ${runId} has no specs.`);
+	}
+	console.log(`[sizing-matrix] Run contains ${specs.length} spec instances.`);
+	mkdirSync(cacheDir, { recursive: true });
+
+	const reportPaths: string[] = [];
+	for (const spec of specs) {
+		const instance = await currentsGet<CurrentsInstanceDetails>(
+			apiKey,
+			`/instances/${spec.instanceId}`,
+		);
+		const attachment = instance.results?.attachments?.find((a) => a.name === 'run-report.json');
+		if (!attachment) {
+			console.warn(
+				`[sizing-matrix] Spec ${spec.spec} (instance ${spec.instanceId}) has no run-report.json attachment — skipping.`,
+			);
+			continue;
+		}
+		const filename = `${sanitiseFilename(spec.spec)}.${spec.instanceId}.json`;
+		const outPath = join(cacheDir, filename);
+		await downloadTo(attachment.readUrl, outPath);
+		reportPaths.push(outPath);
+	}
+	console.log(
+		`[sizing-matrix] Downloaded ${reportPaths.length} run-report.json file(s) → ${cacheDir}`,
+	);
+	return { reportPaths, commitSha: run.commit?.sha?.slice(0, 12) };
+}
+
+async function downloadTo(url: string, outPath: string): Promise<void> {
+	const res = await fetch(url);
+	if (!res.ok) throw new Error(`Download ${url} failed: ${res.status}`);
+	const buf = Buffer.from(await res.arrayBuffer());
+	writeFileSync(outPath, buf);
+}
+
+function sanitiseFilename(spec: string): string {
+	return spec.replace(/[^a-z0-9._-]+/gi, '-').slice(0, 120);
+}
+
+function findRunReports(root: string): string[] {
+	const found: string[] = [];
+	const stack = [root];
+	while (stack.length) {
+		const current = stack.pop();
+		if (!current) continue;
+		const stat = statSync(current);
+		if (stat.isFile()) {
+			if (current.endsWith('.json') && current.includes('run-report')) found.push(current);
+			continue;
+		}
+		if (!stat.isDirectory()) continue;
+		for (const entry of readdirSync(current)) {
+			stack.push(join(current, entry));
+		}
+	}
+	return found.sort();
+}
+
+function loadReport(path: string): { path: string; report: RunReport } | undefined {
+	try {
+		const report = JSON.parse(readFileSync(path, 'utf8')) as RunReport;
+		if (report.schemaVersion !== 1) {
+			console.warn(`[sizing-matrix] Skipping ${path}: schemaVersion ${report.schemaVersion} != 1`);
+			return undefined;
+		}
+		return { path, report };
+	} catch (error) {
+		console.warn(`[sizing-matrix] Failed to parse ${path}: ${(error as Error).message}`);
+		return undefined;
+	}
+}
+
+async function main(): Promise<void> {
+	const args = parseArgs(process.argv.slice(2));
+	const mapping = loadMapping(args.mapping);
+
+	let reportPaths: string[];
+	let commitSha = args.commitSha;
+	if (args.currentsRun) {
+		const cacheDir = join(tmpdir(), `sizing-aggregator-cache`, args.currentsRun);
+		const fetched = await fetchCurrentsRun(args.currentsRun, cacheDir);
+		reportPaths = fetched.reportPaths;
+		if (fetched.commitSha) commitSha = fetched.commitSha;
+	} else if (args.input) {
+		reportPaths = findRunReports(args.input);
+	} else {
+		throw new Error('Either --input or --currents-run is required');
+	}
+
+	const reports = reportPaths
+		.map(loadReport)
+		.filter((r): r is { path: string; report: RunReport } => r !== undefined);
+
+	if (reports.length === 0) {
+		throw new Error(`No valid run-report.json files found`);
+	}
+	console.log(`[sizing-matrix] Aggregating ${reports.length} run-report.json files…`);
+
+	const input: AggregateInput = {
+		reports,
+		mapping,
+		hardware: DEFAULT_HARDWARE,
+		n8nVersion: args.n8nVersion,
+		commitSha,
+		runDate: new Date().toISOString(),
+	};
+	const matrix = aggregate(input);
+
+	mkdirSync(dirname(args.out), { recursive: true });
+	writeFileSync(args.out, JSON.stringify(matrix, null, 2));
+	console.log(`[sizing-matrix] Wrote ${matrix.cells.length} cell(s) → ${args.out}`);
+
+	if (args.markdownOut) {
+		mkdirSync(dirname(args.markdownOut), { recursive: true });
+		writeFileSync(args.markdownOut, renderMarkdown(matrix));
+		console.log(`[sizing-matrix] Rendered markdown guide → ${args.markdownOut}`);
+	}
+
+	for (const cell of matrix.cells) {
+		const shapeKeys = Object.keys(cell.shapes);
+		console.log(`  ${cell.scale}: shapes [${shapeKeys.join(', ')}]`);
+		for (const shape of shapeKeys) {
+			const r = cell.shapes[shape as keyof typeof cell.shapes];
+			if (!r) continue;
+			console.log(
+				`    ${shape}: ceiling=${r.ceilingExecPerSec.p50.toFixed(1)}/s ` +
+					`green=${r.greenSustainedExecPerSec.toFixed(1)}/s ` +
+					`p99=${r.latency.p99.toFixed(0)}ms ` +
+					`workloadIops=${r.io.workloadIopsPerSec.toFixed(0)} ` +
+					`overhead=${r.io.overheadFactor.toFixed(2)}x ` +
+					`bottleneck=${r.bottleneck} ` +
+					`verdict=${r.verdict} ` +
+					`(n=${r.ceilingExecPerSec.n})`,
+			);
+		}
+	}
+}
+
+main().catch((error) => {
+	console.error(`[sizing-matrix] ${(error as Error).message}`);
+	process.exit(1);
+});

--- a/packages/testing/playwright/utils/benchmark/sizing-matrix.ts
+++ b/packages/testing/playwright/utils/benchmark/sizing-matrix.ts
@@ -1,0 +1,641 @@
+/**
+ * Aggregated sizing-matrix artifact emitted from N `run-report.json` files.
+ *
+ * Schema lock: DEVP-185. The matrix is two-axis — scale (S0–S4 throughput
+ * slices) × shape (L/D/A/X workload archetypes). Each cell carries a
+ * topology (output, not input) and a per-shape result that collapses ≥3
+ * cold runs into `{p50, p95, max, n}`. v0 tolerates `n=1` cells and marks
+ * verdict='amber' so the renderer can flag low-confidence data.
+ */
+
+import type { RunReport, ServiceMetrics } from './run-report';
+
+export type Scale = 'S0' | 'S1' | 'S2' | 'S3' | 'S4';
+export type Shape = 'L' | 'D' | 'A' | 'X';
+export type Verdict = 'green' | 'amber' | 'red';
+export type Bottleneck = 'main-cpu' | 'pg-cpu' | 'worker-cpu' | 'queue' | 'network';
+
+export interface Topology {
+	mains: number;
+	webhookProcs: number;
+	workers: number;
+	mainVcpu: number;
+	mainRamGb: number;
+	workerVcpu?: number;
+	workerRamGb?: number;
+	pgVcpu: number;
+	pgRamGb: number;
+	pgIops?: number;
+	redisVcpu: number;
+	redisRamGb: number;
+}
+
+export interface HardwareInfo {
+	runner: string;
+	vcpu: number;
+	ramGb: number;
+}
+
+export interface SourceRun {
+	runReportPath: string;
+	commitSha: string;
+	spec: string;
+}
+
+export interface PercentileSummary {
+	p50: number;
+	p95: number;
+	max: number;
+	n: number;
+}
+
+export interface ShapeResult {
+	ceilingExecPerSec: PercentileSummary;
+	/** Steady-state ceiling — closer to the architectural limit than total exec/sec. */
+	tailExecPerSec?: PercentileSummary;
+	reqPerSec?: PercentileSummary;
+	latency: { p50: number; p975: number; p99: number };
+	headroomAtCeiling: {
+		mainCpuPct: number;
+		workerCpuPct?: number;
+		pgCpuPct: number;
+		pgCpuPctPeak: number;
+		pgBufferHit: number;
+		eventLoopLagMs: number;
+	};
+	io: {
+		/** `pg_stat_io` `client backend` (reads+writes+extends) / sec. */
+		workloadIopsPerSec: number;
+		/** Sum of bgwriter + checkpointer + walwriter + autovacuum + standalone, per sec. */
+		overheadIopsPerSec: number;
+		/** Ratio total / workload. ~1.0 means workload-dominated; >1.5 means overhead-heavy. */
+		overheadFactor: number;
+		walMbPerSec: number;
+		walRecordsPerSec: number;
+	};
+	bottleneck: Bottleneck;
+	verdict: Verdict;
+	/** Derived: throughput at which all headroom signals would stay green. */
+	greenSustainedExecPerSec: number;
+	sourceRuns: SourceRun[];
+}
+
+export interface SizingCell {
+	scale: Scale;
+	topology: Topology;
+	shapes: Partial<Record<Shape, ShapeResult>>;
+}
+
+export interface SizingMatrix {
+	schemaVersion: 1;
+	n8nVersion: string;
+	commitSha: string;
+	runDate: string;
+	hardware: HardwareInfo;
+	cells: SizingCell[];
+}
+
+/**
+ * Maps each benchmark spec path to the cell coordinates it contributes to.
+ * Bridges the current free-form `scenario.dimensions` to the locked schema.
+ * Move to JSON once stable.
+ */
+export interface SpecMapping {
+	[specPath: string]: {
+		scale: Scale;
+		shape: Shape;
+		topology: Topology;
+	};
+}
+
+export interface AggregateInput {
+	reports: Array<{ path: string; report: RunReport }>;
+	mapping: SpecMapping;
+	hardware: HardwareInfo;
+	n8nVersion: string;
+	commitSha: string;
+	runDate?: string;
+}
+
+const GREEN_THRESHOLDS = {
+	mainCpuPct: 75,
+	pgCpuPct: 70,
+	eventLoopLagMs: 25,
+	httpP99Ms: 100,
+} as const;
+
+const AMBER_THRESHOLDS = {
+	mainCpuPct: 85,
+	pgCpuPct: 85,
+	eventLoopLagMs: 100,
+	httpP99Ms: 500,
+} as const;
+
+export function aggregate(input: AggregateInput): SizingMatrix {
+	const groups = groupByCell(input.reports, input.mapping);
+	const cells = Array.from(groups.entries())
+		.map(([key, entries]) => buildCell(key, entries))
+		.sort(byScale);
+
+	return {
+		schemaVersion: 1,
+		n8nVersion: input.n8nVersion,
+		commitSha: input.commitSha,
+		runDate: input.runDate ?? new Date().toISOString(),
+		hardware: input.hardware,
+		cells,
+	};
+}
+
+interface CellGroupEntry {
+	scale: Scale;
+	shape: Shape;
+	topology: Topology;
+	path: string;
+	report: RunReport;
+}
+
+function groupByCell(
+	reports: Array<{ path: string; report: RunReport }>,
+	mapping: SpecMapping,
+): Map<Scale, CellGroupEntry[]> {
+	const byScale = new Map<Scale, CellGroupEntry[]>();
+	for (const { path, report } of reports) {
+		const cellCoord = findMapping(path, report, mapping);
+		if (!cellCoord) {
+			console.warn(
+				`[sizing-matrix] No mapping for spec "${report.scenario.spec}" (file: ${path}) — skipping.`,
+			);
+			continue;
+		}
+		const entry: CellGroupEntry = { ...cellCoord, path, report };
+		const existing = byScale.get(cellCoord.scale) ?? [];
+		existing.push(entry);
+		byScale.set(cellCoord.scale, existing);
+	}
+	return byScale;
+}
+
+/**
+ * Mapping keys identify specs by path fragment (e.g. `webhook/webhook-single-instance.spec.ts`).
+ * `scenario.spec` is the human-readable test title and is unreliable for matching,
+ * so we also test against the run-report's local filesystem path and the spec
+ * title's normalised form. First match wins.
+ */
+function findMapping(path: string, report: RunReport, mapping: SpecMapping) {
+	const candidates = [path, report.scenario.spec, normaliseSpecTitle(report.scenario.spec)];
+	for (const [key, value] of Object.entries(mapping)) {
+		const fragment = key.toLowerCase();
+		const fileStem =
+			key
+				.split('/')
+				.pop()
+				?.replace(/\.spec\.ts$/, '') ?? '';
+		const stemFragment = fileStem.toLowerCase();
+		for (const candidate of candidates) {
+			const haystack = candidate.toLowerCase();
+			if (haystack.includes(fragment)) return value;
+			if (stemFragment && haystack.includes(stemFragment)) return value;
+		}
+	}
+	return undefined;
+}
+
+function normaliseSpecTitle(title: string): string {
+	return title.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+}
+
+function buildCell(scale: Scale, entries: CellGroupEntry[]): SizingCell {
+	const topology = entries[0]?.topology;
+	if (!topology) throw new Error(`No entries for scale ${scale}`);
+
+	const byShape = new Map<Shape, CellGroupEntry[]>();
+	for (const entry of entries) {
+		const list = byShape.get(entry.shape) ?? [];
+		list.push(entry);
+		byShape.set(entry.shape, list);
+	}
+
+	const shapes: SizingCell['shapes'] = {};
+	for (const [shape, group] of byShape.entries()) {
+		shapes[shape] = buildShapeResult(group);
+	}
+
+	return { scale, topology, shapes };
+}
+
+function buildShapeResult(group: CellGroupEntry[]): ShapeResult {
+	const perRun = group.map((entry) => projectRun(entry));
+	const execs = perRun.map((r) => r.execPerSec).filter((v) => v > 0);
+	const tailExecs = perRun
+		.map((r) => r.tailExecPerSec)
+		.filter((v): v is number => v !== undefined && v > 0);
+	const reqs = perRun.map((r) => r.reqPerSec).filter((v): v is number => v !== undefined && v > 0);
+	const latP50 = mean(perRun.map((r) => r.latency.p50).filter((v) => v > 0));
+	const latP975 = mean(perRun.map((r) => r.latency.p975).filter((v) => v > 0));
+	const latP99 = mean(perRun.map((r) => r.latency.p99).filter((v) => v > 0));
+
+	const headroom = headroomFromGroup(group);
+	const ioMetrics = ioFromGroup(group);
+	const bottleneck = detectBottleneck(headroom, latP99);
+	const verdict = scoreVerdict(headroom, latP99, group.length);
+
+	// Per-run greens: project each run's exec rate to its own headroom limits,
+	// then take the median across runs. Cap at the cell's measured max ceiling
+	// so we never recommend above what we've observed.
+	const ceilingMax = execs.length ? Math.max(...execs) : 0;
+	const perRunGreens = perRun.map((r) => r.greenProjection).filter((v) => v > 0);
+	const greenMedian = perRunGreens.length ? median(perRunGreens) : 0;
+	const greenSustainedExecPerSec = Math.min(greenMedian, ceilingMax);
+
+	return {
+		ceilingExecPerSec: summarise(execs),
+		tailExecPerSec: tailExecs.length ? summarise(tailExecs) : undefined,
+		reqPerSec: reqs.length ? summarise(reqs) : undefined,
+		latency: { p50: latP50, p975: latP975, p99: latP99 },
+		headroomAtCeiling: headroom,
+		io: ioMetrics,
+		bottleneck,
+		verdict,
+		greenSustainedExecPerSec,
+		sourceRuns: group.map((g) => ({
+			runReportPath: g.path,
+			commitSha: extractSha(g.report) ?? 'unknown',
+			spec: g.report.scenario.spec,
+		})),
+	};
+}
+
+interface PerRunProjection {
+	execPerSec: number;
+	tailExecPerSec?: number;
+	reqPerSec?: number;
+	latency: { p50: number; p975: number; p99: number };
+	greenProjection: number;
+}
+
+/**
+ * Per-run projection of "what rate could this run sustain at green headroom?"
+ * Uses *this run's* CPU usage and lag, not cell-level averages — so the
+ * projection is consistent with the run that produced the throughput number.
+ */
+function projectRun(entry: CellGroupEntry): PerRunProjection {
+	const t = entry.report.throughput;
+	const execPerSec = t.execPerSec ?? 0;
+	const mainCpu = entry.report.containers.find((c) => c.name === 'n8n-main')?.cpuPct ?? 0;
+	const pgCpu = entry.report.containers.find((c) => c.name === 'postgres')?.cpuPct ?? 0;
+	const lag =
+		entry.report.services
+			.filter((s): s is Extract<ServiceMetrics, { kind: 'n8n-main' }> => s.kind === 'n8n-main')
+			.map((s) => (s.eventLoopLagSec ?? 0) * 1000)[0] ?? 0;
+
+	const mainFactor = mainCpu > 0 ? GREEN_THRESHOLDS.mainCpuPct / mainCpu : Infinity;
+	const pgFactor = pgCpu > 0 ? GREEN_THRESHOLDS.pgCpuPct / pgCpu : Infinity;
+	const lagFactor = lag > 0 ? GREEN_THRESHOLDS.eventLoopLagMs / lag : Infinity;
+	const limit = Math.min(mainFactor, pgFactor, lagFactor);
+	const greenProjection = Number.isFinite(limit) ? execPerSec * limit : execPerSec;
+
+	return {
+		execPerSec,
+		tailExecPerSec: t.tailExecPerSec,
+		reqPerSec: t.reqPerSec,
+		latency: {
+			p50: t.p50Ms ?? 0,
+			p975: t.p97_5Ms ?? 0,
+			p99: t.p99Ms ?? 0,
+		},
+		greenProjection,
+	};
+}
+
+function headroomFromGroup(group: CellGroupEntry[]): ShapeResult['headroomAtCeiling'] {
+	const mainCpu = mean(definedNumbers(group, (g) => containerValues(g, 'n8n-main', 'cpuPct')));
+	const workerVals = group.flatMap((g) => containerValues(g, 'n8n-worker', 'cpuPct'));
+	const workerDefined = workerVals.filter(isNumber);
+	const workerCpu = workerDefined.length ? mean(workerDefined) : undefined;
+	const pgCpuAvg = mean(definedNumbers(group, (g) => containerValues(g, 'postgres', 'cpuPct')));
+	const pgCpuPeak = mean(
+		definedNumbers(group, (g) => containerValues(g, 'postgres', 'cpuPctPeak')),
+	);
+	const eventLoopLagMs = mean(
+		group.flatMap((g) =>
+			g.report.services
+				.filter((s): s is Extract<ServiceMetrics, { kind: 'n8n-main' }> => s.kind === 'n8n-main')
+				.map((s) => (s.eventLoopLagSec ?? 0) * 1000),
+		),
+	);
+	const pgBufferHit = mean(
+		group.flatMap((g) =>
+			g.report.services
+				.filter((s): s is Extract<ServiceMetrics, { kind: 'postgres' }> => s.kind === 'postgres')
+				.map((s) => s.saturation.bufferHitRatio ?? 0),
+		),
+	);
+
+	return {
+		mainCpuPct: mainCpu,
+		workerCpuPct: workerCpu,
+		pgCpuPct: pgCpuAvg,
+		pgCpuPctPeak: pgCpuPeak,
+		pgBufferHit,
+		eventLoopLagMs,
+	};
+}
+
+function ioFromGroup(group: CellGroupEntry[]): ShapeResult['io'] {
+	const perRun = group.map((g) => derivePerRunIo(g.report));
+	const workloadIopsPerSec = mean(perRun.map((r) => r.workload));
+	const overheadIopsPerSec = mean(perRun.map((r) => r.overhead));
+	const overheadFactor =
+		workloadIopsPerSec > 0 ? (workloadIopsPerSec + overheadIopsPerSec) / workloadIopsPerSec : 0;
+	const walMbPerSec = mean(perRun.map((r) => r.walMbPerSec));
+	const walRecordsPerSec = mean(perRun.map((r) => r.walRecordsPerSec));
+	return {
+		workloadIopsPerSec,
+		overheadIopsPerSec,
+		overheadFactor,
+		walMbPerSec,
+		walRecordsPerSec,
+	};
+}
+
+function derivePerRunIo(report: RunReport): {
+	workload: number;
+	overhead: number;
+	walMbPerSec: number;
+	walRecordsPerSec: number;
+} {
+	const elapsedSec = (report.duration.totalMs ?? 1) / 1000;
+	const pg = report.services.find(
+		(s): s is Extract<ServiceMetrics, { kind: 'postgres' }> => s.kind === 'postgres',
+	);
+	if (!pg) {
+		return { workload: 0, overhead: 0, walMbPerSec: 0, walRecordsPerSec: 0 };
+	}
+	const sumIo = (filter: (b: string) => boolean) =>
+		pg.io
+			.filter((row) => filter(row.backendType))
+			.reduce((acc, row) => acc + row.reads + row.writes + row.extends, 0);
+
+	const workloadOps = sumIo((b) => b === 'client backend');
+	const overheadOps = sumIo(
+		(b) =>
+			b === 'background writer' ||
+			b === 'checkpointer' ||
+			b === 'walwriter' ||
+			b === 'autovacuum worker' ||
+			b === 'autovacuum launcher' ||
+			b === 'standalone backend',
+	);
+
+	return {
+		workload: workloadOps / elapsedSec,
+		overhead: overheadOps / elapsedSec,
+		walMbPerSec: pg.saturation.walMbPerSec ?? 0,
+		walRecordsPerSec: pg.saturation.walRecordsPerSec ?? 0,
+	};
+}
+
+function detectBottleneck(headroom: ShapeResult['headroomAtCeiling'], p99: number): Bottleneck {
+	// Pick the resource closest to or over its red threshold first.
+	const candidates: Array<[Bottleneck, number]> = [
+		['main-cpu', headroom.mainCpuPct / AMBER_THRESHOLDS.mainCpuPct],
+		['pg-cpu', headroom.pgCpuPct / AMBER_THRESHOLDS.pgCpuPct],
+	];
+	if (headroom.workerCpuPct !== undefined) {
+		candidates.push(['worker-cpu', headroom.workerCpuPct / AMBER_THRESHOLDS.mainCpuPct]);
+	}
+	candidates.push(['network', p99 / AMBER_THRESHOLDS.httpP99Ms]);
+	candidates.sort((a, b) => b[1] - a[1]);
+	return candidates[0]?.[0] ?? 'main-cpu';
+}
+
+function scoreVerdict(
+	headroom: ShapeResult['headroomAtCeiling'],
+	p99: number,
+	sampleCount: number,
+): Verdict {
+	if (sampleCount < 3) return 'amber'; // low-confidence regardless of headroom
+	const anyRed =
+		headroom.mainCpuPct > AMBER_THRESHOLDS.mainCpuPct ||
+		headroom.pgCpuPct > AMBER_THRESHOLDS.pgCpuPct ||
+		headroom.eventLoopLagMs > AMBER_THRESHOLDS.eventLoopLagMs ||
+		p99 > AMBER_THRESHOLDS.httpP99Ms;
+	if (anyRed) return 'red';
+	const anyAmber =
+		headroom.mainCpuPct > GREEN_THRESHOLDS.mainCpuPct ||
+		headroom.pgCpuPct > GREEN_THRESHOLDS.pgCpuPct ||
+		headroom.eventLoopLagMs > GREEN_THRESHOLDS.eventLoopLagMs ||
+		p99 > GREEN_THRESHOLDS.httpP99Ms;
+	return anyAmber ? 'amber' : 'green';
+}
+
+function median(values: number[]): number {
+	if (values.length === 0) return 0;
+	const sorted = [...values].sort((a, b) => a - b);
+	const mid = Math.floor(sorted.length / 2);
+	if (sorted.length % 2 === 1) return sorted[mid] ?? 0;
+	return ((sorted[mid - 1] ?? 0) + (sorted[mid] ?? 0)) / 2;
+}
+
+function summarise(values: number[]): PercentileSummary {
+	if (values.length === 0) return { p50: 0, p95: 0, max: 0, n: 0 };
+	const sorted = [...values].sort((a, b) => a - b);
+	return {
+		p50: percentile(sorted, 0.5),
+		p95: percentile(sorted, 0.95),
+		max: sorted[sorted.length - 1] ?? 0,
+		n: values.length,
+	};
+}
+
+function percentile(sortedAsc: number[], p: number): number {
+	if (sortedAsc.length === 0) return 0;
+	if (sortedAsc.length === 1) return sortedAsc[0] ?? 0;
+	const idx = Math.min(sortedAsc.length - 1, Math.floor(p * sortedAsc.length));
+	return sortedAsc[idx] ?? 0;
+}
+
+function mean(values: number[]): number {
+	if (values.length === 0) return 0;
+	return values.reduce((acc, v) => acc + v, 0) / values.length;
+}
+
+function isNumber(value: number | undefined): value is number {
+	return typeof value === 'number' && !Number.isNaN(value);
+}
+
+function containerValues(
+	entry: CellGroupEntry,
+	name: string,
+	field: 'cpuPct' | 'cpuPctPeak',
+): Array<number | undefined> {
+	return entry.report.containers.filter((c) => c.name === name).map((c) => c[field]);
+}
+
+function definedNumbers(
+	group: CellGroupEntry[],
+	pick: (entry: CellGroupEntry) => Array<number | undefined>,
+): number[] {
+	return group.flatMap(pick).filter(isNumber);
+}
+
+function byScale(a: SizingCell, b: SizingCell): number {
+	const order: Scale[] = ['S0', 'S1', 'S2', 'S3', 'S4'];
+	return order.indexOf(a.scale) - order.indexOf(b.scale);
+}
+
+function extractSha(report: RunReport): string | undefined {
+	const value = report.scenario.dimensions['commitSha'];
+	return typeof value === 'string' ? value : undefined;
+}
+
+/**
+ * Renders a `SizingMatrix` to the customer-facing markdown guide. Reads only
+ * the matrix object — no run-report or service-side state — so the same
+ * function is reusable by ad-hoc tooling and a future publish pipeline.
+ */
+export function renderMarkdown(matrix: SizingMatrix): string {
+	const lines: string[] = [];
+	lines.push('# n8n Self-Hosted Sizing Guide');
+	lines.push('');
+	lines.push(
+		`*Generated for n8n \`${matrix.n8nVersion}\` · commit \`${matrix.commitSha}\` · ${matrix.runDate.slice(0, 10)}*`,
+	);
+	lines.push('');
+	lines.push(
+		`*Hardware baseline:* \`${matrix.hardware.runner}\` (${matrix.hardware.vcpu} vCPU / ${matrix.hardware.ramGb} GB).`,
+	);
+	lines.push('');
+	lines.push(
+		'> **Status:** generated from the benchmark substrate at every release. ' +
+			'Cells with **verdict: amber** are single-run or low-sample — informational, ' +
+			'not promotion-ready. Each cell ships **two throughput numbers** — the ' +
+			'saturation **ceiling** observed in CI, and the **green-sustained** ' +
+			'recommendation derived from headroom thresholds. Size to the green number.',
+	);
+	lines.push('');
+
+	const shapes: Shape[] = ['L', 'D', 'A', 'X'];
+	for (const shape of shapes) {
+		const cellsWithShape = matrix.cells.filter((c) => c.shapes[shape]);
+		if (cellsWithShape.length === 0) continue;
+
+		lines.push(`## Shape ${shape}`);
+		lines.push('');
+		lines.push(renderShapeTable(cellsWithShape, shape));
+		lines.push('');
+		lines.push(renderShapeDetail(cellsWithShape, shape));
+		lines.push('');
+	}
+
+	lines.push('---');
+	lines.push('');
+	lines.push('## Methodology');
+	lines.push('');
+	lines.push(
+		`Cells are aggregated by the substrate at \`packages/testing/playwright/utils/benchmark/sizing-matrix.ts\` from per-run \`run-report.json\` files. ` +
+			"Each cell's **ceiling** is the p50/p95/max of `execPerSec` across cold runs; " +
+			'**green-sustained** is the ceiling scaled by headroom (main CPU < 75%, PG CPU < 70%, event-loop lag < 25 ms). ' +
+			'**Workload IOPS** is `pg_stat_io` `client backend` reads+writes+extends per second; ' +
+			'**overhead factor** is `(workload + bgwriter + checkpointer + walwriter + autovacuum) / workload`. ' +
+			'WAL is reported separately (`MB/s`, `records/s`).',
+	);
+	lines.push('');
+	return lines.join('\n');
+}
+
+function renderShapeTable(cells: SizingCell[], shape: Shape): string {
+	const header =
+		'| Scale | Mains | Webhook procs | Workers | PG (vCPU/RAM) | Redis | Ceiling exec/s | Green sustained | Req/s | p99 ms | Verdict |';
+	const sep = '|---|---:|---:|---:|---|---|---:|---:|---:|---:|---|';
+	const rows: string[] = [header, sep];
+	for (const cell of cells) {
+		const result = cell.shapes[shape];
+		if (!result) continue;
+		rows.push(
+			[
+				`**${cell.scale}**`,
+				`${cell.topology.mains}× (${cell.topology.mainVcpu} vCPU / ${cell.topology.mainRamGb} GB)`,
+				cell.topology.webhookProcs > 0 ? `${cell.topology.webhookProcs}×` : '(in main)',
+				cell.topology.workers > 0 && cell.topology.workerVcpu
+					? `${cell.topology.workers}× (${cell.topology.workerVcpu} vCPU / ${cell.topology.workerRamGb} GB)`
+					: '—',
+				`${cell.topology.pgVcpu} vCPU / ${cell.topology.pgRamGb} GB`,
+				`${cell.topology.redisVcpu} vCPU / ${cell.topology.redisRamGb} GB`,
+				result.ceilingExecPerSec.p50.toFixed(1),
+				result.greenSustainedExecPerSec.toFixed(1),
+				result.reqPerSec ? result.reqPerSec.p50.toFixed(1) : '—',
+				result.latency.p99.toFixed(0),
+				verdictBadge(result.verdict),
+			].join(' | '),
+		);
+	}
+	return rows.join('\n');
+}
+
+function renderShapeDetail(cells: SizingCell[], shape: Shape): string {
+	const lines: string[] = [];
+	lines.push('<details>');
+	lines.push(`<summary>Cell detail — Shape ${shape}</summary>`);
+	lines.push('');
+	for (const cell of cells) {
+		const result = cell.shapes[shape];
+		if (!result) continue;
+		lines.push(`### ${cell.scale}-${shape}  (n=${result.ceilingExecPerSec.n})`);
+		lines.push('');
+		lines.push('| Field | Value |');
+		lines.push('|---|---|');
+		lines.push(`| Ceiling exec/s (p50/p95/max) | ${fmtPercentile(result.ceilingExecPerSec)} |`);
+		if (result.tailExecPerSec) {
+			lines.push(`| Tail exec/s (steady-state) | ${fmtPercentile(result.tailExecPerSec)} |`);
+		}
+		lines.push(
+			`| **Green sustained recommendation** | ${result.greenSustainedExecPerSec.toFixed(1)} exec/s |`,
+		);
+		lines.push(
+			`| Latency p50 / p97.5 / p99 | ${result.latency.p50.toFixed(0)} / ${result.latency.p975.toFixed(0)} / ${result.latency.p99.toFixed(0)} ms |`,
+		);
+		lines.push(`| Main CPU at ceiling | ${result.headroomAtCeiling.mainCpuPct.toFixed(1)}% |`);
+		if (result.headroomAtCeiling.workerCpuPct !== undefined) {
+			lines.push(
+				`| Worker CPU at ceiling | ${result.headroomAtCeiling.workerCpuPct.toFixed(1)}% |`,
+			);
+		}
+		lines.push(
+			`| PG CPU avg / peak | ${result.headroomAtCeiling.pgCpuPct.toFixed(1)}% / ${result.headroomAtCeiling.pgCpuPctPeak.toFixed(1)}% |`,
+		);
+		lines.push(
+			`| PG buffer-hit ratio | ${(result.headroomAtCeiling.pgBufferHit * 100).toFixed(2)}% |`,
+		);
+		lines.push(`| Event-loop lag | ${result.headroomAtCeiling.eventLoopLagMs.toFixed(1)} ms |`);
+		lines.push(`| **Workload IOPS** | ${result.io.workloadIopsPerSec.toFixed(0)} ops/s |`);
+		lines.push(
+			`| Overhead IOPS (autovac + bgwriter + checkpointer + walwriter) | ${result.io.overheadIopsPerSec.toFixed(0)} ops/s |`,
+		);
+		lines.push(`| **Overhead factor** | ${result.io.overheadFactor.toFixed(2)}× workload |`);
+		lines.push(
+			`| WAL throughput | ${result.io.walMbPerSec.toFixed(2)} MB/s · ${result.io.walRecordsPerSec.toFixed(0)} records/s |`,
+		);
+		lines.push(`| Bottleneck | \`${result.bottleneck}\` |`);
+		lines.push(`| Verdict | ${verdictBadge(result.verdict)} |`);
+		lines.push(`| Source runs | ${result.sourceRuns.length} |`);
+		lines.push('');
+		for (const src of result.sourceRuns) {
+			lines.push(`- \`${src.spec}\``);
+		}
+		lines.push('');
+	}
+	lines.push('</details>');
+	return lines.join('\n');
+}
+
+function verdictBadge(verdict: Verdict): string {
+	if (verdict === 'green') return '🟢 green';
+	if (verdict === 'amber') return '🟠 amber (n<3, low confidence)';
+	return '🔴 red';
+}
+
+function fmtPercentile(p: PercentileSummary): string {
+	return `${p.p50.toFixed(1)} / ${p.p95.toFixed(1)} / ${p.max.toFixed(1)}`;
+}


### PR DESCRIPTION
## Summary

- Implements aggregator + markdown renderer for the [DEVP-185](https://linear.app/n8n/issue/DEVP-185/lock-sizing-matrix-schema-cells-shapes) sizing-matrix schema — collapses N `run-report.json` files into one `sizing-matrix.json` keyed by `(scale, shape)`, and renders a customer-facing markdown guide from it.
- Supports two input modes: local directory of downloaded `run-report.json` files, or a Currents run ID (`CURRENTS_API_KEY` env) for direct fetch.
- Emits the DEVP-185-conformant schema, with per-cell IOPS breakdown (workload vs overhead, derived from `pg_stat_io` per-backend totals), WAL throughput, and headroom-derived green-sustained recommendations capped at the measured ceiling.

## Files

- `packages/testing/playwright/utils/benchmark/sizing-matrix.ts` (new) — types matching DEVP-185 + pure aggregation logic.
- `packages/testing/playwright/scripts/sizing-matrix-aggregate.ts` (new) — CLI entry.

## Validation

Aggregator was exercised against **14 `run-report.json` files** from the 2026-05-24 master bench (commit `f784205721`), producing 5 populated cells:

| Cell | n | Ceiling exec/s | Green | Overhead × | Bottleneck |
|---|---:|---:|---:|---:|---|
| S0-L | 2 | 846 | 477 | 1.68 | network (classifier bug — known) |
| S0-X | 1 | 306 | 252 | 2.08 | main-cpu |
| S1-L | 8 | 330 | 254 | 2.11 | pg-cpu |
| S1-D | 2 | 461 | 223 | 2.12 | network (classifier bug — known) |
| S1-X | 1 | 69 | 69 | 1.72 | worker-cpu |

The S1-L cell is the first real n>=2 collapse — combines webhook-queue-baseline + webhook-main-scaling + 4 sync-latency-floor sub-tests + kafka burst-drain + kafka queue-mode-sustained-rate.

## Known limitations (intentional in v0)

- **Bottleneck classifier mislabels async backlog as "network".** Async webhook tests with high p99 (queue draining) get tagged `network` when the real bottleneck is queue depth. Fast-follow.
- **`scenario.dimensions` doesn't yet carry scale/shape.** Spec-to-cell mapping is currently a bridge table inside the CLI. DEVP-185 acceptance criterion #2 (updating bench specs to declare canonical dimensions in `benchConfig`) will eventually retire the mapping table.
- **No A-shape cells.** No canonical LLM benchmark workflow exists yet — separate sub-ticket under DEVP-120.
- **Single-CI-run sampling.** All measured cells come from one bench run. Verdict downgrades to `amber` automatically when `n<3`.

## Test plan

- [ ] `pnpm --filter=n8n-playwright typecheck` passes (confirmed local — clean)
- [ ] `npx tsx packages/testing/playwright/scripts/sizing-matrix-aggregate.ts --input <dir> --out matrix.json --markdown-out guide.md` runs end-to-end against any local directory of `run-report.json` files
- [ ] CLI errors cleanly when neither `--input` nor `--currents-run` is supplied
- [ ] Output `sizing-matrix.json` conforms to the DEVP-185 `SizingMatrix` shape (schemaVersion 1)

## References

- Schema: [DEVP-185 Lock sizing matrix schema](https://linear.app/n8n/issue/DEVP-185/lock-sizing-matrix-schema-cells-shapes)
- Umbrella: [DEVP-120 Instance Sizing](https://linear.app/n8n/issue/DEVP-120/instance-sizing)
- Customer-facing draft: [Brain Hub — Proposed Shape](https://www.notion.so/3695b6e0c94f815caf49d336b5b985b5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)