### PR TITLE
feat(core): Add option to track only published workflows with OpenTelemetry and make it the default

### DIFF
--- a/packages/cli/src/modules/otel/__tests__/otel-lifecycle-handler.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/otel-lifecycle-handler.test.ts
@@ -12,7 +12,7 @@ import type { OwnershipService } from '@/services/ownership.service';
 
 import type { ExecutionLevelTracer } from '../execution-level-tracer';
 import { OtelLifecycleHandler, countInputItems, countOutputItems } from '../otel-lifecycle-handler';
-import type { OtelConfig } from '../otel.config';
+import { OtelConfig } from '../otel.config';
 import type { TracingContext, TraceContextService } from '../tracing-context';
 
 const emptyExecutionData = {
@@ -20,11 +20,15 @@ const emptyExecutionData = {
 	executionData: undefined,
 } as unknown as IRunExecutionData;
 
+function makeOtelConfig(overrides: Partial<OtelConfig> = {}): OtelConfig {
+	return Object.assign(new OtelConfig(), overrides);
+}
+
 describe('OtelLifecycleHandler', () => {
 	describe('onWorkflowStart', () => {
 		const tracer = mock<ExecutionLevelTracer>();
 		const traceContextService = mock<TraceContextService>();
-		const config = mock<OtelConfig>();
+		let config = makeOtelConfig();
 		const ownershipService = mock<OwnershipService>();
 		const logger = mock<Logger>();
 		let handler: OtelLifecycleHandler;
@@ -57,7 +61,7 @@ describe('OtelLifecycleHandler', () => {
 
 		beforeEach(() => {
 			jest.clearAllMocks();
-			config.publishedOnly = false;
+			config = makeOtelConfig({ publishedOnly: false });
 			handler = new OtelLifecycleHandler(
 				tracer,
 				traceContextService,
@@ -161,7 +165,7 @@ describe('OtelLifecycleHandler', () => {
 	describe('onWorkflowResume', () => {
 		const tracer = mock<ExecutionLevelTracer>();
 		const traceContextService = mock<TraceContextService>();
-		const config = mock<OtelConfig>();
+		let config = makeOtelConfig();
 		const ownershipService = mock<OwnershipService>();
 		const logger = mock<Logger>();
 		let handler: OtelLifecycleHandler;
@@ -175,7 +179,7 @@ describe('OtelLifecycleHandler', () => {
 
 		beforeEach(() => {
 			jest.clearAllMocks();
-			config.publishedOnly = false;
+			config = makeOtelConfig({ publishedOnly: false });
 			handler = new OtelLifecycleHandler(
 				tracer,
 				traceContextService,
@@ -259,14 +263,14 @@ describe('OtelLifecycleHandler', () => {
 	describe('onWorkflowEnd', () => {
 		const tracer = mock<ExecutionLevelTracer>();
 		const traceContextService = mock<TraceContextService>();
-		const config = mock<OtelConfig>();
+		let config = makeOtelConfig();
 		const ownershipService = mock<OwnershipService>();
 		const logger = mock<Logger>();
 		let handler: OtelLifecycleHandler;
 
 		beforeEach(() => {
 			jest.clearAllMocks();
-			config.publishedOnly = false;
+			config = makeOtelConfig({ publishedOnly: false });
 			handler = new OtelLifecycleHandler(
 				tracer,
 				traceContextService,
@@ -334,7 +338,7 @@ describe('OtelLifecycleHandler', () => {
 	describe('onNodeStart / onNodeEnd', () => {
 		const tracer = mock<ExecutionLevelTracer>();
 		const traceContextService = mock<TraceContextService>();
-		const config = mock<OtelConfig>();
+		let config = makeOtelConfig();
 		const ownershipService = mock<OwnershipService>();
 		const logger = mock<Logger>();
 		let handler: OtelLifecycleHandler;
@@ -371,8 +375,7 @@ describe('OtelLifecycleHandler', () => {
 
 		beforeEach(() => {
 			jest.clearAllMocks();
-			config.publishedOnly = false;
-			config.includeNodeSpans = true;
+			config = makeOtelConfig({ publishedOnly: false, includeNodeSpans: true });
 			handler = new OtelLifecycleHandler(
 				tracer,
 				traceContextService,
@@ -469,7 +472,7 @@ describe('OtelLifecycleHandler', () => {
 describe('publishedOnly filter', () => {
 	const tracer = mock<ExecutionLevelTracer>();
 	const traceContextService = mock<TraceContextService>();
-	const config = mock<OtelConfig>();
+	let config = makeOtelConfig();
 	const ownershipService = mock<OwnershipService>();
 	const logger = mock<Logger>();
 	let handler: OtelLifecycleHandler;
@@ -535,8 +538,7 @@ describe('publishedOnly filter', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
-		config.publishedOnly = true;
-		config.includeNodeSpans = true;
+		config = makeOtelConfig({ publishedOnly: true, includeNodeSpans: true });
 		ownershipService.getWorkflowProjectCached.mockResolvedValue({ id: 'proj-1' } as never);
 		traceContextService.get.mockResolvedValue(undefined);
 		handler = new OtelLifecycleHandler(

--- a/packages/cli/src/modules/otel/__tests__/otel-lifecycle-handler.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/otel-lifecycle-handler.test.ts
@@ -57,6 +57,7 @@ describe('OtelLifecycleHandler', () => {
 
 		beforeEach(() => {
 			jest.clearAllMocks();
+			config.publishedOnly = false;
 			handler = new OtelLifecycleHandler(
 				tracer,
 				traceContextService,
@@ -174,6 +175,7 @@ describe('OtelLifecycleHandler', () => {
 
 		beforeEach(() => {
 			jest.clearAllMocks();
+			config.publishedOnly = false;
 			handler = new OtelLifecycleHandler(
 				tracer,
 				traceContextService,
@@ -264,6 +266,7 @@ describe('OtelLifecycleHandler', () => {
 
 		beforeEach(() => {
 			jest.clearAllMocks();
+			config.publishedOnly = false;
 			handler = new OtelLifecycleHandler(
 				tracer,
 				traceContextService,
@@ -368,6 +371,7 @@ describe('OtelLifecycleHandler', () => {
 
 		beforeEach(() => {
 			jest.clearAllMocks();
+			config.publishedOnly = false;
 			config.includeNodeSpans = true;
 			handler = new OtelLifecycleHandler(
 				tracer,
@@ -459,6 +463,129 @@ describe('OtelLifecycleHandler', () => {
 
 			expect(tracer.endNode).not.toHaveBeenCalled();
 		});
+	});
+});
+
+describe('publishedOnly filter', () => {
+	const tracer = mock<ExecutionLevelTracer>();
+	const traceContextService = mock<TraceContextService>();
+	const config = mock<OtelConfig>();
+	const ownershipService = mock<OwnershipService>();
+	const logger = mock<Logger>();
+	let handler: OtelLifecycleHandler;
+
+	const inactiveWorkflow = {
+		id: 'wf-1',
+		name: 'Test',
+		versionId: 'v1',
+		nodes: [],
+		connections: {},
+		active: false,
+		isArchived: false,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+		activeVersionId: null,
+	};
+
+	const activeWorkflow = { ...inactiveWorkflow, active: true };
+
+	const makeWorkflowStartCtx = (workflow: object): WorkflowExecuteBeforeContext => ({
+		type: 'workflowExecuteBefore',
+		workflow: workflow as never,
+		workflowInstance: undefined as never,
+		executionId: 'exec-1',
+	});
+
+	const makeWorkflowEndCtx = (workflow: object): WorkflowExecuteAfterContext =>
+		({
+			type: 'workflowExecuteAfter',
+			workflow,
+			executionId: 'exec-1',
+			newStaticData: {},
+			runData: {
+				status: 'success',
+				mode: 'manual',
+				data: { resultData: { runData: {}, pinData: {} } },
+			},
+		}) as unknown as WorkflowExecuteAfterContext;
+
+	const makeNodeStartCtx = (workflow: object): NodeExecuteBeforeContext =>
+		({
+			type: 'nodeExecuteBefore',
+			workflow,
+			nodeName: 'Node1',
+			executionId: 'exec-1',
+		}) as unknown as NodeExecuteBeforeContext;
+
+	const makeNodeEndCtx = (workflow: object): NodeExecuteAfterContext =>
+		({
+			type: 'nodeExecuteAfter',
+			workflow,
+			nodeName: 'Node1',
+			executionId: 'exec-1',
+			taskData: {
+				startTime: 0,
+				executionTime: 10,
+				executionIndex: 0,
+				source: [],
+				data: { main: [[{ json: {} }]] },
+			},
+			executionData: emptyExecutionData,
+		}) as unknown as NodeExecuteAfterContext;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		config.publishedOnly = true;
+		config.includeNodeSpans = true;
+		ownershipService.getWorkflowProjectCached.mockResolvedValue({ id: 'proj-1' } as never);
+		traceContextService.get.mockResolvedValue(undefined);
+		handler = new OtelLifecycleHandler(
+			tracer,
+			traceContextService,
+			config,
+			ownershipService,
+			logger,
+		);
+	});
+
+	it('should skip all tracing for an inactive workflow when publishedOnly is true', async () => {
+		await handler.onWorkflowStart(makeWorkflowStartCtx(inactiveWorkflow));
+		handler.onWorkflowEnd(makeWorkflowEndCtx(inactiveWorkflow));
+		handler.onNodeStart(makeNodeStartCtx(inactiveWorkflow));
+		handler.onNodeEnd(makeNodeEndCtx(inactiveWorkflow));
+
+		expect(tracer.startWorkflow).not.toHaveBeenCalled();
+		expect(traceContextService.persist).not.toHaveBeenCalled();
+		expect(tracer.endWorkflow).not.toHaveBeenCalled();
+		expect(tracer.startNode).not.toHaveBeenCalled();
+		expect(tracer.endNode).not.toHaveBeenCalled();
+	});
+
+	it('should trace an active workflow when publishedOnly is true', async () => {
+		tracer.startWorkflow.mockReturnValue({ traceparent: '00-abc-def-01' });
+
+		await handler.onWorkflowStart(makeWorkflowStartCtx(activeWorkflow));
+
+		expect(tracer.startWorkflow).toHaveBeenCalled();
+		expect(traceContextService.persist).toHaveBeenCalled();
+	});
+
+	it('should trace an inactive workflow when publishedOnly is false', async () => {
+		config.publishedOnly = false;
+		tracer.startWorkflow.mockReturnValue({ traceparent: '00-abc-def-01' });
+
+		await handler.onWorkflowStart(makeWorkflowStartCtx(inactiveWorkflow));
+
+		expect(tracer.startWorkflow).toHaveBeenCalled();
+	});
+
+	it('should also treat activeVersionId as published', async () => {
+		const workflowWithVersionId = { ...inactiveWorkflow, active: false, activeVersionId: 'v123' };
+		tracer.startWorkflow.mockReturnValue({ traceparent: '00-abc-def-01' });
+
+		await handler.onWorkflowStart(makeWorkflowStartCtx(workflowWithVersionId));
+
+		expect(tracer.startWorkflow).toHaveBeenCalled();
 	});
 });
 

--- a/packages/cli/src/modules/otel/__tests__/otel-workflow-tracing.integration.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/otel-workflow-tracing.integration.test.ts
@@ -30,6 +30,7 @@ beforeAll(async () => {
 	savedEnv = saveAndSetEnv({
 		N8N_OTEL_ENABLED: 'true',
 		N8N_OTEL_TRACES_INCLUDE_NODE_SPANS: 'true',
+		N8N_OTEL_TRACES_PUBLISHED_ONLY: 'false',
 	});
 	const env = await initOtelTestEnvironment();
 	otel = env.otel;

--- a/packages/cli/src/modules/otel/otel-lifecycle-handler.ts
+++ b/packages/cli/src/modules/otel/otel-lifecycle-handler.ts
@@ -8,6 +8,7 @@ import type {
 	NodeExecuteAfterContext,
 } from '@n8n/decorators';
 import { Service } from '@n8n/di';
+import type { IWorkflowBase } from 'n8n-workflow';
 
 import { OwnershipService } from '@/services/ownership.service';
 
@@ -25,8 +26,14 @@ export class OtelLifecycleHandler {
 		private readonly logger: Logger,
 	) {}
 
+	private isPublishedWorkflow(workflow: IWorkflowBase): boolean {
+		return !!(workflow.activeVersionId ?? workflow.active);
+	}
+
 	@OnLifecycleEvent('workflowExecuteBefore')
 	async onWorkflowStart(ctx: WorkflowExecuteBeforeContext): Promise<void> {
+		if (this.config.publishedOnly && !this.isPublishedWorkflow(ctx.workflow)) return;
+
 		const parentExecutionId = ctx.executionData?.parentExecution?.executionId;
 		const tracingContext = parentExecutionId
 			? // This will only be set when we are a "sub-workflow"
@@ -64,6 +71,8 @@ export class OtelLifecycleHandler {
 
 	@OnLifecycleEvent('workflowExecuteResume')
 	async onWorkflowResume(ctx: WorkflowExecuteResumeContext): Promise<void> {
+		if (this.config.publishedOnly && !this.isPublishedWorkflow(ctx.workflow)) return;
+
 		const previousWorkflowExecution = await this.traceContextService.get(ctx.executionId);
 
 		const project = await this.ownershipService
@@ -92,6 +101,8 @@ export class OtelLifecycleHandler {
 
 	@OnLifecycleEvent('workflowExecuteAfter')
 	onWorkflowEnd(ctx: WorkflowExecuteAfterContext): void {
+		if (this.config.publishedOnly && !this.isPublishedWorkflow(ctx.workflow)) return;
+
 		this.tracer.endWorkflow({
 			executionId: ctx.executionId,
 			status: ctx.runData.status,
@@ -104,6 +115,7 @@ export class OtelLifecycleHandler {
 
 	@OnLifecycleEvent('nodeExecuteBefore')
 	onNodeStart(ctx: NodeExecuteBeforeContext): void {
+		if (this.config.publishedOnly && !this.isPublishedWorkflow(ctx.workflow)) return;
 		if (!this.config.includeNodeSpans) return;
 
 		const node = ctx.workflow.nodes.find((n) => n.name === ctx.nodeName);
@@ -117,6 +129,7 @@ export class OtelLifecycleHandler {
 
 	@OnLifecycleEvent('nodeExecuteAfter')
 	onNodeEnd(ctx: NodeExecuteAfterContext): void {
+		if (this.config.publishedOnly && !this.isPublishedWorkflow(ctx.workflow)) return;
 		if (!this.config.includeNodeSpans) return;
 
 		const node = ctx.workflow.nodes.find((n) => n.name === ctx.nodeName);

--- a/packages/cli/src/modules/otel/otel.config.ts
+++ b/packages/cli/src/modules/otel/otel.config.ts
@@ -28,4 +28,8 @@ export class OtelConfig {
 
 	@Env('N8N_OTEL_TRACES_INJECT_OUTBOUND')
 	injectOutbound: boolean = true;
+
+	/** When true, only traces executions of published (active) workflows. */
+	@Env('N8N_OTEL_TRACES_PUBLISHED_ONLY')
+	publishedOnly: boolean = true;
 }


### PR DESCRIPTION
## Summary

Demo video: https://www.loom.com/share/80b4aeefac2c4baba45f613efefece7c

Adds new env var `N8N_OTEL_TRACES_PUBLISHED_ONLY` to OtelConfig.

Proof that `ctx.workflow.active` and `ctx.worfklow.activeVersionId` are defined in lifecycle hooks:

<img width="1166" height="739" alt="Screenshot 2026-05-27 at 11 03 28" src="https://github.com/user-attachments/assets/e2b97d21-5983-452e-b0cf-95a1156bccbe" />

### How to test

launch your n8n server with these env vars:
```
N8N_OTEL_ENABLED=true
N8N_OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318
N8N_OTEL_TRACES_PUBLISHED_ONLY=true
```


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-511/track-only-published-workflows-with-otel


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
