### PR TITLE
fix(editor): Avoid duplicate empty-state prompt copy (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/views/WorkflowsView.test.ts
+++ b/packages/frontend/editor-ui/src/app/views/WorkflowsView.test.ts
@@ -156,6 +156,16 @@ describe('WorkflowsView', () => {
 				expect(getByText('There are currently no workflows to view')).toBeInTheDocument();
 			});
 
+			it('does not repeat generic prompt in fallback empty state', async () => {
+				const projectsStore = mockedStore(useProjectsStore);
+				projectsStore.currentProject = { scopes: ['workflow:create'] } as Project;
+
+				const { getAllByText } = renderComponent({ pinia });
+				await waitAllPromises();
+
+				expect(getAllByText('What do you want to build?')).toHaveLength(1);
+			});
+
 			it('for user with create scope', async () => {
 				const projectsStore = mockedStore(useProjectsStore);
 				projectsStore.currentProject = { scopes: ['workflow:create'] } as Project;

--- a/packages/frontend/editor-ui/src/features/workflows/composables/useWorkflowsEmptyState.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/composables/useWorkflowsEmptyState.ts
@@ -96,9 +96,11 @@ export function useWorkflowsEmptyState() {
 			return i18n.baseText('workflows.empty.description.readOnlyEnv');
 		} else if (!projectPermissions.value.workflow.create) {
 			return i18n.baseText('workflows.empty.description.noPermission');
-		} else {
+		} else if (showRecommendedTemplatesInline.value) {
 			return i18n.baseText('workflows.empty.description');
 		}
+
+		return '';
 	});
 
 	return {


### PR DESCRIPTION
## Summary

Avoid duplicate empty-state prompt copy on the workflows page by suppressing the generic description when the fallback heading already asks “What do you want to build?”.

Adds regression coverage to ensure the generic prompt appears only once in the fallback create-scope empty state.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5296

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
