### PR TITLE
fix(API): Fix false positive XSS check for arrow characters in workflow names

### DIFF
--- a/packages/@n8n/api-types/src/utils/__tests__/xss-check.test.ts
+++ b/packages/@n8n/api-types/src/utils/__tests__/xss-check.test.ts
@@ -11,6 +11,13 @@ describe('xssCheck', () => {
 		'name-with-dashes_and.dots',
 		'name/with/slashes',
 		'name (with) (parens)',
+		// Standalone `>` is not tag markup and must be accepted
+		'7 > 3 is true',
+		'price > 100',
+		// `->` arrows are common in workflow names and must be accepted
+		'Webhook -> Process -> Send Email',
+		'a -> b',
+		'foo --> bar',
 	])('returns true for plain string %p', (value) => {
 		expect(xssCheck(value)).toBe(true);
 	});
@@ -25,7 +32,6 @@ describe('xssCheck', () => {
 		'<style>body{}</style>',
 		'<SCRIPT>alert(1)</SCRIPT>',
 		'<script src=//evil.com></script>',
-		'7 > 3 is true',
 		'< not really a tag',
 	])('returns false for value containing HTML-significant characters %p', (value) => {
 		expect(xssCheck(value)).toBe(false);

--- a/packages/@n8n/api-types/src/utils/xss-check.ts
+++ b/packages/@n8n/api-types/src/utils/xss-check.ts
@@ -1,10 +1,16 @@
 import xss from 'xss';
 
 /**
- * Returns `true` when the value is preserved by `xss({ whiteList: {} })`,
- * i.e. contains no HTML-significant characters.
+ * Returns `true` when the value contains no HTML tag markup.
+ *
+ * Sanitizes with an empty allow-list, but overrides `escapeHtml` to only
+ * escape the tag-opening `<` character. Any real tag must start with `<`, so
+ * tag-bearing input is still altered and rejected, while a standalone `>`
+ * is preserved. This avoids false positives for common, harmless sequences
+ * such as the `->` arrows used in workflow names.
  *
  * Use as a zod refine guard for user-supplied names (workflows, data tables,
  * user names, API keys, etc.).
  */
-export const xssCheck = (value: string): boolean => value === xss(value, { whiteList: {} });
+export const xssCheck = (value: string): boolean =>
+	value === xss(value, { whiteList: {}, escapeHtml: (html) => html.replace(/</g, '&lt;') });


### PR DESCRIPTION
## Summary

Workflow names that contain a standalone `>` — most commonly the `->` arrows
used to describe data flow (e.g. `Webhook -> Process -> Send Email`) — could
not be saved. Autosave failed with `Potentially malicious string`.

The shared `xssCheck` refine (used for workflow names, data table names, user
names and API key labels) compared a value against its sanitized form produced
by the `xss` library. With the default `escapeHtml`, the sanitizer escapes both
`<` and `>`, so any standalone `>` changed the string and the value was
rejected.

This PR overrides `escapeHtml` to escape only the tag-opening `<`. Every HTML
tag must begin with `<`, so tag-bearing input is still altered and rejected,
while harmless standalone `>` characters are preserved and accepted. Real XSS
payloads such as `<script>alert(1)</script>` and `<img src=x onerror=alert(1)>`
remain rejected.

**How to test**

1. Create or open a workflow and rename it to `Webhook -> Process -> Send Email`.
2. The workflow now saves/autosaves without the `Potentially malicious string` error.
3. Names containing real markup (e.g. `<b>bold</b>`) are still rejected.

Unit tests in `packages/@n8n/api-types/src/utils/__tests__/xss-check.test.ts`
cover both the accepted arrow names and the rejected markup.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #31281

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
