### PR TITLE
fix(editor): Apply prettier formatting to resource center files (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/experiments/resourceCenter/components/ResourceFeatureCard.vue
+++ b/packages/frontend/editor-ui/src/experiments/resourceCenter/components/ResourceFeatureCard.vue
@@ -113,7 +113,8 @@ const resolvedArtworkNodeTypes = computed(() => {
 	border-radius: var(--radius--lg);
 	border: 1px solid
 		var(--feature--border-color--card, color-mix(in srgb, var(--feature--color--accent) 16%, white));
-	background: radial-gradient(circle at 88% 12%, rgba(255, 255, 255, 0.92), transparent 18rem),
+	background:
+		radial-gradient(circle at 88% 12%, rgba(255, 255, 255, 0.92), transparent 18rem),
 		linear-gradient(
 			122deg,
 			var(--feature--color--background--surface) 0%,
@@ -173,8 +174,8 @@ const resolvedArtworkNodeTypes = computed(() => {
 
 	&.dark {
 		--feature--border-color--card: rgba(255, 255, 255, 0.1);
-		--feature--shadow--card: 0 0 0 0.5px
-				color-mix(in srgb, var(--feature--color--accent) 28%, transparent),
+		--feature--shadow--card:
+			0 0 0 0.5px color-mix(in srgb, var(--feature--color--accent) 28%, transparent),
 			0 1px 3px -1px rgba(0, 0, 0, 0.18);
 	}
 }
@@ -240,7 +241,8 @@ const resolvedArtworkNodeTypes = computed(() => {
 	color: white;
 	font-size: var(--font-size--2xs);
 	font-weight: var(--font-weight--bold);
-	box-shadow: 0 0.75rem 1.5rem -1rem color-mix(in srgb, var(--feature--shadow--accent) 42%, transparent);
+	box-shadow: 0 0.75rem 1.5rem -1rem
+		color-mix(in srgb, var(--feature--shadow--accent) 42%, transparent);
 	cursor: pointer;
 	transition:
 		transform 0.18s ease,

--- a/packages/frontend/editor-ui/src/experiments/resourceCenter/views/ResourceCenterView.vue
+++ b/packages/frontend/editor-ui/src/experiments/resourceCenter/views/ResourceCenterView.vue
@@ -311,11 +311,12 @@ onMounted(() => {
 	);
 	--resource-center--icon-color--search: var(--color--text--tint-1);
 	--resource-center--color--text--placeholder: var(--color--text--tint-1);
-	--resource-center--shadow--search: 0 1px 2px -1px color-mix(in srgb, var(--color--text--shade-1)
-				10%, transparent);
+	--resource-center--shadow--search: 0 1px 2px -1px
+		color-mix(in srgb, var(--color--text--shade-1) 10%, transparent);
 	--resource-center--color--background--card: white;
 	--resource-center--border-color--card: rgba(0, 0, 0, 0.1);
-	--resource-center--shadow--card: 0 0 0 0.5px rgba(0, 0, 0, 0.1), 0 1px 3px -1px rgba(0, 0, 0, 0.1);
+	--resource-center--shadow--card:
+		0 0 0 0.5px rgba(0, 0, 0, 0.1), 0 1px 3px -1px rgba(0, 0, 0, 0.1);
 	--resource-center--color--background--card-tag: color-mix(
 		in srgb,
 		var(--color--foreground--tint-2) 9%,
@@ -329,8 +330,8 @@ onMounted(() => {
 	--resource-center--color--text--card-tag: var(--color--text--shade-1);
 	--resource-center--color--background--icon-token: #ebebeb;
 	--resource-center--border-color--icon-token: white;
-	--resource-center--shadow--icon-token: 0 0 0 0.5px rgba(0, 0, 0, 0.04),
-		0 1px 2px rgba(0, 0, 0, 0.04);
+	--resource-center--shadow--icon-token:
+		0 0 0 0.5px rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.04);
 	--resource-center--color--background--count-bubble: #e0e0e0;
 	--resource-center--border-color--count-bubble: rgba(0, 0, 0, 0.04);
 	--resource-center--color--text--count-bubble: #444;
@@ -351,8 +352,8 @@ onMounted(() => {
 		--resource-center--shadow--search: none;
 		--resource-center--color--background--card: #262626;
 		--resource-center--border-color--card: rgba(255, 255, 255, 0.1);
-		--resource-center--shadow--card: 0 0 0 0.5px rgba(0, 0, 0, 0.1),
-			0 1px 3px -1px rgba(0, 0, 0, 0.1);
+		--resource-center--shadow--card:
+			0 0 0 0.5px rgba(0, 0, 0, 0.1), 0 1px 3px -1px rgba(0, 0, 0, 0.1);
 		--resource-center--color--background--card-tag: rgba(255, 255, 255, 0.06);
 		--resource-center--border-color--card-tag: rgba(255, 255, 255, 0.08);
 		--resource-center--color--text--card-tag: #f5f5f5;


### PR DESCRIPTION
## Summary

Two Vue files under `packages/frontend/editor-ui/src/experiments/resourceCenter/` failed `prettier --check` on master, breaking `install-and-build` CI on every new PR. Running `prettier --write` on them resolves the failure.

- `src/experiments/resourceCenter/components/ResourceFeatureCard.vue`
- `src/experiments/resourceCenter/views/ResourceCenterView.vue`

## Test plan

- [ ] CI `install-and-build` passes
- [ ] Pure formatting — no behavior change