### PR TITLE
chore(core): Remove redundant memory string from OM (no-changelog)

### DIFF
--- a/packages/@n8n/agents/src/runtime/__tests__/message-list.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/message-list.test.ts
@@ -143,17 +143,17 @@ describe('AgentMessageList — forLlm observation memory', () => {
 	it('injects the rendered observation log into the system prompt', () => {
 		const list = new AgentMessageList();
 		list.observationLogMemory = [
-			'## Memory',
-			'',
+			'<observations>',
 			'The following is your memory of this conversation.',
 			'',
 			'* CRITICAL (14:30) User wants the SDK to stay unopinionated.',
+			'</observations>',
 		].join('\n');
 
 		const prompt = systemContent(list);
 
 		expect(prompt).toContain('Base instructions');
-		expect(prompt).toContain('## Memory');
+		expect(prompt).toContain('<observations>');
 		expect(prompt).toContain('* CRITICAL (14:30) User wants the SDK to stay unopinionated.');
 	});
 

--- a/packages/@n8n/agents/src/runtime/__tests__/observation-log-observer.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/observation-log-observer.test.ts
@@ -69,7 +69,7 @@ describe('observation-log observer defaults', () => {
 			transcriptTokenCount: 42,
 			observationLogTail: [],
 			renderedObservationLogTail:
-				'## Memory\n\n* CRITICAL (14:28) User is rebuilding observational memory.',
+				'<observations>\n* CRITICAL (14:28) User is rebuilding observational memory.\n</observations>',
 		});
 
 		expect(prompt).toContain('Current timestamp: 2026-05-12T14:30:00.000Z');

--- a/packages/@n8n/agents/src/runtime/__tests__/observation-log-renderer.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/observation-log-renderer.test.ts
@@ -40,8 +40,6 @@ describe('renderObservationLog', () => {
 		expect(renderObservationLog([child, dropped, parent])).toBe(
 			[
 				'<observations>',
-				'## Memory',
-				'',
 				'The following is your memory of this conversation. It accumulates as observations are made. Older entries may have been merged or dropped during periodic restructuring.',
 				'Marker legend: CRITICAL = must retain, IMPORTANT = useful continuity, INFO = contextual detail, COMPLETION = completed/resolved.',
 				'',

--- a/packages/@n8n/agents/src/runtime/observation-log-renderer.ts
+++ b/packages/@n8n/agents/src/runtime/observation-log-renderer.ts
@@ -78,7 +78,7 @@ export function renderObservationLog(
 
 	if (roots.length === 0) return null;
 
-	const lines: string[] = ['<observations>', '## Memory', '', MEMORY_INTRO, MARKER_LEGEND, ''];
+	const lines: string[] = ['<observations>', MEMORY_INTRO, MARKER_LEGEND, ''];
 	for (const root of roots) {
 		lines.push(renderBullet(root));
 		for (const child of childrenByParent.get(root.id) ?? []) {

--- a/packages/cli/src/modules/agents/__tests__/observation-log-observer.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/observation-log-observer.test.ts
@@ -28,7 +28,7 @@ describe('n8n observation-log observer policy', () => {
 			transcriptTokenCount: 42,
 			observationLogTail: [],
 			renderedObservationLogTail:
-				'## Memory\n\n* CRITICAL (14:28) User is rebuilding observational memory.',
+				'<observations>\n* CRITICAL (14:28) User is rebuilding observational memory.\n</observations>',
 		});
 
 		expect(prompt).toContain('Current timestamp: 2026-05-12T14:30:00.000Z');


### PR DESCRIPTION
## Summary

Removes redundant memory string from OM prompts

## Related Linear tickets, Github issues, and Community forum posts

Resolves https://linear.app/n8n/issue/INS-392/remove-redundant-memory-heading

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
