### PR TITLE
test: Add sandbox service test container

### DIFF
--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -74,7 +74,7 @@ jobs:
 
       - name: Start sandbox service
         if: ${{ inputs.sandbox-provider == 'n8n-sandbox' }}
-        run: npx tsx packages/testing/containers/start-sandbox.ts --network n8n-eval-net
+        run: pnpm tsx packages/testing/containers/start-sandbox.ts --network n8n-eval-net
 
       - name: Start n8n containers
         env:

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -72,96 +72,9 @@ jobs:
         env:
           INCLUDE_TEST_CONTROLLER: 'true'
 
-      - name: Generate mTLS certificates for sandbox service
-        if: ${{ inputs.sandbox-provider == 'n8n-sandbox' }}
-        run: |
-          TLS_DIR="$RUNNER_TEMP/sandbox-tls"
-          mkdir -p "$TLS_DIR"
-          docker run --rm \
-            --user 0:0 \
-            --entrypoint sh \
-            -v "$TLS_DIR:/tls" \
-            -e NUM_RUNNERS=1 \
-            n8nio/n8n-sandbox-service-api:latest \
-            -c 'bootstrap-mtls.sh --out-dir /tls --api-san sandbox-api --control-san-prefix sandbox-runner --world-readable && chown -R sandbox-api:sandbox-api /tls/api'
-
-      - name: Create Docker network
-        if: ${{ inputs.sandbox-provider == 'n8n-sandbox' }}
-        run: docker network create n8n-eval-net
-
       - name: Start sandbox service
         if: ${{ inputs.sandbox-provider == 'n8n-sandbox' }}
-        run: |
-          TLS_DIR="$RUNNER_TEMP/sandbox-tls"
-
-          # Start sandbox API
-          docker run -d --name sandbox-api \
-            --network n8n-eval-net \
-            -v "$TLS_DIR/api:/tls:ro" \
-            -e SANDBOX_API_KEYS=n8n-sandbox-ci-key \
-            -e SANDBOX_API_RUNNER_REGISTRATION_TOKEN=ci-reg-token \
-            -e SANDBOX_API_RUNNER_API_KEY=ci-runner-key \
-            -e SANDBOX_API_GRPC_TLS_CERT_FILE=/tls/grpc-server.crt \
-            -e SANDBOX_API_GRPC_TLS_KEY_FILE=/tls/grpc-server.key \
-            -e SANDBOX_API_GRPC_TLS_CLIENT_CA_FILE=/tls/ca.crt \
-            -e SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_CA_FILE=/tls/ca.crt \
-            -e SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_CERT_FILE=/tls/control-grpc-api-client.crt \
-            -e SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_KEY_FILE=/tls/control-grpc-api-client.key \
-            -e SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_SERVER_NAME=sandbox-runner-1 \
-            -e SANDBOX_API_LOG_LEVEL=warn \
-            n8nio/n8n-sandbox-service-api:latest
-
-          # Wait for API health (up to 60s)
-          for i in $(seq 1 60); do
-            if docker exec sandbox-api wget -q -O /dev/null http://localhost:8080/healthz 2>/dev/null; then
-              echo "Sandbox API healthy after ${i}s"
-              break
-            fi
-            if [ "$i" -eq 60 ]; then
-              echo "::error::Sandbox API failed to start within 60s"
-              docker logs sandbox-api --tail 30 || true
-              exit 1
-            fi
-            sleep 1
-          done
-
-          # Start sandbox runner (DinD)
-          docker run -d --name sandbox-runner-1 \
-            --network n8n-eval-net \
-            --privileged \
-            -v "$TLS_DIR/runner:/tls:ro" \
-            -e SANDBOX_RUNNER_API_KEYS=ci-runner-key \
-            -e SANDBOX_RUNNER_REGISTRATION_TOKEN=ci-reg-token \
-            -e SANDBOX_RUNNER_API_GRPC_ADDR=sandbox-api:9090 \
-            -e SANDBOX_RUNNER_HTTP_BASE_URL=http://sandbox-runner-1:8080 \
-            -e SANDBOX_RUNNER_CONTROL_GRPC_LISTEN_ADDR=:9091 \
-            -e SANDBOX_RUNNER_CONTROL_GRPC_ADVERTISE_ADDR=sandbox-runner-1:9091 \
-            -e SANDBOX_RUNNER_ID=ci-runner-1 \
-            -e SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE=n8nio/n8n-sandbox-service-sandbox:latest \
-            -e SANDBOX_RUNNER_LOG_LEVEL=warn \
-            -e SANDBOX_RUNNER_REGISTRATION_GRPC_CA_FILE=/tls/ca.crt \
-            -e SANDBOX_RUNNER_REGISTRATION_GRPC_CERT_FILE=/tls/grpc-client.crt \
-            -e SANDBOX_RUNNER_REGISTRATION_GRPC_KEY_FILE=/tls/grpc-client.key \
-            -e SANDBOX_RUNNER_REGISTRATION_GRPC_SERVER_NAME=sandbox-api \
-            -e SANDBOX_RUNNER_CONTROL_GRPC_TLS_CERT_FILE=/tls/control-grpc-server.crt \
-            -e SANDBOX_RUNNER_CONTROL_GRPC_TLS_KEY_FILE=/tls/control-grpc-server.key \
-            -e SANDBOX_RUNNER_CONTROL_GRPC_TLS_CLIENT_CA_FILE=/tls/ca.crt \
-            -e SANDBOX_RUNNER_LOG_LEVEL=warn \
-            n8nio/n8n-sandbox-service-runner-dind:latest
-
-          # Wait for runner health (up to 120s — DinD daemon needs time to start)
-          for i in $(seq 1 120); do
-            if docker exec sandbox-runner-1 wget -q -O /dev/null --header='X-Api-Key: ci-runner-key' http://localhost:8080/healthz 2>/dev/null; then
-              echo "Sandbox runner healthy after ${i}s"
-              break
-            fi
-            if [ "$i" -eq 120 ]; then
-              echo "::error::Sandbox runner failed to start within 120s"
-              docker logs sandbox-runner-1 --tail 30 || true
-              exit 1
-            fi
-            sleep 1
-          done
+        run: npx tsx packages/testing/containers/start-sandbox.ts --network n8n-eval-net
 
       - name: Start n8n containers
         env:
@@ -192,7 +105,7 @@ jobs:
 
           # Use the eval network when sandbox service is running
           NETWORK_ARGS=()
-          if [ "$SANDBOX_PROVIDER" != "daytona" ]; then
+          if [ "$SANDBOX_PROVIDER" == "n8n-sandbox" ]; then
             NETWORK_ARGS+=(--network n8n-eval-net)
           fi
 

--- a/packages/testing/containers/services/registry.ts
+++ b/packages/testing/containers/services/registry.ts
@@ -14,6 +14,7 @@ import { postgres, createPostgresHelper } from './postgres';
 import { postgresExporter } from './postgres-exporter';
 import { proxy, createProxyHelper } from './proxy';
 import { redis } from './redis';
+import { sandbox } from './sandbox';
 import { taskRunner } from './task-runner';
 import { tracing, createTracingHelper } from './tracing';
 import type { Service, ServiceName, ServiceResult, HelperFactories } from './types';
@@ -43,6 +44,7 @@ export const services: Record<ServiceName, Service<ServiceResult>> = {
 	kent,
 	postgresExporter,
 	cadvisor,
+	sandbox,
 };
 
 export const helperFactories: Partial<HelperFactories> = {

--- a/packages/testing/containers/services/sandbox.ts
+++ b/packages/testing/containers/services/sandbox.ts
@@ -136,9 +136,9 @@ export const sandbox: Service<SandboxResult> = {
 				})
 				.withExposedPorts(API_HTTP_PORT)
 				.withWaitStrategy(
-					Wait.forHttp('/healthz', API_HTTP_PORT)
-						.forResponsePredicate((res) => res === '')
-						.withStartupTimeout(120_000),
+					Wait.forSuccessfulCommand(
+						`wget -q -O /dev/null --header='X-Api-Key: ${RUNNER_API_KEY}' http://localhost:${API_HTTP_PORT}/healthz`,
+					).withStartupTimeout(120_000),
 				)
 				.withLogConsumer(runnerConsumer)
 				.withReuse()

--- a/packages/testing/containers/services/sandbox.ts
+++ b/packages/testing/containers/services/sandbox.ts
@@ -1,0 +1,168 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { StartedNetwork, StartedTestContainer } from 'testcontainers';
+import { GenericContainer, Wait } from 'testcontainers';
+
+import { createSilentLogConsumer } from '../helpers/utils';
+import { TEST_CONTAINER_IMAGES } from '../test-containers';
+import type { Service, ServiceResult } from './types';
+
+const API_HOSTNAME = 'sandbox-api';
+const RUNNER_HOSTNAME = 'sandbox-runner-1';
+const API_HTTP_PORT = 8080;
+const API_GRPC_PORT = 9090;
+
+const API_KEY = 'n8n-sandbox-ci-key';
+const RUNNER_API_KEY = 'ci-runner-key';
+const REGISTRATION_TOKEN = 'ci-reg-token';
+
+export interface SandboxMeta {
+	apiUrl: string;
+	apiKey: string;
+}
+
+export type SandboxResult = ServiceResult<SandboxMeta> & {
+	containers: StartedTestContainer[];
+};
+
+async function generateMtlsCerts(network: StartedNetwork, projectName: string): Promise<string> {
+	const tlsDir = mkdtempSync(join(tmpdir(), `${projectName}-sandbox-tls-`));
+	const { consumer, throwWithLogs } = createSilentLogConsumer();
+
+	try {
+		const certContainer = await new GenericContainer(TEST_CONTAINER_IMAGES.sandboxApi)
+			.withName(`${projectName}-sandbox-cert-gen`)
+			.withNetwork(network)
+			.withUser('0:0')
+			.withEntrypoint(['sh'])
+			.withCommand([
+				'-c',
+				'bootstrap-mtls.sh --out-dir /tls --api-san sandbox-api --control-san-prefix sandbox-runner --world-readable && chown -R sandbox-api:sandbox-api /tls/api',
+			])
+			.withBindMounts([{ source: tlsDir, target: '/tls', mode: 'rw' }])
+			.withEnvironment({ NUM_RUNNERS: '1' })
+			.withWaitStrategy(Wait.forSuccessfulCommand('test -f /tls/api/grpc-server.crt'))
+			.withLogConsumer(consumer)
+			.start();
+		await certContainer.stop();
+	} catch (error: unknown) {
+		return throwWithLogs(error);
+	}
+
+	return tlsDir;
+}
+
+export const sandbox: Service<SandboxResult> = {
+	description: 'Sandbox service (API + runner)',
+
+	async start(network: StartedNetwork, projectName: string): Promise<SandboxResult> {
+		const tlsDir = await generateMtlsCerts(network, projectName);
+		const { consumer: apiConsumer, throwWithLogs: throwApiLogs } = createSilentLogConsumer();
+		const { consumer: runnerConsumer, throwWithLogs: throwRunnerLogs } = createSilentLogConsumer();
+
+		let apiContainer: StartedTestContainer;
+		try {
+			apiContainer = await new GenericContainer(TEST_CONTAINER_IMAGES.sandboxApi)
+				.withName(`${projectName}-${API_HOSTNAME}`)
+				.withNetwork(network)
+				.withNetworkAliases(API_HOSTNAME)
+				.withLabels({
+					'com.docker.compose.project': projectName,
+					'com.docker.compose.service': API_HOSTNAME,
+				})
+				.withBindMounts([{ source: join(tlsDir, 'api'), target: '/tls', mode: 'ro' }])
+				.withEnvironment({
+					SANDBOX_API_KEYS: API_KEY,
+					SANDBOX_API_RUNNER_REGISTRATION_TOKEN: REGISTRATION_TOKEN,
+					SANDBOX_API_RUNNER_API_KEY: RUNNER_API_KEY,
+					SANDBOX_API_GRPC_TLS_CERT_FILE: '/tls/grpc-server.crt',
+					SANDBOX_API_GRPC_TLS_KEY_FILE: '/tls/grpc-server.key',
+					SANDBOX_API_GRPC_TLS_CLIENT_CA_FILE: '/tls/ca.crt',
+					SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_CA_FILE: '/tls/ca.crt',
+					SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_CERT_FILE: '/tls/control-grpc-api-client.crt',
+					SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_KEY_FILE: '/tls/control-grpc-api-client.key',
+					SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_SERVER_NAME: RUNNER_HOSTNAME,
+					SANDBOX_API_LOG_LEVEL: 'warn',
+				})
+				.withExposedPorts(API_HTTP_PORT, API_GRPC_PORT)
+				.withWaitStrategy(
+					Wait.forHttp('/healthz', API_HTTP_PORT).forStatusCode(200).withStartupTimeout(60_000),
+				)
+				.withLogConsumer(apiConsumer)
+				.withReuse()
+				.start();
+		} catch (error: unknown) {
+			return throwApiLogs(error);
+		}
+
+		let runnerContainer: StartedTestContainer;
+		try {
+			runnerContainer = await new GenericContainer(TEST_CONTAINER_IMAGES.sandboxRunner)
+				.withName(`${projectName}-${RUNNER_HOSTNAME}`)
+				.withNetwork(network)
+				.withNetworkAliases(RUNNER_HOSTNAME)
+				.withLabels({
+					'com.docker.compose.project': projectName,
+					'com.docker.compose.service': RUNNER_HOSTNAME,
+				})
+				.withPrivilegedMode()
+				.withBindMounts([{ source: join(tlsDir, 'runner'), target: '/tls', mode: 'ro' }])
+				.withEnvironment({
+					SANDBOX_RUNNER_API_KEYS: RUNNER_API_KEY,
+					SANDBOX_RUNNER_REGISTRATION_TOKEN: REGISTRATION_TOKEN,
+					SANDBOX_RUNNER_API_GRPC_ADDR: `${API_HOSTNAME}:${API_GRPC_PORT}`,
+					SANDBOX_RUNNER_HTTP_BASE_URL: `http://${RUNNER_HOSTNAME}:${API_HTTP_PORT}`,
+					SANDBOX_RUNNER_CONTROL_GRPC_LISTEN_ADDR: ':9091',
+					SANDBOX_RUNNER_CONTROL_GRPC_ADVERTISE_ADDR: `${RUNNER_HOSTNAME}:9091`,
+					SANDBOX_RUNNER_ID: 'ci-runner-1',
+					SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE: TEST_CONTAINER_IMAGES.sandboxSandbox,
+					SANDBOX_RUNNER_LOG_LEVEL: 'warn',
+					SANDBOX_RUNNER_REGISTRATION_GRPC_CA_FILE: '/tls/ca.crt',
+					SANDBOX_RUNNER_REGISTRATION_GRPC_CERT_FILE: '/tls/grpc-client.crt',
+					SANDBOX_RUNNER_REGISTRATION_GRPC_KEY_FILE: '/tls/grpc-client.key',
+					SANDBOX_RUNNER_REGISTRATION_GRPC_SERVER_NAME: API_HOSTNAME,
+					SANDBOX_RUNNER_CONTROL_GRPC_TLS_CERT_FILE: '/tls/control-grpc-server.crt',
+					SANDBOX_RUNNER_CONTROL_GRPC_TLS_KEY_FILE: '/tls/control-grpc-server.key',
+					SANDBOX_RUNNER_CONTROL_GRPC_TLS_CLIENT_CA_FILE: '/tls/ca.crt',
+				})
+				.withExposedPorts(API_HTTP_PORT)
+				.withWaitStrategy(
+					Wait.forHttp('/healthz', API_HTTP_PORT)
+						.forResponsePredicate((res) => res === '')
+						.withStartupTimeout(120_000),
+				)
+				.withLogConsumer(runnerConsumer)
+				.withReuse()
+				.start();
+		} catch (error: unknown) {
+			return throwRunnerLogs(error);
+		}
+
+		return {
+			container: apiContainer,
+			containers: [apiContainer, runnerContainer],
+			meta: {
+				apiUrl: `http://${API_HOSTNAME}:${API_HTTP_PORT}`,
+				apiKey: API_KEY,
+			},
+		};
+	},
+
+	env(result: SandboxResult, external?: boolean): Record<string, string> {
+		if (external) {
+			const host = result.container.getHost();
+			const port = result.container.getMappedPort(API_HTTP_PORT);
+			return {
+				N8N_INSTANCE_AI_SANDBOX_PROVIDER: 'n8n-sandbox',
+				N8N_SANDBOX_SERVICE_URL: `http://${host}:${port}`,
+				N8N_SANDBOX_SERVICE_API_KEY: API_KEY,
+			};
+		}
+		return {
+			N8N_INSTANCE_AI_SANDBOX_PROVIDER: 'n8n-sandbox',
+			N8N_SANDBOX_SERVICE_URL: result.meta.apiUrl,
+			N8N_SANDBOX_SERVICE_API_KEY: result.meta.apiKey,
+		};
+	},
+};

--- a/packages/testing/containers/services/sandbox.ts
+++ b/packages/testing/containers/services/sandbox.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync } from 'node:fs';
+import { chmodSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { StartedNetwork, StartedTestContainer } from 'testcontainers';
@@ -26,8 +26,11 @@ export type SandboxResult = ServiceResult<SandboxMeta> & {
 	containers: StartedTestContainer[];
 };
 
+const CERT_GEN_SENTINEL = 'SANDBOX_CERTS_READY';
+
 async function generateMtlsCerts(network: StartedNetwork, projectName: string): Promise<string> {
 	const tlsDir = mkdtempSync(join(tmpdir(), `${projectName}-sandbox-tls-`));
+	chmodSync(tlsDir, 0o755);
 	const { consumer, throwWithLogs } = createSilentLogConsumer();
 
 	try {
@@ -38,11 +41,16 @@ async function generateMtlsCerts(network: StartedNetwork, projectName: string): 
 			.withEntrypoint(['sh'])
 			.withCommand([
 				'-c',
-				'bootstrap-mtls.sh --out-dir /tls --api-san sandbox-api --control-san-prefix sandbox-runner --world-readable && chown -R sandbox-api:sandbox-api /tls/api',
+				[
+					'bootstrap-mtls.sh --out-dir /tls --api-san sandbox-api --control-san-prefix sandbox-runner --world-readable',
+					'chown -R sandbox-api:sandbox-api /tls/api',
+					'chmod -R a+rX /tls',
+					`echo ${CERT_GEN_SENTINEL}`,
+				].join(' && '),
 			])
 			.withBindMounts([{ source: tlsDir, target: '/tls', mode: 'rw' }])
 			.withEnvironment({ NUM_RUNNERS: '1' })
-			.withWaitStrategy(Wait.forSuccessfulCommand('test -f /tls/api/grpc-server.crt'))
+			.withWaitStrategy(Wait.forLogMessage(CERT_GEN_SENTINEL))
 			.withLogConsumer(consumer)
 			.start();
 		await certContainer.stop();

--- a/packages/testing/containers/services/types.ts
+++ b/packages/testing/containers/services/types.ts
@@ -24,6 +24,7 @@ export const SERVICE_NAMES = [
 	'kent',
 	'postgresExporter',
 	'cadvisor',
+	'sandbox',
 ] as const;
 
 export type ServiceName = (typeof SERVICE_NAMES)[number];

--- a/packages/testing/containers/start-sandbox.ts
+++ b/packages/testing/containers/start-sandbox.ts
@@ -1,0 +1,192 @@
+#!/usr/bin/env tsx
+/**
+ * Standalone script to start the n8n sandbox service (API + runner) using
+ * raw Docker commands. Used by CI workflows where the sandbox must join an
+ * existing Docker network alongside separately-managed n8n containers.
+ *
+ * Usage: pnpm tsx packages/testing/containers/start-sandbox.ts [--network <name>]
+ */
+import { execFileSync, execSync } from 'node:child_process';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseArgs } from 'node:util';
+
+import { TEST_CONTAINER_IMAGES } from './test-containers';
+
+const { values } = parseArgs({
+	options: { network: { type: 'string', default: 'n8n-eval-net' } },
+	strict: false,
+});
+
+const network = values.network ?? 'n8n-eval-net';
+
+const API_KEY = 'n8n-sandbox-ci-key';
+const RUNNER_API_KEY = 'ci-runner-key';
+const REGISTRATION_TOKEN = 'ci-reg-token';
+
+function docker(...args: string[]) {
+	console.log(`$ docker ${args.join(' ')}`);
+	execFileSync('docker', args, { stdio: 'inherit' });
+}
+
+function dockerQuiet(...args: string[]): string {
+	return execFileSync('docker', args, { encoding: 'utf-8' }).trim();
+}
+
+function waitForHealth(
+	container: string,
+	healthCmd: string[],
+	timeoutSeconds: number,
+	label: string,
+) {
+	console.log(`Waiting for ${label} to become healthy...`);
+	for (let i = 1; i <= timeoutSeconds; i++) {
+		try {
+			execFileSync('docker', ['exec', container, ...healthCmd], { stdio: 'pipe' });
+			console.log(`${label} healthy after ${i}s`);
+			return;
+		} catch {
+			if (i === timeoutSeconds) {
+				try {
+					execFileSync('docker', ['logs', container, '--tail', '30'], { stdio: 'inherit' });
+				} catch {
+					/* best-effort log dump */
+				}
+				throw new Error(`${label} failed to start within ${timeoutSeconds}s`);
+			}
+			execSync('sleep 1');
+		}
+	}
+}
+
+// 1. Generate mTLS certificates
+const tlsDir = mkdtempSync(join(tmpdir(), 'sandbox-tls-'));
+console.log(`Generating mTLS certificates in ${tlsDir}`);
+
+docker(
+	'run',
+	'--rm',
+	'--user',
+	'0:0',
+	'--entrypoint',
+	'sh',
+	'-v',
+	`${tlsDir}:/tls`,
+	'-e',
+	'NUM_RUNNERS=1',
+	TEST_CONTAINER_IMAGES.sandboxApi,
+	'-c',
+	'bootstrap-mtls.sh --out-dir /tls --api-san sandbox-api --control-san-prefix sandbox-runner --world-readable && chown -R sandbox-api:sandbox-api /tls/api',
+);
+
+// 2. Ensure network exists
+try {
+	dockerQuiet('network', 'inspect', network);
+} catch {
+	docker('network', 'create', network);
+}
+
+// 3. Start sandbox API
+docker(
+	'run',
+	'-d',
+	'--name',
+	'sandbox-api',
+	'--network',
+	network,
+	'-v',
+	`${tlsDir}/api:/tls:ro`,
+	'-e',
+	`SANDBOX_API_KEYS=${API_KEY}`,
+	'-e',
+	`SANDBOX_API_RUNNER_REGISTRATION_TOKEN=${REGISTRATION_TOKEN}`,
+	'-e',
+	`SANDBOX_API_RUNNER_API_KEY=${RUNNER_API_KEY}`,
+	'-e',
+	'SANDBOX_API_GRPC_TLS_CERT_FILE=/tls/grpc-server.crt',
+	'-e',
+	'SANDBOX_API_GRPC_TLS_KEY_FILE=/tls/grpc-server.key',
+	'-e',
+	'SANDBOX_API_GRPC_TLS_CLIENT_CA_FILE=/tls/ca.crt',
+	'-e',
+	'SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_CA_FILE=/tls/ca.crt',
+	'-e',
+	'SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_CERT_FILE=/tls/control-grpc-api-client.crt',
+	'-e',
+	'SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_KEY_FILE=/tls/control-grpc-api-client.key',
+	'-e',
+	'SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_SERVER_NAME=sandbox-runner-1',
+	'-e',
+	'SANDBOX_API_LOG_LEVEL=warn',
+	TEST_CONTAINER_IMAGES.sandboxApi,
+);
+
+waitForHealth(
+	'sandbox-api',
+	['wget', '-q', '-O', '/dev/null', 'http://localhost:8080/healthz'],
+	60,
+	'Sandbox API',
+);
+
+// 4. Start sandbox runner (DinD — requires privileged mode)
+docker(
+	'run',
+	'-d',
+	'--name',
+	'sandbox-runner-1',
+	'--network',
+	network,
+	'--privileged',
+	'-v',
+	`${tlsDir}/runner:/tls:ro`,
+	'-e',
+	`SANDBOX_RUNNER_API_KEYS=${RUNNER_API_KEY}`,
+	'-e',
+	`SANDBOX_RUNNER_REGISTRATION_TOKEN=${REGISTRATION_TOKEN}`,
+	'-e',
+	'SANDBOX_RUNNER_API_GRPC_ADDR=sandbox-api:9090',
+	'-e',
+	'SANDBOX_RUNNER_HTTP_BASE_URL=http://sandbox-runner-1:8080',
+	'-e',
+	'SANDBOX_RUNNER_CONTROL_GRPC_LISTEN_ADDR=:9091',
+	'-e',
+	'SANDBOX_RUNNER_CONTROL_GRPC_ADVERTISE_ADDR=sandbox-runner-1:9091',
+	'-e',
+	'SANDBOX_RUNNER_ID=ci-runner-1',
+	'-e',
+	`SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE=${TEST_CONTAINER_IMAGES.sandboxSandbox}`,
+	'-e',
+	'SANDBOX_RUNNER_LOG_LEVEL=warn',
+	'-e',
+	'SANDBOX_RUNNER_REGISTRATION_GRPC_CA_FILE=/tls/ca.crt',
+	'-e',
+	'SANDBOX_RUNNER_REGISTRATION_GRPC_CERT_FILE=/tls/grpc-client.crt',
+	'-e',
+	'SANDBOX_RUNNER_REGISTRATION_GRPC_KEY_FILE=/tls/grpc-client.key',
+	'-e',
+	'SANDBOX_RUNNER_REGISTRATION_GRPC_SERVER_NAME=sandbox-api',
+	'-e',
+	'SANDBOX_RUNNER_CONTROL_GRPC_TLS_CERT_FILE=/tls/control-grpc-server.crt',
+	'-e',
+	'SANDBOX_RUNNER_CONTROL_GRPC_TLS_KEY_FILE=/tls/control-grpc-server.key',
+	'-e',
+	'SANDBOX_RUNNER_CONTROL_GRPC_TLS_CLIENT_CA_FILE=/tls/ca.crt',
+	TEST_CONTAINER_IMAGES.sandboxRunner,
+);
+
+waitForHealth(
+	'sandbox-runner-1',
+	[
+		'wget',
+		'-q',
+		'-O',
+		'/dev/null',
+		'--header=X-Api-Key: ci-runner-key',
+		'http://localhost:8080/healthz',
+	],
+	120,
+	'Sandbox runner',
+);
+
+console.log('Sandbox service is ready');

--- a/packages/testing/containers/start-sandbox.ts
+++ b/packages/testing/containers/start-sandbox.ts
@@ -1,192 +1,42 @@
 #!/usr/bin/env tsx
 /**
- * Standalone script to start the n8n sandbox service (API + runner) using
- * raw Docker commands. Used by CI workflows where the sandbox must join an
- * existing Docker network alongside separately-managed n8n containers.
+ * Standalone script to start the n8n sandbox service (API + runner) using the
+ * testcontainers-based sandbox service definition. Creates a named Docker
+ * network so that separately-started n8n containers can join it.
  *
  * Usage: pnpm tsx packages/testing/containers/start-sandbox.ts [--network <name>]
  */
-import { execFileSync, execSync } from 'node:child_process';
-import { mkdtempSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 import { parseArgs } from 'node:util';
+import { Network } from 'testcontainers';
+import type { Uuid } from 'testcontainers';
 
-import { TEST_CONTAINER_IMAGES } from './test-containers';
+import { sandbox } from './services/sandbox';
 
 const { values } = parseArgs({
 	options: { network: { type: 'string', default: 'n8n-eval-net' } },
 	strict: false,
 });
 
-const network = values.network ?? 'n8n-eval-net';
+const networkName = values.network ?? 'n8n-eval-net';
+const projectName = 'n8n-sandbox-ci';
 
-const API_KEY = 'n8n-sandbox-ci-key';
-const RUNNER_API_KEY = 'ci-runner-key';
-const REGISTRATION_TOKEN = 'ci-reg-token';
-
-function docker(...args: string[]) {
-	console.log(`$ docker ${args.join(' ')}`);
-	execFileSync('docker', args, { stdio: 'inherit' });
-}
-
-function dockerQuiet(...args: string[]): string {
-	return execFileSync('docker', args, { encoding: 'utf-8' }).trim();
-}
-
-function waitForHealth(
-	container: string,
-	healthCmd: string[],
-	timeoutSeconds: number,
-	label: string,
-) {
-	console.log(`Waiting for ${label} to become healthy...`);
-	for (let i = 1; i <= timeoutSeconds; i++) {
-		try {
-			execFileSync('docker', ['exec', container, ...healthCmd], { stdio: 'pipe' });
-			console.log(`${label} healthy after ${i}s`);
-			return;
-		} catch {
-			if (i === timeoutSeconds) {
-				try {
-					execFileSync('docker', ['logs', container, '--tail', '30'], { stdio: 'inherit' });
-				} catch {
-					/* best-effort log dump */
-				}
-				throw new Error(`${label} failed to start within ${timeoutSeconds}s`);
-			}
-			execSync('sleep 1');
-		}
+class FixedName implements Uuid {
+	constructor(private readonly name: string) {}
+	nextUuid() {
+		return this.name;
 	}
 }
 
-// 1. Generate mTLS certificates
-const tlsDir = mkdtempSync(join(tmpdir(), 'sandbox-tls-'));
-console.log(`Generating mTLS certificates in ${tlsDir}`);
+async function main() {
+	console.log(`Creating network "${networkName}"...`);
+	const network = await new Network(new FixedName(networkName)).start();
 
-docker(
-	'run',
-	'--rm',
-	'--user',
-	'0:0',
-	'--entrypoint',
-	'sh',
-	'-v',
-	`${tlsDir}:/tls`,
-	'-e',
-	'NUM_RUNNERS=1',
-	TEST_CONTAINER_IMAGES.sandboxApi,
-	'-c',
-	'bootstrap-mtls.sh --out-dir /tls --api-san sandbox-api --control-san-prefix sandbox-runner --world-readable && chown -R sandbox-api:sandbox-api /tls/api',
-);
+	console.log('Starting sandbox service...');
+	const result = await sandbox.start(network, projectName);
 
-// 2. Ensure network exists
-try {
-	dockerQuiet('network', 'inspect', network);
-} catch {
-	docker('network', 'create', network);
+	console.log(`Sandbox API URL: ${result.meta.apiUrl}`);
+	console.log(`Network: ${network.getName()}`);
+	console.log('Sandbox service is ready');
 }
 
-// 3. Start sandbox API
-docker(
-	'run',
-	'-d',
-	'--name',
-	'sandbox-api',
-	'--network',
-	network,
-	'-v',
-	`${tlsDir}/api:/tls:ro`,
-	'-e',
-	`SANDBOX_API_KEYS=${API_KEY}`,
-	'-e',
-	`SANDBOX_API_RUNNER_REGISTRATION_TOKEN=${REGISTRATION_TOKEN}`,
-	'-e',
-	`SANDBOX_API_RUNNER_API_KEY=${RUNNER_API_KEY}`,
-	'-e',
-	'SANDBOX_API_GRPC_TLS_CERT_FILE=/tls/grpc-server.crt',
-	'-e',
-	'SANDBOX_API_GRPC_TLS_KEY_FILE=/tls/grpc-server.key',
-	'-e',
-	'SANDBOX_API_GRPC_TLS_CLIENT_CA_FILE=/tls/ca.crt',
-	'-e',
-	'SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_CA_FILE=/tls/ca.crt',
-	'-e',
-	'SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_CERT_FILE=/tls/control-grpc-api-client.crt',
-	'-e',
-	'SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_KEY_FILE=/tls/control-grpc-api-client.key',
-	'-e',
-	'SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_SERVER_NAME=sandbox-runner-1',
-	'-e',
-	'SANDBOX_API_LOG_LEVEL=warn',
-	TEST_CONTAINER_IMAGES.sandboxApi,
-);
-
-waitForHealth(
-	'sandbox-api',
-	['wget', '-q', '-O', '/dev/null', 'http://localhost:8080/healthz'],
-	60,
-	'Sandbox API',
-);
-
-// 4. Start sandbox runner (DinD — requires privileged mode)
-docker(
-	'run',
-	'-d',
-	'--name',
-	'sandbox-runner-1',
-	'--network',
-	network,
-	'--privileged',
-	'-v',
-	`${tlsDir}/runner:/tls:ro`,
-	'-e',
-	`SANDBOX_RUNNER_API_KEYS=${RUNNER_API_KEY}`,
-	'-e',
-	`SANDBOX_RUNNER_REGISTRATION_TOKEN=${REGISTRATION_TOKEN}`,
-	'-e',
-	'SANDBOX_RUNNER_API_GRPC_ADDR=sandbox-api:9090',
-	'-e',
-	'SANDBOX_RUNNER_HTTP_BASE_URL=http://sandbox-runner-1:8080',
-	'-e',
-	'SANDBOX_RUNNER_CONTROL_GRPC_LISTEN_ADDR=:9091',
-	'-e',
-	'SANDBOX_RUNNER_CONTROL_GRPC_ADVERTISE_ADDR=sandbox-runner-1:9091',
-	'-e',
-	'SANDBOX_RUNNER_ID=ci-runner-1',
-	'-e',
-	`SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE=${TEST_CONTAINER_IMAGES.sandboxSandbox}`,
-	'-e',
-	'SANDBOX_RUNNER_LOG_LEVEL=warn',
-	'-e',
-	'SANDBOX_RUNNER_REGISTRATION_GRPC_CA_FILE=/tls/ca.crt',
-	'-e',
-	'SANDBOX_RUNNER_REGISTRATION_GRPC_CERT_FILE=/tls/grpc-client.crt',
-	'-e',
-	'SANDBOX_RUNNER_REGISTRATION_GRPC_KEY_FILE=/tls/grpc-client.key',
-	'-e',
-	'SANDBOX_RUNNER_REGISTRATION_GRPC_SERVER_NAME=sandbox-api',
-	'-e',
-	'SANDBOX_RUNNER_CONTROL_GRPC_TLS_CERT_FILE=/tls/control-grpc-server.crt',
-	'-e',
-	'SANDBOX_RUNNER_CONTROL_GRPC_TLS_KEY_FILE=/tls/control-grpc-server.key',
-	'-e',
-	'SANDBOX_RUNNER_CONTROL_GRPC_TLS_CLIENT_CA_FILE=/tls/ca.crt',
-	TEST_CONTAINER_IMAGES.sandboxRunner,
-);
-
-waitForHealth(
-	'sandbox-runner-1',
-	[
-		'wget',
-		'-q',
-		'-O',
-		'/dev/null',
-		'--header=X-Api-Key: ci-runner-key',
-		'http://localhost:8080/healthz',
-	],
-	120,
-	'Sandbox runner',
-);
-
-console.log('Sandbox service is ready');
+await main();

--- a/packages/testing/containers/start-sandbox.ts
+++ b/packages/testing/containers/start-sandbox.ts
@@ -39,4 +39,7 @@ async function main() {
 	console.log('Sandbox service is ready');
 }
 
-await main();
+main().catch((error) => {
+	console.error(error);
+	process.exit(1);
+});

--- a/packages/testing/containers/test-containers.ts
+++ b/packages/testing/containers/test-containers.ts
@@ -43,6 +43,9 @@ const DEFAULT_IMAGES = {
 	localstack: 'localstack/localstack:4.13.1',
 	postgresExporter: 'prometheuscommunity/postgres-exporter:v0.17.1',
 	cadvisor: 'gcr.io/cadvisor/cadvisor:v0.49.1',
+	sandboxApi: 'n8nio/n8n-sandbox-service-api:latest',
+	sandboxRunner: 'n8nio/n8n-sandbox-service-runner-dind:latest',
+	sandboxSandbox: 'n8nio/n8n-sandbox-service-sandbox:latest',
 } as const;
 
 /** Convert camelCase to SCREAMING_SNAKE_CASE for env var names */
@@ -121,4 +124,7 @@ export const TEST_CONTAINER_IMAGES = {
 	localstack: getImage('localstack'),
 	postgresExporter: getImage('postgresExporter'),
 	cadvisor: getImage('cadvisor'),
+	sandboxApi: getImage('sandboxApi'),
+	sandboxRunner: getImage('sandboxRunner'),
+	sandboxSandbox: getImage('sandboxSandbox'),
 } as const;


### PR DESCRIPTION
## Summary

Followup to https://github.com/n8n-io/n8n/pull/31051

Register the sandbox service (API, runner, sandbox images) in the test container registry and simplify the CI eval workflow:

- Add `sandbox` to `SERVICE_NAMES`, service registry, and container image map (`sandboxApi`, `sandboxRunner`, `sandboxSandbox`)
- Replace ~90 lines of inline Docker/mTLS bootstrap in the CI workflow with a single call to `start-sandbox.ts`
- Fix the network condition to explicitly check `== "n8n-sandbox"` instead of `!= "daytona"`, so new providers don't accidentally join the eval network

CI run here: https://github.com/n8n-io/n8n/actions/runs/26512748988/job/78081262085

- [x] I have seen this code, I have run this code, and I take responsibility for this code.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3198

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI