### PR TITLE
fix(core): Error workflows show up as separate span in otel traces

### DIFF
--- a/packages/cli/src/modules/otel/__tests__/otel-lifecycle-handler.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/otel-lifecycle-handler.test.ts
@@ -134,6 +134,28 @@ describe('OtelLifecycleHandler', () => {
 			);
 		});
 
+		it('should inherit parent tracingContext for error workflows, linking the span to the failed execution', async () => {
+			traceContextService.get.mockResolvedValueOnce(parentTracingContext);
+
+			const ctx: WorkflowExecuteBeforeContext = {
+				...baseCtx,
+				executionId: 'exec-error-workflow',
+				executionData: {
+					parentExecution: { executionId: 'exec-failed', workflowId: 'wf-failed' },
+				} as IRunExecutionData,
+			};
+
+			await handler.onWorkflowStart(ctx);
+
+			// Should look up the failed parent execution's trace context, not the error workflow one
+			expect(traceContextService.get).toHaveBeenCalledTimes(1);
+			expect(traceContextService.get).toHaveBeenCalledWith('exec-failed');
+			expect(traceContextService.get).not.toHaveBeenCalledWith('exec-error-workflow');
+			expect(tracer.startWorkflow).toHaveBeenCalledWith(
+				expect.objectContaining({ tracingContext: parentTracingContext }),
+			);
+		});
+
 		it('should create root span when no own or parent context exists', async () => {
 			traceContextService.get.mockResolvedValue(undefined);
 

--- a/packages/cli/src/modules/otel/otel-lifecycle-handler.ts
+++ b/packages/cli/src/modules/otel/otel-lifecycle-handler.ts
@@ -36,7 +36,7 @@ export class OtelLifecycleHandler {
 
 		const parentExecutionId = ctx.executionData?.parentExecution?.executionId;
 		const tracingContext = parentExecutionId
-			? // This will only be set when we are a "sub-workflow"
+			? // Set for sub-workflows and error workflows to link their spans to the parent
 				await this.traceContextService.get(parentExecutionId)
 			: // This will return "null" if there is no traceparent header in the trigger node. (e.g. webhook)
 				await this.traceContextService.get(ctx.executionId);

--- a/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-execution.service.test.ts
@@ -887,6 +887,7 @@ describe('WorkflowExecutionService', () => {
 										parentExecution: {
 											executionId: 'execution-id',
 											workflowId: 'workflow-id',
+											shouldResume: false,
 										},
 									},
 								},
@@ -898,6 +899,11 @@ describe('WorkflowExecutionService', () => {
 							runData: {},
 						},
 						startData: {},
+						parentExecution: {
+							executionId: 'execution-id',
+							workflowId: 'workflow-id',
+							shouldResume: false,
+						},
 					}),
 					resumeToken: expect.any(String),
 				},

--- a/packages/cli/src/workflows/workflow-execution.service.ts
+++ b/packages/cli/src/workflows/workflow-execution.service.ts
@@ -425,6 +425,7 @@ export class WorkflowExecutionService {
 							executionId: workflowErrorData.execution.id,
 							workflowId: workflowErrorData.workflow.id,
 							executionContext: workflowErrorData.execution.executionContext,
+							shouldResume: false, // Error workflows must not resume the failed parent workflow
 						}
 					: undefined;
 
@@ -454,6 +455,7 @@ export class WorkflowExecutionService {
 				executionData: {
 					nodeExecutionStack,
 				},
+				parentExecution,
 			});
 
 			const runData: IWorkflowExecutionDataProcess = {


### PR DESCRIPTION

## Summary

### Before

Failed workflow and its error workflow show up in two different traces

<img width="832" height="284" alt="image" src="https://github.com/user-attachments/assets/2a2a3cf2-6fcc-408c-8f37-4df287b7c053" />


### After

Fialed workflow and its error workflow show up as one trace.

<img width="834" height="139" alt="image" src="https://github.com/user-attachments/assets/d4ad8d42-7eb9-4c8b-9a4a-40aa5817372d" />


<img width="2463" height="561" alt="image" src="https://github.com/user-attachments/assets/ba3008f6-9526-49f8-9a53-2d1fd59bbbad" />


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
