### PR TITLE
chore: Accept reviewStatus alongside status in test fetch script

### DIFF
--- a/packages/@n8n/workflow-sdk/scripts/fetch-test-workflows.ts
+++ b/packages/@n8n/workflow-sdk/scripts/fetch-test-workflows.ts
@@ -9,7 +9,7 @@
  *
  * API:
  *   GET https://api.n8n.io/api/workflows/{id}
- *   Response: { data: { attributes: { name, status, workflow: { nodes, connections, ... } } } }
+ *   Response: { data: { attributes: { name, status | reviewStatus, workflow: { nodes, connections, ... } } } }
  *
  *   GET https://n8n.io/api/product-api/workflows/search?rows=100&page=1
  *   Returns workflow metadata for discovering IDs
@@ -24,7 +24,8 @@ interface WorkflowResponse {
 	data: {
 		attributes: {
 			name: string;
-			status: string;
+			status?: string;
+			reviewStatus?: string;
 			workflow: {
 				nodes: unknown[];
 				connections: Record<string, unknown>;
@@ -132,11 +133,12 @@ async function main() {
 		const data = await fetchWorkflow(id);
 
 		if (data && data.data && data.data.attributes) {
-			const { name, status, workflow } = data.data.attributes;
+			const { name, status, reviewStatus, workflow } = data.data.attributes;
+			const effectiveStatus = status ?? reviewStatus;
 
 			// Only include published workflows
-			if (status !== 'published') {
-				console.log(`  Skipping: status=${status} (not published)`);
+			if (effectiveStatus !== 'published') {
+				console.log(`  Skipping: status=${effectiveStatus} (not published)`);
 				continue;
 			}
 


### PR DESCRIPTION
## Summary

The creators-site templates API is renaming the workflow `status` field to `reviewStatus` ahead of a Strapi v4 → v5 migration (v5 reserves `status` as a draft/publish system field). The test-fixture fetch script in `@n8n/workflow-sdk` reads the response field client-side to filter for published workflows, so it would silently skip every template once the rename ships. This PR makes the script accept either field name (`status ?? reviewStatus`) so it keeps working across the rename window.

Dev-only change to `scripts/fetch-test-workflows.ts`; no runtime/product impact. To test: run `npx tsx packages/@n8n/workflow-sdk/scripts/fetch-test-workflows.ts` against the current API and confirm published workflows are still downloaded.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5315/support-either-status-or-review-status-in-main-repo

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. — n/a, dev script.
- [x] Tests included. — n/a, dev script with no existing test coverage; behavior is a forward-compat fallback.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI