### PR TITLE
feat(NVIDIA Nemotron Chat Model Node): Restrict model selector to supported models

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatNvidia/LmChatNvidia.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatNvidia/LmChatNvidia.node.ts
@@ -16,12 +16,18 @@ import {
 import type { OpenAICompatibleCredential } from '../../../types/types';
 import { openAiFailedAttemptHandler } from '../../vendors/OpenAi/helpers/error-handling';
 
-const NEMOTRON_FALLBACK_MODELS = [
-	'nvidia/llama-3.3-nemotron-super-49b-v1',
-	'nvidia/llama-3.1-nemotron-70b-instruct',
+// Allow-list of supported Nemotron chat models. The selector fetches the live
+// catalog from the API and reduces it to these ids; if the fetch fails, this
+// same list is shown as the static fallback.
+const NEMOTRON_SUPPORTED_MODELS = [
 	'nvidia/llama-3.1-nemotron-nano-8b-v1',
-	'nvidia/nemotron-4-340b-instruct',
-	'nvidia/nemotron-mini-4b-instruct',
+	'nvidia/llama-3.3-nemotron-super-49b-v1',
+	'nvidia/llama-3.3-nemotron-super-49b-v1.5',
+	'nvidia/nemotron-3-nano-30b-a3b',
+	'nvidia/nemotron-3-nano-omni-30b-a3b-reasoning',
+	'nvidia/nemotron-3-super-120b-a12b',
+	'nvidia/nemotron-nano-12b-v2-vl',
+	'nvidia/nvidia-nemotron-nano-9b-v2',
 ];
 
 export class LmChatNvidia implements INodeType {
@@ -103,7 +109,7 @@ export class LmChatNvidia implements INodeType {
 									{
 										type: 'filter',
 										properties: {
-											pass: '={{ /nemotron/i.test($responseItem.id) }}',
+											pass: `={{ ${JSON.stringify(NEMOTRON_SUPPORTED_MODELS)}.includes($responseItem.id) }}`,
 										},
 									},
 									{
@@ -131,7 +137,7 @@ export class LmChatNvidia implements INodeType {
 					},
 				},
 				default: 'nvidia/llama-3.3-nemotron-super-49b-v1',
-				options: NEMOTRON_FALLBACK_MODELS.map((id) => ({ name: id, value: id })),
+				options: NEMOTRON_SUPPORTED_MODELS.map((id) => ({ name: id, value: id })),
 			},
 			{
 				displayName: 'Options',

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatNvidia/test/LmChatNvidia.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatNvidia/test/LmChatNvidia.test.ts
@@ -46,7 +46,7 @@ describe('LmChatNvidia', () => {
 		});
 		ctx.getNode = vi.fn().mockReturnValue(nodeDef);
 		ctx.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
-			if (paramName === 'model') return 'nvidia/llama-3.1-nemotron-70b-instruct';
+			if (paramName === 'model') return 'nvidia/llama-3.3-nemotron-super-49b-v1';
 			if (paramName === 'options') return {};
 			return undefined;
 		});
@@ -80,13 +80,36 @@ describe('LmChatNvidia', () => {
 			expect(node.description.outputNames).toEqual(['Model']);
 		});
 
-		it('should filter to Nemotron models in loadOptions', () => {
+		it('should reduce the fetched catalog to the supported allow-list in loadOptions', () => {
 			const modelProp = node.description.properties.find((p) => p?.name === 'model');
 			expect(modelProp).toBeDefined();
 			const postReceive = (modelProp?.typeOptions as any)?.loadOptions?.routing?.output
 				?.postReceive as Array<{ type: string; properties: { pass?: string } }>;
 			const filterStep = postReceive.find((step) => step.type === 'filter');
-			expect(filterStep?.properties.pass).toMatch(/nemotron/i);
+			const pass = filterStep?.properties.pass ?? '';
+
+			// The filter keeps only ids present in the allow-list (built from the same
+			// constant that backs the static options), excluding e.g. reward models.
+			const supported = ((modelProp as any)?.options as Array<{ value: string }>).map(
+				(o) => o.value,
+			);
+			expect(pass).toContain('.includes($responseItem.id)');
+			for (const id of supported) {
+				expect(pass).toContain(id);
+			}
+			expect(pass).not.toContain('nemotron-70b-reward');
+		});
+
+		it('should expose the supported models as static fallback options', () => {
+			const modelProp = node.description.properties.find((p) => p?.name === 'model');
+			const options = (modelProp as any)?.options as Array<{ name: string; value: string }>;
+			const values = options.map((o) => o.value);
+
+			expect(values).toContain('nvidia/llama-3.3-nemotron-super-49b-v1');
+			expect(values).toContain('nvidia/nemotron-3-super-120b-a12b');
+			expect(values).not.toContain('nvidia/llama-3.1-nemotron-70b-reward');
+			// The default must be one of the offered options.
+			expect(values).toContain((modelProp as any)?.default);
 		});
 	});
 
@@ -100,7 +123,7 @@ describe('LmChatNvidia', () => {
 			expect(MockedChatOpenAI).toHaveBeenCalledWith(
 				expect.objectContaining({
 					apiKey: 'test-key',
-					model: 'nvidia/llama-3.1-nemotron-70b-instruct',
+					model: 'nvidia/llama-3.3-nemotron-super-49b-v1',
 					configuration: expect.objectContaining({
 						baseURL: 'https://integrate.api.nvidia.com/v1',
 					}),
@@ -138,7 +161,7 @@ describe('LmChatNvidia', () => {
 		it('should pass options through to ChatOpenAI', async () => {
 			const ctx = setupMockContext();
 			ctx.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
-				if (paramName === 'model') return 'nvidia/llama-3.1-nemotron-70b-instruct';
+				if (paramName === 'model') return 'nvidia/llama-3.3-nemotron-super-49b-v1';
 				if (paramName === 'options')
 					return {
 						temperature: 0.5,
@@ -170,7 +193,7 @@ describe('LmChatNvidia', () => {
 		it('should set response_format in modelKwargs when responseFormat is provided', async () => {
 			const ctx = setupMockContext();
 			ctx.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
-				if (paramName === 'model') return 'nvidia/llama-3.1-nemotron-70b-instruct';
+				if (paramName === 'model') return 'nvidia/llama-3.3-nemotron-super-49b-v1';
 				if (paramName === 'options') return { responseFormat: 'json_object' };
 				return undefined;
 			});


### PR DESCRIPTION
## Summary

The NVIDIA Nemotron Chat Model node's model selector previously listed **any** model returned by the NVIDIA `/v1/models` catalog whose id matched the substring regex `/nemotron/i`. Because the API exposes no field that distinguishes a chat model from a reward/embedding/safety model (every entry is just `"object": "model"`), this leaked non-chat models such as `nvidia/llama-3.1-nemotron-70b-reward` into the dropdown.

This PR replaces the substring filter with an explicit **allow-list** of supported Nemotron chat models.

### Behaviour

- **API succeeds** → the selector fetches the live `/v1/models` catalog and reduces it to the ids in the allow-list (sorted). Anything not on the list is hidden.
- **API fails** → the selector falls back to the same allow-list rendered as static options.
- Default remains `nvidia/llama-3.3-nemotron-super-49b-v1`.

### Supported models (allow-list)

```
nvidia/llama-3.1-nemotron-nano-8b-v1
nvidia/llama-3.3-nemotron-super-49b-v1
nvidia/llama-3.3-nemotron-super-49b-v1.5
nvidia/nemotron-3-nano-30b-a3b
nvidia/nemotron-3-nano-omni-30b-a3b-reasoning
nvidia/nemotron-3-super-120b-a12b
nvidia/nemotron-nano-12b-v2-vl
nvidia/nvidia-nemotron-nano-9b-v2
```

### Changes

- `LmChatNvidia.node.ts`: replaced `NEMOTRON_FALLBACK_MODELS` with `NEMOTRON_SUPPORTED_MODELS`; changed the `filter` postReceive step from `/nemotron/i.test(...)` to an allow-list membership check built from the same constant (single source of truth for the dynamic filter and static fallback).
- `LmChatNvidia.test.ts`: updated/added tests for allow-list filtering and static fallback options.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-13

## Screenshots

<img width="1842" height="943" alt="image" src="https://github.com/user-attachments/assets/f873b5d5-cecf-465f-a8f5-9155ae256f5a" />

(new models in dropdown are now restricted per models provided by Nvidia)

## How to test

### Automated

```bash
cd packages/@n8n/nodes-langchain
pnpm test LmChatNvidia
pnpm lint
```

All tests should pass with no lint errors.

### Manual — happy path (API reachable)

1. Get an NVIDIA API key from https://build.nvidia.com (free tier works).
2. Run n8n locally (`pnpm dev`), add an **AI Agent** node, and attach an **NVIDIA Nemotron Chat Model** sub-node.
3. Create an `nvidiaApi` credential with Base URL `https://integrate.api.nvidia.com/v1`.
4. Open the **Model** dropdown:
   - ✅ Only the 8 supported models appear.
   - ✅ Non-chat entries (e.g. `nvidia/llama-3.1-nemotron-70b-reward`) are not listed.
   - ✅ The list is sorted alphabetically.
5. Select a model, send a test prompt, and confirm a completion is returned.

### Manual — API failure / fallback path

Set the credential Base URL to an unreachable host (e.g. `https://integrate.api.nvidia.com/v1-does-not-exist`), or use an invalid API key, or go offline, then open the **Model** dropdown.

- ✅ The dropdown still shows the 8 supported models (static fallback).

### Manual — self-hosted NIM (optional)

Point the credential at a self-hosted NIM (`http://localhost:8000/v1`).

- ✅ A served model appears only if its id is in the allow-list.
- ⚠️ A self-hosted NIM serving a Nemotron model with a custom id outside the allow-list will have that id hidden. This is the intended trade-off of an allow-list; flagging in case we want a follow-up to relax it for self-hosted deployments.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
