### PR TITLE
fix(editor): Prevent drag and drop of a folder onto itself

### DIFF
--- a/packages/frontend/editor-ui/src/features/core/folders/composables/useFolders.test.ts
+++ b/packages/frontend/editor-ui/src/features/core/folders/composables/useFolders.test.ts
@@ -25,7 +25,7 @@ describe('useFolders', () => {
 		vi.clearAllMocks();
 	});
 
-	const { validateFolderName, onDragStart, onDragEnd } = useFolders();
+	const { validateFolderName, onDragStart, onDragEnd, handleDrop } = useFolders();
 
 	describe('validateFolderName', () => {
 		describe('Valid folder names', () => {
@@ -204,6 +204,61 @@ describe('useFolders', () => {
 			expect(document.body.classList.contains('dragging-resource')).toBe(false);
 			expect(mockFoldersStore.draggedElement).toBeNull();
 			expect(mockFoldersStore.activeDropTarget).toBeNull();
+		});
+	});
+
+	describe('handleDrop', () => {
+		it('should return a valid drag and drop pair for a valid folder to folder drop', () => {
+			const element = document.createElement('div');
+			element.setAttribute('data-target', 'folder');
+			element.setAttribute('data-resourceid', 'folder-456');
+			element.setAttribute('data-resourcename', 'Target Folder');
+			document.body.appendChild(element);
+
+			document.body.classList.add('dragging-resource');
+			const expectedDraggedResource = { type: 'folder', id: 'folder-123', name: 'Some Folder' };
+			mockFoldersStore.draggedElement = expectedDraggedResource;
+
+			const expectedDropTarget = {
+				type: 'folder',
+				id: 'folder-456',
+				name: 'Target Folder',
+			};
+
+			mockFoldersStore.activeDropTarget = expectedDropTarget;
+
+			const result = handleDrop({
+				target: element,
+				preventDefault: vi.fn(),
+			} as unknown as MouseEvent);
+
+			expect(result).to.deep.equal({
+				draggedResource: expectedDraggedResource,
+				dropTarget: expectedDropTarget,
+			});
+
+			document.body.removeChild(element);
+		});
+
+		it('should not allow dropping a folder onto itself', () => {
+			const element = document.createElement('div');
+			element.setAttribute('data-target', 'folder');
+			element.setAttribute('data-resourceid', 'folder-123');
+			element.setAttribute('data-resourcename', 'Test');
+			document.body.appendChild(element);
+
+			document.body.classList.add('dragging-resource');
+			mockFoldersStore.draggedElement = { type: 'folder', id: 'folder-123', name: 'Test' };
+			mockFoldersStore.activeDropTarget = { type: 'folder', id: 'folder-123', name: 'Test' };
+
+			const result = handleDrop({
+				target: element,
+				preventDefault: vi.fn(),
+			} as unknown as MouseEvent);
+
+			expect(result).to.deep.equal({});
+
+			document.body.removeChild(element);
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/core/folders/composables/useFolders.ts
+++ b/packages/frontend/editor-ui/src/features/core/folders/composables/useFolders.ts
@@ -145,6 +145,11 @@ export function useFolders() {
 		const dropTarget = getDragAndDropTarget(eventTarget);
 		if (!dropTarget || !isDropTarget(dropTarget)) return {};
 
+		// prevent dropping a resource onto itself
+		if (dropTarget.id === draggedResourceId && dropTarget.type === draggedResourceType) {
+			return {};
+		}
+
 		return {
 			draggedResource: {
 				type: draggedResourceType,


### PR DESCRIPTION
## Summary

When you drag and drop a folder in the Workflows list onto itself:

- The folder disappears from the view (until rerendering)
- Error message "Cannot set a folder as its own parent"

Steps to reproduce  (or with recording or screenshots)

- Start dragging a folder
- Release onto itself

https://github.com/user-attachments/assets/c1695dcb-66ed-4549-8879-e2ea97450737

<!--
Describe what the PR does and how to test.
Photos and videos are recommended.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5337

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->



## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
