### PR TITLE
feat: Require name and reject default placeholder in package-name-convention lint (no-changelog)

### DIFF
--- a/packages/@n8n/eslint-plugin-community-nodes/docs/rules/package-name-convention.md
+++ b/packages/@n8n/eslint-plugin-community-nodes/docs/rules/package-name-convention.md
@@ -10,6 +10,8 @@
 
 Validates that your package name follows the correct n8n community node naming convention. Package names must start with `n8n-nodes-` and can optionally be scoped.
 
+The rule also requires a `name` field to be present and rejects the default placeholder (`n8n-nodes-<...>`) that ships with the node starter template, so packages are not published with a missing or unfilled name.
+
 ## Examples
 
 ### ❌ Incorrect
@@ -29,6 +31,18 @@ Validates that your package name follows the correct n8n community node naming c
 ```json
 {
   "name": "@company/my-service"
+}
+```
+
+```json
+{
+  "name": "n8n-nodes-<...>"
+}
+```
+
+```json
+{
+  "version": "1.0.0"
 }
 ```
 

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/package-name-convention.test.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/package-name-convention.test.ts
@@ -27,11 +27,6 @@ ruleTester.run('package-name-convention', PackageNameConventionRule, {
 			code: '{ "name": "@author/n8n-nodes-service", "version": "1.0.0" }',
 		},
 		{
-			name: 'object without name property',
-			filename: 'package.json',
-			code: '{ "version": "1.0.0", "description": "test" }',
-		},
-		{
 			name: 'non-package.json file ignored',
 			filename: 'some-config.json',
 			code: '{ "name": "my-config", "type": "config" }',
@@ -182,6 +177,38 @@ ruleTester.run('package-name-convention', PackageNameConventionRule, {
 					messageId: 'invalidPackageName',
 					data: { packageName: '@company/n8n-nodes-' },
 					suggestions: [],
+				},
+			],
+		},
+		{
+			name: 'missing name property',
+			filename: 'package.json',
+			code: '{ "version": "1.0.0", "description": "test" }',
+			errors: [
+				{
+					messageId: 'missingName',
+				},
+			],
+		},
+		{
+			name: 'default placeholder name',
+			filename: 'package.json',
+			code: '{ "name": "n8n-nodes-<...>", "version": "1.0.0" }',
+			errors: [
+				{
+					messageId: 'defaultPlaceholderName',
+					data: { packageName: 'n8n-nodes-<...>' },
+				},
+			],
+		},
+		{
+			name: 'name containing default placeholder',
+			filename: 'package.json',
+			code: '{ "name": "@company/n8n-nodes-<...>", "version": "1.0.0" }',
+			errors: [
+				{
+					messageId: 'defaultPlaceholderName',
+					data: { packageName: '@company/n8n-nodes-<...>' },
 				},
 			],
 		},

--- a/packages/@n8n/eslint-plugin-community-nodes/src/rules/package-name-convention.ts
+++ b/packages/@n8n/eslint-plugin-community-nodes/src/rules/package-name-convention.ts
@@ -15,6 +15,10 @@ export const PackageNameConventionRule = createRule({
 			renameTo: "Rename to '{{suggestedName}}'",
 			invalidPackageName:
 				'Package name "{{ packageName }}" must follow the convention "n8n-nodes-[PACKAGE-NAME]" or "@[AUTHOR]/n8n-nodes-[PACKAGE-NAME]"',
+			missingName:
+				'Package name is missing. Add a "name" field following the convention "n8n-nodes-[PACKAGE-NAME]" or "@[AUTHOR]/n8n-nodes-[PACKAGE-NAME]"',
+			defaultPlaceholderName:
+				'Package name "{{ packageName }}" still contains the default placeholder. Replace "<...>" with your package name',
 		},
 		schema: [],
 		hasSuggestions: true,
@@ -34,6 +38,10 @@ export const PackageNameConventionRule = createRule({
 				const nameProperty = findJsonProperty(node, 'name');
 
 				if (!nameProperty) {
+					context.report({
+						node,
+						messageId: 'missingName',
+					});
 					return;
 				}
 
@@ -43,6 +51,17 @@ export const PackageNameConventionRule = createRule({
 
 				const packageName = nameProperty.value.value;
 				const packageNameStr = typeof packageName === 'string' ? packageName : null;
+
+				if (packageNameStr && isDefaultPlaceholderName(packageNameStr)) {
+					context.report({
+						node: nameProperty,
+						messageId: 'defaultPlaceholderName',
+						data: {
+							packageName: packageNameStr,
+						},
+					});
+					return;
+				}
 
 				if (!packageNameStr || !isValidPackageName(packageNameStr)) {
 					const suggestions: ReportSuggestionArray<'invalidPackageName' | 'renameTo'> = [];
@@ -74,6 +93,10 @@ export const PackageNameConventionRule = createRule({
 		};
 	},
 });
+
+function isDefaultPlaceholderName(name: string): boolean {
+	return name.includes('<...>');
+}
 
 function isValidPackageName(name: string): boolean {
 	const unscoped = /^n8n-nodes-.+$/;


### PR DESCRIPTION
## Summary

Extends the `package-name-convention` rule in `@n8n/eslint-plugin-community-nodes` so it covers two cases it previously let slip through:

- **Missing `name`** — the rule used to return early when `package.json` had no `name` key. It now reports a `missingName` error.
- **Default placeholder** — `n8n-nodes-<...>` (and scoped variants like `@company/n8n-nodes-<...>`) matched the convention regex and passed. A new `defaultPlaceholderName` check now rejects any name containing the `<...>` placeholder before the format check runs.

Both report at severity `error` (the rule is already enabled as `error` in both configs).

This migrates the `community-package-json-name-missing` and `community-package-json-name-still-default` checks from the external `eslint-plugin-n8n-nodes-base` plugin (Phase 2 of the dependency-removal migration).

### How to test

```bash
cd packages/@n8n/eslint-plugin-community-nodes
pnpm test package-name-convention.test.ts
```

All 17 cases pass, including the new missing-name and placeholder scenarios.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CE-888

Part of CE-856 (meta ticket for external plugin dependency removal).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI