### PR TITLE
fix(editor): Reduce length penalty so longer node names rank fairly

### DIFF
--- a/packages/@n8n/utils/src/search/sublimeSearch.test.ts
+++ b/packages/@n8n/utils/src/search/sublimeSearch.test.ts
@@ -1,22 +1,40 @@
+import { reRankSearchResults } from './reRankSearchResults';
 import topLevel from './snapshots/toplevel.snapshot.json';
 import { sublimeSearch } from './sublimeSearch';
 
+// Mirrors packages/frontend/editor-ui/data/node-popularity.json scaled by the factor
+// applied in useViewStacks.ts. Only the nodes asserted below are included.
+const popularity: Record<string, number> = {
+	/* eslint-disable @typescript-eslint/naming-convention */
+	'n8n-nodes-base.set': 0.959 * 200,
+	'n8n-nodes-base.editImage': 0.617 * 200,
+	'n8n-nodes-base.executeWorkflow': 0.796 * 200,
+	'n8n-nodes-base.executionData': 0.665 * 200,
+	'n8n-nodes-base.executeCommand': 0.681 * 200,
+	'@n8n/n8n-nodes-langchain.agent': 0.975 * 200,
+	/* eslint-enable @typescript-eslint/naming-convention */
+};
+
 describe('sublimeSearch', () => {
 	describe('search finds specific matches first', () => {
-		// Note that this only tests the order of the specified matches
-		// Further results may appear after the listed ones
+		// Mirrors the production pipeline in useViewStacks.ts:
+		//   sublimeSearch(query, items) → reRankSearchResults(results, { popularity })
+		// Note that this only tests the order of the specified matches.
+		// Further results may appear after the listed ones.
 		const testCases: Array<[string, string[]]> = [
 			['set', ['Edit Fields (Set)']],
+			['edit', ['Edit Fields (Set)']],
+			['exec', ['Execute Sub-workflow']],
 			['agent', ['AI Agent', 'Magento 2']],
 		];
 
 		test.each(testCases)(
 			'should return at least "$expectedOrder" for filter "$filter"',
 			(filter, expectedOrder) => {
-				// These match the weights in the production use case
 				const results = sublimeSearch(filter, topLevel);
+				const reRanked = reRankSearchResults(results, { popularity });
 
-				const resultNames = results.map((result) => result.item.properties.displayName);
+				const resultNames = reRanked.map((result) => result.item.properties.displayName);
 				expectedOrder.forEach((expectedName, index) => {
 					expect(resultNames[index]).toBe(expectedName);
 				});

--- a/packages/@n8n/utils/src/search/sublimeSearch.test.ts
+++ b/packages/@n8n/utils/src/search/sublimeSearch.test.ts
@@ -6,12 +6,9 @@ import { sublimeSearch } from './sublimeSearch';
 // applied in useViewStacks.ts. Only the nodes asserted below are included.
 const popularity: Record<string, number> = {
 	/* eslint-disable @typescript-eslint/naming-convention */
-	'n8n-nodes-base.set': 0.959 * 200,
-	'n8n-nodes-base.editImage': 0.617 * 200,
-	'n8n-nodes-base.executeWorkflow': 0.796 * 200,
-	'n8n-nodes-base.executionData': 0.665 * 200,
-	'n8n-nodes-base.executeCommand': 0.681 * 200,
-	'@n8n/n8n-nodes-langchain.agent': 0.975 * 200,
+	'n8n-nodes-base.set': 0.959 * 100,
+	'n8n-nodes-base.editImage': 0.617 * 100,
+	'@n8n/n8n-nodes-langchain.agent': 0.975 * 100,
 	/* eslint-enable @typescript-eslint/naming-convention */
 };
 
@@ -24,7 +21,6 @@ describe('sublimeSearch', () => {
 		const testCases: Array<[string, string[]]> = [
 			['set', ['Edit Fields (Set)']],
 			['edit', ['Edit Fields (Set)']],
-			['exec', ['Execute Sub-workflow']],
 			['agent', ['AI Agent', 'Magento 2']],
 		];
 

--- a/packages/@n8n/utils/src/search/sublimeSearch.ts
+++ b/packages/@n8n/utils/src/search/sublimeSearch.ts
@@ -10,7 +10,7 @@ const FIRST_LETTER_BONUS = 15; // bonus if the first letter is matched
 
 const LEADING_LETTER_PENALTY = -20; // penalty applied for every letter in str before the first match
 const MAX_LEADING_LETTER_PENALTY = -200; // maximum penalty for leading letters
-const UNMATCHED_LETTER_PENALTY = -5;
+const UNMATCHED_LETTER_PENALTY = -2.5;
 
 export const DEFAULT_KEYS = [
 	{ key: 'properties.displayName', weight: 1.3 },

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/composables/useViewStacks.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/composables/useViewStacks.ts
@@ -106,7 +106,7 @@ export interface ViewStack {
 const nodePopularityMap = Object.values(nodePopularity).reduce((acc, node) => {
 	return {
 		...acc,
-		[node.id]: node.popularity * 200, // Scale the popularity score
+		[node.id]: node.popularity * 100, // Scale the popularity score
 	};
 }, {});
 

--- a/packages/frontend/editor-ui/src/features/shared/nodeCreator/composables/useViewStacks.ts
+++ b/packages/frontend/editor-ui/src/features/shared/nodeCreator/composables/useViewStacks.ts
@@ -106,7 +106,7 @@ export interface ViewStack {
 const nodePopularityMap = Object.values(nodePopularity).reduce((acc, node) => {
 	return {
 		...acc,
-		[node.id]: node.popularity * 100, // Scale the popularity score
+		[node.id]: node.popularity * 200, // Scale the popularity score
 	};
 }, {});
 


### PR DESCRIPTION
## Summary

When searching `edit` in the node creator, `Edit Image` ranked above `Edit Fields (Set)` despite Set's much-higher popularity, because `Edit Fields (Set)` is 7 characters longer and the per-unmatched-character penalty (×1.3 displayName weight) was steep enough to outweigh popularity.

Also updates `sublimeSearch.test.ts` to mirror the production pipeline (`sublimeSearch` + `reRankSearchResults` with popularity), since the previous test asserted pure-fuzzy ranking which isn't what users see.

## Impact across ~150 common queries

Scanned 150 common prefix queries against the snapshot. **13 changed their top result** — 12 are improvements, 1 is debatable:

| Query | Before | After | Verdict |
|---|---|---|---|
| `a` | HTTP Request | AI Agent | ✓ |
| `h` / `ht` | HTML | HTTP Request | ✓ |
| `n` | n8n | Notion | ✓ |
| `p` | Code | Postgres | ✓ |
| `s` | SSH | Switch | ✓ |
| `da` | OpenAI | Date & Time | ✓ |
| `ma` | Edit Fields (Set) | Manual Trigger | ✓ |
| `se` | Edit Fields (Set) | Send Email | ✓ |
| `cal` | Execute Sub-workflow | Cal.com Trigger | ✓ |
| **`edit`** | **Edit Image** | **Edit Fields (Set)** | ✓ ADO-5305 fix |
| `image` | QuickChart | Edit Image | ✓ |
| `email` | Gmail | Email Trigger (IMAP) | debatable — Email Trigger literally starts with "email", Gmail matches only via alias |

The `email` case is the only debatable one. It's the same dynamic as the bug we're fixing: a node whose displayName matches the prefix exactly now outranks one that matches only via an alias. Gmail still appears in position 2.

## What we did NOT fix

Earlier in the investigation I tested also bumping the popularity scaling factor (×100 → ×200) to fix `exec` → `Execute Sub-workflow` (currently `Execution Data` wins). That bump caused worse regressions on other queries (`note` → OpenRouter Chat Model, `re` → AI Agent, `tr` → Edit Fields via the "Transform" alias, `mat` → Manual Trigger). Those regressions trace to:
- generic-sounding aliases on popular nodes (Set has `"Transform"`, AI Agent has `"ReAct"`)
- popularity data with zero or missing entries for visible core nodes (Sticky Note popularity is `0`)

These are pre-existing data/algorithm issues. Bumping popularity weight surfaces them without fixing them, so I reverted that change. `exec` ranking is unchanged from master.

## Historical context

This is a recurring tuning problem when new long-named nodes are added:
- PR #4399 (2022) introduced the algorithm. `UNMATCHED_LETTER_PENALTY = -5` was inherited from `lib_fts`, the upstream reference algorithm — never deliberately chosen for n8n's data.
- PR #7215 (2023) tuned `SEQUENTIAL_BONUS` + `LEADING_LETTER_PENALTY` for the same class of problem (`Set` ranking).
- PR #15302 (2025) tuned `SEPARATOR_BONUS` for `agent` vs `Magento 2`.
- This PR is the first time `UNMATCHED_LETTER_PENALTY` has been touched since 2022.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5305

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)