### PR TITLE
ci: Skip Electron binary download on all CI installs

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -117,6 +117,10 @@ runs:
         INSTALL_LOG: ${{ runner.temp }}/pnpm-install.log
         SAFE_CHAIN_LOGGING: verbose
         DEBUG: pnpm:*
+        # Skip the Electron binary download triggered by @n8n/local-gateway's
+        # postinstall. CI never runs the Electron app, but the ~150MB binary
+        # fetch fires on every install otherwise.
+        ELECTRON_SKIP_BINARY_DOWNLOAD: 1
       run: |
         set +o pipefail
         timeout --kill-after=30s 300s $INSTALL_COMMAND \

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -8,11 +8,6 @@ concurrency:
   group: ci-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
   cancel-in-progress: true
 
-env:
-  # Skip Electron binary download in @n8n/local-gateway's postinstall — PR CI
-  # never runs the Electron app, but the ~150MB download fires on every install.
-  ELECTRON_SKIP_BINARY_DOWNLOAD: 1
-
 jobs:
   install-and-build:
     name: Install & Build

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -8,6 +8,11 @@ concurrency:
   group: ci-${{ github.event.pull_request.number || github.event.merge_group.head_sha || github.ref }}
   cancel-in-progress: true
 
+env:
+  # Skip Electron binary download in @n8n/local-gateway's postinstall — PR CI
+  # never runs the Electron app, but the ~150MB download fires on every install.
+  ELECTRON_SKIP_BINARY_DOWNLOAD: 1
+
 jobs:
   install-and-build:
     name: Install & Build


### PR DESCRIPTION
## Summary

Adds `ELECTRON_SKIP_BINARY_DOWNLOAD=1` as a workflow-level env var in `ci-pull-requests.yml`.

### Why

The `@n8n/local-gateway` package defines a `postinstall` script that invokes `node node_modules/electron/install.js`, which downloads the matching Electron binary (~150 MB) from GitHub Releases into `~/.cache/electron`. That download fires on every `pnpm install` in CI, even though PR CI never actually runs the Electron app. 

We are suspecting that this might be a co-contributor the the install & build step flake failures in our CI

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created. (N/A — internal CI change)
- [x] Tests included. (N/A — CI infra)
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI