### PR TITLE
Document Tuning Engines Instance AI endpoint

### DIFF
--- a/packages/@n8n/instance-ai/docs/configuration.md
+++ b/packages/@n8n/instance-ai/docs/configuration.md
@@ -189,6 +189,11 @@ N8N_INSTANCE_AI_GATEWAY_API_KEY=my-secret-key
 N8N_INSTANCE_AI_MODEL=custom/llama-3.1-70b
 N8N_INSTANCE_AI_MODEL_URL=http://localhost:1234/v1
 
+# With a governed OpenAI-compatible endpoint (e.g. Tuning Engines)
+N8N_INSTANCE_AI_MODEL=custom/gpt-4o
+N8N_INSTANCE_AI_MODEL_URL=https://api.tuningengines.com/v1
+N8N_INSTANCE_AI_MODEL_API_KEY=sk-te-your-inference-key
+
 # Full configuration with observational memory tuning
 N8N_INSTANCE_AI_MODEL=anthropic/claude-opus-4-7
 N8N_INSTANCE_AI_MCP_SERVERS="github=https://mcp.github.com/sse"


### PR DESCRIPTION
## Why

Instance AI already supports custom OpenAI-compatible endpoints through `N8N_INSTANCE_AI_MODEL_URL` and `N8N_INSTANCE_AI_MODEL_API_KEY`.

Tuning Engines fits that configuration path for teams that want n8n Instance AI to keep owning workflow generation and execution, while model calls go through a governed AI endpoint with tenant model access, policy checks, audit logs, traces, and usage/cost accounting.

## What changed

- Adds a small Tuning Engines example to the existing custom OpenAI-compatible endpoint configuration block.
- Uses placeholder env vars only; no secrets or internal provider details.
- Does not add a new provider, node, credential type, or runtime behavior.

## Validation

- Docs-only change.
- Checked the modified configuration block locally.
