### PR TITLE
fix(core): Polyfill DOMMatrix when parsing PDFs in Data Loader

### DIFF
--- a/packages/@n8n/ai-utilities/package.json
+++ b/packages/@n8n/ai-utilities/package.json
@@ -102,6 +102,7 @@
     "tmp-promise": "3.0.3",
     "js-tiktoken": "catalog:",
     "https-proxy-agent": "catalog:",
+    "@thednp/dommatrix": "^2.0.12",
     "pdf-parse": "catalog:",
     "proxy-from-env": "^1.1.0",
     "undici": "^6.21.0"

--- a/packages/@n8n/ai-utilities/src/__tests__/utils/loaders/n8n-pdf-loader.test.ts
+++ b/packages/@n8n/ai-utilities/src/__tests__/utils/loaders/n8n-pdf-loader.test.ts
@@ -225,4 +225,35 @@ describe('N8nPdfLoader', () => {
 			blobType: 'application/pdf',
 		});
 	});
+
+	// `pdf-parse` v2 is backed by pdfjs-dist, which references the `DOMMatrix`
+	// global. Node.js does not provide it, so the loader must polyfill it before
+	// parsing — otherwise pdfjs throws "DOMMatrix is not defined" on PDFs that
+	// exercise that code path.
+	describe('DOMMatrix polyfill', () => {
+		const hadDomMatrix = 'DOMMatrix' in globalThis;
+		const originalDomMatrix: unknown = Reflect.get(globalThis, 'DOMMatrix');
+
+		afterAll(() => {
+			if (hadDomMatrix) {
+				Reflect.set(globalThis, 'DOMMatrix', originalDomMatrix);
+			} else {
+				Reflect.deleteProperty(globalThis, 'DOMMatrix');
+			}
+		});
+
+		it('defines a usable DOMMatrix global before parsing when one is absent', async () => {
+			Reflect.deleteProperty(globalThis, 'DOMMatrix');
+			mockGetText.mockResolvedValue({
+				pages: [{ num: 1, text: 'page' }],
+				text: 'page',
+				total: 1,
+			});
+
+			const loader = new N8nPdfLoader(makeBlob());
+			await loader.load();
+
+			expect(typeof Reflect.get(globalThis, 'DOMMatrix')).toBe('function');
+		});
+	});
 });

--- a/packages/@n8n/ai-utilities/src/utils/loaders/n8n-pdf-loader.ts
+++ b/packages/@n8n/ai-utilities/src/utils/loaders/n8n-pdf-loader.ts
@@ -25,6 +25,13 @@ export class N8nPdfLoader extends BufferLoader {
 	}
 
 	protected async parse(raw: Buffer, metadata: Record<string, unknown>): Promise<Document[]> {
+		// pdf-parse v2 is backed by pdfjs-dist, which expects a `DOMMatrix` global
+		// that Node.js does not provide. Polyfill it before parsing.
+		if (typeof Reflect.get(globalThis, 'DOMMatrix') === 'undefined') {
+			const { default: DOMMatrix } = await import('@thednp/dommatrix');
+			Reflect.set(globalThis, 'DOMMatrix', DOMMatrix);
+		}
+
 		const { PDFParse } = await import('pdf-parse');
 
 		// Buffer extends Uint8Array; PDFParse accepts it directly.

--- a/packages/@n8n/instance-ai/package.json
+++ b/packages/@n8n/instance-ai/package.json
@@ -61,6 +61,7 @@
     "@n8n/utils": "workspace:*",
     "@n8n/workflow-sdk": "workspace:*",
     "@opentelemetry/api": "^1.9.0",
+    "@thednp/dommatrix": "^2.0.12",
     "csv-parse": "catalog:",
     "fast-glob": "catalog:",
     "flatted": "catalog:",

--- a/packages/@n8n/instance-ai/src/parsers/__tests__/pdf-parser.test.ts
+++ b/packages/@n8n/instance-ai/src/parsers/__tests__/pdf-parser.test.ts
@@ -97,4 +97,34 @@ describe('extractPdfText', () => {
 			}),
 		).rejects.toThrow(/no extractable text/);
 	});
+
+	// `pdf-parse` v2 is backed by pdfjs-dist, which references the `DOMMatrix`
+	// global. Node.js does not provide it, so the parser must polyfill it before
+	// parsing — otherwise pdfjs throws "DOMMatrix is not defined" on PDFs that
+	// exercise that code path.
+	describe('DOMMatrix polyfill', () => {
+		const hadDomMatrix = 'DOMMatrix' in globalThis;
+		const originalDomMatrix: unknown = Reflect.get(globalThis, 'DOMMatrix');
+
+		afterAll(() => {
+			if (hadDomMatrix) {
+				Reflect.set(globalThis, 'DOMMatrix', originalDomMatrix);
+			} else {
+				Reflect.deleteProperty(globalThis, 'DOMMatrix');
+			}
+		});
+
+		it('defines a usable DOMMatrix global before parsing when one is absent', async () => {
+			Reflect.deleteProperty(globalThis, 'DOMMatrix');
+			mockGetText.mockResolvedValue({ text: 'Hello world', total: 1 });
+
+			await extractPdfText({
+				data: toBase64('pdf-bytes'),
+				mimeType: 'application/pdf',
+				fileName: 'doc.pdf',
+			});
+
+			expect(typeof Reflect.get(globalThis, 'DOMMatrix')).toBe('function');
+		});
+	});
 });

--- a/packages/@n8n/instance-ai/src/parsers/pdf-parser.ts
+++ b/packages/@n8n/instance-ai/src/parsers/pdf-parser.ts
@@ -22,6 +22,13 @@ export async function extractPdfText(attachment: AttachmentInfo): Promise<PdfExt
 		throw new Error(formatSizeLimitMessage(decoded.length));
 	}
 
+	// pdf-parse v2 is backed by pdfjs-dist, which expects a `DOMMatrix` global
+	// that Node.js does not provide. Polyfill it before parsing.
+	if (typeof Reflect.get(globalThis, 'DOMMatrix') === 'undefined') {
+		const { default: DOMMatrix } = await import('@thednp/dommatrix');
+		Reflect.set(globalThis, 'DOMMatrix', DOMMatrix);
+	}
+
 	const { PDFParse } = await import('pdf-parse');
 
 	const parser = new PDFParse({ data: decoded });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -838,6 +838,9 @@ importers:
       '@n8n/utils':
         specifier: workspace:*
         version: link:../utils
+      '@thednp/dommatrix':
+        specifier: ^2.0.12
+        version: 2.0.12
       https-proxy-agent:
         specifier: 'catalog:'
         version: 7.0.6
@@ -1932,6 +1935,9 @@ importers:
       '@opentelemetry/api':
         specifier: ^1.9.0
         version: 1.9.0
+      '@thednp/dommatrix':
+        specifier: ^2.0.12
+        version: 2.0.12
       csv-parse:
         specifier: 'catalog:'
         version: 6.2.1


### PR DESCRIPTION
## Summary

The **Default Data Loader** node and the instance-ai PDF attachment parser extract PDF text via `pdf-parse` v2, which is backed by `pdfjs-dist`. `pdfjs` dereferences the `DOMMatrix` browser global on certain PDF content (transforms, images, annotations). Node.js does not provide `DOMMatrix`, so those PDFs fail with **`DOMMatrix is not defined`** — the error users hit in the Data Loader node.

`packages/nodes-base/utils/binary.ts` already polyfills `DOMMatrix` (via `@thednp/dommatrix`) for its own `pdfjs-dist` usage, but the two `pdf-parse` v2 call sites did not. This PR adds the same polyfill before parsing in both:

- `@n8n/ai-utilities` → `N8nPdfLoader` (used by the Default Data Loader node)
- `@n8n/instance-ai` → `extractPdfText` (PDF attachment parser)

`@thednp/dommatrix` is added as a dependency to both packages (pinned `^2.0.12`, matching `nodes-base`).

### How to test

1. Run a workflow with a **Default Data Loader** (`dataType: binary`) feeding a PDF into a vector store / embeddings (e.g. Google Drive → Supabase Vector Store, as in the linked issue).
2. Use a PDF that previously triggered `DOMMatrix is not defined`.
3. The node now parses the PDF and produces documents instead of erroring.

Regression tests are included in both packages. They simulate the Node environment (no `DOMMatrix` global) and assert the parser installs a usable `DOMMatrix` before handing off to `pdf-parse`. Removing the polyfill makes these tests fail.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AI-2551

closes #30841

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI