### PR TITLE
chore(editor): Add telemetry for workflow publish timeline (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistory.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistory.test.ts
@@ -67,6 +67,17 @@ const renderComponent = createComponentRenderer(WorkflowHistoryPage, {
 				</div>`,
 			}),
 			WorkflowHistoryContent: true,
+			WorkflowPublishTimelineContent: defineComponent({
+				props: {
+					id: {
+						type: String,
+						default: versionId,
+					},
+				},
+				template: `<div>
+						<button data-test-id="stub-publish-timeline-select" @click="() => $emit('selectVersion', id)" />
+					</div>`,
+			}),
 			WorkflowHistoryList: defineComponent({
 				props: {
 					id: {
@@ -249,6 +260,89 @@ describe('WorkflowHistory', () => {
 			expect(telemetry.track).toHaveBeenCalledWith('User downloaded version', {
 				instance_id: '',
 				workflow_id: workflowId,
+			});
+		});
+	});
+
+	describe('publish timeline', () => {
+		const cleanRouteState = () => {
+			Object.keys(route.params).forEach((key) => delete route.params[key]);
+			Object.keys(route.query).forEach((key) => delete route.query[key]);
+		};
+
+		beforeEach(cleanRouteState);
+		afterEach(cleanRouteState);
+
+		it('should track telemetry when landing on the publish timeline tab via query param', async () => {
+			route.params.workflowId = workflowId;
+			route.query.tab = 'publishTimeline';
+
+			renderComponent({ pinia });
+
+			await waitFor(() => {
+				expect(telemetry.track).toHaveBeenCalledWith('User opened publish timeline', {
+					instance_id: '',
+					workflow_id: workflowId,
+				});
+			});
+		});
+
+		it('should not track publish timeline telemetry when landing on the history tab', async () => {
+			route.params.workflowId = workflowId;
+
+			renderComponent({ pinia });
+
+			await waitFor(() => {
+				expect(telemetry.track).toHaveBeenCalledWith(
+					'User opened workflow history',
+					expect.anything(),
+				);
+			});
+			expect(telemetry.track).not.toHaveBeenCalledWith(
+				'User opened publish timeline',
+				expect.anything(),
+			);
+		});
+
+		it('should track telemetry when switching to the publish timeline tab', async () => {
+			route.params.workflowId = workflowId;
+
+			const { getByTestId } = renderComponent({ pinia });
+			await flushPromises();
+
+			await userEvent.click(
+				within(getByTestId('tab-publishTimeline')).getByText('Publish Timeline'),
+			);
+
+			await waitFor(() => {
+				expect(telemetry.track).toHaveBeenCalledWith('User opened publish timeline', {
+					instance_id: '',
+					workflow_id: workflowId,
+				});
+			});
+		});
+
+		it('should track telemetry when selecting a version from the publish timeline', async () => {
+			route.params.workflowId = workflowId;
+			route.query.tab = 'publishTimeline';
+
+			const { getByTestId } = renderComponent({ pinia });
+			await flushPromises();
+
+			await userEvent.click(getByTestId('stub-publish-timeline-select'));
+
+			await waitFor(() => {
+				expect(telemetry.track).toHaveBeenCalledWith(
+					'User selected version from publish timeline',
+					{
+						instance_id: '',
+						workflow_id: workflowId,
+					},
+				);
+				expect(router.push).toHaveBeenCalledWith({
+					name: VIEWS.WORKFLOW_HISTORY,
+					params: { workflowId, versionId },
+				});
 			});
 		});
 	});

--- a/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistory.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowHistory/views/WorkflowHistory.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onBeforeMount, ref, watchEffect, computed, h } from 'vue';
+import { onBeforeMount, ref, watch, watchEffect, computed, h } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import type { IWorkflowDb, UserAction } from '@/Interface';
 import {
@@ -185,8 +185,22 @@ const loadMore = async (queryParams: WorkflowHistoryRequestParams) => {
 	workflowHistory.value = workflowHistory.value.concat(history);
 };
 
+watch(activeTab, (newTab) => {
+	if (newTab === 'publishTimeline') {
+		sendTelemetry('User opened publish timeline');
+	}
+});
+
+const onSelectPublishTimelineVersion = async (id: WorkflowVersionId) => {
+	sendTelemetry('User selected version from publish timeline');
+	await navigateToVersion(id);
+};
+
 onBeforeMount(async () => {
 	sendTelemetry('User opened workflow history');
+	if (activeTab.value === 'publishTimeline') {
+		sendTelemetry('User opened publish timeline');
+	}
 	try {
 		const [workflow] = await Promise.all([
 			workflowsListStore.fetchWorkflow(workflowId.value),
@@ -653,7 +667,7 @@ watchEffect(async () => {
 				v-if="canRender && activeTab === 'publishTimeline'"
 				:workflow-id="workflowId"
 				:selected-version-id="versionId"
-				@select-version="navigateToVersion"
+				@select-version="onSelectPublishTimelineVersion"
 			/>
 		</div>
 		<div :class="$style.contentComponentWrapper">


### PR DESCRIPTION
## Summary

Adds two telemetry events to the workflow history page so we can measure engagement with the Publish Timeline tab:

- `User opened publish timeline` — fired when the tab is opened (via click or deep link with `?tab=publishTimeline`).
- `User selected version from publish timeline` — fired when a published-version entry in the timeline is clicked. The generic `User selected version` event still fires alongside, so existing metrics are unaffected.

Both events carry the standard `instance_id` + `workflow_id` payload.

**How to test:** Open a workflow's history page, switch to the Publish Timeline tab, then click a published version entry. Verify the two new events appear in the telemetry pipeline.

## Related Linear tickets, Github issues, and Community forum posts

N/A — internal instrumentation follow-up.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI