### PR TITLE
feat(metrics): Expose tags to metrics endpoint

### DIFF
--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -12,6 +12,7 @@ import promClient from 'prom-client';
 
 import type { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
 import type { EventService } from '@/events/event.service';
+import { WorkflowHookContextService } from '@/workflow-hook-context.service';
 
 import { PrometheusMetricsService } from '../prometheus-metrics.service';
 
@@ -35,6 +36,7 @@ describe('PrometheusMetricsService', () => {
 	let instanceSettings: InstanceSettings;
 	let workflowRepository: WorkflowRepository;
 	let licenseMetricsRepository: LicenseMetricsRepository;
+	let workflowHookContextService: WorkflowHookContextService;
 	let prometheusMetricsService: PrometheusMetricsService;
 
 	beforeEach(() => {
@@ -78,6 +80,8 @@ describe('PrometheusMetricsService', () => {
 		instanceSettings = mock<InstanceSettings>({ instanceType: 'main' });
 		workflowRepository = mock<WorkflowRepository>();
 		licenseMetricsRepository = mock<LicenseMetricsRepository>();
+		workflowHookContextService = mockInstance(WorkflowHookContextService);
+		jest.mocked(workflowHookContextService.getWorkflowTags).mockResolvedValue([]);
 
 		prometheusMetricsService = new PrometheusMetricsService(
 			mock(),
@@ -596,7 +600,7 @@ describe('PrometheusMetricsService', () => {
 			expect(promClient.Histogram).toHaveBeenCalledWith({
 				name: 'n8n_workflow_execution_duration_seconds',
 				help: 'Workflow execution duration in seconds.',
-				labelNames: ['status', 'mode'],
+				labelNames: ['status', 'mode', 'workflow_tags'],
 				buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600],
 			});
 
@@ -616,7 +620,7 @@ describe('PrometheusMetricsService', () => {
 
 			expect(promClient.Histogram).toHaveBeenCalledWith(
 				expect.objectContaining({
-					labelNames: ['status', 'mode', 'workflow_id'],
+					labelNames: ['status', 'mode', 'workflow_id', 'workflow_tags'],
 				}),
 			);
 		});
@@ -627,7 +631,7 @@ describe('PrometheusMetricsService', () => {
 			await prometheusMetricsService.init(app);
 
 			const handler = getEventHandler();
-			handler({
+			await handler({
 				runData: {
 					startedAt: new Date('2026-01-01T00:00:00Z'),
 					stoppedAt: new Date('2026-01-01T00:00:05Z'),
@@ -638,7 +642,7 @@ describe('PrometheusMetricsService', () => {
 			});
 
 			expect(promClient.Histogram.prototype.observe).toHaveBeenCalledWith(
-				{ status: 'success', mode: 'trigger' },
+				{ status: 'success', mode: 'trigger', workflow_tags: '' },
 				5,
 			);
 		});
@@ -649,7 +653,7 @@ describe('PrometheusMetricsService', () => {
 			await prometheusMetricsService.init(app);
 
 			const handler = getEventHandler();
-			handler({
+			await handler({
 				runData: {
 					startedAt: new Date('2026-01-01T00:00:00Z'),
 					stoppedAt: new Date('2026-01-01T00:00:02.5Z'),
@@ -660,7 +664,7 @@ describe('PrometheusMetricsService', () => {
 			});
 
 			expect(promClient.Histogram.prototype.observe).toHaveBeenCalledWith(
-				{ status: 'failed', mode: 'webhook' },
+				{ status: 'failed', mode: 'webhook', workflow_tags: '' },
 				2.5,
 			);
 		});
@@ -671,7 +675,7 @@ describe('PrometheusMetricsService', () => {
 			await prometheusMetricsService.init(app);
 
 			const handler = getEventHandler();
-			handler({
+			await handler({
 				runData: {
 					startedAt: new Date('2026-01-01T00:00:00Z'),
 					stoppedAt: new Date('2026-01-01T00:00:03Z'),
@@ -682,7 +686,7 @@ describe('PrometheusMetricsService', () => {
 			});
 
 			expect(promClient.Histogram.prototype.observe).toHaveBeenCalledWith(
-				{ status: 'failed', mode: 'trigger' },
+				{ status: 'failed', mode: 'trigger', workflow_tags: '' },
 				3,
 			);
 		});
@@ -694,7 +698,7 @@ describe('PrometheusMetricsService', () => {
 			await prometheusMetricsService.init(app);
 
 			const handler = getEventHandler();
-			handler({
+			await handler({
 				runData: {
 					startedAt: new Date('2026-01-01T00:00:00Z'),
 					stoppedAt: new Date('2026-01-01T00:00:01Z'),
@@ -705,7 +709,132 @@ describe('PrometheusMetricsService', () => {
 			});
 
 			expect(promClient.Histogram.prototype.observe).toHaveBeenCalledWith(
-				{ status: 'success', mode: 'manual', workflow_id: 'wf_789' },
+				{ status: 'success', mode: 'manual', workflow_id: 'wf_789', workflow_tags: '' },
+				1,
+			);
+		});
+
+		it('should include sorted workflow tag names in observation labels', async () => {
+			prometheusMetricsService.enableMetric('workflowExecutionDuration');
+			promClient.Histogram.prototype.observe = jest.fn();
+			await prometheusMetricsService.init(app);
+
+			const handler = getEventHandler();
+			await handler({
+				runData: {
+					startedAt: new Date('2026-01-01T00:00:00Z'),
+					stoppedAt: new Date('2026-01-01T00:00:01Z'),
+					status: 'success',
+					mode: 'manual',
+				},
+				workflow: {
+					id: 'wf_789',
+					name: 'My Workflow',
+					tags: [{ name: 'prod' }, { name: 'customer' }],
+				},
+			});
+
+			expect(promClient.Histogram.prototype.observe).toHaveBeenCalledWith(
+				{ status: 'success', mode: 'manual', workflow_tags: 'customer,prod' },
+				1,
+			);
+		});
+
+		it('should dedupe and filter workflow tag names in observation labels', async () => {
+			prometheusMetricsService.enableMetric('workflowExecutionDuration');
+			promClient.Histogram.prototype.observe = jest.fn();
+			await prometheusMetricsService.init(app);
+
+			const handler = getEventHandler();
+			await handler({
+				runData: {
+					startedAt: new Date('2026-01-01T00:00:00Z'),
+					stoppedAt: new Date('2026-01-01T00:00:01Z'),
+					status: 'success',
+					mode: 'manual',
+				},
+				workflow: {
+					id: 'wf_789',
+					name: 'My Workflow',
+					tags: [{ name: 'prod' }, { name: 'customer' }, { name: 'prod' }, { name: '' }],
+				},
+			});
+
+			expect(promClient.Histogram.prototype.observe).toHaveBeenCalledWith(
+				{ status: 'success', mode: 'manual', workflow_tags: 'customer,prod' },
+				1,
+			);
+		});
+
+		it('should use an empty workflow_tags label when the workflow has no tags', async () => {
+			prometheusMetricsService.enableMetric('workflowExecutionDuration');
+			promClient.Histogram.prototype.observe = jest.fn();
+			await prometheusMetricsService.init(app);
+
+			const handler = getEventHandler();
+			await handler({
+				runData: {
+					startedAt: new Date('2026-01-01T00:00:00Z'),
+					stoppedAt: new Date('2026-01-01T00:00:01Z'),
+					status: 'success',
+					mode: 'manual',
+				},
+				workflow: { id: 'wf_789', name: 'My Workflow', tags: [] },
+			});
+
+			expect(promClient.Histogram.prototype.observe).toHaveBeenCalledWith(
+				{ status: 'success', mode: 'manual', workflow_tags: '' },
+				1,
+			);
+		});
+
+		it('should look up workflow tags when the workflow has no tags relation', async () => {
+			prometheusMetricsService.enableMetric('workflowExecutionDuration');
+			promClient.Histogram.prototype.observe = jest.fn();
+			jest
+				.mocked(workflowHookContextService.getWorkflowTags)
+				.mockResolvedValue(['prod', 'customer']);
+			await prometheusMetricsService.init(app);
+
+			const handler = getEventHandler();
+			await handler({
+				runData: {
+					startedAt: new Date('2026-01-01T00:00:00Z'),
+					stoppedAt: new Date('2026-01-01T00:00:01Z'),
+					status: 'success',
+					mode: 'manual',
+				},
+				workflow: { id: 'wf_789', name: 'My Workflow' },
+			});
+
+			expect(workflowHookContextService.getWorkflowTags).toHaveBeenCalledWith('wf_789');
+			expect(promClient.Histogram.prototype.observe).toHaveBeenCalledWith(
+				{ status: 'success', mode: 'manual', workflow_tags: 'customer,prod' },
+				1,
+			);
+		});
+
+		it('should still observe duration when workflow tag lookup fails', async () => {
+			prometheusMetricsService.enableMetric('workflowExecutionDuration');
+			promClient.Histogram.prototype.observe = jest.fn();
+			jest
+				.mocked(workflowHookContextService.getWorkflowTags)
+				.mockRejectedValue(new Error('lookup failed'));
+			await prometheusMetricsService.init(app);
+
+			const handler = getEventHandler();
+			await handler({
+				runData: {
+					startedAt: new Date('2026-01-01T00:00:00Z'),
+					stoppedAt: new Date('2026-01-01T00:00:01Z'),
+					status: 'success',
+					mode: 'manual',
+				},
+				workflow: { id: 'wf_789', name: 'My Workflow' },
+			});
+
+			expect(promClient.Histogram.prototype.observe).toHaveBeenCalledWith(
+				{ status: 'success', mode: 'manual', workflow_tags: '' },
 				1,
 			);
 		});
@@ -716,7 +845,7 @@ describe('PrometheusMetricsService', () => {
 			await prometheusMetricsService.init(app);
 
 			const handler = getEventHandler();
-			handler({
+			await handler({
 				runData: {
 					startedAt: new Date('2026-01-01T00:00:00Z'),
 					stoppedAt: undefined,
@@ -735,7 +864,7 @@ describe('PrometheusMetricsService', () => {
 			await prometheusMetricsService.init(app);
 
 			const handler = getEventHandler();
-			handler({
+			await handler({
 				runData: undefined,
 				workflow: { id: 'wf_123', name: 'Test' },
 			});

--- a/packages/cli/src/metrics/prometheus-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus-metrics.service.ts
@@ -4,12 +4,12 @@ import { GlobalConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
 import { LicenseMetricsRepository, WorkflowRepository } from '@n8n/db';
 import { OnLeaderStepdown, OnLeaderTakeover } from '@n8n/decorators';
-import { Service } from '@n8n/di';
+import { Container, Service } from '@n8n/di';
 import type express from 'express';
 import promBundle from 'express-prom-bundle';
 import { DateTime } from 'luxon';
 import { InstanceSettings } from 'n8n-core';
-import { EventMessageTypeNames, jsonParse } from 'n8n-workflow';
+import { EventMessageTypeNames, jsonParse, type IWorkflowBase } from 'n8n-workflow';
 import promClient, { type Counter, type Gauge, type Histogram } from 'prom-client';
 import semverParse from 'semver/functions/parse';
 
@@ -18,8 +18,19 @@ import type { EventMessageTypes } from '@/eventbus';
 import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
 import { EventService } from '@/events/event.service';
 import { CacheService } from '@/services/cache/cache.service';
+import { WorkflowHookContextService } from '@/workflow-hook-context.service';
 
 import type { Includes, MetricCategory, MetricLabel } from './types';
+
+type WorkflowWithMaybeTags = IWorkflowBase & {
+	tags: Array<{ name?: unknown }>;
+};
+
+function hasWorkflowTags(workflow: IWorkflowBase): workflow is WorkflowWithMaybeTags {
+	return 'tags' in workflow && Array.isArray(workflow.tags);
+}
+
+const WORKFLOW_TAGS_CACHE_TTL_MS = 30 * Time.seconds.toMilliseconds;
 
 @Service()
 export class PrometheusMetricsService {
@@ -40,6 +51,8 @@ export class PrometheusMetricsService {
 	private readonly gauges: Record<string, Gauge<string>> = {};
 
 	private readonly histograms: Record<string, Histogram<string>> = {};
+
+	private readonly workflowTagsCache = new Map<string, { label: string; expiresAt: number }>();
 
 	private readonly prefix = this.globalConfig.endpoints.metrics.prefix;
 
@@ -355,13 +368,14 @@ export class PrometheusMetricsService {
 	 *
 	 * Observes duration from `startedAt` to `stoppedAt` on each completed workflow execution.
 	 * Labels: `status` (success/failed), `mode` (manual/trigger/webhook/etc.),
-	 * and optionally `workflow_id` (gated by existing config flag).
+	 * `workflow_tags`, and optionally `workflow_id` (gated by existing config flag).
 	 */
 	private initWorkflowExecutionDurationMetric() {
 		if (!this.includes.metrics.workflowExecutionDuration) return;
 
 		const labelNames = ['status', 'mode'];
 		if (this.includes.labels.workflowId) labelNames.push('workflow_id');
+		labelNames.push('workflow_tags');
 
 		this.histograms.workflowExecutionDuration = new promClient.Histogram({
 			name: this.prefix + 'workflow_execution_duration_seconds',
@@ -370,7 +384,7 @@ export class PrometheusMetricsService {
 			buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600],
 		});
 
-		this.eventService.on('workflow-post-execute', ({ runData, workflow }) => {
+		this.eventService.on('workflow-post-execute', async ({ runData, workflow }) => {
 			if (!runData?.stoppedAt) return;
 
 			const durationSeconds = (runData.stoppedAt.getTime() - runData.startedAt.getTime()) / 1000;
@@ -383,8 +397,48 @@ export class PrometheusMetricsService {
 				labels.workflow_id = String(workflow.id ?? 'unknown');
 			}
 
+			labels.workflow_tags = await this.getWorkflowTagsLabel(workflow);
+
 			this.histograms.workflowExecutionDuration?.observe(labels, durationSeconds);
 		});
+	}
+
+	private async getWorkflowTagsLabel(workflow: IWorkflowBase): Promise<string> {
+		if (hasWorkflowTags(workflow)) {
+			return this.toWorkflowTagsLabel(workflow.tags.map(({ name }) => name));
+		}
+
+		const cached = this.workflowTagsCache.get(workflow.id);
+		const now = Date.now();
+		if (cached && cached.expiresAt > now) return cached.label;
+
+		try {
+			const workflowTags = await Container.get(WorkflowHookContextService).getWorkflowTags(
+				workflow.id,
+			);
+			const label = this.toWorkflowTagsLabel(workflowTags);
+
+			this.workflowTagsCache.set(workflow.id, {
+				label,
+				expiresAt: now + WORKFLOW_TAGS_CACHE_TTL_MS,
+			});
+
+			return label;
+		} catch {
+			return '';
+		}
+	}
+
+	private toWorkflowTagsLabel(tagNames: unknown[]): string {
+		return [
+			...new Set(
+				tagNames.filter(
+					(tagName): tagName is string => typeof tagName === 'string' && tagName !== '',
+				),
+			),
+		]
+			.sort()
+			.join(',');
 	}
 
 	/**

--- a/packages/cli/test/integration/prometheus-metrics.test.ts
+++ b/packages/cli/test/integration/prometheus-metrics.test.ts
@@ -362,9 +362,22 @@ describe('PrometheusMetricsService', () => {
 		/**
 		 * Act
 		 */
+		const workflow = {
+			id: 'wf_1',
+			name: 'Test',
+			active: true,
+			activeVersionId: null,
+			isArchived: false,
+			createdAt: new Date('2026-01-01T00:00:00Z'),
+			updatedAt: new Date('2026-01-01T00:00:00Z'),
+			nodes: [],
+			connections: {},
+			tags: [],
+		} satisfies IWorkflowBase & { tags: [] };
+
 		eventService.emit('workflow-post-execute', {
 			executionId: 'exec_123',
-			workflow: { id: 'wf_1', name: 'Test' } as IWorkflowBase,
+			workflow,
 			runData: {
 				startedAt: new Date('2026-01-01T00:00:00Z'),
 				stoppedAt: new Date('2026-01-01T00:00:02Z'),


### PR DESCRIPTION
## Summary

Expose workflow tags on the Prometheus workflow execution duration metric.

n8n_workflow_execution_duration_seconds now always includes a workflow_tags label when the metric is enabled. Tag values are normalized as a sorted, comma-separated list of tag names, for example workflow_tags="customer,prod". Workflows without tags use an empty label value. If execution data does not include loaded workflow tags, the metric service falls back to fetching them via the workflow hook context and caches the result briefly.


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
