### PR TITLE
fix(editor): Persist credential selection in NDV

### DIFF
--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.test.ts
@@ -995,6 +995,161 @@ describe('useWorkflowDocumentNodes', () => {
 
 			expect(result).toBe(0);
 		});
+
+		it('fires onStateDirty and syncWorkflowObject for each assigned node', () => {
+			const credential = { id: 'cred-1', name: 'Test Credential' };
+
+			getNodeType.mockReturnValue({
+				credentials: [{ name: 'slackApi', required: true }],
+				inputs: [],
+				group: [],
+				webhooks: [],
+				properties: [],
+			});
+
+			const syncWorkflowObject = vi.fn();
+			const dirtyHandler = vi.fn();
+
+			const workflowDocumentNodes = useWorkflowDocumentNodes({
+				...deps,
+				syncWorkflowObject,
+			});
+			workflowDocumentNodes.onStateDirty(dirtyHandler);
+			workflowDocumentNodes.setNodes([
+				createNode({ name: 'Current Node', type: 'n8n-nodes-base.slack', typeVersion: 1 }),
+				createNode({ name: 'Slack Node 1', type: 'n8n-nodes-base.slack', typeVersion: 1 }),
+				createNode({ name: 'Slack Node 2', type: 'n8n-nodes-base.slack', typeVersion: 1 }),
+			]);
+
+			syncWorkflowObject.mockClear();
+			dirtyHandler.mockClear();
+
+			workflowDocumentNodes.assignCredentialToMatchingNodes({
+				credentials: credential,
+				type: 'slackApi',
+				currentNodeName: 'Current Node',
+			});
+
+			expect(syncWorkflowObject).toHaveBeenCalledTimes(2);
+			expect(dirtyHandler).toHaveBeenCalledTimes(2);
+		});
+	});
+
+	describe('replaceInvalidWorkflowCredentials', () => {
+		it('replaces credentials on every node that referenced the invalid credential by id', () => {
+			const invalid = { id: 'invalid-id', name: 'Old' };
+			const replacement = { id: 'new-id', name: 'New' };
+
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([
+				createNode({ name: 'A', credentials: { slackApi: { ...invalid } } }),
+				createNode({ name: 'B', credentials: { slackApi: { ...invalid } } }),
+				createNode({ name: 'C', credentials: { slackApi: { id: 'other-id', name: 'Other' } } }),
+			]);
+
+			workflowDocumentNodes.replaceInvalidWorkflowCredentials({
+				credentials: replacement,
+				invalid,
+				type: 'slackApi',
+			});
+
+			expect(workflowDocumentNodes.getNodeByName('A')?.credentials?.slackApi).toEqual(replacement);
+			expect(workflowDocumentNodes.getNodeByName('B')?.credentials?.slackApi).toEqual(replacement);
+			expect(workflowDocumentNodes.getNodeByName('C')?.credentials?.slackApi).toEqual({
+				id: 'other-id',
+				name: 'Other',
+			});
+		});
+
+		it('replaces placeholder credentials (id: null) matched by name', () => {
+			const placeholder = { id: null, name: 'Placeholder' };
+			const replacement = { id: 'real-id', name: 'Real' };
+
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.setNodes([
+				createNode({ name: 'A', credentials: { slackApi: placeholder } }),
+			]);
+
+			workflowDocumentNodes.replaceInvalidWorkflowCredentials({
+				credentials: replacement,
+				invalid: placeholder,
+				type: 'slackApi',
+			});
+
+			expect(workflowDocumentNodes.getNodeByName('A')?.credentials?.slackApi).toEqual(replacement);
+		});
+
+		it('fires onStateDirty and syncWorkflowObject for each replaced node', () => {
+			const invalid = { id: 'invalid-id', name: 'Old' };
+			const replacement = { id: 'new-id', name: 'New' };
+
+			const syncWorkflowObject = vi.fn();
+			const dirtyHandler = vi.fn();
+
+			const workflowDocumentNodes = useWorkflowDocumentNodes({
+				...deps,
+				syncWorkflowObject,
+			});
+			workflowDocumentNodes.onStateDirty(dirtyHandler);
+			workflowDocumentNodes.setNodes([
+				createNode({ name: 'A', credentials: { slackApi: { ...invalid } } }),
+				createNode({ name: 'B', credentials: { slackApi: { ...invalid } } }),
+			]);
+
+			syncWorkflowObject.mockClear();
+			dirtyHandler.mockClear();
+
+			workflowDocumentNodes.replaceInvalidWorkflowCredentials({
+				credentials: replacement,
+				invalid,
+				type: 'slackApi',
+			});
+
+			expect(syncWorkflowObject).toHaveBeenCalledTimes(2);
+			expect(dirtyHandler).toHaveBeenCalledTimes(2);
+		});
+
+		// ADO-5299: prior to the fix, `replaceInvalidWorkflowCredentials` mutated
+		// `node.credentials` in place without going through `updateNodeAtIndex`. The
+		// NodeCredentials flow then emitted `credentialSelected` → updateNodeProperties,
+		// which compared the (already-mutated) node against the new value via deep
+		// `isEqual` and saw no change — leaving `onStateDirty` unfired, so autosave
+		// never ran and the new credential silently failed to persist.
+		it('marks state dirty so a subsequent equal updateNodeProperties does not eat the signal', () => {
+			const invalid = { id: null, name: 'Placeholder' };
+			const replacement = { id: 'real-id', name: 'Real' };
+
+			const dirtyHandler = vi.fn();
+			const workflowDocumentNodes = useWorkflowDocumentNodes(deps);
+			workflowDocumentNodes.onStateDirty(dirtyHandler);
+			workflowDocumentNodes.setNodes([
+				createNode({ name: 'A', credentials: { slackApi: { ...invalid } } }),
+			]);
+
+			workflowDocumentNodes.replaceInvalidWorkflowCredentials({
+				credentials: replacement,
+				invalid,
+				type: 'slackApi',
+			});
+
+			const dirtyCountAfterReplace = dirtyHandler.mock.calls.length;
+
+			// Simulate NodeCredentials' follow-up emit('credentialSelected', ...):
+			// builds the credentials object from the (already-mutated) node and routes
+			// it through updateNodeProperties. updateNodeAtIndex's isEqual will see no
+			// change and return false — but the earlier dirty trigger has already fired,
+			// so autosave still runs.
+			const node = workflowDocumentNodes.getNodeByName('A');
+			workflowDocumentNodes.updateNodeProperties({
+				name: 'A',
+				properties: {
+					credentials: { ...(node?.credentials ?? {}), slackApi: replacement },
+				},
+			});
+
+			expect(dirtyHandler.mock.calls.length).toBeGreaterThanOrEqual(dirtyCountAfterReplace);
+			expect(dirtyCountAfterReplace).toBe(1);
+		});
 	});
 
 	describe('port subsystem (nodeInputsByNodeId / nodeOutputsByNodeId)', () => {

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentNodes.ts
@@ -570,7 +570,7 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 		invalid: INodeCredentialsDetails;
 		type: string;
 	}) {
-		nodes.value.forEach((node: INodeUi) => {
+		nodes.value.forEach((node: INodeUi, nodeIndex) => {
 			const nodeCredentials: INodeCredentials | undefined = (node as unknown as INode).credentials;
 			if (!nodeCredentials?.[data.type]) {
 				return;
@@ -578,23 +578,26 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 
 			const nodeCredentialDetails: INodeCredentialsDetails | string = nodeCredentials[data.type];
 
-			if (
-				typeof nodeCredentialDetails === 'string' &&
-				nodeCredentialDetails === data.invalid.name
-			) {
-				(node.credentials as INodeCredentials)[data.type] = data.credentials;
+			const matchesInvalid =
+				(typeof nodeCredentialDetails === 'string' &&
+					nodeCredentialDetails === data.invalid.name) ||
+				(typeof nodeCredentialDetails !== 'string' &&
+					nodeCredentialDetails.id === null &&
+					nodeCredentialDetails.name === data.invalid.name) ||
+				(typeof nodeCredentialDetails !== 'string' &&
+					nodeCredentialDetails.id !== null &&
+					nodeCredentialDetails.id === data.invalid.id);
+
+			if (!matchesInvalid) {
 				return;
 			}
 
-			if (nodeCredentialDetails.id === null) {
-				if (nodeCredentialDetails.name === data.invalid.name) {
-					(node.credentials as INodeCredentials)[data.type] = data.credentials;
-				}
-				return;
-			}
+			const changed = updateNodeAtIndex(nodeIndex, {
+				credentials: { ...nodeCredentials, [data.type]: data.credentials },
+			});
 
-			if (nodeCredentialDetails.id === data.invalid.id) {
-				(node.credentials as INodeCredentials)[data.type] = data.credentials;
+			if (changed) {
+				void onStateDirty.trigger();
 			}
 		});
 	}
@@ -607,7 +610,7 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 	}): number {
 		let updatedNodesCount = 0;
 
-		nodes.value.forEach((node: INodeUi) => {
+		nodes.value.forEach((node: INodeUi, nodeIndex) => {
 			// Skip the current node (it was just set)
 			if (node.name === data.currentNodeName) {
 				return;
@@ -644,11 +647,14 @@ export function useWorkflowDocumentNodes(deps: WorkflowDocumentNodesDeps) {
 				return;
 			}
 
-			// Assign the same credential to the node
-			node.credentials ??= {} satisfies INodeCredentials;
-			node.credentials[data.type] = data.credentials;
+			const changed = updateNodeAtIndex(nodeIndex, {
+				credentials: { ...(node.credentials ?? {}), [data.type]: data.credentials },
+			});
 
-			updatedNodesCount++;
+			if (changed) {
+				void onStateDirty.trigger();
+				updatedNodesCount++;
+			}
 		});
 
 		return updatedNodesCount;


### PR DESCRIPTION
## Summary

- Route `replaceInvalidWorkflowCredentials` and `assignCredentialToMatchingNodes` through `updateNodeAtIndex` so credential changes sync the workflow object and fire `onStateDirty`.
- Direct in-place mutation of `node.credentials` caused `NodeCredentials.vue`'s follow-up `updateNodeProperties` emit to deep-compare the (already-mutated) node to itself and skip firing the dirty signal — autosave never ran and the selection was silently lost.

Same root cause pattern as ADO-5197 (Resource Mapper field deletions): mutations that bypass `updateNodeAtIndex` short-circuit downstream change detection.

Linear: https://linear.app/n8n/issue/ADO-5299

## Test plan

- [x] `pnpm exec vitest run src/app/stores/workflowDocument/useWorkflowDocumentNodes.test.ts` — 80 passing (5 new assertions covering `onStateDirty` + `syncWorkflowObject` invocations and a regression test that locks in the dirty signal across the credential-replace → update-properties chain).
- [x] `pnpm exec vitest run src/app/stores/workflowDocument.store.test.ts src/features/credentials/components/NodeCredentials.test.ts src/features/ndv/settings/components/NodeSettings.test.ts` — green.
- [x] `pnpm typecheck`
- [ ] Manual: open NDV on a node, switch credential, save & reopen → selection persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)