### PR TITLE
fix(core): Make AI tool nodes continue on error by default

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.test.ts
@@ -1,4 +1,5 @@
 import { DynamicTool } from '@langchain/classic/tools';
+import { JsTaskRunnerSandbox } from 'n8n-nodes-base/dist/nodes/Code/JsTaskRunnerSandbox';
 import {
 	type IExecuteFunctions,
 	type INode,
@@ -8,6 +9,8 @@ import {
 import { mock } from 'vitest-mock-extended';
 
 import { ToolCode } from './ToolCode.node';
+
+vi.mock('n8n-nodes-base/dist/nodes/Code/JsTaskRunnerSandbox');
 
 describe('ToolCode', () => {
 	describe('supplyData', () => {
@@ -206,6 +209,88 @@ describe('ToolCode', () => {
 				],
 			]);
 			expect(DynamicTool.prototype.invoke).toHaveBeenCalledTimes(2);
+		});
+
+		it('should throw when the code throws so the engine records the tool failure', async () => {
+			const node = new ToolCode();
+			const inputData: INodeExecutionData[] = [{ json: { query: 'test query' } }];
+
+			vi.mocked(JsTaskRunnerSandbox).mockImplementation(
+				() =>
+					({
+						runCodeForTool: vi.fn().mockRejectedValue(new Error('boom')),
+					}) as unknown as JsTaskRunnerSandbox,
+			);
+
+			const mockExecute = mock<IExecuteFunctions>({
+				getInputData: vi.fn(() => inputData),
+				getNode: vi.fn(() => mock<INode>({ typeVersion: 1.2, name: 'test tool' })),
+				getNodeParameter: vi.fn().mockImplementation((paramName) => {
+					switch (paramName) {
+						case 'description':
+							return 'description text';
+						case 'name':
+							return 'wrong_field';
+						case 'specifyInputSchema':
+							return false;
+						case 'language':
+							return 'javaScript';
+						case 'jsCode':
+							return 'throw new Error("boom");';
+						default:
+							return;
+					}
+				}),
+				// @ts-expect-error - Mocking
+				getMode: vi.fn(() => 'manual'),
+			});
+
+			DynamicTool.prototype.invoke = vi.fn(async function (this: DynamicTool, args: unknown) {
+				return await this.func(args as string);
+			});
+
+			// @ts-expect-error - Mocking
+			await expect(node.execute.call(mockExecute)).rejects.toThrow(/boom/);
+		});
+
+		it('should keep returning error string when invoked via supplyData (legacy path)', async () => {
+			const node = new ToolCode();
+
+			vi.mocked(JsTaskRunnerSandbox).mockImplementation(
+				() =>
+					({
+						runCodeForTool: vi.fn().mockRejectedValue(new Error('boom')),
+					}) as unknown as JsTaskRunnerSandbox,
+			);
+
+			const mockSupply = mock<ISupplyDataFunctions>({
+				getNode: vi.fn(() => mock<INode>({ typeVersion: 1.2, name: 'test tool' })),
+				getNodeParameter: vi.fn().mockImplementation((paramName) => {
+					switch (paramName) {
+						case 'description':
+							return 'description text';
+						case 'name':
+							return 'wrong_field';
+						case 'specifyInputSchema':
+							return false;
+						case 'language':
+							return 'javaScript';
+						case 'jsCode':
+							return 'throw new Error("boom");';
+						default:
+							return;
+					}
+				}),
+				// @ts-expect-error - Mocking
+				getMode: vi.fn(() => 'manual'),
+				addInputData: vi.fn(() => ({ index: 0 })),
+				addOutputData: vi.fn(),
+			});
+
+			const supplyDataResult = await node.supplyData.call(mockSupply, 0);
+			const tool = supplyDataResult.response as DynamicTool;
+
+			await expect(tool.func('query')).resolves.toMatch(/There was an error/);
 		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.test.ts
@@ -263,31 +263,30 @@ describe('ToolCode', () => {
 					}) as unknown as JsTaskRunnerSandbox,
 			);
 
-			const mockSupply = mock<ISupplyDataFunctions>({
-				getNode: vi.fn(() => mock<INode>({ typeVersion: 1.2, name: 'test tool' })),
-				getNodeParameter: vi.fn().mockImplementation((paramName) => {
-					switch (paramName) {
-						case 'description':
-							return 'description text';
-						case 'name':
-							return 'wrong_field';
-						case 'specifyInputSchema':
-							return false;
-						case 'language':
-							return 'javaScript';
-						case 'jsCode':
-							return 'throw new Error("boom");';
-						default:
-							return;
-					}
+			const supplyDataResult = await node.supplyData.call(
+				mock<ISupplyDataFunctions>({
+					getNode: vi.fn(() => mock<INode>({ typeVersion: 1.2, name: 'test tool' })),
+					getNodeParameter: vi.fn().mockImplementation((paramName, _itemIndex) => {
+						switch (paramName) {
+							case 'description':
+								return 'description text';
+							case 'name':
+								return 'wrong_field';
+							case 'specifyInputSchema':
+								return false;
+							case 'language':
+								return 'javaScript';
+							case 'jsCode':
+								return 'throw new Error("boom");';
+							default:
+								return;
+						}
+					}),
+					addInputData: vi.fn(() => ({ index: 0 })),
+					addOutputData: vi.fn(),
 				}),
-				// @ts-expect-error - Mocking
-				getMode: vi.fn(() => 'manual'),
-				addInputData: vi.fn(() => ({ index: 0 })),
-				addOutputData: vi.fn(),
-			});
-
-			const supplyDataResult = await node.supplyData.call(mockSupply, 0);
+				0,
+			);
 			const tool = supplyDataResult.response as DynamicTool;
 
 			await expect(tool.func('query')).resolves.toMatch(/There was an error/);

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolCode/ToolCode.node.ts
@@ -121,6 +121,14 @@ function getTool(
 			void ctx.addOutputData(NodeConnectionTypes.AiTool, index, [[{ json: { response } }]]);
 		}
 
+		// When invoked from `execute` (log=false) the engine, not the agent, is
+		// driving execution: throw so workflow-execute can record the error
+		// against the tool run. Continue-on-fail for AI tools still lets the
+		// agent receive the error and decide whether to retry.
+		if (executionError && !log) {
+			throw executionError;
+		}
+
 		return response;
 	};
 

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/ToolWorkflowV2.test.ts
@@ -191,6 +191,31 @@ describe('WorkflowTool::WorkflowToolService', () => {
 			expect(result).toContain('There was an error');
 			expect(context.addOutputData).toHaveBeenCalled();
 		});
+
+		it('should throw on tool error when manualLogging is false so the engine records the failure', async () => {
+			const toolParams = {
+				ctx: context,
+				name: 'TestTool',
+				description: 'Test Description',
+				itemIndex: 0,
+				manualLogging: false,
+			};
+
+			vi.spyOn(context, 'executeWorkflow').mockRejectedValueOnce(
+				new Error('Workflow execution failed'),
+			);
+			vi.spyOn(context, 'addInputData').mockReturnValue({ index: 0 });
+			vi.spyOn(context, 'getNodeParameter').mockReturnValue('database');
+			vi.spyOn(context, 'getWorkflowDataProxy').mockReturnValue({
+				$execution: { id: 'exec-id' },
+				$workflow: { id: 'workflow-id' },
+			} as unknown as IWorkflowDataProxyData);
+			vi.spyOn(context, 'cloneWith').mockReturnValue(context);
+
+			const tool = await service.createTool(toolParams);
+
+			await expect(tool.func('test query')).rejects.toThrow(/Workflow execution failed/);
+		});
 	});
 
 	describe('handleToolResponse', () => {

--- a/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/utils/WorkflowToolService.ts
+++ b/packages/@n8n/nodes-langchain/nodes/tools/ToolWorkflow/v2/utils/WorkflowToolService.ts
@@ -202,6 +202,14 @@ export class WorkflowToolService {
 					}
 
 					if (tryIndex === maxTries - 1) {
+						// When called by the engine (manualLogging=false), throw so
+						// workflow-execute records the failure against this tool run.
+						// Continue-on-fail for AI tools still surfaces the error to the
+						// agent so it can iterate. The legacy agent-direct path keeps
+						// returning the error string for backwards compatibility.
+						if (!manualLogging) {
+							throw executionError;
+						}
 						return errorResponse;
 					}
 				}

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1956,14 +1956,28 @@ export class WorkflowExecute {
 							},
 						]);
 
+						// AI tools default to continue-on-fail: the agent should receive the
+						// error as a tool response so it can retry or give up. Workflow keeps
+						// running and the canvas still shows the failure because
+						// taskData.executionStatus stays 'error' (set above).
+						const isAiToolExecution =
+							executionNode.rewireOutputLogTo === NodeConnectionTypes.AiTool;
+
 						if (
 							executionData.node.continueOnFail === true ||
 							['continueRegularOutput', 'continueErrorOutput'].includes(
 								executionData.node.onError || '',
-							)
+							) ||
+							isAiToolExecution
 						) {
 							// Workflow should continue running even if node errors
-							if (Object.hasOwn(executionData.data, 'main') && executionData.data.main.length > 0) {
+							if (isAiToolExecution) {
+								// Surface the error on the ai_tool channel so the agent receives it
+								nodeSuccessData = [[{ json: { error: executionError.message } }]];
+							} else if (
+								Object.hasOwn(executionData.data, 'main') &&
+								executionData.data.main.length > 0
+							) {
 								// Simply get the input data of the node if it has any and pass it through
 								// to the next node
 								if (executionData.data.main[0] !== null) {

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -1956,19 +1956,20 @@ export class WorkflowExecute {
 							},
 						]);
 
-						// AI tools default to continue-on-fail: the agent should receive the
-						// error as a tool response so it can retry or give up. Workflow keeps
-						// running and the canvas still shows the failure because
-						// taskData.executionStatus stays 'error' (set above).
+						// AI tools default to continue-on-fail so the agent receives the
+						// error as a tool response. Explicit `onError: 'stopWorkflow'`
+						// still wins.
 						const isAiToolExecution =
 							executionNode.rewireOutputLogTo === NodeConnectionTypes.AiTool;
+						const aiToolDefaultsToContinue =
+							isAiToolExecution && executionData.node.onError !== 'stopWorkflow';
 
 						if (
 							executionData.node.continueOnFail === true ||
 							['continueRegularOutput', 'continueErrorOutput'].includes(
 								executionData.node.onError || '',
 							) ||
-							isAiToolExecution
+							aiToolDefaultsToContinue
 						) {
 							// Workflow should continue running even if node errors
 							if (isAiToolExecution) {

--- a/packages/frontend/editor-ui/src/app/stores/executionData.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/executionData.store.test.ts
@@ -633,6 +633,20 @@ describe('executionData.store', () => {
 			expect(store.executionIssuesByNodeName.get('NodeA')?.value).toEqual(['e1 (d1)', 'e2 (d2)']);
 		});
 
+		it('hides earlier errors when the latest task succeeded (AI tool retry)', async () => {
+			const store = useExecutionDataStore(createExecutionDataId('exec-1'));
+
+			setExecutionWithRunData(store, {
+				NodeA: [
+					{ executionStatus: 'error', error: { message: 'wrong password' } },
+					{ executionStatus: 'success' },
+				],
+			});
+			await flushPromises();
+
+			expect(store.executionIssuesByNodeName.get('NodeA')?.value).toEqual([]);
+		});
+
 		it('returns [] when a node has tasks but no errors', async () => {
 			const store = useExecutionDataStore(createExecutionDataId('exec-1'));
 

--- a/packages/frontend/editor-ui/src/app/stores/executionData.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/executionData.store.ts
@@ -84,6 +84,10 @@ export function useExecutionDataStore(id: ExecutionDataId) {
 		function computeNodeExecutionIssues(nodeName: string): string[] {
 			const tasks = executionRunData.value?.[nodeName];
 			if (!tasks) return [];
+			// If the latest run succeeded, hide errors from earlier runs. This
+			// matters for AI tools the agent retries: a failure followed by a
+			// successful retry should leave the canvas in the success state.
+			if (tasks.at(-1)?.executionStatus === 'success') return [];
 			const issues: string[] = [];
 			for (const task of tasks) {
 				if (task?.error) {


### PR DESCRIPTION
## Summary

When an AI tool fails, the agent should be able to receive the error, decide whether to retry, and continue iterating — while the canvas accurately reflects the tool's failed state. Previously, the workflow either halted on tool errors, or (for tools that internally caught and returned error strings like `ToolCode`, `ToolWorkflow`) the canvas showed a green check even though the call had errored.

### What changed

- **Engine (`workflow-execute.ts`)**: Nodes executed as AI tools (`rewireOutputLogTo === 'ai_tool'`) now default to continue-on-fail. On error, the engine still records `executionStatus: 'error'` and `taskData.error` (canvas shows red), but surfaces `{ error: message }` on the `ai_tool` output channel so the agent receives it via `EngineResponse`. Workflow does not halt. **`onError: 'stopWorkflow'` is still honored** — if the user explicitly opts in (e.g. via the public/MCP API), the engine falls through to the stop branch and aborts the workflow as before.
- **`ToolCode.node.ts` / `WorkflowToolService.ts`**: When invoked by the engine (V3 path, `log=false` / `manualLogging=false`), the inner tool handlers now throw instead of swallowing errors as `"There was an error: ..."` strings. The engine catches and handles the failure. The legacy V1/V2 agent-direct-invoke path (`log=true` / `manualLogging=true`) keeps returning the error string for backwards compatibility.
- **Editor UI (`executionData.store.ts`)**: When a node's latest task succeeded, errors from earlier tasks are hidden. This matters for the agent-retry pattern: a failure followed by a successful retry now leaves the canvas in the success state instead of being stuck red.

### Scope

In scope: **Code Tool** (`ToolCode`) and **Workflow Tool v2** (`ToolWorkflowV2`) — the two tools that implement `execute()` and previously swallowed errors into success strings, causing the green-check-on-failure UX.

Out of scope: **HTTP Request Tool** (`ToolHttpRequest`). It does not implement `execute()`, so the V3 engine path never dispatches to it — the agent calls its `tool.func()` directly via LangChain. Functionally it already returns the error to the agent (no workflow halt), but the canvas still shows green on a failed HTTP call. Bringing it to parity needs an `execute()` method on the node, which is a separate change. Tracked as a follow-up.

### How to test

1. Build an AI Agent workflow with an OpenAI/Anthropic chat model and a Code Tool whose code throws (e.g., `throw new Error('boom')`).
2. Run the workflow.
3. Confirm the tool node turns red with the error message, the workflow does not halt, and the agent receives the error in its observation.
4. For the retry path: have the tool throw on a wrong input and succeed on a correct input (e.g., a password check). After the agent retries with the correct value, the canvas should end on a green check.
5. For the explicit opt-out: set `onError: 'stopWorkflow'` on the tool node (via the public/MCP API, since the canvas UI hides the setting for sub-nodes today). Trigger a tool error and confirm the workflow halts as it did before this PR.

### Tests

- Added 2 unit tests in `ToolCode.node.test.ts` covering throw-on-engine-path and legacy error-string return on supplyData.
- Added 1 unit test in `ToolWorkflowV2.test.ts` covering `manualLogging=false` throwing.
- Added 1 store test in `executionData.store.test.ts` covering `[error, success]` retry surfacing as no issues.
- All existing tests pass: `packages/core` (1807), `packages/@n8n/nodes-langchain` tools+agents (260), editor-ui store + canvas-mapping (39 + 84).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2511

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)