### PR TITLE
ci: Move to useblacksmith/checkout to reduce git checkout flakes

### DIFF
--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -37,7 +37,7 @@ jobs:
       affected_packages: ${{ steps.affected-packages.outputs.list }}
       changed_files: ${{ steps.ci-filter.outputs.changed-files }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           # Use merge_group SHA when in merge queue, otherwise PR merge ref
           ref: ${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || format('refs/pull/{0}/merge', github.event.pull_request.number) }}
@@ -175,7 +175,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
     needs: install-and-build
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ needs.install-and-build.outputs.commit_sha }}
 
@@ -198,7 +198,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
     needs: install-and-build
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ needs.install-and-build.outputs.commit_sha }}
 
@@ -368,7 +368,7 @@ jobs:
     if: always()
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           sparse-checkout: .github/actions/ci-filter
           sparse-checkout-cone-mode: false
@@ -377,7 +377,7 @@ jobs:
         with:
           mode: validate
           job-results: ${{ toJSON(needs) }}
-          
+
   # Posts a QA metrics comparison comment on the PR.
   # Runs after all checks so any job can emit metrics before this reports.
   post-qa-metrics-comment:

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -37,7 +37,7 @@ jobs:
       affected_packages: ${{ steps.affected-packages.outputs.list }}
       changed_files: ${{ steps.ci-filter.outputs.changed-files }}
     steps:
-      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           # Use merge_group SHA when in merge queue, otherwise PR merge ref
           ref: ${{ github.event_name == 'merge_group' && github.event.merge_group.head_sha || format('refs/pull/{0}/merge', github.event.pull_request.number) }}
@@ -175,7 +175,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
     needs: install-and-build
     steps:
-      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ needs.install-and-build.outputs.commit_sha }}
 
@@ -198,7 +198,7 @@ jobs:
     runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
     needs: install-and-build
     steps:
-      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ needs.install-and-build.outputs.commit_sha }}
 
@@ -368,7 +368,7 @@ jobs:
     if: always()
     runs-on: ubuntu-slim
     steps:
-      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           sparse-checkout: .github/actions/ci-filter
           sparse-checkout-cone-mode: false

--- a/.github/workflows/prepare-docker-reusable.yml
+++ b/.github/workflows/prepare-docker-reusable.yml
@@ -34,7 +34,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ inputs.branch || github.ref }}
           fetch-depth: 1

--- a/.github/workflows/prepare-docker-reusable.yml
+++ b/.github/workflows/prepare-docker-reusable.yml
@@ -34,7 +34,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ inputs.branch || github.ref }}
           fetch-depth: 1

--- a/.github/workflows/sec-poutine-reusable.yml
+++ b/.github/workflows/sec-poutine-reusable.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/sec-poutine-reusable.yml
+++ b/.github/workflows/sec-poutine-reusable.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/test-bench-reusable.yml
+++ b/.github/workflows/test-bench-reusable.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.repository == 'n8n-io/n8n'
     runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-2vcpu-ubuntu-2204' }}
     steps:
-      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/test-bench-reusable.yml
+++ b/.github/workflows/test-bench-reusable.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.repository == 'n8n-io/n8n'
     runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-2vcpu-ubuntu-2204' }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/test-db-reusable.yml
+++ b/.github/workflows/test-db-reusable.yml
@@ -35,7 +35,7 @@ jobs:
       TEST_IMAGE_POSTGRES: ${{ matrix.TEST_IMAGE_POSTGRES }}
       COVERAGE_ENABLED: ${{ matrix.collectCoverage }}
     steps:
-      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/test-db-reusable.yml
+++ b/.github/workflows/test-db-reusable.yml
@@ -35,7 +35,7 @@ jobs:
       TEST_IMAGE_POSTGRES: ${{ matrix.TEST_IMAGE_POSTGRES }}
       COVERAGE_ENABLED: ${{ matrix.collectCoverage }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/test-dev-server-smoke-reusable.yml
+++ b/.github/workflows/test-dev-server-smoke-reusable.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           fetch-depth: 1
           ref: ${{ inputs.ref }}

--- a/.github/workflows/test-dev-server-smoke-reusable.yml
+++ b/.github/workflows/test-dev-server-smoke-reusable.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           fetch-depth: 1
           ref: ${{ inputs.ref }}

--- a/.github/workflows/test-e2e-reusable.yml
+++ b/.github/workflows/test-e2e-reusable.yml
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           fetch-depth: 1
           ref: ${{ inputs.branch || github.ref }}

--- a/.github/workflows/test-e2e-reusable.yml
+++ b/.github/workflows/test-e2e-reusable.yml
@@ -83,7 +83,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           fetch-depth: 1
           ref: ${{ inputs.branch || github.ref }}

--- a/.github/workflows/test-evals-discovery.yml
+++ b/.github/workflows/test-evals-discovery.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ inputs.branch || github.ref }}
           fetch-depth: 1

--- a/.github/workflows/test-evals-discovery.yml
+++ b/.github/workflows/test-evals-discovery.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+        uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ inputs.branch || github.ref }}
           fetch-depth: 1

--- a/.github/workflows/test-linting-reusable.yml
+++ b/.github/workflows/test-linting-reusable.yml
@@ -22,7 +22,7 @@ jobs:
     name: Lint
     runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/test-linting-reusable.yml
+++ b/.github/workflows/test-linting-reusable.yml
@@ -22,7 +22,7 @@ jobs:
     name: Lint
     runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
     steps:
-      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/test-unit-reusable.yml
+++ b/.github/workflows/test-unit-reusable.yml
@@ -46,7 +46,7 @@ jobs:
       AFFECTED_PACKAGES: ${{ inputs.affectedPackages }}
       CHANGED_FILES: ${{ inputs.changedFiles }}
     steps:
-      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ inputs.ref }}
 
@@ -91,7 +91,7 @@ jobs:
       AFFECTED_PACKAGES: ${{ inputs.affectedPackages }}
       CHANGED_FILES: ${{ inputs.changedFiles }}
     steps:
-      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ inputs.ref }}
 
@@ -136,7 +136,7 @@ jobs:
       AFFECTED_PACKAGES: ${{ inputs.affectedPackages }}
       CHANGED_FILES: ${{ inputs.changedFiles }}
     steps:
-      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ inputs.ref }}
 
@@ -185,7 +185,7 @@ jobs:
       AFFECTED_PACKAGES: ${{ inputs.affectedPackages }}
       CHANGED_FILES: ${{ inputs.changedFiles }}
     steps:
-      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/test-unit-reusable.yml
+++ b/.github/workflows/test-unit-reusable.yml
@@ -46,7 +46,7 @@ jobs:
       AFFECTED_PACKAGES: ${{ inputs.affectedPackages }}
       CHANGED_FILES: ${{ inputs.changedFiles }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ inputs.ref }}
 
@@ -91,7 +91,7 @@ jobs:
       AFFECTED_PACKAGES: ${{ inputs.affectedPackages }}
       CHANGED_FILES: ${{ inputs.changedFiles }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ inputs.ref }}
 
@@ -136,7 +136,7 @@ jobs:
       AFFECTED_PACKAGES: ${{ inputs.affectedPackages }}
       CHANGED_FILES: ${{ inputs.changedFiles }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ inputs.ref }}
 
@@ -185,7 +185,7 @@ jobs:
       AFFECTED_PACKAGES: ${{ inputs.affectedPackages }}
       CHANGED_FILES: ${{ inputs.changedFiles }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/test-workflow-scripts-reusable.yml
+++ b/.github/workflows/test-workflow-scripts-reusable.yml
@@ -22,7 +22,7 @@ jobs:
     name: Run tests for workflow scripts
     runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-slim' || 'blacksmith-4vcpu-ubuntu-2204' }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/test-workflow-scripts-reusable.yml
+++ b/.github/workflows/test-workflow-scripts-reusable.yml
@@ -22,7 +22,7 @@ jobs:
     name: Run tests for workflow scripts
     runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-slim' || 'blacksmith-4vcpu-ubuntu-2204' }}
     steps:
-      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           ref: ${{ inputs.ref }}
 

--- a/.github/workflows/util-qa-metrics-comment-reusable.yml
+++ b/.github/workflows/util-qa-metrics-comment-reusable.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           sparse-checkout: .github/scripts/post-qa-metrics-comment.mjs
           sparse-checkout-cone-mode: false

--- a/.github/workflows/util-qa-metrics-comment-reusable.yml
+++ b/.github/workflows/util-qa-metrics-comment-reusable.yml
@@ -25,7 +25,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: useblacksmith/checkout@deedae8edb2e684ba22896a5fd2a3cb85db6b # v1
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
         with:
           sparse-checkout: .github/scripts/post-qa-metrics-comment.mjs
           sparse-checkout-cone-mode: false


### PR DESCRIPTION
## Summary

Moved all checkout actions in the `ci-pull-request.yml` workflow to use `useblacksmith/checkout`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-259

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
