### PR TITLE
ci: Trigger full PR pipeline for #31649

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -195,3 +195,4 @@ minimumReleaseAge: 4320
 minimumReleaseAgeExclude:
   - '@n8n/*'
   - '@n8n_io/*'
+


### PR DESCRIPTION
Stacked on top of #31649 to validate the `setup-nodejs` action bump against the full PR CI matrix.

PR #31649 only touches `.github/actions/setup-nodejs/action.yml`, which is excluded by the `ci-filter` path filters in `ci-pull-requests.yml` (the `ci`, `runtime`, `unit`, `db`, `dev-server-smoke`, etc. filters all carry `!.github/**`). As a result, only Install & Build + Poutine ran on the original PR — Lint, Unit, DB, E2E, Typecheck, Performance, dev-server-smoke and friends were all skipped.

This stacked PR adds a one-line no-op (trailing newline) to `pnpm-workspace.yaml` so the path filters trigger and the gated jobs actually exercise the updated `setup-nodejs` action end-to-end. Merge `#31649` once this run is green; close this PR without merging.

Original run: https://github.com/n8n-io/n8n/actions/runs/26882845666