### PR TITLE
fix(core): Rebuild isolated-vm in Docker image for musl libc

### DIFF
--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -6,7 +6,16 @@ FROM node:${NODE_VERSION}-alpine3.22 AS builder
 COPY ./compiled /usr/local/lib/node_modules/n8n
 RUN apk add --no-cache python3 make g++ && \
     cd /usr/local/lib/node_modules/n8n && \
-    npm rebuild sqlite3
+    npm rebuild sqlite3 && \
+    # Rebuild isolated-vm from source. node-gyp-build's musl detection relies
+    # on /etc/alpine-release which DHI Alpine omits, so the bundled prebuilt
+    # loader picks the glibc binary and segfaults in musl pthread paths.
+    # Removing prebuilds and invoking node-gyp directly avoids npm rebuild's
+    # double-build behavior (built-in node-gyp + install-script node-gyp)
+    # which races on dep-file state.
+    rm -rf node_modules/isolated-vm/prebuilds && \
+    cd node_modules/isolated-vm && \
+    npx --yes node-gyp rebuild --release -j max
 
 FROM n8nio/base:${NODE_VERSION}
 


### PR DESCRIPTION
## Summary

Rebuilds `isolated-vm` from source in the Alpine builder stage of the n8n Docker image so it links against musl libc.

### Background

n8n cloud pods (DHI Alpine 3.22 base) intermittently segfault within seconds of startup, or hang during `IsolatedVmBridge.initialize()` at `await jail.set('global', jail.derefInto())` — `/healthz` returns 200, `/healthz/readiness` stays 503 forever, no `[IsolatedVmBridge]` log lines ever appear.

### Root cause

`isolated-vm@6.1.2` ships both `prebuilds/linux-x64/isolated-vm.abi137.glibc.node` and `…musl.node`. `node-gyp-build@4.8.4` picks one at load time, detecting musl via `fs.existsSync('/etc/alpine-release')`. **Docker Hardened Image (DHI) Alpine ships without `/etc/alpine-release`** — only `/etc/os-release` is present. With no alpine-release file, `node-gyp-build` defaults to `libc=glibc` and loads the glibc binary, which crashes/wedges in musl pthread paths the first time `jail.set` exercises them.

The previously-built image only does `npm rebuild sqlite3`. sqlite3 works because its install script uses `prebuild-install` (which fails to find a matching prebuilt and falls through to `node-gyp rebuild`). isolated-vm's install script uses `node-gyp-build`, which short-circuits as soon as it finds *any* prebuilt — even the wrong one.

### Fix

Rebuild isolated-vm from source in the builder stage, parallel to the existing sqlite3 handling:

- `rm -rf node_modules/isolated-vm/prebuilds` first — avoids `node-gyp-build`'s short-circuit and removes the wrong-libc landmine.
- Invoke `node-gyp rebuild` directly (not `npm rebuild isolated-vm`) — `npm rebuild` double-invokes node-gyp for packages with `binding.gyp` and the two passes race on dep-file state, breaking the build.
- Resulting `build/Release/isolated_vm.node` is musl-linked (verified: `strings | grep libc` → `libc.musl-x86_64.so.1`).

No DHI runtime image tampering, no `/etc/alpine-release` backfill (which could trip vuln scanners).

### How to test

Local hammer test using a debug flag that loops `new IsolatedVmBridge().initialize()` with per-init timeout:

- **Before fix** (`n8nio/n8n:local`): wedges at ~63 bridges, rate drops to 1/s.
- **After fix** (`n8nio/n8n:local-fixed`): sustained 77/s, 20k+ bridges, no hangs (8h+ run).

Build + smoke:

```bash
pnpm build:docker
docker run --rm -p 5679:5678 \
  -e N8N_EXPRESSION_ENGINE=vm \
  --memory=1g --memory-swap=1g \
  n8nio/n8n:local
# verify musl linkage:
docker run --rm --entrypoint sh n8nio/n8n:local -c \
  'strings /usr/local/lib/node_modules/n8n/node_modules/.pnpm/isolated-vm@6.1.2/node_modules/isolated-vm/build/Release/isolated_vm.node | grep libc'
# expect: libc.musl-x86_64.so.1
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3289

Related prior fix (arm64-specific, didn't cover the DHI-Alpine case): #26869

### Follow-up: latent oracledb issue (not in this PR)

`oracledb@6.10.0` ships a single `oracledb-6.10.0-linux-x64.node` linked against glibc only (`libc.so.6`, GLIBC_2.14 symbols). Workflows using the Oracle DB node on Alpine will crash similarly. Out of scope here — needs separate handling (Instant Client install or build-from-source).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI