### PR TITLE
fix(RSS Feed Trigger Node): Honor "Continue (using error output)" on HTTP and parse errors

### DIFF
--- a/packages/nodes-base/nodes/RssFeedRead/RssFeedReadTrigger.node.ts
+++ b/packages/nodes-base/nodes/RssFeedRead/RssFeedReadTrigger.node.ts
@@ -61,14 +61,30 @@ export class RssFeedReadTrigger implements INodeType {
 		try {
 			feed = await parseFeedUrl(this.helpers, feedUrl);
 		} catch (error) {
-			if (error.code === 'ECONNREFUSED') {
-				throw new NodeOperationError(
-					this.getNode(),
-					`It was not possible to connect to the URL. Please make sure the URL "${feedUrl}" it is valid!`,
-				);
+			const node = this.getNode();
+			const message =
+				(error as { code?: string }).code === 'ECONNREFUSED'
+					? `It was not possible to connect to the URL. Please make sure the URL "${feedUrl}" it is valid!`
+					: (error as Error).message;
+
+			// Route HTTP/parse failures through the node's configured error path so users
+			// can handle them with "Continue (using error output)" instead of falling through
+			// to the global Error Workflow. The engine inspects items with `json.error` and,
+			// when `onError === 'continueErrorOutput'`, moves them to the node's error output
+			// (see WorkflowExecute.handleNodeErrorOutput).
+			if (
+				node.onError === 'continueErrorOutput' ||
+				node.onError === 'continueRegularOutput' ||
+				node.continueOnFail === true
+			) {
+				return [[{ json: { error: message } }]];
 			}
 
-			throw new NodeOperationError(this.getNode(), error as Error);
+			if ((error as { code?: string }).code === 'ECONNREFUSED') {
+				throw new NodeOperationError(node, message);
+			}
+
+			throw new NodeOperationError(node, error as Error);
 		}
 
 		const returnData: IDataObject[] = [];

--- a/packages/nodes-base/nodes/RssFeedRead/test/RssFeedRead.test.ts
+++ b/packages/nodes-base/nodes/RssFeedRead/test/RssFeedRead.test.ts
@@ -1,6 +1,6 @@
 import { mock } from 'jest-mock-extended';
 import { returnJsonArray } from 'n8n-core';
-import type { IPollFunctions } from 'n8n-workflow';
+import type { INode, IPollFunctions } from 'n8n-workflow';
 import Parser from 'rss-parser';
 
 import { RssFeedReadTrigger } from '../RssFeedReadTrigger.node';
@@ -90,6 +90,98 @@ describe('RssFeedReadTrigger', () => {
 			);
 			expect(Parser.prototype.parseString).toHaveBeenCalledWith('<rss />');
 			expect(pollData.lastItemDate).toEqual(lastItemDate);
+		});
+
+		describe('error handling honors node.onError', () => {
+			const httpError = Object.assign(new Error('Request failed with status code 404'), {
+				code: 404,
+			});
+
+			const setupPoll = (nodeOverrides: Partial<INode>, mode: 'trigger' | 'manual' = 'trigger') => {
+				pollFunctions.getNodeParameter.mockReturnValue(feedUrl);
+				pollFunctions.getWorkflowStaticData.mockReturnValue(mock({}));
+				pollFunctions.getMode.mockReturnValue(mode);
+				pollFunctions.getNode.mockReturnValue(
+					mock<INode>({ name: 'RSS Feed Trigger', ...nodeOverrides }),
+				);
+				helpers.httpRequest.mockRejectedValue(httpError);
+			};
+
+			it('emits an item with json.error when onError is "continueErrorOutput"', async () => {
+				// The execution engine moves items with `json.error` to the error output
+				// (see WorkflowExecute.handleNodeErrorOutput). The trigger only needs to
+				// emit the item; the engine handles the routing.
+				setupPoll({ onError: 'continueErrorOutput' });
+
+				const result = await node.poll.call(pollFunctions);
+
+				expect(result).toEqual([[{ json: { error: 'Request failed with status code 404' } }]]);
+			});
+
+			it('emits an item with json.error when onError is "continueRegularOutput"', async () => {
+				setupPoll({ onError: 'continueRegularOutput' });
+
+				const result = await node.poll.call(pollFunctions);
+
+				expect(result).toEqual([[{ json: { error: 'Request failed with status code 404' } }]]);
+			});
+
+			it('emits an item with json.error when legacy continueOnFail is true', async () => {
+				setupPoll({ continueOnFail: true });
+
+				const result = await node.poll.call(pollFunctions);
+
+				expect(result).toEqual([[{ json: { error: 'Request failed with status code 404' } }]]);
+			});
+
+			it('throws when onError is "stopWorkflow"', async () => {
+				setupPoll({ onError: 'stopWorkflow' });
+
+				await expect(node.poll.call(pollFunctions)).rejects.toThrow(
+					'Request failed with status code 404',
+				);
+			});
+
+			it('throws when onError is unset (default behavior)', async () => {
+				setupPoll({});
+
+				await expect(node.poll.call(pollFunctions)).rejects.toThrow(
+					'Request failed with status code 404',
+				);
+			});
+
+			it('emits an item with json.error in manual mode too', async () => {
+				setupPoll({ onError: 'continueErrorOutput' }, 'manual');
+
+				const result = await node.poll.call(pollFunctions);
+
+				expect(result).toEqual([[{ json: { error: 'Request failed with status code 404' } }]]);
+			});
+
+			it('formats ECONNREFUSED errors with a friendly message when routed to the error output', async () => {
+				pollFunctions.getNodeParameter.mockReturnValue(feedUrl);
+				pollFunctions.getWorkflowStaticData.mockReturnValue(mock({}));
+				pollFunctions.getMode.mockReturnValue('trigger');
+				pollFunctions.getNode.mockReturnValue(
+					mock<INode>({ name: 'RSS Feed Trigger', onError: 'continueErrorOutput' }),
+				);
+				const connectionError = Object.assign(new Error('connect ECONNREFUSED'), {
+					code: 'ECONNREFUSED',
+				});
+				helpers.httpRequest.mockRejectedValue(connectionError);
+
+				const result = await node.poll.call(pollFunctions);
+
+				expect(result).toEqual([
+					[
+						{
+							json: {
+								error: `It was not possible to connect to the URL. Please make sure the URL "${feedUrl}" it is valid!`,
+							},
+						},
+					],
+				]);
+			});
 		});
 	});
 });


### PR DESCRIPTION
## Summary

`RssFeedReadTrigger.poll()` unconditionally rethrew any failure from `parseFeedUrl` as a `NodeOperationError`, which surfaced as a poll/trigger failure and routed to the global Error Workflow — ignoring the node's configured **On Error** behavior. Users who set "Continue (using error output)" expected HTTP 4xx/5xx and parse failures to flow through the node's error output instead.

This change catches errors inside `poll()` and, when the node is configured with `continueErrorOutput`, `continueRegularOutput`, or the legacy `continueOnFail`, returns a regular-output item carrying `{ json: { error: <message> } }`. The execution engine's existing `WorkflowExecute.handleNodeErrorOutput` then moves that item to the error output when `onError === 'continueErrorOutput'`, matching the contract that every other node already uses (`Slack/V2.node.ts:393`, `Xml.node.ts:307`, `HttpRequest/V1.node.ts:1033`, etc.). When `onError` is `stopWorkflow` or unset, behavior is unchanged — the error is still thrown.

ECONNREFUSED keeps its friendly "could not connect" message in both paths.

### How to test

1. Drop an RSS Feed Trigger on a fresh canvas with `Feed URL = https://httpbin.org/status/404` (or any URL that returns a non-2xx).
2. Set **On Error** to **Continue (using error output)**, wire a Set node to each output.
3. Click **Execute workflow** — Trigger goes green, no toast, **Error branch** receives `{ "error": "Request failed with status code 404" }`, **Success branch** is empty.
4. Flip **On Error** back to **Stop Workflow** and re-execute — pre-fix behavior is preserved (toast / global Error Workflow on activated workflows).

Unit tests cover all three modes (`continueErrorOutput`, `continueRegularOutput`, `continueOnFail`), the default stop-workflow path, manual mode, and the ECONNREFUSED message.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5164

fixes #31372

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI