### PR TITLE
refactor(core): Add InstanceAiPlannedTaskScheduler for planned-task orchestration

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-planned-task-scheduler.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-planned-task-scheduler.test.ts
@@ -209,7 +209,7 @@ describe('InstanceAiPlannedTaskScheduler', () => {
 
 	describe('doSchedulePlannedTasks', () => {
 		it('cancels the run when the owner is no longer authorized', async () => {
-			const { scheduler, host, internals } = buildScheduler({
+			const { host, internals } = buildScheduler({
 				host: { revalidateActiveUser: jest.fn(async () => null) },
 			});
 

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai-planned-task-scheduler.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai-planned-task-scheduler.test.ts
@@ -1,0 +1,335 @@
+jest.mock('@n8n/instance-ai', () => ({
+	ThreadTaskStorage: class {},
+	PlannedTaskStorage: class {},
+	PlannedTaskCoordinator: class {},
+	createAllTools: jest.fn(() => new Map()),
+	applyPlannedTaskPermissions: jest.fn((context: unknown) => context),
+	startBuildWorkflowAgentTask: jest.fn(),
+	startDetachedDelegateTask: jest.fn(),
+}));
+
+import type { User } from '@n8n/db';
+import type {
+	ManagedBackgroundTask,
+	OrchestrationContext,
+	PlannedTaskGraph,
+	PlannedTaskRecord,
+} from '@n8n/instance-ai';
+
+import {
+	InstanceAiPlannedTaskScheduler,
+	type InstanceAiPlannedTaskSchedulerHost,
+} from '../instance-ai-planned-task-scheduler';
+
+const fakeUser = { id: 'user-1' } as User;
+
+type PlannedTaskCoordinatorMock = {
+	getGraph: jest.Mock;
+	tick: jest.Mock;
+	markSucceeded: jest.Mock;
+	markFailed: jest.Mock;
+	markCancelled: jest.Mock;
+	markRunning: jest.Mock;
+	markCheckpointFailed: jest.Mock;
+	revertToActive: jest.Mock;
+	revertCheckpointToPlanned: jest.Mock;
+	clear: jest.Mock;
+};
+
+type SchedulerInternals = {
+	doSchedulePlannedTasks: (user: User, threadId: string) => Promise<void>;
+	reenterCheckpointById: InstanceAiPlannedTaskScheduler['reenterCheckpointById'];
+	queuePendingCheckpointReentry: InstanceAiPlannedTaskScheduler['queuePendingCheckpointReentry'];
+	createPlannedTaskState: jest.Mock;
+	pendingCheckpointReentries: Map<string, Set<string>>;
+};
+
+function buildScheduler(
+	overrides: {
+		host?: Partial<InstanceAiPlannedTaskSchedulerHost>;
+		runState?: Record<string, unknown>;
+		backgroundTasks?: Record<string, unknown>;
+		eventBus?: Record<string, unknown>;
+		maxConcurrentTasksPerThread?: number;
+	} = {},
+): {
+	scheduler: InstanceAiPlannedTaskScheduler;
+	internals: SchedulerInternals;
+	host: InstanceAiPlannedTaskSchedulerHost;
+	plannedTaskService: PlannedTaskCoordinatorMock;
+	eventBus: { publish: jest.Mock };
+} {
+	const host: InstanceAiPlannedTaskSchedulerHost = {
+		revalidateActiveUser: jest.fn(async () => fakeUser),
+		cancelRun: jest.fn(),
+		startInternalFollowUpRun: jest.fn(async () => 'follow-up-run'),
+		createPlannedTaskEnvironment: jest.fn(async () => ({
+			orchestrationContext: {} as OrchestrationContext,
+		})),
+		...overrides.host,
+	};
+	const eventBus = (overrides.eventBus ?? { publish: jest.fn() }) as { publish: jest.Mock };
+	const scheduler = new InstanceAiPlannedTaskScheduler({
+		logger: { debug: jest.fn(), warn: jest.fn(), error: jest.fn(), info: jest.fn() } as never,
+		eventBus: eventBus as never,
+		agentMemory: {} as never,
+		runState: (overrides.runState ?? {
+			hasLiveRun: jest.fn(() => false),
+			getActiveRunId: jest.fn(() => undefined),
+			hasSuspendedRun: jest.fn(() => false),
+		}) as never,
+		backgroundTasks: (overrides.backgroundTasks ?? {
+			getRunningTasks: jest.fn(() => []),
+			getRunningTasksByParentCheckpoint: jest.fn(() => []),
+		}) as never,
+		maxConcurrentTasksPerThread: overrides.maxConcurrentTasksPerThread ?? 5,
+		host,
+	});
+
+	const plannedTaskService: PlannedTaskCoordinatorMock = {
+		getGraph: jest.fn(async () => null),
+		tick: jest.fn(async () => ({ type: 'none' })),
+		markSucceeded: jest.fn(async () => null),
+		markFailed: jest.fn(async () => null),
+		markCancelled: jest.fn(async () => null),
+		markRunning: jest.fn(async () => {}),
+		markCheckpointFailed: jest.fn(async () => {}),
+		revertToActive: jest.fn(async () => {}),
+		revertCheckpointToPlanned: jest.fn(async () => {}),
+		clear: jest.fn(async () => {}),
+	};
+	const internals = scheduler as unknown as SchedulerInternals;
+	internals.createPlannedTaskState = jest.fn(async () => ({
+		plannedTaskService,
+		taskStorage: { save: jest.fn(async () => {}) },
+		memory: {},
+	}));
+
+	return { scheduler, internals, host, plannedTaskService, eventBus };
+}
+
+describe('InstanceAiPlannedTaskScheduler', () => {
+	describe('buildPlannedTaskFollowUpMessage', () => {
+		it('wraps the plan payload in a typed follow-up envelope', () => {
+			const { scheduler } = buildScheduler();
+			const graph = {
+				tasks: [
+					{ id: 't1', title: 'Build', kind: 'build-workflow', status: 'succeeded', deps: [] },
+				],
+			} as unknown as PlannedTaskGraph;
+
+			const message = scheduler.buildPlannedTaskFollowUpMessage('synthesize', graph);
+
+			expect(message).toContain('<planned-task-follow-up type="synthesize">');
+			expect(message).toContain('"id": "t1"');
+			expect(message).toContain('(continue)');
+		});
+
+		it('includes the checkpoint dependency context when provided', () => {
+			const { scheduler } = buildScheduler();
+			const graph = {
+				tasks: [
+					{
+						id: 'dep',
+						title: 'Builder',
+						kind: 'build-workflow',
+						status: 'succeeded',
+						deps: [],
+						outcome: { workflowId: 'wf-1' },
+					},
+					{ id: 'cp', title: 'Verify', kind: 'checkpoint', status: 'running', deps: ['dep'] },
+				],
+			} as unknown as PlannedTaskGraph;
+			const checkpoint = graph.tasks[1] as PlannedTaskRecord;
+
+			const message = scheduler.buildPlannedTaskFollowUpMessage('checkpoint', graph, {
+				checkpoint,
+			});
+
+			expect(message).toContain('<planned-task-follow-up type="checkpoint">');
+			expect(message).toContain('"dependsOn"');
+			expect(message).toContain('"id": "dep"');
+		});
+	});
+
+	describe('getCheckpointAllowedWorkflowIds', () => {
+		it('returns the workflow IDs of the checkpoint dependencies', async () => {
+			const { scheduler, plannedTaskService } = buildScheduler();
+			plannedTaskService.getGraph.mockResolvedValue({
+				tasks: [
+					{ id: 'dep', deps: [], outcome: { workflowId: 'wf-1' } },
+					{ id: 'other', deps: [], outcome: { workflowId: 'wf-2' } },
+					{ id: 'cp', kind: 'checkpoint', deps: ['dep'] },
+				],
+			});
+
+			const allowed = await scheduler.getCheckpointAllowedWorkflowIds('thread-a', 'cp');
+
+			expect([...allowed]).toEqual(['wf-1']);
+		});
+
+		it('returns an empty set when the checkpoint is missing', async () => {
+			const { scheduler, plannedTaskService } = buildScheduler();
+			plannedTaskService.getGraph.mockResolvedValue({ tasks: [] });
+
+			const allowed = await scheduler.getCheckpointAllowedWorkflowIds('thread-a', 'cp');
+
+			expect(allowed.size).toBe(0);
+		});
+	});
+
+	describe('handlePlannedTaskSettlement', () => {
+		it('ignores tasks that are not planned tasks', async () => {
+			const { scheduler, host } = buildScheduler();
+			const task = { threadId: 'thread-a' } as ManagedBackgroundTask;
+
+			await scheduler.handlePlannedTaskSettlement(fakeUser, task, 'succeeded');
+
+			expect(host.startInternalFollowUpRun).not.toHaveBeenCalled();
+		});
+
+		it('marks the planned task succeeded and reschedules', async () => {
+			const { scheduler, plannedTaskService, internals } = buildScheduler();
+			const task = {
+				threadId: 'thread-a',
+				plannedTaskId: 'pt-1',
+				result: 'done',
+			} as ManagedBackgroundTask;
+
+			await scheduler.handlePlannedTaskSettlement(fakeUser, task, 'succeeded');
+
+			expect(plannedTaskService.markSucceeded).toHaveBeenCalledWith('thread-a', 'pt-1', {
+				result: 'done',
+				outcome: undefined,
+			});
+			// schedulePlannedTasks → doSchedulePlannedTasks revalidates the owner.
+			expect(internals.createPlannedTaskState).toHaveBeenCalled();
+		});
+	});
+
+	describe('doSchedulePlannedTasks', () => {
+		it('cancels the run when the owner is no longer authorized', async () => {
+			const { scheduler, host, internals } = buildScheduler({
+				host: { revalidateActiveUser: jest.fn(async () => null) },
+			});
+
+			await internals.doSchedulePlannedTasks(fakeUser, 'thread-a');
+
+			expect(host.cancelRun).toHaveBeenCalledWith('thread-a');
+			expect(internals.createPlannedTaskState).not.toHaveBeenCalled();
+		});
+
+		it('starts a replan follow-up for the revalidated owner', async () => {
+			const freshUser = { id: 'user-1' } as User;
+			const { scheduler, host, plannedTaskService } = buildScheduler({
+				host: { revalidateActiveUser: jest.fn(async () => freshUser) },
+			});
+			const graph = { planRunId: 'plan-1', messageGroupId: 'group-1', tasks: [] };
+			plannedTaskService.getGraph.mockResolvedValue(graph);
+			plannedTaskService.tick.mockResolvedValue({ type: 'replan', graph, failedTask: undefined });
+
+			await (scheduler as unknown as SchedulerInternals).doSchedulePlannedTasks(
+				fakeUser,
+				'thread-a',
+			);
+
+			expect(host.startInternalFollowUpRun).toHaveBeenCalledWith(
+				freshUser,
+				'thread-a',
+				expect.stringContaining('<planned-task-follow-up type="replan">'),
+				'group-1',
+				true,
+			);
+		});
+
+		it('reverts the graph to active when the replan follow-up cannot start', async () => {
+			const { scheduler, plannedTaskService } = buildScheduler({
+				host: {
+					revalidateActiveUser: jest.fn(async () => fakeUser),
+					startInternalFollowUpRun: jest.fn(async () => ''),
+				},
+			});
+			const graph = { planRunId: 'plan-1', messageGroupId: 'group-1', tasks: [] };
+			plannedTaskService.getGraph.mockResolvedValue(graph);
+			plannedTaskService.tick.mockResolvedValue({ type: 'replan', graph, failedTask: undefined });
+
+			await (scheduler as unknown as SchedulerInternals).doSchedulePlannedTasks(
+				fakeUser,
+				'thread-a',
+			);
+
+			expect(plannedTaskService.revertToActive).toHaveBeenCalledWith('thread-a');
+		});
+	});
+
+	describe('reenterCheckpointById', () => {
+		it('re-enters a running checkpoint follow-up', async () => {
+			const { scheduler, host, plannedTaskService } = buildScheduler();
+			plannedTaskService.getGraph.mockResolvedValue({
+				tasks: [{ id: 'cp', kind: 'checkpoint', status: 'running', deps: [] }],
+			});
+
+			const result = await scheduler.reenterCheckpointById(fakeUser, 'thread-a', 'cp');
+
+			expect(result).toBe(true);
+			expect(host.startInternalFollowUpRun).toHaveBeenCalledWith(
+				fakeUser,
+				'thread-a',
+				expect.stringContaining('<planned-task-follow-up type="checkpoint">'),
+				undefined,
+				false,
+				{ isCheckpointFollowUp: true, checkpointTaskId: 'cp' },
+			);
+		});
+
+		it('does not re-enter when the checkpoint is no longer running', async () => {
+			const { scheduler, host, plannedTaskService } = buildScheduler();
+			plannedTaskService.getGraph.mockResolvedValue({
+				tasks: [{ id: 'cp', kind: 'checkpoint', status: 'succeeded', deps: [] }],
+			});
+
+			const result = await scheduler.reenterCheckpointById(fakeUser, 'thread-a', 'cp');
+
+			expect(result).toBe(false);
+			expect(host.startInternalFollowUpRun).not.toHaveBeenCalled();
+		});
+	});
+
+	describe('drainPendingCheckpointReentries', () => {
+		it('re-enters each queued checkpoint when the thread is idle', async () => {
+			const { scheduler, internals } = buildScheduler();
+			internals.reenterCheckpointById = jest.fn(async () => true);
+			scheduler.queuePendingCheckpointReentry('thread-a', 'cp-1');
+			scheduler.queuePendingCheckpointReentry('thread-a', 'cp-2');
+
+			await scheduler.drainPendingCheckpointReentries(fakeUser, 'thread-a');
+
+			expect(internals.reenterCheckpointById).toHaveBeenCalledTimes(2);
+			expect(internals.pendingCheckpointReentries.get('thread-a')).toBeUndefined();
+		});
+
+		it('keeps a marker queued when its parent siblings are still running', async () => {
+			const backgroundTasks = {
+				getRunningTasksByParentCheckpoint: jest.fn((_threadId: string, cp: string) =>
+					cp === 'cp-1' ? [{ taskId: 'sibling' }] : [],
+				),
+			};
+			const { scheduler, internals } = buildScheduler({
+				runState: {
+					getActiveRunId: jest.fn(() => undefined),
+					hasSuspendedRun: jest.fn(() => false),
+				},
+				backgroundTasks,
+			});
+			internals.reenterCheckpointById = jest.fn(async () => true);
+			scheduler.queuePendingCheckpointReentry('thread-a', 'cp-1');
+			scheduler.queuePendingCheckpointReentry('thread-a', 'cp-2');
+
+			await scheduler.drainPendingCheckpointReentries(fakeUser, 'thread-a');
+
+			expect(internals.reenterCheckpointById).toHaveBeenCalledTimes(1);
+			expect(internals.reenterCheckpointById).toHaveBeenCalledWith(fakeUser, 'thread-a', 'cp-2');
+			expect(internals.pendingCheckpointReentries.get('thread-a')).toEqual(new Set(['cp-1']));
+		});
+	});
+});

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -149,6 +149,10 @@ import {
 	type TerminalOutcome,
 } from '@n8n/instance-ai';
 
+import {
+	InstanceAiPlannedTaskScheduler,
+	type InstanceAiPlannedTaskSchedulerHost,
+} from '../instance-ai-planned-task-scheduler';
 import { InstanceAiService } from '../instance-ai.service';
 
 type ServiceInternals = {
@@ -165,6 +169,46 @@ type ServiceInternals = {
 	};
 	logger: { debug: jest.Mock; warn: jest.Mock; error: jest.Mock };
 };
+
+/**
+ * Build a planned-task scheduler instance for unit tests, with all
+ * collaborators replaced by jest mocks. The returned object is typed for
+ * test-only access to the scheduler's internals.
+ */
+function buildSchedulerInternals<T>(overrides: {
+	host?: Partial<InstanceAiPlannedTaskSchedulerHost>;
+	runState?: Record<string, unknown>;
+	backgroundTasks?: Record<string, unknown>;
+	eventBus?: Record<string, unknown>;
+	agentMemory?: unknown;
+	logger?: Record<string, unknown>;
+	maxConcurrentTasksPerThread?: number;
+}): { scheduler: InstanceAiPlannedTaskScheduler; internals: T } {
+	const host: InstanceAiPlannedTaskSchedulerHost = {
+		revalidateActiveUser: jest.fn(async () => null),
+		cancelRun: jest.fn(),
+		startInternalFollowUpRun: jest.fn(async () => 'follow-up-run'),
+		createPlannedTaskEnvironment: jest.fn(async () => ({
+			orchestrationContext: {} as never,
+		})),
+		...overrides.host,
+	};
+	const scheduler = new InstanceAiPlannedTaskScheduler({
+		logger: (overrides.logger ?? {
+			debug: jest.fn(),
+			warn: jest.fn(),
+			error: jest.fn(),
+			info: jest.fn(),
+		}) as never,
+		eventBus: (overrides.eventBus ?? { publish: jest.fn() }) as never,
+		agentMemory: (overrides.agentMemory ?? {}) as never,
+		runState: (overrides.runState ?? {}) as never,
+		backgroundTasks: (overrides.backgroundTasks ?? {}) as never,
+		maxConcurrentTasksPerThread: overrides.maxConcurrentTasksPerThread ?? 5,
+		host,
+	});
+	return { scheduler, internals: scheduler as unknown as T };
+}
 
 type RunningTask = { taskId: string };
 type MarkedWorkflow = { workflowId: string };
@@ -201,13 +245,6 @@ type BackgroundTaskFollowUpServiceInternals = {
 	finalizeBackgroundTaskTracing: jest.MockedFunction<
 		(task: ManagedBackgroundTask, status: 'completed' | 'failed' | 'cancelled') => Promise<void>
 	>;
-	handlePlannedTaskSettlement: jest.MockedFunction<
-		(
-			user: User,
-			task: ManagedBackgroundTask,
-			status: 'succeeded' | 'failed' | 'cancelled',
-		) => Promise<void>
-	>;
 	recordBackgroundTerminalOutcome: jest.MockedFunction<
 		(task: ManagedBackgroundTask) => Promise<void>
 	>;
@@ -228,12 +265,21 @@ type BackgroundTaskFollowUpServiceInternals = {
 			messageGroupId?: string,
 		) => Promise<string | undefined>
 	>;
-	queuePendingCheckpointReentry: jest.MockedFunction<
-		(threadId: string, checkpointTaskId: string) => void
-	>;
-	maybeReenterParentCheckpoint: jest.MockedFunction<
-		(user: User, threadId: string, task: ManagedBackgroundTask) => Promise<boolean>
-	>;
+	plannedTaskScheduler: {
+		handlePlannedTaskSettlement: jest.MockedFunction<
+			(
+				user: User,
+				task: ManagedBackgroundTask,
+				status: 'succeeded' | 'failed' | 'cancelled',
+			) => Promise<void>
+		>;
+		queuePendingCheckpointReentry: jest.MockedFunction<
+			(threadId: string, checkpointTaskId: string) => void
+		>;
+		maybeReenterParentCheckpoint: jest.MockedFunction<
+			(user: User, threadId: string, task: ManagedBackgroundTask) => Promise<boolean>
+		>;
+	};
 	logger: { warn: jest.Mock; debug: jest.Mock };
 };
 
@@ -285,13 +331,6 @@ function createBackgroundTaskFollowUpService({
 	service.finalizeBackgroundTaskTracing = jest.fn(
 		async (_task: ManagedBackgroundTask, _status: 'completed' | 'failed' | 'cancelled') => {},
 	);
-	service.handlePlannedTaskSettlement = jest.fn(
-		async (
-			_user: User,
-			_task: ManagedBackgroundTask,
-			_status: 'succeeded' | 'failed' | 'cancelled',
-		) => {},
-	);
 	service.recordBackgroundTerminalOutcome = jest.fn(async (_task: ManagedBackgroundTask) => {});
 	service.saveAgentTreeSnapshot = jest.fn(
 		async (
@@ -306,10 +345,19 @@ function createBackgroundTaskFollowUpService({
 		async (_user: User, _threadId: string, _message: string, _messageGroupId?: string) =>
 			'run-follow-up',
 	);
-	service.queuePendingCheckpointReentry = jest.fn();
-	service.maybeReenterParentCheckpoint = jest.fn(
-		async (_user: User, _threadId: string, _task: ManagedBackgroundTask) => false,
-	);
+	service.plannedTaskScheduler = {
+		handlePlannedTaskSettlement: jest.fn(
+			async (
+				_user: User,
+				_task: ManagedBackgroundTask,
+				_status: 'succeeded' | 'failed' | 'cancelled',
+			) => {},
+		),
+		queuePendingCheckpointReentry: jest.fn(),
+		maybeReenterParentCheckpoint: jest.fn(
+			async (_user: User, _threadId: string, _task: ManagedBackgroundTask) => false,
+		),
+	};
 	service.logger = { warn: jest.fn(), debug: jest.fn() };
 
 	return {
@@ -390,29 +438,30 @@ type TemporaryCleanupService = {
 };
 
 function createCheckpointService(): ServiceInternals {
-	// Bypass the constructor — we only exercise the three pending-reentry helpers
-	// and their direct dependencies. Everything else (scheduler, event bus, etc.)
-	// is out of scope for this unit.
-	const service = Object.create(InstanceAiService.prototype) as unknown as ServiceInternals;
-
-	service.pendingCheckpointReentries = new Map();
-	service.reenterCheckpointById = jest.fn(
-		async (_user: User, _threadId: string, _checkpointTaskId: string, _mgid?: string) => true,
-	);
-	service.backgroundTasks = {
+	// Exercise the scheduler's three pending-reentry helpers against jest-mocked
+	// collaborators. `reenterCheckpointById` is replaced with a spy so the drain
+	// logic can be asserted in isolation.
+	const backgroundTasks = {
 		getRunningTasksByParentCheckpoint: jest.fn(() => []),
 	};
-	service.runState = {
+	const runState = {
 		getActiveRunId: jest.fn(() => undefined),
 		hasSuspendedRun: jest.fn(() => false),
 	};
-	service.logger = {
+	const logger = {
 		debug: jest.fn(),
 		warn: jest.fn(),
 		error: jest.fn(),
 	};
-
-	return service;
+	const { internals } = buildSchedulerInternals<ServiceInternals>({
+		backgroundTasks,
+		runState,
+		logger,
+	});
+	internals.reenterCheckpointById = jest.fn(
+		async (_user: User, _threadId: string, _checkpointTaskId: string, _mgid?: string) => true,
+	);
+	return internals;
 }
 
 type CheckpointPruneServiceInternals = {
@@ -675,8 +724,11 @@ type TerminalGuardOrderServiceInternals = {
 	reapAiTemporaryFromRun: jest.Mock;
 	countCreditsIfFirst: jest.Mock;
 	maybeFinalizeRunTraceRoot: jest.Mock;
-	schedulePlannedTasks: jest.Mock;
-	drainPendingCheckpointReentries: jest.Mock;
+	plannedTaskScheduler: {
+		schedulePlannedTasks: jest.Mock;
+		drainPendingCheckpointReentries: jest.Mock;
+		finalizeCheckpointFollowUp: jest.Mock;
+	};
 	processResumedStream: (
 		agent: unknown,
 		resumeData: unknown,
@@ -749,8 +801,11 @@ function createTerminalGuardOrderService(): TerminalGuardOrderServiceInternals {
 	service.reapAiTemporaryFromRun = jest.fn(async () => []);
 	service.countCreditsIfFirst = jest.fn(async () => {});
 	service.maybeFinalizeRunTraceRoot = jest.fn(async () => {});
-	service.schedulePlannedTasks = jest.fn(async () => {});
-	service.drainPendingCheckpointReentries = jest.fn(async () => {});
+	service.plannedTaskScheduler = {
+		schedulePlannedTasks: jest.fn(async () => {}),
+		drainPendingCheckpointReentries: jest.fn(async () => {}),
+		finalizeCheckpointFollowUp: jest.fn(async () => {}),
+	};
 	return service;
 }
 
@@ -1047,7 +1102,7 @@ describe('InstanceAiService — runtime workspace setup', () => {
 			spawnBackgroundTask: jest.Mock;
 			cancelBackgroundTask: jest.Mock;
 			backgroundTasks: { touchTask: jest.Mock };
-			schedulePlannedTasks: jest.Mock;
+			plannedTaskScheduler: { schedulePlannedTasks: jest.Mock };
 			sendCorrectionToTask: jest.Mock;
 			sandboxes: Map<string, unknown>;
 			sandboxCreations: Map<string, Promise<unknown>>;
@@ -1089,7 +1144,7 @@ describe('InstanceAiService — runtime workspace setup', () => {
 		service.spawnBackgroundTask = jest.fn();
 		service.cancelBackgroundTask = jest.fn();
 		service.backgroundTasks = { touchTask: jest.fn() };
-		service.schedulePlannedTasks = jest.fn();
+		service.plannedTaskScheduler = { schedulePlannedTasks: jest.fn() };
 		service.sendCorrectionToTask = jest.fn();
 		service.sandboxes = new Map();
 		service.sandboxCreations = new Map();
@@ -1561,9 +1616,6 @@ function createPlannedTaskSchedulerService(): {
 	};
 	graph: { planRunId: string; messageGroupId: string; tasks: Array<{ id: string }> };
 } {
-	const service = Object.create(
-		InstanceAiService.prototype,
-	) as unknown as PlannedTaskSchedulerServiceInternals;
 	const graph = { planRunId: 'plan-run-1', messageGroupId: 'group-1', tasks: [] };
 	const plannedTaskService = {
 		getGraph: jest.fn(async () => graph),
@@ -1573,18 +1625,45 @@ function createPlannedTaskSchedulerService(): {
 		markRunning: jest.fn(async () => {}),
 	};
 
-	service.revalidateActiveUser = jest.fn();
-	service.cancelRun = jest.fn();
-	service.createPlannedTaskState = jest.fn(async () => ({ plannedTaskService }));
-	service.syncPlannedTasksToUi = jest.fn(async () => {});
-	service.backgroundTasks = { getRunningTasks: jest.fn(() => []) };
-	service.startInternalFollowUpRun = jest.fn(async () => 'follow-up-run');
-	service.buildPlannedTaskFollowUpMessage = jest.fn(() => 'follow-up message');
-	service.runState = {
+	const revalidateActiveUser = jest.fn<Promise<User | null>, [string]>();
+	const cancelRun = jest.fn();
+	const startInternalFollowUpRun = jest.fn(async () => 'follow-up-run');
+	const runState = {
 		getThreadResearchMode: jest.fn(() => false),
 		hasLiveRun: jest.fn(() => false),
 	};
-	service.logger = { warn: jest.fn() };
+	const backgroundTasks = { getRunningTasks: jest.fn(() => []) };
+	const logger = { warn: jest.fn() };
+
+	const { internals } = buildSchedulerInternals<{
+		doSchedulePlannedTasks: (user: User, threadId: string) => Promise<void>;
+		createPlannedTaskState: jest.Mock;
+		syncPlannedTasksToUi: jest.Mock;
+		buildPlannedTaskFollowUpMessage: jest.Mock;
+	}>({
+		host: { revalidateActiveUser, cancelRun, startInternalFollowUpRun },
+		runState,
+		backgroundTasks,
+		logger,
+	});
+	// Stub the scheduler's persistence + UI seams so the tick/dispatch logic can
+	// be exercised without real storage.
+	internals.createPlannedTaskState = jest.fn(async () => ({ plannedTaskService }));
+	internals.syncPlannedTasksToUi = jest.fn(async () => {});
+	internals.buildPlannedTaskFollowUpMessage = jest.fn(() => 'follow-up message');
+
+	const service: PlannedTaskSchedulerServiceInternals = {
+		doSchedulePlannedTasks: (user, threadId) => internals.doSchedulePlannedTasks(user, threadId),
+		revalidateActiveUser,
+		cancelRun,
+		createPlannedTaskState: internals.createPlannedTaskState,
+		syncPlannedTasksToUi: internals.syncPlannedTasksToUi,
+		backgroundTasks,
+		startInternalFollowUpRun,
+		buildPlannedTaskFollowUpMessage: internals.buildPlannedTaskFollowUpMessage,
+		runState,
+		logger,
+	};
 
 	return { service, plannedTaskService, graph };
 }

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.threadPushRef.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.threadPushRef.test.ts
@@ -71,6 +71,7 @@ describe('InstanceAiService — threadPushRef lifetime', () => {
 			creditedThreads: Map<string, unknown>;
 			schedulerLocks: Map<string, unknown>;
 			liveness: { clearThreadState: jest.Mock };
+			plannedTaskScheduler: { clearThreadState: jest.Mock };
 			domainAccessTrackersByThread: Map<string, unknown>;
 			eventBus: { clearThread: jest.Mock };
 			finalizeRemainingMessageTraceRoots: jest.Mock;
@@ -90,6 +91,7 @@ describe('InstanceAiService — threadPushRef lifetime', () => {
 		service.creditedThreads = new Map();
 		service.schedulerLocks = new Map();
 		service.liveness = { clearThreadState: jest.fn() };
+		service.plannedTaskScheduler = { clearThreadState: jest.fn() };
 		service.domainAccessTrackersByThread = new Map();
 		service.eventBus = { clearThread: jest.fn() };
 		service.finalizeRemainingMessageTraceRoots = jest.fn(async () => {});

--- a/packages/cli/src/modules/instance-ai/instance-ai-planned-task-scheduler.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai-planned-task-scheduler.ts
@@ -1,0 +1,760 @@
+import type { TaskList } from '@n8n/api-types';
+import type { Logger } from '@n8n/backend-common';
+import type { User } from '@n8n/db';
+import {
+	PlannedTaskCoordinator,
+	PlannedTaskStorage,
+	ThreadTaskStorage,
+	applyPlannedTaskPermissions,
+	createAllTools,
+	startBuildWorkflowAgentTask,
+	startDetachedDelegateTask,
+	type BackgroundTaskManager,
+	type ManagedBackgroundTask,
+	type OrchestrationContext,
+	type PlannedTaskGraph,
+	type PlannedTaskRecord,
+	type RunStateRegistry,
+} from '@n8n/instance-ai';
+
+import type { InProcessEventBus } from './event-bus/in-process-event-bus';
+import { AUTO_FOLLOW_UP_MESSAGE } from './internal-messages';
+import type { TypeORMAgentMemory } from './storage/typeorm-agent-memory';
+
+const ORCHESTRATOR_AGENT_ID = 'agent-001';
+
+const PLANNED_TASK_CONTEXT_VALUE_LIMIT = 1_500;
+
+function getErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+function stringifyForContextValue(value: unknown): string {
+	if (typeof value === 'string') return value;
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return String(value);
+	}
+}
+
+function truncateContextValue(value: string): string {
+	if (value.length <= PLANNED_TASK_CONTEXT_VALUE_LIMIT) return value;
+	return `${value.slice(0, PLANNED_TASK_CONTEXT_VALUE_LIMIT)}...`;
+}
+
+function buildPlannedTaskConversationContext(
+	task: PlannedTaskRecord,
+	graph: PlannedTaskGraph | undefined,
+): string | undefined {
+	if (!graph) return undefined;
+
+	const parts: string[] = [
+		`Approved plan task: ${task.title}`,
+		`Task id: ${task.id}`,
+		`Task kind: ${task.kind}`,
+		`Plan run id: ${graph.planRunId}`,
+	];
+
+	if (task.workflowId) {
+		parts.push(`Target workflow id: ${task.workflowId}`);
+	}
+
+	const dependencies = graph.tasks.filter((candidate) => task.deps.includes(candidate.id));
+	if (dependencies.length > 0) {
+		parts.push('Completed dependency context:');
+		for (const dependency of dependencies) {
+			const dependencyParts = [
+				`- ${dependency.id} (${dependency.kind}, ${dependency.status}): ${dependency.title}`,
+			];
+			if (dependency.result) {
+				dependencyParts.push(`result=${truncateContextValue(dependency.result)}`);
+			}
+			if (dependency.error) {
+				dependencyParts.push(`error=${truncateContextValue(dependency.error)}`);
+			}
+			if (dependency.outcome) {
+				dependencyParts.push(
+					`outcome=${truncateContextValue(stringifyForContextValue(dependency.outcome))}`,
+				);
+			}
+			parts.push(dependencyParts.join(' '));
+		}
+	}
+
+	return parts.join('\n');
+}
+
+/**
+ * The slice of the orchestrator run loop the scheduler drives back into. The
+ * scheduler decides *when* a planned-task follow-up turn must run and *which*
+ * checkpoint to re-enter; the host owns the heavy run-loop machinery (run-state
+ * registration, executor spawn, trace wiring) and exposes it through these
+ * minimal callbacks.
+ */
+export interface InstanceAiPlannedTaskSchedulerHost {
+	/** Re-resolve the run owner and confirm they still have AI Assistant access. */
+	revalidateActiveUser(userId: string): Promise<User | null>;
+
+	/** Cancel the live run for a thread (used when the owner lost authorization). */
+	cancelRun(threadId: string): void;
+
+	/**
+	 * Start a fresh internal orchestrator turn (synthesize / replan / checkpoint
+	 * follow-up). Returns the new run ID, or an empty string when a run was
+	 * already live and the follow-up was skipped.
+	 */
+	startInternalFollowUpRun(
+		user: User,
+		threadId: string,
+		message: string,
+		messageGroupId?: string,
+		isReplanFollowUp?: boolean,
+		checkpoint?: { isCheckpointFollowUp: true; checkpointTaskId: string },
+	): Promise<string>;
+
+	/**
+	 * Build the orchestration context used to dispatch planned tasks (sub-agent
+	 * builders / delegates), already wired with tracing and the thread's push ref.
+	 */
+	createPlannedTaskEnvironment(
+		user: User,
+		threadId: string,
+		planRunId: string,
+		messageGroupId?: string,
+	): Promise<{ orchestrationContext: OrchestrationContext }>;
+}
+
+export interface InstanceAiPlannedTaskSchedulerOptions {
+	logger: Logger;
+	eventBus: InProcessEventBus;
+	agentMemory: TypeORMAgentMemory;
+	runState: RunStateRegistry<User>;
+	backgroundTasks: BackgroundTaskManager;
+	maxConcurrentTasksPerThread: number;
+	host: InstanceAiPlannedTaskSchedulerHost;
+}
+
+/**
+ * Drives the planned-task lifecycle for a conversation: projecting the plan
+ * graph onto the UI checklist, dispatching ready tasks to sub-agents, and
+ * settling completed tasks back into the graph. It also owns checkpoint
+ * re-entry — the orchestration that re-opens a checkpoint follow-up turn once
+ * its dependent work has finished, including the deferred re-entries that could
+ * not fire while a run was live.
+ *
+ * Scheduling is serialized per thread so concurrent settlements (a background
+ * task finishing, a run ending, a checkpoint draining) never interleave passes
+ * over the same graph.
+ */
+export class InstanceAiPlannedTaskScheduler {
+	private readonly logger: Logger;
+
+	private readonly eventBus: InProcessEventBus;
+
+	private readonly agentMemory: TypeORMAgentMemory;
+
+	private readonly runState: RunStateRegistry<User>;
+
+	private readonly backgroundTasks: BackgroundTaskManager;
+
+	private readonly maxConcurrentTasksPerThread: number;
+
+	private readonly host: InstanceAiPlannedTaskSchedulerHost;
+
+	/** Per-thread promise chain that serializes schedulePlannedTasks calls. */
+	private readonly schedulerLocks = new Map<string, Promise<void>>();
+
+	/**
+	 * Checkpoint re-entries that could not fire when their parent-tagged child
+	 * settled (an orchestrator run was live, or other parent siblings were
+	 * still running). Drained from the post-run cleanup path so the checkpoint
+	 * is never left orphaned.
+	 */
+	private readonly pendingCheckpointReentries = new Map<string, Set<string>>();
+
+	constructor(options: InstanceAiPlannedTaskSchedulerOptions) {
+		this.logger = options.logger;
+		this.eventBus = options.eventBus;
+		this.agentMemory = options.agentMemory;
+		this.runState = options.runState;
+		this.backgroundTasks = options.backgroundTasks;
+		this.maxConcurrentTasksPerThread = options.maxConcurrentTasksPerThread;
+		this.host = options.host;
+	}
+
+	/** Forget the per-thread scheduler chain when a thread is cleared. */
+	clearThreadState(threadId: string): void {
+		this.schedulerLocks.delete(threadId);
+	}
+
+	private projectPlannedTaskList(graph: PlannedTaskGraph): TaskList {
+		return {
+			tasks: graph.tasks.map((task) => ({
+				id: task.id,
+				description: task.title,
+				status:
+					task.status === 'planned'
+						? 'todo'
+						: task.status === 'running'
+							? 'in_progress'
+							: task.status === 'succeeded'
+								? 'done'
+								: task.status,
+			})),
+		};
+	}
+
+	buildPlannedTaskFollowUpMessage(
+		type: 'synthesize' | 'replan' | 'checkpoint',
+		graph: PlannedTaskGraph,
+		options: { failedTask?: PlannedTaskRecord; checkpoint?: PlannedTaskRecord } = {},
+	): string {
+		const payload: Record<string, unknown> = {
+			tasks: graph.tasks.map((task) => ({
+				id: task.id,
+				title: task.title,
+				kind: task.kind,
+				status: task.status,
+				result: task.result,
+				error: task.error,
+				outcome: task.outcome,
+			})),
+		};
+
+		if (options.failedTask) {
+			payload.failedTask = {
+				id: options.failedTask.id,
+				title: options.failedTask.title,
+				kind: options.failedTask.kind,
+				error: options.failedTask.error,
+				result: options.failedTask.result,
+			};
+		}
+
+		if (options.checkpoint) {
+			const depOutcomes = graph.tasks
+				.filter((t) => options.checkpoint!.deps.includes(t.id))
+				.map((t) => ({
+					id: t.id,
+					title: t.title,
+					kind: t.kind,
+					status: t.status,
+					result: t.result,
+					outcome: t.outcome,
+				}));
+			payload.checkpoint = {
+				id: options.checkpoint.id,
+				title: options.checkpoint.title,
+				instructions: options.checkpoint.spec,
+				dependsOn: depOutcomes,
+			};
+		}
+
+		return `<planned-task-follow-up type="${type}">\n${JSON.stringify(payload, null, 2)}\n</planned-task-follow-up>\n\n${AUTO_FOLLOW_UP_MESSAGE}`;
+	}
+
+	private async createPlannedTaskState() {
+		const memory = this.agentMemory;
+		const taskStorage = new ThreadTaskStorage(memory);
+		const plannedTaskStorage = new PlannedTaskStorage(memory);
+		const plannedTaskService = new PlannedTaskCoordinator(plannedTaskStorage);
+		return { memory, taskStorage, plannedTaskService };
+	}
+
+	private async syncPlannedTasksToUi(threadId: string, graph: PlannedTaskGraph): Promise<void> {
+		const { taskStorage } = await this.createPlannedTaskState();
+		const tasks = this.projectPlannedTaskList(graph);
+		await taskStorage.save(threadId, tasks);
+		this.eventBus.publish(threadId, {
+			type: 'tasks-update',
+			runId: graph.planRunId,
+			agentId: ORCHESTRATOR_AGENT_ID,
+			payload: { tasks },
+		});
+	}
+
+	/**
+	 * Drop any persisted planned-task graph that is still `awaiting_approval`,
+	 * and clear the UI checklist. Called on run cancellation and HITL timeout so
+	 * stale approval state doesn't linger. A graph in `active` / `awaiting_replan`
+	 * is already in-flight and has its own settlement logic.
+	 */
+	async cancelAwaitingApprovalPlan(threadId: string): Promise<void> {
+		try {
+			const { plannedTaskService, taskStorage } = await this.createPlannedTaskState();
+			const graph = await plannedTaskService.getGraph(threadId);
+			if (!graph || graph.status !== 'awaiting_approval') return;
+
+			await plannedTaskService.clear(threadId);
+			await taskStorage.save(threadId, { tasks: [] });
+			this.eventBus.publish(threadId, {
+				type: 'tasks-update',
+				runId: graph.planRunId,
+				agentId: ORCHESTRATOR_AGENT_ID,
+				payload: { tasks: { tasks: [] }, planItems: [] },
+			});
+		} catch (error) {
+			this.logger.warn('Failed to clean up awaiting_approval plan on cancel', {
+				threadId,
+				error: getErrorMessage(error),
+			});
+		}
+	}
+
+	private async dispatchPlannedTask(
+		task: PlannedTaskRecord,
+		context: OrchestrationContext,
+		graph?: PlannedTaskGraph,
+	): Promise<void> {
+		// Plan approval authorizes the task-family's non-destructive tools,
+		// so the sub-agent can execute without a redundant second confirmation.
+		const taskContext = this.createPlannedTaskContext(task.kind, context);
+		const conversationContext = buildPlannedTaskConversationContext(task, graph);
+
+		let started: { taskId: string; agentId: string; result: string } | null = null;
+
+		switch (task.kind) {
+			case 'build-workflow':
+				started = await startBuildWorkflowAgentTask(taskContext, {
+					task: task.spec,
+					workflowId: task.workflowId,
+					plannedTaskId: task.id,
+					conversationContext,
+				});
+				break;
+			case 'delegate':
+				started = await startDetachedDelegateTask(taskContext, {
+					title: task.title,
+					spec: task.spec,
+					tools: task.tools ?? [],
+					plannedTaskId: task.id,
+					conversationContext,
+				});
+				break;
+		}
+
+		if (!started?.taskId) {
+			await context.plannedTaskService?.markFailed(context.threadId, task.id, {
+				error: started?.result || `Failed to start planned task "${task.title}"`,
+			});
+			return;
+		}
+
+		await context.plannedTaskService?.markRunning(context.threadId, task.id, {
+			agentId: started.agentId,
+			backgroundTaskId: started.taskId,
+		});
+
+		const nextGraph = await context.plannedTaskService?.getGraph(context.threadId);
+		if (nextGraph) {
+			await this.syncPlannedTasksToUi(context.threadId, nextGraph);
+		}
+	}
+
+	/**
+	 * Creates a task-scoped OrchestrationContext with plan-approved permission
+	 * overrides. Rebuilds domain tools so each sub-agent gets its own closure
+	 * with the correct permissions, preventing cross-task leakage.
+	 */
+	private createPlannedTaskContext(
+		kind: PlannedTaskRecord['kind'],
+		context: OrchestrationContext,
+	): OrchestrationContext {
+		if (!context.domainContext) return context;
+
+		const taskDomainContext = applyPlannedTaskPermissions(context.domainContext, kind);
+		if (taskDomainContext === context.domainContext) return context;
+
+		return {
+			...context,
+			domainContext: taskDomainContext,
+			domainTools: createAllTools(taskDomainContext),
+		};
+	}
+
+	/**
+	 * Resolve the workflow IDs the checkpoint task is verifying so the runWorkflow
+	 * permission override can be scoped. Walks the checkpoint's `dependsOn` to find
+	 * the build-workflow tasks it depends on and reads their `outcome.workflowId`.
+	 * Returns an empty set when the graph is missing or the checkpoint has no
+	 * resolved workflow deps (in which case the override applies broadly via the
+	 * `allowList === undefined` short-circuit only if we don't set the field).
+	 */
+	async getCheckpointAllowedWorkflowIds(
+		threadId: string,
+		checkpointTaskId: string,
+	): Promise<ReadonlySet<string>> {
+		try {
+			const { plannedTaskService } = await this.createPlannedTaskState();
+			const graph = await plannedTaskService.getGraph(threadId);
+			const checkpoint = graph?.tasks.find((t) => t.id === checkpointTaskId);
+			if (!graph || !checkpoint) return new Set();
+			const deps = new Set(checkpoint.deps);
+			const allowed = new Set<string>();
+			for (const task of graph.tasks) {
+				if (!deps.has(task.id)) continue;
+				const workflowId = task.outcome?.workflowId;
+				if (typeof workflowId === 'string' && workflowId.length > 0) {
+					allowed.add(workflowId);
+				}
+			}
+			return allowed;
+		} catch (error) {
+			this.logger.warn('Failed to resolve checkpoint allowed workflow IDs', {
+				threadId,
+				checkpointTaskId,
+				error: getErrorMessage(error),
+			});
+			return new Set();
+		}
+	}
+
+	async handlePlannedTaskSettlement(
+		user: User,
+		task: ManagedBackgroundTask,
+		status: 'succeeded' | 'failed' | 'cancelled',
+	): Promise<void> {
+		if (!task.plannedTaskId) return;
+
+		const { plannedTaskService } = await this.createPlannedTaskState();
+		let graph: PlannedTaskGraph | null = null;
+
+		if (status === 'succeeded') {
+			graph = await plannedTaskService.markSucceeded(task.threadId, task.plannedTaskId, {
+				result: task.result,
+				outcome: task.outcome,
+			});
+		} else if (status === 'failed') {
+			graph = await plannedTaskService.markFailed(task.threadId, task.plannedTaskId, {
+				error: task.error,
+			});
+		} else {
+			graph = await plannedTaskService.markCancelled(task.threadId, task.plannedTaskId, {
+				error: task.error,
+			});
+		}
+
+		if (graph) {
+			await this.syncPlannedTasksToUi(task.threadId, graph);
+		}
+
+		await this.schedulePlannedTasks(user, task.threadId);
+	}
+
+	async schedulePlannedTasks(user: User, threadId: string): Promise<void> {
+		const prev = this.schedulerLocks.get(threadId) ?? Promise.resolve();
+		// eslint-disable-next-line @typescript-eslint/promise-function-async
+		const current = prev.then(() => this.doSchedulePlannedTasks(user, threadId)).catch(() => {});
+		this.schedulerLocks.set(threadId, current);
+		await current;
+	}
+
+	private async doSchedulePlannedTasks(user: User, threadId: string): Promise<void> {
+		const revalidated = await this.host.revalidateActiveUser(user.id);
+		if (!revalidated) {
+			this.logger.warn('Cancelling run: user no longer authorized for AI Assistant', {
+				userId: user.id,
+				threadId,
+			});
+			this.host.cancelRun(threadId);
+			return;
+		}
+
+		const activeUser = revalidated;
+
+		const { plannedTaskService } = await this.createPlannedTaskState();
+		const graph = await plannedTaskService.getGraph(threadId);
+		if (!graph) return;
+
+		await this.syncPlannedTasksToUi(threadId, graph);
+
+		const availableSlots = Math.max(
+			0,
+			this.maxConcurrentTasksPerThread - this.backgroundTasks.getRunningTasks(threadId).length,
+		);
+		const action = await plannedTaskService.tick(threadId, { availableSlots });
+		if (action.type === 'none') return;
+
+		if (action.type === 'replan') {
+			await this.syncPlannedTasksToUi(threadId, action.graph);
+			const startedRunId = await this.host.startInternalFollowUpRun(
+				activeUser,
+				threadId,
+				this.buildPlannedTaskFollowUpMessage('replan', action.graph, {
+					failedTask: action.failedTask,
+				}),
+				action.graph.messageGroupId,
+				true,
+			);
+			// tick() already transitioned the graph to `awaiting_replan`. If the
+			// follow-up run couldn't start (live run present), revert the status
+			// so the next schedulePlannedTasks() pass can re-emit this action.
+			// Without this, tick() returns `none` for non-active graphs and the
+			// replan is silently lost.
+			if (!startedRunId) {
+				await plannedTaskService.revertToActive(threadId);
+			}
+			return;
+		}
+
+		if (action.type === 'synthesize') {
+			await this.syncPlannedTasksToUi(threadId, action.graph);
+			const startedRunId = await this.host.startInternalFollowUpRun(
+				activeUser,
+				threadId,
+				this.buildPlannedTaskFollowUpMessage('synthesize', action.graph),
+				action.graph.messageGroupId,
+			);
+			// Same rollback as replan: tick() transitioned to `completed`, but if
+			// the synthesize follow-up didn't actually start, revert so the next
+			// tick can emit it again.
+			if (!startedRunId) {
+				await plannedTaskService.revertToActive(threadId);
+			}
+			return;
+		}
+
+		if (action.type === 'orchestrate-checkpoint') {
+			// Defer if a run is already active or suspended. The currently-live
+			// run's post-finally reschedule hook will pick this checkpoint up.
+			if (this.runState.hasLiveRun(threadId)) {
+				return;
+			}
+
+			const checkpoint = action.tasks[0];
+
+			// Mark running before starting the follow-up so complete-checkpoint
+			// (which requires status === 'running') always sees the correct state.
+			// If startInternalFollowUpRun no-ops below (tight race), we roll back
+			// the transition to avoid leaving the task in a phantom 'running' state.
+			await plannedTaskService.markRunning(threadId, checkpoint.id, {
+				agentId: ORCHESTRATOR_AGENT_ID,
+			});
+			const graphAfterMark = (await plannedTaskService.getGraph(threadId)) ?? action.graph;
+			await this.syncPlannedTasksToUi(threadId, graphAfterMark);
+
+			const checkpointRecord =
+				graphAfterMark.tasks.find((t) => t.id === checkpoint.id) ?? checkpoint;
+
+			const startedRunId = await this.host.startInternalFollowUpRun(
+				activeUser,
+				threadId,
+				this.buildPlannedTaskFollowUpMessage('checkpoint', graphAfterMark, {
+					checkpoint: checkpointRecord,
+				}),
+				action.graph.messageGroupId,
+				false,
+				{ isCheckpointFollowUp: true, checkpointTaskId: checkpoint.id },
+			);
+
+			if (!startedRunId) {
+				// Rare race: the outer hasLiveRun check passed but the inner guard
+				// in startInternalFollowUpRun did not (another path started a run
+				// between our two checks). Revert the checkpoint back to `planned`
+				// so the next scheduler tick re-emits `orchestrate-checkpoint` —
+				// marking it `failed` here would cascade cancel to every dependent
+				// and destroy downstream work even though nothing actually failed.
+				this.logger.warn(
+					'Checkpoint follow-up run did not start — reverting checkpoint to planned for retry',
+					{ threadId, checkpointTaskId: checkpoint.id },
+				);
+				await plannedTaskService.revertCheckpointToPlanned(threadId, checkpoint.id);
+			}
+			return;
+		}
+
+		const environment = await this.host.createPlannedTaskEnvironment(
+			activeUser,
+			threadId,
+			action.graph.planRunId,
+			action.graph.messageGroupId,
+		);
+
+		for (const task of action.tasks) {
+			await this.dispatchPlannedTask(task, environment.orchestrationContext, action.graph);
+		}
+
+		await this.doSchedulePlannedTasks(activeUser, threadId);
+	}
+
+	queuePendingCheckpointReentry(threadId: string, checkpointTaskId: string): void {
+		let set = this.pendingCheckpointReentries.get(threadId);
+		if (!set) {
+			set = new Set();
+			this.pendingCheckpointReentries.set(threadId, set);
+		}
+		set.add(checkpointTaskId);
+	}
+
+	/**
+	 * Drain any checkpoint re-entries whose parent-tagged children settled while
+	 * an orchestrator run was live (or while other siblings were still running).
+	 * Called from the post-run cleanup path in every run-ending `finally` block,
+	 * so the checkpoint is never left orphaned when the settlement path could
+	 * not fire immediately.
+	 */
+	async drainPendingCheckpointReentries(user: User, threadId: string): Promise<void> {
+		const set = this.pendingCheckpointReentries.get(threadId);
+		if (!set || set.size === 0) return;
+		const snapshot = [...set];
+		for (const checkpointTaskId of snapshot) {
+			// If a new run started while we were draining, stop — the next run's
+			// cleanup will pick up the remaining markers.
+			if (this.runState.getActiveRunId(threadId) || this.runState.hasSuspendedRun(threadId)) {
+				return;
+			}
+			// A new parent-tagged child is running — let its settlement drive the
+			// checkpoint instead of racing another re-entry.
+			const siblings = this.backgroundTasks.getRunningTasksByParentCheckpoint(
+				threadId,
+				checkpointTaskId,
+			);
+			if (siblings.length > 0) continue;
+			set.delete(checkpointTaskId);
+			await this.reenterCheckpointById(user, threadId, checkpointTaskId);
+		}
+		if (set.size === 0) this.pendingCheckpointReentries.delete(threadId);
+	}
+
+	/**
+	 * Fire a synthetic `<planned-task-follow-up type="checkpoint">` for the
+	 * given checkpoint task id when the parent-tagged children that drove it
+	 * are no longer running and no new orchestrator run is live. Used by both
+	 * the immediate re-entry path (via `maybeReenterParentCheckpoint`) and the
+	 * deferred drain (via `drainPendingCheckpointReentries`).
+	 */
+	async reenterCheckpointById(
+		user: User,
+		threadId: string,
+		checkpointTaskId: string,
+		messageGroupId?: string,
+	): Promise<boolean> {
+		try {
+			const { plannedTaskService } = await this.createPlannedTaskState();
+			const graph = await plannedTaskService.getGraph(threadId);
+			const checkpoint = graph?.tasks.find((t) => t.id === checkpointTaskId);
+			if (!graph || !checkpoint || checkpoint.kind !== 'checkpoint') return false;
+			if (checkpoint.status !== 'running') return false;
+
+			const startedRunId = await this.host.startInternalFollowUpRun(
+				user,
+				threadId,
+				this.buildPlannedTaskFollowUpMessage('checkpoint', graph, { checkpoint }),
+				messageGroupId,
+				false,
+				{ isCheckpointFollowUp: true, checkpointTaskId },
+			);
+			if (!startedRunId) return false;
+			this.logger.debug('Re-entered checkpoint follow-up', {
+				threadId,
+				checkpointTaskId,
+				messageGroupId,
+			});
+			return true;
+		} catch (error) {
+			this.logger.error('Failed to re-enter checkpoint follow-up', {
+				threadId,
+				checkpointTaskId,
+				error: getErrorMessage(error),
+			});
+			return false;
+		}
+	}
+
+	/**
+	 * When a direct background task (builder/research/data-table/delegate)
+	 * settles and was spawned inside a checkpoint follow-up, try to re-enter
+	 * that checkpoint so the orchestrator can call `complete-checkpoint`.
+	 *
+	 * Returns `true` only when a follow-up was actually started. Returns
+	 * `false` in every other case (checkpoint no longer running, siblings
+	 * still in-flight, an orchestrator run is active or suspended, or the
+	 * graph no longer has the checkpoint). The caller is responsible for
+	 * queuing a deferred re-entry in the false case — never falling through
+	 * to a generic `<background-task-completed>` shell, which would re-open
+	 * the orphan bug.
+	 */
+	async maybeReenterParentCheckpoint(
+		user: User,
+		threadId: string,
+		task: ManagedBackgroundTask,
+	): Promise<boolean> {
+		const parentCheckpointId = task.parentCheckpointId;
+		if (!parentCheckpointId) return false;
+
+		// If other parent-tagged children are still running, let the LAST one
+		// re-drive the checkpoint; emitting multiple re-dispatches would race.
+		const siblings = this.backgroundTasks
+			.getRunningTasksByParentCheckpoint(threadId, parentCheckpointId)
+			.filter((t) => t.taskId !== task.taskId);
+		if (siblings.length > 0) return false;
+
+		// If a run is live, defer — startInternalFollowUpRun would be rejected
+		// and we must not fall through to the shell path.
+		if (this.runState.getActiveRunId(threadId) || this.runState.hasSuspendedRun(threadId)) {
+			return false;
+		}
+
+		return await this.reenterCheckpointById(
+			user,
+			threadId,
+			parentCheckpointId,
+			task.messageGroupId,
+		);
+	}
+
+	async finalizeCheckpointFollowUp(
+		user: User,
+		threadId: string,
+		checkpointTaskId: string,
+	): Promise<void> {
+		try {
+			const { plannedTaskService } = await this.createPlannedTaskState();
+			const graph = await plannedTaskService.getGraph(threadId);
+			const task = graph?.tasks.find((t) => t.id === checkpointTaskId);
+			if (task && task.status === 'running') {
+				// If the orchestrator spawned a detached sub-agent inside this
+				// checkpoint's turn (builder, research, data-table, delegate) and
+				// that child is still running, leave the checkpoint running. The
+				// child's settlement path re-emits `orchestrate-checkpoint` so the
+				// orchestrator re-enters the same checkpoint context and can then
+				// call `complete-checkpoint`.
+				const inflightChildren = this.backgroundTasks.getRunningTasksByParentCheckpoint(
+					threadId,
+					checkpointTaskId,
+				);
+				if (inflightChildren.length > 0) {
+					this.logger.debug(
+						'Checkpoint run ended with in-flight child tasks — deferring finalization',
+						{
+							threadId,
+							checkpointTaskId,
+							inflightTaskIds: inflightChildren.map((t) => t.taskId),
+						},
+					);
+				} else {
+					this.logger.warn('Checkpoint run ended without reporting completion — marking failed', {
+						threadId,
+						checkpointTaskId,
+					});
+					await plannedTaskService.markCheckpointFailed(threadId, checkpointTaskId, {
+						error: 'Checkpoint run ended without reporting completion',
+					});
+					const nextGraph = await plannedTaskService.getGraph(threadId);
+					if (nextGraph) {
+						await this.syncPlannedTasksToUi(threadId, nextGraph);
+					}
+				}
+			}
+		} catch (error) {
+			this.logger.error('Checkpoint finalization failed', {
+				threadId,
+				checkpointTaskId,
+				error: getErrorMessage(error),
+			});
+		}
+
+		await this.schedulePlannedTasks(user, threadId);
+	}
+}

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -10,7 +10,6 @@ import {
 	type InstanceAiGatewayCapabilities,
 	type McpToolCallResult,
 	type ToolCategory,
-	type TaskList,
 } from '@n8n/api-types';
 import type { Message, Workspace } from '@n8n/agents';
 import { Logger } from '@n8n/backend-common';
@@ -50,14 +49,11 @@ import {
 	PlannedTaskCoordinator,
 	PlannedTaskStorage,
 	TerminalOutcomeStorage,
-	applyPlannedTaskPermissions,
 	PLANNED_TASK_PERMISSION_OVERRIDES,
 	releaseTraceClient,
 	submitLangsmithUserFeedback,
 	resumeAgentRun,
 	RunStateRegistry,
-	startBuildWorkflowAgentTask,
-	startDetachedDelegateTask,
 	streamAgentRun,
 	truncateToTitle,
 	generateTitleForRun,
@@ -71,8 +67,6 @@ import {
 	type ModelConfig,
 	type OrchestrationContext,
 	type InstanceAiTraceContext,
-	type PlannedTaskGraph,
-	type PlannedTaskRecord,
 	type SandboxConfig,
 	type SpawnBackgroundTaskOptions,
 	type SpawnBackgroundTaskResult,
@@ -114,6 +108,10 @@ import { InstanceAiPendingConfirmationRepository } from './repositories/instance
 import { InstanceAiThreadRepository } from './repositories/instance-ai-thread.repository';
 import { TraceReplayState } from './trace-replay-state';
 import { INSTANCE_AI_RUN_TIMEOUT_REASON, InstanceAiLivenessService } from './liveness';
+import {
+	InstanceAiPlannedTaskScheduler,
+	type InstanceAiPlannedTaskSchedulerHost,
+} from './instance-ai-planned-task-scheduler';
 import {
 	buildInstanceAiRunTraceMetadata,
 	type InstanceAiRunTraceMetadataOptions,
@@ -339,64 +337,6 @@ function getAbortReason(signal: AbortSignal): string {
 const INSTANCE_AI_FEEDBACK_NAMESPACE = 'c5be4c87-5b6e-49ed-afe1-9c5c1f99a5c0';
 const MAX_CONCURRENT_BACKGROUND_TASKS_PER_THREAD = 5;
 
-function stringifyForContextValue(value: unknown): string {
-	if (typeof value === 'string') return value;
-	try {
-		return JSON.stringify(value);
-	} catch {
-		return String(value);
-	}
-}
-
-const PLANNED_TASK_CONTEXT_VALUE_LIMIT = 1_500;
-
-function truncateContextValue(value: string): string {
-	if (value.length <= PLANNED_TASK_CONTEXT_VALUE_LIMIT) return value;
-	return `${value.slice(0, PLANNED_TASK_CONTEXT_VALUE_LIMIT)}...`;
-}
-
-function buildPlannedTaskConversationContext(
-	task: PlannedTaskRecord,
-	graph: PlannedTaskGraph | undefined,
-): string | undefined {
-	if (!graph) return undefined;
-
-	const parts: string[] = [
-		`Approved plan task: ${task.title}`,
-		`Task id: ${task.id}`,
-		`Task kind: ${task.kind}`,
-		`Plan run id: ${graph.planRunId}`,
-	];
-
-	if (task.workflowId) {
-		parts.push(`Target workflow id: ${task.workflowId}`);
-	}
-
-	const dependencies = graph.tasks.filter((candidate) => task.deps.includes(candidate.id));
-	if (dependencies.length > 0) {
-		parts.push('Completed dependency context:');
-		for (const dependency of dependencies) {
-			const dependencyParts = [
-				`- ${dependency.id} (${dependency.kind}, ${dependency.status}): ${dependency.title}`,
-			];
-			if (dependency.result) {
-				dependencyParts.push(`result=${truncateContextValue(dependency.result)}`);
-			}
-			if (dependency.error) {
-				dependencyParts.push(`error=${truncateContextValue(dependency.error)}`);
-			}
-			if (dependency.outcome) {
-				dependencyParts.push(
-					`outcome=${truncateContextValue(stringifyForContextValue(dependency.outcome))}`,
-				);
-			}
-			parts.push(dependencyParts.join(' '));
-		}
-	}
-
-	return parts.join('\n');
-}
-
 /**
  * When HTTP_PROXY / HTTPS_PROXY is set (e.g. in e2e tests with MockServer),
  * return a fetch function that routes requests through the proxy. Node.js's
@@ -552,16 +492,11 @@ export class InstanceAiService {
 	/** Tracks the iframe pushRef per thread for live execution push events. */
 	private readonly threadPushRef = new Map<string, string>();
 
-	/** Per-thread promise chain that serializes schedulePlannedTasks calls. */
-	private readonly schedulerLocks = new Map<string, Promise<void>>();
-
 	/**
-	 * Checkpoint re-entries that could not fire when their parent-tagged child
-	 * settled (an orchestrator run was live, or other parent siblings were
-	 * still running). Drained from the post-run cleanup path so the checkpoint
-	 * is never left orphaned.
+	 * Drives the planned-task lifecycle and checkpoint re-entry for each
+	 * conversation, calling back into this service's run loop through a port.
 	 */
-	private readonly pendingCheckpointReentries = new Map<string, Set<string>>();
+	private readonly plannedTaskScheduler: InstanceAiPlannedTaskScheduler;
 
 	private readonly pendingTerminalOutcomes = new Map<string, TerminalOutcome>();
 
@@ -664,6 +599,15 @@ export class InstanceAiService {
 			onPendingConfirmationRejected: (requestId) => {
 				void this.dropPendingConfirmation(requestId);
 			},
+		});
+		this.plannedTaskScheduler = new InstanceAiPlannedTaskScheduler({
+			logger: this.logger,
+			eventBus: this.eventBus,
+			agentMemory: this.agentMemory,
+			runState: this.runState,
+			backgroundTasks: this.backgroundTasks,
+			maxConcurrentTasksPerThread: MAX_CONCURRENT_BACKGROUND_TASKS_PER_THREAD,
+			host: this.createPlannedTaskSchedulerHost(),
 		});
 		this.defaultTimeZone = globalConfig.generic.timezone;
 		const restEndpoint = globalConfig.endpoints.rest;
@@ -1630,7 +1574,7 @@ export class InstanceAiService {
 				);
 			});
 			if (user) {
-				void this.handlePlannedTaskSettlement(user, task, 'cancelled');
+				void this.plannedTaskScheduler.handlePlannedTaskSettlement(user, task, 'cancelled');
 			}
 		}
 
@@ -1642,7 +1586,7 @@ export class InstanceAiService {
 		// threadHasExistingPlan(). Only target awaiting_approval — active and
 		// awaiting_replan graphs have their own settlement logic via the
 		// background-task cancellations above.
-		void this.cancelAwaitingApprovalPlan(threadId);
+		void this.plannedTaskScheduler.cancelAwaitingApprovalPlan(threadId);
 
 		const { active, suspended } = this.runState.cancelThread(threadId);
 		if (active) {
@@ -1701,7 +1645,7 @@ export class InstanceAiService {
 
 		const user = this.runState.getThreadUser(threadId);
 		if (user) {
-			void this.handlePlannedTaskSettlement(user, task, 'cancelled');
+			void this.plannedTaskScheduler.handlePlannedTaskSettlement(user, task, 'cancelled');
 		}
 	}
 
@@ -1980,7 +1924,7 @@ export class InstanceAiService {
 		});
 
 		this.creditedThreads.delete(threadId);
-		this.schedulerLocks.delete(threadId);
+		this.plannedTaskScheduler.clearThreadState(threadId);
 		this.domainAccessTrackersByThread.delete(threadId);
 		this.threadPushRef.delete(threadId);
 		this.deleteTraceContextsForThread(threadId);
@@ -2376,80 +2320,6 @@ export class InstanceAiService {
 		});
 	}
 
-	private projectPlannedTaskList(graph: PlannedTaskGraph): TaskList {
-		return {
-			tasks: graph.tasks.map((task) => ({
-				id: task.id,
-				description: task.title,
-				status:
-					task.status === 'planned'
-						? 'todo'
-						: task.status === 'running'
-							? 'in_progress'
-							: task.status === 'succeeded'
-								? 'done'
-								: task.status,
-			})),
-		};
-	}
-
-	private buildPlannedTaskFollowUpMessage(
-		type: 'synthesize' | 'replan' | 'checkpoint',
-		graph: PlannedTaskGraph,
-		options: { failedTask?: PlannedTaskRecord; checkpoint?: PlannedTaskRecord } = {},
-	): string {
-		const payload: Record<string, unknown> = {
-			tasks: graph.tasks.map((task) => ({
-				id: task.id,
-				title: task.title,
-				kind: task.kind,
-				status: task.status,
-				result: task.result,
-				error: task.error,
-				outcome: task.outcome,
-			})),
-		};
-
-		if (options.failedTask) {
-			payload.failedTask = {
-				id: options.failedTask.id,
-				title: options.failedTask.title,
-				kind: options.failedTask.kind,
-				error: options.failedTask.error,
-				result: options.failedTask.result,
-			};
-		}
-
-		if (options.checkpoint) {
-			const depOutcomes = graph.tasks
-				.filter((t) => options.checkpoint!.deps.includes(t.id))
-				.map((t) => ({
-					id: t.id,
-					title: t.title,
-					kind: t.kind,
-					status: t.status,
-					result: t.result,
-					outcome: t.outcome,
-				}));
-			payload.checkpoint = {
-				id: options.checkpoint.id,
-				title: options.checkpoint.title,
-				instructions: options.checkpoint.spec,
-				dependsOn: depOutcomes,
-			};
-		}
-
-		return `<planned-task-follow-up type="${type}">\n${JSON.stringify(payload, null, 2)}\n</planned-task-follow-up>\n\n${AUTO_FOLLOW_UP_MESSAGE}`;
-	}
-
-	private async createPlannedTaskState() {
-		const memory = this.agentMemory;
-		const taskStorage = new ThreadTaskStorage(memory);
-		const plannedTaskStorage = new PlannedTaskStorage(memory);
-		const plannedTaskService = new PlannedTaskCoordinator(plannedTaskStorage);
-		return { memory, taskStorage, plannedTaskService };
-	}
-
 	private evaluateTerminalResponse(
 		threadId: string,
 		runId: string,
@@ -2817,46 +2687,6 @@ export class InstanceAiService {
 		}
 	}
 
-	private async syncPlannedTasksToUi(threadId: string, graph: PlannedTaskGraph): Promise<void> {
-		const { taskStorage } = await this.createPlannedTaskState();
-		const tasks = this.projectPlannedTaskList(graph);
-		await taskStorage.save(threadId, tasks);
-		this.eventBus.publish(threadId, {
-			type: 'tasks-update',
-			runId: graph.planRunId,
-			agentId: ORCHESTRATOR_AGENT_ID,
-			payload: { tasks },
-		});
-	}
-
-	/**
-	 * Drop any persisted planned-task graph that is still `awaiting_approval`,
-	 * and clear the UI checklist. Called on run cancellation and HITL timeout so
-	 * stale approval state doesn't linger. A graph in `active` / `awaiting_replan`
-	 * is already in-flight and has its own settlement logic.
-	 */
-	private async cancelAwaitingApprovalPlan(threadId: string): Promise<void> {
-		try {
-			const { plannedTaskService, taskStorage } = await this.createPlannedTaskState();
-			const graph = await plannedTaskService.getGraph(threadId);
-			if (!graph || graph.status !== 'awaiting_approval') return;
-
-			await plannedTaskService.clear(threadId);
-			await taskStorage.save(threadId, { tasks: [] });
-			this.eventBus.publish(threadId, {
-				type: 'tasks-update',
-				runId: graph.planRunId,
-				agentId: ORCHESTRATOR_AGENT_ID,
-				payload: { tasks: { tasks: [] }, planItems: [] },
-			});
-		} catch (error) {
-			this.logger.warn('Failed to clean up awaiting_approval plan on cancel', {
-				threadId,
-				error: error instanceof Error ? error.message : String(error),
-			});
-		}
-	}
-
 	private async createExecutionEnvironment(
 		user: User,
 		threadId: string,
@@ -3067,7 +2897,8 @@ export class InstanceAiService {
 			touchRun: () => this.runState.touchActiveRun(threadId),
 			touchBackgroundTask: (taskId) => this.backgroundTasks.touchTask(threadId, taskId),
 			plannedTaskService,
-			schedulePlannedTasks: async () => await this.schedulePlannedTasks(user, threadId),
+			schedulePlannedTasks: async () =>
+				await this.plannedTaskScheduler.schedulePlannedTasks(user, threadId),
 			iterationLog,
 			sendCorrectionToTask: (taskId, correction) =>
 				this.sendCorrectionToTask(threadId, taskId, correction),
@@ -3097,146 +2928,6 @@ export class InstanceAiService {
 			modelId,
 			orchestrationContext,
 		};
-	}
-
-	private async dispatchPlannedTask(
-		task: PlannedTaskRecord,
-		context: OrchestrationContext,
-		graph?: PlannedTaskGraph,
-	): Promise<void> {
-		// Plan approval authorizes the task-family's non-destructive tools,
-		// so the sub-agent can execute without a redundant second confirmation.
-		const taskContext = this.createPlannedTaskContext(task.kind, context);
-		const conversationContext = buildPlannedTaskConversationContext(task, graph);
-
-		let started: { taskId: string; agentId: string; result: string } | null = null;
-
-		switch (task.kind) {
-			case 'build-workflow':
-				started = await startBuildWorkflowAgentTask(taskContext, {
-					task: task.spec,
-					workflowId: task.workflowId,
-					plannedTaskId: task.id,
-					conversationContext,
-				});
-				break;
-			case 'delegate':
-				started = await startDetachedDelegateTask(taskContext, {
-					title: task.title,
-					spec: task.spec,
-					tools: task.tools ?? [],
-					plannedTaskId: task.id,
-					conversationContext,
-				});
-				break;
-		}
-
-		if (!started?.taskId) {
-			await context.plannedTaskService?.markFailed(context.threadId, task.id, {
-				error: started?.result || `Failed to start planned task "${task.title}"`,
-			});
-			return;
-		}
-
-		await context.plannedTaskService?.markRunning(context.threadId, task.id, {
-			agentId: started.agentId,
-			backgroundTaskId: started.taskId,
-		});
-
-		const nextGraph = await context.plannedTaskService?.getGraph(context.threadId);
-		if (nextGraph) {
-			await this.syncPlannedTasksToUi(context.threadId, nextGraph);
-		}
-	}
-
-	/**
-	 * Creates a task-scoped OrchestrationContext with plan-approved permission
-	 * overrides. Rebuilds domain tools so each sub-agent gets its own closure
-	 * with the correct permissions, preventing cross-task leakage.
-	 */
-	private createPlannedTaskContext(
-		kind: PlannedTaskRecord['kind'],
-		context: OrchestrationContext,
-	): OrchestrationContext {
-		if (!context.domainContext) return context;
-
-		const taskDomainContext = applyPlannedTaskPermissions(context.domainContext, kind);
-		if (taskDomainContext === context.domainContext) return context;
-
-		return {
-			...context,
-			domainContext: taskDomainContext,
-			domainTools: createAllTools(taskDomainContext),
-		};
-	}
-
-	/**
-	 * Resolve the workflow IDs the checkpoint task is verifying so the runWorkflow
-	 * permission override can be scoped. Walks the checkpoint's `dependsOn` to find
-	 * the build-workflow tasks it depends on and reads their `outcome.workflowId`.
-	 * Returns an empty set when the graph is missing or the checkpoint has no
-	 * resolved workflow deps (in which case the override applies broadly via the
-	 * `allowList === undefined` short-circuit only if we don't set the field).
-	 */
-	private async getCheckpointAllowedWorkflowIds(
-		threadId: string,
-		checkpointTaskId: string,
-	): Promise<ReadonlySet<string>> {
-		try {
-			const { plannedTaskService } = await this.createPlannedTaskState();
-			const graph = await plannedTaskService.getGraph(threadId);
-			const checkpoint = graph?.tasks.find((t) => t.id === checkpointTaskId);
-			if (!graph || !checkpoint) return new Set();
-			const deps = new Set(checkpoint.deps);
-			const allowed = new Set<string>();
-			for (const task of graph.tasks) {
-				if (!deps.has(task.id)) continue;
-				const workflowId = task.outcome?.workflowId;
-				if (typeof workflowId === 'string' && workflowId.length > 0) {
-					allowed.add(workflowId);
-				}
-			}
-			return allowed;
-		} catch (error) {
-			this.logger.warn('Failed to resolve checkpoint allowed workflow IDs', {
-				threadId,
-				checkpointTaskId,
-				error: error instanceof Error ? error.message : String(error),
-			});
-			return new Set();
-		}
-	}
-
-	private async handlePlannedTaskSettlement(
-		user: User,
-		task: ManagedBackgroundTask,
-		status: 'succeeded' | 'failed' | 'cancelled',
-	): Promise<void> {
-		if (!task.plannedTaskId) return;
-
-		const { plannedTaskService } = await this.createPlannedTaskState();
-		let graph: PlannedTaskGraph | null = null;
-
-		if (status === 'succeeded') {
-			graph = await plannedTaskService.markSucceeded(task.threadId, task.plannedTaskId, {
-				result: task.result,
-				outcome: task.outcome,
-			});
-		} else if (status === 'failed') {
-			graph = await plannedTaskService.markFailed(task.threadId, task.plannedTaskId, {
-				error: task.error,
-			});
-		} else {
-			graph = await plannedTaskService.markCancelled(task.threadId, task.plannedTaskId, {
-				error: task.error,
-			});
-		}
-
-		if (graph) {
-			await this.syncPlannedTasksToUi(task.threadId, graph);
-		}
-
-		await this.schedulePlannedTasks(user, task.threadId);
 	}
 
 	private async startInternalFollowUpRun(
@@ -3286,147 +2977,61 @@ export class InstanceAiService {
 		return runId;
 	}
 
-	private async schedulePlannedTasks(user: User, threadId: string): Promise<void> {
-		const prev = this.schedulerLocks.get(threadId) ?? Promise.resolve();
-		// eslint-disable-next-line @typescript-eslint/promise-function-async
-		const current = prev.then(() => this.doSchedulePlannedTasks(user, threadId)).catch(() => {});
-		this.schedulerLocks.set(threadId, current);
-		await current;
-	}
-
-	private async doSchedulePlannedTasks(user: User, threadId: string): Promise<void> {
-		const revalidated = await this.revalidateActiveUser(user.id);
-		if (!revalidated) {
-			this.logger.warn('Cancelling run: user no longer authorized for AI Assistant', {
-				userId: user.id,
-				threadId,
-			});
-			this.cancelRun(threadId);
-			return;
-		}
-
-		const activeUser = revalidated;
-
-		const { plannedTaskService } = await this.createPlannedTaskState();
-		const graph = await plannedTaskService.getGraph(threadId);
-		if (!graph) return;
-
-		await this.syncPlannedTasksToUi(threadId, graph);
-
-		const availableSlots = Math.max(
-			0,
-			MAX_CONCURRENT_BACKGROUND_TASKS_PER_THREAD -
-				this.backgroundTasks.getRunningTasks(threadId).length,
-		);
-		const action = await plannedTaskService.tick(threadId, { availableSlots });
-		if (action.type === 'none') return;
-
-		if (action.type === 'replan') {
-			await this.syncPlannedTasksToUi(threadId, action.graph);
-			const startedRunId = await this.startInternalFollowUpRun(
-				activeUser,
-				threadId,
-				this.buildPlannedTaskFollowUpMessage('replan', action.graph, {
-					failedTask: action.failedTask,
-				}),
-				action.graph.messageGroupId,
-				true,
-			);
-			// tick() already transitioned the graph to `awaiting_replan`. If the
-			// follow-up run couldn't start (live run present), revert the status
-			// so the next schedulePlannedTasks() pass can re-emit this action.
-			// Without this, tick() returns `none` for non-active graphs and the
-			// replan is silently lost.
-			if (!startedRunId) {
-				await plannedTaskService.revertToActive(threadId);
-			}
-			return;
-		}
-
-		if (action.type === 'synthesize') {
-			await this.syncPlannedTasksToUi(threadId, action.graph);
-			const startedRunId = await this.startInternalFollowUpRun(
-				activeUser,
-				threadId,
-				this.buildPlannedTaskFollowUpMessage('synthesize', action.graph),
-				action.graph.messageGroupId,
-			);
-			// Same rollback as replan: tick() transitioned to `completed`, but if
-			// the synthesize follow-up didn't actually start, revert so the next
-			// tick can emit it again.
-			if (!startedRunId) {
-				await plannedTaskService.revertToActive(threadId);
-			}
-			return;
-		}
-
-		if (action.type === 'orchestrate-checkpoint') {
-			// Defer if a run is already active or suspended. The currently-live
-			// run's post-finally reschedule hook will pick this checkpoint up.
-			if (this.runState.hasLiveRun(threadId)) {
-				return;
-			}
-
-			const checkpoint = action.tasks[0];
-
-			// Mark running before starting the follow-up so complete-checkpoint
-			// (which requires status === 'running') always sees the correct state.
-			// If startInternalFollowUpRun no-ops below (tight race), we roll back
-			// the transition to avoid leaving the task in a phantom 'running' state.
-			await plannedTaskService.markRunning(threadId, checkpoint.id, {
-				agentId: ORCHESTRATOR_AGENT_ID,
-			});
-			const graphAfterMark = (await plannedTaskService.getGraph(threadId)) ?? action.graph;
-			await this.syncPlannedTasksToUi(threadId, graphAfterMark);
-
-			const checkpointRecord =
-				graphAfterMark.tasks.find((t) => t.id === checkpoint.id) ?? checkpoint;
-
-			const startedRunId = await this.startInternalFollowUpRun(
-				activeUser,
-				threadId,
-				this.buildPlannedTaskFollowUpMessage('checkpoint', graphAfterMark, {
-					checkpoint: checkpointRecord,
-				}),
-				action.graph.messageGroupId,
-				false,
-				{ isCheckpointFollowUp: true, checkpointTaskId: checkpoint.id },
-			);
-
-			if (!startedRunId) {
-				// Rare race: the outer hasLiveRun check passed but the inner guard
-				// in startInternalFollowUpRun did not (another path started a run
-				// between our two checks). Revert the checkpoint back to `planned`
-				// so the next scheduler tick re-emits `orchestrate-checkpoint` —
-				// marking it `failed` here would cascade cancel to every dependent
-				// and destroy downstream work even though nothing actually failed.
-				this.logger.warn(
-					'Checkpoint follow-up run did not start — reverting checkpoint to planned for retry',
-					{ threadId, checkpointTaskId: checkpoint.id },
-				);
-				await plannedTaskService.revertCheckpointToPlanned(threadId, checkpoint.id);
-			}
-			return;
-		}
-
+	/**
+	 * Build the orchestration context the scheduler uses to dispatch planned
+	 * tasks. Wires tracing for the plan run and routes workflow execution push
+	 * events to the user's iframe session, matching the orchestrator main-run
+	 * path.
+	 */
+	private async createPlannedTaskEnvironment(
+		user: User,
+		threadId: string,
+		planRunId: string,
+		messageGroupId?: string,
+	): Promise<{ orchestrationContext: OrchestrationContext }> {
 		const environment = await this.createExecutionEnvironment(
-			activeUser,
+			user,
 			threadId,
-			action.graph.planRunId,
+			planRunId,
 			createInertAbortSignal(),
-			action.graph.messageGroupId,
+			messageGroupId,
 			// Route planned-task workflow runs (build agent, checkpoint verifications)
 			// to the user's iframe session so live execution push events reach the
 			// frontend, matching the orchestrator main-run path.
 			this.threadPushRef.get(threadId),
 		);
-		environment.orchestrationContext.tracing = this.getTraceContext(action.graph.planRunId);
+		environment.orchestrationContext.tracing = this.getTraceContext(planRunId);
+		return { orchestrationContext: environment.orchestrationContext };
+	}
 
-		for (const task of action.tasks) {
-			await this.dispatchPlannedTask(task, environment.orchestrationContext, action.graph);
-		}
-
-		await this.doSchedulePlannedTasks(activeUser, threadId);
+	/**
+	 * The run-loop seam the planned-task scheduler delegates back into. The
+	 * scheduler owns *when* a follow-up turn or checkpoint re-entry happens; the
+	 * service keeps ownership of the executor spawn and run-state machinery.
+	 */
+	private createPlannedTaskSchedulerHost(): InstanceAiPlannedTaskSchedulerHost {
+		return {
+			revalidateActiveUser: async (userId) => await this.revalidateActiveUser(userId),
+			cancelRun: (threadId) => this.cancelRun(threadId),
+			startInternalFollowUpRun: async (
+				user,
+				threadId,
+				message,
+				messageGroupId,
+				isReplanFollowUp,
+				checkpoint,
+			) =>
+				await this.startInternalFollowUpRun(
+					user,
+					threadId,
+					message,
+					messageGroupId,
+					isReplanFollowUp,
+					checkpoint,
+				),
+			createPlannedTaskEnvironment: async (user, threadId, planRunId, messageGroupId) =>
+				await this.createPlannedTaskEnvironment(user, threadId, planRunId, messageGroupId),
+		};
 	}
 
 	/**
@@ -3517,10 +3122,11 @@ export class InstanceAiService {
 				// Scope the runWorkflow override to the workflows this checkpoint is verifying:
 				// the orchestrator can call `executions(action="run")` on a depended-on workflow
 				// without HITL, but any other workflow id still requires user approval.
-				context.allowedRunWorkflowIds = await this.getCheckpointAllowedWorkflowIds(
-					threadId,
-					checkpoint.checkpointTaskId,
-				);
+				context.allowedRunWorkflowIds =
+					await this.plannedTaskScheduler.getCheckpointAllowedWorkflowIds(
+						threadId,
+						checkpoint.checkpointTaskId,
+					);
 			}
 
 			// Thread attachments into the domain context so parse-file can access them
@@ -4057,198 +3663,17 @@ export class InstanceAiService {
 			//      this call, and tick() is a no-op when no graph exists.
 			if (!this.runState.hasSuspendedRun(threadId)) {
 				if (checkpoint?.isCheckpointFollowUp) {
-					await this.finalizeCheckpointFollowUp(user, threadId, checkpoint.checkpointTaskId);
-				} else {
-					await this.schedulePlannedTasks(user, threadId);
-				}
-				await this.drainPendingCheckpointReentries(user, threadId);
-			}
-		}
-	}
-
-	/**
-	 * Post-run cleanup for a checkpoint follow-up. Ensures the checkpoint task is
-	 * terminal (marking it failed if the orchestrator abandoned it) and re-ticks
-	 * the scheduler so the next planned action can fire.
-	 */
-	private queuePendingCheckpointReentry(threadId: string, checkpointTaskId: string): void {
-		let set = this.pendingCheckpointReentries.get(threadId);
-		if (!set) {
-			set = new Set();
-			this.pendingCheckpointReentries.set(threadId, set);
-		}
-		set.add(checkpointTaskId);
-	}
-
-	/**
-	 * Drain any checkpoint re-entries whose parent-tagged children settled while
-	 * an orchestrator run was live (or while other siblings were still running).
-	 * Called from the post-run cleanup path in every run-ending `finally` block,
-	 * so the checkpoint is never left orphaned when the settlement path could
-	 * not fire immediately.
-	 */
-	private async drainPendingCheckpointReentries(user: User, threadId: string): Promise<void> {
-		const set = this.pendingCheckpointReentries.get(threadId);
-		if (!set || set.size === 0) return;
-		const snapshot = [...set];
-		for (const checkpointTaskId of snapshot) {
-			// If a new run started while we were draining, stop — the next run's
-			// cleanup will pick up the remaining markers.
-			if (this.runState.getActiveRunId(threadId) || this.runState.hasSuspendedRun(threadId)) {
-				return;
-			}
-			// A new parent-tagged child is running — let its settlement drive the
-			// checkpoint instead of racing another re-entry.
-			const siblings = this.backgroundTasks.getRunningTasksByParentCheckpoint(
-				threadId,
-				checkpointTaskId,
-			);
-			if (siblings.length > 0) continue;
-			set.delete(checkpointTaskId);
-			await this.reenterCheckpointById(user, threadId, checkpointTaskId);
-		}
-		if (set.size === 0) this.pendingCheckpointReentries.delete(threadId);
-	}
-
-	/**
-	 * Fire a synthetic `<planned-task-follow-up type="checkpoint">` for the
-	 * given checkpoint task id when the parent-tagged children that drove it
-	 * are no longer running and no new orchestrator run is live. Used by both
-	 * the immediate re-entry path (via `maybeReenterParentCheckpoint`) and the
-	 * deferred drain (via `drainPendingCheckpointReentries`).
-	 */
-	private async reenterCheckpointById(
-		user: User,
-		threadId: string,
-		checkpointTaskId: string,
-		messageGroupId?: string,
-	): Promise<boolean> {
-		try {
-			const { plannedTaskService } = await this.createPlannedTaskState();
-			const graph = await plannedTaskService.getGraph(threadId);
-			const checkpoint = graph?.tasks.find((t) => t.id === checkpointTaskId);
-			if (!graph || !checkpoint || checkpoint.kind !== 'checkpoint') return false;
-			if (checkpoint.status !== 'running') return false;
-
-			const startedRunId = await this.startInternalFollowUpRun(
-				user,
-				threadId,
-				this.buildPlannedTaskFollowUpMessage('checkpoint', graph, { checkpoint }),
-				messageGroupId,
-				false,
-				{ isCheckpointFollowUp: true, checkpointTaskId },
-			);
-			if (!startedRunId) return false;
-			this.logger.debug('Re-entered checkpoint follow-up', {
-				threadId,
-				checkpointTaskId,
-				messageGroupId,
-			});
-			return true;
-		} catch (error) {
-			this.logger.error('Failed to re-enter checkpoint follow-up', {
-				threadId,
-				checkpointTaskId,
-				error: error instanceof Error ? error.message : String(error),
-			});
-			return false;
-		}
-	}
-
-	/**
-	 * When a direct background task (builder/research/data-table/delegate)
-	 * settles and was spawned inside a checkpoint follow-up, try to re-enter
-	 * that checkpoint so the orchestrator can call `complete-checkpoint`.
-	 *
-	 * Returns `true` only when a follow-up was actually started. Returns
-	 * `false` in every other case (checkpoint no longer running, siblings
-	 * still in-flight, an orchestrator run is active or suspended, or the
-	 * graph no longer has the checkpoint). The caller is responsible for
-	 * queuing a deferred re-entry in the false case — never falling through
-	 * to a generic `<background-task-completed>` shell, which would re-open
-	 * the orphan bug.
-	 */
-	private async maybeReenterParentCheckpoint(
-		user: User,
-		threadId: string,
-		task: ManagedBackgroundTask,
-	): Promise<boolean> {
-		const parentCheckpointId = task.parentCheckpointId;
-		if (!parentCheckpointId) return false;
-
-		// If other parent-tagged children are still running, let the LAST one
-		// re-drive the checkpoint; emitting multiple re-dispatches would race.
-		const siblings = this.backgroundTasks
-			.getRunningTasksByParentCheckpoint(threadId, parentCheckpointId)
-			.filter((t) => t.taskId !== task.taskId);
-		if (siblings.length > 0) return false;
-
-		// If a run is live, defer — startInternalFollowUpRun would be rejected
-		// and we must not fall through to the shell path.
-		if (this.runState.getActiveRunId(threadId) || this.runState.hasSuspendedRun(threadId)) {
-			return false;
-		}
-
-		return await this.reenterCheckpointById(
-			user,
-			threadId,
-			parentCheckpointId,
-			task.messageGroupId,
-		);
-	}
-
-	private async finalizeCheckpointFollowUp(
-		user: User,
-		threadId: string,
-		checkpointTaskId: string,
-	): Promise<void> {
-		try {
-			const { plannedTaskService } = await this.createPlannedTaskState();
-			const graph = await plannedTaskService.getGraph(threadId);
-			const task = graph?.tasks.find((t) => t.id === checkpointTaskId);
-			if (task && task.status === 'running') {
-				// If the orchestrator spawned a detached sub-agent inside this
-				// checkpoint's turn (builder, research, data-table, delegate) and
-				// that child is still running, leave the checkpoint running. The
-				// child's settlement path re-emits `orchestrate-checkpoint` so the
-				// orchestrator re-enters the same checkpoint context and can then
-				// call `complete-checkpoint`.
-				const inflightChildren = this.backgroundTasks.getRunningTasksByParentCheckpoint(
-					threadId,
-					checkpointTaskId,
-				);
-				if (inflightChildren.length > 0) {
-					this.logger.debug(
-						'Checkpoint run ended with in-flight child tasks — deferring finalization',
-						{
-							threadId,
-							checkpointTaskId,
-							inflightTaskIds: inflightChildren.map((t) => t.taskId),
-						},
+					await this.plannedTaskScheduler.finalizeCheckpointFollowUp(
+						user,
+						threadId,
+						checkpoint.checkpointTaskId,
 					);
 				} else {
-					this.logger.warn('Checkpoint run ended without reporting completion — marking failed', {
-						threadId,
-						checkpointTaskId,
-					});
-					await plannedTaskService.markCheckpointFailed(threadId, checkpointTaskId, {
-						error: 'Checkpoint run ended without reporting completion',
-					});
-					const nextGraph = await plannedTaskService.getGraph(threadId);
-					if (nextGraph) {
-						await this.syncPlannedTasksToUi(threadId, nextGraph);
-					}
+					await this.plannedTaskScheduler.schedulePlannedTasks(user, threadId);
 				}
+				await this.plannedTaskScheduler.drainPendingCheckpointReentries(user, threadId);
 			}
-		} catch (error) {
-			this.logger.error('Checkpoint finalization failed', {
-				threadId,
-				checkpointTaskId,
-				error: error instanceof Error ? error.message : String(error),
-			});
 		}
-
-		await this.schedulePlannedTasks(user, threadId);
 	}
 
 	async resolveConfirmation(
@@ -4975,15 +4400,15 @@ export class InstanceAiService {
 			// the orchestrate-checkpoint branch was skipped because of hasLiveRun.
 			if (!this.runState.hasSuspendedRun(opts.threadId)) {
 				if (opts.checkpoint?.isCheckpointFollowUp) {
-					await this.finalizeCheckpointFollowUp(
+					await this.plannedTaskScheduler.finalizeCheckpointFollowUp(
 						opts.user,
 						opts.threadId,
 						opts.checkpoint.checkpointTaskId,
 					);
 				} else {
-					await this.schedulePlannedTasks(opts.user, opts.threadId);
+					await this.plannedTaskScheduler.schedulePlannedTasks(opts.user, opts.threadId);
 				}
-				await this.drainPendingCheckpointReentries(opts.user, opts.threadId);
+				await this.plannedTaskScheduler.drainPendingCheckpointReentries(opts.user, opts.threadId);
 			}
 		}
 	}
@@ -5046,7 +4471,7 @@ export class InstanceAiService {
 
 				const user = this.runState.getThreadUser(opts.threadId);
 				if (user) {
-					await this.handlePlannedTaskSettlement(user, task, 'succeeded');
+					await this.plannedTaskScheduler.handlePlannedTaskSettlement(user, task, 'succeeded');
 				}
 			},
 			onFailed: async (task) => {
@@ -5060,7 +4485,7 @@ export class InstanceAiService {
 
 				const user = this.runState.getThreadUser(opts.threadId);
 				if (user) {
-					await this.handlePlannedTaskSettlement(user, task, 'failed');
+					await this.plannedTaskScheduler.handlePlannedTaskSettlement(user, task, 'failed');
 				}
 			},
 			onSettled: async (task) => {
@@ -5090,12 +4515,22 @@ export class InstanceAiService {
 				if (parentCheckpointId) {
 					const user = this.runState.getThreadUser(opts.threadId);
 					if (!user) {
-						this.queuePendingCheckpointReentry(opts.threadId, parentCheckpointId);
+						this.plannedTaskScheduler.queuePendingCheckpointReentry(
+							opts.threadId,
+							parentCheckpointId,
+						);
 						return;
 					}
-					const reentered = await this.maybeReenterParentCheckpoint(user, opts.threadId, task);
+					const reentered = await this.plannedTaskScheduler.maybeReenterParentCheckpoint(
+						user,
+						opts.threadId,
+						task,
+					);
 					if (!reentered) {
-						this.queuePendingCheckpointReentry(opts.threadId, parentCheckpointId);
+						this.plannedTaskScheduler.queuePendingCheckpointReentry(
+							opts.threadId,
+							parentCheckpointId,
+						);
 					}
 					return;
 				}


### PR DESCRIPTION
## Summary

Extracts planned-task scheduling + checkpoint re-entry orchestration out of the ~5.6k-line `InstanceAiService` into a dedicated `InstanceAiPlannedTaskScheduler`, as part of breaking that service into focused, independently-testable units. This is the largest of the extractions.

The scheduler owns the `schedulerLocks` and `pendingCheckpointReentries` maps and the planned-task lifecycle + checkpoint-reentry methods. It's a programmatic collaborator with a small typed host port (`revalidateActiveUser`, `cancelRun`, `startInternalFollowUpRun`, `createPlannedTaskEnvironment`) — the heavy run-loop machinery (run-state registration, executor spawn) stays in `InstanceAiService` and is reached through the port. Pure refactor — no behaviour change.

**How to test:**
\`\`\`bash
cd packages/cli
pnpm typecheck
pnpm test src/modules/instance-ai
\`\`\`
Typecheck clean; all instance-ai unit tests pass, including the new `__tests__/instance-ai-planned-task-scheduler.test.ts`.

> One of several independent `InstanceAiService` extraction PRs branched off `master`; they touch the same file, so expect to rebase as siblings merge.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-393

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI