### PR TITLE
ci: Add workflow to clean up stale branches

### DIFF
--- a/.github/workflows/clean-stale-branches.yml
+++ b/.github/workflows/clean-stale-branches.yml
@@ -1,0 +1,26 @@
+on:
+  # schedule:
+  #   - cron: "0 0 * * *" # Everday at midnight
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Is this a dry run or an actual run?'
+        type: boolean
+        default: true
+
+permissions:
+  issues: write
+  contents: write
+
+jobs:
+  remove-stale-branches:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stale Branches
+        uses: crs-k/stale-branches@e876b957ab08f0bad43c8cc271a22cdd7604bd09 # v9.0.1
+        with:
+          dry-run: ${{ inputs.dry-run }}
+          days-before-stale: 90
+          days-before-delete: 100
+          include-protected-branches: false  # Disable legacy branch protection checks
+          include-ruleset-branches: true     # Enable repository ruleset checks


### PR DESCRIPTION
## Summary

Adds a (currently manually) runnable workflow to delete stable Git branches.

Current setup marks Issues built on stale branches as "stale" via label after 90 days, and deletes them after 100 days of inactivity.

This PR introduces the job to master so it can be run in dry-run mode. Another PR is going to add a cron to run this nightly.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
