### PR TITLE
ci: Restore default build in grind-changed-tests workflow

### DIFF
--- a/.github/workflows/grind-changed-tests.yml
+++ b/.github/workflows/grind-changed-tests.yml
@@ -32,12 +32,6 @@ jobs:
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-nodejs
-        with:
-          # Build editor-ui's dependencies (e.g. @n8n/api-types) but not
-          # editor-ui itself — Vitest transforms editor-ui sources on the fly,
-          # while tsc-built deps must exist on disk for import resolution.
-          # Turbo cache makes this near-instant on subsequent runs.
-          build-command: 'pnpm --filter=n8n-editor-ui^... build'
 
       - name: Install .github/scripts dependencies
         run: pnpm install --frozen-lockfile --dir ./.github/scripts --ignore-workspace


### PR DESCRIPTION
## Summary

Restores the default `pnpm build` in the grind-changed-tests workflow. The custom `pnpm --filter=n8n-editor-ui^... build` build-command introduced in #31543 broke the workflow because the `--summarize` flag appended by `setup-nodejs` was forwarded into each filtered package's underlying `tsc` invocation (e.g. `@n8n/vitest-config`) and `tsc` exits non-zero on unknown flags. Falling back to the default `pnpm build` (which is `turbo run build`) keeps `--summarize` on turbo where it belongs.

[Example failing run](https://github.com/n8n-io/n8n/actions/runs/26818928332/job/79067910969?pr=31519):

```
/home/runner/_work/n8n/n8n/packages/@n8n/vitest-config:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @n8n/vitest-config@1.13.0 build: `tsc -p tsconfig.build.json --summarize`
Exit status 1
```

## Test plan
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] Verify the workflow run on this PR completes the `Setup Node.js` step without `ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL`
- [ ] Confirm the grind step still produces a comment on a PR that touches an editor-ui `*.test.ts` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)