### PR TITLE
test(core): Make CBC wrong-key decryption tests deterministic

### DIFF
--- a/packages/core/src/encryption/__tests__/cipher.test.ts
+++ b/packages/core/src/encryption/__tests__/cipher.test.ts
@@ -10,6 +10,17 @@ describe('Cipher', () => {
 	mockInstance(InstanceSettings, { encryptionKey: 'test_key' });
 	const cipher = Container.get(Cipher);
 
+	// Decrypts CBC ciphertext with the given key, normalizing a padding-validation
+	// throw into a sentinel. Used to assert wrong-key decryption never recovers the
+	// original plaintext without relying on the flaky ~255/256 chance that CBC throws.
+	const decryptWithCbcKey = (ciphertext: string, key: string): string => {
+		try {
+			return cipher.decryptWithKey(ciphertext, key, 'aes-256-cbc');
+		} catch {
+			return '\0__decryption-threw__';
+		}
+	};
+
 	describe('encrypt', () => {
 		it('should encrypt strings', () => {
 			const encrypted = cipher.encrypt('random-string');
@@ -52,9 +63,12 @@ describe('Cipher', () => {
 			expect(cipher.decryptWithKey(encrypted, 'test_key', 'aes-256-cbc')).toEqual('random-string');
 		});
 
-		it('should fail to decrypt with a non-instance key', () => {
+		it('should not recover the plaintext with a non-instance key', () => {
 			const encrypted = cipher.encryptWithInstanceKey('random-string');
-			expect(() => cipher.decryptWithKey(encrypted, 'some-other-key', 'aes-256-cbc')).toThrow();
+			// Unauthenticated CBC cannot reliably detect a wrong key: decryption
+			// either throws on padding validation or yields garbage, but it must
+			// never return the original plaintext.
+			expect(decryptWithCbcKey(encrypted, 'some-other-key')).not.toEqual('random-string');
 		});
 	});
 
@@ -85,9 +99,12 @@ describe('Cipher', () => {
 			expect(first).not.toEqual(second);
 		});
 
-		it('should fail to decrypt with a different key', () => {
+		it('should not recover the plaintext with a different key', () => {
 			const encrypted = cipher.encryptWithKey('random-string', 'key-a', 'aes-256-cbc');
-			expect(() => cipher.decryptWithKey(encrypted, 'key-b', 'aes-256-cbc')).toThrow();
+			// Unauthenticated CBC cannot reliably detect a wrong key: decryption
+			// either throws on padding validation or yields garbage, but it must
+			// never return the original plaintext.
+			expect(decryptWithCbcKey(encrypted, 'key-b')).not.toEqual('random-string');
 		});
 
 		it('should be interoperable with legacy encrypt when given the same key', () => {


### PR DESCRIPTION
## Summary

The CBC wrong-key decryption tests in `cipher.test.ts` were flaky.

`aes-256-cbc` is unauthenticated, so the only thing that makes a wrong-key
decryption throw is `decipher.final()` failing PKCS7 padding validation. For a
random last plaintext block that validation succeeds by chance ~1/256 of the
time (when the last byte happens to be `0x01`, a valid 1-byte pad). Because the
salt is random per encrypt, the derived key/IV change every run — so ~0.4% of
runs decrypt wrong-key ciphertext to garbage *without throwing*, and the
`toThrow()` assertion silently failed. Running the loop 10,000 times surfaced
this reliably.

The fix changes the two CBC wrong-key tests to assert the contract CBC actually
guarantees: **a wrong key never recovers the original plaintext** — it either
throws on padding validation or yields garbage, but it never returns the input.
A small `decryptWithCbcKey` helper normalizes the "threw" case into a sentinel
so both outcomes collapse to "≠ original plaintext".

This is a test-only change. The GCM wrong-key test is untouched — GCM is
authenticated, so its `toThrow()` is deterministic and correct.

**How to test:** `pnpm --filter n8n-core test src/encryption/__tests__/cipher.test.ts` — 30 tests pass deterministically.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI