### PR TITLE
chore: Refresh E2E orchestration metrics from Currents

### DIFF
--- a/.github/test-metrics/playwright.json
+++ b/.github/test-metrics/playwright.json
@@ -1,811 +1,851 @@
 {
-  "updatedAt": "2026-04-23T08:33:49.040Z",
+  "updatedAt": "2026-05-30T21:09:56.531Z",
   "source": "currents",
   "projectId": "LRxcNt",
   "specs": {
-    "tests/e2e/projects/projects.spec.ts": {
-      "avgDuration": 145839,
-      "testCount": 7,
-      "flakyRate": 0.0312
-    },
     "tests/e2e/workflows/editor/canvas/actions.spec.ts": {
-      "avgDuration": 142139,
-      "testCount": 19,
-      "flakyRate": 0.1119
+      "avgDuration": 147589,
+      "testCount": 20,
+      "flakyRate": 0.0725
+    },
+    "tests/e2e/projects/projects.spec.ts": {
+      "avgDuration": 140795,
+      "testCount": 7,
+      "flakyRate": 0.0074
     },
     "tests/e2e/credentials/crud.spec.ts": {
-      "avgDuration": 132235,
+      "avgDuration": 135501,
       "testCount": 14,
-      "flakyRate": 0.004
+      "flakyRate": 0
     },
     "tests/e2e/workflows/list/workflows.spec.ts": {
-      "avgDuration": 121356,
+      "avgDuration": 123645,
       "testCount": 10,
-      "flakyRate": 0.0027
-    },
-    "tests/e2e/ai/langchain-agents.spec.ts": {
-      "avgDuration": 121124,
-      "testCount": 7,
-      "flakyRate": 0.0785
-    },
-    "tests/e2e/workflows/editor/code/code-node.spec.ts": {
-      "avgDuration": 111219,
-      "testCount": 12,
-      "flakyRate": 0.1577
-    },
-    "tests/e2e/workflows/editor/canvas/canvas-zoom.spec.ts": {
-      "avgDuration": 107017,
-      "testCount": 13,
-      "flakyRate": 0.0663
+      "flakyRate": 0.0015
     },
     "tests/e2e/workflows/editor/canvas/undo-redo.spec.ts": {
-      "avgDuration": 105543,
+      "avgDuration": 113108,
       "testCount": 14,
-      "flakyRate": 0.0026
+      "flakyRate": 0
     },
-    "tests/e2e/ai/assistant-basic.spec.ts": {
-      "avgDuration": 105036,
-      "testCount": 11,
-      "flakyRate": 0.0267
+    "tests/e2e/workflows/editor/code/code-node.spec.ts": {
+      "avgDuration": 106521,
+      "testCount": 12,
+      "flakyRate": 0.0206
     },
-    "tests/e2e/workflows/editor/ndv/ndv-core.spec.ts": {
-      "avgDuration": 102838,
-      "testCount": 14,
-      "flakyRate": 0.0186
-    },
-    "tests/e2e/workflows/editor/canvas/canvas-nodes.spec.ts": {
-      "avgDuration": 101219,
-      "testCount": 8,
-      "flakyRate": 0.1235
+    "tests/e2e/ai/langchain-agents.spec.ts": {
+      "avgDuration": 102809,
+      "testCount": 7,
+      "flakyRate": 0.0045
     },
     "tests/e2e/settings/personal/two-factor-authentication.spec.ts": {
-      "avgDuration": 99044,
+      "avgDuration": 102682,
       "testCount": 7,
-      "flakyRate": 0.0041
+      "flakyRate": 0.0015
     },
-    "tests/e2e/workflows/editor/ndv/ndv-data-display.spec.ts": {
-      "avgDuration": 98333,
-      "testCount": 11,
-      "flakyRate": 0.0957
-    },
-    "tests/e2e/ai/hitl-for-tools.spec.ts": {
-      "avgDuration": 97973,
-      "testCount": 2,
-      "flakyRate": 0.5374
+    "tests/e2e/workflows/editor/canvas/canvas-zoom.spec.ts": {
+      "avgDuration": 101807,
+      "testCount": 13,
+      "flakyRate": 0.0193
     },
     "tests/e2e/data-tables/tables.spec.ts": {
-      "avgDuration": 97875,
+      "avgDuration": 98164,
       "testCount": 7,
       "flakyRate": 0
+    },
+    "tests/e2e/workflows/editor/ndv/ndv-core.spec.ts": {
+      "avgDuration": 97676,
+      "testCount": 14,
+      "flakyRate": 0.0015
     },
     "tests/e2e/workflows/editor/code/editors.spec.ts": {
-      "avgDuration": 94275,
-      "testCount": 11,
-      "flakyRate": 0.0161
-    },
-    "tests/e2e/ai/builder-setup-wizard.spec.ts": {
-      "avgDuration": 86408,
-      "testCount": 9,
-      "flakyRate": 0.012
-    },
-    "tests/e2e/projects/folders-operations.spec.ts": {
-      "avgDuration": 85831,
-      "testCount": 14,
-      "flakyRate": 0
-    },
-    "tests/e2e/data-tables/details.spec.ts": {
-      "avgDuration": 85096,
+      "avgDuration": 97261,
       "testCount": 11,
       "flakyRate": 0
-    },
-    "tests/e2e/nodes/webhook.spec.ts": {
-      "avgDuration": 82010,
-      "testCount": 9,
-      "flakyRate": 0
-    },
-    "tests/e2e/instance-ai/instance-ai-workflow-setup.spec.ts": {
-      "avgDuration": 79197,
-      "testCount": 1,
-      "flakyRate": 0.2011
-    },
-    "tests/e2e/workflows/executions/list.spec.ts": {
-      "avgDuration": 76906,
-      "testCount": 11,
-      "flakyRate": 0.0991
-    },
-    "tests/e2e/auth/oidc.spec.ts": {
-      "avgDuration": 76202,
-      "testCount": 1,
-      "flakyRate": 0.0471
-    },
-    "tests/e2e/ai/langchain-chains.spec.ts": {
-      "avgDuration": 75974,
-      "testCount": 4,
-      "flakyRate": 0.0672
-    },
-    "tests/e2e/workflows/editor/ndv/pinning.spec.ts": {
-      "avgDuration": 75639,
-      "testCount": 10,
-      "flakyRate": 0.2051
-    },
-    "tests/e2e/sharing/credential-visibility.spec.ts": {
-      "avgDuration": 75559,
-      "testCount": 5,
-      "flakyRate": 0.0013
-    },
-    "tests/e2e/workflows/templates/credentials-setup.spec.ts": {
-      "avgDuration": 75433,
-      "testCount": 8,
-      "flakyRate": 0.0054
-    },
-    "tests/e2e/workflows/editor/execution/execution.spec.ts": {
-      "avgDuration": 71731,
-      "testCount": 14,
-      "flakyRate": 0.0559
-    },
-    "tests/e2e/workflows/editor/ndv/ndv-parameters.spec.ts": {
-      "avgDuration": 71468,
-      "testCount": 9,
-      "flakyRate": 0.0146
-    },
-    "tests/e2e/workflows/editor/expressions/mapping.spec.ts": {
-      "avgDuration": 70224,
-      "testCount": 10,
-      "flakyRate": 0.1191
-    },
-    "tests/e2e/workflows/editor/subworkflows/extraction.spec.ts": {
-      "avgDuration": 69893,
-      "testCount": 3,
-      "flakyRate": 0.0027
-    },
-    "tests/e2e/chat-hub/chat-hub-workflow-agent.spec.ts": {
-      "avgDuration": 65232,
-      "testCount": 2,
-      "flakyRate": 0.1237
-    },
-    "tests/e2e/building-blocks/node-details-configuration.spec.ts": {
-      "avgDuration": 64730,
-      "testCount": 7,
-      "flakyRate": 0.0134
     },
     "tests/e2e/workflows/editor/execution/logs.spec.ts": {
-      "avgDuration": 63666,
+      "avgDuration": 97008,
       "testCount": 8,
-      "flakyRate": 0.0013
+      "flakyRate": 0.0672
     },
-    "tests/e2e/ai/assistant-credential-help.spec.ts": {
-      "avgDuration": 63432,
-      "testCount": 4,
-      "flakyRate": 0.0372
+    "tests/e2e/ai/assistant-basic.spec.ts": {
+      "avgDuration": 94686,
+      "testCount": 11,
+      "flakyRate": 0.003
+    },
+    "tests/e2e/ai/builder-setup-wizard.spec.ts": {
+      "avgDuration": 94290,
+      "testCount": 9,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/workflows/editor/canvas/canvas-nodes.spec.ts": {
+      "avgDuration": 90153,
+      "testCount": 8,
+      "flakyRate": 0.0447
+    },
+    "tests/e2e/workflows/editor/ndv/ndv-data-display.spec.ts": {
+      "avgDuration": 86872,
+      "testCount": 11,
+      "flakyRate": 0.003
+    },
+    "tests/e2e/data-tables/details.spec.ts": {
+      "avgDuration": 85776,
+      "testCount": 11,
+      "flakyRate": 0
+    },
+    "tests/e2e/projects/folders-operations.spec.ts": {
+      "avgDuration": 84269,
+      "testCount": 14,
+      "flakyRate": 0.0044
+    },
+    "tests/e2e/nodes/webhook.spec.ts": {
+      "avgDuration": 83651,
+      "testCount": 9,
+      "flakyRate": 0.0075
+    },
+    "tests/e2e/workflows/editor/ndv/ndv-parameters.spec.ts": {
+      "avgDuration": 81370,
+      "testCount": 9,
+      "flakyRate": 0.0651
+    },
+    "tests/e2e/workflows/editor/canvas/node-groups.spec.ts": {
+      "avgDuration": 80965,
+      "testCount": 13,
+      "flakyRate": 0.0064
+    },
+    "tests/e2e/workflows/executions/list.spec.ts": {
+      "avgDuration": 78344,
+      "testCount": 11,
+      "flakyRate": 0.0711
+    },
+    "tests/e2e/sharing/credential-visibility.spec.ts": {
+      "avgDuration": 77671,
+      "testCount": 5,
+      "flakyRate": 0.0045
+    },
+    "tests/e2e/workflows/templates/credentials-setup.spec.ts": {
+      "avgDuration": 76596,
+      "testCount": 8,
+      "flakyRate": 0.0045
     },
     "tests/e2e/projects/project-settings.spec.ts": {
-      "avgDuration": 61555,
+      "avgDuration": 74890,
+      "testCount": 10,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/instance-ai/instance-ai-sidebar.spec.ts": {
+      "avgDuration": 69144,
+      "testCount": 4,
+      "flakyRate": 0.1581
+    },
+    "tests/e2e/ai/langchain-chains.spec.ts": {
+      "avgDuration": 68598,
+      "testCount": 4,
+      "flakyRate": 0
+    },
+    "tests/e2e/ai/ai-2505-pdf-embed.spec.ts": {
+      "avgDuration": 65301,
+      "testCount": 1,
+      "flakyRate": 0.007
+    },
+    "tests/e2e/workflows/editor/ndv/pinning.spec.ts": {
+      "avgDuration": 64729,
+      "testCount": 10,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/ai/hitl-for-tools.spec.ts": {
+      "avgDuration": 63651,
+      "testCount": 2,
+      "flakyRate": 0.3423
+    },
+    "tests/e2e/building-blocks/canvas-actions.spec.ts": {
+      "avgDuration": 63214,
+      "testCount": 9,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/workflows/editor/viewer-permissions.spec.ts": {
+      "avgDuration": 62889,
+      "testCount": 3,
+      "flakyRate": 0.0178
+    },
+    "tests/e2e/workflows/editor/expressions/mapping.spec.ts": {
+      "avgDuration": 62666,
       "testCount": 10,
       "flakyRate": 0
     },
-    "tests/e2e/ai/assistant-code-help.spec.ts": {
-      "avgDuration": 60878,
-      "testCount": 2,
-      "flakyRate": 0.0625
+    "tests/e2e/workflows/editor/execution/execution.spec.ts": {
+      "avgDuration": 61908,
+      "testCount": 14,
+      "flakyRate": 0
     },
-    "tests/e2e/workflows/editor/viewer-permissions.spec.ts": {
-      "avgDuration": 59873,
-      "testCount": 3,
-      "flakyRate": 0.0068
-    },
-    "tests/e2e/workflows/executions/filter.spec.ts": {
-      "avgDuration": 59605,
-      "testCount": 2,
-      "flakyRate": 0.0054
-    },
-    "tests/e2e/workflows/editor/execution/debug.spec.ts": {
-      "avgDuration": 58599,
-      "testCount": 4,
-      "flakyRate": 0.1767
-    },
-    "tests/e2e/workflows/editor/ndv/paired-item.spec.ts": {
-      "avgDuration": 58414,
-      "testCount": 6,
-      "flakyRate": 0.0704
-    },
-    "tests/e2e/workflows/editor/expressions/modal.spec.ts": {
-      "avgDuration": 57432,
-      "testCount": 6,
-      "flakyRate": 0.0013
-    },
-    "tests/e2e/workflows/editor/routing.spec.ts": {
-      "avgDuration": 57184,
-      "testCount": 6,
-      "flakyRate": 0.0027
+    "tests/e2e/workflows/editor/workflow-actions/archive.spec.ts": {
+      "avgDuration": 57840,
+      "testCount": 9,
+      "flakyRate": 0.0119
     },
     "tests/e2e/ai/langchain-vectorstores.spec.ts": {
-      "avgDuration": 56315,
+      "avgDuration": 57456,
       "testCount": 2,
-      "flakyRate": 0.1151
+      "flakyRate": 0.0045
+    },
+    "tests/e2e/workflows/editor/expressions/modal.spec.ts": {
+      "avgDuration": 56975,
+      "testCount": 6,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/workflows/editor/ndv/paired-item.spec.ts": {
+      "avgDuration": 56960,
+      "testCount": 6,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/auth/oidc.spec.ts": {
+      "avgDuration": 55757,
+      "testCount": 1,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/ai/workflow-builder.spec.ts": {
+      "avgDuration": 55728,
+      "testCount": 5,
+      "flakyRate": 0.0469
+    },
+    "tests/e2e/instance-ai/instance-ai-workflow-execution.spec.ts": {
+      "avgDuration": 55629,
+      "testCount": 5,
+      "flakyRate": 0.129
     },
     "tests/e2e/workflows/editor/ndv/resource-locator.spec.ts": {
       "avgDuration": 55531,
       "testCount": 7,
-      "flakyRate": 0.0041
+      "flakyRate": 0.1257
     },
-    "tests/e2e/workflows/editor/expressions/inline.spec.ts": {
-      "avgDuration": 54696,
-      "testCount": 7,
-      "flakyRate": 0.0538
+    "tests/e2e/workflows/editor/routing.spec.ts": {
+      "avgDuration": 54730,
+      "testCount": 6,
+      "flakyRate": 0
     },
-    "tests/e2e/building-blocks/credential-mismatch.spec.ts": {
-      "avgDuration": 54499,
-      "testCount": 2,
-      "flakyRate": 0.0412
-    },
-    "tests/e2e/nodes/send-and-wait.spec.ts": {
-      "avgDuration": 53606,
-      "testCount": 5,
-      "flakyRate": 0.012
+    "tests/e2e/ai/assistant-credential-help.spec.ts": {
+      "avgDuration": 53463,
+      "testCount": 4,
+      "flakyRate": 0
     },
     "tests/e2e/workflows/checklist/production-checklist.spec.ts": {
-      "avgDuration": 52161,
+      "avgDuration": 53437,
       "testCount": 7,
       "flakyRate": 0
     },
-    "tests/e2e/projects/folders-basic.spec.ts": {
-      "avgDuration": 51988,
-      "testCount": 11,
-      "flakyRate": 0.0053
-    },
-    "tests/e2e/dynamic-credentials/execution-status.spec.ts": {
-      "avgDuration": 51897,
-      "testCount": 2,
-      "flakyRate": 0.0082
-    },
-    "tests/e2e/building-blocks/canvas-actions.spec.ts": {
-      "avgDuration": 51749,
-      "testCount": 9,
-      "flakyRate": 0
-    },
-    "tests/e2e/ai/assistant-support-chat.spec.ts": {
-      "avgDuration": 50560,
-      "testCount": 3,
-      "flakyRate": 0.0173
-    },
-    "tests/e2e/nodes/form-trigger-node.spec.ts": {
-      "avgDuration": 50070,
-      "testCount": 5,
-      "flakyRate": 0.0026
-    },
-    "tests/e2e/regression/ADO-4462-template-setup-experiment.spec.ts": {
-      "avgDuration": 49814,
-      "testCount": 2,
-      "flakyRate": 0.0066
-    },
-    "tests/e2e/workflows/editor/expressions/transformation.spec.ts": {
-      "avgDuration": 49292,
-      "testCount": 6,
-      "flakyRate": 0
-    },
-    "tests/e2e/projects/folders-advanced.spec.ts": {
-      "avgDuration": 47905,
-      "testCount": 6,
-      "flakyRate": 0.0013
-    },
-    "tests/e2e/projects/projects-move-resources.spec.ts": {
-      "avgDuration": 47659,
-      "testCount": 2,
-      "flakyRate": 0.0013
-    },
-    "tests/e2e/workflows/editor/tags.spec.ts": {
-      "avgDuration": 47115,
+    "tests/e2e/workflows/editor/expressions/inline.spec.ts": {
+      "avgDuration": 53365,
       "testCount": 7,
-      "flakyRate": 0.0067
+      "flakyRate": 0.0404
     },
     "tests/e2e/chat-hub/chat-hub-basic.spec.ts": {
-      "avgDuration": 46528,
+      "avgDuration": 52778,
       "testCount": 3,
-      "flakyRate": 0.066
-    },
-    "tests/e2e/instance-ai/instance-ai-artifacts.spec.ts": {
-      "avgDuration": 46260,
-      "testCount": 2,
-      "flakyRate": 0.0068
-    },
-    "tests/e2e/workflows/editor/workflow-actions/publish.spec.ts": {
-      "avgDuration": 45772,
-      "testCount": 8,
-      "flakyRate": 0.0054
-    },
-    "tests/e2e/api/waiting-endpoint-security.spec.ts": {
-      "avgDuration": 45699,
-      "testCount": 2,
-      "flakyRate": 0.0346
-    },
-    "tests/e2e/building-blocks/credentials.spec.ts": {
-      "avgDuration": 45585,
-      "testCount": 6,
-      "flakyRate": 0.0052
-    },
-    "tests/e2e/nodes/kafka-nodes.spec.ts": {
-      "avgDuration": 45389,
-      "testCount": 2,
-      "flakyRate": 0.0241
-    },
-    "tests/e2e/instance-ai/instance-ai-sidebar.spec.ts": {
-      "avgDuration": 45303,
-      "testCount": 4,
-      "flakyRate": 0.25
-    },
-    "tests/e2e/credentials/global.spec.ts": {
-      "avgDuration": 44792,
-      "testCount": 5,
-      "flakyRate": 0.0054
-    },
-    "tests/e2e/api/binary-data-xss.spec.ts": {
-      "avgDuration": 44412,
-      "testCount": 1,
-      "flakyRate": 0.0747
-    },
-    "tests/e2e/ai/workflow-builder.spec.ts": {
-      "avgDuration": 43010,
-      "testCount": 5,
-      "flakyRate": 0.0368
-    },
-    "tests/e2e/instance-ai/instance-ai-workflow-execution.spec.ts": {
-      "avgDuration": 42767,
-      "testCount": 5,
-      "flakyRate": 0.0161
-    },
-    "tests/e2e/node-creator/categories.spec.ts": {
-      "avgDuration": 42711,
-      "testCount": 5,
-      "flakyRate": 0.009
-    },
-    "tests/e2e/ai/chat-session.spec.ts": {
-      "avgDuration": 42706,
-      "testCount": 1,
-      "flakyRate": 0.0343
-    },
-    "tests/e2e/settings/log-streaming/log-streaming-observability.spec.ts": {
-      "avgDuration": 41436,
-      "testCount": 2,
-      "flakyRate": 0.0027
-    },
-    "tests/e2e/workflows/editor/subworkflows/workflow-selector.spec.ts": {
-      "avgDuration": 41332,
-      "testCount": 5,
-      "flakyRate": 0.0027
-    },
-    "tests/e2e/chat-hub/chat-hub-attachment.spec.ts": {
-      "avgDuration": 41211,
-      "testCount": 3,
-      "flakyRate": 0.0875
-    },
-    "tests/e2e/workflows/editor/ndv/resource-mapper.spec.ts": {
-      "avgDuration": 40519,
-      "testCount": 5,
-      "flakyRate": 0.0189
-    },
-    "tests/e2e/workflows/templates/templates.spec.ts": {
-      "avgDuration": 40022,
-      "testCount": 9,
-      "flakyRate": 0.0027
-    },
-    "tests/e2e/workflows/editor/ndv/ndv-floating-nodes.spec.ts": {
-      "avgDuration": 39105,
-      "testCount": 4,
-      "flakyRate": 0.0175
-    },
-    "tests/e2e/auth/token-exchange.spec.ts": {
-      "avgDuration": 38468,
-      "testCount": 9,
-      "flakyRate": 0.0323
-    },
-    "tests/e2e/nodes/community-nodes.spec.ts": {
-      "avgDuration": 38218,
-      "testCount": 3,
-      "flakyRate": 0.0107
-    },
-    "tests/e2e/building-blocks/workflow-entry-points.spec.ts": {
-      "avgDuration": 37381,
-      "testCount": 5,
-      "flakyRate": 0.0103
-    },
-    "tests/e2e/cloud/cloud.spec.ts": {
-      "avgDuration": 34483,
-      "testCount": 3,
-      "flakyRate": 0.0027
-    },
-    "tests/e2e/chat-hub/chat-hub-tools.spec.ts": {
-      "avgDuration": 34002,
-      "testCount": 1,
-      "flakyRate": 0.0174
-    },
-    "tests/e2e/app-config/security-notifications.spec.ts": {
-      "avgDuration": 32429,
-      "testCount": 5,
-      "flakyRate": 0.0106
-    },
-    "tests/e2e/ai/rag-callout.spec.ts": {
-      "avgDuration": 32378,
-      "testCount": 2,
-      "flakyRate": 0.0145
-    },
-    "tests/e2e/settings/external-secrets/aws-secrets-manager.spec.ts": {
-      "avgDuration": 32073,
-      "testCount": 1,
-      "flakyRate": 0.0109
-    },
-    "tests/e2e/instance-ai/instance-ai-workflow-preview.spec.ts": {
-      "avgDuration": 30167,
-      "testCount": 4,
-      "flakyRate": 0.0014
-    },
-    "tests/e2e/workflows/editor/execution/inject-previous.spec.ts": {
-      "avgDuration": 29712,
-      "testCount": 2,
-      "flakyRate": 0.1852
-    },
-    "tests/e2e/workflows/list/import.spec.ts": {
-      "avgDuration": 29156,
-      "testCount": 5,
-      "flakyRate": 0
-    },
-    "tests/e2e/settings/personal/personal.spec.ts": {
-      "avgDuration": 28877,
-      "testCount": 2,
-      "flakyRate": 0.0013
-    },
-    "tests/e2e/sentry/sentry-baseline.spec.ts": {
-      "avgDuration": 28694,
-      "testCount": 3,
-      "flakyRate": 0.0121
-    },
-    "tests/e2e/chat-hub/chat-hub-personal-agent.spec.ts": {
-      "avgDuration": 28161,
-      "testCount": 2,
-      "flakyRate": 0.0094
-    },
-    "tests/e2e/instance-ai/instance-ai-confirmations.spec.ts": {
-      "avgDuration": 27904,
-      "testCount": 2,
-      "flakyRate": 0.0534
-    },
-    "tests/e2e/api/webhook-external.spec.ts": {
-      "avgDuration": 27661,
-      "testCount": 2,
-      "flakyRate": 0.0174
-    },
-    "tests/e2e/api/webhook-isolation.spec.ts": {
-      "avgDuration": 27589,
-      "testCount": 14,
-      "flakyRate": 0.0357
-    },
-    "tests/e2e/workflows/editor/subworkflows/debugging.spec.ts": {
-      "avgDuration": 27515,
-      "testCount": 4,
-      "flakyRate": 0.0013
+      "flakyRate": 0.0179
     },
     "tests/e2e/instance-ai/instance-ai-chat-basics.spec.ts": {
-      "avgDuration": 27250,
+      "avgDuration": 50961,
       "testCount": 4,
-      "flakyRate": 0.0082
+      "flakyRate": 0.0254
     },
-    "tests/e2e/app-config/demo-reimport.spec.ts": {
-      "avgDuration": 26540,
-      "testCount": 3,
-      "flakyRate": 0.0129
-    },
-    "tests/e2e/workflows/editor/editor-after-route-changes.spec.ts": {
-      "avgDuration": 26171,
-      "testCount": 1,
-      "flakyRate": 0.0013
-    },
-    "tests/e2e/settings/environments/variables.spec.ts": {
-      "avgDuration": 26145,
+    "tests/e2e/building-blocks/node-details-configuration.spec.ts": {
+      "avgDuration": 50330,
       "testCount": 7,
-      "flakyRate": 0.0026
-    },
-    "tests/e2e/settings/external-secrets/secret-providers-connections-ui.spec.ts": {
-      "avgDuration": 25879,
-      "testCount": 2,
-      "flakyRate": 0.0041
-    },
-    "tests/e2e/node-creator/actions.spec.ts": {
-      "avgDuration": 25007,
-      "testCount": 4,
-      "flakyRate": 0.0013
-    },
-    "tests/e2e/building-blocks/user-service.spec.ts": {
-      "avgDuration": 24381,
-      "testCount": 8,
-      "flakyRate": 0.0013
-    },
-    "tests/e2e/node-creator/navigation.spec.ts": {
-      "avgDuration": 24308,
-      "testCount": 4,
       "flakyRate": 0
     },
-    "tests/e2e/workflows/demo-diff.spec.ts": {
-      "avgDuration": 24192,
-      "testCount": 9,
-      "flakyRate": 0.0013
-    },
-    "tests/e2e/chat-hub/chat-hub-chat-user.spec.ts": {
-      "avgDuration": 23743,
-      "testCount": 1,
-      "flakyRate": 0.008
-    },
-    "tests/e2e/settings/log-streaming/log-streaming.spec.ts": {
-      "avgDuration": 23010,
-      "testCount": 5,
+    "tests/e2e/workflows/editor/expressions/transformation.spec.ts": {
+      "avgDuration": 50264,
+      "testCount": 6,
       "flakyRate": 0
     },
-    "tests/e2e/api/wait-form-resume.spec.ts": {
-      "avgDuration": 22736,
-      "testCount": 2,
-      "flakyRate": 0.012
-    },
-    "tests/e2e/capabilities/task-runner.spec.ts": {
-      "avgDuration": 22558,
-      "testCount": 2,
-      "flakyRate": 0.0053
-    },
-    "tests/e2e/auth/password-reset.spec.ts": {
-      "avgDuration": 22178,
-      "testCount": 1,
-      "flakyRate": 0.0121
-    },
-    "tests/e2e/sharing/access-control.spec.ts": {
-      "avgDuration": 21931,
+    "tests/e2e/nodes/form-trigger-node.spec.ts": {
+      "avgDuration": 49969,
       "testCount": 5,
-      "flakyRate": 0.0027
-    },
-    "tests/e2e/sharing/workflow-sharing.spec.ts": {
-      "avgDuration": 21388,
-      "testCount": 4,
       "flakyRate": 0.0118
     },
-    "tests/e2e/app-config/versions.spec.ts": {
-      "avgDuration": 21384,
-      "testCount": 1,
-      "flakyRate": 0.017
-    },
-    "tests/e2e/chat-hub/chat-hub-settings.spec.ts": {
-      "avgDuration": 20987,
+    "tests/e2e/projects/projects-move-resources.spec.ts": {
+      "avgDuration": 49198,
       "testCount": 2,
-      "flakyRate": 0.0241
-    },
-    "tests/e2e/node-creator/vector-stores.spec.ts": {
-      "avgDuration": 20563,
-      "testCount": 3,
       "flakyRate": 0
     },
-    "tests/e2e/instance-ai/instance-ai-timeline.spec.ts": {
-      "avgDuration": 20474,
-      "testCount": 1,
-      "flakyRate": 0.0082
-    },
-    "tests/e2e/settings/users/users.spec.ts": {
-      "avgDuration": 20357,
+    "tests/e2e/credentials/global.spec.ts": {
+      "avgDuration": 48731,
       "testCount": 5,
-      "flakyRate": 0.0027
+      "flakyRate": 0
     },
-    "tests/e2e/nodes/if-node.spec.ts": {
-      "avgDuration": 19866,
+    "tests/e2e/workflows/editor/workflow-actions/publish.spec.ts": {
+      "avgDuration": 47925,
+      "testCount": 8,
+      "flakyRate": 0.003
+    },
+    "tests/e2e/projects/folders-basic.spec.ts": {
+      "avgDuration": 47621,
+      "testCount": 10,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/editor/tags.spec.ts": {
+      "avgDuration": 46815,
+      "testCount": 7,
+      "flakyRate": 0.0029
+    },
+    "tests/e2e/workflows/editor/execution/executions-list-infinite-scroll.spec.ts": {
+      "avgDuration": 46590,
       "testCount": 2,
-      "flakyRate": 0.0492
+      "flakyRate": 0.0088
     },
-    "tests/e2e/regression/PAY-4367-node-shifting-cyclic.spec.ts": {
-      "avgDuration": 19346,
+    "tests/e2e/ai/assistant-support-chat.spec.ts": {
+      "avgDuration": 46479,
       "testCount": 3,
+      "flakyRate": 0.0342
+    },
+    "tests/e2e/workflows/editor/execution/debug.spec.ts": {
+      "avgDuration": 46230,
+      "testCount": 4,
+      "flakyRate": 0.0238
+    },
+    "tests/e2e/workflows/editor/subworkflows/workflow-selector.spec.ts": {
+      "avgDuration": 45917,
+      "testCount": 5,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/ai/assistant-code-help.spec.ts": {
+      "avgDuration": 45830,
+      "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/dynamic-credentials/execution-status.spec.ts": {
+      "avgDuration": 45346,
+      "testCount": 2,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/chat-hub/chat-hub-workflow-agent.spec.ts": {
+      "avgDuration": 45232,
+      "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/building-blocks/credentials.spec.ts": {
+      "avgDuration": 43620,
+      "testCount": 6,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/executions/filter.spec.ts": {
+      "avgDuration": 43069,
+      "testCount": 2,
+      "flakyRate": 0.1456
+    },
+    "tests/e2e/capabilities/proxy-server.spec.ts": {
+      "avgDuration": 42728,
+      "testCount": 4,
+      "flakyRate": 0
+    },
+    "tests/e2e/settings/log-streaming/log-streaming-observability.spec.ts": {
+      "avgDuration": 42703,
+      "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/templates/templates.spec.ts": {
+      "avgDuration": 42366,
+      "testCount": 9,
+      "flakyRate": 0.149
+    },
+    "tests/e2e/instance-ai/instance-ai-confirmations.spec.ts": {
+      "avgDuration": 41968,
+      "testCount": 5,
+      "flakyRate": 0.0433
+    },
+    "tests/e2e/projects/folders-advanced.spec.ts": {
+      "avgDuration": 41959,
+      "testCount": 6,
+      "flakyRate": 0
+    },
+    "tests/e2e/ai/rag-callout.spec.ts": {
+      "avgDuration": 41455,
+      "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/chat-hub/chat-hub-attachment.spec.ts": {
+      "avgDuration": 41438,
+      "testCount": 3,
+      "flakyRate": 0.0249
+    },
+    "tests/e2e/chat-hub/chat-hub-tools.spec.ts": {
+      "avgDuration": 40986,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/instance-ai/instance-ai-artifacts.spec.ts": {
+      "avgDuration": 40886,
+      "testCount": 2,
+      "flakyRate": 0.0089
+    },
+    "tests/e2e/nodes/kafka-nodes.spec.ts": {
+      "avgDuration": 39672,
+      "testCount": 2,
+      "flakyRate": 0.003
+    },
+    "tests/e2e/workflows/editor/ndv/ndv-floating-nodes.spec.ts": {
+      "avgDuration": 39320,
+      "testCount": 4,
+      "flakyRate": 0
+    },
+    "tests/e2e/cloud/cloud.spec.ts": {
+      "avgDuration": 39318,
+      "testCount": 3,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/instance-ai/instance-ai-workflow-preview.spec.ts": {
+      "avgDuration": 38388,
+      "testCount": 4,
+      "flakyRate": 0.0673
+    },
+    "tests/e2e/workflows/editor/subworkflows/extraction.spec.ts": {
+      "avgDuration": 36213,
+      "testCount": 3,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/workflows/editor/ndv/resource-mapper.spec.ts": {
+      "avgDuration": 35393,
+      "testCount": 5,
+      "flakyRate": 0.0075
+    },
+    "tests/e2e/regression/ADO-4462-template-setup-experiment.spec.ts": {
+      "avgDuration": 34370,
+      "testCount": 2,
+      "flakyRate": 0.0597
+    },
+    "tests/e2e/building-blocks/credential-mismatch.spec.ts": {
+      "avgDuration": 32894,
+      "testCount": 2,
       "flakyRate": 0
     },
     "tests/e2e/app-config/demo.spec.ts": {
-      "avgDuration": 19291,
+      "avgDuration": 32764,
       "testCount": 4,
-      "flakyRate": 0.0225
+      "flakyRate": 0.003
     },
-    "tests/e2e/auth/signin.spec.ts": {
-      "avgDuration": 19199,
-      "testCount": 1,
-      "flakyRate": 0.016
-    },
-    "tests/e2e/node-creator/special-nodes.spec.ts": {
-      "avgDuration": 19124,
-      "testCount": 3,
-      "flakyRate": 0.0013
-    },
-    "tests/e2e/auth/authenticated.spec.ts": {
-      "avgDuration": 17774,
+    "tests/e2e/building-blocks/workflow-entry-points.spec.ts": {
+      "avgDuration": 31263,
       "testCount": 5,
+      "flakyRate": 0.0007
+    },
+    "tests/e2e/api/binary-data-xss.spec.ts": {
+      "avgDuration": 30320,
+      "testCount": 1,
+      "flakyRate": 0.003
+    },
+    "tests/e2e/nodes/send-and-wait.spec.ts": {
+      "avgDuration": 29701,
+      "testCount": 5,
+      "flakyRate": 0
+    },
+    "tests/e2e/node-creator/navigation.spec.ts": {
+      "avgDuration": 29411,
+      "testCount": 4,
       "flakyRate": 0
     },
     "tests/e2e/nodes/mcp-trigger.spec.ts": {
-      "avgDuration": 16536,
+      "avgDuration": 29273,
       "testCount": 23,
-      "flakyRate": 0.0384
+      "flakyRate": 0.0163
     },
-    "tests/e2e/workflows/editor/ndv/io-filter.spec.ts": {
-      "avgDuration": 15951,
+    "tests/e2e/app-config/security-notifications.spec.ts": {
+      "avgDuration": 29144,
+      "testCount": 5,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/workflows/list/import.spec.ts": {
+      "avgDuration": 29107,
+      "testCount": 5,
+      "flakyRate": 0
+    },
+    "tests/e2e/sentry/sentry-baseline.spec.ts": {
+      "avgDuration": 27861,
+      "testCount": 3,
+      "flakyRate": 0.009
+    },
+    "tests/e2e/nodes/community-nodes.spec.ts": {
+      "avgDuration": 27799,
+      "testCount": 3,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/demo-diff.spec.ts": {
+      "avgDuration": 27383,
+      "testCount": 9,
+      "flakyRate": 0
+    },
+    "tests/e2e/instance-ai/instance-ai-attachments.spec.ts": {
+      "avgDuration": 27310,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/building-blocks/user-service.spec.ts": {
+      "avgDuration": 26659,
+      "testCount": 8,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/editor/subworkflows/debugging.spec.ts": {
+      "avgDuration": 26524,
+      "testCount": 4,
+      "flakyRate": 0
+    },
+    "tests/e2e/settings/external-secrets/aws-secrets-manager.spec.ts": {
+      "avgDuration": 26395,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/node-creator/special-nodes.spec.ts": {
+      "avgDuration": 26202,
+      "testCount": 3,
+      "flakyRate": 0
+    },
+    "tests/e2e/api/waiting-endpoint-security.spec.ts": {
+      "avgDuration": 26169,
       "testCount": 2,
       "flakyRate": 0
     },
-    "tests/e2e/app-config/env-feature-flags.spec.ts": {
-      "avgDuration": 15528,
+    "tests/e2e/nodes/http-request-node.spec.ts": {
+      "avgDuration": 25946,
       "testCount": 2,
-      "flakyRate": 0.0173
+      "flakyRate": 0
     },
-    "tests/e2e/capabilities/proxy-server.spec.ts": {
-      "avgDuration": 15282,
+    "tests/e2e/settings/environments/variables.spec.ts": {
+      "avgDuration": 25793,
+      "testCount": 7,
+      "flakyRate": 0
+    },
+    "tests/e2e/settings/external-secrets/secret-providers-connections-ui.spec.ts": {
+      "avgDuration": 25779,
+      "testCount": 2,
+      "flakyRate": 0.0193
+    },
+    "tests/e2e/chat-hub/chat-hub-chat-user.spec.ts": {
+      "avgDuration": 25157,
+      "testCount": 1,
+      "flakyRate": 0.006
+    },
+    "tests/e2e/mcp-registry/mcp-registry.spec.ts": {
+      "avgDuration": 25147,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/node-creator/actions.spec.ts": {
+      "avgDuration": 24552,
       "testCount": 4,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/api/webhook-isolation.spec.ts": {
+      "avgDuration": 24448,
+      "testCount": 14,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/settings/personal/personal.spec.ts": {
+      "avgDuration": 24246,
+      "testCount": 2,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/sharing/access-control.spec.ts": {
+      "avgDuration": 24246,
+      "testCount": 5,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/api/form-endpoint-isolation.spec.ts": {
+      "avgDuration": 24118,
+      "testCount": 2,
+      "flakyRate": 0.0075
+    },
+    "tests/e2e/chat-hub/chat-hub-personal-agent.spec.ts": {
+      "avgDuration": 24008,
+      "testCount": 2,
+      "flakyRate": 0.0117
+    },
+    "tests/e2e/settings/log-streaming/log-streaming.spec.ts": {
+      "avgDuration": 23366,
+      "testCount": 5,
+      "flakyRate": 0
+    },
+    "tests/e2e/auth/password-reset.spec.ts": {
+      "avgDuration": 23160,
+      "testCount": 1,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/node-creator/vector-stores.spec.ts": {
+      "avgDuration": 22336,
+      "testCount": 3,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/editor/editor-after-route-changes.spec.ts": {
+      "avgDuration": 22281,
+      "testCount": 1,
+      "flakyRate": 0.0821
+    },
+    "tests/e2e/auth/authenticated.spec.ts": {
+      "avgDuration": 21885,
+      "testCount": 5,
+      "flakyRate": 0
+    },
+    "tests/e2e/auth/token-exchange.spec.ts": {
+      "avgDuration": 21394,
+      "testCount": 9,
+      "flakyRate": 0.0118
+    },
+    "tests/e2e/capabilities/task-runner.spec.ts": {
+      "avgDuration": 21067,
+      "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/instance-ai/instance-ai-remediation-guard.spec.ts": {
+      "avgDuration": 19867,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/settings/users/users.spec.ts": {
+      "avgDuration": 19292,
+      "testCount": 5,
+      "flakyRate": 0
+    },
+    "tests/e2e/regression/PAY-4367-node-shifting-cyclic.spec.ts": {
+      "avgDuration": 18833,
+      "testCount": 3,
+      "flakyRate": 0
+    },
+    "tests/e2e/api/webhook-external.spec.ts": {
+      "avgDuration": 18502,
+      "testCount": 2,
+      "flakyRate": 0.0029
+    },
+    "tests/e2e/sharing/workflow-sharing.spec.ts": {
+      "avgDuration": 18327,
+      "testCount": 4,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/node-creator/workflows.spec.ts": {
+      "avgDuration": 18311,
+      "testCount": 2,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/workflows/editor/execution/inject-previous.spec.ts": {
+      "avgDuration": 18026,
+      "testCount": 2,
+      "flakyRate": 0.003
+    },
+    "tests/e2e/workflows/editor/ndv/io-filter.spec.ts": {
+      "avgDuration": 17435,
+      "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/api/wait-form-resume.spec.ts": {
+      "avgDuration": 17145,
+      "testCount": 2,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/chat-hub/chat-hub-settings.spec.ts": {
+      "avgDuration": 15994,
+      "testCount": 2,
+      "flakyRate": 0.006
+    },
+    "tests/e2e/nodes/if-node.spec.ts": {
+      "avgDuration": 15212,
+      "testCount": 2,
       "flakyRate": 0
     },
     "tests/e2e/sharing/credential-sharing.spec.ts": {
-      "avgDuration": 15216,
+      "avgDuration": 15083,
       "testCount": 3,
-      "flakyRate": 0.0013
-    },
-    "tests/e2e/credentials/api-operations.spec.ts": {
-      "avgDuration": 14860,
-      "testCount": 5,
-      "flakyRate": 0.0105
-    },
-    "tests/e2e/nodes/http-request-node.spec.ts": {
-      "avgDuration": 14686,
-      "testCount": 2,
       "flakyRate": 0
     },
     "tests/e2e/workflows/editor/execution/partial.spec.ts": {
-      "avgDuration": 14544,
+      "avgDuration": 14503,
       "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/auth/admin-smoke.spec.ts": {
+      "avgDuration": 13957,
+      "testCount": 1,
       "flakyRate": 0
     },
     "tests/e2e/regression/AI-812-partial-execs-broken-when-using-chat-trigger.spec.ts": {
-      "avgDuration": 13766,
+      "avgDuration": 13400,
       "testCount": 2,
-      "flakyRate": 0.0013
+      "flakyRate": 0.0045
     },
-    "tests/e2e/nodes/pdf-node.spec.ts": {
-      "avgDuration": 12804,
-      "testCount": 1,
-      "flakyRate": 0.0187
+    "tests/e2e/app-config/demo-reimport.spec.ts": {
+      "avgDuration": 12143,
+      "testCount": 3,
+      "flakyRate": 0.0104
     },
     "tests/e2e/regression/ADO-2372-prevent-clipping-params.spec.ts": {
-      "avgDuration": 12015,
+      "avgDuration": 12133,
       "testCount": 2,
       "flakyRate": 0
-    },
-    "tests/e2e/node-creator/workflows.spec.ts": {
-      "avgDuration": 11677,
-      "testCount": 2,
-      "flakyRate": 0
-    },
-    "tests/e2e/mcp/mcp-service.spec.ts": {
-      "avgDuration": 11437,
-      "testCount": 26,
-      "flakyRate": 0.0026
     },
     "tests/e2e/settings/workers/workers.spec.ts": {
-      "avgDuration": 11242,
+      "avgDuration": 11351,
       "testCount": 4,
       "flakyRate": 0
     },
-    "tests/e2e/regression/ADO-1338-ndv-missing-input-panel.spec.ts": {
-      "avgDuration": 9201,
+    "tests/e2e/instance-ai/instance-ai-timeline.spec.ts": {
+      "avgDuration": 10375,
       "testCount": 1,
+      "flakyRate": 0.0134
+    },
+    "tests/e2e/nodes/pdf-node.spec.ts": {
+      "avgDuration": 9150,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/regression/ADO-1338-ndv-missing-input-panel.spec.ts": {
+      "avgDuration": 9059,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/ai/chat-session.spec.ts": {
+      "avgDuration": 8746,
+      "testCount": 1,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/api/discovery.spec.ts": {
+      "avgDuration": 8274,
+      "testCount": 4,
       "flakyRate": 0
     },
     "tests/e2e/workflows/editor/ndv/schema-preview.spec.ts": {
-      "avgDuration": 8160,
-      "testCount": 1,
-      "flakyRate": 0.0013
-    },
-    "tests/e2e/regression/SUG-121-fields-reset-after-closing-ndv.spec.ts": {
-      "avgDuration": 7787,
-      "testCount": 1,
-      "flakyRate": 0.0093
-    },
-    "tests/e2e/regression/CAT-726-canvas-node-connectors-not-rendered-when-nodes-inserted.spec.ts": {
-      "avgDuration": 7780,
+      "avgDuration": 8106,
       "testCount": 1,
       "flakyRate": 0
     },
-    "tests/e2e/regression/SUG-38-inline-expression-preview.spec.ts": {
-      "avgDuration": 7567,
+    "tests/e2e/regression/CAT-726-canvas-node-connectors-not-rendered-when-nodes-inserted.spec.ts": {
+      "avgDuration": 8098,
+      "testCount": 1,
+      "flakyRate": 0.0133
+    },
+    "tests/e2e/app-config/env-feature-flags.spec.ts": {
+      "avgDuration": 7862,
+      "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/auth/signin.spec.ts": {
+      "avgDuration": 7781,
+      "testCount": 1,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/regression/SUG-121-fields-reset-after-closing-ndv.spec.ts": {
+      "avgDuration": 7424,
+      "testCount": 1,
+      "flakyRate": 0.0089
+    },
+    "tests/e2e/settings/community-nodes/community-nodes.spec.ts": {
+      "avgDuration": 7299,
       "testCount": 1,
       "flakyRate": 0
     },
     "tests/e2e/regression/AI-1401-sub-nodes-input-panel.spec.ts": {
-      "avgDuration": 7265,
+      "avgDuration": 7297,
       "testCount": 1,
-      "flakyRate": 0.0013
+      "flakyRate": 0
+    },
+    "tests/e2e/regression/SUG-38-inline-expression-preview.spec.ts": {
+      "avgDuration": 7142,
+      "testCount": 1,
+      "flakyRate": 0
     },
     "tests/e2e/regression/AI-716-correctly-set-up-agent-model-shows-error.spec.ts": {
-      "avgDuration": 6890,
+      "avgDuration": 6869,
       "testCount": 1,
       "flakyRate": 0
     },
-    "tests/e2e/nodes/email-send-node.spec.ts": {
-      "avgDuration": 6881,
-      "testCount": 1,
-      "flakyRate": 0
-    },
-    "tests/e2e/settings/community-nodes/community-nodes.spec.ts": {
-      "avgDuration": 6732,
-      "testCount": 1,
-      "flakyRate": 0
-    },
-    "tests/e2e/credentials/oauth.spec.ts": {
-      "avgDuration": 6641,
+    "tests/e2e/journeys/admin-views-executions-list.spec.ts": {
+      "avgDuration": 6694,
       "testCount": 1,
       "flakyRate": 0
     },
     "tests/e2e/regression/ADO-2230-ndv-reset-data-pagination.spec.ts": {
-      "avgDuration": 6144,
+      "avgDuration": 6460,
       "testCount": 1,
       "flakyRate": 0
     },
-    "tests/e2e/workflows/editor/canvas/stickies.spec.ts": {
-      "avgDuration": 6120,
+    "tests/e2e/credentials/oauth.spec.ts": {
+      "avgDuration": 6454,
       "testCount": 1,
-      "flakyRate": 0.0013
+      "flakyRate": 0.0045
+    },
+    "tests/e2e/nodes/email-send-node.spec.ts": {
+      "avgDuration": 6317,
+      "testCount": 1,
+      "flakyRate": 0
     },
     "tests/e2e/nodes/schedule-trigger-node.spec.ts": {
-      "avgDuration": 5988,
+      "avgDuration": 5942,
+      "testCount": 1,
+      "flakyRate": 0
+    },
+    "tests/e2e/credentials/api-operations.spec.ts": {
+      "avgDuration": 5920,
+      "testCount": 5,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/app-config/versions.spec.ts": {
+      "avgDuration": 5749,
       "testCount": 1,
       "flakyRate": 0
     },
     "tests/e2e/workflows/editor/canvas/focus-panel.spec.ts": {
-      "avgDuration": 5522,
+      "avgDuration": 5366,
       "testCount": 1,
       "flakyRate": 0
     },
-    "tests/e2e/nodes/n8n-trigger.spec.ts": {
-      "avgDuration": 5439,
-      "testCount": 2,
+    "tests/e2e/regression/ADO-2929-can-load-old-switch-node-workflows.spec.ts": {
+      "avgDuration": 5249,
+      "testCount": 1,
       "flakyRate": 0
     },
-    "tests/e2e/regression/ADO-2929-can-load-old-switch-node-workflows.spec.ts": {
-      "avgDuration": 5324,
+    "tests/e2e/workflows/editor/canvas/stickies.spec.ts": {
+      "avgDuration": 5179,
       "testCount": 1,
       "flakyRate": 0
     },
     "tests/e2e/settings/log-streaming/log-streaming-ui-e2e.spec.ts": {
-      "avgDuration": 4942,
+      "avgDuration": 4850,
       "testCount": 1,
       "flakyRate": 0
     },
-    "tests/e2e/auth/admin-smoke.spec.ts": {
-      "avgDuration": 4506,
-      "testCount": 1,
-      "flakyRate": 0.0013
-    },
     "tests/e2e/workflows/demo-executable-chat-trigger.spec.ts": {
-      "avgDuration": 4028,
+      "avgDuration": 4424,
       "testCount": 1,
+      "flakyRate": 0.0044
+    },
+    "tests/e2e/mcp/mcp-service.spec.ts": {
+      "avgDuration": 4375,
+      "testCount": 26,
       "flakyRate": 0
     },
     "tests/e2e/workflows/editor/subworkflows/wait.spec.ts": {
-      "avgDuration": 3334,
+      "avgDuration": 4232,
       "testCount": 4,
-      "flakyRate": 0.0066
-    },
-    "tests/e2e/api/discovery.spec.ts": {
-      "avgDuration": 3260,
-      "testCount": 4,
-      "flakyRate": 0.0027
+      "flakyRate": 0.0103
     },
     "tests/e2e/workflows/editor/subworkflows/subworkflow-version-resolution.spec.ts": {
-      "avgDuration": 1895,
+      "avgDuration": 2352,
       "testCount": 4,
-      "flakyRate": 0.004
+      "flakyRate": 0.0015
     },
     "tests/e2e/dynamic-credentials/external-user-trigger.spec.ts": {
-      "avgDuration": 1609,
+      "avgDuration": 1179,
       "testCount": 1,
-      "flakyRate": 0.0014
+      "flakyRate": 0
+    },
+    "tests/e2e/instance-ai/instance-ai-workflow-setup.spec.ts": {
+      "avgDuration": 1105,
+      "testCount": 10,
+      "flakyRate": 0.0015
     },
     "tests/e2e/dynamic-credentials/resolver-deletion.spec.ts": {
       "avgDuration": 60000,
       "testCount": 3,
+      "flakyRate": 0.0015
+    },
+    "tests/e2e/nodes/n8n-trigger.spec.ts": {
+      "avgDuration": 60000,
+      "testCount": 2,
       "flakyRate": 0
     },
     "tests/e2e/nodes/code-node-api.spec.ts": {
@@ -818,22 +858,42 @@
       "testCount": 1,
       "flakyRate": 0
     },
-    "tests/e2e/instance-ai/instance-ai-workflow-setup-actions.spec.ts": {
+    "tests/e2e/instance-ai/instance-ai-timeouts.spec.ts": {
       "avgDuration": 60000,
-      "testCount": 2,
-      "flakyRate": 0
-    },
-    "tests/e2e/source-control/pull.spec.ts": {
-      "avgDuration": 60000,
-      "testCount": 2,
-      "flakyRate": 0
-    },
-    "tests/e2e/workflows/editor/workflow-actions/archive.spec.ts": {
-      "avgDuration": 60000,
-      "testCount": 7,
+      "testCount": 1,
       "flakyRate": 0
     },
     "tests/e2e/source-control/push.spec.ts": {
+      "avgDuration": 60000,
+      "testCount": 4,
+      "flakyRate": 0
+    },
+    "tests/e2e/settings/environments/source-control.spec.ts": {
+      "avgDuration": 60000,
+      "testCount": 4,
+      "flakyRate": 0
+    },
+    "tests/e2e/ai/langchain-memory.spec.ts": {
+      "avgDuration": 60000,
+      "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/editor/workflow-actions/duplicate.spec.ts": {
+      "avgDuration": 60000,
+      "testCount": 2,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/editor/workflow-actions/copy-paste.spec.ts": {
+      "avgDuration": 60000,
+      "testCount": 3,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/editor/workflow-actions/settings.spec.ts": {
+      "avgDuration": 60000,
+      "testCount": 3,
+      "flakyRate": 0
+    },
+    "tests/e2e/workflows/editor/workflow-actions/run.spec.ts": {
       "avgDuration": 60000,
       "testCount": 4,
       "flakyRate": 0
@@ -843,12 +903,7 @@
       "testCount": 2,
       "flakyRate": 0
     },
-    "tests/e2e/settings/environments/source-control.spec.ts": {
-      "avgDuration": 60000,
-      "testCount": 4,
-      "flakyRate": 0
-    },
-    "tests/e2e/workflows/editor/workflow-actions/duplicate.spec.ts": {
+    "tests/e2e/source-control/pull.spec.ts": {
       "avgDuration": 60000,
       "testCount": 2,
       "flakyRate": 0
@@ -858,9 +913,9 @@
       "testCount": 1,
       "flakyRate": 0
     },
-    "tests/e2e/workflows/editor/workflow-actions/settings.spec.ts": {
+    "tests/e2e/workflows/editor/execution/previous-nodes.spec.ts": {
       "avgDuration": 60000,
-      "testCount": 3,
+      "testCount": 1,
       "flakyRate": 0
     },
     "tests/e2e/ai/evaluations.spec.ts": {
@@ -868,24 +923,9 @@
       "testCount": 1,
       "flakyRate": 0
     },
-    "tests/e2e/workflows/editor/workflow-actions/copy-paste.spec.ts": {
-      "avgDuration": 60000,
-      "testCount": 3,
-      "flakyRate": 0
-    },
-    "tests/e2e/workflows/editor/execution/previous-nodes.spec.ts": {
+    "tests/e2e/node-creator/categories.spec.ts": {
       "avgDuration": 60000,
       "testCount": 1,
-      "flakyRate": 0
-    },
-    "tests/e2e/workflows/editor/workflow-actions/run.spec.ts": {
-      "avgDuration": 60000,
-      "testCount": 4,
-      "flakyRate": 0
-    },
-    "tests/e2e/ai/langchain-memory.spec.ts": {
-      "avgDuration": 60000,
-      "testCount": 2,
       "flakyRate": 0
     }
   }


### PR DESCRIPTION
## Summary

Refreshes the spec duration metrics (`​.github/test-metrics/playwright.json`) that the janitor orchestrator uses to distribute Playwright E2E specs across the 16 CI shards. The file was last updated **2026-04-23** (~5 weeks stale); this re-pulls current durations from Currents (project `LRxcNt`).

## Effect on the shard distribution

| Metric | Stale (Apr 23) | Refreshed (May 30) |
|---|---|---|
| Total modeled test time | 125.0 min | **116.9 min** |
| Predicted wall (longest shard) | ~9.0 min | **~8.5 min** |
| Per-shard spread | 8.1–9.0 min | **7.7–8.5 min** |

## Notes

- Data-only change; no logic touched. Regenerated via `fetch-currents-metrics.mjs --project=LRxcNt`.
- The predicted ~8.5 min is the packing estimate (container boot is correctly modeled at ~25s — confirmed against `qa_performance_metrics`, multi-main p50 19s / p90 30s). The live ~11 min wall is dominated by test-level scheduling tails, which a metrics refresh alone doesn't address — tracked separately.
- Considered bumping `maxGroupDuration` but it's inert at current spec sizes (only the `proxy` group exceeds the cap, and it splits into 2 either way), so it was dropped.
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
🤖 Generated with [Claude Code](https://claude.com/claude-code)