### PR TITLE
feat(core): Support structured output for agents called from workflows (no-changelog)

### DIFF
--- a/packages/@n8n/agents/src/__tests__/integration/structured-output.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/structured-output.test.ts
@@ -20,6 +20,30 @@ function createStructuredAgent(provider: 'anthropic' | 'openai'): Agent {
 		.structuredOutput(answerSchema);
 }
 
+// Raw JSON Schema equivalent of `answerSchema` — exercises the JSON Schema path
+// (as used when a workflow node supplies the schema dynamically).
+const answerJsonSchema = {
+	type: 'object' as const,
+	properties: {
+		city: { type: 'string' as const, description: 'The name of the city' },
+		country: { type: 'string' as const, description: 'The country the city is in' },
+		population_millions: {
+			type: 'number' as const,
+			description: 'Approximate population in millions',
+		},
+	},
+	required: ['city', 'country', 'population_millions'],
+};
+
+function createJsonSchemaStructuredAgent(provider: 'anthropic' | 'openai'): Agent {
+	return new Agent('structured-output-json-schema-test')
+		.model(getModel(provider))
+		.instructions(
+			'You answer geography questions. Always respond with the structured output schema. Be precise and factual.',
+		)
+		.structuredOutput(answerJsonSchema);
+}
+
 function createStructuredAgentWithTool(provider: 'anthropic' | 'openai'): Agent {
 	const lookupTool = new Tool('lookup_capital')
 		.description('Look up the capital city of a country')
@@ -84,6 +108,24 @@ describe('structured output integration', () => {
 		expect(result.finishReason).toBe('stop');
 		expect(result.structuredOutput).toBeDefined();
 
+		const parsed = answerSchema.safeParse(result.structuredOutput);
+		expect(parsed.success).toBe(true);
+		if (parsed.success) {
+			expect(parsed.data.city.toLowerCase()).toContain('paris');
+			expect(parsed.data.country.toLowerCase()).toContain('france');
+			expect(parsed.data.population_millions).toBeGreaterThan(0);
+		}
+	});
+
+	it('returns parsed structuredOutput when configured with a raw JSON Schema', async () => {
+		const agent = createJsonSchemaStructuredAgent('anthropic');
+
+		const result = await agent.generate('What is the capital of France?');
+
+		expect(result.finishReason).toBe('stop');
+		expect(result.structuredOutput).toBeDefined();
+
+		// The output still conforms to the equivalent Zod shape.
 		const parsed = answerSchema.safeParse(result.structuredOutput);
 		expect(parsed.success).toBe(true);
 		if (parsed.success) {

--- a/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
@@ -1813,6 +1813,38 @@ describe('AgentRuntime.generate() — structured output', () => {
 		);
 	});
 
+	it('disables strict JSON Schema validation for OpenAI/Groq when a raw JSON Schema is configured', async () => {
+		generateText.mockResolvedValue(makeGenerateSuccessWithOutput({ answer: 'x', score: 1 }));
+
+		const { runtime } = createJsonSchemaStructuredRuntime();
+		await runtime.generate('hello');
+
+		const callArgs = (generateText.mock.calls[0] as [unknown, unknown])[0] as Record<
+			string,
+			unknown
+		>;
+		expect(callArgs.providerOptions).toEqual(
+			expect.objectContaining({
+				openai: { strictJsonSchema: false },
+				groq: { strictJsonSchema: false },
+			}),
+		);
+	});
+
+	it('keeps strict JSON Schema validation (no relaxation) for a Zod schema', async () => {
+		generateText.mockResolvedValue(makeGenerateSuccessWithOutput({ answer: 'x', score: 1 }));
+
+		const { runtime } = createStructuredRuntime();
+		await runtime.generate('hello');
+
+		const callArgs = (generateText.mock.calls[0] as [unknown, unknown])[0] as Record<
+			string,
+			unknown
+		>;
+		// No thinking/provider options configured and Zod output → no strict override.
+		expect(callArgs.providerOptions).toBeUndefined();
+	});
+
 	it('preserves structuredOutput through tool-call iterations', async () => {
 		const tool: BuiltTool = {
 			name: 'add',

--- a/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
@@ -1,4 +1,5 @@
 import * as aiModule from 'ai';
+import type { JSONSchema7 } from 'json-schema';
 import type { Mock, MockedFunction } from 'vitest';
 import { z } from 'zod';
 
@@ -49,6 +50,7 @@ vi.mock('ai', async () => {
 		generateText: vi.fn(),
 		streamText: vi.fn(),
 		tool: vi.fn((config: unknown) => config),
+		jsonSchema: vi.fn((schema: unknown) => ({ _type: 'jsonSchema', schema })),
 		Output: {
 			object: vi.fn(({ schema }: { schema: unknown }) => ({ _type: 'object', schema })),
 		},
@@ -59,11 +61,12 @@ vi.mock('ai', async () => {
 // Helpers
 // ---------------------------------------------------------------------------
 
-const { embed, embedMany, generateText, streamText } = aiModule as unknown as {
+const { embed, embedMany, generateText, streamText, jsonSchema } = aiModule as unknown as {
 	embed: Mock;
 	embedMany: Mock;
 	generateText: Mock;
 	streamText: Mock;
+	jsonSchema: Mock;
 };
 
 /** Minimal successful generateText response. */
@@ -212,6 +215,12 @@ function createRuntime(eventBus?: AgentEventBus) {
 
 const testSchema = z.object({ answer: z.string(), score: z.number() });
 
+const testJsonSchema: JSONSchema7 = {
+	type: 'object',
+	properties: { answer: { type: 'string' }, score: { type: 'number' } },
+	required: ['answer', 'score'],
+};
+
 /** Build a runtime configured with structuredOutput. */
 function createStructuredRuntime(options?: { tools?: BuiltTool[]; eventBus?: AgentEventBus }) {
 	const bus = options?.eventBus ?? new AgentEventBus();
@@ -222,6 +231,19 @@ function createStructuredRuntime(options?: { tools?: BuiltTool[]; eventBus?: Age
 		structuredOutput: testSchema,
 		eventBus: bus,
 		...(options?.tools ? { tools: options.tools } : {}),
+	});
+	return { runtime, bus };
+}
+
+/** Build a runtime configured with a raw JSON Schema structuredOutput. */
+function createJsonSchemaStructuredRuntime() {
+	const bus = new AgentEventBus();
+	const runtime = new AgentRuntime({
+		name: 'test-structured-json',
+		model: 'openai/gpt-4o-mini',
+		instructions: 'You are a test assistant.',
+		structuredOutput: testJsonSchema,
+		eventBus: bus,
 	});
 	return { runtime, bus };
 }
@@ -1754,6 +1776,41 @@ describe('AgentRuntime.generate() — structured output', () => {
 			unknown
 		>;
 		expect(callArgs.output).toBeUndefined();
+	});
+
+	it('returns structuredOutput when a raw JSON Schema is configured', async () => {
+		const expected = { answer: 'Paris', score: 0.95 };
+		generateText.mockResolvedValue(makeGenerateSuccessWithOutput(expected));
+
+		const { runtime } = createJsonSchemaStructuredRuntime();
+		const result = await runtime.generate('What is the capital of France?');
+
+		expect(result.structuredOutput).toEqual(expected);
+		expect(result.finishReason).toBe('stop');
+	});
+
+	it('wraps a provider-strict JSON Schema output spec via jsonSchema() before passing to generateText', async () => {
+		generateText.mockResolvedValue(makeGenerateSuccessWithOutput({ answer: 'x', score: 1 }));
+
+		const { runtime } = createJsonSchemaStructuredRuntime();
+		await runtime.generate('hello');
+
+		// Raw JSON Schema is made provider-strict (additionalProperties: false) and
+		// wrapped with the AI SDK's jsonSchema() helper, rather than passed through
+		// directly (which is what Zod schemas do).
+		const strictTestJsonSchema = { ...testJsonSchema, additionalProperties: false };
+		expect(jsonSchema).toHaveBeenCalledWith(strictTestJsonSchema);
+
+		const callArgs = (generateText.mock.calls[0] as [unknown, unknown])[0] as Record<
+			string,
+			unknown
+		>;
+		expect(callArgs.output).toEqual(
+			expect.objectContaining({
+				_type: 'object',
+				schema: { _type: 'jsonSchema', schema: strictTestJsonSchema },
+			}),
+		);
 	});
 
 	it('preserves structuredOutput through tool-call iterations', async () => {

--- a/packages/@n8n/agents/src/runtime/__tests__/tool-adapter.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/tool-adapter.test.ts
@@ -2,7 +2,7 @@ import type { JSONSchema7 } from 'json-schema';
 import { z } from 'zod';
 
 import type { BuiltTool } from '../../types';
-import { executeTool, toAiSdkTools, toStrictJsonSchema } from '../tool-adapter';
+import { executeTool, toAiSdkTools, lockAdditionalProperties } from '../tool-adapter';
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -224,12 +224,12 @@ describe('executeTool — context propagation', () => {
 });
 
 // ---------------------------------------------------------------------------
-// toStrictJsonSchema
+// lockAdditionalProperties
 // ---------------------------------------------------------------------------
 
-describe('toStrictJsonSchema', () => {
+describe('lockAdditionalProperties', () => {
 	it('sets additionalProperties:false on a root object that omits it', () => {
-		const result = toStrictJsonSchema({
+		const result = lockAdditionalProperties({
 			type: 'object',
 			properties: { name: { type: 'string' } },
 			required: ['name'],
@@ -244,13 +244,15 @@ describe('toStrictJsonSchema', () => {
 	});
 
 	it('normalises an object that declares properties without a type', () => {
-		const result = toStrictJsonSchema({ properties: { id: { type: 'string' } } } as JSONSchema7);
+		const result = lockAdditionalProperties({
+			properties: { id: { type: 'string' } },
+		} as JSONSchema7);
 
 		expect(result).toMatchObject({ type: 'object', additionalProperties: false });
 	});
 
 	it('applies additionalProperties:false recursively to nested objects', () => {
-		const result = toStrictJsonSchema({
+		const result = lockAdditionalProperties({
 			type: 'object',
 			properties: {
 				address: {
@@ -271,7 +273,7 @@ describe('toStrictJsonSchema', () => {
 	});
 
 	it('recurses into $defs and anyOf branches', () => {
-		const result = toStrictJsonSchema({
+		const result = lockAdditionalProperties({
 			type: 'object',
 			properties: { ref: { $ref: '#/$defs/Inner' } },
 			anyOf: [{ type: 'object', properties: { a: { type: 'string' } } }],
@@ -287,7 +289,7 @@ describe('toStrictJsonSchema', () => {
 	});
 
 	it('does not override an explicit additionalProperties value', () => {
-		const result = toStrictJsonSchema({
+		const result = lockAdditionalProperties({
 			type: 'object',
 			properties: { name: { type: 'string' } },
 			additionalProperties: true,
@@ -298,7 +300,7 @@ describe('toStrictJsonSchema', () => {
 
 	it('does not mutate the input schema', () => {
 		const input: JSONSchema7 = { type: 'object', properties: { name: { type: 'string' } } };
-		toStrictJsonSchema(input);
+		lockAdditionalProperties(input);
 		expect(input.additionalProperties).toBeUndefined();
 	});
 
@@ -312,7 +314,7 @@ describe('toStrictJsonSchema', () => {
 			writable: true,
 			configurable: true,
 		});
-		const result = toStrictJsonSchema({ type: 'object', properties });
+		const result = lockAdditionalProperties({ type: 'object', properties });
 
 		const resultProps = result.properties as Record<string, JSONSchema7>;
 		// The dangerous key is kept as a real own property, and the rebuilt object's

--- a/packages/@n8n/agents/src/runtime/__tests__/tool-adapter.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/tool-adapter.test.ts
@@ -2,7 +2,7 @@ import type { JSONSchema7 } from 'json-schema';
 import { z } from 'zod';
 
 import type { BuiltTool } from '../../types';
-import { executeTool, toAiSdkTools } from '../tool-adapter';
+import { executeTool, toAiSdkTools, toStrictJsonSchema } from '../tool-adapter';
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -220,5 +220,104 @@ describe('executeTool — context propagation', () => {
 		await executeTool({}, tool, undefined, undefined, 'call-1', { abortSignal: signal });
 
 		expect(handler).toHaveBeenCalledWith({}, expect.objectContaining({ abortSignal: signal }));
+	});
+});
+
+// ---------------------------------------------------------------------------
+// toStrictJsonSchema
+// ---------------------------------------------------------------------------
+
+describe('toStrictJsonSchema', () => {
+	it('sets additionalProperties:false on a root object that omits it', () => {
+		const result = toStrictJsonSchema({
+			type: 'object',
+			properties: { name: { type: 'string' } },
+			required: ['name'],
+		});
+
+		expect(result).toEqual({
+			type: 'object',
+			properties: { name: { type: 'string' } },
+			required: ['name'],
+			additionalProperties: false,
+		});
+	});
+
+	it('normalises an object that declares properties without a type', () => {
+		const result = toStrictJsonSchema({ properties: { id: { type: 'string' } } } as JSONSchema7);
+
+		expect(result).toMatchObject({ type: 'object', additionalProperties: false });
+	});
+
+	it('applies additionalProperties:false recursively to nested objects', () => {
+		const result = toStrictJsonSchema({
+			type: 'object',
+			properties: {
+				address: {
+					type: 'object',
+					properties: { city: { type: 'string' } },
+				},
+				tags: {
+					type: 'array',
+					items: { type: 'object', properties: { label: { type: 'string' } } },
+				},
+			},
+		});
+
+		const props = (result.properties ?? {}) as Record<string, JSONSchema7>;
+		expect(props.address.additionalProperties).toBe(false);
+		const items = props.tags.items as JSONSchema7;
+		expect(items.additionalProperties).toBe(false);
+	});
+
+	it('recurses into $defs and anyOf branches', () => {
+		const result = toStrictJsonSchema({
+			type: 'object',
+			properties: { ref: { $ref: '#/$defs/Inner' } },
+			anyOf: [{ type: 'object', properties: { a: { type: 'string' } } }],
+			$defs: {
+				Inner: { type: 'object', properties: { b: { type: 'number' } } },
+			},
+		});
+
+		const defs = (result.$defs ?? {}) as Record<string, JSONSchema7>;
+		expect(defs.Inner.additionalProperties).toBe(false);
+		const anyOf = (result.anyOf ?? []) as JSONSchema7[];
+		expect(anyOf[0].additionalProperties).toBe(false);
+	});
+
+	it('does not override an explicit additionalProperties value', () => {
+		const result = toStrictJsonSchema({
+			type: 'object',
+			properties: { name: { type: 'string' } },
+			additionalProperties: true,
+		});
+
+		expect(result.additionalProperties).toBe(true);
+	});
+
+	it('does not mutate the input schema', () => {
+		const input: JSONSchema7 = { type: 'object', properties: { name: { type: 'string' } } };
+		toStrictJsonSchema(input);
+		expect(input.additionalProperties).toBeUndefined();
+	});
+
+	it('handles a property literally named __proto__ as an own property without mutating the prototype chain', () => {
+		// Build an object with a real own `__proto__` property (a plain object
+		// literal would instead set the prototype) to exercise the safe re-mapping.
+		const properties: Record<string, JSONSchema7> = {};
+		Object.defineProperty(properties, '__proto__', {
+			value: { type: 'string' },
+			enumerable: true,
+			writable: true,
+			configurable: true,
+		});
+		const result = toStrictJsonSchema({ type: 'object', properties });
+
+		const resultProps = result.properties as Record<string, JSONSchema7>;
+		// The dangerous key is kept as a real own property, and the rebuilt object's
+		// prototype is left untouched (Object.defineProperty, not bracket assignment).
+		expect(Object.getPrototypeOf(resultProps)).toBe(Object.prototype);
+		expect(Object.prototype.hasOwnProperty.call(resultProps, '__proto__')).toBe(true);
 	});
 });

--- a/packages/@n8n/agents/src/runtime/__tests__/tool-adapter.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/tool-adapter.test.ts
@@ -2,7 +2,7 @@ import type { JSONSchema7 } from 'json-schema';
 import { z } from 'zod';
 
 import type { BuiltTool } from '../../types';
-import { executeTool, toAiSdkTools, lockAdditionalProperties } from '../tool-adapter';
+import { executeTool, toAiSdkTools } from '../tool-adapter';
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -220,106 +220,5 @@ describe('executeTool — context propagation', () => {
 		await executeTool({}, tool, undefined, undefined, 'call-1', { abortSignal: signal });
 
 		expect(handler).toHaveBeenCalledWith({}, expect.objectContaining({ abortSignal: signal }));
-	});
-});
-
-// ---------------------------------------------------------------------------
-// lockAdditionalProperties
-// ---------------------------------------------------------------------------
-
-describe('lockAdditionalProperties', () => {
-	it('sets additionalProperties:false on a root object that omits it', () => {
-		const result = lockAdditionalProperties({
-			type: 'object',
-			properties: { name: { type: 'string' } },
-			required: ['name'],
-		});
-
-		expect(result).toEqual({
-			type: 'object',
-			properties: { name: { type: 'string' } },
-			required: ['name'],
-			additionalProperties: false,
-		});
-	});
-
-	it('normalises an object that declares properties without a type', () => {
-		const result = lockAdditionalProperties({
-			properties: { id: { type: 'string' } },
-		} as JSONSchema7);
-
-		expect(result).toMatchObject({ type: 'object', additionalProperties: false });
-	});
-
-	it('applies additionalProperties:false recursively to nested objects', () => {
-		const result = lockAdditionalProperties({
-			type: 'object',
-			properties: {
-				address: {
-					type: 'object',
-					properties: { city: { type: 'string' } },
-				},
-				tags: {
-					type: 'array',
-					items: { type: 'object', properties: { label: { type: 'string' } } },
-				},
-			},
-		});
-
-		const props = (result.properties ?? {}) as Record<string, JSONSchema7>;
-		expect(props.address.additionalProperties).toBe(false);
-		const items = props.tags.items as JSONSchema7;
-		expect(items.additionalProperties).toBe(false);
-	});
-
-	it('recurses into $defs and anyOf branches', () => {
-		const result = lockAdditionalProperties({
-			type: 'object',
-			properties: { ref: { $ref: '#/$defs/Inner' } },
-			anyOf: [{ type: 'object', properties: { a: { type: 'string' } } }],
-			$defs: {
-				Inner: { type: 'object', properties: { b: { type: 'number' } } },
-			},
-		});
-
-		const defs = (result.$defs ?? {}) as Record<string, JSONSchema7>;
-		expect(defs.Inner.additionalProperties).toBe(false);
-		const anyOf = (result.anyOf ?? []) as JSONSchema7[];
-		expect(anyOf[0].additionalProperties).toBe(false);
-	});
-
-	it('does not override an explicit additionalProperties value', () => {
-		const result = lockAdditionalProperties({
-			type: 'object',
-			properties: { name: { type: 'string' } },
-			additionalProperties: true,
-		});
-
-		expect(result.additionalProperties).toBe(true);
-	});
-
-	it('does not mutate the input schema', () => {
-		const input: JSONSchema7 = { type: 'object', properties: { name: { type: 'string' } } };
-		lockAdditionalProperties(input);
-		expect(input.additionalProperties).toBeUndefined();
-	});
-
-	it('handles a property literally named __proto__ as an own property without mutating the prototype chain', () => {
-		// Build an object with a real own `__proto__` property (a plain object
-		// literal would instead set the prototype) to exercise the safe re-mapping.
-		const properties: Record<string, JSONSchema7> = {};
-		Object.defineProperty(properties, '__proto__', {
-			value: { type: 'string' },
-			enumerable: true,
-			writable: true,
-			configurable: true,
-		});
-		const result = lockAdditionalProperties({ type: 'object', properties });
-
-		const resultProps = result.properties as Record<string, JSONSchema7>;
-		// The dangerous key is kept as a real own property, and the rebuilt object's
-		// prototype is left untouched (Object.defineProperty, not bracket assignment).
-		expect(Object.getPrototypeOf(resultProps)).toBe(Object.prototype);
-		expect(Object.prototype.hasOwnProperty.call(resultProps, '__proto__')).toBe(true);
 	});
 });

--- a/packages/@n8n/agents/src/runtime/agent-runtime.ts
+++ b/packages/@n8n/agents/src/runtime/agent-runtime.ts
@@ -79,7 +79,6 @@ import {
 	isSuspendedToolResult,
 	toAiSdkProviderTools,
 	toAiSdkTools,
-	lockAdditionalProperties,
 } from './tool-adapter';
 import { isCancellation } from '../sdk/cancellation';
 import { Telemetry } from '../sdk/telemetry';
@@ -95,6 +94,7 @@ import type {
 import type { AgentDbMessage, AgentMessage, ContentToolCall, Message } from '../types/sdk/message';
 import type { ObservationLogScope, ObservationLogTaskKind } from '../types/sdk/observation-log';
 import type { JSONObject, JSONValue } from '../types/utils/json';
+import { lockAdditionalProperties } from '../utils/json-schema';
 import { parseWithSchema } from '../utils/parse';
 import { isZodSchema } from '../utils/zod';
 

--- a/packages/@n8n/agents/src/runtime/agent-runtime.ts
+++ b/packages/@n8n/agents/src/runtime/agent-runtime.ts
@@ -79,7 +79,7 @@ import {
 	isSuspendedToolResult,
 	toAiSdkProviderTools,
 	toAiSdkTools,
-	toStrictJsonSchema,
+	lockAdditionalProperties,
 } from './tool-adapter';
 import { isCancellation } from '../sdk/cancellation';
 import { Telemetry } from '../sdk/telemetry';
@@ -2308,20 +2308,23 @@ export class AgentRuntime {
 			this.buildCallProviderOptions(execOptions?.providerOptions),
 			isRawJsonSchemaOutput,
 		);
+
+		const outputSpec = outputSchema
+			? Output.object({
+					// Zod schemas pass through directly; a raw JSON Schema gets
+					// `additionalProperties: false` locked onto every object (required by Anthropic)
+					// and wrapped with the AI SDK's `jsonSchema()` helper.
+					schema: isZodSchema(outputSchema)
+						? outputSchema
+						: jsonSchema(lockAdditionalProperties(outputSchema)),
+				})
+			: undefined;
+
 		return {
 			model,
 			aiProviderTools,
 			providerOptions,
-			outputSpec: outputSchema
-				? Output.object({
-						// Zod schemas pass through directly; a raw JSON Schema is made
-						// provider-strict (additionalProperties: false on every object)
-						// and wrapped with the AI SDK's `jsonSchema()` helper.
-						schema: isZodSchema(outputSchema)
-							? outputSchema
-							: jsonSchema(toStrictJsonSchema(outputSchema)),
-					})
-				: undefined,
+			outputSpec,
 		};
 	}
 
@@ -2337,9 +2340,6 @@ export class AgentRuntime {
 	 * Zod-defined output keeps strict mode (zod-to-json-schema already produces a
 	 * strict-compliant schema). Providers that hardcode strict (e.g. xAI) or use
 	 * a different namespace (e.g. Azure) are unaffected and remain strict.
-	 *
-	 * Setting options under providers that aren't the active one is a no-op — the
-	 * AI SDK only reads the namespace matching the model in use.
 	 */
 	private relaxStrictJsonSchemaIfNeeded(
 		providerOptions: Record<string, Record<string, unknown>> | undefined,

--- a/packages/@n8n/agents/src/runtime/agent-runtime.ts
+++ b/packages/@n8n/agents/src/runtime/agent-runtime.ts
@@ -2303,10 +2303,15 @@ export class AgentRuntime {
 		const aiProviderTools = toAiSdkProviderTools(this.config.providerTools);
 		const model = createModel(this.config.model);
 		const outputSchema = this.config.structuredOutput;
+		const isRawJsonSchemaOutput = outputSchema !== undefined && !isZodSchema(outputSchema);
+		const providerOptions = this.relaxStrictJsonSchemaIfNeeded(
+			this.buildCallProviderOptions(execOptions?.providerOptions),
+			isRawJsonSchemaOutput,
+		);
 		return {
 			model,
 			aiProviderTools,
-			providerOptions: this.buildCallProviderOptions(execOptions?.providerOptions),
+			providerOptions,
 			outputSpec: outputSchema
 				? Output.object({
 						// Zod schemas pass through directly; a raw JSON Schema is made
@@ -2318,6 +2323,36 @@ export class AgentRuntime {
 					})
 				: undefined,
 		};
+	}
+
+	/**
+	 * When structured output is driven by a raw JSON Schema (e.g. one a user
+	 * typed into a workflow node), opt out of strict JSON Schema validation for
+	 * the providers that default to it (OpenAI, Groq). Their strict mode rejects
+	 * schemas whose objects don't list every property in `required` or that use
+	 * keywords it doesn't allow — common in hand-written schemas. With strict off
+	 * the provider still steers generation toward the schema, and the runtime
+	 * validates the model's output against it afterwards.
+	 *
+	 * Zod-defined output keeps strict mode (zod-to-json-schema already produces a
+	 * strict-compliant schema). Providers that hardcode strict (e.g. xAI) or use
+	 * a different namespace (e.g. Azure) are unaffected and remain strict.
+	 *
+	 * Setting options under providers that aren't the active one is a no-op — the
+	 * AI SDK only reads the namespace matching the model in use.
+	 */
+	private relaxStrictJsonSchemaIfNeeded(
+		providerOptions: Record<string, Record<string, unknown>> | undefined,
+		isRawJsonSchemaOutput: boolean,
+	): Record<string, Record<string, unknown>> | undefined {
+		if (!isRawJsonSchemaOutput) return providerOptions;
+
+		const result: Record<string, Record<string, unknown>> = { ...providerOptions };
+		for (const provider of ['openai', 'groq']) {
+			// Keep any caller-provided value (spread last so it wins).
+			result[provider] = { strictJsonSchema: false, ...result[provider] };
+		}
+		return result;
 	}
 
 	/** Build the current local tool view; deferred loads can change this between iterations. */

--- a/packages/@n8n/agents/src/runtime/agent-runtime.ts
+++ b/packages/@n8n/agents/src/runtime/agent-runtime.ts
@@ -1,5 +1,6 @@
 import type { ProviderOptions } from '@ai-sdk/provider-utils';
 import type { StreamTextTransform, TelemetrySettings, ToolCallRepairFunction, ToolSet } from 'ai';
+import type { JSONSchema7 } from 'json-schema';
 import type { z } from 'zod';
 import { zodToJsonSchema, type JsonSchema7Type } from 'zod-to-json-schema';
 
@@ -78,6 +79,7 @@ import {
 	isSuspendedToolResult,
 	toAiSdkProviderTools,
 	toAiSdkTools,
+	toStrictJsonSchema,
 } from './tool-adapter';
 import { isCancellation } from '../sdk/cancellation';
 import { Telemetry } from '../sdk/telemetry';
@@ -194,7 +196,7 @@ export interface AgentRuntimeConfig {
 	observationLog?: ObservationLogMemoryConfig;
 	observationalMemory?: ObservationalMemoryConfig;
 	episodicMemory?: EpisodicMemoryConfig;
-	structuredOutput?: z.ZodType;
+	structuredOutput?: z.ZodType | JSONSchema7;
 	checkpointStorage?: 'memory' | CheckpointStore;
 	thinking?: ThinkingConfig;
 	eventBus?: AgentEventBus;
@@ -2297,15 +2299,23 @@ export class AgentRuntime {
 	private buildStaticLoopContext(
 		execOptions?: ExecutionOptions & { persistence?: AgentPersistenceOptions },
 	) {
-		const { Output } = getAiSdk();
+		const { Output, jsonSchema } = getAiSdk();
 		const aiProviderTools = toAiSdkProviderTools(this.config.providerTools);
 		const model = createModel(this.config.model);
+		const outputSchema = this.config.structuredOutput;
 		return {
 			model,
 			aiProviderTools,
 			providerOptions: this.buildCallProviderOptions(execOptions?.providerOptions),
-			outputSpec: this.config.structuredOutput
-				? Output.object({ schema: this.config.structuredOutput })
+			outputSpec: outputSchema
+				? Output.object({
+						// Zod schemas pass through directly; a raw JSON Schema is made
+						// provider-strict (additionalProperties: false on every object)
+						// and wrapped with the AI SDK's `jsonSchema()` helper.
+						schema: isZodSchema(outputSchema)
+							? outputSchema
+							: jsonSchema(toStrictJsonSchema(outputSchema)),
+					})
 				: undefined,
 		};
 	}

--- a/packages/@n8n/agents/src/runtime/tool-adapter.ts
+++ b/packages/@n8n/agents/src/runtime/tool-adapter.ts
@@ -1,5 +1,4 @@
 import type { Tool as AiSdkTool } from 'ai';
-import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 import { z } from 'zod';
 
 import { loadAi } from './lazy-ai';
@@ -12,6 +11,7 @@ import {
 	type ToolExecutionContext,
 	type ToolContext,
 } from '../types';
+import { fixSchema } from '../utils/json-schema';
 import { isZodSchema } from '../utils/zod';
 
 type AiSdkProviderTool = AiSdkTool & {
@@ -57,113 +57,6 @@ export function toAiSdkProviderTools(tools?: BuiltProviderTool[]): Record<string
 		result[t.name] = providerTool;
 	}
 	return result;
-}
-
-export const fixSchema = (schema: JSONSchema7): JSONSchema7 => {
-	// Ensure 'type: object' is present when properties are present (required by some providers):
-	if (
-		typeof schema === 'object' &&
-		schema !== null &&
-		'properties' in schema &&
-		!('type' in schema)
-	) {
-		return { ...schema, type: 'object' as const };
-	}
-	return schema;
-};
-
-/**
- * Recursively set `additionalProperties: false` on every object in a JSON
- * Schema so it can be used as a *structured output* schema.
- *
- * This only applies the JSON Schema keyword — it closes objects to undeclared
- * keys. It is NOT a provider "strict mode": it does not require every property
- * to be in `required`, so declared-optional fields stay optional.
- *
- * Anthropic's structured output rejects any object that omits
- * `additionalProperties: false`. Zod schemas get this during conversion, but a
- * raw JSON Schema (e.g. typed into a workflow node) usually omits it. We also
- * normalise objects that declare `properties` without a `type` (mirrors
- * {@link fixSchema}).
- *
- * Returns a deep copy — the input schema is never mutated.
- */
-export function lockAdditionalProperties(schema: JSONSchema7): JSONSchema7 {
-	const result = lockDefinition(schema);
-	// `lockDefinition` returns a JSONSchema7Definition (object | boolean, since
-	// JSON Schema allows a bare `true`/`false`), but a structured-output schema is
-	// always an object — narrow back to JSONSchema7. The `: schema` fallback only
-	// covers the boolean case, which never happens here.
-	return typeof result === 'object' ? result : schema;
-}
-
-function lockDefinition(schema: JSONSchema7Definition): JSONSchema7Definition {
-	if (typeof schema !== 'object' || schema === null) return schema;
-
-	const result: JSONSchema7 = { ...schema };
-
-	// Normalise objects that list properties but omit the type (mirrors fixSchema).
-	if (result.properties !== undefined && result.type === undefined) {
-		result.type = 'object';
-	}
-
-	const isObjectSchema =
-		result.type === 'object' ||
-		(Array.isArray(result.type) && result.type.includes('object')) ||
-		result.properties !== undefined;
-
-	if (isObjectSchema && result.additionalProperties === undefined) {
-		result.additionalProperties = false;
-	}
-
-	if (result.properties) {
-		result.properties = mapDefinitions(result.properties);
-	}
-	if (result.$defs) {
-		result.$defs = mapDefinitions(result.$defs);
-	}
-	if (result.definitions) {
-		result.definitions = mapDefinitions(result.definitions);
-	}
-	if (result.items !== undefined) {
-		result.items = Array.isArray(result.items)
-			? result.items.map(lockDefinition)
-			: lockDefinition(result.items);
-	}
-	if (typeof result.additionalProperties === 'object' && result.additionalProperties !== null) {
-		result.additionalProperties = lockDefinition(result.additionalProperties);
-	}
-	for (const key of ['allOf', 'anyOf', 'oneOf'] as const) {
-		const branch = result[key];
-		if (Array.isArray(branch)) {
-			result[key] = branch.map(lockDefinition);
-		}
-	}
-	if (result.not !== undefined) {
-		result.not = lockDefinition(result.not);
-	}
-
-	return result;
-}
-
-/**
- * Re-map a record of sub-schemas, locking each value. Uses
- * `Object.defineProperty` so a user-supplied property name like `__proto__`
- * becomes a normal own property instead of mutating the prototype chain.
- */
-function mapDefinitions(
-	record: Record<string, JSONSchema7Definition>,
-): Record<string, JSONSchema7Definition> {
-	const out: Record<string, JSONSchema7Definition> = {};
-	for (const [key, value] of Object.entries(record)) {
-		Object.defineProperty(out, key, {
-			value: lockDefinition(value),
-			enumerable: true,
-			writable: true,
-			configurable: true,
-		});
-	}
-	return out;
 }
 
 /**

--- a/packages/@n8n/agents/src/runtime/tool-adapter.ts
+++ b/packages/@n8n/agents/src/runtime/tool-adapter.ts
@@ -1,5 +1,5 @@
 import type { Tool as AiSdkTool } from 'ai';
-import type { JSONSchema7 } from 'json-schema';
+import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 import { z } from 'zod';
 
 import { loadAi } from './lazy-ai';
@@ -59,7 +59,7 @@ export function toAiSdkProviderTools(tools?: BuiltProviderTool[]): Record<string
 	return result;
 }
 
-const fixSchema = (schema: JSONSchema7): JSONSchema7 => {
+export const fixSchema = (schema: JSONSchema7): JSONSchema7 => {
 	// Ensure 'type: object' is present when properties are present (required by some providers):
 	if (
 		typeof schema === 'object' &&
@@ -71,6 +71,93 @@ const fixSchema = (schema: JSONSchema7): JSONSchema7 => {
 	}
 	return schema;
 };
+
+/**
+ * Recursively prepare a JSON Schema for use as a *structured output* schema.
+ *
+ * Both Anthropic and OpenAI strict structured outputs reject any object schema
+ * that does not explicitly set `additionalProperties: false`. Zod schemas get
+ * this for free during conversion, but a raw JSON Schema (e.g. supplied by a
+ * workflow node) usually omits it. We set it on every object that doesn't
+ * specify it, and normalise objects that declare `properties` without a `type`
+ * (mirrors {@link fixSchema}).
+ *
+ * Returns a deep copy — the input schema is never mutated.
+ */
+export function toStrictJsonSchema(schema: JSONSchema7): JSONSchema7 {
+	const result = strictifyDefinition(schema);
+	// The public entry point is only ever called with an object schema.
+	return typeof result === 'object' ? result : schema;
+}
+
+function strictifyDefinition(schema: JSONSchema7Definition): JSONSchema7Definition {
+	if (typeof schema !== 'object' || schema === null) return schema;
+
+	const result: JSONSchema7 = { ...schema };
+
+	// Normalise objects that list properties but omit the type (mirrors fixSchema).
+	if (result.properties !== undefined && result.type === undefined) {
+		result.type = 'object';
+	}
+
+	const isObjectSchema =
+		result.type === 'object' ||
+		(Array.isArray(result.type) && result.type.includes('object')) ||
+		result.properties !== undefined;
+
+	if (isObjectSchema && result.additionalProperties === undefined) {
+		result.additionalProperties = false;
+	}
+
+	if (result.properties) {
+		result.properties = mapDefinitions(result.properties);
+	}
+	if (result.$defs) {
+		result.$defs = mapDefinitions(result.$defs);
+	}
+	if (result.definitions) {
+		result.definitions = mapDefinitions(result.definitions);
+	}
+	if (result.items !== undefined) {
+		result.items = Array.isArray(result.items)
+			? result.items.map(strictifyDefinition)
+			: strictifyDefinition(result.items);
+	}
+	if (typeof result.additionalProperties === 'object' && result.additionalProperties !== null) {
+		result.additionalProperties = strictifyDefinition(result.additionalProperties);
+	}
+	for (const key of ['allOf', 'anyOf', 'oneOf'] as const) {
+		const branch = result[key];
+		if (Array.isArray(branch)) {
+			result[key] = branch.map(strictifyDefinition);
+		}
+	}
+	if (result.not !== undefined) {
+		result.not = strictifyDefinition(result.not);
+	}
+
+	return result;
+}
+
+/**
+ * Re-map a record of sub-schemas, strictifying each value. Uses
+ * `Object.defineProperty` so a user-supplied property name like `__proto__`
+ * becomes a normal own property instead of mutating the prototype chain.
+ */
+function mapDefinitions(
+	record: Record<string, JSONSchema7Definition>,
+): Record<string, JSONSchema7Definition> {
+	const out: Record<string, JSONSchema7Definition> = {};
+	for (const [key, value] of Object.entries(record)) {
+		Object.defineProperty(out, key, {
+			value: strictifyDefinition(value),
+			enumerable: true,
+			writable: true,
+			configurable: true,
+		});
+	}
+	return out;
+}
 
 /**
  * Convert an array of BuiltTools into a Record of AI SDK tool definitions.

--- a/packages/@n8n/agents/src/runtime/tool-adapter.ts
+++ b/packages/@n8n/agents/src/runtime/tool-adapter.ts
@@ -73,24 +73,31 @@ export const fixSchema = (schema: JSONSchema7): JSONSchema7 => {
 };
 
 /**
- * Recursively prepare a JSON Schema for use as a *structured output* schema.
+ * Recursively set `additionalProperties: false` on every object in a JSON
+ * Schema so it can be used as a *structured output* schema.
  *
- * Both Anthropic and OpenAI strict structured outputs reject any object schema
- * that does not explicitly set `additionalProperties: false`. Zod schemas get
- * this for free during conversion, but a raw JSON Schema (e.g. supplied by a
- * workflow node) usually omits it. We set it on every object that doesn't
- * specify it, and normalise objects that declare `properties` without a `type`
- * (mirrors {@link fixSchema}).
+ * This only applies the JSON Schema keyword — it closes objects to undeclared
+ * keys. It is NOT a provider "strict mode": it does not require every property
+ * to be in `required`, so declared-optional fields stay optional.
+ *
+ * Anthropic's structured output rejects any object that omits
+ * `additionalProperties: false`. Zod schemas get this during conversion, but a
+ * raw JSON Schema (e.g. typed into a workflow node) usually omits it. We also
+ * normalise objects that declare `properties` without a `type` (mirrors
+ * {@link fixSchema}).
  *
  * Returns a deep copy — the input schema is never mutated.
  */
-export function toStrictJsonSchema(schema: JSONSchema7): JSONSchema7 {
-	const result = strictifyDefinition(schema);
-	// The public entry point is only ever called with an object schema.
+export function lockAdditionalProperties(schema: JSONSchema7): JSONSchema7 {
+	const result = lockDefinition(schema);
+	// `lockDefinition` returns a JSONSchema7Definition (object | boolean, since
+	// JSON Schema allows a bare `true`/`false`), but a structured-output schema is
+	// always an object — narrow back to JSONSchema7. The `: schema` fallback only
+	// covers the boolean case, which never happens here.
 	return typeof result === 'object' ? result : schema;
 }
 
-function strictifyDefinition(schema: JSONSchema7Definition): JSONSchema7Definition {
+function lockDefinition(schema: JSONSchema7Definition): JSONSchema7Definition {
 	if (typeof schema !== 'object' || schema === null) return schema;
 
 	const result: JSONSchema7 = { ...schema };
@@ -120,27 +127,27 @@ function strictifyDefinition(schema: JSONSchema7Definition): JSONSchema7Definiti
 	}
 	if (result.items !== undefined) {
 		result.items = Array.isArray(result.items)
-			? result.items.map(strictifyDefinition)
-			: strictifyDefinition(result.items);
+			? result.items.map(lockDefinition)
+			: lockDefinition(result.items);
 	}
 	if (typeof result.additionalProperties === 'object' && result.additionalProperties !== null) {
-		result.additionalProperties = strictifyDefinition(result.additionalProperties);
+		result.additionalProperties = lockDefinition(result.additionalProperties);
 	}
 	for (const key of ['allOf', 'anyOf', 'oneOf'] as const) {
 		const branch = result[key];
 		if (Array.isArray(branch)) {
-			result[key] = branch.map(strictifyDefinition);
+			result[key] = branch.map(lockDefinition);
 		}
 	}
 	if (result.not !== undefined) {
-		result.not = strictifyDefinition(result.not);
+		result.not = lockDefinition(result.not);
 	}
 
 	return result;
 }
 
 /**
- * Re-map a record of sub-schemas, strictifying each value. Uses
+ * Re-map a record of sub-schemas, locking each value. Uses
  * `Object.defineProperty` so a user-supplied property name like `__proto__`
  * becomes a normal own property instead of mutating the prototype chain.
  */
@@ -150,7 +157,7 @@ function mapDefinitions(
 	const out: Record<string, JSONSchema7Definition> = {};
 	for (const [key, value] of Object.entries(record)) {
 		Object.defineProperty(out, key, {
-			value: strictifyDefinition(value),
+			value: lockDefinition(value),
 			enumerable: true,
 			writable: true,
 			configurable: true,

--- a/packages/@n8n/agents/src/sdk/agent.ts
+++ b/packages/@n8n/agents/src/sdk/agent.ts
@@ -1,4 +1,5 @@
 import type { ProviderOptions } from '@ai-sdk/provider-utils';
+import type { JSONSchema7 } from 'json-schema';
 import type { z } from 'zod';
 
 import { getModelCost } from './catalog';
@@ -156,7 +157,7 @@ export class Agent implements BuiltAgent, AgentBuilder {
 
 	private agentEvals: BuiltEval[] = [];
 
-	private outputSchema?: z.ZodType;
+	private outputSchema?: z.ZodType | JSONSchema7;
 
 	private checkpointStore?: 'memory' | CheckpointStore;
 
@@ -361,6 +362,10 @@ export class Agent implements BuiltAgent, AgentBuilder {
 	 * Set a structured output schema. When set, the agent's response will be
 	 * parsed into a typed object matching the schema, available as `result.output`.
 	 *
+	 * Accepts either a Zod schema or a raw JSON Schema. JSON Schema is useful
+	 * when the schema is supplied dynamically (e.g. entered in a workflow node)
+	 * and there is no Zod type to compile against.
+	 *
 	 * @example
 	 * ```typescript
 	 * const agent = new Agent('extractor')
@@ -375,7 +380,7 @@ export class Agent implements BuiltAgent, AgentBuilder {
 	 * console.log(result.structuredOutput); // { code: '...', explanation: '...' }
 	 * ```
 	 */
-	structuredOutput(schema: z.ZodType): this {
+	structuredOutput(schema: z.ZodType | JSONSchema7): this {
 		this.outputSchema = schema;
 		return this;
 	}

--- a/packages/@n8n/agents/src/utils/__tests__/json-schema.test.ts
+++ b/packages/@n8n/agents/src/utils/__tests__/json-schema.test.ts
@@ -1,0 +1,124 @@
+import type { JSONSchema7 } from 'json-schema';
+
+import { fixSchema, lockAdditionalProperties } from '../json-schema';
+
+describe('fixSchema', () => {
+	it('adds type "object" when properties is present but type is absent', () => {
+		expect(fixSchema({ properties: { name: { type: 'string' } } })).toEqual({
+			type: 'object',
+			properties: { name: { type: 'string' } },
+		});
+	});
+
+	it('leaves the type untouched when it is already set', () => {
+		const schema: JSONSchema7 = { type: 'object', properties: { a: { type: 'number' } } };
+		expect(fixSchema(schema)).toEqual(schema);
+	});
+
+	it('does not add a type when there are no properties', () => {
+		expect(fixSchema({ description: 'no properties' })).toEqual({ description: 'no properties' });
+	});
+
+	it('does not mutate the input schema', () => {
+		const input: JSONSchema7 = { properties: { x: { type: 'string' } } };
+		fixSchema(input);
+		expect(input).not.toHaveProperty('type');
+	});
+});
+
+describe('lockAdditionalProperties', () => {
+	it('sets additionalProperties:false on a root object that omits it', () => {
+		const result = lockAdditionalProperties({
+			type: 'object',
+			properties: { name: { type: 'string' } },
+			required: ['name'],
+		});
+
+		expect(result).toEqual({
+			type: 'object',
+			properties: { name: { type: 'string' } },
+			required: ['name'],
+			additionalProperties: false,
+		});
+	});
+
+	it('normalises an object that declares properties without a type', () => {
+		const result = lockAdditionalProperties({
+			properties: { id: { type: 'string' } },
+		} as JSONSchema7);
+
+		expect(result).toMatchObject({ type: 'object', additionalProperties: false });
+	});
+
+	it('applies additionalProperties:false recursively to nested objects', () => {
+		const result = lockAdditionalProperties({
+			type: 'object',
+			properties: {
+				address: {
+					type: 'object',
+					properties: { city: { type: 'string' } },
+				},
+				tags: {
+					type: 'array',
+					items: { type: 'object', properties: { label: { type: 'string' } } },
+				},
+			},
+		});
+
+		const props = (result.properties ?? {}) as Record<string, JSONSchema7>;
+		expect(props.address.additionalProperties).toBe(false);
+		const items = props.tags.items as JSONSchema7;
+		expect(items.additionalProperties).toBe(false);
+	});
+
+	it('recurses into $defs and anyOf branches', () => {
+		const result = lockAdditionalProperties({
+			type: 'object',
+			properties: { ref: { $ref: '#/$defs/Inner' } },
+			anyOf: [{ type: 'object', properties: { a: { type: 'string' } } }],
+			$defs: {
+				Inner: { type: 'object', properties: { b: { type: 'number' } } },
+			},
+		});
+
+		const defs = (result.$defs ?? {}) as Record<string, JSONSchema7>;
+		expect(defs.Inner.additionalProperties).toBe(false);
+		const anyOf = (result.anyOf ?? []) as JSONSchema7[];
+		expect(anyOf[0].additionalProperties).toBe(false);
+	});
+
+	it('does not override an explicit additionalProperties value', () => {
+		const result = lockAdditionalProperties({
+			type: 'object',
+			properties: { name: { type: 'string' } },
+			additionalProperties: true,
+		});
+
+		expect(result.additionalProperties).toBe(true);
+	});
+
+	it('does not mutate the input schema', () => {
+		const input: JSONSchema7 = { type: 'object', properties: { name: { type: 'string' } } };
+		lockAdditionalProperties(input);
+		expect(input.additionalProperties).toBeUndefined();
+	});
+
+	it('handles a property literally named __proto__ as an own property without mutating the prototype chain', () => {
+		// Build an object with a real own `__proto__` property (a plain object
+		// literal would instead set the prototype) to exercise the safe re-mapping.
+		const properties: Record<string, JSONSchema7> = {};
+		Object.defineProperty(properties, '__proto__', {
+			value: { type: 'string' },
+			enumerable: true,
+			writable: true,
+			configurable: true,
+		});
+		const result = lockAdditionalProperties({ type: 'object', properties });
+
+		const resultProps = result.properties as Record<string, JSONSchema7>;
+		// The dangerous key is kept as a real own property, and the rebuilt object's
+		// prototype is left untouched (Object.defineProperty, not bracket assignment).
+		expect(Object.getPrototypeOf(resultProps)).toBe(Object.prototype);
+		expect(Object.prototype.hasOwnProperty.call(resultProps, '__proto__')).toBe(true);
+	});
+});

--- a/packages/@n8n/agents/src/utils/json-schema.ts
+++ b/packages/@n8n/agents/src/utils/json-schema.ts
@@ -2,8 +2,7 @@ import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
 
 /**
  * Pure JSON Schema transforms used when handing a raw JSON Schema to a model
- * provider (tool input schemas and structured-output schemas). No AI SDK
- * dependency — just schema-in, schema-out.
+ * provider (tool input schemas and structured-output schemas).
  */
 
 /**
@@ -32,18 +31,12 @@ export const fixSchema = (schema: JSONSchema7): JSONSchema7 => {
  *
  * Anthropic's structured output rejects any object that omits
  * `additionalProperties: false`. Zod schemas get this during conversion, but a
- * raw JSON Schema (e.g. typed into a workflow node) usually omits it. We also
- * normalise objects that declare `properties` without a `type` (mirrors
- * {@link fixSchema}).
+ * raw JSON Schema (e.g. typed into a workflow node) usually omits it.
  *
  * Returns a deep copy — the input schema is never mutated.
  */
 export function lockAdditionalProperties(schema: JSONSchema7): JSONSchema7 {
 	const result = lockDefinition(schema);
-	// `lockDefinition` returns a JSONSchema7Definition (object | boolean, since
-	// JSON Schema allows a bare `true`/`false`), but a structured-output schema is
-	// always an object — narrow back to JSONSchema7. The `: schema` fallback only
-	// covers the boolean case, which never happens here.
 	return typeof result === 'object' ? result : schema;
 }
 

--- a/packages/@n8n/agents/src/utils/json-schema.ts
+++ b/packages/@n8n/agents/src/utils/json-schema.ts
@@ -1,0 +1,117 @@
+import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
+
+/**
+ * Pure JSON Schema transforms used when handing a raw JSON Schema to a model
+ * provider (tool input schemas and structured-output schemas). No AI SDK
+ * dependency — just schema-in, schema-out.
+ */
+
+/**
+ * Ensure `type: "object"` is present when an object lists `properties` but omits
+ * the type — some providers require the explicit type.
+ */
+export const fixSchema = (schema: JSONSchema7): JSONSchema7 => {
+	if (
+		typeof schema === 'object' &&
+		schema !== null &&
+		'properties' in schema &&
+		!('type' in schema)
+	) {
+		return { ...schema, type: 'object' as const };
+	}
+	return schema;
+};
+
+/**
+ * Recursively set `additionalProperties: false` on every object in a JSON
+ * Schema so it can be used as a *structured output* schema.
+ *
+ * This only applies the JSON Schema keyword — it closes objects to undeclared
+ * keys. It is NOT a provider "strict mode": it does not require every property
+ * to be in `required`, so declared-optional fields stay optional.
+ *
+ * Anthropic's structured output rejects any object that omits
+ * `additionalProperties: false`. Zod schemas get this during conversion, but a
+ * raw JSON Schema (e.g. typed into a workflow node) usually omits it. We also
+ * normalise objects that declare `properties` without a `type` (mirrors
+ * {@link fixSchema}).
+ *
+ * Returns a deep copy — the input schema is never mutated.
+ */
+export function lockAdditionalProperties(schema: JSONSchema7): JSONSchema7 {
+	const result = lockDefinition(schema);
+	// `lockDefinition` returns a JSONSchema7Definition (object | boolean, since
+	// JSON Schema allows a bare `true`/`false`), but a structured-output schema is
+	// always an object — narrow back to JSONSchema7. The `: schema` fallback only
+	// covers the boolean case, which never happens here.
+	return typeof result === 'object' ? result : schema;
+}
+
+function lockDefinition(schema: JSONSchema7Definition): JSONSchema7Definition {
+	if (typeof schema !== 'object' || schema === null) return schema;
+
+	const result: JSONSchema7 = { ...schema };
+
+	// Normalise objects that list properties but omit the type (mirrors fixSchema).
+	if (result.properties !== undefined && result.type === undefined) {
+		result.type = 'object';
+	}
+
+	const isObjectSchema =
+		result.type === 'object' ||
+		(Array.isArray(result.type) && result.type.includes('object')) ||
+		result.properties !== undefined;
+
+	if (isObjectSchema && result.additionalProperties === undefined) {
+		result.additionalProperties = false;
+	}
+
+	if (result.properties) {
+		result.properties = mapDefinitions(result.properties);
+	}
+	if (result.$defs) {
+		result.$defs = mapDefinitions(result.$defs);
+	}
+	if (result.definitions) {
+		result.definitions = mapDefinitions(result.definitions);
+	}
+	if (result.items !== undefined) {
+		result.items = Array.isArray(result.items)
+			? result.items.map(lockDefinition)
+			: lockDefinition(result.items);
+	}
+	if (typeof result.additionalProperties === 'object' && result.additionalProperties !== null) {
+		result.additionalProperties = lockDefinition(result.additionalProperties);
+	}
+	for (const key of ['allOf', 'anyOf', 'oneOf'] as const) {
+		const branch = result[key];
+		if (Array.isArray(branch)) {
+			result[key] = branch.map(lockDefinition);
+		}
+	}
+	if (result.not !== undefined) {
+		result.not = lockDefinition(result.not);
+	}
+
+	return result;
+}
+
+/**
+ * Re-map a record of sub-schemas, locking each value. Uses
+ * `Object.defineProperty` so a user-supplied property name like `__proto__`
+ * becomes a normal own property instead of mutating the prototype chain.
+ */
+function mapDefinitions(
+	record: Record<string, JSONSchema7Definition>,
+): Record<string, JSONSchema7Definition> {
+	const out: Record<string, JSONSchema7Definition> = {};
+	for (const [key, value] of Object.entries(record)) {
+		Object.defineProperty(out, key, {
+			value: lockDefinition(value),
+			enumerable: true,
+			writable: true,
+			configurable: true,
+		});
+	}
+	return out;
+}

--- a/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
+++ b/packages/cli/src/__tests__/workflow-execute-additional-data.test.ts
@@ -1007,6 +1007,42 @@ describe('WorkflowExecuteAdditionalData', () => {
 				'project-1',
 				'user-1',
 				true,
+				undefined,
+			);
+		});
+
+		it('forwards the outputSchema to executeForWorkflow', async () => {
+			const additionalData = mock<IWorkflowExecuteAdditionalData>({
+				userId: 'user-1',
+				projectId: 'project-1',
+				workflowId: 'workflow-1',
+			});
+			const outputSchema = {
+				type: 'object' as const,
+				properties: { answer: { type: 'string' as const } },
+				required: ['answer'],
+			};
+
+			await executeAgent(
+				AGENT_ID,
+				MESSAGE,
+				EXEC_ID,
+				THREAD_ID,
+				additionalData,
+				'manual',
+				outputSchema,
+			);
+
+			expect(agentsService.executeForWorkflow).toHaveBeenCalledWith(
+				AGENT_ID,
+				MESSAGE,
+				EXEC_ID,
+				THREAD_ID,
+				'user-1',
+				'project-1',
+				'user-1',
+				true,
+				outputSchema,
 			);
 		});
 
@@ -1036,6 +1072,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 				'project-1',
 				undefined,
 				true,
+				undefined,
 			);
 		});
 
@@ -1090,6 +1127,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 					'project-1',
 					'user-1',
 					true,
+					undefined,
 				);
 			},
 		);
@@ -1123,6 +1161,7 @@ describe('WorkflowExecuteAdditionalData', () => {
 				'project-1',
 				'user-1',
 				false,
+				undefined,
 			);
 		});
 	});

--- a/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
@@ -1536,6 +1536,56 @@ describe('AgentsService', () => {
 		});
 	});
 	describe('executeForWorkflow', () => {
+		const outputSchema: JSONSchema7 = {
+			type: 'object',
+			properties: { answer: { type: 'string' } },
+			required: ['answer'],
+		};
+
+		const makeErrorChunkStream = (errorMessage: string) => {
+			const chunks = [{ type: 'error', error: new Error(errorMessage) }];
+			let idx = 0;
+			return jest.fn().mockResolvedValue({
+				stream: {
+					getReader: () => ({
+						read: jest
+							.fn()
+							.mockImplementation(async () =>
+								idx < chunks.length
+									? { done: false, value: chunks[idx++] }
+									: { done: true, value: undefined },
+							),
+						releaseLock: jest.fn(),
+					}),
+				},
+			});
+		};
+
+		const setupErroringAgent = (errorMessage: string) => {
+			const schema: AgentJsonConfig = {
+				name: 'Test Agent',
+				model: 'anthropic/claude-sonnet-4-5',
+				instructions: 'Be helpful',
+			};
+			const agent = makeAgent({
+				schema,
+				activeVersionId: versionId,
+				activeVersion: makeAgentHistory({ schema, publishedById: userId }),
+			});
+			agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
+			Container.set(CredentialsService, mock<CredentialsService>());
+
+			jest.spyOn(service as never, 'reconstructFromConfig').mockResolvedValue({
+				agent: {
+					name: 'Test Agent',
+					structuredOutput: jest.fn(),
+					stream: makeErrorChunkStream(errorMessage),
+					close: jest.fn(),
+				},
+				toolRegistry: {},
+			} as never);
+		};
+
 		it('passes execution-scoped persistence for workflow executions', async () => {
 			const schema: AgentJsonConfig = {
 				name: 'Test Agent',
@@ -1670,12 +1720,6 @@ describe('AgentsService', () => {
 				toolRegistry: {},
 			} as never);
 
-			const outputSchema: JSONSchema7 = {
-				type: 'object',
-				properties: { answer: { type: 'string' } },
-				required: ['answer'],
-			};
-
 			await service.executeForWorkflow(
 				agentId,
 				'hello',
@@ -1732,56 +1776,6 @@ describe('AgentsService', () => {
 
 			expect(structuredOutput).not.toHaveBeenCalled();
 		});
-
-		const makeErrorChunkStream = (errorMessage: string) => {
-			const chunks = [{ type: 'error', error: new Error(errorMessage) }];
-			let idx = 0;
-			return jest.fn().mockResolvedValue({
-				stream: {
-					getReader: () => ({
-						read: jest
-							.fn()
-							.mockImplementation(async () =>
-								idx < chunks.length
-									? { done: false, value: chunks[idx++] }
-									: { done: true, value: undefined },
-							),
-						releaseLock: jest.fn(),
-					}),
-				},
-			});
-		};
-
-		const setupErroringAgent = (errorMessage: string) => {
-			const schema: AgentJsonConfig = {
-				name: 'Test Agent',
-				model: 'anthropic/claude-sonnet-4-5',
-				instructions: 'Be helpful',
-			};
-			const agent = makeAgent({
-				schema,
-				activeVersionId: versionId,
-				activeVersion: makeAgentHistory({ schema, publishedById: userId }),
-			});
-			agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
-			Container.set(CredentialsService, mock<CredentialsService>());
-
-			jest.spyOn(service as never, 'reconstructFromConfig').mockResolvedValue({
-				agent: {
-					name: 'Test Agent',
-					structuredOutput: jest.fn(),
-					stream: makeErrorChunkStream(errorMessage),
-					close: jest.fn(),
-				},
-				toolRegistry: {},
-			} as never);
-		};
-
-		const outputSchema: JSONSchema7 = {
-			type: 'object',
-			properties: { answer: { type: 'string' } },
-			required: ['answer'],
-		};
 
 		it('surfaces an actionable error when structured output fails', async () => {
 			setupErroringAgent('No output generated. Check the stream for errors.');

--- a/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
@@ -1732,6 +1732,92 @@ describe('AgentsService', () => {
 
 			expect(structuredOutput).not.toHaveBeenCalled();
 		});
+
+		const makeErrorChunkStream = (errorMessage: string) => {
+			const chunks = [{ type: 'error', error: new Error(errorMessage) }];
+			let idx = 0;
+			return jest.fn().mockResolvedValue({
+				stream: {
+					getReader: () => ({
+						read: jest
+							.fn()
+							.mockImplementation(async () =>
+								idx < chunks.length
+									? { done: false, value: chunks[idx++] }
+									: { done: true, value: undefined },
+							),
+						releaseLock: jest.fn(),
+					}),
+				},
+			});
+		};
+
+		const setupErroringAgent = (errorMessage: string) => {
+			const schema: AgentJsonConfig = {
+				name: 'Test Agent',
+				model: 'anthropic/claude-sonnet-4-5',
+				instructions: 'Be helpful',
+			};
+			const agent = makeAgent({
+				schema,
+				activeVersionId: versionId,
+				activeVersion: makeAgentHistory({ schema, publishedById: userId }),
+			});
+			agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
+			Container.set(CredentialsService, mock<CredentialsService>());
+
+			jest.spyOn(service as never, 'reconstructFromConfig').mockResolvedValue({
+				agent: {
+					name: 'Test Agent',
+					structuredOutput: jest.fn(),
+					stream: makeErrorChunkStream(errorMessage),
+					close: jest.fn(),
+				},
+				toolRegistry: {},
+			} as never);
+		};
+
+		const outputSchema: JSONSchema7 = {
+			type: 'object',
+			properties: { answer: { type: 'string' } },
+			required: ['answer'],
+		};
+
+		it('surfaces an actionable error when structured output fails', async () => {
+			setupErroringAgent('No output generated. Check the stream for errors.');
+
+			await expect(
+				service.executeForWorkflow(
+					agentId,
+					'hello',
+					'execution-1',
+					'thread-1',
+					userId,
+					projectId,
+					userId,
+					true,
+					outputSchema,
+				),
+			).rejects.toThrow('could not return structured output');
+		});
+
+		it('falls back to the generic error when the failure is unrelated to structured output', async () => {
+			setupErroringAgent('Model credential is invalid');
+
+			await expect(
+				service.executeForWorkflow(
+					agentId,
+					'hello',
+					'execution-1',
+					'thread-1',
+					userId,
+					projectId,
+					userId,
+					true,
+					outputSchema,
+				),
+			).rejects.toThrow('Agent execution failed: Model credential is invalid');
+		});
 	});
 
 	describe('unpublishAgent', () => {

--- a/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
@@ -1798,7 +1798,7 @@ describe('AgentsService', () => {
 					true,
 					outputSchema,
 				),
-			).rejects.toThrow('could not return structured output');
+			).rejects.toThrow('structured output');
 		});
 
 		it('falls back to the generic error when the failure is unrelated to structured output', async () => {

--- a/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agents.service.test.ts
@@ -6,6 +6,7 @@ import { mockLogger } from '@n8n/backend-test-utils';
 import type { User } from '@n8n/db';
 import type { CredentialsEntity } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
+import type { JSONSchema7 } from 'json-schema';
 
 import type { Publisher } from '@/scaling/pubsub/publisher.service';
 import type { Telemetry } from '@/telemetry';
@@ -1637,6 +1638,99 @@ describe('AgentsService', () => {
 				user_id: userId,
 				message_count: 1,
 			});
+		});
+
+		it('applies a per-call output schema to the compiled agent', async () => {
+			const schema: AgentJsonConfig = {
+				name: 'Test Agent',
+				model: 'anthropic/claude-sonnet-4-5',
+				instructions: 'Be helpful',
+			};
+			const agent = makeAgent({
+				schema,
+				activeVersionId: versionId,
+				activeVersion: makeAgentHistory({ schema, publishedById: userId }),
+			});
+			agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
+			Container.set(CredentialsService, mock<CredentialsService>());
+
+			const structuredOutput = jest.fn();
+			const stream = jest.fn().mockResolvedValue({
+				stream: {
+					getReader: () => ({
+						read: jest.fn().mockResolvedValue({ done: true, value: undefined }),
+						releaseLock: jest.fn(),
+					}),
+				},
+			});
+			// Spy reconstructFromConfig so the real compileIsolated runs and applies
+			// the per-call schema to the builder before it is returned.
+			jest.spyOn(service as never, 'reconstructFromConfig').mockResolvedValue({
+				agent: { name: 'Test Agent', structuredOutput, stream, close: jest.fn() },
+				toolRegistry: {},
+			} as never);
+
+			const outputSchema: JSONSchema7 = {
+				type: 'object',
+				properties: { answer: { type: 'string' } },
+				required: ['answer'],
+			};
+
+			await service.executeForWorkflow(
+				agentId,
+				'hello',
+				'execution-1',
+				'thread-1',
+				userId,
+				projectId,
+				userId,
+				true,
+				outputSchema,
+			);
+
+			expect(structuredOutput).toHaveBeenCalledWith(outputSchema);
+		});
+
+		it('does not set an output schema when none is provided', async () => {
+			const schema: AgentJsonConfig = {
+				name: 'Test Agent',
+				model: 'anthropic/claude-sonnet-4-5',
+				instructions: 'Be helpful',
+			};
+			const agent = makeAgent({
+				schema,
+				activeVersionId: versionId,
+				activeVersion: makeAgentHistory({ schema, publishedById: userId }),
+			});
+			agentRepository.findByIdAndProjectId.mockResolvedValue(agent);
+			Container.set(CredentialsService, mock<CredentialsService>());
+
+			const structuredOutput = jest.fn();
+			const stream = jest.fn().mockResolvedValue({
+				stream: {
+					getReader: () => ({
+						read: jest.fn().mockResolvedValue({ done: true, value: undefined }),
+						releaseLock: jest.fn(),
+					}),
+				},
+			});
+			jest.spyOn(service as never, 'reconstructFromConfig').mockResolvedValue({
+				agent: { name: 'Test Agent', structuredOutput, stream, close: jest.fn() },
+				toolRegistry: {},
+			} as never);
+
+			await service.executeForWorkflow(
+				agentId,
+				'hello',
+				'execution-1',
+				'thread-1',
+				userId,
+				projectId,
+				userId,
+				true,
+			);
+
+			expect(structuredOutput).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -55,6 +55,7 @@ import { draftChatMemoryResourceId } from './utils/agent-memory-scope';
 import { executionsToMessagesDto } from './utils/execution-to-message-mapper';
 import { generateAgentResourceId } from './utils/agent-resource-id';
 import { streamAgentChunks } from './utils/agent-stream';
+import { describeStructuredOutputError } from './utils/structured-output-error';
 import { AgentExecutionService } from './agent-execution.service';
 import { AgentSkillsService } from './agent-skills.service';
 import { AGENT_THREAD_PREFIX } from './builder/builder-tool-names';
@@ -190,43 +191,6 @@ function getMaxIterationsChunks(): StreamChunk[] {
 		},
 		{ type: 'text-end', id },
 	];
-}
-
-/**
- * Map a low-level agent execution error to an actionable message when the run
- * requested structured output. Returns `null` when the error doesn't look
- * structured-output related, so the caller falls back to the generic message.
- *
- * Structured output is enforced by the model provider, so failures surface as
- * an opaque parse/validation error (e.g. "No output generated") or a provider
- * 400. This adds the context a workflow builder needs: not every model/provider
- * supports JSON Schema structured output, and strict providers require every
- * property to be listed in `required`.
- */
-function describeStructuredOutputError(rawError: string): string | null {
-	const haystack = rawError.toLowerCase();
-	const signals = [
-		'no object generated',
-		'no output generated',
-		'did not match schema',
-		'could not parse the response',
-		'response_format',
-		'json_schema',
-		'output_config',
-		'additionalproperties',
-		'invalid schema',
-		'structured output',
-		'does not support',
-	];
-	if (!signals.some((signal) => haystack.includes(signal))) return null;
-
-	return (
-		'The agent could not return structured output matching the provided schema. ' +
-		'The selected model or provider may not support JSON Schema structured output, or the ' +
-		'schema may be incompatible with it — some providers (e.g. OpenAI and xAI) require every ' +
-		'property to be listed in "required", and some (e.g. DeepSeek) do not support structured ' +
-		`output at all. Provider error: ${rawError}`
-	);
 }
 
 @Service()

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -192,6 +192,43 @@ function getMaxIterationsChunks(): StreamChunk[] {
 	];
 }
 
+/**
+ * Map a low-level agent execution error to an actionable message when the run
+ * requested structured output. Returns `null` when the error doesn't look
+ * structured-output related, so the caller falls back to the generic message.
+ *
+ * Structured output is enforced by the model provider, so failures surface as
+ * an opaque parse/validation error (e.g. "No output generated") or a provider
+ * 400. This adds the context a workflow builder needs: not every model/provider
+ * supports JSON Schema structured output, and strict providers require every
+ * property to be listed in `required`.
+ */
+function describeStructuredOutputError(rawError: string): string | null {
+	const haystack = rawError.toLowerCase();
+	const signals = [
+		'no object generated',
+		'no output generated',
+		'did not match schema',
+		'could not parse the response',
+		'response_format',
+		'json_schema',
+		'output_config',
+		'additionalproperties',
+		'invalid schema',
+		'structured output',
+		'does not support',
+	];
+	if (!signals.some((signal) => haystack.includes(signal))) return null;
+
+	return (
+		'The agent could not return structured output matching the provided schema. ' +
+		'The selected model or provider may not support JSON Schema structured output, or the ' +
+		'schema may be incompatible with it — some providers (e.g. OpenAI and xAI) require every ' +
+		'property to be listed in "required", and some (e.g. DeepSeek) do not support structured ' +
+		`output at all. Provider error: ${rawError}`
+	);
+}
+
 @Service()
 export class AgentsService {
 	/**
@@ -1450,11 +1487,22 @@ export class AgentsService {
 		}
 
 		if (messageRecord.error) {
+			if (outputSchema) {
+				const structuredOutputError = describeStructuredOutputError(messageRecord.error);
+				if (structuredOutputError) {
+					throw new OperationalError(structuredOutputError);
+				}
+			}
 			throw new OperationalError(`Agent execution failed: ${messageRecord.error}`);
 		}
 
 		if (messageRecord.finishReason === 'error') {
-			throw new OperationalError('Agent execution finished with an error.');
+			throw new OperationalError(
+				outputSchema
+					? 'Agent execution finished with an error while producing structured output. ' +
+							"The agent's model or provider may not support JSON Schema structured output."
+					: 'Agent execution finished with an error.',
+			);
 		}
 
 		return {

--- a/packages/cli/src/modules/agents/agents.service.ts
+++ b/packages/cli/src/modules/agents/agents.service.ts
@@ -30,6 +30,7 @@ import { In, ProjectRelationRepository, User } from '@n8n/db';
 import { OnPubSubEvent } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
 import type { EntityManager } from '@n8n/typeorm';
+import type { JSONSchema7 } from 'json-schema';
 import {
 	deepCopy,
 	OperationalError,
@@ -1303,6 +1304,7 @@ export class AgentsService {
 		agentEntity: Agent,
 		credentialProvider: CredentialProvider,
 		userId: string,
+		outputSchema?: JSONSchema7,
 	): Promise<{ ok: boolean; agent?: BuiltAgent; error?: string }> {
 		if (!agentEntity.schema) {
 			return { ok: false, error: 'Agent has no JSON config. Create a config first.' };
@@ -1314,6 +1316,13 @@ export class AgentsService {
 				credentialProvider,
 				userId,
 			);
+			// Apply a per-call structured-output schema (e.g. supplied by a
+			// workflow node) before the builder is cast to its runtime view. The
+			// isolated agent is freshly built and uncached, so this never leaks
+			// into concurrent chat / integration executions.
+			if (outputSchema) {
+				reconstructed.structuredOutput(outputSchema);
+			}
 			return { ok: true, agent: reconstructed as BuiltAgent };
 		} catch (e) {
 			return {
@@ -1348,6 +1357,7 @@ export class AgentsService {
 		projectId: string,
 		telemetryUserId?: string,
 		useDraftVersion?: boolean,
+		outputSchema?: JSONSchema7,
 	): Promise<ExecuteAgentData> {
 		const agentEntity = await this.agentRepository.findByIdAndProjectId(agentId, projectId);
 		if (!agentEntity) {
@@ -1365,7 +1375,12 @@ export class AgentsService {
 			agentData = this.getPublishedAgent(agentEntity);
 		}
 
-		const compiled = await this.compileIsolated(agentData, credentialProvider, userId);
+		const compiled = await this.compileIsolated(
+			agentData,
+			credentialProvider,
+			userId,
+			outputSchema,
+		);
 		if (!compiled.ok || !compiled.agent) {
 			throw new OperationalError(`Failed to compile agent: ${compiled.error ?? 'unknown error'}`);
 		}

--- a/packages/cli/src/modules/agents/utils/__tests__/structured-output-error.test.ts
+++ b/packages/cli/src/modules/agents/utils/__tests__/structured-output-error.test.ts
@@ -5,15 +5,26 @@ describe('describeStructuredOutputError', () => {
 		'No output generated. Check the stream for errors.',
 		'No object generated: response did not match schema',
 		'No object generated: could not parse the response',
-		'Invalid schema for response_format',
-		"output_config.format.schema: 'additionalProperties' must be explicitly set to false",
-		'This model does not support structured output',
-	])('returns an actionable message for structured-output error: %s', (rawError) => {
+	])('summarises a generic SDK error without echoing the raw text: %s', (rawError) => {
 		const result = describeStructuredOutputError(rawError);
 
 		expect(result).not.toBeNull();
-		expect(result).toContain('could not return structured output');
-		// The original provider error is preserved for debugging.
+		expect(result).toContain('structured output');
+		// The unhelpful SDK wrapper is not appended.
+		expect(result).not.toContain(rawError);
+		expect(result).not.toContain('Check the stream');
+	});
+
+	it.each([
+		'Invalid schema for response_format',
+		"output_config.format.schema: 'additionalProperties' must be explicitly set to false",
+		'This model does not support structured output',
+	])('appends an informative provider error: %s', (rawError) => {
+		const result = describeStructuredOutputError(rawError);
+
+		expect(result).not.toBeNull();
+		expect(result).toContain('structured output');
+		// A provider error with real detail is preserved for debugging.
 		expect(result).toContain(rawError);
 	});
 

--- a/packages/cli/src/modules/agents/utils/__tests__/structured-output-error.test.ts
+++ b/packages/cli/src/modules/agents/utils/__tests__/structured-output-error.test.ts
@@ -1,0 +1,29 @@
+import { describeStructuredOutputError } from '../structured-output-error';
+
+describe('describeStructuredOutputError', () => {
+	it.each([
+		'No output generated. Check the stream for errors.',
+		'No object generated: response did not match schema',
+		'No object generated: could not parse the response',
+		'Invalid schema for response_format',
+		"output_config.format.schema: 'additionalProperties' must be explicitly set to false",
+		'This model does not support structured output',
+	])('returns an actionable message for structured-output error: %s', (rawError) => {
+		const result = describeStructuredOutputError(rawError);
+
+		expect(result).not.toBeNull();
+		expect(result).toContain('could not return structured output');
+		// The original provider error is preserved for debugging.
+		expect(result).toContain(rawError);
+	});
+
+	it('matches case-insensitively', () => {
+		expect(describeStructuredOutputError('JSON_SCHEMA is invalid')).not.toBeNull();
+	});
+
+	it('returns null for errors unrelated to structured output', () => {
+		expect(describeStructuredOutputError('Model credential is invalid')).toBeNull();
+		expect(describeStructuredOutputError('Request timed out')).toBeNull();
+		expect(describeStructuredOutputError('Rate limit exceeded')).toBeNull();
+	});
+});

--- a/packages/cli/src/modules/agents/utils/structured-output-error.ts
+++ b/packages/cli/src/modules/agents/utils/structured-output-error.ts
@@ -1,0 +1,36 @@
+/**
+ * Map a low-level agent execution error to an actionable message when the run
+ * requested structured output. Returns `null` when the error doesn't look
+ * structured-output related, so the caller falls back to the generic message.
+ *
+ * Structured output is enforced by the model provider, so failures surface as
+ * an opaque parse/validation error (e.g. "No output generated") or a provider
+ * 400. This adds the context a workflow builder needs: not every model/provider
+ * supports JSON Schema structured output, and strict providers require every
+ * property to be listed in `required`.
+ */
+export function describeStructuredOutputError(rawError: string): string | null {
+	const haystack = rawError.toLowerCase();
+	const signals = [
+		'no object generated',
+		'no output generated',
+		'did not match schema',
+		'could not parse the response',
+		'response_format',
+		'json_schema',
+		'output_config',
+		'additionalproperties',
+		'invalid schema',
+		'structured output',
+		'does not support',
+	];
+	if (!signals.some((signal) => haystack.includes(signal))) return null;
+
+	return (
+		'The agent could not return structured output matching the provided schema. ' +
+		'The selected model or provider may not support JSON Schema structured output, or the ' +
+		'schema may be incompatible with it — some providers (e.g. OpenAI and xAI) require every ' +
+		'property to be listed in "required", and some (e.g. DeepSeek) do not support structured ' +
+		`output at all. Provider error: ${rawError}`
+	);
+}

--- a/packages/cli/src/modules/agents/utils/structured-output-error.ts
+++ b/packages/cli/src/modules/agents/utils/structured-output-error.ts
@@ -1,13 +1,13 @@
 /**
- * Map a low-level agent execution error to an actionable message when the run
- * requested structured output. Returns `null` when the error doesn't look
- * structured-output related, so the caller falls back to the generic message.
+ * Map a low-level agent execution error to a concise, actionable message when
+ * the run requested structured output. Returns `null` when the error doesn't
+ * look structured-output related, so the caller falls back to the generic
+ * message.
  *
  * Structured output is enforced by the model provider, so failures surface as
  * an opaque parse/validation error (e.g. "No output generated") or a provider
- * 400. This adds the context a workflow builder needs: not every model/provider
- * supports JSON Schema structured output, and strict providers require every
- * property to be listed in `required`.
+ * 400. Provider-specific guidance (which models support it, the "all required"
+ * rule) lives in the node's NDV notice — the runtime error stays short.
  */
 export function describeStructuredOutputError(rawError: string): string | null {
 	const haystack = rawError.toLowerCase();
@@ -26,11 +26,22 @@ export function describeStructuredOutputError(rawError: string): string | null {
 	];
 	if (!signals.some((signal) => haystack.includes(signal))) return null;
 
-	return (
-		'The agent could not return structured output matching the provided schema. ' +
-		'The selected model or provider may not support JSON Schema structured output, or the ' +
-		'schema may be incompatible with it — some providers (e.g. OpenAI and xAI) require every ' +
-		'property to be listed in "required", and some (e.g. DeepSeek) do not support structured ' +
-		`output at all. Provider error: ${rawError}`
-	);
+	const message =
+		"Couldn't get structured output matching the schema — the model may not support it.";
+
+	// Only echo the raw provider error when it adds something beyond the AI SDK's
+	// generic "no output generated / could not parse" wrapper — e.g. a provider
+	// 400 that names the offending schema constraint. Otherwise it's just noise.
+	const informativeSignals = [
+		'additionalproperties',
+		'response_format',
+		'json_schema',
+		'output_config',
+		'invalid schema',
+		'does not support',
+		'required',
+	];
+	const hasUsefulDetail = informativeSignals.some((signal) => haystack.includes(signal));
+
+	return hasUsefulDetail ? `${message} (${rawError})` : message;
 }

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -7,6 +7,7 @@ import { Time } from '@n8n/constants';
 import { ExecutionRepository, WorkflowRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import type { ServiceIdentifier } from '@n8n/di';
+import type { JSONSchema7 } from 'json-schema';
 import { ExternalSecretsProxy, WorkflowExecute } from 'n8n-core';
 import {
 	UnexpectedError,
@@ -319,6 +320,7 @@ export async function executeAgent(
 	threadId: string,
 	additionalData: IWorkflowExecuteAdditionalData,
 	executionMode: WorkflowExecuteMode,
+	outputSchema?: JSONSchema7,
 ): Promise<ExecuteAgentData> {
 	let userId = additionalData.userId;
 	const telemetryUserId = additionalData.userId;
@@ -363,6 +365,7 @@ export async function executeAgent(
 		projectId,
 		telemetryUserId,
 		useDraftVersion,
+		outputSchema,
 	);
 }
 

--- a/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
@@ -176,6 +176,7 @@ export class BaseExecuteContext extends NodeExecutionContext {
 			threadId,
 			this.additionalData,
 			this.additionalData.rootExecutionMode ?? this.getMode(),
+			agentInfo.outputSchema,
 		);
 	}
 

--- a/packages/frontend/editor-ui/src/features/agents/__tests__/SessionDetailPanel.spec.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/SessionDetailPanel.spec.ts
@@ -216,6 +216,36 @@ describe('SessionDetailPanel — other kinds', () => {
 		expect(w.find('[data-test-id="markdown"]').exists()).toBe(true);
 	});
 
+	it('renders plain-text agent messages as markdown', () => {
+		const w = mountIt({ kind: 'agent', executionId: 'e1', timestamp: 0, content: 'Hello there' });
+		expect(w.find('[data-test-id="markdown"]').exists()).toBe(true);
+		expect(w.find('pre').exists()).toBe(false);
+	});
+
+	it('pretty-prints an agent message whose content is structured JSON output', () => {
+		const w = mountIt({
+			kind: 'agent',
+			executionId: 'e1',
+			timestamp: 0,
+			content: '{"city":"Tokyo","country":"Japan","population_millions":14.04}',
+		});
+		// JSON output is rendered in a <pre>, not via markdown.
+		expect(w.find('[data-test-id="markdown"]').exists()).toBe(false);
+		const pre = w.find('pre');
+		expect(pre.exists()).toBe(true);
+		expect(pre.text()).toContain('city');
+		expect(pre.text()).toContain('Tokyo');
+		expect(pre.text()).toContain('population_millions');
+		// Pretty-printed across multiple lines rather than a single raw string.
+		expect(pre.text().split('\n').length).toBeGreaterThan(1);
+	});
+
+	it('keeps markdown for an agent message that is valid JSON but not an object', () => {
+		const w = mountIt({ kind: 'agent', executionId: 'e1', timestamp: 0, content: '42' });
+		expect(w.find('[data-test-id="markdown"]').exists()).toBe(true);
+		expect(w.find('pre').exists()).toBe(false);
+	});
+
 	it('emits close when the close button is clicked', async () => {
 		const w = mountIt({ kind: 'user', executionId: 'e1', timestamp: 0, content: 'hi' });
 		await w.find('[data-test-id="detail-close"]').trigger('click');

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionDetailPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionDetailPanel.vue
@@ -263,8 +263,8 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 									<N8nTooltip
 										:content="
 											copiedBlock === 'workflow-output'
-												? i18n.baseText('agents.builder.addTrigger.copied')
-												: i18n.baseText('agents.builder.addTrigger.copy')
+												? i18n.baseText('generic.copied')
+												: i18n.baseText('generic.copy')
 										"
 									>
 										<N8nButton
@@ -274,8 +274,8 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 											:icon="copiedBlock === 'workflow-output' ? 'check' : 'copy'"
 											:aria-label="
 												copiedBlock === 'workflow-output'
-													? i18n.baseText('agents.builder.addTrigger.copied')
-													: i18n.baseText('agents.builder.addTrigger.copy')
+													? i18n.baseText('generic.copied')
+													: i18n.baseText('generic.copy')
 											"
 											@click="copyJsonBlock('workflow-output', item.toolOutput)"
 										/>
@@ -300,8 +300,8 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 										<N8nTooltip
 											:content="
 												copiedBlock === 'tool-input'
-													? i18n.baseText('agents.builder.addTrigger.copied')
-													: i18n.baseText('agents.builder.addTrigger.copy')
+													? i18n.baseText('generic.copied')
+													: i18n.baseText('generic.copy')
 											"
 										>
 											<N8nButton
@@ -311,8 +311,8 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 												:icon="copiedBlock === 'tool-input' ? 'check' : 'copy'"
 												:aria-label="
 													copiedBlock === 'tool-input'
-														? i18n.baseText('agents.builder.addTrigger.copied')
-														: i18n.baseText('agents.builder.addTrigger.copy')
+														? i18n.baseText('generic.copied')
+														: i18n.baseText('generic.copy')
 												"
 												@click="copyJsonBlock('tool-input', item.toolInput)"
 											/>
@@ -332,8 +332,8 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 										<N8nTooltip
 											:content="
 												copiedBlock === 'tool-output'
-													? i18n.baseText('agents.builder.addTrigger.copied')
-													: i18n.baseText('agents.builder.addTrigger.copy')
+													? i18n.baseText('generic.copied')
+													: i18n.baseText('generic.copy')
 											"
 										>
 											<N8nButton
@@ -343,8 +343,8 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 												:icon="copiedBlock === 'tool-output' ? 'check' : 'copy'"
 												:aria-label="
 													copiedBlock === 'tool-output'
-														? i18n.baseText('agents.builder.addTrigger.copied')
-														: i18n.baseText('agents.builder.addTrigger.copy')
+														? i18n.baseText('generic.copied')
+														: i18n.baseText('generic.copy')
 												"
 												@click="copyJsonBlock('tool-output', item.toolOutput)"
 											/>
@@ -377,8 +377,8 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 								<N8nTooltip
 									:content="
 										copiedBlock === 'agent-output'
-											? i18n.baseText('agents.builder.addTrigger.copied')
-											: i18n.baseText('agents.builder.addTrigger.copy')
+											? i18n.baseText('generic.copied')
+											: i18n.baseText('generic.copy')
 									"
 								>
 									<N8nButton
@@ -388,8 +388,8 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 										:icon="copiedBlock === 'agent-output' ? 'check' : 'copy'"
 										:aria-label="
 											copiedBlock === 'agent-output'
-												? i18n.baseText('agents.builder.addTrigger.copied')
-												: i18n.baseText('agents.builder.addTrigger.copy')
+												? i18n.baseText('generic.copied')
+												: i18n.baseText('generic.copy')
 										"
 										@click="copyJsonBlock('agent-output', agentStructuredContent)"
 									/>

--- a/packages/frontend/editor-ui/src/features/agents/components/SessionDetailPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/SessionDetailPanel.vue
@@ -132,6 +132,26 @@ const isSubAgent = computed((): boolean =>
 	props.item ? isSubAgentTimelineItem(props.item) : false,
 );
 
+/**
+ * For an agent (assistant) message the persisted content is the raw response
+ * text. When that text is a JSON object/array — i.e. the agent produced
+ * structured output — parse it so it can be pretty-printed instead of shown as
+ * a raw one-line string. Plain-text answers return `undefined` and keep their
+ * markdown rendering.
+ */
+const agentStructuredContent = computed((): unknown => {
+	const item = props.item;
+	if (!item || item.kind !== 'agent') return undefined;
+	const content = item.content?.trim();
+	if (!content || (!content.startsWith('{') && !content.startsWith('['))) return undefined;
+	try {
+		const parsed: unknown = JSON.parse(content);
+		return parsed !== null && typeof parsed === 'object' ? parsed : undefined;
+	} catch {
+		return undefined;
+	}
+});
+
 const headerTitle = computed((): string => {
 	const item = props.item;
 	if (!item) return '';
@@ -349,6 +369,36 @@ const workflowFormOutput = computed((): { formUrl: string; message: string } | n
 							:node-parameters="item.nodeParameters"
 							:success="item.toolSuccess"
 						/>
+					</template>
+
+					<template v-else-if="item.kind === 'agent' && agentStructuredContent !== undefined">
+						<div :class="$style.codeBlock">
+							<div :class="$style.codeBlockCopy">
+								<N8nTooltip
+									:content="
+										copiedBlock === 'agent-output'
+											? i18n.baseText('agents.builder.addTrigger.copied')
+											: i18n.baseText('agents.builder.addTrigger.copy')
+									"
+								>
+									<N8nButton
+										variant="outline"
+										size="small"
+										icon-only
+										:icon="copiedBlock === 'agent-output' ? 'check' : 'copy'"
+										:aria-label="
+											copiedBlock === 'agent-output'
+												? i18n.baseText('agents.builder.addTrigger.copied')
+												: i18n.baseText('agents.builder.addTrigger.copy')
+										"
+										@click="copyJsonBlock('agent-output', agentStructuredContent)"
+									/>
+								</N8nTooltip>
+							</div>
+							<!-- eslint-disable vue/no-v-html -->
+							<pre :class="$style.json" v-html="highlightJson(agentStructuredContent)" />
+							<!-- eslint-enable vue/no-v-html -->
+						</div>
 					</template>
 
 					<template v-else-if="item.kind === 'user' || item.kind === 'agent'">

--- a/packages/nodes-base/nodes/MessageAnAgent/MessageAnAgent.node.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/MessageAnAgent.node.ts
@@ -1,3 +1,4 @@
+import type { JSONSchema7 } from 'json-schema';
 import type {
 	IDataObject,
 	IExecuteFunctions,
@@ -6,8 +7,53 @@ import type {
 	INodeType,
 	INodeTypeDescription,
 } from 'n8n-workflow';
-import { NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
+import { jsonParse, NodeConnectionTypes, NodeOperationError } from 'n8n-workflow';
 import crypto from 'node:crypto';
+
+/**
+ * Read and parse the per-item structured-output JSON Schema. Returns `undefined`
+ * when the toggle is off; throws a user-facing error when the toggle is on but
+ * the schema is empty or not valid JSON.
+ */
+function getStructuredOutputSchema(
+	ctx: IExecuteFunctions,
+	itemIndex: number,
+): JSONSchema7 | undefined {
+	const useStructuredOutput = ctx.getNodeParameter(
+		'useStructuredOutput',
+		itemIndex,
+		false,
+	) as boolean;
+	if (!useStructuredOutput) return undefined;
+
+	const rawSchema = ctx.getNodeParameter('outputSchema', itemIndex, '') as string;
+	if (!rawSchema.trim()) {
+		throw new NodeOperationError(
+			ctx.getNode(),
+			'Output schema is empty. Provide a JSON Schema or turn off "Output Structured Data".',
+			{ itemIndex },
+		);
+	}
+
+	let parsed: JSONSchema7;
+	try {
+		parsed = jsonParse<JSONSchema7>(rawSchema);
+	} catch (error) {
+		throw new NodeOperationError(
+			ctx.getNode(),
+			`Output schema is not valid JSON: ${(error as Error).message}`,
+			{ itemIndex },
+		);
+	}
+
+	if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+		throw new NodeOperationError(ctx.getNode(), 'Output schema must be a JSON Schema object', {
+			itemIndex,
+		});
+	}
+
+	return parsed;
+}
 
 export class MessageAnAgent implements INodeType {
 	description: INodeTypeDescription = {
@@ -74,6 +120,39 @@ export class MessageAnAgent implements INodeType {
 				description: 'The message to send to the agent',
 				typeOptions: {
 					rows: 4,
+				},
+			},
+			{
+				displayName: 'Output Structured Data',
+				name: 'useStructuredOutput',
+				type: 'boolean',
+				default: false,
+				description:
+					'Whether to constrain the agent response to a JSON Schema you provide. The conforming object is returned on the "structuredOutput" field.',
+			},
+			{
+				displayName: 'Output Schema',
+				name: 'outputSchema',
+				type: 'json',
+				default: `{
+  "type": "object",
+  "properties": {
+    "result": {
+      "type": "string",
+      "description": "The result of the task"
+    }
+  },
+  "required": ["result"]
+}`,
+				description: 'The JSON Schema that the agent response must conform to',
+				hint: 'Use <a target="_blank" href="https://json-schema.org/">JSON Schema</a> format',
+				typeOptions: {
+					rows: 10,
+				},
+				displayOptions: {
+					show: {
+						useStructuredOutput: [true],
+					},
 				},
 			},
 			{
@@ -148,8 +227,10 @@ export class MessageAnAgent implements INodeType {
 					});
 				}
 
+				const outputSchema = getStructuredOutputSchema(this, i);
+
 				const result = await this.executeAgent(
-					{ agentId, sessionId: sessionIdOverride || undefined },
+					{ agentId, sessionId: sessionIdOverride || undefined, outputSchema },
 					message,
 					executionId,
 					i,

--- a/packages/nodes-base/nodes/MessageAnAgent/MessageAnAgent.node.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/MessageAnAgent.node.ts
@@ -26,22 +26,34 @@ function getStructuredOutputSchema(
 	) as boolean;
 	if (!useStructuredOutput) return undefined;
 
-	const rawSchema = ctx.getNodeParameter('outputSchema', itemIndex, '') as string;
-	if (!rawSchema.trim()) {
-		throw new NodeOperationError(
-			ctx.getNode(),
-			'Output schema is empty. Provide a JSON Schema or turn off "Require Specific Output Format".',
-			{ itemIndex },
-		);
-	}
+	const rawSchema = ctx.getNodeParameter('outputSchema', itemIndex, '') as unknown;
 
 	let parsed: JSONSchema7;
-	try {
-		parsed = jsonParse<JSONSchema7>(rawSchema);
-	} catch (error) {
+
+	if (typeof rawSchema === 'object') {
+		parsed = rawSchema as JSONSchema7;
+	} else if (typeof rawSchema === 'string') {
+		if (!rawSchema.trim()) {
+			throw new NodeOperationError(
+				ctx.getNode(),
+				'Output schema is empty. Provide a JSON Schema or turn off "Require Specific Output Format".',
+				{ itemIndex },
+			);
+		}
+
+		try {
+			parsed = jsonParse<JSONSchema7>(rawSchema);
+		} catch (error) {
+			throw new NodeOperationError(
+				ctx.getNode(),
+				`Output schema is not valid JSON: ${(error as Error).message}`,
+				{ itemIndex },
+			);
+		}
+	} else {
 		throw new NodeOperationError(
 			ctx.getNode(),
-			`Output schema is not valid JSON: ${(error as Error).message}`,
+			'Output schema is not valid JSON. Provide a JSON Schema or turn off "Require Specific Output Format".',
 			{ itemIndex },
 		);
 	}

--- a/packages/nodes-base/nodes/MessageAnAgent/MessageAnAgent.node.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/MessageAnAgent.node.ts
@@ -30,7 +30,7 @@ function getStructuredOutputSchema(
 	if (!rawSchema.trim()) {
 		throw new NodeOperationError(
 			ctx.getNode(),
-			'Output schema is empty. Provide a JSON Schema or turn off "Output Structured Data".',
+			'Output schema is empty. Provide a JSON Schema or turn off "Require Specific Output Format".',
 			{ itemIndex },
 		);
 	}
@@ -157,7 +157,7 @@ export class MessageAnAgent implements INodeType {
 			},
 			{
 				displayName:
-					'Structured output is enforced by the model provider. For best results across providers, mark every property as required. Some providers reject optional fields or advanced keywords (e.g. OpenAI and xAI strict mode), and a few do not support structured output at all (e.g. DeepSeek).',
+					'Structured output is enforced by the model provider. For best results across providers, mark every property as required. Some providers reject optional fields or advanced keywords (e.g. OpenAI and xAI), and a few do not support structured output at all (e.g. DeepSeek).',
 				name: 'structuredOutputNotice',
 				type: 'notice',
 				default: '',

--- a/packages/nodes-base/nodes/MessageAnAgent/MessageAnAgent.node.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/MessageAnAgent.node.ts
@@ -123,7 +123,7 @@ export class MessageAnAgent implements INodeType {
 				},
 			},
 			{
-				displayName: 'Output Structured Data',
+				displayName: 'Require Specific Output Format',
 				name: 'useStructuredOutput',
 				type: 'boolean',
 				default: false,
@@ -149,6 +149,18 @@ export class MessageAnAgent implements INodeType {
 				typeOptions: {
 					rows: 10,
 				},
+				displayOptions: {
+					show: {
+						useStructuredOutput: [true],
+					},
+				},
+			},
+			{
+				displayName:
+					'Structured output is enforced by the model provider. For best results across providers, mark every property as required. Some providers reject optional fields or advanced keywords (e.g. OpenAI and xAI strict mode), and a few do not support structured output at all (e.g. DeepSeek).',
+				name: 'structuredOutputNotice',
+				type: 'notice',
+				default: '',
 				displayOptions: {
 					show: {
 						useStructuredOutput: [true],

--- a/packages/nodes-base/nodes/MessageAnAgent/__tests__/MessageAnAgent.node.test.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/__tests__/MessageAnAgent.node.test.ts
@@ -236,4 +236,81 @@ describe('MessageAnAgent Node', () => {
 			{ toolName: 'search', input: { query: 'test' }, result: { found: true } },
 		]);
 	});
+
+	it('should forward the parsed output schema when structured output is enabled', async () => {
+		const schemaString = JSON.stringify({
+			type: 'object',
+			properties: { result: { type: 'string' } },
+			required: ['result'],
+		});
+
+		executeFunctions.getInputData.mockReturnValue([{ json: {} }]);
+		executeFunctions.getNodeParameter.mockImplementation(
+			(param: string, _itemIndex?: number, fallback?: unknown) => {
+				if (param === 'agentId') return { mode: 'id', value: 'agent-1' };
+				if (param === 'message') return 'Hello agent';
+				if (param === 'advanced') return fallback ?? {};
+				if (param === 'useStructuredOutput') return true;
+				if (param === 'outputSchema') return schemaString;
+				return undefined;
+			},
+		);
+		executeFunctions.executeAgent.mockResolvedValue(mockAgentResult);
+
+		await node.execute.call(executeFunctions);
+
+		expect(executeFunctions.executeAgent).toHaveBeenCalledWith(
+			{
+				agentId: 'agent-1',
+				sessionId: undefined,
+				outputSchema: {
+					type: 'object',
+					properties: { result: { type: 'string' } },
+					required: ['result'],
+				},
+			},
+			'Hello agent',
+			'exec-123',
+			0,
+		);
+	});
+
+	it('should throw NodeOperationError when the output schema is not valid JSON', async () => {
+		executeFunctions.getInputData.mockReturnValue([{ json: {} }]);
+		executeFunctions.getNodeParameter.mockImplementation(
+			(param: string, _itemIndex?: number, fallback?: unknown) => {
+				if (param === 'agentId') return { mode: 'id', value: 'agent-1' };
+				if (param === 'message') return 'Hello agent';
+				if (param === 'advanced') return fallback ?? {};
+				if (param === 'useStructuredOutput') return true;
+				if (param === 'outputSchema') return '{ not valid json';
+				return undefined;
+			},
+		);
+		executeFunctions.continueOnFail.mockReturnValue(false);
+
+		await expect(node.execute.call(executeFunctions)).rejects.toThrow(NodeOperationError);
+		await expect(node.execute.call(executeFunctions)).rejects.toThrow(
+			'Output schema is not valid JSON',
+		);
+		expect(executeFunctions.executeAgent).not.toHaveBeenCalled();
+	});
+
+	it('should throw NodeOperationError when structured output is enabled with an empty schema', async () => {
+		executeFunctions.getInputData.mockReturnValue([{ json: {} }]);
+		executeFunctions.getNodeParameter.mockImplementation(
+			(param: string, _itemIndex?: number, fallback?: unknown) => {
+				if (param === 'agentId') return { mode: 'id', value: 'agent-1' };
+				if (param === 'message') return 'Hello agent';
+				if (param === 'advanced') return fallback ?? {};
+				if (param === 'useStructuredOutput') return true;
+				if (param === 'outputSchema') return '   ';
+				return undefined;
+			},
+		);
+		executeFunctions.continueOnFail.mockReturnValue(false);
+
+		await expect(node.execute.call(executeFunctions)).rejects.toThrow('Output schema is empty');
+		expect(executeFunctions.executeAgent).not.toHaveBeenCalled();
+	});
 });

--- a/packages/nodes-base/nodes/MessageAnAgent/__tests__/MessageAnAgent.node.test.ts
+++ b/packages/nodes-base/nodes/MessageAnAgent/__tests__/MessageAnAgent.node.test.ts
@@ -313,4 +313,76 @@ describe('MessageAnAgent Node', () => {
 		await expect(node.execute.call(executeFunctions)).rejects.toThrow('Output schema is empty');
 		expect(executeFunctions.executeAgent).not.toHaveBeenCalled();
 	});
+
+	it('forwards an already-parsed object schema (e.g. from an expression) without calling .trim()', async () => {
+		// A `type: "json"` parameter backed by an expression like
+		// `={{ $json.outputSchema }}` resolves to an object, not a string.
+		const schemaObject = {
+			type: 'object',
+			properties: { result: { type: 'string' } },
+			required: ['result'],
+		};
+
+		executeFunctions.getInputData.mockReturnValue([{ json: {} }]);
+		executeFunctions.getNodeParameter.mockImplementation(
+			(param: string, _itemIndex?: number, fallback?: unknown) => {
+				if (param === 'agentId') return { mode: 'id', value: 'agent-1' };
+				if (param === 'message') return 'Hello agent';
+				if (param === 'advanced') return fallback ?? {};
+				if (param === 'useStructuredOutput') return true;
+				if (param === 'outputSchema') return schemaObject;
+				return undefined;
+			},
+		);
+		executeFunctions.executeAgent.mockResolvedValue(mockAgentResult);
+
+		await node.execute.call(executeFunctions);
+
+		expect(executeFunctions.executeAgent).toHaveBeenCalledWith(
+			{ agentId: 'agent-1', sessionId: undefined, outputSchema: schemaObject },
+			'Hello agent',
+			'exec-123',
+			0,
+		);
+	});
+
+	it('throws NodeOperationError when the output schema resolves to an array', async () => {
+		executeFunctions.getInputData.mockReturnValue([{ json: {} }]);
+		executeFunctions.getNodeParameter.mockImplementation(
+			(param: string, _itemIndex?: number, fallback?: unknown) => {
+				if (param === 'agentId') return { mode: 'id', value: 'agent-1' };
+				if (param === 'message') return 'Hello agent';
+				if (param === 'advanced') return fallback ?? {};
+				if (param === 'useStructuredOutput') return true;
+				if (param === 'outputSchema') return [{ type: 'object' }];
+				return undefined;
+			},
+		);
+		executeFunctions.continueOnFail.mockReturnValue(false);
+
+		await expect(node.execute.call(executeFunctions)).rejects.toThrow(
+			'Output schema must be a JSON Schema object',
+		);
+		expect(executeFunctions.executeAgent).not.toHaveBeenCalled();
+	});
+
+	it('throws NodeOperationError when the output schema resolves to a non-object, non-string value', async () => {
+		executeFunctions.getInputData.mockReturnValue([{ json: {} }]);
+		executeFunctions.getNodeParameter.mockImplementation(
+			(param: string, _itemIndex?: number, fallback?: unknown) => {
+				if (param === 'agentId') return { mode: 'id', value: 'agent-1' };
+				if (param === 'message') return 'Hello agent';
+				if (param === 'advanced') return fallback ?? {};
+				if (param === 'useStructuredOutput') return true;
+				if (param === 'outputSchema') return 42;
+				return undefined;
+			},
+		);
+		executeFunctions.continueOnFail.mockReturnValue(false);
+
+		await expect(node.execute.call(executeFunctions)).rejects.toThrow(
+			'Output schema is not valid JSON',
+		);
+		expect(executeFunctions.executeAgent).not.toHaveBeenCalled();
+	});
 });

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2007,9 +2007,8 @@ export interface ExecuteAgentInfo {
 	sessionId?: string;
 	/**
 	 * Optional JSON Schema describing the shape the agent should return. When
-	 * provided, it is applied to this call only (overriding the agent's own
-	 * config), and the conforming object is surfaced on
-	 * {@link ExecuteAgentData.structuredOutput}.
+	 * provided, it is applied to this call only, and the conforming object is
+	 * surfaced on {@link ExecuteAgentData.structuredOutput}.
 	 */
 	outputSchema?: JSONSchema7;
 }

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -7,6 +7,7 @@ import type FormData from 'form-data';
 import type { PathLike } from 'fs';
 import type { IncomingHttpHeaders } from 'http';
 import type { AgentOptions } from 'https';
+import type { JSONSchema7 } from 'json-schema';
 import type { ReplyHeaders, RequestBodyMatcher, RequestHeaderMatcher } from 'nock';
 import type { Client as SSHClient } from 'ssh2';
 import type { Readable } from 'stream';
@@ -2004,6 +2005,13 @@ export interface ExecuteAgentInfo {
 	 * from the workflow execution id and item index.
 	 */
 	sessionId?: string;
+	/**
+	 * Optional JSON Schema describing the shape the agent should return. When
+	 * provided, it is applied to this call only (overriding the agent's own
+	 * config), and the conforming object is surfaced on
+	 * {@link ExecuteAgentData.structuredOutput}.
+	 */
+	outputSchema?: JSONSchema7;
 }
 
 export interface ExecuteAgentOptions {
@@ -3248,6 +3256,7 @@ export interface IWorkflowExecuteAdditionalData {
 		threadId: string,
 		additionalData: IWorkflowExecuteAdditionalData,
 		executionMode: WorkflowExecuteMode,
+		outputSchema?: JSONSchema7,
 	) => Promise<ExecuteAgentData>;
 	listAgents?: (userId: string) => Promise<Array<{ id: string; name: string }>>;
 	getRunExecutionData: (executionId: string) => Promise<IRunExecutionData | undefined>;


### PR DESCRIPTION
## Summary

Adds **structured output** to the **Message an n8n Agent** node: a workflow can constrain an agent's response to a JSON Schema and receive a typed object on the node's `structuredOutput` output.

**Node** — a *Require Specific Output Format* toggle reveals an *Output Schema* (JSON Schema) field, plus a notice that enforcement is provider-dependent. The conforming object is returned on the existing `structuredOutput` output; `response` still holds the text.

**Runtime threading** — the schema flows per-call: node → `executeAgent` → `executeForWorkflow` → applied to a freshly-built, isolated agent.

**`@n8n/agents` SDK** (`utils/json-schema.ts`) —
- `structuredOutput()` now accepts a raw JSON Schema in addition to a Zod schema.
- `lockAdditionalProperties` recursively sets `additionalProperties: false` on every object (required by Anthropic's structured output; harmless elsewhere). This is **not** provider "strict mode" — declared-optional fields stay optional.
- OpenAI/Groq default to strict mode and would otherwise reject schemas with optional fields, so strict mode is relaxed there; the model's output is still validated against the schema afterwards.

**Errors** — a failed structured-output run surfaces a concise, actionable message (*"Couldn't get structured output matching the schema — the model may not support it"*) instead of the opaque SDK error, while still appending genuinely-informative provider errors (e.g. a 400 naming `additionalProperties`).

**Editor** — the agent session detail panel now pretty-prints structured-output (JSON) agent messages with syntax highlighting and a copy button, instead of a raw one-line string.

### Provider support
Structured output is enforced by the model provider, so it needs a model that supports JSON Schema structured output (e.g. Claude Sonnet 4.5/4.6, OpenAI, Groq, Mistral, Cohere, Gemini). Models without support (e.g. Claude 3.7 Sonnet, DeepSeek) **fail loudly** with the clear error above.

### How to test
1. Create and **publish** an agent with a model that supports structured output (e.g. Claude Sonnet 4.6).
2. In a workflow add **Message an n8n Agent**, pick the agent, enter a message.
3. Enable **Require Specific Output Format** and paste a JSON Schema, e.g.
   `{ "type": "object", "properties": { "sentiment": { "type": "string" }, "score": { "type": "number" } }, "required": ["sentiment", "score"] }`
4. Run → the node output's `structuredOutput` is a populated object matching the schema; `response` still holds the text.
5. Open the agent's session detail view → the agent message renders as formatted JSON with a copy button.
6. With the toggle off, behaviour is unchanged (`structuredOutput` is `null`).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-227

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
