### PR TITLE
fix: Add item-flow builder guidance (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/README.md
+++ b/packages/@n8n/instance-ai/evaluations/README.md
@@ -5,7 +5,7 @@ Tests whether workflows built by Instance AI actually work by executing them wit
 Four harnesses live here:
 
 - **`eval:instance-ai`** — end-to-end build + mocked execution + LLM verification (drives a running n8n instance)
-- **`eval:subagent`** — compatibility corpus that drives the live orchestrator build path, scored by binary checks
+- **`eval:subagent`** — legacy command name for the workflow-build compatibility corpus; it drives the live orchestrator/skill build path, scored by binary checks
 - **`eval:discovery`** — orchestrator in-process, scored against required or forbidden tool/dispatch events (no n8n server)
 - **`eval:pairwise`** — live orchestrator workflow builds, scored by an LLM judge panel against do/don't lists. Intended for head-to-head comparison with `ai-workflow-builder.ee` on the same dataset
 

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/index.ts
@@ -18,6 +18,8 @@ import { hasStartNode } from './has-start-node';
 import { hasTrigger } from './has-trigger';
 import { httpGenericAuthTypeMatchesPrompt } from './http-generic-auth-type-matches-prompt';
 import { inboundTriggerAuthDefaults } from './inbound-trigger-auth-defaults';
+import { itemFlowIndependentSourceExecuteOnce } from './item-flow-independent-source-execute-once';
+import { itemFlowPairedItemReferences } from './item-flow-paired-item-references';
 import { memoryProperlyConnected } from './memory-properly-connected';
 import { memorySessionKeyExpression } from './memory-session-key-expression';
 import { noDisabledNodes } from './no-disabled-nodes';
@@ -50,6 +52,8 @@ export const CONNECTION_TOPOLOGY_CHECKS: BinaryCheck[] = [
 
 export const PARAMETER_CORRECTNESS_CHECKS: BinaryCheck[] = [
 	expressionsReferenceExistingNodes,
+	itemFlowPairedItemReferences,
+	itemFlowIndependentSourceExecuteOnce,
 	validFieldReferences,
 	validNodeConfig,
 	noEmptySetNodes,

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/item-flow-independent-source-execute-once.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/item-flow-independent-source-execute-once.ts
@@ -1,0 +1,130 @@
+import type { WorkflowNodeResponse } from '../../clients/n8n-client';
+import type { BinaryCheck, BinaryCheckContext } from '../types';
+import { HTTP_REQUEST_TYPE, forEachConnection, isTriggerNode } from '../utils';
+
+const SINGLE_EXECUTION_PROMPT_PATTERNS = [
+	/fetch(?:ed)? only once/i,
+	/fetch(?:ed)? .* once/i,
+	/only once for the whole/i,
+	/not once for each/i,
+	/shared context/i,
+	/execute once/i,
+];
+
+const MULTI_ITEM_ANCESTOR_HINTS = [
+	/filter/i,
+	/split/i,
+	/loop/i,
+	/item list/i,
+	/items/i,
+	/launch tasks/i,
+	/due tasks/i,
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
+function getItemFlowAnnotations(ctx: BinaryCheckContext): Record<string, unknown> {
+	const itemFlow = ctx.annotations?.itemFlow;
+	return isRecord(itemFlow) ? itemFlow : {};
+}
+
+function getStringArrayAnnotation(ctx: BinaryCheckContext, key: string): string[] {
+	const value = getItemFlowAnnotations(ctx)[key];
+	return Array.isArray(value)
+		? value.filter((item): item is string => typeof item === 'string')
+		: [];
+}
+
+function requiresSingleExecution(ctx: BinaryCheckContext): boolean {
+	const annotatedNodes = getStringArrayAnnotation(ctx, 'singleExecutionNodes');
+	if (annotatedNodes.length > 0) return true;
+	return SINGLE_EXECUTION_PROMPT_PATTERNS.some((pattern) => pattern.test(ctx.prompt));
+}
+
+function nodeHaystack(node: WorkflowNodeResponse): string {
+	return `${node.name} ${node.type} ${JSON.stringify(node.parameters ?? {})}`;
+}
+
+function isIndependentSourceCandidate(
+	node: WorkflowNodeResponse,
+	ctx: BinaryCheckContext,
+): boolean {
+	const annotatedNodes = new Set(getStringArrayAnnotation(ctx, 'singleExecutionNodes'));
+	if (annotatedNodes.has(node.name)) return true;
+
+	const haystack = nodeHaystack(node).toLowerCase();
+	return node.type === HTTP_REQUEST_TYPE && haystack.includes('release');
+}
+
+function collectParents(connections: Record<string, unknown>): Map<string, Set<string>> {
+	const parents = new Map<string, Set<string>>();
+	forEachConnection(connections, (source, _connectionType, link) => {
+		const existing = parents.get(link.node) ?? new Set<string>();
+		existing.add(source);
+		parents.set(link.node, existing);
+	});
+	return parents;
+}
+
+function hasLikelyMultiItemAncestor(
+	nodeName: string,
+	nodeByName: Map<string, WorkflowNodeResponse>,
+	parentsByNode: Map<string, Set<string>>,
+	seen = new Set<string>(),
+): boolean {
+	const parents = parentsByNode.get(nodeName);
+	if (!parents) return false;
+
+	for (const parentName of parents) {
+		if (seen.has(parentName)) continue;
+		seen.add(parentName);
+
+		const parent = nodeByName.get(parentName);
+		if (!parent) continue;
+
+		const haystack = nodeHaystack(parent);
+		if (
+			!isTriggerNode(parent.type) &&
+			MULTI_ITEM_ANCESTOR_HINTS.some((pattern) => pattern.test(haystack))
+		) {
+			return true;
+		}
+
+		if (hasLikelyMultiItemAncestor(parentName, nodeByName, parentsByNode, seen)) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+export const itemFlowIndependentSourceExecuteOnce: BinaryCheck = {
+	name: 'item_flow_independent_source_execute_once',
+	description: 'Independent source fetches do not multiply across incoming items',
+	kind: 'deterministic',
+	dimension: 'parameter_correctness',
+	run(workflow, ctx) {
+		if (!requiresSingleExecution(ctx)) return { pass: true, applicable: false };
+
+		const nodes = workflow.nodes ?? [];
+		const nodeByName = new Map(nodes.map((node) => [node.name, node]));
+		const parentsByNode = collectParents(workflow.connections ?? {});
+		const issues = nodes
+			.filter((node) => isIndependentSourceCandidate(node, ctx))
+			.filter((node) => node.executeOnce !== true)
+			.filter((node) => hasLikelyMultiItemAncestor(node.name, nodeByName, parentsByNode))
+			.map(
+				(node) =>
+					`"${node.name}" is downstream of an item-producing path but executeOnce is not true`,
+			);
+
+		if (issues.length === 0) return { pass: true };
+
+		return {
+			pass: false,
+			comment: `Independent item-flow sources should run once for shared context: ${issues.join('; ')}`,
+		};
+	},
+};

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/item-flow-paired-item-references.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/item-flow-paired-item-references.ts
@@ -1,0 +1,133 @@
+import type { WorkflowNodeResponse } from '../../clients/n8n-client';
+import type { BinaryCheck, BinaryCheckContext } from '../types';
+import { extractExpressionsFromParams } from '../utils';
+
+const PAIRED_ITEM_PROMPT_PATTERNS = [
+	/paired item/i,
+	/same paired/i,
+	/same item/i,
+	/do not use \.first/i,
+	/reuse the first/i,
+	/first event id/i,
+	/multiple (?:email|invite|item)/i,
+];
+
+const UPSTREAM_REPLACEMENT_PROMPT_PATTERNS = [
+	/current \$json/i,
+	/archive .*output.*no longer contains/i,
+	/gets undefined/i,
+	/referenc(?:e|ing) the upstream/i,
+	/upstream extraction/i,
+];
+
+const FIRST_ITEM_REFERENCE_PATTERNS = [
+	{
+		label: '$("...").first()',
+		pattern: /\$\(\s*(['"`])((?:\\.|(?!\1)[^\\])*)\1\s*\)\.first\s*\(/,
+	},
+	{
+		label: '$items(...)[0]',
+		pattern: /\$items\(\s*(['"`])((?:\\.|(?!\1)[^\\])*)\1[^)]*\)\s*\[\s*0\s*\]/,
+	},
+	{
+		label: '$input.first()',
+		pattern: /\$input\.first\s*\(/,
+	},
+] as const;
+
+const CURRENT_JSON_EVENT_ID = /\$json\.(?:calendarEventId|eventId|eventID|calendar_event_id)\b/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
+function getItemFlowAnnotations(ctx: BinaryCheckContext): Record<string, unknown> {
+	const itemFlow = ctx.annotations?.itemFlow;
+	return isRecord(itemFlow) ? itemFlow : {};
+}
+
+function hasAnnotationFlag(ctx: BinaryCheckContext, flag: string): boolean {
+	return getItemFlowAnnotations(ctx)[flag] === true;
+}
+
+function matchesAny(text: string, patterns: RegExp[]): boolean {
+	return patterns.some((pattern) => pattern.test(text));
+}
+
+function requiresPairedItemReferences(ctx: BinaryCheckContext): boolean {
+	return (
+		hasAnnotationFlag(ctx, 'requiresPairedItemReferences') ||
+		matchesAny(ctx.prompt, PAIRED_ITEM_PROMPT_PATTERNS)
+	);
+}
+
+function requiresUpstreamReferenceAfterReplacement(ctx: BinaryCheckContext): boolean {
+	return (
+		hasAnnotationFlag(ctx, 'requiresUpstreamReferenceAfterReplacement') ||
+		matchesAny(ctx.prompt, UPSTREAM_REPLACEMENT_PROMPT_PATTERNS)
+	);
+}
+
+function getFirstItemReferenceLabel(expression: string): string | undefined {
+	return FIRST_ITEM_REFERENCE_PATTERNS.find(({ pattern }) => pattern.test(expression))?.label;
+}
+
+function isCalendarLookupNode(node: WorkflowNodeResponse): boolean {
+	const haystack =
+		`${node.name} ${node.type} ${JSON.stringify(node.parameters ?? {})}`.toLowerCase();
+	return haystack.includes('calendar') && /(event|lookup|fetch|get)/i.test(haystack);
+}
+
+function shortExpression(expression: string): string {
+	const compact = expression.replace(/\s+/g, ' ').trim();
+	return compact.length > 120 ? `${compact.slice(0, 117)}...` : compact;
+}
+
+export const itemFlowPairedItemReferences: BinaryCheck = {
+	name: 'item_flow_paired_item_references',
+	description: 'Item-flow expressions preserve paired upstream item context',
+	kind: 'deterministic',
+	dimension: 'parameter_correctness',
+	run(workflow, ctx) {
+		const checkPairedReferences = requiresPairedItemReferences(ctx);
+		const checkUpstreamReplacement = requiresUpstreamReferenceAfterReplacement(ctx);
+		if (!checkPairedReferences && !checkUpstreamReplacement) {
+			return { pass: true, applicable: false };
+		}
+
+		const issues: string[] = [];
+
+		for (const node of workflow.nodes ?? []) {
+			const expressions = extractExpressionsFromParams(node.parameters ?? {});
+			for (const expression of expressions) {
+				if (checkPairedReferences) {
+					const firstItemReference = getFirstItemReferenceLabel(expression);
+					if (firstItemReference) {
+						issues.push(
+							`"${node.name}" uses ${firstItemReference} in ${shortExpression(expression)}`,
+						);
+					}
+				}
+
+				if (
+					checkUpstreamReplacement &&
+					isCalendarLookupNode(node) &&
+					CURRENT_JSON_EVENT_ID.test(expression)
+				) {
+					issues.push(
+						`"${node.name}" reads eventId from current $json instead of the upstream extraction item`,
+					);
+				}
+			}
+		}
+
+		return {
+			pass: issues.length === 0,
+			...(issues.length > 0
+				? {
+						comment: `Item-flow expressions lose paired source context: ${issues.join('; ')}`,
+					}
+				: {}),
+		};
+	},
+};

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/item-flow-semantics.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/item-flow-semantics.test.ts
@@ -1,0 +1,169 @@
+import { itemFlowIndependentSourceExecuteOnce } from './item-flow-independent-source-execute-once';
+import { itemFlowPairedItemReferences } from './item-flow-paired-item-references';
+import type { WorkflowResponse } from '../../clients/n8n-client';
+import { runBinaryChecks } from '../index';
+
+function pairedEventWorkflow(eventIdExpression: string): WorkflowResponse {
+	return {
+		id: 'workflow-1',
+		versionId: 'version-1',
+		name: 'Paired calendar event workflow',
+		active: false,
+		nodes: [
+			{ name: 'Gmail Trigger', type: 'n8n-nodes-base.gmailTrigger', parameters: {} },
+			{
+				name: 'Extract Event ID',
+				type: 'n8n-nodes-base.set',
+				parameters: {
+					assignments: {
+						assignments: [
+							{ name: 'eventId', value: '={{ $json.body.match(/event:([^\\s]+)/)[1] }}' },
+							{ name: 'messageId', value: '={{ $json.id }}' },
+						],
+					},
+				},
+			},
+			{
+				name: 'Archive Gmail Invite',
+				type: 'n8n-nodes-base.gmail',
+				parameters: {
+					operation: 'addLabels',
+					messageId: "={{ $('Extract Event ID').item.json.messageId }}",
+				},
+			},
+			{
+				name: 'Get Calendar Event',
+				type: 'n8n-nodes-base.googleCalendar',
+				parameters: { operation: 'get', eventId: eventIdExpression },
+			},
+		],
+		connections: {
+			'Gmail Trigger': { main: [[{ node: 'Extract Event ID', type: 'main', index: 0 }]] },
+			'Extract Event ID': { main: [[{ node: 'Archive Gmail Invite', type: 'main', index: 0 }]] },
+			'Archive Gmail Invite': { main: [[{ node: 'Get Calendar Event', type: 'main', index: 0 }]] },
+		},
+	};
+}
+
+function releaseDigestWorkflow(releaseExecuteOnce?: boolean): WorkflowResponse {
+	return {
+		id: 'workflow-2',
+		versionId: 'version-1',
+		name: 'Release digest workflow',
+		active: false,
+		nodes: [
+			{ name: 'Schedule Trigger', type: 'n8n-nodes-base.scheduleTrigger', parameters: {} },
+			{
+				name: 'Fetch Launch Tasks',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: { url: 'https://ops.example.com/api/launch-tasks' },
+			},
+			{
+				name: 'Filter Due Tasks',
+				type: 'n8n-nodes-base.filter',
+				parameters: { conditions: { options: {}, conditions: [] } },
+			},
+			{
+				name: 'Fetch Current Product Releases',
+				type: 'n8n-nodes-base.httpRequest',
+				parameters: { url: 'https://ops.example.com/api/releases' },
+				...(releaseExecuteOnce === undefined ? {} : { executeOnce: releaseExecuteOnce }),
+			},
+			{
+				name: 'Post Slack Digest',
+				type: 'n8n-nodes-base.slack',
+				parameters: { text: '={{ "Release readiness" }}' },
+			},
+		],
+		connections: {
+			'Schedule Trigger': { main: [[{ node: 'Fetch Launch Tasks', type: 'main', index: 0 }]] },
+			'Fetch Launch Tasks': { main: [[{ node: 'Filter Due Tasks', type: 'main', index: 0 }]] },
+			'Filter Due Tasks': {
+				main: [[{ node: 'Fetch Current Product Releases', type: 'main', index: 0 }]],
+			},
+			'Fetch Current Product Releases': {
+				main: [[{ node: 'Post Slack Digest', type: 'main', index: 0 }]],
+			},
+		},
+	};
+}
+
+describe('item-flow binary checks', () => {
+	it('fails when paired item prompts use the first extracted event id for every item', async () => {
+		const result = await itemFlowPairedItemReferences.run(
+			pairedEventWorkflow("={{ $('Extract Event ID').first().json.eventId }}"),
+			{
+				prompt:
+					'There can be multiple emails in one execution. Use the paired item relationship and do not use .first() for the event ID.',
+			},
+		);
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('Get Calendar Event');
+		expect(result.comment).toContain('$("...").first()');
+	});
+
+	it('fails when a calendar lookup reads eventId from current $json after a replacing Gmail archive node', async () => {
+		const result = await itemFlowPairedItemReferences.run(
+			pairedEventWorkflow('={{ $json.eventId }}'),
+			{
+				prompt:
+					'After the archive step the Gmail node output no longer contains the extracted event ID. Do not use the current $json after the Gmail archive output to read eventId; reference the upstream extraction step explicitly.',
+			},
+		);
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('current $json');
+		expect(result.comment).toContain('upstream extraction');
+	});
+
+	it('passes when a calendar lookup uses the paired upstream extraction item', async () => {
+		const result = await itemFlowPairedItemReferences.run(
+			pairedEventWorkflow("={{ $('Extract Event ID').item.json.eventId }}"),
+			{
+				prompt:
+					'Archive the corresponding Gmail message only when the same paired Calendar event has declined. Use the paired item relationship.',
+			},
+		);
+
+		expect(result).toEqual({ pass: true });
+	});
+
+	it('fails when an independent release fetch would multiply across filtered task items', async () => {
+		const result = await itemFlowIndependentSourceExecuteOnce.run(releaseDigestWorkflow(), {
+			prompt:
+				'The release list is shared context for the digest and must be fetched only once, not once for each launch task.',
+		});
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('Fetch Current Product Releases');
+		expect(result.comment).toContain('executeOnce');
+	});
+
+	it('passes when the independent release fetch is configured to execute once', async () => {
+		const result = await itemFlowIndependentSourceExecuteOnce.run(releaseDigestWorkflow(true), {
+			prompt:
+				'The release list is shared context for the digest and must be fetched only once, not once for each launch task.',
+		});
+
+		expect(result).toEqual({ pass: true });
+	});
+
+	it('surfaces the item-flow failures through the binary-check runner', async () => {
+		const { outcomes } = await runBinaryChecks(
+			pairedEventWorkflow("={{ $('Extract Event ID').first().json.eventId }}"),
+			{
+				prompt:
+					'There can be multiple emails in one execution. Use the paired item relationship and do not use .first() for the event ID.',
+			},
+			{ only: ['item_flow_paired_item_references'] },
+		);
+
+		expect(outcomes).toEqual([
+			expect.objectContaining({
+				name: 'item_flow_paired_item_references',
+				status: 'fail',
+			}),
+		]);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/response-matches-workflow-changes.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/response-matches-workflow-changes.ts
@@ -24,6 +24,7 @@ Rules:
 - If the agent claims a specific configuration change, verify it differs between before and after.
 - If the agent claims connections between nodes, verify those connections exist in the AFTER workflow.
 - Ignore general/vague statements that don't make specific claims (e.g., "I built a workflow for you").
+- Treat SDK helper claims such as \`nodeJson(sourceNode, 'field.path')\` as equivalent to the generated workflow expression \`$('Source Node').item.json.field.path\` when the referenced node and JSON path match semantically.
 - If the agent's response contains NO specific claims about workflow changes, pass (nothing to verify).
 - A single verifiably false claim means fail.`,
 	humanTemplate: `User Request: {userPrompt}

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/valid-data-flow.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/valid-data-flow.ts
@@ -17,6 +17,8 @@ Important n8n context:
 - Set nodes output exactly the fields defined in their assignments
 - AI Agent nodes output \`{ output: string }\`
 - Merge nodes combine fields from all inputs
+- Filter and IF nodes preserve the current item shape on the matching output. Do not fail an expression solely because it references a paired upstream node instead of current \`$json\` after a Filter/IF, as long as the referenced node exists and the field exists there.
+- \`$('NodeName').item.json.field\` is the paired item from that upstream node, not always item 0.
 
 Focus on CRITICAL issues only:
 - Expressions referencing fields that clearly don't exist upstream (e.g., \`$json.transcript\` when no node produces a transcript field)

--- a/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
+++ b/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
@@ -48,6 +48,7 @@ export interface WorkflowNodeResponse {
 	type: string;
 	typeVersion?: number;
 	parameters?: Record<string, unknown>;
+	executeOnce?: boolean;
 	onError?: 'stopWorkflow' | 'continueRegularOutput' | 'continueErrorOutput';
 	disabled?: boolean;
 	credentials?: Record<string, unknown>;
@@ -133,6 +134,17 @@ export class N8nClient {
 	}
 
 	// -- Instance-AI endpoints -----------------------------------------------
+
+	/**
+	 * Ensure a conversation thread exists before sending chat messages.
+	 * POST /rest/instance-ai/threads body: { threadId }
+	 */
+	async ensureThread(threadId: string): Promise<void> {
+		await this.fetch('/rest/instance-ai/threads', {
+			method: 'POST',
+			body: { threadId },
+		});
+	}
 
 	/**
 	 * Send a chat message to the instance-ai agent.

--- a/packages/@n8n/instance-ai/evaluations/data/subagent/item-flow-independent-fetch-execute-once.json
+++ b/packages/@n8n/instance-ai/evaluations/data/subagent/item-flow-independent-fetch-execute-once.json
@@ -1,0 +1,9 @@
+{
+	"id": "item-flow-independent-fetch-execute-once",
+	"prompt": "Every weekday morning, fetch open launch tasks from GET https://ops.example.com/api/launch-tasks, keep only tasks due in the next 7 days, fetch current product releases from GET https://ops.example.com/api/releases, and post one Slack digest to #release-readiness. The release list is shared context for the digest and must be fetched only once, not once for each launch task.",
+	"annotations": {
+		"itemFlow": {
+			"singleExecutionNodes": ["Fetch Current Product Releases", "Fetch Releases"]
+		}
+	}
+}

--- a/packages/@n8n/instance-ai/evaluations/data/subagent/item-flow-paired-item-not-first-calendar-events.json
+++ b/packages/@n8n/instance-ai/evaluations/data/subagent/item-flow-paired-item-not-first-calendar-events.json
@@ -1,0 +1,9 @@
+{
+	"id": "item-flow-paired-item-not-first-calendar-events",
+	"prompt": "Build a workflow that reviews multiple declined Gmail calendar invites in one run and archives only the ones whose matching Google Calendar event has every required attendee declined. For each Gmail invite item, extract its calendar event ID from the email body, then fetch that exact Calendar event for that same item. There can be multiple emails in one execution, so do not reuse the first event ID for every item. Use the paired item relationship when referencing the extraction node; do not use .first() for the event ID. The workflow is incomplete unless it has a final Gmail message archive action after the all-declined check; configure that archive action as `operation: 'removeLabels'` with `labelIds: ['INBOX']` for the matching messages.",
+	"annotations": {
+		"itemFlow": {
+			"requiresPairedItemReferences": true
+		}
+	}
+}

--- a/packages/@n8n/instance-ai/evaluations/data/subagent/item-flow-upstream-reference-after-replacement.json
+++ b/packages/@n8n/instance-ai/evaluations/data/subagent/item-flow-upstream-reference-after-replacement.json
@@ -1,0 +1,9 @@
+{
+	"id": "item-flow-upstream-reference-after-replacement",
+	"prompt": "Build a Gmail and Google Calendar workflow that extracts the calendar event ID from a Gmail invite, archives the Gmail message, then fetches the Calendar event. After the archive step the Gmail node output no longer contains the extracted event ID, so keep the extracted ID available by referencing the upstream extraction step explicitly. Do not use the current $json after the Gmail archive output to read eventId.",
+	"annotations": {
+		"itemFlow": {
+			"requiresUpstreamReferenceAfterReplacement": true
+		}
+	}
+}

--- a/packages/@n8n/instance-ai/evaluations/harness/chat-loop.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/chat-loop.ts
@@ -2,7 +2,7 @@
 // Shared agent-run chat loop
 //
 // Drives an agent run to completion: opens an SSE event stream, waits for
-// the main run to finish, drains background sub-agents, auto-approves any
+// the main run to finish, drains background agent tasks, auto-approves any
 // confirmation requests, and surfaces the captured events.
 //
 // Used by `harness/runner.ts` (workflow eval) and the computer-use eval
@@ -99,7 +99,7 @@ export async function waitForAllActivity(config: WaitConfig): Promise<void> {
 			`[${config.threadId}] Run #${String(runFinishCount)} finished -- time: ${String(Date.now() - config.startTime)}ms`,
 		);
 
-		// Wait for background tasks (sub-agents) to complete
+		// Wait for background agent tasks to complete
 		const remainingMs = Math.max(0, config.timeoutMs - (Date.now() - config.startTime));
 		await waitForBackgroundTasks(config, remainingMs);
 
@@ -140,11 +140,11 @@ async function waitForBackgroundTasks(config: WaitConfig, timeoutMs: number): Pr
 
 	const hasSpawnedAgents = config.events.some((e) => e.type === 'agent-spawned');
 	if (!hasSpawnedAgents) {
-		config.logger.verbose('No sub-agents spawned -- skipping background task wait');
+		config.logger.verbose('No background agent tasks spawned -- skipping background task wait');
 		return;
 	}
 
-	config.logger.verbose('Sub-agent(s) detected -- waiting for background tasks...');
+	config.logger.verbose('Background agent task(s) detected -- waiting for completion...');
 
 	// Log on count change, plus a heartbeat every 20s so a long stable wait still
 	// emits a liveness signal without spamming every poll interval.

--- a/packages/@n8n/instance-ai/evaluations/harness/runner.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/runner.ts
@@ -299,7 +299,7 @@ function isMultiTurnConversation(conversation: ConversationTurn[]): boolean {
 export async function buildWorkflow(config: BuildWorkflowConfig): Promise<BuildResult> {
 	const { client, conversation, logger } = config;
 	const openingMessage = conversation[0]?.text ?? '';
-	const threadId = `eval-${crypto.randomUUID()}`;
+	const threadId = crypto.randomUUID();
 	const startTime = Date.now();
 	const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
@@ -315,6 +315,8 @@ export async function buildWorkflow(config: BuildWorkflowConfig): Promise<BuildR
 		logger.info(
 			`  Building workflow${isMultiTurn ? ' [multi-turn]' : ''}: "${truncate(openingMessage, 60)}"${config.laneTag ?? ''}`,
 		);
+
+		await client.ensureThread(threadId);
 
 		const ssePromise = startSseConnection(client, threadId, events, abortController.signal).catch(
 			() => {},

--- a/packages/@n8n/instance-ai/evaluations/harness/runner.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/runner.ts
@@ -299,7 +299,7 @@ function isMultiTurnConversation(conversation: ConversationTurn[]): boolean {
 export async function buildWorkflow(config: BuildWorkflowConfig): Promise<BuildResult> {
 	const { client, conversation, logger } = config;
 	const openingMessage = conversation[0]?.text ?? '';
-	const threadId = crypto.randomUUID();
+	const threadId = `eval-${crypto.randomUUID()}`;
 	const startTime = Date.now();
 	const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 

--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -21,7 +21,7 @@ You are an expert n8n workflow builder. You generate complete, valid
 TypeScript code using `@n8n/workflow-sdk`.
 
 This skill runs inside the orchestrator. It does not introduce a separate
-builder agent, sub-agent handoff, sandbox workspace, or separate tool allowlist.
+builder agent, delegated handoff, sandbox workspace, or separate tool allowlist.
 Use the orchestrator tools already available in the current turn. If a relevant
 orchestrator or MCP tool is available through tool search, use it when it helps
 complete the build.
@@ -335,7 +335,7 @@ column names.
 - Use `@n8n/workflow-sdk`.
 - Do not specify node positions. They are auto-calculated by the layout engine.
 - Use `expr('{{ $json.field }}')` for n8n expressions. Variables must be inside
-  `{{ }}`.
+  `{{ }}`. `$json` is only the current item from the immediate predecessor.
 - Do not use TypeScript-only syntax that the workflow parser cannot interpret,
   such as `as const`.
 - Use string values directly for discriminator fields like `resource` and
@@ -392,8 +392,10 @@ Follow these rules strictly when generating workflows:
    alive, and do not add an IF gate before a loop only to check whether items
    exist.
 3. Use `executeOnce: true` for a node that receives many items but should run
-   once, such as a summary notification, report generation, or API call that
-   does not vary per input item.
+   once, such as a summary notification, report generation, shared-context
+   fetch, or API call that does not vary per input item. Duplicate
+   notifications or repeated shared-context fetches usually mean this is
+   missing.
 4. Pick the right control-flow primitive:
    - Per-item loop with side effects: `splitInBatches` with `batchSize: 1`,
      feeding the per-item work and looping back via `nextBatch`.
@@ -402,6 +404,9 @@ Follow these rules strictly when generating workflows:
      and `.onFalse()`.
    - Many mutually exclusive paths keyed off a value: Switch with
      `.onCase(index, target)`.
+   - A Filter or IF only selects items; it does not perform the requested side
+     effect. If the user asks to archive, update, delete, send, or create only
+     matching items, wire the corresponding action node on the matching path.
 5. Input and output indices are zero-based. `.input(0)` and `.output(0)` are the
    first input and output. `.input(1)` is the second input, not the first.
 
@@ -428,13 +433,17 @@ Follow these rules strictly when generating workflows:
   clarification or use placeholders. Do not guess.
 - Pay attention to `@builderHint` annotations in search results and type
   definitions. They contain node-specific configuration rules and examples.
+- Gmail archive: the message resource has no `archive` operation. To archive a
+  Gmail message, remove the `INBOX` label with `operation: 'removeLabels'` and
+  `labelIds: ['INBOX']`; do not add an invented `ARCHIVE` label.
 
 ## Expression Reference
 
 Available variables inside `expr('{{ ... }}')`:
 
-- `$json`: current item's JSON data from the immediate predecessor node.
-- `$('NodeName').item.json`: access another node's output by name.
+- `$json`: current item's JSON data from the immediate predecessor node only.
+- `$('NodeName').item.json`: access another node's output item paired with the
+  current item.
 - `$input.first()`, `$input.all()`, and `$input.item`.
 - `$binary`: binary data from the current item.
 - `$now` and `$today`: Luxon date/time helpers.
@@ -451,11 +460,18 @@ expr('{{ $("Source").all().map(i => ({ option: i.json.name })) }}')
 
 When `$json` is unsafe, reference the source node explicitly. This matters for
 AI Agent subnodes, fan-in nodes after IF/Switch/Merge, and values that come from
-further upstream:
+further upstream or from before a node that replaces item JSON:
 
 ```ts
 sessionKey: nodeJson(telegramTrigger, 'message.chat.id')
+eventId: nodeJson(extractEventId, 'eventId')
 ```
+
+Use `$('NodeName').item.json.field` or `nodeJson(sourceNode, 'field')` for
+per-item upstream values. Do not use `.first()` or `$input.first()` for
+per-item data in a multi-item workflow; it always reads item 0 and makes every
+downstream item reuse the first value. Use `.first()` only for a true global
+first item, such as a single configuration row.
 
 ## SDK Patterns Reference
 

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/expressions.test.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/expressions.test.ts
@@ -1,0 +1,15 @@
+import { EXPRESSION_REFERENCE } from './expressions';
+
+describe('EXPRESSION_REFERENCE', () => {
+	it('explains paired item references versus first item references', () => {
+		expect(EXPRESSION_REFERENCE).toContain("$('NodeName').item.json");
+		expect(EXPRESSION_REFERENCE).toContain('paired item');
+		expect(EXPRESSION_REFERENCE).toContain('every downstream item reuses the first value');
+	});
+
+	it('warns that replacing nodes require explicit upstream references', () => {
+		expect(EXPRESSION_REFERENCE).toContain('Gmail archive/update');
+		expect(EXPRESSION_REFERENCE).toContain('read the earlier node directly');
+		expect(EXPRESSION_REFERENCE).toContain("nodeJson(extractEventId, 'eventId')");
+	});
+});

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/expressions.test.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/expressions.test.ts
@@ -8,7 +8,7 @@ describe('EXPRESSION_REFERENCE', () => {
 	});
 
 	it('warns that replacing nodes require explicit upstream references', () => {
-		expect(EXPRESSION_REFERENCE).toContain('Gmail archive/update');
+		expect(EXPRESSION_REFERENCE).toContain('after another node replaces item JSON');
 		expect(EXPRESSION_REFERENCE).toContain('read the earlier node directly');
 		expect(EXPRESSION_REFERENCE).toContain("nodeJson(extractEventId, 'eventId')");
 	});

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/expressions.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/expressions.ts
@@ -4,12 +4,12 @@
  * Consumed by:
  * - Code Builder Agent (ai-workflow-builder.ee)
  * - MCP Server (external SDK reference)
- * - Instance AI builder sub-agent
+ * - Instance AI workflow-builder skill
  */
 export const EXPRESSION_REFERENCE = `Available variables inside \`expr('{{ ... }}')\`:
 
-- \`$json\` — current item's JSON data from the immediate predecessor node
-- \`$('NodeName').item.json\` — access any node's output by name
+- \`$json\` — current item's JSON data from the immediate predecessor node only
+- \`$('NodeName').item.json\` — access the output item from another node that is paired with the current item
 - \`nodeJson(node, 'field.path')\` — SDK helper equivalent to \`expr('{{ $("NodeName").item.json.field.path }}')\`
 - \`$input.first()\` — first item from immediate predecessor
 - \`$input.all()\` — all items from immediate predecessor
@@ -38,6 +38,13 @@ Dynamic data from other nodes — \`$()\` MUST always be inside \`{{ }}\`, never
 - CORRECT: \`expr('{{ $("Source").all().map(i => ({ option: i.json.name })) }}')\` — $() inside {{ }}
 - CORRECT: \`expr('{{ { "fields": [{ "values": $("Fetch Projects").all().map(i => ({ option: i.json.name })) }] } }}')\` — complex JSON inside {{ }}
 
+Item flow semantics — choose the reference that matches the current item:
+
+- Use \`$('NodeName').item.json.field\` or \`nodeJson(sourceNode, 'field')\` when the current node needs the value from the same paired item produced upstream.
+- Do NOT use \`.first()\` or \`$input.first()\` for per-item data in a multi-item workflow. \`.first()\` always reads item 0, so every downstream item reuses the first value.
+- Use \`.first()\` only when the workflow genuinely needs one global first item, such as a single configuration row.
+- If an upstream value is needed after another node replaces item JSON (for example Gmail archive/update, HTTP Request, or Set without keeping input fields), reference the upstream node explicitly with \`$('Extract Data').item.json.field\`; do not expect the value to still exist on \`$json\`.
+
 When \`$json\` is unsafe - use \`nodeJson(node, 'path')\` or \`$('NodeName').item.json.path\` instead:
 
 - AI Agent subnodes: memory, language model, parser, retriever, vector store, and tool subnodes do not have the same immediate predecessor context as a main-flow node.
@@ -46,6 +53,9 @@ When \`$json\` is unsafe - use \`nodeJson(node, 'path')\` or \`$('NodeName').ite
 - Multi-branch fan-in: if a node receives data after IF/Switch/Merge-style branching, \`$json\` only means the current incoming item and may not contain the source field you need.
   WRONG: \`expr('{{ $json.userId }}')\`
   CORRECT: \`nodeJson(userLookup, 'user.id')\`
+- Replacing nodes: if Gmail archive/update, HTTP Request, or Set output no longer contains a field extracted earlier, read the earlier node directly.
+  WRONG: \`expr('{{ $json.eventId }}')\`
+  CORRECT: \`nodeJson(extractEventId, 'eventId')\`
 - Further-upstream data: if the value comes from any node other than the immediate main predecessor, reference that node explicitly.
   WRONG: \`expr('{{ $json.email }}')\`
   CORRECT: \`nodeJson(formTrigger, 'body.email')\``;

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/expressions.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/expressions.ts
@@ -43,7 +43,7 @@ Item flow semantics — choose the reference that matches the current item:
 - Use \`$('NodeName').item.json.field\` or \`nodeJson(sourceNode, 'field')\` when the current node needs the value from the same paired item produced upstream.
 - Do NOT use \`.first()\` or \`$input.first()\` for per-item data in a multi-item workflow. \`.first()\` always reads item 0, so every downstream item reuses the first value.
 - Use \`.first()\` only when the workflow genuinely needs one global first item, such as a single configuration row.
-- If an upstream value is needed after another node replaces item JSON (for example Gmail archive/update, HTTP Request, or Set without keeping input fields), reference the upstream node explicitly with \`$('Extract Data').item.json.field\`; do not expect the value to still exist on \`$json\`.
+- If an upstream value is needed after another node replaces item JSON, reference the upstream node explicitly with \`$('Extract Data').item.json.field\`; do not expect the value to still exist on \`$json\`.
 
 When \`$json\` is unsafe - use \`nodeJson(node, 'path')\` or \`$('NodeName').item.json.path\` instead:
 
@@ -53,7 +53,7 @@ When \`$json\` is unsafe - use \`nodeJson(node, 'path')\` or \`$('NodeName').ite
 - Multi-branch fan-in: if a node receives data after IF/Switch/Merge-style branching, \`$json\` only means the current incoming item and may not contain the source field you need.
   WRONG: \`expr('{{ $json.userId }}')\`
   CORRECT: \`nodeJson(userLookup, 'user.id')\`
-- Replacing nodes: if Gmail archive/update, HTTP Request, or Set output no longer contains a field extracted earlier, read the earlier node directly.
+- Replacing nodes: if the current output no longer contains a field extracted earlier, read the earlier node directly.
   WRONG: \`expr('{{ $json.eventId }}')\`
   CORRECT: \`nodeJson(extractEventId, 'eventId')\`
 - Further-upstream data: if the value comes from any node other than the immediate main predecessor, reference that node explicitly.

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-rules.test.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-rules.test.ts
@@ -14,12 +14,6 @@ describe('WORKFLOW_RULES', () => {
 		expect(WORKFLOW_RULES).toContain('missing `executeOnce: true`');
 	});
 
-	it('explains how to archive Gmail messages', () => {
-		expect(WORKFLOW_RULES).toContain('Gmail archive means remove INBOX');
-		expect(WORKFLOW_RULES).toContain("operation: 'removeLabels'");
-		expect(WORKFLOW_RULES).toContain("labelIds: ['INBOX']");
-	});
-
 	it('requires action nodes after predicate-only routing', () => {
 		expect(WORKFLOW_RULES).toContain('A Filter or IF only selects items');
 		expect(WORKFLOW_RULES).toContain('wire the corresponding action node on the matching path');

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-rules.test.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-rules.test.ts
@@ -7,4 +7,21 @@ describe('WORKFLOW_RULES', () => {
 		expect(WORKFLOW_RULES).toContain('Never synthesize credential IDs');
 		expect(WORKFLOW_RULES).toContain('mock-*');
 	});
+
+	it('connects duplicate item-flow symptoms to executeOnce', () => {
+		expect(WORKFLOW_RULES).toContain('fetches shared context independently');
+		expect(WORKFLOW_RULES).toContain('Duplicate notifications');
+		expect(WORKFLOW_RULES).toContain('missing `executeOnce: true`');
+	});
+
+	it('explains how to archive Gmail messages', () => {
+		expect(WORKFLOW_RULES).toContain('Gmail archive means remove INBOX');
+		expect(WORKFLOW_RULES).toContain("operation: 'removeLabels'");
+		expect(WORKFLOW_RULES).toContain("labelIds: ['INBOX']");
+	});
+
+	it('requires action nodes after predicate-only routing', () => {
+		expect(WORKFLOW_RULES).toContain('A Filter or IF only selects items');
+		expect(WORKFLOW_RULES).toContain('wire the corresponding action node on the matching path');
+	});
 });

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-rules.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-rules.ts
@@ -44,8 +44,4 @@ export const WORKFLOW_RULES = `Follow these rules strictly when generating workf
    - When wiring N branches to a Merge node, the indices are \`0, 1, ..., N-1\` — never \`1, 2, ..., N\`.
    - Counter-examples to AVOID:
      - WRONG: \`sourceA.to(merge.input(1))\` followed by \`sourceB.to(merge.input(2))\` — this skips input 0 entirely; the first branch is silently dropped.
-     - CORRECT: \`sourceA.to(merge.input(0))\` followed by \`sourceB.to(merge.input(1))\`.
-
-6. **Gmail archive means remove INBOX**
-   - Gmail message nodes do not have an \`archive\` operation. To archive a message, use \`operation: 'removeLabels'\` with \`labelIds: ['INBOX']\`
-   - Do not use \`addLabels\` with an invented \`ARCHIVE\` label.`;
+     - CORRECT: \`sourceA.to(merge.input(0))\` followed by \`sourceB.to(merge.input(1))\`.`;

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-rules.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-rules.ts
@@ -4,7 +4,7 @@
  * Consumed by:
  * - Code Builder Agent (ai-workflow-builder.ee)
  * - MCP Server (external SDK reference)
- * - Instance AI builder sub-agent
+ * - Instance AI workflow-builder skill
  */
 export const WORKFLOW_RULES = `Follow these rules strictly when generating workflows:
 
@@ -26,6 +26,8 @@ export const WORKFLOW_RULES = `Follow these rules strictly when generating workf
 3. **Use \`executeOnce: true\` for single-execution nodes**
    - When a node receives N items but should only execute once (not N times), set \`executeOnce: true\`
    - Common cases: sending a summary notification, generating a report, calling an API that doesn't need per-item execution
+   - If a node fetches shared context independently but is chained after a multi-item source, set \`executeOnce: true\` so it does not run once per incoming item
+   - Duplicate notifications, duplicate API calls, or repeated shared-context fetches usually mean a downstream node is missing \`executeOnce: true\` or should be on a parallel branch
    - Example: \`config: { ..., executeOnce: true }\`
 
 4. **Pick the right control-flow primitive**
@@ -33,6 +35,7 @@ export const WORKFLOW_RULES = `Follow these rules strictly when generating workf
    - **Drop items that don't match a predicate** → \`filter\`. It emits 0 items when nothing matches, and the chain stops cleanly.
    - **Two mutually exclusive paths that both do real work** → \`IF\` (\`onTrue\` / \`onFalse\`).
    - **Many mutually exclusive paths keyed off a value** → \`switch\` (\`onCase\`).
+   - A Filter or IF only selects items; it does not perform a requested side effect. If the user asks to archive, update, delete, send, or create only matching items, wire the corresponding action node on the matching path.
    - Nested control flow is supported: \`ifNode.onTrue(loopBuilder)\`, \`switchNode.onCase(0, loopBuilder)\`, and \`splitInBatches(sib).onEachBatch(ifElseBuilder)\` all compile and wire correctly. Use them when the semantics genuinely call for it, not as a workaround for empty-list handling.
 
 5. **Input and output indices are 0-based — \`.input(0)\` is the FIRST input**
@@ -41,4 +44,8 @@ export const WORKFLOW_RULES = `Follow these rules strictly when generating workf
    - When wiring N branches to a Merge node, the indices are \`0, 1, ..., N-1\` — never \`1, 2, ..., N\`.
    - Counter-examples to AVOID:
      - WRONG: \`sourceA.to(merge.input(1))\` followed by \`sourceB.to(merge.input(2))\` — this skips input 0 entirely; the first branch is silently dropped.
-     - CORRECT: \`sourceA.to(merge.input(0))\` followed by \`sourceB.to(merge.input(1))\`.`;
+     - CORRECT: \`sourceA.to(merge.input(0))\` followed by \`sourceB.to(merge.input(1))\`.
+
+6. **Gmail archive means remove INBOX**
+   - Gmail message nodes do not have an \`archive\` operation. To archive a message, use \`operation: 'removeLabels'\` with \`labelIds: ['INBOX']\`
+   - Do not use \`addLabels\` with an invented \`ARCHIVE\` label.`;

--- a/packages/nodes-base/nodes/Google/Gmail/Gmail.node.ts
+++ b/packages/nodes-base/nodes/Google/Gmail/Gmail.node.ts
@@ -22,6 +22,16 @@ export class Gmail extends VersionedNodeType {
 							'Use Gmail Trigger for scheduled email fetching, which is simpler for user than Schedule Trigger with Gmail getAll',
 					},
 				],
+				extraTypeDefContent: [
+					{
+						displayOptions: { show: { resource: ['message'], operation: ['removeLabels'] } },
+						content: `<patterns>
+<pattern title="Archive a Gmail message">
+Use the message \`removeLabels\` operation with \`labelIds: ['INBOX']\`. Gmail has no separate archive operation, and \`addLabels\` with an invented \`ARCHIVE\` label does not archive the message.
+</pattern>
+</patterns>`,
+					},
+				],
 			},
 			schemaPath: 'Google/Gmail',
 		};


### PR DESCRIPTION
## Summary

Adds focused Instance AI workflow-builder guidance and SDK prompt reference coverage for item-flow regressions from INS-335:

- Preserve paired upstream item references instead of first item references
- Fetch independent shared context once with executeOnce
- Use Gmail removeLabels INBOX for archive flows and wire action nodes after filters

Adds deterministic binary checks plus three workflow-build eval fixtures for the root and adjacent failures from the trace. Keeps eval:subagent wording as a legacy command name while describing the runtime as orchestrator and skill backed.

## Methodology

Followed Evaluation Driven Development for the ticket:

1. Assessed the Linear ticket and LangSmith trace to isolate the root item-flow failure and adjacent error modes.
2. Wrote failing eval coverage first around the trace behaviors:
   - paired upstream item references should not collapse to item 0 via `.first()` / `$input.first()`
   - values extracted before a replacing node should be referenced from the upstream item, not current `$json`
   - independent shared-context fetches behind multi-item paths should use `executeOnce`
3. Ran the item-flow evals over repeated iterations to confirm they consistently reproduced the reported failures before changing guidance.
4. Kept the set lean by removing broader workflow execution fixtures and retaining the three workflow-build compatibility cases that reproduce the observed skill-path behavior.
5. Updated the workflow-builder skill and SDK prompt references, then confirmed the same evals passed with the new guidance.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-335

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created. Internal Instance AI guidance and eval docs updated; external docs not needed.
- [x] Tests included.
- [ ] PR Labeled with Backport to Beta, Backport to Stable, or Backport to v1 (if the PR is an urgent fix that needs to be backported)
