### PR TITLE
fix: Only allow specified AWS regions

### DIFF
--- a/packages/nodes-base/credentials/common/aws/utils.test.ts
+++ b/packages/nodes-base/credentials/common/aws/utils.test.ts
@@ -1,5 +1,5 @@
 import { ApplicationError } from 'n8n-workflow';
-import type { AwsAssumeRoleCredentialsType, AWSRegion } from './types';
+import type { AwsAssumeRoleCredentialsType, AwsIamCredentialsType, AWSRegion } from './types';
 
 global.fetch = jest.fn();
 
@@ -13,7 +13,7 @@ jest.mock('xml2js', () => ({
 
 import { sign } from 'aws4';
 import { parseString } from 'xml2js';
-import { assumeRole } from './utils';
+import { assertSupportedAwsRegion, assumeRole, awsGetSignInOptionsAndUpdateRequest } from './utils';
 import * as systemCredentialsUtils from './system-credentials-utils';
 
 describe('assumeRole', () => {
@@ -749,4 +749,144 @@ describe('assumeRole', () => {
 			});
 		});
 	});
+});
+
+describe('assertSupportedAwsRegion', () => {
+	it.each([
+		['us-east-1'],
+		['eu-west-1'],
+		['ap-southeast-2'],
+		['cn-north-1'],
+		['us-gov-west-1'],
+		['eu-central-2'],
+	])('accepts the supported region %s', (region) => {
+		expect(() => assertSupportedAwsRegion(region)).not.toThrow();
+	});
+
+	it.each([
+		[''],
+		['us-east'],
+		['us-fake-1'],
+		['US-EAST-1'],
+		[' us-east-1'],
+		['us-east-1 '],
+		['us-east-1/foo'],
+		['us-east-1?x=1'],
+		['us-east-1#frag'],
+		['us-east-1:8080'],
+		['@example.com#'],
+		['@example.com'],
+		['example.com'],
+		['169.254.169.254'],
+		['localhost'],
+	])('rejects unsupported region value %s', (region) => {
+		expect(() => assertSupportedAwsRegion(region)).toThrow(ApplicationError);
+		expect(() => assertSupportedAwsRegion(region)).toThrow('Unsupported AWS region');
+	});
+
+	it.each([[undefined], [null], [0], [true], [{}], [['us-east-1']]])(
+		'rejects non-string region value %s',
+		(region) => {
+			expect(() => assertSupportedAwsRegion(region)).toThrow(ApplicationError);
+		},
+	);
+});
+
+describe('awsGetSignInOptionsAndUpdateRequest', () => {
+	const baseCredentials: AwsIamCredentialsType = {
+		region: 'us-east-1',
+		customEndpoints: false,
+		accessKeyId: 'AKIA-test',
+		secretAccessKey: 'secret-test',
+		temporaryCredentials: false,
+	};
+
+	it('builds an endpoint URL for a supported region without throwing', () => {
+		const { url, signOpts } = awsGetSignInOptionsAndUpdateRequest(
+			{ headers: {} } as any,
+			baseCredentials,
+			'/path',
+			'GET',
+			'lambda',
+			'us-east-1',
+		);
+
+		expect(new URL(url).host).toBe('lambda.us-east-1.amazonaws.com');
+		expect(signOpts.host).toBe('lambda.us-east-1.amazonaws.com');
+		expect(signOpts.region).toBe('us-east-1');
+	});
+
+	it('uses the China domain for China regions', () => {
+		const { url } = awsGetSignInOptionsAndUpdateRequest(
+			{ headers: {} } as any,
+			{ ...baseCredentials, region: 'cn-north-1' },
+			'/path',
+			'GET',
+			'lambda',
+			'cn-north-1',
+		);
+
+		expect(new URL(url).host).toBe('lambda.cn-north-1.amazonaws.com.cn');
+	});
+
+	it.each([
+		'@example.com#',
+		'us-east-1/foo',
+		'us-east-1#frag',
+		'us-east-1:8080',
+		'us-fake-1',
+		'',
+		' us-east-1 ',
+	])('rejects unsupported region value %s before any URL is built', (region) => {
+		expect(() =>
+			awsGetSignInOptionsAndUpdateRequest(
+				{ headers: {} } as any,
+				baseCredentials,
+				'/path',
+				'GET',
+				'lambda',
+				region as any,
+			),
+		).toThrow(ApplicationError);
+	});
+});
+
+describe('assumeRole region validation', () => {
+	let mockFetch: jest.MockedFunction<typeof fetch>;
+	let mockSign: jest.MockedFunction<typeof sign>;
+	let consoleErrorSpy: jest.SpyInstance;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
+		mockSign = sign as jest.MockedFunction<typeof sign>;
+		consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+		mockSign.mockImplementation((request: any) => request as any);
+	});
+
+	afterEach(() => {
+		consoleErrorSpy.mockRestore();
+	});
+
+	it.each(['@example.com#', 'us-fake-1', '', 'us-east-1/foo', 'us-east-1#frag'])(
+		'rejects unsupported region value %s without signing or sending a request',
+		async (region) => {
+			const credentials: AwsAssumeRoleCredentialsType = {
+				region: 'us-east-1',
+				customEndpoints: false,
+				useSystemCredentialsForRole: false,
+				roleArn: 'arn:aws:iam::123456789012:role/TestRole',
+				stsAccessKeyId: 'sts-access-key',
+				stsSecretAccessKey: 'sts-secret-key',
+			};
+
+			await expect(assumeRole(credentials, region as any)).rejects.toThrow(ApplicationError);
+			await expect(assumeRole(credentials, region as any)).rejects.toThrow(
+				'Unsupported AWS region',
+			);
+
+			expect(mockSign).not.toHaveBeenCalled();
+			expect(mockFetch).not.toHaveBeenCalled();
+		},
+	);
 });

--- a/packages/nodes-base/credentials/common/aws/utils.ts
+++ b/packages/nodes-base/credentials/common/aws/utils.ts
@@ -40,6 +40,19 @@ function shouldStringifyBody<T>(value: T, headers: IDataObject): boolean {
 	return false;
 }
 
+const SUPPORTED_AWS_REGIONS: ReadonlySet<string> = new Set(regions.map((r) => r.name));
+
+/**
+ * Ensures the region value belongs to the supported AWS regions list before it
+ * is interpolated into request URLs or signing options. Anything outside the
+ * known set is rejected with a controlled error.
+ */
+export function assertSupportedAwsRegion(region: unknown): asserts region is AWSRegion {
+	if (typeof region !== 'string' || !SUPPORTED_AWS_REGIONS.has(region)) {
+		throw new ApplicationError('Unsupported AWS region');
+	}
+}
+
 /**
  * Gets the AWS domain for a specific region.
  *
@@ -108,6 +121,7 @@ export function awsGetSignInOptionsAndUpdateRequest(
 	service: string,
 	region: AWSRegion,
 ): { signOpts: Request; url: string } {
+	assertSupportedAwsRegion(region);
 	let body = requestOptions.body;
 	let endpoint: URL;
 	let query = requestOptions.qs?.query as IDataObject;
@@ -242,6 +256,7 @@ export async function assumeRole(
 	secretAccessKey: string;
 	sessionToken: string;
 }> {
+	assertSupportedAwsRegion(region);
 	let stsCallCredentials: { accessKeyId: string; secretAccessKey: string; sessionToken?: string };
 
 	const useSystemCredentialsForRole = credentials.useSystemCredentialsForRole ?? false;

--- a/packages/nodes-base/nodes/Aws/Textract/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/Textract/GenericFunctions.ts
@@ -16,11 +16,13 @@ import { NodeApiError, sanitizeXmlName } from 'n8n-workflow';
 import { URL } from 'url';
 import { parseString } from 'xml2js';
 import { getAwsCredentials } from '../GenericFunctions';
+import { assertSupportedAwsRegion } from '../../../credentials/common/aws/utils';
 
 function getEndpointForService(
 	service: string,
 	credentials: ICredentialDataDecryptedObject,
 ): string {
+	assertSupportedAwsRegion(credentials.region);
 	let endpoint;
 	if (service === 'lambda' && credentials.lambdaEndpoint) {
 		endpoint = credentials.lambdaEndpoint;
@@ -29,7 +31,7 @@ function getEndpointForService(
 	} else {
 		endpoint = `https://${service}.${credentials.region}.amazonaws.com`;
 	}
-	return (endpoint as string).replace('{region}', credentials.region as string);
+	return (endpoint as string).replace('{region}', credentials.region);
 }
 
 export async function awsApiRequest(

--- a/packages/nodes-base/nodes/Aws/Textract/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Aws/Textract/test/GenericFunctions.test.ts
@@ -1,6 +1,60 @@
-import { simplify, type IExpenseDocument } from '../GenericFunctions';
+import { mock } from 'jest-mock-extended';
+import type { ICredentialTestFunctions } from 'n8n-workflow';
+import { ApplicationError } from 'n8n-workflow';
+
+jest.mock('aws4', () => ({
+	sign: jest.fn(),
+}));
+
+import { sign } from 'aws4';
+import { simplify, validateCredentials, type IExpenseDocument } from '../GenericFunctions';
 
 describe('AWS Textract Generic Functions', () => {
+	const mockSign = sign as jest.MockedFunction<typeof sign>;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('validateCredentials region validation', () => {
+		const buildContext = () => {
+			const helpers = { request: jest.fn() };
+			const context = mock<ICredentialTestFunctions>({
+				helpers: helpers as never,
+			});
+			return { context, helpers };
+		};
+
+		const baseCredentials = {
+			accessKeyId: 'AKIA-test',
+			secretAccessKey: 'secret-test',
+			temporaryCredentials: false,
+		};
+
+		it.each([
+			'@example.com#',
+			'us-fake-1',
+			'',
+			'us-east-1/foo',
+			'us-east-1#frag',
+			'us-east-1:8080',
+			' us-east-1 ',
+		])('rejects unsupported region value %s without signing or sending', async (region) => {
+			const { context, helpers } = buildContext();
+			const credentials = { ...baseCredentials, region };
+
+			await expect(validateCredentials.call(context, credentials, 'textract')).rejects.toThrow(
+				ApplicationError,
+			);
+			await expect(validateCredentials.call(context, credentials, 'textract')).rejects.toThrow(
+				'Unsupported AWS region',
+			);
+
+			expect(mockSign).not.toHaveBeenCalled();
+			expect(helpers.request).not.toHaveBeenCalled();
+		});
+	});
+
 	describe('simplify function', () => {
 		it('should simplify expense document response correctly', () => {
 			const input = {

--- a/packages/nodes-base/nodes/Aws/Transcribe/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Aws/Transcribe/GenericFunctions.ts
@@ -15,10 +15,13 @@ import type {
 import { NodeApiError } from 'n8n-workflow';
 import { URL } from 'url';
 
+import { assertSupportedAwsRegion } from '../../../credentials/common/aws/utils';
+
 function getEndpointForService(
 	service: string,
 	credentials: ICredentialDataDecryptedObject,
 ): string {
+	assertSupportedAwsRegion(credentials.region);
 	let endpoint;
 	if (service === 'lambda' && credentials.lambdaEndpoint) {
 		endpoint = credentials.lambdaEndpoint;
@@ -27,7 +30,7 @@ function getEndpointForService(
 	} else {
 		endpoint = `https://${service}.${credentials.region}.amazonaws.com`;
 	}
-	return (endpoint as string).replace('{region}', credentials.region as string);
+	return (endpoint as string).replace('{region}', credentials.region);
 }
 
 export async function awsApiRequest(

--- a/packages/nodes-base/nodes/Aws/Transcribe/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Aws/Transcribe/test/GenericFunctions.test.ts
@@ -1,0 +1,70 @@
+import { mock } from 'jest-mock-extended';
+import type { IExecuteFunctions } from 'n8n-workflow';
+import { ApplicationError } from 'n8n-workflow';
+
+jest.mock('aws4', () => ({
+	sign: jest.fn(),
+}));
+
+import { sign } from 'aws4';
+import { awsApiRequest } from '../GenericFunctions';
+
+describe('AWS Transcribe Generic Functions', () => {
+	const mockSign = sign as jest.MockedFunction<typeof sign>;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('awsApiRequest region validation', () => {
+		const buildContext = (region: unknown) => {
+			const helpers = { request: jest.fn() };
+			const context = mock<IExecuteFunctions>({
+				getCredentials: jest.fn().mockResolvedValue({
+					region,
+					accessKeyId: 'AKIA-test',
+					secretAccessKey: 'secret-test',
+				}),
+				helpers: helpers as never,
+			});
+			return { context, helpers };
+		};
+
+		it.each(['us-east-1', 'eu-west-1', 'ap-southeast-2'])(
+			'accepts the supported region %s and proceeds to sign and send',
+			async (region) => {
+				const { context, helpers } = buildContext(region);
+				helpers.request.mockResolvedValue('{}');
+
+				await awsApiRequest.call(context, 'transcribe', 'POST', '/');
+
+				expect(mockSign).toHaveBeenCalledTimes(1);
+				expect(helpers.request).toHaveBeenCalledTimes(1);
+				const requestArg = helpers.request.mock.calls[0][0];
+				expect(new URL(requestArg.uri).host).toBe(`transcribe.${region}.amazonaws.com`);
+			},
+		);
+
+		it.each([
+			'@example.com#',
+			'us-fake-1',
+			'',
+			'us-east-1/foo',
+			'us-east-1#frag',
+			'us-east-1:8080',
+			' us-east-1 ',
+		])('rejects unsupported region value %s without signing or sending', async (region) => {
+			const { context, helpers } = buildContext(region);
+
+			await expect(awsApiRequest.call(context, 'transcribe', 'POST', '/')).rejects.toThrow(
+				ApplicationError,
+			);
+			await expect(awsApiRequest.call(context, 'transcribe', 'POST', '/')).rejects.toThrow(
+				'Unsupported AWS region',
+			);
+
+			expect(mockSign).not.toHaveBeenCalled();
+			expect(helpers.request).not.toHaveBeenCalled();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Throws an error when an invalid AWS region is used.

## How to test

1. use following workflow
2. create an AWS credentials object (just any invalid key) used in these nodes and set the region via expression to something invalid like `invalid-region`
3. run the different nodes and observe an error about invalid region

```json
{
  "nodes": [
    {
      "parameters": {
        "resource": "bucket",
        "name": "dsa",
        "additionalFields": {}
      },
      "type": "n8n-nodes-base.awsS3",
      "typeVersion": 2,
      "position": [
        352,
        240
      ],
      "id": "416c8786-fe65-4ff4-b272-50479e550ac3",
      "name": "Create a bucket",
      "credentials": {
        "aws": {
          "id": "mSW2lgnUHaOGBacK",
          "name": "AWS (IAM) account"
        }
      }
    },
    {
      "parameters": {},
      "type": "n8n-nodes-base.awsTextract",
      "typeVersion": 1,
      "position": [
        352,
        400
      ],
      "id": "ac3e8f28-8977-48fc-b2da-4b9b10373c1c",
      "name": "AWS Textract",
      "credentials": {
        "aws": {
          "id": "mSW2lgnUHaOGBacK",
          "name": "AWS (IAM) account"
        }
      }
    },
    {
      "parameters": {
        "jsCode": "\nreturn [{binary: {data: {\n            \"data\": \"\",\n            \"fileName\": \"cat.png\",\n            \"mimeType\": \"image/png\"\n}}}];"
      },
      "type": "n8n-nodes-base.code",
      "typeVersion": 2,
      "position": [
        112,
        400
      ],
      "id": "f5c18fbe-fdb4-4353-921b-5920611d4f73",
      "name": "Code in JavaScript"
    },
    {
      "parameters": {
        "operation": "get"
      },
      "type": "n8n-nodes-base.awsTranscribe",
      "typeVersion": 1,
      "position": [
        352,
        576
      ],
      "id": "cbadd5b2-a19b-4202-bb6d-29f1f99fb062",
      "name": "Get transcriptionJob",
      "credentials": {
        "aws": {
          "id": "mSW2lgnUHaOGBacK",
          "name": "AWS (IAM) account"
        }
      }
    }
  ],
  "connections": {
    "Code in JavaScript": {
      "main": [
        [
          {
            "node": "AWS Textract",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "acd7615bcc3af421bbd7517e305cc16505176a6a47045dbe39e25d904c940573"
  }
}
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5045


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
