### PR TITLE
refactor(core): Use Time constants for time-based config defaults

### DIFF
--- a/packages/@n8n/config/package.json
+++ b/packages/@n8n/config/package.json
@@ -22,6 +22,7 @@
     "dist/**/*"
   ],
   "dependencies": {
+    "@n8n/constants": "workspace:*",
     "@n8n/di": "workspace:*",
     "reflect-metadata": "catalog:",
     "zod": "catalog:"

--- a/packages/@n8n/config/src/configs/agents.config.ts
+++ b/packages/@n8n/config/src/configs/agents.config.ts
@@ -30,7 +30,7 @@ class AgentsModuleArray extends CommaSeparatedStringArray<AgentsModuleName> {
 export class AgentsConfig {
 	/** TTL in seconds for agent checkpoint records. Stale checkpoints older than this are pruned. */
 	@Env('N8N_AGENTS_CHECKPOINT_TTL')
-	checkpointTtlSeconds: number = 4 * Time.days.toSeconds;
+	checkpointTtlSeconds: number = 96 * Time.hours.toSeconds;
 
 	/** Maximum number of sub-agents a single parent run may spawn. Bounds fan-out width. */
 	@Env('N8N_AGENTS_SUBAGENT_MAX_CHILDREN')

--- a/packages/@n8n/config/src/configs/agents.config.ts
+++ b/packages/@n8n/config/src/configs/agents.config.ts
@@ -1,3 +1,5 @@
+import { Time } from '@n8n/constants';
+
 import { CommaSeparatedStringArray } from '../custom-types';
 import { Config, Env } from '../decorators';
 
@@ -28,7 +30,7 @@ class AgentsModuleArray extends CommaSeparatedStringArray<AgentsModuleName> {
 export class AgentsConfig {
 	/** TTL in seconds for agent checkpoint records. Stale checkpoints older than this are pruned. */
 	@Env('N8N_AGENTS_CHECKPOINT_TTL')
-	checkpointTtlSeconds: number = 345600; // 96 hours
+	checkpointTtlSeconds: number = 4 * Time.days.toSeconds;
 
 	/** Maximum number of sub-agents a single parent run may spawn. Bounds fan-out width. */
 	@Env('N8N_AGENTS_SUBAGENT_MAX_CHILDREN')
@@ -36,7 +38,7 @@ export class AgentsConfig {
 
 	/** Abort an individual sub-agent run after this many milliseconds. */
 	@Env('N8N_AGENTS_SUBAGENT_TIMEOUT_MS')
-	subAgentTimeoutMs: number = 300000; // 5 minutes
+	subAgentTimeoutMs: number = 5 * Time.minutes.toMilliseconds;
 
 	/**
 	 * Comma-separated list of agent sub-feature modules to enable. Each entry

--- a/packages/@n8n/config/src/configs/ai.config.ts
+++ b/packages/@n8n/config/src/configs/ai.config.ts
@@ -1,3 +1,5 @@
+import { Time } from '@n8n/constants';
+
 import { Config, Env } from '../decorators';
 
 @Config
@@ -9,10 +11,10 @@ export class AiConfig {
 	/**
 	 * Maximum time in milliseconds to wait for an HTTP response from an AI service.
 	 * Matches the maximum workflow execution timeout, EXECUTIONS_TIMEOUT_MAX (1 hour) so AI calls do not outlive executions.
-	 * Default: 3600000 (1 hour).
+	 * Default: 1 hour.
 	 */
 	@Env('N8N_AI_TIMEOUT_MAX')
-	timeout: number = 3600000;
+	timeout: number = 1 * Time.hours.toMilliseconds;
 
 	/**
 	 * Whether workflow and node parameter values may be sent to AI providers.

--- a/packages/@n8n/config/src/configs/cache.config.ts
+++ b/packages/@n8n/config/src/configs/cache.config.ts
@@ -1,3 +1,4 @@
+import { Time } from '@n8n/constants';
 import { z } from 'zod';
 
 import { Config, Env, Nested } from '../decorators';
@@ -13,7 +14,7 @@ class MemoryConfig {
 
 	/** Time to live in milliseconds for entries in the memory cache. Default: 1 hour. */
 	@Env('N8N_CACHE_MEMORY_TTL')
-	ttl: number = 3600 * 1000; // 1 hour
+	ttl: number = 1 * Time.hours.toMilliseconds;
 }
 
 @Config
@@ -24,7 +25,7 @@ class RedisConfig {
 
 	/** Time to live in milliseconds for Redis cache entries. Set to 0 to disable expiry. Default: 1 hour. */
 	@Env('N8N_CACHE_REDIS_TTL')
-	ttl: number = 3600 * 1000; // 1 hour
+	ttl: number = 1 * Time.hours.toMilliseconds;
 }
 
 @Config

--- a/packages/@n8n/config/src/configs/chat-hub.config.ts
+++ b/packages/@n8n/config/src/configs/chat-hub.config.ts
@@ -1,3 +1,5 @@
+import { Time } from '@n8n/constants';
+
 import { Config, Env } from '../decorators';
 
 @Config
@@ -8,14 +10,14 @@ export class ChatHubConfig {
 	 * After this TTL, responses from those executions are no longer captured or sent to the client.
 	 */
 	@Env('N8N_CHAT_HUB_EXECUTION_CONTEXT_TTL')
-	executionContextTtl: number = 3600;
+	executionContextTtl: number = 1 * Time.hours.toSeconds;
 
 	/**
 	 * Time to live in seconds for stream state in Chat Hub.
 	 * Inactive streams are cleaned up after this duration.
 	 */
 	@Env('N8N_CHAT_HUB_STREAM_STATE_TTL')
-	streamStateTtl: number = 300;
+	streamStateTtl: number = 5 * Time.minutes.toSeconds;
 
 	/** Maximum number of response chunks to buffer per stream for reconnection in Chat Hub. */
 	@Env('N8N_CHAT_HUB_MAX_BUFFERED_CHUNKS')

--- a/packages/@n8n/config/src/configs/data-table.config.ts
+++ b/packages/@n8n/config/src/configs/data-table.config.ts
@@ -1,6 +1,8 @@
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
+import { Time } from '@n8n/constants';
+
 import { Config, Env } from '../decorators';
 
 @Config
@@ -21,7 +23,7 @@ export class DataTableConfig {
 	 * Reduces database load when validating size repeatedly.
 	 */
 	@Env('N8N_DATA_TABLES_SIZE_CHECK_CACHE_DURATION_MS')
-	sizeCheckCacheDuration: number = 5 * 1000;
+	sizeCheckCacheDuration: number = 5 * Time.seconds.toMilliseconds;
 
 	/**
 	 * Maximum file size in bytes for CSV uploads to data tables.
@@ -32,14 +34,14 @@ export class DataTableConfig {
 
 	/** Interval in milliseconds between cleanup runs for orphaned upload files. Default: 60000 milliseconds. */
 	@Env('N8N_DATA_TABLES_CLEANUP_INTERVAL_MS')
-	cleanupIntervalMs: number = 60 * 1000;
+	cleanupIntervalMs: number = 1 * Time.minutes.toMilliseconds;
 
 	/**
 	 * Age in milliseconds after which an uploaded file is treated as orphaned and deleted during cleanup.
 	 * Default: 2 minutes.
 	 */
 	@Env('N8N_DATA_TABLES_FILE_MAX_AGE_MS')
-	fileMaxAgeMs: number = 2 * 60 * 1000;
+	fileMaxAgeMs: number = 2 * Time.minutes.toMilliseconds;
 
 	/**
 	 * Directory for temporary CSV uploads before import. Files in this directory are pruned by cleanup (see fileMaxAgeMs).

--- a/packages/@n8n/config/src/configs/data-table.config.ts
+++ b/packages/@n8n/config/src/configs/data-table.config.ts
@@ -1,7 +1,6 @@
+import { Time } from '@n8n/constants';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-
-import { Time } from '@n8n/constants';
 
 import { Config, Env } from '../decorators';
 

--- a/packages/@n8n/config/src/configs/data-table.config.ts
+++ b/packages/@n8n/config/src/configs/data-table.config.ts
@@ -32,7 +32,7 @@ export class DataTableConfig {
 	@Env('N8N_DATA_TABLES_UPLOAD_MAX_FILE_SIZE_BYTES')
 	uploadMaxFileSize?: number;
 
-	/** Interval in milliseconds between cleanup runs for orphaned upload files. Default: 60000 milliseconds. */
+	/** Interval in milliseconds between cleanup runs for orphaned upload files. Default: 1 minute. */
 	@Env('N8N_DATA_TABLES_CLEANUP_INTERVAL_MS')
 	cleanupIntervalMs: number = 1 * Time.minutes.toMilliseconds;
 

--- a/packages/@n8n/config/src/configs/database.config.ts
+++ b/packages/@n8n/config/src/configs/database.config.ts
@@ -1,3 +1,4 @@
+import { Time } from '@n8n/constants';
 import { z } from 'zod';
 
 import { Config, Env, Nested } from '../decorators';
@@ -88,11 +89,11 @@ class PostgresConfig {
 
 	/** Maximum time in milliseconds for a single query. Queries exceeding this are cancelled. Set to 0 to disable. */
 	@Env('DB_POSTGRESDB_STATEMENT_TIMEOUT')
-	statementTimeoutMs: number = 5 * 60 * 1000; // 5 minutes
+	statementTimeoutMs: number = 5 * Time.minutes.toMilliseconds;
 
 	/** Maximum lifetime in milliseconds of a pooled Postgres connection before it is recycled. Set to 0 to disable. */
 	@Env('DB_POSTGRESDB_MAX_CONNECTION_LIFETIME_MS')
-	maxConnectionLifetimeMs: number = 60 * 60 * 1000;
+	maxConnectionLifetimeMs: number = 1 * Time.hours.toMilliseconds;
 
 	/** Whether to enable TCP keepalive on Postgres connections so dead peers are detected without waiting for a query. */
 	@Env('DB_POSTGRESDB_KEEP_ALIVE')

--- a/packages/@n8n/config/src/configs/executions.config.ts
+++ b/packages/@n8n/config/src/configs/executions.config.ts
@@ -1,3 +1,4 @@
+import { Time } from '@n8n/constants';
 import z from 'zod';
 
 import { Config, Env, Nested } from '../decorators';
@@ -98,7 +99,7 @@ export class ExecutionsConfig {
 
 	/** Upper bound in seconds for execution timeout. Default: 1 hour. */
 	@Env('EXECUTIONS_TIMEOUT_MAX')
-	maxTimeout: number = 3600; // 1h
+	maxTimeout: number = 1 * Time.hours.toSeconds;
 
 	/** Whether to delete past executions on a rolling basis. */
 	@Env('EXECUTIONS_DATA_PRUNE')

--- a/packages/@n8n/config/src/configs/instance-ai.config.ts
+++ b/packages/@n8n/config/src/configs/instance-ai.config.ts
@@ -1,3 +1,5 @@
+import { Time } from '@n8n/constants';
+
 import { Config, Env } from '../decorators';
 
 @Config
@@ -64,7 +66,7 @@ export class InstanceAiConfig {
 
 	/** Default command timeout in the sandbox (milliseconds). */
 	@Env('N8N_INSTANCE_AI_SANDBOX_TIMEOUT')
-	sandboxTimeout: number = 300_000;
+	sandboxTimeout: number = 5 * Time.minutes.toMilliseconds;
 
 	/** Prefix prepended to every Daytona sandbox name (e.g. `eval-baseline-daily`); also surfaced as a `name_prefix` label. */
 	@Env('N8N_INSTANCE_AI_SANDBOX_NAME_PREFIX')
@@ -76,11 +78,11 @@ export class InstanceAiConfig {
 	 * Only used in proxy mode (when a `getAuthToken` callback is configured); ignored for static API keys.
 	 */
 	@Env('N8N_INSTANCE_AI_DAYTONA_TOKEN_REFRESH_SKEW_MS')
-	daytonaTokenRefreshSkewMs: number = 5 * 60 * 1000;
+	daytonaTokenRefreshSkewMs: number = 5 * Time.minutes.toMilliseconds;
 
 	/** How long to keep completed workflow-builder sandboxes warm for follow-up fixes. 0 = disabled. */
 	@Env('N8N_INSTANCE_AI_BUILDER_SANDBOX_TTL_MS')
-	builderSandboxTtlMs: number = 15 * 60 * 1000;
+	builderSandboxTtlMs: number = 15 * Time.minutes.toMilliseconds;
 
 	/** Brave Search API key for web search. No key = search + research agent disabled. */
 	@Env('INSTANCE_AI_BRAVE_SEARCH_API_KEY')
@@ -100,13 +102,13 @@ export class InstanceAiConfig {
 
 	/** Interval in milliseconds between native persistence pruning runs. 0 = disabled. */
 	@Env('N8N_INSTANCE_AI_SNAPSHOT_PRUNE_INTERVAL')
-	snapshotPruneInterval: number = 60 * 60 * 1000; // 1 hour
+	snapshotPruneInterval: number = 1 * Time.hours.toMilliseconds;
 
 	/** Retention period in milliseconds for stale native persistence checkpoints before pruning. */
 	@Env('N8N_INSTANCE_AI_SNAPSHOT_RETENTION')
-	snapshotRetention: number = 24 * 60 * 60 * 1000; // 24 hours
+	snapshotRetention: number = 1 * Time.days.toMilliseconds;
 
 	/** Timeout in milliseconds for HITL confirmation requests. 0 = no timeout. */
 	@Env('N8N_INSTANCE_AI_CONFIRMATION_TIMEOUT')
-	confirmationTimeout: number = 24 * 60 * 60 * 1000; // 24 hours
+	confirmationTimeout: number = 1 * Time.days.toMilliseconds;
 }

--- a/packages/@n8n/config/src/configs/instance-ai.config.ts
+++ b/packages/@n8n/config/src/configs/instance-ai.config.ts
@@ -106,9 +106,9 @@ export class InstanceAiConfig {
 
 	/** Retention period in milliseconds for stale native persistence checkpoints before pruning. */
 	@Env('N8N_INSTANCE_AI_SNAPSHOT_RETENTION')
-	snapshotRetention: number = 1 * Time.days.toMilliseconds;
+	snapshotRetention: number = 24 * Time.hours.toMilliseconds;
 
 	/** Timeout in milliseconds for HITL confirmation requests. 0 = no timeout. */
 	@Env('N8N_INSTANCE_AI_CONFIRMATION_TIMEOUT')
-	confirmationTimeout: number = 1 * Time.days.toMilliseconds;
+	confirmationTimeout: number = 24 * Time.hours.toMilliseconds;
 }

--- a/packages/@n8n/config/src/configs/runners.config.ts
+++ b/packages/@n8n/config/src/configs/runners.config.ts
@@ -1,3 +1,4 @@
+import { Time } from '@n8n/constants';
 import { z } from 'zod';
 
 import { Config, Env } from '../decorators';
@@ -51,7 +52,7 @@ export class TaskRunnersConfig {
 	 * Kept high for backwards compatibility - n8n v3 will reduce this to `60`
 	 */
 	@Env('N8N_RUNNERS_TASK_TIMEOUT')
-	taskTimeout: number = 300; // 5 minutes
+	taskTimeout: number = 5 * Time.minutes.toSeconds;
 
 	/**
 	 * How long (in seconds) a task request can wait for a runner to become

--- a/packages/@n8n/config/src/configs/scaling-mode.config.ts
+++ b/packages/@n8n/config/src/configs/scaling-mode.config.ts
@@ -1,3 +1,5 @@
+import { Time } from '@n8n/constants';
+
 import { Config, Env, Nested } from '../decorators';
 
 @Config
@@ -37,14 +39,14 @@ class RedisConfig {
 
 	/** Max cumulative timeout (in milliseconds) of connection retries before process exit. */
 	@Env('QUEUE_BULL_REDIS_TIMEOUT_THRESHOLD')
-	timeoutThreshold: number = 10_000;
+	timeoutThreshold: number = 10 * Time.seconds.toMilliseconds;
 
 	/** Slot refresh timeout (in milliseconds) before a timeout occurs while refreshing slots from the cluster. */
 	@Env('QUEUE_BULL_REDIS_SLOT_REFRESH_TIMEOUT')
-	slotsRefreshTimeout: number = 1_000;
+	slotsRefreshTimeout: number = 1 * Time.seconds.toMilliseconds;
 	/** Slot refresh interval (in milliseconds) between every automatic slot refresh. */
 	@Env('QUEUE_BULL_REDIS_SLOT_REFRESH_INTERVAL')
-	slotsRefreshInterval: number = 5_000;
+	slotsRefreshInterval: number = 5 * Time.seconds.toMilliseconds;
 
 	/** Redis username. Redis 6.0 or higher required. */
 	@Env('QUEUE_BULL_REDIS_USERNAME')
@@ -81,11 +83,11 @@ class RedisConfig {
 
 	/** TCP keep-alive initial delay in milliseconds. */
 	@Env('QUEUE_BULL_REDIS_KEEP_ALIVE_DELAY')
-	keepAliveDelay: number = 5000;
+	keepAliveDelay: number = 5 * Time.seconds.toMilliseconds;
 
 	/** TCP keep-alive interval in milliseconds. */
 	@Env('QUEUE_BULL_REDIS_KEEP_ALIVE_INTERVAL')
-	keepAliveInterval: number = 5000;
+	keepAliveInterval: number = 5 * Time.seconds.toMilliseconds;
 
 	/** Whether to reconnect to Redis on READONLY errors i.e., failover events. */
 	@Env('QUEUE_BULL_REDIS_RECONNECT_ON_FAILOVER')
@@ -96,15 +98,15 @@ class RedisConfig {
 class SettingsConfig {
 	/** How long (in milliseconds) is the lease period for a worker processing a job. */
 	@Env('QUEUE_WORKER_LOCK_DURATION')
-	lockDuration: number = 60_000;
+	lockDuration: number = 1 * Time.minutes.toMilliseconds;
 
 	/** How often (in milliseconds) a worker must renew the lease. */
 	@Env('QUEUE_WORKER_LOCK_RENEW_TIME')
-	lockRenewTime: number = 10_000;
+	lockRenewTime: number = 10 * Time.seconds.toMilliseconds;
 
 	/** How often (in milliseconds) Bull must check for stalled jobs. `0` to disable. */
 	@Env('QUEUE_WORKER_STALLED_INTERVAL')
-	stalledInterval: number = 30_000;
+	stalledInterval: number = 30 * Time.seconds.toMilliseconds;
 }
 
 @Config

--- a/packages/@n8n/constants/src/time.ts
+++ b/packages/@n8n/constants/src/time.ts
@@ -12,6 +12,7 @@ export const Time = {
 	},
 	minutes: {
 		toMilliseconds: 60 * 1000,
+		toSeconds: 60,
 	},
 	hours: {
 		toMilliseconds: 60 * 60 * 1000,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1385,6 +1385,9 @@ importers:
 
   packages/@n8n/config:
     dependencies:
+      '@n8n/constants':
+        specifier: workspace:*
+        version: link:../constants
       '@n8n/di':
         specifier: workspace:*
         version: link:../di


### PR DESCRIPTION
## Summary

Follow-up to #31008. Replace magic time multiplications across `@n8n/config` with the readable `Time.*.to*` constants from `@n8n/constants`. Single-PR sweep so the whole package converges on one pattern.

Pattern: `N * Time.<unit>.to<TargetUnit>` for every duration default with a natural human unit. Covers both new-from-#31008 lines and pre-existing values (e.g. `60_000`, `10_000`, `3600 * 1000`, `24 * 60 * 60 * 1000`).

### Constants change

- `@n8n/constants/src/time.ts`: added `minutes.toSeconds = 60` so second-valued fields like `runners.taskTimeout` can use the same pattern.

### Config files touched (10)

| File | What changed |
|---|---|
| `database.config.ts` | `statementTimeoutMs` (5 min), `maxConnectionLifetimeMs` (1 h) |
| `cache.config.ts` | memory + redis TTLs (1 h each) |
| `data-table.config.ts` | size-check cache (5 s), cleanup interval (1 min), file max age (2 min) |
| `instance-ai.config.ts` | sandbox timeout (5 min), daytona refresh skew (5 min), builder TTL (15 min), snapshot prune (1 h), snapshot retention + confirmation timeout (1 day each) |
| `ai.config.ts` | AI HTTP timeout (1 h) |
| `agents.config.ts` | checkpoint TTL (4 days in seconds), sub-agent timeout (5 min) |
| `runners.config.ts` | task timeout (5 min in seconds, using new `Time.minutes.toSeconds`) |
| `scaling-mode.config.ts` | redis timeouts/intervals + lock duration/renew/stalled-interval (8 values, including `10_000` and `60_000`) |
| `chat-hub.config.ts` | execution-context TTL (1 h), stream-state TTL (5 min) |
| `executions.config.ts` | max timeout (1 h) |

No behavior change — every resolved value is numerically identical to the previous one. Default-assertion tests in `config.test.ts` and `db-connection.test.ts` continue to lock in the same raw numbers.

### How to test

- `pnpm --filter @n8n/constants build` (constants needs rebuilding since `@n8n/config` consumes its dist)
- `pnpm --filter @n8n/config typecheck` — clean
- `pnpm --filter @n8n/config test` — 82/82 pass
- `pnpm --filter @n8n/db test` — 314/314 pass

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #31008 — addresses review comment https://github.com/n8n-io/n8n/pull/31008#discussion_r3342541979

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI