### PR TITLE
fix(core): Use timestamptz for data table date columns

### DIFF
--- a/packages/cli/src/modules/data-table/__tests__/sql-utils.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/sql-utils.test.ts
@@ -219,6 +219,15 @@ describe('sql-utils', () => {
 
 			expect(query).toBe('ALTER TABLE "data_table_user_abc" ADD "email" DOUBLE PRECISION');
 		});
+
+		it('should use timestamptz for date columns on postgres', () => {
+			const tableName = 'data_table_user_abc';
+			const column = { name: 'registeredAt', type: 'date' as const };
+
+			const query = addColumnQuery(tableName, column, 'postgres');
+
+			expect(query).toBe('ALTER TABLE "data_table_user_abc" ADD "registeredAt" TIMESTAMPTZ');
+		});
 	});
 
 	describe('deleteColumnQuery', () => {

--- a/packages/cli/src/modules/data-table/utils/sql-utils.ts
+++ b/packages/cli/src/modules/data-table/utils/sql-utils.ts
@@ -61,7 +61,7 @@ function dataTableColumnTypeToSql(
 			return 'BOOLEAN';
 		case 'date':
 			if (dbType === 'postgres') {
-				return 'TIMESTAMP';
+				return 'TIMESTAMPTZ';
 			}
 			return 'DATETIME';
 		default:


### PR DESCRIPTION
## Summary

Creating new date data table columns from the UI was using timestamp (no timezone) data type in postgresql which was resulting in an incorrect value being persisted and then shown to the user.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5254

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
