### PR TITLE
ci: Auto-approve non-conflicting backport PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -22,6 +22,8 @@ jobs:
       github.event.pull_request.merged == true ||
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-slim
+    outputs:
+      created_pull_numbers: ${{ steps.backport.outputs.created_pull_numbers }}
     steps:
       - name: Generate GitHub App Token
         id: generate-token
@@ -50,6 +52,7 @@ jobs:
         run: node .github/scripts/compute-backport-targets.mjs
 
       - name: Backport
+        id: backport
         if: steps.targets.outputs.target_branches != ''
         uses: korthout/backport-action@4aaf0e03a94ff0a619c9a511b61aeb42adea5b02 # v4.2.0
         with:
@@ -82,3 +85,42 @@ jobs:
             {
               "conflict_resolution": "draft_commit_conflicts"
             }
+
+  prepare-auto-merge:
+    needs: [backport]
+    if: needs.backport.outputs.created_pull_numbers != ''
+    runs-on: ubuntu-slim
+    outputs:
+      pr_numbers_json: ${{ steps.filter.outputs.pr_numbers_json }}
+    steps:
+      - name: Filter out draft PRs
+        id: filter
+        env:
+          PR_NUMBERS: ${{ needs.backport.outputs.created_pull_numbers }}
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          mergeable_json="[]"
+          for pr in $PR_NUMBERS; do
+            is_draft=$(gh pr view "$pr" --repo "$REPOSITORY" --json isDraft --jq '.isDraft')
+            if [ "$is_draft" = "true" ]; then
+              echo "Skipping draft PR #$pr (conflicts to resolve)"
+            else
+              mergeable_json=$(echo "$mergeable_json" | jq -c --arg pr "$pr" '. + [$pr]')
+            fi
+          done
+          echo "pr_numbers_json=$mergeable_json" >> "$GITHUB_OUTPUT"
+
+  auto-merge-successful-backports:
+    needs: [prepare-auto-merge]
+    if: needs.prepare-auto-merge.outputs.pr_numbers_json != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        pr_number: ${{ fromJSON(needs.prepare-auto-merge.outputs.pr_numbers_json) }}
+    uses: ./.github/workflows/util-approve-and-set-automerge.yml
+    with:
+      pull-request-number: ${{ matrix.pr_number }}
+    secrets: inherit
+


### PR DESCRIPTION
## Summary

Auto-approve backport PRs if there are no conflicts.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-251

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
