### PR TITLE
fix(editor): Block members from project creation regardless of scope

### DIFF
--- a/packages/frontend/editor-ui/src/features/collaboration/projects/projects.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/projects.store.test.ts
@@ -6,6 +6,8 @@ import * as projectsApi from './projects.api';
 import type { Project, ProjectListItem } from './projects.types';
 import { ProjectTypes } from './projects.types';
 import type { ProjectRole, Scope } from '@n8n/permissions';
+import { hasPermission } from '@/app/utils/rbac/permissions';
+import { hasRole } from '@/app/utils/rbac/checks';
 
 // Minimal router mock to satisfy useRoute usage in the store
 vi.mock('vue-router', async (importOriginal) => ({
@@ -19,6 +21,14 @@ vi.mock('./projects.api', () => ({
 	addProjectMembers: vi.fn(),
 	updateProjectMemberRole: vi.fn(),
 	deleteProjectMember: vi.fn(),
+}));
+
+vi.mock('@/app/utils/rbac/permissions', () => ({
+	hasPermission: vi.fn().mockReturnValue(false),
+}));
+
+vi.mock('@/app/utils/rbac/checks', () => ({
+	hasRole: vi.fn().mockReturnValue(false),
 }));
 
 // Typed mocked facade for the API module
@@ -179,5 +189,42 @@ describe('useProjectsStore.updateProject (partial payloads)', () => {
 		);
 		expect(mockedProjectsApi.getProject).toHaveBeenCalledWith(expect.anything(), 'p1');
 		expect(store.currentProject?.relations.length).toBe(0);
+	});
+});
+
+describe('useProjectsStore.hasPermissionToCreateProjects', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+		vi.clearAllMocks();
+	});
+
+	it('returns true when scope is present and role is not member/chatUser', () => {
+		vi.mocked(hasPermission).mockReturnValue(true);
+		vi.mocked(hasRole).mockReturnValue(false);
+		const store = useProjectsStore();
+		expect(store.hasPermissionToCreateProjects).toBe(true);
+	});
+
+	it('returns false for members even when the project:create scope is granted', () => {
+		vi.mocked(hasPermission).mockReturnValue(true);
+		vi.mocked(hasRole).mockImplementation((roles) => (roles as string[]).includes('global:member'));
+		const store = useProjectsStore();
+		expect(store.hasPermissionToCreateProjects).toBe(false);
+	});
+
+	it('returns false for chat users even when the project:create scope is granted', () => {
+		vi.mocked(hasPermission).mockReturnValue(true);
+		vi.mocked(hasRole).mockImplementation((roles) =>
+			(roles as string[]).includes('global:chatUser'),
+		);
+		const store = useProjectsStore();
+		expect(store.hasPermissionToCreateProjects).toBe(false);
+	});
+
+	it('returns false when the scope is missing', () => {
+		vi.mocked(hasPermission).mockReturnValue(false);
+		vi.mocked(hasRole).mockReturnValue(false);
+		const store = useProjectsStore();
+		expect(store.hasPermissionToCreateProjects).toBe(false);
 	});
 });

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/projects.store.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/projects.store.ts
@@ -78,8 +78,10 @@ export const useProjectsStore = defineStore(STORES.PROJECTS, () => {
 				(isTeamProjectFeatureEnabled.value && !isTeamProjectLimitExceeded.value)) &&
 			!sourceControlStore.preferences.branchReadOnly,
 	);
-	const hasPermissionToCreateProjects = computed(() =>
-		hasPermission(['rbac'], { rbac: { scope: 'project:create' } }),
+	const hasPermissionToCreateProjects = computed(
+		() =>
+			hasPermission(['rbac'], { rbac: { scope: 'project:create' } }) &&
+			!hasRole(['global:member', 'global:chatUser']),
 	);
 	const canViewProjects = computed(
 		() => !settingsStore.isChatFeatureEnabled || !hasRole(['global:chatUser']),


### PR DESCRIPTION
## Summary

For non-admin users (members/chat users) the disabled "Project" item in the sidebar `+` dropdown was showing the cloud "limit reached" tooltip (with a nonsensical `-1` interpolated) instead of the "permission denied" copy. The current `projectsLimitReachedMessage` already prioritises the permission-denied branch, but `hasPermissionToCreateProjects` was resolving to `true` for users whose role should not allow creating projects (e.g. when the `project:create` scope leaks into a member's global scopes via a misconfigured/custom role). This PR makes `hasPermissionToCreateProjects` deny members and chat users regardless of scope, mirroring the existing `canViewProjects` role guard.

To test: log in as a member on an instance where the team-project feature is enabled, open the sidebar `+` dropdown, hover the disabled "Project" item and confirm the tooltip reads the permission-denied copy.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5255

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI