### PR TITLE
fix(core): Sort MCP search_workflows by most recently edited

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/search-workflows.tool.test.ts
@@ -145,6 +145,28 @@ describe('search-workflows MCP tool', () => {
 			});
 		});
 
+		test('defaults to sorting by most recently updated first', async () => {
+			const workflowService = mockInstance(WorkflowService, {
+				getMany: jest.fn().mockResolvedValue({ workflows: [], count: 0 }),
+			});
+			await searchWorkflows(user, workflowService as unknown as WorkflowService, {});
+
+			const [, optionsArg] = (workflowService.getMany as jest.Mock).mock.calls[0];
+			expect(optionsArg.sortBy).toBe('updatedAt:desc');
+		});
+
+		test('passes through explicit sortBy option', async () => {
+			const workflowService = mockInstance(WorkflowService, {
+				getMany: jest.fn().mockResolvedValue({ workflows: [], count: 0 }),
+			});
+			await searchWorkflows(user, workflowService as unknown as WorkflowService, {
+				sortBy: 'name:asc',
+			});
+
+			const [, optionsArg] = (workflowService.getMany as jest.Mock).mock.calls[0];
+			expect(optionsArg.sortBy).toBe('name:asc');
+		});
+
 		test('clamps non-positive limit up to 1', async () => {
 			const workflowService = mockInstance(WorkflowService, {
 				getMany: jest.fn().mockResolvedValue({ workflows: [], count: 0 }),

--- a/packages/cli/src/modules/mcp/mcp.types.ts
+++ b/packages/cli/src/modules/mcp/mcp.types.ts
@@ -24,10 +24,22 @@ export type ToolDefinition<InputArgs extends z.ZodRawShape = z.ZodRawShape> = {
 };
 
 // Shared MCP tool types
+export const SEARCH_WORKFLOWS_SORT_BY_VALUES = [
+	'updatedAt:desc',
+	'updatedAt:asc',
+	'createdAt:desc',
+	'createdAt:asc',
+	'name:asc',
+	'name:desc',
+] as const;
+
+export type SearchWorkflowsSortBy = (typeof SEARCH_WORKFLOWS_SORT_BY_VALUES)[number];
+
 export type SearchWorkflowsParams = {
 	limit?: number;
 	query?: string;
 	projectId?: string;
+	sortBy?: SearchWorkflowsSortBy;
 };
 
 export type SearchWorkflowsItem = {

--- a/packages/cli/src/modules/mcp/tools/search-workflows.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/search-workflows.tool.ts
@@ -2,11 +2,13 @@ import { type User, type WorkflowEntity } from '@n8n/db';
 import z from 'zod';
 
 import { USER_CALLED_MCP_TOOL_EVENT } from '../mcp.constants';
+import { SEARCH_WORKFLOWS_SORT_BY_VALUES } from '../mcp.types';
 import type {
 	ToolDefinition,
 	SearchWorkflowsParams,
 	SearchWorkflowsResult,
 	SearchWorkflowsItem,
+	SearchWorkflowsSortBy,
 	UserCalledMCPToolEventPayload,
 } from '../mcp.types';
 
@@ -17,10 +19,18 @@ import { createLimitSchema } from './schemas';
 
 const MAX_RESULTS = 200;
 
+const DEFAULT_SORT_BY: SearchWorkflowsSortBy = 'updatedAt:desc';
+
 const inputSchema = {
 	limit: createLimitSchema(MAX_RESULTS),
 	query: z.string().optional().describe('Filter by name or description'),
 	projectId: z.string().optional(),
+	sortBy: z
+		.enum(SEARCH_WORKFLOWS_SORT_BY_VALUES)
+		.optional()
+		.describe(
+			`Sort order for results (default: ${DEFAULT_SORT_BY}). Use updatedAt:desc to find the most recently edited workflows first.`,
+		),
 } satisfies z.ZodRawShape;
 
 const outputSchema = {
@@ -38,7 +48,9 @@ const outputSchema = {
 				updatedAt: z
 					.string()
 					.nullable()
-					.describe('The ISO timestamp when the workflow was last updated'),
+					.describe(
+						'ISO timestamp the workflow definition was last saved. Use this to identify recently edited workflows.',
+					),
 				triggerCount: z
 					.number()
 					.nullable()
@@ -82,12 +94,14 @@ export const createSearchWorkflowsTool = (
 			limit = MAX_RESULTS,
 			query,
 			projectId,
+			sortBy,
 		}: {
 			limit?: number;
 			query?: string;
 			projectId?: string;
+			sortBy?: SearchWorkflowsSortBy;
 		}) => {
-			const parameters = { limit, query, projectId };
+			const parameters = { limit, query, projectId, sortBy };
 			const telemetryPayload: UserCalledMCPToolEventPayload = {
 				user_id: user.id,
 				tool_name: 'search_workflows',
@@ -99,6 +113,7 @@ export const createSearchWorkflowsTool = (
 					limit,
 					query,
 					projectId,
+					sortBy,
 				});
 
 				// Track successful execution
@@ -136,12 +151,13 @@ export const createSearchWorkflowsTool = (
 export async function searchWorkflows(
 	user: User,
 	workflowService: WorkflowService,
-	{ limit = MAX_RESULTS, query, projectId }: SearchWorkflowsParams,
+	{ limit = MAX_RESULTS, query, projectId, sortBy = DEFAULT_SORT_BY }: SearchWorkflowsParams,
 ): Promise<SearchWorkflowsResult> {
 	const safeLimit = Math.min(Math.max(1, limit), MAX_RESULTS);
 
 	const options: ListQuery.Options = {
 		take: safeLimit,
+		sortBy,
 		filter: {
 			isArchived: false,
 			...(query ? { query } : {}),


### PR DESCRIPTION
## Summary

The `search_workflows` MCP tool relied on the workflow repository's default sort, which is `updatedAt ASC`. With the 200-result page size, the most recently edited workflows fell past the page boundary, so agents asking "what did I last edit?" got workflows from months ago.

Changes:
- Default the MCP tool to `updatedAt:desc` so most recently edited workflows come first.
- Expose a `sortBy` input (`updatedAt`, `createdAt`, `name` paired with `asc`/`desc`) so agents can request other orderings explicitly.
- Tighten the `updatedAt` field description to make its meaning unambiguous to LLM clients.

Tested manually via Claude Code MCP against a local instance:

| Probe | First result `updatedAt` | Result |
| --- | --- | --- |
| no `sortBy` | most recent (today) | newest first |
| `sortBy: updatedAt:asc` | oldest | oldest first (reproduces the original bug on demand) |
| `sortBy: name:asc` | alpha | case-folded alpha order |

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5293

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)