### PR TITLE
feat(core): Add workflowConflictPolicy to package import

### DIFF
--- a/packages/@n8n/api-types/src/dto/packages/__tests__/import-package-request.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/packages/__tests__/import-package-request.dto.test.ts
@@ -2,14 +2,20 @@ import { ImportPackageRequestDto } from '../import-package-request.dto';
 
 describe('ImportPackageRequestDto', () => {
 	it('accepts omitted routing fields', () => {
-		expect(ImportPackageRequestDto.safeParse({}).success).toBe(true);
+		expect(ImportPackageRequestDto.safeParse({ workflowConflictPolicy: 'fail' }).success).toBe(
+			true,
+		);
 	});
 
 	it('treats empty projectId and folderId as omitted', () => {
-		const result = ImportPackageRequestDto.safeParse({ projectId: '', folderId: '   ' });
+		const result = ImportPackageRequestDto.safeParse({
+			projectId: '',
+			folderId: '   ',
+			workflowConflictPolicy: 'fail',
+		});
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect(result.data).toEqual({});
+			expect(result.data).toEqual({ workflowConflictPolicy: 'fail' });
 		}
 	});
 
@@ -17,12 +23,14 @@ describe('ImportPackageRequestDto', () => {
 		const result = ImportPackageRequestDto.safeParse({
 			projectId: '  proj-1  ',
 			folderId: 'fld-1',
+			workflowConflictPolicy: 'new-version',
 		});
 		expect(result.success).toBe(true);
 		if (result.success) {
 			expect(result.data).toEqual({
 				projectId: 'proj-1',
 				folderId: 'fld-1',
+				workflowConflictPolicy: 'new-version',
 			});
 		}
 	});
@@ -30,17 +38,23 @@ describe('ImportPackageRequestDto', () => {
 	it('strips unknown keys such as the package placeholder', () => {
 		const result = ImportPackageRequestDto.safeParse({
 			projectId: 'proj-1',
+			workflowConflictPolicy: 'skip',
 			package: '',
 		});
 		expect(result.success).toBe(true);
 		if (result.success) {
-			expect(result.data).toEqual({ projectId: 'proj-1' });
+			expect(result.data).toEqual({ projectId: 'proj-1', workflowConflictPolicy: 'skip' });
 		}
 	});
 
+	it('rejects omitted workflowConflictPolicy', () => {
+		expect(ImportPackageRequestDto.safeParse({}).success).toBe(false);
+	});
+
 	it.each([
-		{ name: 'non-string projectId', request: { projectId: 1 } },
-		{ name: 'non-string folderId', request: { folderId: false } },
+		{ name: 'non-string projectId', request: { projectId: 1, workflowConflictPolicy: 'fail' } },
+		{ name: 'non-string folderId', request: { folderId: false, workflowConflictPolicy: 'fail' } },
+		{ name: 'unknown workflowConflictPolicy', request: { workflowConflictPolicy: 'overwrite' } },
 	])('rejects $name', ({ request }) => {
 		expect(ImportPackageRequestDto.safeParse(request).success).toBe(false);
 	});

--- a/packages/@n8n/api-types/src/dto/packages/import-package-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/packages/import-package-request.dto.ts
@@ -3,7 +3,11 @@ import { z } from 'zod';
 import { Z } from '../../zod-class';
 
 /** Multipart text field names validated by {@link ImportPackageRequestDto}. */
-export const IMPORT_PACKAGE_REQUEST_FORM_FIELDS = ['projectId', 'folderId'] as const;
+export const IMPORT_PACKAGE_REQUEST_FORM_FIELDS = [
+	'projectId',
+	'folderId',
+	'workflowConflictPolicy',
+] as const;
 
 /** Multipart text fields: empty / whitespace-only values become `undefined`. */
 const optionalFormId = z
@@ -18,4 +22,5 @@ const optionalFormId = z
 export class ImportPackageRequestDto extends Z.class({
 	projectId: optionalFormId,
 	folderId: optionalFormId,
+	workflowConflictPolicy: z.enum(['new-version', 'fail', 'skip']),
 }) {}

--- a/packages/cli/src/errors/response-errors/conflict.error.ts
+++ b/packages/cli/src/errors/response-errors/conflict.error.ts
@@ -1,7 +1,11 @@
 import { ResponseError } from './abstract/response.error';
 
 export class ConflictError extends ResponseError {
-	constructor(message: string, hint: string | undefined = undefined) {
+	constructor(
+		message: string,
+		hint: string | undefined = undefined,
+		readonly meta?: Record<string, unknown>,
+	) {
 		super(message, 409, 409, hint);
 	}
 }

--- a/packages/cli/src/modules/n8n-packages/__tests__/import-pipeline.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/import-pipeline.integration.test.ts
@@ -1,21 +1,37 @@
 import { LicenseState } from '@n8n/backend-common';
-import { createTeamProject, testDb, testModules } from '@n8n/backend-test-utils';
-import { ProjectRepository, SharedWorkflowRepository, WorkflowRepository } from '@n8n/db';
+import {
+	createActiveWorkflow,
+	createTeamProject,
+	createWorkflow,
+	mockInstance,
+	testDb,
+	testModules,
+} from '@n8n/backend-test-utils';
+import type { Project } from '@n8n/db';
+import {
+	ProjectRepository,
+	SharedWorkflowRepository,
+	WorkflowHistoryRepository,
+	WorkflowRepository,
+} from '@n8n/db';
 import { Container } from '@n8n/di';
 import type { Readable } from 'node:stream';
 
+import { ActiveWorkflowManager } from '@/active-workflow-manager';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { EventService } from '@/events/event.service';
 
 import { createFolder } from '@test-integration/db/folders';
 import { createMember, createOwner } from '@test-integration/db/users';
 import { LicenseMocker } from '@test-integration/license';
+import { initNodeTypes } from '@test-integration/utils';
 
 import { N8nPackagesService } from '../n8n-packages.service';
 import { TarPackageWriter } from '../io/tar/tar-package-writer';
 import { FORMAT_VERSION } from '../spec/constants';
 import type { PackageManifest } from '../spec/manifest.schema';
 import type { SerializedWorkflow } from '../spec/serialized/workflow.schema';
+import type { WorkflowConflictPolicy } from '../n8n-packages.types';
 
 async function streamToBuffer(stream: Readable): Promise<Buffer> {
 	const chunks: Buffer[] = [];
@@ -25,7 +41,11 @@ async function streamToBuffer(stream: Readable): Promise<Buffer> {
 	return Buffer.concat(chunks);
 }
 
-const validWorkflow = (id: string, name: string): SerializedWorkflow => ({
+const validWorkflow = (
+	id: string,
+	name: string,
+	overrides: Partial<SerializedWorkflow> = {},
+): SerializedWorkflow => ({
 	id,
 	name,
 	nodes: [
@@ -43,6 +63,7 @@ const validWorkflow = (id: string, name: string): SerializedWorkflow => ({
 	parentFolderId: null,
 	active: false,
 	isArchived: false,
+	...overrides,
 });
 
 /**
@@ -74,6 +95,18 @@ const brokenWorkflow = (id: string, name: string): SerializedWorkflow => ({
 	isArchived: false,
 });
 
+/**
+ * Seeds an owned workflow in a project with a given `sourceWorkflowId` (the
+ * `createWorkflow` helper's `Partial<IWorkflowDb>` param doesn't expose that
+ * column, so it's set directly after creation).
+ */
+async function seedExistingWorkflow(project: Project, name: string, sourceWorkflowId: string) {
+	const workflow = await createWorkflow({ name }, project);
+	await Container.get(WorkflowRepository).update(workflow.id, { sourceWorkflowId });
+	workflow.sourceWorkflowId = sourceWorkflowId;
+	return workflow;
+}
+
 async function buildPackage(workflows: SerializedWorkflow[]): Promise<Buffer> {
 	const writer = new TarPackageWriter();
 
@@ -100,9 +133,16 @@ async function buildPackage(workflows: SerializedWorkflow[]): Promise<Buffer> {
 
 const licenseMocker = new LicenseMocker();
 
+// Reactivating an active workflow on new-version import calls into the active
+// workflow manager; mock it so trigger registration succeeds without real infra.
+const activeWorkflowManager = mockInstance(ActiveWorkflowManager);
+
 beforeAll(async () => {
 	await testModules.loadModules(['n8n-packages']);
 	await testDb.init();
+	// Register node types so the reactivation path's webhook-conflict check can
+	// resolve the trigger nodes used by the seeded/imported workflows.
+	await initNodeTypes();
 	licenseMocker.mockLicenseState(Container.get(LicenseState));
 });
 
@@ -111,7 +151,13 @@ afterAll(async () => {
 });
 
 beforeEach(async () => {
-	await testDb.truncate(['WorkflowEntity', 'SharedWorkflow', 'Folder', 'Project']);
+	await testDb.truncate([
+		'WorkflowEntity',
+		'WorkflowHistory',
+		'SharedWorkflow',
+		'Folder',
+		'Project',
+	]);
 });
 
 describe('ImportPipeline batch validation', () => {
@@ -137,6 +183,7 @@ describe('ImportPipeline batch validation', () => {
 			Container.get(N8nPackagesService).importPackage({
 				user: owner,
 				packageBuffer: tarBuffer,
+				workflowConflictPolicy: 'fail',
 			}),
 		).rejects.toThrow();
 
@@ -161,6 +208,7 @@ describe('ImportPipeline batch validation', () => {
 		const result = await Container.get(N8nPackagesService).importPackage({
 			user: owner,
 			packageBuffer: tarBuffer,
+			workflowConflictPolicy: 'fail',
 		});
 
 		expect(result.workflows).toHaveLength(2);
@@ -190,9 +238,10 @@ describe('ImportPipeline routing matrix', () => {
 			owner.id,
 		);
 
-		await Container.get(N8nPackagesService).importPackage({
+		const result = await Container.get(N8nPackagesService).importPackage({
 			user: owner,
 			packageBuffer: await singleWorkflowPackage(),
+			workflowConflictPolicy: 'fail',
 		});
 
 		const shared = await Container.get(SharedWorkflowRepository).findOneOrFail({
@@ -205,6 +254,9 @@ describe('ImportPipeline routing matrix', () => {
 			relations: ['parentFolder'],
 		});
 		expect(workflow.parentFolder).toBeNull();
+
+		// The response carries the source→target workflow id binding.
+		expect(result.bindings.workflows).toEqual({ 'wf-routed': workflow.id });
 	});
 
 	it('lands in the requested folder of the personal project when only folderId is given', async () => {
@@ -218,6 +270,7 @@ describe('ImportPipeline routing matrix', () => {
 			user: owner,
 			folderId: folder.id,
 			packageBuffer: await singleWorkflowPackage(),
+			workflowConflictPolicy: 'fail',
 		});
 
 		const workflow = await Container.get(WorkflowRepository).findOneOrFail({
@@ -235,6 +288,7 @@ describe('ImportPipeline routing matrix', () => {
 			user: owner,
 			projectId: teamProject.id,
 			packageBuffer: await singleWorkflowPackage(),
+			workflowConflictPolicy: 'fail',
 		});
 
 		const shared = await Container.get(SharedWorkflowRepository).findOneOrFail({
@@ -259,6 +313,7 @@ describe('ImportPipeline routing matrix', () => {
 			projectId: teamProject.id,
 			folderId: folder.id,
 			packageBuffer: await singleWorkflowPackage(),
+			workflowConflictPolicy: 'fail',
 		});
 
 		const workflow = await Container.get(WorkflowRepository).findOneOrFail({
@@ -266,6 +321,223 @@ describe('ImportPipeline routing matrix', () => {
 			relations: ['parentFolder'],
 		});
 		expect(workflow.parentFolder?.id).toBe(folder.id);
+	});
+});
+
+describe('ImportPipeline workflow conflict policy', () => {
+	it.each<WorkflowConflictPolicy>(['new-version', 'skip'])(
+		'%s handles matched and fresh workflows in one package',
+		async (workflowConflictPolicy) => {
+			const owner = await createOwner();
+			const personalProject = await Container.get(
+				ProjectRepository,
+			).getPersonalProjectForUserOrFail(owner.id);
+			const existing = await seedExistingWorkflow(
+				personalProject,
+				'Existing workflow',
+				'wf-existing',
+			);
+
+			const result = await Container.get(N8nPackagesService).importPackage({
+				user: owner,
+				packageBuffer: await buildPackage([
+					validWorkflow('wf-existing', 'Imported replacement', {
+						nodes: [
+							...validWorkflow('wf-existing', 'Imported replacement').nodes,
+							{
+								id: 'set-node',
+								name: 'Set Data',
+								type: 'n8n-nodes-base.set',
+								typeVersion: 3,
+								position: [200, 0],
+								parameters: {},
+							},
+						],
+					}),
+					validWorkflow('wf-fresh', 'Fresh workflow'),
+				]),
+				workflowConflictPolicy,
+			});
+
+			const matchedSummary = result.workflows.find(
+				({ sourceWorkflowId }) => sourceWorkflowId === 'wf-existing',
+			);
+			const freshSummary = result.workflows.find(
+				({ sourceWorkflowId }) => sourceWorkflowId === 'wf-fresh',
+			);
+
+			expect(matchedSummary).toMatchObject({
+				localId: existing.id,
+				status: workflowConflictPolicy === 'new-version' ? 'updated' : 'skipped',
+			});
+			expect(freshSummary).toMatchObject({ status: 'created', name: 'Fresh workflow' });
+
+			const workflows = await Container.get(WorkflowRepository).find();
+			expect(workflows).toHaveLength(2);
+
+			const storedExisting = await Container.get(WorkflowRepository).findOneByOrFail({
+				id: existing.id,
+			});
+			expect(storedExisting.name).toBe(
+				workflowConflictPolicy === 'new-version' ? 'Imported replacement' : 'Existing workflow',
+			);
+		},
+	);
+
+	it('new-version reactivates an active workflow and advances its active version', async () => {
+		const owner = await createOwner();
+		const personalProject = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(
+			owner.id,
+		);
+
+		const active = await createActiveWorkflow({ name: 'Active workflow' }, personalProject);
+		await Container.get(WorkflowRepository).update(active.id, { sourceWorkflowId: 'wf-active' });
+		const originalActiveVersionId = active.activeVersionId;
+		expect(originalActiveVersionId).not.toBeNull();
+
+		const historyRepo = Container.get(WorkflowHistoryRepository);
+		const historyBefore = await historyRepo.count({ where: { workflowId: active.id } });
+
+		const result = await Container.get(N8nPackagesService).importPackage({
+			user: owner,
+			// Different nodes than the seeded workflow → saves a new version → republishes.
+			// Uses a real trigger node so the reactivation validation passes.
+			packageBuffer: await buildPackage([
+				validWorkflow('wf-active', 'Active updated', {
+					nodes: [
+						{
+							id: 'schedule-trigger',
+							name: 'Schedule Trigger',
+							type: 'n8n-nodes-base.scheduleTrigger',
+							typeVersion: 1,
+							position: [0, 0],
+							parameters: {},
+						},
+					],
+				}),
+			]),
+			workflowConflictPolicy: 'new-version',
+		});
+
+		const summary = result.workflows.find(
+			({ sourceWorkflowId }) => sourceWorkflowId === 'wf-active',
+		);
+		expect(summary).toMatchObject({ localId: active.id, status: 'updated' });
+		expect(summary?.activeVersionId).toEqual(expect.any(String));
+		expect(summary?.activeVersionId).not.toBe(originalActiveVersionId);
+
+		const stored = await Container.get(WorkflowRepository).findOneByOrFail({ id: active.id });
+		expect(stored.active).toBe(true);
+		expect(stored.activeVersionId).toBe(summary?.activeVersionId);
+		expect(stored.activeVersionId).not.toBe(originalActiveVersionId);
+
+		// A new history version was written for the imported content.
+		const historyAfter = await historyRepo.count({ where: { workflowId: active.id } });
+		expect(historyAfter).toBe(historyBefore + 1);
+
+		// Reactivation went through the active workflow manager.
+		expect(activeWorkflowManager.add).toHaveBeenCalled();
+	});
+
+	it('fails before writing any workflows when conflicts exist under fail policy', async () => {
+		const owner = await createOwner();
+		const personalProject = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(
+			owner.id,
+		);
+		const existing = await seedExistingWorkflow(
+			personalProject,
+			'Existing workflow',
+			'wf-existing',
+		);
+		const workflowRepo = Container.get(WorkflowRepository);
+		const workflowsBefore = await workflowRepo.count();
+
+		await expect(
+			Container.get(N8nPackagesService).importPackage({
+				user: owner,
+				packageBuffer: await buildPackage([
+					validWorkflow('wf-existing', 'Conflicting workflow'),
+					validWorkflow('wf-fresh', 'Fresh workflow'),
+				]),
+				workflowConflictPolicy: 'fail',
+			}),
+		).rejects.toMatchObject({
+			message: 'WORKFLOW_CONFLICT',
+			meta: {
+				conflicts: [
+					{
+						sourceWorkflowId: 'wf-existing',
+						existingWorkflowId: existing.id,
+						name: 'Existing workflow',
+					},
+				],
+			},
+		});
+
+		expect(await workflowRepo.count()).toBe(workflowsBefore);
+	});
+
+	it('rejects ambiguous source workflow matches before applying the policy', async () => {
+		const owner = await createOwner();
+		const personalProject = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(
+			owner.id,
+		);
+		await seedExistingWorkflow(personalProject, 'First match', 'wf-ambiguous');
+		await seedExistingWorkflow(personalProject, 'Second match', 'wf-ambiguous');
+
+		await expect(
+			Container.get(N8nPackagesService).importPackage({
+				user: owner,
+				packageBuffer: await buildPackage([validWorkflow('wf-ambiguous', 'Incoming')]),
+				workflowConflictPolicy: 'skip',
+			}),
+		).rejects.toMatchObject({
+			message: 'AMBIGUOUS_SOURCE_WORKFLOW_ID',
+			meta: {
+				ambiguous: [
+					{
+						sourceWorkflowId: 'wf-ambiguous',
+						matches: expect.arrayContaining([
+							expect.objectContaining({ name: 'First match' }),
+							expect.objectContaining({ name: 'Second match' }),
+						]),
+					},
+				],
+			},
+		});
+	});
+
+	it('matches a never-imported workflow by its own id when re-importing into the origin instance', async () => {
+		const owner = await createOwner();
+		const personalProject = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(
+			owner.id,
+		);
+
+		// Authored here, so `sourceWorkflowId` is null. A package exported from this
+		// instance carries this workflow's own id as its package source id, so the
+		// match must fall back to the id (decision #12) instead of creating a duplicate.
+		const original = await createWorkflow({ name: 'Authored here' }, personalProject);
+		expect(original.sourceWorkflowId ?? null).toBeNull();
+
+		const result = await Container.get(N8nPackagesService).importPackage({
+			user: owner,
+			packageBuffer: await buildPackage([validWorkflow(original.id, 'Updated via re-import')]),
+			workflowConflictPolicy: 'new-version',
+		});
+
+		expect(result.workflows).toEqual([
+			expect.objectContaining({
+				sourceWorkflowId: original.id,
+				localId: original.id,
+				status: 'updated',
+			}),
+		]);
+		expect(result.bindings.workflows).toEqual({ [original.id]: original.id });
+
+		// Updated in place — no duplicate created.
+		const workflows = await Container.get(WorkflowRepository).find();
+		expect(workflows).toHaveLength(1);
+		expect(workflows[0].name).toBe('Updated via re-import');
 	});
 });
 
@@ -292,6 +564,7 @@ describe('ImportPipeline rejection cases', () => {
 			Container.get(N8nPackagesService).importPackage({
 				user: owner,
 				packageBuffer: tarBuffer,
+				workflowConflictPolicy: 'fail',
 			}),
 		).rejects.toThrow(BadRequestError);
 	});
@@ -304,6 +577,7 @@ describe('ImportPipeline rejection cases', () => {
 				user: owner,
 				projectId: 'does-not-exist',
 				packageBuffer: await singleWorkflowPackage(),
+				workflowConflictPolicy: 'fail',
 			}),
 		).rejects.toThrow(/Project not found/i);
 	});
@@ -318,6 +592,7 @@ describe('ImportPipeline rejection cases', () => {
 				user: outsider,
 				projectId: teamProject.id,
 				packageBuffer: await singleWorkflowPackage(),
+				workflowConflictPolicy: 'fail',
 			}),
 		).rejects.toThrow();
 	});
@@ -335,6 +610,7 @@ describe('ImportPipeline rejection cases', () => {
 				projectId: teamProject.id,
 				folderId: strayFolder.id,
 				packageBuffer: await singleWorkflowPackage(),
+				workflowConflictPolicy: 'fail',
 			}),
 		).rejects.toThrow(/folder/i);
 	});
@@ -359,6 +635,7 @@ describe('ImportPipeline rejection cases', () => {
 			Container.get(N8nPackagesService).importPackage({
 				user: owner,
 				packageBuffer: await streamToBuffer(writer.finalize()),
+				workflowConflictPolicy: 'fail',
 			}),
 		).rejects.toThrow(BadRequestError);
 	});
@@ -382,6 +659,7 @@ describe('ImportPipeline rejection cases', () => {
 			Container.get(N8nPackagesService).importPackage({
 				user: owner,
 				packageBuffer: await streamToBuffer(writer.finalize()),
+				workflowConflictPolicy: 'fail',
 			}),
 		).rejects.toThrow(/missing/i);
 	});
@@ -400,6 +678,7 @@ describe('ImportPipeline event emission', () => {
 					validWorkflow('wf-event-1', 'Event One'),
 					validWorkflow('wf-event-2', 'Event Two'),
 				]),
+				workflowConflictPolicy: 'fail',
 			});
 
 			const createdEvents = emitSpy.mock.calls.filter(([name]) => name === 'workflow-created');
@@ -431,6 +710,7 @@ describe('ImportPipeline event emission', () => {
 						validWorkflow('wf-good', 'Good'),
 						brokenWorkflow('wf-broken', 'Broken'),
 					]),
+					workflowConflictPolicy: 'fail',
 				}),
 			).rejects.toThrow();
 

--- a/packages/cli/src/modules/n8n-packages/__tests__/utils/import-package-upload.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/utils/import-package-upload.test.ts
@@ -89,11 +89,11 @@ describe('resolveImportPackageUpload', () => {
 		expect(file.buffer).toBe(packageBuffer);
 	});
 
-	it('accepts only optional routing fields in the body', () => {
+	it('accepts routing and workflow update policy fields in the body', () => {
 		expect(() =>
 			resolveImportPackageUpload({
 				files: [makeFile('package', packageBuffer)],
-				body: { folderId: 'fld-1', package: '' },
+				body: { folderId: 'fld-1', workflowConflictPolicy: 'skip', package: '' },
 			}),
 		).not.toThrow();
 	});

--- a/packages/cli/src/modules/n8n-packages/engine/import-pipeline.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/import-pipeline.ts
@@ -12,10 +12,12 @@ import { EventService } from '@/events/event.service';
 import { FolderService } from '@/services/folder.service';
 import { ProjectService } from '@/services/project.service.ee';
 import * as WorkflowHelpers from '@/workflow-helpers';
-import { WorkflowCreationService } from '@/workflows/workflow-creation.service';
 
+import { WorkflowImporter } from '../entities/workflow/workflow-importer';
 import { WorkflowSerializer } from '../entities/workflow/workflow.serializer';
+import type { PreparedWorkflow } from '../entities/workflow/workflow-conflict-policy.types';
 import { TarPackageReader } from '../io/tar/tar-package-reader';
+import { createEmptyBindings } from '../n8n-packages.types';
 import type { ImportPackageRequest, ImportResult } from '../n8n-packages.types';
 import { packageManifestSchema } from '../spec/manifest.schema';
 import type { SerializedWorkflow } from '../spec/serialized/workflow.schema';
@@ -27,23 +29,18 @@ interface ImportTarget {
 	folderId: string | null;
 }
 
-interface PreparedWorkflow {
-	entity: WorkflowEntity;
-	sourceId: string;
-}
-
 @Service()
 export class ImportPipeline {
 	private readonly maxUncompressedPackageBytes: number;
 
 	constructor(
 		private readonly workflowSerializer: WorkflowSerializer,
-		private readonly workflowCreationService: WorkflowCreationService,
 		globalConfig: GlobalConfig,
 		private readonly projectRepository: ProjectRepository,
 		private readonly projectService: ProjectService,
 		private readonly folderService: FolderService,
 		private readonly eventService: EventService,
+		private readonly workflowImporter: WorkflowImporter,
 	) {
 		this.maxUncompressedPackageBytes = globalConfig.endpoints.payloadSizeMax * MEGABYTE_IN_BYTES;
 	}
@@ -58,22 +55,22 @@ export class ImportPipeline {
 		// Validates every workflow first so a malformed package aborts before the first DB write.
 		const prepared = await this.prepareWorkflows(manifest.workflows ?? [], reader);
 
-		const created: WorkflowEntity[] = [];
-		for (const { entity, sourceId } of prepared) {
-			const saved = await this.workflowCreationService.createWorkflow(request.user, entity, {
+		const { outcomes, bindings } = await this.workflowImporter.importWorkflows(
+			prepared,
+			request.workflowConflictPolicy,
+			{
+				user: request.user,
 				projectId: target.projectId,
-				parentFolderId: target.folderId ?? undefined,
-				publicApi: true,
-				source: 'import',
-				sourceWorkflowId: sourceId,
-			});
-			created.push(saved);
-		}
+				folderId: target.folderId,
+			},
+			createEmptyBindings(),
+		);
 
+		const imported = outcomes.filter(({ status }) => status !== 'skipped');
 		this.eventService.emit('workflows-imported', {
 			user: request.user,
 			projectId: target.projectId,
-			workflowIds: created.map((w) => w.id),
+			workflowIds: imported.map(({ workflow }) => workflow.id),
 			packageSourceId: manifest.sourceId,
 			packageVersion: manifest.packageFormatVersion,
 		});
@@ -84,14 +81,16 @@ export class ImportPipeline {
 				sourceId: manifest.sourceId,
 				exportedAt: manifest.exportedAt,
 			},
-			workflows: created.map((w) => ({
-				sourceId: w.sourceWorkflowId ?? '',
-				localId: w.id,
-				name: w.name,
+			workflows: outcomes.map(({ workflow, sourceWorkflowId, status }) => ({
+				sourceWorkflowId,
+				localId: workflow.id,
+				name: workflow.name,
 				projectId: target.projectId,
-				parentFolderId: w.parentFolder?.id ?? null,
-				activeVersionId: w.activeVersionId ?? null,
+				parentFolderId: workflow.parentFolder?.id ?? null,
+				activeVersionId: workflow.activeVersionId ?? null,
+				status,
 			})),
+			bindings,
 		};
 	}
 
@@ -145,7 +144,7 @@ export class ImportPipeline {
 
 			WorkflowHelpers.validateWorkflowStructure(entity);
 
-			prepared.push({ entity, sourceId: entry.id });
+			prepared.push({ entity, sourceWorkflowId: entry.id });
 		}
 
 		return prepared;

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/workflow-import-match.service.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/__tests__/workflow-import-match.service.test.ts
@@ -1,0 +1,127 @@
+import type { WorkflowEntity } from '@n8n/db';
+import { mock } from 'jest-mock-extended';
+
+import { ConflictError } from '@/errors/response-errors/conflict.error';
+import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+
+import { WorkflowImportMatchService } from '../workflow-import-match.service';
+
+function workflow(attrs: {
+	id: string;
+	sourceWorkflowId?: string | null;
+	name?: string;
+}): WorkflowEntity {
+	return {
+		id: attrs.id,
+		name: attrs.name ?? `Workflow ${attrs.id}`,
+		sourceWorkflowId: attrs.sourceWorkflowId ?? null,
+	} as unknown as WorkflowEntity;
+}
+
+function makeService(returned: WorkflowEntity[]) {
+	const finder = mock<WorkflowFinderService>();
+	finder.findOwnedWorkflowsBySourceWorkflowIds.mockResolvedValue(returned);
+	return { service: new WorkflowImportMatchService(finder), finder };
+}
+
+describe('WorkflowImportMatchService', () => {
+	it('returns an empty map without hitting the finder when no source ids are requested', async () => {
+		const { service, finder } = makeService([]);
+
+		const result = await service.findBySourceWorkflowIds('project-1', []);
+
+		expect(result.size).toBe(0);
+		expect(finder.findOwnedWorkflowsBySourceWorkflowIds).not.toHaveBeenCalled();
+	});
+
+	it('passes the project, source ids, and relation options through to the finder', async () => {
+		const { service, finder } = makeService([]);
+
+		await service.findBySourceWorkflowIds('project-1', ['wf-a', 'wf-b']);
+
+		expect(finder.findOwnedWorkflowsBySourceWorkflowIds).toHaveBeenCalledWith(
+			'project-1',
+			['wf-a', 'wf-b'],
+			{ includeActiveVersion: true, includeParentFolder: true },
+		);
+	});
+
+	it('keys an imported workflow by its sourceWorkflowId', async () => {
+		const imported = workflow({ id: 'local-1', sourceWorkflowId: 'wf-source' });
+		const { service } = makeService([imported]);
+
+		const result = await service.findBySourceWorkflowIds('project-1', ['wf-source']);
+
+		expect(result.get('wf-source')).toBe(imported);
+		expect(result.has('local-1')).toBe(false);
+	});
+
+	it('falls back to the workflow’s own id when sourceWorkflowId is null (decision #12)', async () => {
+		// A workflow authored on this instance (never imported) has no
+		// sourceWorkflowId, so it must match by its original id.
+		const original = workflow({ id: 'wf-source', sourceWorkflowId: null });
+		const { service } = makeService([original]);
+
+		const result = await service.findBySourceWorkflowIds('project-1', ['wf-source']);
+
+		expect(result.get('wf-source')).toBe(original);
+	});
+
+	it('prefers sourceWorkflowId over id so a foreign id collision is not a match', async () => {
+		// id 'wf-source' collides with the requested id, but this workflow's real
+		// identity is its sourceWorkflowId 'other-source', so it keys there only.
+		const imported = workflow({ id: 'wf-source', sourceWorkflowId: 'other-source' });
+		const { service } = makeService([imported]);
+
+		const result = await service.findBySourceWorkflowIds('project-1', ['wf-source']);
+
+		expect(result.has('wf-source')).toBe(false);
+		expect(result.get('other-source')).toBe(imported);
+	});
+
+	it('rejects as ambiguous when two workflows share the same sourceWorkflowId', async () => {
+		const first = workflow({ id: 'local-1', sourceWorkflowId: 'wf-dup', name: 'First' });
+		const second = workflow({ id: 'local-2', sourceWorkflowId: 'wf-dup', name: 'Second' });
+		const { service } = makeService([first, second]);
+
+		await expect(service.findBySourceWorkflowIds('project-1', ['wf-dup'])).rejects.toMatchObject({
+			message: 'AMBIGUOUS_SOURCE_WORKFLOW_ID',
+			meta: {
+				code: 'AMBIGUOUS_SOURCE_WORKFLOW_ID',
+				ambiguous: [
+					{
+						sourceWorkflowId: 'wf-dup',
+						matches: [
+							{ id: 'local-1', name: 'First' },
+							{ id: 'local-2', name: 'Second' },
+						],
+					},
+				],
+			},
+		});
+	});
+
+	it('rejects when a never-imported original and an imported workflow resolve to the same key', async () => {
+		// 'wf-x' is both an original's own id and another workflow's source id —
+		// the id fallback collides with a real source match, which is ambiguous.
+		const original = workflow({ id: 'wf-x', sourceWorkflowId: null, name: 'Original' });
+		const imported = workflow({ id: 'local-2', sourceWorkflowId: 'wf-x', name: 'Imported' });
+		const { service } = makeService([original, imported]);
+
+		await expect(service.findBySourceWorkflowIds('project-1', ['wf-x'])).rejects.toThrow(
+			ConflictError,
+		);
+	});
+
+	it('keeps distinct source ids in separate map entries', async () => {
+		const a = workflow({ id: 'local-a', sourceWorkflowId: 'wf-a' });
+		const b = workflow({ id: 'wf-b', sourceWorkflowId: null });
+		const { service } = makeService([a, b]);
+
+		const result = await service.findBySourceWorkflowIds('project-1', ['wf-a', 'wf-b']);
+
+		expect(result.size).toBe(2);
+		expect(result.get('wf-a')).toBe(a);
+		expect(result.get('wf-b')).toBe(b);
+	});
+});

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/fail-workflow-conflict-policy.handler.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/fail-workflow-conflict-policy.handler.ts
@@ -1,0 +1,37 @@
+import type { WorkflowEntity } from '@n8n/db';
+import { Service } from '@n8n/di';
+
+import { ConflictError } from '@/errors/response-errors/conflict.error';
+import { WorkflowCreationService } from '@/workflows/workflow-creation.service';
+
+import { WorkflowConflictPolicyHandler } from './workflow-conflict-policy-handler';
+import type {
+	WorkflowConflict,
+	WorkflowImportOutcome,
+	WorkflowMatchContext,
+} from './workflow-conflict-policy.types';
+
+@Service()
+export class FailWorkflowConflictPolicyHandler extends WorkflowConflictPolicyHandler {
+	constructor(workflowCreationService: WorkflowCreationService) {
+		super(workflowCreationService);
+	}
+
+	preFlight(conflicts: WorkflowConflict[]): void {
+		if (conflicts.length === 0) return;
+
+		throw new ConflictError('WORKFLOW_CONFLICT', undefined, {
+			code: 'WORKFLOW_CONFLICT',
+			conflicts,
+		});
+	}
+
+	async handle(
+		entity: WorkflowEntity,
+		sourceWorkflowId: string,
+		_match: WorkflowEntity | null,
+		context: WorkflowMatchContext,
+	): Promise<WorkflowImportOutcome> {
+		return await this.createWorkflow(entity, sourceWorkflowId, context);
+	}
+}

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/new-version-workflow-conflict-policy.handler.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/new-version-workflow-conflict-policy.handler.ts
@@ -1,0 +1,40 @@
+import type { WorkflowEntity } from '@n8n/db';
+import { Service } from '@n8n/di';
+
+import { WorkflowCreationService } from '@/workflows/workflow-creation.service';
+import { WorkflowService } from '@/workflows/workflow.service';
+
+import { WorkflowConflictPolicyHandler } from './workflow-conflict-policy-handler';
+import type { WorkflowImportOutcome, WorkflowMatchContext } from './workflow-conflict-policy.types';
+
+@Service()
+export class NewVersionWorkflowConflictPolicyHandler extends WorkflowConflictPolicyHandler {
+	constructor(
+		workflowCreationService: WorkflowCreationService,
+		private readonly workflowService: WorkflowService,
+	) {
+		super(workflowCreationService);
+	}
+
+	preFlight(): void {}
+
+	async handle(
+		entity: WorkflowEntity,
+		sourceWorkflowId: string,
+		match: WorkflowEntity | null,
+		context: WorkflowMatchContext,
+	): Promise<WorkflowImportOutcome> {
+		if (!match) {
+			return await this.createWorkflow(entity, sourceWorkflowId, context);
+		}
+
+		const workflow = await this.workflowService.update(context.user, entity, match.id, {
+			publicApi: true,
+			publishIfActive: true,
+			source: 'import',
+		});
+		workflow.parentFolder = match.parentFolder;
+
+		return { status: 'updated', workflow, sourceWorkflowId };
+	}
+}

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/skip-workflow-conflict-policy.handler.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/skip-workflow-conflict-policy.handler.ts
@@ -1,0 +1,29 @@
+import type { WorkflowEntity } from '@n8n/db';
+import { Service } from '@n8n/di';
+
+import { WorkflowCreationService } from '@/workflows/workflow-creation.service';
+
+import { WorkflowConflictPolicyHandler } from './workflow-conflict-policy-handler';
+import type { WorkflowImportOutcome, WorkflowMatchContext } from './workflow-conflict-policy.types';
+
+@Service()
+export class SkipWorkflowConflictPolicyHandler extends WorkflowConflictPolicyHandler {
+	constructor(workflowCreationService: WorkflowCreationService) {
+		super(workflowCreationService);
+	}
+
+	preFlight(): void {}
+
+	async handle(
+		entity: WorkflowEntity,
+		sourceWorkflowId: string,
+		match: WorkflowEntity | null,
+		context: WorkflowMatchContext,
+	): Promise<WorkflowImportOutcome> {
+		if (match) {
+			return { status: 'skipped', workflow: match, sourceWorkflowId };
+		}
+
+		return await this.createWorkflow(entity, sourceWorkflowId, context);
+	}
+}

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-conflict-policy-handler.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-conflict-policy-handler.ts
@@ -1,0 +1,38 @@
+import type { WorkflowEntity } from '@n8n/db';
+
+import type { WorkflowCreationService } from '@/workflows/workflow-creation.service';
+
+import type {
+	WorkflowConflict,
+	WorkflowImportOutcome,
+	WorkflowMatchContext,
+} from './workflow-conflict-policy.types';
+
+export abstract class WorkflowConflictPolicyHandler {
+	constructor(protected readonly workflowCreationService: WorkflowCreationService) {}
+
+	abstract preFlight(conflicts: WorkflowConflict[]): void;
+
+	abstract handle(
+		entity: WorkflowEntity,
+		sourceWorkflowId: string,
+		match: WorkflowEntity | null,
+		context: WorkflowMatchContext,
+	): Promise<WorkflowImportOutcome>;
+
+	protected async createWorkflow(
+		entity: WorkflowEntity,
+		sourceWorkflowId: string,
+		context: WorkflowMatchContext,
+	): Promise<WorkflowImportOutcome> {
+		const workflow = await this.workflowCreationService.createWorkflow(context.user, entity, {
+			projectId: context.projectId,
+			parentFolderId: context.folderId ?? undefined,
+			publicApi: true,
+			source: 'import',
+			sourceWorkflowId,
+		});
+
+		return { status: 'created', workflow, sourceWorkflowId };
+	}
+}

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-conflict-policy.factory.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-conflict-policy.factory.ts
@@ -1,0 +1,30 @@
+import { Service } from '@n8n/di';
+
+import { FailWorkflowConflictPolicyHandler } from './fail-workflow-conflict-policy.handler';
+import { NewVersionWorkflowConflictPolicyHandler } from './new-version-workflow-conflict-policy.handler';
+import { SkipWorkflowConflictPolicyHandler } from './skip-workflow-conflict-policy.handler';
+import type { WorkflowConflictPolicyHandler } from './workflow-conflict-policy-handler';
+import type { WorkflowConflictPolicy } from '../../n8n-packages.types';
+
+@Service()
+export class WorkflowConflictPolicyFactory {
+	private readonly handlers: Record<WorkflowConflictPolicy, WorkflowConflictPolicyHandler>;
+
+	constructor(
+		newVersion: NewVersionWorkflowConflictPolicyHandler,
+		fail: FailWorkflowConflictPolicyHandler,
+		skip: SkipWorkflowConflictPolicyHandler,
+	) {
+		/* eslint-disable @typescript-eslint/naming-convention -- API workflow conflict policy keys */
+		this.handlers = {
+			'new-version': newVersion,
+			fail,
+			skip,
+		};
+		/* eslint-enable @typescript-eslint/naming-convention */
+	}
+
+	getHandler(policy: WorkflowConflictPolicy): WorkflowConflictPolicyHandler {
+		return this.handlers[policy];
+	}
+}

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-conflict-policy.types.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-conflict-policy.types.ts
@@ -1,0 +1,24 @@
+import type { User, WorkflowEntity } from '@n8n/db';
+
+export interface WorkflowMatchContext {
+	user: User;
+	projectId: string;
+	folderId: string | null;
+}
+
+export interface WorkflowImportOutcome {
+	status: 'created' | 'updated' | 'skipped';
+	workflow: WorkflowEntity;
+	sourceWorkflowId: string;
+}
+
+export interface PreparedWorkflow {
+	entity: WorkflowEntity;
+	sourceWorkflowId: string;
+}
+
+export interface WorkflowConflict {
+	sourceWorkflowId: string;
+	existingWorkflowId: string;
+	name: string;
+}

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-import-match.service.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-import-match.service.ts
@@ -1,0 +1,70 @@
+import { type WorkflowEntity } from '@n8n/db';
+import { Service } from '@n8n/di';
+
+import { ConflictError } from '@/errors/response-errors/conflict.error';
+import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+
+@Service()
+export class WorkflowImportMatchService {
+	constructor(private readonly workflowFinderService: WorkflowFinderService) {}
+
+	async findBySourceWorkflowIds(
+		projectId: string,
+		sourceWorkflowIds: string[],
+	): Promise<Map<string, WorkflowEntity>> {
+		if (sourceWorkflowIds.length === 0) return new Map();
+
+		const workflows = await this.workflowFinderService.findOwnedWorkflowsBySourceWorkflowIds(
+			projectId,
+			sourceWorkflowIds,
+			{ includeActiveVersion: true, includeParentFolder: true },
+		);
+
+		// Build the source-id → match map in one pass, collecting only the keys
+		// that resolve to more than one workflow as collisions to reject.
+		const matchBySourceWorkflowId = new Map<string, WorkflowEntity>();
+		const collisionsBySourceWorkflowId = new Map<string, WorkflowEntity[]>();
+
+		for (const workflow of workflows) {
+			// A workflow authored on this instance (never imported) has no
+			// `sourceWorkflowId`, so fall back to its own id: re-importing a package
+			// exported from here matches the originals by their original id.
+			const key = workflow.sourceWorkflowId ?? workflow.id;
+
+			const firstMatch = matchBySourceWorkflowId.get(key);
+			if (!firstMatch) {
+				matchBySourceWorkflowId.set(key, workflow);
+				continue;
+			}
+
+			const collisions = collisionsBySourceWorkflowId.get(key);
+			if (collisions) {
+				collisions.push(workflow);
+			} else {
+				collisionsBySourceWorkflowId.set(key, [firstMatch, workflow]);
+			}
+		}
+
+		this.rejectAmbiguousMatches(collisionsBySourceWorkflowId);
+
+		return matchBySourceWorkflowId;
+	}
+
+	private rejectAmbiguousMatches(
+		collisionsBySourceWorkflowId: Map<string, WorkflowEntity[]>,
+	): void {
+		if (collisionsBySourceWorkflowId.size === 0) return;
+
+		const ambiguous = Array.from(collisionsBySourceWorkflowId.entries()).map(
+			([sourceWorkflowId, matches]) => ({
+				sourceWorkflowId,
+				matches: matches.map(({ id, name }) => ({ id, name })),
+			}),
+		);
+
+		throw new ConflictError('AMBIGUOUS_SOURCE_WORKFLOW_ID', undefined, {
+			code: 'AMBIGUOUS_SOURCE_WORKFLOW_ID',
+			ambiguous,
+		});
+	}
+}

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-importer.ts
@@ -1,0 +1,70 @@
+import { Service } from '@n8n/di';
+
+import type { PackageImportBindings, WorkflowConflictPolicy } from '../../n8n-packages.types';
+import { WorkflowImportMatchService } from './workflow-import-match.service';
+import { WorkflowConflictPolicyFactory } from './workflow-conflict-policy.factory';
+import type {
+	PreparedWorkflow,
+	WorkflowConflict,
+	WorkflowImportOutcome,
+	WorkflowMatchContext,
+} from './workflow-conflict-policy.types';
+
+export interface WorkflowImportResult {
+	outcomes: WorkflowImportOutcome[];
+	bindings: PackageImportBindings;
+}
+
+/**
+ * Coordinates importing a batch of prepared workflows under a given conflict
+ * policy: selects the policy handler, matches each workflow against existing
+ * ones in the destination project, runs the policy pre-flight check, then
+ * dispatches each workflow to the handler.
+ */
+@Service()
+export class WorkflowImporter {
+	constructor(
+		private readonly workflowConflictPolicyFactory: WorkflowConflictPolicyFactory,
+		private readonly workflowImportMatchService: WorkflowImportMatchService,
+	) {}
+
+	async importWorkflows(
+		prepared: PreparedWorkflow[],
+		policy: WorkflowConflictPolicy,
+		context: WorkflowMatchContext,
+		bindings: PackageImportBindings,
+	): Promise<WorkflowImportResult> {
+		const workflowConflictPolicyHandler = this.workflowConflictPolicyFactory.getHandler(policy);
+
+		const matchBySourceWorkflowId = await this.workflowImportMatchService.findBySourceWorkflowIds(
+			context.projectId,
+			prepared.map(({ sourceWorkflowId }) => sourceWorkflowId),
+		);
+
+		const conflicts: WorkflowConflict[] = Array.from(matchBySourceWorkflowId.entries()).map(
+			([sourceWorkflowId, match]) => ({
+				sourceWorkflowId,
+				existingWorkflowId: match.id,
+				name: match.name,
+			}),
+		);
+		workflowConflictPolicyHandler.preFlight(conflicts);
+
+		const outcomes: WorkflowImportOutcome[] = [];
+		const workflowBindings = { ...bindings.workflows };
+		for (const { entity, sourceWorkflowId } of prepared) {
+			const match = matchBySourceWorkflowId.get(sourceWorkflowId) ?? null;
+			const outcome = await workflowConflictPolicyHandler.handle(
+				entity,
+				sourceWorkflowId,
+				match,
+				context,
+			);
+			outcomes.push(outcome);
+			// Works for every status: created/updated/skipped all resolve to a real target id.
+			workflowBindings[sourceWorkflowId] = outcome.workflow.id;
+		}
+
+		return { outcomes, bindings: { ...bindings, workflows: workflowBindings } };
+	}
+}

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
@@ -1,5 +1,7 @@
 import type { User } from '@n8n/db';
 
+export type WorkflowConflictPolicy = 'new-version' | 'fail' | 'skip';
+
 export interface ExportWorkflowsRequest {
 	user: User;
 	workflowIds: string[];
@@ -10,15 +12,34 @@ export interface ImportPackageRequest {
 	projectId?: string;
 	folderId?: string;
 	packageBuffer: Buffer;
+	workflowConflictPolicy: WorkflowConflictPolicy;
 }
 
 export interface ImportedWorkflowSummary {
-	sourceId: string;
+	sourceWorkflowId: string;
 	localId: string;
 	name: string;
 	projectId: string;
 	parentFolderId: string | null;
 	activeVersionId: string | null;
+	status: 'created' | 'updated' | 'skipped';
+}
+
+/** Source id → target id mapping for one entity type within an imported package. */
+export type BindingMap = Record<string, string>;
+
+/**
+ * Source→target id mappings produced while importing a package, one map per
+ * entity type. Only workflows are imported for now.
+ */
+export interface PackageImportBindings {
+	workflows: BindingMap;
+}
+
+export function createEmptyBindings(): PackageImportBindings {
+	return {
+		workflows: {},
+	};
 }
 
 export interface ImportResult {
@@ -28,4 +49,5 @@ export interface ImportResult {
 		exportedAt: string;
 	};
 	workflows: ImportedWorkflowSummary[];
+	bindings: PackageImportBindings;
 }

--- a/packages/cli/src/modules/n8n-packages/utils/import-package-upload.ts
+++ b/packages/cli/src/modules/n8n-packages/utils/import-package-upload.ts
@@ -17,7 +17,7 @@ const IMPORT_PACKAGE_BODY_FIELD_SET = new Set<string>([
 /** Max length for optional routing ids in multipart form fields. */
 const IMPORT_PACKAGE_FIELD_SIZE_BYTES = 128;
 
-/** `package` file + optional `projectId` / `folderId` fields + small margin. */
+/** `package` file + routing / policy fields + small margin. */
 const IMPORT_PACKAGE_MAX_PARTS = 5;
 
 export function createN8nPackageMulterOptions(globalConfig: GlobalConfig): multer.Options {

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/n8n-packages.handler.ts
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/n8n-packages.handler.ts
@@ -77,6 +77,7 @@ const n8nPackagesHandlers: N8nPackagesHandlers = {
 				user: req.user,
 				projectId: payload.data.projectId,
 				folderId: payload.data.folderId,
+				workflowConflictPolicy: payload.data.workflowConflictPolicy,
 				packageBuffer: packageFile.buffer,
 			});
 			return res.status(200).json(result);

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/paths/n8n-packages.import.yml
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/paths/n8n-packages.import.yml
@@ -10,12 +10,14 @@ post:
 
     Imports a gzip-compressed tar package (`.n8np`) into the target project. Send the
     archive as the multipart field `package`. Optional routing uses form fields
-    `projectId` and `folderId` (omit or leave empty for defaults). Maximum upload size
+    `projectId` and `folderId` (omit or leave empty for defaults). The required
+    `workflowConflictPolicy` field controls what happens when a package workflow
+    matches an existing workflow by source id in the target project. Maximum upload size
     is `N8N_ENDPOINTS_PAYLOAD_SIZE_MAX` MB (default 16).
 
     The package must declare its manifest at `manifest.json` and include every file
     referenced by the manifest. The caller is authorised through the `workflow:import`
-    scope. Each imported workflow is created with a fresh local id and arrives inactive.
+    scope. Newly created workflows receive a fresh local id and arrive inactive.
   requestBody:
     required: true
     content:
@@ -24,6 +26,7 @@ post:
           type: object
           required:
             - package
+            - workflowConflictPolicy
           properties:
             package:
               type: string
@@ -39,6 +42,16 @@ post:
               description: >
                 Optional folder within the target project. Omit or send empty for
                 project root.
+            workflowConflictPolicy:
+              type: string
+              enum:
+                - new-version
+                - fail
+                - skip
+              description: >
+                `new-version` updates matching workflows and creates a new version,
+                `fail` rejects the import when any matching workflow exists, and
+                `skip` leaves matching workflows untouched while importing the rest.
   responses:
     '200':
       description: Import succeeded.
@@ -49,6 +62,7 @@ post:
             required:
               - package
               - workflows
+              - bindings
             properties:
               package:
                 type: object
@@ -69,14 +83,15 @@ post:
                 items:
                   type: object
                   required:
-                    - sourceId
+                    - sourceWorkflowId
                     - localId
                     - name
                     - projectId
                     - parentFolderId
                     - activeVersionId
+                    - status
                   properties:
-                    sourceId:
+                    sourceWorkflowId:
                       type: string
                       description: Workflow id as it appeared in the package.
                     localId:
@@ -93,8 +108,73 @@ post:
                       type: string
                       nullable: true
                       description: >
-                        Published version on the target instance. Always null
-                        immediately after import.
+                        Published version on the target instance, if any.
+                    status:
+                      type: string
+                      enum:
+                        - created
+                        - updated
+                        - skipped
+                      description: Import outcome for this package workflow.
+              bindings:
+                type: object
+                description: >
+                  Source id → target id mappings produced during import, one map per
+                  entity type. Each value maps an id as it appeared in the package to
+                  the id on the target instance. Only workflows are imported for now.
+                required:
+                  - workflows
+                properties:
+                  workflows:
+                    type: object
+                    additionalProperties:
+                      type: string
+    '409':
+      description: Workflow source id conflict.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: number
+              message:
+                type: string
+              meta:
+                type: object
+                properties:
+                  code:
+                    type: string
+                    enum:
+                      - WORKFLOW_CONFLICT
+                      - AMBIGUOUS_SOURCE_WORKFLOW_ID
+                  conflicts:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        sourceWorkflowId:
+                          type: string
+                        existingWorkflowId:
+                          type: string
+                        name:
+                          type: string
+                  ambiguous:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        sourceWorkflowId:
+                          type: string
+                        matches:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              id:
+                                type: string
+                              name:
+                                type: string
     '400':
       $ref: '../../../../shared/spec/responses/badRequest.yml'
     '401':

--- a/packages/cli/src/workflows/workflow-finder.service.ts
+++ b/packages/cli/src/workflows/workflow-finder.service.ts
@@ -5,7 +5,7 @@ import { hasGlobalScope, type Scope } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import type { EntityManager, FindOptionsWhere } from '@n8n/typeorm';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
-import { In } from '@n8n/typeorm';
+import { In, IsNull } from '@n8n/typeorm';
 
 import { userHasScopes } from '@/permissions.ee/check-access';
 import { RoleService } from '@/services/role.service';
@@ -147,6 +147,45 @@ export class WorkflowFinderService {
 			workflows.push(workflow);
 		}
 		return workflows;
+	}
+
+	/**
+	 * Finds owned workflows in a project that correspond to the given package
+	 * source workflow ids. A workflow matches when its `sourceWorkflowId` equals
+	 * one of the ids, or — for workflows authored on this instance that were never
+	 * imported (`sourceWorkflowId` is null) — when its own id equals one of the
+	 * ids. The latter lets a package exported from this instance re-match its
+	 * originals on re-import.
+	 */
+	async findOwnedWorkflowsBySourceWorkflowIds(
+		projectId: string,
+		sourceWorkflowIds: string[],
+		options: { includeActiveVersion?: boolean; includeParentFolder?: boolean } = {},
+	): Promise<WorkflowEntity[]> {
+		if (sourceWorkflowIds.length === 0) return [];
+
+		const sharedWorkflows = await this.sharedWorkflowRepository.find({
+			where: [
+				{
+					projectId,
+					role: 'workflow:owner',
+					workflow: { sourceWorkflowId: In(sourceWorkflowIds), isArchived: false },
+				},
+				{
+					projectId,
+					role: 'workflow:owner',
+					workflow: { sourceWorkflowId: IsNull(), id: In(sourceWorkflowIds), isArchived: false },
+				},
+			],
+			relations: {
+				workflow: {
+					activeVersion: options.includeActiveVersion,
+					parentFolder: options.includeParentFolder,
+				},
+			},
+		});
+
+		return sharedWorkflows.map(({ workflow }) => workflow);
 	}
 
 	async hasProjectScopeForUser(user: User, scopes: Scope[], projectId: string) {

--- a/packages/cli/test/integration/public-api/n8n-packages-import.test.ts
+++ b/packages/cli/test/integration/public-api/n8n-packages-import.test.ts
@@ -119,6 +119,7 @@ describe('POST /n8n-packages/import', () => {
 
 		const response = await authOwnerAgent
 			.post('/n8n-packages/import')
+			.field('workflowConflictPolicy', 'fail')
 			.attach('package', tarBuffer, 'import.n8np');
 
 		expect(response.statusCode).toBe(200);
@@ -130,14 +131,18 @@ describe('POST /n8n-packages/import', () => {
 			},
 			workflows: [
 				{
-					sourceId: 'wf-http-source',
+					sourceWorkflowId: 'wf-http-source',
 					localId: expect.any(String),
 					name: 'HTTP Imported',
 					projectId: ownerPersonalProject.id,
 					parentFolderId: null,
 					activeVersionId: null,
+					status: 'created',
 				},
 			],
+			bindings: {
+				workflows: { 'wf-http-source': expect.any(String) },
+			},
 		});
 
 		expect(response.body.workflows[0].localId).not.toBe('wf-http-source');


### PR DESCRIPTION
## Summary

Adds a required `workflowConflictPolicy` body param to `POST /n8n-packages/import` that controls how package workflows matching an existing workflow (by `sourceWorkflowId`) in the destination project are handled:

- **`new-version`** — update the existing workflow in place (reactivating with new triggers when it was active), preserving placement (project/sharing/ownership/folder).
- **`fail`** — detect all conflicts up front and return `409 WORKFLOW_CONFLICT` before any writes.
- **`skip`** — leave the existing workflow untouched and continue importing the rest.

Workflows with no `sourceWorkflowId` match are always created fresh. Multiple destination matches for one source id will result in error `409 AMBIGUOUS_SOURCE_WORKFLOW_ID`.

**Design / structure:**
- Strategy pattern: abstract `workflowConflictPolicyHandler` with `new-version` / `fail` / `skip` concrete handlers and a factory.
- `WorkflowImportMatchService` looks up destination matches through `WorkflowFinderService` (new `findOwnedWorkflowsBySourceIds`) — module services don't touch repositories directly.
- A `WorkflowImporter` coordinator owns handler selection → match lookup → pre-flight → per-workflow dispatch; the pipeline delegates and shapes the response.
- Response reports per-workflow `status` (`created` | `updated` | `skipped`) and a `bindings` object of source→target id maps (only `workflows` populated for now).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-563

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with backport label (if urgent fix).
