### PR TITLE
refactor(core): Route $fromAI() through typed-RPC dispatcher

### DIFF
--- a/packages/@n8n/expression-runtime/src/__tests__/typed-rpc.test.ts
+++ b/packages/@n8n/expression-runtime/src/__tests__/typed-rpc.test.ts
@@ -505,3 +505,97 @@ describe('Typed RPC: $items() routes via getItems', () => {
 		expect(result).toBeUndefined();
 	});
 });
+
+describe('Typed RPC: $fromAI() routes via fromAi', () => {
+	let evaluator: ExpressionEvaluator;
+	const caller = {};
+
+	beforeAll(async () => {
+		evaluator = new ExpressionEvaluator({
+			createBridge: () => new IsolatedVmBridge({ timeout: 5000 }),
+			maxCodeCacheSize: 64,
+		});
+		await evaluator.initialize();
+		await evaluator.acquire(caller);
+	});
+
+	afterAll(async () => {
+		await evaluator.release(caller);
+		await evaluator.dispose();
+	});
+
+	it('returns the resolved value of data.$fromAI(name)', () => {
+		const data: Record<string, unknown> = {
+			$fromAI: (name?: string) => `resolved:${name}`,
+		};
+
+		const result = evaluator.evaluate("{{ $fromAI('placeholder_one') }}", data, caller);
+		expect(result).toBe('resolved:placeholder_one');
+	});
+
+	it('forwards name, description, type, and defaultValue verbatim', () => {
+		const calls: Array<unknown[]> = [];
+		const data: Record<string, unknown> = {
+			$fromAI: (...args: unknown[]) => {
+				calls.push(args);
+				return 'ok';
+			},
+		};
+
+		evaluator.evaluate("{{ $fromAI('a') }}", data, caller);
+		evaluator.evaluate("{{ $fromAI('a', 'description') }}", data, caller);
+		evaluator.evaluate("{{ $fromAI('a', 'description', 'number') }}", data, caller);
+		evaluator.evaluate("{{ $fromAI('a', 'description', 'number', 42) }}", data, caller);
+
+		expect(calls).toEqual([
+			['a', undefined, undefined, undefined],
+			['a', 'description', undefined, undefined],
+			['a', 'description', 'number', undefined],
+			['a', 'description', 'number', 42],
+		]);
+	});
+
+	it('forwards arbitrary defaultValue shapes (number, string, boolean, null, object)', () => {
+		// `defaultValue` is `z.unknown()` because the host applies no shape
+		// constraint — it just returns the fallback via `??`. Verify the
+		// bridge structured-clones each shape through to the host.
+		const calls: Array<unknown[]> = [];
+		const data: Record<string, unknown> = {
+			$fromAI: (...args: unknown[]) => {
+				calls.push(args);
+				return 'ok';
+			},
+		};
+
+		evaluator.evaluate("{{ $fromAI('a', '', 'string', 42) }}", data, caller);
+		evaluator.evaluate("{{ $fromAI('a', '', 'string', 'fallback') }}", data, caller);
+		evaluator.evaluate("{{ $fromAI('a', '', 'string', true) }}", data, caller);
+		evaluator.evaluate("{{ $fromAI('a', '', 'string', null) }}", data, caller);
+		evaluator.evaluate("{{ $fromAI('a', '', 'string', { nested: 'value' }) }}", data, caller);
+
+		expect(calls.map((c) => c[3])).toEqual([42, 'fallback', true, null, { nested: 'value' }]);
+	});
+
+	it('$fromAi (mid-case) alias routes through the same handler', () => {
+		const data: Record<string, unknown> = {
+			$fromAI: (name?: string) => `via-aliases:${name}`,
+		};
+
+		expect(evaluator.evaluate("{{ $fromAi('x') }}", data, caller)).toBe('via-aliases:x');
+	});
+
+	it('$fromai (all-lower) alias routes through the same handler', () => {
+		const data: Record<string, unknown> = {
+			$fromAI: (name?: string) => `via-aliases:${name}`,
+		};
+
+		expect(evaluator.evaluate("{{ $fromai('x') }}", data, caller)).toBe('via-aliases:x');
+	});
+
+	it('handles missing data.$fromAI gracefully (returns undefined)', () => {
+		const data: Record<string, unknown> = {};
+
+		const result = evaluator.evaluate("{{ $fromAI('placeholder') }}", data, caller);
+		expect(result).toBeUndefined();
+	});
+});

--- a/packages/@n8n/expression-runtime/src/bridge/__tests__/bridge-messages.test.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/__tests__/bridge-messages.test.ts
@@ -59,6 +59,17 @@ describe('bridgeMessageSchema', () => {
 			expect(parsed.type).toBe('getItems');
 		});
 
+		it('parses a valid fromAi envelope', () => {
+			const parsed = bridgeMessageSchema.parse({
+				type: 'fromAi',
+				name: 'placeholder',
+				description: 'A description',
+				valueType: 'string',
+				defaultValue: 'fallback',
+			});
+			expect(parsed.type).toBe('fromAi');
+		});
+
 		it('rejects an unknown discriminator value', () => {
 			expect(() => bridgeMessageSchema.parse({ type: 'evalArbitrary', nodeName: 'Foo' })).toThrow();
 		});
@@ -76,6 +87,43 @@ describe('bridgeMessageSchema', () => {
 				expect(() => bridgeMessageSchema.parse({ type, branchIndex: 0 })).toThrow();
 			},
 		);
+	});
+
+	describe('fromAi', () => {
+		it('accepts a minimal envelope (type only)', () => {
+			// `name` is optional in the schema so empty calls reach the host's
+			// friendly `ExpressionError("Add a key, e.g. $fromAI(...)")` rather
+			// than a generic zod error.
+			expect(() => bridgeMessageSchema.parse({ type: 'fromAi' })).not.toThrow();
+		});
+
+		it('accepts arbitrary defaultValue shapes', () => {
+			// defaultValue is z.unknown() — host applies no shape constraint.
+			for (const defaultValue of [42, 'str', true, null, { nested: 1 }, [1, 2]]) {
+				expect(() =>
+					bridgeMessageSchema.parse({ type: 'fromAi', name: 'a', defaultValue }),
+				).not.toThrow();
+			}
+		});
+
+		it('rejects non-string name', () => {
+			expect(() => bridgeMessageSchema.parse({ type: 'fromAi', name: 123 })).toThrow();
+		});
+
+		it('rejects non-string description / valueType', () => {
+			expect(() =>
+				bridgeMessageSchema.parse({ type: 'fromAi', name: 'a', description: 1 }),
+			).toThrow();
+			expect(() =>
+				bridgeMessageSchema.parse({ type: 'fromAi', name: 'a', valueType: 1 }),
+			).toThrow();
+		});
+
+		it('rejects extra fields (.strict)', () => {
+			expect(() =>
+				bridgeMessageSchema.parse({ type: 'fromAi', name: 'a', hijack: 'extra' }),
+			).toThrow();
+		});
 	});
 
 	describe('getItems', () => {

--- a/packages/@n8n/expression-runtime/src/bridge/bridge-messages.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/bridge-messages.ts
@@ -121,7 +121,8 @@ export const fromAiMessage = z
 		name: z.string().optional(),
 		description: z.string().optional(),
 		valueType: z.string().optional(),
-		defaultValue: z.unknown().optional(),
+		// `z.unknown()` already accepts `undefined`, so no `.optional()` needed.
+		defaultValue: z.unknown(),
 	})
 	.strict();
 

--- a/packages/@n8n/expression-runtime/src/bridge/bridge-messages.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/bridge-messages.ts
@@ -94,6 +94,38 @@ export const getItemsMessage = z
 	.strict();
 
 /**
+ * `$fromAI(name, description?, type?, defaultValue?)` — the AI-builder
+ * placeholder accessor (aliases: `$fromAi`, `$fromai`).
+ *
+ * Two deliberate looseness points in this schema, both to preserve host
+ * contract / parity:
+ *
+ * 1. `name` is `z.string().optional()` (not required) so a call missing
+ *    the argument or passing an empty string reaches the host, which
+ *    throws the user-friendly `ExpressionError("Add a key, e.g. $fromAI('placeholder_name')")`.
+ *    Requiring it here would replace that error with a generic zod
+ *    message. The host also validates the regex `[a-zA-Z0-9_-]{0,64}`;
+ *    we don't pre-empt that either.
+ * 2. `defaultValue` is `z.unknown()` because the host accepts any value
+ *    as the fallback return (`handleFromAi` returns it directly via
+ *    `??`). Structured-clone at the bridge boundary still prevents
+ *    functions and other non-cloneable values from crossing.
+ *
+ * `description` and `type` are forwarded even though the host currently
+ * ignores them (`_description`, `_type`), so the protocol matches the
+ * documented call signature.
+ */
+export const fromAiMessage = z
+	.object({
+		type: z.literal('fromAi'),
+		name: z.string().optional(),
+		description: z.string().optional(),
+		valueType: z.string().optional(),
+		defaultValue: z.unknown().optional(),
+	})
+	.strict();
+
+/**
  * The full set of messages the bridge will accept. Discriminator is `type`.
  *
  * Use `.strict()` on each member so unknown fields are rejected rather than
@@ -108,6 +140,7 @@ export const bridgeMessageSchema = z.discriminatedUnion('type', [
 	getInputLastMessage,
 	getInputAllMessage,
 	getItemsMessage,
+	fromAiMessage,
 ]);
 
 export type BridgeMessage = z.infer<typeof bridgeMessageSchema>;

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -496,6 +496,8 @@ export class IsolatedVmBridge implements RuntimeBridge {
 						return this.handleGetInputAll(data);
 					case 'getItems':
 						return this.handleGetItems(msg, data);
+					case 'fromAi':
+						return this.handleFromAi(msg, data);
 					default: {
 						// Unreachable at runtime — zod rejects unknown `type` values
 						// before the switch. The `never` assignment is the compile-time
@@ -586,6 +588,23 @@ export class IsolatedVmBridge implements RuntimeBridge {
 		data: WorkflowData,
 	): unknown {
 		return data.$items?.(msg.nodeName, msg.outputIndex, msg.runIndex);
+	}
+
+	/**
+	 * Handler for `$fromAI(name, description?, type?, defaultValue?)` and its
+	 * `$fromAi` / `$fromai` aliases. Reads the literal `$fromAI` property
+	 * off `data` (host-wired) and forwards the args. The host validates
+	 * `name` (required + regex) and applies its own resolution / fallback
+	 * logic, so empty / invalid names surface as the host's structured
+	 * `ExpressionError` rather than a generic zod parse error.
+	 *
+	 * @private
+	 */
+	private handleFromAi(
+		msg: Extract<BridgeMessage, { type: 'fromAi' }>,
+		data: WorkflowData,
+	): unknown {
+		return data.$fromAI?.(msg.name, msg.description, msg.valueType, msg.defaultValue);
 	}
 
 	/**

--- a/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
+++ b/packages/@n8n/expression-runtime/src/bridge/isolated-vm-bridge.ts
@@ -598,6 +598,12 @@ export class IsolatedVmBridge implements RuntimeBridge {
 	 * logic, so empty / invalid names surface as the host's structured
 	 * `ExpressionError` rather than a generic zod parse error.
 	 *
+	 * Note: `msg.valueType` maps to the host's third positional parameter
+	 * (`_type` in `WorkflowDataProxy.handleFromAi`). The bridge protocol
+	 * renames it to avoid collision with the `type` discriminator on the
+	 * envelope — the host parameter currently goes unused, but if it ever
+	 * gains a name (`type`), this mapping should stay explicit.
+	 *
 	 * @private
 	 */
 	private handleFromAi(

--- a/packages/@n8n/expression-runtime/src/runtime/context.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/context.ts
@@ -268,6 +268,30 @@ export function buildContext(
 		return result;
 	};
 
+	// $fromAI / $fromAi / $fromai — AI-builder placeholder accessor.
+	// All three host aliases route to the same `handleFromAi` callback;
+	// the typed-RPC envelope is identical regardless of which name the
+	// expression used. `name` is forwarded as-is — host validates it
+	// (required, regex-restricted) and emits a structured `ExpressionError`
+	// on bad input.
+	const sendFromAi = (
+		name?: string,
+		description?: string,
+		valueType?: string,
+		defaultValue?: unknown,
+	) => {
+		const result = callbacks.callHost.applySync(
+			null,
+			[{ type: 'fromAi', name, description, valueType, defaultValue }],
+			{ arguments: { copy: true }, result: { copy: true } },
+		);
+		throwIfErrorSentinel(result);
+		return result;
+	};
+	target.$fromAI = sendFromAi;
+	target.$fromAi = sendFromAi;
+	target.$fromai = sendFromAi;
+
 	// -------------------------------------------------------------------------
 	// Resolve an unknown key from the host. Called by the proxy's has/get traps
 	// for keys not already on the target. The resolved value is cached on target

--- a/packages/@n8n/expression-runtime/src/types/evaluator.ts
+++ b/packages/@n8n/expression-runtime/src/types/evaluator.ts
@@ -142,10 +142,27 @@ export interface InputProxy {
  * primitives (`getValueAtPath`, `getArrayElement`), which read paths off
  * the index signature without needing per-key types.
  */
+/**
+ * Signature shared by `$fromAI`, `$fromAi`, and `$fromai` — the three
+ * host-side aliases that resolve to the same `handleFromAi` callback in
+ * `WorkflowDataProxy`. The `name` argument is optional in the type so
+ * empty / missing calls reach the host, which throws a friendly
+ * `ExpressionError` rather than a generic zod / runtime error.
+ */
+export type FromAi = (
+	name?: string,
+	description?: string,
+	valueType?: string,
+	defaultValue?: unknown,
+) => unknown;
+
 export interface WorkflowData {
 	$?: (nodeName: string) => NodeProxy | null | undefined;
 	$input?: InputProxy;
 	$items?: (nodeName?: string, outputIndex?: number, runIndex?: number) => unknown;
+	$fromAI?: FromAi;
+	$fromAi?: FromAi;
+	$fromai?: FromAi;
 	[key: string]: unknown;
 }
 


### PR DESCRIPTION
## Summary

Adds the `fromAi` typed RPC covering `$fromAI(name, description?, type?, defaultValue?)` and its `$fromAi` / `$fromai` aliases (all three map to the same host callback `handleFromAi`).

In-isolate, `target.$fromAI = target.$fromAi = target.$fromai = sendFromAi` — a single closure shared across the three property bindings. The envelope always carries `type: 'fromAi'` regardless of which alias the user invoked.

The handler is a one-liner: `data.$fromAI?.(msg.name, msg.description, msg.valueType, msg.defaultValue)` — literal property name, zod-validated args.

### Schema looseness — two deliberate points

Both preserve the host contract / parity:

1. **`name` is `z.string().optional()` (not required).** Empty / missing calls reach the host, which throws a friendly `ExpressionError("Add a key, e.g. $fromAI('placeholder_name')")`. Requiring it in zod would replace that with a generic parse error. The host also enforces the regex `[a-zA-Z0-9_-]{0,64}` — also left to the host.
2. **`defaultValue` is `z.unknown()`** because the host applies no shape constraint (it returns the fallback verbatim via `??`). Structured-clone at the bridge boundary still prevents functions and other non-cloneable values from crossing.

`description` and `type` are forwarded even though the host currently ignores them, so the protocol matches the documented call signature.

Extends `WorkflowData` with a shared `FromAi` function type and `$fromAI` / `$fromAi` / `$fromai` properties.

### Review follow-ups (separate commits)

- `92055de1d5` — dropped redundant `.optional()` on `z.unknown()` defaultValue
- `ad84597405` — documented the `valueType` ↔ host `_type` mapping

### Stacking

**Stacks on #31146** — review/merge that one first; GitHub will auto-rebase this PR onto master afterward.

Related PRs in the typed-RPC migration:

- #30098 (Step 0) — merged
- #30736 (jmespath) — merged
- #30807 (dispatcher + `getNodeFirst`) — merged
- #30825 (`getNodeLast` + `getNodeAll`) — merged
- #30976 (registry refactor + `isKeyOf`) — merged
- #30977 (`$input.*` typed RPCs) — open
- #31146 (`$items` typed RPC) — draft, **this PR stacks on it**

### How to test

- `pnpm --filter @n8n/expression-runtime test` exercises both the new `fromAiMessage` schema and the dispatcher end-to-end via `typed-rpc.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2982

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created. — N/A, internal refactor (no behavioural change)
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
- [x] I have notified the Product Manager. — N/A, internal refactor

🤖 PR Summary generated by AI