### PR TITLE
refactor(editor): Replace floating chat input with sticky input dock (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
@@ -446,59 +446,6 @@ watch(
 	},
 );
 
-// --- Floating input dynamic padding ---
-const inputContainerRef = useTemplateRef<HTMLElement>('inputContainer');
-const inputSwapRef = useTemplateRef<HTMLElement>('inputSwap');
-const inputAreaHeight = ref(120);
-const scrollButtonBottomOffset = ref(144);
-let inputContainerResizeObserver: ResizeObserver | null = null;
-let inputSwapResizeObserver: ResizeObserver | null = null;
-
-function updateScrollButtonBottomOffset() {
-	const container = inputContainerRef.value;
-	const inputSwap = inputSwapRef.value;
-	if (!container || !inputSwap) {
-		scrollButtonBottomOffset.value = inputAreaHeight.value + 24;
-		return;
-	}
-
-	const containerBottom = container.getBoundingClientRect().bottom;
-	const inputSwapTop = inputSwap.getBoundingClientRect().top;
-	scrollButtonBottomOffset.value = Math.max(24, containerBottom - inputSwapTop + 24);
-}
-
-watch(
-	inputContainerRef,
-	(el) => {
-		inputContainerResizeObserver?.disconnect();
-		if (el) {
-			inputContainerResizeObserver = new ResizeObserver((entries) => {
-				for (const entry of entries) {
-					inputAreaHeight.value = entry.borderBoxSize[0]?.blockSize ?? entry.contentRect.height;
-				}
-				updateScrollButtonBottomOffset();
-			});
-			inputContainerResizeObserver.observe(el);
-		}
-	},
-	{ immediate: true },
-);
-
-watch(
-	inputSwapRef,
-	(el) => {
-		inputSwapResizeObserver?.disconnect();
-		if (el) {
-			inputSwapResizeObserver = new ResizeObserver(() => {
-				updateScrollButtonBottomOffset();
-			});
-			inputSwapResizeObserver.observe(el);
-			updateScrollButtonBottomOffset();
-		}
-	},
-	{ immediate: true },
-);
-
 function reconnectThreadAfterHydration(): void {
 	void thread.loadHistoricalMessages().then((hydrationStatus) => {
 		if (hydrationStatus === 'stale') return;
@@ -535,8 +482,6 @@ onMounted(() => {
 onUnmounted(() => {
 	thread.closeSSE();
 	contentResizeObserver?.disconnect();
-	inputContainerResizeObserver?.disconnect();
-	inputSwapResizeObserver?.disconnect();
 });
 
 const workflowPreviewRef =
@@ -681,110 +626,107 @@ function handleWorkflowFailures(report: WorkflowFailuresReport) {
 				data-test-id="instance-ai-content-area"
 			>
 				<div :class="$style.chatContent">
-					<N8nScrollArea :class="$style.scrollArea">
-						<div
-							ref="scrollable"
-							:class="$style.messageList"
-							:style="{ paddingBottom: `calc(${inputAreaHeight}px + var(--spacing--sm))` }"
-						>
-							<TransitionGroup name="message-slide">
-								<InstanceAiMessage
-									v-for="message in displayedMessages"
-									:key="message.id"
-									:message="message"
-								/>
-							</TransitionGroup>
-							<!-- Builder sub-agents are extracted from their parent assistant
+					<N8nScrollArea as-child :class="$style.scrollArea">
+						<div ref="scrollable" :class="$style.scrollContent">
+							<div :class="$style.messageList">
+								<TransitionGroup name="message-slide">
+									<InstanceAiMessage
+										v-for="message in displayedMessages"
+										:key="message.id"
+										:message="message"
+									/>
+								</TransitionGroup>
+								<!-- Builder sub-agents are extracted from their parent assistant
      messages and rendered here so they always sit at the bottom
      of the conversation. -->
-							<div v-if="builderAgents.length" :class="$style.builderAgents">
-								<AgentSection
-									v-for="builder in builderAgents"
-									:key="builder.agentId"
-									:agent-node="builder"
-								/>
-							</div>
-							<!-- Inline confirmations (questions, plan review, text, setup,
-								 credential, gateway resource-decision, continue) render in
-								 the chat flow. Floating-eligible items take over the chat
-								 input slot below instead — see `hasFloatingConfirmation`. -->
-							<InstanceAiConfirmationPanel kind="inline" />
-							<Transition name="confirmation-slide">
-								<InstanceAiFixWithAiPanel
-									v-if="activeFixWithAiOffer"
-									:node-name="activeFixWithAiOffer.errors[0].nodeName"
-									:error-message="activeFixWithAiOffer.errors[0].errorMessage"
-									:failed-count="activeFixWithAiOffer.errors.length"
-									@fix-with-ai="handleFixWithAiFromOffer"
-									@dismiss="dismissFixWithAiOffer"
-								/>
-							</Transition>
-						</div>
-					</N8nScrollArea>
-
-					<!-- Scroll to bottom button -->
-					<div
-						:class="$style.scrollButtonContainer"
-						:style="{ bottom: `${scrollButtonBottomOffset}px` }"
-					>
-						<Transition name="scroll-button-fade">
-							<N8nIconButton
-								v-if="userScrolledUp && thread.hasMessages"
-								variant="outline"
-								icon="arrow-down"
-								size="large"
-								icon-size="large"
-								:class="$style.scrollToBottomButton"
-								@click="
-									scrollToBottom(true);
-									userScrolledUp = false;
-								"
-							/>
-						</Transition>
-					</div>
-
-					<!-- Floating input — replaced by the confirmation panel while a
-						 floating-eligible approval is pending. StatusBar and credit
-						 banner stay anchored above the slot in both states. The
-						 leaving child is positioned absolutely during the cross-fade
-						 so the in-flow child can size the slot to its natural
-						 height. -->
-					<div ref="inputContainer" :class="$style.inputContainer">
-						<div :class="$style.inputConstraint">
-							<InstanceAiStatusBar />
-							<CreditWarningBanner
-								v-if="creditBanner.visible.value"
-								:credits-remaining="store.creditsRemaining"
-								:credits-quota="store.creditsQuota"
-								@upgrade-click="goToUpgrade('instance-ai', 'upgrade-instance-ai')"
-								@dismiss="creditBanner.dismiss()"
-							/>
-							<div ref="inputSwap" :class="$style.inputSwap">
-								<Transition name="input-swap">
-									<InstanceAiConfirmationPanel
-										v-if="hasFloatingConfirmation"
-										key="floating-confirmation"
-										kind="floating"
+								<div v-if="builderAgents.length" :class="$style.builderAgents">
+									<AgentSection
+										v-for="builder in builderAgents"
+										:key="builder.agentId"
+										:agent-node="builder"
 									/>
-									<InstanceAiInput
-										v-else
-										ref="chatInputRef"
-										key="chat-input"
-										:is-streaming="thread.isStreaming"
-										:is-submitting="thread.isSendingMessage"
-										:is-awaiting-confirmation="thread.isAwaitingConfirmation"
-										:is-plan-edit-mode="thread.activePlanEdit !== null"
-										:current-thread-id="thread.id"
-										:amend-context="thread.amendContext"
-										:contextual-suggestion="thread.contextualSuggestion"
-										@submit="handleSubmit"
-										@stop="handleStop"
-										@cancel-plan-edit="thread.cancelPlanEdit"
+								</div>
+								<!-- Inline confirmations (questions, plan review, text, setup,
+									 credential, gateway resource-decision, continue) render in
+									 the chat flow. Floating-eligible items take over the chat
+									 input slot below instead - see `hasFloatingConfirmation`. -->
+								<InstanceAiConfirmationPanel kind="inline" />
+								<Transition name="confirmation-slide">
+									<InstanceAiFixWithAiPanel
+										v-if="activeFixWithAiOffer"
+										:node-name="activeFixWithAiOffer.errors[0].nodeName"
+										:error-message="activeFixWithAiOffer.errors[0].errorMessage"
+										:failed-count="activeFixWithAiOffer.errors.length"
+										@fix-with-ai="handleFixWithAiFromOffer"
+										@dismiss="dismissFixWithAiOffer"
 									/>
 								</Transition>
 							</div>
+
+							<!-- Floating input slot - replaced by the confirmation panel while a
+								 floating-eligible approval is pending. StatusBar and credit
+								 banner stay anchored above the slot in both states. The
+								 leaving child is positioned absolutely during the cross-fade
+								 so the in-flow child can size the slot to its natural
+								 height. -->
+							<div :class="$style.inputDock">
+								<!-- Scroll to bottom button -->
+								<div :class="$style.scrollButtonContainer">
+									<Transition name="scroll-button-fade">
+										<N8nIconButton
+											v-if="userScrolledUp && thread.hasMessages"
+											variant="outline"
+											icon="arrow-down"
+											size="large"
+											icon-size="large"
+											:class="$style.scrollToBottomButton"
+											@click="
+												scrollToBottom(true);
+												userScrolledUp = false;
+											"
+										/>
+									</Transition>
+								</div>
+
+								<div :class="$style.inputContainer">
+									<div :class="$style.inputConstraint">
+										<InstanceAiStatusBar />
+										<CreditWarningBanner
+											v-if="creditBanner.visible.value"
+											:credits-remaining="store.creditsRemaining"
+											:credits-quota="store.creditsQuota"
+											@upgrade-click="goToUpgrade('instance-ai', 'upgrade-instance-ai')"
+											@dismiss="creditBanner.dismiss()"
+										/>
+										<div :class="$style.inputSwap">
+											<Transition name="input-swap">
+												<InstanceAiConfirmationPanel
+													v-if="hasFloatingConfirmation"
+													key="floating-confirmation"
+													kind="floating"
+												/>
+												<InstanceAiInput
+													v-else
+													ref="chatInputRef"
+													key="chat-input"
+													:is-streaming="thread.isStreaming"
+													:is-submitting="thread.isSendingMessage"
+													:is-awaiting-confirmation="thread.isAwaitingConfirmation"
+													:is-plan-edit-mode="thread.activePlanEdit !== null"
+													:current-thread-id="thread.id"
+													:amend-context="thread.amendContext"
+													:contextual-suggestion="thread.contextualSuggestion"
+													@submit="handleSubmit"
+													@stop="handleStop"
+													@cancel-plan-edit="thread.cancelPlanEdit"
+												/>
+											</Transition>
+										</div>
+									</div>
+								</div>
+							</div>
 						</div>
-					</div>
+					</N8nScrollArea>
 				</div>
 
 				<!-- Artifacts panel (below header, beside chat) -->
@@ -1032,6 +974,13 @@ function handleWorkflowFailures(report: WorkflowFailuresReport) {
 	min-height: 0;
 }
 
+.scrollContent {
+	width: 100%;
+	min-height: 100%;
+	display: flex;
+	flex-direction: column;
+}
+
 .messageList {
 	width: calc(100% - var(--instance-ai-artifacts-layout-width));
 	max-width: 800px;
@@ -1064,14 +1013,19 @@ function handleWorkflowFailures(report: WorkflowFailuresReport) {
 	margin-top: var(--spacing--xs);
 }
 
+.inputDock {
+	position: sticky;
+	bottom: 0;
+	margin-top: auto;
+	z-index: 3;
+	pointer-events: none;
+}
+
 .scrollButtonContainer {
-	position: absolute;
-	left: 0;
-	right: 0;
 	display: flex;
 	justify-content: center;
 	pointer-events: none;
-	z-index: 3;
+	margin-bottom: var(--spacing--sm);
 	transform: translateX(calc(var(--instance-ai-artifacts-layout-width) / -2));
 }
 
@@ -1108,14 +1062,9 @@ function handleWorkflowFailures(report: WorkflowFailuresReport) {
 }
 
 .inputContainer {
-	position: absolute;
-	bottom: 0;
-	left: 0;
-	right: 0;
 	padding: 0 var(--spacing--lg) var(--spacing--sm);
 	background: linear-gradient(transparent 0%, var(--color--background--light-2) 30%);
 	pointer-events: none;
-	z-index: 2;
 
 	& > * {
 		pointer-events: auto;


### PR DESCRIPTION
## Summary

Refactors the chat input layout in the Instance AI thread view (`InstanceAiThreadView.vue`), swapping the imperatively-measured floating input for a CSS sticky dock.

Previously the chat input was `position: absolute` over the scroll area, and a pair of `ResizeObserver`s measured its height at runtime to:
- push `padding-bottom` onto the message list so content wasn't hidden behind the input, and
- position the scroll-to-bottom button above the input.

This replaces that machinery with native sticky positioning:
- Removes `inputAreaHeight`, `scrollButtonBottomOffset`, `updateScrollButtonBottomOffset()`, and the two `ResizeObserver`s (plus their `onUnmounted` teardown).
- The input + scroll-to-bottom button now live **inside** the scroll flow via `N8nScrollArea as-child` → a flex `.scrollContent` column, with the input docked using `position: sticky; bottom: 0; margin-top: auto`.

Net result: same visual behavior (input stays pinned to the bottom, content scrolls behind it, scroll-to-bottom button sits just above the input), driven by CSS instead of JS measurement. ~50 lines of observer logic removed.

### How to test
1. Open the Instance AI assistant and start a thread.
2. Send enough messages to overflow the viewport — confirm the input stays docked at the bottom and the message list isn't clipped behind it.
3. Scroll up — the scroll-to-bottom button appears just above the input; click it to jump back down.
4. Trigger a floating confirmation (e.g. plan review) — confirm it takes over the input slot and the dock still sizes correctly.
5. Resize the window / chat panel and toggle the credit warning banner — layout should stay correct without the previous JS reflow.

## Related Linear tickets, Github issues, and Community forum posts

_None._

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI