### PR TITLE
feat(core): Preserve real failure in blocked submit-workflow responses

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/submit-workflow-identity.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/submit-workflow-identity.test.ts
@@ -279,12 +279,112 @@ describe('wrapSubmitExecuteWithIdentity', () => {
 		const second = await wrapped({});
 
 		expect(first.remediation).toBe(remediation);
+		// Short-circuited blocked responses preserve the real failure from the
+		// last actual attempt (errors[]) rather than echoing remediation guidance.
+		// The remediation itself is still propagated so the `shouldEdit: false`
+		// signal remains intact.
 		expect(second).toMatchObject({
 			success: false,
-			errors: ['Stop editing.'],
+			errors: ['Workflow save failed.'],
 			remediation,
 		});
 		expect(execute).toHaveBeenCalledTimes(1);
+	});
+
+	it('carries Phase 1 errorDetails and nodeIndex through to short-circuited blocked responses', async () => {
+		// Without this, the AI sees the remediation guidance ("Stop editing.") as the only error signal on follow-up calls
+		// and loses the structured Zod path / offending node JSON / nodeIndex.
+		let terminalRemediation: SubmitWorkflowOutput['remediation'];
+		const remediation = createRemediation({
+			category: 'blocked',
+			shouldEdit: false,
+			reason: 'workflow_save_failed',
+			guidance: 'Stop editing.',
+		});
+		const richFirstFailure: SubmitWorkflowOutput = {
+			success: false,
+			errors: ['Workflow save failed: nodes[9].position invalid_type'],
+			errorDetails: [
+				{
+					path: 'nodes[9].position',
+					code: 'invalid_type',
+					message: 'Expected tuple, received null',
+					offendingValue: null,
+					nodeJson: {
+						name: 'Manual Trigger (temp)',
+						type: 'n8n-nodes-base.manualTrigger',
+					},
+				},
+			],
+			nodeIndex: [
+				{ index: 0, name: 'Gmail Trigger' },
+				{ index: 9, name: 'Manual Trigger (temp)' },
+			],
+			remediation,
+		};
+		const execute = jest
+			.fn<Promise<SubmitWorkflowOutput>, [SubmitWorkflowInput]>()
+			.mockResolvedValueOnce(richFirstFailure)
+			.mockResolvedValueOnce({ success: true, workflowId: 'wf_should_not_save' });
+		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath, {
+			getTerminalRemediation: () => terminalRemediation,
+			onTerminalRemediation: (recorded) => {
+				terminalRemediation = recorded;
+			},
+		});
+
+		await wrapped({});
+		const second = await wrapped({});
+
+		expect(execute).toHaveBeenCalledTimes(1);
+		expect(second).toMatchObject({
+			success: false,
+			errors: ['Workflow save failed: nodes[9].position invalid_type'],
+			errorDetails: richFirstFailure.errorDetails,
+			nodeIndex: richFirstFailure.nodeIndex,
+			remediation,
+		});
+	});
+
+	it('falls back to remediation guidance when no prior failure was captured', async () => {
+		// If a terminal remediation appears before any submit attempt has run
+		// (e.g. carried over from a different code path), there's no real error
+		// to preserve — fall back to the guidance text so the AI still gets a
+		// human-readable explanation rather than an empty errors[].
+		const remediation = createRemediation({
+			category: 'needs_setup',
+			shouldEdit: false,
+			reason: 'mocked_credentials_or_placeholders',
+			guidance: 'Route to setup.',
+		});
+		const state: WorkflowLoopState = {
+			workItemId: 'wi_test',
+			threadId: 'thread_1',
+			runId: 'run_1',
+			phase: 'blocked',
+			status: 'blocked',
+			source: 'create',
+			rebuildAttempts: 0,
+			lastRemediation: remediation,
+		};
+		const execute = jest.fn<Promise<SubmitWorkflowOutput>, [SubmitWorkflowInput]>();
+		const wrapped = wrapSubmitExecuteWithIdentity(execute, resolvePath, {
+			getWorkflowLoopState: async () => {
+				await Promise.resolve();
+				return state;
+			},
+		});
+
+		const result = await wrapped({});
+
+		expect(execute).not.toHaveBeenCalled();
+		expect(result).toMatchObject({
+			success: false,
+			errors: ['Route to setup.'],
+			remediation,
+		});
+		expect(result.errorDetails).toBeUndefined();
+		expect(result.nodeIndex).toBeUndefined();
 	});
 
 	it('returns terminal remediation to concurrent submit waiters when the first submit stops editing', async () => {
@@ -320,9 +420,12 @@ describe('wrapSubmitExecuteWithIdentity', () => {
 		release();
 
 		await expect(first).resolves.toMatchObject({ success: false, remediation });
+		// Concurrent waiters get the same preserved-real-errors treatment as
+		// sequential short-circuits — see the "records terminal submit output"
+		// case above for rationale.
 		await expect(second).resolves.toMatchObject({
 			success: false,
-			errors: ['Stop editing.'],
+			errors: ['Workflow save failed.'],
 			remediation,
 		});
 		expect(execute).toHaveBeenCalledTimes(1);

--- a/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow-identity.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow-identity.ts
@@ -23,6 +23,7 @@ import {
 	submitWorkflowInputSchema,
 	submitWorkflowOutputSchema,
 	type SubmitWorkflowAttempt,
+	type SubmitWorkflowErrorDetail,
 	type SubmitWorkflowInput,
 	type SubmitWorkflowOutput,
 } from './submit-workflow.tool';
@@ -127,6 +128,21 @@ export function wrapSubmitExecuteWithIdentity(
 ): SubmitExecute {
 	const pending = new Map<string, Promise<string>>();
 
+	/**
+	 * Diagnostic data captured from the most recent failed submit, so that
+	 * short-circuited blocked responses can carry the *real* failure context
+	 * instead of just the remediation guidance text. Without this, the AI sees
+	 * a generic "stop editing" message on every follow-up attempt and loses the
+	 * actual error that triggered the block.
+	 */
+	let lastFailedDiagnostic:
+		| {
+				errors?: string[];
+				errorDetails?: SubmitWorkflowErrorDetail[];
+				nodeIndex?: Array<{ index: number; name: string }>;
+		  }
+		| undefined;
+
 	function recordTerminalRemediation(
 		workflowId: string | undefined,
 		remediation: RemediationMetadata | undefined,
@@ -148,6 +164,13 @@ export function wrapSubmitExecuteWithIdentity(
 		fallbackWorkflowId?: string,
 	): SubmitWorkflowOutput {
 		const guarded = options.budgetTracker?.applyToOutput(path, output) ?? output;
+		if (!guarded.success) {
+			lastFailedDiagnostic = {
+				errors: guarded.errors,
+				errorDetails: guarded.errorDetails,
+				nodeIndex: guarded.nodeIndex,
+			};
+		}
 		recordTerminalRemediation(guarded.workflowId ?? fallbackWorkflowId, guarded.remediation);
 		return guarded;
 	}
@@ -167,9 +190,14 @@ export function wrapSubmitExecuteWithIdentity(
 			attemptCount: terminalRemediation.attemptCount,
 			reason: terminalRemediation.reason,
 		});
+
+		const hasRealErrors =
+			lastFailedDiagnostic?.errors !== undefined && lastFailedDiagnostic.errors.length > 0;
 		return {
 			success: false,
-			errors: [terminalRemediation.guidance],
+			errors: hasRealErrors ? lastFailedDiagnostic!.errors : [terminalRemediation.guidance],
+			errorDetails: lastFailedDiagnostic?.errorDetails,
+			nodeIndex: lastFailedDiagnostic?.nodeIndex,
 			remediation: terminalRemediation,
 		};
 	}

--- a/packages/@n8n/instance-ai/src/workflow-loop/__tests__/workflow-loop-controller.test.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/__tests__/workflow-loop-controller.test.ts
@@ -233,6 +233,68 @@ describe('handleBuildOutcome', () => {
 		});
 	});
 
+	it('surfaces the build outcome failureSignature as the blocked reason, not the budget-exhausted guidance', () => {
+		// When the pre-save submit budget is hit, the loop synthesises a fresh terminalRemediation
+		// with generic "budget exhausted" guidance. The orchestrator-visible reason text must come
+		// from the build outcome's real failure (failureSignature / blockingReason) so the AI keeps
+		// seeing the actual error rather than the generic notice. The synthetic remediation still
+		// carries shouldEdit:false - the stop signal lives on the remediation object, not in the error text.
+		const realFailure =
+			'Workflow save failed: nodes[9].parameters (invalid_type): Expected object, received null';
+		let state = makeState({ runId: 'run_1' });
+		const first = handleBuildOutcome(state, [], {
+			...makeOutcome({
+				runId: 'run_1',
+				submitted: false,
+				failureSignature: realFailure,
+				remediation: createRemediation({
+					category: 'code_fixable',
+					shouldEdit: true,
+					guidance: 'Fix code and resubmit.',
+				}),
+			}),
+		});
+		state = first.state;
+		const second = handleBuildOutcome(state, [first.attempt], {
+			...makeOutcome({
+				runId: 'run_1',
+				submitted: false,
+				failureSignature: realFailure,
+				remediation: createRemediation({
+					category: 'code_fixable',
+					shouldEdit: true,
+					guidance: 'Fix code and resubmit.',
+				}),
+			}),
+		});
+		state = second.state;
+		const third = handleBuildOutcome(state, [first.attempt, second.attempt], {
+			...makeOutcome({
+				runId: 'run_1',
+				submitted: false,
+				failureSignature: realFailure,
+				remediation: createRemediation({
+					category: 'code_fixable',
+					shouldEdit: true,
+					guidance: 'Fix code and resubmit.',
+				}),
+			}),
+		});
+
+		expect(third.action.type).toBe('blocked');
+		// The reason text the orchestrator sees is the real failure, not the
+		// "The workflow could not be saved after three submit attempts..." copy
+		// that lives on `state.lastRemediation`.
+		if (third.action.type === 'blocked') {
+			expect(third.action.reason).toBe(realFailure);
+		}
+		expect(third.state.lastRemediation).toMatchObject({
+			category: 'blocked',
+			shouldEdit: false,
+			reason: 'pre_save_submit_budget_exhausted',
+		});
+	});
+
 	it('ignores stale build outcomes from a different run without resetting state', () => {
 		const state = makeState({
 			runId: 'run_current',

--- a/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-controller.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-controller.ts
@@ -124,10 +124,16 @@ export function handleBuildOutcome(
 			outcome.needsUserInput || terminalRemediation?.shouldEdit === false ? 'blocked' : 'failure';
 		attempt.failureSignature = outcome.failureSignature;
 
+		// Prefer the build outcome's own failure description over the remediation
+		// guidance text. The guidance is for "what to do next" (e.g. "budget
+		// exhausted, stop editing") while blockingReason / failureSignature carry
+		// "what went wrong" — the AI needs the latter as the primary error signal.
+		// Falling back to terminal guidance only when the outcome has no specific
+		// failure info preserves the previous behaviour for empty-outcome cases.
 		const reason =
-			terminalRemediation?.guidance ??
 			outcome.blockingReason ??
 			outcome.failureSignature ??
+			terminalRemediation?.guidance ??
 			'Builder failed to submit workflow';
 		const nextState: WorkflowLoopState = {
 			...normalizedState,


### PR DESCRIPTION
## Summary

AI Assistant would sometimes get into those death loops where it really couldn't understand the issue, and one reason was us losing the actual error when retry budget was exhausted.

When the per-file submit budget exhausts or a previous attempt's remediation flips shouldEdit to false, the identity wrapper used to return `errors: [remediation.guidance]` on every subsequent call, burying the actual failure under generic "stop editing" copy. The loop controller compounded this by hoisting `terminalRemediation.guidance` above `outcome.failureSignature` when computing the orchestrator-visible reason text.

Capture each failed submit's errors / errorDetails / nodeIndex in the identity wrapper closure and reuse them in short-circuited blocked responses, falling back to guidance only when no prior failure exists. Flip the loop controller's reason precedence to prefer `outcome.blockingReason` / `outcome.failureSignature` over the remediation guidance. The `shouldEdit: false` "stop" signal still lives on the remediation object — only the error text channel changes.

## Related Linear tickets, Github issues, and Community forum posts

Sibling PR: https://github.com/n8n-io/n8n/pull/31296
https://linear.app/n8n/issue/INS-336/failed-to-edit-workflow-because-it-couldnt-get-node-params-right

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
