### PR TITLE
ci: Exclude .grammar files from coverage

### DIFF
--- a/packages/@n8n/vitest-config/frontend.ts
+++ b/packages/@n8n/vitest-config/frontend.ts
@@ -13,6 +13,7 @@ export const createVitestConfig = (options: InlineConfig = {}) => {
 			coverage: {
 				enabled: false,
 				include: ['src/**'],
+				exclude: ['**/*.grammar'],
 				provider: 'v8',
 				reporter: ['text-summary', 'lcov', 'html-spa'],
 			},

--- a/packages/@n8n/vitest-config/node.ts
+++ b/packages/@n8n/vitest-config/node.ts
@@ -18,6 +18,7 @@ export const createBaseInlineConfig = (options: InlineConfig = {}): InlineConfig
 					provider: 'v8',
 					reporter: process.env.CI === 'true' ? 'cobertura' : 'text-summary',
 					include: ['src/**/*'],
+					exclude: ['**/*.grammar'],
 				},
 			}
 		: {}),


### PR DESCRIPTION
## Summary

[Coverage reports](https://github.com/n8n-io/n8n/actions/runs/26216472159/job/77140893167#step:5:1778) were constantly throwing non-blocking errors on unit test suites due to Coverage tools not being able to parse the `.grammar` files in our codemirror packages.

This PR excludes those files from the coverage. We might have other files we want to exclude, so I introduced the `exclude` array to both vitest configs so we can start adding items there when we find them.

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/actions/runs/26216472159/job/77140893167#step:5:1778

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
