### PR TITLE
test(Text Classifier Node): Deflake delayBetweenBatches test

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/test/TextClassifier.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/test/TextClassifier.node.test.ts
@@ -1,4 +1,5 @@
 import { FakeChatModel } from '@langchain/core/utils/testing';
+import type * as N8nWorkflow from 'n8n-workflow';
 import type { IExecuteFunctions, INode } from 'n8n-workflow';
 import { sleep } from 'n8n-workflow';
 import type { Mock, Mocked } from 'vitest';
@@ -12,7 +13,7 @@ vi.mock('../processItem', () => ({
 }));
 
 vi.mock('n8n-workflow', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('n8n-workflow')>();
+	const actual = await importOriginal<typeof N8nWorkflow>();
 	return {
 		...actual,
 		sleep: vi.fn().mockResolvedValue(undefined),

--- a/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/test/TextClassifier.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/test/TextClassifier.node.test.ts
@@ -1,5 +1,6 @@
 import { FakeChatModel } from '@langchain/core/utils/testing';
 import type { IExecuteFunctions, INode } from 'n8n-workflow';
+import { sleep } from 'n8n-workflow';
 import type { Mock, Mocked } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
@@ -9,6 +10,14 @@ import { TextClassifier } from '../TextClassifier.node';
 vi.mock('../processItem', () => ({
 	processItem: vi.fn(),
 }));
+
+vi.mock('n8n-workflow', async (importOriginal) => {
+	const actual = await importOriginal<typeof import('n8n-workflow')>();
+	return {
+		...actual,
+		sleep: vi.fn().mockResolvedValue(undefined),
+	};
+});
 
 describe('TextClassifier Node', () => {
 	let node: TextClassifier;
@@ -146,11 +155,11 @@ describe('TextClassifier Node', () => {
 
 			(processItem as Mock).mockResolvedValue({ test: true });
 
-			const startTime = Date.now();
 			await node.execute.call(mockExecuteFunction);
-			const endTime = Date.now();
 
-			expect(endTime - startTime).toBeGreaterThanOrEqual(200);
+			// 6 items / batchSize 2 = 3 batches => 2 inter-batch delays of 100ms
+			expect(sleep).toHaveBeenCalledTimes(2);
+			expect(sleep).toHaveBeenCalledWith(100);
 		});
 
 		it('should handle errors in batch processing', async () => {


### PR DESCRIPTION
## Summary

- Deflake `TextClassifier > execute > should respect delayBetweenBatches` by mocking `sleep` from `n8n-workflow` and asserting call count + argument instead of measuring wall-clock elapsed time.
- The previous assertion compared `Date.now()` deltas against a 200ms boundary; CI observed 199ms (`AssertionError: expected 199 to be greater than or equal to 200`). Local grind reproduced 1/10 failures before the fix.
- After the fix: `pnpm grind` runs 100/100 deterministic passes.

## Test plan
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] `pnpm grind packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/test/TextClassifier.node.test.ts 100` → 100/100 passed
- [x] `pnpm typecheck` in `packages/@n8n/nodes-langchain` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)