### PR TITLE
fix(editor): Use `color-mix()` for subtle button hover/active states and update guideline (no-changelog)

### DIFF
--- a/.agents/skills/design-system/SKILL.md
+++ b/.agents/skills/design-system/SKILL.md
@@ -20,6 +20,7 @@ Reference these guidelines when:
 - ALWAYS use CSS variables for styles from `packages/frontend/@n8n/design-system/src/css/_tokens.scss` or `packages/frontend/@n8n/design-system/src/css/_primitives.scss`. Use hard-coded values only when no suitable tokens.
 - ALWAYS prefer using existing components from `packages/frontend/@n8n/design-system/src/components`. Prefer components that aren't marked `@deprecated`.
 - Use `light-dark()` when alternating colors for ligh/dark mode
+- If you need to add hover/active alpha behavior to solid components, prefer `color-mix()` with explicit percentages.
 - When working with animations or transitions, ALWAYS prefer using mixins from `packages/frontend/@n8n/design-system/src/css/mixins/motion.scss`
 - When reviewing animations, follow the guides in `rules/web-animation-guidelines.md`
 - When reviewing UI changes or adding new components, follow `rules/web-interface-guidelines.md`

--- a/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
@@ -254,12 +254,12 @@ const handleClick = (event: MouseEvent) => {
 		--button--color--background-hover: color-mix(
 			in srgb,
 			var(--button--color--background),
-			var(--background--hover)
+			light-dark(var(--color--black), var(--color--white)) 5%
 		);
 		--button--color--background-active: color-mix(
 			in srgb,
 			var(--button--color--background),
-			var(--background--active)
+			light-dark(var(--color--black), var(--color--white)) 10%
 		);
 		--button--shadow: var(--shadow--xs);
 		--button--shadow--hover: var(--shadow--xs);

--- a/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nButton/Button.vue
@@ -254,12 +254,12 @@ const handleClick = (event: MouseEvent) => {
 		--button--color--background-hover: color-mix(
 			in srgb,
 			var(--button--color--background),
-			light-dark(var(--color--black), var(--color--white)) 5%
+			light-dark(var(--color--neutral-black), var(--color--neutral-white)) 5%
 		);
 		--button--color--background-active: color-mix(
 			in srgb,
 			var(--button--color--background),
-			light-dark(var(--color--black), var(--color--white)) 10%
+			light-dark(var(--color--neutral-black), var(--color--neutral-white)) 10%
 		);
 		--button--shadow: var(--shadow--xs);
 		--button--shadow--hover: var(--shadow--xs);


### PR DESCRIPTION
## Summary

Use explicit `color-mix()` values for subtle button hover and active backgrounds so solid components keep consistent alpha behavior across light and dark themes.

Also documents the design-system guideline to prefer `color-mix()` with explicit percentages for hover/active alpha on solid components.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DS-535

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
