### PR TITLE
fix(core): Store OAuth CSRF and PKCE state per-flow in the cache

### DIFF
--- a/packages/cli/src/controllers/oauth/__tests__/oauth1-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth1-credential.controller.test.ts
@@ -98,9 +98,10 @@ describe('OAuth1CredentialController', () => {
 			};
 			oauthService.resolveCredential.mockResolvedValueOnce([
 				mockResolvedCredential,
-				{ csrfSecret: 'invalid', oauth_token_secret: 'request-token-secret' },
+				{ csrfSecret: 'invalid' },
 				{ accessTokenUrl: 'https://example.domain/oauth/access_token' },
 				mockState,
+				{ csrfSecret: 'csrf-secret', oauthTokenSecret: 'request-token-secret' },
 			]);
 			oauthService.getOAuth1AccessToken.mockResolvedValueOnce(accessTokenData);
 
@@ -130,6 +131,7 @@ describe('OAuth1CredentialController', () => {
 				{ csrfSecret: 'invalid' },
 				{ accessTokenUrl: 'https://example.domain/oauth/access_token' },
 				mockState,
+				{ csrfSecret: 'csrf-secret' },
 			]);
 			oauthService.getOAuth1AccessToken.mockResolvedValueOnce(accessTokenData);
 
@@ -143,7 +145,6 @@ describe('OAuth1CredentialController', () => {
 						oauth_token_secret: 'secret',
 					}),
 				}),
-				['csrfSecret', 'oauth_token_secret'],
 			);
 			expect(res.render).toHaveBeenCalledWith('oauth-callback');
 		});
@@ -173,6 +174,7 @@ describe('OAuth1CredentialController', () => {
 				{ csrfSecret: 'invalid' },
 				{ accessTokenUrl: 'https://example.domain/oauth/access_token' },
 				mockState,
+				{ csrfSecret: 'csrf-secret' },
 			]);
 			oauthService.getOAuth1AccessToken.mockResolvedValueOnce(accessTokenData);
 			oauthService.saveDynamicCredential.mockResolvedValueOnce(undefined);
@@ -226,6 +228,7 @@ describe('OAuth1CredentialController', () => {
 				{ csrfSecret: 'invalid' },
 				{ accessTokenUrl: 'https://example.domain/oauth/access_token' },
 				mockState,
+				{ csrfSecret: 'csrf-secret' },
 			]);
 			oauthService.getOAuth1AccessToken.mockResolvedValueOnce(accessTokenData);
 			oauthService.saveDynamicCredential.mockResolvedValueOnce(undefined);
@@ -263,6 +266,7 @@ describe('OAuth1CredentialController', () => {
 				{ csrfSecret: 'invalid' },
 				{ accessTokenUrl: 'https://example.domain/oauth/access_token' },
 				mockState,
+				{ csrfSecret: 'csrf-secret' },
 			]);
 			oauthService.getOAuth1AccessToken.mockResolvedValueOnce(accessTokenData);
 
@@ -299,6 +303,7 @@ describe('OAuth1CredentialController', () => {
 				{ csrfSecret: 'invalid' },
 				{ accessTokenUrl: 'https://example.domain/oauth/access_token' },
 				mockState,
+				{ csrfSecret: 'csrf-secret' },
 			]);
 			oauthService.getOAuth1AccessToken.mockResolvedValueOnce(accessTokenData);
 
@@ -336,6 +341,7 @@ describe('OAuth1CredentialController', () => {
 				{ csrfSecret: 'invalid' },
 				{ accessTokenUrl: 'https://example.domain/oauth/access_token' },
 				mockState,
+				{ csrfSecret: 'csrf-secret' },
 			]);
 			oauthService.getOAuth1AccessToken.mockResolvedValueOnce(accessTokenData);
 
@@ -371,6 +377,7 @@ describe('OAuth1CredentialController', () => {
 				{ csrfSecret: 'invalid' },
 				{ accessTokenUrl: 'https://example.domain/oauth/access_token' },
 				mockState,
+				{ csrfSecret: 'csrf-secret' },
 			]);
 			oauthService.getOAuth1AccessToken.mockResolvedValueOnce(accessTokenData);
 
@@ -384,7 +391,6 @@ describe('OAuth1CredentialController', () => {
 						oauth_token_secret: 'secret',
 					}),
 				}),
-				['csrfSecret', 'oauth_token_secret'],
 			);
 			expect(res.render).toHaveBeenCalledWith('oauth-callback');
 		});

--- a/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
@@ -123,6 +123,7 @@ describe('OAuth2CredentialController', () => {
 					authentication: 'header',
 				},
 				mockState,
+				{ csrfSecret: 'csrf-secret' },
 			]);
 			oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
 			externalHooks.run.mockResolvedValue(undefined);
@@ -142,7 +143,6 @@ describe('OAuth2CredentialController', () => {
 				expect.objectContaining({
 					oauthTokenData: { access_token: 'new_token', refresh_token: 'refresh_token' },
 				}),
-				['csrfSecret'],
 			);
 			expect(res.render).toHaveBeenCalledWith('oauth-callback');
 			expect(externalHooks.run).toHaveBeenCalledWith('oauth2.callback', expect.any(Array));
@@ -189,6 +189,7 @@ describe('OAuth2CredentialController', () => {
 					authentication: 'header',
 				},
 				mockState,
+				{ csrfSecret: 'csrf-secret' },
 			]);
 			oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
 			externalHooks.run.mockResolvedValue(undefined);
@@ -261,6 +262,7 @@ describe('OAuth2CredentialController', () => {
 					authentication: 'header',
 				},
 				mockState,
+				{ csrfSecret: 'csrf-secret' },
 			]);
 			oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
 			externalHooks.run.mockResolvedValue(undefined);
@@ -320,6 +322,7 @@ describe('OAuth2CredentialController', () => {
 					authentication: 'header',
 				},
 				mockState,
+				{ csrfSecret: 'csrf-secret' },
 			]);
 			oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
 			externalHooks.run.mockResolvedValue(undefined);
@@ -380,6 +383,7 @@ describe('OAuth2CredentialController', () => {
 					authentication: 'header',
 				},
 				mockState,
+				{ csrfSecret: 'csrf-secret' },
 			]);
 			oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
 			externalHooks.run.mockResolvedValue(undefined);
@@ -438,6 +442,7 @@ describe('OAuth2CredentialController', () => {
 					authentication: 'header',
 				},
 				mockState,
+				{ csrfSecret: 'csrf-secret' },
 			]);
 			oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
 			externalHooks.run.mockResolvedValue(undefined);
@@ -457,7 +462,6 @@ describe('OAuth2CredentialController', () => {
 				expect.objectContaining({
 					oauthTokenData: { access_token: 'new_token', refresh_token: 'refresh_token' },
 				}),
-				['csrfSecret'],
 			);
 			expect(res.render).toHaveBeenCalledWith('oauth-callback');
 		});
@@ -498,6 +502,7 @@ describe('OAuth2CredentialController', () => {
 					authentication: 'header',
 				},
 				mockState,
+				{ csrfSecret: 'csrf-secret', codeVerifier: 'code_verifier' },
 			]);
 			oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
 			externalHooks.run.mockResolvedValue(undefined);
@@ -557,6 +562,7 @@ describe('OAuth2CredentialController', () => {
 					authentication: 'body',
 				},
 				mockState,
+				{ csrfSecret: 'csrf-secret', codeVerifier: 'code_verifier' },
 			]);
 			oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
 			externalHooks.run.mockResolvedValue(undefined);
@@ -620,6 +626,7 @@ describe('OAuth2CredentialController', () => {
 					authentication: 'body',
 				},
 				mockState,
+				{ csrfSecret: 'csrf-secret' },
 			]);
 			oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
 			externalHooks.run.mockResolvedValue(undefined);
@@ -681,6 +688,7 @@ describe('OAuth2CredentialController', () => {
 					authentication: 'header',
 				},
 				mockState,
+				{ csrfSecret: 'csrf-secret' },
 			]);
 			oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
 			externalHooks.run.mockResolvedValue(undefined);
@@ -707,7 +715,6 @@ describe('OAuth2CredentialController', () => {
 						}),
 					}),
 				}),
-				['csrfSecret'],
 			);
 		});
 
@@ -742,6 +749,7 @@ describe('OAuth2CredentialController', () => {
 						jweEnabled,
 					} as any,
 					baseState,
+					{ csrfSecret: 'csrf-secret' },
 				]);
 				oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
 				externalHooks.run.mockResolvedValue(undefined);
@@ -773,7 +781,6 @@ describe('OAuth2CredentialController', () => {
 					expect.objectContaining({
 						oauthTokenData: expect.objectContaining({ access_token: 'decrypted' }),
 					}),
-					['csrfSecret'],
 				);
 			});
 
@@ -816,7 +823,6 @@ describe('OAuth2CredentialController', () => {
 					expect.objectContaining({
 						oauthTokenData: expect.objectContaining({ access_token: 'plaintext' }),
 					}),
-					['csrfSecret'],
 				);
 			});
 
@@ -855,6 +861,7 @@ describe('OAuth2CredentialController', () => {
 						jweEnabled: true,
 					} as any,
 					dynamicState,
+					{ csrfSecret: 'csrf-secret' },
 				]);
 				oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
 				externalHooks.run.mockResolvedValue(undefined);
@@ -925,6 +932,7 @@ describe('OAuth2CredentialController', () => {
 					authentication: 'header',
 				},
 				mockState,
+				{ csrfSecret: 'csrf-secret' },
 			]);
 			oauthService.getBaseUrl.mockReturnValue('http://localhost:5678/rest/oauth2-credential');
 			externalHooks.run.mockResolvedValue(undefined);

--- a/packages/cli/src/controllers/oauth/oauth1-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth1-credential.controller.ts
@@ -45,25 +45,17 @@ export class OAuth1CredentialController {
 				);
 			}
 
-			const [credential, decryptedData, oauthCredentials, state] =
+			const [credential, , oauthCredentials, state, flowState] =
 				await this.oauthService.resolveCredential<OAuth1CredentialData>(req);
-
-			const oauthTokenSecret =
-				typeof decryptedData.oauth_token_secret === 'string'
-					? decryptedData.oauth_token_secret
-					: '';
 
 			const oauthTokenData = await this.oauthService.getOAuth1AccessToken(oauthCredentials, {
 				oauthToken: oauth_token,
 				oauthVerifier: oauth_verifier,
-				oauthTokenSecret,
+				oauthTokenSecret: flowState.oauthTokenSecret ?? '',
 			});
 
 			if (!state.origin || state.origin === 'static-credential') {
-				await this.oauthService.encryptAndSaveData(credential, { oauthTokenData }, [
-					'csrfSecret',
-					'oauth_token_secret',
-				]);
+				await this.oauthService.encryptAndSaveData(credential, { oauthTokenData });
 
 				this.logger.debug('OAuth1 callback successful for new credential', {
 					credentialId: credential.id,

--- a/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
@@ -46,7 +46,7 @@ export class OAuth2CredentialController {
 				);
 			}
 
-			const [credential, decryptedDataOriginal, oauthCredentials, state] =
+			const [credential, decryptedDataOriginal, oauthCredentials, state, flowState] =
 				await this.oauthService.resolveCredential<OAuth2CredentialData>(req);
 
 			const oAuthOptions = this.convertCredentialToOptions(oauthCredentials);
@@ -57,7 +57,7 @@ export class OAuth2CredentialController {
 			const body: Record<string, string> = { ...(oAuthOptions.body ?? {}) };
 
 			if (isPkce) {
-				body.code_verifier = decryptedDataOriginal.codeVerifier as string;
+				body.code_verifier = flowState.codeVerifier as string;
 			}
 
 			if (isBodyAuth) {
@@ -105,7 +105,7 @@ export class OAuth2CredentialController {
 			} as ICredentialDataDecryptedObject;
 
 			if (!state.origin || state.origin === 'static-credential') {
-				await this.oauthService.encryptAndSaveData(credential, { oauthTokenData }, ['csrfSecret']);
+				await this.oauthService.encryptAndSaveData(credential, { oauthTokenData });
 
 				this.logger.debug('OAuth2 callback successful for credential', {
 					credentialId: credential.id,

--- a/packages/cli/src/oauth/__tests__/oauth.service.test.ts
+++ b/packages/cli/src/oauth/__tests__/oauth.service.test.ts
@@ -31,6 +31,7 @@ import {
 	type OAuth1CredentialData,
 } from '@/oauth/oauth.service';
 import type { OAuthRequest } from '@/requests';
+import { CacheService } from '@/services/cache/cache.service';
 import { UrlService } from '@/services/url.service';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 
@@ -53,6 +54,7 @@ describe('OauthService', () => {
 	const oauthJweServiceProxy = mockInstance(OAuthJweServiceProxy);
 	const browserBindingService = mockInstance(OAuthBrowserBindingService);
 	const eventService = mockInstance(EventService);
+	const cacheService = mockInstance(CacheService);
 
 	let service: OauthService;
 
@@ -98,6 +100,7 @@ describe('OauthService', () => {
 			oauthJweServiceProxy,
 			browserBindingService,
 			eventService,
+			cacheService,
 		);
 	});
 
@@ -888,9 +891,9 @@ describe('OauthService', () => {
 				origin: 'static-credential',
 				createdAt: Date.now(),
 			};
-			const decrypted = { csrfSecret };
+			const flowState = { csrfSecret };
 
-			const result = (service as any).verifyCsrfState(decrypted, state);
+			const result = (service as any).verifyCsrfState(flowState, state);
 
 			expect(result).toBe(true);
 		});
@@ -906,9 +909,9 @@ describe('OauthService', () => {
 				origin: 'dynamic-credential',
 				createdAt: Date.now(),
 			};
-			const decrypted = { csrfSecret };
+			const flowState = { csrfSecret };
 
-			const result = (service as any).verifyCsrfState(decrypted, state);
+			const result = (service as any).verifyCsrfState(flowState, state);
 
 			expect(result).toBe(true);
 		});
@@ -925,14 +928,14 @@ describe('OauthService', () => {
 				origin: 'static-credential',
 				createdAt: expiredTime,
 			};
-			const decrypted = { csrfSecret };
+			const flowState = { csrfSecret };
 
-			const result = (service as any).verifyCsrfState(decrypted, state);
+			const result = (service as any).verifyCsrfState(flowState, state);
 
 			expect(result).toBe(false);
 		});
 
-		it('should return false when csrfSecret is missing', () => {
+		it('should return false when flowState is undefined (cache miss / replay)', () => {
 			const token = new (require('csrf'))();
 			const csrfSecret = 'csrf-secret';
 			const stateToken = token.create(csrfSecret);
@@ -943,9 +946,8 @@ describe('OauthService', () => {
 				origin: 'static-credential',
 				createdAt: Date.now(),
 			};
-			const decrypted = {};
 
-			const result = (service as any).verifyCsrfState(decrypted, state);
+			const result = (service as any).verifyCsrfState(undefined, state);
 
 			expect(result).toBe(false);
 		});
@@ -957,11 +959,45 @@ describe('OauthService', () => {
 				origin: 'static-credential',
 				createdAt: Date.now(),
 			};
-			const decrypted = { csrfSecret: 'csrf-secret' };
+			const flowState = { csrfSecret: 'csrf-secret' };
 
-			const result = (service as any).verifyCsrfState(decrypted, state);
+			const result = (service as any).verifyCsrfState(flowState, state);
 
 			expect(result).toBe(false);
+		});
+	});
+
+	describe('storeOauthFlowState / consumeOauthFlowState', () => {
+		it('stores the flow state in the cache under the token key with MAX_CSRF_AGE TTL', async () => {
+			await service.storeOauthFlowState('the-token', {
+				csrfSecret: 'csrf-secret',
+				codeVerifier: 'code-verifier',
+			});
+
+			expect(cacheService.set).toHaveBeenCalledWith(
+				'oauth:flow:the-token',
+				{ csrfSecret: 'csrf-secret', codeVerifier: 'code-verifier' },
+				5 * Time.minutes.toMilliseconds,
+			);
+		});
+
+		it('reads then deletes the flow state on consume (replay protection)', async () => {
+			cacheService.get.mockResolvedValue({ csrfSecret: 'csrf-secret' });
+
+			const result = await service.consumeOauthFlowState('the-token');
+
+			expect(cacheService.get).toHaveBeenCalledWith('oauth:flow:the-token');
+			expect(cacheService.delete).toHaveBeenCalledWith('oauth:flow:the-token');
+			expect(result).toEqual({ csrfSecret: 'csrf-secret' });
+		});
+
+		it('returns undefined and does not delete when cache misses', async () => {
+			cacheService.get.mockResolvedValue(undefined);
+
+			const result = await service.consumeOauthFlowState('the-token');
+
+			expect(result).toBeUndefined();
+			expect(cacheService.delete).not.toHaveBeenCalled();
 		});
 	});
 
@@ -983,7 +1019,7 @@ describe('OauthService', () => {
 			const encodedState = Buffer.from(JSON.stringify(state)).toString('base64');
 
 			const mockCredential = mock<CredentialsEntity>({ id: 'credential-id' });
-			const mockDecryptedData = { csrfSecret: 'csrf-secret' };
+			const mockDecryptedData = { someField: 'value' };
 			const mockOAuthCredentials = { clientId: 'client-id' };
 			const mockAdditionalData = mock<IWorkflowExecuteAdditionalData>();
 
@@ -997,6 +1033,10 @@ describe('OauthService', () => {
 			jest.mocked(WorkflowExecuteAdditionalData.getBase).mockResolvedValue(mockAdditionalData);
 			credentialsHelper.getDecrypted.mockResolvedValue(mockDecryptedData);
 			credentialsHelper.applyDefaultsAndOverwrites.mockResolvedValue(mockOAuthCredentials);
+			cacheService.get.mockResolvedValue({
+				csrfSecret: 'csrf-secret',
+				codeVerifier: 'code-verifier',
+			});
 
 			jest.spyOn(service as any, 'verifyCsrfState').mockReturnValue(true);
 
@@ -1012,6 +1052,47 @@ describe('OauthService', () => {
 				userId: 'user-id',
 				origin: 'static-credential',
 			});
+			// Flow state read from cache and consumed (replay protection)
+			expect(result[4]).toEqual({ csrfSecret: 'csrf-secret', codeVerifier: 'code-verifier' });
+			expect(cacheService.delete).toHaveBeenCalledWith(`oauth:flow:${stateToken}`);
+		});
+
+		it('should reject the callback when the flow state is missing (replay / unknown state)', async () => {
+			const token = new (require('csrf'))();
+			const stateToken = token.create('csrf-secret');
+
+			const csrfData = {
+				cid: 'credential-id',
+				userId: 'user-id',
+				origin: 'static-credential' as const,
+			};
+			const state = {
+				token: stateToken,
+				createdAt: timestamp,
+				data: 'encrypted-data',
+			};
+			const encodedState = Buffer.from(JSON.stringify(state)).toString('base64');
+
+			const mockCredential = mock<CredentialsEntity>({ id: 'credential-id' });
+			const mockDecryptedData = {};
+			const mockOAuthCredentials = { clientId: 'client-id' };
+			const mockAdditionalData = mock<IWorkflowExecuteAdditionalData>();
+
+			const req = mock<OAuthRequest.OAuth2Credential.Callback>({
+				query: { state: encodedState },
+				user: mock<User>({ id: 'user-id' }),
+			});
+
+			cipher.decryptV2.mockResolvedValue(JSON.stringify(csrfData));
+			credentialsFinderService.findCredentialForUser.mockResolvedValue(mockCredential);
+			jest.mocked(WorkflowExecuteAdditionalData.getBase).mockResolvedValue(mockAdditionalData);
+			credentialsHelper.getDecrypted.mockResolvedValue(mockDecryptedData);
+			credentialsHelper.applyDefaultsAndOverwrites.mockResolvedValue(mockOAuthCredentials);
+			cacheService.get.mockResolvedValue(undefined);
+
+			await expect(service.resolveCredential(req)).rejects.toThrow(
+				'The OAuth callback state is invalid!',
+			);
 		});
 
 		it('should throw NotFoundError when credential is not found', async () => {
@@ -1250,16 +1331,18 @@ describe('OauthService', () => {
 			);
 		});
 
-		it('should remove csrfSecret from credential data', async () => {
+		it('should not persist csrfSecret on the credential when given oauth token data', async () => {
 			const credential = mock<CredentialsEntity>({
 				id: 'credential-id',
 				name: 'Test Credential',
 				type: 'googleOAuth2Api',
 				data: 'encrypted-data',
 			});
+			// csrfSecret no longer lives on credential.data — the only path that used to
+			// strip it on save is gone. This test guards that we still never persist it
+			// even if some caller mistakenly includes it.
 			const oauthTokenData = {
 				access_token: 'access-token',
-				csrfSecret: 'csrf-secret',
 			};
 			const authToken = 'token123'; // Controller splits 'Bearer token123' and passes just 'token123'
 			const credentialResolverId = 'resolver-id';
@@ -1273,7 +1356,6 @@ describe('OauthService', () => {
 				credentialResolverId,
 			);
 
-			// Verify that storeIfNeeded was called with data that doesn't include csrfSecret
 			const callArgs = dynamicCredentialsProxy.storeIfNeeded.mock.calls[0];
 			const staticData = callArgs[3] as any;
 			expect(staticData).not.toHaveProperty('csrfSecret');
@@ -1654,12 +1736,13 @@ describe('OauthService', () => {
 			});
 
 			expect(authUri).toContain('https://example.domain/oauth2/auth');
-			expect(service.encryptAndSaveData).toHaveBeenCalled();
-			const callArgs = (service.encryptAndSaveData as jest.Mock).mock.calls[0];
-			expect(callArgs[0]).toBe(credential);
-			expect(callArgs[1]).toHaveProperty('csrfSecret');
-			expect(typeof callArgs[1].csrfSecret).toBe('string');
-			expect(callArgs[2] || []).toEqual([]);
+			// CSRF/PKCE state must not be persisted to the credential; it lives in the cache.
+			expect(service.encryptAndSaveData).not.toHaveBeenCalled();
+			expect(cacheService.set).toHaveBeenCalledWith(
+				expect.stringMatching(/^oauth:flow:/),
+				expect.objectContaining({ csrfSecret: expect.any(String) }),
+				expect.any(Number),
+			);
 			expect(externalHooks.run).toHaveBeenCalledWith('oauth2.authenticate', [
 				expect.objectContaining({
 					state: expect.any(String), // base64State
@@ -1734,12 +1817,16 @@ describe('OauthService', () => {
 			});
 
 			expect(authUri).toContain('code_challenge=code_challenge');
-			expect(service.encryptAndSaveData).toHaveBeenCalled();
-			const callArgs = (service.encryptAndSaveData as jest.Mock).mock.calls[0];
-			expect(callArgs[0]).toBe(credential);
-			expect(callArgs[1]).toHaveProperty('csrfSecret');
-			expect(callArgs[1]).toHaveProperty('codeVerifier', 'code_verifier');
-			expect(callArgs[2] || []).toEqual([]);
+			// CSRF + PKCE state both go to the cache, not to the credential
+			expect(service.encryptAndSaveData).not.toHaveBeenCalled();
+			expect(cacheService.set).toHaveBeenCalledWith(
+				expect.stringMatching(/^oauth:flow:/),
+				expect.objectContaining({
+					csrfSecret: expect.any(String),
+					codeVerifier: 'code_verifier',
+				}),
+				expect.any(Number),
+			);
 		});
 
 		it('should generate auth URI with auth query parameters', async () => {
@@ -1853,6 +1940,7 @@ describe('OauthService', () => {
 				'oauth2.dynamicClientRegistration',
 				expect.any(Array),
 			);
+			// DCR-driven fields still get persisted to the credential, but CSRF/PKCE do not.
 			expect(service.encryptAndSaveData).toHaveBeenCalled();
 			const callArgs = (service.encryptAndSaveData as jest.Mock).mock.calls[0];
 			expect(callArgs[0]).toBe(credential);
@@ -1862,9 +1950,16 @@ describe('OauthService', () => {
 			expect(callArgs[1]).toHaveProperty('clientSecret', 'registered_client_secret');
 			expect(callArgs[1]).toHaveProperty('scope', 'openid profile');
 			expect(callArgs[1]).toHaveProperty('grantType', 'pkce');
-			expect(callArgs[1]).toHaveProperty('csrfSecret');
-			expect(callArgs[1]).toHaveProperty('codeVerifier', 'code_verifier');
-			expect(callArgs[2] || []).toEqual([]);
+			expect(callArgs[1]).not.toHaveProperty('csrfSecret');
+			expect(callArgs[1]).not.toHaveProperty('codeVerifier');
+			expect(cacheService.set).toHaveBeenCalledWith(
+				expect.stringMatching(/^oauth:flow:/),
+				expect.objectContaining({
+					csrfSecret: expect.any(String),
+					codeVerifier: 'code_verifier',
+				}),
+				expect.any(Number),
+			);
 		});
 
 		it('should throw BadRequestError when OAuth2 server metadata is invalid', async () => {
@@ -2026,7 +2121,9 @@ describe('OauthService', () => {
 
 			jest.spyOn(service, 'getOAuthCredentials').mockResolvedValue(oauthCredentials);
 			jest.spyOn(service, 'encryptAndSaveData').mockResolvedValue(undefined);
-			jest.spyOn(service, 'createCsrfState').mockResolvedValue(['csrf-secret', 'base64-state']);
+			jest
+				.spyOn(service, 'createCsrfState')
+				.mockResolvedValue(['csrf-secret', 'base64-state', 'state-token']);
 
 			await service.generateAOauth2AuthUri(credential, {
 				cid: credential.id,
@@ -2053,7 +2150,9 @@ describe('OauthService', () => {
 
 				jest.spyOn(service, 'getOAuthCredentials').mockResolvedValue(oauthCredentials);
 				jest.spyOn(service, 'encryptAndSaveData').mockResolvedValue(undefined);
-				jest.spyOn(service, 'createCsrfState').mockResolvedValue(['csrf-secret', 'base64-state']);
+				jest
+					.spyOn(service, 'createCsrfState')
+					.mockResolvedValue(['csrf-secret', 'base64-state', 'state-token']);
 				browserBindingService.isEnabled.mockReturnValue(true);
 
 				const csrfData: CreateCsrfStateData = {
@@ -2076,7 +2175,9 @@ describe('OauthService', () => {
 
 				jest.spyOn(service, 'getOAuthCredentials').mockResolvedValue(oauthCredentials);
 				jest.spyOn(service, 'encryptAndSaveData').mockResolvedValue(undefined);
-				jest.spyOn(service, 'createCsrfState').mockResolvedValue(['csrf-secret', 'base64-state']);
+				jest
+					.spyOn(service, 'createCsrfState')
+					.mockResolvedValue(['csrf-secret', 'base64-state', 'state-token']);
 				browserBindingService.isEnabled.mockReturnValue(false);
 
 				const csrfData: CreateCsrfStateData = {
@@ -2101,7 +2202,9 @@ describe('OauthService', () => {
 
 				jest.spyOn(service, 'getOAuthCredentials').mockResolvedValue(oauthCredentials);
 				jest.spyOn(service, 'encryptAndSaveData').mockResolvedValue(undefined);
-				jest.spyOn(service, 'createCsrfState').mockResolvedValue(['csrf-secret', 'base64-state']);
+				jest
+					.spyOn(service, 'createCsrfState')
+					.mockResolvedValue(['csrf-secret', 'base64-state', 'state-token']);
 				browserBindingService.isEnabled.mockReturnValue(true);
 				browserBindingService.ensureBindingCookie.mockReturnValue('nonce-value');
 				browserBindingService.computeHash.mockReturnValue('hash-value');
@@ -3274,13 +3377,16 @@ describe('OauthService', () => {
 			});
 
 			expect(authUri).toContain('https://example.domain/oauth/authorize?oauth_token=random-token');
-			expect(service.encryptAndSaveData).toHaveBeenCalledWith(
-				credential,
+			// Neither csrfSecret nor the request-token secret may be persisted to the
+			// credential — both live in the per-flow cache entry.
+			expect(service.encryptAndSaveData).not.toHaveBeenCalled();
+			expect(cacheService.set).toHaveBeenCalledWith(
+				expect.stringMatching(/^oauth:flow:/),
 				expect.objectContaining({
 					csrfSecret: expect.any(String),
-					oauth_token_secret: 'random-secret',
+					oauthTokenSecret: 'random-secret',
 				}),
-				[],
+				expect.any(Number),
 			);
 			expect(externalHooks.run).toHaveBeenCalledWith('oauth1.authenticate', expect.any(Array));
 		});
@@ -3332,7 +3438,12 @@ describe('OauthService', () => {
 			});
 
 			expect(authUri).toContain('https://example.domain/oauth/authorize?oauth_token=random-token');
-			expect(service.encryptAndSaveData).toHaveBeenCalled();
+			expect(service.encryptAndSaveData).not.toHaveBeenCalled();
+			expect(cacheService.set).toHaveBeenCalledWith(
+				expect.stringMatching(/^oauth:flow:/),
+				expect.objectContaining({ csrfSecret: expect.any(String) }),
+				expect.any(Number),
+			);
 		});
 
 		it('should handle request token URL errors', async () => {

--- a/packages/cli/src/oauth/__tests__/oauth.service.test.ts
+++ b/packages/cli/src/oauth/__tests__/oauth.service.test.ts
@@ -916,7 +916,11 @@ describe('OauthService', () => {
 			expect(result).toBe(true);
 		});
 
-		it('should return false when CSRF state is expired', () => {
+		it('does not gate on createdAt — expiry is enforced by the cache TTL, not here', () => {
+			// Expiry now lives at the cache layer (TTL = MAX_CSRF_AGE): an expired flow is
+			// evicted and reaches verifyCsrfState as `undefined`. So given a present flowState,
+			// a stale createdAt is no longer a rejection reason at this layer. The real expiry
+			// path is covered by the cache-miss test below + the storeOauthFlowState TTL test.
 			const csrfSecret = 'csrf-secret';
 			const token = new (require('csrf'))();
 			const stateToken = token.create(csrfSecret);
@@ -932,7 +936,7 @@ describe('OauthService', () => {
 
 			const result = (service as any).verifyCsrfState(flowState, state);
 
-			expect(result).toBe(false);
+			expect(result).toBe(true);
 		});
 
 		it('should return false when flowState is undefined (cache miss / replay)', () => {
@@ -1188,6 +1192,7 @@ describe('OauthService', () => {
 			jest.mocked(WorkflowExecuteAdditionalData.getBase).mockResolvedValue(mockAdditionalData);
 			credentialsHelper.getDecrypted.mockResolvedValue(mockDecryptedData);
 			credentialsHelper.applyDefaultsAndOverwrites.mockResolvedValue(mockOAuthCredentials);
+			cacheService.get.mockResolvedValue({ csrfSecret: 'csrf-secret' });
 
 			const verifySpy = jest.spyOn(service as any, 'verifyCsrfState').mockReturnValue(true);
 
@@ -1260,6 +1265,7 @@ describe('OauthService', () => {
 			jest.mocked(WorkflowExecuteAdditionalData.getBase).mockResolvedValue(mockAdditionalData);
 			credentialsHelper.getDecrypted.mockResolvedValue(mockDecryptedData);
 			credentialsHelper.applyDefaultsAndOverwrites.mockResolvedValue(mockOAuthCredentials);
+			cacheService.get.mockResolvedValue({ csrfSecret: 'csrf-secret' });
 
 			const verifySpy = jest.spyOn(service as any, 'verifyCsrfState').mockReturnValue(true);
 

--- a/packages/cli/src/oauth/oauth.service.ts
+++ b/packages/cli/src/oauth/oauth.service.ts
@@ -57,6 +57,21 @@ import { DynamicCredentialsProxy } from '@/credentials/dynamic-credentials-proxy
 import { EventService } from '@/events/event.service';
 import { OAuthJweServiceProxy } from '@/oauth/oauth-jwe-service.proxy';
 import { OAuthBrowserBindingService } from '@/oauth/oauth-browser-binding.service';
+import { CacheService } from '@/services/cache/cache.service';
+
+/**
+ * Per-flow OAuth state stored in CacheService, keyed by the CSRF state token.
+ * Lives only for the duration of an in-flight OAuth handshake.
+ */
+export type OauthFlowState = {
+	csrfSecret: string;
+	/** OAuth2 PKCE verifier, needed to exchange the code in the callback. */
+	codeVerifier?: string;
+	/** OAuth1 request-token secret, needed to sign the access-token request in the callback. */
+	oauthTokenSecret?: string;
+};
+
+const OAUTH_FLOW_CACHE_PREFIX = 'oauth:flow:';
 
 export function shouldSkipAuthOnOAuthCallback() {
 	const value = process.env.N8N_SKIP_AUTH_ON_OAUTH_CALLBACK?.toLowerCase() ?? 'false';
@@ -83,7 +98,12 @@ export class OauthService {
 		private readonly oauthJweServiceProxy: OAuthJweServiceProxy,
 		private readonly browserBindingService: OAuthBrowserBindingService,
 		private readonly eventService: EventService,
+		private readonly cacheService: CacheService,
 	) {}
+
+	private oauthFlowCacheKey(token: string): string {
+		return `${OAUTH_FLOW_CACHE_PREFIX}${token}`;
+	}
 
 	private validateOAuthUrlOrThrow(url: string): void {
 		try {
@@ -270,17 +290,40 @@ export class OauthService {
 		return await this.credentialsRepository.findOneBy({ id: credentialId });
 	}
 
-	async createCsrfState(data: CreateCsrfStateData): Promise<[string, string]> {
+	async createCsrfState(data: CreateCsrfStateData): Promise<[string, string, string]> {
 		const token = new Csrf();
 		const csrfSecret = token.secretSync();
+		const stateToken = token.create(csrfSecret);
 		const state: CsrfState = {
-			token: token.create(csrfSecret),
+			token: stateToken,
 			createdAt: Date.now(),
 			data: await this.cipher.encryptV2(JSON.stringify(data)),
 		};
 
 		const base64State = Buffer.from(JSON.stringify(state)).toString('base64');
-		return [csrfSecret, base64State];
+		return [csrfSecret, base64State, stateToken];
+	}
+
+	/**
+	 * Stash per-flow OAuth state (CSRF secret + optional PKCE verifier) in the cache
+	 * keyed by the CSRF state token. Replaces the previous behavior of writing this
+	 * state to the shared CredentialsEntity.data — which races when multiple users
+	 * initiate OAuth against the same credential blueprint.
+	 */
+	async storeOauthFlowState(stateToken: string, flowState: OauthFlowState): Promise<void> {
+		await this.cacheService.set(this.oauthFlowCacheKey(stateToken), flowState, MAX_CSRF_AGE);
+	}
+
+	/**
+	 * Read and consume the per-flow OAuth state. Consume-once: the entry is deleted
+	 * after a successful read to prevent replay.
+	 */
+	async consumeOauthFlowState(stateToken: string): Promise<OauthFlowState | undefined> {
+		const key = this.oauthFlowCacheKey(stateToken);
+		const value = await this.cacheService.get<OauthFlowState>(key);
+		if (value === undefined) return undefined;
+		await this.cacheService.delete(key);
+		return value;
 	}
 
 	protected async decodeCsrfState(
@@ -363,23 +406,28 @@ export class OauthService {
 		return [{ ...decoded, ...decryptedState }, credential];
 	}
 
-	protected verifyCsrfState(
-		decrypted: ICredentialDataDecryptedObject & { csrfSecret?: string },
-		state: CsrfState,
-	) {
+	protected verifyCsrfState(flowState: OauthFlowState | undefined, state: CsrfState): boolean {
+		if (!flowState) return false;
+
 		const token = new Csrf();
 
 		return (
 			Date.now() - state.createdAt <= MAX_CSRF_AGE &&
-			decrypted.csrfSecret !== undefined &&
-			token.verify(decrypted.csrfSecret, state.token)
+			typeof flowState.csrfSecret === 'string' &&
+			token.verify(flowState.csrfSecret, state.token)
 		);
 	}
 
 	async resolveCredential<T>(
 		req: OAuthRequest.OAuth1Credential.Callback | OAuthRequest.OAuth2Credential.Callback,
 	): Promise<
-		[CredentialsEntity, ICredentialDataDecryptedObject, T, CsrfState & CreateCsrfStateData]
+		[
+			CredentialsEntity,
+			ICredentialDataDecryptedObject,
+			T,
+			CsrfState & CreateCsrfStateData,
+			OauthFlowState,
+		]
 	> {
 		const { state: encodedState } = req.query;
 		const [state, credential] = await this.decodeCsrfState(encodedState, req);
@@ -399,11 +447,13 @@ export class OauthService {
 			additionalData,
 		);
 
-		if (!this.verifyCsrfState(decryptedDataOriginal, state)) {
+		const flowState = await this.consumeOauthFlowState(state.token);
+
+		if (!this.verifyCsrfState(flowState, state)) {
 			throw new UnexpectedError('The OAuth callback state is invalid!');
 		}
 
-		return [credential, decryptedDataOriginal, oauthCredentials, state];
+		return [credential, decryptedDataOriginal, oauthCredentials, state, flowState!];
 	}
 
 	renderCallbackError(res: Response, message: string, reason?: string) {
@@ -727,7 +777,7 @@ export class OauthService {
 		this.validateOAuthUrlOrThrow(oauthCredentials.accessTokenUrl ?? '');
 
 		// Generate a CSRF prevention token and send it as an OAuth2 state string
-		const [csrfSecret, state] = await this.createCsrfState(csrfData);
+		const [csrfSecret, state, stateToken] = await this.createCsrfState(csrfData);
 
 		const oAuthOptions = {
 			...this.convertCredentialToOptions(oauthCredentials),
@@ -740,7 +790,7 @@ export class OauthService {
 
 		await this.externalHooks.run('oauth2.authenticate', [oAuthOptions]);
 
-		toUpdate.csrfSecret = csrfSecret;
+		const flowState: OauthFlowState = { csrfSecret };
 		if (oauthCredentials.grantType === 'pkce') {
 			const { code_verifier, code_challenge } = await pkceChallenge();
 			oAuthOptions.query = {
@@ -748,10 +798,16 @@ export class OauthService {
 				code_challenge,
 				code_challenge_method: 'S256',
 			};
-			toUpdate.codeVerifier = code_verifier;
+			flowState.codeVerifier = code_verifier;
 		}
 
-		await this.encryptAndSaveData(credential, toUpdate);
+		await this.storeOauthFlowState(stateToken, flowState);
+
+		// Only persist DCR-driven updates to the credential. CSRF/PKCE state lives in the cache
+		// to avoid cross-user races on shared credentials.
+		if (Object.keys(toUpdate).length > 0) {
+			await this.encryptAndSaveData(credential, toUpdate);
+		}
 
 		const oAuthObj = new ClientOAuth2(oAuthOptions);
 		const returnUri = oAuthObj.code.getUri();
@@ -779,7 +835,7 @@ export class OauthService {
 		this.validateOAuthUrlOrThrow(oauthCredentials.requestTokenUrl ?? '');
 		this.validateOAuthUrlOrThrow(oauthCredentials.accessTokenUrl ?? '');
 
-		const [csrfSecret, state] = await this.createCsrfState(csrfData);
+		const [csrfSecret, state, stateToken] = await this.createCsrfState(csrfData);
 
 		const signatureMethod = oauthCredentials.signatureMethod;
 
@@ -842,13 +898,13 @@ export class OauthService {
 		returnUriUrl.searchParams.set('oauth_token', responseJson.oauth_token);
 		const returnUri = returnUriUrl.toString();
 
-		// The request token secret is required to sign the later access token
-		// request, so it must be persisted until the callback completes.
-		await this.encryptAndSaveData(
-			credential,
-			{ csrfSecret, oauth_token_secret: responseJson.oauth_token_secret ?? '' },
-			[],
-		);
+		// The request-token secret is required to sign the later access-token request, so it
+		// must outlive this call. It lives in the cache (not on the shared credential) so
+		// concurrent flows by different users don't clobber each other's secret.
+		await this.storeOauthFlowState(stateToken, {
+			csrfSecret,
+			oauthTokenSecret: responseJson.oauth_token_secret ?? '',
+		});
 
 		this.logger.debug('OAuth1 authorization url created for credential', {
 			csrfData,
@@ -1062,7 +1118,7 @@ export class OauthService {
 		authMetadata: Record<string, unknown> = {},
 	) {
 		const credentials = new Credentials(credential, credential.type, credential.data);
-		await credentials.updateData(oauthTokenData, ['csrfSecret']);
+		await credentials.updateData(oauthTokenData);
 
 		const credentialStoreMetadata: CredentialStoreMetadata = {
 			id: credential.id,

--- a/packages/cli/src/oauth/oauth.service.ts
+++ b/packages/cli/src/oauth/oauth.service.ts
@@ -407,14 +407,15 @@ export class OauthService {
 	}
 
 	protected verifyCsrfState(flowState: OauthFlowState | undefined, state: CsrfState): boolean {
+		// Expiry is enforced by the cache TTL (MAX_CSRF_AGE): an expired flow is evicted
+		// and surfaces here as `flowState === undefined`. So a missing entry covers both
+		// "never existed / already consumed" (replay) and "expired".
 		if (!flowState) return false;
 
 		const token = new Csrf();
 
 		return (
-			Date.now() - state.createdAt <= MAX_CSRF_AGE &&
-			typeof flowState.csrfSecret === 'string' &&
-			token.verify(flowState.csrfSecret, state.token)
+			typeof flowState.csrfSecret === 'string' && token.verify(flowState.csrfSecret, state.token)
 		);
 	}
 
@@ -449,11 +450,11 @@ export class OauthService {
 
 		const flowState = await this.consumeOauthFlowState(state.token);
 
-		if (!this.verifyCsrfState(flowState, state)) {
+		if (!flowState || !this.verifyCsrfState(flowState, state)) {
 			throw new UnexpectedError('The OAuth callback state is invalid!');
 		}
 
-		return [credential, decryptedDataOriginal, oauthCredentials, state, flowState!];
+		return [credential, decryptedDataOriginal, oauthCredentials, state, flowState];
 	}
 
 	renderCallbackError(res: Response, message: string, reason?: string) {

--- a/packages/cli/test/integration/controllers/oauth/oauth1.api.test.ts
+++ b/packages/cli/test/integration/controllers/oauth/oauth1.api.test.ts
@@ -246,4 +246,118 @@ describe('OAuth1 API', () => {
 			expect(credentials.oauthTokenData).toBeUndefined();
 		});
 	});
+
+	describe('per-flow state isolation', () => {
+		const renderCallback = () =>
+			jest.spyOn(Response, 'render').mockImplementation(function (this: any) {
+				this.end();
+				return this;
+			});
+
+		const mockRequestTokenEndpoint = () => {
+			nock('https://test.domain')
+				.post('/oauth1/request_token')
+				.reply(200, 'oauth_token=request_token&oauth_token_secret=request_secret');
+		};
+
+		// IAM-719: concurrent OAuth1 flows on the same shared credential must not race
+		// on the per-flow csrfSecret.
+		it('lets two users complete concurrent OAuth1 flows on the same credential', async () => {
+			const teamProject = await createTeamProject(undefined, owner);
+			const editorA = await createMember();
+			const editorB = await createMember();
+			await linkUserToProject(editorA, teamProject, 'project:editor');
+			await linkUserToProject(editorB, teamProject, 'project:editor');
+			const projectCredential = await saveCredential(sharedCredentialPayload, {
+				project: teamProject,
+				role: 'credential:owner',
+			});
+			const editorAAgent = testServer.authAgentFor(editorA);
+			const editorBAgent = testServer.authAgentFor(editorB);
+
+			const oauthService = Container.get(OauthService);
+			const csrfSpy = jest.spyOn(oauthService, 'createCsrfState').mockClear();
+			renderCallback();
+
+			mockRequestTokenEndpoint();
+			await editorAAgent
+				.get('/oauth1-credential/auth')
+				.query({ id: projectCredential.id })
+				.expect(200);
+			mockRequestTokenEndpoint();
+			await editorBAgent
+				.get('/oauth1-credential/auth')
+				.query({ id: projectCredential.id })
+				.expect(200);
+
+			const [, stateA] = await csrfSpy.mock.results[0].value;
+			const [, stateB] = await csrfSpy.mock.results[1].value;
+			expect(stateA).not.toBe(stateB);
+
+			nock('https://test.domain')
+				.post('/oauth1/access_token')
+				.reply(200, 'oauth_token=token_A&oauth_token_secret=secret_A');
+			nock('https://test.domain')
+				.post('/oauth1/access_token')
+				.reply(200, 'oauth_token=token_B&oauth_token_secret=secret_B');
+
+			await editorAAgent
+				.get('/oauth1-credential/callback')
+				.query({
+					oauth_token: 'request_token',
+					oauth_verifier: 'verifier',
+					state: stateA,
+				})
+				.expect(200);
+
+			await editorBAgent
+				.get('/oauth1-credential/callback')
+				.query({
+					oauth_token: 'request_token',
+					oauth_verifier: 'verifier',
+					state: stateB,
+				})
+				.expect(200);
+		});
+
+		it('rejects a replayed OAuth1 callback (state token already consumed)', async () => {
+			const ownerAgent = testServer.authAgentFor(owner);
+			const oauthService = Container.get(OauthService);
+			const csrfSpy = jest.spyOn(oauthService, 'createCsrfState').mockClear();
+			const renderSpy = renderCallback();
+
+			mockRequestTokenEndpoint();
+			await ownerAgent.get('/oauth1-credential/auth').query({ id: credential.id }).expect(200);
+			const [, state] = await csrfSpy.mock.results[0].value;
+
+			nock('https://test.domain')
+				.post('/oauth1/access_token')
+				.reply(200, 'oauth_token=first_token&oauth_token_secret=first_secret');
+
+			await ownerAgent
+				.get('/oauth1-credential/callback')
+				.query({
+					oauth_token: 'request_token',
+					oauth_verifier: 'verifier',
+					state,
+				})
+				.expect(200);
+			expect(renderSpy).toHaveBeenLastCalledWith('oauth-callback');
+
+			await ownerAgent
+				.get('/oauth1-credential/callback')
+				.query({
+					oauth_token: 'request_token',
+					oauth_verifier: 'verifier',
+					state,
+				})
+				.expect(200);
+			expect(renderSpy).toHaveBeenLastCalledWith(
+				'oauth-error-callback',
+				expect.objectContaining({
+					error: expect.objectContaining({ message: 'The OAuth callback state is invalid!' }),
+				}),
+			);
+		});
+	});
 });

--- a/packages/cli/test/integration/controllers/oauth/oauth2.api.test.ts
+++ b/packages/cli/test/integration/controllers/oauth/oauth2.api.test.ts
@@ -235,6 +235,132 @@ describe('OAuth2 API', () => {
 			...credentialData,
 			oauthTokenData: { access_token: 'updated_token' },
 		});
+		// CSRF/PKCE state must never be persisted on the credential.
+		expect(await updatedCredential.getData()).not.toHaveProperty('csrfSecret');
+		expect(await updatedCredential.getData()).not.toHaveProperty('codeVerifier');
+	});
+
+	describe('per-flow state isolation', () => {
+		const renderCallback = () =>
+			jest.spyOn(Response, 'render').mockImplementation(function (this: any) {
+				this.end();
+				return this;
+			});
+
+		// IAM-719: when two users on the same shared credential start OAuth concurrently,
+		// neither flow may clobber the other's CSRF/PKCE state.
+		// We use a project-scoped credential with two editors — both have credential:update,
+		// which is the realistic setup where multiple users connect their own account to
+		// the same shared blueprint.
+		it('lets two users complete concurrent OAuth flows on the same credential', async () => {
+			const teamProject = await createTeamProject(undefined, owner);
+			const editorA = await createMember();
+			const editorB = await createMember();
+			await linkUserToProject(editorA, teamProject, 'project:editor');
+			await linkUserToProject(editorB, teamProject, 'project:editor');
+			const projectCredential = await saveCredential(
+				{ name: 'Project OAuth2', type: 'testOAuth2Api', data: credentialData },
+				{ project: teamProject, role: 'credential:owner' },
+			);
+			const editorAAgent = testServer.authAgentFor(editorA);
+			const editorBAgent = testServer.authAgentFor(editorB);
+
+			const oauthService = Container.get(OauthService);
+			const csrfSpy = jest.spyOn(oauthService, 'createCsrfState').mockClear();
+			renderCallback();
+
+			// Both users initiate /auth back-to-back. Under the old behavior the second
+			// init would overwrite the first user's csrfSecret on the shared credential
+			// and the first user's callback would fail.
+			await editorAAgent
+				.get('/oauth2-credential/auth')
+				.query({ id: projectCredential.id })
+				.expect(200);
+			await editorBAgent
+				.get('/oauth2-credential/auth')
+				.query({ id: projectCredential.id })
+				.expect(200);
+
+			const [, stateA] = await csrfSpy.mock.results[0].value;
+			const [, stateB] = await csrfSpy.mock.results[1].value;
+			expect(stateA).not.toBe(stateB);
+
+			nock('https://test.domain').post('/oauth2/token').reply(200, { access_token: 'token_A' });
+			nock('https://test.domain').post('/oauth2/token').reply(200, { access_token: 'token_B' });
+
+			// Editor A completes first; editor B's flow must still succeed afterwards.
+			await editorAAgent
+				.get('/oauth2-credential/callback')
+				.query({ code: 'code_A', state: stateA })
+				.expect(200);
+
+			await editorBAgent
+				.get('/oauth2-credential/callback')
+				.query({ code: 'code_B', state: stateB })
+				.expect(200);
+		});
+
+		it('rejects a replayed callback (state token already consumed)', async () => {
+			const oauthService = Container.get(OauthService);
+			const csrfSpy = jest.spyOn(oauthService, 'createCsrfState').mockClear();
+			const renderSpy = renderCallback();
+
+			await ownerAgent.get('/oauth2-credential/auth').query({ id: credential.id }).expect(200);
+			const [, state] = await csrfSpy.mock.results[0].value;
+
+			nock('https://test.domain').post('/oauth2/token').reply(200, { access_token: 'first_token' });
+
+			// First callback consumes the state.
+			await ownerAgent
+				.get('/oauth2-credential/callback')
+				.query({ code: 'auth_code', state })
+				.expect(200);
+			expect(renderSpy).toHaveBeenLastCalledWith('oauth-callback');
+
+			// Replay with the same state must be rejected.
+			await ownerAgent
+				.get('/oauth2-credential/callback')
+				.query({ code: 'auth_code', state })
+				.expect(200);
+			expect(renderSpy).toHaveBeenLastCalledWith(
+				'oauth-error-callback',
+				expect.objectContaining({
+					error: expect.objectContaining({ message: 'The OAuth callback state is invalid!' }),
+				}),
+			);
+		});
+
+		it('rejects a callback whose state has no matching entry in the cache', async () => {
+			const oauthService = Container.get(OauthService);
+			const renderSpy = renderCallback();
+
+			// Build a syntactically valid encoded state — same shape as createCsrfState
+			// produces — but never stored in the cache. Must be rejected.
+			const fakeState = {
+				token: 'forged-token',
+				createdAt: Date.now(),
+				data: oauthService['cipher'].encrypt(
+					JSON.stringify({
+						cid: credential.id,
+						origin: 'static-credential',
+						userId: owner.id,
+					}),
+				),
+			};
+			const encodedState = Buffer.from(JSON.stringify(fakeState)).toString('base64');
+
+			await ownerAgent
+				.get('/oauth2-credential/callback')
+				.query({ code: 'auth_code', state: encodedState })
+				.expect(200);
+
+			expect(renderSpy).toHaveBeenLastCalledWith(
+				'oauth-error-callback',
+				expect.objectContaining({
+					error: expect.objectContaining({ message: 'The OAuth callback state is invalid!' }),
+				}),
+			);
+		});
 	});
 
 	describe('OAuth reconnect authorization', () => {


### PR DESCRIPTION
## Summary

Move the per-flow `csrfSecret` and PKCE `codeVerifier` off `CredentialsEntity.data` and into `CacheService`, keyed by the CSRF state token (TTL = `MAX_CSRF_AGE`). Previously, when two users initiated OAuth against the same shared credential, the second `/auth` call would overwrite the first user's state and the first user's callback would fail with a CSRF or PKCE mismatch. Cache entries are now consumed once on successful callback for replay protection.

**How to test:** Unit and integration tests cover the single-user happy path (regression), two concurrent users on the same project-shared credential succeeding independently, replayed callbacks being rejected, and forged-state callbacks being rejected.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-719

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI