### PR TITLE
ci: Sanitize inputs before passing them to bash in test-evals-ai

### DIFF
--- a/.github/workflows/test-evals-ai.yml
+++ b/.github/workflows/test-evals-ai.yml
@@ -110,6 +110,10 @@ jobs:
     steps:
       - name: Set configuration based on trigger
         id: config
+        env:
+          BRANCH: ${{ inputs.branch || 'master' }}
+          SPEC_REPETITIONS: ${{ inputs.spec_repetitions || '1' }}
+          SPEC_JUDGES: ${{ inputs.spec_judges || '1' }}
         run: |
           EVENT_NAME="${{ github.event_name }}"
 
@@ -124,9 +128,9 @@ jobs:
           else
             # Manual dispatch: use provided values for spec evals
             {
-              echo "branch=${{ inputs.branch || 'master' }}"
-              echo "spec_repetitions=${{ inputs.spec_repetitions || '1' }}"
-              echo "spec_judges=${{ inputs.spec_judges || '1' }}"
+              echo "branch=$BRANCH"
+              echo "spec_repetitions=$SPEC_REPETITIONS"
+              echo "spec_judges=$SPEC_JUDGES"
               echo "experiment_prefix=CI_manual"
             } >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Summary

Sanitize inputs before passing them to bash in test-evals-ai

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-217


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
