### PR TITLE
test(agents-sdk): Add unit tests for deterministic eval functions

### DIFF
--- a/packages/@n8n/agents/src/evals/__tests__/categorization.test.ts
+++ b/packages/@n8n/agents/src/evals/__tests__/categorization.test.ts
@@ -1,0 +1,109 @@
+import { categorization } from '../categorization';
+
+describe('categorization', () => {
+	const evalFn = categorization();
+
+	describe('exact match', () => {
+		it('returns pass: true when output exactly matches expected', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'positive',
+				expected: 'positive',
+			});
+			expect(result.pass).toBe(true);
+			expect(result.reasoning).toBe('Exact match');
+		});
+
+		it('is case-insensitive for exact matches', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'Positive',
+				expected: 'positive',
+			});
+			expect(result.pass).toBe(true);
+		});
+
+		it('trims whitespace before comparing', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '  positive  ',
+				expected: 'positive',
+			});
+			expect(result.pass).toBe(true);
+		});
+	});
+
+	describe('contains match', () => {
+		it('returns pass: true when output contains the expected label', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'The sentiment is positive',
+				expected: 'positive',
+			});
+			expect(result.pass).toBe(true);
+			expect(result.reasoning).toContain('Output contains expected label');
+		});
+
+		it('returns pass: true when the label is embedded within a word', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'This is positively great',
+				expected: 'positive',
+			});
+			expect(result.pass).toBe(true);
+		});
+	});
+
+	describe('no match', () => {
+		it('returns pass: false when output does not match expected', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'negative',
+				expected: 'positive',
+			});
+			expect(result.pass).toBe(false);
+			expect(result.reasoning).toContain('Expected');
+			expect(result.reasoning).toContain('positive');
+			expect(result.reasoning).toContain('negative');
+		});
+
+		it('returns pass: false for completely unrelated strings', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'The sky is blue',
+				expected: 'positive',
+			});
+			expect(result.pass).toBe(false);
+		});
+	});
+
+	describe('edge cases', () => {
+		it('returns pass: false when expected is undefined', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'positive',
+			});
+			expect(result.pass).toBe(false);
+			expect(result.reasoning).toBe('No expected category provided');
+		});
+
+		it('returns pass: false when expected is an empty string', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'positive',
+				expected: '',
+			});
+			expect(result.pass).toBe(false);
+			expect(result.reasoning).toBe('No expected category provided');
+		});
+
+		it('returns pass: false when output is empty but expected is not', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '',
+				expected: 'positive',
+			});
+			expect(result.pass).toBe(false);
+		});
+	});
+});

--- a/packages/@n8n/agents/src/evals/__tests__/contains-keywords.test.ts
+++ b/packages/@n8n/agents/src/evals/__tests__/contains-keywords.test.ts
@@ -1,0 +1,117 @@
+import { containsKeywords } from '../contains-keywords';
+
+describe('containsKeywords', () => {
+	const evalFn = containsKeywords();
+
+	describe('all keywords present', () => {
+		it('returns pass: true when a single keyword is found', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'The weather in London is rainy today',
+				expected: 'weather',
+			});
+			expect(result.pass).toBe(true);
+			expect(result.reasoning).toBe('All 1 keywords found');
+		});
+
+		it('returns pass: true when all keywords are found', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'The weather in London is rainy today',
+				expected: 'weather, London, rainy',
+			});
+			expect(result.pass).toBe(true);
+			expect(result.reasoning).toBe('All 3 keywords found');
+		});
+
+		it('is case-insensitive', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'The Weather In London Is Rainy Today',
+				expected: 'weather, london, rainy',
+			});
+			expect(result.pass).toBe(true);
+		});
+
+		it('finds keywords as substrings', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'The weatherman said it will rain',
+				expected: 'weather',
+			});
+			expect(result.pass).toBe(true);
+		});
+
+		it('trims whitespace around expected keywords', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'The weather in London is rainy',
+				expected: '  weather  ,  London  ',
+			});
+			expect(result.pass).toBe(true);
+		});
+	});
+
+	describe('missing keywords', () => {
+		it('returns pass: false when some keywords are missing', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'The weather is nice today',
+				expected: 'weather, London, rainy',
+			});
+			expect(result.pass).toBe(false);
+			expect(result.reasoning).toContain('Missing');
+			expect(result.reasoning).toContain('london');
+			expect(result.reasoning).toContain('rainy');
+		});
+
+		it('returns pass: false when all keywords are missing', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'Nothing relevant here',
+				expected: 'weather, London',
+			});
+			expect(result.pass).toBe(false);
+		});
+	});
+
+	describe('edge cases', () => {
+		it('returns pass: false when expected is undefined', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'some text',
+			});
+			expect(result.pass).toBe(false);
+			expect(result.reasoning).toBe('No expected keywords provided');
+		});
+
+		it('returns pass: false when expected is an empty string', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'some text',
+				expected: '',
+			});
+			expect(result.pass).toBe(false);
+			expect(result.reasoning).toBe('No expected keywords provided');
+		});
+
+		it('returns pass: false when expected contains only commas and whitespace', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'some text',
+				expected: '  ,  ,  ',
+			});
+			expect(result.pass).toBe(false);
+			expect(result.reasoning).toBe('No keywords to check');
+		});
+
+		it('handles empty output', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '',
+				expected: 'weather',
+			});
+			expect(result.pass).toBe(false);
+		});
+	});
+});

--- a/packages/@n8n/agents/src/evals/__tests__/json-validity.test.ts
+++ b/packages/@n8n/agents/src/evals/__tests__/json-validity.test.ts
@@ -1,0 +1,115 @@
+import { jsonValidity } from '../json-validity';
+
+describe('jsonValidity', () => {
+	const evalFn = jsonValidity();
+
+	describe('valid JSON', () => {
+		it('accepts a JSON object', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '{"name": "test", "value": 42}',
+			});
+			expect(result.pass).toBe(true);
+			expect(result.reasoning).toBe('Valid JSON');
+		});
+
+		it('accepts a JSON array', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '[1, 2, 3]',
+			});
+			expect(result.pass).toBe(true);
+		});
+
+		it('accepts a JSON string', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '"hello"',
+			});
+			expect(result.pass).toBe(true);
+		});
+
+		it('accepts a JSON number', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '42',
+			});
+			expect(result.pass).toBe(true);
+		});
+
+		it('accepts a JSON boolean', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'true',
+			});
+			expect(result.pass).toBe(true);
+		});
+
+		it('accepts JSON null', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'null',
+			});
+			expect(result.pass).toBe(true);
+		});
+
+		it('accepts nested JSON', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '{"level1": {"level2": [1, 2, {"key": "val"}]}}',
+			});
+			expect(result.pass).toBe(true);
+		});
+	});
+
+	describe('invalid JSON', () => {
+		it('rejects plain text', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'hello world',
+			});
+			expect(result.pass).toBe(false);
+			expect(result.reasoning).toMatch(/invalid json/i);
+		});
+
+		it('rejects JSON with trailing comma', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '{"a": 1,}',
+			});
+			expect(result.pass).toBe(false);
+		});
+
+		it('rejects single quotes instead of double quotes', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: "{'a': 1}",
+			});
+			expect(result.pass).toBe(false);
+		});
+
+		it('rejects an empty string', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '',
+			});
+			expect(result.pass).toBe(false);
+		});
+
+		it('rejects whitespace-only string', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '   ',
+			});
+			expect(result.pass).toBe(false);
+		});
+
+		it('rejects undefined as a value', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '{"a": undefined}',
+			});
+			expect(result.pass).toBe(false);
+		});
+	});
+});

--- a/packages/@n8n/agents/src/evals/__tests__/parse-judge-response.test.ts
+++ b/packages/@n8n/agents/src/evals/__tests__/parse-judge-response.test.ts
@@ -1,0 +1,117 @@
+import { parseJudgeResponse } from '../parse-judge-response';
+
+describe('parseJudgeResponse', () => {
+	describe('JSON with markdown code fences', () => {
+		it('parses a JSON block within ```json fences', () => {
+			const result = parseJudgeResponse('```json\n{"pass": true, "reasoning": "Correct"}\n```');
+			expect(result.pass).toBe(true);
+			expect(result.reasoning).toBe('Correct');
+		});
+
+		it('parses a JSON block within plain ``` fences', () => {
+			const result = parseJudgeResponse('```\n{"pass": false, "reasoning": "Wrong"}\n```');
+			expect(result.pass).toBe(false);
+			expect(result.reasoning).toBe('Wrong');
+		});
+
+		it('handles fences without leading newline', () => {
+			const result = parseJudgeResponse('```json{"pass": true}```');
+			expect(result.pass).toBe(true);
+		});
+	});
+
+	describe('plain JSON', () => {
+		it('parses a simple pass JSON object', () => {
+			const result = parseJudgeResponse('{"pass": true, "reasoning": "All good"}');
+			expect(result.pass).toBe(true);
+			expect(result.reasoning).toBe('All good');
+		});
+
+		it('parses a simple fail JSON object', () => {
+			const result = parseJudgeResponse('{"pass": false, "reasoning": "Not good"}');
+			expect(result.pass).toBe(false);
+			expect(result.reasoning).toBe('Not good');
+		});
+	});
+
+	describe('legacy score format', () => {
+		it('passes when score is >= 0.7', () => {
+			const result = parseJudgeResponse('{"score": 0.85, "reasoning": "Mostly correct"}');
+			expect(result.pass).toBe(true);
+		});
+
+		it('fails when score is < 0.7', () => {
+			const result = parseJudgeResponse('{"score": 0.3, "reasoning": "Mostly wrong"}');
+			expect(result.pass).toBe(false);
+		});
+
+		it('handles score exactly at boundary of 0.7', () => {
+			const result = parseJudgeResponse('{"score": 0.7, "reasoning": "Borderline"}');
+			expect(result.pass).toBe(true);
+		});
+	});
+
+	describe('pass/fail overrides score', () => {
+		it('uses pass field when both pass and score are present', () => {
+			const result = parseJudgeResponse('{"pass": false, "score": 0.9, "reasoning": "Override"}');
+			expect(result.pass).toBe(false);
+		});
+	});
+
+	describe('raw text fallback', () => {
+		it('passes when text contains "pass" keyword without "fail"', () => {
+			const result = parseJudgeResponse('This response should pass the test');
+			expect(result.pass).toBe(true);
+		});
+
+		it('fails when text contains "fail" keyword', () => {
+			const result = parseJudgeResponse('This response should fail the test');
+			expect(result.pass).toBe(false);
+		});
+
+		it('fails when text contains both "pass" and "fail"', () => {
+			const result = parseJudgeResponse('Attempt to pass but ultimately fail');
+			expect(result.pass).toBe(false);
+		});
+
+		it('falls back to reasoning as the raw text when JSON has no reasoning', () => {
+			const result = parseJudgeResponse('{"pass": true}');
+			expect(result.pass).toBe(true);
+			expect(result.reasoning).toBe('{"pass": true}');
+		});
+
+		it('fails on empty text', () => {
+			const result = parseJudgeResponse('');
+			expect(result.pass).toBe(false);
+		});
+	});
+
+	describe('JSON pass/false detection in raw text', () => {
+		it('detects "pass": true in malformed JSON', () => {
+			const result = parseJudgeResponse('Some text {"pass": true} more text');
+			expect(result.pass).toBe(true);
+		});
+
+		it('detects "pass":false in malformed JSON', () => {
+			const result = parseJudgeResponse('Some text {"pass":false} more text');
+			expect(result.pass).toBe(false);
+		});
+
+		it('prefers JSON detection over keyword pass/fail', () => {
+			const result = parseJudgeResponse('This should {"pass": false} but mentions pass');
+			expect(result.pass).toBe(false);
+		});
+	});
+
+	describe('edge cases', () => {
+		it('handles text with only whitespace', () => {
+			const result = parseJudgeResponse('   ');
+			expect(result.pass).toBe(false);
+		});
+
+		it('handles text with surrounding whitespace in markdown fences', () => {
+			const result = parseJudgeResponse('  ```json\n{"pass": true}\n```  ');
+			expect(result.pass).toBe(true);
+		});
+	});
+});

--- a/packages/@n8n/agents/src/evals/__tests__/string-similarity.test.ts
+++ b/packages/@n8n/agents/src/evals/__tests__/string-similarity.test.ts
@@ -1,0 +1,121 @@
+import { stringSimilarity } from '../string-similarity';
+
+describe('stringSimilarity', () => {
+	const evalFn = stringSimilarity();
+
+	describe('identical strings', () => {
+		it('returns pass: true with 100% similarity for identical strings', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'hello world',
+				expected: 'hello world',
+			});
+			expect(result.pass).toBe(true);
+			expect(result.reasoning).toContain('100.0%');
+		});
+
+		it('is case-insensitive — mixed case matches', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'Hello World',
+				expected: 'hello world',
+			});
+			expect(result.pass).toBe(true);
+			expect(result.reasoning).toContain('100.0%');
+		});
+
+		it('trims whitespace before comparing', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '  hello world  ',
+				expected: 'hello world',
+			});
+			expect(result.pass).toBe(true);
+			expect(result.reasoning).toContain('100.0%');
+		});
+	});
+
+	describe('similar but not identical strings', () => {
+		it('returns pass: true when similarity >= 0.7', async () => {
+			// "abcde" and "abcdf" share "ab","bc","cd" => 6/8 = 0.75
+			const result = await evalFn.run({
+				input: '',
+				output: 'abcde',
+				expected: 'abcdf',
+			});
+			expect(result.pass).toBe(true);
+			expect(result.reasoning).toContain('75.0%');
+		});
+
+		it('returns pass: false when similarity < 0.7', async () => {
+			// "abcde" and "abXde" share "ab","de" => 4/8 = 0.5
+			const result = await evalFn.run({
+				input: '',
+				output: 'abcde',
+				expected: 'abXde',
+			});
+			expect(result.pass).toBe(false);
+			expect(result.reasoning).toContain('50.0%');
+		});
+	});
+
+	describe('edge cases', () => {
+		it('returns pass: false when expected is undefined', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'anything',
+			});
+			expect(result.pass).toBe(false);
+			expect(result.reasoning).toBe('No expected value provided');
+		});
+
+		it('matches identical single-character strings (similarity = 1)', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'a',
+				expected: 'a',
+			});
+			expect(result.pass).toBe(true);
+			expect(result.reasoning).toContain('100.0%');
+		});
+
+		it('returns 0 similarity for different single-character strings', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'a',
+				expected: 'b',
+			});
+			expect(result.pass).toBe(false);
+			expect(result.reasoning).toContain('0.0%');
+		});
+
+		it('returns 0 similarity when one string has fewer than 2 characters', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'a',
+				expected: 'ab',
+			});
+			expect(result.pass).toBe(false);
+			expect(result.reasoning).toContain('0.0%');
+		});
+
+		it('handles empty string output', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '',
+				expected: 'hello',
+			});
+			expect(result.pass).toBe(false);
+		});
+
+		it('handles completely different strings', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: 'abcdef',
+				expected: 'ghijkl',
+			});
+			expect(result.pass).toBe(false);
+			expect(result.reasoning).toContain('0.0%');
+		});
+	});
+});

--- a/packages/@n8n/agents/src/evals/__tests__/tool-call-accuracy.test.ts
+++ b/packages/@n8n/agents/src/evals/__tests__/tool-call-accuracy.test.ts
@@ -1,0 +1,141 @@
+import { toolCallAccuracy } from '../tool-call-accuracy';
+
+describe('toolCallAccuracy', () => {
+	const evalFn = toolCallAccuracy();
+
+	describe('all expected tools called', () => {
+		it('returns pass: true when a single expected tool was called', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '',
+				expected: 'search',
+				toolCalls: [{ tool: 'search', input: {}, output: {} }],
+			});
+			expect(result.pass).toBe(true);
+			expect(result.reasoning).toBe('All 1 expected tools were called');
+		});
+
+		it('returns pass: true when all expected tools were called', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '',
+				expected: 'search, calculator',
+				toolCalls: [
+					{ tool: 'search', input: {}, output: {} },
+					{ tool: 'calculator', input: {}, output: {} },
+				],
+			});
+			expect(result.pass).toBe(true);
+			expect(result.reasoning).toBe('All 2 expected tools were called');
+		});
+
+		it('is case-insensitive for tool names', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '',
+				expected: 'Search, CALCULATOR',
+				toolCalls: [
+					{ tool: 'search', input: {}, output: {} },
+					{ tool: 'calculator', input: {}, output: {} },
+				],
+			});
+			expect(result.pass).toBe(true);
+		});
+
+		it('ignores extra tool calls beyond the expected ones', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '',
+				expected: 'search',
+				toolCalls: [
+					{ tool: 'search', input: {}, output: {} },
+					{ tool: 'calculator', input: {}, output: {} },
+				],
+			});
+			expect(result.pass).toBe(true);
+		});
+	});
+
+	describe('missing expected tools', () => {
+		it('returns pass: false when some expected tools are missing', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '',
+				expected: 'search, calculator',
+				toolCalls: [{ tool: 'search', input: {}, output: {} }],
+			});
+			expect(result.pass).toBe(false);
+			expect(result.reasoning).toContain('Missing tools');
+			expect(result.reasoning).toContain('calculator');
+		});
+
+		it('returns pass: false when no tools were called', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '',
+				expected: 'search',
+				toolCalls: [],
+			});
+			expect(result.pass).toBe(false);
+			expect(result.reasoning).toContain('Missing tools');
+			expect(result.reasoning).toContain('search');
+		});
+	});
+
+	describe('edge cases', () => {
+		it('returns pass: false when expected is undefined', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '',
+				toolCalls: [{ tool: 'search', input: {}, output: {} }],
+			});
+			expect(result.pass).toBe(false);
+			expect(result.reasoning).toBe('No expected tool names provided');
+		});
+
+		it('returns pass: false when expected is an empty string', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '',
+				expected: '',
+				toolCalls: [{ tool: 'search', input: {}, output: {} }],
+			});
+			expect(result.pass).toBe(false);
+			expect(result.reasoning).toBe('No expected tool names provided');
+		});
+
+		it('returns pass: false when expected contains only whitespace', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '',
+				expected: '   ,  ,  ',
+				toolCalls: [{ tool: 'search', input: {}, output: {} }],
+			});
+			expect(result.pass).toBe(false);
+			expect(result.reasoning).toBe('No expected tools to check');
+		});
+
+		it('handles toolCalls being undefined', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '',
+				expected: 'search',
+			});
+			expect(result.pass).toBe(false);
+			expect(result.reasoning).toContain('Missing tools');
+		});
+
+		it('trims whitespace around expected tool names', async () => {
+			const result = await evalFn.run({
+				input: '',
+				output: '',
+				expected: '  search  ,  calculator  ',
+				toolCalls: [
+					{ tool: 'search', input: {}, output: {} },
+					{ tool: 'calculator', input: {}, output: {} },
+				],
+			});
+			expect(result.pass).toBe(true);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds unit test coverage for all 6 deterministic eval utility functions in `@n8n/agents/src/evals/`:

- `string-similarity.ts` — Dice coefficient edge cases
- `tool-call-accuracy.ts` — tool presence validation
- `json-validity.ts` — JSON parse validation
- `contains-keywords.ts` — keyword matching
- `categorization.ts` — label matching
- `parse-judge-response.ts` — LLM response parsing

All functions are pure/deterministic and ideal for unit testing. Follows existing test patterns from `sdk/__tests__/`.

## Related Linear tickets, Github issues, and Community forum posts

N/A — standalone test coverage improvement, no linked issue.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

## Test Plan

- [x] All new tests pass
- [x] No breaking changes to eval function signatures