### PR TITLE
fix(core): Display native web search results in agent session timeline (no-changelog)

### DIFF
--- a/packages/@n8n/agents/src/runtime/__tests__/stream.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/stream.test.ts
@@ -3,6 +3,7 @@ import type { TextStreamPart, ToolSet } from 'ai';
 import { convertChunk } from '../stream';
 
 type ToolCallChunk = Extract<TextStreamPart<ToolSet>, { type: 'tool-call' }>;
+type ToolResultChunk = Extract<TextStreamPart<ToolSet>, { type: 'tool-result' }>;
 
 describe('convertChunk — tool-call invalid/error handling', () => {
 	it('returns a tool-result with isError when c.invalid is true', () => {
@@ -76,5 +77,64 @@ describe('convertChunk — tool-call invalid/error handling', () => {
 
 		const result = convertChunk(chunk);
 		expect(result).toMatchObject({ type: 'tool-result', toolName: '', isError: true });
+	});
+});
+
+describe('convertChunk — tool-result output passthrough', () => {
+	it('passes a raw array output through verbatim (e.g. native web search results)', () => {
+		const output = [
+			{ title: 'n8n', url: 'https://n8n.io' },
+			{ title: 'Docs', url: 'https://docs.n8n.io' },
+		];
+		const chunk = {
+			type: 'tool-result',
+			toolCallId: 'tc-1',
+			toolName: 'anthropic.web_search_20250305',
+			input: { query: 'n8n' },
+			output,
+			providerExecuted: true,
+		} as unknown as ToolResultChunk;
+
+		expect(convertChunk(chunk)).toEqual({
+			type: 'tool-result',
+			toolCallId: 'tc-1',
+			toolName: 'anthropic.web_search_20250305',
+			output,
+		});
+	});
+
+	it('passes a raw object output through verbatim without unwrapping a coincidental "value" key', () => {
+		const output = { value: 42, unit: 'C' };
+		const chunk = {
+			type: 'tool-result',
+			toolCallId: 'tc-2',
+			toolName: 'get_temperature',
+			input: {},
+			output,
+		} as unknown as ToolResultChunk;
+
+		expect(convertChunk(chunk)).toEqual({
+			type: 'tool-result',
+			toolCallId: 'tc-2',
+			toolName: 'get_temperature',
+			output,
+		});
+	});
+
+	it('falls back to empty strings when toolCallId and toolName are absent', () => {
+		const chunk = {
+			type: 'tool-result',
+			toolCallId: undefined,
+			toolName: undefined,
+			input: {},
+			output: 'plain text result',
+		} as unknown as ToolResultChunk;
+
+		expect(convertChunk(chunk)).toEqual({
+			type: 'tool-result',
+			toolCallId: '',
+			toolName: '',
+			output: 'plain text result',
+		});
 	});
 });

--- a/packages/@n8n/agents/src/runtime/stream.ts
+++ b/packages/@n8n/agents/src/runtime/stream.ts
@@ -96,12 +96,16 @@ export function convertChunk(c: TextStreamPart<ToolSet>): StreamChunk | undefine
 		}
 
 		case 'tool-result':
+			// The fullStream emits the raw tool output here, not the
+			// `{ type, value }` ToolResultOutput wrapper used on the message
+			// side — so pass it through verbatim. Only provider-executed tools
+			// (e.g. native web search) reach this branch; local tool results are
+			// written directly by the runtime and never pass through convertChunk.
 			return {
 				type: 'tool-result',
 				toolCallId: c.toolCallId ?? '',
 				toolName: c.toolName ?? '',
-				// eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-				output: c.output && 'value' in c.output ? (c.output.value as JSONValue) : null,
+				output: c.output,
 			};
 
 		case 'error':


### PR DESCRIPTION
## Summary

Native web search (Anthropic / OpenAI) tool calls showed up in the agent session timeline, but their **results were always empty**. Brave / SearXNG web search was unaffected.

**Root cause:** native web search is a *provider-executed* tool — the model provider runs it server-side and the AI SDK surfaces its result only through the `fullStream`, which the runtime maps via `convertChunk` (`packages/@n8n/agents/src/runtime/stream.ts`). The `tool-result` case unwrapped `c.output.value`, but AI SDK v6 streams the **raw** tool output here (no `{ type, value }` wrapper — that shape only exists on the message-input side). So `'value' in c.output` was false and the output was recorded as `null`, leaving the timeline detail blank.

Locally-executed tools (Brave / SearXNG and every other tool) are never affected: they have no AI SDK `execute`, so the runtime writes their results directly and they bypass `convertChunk` entirely. Provider-executed results were already `null` before this change, so there is nothing for it to regress.

**Fix:** pass the streamed tool output through verbatim instead of unwrapping a non-existent `.value`.

## How to test

1. Configure an agent using native Anthropic or OpenAI web search.
2. Send a prompt that triggers a web search.
3. Open the agent's session timeline and select the web search step.
4. The step's output now shows the search results (previously empty). Brave / SearXNG continue to work as before.

Added unit tests in `stream.test.ts` covering raw `tool-result` passthrough (array output, object output without unwrapping a coincidental `value` key, and empty-string id/name fallbacks).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-189

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
