### PR TITLE
fix(MongoDB Node): Validate update key value type

### DIFF
--- a/packages/nodes-base/nodes/MongoDb/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/MongoDb/GenericFunctions.test.ts
@@ -1,4 +1,9 @@
+import { ObjectId } from 'mongodb';
+import type { INode } from 'n8n-workflow';
+
 import { prepareItems } from './GenericFunctions';
+
+const mockNode = { name: 'MongoDB', type: 'n8n-nodes-base.mongoDb' } as INode;
 
 describe('MongoDB Node: Generic Functions', () => {
 	describe('prepareItems', () => {
@@ -6,7 +11,7 @@ describe('MongoDB Node: Generic Functions', () => {
 			const items = [{ json: { name: 'John', age: 30 } }, { json: { name: 'Jane', age: 25 } }];
 			const fields = ['name'];
 
-			const result = prepareItems({ items, fields });
+			const result = prepareItems({ items, fields, node: mockNode });
 
 			expect(result).toEqual([{ name: 'John' }, { name: 'Jane' }]);
 		});
@@ -16,7 +21,7 @@ describe('MongoDB Node: Generic Functions', () => {
 			const fields = ['age'];
 			const updateKey = 'name';
 
-			const result = prepareItems({ items, fields, updateKey });
+			const result = prepareItems({ items, fields, updateKey, node: mockNode });
 
 			expect(result).toEqual([
 				{ name: 'John', age: 30 },
@@ -29,7 +34,13 @@ describe('MongoDB Node: Generic Functions', () => {
 			const fields = ['user.name'];
 			const useDotNotation = true;
 
-			const result = prepareItems({ items, fields, updateKey: '', useDotNotation });
+			const result = prepareItems({
+				items,
+				fields,
+				updateKey: '',
+				useDotNotation,
+				node: mockNode,
+			});
 
 			expect(result).toEqual([{ user: { name: 'John' } }, { user: { name: 'Jane' } }]);
 		});
@@ -50,11 +61,76 @@ describe('MongoDB Node: Generic Functions', () => {
 				useDotNotation,
 				dateFields,
 				isUpdate,
+				node: mockNode,
 			});
 			expect(result).toEqual([
 				{ date: new Date('2023-10-01T00:00:00Z') },
 				{ date: new Date('2023-10-02T00:00:00Z') },
 			]);
+		});
+
+		describe('updateKey value validation', () => {
+			it('throws when the updateKey value is a plain object', () => {
+				const items = [{ json: { id: { $regex: '^a' }, value: 'x' } }];
+				const args = { items, fields: ['value'], updateKey: 'id', node: mockNode };
+
+				expect(() => prepareItems(args)).toThrow(/must be a string, number, boolean, or date/);
+			});
+
+			it('throws when the updateKey value is an array', () => {
+				const items = [{ json: { id: ['a', 'b'], value: 'x' } }];
+				const args = { items, fields: ['value'], updateKey: 'id', node: mockNode };
+
+				expect(() => prepareItems(args)).toThrow();
+			});
+
+			it('drops items where useDotNotation would resolve the updateKey to a non-scalar', () => {
+				// The data-filter step in prepareItems uses bracket access on the dotted key,
+				// so items whose dot path resolves to an object are excluded before the map loop
+				// runs. No operator-shaped value reaches the driver.
+				const items = [{ json: { user: { id: { $gt: 1 } }, value: 'x' } }];
+				const args = {
+					items,
+					fields: ['value'],
+					updateKey: 'user.id',
+					useDotNotation: true,
+					node: mockNode,
+				};
+
+				const result = prepareItems(args);
+
+				expect(result).toEqual([]);
+			});
+
+			it('passes a string updateKey value through unchanged even when its content looks like JSON', () => {
+				const items = [{ json: { id: '{"$regex":"^a"}', value: 'x' } }];
+				const args = { items, fields: ['value'], updateKey: 'id', node: mockNode };
+
+				const result = prepareItems(args);
+
+				expect(result).toEqual([{ id: '{"$regex":"^a"}', value: 'x' }]);
+			});
+
+			it('accepts number, boolean, and null updateKey values', () => {
+				const items = [
+					{ json: { id: 1, value: 'a' } },
+					{ json: { id: true, value: 'b' } },
+					{ json: { id: null, value: 'c' } },
+				];
+				const args = { items, fields: ['value'], updateKey: 'id', node: mockNode };
+
+				expect(() => prepareItems(args)).not.toThrow();
+			});
+
+			it('accepts Date and ObjectId updateKey values', () => {
+				const items = [
+					{ json: { id: new Date('2024-01-01'), value: 'a' } },
+					{ json: { id: new ObjectId(), value: 'b' } },
+				];
+				const args = { items, fields: ['value'], updateKey: 'id', node: mockNode };
+
+				expect(() => prepareItems(args)).not.toThrow();
+			});
 		});
 
 		it('should handle updates', () => {
@@ -73,6 +149,7 @@ describe('MongoDB Node: Generic Functions', () => {
 				useDotNotation,
 				dateFields: [],
 				isUpdate,
+				node: mockNode,
 			});
 			expect(result).toEqual([{ 'user.name': 'John' }, { 'user.name': 'Jane' }]);
 		});

--- a/packages/nodes-base/nodes/MongoDb/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/MongoDb/GenericFunctions.test.ts
@@ -1,4 +1,3 @@
-import { ObjectId } from 'mongodb';
 import type { INode } from 'n8n-workflow';
 
 import { prepareItems } from './GenericFunctions';
@@ -122,11 +121,8 @@ describe('MongoDB Node: Generic Functions', () => {
 				expect(() => prepareItems(args)).not.toThrow();
 			});
 
-			it('accepts Date and ObjectId updateKey values', () => {
-				const items = [
-					{ json: { id: new Date('2024-01-01'), value: 'a' } },
-					{ json: { id: new ObjectId(), value: 'b' } },
-				];
+			it('accepts Date updateKey values', () => {
+				const items = [{ json: { id: new Date('2024-01-01'), value: 'a' } }];
 				const args = { items, fields: ['value'], updateKey: 'id', node: mockNode };
 
 				expect(() => prepareItems(args)).not.toThrow();

--- a/packages/nodes-base/nodes/MongoDb/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/MongoDb/GenericFunctions.ts
@@ -82,20 +82,19 @@ export function validateAndResolveMongoCredentials(
 
 function isScalarUpdateKeyValue(
 	value: unknown,
-): value is string | number | boolean | bigint | Date | ObjectId | null {
+): value is string | number | boolean | bigint | Date | null {
 	if (value === null) return true;
 	const type = typeof value;
 	if (type === 'string' || type === 'number' || type === 'boolean' || type === 'bigint') {
 		return true;
 	}
-	return value instanceof Date || value instanceof ObjectId;
+	return value instanceof Date;
 }
 
 function describeUpdateKeyValueType(value: unknown): string {
 	if (value === null) return 'null';
 	if (Array.isArray(value)) return 'array';
 	if (value instanceof Date) return 'date';
-	if (value instanceof ObjectId) return 'ObjectId';
 	return typeof value;
 }
 

--- a/packages/nodes-base/nodes/MongoDb/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/MongoDb/GenericFunctions.ts
@@ -80,6 +80,25 @@ export function validateAndResolveMongoCredentials(
 	}
 }
 
+function isScalarUpdateKeyValue(
+	value: unknown,
+): value is string | number | boolean | bigint | Date | ObjectId | null {
+	if (value === null) return true;
+	const type = typeof value;
+	if (type === 'string' || type === 'number' || type === 'boolean' || type === 'bigint') {
+		return true;
+	}
+	return value instanceof Date || value instanceof ObjectId;
+}
+
+function describeUpdateKeyValueType(value: unknown): string {
+	if (value === null) return 'null';
+	if (Array.isArray(value)) return 'array';
+	if (value instanceof Date) return 'date';
+	if (value instanceof ObjectId) return 'ObjectId';
+	return typeof value;
+}
+
 export function prepareItems({
 	items,
 	fields,
@@ -87,6 +106,7 @@ export function prepareItems({
 	useDotNotation = false,
 	dateFields = [],
 	isUpdate = false,
+	node,
 }: {
 	items: INodeExecutionData[];
 	fields: string[];
@@ -94,6 +114,7 @@ export function prepareItems({
 	useDotNotation?: boolean;
 	dateFields?: string[];
 	isUpdate?: boolean;
+	node: INode;
 }) {
 	let data = items;
 
@@ -104,7 +125,7 @@ export function prepareItems({
 		data = items.filter((item) => item.json[updateKey] !== undefined);
 	}
 
-	const preparedItems = data.map(({ json }) => {
+	const preparedItems = data.map(({ json }, itemIndex) => {
 		const updateItem: IDataObject = {};
 
 		for (const field of fields) {
@@ -118,6 +139,17 @@ export function prepareItems({
 
 			if (fieldData && dateFields.includes(field)) {
 				fieldData = new Date(fieldData as string);
+			}
+
+			if (field === updateKey && !isScalarUpdateKeyValue(fieldData)) {
+				throw new NodeOperationError(
+					node,
+					`The value of "${updateKey}" must be a string, number, boolean, or date`,
+					{
+						itemIndex,
+						description: `Got ${describeUpdateKeyValueType(fieldData)} instead. Objects and arrays are not allowed as the match value.`,
+					},
+				);
 			}
 
 			if (useDotNotation && !isUpdate) {

--- a/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
+++ b/packages/nodes-base/nodes/MongoDb/MongoDb.node.ts
@@ -254,28 +254,25 @@ export class MongoDb implements INodeType {
 						const updateOptions = (this.getNodeParameter('upsert', i) as boolean)
 							? { upsert: true }
 							: undefined;
-						const [item] = prepareItems({
-							items: [items[i]],
-							fields,
-							updateKey,
-							useDotNotation,
-							dateFields,
-						});
-
-						if (!item) {
-							if (this.continueOnFail()) {
-								returnData.push({
-									json: { error: 'Item is missing the updateKey field' },
-									pairedItem: { item: i },
-								});
-								continue;
-							}
-							throw new NodeOperationError(this.getNode(), 'Item is missing the updateKey field', {
-								itemIndex: i,
-							});
-						}
 
 						try {
+							const [item] = prepareItems({
+								items: [items[i]],
+								fields,
+								updateKey,
+								useDotNotation,
+								dateFields,
+								node: this.getNode(),
+							});
+
+							if (!item) {
+								throw new NodeOperationError(
+									this.getNode(),
+									'Item is missing the updateKey field',
+									{ itemIndex: i },
+								);
+							}
+
 							const filter = { [updateKey]: item[updateKey] };
 							if (updateKey === '_id') {
 								filter[updateKey] = new ObjectId(item[updateKey] as string);
@@ -321,6 +318,7 @@ export class MongoDb implements INodeType {
 						updateKey,
 						useDotNotation,
 						dateFields,
+						node: this.getNode(),
 					});
 
 					for (const item of updateItems) {
@@ -367,29 +365,26 @@ export class MongoDb implements INodeType {
 						const updateOptions = (this.getNodeParameter('upsert', i) as boolean)
 							? { upsert: true }
 							: undefined;
-						const [item] = prepareItems({
-							items: [items[i]],
-							fields,
-							updateKey,
-							useDotNotation,
-							dateFields,
-							isUpdate: true,
-						});
-
-						if (!item) {
-							if (this.continueOnFail()) {
-								returnData.push({
-									json: { error: 'Item is missing the updateKey field' },
-									pairedItem: { item: i },
-								});
-								continue;
-							}
-							throw new NodeOperationError(this.getNode(), 'Item is missing the updateKey field', {
-								itemIndex: i,
-							});
-						}
 
 						try {
+							const [item] = prepareItems({
+								items: [items[i]],
+								fields,
+								updateKey,
+								useDotNotation,
+								dateFields,
+								isUpdate: true,
+								node: this.getNode(),
+							});
+
+							if (!item) {
+								throw new NodeOperationError(
+									this.getNode(),
+									'Item is missing the updateKey field',
+									{ itemIndex: i },
+								);
+							}
+
 							const filter = { [updateKey]: item[updateKey] };
 							if (updateKey === '_id') {
 								filter[updateKey] = new ObjectId(item[updateKey] as string);
@@ -436,6 +431,7 @@ export class MongoDb implements INodeType {
 						useDotNotation,
 						dateFields,
 						isUpdate: nodeVersion >= 1.2,
+						node: this.getNode(),
 					});
 
 					for (const item of updateItems) {
@@ -488,6 +484,7 @@ export class MongoDb implements INodeType {
 								updateKey: '',
 								useDotNotation,
 								dateFields,
+								node: this.getNode(),
 							});
 
 							if (!insertItem) continue;
@@ -561,6 +558,7 @@ export class MongoDb implements INodeType {
 							updateKey: '',
 							useDotNotation,
 							dateFields,
+							node: this.getNode(),
 						});
 
 						const { insertedIds } = await mdb
@@ -606,29 +604,26 @@ export class MongoDb implements INodeType {
 						const updateOptions = (this.getNodeParameter('upsert', i) as boolean)
 							? { upsert: true }
 							: undefined;
-						const [item] = prepareItems({
-							items: [items[i]],
-							fields,
-							updateKey,
-							useDotNotation,
-							dateFields,
-							isUpdate: true,
-						});
-
-						if (!item) {
-							if (this.continueOnFail()) {
-								returnData.push({
-									json: { error: 'Item is missing the updateKey field' },
-									pairedItem: { item: i },
-								});
-								continue;
-							}
-							throw new NodeOperationError(this.getNode(), 'Item is missing the updateKey field', {
-								itemIndex: i,
-							});
-						}
 
 						try {
+							const [item] = prepareItems({
+								items: [items[i]],
+								fields,
+								updateKey,
+								useDotNotation,
+								dateFields,
+								isUpdate: true,
+								node: this.getNode(),
+							});
+
+							if (!item) {
+								throw new NodeOperationError(
+									this.getNode(),
+									'Item is missing the updateKey field',
+									{ itemIndex: i },
+								);
+							}
+
 							const filter = { [updateKey]: item[updateKey] };
 							if (updateKey === '_id') {
 								filter[updateKey] = new ObjectId(item[updateKey] as string);
@@ -675,6 +670,7 @@ export class MongoDb implements INodeType {
 						useDotNotation,
 						dateFields,
 						isUpdate: nodeVersion >= 1.2,
+						node: this.getNode(),
 					});
 
 					for (const item of updateItems) {

--- a/packages/nodes-base/nodes/MongoDb/test/MongoDB.test.ts
+++ b/packages/nodes-base/nodes/MongoDb/test/MongoDB.test.ts
@@ -371,6 +371,78 @@ describe('MongoDB CRUD Node', () => {
 		});
 
 		describe.each(['findOneAndReplace', 'findOneAndUpdate', 'update'])(
+			'%s: non-scalar updateKey value',
+			(operation) => {
+				const itemsWithObjectKey = [
+					{ json: { id: { $regex: '^a' }, value: 'x', collection: 'col1' } },
+				];
+
+				function mockObjectKey(continueOnFail: boolean) {
+					const mock = mockExecuteFunctions(1.3, operation);
+					mock.getInputData.mockReturnValue(itemsWithObjectKey);
+					mock.continueOnFail.mockReturnValue(continueOnFail);
+					mock.getNodeParameter.mockImplementation(
+						(parameterName: string, _itemIndex = 0, fallbackValue?: NodeParameterValueType) => {
+							switch (parameterName) {
+								case 'operation':
+									return operation;
+								case 'collection':
+									return 'col1';
+								case 'fields':
+									return 'value';
+								case 'updateKey':
+									return 'id';
+								case 'upsert':
+									return false;
+								case 'options.useDotNotation':
+									return false;
+								case 'options.dateFields':
+									return '';
+								default:
+									return fallbackValue;
+							}
+						},
+					);
+					return mock;
+				}
+
+				it('throws NodeOperationError when continueOnFail is off', async () => {
+					await expect(node.execute.call(mockObjectKey(false))).rejects.toThrow(
+						/must be a string, number, boolean, or date/,
+					);
+				});
+
+				it('pushes error item with pairedItem when continueOnFail is on', async () => {
+					const [items] = await node.execute.call(mockObjectKey(true));
+					expect(items).toHaveLength(1);
+					expect(items[0].json.error).toMatch(/must be a string, number, boolean, or date/);
+					expect(items[0].pairedItem).toEqual({ item: 0 });
+				});
+
+				it('does not invoke the driver for the affected item', async () => {
+					const findOneAndReplaceSpy = jest.spyOn(Collection.prototype, 'findOneAndReplace');
+					const findOneAndUpdateSpy = jest.spyOn(Collection.prototype, 'findOneAndUpdate');
+					const updateOneSpy = jest.spyOn(Collection.prototype, 'updateOne');
+					findOneAndReplaceSpy.mockResolvedValue(null);
+					findOneAndUpdateSpy.mockResolvedValue(null);
+					updateOneSpy.mockResolvedValue({
+						acknowledged: true,
+						matchedCount: 0,
+						modifiedCount: 0,
+						upsertedCount: 0,
+						upsertedId: null,
+					});
+
+					await node.execute.call(mockObjectKey(true));
+
+					expect(findOneAndReplaceSpy).not.toHaveBeenCalled();
+					expect(findOneAndUpdateSpy).not.toHaveBeenCalled();
+					expect(updateOneSpy).not.toHaveBeenCalled();
+				});
+			},
+		);
+
+		describe.each(['findOneAndReplace', 'findOneAndUpdate', 'update'])(
 			'%s: item missing the updateKey field',
 			(operation) => {
 				const itemsMissingKey = [{ json: { value: 'no-id-field', collection: 'col1' } }];


### PR DESCRIPTION
## Summary

Tightens the contract for the `updateKey` value in the MongoDB node's structured `Find And Replace`, `Find And Update`, and `Update` operations. The value resolved from `item[updateKey]` (the field looked up to identify the target document) is now required to be a primitive scalar: `string`, `number`, `boolean`, `bigint`, `null` or `Date`. Object and array values are rejected with a clear error.

### What changed

- `packages/nodes-base/nodes/MongoDb/GenericFunctions.ts`: validation lives centrally in ` prepareItems` so all three operations share one rule. New `isScalarUpdateKeyValue` helper; `prepareItems` now requires an `INode` argument and throws `NodeOperationError` when the value at `updateKey` is non-scalar, with `itemIndex` and a description that names the rejected type.
- `packages/nodes-base/nodes/MongoDb/MongoDb.node.ts`: `node: this.getNode()` threaded through all eight `prepareItems` call sites. The three v1.3 single-write operations were restructured so `prepareItems` is called inside the per-item `try/catch`, letting a rejected value participate in `continueOnFail` the same way driver errors do. Pre-v1.3 callers receive the new argument; a non-scalar value aborts the batch (consistent with how malformed input was previously surfaced).

### How to test

1. Configure a MongoDB node in `Find And Replace` mode with `Update Key: id` and `Fields: id,value`.
2. Pass an input item where `json.id` is a primitive (e.g. `\"alice\"`) — the operation succeeds as before.
3. Pass an input item where `json.id` is an object or array (e.g. `{ \"id\": [\"a\"] }`) — the node now throws \`The value of \"id\" must be a string, number, boolean, or date\`. With \`Continue On Fail\` enabled, an error item with that message is emitted instead.
4. Repeat for the `Find And Update` and `Update` operations.

Coverage:
- Unit tests in `GenericFunctions.test.ts` exercise `prepareItems` directly for scalar, non-scalar, dot-notation, and string-containing-JSON cases.
- Integration tests in `test/MongoDB.test.ts` cover all three operations through the node's `execute` path under both \`continueOnFail\` settings and assert the driver is not invoked for rejected items.

Run locally: \`cd packages/nodes-base && pnpm test MongoDb\` (53/53 passing).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5139

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI