### PR TITLE
chore(core): Backport workflow engine-parity test workspace (no-changelog)

### DIFF
--- a/packages/@n8n/vitest-config/node.ts
+++ b/packages/@n8n/vitest-config/node.ts
@@ -1,27 +1,28 @@
 import { defineConfig } from 'vitest/config';
 import type { InlineConfig } from 'vitest/node';
 
-export const createVitestConfig = (options: InlineConfig = {}) => {
-	const vitestConfig = defineConfig({
-		test: {
-			silent: true,
-			globals: true,
-			environment: 'node',
-			...(process.env.COVERAGE_ENABLED === 'true'
-				? {
-						coverage: {
-							enabled: true,
-							provider: 'v8',
-							reporter: process.env.CI === 'true' ? 'cobertura' : 'text-summary',
-							all: true,
-						},
-					}
-				: {}),
-			...options,
-		},
-	});
+/**
+ * Shared test options without the outer defineConfig wrapper.
+ * Use this when you need to spread the config into workspace projects.
+ */
+export const createBaseInlineConfig = (options: InlineConfig = {}): InlineConfig => ({
+	silent: true,
+	globals: true,
+	environment: 'node',
+	...(process.env.COVERAGE_ENABLED === 'true'
+		? {
+				coverage: {
+					enabled: true,
+					provider: 'v8',
+					reporter: process.env.CI === 'true' ? 'cobertura' : 'text-summary',
+					all: true,
+				},
+			}
+		: {}),
+	...options,
+});
 
-	return vitestConfig;
-};
+export const createVitestConfig = (options: InlineConfig = {}) =>
+	defineConfig({ test: createBaseInlineConfig(options) });
 
 export const vitestConfig = createVitestConfig();

--- a/packages/workflow/test/ExpressionExtensions/date-extensions.test.ts
+++ b/packages/workflow/test/ExpressionExtensions/date-extensions.test.ts
@@ -2,7 +2,7 @@
 
 import { DateTime } from 'luxon';
 
-import { evaluate, getLocalISOString } from './helpers';
+import { asDateTime, evaluate, getLocalISOString } from './helpers';
 import { dateExtensions } from '../../src/extensions/date-extensions';
 import { getGlobalState } from '../../src/global-state';
 
@@ -19,9 +19,13 @@ describe('Data Transformation Functions', () => {
 
 		describe('.beginningOf', () => {
 			test('.beginningOf("week") should work correctly on a date', () => {
-				expect(evaluate('={{ DateTime.local(2023, 1, 20).beginningOf("week") }}')).toEqual(
-					DateTime.local(2023, 1, 16, { zone: defaultTimezone }),
+				const result = asDateTime(
+					evaluate('={{ DateTime.local(2023, 1, 20).beginningOf("week") }}'),
 				);
+				expect(result).toBeInstanceOf(DateTime);
+				expect(result.toISODate()).toEqual('2023-01-16');
+				expect(result.hour).toEqual(0);
+				expect(result.minute).toEqual(0);
 
 				expect(evaluate('={{ new Date(2023, 0, 20).beginningOf("week") }}')).toEqual(
 					DateTime.local(2023, 1, 16, { zone: defaultTimezone }).toJSDate(),
@@ -57,9 +61,12 @@ describe('Data Transformation Functions', () => {
 		});
 
 		test('.endOfMonth() should work correctly on a date', () => {
-			expect(evaluate('={{ DateTime.local(2023, 1, 16).endOfMonth() }}')).toEqual(
-				DateTime.local(2023, 1, 31, 23, 59, 59, 999, { zone: defaultTimezone }),
-			);
+			const result = asDateTime(evaluate('={{ DateTime.local(2023, 1, 16).endOfMonth() }}'));
+			expect(result).toBeInstanceOf(DateTime);
+			expect(result.toISODate()).toEqual('2023-01-31');
+			expect(result.hour).toEqual(23);
+			expect(result.minute).toEqual(59);
+
 			expect(evaluate('={{ new Date(2023, 0, 16).endOfMonth() }}')).toEqual(
 				DateTime.local(2023, 1, 31, 23, 59, 59, 999, { zone: defaultTimezone }).toJSDate(),
 			);
@@ -239,9 +246,9 @@ describe('Data Transformation Functions', () => {
 
 		describe('.toDateTime', () => {
 			test('should return itself for DateTime', () => {
-				const result = evaluate(
-					"={{ DateTime.fromFormat('01-01-2024', 'dd-MM-yyyy').toDateTime() }}",
-				) as unknown as DateTime;
+				const result = asDateTime(
+					evaluate("={{ DateTime.fromFormat('01-01-2024', 'dd-MM-yyyy').toDateTime() }}"),
+				);
 				expect(result).toBeInstanceOf(DateTime);
 				expect(result.day).toEqual(1);
 				expect(result.month).toEqual(1);
@@ -249,9 +256,7 @@ describe('Data Transformation Functions', () => {
 			});
 
 			test('should return a DateTime for JS Date', () => {
-				const result = evaluate(
-					'={{ new Date(2024, 0, 1, 12).toDateTime() }}',
-				) as unknown as DateTime;
+				const result = asDateTime(evaluate('={{ new Date(2024, 0, 1, 12).toDateTime() }}'));
 				expect(result).toBeInstanceOf(DateTime);
 				expect(result.day).toEqual(1);
 				expect(result.month).toEqual(1);

--- a/packages/workflow/test/ExpressionExtensions/helpers.ts
+++ b/packages/workflow/test/ExpressionExtensions/helpers.ts
@@ -1,3 +1,6 @@
+import { DateTime, Duration, Interval } from 'luxon';
+import { afterAll, beforeAll } from 'vitest';
+
 import type { IDataObject } from '../../src/interfaces';
 import { Workflow } from '../../src/workflow';
 import * as Helpers from '../helpers';
@@ -20,6 +23,15 @@ export const workflow = new Workflow({
 });
 export const expression = workflow.expression;
 
+// acquireIsolate/releaseIsolate are no-ops for the legacy engine, so these
+// hooks are safe to register unconditionally.
+beforeAll(async () => {
+	await expression.acquireIsolate();
+});
+afterAll(async () => {
+	await expression.releaseIsolate();
+});
+
 export const evaluate = (value: string, values?: IDataObject[]) =>
 	expression.getParameterValue(
 		value,
@@ -31,6 +43,29 @@ export const evaluate = (value: string, values?: IDataObject[]) =>
 		'manual',
 		{},
 	);
+
+/**
+ * Normalize expression results that may be Luxon instances (legacy engine)
+ * or ISO strings (VM engine). The VM engine serializes Luxon types to ISO
+ * strings at the isolate boundary.
+ */
+export const asDateTime = (v: unknown): DateTime => {
+	if (DateTime.isDateTime(v)) return v;
+	if (typeof v !== 'string') throw new Error(`Expected DateTime or ISO string, got ${typeof v}`);
+	return DateTime.fromISO(v);
+};
+
+export const asDuration = (v: unknown): Duration => {
+	if (Duration.isDuration(v)) return v;
+	if (typeof v !== 'string') throw new Error(`Expected Duration or ISO string, got ${typeof v}`);
+	return Duration.fromISO(v);
+};
+
+export const asInterval = (v: unknown): Interval => {
+	if (Interval.isInterval(v)) return v;
+	if (typeof v !== 'string') throw new Error(`Expected Interval or ISO string, got ${typeof v}`);
+	return Interval.fromISO(v);
+};
 
 export const getLocalISOString = (date: Date) => {
 	const offset = date.getTimezoneOffset();

--- a/packages/workflow/test/ExpressionExtensions/string-extensions.test.ts
+++ b/packages/workflow/test/ExpressionExtensions/string-extensions.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { DateTime } from 'luxon';
 
-import { evaluate } from './helpers';
+import { asDateTime, evaluate } from './helpers';
 import { ExpressionExtensionError } from '../../src/errors';
 
 describe('Data Transformation Functions', () => {
@@ -276,13 +276,17 @@ describe('Data Transformation Functions', () => {
 		});
 
 		test('.toDateTime should work on a variety of formats', () => {
-			expect(evaluate('={{ "Wed, 21 Oct 2015 07:28:00 GMT".toDateTime() }}')).toBeInstanceOf(
+			expect(
+				asDateTime(evaluate('={{ "Wed, 21 Oct 2015 07:28:00 GMT".toDateTime() }}')),
+			).toBeInstanceOf(DateTime);
+			expect(asDateTime(evaluate('={{ "2008-11-11".toDateTime() }}'))).toBeInstanceOf(DateTime);
+			expect(asDateTime(evaluate('={{ "1-Feb-2024".toDateTime() }}'))).toBeInstanceOf(DateTime);
+			expect(asDateTime(evaluate('={{ "1713976144063".toDateTime("ms") }}'))).toBeInstanceOf(
 				DateTime,
 			);
-			expect(evaluate('={{ "2008-11-11".toDateTime() }}')).toBeInstanceOf(DateTime);
-			expect(evaluate('={{ "1-Feb-2024".toDateTime() }}')).toBeInstanceOf(DateTime);
-			expect(evaluate('={{ "1713976144063".toDateTime("ms") }}')).toBeInstanceOf(DateTime);
-			expect(evaluate('={{ "31-01-2024".toDateTime("dd-MM-yyyy") }}')).toBeInstanceOf(DateTime);
+			expect(asDateTime(evaluate('={{ "31-01-2024".toDateTime("dd-MM-yyyy") }}'))).toBeInstanceOf(
+				DateTime,
+			);
 
 			vi.useFakeTimers({ now: new Date() });
 			expect(() => evaluate('={{ "hi".toDateTime() }}')).toThrow(

--- a/packages/workflow/test/expression-array-proxy-semantics.test.ts
+++ b/packages/workflow/test/expression-array-proxy-semantics.test.ts
@@ -25,6 +25,16 @@ describe('Expression — array proxy semantics (engine parity)', () => {
 	});
 	const expression = workflow.expression;
 
+	// acquireIsolate/releaseIsolate are no-ops for the legacy engine, so these
+	// hooks are safe to register unconditionally; under the vm engine they
+	// reserve the isolate this suite's expressions evaluate against.
+	beforeAll(async () => {
+		await expression.acquireIsolate();
+	});
+	afterAll(async () => {
+		await expression.releaseIsolate();
+	});
+
 	const evaluate = (value: string, json: unknown) => {
 		const data: INodeExecutionData[] = [{ json: json as INodeExecutionData['json'] }];
 		return expression.getParameterValue(value, null, 0, 0, 'node', data, 'manual', {});

--- a/packages/workflow/test/expression-vm-errors.test.ts
+++ b/packages/workflow/test/expression-vm-errors.test.ts
@@ -1,0 +1,213 @@
+import { TimeoutError, MemoryLimitError, SecurityViolationError } from '@n8n/expression-runtime';
+import type { IExpressionEvaluator } from '@n8n/expression-runtime';
+import { mock } from 'vitest-mock-extended';
+
+import { ExpressionError } from '../src/errors/expression.error';
+import { ExpressionExtensionError } from '../src/errors/expression-extension.error';
+import { Expression } from '../src/expression';
+import { Workflow } from '../src/workflow';
+import * as Helpers from './helpers';
+
+/**
+ * Tests that VM-specific error types from @n8n/expression-runtime
+ * are caught and wrapped in workflow ExpressionError instances.
+ *
+ * The runtime package defines its own ExpressionError class hierarchy
+ * (TimeoutError, MemoryLimitError, SecurityViolationError), which is
+ * different from packages/workflow's ExpressionError. Without explicit
+ * handling, these errors bypass the isExpressionError() check and
+ * propagate as raw runtime errors.
+ */
+describe('Expression VM error handling', () => {
+	const nodeTypes = Helpers.NodeTypes();
+	const workflow = new Workflow({
+		id: '1',
+		nodes: [
+			{
+				name: 'node',
+				typeVersion: 1,
+				type: 'test.set',
+				id: 'uuid-1234',
+				position: [0, 0],
+				parameters: {},
+			},
+		],
+		connections: {},
+		active: false,
+		nodeTypes,
+	});
+
+	let originalEngine: 'legacy' | 'vm';
+	let originalEvaluator: IExpressionEvaluator | undefined;
+
+	beforeEach(async () => {
+		originalEngine = Expression.getActiveImplementation();
+		originalEvaluator = (Expression as any).vmEvaluator;
+		await workflow.expression.acquireIsolate();
+	});
+
+	afterEach(async () => {
+		await workflow.expression.releaseIsolate();
+		Expression.setExpressionEngine(originalEngine);
+		(Expression as any).vmEvaluator = originalEvaluator;
+	});
+
+	function setVmEvaluator(evaluator: Pick<IExpressionEvaluator, 'evaluate'>) {
+		Expression.setExpressionEngine('vm');
+		(Expression as any).vmEvaluator = mock<IExpressionEvaluator>(evaluator);
+	}
+
+	const evaluate = (expr: string) =>
+		workflow.expression.getParameterValue(expr, null, 0, 0, 'node', [], 'manual', {});
+
+	it('should wrap TimeoutError in ExpressionError', () => {
+		const timeoutError = new TimeoutError('Expression timed out after 5000ms', {});
+		setVmEvaluator({
+			evaluate: () => {
+				throw timeoutError;
+			},
+		});
+
+		let caught: unknown;
+		try {
+			evaluate('={{ $json.id }}');
+		} catch (error) {
+			caught = error;
+		}
+
+		expect(caught).toBeInstanceOf(ExpressionError);
+		expect((caught as ExpressionError).message).toBe('Expression timed out');
+		expect((caught as ExpressionError).cause).toBe(timeoutError);
+	});
+
+	it('should wrap MemoryLimitError in ExpressionError', () => {
+		const memoryError = new MemoryLimitError('Expression exceeded memory limit of 128MB', {});
+		setVmEvaluator({
+			evaluate: () => {
+				throw memoryError;
+			},
+		});
+
+		let caught: unknown;
+		try {
+			evaluate('={{ $json.id }}');
+		} catch (error) {
+			caught = error;
+		}
+
+		expect(caught).toBeInstanceOf(ExpressionError);
+		expect((caught as ExpressionError).message).toBe('Expression exceeded memory limit');
+		expect((caught as ExpressionError).cause).toBe(memoryError);
+	});
+
+	it('should wrap SecurityViolationError in ExpressionError', () => {
+		const securityError = new SecurityViolationError(
+			'Cannot access "constructor" due to security concerns',
+			{},
+		);
+		setVmEvaluator({
+			evaluate: () => {
+				throw securityError;
+			},
+		});
+
+		let caught: unknown;
+		try {
+			evaluate('={{ $json.id }}');
+		} catch (error) {
+			caught = error;
+		}
+
+		expect(caught).toBeInstanceOf(ExpressionError);
+		expect((caught as ExpressionError).message).toBe(
+			'Cannot access "constructor" due to security concerns',
+		);
+		expect((caught as ExpressionError).cause).toBe(securityError);
+	});
+
+	it('should preserve description when reconstructing ExpressionError across isolate boundary', () => {
+		const expressionError = new ExpressionError('something went wrong', {
+			description: 'A human-readable description',
+		});
+		const connectionInputData = [
+			{
+				json: {
+					get boom(): never {
+						throw expressionError;
+					},
+				},
+			},
+		];
+
+		let caught: unknown;
+		try {
+			workflow.expression.getParameterValue(
+				'={{ $json.boom }}',
+				null,
+				0,
+				0,
+				'node',
+				connectionInputData,
+				'manual',
+				{},
+			);
+		} catch (error) {
+			caught = error;
+		}
+
+		expect(caught).toBeInstanceOf(ExpressionError);
+		expect(caught).toEqual(expressionError);
+	});
+
+	it('should preserve description when reconstructing ExpressionExtensionError across isolate boundary', () => {
+		const expressionExtensionError = new ExpressionExtensionError('extension failed', {
+			description: 'Extension-specific description',
+		});
+		const connectionInputData = [
+			{
+				json: {
+					get boom(): never {
+						throw expressionExtensionError;
+					},
+				},
+			},
+		];
+
+		let caught: unknown;
+		try {
+			workflow.expression.getParameterValue(
+				'={{ $json.boom }}',
+				null,
+				0,
+				0,
+				'node',
+				connectionInputData,
+				'manual',
+				{},
+			);
+		} catch (error) {
+			caught = error;
+		}
+
+		expect(caught).toBeInstanceOf(ExpressionExtensionError);
+		expect(caught).toEqual(expressionExtensionError);
+	});
+
+	it('should convert built-in SyntaxError to ExpressionError', () => {
+		setVmEvaluator({
+			evaluate: () => {
+				throw new SyntaxError('Unexpected token');
+			},
+		});
+
+		let caught: unknown;
+		try {
+			evaluate('={{ $json.id }}');
+		} catch (error) {
+			caught = error;
+		}
+
+		expect(caught).toBeInstanceOf(ExpressionError);
+		expect((caught as ExpressionError).message).toBe('invalid syntax');
+	});
+});

--- a/packages/workflow/test/expression.test.ts
+++ b/packages/workflow/test/expression.test.ts
@@ -469,28 +469,46 @@ describe('Expression', () => {
 				);
 			});
 
+			// The $jmespath restricted-identifier defense differs by engine:
+			//   legacy → the host wrapper (workflow-data-proxy.ts) throws
+			//            "due to security concerns" via an explicit token denylist.
+			//   vm     → jmespath runs in-isolate with no denylist, but a restricted
+			//            identifier can never leak a usable constructor/prototype to
+			//            the host: `constructor` resolves to the Object constructor,
+			//            which fails to serialize across the isolate boundary (throws),
+			//            while `getPrototypeOf`/`prototype`/`__proto__` are key-misses
+			//            or non-cloneable internals → the result is never a callable.
+			//            (Structural isolation rather than a denylist — see
+			//            packages/@n8n/expression-runtime/src/runtime/jmespath.ts.)
+			const expectJmespathBlocked = (expr: string) => {
+				if (process.env.N8N_EXPRESSION_ENGINE === 'vm') {
+					let result: unknown;
+					let threw = false;
+					try {
+						result = evaluate(expr);
+					} catch {
+						threw = true;
+					}
+					expect(threw || typeof result !== 'function').toBe(true);
+				} else {
+					expect(() => evaluate(expr)).toThrow(/due to security concerns/);
+				}
+			};
+
 			it('should reject jmespath queries that reference restricted identifiers', () => {
-				expect(() => evaluate('={{ $jmespath({a:1}, "constructor") }}')).toThrow(
-					/due to security concerns/,
-				);
-				expect(() => evaluate('={{ $jmespath({a:1}, "__proto__") }}')).toThrow(
-					/due to security concerns/,
-				);
-				expect(() => evaluate('={{ $jmespath({a:1}, "prototype") }}')).toThrow(
-					/due to security concerns/,
-				);
+				expectJmespathBlocked('={{ $jmespath({a:1}, "constructor") }}');
+				expectJmespathBlocked('={{ $jmespath({a:1}, "__proto__") }}');
+				expectJmespathBlocked('={{ $jmespath({a:1}, "prototype") }}');
 			});
 
 			it('should reject jmespath queries that reference restricted identifiers (alias)', () => {
-				expect(() => evaluate('={{ $jmesPath({a:1}, "getPrototypeOf") }}')).toThrow(
-					/due to security concerns/,
-				);
+				expectJmespathBlocked('={{ $jmesPath({a:1}, "getPrototypeOf") }}');
 			});
 
 			it('should reject computed-string jmespath queries built from restricted identifiers', () => {
-				const payload =
-					'={{ $jmespath({a:1}, String.fromCharCode(99,111,110,115,116,114,117,99,116,111,114)) }}';
-				expect(() => evaluate(payload)).toThrow(/due to security concerns/);
+				expectJmespathBlocked(
+					'={{ $jmespath({a:1}, String.fromCharCode(99,111,110,115,116,114,117,99,116,111,114)) }}',
+				);
 			});
 
 			it('should still allow jmespath queries that contain restricted names as substrings', () => {

--- a/packages/workflow/test/expression.test.ts
+++ b/packages/workflow/test/expression.test.ts
@@ -2,7 +2,7 @@
 
 import { DateTime, Duration, Interval } from 'luxon';
 
-import { workflow } from './ExpressionExtensions/helpers';
+import { workflow, asDuration, asInterval } from './ExpressionExtensions/helpers';
 import { baseFixtures } from './ExpressionFixtures/base';
 import type { ExpressionTestEvaluation, ExpressionTestTransform } from './ExpressionFixtures/base';
 import * as Helpers from './helpers';
@@ -32,6 +32,13 @@ describe('Expression', () => {
 			nodeTypes,
 		});
 		const expression = workflow.expression;
+
+		beforeAll(async () => {
+			await expression.acquireIsolate();
+		});
+		afterAll(async () => {
+			await expression.releaseIsolate();
+		});
 
 		const evaluate = (value: string) =>
 			expression.getParameterValue(value, null, 0, 0, 'node', [], 'manual', {});
@@ -86,32 +93,41 @@ describe('Expression', () => {
 			);
 
 			vi.useFakeTimers({ now: new Date() });
-			expect(evaluate('={{Interval.after(new Date(), 100)}}')).toEqual(
-				Interval.after(new Date(), 100),
-			);
+			const intervalResult = asInterval(evaluate('={{Interval.after(new Date(), 100)}}'));
+			expect(intervalResult).toBeInstanceOf(Interval);
+			expect(intervalResult.length('milliseconds')).toEqual(100);
 			vi.useRealTimers();
 
-			expect(evaluate('={{Duration.fromMillis(100)}}')).toEqual(Duration.fromMillis(100));
+			const durationResult = asDuration(evaluate('={{Duration.fromMillis(100)}}'));
+			expect(durationResult).toBeInstanceOf(Duration);
+			expect(durationResult.toMillis()).toEqual(100);
 
 			expect(evaluate('={{new Object()}}')).toEqual(new Object());
 
 			expect(evaluate('={{new Array()}}')).toEqual([]);
-			expect(evaluate('={{new Int8Array()}}')).toEqual(new Int8Array());
-			expect(evaluate('={{new Uint8Array()}}')).toEqual(new Uint8Array());
-			expect(evaluate('={{new Uint8ClampedArray()}}')).toEqual(new Uint8ClampedArray());
-			expect(evaluate('={{new Int16Array()}}')).toEqual(new Int16Array());
-			expect(evaluate('={{new Uint16Array()}}')).toEqual(new Uint16Array());
-			expect(evaluate('={{new Int32Array()}}')).toEqual(new Int32Array());
-			expect(evaluate('={{new Uint32Array()}}')).toEqual(new Uint32Array());
-			expect(evaluate('={{new Float32Array()}}')).toEqual(new Float32Array());
-			expect(evaluate('={{new Float64Array()}}')).toEqual(new Float64Array());
-			expect(evaluate('={{new BigInt64Array()}}')).toEqual(new BigInt64Array());
-			expect(evaluate('={{new BigUint64Array()}}')).toEqual(new BigUint64Array());
+			// Typed arrays: verify constructors are accessible and return correct length.
+			// We don't use toEqual(new Int8Array()) because the VM engine returns typed
+			// arrays from a different V8 realm, which breaks instanceof/toEqual despite
+			// being functionally identical. This is fine — typed arrays aren't a practical
+			// expression return type (they don't survive JSON serialization).
+			expect(evaluate('={{new Int8Array(3).length}}')).toEqual(3);
+			expect(evaluate('={{new Uint8Array(3).length}}')).toEqual(3);
+			expect(evaluate('={{new Uint8ClampedArray(3).length}}')).toEqual(3);
+			expect(evaluate('={{new Int16Array(3).length}}')).toEqual(3);
+			expect(evaluate('={{new Uint16Array(3).length}}')).toEqual(3);
+			expect(evaluate('={{new Int32Array(3).length}}')).toEqual(3);
+			expect(evaluate('={{new Uint32Array(3).length}}')).toEqual(3);
+			expect(evaluate('={{new Float32Array(3).length}}')).toEqual(3);
+			expect(evaluate('={{new Float64Array(3).length}}')).toEqual(3);
+			expect(evaluate('={{new BigInt64Array(3).length}}')).toEqual(3);
+			expect(evaluate('={{new BigUint64Array(3).length}}')).toEqual(3);
 
 			expect(evaluate('={{new Map()}}')).toEqual(new Map());
-			expect(evaluate('={{new WeakMap()}}')).toEqual(new WeakMap());
+			// WeakMap/WeakSet are not structured-cloneable, so they can't cross
+			// the VM isolate boundary. Verify the constructors are accessible instead.
+			expect(evaluate('={{new WeakMap() instanceof WeakMap}}')).toEqual(true);
 			expect(evaluate('={{new Set()}}')).toEqual(new Set());
-			expect(evaluate('={{new WeakSet()}}')).toEqual(new WeakSet());
+			expect(evaluate('={{new WeakSet() instanceof WeakSet}}')).toEqual(true);
 
 			expect(evaluate('={{new Error()}}')).toEqual(new Error());
 			expect(evaluate('={{new TypeError()}}')).toEqual(new TypeError());
@@ -121,13 +137,16 @@ describe('Expression', () => {
 			expect(evaluate('={{new ReferenceError()}}')).toEqual(new ReferenceError());
 			expect(evaluate('={{new URIError()}}')).toEqual(new URIError());
 
-			expect(evaluate('={{Intl}}')).toEqual(Intl);
+			// Intl from the isolate is a different realm object; verify it's accessible
+			expect(evaluate('={{typeof Intl}}')).toEqual('object');
 
-			expect(evaluate('={{new String()}}')).toEqual(new String());
-			expect(evaluate("={{new RegExp('')}}")).toEqual(new RegExp(''));
+			expect(evaluate('={{new String().toString()}}')).toEqual('');
+			expect(evaluate("={{new RegExp('').source}}")).toEqual('(?:)');
 
-			expect(evaluate('={{Math}}')).toEqual(Math);
-			expect(evaluate('={{new Number()}}')).toEqual(new Number());
+			// Namespace objects (Math, Atomics) come from a different V8 realm in the
+			// VM engine, so toEqual fails despite identical content. Verify accessibility.
+			expect(evaluate('={{typeof Math}}')).toEqual('object');
+			expect(evaluate('={{new Number().valueOf()}}')).toEqual(0);
 			expect(evaluate("={{BigInt('1')}}")).toEqual(BigInt('1'));
 			expect(evaluate('={{Infinity}}')).toEqual(Infinity);
 			expect(evaluate('={{NaN}}')).toEqual(NaN);
@@ -137,12 +156,12 @@ describe('Expression', () => {
 			expect(evaluate("={{parseInt('1', 10)}}")).toEqual(parseInt('1', 10));
 
 			expect(evaluate('={{JSON.stringify({})}}')).toEqual(JSON.stringify({}));
-			expect(evaluate('={{new ArrayBuffer(10)}}')).toEqual(new ArrayBuffer(10));
-			expect(evaluate('={{new SharedArrayBuffer(10)}}')).toEqual(new SharedArrayBuffer(10));
-			expect(evaluate('={{Atomics}}')).toEqual(Atomics);
-			expect(evaluate('={{new DataView(new ArrayBuffer(1))}}')).toEqual(
-				new DataView(new ArrayBuffer(1)),
-			);
+			// ArrayBuffer, SharedArrayBuffer, DataView, and Atomics come from a
+			// different V8 realm in the VM engine. Verify accessibility instead.
+			expect(evaluate('={{new ArrayBuffer(10).byteLength}}')).toEqual(10);
+			expect(evaluate('={{new SharedArrayBuffer(10).byteLength}}')).toEqual(10);
+			expect(evaluate('={{typeof Atomics}}')).toEqual('object');
+			expect(evaluate('={{new DataView(new ArrayBuffer(1)).byteLength}}')).toEqual(1);
 
 			expect(evaluate("={{encodeURI('https://google.com')}}")).toEqual(
 				encodeURI('https://google.com'),
@@ -754,6 +773,13 @@ describe('Expression', () => {
 
 	describe('Test all expression value fixtures', () => {
 		const expression = workflow.expression;
+
+		beforeAll(async () => {
+			await expression.acquireIsolate();
+		});
+		afterAll(async () => {
+			await expression.releaseIsolate();
+		});
 
 		const evaluate = (value: string, data: INodeExecutionData[]) => {
 			const itemIndex = data.length === 0 ? -1 : 0;

--- a/packages/workflow/test/setup-vm-evaluator.ts
+++ b/packages/workflow/test/setup-vm-evaluator.ts
@@ -1,0 +1,26 @@
+import { Expression } from '../src/expression';
+
+// Only runs when N8N_EXPRESSION_ENGINE=vm is set.
+// Initializes the VM evaluator once per vitest worker before all tests,
+// and disposes it after.
+if (process.env.N8N_EXPRESSION_ENGINE === 'vm') {
+	beforeAll(async () => {
+		await Expression.initExpressionEngine({
+			engine: 'vm',
+			poolSize: 1,
+			maxCodeCacheSize: 1024,
+			bridgeTimeout: 5000,
+			bridgeMemoryLimit: 128,
+		});
+	});
+
+	// Under Stryker, the worker process exits the moment vitest finishes — the
+	// OS reclaims isolated-vm native handles either way. Calling dispose here
+	// aborts the worker on Node 24 with a native finaliser assertion, which
+	// Stryker reports as a dry-run failure.
+	if (!process.env.STRYKER_RUN) {
+		afterAll(async () => {
+			await Expression.disposeExpressionEngine();
+		});
+	}
+}

--- a/packages/workflow/test/workflow.test.ts
+++ b/packages/workflow/test/workflow.test.ts
@@ -1742,7 +1742,7 @@ describe('Workflow', () => {
 		const nodeTypes = Helpers.NodeTypes();
 
 		for (const testData of tests) {
-			test(testData.description, () => {
+			test(testData.description, async () => {
 				const nodes: INode[] = [
 					{
 						name: 'Node1',
@@ -1818,64 +1818,70 @@ describe('Workflow', () => {
 				};
 
 				const workflow = new Workflow({ nodes, connections, active: false, nodeTypes });
-				const activeNodeName = testData.input.hasOwnProperty('Node3') ? 'Node3' : 'Node2';
+				await workflow.expression.acquireIsolate();
+				try {
+					const activeNodeName = testData.input.hasOwnProperty('Node3') ? 'Node3' : 'Node2';
 
-				const runExecutionData = createRunExecutionData({
-					resultData: {
-						runData: {
-							Node1: [
-								{
-									source: [
-										{
-											previousNode: 'test',
-										},
-									],
-									startTime: 1,
-									executionTime: 1,
-									executionIndex: 0,
-									data: {
-										main: [
-											[
-												{
-													json: testData.input.Node1.outputJson || testData.input.Node1.parameters,
-													binary: testData.input.Node1.outputBinary,
-												},
-											],
+					const runExecutionData = createRunExecutionData({
+						resultData: {
+							runData: {
+								Node1: [
+									{
+										source: [
+											{
+												previousNode: 'test',
+											},
 										],
+										startTime: 1,
+										executionTime: 1,
+										executionIndex: 0,
+										data: {
+											main: [
+												[
+													{
+														json:
+															testData.input.Node1.outputJson || testData.input.Node1.parameters,
+														binary: testData.input.Node1.outputBinary,
+													},
+												],
+											],
+										},
 									},
-								},
-							],
-							Node2: [],
-							'Node 4 with spaces': [],
+								],
+								Node2: [],
+								'Node 4 with spaces': [],
+							},
 						},
-					},
-				});
+					});
 
-				const itemIndex = 0;
-				const runIndex = 0;
-				const connectionInputData: INodeExecutionData[] =
-					runExecutionData.resultData.runData.Node1[0].data!.main[0]!;
+					const itemIndex = 0;
+					const runIndex = 0;
+					const connectionInputData: INodeExecutionData[] =
+						runExecutionData.resultData.runData.Node1[0].data!.main[0]!;
 
-				for (const parameterName of Object.keys(testData.output)) {
-					const parameterValue = nodes.find((node) => node.name === activeNodeName)!.parameters[
-						parameterName
-					];
-					const result = workflow.expression.getParameterValue(
-						parameterValue,
-						runExecutionData,
-						runIndex,
-						itemIndex,
-						activeNodeName,
-						connectionInputData,
-						'manual',
-						{},
-					);
-					expect(result).toEqual(testData.output[parameterName]);
+					for (const parameterName of Object.keys(testData.output)) {
+						const parameterValue = nodes.find((node) => node.name === activeNodeName)!.parameters[
+							parameterName
+						];
+						const result = workflow.expression.getParameterValue(
+							parameterValue,
+							runExecutionData,
+							runIndex,
+							itemIndex,
+							activeNodeName,
+							connectionInputData,
+							'manual',
+							{},
+						);
+						expect(result).toEqual(testData.output[parameterName]);
+					}
+				} finally {
+					await workflow.expression.releaseIsolate();
 				}
 			});
 		}
 
-		test('should also resolve all child parameters when the parent get requested', () => {
+		test('should also resolve all child parameters when the parent get requested', async () => {
 			const nodes: INode[] = [
 				{
 					name: 'Node1',
@@ -1902,64 +1908,69 @@ describe('Workflow', () => {
 			const connections: IConnections = {};
 
 			const workflow = new Workflow({ nodes, connections, active: false, nodeTypes });
-			const activeNodeName = 'Node1';
+			await workflow.expression.acquireIsolate();
+			try {
+				const activeNodeName = 'Node1';
 
-			const runExecutionData = createRunExecutionData({
-				resultData: {
-					runData: {
-						Node1: [
-							{
-								startTime: 1,
-								executionTime: 1,
-								executionIndex: 0,
-								data: {
-									main: [
-										[
-											{
-												json: {},
-											},
+				const runExecutionData = createRunExecutionData({
+					resultData: {
+						runData: {
+							Node1: [
+								{
+									startTime: 1,
+									executionTime: 1,
+									executionIndex: 0,
+									data: {
+										main: [
+											[
+												{
+													json: {},
+												},
+											],
 										],
-									],
+									},
+									source: [],
 								},
-								source: [],
-							},
-						],
+							],
+						},
 					},
-				},
-			});
+				});
 
-			const itemIndex = 0;
-			const runIndex = 0;
-			const connectionInputData: INodeExecutionData[] =
-				runExecutionData.resultData.runData.Node1[0].data!.main[0]!;
-			const parameterName = 'values';
+				const itemIndex = 0;
+				const runIndex = 0;
+				const connectionInputData: INodeExecutionData[] =
+					runExecutionData.resultData.runData.Node1[0].data!.main[0]!;
+				const parameterName = 'values';
 
-			const parameterValue = nodes.find((node) => node.name === activeNodeName)!.parameters[
-				parameterName
-			];
-			const result = workflow.expression.getParameterValue(
-				parameterValue,
-				runExecutionData,
-				runIndex,
-				itemIndex,
-				activeNodeName,
-				connectionInputData,
-				'manual',
-				{},
-			);
+				const parameterValue = nodes.find((node) => node.name === activeNodeName)!.parameters[
+					parameterName
+				];
+				const result = workflow.expression.getParameterValue(
+					parameterValue,
+					runExecutionData,
+					runIndex,
+					itemIndex,
+					activeNodeName,
+					connectionInputData,
+					'manual',
+					{},
+				);
 
-			expect(result).toEqual({
-				string: [
-					{
-						name: 'name1',
-						value: 'value1',
-					},
-					{
-						name: 'name2',
-						value: 'value1A',
-					},
-				],
-			});
+				expect(result).toEqual({
+					string: [
+						{
+							name: 'name1',
+							value: 'value1',
+						},
+						{
+							name: 'name2',
+							value: 'value1A',
+						},
+					],
+				});
+			} finally {
+				await workflow.expression.releaseIsolate();
+			}
 		});
 	});
 

--- a/packages/workflow/vitest.config.ts
+++ b/packages/workflow/vitest.config.ts
@@ -1,3 +1,30 @@
-import { createVitestConfig } from '@n8n/vitest-config/node';
+import { defineConfig } from 'vitest/config';
+import { createBaseInlineConfig } from '@n8n/vitest-config/node';
 
-export default createVitestConfig({ include: ['test/**/*.test.ts'] });
+// On vitest 3.1.x the multi-config key is `test.workspace` (renamed to
+// `test.projects` in 3.2). Each project repeats the shared inline config
+// directly — vitest 3.1 workspaces do not auto-inherit from the root.
+const sharedTestConfig = createBaseInlineConfig({
+	include: ['test/**/*.test.ts'],
+	setupFiles: ['./test/setup-vm-evaluator.ts'],
+});
+
+export default defineConfig({
+	test: {
+		workspace: [
+			{
+				test: {
+					...sharedTestConfig,
+					name: 'legacy-engine',
+				},
+			},
+			{
+				test: {
+					...sharedTestConfig,
+					name: 'vm-engine',
+					env: { N8N_EXPRESSION_ENGINE: 'vm' },
+				},
+			},
+		],
+	},
+});


### PR DESCRIPTION
**Linear:** [CAT-2844](https://linear.app/n8n/issue/CAT-2844) · Phase 7 of 8 — final
**Stacks on:** #31389 (Phase 5 — `ExpressionObservabilityProvider`)

> Phase 6 (editor-ui Vite stub) was pulled forward into Phase 3. Phase 8 (Alpine/musl native-module verification) dissolved on inspection: `isolated-vm@6.1.2` ships musl prebuilds for both arches, and 1.x's existing inline `npm rebuild sqlite3` in a toolchain-free runtime image is proof the prebuild-load path already works. No Docker changes needed.

Two commits in this PR:

## Commit 1 — `createBaseInlineConfig` in `@n8n/vitest-config`

Exposes the inline test config builder so individual packages can spread it into vitest workspace configs. Used by commit 2.

## Commit 2 — Workflow engine-parity test workspace

Switches `packages/workflow` vitest to a two-project workspace that runs the entire test suite twice: once under `engine=legacy` (default) and once under `engine=vm` (`N8N_EXPRESSION_ENGINE=vm`). Matches master's parity strategy on 1.x's vitest 3.1.x (`test.workspace`; renamed to `test.projects` in 3.2).

Includes:
- `vitest.config.ts` — `legacy-engine` + `vm-engine` workspace projects
- `test/setup-vm-evaluator.ts` — env-gated `initExpressionEngine` before all (byte-identical to master)
- `test/expression-vm-errors.test.ts` — VM error wrapping (`TimeoutError` / `MemoryLimitError` / `SecurityViolationError` / cross-isolate `ExpressionError` reconstruction) (byte-identical to master)
- `test/ExpressionExtensions/helpers.ts` — shared acquire/release hooks and `asDateTime` / `asDuration` / `asInterval` coercion helpers for VM-serialised Luxon results
- `test/expression.test.ts` + `test/workflow.test.ts` — acquire/release wraps on direct `getParameterValue` callers; typed-array / cross-realm asserts adapted for VM behaviour
- `test/ExpressionExtensions/{date,string}-extensions.test.ts` — `asDateTime` coercion on `DateTime`-returning assertions

All 3462 tests pass under both engines (88 file runs = 44 × 2 projects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)