### PR TITLE
ci: Run ci-master only from master branch

### DIFF
--- a/.github/workflows/ci-master.yml
+++ b/.github/workflows/ci-master.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - 1.x
     paths-ignore:
       - packages/@n8n/task-runner-python/**
 


### PR DESCRIPTION
## Summary

CI: Master has been running on merges to `master` as well as `1.x` for a while. Due to the node matrix not being backported to 1.x, the 1.x runs have been failing since the start of April.

This PR removes the running branch `1.x` from the CI script. Let's re-explore if we want to run this for 1.x changes in the future too and re-introduce a new workflow for that.

## Related Linear tickets, Github issues, and Community forum posts

[Example failed run](https://github.com/n8n-io/n8n/actions/runs/26879878880/job/79276865454)


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
