### PR TITLE
ci: Fix coverage include/exclude to prevent RolldownErrors

### DIFF
--- a/packages/@n8n/vitest-config/frontend.ts
+++ b/packages/@n8n/vitest-config/frontend.ts
@@ -12,8 +12,7 @@ export const createVitestConfig = (options: InlineConfig = {}) => {
 			outputFile: { junit: './junit.xml' },
 			coverage: {
 				enabled: false,
-				include: ['src/**'],
-				exclude: ['**/*.grammar'],
+				include: ['src/**/*.{ts,vue}'],
 				provider: 'v8',
 				reporter: ['text-summary', 'lcov', 'html-spa'],
 			},

--- a/packages/@n8n/vitest-config/node.ts
+++ b/packages/@n8n/vitest-config/node.ts
@@ -17,8 +17,7 @@ export const createBaseInlineConfig = (options: InlineConfig = {}): InlineConfig
 					enabled: true,
 					provider: 'v8',
 					reporter: process.env.CI === 'true' ? 'cobertura' : 'text-summary',
-					include: ['src/**/*'],
-					exclude: ['**/*.grammar'],
+					include: ['src/**/*.ts'],
 				},
 			}
 		: {}),


### PR DESCRIPTION
## Summary

Excluding grammar files in https://github.com/n8n-io/n8n/pull/31050 wasn't enough as we have multiple other offenders of having non-source files in the `src` directories. Instead, get rid of exclusions and make inclusions on coverage tighter to only include our typescript (and vue) source files.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-231

Fixes [non-blocking rolldownerrors in unit tests](https://github.com/n8n-io/n8n/actions/runs/26505450555/job/78057290204?pr=31187#step:5:338)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
