### PR TITLE
fix(editor): Decouple collaboration store lifecycle from CollaborationPane

### DIFF
--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -136,6 +136,7 @@ import { type ContextMenuAction } from '@/features/shared/contextMenu/composable
 import { useExperimentalNdvStore } from '@/features/workflows/canvas/experimental/experimentalNdv.store';
 import { useActivityDetection } from '@/app/composables/useActivityDetection';
 import { useCollaborationStore } from '@/features/collaboration/collaboration/collaboration.store';
+import { useCollaborationLifecycle } from '@/features/collaboration/collaboration/composables/useCollaborationLifecycle';
 import { useInjectWorkflowId } from '@/app/composables/useInjectWorkflowId';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
@@ -288,6 +289,10 @@ const hideCanvasControls = computed(() => {
 
 const isDemoRoute = computed(() => route.name === VIEWS.DEMO);
 const isReadOnlyRoute = computed(() => !!route?.meta?.readOnlyCanvas);
+
+useCollaborationLifecycle(workflowId, {
+	enabled: computed(() => !isDemoRoute.value),
+});
 const isReadOnlyEnvironment = computed(() => {
 	return sourceControlStore.preferences.branchReadOnly;
 });

--- a/packages/frontend/editor-ui/src/features/collaboration/collaboration/components/CollaborationPane.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/collaboration/components/CollaborationPane.test.ts
@@ -3,17 +3,6 @@ import { mock } from 'vitest-mock-extended';
 
 import { STORES } from '@n8n/stores';
 import CollaborationPane from './CollaborationPane.vue';
-
-vi.mock('vue-router', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('vue-router')>();
-	return {
-		...actual,
-		useRoute: () => ({
-			name: 'NodeView',
-			params: { workflowId: 'test-workflow-id' },
-		}),
-	};
-});
 import type { IUser } from '@n8n/rest-api-client/api/users';
 
 import type { RenderOptions } from '@/__tests__/render';

--- a/packages/frontend/editor-ui/src/features/collaboration/collaboration/components/CollaborationPane.vue
+++ b/packages/frontend/editor-ui/src/features/collaboration/collaboration/components/CollaborationPane.vue
@@ -1,25 +1,13 @@
 <script setup lang="ts">
-import { onMounted, onBeforeUnmount, computed, watch } from 'vue';
-import { useDocumentVisibility } from '@vueuse/core';
+import { computed } from 'vue';
 
 import { useUsersStore } from '@/features/settings/users/users.store';
 import { useCollaborationStore } from '../collaboration.store';
 
 import { N8nUserStack } from '@n8n/design-system';
-import { useWorkflowId } from '@/app/composables/useWorkflowId';
 
 const collaborationStore = useCollaborationStore();
 const usersStore = useUsersStore();
-const workflowId = useWorkflowId();
-
-const visibility = useDocumentVisibility();
-watch(visibility, (visibilityState) => {
-	if (visibilityState === 'hidden') {
-		collaborationStore.stopHeartbeat();
-	} else {
-		collaborationStore.startHeartbeat();
-	}
-});
 
 const showUserStack = computed(() => collaborationStore.collaborators.length > 1);
 
@@ -33,14 +21,6 @@ const collaboratorsSorted = computed(() => {
 });
 
 const currentUserEmail = computed(() => usersStore.currentUser?.email);
-
-onMounted(() => {
-	void collaborationStore.initialize(workflowId.value);
-});
-
-onBeforeUnmount(() => {
-	collaborationStore.terminate();
-});
 </script>
 
 <template>

--- a/packages/frontend/editor-ui/src/features/collaboration/collaboration/composables/useCollaborationLifecycle.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/collaboration/composables/useCollaborationLifecycle.test.ts
@@ -1,0 +1,175 @@
+import { setActivePinia, createPinia } from 'pinia';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+import { defineComponent, h, nextTick, ref, type Ref } from 'vue';
+import { mount, type VueWrapper } from '@vue/test-utils';
+
+import { useCollaborationLifecycle } from './useCollaborationLifecycle';
+
+const mockInitialize = vi.fn();
+const mockTerminate = vi.fn();
+const mockStartHeartbeat = vi.fn();
+const mockStopHeartbeat = vi.fn();
+const visibility = ref<'visible' | 'hidden'>('visible');
+
+vi.mock('../collaboration.store', () => ({
+	useCollaborationStore: () => ({
+		initialize: mockInitialize,
+		terminate: mockTerminate,
+		startHeartbeat: mockStartHeartbeat,
+		stopHeartbeat: mockStopHeartbeat,
+	}),
+}));
+
+vi.mock('@vueuse/core', () => ({
+	useDocumentVisibility: () => visibility,
+}));
+
+const wrappers: Array<VueWrapper> = [];
+
+function createHost(workflowId: Ref<string>, enabled: Ref<boolean>) {
+	return defineComponent({
+		setup() {
+			useCollaborationLifecycle(workflowId, { enabled });
+			return () => h('div');
+		},
+	});
+}
+
+function mountHost(workflowId: Ref<string>, enabled: Ref<boolean>) {
+	const wrapper = mount(createHost(workflowId, enabled));
+	wrappers.push(wrapper);
+	return wrapper;
+}
+
+describe('useCollaborationLifecycle', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+		vi.clearAllMocks();
+		visibility.value = 'visible';
+	});
+
+	afterEach(() => {
+		while (wrappers.length > 0) {
+			wrappers.pop()?.unmount();
+		}
+	});
+
+	test('initializes when workflowId is present and enabled', async () => {
+		const workflowId = ref('workflow-1');
+		const enabled = ref(true);
+		mountHost(workflowId, enabled);
+		await nextTick();
+
+		expect(mockInitialize).toHaveBeenCalledWith('workflow-1');
+		expect(mockTerminate).not.toHaveBeenCalled();
+	});
+
+	test('does not initialize when workflowId is empty', async () => {
+		const workflowId = ref('');
+		const enabled = ref(true);
+		mountHost(workflowId, enabled);
+		await nextTick();
+
+		expect(mockInitialize).not.toHaveBeenCalled();
+	});
+
+	test('does not initialize when disabled', async () => {
+		const workflowId = ref('workflow-1');
+		const enabled = ref(false);
+		mountHost(workflowId, enabled);
+		await nextTick();
+
+		expect(mockInitialize).not.toHaveBeenCalled();
+	});
+
+	test('terminates and re-initializes when workflowId changes', async () => {
+		const workflowId = ref('workflow-1');
+		const enabled = ref(true);
+		mountHost(workflowId, enabled);
+		await nextTick();
+
+		expect(mockInitialize).toHaveBeenCalledWith('workflow-1');
+
+		workflowId.value = 'workflow-2';
+		await nextTick();
+
+		expect(mockTerminate).toHaveBeenCalledTimes(1);
+		expect(mockInitialize).toHaveBeenLastCalledWith('workflow-2');
+	});
+
+	test('initializes when workflowId transitions from empty to set', async () => {
+		const workflowId = ref('');
+		const enabled = ref(true);
+		mountHost(workflowId, enabled);
+		await nextTick();
+		expect(mockInitialize).not.toHaveBeenCalled();
+
+		workflowId.value = 'workflow-1';
+		await nextTick();
+
+		expect(mockTerminate).not.toHaveBeenCalled();
+		expect(mockInitialize).toHaveBeenCalledWith('workflow-1');
+	});
+
+	test('terminates when workflowId becomes empty', async () => {
+		const workflowId = ref('workflow-1');
+		const enabled = ref(true);
+		mountHost(workflowId, enabled);
+		await nextTick();
+
+		workflowId.value = '';
+		await nextTick();
+
+		expect(mockTerminate).toHaveBeenCalledTimes(1);
+	});
+
+	test('terminates on unmount', async () => {
+		const workflowId = ref('workflow-1');
+		const enabled = ref(true);
+		const wrapper = mountHost(workflowId, enabled);
+		await nextTick();
+
+		wrapper.unmount();
+
+		expect(mockTerminate).toHaveBeenCalledTimes(1);
+	});
+
+	test('stops heartbeat when document becomes hidden', async () => {
+		const workflowId = ref('workflow-1');
+		const enabled = ref(true);
+		mountHost(workflowId, enabled);
+		await nextTick();
+
+		visibility.value = 'hidden';
+		await nextTick();
+
+		expect(mockStopHeartbeat).toHaveBeenCalled();
+	});
+
+	test('starts heartbeat when document becomes visible again', async () => {
+		const workflowId = ref('workflow-1');
+		const enabled = ref(true);
+		mountHost(workflowId, enabled);
+		await nextTick();
+
+		visibility.value = 'hidden';
+		await nextTick();
+		visibility.value = 'visible';
+		await nextTick();
+
+		expect(mockStartHeartbeat).toHaveBeenCalled();
+	});
+
+	test('does not toggle heartbeat when no workflow is active', async () => {
+		const workflowId = ref('');
+		const enabled = ref(true);
+		mountHost(workflowId, enabled);
+		await nextTick();
+
+		visibility.value = 'hidden';
+		await nextTick();
+
+		expect(mockStopHeartbeat).not.toHaveBeenCalled();
+		expect(mockStartHeartbeat).not.toHaveBeenCalled();
+	});
+});

--- a/packages/frontend/editor-ui/src/features/collaboration/collaboration/composables/useCollaborationLifecycle.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/collaboration/composables/useCollaborationLifecycle.ts
@@ -1,0 +1,60 @@
+import { onBeforeUnmount, watch, type Ref } from 'vue';
+import { useDocumentVisibility } from '@vueuse/core';
+
+import { useCollaborationStore } from '../collaboration.store';
+
+/**
+ * Owns the collaboration store lifecycle for a workflow editor view.
+ *
+ * Must be called from a stable component (e.g. NodeView) — not from a child
+ * whose render position depends on connection state or collaborator count.
+ * If lifecycle is tied to such a child, transient unmounts terminate the
+ * collaboration session and the push listener never recovers.
+ */
+export function useCollaborationLifecycle(
+	workflowId: Ref<string>,
+	options: { enabled: Ref<boolean> },
+) {
+	const collaborationStore = useCollaborationStore();
+	const visibility = useDocumentVisibility();
+
+	let activeWorkflowId = '';
+
+	function start(id: string) {
+		activeWorkflowId = id;
+		void collaborationStore.initialize(id);
+	}
+
+	function stop() {
+		if (!activeWorkflowId) return;
+		activeWorkflowId = '';
+		collaborationStore.terminate();
+	}
+
+	watch(
+		[() => workflowId.value, () => options.enabled.value] as const,
+		([id, enabled]) => {
+			const shouldRun = enabled && !!id;
+			if (shouldRun && id !== activeWorkflowId) {
+				stop();
+				start(id);
+			} else if (!shouldRun) {
+				stop();
+			}
+		},
+		{ immediate: true },
+	);
+
+	watch(visibility, (state) => {
+		if (!activeWorkflowId) return;
+		if (state === 'hidden') {
+			collaborationStore.stopHeartbeat();
+		} else {
+			collaborationStore.startHeartbeat();
+		}
+	});
+
+	onBeforeUnmount(() => {
+		stop();
+	});
+}


### PR DESCRIPTION
## Summary

`CollaborationPane.vue` owned the collaboration store lifecycle via `onMounted` (`initialize`) and `onBeforeUnmount` (`terminate`). The pane is rendered inside `<ConnectionTracker>`'s slot, which swaps to an error banner via `v-if` when a connection blip is detected — so any transient unmount of the pane called `terminate()`, sending `workflowClosed`, removing the push listener, and clearing the outgoing queue. The editor stayed offline even after the WebSocket reconnected.

This PR moves init/terminate (and the document-visibility heartbeat watcher) into a new `useCollaborationLifecycle` composable, called from `NodeView.vue` (gated off for the demo route). `CollaborationPane.vue` becomes purely presentational. The composable also reacts to workflowId changes (terminate old → init new).

**How to test:**
1. Open any saved workflow on a single-user instance.
2. Confirm the editor stays online; no `workflowClosed` is sent shortly after opening the workflow (inspect WebSocket frames in DevTools).
3. Navigate between workflows — confirm `workflowClosed` for the previous workflow and `workflowOpened` for the new one are sent.
4. Open a new workflow, save it, and confirm collaboration starts after first save.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5309
fixes #31279

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI