### PR TITLE
fix(editor): Hide private credential connect controls without update permission

### DIFF
--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialCard.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialCard.test.ts
@@ -341,6 +341,7 @@ describe('CredentialCard', () => {
 				id: 'cred-1',
 				isResolvable: true,
 				connectedByMe: false,
+				scopes: ['credential:update'],
 				homeProject: { name: 'Test Project' },
 				...overrides,
 			});
@@ -352,6 +353,14 @@ describe('CredentialCard', () => {
 
 			expect(getByTestId('credential-card-connect')).toBeInTheDocument();
 			expect(queryByTestId('credential-card-not-connected')).not.toBeInTheDocument();
+		});
+
+		it('should hide the Connect button when the user lacks update permission', () => {
+			const { queryByTestId } = renderComponent({
+				props: { data: privateUnconnectedData({ scopes: ['credential:read'] }) },
+			});
+
+			expect(queryByTestId('credential-card-connect')).not.toBeInTheDocument();
 		});
 
 		it('should still show project badge alongside the Connect button', () => {

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialCard.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialCard.vue
@@ -75,7 +75,8 @@ const isPrivateUnconnected = computed(
 	() =>
 		isDynamicCredentialsEnabled.value &&
 		props.data.isResolvable === true &&
-		props.data.connectedByMe === false,
+		props.data.connectedByMe === false &&
+		credentialPermissions.value.update === true,
 );
 
 const isPrivateConnected = computed(

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.test.ts
@@ -7,6 +7,7 @@ import { setActivePinia } from 'pinia';
 import type { ICredentialType, INodeTypeDescription } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 import type { FrontendSettings } from '@n8n/api-types';
+import type { Scope } from '@n8n/permissions';
 import NodeCredentials from './NodeCredentials.vue';
 import type { RenderOptions } from '@/__tests__/render';
 import { createComponentRenderer } from '@/__tests__/render';
@@ -131,6 +132,7 @@ function createCredential(
 		type: string;
 		isManaged: boolean;
 		isResolvable: boolean;
+		scopes: Scope[];
 	}> = {},
 ) {
 	return {
@@ -1417,6 +1419,7 @@ describe('NodeCredentials', () => {
 			name: 'My Slack',
 			type: 'openAiApi',
 			isResolvable: true,
+			scopes: ['credential:update'],
 		});
 
 		const notionNode: INodeUi = {
@@ -1483,6 +1486,20 @@ describe('NodeCredentials', () => {
 
 			expect(screen.getByText("Your account isn't connected yet.")).toBeInTheDocument();
 			expect(screen.getByTestId('node-credential-private-connect')).toBeInTheDocument();
+		});
+
+		it('hides the Connect link when the user lacks update permission', async () => {
+			credentialsStore.state.credentials = {
+				'private-cred-id': {
+					...privateCredential,
+					connectedByMe: false,
+					scopes: ['credential:read'],
+				},
+			};
+			renderComponent({ props: { node: notionNode, overrideCredType: 'openAiApi' } });
+
+			expect(screen.getByText("Your account isn't connected yet.")).toBeInTheDocument();
+			expect(screen.queryByTestId('node-credential-private-connect')).not.toBeInTheDocument();
 		});
 
 		it('clicking Connect link calls uiStore.openExistingCredential with the credential id', async () => {

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -180,6 +180,11 @@ function isPrivateConnected(credentialType: string): boolean {
 	return getSelectedPrivateCredential(credentialType)?.connectedByMe === true;
 }
 
+function canConnectPrivateCredential(credentialType: string): boolean {
+	const credential = getSelectedPrivateCredential(credentialType);
+	return getResourcePermissions(credential?.scopes).credential.update === true;
+}
+
 watch(
 	() => props.node.parameters,
 	(newValue, oldValue) => {
@@ -910,6 +915,7 @@ async function onQuickConnectSignIn(credentialTypeName: string) {
 											i18n.baseText('credentials.private.callout.notConnected')
 										}}</N8nText>
 										<N8nLink
+											v-if="canConnectPrivateCredential(type.name)"
 											data-test-id="node-credential-private-connect"
 											@click="editCredential(type.name)"
 										>


### PR DESCRIPTION
## Summary

Users with only `credential:read` on a private (resolvable) credential — e.g. a `project:viewer` — were still shown the **Connect** button on the credential card and the **Connect** link in the node detail view. Clicking it failed server-side, since the OAuth endpoints require `credential:update`. This gates both affordances behind the `credential:update` scope so they only appear to users who can actually act on them; the informational "not connected yet" callout still renders. The Disconnect action is intentionally left ungated, since the backend always allows a user to clear their own stored connection.

**To test:** As a `project:viewer`, open the credential list and a node that uses an unconnected private credential — the Connect button/link should no longer appear (only the status notice). As an owner/editor, the Connect controls should still appear and work.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-746

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI