### PR TITLE
test(ai-builder): Restore step-based checkpoint helper

### DIFF
--- a/packages/@n8n/ai-workflow-builder.ee/src/test/checkpoint-persistence.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/test/checkpoint-persistence.test.ts
@@ -11,6 +11,7 @@
  */
 import { AIMessage, HumanMessage } from '@langchain/core/messages';
 import type { BaseMessage } from '@langchain/core/messages';
+import type { CheckpointTuple } from '@langchain/langgraph';
 import {
 	Annotation,
 	Command,
@@ -41,9 +42,28 @@ async function getCheckpointMessages(
 	checkpointer: MemorySaver,
 	threadId: string,
 ): Promise<BaseMessage[]> {
-	const tuple = await checkpointer.getTuple({ configurable: { thread_id: threadId } });
-	const messages = tuple?.checkpoint?.channel_values?.messages;
+	let latestTuple: CheckpointTuple | undefined;
+	for await (const tuple of checkpointer.list({ configurable: { thread_id: threadId } })) {
+		if (!latestTuple || isLaterCheckpoint(tuple, latestTuple)) latestTuple = tuple;
+	}
+
+	const messages = latestTuple?.checkpoint?.channel_values?.messages;
 	return Array.isArray(messages) ? (messages as BaseMessage[]) : [];
+}
+
+function isLaterCheckpoint(candidate: CheckpointTuple, current: CheckpointTuple): boolean {
+	const candidateStep = getCheckpointStep(candidate);
+	const currentStep = getCheckpointStep(current);
+
+	if (candidateStep !== currentStep) return candidateStep > currentStep;
+
+	return candidate.checkpoint.ts > current.checkpoint.ts;
+}
+
+function getCheckpointStep(tuple: CheckpointTuple): number {
+	const step = tuple.metadata?.step;
+
+	return typeof step === 'number' ? step : Number.NEGATIVE_INFINITY;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Reverts #31081. The cat-bot's refactor swapped the test helper from `checkpointer.list()` + step/timestamp picker to `checkpointer.getTuple()`, which returns a checkpoint *before* the final state update in the sequential interrupt/resume case. The test `'should persist Command.update messages across two sequential interrupts and resumes'` fails on master HEAD as a result:

```
FAIL src/test/checkpoint-persistence.test.ts
  ● LangGraph Checkpoint Message Persistence › should persist Command.update messages across two sequential interrupts and resumes

    expect(received).toContain(expected) // indexOf

    Expected value: "done"
    Received array: ["q1-data", "a1-data", "request", "q2-data", "a2-data"]

      at Object.<anonymous> (src/test/checkpoint-persistence.test.ts:191:20)
```

Reproduced locally against `97d036072d` (latest master). The `step2` node *does* append `new AIMessage('done')` after the second resume, but `getTuple()` is returning an earlier checkpoint that doesn't include it. The pre-revert helper (which iterates `checkpointer.list()` and picks the highest-step tuple) returns the post-completion checkpoint correctly.

This is blocking unrelated PRs (e.g. #30961) because Backend Unit Tests is a required check.

Master's own `ci-master.yml` reported green on the merge because that workflow doesn't run the Backend Unit Tests job — the failure only surfaces in PR CI via `test-unit-reusable.yml`.

If the helper change is desirable, it should land alongside whatever fix makes `getTuple()` return the right checkpoint here.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`

## Test plan

- [x] `pnpm --filter @n8n/ai-workflow-builder.ee test src/test/checkpoint-persistence.test.ts` — 5/5 passing after revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)