### PR TITLE
fix(editor): Stop autosave retry loop on permanent 4xx responses

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.test.ts
@@ -11,6 +11,7 @@ import { useWorkflowSaveStore } from '@/app/stores/workflowSave.store';
 import { useBackendConnectionStore } from '@/app/stores/backendConnection.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import type { WorkflowDataUpdate } from '@n8n/rest-api-client/api/workflows';
+import { ResponseError } from '@n8n/rest-api-client';
 import { mockedStore } from '@/__tests__/utils';
 import { createTestNode, createTestWorkflow, mockNodeTypeDescription } from '@/__tests__/mocks';
 import { CHAT_TRIGGER_NODE_TYPE } from 'n8n-workflow';
@@ -1132,6 +1133,91 @@ describe('useWorkflowSaving', () => {
 				expect(saveStore.pendingSave).toBeNull();
 				expect(saveStore.retryCount).toBe(initialRetryCount + 1);
 				expect(saveStore.lastError).toBe(errorMessage);
+				expect(saveStore.isRetrying).toBe(true);
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
+		it('should not retry autosave on permanent 4xx and should block further autosaves', async () => {
+			const workflow = createTestWorkflow({
+				id: 'w-autosave-4xx',
+				nodes: [createTestNode({ type: CHAT_TRIGGER_NODE_TYPE, disabled: false })],
+				active: true,
+			});
+
+			vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue(workflow);
+			const errorMessage = 'Potentially malicious string';
+			const responseError = new ResponseError(errorMessage, { httpStatusCode: 400 });
+			vi.spyOn(workflowsStore, 'updateWorkflow').mockRejectedValue(responseError);
+
+			workflowsStore.setWorkflowId(workflow.id);
+			useWorkflowDocumentStore(createWorkflowDocumentId(workflow.id)).hydrate(workflow);
+			workflowsListStore.workflowsById = { [workflow.id]: workflow };
+			workflowsStore.setWorkflowId(workflow.id);
+
+			const uiStore = useUIStore();
+			uiStore.markStateDirty();
+			const dirtyCountAtBlock = uiStore.dirtyStateSetCount;
+
+			const saveStore = useWorkflowSaveStore();
+
+			const { saveCurrentWorkflow, autoSaveWorkflow } = useWorkflowSaving({ router });
+
+			const result = await saveCurrentWorkflow({ id: workflow.id }, true, false, true);
+
+			expect(result).toBe(false);
+			expect(saveStore.retryCount).toBe(0);
+			expect(saveStore.isRetrying).toBe(false);
+			expect(saveStore.blockedOnInput).toBe(true);
+			expect(saveStore.blockedAtDirtyCount).toBe(dirtyCountAtBlock);
+			expect(saveStore.lastError).toBe(errorMessage);
+
+			// Subsequent scheduleAutoSave calls without a new edit should be ignored.
+			autoSaveWorkflow();
+			expect(saveStore.autoSaveState).toBe(AutoSaveState.Idle);
+
+			// User edits the workflow: dirty count advances → block clears, autosave resumes.
+			uiStore.markStateDirty();
+			autoSaveWorkflow();
+			expect(saveStore.blockedOnInput).toBe(false);
+			expect(saveStore.autoSaveState).toBe(AutoSaveState.Scheduled);
+		});
+
+		it('should retry autosave on 409 conflict (still treated as retryable)', async () => {
+			vi.useFakeTimers();
+
+			try {
+				const workflow = createTestWorkflow({
+					id: 'w-autosave-409',
+					nodes: [createTestNode({ type: CHAT_TRIGGER_NODE_TYPE, disabled: false })],
+					active: true,
+				});
+
+				vi.spyOn(workflowsListStore, 'fetchWorkflow').mockResolvedValue(workflow);
+				const errorMessage = 'Conflict';
+				const responseError = new ResponseError(errorMessage, {
+					errorCode: 409,
+					httpStatusCode: 409,
+				});
+				vi.spyOn(workflowsStore, 'updateWorkflow').mockRejectedValue(responseError);
+
+				workflowsStore.setWorkflowId(workflow.id);
+				useWorkflowDocumentStore(createWorkflowDocumentId(workflow.id)).hydrate(workflow);
+				workflowsListStore.workflowsById = { [workflow.id]: workflow };
+				workflowsStore.setWorkflowId(workflow.id);
+
+				modalConfirmSpy.mockResolvedValue(MODAL_CANCEL);
+
+				const saveStore = useWorkflowSaveStore();
+
+				const { saveCurrentWorkflow } = useWorkflowSaving({ router });
+
+				const result = await saveCurrentWorkflow({ id: workflow.id }, true, false, true);
+
+				expect(result).toBe(false);
+				expect(saveStore.blockedOnInput).toBe(false);
+				expect(saveStore.retryCount).toBe(1);
 				expect(saveStore.isRetrying).toBe(true);
 			} finally {
 				vi.useRealTimers();

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowSaving.ts
@@ -40,6 +40,16 @@ import { useWorkflowId } from '@/app/composables/useWorkflowId';
 import { useWorkflowSaveStore } from '@/app/stores/workflowSave.store';
 import { useBackendConnectionStore } from '@/app/stores/backendConnection.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
+import { ResponseError } from '@n8n/rest-api-client';
+
+function isPermanentClientError(error: unknown): boolean {
+	if (!(error instanceof ResponseError)) return false;
+	const status = error.httpStatusCode;
+	if (typeof status !== 'number') return false;
+	// 409 has its own conflict-resolution flow; all other 4xx are treated as
+	// permanent (the same payload will keep failing until the user edits it).
+	return status >= 400 && status < 500 && status !== 409;
+}
 
 export function useWorkflowSaving({
 	router,
@@ -304,6 +314,25 @@ export function useWorkflowSaving({
 
 				// Handle autosave failures with exponential backoff
 				if (autosaved) {
+					// Permanent client errors (4xx other than 409, which has its own conflict
+					// flow) will not be fixed by retrying — keep retrying just spams the server
+					// with the same invalid payload. Stop the loop and wait for the user to
+					// change the input (detected via dirtyStateSetCount in scheduleAutoSave).
+					if (isPermanentClientError(error)) {
+						saveStore.resetRetry();
+						saveStore.setLastError(error.message);
+						saveStore.setBlockedOnInput(true, uiStore.dirtyStateSetCount);
+
+						toast.showMessage({
+							title: i18n.baseText('workflowHelpers.showMessage.title'),
+							message: error.message,
+							type: 'error',
+							duration: 0,
+						});
+
+						return false;
+					}
+
 					saveStore.incrementRetry();
 					saveStore.setLastError(error.message);
 
@@ -574,7 +603,7 @@ export function useWorkflowSaving({
 						saveStore.setAutoSaveState(AutoSaveState.Idle);
 					}
 					// If changes were made during save, reschedule autosave
-					if (uiStore.stateIsDirty && !saveStore.isRetrying) {
+					if (uiStore.stateIsDirty && !saveStore.isRetrying && !saveStore.blockedOnInput) {
 						saveStore.setAutoSaveState(AutoSaveState.Scheduled);
 						void autoSaveWorkflowDebounced();
 					}
@@ -605,6 +634,17 @@ export function useWorkflowSaving({
 		// Don't schedule if we're offline
 		if (!backendConnectionStore.isOnline) {
 			return;
+		}
+
+		// A previous save hit a permanent 4xx. Stay blocked until the user makes
+		// a new edit — detected by dirtyStateSetCount advancing past the value at
+		// the time the block was set.
+		if (saveStore.blockedOnInput) {
+			const blockedAt = saveStore.blockedAtDirtyCount;
+			if (blockedAt === null || uiStore.dirtyStateSetCount <= blockedAt) {
+				return;
+			}
+			saveStore.setBlockedOnInput(false);
 		}
 
 		saveStore.setAutoSaveState(AutoSaveState.Scheduled);

--- a/packages/frontend/editor-ui/src/app/stores/workflowSave.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowSave.store.ts
@@ -23,6 +23,11 @@ export const useWorkflowSaveStore = defineStore('workflowSave', () => {
 	const lastError = ref<string | null>(null);
 	const conflictModalShown = ref(false);
 
+	// Permanent client-error state: when a 4xx (other than 409) blocks autosave,
+	// we stop retrying until the user makes a new edit (tracked by dirtyStateSetCount).
+	const blockedOnInput = ref(false);
+	const blockedAtDirtyCount = ref<number | null>(null);
+
 	function setAutoSaveState(state: AutoSaveState) {
 		autoSaveState.value = state;
 	}
@@ -52,12 +57,19 @@ export const useWorkflowSaveStore = defineStore('workflowSave', () => {
 		conflictModalShown.value = value;
 	}
 
+	function setBlockedOnInput(value: boolean, atDirtyCount: number | null = null) {
+		blockedOnInput.value = value;
+		blockedAtDirtyCount.value = value ? atDirtyCount : null;
+	}
+
 	function resetRetry() {
 		retryCount.value = 0;
 		retryDelay.value = RETRY_START_DELAY;
 		isRetrying.value = false;
 		lastError.value = null;
 		conflictModalShown.value = false;
+		blockedOnInput.value = false;
+		blockedAtDirtyCount.value = null;
 	}
 
 	function reset() {
@@ -74,6 +86,8 @@ export const useWorkflowSaveStore = defineStore('workflowSave', () => {
 		isRetrying,
 		lastError,
 		conflictModalShown,
+		blockedOnInput,
+		blockedAtDirtyCount,
 		setAutoSaveState,
 		setPendingSave,
 		incrementRetry,
@@ -81,6 +95,7 @@ export const useWorkflowSaveStore = defineStore('workflowSave', () => {
 		setRetrying,
 		setLastError,
 		setConflictModalShown,
+		setBlockedOnInput,
 		resetRetry,
 		reset,
 	};


### PR DESCRIPTION
## Summary

Autosave catches every save error and reschedules a retry with exponential backoff as long as the workflow is dirty. That's the right behavior for transient failures (network blips, 5xx), but wrong for permanent client errors like `400` validation rejections — the same payload will keep failing, and the retry loop just spams the server (Sentry recorded 97+ identical 400s over 16 days for one user).

This PR classifies 4xx responses other than 409 (which has its own conflict flow) as permanent:

- Stop the retry loop immediately, surface a persistent error toast.
- Set a `blockedOnInput` flag on the save store, snapshotting `dirtyStateSetCount` at the time of the block.
- `scheduleAutoSave` ignores subsequent triggers until `dirtyStateSetCount` advances past the snapshot — i.e. until the user edits the workflow — at which point the flag clears and autosave resumes.

Manual saves and 409 conflicts keep their existing behaviour. 5xx and non-`ResponseError` failures still go through exponential backoff as before.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5311

Closes ADO-5311.

## Test plan

- [x] `pnpm test src/app/composables/useWorkflowSaving.test.ts` — added coverage:
  - permanent 400 sets `blockedOnInput`, leaves `retryCount` at 0, ignores `autoSaveWorkflow()` until dirty count advances, then resumes.
  - 409 still flows through the retry path (regression guard).
- [x] `pnpm typecheck`
- [x] `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)