### PR TITLE
fix(core): Reject unsafe property tokens in in-isolate $jmespath (backport to 1.x)

### DIFF
--- a/packages/@n8n/expression-runtime/src/runtime/jmespath.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/jmespath.ts
@@ -2,6 +2,37 @@ import * as jmespath from 'jmespath';
 
 import { ExpressionError } from './safe-globals';
 
+const unsafeJmespathProperties = [
+	'__proto__',
+	'prototype',
+	'constructor',
+	'getPrototypeOf',
+	'setPrototypeOf',
+	'getOwnPropertyDescriptor',
+	'getOwnPropertyDescriptors',
+	'defineProperty',
+	'defineProperties',
+	'mainModule',
+	'binding',
+	'_linkedBinding',
+	'_load',
+	'prepareStackTrace',
+	'__lookupGetter__',
+	'__lookupSetter__',
+	'__defineGetter__',
+	'__defineSetter__',
+	'caller',
+	'arguments',
+	'getBuiltinModule',
+	'dlopen',
+	'execve',
+	'loadEnvFile',
+];
+
+const unsafeJmespathPropertyPattern = new RegExp(
+	`\\b(?:${unsafeJmespathProperties.map((p) => p.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|')})\\b`,
+);
+
 /**
  * In-isolate `$jmespath` / `$jmesPath` implementation.
  *
@@ -15,6 +46,7 @@ import { ExpressionError } from './safe-globals';
  *
  * Behavioural parity with the host wrapper:
  *   - Throws `ExpressionError` (same name) when args are wrong.
+ *   - Rejects queries that contain unsafe property tokens.
  *   - Spreads non-array, non-null objects to drop proxies at the top level.
  *
  * Note on lazy proxies: when `data` is a lazy proxy (e.g. `$json`), each
@@ -26,6 +58,15 @@ import { ExpressionError } from './safe-globals';
 export function jmesPath(data: unknown, query: string): unknown {
 	if (typeof data !== 'object' || typeof query !== 'string') {
 		throw new ExpressionError('expected two arguments (Object, string) for this function');
+	}
+
+	// jmespath decodes escape sequences inside quoted identifiers, so the
+	// token check must run against an unescaped query. Reject any backslash
+	// up front to keep the property-name match meaningful.
+	if (query.includes('\\') || unsafeJmespathPropertyPattern.test(query)) {
+		throw new ExpressionError(
+			'Cannot access this property in a jmespath query due to security concerns',
+		);
 	}
 
 	if (data !== null && !Array.isArray(data) && typeof data === 'object') {

--- a/packages/workflow/test/expression.test.ts
+++ b/packages/workflow/test/expression.test.ts
@@ -470,46 +470,28 @@ describe('Expression', () => {
 				);
 			});
 
-			// The $jmespath restricted-identifier defense differs by engine:
-			//   legacy → the host wrapper (workflow-data-proxy.ts) throws
-			//            "due to security concerns" via an explicit token denylist.
-			//   vm     → jmespath runs in-isolate with no denylist, but a restricted
-			//            identifier can never leak a usable constructor/prototype to
-			//            the host: `constructor` resolves to the Object constructor,
-			//            which fails to serialize across the isolate boundary (throws),
-			//            while `getPrototypeOf`/`prototype`/`__proto__` are key-misses
-			//            or non-cloneable internals → the result is never a callable.
-			//            (Structural isolation rather than a denylist — see
-			//            packages/@n8n/expression-runtime/src/runtime/jmespath.ts.)
-			const expectJmespathBlocked = (expr: string) => {
-				if (process.env.N8N_EXPRESSION_ENGINE === 'vm') {
-					let result: unknown;
-					let threw = false;
-					try {
-						result = evaluate(expr);
-					} catch {
-						threw = true;
-					}
-					expect(threw || typeof result !== 'function').toBe(true);
-				} else {
-					expect(() => evaluate(expr)).toThrow(/due to security concerns/);
-				}
-			};
-
 			it('should reject jmespath queries that reference restricted identifiers', () => {
-				expectJmespathBlocked('={{ $jmespath({a:1}, "constructor") }}');
-				expectJmespathBlocked('={{ $jmespath({a:1}, "__proto__") }}');
-				expectJmespathBlocked('={{ $jmespath({a:1}, "prototype") }}');
+				expect(() => evaluate('={{ $jmespath({a:1}, "constructor") }}')).toThrow(
+					/due to security concerns/,
+				);
+				expect(() => evaluate('={{ $jmespath({a:1}, "__proto__") }}')).toThrow(
+					/due to security concerns/,
+				);
+				expect(() => evaluate('={{ $jmespath({a:1}, "prototype") }}')).toThrow(
+					/due to security concerns/,
+				);
 			});
 
 			it('should reject jmespath queries that reference restricted identifiers (alias)', () => {
-				expectJmespathBlocked('={{ $jmesPath({a:1}, "getPrototypeOf") }}');
+				expect(() => evaluate('={{ $jmesPath({a:1}, "getPrototypeOf") }}')).toThrow(
+					/due to security concerns/,
+				);
 			});
 
 			it('should reject computed-string jmespath queries built from restricted identifiers', () => {
-				expectJmespathBlocked(
-					'={{ $jmespath({a:1}, String.fromCharCode(99,111,110,115,116,114,117,99,116,111,114)) }}',
-				);
+				const payload =
+					'={{ $jmespath({a:1}, String.fromCharCode(99,111,110,115,116,114,117,99,116,111,114)) }}';
+				expect(() => evaluate(payload)).toThrow(/due to security concerns/);
 			});
 
 			it('should still allow jmespath queries that contain restricted names as substrings', () => {


### PR DESCRIPTION
## Summary

Backports the in-isolate `$jmespath` security denylist (already on `master` and on 1.x's **legacy** host wrapper) to the VM expression engine's in-isolate `jmespath.ts`, restoring **VM-vs-legacy parity** on `1.x`.

The in-isolate `$jmespath` on `1.x` did **not** reject `constructor` / `__proto__` / `prototype` / etc., whereas the legacy engine (and `master`'s VM engine) do. This adds the same `unsafeJmespathProperties` token denylist + backslash-escape rejection, throwing the same `ExpressionError('Cannot access this property in a jmespath query due to security concerns')`.

## Why it was missing (the seam)

- **2026-05-27** — `chore: Bundle/1.x` (#31174) hardened the **legacy** path (`workflow-data-proxy.ts`) on `1.x`. The in-isolate `jmespath.ts` wasn't on `1.x` yet, so it couldn't be touched.
- **2026-05-27** — `master` got the **in-isolate** denylist (via `chore: Bundle/2.x` #31173).
- **~2026-06-02** — the `@n8n/expression-runtime` package (incl. in-isolate `jmespath.ts`) was backported to public `1.x` (CAT-2844 / #31186), carrying the **pre-denylist** version (branch-cut predated #31173).


## Changes

- `packages/@n8n/expression-runtime/src/runtime/jmespath.ts` — denylist + guard, **verbatim with `master`**.
- `packages/workflow/test/expression.test.ts` — replaced the lenient per-engine `expectJmespathBlocked` helper with `master`'s strict both-engine `toThrow(/due to security concerns/)` assertions.

## Testing

- jmespath restricted-identifier tests pass under **both** the legacy and VM engines (the VM engine now rejects the tokens).
- `@n8n/expression-runtime` unit tests (339) pass.
- Lint clean.

## Notes

- **Non-urgent / not user-facing:** the VM expression engine is opt-in and off by default on `1.x`. Per the CAT-3210 analysis, in-isolate `constructor`/proto access is non-exploitable across the isolate boundary anyway — this is behavioural parity + defense-in-depth before any flag enablement.
- Surfaced during the relevance assessment of [CAT-3267](https://linear.app/n8n/issue/CAT-3267).
- Part of the Expression Isolation - Production Readiness effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)