### PR TITLE
refactor(editor): Prep for per-workflow NDV store scoping (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useNodeExecution.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeExecution.ts
@@ -286,6 +286,8 @@ export function useNodeExecution(
 				prompt,
 				`parameters.${AI_TRANSFORM_JS_CODE}`,
 				workflowDocumentStore.value.documentId,
+				ndvStore.activeNode,
+				ndvStore.pushRef,
 				5,
 			);
 
@@ -315,12 +317,12 @@ export function useNodeExecution(
 				value: prompt,
 			});
 
-			telemetry.trackAiTransform('generationFinished', {
+			telemetry.trackAiTransform('generationFinished', ndvStore.pushRef, {
 				prompt,
 				code: updateInformation.value,
 			});
 		} catch (error) {
-			telemetry.trackAiTransform('generationFinished', {
+			telemetry.trackAiTransform('generationFinished', ndvStore.pushRef, {
 				prompt: nodeRef.value?.parameters?.instructions as string,
 				code: '',
 				hasError: true,

--- a/packages/frontend/editor-ui/src/app/plugins/telemetry/index.ts
+++ b/packages/frontend/editor-ui/src/app/plugins/telemetry/index.ts
@@ -13,7 +13,6 @@ import {
 	POSTHOG_EVENTS_BLACKLIST,
 } from '@/app/constants';
 import { useRootStore } from '@n8n/stores/useRootStore';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { usePostHog } from '@/app/stores/posthog.store';
@@ -167,10 +166,10 @@ export class Telemetry {
 		});
 	}
 
-	trackAskAI(event: string, properties: IDataObject = {}) {
+	trackAskAI(event: string, ndvPushRef: string, properties: IDataObject = {}) {
 		if (this.rudderStack) {
 			properties.session_id = useRootStore().pushRef;
-			properties.ndv_session_id = useNDVStore().pushRef;
+			properties.ndv_session_id = ndvPushRef;
 
 			switch (event) {
 				case 'askAi.generationFinished':
@@ -181,10 +180,10 @@ export class Telemetry {
 		}
 	}
 
-	trackAiTransform(event: string, properties: IDataObject = {}) {
+	trackAiTransform(event: string, ndvPushRef: string, properties: IDataObject = {}) {
 		if (this.rudderStack) {
 			properties.session_id = useRootStore().pushRef;
-			properties.ndv_session_id = useNDVStore().pushRef;
+			properties.ndv_session_id = ndvPushRef;
 
 			switch (event) {
 				case 'generationFinished':

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -527,8 +527,10 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		currentState.value.clearActiveNodeExecutionData(nodeName);
 	}
 
+	// TODO(per-workflow-ndv-PR2): remove this shim once consumers (assistant.store)
+	// switch to a hoisted scoped NDV store. External FE-hooks consumers reach this
+	// via `workflowsStore.activeNode()` and will lose this surface.
 	function activeNode(): INodeUi | null {
-		// kept here for FE hooks
 		const ndvStore = useNDVStore();
 		return ndvStore.activeNode;
 	}

--- a/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflows.store.ts
@@ -527,9 +527,9 @@ export const useWorkflowsStore = defineStore(STORES.WORKFLOWS, () => {
 		currentState.value.clearActiveNodeExecutionData(nodeName);
 	}
 
-	// TODO(per-workflow-ndv-PR2): remove this shim once consumers (assistant.store)
-	// switch to a hoisted scoped NDV store. External FE-hooks consumers reach this
-	// via `workflowsStore.activeNode()` and will lose this surface.
+	// TODO: remove this shim once consumers (assistant.store) switch to a hoisted
+	// scoped NDV store. External FE-hooks consumers reach this via
+	// `workflowsStore.activeNode()` and will lose this surface.
 	function activeNode(): INodeUi | null {
 		const ndvStore = useNDVStore();
 		return ndvStore.activeNode;

--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
@@ -32,10 +32,10 @@ import { v4 as uuid } from 'uuid';
 export const ENABLED_VIEWS = ASSISTANT_ENABLED_VIEWS;
 const READABLE_TYPES = ['code-diff', 'text', 'block'];
 
-// TODO(per-workflow-ndv-PR2): the `workflowsStore.activeNode()` calls below will
-// switch to a hoisted scoped NDV store (`useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId)).activeNode`).
-// Leaving them on the shim in PR1 preserves state consistency with NDV components
-// that still write to the default store; they all flip together in PR2.
+// TODO: the `workflowsStore.activeNode()` calls below will switch to a hoisted
+// scoped NDV store (`useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId)).activeNode`).
+// Leaving them on the shim for now preserves state consistency with NDV components
+// that still write to the default store; they need to flip together.
 export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 	const settings = useSettingsStore();
 	const rootStore = useRootStore();

--- a/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/assistant.store.ts
@@ -32,6 +32,10 @@ import { v4 as uuid } from 'uuid';
 export const ENABLED_VIEWS = ASSISTANT_ENABLED_VIEWS;
 const READABLE_TYPES = ['code-diff', 'text', 'block'];
 
+// TODO(per-workflow-ndv-PR2): the `workflowsStore.activeNode()` calls below will
+// switch to a hoisted scoped NDV store (`useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId)).activeNode`).
+// Leaving them on the shim in PR1 preserves state consistency with NDV components
+// that still write to the default store; they all flip together in PR2.
 export const useAssistantStore = defineStore(STORES.ASSISTANT, () => {
 	const settings = useSettingsStore();
 	const rootStore = useRootStore();

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ButtonParameter/ButtonParameter.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ButtonParameter/ButtonParameter.vue
@@ -110,6 +110,8 @@ async function onSubmit() {
 					prompt.value,
 					getPath(target as string),
 					workflowDocumentStore.value.documentId,
+					ndvStore.activeNode,
+					ndvStore.pushRef,
 					5,
 				);
 				if (!updateInformation) return;
@@ -123,7 +125,7 @@ async function onSubmit() {
 					value: prompt.value,
 				});
 
-				useTelemetry().trackAiTransform('generationFinished', {
+				useTelemetry().trackAiTransform('generationFinished', ndvStore.pushRef, {
 					prompt: prompt.value,
 					code: updateInformation.value,
 				});
@@ -139,7 +141,7 @@ async function onSubmit() {
 
 		stopLoading();
 	} catch (error) {
-		useTelemetry().trackAiTransform('generationFinished', {
+		useTelemetry().trackAiTransform('generationFinished', ndvStore.pushRef, {
 			prompt: prompt.value,
 			code: '',
 			hasError: true,
@@ -162,7 +164,7 @@ function onPromptInput(inputValue: string) {
 }
 
 onMounted(() => {
-	parentNodes.value = getParentNodes(workflowDocumentStore.value.documentId);
+	parentNodes.value = getParentNodes(workflowDocumentStore.value.documentId, ndvStore.activeNode);
 });
 
 function cleanTextareaRowsData() {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/utils/buttonParameter.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/utils/buttonParameter.utils.test.ts
@@ -24,12 +24,6 @@ vi.mock('@n8n/stores/useRootStore', () => ({
 	}),
 }));
 
-vi.mock('@/features/ndv/shared/ndv.store', () => ({
-	useNDVStore: () => ({
-		pushRef: 'mockNdvPushRef',
-	}),
-}));
-
 vi.mock('@/app/stores/settings.store', () => ({
 	useSettingsStore: vi.fn(() => ({ settings: {}, isAskAiEnabled: true })),
 }));
@@ -60,6 +54,8 @@ describe('generateCodeForAiTransform - Retry Tests', () => {
 			'test prompt',
 			'test/path',
 			createWorkflowDocumentId(''),
+			null,
+			'mockNdvPushRef',
 			2,
 		);
 
@@ -74,7 +70,14 @@ describe('generateCodeForAiTransform - Retry Tests', () => {
 		vi.mocked(generateCodeForPrompt).mockRejectedValue(new Error('All attempts failed'));
 
 		await expect(
-			generateCodeForAiTransform('test prompt', 'test/path', createWorkflowDocumentId(''), 3),
+			generateCodeForAiTransform(
+				'test prompt',
+				'test/path',
+				createWorkflowDocumentId(''),
+				null,
+				'mockNdvPushRef',
+				3,
+			),
 		).rejects.toThrow('All attempts failed');
 
 		expect(generateCodeForPrompt).toHaveBeenCalledTimes(3);
@@ -88,6 +91,8 @@ describe('generateCodeForAiTransform - Retry Tests', () => {
 			'test prompt',
 			'test/path',
 			createWorkflowDocumentId(''),
+			null,
+			'mockNdvPushRef',
 		);
 
 		expect(result).toEqual({

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/utils/buttonParameter.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/utils/buttonParameter.utils.ts
@@ -1,6 +1,5 @@
 import type { Schema } from '@/Interface';
-import { ApplicationError, type INodeExecutionData } from 'n8n-workflow';
-import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { ApplicationError, type INode, type INodeExecutionData } from 'n8n-workflow';
 import { useDataSchema } from '@/app/composables/useDataSchema';
 import { executionDataToJson } from '@/app/utils/nodeTypesUtils';
 import { generateCodeForPrompt } from '@/features/ai/assistant/assistant.api';
@@ -20,14 +19,13 @@ export type TextareaRowData = {
 	linesToRowsMap: number[][];
 };
 
-export function getParentNodes(workflowDocumentId: WorkflowDocumentId) {
+export function getParentNodes(workflowDocumentId: WorkflowDocumentId, activeNode: INode | null) {
 	const workflowDocumentStore = useWorkflowDocumentStore(workflowDocumentId);
-	const activeNode = useNDVStore().activeNode;
 
 	if (!activeNode) return [];
 
 	return workflowDocumentStore
-		.getParentNodesByDepth(activeNode?.name)
+		.getParentNodesByDepth(activeNode.name)
 		.filter(({ name }, i, nodes) => {
 			return name !== activeNode.name && nodes.findIndex((node) => node.name === name) === i;
 		})
@@ -35,8 +33,8 @@ export function getParentNodes(workflowDocumentId: WorkflowDocumentId) {
 		.filter((n) => n !== null);
 }
 
-export function getSchemas(workflowDocumentId: WorkflowDocumentId) {
-	const parentNodes = getParentNodes(workflowDocumentId);
+export function getSchemas(workflowDocumentId: WorkflowDocumentId, activeNode: INode | null) {
+	const parentNodes = getParentNodes(workflowDocumentId, activeNode);
 	const parentNodesNames = parentNodes.map((node) => node?.name);
 	const { getSchemaForExecutionData, getInputDataWithPinned } = useDataSchema();
 	const parentNodesSchemas: Array<{ nodeName: string; schema: Schema }> = parentNodes
@@ -187,16 +185,18 @@ export async function generateCodeForAiTransform(
 	prompt: string,
 	path: string,
 	workflowDocumentId: WorkflowDocumentId,
+	activeNode: INode | null,
+	ndvPushRef: string,
 	retries = 1,
 ) {
-	const schemas = getSchemas(workflowDocumentId);
+	const schemas = getSchemas(workflowDocumentId, activeNode);
 
 	const payload: AskAiRequest.RequestPayload = {
 		question: prompt,
 		context: {
 			schema: schemas.parentNodesSchemas,
 			inputSchema: schemas.inputSchema!,
-			ndvPushRef: useNDVStore().pushRef,
+			ndvPushRef,
 			pushRef: useRootStore().pushRef,
 		},
 		forNode: 'transform',

--- a/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/AskAI/AskAI.vue
+++ b/packages/frontend/editor-ui/src/features/shared/editors/components/CodeNodeEditor/AskAI/AskAI.vue
@@ -190,7 +190,7 @@ async function onSubmit() {
 			type: 'success',
 			title: i18n.baseText('codeNodeEditor.askAi.generationCompleted'),
 		});
-		useTelemetry().trackAskAI('askAi.generationFinished', {
+		useTelemetry().trackAskAI('askAi.generationFinished', ndvStore.pushRef, {
 			prompt: prompt.value,
 			code,
 		});
@@ -204,7 +204,7 @@ async function onSubmit() {
 			),
 		});
 		stopLoading();
-		useTelemetry().trackAskAI('askAi.generationFinished', {
+		useTelemetry().trackAskAI('askAi.generationFinished', ndvStore.pushRef, {
 			prompt: prompt.value,
 			code: '',
 			hasError: true,


### PR DESCRIPTION
## Summary

Decouple the non-component NDV callers (`buttonParameter.utils`, `Telemetry` plugin) from direct `useNDVStore()` lookups so the next PR can flip `injectNDVStore()` to a workflow-document-scoped, `ShallowRef`-returning helper atomically. This PR is intentionally behavior-preserving: every callsite still resolves to the same default NDV store as before, but now via parameters passed in from the caller's own setup-time store. The remaining `useNDVStore()` shim in `workflows.store.activeNode()` and the four `workflowsStore.activeNode()` callers in `assistant.store` are annotated with `TODO(per-workflow-ndv-PR2)` markers — they must flip together with the NDV components in PR2 to keep `activeNode` reads and writes on a single store. Test it by exercising the AI Transform and Ask AI flows (generate code in a Code/AI Transform node, confirm telemetry events still fire with `ndv_session_id`).

## Related Linear tickets, Github issues, and Community forum posts

Prework for the per-workflow NDV store scoping migration (no Linear ticket yet).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI