### PR TITLE
fix: Add fallback text to model selector if upstream llm provider returns only model id

### DIFF
--- a/packages/cli/src/modules/chat-hub/__tests__/chat-hub-models.service.integration.test.ts
+++ b/packages/cli/src/modules/chat-hub/__tests__/chat-hub-models.service.integration.test.ts
@@ -61,6 +61,22 @@ describe('ChatHubModelsService', () => {
 		member = await createMember();
 	});
 
+	describe('transformAndFilterModels', () => {
+		it('should use model name when provided', () => {
+			const rawModels = [{ name: 'GPT-4o', value: 'gpt-4o' }];
+			const result = (chatHubModelsService as any).transformAndFilterModels(rawModels, 'openai');
+			expect(result).toHaveLength(1);
+			expect(result[0].name).toBe('GPT-4o');
+		});
+
+		it('should fall back to model id when name is empty string', () => {
+			const rawModels = [{ name: '', value: 'gpt-4o' }];
+			const result = (chatHubModelsService as any).transformAndFilterModels(rawModels, 'openai');
+			expect(result).toHaveLength(1);
+			expect(result[0].name).toBe('gpt-4o');
+		});
+	});
+
 	describe('getModels', () => {
 		describe('n8n workflow agents', () => {
 			it('should return empty models when user has no workflows', async () => {

--- a/packages/cli/src/modules/chat-hub/chat-hub.models.service.ts
+++ b/packages/cli/src/modules/chat-hub/chat-hub.models.service.ts
@@ -910,7 +910,7 @@ export class ChatHubModelsService {
 			return [
 				{
 					id,
-					name: model.name,
+					name: model.name || id,
 					description: model.description ?? null,
 					icon: null,
 					model: {


### PR DESCRIPTION
## Summary

---
Update 2026/09/07:

Closes https://github.com/n8n-io/n8n/issues/38015

---

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

Fix an UI visual issue if OpenAI/Anthropic compatible models only returns model id without a model name

The label should not be empty, it should at least have a fallback value.


<img width="430" height="316" alt="Screenshot 2026-05-31 at 7 28 52 PM" src="https://github.com/user-attachments/assets/3276585a-6048-4fc0-b4b9-e646605d9125" />


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
