### PR TITLE
feat(core): Add telemetry for data redaction enforcement instance policy (no-changelog)

### DIFF
--- a/packages/@n8n/utils/src/index.ts
+++ b/packages/@n8n/utils/src/index.ts
@@ -13,3 +13,4 @@ export * from './files/path';
 export * from './placeholder';
 export * from './jwt';
 export * from './scrub-secrets';
+export * from './types';

--- a/packages/@n8n/utils/src/index.ts
+++ b/packages/@n8n/utils/src/index.ts
@@ -13,4 +13,4 @@ export * from './files/path';
 export * from './placeholder';
 export * from './jwt';
 export * from './scrub-secrets';
-export * from './types';
+export type * from './types';

--- a/packages/@n8n/utils/src/types.ts
+++ b/packages/@n8n/utils/src/types.ts
@@ -1,0 +1,14 @@
+/**
+ * Like `Omit`, but distributes over union members so each branch keeps its own
+ * shape. Plain `Omit<A | B, K>` collapses the union into a single object type and
+ * loses the discriminant correlation; `DistributiveOmit` preserves `A | B`.
+ *
+ * @example
+ * type Event =
+ *   | { kind: 'a'; value: boolean }
+ *   | { kind: 'b'; value: string };
+ *
+ * // { kind: 'a'; value: boolean } | { kind: 'b'; value: string }
+ * type WithoutKind = DistributiveOmit<Event, never>;
+ */
+export type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;

--- a/packages/cli/src/controllers/__tests__/security-settings.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/security-settings.controller.test.ts
@@ -1,0 +1,129 @@
+import type { UpdateSecuritySettingsDto } from '@n8n/api-types';
+import type { InstanceSettingsLoaderConfig } from '@n8n/config';
+import type { AuthenticatedRequest } from '@n8n/db';
+import { mock } from 'jest-mock-extended';
+
+import type { EventService } from '@/events/event.service';
+import type { InstanceRedactionEnforcementService } from '@/modules/redaction/instance-redaction-enforcement.service';
+import { N8N_ENV_FEAT_REDACTION_ENFORCEMENT } from '@/modules/redaction/redaction-enforcement.feature-flag';
+import type { SecuritySettingsService } from '@/services/security-settings.service';
+
+import { SecuritySettingsController } from '../security-settings.controller';
+
+describe('SecuritySettingsController', () => {
+	const securitySettingsService = mock<SecuritySettingsService>();
+	const eventService = mock<EventService>();
+	const instanceSettingsLoaderConfig = mock<InstanceSettingsLoaderConfig>({
+		securityPolicyManagedByEnv: false,
+	});
+	const instanceRedactionEnforcementService = mock<InstanceRedactionEnforcementService>();
+
+	const controller = new SecuritySettingsController(
+		securitySettingsService,
+		eventService,
+		instanceSettingsLoaderConfig,
+		instanceRedactionEnforcementService,
+	);
+
+	const req = mock<AuthenticatedRequest>({
+		user: { id: 'user-1', email: 'admin@n8n.io', firstName: 'Admin', lastName: 'User' },
+	});
+
+	const flagBefore = process.env[N8N_ENV_FEAT_REDACTION_ENFORCEMENT];
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		process.env[N8N_ENV_FEAT_REDACTION_ENFORCEMENT] = 'true';
+	});
+
+	afterAll(() => {
+		if (flagBefore === undefined) {
+			delete process.env[N8N_ENV_FEAT_REDACTION_ENFORCEMENT];
+		} else {
+			process.env[N8N_ENV_FEAT_REDACTION_ENFORCEMENT] = flagBefore;
+		}
+	});
+
+	const redactionPolicyEvents = () =>
+		eventService.emit.mock.calls.filter(
+			([name, payload]) =>
+				name === 'instance-policies-updated' &&
+				typeof payload === 'object' &&
+				payload !== null &&
+				'settingName' in payload &&
+				String(payload.settingName).startsWith('data_redaction'),
+		);
+
+	const dto = (floor: 'off' | 'production' | 'all') =>
+		({ redactionEnforcement: { floor } }) as UpdateSecuritySettingsDto;
+
+	describe('updateSecuritySettings — redaction telemetry', () => {
+		it('emits the redaction floor when enforcement is enabled', async () => {
+			instanceRedactionEnforcementService.get.mockResolvedValue('off');
+
+			await controller.updateSecuritySettings(req, mock(), dto('all'));
+
+			expect(instanceRedactionEnforcementService.set).toHaveBeenCalledWith('all');
+			expect(eventService.emit).toHaveBeenCalledWith(
+				'redaction-enforcement-updated',
+				expect.anything(),
+			);
+			expect(redactionPolicyEvents()).toEqual([
+				[
+					'instance-policies-updated',
+					expect.objectContaining({
+						settingName: 'data_redaction_enforcement_floor',
+						value: 'all',
+					}),
+				],
+			]);
+		});
+
+		it('reports the production-only floor as `production`', async () => {
+			instanceRedactionEnforcementService.get.mockResolvedValue('off');
+
+			await controller.updateSecuritySettings(req, mock(), dto('production'));
+
+			expect(instanceRedactionEnforcementService.set).toHaveBeenCalledWith('production');
+			expect(redactionPolicyEvents().map(([, payload]) => payload)).toEqual([
+				expect.objectContaining({
+					settingName: 'data_redaction_enforcement_floor',
+					value: 'production',
+				}),
+			]);
+		});
+
+		it('reports `off` when enforcement is disabled', async () => {
+			instanceRedactionEnforcementService.get.mockResolvedValue('production');
+
+			await controller.updateSecuritySettings(req, mock(), dto('off'));
+
+			expect(instanceRedactionEnforcementService.set).toHaveBeenCalledWith('off');
+			expect(redactionPolicyEvents().map(([, payload]) => payload)).toEqual([
+				expect.objectContaining({
+					settingName: 'data_redaction_enforcement_floor',
+					value: 'off',
+				}),
+			]);
+		});
+
+		it('emits nothing when the floor is unchanged', async () => {
+			instanceRedactionEnforcementService.get.mockResolvedValue('production');
+
+			await controller.updateSecuritySettings(req, mock(), dto('production'));
+
+			expect(instanceRedactionEnforcementService.set).not.toHaveBeenCalled();
+			expect(redactionPolicyEvents()).toHaveLength(0);
+		});
+
+		it('ignores redaction settings when the feature flag is disabled', async () => {
+			process.env[N8N_ENV_FEAT_REDACTION_ENFORCEMENT] = 'false';
+
+			await controller.updateSecuritySettings(req, mock(), dto('all'));
+
+			expect(instanceRedactionEnforcementService.get).not.toHaveBeenCalled();
+			expect(instanceRedactionEnforcementService.set).not.toHaveBeenCalled();
+			expect(redactionPolicyEvents()).toHaveLength(0);
+		});
+	});
+});

--- a/packages/cli/src/controllers/security-settings.controller.ts
+++ b/packages/cli/src/controllers/security-settings.controller.ts
@@ -10,6 +10,7 @@ import type { Response } from 'express';
 
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { EventService } from '@/events/event.service';
+import type { RelayEventMap } from '@/events/maps/relay.event-map';
 import { InstanceRedactionEnforcementService } from '@/modules/redaction/instance-redaction-enforcement.service';
 import { isRedactionEnforcementEnabled } from '@/modules/redaction/redaction-enforcement.feature-flag';
 import { SecuritySettingsService } from '@/services/security-settings.service';
@@ -106,6 +107,10 @@ export class SecuritySettingsController {
 					before,
 					after,
 				});
+				// Report the redaction enforcement floor alongside the other instance
+				// policies. `'off' | 'production' | 'all'` captures both adoption
+				// (off vs not) and scope (production vs production+manual).
+				this.emitInstancePolicyUpdated(req, 'data_redaction_enforcement_floor', after);
 			}
 		}
 
@@ -114,8 +119,8 @@ export class SecuritySettingsController {
 
 	private emitInstancePolicyUpdated(
 		req: AuthenticatedRequest,
-		settingName: '2fa_enforcement' | 'workflow_publishing' | 'workflow_sharing',
-		value: boolean,
+		settingName: RelayEventMap['instance-policies-updated']['settingName'],
+		value: RelayEventMap['instance-policies-updated']['value'],
 	) {
 		this.eventService.emit('instance-policies-updated', {
 			user: {

--- a/packages/cli/src/controllers/security-settings.controller.ts
+++ b/packages/cli/src/controllers/security-settings.controller.ts
@@ -6,6 +6,7 @@ import {
 	PERSONAL_SPACE_PUBLISHING_SETTING,
 	PERSONAL_SPACE_SHARING_SETTING,
 } from '@n8n/permissions';
+import type { DistributiveOmit } from '@n8n/utils';
 import type { Response } from 'express';
 
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
@@ -14,9 +15,6 @@ import type { RelayEventMap } from '@/events/maps/relay.event-map';
 import { InstanceRedactionEnforcementService } from '@/modules/redaction/instance-redaction-enforcement.service';
 import { isRedactionEnforcementEnabled } from '@/modules/redaction/redaction-enforcement.feature-flag';
 import { SecuritySettingsService } from '@/services/security-settings.service';
-
-/** Distributes `Omit` over a union so each member is narrowed independently. */
-type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;
 
 /**
  * The `instance-policies-updated` payload without the `user` envelope. Kept as a

--- a/packages/cli/src/controllers/security-settings.controller.ts
+++ b/packages/cli/src/controllers/security-settings.controller.ts
@@ -15,6 +15,16 @@ import { InstanceRedactionEnforcementService } from '@/modules/redaction/instanc
 import { isRedactionEnforcementEnabled } from '@/modules/redaction/redaction-enforcement.feature-flag';
 import { SecuritySettingsService } from '@/services/security-settings.service';
 
+/** Distributes `Omit` over a union so each member is narrowed independently. */
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;
+
+/**
+ * The `instance-policies-updated` payload without the `user` envelope. Kept as a
+ * distributed union so each `settingName` stays bound to its own `value` type
+ * (boolean settings cannot be emitted with a redaction floor, and vice versa).
+ */
+type InstancePolicyUpdate = DistributiveOmit<RelayEventMap['instance-policies-updated'], 'user'>;
+
 @RestController('/settings/security')
 export class SecuritySettingsController {
 	constructor(
@@ -79,7 +89,10 @@ export class SecuritySettingsController {
 				dto.personalSpacePublishing,
 			);
 			updatedSettings.personalSpacePublishing = dto.personalSpacePublishing;
-			this.emitInstancePolicyUpdated(req, 'workflow_publishing', dto.personalSpacePublishing);
+			this.emitInstancePolicyUpdated(req, {
+				settingName: 'workflow_publishing',
+				value: dto.personalSpacePublishing,
+			});
 		}
 		if (dto.personalSpaceSharing !== undefined) {
 			await this.securitySettingsService.setPersonalSpaceSetting(
@@ -87,7 +100,10 @@ export class SecuritySettingsController {
 				dto.personalSpaceSharing,
 			);
 			updatedSettings.personalSpaceSharing = dto.personalSpaceSharing;
-			this.emitInstancePolicyUpdated(req, 'workflow_sharing', dto.personalSpaceSharing);
+			this.emitInstancePolicyUpdated(req, {
+				settingName: 'workflow_sharing',
+				value: dto.personalSpaceSharing,
+			});
 		}
 
 		if (dto.redactionEnforcement !== undefined && isRedactionEnforcementEnabled()) {
@@ -110,18 +126,17 @@ export class SecuritySettingsController {
 				// Report the redaction enforcement floor alongside the other instance
 				// policies. `'off' | 'production' | 'all'` captures both adoption
 				// (off vs not) and scope (production vs production+manual).
-				this.emitInstancePolicyUpdated(req, 'data_redaction_enforcement_floor', after);
+				this.emitInstancePolicyUpdated(req, {
+					settingName: 'data_redaction_enforcement_floor',
+					value: after,
+				});
 			}
 		}
 
 		return updatedSettings;
 	}
 
-	private emitInstancePolicyUpdated(
-		req: AuthenticatedRequest,
-		settingName: RelayEventMap['instance-policies-updated']['settingName'],
-		value: RelayEventMap['instance-policies-updated']['value'],
-	) {
+	private emitInstancePolicyUpdated(req: AuthenticatedRequest, update: InstancePolicyUpdate) {
 		this.eventService.emit('instance-policies-updated', {
 			user: {
 				id: req.user.id,
@@ -130,8 +145,7 @@ export class SecuritySettingsController {
 				lastName: req.user.lastName,
 				role: req.user.role,
 			},
-			settingName,
-			value,
+			...update,
 		});
 	}
 }

--- a/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/log-streaming-event-relay.test.ts
@@ -2656,6 +2656,24 @@ describe('LogStreamingEventRelay', () => {
 				},
 			});
 		});
+
+		it('does not emit an audit event for data_redaction_enforcement_floor (telemetry-only; audit is handled by redaction-enforcement-updated)', () => {
+			const event: RelayEventMap['instance-policies-updated'] = {
+				user: {
+					id: 'user404',
+					email: 'admin7@example.com',
+					firstName: 'Seventh',
+					lastName: 'Admin',
+					role: { slug: 'global:admin' },
+				},
+				settingName: 'data_redaction_enforcement_floor',
+				value: 'all',
+			};
+
+			eventService.emit('instance-policies-updated', event);
+
+			expect(eventBus.sendAuditEvent).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('redaction enforcement events', () => {

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -1,6 +1,5 @@
-import type { NodeTypes } from '@/node-types';
-import { mockInstance } from '@n8n/backend-test-utils';
 import type { LicenseState } from '@n8n/backend-common';
+import { mockInstance } from '@n8n/backend-test-utils';
 import type { GlobalConfig } from '@n8n/config';
 import {
 	type CredentialsEntity,
@@ -32,6 +31,7 @@ import type { RelayEventMap } from '@/events/maps/relay.event-map';
 import { TelemetryEventRelay, getSemanticVersioning } from '@/events/relays/telemetry.event-relay';
 import type { License } from '@/license';
 import { OtelConfig } from '@/modules/otel/otel.config';
+import type { NodeTypes } from '@/node-types';
 import type { Telemetry } from '@/telemetry';
 
 const flushPromises = async () => await new Promise((resolve) => setImmediate(resolve));
@@ -2971,6 +2971,21 @@ describe('TelemetryEventRelay', () => {
 			expect(telemetry.track).toHaveBeenCalledWith('User updated instance policies', {
 				user_id: 'user456',
 				'2fa_enforcement': false,
+			});
+		});
+
+		it('should track data_redaction_enforcement_floor update', () => {
+			const event: RelayEventMap['instance-policies-updated'] = {
+				user: { id: 'user-redaction' },
+				settingName: 'data_redaction_enforcement_floor',
+				value: 'all',
+			};
+
+			eventService.emit('instance-policies-updated', event);
+
+			expect(telemetry.track).toHaveBeenCalledWith('User updated instance policies', {
+				user_id: 'user-redaction',
+				data_redaction_enforcement_floor: 'all',
 			});
 		});
 	});

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -978,15 +978,16 @@ export type RelayEventMap = {
 
 	// #region Instance Policies
 
-	'instance-policies-updated': {
-		user: UserLike;
-		settingName:
-			| '2fa_enforcement'
-			| 'workflow_publishing'
-			| 'workflow_sharing'
-			| 'data_redaction_enforcement_floor';
-		value: boolean | RedactionFloor;
-	};
+	'instance-policies-updated': { user: UserLike } & (
+		| {
+				settingName: '2fa_enforcement' | 'workflow_publishing' | 'workflow_sharing';
+				value: boolean;
+		  }
+		| {
+				settingName: 'data_redaction_enforcement_floor';
+				value: RedactionFloor;
+		  }
+	);
 
 	'redaction-enforcement-updated': {
 		user: UserLike;

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -980,8 +980,12 @@ export type RelayEventMap = {
 
 	'instance-policies-updated': {
 		user: UserLike;
-		settingName: '2fa_enforcement' | 'workflow_publishing' | 'workflow_sharing';
-		value: boolean;
+		settingName:
+			| '2fa_enforcement'
+			| 'workflow_publishing'
+			| 'workflow_sharing'
+			| 'data_redaction_enforcement_floor';
+		value: boolean | RedactionFloor;
 	};
 
 	'redaction-enforcement-updated': {

--- a/packages/cli/src/events/relays/log-streaming.event-relay.ts
+++ b/packages/cli/src/events/relays/log-streaming.event-relay.ts
@@ -1053,6 +1053,10 @@ export class LogStreamingEventRelay extends EventRelay {
 					payload: user,
 				});
 				break;
+			case 'data_redaction_enforcement_floor':
+				// Telemetry-only signal. The audit trail for redaction enforcement
+				// is emitted separately via 'redaction-enforcement-updated'.
+				break;
 			default:
 				assertNever(settingName);
 		}


### PR DESCRIPTION
## Summary

Adds the data redaction enforcement policy to the existing `User updated instance policies` telemetry event, alongside the policies it already reports (2FA enforcement, workflow publishing, sharing).

A single field is sent from the security settings update handler (`POST /rest/settings/security`) when the enforcement floor changes:

- `data_redaction_enforcement_floor`: `'off' | 'production' | 'all'`

This mirrors the `RedactionFloor` model established by #31504, and captures both adoption and scope in one field:

| floor | meaning |
| --- | --- |
| `off` | enforcement disabled |
| `production` | production executions |
| `all` | manual and production executions |

The field follows the existing per-setting emit pattern and fires only when the floor actually changes.

### How to test

- Unit tests: `cd packages/cli && pnpm test security-settings.controller telemetry-event-relay`
- Manually (needs `N8N_ENV_FEAT_REDACTION_ENFORCEMENT=true` and `feat:personalSpacePolicy` licensed): change the Data redaction floor in Settings > Security & Policies and save. The event fires with `data_redaction_enforcement_floor` set to the new floor.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-22

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI