### PR TITLE
core(testing): Add n8n sandbox service containers 

### DIFF
--- a/packages/testing/containers/README.md
+++ b/packages/testing/containers/README.md
@@ -29,6 +29,12 @@ pnpm stack --plan starter
 
 # Public tunnel for webhook testing
 pnpm stack --tunnel
+
+# Instance AI n8n sandbox service
+pnpm stack --sandbox=n8n-sandbox
+
+# Services only for local pnpm dev
+pnpm services --sandbox=n8n-sandbox
 ```
 
 When started, you'll see the URL: `http://localhost:[port]`
@@ -363,6 +369,7 @@ Now usable as `test.use({ capability: 'my-capability' })`.
 | `taskRunner` | - | External task runner |
 | `loadBalancer` | - | Caddy for multi-main |
 | `cloudflared` | - | Cloudflare Tunnel for public webhook URLs |
+| `n8nSandbox` | - | n8n sandbox service for Instance AI |
 
 **Note:** For observability (logs + metrics), enable all three: `['victoriaLogs', 'victoriaMetrics', 'vector']`.
 The `observability` capability shortcut handles this automatically: `test.use({ capability: 'observability' })`.
@@ -384,6 +391,7 @@ The `observability` capability shortcut handles this automatically: `test.use({ 
 | `--oidc` | Enable Keycloak |
 | `--source-control` | Enable Gitea |
 | `--mailpit` | Enable email testing (Mailpit) |
+| `--sandbox n8n-sandbox` | Enable n8n sandbox service for Instance AI |
 
 ## Telemetry
 

--- a/packages/testing/containers/n8n-start-stack.ts
+++ b/packages/testing/containers/n8n-start-stack.ts
@@ -8,6 +8,7 @@ import type { CloudflaredResult } from './services/cloudflared';
 import type { KentResult } from './services/kent';
 import type { KeycloakResult } from './services/keycloak';
 import type { MailpitResult } from './services/mailpit';
+import type { N8nSandboxResult } from './services/n8n-sandbox';
 import type { NgrokResult } from './services/ngrok';
 import { services as SERVICE_REGISTRY } from './services/registry';
 import type { TracingResult } from './services/tracing';
@@ -60,6 +61,7 @@ ${colors.yellow}Options:${colors.reset}
   --ngrok           Enable ngrok tunnel for public URL (requires NGROK_AUTHTOKEN env var)
   --mailpit         Enable Mailpit for email testing
   --kent            Enable Kent (Sentry mock) for error tracking testing
+  --sandbox <name>  Enable Instance AI sandbox provider (n8n-sandbox)
   --mains <n>       Number of main instances (default: 1)
   --workers <n>     Number of worker instances (default: 1)
   --name <name>     Project name for parallel runs
@@ -100,6 +102,9 @@ ${colors.yellow}Examples:${colors.reset}
   ${colors.bright}# With tracing stack (Jaeger UI for workflow execution visualization)${colors.reset}
   npm run stack --queue --tracing
 
+  ${colors.bright}# With Instance AI n8n sandbox service${colors.reset}
+  npm run stack --sandbox=n8n-sandbox
+
   ${colors.bright}# With public tunnel (webhooks accessible from internet)${colors.reset}
   npm run stack --tunnel
 
@@ -118,6 +123,7 @@ ${Object.keys(BASE_PERFORMANCE_PLANS)
   pnpm services --services postgres
   pnpm services --services postgres,redis
   pnpm services --services postgres,mailpit,proxy
+  pnpm services --sandbox=n8n-sandbox
 
   ${colors.bright}# Parallel instances${colors.reset}
   npm run stack --name test-1
@@ -131,6 +137,12 @@ ${colors.yellow}Notes:${colors.reset}
   • Performance plans simulate cloud constraints (SQLite only, resource-limited)
   • Press Ctrl+C to stop all containers
 `);
+}
+
+const SENSITIVE_ENV_NAME_PATTERN = /(PASSWORD|SECRET|TOKEN|API_KEY|PRIVATE_KEY)/i;
+
+function formatEnvSummaryValue(key: string, value: string): string {
+	return `${key}=${SENSITIVE_ENV_NAME_PATTERN.test(key) ? '<redacted>' : value}`;
 }
 
 async function main() {
@@ -151,6 +163,7 @@ async function main() {
 			ngrok: { type: 'boolean' },
 			mailpit: { type: 'boolean' },
 			kent: { type: 'boolean' },
+			sandbox: { type: 'string' },
 			mains: { type: 'string' },
 			workers: { type: 'string' },
 			name: { type: 'string' },
@@ -189,6 +202,13 @@ async function main() {
 	if (values.ngrok) services.push('ngrok');
 	if (values.mailpit) services.push('mailpit');
 	if (values.kent) services.push('kent');
+	if (values.sandbox) {
+		if (values.sandbox !== 'n8n-sandbox') {
+			log.error(`Unsupported sandbox provider: '${values.sandbox}'. Supported: n8n-sandbox`);
+			process.exit(1);
+		}
+		services.push('n8nSandbox');
+	}
 
 	// Build configuration
 	const config: N8NConfig = {
@@ -261,7 +281,9 @@ async function main() {
 	// Services-only mode: start containers, write .env, no n8n
 	if (servicesOnly) {
 		if (services.length === 0) {
-			log.error('No services specified. Use flags like --postgres, --redis, --mailpit, etc.');
+			log.error(
+				'No services specified. Use flags like --postgres, --redis, --mailpit, --sandbox, etc.',
+			);
 			process.exit(1);
 		}
 
@@ -292,7 +314,7 @@ async function main() {
 					...(service.extraEnv?.(result, true) ?? {}),
 				};
 				const varSummary = Object.entries(vars)
-					.map(([k, v]) => `${k}=${v}`)
+					.map(([k, v]) => formatEnvSummaryValue(k, v))
 					.join(', ');
 				log.success(`${name}${varSummary ? `: ${varSummary}` : ''}`);
 			}
@@ -302,6 +324,14 @@ async function main() {
 			if (mailpitResult) {
 				console.log('');
 				log.info(`Mailpit UI: ${colors.cyan}${mailpitResult.meta.apiBaseUrl}${colors.reset}`);
+			}
+
+			const sandboxResult = stack.serviceResults.n8nSandbox as N8nSandboxResult | undefined;
+			if (sandboxResult) {
+				console.log('');
+				log.info(
+					`n8n Sandbox API: ${colors.cyan}${sandboxResult.meta.externalServiceUrl}${colors.reset}`,
+				);
 			}
 
 			console.log('');
@@ -414,6 +444,14 @@ async function main() {
 			log.info(`Frontend DSN: ${colors.cyan}${kentResult.meta.frontendDsn}${colors.reset}`);
 		}
 
+		const sandboxResult = stack.serviceResults.n8nSandbox as N8nSandboxResult | undefined;
+		if (sandboxResult) {
+			console.log('');
+			log.header('Instance AI Sandbox');
+			log.info(`Provider: ${colors.cyan}n8n-sandbox${colors.reset}`);
+			log.info(`API URL: ${colors.cyan}${sandboxResult.meta.externalServiceUrl}${colors.reset}`);
+		}
+
 		console.log('');
 		log.info('Containers are running in the background');
 		log.info(
@@ -455,6 +493,7 @@ function displayConfig(config: N8NConfig) {
 	if (services.includes('tracing')) enabledFeatures.push('Tracing (Jaeger)');
 	if (services.includes('mailpit')) enabledFeatures.push('Email (Mailpit)');
 	if (services.includes('kent')) enabledFeatures.push('Sentry Mock (Kent)');
+	if (services.includes('n8nSandbox')) enabledFeatures.push('Instance AI Sandbox');
 
 	if (enabledFeatures.length > 0) {
 		log.info(`Services: ${enabledFeatures.join(', ')}`);
@@ -472,6 +511,12 @@ function displayConfig(config: N8NConfig) {
 		log.info('Tracing: enabled (n8n-tracer + Jaeger)');
 	} else {
 		log.info('Tracing: disabled');
+	}
+
+	if (services.includes('n8nSandbox')) {
+		log.info('Instance AI sandbox: enabled (n8n-sandbox)');
+	} else {
+		log.info('Instance AI sandbox: disabled');
 	}
 
 	// Display tunnel status

--- a/packages/testing/containers/services/n8n-sandbox.ts
+++ b/packages/testing/containers/services/n8n-sandbox.ts
@@ -1,0 +1,226 @@
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+	GenericContainer,
+	type StartedNetwork,
+	type StartedTestContainer,
+	Wait,
+} from 'testcontainers';
+
+import { createSilentLogConsumer } from '../helpers/utils';
+import { TEST_CONTAINER_IMAGES } from '../test-containers';
+import type { Service, ServiceResult } from './types';
+
+const API_HOST = 'sandbox-api';
+const RUNNER_HOST = 'sandbox-runner-1';
+const RUNNER_CONTROL_HOST_PREFIX = 'sandbox-runner';
+
+const API_HTTP_PORT = 8080;
+const RUNNER_HTTP_PORT = 8080;
+
+const API_KEY = 'n8n-sandbox-ci-key';
+const RUNNER_REGISTRATION_TOKEN = 'ci-reg-token';
+const RUNNER_API_KEY = 'ci-runner-key';
+
+export interface N8nSandboxMeta {
+	internalServiceUrl: string;
+	externalServiceUrl: string;
+	apiKey: string;
+	tlsDir: string;
+}
+
+export type N8nSandboxResult = ServiceResult<N8nSandboxMeta> & {
+	containers: StartedTestContainer[];
+};
+
+function labelsFor(projectName: string, service: string): Record<string, string> {
+	return {
+		'com.docker.compose.project': projectName,
+		'com.docker.compose.service': service,
+	};
+}
+
+function formatExecFailure(operation: string, output: string): Error {
+	return new Error(`${operation} failed:\n${output}`);
+}
+
+async function generateMtlsCertificates(
+	network: StartedNetwork,
+	projectName: string,
+	tlsDir: string,
+	consumer: ReturnType<typeof createSilentLogConsumer>['consumer'],
+): Promise<void> {
+	let bootstrapContainer: StartedTestContainer | undefined;
+	try {
+		bootstrapContainer = await new GenericContainer(TEST_CONTAINER_IMAGES.n8nSandboxServiceApi)
+			.withName(`${projectName}-sandbox-bootstrap`)
+			.withNetwork(network)
+			.withUser('root')
+			.withBindMounts([{ source: tlsDir, target: '/tls', mode: 'rw' }])
+			.withEntrypoint(['sh'])
+			.withCommand(['-c', 'sleep infinity'])
+			.withLabels(labelsFor(projectName, 'sandbox-bootstrap'))
+			.withLogConsumer(consumer)
+			.start();
+
+		const command = [
+			'sh',
+			'-c',
+			[
+				'NUM_RUNNERS=1',
+				'bootstrap-mtls.sh',
+				'--out-dir /tls',
+				`--api-san ${API_HOST}`,
+				`--control-san-prefix ${RUNNER_CONTROL_HOST_PREFIX}`,
+				'--world-readable',
+			].join(' '),
+		];
+		const result = await bootstrapContainer.exec(command);
+		if (result.exitCode !== 0) {
+			throw formatExecFailure('n8n sandbox mTLS bootstrap', result.output);
+		}
+	} finally {
+		if (bootstrapContainer) {
+			await bootstrapContainer.stop();
+		}
+	}
+}
+
+export const n8nSandbox: Service<N8nSandboxResult> = {
+	description: 'n8n Sandbox Service',
+
+	async start(network: StartedNetwork, projectName: string): Promise<N8nSandboxResult> {
+		const { consumer, throwWithLogs } = createSilentLogConsumer();
+		const tlsDir = await mkdtemp(join(tmpdir(), `${projectName}-sandbox-tls-`));
+
+		try {
+			await generateMtlsCertificates(network, projectName, tlsDir, consumer);
+
+			const apiContainer = await new GenericContainer(TEST_CONTAINER_IMAGES.n8nSandboxServiceApi)
+				.withName(`${projectName}-${API_HOST}`)
+				.withNetwork(network)
+				.withNetworkAliases(API_HOST)
+				.withExposedPorts(API_HTTP_PORT)
+				.withBindMounts([{ source: join(tlsDir, 'api'), target: '/tls', mode: 'ro' }])
+				.withEnvironment({
+					SANDBOX_API_KEYS: API_KEY,
+					SANDBOX_API_RUNNER_REGISTRATION_TOKEN: RUNNER_REGISTRATION_TOKEN,
+					SANDBOX_API_RUNNER_API_KEY: RUNNER_API_KEY,
+					SANDBOX_API_GRPC_TLS_CERT_FILE: '/tls/grpc-server.crt',
+					SANDBOX_API_GRPC_TLS_KEY_FILE: '/tls/grpc-server.key',
+					SANDBOX_API_GRPC_TLS_CLIENT_CA_FILE: '/tls/ca.crt',
+					SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_CA_FILE: '/tls/ca.crt',
+					SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_CERT_FILE: '/tls/control-grpc-api-client.crt',
+					SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_KEY_FILE: '/tls/control-grpc-api-client.key',
+					SANDBOX_API_RUNNER_CONTROL_GRPC_TLS_SERVER_NAME: RUNNER_HOST,
+					SANDBOX_API_LOG_LEVEL: 'warn',
+				})
+				.withWaitStrategy(
+					Wait.forHttp('/healthz', API_HTTP_PORT).forStatusCode(200).withStartupTimeout(60000),
+				)
+				.withLabels(labelsFor(projectName, API_HOST))
+				.withReuse()
+				.withLogConsumer(consumer)
+				.start();
+
+			const runnerContainer = await new GenericContainer(
+				TEST_CONTAINER_IMAGES.n8nSandboxServiceRunner,
+			)
+				.withName(`${projectName}-${RUNNER_HOST}`)
+				.withNetwork(network)
+				.withNetworkAliases(RUNNER_HOST)
+				.withPrivilegedMode()
+				.withExposedPorts(RUNNER_HTTP_PORT)
+				.withBindMounts([{ source: join(tlsDir, 'runner'), target: '/tls', mode: 'ro' }])
+				.withEnvironment({
+					SANDBOX_RUNNER_API_KEYS: RUNNER_API_KEY,
+					SANDBOX_RUNNER_REGISTRATION_TOKEN: RUNNER_REGISTRATION_TOKEN,
+					SANDBOX_RUNNER_API_GRPC_ADDR: `${API_HOST}:9090`,
+					SANDBOX_RUNNER_HTTP_BASE_URL: `http://${RUNNER_HOST}:${RUNNER_HTTP_PORT}`,
+					SANDBOX_RUNNER_CONTROL_GRPC_LISTEN_ADDR: ':9091',
+					SANDBOX_RUNNER_CONTROL_GRPC_ADVERTISE_ADDR: `${RUNNER_HOST}:9091`,
+					SANDBOX_RUNNER_ID: 'ci-runner-1',
+					SANDBOX_RUNNER_DOCKER_SANDBOX_IMAGE: TEST_CONTAINER_IMAGES.n8nSandboxServiceSandbox,
+					SANDBOX_RUNNER_LOG_LEVEL: 'warn',
+					SANDBOX_RUNNER_REGISTRATION_GRPC_CA_FILE: '/tls/ca.crt',
+					SANDBOX_RUNNER_REGISTRATION_GRPC_CERT_FILE: '/tls/grpc-client.crt',
+					SANDBOX_RUNNER_REGISTRATION_GRPC_KEY_FILE: '/tls/grpc-client.key',
+					SANDBOX_RUNNER_REGISTRATION_GRPC_SERVER_NAME: API_HOST,
+					SANDBOX_RUNNER_CONTROL_GRPC_TLS_CERT_FILE: '/tls/control-grpc-server.crt',
+					SANDBOX_RUNNER_CONTROL_GRPC_TLS_KEY_FILE: '/tls/control-grpc-server.key',
+					SANDBOX_RUNNER_CONTROL_GRPC_TLS_CLIENT_CA_FILE: '/tls/ca.crt',
+				})
+				.withWaitStrategy(
+					Wait.forHttp('/healthz', RUNNER_HTTP_PORT)
+						.withHeaders({ 'X-Api-Key': RUNNER_API_KEY })
+						.forStatusCode(200)
+						.withStartupTimeout(120000),
+				)
+				.withLabels(labelsFor(projectName, RUNNER_HOST))
+				.withReuse()
+				.withLogConsumer(consumer)
+				.start();
+
+			const externalServiceUrl = `http://${apiContainer.getHost()}:${apiContainer.getMappedPort(
+				API_HTTP_PORT,
+			)}`;
+
+			return {
+				container: apiContainer,
+				containers: [apiContainer, runnerContainer],
+				meta: {
+					internalServiceUrl: `http://${API_HOST}:${API_HTTP_PORT}`,
+					externalServiceUrl,
+					apiKey: API_KEY,
+					tlsDir,
+				},
+			};
+		} catch (error) {
+			return throwWithLogs(error);
+		}
+	},
+
+	env(result: N8nSandboxResult, external?: boolean): Record<string, string> {
+		return {
+			N8N_INSTANCE_AI_SANDBOX_ENABLED: 'true',
+			N8N_INSTANCE_AI_SANDBOX_PROVIDER: 'n8n-sandbox',
+			N8N_SANDBOX_SERVICE_URL: external
+				? result.meta.externalServiceUrl
+				: result.meta.internalServiceUrl,
+			N8N_SANDBOX_SERVICE_API_KEY: result.meta.apiKey,
+		};
+	},
+
+	async verifyFromN8n(
+		result: N8nSandboxResult,
+		n8nContainers: StartedTestContainer[],
+	): Promise<void> {
+		const healthUrl = `${result.meta.internalServiceUrl}/healthz`;
+		const script = `
+const url = ${JSON.stringify(healthUrl)};
+const apiKey = ${JSON.stringify(result.meta.apiKey)};
+fetch(url, { headers: { 'X-Api-Key': apiKey } })
+  .then((response) => {
+    if (!response.ok) {
+      console.error('Unexpected status', response.status);
+      process.exit(1);
+    }
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+`;
+
+		for (const container of n8nContainers) {
+			const check = await container.exec(['node', '-e', script]);
+			if (check.exitCode !== 0) {
+				throw formatExecFailure(
+					`${container.getName()} could not reach n8n sandbox service`,
+					check.output,
+				);
+			}
+		}
+	},
+};

--- a/packages/testing/containers/services/registry.ts
+++ b/packages/testing/containers/services/registry.ts
@@ -8,6 +8,7 @@ import { loadBalancer } from './load-balancer';
 import { localstack, createLocalStackHelper } from './localstack';
 import { mailpit, createMailpitHelper } from './mailpit';
 import { mysqlService } from './mysql';
+import { n8nSandbox } from './n8n-sandbox';
 import { ngrok } from './ngrok';
 import { createObservabilityHelper } from './observability';
 import { postgres, createPostgresHelper } from './postgres';
@@ -43,6 +44,7 @@ export const services: Record<ServiceName, Service<ServiceResult>> = {
 	kent,
 	postgresExporter,
 	cadvisor,
+	n8nSandbox,
 };
 
 export const helperFactories: Partial<HelperFactories> = {

--- a/packages/testing/containers/services/types.ts
+++ b/packages/testing/containers/services/types.ts
@@ -24,6 +24,7 @@ export const SERVICE_NAMES = [
 	'kent',
 	'postgresExporter',
 	'cadvisor',
+	'n8nSandbox',
 ] as const;
 
 export type ServiceName = (typeof SERVICE_NAMES)[number];

--- a/packages/testing/containers/test-containers.ts
+++ b/packages/testing/containers/test-containers.ts
@@ -43,6 +43,9 @@ const DEFAULT_IMAGES = {
 	localstack: 'localstack/localstack:4.13.1',
 	postgresExporter: 'prometheuscommunity/postgres-exporter:v0.17.1',
 	cadvisor: 'gcr.io/cadvisor/cadvisor:v0.49.1',
+	n8nSandboxServiceApi: 'n8nio/n8n-sandbox-service-api:latest',
+	n8nSandboxServiceRunner: 'n8nio/n8n-sandbox-service-runner-dind:latest',
+	n8nSandboxServiceSandbox: 'n8nio/n8n-sandbox-service-sandbox:latest',
 } as const;
 
 /** Convert camelCase to SCREAMING_SNAKE_CASE for env var names */
@@ -121,4 +124,7 @@ export const TEST_CONTAINER_IMAGES = {
 	localstack: getImage('localstack'),
 	postgresExporter: getImage('postgresExporter'),
 	cadvisor: getImage('cadvisor'),
+	n8nSandboxServiceApi: getImage('n8nSandboxServiceApi'),
+	n8nSandboxServiceRunner: getImage('n8nSandboxServiceRunner'),
+	n8nSandboxServiceSandbox: getImage('n8nSandboxServiceSandbox'),
 } as const;


### PR DESCRIPTION
## Summary
Adds n8n sandbox service support to the Testcontainers-based n8n stack.

This introduces a reusable `n8nSandbox` service that starts the sandbox API and DinD runner sidecars on the stack network, generates the required mTLS certificates, exposes host-compatible env vars for local `pnpm dev`, and registers the sandbox images for local overrides.

Key changes:
- Add `packages/testing/containers/services/n8n-sandbox.ts`
- Register `n8nSandbox` in the service registry and service names
- Add sandbox service image defaults and `TEST_IMAGE_N8N_SANDBOX_SERVICE_*` overrides
- Add `--sandbox=n8n-sandbox` support to `pnpm stack` / `pnpm services`
- Redact sensitive env values in the services summary while still writing real values to `packages/cli/bin/.env`
- Document the service in the test containers README

This PR only adds the container plumbing. The Instance AI runtime changes that depend on this service are in the follow-up PR.

How to test:

```bash
pnpm --filter n8n-containers lint
pnpm --filter n8n-containers format:check
pnpm --filter n8n-containers stack:help
pnpm --filter n8n-containers services --sandbox=n8n-sandbox
```

## Related Linear tickets, Github issues, and Community forum posts

Related to https://linear.app/n8n/issue/CAT-3198

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

