### PR TITLE
refactor(core): Rename N8N_OTEL_TRACES_PUBLISHED_ONLY env var to N8N_OTEL_TRACES_PRODUCTION_ONLY

### DIFF
--- a/packages/cli/src/modules/otel/__tests__/otel-lifecycle-handler.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/otel-lifecycle-handler.test.ts
@@ -75,7 +75,7 @@ describe('OtelLifecycleHandler', () => {
 
 		beforeEach(() => {
 			jest.clearAllMocks();
-			config = makeOtelConfig({ publishedOnly: false });
+			config = makeOtelConfig({ productionExecutionsOnly: false });
 			handler = new OtelLifecycleHandler(
 				tracer,
 				traceContextService,
@@ -321,7 +321,7 @@ describe('OtelLifecycleHandler', () => {
 
 		beforeEach(() => {
 			jest.clearAllMocks();
-			config = makeOtelConfig({ publishedOnly: false });
+			config = makeOtelConfig({ productionExecutionsOnly: false });
 			handler = new OtelLifecycleHandler(
 				tracer,
 				traceContextService,
@@ -437,7 +437,7 @@ describe('OtelLifecycleHandler', () => {
 
 		beforeEach(() => {
 			jest.clearAllMocks();
-			config = makeOtelConfig({ publishedOnly: false });
+			config = makeOtelConfig({ productionExecutionsOnly: false });
 			handler = new OtelLifecycleHandler(
 				tracer,
 				traceContextService,
@@ -542,7 +542,7 @@ describe('OtelLifecycleHandler', () => {
 
 		beforeEach(() => {
 			jest.clearAllMocks();
-			config = makeOtelConfig({ publishedOnly: false, includeNodeSpans: true });
+			config = makeOtelConfig({ productionExecutionsOnly: false, includeNodeSpans: true });
 			handler = new OtelLifecycleHandler(
 				tracer,
 				traceContextService,
@@ -636,7 +636,7 @@ describe('OtelLifecycleHandler', () => {
 	});
 });
 
-describe('publishedOnly filter', () => {
+describe('productionExecutionsOnly filter', () => {
 	const tracer = mock<ExecutionLevelTracer>();
 	const traceContextService = mock<TraceContextService>();
 	let config = makeOtelConfig();
@@ -705,7 +705,7 @@ describe('publishedOnly filter', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
-		config = makeOtelConfig({ publishedOnly: true, includeNodeSpans: true });
+		config = makeOtelConfig({ productionExecutionsOnly: true, includeNodeSpans: true });
 		ownershipService.getWorkflowProjectCached.mockResolvedValue({ id: 'proj-1' } as never);
 		traceContextService.get.mockResolvedValue(undefined);
 		handler = new OtelLifecycleHandler(
@@ -717,7 +717,7 @@ describe('publishedOnly filter', () => {
 		);
 	});
 
-	it('should skip all tracing for an inactive workflow when publishedOnly is true', async () => {
+	it('should skip all tracing for an inactive workflow when productionExecutionsOnly is true', async () => {
 		await handler.onWorkflowStart(makeWorkflowStartCtx(inactiveWorkflow));
 		handler.onWorkflowEnd(makeWorkflowEndCtx(inactiveWorkflow));
 		handler.onNodeStart(makeNodeStartCtx(inactiveWorkflow));
@@ -730,7 +730,7 @@ describe('publishedOnly filter', () => {
 		expect(tracer.endNode).not.toHaveBeenCalled();
 	});
 
-	it('should trace an active workflow when publishedOnly is true', async () => {
+	it('should trace an active workflow when productionExecutionsOnly is true', async () => {
 		tracer.startWorkflow.mockReturnValue({ traceparent: '00-abc-def-01' });
 
 		await handler.onWorkflowStart(makeWorkflowStartCtx(activeWorkflow));
@@ -739,8 +739,8 @@ describe('publishedOnly filter', () => {
 		expect(traceContextService.persist).toHaveBeenCalled();
 	});
 
-	it('should trace an inactive workflow when publishedOnly is false', async () => {
-		config.publishedOnly = false;
+	it('should trace an inactive workflow when productionExecutionsOnly is false', async () => {
+		config.productionExecutionsOnly = false;
 		tracer.startWorkflow.mockReturnValue({ traceparent: '00-abc-def-01' });
 
 		await handler.onWorkflowStart(makeWorkflowStartCtx(inactiveWorkflow));

--- a/packages/cli/src/modules/otel/__tests__/otel-workflow-tracing.integration.test.ts
+++ b/packages/cli/src/modules/otel/__tests__/otel-workflow-tracing.integration.test.ts
@@ -30,7 +30,7 @@ beforeAll(async () => {
 	savedEnv = saveAndSetEnv({
 		N8N_OTEL_ENABLED: 'true',
 		N8N_OTEL_TRACES_INCLUDE_NODE_SPANS: 'true',
-		N8N_OTEL_TRACES_PUBLISHED_ONLY: 'false',
+		N8N_OTEL_TRACES_PRODUCTION_ONLY: 'false',
 	});
 	const env = await initOtelTestEnvironment();
 	otel = env.otel;

--- a/packages/cli/src/modules/otel/otel-lifecycle-handler.ts
+++ b/packages/cli/src/modules/otel/otel-lifecycle-handler.ts
@@ -51,7 +51,7 @@ export class OtelLifecycleHandler {
 
 	@OnLifecycleEvent('workflowExecuteBefore')
 	async onWorkflowStart(ctx: WorkflowExecuteBeforeContext): Promise<void> {
-		if (this.config.publishedOnly && !this.isPublishedWorkflow(ctx.workflow)) return;
+		if (this.config.productionExecutionsOnly && !this.isPublishedWorkflow(ctx.workflow)) return;
 
 		const parentExecutionId = ctx.executionData?.parentExecution?.executionId;
 		const tracingContext = parentExecutionId
@@ -96,7 +96,7 @@ export class OtelLifecycleHandler {
 
 	@OnLifecycleEvent('workflowExecuteResume')
 	async onWorkflowResume(ctx: WorkflowExecuteResumeContext): Promise<void> {
-		if (this.config.publishedOnly && !this.isPublishedWorkflow(ctx.workflow)) return;
+		if (this.config.productionExecutionsOnly && !this.isPublishedWorkflow(ctx.workflow)) return;
 
 		const previousWorkflowExecution = await this.traceContextService.get(ctx.executionId);
 
@@ -132,7 +132,7 @@ export class OtelLifecycleHandler {
 
 	@OnLifecycleEvent('workflowExecuteAfter')
 	onWorkflowEnd(ctx: WorkflowExecuteAfterContext): void {
-		if (this.config.publishedOnly && !this.isPublishedWorkflow(ctx.workflow)) return;
+		if (this.config.productionExecutionsOnly && !this.isPublishedWorkflow(ctx.workflow)) return;
 
 		this.tracer.endWorkflow({
 			executionId: ctx.executionId,
@@ -146,7 +146,7 @@ export class OtelLifecycleHandler {
 
 	@OnLifecycleEvent('nodeExecuteBefore')
 	onNodeStart(ctx: NodeExecuteBeforeContext): void {
-		if (this.config.publishedOnly && !this.isPublishedWorkflow(ctx.workflow)) return;
+		if (this.config.productionExecutionsOnly && !this.isPublishedWorkflow(ctx.workflow)) return;
 		if (!this.config.includeNodeSpans) return;
 
 		const node = ctx.workflow.nodes.find((n) => n.name === ctx.nodeName);
@@ -160,7 +160,7 @@ export class OtelLifecycleHandler {
 
 	@OnLifecycleEvent('nodeExecuteAfter')
 	onNodeEnd(ctx: NodeExecuteAfterContext): void {
-		if (this.config.publishedOnly && !this.isPublishedWorkflow(ctx.workflow)) return;
+		if (this.config.productionExecutionsOnly && !this.isPublishedWorkflow(ctx.workflow)) return;
 		if (!this.config.includeNodeSpans) return;
 
 		const node = ctx.workflow.nodes.find((n) => n.name === ctx.nodeName);

--- a/packages/cli/src/modules/otel/otel.config.ts
+++ b/packages/cli/src/modules/otel/otel.config.ts
@@ -29,7 +29,7 @@ export class OtelConfig {
 	@Env('N8N_OTEL_TRACES_INJECT_OUTBOUND')
 	injectOutbound: boolean = true;
 
-	/** When true, only traces executions of published (active) workflows. */
-	@Env('N8N_OTEL_TRACES_PUBLISHED_ONLY')
-	publishedOnly: boolean = true;
+	/** When true, only traces production executions of published (active) workflows, not manual/test runs. */
+	@Env('N8N_OTEL_TRACES_PRODUCTION_ONLY')
+	productionExecutionsOnly: boolean = true;
 }


### PR DESCRIPTION
## Summary

Renames the OpenTelemetry env var `N8N_OTEL_TRACES_PUBLISHED_ONLY` to `N8N_OTEL_TRACES_PRODUCTION_ONLY` to make its intent clearer.

The variable controls whether OTEL traces are emitted **only for production executions of published (active) workflows**, skipping manual/test runs. The previous name (`PUBLISHED_ONLY`) was ambiguous about the run-type semantics; `PRODUCTION_ONLY` aligns with how we describe executions in our docs ([Manual, partial, and production executions](https://docs.n8n.io/workflows/executions/manual-partial-and-production-executions/)).

This is a pure rename — **no behavior change**. Internally the config field is renamed `publishedOnly` → `productionExecutionsOnly`; the underlying `isPublishedWorkflow` check is unchanged.

> [!WARNING]
> **Breaking change.** `N8N_OTEL_TRACES_PUBLISHED_ONLY` was introduced in `n8n@2.24.0` and is removed (no alias). Instances that set the old variable must update to `N8N_OTEL_TRACES_PRODUCTION_ONLY`. Default remains `true`, so instances that never set it are unaffected.

### How to test

- `pnpm --filter n8n test src/modules/otel` — all OTEL suites pass (92 tests).
- Set `N8N_OTEL_TRACES_PRODUCTION_ONLY=false` and confirm manual runs of inactive workflows are traced.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-665

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI