### PR TITLE
test: Resolve test-config module aliases dynamically instead of hardcoding versions (no-changelog)

### DIFF
--- a/packages/@n8n/ai-utilities/vite.config.ts
+++ b/packages/@n8n/ai-utilities/vite.config.ts
@@ -16,13 +16,12 @@ export default mergeConfig(
 				// Workspace deps CJS-require zod while tests ESM-import it, so
 				// `schema instanceof ZodSchema` in src/converters/tool.ts fails across the
 				// two. Pin the top-level `zod` import to the CJS file so both share one
-				// module instance. Subpaths like `zod/v4` keep their normal resolution.
+				// module instance. `require.resolve` follows zod's `require` export condition,
+				// so it tracks the installed (catalog) version automatically. Subpaths like
+				// `zod/v4` keep their normal resolution.
 				{
 					find: /^zod$/,
-					replacement: path.resolve(
-						__dirname,
-						'../../../node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/cjs/index.js',
-					),
+					replacement: require.resolve('zod'),
 				},
 			],
 		},

--- a/packages/@n8n/instance-ai/vite.config.ts
+++ b/packages/@n8n/instance-ai/vite.config.ts
@@ -50,13 +50,12 @@ export default mergeConfig(
 				// Workspace deps CJS-require zod while test files ESM-import it, so
 				// `instanceof` checks (e.g. in sanitize-mcp-schemas) fail across the two
 				// module instances. Pin the top-level `zod` import to the CJS file so all
-				// code paths share one instance. Subpaths like `zod/v4` resolve normally.
+				// code paths share one instance. `require.resolve` follows zod's `require`
+				// export condition, so it tracks the installed (catalog) version
+				// automatically. Subpaths like `zod/v4` resolve normally.
 				{
 					find: /^zod$/,
-					replacement: path.resolve(
-						__dirname,
-						'../../../node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/cjs/index.js',
-					),
+					replacement: require.resolve('zod'),
 				},
 			],
 		},

--- a/packages/@n8n/nodes-langchain/vite.config.ts
+++ b/packages/@n8n/nodes-langchain/vite.config.ts
@@ -12,7 +12,10 @@ export default mergeConfig(
 			alias: {
 				'@utils': path.resolve(__dirname, './utils'),
 				'@nodes-testing': path.resolve(__dirname, '../../core/nodes-testing'),
-				'n8n-workflow': path.resolve(__dirname, '../../workflow/dist/cjs/index.js'),
+				// Pin n8n-workflow to its CJS build so the single module instance is shared
+				// across CJS-required workspace deps and ESM-imported test code.
+				// `require.resolve` follows the `require` export condition (the CJS dist).
+				'n8n-workflow': require.resolve('n8n-workflow'),
 			},
 		},
 	}),

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -16,14 +16,12 @@ export default mergeConfig(
 				// `./dist/cjs/index.js` for `require`) — two separate files with two separate
 				// `ZodType` classes. @n8n/config dist CJS-requires zod, test files ESM-import
 				// it, and `instanceof` fails between them. Pin the top-level `zod` import to the
-				// CJS file so both code paths share a single module instance. Subpaths like
-				// `zod/v4` keep their normal resolution.
+				// CJS file so both code paths share a single module instance. `require.resolve`
+				// follows zod's `require` export condition, so it tracks the installed (catalog)
+				// version automatically. Subpaths like `zod/v4` keep their normal resolution.
 				{
 					find: /^zod$/,
-					replacement: path.resolve(
-						__dirname,
-						'../../node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/cjs/index.js',
-					),
+					replacement: require.resolve('zod'),
 				},
 			],
 		},


### PR DESCRIPTION
## Summary

Four Vitest configs alias `zod` (and one aliases `n8n-workflow`) to that package's **CJS** build to avoid the dual-package hazard: a package shipping separate ESM (`dist/esm`) and CJS (`dist/cjs`) builds exposes two distinct class identities, so `instanceof` checks fail when one copy is `require`d (by CJS-compiled workspace deps) and the other is `import`ed (Vitest inlines test code and resolves the ESM condition). Forcing every import to the CJS file unifies the module instance.

The problem was *how* the alias pointed there — a hardcoded path baking in both a pinned version and pnpm internals:

```
node_modules/.pnpm/zod@3.25.67/node_modules/zod/dist/cjs/index.js
```

A catalog bump or pnpm-layout change silently breaks this — no error, just the `instanceof` failures quietly return. `zod` is `catalog:` everywhere, so the version should never be hand-written.

This replaces each hardcoded path with `require.resolve(<pkg>)`, which follows the package's `require` export condition (the CJS build by definition) and tracks the installed version automatically. All four configs are CJS (no `"type": "module"`, they already use `__dirname`), so `require.resolve` is available without `createRequire`.

**Files changed:**
- `packages/core/vite.config.ts` — `zod`
- `packages/@n8n/ai-utilities/vite.config.ts` — `zod`
- `packages/@n8n/instance-ai/vite.config.ts` — `zod`
- `packages/@n8n/nodes-langchain/vite.config.ts` — `n8n-workflow`

### How to test

Run the affected suites — the `instanceof` checks that motivated the alias fail loudly if CJS unification breaks:

```bash
pnpm --filter n8n-core test
pnpm --filter @n8n/ai-utilities test          # exercises src/converters/tool.ts instanceof ZodSchema
pnpm --filter @n8n/instance-ai test           # exercises sanitize-mcp-schemas instanceof
pnpm --filter @n8n/n8n-nodes-langchain test
```

All four pass locally. Sanity-check resolution is unchanged (prints the same paths the hardcoded strings pointed at):

```bash
cd packages/core && node -e "console.log(require.resolve('zod'))"
cd packages/@n8n/nodes-langchain && node -e "console.log(require.resolve('n8n-workflow'))"
```

## Related Linear tickets, Github issues, and Community forum posts

N/A — maintenance cleanup.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!-- Test-config-only change; covered by the existing suites that exercise the instanceof paths. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI