### PR TITLE
fix(core): Insights page shows license paywall for licensed users

### DIFF
--- a/packages/frontend/editor-ui/public/static/posthog.init.js
+++ b/packages/frontend/editor-ui/public/static/posthog.init.js
@@ -27,7 +27,7 @@
 						return u.toString(1) + '.people (stub)';
 					},
 					o =
-						'capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag onFeatureFlags reloadFeatureFlags'.split(
+						'capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag onFeatureFlags reloadFeatureFlags group'.split(
 							' ',
 						),
 					n = 0;

--- a/packages/frontend/editor-ui/src/app/init.test.ts
+++ b/packages/frontend/editor-ui/src/app/init.test.ts
@@ -8,6 +8,7 @@ import { useSettingsStore } from '@/app/stores/settings.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { useSSOStore } from '@/features/settings/sso/sso.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
+import { usePostHog } from '@/app/stores/posthog.store';
 import { useVersionsStore } from '@/app/stores/versions.store';
 import { useBannersStore } from '@/features/shared/banners/banners.store';
 import type { Cloud, CurrentUserResponse } from '@n8n/rest-api-client';
@@ -189,6 +190,21 @@ describe('Init', () => {
 					oidc: false,
 				},
 			});
+		});
+
+		it('should still call getModuleSettings if postHogStore.init throws', async () => {
+			const postHogStore = mockedStore(usePostHog);
+			vi.spyOn(postHogStore, 'init').mockImplementation(() => {
+				throw new Error('PostHog init failed');
+			});
+
+			usersStore.registerLoginHook.mockImplementation(async (hook) => {
+				await hook(mock<CurrentUserResponse>({ id: 'userId', role: 'global:member' }));
+			});
+
+			await initializeCore();
+
+			expect(settingsStore.getModuleSettings).toHaveBeenCalled();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/init.ts
+++ b/packages/frontend/editor-ui/src/app/init.ts
@@ -265,7 +265,12 @@ function registerAuthenticationHooks() {
 			userId: user.id,
 			userRole: user.role,
 		});
-		postHogStore.init(user.featureFlags);
+		try {
+			postHogStore.init(user.featureFlags);
+		} catch (e) {
+			// don't let posthog failing prevent further function calls
+			console.error(e);
+		}
 		npsSurveyStore.setupNpsSurveyOnLogin(user.id, user.settings);
 		await settingsStore.getModuleSettings();
 		void bannersStore.loadDynamicBanners();


### PR DESCRIPTION
## Summary

Cloud users are reporting that the insights dashboard is showing a paywall notice.
When investigating that on my own cloud instance, I noticed that there is no http request to `GET /rest/module-settings`, which is the endpoint we fetch to set the state which controls whether the insights dashboard is visible or not.

The reason for this request not firing, is that posthog initialization is failing in the same scope before the code that calls this endpoint is executed.

See https://github.com/n8n-io/n8n/blob/master/packages/frontend/editor-ui/src/app/init.ts#L268-L270

This PR wraps posthog initialization in a try-catch block, so that the following functions will still be called.

Finally, https://github.com/n8n-io/n8n/pull/31406/commits/2d8f0648afa6a313827a1a4b17a60e061caf61a0 adds the `group` method to the posthog stub for the posthog init script, which fixes the `postHogStore.init` call.
Still, we should keep the try/catch block around it, as failing posthog initialization shouldn't affect the rest of the app.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/LIGO-658/regression-insights-paywall-shown-to-enterprise-accounts-after-upgrade


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
