### PR TITLE
fix(core): Preserve published workflow history during pruning

### DIFF
--- a/packages/@n8n/db/src/repositories/workflow-history.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-history.repository.ts
@@ -2,7 +2,7 @@ import { Service } from '@n8n/di';
 import { DataSource, In, LessThan, Repository } from '@n8n/typeorm';
 import { DiffMetaData, DiffRule, groupWorkflows, SKIP_RULES } from 'n8n-workflow';
 
-import { WorkflowHistory, WorkflowEntity } from '../entities';
+import { WorkflowHistory, WorkflowEntity, WorkflowPublishedVersion } from '../entities';
 import { WorkflowPublishHistoryRepository } from './workflow-publish-history.repository';
 
 @Service()
@@ -39,13 +39,22 @@ export class WorkflowHistoryRepository extends Repository<WorkflowHistory> {
 			.where('w.activeVersionId IS NOT NULL')
 			.getQuery();
 
+		const publishedVersionIdsSubquery = this.manager
+			.createQueryBuilder()
+			.subQuery()
+			.select('wpv.publishedVersionId')
+			.from(WorkflowPublishedVersion, 'wpv')
+			.where('wpv.publishedVersionId IS NOT NULL')
+			.getQuery();
+
 		const query = this.manager
 			.createQueryBuilder()
 			.delete()
 			.from(WorkflowHistory)
 			.where('createdAt < :date', { date })
 			.andWhere(`versionId NOT IN (${currentVersionIdsSubquery})`)
-			.andWhere(`versionId NOT IN (${activeVersionIdsSubquery})`);
+			.andWhere(`versionId NOT IN (${activeVersionIdsSubquery})`)
+			.andWhere(`versionId NOT IN (${publishedVersionIdsSubquery})`);
 
 		if (preserveNamedVersions) {
 			query.andWhere('name IS NULL');

--- a/packages/cli/test/integration/workflow-history-manager.test.ts
+++ b/packages/cli/test/integration/workflow-history-manager.test.ts
@@ -5,7 +5,11 @@ import {
 	createActiveWorkflow,
 } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
-import { WorkflowHistoryRepository, WorkflowRepository } from '@n8n/db';
+import {
+	WorkflowHistoryRepository,
+	WorkflowPublishedVersionRepository,
+	WorkflowRepository,
+} from '@n8n/db';
 import { Container } from '@n8n/di';
 import { In } from '@n8n/typeorm';
 import { DateTime } from 'luxon';
@@ -18,18 +22,25 @@ import { createManyWorkflowHistoryItems } from './shared/db/workflow-history';
 describe('Workflow History Manager', () => {
 	const license = mockInstance(License);
 	let repo: WorkflowHistoryRepository;
+	let workflowPublishedVersionRepo: WorkflowPublishedVersionRepository;
 	let manager: WorkflowHistoryManager;
 	let globalConfig: GlobalConfig;
 
 	beforeAll(async () => {
 		await testDb.init();
 		repo = Container.get(WorkflowHistoryRepository);
+		workflowPublishedVersionRepo = Container.get(WorkflowPublishedVersionRepository);
 		manager = Container.get(WorkflowHistoryManager);
 		globalConfig = Container.get(GlobalConfig);
 	});
 
 	beforeEach(async () => {
-		await testDb.truncate(['WorkflowEntity', 'WorkflowHistory', 'WorkflowPublishHistory']);
+		await testDb.truncate([
+			'WorkflowPublishedVersion',
+			'WorkflowEntity',
+			'WorkflowHistory',
+			'WorkflowPublishHistory',
+		]);
 		jest.clearAllMocks();
 
 		globalConfig.workflowHistory.pruneTime = -1;
@@ -162,6 +173,35 @@ describe('Workflow History Manager', () => {
 
 		// Other old versions should be deleted
 		const otherVersionIds = workflowVersions.slice(2).map((i) => i.versionId);
+		expect(await repo.count({ where: { versionId: In(otherVersionIds) } })).toBe(0);
+	});
+
+	test('should not prune published versions', async () => {
+		globalConfig.workflowHistory.pruneTime = 24;
+
+		const workflow = await createActiveWorkflow();
+		const workflowVersions = await createManyWorkflowHistoryItems(
+			workflow.id,
+			5,
+			DateTime.now().minus({ days: 2 }).toJSDate(),
+		);
+
+		workflow.versionId = workflowVersions[0].versionId;
+		workflow.activeVersionId = workflowVersions[1].versionId;
+
+		await Container.get(WorkflowRepository).save(workflow);
+		await workflowPublishedVersionRepo.setPublishedVersion(
+			workflow.id,
+			workflowVersions[2].versionId,
+		);
+
+		await expect(manager.prune()).resolves.toBeUndefined();
+
+		expect(await repo.count({ where: { versionId: workflow.versionId } })).toBe(1);
+		expect(await repo.count({ where: { versionId: workflow.activeVersionId } })).toBe(1);
+		expect(await repo.count({ where: { versionId: workflowVersions[2].versionId } })).toBe(1);
+
+		const otherVersionIds = workflowVersions.slice(3).map((i) => i.versionId);
 		expect(await repo.count({ where: { versionId: In(otherVersionIds) } })).toBe(0);
 	});
 


### PR DESCRIPTION
## Summary

Preserves workflow history rows that are still referenced by `workflow_published_version` during workflow-history pruning.

This fixes a SQLite foreign key constraint failure when pruning old workflow history versions that are no longer current or active, but are still published.

### Root Cause

WorkflowHistoryManager.prune() deletes old workflow_history rows while preserving current and active versions, but it did not preserve rows referenced by workflow_published_version.publishedVersionId. SQLite enforces that FK strictly, so pruning a published historical version failed with SQLITE_CONSTRAINT: FOREIGN KEY constraint failed.

### Implementation Summary

Added a WorkflowPublishedVersion subquery to WorkflowHistoryRepository.deleteEarlierThanExceptCurrentAndActive() and excluded those publishedVersionIds from deletion. This matches the existing pattern already used for current and active workflow versions.

### Test Coverage Added

Added an integration test that:

* creates old workflow history versions,
* marks one version as current,
* marks one as active,
* marks one as published,
* runs pruning,
* verifies current, active, and published versions remain,
* verifies other old versions are pruned.

Tested with:

* `pnpm test:sqlite workflow-history-manager.test.ts`
* `pnpm build` in `packages/workflow`
* `pnpm build` in `packages/@n8n/db`
* targeted ESLint checks for changed files
* targeted Biome checks for changed files
* `git diff --check`

## Related Linear tickets, Github issues, and Community forum posts

Fixes #31334

## Review / Merge checklist

* [x] I have seen this code, I have run this code, and I take responsibility for this code.
* [x] PR title and summary are descriptive. ([[conventions](https://chatgpt.com/blob/master/.github/pull_request_title_conventions.md)](../blob/master/.github/pull_request_title_conventions.md))
* [ ] [[Docs updated](https://github.com/n8n-io/n8n-docs)](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
* [x] Tests included.
* [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

