### PR TITLE
fix(core): Lock execution row during data-only condition re-check

### DIFF
--- a/packages/cli/src/executions/__tests__/execution-persistence.test.ts
+++ b/packages/cli/src/executions/__tests__/execution-persistence.test.ts
@@ -643,7 +643,7 @@ describe('ExecutionPersistence', () => {
 				mockEntity('fs');
 
 				const mockTx = createMockTransaction();
-				mockTx.count.mockResolvedValue(0);
+				mockTx.findOne.mockResolvedValue(null);
 				executionRepository.manager.transaction = createMockTx(mockTx);
 
 				const result = await executionPersistence.updateExistingExecution(
@@ -653,12 +653,52 @@ describe('ExecutionPersistence', () => {
 				);
 
 				expect(result).toBe(false);
-				expect(mockTx.count).toHaveBeenCalledWith(ExecutionEntity, {
-					where: { id: executionId, finished: false },
-				});
 				expect(mockTx.update).not.toHaveBeenCalled();
 				expect(fsStore.read).not.toHaveBeenCalled();
 				expect(fsStore.write).not.toHaveBeenCalled();
+			});
+
+			it('should take a pessimistic row lock to re-verify conditions on the data-only path (postgres)', async () => {
+				const executionPersistence = createPersistenceService('fs', 'postgresdb');
+				mockEntity('fs');
+				fsStore.read.mockResolvedValue(existingBundle);
+
+				const mockTx = createMockTransaction();
+				mockTx.findOne.mockResolvedValue({ id: executionId });
+				executionRepository.manager.transaction = createMockTx(mockTx);
+
+				await executionPersistence.updateExistingExecution(
+					executionId,
+					{ data: runData },
+					{ requireNotFinished: true },
+				);
+
+				expect(mockTx.findOne).toHaveBeenCalledWith(ExecutionEntity, {
+					where: { id: executionId, finished: false },
+					select: ['id'],
+					lock: { mode: 'pessimistic_write' },
+				});
+			});
+
+			it('should not take a lock on the data-only path under sqlite', async () => {
+				const executionPersistence = createPersistenceService('fs', 'sqlite');
+				mockEntity('fs');
+				fsStore.read.mockResolvedValue(existingBundle);
+
+				const mockTx = createMockTransaction();
+				mockTx.findOne.mockResolvedValue({ id: executionId });
+				executionRepository.manager.transaction = createMockTx(mockTx);
+
+				await executionPersistence.updateExistingExecution(
+					executionId,
+					{ data: runData },
+					{ requireNotFinished: true },
+				);
+
+				expect(mockTx.findOne).toHaveBeenCalledWith(ExecutionEntity, {
+					where: { id: executionId, finished: false },
+					select: ['id'],
+				});
 			});
 
 			it('should perform the fs write on a data-only update when conditions match', async () => {
@@ -667,7 +707,7 @@ describe('ExecutionPersistence', () => {
 				fsStore.read.mockResolvedValue(existingBundle);
 
 				const mockTx = createMockTransaction();
-				mockTx.count.mockResolvedValue(1);
+				mockTx.findOne.mockResolvedValue({ id: executionId });
 				executionRepository.manager.transaction = createMockTx(mockTx);
 
 				const result = await executionPersistence.updateExistingExecution(
@@ -677,7 +717,7 @@ describe('ExecutionPersistence', () => {
 				);
 
 				expect(result).toBe(true);
-				expect(mockTx.count).toHaveBeenCalled();
+				expect(mockTx.findOne).toHaveBeenCalled();
 				expect(fsStore.write).toHaveBeenCalled();
 			});
 

--- a/packages/cli/src/executions/execution-persistence.ts
+++ b/packages/cli/src/executions/execution-persistence.ts
@@ -180,14 +180,16 @@ export class ExecutionPersistence {
 				if ((result.affected ?? 0) === 0) return false;
 			} else if (conditions) {
 				// No entity columns to update, but the caller still requested a guarded write.
-				// Re-verify the conditions inside the transaction so a data-only update can't slip
-				// past a `requireStatus` / `requireNotFinished` / `requireNotCanceled` check.
-				// TODO(CAT-3212): In Postgres this COUNT alone does not prevent a concurrent
-				// transaction from changing the row's status between the check and the data write —
-				// a row-level lock (e.g. `SELECT ... FOR UPDATE`) is required for true race-safety.
-				// SQLite is unaffected because `BEGIN` already takes an exclusive write lock.
-				const matchingRows = await tx.count(ExecutionEntity, { where: whereCondition });
-				if (matchingRows === 0) return false;
+				const lock =
+					this.databaseConfig.type === 'postgresdb'
+						? { mode: 'pessimistic_write' as const }
+						: undefined;
+				const matchingRow = await tx.findOne(ExecutionEntity, {
+					where: whereCondition,
+					select: ['id'],
+					lock,
+				});
+				if (!matchingRow) return false;
 			}
 
 			// TODO(CAT-3213): callers may supply only `data` or only `workflowData`, so we read


### PR DESCRIPTION
https://linear.app/n8n/issue/CAT-3212

- [x] I have seen this code, I have run this code, and I take responsibility for this code.