### PR TITLE
fix: correct typo 'teh' -> 'the' in code comments

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/document/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/document/analyze.operation.ts
@@ -54,7 +54,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the document(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the document(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/image/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/image/analyze.operation.ts
@@ -53,7 +53,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the image(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the image(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/audio/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/audio/analyze.operation.ts
@@ -53,7 +53,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the audio(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the audio(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/audio/transcribe.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/audio/transcribe.operation.ts
@@ -50,7 +50,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the audio(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the audio(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/document/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/document/analyze.operation.ts
@@ -54,7 +54,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the document(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the document(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/video/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/video/analyze.operation.ts
@@ -53,7 +53,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the video(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the video(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],

--- a/packages/cli/src/services/credentials-tester.service.ts
+++ b/packages/cli/src/services/credentials-tester.service.ts
@@ -116,7 +116,7 @@ export class CredentialsTester {
 
 			// Check each of the node versions for credential tests
 			for (const nodeType of allNodeTypes) {
-				// Check each of teh credentials
+				// Check each of the credentials
 				for (const { name, testedBy } of nodeType.description.credentials ?? []) {
 					if (
 						name === credentialType &&

--- a/packages/frontend/@n8n/design-system/src/components/TableHeaderControlsButton/TableHeaderControlsButton.vue
+++ b/packages/frontend/@n8n/design-system/src/components/TableHeaderControlsButton/TableHeaderControlsButton.vue
@@ -14,7 +14,7 @@ export type ColumnHeader =
 			visible: boolean;
 			disabled: false;
 	  }
-	// Disabled state ensures current sort order is not lost if user resorts teh columns
+	// Disabled state ensures current sort order is not lost if user resorts the columns
 	// even if some columns are disabled / not available in the current run
 	| { key: string; disabled: true };
 

--- a/packages/nodes-base/nodes/Cortex/ResponderDescription.ts
+++ b/packages/nodes-base/nodes/Cortex/ResponderDescription.ts
@@ -69,7 +69,7 @@ export const responderFields: INodeProperties[] = [
 		type: 'boolean',
 		default: false,
 		// eslint-disable-next-line n8n-nodes-base/node-param-description-boolean-without-whether
-		description: 'Choose between providing JSON object or seperated attributes',
+		description: 'Choose between providing JSON object or separated attributes',
 		displayOptions: {
 			show: {
 				resource: ['responder'],

--- a/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
@@ -205,7 +205,7 @@ export class GitlabTrigger implements INodeType {
 						return false;
 					}
 
-					// Some error occured
+					// Some error occurred
 					throw error;
 				}
 

--- a/packages/nodes-base/nodes/Keap/EmailDescription.ts
+++ b/packages/nodes-base/nodes/Keap/EmailDescription.ts
@@ -308,7 +308,7 @@ export const emailFields: INodeProperties[] = [
 			},
 		},
 		default: '',
-		description: 'Contact IDs to receive the email. Multiple can be added seperated by comma.',
+		description: 'Contact IDs to receive the email. Multiple can be added separated by comma.',
 	},
 	{
 		displayName: 'Subject',

--- a/packages/nodes-base/nodes/Stripe/StripeTrigger.node.ts
+++ b/packages/nodes-base/nodes/Stripe/StripeTrigger.node.ts
@@ -877,7 +877,7 @@ export class StripeTrigger implements INodeType {
 						return false;
 					}
 
-					// Some error occured
+					// Some error occurred
 					throw error;
 				}
 


### PR DESCRIPTION
Corrects minor spelling typos in code comments across CLI and design-system packages. No functional changes.