### PR TITLE
fix(core): Allow emails in npm person strings in no-template-placeholders lint rule

### DIFF
--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-template-placeholders.test.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-template-placeholders.test.ts
@@ -37,6 +37,24 @@ ruleTester.run('no-template-placeholders', NoTemplatePlaceholdersRule, {
 			filename: 'package.json',
 			code: '{ "name": "n8n-nodes-example", "private": false, "engines": { "node": ">=18" } }',
 		},
+		{
+			name: 'npm person string with email in author is not flagged',
+			filename: 'package.json',
+			code: '{ "author": "Jane Doe <jane@example.com>" }',
+		},
+		{
+			name: 'npm person string with email and url in author is not flagged',
+			filename: 'package.json',
+			code: '{ "author": "Jane Doe <jane@example.com> (https://example.com)" }',
+		},
+		{
+			name: 'npm person strings in contributors and maintainers are not flagged',
+			filename: 'package.json',
+			code: `{
+				"contributors": ["Jane Doe <jane@example.com> (https://example.com)"],
+				"maintainers": ["John Roe <john.roe+n8n@example.org>"]
+			}`,
+		},
 	],
 	invalid: [
 		{

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-template-placeholders.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/no-template-placeholders.ts
@@ -3,7 +3,9 @@ import { AST_NODE_TYPES } from '@typescript-eslint/utils';
 
 import { createRule } from '../utils/index.js';
 
-const ANGLE_PLACEHOLDER = /<[^<>\n]+?>/;
+// Excludes `@` so that emails inside npm "person" strings
+// (e.g. `"author": "Jane Doe <jane@example.com>"`) are not flagged.
+const ANGLE_PLACEHOLDER = /<[^<>\n@]+?>/;
 const MUSTACHE_PLACEHOLDER = /\{\{[^{}\n]+?\}\}/;
 
 function findPlaceholder(value: string): { pattern: string; type: 'angle' | 'mustache' } | null {


### PR DESCRIPTION
## Summary

The `no-template-placeholders` ESLint rule's angle-bracket regex (`<[^<>\n]+?>`) matched any text inside `<...>`, which incorrectly flagged the email portion of valid npm "person" strings — e.g. `"author": "Jane Doe <jane@example.com>"`, also used in `contributors` and `maintainers` arrays.

Real placeholder identifiers like `<PACKAGE_NAME>`, `<USERNAME>`, `<SERVICE>`, `<CREDENTIAL>` never contain `@`, while npm person-string emails always do. Excluding `@` from the character class is a minimal, targeted fix that preserves all existing placeholder detection while permitting valid person strings.

- Tightened `ANGLE_PLACEHOLDER` regex to `/<[^<>\n@]+?>/`
- Added valid-case tests for `author` (with email; with email + url) and `contributors`/`maintainers` arrays of person strings

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CE-1261

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

Made with [Cursor](https://cursor.com)