### PR TITLE
feat(ai-builder): Add `datasets` field for PR-tier suite (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -139,8 +139,22 @@ dotenvx run -f ../../../.env.local -- pnpm eval:instance-ai --iterations 3
 | `--concurrency` | `16` | Max concurrent scenarios (builds are separately capped at 4) |
 | `--experiment-name` | auto | LangSmith experiment prefix (defaults to `{branch}-{sha}` in CI or `local-{branch}-{sha}-dirty?` locally) |
 | `--iterations` | `1` | Run each test case N times with fresh builds |
+| `--tier` | — | Filter to test cases whose `datasets` array contains this value (e.g. `--tier pr` for the PR-time set). Combines with `--filter`/`--exclude`. |
 
 **pass@k / pass^k**: with `--iterations N`, each scenario runs N times. `pass@k` is the fraction of scenarios that passed *at least once*; `pass^k` is the fraction that passed *every* time. `pass@k` shows whether something is *possible*; `pass^k` shows whether it's *reliable*.
+
+### Test-case datasets (logical groupings)
+
+Each test case declares a `datasets` array in its JSON (default `["full"]` if omitted). The value identifies one or more logical groupings the case belongs to. Two named groupings exist today:
+
+| Value | What it means |
+|------|----------------|
+| `full` | Default — every case runs in this grouping. Use for nightly / full-suite runs. |
+| `pr` | Curated thin set for PR-time runs. ~6 cases, chosen for capability diversity and high baseline reliability. |
+
+A case can belong to multiple groupings — e.g. PR-tier cases declare `"datasets": ["pr", "full"]` so they run in both contexts. On sync, each value is propagated to the LangSmith example as a split alongside the file slug, so `--tier <name>` translates to a server-side splits filter.
+
+**Adding a case to `pr`**: edit the case's JSON, add `"pr"` to its `datasets` array, re-sync. No promotion process is enforced today — use judgment about reliability + capability coverage when curating.
 
 ### Outputs
 

--- a/packages/@n8n/instance-ai/evaluations/__tests__/data-workflows.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/data-workflows.test.ts
@@ -134,4 +134,56 @@ describe('loadWorkflowTestCasesWithFiles', () => {
 			expect(slugs('weather', 'weather')).toEqual([]);
 		});
 	});
+
+	describe('--tier (datasets-field filter)', () => {
+		it('defaults to ["full"] when a test case omits the datasets field', () => {
+			// STUB_TEST_CASE doesn't declare datasets — Zod default fills it in.
+			const cases = loadWorkflowTestCasesWithFiles();
+			expect(cases.every((c) => c.testCase.datasets.includes('full'))).toBe(true);
+		});
+
+		it('filters to test cases whose datasets array contains the tier', () => {
+			// Re-mock so two cases declare different datasets memberships.
+			mockedReadFile.mockImplementation((p) => {
+				const filename = String(p);
+				if (filename.includes('weather-alert')) {
+					return JSON.stringify({
+						...JSON.parse(STUB_TEST_CASE),
+						datasets: ['pr', 'full'],
+					});
+				}
+				return STUB_TEST_CASE; // default → ['full']
+			});
+
+			const inPr = loadWorkflowTestCasesWithFiles(undefined, undefined, 'pr')
+				.map((c) => c.fileSlug)
+				.sort();
+			const inFull = loadWorkflowTestCasesWithFiles(undefined, undefined, 'full')
+				.map((c) => c.fileSlug)
+				.sort();
+
+			expect(inPr).toEqual(['weather-alert']);
+			expect(inFull.length).toBe(7); // all .json files end up in full
+		});
+
+		it('composes with --filter: tier filter applies after substring filter', () => {
+			mockedReadFile.mockImplementation((p) => {
+				const filename = String(p);
+				if (filename.includes('weather-alert')) {
+					return JSON.stringify({
+						...JSON.parse(STUB_TEST_CASE),
+						datasets: ['pr', 'full'],
+					});
+				}
+				return STUB_TEST_CASE;
+			});
+
+			// `weather` substring matches weather-alert + weather-monitoring;
+			// `--tier pr` keeps only weather-alert (the only one tagged 'pr').
+			const result = loadWorkflowTestCasesWithFiles('weather', undefined, 'pr')
+				.map((c) => c.fileSlug)
+				.sort();
+			expect(result).toEqual(['weather-alert']);
+		});
+	});
 });

--- a/packages/@n8n/instance-ai/evaluations/__tests__/data-workflows.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/data-workflows.test.ts
@@ -4,6 +4,7 @@ jest.mock('fs', () => ({
 }));
 
 import { readdirSync, readFileSync } from 'fs';
+import { jsonParse } from 'n8n-workflow';
 
 import { loadWorkflowTestCasesWithFiles } from '../data/workflows';
 
@@ -122,8 +123,6 @@ describe('loadWorkflowTestCasesWithFiles', () => {
 
 	describe('--filter combined with --exclude', () => {
 		it('applies exclude after filter', () => {
-			// filter narrows to weather-* and form-to-hubspot, then exclude
-			// removes weather-monitoring
 			expect(slugs('weather,form-to-hubspot', 'monitoring')).toEqual([
 				'form-to-hubspot',
 				'weather-alert',
@@ -137,22 +136,20 @@ describe('loadWorkflowTestCasesWithFiles', () => {
 
 	describe('--tier (datasets-field filter)', () => {
 		it('defaults to ["full"] when a test case omits the datasets field', () => {
-			// STUB_TEST_CASE doesn't declare datasets — Zod default fills it in.
 			const cases = loadWorkflowTestCasesWithFiles();
 			expect(cases.every((c) => c.testCase.datasets.includes('full'))).toBe(true);
 		});
 
 		it('filters to test cases whose datasets array contains the tier', () => {
-			// Re-mock so two cases declare different datasets memberships.
 			mockedReadFile.mockImplementation((p) => {
 				const filename = String(p);
 				if (filename.includes('weather-alert')) {
 					return JSON.stringify({
-						...JSON.parse(STUB_TEST_CASE),
+						...jsonParse(STUB_TEST_CASE),
 						datasets: ['pr', 'full'],
 					});
 				}
-				return STUB_TEST_CASE; // default → ['full']
+				return STUB_TEST_CASE;
 			});
 
 			const inPr = loadWorkflowTestCasesWithFiles(undefined, undefined, 'pr')
@@ -171,15 +168,13 @@ describe('loadWorkflowTestCasesWithFiles', () => {
 				const filename = String(p);
 				if (filename.includes('weather-alert')) {
 					return JSON.stringify({
-						...JSON.parse(STUB_TEST_CASE),
+						...jsonParse(STUB_TEST_CASE),
 						datasets: ['pr', 'full'],
 					});
 				}
 				return STUB_TEST_CASE;
 			});
 
-			// `weather` substring matches weather-alert + weather-monitoring;
-			// `--tier pr` keeps only weather-alert (the only one tagged 'pr').
 			const result = loadWorkflowTestCasesWithFiles('weather', undefined, 'pr')
 				.map((c) => c.fileSlug)
 				.sort();

--- a/packages/@n8n/instance-ai/evaluations/__tests__/data-workflows.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/data-workflows.test.ts
@@ -160,7 +160,8 @@ describe('loadWorkflowTestCasesWithFiles', () => {
 				.sort();
 
 			expect(inPr).toEqual(['weather-alert']);
-			expect(inFull.length).toBe(7); // all .json files end up in full
+			const allSlugs = loadWorkflowTestCasesWithFiles().map((c) => c.fileSlug).sort();
+			expect(inFull).toEqual(allSlugs);
 		});
 
 		it('composes with --filter: tier filter applies after substring filter', () => {
@@ -179,6 +180,19 @@ describe('loadWorkflowTestCasesWithFiles', () => {
 				.map((c) => c.fileSlug)
 				.sort();
 			expect(result).toEqual(['weather-alert']);
+		});
+
+		it('throws when --tier matches no test cases (catches typos instead of silent green)', () => {
+			expect(() => loadWorkflowTestCasesWithFiles(undefined, undefined, 'prr')).toThrow(
+				/No test cases match --tier "prr"/,
+			);
+		});
+
+		it('rejects a test case that declares an empty datasets array', () => {
+			mockedReadFile.mockImplementation(() =>
+				JSON.stringify({ ...jsonParse(STUB_TEST_CASE), datasets: [] }),
+			);
+			expect(() => loadWorkflowTestCasesWithFiles()).toThrow(/datasets/i);
 		});
 	});
 });

--- a/packages/@n8n/instance-ai/evaluations/__tests__/dataset-sync.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/dataset-sync.test.ts
@@ -51,6 +51,7 @@ function existingExample(id: string, testCaseFile: string, scenarioName: string)
 			tags: ['test'],
 			triggerType: 'manual',
 		},
+		split: [testCaseFile, 'full'],
 		outputs: {},
 		runs: [],
 	} as unknown as Example;
@@ -170,6 +171,24 @@ describe('syncDataset', () => {
 		expect(createExamples).toHaveBeenCalledTimes(1);
 		const created = createExamples.mock.calls[0][0];
 		expect((created[0] as unknown as { split: string[] }).split).toEqual(['foo', 'pr', 'full']);
+	});
+
+	it('updates an existing example when only its split (tier membership) changed', async () => {
+		const existing = existingExample('split-uuid', 'foo', 'happy-path'); // split: ['foo', 'full']
+		const fixture = scenarioFixture('foo', 'happy-path');
+		fixture.testCase.datasets = ['pr', 'full']; // now also tagged 'pr'
+		mockedLoad.mockReturnValue([fixture]);
+		const { client, createExamples, updateExamples } = buildClient([existing]);
+
+		await syncDataset(client, 'ds', logger);
+
+		expect(createExamples).not.toHaveBeenCalled();
+		expect(updateExamples).toHaveBeenCalledTimes(1);
+		expect((updateExamples.mock.calls[0][0][0] as unknown as { split: string[] }).split).toEqual([
+			'foo',
+			'pr',
+			'full',
+		]);
 	});
 
 	it('creates a fresh example when a previously-deleted scenario is re-added (resurrection path)', async () => {

--- a/packages/@n8n/instance-ai/evaluations/__tests__/dataset-sync.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/dataset-sync.test.ts
@@ -26,6 +26,7 @@ function scenarioFixture(testCaseFile: string, scenarioName: string) {
 					successCriteria: `criteria for ${scenarioName}`,
 				},
 			],
+			datasets: ['full'],
 		},
 		fileSlug: testCaseFile,
 	};
@@ -156,6 +157,19 @@ describe('syncDataset', () => {
 		expect(createExamples).not.toHaveBeenCalled();
 		expect(updateExamples).not.toHaveBeenCalled();
 		expect(deleteExamples).not.toHaveBeenCalled();
+	});
+
+	it('writes datasets values into the example split alongside the file slug', async () => {
+		const fixture = scenarioFixture('foo', 'happy-path');
+		fixture.testCase.datasets = ['pr', 'full'];
+		mockedLoad.mockReturnValue([fixture]);
+		const { client, createExamples } = buildClient([]);
+
+		await syncDataset(client, 'ds', logger);
+
+		expect(createExamples).toHaveBeenCalledTimes(1);
+		const created = createExamples.mock.calls[0][0];
+		expect((created[0] as unknown as { split: string[] }).split).toEqual(['foo', 'pr', 'full']);
 	});
 
 	it('creates a fresh example when a previously-deleted scenario is re-added (resurrection path)', async () => {

--- a/packages/@n8n/instance-ai/evaluations/cli/args.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/args.ts
@@ -51,6 +51,11 @@ export interface CliArgs {
 	 *  wire-server interception path. Useful for A/B comparison or when a
 	 *  specific root needs to stay on the pinned baseline. CSV of node names. */
 	pinAiRoots?: string[];
+	/** Filter test cases by the `datasets` field (e.g. `pr`, `full`). When set,
+	 *  only test cases whose `datasets` array contains this value will run, and
+	 *  LangSmith examples are queried via the matching split. Defaults to
+	 *  unset → run everything matched by `--filter` / `--exclude`. */
+	tier?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -73,6 +78,7 @@ const cliArgsSchema = z.object({
 	experimentName: z.string().optional(),
 	iterations: z.number().int().positive().default(1),
 	pinAiRoots: z.array(z.string().min(1)).optional(),
+	tier: z.string().min(1).optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -99,6 +105,7 @@ export function parseCliArgs(argv: string[]): CliArgs {
 		experimentName: validated.experimentName,
 		iterations: validated.iterations,
 		pinAiRoots: validated.pinAiRoots,
+		tier: validated.tier,
 	};
 }
 
@@ -122,6 +129,7 @@ interface RawArgs {
 	experimentName?: string;
 	iterations: number;
 	pinAiRoots?: string[];
+	tier?: string;
 }
 
 function parseRawArgs(argv: string[]): RawArgs {
@@ -224,6 +232,11 @@ function parseRawArgs(argv: string[]): RawArgs {
 				i++;
 				break;
 			}
+
+			case '--tier':
+				result.tier = nextArg(argv, i, '--tier');
+				i++;
+				break;
 
 			default:
 				// Fail loudly on unknown flags. Strip any =value payload before

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -280,7 +280,7 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 
 	const lsClient = new Client();
 	const datasetName = await syncDataset(lsClient, args.dataset, logger, args.filter, args.exclude);
-	const testCasesWithFiles = loadWorkflowTestCasesWithFiles(args.filter, args.exclude);
+	const testCasesWithFiles = loadWorkflowTestCasesWithFiles(args.filter, args.exclude, args.tier);
 
 	// Stash transcripts by threadId so reshapeLangSmithRuns can merge them in —
 	// the LangSmith target() output schema doesn't carry the full transcript.
@@ -586,6 +586,7 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 		datasetName,
 		args.filter,
 		args.exclude,
+		args.tier,
 		logger,
 	);
 	const evaluateData =
@@ -700,12 +701,14 @@ function filteredExamplesIterable(
 	datasetName: string,
 	filter: string | undefined,
 	exclude: string | undefined,
+	tier: string | undefined,
 	logger: EvalLogger,
 ): AsyncIterable<Example> {
-	const slugs = loadWorkflowTestCasesWithFiles(filter, exclude).map((tc) => tc.fileSlug);
+	const slugs = loadWorkflowTestCasesWithFiles(filter, exclude, tier).map((tc) => tc.fileSlug);
 	const labelParts: string[] = [];
 	if (filter) labelParts.push(`filter "${filter}"`);
 	if (exclude) labelParts.push(`exclude "${exclude}"`);
+	if (tier) labelParts.push(`tier "${tier}"`);
 	const label = labelParts.length > 0 ? labelParts.join(' + ') : 'Local test cases';
 	if (slugs.length === 0) {
 		logger.info(`${label} matched no local test case files`);
@@ -896,7 +899,7 @@ function reshapeLangSmithRuns(
 async function runDirectLoop(config: RunConfig): Promise<MultiRunEvaluation> {
 	const { args, lanes, logger, prebuiltManifest } = config;
 
-	const testCasesWithFiles = loadWorkflowTestCasesWithFiles(args.filter, args.exclude);
+	const testCasesWithFiles = loadWorkflowTestCasesWithFiles(args.filter, args.exclude, args.tier);
 	if (testCasesWithFiles.length === 0) {
 		console.log('No workflow test cases found in evaluations/data/workflows/');
 		return { totalRuns: 0, testCases: [] };

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/airtable-split-to-slack.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/airtable-split-to-slack.json
@@ -25,6 +25,7 @@
 	"complexity": "medium",
 	"tags": ["build", "schedule", "http-request", "airtable", "slack", "split-out"],
 	"triggerType": "schedule",
+	"datasets": ["pr", "full"],
 	"executionScenarios": [
 		{
 			"name": "happy-path",

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/index.ts
@@ -78,5 +78,13 @@ export function loadWorkflowTestCasesWithFiles(
 		fileSlug: basename(f, '.json'),
 	}));
 	if (!tier) return cases;
-	return cases.filter(({ testCase }) => testCase.datasets.includes(tier));
+
+	const matched = cases.filter(({ testCase }) => testCase.datasets.includes(tier));
+	if (matched.length === 0) {
+		const known = [...new Set(cases.flatMap(({ testCase }) => testCase.datasets))].sort();
+		throw new Error(
+			`No test cases match --tier "${tier}". Known tiers: ${known.join(', ') || '(none)'}.`,
+		);
+	}
+	return matched;
 }

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/index.ts
@@ -71,9 +71,12 @@ function getJsonFiles(filter?: string, exclude?: string): string[] {
 export function loadWorkflowTestCasesWithFiles(
 	filter?: string,
 	exclude?: string,
+	tier?: string,
 ): WorkflowTestCaseWithFile[] {
-	return getJsonFiles(filter, exclude).map((f) => ({
+	const cases = getJsonFiles(filter, exclude).map((f) => ({
 		testCase: parseTestCaseFile(f),
 		fileSlug: basename(f, '.json'),
 	}));
+	if (!tier) return cases;
+	return cases.filter(({ testCase }) => testCase.datasets.includes(tier));
 }

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/notification-router.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/notification-router.json
@@ -25,6 +25,7 @@
 	"complexity": "medium",
 	"tags": ["build", "webhook", "switch", "microsoft-teams", "slack", "gmail", "routing"],
 	"triggerType": "webhook",
+	"datasets": ["pr", "full"],
 	"executionScenarios": [
 		{
 			"name": "high-priority",

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/rest-api-data-pipeline.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/rest-api-data-pipeline.json
@@ -25,6 +25,7 @@
 	"complexity": "medium",
 	"tags": ["build", "http-request", "slack", "data-transformation", "schedule"],
 	"triggerType": "schedule",
+	"datasets": ["pr", "full"],
 	"executionScenarios": [
 		{
 			"name": "happy-path",

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/schema.ts
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/schema.ts
@@ -20,6 +20,13 @@ export const WorkflowTestCaseSchema = z.object({
 	triggerType: z.enum(['manual', 'webhook', 'schedule', 'form']).optional(),
 	executionScenarios: z.array(ExecutionScenarioSchema).min(1),
 	messageBudget: z.number().int().positive().optional(),
+	/**
+	 * Logical groupings this case belongs to (e.g. `['pr', 'full']`). Used by
+	 * the eval CLI's `--tier` flag and propagated to LangSmith as example
+	 * splits, so subsets can be evaluated and compared independently. Defaults
+	 * to `['full']` — cases without this field run in the full suite only.
+	 */
+	datasets: z.array(z.string()).default(['full']),
 });
 
 export type WorkflowTestCaseInput = z.infer<typeof WorkflowTestCaseSchema>;

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/schema.ts
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/schema.ts
@@ -26,7 +26,7 @@ export const WorkflowTestCaseSchema = z.object({
 	 * splits, so subsets can be evaluated and compared independently. Defaults
 	 * to `['full']` — cases without this field run in the full suite only.
 	 */
-	datasets: z.array(z.string()).default(['full']),
+	datasets: z.array(z.string()).min(1).default(['full']),
 });
 
 export type WorkflowTestCaseInput = z.infer<typeof WorkflowTestCaseSchema>;

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/telegram-chatbot-memory-session.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/telegram-chatbot-memory-session.json
@@ -24,6 +24,7 @@
 	"messageBudget": 6,
 	"complexity": "medium",
 	"tags": ["build", "telegram", "chatbot", "ai-agent", "memory", "expressions"],
+	"datasets": ["pr", "full"],
 	"executionScenarios": [
 		{
 			"name": "distinct-telegram-chat",

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/weather-alert.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/weather-alert.json
@@ -25,6 +25,7 @@
 	"complexity": "simple",
 	"tags": ["build", "schedule", "http-request", "gmail", "conditional"],
 	"triggerType": "schedule",
+	"datasets": ["pr", "full"],
 	"executionScenarios": [
 		{
 			"name": "happy-path",

--- a/packages/@n8n/instance-ai/evaluations/data/workflows/workflow-data-table.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/workflow-data-table.json
@@ -25,6 +25,7 @@
 	"complexity": "complex",
 	"tags": ["build", "schedule", "data-table", "n8n-api"],
 	"triggerType": "schedule",
+	"datasets": ["pr", "full"],
 	"executionScenarios": [
 		{
 			"name": "happy-path",

--- a/packages/@n8n/instance-ai/evaluations/langsmith/dataset-sync.ts
+++ b/packages/@n8n/instance-ai/evaluations/langsmith/dataset-sync.ts
@@ -121,7 +121,8 @@ export async function syncDataset(
 		if (existingExample) {
 			if (
 				hasInputsChanged(existingExample.inputs, inputs) ||
-				hasMetadataChanged(existingExample.metadata, metadata)
+				hasMetadataChanged(existingExample.metadata, metadata) ||
+				hasSplitChanged(existingExample.split, split)
 			) {
 				toUpdate.push({
 					id: existingExample.id,
@@ -271,4 +272,13 @@ function hasMetadataChanged(existing: unknown, incoming: DatasetExampleMetadata)
 		e.triggerType !== (incoming.triggerType ?? '') ||
 		JSON.stringify(e.tags) !== JSON.stringify(incoming.tags ?? [])
 	);
+}
+
+// Split (file slug + datasets/tiers) is order-insensitive — compare as sets so a
+// reorder isn't a change, but adding/removing a tier is and triggers a re-sync.
+function hasSplitChanged(existing: string | string[] | undefined, incoming: string[]): boolean {
+	const current = existing === undefined ? [] : Array.isArray(existing) ? existing : [existing];
+	if (current.length !== incoming.length) return true;
+	const incomingSet = new Set(incoming);
+	return !current.every((s) => incomingSet.has(s));
 }

--- a/packages/@n8n/instance-ai/evaluations/langsmith/dataset-sync.ts
+++ b/packages/@n8n/instance-ai/evaluations/langsmith/dataset-sync.ts
@@ -92,9 +92,10 @@ export async function syncDataset(
 		existingByDerivedId.set(`${inputs.data.testCaseFile}/${inputs.data.scenarioName}`, example);
 	}
 
-	// Diff and sync
-	const toCreate: Array<{ id: string; inputs: KVMap; metadata: KVMap; split: string }> = [];
-	const toUpdate: Array<{ id: string; inputs: KVMap; metadata: KVMap; split: string }> = [];
+	// Diff and sync. `split` is multi-valued so a case can belong to multiple
+	// logical groupings (e.g. ['pr', 'full']) in addition to its per-file slug.
+	const toCreate: Array<{ id: string; inputs: KVMap; metadata: KVMap; split: string[] }> = [];
+	const toUpdate: Array<{ id: string; inputs: KVMap; metadata: KVMap; split: string[] }> = [];
 
 	for (const scenario of scenarios) {
 		const derivedId = `${scenario.testCaseFile}/${scenario.scenarioName}`;
@@ -114,6 +115,8 @@ export async function syncDataset(
 			triggerType: scenario.triggerType,
 		};
 
+		const split = [scenario.testCaseFile, ...scenario.datasets];
+
 		const existingExample = existingByDerivedId.get(derivedId);
 		if (existingExample) {
 			if (
@@ -124,7 +127,7 @@ export async function syncDataset(
 					id: existingExample.id,
 					inputs,
 					metadata,
-					split: scenario.testCaseFile,
+					split,
 				});
 			}
 		} else {
@@ -132,7 +135,7 @@ export async function syncDataset(
 				id: randomUUID(),
 				inputs,
 				metadata,
-				split: scenario.testCaseFile,
+				split,
 			});
 		}
 	}
@@ -183,6 +186,8 @@ interface FlatScenario {
 	complexity?: 'simple' | 'medium' | 'complex';
 	tags?: string[];
 	triggerType?: 'manual' | 'webhook' | 'schedule' | 'form';
+	/** Logical groupings (e.g. ['pr', 'full']) — written into the LangSmith example's splits alongside the file slug. */
+	datasets: string[];
 }
 
 /**
@@ -211,6 +216,7 @@ function buildRoundRobinScenarios(testCasesWithFiles: WorkflowTestCaseWithFile[]
 					complexity: testCase.complexity,
 					tags: testCase.tags,
 					triggerType: testCase.triggerType,
+					datasets: testCase.datasets,
 				});
 			}
 		}

--- a/packages/@n8n/instance-ai/evaluations/types.ts
+++ b/packages/@n8n/instance-ai/evaluations/types.ts
@@ -184,6 +184,8 @@ export interface WorkflowTestCase {
 	executionScenarios: ExecutionScenario[];
 	/** Max follow-up messages the proxy will send. Ignored in auto-approve mode. */
 	messageBudget?: number;
+	/** Logical groupings this case belongs to (e.g. `['pr', 'full']`). Defaults to `['full']`. */
+	datasets: string[];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
> **Stacked on #31428.** Base branch is `fix/eval-mock-tolerate-idless-credentials`. The diff in the Files tab shows only the new work on top of that branch; when #31428 merges to master, this PR auto-retargets.

## Summary

Adds a logical-grouping mechanism (`datasets: string[]`) to the workflow eval test cases so the CLI can filter to a subset (today: `pr`) for cost-bounded PR runs, while the full suite continues to run nightly / on demand.

This is the **test-suite half** of the "re-enable evals on PRs at moderate cost" effort. The trigger half follows in a stacked PR.

Extends [TRUST-134](https://linear.app/n8n/issue/TRUST-134/fiximprov-prepare-thin-test-dataset-for-prs).

## What changed

- **New `datasets: string[]` field on every test case.** Zod-defaulted to `['full']` — cases omitting the field automatically run in the full suite, so no ghost cases.
- **6 capability-diverse, high-reliability cases tagged `["pr", "full"]`** (all 10/10 on the May 15 baseline):
  - `notification-router` — webhook + Switch + Teams/Slack/Gmail (branch routing)
  - `weather-alert` — schedule + HTTP + IF + Gmail (conditional)
  - `airtable-split-to-slack` — schedule + HTTP-bearer + Split Out + Slack (fan-out)
  - `rest-api-data-pipeline` — schedule + HTTP + filter + Slack (transform)
  - `telegram-chatbot-memory-session` — chat trigger + AI Agent + memory (agent loop)
  - `workflow-data-table` — schedule + n8n API + Data Table (upsert)
- **New `--tier <name>` CLI flag** filters local test cases by `datasets` membership. Composes with `--filter` / `--exclude` (intersection).
- **LangSmith sync writes `datasets` values into each example's `split` array** alongside the existing file-slug split. The SDK's `split?: string | string[]` is multi-valued; one example can belong to many splits at once. Single LangSmith dataset preserved; existing baseline `instance-ai-baseline-9b3c4676` remains valid.
- **README**: added a short "Test-case datasets (logical groupings)" section with field reference and curation guidance.

## Why this design

- **Repo JSON stays canonical.** LangSmith is a derived consumer.
- **One LangSmith dataset, multi-valued splits** vs separate `-pr` / `-full` datasets: no data duplication, baselines stay valid, future tiers (e.g. `ai-nodes`) cost nothing to add.
- **Defaults bias toward inclusion.** Adding a new test case JSON gets you in the full suite automatically.

## Test plan

- [x] `pnpm --filter @n8n/instance-ai typecheck` clean
- [x] `pnpm --filter @n8n/instance-ai lint` clean
- [x] `pnpm --filter @n8n/instance-ai test` — 2329/2329 pass
- [x] New tests cover:
  - Schema default behavior (`datasets` defaults to `['full']` when omitted)
  - Loader filtering by `--tier`
  - `--tier` composing with `--filter` (intersection)
  - Sync writing `datasets` values into the example split array
- [ ] Manual end-to-end: `pnpm eval:instance-ai --tier pr --iterations 1` runs only 6 cases — to validate after #31428 merges and master baseline is refreshed

## Follow-up (separate stacked PR)

The CI trigger configuration that uses `--tier pr` for PR-time runs is the next piece (re-scoped TRUST-71).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
