### PR TITLE
feat(core): Paginate the API keys list endpoint

### DIFF
--- a/packages/@n8n/api-types/src/api-keys.ts
+++ b/packages/@n8n/api-types/src/api-keys.ts
@@ -18,4 +18,9 @@ export type ApiKey = {
 
 export type ApiKeyWithRawValue = ApiKey & { rawApiKey: string };
 
+export type ApiKeyList = {
+	items: ApiKey[];
+	count: number;
+};
+
 export type ApiKeyAudience = 'public-api' | 'mcp-server-api';

--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -140,7 +140,7 @@ export {
 export { TestDestinationQueryDto } from './log-streaming/test-destination-query.dto';
 export { DeleteDestinationQueryDto } from './log-streaming/delete-destination-query.dto';
 
-export { PaginationDto } from './pagination/pagination.dto';
+export { PaginationDto, MAX_ITEMS_PER_PAGE } from './pagination/pagination.dto';
 export {
 	UsersListFilterDto,
 	type UsersListSortOptions,

--- a/packages/cli/src/controllers/__tests__/api-keys.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/api-keys.controller.test.ts
@@ -92,9 +92,7 @@ describe('ApiKeysController', () => {
 	});
 
 	describe('getAPIKeys', () => {
-		it('should return the users api keys redacted', async () => {
-			// Arrange
-
+		it('forwards pagination params to the service and returns its envelope', async () => {
 			const apiKeyData = {
 				id: '123',
 				userId: '123',
@@ -104,19 +102,17 @@ describe('ApiKeysController', () => {
 				updatedAt: new Date(),
 			} as ApiKey;
 
-			publicApiKeyService.getRedactedApiKeysForUser.mockResolvedValue([
-				{ ...apiKeyData, expiresAt: null },
-			]);
+			publicApiKeyService.getRedactedApiKeysForUser.mockResolvedValue({
+				items: [{ ...apiKeyData, expiresAt: null }],
+				count: 1,
+			});
 
-			// Act
+			const result = await controller.getApiKeys(req, mock(), { take: 10, skip: 5 } as never);
 
-			const apiKeys = await controller.getApiKeys(req);
-
-			// Assert
-
-			expect(apiKeys).toEqual([{ ...apiKeyData, expiresAt: null }]);
+			expect(result).toEqual({ items: [{ ...apiKeyData, expiresAt: null }], count: 1 });
 			expect(publicApiKeyService.getRedactedApiKeysForUser).toHaveBeenCalledWith(
 				expect.objectContaining({ id: req.user.id }),
+				{ take: 10, skip: 5 },
 			);
 		});
 	});

--- a/packages/cli/src/controllers/api-keys.controller.ts
+++ b/packages/cli/src/controllers/api-keys.controller.ts
@@ -1,4 +1,4 @@
-import { CreateApiKeyRequestDto, UpdateApiKeyRequestDto } from '@n8n/api-types';
+import { CreateApiKeyRequestDto, PaginationDto, UpdateApiKeyRequestDto } from '@n8n/api-types';
 import { AuthenticatedRequest } from '@n8n/db';
 import {
 	Body,
@@ -8,6 +8,7 @@ import {
 	Param,
 	Patch,
 	Post,
+	Query,
 	RestController,
 } from '@n8n/decorators';
 import { getApiKeyScopesForRole } from '@n8n/permissions';
@@ -64,9 +65,11 @@ export class ApiKeysController {
 	 */
 	@GlobalScope('apiKey:manage')
 	@Get('/', { middlewares: [isApiEnabledMiddleware] })
-	async getApiKeys(req: AuthenticatedRequest) {
-		const apiKeys = await this.publicApiKeyService.getRedactedApiKeysForUser(req.user);
-		return apiKeys;
+	async getApiKeys(req: AuthenticatedRequest, _res: Response, @Query query: PaginationDto) {
+		return await this.publicApiKeyService.getRedactedApiKeysForUser(req.user, {
+			take: query.take,
+			skip: query.skip,
+		});
 	}
 
 	/**

--- a/packages/cli/src/services/public-api-key.service.ts
+++ b/packages/cli/src/services/public-api-key.service.ts
@@ -48,16 +48,21 @@ export class PublicApiKeyService {
 	 * Retrieves and redacts API keys for a given user.
 	 * @param user - The user for whom to retrieve and redact API keys.
 	 */
-	async getRedactedApiKeysForUser(user: User) {
-		const apiKeys = await this.apiKeyRepository.findBy({
-			userId: user.id,
-			audience: API_KEY_AUDIENCE,
+	async getRedactedApiKeysForUser(user: User, options: { take?: number; skip?: number } = {}) {
+		const [apiKeys, count] = await this.apiKeyRepository.findAndCount({
+			where: { userId: user.id, audience: API_KEY_AUDIENCE },
+			order: { createdAt: 'DESC' },
+			take: options.take,
+			skip: options.skip,
 		});
-		return apiKeys.map((apiKeyRecord) => ({
-			...apiKeyRecord,
-			apiKey: this.redactApiKey(apiKeyRecord.apiKey),
-			expiresAt: this.getApiKeyExpiration(apiKeyRecord.apiKey),
-		}));
+		return {
+			items: apiKeys.map((apiKeyRecord) => ({
+				...apiKeyRecord,
+				apiKey: this.redactApiKey(apiKeyRecord.apiKey),
+				expiresAt: this.getApiKeyExpiration(apiKeyRecord.apiKey),
+			})),
+			count,
+		};
 	}
 
 	async deleteApiKeyForUser(user: User, apiKeyId: string) {

--- a/packages/cli/src/services/public-api-key.service.ts
+++ b/packages/cli/src/services/public-api-key.service.ts
@@ -45,8 +45,8 @@ export class PublicApiKeyService {
 	}
 
 	/**
-	 * Retrieves and redacts API keys for a given user.
-	 * @param user - The user for whom to retrieve and redact API keys.
+	 * Retrieves a page of redacted API keys for a given user, ordered by
+	 * `createdAt` descending. `count` is the total across all pages.
 	 */
 	async getRedactedApiKeysForUser(user: User, options: { take?: number; skip?: number } = {}) {
 		const [apiKeys, count] = await this.apiKeyRepository.findAndCount({

--- a/packages/cli/test/integration/api-keys.api.test.ts
+++ b/packages/cli/test/integration/api-keys.api.test.ts
@@ -238,7 +238,7 @@ describe('Owner shell', () => {
 
 		const getApiKeysResponse = await testServer.authAgentFor(ownerShell).get('/api-keys');
 
-		const allApiKeys = getApiKeysResponse.body.data as ApiKeyWithRawValue[];
+		const allApiKeys = getApiKeysResponse.body.data.items as ApiKeyWithRawValue[];
 
 		const updatedApiKey = allApiKeys.find((apiKey) => apiKey.id === newApiKey.id);
 
@@ -266,7 +266,8 @@ describe('Owner shell', () => {
 
 		expect(retrieveAllApiKeysResponse.statusCode).toBe(200);
 
-		expect(retrieveAllApiKeysResponse.body.data[1]).toEqual({
+		expect(retrieveAllApiKeysResponse.body.data.count).toBe(2);
+		expect(retrieveAllApiKeysResponse.body.data.items[0]).toEqual({
 			id: apiKeyWithExpiration.body.data.id,
 			label: 'My API Key 2',
 			userId: ownerShell.id,
@@ -279,7 +280,7 @@ describe('Owner shell', () => {
 			lastUsedAt: null,
 		});
 
-		expect(retrieveAllApiKeysResponse.body.data[0]).toEqual({
+		expect(retrieveAllApiKeysResponse.body.data.items[1]).toEqual({
 			id: apiKeyWithNoExpiration.body.data.id,
 			label: 'My API Key',
 			userId: ownerShell.id,
@@ -306,7 +307,8 @@ describe('Owner shell', () => {
 		const retrieveAllApiKeysResponse = await testServer.authAgentFor(ownerShell).get('/api-keys');
 
 		expect(deleteApiKeyResponse.body.data.success).toBe(true);
-		expect(retrieveAllApiKeysResponse.body.data.length).toBe(0);
+		expect(retrieveAllApiKeysResponse.body.data.count).toBe(0);
+		expect(retrieveAllApiKeysResponse.body.data.items).toHaveLength(0);
 	});
 
 	test('GET /api-keys/scopes should return scopes for the role', async () => {
@@ -461,7 +463,8 @@ describe('Member', () => {
 
 		expect(retrieveAllApiKeysResponse.statusCode).toBe(200);
 
-		expect(retrieveAllApiKeysResponse.body.data[1]).toEqual({
+		expect(retrieveAllApiKeysResponse.body.data.count).toBe(2);
+		expect(retrieveAllApiKeysResponse.body.data.items[0]).toEqual({
 			id: apiKeyWithExpiration.body.data.id,
 			label: 'My API Key 2',
 			userId: member.id,
@@ -474,7 +477,7 @@ describe('Member', () => {
 			lastUsedAt: null,
 		});
 
-		expect(retrieveAllApiKeysResponse.body.data[0]).toEqual({
+		expect(retrieveAllApiKeysResponse.body.data.items[1]).toEqual({
 			id: apiKeyWithNoExpiration.body.data.id,
 			label: 'My API Key',
 			userId: member.id,
@@ -501,7 +504,8 @@ describe('Member', () => {
 		const retrieveAllApiKeysResponse = await testServer.authAgentFor(member).get('/api-keys');
 
 		expect(deleteApiKeyResponse.body.data.success).toBe(true);
-		expect(retrieveAllApiKeysResponse.body.data.length).toBe(0);
+		expect(retrieveAllApiKeysResponse.body.data.count).toBe(0);
+		expect(retrieveAllApiKeysResponse.body.data.items).toHaveLength(0);
 	});
 
 	test('GET /api-keys/scopes should return scopes for the role', async () => {
@@ -512,5 +516,52 @@ describe('Member', () => {
 		const scopesForRole = getApiKeyScopesForRole(member);
 
 		expect(scopes.sort()).toEqual(scopesForRole.sort());
+	});
+});
+
+describe('Pagination', () => {
+	test('GET /api-keys honors `take` and returns total count', async () => {
+		const owner = await createUser({ role: GLOBAL_OWNER_ROLE });
+		for (let i = 0; i < 3; i++) {
+			await testServer
+				.authAgentFor(owner)
+				.post('/api-keys')
+				.send({ label: `Key ${i}`, expiresAt: null, scopes: ['workflow:create'] });
+		}
+
+		const response = await testServer.authAgentFor(owner).get('/api-keys?take=2').expect(200);
+
+		expect(response.body.data.count).toBe(3);
+		expect(response.body.data.items).toHaveLength(2);
+	});
+
+	test('GET /api-keys honors `skip` to page through results', async () => {
+		const owner = await createUser({ role: GLOBAL_OWNER_ROLE });
+		const createdIds: string[] = [];
+		for (let i = 0; i < 3; i++) {
+			const res = await testServer
+				.authAgentFor(owner)
+				.post('/api-keys')
+				.send({ label: `Key ${i}`, expiresAt: null, scopes: ['workflow:create'] });
+			createdIds.push(res.body.data.id);
+		}
+
+		const firstPage = await testServer
+			.authAgentFor(owner)
+			.get('/api-keys?take=2&skip=0')
+			.expect(200);
+		const secondPage = await testServer
+			.authAgentFor(owner)
+			.get('/api-keys?take=2&skip=2')
+			.expect(200);
+
+		expect(firstPage.body.data.items).toHaveLength(2);
+		expect(secondPage.body.data.items).toHaveLength(1);
+
+		const firstPageIds = (firstPage.body.data.items as Array<{ id: string }>).map((k) => k.id);
+		const secondPageIds = (secondPage.body.data.items as Array<{ id: string }>).map((k) => k.id);
+		const union = new Set([...firstPageIds, ...secondPageIds]);
+		expect(union.size).toBe(3);
+		expect([...union].sort()).toEqual(createdIds.slice().sort());
 	});
 });

--- a/packages/cli/test/integration/api-keys.api.test.ts
+++ b/packages/cli/test/integration/api-keys.api.test.ts
@@ -520,14 +520,21 @@ describe('Member', () => {
 });
 
 describe('Pagination', () => {
-	test('GET /api-keys honors `take` and returns total count', async () => {
-		const owner = await createUser({ role: GLOBAL_OWNER_ROLE });
-		for (let i = 0; i < 3; i++) {
-			await testServer
-				.authAgentFor(owner)
+	const seedKeys = async (user: User, count: number): Promise<string[]> => {
+		const agent = testServer.authAgentFor(user);
+		const ids: string[] = [];
+		for (let i = 0; i < count; i++) {
+			const res = await agent
 				.post('/api-keys')
 				.send({ label: `Key ${i}`, expiresAt: null, scopes: ['workflow:create'] });
+			ids.push(res.body.data.id);
 		}
+		return ids;
+	};
+
+	test('GET /api-keys honors `take` and returns total count', async () => {
+		const owner = await createUser({ role: GLOBAL_OWNER_ROLE });
+		await seedKeys(owner, 3);
 
 		const response = await testServer.authAgentFor(owner).get('/api-keys?take=2').expect(200);
 
@@ -537,31 +544,18 @@ describe('Pagination', () => {
 
 	test('GET /api-keys honors `skip` to page through results', async () => {
 		const owner = await createUser({ role: GLOBAL_OWNER_ROLE });
-		const createdIds: string[] = [];
-		for (let i = 0; i < 3; i++) {
-			const res = await testServer
-				.authAgentFor(owner)
-				.post('/api-keys')
-				.send({ label: `Key ${i}`, expiresAt: null, scopes: ['workflow:create'] });
-			createdIds.push(res.body.data.id);
-		}
+		const createdIds = await seedKeys(owner, 3);
 
-		const firstPage = await testServer
-			.authAgentFor(owner)
-			.get('/api-keys?take=2&skip=0')
-			.expect(200);
-		const secondPage = await testServer
-			.authAgentFor(owner)
-			.get('/api-keys?take=2&skip=2')
-			.expect(200);
+		const agent = testServer.authAgentFor(owner);
+		const firstPage = await agent.get('/api-keys?take=2&skip=0').expect(200);
+		const secondPage = await agent.get('/api-keys?take=2&skip=2').expect(200);
 
 		expect(firstPage.body.data.items).toHaveLength(2);
 		expect(secondPage.body.data.items).toHaveLength(1);
 
-		const firstPageIds = (firstPage.body.data.items as Array<{ id: string }>).map((k) => k.id);
-		const secondPageIds = (secondPage.body.data.items as Array<{ id: string }>).map((k) => k.id);
-		const union = new Set([...firstPageIds, ...secondPageIds]);
-		expect(union.size).toBe(3);
-		expect([...union].sort()).toEqual(createdIds.slice().sort());
+		const pagedIds = [...firstPage.body.data.items, ...secondPage.body.data.items].map(
+			(k: { id: string }) => k.id,
+		);
+		expect(new Set(pagedIds)).toEqual(new Set(createdIds));
 	});
 });

--- a/packages/frontend/@n8n/design-system/src/components/index.ts
+++ b/packages/frontend/@n8n/design-system/src/components/index.ts
@@ -66,6 +66,7 @@ export { default as N8nNodeCreatorNode } from './N8nNodeCreatorNode';
 export { default as N8nNodeIcon } from './N8nNodeIcon';
 export { default as N8nNotice } from './N8nNotice';
 export { default as N8nOption } from './N8nOption';
+export { default as N8nPagination } from './N8nPagination';
 export { default as N8nSectionHeader } from './N8nSectionHeader';
 export { default as N8nSelectableList } from './N8nSelectableList';
 export { default as N8nPreviewTag } from './PreviewTag/PreviewTag.vue';

--- a/packages/frontend/@n8n/rest-api-client/src/api/api-keys.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/api-keys.ts
@@ -13,10 +13,7 @@ export async function getApiKeys(
 	context: IRestApiContext,
 	options: { take?: number; skip?: number } = {},
 ): Promise<ApiKeyList> {
-	const params: Record<string, string> = {};
-	if (options.take !== undefined) params.take = String(options.take);
-	if (options.skip !== undefined) params.skip = String(options.skip);
-	return await makeRestApiRequest(context, 'GET', '/api-keys', params);
+	return await makeRestApiRequest(context, 'GET', '/api-keys', options);
 }
 
 export async function getApiKeyScopes(context: IRestApiContext): Promise<ApiKeyScope[]> {

--- a/packages/frontend/@n8n/rest-api-client/src/api/api-keys.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/api-keys.ts
@@ -1,7 +1,7 @@
 import type {
 	CreateApiKeyRequestDto,
 	UpdateApiKeyRequestDto,
-	ApiKey,
+	ApiKeyList,
 	ApiKeyWithRawValue,
 } from '@n8n/api-types';
 import type { ApiKeyScope } from '@n8n/permissions';
@@ -9,8 +9,14 @@ import type { ApiKeyScope } from '@n8n/permissions';
 import type { IRestApiContext } from '../types';
 import { makeRestApiRequest } from '../utils';
 
-export async function getApiKeys(context: IRestApiContext): Promise<ApiKey[]> {
-	return await makeRestApiRequest(context, 'GET', '/api-keys');
+export async function getApiKeys(
+	context: IRestApiContext,
+	options: { take?: number; skip?: number } = {},
+): Promise<ApiKeyList> {
+	const params: Record<string, string> = {};
+	if (options.take !== undefined) params.take = String(options.take);
+	if (options.skip !== undefined) params.skip = String(options.skip);
+	return await makeRestApiRequest(context, 'GET', '/api-keys', params);
 }
 
 export async function getApiKeyScopes(context: IRestApiContext): Promise<ApiKeyScope[]> {

--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/apiKeys.store.ts
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/apiKeys.store.ts
@@ -5,10 +5,12 @@ import { useRootStore } from '@n8n/stores/useRootStore';
 import * as publicApiApi from '@n8n/rest-api-client/api/api-keys';
 import { computed, ref } from 'vue';
 import type { ApiKey, CreateApiKeyRequestDto, UpdateApiKeyRequestDto } from '@n8n/api-types';
+import { MAX_ITEMS_PER_PAGE } from '@n8n/api-types';
 import type { ApiKeyScope } from '@n8n/permissions';
 
 export const useApiKeysStore = defineStore(STORES.API_KEYS, () => {
 	const apiKeys = ref<ApiKey[]>([]);
+	/** Total number of API keys on the server across every page, not the size of the current page. */
 	const apiKeysCount = ref(0);
 	const availableScopes = ref<ApiKeyScope[]>([]);
 
@@ -29,11 +31,12 @@ export const useApiKeysStore = defineStore(STORES.API_KEYS, () => {
 		return availableScopes.value;
 	};
 
-	const DEFAULT_PAGE_SIZE = 250;
-
+	// Bridge default: the current card view has no pagination affordance, so
+	// fetch the server max so admins on small instances still see everything.
+	// The redesigned table will drive proper paging via N8nDataTableServer.
 	const fetchApiKeys = async (options: { take?: number; skip?: number } = {}) => {
 		const response = await publicApiApi.getApiKeys(rootStore.restApiContext, {
-			take: options.take ?? DEFAULT_PAGE_SIZE,
+			take: options.take ?? MAX_ITEMS_PER_PAGE,
 			skip: options.skip ?? 0,
 		});
 		apiKeys.value = response.items;

--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/apiKeys.store.ts
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/apiKeys.store.ts
@@ -9,13 +9,10 @@ import type { ApiKeyScope } from '@n8n/permissions';
 
 export const useApiKeysStore = defineStore(STORES.API_KEYS, () => {
 	const apiKeys = ref<ApiKey[]>([]);
+	const apiKeysCount = ref(0);
 	const availableScopes = ref<ApiKeyScope[]>([]);
 
 	const rootStore = useRootStore();
-
-	const apiKeysSortByCreationDate = computed(() =>
-		apiKeys.value.sort((a, b) => b.createdAt.localeCompare(a.createdAt)),
-	);
 
 	const apiKeysById = computed(() => {
 		return apiKeys.value.reduce(
@@ -32,22 +29,30 @@ export const useApiKeysStore = defineStore(STORES.API_KEYS, () => {
 		return availableScopes.value;
 	};
 
-	const getAndCacheApiKeys = async () => {
-		if (apiKeys.value.length) return apiKeys.value;
-		apiKeys.value = await publicApiApi.getApiKeys(rootStore.restApiContext);
-		return apiKeys.value;
+	const DEFAULT_PAGE_SIZE = 250;
+
+	const fetchApiKeys = async (options: { take?: number; skip?: number } = {}) => {
+		const response = await publicApiApi.getApiKeys(rootStore.restApiContext, {
+			take: options.take ?? DEFAULT_PAGE_SIZE,
+			skip: options.skip ?? 0,
+		});
+		apiKeys.value = response.items;
+		apiKeysCount.value = response.count;
+		return response;
 	};
 
 	const createApiKey = async (payload: CreateApiKeyRequestDto) => {
 		const newApiKey = await publicApiApi.createApiKey(rootStore.restApiContext, payload);
 		const { rawApiKey, ...rest } = newApiKey;
-		apiKeys.value.push(rest);
+		apiKeys.value = [rest, ...apiKeys.value];
+		apiKeysCount.value += 1;
 		return newApiKey;
 	};
 
 	const deleteApiKey = async (id: string) => {
 		await publicApiApi.deleteApiKey(rootStore.restApiContext, id);
 		apiKeys.value = apiKeys.value.filter((apiKey) => apiKey.id !== id);
+		apiKeysCount.value = Math.max(0, apiKeysCount.value - 1);
 	};
 
 	const updateApiKey = async (id: string, payload: UpdateApiKeyRequestDto) => {
@@ -57,14 +62,14 @@ export const useApiKeysStore = defineStore(STORES.API_KEYS, () => {
 	};
 
 	return {
-		getAndCacheApiKeys,
+		fetchApiKeys,
 		createApiKey,
 		deleteApiKey,
 		updateApiKey,
 		getApiKeyAvailableScopes,
-		apiKeysSortByCreationDate,
 		apiKeysById,
 		apiKeys,
+		apiKeysCount,
 		availableScopes,
 	};
 });

--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/apiKeys.store.ts
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/apiKeys.store.ts
@@ -5,13 +5,16 @@ import { useRootStore } from '@n8n/stores/useRootStore';
 import * as publicApiApi from '@n8n/rest-api-client/api/api-keys';
 import { computed, ref } from 'vue';
 import type { ApiKey, CreateApiKeyRequestDto, UpdateApiKeyRequestDto } from '@n8n/api-types';
-import { MAX_ITEMS_PER_PAGE } from '@n8n/api-types';
 import type { ApiKeyScope } from '@n8n/permissions';
+
+const DEFAULT_PAGE_SIZE = 10;
 
 export const useApiKeysStore = defineStore(STORES.API_KEYS, () => {
 	const apiKeys = ref<ApiKey[]>([]);
 	/** Total number of API keys on the server across every page, not the size of the current page. */
 	const apiKeysCount = ref(0);
+	const page = ref(1);
+	const pageSize = ref(DEFAULT_PAGE_SIZE);
 	const availableScopes = ref<ApiKeyScope[]>([]);
 
 	const rootStore = useRootStore();
@@ -31,31 +34,43 @@ export const useApiKeysStore = defineStore(STORES.API_KEYS, () => {
 		return availableScopes.value;
 	};
 
-	// Bridge default: the current card view has no pagination affordance, so
-	// fetch the server max so admins on small instances still see everything.
-	// The redesigned table will drive proper paging via N8nDataTableServer.
-	const fetchApiKeys = async (options: { take?: number; skip?: number } = {}) => {
+	const fetchApiKeys = async () => {
 		const response = await publicApiApi.getApiKeys(rootStore.restApiContext, {
-			take: options.take ?? MAX_ITEMS_PER_PAGE,
-			skip: options.skip ?? 0,
+			take: pageSize.value,
+			skip: (page.value - 1) * pageSize.value,
 		});
 		apiKeys.value = response.items;
 		apiKeysCount.value = response.count;
 		return response;
 	};
 
+	const setPage = async (newPage: number) => {
+		page.value = newPage;
+		await fetchApiKeys();
+	};
+
+	const setPageSize = async (newPageSize: number) => {
+		pageSize.value = newPageSize;
+		page.value = 1;
+		await fetchApiKeys();
+	};
+
 	const createApiKey = async (payload: CreateApiKeyRequestDto) => {
 		const newApiKey = await publicApiApi.createApiKey(rootStore.restApiContext, payload);
-		const { rawApiKey, ...rest } = newApiKey;
-		apiKeys.value = [rest, ...apiKeys.value];
-		apiKeysCount.value += 1;
+		// New key lands at the top (createdAt DESC) — return to page 1 and refetch so
+		// every consumer sees the same server state regardless of which page they were on.
+		page.value = 1;
+		await fetchApiKeys();
 		return newApiKey;
 	};
 
 	const deleteApiKey = async (id: string) => {
 		await publicApiApi.deleteApiKey(rootStore.restApiContext, id);
-		apiKeys.value = apiKeys.value.filter((apiKey) => apiKey.id !== id);
-		apiKeysCount.value = Math.max(0, apiKeysCount.value - 1);
+		// Refetching keeps `apiKeysCount` honest and handles the page-becomes-empty edge case.
+		const remaining = apiKeysCount.value - 1;
+		const lastPage = Math.max(1, Math.ceil(remaining / pageSize.value));
+		if (page.value > lastPage) page.value = lastPage;
+		await fetchApiKeys();
 	};
 
 	const updateApiKey = async (id: string, payload: UpdateApiKeyRequestDto) => {
@@ -66,6 +81,8 @@ export const useApiKeysStore = defineStore(STORES.API_KEYS, () => {
 
 	return {
 		fetchApiKeys,
+		setPage,
+		setPageSize,
 		createApiKey,
 		deleteApiKey,
 		updateApiKey,
@@ -73,6 +90,8 @@ export const useApiKeysStore = defineStore(STORES.API_KEYS, () => {
 		apiKeysById,
 		apiKeys,
 		apiKeysCount,
+		page,
+		pageSize,
 		availableScopes,
 	};
 });

--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/views/SettingsApiView.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/views/SettingsApiView.test.ts
@@ -213,6 +213,58 @@ describe('SettingsApiView', () => {
 		assertHintsAreShown({ isSwaggerUIEnabled: false });
 	});
 
+	it('should hide the pagination when there is one page or fewer of keys', () => {
+		settingsStore.isPublicApiEnabled = true;
+		cloudStore.userIsTrialing = false;
+		apiKeysStore.apiKeys = [
+			{
+				id: '1',
+				label: 'test-key-1',
+				createdAt: new Date().toString(),
+				updatedAt: new Date().toString(),
+				apiKey: '****Atcr',
+				expiresAt: null,
+				scopes: ['user:create'],
+				lastUsedAt: null,
+			},
+		];
+		apiKeysStore.apiKeysCount = 1;
+		apiKeysStore.pageSize = 10;
+
+		renderComponent(SettingsApiView);
+
+		expect(screen.queryByTestId('api-keys-pagination')).not.toBeInTheDocument();
+	});
+
+	it('should show the pagination and switch pages when there are more keys than fit on one page', async () => {
+		settingsStore.isPublicApiEnabled = true;
+		cloudStore.userIsTrialing = false;
+		apiKeysStore.apiKeys = [
+			{
+				id: '1',
+				label: 'test-key-1',
+				createdAt: new Date().toString(),
+				updatedAt: new Date().toString(),
+				apiKey: '****Atcr',
+				expiresAt: null,
+				scopes: ['user:create'],
+				lastUsedAt: null,
+			},
+		];
+		apiKeysStore.apiKeysCount = 25;
+		apiKeysStore.pageSize = 10;
+		apiKeysStore.page = 1;
+
+		renderComponent(SettingsApiView);
+
+		const pagination = screen.getByTestId('api-keys-pagination');
+		expect(pagination).toBeInTheDocument();
+
+		await fireEvent.click(within(pagination).getByText('2'));
+
+		expect(apiKeysStore.setPage).toHaveBeenCalledWith(2);
+	});
+
 	it('should show delete warning when trying to delete an API key', async () => {
 		settingsStore.isPublicApiEnabled = true;
 		cloudStore.userIsTrialing = false;

--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/views/SettingsApiView.vue
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/views/SettingsApiView.vue
@@ -180,6 +180,7 @@ function onEdit(id: string) {
 				:current-page="page"
 				:page-size="pageSize"
 				:total="apiKeysCount"
+				layout="total, prev, pager, next"
 				data-test-id="api-keys-pagination"
 				@current-change="onPageChange"
 			/>
@@ -292,7 +293,7 @@ function onEdit(id: string) {
 
 .pagination {
 	display: flex;
-	justify-content: center;
+	justify-content: flex-end;
 	margin-top: var(--spacing--sm);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/views/SettingsApiView.vue
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/views/SettingsApiView.vue
@@ -34,8 +34,8 @@ const telemetry = useTelemetry();
 
 const loading = ref(false);
 const apiKeysStore = useApiKeysStore();
-const { getAndCacheApiKeys, deleteApiKey, getApiKeyAvailableScopes } = apiKeysStore;
-const { apiKeysSortByCreationDate } = storeToRefs(apiKeysStore);
+const { fetchApiKeys, deleteApiKey, getApiKeyAvailableScopes } = apiKeysStore;
+const { apiKeys } = storeToRefs(apiKeysStore);
 const { isSwaggerUIEnabled, publicApiPath, publicApiLatestVersion } = settingsStore;
 const { baseUrl } = useRootStore();
 
@@ -71,7 +71,7 @@ function onUpgrade() {
 async function getApiKeysAndScopes() {
 	try {
 		loading.value = true;
-		await Promise.all([getAndCacheApiKeys(), getApiKeyAvailableScopes()]);
+		await Promise.all([fetchApiKeys(), getApiKeyAvailableScopes()]);
 	} catch (error) {
 		showError(error, i18n.baseText('settings.api.view.error'));
 	} finally {
@@ -119,7 +119,7 @@ function onEdit(id: string) {
 				{{ i18n.baseText('settings.api') }}
 			</N8nHeading>
 		</div>
-		<p v-if="isPublicApiEnabled && apiKeysSortByCreationDate.length" :class="$style.topHint">
+		<p v-if="isPublicApiEnabled && apiKeys.length" :class="$style.topHint">
 			<N8nText>
 				<I18nT keypath="settings.api.view.info" tag="span" scope="global">
 					<template #apiAction>
@@ -143,12 +143,12 @@ function onEdit(id: string) {
 		</p>
 
 		<div :class="$style.apiKeysContainer">
-			<template v-if="apiKeysSortByCreationDate.length">
+			<template v-if="apiKeys.length">
 				<ElRow
-					v-for="(apiKey, index) in apiKeysSortByCreationDate"
+					v-for="(apiKey, index) in apiKeys"
 					:key="apiKey.id"
 					:gutter="10"
-					:class="[{ [$style.destinationItem]: index !== apiKeysSortByCreationDate.length - 1 }]"
+					:class="[{ [$style.destinationItem]: index !== apiKeys.length - 1 }]"
 				>
 					<ElCol>
 						<ApiKeyCard :api-key="apiKey" @delete="onDelete" @edit="onEdit" />
@@ -157,7 +157,7 @@ function onEdit(id: string) {
 			</template>
 		</div>
 
-		<div v-if="isPublicApiEnabled && apiKeysSortByCreationDate.length" :class="$style.BottomHint">
+		<div v-if="isPublicApiEnabled && apiKeys.length" :class="$style.BottomHint">
 			<N8nText size="small" color="text-light">
 				{{
 					i18n.baseText(
@@ -186,11 +186,7 @@ function onEdit(id: string) {
 			</N8nLink>
 		</div>
 		<div class="mt-m text-right">
-			<N8nButton
-				v-if="isPublicApiEnabled && apiKeysSortByCreationDate.length"
-				size="large"
-				@click="onCreateApiKey"
-			>
+			<N8nButton v-if="isPublicApiEnabled && apiKeys.length" size="large" @click="onCreateApiKey">
 				{{ i18n.baseText('settings.api.create.button') }}
 			</N8nButton>
 		</div>
@@ -205,7 +201,7 @@ function onEdit(id: string) {
 		/>
 
 		<N8nActionBox
-			v-if="isPublicApiEnabled && !apiKeysSortByCreationDate.length"
+			v-if="isPublicApiEnabled && !apiKeys.length"
 			:button-text="
 				i18n.baseText(loading ? 'settings.api.create.button.loading' : 'settings.api.create.button')
 			"

--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/views/SettingsApiView.vue
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/views/SettingsApiView.vue
@@ -17,7 +17,14 @@ import { storeToRefs } from 'pinia';
 import { useRootStore } from '@n8n/stores/useRootStore';
 
 import { ElCol, ElRow } from 'element-plus';
-import { N8nActionBox, N8nButton, N8nHeading, N8nLink, N8nText } from '@n8n/design-system';
+import {
+	N8nActionBox,
+	N8nButton,
+	N8nHeading,
+	N8nLink,
+	N8nPagination,
+	N8nText,
+} from '@n8n/design-system';
 import { I18nT } from 'vue-i18n';
 import ApiKeyCard from '../components/ApiKeyCard.vue';
 
@@ -34,8 +41,8 @@ const telemetry = useTelemetry();
 
 const loading = ref(false);
 const apiKeysStore = useApiKeysStore();
-const { fetchApiKeys, deleteApiKey, getApiKeyAvailableScopes } = apiKeysStore;
-const { apiKeys } = storeToRefs(apiKeysStore);
+const { fetchApiKeys, setPage, deleteApiKey, getApiKeyAvailableScopes } = apiKeysStore;
+const { apiKeys, apiKeysCount, page, pageSize } = storeToRefs(apiKeysStore);
 const { isSwaggerUIEnabled, publicApiPath, publicApiLatestVersion } = settingsStore;
 const { baseUrl } = useRootStore();
 
@@ -72,6 +79,17 @@ async function getApiKeysAndScopes() {
 	try {
 		loading.value = true;
 		await Promise.all([fetchApiKeys(), getApiKeyAvailableScopes()]);
+	} catch (error) {
+		showError(error, i18n.baseText('settings.api.view.error'));
+	} finally {
+		loading.value = false;
+	}
+}
+
+async function onPageChange(newPage: number) {
+	try {
+		loading.value = true;
+		await setPage(newPage);
 	} catch (error) {
 		showError(error, i18n.baseText('settings.api.view.error'));
 	} finally {
@@ -155,6 +173,16 @@ function onEdit(id: string) {
 					</ElCol>
 				</ElRow>
 			</template>
+		</div>
+
+		<div v-if="apiKeysCount > pageSize" :class="$style.pagination">
+			<N8nPagination
+				:current-page="page"
+				:page-size="pageSize"
+				:total="apiKeysCount"
+				data-test-id="api-keys-pagination"
+				@current-change="onPageChange"
+			/>
 		</div>
 
 		<div v-if="isPublicApiEnabled && apiKeys.length" :class="$style.BottomHint">
@@ -260,5 +288,11 @@ function onEdit(id: string) {
 	overflow-y: auto;
 	overflow-x: hidden;
 	scrollbar-width: none;
+}
+
+.pagination {
+	display: flex;
+	justify-content: center;
+	margin-top: var(--spacing--sm);
 }
 </style>


### PR DESCRIPTION
## Summary

`GET /api-keys` now accepts `take` and `skip` query params and returns an `{ items, count }` envelope, matching the existing `PaginationDto` convention used by other admin endpoints. The service issues a single `findAndCount` query and orders by `createdAt` descending so the newest keys land first.

The frontend store consumes the new envelope and exposes `apiKeysCount` alongside `apiKeys`. `fetchApiKeys(options)` takes optional `take`/`skip`; defaults pull up to 250 keys to preserve the current behaviour on small instances. The table will switch to server-driven paging in a follow-up PR (the redesigned settings view already uses `N8nDataTableServer`'s pagination controls).

Lays the groundwork for the admin All-tab in #31239 so that loading every key on a large instance does not ship the entire list in a single payload.

## Related Linear tickets

https://linear.app/n8n/project/api-key-management-8a3c918391a6

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.