### PR TITLE
fix(core): Normalize data table date offsets (no-changelog)

### DIFF
--- a/packages/cli/src/modules/data-table/__tests__/sql-utils.test.ts
+++ b/packages/cli/src/modules/data-table/__tests__/sql-utils.test.ts
@@ -84,6 +84,32 @@ describe('sql-utils', () => {
 			expect(result[0].updatedAt).toEqual(new Date(dateString));
 		});
 
+		it('should normalize date values from ISO strings with timezone offsets', () => {
+			const columns = [createColumn('birthday', 'date')];
+			const dateString = '2024-01-15T10:30:00.000+02:00';
+			const expectedDate = new Date('2024-01-15T08:30:00.000Z');
+			const rows = [{ id: 1, birthday: dateString, createdAt: dateString, updatedAt: dateString }];
+
+			const result = normalizeRows(rows, columns);
+
+			expect(result[0].birthday).toEqual(expectedDate);
+			expect(result[0].createdAt).toEqual(expectedDate);
+			expect(result[0].updatedAt).toEqual(expectedDate);
+		});
+
+		it('should normalize date values from postgres timestamptz strings', () => {
+			const columns = [createColumn('birthday', 'date')];
+			const dateString = '2024-01-15 10:30:00+02';
+			const expectedDate = new Date('2024-01-15T08:30:00.000Z');
+			const rows = [{ id: 1, birthday: dateString, createdAt: dateString, updatedAt: dateString }];
+
+			const result = normalizeRows(rows, columns);
+
+			expect(result[0].birthday).toEqual(expectedDate);
+			expect(result[0].createdAt).toEqual(expectedDate);
+			expect(result[0].updatedAt).toEqual(expectedDate);
+		});
+
 		it('should normalize date values from strings of sqlite format', () => {
 			const columns = [createColumn('birthday', 'date')];
 			const dateString = '2024-01-15 10:30:00';

--- a/packages/cli/src/modules/data-table/utils/sql-utils.ts
+++ b/packages/cli/src/modules/data-table/utils/sql-utils.ts
@@ -200,13 +200,33 @@ function normalizeBoolean<T>(value: T): T | boolean {
 	return value;
 }
 
+function dateStringHasExplicitTimezone(dateString: string) {
+	const separatorIndex = dateString.includes('T')
+		? dateString.indexOf('T')
+		: dateString.search(/\s/);
+	if (separatorIndex === -1) return false;
+
+	const timePart = dateString.slice(separatorIndex + 1);
+	if (!timePart.includes(':')) return false;
+
+	return (
+		timePart.endsWith('Z') ||
+		timePart.endsWith('z') ||
+		timePart.includes('+') ||
+		timePart.includes('-')
+	);
+}
+
 // Convert date objects or strings to dates in UTC
 export function normalizeDate(value: unknown): Date | null {
 	if (value instanceof Date) return value;
 
 	if (typeof value === 'string') {
+		const dateString = value.trim();
 		// sqlite returns date strings without timezone information, but we store them as UTC
-		const parsed = new Date(value.endsWith('Z') ? value : value + 'Z');
+		const parsed = new Date(
+			dateStringHasExplicitTimezone(dateString) ? dateString : `${dateString}Z`,
+		);
 		if (!isNaN(parsed.getTime())) return parsed;
 	}
 


### PR DESCRIPTION
## Summary

Fix data table date normalization so string values that already include a timezone offset are parsed directly instead of appending `Z`. Timezone-less date strings continue to be treated as UTC for existing SQLite and timestamp-column behavior.

This issue is latent in normal Postgres API/UI usage because the driver usually returns timestamp and timestamptz values as JavaScript `Date` objects, so `normalizeDate()` exits before parsing a string. The unsafe path still exists for textual timestamptz values: appending `Z` to a value that already has an offset can either make ISO strings invalid or make Postgres-style strings resolve to the wrong instant.

## Related Linear tickets, Github issues, and Community forum posts

N/A - no Linear ticket, GitHub issue, or Community forum post was provided.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
