### PR TITLE
feat(core): Allow stricter-than-floor workflow redaction updates

### DIFF
--- a/packages/cli/src/modules/redaction/__tests__/redaction-enforcement.service.test.ts
+++ b/packages/cli/src/modules/redaction/__tests__/redaction-enforcement.service.test.ts
@@ -1,53 +1,108 @@
+import type { RedactionEnforcementSettings, RedactionFloor } from '@n8n/api-types';
+import { mock } from 'jest-mock-extended';
+import type { WorkflowSettings } from 'n8n-workflow';
+
+import { floorToSettings } from '@/controllers/redaction-enforcement-mapper';
 import { UnprocessableRequestError } from '@/errors/response-errors/unprocessable.error';
 
-import { RedactionConfig } from '../redaction.config';
+import type { InstanceRedactionEnforcementService } from '../instance-redaction-enforcement.service';
 import { RedactionEnforcementService } from '../redaction-enforcement.service';
 
 describe('RedactionEnforcementService', () => {
-	function createService(enforcement: boolean) {
-		const config = new RedactionConfig();
-		config.enforcement = enforcement;
-		return new RedactionEnforcementService(config);
+	function createService(floor: RedactionFloor) {
+		const instanceRedactionEnforcementService = mock<InstanceRedactionEnforcementService>();
+		const settings: RedactionEnforcementSettings = floorToSettings(floor);
+		instanceRedactionEnforcementService.get.mockResolvedValue(settings);
+		return new RedactionEnforcementService(instanceRedactionEnforcementService);
 	}
 
-	describe('isEnforced()', () => {
-		test('returns true when env flag is on', () => {
-			expect(createService(true).isEnforced()).toBe(true);
-		});
-
-		test('returns false when env flag is off', () => {
-			expect(createService(false).isEnforced()).toBe(false);
-		});
+	describe('getFloor()', () => {
+		test.each<RedactionFloor>(['off', 'production', 'all'])(
+			'returns floor %s from instance settings',
+			async (floor) => {
+				const service = createService(floor);
+				await expect(service.getFloor()).resolves.toBe(floor);
+			},
+		);
 	});
 
 	describe('assertPolicyChangeAllowed()', () => {
-		test('does nothing when enforcement is off', () => {
-			const service = createService(false);
-			expect(() => service.assertPolicyChangeAllowed('none', 'all')).not.toThrow();
+		test('allows when incoming policy is undefined (field not in payload)', async () => {
+			const service = createService('all');
+			await expect(service.assertPolicyChangeAllowed('none', undefined)).resolves.toBeUndefined();
 		});
 
-		test('does nothing when incoming policy is undefined (field not in payload)', () => {
-			const service = createService(true);
-			expect(() => service.assertPolicyChangeAllowed('none', undefined)).not.toThrow();
+		test('allows when incoming policy matches current policy (preserves legacy below-floor state)', async () => {
+			const service = createService('all');
+			await expect(service.assertPolicyChangeAllowed('none', 'none')).resolves.toBeUndefined();
 		});
 
-		test('does nothing when incoming policy matches current policy', () => {
-			const service = createService(true);
-			expect(() => service.assertPolicyChangeAllowed('all', 'all')).not.toThrow();
+		describe('floor=off', () => {
+			test.each<WorkflowSettings.RedactionPolicy>(['none', 'manual-only', 'non-manual', 'all'])(
+				'allows any change to %s',
+				async (incoming) => {
+					const service = createService('off');
+					await expect(service.assertPolicyChangeAllowed('all', incoming)).resolves.toBeUndefined();
+				},
+			);
 		});
 
-		test('throws 422 when incoming policy differs from current and enforcement is on', () => {
-			const service = createService(true);
-			expect(() => service.assertPolicyChangeAllowed('none', 'all')).toThrow(
+		describe('floor=production', () => {
+			test.each<WorkflowSettings.RedactionPolicy>(['non-manual', 'all'])(
+				'allows change to %s (meets or exceeds floor)',
+				async (incoming) => {
+					const service = createService('production');
+					await expect(service.assertPolicyChangeAllowed('all', incoming)).resolves.toBeUndefined();
+				},
+			);
+
+			test.each<WorkflowSettings.RedactionPolicy>(['none', 'manual-only'])(
+				'rejects change to %s (does not redact production)',
+				async (incoming) => {
+					const service = createService('production');
+					await expect(service.assertPolicyChangeAllowed('all', incoming)).rejects.toThrow(
+						UnprocessableRequestError,
+					);
+				},
+			);
+		});
+
+		describe('floor=all', () => {
+			test('allows change to all (matches floor)', async () => {
+				const service = createService('all');
+				await expect(
+					service.assertPolicyChangeAllowed('non-manual', 'all'),
+				).resolves.toBeUndefined();
+			});
+
+			test.each<WorkflowSettings.RedactionPolicy>(['none', 'manual-only', 'non-manual'])(
+				'rejects change to %s (does not redact both channels)',
+				async (incoming) => {
+					const service = createService('all');
+					await expect(service.assertPolicyChangeAllowed('all', incoming)).rejects.toThrow(
+						UnprocessableRequestError,
+					);
+				},
+			);
+		});
+
+		test('error message names the floor as the reason', async () => {
+			const service = createService('production');
+			await expect(service.assertPolicyChangeAllowed('all', 'none')).rejects.toThrow(
+				'Workflow redaction policy cannot be weaker than the instance floor.',
+			);
+		});
+
+		test('rejects upgrade from undefined current to below-floor incoming', async () => {
+			const service = createService('production');
+			await expect(service.assertPolicyChangeAllowed(undefined, 'none')).rejects.toThrow(
 				UnprocessableRequestError,
 			);
 		});
 
-		test('throws when current is undefined and incoming is defined', () => {
-			const service = createService(true);
-			expect(() => service.assertPolicyChangeAllowed(undefined, 'all')).toThrow(
-				UnprocessableRequestError,
-			);
+		test('allows upgrade from undefined current to meets-floor incoming', async () => {
+			const service = createService('production');
+			await expect(service.assertPolicyChangeAllowed(undefined, 'all')).resolves.toBeUndefined();
 		});
 	});
 });

--- a/packages/cli/src/modules/redaction/__tests__/redaction-enforcement.service.test.ts
+++ b/packages/cli/src/modules/redaction/__tests__/redaction-enforcement.service.test.ts
@@ -2,7 +2,7 @@ import type { RedactionEnforcementSettings, RedactionFloor } from '@n8n/api-type
 import { mock } from 'jest-mock-extended';
 import type { WorkflowSettings } from 'n8n-workflow';
 
-import { floorToSettings } from '@/controllers/redaction-enforcement-mapper';
+import { floorToSettings } from '../redaction-enforcement-mapper';
 import { UnprocessableRequestError } from '@/errors/response-errors/unprocessable.error';
 
 import type { InstanceRedactionEnforcementService } from '../instance-redaction-enforcement.service';
@@ -15,16 +15,6 @@ describe('RedactionEnforcementService', () => {
 		instanceRedactionEnforcementService.get.mockResolvedValue(settings);
 		return new RedactionEnforcementService(instanceRedactionEnforcementService);
 	}
-
-	describe('getFloor()', () => {
-		test.each<RedactionFloor>(['off', 'production', 'all'])(
-			'returns floor %s from instance settings',
-			async (floor) => {
-				const service = createService(floor);
-				await expect(service.getFloor()).resolves.toBe(floor);
-			},
-		);
-	});
 
 	describe('assertPolicyChangeAllowed()', () => {
 		test('allows when incoming policy is undefined (field not in payload)', async () => {

--- a/packages/cli/src/modules/redaction/__tests__/redaction-policy.test.ts
+++ b/packages/cli/src/modules/redaction/__tests__/redaction-policy.test.ts
@@ -1,0 +1,47 @@
+import type { RedactionFloor } from '@n8n/api-types';
+import type { WorkflowSettings } from 'n8n-workflow';
+
+import { policyForFloor, policyMeetsFloor } from '../redaction-policy';
+
+type Policy = WorkflowSettings.RedactionPolicy;
+
+describe('policyMeetsFloor', () => {
+	// Exhaustive: every policy × every floor. Single source of truth for the matrix.
+	const CASES: Array<[RedactionFloor, Policy, boolean]> = [
+		['off', 'none', true],
+		['off', 'manual-only', true],
+		['off', 'non-manual', true],
+		['off', 'all', true],
+
+		['production', 'none', false],
+		['production', 'manual-only', false],
+		['production', 'non-manual', true],
+		['production', 'all', true],
+
+		['all', 'none', false],
+		['all', 'manual-only', false],
+		['all', 'non-manual', false],
+		['all', 'all', true],
+	];
+
+	it.each(CASES)('floor=%s, policy=%s → %s', (floor, policy, expected) => {
+		expect(policyMeetsFloor(policy, floor)).toBe(expected);
+	});
+});
+
+describe('policyForFloor', () => {
+	it.each<[RedactionFloor, Policy | undefined]>([
+		['off', undefined],
+		['production', 'non-manual'],
+		['all', 'all'],
+	])('floor=%s seeds %s', (floor, expected) => {
+		expect(policyForFloor(floor)).toBe(expected);
+	});
+
+	// Invariant: a seeded policy always satisfies its own floor.
+	it.each<RedactionFloor>(['production', 'all'])('seed for floor=%s meets that floor', (floor) => {
+		const seed = policyForFloor(floor);
+		expect(seed).toBeDefined();
+		expect(policyMeetsFloor(seed as Policy, floor)).toBe(true);
+	});
+});

--- a/packages/cli/src/modules/redaction/redaction-enforcement.service.ts
+++ b/packages/cli/src/modules/redaction/redaction-enforcement.service.ts
@@ -1,36 +1,74 @@
+import type { RedactionFloor } from '@n8n/api-types';
 import { Service } from '@n8n/di';
 import type { WorkflowSettings } from 'n8n-workflow';
 
+import { settingsToFloor } from '@/controllers/redaction-enforcement-mapper';
 import { UnprocessableRequestError } from '@/errors/response-errors/unprocessable.error';
 
-import { RedactionConfig } from './redaction.config';
+import { InstanceRedactionEnforcementService } from './instance-redaction-enforcement.service';
+
+const POLICY_SCOPE: Record<
+	WorkflowSettings.RedactionPolicy,
+	{ production: boolean; manual: boolean }
+> = {
+	none: { production: false, manual: false },
+	'manual-only': { production: false, manual: true },
+	'non-manual': { production: true, manual: false },
+	all: { production: true, manual: true },
+};
+
+const FLOOR_REQUIREMENTS: Record<RedactionFloor, { production: boolean; manual: boolean }> = {
+	off: { production: false, manual: false },
+	production: { production: true, manual: false },
+	all: { production: true, manual: true },
+};
 
 /**
- * Reports whether the workflow redaction policy is enforced at the instance level
- * and asserts that incoming updates do not modify the policy when enforcement is on.
+ * Reports the active instance redaction floor and asserts that incoming
+ * workflow updates do not weaken the policy below it.
  *
- * The current check reads the env feature flag directly. When the enforcement cache
- * lands, this is the single place to swap in the cache lookup so call sites stay
- * unchanged.
+ * Progressive restriction model: workflows may match or exceed the floor;
+ * changes that would drop the policy below the floor are rejected with 422.
+ * Pre-existing below-floor state is preserved (no retroactive application) —
+ * an update only fails when the *incoming* policy violates the floor.
  */
 @Service()
 export class RedactionEnforcementService {
-	constructor(private readonly config: RedactionConfig) {}
+	constructor(
+		private readonly instanceRedactionEnforcementService: InstanceRedactionEnforcementService,
+	) {}
 
-	isEnforced(): boolean {
-		return this.config.enforcement;
+	async getFloor(): Promise<RedactionFloor> {
+		const settings = await this.instanceRedactionEnforcementService.get();
+		return settingsToFloor(settings);
 	}
 
-	assertPolicyChangeAllowed(
+	async assertPolicyChangeAllowed(
 		currentPolicy: WorkflowSettings.RedactionPolicy | undefined,
 		incomingPolicy: WorkflowSettings.RedactionPolicy | undefined,
-	): void {
-		if (!this.isEnforced()) return;
+	): Promise<void> {
+		// Field absent from payload: nothing to validate.
 		if (incomingPolicy === undefined) return;
+		// Unchanged: preserve legacy below-floor state (no retroactive application).
 		if (incomingPolicy === currentPolicy) return;
 
-		throw new UnprocessableRequestError(
-			'Workflow redaction policy is enforced at the instance level and cannot be modified.',
-		);
+		const floor = await this.getFloor();
+		if (floor === 'off') return;
+
+		this.assertMeetsFloor(incomingPolicy, floor);
+	}
+
+	assertMeetsFloor(policy: WorkflowSettings.RedactionPolicy, floor: RedactionFloor): void {
+		const required = FLOOR_REQUIREMENTS[floor];
+		const scope = POLICY_SCOPE[policy];
+
+		const weakerThanFloor =
+			(required.production && !scope.production) || (required.manual && !scope.manual);
+
+		if (weakerThanFloor) {
+			throw new UnprocessableRequestError(
+				'Workflow redaction policy cannot be weaker than the instance floor.',
+			);
+		}
 	}
 }

--- a/packages/cli/src/modules/redaction/redaction-enforcement.service.ts
+++ b/packages/cli/src/modules/redaction/redaction-enforcement.service.ts
@@ -1,4 +1,3 @@
-import type { RedactionFloor } from '@n8n/api-types';
 import { Service } from '@n8n/di';
 import type { WorkflowSettings } from 'n8n-workflow';
 
@@ -6,22 +5,7 @@ import { settingsToFloor } from './redaction-enforcement-mapper';
 import { UnprocessableRequestError } from '@/errors/response-errors/unprocessable.error';
 
 import { InstanceRedactionEnforcementService } from './instance-redaction-enforcement.service';
-
-const POLICY_SCOPE: Record<
-	WorkflowSettings.RedactionPolicy,
-	{ production: boolean; manual: boolean }
-> = {
-	none: { production: false, manual: false },
-	'manual-only': { production: false, manual: true },
-	'non-manual': { production: true, manual: false },
-	all: { production: true, manual: true },
-};
-
-const FLOOR_REQUIREMENTS: Record<RedactionFloor, { production: boolean; manual: boolean }> = {
-	off: { production: false, manual: false },
-	production: { production: true, manual: false },
-	all: { production: true, manual: true },
-};
+import { policyMeetsFloor, REDACTION_FLOOR_VIOLATION_MESSAGE } from './redaction-policy';
 
 /**
  * Reports the active instance redaction floor and asserts that incoming
@@ -38,7 +22,7 @@ export class RedactionEnforcementService {
 		private readonly instanceRedactionEnforcementService: InstanceRedactionEnforcementService,
 	) {}
 
-	private async getFloor(): Promise<RedactionFloor> {
+	private async getFloor() {
 		const settings = await this.instanceRedactionEnforcementService.get();
 		return settingsToFloor(settings);
 	}
@@ -53,22 +37,8 @@ export class RedactionEnforcementService {
 		if (incomingPolicy === currentPolicy) return;
 
 		const floor = await this.getFloor();
-		if (floor === 'off') return;
-
-		this.assertMeetsFloor(incomingPolicy, floor);
-	}
-
-	private assertMeetsFloor(policy: WorkflowSettings.RedactionPolicy, floor: RedactionFloor): void {
-		const required = FLOOR_REQUIREMENTS[floor];
-		const scope = POLICY_SCOPE[policy];
-
-		const weakerThanFloor =
-			(required.production && !scope.production) || (required.manual && !scope.manual);
-
-		if (weakerThanFloor) {
-			throw new UnprocessableRequestError(
-				'Workflow redaction policy cannot be weaker than the instance floor.',
-			);
+		if (!policyMeetsFloor(incomingPolicy, floor)) {
+			throw new UnprocessableRequestError(REDACTION_FLOOR_VIOLATION_MESSAGE);
 		}
 	}
 }

--- a/packages/cli/src/modules/redaction/redaction-enforcement.service.ts
+++ b/packages/cli/src/modules/redaction/redaction-enforcement.service.ts
@@ -2,7 +2,7 @@ import type { RedactionFloor } from '@n8n/api-types';
 import { Service } from '@n8n/di';
 import type { WorkflowSettings } from 'n8n-workflow';
 
-import { settingsToFloor } from '@/controllers/redaction-enforcement-mapper';
+import { settingsToFloor } from './redaction-enforcement-mapper';
 import { UnprocessableRequestError } from '@/errors/response-errors/unprocessable.error';
 
 import { InstanceRedactionEnforcementService } from './instance-redaction-enforcement.service';
@@ -38,7 +38,7 @@ export class RedactionEnforcementService {
 		private readonly instanceRedactionEnforcementService: InstanceRedactionEnforcementService,
 	) {}
 
-	async getFloor(): Promise<RedactionFloor> {
+	private async getFloor(): Promise<RedactionFloor> {
 		const settings = await this.instanceRedactionEnforcementService.get();
 		return settingsToFloor(settings);
 	}
@@ -58,7 +58,7 @@ export class RedactionEnforcementService {
 		this.assertMeetsFloor(incomingPolicy, floor);
 	}
 
-	assertMeetsFloor(policy: WorkflowSettings.RedactionPolicy, floor: RedactionFloor): void {
+	private assertMeetsFloor(policy: WorkflowSettings.RedactionPolicy, floor: RedactionFloor): void {
 		const required = FLOOR_REQUIREMENTS[floor];
 		const scope = POLICY_SCOPE[policy];
 

--- a/packages/cli/src/modules/redaction/redaction-policy.ts
+++ b/packages/cli/src/modules/redaction/redaction-policy.ts
@@ -1,0 +1,50 @@
+import type { RedactionFloor } from '@n8n/api-types';
+import type { WorkflowSettings } from 'n8n-workflow';
+
+type RedactionPolicy = WorkflowSettings.RedactionPolicy;
+type RedactionScope = { production: boolean; manual: boolean };
+
+/** What each workflow redaction policy actually redacts. */
+const POLICY_SCOPE: Record<RedactionPolicy, RedactionScope> = {
+	none: { production: false, manual: false },
+	'manual-only': { production: false, manual: true },
+	'non-manual': { production: true, manual: false },
+	all: { production: true, manual: true },
+};
+
+/** What each instance floor requires be redacted. */
+const FLOOR_REQUIREMENTS: Record<RedactionFloor, RedactionScope> = {
+	off: { production: false, manual: false },
+	production: { production: true, manual: false },
+	all: { production: true, manual: true },
+};
+
+/** Minimum policy that satisfies a floor — used to seed new workflows. */
+const FLOOR_SEED_POLICY: Record<RedactionFloor, RedactionPolicy | undefined> = {
+	off: undefined,
+	production: 'non-manual',
+	all: 'all',
+};
+
+/** Canonical 422 message. Single source of truth — do not inline elsewhere. */
+export const REDACTION_FLOOR_VIOLATION_MESSAGE =
+	'Workflow redaction policy cannot be weaker than the instance floor.';
+
+/**
+ * True when `policy` redacts at least everything `floor` requires.
+ * Progressive-restriction model: equal-or-stricter passes, weaker fails.
+ */
+export function policyMeetsFloor(policy: RedactionPolicy, floor: RedactionFloor): boolean {
+	const required = FLOOR_REQUIREMENTS[floor];
+	const scope = POLICY_SCOPE[policy];
+	return (!required.production || scope.production) && (!required.manual || scope.manual);
+}
+
+/**
+ * Minimum policy a new workflow should be seeded with for `floor`,
+ * or `undefined` when the floor requires nothing (no seed).
+ * Invariant: the returned policy always satisfies `policyMeetsFloor(_, floor)`.
+ */
+export function policyForFloor(floor: RedactionFloor): RedactionPolicy | undefined {
+	return FLOOR_SEED_POLICY[floor];
+}

--- a/packages/cli/src/modules/redaction/redaction.config.ts
+++ b/packages/cli/src/modules/redaction/redaction.config.ts
@@ -1,8 +1,0 @@
-import { Config, Env } from '@n8n/config';
-
-@Config
-export class RedactionConfig {
-	/** Whether the workflow redaction policy is enforced at the instance level. When on, the policy cannot be modified through any workflow update path. */
-	@Env('N8N_ENV_FEAT_REDACTION_ENFORCEMENT')
-	enforcement: boolean = false;
-}

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -1267,16 +1267,14 @@ describe('SourceControlImportService', () => {
 					}),
 				);
 
-				redactionEnforcementService.assertPolicyChangeAllowed.mockImplementationOnce(() => {
-					throw new Error(
-						'Workflow redaction policy is enforced at the instance level and cannot be modified.',
-					);
-				});
+				redactionEnforcementService.assertPolicyChangeAllowed.mockRejectedValueOnce(
+					new Error('Workflow redaction policy cannot be weaker than the instance floor.'),
+				);
 
 				const candidates = [mock<SourceControlledFile>({ file: mockWorkflowFile, id: '1' })];
 
 				await expect(service.importWorkflowFromWorkFolder(candidates, mockUserId)).rejects.toThrow(
-					'Workflow redaction policy is enforced at the instance level',
+					'Workflow redaction policy cannot be weaker than the instance floor.',
 				);
 
 				expect(redactionEnforcementService.assertPolicyChangeAllowed).toHaveBeenCalledWith(

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -773,7 +773,7 @@ export class SourceControlImportService {
 		}
 		const existingWorkflow = existingWorkflows.find((e) => e.id === id);
 
-		this.redactionEnforcementService.assertPolicyChangeAllowed(
+		await this.redactionEnforcementService.assertPolicyChangeAllowed(
 			existingWorkflow?.settings?.redactionPolicy,
 			importedWorkflow.settings?.redactionPolicy,
 		);

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml
@@ -49,6 +49,22 @@ properties:
   timeSavedPerExecution:
     type: number
     description: Estimated time saved per execution in minutes
+  redactionPolicy:
+    type: string
+    enum: ['none', 'non-manual', 'manual-only', 'all']
+    description: |
+      Controls whether execution data is redacted for this workflow.
+
+      Available options:
+      - `none` (default): No redaction — all execution data is stored.
+      - `non-manual`: Redact production (non-manually triggered) executions only.
+      - `manual-only`: Redact manually triggered executions only.
+      - `all`: Redact all executions (manual and production).
+
+      When the instance has a redaction floor configured, the policy must be equal to
+      or stricter than the floor. Requests that would weaken the policy below the
+      instance floor are rejected with 422.
+    example: non-manual
   availableInMCP:
     type: boolean
     description: |

--- a/packages/cli/src/workflows/__tests__/workflow.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.test.ts
@@ -461,13 +461,13 @@ describe('WorkflowService', () => {
 			);
 		});
 
-		test('should reject update with 422 when enforcement is on and redactionPolicy is changing', async () => {
+		test('should reject update with 422 when redactionPolicy change violates the instance floor', async () => {
 			setupExistingWorkflow({ redactionPolicy: 'none' });
-			redactionEnforcementServiceMock.assertPolicyChangeAllowed.mockImplementationOnce(() => {
-				throw new UnprocessableRequestError(
-					'Workflow redaction policy is enforced at the instance level and cannot be modified.',
-				);
-			});
+			redactionEnforcementServiceMock.assertPolicyChangeAllowed.mockRejectedValueOnce(
+				new UnprocessableRequestError(
+					'Workflow redaction policy cannot be weaker than the instance floor.',
+				),
+			);
 
 			const user = mock<User>();
 			await expect(

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -346,7 +346,7 @@ export class WorkflowService {
 			throw new BadRequestError('Cannot update an archived workflow.');
 		}
 
-		this.redactionEnforcementService.assertPolicyChangeAllowed(
+		await this.redactionEnforcementService.assertPolicyChangeAllowed(
 			workflow.settings?.redactionPolicy,
 			workflowUpdateData.settings?.redactionPolicy,
 		);


### PR DESCRIPTION
## Summary

Relaxes the workflow update guard introduced in IAM-626. Pre-IAM-703, any change to `settings.redactionPolicy` was rejected when `N8N_ENV_FEAT_REDACTION_ENFORCEMENT=true`. Under the progressive restriction model agreed on 2026-05-19, only changes that drop the policy **below the instance floor** are rejected — equal-or-stricter changes succeed.

When a change is rejected, the API returns `422 Unprocessable Entity` with:

> Workflow redaction policy cannot be weaker than the instance floor.

The guard covers all three write paths (unchanged from IAM-626):

1. **REST `PATCH /workflows/:workflowId`** (Editor UI, internal API)
2. **Public API `PUT /api/v1/workflows/:id`** (routes through `WorkflowService.update`)
3. **Source-control pull** (workflow import from a remote repo)

`RedactionEnforcementService` now reads the active floor from `InstanceRedactionEnforcementService` (cache-backed, shipped in IAM-425) instead of the bare env flag. `assertPolicyChangeAllowed` is now async; both call sites already lived in async methods, so adding `await` was mechanical.

Pre-existing below-floor state is preserved — an update only fails when the **incoming** policy weakens the redaction below the floor. This honours the project's "no retroactive application" decision.

### Floor → required scope

| Floor | Required redactions | Allowed `redactionPolicy` values |
|---|---|---|
| `off` | none | any (`none`, `manual-only`, `non-manual`, `all`) |
| `production` | production redacted | `non-manual`, `all` |
| `all` | production + manual redacted | `all` |

### Behaviour matrix (replaces IAM-626 matrix)

| Floor | Incoming policy | Result |
|---|---|---|
| `off` | any | Update succeeds |
| `production` | `non-manual` or `all` | Update succeeds |
| `production` | `none` or `manual-only` | **422** |
| `all` | `all` | Update succeeds |
| `all` | anything else | **422** |
| any | omitted from payload | Update succeeds |
| any | unchanged vs stored value | Update succeeds (preserves legacy state) |

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-703

Builds on:
- IAM-626 — the original (now-relaxed) guard
- IAM-425 — `InstanceRedactionEnforcementService` (DB + cache layer)
- IAM-619 — Security & Policies API surface (floor read/write)

Related:
- IAM-701 (in review) — FE companion (per-select lock + floor hints)
- IAM-700 — execution-side mirror (strictest-per-channel resolution)
- IAM-625 — E2E Playwright coverage

## Manual testing steps

Prereqs: a fresh n8n instance with the data-redaction license active and at least one existing workflow. Each scenario assumes `N8N_ENV_FEAT_REDACTION_ENFORCEMENT=true` unless stated otherwise.

### Scenario 1 — Floor `off`: any change succeeds (regression check)

1. Start n8n with the flag on, but leave the floor unset (or set it to `off` via **Settings → Security & Policies → Data redaction**).
2. Pick a workflow whose stored `redactionPolicy` is `none`.
3. Public API:
   ```bash
   curl -i -X PUT http://localhost:5678/api/v1/workflows/<id> \
     -H "X-N8N-API-KEY: <key>" -H "Content-Type: application/json" \
     -d '{"name":"wf","nodes":[],"connections":{},"settings":{"redactionPolicy":"all"}}'
   ```
4. **Expected**: `200 OK`. `GET` confirms `redactionPolicy: "all"`.
5. Repeat downward (`all` → `none`). Also succeeds.

### Scenario 2 — Floor `production`: weaker policy rejected, stricter accepted

1. Set the floor to **Production executions** via the Security & Policies UI (or `POST /rest/settings/security` with `redactionEnforcement.floor = "production"`).
2. Pick a workflow stored as `redactionPolicy: all`.
3. **Reject path** — downgrade to `none`:
   ```bash
   curl -i -X PUT http://localhost:5678/api/v1/workflows/<id> \
     -H "X-N8N-API-KEY: <key>" -H "Content-Type: application/json" \
     -d '{"name":"wf","nodes":[],"connections":{},"settings":{"redactionPolicy":"none"}}'
   ```
   **Expected**: `HTTP/1.1 422 Unprocessable Entity`, body contains `"Workflow redaction policy cannot be weaker than the instance floor."`. `GET` shows the workflow still has `redactionPolicy: "all"`.
4. **Accept path** — switch to `non-manual` (meets floor) or back to `all`:
   ```bash
   curl -i -X PUT http://localhost:5678/api/v1/workflows/<id> \
     -H "X-N8N-API-KEY: <key>" -H "Content-Type: application/json" \
     -d '{"name":"wf","nodes":[],"connections":{},"settings":{"redactionPolicy":"non-manual"}}'
   ```
   **Expected**: `200 OK`.

### Scenario 3 — Floor `all`: only `all` accepted

1. Set the floor to **Manual and production executions**.
2. Pick a workflow stored as `redactionPolicy: all`.
3. **Reject paths** — try `non-manual` and `none`. Both return **422**.
4. **Accept path** — re-send `all`:
   ```bash
   curl -i -X PUT http://localhost:5678/api/v1/workflows/<id> \
     -H "X-N8N-API-KEY: <key>" -H "Content-Type: application/json" \
     -d '{"name":"wf","nodes":[],"connections":{},"settings":{"redactionPolicy":"all"}}'
   ```
   **Expected**: `200 OK`.

### Scenario 4 — Field omitted from payload → succeeds at any floor

1. With any floor (try `all`), update only the workflow's name:
   ```bash
   curl -i -X PUT http://localhost:5678/api/v1/workflows/<id> \
     -H "X-N8N-API-KEY: <key>" -H "Content-Type: application/json" \
     -d '{"name":"renamed","nodes":[],"connections":{}}'
   ```
2. **Expected**: `200 OK`, name updated, `redactionPolicy` untouched.

### Scenario 5 — Pre-existing below-floor state is preserved

1. With floor `off`, set a workflow's `redactionPolicy` to `none` and save.
2. Raise the floor to `production`.
3. From the editor, save the workflow again **without changing redaction** (e.g. tweak the name).
4. **Expected**: `200 OK`. The legacy `none` value persists — the floor is not retroactively applied.
5. Re-sending the same `none` via API also succeeds (`incomingPolicy === currentPolicy` short-circuit):
   ```bash
   curl -i -X PUT http://localhost:5678/api/v1/workflows/<id> \
     -H "X-N8N-API-KEY: <key>" -H "Content-Type: application/json" \
     -d '{"name":"wf","nodes":[],"connections":{},"settings":{"redactionPolicy":"none"}}'
   ```
   **Expected**: `200 OK`.
6. *Now* try to change it to anything still below floor (no-op since it stays `none`) — covered by Scenario 2.

### Scenario 6 — Source-control import: below-floor → rejected

1. Set up two instances against the same git repo. On instance A (floor `off`), set a workflow's `redactionPolicy` to `none` and push.
2. On instance B, set the same workflow locally to `redactionPolicy: all`, raise the floor to `production`, then restart with the flag on.
3. From instance B's UI: **Source Control → Pull**.
4. **Expected**: the pull surfaces a 422 mentioning *"Workflow redaction policy cannot be weaker than the instance floor."*. The local workflow remains `all`.

### Scenario 7 — Source-control import: meets-or-exceeds floor → succeeds

1. Same setup as Scenario 6, but on instance A push `redactionPolicy: all`.
2. Pull on instance B (floor `production`).
3. **Expected**: pull succeeds; other workflow fields (name, nodes) update normally.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. (Covered by IAM-623.)
- [x] Tests included. (16 new cases in `redaction-enforcement.service.test.ts` covering the floor × policy matrix and AC scenarios; existing `workflow.service.test.ts` and `source-control-import.service.ee.test.ts` cases updated for the async signature and new error string.)
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)