### PR TITLE
fix(core): tighten authorization on additional REST endpoints

### DIFF
--- a/packages/cli/src/evaluation.ee/test-runs.controller.ee.ts
+++ b/packages/cli/src/evaluation.ee/test-runs.controller.ee.ts
@@ -99,8 +99,9 @@ export class TestRunsController {
 	async delete(req: TestRunsRequest.Delete) {
 		const { id: testRunId } = req.params;
 
-		// Check test run exist
-		await this.getTestRun(req.params.id, req.params.workflowId, req.user);
+		// Check test run exist. Deleting a run mutates state, so require
+		// `workflow:update` — a read-only viewer must not be able to delete runs.
+		await this.getTestRun(req.params.id, req.params.workflowId, req.user, ['workflow:update']);
 
 		await this.testRunRepository.delete({ id: testRunId });
 
@@ -113,8 +114,12 @@ export class TestRunsController {
 	async cancel(req: TestRunsRequest.Cancel, res: express.Response) {
 		const { id: testRunId } = req.params;
 
-		// Check test definition and test run exist
-		const testRun = await this.getTestRun(req.params.id, req.params.workflowId, req.user);
+		// Check test definition and test run exist. Cancelling mutates execution
+		// state, so require `workflow:execute` (matching cancelCase) — a read-only
+		// viewer must not be able to cancel a run.
+		const testRun = await this.getTestRun(req.params.id, req.params.workflowId, req.user, [
+			'workflow:execute',
+		]);
 
 		if (this.testRunnerService.canBeCancelled(testRun)) {
 			const message = `The test run "${testRunId}" cannot be cancelled`;
@@ -162,7 +167,9 @@ export class TestRunsController {
 	) {
 		const { workflowId } = req.params;
 
-		await this.assertUserHasAccessToWorkflow(workflowId, req.user);
+		// Starting a run triggers real workflow executions, so require
+		// `workflow:execute` — a read-only viewer must not be able to launch runs.
+		await this.assertUserHasAccessToWorkflow(workflowId, req.user, ['workflow:execute']);
 
 		const concurrency = payload.concurrency ?? 1;
 

--- a/packages/cli/src/license/license.controller.ts
+++ b/packages/cli/src/license/license.controller.ts
@@ -41,6 +41,7 @@ export class LicenseController {
 	}
 
 	@Post('/enterprise/community-registered')
+	@GlobalScope('license:manage')
 	async registerCommunityEdition(
 		req: AuthenticatedRequest,
 		_res: Response,

--- a/packages/cli/src/modules/dynamic-credentials.ee/__tests__/dynamic-credentials.controller.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/__tests__/dynamic-credentials.controller.test.ts
@@ -31,7 +31,7 @@ describe('DynamicCredentialsController', () => {
 	const resolverRegistry = mockInstance(DynamicCredentialResolverRegistry);
 	const dynamicCredentialWebService = mockInstance(DynamicCredentialWebService);
 	const cipher = mockInstance(Cipher);
-	mockInstance(CredentialsFinderService);
+	const credentialsFinderService = mockInstance(CredentialsFinderService);
 	mockInstance(CredentialConnectionStatusService);
 	mockInstance(EventService);
 
@@ -51,6 +51,27 @@ describe('DynamicCredentialsController', () => {
 			identity: 'token123',
 			version: 1 as const,
 			metadata: {},
+		});
+
+		// Default: an authenticated caller can access the credential (gate is a no-op
+		// for the existing cases; deny-path is covered by its own test below).
+		credentialsFinderService.findCredentialForUser.mockResolvedValue(mock<CredentialsEntity>());
+	});
+
+	describe('in-app access control', () => {
+		it('returns 404 when an authenticated user cannot access the credential', async () => {
+			credentialsFinderService.findCredentialForUser.mockResolvedValue(null);
+			const req = mock<Request>({
+				params: { id: 'foreign-credential' },
+				query: { resolverId: 'resolver-123' },
+				headers: { authorization: 'Bearer token123' },
+			});
+			const res = mock<Response>();
+
+			await expect(controller.authorizeCredential(req, res)).rejects.toThrow(
+				'Credential not found',
+			);
+			expect(enterpriseCredentialsService.getOne).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/modules/dynamic-credentials.ee/__tests__/workflow-status.controller.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/__tests__/workflow-status.controller.test.ts
@@ -1,11 +1,14 @@
 import { mock } from 'jest-mock-extended';
+import type { WorkflowEntity } from '@n8n/db';
 import type { Request, Response } from 'express';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import type { DynamicCredentialCorsService } from '../services/dynamic-credential-cors.service';
 import type { DynamicCredentialWebService } from '../services/dynamic-credential-web.service';
 import { WorkflowStatusController } from '../workflow-status.controller';
 import type { CredentialResolverWorkflowService } from '../services/credential-resolver-workflow.service';
 import type { UrlService } from '@/services/url.service';
+import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import type { GlobalConfig } from '@n8n/config';
 
 jest.mock('../utils', () => ({
@@ -19,6 +22,7 @@ describe('WorkflowStatusController', () => {
 	let mockGlobalConfig: jest.Mocked<GlobalConfig>;
 	let mockDynamicCredentialCorsService: jest.Mocked<DynamicCredentialCorsService>;
 	let mockDynamicCredentialWebService: jest.Mocked<DynamicCredentialWebService>;
+	let mockWorkflowFinderService: jest.Mocked<WorkflowFinderService>;
 
 	beforeEach(() => {
 		jest.clearAllMocks();
@@ -49,13 +53,46 @@ describe('WorkflowStatusController', () => {
 			metadata: {},
 		});
 
+		mockWorkflowFinderService = mock<WorkflowFinderService>();
+		// Default: the caller can access the workflow (gate is a no-op for the
+		// existing cases; deny-path is covered by its own test below).
+		mockWorkflowFinderService.findWorkflowForUser.mockResolvedValue(mock<WorkflowEntity>());
+
 		controller = new WorkflowStatusController(
 			mockService,
 			mockUrlService,
 			mockGlobalConfig,
 			mockDynamicCredentialCorsService,
 			mockDynamicCredentialWebService,
+			mockWorkflowFinderService,
 		);
+	});
+
+	describe('in-app access control', () => {
+		it('returns 404 when an authenticated user cannot access the workflow', async () => {
+			mockWorkflowFinderService.findWorkflowForUser.mockResolvedValue(null);
+			const req = mock<Request>();
+			req.params = { workflowId: 'foreign-workflow' };
+			req.headers = { authorization: 'Bearer token-123' };
+			const res = mock<Response>();
+
+			await expect(controller.checkWorkflowForExecution(req, res)).rejects.toThrow(NotFoundError);
+			expect(mockService.getWorkflowStatus).not.toHaveBeenCalled();
+		});
+
+		it('skips the user access check for external (token-only) callers', async () => {
+			mockService.getWorkflowStatus.mockResolvedValue([]);
+			const req = mock<Request>();
+			req.params = { workflowId: 'wf-1' };
+			req.headers = { authorization: 'Bearer token-123' };
+			// external resolver caller: no session user
+			(req as unknown as { user?: unknown }).user = undefined;
+			const res = mock<Response>();
+
+			await controller.checkWorkflowForExecution(req, res);
+			expect(mockWorkflowFinderService.findWorkflowForUser).not.toHaveBeenCalled();
+			expect(mockService.getWorkflowStatus).toHaveBeenCalled();
+		});
 	});
 
 	describe('checkWorkflowForExecution', () => {

--- a/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.controller.ts
@@ -37,7 +37,25 @@ export class DynamicCredentialsController {
 		private readonly eventService: EventService,
 	) {}
 
-	private async findCredentialToUse(credentialId: string): Promise<CredentialsEntity> {
+	private async findCredentialToUse(
+		credentialId: string,
+		req: Request,
+	): Promise<CredentialsEntity> {
+		// External resolver callers authenticate via the endpoint token and carry no
+		// user. In-app callers carry a session user, so verify they actually have
+		// access to this credential rather than letting them target any id.
+		const user = (req as AuthenticatedRequest).user;
+		if (user) {
+			const accessible = await this.credentialsFinderService.findCredentialForUser(
+				credentialId,
+				user,
+				['credential:read'],
+			);
+			if (!accessible) {
+				throw new NotFoundError('Credential not found');
+			}
+		}
+
 		const credential = await this.enterpriseCredentialsService.getOne(credentialId);
 
 		if (!credential) {
@@ -96,7 +114,7 @@ export class DynamicCredentialsController {
 	async revokeCredential(req: Request, res: Response): Promise<void> {
 		this.dynamicCredentialCorsService.applyCorsHeadersIfEnabled(req, res, ['delete', 'options']);
 		const credentialContext = this.dynamicCredentialWebService.getCredentialContextFromRequest(req);
-		const credential = await this.findCredentialToUse(req.params.id);
+		const credential = await this.findCredentialToUse(req.params.id, req);
 
 		const resolverId = req.query.resolverId as string | undefined;
 		const { resolver, resolverEntity } = await this.getResolverInstance(resolverId);
@@ -137,7 +155,7 @@ export class DynamicCredentialsController {
 	async authorizeCredential(req: Request, res: Response): Promise<string> {
 		this.dynamicCredentialCorsService.applyCorsHeadersIfEnabled(req, res, ['post', 'options']);
 		const credentialContext = this.dynamicCredentialWebService.getCredentialContextFromRequest(req);
-		const credential = await this.findCredentialToUse(req.params.id);
+		const credential = await this.findCredentialToUse(req.params.id, req);
 
 		const resolverId = req.query.resolverId as string | undefined;
 		const { resolver, resolverEntity } = await this.getResolverInstance(resolverId);

--- a/packages/cli/src/modules/dynamic-credentials.ee/workflow-status.controller.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/workflow-status.controller.ts
@@ -1,12 +1,15 @@
 import { WorkflowExecutionStatus } from '@n8n/api-types';
 import { GlobalConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
+import { AuthenticatedRequest } from '@n8n/db';
 import { Get, Options, RestController } from '@n8n/decorators';
 import { Container } from '@n8n/di';
 import { Request, Response } from 'express';
 
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { UrlService } from '@/services/url.service';
+import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
 import { DynamicCredentialsConfig } from './dynamic-credentials.config';
 import { CredentialResolverWorkflowService } from './services/credential-resolver-workflow.service';
@@ -24,6 +27,7 @@ export class WorkflowStatusController {
 		private readonly globalConfig: GlobalConfig,
 		private readonly dynamicCredentialCorsService: DynamicCredentialCorsService,
 		private readonly dynamicCredentialWebService: DynamicCredentialWebService,
+		private readonly workflowFinderService: WorkflowFinderService,
 	) {}
 
 	/**
@@ -60,6 +64,19 @@ export class WorkflowStatusController {
 
 		if (!workflowId) {
 			throw new BadRequestError('Workflow ID is missing');
+		}
+
+		// External resolver callers authenticate via the endpoint token and carry no
+		// user. In-app callers carry a session user, so verify they can access the
+		// workflow rather than letting them read any workflow's credential metadata.
+		const user = (req as AuthenticatedRequest).user;
+		if (user) {
+			const workflow = await this.workflowFinderService.findWorkflowForUser(workflowId, user, [
+				'workflow:read',
+			]);
+			if (!workflow) {
+				throw new NotFoundError('Workflow not found');
+			}
 		}
 
 		const status = await this.credentialResolverWorkflowService.getWorkflowStatus(

--- a/packages/cli/src/modules/instance-registry/__tests__/instance-registry.controller.test.ts
+++ b/packages/cli/src/modules/instance-registry/__tests__/instance-registry.controller.test.ts
@@ -1,4 +1,6 @@
 import type { InstanceRegistration } from '@n8n/api-types';
+import { ControllerRegistryMetadata, type Controller } from '@n8n/decorators';
+import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 
 import type { CheckService } from '../checks/check.service';
@@ -105,6 +107,18 @@ describe('InstanceRegistryController', () => {
 						severity: 'warning',
 					},
 				],
+			});
+		});
+	});
+
+	describe('route access scopes', () => {
+		it('gates getClusterInfo behind the orchestration:read global scope', () => {
+			const metadata = Container.get(ControllerRegistryMetadata).getControllerMetadata(
+				InstanceRegistryController as Controller,
+			);
+			expect(metadata.routes.get('getClusterInfo')?.accessScope).toEqual({
+				scope: 'orchestration:read',
+				globalOnly: true,
 			});
 		});
 	});

--- a/packages/cli/src/modules/instance-registry/instance-registry.controller.ts
+++ b/packages/cli/src/modules/instance-registry/instance-registry.controller.ts
@@ -1,5 +1,5 @@
 import type { ClusterCheckSummary, ClusterInfoResponse } from '@n8n/api-types';
-import { Get, RestController } from '@n8n/decorators';
+import { Get, GlobalScope, RestController } from '@n8n/decorators';
 
 import { CheckService } from './checks/check.service';
 import { InstanceRegistryService } from './instance-registry.service';
@@ -12,6 +12,7 @@ export class InstanceRegistryController {
 	) {}
 
 	@Get('/')
+	@GlobalScope('orchestration:read')
 	async getClusterInfo(): Promise<ClusterInfoResponse> {
 		const [instances, { results }] = await Promise.all([
 			this.instanceRegistryService.getAllInstances(),

--- a/packages/cli/src/modules/sso-saml/__tests__/saml.controller.ee.test.ts
+++ b/packages/cli/src/modules/sso-saml/__tests__/saml.controller.ee.test.ts
@@ -1,4 +1,6 @@
 import { GLOBAL_OWNER_ROLE, type AuthenticatedRequest, type User } from '@n8n/db';
+import { ControllerRegistryMetadata, type Controller } from '@n8n/decorators';
+import { Container } from '@n8n/di';
 import { type Response } from 'express';
 import { mock } from 'jest-mock-extended';
 
@@ -403,5 +405,17 @@ describe('SAML env-managed write protection', () => {
 		await expect(
 			envManagedController.toggleEnabledPost(req, res, { loginEnabled: true }),
 		).rejects.toThrow('cannot be modified through the API');
+	});
+
+	describe('route access scopes', () => {
+		test('configGet (read) is gated by saml:manage, matching the write endpoints', () => {
+			const metadata = Container.get(ControllerRegistryMetadata).getControllerMetadata(
+				SamlController as Controller,
+			);
+			expect(metadata.routes.get('configGet')?.accessScope).toEqual({
+				scope: 'saml:manage',
+				globalOnly: true,
+			});
+		});
 	});
 });

--- a/packages/cli/src/modules/sso-saml/saml.controller.ee.ts
+++ b/packages/cli/src/modules/sso-saml/saml.controller.ee.ts
@@ -53,6 +53,7 @@ export class SamlController {
 	 * Return SAML config
 	 */
 	@Get('/config', { middlewares: [samlLicensedMiddleware] })
+	@GlobalScope('saml:manage')
 	async configGet() {
 		const prefs = this.samlService.samlPreferences;
 		return {


### PR DESCRIPTION
## Summary

Follow-up to the source-control read-endpoint hardening. A repo-wide review of all 90 `@RestController`s surfaced a handful of endpoints whose authorization was weaker than their siblings. This PR fixes the confirmed ones (each verified by reading the full handler → service → middleware path).

| # | Endpoint | Before | After |
| --- | --- | --- | --- |
| 1 | `GET /sso/saml/config` | license check only | `@GlobalScope('saml:manage')` (matches `POST /config`) |
| 2 | `POST /license/enterprise/community-registered` | none | `@GlobalScope('license:manage')` (matches sibling license mutations) |
| 3 | `GET /instance-registry` | none | `@GlobalScope('orchestration:read')` (FE store already degrades gracefully) |
| 4 | `POST /workflows/:id/test-runs/new`, `…/cancel`, `DELETE …/test-runs/:id` | `workflow:read` | `workflow:execute` (create/cancel), `workflow:update` (delete) — matches `cancelCase` |
| 5 | dynamic-credentials `authorize` / `revoke` / `execution-status` | id looked up unscoped for any authenticated session | when a session user is present, verify `credential:read` / `workflow:read`; token-only external path unchanged |

### Notes

- #1–#3 are read/registration endpoints that were missing the scope their mutating siblings already enforce.
- #3: gating is safe because `instanceRegistry.store` swallows fetch errors by design (the About dialog / bug report just omit cluster info for non-admins).
- #5 preserves the external resolver-callback flow (which authenticates via the endpoint token and carries no `req.user`); only the in-app authenticated path gains the access check.

### Not included
- `GET /binary-data` (no ownership check) is **not** fixed here: binary-data IDs are `mode:path` with no reliable execution linkage, so a correct ownership check needs a design change (resolve execution → `execution:read`). Flagged for a separate ticket.
- Several by-design info-disclosure reads (`GET /license`, `GET /roles`, `GET /projects/count`, `GET /module-settings`) are left as-is — they return non-secret metadata to authenticated users and are a product call, not bugs.

## Testing

- New deny-path unit tests for dynamic-credentials (`authorize` 404s when the session user lacks access) and workflow execution-status (404 for inaccessible workflow; external token path skips the check).
- New route-scope regression guards for SAML `configGet` and instance-registry `getClusterInfo`.
- Existing test-runs / SAML / instance-registry / dynamic-credentials suites updated and green (355+ affected tests).
- `pnpm typecheck`: no new errors.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up hardening identified during CAT-3235 review — https://linear.app/n8n/issue/CAT-3235

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)