### PR TITLE
fix(editor): Clear pin data on workspace initialization of production execution

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -3060,12 +3060,16 @@ export function useCanvasOperations() {
 			toast.showMessage({ title, message, type: 'error', duration: 0 });
 		}
 
-		await initializeWorkspace(data.workflowData);
+		const { workflowDocumentStore: openedDocumentStore } = await initializeWorkspace(
+			data.workflowData,
+		);
 
 		workflowState.setWorkflowExecutionData(data);
 
 		if (!['manual', 'evaluation'].includes(data.mode)) {
-			workflowDocumentStore.value.setPinData({});
+			// Clear on the store initializeWorkspace just populated — injection
+			// may resolve to a different store than the one initState wrote to.
+			openedDocumentStore.setPinData({});
 		}
 
 		if (nodeId) {


### PR DESCRIPTION
## Summary

Fixes a regression from #30077 (d5d290d706) where the production-execution canvas preview shows pin icons and data on nodes even though pin data should be hidden for non-manual / non-evaluation runs.

### How to test

1. Open a workflow that has pin data on at least one node.
2. Trigger a production execution (webhook / schedule / etc.).
3. Open the workflow's **Executions** tab and select the production execution.
4. Verify the canvas does **not** show pin icons or "manual" labels on the nodes, and we show the execution data (instead of pin data) on master.
5. Open a manual execution from the same list and verify pin icons still display as expected.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5253/community-issue-pinned-data-shown-in-execution-view-instead-of-actual
Fixes #30771 

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI