### PR TITLE
fix(editor): Drop nodes grouping validation for single main io on the start and end group nodes (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -3862,8 +3862,6 @@
 	"canvas.nodeGroup.connectionRemoveBlocked.title": "Connection not removed",
 	"canvas.nodeGroup.connectionChangeBlocked.message": "This change would break '{group}'. You can make this change after ungrouping it.",
 	"canvas.nodeGroup.connectionChangeBlocked.nonMainBoundary": "The sub-node connection between '{source}' and '{target}' crosses the boundary of '{group}'. You can make this change after ungrouping it.",
-	"canvas.nodeGroup.connectionChangeBlocked.multipleInputBranches": "'{group}' can have only one main input branch. You can make this change after ungrouping it.",
-	"canvas.nodeGroup.connectionChangeBlocked.multipleOutputBranches": "'{group}' can have only one main output branch. You can make this change after ungrouping it.",
 	"canvas.nodeGroup.connectionChangeBlocked.multipleInputNodes": "'{group}' can have only one entry point. You can make this change after ungrouping it.",
 	"canvas.nodeGroup.connectionChangeBlocked.inputEdgeToNonRoot": "Connections into '{group}' must go to its first node. You can make this change after ungrouping it.",
 	"canvas.nodeGroup.connectionChangeBlocked.multipleOutputNodes": "'{group}' can have only one exit point. You can make this change after ungrouping it.",

--- a/packages/frontend/editor-ui/src/app/composables/useSelectionValidation.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useSelectionValidation.test.ts
@@ -429,7 +429,7 @@ describe('useSelectionValidation', () => {
 		}
 	});
 
-	it('returns multiple-output-branches for an end node with multiple main outputs', () => {
+	it('allows grouping an end node with multiple main outputs', () => {
 		const graph = makeLinearGraph();
 		const nodeTypes: Record<string, INodeTypeDescription> = {
 			'n8n-nodes-base.set': makeNodeType({ name: 'n8n-nodes-base.set' }),
@@ -444,13 +444,31 @@ describe('useSelectionValidation', () => {
 		const { isSelectionGroupable } = useSelectionValidation();
 		const result = isSelectionGroupable(['a', 'b']);
 
+		expect(result.valid).toBe(true);
+	});
+
+	it('returns multiple-output-branches for extraction when the end node has multiple main outputs', () => {
+		const graph = makeLinearGraph();
+		const nodeTypes: Record<string, INodeTypeDescription> = {
+			'n8n-nodes-base.set': makeNodeType({ name: 'n8n-nodes-base.set' }),
+			'n8n-nodes-base.if': makeNodeType({
+				name: 'n8n-nodes-base.if',
+				outputs: ['main', 'main'],
+			}),
+		};
+		graph.nodes.b.type = 'n8n-nodes-base.if';
+		setupGraph(graph, nodeTypes);
+
+		const { isSelectionExtractable } = useSelectionValidation();
+		const result = isSelectionExtractable(['a', 'b']);
+
 		expect(result.valid).toBe(false);
 		if (!result.valid) {
 			expect(result.reason).toBe('multiple-output-branches');
 		}
 	});
 
-	it('resolves dynamic outputs before validating end node branch count', () => {
+	it('resolves dynamic outputs before validating end node branch count for extraction', () => {
 		const graph = makeLinearGraph();
 		const nodeTypes: Record<string, INodeTypeDescription> = {
 			'n8n-nodes-base.set': makeNodeType({ name: 'n8n-nodes-base.set' }),
@@ -464,8 +482,8 @@ describe('useSelectionValidation', () => {
 
 		const getNodeOutputsSpy = vi.spyOn(NodeHelpers, 'getNodeOutputs');
 
-		const { isSelectionGroupable } = useSelectionValidation();
-		const result = isSelectionGroupable(['a', 'b']);
+		const { isSelectionExtractable } = useSelectionValidation();
+		const result = isSelectionExtractable(['a', 'b']);
 
 		expect(getNodeOutputsSpy).toHaveBeenCalledWith(
 			expect.objectContaining({ expression: expect.any(Object) }),
@@ -478,7 +496,7 @@ describe('useSelectionValidation', () => {
 		}
 	});
 
-	it('includes the continueErrorOutput branch when validating end node branch count', () => {
+	it('allows grouping when the end node has an error output branch', () => {
 		const graph = makeLinearGraph();
 		const nodeTypes: Record<string, INodeTypeDescription> = {
 			'n8n-nodes-base.set': makeNodeType({ name: 'n8n-nodes-base.set' }),
@@ -488,6 +506,20 @@ describe('useSelectionValidation', () => {
 
 		const { isSelectionGroupable } = useSelectionValidation();
 		const result = isSelectionGroupable(['a', 'b']);
+
+		expect(result.valid).toBe(true);
+	});
+
+	it('returns multiple-output-branches for extraction when the end node has an error output branch', () => {
+		const graph = makeLinearGraph();
+		const nodeTypes: Record<string, INodeTypeDescription> = {
+			'n8n-nodes-base.set': makeNodeType({ name: 'n8n-nodes-base.set' }),
+		};
+		graph.nodes.b.onError = 'continueErrorOutput';
+		setupGraph(graph, nodeTypes);
+
+		const { isSelectionExtractable } = useSelectionValidation();
+		const result = isSelectionExtractable(['a', 'b']);
 
 		expect(result.valid).toBe(false);
 		if (!result.valid) {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupOperationGuards.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupOperationGuards.ts
@@ -33,12 +33,6 @@ const BLOCKED_TITLE_KEY: Record<ConnectionChangeAction, BaseTextKey> = {
 	remove: 'canvas.nodeGroup.connectionRemoveBlocked.title',
 };
 
-const MESSAGE_KEY_BY_REASON: Partial<Record<InvalidGroupValidationResult['reason'], BaseTextKey>> =
-	{
-		'multiple-input-branches': 'canvas.nodeGroup.connectionChangeBlocked.multipleInputBranches',
-		'multiple-output-branches': 'canvas.nodeGroup.connectionChangeBlocked.multipleOutputBranches',
-	};
-
 const MESSAGE_KEY_BY_ERROR_CODE: Record<ExtractableErrorCode, BaseTextKey> = {
 	'Multiple Input Nodes': 'canvas.nodeGroup.connectionChangeBlocked.multipleInputNodes',
 	'Input Edge To Non-Root Node': 'canvas.nodeGroup.connectionChangeBlocked.inputEdgeToNonRoot',
@@ -171,8 +165,7 @@ export function useCanvasNodeGroupOperationGuards() {
 				? MESSAGE_KEY_BY_ERROR_CODE[result.errors[0].errorCode]
 				: undefined;
 
-		const key: BaseTextKey =
-			errorCodeKey ?? MESSAGE_KEY_BY_REASON[result.reason] ?? FALLBACK_MESSAGE_KEY;
+		const key: BaseTextKey = errorCodeKey ?? FALLBACK_MESSAGE_KEY;
 		return i18n.baseText(key, { interpolate: groupInterpolation });
 	}
 

--- a/packages/testing/playwright/tests/e2e/workflows/editor/canvas/node-groups.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/canvas/node-groups.spec.ts
@@ -4,12 +4,14 @@ import { test, expect } from '../../../../../fixtures/base';
 import type { TestRequirements } from '../../../../../Types';
 
 const FIXTURE = 'Canvas-node-groups-fixture.json';
+const IF_FIXTURE = 'Canvas-node-groups-if-fixture.json';
 const PERSISTED_FIXTURE = 'Canvas-node-groups-persisted-fixture.json';
 const TRIGGER = 'When clicking ‘Execute workflow’';
 const DEFAULT_GROUP_TITLE = 'Group 1';
 const PERSISTED_GROUP_TITLE = 'Persisted group';
 const SET_A_NODE_ID = 'b2e0f1a8-5b8f-4b2b-a0c2-9b3e2d2a0002';
 const SET_B_NODE_ID = 'c3f1a2b8-6c9f-4c2c-b0d2-aa4f3e3b0003';
+const AUTOSAVE_TIMEOUT = 5_000;
 
 // PERSISTED_FIXTURE has 4 workflow nodes but one group containing 2 of them.
 // Groups load collapsed by default, so only 2 canvas nodes render (trigger + Set C).
@@ -35,7 +37,6 @@ test.describe(
 			await setupRequirements(requirements);
 			const importResult = await n8n.start.fromImportedWorkflow(FIXTURE);
 			workflowId = importResult.workflowId;
-			await expect(n8n.canvas.getCanvasNodes()).toHaveCount(4);
 			await n8n.canvas.clickZoomToFitButton();
 			await n8n.canvas.deselectAll();
 		});
@@ -153,7 +154,9 @@ test.describe(
 		test('includes nodeGroups in the autosave PATCH payload', async ({ n8n }) => {
 			await n8n.canvas.selectNodes(['Set A', 'Set B']);
 
-			const saveResponsePromise = n8n.canvas.waitForSaveWorkflowCompleted();
+			const saveResponsePromise = n8n.canvas.waitForSaveWorkflowCompleted({
+				timeout: AUTOSAVE_TIMEOUT,
+			});
 			await n8n.canvas.selectionToolbar.groupButton().click();
 			await expect(n8n.canvas.getNodeGroups()).toHaveCount(1);
 
@@ -176,10 +179,14 @@ test.describe(
 
 		test('persists groups after autosave and reload', async ({ n8n }) => {
 			await n8n.canvas.selectNodes(['Set A', 'Set B']);
+
+			const saveResponsePromise = n8n.canvas.waitForSaveWorkflowCompleted({
+				timeout: AUTOSAVE_TIMEOUT,
+			});
 			await n8n.canvas.selectionToolbar.groupButton().click();
 			await expect(n8n.canvas.getNodeGroups()).toHaveCount(1);
 
-			await n8n.canvas.waitForSaveWorkflowCompleted();
+			await saveResponsePromise;
 
 			const persisted = await n8n.api.workflows.getWorkflow(workflowId);
 			expect(persisted.nodeGroups).toEqual(
@@ -225,6 +232,36 @@ test.describe(
 
 			const after = await n8n.canvas.getNodeGroupBoundingBox(DEFAULT_GROUP_TITLE);
 			expect(after.width).toBeGreaterThan(before.width);
+		});
+	},
+);
+
+test.describe(
+	'Canvas node groups with multi-output boundary',
+	{
+		annotation: [{ type: 'owner', description: 'Adore' }],
+	},
+	() => {
+		test.beforeEach(async ({ n8n, setupRequirements }) => {
+			await setupRequirements(requirements);
+			await n8n.start.fromImportedWorkflow(IF_FIXTURE);
+			await n8n.canvas.clickZoomToFitButton();
+			await n8n.canvas.deselectAll();
+		});
+
+		test('allows grouping but not extraction when the selection ends in an IF node with both branches connected', async ({
+			n8n,
+		}) => {
+			await n8n.canvas.selectNodes(['Set A', 'If']);
+
+			await expect(n8n.canvas.connectionBetweenNodes('If', 'Set B')).toHaveCount(1);
+			await expect(n8n.canvas.connectionBetweenNodes('If', 'Set C')).toHaveCount(1);
+			await expect(n8n.canvas.selectionToolbar.groupButton()).toBeVisible();
+			await expect(n8n.canvas.selectionToolbar.extractSubWorkflowButton()).toBeHidden();
+			await n8n.canvas.selectionToolbar.groupButton().click();
+
+			await expect(n8n.canvas.getNodeGroups()).toHaveCount(1);
+			await expect(n8n.canvas.getNodeGroupTitle(DEFAULT_GROUP_TITLE)).toBeVisible();
 		});
 	},
 );

--- a/packages/testing/playwright/tests/e2e/workflows/editor/canvas/node-groups.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/canvas/node-groups.spec.ts
@@ -37,6 +37,7 @@ test.describe(
 			await setupRequirements(requirements);
 			const importResult = await n8n.start.fromImportedWorkflow(FIXTURE);
 			workflowId = importResult.workflowId;
+			await expect(n8n.canvas.getCanvasNodes()).toHaveCount(4);
 			await n8n.canvas.clickZoomToFitButton();
 			await n8n.canvas.deselectAll();
 		});
@@ -245,6 +246,7 @@ test.describe(
 		test.beforeEach(async ({ n8n, setupRequirements }) => {
 			await setupRequirements(requirements);
 			await n8n.start.fromImportedWorkflow(IF_FIXTURE);
+			await expect(n8n.canvas.getCanvasNodes()).toHaveCount(5);
 			await n8n.canvas.clickZoomToFitButton();
 			await n8n.canvas.deselectAll();
 		});

--- a/packages/testing/playwright/workflows/Canvas-node-groups-if-fixture.json
+++ b/packages/testing/playwright/workflows/Canvas-node-groups-if-fixture.json
@@ -1,0 +1,120 @@
+{
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [0, 0],
+			"id": "f1c5b6a8-1f5b-4a92-9bb2-3e6e8a8a0001",
+			"name": "When clicking ‘Execute workflow’"
+		},
+		{
+			"parameters": {
+				"assignments": {
+					"assignments": [
+						{
+							"id": "0d8c0f6d-fb43-4d62-9c3d-1c8e2e3f0001",
+							"name": "v",
+							"value": "1",
+							"type": "string"
+						}
+					]
+				},
+				"options": {}
+			},
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 3.4,
+			"position": [220, 0],
+			"id": "b2e0f1a8-5b8f-4b2b-a0c2-9b3e2d2a0002",
+			"name": "Set A"
+		},
+		{
+			"parameters": {
+				"conditions": {
+					"options": {
+						"caseSensitive": true,
+						"leftValue": "",
+						"typeValidation": "strict",
+						"version": 2
+					},
+					"conditions": [
+						{
+							"id": "553f50d9-5023-433f-8f62-eebc9c9e2269",
+							"leftValue": "={{ $json.v }}",
+							"rightValue": "1",
+							"operator": {
+								"type": "string",
+								"operation": "equals"
+							}
+						}
+					],
+					"combinator": "and"
+				},
+				"options": {}
+			},
+			"type": "n8n-nodes-base.if",
+			"typeVersion": 2.2,
+			"position": [440, 0],
+			"id": "e5f1a2b8-6c9f-4c2c-b0d2-aa4f3e3b0005",
+			"name": "If"
+		},
+		{
+			"parameters": {
+				"assignments": {
+					"assignments": [
+						{
+							"id": "0d8c0f6d-fb43-4d62-9c3d-1c8e2e3f0002",
+							"name": "v",
+							"value": "true",
+							"type": "string"
+						}
+					]
+				},
+				"options": {}
+			},
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 3.4,
+			"position": [660, -80],
+			"id": "c3f1a2b8-6c9f-4c2c-b0d2-aa4f3e3b0003",
+			"name": "Set B"
+		},
+		{
+			"parameters": {
+				"assignments": {
+					"assignments": [
+						{
+							"id": "0d8c0f6d-fb43-4d62-9c3d-1c8e2e3f0003",
+							"name": "v",
+							"value": "false",
+							"type": "string"
+						}
+					]
+				},
+				"options": {}
+			},
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 3.4,
+			"position": [660, 80],
+			"id": "d4f1a2b8-7c9f-4c2c-b0d2-bb5f3e3b0004",
+			"name": "Set C"
+		}
+	],
+	"connections": {
+		"When clicking ‘Execute workflow’": {
+			"main": [[{ "node": "Set A", "type": "main", "index": 0 }]]
+		},
+		"Set A": {
+			"main": [[{ "node": "If", "type": "main", "index": 0 }]]
+		},
+		"If": {
+			"main": [
+				[{ "node": "Set B", "type": "main", "index": 0 }],
+				[{ "node": "Set C", "type": "main", "index": 0 }]
+			]
+		}
+	},
+	"pinData": {},
+	"meta": {
+		"instanceId": "canvas-node-groups-if-fixture"
+	}
+}

--- a/packages/workflow/src/node-grouping-validation.ts
+++ b/packages/workflow/src/node-grouping-validation.ts
@@ -51,12 +51,77 @@ export type NodeGroupValidationResult<TNode extends INode = INode> =
 			connection: { source: string; target: string; type: string };
 	  };
 
-export function validateNodeSelectionForExtraction<TNode extends INode>({
+export function validateNodeSelectionForExtraction<TNode extends INode>(
+	input: NodeGroupingValidationInput<TNode>,
+): NodeSelectionValidationResult<TNode> {
+	const subgraphResult = validateNodeSelectionSubgraph(input);
+	if (!subgraphResult.valid) return subgraphResult;
+
+	const { start, end } = subgraphResult.subGraphData;
+	const nodesByName = new Map(input.nodes.map((node) => [node.name, node]));
+
+	if (
+		start &&
+		!hasSingleMainIO(
+			start,
+			'inputs',
+			nodesByName,
+			input.getNodeType,
+			input.getNodeInputs,
+			input.getNodeOutputs,
+		)
+	) {
+		return { valid: false, reason: 'multiple-input-branches', node: start };
+	}
+
+	if (
+		end &&
+		!hasSingleMainIO(
+			end,
+			'outputs',
+			nodesByName,
+			input.getNodeType,
+			input.getNodeInputs,
+			input.getNodeOutputs,
+		)
+	) {
+		return { valid: false, reason: 'multiple-output-branches', node: end };
+	}
+
+	return subgraphResult;
+}
+
+export function validateNodeSelectionForGrouping<TNode extends INode>(
+	input: NodeGroupingValidationInput<TNode>,
+): NodeGroupValidationResult<TNode> {
+	const alreadyGroupedNodeIds = findAlreadyGroupedNodeIds(
+		input.nodes.map((node) => node.id),
+		input.existingNodeGroups ?? [],
+	);
+	if (alreadyGroupedNodeIds.length > 0) {
+		return { valid: false, reason: 'node-already-grouped', nodeIds: alreadyGroupedNodeIds };
+	}
+
+	const extractableResult = validateNodeSelectionSubgraph(input);
+	if (!extractableResult.valid) return extractableResult;
+
+	const nodeNames = new Set(extractableResult.subGraph.map((node) => node.name));
+	const boundaryConnection = findNonMainBoundaryConnection(
+		nodeNames,
+		input.connectionsBySourceNode,
+	);
+
+	if (boundaryConnection) {
+		return { valid: false, reason: 'non-main-boundary', connection: boundaryConnection };
+	}
+
+	return extractableResult;
+}
+
+function validateNodeSelectionSubgraph<TNode extends INode>({
 	nodes,
 	connectionsBySourceNode,
 	getNodeType,
-	getNodeInputs,
-	getNodeOutputs,
 }: NodeGroupingValidationInput<TNode>): NodeSelectionValidationResult<TNode> {
 	const triggers = nodes.filter((node) => {
 		const nodeType = getNodeType(node);
@@ -86,51 +151,7 @@ export function validateNodeSelectionForExtraction<TNode extends INode>({
 		return { valid: false, reason: 'invalid-subgraph', errors: [disconnectedSelectionError] };
 	}
 
-	const nodesByName = new Map(nodes.map((node) => [node.name, node]));
-	const { start, end } = selection;
-
-	if (
-		start &&
-		!hasSingleMainIO(start, 'inputs', nodesByName, getNodeType, getNodeInputs, getNodeOutputs)
-	) {
-		return { valid: false, reason: 'multiple-input-branches', node: start };
-	}
-
-	if (
-		end &&
-		!hasSingleMainIO(end, 'outputs', nodesByName, getNodeType, getNodeInputs, getNodeOutputs)
-	) {
-		return { valid: false, reason: 'multiple-output-branches', node: end };
-	}
-
 	return { valid: true, subGraph: nodes, subGraphData: selection };
-}
-
-export function validateNodeSelectionForGrouping<TNode extends INode>(
-	input: NodeGroupingValidationInput<TNode>,
-): NodeGroupValidationResult<TNode> {
-	const alreadyGroupedNodeIds = findAlreadyGroupedNodeIds(
-		input.nodes.map((node) => node.id),
-		input.existingNodeGroups ?? [],
-	);
-	if (alreadyGroupedNodeIds.length > 0) {
-		return { valid: false, reason: 'node-already-grouped', nodeIds: alreadyGroupedNodeIds };
-	}
-
-	const extractableResult = validateNodeSelectionForExtraction(input);
-	if (!extractableResult.valid) return extractableResult;
-
-	const nodeNames = new Set(extractableResult.subGraph.map((node) => node.name));
-	const boundaryConnection = findNonMainBoundaryConnection(
-		nodeNames,
-		input.connectionsBySourceNode,
-	);
-
-	if (boundaryConnection) {
-		return { valid: false, reason: 'non-main-boundary', connection: boundaryConnection };
-	}
-
-	return extractableResult;
 }
 
 function findAlreadyGroupedNodeIds(

--- a/packages/workflow/src/node-grouping-validation.ts
+++ b/packages/workflow/src/node-grouping-validation.ts
@@ -57,33 +57,20 @@ export function validateNodeSelectionForExtraction<TNode extends INode>(
 	const subgraphResult = validateNodeSelectionSubgraph(input);
 	if (!subgraphResult.valid) return subgraphResult;
 
+	const { nodes, getNodeType, getNodeInputs, getNodeOutputs } = input;
 	const { start, end } = subgraphResult.subGraphData;
-	const nodesByName = new Map(input.nodes.map((node) => [node.name, node]));
+	const nodesByName = new Map(nodes.map((node) => [node.name, node]));
 
 	if (
 		start &&
-		!hasSingleMainIO(
-			start,
-			'inputs',
-			nodesByName,
-			input.getNodeType,
-			input.getNodeInputs,
-			input.getNodeOutputs,
-		)
+		!hasSingleMainIO(start, 'inputs', nodesByName, getNodeType, getNodeInputs, getNodeOutputs)
 	) {
 		return { valid: false, reason: 'multiple-input-branches', node: start };
 	}
 
 	if (
 		end &&
-		!hasSingleMainIO(
-			end,
-			'outputs',
-			nodesByName,
-			input.getNodeType,
-			input.getNodeInputs,
-			input.getNodeOutputs,
-		)
+		!hasSingleMainIO(end, 'outputs', nodesByName, getNodeType, getNodeInputs, getNodeOutputs)
 	) {
 		return { valid: false, reason: 'multiple-output-branches', node: end };
 	}

--- a/packages/workflow/test/node-grouping-validation.test.ts
+++ b/packages/workflow/test/node-grouping-validation.test.ts
@@ -255,7 +255,7 @@ describe('node grouping validation', () => {
 		expect(result.valid).toBe(true);
 	});
 
-	it('returns multiple-input-branches for a start node with multiple main inputs', () => {
+	it('allows grouping a start node with multiple main inputs', () => {
 		const graph = makeLinearGraph();
 		graph.nodes[1].type = 'n8n-nodes-base.merge';
 
@@ -271,17 +271,36 @@ describe('node grouping validation', () => {
 			},
 		});
 
+		expect(result.valid).toBe(true);
+	});
+
+	it('returns multiple-input-branches for extraction when the start node has multiple main inputs', () => {
+		const graph = makeLinearGraph();
+		graph.nodes[1].type = 'n8n-nodes-base.merge';
+
+		const result = validateNodeSelectionForExtraction({
+			nodes: [graph.nodes[1], graph.nodes[2]],
+			connectionsBySourceNode: graph.connections,
+			getNodeType: (node) =>
+				node.type === 'n8n-nodes-base.merge'
+					? makeNodeType({
+							name: 'n8n-nodes-base.merge',
+							inputs: [NodeConnectionTypes.Main, NodeConnectionTypes.Main],
+						})
+					: makeNodeType(),
+		});
+
 		expect(result.valid).toBe(false);
 		if (!result.valid) {
 			expect(result.reason).toBe('multiple-input-branches');
 		}
 	});
 
-	it('uses resolved inputs when checking start node branch count', () => {
+	it('uses resolved inputs when checking start node branch count for extraction', () => {
 		const graph = makeLinearGraph();
 		graph.nodes[1].type = 'n8n-nodes-base.merge';
 
-		const result = validateNodeSelectionForGrouping({
+		const result = validateNodeSelectionForExtraction({
 			nodes: [graph.nodes[1], graph.nodes[2]],
 			connectionsBySourceNode: graph.connections,
 			getNodeType: (node) =>
@@ -300,7 +319,7 @@ describe('node grouping validation', () => {
 		}
 	});
 
-	it('returns multiple-output-branches for an end node with multiple main outputs', () => {
+	it('allows grouping an end node with multiple main outputs', () => {
 		const graph = makeLinearGraph();
 		graph.nodes[1].type = 'n8n-nodes-base.if';
 
@@ -316,17 +335,36 @@ describe('node grouping validation', () => {
 			},
 		});
 
+		expect(result.valid).toBe(true);
+	});
+
+	it('returns multiple-output-branches for extraction when the end node has multiple main outputs', () => {
+		const graph = makeLinearGraph();
+		graph.nodes[1].type = 'n8n-nodes-base.if';
+
+		const result = validateNodeSelectionForExtraction({
+			nodes: [graph.nodes[0], graph.nodes[1]],
+			connectionsBySourceNode: graph.connections,
+			getNodeType: (node) =>
+				node.type === 'n8n-nodes-base.if'
+					? makeNodeType({
+							name: 'n8n-nodes-base.if',
+							outputs: [NodeConnectionTypes.Main, NodeConnectionTypes.Main],
+						})
+					: makeNodeType(),
+		});
+
 		expect(result.valid).toBe(false);
 		if (!result.valid) {
 			expect(result.reason).toBe('multiple-output-branches');
 		}
 	});
 
-	it('uses resolved outputs when checking end node branch count', () => {
+	it('uses resolved outputs when checking end node branch count for extraction', () => {
 		const graph = makeLinearGraph();
 		graph.nodes[1].type = 'n8n-nodes-base.switch';
 
-		const result = validateNodeSelectionForGrouping({
+		const result = validateNodeSelectionForExtraction({
 			nodes: [graph.nodes[0], graph.nodes[1]],
 			connectionsBySourceNode: graph.connections,
 			getNodeType: (node) =>


### PR DESCRIPTION
## Summary

Drop nodes grouping validation for single main io on the start and end group nodes.

Enables eg having a merge node as the first node in the group or if node as last
<img width="978" height="413" alt="image" src="https://github.com/user-attachments/assets/b6563bd6-aeb0-4c68-890e-7afe59c78af3" />
<img width="1033" height="305" alt="image" src="https://github.com/user-attachments/assets/a8efe3a4-7047-4947-81b9-f7fecf0ef841" />



## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5304

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI