### PR TITLE
fix(core): Improve validator error messages for name and label fields

### DIFF
--- a/packages/@n8n/api-types/src/dto/api-keys/update-api-key-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/api-keys/update-api-key-request.dto.ts
@@ -11,6 +11,8 @@ const xssCheck = (value: string) =>
 	});
 
 export class UpdateApiKeyRequestDto extends Z.class({
-	label: z.string().max(50).min(1).refine(xssCheck, { message: 'Label cannot contain "<" or ">"' }),
+	label: z.string().max(50).min(1).refine(xssCheck, {
+		message: 'Label can only contain letters, numbers, spaces and punctuation',
+	}),
 	scopes: scopesSchema,
 }) {}

--- a/packages/@n8n/api-types/src/dto/api-keys/update-api-key-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/api-keys/update-api-key-request.dto.ts
@@ -11,6 +11,6 @@ const xssCheck = (value: string) =>
 	});
 
 export class UpdateApiKeyRequestDto extends Z.class({
-	label: z.string().max(50).min(1).refine(xssCheck),
+	label: z.string().max(50).min(1).refine(xssCheck, { message: 'Label cannot contain "<" or ">"' }),
 	scopes: scopesSchema,
 }) {}

--- a/packages/@n8n/api-types/src/dto/user/user-update-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/user/user-update-request.dto.ts
@@ -18,10 +18,10 @@ const nameSchema = () =>
 		.min(1)
 		.max(32)
 		.refine(xssCheck, {
-			message: 'Potentially malicious string',
+			message: 'Name cannot contain "<" or ">"',
 		})
 		.refine(urlCheck, {
-			message: 'Potentially malicious string',
+			message: 'Name cannot contain a URL',
 		});
 
 export class UserUpdateRequestDto extends Z.class({

--- a/packages/@n8n/api-types/src/dto/user/user-update-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/user/user-update-request.dto.ts
@@ -18,7 +18,7 @@ const nameSchema = () =>
 		.min(1)
 		.max(32)
 		.refine(xssCheck, {
-			message: 'Name cannot contain "<" or ">"',
+			message: 'Name can only contain letters, numbers, spaces and punctuation',
 		})
 		.refine(urlCheck, {
 			message: 'Name cannot contain a URL',

--- a/packages/@n8n/db/src/utils/validators/__tests__/no-url.validator.test.ts
+++ b/packages/@n8n/db/src/utils/validators/__tests__/no-url.validator.test.ts
@@ -20,7 +20,7 @@ describe('NoUrl', () => {
 				expect(errors).toHaveLength(1);
 				const [error] = errors;
 				expect(error.property).toEqual('name');
-				expect(error.constraints).toEqual({ NoUrl: 'Cannot contain a URL' });
+				expect(error.constraints).toEqual({ NoUrl: 'URLs are not allowed' });
 			});
 		}
 	});

--- a/packages/@n8n/db/src/utils/validators/__tests__/no-url.validator.test.ts
+++ b/packages/@n8n/db/src/utils/validators/__tests__/no-url.validator.test.ts
@@ -20,7 +20,7 @@ describe('NoUrl', () => {
 				expect(errors).toHaveLength(1);
 				const [error] = errors;
 				expect(error.property).toEqual('name');
-				expect(error.constraints).toEqual({ NoUrl: 'Potentially malicious string' });
+				expect(error.constraints).toEqual({ NoUrl: 'Cannot contain a URL' });
 			});
 		}
 	});

--- a/packages/@n8n/db/src/utils/validators/__tests__/no-xss.validator.test.ts
+++ b/packages/@n8n/db/src/utils/validators/__tests__/no-xss.validator.test.ts
@@ -30,7 +30,7 @@ describe('NoXss', () => {
 				expect(errors).toHaveLength(1);
 				const [error] = errors;
 				expect(error.property).toEqual('name');
-				expect(error.constraints).toEqual({ NoXss: 'Potentially malicious string' });
+				expect(error.constraints).toEqual({ NoXss: 'Cannot contain "<" or ">"' });
 			});
 		}
 	});
@@ -111,7 +111,7 @@ describe('NoXss', () => {
 				expect(errors).toHaveLength(1);
 				const [error] = errors;
 				expect(error.property).toEqual('categories');
-				expect(error.constraints).toEqual({ NoXss: 'Potentially malicious string' });
+				expect(error.constraints).toEqual({ NoXss: 'Cannot contain "<" or ">"' });
 			});
 		}
 	});

--- a/packages/@n8n/db/src/utils/validators/__tests__/no-xss.validator.test.ts
+++ b/packages/@n8n/db/src/utils/validators/__tests__/no-xss.validator.test.ts
@@ -30,7 +30,9 @@ describe('NoXss', () => {
 				expect(errors).toHaveLength(1);
 				const [error] = errors;
 				expect(error.property).toEqual('name');
-				expect(error.constraints).toEqual({ NoXss: 'Cannot contain "<" or ">"' });
+				expect(error.constraints).toEqual({
+					NoXss: 'Only letters, numbers, spaces and punctuation are allowed',
+				});
 			});
 		}
 	});
@@ -111,7 +113,9 @@ describe('NoXss', () => {
 				expect(errors).toHaveLength(1);
 				const [error] = errors;
 				expect(error.property).toEqual('categories');
-				expect(error.constraints).toEqual({ NoXss: 'Cannot contain "<" or ">"' });
+				expect(error.constraints).toEqual({
+					NoXss: 'Only letters, numbers, spaces and punctuation are allowed',
+				});
 			});
 		}
 	});

--- a/packages/@n8n/db/src/utils/validators/no-url.validator.ts
+++ b/packages/@n8n/db/src/utils/validators/no-url.validator.ts
@@ -10,7 +10,7 @@ class NoUrlConstraint implements ValidatorConstraintInterface {
 	}
 
 	defaultMessage() {
-		return 'Cannot contain a URL';
+		return 'URLs are not allowed';
 	}
 }
 

--- a/packages/@n8n/db/src/utils/validators/no-url.validator.ts
+++ b/packages/@n8n/db/src/utils/validators/no-url.validator.ts
@@ -10,7 +10,7 @@ class NoUrlConstraint implements ValidatorConstraintInterface {
 	}
 
 	defaultMessage() {
-		return 'Potentially malicious string';
+		return 'Cannot contain a URL';
 	}
 }
 

--- a/packages/@n8n/db/src/utils/validators/no-xss.validator.ts
+++ b/packages/@n8n/db/src/utils/validators/no-xss.validator.ts
@@ -16,7 +16,7 @@ class NoXssConstraint implements ValidatorConstraintInterface {
 	}
 
 	defaultMessage() {
-		return 'Potentially malicious string';
+		return 'Cannot contain "<" or ">"';
 	}
 }
 

--- a/packages/@n8n/db/src/utils/validators/no-xss.validator.ts
+++ b/packages/@n8n/db/src/utils/validators/no-xss.validator.ts
@@ -16,7 +16,7 @@ class NoXssConstraint implements ValidatorConstraintInterface {
 	}
 
 	defaultMessage() {
-		return 'Cannot contain "<" or ">"';
+		return 'Only letters, numbers, spaces and punctuation are allowed';
 	}
 }
 


### PR DESCRIPTION
## Summary

Replaces the developer-facing `Potentially malicious string` validation message with positive, user-friendly copy that lists which characters are allowed. The string previously surfaced verbatim in toasts and inline errors when a user typed `<`, `>` or a URL into a name or label field.

- `NoXss` class-validator default → `Only letters, numbers, spaces and punctuation are allowed`
- `NoUrl` class-validator default → `URLs are not allowed`
- User first/last name zod refines → `Name can only contain letters, numbers, spaces and punctuation` / `Name cannot contain a URL`
- API key label zod refine → `Label can only contain letters, numbers, spaces and punctuation` (was previously falling back to zod's generic `Invalid input`)

To test: enter `<`, `>`, or a URL into the affected fields (user first/last name, API key label, survey answers) and verify the error message names what is allowed.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5312

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI