### PR TITLE
fix(core): Continue agent execution when requested AI tool fails

### DIFF
--- a/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-process-process-run-execution-data.test.ts
@@ -20,8 +20,6 @@ jest.mock('node:fs', () => ({
 }));
 
 import { DirectedGraph } from '../partial-execution-utils';
-import { createNodeData, toITaskData } from '../partial-execution-utils/__tests__/helpers';
-import { WorkflowExecute } from '../workflow-execute';
 import {
 	types,
 	nodeTypes,
@@ -29,6 +27,8 @@ import {
 	nodeTypeArguments,
 	modifyNode,
 } from './mock-node-types';
+import { createNodeData, toITaskData } from '../partial-execution-utils/__tests__/helpers';
+import { WorkflowExecute } from '../workflow-execute';
 
 describe('processRunExecutionData', () => {
 	const runHook = jest.fn().mockResolvedValue(undefined);
@@ -819,6 +819,90 @@ describe('processRunExecutionData', () => {
 			// Error should be captured
 			expect(toolRunData.error).toBeDefined();
 			expect(toolRunData.error?.message).toContain(errorMessage);
+		});
+
+		test('resumes agent when requested AI tool fails and agent continues on fail', async () => {
+			const errorMessage = 'Tool execution failed with validation error';
+			const errorThrowingNode: INodeType = {
+				...passThroughNode,
+				async execute(): Promise<INodeExecutionData[][]> {
+					throw new Error(errorMessage);
+				},
+			};
+
+			const toolNode = createNodeData({ name: 'errorTool', type: 'errorThrowingNode' });
+			const agentNodeType = modifyNode(passThroughNode)
+				.return({
+					actions: [
+						{
+							actionType: 'ExecutionNodeAction',
+							nodeName: toolNode.name,
+							input: { query: 'test input that will fail' },
+							type: 'ai_tool',
+							id: 'action_1',
+							metadata: {},
+						},
+					],
+					metadata: { requestId: 'test_request' },
+				})
+				.return((response?: EngineResponse) => [
+					[
+						{
+							json: {
+								agentResult: 'Agent completed',
+								toolError: response?.actionResponses?.[0]?.data.data?.ai_tool?.[0]?.[0]?.json.error,
+							},
+						},
+					],
+				])
+				.done();
+			const agentNode = createNodeData({ name: 'agentNode', type: 'agentNodeType' });
+			agentNode.continueOnFail = true;
+			const afterNode = createNodeData({ name: 'afterNode', type: types.passThrough });
+
+			const customNodeTypes = NodeTypes({
+				...nodeTypeArguments,
+				agentNodeType: { type: agentNodeType, sourcePath: '' },
+				errorThrowingNode: { type: errorThrowingNode, sourcePath: '' },
+			});
+
+			const workflow = new DirectedGraph()
+				.addNodes(agentNode, toolNode, afterNode)
+				.addConnections({ from: agentNode, to: afterNode })
+				.addConnections({ from: toolNode, to: agentNode, type: 'ai_tool' })
+				.toWorkflow({
+					name: '',
+					active: false,
+					nodeTypes: customNodeTypes,
+					settings: { executionOrder: 'v1' },
+				});
+
+			const executionData = createRunExecutionData({
+				startData: { startNodes: [{ name: agentNode.name, sourceData: null }] },
+				executionData: {
+					nodeExecutionStack: [
+						{
+							data: { main: [[{ json: { prompt: 'test prompt' } }]] },
+							node: agentNode,
+							source: { main: [{ previousNode: 'Start' }] },
+						},
+					],
+				},
+			});
+
+			const workflowExecute = new WorkflowExecute(additionalData, executionMode, executionData);
+
+			const result = await workflowExecute.processRunExecutionData(workflow);
+			const runData = result.data.resultData.runData;
+
+			expect(runData[toolNode.name][0].data?.ai_tool?.[0]?.[0]?.json).toMatchObject({
+				error: errorMessage,
+			});
+			expect(runData[agentNode.name].at(-1)?.data?.main?.[0]?.[0]?.json).toMatchObject({
+				agentResult: 'Agent completed',
+				toolError: errorMessage,
+			});
+			expect(runData[afterNode.name]).toHaveLength(1);
 		});
 	});
 

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -88,6 +88,25 @@ import { RoutingNode } from './routing-node';
 import { TriggersAndPollers } from './triggers-and-pollers';
 import { convertBinaryData } from '../utils/convert-binary-data';
 
+function shouldContinueOnFail(node: INode | undefined) {
+	if (!node) return false;
+
+	return (
+		node.continueOnFail === true ||
+		['continueRegularOutput', 'continueErrorOutput'].includes(node.onError ?? '')
+	);
+}
+
+function getAiToolRequestingNode(executionData: IExecuteData, workflow: Workflow) {
+	if (!executionData.node.rewireOutputLogTo) return undefined;
+
+	const parentNodeName = executionData.source?.main?.find(
+		(source) => source !== null && source !== undefined,
+	)?.previousNode;
+
+	return parentNodeName ? (workflow.getNode(parentNodeName) ?? undefined) : undefined;
+}
+
 interface RunWorkflowOptions {
 	workflow: Workflow;
 	startNode?: INode;
@@ -1956,14 +1975,19 @@ export class WorkflowExecute {
 							},
 						]);
 
+						const requestingAiToolNode = getAiToolRequestingNode(executionData, workflow);
+
 						if (
-							executionData.node.continueOnFail === true ||
-							['continueRegularOutput', 'continueErrorOutput'].includes(
-								executionData.node.onError || '',
-							)
+							shouldContinueOnFail(executionData.node) ||
+							shouldContinueOnFail(requestingAiToolNode)
 						) {
 							// Workflow should continue running even if node errors
-							if (Object.hasOwn(executionData.data, 'main') && executionData.data.main.length > 0) {
+							if (requestingAiToolNode && executionNode.rewireOutputLogTo) {
+								nodeSuccessData = [[{ json: { error: executionError.message } }]];
+							} else if (
+								Object.hasOwn(executionData.data, 'main') &&
+								executionData.data.main.length > 0
+							) {
 								// Simply get the input data of the node if it has any and pass it through
 								// to the next node
 								if (executionData.data.main[0] !== null) {


### PR DESCRIPTION
## Summary

Fixes AI Agent execution when a requested AI tool fails and the agent is configured to continue on fail.

Previously, the execution engine handled the failed tool node in isolation, so it only considered the tool node's error handling settings. This change also checks the requesting agent node when the failed node is an AI tool execution routed back to the agent. When the agent should continue, the tool error is returned as AI tool output so the agent can resume and the workflow can continue.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/NODE-4950/bug-when-mcp-client-tool-node-errors-the-agent-execution-fails-no

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
