### PR TITLE
fix(editor): Avoid recursive name collision in N8nToggle (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nToggle/Toggle.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nToggle/Toggle.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { Toggle, ToggleGroupItem, type AcceptableValue } from 'reka-ui';
+import { Toggle as TogglePrimitive, ToggleGroupItem, type AcceptableValue } from 'reka-ui';
 import { computed, ref, useAttrs, useCssModule } from 'vue';
 
 import type { IconName } from '@n8n/design-system/components/N8nIcon/icons';
@@ -88,7 +88,7 @@ const pressed = computed({
 			</span>
 		</ToggleGroupItem>
 
-		<Toggle
+		<TogglePrimitive
 			v-else
 			v-bind="attrs"
 			v-model="pressed"
@@ -103,7 +103,7 @@ const pressed = computed({
 				<N8nIcon v-if="icon" :icon="icon" :size="computedIconSize" />
 				<slot />
 			</span>
-		</Toggle>
+		</TogglePrimitive>
 	</N8nTooltip>
 </template>
 


### PR DESCRIPTION
## Summary

The SFC at `packages/frontend/@n8n/design-system/src/components/N8nToggle/Toggle.vue` imports `Toggle` from `reka-ui` and uses `<Toggle>` in its `<template>`. Because the SFC's own filename-derived component name is also `Toggle`, vue-tsc resolves the template tag to the SFC's recursive self-reference (which requires the `label` prop) instead of the imported `reka-ui` primitive. This produced the following TS2345 in CI:

```
../design-system/src/components/N8nToggle/Toggle.vue:91:4 - error TS2345:
Argument of type '{ "aria-label": string; dataIconOnly: string; class: string; modelValue: boolean; ... }'
is not assignable to parameter of type '{ readonly modelValue?: boolean | null | undefined;
readonly value?: AcceptableValue | undefined; readonly label: string; ... }'.
```

The error blocked `pnpm turbo test:changed --filter=n8n-nodes-base` on every PR touching `packages/nodes-base/**`, because that task transitively builds `@n8n/design-system` and vue-tsc fails before tests can run.

Introduced by #29987 (commit `e71837765b`).

## Fix

Rename the `reka-ui` `Toggle` import to `TogglePrimitive` in `<script setup>` so the template tag is unambiguous, and update the matching `<Toggle>` / `</Toggle>` pair in the `v-else` branch (line 91) to `<TogglePrimitive>` / `</TogglePrimitive>`. `<ToggleGroupItem>` is left untouched since its name doesn't collide.

Public component API (props, emits, slots, exported `ToggleProps` type) is unchanged, so callers (e.g. `McpAccessToggle` in editor-ui) keep working without any edits.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included. (Existing `Toggle.test.ts` covers both branches; no new test needed — the change is a non-semantic rename to disambiguate the template token.)
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

## Test plan

- [x] `pnpm --filter @n8n/design-system typecheck` passes
- [x] `pnpm turbo build --filter=@n8n/design-system` passes (9/9 tasks)
- [x] `pnpm --filter @n8n/design-system test` passes (1096/1096 tests, including `Toggle.test.ts` and the `<N8nToggle>` recursive template tests in `N8nToggleGroup` usage)
- [x] `pnpm turbo typecheck --filter=n8n-editor-ui` passes (49/49 tasks — exercises the `MCPHeaderActions` / `McpAccessToggle` consumer)
- [ ] CI: confirm `n8n-nodes-base#test:changed` is unblocked on a downstream PR (e.g. #31255)