### PR TITLE
chore(core): Add VM expression-engine API to Expression class (no-changelog)

### DIFF
--- a/packages/@n8n/config/src/configs/__tests__/expression-engine.config.test.ts
+++ b/packages/@n8n/config/src/configs/__tests__/expression-engine.config.test.ts
@@ -1,0 +1,123 @@
+import { Container } from '@n8n/di';
+
+import { ExpressionEngineConfig } from '../expression-engine.config';
+
+describe('ExpressionEngineConfig', () => {
+	const originalEnv = process.env;
+
+	beforeEach(() => {
+		Container.reset();
+		jest.resetAllMocks();
+		process.env = { ...originalEnv };
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+	});
+
+	describe('defaults', () => {
+		test('bridgeTimeout defaults to 5000', () => {
+			expect(Container.get(ExpressionEngineConfig).bridgeTimeout).toBe(5000);
+		});
+
+		test('bridgeMemoryLimit defaults to 128', () => {
+			expect(Container.get(ExpressionEngineConfig).bridgeMemoryLimit).toBe(128);
+		});
+	});
+
+	describe('N8N_EXPRESSION_ENGINE_IDLE_TIMEOUT', () => {
+		test('overrides idleTimeout', () => {
+			process.env.N8N_EXPRESSION_ENGINE_IDLE_TIMEOUT = '60';
+			const config = Container.get(ExpressionEngineConfig);
+			expect(config.idleTimeout).toBe(60);
+		});
+
+		test('parses "0" as the number 0 (distinct from undefined/unset)', () => {
+			process.env.N8N_EXPRESSION_ENGINE_IDLE_TIMEOUT = '0';
+			const config = Container.get(ExpressionEngineConfig);
+			expect(config.idleTimeout).toBe(0);
+			expect(config.idleTimeout).not.toBeUndefined();
+		});
+	});
+
+	describe('N8N_EXPRESSION_ENGINE_TIMEOUT', () => {
+		test('overrides bridgeTimeout', () => {
+			process.env.N8N_EXPRESSION_ENGINE_TIMEOUT = '1000';
+			expect(Container.get(ExpressionEngineConfig).bridgeTimeout).toBe(1000);
+		});
+
+		test('falls back to default on non-numeric value', () => {
+			const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+			process.env.N8N_EXPRESSION_ENGINE_TIMEOUT = 'not-a-number';
+			expect(Container.get(ExpressionEngineConfig).bridgeTimeout).toBe(5000);
+			expect(consoleWarnSpy).toHaveBeenCalled();
+		});
+	});
+
+	describe('N8N_EXPRESSION_ENGINE_MEMORY_LIMIT', () => {
+		test('overrides bridgeMemoryLimit', () => {
+			process.env.N8N_EXPRESSION_ENGINE_MEMORY_LIMIT = '64';
+			expect(Container.get(ExpressionEngineConfig).bridgeMemoryLimit).toBe(64);
+		});
+
+		test('falls back to default on non-numeric value', () => {
+			const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+			process.env.N8N_EXPRESSION_ENGINE_MEMORY_LIMIT = 'not-a-number';
+			expect(Container.get(ExpressionEngineConfig).bridgeMemoryLimit).toBe(128);
+			expect(consoleWarnSpy).toHaveBeenCalled();
+		});
+	});
+
+	describe('observability defaults', () => {
+		test('observabilityEnabled defaults to true', () => {
+			expect(Container.get(ExpressionEngineConfig).observabilityEnabled).toBe(true);
+		});
+
+		test('tracesEnabled defaults to true', () => {
+			expect(Container.get(ExpressionEngineConfig).tracesEnabled).toBe(true);
+		});
+
+		test('slowEvaluationThresholdMs defaults to 50', () => {
+			expect(Container.get(ExpressionEngineConfig).slowEvaluationThresholdMs).toBe(50);
+		});
+
+		test('tracesSampleRate defaults to 0', () => {
+			expect(Container.get(ExpressionEngineConfig).tracesSampleRate).toBe(0);
+		});
+	});
+
+	describe('observability overrides', () => {
+		test('N8N_EXPRESSION_ENGINE_OBSERVABILITY_ENABLED disables observability', () => {
+			process.env.N8N_EXPRESSION_ENGINE_OBSERVABILITY_ENABLED = 'false';
+			expect(Container.get(ExpressionEngineConfig).observabilityEnabled).toBe(false);
+		});
+
+		test('N8N_EXPRESSION_ENGINE_SLOW_EVAL_THRESHOLD_MS overrides threshold', () => {
+			process.env.N8N_EXPRESSION_ENGINE_SLOW_EVAL_THRESHOLD_MS = '100';
+			expect(Container.get(ExpressionEngineConfig).slowEvaluationThresholdMs).toBe(100);
+		});
+
+		test('N8N_EXPRESSION_ENGINE_SLOW_EVAL_THRESHOLD_MS falls back to default on non-positive value', () => {
+			const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+			process.env.N8N_EXPRESSION_ENGINE_SLOW_EVAL_THRESHOLD_MS = '0';
+			expect(Container.get(ExpressionEngineConfig).slowEvaluationThresholdMs).toBe(50);
+			expect(consoleWarnSpy).toHaveBeenCalled();
+		});
+
+		test('N8N_EXPRESSION_ENGINE_TRACES_SAMPLE_RATE overrides sample rate', () => {
+			process.env.N8N_EXPRESSION_ENGINE_TRACES_SAMPLE_RATE = '0.25';
+			expect(Container.get(ExpressionEngineConfig).tracesSampleRate).toBe(0.25);
+		});
+
+		test('N8N_EXPRESSION_ENGINE_TRACES_SAMPLE_RATE falls back to default on out-of-range value', () => {
+			const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+			process.env.N8N_EXPRESSION_ENGINE_TRACES_SAMPLE_RATE = '1.5';
+			expect(Container.get(ExpressionEngineConfig).tracesSampleRate).toBe(0);
+			expect(consoleWarnSpy).toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/@n8n/config/src/configs/expression-engine.config.ts
+++ b/packages/@n8n/config/src/configs/expression-engine.config.ts
@@ -1,0 +1,64 @@
+import z from 'zod';
+
+import { Config, Env } from '../decorators';
+
+const expressionEngineSchema = z.enum(['legacy', 'vm']);
+
+@Config
+export class ExpressionEngineConfig {
+	/**
+	 * Which expression engine to use.
+	 * - `legacy` runs expressions without isolation.
+	 * - `vm` runs expressions in a V8 isolate.
+	 *
+	 * `vm` is currently **experimental**. Use at your own risk.
+	 */
+	@Env('N8N_EXPRESSION_ENGINE', expressionEngineSchema)
+	engine: 'legacy' | 'vm' = 'legacy';
+
+	/** Number of V8 isolates ready in the pool. */
+	@Env('N8N_EXPRESSION_ENGINE_POOL_SIZE')
+	poolSize: number = 1;
+
+	/** Max number of AST-transformed expressions to cache. */
+	@Env('N8N_EXPRESSION_ENGINE_MAX_CODE_CACHE_SIZE')
+	maxCodeCacheSize: number = 1024;
+
+	/**
+	 * Execution timeout in milliseconds for each expression evaluation in the VM bridge.
+	 */
+	@Env('N8N_EXPRESSION_ENGINE_TIMEOUT')
+	bridgeTimeout: number = 5000;
+
+	/** Memory limit in MB for the V8 isolate used by the VM bridge. */
+	@Env('N8N_EXPRESSION_ENGINE_MEMORY_LIMIT')
+	bridgeMemoryLimit: number = 128;
+
+	/**
+	 * Whether to emit observability signals (metrics, traces, logs) for the VM evaluator.
+	 * Only takes effect when `engine === 'vm'`; legacy mode never emits expression metrics
+	 * regardless of this setting.
+	 */
+	@Env('N8N_EXPRESSION_ENGINE_OBSERVABILITY_ENABLED')
+	observabilityEnabled: boolean = true;
+
+	/**
+	 * Whether to emit OpenTelemetry spans for expression evaluation.
+	 * Slow evaluations (>slowEvaluationThresholdMs) and errors always emit a span.
+	 * Healthy-path evaluations are sampled at tracesSampleRate.
+	 */
+	@Env('N8N_EXPRESSION_ENGINE_TRACES_ENABLED')
+	tracesEnabled: boolean = true;
+
+	/** Threshold in ms above which an evaluation is considered "slow" and gets a span. */
+	@Env('N8N_EXPRESSION_ENGINE_SLOW_EVAL_THRESHOLD_MS', z.number({ coerce: true }).positive())
+	slowEvaluationThresholdMs: number = 50;
+
+	/** Head-based sampling rate (0.0–1.0) for healthy-path spans. Slow and erroring expressions always emit. */
+	@Env('N8N_EXPRESSION_ENGINE_TRACES_SAMPLE_RATE', z.number({ coerce: true }).min(0).max(1))
+	tracesSampleRate: number = 0.0;
+
+	/** If set, scale the pool to 0 warm isolates after this many seconds with no acquire. */
+	@Env('N8N_EXPRESSION_ENGINE_IDLE_TIMEOUT')
+	idleTimeout?: number;
+}

--- a/packages/@n8n/config/src/index.ts
+++ b/packages/@n8n/config/src/index.ts
@@ -14,6 +14,7 @@ import { DynamicBannersConfig } from './configs/dynamic-banners.config';
 import { EndpointsConfig } from './configs/endpoints.config';
 import { EventBusConfig } from './configs/event-bus.config';
 import { ExecutionsConfig } from './configs/executions.config';
+import { ExpressionEngineConfig } from './configs/expression-engine.config';
 import { ExternalHooksConfig } from './configs/external-hooks.config';
 import { GenericConfig } from './configs/generic.config';
 import { HiringBannerConfig } from './configs/hiring-banner.config';
@@ -45,6 +46,7 @@ export type { TaskRunnerMode } from './configs/runners.config';
 export { TaskRunnersConfig } from './configs/runners.config';
 export { SecurityConfig } from './configs/security.config';
 export { ExecutionsConfig } from './configs/executions.config';
+export { ExpressionEngineConfig } from './configs/expression-engine.config';
 export { LOG_SCOPES } from './configs/logging.config';
 export type { LogScope } from './configs/logging.config';
 export { WorkflowsConfig } from './configs/workflows.config';
@@ -82,6 +84,9 @@ export class GlobalConfig {
 
 	@Nested
 	publicApi: PublicApiConfig;
+
+	@Nested
+	expressionEngine: ExpressionEngineConfig;
 
 	@Nested
 	externalHooks: ExternalHooksConfig;

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -152,6 +152,17 @@ describe('GlobalConfig', () => {
 				maxFileSizeInKB: 10240,
 			},
 		},
+		expressionEngine: {
+			engine: 'legacy',
+			poolSize: 1,
+			maxCodeCacheSize: 1024,
+			bridgeTimeout: 5000,
+			bridgeMemoryLimit: 128,
+			observabilityEnabled: true,
+			tracesEnabled: true,
+			slowEvaluationThresholdMs: 50,
+			tracesSampleRate: 0,
+		},
 		externalHooks: {
 			files: [],
 		},

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -26,6 +26,11 @@ const packagesDir = resolve(__dirname, '..', '..');
 const alias = [
 	{ find: '@', replacement: resolve(__dirname, 'src') },
 	{ find: 'stream', replacement: 'stream-browserify' },
+	// Stub out @n8n/expression-runtime for browser build (it pulls in isolated-vm, a Node.js-only native module)
+	{
+		find: '@n8n/expression-runtime',
+		replacement: resolve(__dirname, 'vite/expression-runtime-stub.ts'),
+	},
 	// Ensure bare imports resolve to sources (not dist)
 	{ find: '@n8n/i18n', replacement: resolve(packagesDir, 'frontend', '@n8n', 'i18n', 'src') },
 	{

--- a/packages/frontend/editor-ui/vite/expression-runtime-stub.ts
+++ b/packages/frontend/editor-ui/vite/expression-runtime-stub.ts
@@ -1,0 +1,54 @@
+/**
+ * Browser stub for @n8n/expression-runtime.
+ * The real implementation uses isolated-vm (a Node.js-only native module).
+ * IS_FRONTEND guards in expression.ts prevent these from ever being instantiated.
+ */
+
+export class ExpressionEvaluator {
+	constructor(_config?: unknown) {
+		throw new Error('ExpressionEvaluator is not available in browser environments');
+	}
+}
+
+export class IsolatedVmBridge {
+	constructor(_config?: unknown) {
+		throw new Error('IsolatedVmBridge is not available in browser environments');
+	}
+}
+
+export class ExpressionError extends Error {
+	constructor(
+		message: string,
+		public context: Record<string, unknown> = {},
+	) {
+		super(message);
+	}
+}
+export class MemoryLimitError extends Error {}
+export class TimeoutError extends Error {}
+export class SecurityViolationError extends Error {}
+// Note: SyntaxError not re-exported to avoid shadowing built-in
+
+export class RuntimeError extends Error {}
+
+export function extend() {}
+export function extendOptional() {}
+export const EXTENSION_OBJECTS: unknown[] = [];
+export class ExpressionExtensionError extends Error {}
+export class IsolateError extends Error {}
+
+export const DEFAULT_BRIDGE_CONFIG = {};
+
+// Type-only exports (resolved by TypeScript, erased at runtime)
+export type IExpressionEvaluator = never;
+export type EvaluatorConfig = never;
+export type WorkflowData = Record<string, unknown>;
+export type EvaluateOptions = never;
+export type RuntimeBridge = never;
+export type BridgeConfig = never;
+export type ObservabilityProvider = never;
+export type MetricsAPI = never;
+export type TracesAPI = never;
+export type Span = never;
+export type LogsAPI = never;
+export type ExecuteOptions = never;

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@n8n/errors": "workspace:*",
+    "@n8n/expression-runtime": "workspace:*",
     "@n8n/tournament": "1.0.6",
     "ast-types": "0.16.1",
     "callsites": "catalog:",

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -1,11 +1,19 @@
 import { DateTime, Duration, Interval } from 'luxon';
 
 import { ApplicationError } from '@n8n/errors';
+import type { IExpressionEvaluator, ObservabilityProvider } from '@n8n/expression-runtime';
 import { ExpressionExtensionError } from './errors/expression-extension.error';
 import { ExpressionError } from './errors/expression.error';
 import { evaluateExpression, setErrorHandler } from './expression-evaluator-proxy';
-import { sanitizer, sanitizerName } from './expression-sandboxing';
+import {
+	DollarSignValidator,
+	PrototypeSanitizer,
+	ThisSanitizer,
+	sanitizer,
+	sanitizerName,
+} from './expression-sandboxing';
 import { isExpression } from './expressions/expression-helpers';
+import * as LoggerProxy from './logger-proxy';
 import { extend, extendOptional } from './extensions';
 import { extendSyntax } from './extensions/expression-extension';
 import { extendedFunctions } from './extensions/extended-functions';
@@ -179,6 +187,78 @@ const createSafeErrorSubclass = <T extends ErrorConstructor>(ErrorClass: T): T =
 
 export class Expression {
 	constructor(private readonly workflow: Workflow) {}
+
+	private static expressionEngine: 'legacy' | 'vm' = 'legacy';
+
+	private static vmEvaluator?: IExpressionEvaluator;
+
+	/**
+	 * Check if VM evaluator should be used for evaluation.
+	 * @private
+	 */
+	private static shouldUseVm(): boolean {
+		return this.expressionEngine === 'vm' && !IS_FRONTEND && !!this.vmEvaluator;
+	}
+
+	/**
+	 * Initialize the VM evaluator (if feature flag is enabled).
+	 * Should be called once during application startup.
+	 * Only available in Node.js environments (not in browser).
+	 */
+	static async initExpressionEngine(options: {
+		engine: 'legacy' | 'vm';
+		bridgeTimeout: number;
+		bridgeMemoryLimit: number;
+		poolSize: number;
+		maxCodeCacheSize: number;
+		observability?: ObservabilityProvider;
+		idleTimeoutMs?: number;
+	}): Promise<void> {
+		this.expressionEngine = options.engine;
+		if (options.engine !== 'vm' || IS_FRONTEND) return;
+
+		if (!this.vmEvaluator) {
+			// Dynamic import to avoid loading expression-runtime in browser environments
+			const { ExpressionEvaluator, IsolatedVmBridge } = await import('@n8n/expression-runtime');
+			this.vmEvaluator = new ExpressionEvaluator({
+				createBridge: () =>
+					new IsolatedVmBridge({
+						timeout: options.bridgeTimeout,
+						memoryLimit: options.bridgeMemoryLimit,
+						logger: LoggerProxy,
+					}),
+				maxCodeCacheSize: options.maxCodeCacheSize,
+				poolSize: options.poolSize,
+				idleTimeoutMs: options.idleTimeoutMs,
+				hooks: {
+					before: [ThisSanitizer],
+					after: [PrototypeSanitizer, DollarSignValidator],
+				},
+				logger: LoggerProxy,
+				observability: options.observability,
+			});
+			await this.vmEvaluator.initialize();
+		}
+	}
+
+	async acquireIsolate(): Promise<void> {
+		if (Expression.vmEvaluator) await Expression.vmEvaluator.acquire(this);
+	}
+
+	async releaseIsolate(): Promise<void> {
+		if (Expression.vmEvaluator) await Expression.vmEvaluator.release(this);
+	}
+
+	/**
+	 * Dispose the VM evaluator and release resources.
+	 * Should be called during application shutdown or test teardown.
+	 */
+	static async disposeExpressionEngine(): Promise<void> {
+		if (this.vmEvaluator) {
+			await this.vmEvaluator.dispose();
+			this.vmEvaluator = undefined;
+		}
+	}
 
 	static initializeGlobalContext(data: IDataObject) {
 		/**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3386,6 +3386,9 @@ importers:
       '@n8n/errors':
         specifier: workspace:*
         version: link:../@n8n/errors
+      '@n8n/expression-runtime':
+        specifier: workspace:*
+        version: link:../@n8n/expression-runtime
       '@n8n/tournament':
         specifier: 1.0.6
         version: 1.0.6


### PR DESCRIPTION
**Linear:** [CAT-2844](https://linear.app/n8n/issue/CAT-2844) · Phase 3 of 8
**Stacks on:** #31383 (Phase 2 — Register `ExpressionEngineConfig`)

## Changes

Backport the `Expression` class's VM-engine API surface from master:

- Static `Expression.initExpressionEngine(options)` constructs the isolated-vm bridge + evaluator with master's sanitizer hooks (`ThisSanitizer` / `PrototypeSanitizer` / `DollarSignValidator`) and routes bridge + evaluator logs through `LoggerProxy`.
- Static `Expression.disposeExpressionEngine()` tears it down.
- Instance `acquireIsolate()` / `releaseIsolate()` delegate to the evaluator when present, no-op otherwise.
- Static `expressionEngine` / `vmEvaluator` fields + `shouldUseVm()` gate guard the legacy path.

API is inert until the cli wires `initExpressionEngine()` and the callsites start calling acquire/release (Phase 4). v1 behavior unchanged in this commit.

Also pulled forward the editor-ui Vite stub: declaring `@n8n/expression-runtime` as a workflow dep makes Vite try to bundle `isolated-vm` (a native Node module) into the browser build, breaking it. The stub redirects the import at build time; runtime guards in `expression.ts` prevent the stub from ever being instantiated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)