### PR TITLE
fix(Read/Write Files from Disk Node): Escape square brackets in file selector

### DIFF
--- a/packages/nodes-base/nodes/Files/ReadWriteFile/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Files/ReadWriteFile/helpers/utils.ts
@@ -35,10 +35,10 @@ export function errorMapper(
 }
 
 export function escapeSpecialCharacters(str: string) {
-	// Escape parentheses
-	str = str.replace(/[()]/g, '\\$&');
-
-	return str;
+	// fast-glob treats parens and square brackets as glob metacharacters,
+	// but both show up routinely in real file names (especially on Windows)
+	// where users mean them literally, not as patterns.
+	return str.replace(/[()[\]]/g, '\\$&');
 }
 
 export function normalizeFileSelector(fileSelectorRaw: string) {

--- a/packages/nodes-base/nodes/Files/ReadWriteFile/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Files/ReadWriteFile/test/utils.test.ts
@@ -8,7 +8,19 @@ describe('Read/Write Files from Disk', () => {
 			expect(escapeSpecialCharacters(input)).toBe(expectedOutput);
 		});
 
-		it('should not modify strings that do not contain parentheses', () => {
+		it('should escape square brackets in a string', () => {
+			const input = '/home/michael/Desktop/[draft] notes.txt';
+			const expectedOutput = '/home/michael/Desktop/\\[draft\\] notes.txt';
+			expect(escapeSpecialCharacters(input)).toBe(expectedOutput);
+		});
+
+		it('should escape both parentheses and brackets when both are present', () => {
+			const input = '/home/michael/Desktop/test (1) [v2].txt';
+			const expectedOutput = '/home/michael/Desktop/test \\(1\\) \\[v2\\].txt';
+			expect(escapeSpecialCharacters(input)).toBe(expectedOutput);
+		});
+
+		it('should not modify strings that do not contain parentheses or brackets', () => {
 			const input = '/home/michael/Desktop/test.txt';
 			const expectedOutput = '/home/michael/Desktop/test.txt';
 			expect(escapeSpecialCharacters(input)).toBe(expectedOutput);
@@ -37,6 +49,14 @@ describe('Read/Write Files from Disk', () => {
 		it('should normalize Windows file selector with /', () => {
 			const input = 'C:/Users/michael/Desktop/test.txt';
 			const expectedOutput = 'C:/Users/michael/Desktop/test.txt';
+			expect(normalizeFileSelector(input)).toBe(expectedOutput);
+		});
+
+		it('should normalize a Windows file selector that contains brackets in folder names', () => {
+			const input =
+				'C:\\Users\\Administrator\\Desktop\\Manga\\Complete\\VTuber Legend [J-Novel Club] [Antithetical]\\list.txt';
+			const expectedOutput =
+				'C:/Users/Administrator/Desktop/Manga/Complete/VTuber Legend \\[J-Novel Club\\] \\[Antithetical\\]/list.txt';
 			expect(normalizeFileSelector(input)).toBe(expectedOutput);
 		});
 	});


### PR DESCRIPTION
## Summary

Reading a file whose path contains `[` or `]` fails on **Read/Write Files from Disk**
with "No file(s) found", even though the path is correct and the file exists.
This is a 1.x → 2.x regression specifically affecting Windows users, where
brackets are common in folder names (releases, tags, dated subfolders, etc.).

### Root cause

`normalizeFileSelector` converts `\` → `/` (so the path can be passed to
`fast-glob`/`picomatch`), and then calls `escapeSpecialCharacters` to protect
glob metacharacters that real filenames often contain.

That helper only escaped `(` and `)`. Square brackets weren't escaped, so a path
like `…/VTuber Legend [J-Novel Club] [Antithetical]/list.txt` was interpreted by
picomatch as a character-class glob and matched no real files.

### Fix

Extend `escapeSpecialCharacters` to also escape `[` and `]`. This keeps the
existing policy (escape glob meta that commonly appears in real filenames) and
mirrors the workaround community members had been doing manually in
expressions.

The `*` and `?` wildcards still work for users who intentionally write
patterns.

## How to test

1. Create a folder with brackets in the name, e.g. `C:\temp\[release]\readme.txt`.
2. Workflow: Read/Write Files from Disk → operation **Read** → File(s) Selector
   `C:\temp\[release]\readme.txt`.
3. Execute. **Before:** "No file(s) found". **After:** the file is read.

## Related Linear tickets, Github issues, and Community forum posts

Fixes #30278


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)