### PR TITLE
fix(Postgres Node): Validate trigger identifiers

### DIFF
--- a/packages/nodes-base/nodes/Postgres/PostgresTrigger.functions.ts
+++ b/packages/nodes-base/nodes/Postgres/PostgresTrigger.functions.ts
@@ -1,4 +1,3 @@
-import { ApplicationError } from '@n8n/errors';
 import type {
 	ITriggerFunctions,
 	IDataObject,
@@ -6,9 +5,43 @@ import type {
 	INodeListSearchResult,
 	INodeListSearchItems,
 } from 'n8n-workflow';
+import { UserError } from 'n8n-workflow';
 
 import { configurePostgres } from './transport';
 import type { PgpDatabase, PostgresNodeCredentials } from './v2/helpers/interfaces';
+
+const postgresIdentifierRegex = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+const triggerEvents = ['INSERT', 'UPDATE', 'DELETE'] as const;
+
+type TriggerEvent = (typeof triggerEvents)[number];
+
+export function validatePostgresIdentifier(
+	name: unknown,
+	parameterName: string,
+): asserts name is string {
+	if (typeof name !== 'string' || !postgresIdentifierRegex.test(name)) {
+		throw new UserError(
+			`${parameterName} must start with a letter or underscore and contain only letters, digits, and underscores`,
+			{ level: 'warning' },
+		);
+	}
+}
+
+function getFunctionName(functionName: string) {
+	if (functionName.endsWith('()')) {
+		return functionName.slice(0, -2);
+	}
+
+	return functionName;
+}
+
+function getTriggerEvent(firesOn: string): TriggerEvent {
+	if (triggerEvents.includes(firesOn as TriggerEvent)) {
+		return firesOn as TriggerEvent;
+	}
+
+	throw new UserError('Event must be Insert, Update, or Delete', { level: 'warning' });
+}
 
 export function prepareNames(id: string, mode: string, additionalFields: IDataObject) {
 	let suffix = id.replace(/-/g, '_');
@@ -17,19 +50,16 @@ export function prepareNames(id: string, mode: string, additionalFields: IDataOb
 		suffix = `${suffix}_manual`;
 	}
 
-	let functionName =
-		(additionalFields.functionName as string) || `n8n_trigger_function_${suffix}()`;
-
-	if (!(functionName.includes('(') && functionName.includes(')'))) {
-		functionName = `${functionName}()`;
-	}
+	const functionName = getFunctionName(
+		(additionalFields.functionName as string) || `n8n_trigger_function_${suffix}`,
+	);
 
 	const triggerName = (additionalFields.triggerName as string) || `n8n_trigger_${suffix}`;
 	const channelName = (additionalFields.channelName as string) || `n8n_channel_${suffix}`;
 
-	if (channelName.includes('-')) {
-		throw new ApplicationError('Channel name cannot contain hyphens (-)', { level: 'warning' });
-	}
+	validatePostgresIdentifier(functionName, 'Function name');
+	validatePostgresIdentifier(triggerName, 'Trigger name');
+	validatePostgresIdentifier(channelName, 'Channel name');
 
 	return { functionName, triggerName, channelName };
 }
@@ -47,43 +77,26 @@ export async function pgTriggerFunction(
 		extractValue: true,
 	}) as string;
 
-	const target = `${schema}."${tableName}"`;
+	const firesOn = getTriggerEvent(this.getNodeParameter('firesOn', 0) as string);
+	const rowRecord = firesOn === 'DELETE' ? 'OLD' : 'NEW';
 
-	const firesOn = this.getNodeParameter('firesOn', 0) as string;
+	const functionReplace = `CREATE OR REPLACE FUNCTION $1:name() RETURNS trigger LANGUAGE 'plpgsql' COST 100 VOLATILE NOT LEAKPROOF AS $BODY$ begin perform pg_notify($2, row_to_json(${rowRecord})::text); return null; end; $BODY$;`;
 
-	const functionReplace =
-		"CREATE OR REPLACE FUNCTION $1:raw RETURNS trigger LANGUAGE 'plpgsql' COST 100 VOLATILE NOT LEAKPROOF AS $BODY$ begin perform pg_notify('$2:raw', row_to_json($3:raw)::text); return null; end; $BODY$;";
+	const dropIfExist = 'DROP TRIGGER IF EXISTS $1:name ON $2:name.$3:name';
 
-	const dropIfExist = 'DROP TRIGGER IF EXISTS $1:raw ON $2:raw';
+	const functionExists = `CREATE FUNCTION $1:name() RETURNS trigger LANGUAGE 'plpgsql' COST 100 VOLATILE NOT LEAKPROOF AS $BODY$ begin perform pg_notify($2, row_to_json(${rowRecord})::text); return null; end; $BODY$`;
 
-	const functionExists =
-		"CREATE FUNCTION $1:raw RETURNS trigger LANGUAGE 'plpgsql' COST 100 VOLATILE NOT LEAKPROOF AS $BODY$ begin perform pg_notify('$2:raw', row_to_json($3:raw)::text); return null; end; $BODY$";
-
-	const trigger =
-		'CREATE TRIGGER $4:raw AFTER $3:raw ON $1:raw FOR EACH ROW EXECUTE FUNCTION $2:raw';
-
-	const whichData = firesOn === 'DELETE' ? 'old' : 'new';
-
-	if (channelName.includes('-')) {
-		throw new ApplicationError('Channel name cannot contain hyphens (-)', { level: 'warning' });
-	}
+	const trigger = `CREATE TRIGGER $3:name AFTER ${firesOn} ON $1:name.$2:name FOR EACH ROW EXECUTE FUNCTION $4:name()`;
 
 	const replaceIfExists = additionalFields.replaceIfExists ?? false;
 
-	try {
-		if (replaceIfExists || !(additionalFields.triggerName ?? additionalFields.functionName)) {
-			await db.any(functionReplace, [functionName, channelName, whichData]);
-			await db.any(dropIfExist, [triggerName, target, whichData]);
-		} else {
-			await db.any(functionExists, [functionName, channelName, whichData]);
-		}
-		await db.any(trigger, [target, functionName, firesOn, triggerName]);
-	} catch (error) {
-		if ((error as Error).message.includes('near "-"')) {
-			throw new ApplicationError('Names cannot contain hyphens (-)', { level: 'warning' });
-		}
-		throw error;
+	if (replaceIfExists || !(additionalFields.triggerName ?? additionalFields.functionName)) {
+		await db.any(functionReplace, [functionName, channelName]);
+		await db.any(dropIfExist, [triggerName, schema, tableName]);
+	} else {
+		await db.any(functionExists, [functionName, channelName]);
 	}
+	await db.any(trigger, [schema, tableName, triggerName, functionName]);
 }
 
 export async function initDB(this: ITriggerFunctions | ILoadOptionsFunctions) {
@@ -115,7 +128,8 @@ export async function searchTables(this: ILoadOptionsFunctions): Promise<INodeLi
 			[schema.value],
 		);
 	} catch (error) {
-		throw new ApplicationError(error as string);
+		const message = error instanceof Error ? error.message : String(error);
+		throw new UserError(message);
 	}
 	const results: INodeListSearchItems[] = (tableList as IDataObject[]).map((s) => ({
 		name: s.table_name as string,

--- a/packages/nodes-base/nodes/Postgres/PostgresTrigger.node.ts
+++ b/packages/nodes-base/nodes/Postgres/PostgresTrigger.node.ts
@@ -14,6 +14,7 @@ import {
 	searchSchema,
 	searchTables,
 	prepareNames,
+	validatePostgresIdentifier,
 } from './PostgresTrigger.functions';
 
 export class PostgresTrigger implements INodeType {
@@ -279,10 +280,11 @@ export class PostgresTrigger implements INodeType {
 			);
 		} else {
 			pgNames.channelName = this.getNodeParameter('channelName', '') as string;
+			validatePostgresIdentifier(pgNames.channelName, 'Channel name');
 		}
 
 		// listen to channel
-		await connection.none(`LISTEN ${pgNames.channelName}`);
+		await connection.none('LISTEN $1:name', [pgNames.channelName]);
 
 		const cleanUpDb = async () => {
 			try {

--- a/packages/nodes-base/nodes/Postgres/test/PostgresTrigger.test.ts
+++ b/packages/nodes-base/nodes/Postgres/test/PostgresTrigger.test.ts
@@ -1,0 +1,139 @@
+import { mockDeep } from 'jest-mock-extended';
+import type { IDataObject, ITriggerFunctions } from 'n8n-workflow';
+import pgPromise from 'pg-promise';
+
+import {
+	pgTriggerFunction,
+	prepareNames,
+	validatePostgresIdentifier,
+} from '../PostgresTrigger.functions';
+import { PostgresTrigger } from '../PostgresTrigger.node';
+import type { PgpDatabase } from '../v2/helpers/interfaces';
+
+const mockConnect = jest.fn();
+
+jest.mock('../transport', () => ({
+	configurePostgres: jest.fn(() => ({ db: { connect: mockConnect } })),
+}));
+
+const pgp = pgPromise();
+
+describe('PostgresTrigger', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('prepareNames', () => {
+		it('should return default names with normalized function name', () => {
+			expect(prepareNames('node-id', 'trigger', {})).toEqual({
+				functionName: 'n8n_trigger_function_node_id',
+				triggerName: 'n8n_trigger_node_id',
+				channelName: 'n8n_channel_node_id',
+			});
+		});
+
+		it('should normalize custom function names with empty call suffix', () => {
+			expect(
+				prepareNames('node-id', 'trigger', {
+					functionName: 'custom_function()',
+					triggerName: 'custom_trigger',
+					channelName: 'custom_channel',
+				}),
+			).toEqual({
+				functionName: 'custom_function',
+				triggerName: 'custom_trigger',
+				channelName: 'custom_channel',
+			});
+		});
+
+		it('should reject identifiers with unsupported characters', () => {
+			expect(() =>
+				prepareNames('node-id', 'trigger', {
+					functionName: 'custom-function',
+				}),
+			).toThrow(
+				'Function name must start with a letter or underscore and contain only letters, digits, and underscores',
+			);
+
+			expect(() => validatePostgresIdentifier('123_channel', 'Channel name')).toThrow(
+				'Channel name must start with a letter or underscore and contain only letters, digits, and underscores',
+			);
+		});
+	});
+
+	describe('pgTriggerFunction', () => {
+		it('should format trigger setup queries with escaped identifiers', async () => {
+			const any = jest.fn().mockResolvedValue([]);
+			const db = { any } as unknown as PgpDatabase;
+			const triggerFunctions = mockDeep<ITriggerFunctions>();
+
+			triggerFunctions.getNodeParameter.mockImplementation((parameterName: string) => {
+				const parameters: Record<string, unknown> = {
+					schema: 'public',
+					tableName: 'users',
+					firesOn: 'INSERT',
+				};
+
+				return parameters[parameterName] as never;
+			});
+
+			await pgTriggerFunction.call(
+				triggerFunctions,
+				db,
+				{},
+				'custom_function',
+				'custom_trigger',
+				'custom_channel',
+			);
+
+			const formattedQueries = any.mock.calls.map(([query, values]) =>
+				pgp.as.format(query, values as IDataObject[]),
+			);
+
+			expect(formattedQueries).toEqual([
+				"CREATE OR REPLACE FUNCTION \"custom_function\"() RETURNS trigger LANGUAGE 'plpgsql' COST 100 VOLATILE NOT LEAKPROOF AS $BODY$ begin perform pg_notify('custom_channel', row_to_json(NEW)::text); return null; end; $BODY$;",
+				'DROP TRIGGER IF EXISTS "custom_trigger" ON "public"."users"',
+				'CREATE TRIGGER "custom_trigger" AFTER INSERT ON "public"."users" FOR EACH ROW EXECUTE FUNCTION "custom_function"()',
+			]);
+		});
+	});
+
+	describe('trigger', () => {
+		it('should format existing channel listener with identifier placeholder', async () => {
+			const connection = {
+				none: jest.fn().mockResolvedValue(undefined),
+				client: {
+					on: jest.fn(),
+					removeListener: jest.fn(),
+				},
+			};
+			mockConnect.mockResolvedValue(connection);
+
+			const triggerFunctions = mockDeep<ITriggerFunctions>();
+			triggerFunctions.getMode.mockReturnValue('trigger');
+			triggerFunctions.getNode.mockReturnValue({
+				id: 'node-id',
+				name: 'Postgres Trigger',
+				type: 'n8n-nodes-base.postgresTrigger',
+				typeVersion: 1,
+				position: [0, 0],
+				parameters: {},
+			});
+			triggerFunctions.getNodeParameter.mockImplementation((parameterName: string) => {
+				const parameters: Record<string, unknown> = {
+					triggerMode: 'listenTrigger',
+					additionalFields: {},
+					channelName: 'existing_channel',
+				};
+
+				return parameters[parameterName] as never;
+			});
+
+			const node = new PostgresTrigger();
+
+			await node.trigger.call(triggerFunctions);
+
+			expect(connection.none).toHaveBeenCalledWith('LISTEN $1:name', ['existing_channel']);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds validation for Postgres Trigger function, trigger, and channel identifiers before setting up listeners.

Updates the trigger setup and listener SQL to use database-client identifier formatting for generated objects and existing channels.

To test:
- `pushd packages/nodes-base && pnpm test PostgresTrigger.test.ts`
- `pushd packages/nodes-base && pnpm exec eslint nodes/Postgres/PostgresTrigger.functions.ts nodes/Postgres/PostgresTrigger.node.ts nodes/Postgres/test/PostgresTrigger.test.ts --quiet`
- `pushd packages/nodes-base && pnpm typecheck` currently fails on unrelated existing errors in core, Compression, and Form files

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5046

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI