### PR TITLE
refactor(core): Extract test webhook cancel route into a REST controller

### DIFF
--- a/packages/cli/src/abstract-server.ts
+++ b/packages/cli/src/abstract-server.ts
@@ -15,7 +15,7 @@ import { N8N_VERSION, TEMPLATES_DIR } from '@/constants';
 import { ServiceUnavailableError } from '@/errors/response-errors/service-unavailable.error';
 import { ExternalHooks } from '@/external-hooks';
 import { bodyParser, corsMiddleware, rawBodyReader } from '@/middlewares';
-import { send, sendErrorResponse } from '@/response-helper';
+import { sendErrorResponse } from '@/response-helper';
 import { createHandlebarsEngine } from '@/utils/handlebars.util';
 import { LiveWebhooks } from '@/webhooks/live-webhooks';
 import { TestWebhooks } from '@/webhooks/test-webhooks';
@@ -301,16 +301,6 @@ export abstract class AbstractServer {
 
 		if (inDevelopment) {
 			this.setupDevMiddlewares();
-		}
-
-		if (this.testWebhooksEnabled) {
-			const testWebhooks = Container.get(TestWebhooks);
-			// Removes a test webhook
-			// TODO UM: check if this needs validation with user management.
-			this.app.delete(
-				`/${this.restEndpoint}/test-webhook/:id`,
-				send(async (req) => await testWebhooks.cancelWebhook(req.params.id)),
-			);
 		}
 
 		// Setup body parsing middleware after the webhook handlers are setup

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -66,6 +66,7 @@ import '@/evaluation.ee/insights/eval-insights.controller.ee';
 import '@/workflows/workflow-history/workflow-history.controller';
 import '@/workflows/workflows.controller';
 import '@/modules/workflow-index/workflow-dependency.controller';
+import '@/webhooks/test-webhooks.controller';
 import '@/webhooks/webhooks.controller';
 
 import { ChatServer } from './chat/chat-server';

--- a/packages/cli/src/webhooks/test-webhooks.controller.ts
+++ b/packages/cli/src/webhooks/test-webhooks.controller.ts
@@ -1,0 +1,20 @@
+import { AuthenticatedRequest } from '@n8n/db';
+import { Delete, Param, ProjectScope, RestController } from '@n8n/decorators';
+import { Response } from 'express';
+
+import { TestWebhooks } from '@/webhooks/test-webhooks';
+
+@RestController('/test-webhook')
+export class TestWebhooksController {
+	constructor(private readonly testWebhooks: TestWebhooks) {}
+
+	@Delete('/:workflowId')
+	@ProjectScope('workflow:execute')
+	async cancel(
+		_req: AuthenticatedRequest,
+		_res: Response,
+		@Param('workflowId') workflowId: string,
+	) {
+		await this.testWebhooks.cancelWebhook(workflowId);
+	}
+}

--- a/packages/cli/test/integration/controllers/test-webhooks.controller.test.ts
+++ b/packages/cli/test/integration/controllers/test-webhooks.controller.test.ts
@@ -1,0 +1,82 @@
+import {
+	createTeamProject,
+	createWorkflow,
+	linkUserToProject,
+	mockInstance,
+	shareWorkflowWithUsers,
+	testDb,
+} from '@n8n/backend-test-utils';
+import type { User } from '@n8n/db';
+
+import { TestWebhooks } from '@/webhooks/test-webhooks';
+
+import { createMember, createOwner } from '../shared/db/users';
+import { setupTestServer } from '../shared/utils';
+
+const testWebhooks = mockInstance(TestWebhooks);
+
+const testServer = setupTestServer({
+	endpointGroups: ['test-webhooks'],
+	enabledFeatures: ['feat:sharing'],
+	quotas: {
+		'quota:maxTeamProjects': -1,
+	},
+});
+
+let owner: User;
+let member: User;
+
+beforeEach(async () => {
+	await testDb.truncate(['SharedWorkflow', 'ProjectRelation', 'WorkflowEntity', 'Project', 'User']);
+	testWebhooks.cancelWebhook.mockReset();
+	testWebhooks.cancelWebhook.mockResolvedValue(true);
+	owner = await createOwner();
+	member = await createMember();
+});
+
+describe('DELETE /test-webhook/:workflowId', () => {
+	test('rejects unauthenticated requests', async () => {
+		const workflow = await createWorkflow({}, owner);
+
+		await testServer.authlessAgent.delete(`/test-webhook/${workflow.id}`).expect(401);
+
+		expect(testWebhooks.cancelWebhook).not.toHaveBeenCalled();
+	});
+
+	test('rejects callers without access to the workflow', async () => {
+		const workflow = await createWorkflow({}, owner);
+
+		await testServer.authAgentFor(member).delete(`/test-webhook/${workflow.id}`).expect(403);
+
+		expect(testWebhooks.cancelWebhook).not.toHaveBeenCalled();
+	});
+
+	test('rejects callers with project access but no workflow:execute scope', async () => {
+		const teamProject = await createTeamProject(undefined, owner);
+		await linkUserToProject(member, teamProject, 'project:viewer');
+		const workflow = await createWorkflow({}, teamProject);
+
+		await testServer.authAgentFor(member).delete(`/test-webhook/${workflow.id}`).expect(403);
+
+		expect(testWebhooks.cancelWebhook).not.toHaveBeenCalled();
+	});
+
+	test('cancels the test webhook for callers with workflow:execute scope', async () => {
+		const workflow = await createWorkflow({}, owner);
+		await shareWorkflowWithUsers(workflow, [member]);
+
+		await testServer.authAgentFor(member).delete(`/test-webhook/${workflow.id}`).expect(200);
+
+		expect(testWebhooks.cancelWebhook).toHaveBeenCalledTimes(1);
+		expect(testWebhooks.cancelWebhook).toHaveBeenCalledWith(workflow.id);
+	});
+
+	test('returns 404 when the workflow does not exist', async () => {
+		await testServer
+			.authAgentFor(member)
+			.delete('/test-webhook/00000000-0000-0000-0000-000000000000')
+			.expect(404);
+
+		expect(testWebhooks.cancelWebhook).not.toHaveBeenCalled();
+	});
+});

--- a/packages/cli/test/integration/shared/types.ts
+++ b/packages/cli/test/integration/shared/types.ts
@@ -51,7 +51,8 @@ type EndpointGroup =
 	| 'third-party-licenses'
 	| 'mcp'
 	| 'workflowDependencies'
-	| 'encryption-keys';
+	| 'encryption-keys'
+	| 'test-webhooks';
 
 type ModuleName =
 	| 'insights'

--- a/packages/cli/test/integration/shared/utils/test-server.ts
+++ b/packages/cli/test/integration/shared/utils/test-server.ts
@@ -358,6 +358,10 @@ export const setupTestServer = ({
 					case 'encryption-keys':
 						await import('@/modules/encryption-key-manager/encryption-key.controller');
 						break;
+
+					case 'test-webhooks':
+						await import('@/webhooks/test-webhooks.controller');
+						break;
 				}
 			}
 


### PR DESCRIPTION
## Summary

Moves the `DELETE /rest/test-webhook/:workflowId` handler from an inline Express route in `AbstractServer` into a proper `@RestController`, so it follows the same patterns as the rest of the REST surface — dependency injection, decorator-based access scope, and integration tests under `test/integration/controllers/`.

The wire path is unchanged. The closest behavioural neighbour for this action is `ExecutionsController.stop`; this controller mirrors the same scope (`workflow:execute`).

### Changes

- New `TestWebhooksController` at
  `packages/cli/src/webhooks/test-webhooks.controller.ts`.
- Integration test added at
  `packages/cli/test/integration/controllers/test-webhooks.controller.test.ts`.
- Inline route removed from `packages/cli/src/abstract-server.ts`.
- Controller registered via side-effect import in
  `packages/cli/src/server.ts`.

### How to test

- `cd packages/cli && pnpm test:sqlite test/integration/controllers/test-webhooks.controller.test.ts`
- In the editor, run a workflow with a webhook trigger and use **Stop test** on the running execution — the test run ends as before.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/CAT-3260

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
