### PR TITLE
test: Page-scope Instance AI preview NDV output panel locator

### DIFF
--- a/packages/testing/playwright/pages/InstanceAiPage.ts
+++ b/packages/testing/playwright/pages/InstanceAiPage.ts
@@ -231,8 +231,16 @@ export class InstanceAiPage extends BasePage {
 		);
 	}
 
+	/**
+	 * NDV is rendered through a `<Teleport :to="#app-modals">`, and `#app-modals`
+	 * is mounted in `App.vue` as a sibling of the router view — i.e. OUTSIDE both
+	 * `workflow-canvas-host` and `instance-ai-container`. So unlike the canvas
+	 * content above, this must be page-scoped, not scoped to the preview canvas.
+	 * On the `/instance-ai` route the main editor isn't mounted, so the preview's
+	 * NDV is the only `output-panel` on the page.
+	 */
 	getPreviewNdvOutputPanel(): Locator {
-		return this.getPreviewCanvas().getByTestId('output-panel');
+		return this.page.getByTestId('output-panel');
 	}
 
 	// ── Artifacts ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

`E2E / Shard 4` (multi-main e2e) is deterministically red on master for the test
`instance-ai-workflow-execution.spec.ts` → *"should show execution results in NDV output panel when opening node after execution"*. It fails 3/3 retries while the 30 sibling tests pass.

**Root cause:** PR #31126 ("Direct-mount editor in AI artifact preview") scoped every preview locator in `InstanceAiPage.ts` to `[data-test-id="workflow-canvas-host"]`. That's correct for canvas content (nodes, run button, success indicators), but the NDV renders through `<Teleport :to="#app-modals">`, and `#app-modals` is mounted in `App.vue` as a sibling of the router view — **outside both `workflow-canvas-host` and `instance-ai-container`**. So `getPreviewNdvOutputPanel()` could never reach the teleported panel and timed out.

Product behaviour is correct (the failure's accessibility snapshot shows the output panel rendering with data) — this is a test-side locator regression.

**Fix:** page-scope the NDV output panel locator, matching how the already-teleported credential modal is located. On the `/instance-ai` route the main editor isn't mounted, so the preview's NDV is the only `output-panel` on the page.

Audited the rest of `InstanceAiPage.ts` — every other locator targets genuine canvas-host content and is correctly scoped. This is the only teleport casualty.

### How to test

```bash
pnpm build:docker
pnpm --filter=n8n-playwright test:container:multi-main:e2e tests/e2e/instance-ai/instance-ai-workflow-execution.spec.ts
```

The previously-failing NDV-output test should now pass.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-406

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI