### PR TITLE
fix: Fixes PostHog identify and groupidentify calls triggered before effective PostHog initialization

### DIFF
--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -86,6 +86,7 @@ declare global {
 						maskAllInputs?: boolean;
 						maskInputFn?: ((text: string, element?: HTMLElement) => string) | null;
 					};
+					loaded?: (posthog: typeof window.posthog) => void;
 				},
 			): void;
 			isFeatureEnabled?(flagName: string): boolean;

--- a/packages/frontend/editor-ui/src/app/stores/posthog.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/posthog.store.ts
@@ -114,10 +114,6 @@ export const usePostHog = defineStore('posthog', () => {
 		};
 	}
 
-	const groupIdentify = (groupKey: string, instanceId: string) => {
-		window.posthog?.group?.(groupKey, instanceId);
-	};
-
 	const identify = () => {
 		const instanceId = rootStore.instanceId;
 		const user = usersStore.currentUser;
@@ -134,6 +130,11 @@ export const usePostHog = defineStore('posthog', () => {
 		// For PostHog, main ID _cannot_ be `undefined` as done for RudderStack.
 		const id = user ? `${instanceId}#${user.id}` : instanceId;
 		window.posthog?.identify?.(id, traits);
+	};
+
+	const groupIdentify = () => {
+		const instanceId = rootStore.instanceId;
+		window.posthog?.group?.('company', instanceId);
 	};
 
 	const trackExperiment = (featFlags: FeatureFlags, name: string) => {
@@ -185,9 +186,13 @@ export const usePostHog = defineStore('posthog', () => {
 			},
 		};
 
-		window.posthog?.init(config.apiKey, options);
-		identify();
-		groupIdentify('company', instanceId);
+		window.posthog?.init(config.apiKey, {
+			...options,
+			loaded: () => {
+				identify();
+				groupIdentify();
+			},
+		});
 
 		if (evaluatedFeatureFlags && Object.keys(evaluatedFeatureFlags).length) {
 			featureFlags.value = evaluatedFeatureFlags;
@@ -238,7 +243,6 @@ export const usePostHog = defineStore('posthog', () => {
 		waitForFeatureFlags,
 		reset,
 		identify,
-		groupIdentify,
 		setMetadata,
 		capture,
 		overrides,


### PR DESCRIPTION
## Summary
Identify calls were silently failing and recently added groupIdentify calls were throwing due to race condition on PostHog initialisation (calls made before PostHog was effectively initialised).

Implements callback `load` function to defer those calls to after PostHog has effectively initialised.

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
