### PR TITLE
ci: Allow scoped jest runs to pass when no related tests match

### DIFF
--- a/packages/testing/janitor/src/core/test-scoped-runner.test.ts
+++ b/packages/testing/janitor/src/core/test-scoped-runner.test.ts
@@ -16,7 +16,9 @@ describe('buildRunnerArgs', () => {
 		expect(args[0]).toBe('--findRelatedTests');
 		expect(isAbsolute(args[1])).toBe(true);
 		expect(args[1]).toBe('/repo/root/packages/nodes-base/nodes/Foo.node.ts');
-		expect(args[2]).toBe('--summarize');
+		// A scoped jest run that resolves to zero related tests must pass, not exit 1.
+		expect(args[2]).toBe('--passWithNoTests');
+		expect(args[3]).toBe('--summarize');
 	});
 
 	it('vitest scoped: emits `related` with absolute paths and `--run` to avoid watch mode', () => {
@@ -44,7 +46,7 @@ describe('buildRunnerArgs', () => {
 			rootDir,
 			[],
 		);
-		expect(args).toEqual(['--findRelatedTests', '/already/absolute/path.ts']);
+		expect(args).toEqual(['--findRelatedTests', '/already/absolute/path.ts', '--passWithNoTests']);
 	});
 
 	it('jest full: passes through args with no related-tests flag', () => {

--- a/packages/testing/janitor/src/core/test-scoped-runner.ts
+++ b/packages/testing/janitor/src/core/test-scoped-runner.ts
@@ -31,10 +31,15 @@ export function buildRunnerArgs(
 		return runner === 'vitest' ? ['run', ...passthroughArgs] : [...passthroughArgs];
 	}
 	const absoluteFiles = scope.files.map((f) => (isAbsolute(f) ? f : resolve(rootDir, f)));
+	// `jest --findRelatedTests` exits 1 when the changed files resolve to zero
+	// related tests (e.g. a variant like integration that has no matching tests
+	// for this change). `--passWithNoTests` makes that a pass, matching the
+	// `skip` semantics above and `vitest related`'s behaviour.
+	//
 	// `vitest related` defaults to watch mode and does NOT TTY-detect, so it
 	// would hang the CI runner forever. `--run` forces a single-pass execution.
 	return runner === 'jest'
-		? ['--findRelatedTests', ...absoluteFiles, ...passthroughArgs]
+		? ['--findRelatedTests', ...absoluteFiles, '--passWithNoTests', ...passthroughArgs]
 		: ['related', ...absoluteFiles, '--run', ...passthroughArgs];
 }
 


### PR DESCRIPTION
## Summary

janitor test-scoped runs jest --findRelatedTests <changed files> without --passWithNoTests. When a change has no related tests for a variant — common for test:integration:changed, since most changes are unit-covered — jest exits 1 and fails the check. The vitest related path and the janitor's skip path both treat "no tests" as a pass; only the jest branch didn't.

This adds --passWithNoTests to the scoped jest branch in buildRunnerArgs so a legitimately-empty related-test set passes. The JEST_INTEGRATION_BAILOUT list still forces a full run for runtime-coupled changes (entities/repositories/migrations), so this only affects genuine no-coverage cases — not the false-green scenarios that bailout protects.

Deterministic, not flaky: re-runs don't help. Affects jest :changed (cli integration + nodes-base); vitest is unaffected.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-193/bug-scoped-jest-testchanged-fails-when-a-change-has-no-related-tests

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
