### PR TITLE
test(core): Guard $jmespath resolution under the VM expression engine

### DIFF
--- a/packages/workflow/test/expression.test.ts
+++ b/packages/workflow/test/expression.test.ts
@@ -1292,6 +1292,66 @@ describe('Expression', () => {
 		});
 	});
 
+	// CAT-3267: `$jmespath($json, query)` returned null under the VM engine
+	// because `$json` is an in-isolate lazy proxy that could not cross the
+	// isolate bridge to the host-side `$jmespath` wrapper. The fix resolves
+	// `$jmespath` / `$jmesPath` entirely in-isolate so the proxy never crosses
+	// the bridge. Both engines must return the queried value.
+	describe('$jmespath through expression engine (engine parity)', () => {
+		const nodeTypes = Helpers.NodeTypes();
+		const workflow = new Workflow({
+			id: 'test-jmespath',
+			name: 'Test',
+			nodes: [
+				{
+					id: 'node-id',
+					name: 'node',
+					type: 'n8n-nodes-base.set',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+			],
+			connections: {},
+			active: false,
+			nodeTypes,
+		});
+
+		beforeAll(async () => {
+			await workflow.expression.acquireIsolate();
+		});
+		afterAll(async () => {
+			await workflow.expression.releaseIsolate();
+		});
+
+		const evaluate = (expr: string, data: INodeExecutionData[]) =>
+			workflow.expression.getParameterValue(expr, null, 0, 0, 'node', data, 'manual', {});
+
+		it('queries an in-isolate $json proxy (parity)', () => {
+			expect(
+				evaluate('={{ $jmespath($json, "users[*].name") }}', [
+					{ json: { users: [{ name: 'a' }, { name: 'b' }] } },
+				]),
+			).toEqual(['a', 'b']);
+		});
+
+		it('queries via the $jmesPath alias (parity)', () => {
+			expect(
+				evaluate('={{ $jmesPath($json, "users[*].name") }}', [
+					{ json: { users: [{ name: 'a' }, { name: 'b' }] } },
+				]),
+			).toEqual(['a', 'b']);
+		});
+
+		it('resolves a nested-object query (parity)', () => {
+			expect(
+				evaluate('={{ $jmespath($json, "user.address.city") }}', [
+					{ json: { user: { address: { city: 'Berlin' } } } },
+				]),
+			).toBe('Berlin');
+		});
+	});
+
 	describe('getParameterValue with IWorkflowDataProxyData', () => {
 		it('should evaluate simple expression with provided IWorkflowDataProxyData', async () => {
 			const nodeTypes = Helpers.NodeTypes();


### PR DESCRIPTION
## Summary

Adds engine-parity regression tests for `$jmespath` / `$jmesPath` to `packages/workflow/test/expression.test.ts`.

Under `N8N_EXPRESSION_ENGINE=vm`, `={{ $jmespath($json, "users[*].name") }}` used to return `null` instead of the queried value: `$json` is an in-isolate lazy proxy, so passing it to the host-side `$jmespath` wrapper failed at the `isolated-vm` marshaling boundary, and the in-isolate error handler swallowed that to `undefined`/`null`. The fix (#30736) resolves `$jmespath` entirely in-isolate so the proxy never crosses the bridge.

The suite's vitest config runs every case under both the `legacy-engine` and `vm-engine` projects, so each new test is automatically parity-checked. Three minimal cases against an in-isolate `$json` proxy:

- `$jmespath($json, "users[*].name")` → `["a", "b"]`
- `$jmesPath($json, ...)` (capital-P alias) → `["a", "b"]`
- nested-object query `$jmespath($json, "user.address.city")` → `"Berlin"`

### How to test

```bash
pnpm --filter @n8n/expression-runtime build   # rebuild the IIFE runtime bundle first
cd packages/workflow && pnpm test test/expression.test.ts -t "jmespath through expression engine"
```

Both engine projects pass (6 tests). Guard verified by temporarily disabling the in-isolate `target.$jmespath` shadow in `context.ts` and rebuilding: the three tests then fail on `vm-engine` (return `undefined`) while staying green on `legacy-engine`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3267

Guards the fix from #30736.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI