### PR TITLE
fix(core): Coerce non-string node names in buildNodeIndex

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/submit-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/submit-workflow.tool.test.ts
@@ -438,6 +438,23 @@ describe('buildNodeIndex', () => {
 	it('returns an empty array when nodes is missing', () => {
 		expect(buildNodeIndex({ connections: {} } as unknown as WorkflowJSON)).toEqual([]);
 	});
+
+	it('coerces non-string node names to an empty string', () => {
+		const json = {
+			nodes: [
+				{ name: 123, type: 'x', position: [0, 0], parameters: {} },
+				{ type: 'y', position: [0, 0], parameters: {} },
+				{ name: null, type: 'z', position: [0, 0], parameters: {} },
+			],
+			connections: {},
+		} as unknown as WorkflowJSON;
+
+		expect(buildNodeIndex(json)).toEqual([
+			{ index: 0, name: '' },
+			{ index: 1, name: '' },
+			{ index: 2, name: '' },
+		]);
+	});
 });
 
 describe('buildErrorDetails', () => {

--- a/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/submit-workflow.tool.ts
@@ -116,7 +116,12 @@ export function extractStructureIssues(error: unknown): WorkflowStructureIssue[]
  * counting entries in its own SDK-builder code.
  */
 export function buildNodeIndex(json: WorkflowJSON): Array<{ index: number; name: string }> {
-	return (json.nodes ?? []).map((node, index) => ({ index, name: node.name ?? '' }));
+	// Defensively coerce: a malformed workflow may carry a non-string node name,
+	// which would otherwise violate the `z.string()` output schema downstream.
+	return (json.nodes ?? []).map((node, index) => ({
+		index,
+		name: typeof node.name === 'string' ? node.name : '',
+	}));
 }
 
 /**


### PR DESCRIPTION
## Summary

Followup to https://github.com/n8n-io/n8n/pull/31296, addressing leftover comment https://github.com/n8n-io/n8n/pull/31296#pullrequestreview-4388125931 from it - making it always produce a string name even if name contains something else.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
