### PR TITLE
feat(core): Add Linear integration context and actions (no-changelog)

### DIFF
--- a/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
@@ -777,6 +777,36 @@ describe('AgentsService', () => {
 		});
 	});
 
+	describe('credential integrations', () => {
+		it('marks a published agent dirty when saving a credential integration', async () => {
+			const agent = makeAgent({
+				versionId,
+				activeVersionId: versionId,
+				integrations: [],
+			});
+			agentRepository.save.mockResolvedValue(agent);
+
+			await service.saveCredentialIntegration(agent, { type: 'slack', credentialId: 'cred-slack' });
+
+			expect(agent.versionId).not.toBe(versionId);
+			expect(agentRepository.save).toHaveBeenCalledWith(agent);
+		});
+
+		it('marks a published agent dirty when removing a credential integration', async () => {
+			const agent = makeAgent({
+				versionId,
+				activeVersionId: versionId,
+				integrations: [{ type: 'slack', credentialId: 'cred-slack' }],
+			});
+			agentRepository.save.mockResolvedValue(agent);
+
+			await service.removeCredentialIntegration(agent, 'slack', 'cred-slack');
+
+			expect(agent.versionId).not.toBe(versionId);
+			expect(agentRepository.save).toHaveBeenCalledWith(agent);
+		});
+	});
+
 	describe('executeForChatPublished', () => {
 		it('reconstructs from the published skill snapshot instead of the draft skill body', async () => {
 			const publishedSkill = {

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -1622,6 +1622,8 @@ export class AgentsService {
 				)
 			: [...existing, validated];
 
+		markAgentDraftDirty(agent);
+		this.clearRuntimes(agent.id);
 		const result = await this.agentRepository.save(agent);
 		await this.chatIntegrationService.broadcastIntegrationChange(agent.id, integration, 'connect');
 		return result;
@@ -1643,6 +1645,8 @@ export class AgentsService {
 		// filter by ref
 		agent.integrations = agent.integrations.filter((i) => i !== integration);
 
+		markAgentDraftDirty(agent);
+		this.clearRuntimes(agent.id);
 		const result = await this.agentRepository.save(agent);
 		await this.chatIntegrationService.broadcastIntegrationChange(
 			agent.id,

--- a/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
@@ -10,12 +10,14 @@ import {
 	type AgentChatIntegrationContext,
 } from '../agent-chat-integration';
 import type { ComponentMapper } from '../component-mapper';
+import type { IntegrationMessageContextService } from '../integration-message-context.service';
 import type { AgentCredentialIntegrationConfig } from '@n8n/api-types';
 
 type ChatBotLike = ConstructorParameters<typeof AgentChatBridge>[0];
 
 interface FakeThread {
 	id: string;
+	channelId?: string;
 	subscribe: jest.Mock;
 	post: jest.Mock;
 }
@@ -43,6 +45,7 @@ function makeBot() {
 function makeThread(): FakeThread {
 	return {
 		id: 'thread-1',
+		channelId: 'channel-1',
 		subscribe: jest.fn().mockResolvedValue(undefined),
 		post: jest.fn().mockResolvedValue(undefined),
 	};
@@ -264,6 +267,125 @@ describe('AgentChatBridge — consumeStream', () => {
 			expect(thread.post).toHaveBeenCalledTimes(1);
 			const received = await drainIterable(thread.post.mock.calls[0][0]);
 			expect(received).toBe('Hello world');
+		});
+	});
+
+	describe('message context', () => {
+		it('stores a sanitized message subject from the inbound message', async () => {
+			const { bot, handlers } = makeBot();
+			const thread = makeThread();
+			const messageContextStore = mock<IntegrationMessageContextService>();
+			messageContextStore.getLatest.mockResolvedValue(null);
+			const agentExecutor = makeAgentExecutor([{ type: 'finish', finishReason: 'stop' }]);
+
+			new AgentChatBridge(
+				bot as unknown as ChatBotLike,
+				'agent-1',
+				agentExecutor as never,
+				componentMapper,
+				logger,
+				'project-1',
+				streamingIntegration,
+				messageContextStore,
+			);
+
+			await handlers.mention!(thread, {
+				id: 'message-1',
+				text: 'what is this about?',
+				author: { userId: 'u1', userName: 'user1' },
+				get subject() {
+					return Promise.resolve({
+						type: 'issue',
+						id: 'ENG-123',
+						title: 'Fix signup',
+						description: 'Signup fails for invited users',
+						status: 'In Progress',
+						url: 'https://linear.app/n8n/issue/ENG-123/fix-signup',
+						labels: ['Bug'],
+						assignee: { id: 'user-2', name: 'Michael Drury' },
+						author: { id: 'user-3', name: 'Ada Lovelace' },
+						raw: { internal: 'not persisted' },
+					});
+				},
+			});
+
+			expect(messageContextStore.setLatest).toHaveBeenCalledWith(
+				'agent-1:thread-1',
+				'u1',
+				expect.objectContaining({
+					integrationConnectionId: 'test-streaming:cred-1',
+					platform: 'test-streaming',
+					target: { type: 'thread', threadId: 'thread-1', channelId: 'channel-1' },
+					messageId: 'message-1',
+					interactingUserId: 'u1',
+					subject: {
+						type: 'issue',
+						id: 'ENG-123',
+						title: 'Fix signup',
+						description: 'Signup fails for invited users',
+						status: 'In Progress',
+						url: 'https://linear.app/n8n/issue/ENG-123/fix-signup',
+						labels: ['Bug'],
+						assignee: { id: 'user-2', name: 'Michael Drury' },
+						author: { id: 'user-3', name: 'Ada Lovelace' },
+					},
+				}),
+			);
+		});
+
+		it('keeps the previous subject when an action click updates the latest context', async () => {
+			const { bot, handlers } = makeBot();
+			const thread = makeThread();
+			const messageContextStore = mock<IntegrationMessageContextService>();
+			messageContextStore.getLatest.mockResolvedValue({
+				integrationConnectionId: 'test-streaming:cred-1',
+				platform: 'test-streaming',
+				target: { type: 'thread', threadId: 'thread-1', channelId: 'channel-1' },
+				messageId: 'message-1',
+				interactingUserId: 'u1',
+				subject: {
+					type: 'issue',
+					id: 'ENG-123',
+					title: 'Fix signup',
+				},
+				updatedAt: '2026-05-18T10:00:00.000Z',
+			});
+			const agentExecutor = makeAgentExecutor([{ type: 'finish', finishReason: 'stop' }]);
+
+			new AgentChatBridge(
+				bot as unknown as ChatBotLike,
+				'agent-1',
+				agentExecutor as never,
+				componentMapper,
+				logger,
+				'project-1',
+				streamingIntegration,
+				messageContextStore,
+			);
+
+			await handlers.action!({
+				actionId: 'resume:run-1:tool-1:0',
+				value: '{"approved":true}',
+				messageId: 'card-message-1',
+				thread,
+				threadId: 'thread-1',
+				user: { userId: 'u2', userName: 'user2' },
+				adapter: { deleteMessage: jest.fn().mockResolvedValue(undefined) },
+			});
+
+			expect(messageContextStore.setLatest).toHaveBeenCalledWith(
+				'agent-1:thread-1',
+				'u2',
+				expect.objectContaining({
+					messageId: 'card-message-1',
+					interactingUserId: 'u2',
+					subject: {
+						type: 'issue',
+						id: 'ENG-123',
+						title: 'Fix signup',
+					},
+				}),
+			);
 		});
 	});
 });

--- a/packages/cli/src/modules/agents/integrations/__tests__/integration-action-executor.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/integration-action-executor.test.ts
@@ -10,6 +10,11 @@ const slack: AgentCredentialIntegrationConfig = {
 	credentialId: 'cred-a',
 };
 
+const linear: AgentCredentialIntegrationConfig = {
+	type: 'linear',
+	credentialId: 'cred-linear',
+};
+
 describe('ChatIntegrationActionExecutor', () => {
 	it('posts channel messages through the selected integration connection and returns message context', async () => {
 		const sentMessage = {
@@ -235,6 +240,186 @@ describe('ChatIntegrationActionExecutor', () => {
 			error: {
 				code: 'CONNECTION_NOT_AVAILABLE',
 				message: 'The integration connection is not currently available.',
+			},
+		});
+	});
+
+	it('creates Linear issues and returns issue message context', async () => {
+		const issue = {
+			id: 'issue-uuid',
+			identifier: 'ENG-123',
+			title: 'Fix signup',
+			description: 'Signup fails for invited users',
+			url: 'https://linear.app/n8n/issue/ENG-123/fix-signup',
+			createdAt: new Date('2026-05-18T10:00:00.000Z'),
+			updatedAt: new Date('2026-05-18T10:01:00.000Z'),
+			state: Promise.resolve({ id: 'state-1', name: 'Todo', type: 'unstarted' }),
+			assignee: Promise.resolve({
+				id: 'user-1',
+				name: 'Michael Drury',
+				displayName: 'Michael',
+				email: 'michael@example.com',
+				active: true,
+				app: false,
+				isAssignable: true,
+				isMentionable: true,
+				url: 'https://linear.app/n8n/profiles/user-1',
+			}),
+			labels: jest.fn().mockResolvedValue({ nodes: [{ id: 'label-1', name: 'Bug' }] }),
+		};
+		const linearClient = {
+			createIssue: jest.fn().mockResolvedValue({
+				issue: Promise.resolve(issue),
+				issueId: 'issue-uuid',
+			}),
+		};
+		const chat = mock<ChatInstance>();
+		chat.getAdapter.mockReturnValue({ client: linearClient });
+		const chatIntegrationService = mock<ChatIntegrationService>();
+		chatIntegrationService.getChatInstance.mockReturnValue(chat);
+		const executor = new ChatIntegrationActionExecutor(chatIntegrationService);
+		const descriptor = getIntegrationToolConnectionDescriptors([linear], 'agent-1')[0];
+
+		const result = await executor.execute({
+			descriptor,
+			action: 'create_issue',
+			input: {
+				teamId: 'team-1',
+				title: 'Fix signup',
+				description: 'Signup fails for invited users',
+				assigneeId: 'user-1',
+				projectId: 'project-1',
+				labelIds: ['label-1'],
+				priority: 2,
+				stateId: 'state-1',
+				parentId: 'parent-issue-1',
+			},
+			awaitResponse: false,
+		});
+
+		expect(linearClient.createIssue).toHaveBeenCalledWith({
+			teamId: 'team-1',
+			title: 'Fix signup',
+			description: 'Signup fails for invited users',
+			assigneeId: 'user-1',
+			projectId: 'project-1',
+			labelIds: ['label-1'],
+			priority: 2,
+			stateId: 'state-1',
+			parentId: 'parent-issue-1',
+		});
+		expect(result).toEqual({
+			ok: true,
+			issue: {
+				issueId: 'issue-uuid',
+				identifier: 'ENG-123',
+				title: 'Fix signup',
+				description: 'Signup fails for invited users',
+				url: 'https://linear.app/n8n/issue/ENG-123/fix-signup',
+				state: { id: 'state-1', name: 'Todo', type: 'unstarted' },
+				assignee: {
+					userId: 'user-1',
+					name: 'Michael Drury',
+					displayName: 'Michael',
+					email: 'michael@example.com',
+					active: true,
+					isBot: false,
+					isAssignable: true,
+					isMentionable: true,
+					url: 'https://linear.app/n8n/profiles/user-1',
+				},
+				labels: [{ labelId: 'label-1', name: 'Bug' }],
+				createdAt: '2026-05-18T10:00:00.000Z',
+				updatedAt: '2026-05-18T10:01:00.000Z',
+			},
+			messageContext: {
+				integrationConnectionId: 'linear:cred-linear',
+				platform: 'linear',
+				target: { type: 'thread', threadId: 'linear:issue-uuid' },
+				subject: {
+					type: 'issue',
+					id: 'ENG-123',
+					title: 'Fix signup',
+					description: 'Signup fails for invited users',
+					url: 'https://linear.app/n8n/issue/ENG-123/fix-signup',
+					status: 'Todo',
+					labels: ['Bug'],
+					assignee: { id: 'user-1', name: 'Michael Drury' },
+				},
+				updatedAt: expect.any(String),
+			},
+		});
+	});
+
+	it('creates Linear comments and returns comment message context', async () => {
+		const comment = {
+			id: 'comment-1',
+			body: 'I can reproduce this.',
+			url: 'https://linear.app/n8n/issue/ENG-123#comment-1',
+			createdAt: new Date('2026-05-18T10:02:00.000Z'),
+			updatedAt: new Date('2026-05-18T10:03:00.000Z'),
+			user: Promise.resolve({
+				id: 'user-1',
+				name: 'Michael Drury',
+				displayName: 'Michael',
+				email: 'michael@example.com',
+				active: true,
+				app: false,
+			}),
+		};
+		const linearClient = {
+			createComment: jest.fn().mockResolvedValue({
+				comment: Promise.resolve(comment),
+				commentId: 'comment-1',
+			}),
+		};
+		const chat = mock<ChatInstance>();
+		chat.getAdapter.mockReturnValue({ client: linearClient });
+		const chatIntegrationService = mock<ChatIntegrationService>();
+		chatIntegrationService.getChatInstance.mockReturnValue(chat);
+		const executor = new ChatIntegrationActionExecutor(chatIntegrationService);
+		const descriptor = getIntegrationToolConnectionDescriptors([linear], 'agent-1')[0];
+
+		const result = await executor.execute({
+			descriptor,
+			action: 'create_comment',
+			input: {
+				issueId: 'issue-uuid',
+				body: 'I can reproduce this.',
+				parentCommentId: 'parent-1',
+			},
+			awaitResponse: false,
+		});
+
+		expect(linearClient.createComment).toHaveBeenCalledWith({
+			issueId: 'issue-uuid',
+			body: 'I can reproduce this.',
+			parentId: 'parent-1',
+		});
+		expect(result).toEqual({
+			ok: true,
+			comment: {
+				commentId: 'comment-1',
+				body: 'I can reproduce this.',
+				url: 'https://linear.app/n8n/issue/ENG-123#comment-1',
+				createdAt: '2026-05-18T10:02:00.000Z',
+				updatedAt: '2026-05-18T10:03:00.000Z',
+				author: {
+					userId: 'user-1',
+					name: 'Michael Drury',
+					displayName: 'Michael',
+					email: 'michael@example.com',
+					active: true,
+					isBot: false,
+				},
+			},
+			messageContext: {
+				integrationConnectionId: 'linear:cred-linear',
+				platform: 'linear',
+				target: { type: 'thread', threadId: 'linear:issue-uuid:c:parent-1' },
+				messageId: 'comment-1',
+				subject: { type: 'issue', id: 'issue-uuid' },
+				updatedAt: expect.any(String),
 			},
 		});
 	});

--- a/packages/cli/src/modules/agents/integrations/__tests__/integration-context-query-executor.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/integration-context-query-executor.test.ts
@@ -10,6 +10,11 @@ const slack: AgentCredentialIntegrationConfig = {
 	credentialId: 'cred-a',
 };
 
+const linear: AgentCredentialIntegrationConfig = {
+	type: 'linear',
+	credentialId: 'cred-b',
+};
+
 describe('ChatIntegrationContextQueryExecutor', () => {
 	it('searches Slack users by name through the selected integration connection', async () => {
 		const usersList = jest.fn().mockResolvedValue({
@@ -139,6 +144,274 @@ describe('ChatIntegrationContextQueryExecutor', () => {
 				},
 			],
 			resultCount: 1,
+		});
+	});
+
+	it('gets Linear users through the selected integration connection', async () => {
+		const linearClient = {
+			user: jest.fn().mockResolvedValue({
+				id: 'user-1',
+				name: 'Michael Drury',
+				displayName: 'Michael',
+				email: 'michael@example.com',
+				avatarUrl: 'https://example.com/avatar.png',
+				active: true,
+				app: false,
+				isAssignable: true,
+				isMentionable: true,
+				url: 'https://linear.app/n8n/profiles/user-1',
+			}),
+		};
+		const chat = mock<ChatInstance>();
+		chat.getAdapter.mockReturnValue({ client: linearClient });
+
+		const chatIntegrationService = mock<ChatIntegrationService>();
+		chatIntegrationService.getChatInstance.mockReturnValue(chat);
+		const executor = new ChatIntegrationContextQueryExecutor(chatIntegrationService);
+		const descriptor = getIntegrationToolConnectionDescriptors([linear], 'agent-1')[0];
+
+		const result = await executor.execute({
+			descriptor,
+			query: 'get_user',
+			input: { userId: 'user-1' },
+		});
+
+		expect(chatIntegrationService.getChatInstance).toHaveBeenCalledWith('agent-1', {
+			type: 'linear',
+			credentialId: 'cred-b',
+		});
+		expect(chat.getAdapter).toHaveBeenCalledWith('linear');
+		expect(linearClient.user).toHaveBeenCalledWith('user-1');
+		expect(result).toEqual({
+			ok: true,
+			user: {
+				userId: 'user-1',
+				name: 'Michael Drury',
+				displayName: 'Michael',
+				email: 'michael@example.com',
+				avatarUrl: 'https://example.com/avatar.png',
+				active: true,
+				isBot: false,
+				isAssignable: true,
+				isMentionable: true,
+				url: 'https://linear.app/n8n/profiles/user-1',
+			},
+		});
+	});
+
+	it('searches Linear users by query through the selected integration connection', async () => {
+		const linearClient = {
+			users: jest.fn().mockResolvedValue({
+				nodes: [
+					{
+						id: 'user-1',
+						name: 'Michael Drury',
+						displayName: 'Michael',
+						email: 'michael@example.com',
+						active: true,
+						app: false,
+						isAssignable: true,
+						isMentionable: true,
+						url: 'https://linear.app/n8n/profiles/user-1',
+					},
+				],
+				pageInfo: { hasNextPage: false },
+			}),
+		};
+		const chat = mock<ChatInstance>();
+		chat.getAdapter.mockReturnValue({ client: linearClient });
+
+		const chatIntegrationService = mock<ChatIntegrationService>();
+		chatIntegrationService.getChatInstance.mockReturnValue(chat);
+		const executor = new ChatIntegrationContextQueryExecutor(chatIntegrationService);
+		const descriptor = getIntegrationToolConnectionDescriptors([linear], 'agent-1')[0];
+
+		const result = await executor.execute({
+			descriptor,
+			query: 'search_users',
+			input: { query: 'Michael', limit: 5 },
+		});
+
+		expect(linearClient.users).toHaveBeenCalledWith({
+			filter: {
+				and: [
+					{
+						or: [
+							{ name: { containsIgnoreCase: 'Michael' } },
+							{ displayName: { containsIgnoreCase: 'Michael' } },
+							{ email: { containsIgnoreCase: 'Michael' } },
+						],
+					},
+					{ app: { eq: false } },
+				],
+			},
+			first: 5,
+			includeArchived: false,
+			includeDisabled: false,
+		});
+		expect(result).toEqual({
+			ok: true,
+			users: [
+				expect.objectContaining({
+					userId: 'user-1',
+					name: 'Michael Drury',
+					displayName: 'Michael',
+					email: 'michael@example.com',
+				}),
+			],
+			resultCount: 1,
+		});
+	});
+
+	it('gets Linear issues with optional recent comments', async () => {
+		const createdAt = new Date('2026-05-18T10:00:00.000Z');
+		const updatedAt = new Date('2026-05-18T11:00:00.000Z');
+		const commentAuthor = {
+			id: 'user-2',
+			name: 'Ada Lovelace',
+			displayName: 'Ada',
+			email: 'ada@example.com',
+			active: true,
+			app: false,
+			isAssignable: true,
+			isMentionable: true,
+			url: 'https://linear.app/n8n/profiles/user-2',
+		};
+		const issue = {
+			id: 'issue-uuid',
+			identifier: 'ENG-123',
+			title: 'Fix signup',
+			description: 'Signup fails for invited users',
+			url: 'https://linear.app/n8n/issue/ENG-123/fix-signup',
+			priority: 2,
+			priorityLabel: 'High',
+			createdAt,
+			updatedAt,
+			state: Promise.resolve({ id: 'state-1', name: 'In Progress', type: 'started' }),
+			assignee: Promise.resolve(commentAuthor),
+			creator: Promise.resolve(commentAuthor),
+			team: Promise.resolve({ id: 'team-1', key: 'ENG', name: 'Engineering' }),
+			project: Promise.resolve({ id: 'project-1', name: 'Signup' }),
+			labels: jest.fn().mockResolvedValue({ nodes: [{ id: 'label-1', name: 'Bug' }] }),
+			comments: jest.fn().mockResolvedValue({
+				nodes: [
+					{
+						id: 'comment-1',
+						body: 'I can reproduce this.',
+						url: 'https://linear.app/n8n/issue/ENG-123#comment-1',
+						createdAt,
+						updatedAt,
+						user: Promise.resolve(commentAuthor),
+					},
+				],
+			}),
+		};
+		const linearClient = {
+			issue: jest.fn().mockResolvedValue(issue),
+		};
+		const chat = mock<ChatInstance>();
+		chat.getAdapter.mockReturnValue({ client: linearClient });
+
+		const chatIntegrationService = mock<ChatIntegrationService>();
+		chatIntegrationService.getChatInstance.mockReturnValue(chat);
+		const executor = new ChatIntegrationContextQueryExecutor(chatIntegrationService);
+		const descriptor = getIntegrationToolConnectionDescriptors([linear], 'agent-1')[0];
+
+		const result = await executor.execute({
+			descriptor,
+			query: 'get_issue',
+			input: { issueId: 'ENG-123', includeComments: true, commentsLimit: 3 },
+		});
+
+		expect(linearClient.issue).toHaveBeenCalledWith('ENG-123');
+		expect(issue.comments).toHaveBeenCalledWith({ first: 3 });
+		expect(result).toEqual({
+			ok: true,
+			issue: {
+				issueId: 'issue-uuid',
+				identifier: 'ENG-123',
+				title: 'Fix signup',
+				description: 'Signup fails for invited users',
+				url: 'https://linear.app/n8n/issue/ENG-123/fix-signup',
+				priority: { value: 2, label: 'High' },
+				state: { id: 'state-1', name: 'In Progress', type: 'started' },
+				assignee: expect.objectContaining({ userId: 'user-2', name: 'Ada Lovelace' }),
+				creator: expect.objectContaining({ userId: 'user-2', name: 'Ada Lovelace' }),
+				team: { teamId: 'team-1', key: 'ENG', name: 'Engineering' },
+				project: { projectId: 'project-1', name: 'Signup' },
+				labels: [{ labelId: 'label-1', name: 'Bug' }],
+				createdAt: '2026-05-18T10:00:00.000Z',
+				updatedAt: '2026-05-18T11:00:00.000Z',
+				comments: [
+					{
+						commentId: 'comment-1',
+						body: 'I can reproduce this.',
+						url: 'https://linear.app/n8n/issue/ENG-123#comment-1',
+						createdAt: '2026-05-18T10:00:00.000Z',
+						updatedAt: '2026-05-18T11:00:00.000Z',
+						author: expect.objectContaining({ userId: 'user-2', name: 'Ada Lovelace' }),
+					},
+				],
+			},
+		});
+	});
+
+	it('searches Linear issues through the selected integration connection', async () => {
+		const linearClient = {
+			searchIssues: jest.fn().mockResolvedValue({
+				totalCount: 1,
+				nodes: [
+					{
+						id: 'issue-uuid',
+						identifier: 'ENG-123',
+						title: 'Fix signup',
+						description: 'Signup fails for invited users',
+						url: 'https://linear.app/n8n/issue/ENG-123/fix-signup',
+						priority: 2,
+						priorityLabel: 'High',
+						createdAt: new Date('2026-05-18T10:00:00.000Z'),
+						updatedAt: new Date('2026-05-18T11:00:00.000Z'),
+						state: Promise.resolve({ id: 'state-1', name: 'In Progress', type: 'started' }),
+						assignee: Promise.resolve(undefined),
+						creator: Promise.resolve(undefined),
+						team: Promise.resolve({ id: 'team-1', key: 'ENG', name: 'Engineering' }),
+						project: Promise.resolve(undefined),
+						labels: jest.fn().mockResolvedValue({ nodes: [] }),
+					},
+				],
+			}),
+		};
+		const chat = mock<ChatInstance>();
+		chat.getAdapter.mockReturnValue({ client: linearClient });
+
+		const chatIntegrationService = mock<ChatIntegrationService>();
+		chatIntegrationService.getChatInstance.mockReturnValue(chat);
+		const executor = new ChatIntegrationContextQueryExecutor(chatIntegrationService);
+		const descriptor = getIntegrationToolConnectionDescriptors([linear], 'agent-1')[0];
+
+		const result = await executor.execute({
+			descriptor,
+			query: 'search_issues',
+			input: { query: 'signup', teamId: 'team-1', includeArchived: true, limit: 5 },
+		});
+
+		expect(linearClient.searchIssues).toHaveBeenCalledWith('signup', {
+			first: 5,
+			teamId: 'team-1',
+			includeArchived: true,
+		});
+		expect(result).toEqual({
+			ok: true,
+			issues: [
+				expect.objectContaining({
+					issueId: 'issue-uuid',
+					identifier: 'ENG-123',
+					title: 'Fix signup',
+					team: { teamId: 'team-1', key: 'ENG', name: 'Engineering' },
+				}),
+			],
+			resultCount: 1,
+			totalCount: 1,
 		});
 	});
 });

--- a/packages/cli/src/modules/agents/integrations/__tests__/integration-tools.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/integration-tools.test.ts
@@ -96,6 +96,60 @@ describe('integration tools', () => {
 		expect(queryExecutor.execute).not.toHaveBeenCalled();
 	});
 
+	it('context tool returns the current message subject when available', async () => {
+		const messageContextStore = mock<IntegrationMessageContextStore>();
+		messageContextStore.getLatest.mockResolvedValue({
+			integrationConnectionId: 'linear:cred-c',
+			platform: 'linear',
+			target: { type: 'thread', threadId: 'linear:issue-comment-1' },
+			messageId: 'comment-1',
+			subject: {
+				type: 'issue',
+				id: 'ENG-123',
+				title: 'Fix signup',
+				description: 'Signup fails for invited users',
+				status: 'In Progress',
+				url: 'https://linear.app/n8n/issue/ENG-123/fix-signup',
+				labels: ['Bug'],
+				assignee: { id: 'user-1', name: 'Michael Drury' },
+				author: { id: 'user-2', name: 'Ada Lovelace' },
+			},
+			updatedAt: '2026-05-18T10:00:00.000Z',
+		});
+		const queryExecutor = mock<IntegrationContextQueryExecutor>();
+
+		const tool = createIntegrationContextTool({
+			descriptor: getIntegrationToolConnectionDescriptors([linear])[0],
+			messageContextStore,
+			queryExecutor,
+		}).build();
+		const schema = tool.inputSchema as z.ZodType;
+
+		expect(schema.safeParse({ query: 'get_current_subject', input: {} }).success).toBe(true);
+		expect(tool.description).toContain('get_current_subject: no input');
+
+		const result = await tool.handler!(
+			{ query: 'get_current_subject', input: {} },
+			{ persistence: { threadId: 'thread-1', resourceId: 'resource-1' } },
+		);
+
+		expect(result).toEqual({
+			ok: true,
+			subject: {
+				type: 'issue',
+				id: 'ENG-123',
+				title: 'Fix signup',
+				description: 'Signup fails for invited users',
+				status: 'In Progress',
+				url: 'https://linear.app/n8n/issue/ENG-123/fix-signup',
+				labels: ['Bug'],
+				assignee: { id: 'user-1', name: 'Michael Drury' },
+				author: { id: 'user-2', name: 'Ada Lovelace' },
+			},
+		});
+		expect(queryExecutor.execute).not.toHaveBeenCalled();
+	});
+
 	it('context tool schema requires platform IDs for user and channel lookups', () => {
 		const tool = createIntegrationContextTool({
 			descriptor: getIntegrationToolConnectionDescriptors([slackA])[0],
@@ -149,6 +203,48 @@ describe('integration tools', () => {
 		expect(schema.safeParse({ query: 'search_channels', input: {} }).success).toBe(false);
 		expect(tool.description).toContain('search_users: input.query or input.email');
 		expect(tool.description).toContain('search_channels: input.query');
+	});
+
+	it('context tool schema accepts Linear issue lookup and search queries', () => {
+		const tool = createIntegrationContextTool({
+			descriptor: getIntegrationToolConnectionDescriptors([linear], 'agent-1', () => ({
+				contextQueries: [
+					'get_current_message_context',
+					'get_current_subject',
+					'get_current_user',
+					'get_user',
+					'search_users',
+					'get_issue',
+					'search_issues',
+				],
+			}))[0],
+			messageContextStore: mock<IntegrationMessageContextStore>(),
+			queryExecutor: mock<IntegrationContextQueryExecutor>(),
+		}).build();
+		const schema = tool.inputSchema as z.ZodType;
+
+		expect(schema.safeParse({ query: 'get_issue', input: { issueId: 'ENG-123' } }).success).toBe(
+			true,
+		);
+		expect(
+			schema.safeParse({
+				query: 'get_issue',
+				input: { issueId: 'ENG-123', includeComments: true, commentsLimit: 5 },
+			}).success,
+		).toBe(true);
+		expect(schema.safeParse({ query: 'get_issue', input: {} }).success).toBe(false);
+		expect(
+			schema.safeParse({ query: 'search_issues', input: { query: 'signup bug' } }).success,
+		).toBe(true);
+		expect(
+			schema.safeParse({
+				query: 'search_issues',
+				input: { query: 'signup bug', teamId: 'team-1', includeArchived: true, limit: 5 },
+			}).success,
+		).toBe(true);
+		expect(schema.safeParse({ query: 'search_issues', input: {} }).success).toBe(false);
+		expect(tool.description).toContain('get_issue: input.issueId');
+		expect(tool.description).toContain('search_issues: input.query');
 	});
 
 	it('integration tool schemas convert to JSON Schema objects for model providers', () => {
@@ -241,6 +337,75 @@ describe('integration tools', () => {
 		expect(tool.description).toContain('send_channel_message: input.channelId');
 	});
 
+	it('action tool schema accepts Slack emoji reaction actions', () => {
+		const tool = createIntegrationActionTool({
+			descriptor: getIntegrationToolConnectionDescriptors([slackA], 'agent-1', () => ({
+				actions: ['respond', 'send_dm', 'send_channel_message', 'add_reaction'],
+			}))[0],
+			messageContextStore: mock<IntegrationMessageContextStore>(),
+			actionExecutor: mock<IntegrationActionExecutor>(),
+		}).build();
+		const schema = tool.inputSchema as z.ZodType;
+
+		expect(schema.safeParse({ action: 'add_reaction', input: { emoji: 'eyes' } }).success).toBe(
+			true,
+		);
+		expect(
+			schema.safeParse({
+				action: 'add_reaction',
+				input: {
+					emoji: ':white_check_mark:',
+					threadId: 'slack:C123:123.456',
+					messageId: '123.456',
+				},
+			}).success,
+		).toBe(true);
+		expect(schema.safeParse({ action: 'add_reaction', input: {} }).success).toBe(false);
+		expect(tool.description).toContain('add_reaction: input.emoji is required');
+	});
+
+	it('action tool schema accepts Linear issue and comment creation actions', () => {
+		const tool = createIntegrationActionTool({
+			descriptor: getIntegrationToolConnectionDescriptors([linear], 'agent-1', () => ({
+				actions: ['respond', 'create_issue', 'create_comment'],
+			}))[0],
+			messageContextStore: mock<IntegrationMessageContextStore>(),
+			actionExecutor: mock<IntegrationActionExecutor>(),
+		}).build();
+		const schema = tool.inputSchema as z.ZodType;
+
+		expect(
+			schema.safeParse({
+				action: 'create_issue',
+				input: {
+					teamId: 'team-1',
+					title: 'Fix signup',
+					description: 'Signup fails for invited users',
+					assigneeId: 'user-1',
+					projectId: 'project-1',
+					labelIds: ['label-1'],
+					priority: 2,
+					stateId: 'state-1',
+					parentId: 'parent-issue-1',
+				},
+			}).success,
+		).toBe(true);
+		expect(
+			schema.safeParse({ action: 'create_issue', input: { title: 'Missing team' } }).success,
+		).toBe(false);
+		expect(
+			schema.safeParse({
+				action: 'create_comment',
+				input: { issueId: 'issue-1', body: 'I can reproduce this.', parentCommentId: 'comment-1' },
+			}).success,
+		).toBe(true);
+		expect(
+			schema.safeParse({ action: 'create_comment', input: { issueId: 'issue-1' } }).success,
+		).toBe(false);
+		expect(tool.description).toContain('create_issue: input.teamId and input.title');
+		expect(tool.description).toContain('create_comment: input.issueId and input.body');
+	});
+
 	it('interactive action sends first, updates message context, then suspends', async () => {
 		const messageContextStore = mock<IntegrationMessageContextStore>();
 		const actionExecutor = mock<IntegrationActionExecutor>();
@@ -305,5 +470,68 @@ describe('integration tools', () => {
 				messageId: '123.456',
 			}),
 		});
+	});
+
+	it('action tool preserves the current subject when updating message context', async () => {
+		const messageContextStore = mock<IntegrationMessageContextStore>();
+		messageContextStore.getLatest.mockResolvedValue({
+			integrationConnectionId: 'slack:cred-a',
+			platform: 'slack',
+			target: { type: 'thread', threadId: 'slack:C123:123.456', channelId: 'slack:C123' },
+			messageId: '123.456',
+			subject: {
+				type: 'issue',
+				id: 'ENG-123',
+				title: 'Fix signup',
+			},
+			updatedAt: '2026-05-18T10:00:00.000Z',
+		});
+		const actionExecutor = mock<IntegrationActionExecutor>();
+		actionExecutor.execute.mockResolvedValue({
+			ok: true,
+			messageContext: {
+				integrationConnectionId: 'slack:cred-a',
+				platform: 'slack',
+				target: { type: 'dm', userId: 'slack:U123', threadId: 'slack:D123' },
+				messageId: '456.789',
+				updatedAt: '2026-05-18T10:01:00.000Z',
+			},
+		});
+
+		const tool = createIntegrationActionTool({
+			descriptor: getIntegrationToolConnectionDescriptors([slackA])[0],
+			messageContextStore,
+			actionExecutor,
+		}).build();
+
+		const result = await tool.handler!(
+			{ action: 'send_dm', input: { userId: 'slack:U123', message: { text: 'Hello' } } },
+			makeInterruptibleCtx(),
+		);
+
+		expect(messageContextStore.setLatest).toHaveBeenCalledWith(
+			'thread-1',
+			'resource-1',
+			expect.objectContaining({
+				target: { type: 'dm', userId: 'slack:U123', threadId: 'slack:D123' },
+				subject: {
+					type: 'issue',
+					id: 'ENG-123',
+					title: 'Fix signup',
+				},
+			}),
+		);
+		expect(result).toEqual(
+			expect.objectContaining({
+				ok: true,
+				messageContext: expect.objectContaining({
+					subject: {
+						type: 'issue',
+						id: 'ENG-123',
+						title: 'Fix signup',
+					},
+				}),
+			}),
+		);
 	});
 });

--- a/packages/cli/src/modules/agents/integrations/__tests__/linear-integration.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/linear-integration.test.ts
@@ -45,17 +45,30 @@ describe('LinearIntegration', () => {
 		webhookUrlFor: () => 'https://example.test/webhook',
 	});
 
-	it('builds the adapter with an apiKey from a linearApi credential', async () => {
-		await integration.createAdapter(ctx({ apiKey: 'lin_api_xyz', signingSecret: 'sec' }));
+	it('only advertises the Linear OAuth credential type to agents', () => {
+		expect(integration.credentialTypes).toEqual(['linearOAuth2Api']);
+	});
 
-		expect(createLinearAdapter).toHaveBeenCalledWith({
-			apiKey: 'lin_api_xyz',
-			webhookSecret: 'sec',
-			userName: 'AgentName',
-		});
-		expect(fetchSpy.mock.calls[0][1]).toMatchObject({
-			headers: { Authorization: 'lin_api_xyz' },
-		});
+	it('advertises Linear issue and user context queries', () => {
+		expect(integration.contextQueries).toEqual([
+			'get_current_message_context',
+			'get_current_subject',
+			'get_current_user',
+			'get_user',
+			'search_users',
+			'get_issue',
+			'search_issues',
+		]);
+	});
+
+	it('advertises Linear issue and comment actions', () => {
+		expect(integration.actions).toEqual(['respond', 'create_issue', 'create_comment']);
+	});
+
+	it('rejects Linear API token credentials', async () => {
+		await expect(
+			integration.createAdapter(ctx({ apiKey: 'lin_api_xyz', signingSecret: 'sec' })),
+		).rejects.toThrow(/OAuth access token/);
 	});
 
 	it('builds the adapter with an accessToken from a linearOAuth2Api credential', async () => {
@@ -76,26 +89,48 @@ describe('LinearIntegration', () => {
 		});
 	});
 
+	it('uses agent sessions mode for Linear app actor credentials', async () => {
+		await integration.createAdapter(
+			ctx({
+				actor: 'app',
+				oauthTokenData: { access_token: 'oauth_token' },
+				signingSecret: 'sec',
+			}),
+		);
+
+		expect(createLinearAdapter).toHaveBeenCalledWith({
+			accessToken: 'oauth_token',
+			webhookSecret: 'sec',
+			userName: 'AgentName',
+			mode: 'agent-sessions',
+		});
+	});
+
 	it('omits userName when the viewer lookup fails', async () => {
 		fetchSpy.mockResolvedValue({ ok: false } as Response);
 
-		await integration.createAdapter(ctx({ apiKey: 'lin_api_xyz', signingSecret: 'sec' }));
+		await integration.createAdapter(
+			ctx({
+				oauthTokenData: { access_token: 'oauth_token' },
+				signingSecret: 'sec',
+			}),
+		);
 
 		expect(createLinearAdapter).toHaveBeenCalledWith({
-			apiKey: 'lin_api_xyz',
+			accessToken: 'oauth_token',
 			webhookSecret: 'sec',
 		});
 	});
 
 	it('throws when the credential has no token', async () => {
 		await expect(integration.createAdapter(ctx({ signingSecret: 'sec' }))).rejects.toThrow(
-			/Could not extract an API token/,
+			/Could not extract an OAuth access token/,
 		);
 	});
 
 	it('throws when the credential has no signing secret', async () => {
-		await expect(integration.createAdapter(ctx({ apiKey: 'lin_api_xyz' }))).rejects.toThrow(
-			/missing a signing secret/,
-		);
+		await expect(
+			integration.createAdapter(ctx({ oauthTokenData: { access_token: 'oauth_token' } })),
+		).rejects.toThrow(/missing a signing secret/);
 	});
 });

--- a/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
@@ -1,6 +1,6 @@
 import type { AgentMessage, StreamChunk } from '@n8n/agents';
 import { Container } from '@n8n/di';
-import type { ActionEvent, Author, Chat, Message, Thread } from 'chat';
+import type { ActionEvent, Author, Chat, Message, MessageSubject, Thread } from 'chat';
 import type { Logger } from 'n8n-workflow';
 
 import type { AgentsService } from '../agents.service';
@@ -11,7 +11,11 @@ import { ChatIntegrationRegistry } from './agent-chat-integration';
 import { CallbackStore } from './callback-store';
 import type { ComponentMapper } from './component-mapper';
 import { IntegrationMessageContextService } from './integration-message-context.service';
-import { buildIntegrationConnectionId, type IntegrationMessageContext } from './integration-tools';
+import {
+	buildIntegrationConnectionId,
+	type IntegrationMessageContext,
+	type IntegrationMessageSubject,
+} from './integration-tools';
 import { type InternalThread, type TextEndFn, type TextYieldFn, toInternalThreadId } from './types';
 import type { AgentCredentialIntegrationConfig } from '@n8n/api-types';
 
@@ -41,6 +45,42 @@ function isIntegrationActionSuspendPayload(value: unknown): boolean {
 		'type' in value &&
 		value.type === 'integration_action'
 	);
+}
+
+function toIntegrationMessageSubject(
+	subject: MessageSubject | null | undefined,
+): IntegrationMessageSubject | undefined {
+	if (!subject || typeof subject.type !== 'string' || typeof subject.id !== 'string') {
+		return undefined;
+	}
+
+	const assignee = toIntegrationSubjectPerson(subject.assignee);
+	const author = toIntegrationSubjectPerson(subject.author);
+	const labels = subject.labels?.filter((label) => typeof label === 'string');
+
+	return {
+		type: subject.type,
+		id: subject.id,
+		...(typeof subject.title === 'string' ? { title: subject.title } : {}),
+		...(typeof subject.description === 'string' ? { description: subject.description } : {}),
+		...(typeof subject.url === 'string' ? { url: subject.url } : {}),
+		...(typeof subject.status === 'string' ? { status: subject.status } : {}),
+		...(labels && labels.length > 0 ? { labels } : {}),
+		...(assignee ? { assignee } : {}),
+		...(author ? { author } : {}),
+	};
+}
+
+function toIntegrationSubjectPerson(
+	person: MessageSubject['assignee'] | MessageSubject['author'],
+): IntegrationMessageSubject['assignee'] | undefined {
+	if (!person || typeof person.id !== 'string' || typeof person.name !== 'string') {
+		return undefined;
+	}
+	return {
+		id: person.id,
+		name: person.name,
+	};
 }
 
 /**
@@ -234,9 +274,11 @@ export class AgentChatBridge {
 		const platformThreadId = this.resolvePlatformThreadId(thread);
 		const threadId = this.toAgentThreadId(platformThreadId);
 		await this.startThinkingStatus(thread);
+		const subject = await this.resolveMessageSubject(message);
 		await this.updateLatestMessageContext(threadId.id, message.author.userId, thread, {
 			messageId: message.id,
 			interactingUserId: message.author.userId,
+			subject,
 		});
 		// threadId.id is agent-prefixed for observation storage; resourceId keeps
 		// the platform identity so episodic recall remains agent + resource scoped.
@@ -862,12 +904,18 @@ export class AgentChatBridge {
 		threadId: string,
 		resourceId: string,
 		thread: Thread<unknown, unknown>,
-		options: { messageId?: string; interactingUserId?: string } = {},
+		options: {
+			messageId?: string;
+			interactingUserId?: string;
+			subject?: IntegrationMessageSubject;
+		} = {},
 	): Promise<IntegrationMessageContext | undefined> {
 		if (!this.messageContextStore) return undefined;
 
+		const integrationConnectionId = buildIntegrationConnectionId(this.integration);
+		const previousContext = await this.getPreviousContext(threadId, integrationConnectionId);
 		const context: IntegrationMessageContext = {
-			integrationConnectionId: buildIntegrationConnectionId(this.integration),
+			integrationConnectionId,
 			platform: this.integration.type,
 			target: {
 				type: 'thread',
@@ -876,6 +924,8 @@ export class AgentChatBridge {
 			},
 			...(options.messageId ? { messageId: options.messageId } : {}),
 			...(options.interactingUserId ? { interactingUserId: options.interactingUserId } : {}),
+			...(options.subject ? { subject: options.subject } : {}),
+			...(!options.subject && previousContext?.subject ? { subject: previousContext.subject } : {}),
 			updatedAt: new Date().toISOString(),
 		};
 
@@ -888,6 +938,42 @@ export class AgentChatBridge {
 				threadId,
 				error: error instanceof Error ? error.message : String(error),
 			});
+			return undefined;
+		}
+	}
+
+	private async getPreviousContext(
+		threadId: string,
+		integrationConnectionId: string,
+	): Promise<IntegrationMessageContext | undefined> {
+		if (!this.messageContextStore) return undefined;
+		try {
+			const previousContext = await this.messageContextStore.getLatest(threadId);
+			if (previousContext?.integrationConnectionId !== integrationConnectionId) {
+				return undefined;
+			}
+			return previousContext;
+		} catch (error) {
+			this.logger.warn('[AgentChatBridge] Failed to read previous message context', {
+				agentId: this.agentId,
+				threadId,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return undefined;
+		}
+	}
+
+	private async resolveMessageSubject(
+		message: Message<unknown>,
+	): Promise<IntegrationMessageSubject | undefined> {
+		try {
+			return toIntegrationMessageSubject(await message.subject);
+		} catch (error) {
+			this.logger.debug(
+				`[AgentChatBridge] Failed to fetch message subject: ${
+					error instanceof Error ? error.message : String(error)
+				}`,
+			);
 			return undefined;
 		}
 	}

--- a/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-integration.ts
@@ -57,7 +57,10 @@ export abstract class AgentChatIntegration {
 	readonly supportedComponents?: string[];
 
 	/** Read-only context queries exposed through the generated integration context tool. */
-	readonly contextQueries: IntegrationContextQuery[] = ['get_current_message_context'];
+	readonly contextQueries: IntegrationContextQuery[] = [
+		'get_current_message_context',
+		'get_current_subject',
+	];
 
 	/** Side-effecting actions exposed through the generated integration action tool. */
 	readonly actions: IntegrationAction[] = ['respond'];

--- a/packages/cli/src/modules/agents/integrations/integration-action-executor.ts
+++ b/packages/cli/src/modules/agents/integrations/integration-action-executor.ts
@@ -10,8 +10,10 @@ import type {
 	IntegrationActionExecutor,
 	IntegrationActionResult,
 	IntegrationMessageContext,
+	IntegrationMessageSubject,
 	IntegrationToolConnectionDescriptor,
 } from './integration-tools';
+import { normalizeLinearComment, normalizeLinearIssue } from './integration-context-query-executor';
 
 const messageSchema = z.object({
 	text: z.string().optional(),
@@ -43,6 +45,24 @@ const addReactionInputSchema = z.object({
 	emoji: z.string().min(1),
 	threadId: z.string().min(1).optional(),
 	messageId: z.string().min(1).optional(),
+});
+
+const createIssueInputSchema = z.object({
+	teamId: z.string().min(1),
+	title: z.string().min(1),
+	description: z.string().min(1).optional(),
+	assigneeId: z.string().min(1).optional(),
+	projectId: z.string().min(1).optional(),
+	labelIds: z.array(z.string().min(1)).optional(),
+	priority: z.number().int().optional(),
+	stateId: z.string().min(1).optional(),
+	parentId: z.string().min(1).optional(),
+});
+
+const createCommentInputSchema = z.object({
+	issueId: z.string().min(1),
+	body: z.string().min(1),
+	parentCommentId: z.string().min(1).optional(),
 });
 
 const integrationActionResumeSchema = {
@@ -136,6 +156,16 @@ export class ChatIntegrationActionExecutor implements IntegrationActionExecutor 
 				if (result !== undefined) return result;
 			}
 
+			if (params.descriptor.integration.type === 'linear') {
+				const result = await executeLinearAction({
+					chat,
+					descriptor: params.descriptor,
+					action: params.action,
+					input: params.input,
+				});
+				if (result !== undefined) return result;
+			}
+
 			const input = sendChannelMessageInputSchema.parse(params.input);
 			const channelId = normalizePlatformId(params.descriptor.integration.type, input.channelId);
 			const channel = chat.channel(channelId);
@@ -225,10 +255,24 @@ async function subscribeSlackThread(
 	await thread.subscribe?.();
 }
 
+type CreateIssueInput = z.infer<typeof createIssueInputSchema>;
+type CreateCommentInput = z.infer<typeof createCommentInputSchema>;
 type AddReactionInput = z.infer<typeof addReactionInputSchema>;
 
 interface SlackAdapter {
 	addReaction(threadId: string, messageId: string, emoji: string): Promise<void>;
+}
+
+interface LinearAdapter {
+	client: Record<string, unknown>;
+}
+
+interface LinearClientWithCreateIssue {
+	createIssue(input: Record<string, unknown>): Promise<unknown>;
+}
+
+interface LinearClientWithCreateComment {
+	createComment(input: Record<string, unknown>): Promise<unknown>;
 }
 
 async function executeSlackAction(params: {
@@ -323,6 +367,212 @@ function parseSlackChannelId(threadId: string): string | undefined {
 	const [platform, channel] = threadId.split(':');
 	if (platform !== 'slack' || !channel) return undefined;
 	return `${platform}:${channel}`;
+}
+
+async function executeLinearAction(params: {
+	chat: { getAdapter(name: string): unknown };
+	descriptor: IntegrationToolConnectionDescriptor;
+	action: IntegrationAction;
+	input: Record<string, unknown>;
+}): Promise<IntegrationActionResult | undefined> {
+	if (params.action === 'create_issue') {
+		return await createLinearIssue(
+			params.chat,
+			params.descriptor,
+			createIssueInputSchema.parse(params.input),
+		);
+	}
+
+	if (params.action === 'create_comment') {
+		return await createLinearComment(
+			params.chat,
+			params.descriptor,
+			createCommentInputSchema.parse(params.input),
+		);
+	}
+
+	return undefined;
+}
+
+async function createLinearIssue(
+	chat: { getAdapter(name: string): unknown },
+	descriptor: IntegrationToolConnectionDescriptor,
+	input: CreateIssueInput,
+): Promise<IntegrationActionResult> {
+	const adapter = getLinearAdapter(chat);
+	if (!adapter || !hasLinearCreateIssueClient(adapter.client)) {
+		return unsupportedLinearAction('create_issue');
+	}
+
+	const payload = await adapter.client.createIssue(removeUndefinedValues({ ...input }));
+	const rawIssue = await awaitablePayloadProperty(payload, 'issue');
+	const normalizedIssue = await normalizeLinearIssue(rawIssue ?? payload);
+	const issueId =
+		stringRecordProperty(normalizedIssue, 'issueId') ??
+		stringPayloadProperty(payload, 'issueId') ??
+		stringRecordProperty(normalizedIssue, 'identifier');
+
+	if (!issueId) {
+		return {
+			ok: false,
+			error: {
+				code: 'ACTION_FAILED',
+				message: 'Linear did not return an issue ID for the created issue.',
+			},
+		};
+	}
+
+	return {
+		ok: true,
+		issue: normalizedIssue,
+		messageContext: {
+			integrationConnectionId: descriptor.integrationConnectionId,
+			platform: descriptor.integration.type,
+			target: { type: 'thread', threadId: `linear:${issueId}` },
+			subject: buildLinearIssueSubject(normalizedIssue, issueId),
+			updatedAt: new Date().toISOString(),
+		},
+	};
+}
+
+async function createLinearComment(
+	chat: { getAdapter(name: string): unknown },
+	descriptor: IntegrationToolConnectionDescriptor,
+	input: CreateCommentInput,
+): Promise<IntegrationActionResult> {
+	const adapter = getLinearAdapter(chat);
+	if (!adapter || !hasLinearCreateCommentClient(adapter.client)) {
+		return unsupportedLinearAction('create_comment');
+	}
+
+	const payload = await adapter.client.createComment(
+		removeUndefinedValues({
+			issueId: input.issueId,
+			body: input.body,
+			parentId: input.parentCommentId,
+		}),
+	);
+	const rawComment = await awaitablePayloadProperty(payload, 'comment');
+	const normalizedComment = await normalizeLinearComment(rawComment ?? payload);
+	const commentId =
+		stringRecordProperty(normalizedComment, 'commentId') ??
+		stringPayloadProperty(payload, 'commentId');
+
+	return {
+		ok: true,
+		comment: normalizedComment,
+		messageContext: {
+			integrationConnectionId: descriptor.integrationConnectionId,
+			platform: descriptor.integration.type,
+			target: {
+				type: 'thread',
+				threadId: input.parentCommentId
+					? `linear:${input.issueId}:c:${input.parentCommentId}`
+					: `linear:${input.issueId}`,
+			},
+			...(commentId ? { messageId: commentId } : {}),
+			subject: { type: 'issue', id: input.issueId },
+			updatedAt: new Date().toISOString(),
+		},
+	};
+}
+
+function getLinearAdapter(chat: { getAdapter(name: string): unknown }): LinearAdapter | undefined {
+	const adapter = chat.getAdapter('linear');
+	if (!isRecord(adapter) || !isRecord(adapter.client)) return undefined;
+	return { client: adapter.client };
+}
+
+function hasLinearCreateIssueClient(
+	client: Record<string, unknown>,
+): client is Record<string, unknown> & LinearClientWithCreateIssue {
+	return typeof client.createIssue === 'function';
+}
+
+function hasLinearCreateCommentClient(
+	client: Record<string, unknown>,
+): client is Record<string, unknown> & LinearClientWithCreateComment {
+	return typeof client.createComment === 'function';
+}
+
+function unsupportedLinearAction(
+	action: 'create_issue' | 'create_comment',
+): IntegrationActionResult {
+	return {
+		ok: false,
+		error: {
+			code: 'UNSUPPORTED_ACTION',
+			message: `The active Linear connection does not support ${action}.`,
+		},
+	};
+}
+
+function buildLinearIssueSubject(
+	issue: Record<string, unknown>,
+	fallbackIssueId: string,
+): IntegrationMessageSubject {
+	const identifier = stringRecordProperty(issue, 'identifier');
+	const title = stringRecordProperty(issue, 'title');
+	const description = stringRecordProperty(issue, 'description');
+	const url = stringRecordProperty(issue, 'url');
+	const status = stringRecordProperty(recordProperty(issue, 'state'), 'name');
+	const labels = linearLabelNames(issue);
+	const assignee = linearSubjectPerson(recordProperty(issue, 'assignee'));
+
+	return {
+		type: 'issue',
+		id: identifier ?? fallbackIssueId,
+		...(title ? { title } : {}),
+		...(description ? { description } : {}),
+		...(url ? { url } : {}),
+		...(status ? { status } : {}),
+		...(labels.length > 0 ? { labels } : {}),
+		...(assignee ? { assignee } : {}),
+	};
+}
+
+function linearLabelNames(issue: Record<string, unknown>): string[] {
+	const labels = issue.labels;
+	if (!Array.isArray(labels)) return [];
+	return labels
+		.map((label) => stringRecordProperty(label, 'name'))
+		.filter((label): label is string => label !== undefined);
+}
+
+function linearSubjectPerson(value: unknown): IntegrationMessageSubject['assignee'] {
+	if (!isRecord(value)) return undefined;
+	const id = stringRecordProperty(value, 'userId') ?? stringRecordProperty(value, 'id');
+	const name = stringRecordProperty(value, 'name') ?? stringRecordProperty(value, 'displayName');
+	if (!id || !name) return undefined;
+	return { id, name };
+}
+
+async function awaitablePayloadProperty(
+	payload: unknown,
+	key: string,
+): Promise<unknown | undefined> {
+	if (!isRecord(payload)) return undefined;
+	return await Promise.resolve(payload[key]);
+}
+
+function stringPayloadProperty(payload: unknown, key: string): string | undefined {
+	return stringRecordProperty(payload, key);
+}
+
+function recordProperty(record: Record<string, unknown>, key: string): unknown {
+	return record[key];
+}
+
+function stringRecordProperty(value: unknown, key: string): string | undefined {
+	if (!isRecord(value)) return undefined;
+	const property = value[key];
+	return typeof property === 'string' && property.length > 0 ? property : undefined;
+}
+
+function removeUndefinedValues<T extends Record<string, unknown>>(
+	value: T,
+): Record<string, unknown> {
+	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/cli/src/modules/agents/integrations/integration-context-query-executor.ts
+++ b/packages/cli/src/modules/agents/integrations/integration-context-query-executor.ts
@@ -35,6 +35,19 @@ const searchChannelsInputSchema = z.object({
 	includeArchived: z.boolean().default(false),
 });
 
+const getIssueInputSchema = z.object({
+	issueId: z.string().min(1),
+	includeComments: z.boolean().default(false),
+	commentsLimit: z.number().int().min(1).max(20).default(10),
+});
+
+const searchIssuesInputSchema = z.object({
+	query: z.string().min(1),
+	limit: z.number().int().min(1).max(50).default(10),
+	teamId: z.string().min(1).optional(),
+	includeArchived: z.boolean().default(false),
+});
+
 @Service()
 export class ChatIntegrationContextQueryExecutor implements IntegrationContextQueryExecutor {
 	constructor(private readonly chatIntegrationService: ChatIntegrationService) {}
@@ -57,6 +70,11 @@ export class ChatIntegrationContextQueryExecutor implements IntegrationContextQu
 		}
 
 		try {
+			if (params.descriptor.integration.type === 'linear') {
+				const result = await executeLinearQuery(chat, params.query, params.input);
+				if (result !== undefined) return result;
+			}
+
 			if (params.query === 'get_user') {
 				const input = getUserInputSchema.parse(params.input);
 				const user = await chat.getUser(input.userId);
@@ -113,6 +131,28 @@ function connectionUnavailable() {
 
 type SearchUsersInput = z.infer<typeof searchUsersInputSchema>;
 type SearchChannelsInput = z.infer<typeof searchChannelsInputSchema>;
+type GetIssueInput = z.infer<typeof getIssueInputSchema>;
+type SearchIssuesInput = z.infer<typeof searchIssuesInputSchema>;
+
+interface LinearAdapter {
+	client: Record<string, unknown>;
+}
+
+interface LinearClientWithUser {
+	user(userId: string): Promise<unknown>;
+}
+
+interface LinearClientWithUsers {
+	users(options: Record<string, unknown>): Promise<unknown>;
+}
+
+interface LinearClientWithIssue {
+	issue(issueId: string): Promise<unknown>;
+}
+
+interface LinearClientWithIssueSearch {
+	searchIssues(query: string, options: Record<string, unknown>): Promise<unknown>;
+}
 
 interface SlackUserSearchResult {
 	userId: string;
@@ -188,6 +228,377 @@ interface SlackWebClient {
 interface SlackAdapter {
 	client: SlackWebClient;
 	withToken?: (options: Record<string, unknown>) => Promise<Record<string, unknown>>;
+}
+
+async function executeLinearQuery(
+	chat: {
+		getAdapter(name: string): unknown;
+	},
+	query: IntegrationContextQuery,
+	input: Record<string, unknown>,
+): Promise<unknown | undefined> {
+	if (query === 'get_user') {
+		return await getLinearUser(chat, getUserInputSchema.parse(input));
+	}
+	if (query === 'search_users') {
+		return await searchLinearUsers(chat, searchUsersInputSchema.parse(input));
+	}
+	if (query === 'get_issue') {
+		return await getLinearIssue(chat, getIssueInputSchema.parse(input));
+	}
+	if (query === 'search_issues') {
+		return await searchLinearIssues(chat, searchIssuesInputSchema.parse(input));
+	}
+	return undefined;
+}
+
+async function getLinearUser(
+	chat: {
+		getAdapter(name: string): unknown;
+	},
+	input: { userId: string },
+): Promise<unknown> {
+	const adapter = getLinearAdapter(chat);
+	if (!adapter || !hasLinearUserClient(adapter.client)) {
+		return unsupportedLinearQuery('get_user');
+	}
+
+	const user = await adapter.client.user(input.userId);
+	return { ok: true, user: normalizeLinearUser(user) ?? null };
+}
+
+async function searchLinearUsers(
+	chat: {
+		getAdapter(name: string): unknown;
+	},
+	input: SearchUsersInput,
+): Promise<unknown> {
+	const adapter = getLinearAdapter(chat);
+	if (!adapter || !hasLinearUsersClient(adapter.client)) {
+		return unsupportedLinearQuery('search_users');
+	}
+
+	const response = await adapter.client.users({
+		filter: buildLinearUserSearchFilter(input),
+		first: input.limit,
+		includeArchived: input.includeDeleted,
+		includeDisabled: input.includeDeleted,
+	});
+
+	const users = linearNodes(response).map(normalizeLinearUser).filter(isDefined);
+	return { ok: true, users, resultCount: users.length };
+}
+
+async function getLinearIssue(
+	chat: {
+		getAdapter(name: string): unknown;
+	},
+	input: GetIssueInput,
+): Promise<unknown> {
+	const adapter = getLinearAdapter(chat);
+	if (!adapter || !hasLinearIssueClient(adapter.client)) {
+		return unsupportedLinearQuery('get_issue');
+	}
+
+	const issue = await adapter.client.issue(input.issueId);
+	if (!issue) return { ok: true, issue: null };
+
+	return {
+		ok: true,
+		issue: await normalizeLinearIssue(issue, {
+			includeComments: input.includeComments,
+			commentsLimit: input.commentsLimit,
+		}),
+	};
+}
+
+async function searchLinearIssues(
+	chat: {
+		getAdapter(name: string): unknown;
+	},
+	input: SearchIssuesInput,
+): Promise<unknown> {
+	const adapter = getLinearAdapter(chat);
+	if (!adapter || !hasLinearIssueSearchClient(adapter.client)) {
+		return unsupportedLinearQuery('search_issues');
+	}
+
+	const response = await adapter.client.searchIssues(input.query, {
+		first: input.limit,
+		...(input.teamId ? { teamId: input.teamId } : {}),
+		includeArchived: input.includeArchived,
+	});
+
+	const issues = await Promise.all(
+		linearNodes(response).map(async (issue) => await normalizeLinearIssue(issue)),
+	);
+
+	return {
+		ok: true,
+		issues,
+		resultCount: issues.length,
+		...(numberValue(response, 'totalCount') !== undefined
+			? { totalCount: numberValue(response, 'totalCount') }
+			: {}),
+	};
+}
+
+function getLinearAdapter(chat: { getAdapter(name: string): unknown }): LinearAdapter | undefined {
+	const adapter = chat.getAdapter('linear');
+	if (!isRecord(adapter) || !isRecord(adapter.client)) return undefined;
+	return { client: adapter.client };
+}
+
+function hasLinearUserClient(
+	client: Record<string, unknown>,
+): client is Record<string, unknown> & LinearClientWithUser {
+	return typeof client.user === 'function';
+}
+
+function hasLinearUsersClient(
+	client: Record<string, unknown>,
+): client is Record<string, unknown> & LinearClientWithUsers {
+	return typeof client.users === 'function';
+}
+
+function hasLinearIssueClient(
+	client: Record<string, unknown>,
+): client is Record<string, unknown> & LinearClientWithIssue {
+	return typeof client.issue === 'function';
+}
+
+function hasLinearIssueSearchClient(
+	client: Record<string, unknown>,
+): client is Record<string, unknown> & LinearClientWithIssueSearch {
+	return typeof client.searchIssues === 'function';
+}
+
+function unsupportedLinearQuery(
+	query: 'get_user' | 'search_users' | 'get_issue' | 'search_issues',
+) {
+	return {
+		ok: false,
+		error: {
+			code: 'UNSUPPORTED_QUERY',
+			message: `The active Linear connection does not support ${query}.`,
+		},
+	};
+}
+
+function buildLinearUserSearchFilter(input: SearchUsersInput): Record<string, unknown> {
+	const userSearchFilter = buildLinearUserSearchTermFilter(input);
+	if (input.includeBots) return userSearchFilter;
+
+	return {
+		and: [userSearchFilter, { app: { eq: false } }],
+	};
+}
+
+function buildLinearUserSearchTermFilter(input: SearchUsersInput): Record<string, unknown> {
+	if (input.email) {
+		return { email: { eqIgnoreCase: input.email.trim() } };
+	}
+
+	const query = input.query?.trim() ?? '';
+	return {
+		or: [
+			{ name: { containsIgnoreCase: query } },
+			{ displayName: { containsIgnoreCase: query } },
+			{ email: { containsIgnoreCase: query } },
+		],
+	};
+}
+
+export async function normalizeLinearIssue(
+	value: unknown,
+	options: { includeComments?: boolean; commentsLimit?: number } = {},
+): Promise<Record<string, unknown>> {
+	const issue = isRecord(value) ? value : {};
+	const [state, assignee, creator, team, project, labelsConnection] = await Promise.all([
+		awaitableProperty(issue, 'state'),
+		awaitableProperty(issue, 'assignee'),
+		awaitableProperty(issue, 'creator'),
+		awaitableProperty(issue, 'team'),
+		awaitableProperty(issue, 'project'),
+		callLinearConnection(issue, 'labels', { first: 50 }),
+	]);
+
+	const priority = normalizeLinearPriority(issue);
+	const comments = options.includeComments
+		? await normalizeLinearComments(issue, options.commentsLimit ?? 10)
+		: undefined;
+
+	return removeUndefinedValues({
+		issueId: stringProperty(issue, 'id'),
+		identifier: stringProperty(issue, 'identifier'),
+		title: stringProperty(issue, 'title'),
+		description: stringProperty(issue, 'description'),
+		url: stringProperty(issue, 'url'),
+		priority,
+		state: normalizeLinearState(state),
+		assignee: normalizeLinearUser(assignee),
+		creator: normalizeLinearUser(creator),
+		team: normalizeLinearTeam(team),
+		project: normalizeLinearProject(project),
+		labels: linearNodes(labelsConnection).map(normalizeLinearLabel).filter(isDefined),
+		createdAt: isoDateProperty(issue, 'createdAt'),
+		updatedAt: isoDateProperty(issue, 'updatedAt'),
+		...(comments ? { comments } : {}),
+	});
+}
+
+async function normalizeLinearComments(
+	issue: Record<string, unknown>,
+	commentsLimit: number,
+): Promise<Array<Record<string, unknown>> | undefined> {
+	const commentsConnection = await callLinearConnection(issue, 'comments', {
+		first: commentsLimit,
+	});
+	if (!commentsConnection) return undefined;
+	return await Promise.all(
+		linearNodes(commentsConnection).map(async (comment) => await normalizeLinearComment(comment)),
+	);
+}
+
+export async function normalizeLinearComment(value: unknown): Promise<Record<string, unknown>> {
+	const comment = isRecord(value) ? value : {};
+	const author = await awaitableProperty(comment, 'user');
+	return removeUndefinedValues({
+		commentId: stringProperty(comment, 'id'),
+		body: stringProperty(comment, 'body'),
+		url: stringProperty(comment, 'url'),
+		createdAt: isoDateProperty(comment, 'createdAt'),
+		updatedAt: isoDateProperty(comment, 'updatedAt'),
+		author: normalizeLinearUser(author),
+	});
+}
+
+function normalizeLinearUser(value: unknown): Record<string, unknown> | undefined {
+	if (!isRecord(value)) return undefined;
+	const userId = stringProperty(value, 'id');
+	if (!userId) return undefined;
+
+	return removeUndefinedValues({
+		userId,
+		name: stringProperty(value, 'name') ?? userId,
+		displayName: stringProperty(value, 'displayName'),
+		email: stringProperty(value, 'email'),
+		avatarUrl: stringProperty(value, 'avatarUrl'),
+		active: booleanProperty(value, 'active'),
+		isBot: booleanProperty(value, 'app') ?? false,
+		isAssignable: booleanProperty(value, 'isAssignable'),
+		isMentionable: booleanProperty(value, 'isMentionable'),
+		url: stringProperty(value, 'url'),
+	});
+}
+
+function normalizeLinearState(value: unknown): Record<string, unknown> | undefined {
+	if (!isRecord(value)) return undefined;
+	return removeUndefinedValues({
+		id: stringProperty(value, 'id'),
+		name: stringProperty(value, 'name'),
+		type: stringProperty(value, 'type'),
+	});
+}
+
+function normalizeLinearTeam(value: unknown): Record<string, unknown> | undefined {
+	if (!isRecord(value)) return undefined;
+	return removeUndefinedValues({
+		teamId: stringProperty(value, 'id'),
+		key: stringProperty(value, 'key'),
+		name: stringProperty(value, 'name'),
+	});
+}
+
+function normalizeLinearProject(value: unknown): Record<string, unknown> | undefined {
+	if (!isRecord(value)) return undefined;
+	return removeUndefinedValues({
+		projectId: stringProperty(value, 'id'),
+		name: stringProperty(value, 'name'),
+		url: stringProperty(value, 'url'),
+	});
+}
+
+function normalizeLinearLabel(value: unknown): Record<string, unknown> | undefined {
+	if (!isRecord(value)) return undefined;
+	const labelId = stringProperty(value, 'id');
+	const name = stringProperty(value, 'name');
+	if (!labelId || !name) return undefined;
+	return { labelId, name };
+}
+
+function normalizeLinearPriority(
+	issue: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+	const value = numberProperty(issue, 'priority');
+	const label = stringProperty(issue, 'priorityLabel');
+	if (value === undefined && !label) return undefined;
+	return removeUndefinedValues({ value, label });
+}
+
+async function awaitableProperty(
+	record: Record<string, unknown>,
+	key: string,
+): Promise<unknown | undefined> {
+	return await Promise.resolve(record[key]);
+}
+
+async function callLinearConnection(
+	record: Record<string, unknown>,
+	key: string,
+	options: Record<string, unknown>,
+): Promise<unknown | undefined> {
+	const fn = record[key];
+	if (!isLinearConnectionFunction(fn)) return undefined;
+	return await fn.call(record, options);
+}
+
+function linearNodes(value: unknown): unknown[] {
+	if (!isRecord(value) || !Array.isArray(value.nodes)) return [];
+	return value.nodes;
+}
+
+function removeUndefinedValues(value: Record<string, unknown>): Record<string, unknown> {
+	return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined));
+}
+
+function isDefined<T>(value: T | undefined): value is T {
+	return value !== undefined;
+}
+
+function stringProperty(record: Record<string, unknown>, key: string): string | undefined {
+	return stringValue(record[key]);
+}
+
+function numberProperty(record: Record<string, unknown>, key: string): number | undefined {
+	const value = record[key];
+	return typeof value === 'number' ? value : undefined;
+}
+
+function numberValue(value: unknown, key: string): number | undefined {
+	return isRecord(value) ? numberProperty(value, key) : undefined;
+}
+
+function booleanProperty(record: Record<string, unknown>, key: string): boolean | undefined {
+	const value = record[key];
+	return typeof value === 'boolean' ? value : undefined;
+}
+
+function isoDateProperty(record: Record<string, unknown>, key: string): string | undefined {
+	const value = record[key];
+	if (value instanceof Date) return value.toISOString();
+	if (typeof value !== 'string' || value.length === 0) return undefined;
+	const date = new Date(value);
+	return Number.isNaN(date.getTime()) ? value : date.toISOString();
+}
+
+type LinearConnectionFunction = (
+	this: Record<string, unknown>,
+	options: Record<string, unknown>,
+) => unknown | PromiseLike<unknown>;
+
+function isLinearConnectionFunction(value: unknown): value is LinearConnectionFunction {
+	return typeof value === 'function';
 }
 
 async function searchSlackUsers(

--- a/packages/cli/src/modules/agents/integrations/integration-message-context.service.ts
+++ b/packages/cli/src/modules/agents/integrations/integration-message-context.service.ts
@@ -4,6 +4,8 @@ import { AgentResourceRepository } from '../repositories/agent-resource.reposito
 import { AgentThreadRepository } from '../repositories/agent-thread.repository';
 import type {
 	IntegrationMessageContext,
+	IntegrationMessageSubject,
+	IntegrationSubjectPerson,
 	IntegrationMessageContextStore,
 	IntegrationMessageTarget,
 } from './integration-tools';
@@ -79,8 +81,33 @@ export function isIntegrationMessageContext(value: unknown): value is Integratio
 		isIntegrationMessageTarget(context.target) &&
 		(context.messageId === undefined || typeof context.messageId === 'string') &&
 		(context.interactingUserId === undefined || typeof context.interactingUserId === 'string') &&
+		(context.subject === undefined || isIntegrationMessageSubject(context.subject)) &&
 		typeof context.updatedAt === 'string'
 	);
+}
+
+function isIntegrationMessageSubject(value: unknown): value is IntegrationMessageSubject {
+	if (!value || typeof value !== 'object') return false;
+	const subject = value as Record<string, unknown>;
+	return (
+		typeof subject.type === 'string' &&
+		typeof subject.id === 'string' &&
+		(subject.title === undefined || typeof subject.title === 'string') &&
+		(subject.description === undefined || typeof subject.description === 'string') &&
+		(subject.url === undefined || typeof subject.url === 'string') &&
+		(subject.status === undefined || typeof subject.status === 'string') &&
+		(subject.labels === undefined ||
+			(Array.isArray(subject.labels) &&
+				subject.labels.every((label) => typeof label === 'string'))) &&
+		(subject.assignee === undefined || isIntegrationSubjectPerson(subject.assignee)) &&
+		(subject.author === undefined || isIntegrationSubjectPerson(subject.author))
+	);
+}
+
+function isIntegrationSubjectPerson(value: unknown): value is IntegrationSubjectPerson {
+	if (!value || typeof value !== 'object') return false;
+	const person = value as Record<string, unknown>;
+	return typeof person.id === 'string' && typeof person.name === 'string';
 }
 
 function isIntegrationMessageTarget(value: unknown): value is IntegrationMessageTarget {

--- a/packages/cli/src/modules/agents/integrations/integration-tools.ts
+++ b/packages/cli/src/modules/agents/integrations/integration-tools.ts
@@ -27,7 +27,25 @@ export interface IntegrationMessageContext {
 	target: IntegrationMessageTarget;
 	messageId?: string;
 	interactingUserId?: string;
+	subject?: IntegrationMessageSubject;
 	updatedAt: string;
+}
+
+export interface IntegrationMessageSubject {
+	type: string;
+	id: string;
+	title?: string;
+	description?: string;
+	url?: string;
+	status?: string;
+	labels?: string[];
+	assignee?: IntegrationSubjectPerson;
+	author?: IntegrationSubjectPerson;
+}
+
+export interface IntegrationSubjectPerson {
+	id: string;
+	name: string;
 }
 
 export interface IntegrationToolConnectionDescriptor {
@@ -72,14 +90,23 @@ export interface IntegrationActionExecutor {
 
 export type IntegrationContextQuery =
 	| 'get_current_message_context'
+	| 'get_current_subject'
 	| 'get_current_user'
 	| 'get_current_channel_info'
 	| 'get_user'
 	| 'get_channel_info'
 	| 'search_users'
-	| 'search_channels';
+	| 'search_channels'
+	| 'get_issue'
+	| 'search_issues';
 
-export type IntegrationAction = 'respond' | 'send_dm' | 'send_channel_message' | 'add_reaction';
+export type IntegrationAction =
+	| 'respond'
+	| 'send_dm'
+	| 'send_channel_message'
+	| 'add_reaction'
+	| 'create_issue'
+	| 'create_comment';
 
 export type IntegrationActionResult =
 	| {
@@ -97,6 +124,7 @@ export type IntegrationActionResult =
 
 export const DEFAULT_INTEGRATION_CONTEXT_QUERIES: IntegrationContextQuery[] = [
 	'get_current_message_context',
+	'get_current_subject',
 	'get_current_user',
 	'get_current_channel_info',
 	'get_user',
@@ -154,7 +182,9 @@ const noInputSchema = z.object({}).strict();
 const platformUserIdSchema = z
 	.string()
 	.min(1)
-	.describe('Platform user ID, for example a Slack U... user ID. Do not pass a name.');
+	.describe(
+		'Platform user ID, for example a Slack U... ID or Linear user UUID. Do not pass a name.',
+	);
 
 const platformChannelIdSchema = z
 	.string()
@@ -171,6 +201,11 @@ const searchLimitSchema = z
 
 const getCurrentMessageContextInputSchema = z.object({
 	query: z.literal('get_current_message_context'),
+	input: noInputSchema,
+});
+
+const getCurrentSubjectInputSchema = z.object({
+	query: z.literal('get_current_subject'),
 	input: noInputSchema,
 });
 
@@ -242,26 +277,67 @@ const searchChannelsInputSchema = z.object({
 		.strict(),
 });
 
+const getIssueInputSchema = z.object({
+	query: z.literal('get_issue'),
+	input: z
+		.object({
+			issueId: z.string().min(1).describe('Linear issue UUID or identifier such as ENG-123.'),
+			includeComments: z
+				.boolean()
+				.optional()
+				.describe('Whether to include recent comments. Defaults to false.'),
+			commentsLimit: z
+				.number()
+				.int()
+				.min(1)
+				.max(20)
+				.optional()
+				.describe('Maximum number of recent comments to return. Defaults to 10.'),
+		})
+		.strict(),
+});
+
+const searchIssuesInputSchema = z.object({
+	query: z.literal('search_issues'),
+	input: z
+		.object({
+			query: z.string().min(1).describe('Search term for Linear issue title/content.'),
+			limit: searchLimitSchema,
+			teamId: z.string().min(1).optional().describe('Optional Linear team ID to scope search.'),
+			includeArchived: z
+				.boolean()
+				.optional()
+				.describe('Whether to include archived issues. Defaults to false.'),
+		})
+		.strict(),
+});
+
 type IntegrationContextToolInput =
 	| z.infer<typeof getCurrentMessageContextInputSchema>
+	| z.infer<typeof getCurrentSubjectInputSchema>
 	| z.infer<typeof getCurrentUserInputSchema>
 	| z.infer<typeof getCurrentChannelInfoInputSchema>
 	| z.infer<typeof getUserInputSchema>
 	| z.infer<typeof getChannelInfoInputSchema>
 	| z.infer<typeof searchUsersInputSchema>
-	| z.infer<typeof searchChannelsInputSchema>;
+	| z.infer<typeof searchChannelsInputSchema>
+	| z.infer<typeof getIssueInputSchema>
+	| z.infer<typeof searchIssuesInputSchema>;
 
 const CONTEXT_QUERY_INPUT_SCHEMAS: Record<
 	IntegrationContextQuery,
 	z.ZodType<IntegrationContextToolInput>
 > = {
 	get_current_message_context: getCurrentMessageContextInputSchema,
+	get_current_subject: getCurrentSubjectInputSchema,
 	get_current_user: getCurrentUserInputSchema,
 	get_current_channel_info: getCurrentChannelInfoInputSchema,
 	get_user: getUserInputSchema,
 	get_channel_info: getChannelInfoInputSchema,
 	search_users: searchUsersInputSchema,
 	search_channels: searchChannelsInputSchema,
+	get_issue: getIssueInputSchema,
+	search_issues: searchIssuesInputSchema,
 } satisfies Record<IntegrationContextQuery, z.ZodType<IntegrationContextToolInput>>;
 
 function buildContextInputSchema(queries: IntegrationContextQuery[]) {
@@ -329,17 +405,53 @@ const addReactionActionInputSchema = z.object({
 		.strict(),
 });
 
+const createIssueActionInputSchema = z.object({
+	action: z.literal('create_issue'),
+	input: z
+		.object({
+			teamId: z.string().min(1).describe('Linear team ID where the issue should be created.'),
+			title: z.string().min(1).describe('Linear issue title.'),
+			description: z.string().min(1).optional().describe('Optional Linear issue description.'),
+			assigneeId: z.string().min(1).optional().describe('Optional Linear assignee user ID.'),
+			projectId: z.string().min(1).optional().describe('Optional Linear project ID.'),
+			labelIds: z.array(z.string().min(1)).optional().describe('Optional Linear label IDs.'),
+			priority: z.number().int().optional().describe('Optional Linear priority value.'),
+			stateId: z.string().min(1).optional().describe('Optional Linear workflow state ID.'),
+			parentId: z.string().min(1).optional().describe('Optional parent Linear issue ID.'),
+		})
+		.strict(),
+});
+
+const createCommentActionInputSchema = z.object({
+	action: z.literal('create_comment'),
+	input: z
+		.object({
+			issueId: z.string().min(1).describe('Linear issue UUID where the comment should be added.'),
+			body: z.string().min(1).describe('Linear comment body.'),
+			parentCommentId: z
+				.string()
+				.min(1)
+				.optional()
+				.describe('Optional parent Linear comment ID for threaded replies.'),
+		})
+		.strict(),
+});
+
 type IntegrationActionToolInput =
 	| z.infer<typeof respondActionInputSchema>
 	| z.infer<typeof sendDmActionInputSchema>
 	| z.infer<typeof sendChannelMessageActionInputSchema>
-	| z.infer<typeof addReactionActionInputSchema>;
+	| z.infer<typeof addReactionActionInputSchema>
+	| z.infer<typeof createIssueActionInputSchema>
+	| z.infer<typeof createCommentActionInputSchema>;
 
 const ACTION_INPUT_SCHEMAS: Record<IntegrationAction, z.ZodType<IntegrationActionToolInput>> = {
 	respond: respondActionInputSchema,
 	send_dm: sendDmActionInputSchema,
 	send_channel_message: sendChannelMessageActionInputSchema,
 	add_reaction: addReactionActionInputSchema,
+	create_issue: createIssueActionInputSchema,
+	create_comment: createCommentActionInputSchema,
 };
 
 function buildActionInputSchema(actions: IntegrationAction[]) {
@@ -359,18 +471,24 @@ function buildActionInputSchema(actions: IntegrationAction[]) {
 const CONTEXT_QUERY_DESCRIPTIONS = {
 	get_current_message_context:
 		'get_current_message_context: no input. Returns the latest place this agent communicated in this thread.',
+	get_current_subject:
+		'get_current_subject: no input. Returns the subject of the latest message context, such as a Linear issue, when available.',
 	get_current_user:
 		'get_current_user: no input. Returns the latest user who interacted in the current message context.',
 	get_current_channel_info:
 		'get_current_channel_info: no input. Returns metadata for the latest channel in the current message context.',
 	get_user:
-		'get_user: input.userId is required. Use a platform user ID such as a Slack U... ID, not a name, handle, or email.',
+		'get_user: input.userId is required. Use a platform user ID such as a Slack U... ID or Linear user UUID, not a name, handle, or email.',
 	get_channel_info:
 		'get_channel_info: input.channelId is required. Use a platform channel ID such as a Slack C... ID, not a channel name.',
 	search_users:
 		'search_users: input.query or input.email is required. Returns matching platform user IDs for names, handles, or emails.',
 	search_channels:
 		'search_channels: input.query is required. Returns matching platform channel IDs for channel names or IDs.',
+	get_issue:
+		'get_issue: input.issueId is required. For Linear, use an issue UUID or identifier such as ENG-123. Optional input.includeComments and input.commentsLimit add recent comments.',
+	search_issues:
+		'search_issues: input.query is required. For Linear, returns matching issue IDs/identifiers; optional input.teamId, input.limit, and input.includeArchived narrow results.',
 } satisfies Record<IntegrationContextQuery, string>;
 
 const ACTION_DESCRIPTIONS = {
@@ -382,11 +500,22 @@ const ACTION_DESCRIPTIONS = {
 		'send_channel_message: input.channelId and input.message are required. channelId must be a platform channel ID, not a channel name.',
 	add_reaction:
 		'add_reaction: input.emoji is required. For Slack, optional input.threadId and input.messageId target a specific message; otherwise the latest message context is used.',
+	create_issue:
+		'create_issue: input.teamId and input.title are required. For Linear, optional input.description, input.assigneeId, input.projectId, input.labelIds, input.priority, input.stateId, and input.parentId configure the issue.',
+	create_comment:
+		'create_comment: input.issueId and input.body are required. For Linear, optional input.parentCommentId creates a threaded reply.',
 } satisfies Record<IntegrationAction, string>;
 
 const actionSuspendSchema = z.object({
 	type: z.literal('integration_action'),
-	action: z.enum(['respond', 'send_dm', 'send_channel_message', 'add_reaction']),
+	action: z.enum([
+		'respond',
+		'send_dm',
+		'send_channel_message',
+		'add_reaction',
+		'create_issue',
+		'create_comment',
+	]),
 	integrationConnectionId: z.string(),
 	messageContext: z.unknown(),
 });
@@ -449,6 +578,7 @@ export function createIntegrationContextTool(params: {
 			const persistence = ctx.persistence;
 			if (
 				input.query === 'get_current_message_context' ||
+				input.query === 'get_current_subject' ||
 				input.query === 'get_current_user' ||
 				input.query === 'get_current_channel_info'
 			) {
@@ -466,6 +596,9 @@ export function createIntegrationContextTool(params: {
 					if (input.query === 'get_current_message_context') {
 						return { ok: true, context: null };
 					}
+					if (input.query === 'get_current_subject') {
+						return { ok: true, subject: null };
+					}
 					return {
 						ok: false,
 						error: {
@@ -476,6 +609,9 @@ export function createIntegrationContextTool(params: {
 				}
 				if (input.query === 'get_current_message_context') {
 					return { ok: true, context };
+				}
+				if (input.query === 'get_current_subject') {
+					return { ok: true, subject: context.subject ?? null };
 				}
 				if (input.query === 'get_current_user') {
 					if (!context.interactingUserId) {
@@ -556,6 +692,12 @@ export function createIntegrationActionTool(params: {
 					return contextResult;
 				}
 				currentMessageContext = contextResult.context;
+			} else if (persistence) {
+				currentMessageContext = await getOptionalCurrentContext({
+					descriptor,
+					messageContextStore,
+					threadId: persistence.threadId,
+				});
 			}
 
 			const result = await actionExecutor.execute({
@@ -570,21 +712,24 @@ export function createIntegrationActionTool(params: {
 
 			if (!result.ok) return result;
 
+			let actionResult = result;
 			if (result.messageContext && persistence) {
+				const messageContext = withPreviousSubject(result.messageContext, currentMessageContext);
 				await messageContextStore.setLatest(
 					persistence.threadId,
 					persistence.resourceId,
-					result.messageContext,
+					messageContext,
 				);
+				actionResult = { ...result, messageContext };
 			}
 
-			if (!awaitsResponse) return result;
+			if (!awaitsResponse) return actionResult;
 
 			return await interruptCtx.suspend({
 				type: 'integration_action',
 				action: input.action,
 				integrationConnectionId: descriptor.integrationConnectionId,
-				messageContext: result.messageContext,
+				messageContext: actionResult.messageContext,
 			});
 		});
 }
@@ -639,6 +784,31 @@ function shouldAwaitResponse(message: z.infer<typeof messageSchema> | undefined)
 	return richInteraction.components.some((component) =>
 		['button', 'select', 'radio_select'].includes(component.type),
 	);
+}
+
+function withPreviousSubject(
+	context: IntegrationMessageContext,
+	previousContext: IntegrationMessageContext | undefined,
+): IntegrationMessageContext {
+	if (context.subject || !previousContext?.subject) return context;
+	if (context.integrationConnectionId !== previousContext.integrationConnectionId) return context;
+	return { ...context, subject: previousContext.subject };
+}
+
+async function getOptionalCurrentContext(params: {
+	descriptor: IntegrationToolConnectionDescriptor;
+	messageContextStore: IntegrationMessageContextStore;
+	threadId: string;
+}): Promise<IntegrationMessageContext | undefined> {
+	try {
+		const context = await params.messageContextStore.getLatest(params.threadId);
+		if (context?.integrationConnectionId !== params.descriptor.integrationConnectionId) {
+			return undefined;
+		}
+		return context;
+	} catch {
+		return undefined;
+	}
 }
 
 async function getRespondContext(params: {

--- a/packages/cli/src/modules/agents/integrations/platforms/linear-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/linear-integration.ts
@@ -3,8 +3,7 @@ import { Service } from '@n8n/di';
 
 import { AgentChatIntegration, type AgentChatIntegrationContext } from '../agent-chat-integration';
 import { loadLinearAdapter } from '../esm-loader';
-
-type LinearAuth = { kind: 'apiKey'; token: string } | { kind: 'accessToken'; token: string };
+import type { IntegrationAction, IntegrationContextQuery } from '../integration-tools';
 
 /**
  * Linear platform integration.
@@ -22,55 +21,62 @@ type LinearAuth = { kind: 'apiKey'; token: string } | { kind: 'accessToken'; tok
 export class LinearIntegration extends AgentChatIntegration {
 	readonly type = 'linear';
 
-	readonly credentialTypes = ['linearApi', 'linearOAuth2Api'];
+	readonly credentialTypes = ['linearOAuth2Api'];
 
 	readonly displayLabel = 'Linear';
 
 	readonly displayIcon = 'linear';
+
+	readonly contextQueries: IntegrationContextQuery[] = [
+		'get_current_message_context',
+		'get_current_subject',
+		'get_current_user',
+		'get_user',
+		'search_users',
+		'get_issue',
+		'search_issues',
+	];
+
+	readonly actions: IntegrationAction[] = ['respond', 'create_issue', 'create_comment'];
 
 	constructor(private readonly logger: Logger) {
 		super();
 	}
 
 	async createAdapter(ctx: AgentChatIntegrationContext): Promise<unknown> {
-		const auth = this.extractAuth(ctx.credential);
+		const accessToken = this.extractAccessToken(ctx.credential);
 		const webhookSecret = this.extractSigningSecret(ctx.credential);
-		const userName = await this.fetchDisplayName(auth);
+		const userName = await this.fetchDisplayName(accessToken);
+		const mode = this.extractMode(ctx.credential);
 
 		const { createLinearAdapter } = await loadLinearAdapter();
 
 		return createLinearAdapter({
-			...(auth.kind === 'apiKey' ? { apiKey: auth.token } : { accessToken: auth.token }),
+			accessToken,
 			webhookSecret,
 			...(userName ? { userName } : {}),
+			...(mode ? { mode } : {}),
 		});
 	}
 
 	/**
 	 * Determine which auth variant the adapter config expects.
 	 *
-	 * - `linearApi` stores a personal API key in `apiKey` — passed to the adapter
-	 *   as `apiKey` (adapter uses it as-is).
 	 * - `linearOAuth2Api` stores an OAuth access token in
 	 *   `oauthTokenData.access_token` — passed as `accessToken` (adapter skips
 	 *   auto-refresh and treats it as a pre-obtained token, per option B of the
 	 *   @chat-adapter/linear README).
 	 */
-	private extractAuth(credential: Record<string, unknown>): LinearAuth {
-		if (typeof credential.apiKey === 'string' && credential.apiKey) {
-			return { kind: 'apiKey', token: credential.apiKey };
-		}
-
+	private extractAccessToken(credential: Record<string, unknown>): string {
 		const tokenData = credential.oauthTokenData as Record<string, unknown> | undefined;
 		const oauthToken = tokenData?.access_token ?? tokenData?.accessToken;
 		if (typeof oauthToken === 'string' && oauthToken) {
-			return { kind: 'accessToken', token: oauthToken };
+			return oauthToken;
 		}
 
 		throw new Error(
-			'Could not extract an API token from the Linear credential. ' +
-				'Please ensure the credential has a valid API key (linearApi) ' +
-				'or completed OAuth flow (linearOAuth2Api).',
+			'Could not extract an OAuth access token from the Linear credential. ' +
+				'Please ensure the credential has completed the OAuth flow (linearOAuth2Api).',
 		);
 	}
 
@@ -87,17 +93,20 @@ export class LinearIntegration extends AgentChatIntegration {
 		);
 	}
 
+	private extractMode(credential: Record<string, unknown>): 'agent-sessions' | undefined {
+		return credential.actor === 'app' ? 'agent-sessions' : undefined;
+	}
+
 	/**
-	 * Personal API keys go in as a bare `Authorization: <key>` header; OAuth
-	 * access tokens need `Authorization: Bearer <token>`. Returns undefined on
-	 * any failure — the adapter falls back to its default `linear-bot` name.
+	 * OAuth access tokens need `Authorization: Bearer <token>`. Returns
+	 * undefined on any failure — the adapter falls back to its default
+	 * `linear-bot` name.
 	 */
-	private async fetchDisplayName(auth: LinearAuth): Promise<string | undefined> {
-		const authHeader = auth.kind === 'accessToken' ? `Bearer ${auth.token}` : auth.token;
+	private async fetchDisplayName(accessToken: string): Promise<string | undefined> {
 		try {
 			const resp = await fetch('https://api.linear.app/graphql', {
 				method: 'POST',
-				headers: { 'Content-Type': 'application/json', Authorization: authHeader },
+				headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` },
 				body: JSON.stringify({ query: '{ viewer { displayName } }' }),
 			});
 			if (!resp.ok) return undefined;

--- a/packages/cli/src/modules/agents/integrations/platforms/slack-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/slack-integration.ts
@@ -37,6 +37,7 @@ export class SlackIntegration extends AgentChatIntegration {
 
 	readonly contextQueries: IntegrationContextQuery[] = [
 		'get_current_message_context',
+		'get_current_subject',
 		'get_current_user',
 		'get_current_channel_info',
 		'get_user',

--- a/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
+++ b/packages/cli/src/modules/agents/integrations/platforms/telegram-integration.ts
@@ -13,7 +13,7 @@ import { AgentRepository } from '../../repositories/agent.repository';
 import { AgentChatIntegration, type AgentChatIntegrationContext } from '../agent-chat-integration';
 import type { SuspendComponent } from '../component-mapper';
 import { loadTelegramAdapter } from '../esm-loader';
-import type { IntegrationAction, IntegrationContextQuery } from '../integration-tools';
+import type { IntegrationAction } from '../integration-tools';
 
 /**
  * Telegram platform integration.
@@ -41,8 +41,6 @@ export class TelegramIntegration extends AgentChatIntegration {
 	readonly displayIcon = 'telegram';
 
 	readonly supportedComponents = ['section', 'button', 'divider', 'fields'];
-
-	readonly contextQueries: IntegrationContextQuery[] = ['get_current_message_context'];
 
 	readonly actions: IntegrationAction[] = ['respond', 'send_dm'];
 

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentIntegrationCredentialPickers.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentIntegrationCredentialPickers.test.ts
@@ -771,6 +771,7 @@ describe('agent integration credential picker usage', () => {
 	});
 
 	it('defaults Telegram setup to private mode and requires a user ID before connecting', async () => {
+		const onAgentChanged = vi.fn();
 		const wrapper = mount(AgentAddTriggerModal, {
 			props: {
 				modalName: 'agentAddTriggerModal',
@@ -783,6 +784,7 @@ describe('agent integration credential picker usage', () => {
 					connectedTriggers: [],
 					onConnectedTriggersChange: vi.fn(),
 					onTriggerAdded: vi.fn(),
+					onAgentChanged,
 				},
 			},
 			global: { stubs: globalStubs },
@@ -810,6 +812,7 @@ describe('agent integration credential picker usage', () => {
 			'cred-telegram',
 			{ accessMode: 'private', allowedUsers: ['123', '456'] },
 		);
+		expect(onAgentChanged).toHaveBeenCalledOnce();
 	});
 
 	it('renders the Telegram public warning for legacy connected integrations without settings', async () => {
@@ -842,6 +845,7 @@ describe('agent integration credential picker usage', () => {
 	});
 
 	it('disables the Telegram form when connected so users must disconnect to edit', async () => {
+		const onAgentChanged = vi.fn();
 		getIntegrationStatus.mockResolvedValue({
 			integrations: [
 				{
@@ -864,6 +868,7 @@ describe('agent integration credential picker usage', () => {
 					connectedTriggers: [],
 					onConnectedTriggersChange: vi.fn(),
 					onTriggerAdded: vi.fn(),
+					onAgentChanged,
 				},
 			},
 			global: { stubs: globalStubs },
@@ -874,5 +879,17 @@ describe('agent integration credential picker usage', () => {
 		expect(userIds.exists()).toBe(true);
 		expect(userIds.find('input').attributes('disabled')).toBeDefined();
 		expect(wrapper.find('[data-testid="telegram-disconnect-button"]').exists()).toBe(true);
+
+		await wrapper.find('[data-testid="telegram-disconnect-button"]').trigger('click');
+		await flushPromises();
+
+		expect(disconnectIntegration).toHaveBeenCalledWith(
+			{},
+			'project-1',
+			'agent-1',
+			'telegram',
+			'cred-telegram',
+		);
+		expect(onAgentChanged).toHaveBeenCalledOnce();
 	});
 });

--- a/packages/nodes-base/credentials/test/LinearOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/LinearOAuth2Api.credentials.test.ts
@@ -1,0 +1,12 @@
+import { LinearOAuth2Api } from '../LinearOAuth2Api.credentials';
+
+describe('LinearOAuth2Api Credential', () => {
+	const credential = new LinearOAuth2Api();
+
+	it('requests app mentionable scope when authenticating as the application actor', () => {
+		const scopeProperty = credential.properties.find((property) => property.name === 'scope');
+
+		expect(scopeProperty?.default).toContain('$self["actor"] === "app"');
+		expect(scopeProperty?.default).toContain('app:mentionable');
+	});
+});


### PR DESCRIPTION
## Summary

Adds Linear integration support on top of the generic context/action tooling:

- Switches the agent Linear integration path to OAuth credential support.
- Adds Linear context queries for current message/subject/user data and Linear workspace data.
- Adds Linear action support through the integration action executor.
- Wires Linear integration metadata into the chat bridge and integration tool descriptions.

This is PR 3 in the agents chat updates stack and is stacked on PR 2.

Verification performed on the final stacked branch/local checkout:

- `pnpm test agent-builder-interactive.test.ts` in `packages/@n8n/api-types`
- `pnpm test src/modules/agents/builder/interactive/__tests__/ask-credential.tool.test.ts` in `packages/cli`
- `pnpm typecheck` in `packages/@n8n/api-types`
- `pnpm build` in `packages/@n8n/api-types`
- `pnpm typecheck` in `packages/cli`
- `pnpm typecheck` in `packages/frontend/editor-ui`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-58/feature-figure-out-mentions-in-linear
https://linear.app/n8n/issue/AGENT-59/feature-add-context-about-the-ticket-to-linear-integration

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI