### PR TITLE
fix: Quote and validate Postgres table and column identifiers in AI nodes

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryPostgresChat/MemoryPostgresChat.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryPostgresChat/MemoryPostgresChat.node.test.ts
@@ -1,0 +1,99 @@
+import type { ISupplyDataFunctions } from 'n8n-workflow';
+
+import { escapeQualifiedSqlIdentifier } from '@utils/sqlIdentifier';
+
+const postgresChatHistoryConstructor = vi.fn();
+
+vi.mock('@langchain/community/stores/message/postgres', () => ({
+	PostgresChatMessageHistory: class {
+		constructor(args: unknown) {
+			postgresChatHistoryConstructor(args);
+		}
+	},
+}));
+
+vi.mock('@langchain/classic/memory', () => ({
+	BufferMemory: class {},
+	BufferWindowMemory: class {},
+}));
+
+vi.mock('n8n-nodes-base/dist/nodes/Postgres/transport/index', () => ({
+	configurePostgres: vi.fn().mockResolvedValue({ db: { $pool: {} } }),
+}));
+
+vi.mock('n8n-nodes-base/dist/nodes/Postgres/v2/methods/credentialTest', () => ({
+	postgresConnectionTest: vi.fn(),
+}));
+
+vi.mock('@n8n/ai-utilities', () => ({
+	logWrapper: (memory: unknown) => memory,
+	getConnectionHintNoticeField: () => ({}),
+}));
+
+vi.mock('@utils/helpers', () => ({
+	getSessionId: () => 'fixed-session',
+}));
+
+import { MemoryPostgresChat } from './MemoryPostgresChat.node';
+
+describe('MemoryPostgresChat', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	function createContext(tableName: string): ISupplyDataFunctions {
+		return {
+			getCredentials: vi.fn().mockResolvedValue({}),
+			getNodeParameter: vi.fn((name: string) => {
+				if (name === 'tableName') return tableName;
+				return undefined;
+			}),
+			getNode: () => ({ typeVersion: 1, name: 'Postgres Chat Memory' }),
+		} as unknown as ISupplyDataFunctions;
+	}
+
+	it('passes a quoted table name to the chat history store', async () => {
+		const node = new MemoryPostgresChat();
+		const context = createContext('n8n_chat_histories');
+
+		await node.supplyData.call(context, 0);
+
+		expect(postgresChatHistoryConstructor).toHaveBeenCalledTimes(1);
+		const args = postgresChatHistoryConstructor.mock.calls[0]?.[0] as { tableName: string };
+		expect(args.tableName).toBe('"n8n_chat_histories"');
+	});
+
+	it('quotes each part of a schema-qualified table name', async () => {
+		const node = new MemoryPostgresChat();
+		const context = createContext('my_schema.histories');
+
+		await node.supplyData.call(context, 0);
+
+		const args = postgresChatHistoryConstructor.mock.calls[0]?.[0] as { tableName: string };
+		expect(args.tableName).toBe(escapeQualifiedSqlIdentifier('my_schema.histories'));
+		expect(args.tableName).toBe('"my_schema"."histories"');
+	});
+
+	it('falls back to the default when the table name resolves to empty', async () => {
+		const node = new MemoryPostgresChat();
+		// e.g. an expression like {{ $json.tableName }} when the request omits tableName
+		const context = {
+			getCredentials: vi.fn().mockResolvedValue({}),
+			getNodeParameter: vi.fn().mockReturnValue(undefined),
+			getNode: () => ({ typeVersion: 1, name: 'Postgres Chat Memory' }),
+		} as unknown as ISupplyDataFunctions;
+
+		await node.supplyData.call(context, 0);
+
+		const args = postgresChatHistoryConstructor.mock.calls[0]?.[0] as { tableName: string };
+		expect(args.tableName).toBe('"n8n_chat_histories"');
+	});
+
+	it('rejects a statement-breaking table name before it reaches the store', async () => {
+		const node = new MemoryPostgresChat();
+		const context = createContext('foo; DROP TABLE victim; --');
+
+		await expect(node.supplyData.call(context, 0)).rejects.toThrow('Invalid table name');
+		expect(postgresChatHistoryConstructor).not.toHaveBeenCalled();
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryPostgresChat/MemoryPostgresChat.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryPostgresChat/MemoryPostgresChat.node.test.ts
@@ -63,6 +63,16 @@ describe('MemoryPostgresChat', () => {
 		expect(args.tableName).toBe('"n8n_chat_histories"');
 	});
 
+	it('folds a mixed-case table name so it keeps targeting the same table', async () => {
+		const node = new MemoryPostgresChat();
+		const context = createContext('MyHistories');
+
+		await node.supplyData.call(context, 0);
+
+		const args = postgresChatHistoryConstructor.mock.calls[0]?.[0] as { tableName: string };
+		expect(args.tableName).toBe('"myhistories"');
+	});
+
 	it('quotes each part of a schema-qualified table name', async () => {
 		const node = new MemoryPostgresChat();
 		const context = createContext('my_schema.histories');

--- a/packages/@n8n/nodes-langchain/nodes/memory/MemoryPostgresChat/MemoryPostgresChat.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/memory/MemoryPostgresChat/MemoryPostgresChat.node.ts
@@ -1,5 +1,6 @@
-import { PostgresChatMessageHistory } from '@langchain/community/stores/message/postgres';
 import { BufferMemory, BufferWindowMemory } from '@langchain/classic/memory';
+import { PostgresChatMessageHistory } from '@langchain/community/stores/message/postgres';
+import { logWrapper, getConnectionHintNoticeField } from '@n8n/ai-utilities';
 import { configurePostgres } from 'n8n-nodes-base/dist/nodes/Postgres/transport/index';
 import type { PostgresNodeCredentials } from 'n8n-nodes-base/dist/nodes/Postgres/v2/helpers/interfaces';
 import { postgresConnectionTest } from 'n8n-nodes-base/dist/nodes/Postgres/v2/methods/credentialTest';
@@ -9,11 +10,11 @@ import type {
 	INodeTypeDescription,
 	SupplyData,
 } from 'n8n-workflow';
-import { NodeConnectionTypes } from 'n8n-workflow';
+import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 import type pg from 'pg';
 
 import { getSessionId } from '@utils/helpers';
-import { logWrapper, getConnectionHintNoticeField } from '@n8n/ai-utilities';
+import { escapeQualifiedSqlIdentifier, isSafeQualifiedSqlIdentifier } from '@utils/sqlIdentifier';
 
 import {
 	sessionIdOption,
@@ -89,7 +90,22 @@ export class MemoryPostgresChat implements INodeType {
 
 	async supplyData(this: ISupplyDataFunctions, itemIndex: number): Promise<SupplyData> {
 		const credentials = await this.getCredentials<PostgresNodeCredentials>('postgres');
-		const tableName = this.getNodeParameter('tableName', itemIndex, 'n8n_chat_histories') as string;
+		// An expression-bound Table Name can resolve to an empty value (e.g. a request
+		// field that wasn't provided), so fall back to the default instead of failing.
+		const rawTableName =
+			(this.getNodeParameter('tableName', itemIndex, 'n8n_chat_histories') as string) ||
+			'n8n_chat_histories';
+		// The underlying store interpolates the table name directly into SQL.
+		// Reject anything that is not a plain (optionally schema-qualified) identifier,
+		// then quote it as a defence-in-depth measure so nothing unexpected reaches the database.
+		if (!isSafeQualifiedSqlIdentifier(rawTableName)) {
+			throw new NodeOperationError(this.getNode(), `Invalid table name "${rawTableName}"`, {
+				itemIndex,
+				description:
+					'Table names may only contain letters, numbers and underscores, with an optional "schema." prefix.',
+			});
+		}
+		const tableName = escapeQualifiedSqlIdentifier(rawTableName);
 		const sessionId = getSessionId(this, itemIndex);
 
 		const pgConf = await configurePostgres.call(this, credentials);

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/ChatHubVectorStorePGVector/ChatHubVectorStorePGVector.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/ChatHubVectorStorePGVector/ChatHubVectorStorePGVector.node.ts
@@ -199,8 +199,11 @@ export class ChatHubVectorStorePGVector extends createVectorStoreNode({
 			...config,
 			n8nNode: context.getNode(),
 		});
-		await vectorStore.addDocuments(filterChatHubInsertDocuments(documents));
-		vectorStore.client?.release();
+		try {
+			await vectorStore.addDocuments(filterChatHubInsertDocuments(documents));
+		} finally {
+			vectorStore.client?.release();
+		}
 	},
 
 	releaseVectorStoreClient(vectorStore) {

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/ChatHubVectorStorePGVector/ChatHubVectorStorePGVector.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/ChatHubVectorStorePGVector/ChatHubVectorStorePGVector.node.ts
@@ -162,7 +162,10 @@ export class ChatHubVectorStorePGVector extends createVectorStoreNode({
 			filter,
 		};
 
-		const store = await ExtendedPGVectorStore.initialize(embeddings, config);
+		const store = await ExtendedPGVectorStore.initialize(embeddings, {
+			...config,
+			n8nNode: context.getNode(),
+		});
 
 		const originalSearch = store.similaritySearchVectorWithScore.bind(store);
 		store.similaritySearchVectorWithScore = async (...args) => {
@@ -192,7 +195,10 @@ export class ChatHubVectorStorePGVector extends createVectorStoreNode({
 		// Use ExtendedPGVectorStore (not PGVectorStore.fromDocuments, whose static
 		// helpers construct a plain PGVectorStore) so the identifier-quoting
 		// overrides apply on the insert path too.
-		const vectorStore = await ExtendedPGVectorStore.initialize(embeddings, config);
+		const vectorStore = await ExtendedPGVectorStore.initialize(embeddings, {
+			...config,
+			n8nNode: context.getNode(),
+		});
 		await vectorStore.addDocuments(filterChatHubInsertDocuments(documents));
 		vectorStore.client?.release();
 	},

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/ChatHubVectorStorePGVector/ChatHubVectorStorePGVector.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/ChatHubVectorStorePGVector/ChatHubVectorStorePGVector.node.ts
@@ -1,4 +1,4 @@
-import { PGVectorStore, type PGVectorStoreArgs } from '@langchain/community/vectorstores/pgvector';
+import { type PGVectorStoreArgs } from '@langchain/community/vectorstores/pgvector';
 import { createVectorStoreNode, metadataFilterField } from '@n8n/ai-utilities';
 import { configurePostgres } from 'n8n-nodes-base/dist/nodes/Postgres/transport/index';
 import type { PostgresNodeCredentials } from 'n8n-nodes-base/dist/nodes/Postgres/v2/helpers/interfaces';
@@ -14,13 +14,16 @@ import type {
 } from 'n8n-workflow';
 import { jsonParse } from 'n8n-workflow';
 import type pg from 'pg';
-import { getUserScopedSlot } from '../shared/userScoped';
-import { ExtendedPGVectorStore } from '../VectorStorePGVector/VectorStorePGVector.node';
+
+import { escapeQualifiedSqlIdentifier } from '@utils/sqlIdentifier';
+
 import {
 	filterChatHubMetadata,
 	filterChatHubInsertDocuments,
 	CHAT_HUB_RETRIEVE_METADATA_KEYS,
 } from '../shared/chatHub';
+import { getUserScopedSlot } from '../shared/userScoped';
+import { ExtendedPGVectorStore } from '../VectorStorePGVector/VectorStorePGVector.node';
 
 type ChatHubVectorStorePGVectorApiCredentials = PostgresNodeCredentials & {
 	tableNamePrefix: string;
@@ -56,7 +59,7 @@ async function deleteDocuments(
 	if (!filter || Object.keys(filter).length === 0) {
 		// The table is user-scoped (one table per user), so dropping it is safe
 		// and avoids leaving empty ghost tables after user deletion.
-		await pool.query(`DROP TABLE IF EXISTS "${tableName}"`);
+		await pool.query(`DROP TABLE IF EXISTS ${escapeQualifiedSqlIdentifier(tableName)}`);
 		return null;
 	}
 
@@ -72,7 +75,10 @@ async function deleteDocuments(
 		values.push(key, value);
 		paramIndex += 2;
 	}
-	await pool.query(`DELETE FROM "${tableName}" WHERE ${conditions.join(' AND ')}`, values);
+	await pool.query(
+		`DELETE FROM ${escapeQualifiedSqlIdentifier(tableName)} WHERE ${conditions.join(' AND ')}`,
+		values,
+	);
 
 	return null;
 }
@@ -183,11 +189,11 @@ export class ChatHubVectorStorePGVector extends createVectorStoreNode({
 			tableName,
 		};
 
-		const vectorStore = await PGVectorStore.fromDocuments(
-			filterChatHubInsertDocuments(documents),
-			embeddings,
-			config,
-		);
+		// Use ExtendedPGVectorStore (not PGVectorStore.fromDocuments, whose static
+		// helpers construct a plain PGVectorStore) so the identifier-quoting
+		// overrides apply on the insert path too.
+		const vectorStore = await ExtendedPGVectorStore.initialize(embeddings, config);
+		await vectorStore.addDocuments(filterChatHubInsertDocuments(documents));
 		vectorStore.client?.release();
 	},
 

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts
@@ -1,0 +1,89 @@
+import type { Embeddings } from '@langchain/core/embeddings';
+import type pg from 'pg';
+
+import { escapeSqlIdentifier } from '@utils/sqlIdentifier';
+
+// Keep the module import light: the node body calls createVectorStoreNode and
+// configurePostgres at load time, neither of which is needed to exercise the
+// ExtendedPGVectorStore identifier handling.
+vi.mock('@n8n/ai-utilities', () => ({
+	metadataFilterField: {},
+	createVectorStoreNode: () => class {},
+}));
+
+vi.mock('n8n-nodes-base/dist/nodes/Postgres/transport/index', () => ({
+	configurePostgres: vi.fn(),
+}));
+
+import { ExtendedPGVectorStore } from './VectorStorePGVector.node';
+
+const embeddings = {} as unknown as Embeddings;
+
+function createStore(args: {
+	tableName: string;
+	collectionTableName?: string;
+}): ExtendedPGVectorStore {
+	const queryMock = vi.fn().mockResolvedValue({ rows: [] });
+	const pool = { query: queryMock } as unknown as pg.Pool;
+	const store = new ExtendedPGVectorStore(embeddings, {
+		pool,
+		tableName: args.tableName,
+		collectionName: args.collectionTableName ? 'collection' : undefined,
+		collectionTableName: args.collectionTableName,
+	});
+	return store;
+}
+
+describe('ExtendedPGVectorStore', () => {
+	const maliciousName = 'x"; DROP TABLE victim; --';
+
+	describe('computedTableName', () => {
+		it('quotes a plain table name', () => {
+			const store = createStore({ tableName: 'n8n_vectors' });
+			expect(store.computedTableName).toBe('"n8n_vectors"');
+		});
+
+		it('quotes a statement-breaking table name as a single identifier', () => {
+			const store = createStore({ tableName: maliciousName });
+			expect(store.computedTableName).toBe(escapeSqlIdentifier(maliciousName));
+			expect(store.computedTableName).toBe('"x""; DROP TABLE victim; --"');
+		});
+	});
+
+	describe('computedCollectionTableName', () => {
+		it('quotes the collection table name', () => {
+			const store = createStore({
+				tableName: 'n8n_vectors',
+				collectionTableName: maliciousName,
+			});
+			expect(store.computedCollectionTableName).toBe(escapeSqlIdentifier(maliciousName));
+		});
+	});
+
+	describe('ensureCollectionTableInDatabase', () => {
+		it('issues SQL with quoted table, constraint and index identifiers', async () => {
+			const queryMock = vi.fn().mockResolvedValue({ rows: [] });
+			const pool = { query: queryMock } as unknown as pg.Pool;
+			const store = new ExtendedPGVectorStore(embeddings, {
+				pool,
+				tableName: maliciousName,
+				collectionName: 'collection',
+				collectionTableName: 'n8n_collections',
+			});
+
+			await store.ensureCollectionTableInDatabase();
+
+			const sql = queryMock.mock.calls[0]?.[0] as string;
+
+			// Table name only appears as a fully quoted identifier.
+			expect(sql).toContain(escapeSqlIdentifier(maliciousName));
+			// The constraint name embeds the table name but is escaped as one identifier.
+			expect(sql).toContain(escapeSqlIdentifier(`${maliciousName}_collection_id_fkey`));
+			// The index name embeds the collection table name and is escaped too.
+			expect(sql).toContain(escapeSqlIdentifier('idx_n8n_collections_name'));
+			// The quote-then-statement breakout sequence is neutralised: every embedded
+			// double quote is doubled, so `x"; DROP` never appears verbatim.
+			expect(sql).not.toContain('x"; DROP');
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.test.ts
@@ -1,7 +1,8 @@
 import type { Embeddings } from '@langchain/core/embeddings';
+import type { INode } from 'n8n-workflow';
 import type pg from 'pg';
 
-import { escapeSqlIdentifier } from '@utils/sqlIdentifier';
+import { escapeQualifiedSqlIdentifier, escapeSqlIdentifier } from '@utils/sqlIdentifier';
 
 // Keep the module import light: the node body calls createVectorStoreNode and
 // configurePostgres at load time, neither of which is needed to exercise the
@@ -18,10 +19,12 @@ vi.mock('n8n-nodes-base/dist/nodes/Postgres/transport/index', () => ({
 import { ExtendedPGVectorStore } from './VectorStorePGVector.node';
 
 const embeddings = {} as unknown as Embeddings;
+const node = { name: 'Postgres PGVector Store' } as unknown as INode;
 
 function createStore(args: {
 	tableName: string;
 	collectionTableName?: string;
+	filter?: Record<string, unknown>;
 }): ExtendedPGVectorStore {
 	const queryMock = vi.fn().mockResolvedValue({ rows: [] });
 	const pool = { query: queryMock } as unknown as pg.Pool;
@@ -30,7 +33,9 @@ function createStore(args: {
 		tableName: args.tableName,
 		collectionName: args.collectionTableName ? 'collection' : undefined,
 		collectionTableName: args.collectionTableName,
+		filter: args.filter as Record<string, never> | undefined,
 	});
+	store.n8nNode = node;
 	return store;
 }
 
@@ -43,10 +48,15 @@ describe('ExtendedPGVectorStore', () => {
 			expect(store.computedTableName).toBe('"n8n_vectors"');
 		});
 
+		it('folds mixed-case names to preserve the previous unquoted target', () => {
+			const store = createStore({ tableName: 'MyTable' });
+			expect(store.computedTableName).toBe('"mytable"');
+		});
+
 		it('quotes a statement-breaking table name as a single identifier', () => {
 			const store = createStore({ tableName: maliciousName });
-			expect(store.computedTableName).toBe(escapeSqlIdentifier(maliciousName));
-			expect(store.computedTableName).toBe('"x""; DROP TABLE victim; --"');
+			expect(store.computedTableName).toBe(escapeQualifiedSqlIdentifier(maliciousName));
+			expect(store.computedTableName).toBe('"x""; drop table victim; --"');
 		});
 	});
 
@@ -56,7 +66,7 @@ describe('ExtendedPGVectorStore', () => {
 				tableName: 'n8n_vectors',
 				collectionTableName: maliciousName,
 			});
-			expect(store.computedCollectionTableName).toBe(escapeSqlIdentifier(maliciousName));
+			expect(store.computedCollectionTableName).toBe(escapeQualifiedSqlIdentifier(maliciousName));
 		});
 	});
 
@@ -70,20 +80,43 @@ describe('ExtendedPGVectorStore', () => {
 				collectionName: 'collection',
 				collectionTableName: 'n8n_collections',
 			});
+			store.n8nNode = node;
 
 			await store.ensureCollectionTableInDatabase();
 
 			const sql = queryMock.mock.calls[0]?.[0] as string;
 
 			// Table name only appears as a fully quoted identifier.
-			expect(sql).toContain(escapeSqlIdentifier(maliciousName));
+			expect(sql).toContain(escapeQualifiedSqlIdentifier(maliciousName));
 			// The constraint name embeds the table name but is escaped as one identifier.
 			expect(sql).toContain(escapeSqlIdentifier(`${maliciousName}_collection_id_fkey`));
 			// The index name embeds the collection table name and is escaped too.
 			expect(sql).toContain(escapeSqlIdentifier('idx_n8n_collections_name'));
-			// The quote-then-statement breakout sequence is neutralised: every embedded
-			// double quote is doubled, so `x"; DROP` never appears verbatim.
+			// The quote-then-statement breakout sequence is neutralised.
 			expect(sql).not.toContain('x"; DROP');
+		});
+	});
+
+	describe('similaritySearchVectorWithScore', () => {
+		it('rejects a metadata filter key that could break out of a SQL literal', async () => {
+			const store = createStore({ tableName: 'n8n_vectors' });
+
+			await expect(
+				store.similaritySearchVectorWithScore([0.1, 0.2], 4, {
+					"x'); DROP TABLE victim; --": '1',
+				}),
+			).rejects.toThrow('Invalid metadata filter key');
+		});
+
+		it('rejects an unsafe filter supplied at construction time', async () => {
+			const store = createStore({
+				tableName: 'n8n_vectors',
+				filter: { "a' OR '1'='1": 'x' },
+			});
+
+			await expect(store.similaritySearchVectorWithScore([0.1, 0.2], 4)).rejects.toThrow(
+				'Invalid metadata filter key',
+			);
 		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
@@ -7,13 +7,14 @@ import type { EmbeddingsInterface } from '@langchain/core/embeddings';
 import { metadataFilterField, createVectorStoreNode } from '@n8n/ai-utilities';
 import { configurePostgres } from 'n8n-nodes-base/dist/nodes/Postgres/transport/index';
 import type { PostgresNodeCredentials } from 'n8n-nodes-base/dist/nodes/Postgres/v2/helpers/interfaces';
-import type { IExecuteFunctions, INodeProperties, ISupplyDataFunctions } from 'n8n-workflow';
+import type { IExecuteFunctions, INode, INodeProperties, ISupplyDataFunctions } from 'n8n-workflow';
 import { NodeOperationError } from 'n8n-workflow';
 import type pg from 'pg';
 
 import {
 	escapeQualifiedSqlIdentifier,
 	escapeSqlIdentifier,
+	findUnsafeMetadataFilterKey,
 	isSafeQualifiedSqlIdentifier,
 	isSafeSqlIdentifier,
 } from '@utils/sqlIdentifier';
@@ -228,26 +229,6 @@ function validateColumnNames(
 }
 
 /**
- * Validates metadata filter keys. The underlying store interpolates each key
- * into a single-quoted SQL literal, so reject keys that could break out of it.
- */
-function validateFilterKeys(
-	context: IExecuteFunctions | ISupplyDataFunctions,
-	filter: Record<string, unknown> | undefined,
-): void {
-	if (!filter) return;
-
-	for (const key of Object.keys(filter)) {
-		if (key.includes("'") || key.includes('\\')) {
-			throw new NodeOperationError(context.getNode(), `Invalid metadata filter key "${key}"`, {
-				description:
-					"Metadata filter keys must not contain quote (') or backslash (\\) characters.",
-			});
-		}
-	}
-}
-
-/**
  * Extended PGVectorStore class to handle custom filtering.
  * This wrapper is necessary because when used as a retriever,
  * similaritySearchVectorWithScore should use this.filter instead of
@@ -258,6 +239,9 @@ function validateFilterKeys(
  * SQL by the base class.
  */
 export class ExtendedPGVectorStore extends PGVectorStore {
+	/** Node reference used to attribute validation errors; set by `initialize`. */
+	n8nNode!: INode;
+
 	get computedTableName(): string {
 		return this.schemaName === null
 			? escapeQualifiedSqlIdentifier(this.tableName)
@@ -310,10 +294,11 @@ export class ExtendedPGVectorStore extends PGVectorStore {
 
 	static async initialize(
 		embeddings: EmbeddingsInterface,
-		args: PGVectorStoreArgs & { dimensions?: number },
+		args: PGVectorStoreArgs & { dimensions?: number; n8nNode: INode },
 	): Promise<ExtendedPGVectorStore> {
-		const { dimensions, ...rest } = args;
+		const { dimensions, n8nNode, ...rest } = args;
 		const postgresqlVectorStore = new this(embeddings, rest);
+		postgresqlVectorStore.n8nNode = n8nNode;
 
 		await postgresqlVectorStore._initializeClient();
 		await postgresqlVectorStore.ensureTableInDatabase(dimensions);
@@ -330,6 +315,15 @@ export class ExtendedPGVectorStore extends PGVectorStore {
 		filter?: PGVectorStore['FilterType'],
 	) {
 		const mergedFilter = { ...this.filter, ...filter };
+		// Validate here (not only at construction) because load and
+		// retrieve-as-tool modes pass the filter at search time.
+		const unsafeKey = findUnsafeMetadataFilterKey(mergedFilter);
+		if (unsafeKey !== undefined) {
+			throw new NodeOperationError(this.n8nNode, `Invalid metadata filter key "${unsafeKey}"`, {
+				description:
+					"Metadata filter keys must not contain quote (') or backslash (\\) characters.",
+			});
+		}
 		return await super.similaritySearchVectorWithScore(query, k, mergedFilter);
 	}
 }
@@ -356,7 +350,6 @@ export class VectorStorePGVector extends createVectorStoreNode<ExtendedPGVectorS
 	loadFields: retrieveFields,
 	retrieveFields,
 	async getVectorStoreClient(context, filter, embeddings, itemIndex) {
-		validateFilterKeys(context, filter);
 		// An expression-bound Table Name can resolve to an empty value, so fall back to the default.
 		const tableName =
 			(context.getNodeParameter('tableName', itemIndex, '', { extractValue: true }) as string) ||
@@ -401,7 +394,10 @@ export class VectorStorePGVector extends createVectorStoreNode<ExtendedPGVectorS
 			'cosine',
 		) as DistanceStrategy;
 
-		return await ExtendedPGVectorStore.initialize(embeddings, config);
+		return await ExtendedPGVectorStore.initialize(embeddings, {
+			...config,
+			n8nNode: context.getNode(),
+		});
 	},
 
 	async populateVectorStore(context, embeddings, documents, itemIndex) {
@@ -447,7 +443,10 @@ export class VectorStorePGVector extends createVectorStoreNode<ExtendedPGVectorS
 		// Use ExtendedPGVectorStore (not PGVectorStore.fromDocuments, whose static
 		// helpers construct a plain PGVectorStore) so the identifier-quoting
 		// overrides apply on the insert path too.
-		const vectorStore = await ExtendedPGVectorStore.initialize(embeddings, config);
+		const vectorStore = await ExtendedPGVectorStore.initialize(embeddings, {
+			...config,
+			n8nNode: context.getNode(),
+		});
 		await vectorStore.addDocuments(documents);
 		vectorStore.client?.release();
 	},

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
@@ -4,12 +4,19 @@ import {
 	type PGVectorStoreArgs,
 } from '@langchain/community/vectorstores/pgvector';
 import type { EmbeddingsInterface } from '@langchain/core/embeddings';
+import { metadataFilterField, createVectorStoreNode } from '@n8n/ai-utilities';
 import { configurePostgres } from 'n8n-nodes-base/dist/nodes/Postgres/transport/index';
 import type { PostgresNodeCredentials } from 'n8n-nodes-base/dist/nodes/Postgres/v2/helpers/interfaces';
-import type { INodeProperties } from 'n8n-workflow';
+import type { IExecuteFunctions, INodeProperties, ISupplyDataFunctions } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
 import type pg from 'pg';
 
-import { metadataFilterField, createVectorStoreNode } from '@n8n/ai-utilities';
+import {
+	escapeQualifiedSqlIdentifier,
+	escapeSqlIdentifier,
+	isSafeQualifiedSqlIdentifier,
+	isSafeSqlIdentifier,
+} from '@utils/sqlIdentifier';
 
 type CollectionOptions = {
 	useCollection?: boolean;
@@ -179,12 +186,128 @@ const retrieveFields: INodeProperties[] = [
 ];
 
 /**
+ * Validates a table/collection-table name. It is interpolated into SQL (and into
+ * constraint/index names) by the underlying store, so reject anything that is not
+ * a plain, optionally schema-qualified identifier. The value is also quoted before
+ * use, so this rejection is a defence-in-depth layer with a clear error.
+ */
+function validateTableName(
+	context: IExecuteFunctions | ISupplyDataFunctions,
+	value: string,
+	label: string,
+): void {
+	if (!isSafeQualifiedSqlIdentifier(value)) {
+		throw new NodeOperationError(context.getNode(), `Invalid ${label} "${value}"`, {
+			description:
+				'It may only contain letters, numbers and underscores, with an optional "schema." prefix.',
+		});
+	}
+}
+
+/**
+ * Validates the configured column names. They are interpolated into SQL by the
+ * underlying store in both quoted and unquoted positions, so restrict them to
+ * plain identifiers to keep them inert.
+ */
+function validateColumnNames(
+	context: IExecuteFunctions | ISupplyDataFunctions,
+	columns: ColumnOptions,
+): void {
+	for (const [field, value] of Object.entries(columns)) {
+		if (typeof value === 'string' && !isSafeSqlIdentifier(value)) {
+			throw new NodeOperationError(
+				context.getNode(),
+				`Invalid column name "${value}" configured for "${field}"`,
+				{
+					description:
+						'Column names may only contain letters, numbers and underscores, and must not start with a number.',
+				},
+			);
+		}
+	}
+}
+
+/**
+ * Validates metadata filter keys. The underlying store interpolates each key
+ * into a single-quoted SQL literal, so reject keys that could break out of it.
+ */
+function validateFilterKeys(
+	context: IExecuteFunctions | ISupplyDataFunctions,
+	filter: Record<string, unknown> | undefined,
+): void {
+	if (!filter) return;
+
+	for (const key of Object.keys(filter)) {
+		if (key.includes("'") || key.includes('\\')) {
+			throw new NodeOperationError(context.getNode(), `Invalid metadata filter key "${key}"`, {
+				description:
+					"Metadata filter keys must not contain quote (') or backslash (\\) characters.",
+			});
+		}
+	}
+}
+
+/**
  * Extended PGVectorStore class to handle custom filtering.
  * This wrapper is necessary because when used as a retriever,
  * similaritySearchVectorWithScore should use this.filter instead of
  * expecting it from the parameter
+ *
+ * The identifier getters and collection-table setup are overridden so the
+ * table and collection table names are quoted before being interpolated into
+ * SQL by the base class.
  */
 export class ExtendedPGVectorStore extends PGVectorStore {
+	get computedTableName(): string {
+		return this.schemaName === null
+			? escapeQualifiedSqlIdentifier(this.tableName)
+			: `${escapeSqlIdentifier(this.schemaName)}.${escapeSqlIdentifier(this.tableName)}`;
+	}
+
+	get computedCollectionTableName(): string {
+		if (!this.collectionTableName) return '';
+		return this.schemaName === null
+			? escapeQualifiedSqlIdentifier(this.collectionTableName)
+			: `${escapeSqlIdentifier(this.schemaName)}.${escapeSqlIdentifier(this.collectionTableName)}`;
+	}
+
+	async ensureCollectionTableInDatabase(): Promise<void> {
+		try {
+			if (this.skipInitializationCheck) return;
+
+			// The constraint and index names embed the table/collection name as
+			// plain identifier fragments, so escape the composed names too.
+			const indexName = escapeSqlIdentifier(`idx_${this.collectionTableName}_name`);
+			const constraintName = escapeSqlIdentifier(`${this.tableName}_collection_id_fkey`);
+
+			const queryString = `
+        CREATE TABLE IF NOT EXISTS ${this.computedCollectionTableName} (
+          uuid uuid NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+          name character varying,
+          cmetadata jsonb
+        );
+
+        CREATE INDEX IF NOT EXISTS ${indexName} ON ${this.computedCollectionTableName}(name);
+
+        ALTER TABLE ${this.computedTableName}
+          ADD COLUMN collection_id uuid;
+
+        ALTER TABLE ${this.computedTableName}
+          ADD CONSTRAINT ${constraintName}
+          FOREIGN KEY (collection_id)
+          REFERENCES ${this.computedCollectionTableName}(uuid)
+          ON DELETE CASCADE;
+      `;
+			await this.pool.query(queryString);
+		} catch (e) {
+			// Mirror the base class: ignore "already exists" races, surface anything else.
+			if (e instanceof Error && e.message.includes('already exists')) {
+				return;
+			}
+			throw e;
+		}
+	}
+
 	static async initialize(
 		embeddings: EmbeddingsInterface,
 		args: PGVectorStoreArgs & { dimensions?: number },
@@ -233,9 +356,12 @@ export class VectorStorePGVector extends createVectorStoreNode<ExtendedPGVectorS
 	loadFields: retrieveFields,
 	retrieveFields,
 	async getVectorStoreClient(context, filter, embeddings, itemIndex) {
-		const tableName = context.getNodeParameter('tableName', itemIndex, '', {
-			extractValue: true,
-		}) as string;
+		validateFilterKeys(context, filter);
+		// An expression-bound Table Name can resolve to an empty value, so fall back to the default.
+		const tableName =
+			(context.getNodeParameter('tableName', itemIndex, '', { extractValue: true }) as string) ||
+			'n8n_vectors';
+		validateTableName(context, tableName, 'table name');
 		const credentials = await context.getCredentials('postgres');
 		const pgConf = await configurePostgres.call(context, credentials as PostgresNodeCredentials);
 		const pool = pgConf.db.$pool as unknown as pg.Pool;
@@ -253,16 +379,21 @@ export class VectorStorePGVector extends createVectorStoreNode<ExtendedPGVectorS
 		) as CollectionOptions;
 
 		if (collectionOptions?.useCollection) {
+			if (collectionOptions.collectionTableName) {
+				validateTableName(context, collectionOptions.collectionTableName, 'collection table name');
+			}
 			config.collectionName = collectionOptions.collectionName;
 			config.collectionTableName = collectionOptions.collectionTableName;
 		}
 
-		config.columns = context.getNodeParameter('options.columnNames.values', 0, {
+		const columns = context.getNodeParameter('options.columnNames.values', 0, {
 			idColumnName: 'id',
 			vectorColumnName: 'embedding',
 			contentColumnName: 'text',
 			metadataColumnName: 'metadata',
 		}) as ColumnOptions;
+		validateColumnNames(context, columns);
+		config.columns = columns;
 
 		config.distanceStrategy = context.getNodeParameter(
 			'options.distanceStrategy',
@@ -276,9 +407,11 @@ export class VectorStorePGVector extends createVectorStoreNode<ExtendedPGVectorS
 	async populateVectorStore(context, embeddings, documents, itemIndex) {
 		// NOTE: if you are to create the HNSW index before use, you need to consider moving the distanceStrategy field to
 		// shared fields, because you need that strategy when creating the index.
-		const tableName = context.getNodeParameter('tableName', itemIndex, '', {
-			extractValue: true,
-		}) as string;
+		// An expression-bound Table Name can resolve to an empty value, so fall back to the default.
+		const tableName =
+			(context.getNodeParameter('tableName', itemIndex, '', { extractValue: true }) as string) ||
+			'n8n_vectors';
+		validateTableName(context, tableName, 'table name');
 		const credentials = await context.getCredentials('postgres');
 		const pgConf = await configurePostgres.call(context, credentials as PostgresNodeCredentials);
 		const pool = pgConf.db.$pool as unknown as pg.Pool;
@@ -295,18 +428,27 @@ export class VectorStorePGVector extends createVectorStoreNode<ExtendedPGVectorS
 		) as CollectionOptions;
 
 		if (collectionOptions?.useCollection) {
+			if (collectionOptions.collectionTableName) {
+				validateTableName(context, collectionOptions.collectionTableName, 'collection table name');
+			}
 			config.collectionName = collectionOptions.collectionName;
 			config.collectionTableName = collectionOptions.collectionTableName;
 		}
 
-		config.columns = context.getNodeParameter('options.columnNames.values', 0, {
+		const columns = context.getNodeParameter('options.columnNames.values', 0, {
 			idColumnName: 'id',
 			vectorColumnName: 'embedding',
 			contentColumnName: 'text',
 			metadataColumnName: 'metadata',
 		}) as ColumnOptions;
+		validateColumnNames(context, columns);
+		config.columns = columns;
 
-		const vectorStore = await PGVectorStore.fromDocuments(documents, embeddings, config);
+		// Use ExtendedPGVectorStore (not PGVectorStore.fromDocuments, whose static
+		// helpers construct a plain PGVectorStore) so the identifier-quoting
+		// overrides apply on the insert path too.
+		const vectorStore = await ExtendedPGVectorStore.initialize(embeddings, config);
+		await vectorStore.addDocuments(documents);
 		vectorStore.client?.release();
 	},
 

--- a/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vector_store/VectorStorePGVector/VectorStorePGVector.node.ts
@@ -229,6 +229,53 @@ function validateColumnNames(
 }
 
 /**
+ * Builds the PGVectorStore config shared by the retrieve and insert paths:
+ * the connection pool plus the validated table/collection names and columns.
+ * Centralising it keeps the identifier policy in one place.
+ */
+async function buildPgVectorStoreConfig(
+	context: IExecuteFunctions | ISupplyDataFunctions,
+	itemIndex: number,
+): Promise<PGVectorStoreArgs> {
+	// An expression-bound Table Name can resolve to an empty value, so fall back to the default.
+	const tableName =
+		(context.getNodeParameter('tableName', itemIndex, '', { extractValue: true }) as string) ||
+		'n8n_vectors';
+	validateTableName(context, tableName, 'table name');
+
+	const credentials = await context.getCredentials('postgres');
+	const pgConf = await configurePostgres.call(context, credentials as PostgresNodeCredentials);
+	const pool = pgConf.db.$pool as unknown as pg.Pool;
+
+	const config: PGVectorStoreArgs = { pool, tableName };
+
+	const collectionOptions = context.getNodeParameter(
+		'options.collection.values',
+		0,
+		{},
+	) as CollectionOptions;
+
+	if (collectionOptions?.useCollection) {
+		if (collectionOptions.collectionTableName) {
+			validateTableName(context, collectionOptions.collectionTableName, 'collection table name');
+		}
+		config.collectionName = collectionOptions.collectionName;
+		config.collectionTableName = collectionOptions.collectionTableName;
+	}
+
+	const columns = context.getNodeParameter('options.columnNames.values', 0, {
+		idColumnName: 'id',
+		vectorColumnName: 'embedding',
+		contentColumnName: 'text',
+		metadataColumnName: 'metadata',
+	}) as ColumnOptions;
+	validateColumnNames(context, columns);
+	config.columns = columns;
+
+	return config;
+}
+
+/**
  * Extended PGVectorStore class to handle custom filtering.
  * This wrapper is necessary because when used as a retriever,
  * similaritySearchVectorWithScore should use this.filter instead of
@@ -350,44 +397,8 @@ export class VectorStorePGVector extends createVectorStoreNode<ExtendedPGVectorS
 	loadFields: retrieveFields,
 	retrieveFields,
 	async getVectorStoreClient(context, filter, embeddings, itemIndex) {
-		// An expression-bound Table Name can resolve to an empty value, so fall back to the default.
-		const tableName =
-			(context.getNodeParameter('tableName', itemIndex, '', { extractValue: true }) as string) ||
-			'n8n_vectors';
-		validateTableName(context, tableName, 'table name');
-		const credentials = await context.getCredentials('postgres');
-		const pgConf = await configurePostgres.call(context, credentials as PostgresNodeCredentials);
-		const pool = pgConf.db.$pool as unknown as pg.Pool;
-
-		const config: PGVectorStoreArgs = {
-			pool,
-			tableName,
-			filter,
-		};
-
-		const collectionOptions = context.getNodeParameter(
-			'options.collection.values',
-			0,
-			{},
-		) as CollectionOptions;
-
-		if (collectionOptions?.useCollection) {
-			if (collectionOptions.collectionTableName) {
-				validateTableName(context, collectionOptions.collectionTableName, 'collection table name');
-			}
-			config.collectionName = collectionOptions.collectionName;
-			config.collectionTableName = collectionOptions.collectionTableName;
-		}
-
-		const columns = context.getNodeParameter('options.columnNames.values', 0, {
-			idColumnName: 'id',
-			vectorColumnName: 'embedding',
-			contentColumnName: 'text',
-			metadataColumnName: 'metadata',
-		}) as ColumnOptions;
-		validateColumnNames(context, columns);
-		config.columns = columns;
-
+		const config = await buildPgVectorStoreConfig(context, itemIndex);
+		config.filter = filter;
 		config.distanceStrategy = context.getNodeParameter(
 			'options.distanceStrategy',
 			0,
@@ -403,42 +414,7 @@ export class VectorStorePGVector extends createVectorStoreNode<ExtendedPGVectorS
 	async populateVectorStore(context, embeddings, documents, itemIndex) {
 		// NOTE: if you are to create the HNSW index before use, you need to consider moving the distanceStrategy field to
 		// shared fields, because you need that strategy when creating the index.
-		// An expression-bound Table Name can resolve to an empty value, so fall back to the default.
-		const tableName =
-			(context.getNodeParameter('tableName', itemIndex, '', { extractValue: true }) as string) ||
-			'n8n_vectors';
-		validateTableName(context, tableName, 'table name');
-		const credentials = await context.getCredentials('postgres');
-		const pgConf = await configurePostgres.call(context, credentials as PostgresNodeCredentials);
-		const pool = pgConf.db.$pool as unknown as pg.Pool;
-
-		const config: PGVectorStoreArgs = {
-			pool,
-			tableName,
-		};
-
-		const collectionOptions = context.getNodeParameter(
-			'options.collection.values',
-			0,
-			{},
-		) as CollectionOptions;
-
-		if (collectionOptions?.useCollection) {
-			if (collectionOptions.collectionTableName) {
-				validateTableName(context, collectionOptions.collectionTableName, 'collection table name');
-			}
-			config.collectionName = collectionOptions.collectionName;
-			config.collectionTableName = collectionOptions.collectionTableName;
-		}
-
-		const columns = context.getNodeParameter('options.columnNames.values', 0, {
-			idColumnName: 'id',
-			vectorColumnName: 'embedding',
-			contentColumnName: 'text',
-			metadataColumnName: 'metadata',
-		}) as ColumnOptions;
-		validateColumnNames(context, columns);
-		config.columns = columns;
+		const config = await buildPgVectorStoreConfig(context, itemIndex);
 
 		// Use ExtendedPGVectorStore (not PGVectorStore.fromDocuments, whose static
 		// helpers construct a plain PGVectorStore) so the identifier-quoting
@@ -447,8 +423,11 @@ export class VectorStorePGVector extends createVectorStoreNode<ExtendedPGVectorS
 			...config,
 			n8nNode: context.getNode(),
 		});
-		await vectorStore.addDocuments(documents);
-		vectorStore.client?.release();
+		try {
+			await vectorStore.addDocuments(documents);
+		} finally {
+			vectorStore.client?.release();
+		}
 	},
 
 	releaseVectorStoreClient(vectorStore) {

--- a/packages/@n8n/nodes-langchain/utils/sqlIdentifier.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/sqlIdentifier.test.ts
@@ -1,0 +1,80 @@
+import {
+	escapeQualifiedSqlIdentifier,
+	escapeSqlIdentifier,
+	isSafeQualifiedSqlIdentifier,
+	isSafeSqlIdentifier,
+} from './sqlIdentifier';
+
+describe('sqlIdentifier', () => {
+	describe('escapeSqlIdentifier', () => {
+		it('wraps a plain identifier in double quotes', () => {
+			expect(escapeSqlIdentifier('n8n_vectors')).toBe('"n8n_vectors"');
+		});
+
+		it('doubles embedded double quotes', () => {
+			expect(escapeSqlIdentifier('a"b')).toBe('"a""b"');
+		});
+
+		it('contains a statement-breaking value within a single quoted token', () => {
+			const result = escapeSqlIdentifier('foo; DROP TABLE victim; --');
+
+			expect(result).toBe('"foo; DROP TABLE victim; --"');
+			expect(result.startsWith('"')).toBe(true);
+			expect(result.endsWith('"')).toBe(true);
+			// No unescaped quote remains inside, so the value cannot terminate the identifier early.
+			expect(result.slice(1, -1)).not.toContain('"');
+		});
+	});
+
+	describe('escapeQualifiedSqlIdentifier', () => {
+		it('quotes a single identifier', () => {
+			expect(escapeQualifiedSqlIdentifier('n8n_chat_histories')).toBe('"n8n_chat_histories"');
+		});
+
+		it('quotes each part of a schema-qualified identifier', () => {
+			expect(escapeQualifiedSqlIdentifier('my_schema.my_table')).toBe('"my_schema"."my_table"');
+		});
+
+		it('quotes each segment of a value that contains a dot', () => {
+			expect(escapeQualifiedSqlIdentifier('foo"; DROP TABLE victim; --.bar')).toBe(
+				'"foo""; DROP TABLE victim; --"."bar"',
+			);
+		});
+	});
+
+	describe('isSafeSqlIdentifier', () => {
+		it.each(['n8n_vectors', '_private', 'a1', 'Column$1', 'embedding'])('accepts %s', (value) => {
+			expect(isSafeSqlIdentifier(value)).toBe(true);
+		});
+
+		it.each(['a-b', 'a b', '1abc', 'a"b', 'a;b', "a'b", 'a.b', ''])('rejects %s', (value) => {
+			expect(isSafeSqlIdentifier(value)).toBe(false);
+		});
+	});
+
+	describe('isSafeQualifiedSqlIdentifier', () => {
+		it.each(['n8n_vectors', 'my_schema.my_table', 'public.n8n_chat_histories'])(
+			'accepts %s',
+			(value) => {
+				expect(isSafeQualifiedSqlIdentifier(value)).toBe(true);
+			},
+		);
+
+		it.each([
+			'foo(id SERIAL PRIMARY KEY); DROP TABLE victim; --',
+			'x"; DROP TABLE victim; --',
+			'a.',
+			'.a',
+			'a..b',
+			'',
+		])('rejects %s', (value) => {
+			expect(isSafeQualifiedSqlIdentifier(value)).toBe(false);
+		});
+
+		it('rejects non-string values without throwing', () => {
+			expect(isSafeQualifiedSqlIdentifier(undefined)).toBe(false);
+			expect(isSafeQualifiedSqlIdentifier(null)).toBe(false);
+			expect(isSafeQualifiedSqlIdentifier(123)).toBe(false);
+		});
+	});
+});

--- a/packages/@n8n/nodes-langchain/utils/sqlIdentifier.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/sqlIdentifier.test.ts
@@ -72,6 +72,7 @@ describe('sqlIdentifier', () => {
 			'a.',
 			'.a',
 			'a..b',
+			'a.b.c',
 			'',
 		])('rejects %s', (value) => {
 			expect(isSafeQualifiedSqlIdentifier(value)).toBe(false);

--- a/packages/@n8n/nodes-langchain/utils/sqlIdentifier.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/sqlIdentifier.test.ts
@@ -1,6 +1,7 @@
 import {
 	escapeQualifiedSqlIdentifier,
 	escapeSqlIdentifier,
+	findUnsafeMetadataFilterKey,
 	isSafeQualifiedSqlIdentifier,
 	isSafeSqlIdentifier,
 } from './sqlIdentifier';
@@ -35,9 +36,14 @@ describe('sqlIdentifier', () => {
 			expect(escapeQualifiedSqlIdentifier('my_schema.my_table')).toBe('"my_schema"."my_table"');
 		});
 
+		it('folds mixed-case parts to lower case before quoting', () => {
+			expect(escapeQualifiedSqlIdentifier('MyTable')).toBe('"mytable"');
+			expect(escapeQualifiedSqlIdentifier('MySchema.MyTable')).toBe('"myschema"."mytable"');
+		});
+
 		it('quotes each segment of a value that contains a dot', () => {
 			expect(escapeQualifiedSqlIdentifier('foo"; DROP TABLE victim; --.bar')).toBe(
-				'"foo""; DROP TABLE victim; --"."bar"',
+				'"foo""; drop table victim; --"."bar"',
 			);
 		});
 	});
@@ -75,6 +81,19 @@ describe('sqlIdentifier', () => {
 			expect(isSafeQualifiedSqlIdentifier(undefined)).toBe(false);
 			expect(isSafeQualifiedSqlIdentifier(null)).toBe(false);
 			expect(isSafeQualifiedSqlIdentifier(123)).toBe(false);
+		});
+	});
+
+	describe('findUnsafeMetadataFilterKey', () => {
+		it('returns undefined for safe keys (including spaces and dashes)', () => {
+			expect(findUnsafeMetadataFilterKey(undefined)).toBeUndefined();
+			expect(findUnsafeMetadataFilterKey({})).toBeUndefined();
+			expect(findUnsafeMetadataFilterKey({ source: 'docs', 'my key-1': 'x' })).toBeUndefined();
+		});
+
+		it('returns the offending key when it contains a quote or backslash', () => {
+			expect(findUnsafeMetadataFilterKey({ "x'); DROP": '1' })).toBe("x'); DROP");
+			expect(findUnsafeMetadataFilterKey({ ok: '1', 'a\\b': '2' })).toBe('a\\b');
 		});
 	});
 });

--- a/packages/@n8n/nodes-langchain/utils/sqlIdentifier.ts
+++ b/packages/@n8n/nodes-langchain/utils/sqlIdentifier.ts
@@ -1,0 +1,42 @@
+import pg from 'pg';
+
+/**
+ * Matches a plain, unquoted SQL identifier: a leading letter or underscore
+ * followed by letters, digits, underscores or dollar signs. Values that match
+ * this pattern are safe to interpolate into SQL both quoted and unquoted.
+ */
+const SAFE_SQL_IDENTIFIER = /^[A-Za-z_][A-Za-z0-9_$]*$/;
+
+/**
+ * Quotes a single SQL identifier so it can be safely interpolated into a
+ * statement. Wraps the value in double quotes and doubles any embedded quotes.
+ */
+export function escapeSqlIdentifier(name: string): string {
+	return pg.escapeIdentifier(name);
+}
+
+/**
+ * Quotes a possibly schema-qualified identifier (`schema.table`) by escaping
+ * each dot-separated part independently. This preserves schema qualification
+ * while ensuring every segment is safely quoted.
+ */
+export function escapeQualifiedSqlIdentifier(name: string): string {
+	return name.split('.').map(escapeSqlIdentifier).join('.');
+}
+
+/**
+ * Returns true when the value is a plain SQL identifier that requires no
+ * quoting and is safe to interpolate verbatim.
+ */
+export function isSafeSqlIdentifier(name: string): boolean {
+	return SAFE_SQL_IDENTIFIER.test(name);
+}
+
+/**
+ * Returns true when the value is a plain identifier or a schema-qualified
+ * identifier (`schema.table`) where every dot-separated part is itself a plain
+ * identifier. Non-string, empty values and empty segments are rejected.
+ */
+export function isSafeQualifiedSqlIdentifier(name: unknown): boolean {
+	return typeof name === 'string' && name.split('.').every(isSafeSqlIdentifier);
+}

--- a/packages/@n8n/nodes-langchain/utils/sqlIdentifier.ts
+++ b/packages/@n8n/nodes-langchain/utils/sqlIdentifier.ts
@@ -41,12 +41,16 @@ export function isSafeSqlIdentifier(name: string): boolean {
 }
 
 /**
- * Returns true when the value is a plain identifier or a schema-qualified
- * identifier (`schema.table`) where every dot-separated part is itself a plain
- * identifier. Non-string, empty values and empty segments are rejected.
+ * Returns true when the value is either a plain identifier (`name`) or a
+ * schema-qualified one (`schema.name`) — at most two dot-separated parts, each a
+ * plain identifier. Non-strings, empty values, empty segments and anything with
+ * more than two parts (e.g. `a.b.c`) are rejected, matching the documented
+ * "plain name or optional schema. prefix" contract.
  */
 export function isSafeQualifiedSqlIdentifier(name: unknown): boolean {
-	return typeof name === 'string' && name.split('.').every(isSafeSqlIdentifier);
+	if (typeof name !== 'string') return false;
+	const parts = name.split('.');
+	return parts.length <= 2 && parts.every(isSafeSqlIdentifier);
 }
 
 /**

--- a/packages/@n8n/nodes-langchain/utils/sqlIdentifier.ts
+++ b/packages/@n8n/nodes-langchain/utils/sqlIdentifier.ts
@@ -19,9 +19,17 @@ export function escapeSqlIdentifier(name: string): string {
  * Quotes a possibly schema-qualified identifier (`schema.table`) by escaping
  * each dot-separated part independently. This preserves schema qualification
  * while ensuring every segment is safely quoted.
+ *
+ * Each part is lower-cased first to mirror PostgreSQL's folding of unquoted
+ * identifiers: these names were historically interpolated unquoted, so an
+ * existing mixed-case config like `MyTable` keeps resolving to `mytable`
+ * rather than a new, case-sensitive `"MyTable"`.
  */
 export function escapeQualifiedSqlIdentifier(name: string): string {
-	return name.split('.').map(escapeSqlIdentifier).join('.');
+	return name
+		.split('.')
+		.map((part) => escapeSqlIdentifier(part.toLowerCase()))
+		.join('.');
 }
 
 /**
@@ -39,4 +47,16 @@ export function isSafeSqlIdentifier(name: string): boolean {
  */
 export function isSafeQualifiedSqlIdentifier(name: unknown): boolean {
 	return typeof name === 'string' && name.split('.').every(isSafeSqlIdentifier);
+}
+
+/**
+ * Returns the first metadata-filter key that could break out of the
+ * single-quoted SQL literal the store interpolates it into, or undefined when
+ * every key is safe.
+ */
+export function findUnsafeMetadataFilterKey(
+	filter: Record<string, unknown> | undefined,
+): string | undefined {
+	if (!filter) return undefined;
+	return Object.keys(filter).find((key) => key.includes("'") || key.includes('\\'));
 }


### PR DESCRIPTION
## Summary

`Postgres Chat Memory` and `Postgres PGVector Store` (and the internal ChatHub PGVector store) passed user-configured table, collection, and column names through to the SQL built by the underlying `@langchain/community` Postgres stores unchanged. This change hardens that handling:

- **Validate** — table/collection names, column names, and metadata-filter keys are checked against a strict identifier pattern and rejected with a clear node error when they aren't plain, optionally `schema.`-qualified identifiers.
- **Escape** — identifiers are quoted via `pg.escapeIdentifier` before interpolation, including the constraint/index names the library composes from the table name. The PGVector insert path is routed through the extended store so the quoting applies there too (the library's static `fromDocuments` would otherwise bypass it).
- Empty or expression-unset names fall back to the node defaults (`n8n_chat_histories`, `n8n_vectors`) instead of erroring.

Added unit tests for the identifier helper, the extended PGVector store (including collection-table setup), and the memory node.

### Notes
- A valid identifier that names an existing table is still accepted by design (a configurable table name) — it can only reference a table, never run additional statements.
- Non-ASCII identifiers are rejected by the strict pattern; the escape layer would keep them safe, so this is the one knob to widen if internationalised table names are needed.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2527

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
