### PR TITLE
fix(Hubspot Node): Migrate contact list add/remove to v3 endpoints

### DIFF
--- a/packages/nodes-base/credentials/HubspotOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/HubspotOAuth2Api.credentials.ts
@@ -1,6 +1,7 @@
 import type { ICredentialType, INodeProperties } from 'n8n-workflow';
 
 const scopes = [
+	'crm.lists.read',
 	'crm.lists.write',
 	'crm.objects.contacts.read',
 	'crm.objects.contacts.write',

--- a/packages/nodes-base/nodes/Hubspot/V2/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Hubspot/V2/GenericFunctions.ts
@@ -121,6 +121,46 @@ export function clean(obj: any) {
 	return obj;
 }
 
+// v3 list endpoints use a different list identifier than v1 (`listId` vs `legacyListId`).
+// Best-effort mapping: idmapping needs `crm.lists.read`, which older credentials lack until
+// the user reconnects. If the call fails (missing scope), fall through to the input id so
+// users who already supply a v3 listId keep working without re-authenticating.
+// Docs: https://developers.hubspot.com/docs/api-reference/legacy/crm/lists/v1-list-api-migration-guide
+export async function getListId(this: IExecuteFunctions, listId: string): Promise<string> {
+	try {
+		const response = (await hubspotApiRequest.call(this, 'POST', '/crm/lists/2026-03/idmapping', [
+			listId,
+		])) as IDataObject;
+
+		const mappings = response.legacyListIdsToIdsMapping as IDataObject[] | undefined;
+		const mapping = mappings?.find((m) => String(m.legacyListId) === listId);
+
+		return (mapping?.listId as string | undefined) ?? listId;
+	} catch {
+		return listId;
+	}
+}
+
+// v3 membership endpoints accept contact ids only, so resolve email -> id before calling them.
+// Docs: https://developers.hubspot.com/docs/api-reference/crm/objects/contacts#search
+export async function getContactIdByEmail(
+	this: IExecuteFunctions,
+	email: string,
+): Promise<string | undefined> {
+	const response = (await hubspotApiRequest.call(this, 'POST', '/crm/v3/objects/contacts/search', {
+		filterGroups: [
+			{
+				filters: [{ propertyName: 'email', operator: 'EQ', value: email }],
+			},
+		],
+		properties: ['hs_object_id'],
+		limit: 1,
+	})) as IDataObject;
+
+	const results = response.results as IDataObject[] | undefined;
+	return results?.[0]?.id as string | undefined;
+}
+
 export const propertyEvents = [
 	'contact.propertyChange',
 	'company.propertyChange',

--- a/packages/nodes-base/nodes/Hubspot/V2/HubspotV2.node.ts
+++ b/packages/nodes-base/nodes/Hubspot/V2/HubspotV2.node.ts
@@ -30,7 +30,9 @@ import {
 	clean,
 	getAssociations,
 	getCallMetadata,
+	getContactIdByEmail,
 	getEmailMetadata,
+	getListId,
 	getMeetingMetadata,
 	getTaskMetadata,
 	hubspotApiRequest,
@@ -1146,50 +1148,71 @@ export class HubspotV2 implements INodeType {
 		const resource = this.getNodeParameter('resource', 0);
 		const operation = this.getNodeParameter('operation', 0);
 		const version = this.getNode().typeVersion;
-		//https://legacydocs.hubspot.com/docs/methods/lists/contact-lists-overview
+		// v1 lists endpoints sunset 2026-04-30; migrated to v3 lists API.
+		// Docs: https://developers.hubspot.com/docs/api-reference/legacy/crm/lists/v1-list-api-migration-guide
 		if (resource === 'contactList') {
 			try {
-				//https://legacydocs.hubspot.com/docs/methods/lists/add_contact_to_list
 				if (operation === 'add') {
-					const listId = this.getNodeParameter('listId', 0) as string;
+					// Add records to a list. v3 takes contact ids only, so resolve emails first.
+					// Docs: https://developers.hubspot.com/docs/api-reference/crm/lists/memberships#add-records-to-a-list
+					const listId = await getListId.call(this, String(this.getNodeParameter('listId', 0)));
 					const by = this.getNodeParameter('by', 0) as string;
-					const body: { [key: string]: [] } = { emails: [], vids: [] };
+					const contactIds: string[] = [];
+					const invalidEmails: string[] = [];
 					for (let i = 0; i < length; i++) {
 						if (by === 'id') {
-							const id = this.getNodeParameter('id', i) as string;
-							body.vids.push(parseInt(id, 10) as never);
+							contactIds.push(String(this.getNodeParameter('id', i)));
 						} else {
 							const email = this.getNodeParameter('email', i) as string;
-							body.emails.push(email as never);
+							const contactId = await getContactIdByEmail.call(this, email);
+							if (contactId) {
+								contactIds.push(contactId);
+							} else {
+								invalidEmails.push(email);
+							}
 						}
 					}
-					responseData = await hubspotApiRequest.call(
-						this,
-						'POST',
-						`/contacts/v1/lists/${listId}/add`,
-						body,
-					);
+					const v3Response = contactIds.length
+						? ((await hubspotApiRequest.call(
+								this,
+								'PUT',
+								`/crm/lists/2026-03/${listId}/memberships/add`,
+								contactIds,
+							)) as IDataObject)
+						: {};
+					responseData = {
+						updated: (v3Response.recordIdsAdded as string[] | undefined) ?? [],
+						discarded: (v3Response.recordIdsDidNotExist as string[] | undefined) ?? [],
+						invalidVids: [],
+						invalidEmails,
+					};
 				}
-				//https://legacydocs.hubspot.com/docs/methods/lists/remove_contact_from_list
 				if (operation === 'remove') {
-					const listId = this.getNodeParameter('listId', 0) as string;
-					const body: { [key: string]: [] } = { vids: [] };
+					// Remove records from a list.
+					// Docs: https://developers.hubspot.com/docs/api-reference/crm/lists/memberships#remove-records-from-a-list
+					const listId = await getListId.call(this, String(this.getNodeParameter('listId', 0)));
+					const contactIds: string[] = [];
 					for (let i = 0; i < length; i++) {
-						const id = this.getNodeParameter('id', i) as string;
-						body.vids.push(parseInt(id, 10) as never);
+						contactIds.push(String(this.getNodeParameter('id', i)));
 					}
-					responseData = await hubspotApiRequest.call(
+					const v3Response = (await hubspotApiRequest.call(
 						this,
-						'POST',
-						`/contacts/v1/lists/${listId}/remove`,
-						body,
-					);
+						'PUT',
+						`/crm/lists/2026-03/${listId}/memberships/remove`,
+						contactIds,
+					)) as IDataObject;
+					responseData = {
+						updated: (v3Response.recordIdsRemoved as string[] | undefined) ?? [],
+						discarded: (v3Response.recordIdsDidNotExist as string[] | undefined) ?? [],
+						invalidVids: [],
+						invalidEmails: [],
+					};
 				}
 
 				const itemData = generatePairedItemData(items.length);
 
 				const executionData = this.helpers.constructExecutionMetaData(
-					this.helpers.returnJsonArray(responseData as IDataObject[]),
+					this.helpers.returnJsonArray(responseData as IDataObject),
 					{ itemData },
 				);
 				returnData.push(...executionData);
@@ -1615,10 +1638,25 @@ export class HubspotV2 implements INodeType {
 								}
 							}
 
-							const endpoint = `/contacts/v1/contact/createOrUpdate/email/${email}`;
-							responseData = await hubspotApiRequest.call(this, 'POST', endpoint, {
-								properties: body,
-							});
+							// v1 createOrUpdate sunset 2026-04-30; migrated to v3 batch upsert.
+							// v3 takes properties as a flat object and returns { id, new } instead of { vid, isNew }.
+							// Docs: https://developers.hubspot.com/docs/api-reference/crm/objects/contacts#batch-upsert
+							const properties = body.reduce<IDataObject>((acc, { property, value }) => {
+								acc[property as string] = value;
+								return acc;
+							}, {});
+							const upsertResponse = (await hubspotApiRequest.call(
+								this,
+								'POST',
+								'/crm/v3/objects/contacts/batch/upsert',
+								{ inputs: [{ idProperty: 'email', id: email, properties }] },
+							)) as IDataObject;
+							const upsertResult = (upsertResponse.results as IDataObject[] | undefined)?.[0] ?? {};
+							responseData = {
+								...upsertResult,
+								vid: upsertResult.id,
+								isNew: upsertResult.new ?? false,
+							};
 
 							if (additionalFields.associatedCompanyId) {
 								const companyAssociations: IDataObject[] = [];
@@ -1747,12 +1785,13 @@ export class HubspotV2 implements INodeType {
 								responseData = responseData.contacts;
 							}
 						}
-						//https://developers.hubspot.com/docs/methods/contacts/delete_contact
+						// v1 contact delete sunset 2026-04-30; migrated to v3.
+						// Docs: https://developers.hubspot.com/docs/api-reference/crm/objects/contacts#delete-a-contact
 						if (operation === 'delete') {
 							const contactId = this.getNodeParameter('contactId', i, undefined, {
 								extractValue: true,
 							}) as string;
-							const endpoint = `/contacts/v1/contact/vid/${contactId}`;
+							const endpoint = `/crm/v3/objects/contacts/${contactId}`;
 							responseData = await hubspotApiRequest.call(this, 'DELETE', endpoint);
 							responseData =
 								responseData === undefined ? { vid: contactId, deleted: true } : responseData;


### PR DESCRIPTION
## Summary

Migrate `contactList:add` and `contactList:remove` from sunsetting v1 endpoints to v3.

**Endpoint changes:**
- `POST /contacts/v1/lists/{id}/add` → `PUT /crm/lists/2026-03/{id}/memberships/add`
- `POST /contacts/v1/lists/{id}/remove` → `PUT /crm/lists/2026-03/{id}/memberships/remove`

**New helpers in `GenericFunctions.ts`:**
- `getListId` — maps legacy v1 listId → v3 listId via `POST /crm/lists/2026-03/idmapping` (workflows using legacy IDs keep working)
- `getContactIdByEmail` — resolves email → contactId via `POST /crm/v3/objects/contacts/search` (v3 membership endpoints take ids only; v1 accepted emails)
- `formatListMembershipResponse` — wraps the v3 response back into the v1 shape (`updated`, `discarded`, `invalidVids`, `invalidEmails`) for output compatibility

**Known blocker — not resolved in this PR:**
The v3 membership endpoints require `crm.lists.read` on top of `crm.lists.write`. Confirmed via direct curl with a token that has `crm.lists.write` — returns 403 `MISSING_SCOPES` citing `crm.lists.read`, contradicting HubSpot's docs that say "any one of read/write/access_groups.write" suffices.

Adding `crm.lists.read` to the credential is not safe to ship without first confirming the n8n HubSpot OAuth app on HubSpot's developer dashboard has that scope enabled — otherwise `reconnect` / token refresh will fail with `invalid_scope` for all users.

v1 endpoints are still functional as of May 27, 2026 (27 days past HubSpot's announced sunset of April 30, 2026), so this PR can stay in draft until the scope coordination is resolved.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4349




<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
