### PR TITLE
chore(core): Update Instance AI default model to Claude Opus 4.7 (no-changelog)

### DIFF
--- a/packages/@n8n/config/src/configs/instance-ai.config.ts
+++ b/packages/@n8n/config/src/configs/instance-ai.config.ts
@@ -2,9 +2,9 @@ import { Config, Env } from '../decorators';
 
 @Config
 export class InstanceAiConfig {
-	/** LLM model in provider/model format (e.g. "anthropic/claude-sonnet-4-6"). */
+	/** LLM model in provider/model format (e.g. "anthropic/claude-opus-4-7"). */
 	@Env('N8N_INSTANCE_AI_MODEL')
-	model: string = 'anthropic/claude-sonnet-4-6';
+	model: string = 'anthropic/claude-opus-4-7';
 
 	/** Base URL for an OpenAI-compatible endpoint (e.g. "http://localhost:1234/v1" for LM Studio). */
 	@Env('N8N_INSTANCE_AI_MODEL_URL')

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -269,7 +269,7 @@ describe('GlobalConfig', () => {
 			streamStateTtl: 300,
 		},
 		instanceAi: {
-			model: 'anthropic/claude-sonnet-4-6',
+			model: 'anthropic/claude-opus-4-7',
 			modelUrl: '',
 			modelApiKey: '',
 			maxContextWindowTokens: 500_000,

--- a/packages/@n8n/instance-ai/docs/configuration.md
+++ b/packages/@n8n/instance-ai/docs/configuration.md
@@ -8,7 +8,7 @@ All Instance AI configuration is done via environment variables.
 
 | Variable | Type | Default | Description |
 |----------|------|---------|-------------|
-| `N8N_INSTANCE_AI_MODEL` | string | `anthropic/claude-sonnet-4-6` | LLM model in `provider/model` format. Must be set for the module to enable. |
+| `N8N_INSTANCE_AI_MODEL` | string | `anthropic/claude-opus-4-7` | LLM model in `provider/model` format. Must be set for the module to enable. |
 | `N8N_INSTANCE_AI_MODEL_URL` | string | `''` | Base URL for an OpenAI-compatible endpoint (e.g. `http://localhost:1234/v1` for LM Studio). When set, model requests go to this URL instead of the built-in provider. |
 | `N8N_INSTANCE_AI_MODEL_API_KEY` | string | `''` | API key for the custom model endpoint. Optional — some local servers don't require one. |
 | `N8N_INSTANCE_AI_MAX_CONTEXT_WINDOW_TOKENS` | number | `500000` | Hard cap on the context window size (in tokens). The effective window is the lesser of this value and the model's native capability. `0` = use the model's full context window. |
@@ -157,33 +157,33 @@ Runtime behavior:
 
 ```bash
 # Minimal — just set the model
-N8N_INSTANCE_AI_MODEL=anthropic/claude-sonnet-4-6
+N8N_INSTANCE_AI_MODEL=anthropic/claude-opus-4-7
 
 # With MCP servers
-N8N_INSTANCE_AI_MODEL=anthropic/claude-sonnet-4-6
+N8N_INSTANCE_AI_MODEL=anthropic/claude-opus-4-7
 N8N_INSTANCE_AI_MCP_SERVERS="my-tools=https://mcp.example.com/sse"
 
 # With semantic memory
-N8N_INSTANCE_AI_MODEL=anthropic/claude-sonnet-4-6
+N8N_INSTANCE_AI_MODEL=anthropic/claude-opus-4-7
 N8N_INSTANCE_AI_EMBEDDER_MODEL=openai/text-embedding-3-small
 
 # With SearXNG (free, self-hosted search)
-N8N_INSTANCE_AI_MODEL=anthropic/claude-sonnet-4-6
+N8N_INSTANCE_AI_MODEL=anthropic/claude-opus-4-7
 N8N_INSTANCE_AI_SEARXNG_URL=http://searxng:8080
 
 # With Brave Search (paid API, takes priority over SearXNG)
-N8N_INSTANCE_AI_MODEL=anthropic/claude-sonnet-4-6
+N8N_INSTANCE_AI_MODEL=anthropic/claude-opus-4-7
 INSTANCE_AI_BRAVE_SEARCH_API_KEY=BSA-xxx
 
 # With sandbox (Daytona — isolated code execution for builder agent)
-N8N_INSTANCE_AI_MODEL=anthropic/claude-sonnet-4-6
+N8N_INSTANCE_AI_MODEL=anthropic/claude-opus-4-7
 N8N_INSTANCE_AI_SANDBOX_ENABLED=true
 N8N_INSTANCE_AI_SANDBOX_PROVIDER=daytona
 DAYTONA_API_URL=https://app.daytona.io/api
 DAYTONA_API_KEY=dtn_xxx
 
 # With sandbox (local — development only, no isolation)
-N8N_INSTANCE_AI_MODEL=anthropic/claude-sonnet-4-6
+N8N_INSTANCE_AI_MODEL=anthropic/claude-opus-4-7
 N8N_INSTANCE_AI_SANDBOX_ENABLED=true
 N8N_INSTANCE_AI_SANDBOX_PROVIDER=local
 
@@ -195,7 +195,7 @@ N8N_SANDBOX_SERVICE_URL=https://sandbox.example.com
 N8N_SANDBOX_SERVICE_API_KEY=sandbox-key
 
 # With filesystem gateway (user runs daemon on their machine)
-N8N_INSTANCE_AI_MODEL=anthropic/claude-sonnet-4-6
+N8N_INSTANCE_AI_MODEL=anthropic/claude-opus-4-7
 N8N_INSTANCE_AI_GATEWAY_API_KEY=my-secret-key
 # User runs: npx @n8n/computer-use
 
@@ -204,7 +204,7 @@ N8N_INSTANCE_AI_MODEL=custom/llama-3.1-70b
 N8N_INSTANCE_AI_MODEL_URL=http://localhost:1234/v1
 
 # Full configuration with observational memory tuning
-N8N_INSTANCE_AI_MODEL=anthropic/claude-sonnet-4-6
+N8N_INSTANCE_AI_MODEL=anthropic/claude-opus-4-7
 N8N_INSTANCE_AI_MCP_SERVERS="github=https://mcp.github.com/sse"
 N8N_INSTANCE_AI_EMBEDDER_MODEL=openai/text-embedding-3-small
 N8N_INSTANCE_AI_MAX_STEPS=50
@@ -228,7 +228,7 @@ services:
       - "8888:8080"  # optional: expose to host
   n8n:
     environment:
-      N8N_INSTANCE_AI_MODEL: anthropic/claude-sonnet-4-6
+      N8N_INSTANCE_AI_MODEL: anthropic/claude-opus-4-7
       N8N_INSTANCE_AI_SEARXNG_URL: http://searxng:8080
 ```
 

--- a/packages/cli/src/modules/chat-hub/chat-hub.constants.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.constants.ts
@@ -167,6 +167,10 @@ const MODEL_METADATA_REGISTRY: Partial<
 			inputModalities: ['text', 'image'],
 			priority: 80,
 		},
+		'claude-opus-4-7': {
+			inputModalities: ['text', 'image'],
+			priority: 110,
+		},
 		'claude-opus-4-6': {
 			inputModalities: ['text', 'image'],
 			priority: 100,

--- a/packages/cli/src/modules/chat-hub/context-limits.ts
+++ b/packages/cli/src/modules/chat-hub/context-limits.ts
@@ -100,6 +100,7 @@ export const maxContextWindowTokens: Record<ChatHubLLMProvider, Record<string, n
 		'o4-mini-deep-research-2025-06-26': 0,
 	},
 	anthropic: {
+		'claude-opus-4-7': 1000000,
 		'claude-opus-4-6': 1000000,
 		'claude-sonnet-4-6': 1000000,
 		'claude-opus-4-5-20251101': 200000,

--- a/packages/cli/src/modules/instance-ai/__tests__/compaction.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/compaction.service.test.ts
@@ -311,5 +311,26 @@ describe('InstanceAiCompactionService', () => {
 			expect(result).toContain('<conversation-summary>');
 			expect(mockGenerateCompactionSummary).toHaveBeenCalledTimes(1);
 		});
+
+		it('should use the Chat Hub context window for Claude Opus 4.7', async () => {
+			// 40 messages * 3000 tokens = 120k + 8k overhead = 128k.
+			// This would compact with the 128k fallback, but not with Opus 4.7's 1M window.
+			const messages = Array.from({ length: 40 }, (_, i) =>
+				createMessage(`msg-${i}`, i % 2 === 0 ? 'user' : 'assistant', `Msg ${i}`, 3000),
+			);
+			const service = createService();
+			const memory = createMockMemory(messages);
+
+			const result = await service.prepareCompactedContext(
+				'thread-1',
+				memory as never,
+				'anthropic/claude-opus-4-7',
+				20,
+				0.8,
+			);
+
+			expect(result).toBeNull();
+			expect(mockGenerateCompactionSummary).not.toHaveBeenCalled();
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Updates the default Instance AI model to `anthropic/claude-opus-4-7`.

Also adds Claude Opus 4.7 to Chat Hub's shared Anthropic model metadata and context-window registry, so Instance AI compaction uses the shared 1M-token model limit instead of falling back to the conservative default.


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
