### PR TITLE
feat(Rocketchat Node): Add Subscriptions & IM ops

### DIFF
--- a/packages/nodes-base/nodes/Rocketchat/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Rocketchat/GenericFunctions.ts
@@ -32,6 +32,43 @@ export async function rocketchatApiRequest(
 	return await this.helpers.requestWithAuthentication.call(this, 'rocketchatApi', options);
 }
 
+export async function rocketchatApiRequestAllItems(
+	this: IExecuteFunctions | ILoadOptionsFunctions,
+	propertyName: string,
+	resource: string,
+	method: IHttpRequestMethods,
+	operation: string,
+	body: IDataObject = {},
+	queryParams: IDataObject = {},
+): Promise<IDataObject[]> {
+	const returnData: IDataObject[] = [];
+	let responseData: IDataObject;
+	let offset = 0;
+	const { limit: _limit, ...paginationQuery } = queryParams;
+	const count = paginationQuery.count ?? 100;
+
+	do {
+		responseData = (await rocketchatApiRequest.call(this, resource, method, operation, body, {
+			...paginationQuery,
+			offset,
+			count,
+		})) as IDataObject;
+
+		const responseItems = responseData[propertyName] as IDataObject[] | undefined;
+
+		if (!Array.isArray(responseItems) || responseItems.length === 0) {
+			break;
+		}
+
+		returnData.push.apply(returnData, responseItems);
+		offset = returnData.length;
+	} while (
+		returnData.length < ((responseData.total as number | undefined) ?? Number.POSITIVE_INFINITY)
+	);
+
+	return returnData;
+}
+
 export function validateJSON(json: string | undefined): any {
 	let result;
 	try {

--- a/packages/nodes-base/nodes/Rocketchat/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Rocketchat/GenericFunctions.ts
@@ -13,6 +13,7 @@ export async function rocketchatApiRequest(
 	operation: string,
 
 	body: any = {},
+	queryParams?: IDataObject,
 	headers?: IDataObject,
 ): Promise<any> {
 	const credentials = await this.getCredentials('rocketchatApi');
@@ -22,6 +23,7 @@ export async function rocketchatApiRequest(
 		method,
 		body,
 		uri: `${credentials.domain}/api/v1${resource}.${operation}`,
+		qs: queryParams,
 		json: true,
 	};
 	if (Object.keys(options.body as IDataObject).length === 0) {

--- a/packages/nodes-base/nodes/Rocketchat/Rocketchat.node.ts
+++ b/packages/nodes-base/nodes/Rocketchat/Rocketchat.node.ts
@@ -75,6 +75,14 @@ export class Rocketchat implements INodeType {
 						name: 'Chat',
 						value: 'chat',
 					},
+					{
+						name: 'Subscription',
+						value: 'subscriptions',
+					},
+					{
+						name: 'Direct Message',
+						value: 'im',
+					},
 				],
 				default: 'chat',
 			},
@@ -97,6 +105,66 @@ export class Rocketchat implements INodeType {
 					},
 				],
 				default: 'postMessage',
+			},
+			{
+				displayName: 'Operation',
+				name: 'operation',
+				type: 'options',
+				noDataExpression: true,
+				displayOptions: {
+					show: {
+						resource: ['subscriptions'],
+					},
+				},
+				options: [
+					{
+						name: 'Get All',
+						value: 'get',
+						description: 'Retrieve a list of subscriptions',
+						action: 'Get Subscriptions',
+					},
+					{
+						name: 'Mark As Read',
+						value: 'read',
+						description: 'Mark a message as read',
+						action: 'Mark As Read',
+					},
+				],
+				default: 'get',
+			},
+			{
+				displayName: 'Operation',
+				name: 'operation',
+				type: 'options',
+				noDataExpression: true,
+				displayOptions: {
+					show: {
+						resource: ['im'],
+					},
+				},
+				options: [
+					{
+						name: 'Get Messages',
+						value: 'messages',
+						description: 'Retrieve a list of messages',
+						action: 'Get Messages',
+					},
+				],
+				default: 'messages',
+			},
+			{
+				displayName: 'Room ID',
+				name: 'roomId',
+				type: 'string',
+				required: true,
+				displayOptions: {
+					show: {
+						resource: ['subscriptions', 'im'],
+						operation: ['read', 'messages'],
+					},
+				},
+				default: '',
+				description: 'The channel name with the prefix in front of it',
 			},
 			{
 				displayName: 'Channel',
@@ -476,6 +544,33 @@ export class Rocketchat implements INodeType {
 							'POST',
 							'postMessage',
 							body,
+						);
+					}
+				} else if (resource === 'subscriptions') {
+					if (operation === 'get') {
+						responseData = await rocketchatApiRequest.call(
+							this,
+							'/subscriptions',
+							'GET',
+							'get',
+							{},
+						);
+					} else if (operation === 'read') {
+						const roomId = this.getNodeParameter('roomId', i) as string;
+						responseData = await rocketchatApiRequest.call(this, '/subscriptions', 'POST', 'read', {
+							rid: roomId,
+						});
+					}
+				} else if (resource === 'im') {
+					if (operation === 'messages') {
+						const roomId = this.getNodeParameter('roomId', i) as string;
+						responseData = await rocketchatApiRequest.call(
+							this,
+							'/im',
+							'GET',
+							'messages',
+							{},
+							{ roomId },
 						);
 					}
 				}

--- a/packages/nodes-base/nodes/Rocketchat/Rocketchat.node.ts
+++ b/packages/nodes-base/nodes/Rocketchat/Rocketchat.node.ts
@@ -126,7 +126,7 @@ export class Rocketchat implements INodeType {
 					{
 						name: 'Mark As Read',
 						value: 'read',
-						description: 'Mark the subscription as read.',
+						description: 'Mark the subscription as read',
 						action: 'Mark As Read',
 					},
 				],

--- a/packages/nodes-base/nodes/Rocketchat/Rocketchat.node.ts
+++ b/packages/nodes-base/nodes/Rocketchat/Rocketchat.node.ts
@@ -7,7 +7,11 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 
-import { rocketchatApiRequest, validateJSON } from './GenericFunctions';
+import {
+	rocketchatApiRequest,
+	rocketchatApiRequestAllItems,
+	validateJSON,
+} from './GenericFunctions';
 
 interface IField {
 	short?: boolean;
@@ -41,6 +45,15 @@ interface IPostMessageBody {
 	emoji?: string;
 	avatar?: string;
 	attachments?: IAttachment[];
+}
+
+interface ISubscriptionsResponse {
+	update?: IDataObject[];
+	remove?: IDataObject[];
+}
+
+interface IDirectMessagesResponse {
+	messages?: IDataObject[];
 }
 
 export class Rocketchat implements INodeType {
@@ -80,8 +93,8 @@ export class Rocketchat implements INodeType {
 						value: 'subscriptions',
 					},
 					{
-						name: 'Incoming Messages',
-						value: 'im',
+						name: 'Direct Message',
+						value: 'dm',
 					},
 				],
 				default: 'chat',
@@ -118,7 +131,7 @@ export class Rocketchat implements INodeType {
 				},
 				options: [
 					{
-						name: 'Get All',
+						name: 'Get Many',
 						value: 'get',
 						description: 'Retrieve a list of subscriptions',
 						action: 'Get Subscriptions',
@@ -139,7 +152,7 @@ export class Rocketchat implements INodeType {
 				noDataExpression: true,
 				displayOptions: {
 					show: {
-						resource: ['im'],
+						resource: ['dm'],
 					},
 				},
 				options: [
@@ -159,12 +172,42 @@ export class Rocketchat implements INodeType {
 				required: true,
 				displayOptions: {
 					show: {
-						resource: ['subscriptions', 'im'],
+						resource: ['subscriptions', 'dm'],
 						operation: ['read', 'messages'],
 					},
 				},
 				default: '',
-				description: 'The channel name with the prefix in front of it',
+				description: 'The room identifier',
+			},
+			{
+				displayName: 'Return All',
+				name: 'returnAll',
+				type: 'boolean',
+				displayOptions: {
+					show: {
+						resource: ['dm'],
+						operation: ['messages'],
+					},
+				},
+				default: false,
+				description: 'Whether to return all results or only up to a given limit',
+			},
+			{
+				displayName: 'Limit',
+				name: 'limit',
+				type: 'number',
+				displayOptions: {
+					show: {
+						resource: ['dm'],
+						operation: ['messages'],
+						returnAll: [false],
+					},
+				},
+				typeOptions: {
+					minValue: 1,
+				},
+				default: 50,
+				description: 'Max number of results to return',
 			},
 			{
 				displayName: 'Channel',
@@ -440,7 +483,7 @@ export class Rocketchat implements INodeType {
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();
 		const length = items.length;
-		let responseData;
+		let responseData: IDataObject | IDataObject[] = {};
 		const returnData: INodeExecutionData[] = [];
 		const resource = this.getNodeParameter('resource', 0);
 		const operation = this.getNodeParameter('operation', 0);
@@ -548,30 +591,51 @@ export class Rocketchat implements INodeType {
 					}
 				} else if (resource === 'subscriptions') {
 					if (operation === 'get') {
-						responseData = await rocketchatApiRequest.call(
+						const subscriptionsResponse = (await rocketchatApiRequest.call(
 							this,
 							'/subscriptions',
 							'GET',
 							'get',
 							{},
-						);
+						)) as ISubscriptionsResponse;
+						responseData = [
+							...(subscriptionsResponse.update ?? []).map((update) => ({ update })),
+							...(subscriptionsResponse.remove ?? []).map((remove) => ({ remove })),
+						];
 					} else if (operation === 'read') {
 						const roomId = this.getNodeParameter('roomId', i) as string;
 						responseData = await rocketchatApiRequest.call(this, '/subscriptions', 'POST', 'read', {
 							rid: roomId,
 						});
 					}
-				} else if (resource === 'im') {
+				} else if (resource === 'dm') {
 					if (operation === 'messages') {
 						const roomId = this.getNodeParameter('roomId', i) as string;
-						responseData = await rocketchatApiRequest.call(
-							this,
-							'/im',
-							'GET',
-							'messages',
-							{},
-							{ roomId },
-						);
+						const returnAll = this.getNodeParameter('returnAll', i);
+						const qs: IDataObject = { roomId };
+
+						if (returnAll) {
+							responseData = await rocketchatApiRequestAllItems.call(
+								this,
+								'messages',
+								'/dm',
+								'GET',
+								'messages',
+								{},
+								qs,
+							);
+						} else {
+							qs.count = this.getNodeParameter('limit', i);
+							const messagesResponse = (await rocketchatApiRequest.call(
+								this,
+								'/dm',
+								'GET',
+								'messages',
+								{},
+								qs,
+							)) as IDirectMessagesResponse;
+							responseData = messagesResponse.messages ?? [];
+						}
 					}
 				}
 				const executionData = this.helpers.constructExecutionMetaData(

--- a/packages/nodes-base/nodes/Rocketchat/Rocketchat.node.ts
+++ b/packages/nodes-base/nodes/Rocketchat/Rocketchat.node.ts
@@ -126,7 +126,7 @@ export class Rocketchat implements INodeType {
 					{
 						name: 'Mark As Read',
 						value: 'read',
-						description: 'Mark a message as read',
+						description: 'Mark the subscription as read.',
 						action: 'Mark As Read',
 					},
 				],

--- a/packages/nodes-base/nodes/Rocketchat/Rocketchat.node.ts
+++ b/packages/nodes-base/nodes/Rocketchat/Rocketchat.node.ts
@@ -80,7 +80,7 @@ export class Rocketchat implements INodeType {
 						value: 'subscriptions',
 					},
 					{
-						name: 'Incoming Message',
+						name: 'Incoming Messages',
 						value: 'im',
 					},
 				],

--- a/packages/nodes-base/nodes/Rocketchat/Rocketchat.node.ts
+++ b/packages/nodes-base/nodes/Rocketchat/Rocketchat.node.ts
@@ -80,7 +80,7 @@ export class Rocketchat implements INodeType {
 						value: 'subscriptions',
 					},
 					{
-						name: 'Direct Message',
+						name: 'Incoming Message',
 						value: 'im',
 					},
 				],

--- a/packages/nodes-base/nodes/Rocketchat/tests/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Rocketchat/tests/GenericFunctions.test.ts
@@ -1,0 +1,121 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+
+import { rocketchatApiRequest, validateJSON } from '../GenericFunctions';
+
+type RequestOptions = {
+	method?: string;
+	uri?: string;
+	body?: unknown;
+	qs?: unknown;
+	headers?: unknown;
+	json?: boolean;
+};
+
+describe('RocketChat > GenericFunctions', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('validateJSON', () => {
+		it('should parse valid JSON object', () => {
+			const result = validateJSON('{"a":1}');
+			expect(result).toEqual({ a: 1 });
+		});
+
+		it('should parse valid JSON array', () => {
+			const result = validateJSON('[{"a":1}]');
+			expect(result).toEqual([{ a: 1 }]);
+		});
+
+		it('should return empty array on invalid JSON', () => {
+			const result = validateJSON('{invalid}');
+			expect(result).toEqual([]);
+		});
+
+		it('should return empty array when undefined', () => {
+			const result = validateJSON(undefined);
+			expect(result).toEqual([]);
+		});
+	});
+
+	describe('rocketchatApiRequest', () => {
+		function createContext() {
+			const requestWithAuthentication = jest.fn();
+
+			const context = {
+				getCredentials: jest.fn().mockResolvedValue({
+					domain: 'https://chat.example.com',
+				}),
+				helpers: {
+					requestWithAuthentication,
+				},
+			};
+
+			return { context, requestWithAuthentication };
+		}
+
+		it('should build correct request and call helper', async () => {
+			const { context, requestWithAuthentication } = createContext();
+
+			requestWithAuthentication.mockResolvedValueOnce({ ok: true });
+
+			const result = await rocketchatApiRequest.call(
+				context as any,
+				'/chat',
+				'POST',
+				'postMessage',
+				{ text: 'hello' },
+				{ foo: 'bar' },
+				{ header: 'x' },
+			);
+
+			expect(result).toEqual({ ok: true });
+
+			expect(requestWithAuthentication).toHaveBeenCalledWith(
+				'rocketchatApi',
+				expect.objectContaining({
+					method: 'POST',
+					uri: 'https://chat.example.com/api/v1/chat.postMessage',
+					body: { text: 'hello' },
+					qs: { foo: 'bar' },
+					headers: { header: 'x' },
+					json: true,
+				}),
+			);
+		});
+
+		it('should remove empty body', async () => {
+			const { context, requestWithAuthentication } = createContext();
+
+			requestWithAuthentication.mockResolvedValueOnce({ ok: true });
+
+			await rocketchatApiRequest.call(
+				context as unknown as IExecuteFunctions,
+				'/subscriptions',
+				'GET',
+				'get',
+				{},
+			);
+
+			const call = requestWithAuthentication.mock.calls[0][1] as RequestOptions;
+
+			expect(call.body).toBeUndefined();
+		});
+
+		it('should propagate API errors', async () => {
+			const { context, requestWithAuthentication } = createContext();
+
+			requestWithAuthentication.mockRejectedValueOnce(new Error('API Error'));
+
+			await expect(
+				rocketchatApiRequest.call(
+					context as unknown as IExecuteFunctions,
+					'/chat',
+					'POST',
+					'postMessage',
+					{},
+				),
+			).rejects.toThrow('API Error');
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Rocketchat/tests/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Rocketchat/tests/GenericFunctions.test.ts
@@ -1,6 +1,12 @@
 import type { IExecuteFunctions } from 'n8n-workflow';
 
-import { rocketchatApiRequest, validateJSON } from '../GenericFunctions';
+import {
+	rocketchatApiRequest,
+	rocketchatApiRequestAllItems,
+	validateJSON,
+} from '../GenericFunctions';
+
+const jest = vi;
 
 type RequestOptions = {
 	method?: string;
@@ -60,7 +66,7 @@ describe('RocketChat > GenericFunctions', () => {
 			requestWithAuthentication.mockResolvedValueOnce({ ok: true });
 
 			const result = await rocketchatApiRequest.call(
-				context as any,
+				context as unknown as IExecuteFunctions,
 				'/chat',
 				'POST',
 				'postMessage',
@@ -116,6 +122,91 @@ describe('RocketChat > GenericFunctions', () => {
 					{},
 				),
 			).rejects.toThrow('API Error');
+		});
+	});
+
+	describe('rocketchatApiRequestAllItems', () => {
+		function createContext() {
+			const requestWithAuthentication = jest.fn();
+
+			const context = {
+				getCredentials: jest.fn().mockResolvedValue({
+					domain: 'https://chat.example.com',
+				}),
+				helpers: {
+					requestWithAuthentication,
+				},
+			};
+
+			return { context, requestWithAuthentication };
+		}
+
+		it('should request all pages using offset and count', async () => {
+			const { context, requestWithAuthentication } = createContext();
+
+			requestWithAuthentication
+				.mockResolvedValueOnce({
+					messages: [{ _id: 'msg1' }, { _id: 'msg2' }],
+					total: 3,
+				})
+				.mockResolvedValueOnce({
+					messages: [{ _id: 'msg3' }],
+					total: 3,
+				});
+
+			const result = await rocketchatApiRequestAllItems.call(
+				context as unknown as IExecuteFunctions,
+				'messages',
+				'/dm',
+				'GET',
+				'messages',
+				{},
+				{ roomId: 'ROOM1', count: 2 },
+			);
+
+			expect(result).toEqual([{ _id: 'msg1' }, { _id: 'msg2' }, { _id: 'msg3' }]);
+			expect(requestWithAuthentication).toHaveBeenCalledTimes(2);
+			const firstQuery = (requestWithAuthentication.mock.calls[0][1] as RequestOptions).qs;
+			const secondQuery = (requestWithAuthentication.mock.calls[1][1] as RequestOptions).qs;
+			expect(firstQuery).not.toHaveProperty('limit');
+			expect(secondQuery).not.toHaveProperty('limit');
+			expect(firstQuery).toEqual({
+				roomId: 'ROOM1',
+				offset: 0,
+				count: 2,
+			});
+			expect(secondQuery).toEqual({
+				roomId: 'ROOM1',
+				offset: 2,
+				count: 2,
+			});
+		});
+
+		it('should use default limit when none is provided', async () => {
+			const { context, requestWithAuthentication } = createContext();
+
+			requestWithAuthentication.mockResolvedValueOnce({
+				messages: [{ _id: 'msg1' }],
+				total: 1,
+			});
+
+			await rocketchatApiRequestAllItems.call(
+				context as unknown as IExecuteFunctions,
+				'messages',
+				'/dm',
+				'GET',
+				'messages',
+				{},
+				{ roomId: 'ROOM1' },
+			);
+
+			const query = (requestWithAuthentication.mock.calls[0][1] as RequestOptions).qs;
+			expect(query).not.toHaveProperty('limit');
+			expect(query).toEqual({
+				roomId: 'ROOM1',
+				offset: 0,
+				count: 100,
+			});
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Rocketchat/tests/Rocketchat.node.test.ts
+++ b/packages/nodes-base/nodes/Rocketchat/tests/Rocketchat.node.test.ts
@@ -1,0 +1,207 @@
+import type { IExecuteFunctions, IDataObject } from 'n8n-workflow';
+
+import { Rocketchat } from '../Rocketchat.node';
+
+type MockContext = {
+	helpers: {
+		requestWithAuthentication: jest.Mock;
+		constructExecutionMetaData: jest.Mock;
+		returnJsonArray: jest.Mock;
+	};
+	getNodeParameter: jest.Mock;
+	getInputData: jest.Mock;
+	getCredentials: jest.Mock;
+	continueOnFail: jest.Mock;
+};
+
+describe('RocketChat Node', () => {
+	let node: Rocketchat;
+
+	beforeEach(() => {
+		node = new Rocketchat();
+		jest.clearAllMocks();
+	});
+
+	function createExecuteContext(params: Record<string, unknown> = {}): MockContext {
+		const requestWithAuthentication = jest.fn();
+
+		return {
+			getNodeParameter: jest.fn(<T = unknown>(key: string): T => {
+				const defaults: Record<string, unknown> = {
+					options: {},
+					jsonParameters: false,
+					attachments: [],
+				};
+
+				return (params[key] ?? defaults[key]) as T;
+			}),
+
+			getInputData: jest.fn(() => [{ json: {} }]),
+
+			helpers: {
+				requestWithAuthentication,
+
+				constructExecutionMetaData: jest.fn((data: unknown) => data),
+
+				returnJsonArray: jest.fn(<T = unknown>(data: T | T[]): T[] => {
+					return Array.isArray(data) ? data : [data];
+				}),
+			},
+
+			getCredentials: jest.fn().mockResolvedValue({
+				domain: 'https://chat.example.com',
+			}),
+
+			continueOnFail: jest.fn(() => false),
+		};
+	}
+
+	// ---------------- chat.postMessage ----------------
+	describe('execute - chat.postMessage', () => {
+		it('should send message to RocketChat channel', async () => {
+			const context = createExecuteContext({
+				resource: 'chat',
+				operation: 'postMessage',
+				channel: '#general',
+				text: 'hello world',
+				options: {},
+				jsonParameters: false,
+				attachments: [],
+			});
+
+			context.helpers.requestWithAuthentication.mockResolvedValue({
+				id: '123',
+			});
+
+			const result = await node.execute.call(context as unknown as IExecuteFunctions);
+
+			expect(context.helpers.requestWithAuthentication).toHaveBeenCalled();
+			expect(result).toBeDefined();
+		});
+
+		it('should include alias, avatar, emoji when provided', async () => {
+			const context = createExecuteContext({
+				resource: 'chat',
+				operation: 'postMessage',
+				channel: '#general',
+				text: 'hello',
+				options: {
+					alias: 'bot',
+					avatar: 'http://avatar.com',
+					emoji: ':smile:',
+				},
+				jsonParameters: false,
+				attachments: [],
+			});
+
+			context.helpers.requestWithAuthentication.mockResolvedValue({ ok: true });
+
+			await node.execute.call(context as unknown as IExecuteFunctions);
+
+			const call = context.helpers.requestWithAuthentication.mock.calls[0] as [string, IDataObject];
+
+			const body = call[1].body as IDataObject;
+
+			expect(body.alias).toBe('bot');
+			expect(body.avatar).toBe('http://avatar.com');
+			expect(body.emoji).toBe(':smile:');
+		});
+	});
+
+	// ---------------- subscriptions.get ----------------
+	describe('execute - subscriptions.get', () => {
+		it('should fetch subscriptions', async () => {
+			const context = createExecuteContext({
+				resource: 'subscriptions',
+				operation: 'get',
+			});
+
+			context.helpers.requestWithAuthentication.mockResolvedValue({
+				subscriptions: [],
+			});
+
+			await node.execute.call(context as unknown as IExecuteFunctions);
+
+			expect(context.helpers.requestWithAuthentication).toHaveBeenCalled();
+		});
+	});
+
+	// ---------------- subscriptions.read ----------------
+	describe('execute - subscriptions.read', () => {
+		it('should mark subscription as read', async () => {
+			const context = createExecuteContext({
+				resource: 'subscriptions',
+				operation: 'read',
+				roomId: 'ROOM1',
+			});
+
+			context.helpers.requestWithAuthentication.mockResolvedValue({ ok: true });
+
+			await node.execute.call(context as unknown as IExecuteFunctions);
+
+			const call = context.helpers.requestWithAuthentication.mock.calls[0] as [string, IDataObject];
+
+			const body = call[1].body as IDataObject;
+
+			expect(body.rid).toBe('ROOM1');
+		});
+	});
+
+	// ---------------- im.messages ----------------
+	describe('execute - im.messages', () => {
+		it('should get IM messages', async () => {
+			const context = createExecuteContext({
+				resource: 'im',
+				operation: 'messages',
+				roomId: 'ROOM1',
+			});
+
+			context.helpers.requestWithAuthentication.mockResolvedValue({
+				messages: [],
+			});
+
+			await node.execute.call(context as unknown as IExecuteFunctions);
+
+			const call = context.helpers.requestWithAuthentication.mock.calls[0] as [string, IDataObject];
+
+			const qs = call[1].qs as IDataObject;
+
+			expect(qs.roomId).toBe('ROOM1');
+		});
+	});
+
+	// ---------------- error handling ----------------
+	describe('error handling', () => {
+		it('should throw when API fails', async () => {
+			const context = createExecuteContext({
+				resource: 'chat',
+				operation: 'postMessage',
+				channel: '#general',
+				text: 'hello',
+			});
+
+			context.helpers.requestWithAuthentication.mockRejectedValue(new Error('fail'));
+
+			await expect(node.execute.call(context as unknown as IExecuteFunctions)).rejects.toThrow(
+				'fail',
+			);
+		});
+
+		it('should continue on fail when enabled', async () => {
+			const context = createExecuteContext({
+				resource: 'chat',
+				operation: 'postMessage',
+				channel: '#general',
+				text: 'hello',
+			});
+
+			context.continueOnFail.mockReturnValue(true);
+
+			context.helpers.requestWithAuthentication.mockRejectedValue(new Error('fail'));
+
+			const result = await node.execute.call(context as unknown as IExecuteFunctions);
+
+			expect(result).toBeDefined();
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Rocketchat/tests/Rocketchat.node.test.ts
+++ b/packages/nodes-base/nodes/Rocketchat/tests/Rocketchat.node.test.ts
@@ -1,207 +1,73 @@
-import type { IExecuteFunctions, IDataObject } from 'n8n-workflow';
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
 
-import { Rocketchat } from '../Rocketchat.node';
-
-type MockContext = {
-	helpers: {
-		requestWithAuthentication: jest.Mock;
-		constructExecutionMetaData: jest.Mock;
-		returnJsonArray: jest.Mock;
-	};
-	getNodeParameter: jest.Mock;
-	getInputData: jest.Mock;
-	getCredentials: jest.Mock;
-	continueOnFail: jest.Mock;
+const credentials = {
+	rocketchatApi: {
+		domain: 'https://chat.example.com',
+		userId: 'user',
+		authKey: 'token',
+	},
 };
 
 describe('RocketChat Node', () => {
-	let node: Rocketchat;
-
-	beforeEach(() => {
-		node = new Rocketchat();
-		jest.clearAllMocks();
-	});
-
-	function createExecuteContext(params: Record<string, unknown> = {}): MockContext {
-		const requestWithAuthentication = jest.fn();
-
-		return {
-			getNodeParameter: jest.fn(<T = unknown>(key: string): T => {
-				const defaults: Record<string, unknown> = {
-					options: {},
-					jsonParameters: false,
-					attachments: [],
-				};
-
-				return (params[key] ?? defaults[key]) as T;
-			}),
-
-			getInputData: jest.fn(() => [{ json: {} }]),
-
-			helpers: {
-				requestWithAuthentication,
-
-				constructExecutionMetaData: jest.fn((data: unknown) => data),
-
-				returnJsonArray: jest.fn(<T = unknown>(data: T | T[]): T[] => {
-					return Array.isArray(data) ? data : [data];
-				}),
+	nock('https://chat.example.com/api/v1')
+		.post('/chat.postMessage', {
+			channel: '#general',
+			text: 'hello world',
+			alias: 'bot',
+			avatar: 'https://chat.example.com/avatar.png',
+			emoji: ':robot:',
+		})
+		.reply(200, {
+			message: {
+				_id: 'message1',
+				msg: 'hello world',
+				rid: 'GENERAL',
 			},
-
-			getCredentials: jest.fn().mockResolvedValue({
-				domain: 'https://chat.example.com',
-			}),
-
-			continueOnFail: jest.fn(() => false),
-		};
-	}
-
-	// ---------------- chat.postMessage ----------------
-	describe('execute - chat.postMessage', () => {
-		it('should send message to RocketChat channel', async () => {
-			const context = createExecuteContext({
-				resource: 'chat',
-				operation: 'postMessage',
-				channel: '#general',
-				text: 'hello world',
-				options: {},
-				jsonParameters: false,
-				attachments: [],
-			});
-
-			context.helpers.requestWithAuthentication.mockResolvedValue({
-				id: '123',
-			});
-
-			const result = await node.execute.call(context as unknown as IExecuteFunctions);
-
-			expect(context.helpers.requestWithAuthentication).toHaveBeenCalled();
-			expect(result).toBeDefined();
+			success: true,
 		});
 
-		it('should include alias, avatar, emoji when provided', async () => {
-			const context = createExecuteContext({
-				resource: 'chat',
-				operation: 'postMessage',
-				channel: '#general',
-				text: 'hello',
-				options: {
-					alias: 'bot',
-					avatar: 'http://avatar.com',
-					emoji: ':smile:',
-				},
-				jsonParameters: false,
-				attachments: [],
-			});
-
-			context.helpers.requestWithAuthentication.mockResolvedValue({ ok: true });
-
-			await node.execute.call(context as unknown as IExecuteFunctions);
-
-			const call = context.helpers.requestWithAuthentication.mock.calls[0] as [string, IDataObject];
-
-			const body = call[1].body as IDataObject;
-
-			expect(body.alias).toBe('bot');
-			expect(body.avatar).toBe('http://avatar.com');
-			expect(body.emoji).toBe(':smile:');
+	nock('https://chat.example.com/api/v1')
+		.get('/subscriptions.get')
+		.reply(200, {
+			update: [{ rid: 'ROOM1', name: 'general' }],
+			remove: [{ rid: 'ROOM2' }],
+			success: true,
 		});
+
+	nock('https://chat.example.com/api/v1').post('/subscriptions.read', { rid: 'ROOM1' }).reply(200, {
+		success: true,
 	});
 
-	// ---------------- subscriptions.get ----------------
-	describe('execute - subscriptions.get', () => {
-		it('should fetch subscriptions', async () => {
-			const context = createExecuteContext({
-				resource: 'subscriptions',
-				operation: 'get',
-			});
-
-			context.helpers.requestWithAuthentication.mockResolvedValue({
-				subscriptions: [],
-			});
-
-			await node.execute.call(context as unknown as IExecuteFunctions);
-
-			expect(context.helpers.requestWithAuthentication).toHaveBeenCalled();
-		});
-	});
-
-	// ---------------- subscriptions.read ----------------
-	describe('execute - subscriptions.read', () => {
-		it('should mark subscription as read', async () => {
-			const context = createExecuteContext({
-				resource: 'subscriptions',
-				operation: 'read',
-				roomId: 'ROOM1',
-			});
-
-			context.helpers.requestWithAuthentication.mockResolvedValue({ ok: true });
-
-			await node.execute.call(context as unknown as IExecuteFunctions);
-
-			const call = context.helpers.requestWithAuthentication.mock.calls[0] as [string, IDataObject];
-
-			const body = call[1].body as IDataObject;
-
-			expect(body.rid).toBe('ROOM1');
-		});
-	});
-
-	// ---------------- im.messages ----------------
-	describe('execute - im.messages', () => {
-		it('should get IM messages', async () => {
-			const context = createExecuteContext({
-				resource: 'im',
-				operation: 'messages',
-				roomId: 'ROOM1',
-			});
-
-			context.helpers.requestWithAuthentication.mockResolvedValue({
-				messages: [],
-			});
-
-			await node.execute.call(context as unknown as IExecuteFunctions);
-
-			const call = context.helpers.requestWithAuthentication.mock.calls[0] as [string, IDataObject];
-
-			const qs = call[1].qs as IDataObject;
-
-			expect(qs.roomId).toBe('ROOM1');
-		});
-	});
-
-	// ---------------- error handling ----------------
-	describe('error handling', () => {
-		it('should throw when API fails', async () => {
-			const context = createExecuteContext({
-				resource: 'chat',
-				operation: 'postMessage',
-				channel: '#general',
-				text: 'hello',
-			});
-
-			context.helpers.requestWithAuthentication.mockRejectedValue(new Error('fail'));
-
-			await expect(node.execute.call(context as unknown as IExecuteFunctions)).rejects.toThrow(
-				'fail',
-			);
+	nock('https://chat.example.com/api/v1')
+		.get('/dm.messages')
+		.query({ roomId: 'ROOM1', offset: 0, count: 100 })
+		.reply(200, {
+			messages: [{ _id: 'msg1', msg: 'hello' }],
+			count: 1,
+			offset: 0,
+			total: 2,
+			success: true,
 		});
 
-		it('should continue on fail when enabled', async () => {
-			const context = createExecuteContext({
-				resource: 'chat',
-				operation: 'postMessage',
-				channel: '#general',
-				text: 'hello',
-			});
-
-			context.continueOnFail.mockReturnValue(true);
-
-			context.helpers.requestWithAuthentication.mockRejectedValue(new Error('fail'));
-
-			const result = await node.execute.call(context as unknown as IExecuteFunctions);
-
-			expect(result).toBeDefined();
+	nock('https://chat.example.com/api/v1')
+		.get('/dm.messages')
+		.query({ roomId: 'ROOM1', offset: 1, count: 100 })
+		.reply(200, {
+			messages: [{ _id: 'msg2', msg: 'world' }],
+			count: 1,
+			offset: 1,
+			total: 2,
+			success: true,
 		});
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: [
+			'workflows/chat_postMessage.workflow.json',
+			'workflows/subscriptions_get.workflow.json',
+			'workflows/subscriptions_read.workflow.json',
+			'workflows/dm_messages.workflow.json',
+		],
 	});
 });

--- a/packages/nodes-base/nodes/Rocketchat/tests/workflows/chat_postMessage.workflow.json
+++ b/packages/nodes-base/nodes/Rocketchat/tests/workflows/chat_postMessage.workflow.json
@@ -1,0 +1,92 @@
+{
+	"name": "RocketChat post message",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "4de08470-bb1a-4204-aec0-6a0d2c811f2f",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [820, 360]
+		},
+		{
+			"parameters": {
+				"resource": "chat",
+				"operation": "postMessage",
+				"channel": "#general",
+				"text": "hello world",
+				"jsonParameters": false,
+				"options": {
+					"alias": "bot",
+					"avatar": "https://chat.example.com/avatar.png",
+					"emoji": ":robot:"
+				},
+				"attachments": []
+			},
+			"id": "1a73099f-169a-4471-8409-a61eb9298e5d",
+			"name": "RocketChat",
+			"type": "n8n-nodes-base.rocketchat",
+			"typeVersion": 1,
+			"position": [1040, 360],
+			"credentials": {
+				"rocketchatApi": {
+					"id": "rocketchat-test-account",
+					"name": "RocketChat account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "ef8ae0b9-229b-4211-b46d-e6e3cf0f84b7",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1260, 360]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"message": {
+						"_id": "message1",
+						"msg": "hello world",
+						"rid": "GENERAL"
+					},
+					"success": true
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "RocketChat",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"RocketChat": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "0b75ea21-f8fb-47d1-8479-ef07f2d3c9e2",
+	"id": "UzEk0dLuXGyEUBKP",
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Rocketchat/tests/workflows/dm_messages.workflow.json
+++ b/packages/nodes-base/nodes/Rocketchat/tests/workflows/dm_messages.workflow.json
@@ -1,0 +1,88 @@
+{
+	"name": "RocketChat DM messages",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "4de08470-bb1a-4204-aec0-6a0d2c811f2f",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [820, 360]
+		},
+		{
+			"parameters": {
+				"resource": "dm",
+				"operation": "messages",
+				"roomId": "ROOM1",
+				"returnAll": true,
+				"limit": 1
+			},
+			"id": "1a73099f-169a-4471-8409-a61eb9298e5d",
+			"name": "RocketChat",
+			"type": "n8n-nodes-base.rocketchat",
+			"typeVersion": 1,
+			"position": [1040, 360],
+			"credentials": {
+				"rocketchatApi": {
+					"id": "rocketchat-test-account",
+					"name": "RocketChat account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "ef8ae0b9-229b-4211-b46d-e6e3cf0f84b7",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1260, 360]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"_id": "msg1",
+					"msg": "hello"
+				}
+			},
+			{
+				"json": {
+					"_id": "msg2",
+					"msg": "world"
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "RocketChat",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"RocketChat": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "c9124f76-a463-4de5-bf5f-b2a6ff9bf2f1",
+	"id": "dCK6GVwk5E6RoS89",
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Rocketchat/tests/workflows/subscriptions_get.workflow.json
+++ b/packages/nodes-base/nodes/Rocketchat/tests/workflows/subscriptions_get.workflow.json
@@ -1,0 +1,88 @@
+{
+	"name": "RocketChat get subscriptions",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "4de08470-bb1a-4204-aec0-6a0d2c811f2f",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [820, 360]
+		},
+		{
+			"parameters": {
+				"resource": "subscriptions",
+				"operation": "get"
+			},
+			"id": "1a73099f-169a-4471-8409-a61eb9298e5d",
+			"name": "RocketChat",
+			"type": "n8n-nodes-base.rocketchat",
+			"typeVersion": 1,
+			"position": [1040, 360],
+			"credentials": {
+				"rocketchatApi": {
+					"id": "rocketchat-test-account",
+					"name": "RocketChat account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "ef8ae0b9-229b-4211-b46d-e6e3cf0f84b7",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1260, 360]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"update": {
+						"rid": "ROOM1",
+						"name": "general"
+					}
+				}
+			},
+			{
+				"json": {
+					"remove": {
+						"rid": "ROOM2"
+					}
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "RocketChat",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"RocketChat": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "3901f571-3429-4955-9f09-ce8a66c00f25",
+	"id": "K6oHr2ujRDfxHk2t",
+	"tags": []
+}

--- a/packages/nodes-base/nodes/Rocketchat/tests/workflows/subscriptions_read.workflow.json
+++ b/packages/nodes-base/nodes/Rocketchat/tests/workflows/subscriptions_read.workflow.json
@@ -1,0 +1,79 @@
+{
+	"name": "RocketChat read subscription",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "4de08470-bb1a-4204-aec0-6a0d2c811f2f",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [820, 360]
+		},
+		{
+			"parameters": {
+				"resource": "subscriptions",
+				"operation": "read",
+				"roomId": "ROOM1"
+			},
+			"id": "1a73099f-169a-4471-8409-a61eb9298e5d",
+			"name": "RocketChat",
+			"type": "n8n-nodes-base.rocketchat",
+			"typeVersion": 1,
+			"position": [1040, 360],
+			"credentials": {
+				"rocketchatApi": {
+					"id": "rocketchat-test-account",
+					"name": "RocketChat account"
+				}
+			}
+		},
+		{
+			"parameters": {},
+			"id": "ef8ae0b9-229b-4211-b46d-e6e3cf0f84b7",
+			"name": "No Operation, do nothing",
+			"type": "n8n-nodes-base.noOp",
+			"typeVersion": 1,
+			"position": [1260, 360]
+		}
+	],
+	"pinData": {
+		"No Operation, do nothing": [
+			{
+				"json": {
+					"success": true
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "RocketChat",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"RocketChat": {
+			"main": [
+				[
+					{
+						"node": "No Operation, do nothing",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {
+		"executionOrder": "v1"
+	},
+	"versionId": "f8f4c773-6779-4aef-83b8-6d170aa16f3f",
+	"id": "JjNLWkF8NYvMWx58",
+	"tags": []
+}


### PR DESCRIPTION
## Summary

Adds support for additional Rocket.Chat resources and operations:

* Added **Subscriptions** resource

  * Get all subscriptions (`subscriptions.get`)
  * Mark a subscription as read (`subscriptions.read`)
* Added **Incoming Messages (IM)** resource

  * Get messages from a direct message room (`im.messages`)
* Extended the Rocket.Chat API request helper to support query string parameters for GET endpoints that require request parameters in the URL.

## Changes

### Rocket.Chat API Helper

Updated `rocketchatApiRequest()` to accept optional query parameters and pass them through as request query strings (`qs`).

This enables support for Rocket.Chat endpoints such as `im.messages`, which require parameters to be provided via the query string rather than the request body.

### New Resource: Subscriptions

Added a new **Subscriptions** resource with the following operations:

#### Get All

Retrieves the authenticated user's subscriptions using the `subscriptions.get` endpoint.

#### Mark As Read

Marks a room as read using the `subscriptions.read` endpoint.

Required parameter:

* Room ID

### New Resource: Incoming Messages (IM)

Added a new **Incoming Messages** resource with the following operation:

#### Get Messages

Retrieves messages from a direct message room using the `im.messages` endpoint.

Required parameter:

* Room ID

The Room ID is sent as a query parameter to match the Rocket.Chat API requirements.

## Testing

Verified the following operations against a Rocket.Chat instance:

* Subscriptions → Get All
* Subscriptions → Mark As Read
* Incoming Messages → Get Messages

All operations return the expected API responses and correctly handle required Room ID parameters.

## Related Linear tickets, Github issues, and Community forum posts
_None — community contribution adding subscriptions and IM operations on Rocket.chat Node._


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

