### PR TITLE
ci: Move isolatedModules back to jest.config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -9,6 +9,12 @@ const tsJestOptions = {
 		declaration: false,
 		sourceMap: true,
 		rootDir: '.',
+		// Force the transpile-only path for tests. Without this, ts-jest runs
+		// the full type-checker on every transformed file, which combined with
+		// aggressive worker recycling (workerIdleMemoryLimit) makes test runs
+		// ~4-5x slower. Package builds and `pnpm typecheck` read the package
+		// tsconfig directly and are unaffected.
+		isolatedModules: true,
 		// Relax strictness for cross-package imports. ts-jest applies the host
 		// package's tsconfig to every file it transforms, including imports
 		// from packages like nodes-base that disable these in their own

--- a/packages/@n8n/agents/tsconfig.json
+++ b/packages/@n8n/agents/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
 		"types": ["node", "jest"],
-		"isolatedModules": true,
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
 	},
 	"include": ["src/**/*.ts"],

--- a/packages/@n8n/ai-utilities/tsconfig.json
+++ b/packages/@n8n/ai-utilities/tsconfig.json
@@ -10,8 +10,7 @@
 		},
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"emitDecoratorMetadata": true,
-		"experimentalDecorators": true,
-		"isolatedModules": true
+		"experimentalDecorators": true
 	},
 	"include": ["src/**/*.ts", "test/**/*.ts", "integration-tests/**/*.ts"]
 }

--- a/packages/@n8n/ai-workflow-builder.ee/tsconfig.json
+++ b/packages/@n8n/ai-workflow-builder.ee/tsconfig.json
@@ -12,8 +12,7 @@
 			"@/*": ["./src/*"]
 		},
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
-		"types": ["node", "jest"],
-		"isolatedModules": true
+		"types": ["node", "jest"]
 	},
 	"include": ["src/**/*.ts", "test/**/*.ts", "evaluations/**/*.ts", "scripts/**/*.ts"]
 }

--- a/packages/@n8n/computer-use/tsconfig.json
+++ b/packages/@n8n/computer-use/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
 		"types": ["node", "jest"],
-		"isolatedModules": true,
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
 	},
 	"include": ["src/**/*.ts"]

--- a/packages/@n8n/local-gateway/tsconfig.json
+++ b/packages/@n8n/local-gateway/tsconfig.json
@@ -6,8 +6,7 @@
 		"lib": ["es2021", "dom"],
 		"moduleResolution": "nodenext",
 		"module": "nodenext",
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
-		"isolatedModules": true
+		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
 	},
 	"include": ["src/**/*.ts"]
 }

--- a/packages/@n8n/mcp-browser/tsconfig.json
+++ b/packages/@n8n/mcp-browser/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
 		"types": ["node", "jest"],
-		"isolatedModules": true,
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
 	},
 	"include": ["src/**/*.ts"]

--- a/packages/@n8n/task-runner/tsconfig.json
+++ b/packages/@n8n/task-runner/tsconfig.json
@@ -6,7 +6,6 @@
 	"compilerOptions": {
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
-		"isolatedModules": true,
 		"paths": {
 			"@/*": ["./src/*"]
 		},

--- a/packages/@n8n/workflow-sdk/tsconfig.json
+++ b/packages/@n8n/workflow-sdk/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"isolatedModules": true,
 		"types": ["node", "jest"],
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
 	},

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -16,7 +16,6 @@
 		"strict": true,
 		"strictFunctionTypes": false,
 		"strictPropertyInitialization": false,
-		"isolatedModules": false,
 		// TODO: remove all options below this line
 		"useUnknownInCatchVariables": false
 	},

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -12,7 +12,6 @@
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
-		"isolatedModules": true,
 		// TODO: remove all options below this line
 		"useUnknownInCatchVariables": false
 	},


### PR DESCRIPTION
## Summary

Changes introduced [here](https://github.com/n8n-io/n8n/pull/30880) caused slowdown in jest-based testing in CI. Revert the changes, while moving the `isolatedModules` directive from jest config to the compilerOptions to silence deprecation errors.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
