### PR TITLE
ci: Bump grind workflow runner to 4-vCPU

### DIFF
--- a/.github/workflows/grind-changed-tests.yml
+++ b/.github/workflows/grind-changed-tests.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   grind:
     name: Grind changed editor-ui tests
-    runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-2vcpu-ubuntu-2204' }}
+    runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
     # Non-blocking: a failure here surfaces in the PR Checks tab as a soft
     # signal but never gates merge. Remove `continue-on-error` once we have
     # confidence the grind has a low false-positive rate.


### PR DESCRIPTION
## Summary

The `CI: Grind changed tests` job runs on `blacksmith-2vcpu-ubuntu-2204`. The full `pnpm build` invoked by the shared `setup-nodejs` action aborts there with exit **134** (V8 JS-heap OOM / SIGABRT) building `packages/cli`, which fails the **Setup Node.js** step *before* the grind step runs.

Because the job is `continue-on-error: true`, the run still reports **green** — so the failure is invisible at the PR-Checks level. Sampling 25 run-level-green runs from the last 24h:

| Reality | Count |
|---|---|
| `job:failure` / grind step **skipped** | 22 |
| `job:success` / grind passed | 2 |
| `job:failure` / grind ran & failed | 1 |

~88% of runs never actually grind anything.

## Change

Bump the runner `blacksmith-2vcpu-ubuntu-2204` → `blacksmith-4vcpu-ubuntu-2204` (already the most common runner in the repo) so the build fits in memory and the grind executes. The GitHub-provider fallback (`ubuntu-latest`) is unchanged.

## Follow-ups (not this PR)
- Scope `setup-nodejs` to a partial/affected build — the grind only needs editor-ui + deps, not `packages/cli`.
- Make the signal legible so `continue-on-error` doesn't hide setup failures vs real grind failures.
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
https://linear.app/n8n/issue/DEVP-316

🤖 Generated with [Claude Code](https://claude.com/claude-code)