### PR TITLE
feat(core): Add knowledge base to snapshot image

### DIFF
--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -167,8 +167,8 @@ export const buildRuntimeSkillWorkspaceBundle: typeof MaterializeRuntimeSkillsMo
 	lazyFunction(() => loadMaterializeRuntimeSkills().buildRuntimeSkillWorkspaceBundle);
 export const materializeRuntimeSkillsIntoWorkspace: typeof MaterializeRuntimeSkillsMod.materializeRuntimeSkillsIntoWorkspace =
 	lazyFunction(() => loadMaterializeRuntimeSkills().materializeRuntimeSkillsIntoWorkspace);
-export const createPrebakedRuntimeSkillsFromWorkspace: typeof MaterializeRuntimeSkillsMod.createPrebakedRuntimeSkillsFromWorkspace =
-	lazyFunction(() => loadMaterializeRuntimeSkills().createPrebakedRuntimeSkillsFromWorkspace);
+export const loadPrebakedRuntimeSkillsBundle: typeof MaterializeRuntimeSkillsMod.loadPrebakedRuntimeSkillsBundle =
+	lazyFunction(() => loadMaterializeRuntimeSkills().loadPrebakedRuntimeSkillsBundle);
 export declare const SANDBOX_RUNTIME_SKILLS_DIR: typeof MaterializeRuntimeSkillsMod.SANDBOX_RUNTIME_SKILLS_DIR;
 export declare const SANDBOX_RUNTIME_SKILL_REGISTRY_FILE: typeof MaterializeRuntimeSkillsMod.SANDBOX_RUNTIME_SKILL_REGISTRY_FILE;
 export declare const RUNTIME_SKILL_MANIFEST_FILE: typeof MaterializeRuntimeSkillsMod.RUNTIME_SKILL_MANIFEST_FILE;

--- a/packages/@n8n/instance-ai/src/knowledge-base/__tests__/materialize-knowledge-base.test.ts
+++ b/packages/@n8n/instance-ai/src/knowledge-base/__tests__/materialize-knowledge-base.test.ts
@@ -1,0 +1,107 @@
+import { jsonParse } from 'n8n-workflow';
+
+import {
+	buildKnowledgeBaseWorkspaceBundle,
+	createPrebakedKnowledgeBaseFromWorkspace,
+	KNOWLEDGE_BASE_MANIFEST_FILE,
+	materializeKnowledgeBaseIntoWorkspace,
+	SANDBOX_KNOWLEDGE_BASE_DIR,
+} from '../materialize-knowledge-base';
+import type { SandboxWorkspace } from '../../workspace/sandbox-fs';
+
+const ROOT = '/home/daytona/workspace';
+
+function createSandboxWorkspace(files: Map<string, string>): {
+	workspace: SandboxWorkspace;
+	writes: Map<string, string>;
+} {
+	const writes = new Map<string, string>();
+	const workspace: SandboxWorkspace = {
+		filesystem: {
+			provider: 'local',
+			writeFile: jest.fn(async (path: string, content: string | Buffer) => {
+				writes.set(path, Buffer.isBuffer(content) ? content.toString('utf-8') : content);
+			}),
+			mkdir: jest.fn(async () => {}),
+		},
+		sandbox: {
+			executeCommand: jest.fn(async (command: string) => {
+				const readMatch = /^cat '([^']+)' 2>\/dev\/null$/.exec(command);
+				if (readMatch) {
+					const content = files.get(readMatch[1]);
+					return content === undefined
+						? { exitCode: 1, stdout: '', stderr: 'missing' }
+						: { exitCode: 0, stdout: content, stderr: '' };
+				}
+
+				return { exitCode: 0, stdout: '', stderr: '' };
+			}),
+		},
+	};
+
+	return { workspace, writes };
+}
+
+describe('buildKnowledgeBaseWorkspaceBundle', () => {
+	it('builds best-practice markdown files, index, and manifest', () => {
+		const bundle = buildKnowledgeBaseWorkspaceBundle({ root: ROOT });
+
+		expect(bundle.rootDir).toBe(`${ROOT}/${SANDBOX_KNOWLEDGE_BASE_DIR}`);
+		expect(
+			bundle.files.get(`${ROOT}/${SANDBOX_KNOWLEDGE_BASE_DIR}/best-practices/scheduling.md`),
+		).toMatch(/# Best Practices: Scheduling Workflows/);
+		expect(
+			bundle.files.get(`${ROOT}/${SANDBOX_KNOWLEDGE_BASE_DIR}/best-practices/index.json`),
+		).toBeDefined();
+		expect(
+			bundle.files.get(`${ROOT}/${SANDBOX_KNOWLEDGE_BASE_DIR}/${KNOWLEDGE_BASE_MANIFEST_FILE}`),
+		).toBeDefined();
+		expect(bundle.contentHash).toMatch(/^[a-f0-9]{12}$/);
+
+		const index = jsonParse<{ entries: Array<{ id: string; hasDocumentation: boolean }> }>(
+			bundle.files.get(`${ROOT}/${SANDBOX_KNOWLEDGE_BASE_DIR}/best-practices/index.json`) ?? '',
+		);
+		expect(index.entries.some((entry) => entry.id === 'scheduling' && entry.hasDocumentation)).toBe(
+			true,
+		);
+		expect(
+			index.entries.some((entry) => entry.id === 'monitoring' && !entry.hasDocumentation),
+		).toBe(true);
+	});
+});
+
+describe('materializeKnowledgeBaseIntoWorkspace', () => {
+	it('writes knowledge base files when no prebaked manifest exists', async () => {
+		const { workspace, writes } = createSandboxWorkspace(new Map());
+
+		const bundle = await materializeKnowledgeBaseIntoWorkspace({
+			workspace,
+			root: ROOT,
+		});
+
+		expect(bundle.files.size).toBeGreaterThan(0);
+		expect(writes.has(bundle.manifestPath)).toBe(true);
+		expect(writes.has(bundle.indexPath)).toBe(true);
+	});
+
+	it('reuses prebaked knowledge base when the manifest hash matches', async () => {
+		const bundle = buildKnowledgeBaseWorkspaceBundle({ root: ROOT });
+		const files = new Map<string, string>([
+			[bundle.manifestPath, bundle.files.get(bundle.manifestPath) ?? ''],
+		]);
+		const { workspace, writes } = createSandboxWorkspace(files);
+
+		const prebaked = await createPrebakedKnowledgeBaseFromWorkspace({
+			workspace,
+			root: ROOT,
+		});
+		const materialized = await materializeKnowledgeBaseIntoWorkspace({
+			workspace,
+			root: ROOT,
+		});
+
+		expect(prebaked?.contentHash).toBe(bundle.contentHash);
+		expect(materialized.contentHash).toBe(bundle.contentHash);
+		expect(writes.size).toBe(0);
+	});
+});

--- a/packages/@n8n/instance-ai/src/knowledge-base/__tests__/materialize-knowledge-base.test.ts
+++ b/packages/@n8n/instance-ai/src/knowledge-base/__tests__/materialize-knowledge-base.test.ts
@@ -1,14 +1,13 @@
 import { jsonParse } from 'n8n-workflow';
 
+import type { SandboxWorkspace } from '../../workspace/sandbox-fs';
 import {
 	buildKnowledgeBaseWorkspaceBundle,
-	createPrebakedKnowledgeBaseFromWorkspace,
 	KNOWLEDGE_BASE_MANIFEST_FILE,
 	loadPrebakedKnowledgeBaseBundle,
 	materializeKnowledgeBaseIntoWorkspace,
 	SANDBOX_KNOWLEDGE_BASE_DIR,
 } from '../materialize-knowledge-base';
-import type { SandboxWorkspace } from '../../workspace/sandbox-fs';
 
 const ROOT = '/home/daytona/workspace';
 
@@ -22,20 +21,23 @@ function createSandboxWorkspace(files: Map<string, string>): {
 			provider: 'local',
 			writeFile: jest.fn(async (path: string, content: string | Buffer) => {
 				writes.set(path, Buffer.isBuffer(content) ? content.toString('utf-8') : content);
+				await Promise.resolve();
 			}),
-			mkdir: jest.fn(async () => {}),
+			mkdir: jest.fn(async () => await Promise.resolve()),
 		},
 		sandbox: {
 			executeCommand: jest.fn(async (command: string) => {
 				const readMatch = /^cat '([^']+)' 2>\/dev\/null$/.exec(command);
 				if (readMatch) {
 					const content = files.get(readMatch[1]);
-					return content === undefined
-						? { exitCode: 1, stdout: '', stderr: 'missing' }
-						: { exitCode: 0, stdout: content, stderr: '' };
+					return await Promise.resolve(
+						content === undefined
+							? { exitCode: 1, stdout: '', stderr: 'missing' }
+							: { exitCode: 0, stdout: content, stderr: '' },
+					);
 				}
 
-				return { exitCode: 0, stdout: '', stderr: '' };
+				return await Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
 			}),
 		},
 	};

--- a/packages/@n8n/instance-ai/src/knowledge-base/__tests__/materialize-knowledge-base.test.ts
+++ b/packages/@n8n/instance-ai/src/knowledge-base/__tests__/materialize-knowledge-base.test.ts
@@ -89,9 +89,10 @@ describe('materializeKnowledgeBaseIntoWorkspace', () => {
 
 	it('reuses prebaked knowledge base when the manifest hash matches', async () => {
 		const bundle = buildKnowledgeBaseWorkspaceBundle({ root: ROOT });
-		const files = new Map<string, string>([
-			[bundle.manifestPath, bundle.files.get(bundle.manifestPath) ?? ''],
-		]);
+		const files = new Map<string, string>();
+		for (const [path, content] of bundle.files) {
+			files.set(path, content);
+		}
 		const { workspace, writes } = createSandboxWorkspace(files);
 
 		const prebaked = await loadPrebakedKnowledgeBaseBundle({
@@ -106,5 +107,22 @@ describe('materializeKnowledgeBaseIntoWorkspace', () => {
 		expect(prebaked?.contentHash).toBe(bundle.contentHash);
 		expect(materialized.contentHash).toBe(bundle.contentHash);
 		expect(writes.size).toBe(0);
+	});
+
+	it('rematerializes when prebaked manifest exists but payload is incomplete', async () => {
+		const bundle = buildKnowledgeBaseWorkspaceBundle({ root: ROOT });
+		const files = new Map<string, string>([
+			[bundle.manifestPath, bundle.files.get(bundle.manifestPath) ?? ''],
+		]);
+		const { workspace, writes } = createSandboxWorkspace(files);
+
+		const materialized = await materializeKnowledgeBaseIntoWorkspace({
+			workspace,
+			root: ROOT,
+		});
+
+		expect(materialized.contentHash).toBe(bundle.contentHash);
+		expect(writes.has(bundle.indexPath)).toBe(true);
+		expect(writes.size).toBeGreaterThan(1);
 	});
 });

--- a/packages/@n8n/instance-ai/src/knowledge-base/__tests__/materialize-knowledge-base.test.ts
+++ b/packages/@n8n/instance-ai/src/knowledge-base/__tests__/materialize-knowledge-base.test.ts
@@ -4,6 +4,7 @@ import {
 	buildKnowledgeBaseWorkspaceBundle,
 	createPrebakedKnowledgeBaseFromWorkspace,
 	KNOWLEDGE_BASE_MANIFEST_FILE,
+	loadPrebakedKnowledgeBaseBundle,
 	materializeKnowledgeBaseIntoWorkspace,
 	SANDBOX_KNOWLEDGE_BASE_DIR,
 } from '../materialize-knowledge-base';
@@ -91,7 +92,7 @@ describe('materializeKnowledgeBaseIntoWorkspace', () => {
 		]);
 		const { workspace, writes } = createSandboxWorkspace(files);
 
-		const prebaked = await createPrebakedKnowledgeBaseFromWorkspace({
+		const prebaked = await loadPrebakedKnowledgeBaseBundle({
 			workspace,
 			root: ROOT,
 		});

--- a/packages/@n8n/instance-ai/src/knowledge-base/materialize-knowledge-base.ts
+++ b/packages/@n8n/instance-ai/src/knowledge-base/materialize-knowledge-base.ts
@@ -103,14 +103,14 @@ export function buildKnowledgeBaseWorkspaceBundle({
 
 const KNOWLEDGE_BASE_FILE_LABEL = 'Knowledge base file';
 
-export function loadPrebakedKnowledgeBaseBundle({
+export async function loadPrebakedKnowledgeBaseBundle({
 	workspace,
 	root,
 	logger,
 }: MaterializeKnowledgeBaseOptions): Promise<KnowledgeBaseWorkspaceBundle | undefined> {
 	const bundle = buildKnowledgeBaseWorkspaceBundle({ root });
 
-	return loadPrebakedWorkspaceBundle({
+	return await loadPrebakedWorkspaceBundle({
 		workspace,
 		manifestPath: bundle.manifestPath,
 		expectedHash: bundle.contentHash,
@@ -142,7 +142,7 @@ export async function materializeKnowledgeBaseIntoWorkspace(
 		workspace: options.workspace,
 		resourceLabel: KNOWLEDGE_BASE_FILE_LABEL,
 		logger: options.logger,
-		loadPrebaked: () => loadPrebakedKnowledgeBaseBundle(options),
+		loadPrebaked: async () => await loadPrebakedKnowledgeBaseBundle(options),
 		buildBundle: () => buildKnowledgeBaseWorkspaceBundle({ root: options.root }),
 		materializedLogMessage: 'Materialized knowledge base into workspace',
 		materializedLogContext: (bundle) => ({

--- a/packages/@n8n/instance-ai/src/knowledge-base/materialize-knowledge-base.ts
+++ b/packages/@n8n/instance-ai/src/knowledge-base/materialize-knowledge-base.ts
@@ -1,0 +1,163 @@
+import {
+	bestPracticesRegistry,
+	TechniqueDescription,
+	WorkflowTechnique,
+	type WorkflowTechniqueType as BestPracticesGuideId,
+} from '@n8n/workflow-sdk/prompts/best-practices';
+import { join as posixJoin } from 'node:path/posix';
+
+import type { Logger } from '../logger';
+import { computeWorkspaceContentHash } from '../workspace/compute-workspace-content-hash';
+import {
+	loadPrebakedWorkspaceBundle,
+	materializeWorkspaceBundle,
+} from '../workspace/prebaked-workspace-bundle';
+import type { SandboxWorkspace } from '../workspace/sandbox-fs';
+import { stringifyWorkspaceJson, withTrailingNewline } from '../workspace/workspace-file-content';
+import { WORKSPACE_MANIFEST_FILE } from '../workspace/workspace-manifest';
+
+export const SANDBOX_KNOWLEDGE_BASE_DIR = 'knowledge-base';
+export const KNOWLEDGE_BASE_BEST_PRACTICES_DIR = 'best-practices';
+export const KNOWLEDGE_BASE_MANIFEST_FILE = WORKSPACE_MANIFEST_FILE;
+export const KNOWLEDGE_BASE_MANIFEST_SCHEMA_VERSION = 1;
+
+export interface KnowledgeBaseIndexEntry {
+	id: BestPracticesGuideId;
+	description: string;
+	hasDocumentation: boolean;
+	file?: string;
+	version?: string;
+}
+
+export interface KnowledgeBaseBestPracticesIndex {
+	entries: KnowledgeBaseIndexEntry[];
+}
+
+export interface KnowledgeBaseWorkspaceManifest {
+	schemaVersion: typeof KNOWLEDGE_BASE_MANIFEST_SCHEMA_VERSION;
+	contentHash: string;
+}
+
+export interface KnowledgeBaseWorkspaceBundle {
+	rootDir: string;
+	manifestPath: string;
+	indexPath: string;
+	files: Map<string, string>;
+	contentHash: string;
+}
+
+interface MaterializeKnowledgeBaseOptions {
+	workspace: SandboxWorkspace;
+	root: string;
+	logger?: Logger;
+}
+
+export function buildKnowledgeBaseWorkspaceBundle({
+	root,
+}: {
+	root: string;
+}): KnowledgeBaseWorkspaceBundle {
+	const rootDir = posixJoin(root, SANDBOX_KNOWLEDGE_BASE_DIR);
+	const files = new Map<string, string>();
+	const entries: KnowledgeBaseIndexEntry[] = [];
+
+	for (const guideId of Object.values(WorkflowTechnique)) {
+		const doc = bestPracticesRegistry[guideId];
+		const description = TechniqueDescription[guideId];
+		const entry: KnowledgeBaseIndexEntry = {
+			id: guideId,
+			description,
+			hasDocumentation: Boolean(doc),
+		};
+
+		if (doc) {
+			const relativeFilePath = posixJoin(KNOWLEDGE_BASE_BEST_PRACTICES_DIR, `${guideId}.md`);
+			files.set(posixJoin(rootDir, relativeFilePath), withTrailingNewline(doc.getDocumentation()));
+			entry.file = relativeFilePath;
+			entry.version = doc.version;
+		}
+
+		entries.push(entry);
+	}
+
+	const indexPath = posixJoin(rootDir, KNOWLEDGE_BASE_BEST_PRACTICES_DIR, 'index.json');
+	const index: KnowledgeBaseBestPracticesIndex = { entries };
+	files.set(indexPath, stringifyWorkspaceJson(index));
+
+	const manifestPath = posixJoin(rootDir, KNOWLEDGE_BASE_MANIFEST_FILE);
+	const contentHash = computeWorkspaceContentHash(files);
+	const manifest: KnowledgeBaseWorkspaceManifest = {
+		schemaVersion: KNOWLEDGE_BASE_MANIFEST_SCHEMA_VERSION,
+		contentHash,
+	};
+	files.set(manifestPath, stringifyWorkspaceJson(manifest));
+
+	return {
+		rootDir,
+		manifestPath,
+		indexPath,
+		files,
+		contentHash,
+	};
+}
+
+const KNOWLEDGE_BASE_FILE_LABEL = 'Knowledge base file';
+
+function loadPrebakedKnowledgeBaseBundle(
+	workspace: SandboxWorkspace,
+	root: string,
+	logger: Logger | undefined,
+): Promise<KnowledgeBaseWorkspaceBundle | undefined> {
+	const bundle = buildKnowledgeBaseWorkspaceBundle({ root });
+
+	return loadPrebakedWorkspaceBundle({
+		workspace,
+		manifestPath: bundle.manifestPath,
+		expectedHash: bundle.contentHash,
+		hashField: 'contentHash',
+		schemaVersion: KNOWLEDGE_BASE_MANIFEST_SCHEMA_VERSION,
+		resourceLabel: KNOWLEDGE_BASE_FILE_LABEL,
+		logger,
+		invalidManifestLogMessage: 'Ignoring invalid prebaked knowledge base manifest',
+		staleManifestLogMessage: 'Ignoring stale prebaked knowledge base manifest',
+		staleManifestLogKeys: {
+			expected: 'expectedContentHash',
+			actual: 'actualContentHash',
+		},
+		successLogMessage: 'Using prebaked knowledge base from workspace',
+		successLogContext: (loadedBundle) => ({
+			root,
+			knowledgeBaseRoot: loadedBundle.rootDir,
+			contentHash: loadedBundle.contentHash,
+			fileCount: loadedBundle.files.size,
+		}),
+		buildBundle: () => bundle,
+	});
+}
+
+export async function createPrebakedKnowledgeBaseFromWorkspace(
+	options: MaterializeKnowledgeBaseOptions,
+): Promise<KnowledgeBaseWorkspaceBundle | undefined> {
+	return await loadPrebakedKnowledgeBaseBundle(options.workspace, options.root, options.logger);
+}
+
+export async function materializeKnowledgeBaseIntoWorkspace({
+	workspace,
+	root,
+	logger,
+}: MaterializeKnowledgeBaseOptions): Promise<KnowledgeBaseWorkspaceBundle> {
+	return await materializeWorkspaceBundle({
+		workspace,
+		resourceLabel: KNOWLEDGE_BASE_FILE_LABEL,
+		logger,
+		loadPrebaked: async () => await loadPrebakedKnowledgeBaseBundle(workspace, root, logger),
+		buildBundle: () => buildKnowledgeBaseWorkspaceBundle({ root }),
+		materializedLogMessage: 'Materialized knowledge base into workspace',
+		materializedLogContext: (bundle) => ({
+			root,
+			knowledgeBaseRoot: bundle.rootDir,
+			contentHash: bundle.contentHash,
+			fileCount: bundle.files.size,
+		}),
+	});
+}

--- a/packages/@n8n/instance-ai/src/knowledge-base/materialize-knowledge-base.ts
+++ b/packages/@n8n/instance-ai/src/knowledge-base/materialize-knowledge-base.ts
@@ -103,11 +103,11 @@ export function buildKnowledgeBaseWorkspaceBundle({
 
 const KNOWLEDGE_BASE_FILE_LABEL = 'Knowledge base file';
 
-function loadPrebakedKnowledgeBaseBundle(
-	workspace: SandboxWorkspace,
-	root: string,
-	logger: Logger | undefined,
-): Promise<KnowledgeBaseWorkspaceBundle | undefined> {
+export function loadPrebakedKnowledgeBaseBundle({
+	workspace,
+	root,
+	logger,
+}: MaterializeKnowledgeBaseOptions): Promise<KnowledgeBaseWorkspaceBundle | undefined> {
 	const bundle = buildKnowledgeBaseWorkspaceBundle({ root });
 
 	return loadPrebakedWorkspaceBundle({
@@ -135,26 +135,18 @@ function loadPrebakedKnowledgeBaseBundle(
 	});
 }
 
-export async function createPrebakedKnowledgeBaseFromWorkspace(
+export async function materializeKnowledgeBaseIntoWorkspace(
 	options: MaterializeKnowledgeBaseOptions,
-): Promise<KnowledgeBaseWorkspaceBundle | undefined> {
-	return await loadPrebakedKnowledgeBaseBundle(options.workspace, options.root, options.logger);
-}
-
-export async function materializeKnowledgeBaseIntoWorkspace({
-	workspace,
-	root,
-	logger,
-}: MaterializeKnowledgeBaseOptions): Promise<KnowledgeBaseWorkspaceBundle> {
+): Promise<KnowledgeBaseWorkspaceBundle> {
 	return await materializeWorkspaceBundle({
-		workspace,
+		workspace: options.workspace,
 		resourceLabel: KNOWLEDGE_BASE_FILE_LABEL,
-		logger,
-		loadPrebaked: async () => await loadPrebakedKnowledgeBaseBundle(workspace, root, logger),
-		buildBundle: () => buildKnowledgeBaseWorkspaceBundle({ root }),
+		logger: options.logger,
+		loadPrebaked: () => loadPrebakedKnowledgeBaseBundle(options),
+		buildBundle: () => buildKnowledgeBaseWorkspaceBundle({ root: options.root }),
 		materializedLogMessage: 'Materialized knowledge base into workspace',
 		materializedLogContext: (bundle) => ({
-			root,
+			root: options.root,
 			knowledgeBaseRoot: bundle.rootDir,
 			contentHash: bundle.contentHash,
 			fileCount: bundle.files.size,

--- a/packages/@n8n/instance-ai/src/skills/__tests__/materialize-runtime-skills.test.ts
+++ b/packages/@n8n/instance-ai/src/skills/__tests__/materialize-runtime-skills.test.ts
@@ -266,7 +266,9 @@ describe('materializeRuntimeSkillsIntoWorkspace', () => {
 		const root = '/home/daytona/workspace';
 		const bundle = await buildRuntimeSkillWorkspaceBundle({ source, root });
 		if (!bundle) throw new Error('Expected runtime skill bundle');
-		writes.set(bundle.manifestPath, bundle.files.get(bundle.manifestPath) ?? '');
+		for (const [path, content] of bundle.files) {
+			writes.set(path, content);
+		}
 
 		const runtimeSource = createLazyWorkspaceRuntimeSkillSource({
 			source,
@@ -279,7 +281,7 @@ describe('materializeRuntimeSkillsIntoWorkspace', () => {
 		const skillPath = `${skillDir}/SKILL.md`;
 		expect(executeCommand).toHaveBeenCalledTimes(1);
 		expect(writeFile).not.toHaveBeenCalled();
-		expect(writes.get(skillPath)).toBeUndefined();
+		expect(writes.get(skillPath)).toContain('data-tables');
 		expect(result).toMatchObject({
 			success: true,
 			skillId: 'data-table-manager',
@@ -381,12 +383,17 @@ describe('materializeRuntimeSkillsIntoWorkspace', () => {
 			logger,
 		});
 
-		const [[message, meta]] = logger.warn.mock.calls as [
-			[string, { skill?: unknown; bytes?: unknown; maxBytes?: unknown }],
-		];
+		const warnMock = logger.warn as jest.Mock<
+			void,
+			[string, { skill?: unknown; bytes?: unknown; maxBytes?: unknown }?]
+		>;
+		const limitWarnCall = warnMock.mock.calls.find(
+			(call) => call[0] === 'Runtime skill file exceeds load_skill output limit',
+		);
+		expect(limitWarnCall).toBeDefined();
+		const [message, meta] = limitWarnCall!;
 		expect(message).toBe('Runtime skill file exceeds load_skill output limit');
-		expect(meta.skill).toBe('large-skill');
-		expect(typeof meta.bytes).toBe('number');
-		expect(meta.maxBytes).toBe(runtimeSkillMaxOutputBytes);
+		expect(meta?.skill).toBe('large-skill');
+		expect(meta?.maxBytes).toBe(runtimeSkillMaxOutputBytes);
 	});
 });

--- a/packages/@n8n/instance-ai/src/skills/materialize-runtime-skills.ts
+++ b/packages/@n8n/instance-ai/src/skills/materialize-runtime-skills.ts
@@ -87,9 +87,9 @@ const LINKED_FILE_GROUPS = [
 	'examples',
 	'other',
 ] as const satisfies readonly RuntimeSkillLinkedFileGroup[];
-const N8N_SKILL_DIR_TEMPLATE = '${N8N_SKILL_DIR}';
-const N8N_SKILLS_DIR_TEMPLATE = '${N8N_SKILLS_DIR}';
-const N8N_WORKSPACE_DIR_TEMPLATE = '${N8N_WORKSPACE_DIR}';
+const N8N_SKILL_DIR_TEMPLATE = `${N8N_SKILL_DIR}`;
+const N8N_SKILLS_DIR_TEMPLATE = `${N8N_SKILLS_DIR}`;
+const N8N_WORKSPACE_DIR_TEMPLATE = `${N8N_WORKSPACE_DIR}`;
 const LOAD_SKILL_OUTPUT_LIMIT_BYTES = 64 * 1024;
 
 function isNonEmptyRecord(value: Record<string, unknown>): boolean {
@@ -352,19 +352,19 @@ function createMaterializedRuntimeSkillSource(
 
 const RUNTIME_SKILL_FILE_LABEL = 'Runtime skill file';
 
-function loadPrebakedRuntimeSkillsBundle({
+export async function loadPrebakedRuntimeSkillsBundle({
 	source,
 	workspace,
 	root,
 	workspaceRoot = root,
 	logger,
 }: MaterializeRuntimeSkillsOptions): Promise<RuntimeSkillWorkspaceBundle | undefined> {
-	if (source.registry.skills.length === 0) return Promise.resolve(undefined);
+	if (source.registry.skills.length === 0) return undefined;
 
 	const skillsRoot = posixJoin(root, SANDBOX_RUNTIME_SKILLS_DIR);
 	const manifestPath = posixJoin(skillsRoot, RUNTIME_SKILL_MANIFEST_FILE);
 
-	return loadPrebakedWorkspaceBundle({
+	return await loadPrebakedWorkspaceBundle({
 		workspace,
 		manifestPath,
 		expectedHash: source.registry.skillsHash,
@@ -387,8 +387,8 @@ function loadPrebakedRuntimeSkillsBundle({
 			skillsHash: bundle.skillsHash,
 			count: bundle.skills.length,
 		}),
-		buildBundle: () =>
-			buildRuntimeSkillWorkspaceBundle({
+		buildBundle: async () =>
+			await buildRuntimeSkillWorkspaceBundle({
 				source,
 				root,
 				workspaceRoot,
@@ -550,8 +550,6 @@ export async function materializeRuntimeSkillsIntoWorkspace({
 	});
 }
 
-export const createPrebakedRuntimeSkillsFromWorkspace = loadPrebakedRuntimeSkillsBundle;
-
 export function createLazyWorkspaceRuntimeSkillSource({
 	source,
 	workspace,
@@ -568,7 +566,7 @@ export function createLazyWorkspaceRuntimeSkillSource({
 		prepare: async () => {
 			await ensureMaterialized();
 		},
-		loadSkill: async (skillId) => await (await ensureSource()).loadSkill(skillId),
+		loadSkill: async (skillId: string) => await (await ensureSource()).loadSkill(skillId),
 		...(source.loadFile
 			? {
 					loadFile: async (skillId: string, filePath: string) => {

--- a/packages/@n8n/instance-ai/src/skills/materialize-runtime-skills.ts
+++ b/packages/@n8n/instance-ai/src/skills/materialize-runtime-skills.ts
@@ -87,9 +87,9 @@ const LINKED_FILE_GROUPS = [
 	'examples',
 	'other',
 ] as const satisfies readonly RuntimeSkillLinkedFileGroup[];
-const N8N_SKILL_DIR_TEMPLATE = `${N8N_SKILL_DIR}`;
-const N8N_SKILLS_DIR_TEMPLATE = `${N8N_SKILLS_DIR}`;
-const N8N_WORKSPACE_DIR_TEMPLATE = `${N8N_WORKSPACE_DIR}`;
+const N8N_SKILL_DIR_TEMPLATE = '$' + '{N8N_SKILL_DIR}';
+const N8N_SKILLS_DIR_TEMPLATE = '$' + '{N8N_SKILLS_DIR}';
+const N8N_WORKSPACE_DIR_TEMPLATE = '$' + '{N8N_WORKSPACE_DIR}';
 const LOAD_SKILL_OUTPUT_LIMIT_BYTES = 64 * 1024;
 
 function isNonEmptyRecord(value: Record<string, unknown>): boolean {

--- a/packages/@n8n/instance-ai/src/skills/materialize-runtime-skills.ts
+++ b/packages/@n8n/instance-ai/src/skills/materialize-runtime-skills.ts
@@ -13,14 +13,18 @@ import {
 } from '@n8n/agents';
 import { join as posixJoin, normalize as posixNormalize } from 'node:path/posix';
 
-import { formatErrorForLog } from '../error-formatting';
 import type { Logger } from '../logger';
-import { readFileViaSandbox, writeFileViaSandbox } from '../workspace/sandbox-fs';
+import {
+	loadPrebakedWorkspaceBundle,
+	materializeWorkspaceBundle,
+} from '../workspace/prebaked-workspace-bundle';
 import { getWorkspaceRoot } from '../workspace/sandbox-setup';
+import { stringifyWorkspaceJson, withTrailingNewline } from '../workspace/workspace-file-content';
+import { WORKSPACE_MANIFEST_FILE } from '../workspace/workspace-manifest';
 
 export const SANDBOX_RUNTIME_SKILLS_DIR = 'skills';
 export const SANDBOX_RUNTIME_SKILL_REGISTRY_FILE = 'registry.json';
-export const RUNTIME_SKILL_MANIFEST_FILE = '.manifest.json';
+export const RUNTIME_SKILL_MANIFEST_FILE = WORKSPACE_MANIFEST_FILE;
 export const RUNTIME_SKILL_MANIFEST_SCHEMA_VERSION = 1;
 export const N8N_SKILLS_DIR_ENV = 'N8N_SKILLS_DIR';
 export const N8N_SKILL_DIR_ENV = 'N8N_SKILL_DIR';
@@ -65,13 +69,6 @@ interface MaterializeRuntimeSkillsOptions {
 	source: RuntimeSkillSource;
 	workspace: Workspace;
 	root: string;
-	logger?: Logger;
-}
-
-interface PrebakedRuntimeSkillsOptions {
-	source: RuntimeSkillSource;
-	workspace: Workspace;
-	root: string;
 	workspaceRoot?: string;
 	logger?: Logger;
 }
@@ -90,21 +87,28 @@ const LINKED_FILE_GROUPS = [
 	'examples',
 	'other',
 ] as const satisfies readonly RuntimeSkillLinkedFileGroup[];
-const N8N_SKILL_DIR_TEMPLATE = '$' + '{N8N_SKILL_DIR}';
-const N8N_SKILLS_DIR_TEMPLATE = '$' + '{N8N_SKILLS_DIR}';
-const N8N_WORKSPACE_DIR_TEMPLATE = '$' + '{N8N_WORKSPACE_DIR}';
+const N8N_SKILL_DIR_TEMPLATE = '${N8N_SKILL_DIR}';
+const N8N_SKILLS_DIR_TEMPLATE = '${N8N_SKILLS_DIR}';
+const N8N_WORKSPACE_DIR_TEMPLATE = '${N8N_WORKSPACE_DIR}';
 const LOAD_SKILL_OUTPUT_LIMIT_BYTES = 64 * 1024;
 
 function isNonEmptyRecord(value: Record<string, unknown>): boolean {
 	return Object.keys(value).length > 0;
 }
 
-function withTrailingNewline(content: string): string {
-	return content.endsWith('\n') ? content : `${content}\n`;
+function toFrontmatterSection<T>(
+	value: T | undefined,
+	build: (section: T) => Record<string, unknown>,
+): Record<string, unknown> | undefined {
+	if (!value) return undefined;
+	const output = build(value);
+	return isNonEmptyRecord(output) ? output : undefined;
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-	return typeof value === 'object' && value !== null && !Array.isArray(value);
+function materializedSkillById(
+	materialized: MaterializedRuntimeSkill[],
+): Map<string, MaterializedRuntimeSkill> {
+	return new Map(materialized.map((skill) => [skill.id, skill]));
 }
 
 function safeSkillDirectory(entry: RuntimeSkillRegistryEntry): string {
@@ -178,40 +182,35 @@ function substituteRuntimeSkillVars(
 function toFrontmatterInterface(
 	value: RuntimeSkillInterfaceContract | undefined,
 ): Record<string, unknown> | undefined {
-	if (!value) return undefined;
-	const output: Record<string, unknown> = {
-		...(value.displayName ? { display_name: value.displayName } : {}),
-		...(value.shortDescription ? { short_description: value.shortDescription } : {}),
-		...(value.defaultPrompt ? { default_prompt: value.defaultPrompt } : {}),
-		...(value.icon ? { icon: value.icon } : {}),
-		...(value.brandColor ? { brand_color: value.brandColor } : {}),
-	};
-	return isNonEmptyRecord(output) ? output : undefined;
+	return toFrontmatterSection(value, (section) => ({
+		...(section.displayName ? { display_name: section.displayName } : {}),
+		...(section.shortDescription ? { short_description: section.shortDescription } : {}),
+		...(section.defaultPrompt ? { default_prompt: section.defaultPrompt } : {}),
+		...(section.icon ? { icon: section.icon } : {}),
+		...(section.brandColor ? { brand_color: section.brandColor } : {}),
+	}));
 }
 
 function toFrontmatterPolicy(
 	value: RuntimeSkillPolicyContract | undefined,
 ): Record<string, unknown> | undefined {
-	if (!value) return undefined;
-	const output: Record<string, unknown> = {
-		...(value.allowImplicitInvocation !== undefined
-			? { allow_implicit_invocation: value.allowImplicitInvocation }
+	return toFrontmatterSection(value, (section) => ({
+		...(section.allowImplicitInvocation !== undefined
+			? { allow_implicit_invocation: section.allowImplicitInvocation }
 			: {}),
-		...(value.product ? { product: value.product } : {}),
-	};
-	return isNonEmptyRecord(output) ? output : undefined;
+		...(section.product ? { product: section.product } : {}),
+	}));
 }
 
 function toFrontmatterDependencies(
 	value: RuntimeSkillDependenciesContract | undefined,
 ): Record<string, unknown> | undefined {
-	if (!value) return undefined;
-	const output: Record<string, unknown> = {
-		...(value.tools?.length ? { tools: value.tools } : {}),
-		...(value.secrets?.length ? { secrets: value.secrets } : {}),
-		...(value.mcpServers?.length
+	return toFrontmatterSection(value, (section) => ({
+		...(section.tools?.length ? { tools: section.tools } : {}),
+		...(section.secrets?.length ? { secrets: section.secrets } : {}),
+		...(section.mcpServers?.length
 			? {
-					mcp_servers: value.mcpServers.map((server) => ({
+					mcp_servers: section.mcpServers.map((server) => ({
 						name: server.name,
 						...(server.description ? { description: server.description } : {}),
 						...(server.transport ? { transport: server.transport } : {}),
@@ -220,8 +219,7 @@ function toFrontmatterDependencies(
 					})),
 				}
 			: {}),
-	};
-	return isNonEmptyRecord(output) ? output : undefined;
+	}));
 }
 
 function addFrontmatterField(lines: string[], key: string, value: unknown): void {
@@ -240,24 +238,6 @@ function addFrontmatterField(lines: string[], key: string, value: unknown): void
 	if (serialized) {
 		lines.push(`${key}: ${serialized}`);
 	}
-}
-
-function parseRuntimeSkillWorkspaceManifest(raw: string): RuntimeSkillWorkspaceManifest | null {
-	let parsed: unknown;
-	try {
-		parsed = JSON.parse(raw);
-	} catch {
-		return null;
-	}
-
-	if (!isRecord(parsed)) return null;
-	if (parsed.schemaVersion !== RUNTIME_SKILL_MANIFEST_SCHEMA_VERSION) return null;
-	if (typeof parsed.skillsHash !== 'string' || parsed.skillsHash.length === 0) return null;
-
-	return {
-		schemaVersion: RUNTIME_SKILL_MANIFEST_SCHEMA_VERSION,
-		skillsHash: parsed.skillsHash,
-	};
 }
 
 function renderRuntimeSkillMarkdown(
@@ -299,7 +279,7 @@ function materializedRegistry(
 	registry: RuntimeSkillRegistry,
 	materialized: MaterializedRuntimeSkill[],
 ): RuntimeSkillRegistry {
-	const materializedById = new Map(materialized.map((skill) => [skill.id, skill]));
+	const materializedById = materializedSkillById(materialized);
 
 	return {
 		...registry,
@@ -326,7 +306,7 @@ function createMaterializedRuntimeSkillSource(
 	workspaceRoot: string,
 	skillsRoot: string,
 ): RuntimeSkillSource {
-	const materializedById = new Map(materialized.map((skill) => [skill.id, skill]));
+	const materializedById = materializedSkillById(materialized);
 	const loadFile = source.loadFile;
 
 	return {
@@ -370,70 +350,52 @@ function createMaterializedRuntimeSkillSource(
 	};
 }
 
-async function writeWorkspaceFile(
-	workspace: Workspace,
-	filePath: string,
-	content: string,
-	logger?: Logger,
-): Promise<void> {
-	if (workspace.filesystem) {
-		try {
-			await workspace.filesystem.writeFile(filePath, content, { recursive: true });
-			return;
-		} catch (error) {
-			try {
-				await writeFileViaSandbox(workspace, filePath, content);
-				logger?.warn('Sandbox runtime skill filesystem write failed; used command fallback', {
-					path: filePath,
-					error: formatErrorForLog(error),
-				});
-				return;
-			} catch (fallbackError) {
-				throw new Error(
-					`Failed to write runtime skill file "${filePath}": ${formatErrorForLog(error)}; command fallback failed: ${formatErrorForLog(fallbackError)}`,
-				);
-			}
-		}
-	}
+const RUNTIME_SKILL_FILE_LABEL = 'Runtime skill file';
 
-	try {
-		await writeFileViaSandbox(workspace, filePath, content);
-	} catch (error) {
-		throw new Error(
-			`Failed to write runtime skill file "${filePath}": ${formatErrorForLog(error)}`,
-		);
-	}
-}
+function loadPrebakedRuntimeSkillsBundle({
+	source,
+	workspace,
+	root,
+	workspaceRoot = root,
+	logger,
+}: MaterializeRuntimeSkillsOptions): Promise<RuntimeSkillWorkspaceBundle | undefined> {
+	if (source.registry.skills.length === 0) return Promise.resolve(undefined);
 
-async function readWorkspaceFile(
-	workspace: Workspace,
-	filePath: string,
-	logger?: Logger,
-): Promise<string | null> {
-	if (workspace.filesystem) {
-		try {
-			const content = await workspace.filesystem.readFile(filePath, { encoding: 'utf-8' });
-			return Buffer.isBuffer(content) ? content.toString('utf-8') : content;
-		} catch (error) {
-			logger?.debug('Sandbox runtime skill manifest filesystem read missed', {
-				path: filePath,
-				error: formatErrorForLog(error),
-			});
-			return null;
-		}
-	}
+	const skillsRoot = posixJoin(root, SANDBOX_RUNTIME_SKILLS_DIR);
+	const manifestPath = posixJoin(skillsRoot, RUNTIME_SKILL_MANIFEST_FILE);
 
-	if (!workspace.sandbox) return null;
-
-	try {
-		return await readFileViaSandbox(workspace, filePath);
-	} catch (error) {
-		logger?.debug('Sandbox runtime skill manifest command read missed', {
-			path: filePath,
-			error: formatErrorForLog(error),
-		});
-		return null;
-	}
+	return loadPrebakedWorkspaceBundle({
+		workspace,
+		manifestPath,
+		expectedHash: source.registry.skillsHash,
+		hashField: 'skillsHash',
+		schemaVersion: RUNTIME_SKILL_MANIFEST_SCHEMA_VERSION,
+		resourceLabel: RUNTIME_SKILL_FILE_LABEL,
+		logger,
+		invalidManifestLogMessage: 'Ignoring invalid prebaked runtime skills manifest',
+		staleManifestLogMessage: 'Ignoring stale prebaked runtime skills manifest',
+		staleManifestLogKeys: {
+			expected: 'expectedSkillsHash',
+			actual: 'actualSkillsHash',
+		},
+		successLogMessage: 'Using prebaked runtime skills from workspace',
+		successLogContext: (bundle) => ({
+			root,
+			workspaceRoot,
+			skillsRoot: bundle.rootDir,
+			registryPath: bundle.registryPath,
+			skillsHash: bundle.skillsHash,
+			count: bundle.skills.length,
+		}),
+		buildBundle: () =>
+			buildRuntimeSkillWorkspaceBundle({
+				source,
+				root,
+				workspaceRoot,
+				skillsRoot,
+				logger,
+			}),
+	});
 }
 
 function linkedFilesFor(entry: RuntimeSkillRegistryEntry): RuntimeSkillLinkedFile[] {
@@ -523,14 +485,14 @@ export async function buildRuntimeSkillWorkspaceBundle({
 
 	const registry = materializedRegistry(source.registry, materialized);
 	const registryPath = posixJoin(skillsRoot, SANDBOX_RUNTIME_SKILL_REGISTRY_FILE);
-	files.set(registryPath, `${JSON.stringify(registry, null, 2)}\n`);
+	files.set(registryPath, stringifyWorkspaceJson(registry));
 
 	const manifest: RuntimeSkillWorkspaceManifest = {
 		schemaVersion: RUNTIME_SKILL_MANIFEST_SCHEMA_VERSION,
 		skillsHash: source.registry.skillsHash,
 	};
 	const manifestPath = posixJoin(skillsRoot, RUNTIME_SKILL_MANIFEST_FILE);
-	files.set(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+	files.set(manifestPath, stringifyWorkspaceJson(manifest));
 
 	const env: NodeJS.ProcessEnv = {
 		[N8N_WORKSPACE_DIR_ENV]: workspaceRoot,
@@ -562,75 +524,33 @@ export async function materializeRuntimeSkillsIntoWorkspace({
 	root,
 	logger,
 }: MaterializeRuntimeSkillsOptions): Promise<MaterializedRuntimeSkills | undefined> {
-	const bundle = await buildRuntimeSkillWorkspaceBundle({ source, root, logger });
-	if (!bundle) return undefined;
-
-	await Promise.all(
-		[...bundle.files].map(async ([filePath, content]) => {
-			await writeWorkspaceFile(workspace, filePath, content, logger);
-		}),
-	);
-
-	logger?.debug('Materialized runtime skills into workspace', {
-		root,
-		skillsRoot: bundle.rootDir,
-		registryPath: bundle.registryPath,
-		skillsHash: bundle.skillsHash,
-		count: bundle.skills.length,
-	});
-
-	return bundle;
-}
-
-export async function createPrebakedRuntimeSkillsFromWorkspace({
-	source,
-	workspace,
-	root,
-	workspaceRoot = root,
-	logger,
-}: PrebakedRuntimeSkillsOptions): Promise<RuntimeSkillWorkspaceBundle | undefined> {
 	if (source.registry.skills.length === 0) return undefined;
 
-	const skillsRoot = posixJoin(root, SANDBOX_RUNTIME_SKILLS_DIR);
-	const manifestPath = posixJoin(skillsRoot, RUNTIME_SKILL_MANIFEST_FILE);
-	const manifestRaw = await readWorkspaceFile(workspace, manifestPath, logger);
-	if (!manifestRaw) return undefined;
-
-	const manifest = parseRuntimeSkillWorkspaceManifest(manifestRaw);
-	if (!manifest) {
-		logger?.debug('Ignoring invalid prebaked runtime skills manifest', { manifestPath });
-		return undefined;
-	}
-
-	if (manifest.skillsHash !== source.registry.skillsHash) {
-		logger?.debug('Ignoring stale prebaked runtime skills manifest', {
-			manifestPath,
-			expectedSkillsHash: source.registry.skillsHash,
-			actualSkillsHash: manifest.skillsHash,
-		});
-		return undefined;
-	}
-
-	const bundle = await buildRuntimeSkillWorkspaceBundle({
-		source,
-		root,
-		workspaceRoot,
-		skillsRoot,
+	return await materializeWorkspaceBundle({
+		workspace,
+		resourceLabel: RUNTIME_SKILL_FILE_LABEL,
 		logger,
+		loadPrebaked: async () =>
+			await loadPrebakedRuntimeSkillsBundle({ source, workspace, root, logger }),
+		buildBundle: async () => {
+			const bundle = await buildRuntimeSkillWorkspaceBundle({ source, root, logger });
+			if (!bundle) {
+				throw new Error('Expected runtime skill bundle after registry validation');
+			}
+			return bundle;
+		},
+		materializedLogMessage: 'Materialized runtime skills into workspace',
+		materializedLogContext: (bundle) => ({
+			root,
+			skillsRoot: bundle.rootDir,
+			registryPath: bundle.registryPath,
+			skillsHash: bundle.skillsHash,
+			count: bundle.skills.length,
+		}),
 	});
-	if (!bundle) return undefined;
-
-	logger?.debug('Using prebaked runtime skills from workspace', {
-		root,
-		workspaceRoot,
-		skillsRoot: bundle.rootDir,
-		registryPath: bundle.registryPath,
-		skillsHash: bundle.skillsHash,
-		count: bundle.skills.length,
-	});
-
-	return bundle;
 }
+
+export const createPrebakedRuntimeSkillsFromWorkspace = loadPrebakedRuntimeSkillsBundle;
 
 export function createLazyWorkspaceRuntimeSkillSource({
 	source,
@@ -664,19 +584,10 @@ export function createLazyWorkspaceRuntimeSkillSource({
 
 		materializePromise ??= (async () => {
 			const root = await getWorkspaceRoot(runtimeWorkspace);
+			const options = { source, workspace: runtimeWorkspace, root, logger };
 			const result =
-				(await createPrebakedRuntimeSkillsFromWorkspace({
-					source,
-					workspace: runtimeWorkspace,
-					root,
-					logger,
-				})) ??
-				(await materializeRuntimeSkillsIntoWorkspace({
-					source,
-					workspace: runtimeWorkspace,
-					root,
-					logger,
-				}));
+				(await loadPrebakedRuntimeSkillsBundle(options)) ??
+				(await materializeRuntimeSkillsIntoWorkspace(options));
 			if (result) {
 				materialized = result;
 				workspaceSource.registry = result.source.registry;

--- a/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-workflow-agent.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/__tests__/build-workflow-agent.tool.test.ts
@@ -15,7 +15,6 @@ import { UserError } from 'n8n-workflow';
 
 import { executeTool } from '../../../__tests__/tool-test-utils';
 import {
-	RUNTIME_SKILL_MANIFEST_FILE,
 	SANDBOX_RUNTIME_SKILLS_DIR,
 	buildRuntimeSkillWorkspaceBundle,
 	materializeRuntimeSkillsIntoWorkspace,
@@ -292,10 +291,9 @@ describe('materializeBuilderRuntimeSkills', () => {
 			root: bakedRoot,
 		});
 		if (!bundle) throw new Error('Expected runtime skill bundle');
-		builderTarget.writes.set(
-			`${bakedRoot}/${SANDBOX_RUNTIME_SKILLS_DIR}/${RUNTIME_SKILL_MANIFEST_FILE}`,
-			bundle.files.get(bundle.manifestPath) ?? '',
-		);
+		for (const [path, content] of bundle.files) {
+			builderTarget.writes.set(path, content);
+		}
 
 		const result = await materializeBuilderRuntimeSkills(
 			createMockContext({ runtimeSkillCatalog: rawSource }),

--- a/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/build-workflow-agent.tool.ts
@@ -32,9 +32,9 @@ import { buildSubAgentBriefing } from '../../agent/sub-agent-briefing';
 import { MAX_STEPS } from '../../constants/max-steps';
 import type { Logger } from '../../logger';
 import {
-	createPrebakedRuntimeSkillsFromWorkspace,
 	materializeRuntimeSkillsIntoWorkspace,
 	type MaterializedRuntimeSkills,
+	loadPrebakedRuntimeSkillsBundle,
 } from '../../skills/materialize-runtime-skills';
 import { hasRuntimeSkills } from '../../skills/runtime-skills';
 import { consumeStreamWithHitl, requireCompletedHitlText } from '../../stream/consume-with-hitl';
@@ -186,7 +186,7 @@ export async function materializeBuilderRuntimeSkills(
 	let materialized: MaterializedRuntimeSkills | undefined;
 	try {
 		const workspaceRoot = await getWorkspaceRoot(workspace);
-		materialized = await createPrebakedRuntimeSkillsFromWorkspace({
+		materialized = await loadPrebakedRuntimeSkillsBundle({
 			source,
 			workspace,
 			root: workspaceRoot,

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/compute-workspace-content-hash.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/compute-workspace-content-hash.test.ts
@@ -1,0 +1,24 @@
+import { computeWorkspaceContentHash } from '../compute-workspace-content-hash';
+
+describe('computeWorkspaceContentHash', () => {
+	it('returns a stable hash regardless of insertion order', () => {
+		const a = new Map([
+			['/workspace/a.txt', 'alpha'],
+			['/workspace/b.txt', 'beta'],
+		]);
+		const b = new Map([
+			['/workspace/b.txt', 'beta'],
+			['/workspace/a.txt', 'alpha'],
+		]);
+
+		expect(computeWorkspaceContentHash(a)).toBe(computeWorkspaceContentHash(b));
+		expect(computeWorkspaceContentHash(a)).toMatch(/^[a-f0-9]{12}$/);
+	});
+
+	it('changes when file content changes', () => {
+		const original = new Map([['/workspace/a.txt', 'alpha']]);
+		const updated = new Map([['/workspace/a.txt', 'beta']]);
+
+		expect(computeWorkspaceContentHash(original)).not.toBe(computeWorkspaceContentHash(updated));
+	});
+});

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/prebaked-workspace-bundle.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/prebaked-workspace-bundle.test.ts
@@ -1,0 +1,160 @@
+import {
+	loadPrebakedWorkspaceBundle,
+	materializeWorkspaceBundle,
+} from '../prebaked-workspace-bundle';
+import type { SandboxWorkspace } from '../sandbox-fs';
+import { stringifyWorkspaceJson } from '../workspace-file-content';
+
+const ROOT = '/home/daytona/workspace';
+
+function createSandboxWorkspace(files: Map<string, string>): {
+	workspace: SandboxWorkspace;
+	writes: Map<string, string>;
+} {
+	const writes = new Map<string, string>();
+	const workspace: SandboxWorkspace = {
+		filesystem: {
+			provider: 'local',
+			writeFile: jest.fn(async (path: string, content: string | Buffer) => {
+				writes.set(path, Buffer.isBuffer(content) ? content.toString('utf-8') : content);
+			}),
+			mkdir: jest.fn(async () => {}),
+		},
+		sandbox: {
+			executeCommand: jest.fn(async (command: string) => {
+				const readMatch = /^cat '([^']+)' 2>\/dev\/null$/.exec(command);
+				if (readMatch) {
+					const content = files.get(readMatch[1]);
+					return content === undefined
+						? { exitCode: 1, stdout: '', stderr: 'missing' }
+						: { exitCode: 0, stdout: content, stderr: '' };
+				}
+
+				return { exitCode: 0, stdout: '', stderr: '' };
+			}),
+		},
+	};
+
+	return { workspace, writes };
+}
+
+describe('loadPrebakedWorkspaceBundle', () => {
+	const manifestPath = `${ROOT}/bundle/.manifest.json`;
+	const bundle = {
+		rootDir: `${ROOT}/bundle`,
+		files: new Map([[`${ROOT}/bundle/file.txt`, 'content\n']]),
+		contentHash: 'abc123',
+	};
+
+	it('returns the bundle when the manifest hash matches', async () => {
+		const { workspace } = createSandboxWorkspace(
+			new Map([
+				[
+					manifestPath,
+					stringifyWorkspaceJson({ schemaVersion: 1, contentHash: bundle.contentHash }),
+				],
+			]),
+		);
+
+		const result = await loadPrebakedWorkspaceBundle({
+			workspace,
+			manifestPath,
+			expectedHash: bundle.contentHash,
+			hashField: 'contentHash',
+			schemaVersion: 1,
+			resourceLabel: 'Test bundle file',
+			invalidManifestLogMessage: 'invalid',
+			staleManifestLogMessage: 'stale',
+			staleManifestLogKeys: { expected: 'expectedHash', actual: 'actualHash' },
+			successLogMessage: 'success',
+			successLogContext: () => ({ root: ROOT }),
+			buildBundle: () => bundle,
+		});
+
+		expect(result).toBe(bundle);
+	});
+
+	it('returns undefined when the manifest hash is stale', async () => {
+		const { workspace } = createSandboxWorkspace(
+			new Map([[manifestPath, stringifyWorkspaceJson({ schemaVersion: 1, contentHash: 'stale' })]]),
+		);
+
+		const result = await loadPrebakedWorkspaceBundle({
+			workspace,
+			manifestPath,
+			expectedHash: bundle.contentHash,
+			hashField: 'contentHash',
+			schemaVersion: 1,
+			resourceLabel: 'Test bundle file',
+			invalidManifestLogMessage: 'invalid',
+			staleManifestLogMessage: 'stale',
+			staleManifestLogKeys: { expected: 'expectedHash', actual: 'actualHash' },
+			successLogMessage: 'success',
+			successLogContext: () => ({ root: ROOT }),
+			buildBundle: () => bundle,
+		});
+
+		expect(result).toBeUndefined();
+	});
+});
+
+describe('materializeWorkspaceBundle', () => {
+	const manifestPath = `${ROOT}/bundle/.manifest.json`;
+	const bundle = {
+		rootDir: `${ROOT}/bundle`,
+		manifestPath,
+		files: new Map([
+			[`${ROOT}/bundle/file.txt`, 'content\n'],
+			[manifestPath, stringifyWorkspaceJson({ schemaVersion: 1, contentHash: 'abc123' })],
+		]),
+		contentHash: 'abc123',
+	};
+
+	it('writes files when no prebaked manifest exists', async () => {
+		const { workspace, writes } = createSandboxWorkspace(new Map());
+
+		const result = await materializeWorkspaceBundle({
+			workspace,
+			resourceLabel: 'Test bundle file',
+			loadPrebaked: async () => await Promise.resolve(undefined),
+			buildBundle: () => bundle,
+			materializedLogMessage: 'materialized',
+			materializedLogContext: () => ({ root: ROOT }),
+		});
+
+		expect(result).toBe(bundle);
+		expect(writes.has(manifestPath)).toBe(true);
+	});
+
+	it('skips writes when a valid prebaked manifest exists', async () => {
+		const { workspace, writes } = createSandboxWorkspace(
+			new Map([[manifestPath, bundle.files.get(manifestPath) ?? '']]),
+		);
+
+		const result = await materializeWorkspaceBundle({
+			workspace,
+			resourceLabel: 'Test bundle file',
+			loadPrebaked: async () =>
+				await loadPrebakedWorkspaceBundle({
+					workspace,
+					manifestPath,
+					expectedHash: bundle.contentHash,
+					hashField: 'contentHash',
+					schemaVersion: 1,
+					resourceLabel: 'Test bundle file',
+					invalidManifestLogMessage: 'invalid',
+					staleManifestLogMessage: 'stale',
+					staleManifestLogKeys: { expected: 'expectedHash', actual: 'actualHash' },
+					successLogMessage: 'success',
+					successLogContext: () => ({ root: ROOT }),
+					buildBundle: () => bundle,
+				}),
+			buildBundle: () => bundle,
+			materializedLogMessage: 'materialized',
+			materializedLogContext: () => ({ root: ROOT }),
+		});
+
+		expect(result).toBe(bundle);
+		expect(writes.size).toBe(0);
+	});
+});

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/prebaked-workspace-bundle.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/prebaked-workspace-bundle.test.ts
@@ -43,9 +43,10 @@ function createSandboxWorkspace(files: Map<string, string>): {
 
 describe('loadPrebakedWorkspaceBundle', () => {
 	const manifestPath = `${ROOT}/bundle/.manifest.json`;
+	const filePath = `${ROOT}/bundle/file.txt`;
 	const bundle = {
 		rootDir: `${ROOT}/bundle`,
-		files: new Map([[`${ROOT}/bundle/file.txt`, 'content\n']]),
+		files: new Map([[filePath, 'content\n']]),
 		contentHash: 'abc123',
 	};
 
@@ -56,6 +57,7 @@ describe('loadPrebakedWorkspaceBundle', () => {
 					manifestPath,
 					stringifyWorkspaceJson({ schemaVersion: 1, contentHash: bundle.contentHash }),
 				],
+				[filePath, 'content\n'],
 			]),
 		);
 
@@ -99,15 +101,44 @@ describe('loadPrebakedWorkspaceBundle', () => {
 
 		expect(result).toBeUndefined();
 	});
+
+	it('returns undefined when the manifest hash matches but a payload file is missing', async () => {
+		const { workspace } = createSandboxWorkspace(
+			new Map([
+				[
+					manifestPath,
+					stringifyWorkspaceJson({ schemaVersion: 1, contentHash: bundle.contentHash }),
+				],
+			]),
+		);
+
+		const result = await loadPrebakedWorkspaceBundle({
+			workspace,
+			manifestPath,
+			expectedHash: bundle.contentHash,
+			hashField: 'contentHash',
+			schemaVersion: 1,
+			resourceLabel: 'Test bundle file',
+			invalidManifestLogMessage: 'invalid',
+			staleManifestLogMessage: 'stale',
+			staleManifestLogKeys: { expected: 'expectedHash', actual: 'actualHash' },
+			successLogMessage: 'success',
+			successLogContext: () => ({ root: ROOT }),
+			buildBundle: () => bundle,
+		});
+
+		expect(result).toBeUndefined();
+	});
 });
 
 describe('materializeWorkspaceBundle', () => {
 	const manifestPath = `${ROOT}/bundle/.manifest.json`;
+	const filePath = `${ROOT}/bundle/file.txt`;
 	const bundle = {
 		rootDir: `${ROOT}/bundle`,
 		manifestPath,
 		files: new Map([
-			[`${ROOT}/bundle/file.txt`, 'content\n'],
+			[filePath, 'content\n'],
 			[manifestPath, stringifyWorkspaceJson({ schemaVersion: 1, contentHash: 'abc123' })],
 		]),
 		contentHash: 'abc123',
@@ -129,9 +160,39 @@ describe('materializeWorkspaceBundle', () => {
 		expect(writes.has(manifestPath)).toBe(true);
 	});
 
+	it('writes manifest after payload files', async () => {
+		const writeOrder: string[] = [];
+		const writes = new Map<string, string>();
+		const workspace: SandboxWorkspace = {
+			filesystem: {
+				provider: 'local',
+				writeFile: jest.fn(async (path: string, content: string | Buffer) => {
+					writeOrder.push(path);
+					writes.set(path, Buffer.isBuffer(content) ? content.toString('utf-8') : content);
+					await Promise.resolve();
+				}),
+				mkdir: jest.fn(async () => await Promise.resolve()),
+			},
+		};
+
+		await materializeWorkspaceBundle({
+			workspace,
+			resourceLabel: 'Test bundle file',
+			loadPrebaked: async () => await Promise.resolve(undefined),
+			buildBundle: () => bundle,
+			materializedLogMessage: 'materialized',
+			materializedLogContext: () => ({ root: ROOT }),
+		});
+
+		expect(writeOrder.at(-1)).toBe(manifestPath);
+	});
+
 	it('skips writes when a valid prebaked manifest exists', async () => {
 		const { workspace, writes } = createSandboxWorkspace(
-			new Map([[manifestPath, bundle.files.get(manifestPath) ?? '']]),
+			new Map([
+				[manifestPath, bundle.files.get(manifestPath) ?? ''],
+				[filePath, 'content\n'],
+			]),
 		);
 
 		const result = await materializeWorkspaceBundle({

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/prebaked-workspace-bundle.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/prebaked-workspace-bundle.test.ts
@@ -17,20 +17,23 @@ function createSandboxWorkspace(files: Map<string, string>): {
 			provider: 'local',
 			writeFile: jest.fn(async (path: string, content: string | Buffer) => {
 				writes.set(path, Buffer.isBuffer(content) ? content.toString('utf-8') : content);
+				await Promise.resolve();
 			}),
-			mkdir: jest.fn(async () => {}),
+			mkdir: jest.fn(async () => await Promise.resolve()),
 		},
 		sandbox: {
 			executeCommand: jest.fn(async (command: string) => {
 				const readMatch = /^cat '([^']+)' 2>\/dev\/null$/.exec(command);
 				if (readMatch) {
 					const content = files.get(readMatch[1]);
-					return content === undefined
-						? { exitCode: 1, stdout: '', stderr: 'missing' }
-						: { exitCode: 0, stdout: content, stderr: '' };
+					return await Promise.resolve(
+						content === undefined
+							? { exitCode: 1, stdout: '', stderr: 'missing' }
+							: { exitCode: 0, stdout: content, stderr: '' },
+					);
 				}
 
-				return { exitCode: 0, stdout: '', stderr: '' };
+				return await Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
 			}),
 		},
 	};

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/snapshot-manager.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/snapshot-manager.test.ts
@@ -41,7 +41,7 @@ import {
 import type { Logger } from '../../logger';
 import { SnapshotManager } from '../snapshot-manager';
 
-const SNAPSHOT_NAME_PATTERN = /^n8n\/instance-ai:1\.123\.0-[a-f0-9]{12}$/;
+const SNAPSHOT_NAME_PATTERN = /^n8n\/instance-ai:1\.123\.0-[a-f0-9]{12}-[a-f0-9]{12}$/;
 const SKILLS_HASH_A = 'aaaaaaaaaaaa';
 const SKILLS_HASH_B = 'bbbbbbbbbbbb';
 
@@ -111,6 +111,13 @@ function makeFakeDaytona(): FakeDaytona {
 	};
 }
 
+async function knowledgeBaseHash(): Promise<string> {
+	const { buildKnowledgeBaseWorkspaceBundle } = await import(
+		'../../knowledge-base/materialize-knowledge-base'
+	);
+	return buildKnowledgeBaseWorkspaceBundle({ root: '/home/daytona/workspace' }).contentHash;
+}
+
 describe('SnapshotManager.ensureImage', () => {
 	it('bakes runtime skill files and manifest into the Daytona image descriptor', async () => {
 		const manager = new SnapshotManager(undefined, NOOP_LOGGER, '1.123.0');
@@ -125,6 +132,13 @@ describe('SnapshotManager.ensureImage', () => {
 		);
 		expect(image.dockerfile).toContain('/home/daytona/workspace/skills/registry.json');
 		expect(image.dockerfile).toContain('/home/daytona/workspace/skills/.manifest.json');
+		expect(image.dockerfile).toContain(
+			'/home/daytona/workspace/knowledge-base/best-practices/scheduling.md',
+		);
+		expect(image.dockerfile).toContain(
+			'/home/daytona/workspace/knowledge-base/best-practices/index.json',
+		);
+		expect(image.dockerfile).toContain('/home/daytona/workspace/knowledge-base/.manifest.json');
 	});
 
 	it('changes the snapshot suffix when the runtime skills hash changes', async () => {
@@ -152,8 +166,8 @@ describe('SnapshotManager.ensureImage', () => {
 
 		expect(snapshotA).toMatch(SNAPSHOT_NAME_PATTERN);
 		expect(snapshotB).toMatch(SNAPSHOT_NAME_PATTERN);
-		expect(snapshotA).toBe(`n8n/instance-ai:1.123.0-${SKILLS_HASH_A}`);
-		expect(snapshotB).toBe(`n8n/instance-ai:1.123.0-${SKILLS_HASH_B}`);
+		expect(snapshotA).toBe(`n8n/instance-ai:1.123.0-${SKILLS_HASH_A}-${await knowledgeBaseHash()}`);
+		expect(snapshotB).toBe(`n8n/instance-ai:1.123.0-${SKILLS_HASH_B}-${await knowledgeBaseHash()}`);
 		expect(snapshotA).not.toBe(snapshotB);
 	});
 
@@ -180,7 +194,7 @@ describe('SnapshotManager.ensureImage', () => {
 		const snapshotA = await managerA.createSnapshot(daytonaA as never);
 		const snapshotB = await managerB.createSnapshot(daytonaB as never);
 
-		expect(snapshotA).toBe(`n8n/instance-ai:1.123.0-${SKILLS_HASH_A}`);
+		expect(snapshotA).toBe(`n8n/instance-ai:1.123.0-${SKILLS_HASH_A}-${await knowledgeBaseHash()}`);
 		expect(snapshotB).toBe(snapshotA);
 		expect(daytonaA.snapshot.create.mock.calls[0][0].image.dockerfile).toContain(
 			'FROM daytonaio/sandbox:0.5.0',

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/workspace-file-content.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/workspace-file-content.test.ts
@@ -1,0 +1,19 @@
+import { stringifyWorkspaceJson, withTrailingNewline } from '../workspace-file-content';
+
+describe('withTrailingNewline', () => {
+	it('appends a newline when missing', () => {
+		expect(withTrailingNewline('hello')).toBe('hello\n');
+	});
+
+	it('preserves an existing trailing newline', () => {
+		expect(withTrailingNewline('hello\n')).toBe('hello\n');
+	});
+});
+
+describe('stringifyWorkspaceJson', () => {
+	it('pretty-prints JSON with a trailing newline', () => {
+		expect(stringifyWorkspaceJson({ schemaVersion: 1, contentHash: 'abc' })).toBe(
+			'{\n  "schemaVersion": 1,\n  "contentHash": "abc"\n}\n',
+		);
+	});
+});

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/workspace-files.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/workspace-files.test.ts
@@ -1,0 +1,71 @@
+import type { WorkspaceFileTarget } from '../workspace-files';
+import { readWorkspaceFile, writeWorkspaceFile, writeWorkspaceFileMap } from '../workspace-files';
+
+function createWorkspaceTarget(files: Map<string, string>): {
+	target: WorkspaceFileTarget;
+	writes: Map<string, string>;
+} {
+	const writes = new Map<string, string>();
+	const target: WorkspaceFileTarget = {
+		filesystem: {
+			readFile: jest.fn(async (path: string) => {
+				const content = files.get(path);
+				if (content === undefined) throw new Error('missing');
+				return content;
+			}),
+			writeFile: jest.fn(async (path: string, content: string | Buffer) => {
+				writes.set(path, Buffer.isBuffer(content) ? content.toString('utf-8') : content);
+			}),
+		},
+		sandbox: {
+			executeCommand: jest.fn(async (command: string) => {
+				const readMatch = /^cat '([^']+)' 2>\/dev\/null$/.exec(command);
+				if (readMatch) {
+					const content = files.get(readMatch[1]);
+					return content === undefined
+						? { exitCode: 1, stdout: '', stderr: 'missing' }
+						: { exitCode: 0, stdout: content, stderr: '' };
+				}
+
+				return { exitCode: 0, stdout: '', stderr: '' };
+			}),
+		},
+	};
+
+	return { target, writes };
+}
+
+describe('workspace-files', () => {
+	it('reads via filesystem when available', async () => {
+		const { target } = createWorkspaceTarget(new Map([['/tmp/manifest.json', '{"ok":true}']]));
+
+		await expect(readWorkspaceFile(target, '/tmp/manifest.json')).resolves.toBe('{"ok":true}');
+		expect(target.sandbox?.executeCommand).not.toHaveBeenCalled();
+	});
+
+	it('reads via sandbox commands when no filesystem reader is available', async () => {
+		const { target } = createWorkspaceTarget(new Map([['/tmp/manifest.json', '{"ok":true}']]));
+		target.filesystem = {
+			writeFile: jest.fn(async () => {}),
+		};
+
+		await expect(readWorkspaceFile(target, '/tmp/manifest.json')).resolves.toBe('{"ok":true}');
+	});
+
+	it('writes via filesystem and supports batch writes', async () => {
+		const { target, writes } = createWorkspaceTarget(new Map());
+
+		await writeWorkspaceFile(target, '/tmp/a.txt', 'alpha');
+		await writeWorkspaceFileMap(
+			target,
+			new Map([
+				['/tmp/b.txt', 'beta'],
+				['/tmp/c.txt', 'gamma'],
+			]),
+		);
+
+		expect(writes.get('/tmp/a.txt')).toBe('alpha');
+		expect(writes.get('/tmp/b.txt')).toBe('beta');
+		expect(writes.get('/tmp/c.txt')).toBe('gamma');
+	});
+});

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/workspace-files.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/workspace-files.test.ts
@@ -11,10 +11,11 @@ function createWorkspaceTarget(files: Map<string, string>): {
 			readFile: jest.fn(async (path: string) => {
 				const content = files.get(path);
 				if (content === undefined) throw new Error('missing');
-				return content;
+				return await Promise.resolve(content);
 			}),
 			writeFile: jest.fn(async (path: string, content: string | Buffer) => {
 				writes.set(path, Buffer.isBuffer(content) ? content.toString('utf-8') : content);
+				await Promise.resolve();
 			}),
 		},
 		sandbox: {
@@ -22,12 +23,14 @@ function createWorkspaceTarget(files: Map<string, string>): {
 				const readMatch = /^cat '([^']+)' 2>\/dev\/null$/.exec(command);
 				if (readMatch) {
 					const content = files.get(readMatch[1]);
-					return content === undefined
-						? { exitCode: 1, stdout: '', stderr: 'missing' }
-						: { exitCode: 0, stdout: content, stderr: '' };
+					return await Promise.resolve(
+						content === undefined
+							? { exitCode: 1, stdout: '', stderr: 'missing' }
+							: { exitCode: 0, stdout: content, stderr: '' },
+					);
 				}
 
-				return { exitCode: 0, stdout: '', stderr: '' };
+				return await Promise.resolve({ exitCode: 0, stdout: '', stderr: '' });
 			}),
 		},
 	};

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/workspace-manifest.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/workspace-manifest.test.ts
@@ -1,0 +1,43 @@
+import { parseVersionedWorkspaceManifest } from '../workspace-manifest';
+
+describe('parseVersionedWorkspaceManifest', () => {
+	it('parses a valid manifest', () => {
+		expect(
+			parseVersionedWorkspaceManifest(JSON.stringify({ schemaVersion: 1, contentHash: 'abc123' }), {
+				schemaVersion: 1,
+				hashField: 'contentHash',
+			}),
+		).toEqual({
+			schemaVersion: 1,
+			hashField: 'contentHash',
+			hash: 'abc123',
+		});
+	});
+
+	it('returns null for invalid JSON', () => {
+		expect(
+			parseVersionedWorkspaceManifest('not-json', {
+				schemaVersion: 1,
+				hashField: 'contentHash',
+			}),
+		).toBeNull();
+	});
+
+	it('returns null for schema version mismatch', () => {
+		expect(
+			parseVersionedWorkspaceManifest(JSON.stringify({ schemaVersion: 2, contentHash: 'abc' }), {
+				schemaVersion: 1,
+				hashField: 'contentHash',
+			}),
+		).toBeNull();
+	});
+
+	it('returns null for empty hash values', () => {
+		expect(
+			parseVersionedWorkspaceManifest(JSON.stringify({ schemaVersion: 1, skillsHash: '' }), {
+				schemaVersion: 1,
+				hashField: 'skillsHash',
+			}),
+		).toBeNull();
+	});
+});

--- a/packages/@n8n/instance-ai/src/workspace/compute-workspace-content-hash.ts
+++ b/packages/@n8n/instance-ai/src/workspace/compute-workspace-content-hash.ts
@@ -1,0 +1,15 @@
+import { createHash } from 'node:crypto';
+
+/** Stable 12-char hash for a workspace file bundle (path + content, sorted by path). */
+export function computeWorkspaceContentHash(files: Map<string, string>): string {
+	const hash = createHash('sha256');
+	for (const [path, content] of Array.from(files.entries()).sort(([a], [b]) =>
+		a.localeCompare(b),
+	)) {
+		hash.update(path);
+		hash.update('\0');
+		hash.update(content);
+		hash.update('\0');
+	}
+	return hash.digest('hex').slice(0, 12);
+}

--- a/packages/@n8n/instance-ai/src/workspace/prebaked-workspace-bundle.ts
+++ b/packages/@n8n/instance-ai/src/workspace/prebaked-workspace-bundle.ts
@@ -1,10 +1,10 @@
 import type { Logger } from '../logger';
-import { parseVersionedWorkspaceManifest } from './workspace-manifest';
 import {
 	readWorkspaceFile,
 	writeWorkspaceFileMap,
 	type WorkspaceFileTarget,
 } from './workspace-files';
+import { parseVersionedWorkspaceManifest } from './workspace-manifest';
 
 export interface LoadPrebakedWorkspaceBundleOptions<TBundle> {
 	workspace: WorkspaceFileTarget;

--- a/packages/@n8n/instance-ai/src/workspace/prebaked-workspace-bundle.ts
+++ b/packages/@n8n/instance-ai/src/workspace/prebaked-workspace-bundle.ts
@@ -1,0 +1,90 @@
+import type { Logger } from '../logger';
+import { parseVersionedWorkspaceManifest } from './workspace-manifest';
+import {
+	readWorkspaceFile,
+	writeWorkspaceFileMap,
+	type WorkspaceFileTarget,
+} from './workspace-files';
+
+export interface LoadPrebakedWorkspaceBundleOptions<TBundle> {
+	workspace: WorkspaceFileTarget;
+	manifestPath: string;
+	expectedHash: string;
+	hashField: string;
+	schemaVersion: number;
+	resourceLabel: string;
+	logger?: Logger;
+	invalidManifestLogMessage: string;
+	staleManifestLogMessage: string;
+	staleManifestLogKeys: {
+		expected: string;
+		actual: string;
+	};
+	successLogMessage: string;
+	successLogContext: (bundle: TBundle) => Record<string, unknown>;
+	buildBundle: () => Promise<TBundle | undefined> | TBundle | undefined;
+}
+
+/** Reuse a workspace bundle when its manifest hash matches the expected value. */
+export async function loadPrebakedWorkspaceBundle<TBundle>(
+	options: LoadPrebakedWorkspaceBundleOptions<TBundle>,
+): Promise<TBundle | undefined> {
+	const manifestRaw = await readWorkspaceFile(options.workspace, options.manifestPath, {
+		logger: options.logger,
+		resourceLabel: options.resourceLabel,
+	});
+	if (!manifestRaw) return undefined;
+
+	const manifest = parseVersionedWorkspaceManifest(manifestRaw, {
+		schemaVersion: options.schemaVersion,
+		hashField: options.hashField,
+	});
+	if (!manifest) {
+		options.logger?.debug(options.invalidManifestLogMessage, {
+			manifestPath: options.manifestPath,
+		});
+		return undefined;
+	}
+
+	if (manifest.hash !== options.expectedHash) {
+		options.logger?.debug(options.staleManifestLogMessage, {
+			manifestPath: options.manifestPath,
+			[options.staleManifestLogKeys.expected]: options.expectedHash,
+			[options.staleManifestLogKeys.actual]: manifest.hash,
+		});
+		return undefined;
+	}
+
+	const bundle = await options.buildBundle();
+	if (!bundle) return undefined;
+
+	options.logger?.debug(options.successLogMessage, options.successLogContext(bundle));
+	return bundle;
+}
+
+export interface MaterializeWorkspaceBundleOptions<TBundle extends { files: Map<string, string> }> {
+	workspace: WorkspaceFileTarget;
+	resourceLabel: string;
+	logger?: Logger;
+	loadPrebaked: () => Promise<TBundle | undefined>;
+	buildBundle: () => Promise<TBundle> | TBundle;
+	materializedLogMessage: string;
+	materializedLogContext: (bundle: TBundle) => Record<string, unknown>;
+}
+
+/** Materialize a workspace bundle, skipping writes when a valid prebaked manifest exists. */
+export async function materializeWorkspaceBundle<TBundle extends { files: Map<string, string> }>(
+	options: MaterializeWorkspaceBundleOptions<TBundle>,
+): Promise<TBundle> {
+	const prebaked = await options.loadPrebaked();
+	if (prebaked) return prebaked;
+
+	const bundle = await options.buildBundle();
+	await writeWorkspaceFileMap(options.workspace, bundle.files, {
+		logger: options.logger,
+		resourceLabel: options.resourceLabel,
+	});
+
+	options.logger?.debug(options.materializedLogMessage, options.materializedLogContext(bundle));
+	return bundle;
+}

--- a/packages/@n8n/instance-ai/src/workspace/prebaked-workspace-bundle.ts
+++ b/packages/@n8n/instance-ai/src/workspace/prebaked-workspace-bundle.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '../logger';
 import {
 	readWorkspaceFile,
+	writeWorkspaceFile,
 	writeWorkspaceFileMap,
 	type WorkspaceFileTarget,
 } from './workspace-files';
@@ -26,7 +27,7 @@ export interface LoadPrebakedWorkspaceBundleOptions<TBundle> {
 }
 
 /** Reuse a workspace bundle when its manifest hash matches the expected value. */
-export async function loadPrebakedWorkspaceBundle<TBundle>(
+export async function loadPrebakedWorkspaceBundle<TBundle extends { files: Map<string, string> }>(
 	options: LoadPrebakedWorkspaceBundleOptions<TBundle>,
 ): Promise<TBundle | undefined> {
 	const manifestRaw = await readWorkspaceFile(options.workspace, options.manifestPath, {
@@ -58,11 +59,35 @@ export async function loadPrebakedWorkspaceBundle<TBundle>(
 	const bundle = await options.buildBundle();
 	if (!bundle) return undefined;
 
+	const payloadPaths = Array.from(bundle.files.keys()).filter(
+		(path) => path !== options.manifestPath,
+	);
+	const existenceChecks = await Promise.all(
+		payloadPaths.map(async (path) => ({
+			path,
+			exists:
+				(await readWorkspaceFile(options.workspace, path, {
+					logger: options.logger,
+					resourceLabel: options.resourceLabel,
+				})) !== null,
+		})),
+	);
+	const missingPath = existenceChecks.find((check) => !check.exists)?.path;
+	if (missingPath) {
+		options.logger?.debug('Ignoring incomplete prebaked workspace bundle', {
+			manifestPath: options.manifestPath,
+			missingPath,
+		});
+		return undefined;
+	}
+
 	options.logger?.debug(options.successLogMessage, options.successLogContext(bundle));
 	return bundle;
 }
 
-export interface MaterializeWorkspaceBundleOptions<TBundle extends { files: Map<string, string> }> {
+export interface MaterializeWorkspaceBundleOptions<
+	TBundle extends { files: Map<string, string>; manifestPath: string },
+> {
 	workspace: WorkspaceFileTarget;
 	resourceLabel: string;
 	logger?: Logger;
@@ -73,17 +98,28 @@ export interface MaterializeWorkspaceBundleOptions<TBundle extends { files: Map<
 }
 
 /** Materialize a workspace bundle, skipping writes when a valid prebaked manifest exists. */
-export async function materializeWorkspaceBundle<TBundle extends { files: Map<string, string> }>(
-	options: MaterializeWorkspaceBundleOptions<TBundle>,
-): Promise<TBundle> {
+export async function materializeWorkspaceBundle<
+	TBundle extends { files: Map<string, string>; manifestPath: string },
+>(options: MaterializeWorkspaceBundleOptions<TBundle>): Promise<TBundle> {
 	const prebaked = await options.loadPrebaked();
 	if (prebaked) return prebaked;
 
 	const bundle = await options.buildBundle();
-	await writeWorkspaceFileMap(options.workspace, bundle.files, {
+	const payloadFiles = new Map(bundle.files);
+	payloadFiles.delete(bundle.manifestPath);
+
+	await writeWorkspaceFileMap(options.workspace, payloadFiles, {
 		logger: options.logger,
 		resourceLabel: options.resourceLabel,
 	});
+
+	const manifestContent = bundle.files.get(bundle.manifestPath);
+	if (manifestContent !== undefined) {
+		await writeWorkspaceFile(options.workspace, bundle.manifestPath, manifestContent, {
+			logger: options.logger,
+			resourceLabel: options.resourceLabel,
+		});
+	}
 
 	options.logger?.debug(options.materializedLogMessage, options.materializedLogContext(bundle));
 	return bundle;

--- a/packages/@n8n/instance-ai/src/workspace/sandbox-fs.ts
+++ b/packages/@n8n/instance-ai/src/workspace/sandbox-fs.ts
@@ -15,18 +15,7 @@ interface SandboxCommandResult {
 	stderr: string;
 }
 
-export interface SandboxWorkspace {
-	filesystem?: {
-		provider?: string;
-		basePath?: string;
-		init?: () => Promise<void>;
-		writeFile: (
-			path: string,
-			content: string | Buffer,
-			options?: { recursive?: boolean },
-		) => Promise<void>;
-		mkdir: (path: string, options?: { recursive?: boolean }) => Promise<void>;
-	};
+interface SandboxCommandTarget {
 	sandbox?: {
 		provider?: string;
 		executeCommand?: (
@@ -43,6 +32,20 @@ export interface SandboxWorkspace {
 	};
 }
 
+export interface SandboxWorkspace extends SandboxCommandTarget {
+	filesystem?: {
+		provider?: string;
+		basePath?: string;
+		init?: () => Promise<void>;
+		writeFile: (
+			path: string,
+			content: string | Buffer,
+			options?: { recursive?: boolean },
+		) => Promise<void>;
+		mkdir: (path: string, options?: { recursive?: boolean }) => Promise<void>;
+	};
+}
+
 import { getTemplateTelemetrySession } from './template-telemetry';
 
 const BASE64_WRITE_CHUNK_SIZE = 32_000;
@@ -56,7 +59,7 @@ const BASE64_WRITE_CHUNK_SIZE = 32_000;
  * template-usage events. Failures in the observer never break the command.
  */
 export async function runInSandbox(
-	workspace: SandboxWorkspace,
+	workspace: SandboxCommandTarget,
 	command: string,
 	cwd?: string,
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
@@ -94,7 +97,7 @@ export async function runInSandbox(
  * Creates parent directories automatically.
  */
 export async function writeFileViaSandbox(
-	workspace: SandboxWorkspace,
+	workspace: SandboxCommandTarget,
 	filePath: string,
 	content: string | Buffer,
 ): Promise<void> {
@@ -140,7 +143,7 @@ export async function writeFileViaSandbox(
  * Returns null if the file doesn't exist.
  */
 export async function readFileViaSandbox(
-	workspace: SandboxWorkspace,
+	workspace: SandboxCommandTarget,
 	filePath: string,
 ): Promise<string | null> {
 	const result = await runInSandbox(workspace, `cat '${escapeSingleQuotes(filePath)}' 2>/dev/null`);

--- a/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
+++ b/packages/@n8n/instance-ai/src/workspace/sandbox-setup.ts
@@ -39,6 +39,7 @@ import {
 	type SandboxWorkspace,
 	writeFileViaSandbox,
 } from './sandbox-fs';
+import { materializeKnowledgeBaseIntoWorkspace } from '../knowledge-base/materialize-knowledge-base';
 
 const hostRequire = createRequire(__filename);
 const NOOP_LOGGER: Logger = {
@@ -57,6 +58,7 @@ type SandboxWorkspaceSetupStep =
 	| 'list-node-types'
 	| 'write-workspace-files'
 	| 'write-curated-examples'
+	| 'materialize-knowledge-base'
 	| 'install-dependencies'
 	| 'link-workspace-sdk'
 	| 'write-initialization-marker';
@@ -730,6 +732,13 @@ export async function setupSandboxWorkspace(
 				context.logger,
 			),
 	);
+	await setupStep('materialize-knowledge-base', async () => {
+		await materializeKnowledgeBaseIntoWorkspace({
+			workspace,
+			root,
+			logger: context.logger,
+		});
+	});
 
 	// npm install (must run after package.json is in place)
 	await setupStep('install-dependencies', async () => {

--- a/packages/@n8n/instance-ai/src/workspace/snapshot-manager.ts
+++ b/packages/@n8n/instance-ai/src/workspace/snapshot-manager.ts
@@ -1,7 +1,7 @@
 /**
  * Prepares and caches a Daytona Image descriptor with config files,
  * node_modules, and runtime skills pre-installed, and resolves a versioned
- * named snapshot (`n8n/instance-ai:<n8nVersion>-<runtimeSkillsHash>`) for sandbox
+ * named snapshot (`n8n/instance-ai:<n8nVersion>-<skillsHash>-<knowledgeBaseHash>`) for sandbox
  * creation.
  *
  * Two strategies for `ensureSnapshot`:
@@ -23,6 +23,10 @@ import type { RuntimeSkillSource } from '@n8n/agents';
 import { dirname as posixDirname } from 'node:path/posix';
 
 import { loadDaytona } from './lazy-daytona';
+import {
+	buildKnowledgeBaseWorkspaceBundle,
+	type KnowledgeBaseWorkspaceBundle,
+} from '../knowledge-base/materialize-knowledge-base';
 import type { ErrorReporter, Logger } from '../logger';
 import { PACKAGE_JSON, TSCONFIG_JSON, BUILD_MJS } from './sandbox-setup';
 import { buildRuntimeSkillWorkspaceBundle } from '../skills/materialize-runtime-skills';
@@ -37,6 +41,7 @@ export interface CreateSnapshotOptions {
 
 const DAYTONA_WORKSPACE_ROOT = '/home/daytona/workspace';
 const EMPTY_RUNTIME_SKILLS_HASH = '000000000000';
+const EMPTY_KNOWLEDGE_BASE_HASH = '000000000000';
 
 /** Base64-encode content for safe embedding in RUN commands (avoids newline/quote issues). */
 function b64(s: string): string {
@@ -45,6 +50,12 @@ function b64(s: string): string {
 
 function shellQuote(value: string): string {
 	return `'${value.replaceAll("'", "'\"'\"'")}'`;
+}
+
+function workspaceFilesToImageRunCommands(files: Map<string, string>): string[] {
+	return Array.from(files, ([filePath, content]) => {
+		return `mkdir -p ${shellQuote(posixDirname(filePath))} && echo '${b64(content)}' | base64 -d > ${shellQuote(filePath)}`;
+	});
 }
 
 function isAlreadyExistsError(error: unknown): error is TDaytonaError {
@@ -64,6 +75,8 @@ export class SnapshotManager {
 	private runtimeSkillBundlePromise: ReturnType<typeof buildRuntimeSkillWorkspaceBundle> | null =
 		null;
 
+	private knowledgeBaseBundleCache: KnowledgeBaseWorkspaceBundle | null = null;
+
 	constructor(
 		private readonly baseImage: string | undefined,
 		private readonly logger: Logger,
@@ -81,17 +94,16 @@ export class SnapshotManager {
 	private async prepareImage(): Promise<Image> {
 		const base = this.baseImage ?? 'daytonaio/sandbox:0.5.0';
 		const runtimeSkillBundle = await this.runtimeSkillBundle();
-		const runtimeSkillCommands =
-			runtimeSkillBundle === undefined
-				? []
-				: [...runtimeSkillBundle.files].map(([filePath, content]) => {
-						return `mkdir -p ${shellQuote(posixDirname(filePath))} && echo '${b64(content)}' | base64 -d > ${shellQuote(filePath)}`;
-					});
+		const knowledgeBaseBundle = this.knowledgeBaseBundle();
+		const bakedWorkspaceCommands = [
+			...(runtimeSkillBundle ? workspaceFilesToImageRunCommands(runtimeSkillBundle.files) : []),
+			...workspaceFilesToImageRunCommands(knowledgeBaseBundle.files),
+		];
 
 		const { Image } = loadDaytona();
 		let image = Image.base(base)
 			.runCommands(
-				`mkdir -p ${DAYTONA_WORKSPACE_ROOT}/src ${DAYTONA_WORKSPACE_ROOT}/chunks ${DAYTONA_WORKSPACE_ROOT}/node-types`,
+				`mkdir -p ${DAYTONA_WORKSPACE_ROOT}/src ${DAYTONA_WORKSPACE_ROOT}/chunks ${DAYTONA_WORKSPACE_ROOT}/node-types ${DAYTONA_WORKSPACE_ROOT}/knowledge-base/best-practices`,
 			)
 			.runCommands(
 				`echo '${b64(PACKAGE_JSON)}' | base64 -d > ${DAYTONA_WORKSPACE_ROOT}/package.json`,
@@ -99,8 +111,8 @@ export class SnapshotManager {
 				`echo '${b64(BUILD_MJS)}' | base64 -d > ${DAYTONA_WORKSPACE_ROOT}/build.mjs`,
 			);
 
-		if (runtimeSkillCommands.length > 0) {
-			image = image.runCommands(...runtimeSkillCommands);
+		if (bakedWorkspaceCommands.length > 0) {
+			image = image.runCommands(...bakedWorkspaceCommands);
 		}
 
 		image = image.runCommands(`cd ${DAYTONA_WORKSPACE_ROOT} && npm install --ignore-scripts`);
@@ -110,6 +122,8 @@ export class SnapshotManager {
 			dockerfileLength: image.dockerfile.length,
 			runtimeSkillsHash: runtimeSkillBundle?.skillsHash,
 			runtimeSkillFiles: runtimeSkillBundle?.files.size ?? 0,
+			knowledgeBaseHash: knowledgeBaseBundle.contentHash,
+			knowledgeBaseFiles: knowledgeBaseBundle.files.size,
 		});
 
 		return image;
@@ -182,7 +196,10 @@ export class SnapshotManager {
 	private async snapshotSuffix(): Promise<string> {
 		this.snapshotSuffixPromise ??= (async () => {
 			const runtimeSkillBundle = await this.runtimeSkillBundle();
-			return runtimeSkillBundle?.skillsHash ?? EMPTY_RUNTIME_SKILLS_HASH;
+			const knowledgeBaseBundle = this.knowledgeBaseBundle();
+			const skillsHash = runtimeSkillBundle?.skillsHash ?? EMPTY_RUNTIME_SKILLS_HASH;
+			const knowledgeBaseHash = knowledgeBaseBundle.contentHash ?? EMPTY_KNOWLEDGE_BASE_HASH;
+			return `${skillsHash}-${knowledgeBaseHash}`;
 		})();
 
 		return await this.snapshotSuffixPromise;
@@ -198,6 +215,14 @@ export class SnapshotManager {
 		return await this.runtimeSkillBundlePromise;
 	}
 
+	private knowledgeBaseBundle(): KnowledgeBaseWorkspaceBundle {
+		this.knowledgeBaseBundleCache ??= buildKnowledgeBaseWorkspaceBundle({
+			root: DAYTONA_WORKSPACE_ROOT,
+		});
+
+		return this.knowledgeBaseBundleCache;
+	}
+
 	private async snapshotName(): Promise<string> {
 		if (!this.n8nVersion) {
 			throw new Error('SnapshotManager: n8nVersion is required to derive a snapshot name');
@@ -211,5 +236,6 @@ export class SnapshotManager {
 		this.snapshotPromise = null;
 		this.snapshotSuffixPromise = null;
 		this.runtimeSkillBundlePromise = null;
+		this.knowledgeBaseBundleCache = null;
 	}
 }

--- a/packages/@n8n/instance-ai/src/workspace/workspace-file-content.ts
+++ b/packages/@n8n/instance-ai/src/workspace/workspace-file-content.ts
@@ -1,0 +1,9 @@
+/** Ensure workspace text files end with a trailing newline. */
+export function withTrailingNewline(content: string): string {
+	return content.endsWith('\n') ? content : `${content}\n`;
+}
+
+/** Pretty-print JSON for workspace files (always ends with a newline). */
+export function stringifyWorkspaceJson(value: unknown): string {
+	return `${JSON.stringify(value, null, 2)}\n`;
+}

--- a/packages/@n8n/instance-ai/src/workspace/workspace-files.ts
+++ b/packages/@n8n/instance-ai/src/workspace/workspace-files.ts
@@ -1,0 +1,117 @@
+import { formatErrorForLog } from '../error-formatting';
+import type { Logger } from '../logger';
+import { readFileViaSandbox, writeFileViaSandbox, type SandboxWorkspace } from './sandbox-fs';
+
+export interface WorkspaceFileTarget {
+	filesystem?: {
+		readFile?: (path: string, options?: { encoding?: 'utf-8' }) => Promise<string | Buffer>;
+		writeFile: (
+			path: string,
+			content: string | Buffer,
+			options?: { recursive?: boolean },
+		) => Promise<void>;
+	};
+	sandbox?: SandboxWorkspace['sandbox'];
+}
+
+export interface WorkspaceFileOptions {
+	logger?: Logger;
+	/** Used in log and error messages, e.g. "Knowledge base file". */
+	resourceLabel?: string;
+}
+
+function resourceLabel(options?: WorkspaceFileOptions): string {
+	return options?.resourceLabel ?? 'Workspace file';
+}
+
+function decodeWorkspaceFileContent(content: string | Buffer): string {
+	return Buffer.isBuffer(content) ? content.toString('utf-8') : content;
+}
+
+/**
+ * Read a UTF-8 workspace file. Tries the workspace filesystem when available,
+ * otherwise falls back to sandbox shell commands.
+ */
+export async function readWorkspaceFile(
+	workspace: WorkspaceFileTarget,
+	filePath: string,
+	options?: WorkspaceFileOptions,
+): Promise<string | null> {
+	const readFile = workspace.filesystem?.readFile;
+	if (readFile) {
+		try {
+			return decodeWorkspaceFileContent(await readFile(filePath, { encoding: 'utf-8' }));
+		} catch (error) {
+			options?.logger?.debug(`${resourceLabel(options)} filesystem read missed`, {
+				path: filePath,
+				error: formatErrorForLog(error),
+			});
+			return null;
+		}
+	}
+
+	if (!workspace.sandbox) return null;
+
+	try {
+		return await readFileViaSandbox(workspace, filePath);
+	} catch (error) {
+		options?.logger?.debug(`${resourceLabel(options)} command read missed`, {
+			path: filePath,
+			error: formatErrorForLog(error),
+		});
+		return null;
+	}
+}
+
+/**
+ * Write a UTF-8 workspace file. Tries the workspace filesystem first with a
+ * sandbox command fallback when the provider supports both.
+ */
+export async function writeWorkspaceFile(
+	workspace: WorkspaceFileTarget,
+	filePath: string,
+	content: string,
+	options?: WorkspaceFileOptions,
+): Promise<void> {
+	const label = resourceLabel(options);
+
+	if (workspace.filesystem) {
+		try {
+			await workspace.filesystem.writeFile(filePath, content, { recursive: true });
+			return;
+		} catch (error) {
+			try {
+				await writeFileViaSandbox(workspace, filePath, content);
+				options?.logger?.warn(`${label} filesystem write failed; used command fallback`, {
+					path: filePath,
+					error: formatErrorForLog(error),
+				});
+				return;
+			} catch (fallbackError) {
+				throw new Error(
+					`Failed to write ${label.toLowerCase()} "${filePath}": ${formatErrorForLog(error)}; command fallback failed: ${formatErrorForLog(fallbackError)}`,
+				);
+			}
+		}
+	}
+
+	try {
+		await writeFileViaSandbox(workspace, filePath, content);
+	} catch (error) {
+		throw new Error(
+			`Failed to write ${label.toLowerCase()} "${filePath}": ${formatErrorForLog(error)}`,
+		);
+	}
+}
+
+export async function writeWorkspaceFileMap(
+	workspace: WorkspaceFileTarget,
+	files: Map<string, string>,
+	options?: WorkspaceFileOptions,
+): Promise<void> {
+	await Promise.all(
+		Array.from(files, async ([filePath, content]) => {
+			await writeWorkspaceFile(workspace, filePath, content, options);
+		}),
+	);
+}

--- a/packages/@n8n/instance-ai/src/workspace/workspace-manifest.ts
+++ b/packages/@n8n/instance-ai/src/workspace/workspace-manifest.ts
@@ -1,0 +1,39 @@
+import { isRecord } from '../utils/stream-helpers';
+
+export const WORKSPACE_MANIFEST_FILE = '.manifest.json';
+
+export interface VersionedWorkspaceManifest<THashField extends string = string> {
+	schemaVersion: number;
+	hashField: THashField;
+	hash: string;
+}
+
+interface ParseVersionedWorkspaceManifestOptions<THashField extends string> {
+	schemaVersion: number;
+	hashField: THashField;
+}
+
+/** Parse a versioned workspace manifest and validate its hash field. */
+export function parseVersionedWorkspaceManifest<const THashField extends string>(
+	raw: string,
+	options: ParseVersionedWorkspaceManifestOptions<THashField>,
+): VersionedWorkspaceManifest<THashField> | null {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return null;
+	}
+
+	if (!isRecord(parsed)) return null;
+	if (parsed.schemaVersion !== options.schemaVersion) return null;
+
+	const hash = parsed[options.hashField];
+	if (typeof hash !== 'string' || hash.length === 0) return null;
+
+	return {
+		schemaVersion: options.schemaVersion,
+		hashField: options.hashField,
+		hash,
+	};
+}


### PR DESCRIPTION
## Summary

This is part 1 of the knowledge base for Instance AI. For this part, we add the following:

- Adds knowledge base to the base sandbox image
  - Getting the best practices from workflow-sdk into a packaged skills like folder structure
  - Coming up next will be templates and the likes
```
knowledge-base/
  best-practices/
    index.json          # index of all best practices
    {technique}.md      # one doc per best practice
  .manifest.json        # content hash for cache validation
```
- attempt to unify some of the work between skills and KB

Once we have workflow building as a skill (ref: https://github.com/n8n-io/n8n/pull/31412#pullrequestreview-4400397805), we then provide the tools to the orchestrator to lookup knowledge base

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
