### PR TITLE
fix(core): Maintain Slack thread subscriptions across agent publishes (no-changelog)

### DIFF
--- a/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/agent-chat-bridge.test.ts
@@ -441,6 +441,56 @@ describe('AgentChatBridge — consumeStream', () => {
 			expect(thread.post).toHaveBeenCalledWith({ markdown: 'Hello' });
 		});
 
+		it('clears assistant status before responding directly to top-level Slack DMs', async () => {
+			const { bot, handlers } = makeBot();
+			const setAssistantStatus = jest.fn().mockResolvedValue(undefined);
+			bot.getAdapter.mockReturnValue({ setAssistantStatus });
+			const thread = makeThread();
+			const agentExecutor = {
+				executeForChatPublished: jest.fn(() =>
+					toStream([
+						{ type: 'text-delta', id: 't1', delta: 'Hello' },
+						{ type: 'finish', finishReason: 'stop' },
+					]),
+				),
+				resumeForChat: jest.fn(() => toStream([{ type: 'finish', finishReason: 'stop' }])),
+			};
+
+			new AgentChatBridge(
+				bot as unknown as ChatBotLike,
+				'agent-1',
+				agentExecutor as never,
+				componentMapper,
+				logger,
+				'project-1',
+				slackIntegration,
+			);
+
+			await handlers.mention!(thread, {
+				text: 'hi',
+				raw: {
+					type: 'message',
+					channel: 'D123',
+					channel_type: 'im',
+					ts: '1779466577.518139',
+				},
+				author: { userId: 'u1', userName: 'user1' },
+			});
+
+			expect(setAssistantStatus).toHaveBeenNthCalledWith(
+				1,
+				'D123',
+				'1779466577.518139',
+				'Thinking...',
+				['Thinking...'],
+			);
+			expect(setAssistantStatus).toHaveBeenNthCalledWith(2, 'D123', '1779466577.518139', '');
+			expect(setAssistantStatus.mock.invocationCallOrder[1]).toBeLessThan(
+				thread.post.mock.invocationCallOrder[0],
+			);
+			expect(thread.post).toHaveBeenCalledWith({ markdown: 'Hello' });
+		});
+
 		it('retries top-level Slack assistant status when Slack has not materialized the thread yet', async () => {
 			jest.useFakeTimers();
 			const { bot, handlers } = makeBot();

--- a/packages/cli/src/modules/agents/integrations/__tests__/chat-integration.service.test.ts
+++ b/packages/cli/src/modules/agents/integrations/__tests__/chat-integration.service.test.ts
@@ -99,12 +99,13 @@ function buildServiceWith(
 
 describe('ChatIntegrationService.syncToConfig — publish gate', () => {
 	let service: ChatIntegrationService;
+	let projectRelationRepository: ReturnType<typeof mock<ProjectRelationRepository>>;
 	let connectSpy: jest.SpyInstance;
 	let disconnectSpy: jest.SpyInstance;
 
 	beforeEach(() => {
 		Container.reset();
-		({ service } = buildServiceWith());
+		({ service, projectRelationRepository } = buildServiceWith());
 		connectSpy = jest.spyOn(service, 'connect').mockResolvedValue();
 		disconnectSpy = jest.spyOn(service, 'disconnect').mockResolvedValue();
 	});
@@ -123,6 +124,17 @@ describe('ChatIntegrationService.syncToConfig — publish gate', () => {
 		await service.syncToConfig(agent, [slackIntegration], []);
 
 		expect(disconnectSpy).toHaveBeenCalledWith('agent-1', slackIntegration);
+		expect(connectSpy).not.toHaveBeenCalled();
+	});
+
+	it('does not reconnect an already-live integration when republishing', async () => {
+		const agent = makeAgent({ activeVersionId: 'published-version-1' });
+		projectRelationRepository.findUserIdsByProjectId.mockResolvedValue(['user-1']);
+		const internal = service as unknown as { connections: Map<string, unknown> };
+		internal.connections.set('agent-1:slack:cred-1', {});
+
+		await service.syncToConfig(agent, [], [slackIntegration]);
+
 		expect(connectSpy).not.toHaveBeenCalled();
 	});
 });

--- a/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
+++ b/packages/cli/src/modules/agents/integrations/agent-chat-bridge.ts
@@ -27,6 +27,7 @@ interface SlackThreadContext {
 	channelId: string;
 	threadTs: string;
 	hasRealThreadTs: boolean;
+	isDm: boolean;
 }
 
 interface SlackAssistantStatusAdapter {
@@ -36,6 +37,10 @@ interface SlackAssistantStatusAdapter {
 		status: string,
 		loadingMessages?: string[],
 	): Promise<void>;
+}
+
+interface SlackAssistantStatusHandle {
+	clearBeforeResponse(): Promise<void>;
 }
 
 interface AgentExecutor {
@@ -303,7 +308,7 @@ export class AgentChatBridge {
 		// startThinkingStatus (Slack assistant.threads.setStatus) and the lazy
 		// `message.subject` fetch are both remote round-trips on independent
 		// resources — run them concurrently.
-		const [, subject] = await Promise.all([
+		const [statusHandle, subject] = await Promise.all([
 			this.startThinkingStatus(thread, slackThreadContext, statusRetry.signal),
 			this.resolveMessageSubject(message),
 		]);
@@ -331,6 +336,7 @@ export class AgentChatBridge {
 		try {
 			await this.consumeStream(stream, thread, {
 				forceBuffered: this.integration.type === 'slack' && !useNativeSlackThreadFeatures,
+				statusHandle,
 			});
 		} finally {
 			statusRetry.abort();
@@ -356,10 +362,12 @@ export class AgentChatBridge {
 	private async consumeStream(
 		stream: AsyncGenerator<StreamChunk>,
 		thread: Thread,
-		options: { forceBuffered?: boolean } = {},
+		options: { forceBuffered?: boolean; statusHandle?: SlackAssistantStatusHandle } = {},
 	): Promise<void> {
 		if (this.disableStreaming || options.forceBuffered) {
-			await this.consumeStreamBuffered(stream, thread);
+			await this.consumeStreamBuffered(stream, thread, {
+				statusHandle: options.statusHandle,
+			});
 			return;
 		}
 
@@ -442,19 +450,24 @@ export class AgentChatBridge {
 		const ensureStreamingPost = () => {
 			if (!streamingPost) startStreamingPost();
 		};
+		const responseLifecycle = this.createResponseLifecycle({
+			statusHandle: options.statusHandle,
+			ensureStreamingPost,
+			endStreamingPost,
+		});
 
 		try {
 			for await (const chunk of stream) {
 				switch (chunk.type) {
 					case 'text-delta': {
 						const { delta } = chunk;
-						ensureStreamingPost();
+						await responseLifecycle.startStreamingResponse();
 						textStream.yield?.(delta);
 						break;
 					}
 					case 'reasoning-delta': {
 						const { delta } = chunk;
-						ensureStreamingPost();
+						await responseLifecycle.startStreamingResponse();
 						textStream.yield?.(`_${delta}_`);
 						break;
 					}
@@ -463,24 +476,24 @@ export class AgentChatBridge {
 						break;
 					case 'tool-call-suspended':
 						this.richInteractionInputs.delete(chunk.toolCallId);
-						await endStreamingPost();
+						await responseLifecycle.startDiscreteResponse();
 						await this.handleSuspension(chunk, thread);
 						// Don't start new streaming post — wait for next text delta
 						break;
 					case 'tool-result':
 						if (this.isRichInteractionDisplayOnly(chunk)) {
-							await endStreamingPost();
+							await responseLifecycle.startDiscreteResponse();
 							await this.handleDisplayOnly(chunk, thread);
 						} else {
 							this.richInteractionInputs.delete(chunk.toolCallId);
 						}
 						break;
 					case 'message':
-						await endStreamingPost();
+						await responseLifecycle.startDiscreteResponse();
 						await this.handleMessage(chunk, thread);
 						break;
 					case 'error':
-						await endStreamingPost();
+						await responseLifecycle.startDiscreteResponse();
 						await this.postErrorToThread(thread, chunk.error);
 						break;
 					default:
@@ -493,9 +506,38 @@ export class AgentChatBridge {
 			// Always end the streaming post and drop stashed tool-call inputs so
 			// a stream that errors mid-flight between `tool-call` and the
 			// matching `tool-result` does not leak entries.
-			await endStreamingPost();
+			await responseLifecycle.finish();
 			this.richInteractionInputs.clear();
 		}
+	}
+
+	private createResponseLifecycle(options: {
+		statusHandle?: SlackAssistantStatusHandle;
+		ensureStreamingPost?: () => void;
+		endStreamingPost?: () => Promise<void>;
+	}) {
+		let responseStarted = false;
+
+		const clearStatusBeforeFirstResponse = async () => {
+			if (responseStarted) return;
+			responseStarted = true;
+			await options.statusHandle?.clearBeforeResponse();
+		};
+
+		return {
+			startStreamingResponse: async () => {
+				await clearStatusBeforeFirstResponse();
+				options.ensureStreamingPost?.();
+			},
+			startDiscreteResponse: async () => {
+				await options.endStreamingPost?.();
+				await clearStatusBeforeFirstResponse();
+			},
+			finish: async () => {
+				await options.endStreamingPost?.();
+				await clearStatusBeforeFirstResponse();
+			},
+		};
 	}
 
 	/**
@@ -506,14 +548,19 @@ export class AgentChatBridge {
 	private async consumeStreamBuffered(
 		stream: AsyncGenerator<StreamChunk>,
 		thread: Thread,
+		options: { statusHandle?: SlackAssistantStatusHandle } = {},
 	): Promise<void> {
 		let buffer = '';
+		const responseLifecycle = this.createResponseLifecycle({
+			statusHandle: options.statusHandle,
+		});
 
 		const flushBuffer = async () => {
 			const text = buffer;
 			buffer = '';
 			if (!text.trim()) return;
 			try {
+				await responseLifecycle.startDiscreteResponse();
 				// Chat SDK's streaming path wraps accumulated deltas as `{ markdown }`
 				// so the platform adapter applies its markdown parse-mode (Telegram:
 				// sendMessage with parse_mode=Markdown). A raw string bypasses that
@@ -543,11 +590,13 @@ export class AgentChatBridge {
 					case 'tool-call-suspended':
 						this.richInteractionInputs.delete(chunk.toolCallId);
 						await flushBuffer();
+						await responseLifecycle.startDiscreteResponse();
 						await this.handleSuspension(chunk, thread);
 						break;
 					case 'tool-result':
 						if (this.isRichInteractionDisplayOnly(chunk)) {
 							await flushBuffer();
+							await responseLifecycle.startDiscreteResponse();
 							await this.handleDisplayOnly(chunk, thread);
 						} else {
 							this.richInteractionInputs.delete(chunk.toolCallId);
@@ -555,10 +604,12 @@ export class AgentChatBridge {
 						break;
 					case 'message':
 						await flushBuffer();
+						await responseLifecycle.startDiscreteResponse();
 						await this.handleMessage(chunk, thread);
 						break;
 					case 'error':
 						await flushBuffer();
+						await responseLifecycle.startDiscreteResponse();
 						await this.postErrorToThread(thread, chunk.error);
 						break;
 					default:
@@ -567,6 +618,7 @@ export class AgentChatBridge {
 			}
 		} finally {
 			await flushBuffer();
+			await responseLifecycle.finish();
 			this.richInteractionInputs.clear();
 		}
 	}
@@ -913,12 +965,17 @@ export class AgentChatBridge {
 		thread: Thread<unknown, unknown>,
 		slackThreadContext?: SlackThreadContext,
 		statusRetrySignal?: AbortSignal,
-	): Promise<void> {
+	): Promise<SlackAssistantStatusHandle | undefined> {
 		if (this.integration.type !== 'slack') return;
 
 		if (slackThreadContext && !slackThreadContext.hasRealThreadTs) {
 			this.setSlackAssistantStatus(slackThreadContext, statusRetrySignal);
-			return;
+			return slackThreadContext.isDm
+				? {
+						clearBeforeResponse: async () =>
+							await this.clearSlackAssistantStatus(slackThreadContext),
+					}
+				: undefined;
 		}
 
 		try {
@@ -930,6 +987,7 @@ export class AgentChatBridge {
 				error: error instanceof Error ? error.message : String(error),
 			});
 		}
+		return undefined;
 	}
 
 	private setSlackAssistantStatus(
@@ -940,6 +998,22 @@ export class AgentChatBridge {
 		if (!adapter) return;
 
 		void this.setSlackAssistantStatusWithRetry(adapter, context, statusRetrySignal);
+	}
+
+	private async clearSlackAssistantStatus(context: SlackThreadContext): Promise<void> {
+		const adapter = this.getSlackAssistantStatusAdapter();
+		if (!adapter) return;
+
+		try {
+			await adapter.setAssistantStatus(context.channelId, context.threadTs, '');
+		} catch (error) {
+			this.logger.warn('[AgentChatBridge] Failed to clear Slack assistant status', {
+				agentId: this.agentId,
+				channelId: context.channelId,
+				threadTs: context.threadTs,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
 	}
 
 	private async setSlackAssistantStatusWithRetry(
@@ -997,6 +1071,7 @@ export class AgentChatBridge {
 		if (!isRecord(raw)) return undefined;
 
 		const channelId = stringValue(raw.channel);
+		const channelType = stringValue(raw.channel_type);
 		const realThreadTs = stringValue(raw.thread_ts);
 		const threadTs = realThreadTs ?? stringValue(raw.ts);
 		if (!channelId || !threadTs) return undefined;
@@ -1005,6 +1080,7 @@ export class AgentChatBridge {
 			channelId,
 			threadTs,
 			hasRealThreadTs: realThreadTs !== undefined,
+			isDm: channelType === 'im',
 		};
 	}
 

--- a/packages/cli/src/modules/agents/integrations/chat-integration.service.ts
+++ b/packages/cli/src/modules/agents/integrations/chat-integration.service.ts
@@ -374,6 +374,9 @@ export class ChatIntegrationService {
 			: [];
 
 		for (const integration of additions) {
+			const key = this.connectionKey(agent.id, integration.type, integration.credentialId);
+			if (this.connections.has(key)) continue;
+
 			let connected = false;
 			for (const userId of userIds) {
 				try {


### PR DESCRIPTION
## Summary

Fixes Slack agent thread tracking being lost after republishing an agent.Fixes Slack agent thread tracking being lost after republishing an agent.

Republishing was reconnecting an already-live Slack integration, which replaced the in-memory Chat SDK state and dropped subscribed thread tracking. This now skips reconnecting integrations that are already connected, preserving thread subscriptions so replies in existing Slack threads keep routing to the agent without re-tagging.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
