### PR TITLE
feat(core): Restore AI Assistant HITL state across restart

### DIFF
--- a/packages/@n8n/instance-ai/src/runtime/__tests__/run-state-registry.test.ts
+++ b/packages/@n8n/instance-ai/src/runtime/__tests__/run-state-registry.test.ts
@@ -962,7 +962,11 @@ describe('RunStateRegistry', () => {
 			expect(result.suspendedRuns[0].runId).toBe('run_suspended');
 		});
 
-		it('resolves all pending confirmations', () => {
+		it('leaves pending confirmation resolvers untouched and returns their thread ids', () => {
+			// Auto-resolving inline confirmations on shutdown causes the awaiting
+			// tool to run to completion as "denied" and mutate the snapshot
+			// mid-shutdown; we intentionally let them dangle so the user sees
+			// the original confirmation card on reload.
 			const resolve1 = jest.fn();
 			const resolve2 = jest.fn();
 
@@ -979,25 +983,30 @@ describe('RunStateRegistry', () => {
 				createdAt: Date.now(),
 			});
 
-			registry.shutdown();
+			const result = registry.shutdown();
 
-			expect(resolve1).toHaveBeenCalledWith({ approved: false });
-			expect(resolve2).toHaveBeenCalledWith({ approved: false });
+			expect(resolve1).not.toHaveBeenCalled();
+			expect(resolve2).not.toHaveBeenCalled();
+			expect(result.pendingThreadIds).toEqual(expect.arrayContaining(['thread-1', 'thread-2']));
 		});
 
-		it('uses custom cancellation data when provided', () => {
-			const resolve = jest.fn();
+		it('deduplicates pendingThreadIds when one thread has multiple confirmations', () => {
 			registry.registerPendingConfirmation('req-1', {
-				resolve,
-				threadId: 'thread-1',
+				resolve: jest.fn(),
+				threadId: 'thread-shared',
+				userId: 'user-1',
+				createdAt: Date.now(),
+			});
+			registry.registerPendingConfirmation('req-2', {
+				resolve: jest.fn(),
+				threadId: 'thread-shared',
 				userId: 'user-1',
 				createdAt: Date.now(),
 			});
 
-			const customData: ConfirmationData = { approved: false, userInput: 'shutdown' };
-			registry.shutdown(customData);
+			const result = registry.shutdown();
 
-			expect(resolve).toHaveBeenCalledWith(customData);
+			expect(result.pendingThreadIds).toEqual(['thread-shared']);
 		});
 
 		it('leaves registry fully empty after shutdown', () => {

--- a/packages/@n8n/instance-ai/src/runtime/resumable-stream-executor.ts
+++ b/packages/@n8n/instance-ai/src/runtime/resumable-stream-executor.ts
@@ -378,7 +378,9 @@ async function waitForConfirmation(
 	confirmationPromise: Promise<Record<string, unknown>>,
 ): Promise<Record<string, unknown>> {
 	if (signal.aborted) {
-		throw new Error('Run cancelled while waiting for confirmation');
+		throw new Error(
+			'The assistant was interrupted while waiting for your response. Send a new message to continue.',
+		);
 	}
 
 	let abortHandler: (() => void) | undefined;
@@ -387,7 +389,12 @@ async function waitForConfirmation(
 		return await Promise.race([
 			confirmationPromise,
 			new Promise<never>((_, reject) => {
-				abortHandler = () => reject(new Error('Run cancelled while waiting for confirmation'));
+				abortHandler = () =>
+					reject(
+						new Error(
+							'The assistant was interrupted while waiting for your response. Send a new message to continue.',
+						),
+					);
 				signal.addEventListener('abort', abortHandler, { once: true });
 			}),
 		]);

--- a/packages/@n8n/instance-ai/src/runtime/run-state-registry.ts
+++ b/packages/@n8n/instance-ai/src/runtime/run-state-registry.ts
@@ -528,16 +528,36 @@ export class RunStateRegistry<TUser = unknown> {
 		return { ...(active ? { active } : {}), ...(suspended ? { suspended } : {}) };
 	}
 
-	shutdown(cancelledConfirmation: ConfirmationData = { approved: false }): {
+	/**
+	 * Process-wide teardown. Returns the in-flight runs so the service can
+	 * abort them and persist terminal snapshots where appropriate.
+	 *
+	 * Pending confirmations are intentionally NOT resolved — auto-resolving an
+	 * inline HITL (`waitForConfirmation(...)`) with `{ approved: false }`
+	 * causes the awaiting agent tool to run to completion as "denied" before
+	 * the process exits, which then mutates the snapshot tree mid-shutdown
+	 * and clobbers the plan/ask card the user would otherwise see on reload.
+	 * Letting the Promises dangle is safe: the process is exiting, the
+	 * abortController for each active run is aborted next, and the
+	 * `instance_ai_pending_confirmations` row survives so the user can still
+	 * see the confirmation card (and get a clear "lost on restart" error if
+	 * they click confirm — see `handleOrphanedConfirmation`).
+	 *
+	 * `pendingThreadIds` is returned so the service can skip the
+	 * publish-run-finish + terminal-snapshot treatment for runs that are
+	 * only sitting in `activeRuns` because they're waiting on an inline
+	 * confirmation Promise.
+	 */
+	shutdown(): {
 		activeRuns: ActiveRunState[];
 		suspendedRuns: Array<SuspendedRunState<TUser>>;
+		pendingThreadIds: string[];
 	} {
 		const activeRuns = [...this.activeRuns.values()];
 		const suspendedRuns = [...this.suspendedRuns.values()];
-
-		for (const pending of this.pendingConfirmations.values()) {
-			pending.resolve(cancelledConfirmation);
-		}
+		const pendingThreadIds = [
+			...new Set([...this.pendingConfirmations.values()].map((p) => p.threadId)),
+		];
 
 		this.activeRuns.clear();
 		this.suspendedRuns.clear();
@@ -547,6 +567,6 @@ export class RunStateRegistry<TUser = unknown> {
 		this.threadMessageGroupId.clear();
 		this.runIdsByMessageGroup.clear();
 
-		return { activeRuns, suspendedRuns };
+		return { activeRuns, suspendedRuns, pendingThreadIds };
 	}
 }

--- a/packages/@n8n/instance-ai/src/runtime/run-state-registry.ts
+++ b/packages/@n8n/instance-ai/src/runtime/run-state-registry.ts
@@ -10,6 +10,7 @@ import type {
 
 export interface ActiveRunState {
 	runId: string;
+	threadId: string;
 	abortController: AbortController;
 	messageGroupId?: string;
 	tracing?: InstanceAiTraceContext;
@@ -121,6 +122,7 @@ export class RunStateRegistry<TUser = unknown> {
 
 		this.activeRuns.set(options.threadId, {
 			runId,
+			threadId: options.threadId,
 			abortController,
 			messageGroupId,
 			startedAt: now,
@@ -144,7 +146,7 @@ export class RunStateRegistry<TUser = unknown> {
 		const groupRunIds = this.runIdsByMessageGroup.get(messageGroupId);
 		if (groupRunIds) groupRunIds.push(runId);
 
-		return { runId, abortController, messageGroupId };
+		return { runId, threadId: options.threadId, abortController, messageGroupId };
 	}
 
 	getThreadStatus(
@@ -221,6 +223,7 @@ export class RunStateRegistry<TUser = unknown> {
 
 		this.activeRuns.set(threadId, {
 			...activeRun,
+			threadId,
 			tracing,
 		});
 	}
@@ -268,6 +271,7 @@ export class RunStateRegistry<TUser = unknown> {
 		const now = Date.now();
 		this.activeRuns.set(threadId, {
 			runId: suspended.runId,
+			threadId,
 			abortController: suspended.abortController,
 			messageGroupId: suspended.messageGroupId,
 			tracing: suspended.tracing,

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-liveness.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-liveness.service.test.ts
@@ -75,6 +75,7 @@ function createLivenessService() {
 	const finalizeCancelledSuspendedRun = jest.fn(
 		(_suspended: TestSuspendedRun, _reason: string) => {},
 	);
+	const onPendingConfirmationRejected = jest.fn((_requestId: string) => {});
 	const logger = {
 		debug: jest.fn(),
 		warn: jest.fn(),
@@ -87,6 +88,7 @@ function createLivenessService() {
 		backgroundTasks,
 		eventBus,
 		finalizeCancelledSuspendedRun,
+		onPendingConfirmationRejected,
 		logger,
 	});
 
@@ -97,14 +99,22 @@ function createLivenessService() {
 		backgroundTasks,
 		eventBus,
 		finalizeCancelledSuspendedRun,
+		onPendingConfirmationRejected,
 		logger,
 	};
 }
 
 describe('InstanceAiLivenessService', () => {
 	it('cancels timed-out run surfaces without cascading into background tasks', async () => {
-		const { service, policy, runState, backgroundTasks, eventBus, finalizeCancelledSuspendedRun } =
-			createLivenessService();
+		const {
+			service,
+			policy,
+			runState,
+			backgroundTasks,
+			eventBus,
+			finalizeCancelledSuspendedRun,
+			onPendingConfirmationRejected,
+		} = createLivenessService();
 		const activeAbortController = new AbortController();
 		const suspendedAbortController = new AbortController();
 		const suspended = {
@@ -162,6 +172,7 @@ describe('InstanceAiLivenessService', () => {
 			INSTANCE_AI_RUN_TIMEOUT_REASON,
 		);
 		expect(runState.rejectPendingConfirmation).toHaveBeenCalledWith('request-1');
+		expect(onPendingConfirmationRejected).toHaveBeenCalledWith('request-1');
 		expect(backgroundTasks.timeoutTimedOutTasks).toHaveBeenCalledWith(
 			policy,
 			123_456,

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-memory.service.test.ts
@@ -19,6 +19,7 @@ const mockAgentMemory = {
 
 // Mock GlobalConfig
 const mockDbSnapshotStorage = { getAll: jest.fn().mockResolvedValue([]) };
+const mockCheckpointRepository = { findActiveByThreadId: jest.fn().mockResolvedValue([]) };
 
 function createService(options: { threadTtlDays?: number } = {}): InstanceAiMemoryService {
 	const mockConfig = {
@@ -43,6 +44,7 @@ function createService(options: { threadTtlDays?: number } = {}): InstanceAiMemo
 		mockConfig as never,
 		mockAgentMemory as never,
 		mockDbSnapshotStorage as never,
+		mockCheckpointRepository as never,
 	);
 }
 
@@ -171,6 +173,113 @@ describe('InstanceAiMemoryService.getRichMessages', () => {
 		const result = await service.getRichMessages('user-1', 'thread-1');
 
 		expect(result.messages).toEqual([]);
+	});
+
+	it('surfaces in-flight user message from a suspended checkpoint when memory is empty', async () => {
+		// A turn that suspended at HITL never gets `saveToMemory` called by the
+		// SDK, so the user prompt + intermediate assistant messages live only
+		// in `state.messageList.messages`. The /messages endpoint should
+		// surface them so a page reload doesn't drop the original user message.
+		mockListMessages.mockResolvedValue({ messages: [] });
+		mockCheckpointRepository.findActiveByThreadId.mockResolvedValueOnce([
+			{
+				key: 'run_abc',
+				runId: 'run_abc',
+				threadId: 'thread-1',
+				expiredAt: null,
+				state: {
+					messageList: {
+						messages: [
+							{
+								id: 'cp-user-1',
+								role: 'user',
+								content: [{ type: 'text', text: 'execute my workflow' }],
+								createdAt: '2026-01-01T00:00:00.000Z',
+							},
+							{
+								id: 'cp-assistant-1',
+								role: 'assistant',
+								content: [{ type: 'text', text: 'On it!' }],
+								createdAt: '2026-01-01T00:00:01.000Z',
+							},
+						],
+					},
+				},
+				createdAt: new Date('2026-01-01T00:00:01.000Z'),
+				updatedAt: new Date('2026-01-01T00:00:01.000Z'),
+			},
+		]);
+
+		const service = createService();
+		const result = await service.getRichMessages('user-1', 'thread-1');
+
+		expect(result.messages).toHaveLength(2);
+		expect(result.messages[0]).toMatchObject({ id: 'cp-user-1', role: 'user' });
+		expect(result.messages[0].content).toBe('execute my workflow');
+		expect(result.messages[1]).toMatchObject({ id: 'cp-assistant-1', role: 'assistant' });
+	});
+
+	it('prefers stored messages over checkpoint duplicates with the same id', async () => {
+		// When a previously suspended turn resumes and commits its messages to
+		// memory, the same IDs appear in both places. The stored row wins so
+		// any post-suspension edits the SDK made (e.g. final tool outcomes)
+		// are not regressed by the stale checkpoint copy.
+		mockListMessages.mockResolvedValue({
+			messages: [
+				{
+					id: 'msg-1',
+					role: 'user',
+					content: [{ type: 'text', text: 'final version' }],
+					createdAt: new Date('2026-01-01T00:00:00.000Z'),
+				},
+			],
+		});
+		mockCheckpointRepository.findActiveByThreadId.mockResolvedValueOnce([
+			{
+				key: 'run_abc',
+				expiredAt: null,
+				state: {
+					messageList: {
+						messages: [
+							{
+								id: 'msg-1',
+								role: 'user',
+								content: [{ type: 'text', text: 'stale checkpoint copy' }],
+								createdAt: '2026-01-01T00:00:00.000Z',
+							},
+						],
+					},
+				},
+				createdAt: new Date(),
+				updatedAt: new Date(),
+			},
+		]);
+
+		const service = createService();
+		const result = await service.getRichMessages('user-1', 'thread-1');
+
+		expect(result.messages).toHaveLength(1);
+		expect(result.messages[0].content).toBe('final version');
+	});
+
+	it('tolerates a missing or unreadable checkpoint store', async () => {
+		mockListMessages.mockResolvedValue({
+			messages: [
+				{
+					id: 'msg-u',
+					role: 'user',
+					content: 'Hello',
+					createdAt: new Date('2026-01-01T00:00:00.000Z'),
+				},
+			],
+		});
+		mockCheckpointRepository.findActiveByThreadId.mockRejectedValueOnce(new Error('db down'));
+
+		const service = createService();
+		const result = await service.getRichMessages('user-1', 'thread-1');
+
+		expect(result.messages).toHaveLength(1);
+		expect(result.messages[0].role).toBe('user');
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -413,9 +413,10 @@ type CheckpointPruneServiceInternals = {
 	startCheckpointPruning: () => void;
 	stopCheckpointPruning: () => void;
 	pruneStaleCheckpoints: (now?: number) => Promise<void>;
+	pruneStalePendingConfirmations: jest.MockedFunction<(now: number) => Promise<void>>;
 	scheduleCheckpointPrune: jest.MockedFunction<(delayMs?: number) => void>;
 	checkpointStore: {
-		deleteOlderThan: jest.MockedFunction<(olderThan: Date) => Promise<number>>;
+		markExpiredOlderThan: jest.MockedFunction<(olderThan: Date) => Promise<number>>;
 	};
 	checkpointPruneTimer?: NodeJS.Timeout;
 	checkpointPruningStopped: boolean;
@@ -431,8 +432,9 @@ function createCheckpointPruneService(): CheckpointPruneServiceInternals {
 		InstanceAiService.prototype,
 	) as unknown as CheckpointPruneServiceInternals;
 	service.scheduleCheckpointPrune = jest.fn();
+	service.pruneStalePendingConfirmations = jest.fn(async (_now: number) => undefined);
 	service.checkpointStore = {
-		deleteOlderThan: jest.fn(async (_olderThan: Date) => 0),
+		markExpiredOlderThan: jest.fn(async (_olderThan: Date) => 0),
 	};
 	service.checkpointPruningStopped = true;
 	service.instanceAiConfig = {
@@ -1358,15 +1360,16 @@ describe('InstanceAiService — pending checkpoint re-entry', () => {
 });
 
 describe('InstanceAiService — checkpoint pruning', () => {
-	it('deletes checkpoints older than the retention window', async () => {
+	it('marks checkpoints expired older than the retention window', async () => {
 		const service = createCheckpointPruneService();
 		const now = new Date('2026-05-13T12:00:00.000Z').getTime();
 
 		await service.pruneStaleCheckpoints(now);
 
-		expect(service.checkpointStore.deleteOlderThan).toHaveBeenCalledWith(
+		expect(service.checkpointStore.markExpiredOlderThan).toHaveBeenCalledWith(
 			new Date('2026-05-06T12:00:00.000Z'),
 		);
+		expect(service.pruneStalePendingConfirmations).toHaveBeenCalledWith(now);
 		expect(service.scheduleCheckpointPrune).toHaveBeenCalledWith();
 	});
 
@@ -1484,6 +1487,12 @@ type ResolveConfirmationServiceInternals = {
 		findSuspendedByRequestId: jest.Mock;
 		rejectPendingConfirmation: jest.Mock;
 	};
+	resumeSuspendedRun: jest.Mock;
+	dropPendingConfirmation: jest.Mock;
+	pendingConfirmationRepo: { claim: jest.Mock };
+	publishRunFinish: jest.Mock;
+	saveAgentTreeSnapshot: jest.Mock;
+	dbSnapshotStorage: unknown;
 	logger: { debug: jest.Mock; warn: jest.Mock; error: jest.Mock };
 };
 
@@ -1498,6 +1507,12 @@ function createResolveConfirmationService(): ResolveConfirmationServiceInternals
 		findSuspendedByRequestId: jest.fn(),
 		rejectPendingConfirmation: jest.fn(),
 	};
+	service.resumeSuspendedRun = jest.fn(async () => false);
+	service.dropPendingConfirmation = jest.fn(async () => {});
+	service.pendingConfirmationRepo = { claim: jest.fn(async () => undefined) };
+	service.publishRunFinish = jest.fn();
+	service.saveAgentTreeSnapshot = jest.fn(async () => {});
+	service.dbSnapshotStorage = {};
 	service.logger = { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
 	return service;
 }
@@ -1668,6 +1683,55 @@ describe('InstanceAiService — resolveConfirmation', () => {
 		);
 		expect(service.runState.rejectPendingConfirmation).not.toHaveBeenCalled();
 		expect(service.cancelRun).not.toHaveBeenCalled();
+		expect(service.dropPendingConfirmation).toHaveBeenCalledWith('req-1');
+	});
+
+	it('throws a UserError when an orphaned DB row is claimed after a restart', async () => {
+		const service = createResolveConfirmationService();
+		service.revalidateActiveUser.mockResolvedValue({ id: 'user-1' } as unknown as User);
+		service.runState.resolvePendingConfirmation.mockReturnValue(false);
+		service.resumeSuspendedRun.mockResolvedValue(false);
+		service.pendingConfirmationRepo.claim.mockResolvedValue({
+			requestId: 'req-1',
+			threadId: 'thread-1',
+			userId: 'user-1',
+			kind: 'suspended',
+			runId: 'run-1',
+			messageGroupId: 'group-1',
+		});
+
+		await expect(service.resolveConfirmation('user-1', 'req-1', approval)).rejects.toThrow(
+			/lost when the assistant restarted/,
+		);
+
+		expect(service.pendingConfirmationRepo.claim).toHaveBeenCalledWith('req-1', 'user-1');
+		expect(service.publishRunFinish).toHaveBeenCalledWith(
+			'thread-1',
+			'run-1',
+			'cancelled',
+			'restart_lost_confirmation',
+		);
+		expect(service.saveAgentTreeSnapshot).toHaveBeenCalledWith(
+			'thread-1',
+			'run-1',
+			service.dbSnapshotStorage,
+			true,
+			'group-1',
+		);
+	});
+
+	it('returns false silently when no DB row is claimable for an unknown confirmation', async () => {
+		const service = createResolveConfirmationService();
+		service.revalidateActiveUser.mockResolvedValue({ id: 'user-1' } as unknown as User);
+		service.runState.resolvePendingConfirmation.mockReturnValue(false);
+		service.resumeSuspendedRun.mockResolvedValue(false);
+		service.pendingConfirmationRepo.claim.mockResolvedValue(undefined);
+
+		const result = await service.resolveConfirmation('user-1', 'req-missing', approval);
+
+		expect(result).toBe(false);
+		expect(service.publishRunFinish).not.toHaveBeenCalled();
+		expect(service.saveAgentTreeSnapshot).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -340,6 +340,7 @@ type StartRunServiceInternals = {
 	};
 	threadPushRef: Map<string, string>;
 	executeRun: jest.Mock;
+	trackInFlightExecution: jest.Mock;
 };
 
 function createStartRunService(): StartRunServiceInternals {
@@ -357,6 +358,7 @@ function createStartRunService(): StartRunServiceInternals {
 	};
 	service.threadPushRef = new Map();
 	service.executeRun = jest.fn();
+	service.trackInFlightExecution = jest.fn();
 	return service;
 }
 
@@ -565,6 +567,7 @@ type ShutdownServiceInternals = {
 	domainAccessTrackersByThread: Map<string, unknown>;
 	eventBus: { clear: jest.MockedFunction<() => void> };
 	_mcpClientManager?: { disconnect: jest.MockedFunction<() => Promise<void>> };
+	inFlightExecutions: Set<Promise<unknown>>;
 	logger: { debug: jest.Mock; warn: jest.Mock };
 };
 
@@ -1178,6 +1181,7 @@ describe('InstanceAiService — shutdown', () => {
 		service.domainAccessTrackersByThread = new Map();
 		service.eventBus = { clear: jest.fn() };
 		service._mcpClientManager = { disconnect: jest.fn(async () => {}) };
+		service.inFlightExecutions = new Set();
 		service.logger = { debug: jest.fn(), warn: jest.fn() };
 
 		await service.shutdown();
@@ -1597,6 +1601,8 @@ type SuspendedRunResumeServiceInternals = {
 	dbSnapshotStorage: unknown;
 	createOrchestratorResumeTraceContext: jest.Mock;
 	processResumedStream: jest.Mock;
+	dropPendingConfirmation: jest.Mock;
+	trackInFlightExecution: jest.Mock;
 };
 
 function createSuspendedRunResumeService(): SuspendedRunResumeServiceInternals {
@@ -1605,6 +1611,8 @@ function createSuspendedRunResumeService(): SuspendedRunResumeServiceInternals {
 	) as unknown as SuspendedRunResumeServiceInternals;
 	service.revalidateActiveUser = jest.fn();
 	service.cancelRun = jest.fn();
+	service.dropPendingConfirmation = jest.fn(async () => {});
+	service.trackInFlightExecution = jest.fn();
 	service.runState = {
 		findSuspendedByRequestId: jest.fn(() => ({
 			agent: {},

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -1490,10 +1490,12 @@ type ResolveConfirmationServiceInternals = {
 	resumeSuspendedRun: jest.Mock;
 	dropPendingConfirmation: jest.Mock;
 	pendingConfirmationRepo: { claim: jest.Mock };
+	tryResumeFromOrphan: jest.Mock;
+	finalizeUnresumableOrphan: jest.Mock;
 	publishRunFinish: jest.Mock;
 	saveAgentTreeSnapshot: jest.Mock;
 	dbSnapshotStorage: unknown;
-	logger: { debug: jest.Mock; warn: jest.Mock; error: jest.Mock };
+	logger: { debug: jest.Mock; warn: jest.Mock; error: jest.Mock; info: jest.Mock };
 };
 
 function createResolveConfirmationService(): ResolveConfirmationServiceInternals {
@@ -1510,10 +1512,17 @@ function createResolveConfirmationService(): ResolveConfirmationServiceInternals
 	service.resumeSuspendedRun = jest.fn(async () => false);
 	service.dropPendingConfirmation = jest.fn(async () => {});
 	service.pendingConfirmationRepo = { claim: jest.fn(async () => undefined) };
+	service.tryResumeFromOrphan = jest.fn(async () => false);
+	service.finalizeUnresumableOrphan = jest.fn();
 	service.publishRunFinish = jest.fn();
 	service.saveAgentTreeSnapshot = jest.fn(async () => {});
 	service.dbSnapshotStorage = {};
-	service.logger = { debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
+	service.logger = {
+		debug: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+		info: jest.fn(),
+	};
 	return service;
 }
 
@@ -1686,7 +1695,34 @@ describe('InstanceAiService — resolveConfirmation', () => {
 		expect(service.dropPendingConfirmation).toHaveBeenCalledWith('req-1');
 	});
 
-	it('throws a UserError when an orphaned DB row is claimed after a restart', async () => {
+	it('throws a UserError when an inline orphan is reclaimed after a restart (no checkpoint to resume)', async () => {
+		// Inline confirmations were held by an in-process Promise that died
+		// with the previous main; there's nothing to load from the checkpoint
+		// store, so the only honest answer is the terminal UserError.
+		const service = createResolveConfirmationService();
+		service.revalidateActiveUser.mockResolvedValue({ id: 'user-1' } as unknown as User);
+		service.runState.resolvePendingConfirmation.mockReturnValue(false);
+		service.resumeSuspendedRun.mockResolvedValue(false);
+		service.pendingConfirmationRepo.claim.mockResolvedValue({
+			requestId: 'req-1',
+			threadId: 'thread-1',
+			userId: 'user-1',
+			kind: 'inline',
+			runId: 'run-1',
+			messageGroupId: 'group-1',
+		});
+
+		await expect(service.resolveConfirmation('user-1', 'req-1', approval)).rejects.toThrow(
+			/lost when the assistant restarted/,
+		);
+
+		expect(service.tryResumeFromOrphan).not.toHaveBeenCalled();
+		expect(service.finalizeUnresumableOrphan).toHaveBeenCalledWith(
+			expect.objectContaining({ requestId: 'req-1', kind: 'inline' }),
+		);
+	});
+
+	it('falls back to UserError when a suspended orphan lacks the fields needed to resume', async () => {
 		const service = createResolveConfirmationService();
 		service.revalidateActiveUser.mockResolvedValue({ id: 'user-1' } as unknown as User);
 		service.runState.resolvePendingConfirmation.mockReturnValue(false);
@@ -1698,26 +1734,68 @@ describe('InstanceAiService — resolveConfirmation', () => {
 			kind: 'suspended',
 			runId: 'run-1',
 			messageGroupId: 'group-1',
+			// no agentRunId / toolCallId / checkpointKey -> can't resume
 		});
 
 		await expect(service.resolveConfirmation('user-1', 'req-1', approval)).rejects.toThrow(
 			/lost when the assistant restarted/,
 		);
 
-		expect(service.pendingConfirmationRepo.claim).toHaveBeenCalledWith('req-1', 'user-1');
-		expect(service.publishRunFinish).toHaveBeenCalledWith(
-			'thread-1',
-			'run-1',
-			'cancelled',
-			'restart_lost_confirmation',
+		expect(service.tryResumeFromOrphan).not.toHaveBeenCalled();
+		expect(service.finalizeUnresumableOrphan).toHaveBeenCalledWith(
+			expect.objectContaining({ requestId: 'req-1', kind: 'suspended' }),
 		);
-		expect(service.saveAgentTreeSnapshot).toHaveBeenCalledWith(
-			'thread-1',
-			'run-1',
-			service.dbSnapshotStorage,
-			true,
-			'group-1',
+	});
+
+	it('reclaims and resumes a suspended orphan when the checkpoint is still loadable', async () => {
+		const service = createResolveConfirmationService();
+		service.revalidateActiveUser.mockResolvedValue({ id: 'user-1' } as unknown as User);
+		service.runState.resolvePendingConfirmation.mockReturnValue(false);
+		service.resumeSuspendedRun.mockResolvedValue(false);
+		const orphan = {
+			requestId: 'req-1',
+			threadId: 'thread-1',
+			userId: 'user-1',
+			kind: 'suspended',
+			runId: 'run-1',
+			messageGroupId: 'group-1',
+			toolCallId: 'tool-call-1',
+			checkpointKey: 'agent-run-1',
+		};
+		service.pendingConfirmationRepo.claim.mockResolvedValue(orphan);
+		service.tryResumeFromOrphan.mockResolvedValue(true);
+
+		const result = await service.resolveConfirmation('user-1', 'req-1', approval);
+
+		expect(result).toBe(true);
+		expect(service.tryResumeFromOrphan).toHaveBeenCalledWith(orphan, expect.anything());
+		expect(service.finalizeUnresumableOrphan).not.toHaveBeenCalled();
+	});
+
+	it('falls back to UserError when the resume attempt itself fails', async () => {
+		// e.g. checkpoint expired between claim and load, or env build fails
+		const service = createResolveConfirmationService();
+		service.revalidateActiveUser.mockResolvedValue({ id: 'user-1' } as unknown as User);
+		service.runState.resolvePendingConfirmation.mockReturnValue(false);
+		service.resumeSuspendedRun.mockResolvedValue(false);
+		service.pendingConfirmationRepo.claim.mockResolvedValue({
+			requestId: 'req-1',
+			threadId: 'thread-1',
+			userId: 'user-1',
+			kind: 'suspended',
+			runId: 'run-1',
+			messageGroupId: 'group-1',
+			toolCallId: 'tool-call-1',
+			checkpointKey: 'agent-run-1',
+		});
+		service.tryResumeFromOrphan.mockResolvedValue(false);
+
+		await expect(service.resolveConfirmation('user-1', 'req-1', approval)).rejects.toThrow(
+			/lost when the assistant restarted/,
 		);
+
+		expect(service.tryResumeFromOrphan).toHaveBeenCalled();
+		expect(service.finalizeUnresumableOrphan).toHaveBeenCalled();
 	});
 
 	it('returns false silently when no DB row is claimable for an unknown confirmation', async () => {
@@ -1730,8 +1808,8 @@ describe('InstanceAiService — resolveConfirmation', () => {
 		const result = await service.resolveConfirmation('user-1', 'req-missing', approval);
 
 		expect(result).toBe(false);
-		expect(service.publishRunFinish).not.toHaveBeenCalled();
-		expect(service.saveAgentTreeSnapshot).not.toHaveBeenCalled();
+		expect(service.tryResumeFromOrphan).not.toHaveBeenCalled();
+		expect(service.finalizeUnresumableOrphan).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -339,6 +339,10 @@ type StartRunServiceInternals = {
 		setTimeZone: jest.MockedFunction<(threadId: string, timeZone: string) => void>;
 	};
 	threadPushRef: Map<string, string>;
+	userMessagePersistenceByRun: Map<
+		string,
+		{ userId: string; message: { id: string; text: string } }
+	>;
 	executeRun: jest.Mock;
 	trackInFlightExecution: jest.Mock;
 };
@@ -357,6 +361,7 @@ function createStartRunService(): StartRunServiceInternals {
 		setTimeZone: jest.fn(),
 	};
 	service.threadPushRef = new Map();
+	service.userMessagePersistenceByRun = new Map();
 	service.executeRun = jest.fn();
 	service.trackInFlightExecution = jest.fn();
 	return service;

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.threadPushRef.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.threadPushRef.test.ts
@@ -77,6 +77,7 @@ describe('InstanceAiService — threadPushRef lifetime', () => {
 			deleteTraceContextsForThread: jest.Mock;
 			destroySandbox: jest.Mock;
 			reapAiTemporaryForThreadCleanup: jest.Mock;
+			dropPendingConfirmationsForThread: jest.Mock;
 			clearThreadState: (threadId: string) => Promise<void>;
 		};
 		const service = Object.create(InstanceAiService.prototype) as unknown as Internals;
@@ -95,6 +96,7 @@ describe('InstanceAiService — threadPushRef lifetime', () => {
 		service.deleteTraceContextsForThread = jest.fn();
 		service.destroySandbox = jest.fn(async () => {});
 		service.reapAiTemporaryForThreadCleanup = jest.fn(async () => {});
+		service.dropPendingConfirmationsForThread = jest.fn(async () => {});
 
 		await service.clearThreadState('thread-a');
 

--- a/packages/cli/src/modules/instance-ai/__tests__/message-parser.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/message-parser.test.ts
@@ -520,6 +520,215 @@ describe('parseStoredMessages', () => {
 		});
 	});
 
+	describe('multi-run conversational turn (planned-task follow-ups)', () => {
+		// Mirrors the real flow: user sends a message, orchestrator suspends at a
+		// HITL plan-approval, user approves, planned tasks dispatch a builder, the
+		// orchestrator restarts internally (skipped <planned-task-follow-up> user
+		// rows) for checkpoint and synthesize sub-runs, and a snapshot is saved
+		// per sub-run. Without messageGroupId propagation across the turn, the
+		// intra-turn unpaired text rows survive the dedup loop and render as
+		// duplicates of the final snapshot's tree.textContent.
+		it('collapses intra-turn unpaired assistant rows into the final snapshot', () => {
+			const finalTree: InstanceAiAgentNode = {
+				agentId: 'agent-001',
+				role: 'orchestrator',
+				status: 'completed',
+				textContent:
+					'On it!The background workflow-builder task finished.The trigger is a manual trigger. **Workflow** is ready.',
+				reasoning: '',
+				toolCalls: [],
+				children: [],
+				timeline: [{ type: 'text', content: 'On it!' }],
+			};
+
+			const messages: StoredAgentMessage[] = [
+				{
+					id: 'msg-user',
+					role: 'user',
+					content: 'lets build a simple workflow with just a single manual trigger on it',
+					createdAt: makeDate(0),
+				},
+				{
+					id: 'msg-plan-toolcall',
+					role: 'assistant',
+					content: [
+						{
+							type: 'tool-call',
+							toolCallId: 'toolu_plan',
+							toolName: 'plan',
+							input: {},
+							state: 'resolved',
+							output: { result: 'Plan approved and 2 tasks dispatched.' },
+						},
+					],
+					createdAt: makeDate(2),
+				},
+				{
+					id: 'msg-on-it',
+					role: 'assistant',
+					content: [{ type: 'text', text: 'On it!' }],
+					createdAt: makeDate(55),
+				},
+				{
+					id: 'msg-followup-checkpoint',
+					role: 'user',
+					content:
+						'<planned-task-follow-up type="checkpoint">\n{}\n</planned-task-follow-up>\n\n(continue)',
+					createdAt: makeDate(104),
+				},
+				{
+					id: 'msg-trigger-text',
+					role: 'assistant',
+					content: [
+						{ type: 'text', text: 'The trigger is a manual trigger.' },
+						{
+							type: 'tool-call',
+							toolCallId: 'toolu_executions',
+							toolName: 'executions',
+							input: { action: 'run', workflowId: 'wf-1' },
+							state: 'resolved',
+							output: { executionId: '1293', status: 'success' },
+						},
+					],
+					createdAt: makeDate(107),
+				},
+				{
+					id: 'msg-complete-checkpoint',
+					role: 'assistant',
+					content: [
+						{
+							type: 'tool-call',
+							toolCallId: 'toolu_complete',
+							toolName: 'complete-checkpoint',
+							input: { taskId: 'chk-1', status: 'succeeded' },
+							state: 'resolved',
+							output: { ok: true },
+						},
+					],
+					createdAt: makeDate(110),
+				},
+				{
+					id: 'msg-followup-synthesize',
+					role: 'user',
+					content:
+						'<planned-task-follow-up type="synthesize">\n{}\n</planned-task-follow-up>\n\n(continue)',
+					createdAt: makeDate(111),
+				},
+				{
+					id: 'msg-final',
+					role: 'assistant',
+					content: [{ type: 'text', text: '**Workflow** is ready.' }],
+					createdAt: makeDate(114),
+				},
+			];
+
+			const result = parseStoredMessages(messages, [
+				{
+					tree: makeSnapshotTree('On it! (partial)'),
+					runId: 'run_A',
+					messageGroupId: 'mg_turn',
+					runIds: ['run_A'],
+					createdAt: makeDate(11),
+					updatedAt: makeDate(11),
+				},
+				{
+					tree: makeSnapshotTree('On it! checkpoint done (partial)'),
+					runId: 'run_B',
+					messageGroupId: 'mg_turn',
+					runIds: ['run_A', 'run_B'],
+					createdAt: makeDate(111),
+					updatedAt: makeDate(111),
+				},
+				{
+					tree: finalTree,
+					runId: 'run_C',
+					messageGroupId: 'mg_turn',
+					runIds: ['run_A', 'run_B', 'run_C'],
+					createdAt: makeDate(114),
+					updatedAt: makeDate(114),
+				},
+			]);
+
+			// 1 user + 1 collapsed assistant (the final snapshot).
+			expect(result).toHaveLength(2);
+			expect(result[0]).toMatchObject({ id: 'msg-user', role: 'user' });
+			expect(result[1]).toMatchObject({
+				id: 'msg-final',
+				role: 'assistant',
+				messageGroupId: 'mg_turn',
+				agentTree: finalTree,
+			});
+		});
+
+		it('keeps unpaired assistant rows when no paired snapshot exists in the turn', () => {
+			// A turn with no snapshot at all (e.g. a quick text-only reply) must
+			// not be touched by the propagation — there's no group to inherit.
+			const messages: StoredAgentMessage[] = [
+				{
+					id: 'msg-u',
+					role: 'user',
+					content: 'Hi',
+					createdAt: makeDate(0),
+				},
+				{
+					id: 'msg-a1',
+					role: 'assistant',
+					content: [{ type: 'text', text: 'Hello' }],
+					createdAt: makeDate(1),
+				},
+				{
+					id: 'msg-a2',
+					role: 'assistant',
+					content: [{ type: 'text', text: 'World' }],
+					createdAt: makeDate(2),
+				},
+			];
+
+			const result = parseStoredMessages(messages);
+
+			expect(result).toHaveLength(3);
+			expect(result[1].messageGroupId).toBeUndefined();
+			expect(result[2].messageGroupId).toBeUndefined();
+		});
+
+		it('does not propagate group ids across separate turns', () => {
+			// Turn 1 has a paired snapshot; turn 2 has no snapshot. The turn-2
+			// assistant rows must NOT inherit turn-1's group id.
+			const turn1Tree = makeSnapshotTree('Turn 1 result');
+			const messages: StoredAgentMessage[] = [
+				{ id: 'msg-u1', role: 'user', content: 'First', createdAt: makeDate(0) },
+				{
+					id: 'msg-a1',
+					role: 'assistant',
+					content: [{ type: 'text', text: 'Turn 1 result' }],
+					createdAt: makeDate(1),
+				},
+				{ id: 'msg-u2', role: 'user', content: 'Second', createdAt: makeDate(2) },
+				{
+					id: 'msg-a2',
+					role: 'assistant',
+					content: [{ type: 'text', text: 'Turn 2 result' }],
+					createdAt: makeDate(3),
+				},
+			];
+
+			const result = parseStoredMessages(messages, [
+				{
+					tree: turn1Tree,
+					runId: 'run_turn1',
+					messageGroupId: 'mg_turn1',
+					createdAt: makeDate(1),
+					updatedAt: makeDate(1),
+				},
+			]);
+
+			expect(result).toHaveLength(4);
+			expect(result[1]).toMatchObject({ id: 'msg-a1', messageGroupId: 'mg_turn1' });
+			expect(result[3]).toMatchObject({ id: 'msg-a2' });
+			expect(result[3].messageGroupId).toBeUndefined();
+		});
+	});
+
 	describe('edge cases', () => {
 		it('should handle empty message list', () => {
 			const result = parseStoredMessages([]);

--- a/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-memory.service.ts
@@ -21,7 +21,32 @@ import { DbSnapshotStorage } from './storage/db-snapshot-storage';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
 import { parseStoredMessages } from './message-parser';
+import { InstanceAiCheckpointRepository } from './repositories/instance-ai-checkpoint.repository';
 import { TypeORMAgentMemory } from './storage/typeorm-agent-memory';
+
+function isAgentMessageLike(value: unknown): value is AgentDbMessage {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		typeof (value as { id?: unknown }).id === 'string' &&
+		'role' in value
+	);
+}
+
+function messageCreatedAtMs(message: AgentDbMessage): number {
+	const at = message.createdAt;
+	if (at instanceof Date) return at.getTime();
+	const parsed = new Date(at).getTime();
+	return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function mergeMessagesById(stored: AgentDbMessage[], extras: AgentDbMessage[]): AgentDbMessage[] {
+	if (extras.length === 0) return stored;
+	const byId = new Map<string, AgentDbMessage>();
+	for (const message of stored) byId.set(message.id, message);
+	for (const message of extras) if (!byId.has(message.id)) byId.set(message.id, message);
+	return [...byId.values()].sort((a, b) => messageCreatedAtMs(a) - messageCreatedAtMs(b));
+}
 
 @Service()
 export class InstanceAiMemoryService {
@@ -32,6 +57,7 @@ export class InstanceAiMemoryService {
 		globalConfig: GlobalConfig,
 		private readonly agentMemory: TypeORMAgentMemory,
 		private readonly dbSnapshotStorage: DbSnapshotStorage,
+		private readonly checkpointRepository: InstanceAiCheckpointRepository,
 	) {
 		this.instanceAiConfig = globalConfig.instanceAi;
 	}
@@ -123,9 +149,49 @@ export class InstanceAiMemoryService {
 			snapshots = snapshots.filter((s) => !excluded.has(s.runId));
 		}
 
-		const messages = parseStoredMessages(result.messages, snapshots);
+		// Surface the in-flight messages from any suspended checkpoint. The
+		// SDK only commits messages to memory after a successful turn, so
+		// during HITL suspension the user's prompt and intermediate assistant
+		// responses live only inside the checkpoint blob. Without merging
+		// them in, a thread that's waiting on a confirmation renders without
+		// the original user message after a page reload.
+		const checkpointMessages = await this.loadInFlightCheckpointMessages(threadId);
+		const storedMessages = mergeMessagesById(result.messages, checkpointMessages);
+
+		const messages = parseStoredMessages(storedMessages, snapshots);
 
 		return { threadId, messages };
+	}
+
+	private async loadInFlightCheckpointMessages(threadId: string): Promise<AgentDbMessage[]> {
+		let checkpoints;
+		try {
+			checkpoints = await this.checkpointRepository.findActiveByThreadId(threadId);
+		} catch (error) {
+			this.logger.warn('Failed to load in-flight checkpoint messages', {
+				threadId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return [];
+		}
+
+		const merged: AgentDbMessage[] = [];
+		const seen = new Set<string>();
+		for (const checkpoint of checkpoints) {
+			const stateMessages = checkpoint.state?.messageList?.messages ?? [];
+			for (const candidate of stateMessages) {
+				if (!isAgentMessageLike(candidate) || seen.has(candidate.id)) continue;
+				seen.add(candidate.id);
+				merged.push({
+					...candidate,
+					createdAt:
+						candidate.createdAt instanceof Date
+							? candidate.createdAt
+							: new Date(candidate.createdAt),
+				});
+			}
+		}
+		return merged;
 	}
 
 	async getLatestRunSnapshot(

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -1514,6 +1514,13 @@ export class InstanceAiService {
 			this.threadPushRef.set(threadId, pushRef);
 		}
 
+		// Stable id for the user-typed message. Coordinated with the SDK's
+		// end-of-turn save (see executeRun's streamInput construction) so we
+		// end up with exactly one user-message row per turn — and so a save
+		// triggered by `waitForConfirmation` on a suspended HITL turn uses the
+		// same id the SDK would have used for completion.
+		const userMessageId = nanoid();
+
 		this.trackInFlightExecution(
 			this.executeRun(
 				user,
@@ -1524,6 +1531,10 @@ export class InstanceAiService {
 				attachments,
 				messageGroupId,
 				timeZone,
+				false,
+				undefined,
+				undefined,
+				{ id: userMessageId, text: message },
 			),
 		);
 
@@ -2209,6 +2220,41 @@ export class InstanceAiService {
 	}
 
 	/**
+	 * Persist the original user-typed message to thread memory the first time
+	 * a run hits an inline HITL confirmation, so the message bubble survives
+	 * a restart that happens while the run is suspended. The `id` matches the
+	 * one we pass to the SDK's streamInput, so the SDK's eventual end-of-turn
+	 * save (if the run does resume and complete) upserts the same row instead
+	 * of creating a duplicate.
+	 */
+	private async persistUserMessageOnSuspend(
+		threadId: string,
+		userId: string,
+		message: { id: string; text: string },
+	): Promise<void> {
+		try {
+			await this.agentMemory.saveMessages({
+				threadId,
+				resourceId: userId,
+				messages: [
+					{
+						id: message.id,
+						role: 'user',
+						content: [{ type: 'text', text: message.text }],
+						createdAt: new Date(),
+					},
+				],
+			});
+		} catch (error: unknown) {
+			this.logger.warn('Failed to persist user message on HITL suspend', {
+				threadId,
+				userId,
+				error: getErrorMessage(error),
+			});
+		}
+	}
+
+	/**
 	 * Save the in-flight agent tree as a terminal snapshot so the UI doesn't
 	 * sit on a half-rendered turn after the process restarts. Best-effort: a
 	 * DB write failure here must not block the rest of shutdown.
@@ -2748,7 +2794,12 @@ export class InstanceAiService {
 		abortSignal: AbortSignal,
 		messageGroupId?: string,
 		pushRef?: string,
+		userMessagePersistence?: { id: string; text: string },
 	) {
+		// Closure flag so `waitForConfirmation` only writes the user-message
+		// row once even if the run hits multiple HITL points (planner
+		// submit-plan + a later sub-agent ask-user, say).
+		let userMessageSaved = false;
 		const adminSettings = this.settingsService.getAdminSettings();
 		const localGatewayDisabledGlobally = adminSettings.localGatewayDisabled;
 		const localGatewayDisabledForUser = await this.settingsService.isLocalGatewayDisabledForUser(
@@ -2914,6 +2965,17 @@ export class InstanceAiService {
 			formBaseUrl: this.formBaseUrl,
 			waitForConfirmation: async (requestId: string) => {
 				this.runState.touchActiveRun(threadId);
+				// First HITL on this run: persist the original user message to
+				// memory so it survives a restart-while-suspended. The SDK only
+				// commits the turn delta on a clean loop completion, and inline
+				// HITL never reaches that point. Doing this *now* (rather than
+				// at executeRun start) avoids polluting the agent's prompt —
+				// the SDK has already loaded its memory snapshot for this run.
+				if (!userMessageSaved && userMessagePersistence) {
+					userMessageSaved = true;
+					void this.persistUserMessageOnSuspend(threadId, user.id, userMessagePersistence);
+				}
+
 				return await new Promise<ConfirmationData>((resolve) => {
 					this.runState.registerPendingConfirmation(requestId, {
 						resolve,
@@ -3315,6 +3377,7 @@ export class InstanceAiService {
 		isReplanFollowUp: boolean = false,
 		checkpoint?: { isCheckpointFollowUp: true; checkpointTaskId: string },
 		resumeReason?: OrchestratorResumeReason,
+		userMessagePersistence?: { id: string; text: string },
 	): Promise<void> {
 		const signal = abortController.signal;
 		let tracing: InstanceAiTraceContext | undefined;
@@ -3360,6 +3423,7 @@ export class InstanceAiService {
 				signal,
 				messageGroupId,
 				executionPushRef,
+				userMessagePersistence,
 			);
 			activeSnapshotStorage = environment.snapshotStorage;
 			const { context, memory, taskStorage, snapshotStorage, modelId, orchestrationContext } =
@@ -3508,19 +3572,25 @@ export class InstanceAiService {
 				: undefined;
 			let streamInput: string | Message[];
 			try {
-				// Only include non-structured attachments as raw multimodal content
-				if (nonStructuredAttachments.length > 0) {
+				// When this is a user-initiated turn, build the input as an
+				// explicit message object carrying our chosen id. The SDK
+				// preserves the id on its end-of-turn save so the row matches
+				// any user-message row we may have written from inside
+				// `waitForConfirmation`.
+				if (nonStructuredAttachments.length > 0 || userMessagePersistence) {
+					const baseContent = [
+						{ type: 'text' as const, text: fullMessage },
+						...nonStructuredAttachments.map((attachment) => ({
+							type: 'file' as const,
+							data: attachment.data,
+							mediaType: attachment.mimeType,
+						})),
+					];
 					streamInput = [
 						{
+							...(userMessagePersistence ? { id: userMessagePersistence.id } : {}),
 							role: 'user' as const,
-							content: [
-								{ type: 'text' as const, text: fullMessage },
-								...nonStructuredAttachments.map((attachment) => ({
-									type: 'file' as const,
-									data: attachment.data,
-									mediaType: attachment.mimeType,
-								})),
-							],
+							content: baseContent,
 						},
 					];
 				} else {

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -134,6 +134,14 @@ function isTelemetryConfigurableAgent(
 
 const INSTANCE_AI_CHECKPOINT_PRUNE_RETRY_MS = 30 * 1000;
 
+/**
+ * Upper bound on how long `shutdown()` will wait for in-flight executeRun /
+ * processResumedStream promises to drain after their abortControllers fire.
+ * Sized well below n8n's `gracefulShutdownTimeoutInS` (30s default) so a
+ * stuck agent can't burn the whole budget here.
+ */
+const INSTANCE_AI_SHUTDOWN_DRAIN_TIMEOUT_MS = 5 * 1000;
+
 function isTextMessagePart(part: unknown): part is { type: 'text'; text: string } {
 	return (
 		typeof part === 'object' &&
@@ -310,6 +318,15 @@ function createInertAbortSignal(): AbortSignal {
 	return new AbortController().signal;
 }
 
+/**
+ * Sentinel passed to `abortController.abort(reason)` when shutting down a
+ * thread that is waiting on an inline HITL confirmation. The catch handler
+ * in `executeRun` checks for it and skips the terminal-fallback /
+ * run-finish / snapshot writes so the plan/ask card stays intact on reload.
+ * See InstanceAiService.shutdown for the producer side.
+ */
+const INSTANCE_AI_SHUTDOWN_PRESERVE_HITL = 'service_shutdown_preserve_hitl';
+
 function getAbortReason(signal: AbortSignal): string {
 	const reason = (signal as AbortSignal & { reason?: unknown }).reason;
 	if (
@@ -322,6 +339,12 @@ function getAbortReason(signal: AbortSignal): string {
 	}
 	if (reason instanceof Error) return reason.message;
 	return typeof reason === 'string' ? reason : 'user_cancelled';
+}
+
+function isShutdownPreserveHitlAbort(signal: AbortSignal): boolean {
+	return (
+		(signal as AbortSignal & { reason?: unknown }).reason === INSTANCE_AI_SHUTDOWN_PRESERVE_HITL
+	);
 }
 
 // Stable UUID namespace for deterministic feedback IDs. Submitting the same
@@ -554,6 +577,15 @@ export class InstanceAiService {
 	private checkpointPruneTimer: NodeJS.Timeout | undefined;
 
 	private checkpointPruningStopped = true;
+
+	/**
+	 * In-flight `executeRun` / `processResumedStream` promises. Tracked so
+	 * `shutdown()` can drain them before n8n closes the DB connection — the
+	 * SDK's abort-driven `cleanupRun` and `executeRun`'s `finally` block
+	 * both write to the DB during teardown, and racing the connection close
+	 * surfaces as `DriverAlreadyReleasedError` for callers.
+	 */
+	private readonly inFlightExecutions = new Set<Promise<unknown>>();
 
 	constructor(
 		logger: Logger,
@@ -1482,15 +1514,17 @@ export class InstanceAiService {
 			this.threadPushRef.set(threadId, pushRef);
 		}
 
-		void this.executeRun(
-			user,
-			threadId,
-			runId,
-			message,
-			abortController,
-			attachments,
-			messageGroupId,
-			timeZone,
+		this.trackInFlightExecution(
+			this.executeRun(
+				user,
+				threadId,
+				runId,
+				message,
+				abortController,
+				attachments,
+				messageGroupId,
+				timeZone,
+			),
 		);
 
 		return runId;
@@ -1914,12 +1948,38 @@ export class InstanceAiService {
 		this.stopCheckpointPruning();
 		this.liveness.shutdown();
 
-		const { activeRuns, suspendedRuns } = this.runState.shutdown();
+		const { activeRuns, suspendedRuns, pendingThreadIds } = this.runState.shutdown();
+		const threadsWithPendingHitl = new Set(pendingThreadIds);
 		for (const run of activeRuns) {
-			// Publish run-finish first so the terminal event lands in the event
-			// bus before the snapshot reads it; saveAgentTreeSnapshot rebuilds
-			// the tree from the bus, so without this order the persisted tree
-			// would still look mid-stream after the process is gone.
+			// Runs holding an inline HITL confirmation (planner `submit-plan`,
+			// sub-agent `ask-user`) sit in `activeRuns` because the orchestrator
+			// is alive — it's just awaiting the in-process Promise. Their
+			// `instance_ai_pending_confirmations` row survives the restart and
+			// `handleOrphanedConfirmation` will issue the user-visible
+			// `restart_lost_confirmation` UserError + `run-finish` when (if)
+			// the user clicks confirm. If we publish run-finish + re-save the
+			// snapshot here, we'd permanently overwrite the plan/ask card with
+			// a `status: 'cancelled'` tree before the user has a chance to see
+			// it on reload.
+			if (threadsWithPendingHitl.has(run.threadId)) {
+				await this.finalizeRunTracing(run.runId, run.tracing, {
+					status: 'cancelled',
+					reason: 'service_shutdown',
+				});
+				// Abort with a sentinel reason so executeRun's catch handler
+				// recognises this as a "shut down preserving the HITL card"
+				// signal and skips its terminal-fallback / run-finish / snapshot
+				// writes. A plain abort() would otherwise overwrite the plan/ask
+				// snapshot with a cancelled tree before the process exits.
+				run.abortController.abort(INSTANCE_AI_SHUTDOWN_PRESERVE_HITL);
+				continue;
+			}
+
+			// Truly mid-stream run: publish run-finish first so the terminal
+			// event lands in the event bus before the snapshot reads it;
+			// saveAgentTreeSnapshot rebuilds the tree from the bus, so without
+			// this order the persisted tree would still look mid-stream after
+			// the process is gone.
 			this.publishRunFinish(run.threadId, run.runId, 'cancelled', 'service_shutdown');
 			await this.persistShutdownSnapshot(run.threadId, run.runId, run.messageGroupId);
 			await this.finalizeRunTracing(run.runId, run.tracing, {
@@ -1943,6 +2003,16 @@ export class InstanceAiService {
 			task.abortController.abort();
 			await this.finalizeBackgroundTaskTracing(task, 'cancelled');
 		}
+
+		// Drain the now-aborted executeRun / processResumedStream promises
+		// before returning. Each one's finally block does DB work
+		// (`schedulePlannedTasks`, `dropPendingConfirmationsForThread`) and
+		// the SDK's abort-driven `cleanupRun` issues `checkpointStore.delete`,
+		// all of which would race the connection close in `exitSuccessFully`
+		// and surface as `DriverAlreadyReleasedError` otherwise. Bounded so
+		// a hung agent can't block n8n's own graceful-shutdown deadline.
+		await this.drainInFlightExecutions(INSTANCE_AI_SHUTDOWN_DRAIN_TIMEOUT_MS);
+
 		const threadsWithTraces = new Set(
 			[...this.traceContextsByRunId.values()].map((entry) => entry.threadId),
 		);
@@ -1990,6 +2060,36 @@ export class InstanceAiService {
 			void this.pruneStaleCheckpoints();
 		}, delayMs);
 		this.checkpointPruneTimer.unref();
+	}
+
+	/**
+	 * Track a fire-and-forget run so `shutdown()` can wait for its cleanup
+	 * (finally block + SDK `cleanupRun`) to finish before the DB closes.
+	 * The promise removes itself from the set on settle so the set doesn't
+	 * grow unbounded across long-running threads.
+	 */
+	private trackInFlightExecution(promise: Promise<unknown>): void {
+		const tracked = promise.finally(() => {
+			this.inFlightExecutions.delete(tracked);
+		});
+		this.inFlightExecutions.add(tracked);
+	}
+
+	private async drainInFlightExecutions(timeoutMs: number): Promise<void> {
+		if (this.inFlightExecutions.size === 0) return;
+
+		const drain = Promise.allSettled([...this.inFlightExecutions]);
+		const timeout = new Promise<'timeout'>((resolve) => {
+			setTimeout(() => resolve('timeout'), timeoutMs).unref();
+		});
+
+		const outcome = await Promise.race([drain.then(() => 'drained' as const), timeout]);
+		if (outcome === 'timeout') {
+			this.logger.warn('Timed out waiting for in-flight Instance AI runs to drain', {
+				timeoutMs,
+				stillInFlight: this.inFlightExecutions.size,
+			});
+		}
 	}
 
 	private async pruneStaleCheckpoints(now = Date.now()): Promise<void> {
@@ -3041,18 +3141,20 @@ export class InstanceAiService {
 				? 'replan'
 				: 'background_task_completed';
 
-		void this.executeRun(
-			user,
-			threadId,
-			runId,
-			message,
-			abortController,
-			undefined,
-			messageGroupId,
-			timeZone,
-			isReplanFollowUp,
-			checkpoint,
-			resumeReason,
+		this.trackInFlightExecution(
+			this.executeRun(
+				user,
+				threadId,
+				runId,
+				message,
+				abortController,
+				undefined,
+				messageGroupId,
+				timeZone,
+				isReplanFollowUp,
+				checkpoint,
+				resumeReason,
+			),
 		);
 
 		return runId;
@@ -3639,6 +3741,16 @@ export class InstanceAiService {
 				return;
 			}
 
+			// `streamAgentRun` doesn't throw on abort — it returns
+			// `status: 'cancelled'`. When the abort came from shutdown's
+			// preserve-HITL path, falling through into the normal terminal
+			// handling would still call `evaluateTerminalResponse` and
+			// `finalizeRun`, both of which rewrite the snapshot. Bail out
+			// before either fires so the plan/ask card stays on disk.
+			if (result.status === 'cancelled' && isShutdownPreserveHitlAbort(signal)) {
+				return;
+			}
+
 			const outputText = await (result.text ?? Promise.resolve(''));
 			this.evaluateTerminalResponse(threadId, runId, result.status, {
 				messageGroupId,
@@ -3681,6 +3793,15 @@ export class InstanceAiService {
 			}
 		} catch (error) {
 			if (signal.aborted) {
+				// Shutdown asked us to preserve the HITL card on disk: the
+				// service has already finalised tracing and the per-run DB
+				// rows (pending_confirmation, snapshot) are the durable
+				// signal. Emitting the terminal-fallback text + run-finish
+				// here would clobber the plan/ask snapshot the user expects
+				// to see on reload, so just bail out.
+				if (isShutdownPreserveHitlAbort(signal)) {
+					return;
+				}
 				const runTimeout = this.liveness.consumeRunTimeout(runId);
 				const cancellationReason = runTimeout.timedOut
 					? INSTANCE_AI_RUN_TIMEOUT_REASON
@@ -4066,7 +4187,7 @@ export class InstanceAiService {
 
 		this.finalizeUnresumableOrphan(orphan);
 		throw new UserError(
-			'This confirmation was lost when the assistant restarted. Please refresh the page and start a new turn.',
+			'This confirmation was lost when the assistant restarted. Send a new message to continue.',
 		);
 	}
 
@@ -4083,19 +4204,29 @@ export class InstanceAiService {
 		orphan: NonNullable<Awaited<ReturnType<typeof this.pendingConfirmationRepo.claim>>>,
 	): void {
 		try {
+			// Live SSE clients use this to drop their interactive card.
 			this.publishRunFinish(
 				orphan.threadId,
 				orphan.runId,
 				'cancelled',
 				'restart_lost_confirmation',
 			);
-			void this.saveAgentTreeSnapshot(
-				orphan.threadId,
-				orphan.runId,
-				this.dbSnapshotStorage,
-				true,
-				orphan.messageGroupId ?? undefined,
-			);
+			// Terminalise the existing snapshot in place instead of rebuilding
+			// the tree from the in-memory event bus. After a restart the bus
+			// only carries the run-finish we just emitted, so a rebuild would
+			// replace the saved plan/ask card with an empty cancelled tree;
+			// `markRunCancelled` keeps the plan content intact while flipping
+			// all in-flight nodes and confirmation buttons off.
+			void this.dbSnapshotStorage
+				.markRunCancelled(orphan.threadId, orphan.runId)
+				.catch((error: unknown) => {
+					this.logger.warn('Failed to mark orphan snapshot as cancelled', {
+						requestId: orphan.requestId,
+						threadId: orphan.threadId,
+						runId: orphan.runId,
+						error: getErrorMessage(error),
+					});
+				});
 		} catch (error: unknown) {
 			this.logger.warn('Failed to finalize orphaned confirmation snapshot', {
 				requestId: orphan.requestId,
@@ -4327,19 +4458,21 @@ export class InstanceAiService {
 			},
 		});
 
-		void this.processResumedStream(agent, resumeData, {
-			runId,
-			agentRunId,
-			threadId,
-			user: activeUser,
-			toolCallId,
-			signal: abortController.signal,
-			abortController,
-			snapshotStorage: this.dbSnapshotStorage,
-			tracing: resumeTracing ?? tracing,
-			modelId,
-			checkpoint,
-		});
+		this.trackInFlightExecution(
+			this.processResumedStream(agent, resumeData, {
+				runId,
+				agentRunId,
+				threadId,
+				user: activeUser,
+				toolCallId,
+				signal: abortController.signal,
+				abortController,
+				snapshotStorage: this.dbSnapshotStorage,
+				tracing: resumeTracing ?? tracing,
+				modelId,
+				checkpoint,
+			}),
+		);
 		return true;
 	}
 
@@ -4533,6 +4666,10 @@ export class InstanceAiService {
 				return;
 			}
 
+			if (result.status === 'cancelled' && isShutdownPreserveHitlAbort(opts.signal)) {
+				return;
+			}
+
 			const outputText = await (result.text ?? Promise.resolve(''));
 			const messageGroupId = this.traceContextsByRunId.get(opts.runId)?.messageGroupId;
 			this.evaluateTerminalResponse(opts.threadId, opts.runId, result.status, {
@@ -4572,6 +4709,9 @@ export class InstanceAiService {
 			}
 		} catch (error) {
 			if (opts.signal.aborted) {
+				if (isShutdownPreserveHitlAbort(opts.signal)) {
+					return;
+				}
 				const messageGroupId = this.traceContextsByRunId.get(opts.runId)?.messageGroupId;
 				const runTimeout = this.liveness.consumeRunTimeout(opts.runId);
 				const cancellationReason = runTimeout.timedOut

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -109,6 +109,7 @@ import { DbIterationLogStorage } from './storage/db-iteration-log-storage';
 import { TypeORMAgentCheckpointStore } from './storage/typeorm-agent-checkpoint-store';
 import { TypeORMAgentMemory } from './storage/typeorm-agent-memory';
 import { ProxyTokenManager } from '@/services/proxy-token-manager';
+import { InstanceAiPendingConfirmationRepository } from './repositories/instance-ai-pending-confirmation.repository';
 import { InstanceAiThreadRepository } from './repositories/instance-ai-thread.repository';
 import { TraceReplayState } from './trace-replay-state';
 import { INSTANCE_AI_RUN_TIMEOUT_REASON, InstanceAiLivenessService } from './liveness';
@@ -566,6 +567,7 @@ export class InstanceAiService {
 		private readonly aiService: AiService,
 		private readonly push: Push,
 		private readonly threadRepo: InstanceAiThreadRepository,
+		private readonly pendingConfirmationRepo: InstanceAiPendingConfirmationRepository,
 		private readonly urlService: UrlService,
 		private readonly dbSnapshotStorage: DbSnapshotStorage,
 		private readonly dbIterationLogStorage: DbIterationLogStorage,
@@ -592,6 +594,9 @@ export class InstanceAiService {
 			logger: this.logger,
 			finalizeCancelledSuspendedRun: (suspended, reason) => {
 				void this.finalizeCancelledSuspendedRun(suspended, reason);
+			},
+			onPendingConfirmationRejected: (requestId) => {
+				void this.dropPendingConfirmation(requestId);
 			},
 		});
 		this.defaultTimeZone = globalConfig.generic.timezone;
@@ -1563,6 +1568,10 @@ export class InstanceAiService {
 		if (active) {
 			if (reason === INSTANCE_AI_RUN_TIMEOUT_REASON) this.liveness.markRunTimedOut(active.runId);
 			active.abortController.abort();
+			// inline-kind rows are dropped via the resolve-callback fired by
+			// runState.cancelThread; suspended-kind rows (no in-memory
+			// resolver) get cleaned up here so the index never outlives the run.
+			void this.dropPendingConfirmationsForThread(threadId);
 			return;
 		}
 
@@ -1571,6 +1580,8 @@ export class InstanceAiService {
 			suspended.abortController.abort();
 			void this.finalizeCancelledSuspendedRun(suspended, reason);
 		}
+
+		void this.dropPendingConfirmationsForThread(threadId);
 	}
 
 	/** Send a correction message to a running background task. */
@@ -1895,6 +1906,7 @@ export class InstanceAiService {
 		this.deleteTraceContextsForThread(threadId);
 		await this.destroySandbox(threadId);
 		await this.reapAiTemporaryForThreadCleanup(threadId);
+		await this.dropPendingConfirmationsForThread(threadId);
 		this.eventBus.clearThread(threadId);
 	}
 
@@ -1904,18 +1916,28 @@ export class InstanceAiService {
 
 		const { activeRuns, suspendedRuns } = this.runState.shutdown();
 		for (const run of activeRuns) {
-			run.abortController.abort();
+			// Publish run-finish first so the terminal event lands in the event
+			// bus before the snapshot reads it; saveAgentTreeSnapshot rebuilds
+			// the tree from the bus, so without this order the persisted tree
+			// would still look mid-stream after the process is gone.
+			this.publishRunFinish(run.threadId, run.runId, 'cancelled', 'service_shutdown');
+			await this.persistShutdownSnapshot(run.threadId, run.runId, run.messageGroupId);
 			await this.finalizeRunTracing(run.runId, run.tracing, {
 				status: 'cancelled',
 				reason: 'service_shutdown',
 			});
+			run.abortController.abort();
 		}
 		for (const run of suspendedRuns) {
-			run.abortController.abort();
+			// Suspended runs are recoverable from the checkpoint store + pending
+			// confirmation index, so leave the run-finish unpublished and the
+			// snapshot untouched. We only need to abort the in-process stream;
+			// the DB rows are intentionally preserved across restart.
 			await this.finalizeRunTracing(run.runId, run.tracing, {
 				status: 'cancelled',
 				reason: 'service_shutdown',
 			});
+			run.abortController.abort();
 		}
 		for (const task of this.backgroundTasks.cancelAll()) {
 			task.abortController.abort();
@@ -1974,18 +1996,142 @@ export class InstanceAiService {
 		const olderThan = new Date(now - this.instanceAiConfig.snapshotRetention);
 
 		try {
-			const count = await this.checkpointStore.deleteOlderThan(olderThan);
+			const count = await this.checkpointStore.markExpiredOlderThan(olderThan);
 			if (count > 0) {
-				this.logger.info('Deleted stale Instance AI checkpoints', { count });
+				this.logger.info('Expired stale Instance AI checkpoints', { count });
 			} else {
-				this.logger.debug('No stale Instance AI checkpoints to delete');
+				this.logger.debug('No stale Instance AI checkpoints to expire');
 			}
+			await this.pruneStalePendingConfirmations(now);
 			this.scheduleCheckpointPrune();
 		} catch (error: unknown) {
-			this.logger.warn('Failed to delete stale Instance AI checkpoints', {
+			this.logger.warn('Failed to expire stale Instance AI checkpoints', {
 				error: getErrorMessage(error),
 			});
 			this.scheduleCheckpointPrune(INSTANCE_AI_CHECKPOINT_PRUNE_RETRY_MS);
+		}
+	}
+
+	private async pruneStalePendingConfirmations(now: number): Promise<void> {
+		try {
+			const expired = await this.pendingConfirmationRepo.findExpired(new Date(now));
+			if (expired.length === 0) {
+				this.logger.debug('No stale Instance AI pending confirmations to drop');
+				return;
+			}
+			for (const row of expired) {
+				try {
+					await this.pendingConfirmationRepo.deleteByRequestId(row.requestId);
+				} catch (error: unknown) {
+					this.logger.warn('Failed to drop expired pending confirmation', {
+						requestId: row.requestId,
+						error: getErrorMessage(error),
+					});
+				}
+			}
+			this.logger.info('Dropped stale Instance AI pending confirmations', {
+				count: expired.length,
+			});
+		} catch (error: unknown) {
+			this.logger.warn('Failed to scan stale Instance AI pending confirmations', {
+				error: getErrorMessage(error),
+			});
+		}
+	}
+
+	private computePendingConfirmationExpiresAt(): Date | null {
+		const timeoutMs = this.instanceAiConfig.confirmationTimeout;
+		return timeoutMs > 0 ? new Date(Date.now() + timeoutMs) : null;
+	}
+
+	/**
+	 * Persist the index for a HITL confirmation so a fresh process can find it
+	 * after the in-memory `pendingConfirmations` / `suspendedRuns` maps are gone.
+	 * Fire-and-forget: a DB write failure must not block the agent flow, which
+	 * still operates correctly via the in-memory state on this main.
+	 */
+	private async persistPendingConfirmation(params: {
+		requestId: string;
+		threadId: string;
+		userId: string;
+		runId: string;
+		messageGroupId?: string;
+		kind: 'inline' | 'suspended';
+		toolCallId?: string;
+		checkpointKey?: string;
+		checkpointTaskId?: string;
+	}): Promise<void> {
+		try {
+			await this.pendingConfirmationRepo.save(
+				this.pendingConfirmationRepo.create({
+					requestId: params.requestId,
+					threadId: params.threadId,
+					userId: params.userId,
+					kind: params.kind,
+					runId: params.runId,
+					messageGroupId: params.messageGroupId ?? null,
+					toolCallId: params.toolCallId ?? null,
+					checkpointKey: params.checkpointKey ?? null,
+					checkpointTaskId: params.checkpointTaskId ?? null,
+					expiresAt: this.computePendingConfirmationExpiresAt(),
+				}),
+			);
+		} catch (error: unknown) {
+			this.logger.warn('Failed to persist pending confirmation', {
+				requestId: params.requestId,
+				threadId: params.threadId,
+				kind: params.kind,
+				error: getErrorMessage(error),
+			});
+		}
+	}
+
+	private async dropPendingConfirmation(requestId: string): Promise<void> {
+		try {
+			await this.pendingConfirmationRepo.deleteByRequestId(requestId);
+		} catch (error: unknown) {
+			this.logger.warn('Failed to drop pending confirmation', {
+				requestId,
+				error: getErrorMessage(error),
+			});
+		}
+	}
+
+	private async dropPendingConfirmationsForThread(threadId: string): Promise<void> {
+		try {
+			await this.pendingConfirmationRepo.deleteByThreadId(threadId);
+		} catch (error: unknown) {
+			this.logger.warn('Failed to drop pending confirmations for thread', {
+				threadId,
+				error: getErrorMessage(error),
+			});
+		}
+	}
+
+	/**
+	 * Save the in-flight agent tree as a terminal snapshot so the UI doesn't
+	 * sit on a half-rendered turn after the process restarts. Best-effort: a
+	 * DB write failure here must not block the rest of shutdown.
+	 */
+	private async persistShutdownSnapshot(
+		threadId: string,
+		runId: string,
+		messageGroupId: string | undefined,
+	): Promise<void> {
+		try {
+			await this.saveAgentTreeSnapshot(
+				threadId,
+				runId,
+				this.dbSnapshotStorage,
+				true,
+				messageGroupId,
+			);
+		} catch (error: unknown) {
+			this.logger.warn('Failed to persist shutdown snapshot', {
+				threadId,
+				runId,
+				error: getErrorMessage(error),
+			});
 		}
 	}
 
@@ -2201,6 +2347,7 @@ export class InstanceAiService {
 		tracing?: InstanceAiTraceContext;
 	}): Promise<MessageTraceFinalization> {
 		this.runState.cancelThread(args.threadId);
+		void this.dropPendingConfirmationsForThread(args.threadId);
 		args.abortController.abort();
 		await this.finalizeRunTracing(args.runId, args.tracing, {
 			status: 'error',
@@ -2673,6 +2820,15 @@ export class InstanceAiService {
 						threadId,
 						userId: user.id,
 						createdAt: Date.now(),
+					});
+
+					void this.persistPendingConfirmation({
+						requestId,
+						threadId,
+						userId: user.id,
+						runId,
+						messageGroupId,
+						kind: 'inline',
 					});
 
 					// Inline HITL (planner questions / plan approval / sub-agent asks)
@@ -3390,6 +3546,17 @@ export class InstanceAiService {
 						modelId,
 						checkpoint,
 					});
+					void this.persistPendingConfirmation({
+						requestId: result.suspension.requestId,
+						threadId,
+						userId: user.id,
+						runId,
+						messageGroupId,
+						kind: 'suspended',
+						toolCallId: result.suspension.toolCallId,
+						checkpointKey: result.agentRunId,
+						checkpointTaskId: checkpoint?.checkpointTaskId,
+					});
 				}
 
 				// Track intermediate message (text streamed before suspension)
@@ -3840,6 +4007,7 @@ export class InstanceAiService {
 		}
 
 		if (this.runState.resolvePendingConfirmation(freshUser.id, requestId, data)) {
+			void this.dropPendingConfirmation(requestId);
 			this.logger.debug('Resolved pending confirmation (sub-agent HITL)', {
 				requestId,
 				approved: data.approved,
@@ -3852,7 +4020,61 @@ export class InstanceAiService {
 			approved: data.approved,
 		});
 
-		return await this.resumeSuspendedRun(requestingUserId, requestId, data);
+		if (await this.resumeSuspendedRun(requestingUserId, requestId, data)) {
+			return true;
+		}
+
+		// Last resort: the in-memory state is gone, but a persisted index row
+		// may still exist from before a process restart. Surface that as a
+		// clear UserError to the client instead of an opaque 404.
+		await this.handleOrphanedConfirmation(requestingUserId, requestId);
+		return false;
+	}
+
+	private async handleOrphanedConfirmation(userId: string, requestId: string): Promise<void> {
+		let orphan;
+		try {
+			orphan = await this.pendingConfirmationRepo.claim(requestId, userId);
+		} catch (error: unknown) {
+			this.logger.warn('Failed to claim orphaned pending confirmation', {
+				requestId,
+				error: getErrorMessage(error),
+			});
+			return;
+		}
+		if (!orphan) return;
+
+		this.logger.warn('Pending confirmation orphaned by a process restart', {
+			requestId,
+			threadId: orphan.threadId,
+			runId: orphan.runId,
+			kind: orphan.kind,
+		});
+
+		try {
+			this.publishRunFinish(
+				orphan.threadId,
+				orphan.runId,
+				'cancelled',
+				'restart_lost_confirmation',
+			);
+			await this.saveAgentTreeSnapshot(
+				orphan.threadId,
+				orphan.runId,
+				this.dbSnapshotStorage,
+				true,
+				orphan.messageGroupId ?? undefined,
+			);
+		} catch (error: unknown) {
+			this.logger.warn('Failed to finalize orphaned confirmation snapshot', {
+				requestId,
+				error: getErrorMessage(error),
+			});
+		}
+
+		throw new UserError(
+			'This confirmation was lost when the assistant restarted. Please refresh the page and start a new turn.',
+		);
 	}
 
 	private async revalidateActiveUser(userId: string): Promise<User | null> {
@@ -3915,6 +4137,13 @@ export class InstanceAiService {
 		}
 
 		this.runState.activateSuspendedRun(threadId);
+
+		// The in-memory `suspendedRuns` map carries no resolver callback, so
+		// the suspended-kind DB row has to be dropped explicitly here. The
+		// inline-kind drop is wired into the Promise resolver in
+		// `waitForConfirmation` and fires whether the resolution came from the
+		// user, from `cancelThread`, or from a liveness timeout.
+		void this.dropPendingConfirmation(requestId);
 
 		// setup-workflow uses nodeCredentials (per-node) format for its credentials field;
 		// other tools use the flat credentials map. Prefer nodeCredentials when present.
@@ -4055,6 +4284,7 @@ export class InstanceAiService {
 
 			if (result.status === 'suspended') {
 				if (result.suspension) {
+					const resumeMessageGroupId = this.traceContextsByRunId.get(opts.runId)?.messageGroupId;
 					this.runState.suspendRun(opts.threadId, {
 						runId: opts.runId,
 						agentRunId: result.agentRunId,
@@ -4064,11 +4294,22 @@ export class InstanceAiService {
 						toolCallId: result.suspension.toolCallId,
 						requestId: result.suspension.requestId,
 						abortController: opts.abortController,
-						messageGroupId: this.traceContextsByRunId.get(opts.runId)?.messageGroupId,
+						messageGroupId: resumeMessageGroupId,
 						createdAt: Date.now(),
 						tracing: opts.tracing,
 						...(opts.modelId !== undefined ? { modelId: opts.modelId } : {}),
 						checkpoint: opts.checkpoint,
+					});
+					void this.persistPendingConfirmation({
+						requestId: result.suspension.requestId,
+						threadId: opts.threadId,
+						userId: opts.user.id,
+						runId: opts.runId,
+						messageGroupId: resumeMessageGroupId,
+						kind: 'suspended',
+						toolCallId: result.suspension.toolCallId,
+						checkpointKey: result.agentRunId,
+						checkpointTaskId: opts.checkpoint?.checkpointTaskId,
 					});
 				}
 
@@ -4663,6 +4904,8 @@ export class InstanceAiService {
 				...(runTimeout ? { runTimeout } : {}),
 			}),
 		});
+
+		void this.dropPendingConfirmation(suspended.requestId);
 	}
 
 	private async reapAiTemporaryForThreadCleanup(threadId: string): Promise<void> {

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -4025,14 +4025,21 @@ export class InstanceAiService {
 		}
 
 		// Last resort: the in-memory state is gone, but a persisted index row
-		// may still exist from before a process restart. Surface that as a
-		// clear UserError to the client instead of an opaque 404.
-		await this.handleOrphanedConfirmation(requestingUserId, requestId);
-		return false;
+		// may still exist from before a process restart. For `suspended`-kind
+		// rows we try to rebuild the agent from the DB-backed checkpoint and
+		// resume; for `inline`-kind (no checkpoint, just an in-process Promise
+		// that died with the previous process) or any rebuild failure we
+		// publish a terminal `run-finish` and surface a clear UserError so the
+		// client doesn't sit on a stale confirmation card.
+		return await this.resolveOrphanedConfirmation(requestingUserId, requestId, data);
 	}
 
-	private async handleOrphanedConfirmation(userId: string, requestId: string): Promise<void> {
-		let orphan;
+	private async resolveOrphanedConfirmation(
+		userId: string,
+		requestId: string,
+		data: ConfirmationData,
+	): Promise<boolean> {
+		let orphan: Awaited<ReturnType<typeof this.pendingConfirmationRepo.claim>>;
 		try {
 			orphan = await this.pendingConfirmationRepo.claim(requestId, userId);
 		} catch (error: unknown) {
@@ -4040,17 +4047,41 @@ export class InstanceAiService {
 				requestId,
 				error: getErrorMessage(error),
 			});
-			return;
+			return false;
 		}
-		if (!orphan) return;
+		if (!orphan) return false;
 
-		this.logger.warn('Pending confirmation orphaned by a process restart', {
+		this.logger.info('Reclaiming pending confirmation orphaned by a process restart', {
 			requestId,
 			threadId: orphan.threadId,
 			runId: orphan.runId,
 			kind: orphan.kind,
+			hasCheckpoint: Boolean(orphan.checkpointKey),
 		});
 
+		if (orphan.kind === 'suspended' && this.canResumeOrphan(orphan)) {
+			const resumed = await this.tryResumeFromOrphan(orphan, data);
+			if (resumed) return true;
+		}
+
+		this.finalizeUnresumableOrphan(orphan);
+		throw new UserError(
+			'This confirmation was lost when the assistant restarted. Please refresh the page and start a new turn.',
+		);
+	}
+
+	private canResumeOrphan(
+		orphan: NonNullable<Awaited<ReturnType<typeof this.pendingConfirmationRepo.claim>>>,
+	): orphan is typeof orphan & {
+		toolCallId: string;
+		checkpointKey: string;
+	} {
+		return Boolean(orphan.toolCallId && orphan.checkpointKey);
+	}
+
+	private finalizeUnresumableOrphan(
+		orphan: NonNullable<Awaited<ReturnType<typeof this.pendingConfirmationRepo.claim>>>,
+	): void {
 		try {
 			this.publishRunFinish(
 				orphan.threadId,
@@ -4058,7 +4089,7 @@ export class InstanceAiService {
 				'cancelled',
 				'restart_lost_confirmation',
 			);
-			await this.saveAgentTreeSnapshot(
+			void this.saveAgentTreeSnapshot(
 				orphan.threadId,
 				orphan.runId,
 				this.dbSnapshotStorage,
@@ -4067,14 +4098,125 @@ export class InstanceAiService {
 			);
 		} catch (error: unknown) {
 			this.logger.warn('Failed to finalize orphaned confirmation snapshot', {
-				requestId,
+				requestId: orphan.requestId,
 				error: getErrorMessage(error),
 			});
 		}
+	}
 
-		throw new UserError(
-			'This confirmation was lost when the assistant restarted. Please refresh the page and start a new turn.',
-		);
+	/**
+	 * Rebuild the orchestration environment + agent for a checkpoint-backed
+	 * suspended run that survived a process restart, register it as a
+	 * `SuspendedRunState` in the in-memory registry, and hand off to the
+	 * existing `resumeSuspendedRun` path. The original `runId` /
+	 * `messageGroupId` are reused so the frontend's SSE correlation
+	 * (`groupIdByRunId`) keeps working.
+	 */
+	private async tryResumeFromOrphan(
+		orphan: NonNullable<Awaited<ReturnType<typeof this.pendingConfirmationRepo.claim>>> & {
+			toolCallId: string;
+			checkpointKey: string;
+		},
+		data: ConfirmationData,
+	): Promise<boolean> {
+		const user = await this.revalidateActiveUser(orphan.userId);
+		if (!user) {
+			this.logger.warn('Cannot resume orphaned run: user no longer authorized', {
+				requestId: orphan.requestId,
+				userId: orphan.userId,
+			});
+			return false;
+		}
+
+		// Bail early if the checkpoint store doesn't have a usable snapshot —
+		// `load()` throws UserError for expired tombstones and returns
+		// undefined when the row is gone entirely. Either way there's nothing
+		// to resume.
+		try {
+			const state = await this.checkpointStore.load(orphan.checkpointKey);
+			if (!state) {
+				this.logger.warn('Cannot resume orphaned run: checkpoint missing', {
+					requestId: orphan.requestId,
+					checkpointKey: orphan.checkpointKey,
+				});
+				return false;
+			}
+		} catch (error: unknown) {
+			this.logger.warn('Cannot resume orphaned run: checkpoint unavailable', {
+				requestId: orphan.requestId,
+				checkpointKey: orphan.checkpointKey,
+				error: getErrorMessage(error),
+			});
+			return false;
+		}
+
+		const abortController = new AbortController();
+		let environment;
+		try {
+			environment = await this.createExecutionEnvironment(
+				user,
+				orphan.threadId,
+				orphan.runId,
+				abortController.signal,
+				orphan.messageGroupId ?? undefined,
+				this.threadPushRef.get(orphan.threadId),
+			);
+		} catch (error: unknown) {
+			this.logger.warn('Cannot resume orphaned run: failed to build execution environment', {
+				requestId: orphan.requestId,
+				threadId: orphan.threadId,
+				error: getErrorMessage(error),
+			});
+			return false;
+		}
+
+		const mcpServers = this.parseMcpServers(this.instanceAiConfig.mcpServers);
+		let agent;
+		try {
+			agent = await createInstanceAgent({
+				modelId: environment.modelId,
+				context: environment.context,
+				orchestrationContext: environment.orchestrationContext,
+				mcpServers,
+				mcpManager: this.mcpClientManager,
+				memoryConfig: this.createAgentMemoryOptions(),
+				memory: environment.memory,
+				checkpointStore: this.checkpointStore,
+				timeZone: this.runState.getTimeZone(orphan.threadId) ?? this.defaultTimeZone,
+			});
+		} catch (error: unknown) {
+			this.logger.warn('Cannot resume orphaned run: failed to build agent', {
+				requestId: orphan.requestId,
+				threadId: orphan.threadId,
+				error: getErrorMessage(error),
+			});
+			return false;
+		}
+
+		// Re-seed the in-memory runState so `resumeSuspendedRun` can find this
+		// confirmation by requestId and the rest of the cancel / liveness /
+		// shutdown paths see the run as live. We deliberately do NOT call
+		// `persistPendingConfirmation` again — the DB row was already
+		// consumed by `claim()` above.
+		this.runState.suspendRun(orphan.threadId, {
+			runId: orphan.runId,
+			agentRunId: orphan.checkpointKey,
+			agent,
+			threadId: orphan.threadId,
+			user,
+			toolCallId: orphan.toolCallId,
+			requestId: orphan.requestId,
+			abortController,
+			messageGroupId: orphan.messageGroupId ?? undefined,
+			createdAt: Date.now(),
+			tracing: undefined,
+			modelId: environment.modelId,
+			checkpoint: orphan.checkpointTaskId
+				? { isCheckpointFollowUp: true, checkpointTaskId: orphan.checkpointTaskId }
+				: undefined,
+		});
+
+		return await this.resumeSuspendedRun(orphan.userId, orphan.requestId, data);
 	}
 
 	private async revalidateActiveUser(userId: string): Promise<User | null> {

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -318,15 +318,6 @@ function createInertAbortSignal(): AbortSignal {
 	return new AbortController().signal;
 }
 
-/**
- * Sentinel passed to `abortController.abort(reason)` when shutting down a
- * thread that is waiting on an inline HITL confirmation. The catch handler
- * in `executeRun` checks for it and skips the terminal-fallback /
- * run-finish / snapshot writes so the plan/ask card stays intact on reload.
- * See InstanceAiService.shutdown for the producer side.
- */
-const INSTANCE_AI_SHUTDOWN_PRESERVE_HITL = 'service_shutdown_preserve_hitl';
-
 function getAbortReason(signal: AbortSignal): string {
 	const reason = (signal as AbortSignal & { reason?: unknown }).reason;
 	if (
@@ -339,12 +330,6 @@ function getAbortReason(signal: AbortSignal): string {
 	}
 	if (reason instanceof Error) return reason.message;
 	return typeof reason === 'string' ? reason : 'user_cancelled';
-}
-
-function isShutdownPreserveHitlAbort(signal: AbortSignal): boolean {
-	return (
-		(signal as AbortSignal & { reason?: unknown }).reason === INSTANCE_AI_SHUTDOWN_PRESERVE_HITL
-	);
 }
 
 // Stable UUID namespace for deterministic feedback IDs. Submitting the same
@@ -586,6 +571,13 @@ export class InstanceAiService {
 	 * surfaces as `DriverAlreadyReleasedError` for callers.
 	 */
 	private readonly inFlightExecutions = new Set<Promise<unknown>>();
+
+	/**
+	 * Run IDs whose post-stream terminal handling should be skipped when their
+	 * abort fires. Populated by `shutdown()` for runs that were sitting on an
+	 * inline HITL confirmation, and drained by `shouldPreserveHitlOnShutdown(runId)`.
+	 */
+	private readonly preserveHitlOnShutdown = new Set<string>();
 
 	constructor(
 		logger: Logger,
@@ -1977,12 +1969,13 @@ export class InstanceAiService {
 					status: 'cancelled',
 					reason: 'service_shutdown',
 				});
-				// Abort with a sentinel reason so executeRun's catch handler
-				// recognises this as a "shut down preserving the HITL card"
-				// signal and skips its terminal-fallback / run-finish / snapshot
-				// writes. A plain abort() would otherwise overwrite the plan/ask
-				// snapshot with a cancelled tree before the process exits.
-				run.abortController.abort(INSTANCE_AI_SHUTDOWN_PRESERVE_HITL);
+				// Record the policy *before* the abort fires so the run's catch
+				// handler (which runs synchronously off the abort) sees the
+				// flag. The catch path consults `shouldPreserveHitlOnShutdown`
+				// and skips the terminal-fallback / run-finish / snapshot
+				// writes that would otherwise overwrite the plan/ask card.
+				this.preserveHitlOnShutdown.add(run.runId);
+				run.abortController.abort();
 				continue;
 			}
 
@@ -2084,6 +2077,17 @@ export class InstanceAiService {
 			this.inFlightExecutions.delete(tracked);
 		});
 		this.inFlightExecutions.add(tracked);
+	}
+
+	/**
+	 * True when `shutdown()` aborted this run with the explicit policy that its
+	 * inline-HITL snapshot should be left intact. Used by `executeRun` and
+	 * `processResumedStream` to short-circuit the cancelled-path terminal
+	 * finalisation (run-finish event + cancelled tree snapshot) that would
+	 * otherwise overwrite the plan/ask card the user expects to see on reload.
+	 */
+	private shouldPreserveHitlOnShutdown(runId: string): boolean {
+		return this.preserveHitlOnShutdown.has(runId);
 	}
 
 	private async drainInFlightExecutions(timeoutMs: number): Promise<void> {
@@ -3817,7 +3821,7 @@ export class InstanceAiService {
 			// handling would still call `evaluateTerminalResponse` and
 			// `finalizeRun`, both of which rewrite the snapshot. Bail out
 			// before either fires so the plan/ask card stays on disk.
-			if (result.status === 'cancelled' && isShutdownPreserveHitlAbort(signal)) {
+			if (result.status === 'cancelled' && this.shouldPreserveHitlOnShutdown(runId)) {
 				return;
 			}
 
@@ -3869,7 +3873,7 @@ export class InstanceAiService {
 				// signal. Emitting the terminal-fallback text + run-finish
 				// here would clobber the plan/ask snapshot the user expects
 				// to see on reload, so just bail out.
-				if (isShutdownPreserveHitlAbort(signal)) {
+				if (this.shouldPreserveHitlOnShutdown(runId)) {
 					return;
 				}
 				const runTimeout = this.liveness.consumeRunTimeout(runId);
@@ -4736,7 +4740,7 @@ export class InstanceAiService {
 				return;
 			}
 
-			if (result.status === 'cancelled' && isShutdownPreserveHitlAbort(opts.signal)) {
+			if (result.status === 'cancelled' && this.shouldPreserveHitlOnShutdown(opts.runId)) {
 				return;
 			}
 
@@ -4779,7 +4783,7 @@ export class InstanceAiService {
 			}
 		} catch (error) {
 			if (opts.signal.aborted) {
-				if (isShutdownPreserveHitlAbort(opts.signal)) {
+				if (this.shouldPreserveHitlOnShutdown(opts.runId)) {
 					return;
 				}
 				const messageGroupId = this.traceContextsByRunId.get(opts.runId)?.messageGroupId;

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -1558,20 +1558,18 @@ export class InstanceAiService {
 			message: { id: userMessageId, text: message },
 		});
 
-		this.trackInFlightExecution(
-			this.executeRun(
-				user,
-				threadId,
-				runId,
-				message,
-				abortController,
-				attachments,
-				messageGroupId,
-				timeZone,
-				false,
-				undefined,
-				undefined,
-			),
+		this.startExecuteRun(
+			user,
+			threadId,
+			runId,
+			message,
+			abortController,
+			attachments,
+			messageGroupId,
+			timeZone,
+			false,
+			undefined,
+			undefined,
 		);
 
 		return runId;
@@ -2115,12 +2113,32 @@ export class InstanceAiService {
 	 * (finally block + SDK `cleanupRun`) to finish before the DB closes.
 	 * The promise removes itself from the set on settle so the set doesn't
 	 * grow unbounded across long-running threads.
+	 *
+	 * Prefer `startExecuteRun` / `startProcessResumedStream` over calling this
+	 * directly — they make tracking unmissable by binding the spawn and the
+	 * tracking together in one method.
 	 */
 	private trackInFlightExecution(promise: Promise<unknown>): void {
 		const tracked = promise.finally(() => {
 			this.inFlightExecutions.delete(tracked);
 		});
 		this.inFlightExecutions.add(tracked);
+	}
+
+	/**
+	 * Single spawn point for the executor — guarantees shutdown can drain the
+	 * run before closing the DB. New call sites should always go through this
+	 * wrapper rather than invoking `executeRun` directly.
+	 */
+	private startExecuteRun(...args: Parameters<InstanceAiService['executeRun']>): void {
+		this.trackInFlightExecution(this.executeRun(...args));
+	}
+
+	/** Same shutdown-drain contract as `startExecuteRun`, for the resume path. */
+	private startProcessResumedStream(
+		...args: Parameters<InstanceAiService['processResumedStream']>
+	): void {
+		this.trackInFlightExecution(this.processResumedStream(...args));
 	}
 
 	/**
@@ -3247,20 +3265,18 @@ export class InstanceAiService {
 				? 'replan'
 				: 'background_task_completed';
 
-		this.trackInFlightExecution(
-			this.executeRun(
-				user,
-				threadId,
-				runId,
-				message,
-				abortController,
-				undefined,
-				messageGroupId,
-				timeZone,
-				isReplanFollowUp,
-				checkpoint,
-				resumeReason,
-			),
+		this.startExecuteRun(
+			user,
+			threadId,
+			runId,
+			message,
+			abortController,
+			undefined,
+			messageGroupId,
+			timeZone,
+			isReplanFollowUp,
+			checkpoint,
+			resumeReason,
 		);
 
 		return runId;
@@ -3409,6 +3425,11 @@ export class InstanceAiService {
 		await this.doSchedulePlannedTasks(activeUser, threadId);
 	}
 
+	/**
+	 * Run body for a fresh orchestrator turn. Never call directly — go through
+	 * `startExecuteRun` so the promise is registered with `inFlightExecutions`
+	 * and shutdown can drain it before the DB closes.
+	 */
 	private async executeRun(
 		user: User,
 		threadId: string,
@@ -4595,24 +4616,28 @@ export class InstanceAiService {
 			},
 		});
 
-		this.trackInFlightExecution(
-			this.processResumedStream(agent, resumeData, {
-				runId,
-				agentRunId,
-				threadId,
-				user: activeUser,
-				toolCallId,
-				signal: abortController.signal,
-				abortController,
-				snapshotStorage: this.dbSnapshotStorage,
-				tracing: resumeTracing ?? tracing,
-				modelId,
-				checkpoint,
-			}),
-		);
+		this.startProcessResumedStream(agent, resumeData, {
+			runId,
+			agentRunId,
+			threadId,
+			user: activeUser,
+			toolCallId,
+			signal: abortController.signal,
+			abortController,
+			snapshotStorage: this.dbSnapshotStorage,
+			tracing: resumeTracing ?? tracing,
+			modelId,
+			checkpoint,
+		});
 		return true;
 	}
 
+	/**
+	 * Run body for a resumed suspended orchestrator turn. Never call directly
+	 * — go through `startProcessResumedStream` so the promise is registered
+	 * with `inFlightExecutions` and shutdown can drain it before the DB
+	 * closes.
+	 */
 	private async processResumedStream(
 		agent: unknown,
 		resumeData: Record<string, unknown>,

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -2187,26 +2187,14 @@ export class InstanceAiService {
 
 	private async pruneStalePendingConfirmations(now: number): Promise<void> {
 		try {
-			const expired = await this.pendingConfirmationRepo.findExpired(new Date(now));
-			if (expired.length === 0) {
+			const count = await this.pendingConfirmationRepo.deleteExpired(new Date(now));
+			if (count === 0) {
 				this.logger.debug('No stale Instance AI pending confirmations to drop');
 				return;
 			}
-			for (const row of expired) {
-				try {
-					await this.pendingConfirmationRepo.deleteByRequestId(row.requestId);
-				} catch (error: unknown) {
-					this.logger.warn('Failed to drop expired pending confirmation', {
-						requestId: row.requestId,
-						error: getErrorMessage(error),
-					});
-				}
-			}
-			this.logger.info('Dropped stale Instance AI pending confirmations', {
-				count: expired.length,
-			});
+			this.logger.info('Dropped stale Instance AI pending confirmations', { count });
 		} catch (error: unknown) {
-			this.logger.warn('Failed to scan stale Instance AI pending confirmations', {
+			this.logger.warn('Failed to drop stale Instance AI pending confirmations', {
 				error: getErrorMessage(error),
 			});
 		}

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -433,6 +433,26 @@ type OrchestratorResumeReason =
 	| 'planned_checkpoint'
 	| 'replan';
 
+/** A pending-confirmation orphan that's already passed the `canResumeOrphan`
+ *  predicate — i.e. has the SDK-side pointers (`toolCallId`, `checkpointKey`)
+ *  needed to rebuild a suspended run from the checkpoint blob. */
+type ResumableOrphan = NonNullable<
+	Awaited<ReturnType<InstanceAiPendingConfirmationRepository['claim']>>
+> & {
+	toolCallId: string;
+	checkpointKey: string;
+};
+
+/** Result of `rebuildSuspendedRunFromCheckpoint`. Each failure variant
+ *  corresponds to one rebuild step the caller can log distinctly; `ready`
+ *  carries the fully-assembled state for `runState.suspendRun`. */
+type RebuildSuspendedRunOutcome =
+	| { kind: 'ready'; state: SuspendedRunState<User> }
+	| { kind: 'no-user' }
+	| { kind: 'no-checkpoint'; error?: unknown }
+	| { kind: 'env-failure'; error: unknown }
+	| { kind: 'agent-failure'; error: unknown };
+
 /** Collapse the frontend's typed confirmation union into the flat payload
  *  consumed by native tool resume schemas and sub-agent HITL. Only the fields
  *  relevant to the submitted kind are populated — everything else stays undefined.
@@ -4304,10 +4324,7 @@ export class InstanceAiService {
 
 	private canResumeOrphan(
 		orphan: NonNullable<Awaited<ReturnType<typeof this.pendingConfirmationRepo.claim>>>,
-	): orphan is typeof orphan & {
-		toolCallId: string;
-		checkpointKey: string;
-	} {
+	): orphan is ResumableOrphan {
 		return Boolean(orphan.toolCallId && orphan.checkpointKey);
 	}
 
@@ -4355,20 +4372,66 @@ export class InstanceAiService {
 	 * (`groupIdByRunId`) keeps working.
 	 */
 	private async tryResumeFromOrphan(
-		orphan: NonNullable<Awaited<ReturnType<typeof this.pendingConfirmationRepo.claim>>> & {
-			toolCallId: string;
-			checkpointKey: string;
-		},
+		orphan: ResumableOrphan,
 		data: ConfirmationData,
 	): Promise<boolean> {
-		const user = await this.revalidateActiveUser(orphan.userId);
-		if (!user) {
-			this.logger.warn('Cannot resume orphaned run: user no longer authorized', {
-				requestId: orphan.requestId,
-				userId: orphan.userId,
-			});
-			return false;
+		const outcome = await this.rebuildSuspendedRunFromCheckpoint(orphan);
+		switch (outcome.kind) {
+			case 'ready':
+				// Re-seed the in-memory runState so `resumeSuspendedRun` can find
+				// this confirmation by requestId and the rest of the cancel /
+				// liveness / shutdown paths see the run as live. We deliberately
+				// do NOT call `persistPendingConfirmation` again — the DB row
+				// was already consumed by `claim()` above.
+				this.runState.suspendRun(orphan.threadId, outcome.state);
+				return await this.resumeSuspendedRun(orphan.userId, orphan.requestId, data);
+			case 'no-user':
+				this.logger.warn('Cannot resume orphaned run: user no longer authorized', {
+					requestId: orphan.requestId,
+					userId: orphan.userId,
+				});
+				return false;
+			case 'no-checkpoint':
+				this.logger.warn('Cannot resume orphaned run: checkpoint missing or unavailable', {
+					requestId: orphan.requestId,
+					checkpointKey: orphan.checkpointKey,
+					...(outcome.error ? { error: getErrorMessage(outcome.error) } : {}),
+				});
+				return false;
+			case 'env-failure':
+				this.logger.warn('Cannot resume orphaned run: failed to build execution environment', {
+					requestId: orphan.requestId,
+					threadId: orphan.threadId,
+					error: getErrorMessage(outcome.error),
+				});
+				return false;
+			case 'agent-failure':
+				this.logger.warn('Cannot resume orphaned run: failed to build agent', {
+					requestId: orphan.requestId,
+					threadId: orphan.threadId,
+					error: getErrorMessage(outcome.error),
+				});
+				return false;
 		}
+	}
+
+	/**
+	 * Rebuild the in-memory pieces a suspended run needs (user, agent,
+	 * execution environment) from a persisted orphan row + checkpoint, and
+	 * package them into a `SuspendedRunState`. The caller wraps the result in
+	 * `runState.suspendRun` and hands off to `resumeSuspendedRun`.
+	 *
+	 * Returns a discriminated union so the caller can log a precise reason
+	 * per failure mode without inlining each step's try/catch. Logging here
+	 * would be premature — the helper has the failure context but not the
+	 * routing decision (`tryResumeFromOrphan` decides whether the failure is
+	 * worth surfacing to the user vs. just retrying).
+	 */
+	private async rebuildSuspendedRunFromCheckpoint(
+		orphan: ResumableOrphan,
+	): Promise<RebuildSuspendedRunOutcome> {
+		const user = await this.revalidateActiveUser(orphan.userId);
+		if (!user) return { kind: 'no-user' };
 
 		// Bail early if the checkpoint store doesn't have a usable snapshot —
 		// `load()` throws UserError for expired tombstones and returns
@@ -4376,20 +4439,9 @@ export class InstanceAiService {
 		// to resume.
 		try {
 			const state = await this.checkpointStore.load(orphan.checkpointKey);
-			if (!state) {
-				this.logger.warn('Cannot resume orphaned run: checkpoint missing', {
-					requestId: orphan.requestId,
-					checkpointKey: orphan.checkpointKey,
-				});
-				return false;
-			}
+			if (!state) return { kind: 'no-checkpoint' };
 		} catch (error: unknown) {
-			this.logger.warn('Cannot resume orphaned run: checkpoint unavailable', {
-				requestId: orphan.requestId,
-				checkpointKey: orphan.checkpointKey,
-				error: getErrorMessage(error),
-			});
-			return false;
+			return { kind: 'no-checkpoint', error };
 		}
 
 		const abortController = new AbortController();
@@ -4404,12 +4456,7 @@ export class InstanceAiService {
 				this.threadPushRef.get(orphan.threadId),
 			);
 		} catch (error: unknown) {
-			this.logger.warn('Cannot resume orphaned run: failed to build execution environment', {
-				requestId: orphan.requestId,
-				threadId: orphan.threadId,
-				error: getErrorMessage(error),
-			});
-			return false;
+			return { kind: 'env-failure', error };
 		}
 
 		const mcpServers = this.parseMcpServers(this.instanceAiConfig.mcpServers);
@@ -4427,38 +4474,29 @@ export class InstanceAiService {
 				timeZone: this.runState.getTimeZone(orphan.threadId) ?? this.defaultTimeZone,
 			});
 		} catch (error: unknown) {
-			this.logger.warn('Cannot resume orphaned run: failed to build agent', {
-				requestId: orphan.requestId,
-				threadId: orphan.threadId,
-				error: getErrorMessage(error),
-			});
-			return false;
+			return { kind: 'agent-failure', error };
 		}
 
-		// Re-seed the in-memory runState so `resumeSuspendedRun` can find this
-		// confirmation by requestId and the rest of the cancel / liveness /
-		// shutdown paths see the run as live. We deliberately do NOT call
-		// `persistPendingConfirmation` again — the DB row was already
-		// consumed by `claim()` above.
-		this.runState.suspendRun(orphan.threadId, {
-			runId: orphan.runId,
-			agentRunId: orphan.checkpointKey,
-			agent,
-			threadId: orphan.threadId,
-			user,
-			toolCallId: orphan.toolCallId,
-			requestId: orphan.requestId,
-			abortController,
-			messageGroupId: orphan.messageGroupId ?? undefined,
-			createdAt: Date.now(),
-			tracing: undefined,
-			modelId: environment.modelId,
-			checkpoint: orphan.checkpointTaskId
-				? { isCheckpointFollowUp: true, checkpointTaskId: orphan.checkpointTaskId }
-				: undefined,
-		});
-
-		return await this.resumeSuspendedRun(orphan.userId, orphan.requestId, data);
+		return {
+			kind: 'ready',
+			state: {
+				runId: orphan.runId,
+				agentRunId: orphan.checkpointKey,
+				agent,
+				threadId: orphan.threadId,
+				user,
+				toolCallId: orphan.toolCallId,
+				requestId: orphan.requestId,
+				abortController,
+				messageGroupId: orphan.messageGroupId ?? undefined,
+				createdAt: Date.now(),
+				tracing: undefined,
+				modelId: environment.modelId,
+				checkpoint: orphan.checkpointTaskId
+					? { isCheckpointFollowUp: true, checkpointTaskId: orphan.checkpointTaskId }
+					: undefined,
+			},
+		};
 	}
 
 	private async revalidateActiveUser(userId: string): Promise<User | null> {

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -579,6 +579,27 @@ export class InstanceAiService {
 	 */
 	private readonly preserveHitlOnShutdown = new Set<string>();
 
+	/**
+	 * Restart-recovery metadata for runs that haven't yet been persisted by the
+	 * SDK's end-of-turn save. Registered by the run entry point with the chosen
+	 * `messageId` + raw text; consumed by:
+	 *   1. `executeRun`'s streamInput builder, to tag the SDK's message with
+	 *      our id so its eventual end-of-turn save upserts the same row.
+	 *   2. `persistUserMessageOnFirstSuspend`, called from `waitForConfirmation`
+	 *      so an inline HITL that pauses the turn before the SDK can save
+	 *      still leaves the user's prompt in `instance_ai_messages` for
+	 *      restart recovery.
+	 *
+	 * Entries are removed on confirmed DB save and cleared unconditionally in
+	 * `executeRun`'s finally — the SDK's end-of-turn save handles the success
+	 * path, and a mid-turn error means we deliberately don't want a
+	 * half-saved row.
+	 */
+	private readonly userMessagePersistenceByRun = new Map<
+		string,
+		{ userId: string; message: { id: string; text: string } }
+	>();
+
 	constructor(
 		logger: Logger,
 		globalConfig: GlobalConfig,
@@ -1512,6 +1533,10 @@ export class InstanceAiService {
 		// triggered by `waitForConfirmation` on a suspended HITL turn uses the
 		// same id the SDK would have used for completion.
 		const userMessageId = nanoid();
+		this.userMessagePersistenceByRun.set(runId, {
+			userId: user.id,
+			message: { id: userMessageId, text: message },
+		});
 
 		this.trackInFlightExecution(
 			this.executeRun(
@@ -1526,7 +1551,6 @@ export class InstanceAiService {
 				false,
 				undefined,
 				undefined,
-				{ id: userMessageId, text: message },
 			),
 		);
 
@@ -2090,6 +2114,20 @@ export class InstanceAiService {
 		return this.preserveHitlOnShutdown.has(runId);
 	}
 
+	/**
+	 * Idempotent first-suspend persistence. The first `waitForConfirmation`
+	 * for a run consumes the pending entry; later HITLs are no-ops because
+	 * the entry has been removed. If the DB write fails the entry stays in
+	 * the map so the next HITL retries — see `persistUserMessageOnSuspend`'s
+	 * success-boolean return for the retry contract.
+	 */
+	private async persistUserMessageOnFirstSuspend(threadId: string, runId: string): Promise<void> {
+		const entry = this.userMessagePersistenceByRun.get(runId);
+		if (!entry) return;
+		const ok = await this.persistUserMessageOnSuspend(threadId, entry.userId, entry.message);
+		if (ok) this.userMessagePersistenceByRun.delete(runId);
+	}
+
 	private async drainInFlightExecutions(timeoutMs: number): Promise<void> {
 		if (this.inFlightExecutions.size === 0) return;
 
@@ -2235,7 +2273,7 @@ export class InstanceAiService {
 		threadId: string,
 		userId: string,
 		message: { id: string; text: string },
-	): Promise<void> {
+	): Promise<boolean> {
 		try {
 			await this.agentMemory.saveMessages({
 				threadId,
@@ -2249,12 +2287,14 @@ export class InstanceAiService {
 					},
 				],
 			});
+			return true;
 		} catch (error: unknown) {
 			this.logger.warn('Failed to persist user message on HITL suspend', {
 				threadId,
 				userId,
 				error: getErrorMessage(error),
 			});
+			return false;
 		}
 	}
 
@@ -2798,12 +2838,7 @@ export class InstanceAiService {
 		abortSignal: AbortSignal,
 		messageGroupId?: string,
 		pushRef?: string,
-		userMessagePersistence?: { id: string; text: string },
 	) {
-		// Closure flag so `waitForConfirmation` only writes the user-message
-		// row once even if the run hits multiple HITL points (planner
-		// submit-plan + a later sub-agent ask-user, say).
-		let userMessageSaved = false;
 		const adminSettings = this.settingsService.getAdminSettings();
 		const localGatewayDisabledGlobally = adminSettings.localGatewayDisabled;
 		const localGatewayDisabledForUser = await this.settingsService.isLocalGatewayDisabledForUser(
@@ -2975,10 +3010,7 @@ export class InstanceAiService {
 				// HITL never reaches that point. Doing this *now* (rather than
 				// at executeRun start) avoids polluting the agent's prompt —
 				// the SDK has already loaded its memory snapshot for this run.
-				if (!userMessageSaved && userMessagePersistence) {
-					userMessageSaved = true;
-					void this.persistUserMessageOnSuspend(threadId, user.id, userMessagePersistence);
-				}
+				void this.persistUserMessageOnFirstSuspend(threadId, runId);
 
 				return await new Promise<ConfirmationData>((resolve) => {
 					this.runState.registerPendingConfirmation(requestId, {
@@ -3381,8 +3413,10 @@ export class InstanceAiService {
 		isReplanFollowUp: boolean = false,
 		checkpoint?: { isCheckpointFollowUp: true; checkpointTaskId: string },
 		resumeReason?: OrchestratorResumeReason,
-		userMessagePersistence?: { id: string; text: string },
 	): Promise<void> {
+		// Read once at the top so the streamInput builder + (if any later
+		// retry) see the same view of restart-recovery metadata.
+		const userMessagePersistence = this.userMessagePersistenceByRun.get(runId)?.message;
 		const signal = abortController.signal;
 		let tracing: InstanceAiTraceContext | undefined;
 		let messageTraceFinalization: MessageTraceFinalization | undefined;
@@ -3427,7 +3461,6 @@ export class InstanceAiService {
 				signal,
 				messageGroupId,
 				executionPushRef,
-				userMessagePersistence,
 			);
 			activeSnapshotStorage = environment.snapshotStorage;
 			const { context, memory, taskStorage, snapshotStorage, modelId, orchestrationContext } =
@@ -3961,6 +3994,10 @@ export class InstanceAiService {
 			}
 		} finally {
 			this.runState.clearActiveRun(threadId);
+			// Drop any unconsumed first-suspend persistence intent. SDK
+			// end-of-turn save handles the success path; a mid-turn error
+			// means we deliberately don't want a half-saved row.
+			this.userMessagePersistenceByRun.delete(runId);
 			// Note: don't delete threadPushRef here. Planned tasks (build agent,
 			// checkpoint verifications) dispatch later in this same finally and
 			// later still in the post-run scheduler — they need the pushRef to

--- a/packages/cli/src/modules/instance-ai/liveness/instance-ai-liveness.service.ts
+++ b/packages/cli/src/modules/instance-ai/liveness/instance-ai-liveness.service.ts
@@ -92,6 +92,7 @@ export type InstanceAiLivenessServiceOptions<
 	backgroundTasks: InstanceAiLivenessBackgroundTasks;
 	eventBus: InstanceAiLivenessEventBus;
 	finalizeCancelledSuspendedRun: (suspended: TSuspendedRun, reason: string) => void;
+	onPendingConfirmationRejected?: (requestId: string) => void;
 	logger: InstanceAiLivenessLogger;
 };
 
@@ -187,6 +188,7 @@ export class InstanceAiLivenessService<
 				}
 			}
 			this.options.runState.rejectPendingConfirmation(reqId);
+			this.options.onPendingConfirmationRejected?.(reqId);
 		}
 
 		try {

--- a/packages/cli/src/modules/instance-ai/message-parser.ts
+++ b/packages/cli/src/modules/instance-ai/message-parser.ts
@@ -367,6 +367,20 @@ export function parseStoredMessages(
 		messages.push(buildSnapshotMessage(snapshot));
 	}
 
+	// Propagate messageGroupId across assistant rows in the same conversational
+	// turn so the dedup pass below collapses them into a single rendered message.
+	//
+	// Planned-task follow-ups (build → checkpoint → synthesize) produce one
+	// real user message followed by several orchestrator sub-runs separated by
+	// internal `<planned-task-follow-up>` user messages (filtered out earlier).
+	// `takeSnapshotForAssistant` only pairs the sub-runs whose snapshot
+	// timestamp lines up — the intra-turn text rows ("On it!", "The trigger
+	// is…") stay unpaired and their text is also embedded in the final paired
+	// snapshot's `tree.textContent`. Without this propagation those unpaired
+	// rows survive the dedup loop and render as duplicates after a page
+	// reload (the live SSE path used to merge them via the run-start reducer).
+	propagateMessageGroupIdAcrossTurns(messages);
+
 	// Deduplicate assistant messages by messageGroupId.
 	// Follow-up runs in the same group produce separate DB rows; keep only
 	// the latest (which carries the full runIds array and complete tree).
@@ -382,4 +396,42 @@ export function parseStoredMessages(
 	}
 
 	return messages;
+}
+
+/**
+ * For each conversational turn (delimited by real user messages), find the
+ * latest assistant message that already has a `messageGroupId` (i.e. was
+ * paired with a snapshot) and copy that id onto every unpaired assistant
+ * message in the same turn.
+ */
+function propagateMessageGroupIdAcrossTurns(messages: InstanceAiMessage[]): void {
+	let turnStart = 0;
+	for (let i = 0; i <= messages.length; i++) {
+		const atBoundary = i === messages.length || messages[i].role === 'user';
+		if (!atBoundary) continue;
+		propagateMessageGroupIdWithinRange(messages, turnStart, i);
+		turnStart = i + 1;
+	}
+}
+
+function propagateMessageGroupIdWithinRange(
+	messages: InstanceAiMessage[],
+	start: number,
+	end: number,
+): void {
+	let turnGroupId: string | undefined;
+	for (let i = end - 1; i >= start; i--) {
+		const gid = messages[i].messageGroupId;
+		if (gid) {
+			turnGroupId = gid;
+			break;
+		}
+	}
+	if (!turnGroupId) return;
+	for (let i = start; i < end; i++) {
+		const msg = messages[i];
+		if (msg.role === 'assistant' && !msg.messageGroupId) {
+			msg.messageGroupId = turnGroupId;
+		}
+	}
 }

--- a/packages/cli/src/modules/instance-ai/repositories/__tests__/instance-ai-pending-confirmation.repository.test.ts
+++ b/packages/cli/src/modules/instance-ai/repositories/__tests__/instance-ai-pending-confirmation.repository.test.ts
@@ -1,0 +1,102 @@
+import type { DeleteResult, EntityManager, Repository } from '@n8n/typeorm';
+import { mock } from 'jest-mock-extended';
+
+import type { InstanceAiPendingConfirmation } from '../../entities/instance-ai-pending-confirmation.entity';
+import { InstanceAiPendingConfirmationRepository } from '../instance-ai-pending-confirmation.repository';
+
+function makeRow(
+	overrides: Partial<InstanceAiPendingConfirmation> = {},
+): InstanceAiPendingConfirmation {
+	return {
+		requestId: 'req-1',
+		threadId: 'thread-1',
+		userId: 'user-1',
+		kind: 'inline',
+		runId: 'run-1',
+		toolCallId: null,
+		messageGroupId: null,
+		checkpoint: null,
+		checkpointKey: null,
+		checkpointTaskId: null,
+		expiresAt: null,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+		...overrides,
+	} as InstanceAiPendingConfirmation;
+}
+
+describe('InstanceAiPendingConfirmationRepository.claim', () => {
+	function buildRepoWithTxRepo(txRepo: Repository<InstanceAiPendingConfirmation>) {
+		const manager = mock<EntityManager>();
+		manager.getRepository.mockReturnValue(
+			txRepo as unknown as Repository<InstanceAiPendingConfirmation>,
+		);
+		(manager as unknown as { connection: { options: { type: string } } }).connection = {
+			options: { type: 'sqlite' },
+		};
+
+		const outerManager = {
+			transaction: jest.fn(async (cb: (m: EntityManager) => Promise<unknown>) => await cb(manager)),
+		};
+
+		const repo = Object.create(
+			InstanceAiPendingConfirmationRepository.prototype,
+		) as InstanceAiPendingConfirmationRepository;
+		Object.defineProperty(repo, 'manager', {
+			value: outerManager,
+			configurable: true,
+		});
+		return { repo, outerManager };
+	}
+
+	it('returns the row to the caller that wins the delete', async () => {
+		const row = makeRow();
+		const txRepo = mock<Repository<InstanceAiPendingConfirmation>>();
+		txRepo.findOne.mockResolvedValueOnce(row);
+		txRepo.delete.mockResolvedValueOnce({ affected: 1 } as DeleteResult);
+		const { repo } = buildRepoWithTxRepo(txRepo);
+
+		const result = await repo.claim('req-1', 'user-1');
+
+		expect(result).toBe(row);
+		expect(txRepo.findOne).toHaveBeenCalledWith({
+			where: { requestId: 'req-1', userId: 'user-1' },
+		});
+		expect(txRepo.delete).toHaveBeenCalledWith({ requestId: 'req-1', userId: 'user-1' });
+	});
+
+	it('returns undefined when no row matches the requestId+userId', async () => {
+		const txRepo = mock<Repository<InstanceAiPendingConfirmation>>();
+		txRepo.findOne.mockResolvedValueOnce(null);
+		const { repo } = buildRepoWithTxRepo(txRepo);
+
+		const result = await repo.claim('req-missing', 'user-1');
+
+		expect(result).toBeUndefined();
+		expect(txRepo.delete).not.toHaveBeenCalled();
+	});
+
+	it('returns undefined when a concurrent delete claimed the row first', async () => {
+		const txRepo = mock<Repository<InstanceAiPendingConfirmation>>();
+		txRepo.findOne.mockResolvedValueOnce(makeRow());
+		txRepo.delete.mockResolvedValueOnce({ affected: 0 } as DeleteResult);
+		const { repo } = buildRepoWithTxRepo(txRepo);
+
+		const result = await repo.claim('req-1', 'user-1');
+
+		expect(result).toBeUndefined();
+	});
+
+	it('scopes by userId so a different user cannot take the row', async () => {
+		const txRepo = mock<Repository<InstanceAiPendingConfirmation>>();
+		txRepo.findOne.mockResolvedValueOnce(null);
+		const { repo } = buildRepoWithTxRepo(txRepo);
+
+		const result = await repo.claim('req-1', 'attacker-user');
+
+		expect(result).toBeUndefined();
+		expect(txRepo.findOne).toHaveBeenCalledWith({
+			where: { requestId: 'req-1', userId: 'attacker-user' },
+		});
+	});
+});

--- a/packages/cli/src/modules/instance-ai/repositories/instance-ai-checkpoint.repository.ts
+++ b/packages/cli/src/modules/instance-ai/repositories/instance-ai-checkpoint.repository.ts
@@ -1,5 +1,5 @@
 import { Service } from '@n8n/di';
-import { DataSource, Repository } from '@n8n/typeorm';
+import { DataSource, IsNull, Repository } from '@n8n/typeorm';
 
 import { InstanceAiCheckpoint } from '../entities/instance-ai-checkpoint.entity';
 
@@ -7,5 +7,20 @@ import { InstanceAiCheckpoint } from '../entities/instance-ai-checkpoint.entity'
 export class InstanceAiCheckpointRepository extends Repository<InstanceAiCheckpoint> {
 	constructor(dataSource: DataSource) {
 		super(InstanceAiCheckpoint, dataSource.manager);
+	}
+
+	/**
+	 * Live (non-expired) checkpoints for a thread, newest first. Used to
+	 * surface in-flight messages from suspended runs whose `messageList`
+	 * hasn't been committed back to `instance_ai_messages` yet — the SDK
+	 * only saves the turn delta to memory at the end of a successful loop,
+	 * so messages from a turn that suspended at HITL live only in the
+	 * checkpoint blob until the run resumes and completes.
+	 */
+	async findActiveByThreadId(threadId: string): Promise<InstanceAiCheckpoint[]> {
+		return await this.find({
+			where: { threadId, expiredAt: IsNull() },
+			order: { createdAt: 'DESC' },
+		});
 	}
 }

--- a/packages/cli/src/modules/instance-ai/repositories/instance-ai-pending-confirmation.repository.ts
+++ b/packages/cli/src/modules/instance-ai/repositories/instance-ai-pending-confirmation.repository.ts
@@ -1,0 +1,63 @@
+import { Service } from '@n8n/di';
+import { DataSource, LessThan, Repository } from '@n8n/typeorm';
+
+import { InstanceAiPendingConfirmation } from '../entities/instance-ai-pending-confirmation.entity';
+
+@Service()
+export class InstanceAiPendingConfirmationRepository extends Repository<InstanceAiPendingConfirmation> {
+	constructor(dataSource: DataSource) {
+		super(InstanceAiPendingConfirmation, dataSource.manager);
+	}
+
+	/**
+	 * Atomically take ownership of a pending confirmation. Returns the row to
+	 * the caller who wins the delete; concurrent attempts (e.g. parallel
+	 * confirm/cancel/TTL sweep) all return `undefined` except one.
+	 *
+	 * Scoped by `userId` so a different user cannot claim a confirmation that
+	 * was registered for someone else.
+	 */
+	async claim(
+		requestId: string,
+		userId: string,
+	): Promise<InstanceAiPendingConfirmation | undefined> {
+		return await this.manager.transaction(async (manager) => {
+			const repo = manager.getRepository(InstanceAiPendingConfirmation);
+			const row = await repo.findOne({
+				where: { requestId, userId },
+				...(manager.connection.options.type === 'postgres'
+					? { lock: { mode: 'pessimistic_write' as const } }
+					: {}),
+			});
+			if (!row) return undefined;
+
+			const result = await repo.delete({ requestId, userId });
+			if (result.affected === 0) return undefined;
+			return row;
+		});
+	}
+
+	/** Drop a confirmation regardless of owner — for thread/run-level teardown. */
+	async deleteByRequestId(requestId: string): Promise<number> {
+		const result = await this.delete({ requestId });
+		return result.affected ?? 0;
+	}
+
+	async deleteByThreadId(threadId: string): Promise<number> {
+		const result = await this.delete({ threadId });
+		return result.affected ?? 0;
+	}
+
+	async deleteByRunId(runId: string): Promise<number> {
+		const result = await this.delete({ runId });
+		return result.affected ?? 0;
+	}
+
+	async findExpired(now: Date): Promise<InstanceAiPendingConfirmation[]> {
+		return await this.find({ where: { expiresAt: LessThan(now) } });
+	}
+
+	async findByThreadId(threadId: string): Promise<InstanceAiPendingConfirmation[]> {
+		return await this.find({ where: { threadId } });
+	}
+}

--- a/packages/cli/src/modules/instance-ai/repositories/instance-ai-pending-confirmation.repository.ts
+++ b/packages/cli/src/modules/instance-ai/repositories/instance-ai-pending-confirmation.repository.ts
@@ -53,8 +53,9 @@ export class InstanceAiPendingConfirmationRepository extends Repository<Instance
 		return result.affected ?? 0;
 	}
 
-	async findExpired(now: Date): Promise<InstanceAiPendingConfirmation[]> {
-		return await this.find({ where: { expiresAt: LessThan(now) } });
+	async deleteExpired(now: Date): Promise<number> {
+		const result = await this.delete({ expiresAt: LessThan(now) });
+		return result.affected ?? 0;
 	}
 
 	async findByThreadId(threadId: string): Promise<InstanceAiPendingConfirmation[]> {

--- a/packages/cli/src/modules/instance-ai/storage/__tests__/typeorm-agent-checkpoint-store.test.ts
+++ b/packages/cli/src/modules/instance-ai/storage/__tests__/typeorm-agent-checkpoint-store.test.ts
@@ -1,6 +1,6 @@
 import type { SerializableAgentState } from '@n8n/instance-ai';
-import type { DeleteResult, EntityManager, Repository } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
+import { UserError } from 'n8n-workflow';
 
 import type { InstanceAiCheckpoint } from '../../entities/instance-ai-checkpoint.entity';
 import type { InstanceAiCheckpointRepository } from '../../repositories/instance-ai-checkpoint.repository';
@@ -24,15 +24,17 @@ function makeState(overrides: Partial<SerializableAgentState> = {}): Serializabl
 	};
 }
 
-function makeCheckpoint(state: SerializableAgentState = makeState()): InstanceAiCheckpoint {
+function makeCheckpoint(overrides: Partial<InstanceAiCheckpoint> = {}): InstanceAiCheckpoint {
 	return {
 		key: 'checkpoint:run-1',
 		runId: 'run-1',
 		threadId: 'thread-1',
 		resourceId: 'user-1',
-		state,
+		state: makeState(),
+		expiredAt: null,
 		createdAt: new Date(),
 		updatedAt: new Date(),
+		...overrides,
 	} as InstanceAiCheckpoint;
 }
 
@@ -40,19 +42,8 @@ describe('TypeORMAgentCheckpointStore', () => {
 	const checkpointRepo = mock<InstanceAiCheckpointRepository>();
 	let store: TypeORMAgentCheckpointStore;
 
-	function setTransactionManager(txManager: EntityManager): void {
-		const repoManager = checkpointRepo.manager as unknown as { transaction: jest.Mock };
-		repoManager.transaction.mockImplementation(
-			async <T>(callback: (manager: EntityManager) => Promise<T>) => await callback(txManager),
-		);
-	}
-
 	beforeEach(() => {
 		jest.clearAllMocks();
-		Object.defineProperty(checkpointRepo, 'manager', {
-			value: mock<EntityManager>(),
-			configurable: true,
-		});
 		store = new TypeORMAgentCheckpointStore(checkpointRepo);
 	});
 
@@ -64,9 +55,10 @@ describe('TypeORMAgentCheckpointStore', () => {
 		expect(checkpointRepo.save).not.toHaveBeenCalled();
 	});
 
-	it('stores checkpoint state as structured JSON', async () => {
+	it('stores checkpoint state as structured JSON for a fresh key', async () => {
 		const state = makeState();
-		const checkpoint = makeCheckpoint(state);
+		const checkpoint = makeCheckpoint({ state });
+		checkpointRepo.findOne.mockResolvedValueOnce(null);
 		checkpointRepo.create.mockReturnValueOnce(checkpoint);
 
 		await store.save('checkpoint:run-1', state);
@@ -77,79 +69,94 @@ describe('TypeORMAgentCheckpointStore', () => {
 			threadId: 'thread-1',
 			resourceId: 'user-1',
 			state,
+			expiredAt: null,
 		});
 		expect(checkpointRepo.save).toHaveBeenCalledWith(checkpoint);
 	});
 
-	it('serializes concurrent loads so only one caller consumes a checkpoint per process', async () => {
-		let checkpoint: InstanceAiCheckpoint | undefined = makeCheckpoint();
-		const txRepo = mock<Repository<InstanceAiCheckpoint>>();
-		txRepo.findOne.mockImplementation(async () => {
-			const captured = checkpoint;
-			await Promise.resolve();
-			return captured ?? null;
-		});
-		txRepo.delete.mockImplementation(async (): Promise<DeleteResult> => {
-			const affected = checkpoint ? 1 : 0;
-			checkpoint = undefined;
-			return { affected, raw: {} };
-		});
+	it('clears the expired tombstone flag when re-saving the same key', async () => {
+		const existing = makeCheckpoint({ expiredAt: new Date(), state: null });
+		checkpointRepo.findOne.mockResolvedValueOnce(existing);
 
-		const txManager = {
-			connection: { options: { type: 'sqlite' } },
-			getRepository: () => txRepo,
-		} as unknown as EntityManager;
-		setTransactionManager(txManager);
+		const newState = makeState();
+		await store.save('checkpoint:run-1', newState);
 
-		const [first, second] = await Promise.all([
-			store.load('checkpoint:run-1'),
-			store.load('checkpoint:run-1'),
-		]);
-
-		expect([first, second].filter(Boolean)).toHaveLength(1);
-		expect(txRepo.delete).toHaveBeenCalledTimes(1);
+		expect(checkpointRepo.save).toHaveBeenCalledWith(
+			expect.objectContaining({
+				key: 'checkpoint:run-1',
+				expiredAt: null,
+				state: newState,
+			}),
+		);
 	});
 
-	it('uses a pessimistic lock when running on postgres', async () => {
-		const txRepo = mock<Repository<InstanceAiCheckpoint>>();
-		txRepo.findOne.mockResolvedValueOnce(makeCheckpoint());
-		txRepo.delete.mockResolvedValueOnce({ affected: 1, raw: {} });
-		const txManager = {
-			connection: { options: { type: 'postgres' } },
-			getRepository: () => txRepo,
-		} as unknown as EntityManager;
-		setTransactionManager(txManager);
+	it('returns the stored state on load and leaves the row intact', async () => {
+		const checkpoint = makeCheckpoint();
+		checkpointRepo.findOne.mockResolvedValueOnce(checkpoint);
 
-		await store.load('checkpoint:run-1');
+		const loaded = await store.load('checkpoint:run-1');
 
-		const findOptions = txRepo.findOne.mock.calls[0][0];
-		expect(findOptions.lock).toEqual({ mode: 'pessimistic_write' });
+		expect(loaded).toBe(checkpoint.state);
+		expect(checkpointRepo.delete).not.toHaveBeenCalled();
+		expect(checkpointRepo.update).not.toHaveBeenCalled();
 	});
 
-	it('does not use a pessimistic lock when running on sqlite-pooled', async () => {
-		const txRepo = mock<Repository<InstanceAiCheckpoint>>();
-		txRepo.findOne.mockResolvedValueOnce(makeCheckpoint());
-		txRepo.delete.mockResolvedValueOnce({ affected: 1, raw: {} });
-		const txManager = {
-			connection: { options: { type: 'sqlite-pooled' } },
-			getRepository: () => txRepo,
-		} as unknown as EntityManager;
-		setTransactionManager(txManager);
+	it('returns undefined when no checkpoint exists for the key', async () => {
+		checkpointRepo.findOne.mockResolvedValueOnce(null);
 
-		await store.load('checkpoint:run-1');
+		const loaded = await store.load('checkpoint:run-1');
 
-		const findOptions = txRepo.findOne.mock.calls[0][0];
-		expect(findOptions.lock).toBeUndefined();
+		expect(loaded).toBeUndefined();
 	});
 
-	it('deletes stale checkpoints by update time', async () => {
-		checkpointRepo.delete.mockResolvedValueOnce({ affected: 3, raw: {} });
+	it('throws a UserError when loading an expired tombstone', async () => {
+		checkpointRepo.findOne.mockResolvedValueOnce(
+			makeCheckpoint({ expiredAt: new Date(), state: null }),
+		);
+
+		await expect(store.load('checkpoint:run-1')).rejects.toBeInstanceOf(UserError);
+	});
+
+	it('soft-deletes by stamping expiredAt and clearing the state blob', async () => {
+		await store.delete('checkpoint:run-1');
+
+		expect(checkpointRepo.update).toHaveBeenCalledWith(
+			{ key: 'checkpoint:run-1' },
+			expect.objectContaining({ state: null, expiredAt: expect.any(Date) }),
+		);
+		expect(checkpointRepo.delete).not.toHaveBeenCalled();
+	});
+
+	it('marks stale checkpoints expired via the query builder', async () => {
+		const builder = {
+			update: jest.fn(),
+			set: jest.fn(),
+			where: jest.fn(),
+			andWhere: jest.fn(),
+			execute: jest.fn(),
+		};
+		builder.update.mockReturnValue(builder);
+		builder.set.mockReturnValue(builder);
+		builder.where.mockReturnValue(builder);
+		builder.andWhere.mockReturnValue(builder);
+		builder.execute.mockResolvedValueOnce({ affected: 4, raw: {}, generatedMaps: [] });
+
+		(checkpointRepo.createQueryBuilder as unknown as jest.Mock).mockReturnValueOnce(builder);
+
 		const olderThan = new Date('2026-05-01T00:00:00.000Z');
+		await expect(store.markExpiredOlderThan(olderThan)).resolves.toBe(4);
 
-		await expect(store.deleteOlderThan(olderThan)).resolves.toBe(3);
+		expect(builder.set).toHaveBeenCalledWith(
+			expect.objectContaining({ state: null, expiredAt: expect.any(Date) }),
+		);
+		expect(builder.where).toHaveBeenCalledWith('updatedAt < :olderThan', { olderThan });
+		expect(builder.andWhere).toHaveBeenCalledWith('expiredAt IS NULL');
+	});
 
-		expect(checkpointRepo.delete).toHaveBeenCalledWith({
-			updatedAt: expect.any(Object),
-		});
+	it('keeps the deleteOlderThan shim delegating to markExpiredOlderThan', async () => {
+		const spy = jest.spyOn(store, 'markExpiredOlderThan').mockResolvedValueOnce(7);
+
+		await expect(store.deleteOlderThan(new Date(0))).resolves.toBe(7);
+		expect(spy).toHaveBeenCalledTimes(1);
 	});
 });

--- a/packages/cli/src/modules/instance-ai/storage/db-snapshot-storage.ts
+++ b/packages/cli/src/modules/instance-ai/storage/db-snapshot-storage.ts
@@ -5,6 +5,24 @@ import { jsonParse } from 'n8n-workflow';
 
 import { InstanceAiRunSnapshotRepository } from '../repositories/instance-ai-run-snapshot.repository';
 
+/**
+ * Walk a saved agent tree and flip everything in-flight to a terminal state.
+ * Active sub-agents become `cancelled`, loading tool calls stop loading, and
+ * unresolved HITL confirmation cards get a `denied` status so the frontend
+ * stops rendering Allow / Request-changes buttons. Mutates `node` in place.
+ */
+function cancelInFlightNodes(node: InstanceAiAgentNode): void {
+	if (node.status === 'active') node.status = 'cancelled';
+	for (const call of node.toolCalls) {
+		if (!call.isLoading) continue;
+		call.isLoading = false;
+		if (call.confirmation && !call.confirmationStatus) {
+			call.confirmationStatus = 'denied';
+		}
+	}
+	for (const child of node.children) cancelInFlightNodes(child);
+}
+
 export interface SaveSnapshotOptions {
 	messageGroupId?: string;
 	runIds?: string[];
@@ -131,6 +149,27 @@ export class DbSnapshotStorage {
 
 		// No existing row — insert
 		await this.save(threadId, agentTree, runId, options);
+	}
+
+	/**
+	 * Mark an existing snapshot as a cancelled run, terminalising every
+	 * `active` node and every in-flight tool call (including unresolved HITL
+	 * confirmations) in the saved tree. Used when a run is being marked
+	 * terminal after the in-memory event bus is gone — e.g. handling a
+	 * confirmation orphaned by a restart — because rebuilding the tree from
+	 * an empty bus would clobber the saved plan / ask card with an empty
+	 * cancelled tree. Keeps the planner output, tool calls, and confirmation
+	 * payload intact so the user can still see what was being planned, just
+	 * without interactive buttons.
+	 */
+	async markRunCancelled(threadId: string, runId: string): Promise<void> {
+		const key = { threadId, runId };
+		const row = await this.repo.findOneBy(key);
+		if (!row) return;
+
+		const tree = jsonParse<InstanceAiAgentNode>(row.tree);
+		cancelInFlightNodes(tree);
+		await this.repo.update(key, { tree: JSON.stringify(tree) });
 	}
 
 	async getAll(threadId: string): Promise<AgentTreeSnapshot[]> {

--- a/packages/cli/src/modules/instance-ai/storage/typeorm-agent-checkpoint-store.ts
+++ b/packages/cli/src/modules/instance-ai/storage/typeorm-agent-checkpoint-store.ts
@@ -1,15 +1,15 @@
 import { Service } from '@n8n/di';
 import type { CheckpointStore, SerializableAgentState } from '@n8n/instance-ai';
-import { LessThan, type EntityManager } from '@n8n/typeorm';
-import { UnexpectedError } from 'n8n-workflow';
+import { LessThan } from '@n8n/typeorm';
+import { UnexpectedError, UserError } from 'n8n-workflow';
 
-import { InstanceAiCheckpoint } from '../entities/instance-ai-checkpoint.entity';
 import { InstanceAiCheckpointRepository } from '../repositories/instance-ai-checkpoint.repository';
+
+const EXPIRED_CHECKPOINT_MESSAGE =
+	'This action has expired and cannot be resumed. Please start a new turn.';
 
 @Service()
 export class TypeORMAgentCheckpointStore implements CheckpointStore {
-	private readonly loadQueues = new Map<string, Promise<SerializableAgentState | undefined>>();
-
 	constructor(private readonly checkpointRepo: InstanceAiCheckpointRepository) {}
 
 	async save(key: string, state: SerializableAgentState): Promise<void> {
@@ -20,71 +20,76 @@ export class TypeORMAgentCheckpointStore implements CheckpointStore {
 			});
 		}
 
+		const existing = await this.checkpointRepo.findOne({ where: { key } });
+		if (existing) {
+			existing.runId = this.getRunId(key);
+			existing.threadId = threadId;
+			existing.resourceId = state.persistence?.resourceId ?? null;
+			existing.state = state;
+			existing.expiredAt = null;
+			await this.checkpointRepo.save(existing);
+			return;
+		}
+
 		const checkpoint = this.checkpointRepo.create({
 			key,
 			runId: this.getRunId(key),
 			threadId,
 			resourceId: state.persistence?.resourceId ?? null,
 			state,
+			expiredAt: null,
 		});
-
 		await this.checkpointRepo.save(checkpoint);
 	}
 
 	async load(key: string): Promise<SerializableAgentState | undefined> {
-		return await this.serializeLoad(key, async () => await this.loadAndDelete(key));
+		const checkpoint = await this.checkpointRepo.findOne({ where: { key } });
+		if (!checkpoint) return undefined;
+		if (checkpoint.expiredAt !== null || checkpoint.state === null) {
+			throw new UserError(EXPIRED_CHECKPOINT_MESSAGE);
+		}
+		return checkpoint.state;
 	}
 
 	async delete(key: string): Promise<void> {
-		await this.checkpointRepo.delete({ key });
+		// Soft-delete: keep the row as a tombstone (mirrors the first-class
+		// agents' N8NCheckpointStorage) so a stale resume gets a clear
+		// "expired" error instead of an indistinguishable "not found".
+		// The heavy state blob is released so the row stays cheap.
+		await this.checkpointRepo.update({ key }, { expiredAt: new Date(), state: null });
 	}
 
-	async deleteOlderThan(olderThan: Date): Promise<number> {
-		const result = await this.checkpointRepo.delete({ updatedAt: LessThan(olderThan) });
+	async markExpiredOlderThan(olderThan: Date): Promise<number> {
+		const result = await this.checkpointRepo
+			.createQueryBuilder()
+			.update()
+			.set({ expiredAt: new Date(), state: null })
+			.where('updatedAt < :olderThan', { olderThan })
+			.andWhere('expiredAt IS NULL')
+			.execute();
 		return result.affected ?? 0;
 	}
 
-	private async loadAndDelete(key: string): Promise<SerializableAgentState | undefined> {
-		return await this.checkpointRepo.manager.transaction(async (manager) => {
-			const repo = manager.getRepository(InstanceAiCheckpoint);
-			const checkpoint = await repo.findOne({
-				where: { key },
-				...(this.supportsPessimisticWriteLock(manager)
-					? { lock: { mode: 'pessimistic_write' as const } }
-					: {}),
-			});
-			if (!checkpoint) return undefined;
+	/**
+	 * Backwards-compat shim for the SDK's `CheckpointStore`-style pruning
+	 * helper that pre-dates the soft-delete switch. The semantics now match
+	 * `markExpiredOlderThan` — the row stays, the blob does not.
+	 */
+	async deleteOlderThan(olderThan: Date): Promise<number> {
+		return await this.markExpiredOlderThan(olderThan);
+	}
 
-			const result = await repo.delete({ key });
-			if (result.affected === 0) return undefined;
-			return checkpoint.state ?? undefined;
+	/** Drop expired tombstones outright once they're past the GC horizon. */
+	async hardDeleteExpiredOlderThan(olderThan: Date): Promise<number> {
+		const result = await this.checkpointRepo.delete({
+			expiredAt: LessThan(olderThan),
 		});
+		return result.affected ?? 0;
 	}
 
 	private getRunId(key: string): string | null {
 		const separatorIndex = key.lastIndexOf(':');
 		if (separatorIndex < 0 || separatorIndex === key.length - 1) return null;
 		return key.slice(separatorIndex + 1);
-	}
-
-	private supportsPessimisticWriteLock(manager: EntityManager): boolean {
-		return manager.connection.options.type === 'postgres';
-	}
-
-	private async serializeLoad(
-		key: string,
-		load: () => Promise<SerializableAgentState | undefined>,
-	): Promise<SerializableAgentState | undefined> {
-		const previous = this.loadQueues.get(key) ?? Promise.resolve(undefined);
-		const next = previous.catch(() => undefined).then(load);
-		this.loadQueues.set(key, next);
-
-		try {
-			return await next;
-		} finally {
-			if (this.loadQueues.get(key) === next) {
-				this.loadQueues.delete(key);
-			}
-		}
 	}
 }

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAi.threadRuntime.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/instanceAi.threadRuntime.test.ts
@@ -12,9 +12,10 @@ import { createThreadRuntime, type ThreadRuntime } from '../instanceAi.threadRun
 // Mocks
 // ---------------------------------------------------------------------------
 
+const { mockShowError } = vi.hoisted(() => ({ mockShowError: vi.fn() }));
 vi.mock('@/app/composables/useToast', () => ({
 	useToast: vi.fn().mockReturnValue({
-		showError: vi.fn(),
+		showError: mockShowError,
 	}),
 }));
 
@@ -983,6 +984,41 @@ describe('createThreadRuntime - gateway resource-decision confirmation', () => {
 
 		// postConfirmation was called once (inside confirmAction) but threw
 		expect(mockPostConfirmation).toHaveBeenCalledOnce();
+	});
+
+	it('confirmAction surfaces the server UserError message on a 400 response', async () => {
+		const { ResponseError } = await import('@n8n/rest-api-client');
+		const serverError = new ResponseError(
+			'This confirmation was lost when the assistant restarted. Send a new message to continue.',
+		);
+		(serverError as { httpStatusCode?: number }).httpStatusCode = 400;
+		mockPostConfirmation.mockRejectedValueOnce(serverError);
+		mockShowError.mockClear();
+
+		const ok = await activeRuntime(registry).confirmAction('req-lost', {
+			kind: 'approval',
+			approved: true,
+		});
+
+		expect(ok).toBe(false);
+		expect(mockShowError).toHaveBeenCalledTimes(1);
+		const [errorArg, titleArg] = mockShowError.mock.calls[0];
+		expect((errorArg as Error).message).toContain('lost when the assistant restarted');
+		expect(titleArg).toBe('Confirmation failed');
+	});
+
+	it('confirmAction falls back to a generic message on non-400 errors', async () => {
+		mockPostConfirmation.mockRejectedValueOnce(new Error('network error'));
+		mockShowError.mockClear();
+
+		await activeRuntime(registry).confirmAction('req-network', {
+			kind: 'approval',
+			approved: true,
+		});
+
+		expect(mockShowError).toHaveBeenCalledTimes(1);
+		const [errorArg] = mockShowError.mock.calls[0];
+		expect((errorArg as Error).message).toBe('Failed to send confirmation. Try again.');
 	});
 });
 

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.threadRuntime.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/instanceAi.threadRuntime.ts
@@ -856,8 +856,25 @@ export function createThreadRuntime(threadId: string, hooks: ThreadRuntimeHooks)
 		try {
 			await postConfirmation(rootStore.restApiContext, requestId, payload);
 			return true;
-		} catch {
-			toast.showError(new Error('Failed to send confirmation. Try again.'), 'Confirmation failed');
+		} catch (error: unknown) {
+			// Surface the server's UserError text when present (e.g. "This
+			// confirmation was lost when the assistant restarted") so the user
+			// sees the actual reason instead of a generic "Try again". UserError
+			// from `n8n-workflow` is mapped to a 400 with the message in the
+			// response body — `ResponseError.message` exposes that here.
+			const status = error instanceof ResponseError ? error.httpStatusCode : undefined;
+			if (status === 400) {
+				const serverMessage = error instanceof ResponseError && error.message ? error.message : '';
+				toast.showError(
+					new Error(serverMessage || 'The confirmation could not be processed.'),
+					'Confirmation failed',
+				);
+			} else {
+				toast.showError(
+					new Error('Failed to send confirmation. Try again.'),
+					'Confirmation failed',
+				);
+			}
 			return false;
 		}
 	}


### PR DESCRIPTION
## Summary

First half of agents HITL persistence. If you manually test this, perhaps checkout the branch from the followup ticket instead of this one - it's split into two to make the review slightly less painful I hope.

Continued from https://github.com/n8n-io/n8n/pull/31074, followup https://github.com/n8n-io/n8n/pull/31052

Makes Instance AI HITL confirmations survive process restart. Currently the index of "confirmations the assistant is waiting on" lives entirely in-memory (`RunStateRegistry.pendingConfirmations` + `suspendedRuns`), so a restart / crash / multi-main loses every pending HITL prompt and leaves the UI sitting on a card that no longer has any backend state to resume.

This PR adds the resume path on top of the schema in thre migration PR:

- `waitForConfirmation` now writes an `instance_ai_pending_confirmations` row alongside registering the in-memory Promise. The DB row carries the metadata a fresh process needs to find and resume the confirmation (`requestId` PK, `threadId`, `userId`, `kind`, `runId`, `agentRunId`, `toolCallId`, `messageGroupId`, `checkpointKey`, `expiresAt`).
- `resolveConfirmation` keeps the in-memory fast path; on miss it falls through to a new `resolveOrphanedConfirmation` that atomically `claim()`s the persisted row (delete-returning, scoped by `userId` so a different user can't claim someone else's request), rebuilds the orchestration environment + agent from the existing `instance_ai_checkpoints` snapshot, and hands off to the existing `resumeSuspendedRun` path. The original `runId` / `messageGroupId` are reused so the frontend's SSE correlation keeps working.
- `getRichMessages` merges in-flight checkpoint messages into the rendered history so a user reloading the thread sees the prompt + intermediate assistant rows that the SDK hadn't flushed to memory yet (it only commits on a clean turn end).
- `shutdown()` now distinguishes runs with pending HITL (preserve the snapshot + pending-confirmation row + sentinel abort) from truly mid-stream runs (publish `run-finish(cancelled, service_shutdown)`, save terminal snapshot, abort), with a 5s drain on in-flight executions so the SDK's cleanup doesn't race the DB close.
- `DbSnapshotStorage.markRunCancelled` walks the saved tree and flips active nodes/tool calls/unresolved confirmations to a terminal state in place — replaces a rebuild-from-empty-event-bus that previously erased the plan card on orphan claim.
- Frontend surfaces server-side confirmation errors through the existing toast instead of swallowing them.
- A small workaround pre-saves the user message on the first HITL suspend so the user's bubble is visible on reload, since the SDK only flushes the turn delta on a clean loop end. Documented in code as a workaround; cleanly extended by the follow-up cascade PR rather than removed.
- Leader-gated prune sweep marks stale checkpoints expired (1h cadence, 24h retention default) and drops `pending_confirmation` rows past their `expiresAt`.

## Out of scope (follow-up PRs)

- https://github.com/n8n-io/n8n/pull/31052 continues this - replaces the legacy `waitForConfirmation` Promise pattern for the planner via SDK-native `ctx.suspend` cascade, plus the matching frontend plan card dedupe and the expired card UI.
- Background-task HITL (workflow-builder asking for credential approval, browser-credential-setup) - still gone after restart; needs a separate "detached sub-agent rehydration" design.
- Cold-start sweep of `active` planned-task graphs whose `running` tasks have no `BackgroundTaskManager` entry - separate followup.

## Related Linear tickets, Github issues, and Community forum posts

Linear: https://linear.app/n8n/issue/INS-198

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
