### PR TITLE
refactor(core): Route $items() through typed-RPC dispatcher

### DIFF
--- a/packages/@n8n/expression-runtime/src/__tests__/typed-rpc.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/typed-rpc.test.ts
@@ -431,3 +431,77 @@ describe('Typed RPC: $input.{first,last,all} route via getInput*', () => {
 		expect(evaluator.evaluate("{{ 'all' in $input }}", data, caller)).toBe(true);
 	});
 });
+
+describe('Typed RPC: $items() routes via getItems', () => {
+	let evaluator: ExpressionEvaluator;
+	const caller = {};
+
+	beforeAll(async () => {
+		evaluator = new ExpressionEvaluator({
+			createBridge: () => new IsolatedVmBridge({ timeout: 5000 }),
+			maxCodeCacheSize: 64,
+		});
+		await evaluator.initialize();
+		await evaluator.acquire(caller);
+	});
+
+	afterAll(async () => {
+		await evaluator.release(caller);
+		await evaluator.dispose();
+	});
+
+	it('returns the value of data.$items() with no args', () => {
+		const data: Record<string, unknown> = {
+			$items: () => [{ json: { id: 1 } }, { json: { id: 2 } }],
+		};
+
+		const result = evaluator.evaluate('{{ $items() }}', data, caller);
+		expect(result).toEqual([{ json: { id: 1 } }, { json: { id: 2 } }]);
+	});
+
+	it('forwards nodeName, outputIndex, and runIndex verbatim', () => {
+		const calls: Array<unknown[]> = [];
+		const data: Record<string, unknown> = {
+			$items: (...args: unknown[]) => {
+				calls.push(args);
+				return [];
+			},
+		};
+
+		evaluator.evaluate('{{ $items() }}', data, caller);
+		evaluator.evaluate("{{ $items('Foo') }}", data, caller);
+		evaluator.evaluate("{{ $items('Foo', 1) }}", data, caller);
+		evaluator.evaluate("{{ $items('Foo', 0, 2) }}", data, caller);
+
+		expect(calls).toEqual([
+			[undefined, undefined, undefined],
+			['Foo', undefined, undefined],
+			['Foo', 1, undefined],
+			['Foo', 0, 2],
+		]);
+	});
+
+	it('accepts negative runIndex (host sentinel for "latest")', () => {
+		// `WorkflowDataProxy.$items` uses runIndex === undefined ? -1 : runIndex,
+		// so callers can pass -1 explicitly to request the latest run. The
+		// schema permits negatives via z.number().int() (no .nonnegative()).
+		const calls: Array<unknown[]> = [];
+		const data: Record<string, unknown> = {
+			$items: (...args: unknown[]) => {
+				calls.push(args);
+				return [];
+			},
+		};
+
+		evaluator.evaluate("{{ $items('Foo', 0, -1) }}", data, caller);
+
+		expect(calls).toEqual([['Foo', 0, -1]]);
+	});
+
+	it('handles missing data.$items gracefully (returns undefined)', () => {
+		const data: Record<string, unknown> = {};
+
+		const result = evaluator.evaluate('{{ $items() }}', data, caller);
+		expect(result).toBeUndefined();
+	});
+});

--- a/packages/@n8n/expression-runtime/src/bridge/__tests__/bridge-messages.test.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/__tests__/bridge-messages.test.ts
@@ -44,6 +44,21 @@ describe('bridgeMessageSchema', () => {
 			},
 		);
 
+		it('parses a valid getItems envelope (no args)', () => {
+			const parsed = bridgeMessageSchema.parse({ type: 'getItems' });
+			expect(parsed.type).toBe('getItems');
+		});
+
+		it('parses a valid getItems envelope (all args)', () => {
+			const parsed = bridgeMessageSchema.parse({
+				type: 'getItems',
+				nodeName: 'Foo',
+				outputIndex: 0,
+				runIndex: 2,
+			});
+			expect(parsed.type).toBe('getItems');
+		});
+
 		it('rejects an unknown discriminator value', () => {
 			expect(() => bridgeMessageSchema.parse({ type: 'evalArbitrary', nodeName: 'Foo' })).toThrow();
 		});
@@ -61,6 +76,37 @@ describe('bridgeMessageSchema', () => {
 				expect(() => bridgeMessageSchema.parse({ type, branchIndex: 0 })).toThrow();
 			},
 		);
+	});
+
+	describe('getItems', () => {
+		it('accepts negative runIndex (host -1 sentinel for "latest")', () => {
+			// Unlike branchIndex/runIndex on getNode*, getItems allows negative
+			// runIndex because WorkflowDataProxy.$items uses -1 as a sentinel
+			// for "latest run". The schema is `z.number().int()` without
+			// .nonnegative() — guard the behaviour explicitly.
+			expect(() =>
+				bridgeMessageSchema.parse({ type: 'getItems', nodeName: 'Foo', runIndex: -1 }),
+			).not.toThrow();
+		});
+
+		it('rejects non-integer runIndex', () => {
+			expect(() =>
+				bridgeMessageSchema.parse({ type: 'getItems', nodeName: 'Foo', runIndex: 1.5 }),
+			).toThrow();
+		});
+
+		it('rejects negative outputIndex', () => {
+			// outputIndex is still nonnegative — there's no host sentinel for it.
+			expect(() =>
+				bridgeMessageSchema.parse({ type: 'getItems', nodeName: 'Foo', outputIndex: -1 }),
+			).toThrow();
+		});
+
+		it('rejects extra fields (.strict)', () => {
+			expect(() =>
+				bridgeMessageSchema.parse({ type: 'getItems', nodeName: 'Foo', branchIndex: 0 }),
+			).toThrow();
+		});
 	});
 
 	describe('.strict() enforcement', () => {

--- a/packages/@n8n/expression-runtime/src/bridge/bridge-messages.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/bridge-messages.ts
@@ -75,6 +75,25 @@ export const getInputLastMessage = z.object({ type: z.literal('getInputLast') })
 export const getInputAllMessage = z.object({ type: z.literal('getInputAll') }).strict();
 
 /**
+ * `$items(nodeName?, outputIndex?, runIndex?)` — fetch the execution data of
+ * a node by name (or the current node's input if `nodeName` is omitted).
+ *
+ * `runIndex` accepts negative values: the host uses `-1` as a sentinel for
+ * "latest run" (see `WorkflowDataProxy.$items` —
+ * `runIndex === undefined ? -1 : runIndex`). The schema uses
+ * `z.number().int()` without `.nonnegative()` so expressions can pass `-1`
+ * explicitly if they need to.
+ */
+export const getItemsMessage = z
+	.object({
+		type: z.literal('getItems'),
+		nodeName: z.string().optional(),
+		outputIndex: z.number().int().nonnegative().optional(),
+		runIndex: z.number().int().optional(),
+	})
+	.strict();
+
+/**
  * The full set of messages the bridge will accept. Discriminator is `type`.
  *
  * Use `.strict()` on each member so unknown fields are rejected rather than
@@ -88,6 +107,7 @@ export const bridgeMessageSchema = z.discriminatedUnion('type', [
 	getInputFirstMessage,
 	getInputLastMessage,
 	getInputAllMessage,
+	getItemsMessage,
 ]);
 
 export type BridgeMessage = z.infer<typeof bridgeMessageSchema>;

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -494,6 +494,8 @@ export class IsolatedVmBridge implements RuntimeBridge {
 						return this.handleGetInputLast(data);
 					case 'getInputAll':
 						return this.handleGetInputAll(data);
+					case 'getItems':
+						return this.handleGetItems(msg, data);
 					default: {
 						// Unreachable at runtime — zod rejects unknown `type` values
 						// before the switch. The `never` assignment is the compile-time
@@ -568,6 +570,22 @@ export class IsolatedVmBridge implements RuntimeBridge {
 
 	private handleGetInputAll(data: WorkflowData): unknown {
 		return data.$input?.all?.();
+	}
+
+	/**
+	 * Handler for `$items(nodeName?, outputIndex?, runIndex?)` — the
+	 * global accessor for a node's execution data. Reads the literal
+	 * `$items` property off `data` (host-wired by `WorkflowDataProxy`)
+	 * and forwards the validated args verbatim. The host applies its own
+	 * defaults when fields are `undefined`.
+	 *
+	 * @private
+	 */
+	private handleGetItems(
+		msg: Extract<BridgeMessage, { type: 'getItems' }>,
+		data: WorkflowData,
+	): unknown {
+		return data.$items?.(msg.nodeName, msg.outputIndex, msg.runIndex);
 	}
 
 	/**

--- a/packages/@n8n/expression-runtime/src/runtime/context.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/context.ts
@@ -253,6 +253,21 @@ export function buildContext(
 		},
 	});
 
+	// $items — global accessor for a node's execution data. Unlike $() and
+	// $input this is a plain typed-RPC function (not a synthetic Proxy):
+	// the host enforces nothing structural here, the schema validates the
+	// args, and the host's `WorkflowDataProxy.$items` applies its own
+	// defaults when fields are undefined.
+	target.$items = (nodeName?: string, outputIndex?: number, runIndex?: number) => {
+		const result = callbacks.callHost.applySync(
+			null,
+			[{ type: 'getItems', nodeName, outputIndex, runIndex }],
+			{ arguments: { copy: true }, result: { copy: true } },
+		);
+		throwIfErrorSentinel(result);
+		return result;
+	};
+
 	// -------------------------------------------------------------------------
 	// Resolve an unknown key from the host. Called by the proxy's has/get traps
 	// for keys not already on the target. The resolved value is cached on target

--- a/packages/@n8n/expression-runtime/src/types/evaluator.ts
+++ b/packages/@n8n/expression-runtime/src/types/evaluator.ts
@@ -136,15 +136,16 @@ export interface InputProxy {
 /**
  * Workflow data proxy from `WorkflowDataProxy.getDataProxy()`.
  *
- * `$` and `$input` are the typed-RPC accessors (`$('NodeName').first()`,
- * `$input.first()`, etc.) and are called directly from typed-RPC handlers.
- * Everything else flows through the generic data-access primitives
- * (`getValueAtPath`, `getArrayElement`), which read paths off the index
- * signature without needing per-key types.
+ * `$`, `$input`, and `$items` are typed-RPC accessors (`$('NodeName').first()`,
+ * `$input.first()`, `$items(...)`, etc.) and are called directly from
+ * typed-RPC handlers. Everything else flows through the generic data-access
+ * primitives (`getValueAtPath`, `getArrayElement`), which read paths off
+ * the index signature without needing per-key types.
  */
 export interface WorkflowData {
 	$?: (nodeName: string) => NodeProxy | null | undefined;
 	$input?: InputProxy;
+	$items?: (nodeName?: string, outputIndex?: number, runIndex?: number) => unknown;
 	[key: string]: unknown;
 }
 

--- a/packages/workflow/test/expression-items-engine-parity.test.ts
+++ b/packages/workflow/test/expression-items-engine-parity.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+
+import * as Helpers from './helpers';
+import { ExpressionError } from '../src/errors/expression.error';
+import { createRunExecutionData } from '../src';
+import { Workflow } from '../src/workflow';
+
+// Engine-parity tests for `$items()` boundary behaviour.
+//
+// `$items()` was migrated to a typed-RPC under the VM engine in CAT-2982.
+// This file pins the behaviour of edge-case `runIndex` values across both
+// the legacy and VM engines so any divergence in how the runtime handles
+// host-side errors fails exactly one project. See `vitest.config.ts` for
+// the dual-engine setup.
+
+describe('Expression — $items() boundary behaviour (engine parity)', () => {
+	const workflow = new Workflow({
+		id: '1',
+		nodes: [
+			{
+				name: 'Source',
+				typeVersion: 1,
+				type: 'test.set',
+				id: 'source-1',
+				position: [0, 0],
+				parameters: {},
+			},
+			{
+				name: 'Current',
+				typeVersion: 1,
+				type: 'test.set',
+				id: 'current-1',
+				position: [100, 0],
+				parameters: {},
+			},
+		],
+		connections: {
+			Source: {
+				main: [[{ node: 'Current', type: 'main', index: 0 }]],
+			},
+		},
+		active: false,
+		nodeTypes: Helpers.NodeTypes(),
+	});
+	const expression = workflow.expression;
+
+	// Two runs of `Source` so `runIndex = -1` and `runIndex = 1` are valid.
+	const runExecutionData = createRunExecutionData({
+		resultData: {
+			runData: {
+				Source: [
+					{
+						startTime: 0,
+						executionTime: 0,
+						source: [],
+						data: { main: [[{ json: { id: 'run0' } }]] },
+					},
+					{
+						startTime: 0,
+						executionTime: 0,
+						source: [],
+						data: { main: [[{ json: { id: 'run1' } }]] },
+					},
+				],
+			},
+		},
+	});
+
+	beforeAll(async () => {
+		await expression.acquireIsolate();
+	});
+	afterAll(async () => {
+		await expression.releaseIsolate();
+	});
+
+	const evaluate = (expr: string) =>
+		expression.getParameterValue(
+			expr,
+			runExecutionData,
+			0, // runIndex of the active node — irrelevant for these assertions
+			0, // itemIndex
+			'Current',
+			[{ json: {} }],
+			'manual',
+			{},
+		);
+
+	it('$items("Source", 0, -1) returns the latest run (host -1 sentinel)', () => {
+		expect(evaluate('={{ $items("Source", 0, -1)[0].json.id }}')).toBe('run1');
+	});
+
+	it('$items("Source", 0, 0) returns the explicitly-named first run', () => {
+		expect(evaluate('={{ $items("Source", 0, 0)[0].json.id }}')).toBe('run0');
+	});
+
+	it('$items("Source", 0, 999) throws ExpressionError "Run X not found"', () => {
+		// Host throws a structured ExpressionError when the runIndex is past
+		// the known length. Both engines should surface this as-is.
+		expect(() => evaluate('={{ $items("Source", 0, 999) }}')).toThrowError(ExpressionError);
+	});
+
+	it('$items("Source", 0, -2) returns undefined — host TypeError is swallowed by both engines', () => {
+		// Host's `getNodeExecutionData` only special-cases -1; any other
+		// negative runIndex skips the `length <= runIndex` bounds check
+		// (because length > negative) and dereferences `runData[name][-2].data`,
+		// which throws a plain TypeError. Both engines' E() handler swallows
+		// non-ExpressionError throws, so the observable result is undefined.
+		// If a future change makes the VM engine surface the TypeError as an
+		// error (instead of undefined), this test fails on the vm-engine
+		// project and the divergence is caught.
+		expect(evaluate('={{ $items("Source", 0, -2) }}')).toBeUndefined();
+	});
+});

--- a/packages/workflow/test/expression-items-engine-parity.test.ts
+++ b/packages/workflow/test/expression-items-engine-parity.test.ts
@@ -52,12 +52,14 @@ describe('Expression — $items() boundary behaviour (engine parity)', () => {
 					{
 						startTime: 0,
 						executionTime: 0,
+						executionIndex: 0,
 						source: [],
 						data: { main: [[{ json: { id: 'run0' } }]] },
 					},
 					{
 						startTime: 0,
 						executionTime: 0,
+						executionIndex: 1,
 						source: [],
 						data: { main: [[{ json: { id: 'run1' } }]] },
 					},


### PR DESCRIPTION
## Summary

Migrates the global `$items(nodeName?, outputIndex?, runIndex?)` accessor to the typed-RPC dispatcher under the VM engine. This is the global accessor for a named node's execution data (or the current node's input when `nodeName` is omitted).

**Stacks on #30977** — review/merge that one first; GitHub will auto-rebase this PR onto master afterward.

### What changes

- New `getItemsMessage` schema in `bridge-messages.ts` and a one-line `handleGetItems` handler in `isolated-vm-bridge.ts` (`data.$items?.(msg.nodeName, msg.outputIndex, msg.runIndex)`).
- In-isolate wiring in `runtime/context.ts`: `target.$items` is a plain callable that builds the envelope and ships it via `callHost`. Unlike `$()` and `$input`, `$items` is a plain global function — not a method on a synthetic proxy — so there's no Proxy, no per-key registry, and no caching layer.
- Extends `WorkflowData` in `types/evaluator.ts` with `$items?: (nodeName?, outputIndex?, runIndex?) => unknown`.

### Schema design

- `nodeName: z.string().optional()` — `undefined` means "previous node".
- `outputIndex: z.number().int().nonnegative().optional()` — host coalesces `undefined` to `0`.
- `runIndex: z.number().int().optional()` — **negatives allowed**. The host uses `-1` as a sentinel for "latest run" (see `WorkflowDataProxy.$items`: `runIndex === undefined ? -1 : runIndex`). The schema docstring calls this out — this is the only typed RPC that allows negative indices.

### Tests

Adds dual-engine parity tests in `packages/workflow/test/expression-items-engine-parity.test.ts` to pin `runIndex` boundary behaviour across legacy and VM engines:

- `-1` returns latest run (host sentinel).
- `0` returns explicit first run.
- `999` (past length) throws `ExpressionError` from the host.
- `-2` (out-of-range negative) returns `undefined` because the host throws a plain `TypeError` and both engines' `E()` handler swallows non-`ExpressionError` throws. If a future change makes the VM engine surface this differently, the test catches the divergence.

### How to test

```bash
cd packages/@n8n/expression-runtime && pnpm test
cd packages/workflow && pnpm test expression-items-engine-parity
```

## Related Linear tickets, Github issues, and Community forum posts

- Linear: https://linear.app/n8n/issue/CAT-2982
- Stacks on: #30977 (`$input.*` typed RPCs — open)
- Prior PRs in the series (all merged):
  - #30098 — Step 0
  - #30736 — jmespath in-isolate
  - #30807 — dispatcher + `getNodeFirst`
  - #30825 — `getNodeLast` + `getNodeAll`
  - #30976 — registry refactor + `isKeyOf`

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. _(N/A — internal refactor, no user-facing behaviour change.)_
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
- [x] I have notified the Product Manager. _(N/A — internal refactor.)_

🤖 PR Summary generated by AI