### PR TITLE
fix(Schedule Node): Run non-dividing minute intervals by elapsed time

### DIFF
--- a/packages/nodes-base/nodes/Schedule/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Schedule/GenericFunctions.ts
@@ -52,7 +52,13 @@ export function recurrenceCheck(
 	const lastExecution = recurrenceRules[index];
 
 	const momentTz = moment.tz(timezone);
-	if (typeInterval === 'hours') {
+	if (typeInterval === 'minutes') {
+		const minute = momentTz.minute();
+		if (lastExecution === undefined || (minute - lastExecution + 60) % 60 >= intervalSize) {
+			recurrenceRules[index] = minute;
+			return true;
+		}
+	} else if (typeInterval === 'hours') {
 		const hour = momentTz.hour();
 		if (lastExecution === undefined || (hour - lastExecution + 24) % 24 >= intervalSize) {
 			recurrenceRules[index] = hour;
@@ -112,7 +118,11 @@ export const toCronExpression = (interval: ScheduleInterval, nodeKey: string): C
 	if (interval.field === 'seconds') return `*/${interval.secondsInterval} * * * * *`;
 
 	const second = stableInt(nodeKey, 'second', 0, 60);
-	if (interval.field === 'minutes') return `${second} */${interval.minutesInterval} * * * *`;
+	if (interval.field === 'minutes') {
+		const minutes = interval.minutesInterval;
+		if (60 % minutes === 0) return `${second} */${minutes} * * * *`;
+		return `${second} * * * * *`;
+	}
 
 	const minute = interval.triggerAtMinute ?? stableInt(nodeKey, 'minute', 0, 60);
 	if (interval.field === 'hours') {
@@ -141,6 +151,18 @@ export const toCronExpression = (interval: ScheduleInterval, nodeKey: string): C
 
 export function intervalToRecurrence(interval: ScheduleInterval, index: number) {
 	let recurrence: IRecurrenceRule = { activated: false };
+
+	if (interval.field === 'minutes') {
+		const { minutesInterval } = interval;
+		if (60 % minutesInterval !== 0) {
+			recurrence = {
+				activated: true,
+				index,
+				intervalSize: minutesInterval,
+				typeInterval: 'minutes',
+			};
+		}
+	}
 
 	if (interval.field === 'hours') {
 		const { hoursInterval } = interval;

--- a/packages/nodes-base/nodes/Schedule/SchedulerInterface.ts
+++ b/packages/nodes-base/nodes/Schedule/SchedulerInterface.ts
@@ -6,7 +6,7 @@ export type IRecurrenceRule =
 			activated: true;
 			index: number;
 			intervalSize: number;
-			typeInterval: 'hours' | 'days' | 'weeks' | 'months';
+			typeInterval: 'minutes' | 'hours' | 'days' | 'weeks' | 'months';
 	  };
 
 export type ScheduleInterval =

--- a/packages/nodes-base/nodes/Schedule/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Schedule/test/GenericFunctions.test.ts
@@ -13,12 +13,14 @@ jest.mock('moment-timezone');
 const mockedMoment = jest.mocked(moment);
 
 function mockMomentTz(values: {
+	minute?: number;
 	hour?: number;
 	dayOfYear?: number;
 	week?: number;
 	month?: number;
 }) {
 	const tzObj = {
+		minute: () => values.minute ?? 0,
 		hour: () => values.hour ?? 0,
 		dayOfYear: () => values.dayOfYear ?? 1,
 		week: () => values.week ?? 1,
@@ -71,6 +73,15 @@ describe('toCronExpression', () => {
 			TEST_SEED,
 		);
 		expect(result).toEqual('56 */30 * * * *');
+
+		const result1 = toCronExpression(
+			{
+				field: 'minutes',
+				minutesInterval: 50,
+			},
+			TEST_SEED,
+		);
+		expect(result1).toEqual('56 * * * * *');
 	});
 
 	it('should return cron expression for hours interval', () => {
@@ -291,6 +302,43 @@ describe('recurrenceCheck', () => {
 			'UTC',
 		);
 		expect(result).toBe(false);
+	});
+
+	describe('minutes', () => {
+		it('should trigger when exactly on time', () => {
+			mockMomentTz({ minute: 40 });
+			const recurrenceRules = [50]; // lastExecution = minute 50, interval = 50
+			const result = recurrenceCheck(
+				{ activated: true, index: 0, intervalSize: 50, typeInterval: 'minutes' },
+				recurrenceRules,
+				'UTC',
+			);
+			expect(result).toBe(true);
+			expect(recurrenceRules[0]).toBe(40);
+		});
+
+		it('should not trigger before interval has elapsed', () => {
+			mockMomentTz({ minute: 0 });
+			const recurrenceRules = [50]; // only 10 minutes elapsed, need 50
+			const result = recurrenceCheck(
+				{ activated: true, index: 0, intervalSize: 50, typeInterval: 'minutes' },
+				recurrenceRules,
+				'UTC',
+			);
+			expect(result).toBe(false);
+		});
+
+		it('should recover after a missed execution', () => {
+			mockMomentTz({ minute: 45 });
+			const recurrenceRules = [50]; // missed minute 40, now at minute 45
+			const result = recurrenceCheck(
+				{ activated: true, index: 0, intervalSize: 50, typeInterval: 'minutes' },
+				recurrenceRules,
+				'UTC',
+			);
+			expect(result).toBe(true);
+			expect(recurrenceRules[0]).toBe(45);
+		});
 	});
 
 	describe('hours', () => {
@@ -580,6 +628,20 @@ describe('intervalToRecurrence', () => {
 			1,
 		);
 		expect(result.activated).toBe(false);
+
+		const result1 = intervalToRecurrence(
+			{
+				field: 'minutes',
+				minutesInterval: 50,
+			},
+			1,
+		);
+		expect(result1).toEqual({
+			activated: true,
+			index: 1,
+			intervalSize: 50,
+			typeInterval: 'minutes',
+		});
 	});
 
 	it('should return recurrence rule for hours interval', () => {

--- a/packages/nodes-base/nodes/Schedule/test/ScheduleTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Schedule/test/ScheduleTrigger.node.test.ts
@@ -7,6 +7,7 @@ import { testTriggerNode } from '@test/nodes/TriggerHelpers';
 import { ScheduleTrigger } from '../ScheduleTrigger.node';
 
 describe('ScheduleTrigger', () => {
+	const MINUTE = 60 * 1000;
 	const HOUR = 60 * 60 * 1000;
 	const mockDate = new Date('2023-12-28 12:34:56.789Z');
 	const timezone = 'Europe/Berlin';
@@ -84,6 +85,27 @@ describe('ScheduleTrigger', () => {
 
 			jest.advanceTimersByTime(HOUR);
 			expect(emit).toHaveBeenCalledTimes(3);
+		});
+
+		it('should emit every 50 elapsed minutes instead of clock-aligned minute slots', async () => {
+			jest.setSystemTime(new Date('2023-12-28 12:49:56.789Z'));
+
+			const { emit } = await testTriggerNode(ScheduleTrigger, {
+				timezone,
+				node: { parameters: { rule: { interval: [{ field: 'minutes', minutesInterval: 50 }] } } },
+				workflowStaticData: { recurrenceRules: [] },
+			});
+
+			expect(emit).not.toHaveBeenCalled();
+
+			jest.advanceTimersByTime(MINUTE);
+			expect(emit).toHaveBeenCalledTimes(1);
+
+			jest.advanceTimersByTime(10 * MINUTE);
+			expect(emit).toHaveBeenCalledTimes(1);
+
+			jest.advanceTimersByTime(40 * MINUTE);
+			expect(emit).toHaveBeenCalledTimes(2);
 		});
 
 		it('should emit every 18 hours when triggerAtMinute is explicitly set to 0', async () => {


### PR DESCRIPTION
## Summary

Fix Schedule Trigger minute intervals that do not divide evenly into 60 so they run by elapsed time instead of clock-aligned minute slots.

For intervals like 50 minutes, the node now registers a once-per-minute cron and uses recurrence filtering to avoid firing again after only 10 elapsed minutes. Intervals that divide evenly into 60 keep the existing efficient cron expression.

Tested with:

```bash
pnpm test nodes/Schedule/test/GenericFunctions.test.ts nodes/Schedule/test/ScheduleTrigger.node.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

[CAT-3748](https://linear.app/n8n/issue/CAT-3748)

fixes [#30735](<https://github.com/n8n-io/n8n/issues/30735>)

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](<../blob/master/.github/pull_request_title_conventions.md>))
- [ ] [Docs updated](<https://github.com/n8n-io/n8n-docs>) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

Made with [Cursor](<https://cursor.com>)