### PR TITLE
fix(core): Allow dynamic credential OAuth callbacks without skip-auth env var

### DIFF
--- a/packages/cli/src/controllers/oauth/oauth1-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth1-credential.controller.ts
@@ -6,11 +6,7 @@ import { ensureError, jsonStringify } from 'n8n-workflow';
 
 import { OAuthRequest } from '@/requests';
 
-import {
-	OauthService,
-	skipAuthOnOAuthCallback,
-	type OAuth1CredentialData,
-} from '@/oauth/oauth.service';
+import { OauthService, type OAuth1CredentialData } from '@/oauth/oauth.service';
 
 @RestController('/oauth1-credential')
 export class OAuth1CredentialController {
@@ -35,7 +31,7 @@ export class OAuth1CredentialController {
 	}
 
 	/** Verify and store app code. Generate access tokens and store for respective credential */
-	@Get('/callback', { usesTemplates: true, skipAuth: skipAuthOnOAuthCallback })
+	@Get('/callback', { usesTemplates: true, allowUnauthenticated: true })
 	async handleCallback(req: OAuthRequest.OAuth1Credential.Callback, res: Response) {
 		try {
 			const { oauth_verifier, oauth_token, state: encodedState } = req.query;

--- a/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
@@ -11,7 +11,7 @@ import { ensureError, jsonParse, jsonStringify } from 'n8n-workflow';
 
 import { ExternalHooks } from '@/external-hooks';
 import { OAuthJweServiceProxy } from '@/oauth/oauth-jwe-service.proxy';
-import { OauthService, OauthVersion, skipAuthOnOAuthCallback } from '@/oauth/oauth.service';
+import { OauthService, OauthVersion } from '@/oauth/oauth.service';
 import { OAuthRequest } from '@/requests';
 
 @RestController('/oauth2-credential')
@@ -33,7 +33,7 @@ export class OAuth2CredentialController {
 	}
 
 	/** Verify and store app code. Generate access tokens and store for respective credential */
-	@Get('/callback', { usesTemplates: true, skipAuth: skipAuthOnOAuthCallback })
+	@Get('/callback', { usesTemplates: true, allowUnauthenticated: true })
 	async handleCallback(req: OAuthRequest.OAuth2Credential.Callback, res: Response) {
 		try {
 			const { code, state: encodedState } = req.query;

--- a/packages/cli/test/integration/controllers/oauth/oauth1.api.test.ts
+++ b/packages/cli/test/integration/controllers/oauth/oauth1.api.test.ts
@@ -55,6 +55,68 @@ describe('OAuth1 API', () => {
 		nock.cleanAll();
 	});
 
+	describe('callback route accessibility', () => {
+		// The callback route must be reachable without
+		// an n8n session (so external/dynamic-credential OAuth flows complete) while the handler
+		// still enforces session-bound validation for static credentials.
+		it('should reach the handler when called without authentication', async () => {
+			const renderSpy = jest.spyOn(Response, 'render').mockImplementation(function (this: any) {
+				this.end();
+				return this;
+			});
+
+			await testServer.authlessAgent
+				.get('/oauth1-credential/callback')
+				.query({
+					oauth_token: 'request_token',
+					oauth_verifier: 'verifier',
+					state: 'invalid_state',
+				})
+				.expect(200);
+
+			expect(renderSpy).toHaveBeenCalledWith(
+				'oauth-error-callback',
+				expect.objectContaining({
+					error: expect.objectContaining({ message: expect.any(String) }),
+				}),
+			);
+		});
+
+		it('should reject an unauthenticated callback for a static credential', async () => {
+			const oauthService = Container.get(OauthService);
+			const csrfSpy = jest.spyOn(oauthService, 'createCsrfState').mockClear();
+			const renderSpy = jest.spyOn(Response, 'render').mockImplementation(function (this: any) {
+				this.end();
+				return this;
+			});
+
+			nock('https://test.domain')
+				.post('/oauth1/request_token')
+				.reply(200, 'oauth_token=request_token&oauth_token_secret=request_secret');
+
+			await testServer
+				.authAgentFor(owner)
+				.get('/oauth1-credential/auth')
+				.query({ id: credential.id })
+				.expect(200);
+
+			const [, state] = await csrfSpy.mock.results[0].value;
+
+			await testServer.authlessAgent
+				.get('/oauth1-credential/callback')
+				.query({
+					oauth_token: 'request_token',
+					oauth_verifier: 'verifier',
+					state,
+				})
+				.expect(200);
+
+			expect(renderSpy).toHaveBeenCalledWith('oauth-error-callback', {
+				error: { message: 'Unauthorized' },
+			});
+		});
+	});
+
 	describe('OAuth reconnect authorization', () => {
 		const expectNoCsrfStateOnCredential = async (credentialId: string) => {
 			const stored = await getCredentialById(credentialId);

--- a/packages/cli/test/integration/controllers/oauth/oauth2.api.test.ts
+++ b/packages/cli/test/integration/controllers/oauth/oauth2.api.test.ts
@@ -165,9 +165,10 @@ describe('OAuth2 API', () => {
 		// an n8n session (so external/dynamic-credential OAuth flows complete) while the handler
 		// still enforces session-bound validation for static credentials.
 		it('should reach the handler when called without authentication', async () => {
-			const renderSpy = (Response.render = jest.fn(function () {
+			const renderSpy = jest.spyOn(Response, 'render').mockImplementation(function (this: any) {
 				this.end();
-			}));
+				return this;
+			});
 
 			await testServer.authlessAgent
 				.get('/oauth2-credential/callback')
@@ -185,9 +186,10 @@ describe('OAuth2 API', () => {
 		it('should reject an unauthenticated callback for a static credential', async () => {
 			const oauthService = Container.get(OauthService);
 			const csrfSpy = jest.spyOn(oauthService, 'createCsrfState').mockClear();
-			const renderSpy = (Response.render = jest.fn(function () {
+			const renderSpy = jest.spyOn(Response, 'render').mockImplementation(function (this: any) {
 				this.end();
-			}));
+				return this;
+			});
 
 			await ownerAgent.get('/oauth2-credential/auth').query({ id: credential.id }).expect(200);
 
@@ -306,9 +308,10 @@ describe('OAuth2 API', () => {
 			await shareCredentialWithUsers(credential, [sharee]);
 
 			const oauthService = Container.get(OauthService);
-			const renderSpy = (Response.render = jest.fn(function () {
+			const renderSpy = jest.spyOn(Response, 'render').mockImplementation(function (this: any) {
 				this.end();
-			}));
+				return this;
+			});
 
 			// Build a callback state whose decrypted userId equals the requesting member,
 			// so the userId equality check inside decodeCsrfState passes and the credential

--- a/packages/cli/test/integration/controllers/oauth/oauth2.api.test.ts
+++ b/packages/cli/test/integration/controllers/oauth/oauth2.api.test.ts
@@ -160,6 +160,50 @@ describe('OAuth2 API', () => {
 		});
 	});
 
+	describe('callback route accessibility', () => {
+		// The callback route must be reachable without
+		// an n8n session (so external/dynamic-credential OAuth flows complete) while the handler
+		// still enforces session-bound validation for static credentials.
+		it('should reach the handler when called without authentication', async () => {
+			const renderSpy = (Response.render = jest.fn(function () {
+				this.end();
+			}));
+
+			await testServer.authlessAgent
+				.get('/oauth2-credential/callback')
+				.query({ code: 'auth_code', state: 'invalid_state' })
+				.expect(200);
+
+			expect(renderSpy).toHaveBeenCalledWith(
+				'oauth-error-callback',
+				expect.objectContaining({
+					error: expect.objectContaining({ message: expect.any(String) }),
+				}),
+			);
+		});
+
+		it('should reject an unauthenticated callback for a static credential', async () => {
+			const oauthService = Container.get(OauthService);
+			const csrfSpy = jest.spyOn(oauthService, 'createCsrfState').mockClear();
+			const renderSpy = (Response.render = jest.fn(function () {
+				this.end();
+			}));
+
+			await ownerAgent.get('/oauth2-credential/auth').query({ id: credential.id }).expect(200);
+
+			const [, state] = await csrfSpy.mock.results[0].value;
+
+			await testServer.authlessAgent
+				.get('/oauth2-credential/callback')
+				.query({ code: 'auth_code', state })
+				.expect(200);
+
+			expect(renderSpy).toHaveBeenCalledWith('oauth-error-callback', {
+				error: { message: 'Unauthorized' },
+			});
+		});
+	});
+
 	it('should handle a valid callback without auth', async () => {
 		const oauthService = Container.get(OauthService);
 		const csrfSpy = jest.spyOn(oauthService, 'createCsrfState').mockClear();


### PR DESCRIPTION
## Summary

Removes the dependency between dynamic-credential OAuth authorization and `N8N_SKIP_AUTH_ON_OAUTH_CALLBACK=true`. Dynamic credentials are initiated externally (e.g. embed flows) and the browser returning from the IdP has no n8n session — under the v2 secure default the callback was being rejected by auth middleware before reaching the handler.

The handler in `OauthService.decodeCsrfState` already had the right branching: dynamic-credential states are authenticated via encrypted state + HMAC CSRF token + bearer-token identity (no n8n session required), while static-credential states still require a session-bound `userId` match (or the explicit `N8N_SKIP_AUTH_ON_OAUTH_CALLBACK=true` embed bypass). The route-level gate was redundant with that in-handler logic and only served to block dynamic-credential callbacks from ever reaching it.

This change replaces `skipAuth: skipAuthOnOAuthCallback` with `allowUnauthenticated: true` on `/rest/oauth1-credential/callback` and `/rest/oauth2-credential/callback`. `allowUnauthenticated: true` is "soft auth": it populates `req.user` if a session cookie is present, otherwise lets the request through with `req.user === undefined`. The in-handler validation in `decodeCsrfState` then enforces the correct policy per credential origin.

### Resulting auth matrix

| State origin | `N8N_SKIP_AUTH_ON_OAUTH_CALLBACK` | Session | Result |
|---|---|---|---|
| dynamic-credential | any | any | OK — identity validated via state/bearer (**fix**) |
| static-credential | `true` | any | OK — embed bypass preserved |
| static-credential | `false`/unset | matches `state.userId` | OK — permission check via `findCredentialForUser` |
| static-credential | `false`/unset | missing/mismatched | `oauth-error-callback` rendered with `Unauthorized` |

`N8N_SKIP_AUTH_ON_OAUTH_CALLBACK` is retained because it's still meaningful for static credentials in iframe/embed scenarios.

### How to test manually

Prerequisites: dynamic credentials feature flag enabled (`N8N_ENV_FEAT_DYNAMIC_CREDENTIALS=true`) and a configured resolver. `N8N_SKIP_AUTH_ON_OAUTH_CALLBACK` must be **unset** (default).

1. From an external initiator (no n8n session in the callback browser context), trigger a dynamic-credential OAuth2 authorization flow and complete it against the IdP.
2. Confirm the browser is redirected back to `/rest/oauth2-credential/callback` and renders the success page; the token is persisted via the resolver.
3. Confirm that a regular static-credential OAuth2 flow still requires a logged-in user: log out, then visit a callback URL — it should render `oauth-error-callback` with `Unauthorized` (not a JSON 401 from middleware as before).
4. Confirm that with `N8N_SKIP_AUTH_ON_OAUTH_CALLBACK=true`, static-credential callbacks still complete without a session (existing embed behavior preserved).

Repeat steps 1–4 for OAuth1 against a credential that uses OAuth1.

### Behavior change to flag for review

Previously, an unauthenticated callback for a static credential with the env var unset got a JSON `401` from middleware. It now gets `200` with an HTML `oauth-error-callback` page. Same security outcome, arguably better UX for a browser-facing endpoint.

### Tests

- Added integration tests in `oauth1.api.test.ts` and `oauth2.api.test.ts` (env var unset):
  - **Route reachability** — authless callback returns `200` (renders error page) instead of `401` from middleware, proving the route allows the request through.
  - **Static-credential rejection** — authless callback against a valid static-credential state still renders `oauth-error-callback` with `Unauthorized`, proving the in-handler gate is intact.
- The dynamic-credential success path is already covered by existing unit tests on `decodeCsrfState` (`oauth.service.test.ts`): `should bypass user validation for dynamic-credential origin when req.user is undefined` and `… when state has no userId (external flow)`.
- Existing `oauth2.skip-auth.api.test.ts` still passes — env-var-enabled embed bypass is unchanged.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-706

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
