### PR TITLE
ci: Add retry to PR status notification webhook (no-changelog)

### DIFF
--- a/.github/workflows/util-notify-pr-status.yml
+++ b/.github/workflows/util-notify-pr-status.yml
@@ -27,3 +27,5 @@ jobs:
           method: 'POST'
           customHeaders: '{ "x-api-token": "${{ secrets.N8N_NOTIFY_PR_STATUS_CHANGED_TOKEN }}" }'
           data: '{ "event_name": "${{ github.event_name }}", "pr_url": "${{ env.PR_URL }}",  "event": ${{ toJSON(github.event) }} }'
+          retry: 5
+          retryWait: 5000


### PR DESCRIPTION
## Summary

- Add retry (5 attempts) and retryWait (5s) to the PR status notification webhook action to improve reliability when the webhook endpoint is temporarily unavailable.

- [x] I have seen this code, I have run this code, and I take responsibility for this code.

## Review / Merge checklist

- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created.
- [ ] Tests included.