### PR TITLE
fix(editor): Adjust Markdown editor border and toolbar spacing (no-changelog)

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditor.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditor.vue
@@ -212,22 +212,16 @@ defineExpose({
 	padding: 1px;
 	border-radius: var(--input--radius);
 	background-color: var(--input--color--background);
-	box-shadow:
-		var(--input--shadow),
-		inset var(--input--border--shadow);
+	box-shadow: var(--input--shadow), var(--input--border--shadow);
 
 	@include focus.focus-within-ring;
 
 	&:hover:not(.disabled):not(:focus-within) {
-		box-shadow:
-			var(--input--shadow--hover),
-			inset var(--input--border--shadow--hover);
+		box-shadow: var(--input--shadow--hover), var(--input--border--shadow--hover);
 	}
 
 	&:focus-within {
-		box-shadow:
-			var(--input--shadow--focus),
-			inset var(--input--border--shadow--focus);
+		box-shadow: var(--input--shadow--focus), var(--input--border--shadow--focus);
 	}
 }
 .content {

--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditorToolbar.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditorToolbar.vue
@@ -298,7 +298,6 @@ const setTextStyle = (value: string | number) => {
 	position: absolute;
 	inset-inline: 0;
 	top: 0;
-	padding: 2px;
 	z-index: 1;
 	opacity: 0;
 	visibility: hidden;


### PR DESCRIPTION
## Summary

- Make the contained `N8nMarkdownEditor` visually aligned with other inputs by removing the inset border shadow and eliminating the toolbar's extra 2px outer padding so the toolbar sits flush with the editor edge.
- Replace `inset var(--input--border--shadow)` with `var(--input--border--shadow)` for default, hover, and focus box-shadow rules in `packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditor.vue`.
- Remove the `padding: 2px;` on the toolbar root in `packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditorToolbar.vue` so the toolbar aligns flush with the editor.

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/2126014a-2904-44b1-abea-061d67c46e78" width="960px" alt="Before image" /> | <img src="https://github.com/user-attachments/assets/f0cdc8fb-3543-4116-bc02-8b0ce57f0312" width="960px" alt="After image" /> |

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
