### PR TITLE
fix(core): Preserve underlying cause when logging webhook execution failures

### DIFF
--- a/packages/cli/src/webhooks/__tests__/webhook-request-handler.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-request-handler.test.ts
@@ -1,7 +1,9 @@
+import { Logger } from '@n8n/backend-common';
+import { mockInstance } from '@n8n/backend-test-utils';
 import { type Response } from 'express';
 import { mock } from 'jest-mock-extended';
 import { isWebhookHtmlSandboxingDisabled, getHtmlSandboxCSP } from 'n8n-core';
-import { randomString } from 'n8n-workflow';
+import { OperationalError, randomString } from 'n8n-workflow';
 import type { IHttpRequestMethods } from 'n8n-workflow';
 
 import { ResponseError } from '@/errors/response-errors/abstract/response.error';
@@ -20,6 +22,7 @@ jest.mock('n8n-core', () => ({
 }));
 
 describe('WebhookRequestHandler', () => {
+	const logger = mockInstance(Logger);
 	const webhookManager = mock<Required<IWebhookManager>>();
 	const handler = createWebhookHandlerFor(webhookManager) as (
 		req: WebhookRequest | WebhookOptionsRequest,
@@ -207,6 +210,31 @@ describe('WebhookRequestHandler', () => {
 				message: 'Test error',
 				hint: 'Test hint',
 			});
+		});
+
+		it('should log the underlying error cause when execution fails', async () => {
+			const req = mock<WebhookRequest>({
+				path: '/webhook/abc',
+				method: 'GET',
+				params: { path: 'abc' },
+			});
+
+			const res = mock<Response>();
+			res.status.mockReturnValue(res);
+
+			const rootCause = new Error('SQLITE_BUSY: database is locked');
+			const wrapper = new OperationalError('There was a problem executing the workflow', {
+				cause: rootCause,
+			});
+
+			webhookManager.executeWebhook.mockRejectedValueOnce(wrapper);
+
+			await handler(req, res);
+
+			expect(logger.error).toHaveBeenCalledWith(
+				'Error in handling webhook request GET /webhook/abc: There was a problem executing the workflow',
+				expect.objectContaining({ error: wrapper }),
+			);
 		});
 
 		it('should not throw when legacy response headers contain invalid names', async () => {

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -956,15 +956,13 @@ export async function executeWebhook(
 		}
 		return executionId;
 	} catch (e) {
-		if (!(e instanceof UnprocessableRequestError)) {
+		let error: Error;
+		if (e instanceof UnprocessableRequestError) {
+			error = e;
+		} else {
 			Container.get(ErrorReporter).error(e, { executionId });
+			error = new OperationalError('There was a problem executing the workflow', { cause: e });
 		}
-		const error =
-			e instanceof UnprocessableRequestError
-				? e
-				: new OperationalError('There was a problem executing the workflow', {
-						cause: e,
-					});
 		if (didSendResponse) throw error;
 		responseCallback(error, {});
 		return;

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -10,6 +10,7 @@ import type { Project } from '@n8n/db';
 import { ExecutionRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import type express from 'express';
+import merge from 'lodash/merge';
 import { BinaryDataService, ErrorReporter, WAITING_TOKEN_QUERY_PARAM } from 'n8n-core';
 import type {
 	IBinaryData,
@@ -50,20 +51,13 @@ import {
 } from 'n8n-workflow';
 import { finished } from 'stream/promises';
 
-import { WebhookService } from './webhook.service';
-import {
-	WebhookResponseHeaders,
-	type WebhookNodeResponseHeaders,
-} from './webhook-response-headers';
-import type { IWebhookResponseCallbackData, WebhookRequest } from './webhook.types';
-
 import { ActiveExecutions } from '@/active-executions';
 import { AuthService } from '@/auth/auth.service';
 import { MCP_TRIGGER_NODE_TYPE } from '@/constants';
-import { EventService } from '@/events/event.service';
 import { InternalServerError } from '@/errors/response-errors/internal-server.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { UnprocessableRequestError } from '@/errors/response-errors/unprocessable.error';
+import { EventService } from '@/events/event.service';
 import { parseBody } from '@/middlewares';
 import { OwnershipService } from '@/services/ownership.service';
 import { WorkflowStatisticsService } from '@/services/workflow-statistics.service';
@@ -77,7 +71,13 @@ import { createStaticResponse, createStreamResponse } from '@/webhooks/webhook-r
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 import * as WorkflowHelpers from '@/workflow-helpers';
 import { WorkflowRunner } from '@/workflow-runner';
-import merge from 'lodash/merge';
+
+import {
+	WebhookResponseHeaders,
+	type WebhookNodeResponseHeaders,
+} from './webhook-response-headers';
+import { WebhookService } from './webhook.service';
+import type { IWebhookResponseCallbackData, WebhookRequest } from './webhook.types';
 
 // Type guards for MCP queue mode data validation
 interface McpToolCallPayload {
@@ -938,6 +938,8 @@ export async function executeWebhook(
 					return runData;
 				})
 				.catch((e) => {
+					Container.get(ErrorReporter).error(e, { executionId });
+
 					if (!didSendResponse) {
 						responseCallback(
 							new OperationalError('There was a problem executing the workflow', {
@@ -954,6 +956,9 @@ export async function executeWebhook(
 		}
 		return executionId;
 	} catch (e) {
+		if (!(e instanceof UnprocessableRequestError)) {
+			Container.get(ErrorReporter).error(e, { executionId });
+		}
 		const error =
 			e instanceof UnprocessableRequestError
 				? e

--- a/packages/cli/src/webhooks/webhook-request-handler.ts
+++ b/packages/cli/src/webhooks/webhook-request-handler.ts
@@ -84,7 +84,7 @@ class WebhookRequestHandler {
 			} else {
 				logger.error(
 					`Error in handling webhook request ${req.method} ${req.path}: ${error.message}`,
-					{ stacktrace: error.stack },
+					{ error },
 				);
 			}
 


### PR DESCRIPTION

  ## Summary

  When a webhook request fails inside `executeWebhook`, the only log line operators got was:
```
  Error in handling webhook request GET /webhook/...: There was a problem executing the workflow
```

With a stack trace pointing at the wrap site (`webhook-helpers.ts`) and no event in Sentry. The underlying error (DB lock, sub-workflow crash, etc.) was attached as `.cause` but never surfaced anywhere, making issues hard to triage.

  This PR makes two changes:

  1. **`webhook-request-handler.ts`** — switch the log payload from `{ stacktrace: error.stack }` to `{ error }`. `Logger.serializeError` already walks the `.cause` chain recursively when an `Error` lands in metadata, so the structured log now contains the underlying error's name, message, stack, and any deeper causes.

  2. **`webhook-helpers.ts`** — call `ErrorReporter.error(e, { executionId })` on the underlying error in both catch blocks before it gets wrapped with `OperationalError` (which has `shouldReport=false` and is filtered by Sentry's `beforeSend`). The outer catch keeps the `UnprocessableRequestError` exemption — 422 user-input errors are intentionally not reported. `ExecutionCancelledError` is already filtered by `ErrorReporter.error` itself.

  Net effect: operators see the full cause chain in pod logs, and unexpected errors (DB exceptions, sub-workflow code bugs, etc.) reach Sentry but operational/4xx errors are still filtered out. 
  **Note to reviewers: please validate that this logic is correct, as I don't want to accidentally over-spam Sentry with these issues.**

  ### How to test

  1. Hold an exclusive SQLite lock on the n8n DB file and call any webhook.
  2. The pod log entry for `Error in handling webhook request ...` now includes the underlying error's `name`, `message`, `stack`, and cause chain.
  
  Before the log line looked like this:
  ```
  {"level":"error","message":"Error in handling webhook request GET /webhook/cat3220-test: There was a problem executing the workflow","metadata":{"file":"webhook-request-handler.js","function":"handleRequest","stacktrace":"Error: There was a problem executing the workflow\n    at
   Object.executeWebhook (/n8n/packages/cli/dist/webhooks/webhook-helpers.js:960:7)","timestamp":"2026-05-26T10:24:11.213Z"}}
```

After the change, the log line looks like this:
```
{"level":"error","message":"Error in handling webhook request GET /webhook/cat3220-test: There was a problem executing the workflow","metadata":{"error":{"cause":{"message":"SQLITE_BUSY: database is locked","name":"QueryFailedError","stack":"QueryFailedError: SQLITE_BUSY:
  database is locked\n    at Statement.handler (/n8n/node_modules/.pnpm/@n8n+typeorm@0.3.20-17_@sentry+node@10.36.0_pg@8.17.0_sqlite3@5.1.7/node_modules/src/driver/sqlite-pooled/SqliteLibrary.ts:147:29)\n    at Statement.replacement
  (/n8n/node_modules/.pnpm/sqlite3@5.1.7/node_modules/sqlite3/lib/trace.js:25:27)\n    at Statement.replacement (/n8n/node_modules/.pnpm/sqlite3@5.1.7/node_modules/sqlite3/lib/trace.js:25:27)"},"message":"There was a problem executing the workflow","name":"Error","stack":"Error:
  There was a problem executing the workflow\n    at Object.executeWebhook (/n8n/packages/cli/dist/webhooks/webhook-helpers.js:965:7)"},"file":"webhook-request-handler.js","function":"handleRequest","timestamp":"2026-05-26T10:25:04.251Z"}}
```

  ## Related Linear tickets, Github issues, and Community forum posts

  https://linear.app/n8n/issue/CAT-3220

  ## Review / Merge checklist

  - [x] I have seen this code, I have run this code, and I take responsibility for this code.
  - [x] PR title and summary are descriptive.
  - [ ] Docs updated or follow-up ticket created. <!-- N/A — internal observability change -->
  - [x] Tests included.
  - [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1`