### PR TITLE
feat(core): Enforce one pending outbox row per workflow (no-changelog)

### DIFF
--- a/packages/@n8n/db/src/entities/workflow-publication-outbox.ts
+++ b/packages/@n8n/db/src/entities/workflow-publication-outbox.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, PrimaryGeneratedColumn } from '@n8n/typeorm';
+import { Column, Entity, Index, PrimaryGeneratedColumn } from '@n8n/typeorm';
 
 import { WithTimestamps } from './abstract-entity';
 
@@ -10,6 +10,10 @@ export type WorkflowPublicationOutboxStatus =
 	| 'failed';
 
 @Entity({ name: 'workflow_publication_outbox' })
+@Index('IDX_workflow_publication_outbox_pending_workflow', ['workflowId'], {
+	unique: true,
+	where: "status = 'pending'",
+})
 export class WorkflowPublicationOutbox extends WithTimestamps {
 	@PrimaryGeneratedColumn()
 	id: number;

--- a/packages/@n8n/db/src/migrations/common/1784000000020-CreateWorkflowPublicationOutboxTable.ts
+++ b/packages/@n8n/db/src/migrations/common/1784000000020-CreateWorkflowPublicationOutboxTable.ts
@@ -6,7 +6,7 @@ import type { MigrationContext, ReversibleMigration } from '../migration-types';
  * publication request that the outbox consumer will process asynchronously.
  */
 export class CreateWorkflowPublicationOutboxTable1784000000020 implements ReversibleMigration {
-	async up({ schemaBuilder: { createTable, column } }: MigrationContext) {
+	async up({ schemaBuilder: { createTable, createIndex, column } }: MigrationContext) {
 		await createTable('workflow_publication_outbox').withColumns(
 			column('id').int.primary.autoGenerate2,
 			// No foreign keys on workflowId or publishedVersionId: this is a
@@ -34,6 +34,16 @@ export class CreateWorkflowPublicationOutboxTable1784000000020 implements Revers
 				'Error details for surfacing failed publications to the user.',
 			),
 		).withTimestamps;
+
+		// At most one pending record per workflow: enqueueing a newer version
+		// while one is still pending supersedes the older publishedVersionId.
+		await createIndex(
+			'workflow_publication_outbox',
+			['workflowId'],
+			true,
+			'IDX_workflow_publication_outbox_pending_workflow',
+			"status = 'pending'",
+		);
 	}
 
 	async down({ schemaBuilder: { dropTable } }: MigrationContext) {


### PR DESCRIPTION
## Summary

Amends the `workflow_publication_outbox` migration to add a partial unique index `UNIQUE (workflowId) WHERE status = 'pending'`.

Why? If there's a pending publication request for some workflow and a new publication request comes in, we want the newer one to supersede the older one, rather than running them both.

Modify existing migration vs add a new one - since the table was just added today and hasn't been included in any releases, it seems safe to modify if we do it quickly, and save the (readability) overhead of an extra migration.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/CAT-2193
- Follows #26936

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)