### PR TITLE
fix(editor): Render new empty state for quick-connect credentials in standalone mode

### DIFF
--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
@@ -617,6 +617,27 @@ describe('NodeCredentials', () => {
 			expect(screen.queryByTestId('node-credentials-select')).not.toBeInTheDocument();
 		});
 
+		it('should also show quick-connect-empty-state in standalone mode (NODE-5115)', () => {
+			setupQuickConnectStores();
+
+			ndvStore.activeNode = slackNode;
+
+			renderComponent(
+				{
+					props: {
+						node: slackNode,
+						overrideCredType: 'slackOAuth2Api',
+						standalone: true,
+					},
+				},
+				{ merge: true },
+			);
+
+			expect(screen.queryByTestId('quick-connect-empty-state')).toBeInTheDocument();
+			expect(screen.queryByTestId('node-credentials-empty-state')).not.toBeInTheDocument();
+			expect(screen.queryByTestId('node-credentials-select')).not.toBeInTheDocument();
+		});
+
 		it('should derive service name from credential displayName when no quick connect config', () => {
 			setupQuickConnectStores();
 

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -730,7 +730,6 @@ async function onQuickConnectSignIn(credentialTypeName: string) {
 				</div>
 				<div
 					v-else-if="
-						!standalone &&
 						options.length === 0 &&
 						showQuickConnectEmptyState(type) &&
 						quickConnectCredentialType &&


### PR DESCRIPTION
## Summary

The quick-connect empty-state branch in `NodeCredentials.vue` was gated on `!standalone`. As a result, the AI builder credential surfaces (`InstanceAiCredentialSetup.vue`, `WorkflowSetupSectionBody.vue`, `AskCredentialCard.vue`), which embed `NodeCredentials` in `standalone` mode, fell through to the legacy "Select Credential" dropdown for quick-connect-eligible credentials (e.g. Gmail OAuth2, Notion MCP OAuth2). Non-quick-connect credentials (e.g. Telegram) were not affected because their standard empty-state branch has no such gate.

The `QuickConnectButton` sign-in flow works the same way regardless of `standalone` mode, so there is no functional reason for the gate. This PR removes it.

### How to test

1. Configure quick-connect locally (e.g. `N8N_QUICK_CONNECT_OPTIONS` for Gmail / Notion MCP) so the credential edit modal shows the "Sign in with …" button for the relevant types.
2. In the AI assistant, ask for something that requires Gmail credentials (e.g. *"Build a workflow that triggers on new Gmail emails and sends to Telegram"*).
3. When the credential setup card / workflow setup wizard appears for Gmail with no usable Gmail credentials in the project:
   - **Before:** legacy `Select Credential ▼` dropdown + `+ Create new credential` row.
   - **After:** `Sign in with Google` quick-connect button + inline "or set up manually" link, identical to the credential edit modal.
4. Confirm regressions: Telegram (non-quick-connect) still shows the standard `No credentials yet` + `Set up credential` layout; the credential edit modal in the NDV is unchanged.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5115

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
