### PR TITLE
feat(editor): Default workflow resolver to n8n system resolver

### DIFF
--- a/packages/@n8n/api-types/src/index.ts
+++ b/packages/@n8n/api-types/src/index.ts
@@ -117,6 +117,7 @@ export type { BannerName } from './schemas/banner-name.schema';
 export { ViewableMimeTypes } from './schemas/binary-data.schema';
 export { passwordSchema, createPasswordSchema } from './schemas/password.schema';
 export {
+	SYSTEM_RESOLVER_ID,
 	credentialResolverSchema,
 	credentialResolversSchema,
 	credentialResolverTypeSchema,

--- a/packages/@n8n/api-types/src/schemas/credential-resolver.schema.ts
+++ b/packages/@n8n/api-types/src/schemas/credential-resolver.schema.ts
@@ -1,5 +1,12 @@
 import { z } from 'zod';
 
+/**
+ * Stable, well-known id of the system-managed N8N self-connect credential resolver
+ * seeded during module init. Used as the default selection in the workflow-settings
+ * resolver dropdown when no resolver has been chosen.
+ */
+export const SYSTEM_RESOLVER_ID = 'system-n8n';
+
 export const credentialResolverIdSchema = z.string().max(36);
 export const credentialResolverNameSchema = z.string().trim().min(1).max(255);
 export const credentialResolverTypeNameSchema = z.string().trim().min(1).max(255);

--- a/packages/cli/src/modules/dynamic-credentials.ee/constants.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/constants.ts
@@ -2,8 +2,10 @@
  * Stable, well-known id of the system-managed N8N self-connect credential resolver
  * seeded by `N8nResolverSeeder` during module init. Downstream tickets (IAM-660 etc.)
  * reference this id from workflow settings and OAuth callbacks.
+ *
+ * Re-exported from `@n8n/api-types` so the frontend and backend share a single source.
  */
-export const SYSTEM_RESOLVER_ID = 'system-n8n';
+export { SYSTEM_RESOLVER_ID } from '@n8n/api-types';
 
 /**
  * Human-readable name persisted on the seeded row and shown in the workflow-settings

--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.test.ts
@@ -4,7 +4,7 @@ import { createTestingPinia } from '@pinia/testing';
 import type { MockInstance } from 'vitest';
 import { fireEvent, waitFor, within } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
-import type { FrontendSettings } from '@n8n/api-types';
+import { SYSTEM_RESOLVER_ID, type FrontendSettings } from '@n8n/api-types';
 import { createComponentRenderer } from '@/__tests__/render';
 import { createTestWorkflow } from '@/__tests__/mocks';
 import { getDropdownItems, mockedStore, type MockedStore } from '@/__tests__/utils';
@@ -641,7 +641,7 @@ describe('WorkflowSettingsVue', () => {
 				updatedAt: new Date(),
 			},
 			{
-				id: 'resolver-n8n',
+				id: SYSTEM_RESOLVER_ID,
 				name: 'N8n Resolver',
 				type: 'n8n-internal-type',
 				config: '{}',
@@ -707,7 +707,7 @@ describe('WorkflowSettingsVue', () => {
 			});
 		});
 
-		it('should not show "Edit" button when no resolver is selected', async () => {
+		it('should not show "Edit" button when the default n8n system resolver is selected', async () => {
 			const { queryByTestId } = createComponent({ pinia });
 			await flushPromises();
 
@@ -728,7 +728,7 @@ describe('WorkflowSettingsVue', () => {
 		});
 
 		it('should not show "Edit" button when a non-editable resolver is selected', async () => {
-			workflowDocumentStore.setSettings({ credentialResolverId: 'resolver-n8n' });
+			workflowDocumentStore.setSettings({ credentialResolverId: SYSTEM_RESOLVER_ID });
 
 			const { queryByTestId } = createComponent({ pinia });
 			await flushPromises();
@@ -891,10 +891,23 @@ describe('WorkflowSettingsVue', () => {
 				expect(restApiClient.getCredentialResolvers).toHaveBeenCalled();
 			});
 
-			// The stale ID should be cleared — dropdown shows no selected value
+			// The stale ID is cleared and the n8n system resolver is selected as the default.
 			const dropdown = getByTestId('workflow-settings-credential-resolver');
 			const input = dropdown.querySelector('input') as HTMLInputElement;
-			expect(input.value).toBe('');
+			expect(input.value).toBe('N8n Resolver');
+		});
+
+		it('should default to the n8n system resolver when no resolver is selected', async () => {
+			const { getByTestId } = createComponent({ pinia });
+			await flushPromises();
+
+			await waitFor(() => {
+				expect(restApiClient.getCredentialResolvers).toHaveBeenCalled();
+			});
+
+			const dropdown = getByTestId('workflow-settings-credential-resolver');
+			const input = dropdown.querySelector('input') as HTMLInputElement;
+			expect(input.value).toBe('N8n Resolver');
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings.vue
@@ -29,6 +29,7 @@ import {
 } from '@n8n/design-system';
 import type { WorkflowSettings, WorkflowSettingsBinaryMode } from 'n8n-workflow';
 import { BINARY_MODE_COMBINED, BINARY_MODE_SEPARATE } from 'n8n-workflow';
+import { SYSTEM_RESOLVER_ID } from '@n8n/api-types';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { useWorkflowsEEStore } from '@/app/stores/workflows.ee.store';
@@ -149,6 +150,25 @@ const isSelectedResolverEditable = computed(() => {
 
 	const resolverType = credentialResolverTypes.value.find((t) => t.name === resolver.type);
 	return !!resolverType?.options?.length;
+});
+
+// Display-only binding for the resolver dropdown. Falls back to the seeded n8n system
+// resolver when nothing is explicitly chosen so users see the effective default; writes
+// back `undefined` for the system resolver so we don't persist the implicit default.
+const selectedResolverId = computed({
+	get(): string | undefined {
+		const resolverId = workflowSettings.value.credentialResolverId;
+		if (resolverId) return resolverId;
+		return credentialResolvers.value.some((r) => r.id === SYSTEM_RESOLVER_ID)
+			? SYSTEM_RESOLVER_ID
+			: undefined;
+	},
+	set(value: string | undefined) {
+		// Don't persist when the user (re)selects the system resolver — it's the
+		// implicit fallback already, and storing the id would tie the workflow to
+		// a specific seeded row.
+		workflowSettings.value.credentialResolverId = value === SYSTEM_RESOLVER_ID ? undefined : value;
+	},
 });
 
 const helpTexts = computed(() => ({
@@ -964,7 +984,7 @@ onBeforeUnmount(() => {
 						<div :class="$style['credential-resolver-container']">
 							<N8nSelect
 								ref="credentialResolverSelectRef"
-								v-model="workflowSettings.credentialResolverId"
+								v-model="selectedResolverId"
 								:placeholder="i18n.baseText('workflowSettings.credentialResolver.placeholder')"
 								filterable
 								clearable


### PR DESCRIPTION
## Summary

Show the seeded n8n system resolver (`system-n8n`) as the default selection in the workflow settings resolver dropdown when no resolver has been chosen. The selection is display-only: the dropdown falls back to `SYSTEM_RESOLVER_ID` via a computed v-model, but selecting the system resolver writes back `undefined` so workflows continue to rely on the backend's `getEffectiveResolverId` fallback instead of pinning to the seeded row id. `SYSTEM_RESOLVER_ID` is now exposed from `@n8n/api-types` and re-exported from the CLI constants to keep a single source of truth.

To test: open workflow settings on a workflow with no resolver set — the dropdown should display "n8n private credentials" by default. Saving should not add a `credentialResolverId` to the workflow.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI