### PR TITLE
fix(editor): Persist switching workflow credential resolver back to system resolver

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings/WorkflowSettings.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings/WorkflowSettings.test.ts
@@ -988,6 +988,40 @@ describe('WorkflowSettingsVue', () => {
 			);
 		});
 
+		it('should save with empty credentialResolverId when switching back to the system resolver', async () => {
+			workflowDocumentStore.setSettings({ credentialResolverId: 'resolver-1' });
+
+			const { getByTestId, getByRole } = createComponent({ pinia });
+			await flushPromises();
+
+			await waitFor(() => {
+				expect(restApiClient.getCredentialResolvers).toHaveBeenCalled();
+			});
+
+			// Open the dropdown and pick the n8n system resolver
+			const resolverContainer = getByTestId('workflow-settings-credential-resolver');
+			await userEvent.click(within(resolverContainer).getByRole('combobox'));
+
+			await waitFor(async () => {
+				const options = within(document.body as HTMLElement).getAllByRole('option');
+				const systemResolver = options.find((o) => o.textContent?.includes('N8n Resolver'));
+				expect(systemResolver).toBeTruthy();
+				await userEvent.click(systemResolver!);
+			});
+			await flushPromises();
+
+			await userEvent.click(getByRole('button', { name: 'Save' }));
+
+			// `undefined` would be stripped during serialization and the merge on the backend
+			// would keep the old id, so the clear must be sent as an explicit empty string.
+			expect(workflowsStore.updateWorkflow).toHaveBeenCalledWith(
+				'1',
+				expect.objectContaining({
+					settings: expect.objectContaining({ credentialResolverId: '' }),
+				}),
+			);
+		});
+
 		it('should disable credential resolver dropdown when environment is read-only', async () => {
 			sourceControlStore.preferences.branchReadOnly = true;
 

--- a/packages/frontend/editor-ui/src/app/components/WorkflowSettings/WorkflowSettings.vue
+++ b/packages/frontend/editor-ui/src/app/components/WorkflowSettings/WorkflowSettings.vue
@@ -712,6 +712,14 @@ const saveSettings = async () => {
 	}
 	delete data.settings.maxExecutionTimeout;
 
+	// `credentialResolverId` is `undefined` in-memory when the n8n system resolver is
+	// selected. The backend merges settings for partial updates, so an absent key keeps
+	// the previously-saved id. Send an explicit empty string so the merge clears it
+	// (the backend drops the falsy value before persisting).
+	if (isCredentialResolverEnabled.value && !data.settings.credentialResolverId) {
+		data.settings.credentialResolverId = '';
+	}
+
 	isLoading.value = true;
 	data.versionId = workflowDocumentStore.value.versionId;
 	data.expectedChecksum = workflowDocumentStore.value.checksum;


### PR DESCRIPTION
## Summary

When switching a workflow's credential resolver from a custom resolver back to the **n8n system resolver** in Workflow Settings, the change was not persisted on save — after reopening the settings, the workflow was still bound to the previously-selected custom resolver.

**Root cause:** The backend merges workflow settings to support partial updates (`packages/cli/src/workflows/workflow.service.ts`):

```ts
workflowUpdateData.settings = { ...workflow.settings, ...workflowUpdateData.settings };
```

The frontend represents "system resolver selected" as `credentialResolverId = undefined` in-memory (`WorkflowSettings.vue`). Because `undefined` values are dropped during JSON serialization, the key never reached the backend, and the merge silently re-applied the previously-saved custom resolver id. The backend already knows how to clear a falsy/empty `credentialResolverId` (in `removeDefaultValues`), but the frontend never sent a serializable clear signal.

**Fix:** At the save boundary in `WorkflowSettings.vue`, send an explicit empty string instead of `undefined` when the resolver feature is enabled and no resolver is selected, so the merge actually clears the stored value:

```ts
if (isCredentialResolverEnabled.value && !data.settings.credentialResolverId) {
  data.settings.credentialResolverId = '';
}
```

### How to test
1. Open a workflow that has a custom credential resolver selected in Workflow Settings.
2. Change the resolver dropdown back to the n8n system resolver.
3. Save the settings.
4. Reopen Workflow Settings — the workflow should now use the system resolver (not the custom one).

A regression test was added in `WorkflowSettings.test.ts` (`should save with empty credentialResolverId when switching back to the system resolver`), verified to fail before the fix and pass after.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-755

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI