### PR TITLE
fix(core): Stop idle-killing Instance AI active runs awaiting HITL

### DIFF
--- a/packages/@n8n/instance-ai/src/runtime/__tests__/liveness-policy.test.ts
+++ b/packages/@n8n/instance-ai/src/runtime/__tests__/liveness-policy.test.ts
@@ -17,8 +17,8 @@ describe('InstanceAiLivenessPolicy', () => {
 			confirmationTimeoutMs: day,
 			backgroundTaskIdleTimeoutMs: 10 * minute,
 			backgroundTaskMaxLifetimeMs: 30 * minute,
-			activeRunIdleTimeoutMs: 10 * minute,
-			activeRunMaxLifetimeMs: 30 * minute,
+			activeRunIdleTimeoutMs: 0,
+			activeRunMaxLifetimeMs: day,
 		});
 
 		expect(createInstanceAiLivenessPolicyConfig({ confirmationTimeoutMs: 42_000 })).toEqual({
@@ -58,16 +58,27 @@ describe('InstanceAiLivenessPolicy', () => {
 		const decision = createPolicy().evaluate({
 			surface: 'active-run',
 			startedAt: 0,
-			lastActivityAt: 31 * minute,
-			now: 31 * minute,
+			lastActivityAt: day + minute,
+			now: day + minute,
 		});
 
 		expect(decision).toMatchObject({
 			action: 'timeout',
 			reason: 'max_lifetime',
 			surface: 'active-run',
-			timeoutMs: 30 * minute,
+			timeoutMs: day,
 		});
+	});
+
+	it('does not idle-timeout an active run that is waiting on another surface', () => {
+		const decision = createPolicy().evaluate({
+			surface: 'active-run',
+			startedAt: 0,
+			lastActivityAt: 0,
+			now: 6 * 60 * minute,
+		});
+
+		expect(decision).toEqual({ action: 'keep-alive' });
 	});
 
 	it('uses the one-day confirmation timeout for suspended runs and pending confirmations by default', () => {

--- a/packages/@n8n/instance-ai/src/runtime/liveness-policy.ts
+++ b/packages/@n8n/instance-ai/src/runtime/liveness-policy.ts
@@ -21,8 +21,8 @@ export const INSTANCE_AI_DEFAULT_LIVENESS_POLICY_CONFIG = {
 	confirmationTimeoutMs: DAY_MS,
 	backgroundTaskIdleTimeoutMs: 10 * MINUTE_MS,
 	backgroundTaskMaxLifetimeMs: 30 * MINUTE_MS,
-	activeRunIdleTimeoutMs: 10 * MINUTE_MS,
-	activeRunMaxLifetimeMs: 30 * MINUTE_MS,
+	activeRunIdleTimeoutMs: 0,
+	activeRunMaxLifetimeMs: DAY_MS,
 } satisfies InstanceAiLivenessPolicyConfig;
 
 export function createInstanceAiLivenessPolicyConfig(


### PR DESCRIPTION
Active runs are coordinators — when "idle" they are actually waiting on HITL, sub-agents, or background tasks that own their own timeouts. The 10-minute active-run idle timeout was firing during legitimate setup / planning flows and cancelling the turn out from under the user.

Disable idle for active-run and align its max-lifetime with the 24h HITL ceiling so it remains a runaway circuit breaker.

https://linear.app/n8n/issue/INS-385

## Summary

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.