### PR TITLE
fix(Microsoft Teams Trigger Node): Trigger on messages in channels created after activation

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Teams/MicrosoftTeamsTrigger.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/MicrosoftTeamsTrigger.node.ts
@@ -408,14 +408,131 @@ export class MicrosoftTeamsTrigger implements INodeType {
 		}
 
 		const eventNotifications = req.body.value as WebhookNotification[];
+		const triggerEvent = this.getNodeParameter('event', 0) as string;
+		const notificationsToEmit =
+			triggerEvent === 'newChannelMessage'
+				? await handleChannelNotifications.call(this, eventNotifications)
+				: eventNotifications;
+
+		if (notificationsToEmit.length === 0) {
+			return { noWebhookResponse: true };
+		}
+
 		const response: IWebhookResponseData = {
-			workflowData: eventNotifications.map((event) => [
+			workflowData: notificationsToEmit.map((notification) => [
 				{
-					json: (event.resourceData as IDataObject) ?? event,
+					json: (notification.resourceData as IDataObject) ?? notification,
 				} as INodeExecutionData,
 			]),
 		};
 
 		return response;
 	}
+}
+
+/** Uses the channel-list subscription as a maintenance signal for newly created channels. */
+async function handleChannelNotifications(
+	this: IWebhookFunctions,
+	notifications: WebhookNotification[],
+): Promise<WebhookNotification[]> {
+	const webhookData = this.getWorkflowStaticData('node');
+	const webhookUrl = this.getNodeWebhookUrl('default');
+	const webhookSecret = webhookData.webhookSecret;
+	const subscriptionIds = getStringArray(webhookData.subscriptionIds);
+	const notificationsToEmit: WebhookNotification[] = [];
+	const createdSubscriptionIds: string[] = [];
+
+	for (const notification of notifications) {
+		if (!isChannelNotification(notification)) {
+			notificationsToEmit.push(notification);
+			continue;
+		}
+
+		if (notification.changeType !== 'created') {
+			continue;
+		}
+
+		const channelMessageResource = getChannelMessageResource(notification);
+
+		if (!channelMessageResource) {
+			continue;
+		}
+
+		if (!webhookUrl || typeof webhookSecret !== 'string') {
+			this.logger.warn('Cannot create Microsoft Teams channel message subscription', {
+				hasWebhookUrl: Boolean(webhookUrl),
+				hasWebhookSecret: typeof webhookSecret === 'string',
+			});
+			continue;
+		}
+
+		try {
+			if (await hasSubscriptionForResource.call(this, webhookUrl, channelMessageResource)) {
+				continue;
+			}
+
+			const subscription = await createSubscription.call(
+				this,
+				webhookUrl,
+				channelMessageResource,
+				webhookSecret,
+			);
+			createdSubscriptionIds.push(subscription.id);
+		} catch (error) {
+			this.logger.warn('Failed to create Microsoft Teams channel message subscription', {
+				error,
+			});
+		}
+	}
+
+	if (createdSubscriptionIds.length > 0) {
+		webhookData.subscriptionIds = [...subscriptionIds, ...createdSubscriptionIds];
+	}
+
+	return notificationsToEmit;
+}
+
+/** Converts a channel-created notification into the channel-message subscription resource. */
+function getChannelMessageResource(notification: WebhookNotification): string | undefined {
+	const oDataId = notification.resourceData?.['@odata.id'];
+	const resource = typeof oDataId === 'string' ? oDataId : notification.resource;
+	const match = resource.match(/^teams\('([^']+)'\)\/channels\('([^']+)'\)$/);
+
+	if (!match) {
+		return undefined;
+	}
+
+	const [, teamId, channelId] = match;
+	return `/teams/${teamId}/channels/${channelId}/messages`;
+}
+
+/** Identifies maintenance notifications emitted by the channel-list subscription. */
+function isChannelNotification(notification: WebhookNotification): boolean {
+	return notification.resourceData?.['@odata.type'] === '#Microsoft.Graph.channel';
+}
+
+/** Checks Graph before creating a late-bound subscription so retry delivery stays idempotent. */
+async function hasSubscriptionForResource(
+	this: IWebhookFunctions,
+	webhookUrl: string,
+	resource: string,
+): Promise<boolean> {
+	const subscriptions = (await microsoftApiRequestAllItems.call(
+		this,
+		'value',
+		'GET',
+		'/v1.0/subscriptions',
+	)) as SubscriptionResponse[];
+
+	return subscriptions.some(
+		(subscription) =>
+			subscription.notificationUrl === webhookUrl && subscription.resource === resource,
+	);
+}
+
+/** Reads existing subscription IDs from static data without trusting the stored shape. */
+function getStringArray(value: unknown): string[] {
+	return Array.isArray(value)
+		? value.filter((item): item is string => typeof item === 'string')
+		: [];
 }

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/MicrosoftTeamTrigger.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/MicrosoftTeamTrigger.test.ts
@@ -17,6 +17,9 @@ describe('Microsoft Teams Trigger Node', () => {
 
 	beforeEach(() => {
 		mockWebhookFunctions = mock();
+		mockWebhookFunctions.logger = {
+			warn: jest.fn(),
+		};
 		jest.clearAllMocks();
 	});
 
@@ -340,6 +343,295 @@ describe('Microsoft Teams Trigger Node', () => {
 
 			expect(mockResponse.status).not.toHaveBeenCalledWith(401);
 			expect(result.workflowData).toEqual([[{ json: { id: '1' } }]]);
+		});
+
+		it('should create a channel message subscription and not emit channel notifications', async () => {
+			const staticData: {
+				subscriptionIds: string[];
+				webhookSecret: string;
+			} = {
+				subscriptionIds: ['channel-list-subscription'],
+				webhookSecret: 'expected-secret',
+			};
+			const mockRequest = {
+				body: {
+					value: [
+						{
+							changeType: 'created',
+							clientState: 'expected-secret',
+							resource: "teams('team123')/channels('channel123')",
+							resourceData: {
+								id: 'channel123',
+								'@odata.type': '#Microsoft.Graph.channel',
+								'@odata.id': "teams('team123')/channels('channel123')",
+							},
+						},
+					],
+				},
+				query: {},
+			};
+			const mockResponse = {
+				status: jest.fn().mockReturnThis(),
+				send: jest.fn(),
+				end: jest.fn(),
+			};
+
+			(microsoftApiRequestAllItems.call as jest.Mock).mockResolvedValueOnce([]);
+			(microsoftApiRequest.call as jest.Mock).mockResolvedValueOnce({
+				id: 'channel-message-subscription',
+			});
+
+			mockWebhookFunctions.getRequestObject.mockReturnValue(mockRequest);
+			mockWebhookFunctions.getResponseObject.mockReturnValue(mockResponse);
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue(staticData);
+			mockWebhookFunctions.getNodeWebhookUrl.mockReturnValue('https://webhook.url');
+			mockWebhookFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+				if (paramName === 'event') return 'newChannelMessage';
+				return undefined;
+			});
+
+			const result = await new MicrosoftTeamsTrigger().webhook.call(mockWebhookFunctions);
+
+			expect(result.noWebhookResponse).toBe(true);
+			expect(result.workflowData).toBeUndefined();
+			expect(microsoftApiRequest.call).toHaveBeenCalledWith(
+				mockWebhookFunctions,
+				'POST',
+				'/v1.0/subscriptions',
+				expect.objectContaining({
+					notificationUrl: 'https://webhook.url',
+					resource: '/teams/team123/channels/channel123/messages',
+					clientState: 'expected-secret',
+				}),
+			);
+			expect(staticData.subscriptionIds).toEqual([
+				'channel-list-subscription',
+				'channel-message-subscription',
+			]);
+		});
+
+		it('should ignore deleted channel notifications', async () => {
+			const mockRequest = {
+				body: {
+					value: [
+						{
+							changeType: 'deleted',
+							clientState: 'expected-secret',
+							resource: "teams('team123')/channels('channel123')",
+							resourceData: {
+								id: 'channel123',
+								'@odata.type': '#Microsoft.Graph.channel',
+								'@odata.id': "teams('team123')/channels('channel123')",
+							},
+						},
+					],
+				},
+				query: {},
+			};
+			const mockResponse = {
+				status: jest.fn().mockReturnThis(),
+				send: jest.fn(),
+				end: jest.fn(),
+			};
+
+			mockWebhookFunctions.getRequestObject.mockReturnValue(mockRequest);
+			mockWebhookFunctions.getResponseObject.mockReturnValue(mockResponse);
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				webhookSecret: 'expected-secret',
+			});
+			mockWebhookFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+				if (paramName === 'event') return 'newChannelMessage';
+				return undefined;
+			});
+
+			const result = await new MicrosoftTeamsTrigger().webhook.call(mockWebhookFunctions);
+
+			expect(result.noWebhookResponse).toBe(true);
+			expect(result.workflowData).toBeUndefined();
+			expect(microsoftApiRequest.call).not.toHaveBeenCalled();
+		});
+
+		it('should not create duplicate channel message subscriptions', async () => {
+			const mockRequest = {
+				body: {
+					value: [
+						{
+							changeType: 'created',
+							clientState: 'expected-secret',
+							resource: "teams('team123')/channels('channel123')",
+							resourceData: {
+								id: 'channel123',
+								'@odata.type': '#Microsoft.Graph.channel',
+								'@odata.id': "teams('team123')/channels('channel123')",
+							},
+						},
+					],
+				},
+				query: {},
+			};
+			const mockResponse = {
+				status: jest.fn().mockReturnThis(),
+				send: jest.fn(),
+				end: jest.fn(),
+			};
+
+			mockWebhookFunctions.getRequestObject.mockReturnValue(mockRequest);
+			mockWebhookFunctions.getResponseObject.mockReturnValue(mockResponse);
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue({
+				webhookSecret: 'expected-secret',
+			});
+			(microsoftApiRequestAllItems.call as jest.Mock).mockResolvedValueOnce([
+				{
+					id: 'channel-message-subscription',
+					notificationUrl: 'https://webhook.url',
+					resource: '/teams/team123/channels/channel123/messages',
+				},
+			]);
+			mockWebhookFunctions.getNodeWebhookUrl.mockReturnValue('https://webhook.url');
+			mockWebhookFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+				if (paramName === 'event') return 'newChannelMessage';
+				return undefined;
+			});
+
+			const result = await new MicrosoftTeamsTrigger().webhook.call(mockWebhookFunctions);
+
+			expect(result.noWebhookResponse).toBe(true);
+			expect(result.workflowData).toBeUndefined();
+			expect(microsoftApiRequest.call).not.toHaveBeenCalledWith(
+				mockWebhookFunctions,
+				'POST',
+				'/v1.0/subscriptions',
+				expect.anything(),
+			);
+		});
+
+		it('should emit message notifications from a mixed batch', async () => {
+			const staticData: {
+				subscriptionIds: string[];
+				webhookSecret: string;
+			} = {
+				subscriptionIds: ['channel-list-subscription'],
+				webhookSecret: 'expected-secret',
+			};
+			const mockRequest = {
+				body: {
+					value: [
+						{
+							changeType: 'created',
+							clientState: 'expected-secret',
+							resource: "teams('team123')/channels('channel123')",
+							resourceData: {
+								id: 'channel123',
+								'@odata.type': '#Microsoft.Graph.channel',
+								'@odata.id': "teams('team123')/channels('channel123')",
+							},
+						},
+						{
+							changeType: 'created',
+							clientState: 'expected-secret',
+							resource: "teams('team123')/channels('channel123')/messages('message123')",
+							resourceData: {
+								id: 'message123',
+								'@odata.type': '#Microsoft.Graph.chatMessage',
+								'@odata.id': "teams('team123')/channels('channel123')/messages('message123')",
+							},
+						},
+					],
+				},
+				query: {},
+			};
+			const mockResponse = {
+				status: jest.fn().mockReturnThis(),
+				send: jest.fn(),
+				end: jest.fn(),
+			};
+
+			(microsoftApiRequestAllItems.call as jest.Mock).mockResolvedValueOnce([]);
+			(microsoftApiRequest.call as jest.Mock).mockResolvedValueOnce({
+				id: 'channel-message-subscription',
+			});
+
+			mockWebhookFunctions.getRequestObject.mockReturnValue(mockRequest);
+			mockWebhookFunctions.getResponseObject.mockReturnValue(mockResponse);
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue(staticData);
+			mockWebhookFunctions.getNodeWebhookUrl.mockReturnValue('https://webhook.url');
+			mockWebhookFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+				if (paramName === 'event') return 'newChannelMessage';
+				return undefined;
+			});
+
+			const result = await new MicrosoftTeamsTrigger().webhook.call(mockWebhookFunctions);
+
+			expect(result.workflowData).toEqual([
+				[
+					{
+						json: {
+							id: 'message123',
+							'@odata.type': '#Microsoft.Graph.chatMessage',
+							'@odata.id': "teams('team123')/channels('channel123')/messages('message123')",
+						},
+					},
+				],
+			]);
+			expect(staticData.subscriptionIds).toEqual([
+				'channel-list-subscription',
+				'channel-message-subscription',
+			]);
+		});
+
+		it('should log and ack if creating a channel message subscription fails', async () => {
+			const staticData: {
+				subscriptionIds: string[];
+				webhookSecret: string;
+			} = {
+				subscriptionIds: ['channel-list-subscription'],
+				webhookSecret: 'expected-secret',
+			};
+			const mockRequest = {
+				body: {
+					value: [
+						{
+							changeType: 'created',
+							clientState: 'expected-secret',
+							resource: "teams('team123')/channels('channel123')",
+							resourceData: {
+								id: 'channel123',
+								'@odata.type': '#Microsoft.Graph.channel',
+								'@odata.id': "teams('team123')/channels('channel123')",
+							},
+						},
+					],
+				},
+				query: {},
+			};
+			const mockResponse = {
+				status: jest.fn().mockReturnThis(),
+				send: jest.fn(),
+				end: jest.fn(),
+			};
+			const error = new Error('Failed to create subscription');
+
+			(microsoftApiRequestAllItems.call as jest.Mock).mockResolvedValueOnce([]);
+			(microsoftApiRequest.call as jest.Mock).mockRejectedValueOnce(error);
+
+			mockWebhookFunctions.getRequestObject.mockReturnValue(mockRequest);
+			mockWebhookFunctions.getResponseObject.mockReturnValue(mockResponse);
+			mockWebhookFunctions.getWorkflowStaticData.mockReturnValue(staticData);
+			mockWebhookFunctions.getNodeWebhookUrl.mockReturnValue('https://webhook.url');
+			mockWebhookFunctions.getNodeParameter.mockImplementation((paramName: string) => {
+				if (paramName === 'event') return 'newChannelMessage';
+				return undefined;
+			});
+
+			const result = await new MicrosoftTeamsTrigger().webhook.call(mockWebhookFunctions);
+
+			expect(result.noWebhookResponse).toBe(true);
+			expect(result.workflowData).toBeUndefined();
+			expect(staticData.subscriptionIds).toEqual(['channel-list-subscription']);
+			expect(mockWebhookFunctions.logger.warn).toHaveBeenCalledWith(
+				'Failed to create Microsoft Teams channel message subscription',
+				{ error },
+			);
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/utiles-trigger.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/trigger/utiles-trigger.test.ts
@@ -343,6 +343,55 @@ describe('Microsoft Teams Helpers Functions', () => {
 			expect(result).toBe('/teams/team123/channels/channel123/messages');
 		});
 
+		it('should include a channel subscription for newChannelMessage event with watchAllChannels', async () => {
+			mockHookFunctions.getNodeParameter
+				.mockReturnValueOnce(false)
+				.mockReturnValueOnce('team123')
+				.mockReturnValueOnce(true);
+
+			(microsoftApiRequest.call as jest.Mock).mockResolvedValueOnce({
+				value: [
+					{ id: 'channel1', displayName: 'Channel 1' },
+					{ id: 'channel2', displayName: 'Channel 2' },
+				],
+			});
+
+			const result = await getResourcePath.call(mockHookFunctions, 'newChannelMessage');
+
+			expect(result).toEqual([
+				'/teams/team123/channels',
+				'/teams/team123/channels/channel1/messages',
+				'/teams/team123/channels/channel2/messages',
+			]);
+		});
+
+		it('should include channel subscriptions for newChannelMessage event with watchAllTeams', async () => {
+			mockHookFunctions.getNodeParameter.mockReturnValueOnce(true);
+
+			(microsoftApiRequest.call as jest.Mock)
+				.mockResolvedValueOnce({
+					value: [
+						{ id: 'team1', displayName: 'Team 1' },
+						{ id: 'team2', displayName: 'Team 2' },
+					],
+				})
+				.mockResolvedValueOnce({
+					value: [{ id: 'channel1', displayName: 'Channel 1' }],
+				})
+				.mockResolvedValueOnce({
+					value: [{ id: 'channel2', displayName: 'Channel 2' }],
+				});
+
+			const result = await getResourcePath.call(mockHookFunctions, 'newChannelMessage');
+
+			expect(result).toEqual([
+				'/teams/team1/channels',
+				'/teams/team1/channels/channel1/messages',
+				'/teams/team2/channels',
+				'/teams/team2/channels/channel2/messages',
+			]);
+		});
+
 		it('should return the correct resource path for newTeamMember event', async () => {
 			mockHookFunctions.getNodeParameter.mockReturnValueOnce(false);
 			mockHookFunctions.getNodeParameter.mockReturnValueOnce('team123');

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/helpers/types.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/helpers/types.ts
@@ -10,6 +10,7 @@ export interface ChannelResponse {
 
 export interface WebhookNotification {
 	subscriptionId: string;
+	changeType?: string;
 	resource: string;
 	resourceData: ResourceData;
 	tenantId: string;

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/helpers/utils-trigger.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/helpers/utils-trigger.ts
@@ -6,10 +6,14 @@ import type { TeamResponse, ChannelResponse, SubscriptionResponse } from './type
 import { verifySignature as verifySignatureGeneric } from '../../../../../utils/webhook-signature-verification';
 import { microsoftApiRequest } from '../transport';
 
+type SubscriptionContext = IHookFunctions | IWebhookFunctions;
+
+/** Generates the Microsoft Graph clientState secret used to verify webhook notifications. */
 export function generateClientState(): string {
 	return randomBytes(32).toString('hex');
 }
 
+/** Fetches all Microsoft Teams visible to the authenticated account. */
 export async function fetchAllTeams(this: IHookFunctions): Promise<TeamResponse[]> {
 	const { value: teams } = (await microsoftApiRequest.call(
 		this,
@@ -19,6 +23,7 @@ export async function fetchAllTeams(this: IHookFunctions): Promise<TeamResponse[
 	return teams;
 }
 
+/** Fetches all channels for a team so per-channel Graph subscriptions can be created. */
 export async function fetchAllChannels(
 	this: IHookFunctions,
 	teamId: string,
@@ -31,8 +36,9 @@ export async function fetchAllChannels(
 	return channels;
 }
 
+/** Creates a Microsoft Graph change-notification subscription for the given resource path. */
 export async function createSubscription(
-	this: IHookFunctions,
+	this: SubscriptionContext,
 	webhookUrl: string,
 	resourcePath: string,
 	clientState?: string,
@@ -61,6 +67,7 @@ export async function createSubscription(
 	return response;
 }
 
+/** Verifies incoming Microsoft Graph notifications against the stored clientState secret. */
 export function verifyWebhook(this: IWebhookFunctions): boolean {
 	const req = this.getRequestObject();
 	const webhookData = this.getWorkflowStaticData('node');
@@ -87,6 +94,7 @@ export function verifyWebhook(this: IWebhookFunctions): boolean {
 	});
 }
 
+/** Resolves the Graph resource path or paths that must be subscribed for a trigger event. */
 export async function getResourcePath(
 	this: IHookFunctions,
 	event: string,
@@ -133,7 +141,10 @@ export async function getResourcePath(
 				const teamChannels = await Promise.all(
 					teams.map(async (team) => {
 						const channels = await fetchAllChannels.call(this, team.id);
-						return channels.map((channel) => `/teams/${team.id}/channels/${channel.id}/messages`);
+						return [
+							`/teams/${team.id}/channels`,
+							...channels.map((channel) => `/teams/${team.id}/channels/${channel.id}/messages`),
+						];
 					}),
 				);
 				return teamChannels.flat();
@@ -145,7 +156,10 @@ export async function getResourcePath(
 
 				if (watchAllChannels) {
 					const channels = await fetchAllChannels.call(this, teamId);
-					return channels.map((channel) => `/teams/${teamId}/channels/${channel.id}/messages`);
+					return [
+						`/teams/${teamId}/channels`,
+						...channels.map((channel) => `/teams/${teamId}/channels/${channel.id}/messages`),
+					];
 				} else {
 					const channelId = this.getNodeParameter('channelId', undefined, {
 						extractValue: true,

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
@@ -6,13 +6,14 @@ import type {
 	IHttpRequestMethods,
 	IRequestOptions,
 	IHookFunctions,
+	IWebhookFunctions,
 } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
 
 import { capitalize } from '../../../../../utils/utilities';
 
 export async function microsoftApiRequest(
-	this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions,
+	this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions | IWebhookFunctions,
 	method: IHttpRequestMethods,
 	resource: string,
 	body: any = {},
@@ -59,7 +60,7 @@ export async function microsoftApiRequest(
 }
 
 export async function microsoftApiRequestAllItems(
-	this: IExecuteFunctions | ILoadOptionsFunctions,
+	this: IExecuteFunctions | ILoadOptionsFunctions | IWebhookFunctions,
 	propertyName: string,
 	method: IHttpRequestMethods,
 	endpoint: string,


### PR DESCRIPTION
## Summary

When the **New Channel Message** trigger is configured to watch all channels in a team, channels created *after* the workflow was activated did not fire the trigger. Microsoft Graph does not support wildcard subscriptions for channel messages, so only the channels that existed at activation time had a subscription.

This PR adds a channel-list "maintenance" subscription on `/teams/{teamId}/channels`. When a `created` notification for a new channel arrives, the webhook handler creates a message subscription for that channel on the fly and tracks its ID so it is cleaned up on workflow deactivation.

### Changes

- `getResourcePath` now includes `/teams/{teamId}/channels` alongside the per-channel message subscriptions for `newChannelMessage` (both `watchAllChannels` and `watchAllTeams` paths).
- The `webhook()` handler routes channel-maintenance notifications through `handleChannelNotifications`, which:
  - Only acts on `changeType: 'created'` notifications (deleted/updated channels are dropped).
  - Identifies channel notifications via `resourceData['@odata.type'] === '#Microsoft.Graph.channel'`.
  - Checks Microsoft Graph for an existing subscription before POSTing, so notification retries do not produce duplicates.
  - Persists newly created subscription IDs into `workflowStaticData` so they are deleted on workflow deactivation.
  - Filters channel-maintenance notifications out of `workflowData` — users only see the message notifications they configured for.
- `createSubscription` and `microsoftApiRequest*` `this` types widened to accept `IWebhookFunctions` (subscriptions are now also created from the webhook context).


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4078
closes https://github.com/n8n-io/n8n/issues/22575

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
