### PR TITLE
fix(editor): Load all SSO role mapping rules instead of first page

### DIFF
--- a/packages/frontend/@n8n/rest-api-client/src/api/roleMappingRule.test.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/roleMappingRule.test.ts
@@ -1,0 +1,84 @@
+import type { RoleMappingRuleResponse } from './roleMappingRule';
+import { listRoleMappingRules } from './roleMappingRule';
+import type { IRestApiContext } from '../types';
+import * as utils from '../utils';
+
+vi.mock('../utils');
+
+const context = {} as IRestApiContext;
+
+const makeRule = (id: string): RoleMappingRuleResponse => ({
+	id,
+	expression: `expr-${id}`,
+	role: 'global:member',
+	type: 'project',
+	order: Number(id),
+	projectIds: [],
+	createdAt: '',
+	updatedAt: '',
+});
+
+describe('listRoleMappingRules', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('returns every rule when they all fit in a single page', async () => {
+		const items = [makeRule('0'), makeRule('1')];
+		vi.mocked(utils.makeRestApiRequest).mockResolvedValueOnce({ count: 2, items });
+
+		const result = await listRoleMappingRules(context);
+
+		expect(result).toEqual(items);
+		expect(utils.makeRestApiRequest).toHaveBeenCalledTimes(1);
+		expect(utils.makeRestApiRequest).toHaveBeenCalledWith(context, 'GET', '/role-mapping-rule', {
+			skip: 0,
+			take: 250,
+		});
+	});
+
+	it('walks every page until the full count is collected', async () => {
+		const firstPage = Array.from({ length: 250 }, (_, i) => makeRule(String(i)));
+		const secondPage = Array.from({ length: 10 }, (_, i) => makeRule(String(250 + i)));
+
+		vi.mocked(utils.makeRestApiRequest)
+			.mockResolvedValueOnce({ count: 260, items: firstPage })
+			.mockResolvedValueOnce({ count: 260, items: secondPage });
+
+		const result = await listRoleMappingRules(context);
+
+		expect(result).toHaveLength(260);
+		expect(utils.makeRestApiRequest).toHaveBeenCalledTimes(2);
+		expect(utils.makeRestApiRequest).toHaveBeenNthCalledWith(
+			2,
+			context,
+			'GET',
+			'/role-mapping-rule',
+			{
+				skip: 250,
+				take: 250,
+			},
+		);
+	});
+
+	it('stops when a page comes back empty even if the count disagrees', async () => {
+		vi.mocked(utils.makeRestApiRequest)
+			.mockResolvedValueOnce({ count: 999, items: [makeRule('0')] })
+			.mockResolvedValueOnce({ count: 999, items: [] });
+
+		const result = await listRoleMappingRules(context);
+
+		expect(result).toHaveLength(1);
+		expect(utils.makeRestApiRequest).toHaveBeenCalledTimes(2);
+	});
+
+	it('passes through a bare array response', async () => {
+		const items = [makeRule('0')];
+		vi.mocked(utils.makeRestApiRequest).mockResolvedValueOnce(items);
+
+		const result = await listRoleMappingRules(context);
+
+		expect(result).toEqual(items);
+		expect(utils.makeRestApiRequest).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/frontend/@n8n/rest-api-client/src/api/roleMappingRule.ts
+++ b/packages/frontend/@n8n/rest-api-client/src/api/roleMappingRule.ts
@@ -31,11 +31,35 @@ export type PatchRoleMappingRuleInput = {
 	projectIds?: string[];
 };
 
+type RoleMappingRuleListResponse =
+	| { count: number; items: RoleMappingRuleResponse[] }
+	| RoleMappingRuleResponse[];
+
+// The list endpoint paginates with a small default page size, so a single
+// request silently drops every rule past the first page. The settings UI needs
+// the complete set to render and save correctly, so walk every page here.
 export const listRoleMappingRules = async (
 	context: IRestApiContext,
 ): Promise<RoleMappingRuleResponse[]> => {
-	const response = await makeRestApiRequest(context, 'GET', '/role-mapping-rule');
-	return (response as { items: RoleMappingRuleResponse[] }).items ?? response;
+	const pageSize = 250;
+	const rules: RoleMappingRuleResponse[] = [];
+
+	for (let skip = 0; ; skip += pageSize) {
+		const response = await makeRestApiRequest<RoleMappingRuleListResponse>(
+			context,
+			'GET',
+			'/role-mapping-rule',
+			{ skip, take: pageSize },
+		);
+
+		if (Array.isArray(response)) return response;
+
+		rules.push(...response.items);
+
+		if (rules.length >= response.count || response.items.length === 0) break;
+	}
+
+	return rules;
 };
 
 export const createRoleMappingRule = async (


### PR DESCRIPTION
## Summary

SSO role mapping rules (Settings → SSO → per-project Admin/Editor/Viewer rules)
silently disappeared from the UI once there were more than ~9 of them. The rules
kept working on the backend — they were just no longer visible or editable.

### Root cause

The `/role-mapping-rule` list endpoint is paginated with a backend default of
`take=10`. The frontend's `listRoleMappingRules` sent no pagination params, so it
only ever received the first 10 rules (instance + project combined). With a single
instance rule occupying one of those slots, exactly 9 project rules rendered —
matching the report. Every rule past the first page stayed in the database and
continued to apply, but was invisible and uneditable in the settings UI.

### Fix

`listRoleMappingRules` now walks every page (250 per request — the server's max
page size) using `skip`/`take` and the `count` returned by the API, assembling the
complete set before returning. The existing defensive handling for a bare-array
response is preserved.

This is a frontend-only change in `@n8n/rest-api-client`; no backend or API
contract changes.

## How to test

1. On an instance with the provisioning/SSO feature licensed, create more than 10
   project role mapping rules and save.
2. Reload Settings → SSO.
3. **Before:** the list collapses to 9 visible rules.
   **After:** all rules are listed and editable.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #30734

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

## Note for reviewers

This fix resolves the symptom on the frontend. The deeper oddity is that this
admin config endpoint defaults to `take=10` — a page size meant for large
browsable lists, not a settings screen that always needs the full set. I kept
the change minimal and frontend-only to avoid touching the API contract, but
flagging in case the Identity & Access team prefers a server-side fix too.