### PR TITLE
chore: Don't deep compare buffers in vitest

### DIFF
--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/binary-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/binary-helper-functions.test.ts
@@ -274,7 +274,9 @@ describe('test binary data helper methods', () => {
 			const inputData: ITaskDataConnections = { main: [] };
 
 			const result = await getBinaryDataBuffer(inputData, 0, binaryData, 0);
-			expect(result).toEqual(largeBuffer);
+			expect(result.equals(largeBuffer)).toBe(true);
+			expect(result.length).equals(largeBuffer.length);
+
 			expect(result.length).toBe(1024 * 1024);
 		}, 20000);
 


### PR DESCRIPTION
## Summary

"should handle large binary data with IBinaryData" is a known flake in the CI, usually pushing through its generous 20 second timeout.

### Why it's flaky

The test creates a 1 MB buffer (Buffer.alloc(1024 * 1024, 'A')), round-trips it through setBinaryDataBuffer / getBinaryDataBuffer, then runs vitest's expect(result).toEqual(largeBuffer) which deep-compares a 1 MB Buffer element-by-element.

### How it's resolved

Swap `expect(result).toEqual(largeBuffer)` for `expect(result.equals(largeBuffer)).toBe(true)` plus a length check — Buffer.equals is orders of magnitude faster than vitest's deep equality on large Buffers and removes most of the headroom risk.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
