### PR TITLE
fix(ai-builder): Pass the build prompt to prebuilt-workflow eval checks (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/cli/build-mcp-manifest.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/build-mcp-manifest.ts
@@ -12,6 +12,7 @@ import { z } from 'zod';
 
 import { prebuiltManifestSchema, type PrebuiltManifest } from '../harness/prebuilt-workflows';
 import { runWithConcurrency } from '../harness/runner';
+import { buildPromptFromConversation } from '../utils/build-prompt';
 
 // ---------------------------------------------------------------------------
 // CLI argument parsing
@@ -363,26 +364,6 @@ const testCaseSchema = z
 		conversation: z.array(z.object({ role: z.string(), text: z.string() })).min(1),
 	})
 	.passthrough();
-
-function buildPromptFromConversation(
-	conversation: z.infer<typeof testCaseSchema>['conversation'],
-): string {
-	const [firstUserTurn, ...remainingUserTurns] = conversation
-		.filter((turn) => turn.role === 'user')
-		.map((turn) => turn.text.trim())
-		.filter((text) => text.length > 0);
-
-	if (!firstUserTurn) return conversation[0].text;
-	if (remainingUserTurns.length === 0) return firstUserTurn;
-
-	return [
-		firstUserTurn,
-		'Additional details from the user:',
-		...remainingUserTurns.map((turn, index) => `${String(index + 1)}. ${turn}`),
-		'',
-		"Use all details above as requirements. Configure all nodes as completely as possible and don't ask me for credentials; I'll set them up later.",
-	].join('\n\n');
-}
 
 function tailWorkflowId(text: string): string | null {
 	const matches = [...text.matchAll(/WORKFLOW_ID=([A-Za-z0-9_-]+)/g)];

--- a/packages/@n8n/instance-ai/evaluations/cli/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/cli/index.ts
@@ -65,6 +65,7 @@ import type {
 	WorkflowTestCase,
 	WorkflowTestCaseResult,
 } from '../types';
+import { buildPromptFromConversation } from '../utils/build-prompt';
 
 // n8n degrades above ~4 concurrent builds.
 const MAX_CONCURRENT_BUILDS = 4;
@@ -406,10 +407,11 @@ async function runWithLangSmith(config: RunConfig): Promise<{
 				buildDurations.set(key, buildDurationMs);
 				stashTranscript(build);
 				if (build.success && !build.workflowChecks) {
-					// No transcript in prebuilt mode — checks run with empty prompt context.
+					// No transcript in prebuilt mode — feed the same request the MCP built from.
+					const entry = conversationByFileSlug.get(fileSlug);
 					build.workflowChecks = await runWorkflowChecks({
 						workflow: build.workflowJsons[0],
-						prompt: '',
+						prompt: entry ? buildPromptFromConversation(entry.conversation) : '',
 						agentText: undefined,
 						logger,
 					});

--- a/packages/@n8n/instance-ai/evaluations/harness/runner.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/runner.ts
@@ -38,6 +38,7 @@ import type {
 	WorkflowTestCase,
 	WorkflowTestCaseResult,
 } from '../types';
+import { buildPromptFromConversation } from '../utils/build-prompt';
 import { userTurnsAsText } from '../utils/conversation-text';
 import { UserProxyLlm, type ProxyDecisionStats } from '../utils/user-proxy';
 
@@ -109,10 +110,10 @@ export async function runWorkflowTestCase(
 			});
 
 	if (config.prebuiltWorkflowId && build.success && !build.workflowChecks) {
-		// No transcript in prebuilt mode — checks run with empty prompt context.
+		// No transcript in prebuilt mode — feed the same request the MCP built from.
 		build.workflowChecks = await runWorkflowChecks({
 			workflow: build.workflowJsons[0],
-			prompt: '',
+			prompt: buildPromptFromConversation(testCase.conversation),
 			agentText: undefined,
 			logger,
 		});

--- a/packages/@n8n/instance-ai/evaluations/utils/build-prompt.ts
+++ b/packages/@n8n/instance-ai/evaluations/utils/build-prompt.ts
@@ -1,0 +1,24 @@
+/**
+ * Flatten a (possibly multi-turn) test-case conversation into the single request
+ * prompt used to drive a one-shot build, and reused at eval time so prebuilt
+ * workflows are judged against the same request their builder received.
+ */
+export function buildPromptFromConversation(
+	conversation: ReadonlyArray<{ role: string; text: string }>,
+): string {
+	const [firstUserTurn, ...remainingUserTurns] = conversation
+		.filter((turn) => turn.role === 'user')
+		.map((turn) => turn.text.trim())
+		.filter((text) => text.length > 0);
+
+	if (!firstUserTurn) return conversation[0]?.text ?? '';
+	if (remainingUserTurns.length === 0) return firstUserTurn;
+
+	return [
+		firstUserTurn,
+		'Additional details from the user:',
+		...remainingUserTurns.map((turn, index) => `${String(index + 1)}. ${turn}`),
+		'',
+		"Use all details above as requirements. Configure all nodes as completely as possible and don't ask me for credentials; I'll set them up later.",
+	].join('\n\n');
+}


### PR DESCRIPTION
## Summary

Instance AI eval **WHAT-side request-aware checks** (`fulfills_user_request` plus `valid_data_flow`, `correct_node_operations`, `handles_multiple_items`, `no_unnecessary_code_nodes`, `descriptive_node_names`, and the deterministic `http_generic_auth_type_matches_prompt` / `inbound_trigger_auth_defaults` gates) ran with an **empty prompt** for prebuilt/MCP workflows — the prebuilt branches hardcoded `prompt: ''`, so those checks judged against nothing.

This lifts `buildPromptFromConversation` out of `cli/build-mcp-manifest.ts` into a shared `evaluations/utils/build-prompt.ts` and feeds it at eval time, so the checks judge against **the same request the MCP was built from**. Applied to both prebuilt branches:

- `cli/index.ts` — the LangSmith `getOrBuild` path (runs in CI)
- `harness/runner.ts` — the direct/keyless local path

Only prebuilt/MCP runs were affected; normal Instance AI builds always received the real transcript prompt (`userTurnsAsText`). Only `response_matches_workflow_changes` is genuinely build-coupled (needs the agent's reply) and correctly stays N/A for prebuilt.

### Impact
- MCP/prebuilt **WHAT scores will shift** (blind → real) — expected, it's the fix working.
- The "configure fully / don't ask for credentials" trailer in the build prompt is harmless one-shot-era cruft; reusing the one function keeps eval == build and removes a duplicate-helper smell.

### How to test
- `runner-prebuilt` + `runner-workflow-checks` jest suites pass; typecheck/lint clean on the changed files.
- A run with `--prebuilt-workflows <manifest>` now surfaces a meaningful `fulfills_user_request` (previously vacuous).

### Note on tests
The extracted `buildPromptFromConversation` had no unit test (it was private to the manifest builder). A focused `build-prompt.test.ts` is proposed and held pending review, per our "confirm test cases first" convention.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/TRUST-150
- Follow-up that removes the duplicate prebuilt path which let this drift: https://linear.app/n8n/issue/TRUST-146

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI