### PR TITLE
fix(core): Fix dropdown menu safety triangle

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenuItem.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nDropdownMenu/DropdownMenuItem.vue
@@ -107,12 +107,6 @@ const closeSubMenu = () => {
 	}
 };
 
-const openSubMenu = () => {
-	if (!props.disabled) {
-		handleSubMenuOpenChange(true);
-	}
-};
-
 const leadingProps = computed(() => ({
 	class: $style['item-leading'],
 }));
@@ -176,8 +170,6 @@ watch(
 					{ 'is-disabled': !!disabled },
 					{ [$style.highlighted]: highlighted },
 				]"
-				@pointerenter="openSubMenu"
-				@focus="openSubMenu"
 			>
 				<slot name="item-leading" :item="props" :ui="leadingProps">
 					<Icon


### PR DESCRIPTION
## Summary

Recently change was overriding the default safety triangle built into our dropdown library - pushing a change to remove this and fix the regression.

Thanks to @heymynameisrob for catching this!

Fixes an issue introduced here: https://github.com/n8n-io/n8n/pull/30769/changes#diff-bc9b2c441286e7c3f6f9df17728814c079dd0b38ce97ee76768b1ebdbfc4054d


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
