### PR TITLE
fix: correct 'succesfully' typo in Stripe trigger event description

### DIFF
--- a/packages/nodes-base/nodes/Stripe/StripeTrigger.node.ts
+++ b/packages/nodes-base/nodes/Stripe/StripeTrigger.node.ts
@@ -645,7 +645,7 @@ export class StripeTrigger implements INodeType {
 					{
 						name: 'Reporting Report_run.succeeded',
 						value: 'reporting.report_run.succeeded',
-						description: 'Occurs whenever a requested **ReportRun** completed succesfully.',
+						description: 'Occurs whenever a requested **ReportRun** completed successfully.',
 					},
 					{
 						name: 'Reporting Report_type.updated',


### PR DESCRIPTION
## Summary

Fixes a typo in a user-facing event description in the Stripe Trigger node: `succesfully` → `successfully`.

The string appears in the event-list dropdown for the `reporting.report_run.succeeded` event, shown to users in the node editor:

> Occurs whenever a requested **ReportRun** completed ~~succesfully~~ **successfully**.

## Details

- File: `packages/nodes-base/nodes/Stripe/StripeTrigger.node.ts`
- Single-character spelling fix in a description field; no behavior change.
