### PR TITLE
fix(langchain agent Node): Resolve sub-agent tool calls inline when nested

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/execute.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/execute.ts
@@ -8,7 +8,7 @@ import type {
 } from 'n8n-workflow';
 import { getHighlightedResponseKey, sleep } from 'n8n-workflow';
 
-import { buildExecutionContext, executeBatch } from './helpers';
+import { buildExecutionContext, executeBatch, resolveSubAgentRequest } from './helpers';
 import { isExecuteFunctions } from '../../utils';
 
 /** Keys written in `finally` for Tools Agent V3 execution tracing (`setMetadata`). */
@@ -120,7 +120,19 @@ export async function toolsAgentExecute(
 
 		// Return tool call request if any tools need to be executed
 		if (request) {
-			return request;
+			if (isExecuteFunctions(this)) {
+				// Top-level execution — hand the request to the engine, which
+				// schedules the requested tool nodes and resumes us with an
+				// EngineResponse.
+				return request;
+			}
+			// Sub-agent execution (running through `makeHandleToolInvocation`):
+			// the engine can't fulfil EngineRequests from inside a tool callback,
+			// so resolve the sub-agent's tools inline and loop back into this
+			// function until it produces plain node output data.
+			return await resolveSubAgentRequest(this, request, {
+				runAgentBatch: async (engineResponse) => await toolsAgentExecute.call(this, engineResponse),
+			});
 		}
 
 		// Auto-highlight the agent's response output

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/index.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/index.ts
@@ -13,3 +13,8 @@ export { finalizeResult } from './finalizeResult';
 export { executeBatch, type AgentMemoryHitCounters } from './executeBatch';
 
 export { checkMaxIterations } from './checkMaxIterations';
+
+export {
+	resolveSubAgentRequest,
+	type ResolveSubAgentRequestDeps,
+} from './resolveSubAgentRequest';

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/resolveSubAgentRequest.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/resolveSubAgentRequest.ts
@@ -57,13 +57,15 @@ export async function resolveSubAgentRequest(
 	let current: EngineRequest<RequestResponseMetadata> | INodeExecutionData[][] = request;
 
 	const node = ctx.getNode();
+	// Connected tools are stable for the lifetime of a sub-agent run, and
+	// `getConnectedTools` re-resolves every child supply-data tool (MCP,
+	// Vector Store, nested AgentToolV3) — so hoist out of the loop.
+	const tools = (await getTools(ctx)) as ConnectedTool[];
 
 	while (isEngineRequest(current)) {
 		assertNoHitlActions(node, current.actions);
 
 		ctx.getExecutionCancelSignal?.()?.throwIfAborted?.();
-
-		const tools = (await getTools(ctx)) as ConnectedTool[];
 
 		const actionResponses = await Promise.all(
 			current.actions.map(async (action) => await invokeToolAction(node, action, tools)),
@@ -87,7 +89,7 @@ function assertNoHitlActions(node: INode, actions: Action[]): void {
 				`Human-in-the-Loop nodes cannot be used inside a sub-agent. Move "${action.nodeName}" to the top-level workflow.`,
 				{
 					description:
-						'Engine-level approval flows are not available from within a tool callback. Make the human-in-the-loop step part of the top-level Agent instead of a nested AgentToolV3.',
+						'Engine-level approval flows are not available from within a tool callback, so the whole sub-agent step is aborted (any sibling tool calls in the same batch are not executed). Make the human-in-the-loop step part of the top-level Agent instead of a nested AgentToolV3.',
 					extra: { node: node.name },
 				},
 			);
@@ -149,6 +151,12 @@ function buildTaskDataShell(): Pick<
 	ITaskData,
 	'executionTime' | 'startTime' | 'executionIndex' | 'source'
 > {
+	// Engine-scheduled tool runs record real timings and parent source linkage;
+	// we synthesize zeros here because the consumers in the V3 agent batch
+	// path (`buildSteps`, `processHitlResponses`, and the iteration counters
+	// in `executeBatch`/`execute.ts`) only read `data.ai_tool` and
+	// `executionStatus`/`error`. If a future consumer starts reading these
+	// fields on `actionResponses`, populate them via `Date.now()`.
 	return {
 		executionTime: 0,
 		startTime: 0,

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/resolveSubAgentRequest.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/resolveSubAgentRequest.ts
@@ -1,5 +1,7 @@
 import type { DynamicStructuredTool, Tool } from '@langchain/classic/tools';
-import type { RequestResponseMetadata, ToolMetadata } from '@utils/agent-execution';
+import type { RequestResponseMetadata } from '@utils/agent-execution';
+import omit from 'lodash/omit';
+import { isEngineRequest } from 'n8n-core';
 import type {
 	EngineRequest,
 	EngineResponse,
@@ -17,66 +19,42 @@ import { getTools } from '../../common';
 type Action = EngineRequest<RequestResponseMetadata>['actions'][number];
 type ConnectedTool = DynamicStructuredTool | Tool;
 
-function isEngineRequest(
-	value: EngineRequest<RequestResponseMetadata> | INodeExecutionData[][],
-): value is EngineRequest<RequestResponseMetadata> {
-	return !Array.isArray(value) && 'actions' in value;
-}
+const EMPTY_TASK_DATA_SHELL: Pick<
+	ITaskData,
+	'executionTime' | 'startTime' | 'executionIndex' | 'source'
+> = { executionTime: 0, startTime: 0, executionIndex: 0, source: [] };
 
 export type ResolveSubAgentRequestDeps = {
-	/**
-	 * Re-enter the sub-agent with the EngineResponse built from the resolved
-	 * tool invocations. The sub-agent's `maxIterations` is enforced inside this
-	 * callback (via `checkMaxIterations`), so recursion is bounded.
-	 */
 	runAgentBatch: (
 		response: EngineResponse<RequestResponseMetadata>,
 	) => Promise<INodeExecutionData[][] | EngineRequest<RequestResponseMetadata>>;
 };
 
 /**
- * Resolves an `EngineRequest` inline when AgentToolV3 runs as a sub-agent
- * (`ISupplyDataFunctions` context). The parent agent's tool boundary —
- * `makeHandleToolInvocation` in core — cannot fulfil `EngineRequest`s because
- * the workflow engine only schedules nested nodes at the top level. To keep
- * the same observable behaviour the engine would have produced, we:
- *
- *   1. Reject HITL actions upfront (no engine-level suspend/resume here).
- *   2. Invoke the sub-agent's connected LangChain tools in parallel — this
- *      routes execute-only tools through `makeHandleToolInvocation` again
- *      (which preserves canvas observability) and supplyData-resolved tools
- *      through their own `invoke()` paths.
- *   3. Build an `EngineResponse` and re-enter the sub-agent until it produces
- *      plain node output data.
+ * Resolves an `EngineRequest` inline when AgentToolV3 runs as a sub-agent —
+ * `makeHandleToolInvocation` in core can't fulfil engine requests from a tool
+ * callback. HITL is rejected upfront, other tools are invoked in parallel via
+ * `tool.invoke()`, and the loop re-enters until plain node output is produced.
  */
 export async function resolveSubAgentRequest(
 	ctx: ISupplyDataFunctions,
 	request: EngineRequest<RequestResponseMetadata>,
 	deps: ResolveSubAgentRequestDeps,
 ): Promise<INodeExecutionData[][]> {
-	let current: EngineRequest<RequestResponseMetadata> | INodeExecutionData[][] = request;
-
+	let current: INodeExecutionData[][] | EngineRequest<RequestResponseMetadata> = request;
 	const node = ctx.getNode();
-	// Connected tools are stable for the lifetime of a sub-agent run, and
-	// `getConnectedTools` re-resolves every child supply-data tool (MCP,
-	// Vector Store, nested AgentToolV3) — so hoist out of the loop.
+	// Hoisted: tool list is stable for the lifetime of a sub-agent run.
 	const tools = (await getTools(ctx)) as ConnectedTool[];
 
 	while (isEngineRequest(current)) {
 		assertNoHitlActions(node, current.actions);
-
 		ctx.getExecutionCancelSignal?.()?.throwIfAborted?.();
 
 		const actionResponses = await Promise.all(
 			current.actions.map(async (action) => await invokeToolAction(node, action, tools)),
 		);
 
-		const response: EngineResponse<RequestResponseMetadata> = {
-			actionResponses,
-			metadata: current.metadata,
-		};
-
-		current = await deps.runAgentBatch(response);
+		current = await deps.runAgentBatch({ actionResponses, metadata: current.metadata });
 	}
 
 	return current;
@@ -97,42 +75,14 @@ function assertNoHitlActions(node: INode, actions: Action[]): void {
 	}
 }
 
-function findMatchingTool(action: Action, tools: ConnectedTool[]): ConnectedTool | undefined {
-	const toolkitName =
-		typeof action.input?.tool === 'string' ? (action.input.tool as string) : undefined;
-
-	if (toolkitName !== undefined) {
-		const toolkitMatch = tools.find((t) => {
-			const md = t.metadata as ToolMetadata | undefined;
-			return md?.sourceNodeName === action.nodeName && t.name === toolkitName;
-		});
-		if (toolkitMatch) return toolkitMatch;
-	}
-
-	return tools.find(
-		(t) => (t.metadata as ToolMetadata | undefined)?.sourceNodeName === action.nodeName,
-	);
-}
-
-function prepareToolInput(action: Action): IDataObject {
-	// `tool` is an internal marker createEngineRequests adds for toolkit calls
-	// (so the engine knows which toolkit-tool to invoke). The LangChain tool's
-	// own Zod schema doesn't include it, so strip it before invoking.
-	if (typeof action.input?.tool === 'string') {
-		const { tool: _toolName, ...rest } = action.input;
-		return rest;
-	}
-	return action.input;
-}
-
 async function invokeToolAction(
 	node: INode,
 	action: Action,
 	tools: ConnectedTool[],
 ): Promise<ExecuteNodeResult<RequestResponseMetadata>> {
-	const tool = findMatchingTool(action, tools);
+	const tool = tools.find((t) => t.name === action.metadata?.toolName);
 	if (!tool) {
-		return buildErrorResponse(
+		return makeActionError(
 			node,
 			action,
 			`Sub-agent could not find a connected tool for node "${action.nodeName}".`,
@@ -140,54 +90,33 @@ async function invokeToolAction(
 	}
 
 	try {
-		const output = await tool.invoke(prepareToolInput(action));
-		return buildSuccessResponse(action, output);
+		// `input.tool` is a toolkit-dispatch marker added by createEngineRequests;
+		// it isn't part of the LangChain tool's Zod schema, so strip before invoking.
+		const output = await tool.invoke(omit(action.input, 'tool'));
+		return {
+			action,
+			data: {
+				...EMPTY_TASK_DATA_SHELL,
+				executionStatus: 'success',
+				data: { ai_tool: [[{ json: { output } as IDataObject }]] },
+			},
+		};
 	} catch (error) {
-		return buildErrorResponse(node, action, error instanceof Error ? error.message : String(error));
+		return makeActionError(node, action, error instanceof Error ? error.message : String(error));
 	}
 }
 
-function buildTaskDataShell(): Pick<
-	ITaskData,
-	'executionTime' | 'startTime' | 'executionIndex' | 'source'
-> {
-	// Engine-scheduled tool runs record real timings and parent source linkage;
-	// we synthesize zeros here because the consumers in the V3 agent batch
-	// path (`buildSteps`, `processHitlResponses`, and the iteration counters
-	// in `executeBatch`/`execute.ts`) only read `data.ai_tool` and
-	// `executionStatus`/`error`. If a future consumer starts reading these
-	// fields on `actionResponses`, populate them via `Date.now()`.
-	return {
-		executionTime: 0,
-		startTime: 0,
-		executionIndex: 0,
-		source: [],
-	};
-}
-
-function buildSuccessResponse(
-	action: Action,
-	output: unknown,
-): ExecuteNodeResult<RequestResponseMetadata> {
-	const data: ITaskData = {
-		...buildTaskDataShell(),
-		executionStatus: 'success',
-		data: {
-			ai_tool: [[{ json: { output } as IDataObject }]],
-		},
-	};
-	return { action, data };
-}
-
-function buildErrorResponse(
+function makeActionError(
 	node: INode,
 	action: Action,
 	message: string,
 ): ExecuteNodeResult<RequestResponseMetadata> {
-	const data: ITaskData = {
-		...buildTaskDataShell(),
-		executionStatus: 'error',
-		error: new NodeOperationError(node, message),
+	return {
+		action,
+		data: {
+			...EMPTY_TASK_DATA_SHELL,
+			executionStatus: 'error',
+			error: new NodeOperationError(node, message),
+		},
 	};
-	return { action, data };
 }

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/resolveSubAgentRequest.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/resolveSubAgentRequest.ts
@@ -1,28 +1,19 @@
 import type { DynamicStructuredTool, Tool } from '@langchain/classic/tools';
-import type { RequestResponseMetadata } from '@utils/agent-execution';
-import omit from 'lodash/omit';
+import { executeEngineAction, type RequestResponseMetadata } from '@utils/agent-execution';
 import { isEngineRequest } from 'n8n-core';
 import type {
 	EngineRequest,
 	EngineResponse,
-	ExecuteNodeResult,
-	IDataObject,
 	INode,
 	INodeExecutionData,
 	ISupplyDataFunctions,
-	ITaskData,
 } from 'n8n-workflow';
-import { NodeOperationError, UserError } from 'n8n-workflow';
+import { UserError } from 'n8n-workflow';
 
 import { getTools } from '../../common';
 
 type Action = EngineRequest<RequestResponseMetadata>['actions'][number];
 type ConnectedTool = DynamicStructuredTool | Tool;
-
-const EMPTY_TASK_DATA_SHELL: Pick<
-	ITaskData,
-	'executionTime' | 'startTime' | 'executionIndex' | 'source'
-> = { executionTime: 0, startTime: 0, executionIndex: 0, source: [] };
 
 export type ResolveSubAgentRequestDeps = {
 	runAgentBatch: (
@@ -30,12 +21,7 @@ export type ResolveSubAgentRequestDeps = {
 	) => Promise<INodeExecutionData[][] | EngineRequest<RequestResponseMetadata>>;
 };
 
-/**
- * Resolves an `EngineRequest` inline when AgentToolV3 runs as a sub-agent —
- * `makeHandleToolInvocation` in core can't fulfil engine requests from a tool
- * callback. HITL is rejected upfront, other tools are invoked in parallel via
- * `tool.invoke()`, and the loop re-enters until plain node output is produced.
- */
+/** Resolves an EngineRequest inline when AgentToolV3 runs as a sub-agent (engine can't fulfil requests from a tool callback). */
 export async function resolveSubAgentRequest(
 	ctx: ISupplyDataFunctions,
 	request: EngineRequest<RequestResponseMetadata>,
@@ -51,7 +37,7 @@ export async function resolveSubAgentRequest(
 		ctx.getExecutionCancelSignal?.()?.throwIfAborted?.();
 
 		const actionResponses = await Promise.all(
-			current.actions.map(async (action) => await invokeToolAction(node, action, tools)),
+			current.actions.map(async (action) => await executeEngineAction(node, action, tools)),
 		);
 
 		current = await deps.runAgentBatch({ actionResponses, metadata: current.metadata });
@@ -67,56 +53,10 @@ function assertNoHitlActions(node: INode, actions: Action[]): void {
 				`Human-in-the-Loop nodes cannot be used inside a sub-agent. Move "${action.nodeName}" to the top-level workflow.`,
 				{
 					description:
-						'Engine-level approval flows are not available from within a tool callback, so the whole sub-agent step is aborted (any sibling tool calls in the same batch are not executed). Make the human-in-the-loop step part of the top-level Agent instead of a nested AgentToolV3.',
+						'Approval flows need the top-level engine; the sub-agent step is aborted (sibling tool calls skipped).',
 					extra: { node: node.name },
 				},
 			);
 		}
 	}
-}
-
-async function invokeToolAction(
-	node: INode,
-	action: Action,
-	tools: ConnectedTool[],
-): Promise<ExecuteNodeResult<RequestResponseMetadata>> {
-	const tool = tools.find((t) => t.name === action.metadata?.toolName);
-	if (!tool) {
-		return makeActionError(
-			node,
-			action,
-			`Sub-agent could not find a connected tool for node "${action.nodeName}".`,
-		);
-	}
-
-	try {
-		// `input.tool` is a toolkit-dispatch marker added by createEngineRequests;
-		// it isn't part of the LangChain tool's Zod schema, so strip before invoking.
-		const output = await tool.invoke(omit(action.input, 'tool'));
-		return {
-			action,
-			data: {
-				...EMPTY_TASK_DATA_SHELL,
-				executionStatus: 'success',
-				data: { ai_tool: [[{ json: { output } as IDataObject }]] },
-			},
-		};
-	} catch (error) {
-		return makeActionError(node, action, error instanceof Error ? error.message : String(error));
-	}
-}
-
-function makeActionError(
-	node: INode,
-	action: Action,
-	message: string,
-): ExecuteNodeResult<RequestResponseMetadata> {
-	return {
-		action,
-		data: {
-			...EMPTY_TASK_DATA_SHELL,
-			executionStatus: 'error',
-			error: new NodeOperationError(node, message),
-		},
-	};
 }

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/resolveSubAgentRequest.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/resolveSubAgentRequest.ts
@@ -1,0 +1,185 @@
+import type { DynamicStructuredTool, Tool } from '@langchain/classic/tools';
+import type { RequestResponseMetadata, ToolMetadata } from '@utils/agent-execution';
+import type {
+	EngineRequest,
+	EngineResponse,
+	ExecuteNodeResult,
+	IDataObject,
+	INode,
+	INodeExecutionData,
+	ISupplyDataFunctions,
+	ITaskData,
+} from 'n8n-workflow';
+import { NodeOperationError, UserError } from 'n8n-workflow';
+
+import { getTools } from '../../common';
+
+type Action = EngineRequest<RequestResponseMetadata>['actions'][number];
+type ConnectedTool = DynamicStructuredTool | Tool;
+
+function isEngineRequest(
+	value: EngineRequest<RequestResponseMetadata> | INodeExecutionData[][],
+): value is EngineRequest<RequestResponseMetadata> {
+	return !Array.isArray(value) && 'actions' in value;
+}
+
+export type ResolveSubAgentRequestDeps = {
+	/**
+	 * Re-enter the sub-agent with the EngineResponse built from the resolved
+	 * tool invocations. The sub-agent's `maxIterations` is enforced inside this
+	 * callback (via `checkMaxIterations`), so recursion is bounded.
+	 */
+	runAgentBatch: (
+		response: EngineResponse<RequestResponseMetadata>,
+	) => Promise<INodeExecutionData[][] | EngineRequest<RequestResponseMetadata>>;
+};
+
+/**
+ * Resolves an `EngineRequest` inline when AgentToolV3 runs as a sub-agent
+ * (`ISupplyDataFunctions` context). The parent agent's tool boundary —
+ * `makeHandleToolInvocation` in core — cannot fulfil `EngineRequest`s because
+ * the workflow engine only schedules nested nodes at the top level. To keep
+ * the same observable behaviour the engine would have produced, we:
+ *
+ *   1. Reject HITL actions upfront (no engine-level suspend/resume here).
+ *   2. Invoke the sub-agent's connected LangChain tools in parallel — this
+ *      routes execute-only tools through `makeHandleToolInvocation` again
+ *      (which preserves canvas observability) and supplyData-resolved tools
+ *      through their own `invoke()` paths.
+ *   3. Build an `EngineResponse` and re-enter the sub-agent until it produces
+ *      plain node output data.
+ */
+export async function resolveSubAgentRequest(
+	ctx: ISupplyDataFunctions,
+	request: EngineRequest<RequestResponseMetadata>,
+	deps: ResolveSubAgentRequestDeps,
+): Promise<INodeExecutionData[][]> {
+	let current: EngineRequest<RequestResponseMetadata> | INodeExecutionData[][] = request;
+
+	const node = ctx.getNode();
+
+	while (isEngineRequest(current)) {
+		assertNoHitlActions(node, current.actions);
+
+		ctx.getExecutionCancelSignal?.()?.throwIfAborted?.();
+
+		const tools = (await getTools(ctx)) as ConnectedTool[];
+
+		const actionResponses = await Promise.all(
+			current.actions.map(async (action) => await invokeToolAction(node, action, tools)),
+		);
+
+		const response: EngineResponse<RequestResponseMetadata> = {
+			actionResponses,
+			metadata: current.metadata,
+		};
+
+		current = await deps.runAgentBatch(response);
+	}
+
+	return current;
+}
+
+function assertNoHitlActions(node: INode, actions: Action[]): void {
+	for (const action of actions) {
+		if (action.metadata?.hitl) {
+			throw new UserError(
+				`Human-in-the-Loop nodes cannot be used inside a sub-agent. Move "${action.nodeName}" to the top-level workflow.`,
+				{
+					description:
+						'Engine-level approval flows are not available from within a tool callback. Make the human-in-the-loop step part of the top-level Agent instead of a nested AgentToolV3.',
+					extra: { node: node.name },
+				},
+			);
+		}
+	}
+}
+
+function findMatchingTool(action: Action, tools: ConnectedTool[]): ConnectedTool | undefined {
+	const toolkitName =
+		typeof action.input?.tool === 'string' ? (action.input.tool as string) : undefined;
+
+	if (toolkitName !== undefined) {
+		const toolkitMatch = tools.find((t) => {
+			const md = t.metadata as ToolMetadata | undefined;
+			return md?.sourceNodeName === action.nodeName && t.name === toolkitName;
+		});
+		if (toolkitMatch) return toolkitMatch;
+	}
+
+	return tools.find(
+		(t) => (t.metadata as ToolMetadata | undefined)?.sourceNodeName === action.nodeName,
+	);
+}
+
+function prepareToolInput(action: Action): IDataObject {
+	// `tool` is an internal marker createEngineRequests adds for toolkit calls
+	// (so the engine knows which toolkit-tool to invoke). The LangChain tool's
+	// own Zod schema doesn't include it, so strip it before invoking.
+	if (typeof action.input?.tool === 'string') {
+		const { tool: _toolName, ...rest } = action.input;
+		return rest;
+	}
+	return action.input;
+}
+
+async function invokeToolAction(
+	node: INode,
+	action: Action,
+	tools: ConnectedTool[],
+): Promise<ExecuteNodeResult<RequestResponseMetadata>> {
+	const tool = findMatchingTool(action, tools);
+	if (!tool) {
+		return buildErrorResponse(
+			node,
+			action,
+			`Sub-agent could not find a connected tool for node "${action.nodeName}".`,
+		);
+	}
+
+	try {
+		const output = await tool.invoke(prepareToolInput(action));
+		return buildSuccessResponse(action, output);
+	} catch (error) {
+		return buildErrorResponse(node, action, error instanceof Error ? error.message : String(error));
+	}
+}
+
+function buildTaskDataShell(): Pick<
+	ITaskData,
+	'executionTime' | 'startTime' | 'executionIndex' | 'source'
+> {
+	return {
+		executionTime: 0,
+		startTime: 0,
+		executionIndex: 0,
+		source: [],
+	};
+}
+
+function buildSuccessResponse(
+	action: Action,
+	output: unknown,
+): ExecuteNodeResult<RequestResponseMetadata> {
+	const data: ITaskData = {
+		...buildTaskDataShell(),
+		executionStatus: 'success',
+		data: {
+			ai_tool: [[{ json: { output } as IDataObject }]],
+		},
+	};
+	return { action, data };
+}
+
+function buildErrorResponse(
+	node: INode,
+	action: Action,
+	message: string,
+): ExecuteNodeResult<RequestResponseMetadata> {
+	const data: ITaskData = {
+		...buildTaskDataShell(),
+		executionStatus: 'error',
+		error: new NodeOperationError(node, message),
+	};
+	return { action, data };
+}

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/resolveSubAgentRequest.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/resolveSubAgentRequest.test.ts
@@ -1,0 +1,286 @@
+import type { DynamicStructuredTool } from '@langchain/classic/tools';
+import { NodeConnectionTypes, NodeOperationError, UserError } from 'n8n-workflow';
+import type {
+	EngineRequest,
+	EngineResponse,
+	INode,
+	INodeExecutionData,
+	ISupplyDataFunctions,
+} from 'n8n-workflow';
+import { mock } from 'vitest-mock-extended';
+
+import type { RequestResponseMetadata, ToolMetadata } from '@utils/agent-execution';
+
+import { getTools } from '../../../common';
+import { resolveSubAgentRequest } from '../resolveSubAgentRequest';
+
+vi.mock('../../../common', () => ({
+	getTools: vi.fn(),
+}));
+
+const mockedGetTools = vi.mocked(getTools);
+
+type MockedAction = EngineRequest<RequestResponseMetadata>['actions'][number];
+
+function makeAction(overrides: Partial<MockedAction> = {}): MockedAction {
+	return {
+		actionType: 'ExecutionNodeAction',
+		nodeName: 'ToolNode',
+		input: { query: 'hello' },
+		type: NodeConnectionTypes.AiTool,
+		id: 'call_1',
+		metadata: { itemIndex: 0 },
+		...overrides,
+	};
+}
+
+function makeTool(
+	name: string,
+	sourceNodeName: string,
+	invokeImpl: (args: unknown) => unknown | Promise<unknown>,
+	extraMetadata: Partial<ToolMetadata> = {},
+): DynamicStructuredTool {
+	const tool = {
+		name,
+		description: 'test',
+		metadata: { sourceNodeName, ...extraMetadata } as ToolMetadata,
+		invoke: vi.fn(async (args: unknown) => await invokeImpl(args)),
+	} as unknown as DynamicStructuredTool;
+	return tool;
+}
+
+function makeRequest(actions: MockedAction[]): EngineRequest<RequestResponseMetadata> {
+	return { actions, metadata: { iterationCount: 1 } };
+}
+
+function makeCtx(): { ctx: ISupplyDataFunctions; node: INode; abortSignal: AbortController } {
+	const node = mock<INode>({ name: 'sub-agent', id: 'node-1' });
+	const abortController = new AbortController();
+	const ctx = mock<ISupplyDataFunctions>();
+	ctx.getNode.mockReturnValue(node);
+	ctx.getExecutionCancelSignal = vi.fn(() => abortController.signal) as never;
+	return { ctx, node, abortSignal: abortController };
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+});
+
+describe('resolveSubAgentRequest', () => {
+	it('resolves a single non-HITL action by invoking the matched tool and returns the agent output', async () => {
+		const { ctx } = makeCtx();
+		const tool = makeTool('TestTool', 'ToolNode', () => 'tool-output');
+		mockedGetTools.mockResolvedValue([tool]);
+
+		const finalOutput: INodeExecutionData[][] = [[{ json: { output: 'all done' } }]];
+		const runAgentBatch = vi.fn(async () => finalOutput);
+
+		const request = makeRequest([makeAction({ nodeName: 'ToolNode' })]);
+		const result = await resolveSubAgentRequest(ctx, request, { runAgentBatch });
+
+		expect(tool.invoke).toHaveBeenCalledTimes(1);
+		expect(tool.invoke).toHaveBeenCalledWith({ query: 'hello' });
+		expect(runAgentBatch).toHaveBeenCalledTimes(1);
+		expect(runAgentBatch).toHaveBeenCalledWith(
+			expect.objectContaining({
+				actionResponses: expect.arrayContaining([
+					expect.objectContaining({
+						action: expect.objectContaining({ id: 'call_1' }),
+						data: expect.objectContaining({
+							executionStatus: 'success',
+							data: {
+								ai_tool: [[{ json: { output: 'tool-output' } }]],
+							},
+						}),
+					}),
+				]),
+				metadata: { iterationCount: 1 },
+			}),
+		);
+		expect(result).toBe(finalOutput);
+	});
+
+	it('preserves action ordering when multiple actions resolve in parallel out of order', async () => {
+		const { ctx } = makeCtx();
+		const slowTool = makeTool(
+			'Slow',
+			'SlowNode',
+			async () => await new Promise((resolve) => setTimeout(() => resolve('slow-result'), 30)),
+		);
+		const fastTool = makeTool('Fast', 'FastNode', async () => 'fast-result');
+		mockedGetTools.mockResolvedValue([slowTool, fastTool]);
+
+		const actions: MockedAction[] = [
+			makeAction({ id: 'a', nodeName: 'SlowNode' }),
+			makeAction({ id: 'b', nodeName: 'FastNode' }),
+		];
+
+		const runAgentBatch = vi.fn(async (response: EngineResponse<RequestResponseMetadata>) => {
+			// Assert ordering at the moment of consumption.
+			expect(response.actionResponses[0].action.id).toBe('a');
+			expect(response.actionResponses[1].action.id).toBe('b');
+			expect(response.actionResponses[0].data?.data?.ai_tool?.[0]?.[0]?.json).toEqual({
+				output: 'slow-result',
+			});
+			expect(response.actionResponses[1].data?.data?.ai_tool?.[0]?.[0]?.json).toEqual({
+				output: 'fast-result',
+			});
+			return [[{ json: { output: 'done' } }]];
+		});
+
+		await resolveSubAgentRequest(ctx, makeRequest(actions), { runAgentBatch });
+
+		expect(runAgentBatch).toHaveBeenCalledTimes(1);
+	});
+
+	it('throws a UserError naming the offending node when a HITL action is requested', async () => {
+		const { ctx } = makeCtx();
+		mockedGetTools.mockResolvedValue([]);
+
+		const hitlAction = makeAction({
+			nodeName: 'ApprovalGate',
+			metadata: {
+				itemIndex: 0,
+				hitl: {
+					gatedToolNodeName: 'Database',
+					toolName: 'Database',
+					originalInput: {},
+				},
+			},
+		});
+
+		const runAgentBatch = vi.fn();
+
+		await expect(
+			resolveSubAgentRequest(ctx, makeRequest([hitlAction]), { runAgentBatch }),
+		).rejects.toThrow(UserError);
+		await expect(
+			resolveSubAgentRequest(ctx, makeRequest([hitlAction]), { runAgentBatch }),
+		).rejects.toThrow(/ApprovalGate/);
+
+		expect(runAgentBatch).not.toHaveBeenCalled();
+	});
+
+	it('catches tool errors and surfaces them as NodeOperationError ITaskData so the LLM can recover', async () => {
+		const { ctx } = makeCtx();
+		const failingTool = makeTool('Failing', 'ToolNode', () => {
+			throw new Error('upstream failure');
+		});
+		mockedGetTools.mockResolvedValue([failingTool]);
+
+		let capturedResponse: EngineResponse<RequestResponseMetadata> | undefined;
+		const runAgentBatch = vi.fn(async (response: EngineResponse<RequestResponseMetadata>) => {
+			capturedResponse = response;
+			return [[{ json: { output: 'recovered' } }]];
+		});
+
+		await resolveSubAgentRequest(ctx, makeRequest([makeAction()]), { runAgentBatch });
+
+		expect(capturedResponse?.actionResponses).toHaveLength(1);
+		const errorResponse = capturedResponse!.actionResponses[0];
+		expect(errorResponse.data?.executionStatus).toBe('error');
+		expect(errorResponse.data?.error).toBeInstanceOf(NodeOperationError);
+		expect(errorResponse.data?.error?.message).toContain('upstream failure');
+	});
+
+	it('loops until the sub-agent stops returning an EngineRequest', async () => {
+		const { ctx } = makeCtx();
+		const tool = makeTool('TestTool', 'ToolNode', async () => 'partial');
+		mockedGetTools.mockResolvedValue([tool]);
+
+		const followUpRequest = makeRequest([makeAction({ id: 'call_2', nodeName: 'ToolNode' })]);
+		const finalOutput: INodeExecutionData[][] = [[{ json: { output: 'final' } }]];
+
+		const runAgentBatch = vi
+			.fn()
+			.mockResolvedValueOnce(followUpRequest)
+			.mockResolvedValueOnce(finalOutput);
+
+		const result = await resolveSubAgentRequest(ctx, makeRequest([makeAction()]), {
+			runAgentBatch,
+		});
+
+		expect(runAgentBatch).toHaveBeenCalledTimes(2);
+		expect(tool.invoke).toHaveBeenCalledTimes(2);
+		expect(result).toBe(finalOutput);
+	});
+
+	it('honors cancellation: aborts before invoking tools if the cancel signal is already aborted', async () => {
+		const { ctx, abortSignal } = makeCtx();
+		abortSignal.abort();
+		const tool = makeTool('TestTool', 'ToolNode', () => 'should-not-run');
+		mockedGetTools.mockResolvedValue([tool]);
+
+		const runAgentBatch = vi.fn();
+
+		await expect(
+			resolveSubAgentRequest(ctx, makeRequest([makeAction()]), { runAgentBatch }),
+		).rejects.toThrow();
+
+		expect(tool.invoke).not.toHaveBeenCalled();
+		expect(runAgentBatch).not.toHaveBeenCalled();
+	});
+
+	it('propagates maxIterations errors from runAgentBatch unchanged', async () => {
+		const { ctx } = makeCtx();
+		const tool = makeTool('TestTool', 'ToolNode', async () => 'ok');
+		mockedGetTools.mockResolvedValue([tool]);
+
+		const maxIterationsError = new NodeOperationError(
+			mock<INode>(),
+			'Max iterations (10) reached. The agent could not complete the task within the allowed number of iterations.',
+		);
+		const runAgentBatch = vi.fn().mockRejectedValue(maxIterationsError);
+
+		await expect(
+			resolveSubAgentRequest(ctx, makeRequest([makeAction()]), { runAgentBatch }),
+		).rejects.toBe(maxIterationsError);
+	});
+
+	it('strips the toolkit `tool` marker from input before invoking the matching toolkit tool', async () => {
+		const { ctx } = makeCtx();
+		const toolkitToolA = makeTool('search', 'ToolkitNode', async () => 'result-a', {
+			isFromToolkit: true,
+		});
+		const toolkitToolB = makeTool('fetch', 'ToolkitNode', async () => 'result-b', {
+			isFromToolkit: true,
+		});
+		mockedGetTools.mockResolvedValue([toolkitToolA, toolkitToolB]);
+
+		const runAgentBatch = vi.fn(async () => [[{ json: { output: 'done' } }]]);
+
+		await resolveSubAgentRequest(
+			ctx,
+			makeRequest([
+				makeAction({
+					nodeName: 'ToolkitNode',
+					input: { tool: 'fetch', url: 'https://example.com' },
+				}),
+			]),
+			{ runAgentBatch },
+		);
+
+		expect(toolkitToolA.invoke).not.toHaveBeenCalled();
+		expect(toolkitToolB.invoke).toHaveBeenCalledTimes(1);
+		expect(toolkitToolB.invoke).toHaveBeenCalledWith({ url: 'https://example.com' });
+	});
+
+	it('produces an error response when no connected tool matches the requested node name', async () => {
+		const { ctx } = makeCtx();
+		mockedGetTools.mockResolvedValue([]);
+
+		let captured: EngineResponse<RequestResponseMetadata> | undefined;
+		const runAgentBatch = vi.fn(async (response: EngineResponse<RequestResponseMetadata>) => {
+			captured = response;
+			return [[{ json: { output: 'done' } }]];
+		});
+
+		await resolveSubAgentRequest(ctx, makeRequest([makeAction({ nodeName: 'MissingNode' })]), {
+			runAgentBatch,
+		});
+
+		const errorResponse = captured!.actionResponses[0];
+		expect(errorResponse.data?.executionStatus).toBe('error');
+		expect(errorResponse.data?.error?.message).toMatch(/MissingNode/);
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/resolveSubAgentRequest.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/resolveSubAgentRequest.test.ts
@@ -283,4 +283,63 @@ describe('resolveSubAgentRequest', () => {
 		expect(errorResponse.data?.executionStatus).toBe('error');
 		expect(errorResponse.data?.error?.message).toMatch(/MissingNode/);
 	});
+
+	it('handles nested sub-agents (A -> B -> tool) by re-entering the inline branch', async () => {
+		// Simulates Parent (A) -> Inner Sub-Agent (B) -> Leaf Tool. When the
+		// outer (A) sub-agent invokes B, B's tool.invoke triggers a nested
+		// resolveSubAgentRequest run that resolves its own EngineRequest before
+		// returning a string to A. This proves the "re-enter the same branch
+		// naturally" claim in the spec is testable end-to-end.
+		const { ctx: outerCtx } = makeCtx();
+
+		// Inner sub-agent's leaf tool — a plain calculator-style tool.
+		const leafTool = makeTool('LeafTool', 'LeafNode', async () => '42');
+
+		// The inner sub-agent appears to the outer agent as a single tool. Its
+		// `invoke` simulates the inner sub-agent's full lifecycle: it kicks off
+		// its own `resolveSubAgentRequest`, which dispatches `LeafTool`, then
+		// produces a final string answer back to the outer agent.
+		const innerSubAgentTool = makeTool('InnerSubAgent', 'InnerSubAgentNode', async () => {
+			const { ctx: innerCtx } = makeCtx();
+			mockedGetTools.mockResolvedValueOnce([leafTool]);
+
+			const innerRequest = makeRequest([makeAction({ id: 'inner_call_1', nodeName: 'LeafNode' })]);
+			const innerFinal: INodeExecutionData[][] = [[{ json: { output: 'inner answer 42' } }]];
+			const innerRunAgentBatch = vi.fn(async () => innerFinal);
+
+			const innerResult = await resolveSubAgentRequest(innerCtx, innerRequest, {
+				runAgentBatch: innerRunAgentBatch,
+			});
+			// Mirror what makeHandleToolInvocation would do in real wiring: flatten
+			// to a string so the outer agent sees a tool result, not a structure.
+			return JSON.stringify(innerResult[0]?.[0]?.json);
+		});
+
+		// Restore the outer mock after the inner test stub above consumes a
+		// single mockResolvedValueOnce.
+		mockedGetTools.mockResolvedValue([innerSubAgentTool]);
+
+		const outerFinal: INodeExecutionData[][] = [[{ json: { output: 'outer final' } }]];
+		const outerRunAgentBatch = vi.fn(async () => outerFinal);
+
+		const outerRequest = makeRequest([
+			makeAction({ id: 'outer_call_1', nodeName: 'InnerSubAgentNode' }),
+		]);
+		const result = await resolveSubAgentRequest(outerCtx, outerRequest, {
+			runAgentBatch: outerRunAgentBatch,
+		});
+
+		// Inner leaf tool was actually invoked through the recursive entry.
+		expect(leafTool.invoke).toHaveBeenCalledTimes(1);
+		// Outer received the inner sub-agent's stringified result as the tool
+		// output, then ran a single finalize pass.
+		expect(innerSubAgentTool.invoke).toHaveBeenCalledTimes(1);
+		expect(outerRunAgentBatch).toHaveBeenCalledTimes(1);
+		const outerResponse = outerRunAgentBatch.mock
+			.calls[0][0] as EngineResponse<RequestResponseMetadata>;
+		expect(outerResponse.actionResponses[0].data?.data?.ai_tool?.[0]?.[0]?.json).toEqual({
+			output: '{"output":"inner answer 42"}',
+		});
+		expect(result).toBe(outerFinal);
+	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/resolveSubAgentRequest.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/resolveSubAgentRequest.test.ts
@@ -12,7 +12,7 @@ import { mock } from 'vitest-mock-extended';
 import type { RequestResponseMetadata, ToolMetadata } from '@utils/agent-execution';
 
 import { getTools } from '../../../common';
-import { resolveSubAgentRequest } from '../resolveSubAgentRequest';
+import { resolveSubAgentRequest, type ResolveSubAgentRequestDeps } from '../resolveSubAgentRequest';
 
 vi.mock('../../../common', () => ({
 	getTools: vi.fn(),
@@ -320,7 +320,9 @@ describe('resolveSubAgentRequest', () => {
 		mockedGetTools.mockResolvedValue([innerSubAgentTool]);
 
 		const outerFinal: INodeExecutionData[][] = [[{ json: { output: 'outer final' } }]];
-		const outerRunAgentBatch = vi.fn(async () => outerFinal);
+		const outerRunAgentBatch: ResolveSubAgentRequestDeps['runAgentBatch'] = vi.fn(
+			async () => outerFinal,
+		);
 
 		const outerRequest = makeRequest([
 			makeAction({ id: 'outer_call_1', nodeName: 'InnerSubAgentNode' }),
@@ -335,8 +337,7 @@ describe('resolveSubAgentRequest', () => {
 		// output, then ran a single finalize pass.
 		expect(innerSubAgentTool.invoke).toHaveBeenCalledTimes(1);
 		expect(outerRunAgentBatch).toHaveBeenCalledTimes(1);
-		const outerResponse = outerRunAgentBatch.mock
-			.calls[0][0] as EngineResponse<RequestResponseMetadata>;
+		const outerResponse = vi.mocked(outerRunAgentBatch).mock.calls[0]![0];
 		expect(outerResponse.actionResponses[0].data?.data?.ai_tool?.[0]?.[0]?.json).toEqual({
 			output: '{"output":"inner answer 42"}',
 		});

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/resolveSubAgentRequest.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/agents/ToolsAgent/V3/helpers/tests/resolveSubAgentRequest.test.ts
@@ -29,7 +29,7 @@ function makeAction(overrides: Partial<MockedAction> = {}): MockedAction {
 		input: { query: 'hello' },
 		type: NodeConnectionTypes.AiTool,
 		id: 'call_1',
-		metadata: { itemIndex: 0 },
+		metadata: { itemIndex: 0, toolName: 'TestTool' },
 		...overrides,
 	};
 }
@@ -111,8 +111,8 @@ describe('resolveSubAgentRequest', () => {
 		mockedGetTools.mockResolvedValue([slowTool, fastTool]);
 
 		const actions: MockedAction[] = [
-			makeAction({ id: 'a', nodeName: 'SlowNode' }),
-			makeAction({ id: 'b', nodeName: 'FastNode' }),
+			makeAction({ id: 'a', nodeName: 'SlowNode', metadata: { itemIndex: 0, toolName: 'Slow' } }),
+			makeAction({ id: 'b', nodeName: 'FastNode', metadata: { itemIndex: 0, toolName: 'Fast' } }),
 		];
 
 		const runAgentBatch = vi.fn(async (response: EngineResponse<RequestResponseMetadata>) => {
@@ -174,7 +174,11 @@ describe('resolveSubAgentRequest', () => {
 			return [[{ json: { output: 'recovered' } }]];
 		});
 
-		await resolveSubAgentRequest(ctx, makeRequest([makeAction()]), { runAgentBatch });
+		await resolveSubAgentRequest(
+			ctx,
+			makeRequest([makeAction({ metadata: { itemIndex: 0, toolName: 'Failing' } })]),
+			{ runAgentBatch },
+		);
 
 		expect(capturedResponse?.actionResponses).toHaveLength(1);
 		const errorResponse = capturedResponse!.actionResponses[0];
@@ -255,6 +259,7 @@ describe('resolveSubAgentRequest', () => {
 				makeAction({
 					nodeName: 'ToolkitNode',
 					input: { tool: 'fetch', url: 'https://example.com' },
+					metadata: { itemIndex: 0, toolName: 'fetch' },
 				}),
 			]),
 			{ runAgentBatch },
@@ -303,7 +308,13 @@ describe('resolveSubAgentRequest', () => {
 			const { ctx: innerCtx } = makeCtx();
 			mockedGetTools.mockResolvedValueOnce([leafTool]);
 
-			const innerRequest = makeRequest([makeAction({ id: 'inner_call_1', nodeName: 'LeafNode' })]);
+			const innerRequest = makeRequest([
+				makeAction({
+					id: 'inner_call_1',
+					nodeName: 'LeafNode',
+					metadata: { itemIndex: 0, toolName: 'LeafTool' },
+				}),
+			]);
 			const innerFinal: INodeExecutionData[][] = [[{ json: { output: 'inner answer 42' } }]];
 			const innerRunAgentBatch = vi.fn(async () => innerFinal);
 
@@ -325,7 +336,11 @@ describe('resolveSubAgentRequest', () => {
 		);
 
 		const outerRequest = makeRequest([
-			makeAction({ id: 'outer_call_1', nodeName: 'InnerSubAgentNode' }),
+			makeAction({
+				id: 'outer_call_1',
+				nodeName: 'InnerSubAgentNode',
+				metadata: { itemIndex: 0, toolName: 'InnerSubAgent' },
+			}),
 		]);
 		const result = await resolveSubAgentRequest(outerCtx, outerRequest, {
 			runAgentBatch: outerRunAgentBatch,

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV3.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV3.test.ts
@@ -43,27 +43,55 @@ const emptyMemoryHits = { loads: 0, saves: 0 };
 const mockContext = mock<IExecuteFunctions>();
 const mockNode = mock<INode>();
 
-beforeEach(() => {
-	vi.clearAllMocks();
-	mockContext.getNode.mockReturnValue(mockNode);
-	// `isExecuteFunctions` checks `'getExecuteData' in context`. vitest-mock-extended
-	// proxies property access but does not register own properties, so the `in`
-	// check is false by default. Stamp it explicitly so these tests exercise the
-	// top-level (engine-routed) request path; sub-agent inline resolution is
-	// covered separately by resolveSubAgentRequest.test.ts.
-	mockContext.getExecuteData = vi.fn() as never;
-	mockContext.logger = {
+function withCommonFields(ctx: IExecuteFunctions, node: INode): void {
+	ctx.getNode.mockReturnValue(node);
+	ctx.logger = {
 		debug: vi.fn(),
 		info: vi.fn(),
 		warn: vi.fn(),
 		error: vi.fn(),
 	};
-	mockContext.customData = {
+	ctx.customData = {
 		set: vi.fn(),
 		setAll: vi.fn(),
 		get: vi.fn(),
 		getAll: vi.fn(),
 	};
+}
+
+/**
+ * Top-level execution context — `isExecuteFunctions(this)` returns true.
+ *
+ * vitest-mock-extended proxies property access but does not register own
+ * properties, so `'getExecuteData' in mock<IExecuteFunctions>()` is false by
+ * default. Stamp `getExecuteData` explicitly so the V3 executor takes the
+ * engine-routed branch (`if (isExecuteFunctions(this)) return request`).
+ */
+function mockTopLevelContext(): IExecuteFunctions {
+	const ctx = mock<IExecuteFunctions>();
+	withCommonFields(ctx, mockNode);
+	ctx.getExecuteData = vi.fn() as never;
+	return ctx;
+}
+
+/**
+ * Sub-agent execution context — `isExecuteFunctions(this)` returns false.
+ *
+ * Intentionally does NOT set `getExecuteData`, so the V3 executor takes the
+ * inline-resolution branch (delegates to `resolveSubAgentRequest`).
+ */
+function mockSubAgentContext(): IExecuteFunctions {
+	const ctx = mock<IExecuteFunctions>();
+	withCommonFields(ctx, mockNode);
+	return ctx;
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	withCommonFields(mockContext, mockNode);
+	// Default to top-level path for the shared mockContext used by the bulk of
+	// existing tests. Sub-agent path is covered by the dedicated test below.
+	mockContext.getExecuteData = vi.fn() as never;
 });
 
 describe('toolsAgentExecute V3 - Execute Function Logic', () => {
@@ -210,21 +238,7 @@ describe('toolsAgentExecute V3 - Execute Function Logic', () => {
 	});
 
 	it('should delegate to resolveSubAgentRequest when running as a sub-agent (no getExecuteData)', async () => {
-		const subAgentContext = mock<IExecuteFunctions>();
-		subAgentContext.getNode.mockReturnValue(mockNode);
-		subAgentContext.logger = {
-			debug: vi.fn(),
-			info: vi.fn(),
-			warn: vi.fn(),
-			error: vi.fn(),
-		};
-		subAgentContext.customData = {
-			set: vi.fn(),
-			setAll: vi.fn(),
-			get: vi.fn(),
-			getAll: vi.fn(),
-		};
-		// Intentionally do NOT set `getExecuteData`, so `isExecuteFunctions` is false.
+		const subAgentContext = mockSubAgentContext();
 
 		const mockExecutionContext = {
 			items: [{ json: { text: 'test input 1' } }],

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV3.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV3.test.ts
@@ -19,6 +19,7 @@ vi.mock('../../agents/ToolsAgent/V3/helpers', () => ({
 	executeBatch: vi.fn(),
 	checkMaxIterations: vi.fn(),
 	buildResponseMetadata: vi.fn(),
+	resolveSubAgentRequest: vi.fn(),
 }));
 
 // Mock langchain modules
@@ -45,6 +46,12 @@ const mockNode = mock<INode>();
 beforeEach(() => {
 	vi.clearAllMocks();
 	mockContext.getNode.mockReturnValue(mockNode);
+	// `isExecuteFunctions` checks `'getExecuteData' in context`. vitest-mock-extended
+	// proxies property access but does not register own properties, so the `in`
+	// check is false by default. Stamp it explicitly so these tests exercise the
+	// top-level (engine-routed) request path; sub-agent inline resolution is
+	// covered separately by resolveSubAgentRequest.test.ts.
+	mockContext.getExecuteData = vi.fn() as never;
 	mockContext.logger = {
 		debug: vi.fn(),
 		info: vi.fn(),
@@ -200,6 +207,68 @@ describe('toolsAgentExecute V3 - Execute Function Logic', () => {
 				{ json: { output: 'success 3' }, pairedItem: { item: 2 } },
 			],
 		]);
+	});
+
+	it('should delegate to resolveSubAgentRequest when running as a sub-agent (no getExecuteData)', async () => {
+		const subAgentContext = mock<IExecuteFunctions>();
+		subAgentContext.getNode.mockReturnValue(mockNode);
+		subAgentContext.logger = {
+			debug: vi.fn(),
+			info: vi.fn(),
+			warn: vi.fn(),
+			error: vi.fn(),
+		};
+		subAgentContext.customData = {
+			set: vi.fn(),
+			setAll: vi.fn(),
+			get: vi.fn(),
+			getAll: vi.fn(),
+		};
+		// Intentionally do NOT set `getExecuteData`, so `isExecuteFunctions` is false.
+
+		const mockExecutionContext = {
+			items: [{ json: { text: 'test input 1' } }],
+			batchSize: 1,
+			delayBetweenBatches: 0,
+			needsFallback: false,
+			model: {} as any,
+			fallbackModel: null,
+			memory: undefined,
+		};
+
+		const mockRequest: EngineRequest<RequestResponseMetadata> = {
+			actions: [
+				{
+					actionType: 'ExecutionNodeAction' as const,
+					nodeName: 'Test Tool',
+					input: { input: 'test data' },
+					type: 'ai_tool',
+					id: 'call_inline',
+					metadata: { itemIndex: 0 },
+				},
+			],
+			metadata: { previousRequests: [] },
+		};
+
+		const resolvedOutput = [[{ json: { output: 'resolved inline' } }]];
+
+		vi.spyOn(helpers, 'buildExecutionContext').mockResolvedValue(mockExecutionContext);
+		vi.spyOn(helpers, 'executeBatch').mockResolvedValue({
+			returnData: [],
+			request: mockRequest,
+			memoryHits: emptyMemoryHits,
+		});
+		vi.spyOn(helpers, 'resolveSubAgentRequest').mockResolvedValue(resolvedOutput);
+
+		const result = await toolsAgentExecute.call(subAgentContext);
+
+		expect(helpers.resolveSubAgentRequest).toHaveBeenCalledTimes(1);
+		expect(helpers.resolveSubAgentRequest).toHaveBeenCalledWith(
+			subAgentContext,
+			mockRequest,
+			expect.objectContaining({ runAgentBatch: expect.any(Function) }),
+		);
+		expect(result).toBe(resolvedOutput);
 	});
 
 	it('should return request when batch returns tool call request', async () => {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV3.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/ToolsAgent/ToolsAgentV3.test.ts
@@ -5,7 +5,7 @@ import {
 	type EngineRequest,
 	type EngineResponse,
 } from 'n8n-workflow';
-import { mock } from 'vitest-mock-extended';
+import { mock, type MockProxy } from 'vitest-mock-extended';
 
 import type { RequestResponseMetadata } from '@utils/agent-execution';
 
@@ -43,7 +43,7 @@ const emptyMemoryHits = { loads: 0, saves: 0 };
 const mockContext = mock<IExecuteFunctions>();
 const mockNode = mock<INode>();
 
-function withCommonFields(ctx: IExecuteFunctions, node: INode): void {
+function withCommonFields(ctx: MockProxy<IExecuteFunctions>, node: INode): void {
 	ctx.getNode.mockReturnValue(node);
 	ctx.logger = {
 		debug: vi.fn(),
@@ -60,27 +60,14 @@ function withCommonFields(ctx: IExecuteFunctions, node: INode): void {
 }
 
 /**
- * Top-level execution context — `isExecuteFunctions(this)` returns true.
- *
- * vitest-mock-extended proxies property access but does not register own
- * properties, so `'getExecuteData' in mock<IExecuteFunctions>()` is false by
- * default. Stamp `getExecuteData` explicitly so the V3 executor takes the
- * engine-routed branch (`if (isExecuteFunctions(this)) return request`).
- */
-function mockTopLevelContext(): IExecuteFunctions {
-	const ctx = mock<IExecuteFunctions>();
-	withCommonFields(ctx, mockNode);
-	ctx.getExecuteData = vi.fn() as never;
-	return ctx;
-}
-
-/**
  * Sub-agent execution context — `isExecuteFunctions(this)` returns false.
  *
  * Intentionally does NOT set `getExecuteData`, so the V3 executor takes the
  * inline-resolution branch (delegates to `resolveSubAgentRequest`).
+ * The shared top-level `mockContext` defined above gets `getExecuteData`
+ * stamped in `beforeEach`; use this helper to deliberately opt out.
  */
-function mockSubAgentContext(): IExecuteFunctions {
+function mockSubAgentContext(): MockProxy<IExecuteFunctions> {
 	const ctx = mock<IExecuteFunctions>();
 	withCommonFields(ctx, mockNode);
 	return ctx;
@@ -89,8 +76,12 @@ function mockSubAgentContext(): IExecuteFunctions {
 beforeEach(() => {
 	vi.clearAllMocks();
 	withCommonFields(mockContext, mockNode);
-	// Default to top-level path for the shared mockContext used by the bulk of
-	// existing tests. Sub-agent path is covered by the dedicated test below.
+	// `isExecuteFunctions` checks `'getExecuteData' in context`. vitest-mock-extended
+	// proxies property access but does not register own properties, so the `in`
+	// check is false by default. Stamp `getExecuteData` here so the shared
+	// `mockContext` exercises the top-level (engine-routed) request path;
+	// sub-agent inline resolution is covered by `mockSubAgentContext()` below
+	// and by `resolveSubAgentRequest.test.ts`.
 	mockContext.getExecuteData = vi.fn() as never;
 });
 

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/integration/agent-tool-v3.workflow.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/integration/agent-tool-v3.workflow.test.ts
@@ -123,4 +123,83 @@ describe('AgentTool V3 Integration', () => {
 
 		testHarness.setupTest(testData, { credentials });
 	});
+
+	describe('Agent as Tool with inner tool calls (AI-2494)', () => {
+		// Regression test for the case where the sub-agent's LLM emits a tool
+		// call. Before the AI-2494 fix the sub-agent returned an EngineRequest
+		// that the parent's tool boundary rejected with
+		// "The Tool attempted to return an engine request, …" — this fixture
+		// proves the parent sees the sub-agent's real final answer instead.
+		const testData: WorkflowTestData = {
+			description:
+				'should let a sub-agent invoke its own tools inline and surface the result to the parent',
+			input: {
+				workflowData: testHarness.readWorkflowJSON('workflows/sub-agent-with-inner-tool.json'),
+			},
+			output: {
+				nodeData: {
+					'Parent Agent': [
+						[
+							{
+								json: {
+									output: '5 times 5 equals 25.',
+								},
+							},
+						],
+					],
+				},
+			},
+			nock: {
+				baseUrl,
+				mocks: [
+					// 1. Parent agent decides to call the sub-agent
+					{
+						method: 'post',
+						path: '/v1/chat/completions',
+						statusCode: 200,
+						responseBody: toolCallResponse([
+							{
+								id: 'call_parent_1',
+								name: 'MathSubAgent',
+								arguments: JSON.stringify({ input: 'What is 5 times 5?' }),
+							},
+						]),
+					},
+					// 2. Sub-agent's LLM decides to call the Calculator. Pre-fix
+					//    this would produce an EngineRequest the parent's tool
+					//    boundary couldn't fulfil.
+					{
+						method: 'post',
+						path: '/v1/chat/completions',
+						statusCode: 200,
+						responseBody: toolCallResponse([
+							{
+								id: 'call_calc_1',
+								name: 'Calculator',
+								arguments: JSON.stringify({ input: '5 * 5' }),
+							},
+						]),
+					},
+					// 3. Sub-agent's LLM receives the calculator result and
+					//    produces a final text answer.
+					{
+						method: 'post',
+						path: '/v1/chat/completions',
+						statusCode: 200,
+						responseBody: chatCompletionResponse('5 times 5 equals 25.'),
+					},
+					// 4. Parent agent receives the sub-agent's answer and
+					//    produces its own final response.
+					{
+						method: 'post',
+						path: '/v1/chat/completions',
+						statusCode: 200,
+						responseBody: chatCompletionResponse('5 times 5 equals 25.'),
+					},
+				],
+			},
+		};
+
+		testHarness.setupTest(testData, { credentials });
+	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/integration/agent-tool-v3.workflow.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/integration/agent-tool-v3.workflow.test.ts
@@ -124,10 +124,10 @@ describe('AgentTool V3 Integration', () => {
 		testHarness.setupTest(testData, { credentials });
 	});
 
-	describe('Agent as Tool with inner tool calls (AI-2494)', () => {
+	describe('Agent as Tool with inner tool calls', () => {
 		// Regression test for the case where the sub-agent's LLM emits a tool
-		// call. Before the AI-2494 fix the sub-agent returned an EngineRequest
-		// that the parent's tool boundary rejected with
+		// call. Previously the sub-agent returned an EngineRequest that the
+		// parent's tool boundary rejected with
 		// "The Tool attempted to return an engine request, …" — this fixture
 		// proves the parent sees the sub-agent's real final answer instead.
 		const testData: WorkflowTestData = {

--- a/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/integration/workflows/sub-agent-with-inner-tool.json
+++ b/packages/@n8n/nodes-langchain/nodes/agents/Agent/test/integration/workflows/sub-agent-with-inner-tool.json
@@ -1,0 +1,142 @@
+{
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0],
+			"id": "trigger-id",
+			"name": "When clicking 'Execute workflow'"
+		},
+		{
+			"parameters": {
+				"promptType": "define",
+				"text": "Ask the math sub-agent to compute 5 times 5"
+			},
+			"type": "@n8n/n8n-nodes-langchain.agent",
+			"typeVersion": 3.1,
+			"position": [220, 0],
+			"id": "parent-agent-id",
+			"name": "Parent Agent"
+		},
+		{
+			"parameters": {
+				"model": {
+					"__rl": true,
+					"mode": "id",
+					"value": "gpt-4o-mini"
+				},
+				"options": {}
+			},
+			"type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
+			"typeVersion": 1.2,
+			"position": [220, 200],
+			"id": "parent-model-id",
+			"name": "Parent Model",
+			"credentials": {
+				"openAiApi": {
+					"id": "123",
+					"name": "OpenAi account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"toolDescription": "A sub agent that can answer math questions using a calculator",
+				"promptType": "define",
+				"text": "={{ $json.input }}"
+			},
+			"type": "@n8n/n8n-nodes-langchain.agentTool",
+			"typeVersion": 3,
+			"position": [400, 0],
+			"id": "sub-agent-id",
+			"name": "MathSubAgent"
+		},
+		{
+			"parameters": {
+				"model": {
+					"__rl": true,
+					"mode": "id",
+					"value": "gpt-4o-mini"
+				},
+				"options": {}
+			},
+			"type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
+			"typeVersion": 1.2,
+			"position": [400, 200],
+			"id": "child-model-id",
+			"name": "Child Model",
+			"credentials": {
+				"openAiApi": {
+					"id": "123",
+					"name": "OpenAi account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"type": "@n8n/n8n-nodes-langchain.toolCalculator",
+			"typeVersion": 1,
+			"position": [580, 200],
+			"id": "calculator-id",
+			"name": "Calculator"
+		}
+	],
+	"connections": {
+		"When clicking 'Execute workflow'": {
+			"main": [
+				[
+					{
+						"node": "Parent Agent",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Parent Model": {
+			"ai_languageModel": [
+				[
+					{
+						"node": "Parent Agent",
+						"type": "ai_languageModel",
+						"index": 0
+					}
+				]
+			]
+		},
+		"MathSubAgent": {
+			"ai_tool": [
+				[
+					{
+						"node": "Parent Agent",
+						"type": "ai_tool",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Child Model": {
+			"ai_languageModel": [
+				[
+					{
+						"node": "MathSubAgent",
+						"type": "ai_languageModel",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Calculator": {
+			"ai_tool": [
+				[
+					{
+						"node": "MathSubAgent",
+						"type": "ai_tool",
+						"index": 0
+					}
+				]
+			]
+		}
+	}
+}

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/createEngineRequests.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/createEngineRequests.ts
@@ -240,6 +240,7 @@ export function createEngineRequests(
 				metadata: {
 					itemIndex,
 					hitl: hitlMetadata,
+					toolName: toolCall.tool,
 					...extractThinkingMetadata(toolCall, sharedMessageLog, sharedAdditionalKwargs),
 				},
 			};

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/executeEngineAction.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/executeEngineAction.ts
@@ -1,0 +1,60 @@
+import type { DynamicStructuredTool, Tool } from '@langchain/classic/tools';
+import omit from 'lodash/omit';
+import type { EngineRequest, ExecuteNodeResult, IDataObject, INode, ITaskData } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+import type { RequestResponseMetadata } from './types';
+
+type ConnectedTool = DynamicStructuredTool | Tool;
+type Action = EngineRequest<RequestResponseMetadata>['actions'][number];
+
+const EMPTY_TASK_DATA_SHELL: Pick<
+	ITaskData,
+	'executionTime' | 'startTime' | 'executionIndex' | 'source'
+> = { executionTime: 0, startTime: 0, executionIndex: 0, source: [] };
+
+/** Inverse of createEngineRequests: invokes a tool for one action, returns the ActionResponse the agent loop expects. */
+export async function executeEngineAction(
+	node: INode,
+	action: Action,
+	tools: ConnectedTool[],
+): Promise<ExecuteNodeResult<RequestResponseMetadata>> {
+	const tool = tools.find((t) => t.name === action.metadata?.toolName);
+	if (!tool) {
+		return errorResult(
+			node,
+			action,
+			`Sub-agent could not find a connected tool for node "${action.nodeName}".`,
+		);
+	}
+
+	try {
+		// `input.tool` is a toolkit-dispatch marker added by createEngineRequests; strip before invoking.
+		const output = await tool.invoke(omit(action.input, 'tool'));
+		return {
+			action,
+			data: {
+				...EMPTY_TASK_DATA_SHELL,
+				executionStatus: 'success',
+				data: { ai_tool: [[{ json: { output } as IDataObject }]] },
+			},
+		};
+	} catch (error) {
+		return errorResult(node, action, error instanceof Error ? error.message : String(error));
+	}
+}
+
+function errorResult(
+	node: INode,
+	action: Action,
+	message: string,
+): ExecuteNodeResult<RequestResponseMetadata> {
+	return {
+		action,
+		data: {
+			...EMPTY_TASK_DATA_SHELL,
+			executionStatus: 'error',
+			error: new NodeOperationError(node, message),
+		},
+	};
+}

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/index.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/index.ts
@@ -9,6 +9,7 @@
  */
 
 export { createEngineRequests } from './createEngineRequests';
+export { executeEngineAction } from './executeEngineAction';
 export { buildResponseMetadata } from './buildResponseMetadata';
 export { buildSteps } from './buildSteps';
 export { processEventStream } from './processEventStream';

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/createEngineRequests.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/createEngineRequests.test.ts
@@ -44,6 +44,7 @@ describe('createEngineRequests', () => {
 				id: 'call_123',
 				metadata: {
 					itemIndex: 0,
+					toolName: 'calculator',
 				},
 			});
 		});
@@ -78,6 +79,7 @@ describe('createEngineRequests', () => {
 				id: 'call_123',
 				metadata: {
 					itemIndex: 1,
+					toolName: 'calculator',
 				},
 			});
 			expect(result[1]).toEqual({
@@ -88,6 +90,7 @@ describe('createEngineRequests', () => {
 				id: 'call_124',
 				metadata: {
 					itemIndex: 1,
+					toolName: 'search',
 				},
 			});
 		});

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/types.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/types.ts
@@ -152,6 +152,8 @@ export type RequestResponseMetadata = {
 	anthropic?: AnthropicThinkingMetadata;
 	/** HITL (Human-in-the-Loop) metadata - presence indicates this is an HITL tool action */
 	hitl?: HitlMetadata;
+	/** LangChain tool name (preserves the LLM's chosen tool for reverse-lookup). */
+	toolName?: string;
 };
 
 /**

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/get-input-connection-data.test.ts
@@ -633,7 +633,7 @@ describe('makeHandleToolInvocation', () => {
 		]);
 	});
 
-	it('should handle engine requests and return a warning message', async () => {
+	it('should throw a clear UserError when a tool returns an EngineRequest from inside a parent agent', async () => {
 		const mockContext = mock<IExecuteFunctions>();
 		contextFactory.mockReturnValue(mockContext);
 		const mockResult: EngineRequest = { actions: [], metadata: {} };
@@ -645,21 +645,10 @@ describe('makeHandleToolInvocation', () => {
 			connectedNodeType,
 			runExecutionData,
 		);
-		const result = await handleToolInvocation(toolArgs);
 
-		expect(result).toBe(
-			'"Error: The Tool attempted to return an engine request, which is not supported in Agents"',
+		await expect(handleToolInvocation(toolArgs)).rejects.toThrow(
+			/connected tool returned an engine request/i,
 		);
-		expect(mockContext.addOutputData).toHaveBeenCalledWith(NodeConnectionTypes.AiTool, 0, [
-			[
-				{
-					json: {
-						response:
-							'Error: The Tool attempted to return an engine request, which is not supported in Agents',
-					},
-				},
-			],
-		]);
 	});
 
 	it('should continue if json and binary data exist', async () => {

--- a/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
@@ -185,8 +185,20 @@ function mapResult(result?: NodeOutput) {
 	if (result === undefined) {
 		response = undefined;
 	} else if (isEngineRequest(result)) {
-		response =
-			'Error: The Tool attempted to return an engine request, which is not supported in Agents';
+		// Tools running inside `makeHandleToolInvocation` cannot relay an
+		// `EngineRequest` to the workflow engine — the request/response loop
+		// only runs at top level. Sub-agent (`AgentToolV3`) resolves its own
+		// requests inline (see AI-2494), so reaching this branch means another
+		// tool returned an EngineRequest from inside a parent agent's tool
+		// callback. Throw a clear UserError so the failure is loud and the
+		// builder gets an actionable message.
+		throw new UserError(
+			'A connected tool returned an engine request to its parent agent, which is only supported for top-level node execution.',
+			{
+				description:
+					'If you are seeing this from a nested AgentToolV3 sub-agent, ensure your n8n version includes the AI-2494 fix.',
+			},
+		);
 	} else if (containsBinaryData(result) && !containsDataThatIsUsefulToTheAgent(result)) {
 		response = 'Error: The Tool attempted to return binary data, which is not supported in Agents';
 	} else {

--- a/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
@@ -188,15 +188,15 @@ function mapResult(result?: NodeOutput) {
 		// Tools running inside `makeHandleToolInvocation` cannot relay an
 		// `EngineRequest` to the workflow engine — the request/response loop
 		// only runs at top level. Sub-agent (`AgentToolV3`) resolves its own
-		// requests inline (see AI-2494), so reaching this branch means another
-		// tool returned an EngineRequest from inside a parent agent's tool
+		// requests inline, so reaching this branch means another tool
+		// returned an EngineRequest from inside a parent agent's tool
 		// callback. Throw a clear UserError so the failure is loud and the
 		// builder gets an actionable message.
 		throw new UserError(
 			'A connected tool returned an engine request to its parent agent, which is only supported for top-level node execution.',
 			{
 				description:
-					'If you are seeing this from a nested AgentToolV3 sub-agent, ensure your n8n version includes the AI-2494 fix.',
+					'If you are seeing this from a nested AgentToolV3 sub-agent, update n8n — recent versions resolve sub-agent engine requests inline.',
 			},
 		);
 	} else if (containsBinaryData(result) && !containsDataThatIsUsefulToTheAgent(result)) {


### PR DESCRIPTION
## Summary

Fix for AI-2494 / #30773: when `AgentToolV3` is wired as a tool of a parent agent and its inner LLM emits a tool call, the V3 executor returns an `EngineRequest`. That request flows up through the parent's tool boundary (`makeHandleToolInvocation` → `mapResult` in core), which rejects it with:

> `Error: The Tool attempted to return an engine request, which is not supported in Agents`

The sub-agent's tools never run. Same failure hits any tool that emits an `EngineRequest` (MCP Client Tool, Vector Store retrieve-as-tool, HITL) when nested under `AgentToolV3`.

**Fix (Option B+ from the [implementation doc](https://github.com/n8n-io/n8n/blob/master/.claude/specs/ai-2494-sub-agent-engine-request.md)):** detect the sub-agent context (`!isExecuteFunctions(this)`) in `toolsAgentExecute` and resolve the `EngineRequest` inline:

- Reject HITL actions upfront with a clear `UserError` (engine-level suspend/resume isn't available inside a tool callback; the whole sub-agent step aborts).
- Invoke each connected LangChain tool in parallel via `tool.invoke()` — execute-only tools still route through `makeHandleToolInvocation` (canvas observability preserved), supplyData-resolved tools through their own paths.
- Build an `EngineResponse`, loop back into `toolsAgentExecute` until it yields plain node output data.
- Nested `AgentToolV3` chains (A → B → tool) re-enter the same branch naturally.
- Recursion is bounded by each level's own `maxIterations`.

Also harden `mapResult` in core: a tool returning an `EngineRequest` now throws a `UserError` instead of silently substituting an error string, so any future regression fails loud with an actionable message.

### Files changed

- `packages/@n8n/nodes-langchain/.../V3/helpers/resolveSubAgentRequest.ts` *(new)* — inline executor
- `packages/@n8n/nodes-langchain/.../V3/execute.ts` — branch on `isExecuteFunctions(this)`
- `packages/@n8n/nodes-langchain/.../V3/helpers/index.ts` — export
- `packages/core/.../utils/get-input-connection-data.ts` — defensive `UserError` throw
- Unit tests (10 cases incl. nested recursion), integration fixture + test, updated affected mocks

## Behavior change worth flagging in release notes

`packages/core` — `mapResult` used to substitute a string error when a tool returned an `EngineRequest` from inside `makeHandleToolInvocation` (soft fail; LLM saw the error string). It now throws a `UserError` instead, so any custom or community tool that previously returned an `EngineRequest` outside of top-level execution will hard-fail the workflow with an actionable message. AgentToolV3 itself no longer returns an `EngineRequest` from this path, so production users hitting AI-2494 will see the fix transparently — the harder fail is the safety net for any future regression or third-party tool that hits the same shape.

## Follow-ups (not in this PR)

- Sub-agent tracing keys (`ai.agent.iteration.count`, `tool_calls.requested`, etc.) are still gated on `isExecuteFunctions(this)`, so sub-agent runs don't emit them. Pre-existing behaviour, but worth a separate ticket now that the sub-agent loop is a hot path.
- Consider applying a `Backport to Stable` label — AI-2494 is a community regression with active complaints in #30773.

## Related Linear tickets, Github issues, and Community forum posts

- Linear: https://linear.app/n8n/issue/AI-2494
- Closes #30773
- Related: #26389 (community PR proposing a similar fix in core, superseded by this PR)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)