### PR TITLE
feat(core): Add audit event for redaction enforcement policy changes

### DIFF
--- a/packages/cli/src/controllers/security-settings.controller.ts
+++ b/packages/cli/src/controllers/security-settings.controller.ts
@@ -95,14 +95,28 @@ export class SecuritySettingsController {
 			this.emitInstancePolicyUpdated(req, 'workflow_sharing', dto.personalSpaceSharing);
 		}
 
-		// TODO(IAM-622): emit a dedicated audit event with before/after state for
-		// redaction enforcement changes. The existing `instance-policies-updated`
-		// event carries a single boolean and can't represent the `floor` enum.
 		if (dto.redactionEnforcement !== undefined && isRedactionEnforcementEnabled()) {
-			await this.instanceRedactionEnforcementService.set(
-				floorToSettings(dto.redactionEnforcement.floor),
-			);
+			const before = await this.instanceRedactionEnforcementService.get();
+			const after = floorToSettings(dto.redactionEnforcement.floor);
 			updatedSettings.redactionEnforcement = { floor: dto.redactionEnforcement.floor };
+			if (
+				before.enforced !== after.enforced ||
+				before.manual !== after.manual ||
+				before.production !== after.production
+			) {
+				await this.instanceRedactionEnforcementService.set(after);
+				this.eventService.emit('redaction-enforcement-updated', {
+					user: {
+						id: req.user.id,
+						email: req.user.email,
+						firstName: req.user.firstName,
+						lastName: req.user.lastName,
+						role: req.user.role,
+					},
+					before,
+					after,
+				});
+			}
 		}
 
 		return updatedSettings;

--- a/packages/cli/src/eventbus/event-message-classes/index.ts
+++ b/packages/cli/src/eventbus/event-message-classes/index.ts
@@ -107,6 +107,7 @@ export const eventNamesAudit = [
 	'n8n.audit.personal-sharing-restricted.disabled',
 	'n8n.audit.2fa-enforcement.enabled',
 	'n8n.audit.2fa-enforcement.disabled',
+	'n8n.audit.redaction-enforcement.updated',
 	'n8n.audit.execution.data.revealed',
 	'n8n.audit.execution.data.reveal_failure',
 	'n8n.audit.token-exchange.succeeded',

--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -2657,4 +2657,93 @@ describe('LogStreamingEventRelay', () => {
 			});
 		});
 	});
+
+	describe('redaction enforcement events', () => {
+		it('should log `redaction-enforcement.updated` with redacted user and before/after payload', () => {
+			const event: RelayEventMap['redaction-enforcement-updated'] = {
+				user: {
+					id: 'user404',
+					email: 'admin7@example.com',
+					firstName: 'Seventh',
+					lastName: 'Admin',
+					role: { slug: 'global:owner' },
+				},
+				before: { enforced: false, manual: false, production: false },
+				after: { enforced: true, manual: false, production: true },
+			};
+
+			eventService.emit('redaction-enforcement-updated', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.redaction-enforcement.updated',
+				payload: {
+					userId: 'user404',
+					_email: 'admin7@example.com',
+					_firstName: 'Seventh',
+					_lastName: 'Admin',
+					globalRole: 'global:owner',
+					before: { enforced: false, manual: false, production: false },
+					after: { enforced: true, manual: false, production: true },
+				},
+			});
+		});
+
+		it('should log `redaction-enforcement.updated` for downgrade (all -> production)', () => {
+			const event: RelayEventMap['redaction-enforcement-updated'] = {
+				user: {
+					id: 'user404',
+					email: 'admin7@example.com',
+					firstName: 'Seventh',
+					lastName: 'Admin',
+					role: { slug: 'global:owner' },
+				},
+				before: { enforced: true, manual: true, production: true },
+				after: { enforced: true, manual: false, production: true },
+			};
+
+			eventService.emit('redaction-enforcement-updated', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.redaction-enforcement.updated',
+				payload: {
+					userId: 'user404',
+					_email: 'admin7@example.com',
+					_firstName: 'Seventh',
+					_lastName: 'Admin',
+					globalRole: 'global:owner',
+					before: { enforced: true, manual: true, production: true },
+					after: { enforced: true, manual: false, production: true },
+				},
+			});
+		});
+
+		it('should log `redaction-enforcement.updated` for upgrade to `all` (full-tuple passthrough)', () => {
+			const event: RelayEventMap['redaction-enforcement-updated'] = {
+				user: {
+					id: 'user404',
+					email: 'admin7@example.com',
+					firstName: 'Seventh',
+					lastName: 'Admin',
+					role: { slug: 'global:owner' },
+				},
+				before: { enforced: true, manual: false, production: true },
+				after: { enforced: true, manual: true, production: true },
+			};
+
+			eventService.emit('redaction-enforcement-updated', event);
+
+			expect(eventBus.sendAuditEvent).toHaveBeenCalledWith({
+				eventName: 'n8n.audit.redaction-enforcement.updated',
+				payload: {
+					userId: 'user404',
+					_email: 'admin7@example.com',
+					_firstName: 'Seventh',
+					_lastName: 'Admin',
+					globalRole: 'global:owner',
+					before: { enforced: true, manual: false, production: true },
+					after: { enforced: true, manual: true, production: true },
+				},
+			});
+		});
+	});
 });

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -1,4 +1,8 @@
-import type { AuthenticationMethod, ProjectRelation } from '@n8n/api-types';
+import type {
+	AuthenticationMethod,
+	ProjectRelation,
+	RedactionEnforcementSettings,
+} from '@n8n/api-types';
 import type { AuthProviderType, User, IWorkflowDb } from '@n8n/db';
 import type {
 	CancellationReason,
@@ -941,6 +945,12 @@ export type RelayEventMap = {
 		user: UserLike;
 		settingName: '2fa_enforcement' | 'workflow_publishing' | 'workflow_sharing';
 		value: boolean;
+	};
+
+	'redaction-enforcement-updated': {
+		user: UserLike;
+		before: RedactionEnforcementSettings;
+		after: RedactionEnforcementSettings;
 	};
 
 	// #endregion

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -107,6 +107,7 @@ export class LogStreamingEventRelay extends EventRelay {
 			'job-dequeued': (event) => this.jobDequeued(event),
 			'job-stalled': (event) => this.jobStalled(event),
 			'instance-policies-updated': (event) => this.instancePoliciesUpdated(event),
+			'redaction-enforcement-updated': (event) => this.redactionEnforcementUpdated(event),
 			'token-exchange-succeeded': (event) => this.tokenExchangeSucceeded(event),
 			'token-exchange-failed': (event) => this.tokenExchangeFailed(event),
 			'token-exchange-identity-linked': (event) => this.tokenExchangeIdentityLinked(event),
@@ -1034,6 +1035,18 @@ export class LogStreamingEventRelay extends EventRelay {
 			default:
 				assertNever(settingName);
 		}
+	}
+
+	@Redactable()
+	private redactionEnforcementUpdated({
+		user,
+		before,
+		after,
+	}: RelayEventMap['redaction-enforcement-updated']) {
+		void this.eventBus.sendAuditEvent({
+			eventName: 'n8n.audit.redaction-enforcement.updated',
+			payload: { ...user, before, after },
+		});
 	}
 
 	// #endregion

--- a/packages/cli/test/integration/controllers/security-settings.controller.test.ts
+++ b/packages/cli/test/integration/controllers/security-settings.controller.test.ts
@@ -5,6 +5,7 @@ import {
 	PERSONAL_SPACE_SHARING_SETTING,
 } from '@n8n/permissions';
 
+import { EventService } from '@/events/event.service';
 import { InstanceRedactionEnforcementService } from '@/modules/redaction/instance-redaction-enforcement.service';
 import { N8N_ENV_FEAT_REDACTION_ENFORCEMENT } from '@/modules/redaction/redaction-enforcement.feature-flag';
 import { SecuritySettingsService } from '@/services/security-settings.service';
@@ -16,6 +17,7 @@ import { setupTestServer } from '../shared/utils';
 describe('SecuritySettingsController', () => {
 	const securitySettingsService = mockInstance(SecuritySettingsService);
 	const instanceRedactionEnforcementService = mockInstance(InstanceRedactionEnforcementService);
+	const eventService = mockInstance(EventService);
 	const instanceSettingsLoaderConfig = mockInstance(InstanceSettingsLoaderConfig, {
 		securityPolicyManagedByEnv: false,
 	});
@@ -294,6 +296,14 @@ describe('SecuritySettingsController', () => {
 		});
 
 		describe('POST /settings/security', () => {
+			beforeEach(() => {
+				instanceRedactionEnforcementService.get.mockResolvedValue({
+					enforced: false,
+					manual: false,
+					production: false,
+				});
+			});
+
 			it('should ignore redactionEnforcement when feature flag is off', async () => {
 				const response = await ownerAgent
 					.post('/settings/security')
@@ -302,6 +312,10 @@ describe('SecuritySettingsController', () => {
 
 				expect(response.body).toEqual({ data: {} });
 				expect(instanceRedactionEnforcementService.set).not.toHaveBeenCalled();
+				expect(eventService.emit).not.toHaveBeenCalledWith(
+					'redaction-enforcement-updated',
+					expect.anything(),
+				);
 			});
 
 			it('should persist redactionEnforcement.floor = "production" when flag is on', async () => {
@@ -388,6 +402,52 @@ describe('SecuritySettingsController', () => {
 					.expect(400);
 
 				expect(instanceRedactionEnforcementService.set).not.toHaveBeenCalled();
+			});
+
+			describe('audit event emission', () => {
+				it('should emit `redaction-enforcement-updated` with before/after when settings change', async () => {
+					enableRedactionFlag();
+					instanceRedactionEnforcementService.get.mockResolvedValue({
+						enforced: false,
+						manual: false,
+						production: false,
+					});
+					instanceRedactionEnforcementService.set.mockResolvedValue(undefined);
+
+					await ownerAgent
+						.post('/settings/security')
+						.send({ redactionEnforcement: { floor: 'production' } })
+						.expect(200);
+
+					expect(eventService.emit).toHaveBeenCalledWith(
+						'redaction-enforcement-updated',
+						expect.objectContaining({
+							user: expect.objectContaining({ id: expect.any(String) }),
+							before: { enforced: false, manual: false, production: false },
+							after: { enforced: true, manual: false, production: true },
+						}),
+					);
+				});
+
+				it('should not emit when save is idempotent', async () => {
+					enableRedactionFlag();
+					instanceRedactionEnforcementService.get.mockResolvedValue({
+						enforced: true,
+						manual: false,
+						production: true,
+					});
+					instanceRedactionEnforcementService.set.mockResolvedValue(undefined);
+
+					await ownerAgent
+						.post('/settings/security')
+						.send({ redactionEnforcement: { floor: 'production' } })
+						.expect(200);
+
+					expect(eventService.emit).not.toHaveBeenCalledWith(
+						'redaction-enforcement-updated',
+						expect.anything(),
+					);
+				});
 			});
 		});
 	});

--- a/packages/cli/test/integration/controllers/security-settings.controller.test.ts
+++ b/packages/cli/test/integration/controllers/security-settings.controller.test.ts
@@ -356,6 +356,11 @@ describe('SecuritySettingsController', () => {
 
 			it('should persist redactionEnforcement.floor = "off" when flag is on', async () => {
 				enableRedactionFlag();
+				instanceRedactionEnforcementService.get.mockResolvedValue({
+					enforced: true,
+					manual: false,
+					production: true,
+				});
 				instanceRedactionEnforcementService.set.mockResolvedValue(undefined);
 
 				await ownerAgent

--- a/packages/cli/test/integration/controllers/security-settings.controller.test.ts
+++ b/packages/cli/test/integration/controllers/security-settings.controller.test.ts
@@ -434,6 +434,30 @@ describe('SecuritySettingsController', () => {
 					);
 				});
 
+				it('should emit `redaction-enforcement-updated` with before/after when settings are disabled', async () => {
+					enableRedactionFlag();
+					instanceRedactionEnforcementService.get.mockResolvedValue({
+						enforced: true,
+						manual: false,
+						production: true,
+					});
+					instanceRedactionEnforcementService.set.mockResolvedValue(undefined);
+
+					await ownerAgent
+						.post('/settings/security')
+						.send({ redactionEnforcement: { floor: 'off' } })
+						.expect(200);
+
+					expect(eventService.emit).toHaveBeenCalledWith(
+						'redaction-enforcement-updated',
+						expect.objectContaining({
+							user: expect.objectContaining({ id: expect.any(String) }),
+							before: { enforced: true, manual: false, production: true },
+							after: { enforced: false, manual: false, production: false },
+						}),
+					);
+				});
+
 				it('should not emit when save is idempotent', async () => {
 					enableRedactionFlag();
 					instanceRedactionEnforcementService.get.mockResolvedValue({


### PR DESCRIPTION
## Summary

Adds an audit event that fires when an instance admin changes the redaction enforcement floor via `POST /settings/security`. The event carries the actor, the before/after redaction settings (`enforced`, `manual`, `production`), and a timestamp, and is forwarded to log-streaming destinations as `n8n.audit.redaction-enforcement.updated`.

### What changes vs master

- **`security-settings.controller.ts`**: when `redactionEnforcement.floor` is part of the request and the feature flag is on, read the current settings, persist the new ones, and emit `redaction-enforcement-updated` only if the resulting tuple actually changed.
- **`relay.event-map.ts`**: declares the new `redaction-enforcement-updated` event with `user`, `before`, `after` fields.
- **`log-streaming.event-relay.ts`**: maps the internal event to the public `n8n.audit.redaction-enforcement.updated` audit event, applying `@Redactable()` to the user fields so log destinations honor the same redaction prefs as `instance-policies-updated`.
- **`eventbus/event-message-classes/index.ts`**: registers `n8n.audit.redaction-enforcement.updated` in the allowed event-name union.
- **Tests**: unit coverage in `log-streaming-event-relay.test.ts` plus integration coverage in `security-settings.controller.test.ts` for the enable transition, the disable transition, the idempotent save (no emit), and the case where the feature flag is unset (field ignored, no emit).

### Behavior notes

- Emission is gated on the existing `N8N_ENV_FEAT_REDACTION_ENFORCEMENT` flag. When unset, the `redactionEnforcement` field is ignored and no event is produced.
- Idempotent saves (same tuple as stored) are silent.
- Payload shape mirrors the sibling `instance-policies-updated` event.

### How to test

1. Configure a Webhook destination under **Settings → Log streaming** subscribed to audit events.
2. With `N8N_ENV_FEAT_REDACTION_ENFORCEMENT=true`, change the redaction floor in Security & Policies. The webhook receives one event with the expected before/after.
3. Saving the same value twice in a row produces no second event.
4. With the env flag unset, `POST /rest/settings/security` with a `redactionEnforcement` field returns `{"data":{}}` and no event is emitted.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-622

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)
