### PR TITLE
test: Run mutation testing against the legacy expression engine to unblock the nightly

### DIFF
--- a/packages/workflow/test/setup-vm-evaluator.ts
+++ b/packages/workflow/test/setup-vm-evaluator.ts
@@ -14,13 +14,7 @@ if (process.env.N8N_EXPRESSION_ENGINE === 'vm') {
 		});
 	});
 
-	// Under Stryker, the worker process exits the moment vitest finishes — the
-	// OS reclaims isolated-vm native handles either way. Calling dispose here
-	// aborts the worker on Node 24 with a native finaliser assertion, which
-	// Stryker reports as a dry-run failure.
-	if (!process.env.STRYKER_RUN) {
-		afterAll(async () => {
-			await Expression.disposeExpressionEngine();
-		});
-	}
+	afterAll(async () => {
+		await Expression.disposeExpressionEngine();
+	});
 }

--- a/packages/workflow/vitest.stryker.config.ts
+++ b/packages/workflow/vitest.stryker.config.ts
@@ -1,24 +1,15 @@
-// Vitest config used by Stryker only — NOT by `pnpm test`, NOT by CI's
-// unit-test runs. Runs the single forward-looking `vm-engine` project
-// (N8N_EXPRESSION_ENGINE=vm) rather than both engines.
+// Vitest config used by Stryker only — NOT by `pnpm test`, NOT by CI unit runs.
 //
-// Two reasons:
-//   1. Halves Stryker's dry-run cost — only one vitest project loads per
-//      Stryker worker, removing concurrent isolated-vm initialisation
-//      pressure that occasionally crashes the dry-run on local machines.
-//   2. Mutation score reflects test effectiveness against the engine n8n
-//      is moving to. Legacy-engine is being phased out; tests that pass
-//      only under it shouldn't pad the mutation score.
-//
-// The default `vitest.config.ts` still runs both projects for `pnpm test`
-// and CI — engine-equivalence is asserted there.
+// Runs the legacy expression engine, not vm/isolated-vm: the vm evaluator
+// SIGABRTs in Stryker's worker on teardown (upstream isolated-vm #464, repros on
+// Node 22 + 24). Trade-off: vm-only branches in expression.ts go unscored. Swap
+// back to N8N_EXPRESSION_ENGINE=vm once #464 is fixed or we pnpm-patch the guard.
 
 import { defineConfig } from 'vitest/config';
 import { createBaseInlineConfig } from '@n8n/vitest-config/node';
 
 const { reporters, outputFile, ...sharedTestConfig } = createBaseInlineConfig({
 	include: ['test/**/*.test.ts'],
-	setupFiles: ['./test/setup-vm-evaluator.ts'],
 });
 
 export default defineConfig({
@@ -29,10 +20,7 @@ export default defineConfig({
 			{
 				test: {
 					...sharedTestConfig,
-					name: 'vm-engine',
-					// STRYKER_RUN tells setup-vm-evaluator.ts to skip the
-					// isolated-vm disposer on teardown — see that file for why.
-					env: { N8N_EXPRESSION_ENGINE: 'vm', STRYKER_RUN: 'true' },
+					name: 'legacy-engine',
 				},
 			},
 		],


### PR DESCRIPTION
## Summary

The `mutation-health-nightly` workflow has never produced a successful run. The job fails at *Mutate the picked source file*: Stryker's vitest worker **SIGABRTs** when the vm/isolated-vm expression evaluator is torn down, so no `summary.json` is produced and the BigQuery ledger never gets written.

```
Assertion failed: (environment != nullptr), function GetCurrent, file environment.h, line 202
Child process exited unexpectedly with exit code null (SIGABRT)
```

This is upstream [isolated-vm #464](https://github.com/laverdet/isolated-vm/issues/464) (open since 2024, a GC/teardown race). It reproduces on **Node 22 and 24**, and we're already on the latest isolated-vm (6.1.2) — so neither a Node pin nor a version bump fixes it.

This PR switches the **Stryker-only** vitest config (`packages/workflow/vitest.stryker.config.ts`) to the **legacy** expression engine so the dry run completes and the nightly can populate the ledger now. Plain `pnpm test` is untouched — it still runs both engines.

## Changes

- `vitest.stryker.config.ts`: `vm-engine` → `legacy-engine`; drop the `N8N_EXPRESSION_ENGINE=vm` env and the isolated-vm setup file. Comment explains why and when to revert.
- `test/setup-vm-evaluator.ts`: remove the now-dead `STRYKER_RUN` dispose guard (nothing sets that var anymore).

## Trade-off

vm-only branches in `src/expression.ts` (and the vm-evaluator wiring) run as NoCoverage under the legacy engine and aren't scored. Acceptable while vm is behind a flag and legacy is still the production default. The isolated-vm patch that restores vm-engine coverage is tracked in **DEVP-257**.

## Verification

- `pnpm --filter n8n-workflow mutate src/common/find-ai-root-node-names.ts` → completes clean, no SIGABRT (exit 1 = below-threshold, the workflow's normal red path).
- `pnpm test` vm-engine project with always-dispose → exit 0, no crash.
- `pnpm lint` + `pnpm typecheck` → clean.

## Related tickets

- Unblocks https://linear.app/n8n/issue/DEVP-176 (Mutation Health Observability rollout)
- Proper fix: https://linear.app/n8n/issue/DEVP-257 (patch isolated-vm, revert to vm-engine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)