### PR TITLE
fix(LangChain Code Node): Hide node from the node catalogue

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/code/Code.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/code/Code.node.ts
@@ -223,6 +223,7 @@ export class Code implements INodeType {
 		group: ['transform'],
 		version: 1,
 		description: 'LangChain Code Node',
+		hidden: true,
 		defaults: {
 			name: 'LangChain Code',
 		},


### PR DESCRIPTION
## Summary

The LangChain Code node (`@n8n/n8n-nodes-langchain.code`) is a deprecated node that we already hide in our cloud environments. This change hides it from the node catalogue (the "add node" panel) on self-hosted instances as well, so the experience is consistent everywhere.

It sets `hidden: true` on the node's `description`, matching how other deprecated nodes in `packages/@n8n/nodes-langchain` are hidden (e.g. `OpenAiAssistant`, the `VectorStore*Insert` nodes).

Existing workflows that already use the node are unaffected: the node is **not** removed and its runtime behaviour is **unchanged** — this only hides it from the node creator panel.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4502

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI