### PR TITLE
refactor(editor): Migrate manual execution stats to workflow execution state store (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.test.ts
@@ -26,7 +26,6 @@ import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { mockedStore } from '@/__tests__/utils';
 import { useReadyToRunStore } from '@/features/workflows/readyToRun/stores/readyToRun.store';
-import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 
 const opts = {
@@ -693,8 +692,8 @@ describe('manual execution stats tracking', () => {
 			const pinia = createTestingPinia();
 			setActivePinia(pinia);
 
-			const builderStore = mockedStore(useBuilderStore);
-			const incrementSpy = vi.spyOn(builderStore, 'incrementManualExecutionStats');
+			const executionStateStore = useWorkflowExecutionStateStore(createWorkflowDocumentId(''));
+			const incrementSpy = vi.spyOn(executionStateStore, 'incrementManualExecutionStats');
 
 			handleExecutionFinishedWithSuccessOrOther(mock<WorkflowState>(), 'success', false);
 
@@ -705,8 +704,8 @@ describe('manual execution stats tracking', () => {
 			const pinia = createTestingPinia();
 			setActivePinia(pinia);
 
-			const builderStore = mockedStore(useBuilderStore);
-			const incrementSpy = vi.spyOn(builderStore, 'incrementManualExecutionStats');
+			const executionStateStore = useWorkflowExecutionStateStore(createWorkflowDocumentId(''));
+			const incrementSpy = vi.spyOn(executionStateStore, 'incrementManualExecutionStats');
 
 			handleExecutionFinishedWithSuccessOrOther(mock<WorkflowState>(), 'success', true);
 
@@ -717,8 +716,8 @@ describe('manual execution stats tracking', () => {
 			const pinia = createTestingPinia();
 			setActivePinia(pinia);
 
-			const builderStore = mockedStore(useBuilderStore);
-			const incrementSpy = vi.spyOn(builderStore, 'incrementManualExecutionStats');
+			const executionStateStore = useWorkflowExecutionStateStore(createWorkflowDocumentId(''));
+			const incrementSpy = vi.spyOn(executionStateStore, 'incrementManualExecutionStats');
 
 			handleExecutionFinishedWithSuccessOrOther(mock<WorkflowState>(), 'error', false);
 
@@ -829,8 +828,8 @@ describe('manual execution stats tracking', () => {
 			const pinia = createTestingPinia();
 			setActivePinia(pinia);
 
-			const builderStore = mockedStore(useBuilderStore);
-			const incrementSpy = vi.spyOn(builderStore, 'incrementManualExecutionStats');
+			const executionStateStore = useWorkflowExecutionStateStore(createWorkflowDocumentId(''));
+			const incrementSpy = vi.spyOn(executionStateStore, 'incrementManualExecutionStats');
 
 			const execution = mock<SimplifiedExecution>({
 				status: 'error',
@@ -853,8 +852,8 @@ describe('manual execution stats tracking', () => {
 			const pinia = createTestingPinia();
 			setActivePinia(pinia);
 
-			const builderStore = mockedStore(useBuilderStore);
-			const incrementSpy = vi.spyOn(builderStore, 'incrementManualExecutionStats');
+			const executionStateStore = useWorkflowExecutionStateStore(createWorkflowDocumentId(''));
+			const incrementSpy = vi.spyOn(executionStateStore, 'incrementManualExecutionStats');
 
 			const execution = mock<SimplifiedExecution>({
 				status: 'canceled',

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -21,7 +21,6 @@ import {
 import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
 import { createExecutionDataId, useExecutionDataStore } from '@/app/stores/executionData.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
-import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 import {
 	SampleTemplates,
 	isTutorialTemplateId,
@@ -383,7 +382,9 @@ export function handleExecutionFinishedWithErrorOrCanceled(
 
 		toast.showMessage({ title, message, type: 'error', duration: 0 });
 
-		useBuilderStore().incrementManualExecutionStats('error');
+		useWorkflowExecutionStateStore(workflowDocumentStore.documentId).incrementManualExecutionStats(
+			'error',
+		);
 	}
 }
 
@@ -474,7 +475,9 @@ export function handleExecutionFinishedWithSuccessOrOther(
 	// Execution finished is triggered multiple times
 	// use "successToastAlreadyShown" flag to avoid double counting executions
 	if (executionStatus === 'success' && !successToastAlreadyShown) {
-		useBuilderStore().incrementManualExecutionStats('success');
+		const executionStateStore = useWorkflowExecutionStateStore(workflowDocumentStore.documentId);
+		executionStateStore.incrementManualExecutionStats('success');
+		executionStateStore.markHasHadSuccessfulExecution();
 	}
 }
 

--- a/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useWorkflowState.ts
@@ -13,7 +13,6 @@ import {
 } from '@/app/stores/workflowExecutionState.store';
 import { createExecutionDataId, useExecutionDataStore } from '@/app/stores/executionData.store';
 import { isEmpty } from '@/app/utils/typesUtils';
-import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 import type {
 	IExecutionResponse,
 	IExecutionsStopData,
@@ -149,21 +148,20 @@ export function useWorkflowState() {
 		const wid = ws.workflowId;
 		if (!wid) {
 			workflowStateStore.executingNode.executingNode.length = 0;
-			useBuilderStore().resetManualExecutionStats();
+			useWorkflowExecutionStateStore(createWorkflowDocumentId(wid)).resetManualExecutionStats();
 			return;
 		}
 		const workflowExecutionStateStore = useWorkflowExecutionStateStore(
 			createWorkflowDocumentId(wid),
 		);
 		// Disposes every tracked executionData store + IN_PROGRESS placeholder, then clears all
-		// session-level fields.
+		// session-level fields (including manual-execution stats).
 		workflowExecutionStateStore.resetExecutionState();
 		// Then dispose the per-workflow state store so pinia state doesn't accumulate one entry
 		// per workflow ever opened in this session.
 		disposeWorkflowExecutionStateStore(workflowExecutionStateStore);
 
 		workflowStateStore.executingNode.executingNode.length = 0;
-		useBuilderStore().resetManualExecutionStats();
 	}
 
 	return {

--- a/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.test.ts
@@ -1196,6 +1196,121 @@ describe('workflowExecutionState.store', () => {
 		});
 	});
 
+	describe('manualExecStatsInBetweenMessages', () => {
+		it('starts at zero', () => {
+			const workflowExecutionStateStore = useWorkflowExecutionStateStore(
+				createWorkflowDocumentId('wf-stats'),
+			);
+			expect(workflowExecutionStateStore.manualExecStatsInBetweenMessages).toEqual({
+				success: 0,
+				error: 0,
+			});
+		});
+
+		it('increments success and error tallies independently', () => {
+			const workflowExecutionStateStore = useWorkflowExecutionStateStore(
+				createWorkflowDocumentId('wf-stats'),
+			);
+			workflowExecutionStateStore.incrementManualExecutionStats('success');
+			workflowExecutionStateStore.incrementManualExecutionStats('success');
+			workflowExecutionStateStore.incrementManualExecutionStats('error');
+
+			expect(workflowExecutionStateStore.manualExecStatsInBetweenMessages).toEqual({
+				success: 2,
+				error: 1,
+			});
+		});
+
+		it('resetManualExecutionStats clears the tallies', () => {
+			const workflowExecutionStateStore = useWorkflowExecutionStateStore(
+				createWorkflowDocumentId('wf-stats'),
+			);
+			workflowExecutionStateStore.incrementManualExecutionStats('success');
+			workflowExecutionStateStore.resetManualExecutionStats();
+
+			expect(workflowExecutionStateStore.manualExecStatsInBetweenMessages).toEqual({
+				success: 0,
+				error: 0,
+			});
+		});
+
+		it('resetExecutionState clears the tallies', () => {
+			const workflowExecutionStateStore = useWorkflowExecutionStateStore(
+				createWorkflowDocumentId('wf-stats'),
+			);
+			workflowExecutionStateStore.incrementManualExecutionStats('error');
+			workflowExecutionStateStore.resetExecutionState();
+
+			expect(workflowExecutionStateStore.manualExecStatsInBetweenMessages).toEqual({
+				success: 0,
+				error: 0,
+			});
+		});
+
+		it('fires a change event with the manualExecStats field on increment', () => {
+			const id = createWorkflowDocumentId('wf-stats');
+			const workflowExecutionStateStore = useWorkflowExecutionStateStore(id);
+			const spy = vi.fn();
+			workflowExecutionStateStore.onWorkflowExecutionStateChange(spy);
+
+			workflowExecutionStateStore.incrementManualExecutionStats('success');
+
+			expect(spy.mock.calls[0][0]).toMatchObject({
+				action: 'update',
+				payload: { documentId: id, field: 'manualExecStats' },
+			});
+		});
+	});
+
+	describe('hasHadSuccessfulExecution', () => {
+		it('defaults to false', () => {
+			const workflowExecutionStateStore = useWorkflowExecutionStateStore(
+				createWorkflowDocumentId('wf-success'),
+			);
+			expect(workflowExecutionStateStore.hasHadSuccessfulExecution).toBe(false);
+		});
+
+		it('markHasHadSuccessfulExecution sets the flag', () => {
+			const workflowExecutionStateStore = useWorkflowExecutionStateStore(
+				createWorkflowDocumentId('wf-success'),
+			);
+			workflowExecutionStateStore.markHasHadSuccessfulExecution();
+			expect(workflowExecutionStateStore.hasHadSuccessfulExecution).toBe(true);
+		});
+
+		it('is not cleared by resetManualExecutionStats', () => {
+			const workflowExecutionStateStore = useWorkflowExecutionStateStore(
+				createWorkflowDocumentId('wf-success'),
+			);
+			workflowExecutionStateStore.markHasHadSuccessfulExecution();
+			workflowExecutionStateStore.resetManualExecutionStats();
+			expect(workflowExecutionStateStore.hasHadSuccessfulExecution).toBe(true);
+		});
+
+		it('is cleared by resetExecutionState', () => {
+			const workflowExecutionStateStore = useWorkflowExecutionStateStore(
+				createWorkflowDocumentId('wf-success'),
+			);
+			workflowExecutionStateStore.markHasHadSuccessfulExecution();
+			workflowExecutionStateStore.resetExecutionState();
+			expect(workflowExecutionStateStore.hasHadSuccessfulExecution).toBe(false);
+		});
+
+		it('fires a change event with the hasHadSuccessfulExecution field', () => {
+			const id = createWorkflowDocumentId('wf-success');
+			const workflowExecutionStateStore = useWorkflowExecutionStateStore(id);
+			const spy = vi.fn();
+			workflowExecutionStateStore.onWorkflowExecutionStateChange(spy);
+
+			workflowExecutionStateStore.markHasHadSuccessfulExecution();
+
+			expect(spy.mock.calls[0][0]).toMatchObject({
+				action: 'update',
+				payload: { documentId: id, field: 'hasHadSuccessfulExecution' },
+			});
+		});
+	});
+
 	describe('event hook', () => {
 		it('fires onWorkflowExecutionStateChange with workflowId and field discriminator', () => {
 			const id = createWorkflowDocumentId('wf-1');

--- a/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowExecutionState.store.ts
@@ -36,6 +36,8 @@ export type WorkflowExecutionStateField =
 	| 'selectedTriggerNodeName'
 	| 'currentWorkflowExecutions'
 	| 'lastSuccessfulExecutionId'
+	| 'manualExecStats'
+	| 'hasHadSuccessfulExecution'
 	| 'state';
 
 export type WorkflowExecutionStateChangeEvent = ChangeEvent<WorkflowExecutionStateChangePayload>;
@@ -89,6 +91,21 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 		const selectedTriggerNodeName = ref<string | undefined>();
 		const currentWorkflowExecutions = ref<ExecutionSummary[]>([]);
 		const lastSuccessfulExecutionId = ref<string | null>(null);
+		/**
+		 * Tally of manual executions (and their outcomes) that happened since the
+		 * last reset. The AI builder reads this to report how many manual runs
+		 * occurred between builder messages, then resets it on each new message.
+		 */
+		const manualExecStatsInBetweenMessages = ref<{ success: number; error: number }>({
+			success: 0,
+			error: 0,
+		});
+		/**
+		 * Whether any successful execution (full workflow or per-node) has occurred
+		 * for this workflow. Unlike `manualExecStatsInBetweenMessages` it is not reset
+		 * per builder message — it persists until the execution state is fully reset.
+		 */
+		const hasHadSuccessfulExecution = ref(false);
 		/**
 		 * Every execution id ever bound to this workflow's state. Used at
 		 * `resetExecutionState` time to dispose all per-execution data stores
@@ -452,6 +469,25 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			fireChange(CHANGE_ACTION.ADD, 'chatMessages');
 		}
 
+		function incrementManualExecutionStats(type: 'success' | 'error') {
+			manualExecStatsInBetweenMessages.value[type]++;
+			fireChange(CHANGE_ACTION.UPDATE, 'manualExecStats');
+		}
+
+		function resetManualExecutionStats() {
+			manualExecStatsInBetweenMessages.value = { success: 0, error: 0 };
+			fireChange(CHANGE_ACTION.DELETE, 'manualExecStats');
+		}
+
+		/**
+		 * Marks that a successful execution has occurred for this workflow.
+		 * Called when a manual run finishes successfully (see executionFinished handler).
+		 */
+		function markHasHadSuccessfulExecution() {
+			hasHadSuccessfulExecution.value = true;
+			fireChange(CHANGE_ACTION.UPDATE, 'hasHadSuccessfulExecution');
+		}
+
 		function setSelectedTriggerNodeName(value: string | undefined) {
 			selectedTriggerNodeName.value = value;
 			fireChange(
@@ -587,6 +623,8 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			selectedTriggerNodeName.value = undefined;
 			currentWorkflowExecutions.value = [];
 			lastSuccessfulExecutionId.value = null;
+			manualExecStatsInBetweenMessages.value = { success: 0, error: 0 };
+			hasHadSuccessfulExecution.value = false;
 			fireChange(CHANGE_ACTION.DELETE, 'state');
 		}
 
@@ -605,6 +643,8 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			selectedTriggerNodeName: readonly(selectedTriggerNodeName),
 			currentWorkflowExecutions: readonly(currentWorkflowExecutions),
 			lastSuccessfulExecutionId: readonly(lastSuccessfulExecutionId),
+			manualExecStatsInBetweenMessages: readonly(manualExecStatsInBetweenMessages),
+			hasHadSuccessfulExecution: readonly(hasHadSuccessfulExecution),
 			activeExecution,
 			activeExecutionRunData,
 			activeExecutionExecutedNode,
@@ -640,6 +680,9 @@ export function useWorkflowExecutionStateStore(id: WorkflowDocumentId) {
 			addToCurrentExecutions,
 			resetChatMessages,
 			appendChatMessage,
+			incrementManualExecutionStats,
+			resetManualExecutionStats,
+			markHasHadSuccessfulExecution,
 			setSelectedTriggerNodeName,
 			renameExecutionStateNode,
 			setActiveExecution,

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.test.ts
@@ -41,6 +41,7 @@ import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
+import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
 import { AI_BUILDER_PLAN_MODE_EXPERIMENT } from '@/app/constants/experiments';
 
 // Mock useI18n to return the keys instead of translations
@@ -1965,10 +1966,13 @@ describe('AI Builder store', () => {
 	describe('manual execution stats telemetry', () => {
 		it('should include success count in telemetry when sending message', async () => {
 			const builderStore = useBuilderStore();
+			const executionStateStore = useWorkflowExecutionStateStore(
+				createWorkflowDocumentId(workflowsStore.workflowId),
+			);
 
 			apiSpy.mockImplementationOnce(() => {});
 
-			builderStore.incrementManualExecutionStats('success');
+			executionStateStore.incrementManualExecutionStats('success');
 			await builderStore.sendChatMessage({ text: 'test' });
 
 			expect(track).toHaveBeenCalledWith(
@@ -1982,10 +1986,13 @@ describe('AI Builder store', () => {
 
 		it('should include error count in telemetry when sending message', async () => {
 			const builderStore = useBuilderStore();
+			const executionStateStore = useWorkflowExecutionStateStore(
+				createWorkflowDocumentId(workflowsStore.workflowId),
+			);
 
 			apiSpy.mockImplementationOnce(() => {});
 
-			builderStore.incrementManualExecutionStats('error');
+			executionStateStore.incrementManualExecutionStats('error');
 			await builderStore.sendChatMessage({ text: 'test' });
 
 			expect(track).toHaveBeenCalledWith(
@@ -1999,12 +2006,15 @@ describe('AI Builder store', () => {
 
 		it('should include multiple incremented counts in telemetry', async () => {
 			const builderStore = useBuilderStore();
+			const executionStateStore = useWorkflowExecutionStateStore(
+				createWorkflowDocumentId(workflowsStore.workflowId),
+			);
 
 			apiSpy.mockImplementationOnce(() => {});
 
-			builderStore.incrementManualExecutionStats('success');
-			builderStore.incrementManualExecutionStats('success');
-			builderStore.incrementManualExecutionStats('error');
+			executionStateStore.incrementManualExecutionStats('success');
+			executionStateStore.incrementManualExecutionStats('success');
+			executionStateStore.incrementManualExecutionStats('error');
 			await builderStore.sendChatMessage({ text: 'test' });
 
 			expect(track).toHaveBeenCalledWith(
@@ -2018,6 +2028,9 @@ describe('AI Builder store', () => {
 
 		it('should reset stats after sending message', async () => {
 			const builderStore = useBuilderStore();
+			const executionStateStore = useWorkflowExecutionStateStore(
+				createWorkflowDocumentId(workflowsStore.workflowId),
+			);
 
 			// First message with some stats
 			apiSpy.mockImplementationOnce((_ctx, _payload, onMessage, onDone) => {
@@ -2028,8 +2041,8 @@ describe('AI Builder store', () => {
 				onDone();
 			});
 
-			builderStore.incrementManualExecutionStats('success');
-			builderStore.incrementManualExecutionStats('error');
+			executionStateStore.incrementManualExecutionStats('success');
+			executionStateStore.incrementManualExecutionStats('error');
 			await builderStore.sendChatMessage({ text: 'first message' });
 
 			await vi.waitFor(() => expect(builderStore.streaming).toBe(false));

--- a/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/builder.store.ts
@@ -17,6 +17,7 @@ import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
+import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
 import { useBuilderMessages } from './composables/useBuilderMessages';
 import {
 	chatWithBuilder,
@@ -174,10 +175,6 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 	const builderMode = ref<'build' | 'plan'>('build');
 	const creditsQuota = ref<number | undefined>();
 	const creditsClaimed = ref<number | undefined>();
-	const manualExecStatsInBetweenMessages = ref<{ success: number; error: number }>({
-		success: 0,
-		error: 0,
-	});
 
 	// Version restore state — persisted to DB via workflow_builder_session
 	const activeVersionCardId = ref<string | undefined>(undefined);
@@ -211,9 +208,6 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 				.filter(Boolean) as string[],
 		);
 	});
-
-	// Track whether any successful execution (full workflow or per-node) has occurred in this session
-	const hasHadSuccessfulExecution = ref(false);
 
 	// AI-generated test data — persists throughout the session for apply/re-apply
 	const generatedPinData = ref<IPinData | null>(null);
@@ -255,6 +249,9 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 	const workflowsStore = useWorkflowsStore();
 	const workflowDocumentStore = computed(() =>
 		useWorkflowDocumentStore(createWorkflowDocumentId(workflowsStore.workflowId)),
+	);
+	const workflowExecutionStateStore = computed(() =>
+		useWorkflowExecutionStateStore(createWorkflowDocumentId(workflowsStore.workflowId)),
 	);
 	const ndvStore = computed(() => useNDVStore(createWorkflowDocumentId(workflowsStore.workflowId)));
 	const route = useRoute();
@@ -434,7 +431,6 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 		initialGeneration.value = false;
 		lastUserMessageId.value = undefined;
 		loadedSessionsForWorkflowId.value = undefined;
-		hasHadSuccessfulExecution.value = false;
 		generatedPinData.value = null;
 		pinDataApplied.value = false;
 		builderMode.value = 'build';
@@ -457,20 +453,6 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 		if (mode === 'plan' && !isPlanModeAvailable.value) return;
 		builderMode.value = mode;
 		trackWorkflowBuilderJourney('user_switched_builder_mode', { mode });
-	}
-
-	function incrementManualExecutionStats(type: 'success' | 'error') {
-		manualExecStatsInBetweenMessages.value[type]++;
-		if (type === 'success') {
-			hasHadSuccessfulExecution.value = true;
-		}
-	}
-
-	function resetManualExecutionStats() {
-		manualExecStatsInBetweenMessages.value = {
-			success: 0,
-			error: 0,
-		};
 	}
 
 	// Message handling functions
@@ -774,8 +756,10 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 			start_workflow_json: currentWorkflowJson,
 			workflow_id: workflowsStore.workflowId,
 			type,
-			manual_exec_success_count_since_prev_msg: manualExecStatsInBetweenMessages.value.success,
-			manual_exec_error_count_since_prev_msg: manualExecStatsInBetweenMessages.value.error,
+			manual_exec_success_count_since_prev_msg:
+				workflowExecutionStateStore.value.manualExecStatsInBetweenMessages.success,
+			manual_exec_error_count_since_prev_msg:
+				workflowExecutionStateStore.value.manualExecStatsInBetweenMessages.error,
 			user_message_id: userMessageId,
 			code_builder: isCodeBuilder.value,
 			mode,
@@ -986,7 +970,7 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 			mode: builderMode.value,
 		});
 
-		resetManualExecutionStats();
+		workflowExecutionStateStore.value.resetManualExecutionStats();
 
 		prepareForStreaming(
 			text,
@@ -1694,7 +1678,6 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 		versionCardMessages,
 		workflowTodos,
 		hasTodosHiddenByPinnedData,
-		hasHadSuccessfulExecution,
 		hasDeferredPinData,
 		hasGeneratedPinData,
 		pinDataApplied,
@@ -1722,8 +1705,6 @@ export const useBuilderStore = defineStore(STORES.BUILDER, () => {
 		getAiBuilderMadeEdits,
 		resetAiBuilderMadeEdits,
 		setBuilderMadeEdits,
-		incrementManualExecutionStats,
-		resetManualExecutionStats,
 		applyCodeDiff,
 		undoCodeDiff,
 		// Version management

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/ExecuteMessage.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/ExecuteMessage.test.ts
@@ -99,6 +99,7 @@ describe('ExecuteMessage', () => {
 	let logsStore: ReturnType<typeof mockedStore<typeof useLogsStore>>;
 	let uiStore: ReturnType<typeof mockedStore<typeof useUIStore>>;
 	let builderStore: ReturnType<typeof mockedStore<typeof useBuilderStore>>;
+	let workflowExecutionState: ReturnType<typeof useWorkflowExecutionStateStore>;
 	let renderExecuteMessage: () => ReturnType<ReturnType<typeof createComponentRenderer>>;
 
 	beforeEach(() => {
@@ -137,7 +138,7 @@ describe('ExecuteMessage', () => {
 		Object.defineProperty(workflowsStore, 'workflowExecutionData', {
 			get: () => workflowExecutionDataRef,
 		});
-		const workflowExecutionState = useWorkflowExecutionStateStore(
+		workflowExecutionState = useWorkflowExecutionStateStore(
 			createWorkflowDocumentId('test-workflow'),
 		);
 		Object.defineProperty(workflowExecutionState, 'executionWaitingForWebhook', {
@@ -529,7 +530,7 @@ describe('ExecuteMessage', () => {
 			Object.defineProperty(builderStore, 'hasDeferredPinData', { get: () => false });
 			Object.defineProperty(builderStore, 'pinDataApplied', { get: () => true });
 			Object.defineProperty(builderStore, 'isCodeBuilder', { get: () => true });
-			Object.defineProperty(builderStore, 'hasHadSuccessfulExecution', { get: () => true });
+			workflowExecutionState.markHasHadSuccessfulExecution();
 			Object.defineProperty(builderStore, 'hasTodosHiddenByPinnedData', { get: () => true });
 
 			const { queryByTestId, queryByText } = renderExecuteMessage();

--- a/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/ExecuteMessage.vue
+++ b/packages/frontend/editor-ui/src/features/ai/assistant/components/Agent/ExecuteMessage.vue
@@ -130,7 +130,7 @@ const showUnpinSection = computed(
 	() =>
 		(builderStore.isCodeBuilder || builderStore.pinDataApplied) &&
 		builderStore.hasTodosHiddenByPinnedData &&
-		builderStore.hasHadSuccessfulExecution,
+		workflowExecutionState.value.hasHadSuccessfulExecution,
 );
 
 const showFollowUps = computed(() => builderStore.hasDeferredPinData);


### PR DESCRIPTION
## Summary

Moves manual-execution stat tracking out of the global AI builder store and into the per-workflow `workflowExecutionState` store, so the tallies are scoped to a workflow document rather than shared session state. The `manualExecStatsInBetweenMessages` tally, the `hasHadSuccessfulExecution` flag, and their `increment`/`reset`/`mark` actions now live on `workflowExecutionState.store`, fire change events, and are cleared on `resetExecutionState`. The `executionFinished` handlers, `useWorkflowState`, the builder store telemetry, and `ExecuteMessage.vue` are updated to read/write through the new store. To test: run a manual execution while the AI builder is open and confirm the success/error counts reported between builder messages and the unpin section visibility behave as before.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Add Linear ticket URL here if applicable: https://linear.app/n8n/issue/[TICKET-ID] -->

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI