### PR TITLE
fix(core): Allow personal project owners to manage data redaction

### DIFF
--- a/packages/@n8n/permissions/src/roles/scopes/workflow-sharing-scopes.ee.ts
+++ b/packages/@n8n/permissions/src/roles/scopes/workflow-sharing-scopes.ee.ts
@@ -12,6 +12,9 @@ export const WORKFLOW_SHARING_OWNER_SCOPES: Scope[] = [
 	'workflow:unshare',
 	'workflow:move',
 	'workflow:execute-chat',
+	'workflow:enableRedaction',
+	'workflow:disableRedaction',
+	'execution:reveal',
 ];
 
 export const WORKFLOW_SHARING_EDITOR_SCOPES: Scope[] = [

--- a/packages/cli/test/integration/execution-redaction.test.ts
+++ b/packages/cli/test/integration/execution-redaction.test.ts
@@ -335,6 +335,23 @@ describe('GET /executions/:id — Execution Redaction', () => {
 			assertNotRedacted(parseResponseData(response.body));
 		});
 
+		test('member can reveal data on a workflow in their own personal project', async () => {
+			const workflow = await createWorkflow({}, member);
+			const execution = await createExecutionWithRedaction({
+				workflow,
+				mode: 'trigger',
+				policy: 'all',
+			});
+
+			const response = await testServer
+				.authAgentFor(member)
+				.get(`/executions/${execution.id}`)
+				.query({ redactExecutionData: 'false' })
+				.expect(200);
+
+			assertNotRedacted(parseResponseData(response.body));
+		});
+
 		test('project editor without execution:reveal scope gets 403 with structured error', async () => {
 			testServer.license.enable('feat:sharing');
 
@@ -592,7 +609,7 @@ describe('GET /api/v1/executions/:id — Execution Redaction', () => {
 			assertNotRedacted(response.body.data as IRunExecutionData);
 		});
 
-		test('policy "non-manual" with trigger mode — redacts for member (canReveal=false)', async () => {
+		test('policy "non-manual" with trigger mode — redacts for member on own personal project workflow (canReveal=true)', async () => {
 			const workflow = await createWorkflow({}, publicApiMember);
 			const execution = await createExecutionWithRedaction({
 				workflow,
@@ -605,7 +622,7 @@ describe('GET /api/v1/executions/:id — Execution Redaction', () => {
 				.get(`/executions/${execution.id}?includeData=true`)
 				.expect(200);
 
-			assertRedacted(response.body.data as IRunExecutionData, 'workflow_redaction_policy', false);
+			assertRedacted(response.body.data as IRunExecutionData, 'workflow_redaction_policy', true);
 		});
 
 		test('policy "non-manual" with trigger mode — redacts for owner (canReveal=true)', async () => {
@@ -640,7 +657,7 @@ describe('GET /api/v1/executions/:id — Execution Redaction', () => {
 			assertNotRedacted(response.body.data as IRunExecutionData);
 		});
 
-		test('policy "all" with trigger mode — redacts for member (canReveal=false)', async () => {
+		test('policy "all" with trigger mode — redacts for member on own personal project workflow (canReveal=true)', async () => {
 			const workflow = await createWorkflow({}, publicApiMember);
 			const execution = await createExecutionWithRedaction({
 				workflow,
@@ -653,7 +670,7 @@ describe('GET /api/v1/executions/:id — Execution Redaction', () => {
 				.get(`/executions/${execution.id}?includeData=true`)
 				.expect(200);
 
-			assertRedacted(response.body.data as IRunExecutionData, 'workflow_redaction_policy', false);
+			assertRedacted(response.body.data as IRunExecutionData, 'workflow_redaction_policy', true);
 		});
 
 		test('includeData=false — returns execution without data field', async () => {
@@ -775,7 +792,7 @@ describe('GET /api/v1/executions — Execution Redaction', () => {
 		assertRedacted(
 			response.body.data[0].data as IRunExecutionData,
 			'workflow_redaction_policy',
-			false,
+			true,
 		);
 	});
 
@@ -852,10 +869,10 @@ describe('GET /api/v1/executions — Execution Redaction', () => {
 		const wf2Trigger = results.find((e) => e.workflowId === workflow2.id && e.mode === 'trigger');
 		const wf2Webhook = results.find((e) => e.workflowId === workflow2.id && e.mode === 'webhook');
 
-		assertRedacted(wf1Trigger!.data, 'workflow_redaction_policy', false);
+		assertRedacted(wf1Trigger!.data, 'workflow_redaction_policy', true);
 		assertNotRedacted(wf1Manual!.data);
 		assertNotRedacted(wf2Trigger!.data);
-		assertRedacted(wf2Webhook!.data, 'workflow_redaction_policy', false);
+		assertRedacted(wf2Webhook!.data, 'workflow_redaction_policy', true);
 	});
 
 	describe('explicit redactExecutionData=true query param', () => {

--- a/packages/cli/test/integration/workflows/workflows.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflows.controller.test.ts
@@ -224,7 +224,10 @@ describe('POST /workflows', () => {
 		expect(id).toBeDefined();
 		expect(scopes).toEqual(
 			[
+				'execution:reveal',
 				'workflow:delete',
+				'workflow:disableRedaction',
+				'workflow:enableRedaction',
 				'workflow:execute',
 				'workflow:execute-chat',
 				'workflow:export',
@@ -1163,7 +1166,10 @@ describe('GET /workflows', () => {
 			expect(wf1.id).toBe(savedWorkflow1.id);
 			expect(wf1.scopes).toEqual(
 				[
+					'execution:reveal',
 					'workflow:delete',
+					'workflow:disableRedaction',
+					'workflow:enableRedaction',
 					'workflow:execute',
 					'workflow:execute-chat',
 					'workflow:export',
@@ -1217,7 +1223,10 @@ describe('GET /workflows', () => {
 			expect(wf2.id).toBe(savedWorkflow2.id);
 			expect(wf2.scopes).toEqual(
 				[
+					'execution:reveal',
 					'workflow:delete',
+					'workflow:disableRedaction',
+					'workflow:enableRedaction',
 					'workflow:execute',
 					'workflow:execute-chat',
 					'workflow:export',
@@ -2341,7 +2350,10 @@ describe('GET /workflows?includeFolders=true', () => {
 			expect(wf1.id).toBe(savedWorkflow1.id);
 			expect(wf1.scopes).toEqual(
 				[
+					'execution:reveal',
 					'workflow:delete',
+					'workflow:disableRedaction',
+					'workflow:enableRedaction',
 					'workflow:execute',
 					'workflow:execute-chat',
 					'workflow:export',
@@ -2400,7 +2412,10 @@ describe('GET /workflows?includeFolders=true', () => {
 			expect(wf2.id).toBe(savedWorkflow2.id);
 			expect(wf2.scopes).toEqual(
 				[
+					'execution:reveal',
 					'workflow:delete',
+					'workflow:disableRedaction',
+					'workflow:enableRedaction',
 					'workflow:execute',
 					'workflow:execute-chat',
 					'workflow:export',
@@ -3732,6 +3747,33 @@ describe('PATCH /workflows/:workflowId', () => {
 		const dbWorkflow = await workflowRepository.findOneBy({ id: workflow.id });
 		// redactionPolicy must remain 'all' — the disabling change was stripped
 		expect(dbWorkflow?.settings?.redactionPolicy).toBe('all');
+	});
+
+	test('member can enable and disable redactionPolicy on a workflow in their own personal project', async () => {
+		testServer.license.enable('feat:dataRedaction');
+
+		const workflow = await createWorkflowWithHistory(
+			{ settings: { redactionPolicy: 'none' } },
+			member,
+		);
+
+		const enableResponse = await authMemberAgent
+			.patch(`/workflows/${workflow.id}`)
+			.send({ settings: { redactionPolicy: 'all' } });
+
+		expect(enableResponse.statusCode).toBe(200);
+		expect(
+			(await workflowRepository.findOneBy({ id: workflow.id }))?.settings?.redactionPolicy,
+		).toBe('all');
+
+		const disableResponse = await authMemberAgent
+			.patch(`/workflows/${workflow.id}`)
+			.send({ settings: { redactionPolicy: 'none' } });
+
+		expect(disableResponse.statusCode).toBe(200);
+		expect(
+			(await workflowRepository.findOneBy({ id: workflow.id }))?.settings?.redactionPolicy,
+		).toBe('none');
 	});
 });
 


### PR DESCRIPTION
## Summary

Members operating in their **personal project** could not enable workflow data redaction or reveal redacted execution data on workflows they themselves owned. They had to ask a global admin to do it for them, which is nonsensical for a personal workspace. This PR grants the `workflow:owner` sharing role the three scopes that gate that behaviour, so personal-project owners (and team-project admins who own a workflow) regain control over their own data.

### Why

The redaction and reveal access checks AND-filter on two role namespaces at once:

- `WorkflowFinderService.findAllWhere` (used by `findWorkflowIdsWithScopeForUser`, which the redaction service uses to gate reveal)
- `userHasScopes(... { workflowId })` in `check-access.ee.ts`

Both require the user to hold the scope **at the project role level** *and* the workflow's sharing role to contain that scope. `PERSONAL_PROJECT_OWNER_SCOPES` already has `workflow:enableRedaction`, `workflow:disableRedaction` and `execution:reveal`, but `WORKFLOW_SHARING_OWNER_SCOPES` did not, so the workflow-namespace half of the AND collapsed to the empty set and the check returned `false` for the user's own workflow. The same masking also stripped these scopes from the workflow's `scopes` array returned to the editor UI, which is why the settings toggles also appeared locked.

The fix is to add the three scopes to `WORKFLOW_SHARING_OWNER_SCOPES`. The AND-filter still gates everyone else correctly:

| Caller's project role | Has scope at project level? | Workflow role after fix | Net |
|---|---|---|---|
| `project:personalOwner` (personal) | yes | yes | unlocked (the fix) |
| `project:admin` (team) | yes (already in `REGULAR_PROJECT_ADMIN_SCOPES`) | yes | unchanged — already worked |
| `project:editor` (team) on owned workflow | no | yes | still blocked |
| `workflow:editor` sharee | no | no (`WORKFLOW_SHARING_EDITOR_SCOPES` unchanged) | still blocked |

No DB migration is required — `AuthRolesService.syncRoles` diffs in-code role definitions against the DB at startup and rewrites the `workflow:owner` system role's scopes. Custom roles are untouched.

### How to test manually

1. Start n8n with a data-redaction license enabled and the redaction module active.
2. Sign in as a regular member (not the instance owner / admin).
3. In your **personal** project, create a new workflow that returns some data (e.g. a manual trigger with a Set node producing `{ secret: 'top' }`).
4. Open **Workflow Settings → Data redaction**:
   - The production/manual redaction selects should be **enabled** (no lock icon).
   - Set production redaction to **Redact** and save.
5. Execute the workflow as a trigger run, then open the execution.
6. Click **Reveal** on the redacted output → the raw `{ secret: 'top' }` should appear; the reveal must not 403.
7. Negative check: invite a member as `project:editor` to a *team* project, share a workflow to them. Try the same flow as that editor — they should still see the toggles locked and `Reveal` should 403. Permissions for non-owner roles are unchanged.

### Implementation decisions

- The fix is intentionally additive on one role only. Other sharing roles (`workflow:editor`, custom roles) are unchanged, so the blast radius is limited to "workflow owners gain the same redaction control they have at the project level".
- `execution:reveal` is an `execution:*` scope but lives next to `workflow:*` entries in this list. That mirrors how it is already grouped inside `PERSONAL_PROJECT_OWNER_SCOPES` and `REGULAR_PROJECT_ADMIN_SCOPES`.
- Four existing reveal tests in `execution-redaction.test.ts` were asserting `canReveal: false` for a member on their own personal-project workflow — that assertion *encoded* the bug as expected behaviour. They are flipped to `canReveal: true`. A new red→green integration test (`member can reveal data on a workflow in their own personal project`) pins the contract going forward.
- Scope-list assertions in `workflows.controller.test.ts` were updated to include the three new scopes in the cases where the sharing mask is `WORKFLOW_SHARING_OWNER_SCOPES` and the caller's project role also holds the scope (owner viewing own workflow; team admin viewing team workflow; personal owner viewing own workflow). Cases where the project role lacks the scope (member viewing as editor, sharee) are unchanged.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/IAM-692

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)