### PR TITLE
chore: Remove redundant jest config

### DIFF
--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -1,6 +1,0 @@
-/** @type {import('vi').Config} */
-module.exports = {
-	...require('../../vi.config'),
-	globalSetup: '<rootDir>/test/setup.ts',
-	setupFilesAfterEnv: ['<rootDir>/test/setup-mocks.ts'],
-};


### PR DESCRIPTION
## Summary

https://github.com/n8n-io/n8n/pull/31115 removed the jest dependency from the core package and replaced it with Vitest. However a jest config file was left dangling in the package. This PR removes it.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
