### PR TITLE
refactor(core): Sanitize skillsUsed before MCP telemetry (no-changelog)

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
@@ -427,6 +427,51 @@ describe('create-workflow-from-code MCP tool', () => {
 			);
 		});
 
+		test('omits skillsUsed from telemetry when not provided', async () => {
+			await callHandler({ code: 'const wf = ...' });
+
+			const trackedPayload = (telemetry.track as jest.Mock).mock.calls[0][1] as {
+				parameters: Record<string, unknown>;
+			};
+			expect(trackedPayload.parameters).not.toHaveProperty('skillsUsed');
+		});
+
+		test('omits skillsUsed from telemetry when an empty array is passed', async () => {
+			await callHandler({ code: 'const wf = ...', skillsUsed: [] });
+
+			const trackedPayload = (telemetry.track as jest.Mock).mock.calls[0][1] as {
+				parameters: Record<string, unknown>;
+			};
+			expect(trackedPayload.parameters).not.toHaveProperty('skillsUsed');
+		});
+
+		test('normalizes skillsUsed before tracking telemetry', async () => {
+			await callHandler({
+				code: 'const wf = ...',
+				skillsUsed: ['  Workflow-Builder  ', 'workflow-builder', 'has spaces', 'NODE-SELECTION'],
+			});
+
+			expect(telemetry.track).toHaveBeenCalledWith(
+				'User called mcp tool',
+				expect.objectContaining({
+					parameters: expect.objectContaining({
+						skillsUsed: ['workflow-builder', 'node-selection'],
+					}),
+				}),
+			);
+		});
+
+		test('does not reject the call when skillsUsed overflows the cap', async () => {
+			const oversized = Array.from({ length: 60 }, (_, i) => `skill-${i}`);
+			const result = await callHandler({ code: 'const wf = ...', skillsUsed: oversized });
+
+			expect(result.isError).toBeUndefined();
+			const trackedPayload = (telemetry.track as jest.Mock).mock.calls[0][1] as {
+				parameters: { skillsUsed: string[] };
+			};
+			expect(trackedPayload.parameters.skillsUsed).toHaveLength(50);
+		});
+
 		test('assigns webhookId to webhook nodes before saving', async () => {
 			nodeTypes.getByNameAndVersion.mockImplementation(((type: string) => {
 				if (type === 'n8n-nodes-base.webhook') {

--- a/packages/cli/src/modules/mcp/__tests__/skills-used.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/skills-used.test.ts
@@ -24,11 +24,15 @@ describe('sanitizeSkillsUsed', () => {
 		]);
 	});
 
-	test('keeps namespaced identifiers', () => {
-		expect(sanitizeSkillsUsed(['n8n:plan', 'frontend-design:frontend-design'])).toEqual([
-			'n8n:plan',
-			'frontend-design:frontend-design',
+	test('keeps identifiers with underscores and dots', () => {
+		expect(sanitizeSkillsUsed(['snake_case_skill', 'dotted.skill.name'])).toEqual([
+			'snake_case_skill',
+			'dotted.skill.name',
 		]);
+	});
+
+	test('keeps identifiers starting with a digit', () => {
+		expect(sanitizeSkillsUsed(['1-step-skill'])).toEqual(['1-step-skill']);
 	});
 
 	test('trims and lowercases entries', () => {
@@ -44,12 +48,11 @@ describe('sanitizeSkillsUsed', () => {
 				'workflow-builder',
 				'has spaces',
 				'has/slash',
-				'has.dot',
-				'has_underscore',
+				'has:colon',
 				'unicode-‑hyphen',
 				'contains "quote"',
-				'1starts-with-digit',
 				'-starts-with-dash',
+				'.starts-with-dot',
 			]),
 		).toEqual(['workflow-builder']);
 	});
@@ -60,9 +63,9 @@ describe('sanitizeSkillsUsed', () => {
 		]);
 	});
 
-	test('drops entries longer than 128 chars', () => {
-		const tooLong = 'a'.repeat(129);
-		const justRight = 'a'.repeat(128);
+	test('drops entries longer than 64 chars', () => {
+		const tooLong = 'a'.repeat(65);
+		const justRight = 'a'.repeat(64);
 		expect(sanitizeSkillsUsed([tooLong, justRight, 'workflow-builder'])).toEqual([
 			justRight,
 			'workflow-builder',

--- a/packages/cli/src/modules/mcp/__tests__/skills-used.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/skills-used.test.ts
@@ -1,0 +1,90 @@
+import { sanitizeSkillsUsed } from '../tools/workflow-builder/skills-used';
+
+describe('sanitizeSkillsUsed', () => {
+	test('returns undefined for non-array input', () => {
+		expect(sanitizeSkillsUsed(undefined)).toBeUndefined();
+		expect(sanitizeSkillsUsed(null)).toBeUndefined();
+		expect(sanitizeSkillsUsed('workflow-builder')).toBeUndefined();
+		expect(sanitizeSkillsUsed(42)).toBeUndefined();
+		expect(sanitizeSkillsUsed({ skill: 'workflow-builder' })).toBeUndefined();
+	});
+
+	test('returns undefined for an empty array', () => {
+		expect(sanitizeSkillsUsed([])).toBeUndefined();
+	});
+
+	test('returns undefined when every entry is invalid', () => {
+		expect(sanitizeSkillsUsed(['', '   ', 'UPPER CASE', 'has spaces', '!!!'])).toBeUndefined();
+	});
+
+	test('keeps valid kebab-case identifiers', () => {
+		expect(sanitizeSkillsUsed(['workflow-builder', 'node-selection'])).toEqual([
+			'workflow-builder',
+			'node-selection',
+		]);
+	});
+
+	test('keeps namespaced identifiers', () => {
+		expect(sanitizeSkillsUsed(['n8n:plan', 'frontend-design:frontend-design'])).toEqual([
+			'n8n:plan',
+			'frontend-design:frontend-design',
+		]);
+	});
+
+	test('trims and lowercases entries', () => {
+		expect(sanitizeSkillsUsed(['  Workflow-Builder  ', 'NODE-SELECTION'])).toEqual([
+			'workflow-builder',
+			'node-selection',
+		]);
+	});
+
+	test('drops entries with disallowed characters', () => {
+		expect(
+			sanitizeSkillsUsed([
+				'workflow-builder',
+				'has spaces',
+				'has/slash',
+				'has.dot',
+				'has_underscore',
+				'unicode-‑hyphen',
+				'contains "quote"',
+				'1starts-with-digit',
+				'-starts-with-dash',
+			]),
+		).toEqual(['workflow-builder']);
+	});
+
+	test('drops non-string entries', () => {
+		expect(sanitizeSkillsUsed(['workflow-builder', 42, null, undefined, { x: 1 }])).toEqual([
+			'workflow-builder',
+		]);
+	});
+
+	test('drops entries longer than 128 chars', () => {
+		const tooLong = 'a'.repeat(129);
+		const justRight = 'a'.repeat(128);
+		expect(sanitizeSkillsUsed([tooLong, justRight, 'workflow-builder'])).toEqual([
+			justRight,
+			'workflow-builder',
+		]);
+	});
+
+	test('deduplicates after normalization', () => {
+		expect(
+			sanitizeSkillsUsed([
+				'workflow-builder',
+				'Workflow-Builder',
+				'  workflow-builder  ',
+				'node-selection',
+			]),
+		).toEqual(['workflow-builder', 'node-selection']);
+	});
+
+	test('caps the result at 50 entries without rejecting the input', () => {
+		const input = Array.from({ length: 60 }, (_, i) => `skill-${i}`);
+		const result = sanitizeSkillsUsed(input);
+		expect(result).toHaveLength(50);
+		expect(result?.[0]).toBe('skill-0');
+		expect(result?.[49]).toBe('skill-49');
+	});
+});

--- a/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
@@ -424,6 +424,63 @@ describe('update-workflow MCP tool', () => {
 			);
 		});
 
+		test('omits skillsUsed from telemetry when not provided', async () => {
+			await callHandler({
+				workflowId: 'wf-1',
+				operations: [{ type: 'setWorkflowMetadata', name: 'Renamed' }],
+			});
+
+			const trackedPayload = (telemetry.track as jest.Mock).mock.calls[0][1] as {
+				parameters: Record<string, unknown>;
+			};
+			expect(trackedPayload.parameters).not.toHaveProperty('skillsUsed');
+		});
+
+		test('omits skillsUsed from telemetry when an empty array is passed', async () => {
+			await callHandler({
+				workflowId: 'wf-1',
+				skillsUsed: [],
+				operations: [{ type: 'setWorkflowMetadata', name: 'Renamed' }],
+			});
+
+			const trackedPayload = (telemetry.track as jest.Mock).mock.calls[0][1] as {
+				parameters: Record<string, unknown>;
+			};
+			expect(trackedPayload.parameters).not.toHaveProperty('skillsUsed');
+		});
+
+		test('normalizes skillsUsed before tracking telemetry', async () => {
+			await callHandler({
+				workflowId: 'wf-1',
+				skillsUsed: ['  Workflow-Builder  ', 'workflow-builder', 'has spaces', 'NODE-SELECTION'],
+				operations: [{ type: 'setWorkflowMetadata', name: 'Renamed' }],
+			});
+
+			expect(telemetry.track).toHaveBeenCalledWith(
+				'User called mcp tool',
+				expect.objectContaining({
+					parameters: expect.objectContaining({
+						skillsUsed: ['workflow-builder', 'node-selection'],
+					}),
+				}),
+			);
+		});
+
+		test('does not reject the call when skillsUsed overflows the cap', async () => {
+			const oversized = Array.from({ length: 60 }, (_, i) => `skill-${i}`);
+			const result = await callHandler({
+				workflowId: 'wf-1',
+				skillsUsed: oversized,
+				operations: [{ type: 'setWorkflowMetadata', name: 'Renamed' }],
+			});
+
+			expect(result.isError).toBeUndefined();
+			const trackedPayload = (telemetry.track as jest.Mock).mock.calls[0][1] as {
+				parameters: { skillsUsed: string[] };
+			};
+			expect(trackedPayload.parameters.skillsUsed).toHaveLength(50);
+		});
+
 		test('tracks telemetry on failure', async () => {
 			const result = await callHandler({
 				workflowId: 'wf-1',

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
@@ -5,6 +5,7 @@ import { buildInvalidAiToolSourceErrorResponse } from './connection-structure-ch
 import { MCP_CREATE_WORKFLOW_FROM_CODE_TOOL, CODE_BUILDER_VALIDATE_TOOL } from './constants';
 import { autoPopulateNodeCredentials, stripNullCredentialStubs } from './credentials-auto-assign';
 import { validateDataTableReferencesForWorkflow } from './data-table-validation';
+import { sanitizeSkillsUsed } from './skills-used';
 import { USER_CALLED_MCP_TOOL_EVENT } from '../../mcp.constants';
 import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../../mcp.types';
 import { getSdkReferenceHint } from '../workflow-validation.utils';
@@ -26,11 +27,10 @@ const inputSchema = {
 			`Full TypeScript/JavaScript workflow code using the n8n Workflow SDK. Must be validated first with ${CODE_BUILDER_VALIDATE_TOOL.toolName}.`,
 		),
 	skillsUsed: z
-		.array(z.string().min(1).max(128))
-		.max(50)
+		.array(z.string())
 		.optional()
 		.describe(
-			'Names of n8n skills used by the MCP client to produce this workflow create call. Include only skills used since the previous successful workflow create/update call in the current conversation/session.',
+			'Names of n8n skills (lowercase kebab-case identifiers) used by the MCP client to produce this workflow create call. Server-side normalization will trim, lowercase, dedupe, and drop entries that are not valid skill identifiers.',
 		),
 	name: z
 		.string()
@@ -112,7 +112,7 @@ export const createCreateWorkflowFromCodeTool = (
 ): ToolDefinition<typeof inputSchema> => ({
 	name: MCP_CREATE_WORKFLOW_FROM_CODE_TOOL.toolName,
 	config: {
-		description: `Create a workflow in n8n from validated SDK code. This tool expects code that already follows the n8n Workflow SDK patterns and has passed ${CODE_BUILDER_VALIDATE_TOOL.toolName}. If code fails to parse, call get_sdk_reference, rewrite the code using the reference, validate again, then retry creation. If the user named a target project, resolve it via search_projects before calling this tool; when projectId is omitted, the workflow is created in the user's personal project. If you used n8n skills while preparing this workflow change, pass their names in skillsUsed, including only skills used since the last successful create/update workflow-builder tool call in this session. After creation, always tell the user which project the workflow landed in (see the targetProject field in the response).`,
+		description: `Create a workflow in n8n from validated SDK code. This tool expects code that already follows the n8n Workflow SDK patterns and has passed ${CODE_BUILDER_VALIDATE_TOOL.toolName}. If code fails to parse, call get_sdk_reference, rewrite the code using the reference, validate again, then retry creation. If the user named a target project, resolve it via search_projects before calling this tool; when projectId is omitted, the workflow is created in the user's personal project. If you used n8n skills while preparing this workflow, pass their identifiers in skillsUsed. After creation, always tell the user which project the workflow landed in (see the targetProject field in the response).`,
 		inputSchema,
 		outputSchema,
 		annotations: {
@@ -138,12 +138,13 @@ export const createCreateWorkflowFromCodeTool = (
 		projectId?: string;
 		folderId?: string;
 	}) => {
+		const sanitizedSkillsUsed = sanitizeSkillsUsed(skillsUsed);
 		const telemetryPayload: UserCalledMCPToolEventPayload = {
 			user_id: user.id,
 			tool_name: MCP_CREATE_WORKFLOW_FROM_CODE_TOOL.toolName,
 			parameters: {
 				codeLength: code.length,
-				...(skillsUsed !== undefined ? { skillsUsed } : {}),
+				...(sanitizedSkillsUsed !== undefined ? { skillsUsed: sanitizedSkillsUsed } : {}),
 				hasName: !!name,
 				hasProjectId: !!projectId,
 				hasFolderId: !!folderId,

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/skills-used.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/skills-used.ts
@@ -1,0 +1,27 @@
+// Conservative slug shape matching the Claude Code skill naming convention
+// (lowercase kebab-case, optional `namespace:name` form). Anything not matching
+// is dropped before reaching telemetry, so free-form text the LLM may have
+// stuffed into the field (PII, prompts, secrets) is filtered out.
+const SKILL_NAME_PATTERN = /^[a-z][a-z0-9]*(?:[-:][a-z0-9]+)*$/;
+const MAX_SKILLS_LOGGED = 50;
+const MAX_SKILL_NAME_LENGTH = 128;
+
+export function sanitizeSkillsUsed(input: unknown): string[] | undefined {
+	if (!Array.isArray(input)) return undefined;
+
+	const seen = new Set<string>();
+	const out: string[] = [];
+
+	for (const raw of input) {
+		if (typeof raw !== 'string') continue;
+		const normalized = raw.trim().toLowerCase();
+		if (normalized.length === 0 || normalized.length > MAX_SKILL_NAME_LENGTH) continue;
+		if (!SKILL_NAME_PATTERN.test(normalized)) continue;
+		if (seen.has(normalized)) continue;
+		seen.add(normalized);
+		out.push(normalized);
+		if (out.length >= MAX_SKILLS_LOGGED) break;
+	}
+
+	return out.length > 0 ? out : undefined;
+}

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/skills-used.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/skills-used.ts
@@ -1,10 +1,6 @@
-// Conservative slug shape matching the Claude Code skill naming convention
-// (lowercase kebab-case, optional `namespace:name` form). Anything not matching
-// is dropped before reaching telemetry, so free-form text the LLM may have
-// stuffed into the field (PII, prompts, secrets) is filtered out.
-const SKILL_NAME_PATTERN = /^[a-z][a-z0-9]*(?:[-:][a-z0-9]+)*$/;
+import { RUNTIME_SKILL_NAME_PATTERN } from '@n8n/agents';
+
 const MAX_SKILLS_LOGGED = 50;
-const MAX_SKILL_NAME_LENGTH = 128;
 
 export function sanitizeSkillsUsed(input: unknown): string[] | undefined {
 	if (!Array.isArray(input)) return undefined;
@@ -15,8 +11,7 @@ export function sanitizeSkillsUsed(input: unknown): string[] | undefined {
 	for (const raw of input) {
 		if (typeof raw !== 'string') continue;
 		const normalized = raw.trim().toLowerCase();
-		if (normalized.length === 0 || normalized.length > MAX_SKILL_NAME_LENGTH) continue;
-		if (!SKILL_NAME_PATTERN.test(normalized)) continue;
+		if (!RUNTIME_SKILL_NAME_PATTERN.test(normalized)) continue;
 		if (seen.has(normalized)) continue;
 		seen.add(normalized);
 		out.push(normalized);

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -9,6 +9,7 @@ import { MCP_UPDATE_WORKFLOW_TOOL } from './constants';
 import { validateCredentialReferences } from './credential-validation';
 import { autoPopulateNodeCredentials } from './credentials-auto-assign';
 import { validateDataTableReferencesForUpdate } from './data-table-validation';
+import { sanitizeSkillsUsed } from './skills-used';
 import {
 	applyOperations,
 	partialUpdateOperationSchema,
@@ -61,11 +62,10 @@ function collectTouchedNodes(operations: PartialUpdateOperation[]): Map<string, 
 const inputSchema = {
 	workflowId: z.string().describe('The ID of the workflow to update.'),
 	skillsUsed: z
-		.array(z.string().min(1).max(128))
-		.max(50)
+		.array(z.string())
 		.optional()
 		.describe(
-			'Names of n8n skills used by the MCP client to produce this workflow update call. Include only skills used since the previous successful workflow create/update call in the current conversation/session.',
+			'Names of n8n skills (lowercase kebab-case identifiers) used by the MCP client to produce this workflow update call. Server-side normalization will trim, lowercase, dedupe, and drop entries that are not valid skill identifiers.',
 		),
 	operations: z
 		.array(partialUpdateOperationSchema)
@@ -130,7 +130,7 @@ export const createUpdateWorkflowTool = (
 	name: MCP_UPDATE_WORKFLOW_TOOL.toolName,
 	config: {
 		description:
-			'Apply a small list of operations to an existing workflow (see the operations input schema for the supported op types). The whole batch is atomic: if any op fails the workflow is left unchanged. If you used n8n skills while preparing this workflow change, pass their names in skillsUsed, including only skills used since the last successful create/update workflow-builder tool call in this session.',
+			'Apply a small list of operations to an existing workflow (see the operations input schema for the supported op types). The whole batch is atomic: if any op fails the workflow is left unchanged. If you used n8n skills while preparing this update, pass their identifiers in skillsUsed.',
 		inputSchema,
 		outputSchema,
 		annotations: {
@@ -150,12 +150,13 @@ export const createUpdateWorkflowTool = (
 		skillsUsed?: string[];
 		operations: PartialUpdateOperation[];
 	}) => {
+		const sanitizedSkillsUsed = sanitizeSkillsUsed(skillsUsed);
 		const telemetryPayload: UserCalledMCPToolEventPayload = {
 			user_id: user.id,
 			tool_name: MCP_UPDATE_WORKFLOW_TOOL.toolName,
 			parameters: {
 				workflowId,
-				...(skillsUsed !== undefined ? { skillsUsed } : {}),
+				...(sanitizedSkillsUsed !== undefined ? { skillsUsed: sanitizedSkillsUsed } : {}),
 				opCount: operations.length,
 				opTypes: operations.map((op) => op.type),
 			},


### PR DESCRIPTION
## Summary

Stacked on top of #31625. Hardens the new `skillsUsed` MCP tool input before it lands in telemetry, in response to review feedback on the parent PR.

- New `sanitizeSkillsUsed()` helper at `packages/cli/src/modules/mcp/tools/workflow-builder/skills-used.ts`: trims, lowercases, dedupes, caps at 50 entries, and drops anything that doesn't match the kebab-case skill identifier pattern (`/^[a-z][a-z0-9]*(?:[-:][a-z0-9]+)*$/`). Returns `undefined` for empty/all-invalid input so the telemetry payload omits the key rather than recording `skillsUsed: []`.
- Both `create_workflow_from_code` and `update_workflow` schemas relaxed from `z.array(z.string().min(1).max(128)).max(50).optional()` to `z.array(z.string()).optional()`. Validation now lives in the sanitizer, so a malformed list never rejects the whole tool call (this is telemetry-only metadata; failing the user's workflow create/update for it would be the wrong tradeoff).
- Tool descriptions tightened: the "include only skills used since the last successful call" clause was removed. The server has no session state to enforce it and different MCP clients will interpret it differently, biasing the analytics this field exists to produce.

### Why

The parent PR ships an LLM-controlled string array straight into the PostHog event. Without server-side sanitization, the field is a quiet PII / secret exfiltration channel (prompt-injected or hallucinating clients can stuff arbitrary content into "skill names"), and even well-behaved clients can fragment dashboards via whitespace, casing, Unicode-confusable variants, or duplicates.

### Tests

- New unit test file `packages/cli/src/modules/mcp/__tests__/skills-used.test.ts` covering every branch of the sanitizer (non-array, empty, all-invalid, valid kebab-case, namespaced, trim/lowercase, disallowed chars, non-strings, length cap, dedupe, overflow cap).
- Added to both tool test files: omitted-key negative path, empty-array negative path, mixed valid/invalid normalization, and 60-item overflow (asserts the call still succeeds and the recorded list is exactly 50).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5303

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)