### PR TITLE
fix(editor): Show switch-to-static warning after connecting a private credential

### DIFF
--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.test.ts
@@ -13,6 +13,7 @@ import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import type { ICredentialsResponse } from '../../credentials.types';
 import { within, waitFor } from '@testing-library/vue';
+import userEvent from '@testing-library/user-event';
 import type { ICredentialType, INode, INodeTypeDescription } from 'n8n-workflow';
 
 vi.mock('vue-router', async () => ({
@@ -31,6 +32,17 @@ vi.mock('@/app/composables/useToast', () => ({
 		showMessage: vi.fn(),
 	}),
 }));
+
+const { confirmMock } = vi.hoisted(() => ({ confirmMock: vi.fn() }));
+
+vi.mock('@/app/composables/useMessage', () => ({
+	useMessage: () => ({ confirm: confirmMock }),
+}));
+
+vi.mock('@/features/resolvers/composables/useDynamicCredentials', async () => {
+	const { ref } = await vi.importActual<typeof import('vue')>('vue');
+	return { useDynamicCredentials: () => ({ isEnabled: ref(true) }) };
+});
 
 const oAuth2Api: ICredentialType = {
 	name: 'oAuth2Api',
@@ -945,6 +957,61 @@ describe('CredentialEdit', () => {
 
 			await retry(() => expect(credentialsStore.getCredentialData).toHaveBeenCalled());
 			await retry(() => expect(queryByTestId('oauth-not-connected-banner')).not.toBeVisible());
+		});
+
+		describe('switching a connected private credential to static', () => {
+			test('shows the confirmation modal when the current user just connected, even if the server count is stale', async () => {
+				confirmMock.mockResolvedValue('confirm');
+				const pinia = createPiniaForBannerTest();
+				// connectedByMe reflects the in-session connection; connectedUserCount is the
+				// stale server value (0) that does not yet include the current user.
+				const credentialsStore = setupOAuthCredential({
+					isResolvable: true,
+					connectedByMe: true,
+					connectedUserCount: 0,
+				});
+
+				const { getByRole } = renderComponent({
+					props: {
+						activeId: 'cred-banner',
+						modalName: CREDENTIAL_EDIT_MODAL_KEY,
+						mode: 'edit',
+					},
+					pinia,
+				});
+
+				await retry(() => expect(credentialsStore.getCredentialData).toHaveBeenCalled());
+
+				await userEvent.click(getByRole('switch'));
+
+				await retry(() => expect(confirmMock).toHaveBeenCalled());
+				expect(confirmMock.mock.calls[0][0]).toContain('1 user(s)');
+			});
+
+			test('does not show the confirmation modal when no users are connected', async () => {
+				confirmMock.mockResolvedValue('confirm');
+				const pinia = createPiniaForBannerTest();
+				const credentialsStore = setupOAuthCredential({
+					isResolvable: true,
+					connectedByMe: false,
+					connectedUserCount: 0,
+				});
+
+				const { getByRole } = renderComponent({
+					props: {
+						activeId: 'cred-banner',
+						modalName: CREDENTIAL_EDIT_MODAL_KEY,
+						mode: 'edit',
+					},
+					pinia,
+				});
+
+				await retry(() => expect(credentialsStore.getCredentialData).toHaveBeenCalled());
+
+				await userEvent.click(getByRole('switch'));
+
+				expect(confirmMock).not.toHaveBeenCalled();
+			});
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -785,8 +785,12 @@ async function onResolvableChange(value: boolean) {
 			return;
 		}
 	} else if (isTogglingToStatic) {
-		// Private → Static: warn only when there are connected users to disconnect
-		const connectedUserCount = currentCredential.value?.connectedUserCount ?? 0;
+		// Private → Static: warn only when there are connected users to disconnect.
+		// `connectedUserCount` reflects the server state at modal-open and isn't
+		// refreshed when the current user connects within the same session, so fold
+		// in `connectedByMe` to make sure the warning still appears in that case.
+		const serverConnectedCount = currentCredential.value?.connectedUserCount ?? 0;
+		const connectedUserCount = Math.max(serverConnectedCount, connectedByMe.value ? 1 : 0);
 		if (connectedUserCount > 0) {
 			const confirmAction = await confirmModal('switchToStatic', {
 				count: String(connectedUserCount),


### PR DESCRIPTION
## Summary

In the credential edit modal, switching a credential from **private** (dynamic/resolvable) to **static** shows a confirmation modal warning that connected users will be disconnected — but only when `connectedUserCount > 0`. That count is read from the server state at modal-open and is not refreshed when the current user connects their own account within the same session, so switching to static immediately after connecting silently skipped the confirmation. This change folds the in-session `connectedByMe` flag into the effective connected count so the warning still appears.

## How to test

1. Open the credential edit modal for an OAuth credential with dynamic credentials enabled.
2. Toggle the credential to **private** (dynamic) and connect your own account.
3. Immediately toggle back to **static** — the "Switch to Static?" confirmation modal now appears (previously it did not).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-757

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI