### PR TITLE
fix(editor): Validate workflow name on rename

### DIFF
--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -104,6 +104,8 @@ export {
 	MAX_PINNED_DATA_SIZE,
 	MAX_WORKFLOW_SIZE,
 	MAX_EXPECTED_REQUEST_SIZE,
+	WORKFLOW_NAME_MAX_LENGTH,
+	workflowNameSchema,
 } from './workflows/base-workflow.dto';
 export { CreateWorkflowDto } from './workflows/create-workflow.dto';
 export { UpdateWorkflowDto } from './workflows/update-workflow.dto';

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -2762,6 +2762,7 @@
 	"renameAction.emptyName.message": "Please enter a name, or press 'esc' to go back to the old one",
 	"renameAction.emptyName.title": "Name missing",
 	"renameAction.invalidName.title": "Invalid name",
+	"renameAction.invalidName.message": "Name cannot contain '<' or '>'",
 	"resourceLocator.id.placeholder": "Enter ID...",
 	"resourceLocator.mode.id": "By ID",
 	"resourceLocator.mode.url": "By URL",

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.test.ts
@@ -232,6 +232,44 @@ describe('WorkflowDetails', () => {
 		expect(getByText('tag2')).toBeInTheDocument();
 	});
 
+	describe('workflow rename', () => {
+		it('rejects names with HTML-significant characters and shows an error toast', async () => {
+			workflowDocumentStoreRef.value?.setScopes(['workflow:update']);
+			const setNameSpy = vi.spyOn(workflowDocumentStoreRef.value!, 'setName');
+
+			const { getByTestId } = renderComponent({
+				props: { ...defaultProps },
+			});
+
+			const input = getByTestId('inline-edit-input');
+			await userEvent.click(input);
+			await userEvent.clear(input);
+			await userEvent.type(input, 'Bad <name>{Enter}');
+
+			expect(toast.showMessage).toHaveBeenCalledWith(
+				expect.objectContaining({ type: 'error', title: 'Invalid name' }),
+			);
+			expect(setNameSpy).not.toHaveBeenCalled();
+		});
+
+		it('accepts valid names and updates the workflow', async () => {
+			workflowDocumentStoreRef.value?.setScopes(['workflow:update']);
+			const setNameSpy = vi.spyOn(workflowDocumentStoreRef.value!, 'setName');
+
+			const { getByTestId } = renderComponent({
+				props: { ...defaultProps },
+			});
+
+			const input = getByTestId('inline-edit-input');
+			await userEvent.click(input);
+			await userEvent.clear(input);
+			await userEvent.type(input, 'API to CSV{Enter}');
+
+			expect(toast.showMessage).not.toHaveBeenCalled();
+			expect(setNameSpy).toHaveBeenCalledWith('API to CSV');
+		});
+	});
+
 	it('opens share modal on share button click', async () => {
 		const openModalSpy = vi.spyOn(uiStore, 'openModalWithData');
 

--- a/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.vue
+++ b/packages/frontend/editor-ui/src/app/components/MainHeader/WorkflowDetails.vue
@@ -17,6 +17,7 @@ import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useToast } from '@/app/composables/useToast';
 import { nodeViewEventBus } from '@/app/event-bus';
 import type { IWorkflowDb } from '@/Interface';
+import { workflowNameSchema } from '@n8n/api-types';
 import type { FolderShortInfo } from '@/features/core/folders/folders.types';
 import { useFoldersStore } from '@/features/core/folders/folders.store';
 import { ProjectTypes } from '@/features/collaboration/projects/projects.types';
@@ -208,6 +209,18 @@ function onNameSubmit(name: string) {
 	}
 
 	if (newName === props.name) {
+		renameInput.value?.forceCancel();
+		return;
+	}
+
+	const validation = workflowNameSchema.safeParse(newName);
+	if (!validation.success) {
+		toast.showMessage({
+			title: locale.baseText('renameAction.invalidName.title'),
+			message: locale.baseText('renameAction.invalidName.message'),
+			type: 'error',
+		});
+
 		renameInput.value?.forceCancel();
 		return;
 	}


### PR DESCRIPTION
## Summary

The frontend rename handler in `WorkflowDetails.vue` did not run the shared `workflowNameSchema` from `@n8n/api-types`, so autosave would PATCH workflow names containing `<` or `>` and the backend would reject the request with HTTP 400, producing a recurring error toast.

This change exports `workflowNameSchema` from `@n8n/api-types`, applies it in `onNameSubmit`, and shows an inline error toast when the new name fails validation — matching the existing invalid-name UX in the workflows list. Adds the missing `renameAction.invalidName.message` i18n key and two unit tests covering the rejection and happy paths.

**How to test:** open any workflow, click the name to rename it, type a value containing `<` or `>` and press Enter — the rename is cancelled and an "Invalid name" toast appears. A valid name (e.g. `API to CSV`) renames the workflow as before.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5310

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI