### PR TITLE
fix(editor): Suppress error toasts for Instance AI executions

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.test.ts
@@ -34,11 +34,14 @@ const opts = {
 	router: mock<Router>(),
 };
 
-const mockShowMessage = vi.fn();
+const { mockShowMessage, mockUseToast } = vi.hoisted(() => {
+	const showMessage = vi.fn();
+	const useToast = vi.fn(() => ({ showMessage }));
+
+	return { mockShowMessage: showMessage, mockUseToast: useToast };
+});
 vi.mock('@/app/composables/useToast', () => ({
-	useToast: () => ({
-		showMessage: mockShowMessage,
-	}),
+	useToast: mockUseToast,
 }));
 
 vi.mock('@/app/composables/useDocumentTitle', () => ({
@@ -847,6 +850,77 @@ describe('manual execution stats tracking', () => {
 			);
 
 			expect(incrementSpy).toHaveBeenCalledWith('error');
+		});
+
+		it('suppresses execution error toasts for matched execution ids', () => {
+			const pinia = createTestingPinia();
+			setActivePinia(pinia);
+
+			const builderStore = mockedStore(useBuilderStore);
+			const incrementSpy = vi.spyOn(builderStore, 'incrementManualExecutionStats');
+			const executionErrorToastSuppression = {
+				shouldSuppressExecutionErrorToast: vi.fn(
+					(executionId: string) => executionId === 'exec-ai',
+				),
+				clearExecutionErrorToastSuppression: vi.fn(),
+			};
+
+			const execution = mock<SimplifiedExecution>({
+				id: 'exec-ai',
+				status: 'error',
+				data: {
+					resultData: {
+						error: { message: 'test error', name: 'Error' },
+					},
+				},
+			});
+
+			handleExecutionFinishedWithErrorOrCanceled(
+				execution,
+				mock<IRunExecutionData>({ resultData: { error: { message: 'test', name: 'Error' } } }),
+				executionErrorToastSuppression,
+			);
+
+			expect(mockShowMessage).not.toHaveBeenCalled();
+			expect(executionErrorToastSuppression.shouldSuppressExecutionErrorToast).toHaveBeenCalledWith(
+				'exec-ai',
+			);
+			expect(incrementSpy).toHaveBeenCalledWith('error');
+		});
+
+		it('shows execution error toasts for unmatched execution ids', () => {
+			const pinia = createTestingPinia();
+			setActivePinia(pinia);
+
+			const executionErrorToastSuppression = {
+				shouldSuppressExecutionErrorToast: vi.fn(
+					(executionId: string) => executionId === 'exec-ai',
+				),
+				clearExecutionErrorToastSuppression: vi.fn(),
+			};
+
+			const execution = mock<SimplifiedExecution>({
+				id: 'exec-manual',
+				status: 'error',
+				data: {
+					resultData: {
+						error: { message: 'test error', name: 'Error' },
+					},
+				},
+			});
+
+			handleExecutionFinishedWithErrorOrCanceled(
+				execution,
+				mock<IRunExecutionData>({ resultData: { error: { message: 'test', name: 'Error' } } }),
+				executionErrorToastSuppression,
+			);
+
+			expect(mockShowMessage).toHaveBeenCalledWith(
+				expect.objectContaining({ type: 'error', duration: 0 }),
+			);
+			expect(executionErrorToastSuppression.shouldSuppressExecutionErrorToast).toHaveBeenCalledWith(
+				'exec-manual',
+			);
 		});
 
 		it('does not increment stats for canceled executions', () => {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -49,6 +49,7 @@ import {
 import type { useRouter } from 'vue-router';
 import { type WorkflowState } from '@/app/composables/useWorkflowState';
 import { useDocumentTitle } from '@/app/composables/useDocumentTitle';
+import type { ExecutionErrorToastSuppression } from '@/app/constants/injectionKeys';
 
 export type SimplifiedExecution = Pick<
 	IExecutionResponse,
@@ -58,6 +59,7 @@ export type SimplifiedExecution = Pick<
 export type ExecutionFinishedOptions = {
 	router: ReturnType<typeof useRouter>;
 	workflowState: WorkflowState;
+	executionErrorToastSuppression?: ExecutionErrorToastSuppression | null;
 };
 
 /**
@@ -153,13 +155,21 @@ export async function executionFinished(
 	if (execution.data?.waitTill !== undefined) {
 		handleExecutionFinishedWithWaitTill(data.workflowId, options);
 	} else if (execution.status === 'error' || execution.status === 'canceled') {
-		handleExecutionFinishedWithErrorOrCanceled(execution, runExecutionData);
+		handleExecutionFinishedWithErrorOrCanceled(
+			execution,
+			runExecutionData,
+			options.executionErrorToastSuppression,
+		);
 	} else {
 		handleExecutionFinishedWithSuccessOrOther(
 			options.workflowState,
 			execution.status,
 			successToastAlreadyShown,
 		);
+	}
+
+	if (execution.data?.waitTill === undefined) {
+		options.executionErrorToastSuppression?.clearExecutionErrorToastSuppression(execution.id);
 	}
 
 	setRunExecutionData(execution, runExecutionData, options.workflowState);
@@ -317,6 +327,7 @@ export function handleExecutionFinishedWithWaitTill(
 export function handleExecutionFinishedWithErrorOrCanceled(
 	execution: SimplifiedExecution,
 	runExecutionData: IRunExecutionData,
+	executionErrorToastSuppression: ExecutionErrorToastSuppression | null = null,
 ) {
 	const toast = useToast();
 	const i18n = useI18n();
@@ -381,7 +392,9 @@ export function handleExecutionFinishedWithErrorOrCanceled(
 			lastNodeExecuted: execution.data?.resultData.lastNodeExecuted,
 		});
 
-		toast.showMessage({ title, message, type: 'error', duration: 0 });
+		if (executionErrorToastSuppression?.shouldSuppressExecutionErrorToast(execution.id) !== true) {
+			toast.showMessage({ title, message, type: 'error', duration: 0 });
+		}
 
 		useBuilderStore().incrementManualExecutionStats('error');
 	}

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionRecovered.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionRecovered.ts
@@ -7,16 +7,15 @@ import {
 	handleExecutionFinishedWithErrorOrCanceled,
 	handleExecutionFinishedWithWaitTill,
 	setRunExecutionData,
+	type ExecutionFinishedOptions,
 } from './executionFinished';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
 import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
-import type { useRouter } from 'vue-router';
-import type { WorkflowState } from '@/app/composables/useWorkflowState';
 
 export async function executionRecovered(
 	{ data }: ExecutionRecovered,
-	options: { router: ReturnType<typeof useRouter>; workflowState: WorkflowState },
+	options: ExecutionFinishedOptions,
 ) {
 	const workflowsStore = useWorkflowsStore();
 	const workflowExecutionStateStore = useWorkflowExecutionStateStore(
@@ -43,9 +42,17 @@ export async function executionRecovered(
 	if (execution.data?.waitTill !== undefined) {
 		handleExecutionFinishedWithWaitTill(execution.workflowId ?? '', options);
 	} else if (execution.status === 'error' || execution.status === 'canceled') {
-		handleExecutionFinishedWithErrorOrCanceled(execution, runExecutionData);
+		handleExecutionFinishedWithErrorOrCanceled(
+			execution,
+			runExecutionData,
+			options.executionErrorToastSuppression,
+		);
 	} else {
 		handleExecutionFinishedWithSuccessOrOther(options.workflowState, execution.status, false);
+	}
+
+	if (execution.data?.waitTill === undefined) {
+		options.executionErrorToastSuppression?.clearExecutionErrorToastSuppression(execution.id);
 	}
 
 	setRunExecutionData(execution, runExecutionData, options.workflowState);

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue';
+import { hasInjectionContext, inject, ref } from 'vue';
 import type { PushMessage } from '@n8n/api-types';
 
 import { usePushConnectionStore } from '@/app/stores/pushConnection.store';
@@ -24,6 +24,7 @@ import {
 	workflowSettingsUpdated,
 } from '@/app/composables/usePushConnection/handlers';
 import { injectWorkflowState, type WorkflowState } from '@/app/composables/useWorkflowState';
+import { ExecutionErrorToastSuppressionKey } from '@/app/constants/injectionKeys';
 import { createEventQueue } from '@n8n/utils/event-queue';
 import type { useRouter } from 'vue-router';
 
@@ -35,9 +36,13 @@ export function usePushConnection({
 	workflowState?: WorkflowState;
 }) {
 	const pushStore = usePushConnectionStore();
+	const executionErrorToastSuppression = hasInjectionContext()
+		? inject(ExecutionErrorToastSuppressionKey, null)
+		: null;
 	const options = {
 		router,
 		workflowState: workflowState ?? injectWorkflowState(),
+		executionErrorToastSuppression,
 	};
 
 	const { enqueue } = createEventQueue<PushMessage>(processEvent);

--- a/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
+++ b/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
@@ -34,6 +34,13 @@ export const WorkflowExecutionStateStoreKey: InjectionKey<
 export const CanvasRenderDataKey: InjectionKey<Ref<CanvasRenderData>> = Symbol('CanvasRenderData');
 export const ChatHubToolContextKey: InjectionKey<boolean> = Symbol('ChatHubToolContext');
 export const AiBuilderScrollToBottomKey: InjectionKey<() => void> = Symbol('ChatScrollToBottom');
+export interface ExecutionErrorToastSuppression {
+	shouldSuppressExecutionErrorToast: (executionId: string) => boolean;
+	clearExecutionErrorToastSuppression: (executionId: string) => void;
+}
+
+export const ExecutionErrorToastSuppressionKey: InjectionKey<ExecutionErrorToastSuppression> =
+	Symbol('ExecutionErrorToastSuppression');
 /**
  * Context-supplied read-only signal for the workflow editor. When provided and
  * its current value is `true`, the canvas is treated as read-only on top of

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
@@ -22,7 +22,7 @@ import {
 } from '@n8n/design-system';
 import { useElementSize, useScroll, useSessionStorage, useWindowSize } from '@vueuse/core';
 import { useI18n } from '@n8n/i18n';
-import type { InstanceAiAttachment } from '@n8n/api-types';
+import type { InstanceAiAgentNode, InstanceAiAttachment } from '@n8n/api-types';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { usePageRedirectionHelper } from '@/app/composables/usePageRedirectionHelper';
 import { COLLAPSED_MAIN_SIDEBAR_WIDTH, useSidebarLayout } from '@/app/composables/useSidebarLayout';
@@ -36,6 +36,8 @@ import { useCreditWarningBanner } from './composables/useCreditWarningBanner';
 import { useTransitionGate } from './useTransitionGate';
 import { INSTANCE_AI_VIEW, NEW_CONVERSATION_TITLE } from './constants';
 import { useSidebarState } from './instanceAiLayout';
+import { ExecutionErrorToastSuppressionKey } from '@/app/constants/injectionKeys';
+import { usePushConnectionStore } from '@/app/stores/pushConnection.store';
 import InstanceAiMessage from './components/InstanceAiMessage.vue';
 import InstanceAiInput from './components/InstanceAiInput.vue';
 import InstanceAiDebugPanel from './components/InstanceAiDebugPanel.vue';
@@ -73,6 +75,43 @@ const sidebar = useSidebarState();
 const { width: windowWidth } = useWindowSize();
 const { isCollapsed: isMainSidebarCollapsed, sidebarWidth: mainSidebarWidth } = useSidebarLayout();
 const telemetry = useTelemetry();
+
+// --- AI-initiated workflow executions ---
+const aiInitiatedExecutionIds = new Set<string>();
+const pushStore = usePushConnectionStore();
+
+function nodeHasActiveWorkflowRunToolCall(node: InstanceAiAgentNode, workflowId: string): boolean {
+	for (const toolCall of node.toolCalls) {
+		if (!toolCall.isLoading) continue;
+		if (toolCall.toolName !== 'executions') continue;
+
+		const args = toolCall.args as Record<string, unknown> | undefined;
+		if (args?.action === 'run' && args.workflowId === workflowId) return true;
+	}
+
+	return node.children.some((child) => nodeHasActiveWorkflowRunToolCall(child, workflowId));
+}
+
+function threadHasActiveWorkflowRunToolCall(workflowId: string): boolean {
+	return thread.messages.some((message) => {
+		if (!message.agentTree) return false;
+		return nodeHasActiveWorkflowRunToolCall(message.agentTree, workflowId);
+	});
+}
+
+const removeAiExecutionStartedListener = pushStore.addEventListener((event) => {
+	if (event.type !== 'executionStarted') return;
+	if (!threadHasActiveWorkflowRunToolCall(event.data.workflowId)) return;
+
+	aiInitiatedExecutionIds.add(event.data.executionId);
+});
+
+provide(ExecutionErrorToastSuppressionKey, {
+	shouldSuppressExecutionErrorToast: (executionId) => aiInitiatedExecutionIds.has(executionId),
+	clearExecutionErrorToastSuppression: (executionId) => {
+		aiInitiatedExecutionIds.delete(executionId);
+	},
+});
 
 // Running builders render in a dedicated bottom section of the conversation.
 // Once a builder finishes it falls out of this list and AgentTimeline renders
@@ -483,6 +522,8 @@ onMounted(() => {
 });
 
 onUnmounted(() => {
+	removeAiExecutionStartedListener();
+	aiInitiatedExecutionIds.clear();
 	thread.closeSSE();
 	contentResizeObserver?.disconnect();
 });

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiThreadView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiThreadView.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { defineComponent, h, reactive, ref } from 'vue';
+import { defineComponent, h, inject, reactive, ref } from 'vue';
 import userEvent from '@testing-library/user-event';
 import { createTestingPinia } from '@pinia/testing';
 import { setActivePinia } from 'pinia';
@@ -12,10 +12,15 @@ import { usePushConnectionStore } from '@/app/stores/pushConnection.store';
 import { useSettingsStore } from '@/app/stores/settings.store';
 import { SidebarStateKey } from '../instanceAiLayout';
 import type { WorkflowFailuresReport } from '../components/InstanceAiWorkflowPreview.vue';
+import {
+	ExecutionErrorToastSuppressionKey,
+	type ExecutionErrorToastSuppression,
+} from '@/app/constants/injectionKeys';
 import type {
 	FrontendModuleSettings,
 	InstanceAiAgentNode,
 	InstanceAiMessage,
+	PushMessage,
 } from '@n8n/api-types';
 
 const mockWindowSizeState = vi.hoisted(() => ({
@@ -116,12 +121,14 @@ const InstanceAiInputStub = defineComponent({
 let workflowPreviewEmit:
 	| ((event: 'workflow-failures', payload: WorkflowFailuresReport) => void)
 	| null = null;
+let executionErrorToastSuppression: ExecutionErrorToastSuppression | null = null;
 
 const InstanceAiWorkflowPreviewStub = defineComponent({
 	name: 'InstanceAiWorkflowPreviewStub',
 	emits: ['workflow-failures'],
 	setup(_, { emit, expose }) {
 		workflowPreviewEmit = emit as typeof workflowPreviewEmit;
+		executionErrorToastSuppression = inject(ExecutionErrorToastSuppressionKey, null);
 		expose({ requestFitView: vi.fn() });
 		return () => h('div', { 'data-test-id': 'instance-ai-workflow-preview-stub' });
 	},
@@ -222,6 +229,48 @@ function makePlanReviewMessage(): InstanceAiMessage {
 describe('InstanceAiThreadView', () => {
 	let store: ReturnType<typeof mockedStore<typeof useInstanceAiStore>>;
 	let thread: ThreadRuntime;
+	let pushHandlers: Array<(message: PushMessage) => void>;
+
+	function emitPushMessage(message: PushMessage) {
+		for (const handler of [...pushHandlers]) handler(message);
+	}
+
+	function openPreviewForBuild(workflowId = 'wf-1') {
+		if (!thread.producedArtifacts.has(workflowId)) {
+			thread.producedArtifacts.set(workflowId, {
+				type: 'workflow',
+				id: workflowId,
+				name: 'Workflow',
+			});
+		}
+
+		thread.messages.push({
+			id: 'msg-build',
+			role: 'assistant',
+			content: '',
+			reasoning: '',
+			isStreaming: false,
+			createdAt: '2026-04-01T00:00:00.000Z',
+			agentTree: {
+				agentId: 'agent-1',
+				role: 'orchestrator',
+				status: 'completed',
+				textContent: '',
+				reasoning: '',
+				timeline: [],
+				children: [],
+				toolCalls: [
+					{
+						toolCallId: 'tc-build',
+						toolName: 'build-workflow',
+						args: {},
+						isLoading: false,
+						result: { success: true, workflowId },
+					},
+				],
+			},
+		} as never);
+	}
 
 	beforeEach(() => {
 		// Default `stubActions: true` — every store action becomes a no-op spy.
@@ -232,6 +281,8 @@ describe('InstanceAiThreadView', () => {
 			'instance-ai': { ...defaultModuleSettings },
 		};
 		workflowPreviewEmit = null;
+		executionErrorToastSuppression = null;
+		pushHandlers = [];
 
 		thread = reactive({
 			id: 'thread-1',
@@ -290,7 +341,12 @@ describe('InstanceAiThreadView', () => {
 		// Auto-stubbed push-store actions return undefined by default; addEventListener's
 		// caller expects a removeListener function, so return a no-op.
 		const pushStore = mockedStore(usePushConnectionStore);
-		pushStore.addEventListener.mockReturnValue(() => {});
+		pushStore.addEventListener.mockImplementation((handler) => {
+			pushHandlers.push(handler);
+			return () => {
+				pushHandlers = pushHandlers.filter((registeredHandler) => registeredHandler !== handler);
+			};
+		});
 		inputFocusSpy.mockClear();
 		telemetryTrackSpy.mockClear();
 		planEditSubmitState.message = 'Make the plan simpler';
@@ -427,6 +483,72 @@ describe('InstanceAiThreadView', () => {
 		expect(thread.loadHistoricalMessages).toHaveBeenCalledWith();
 	});
 
+	it('suppresses execution error toasts only for Instance AI initiated runs', async () => {
+		thread.messages = [
+			{
+				id: 'msg-run',
+				role: 'assistant',
+				content: '',
+				reasoning: '',
+				isStreaming: true,
+				createdAt: '2026-04-01T00:00:00.000Z',
+				agentTree: {
+					agentId: 'agent-run',
+					role: 'orchestrator',
+					status: 'active',
+					textContent: '',
+					reasoning: '',
+					timeline: [],
+					children: [],
+					toolCalls: [
+						{
+							toolCallId: 'tc-run',
+							toolName: 'executions',
+							args: { action: 'run', workflowId: 'wf-1' },
+							isLoading: true,
+						},
+					],
+				},
+			},
+		] as typeof thread.messages;
+
+		renderView({ props: { threadId: 'thread-1' } });
+		openPreviewForBuild('wf-1');
+
+		await vi.waitFor(() => {
+			expect(executionErrorToastSuppression).not.toBeNull();
+		});
+
+		emitPushMessage({
+			type: 'executionStarted',
+			data: {
+				executionId: 'exec-ai',
+				workflowId: 'wf-1',
+				mode: 'manual',
+				startedAt: new Date('2026-04-01T00:00:00.000Z'),
+				flattedRunData: '',
+			},
+		});
+
+		expect(executionErrorToastSuppression?.shouldSuppressExecutionErrorToast('exec-ai')).toBe(true);
+
+		thread.messages = [];
+		emitPushMessage({
+			type: 'executionStarted',
+			data: {
+				executionId: 'exec-manual',
+				workflowId: 'wf-1',
+				mode: 'manual',
+				startedAt: new Date('2026-04-01T00:00:01.000Z'),
+				flattedRunData: '',
+			},
+		});
+
+		expect(executionErrorToastSuppression?.shouldSuppressExecutionErrorToast('exec-manual')).toBe(
+			false,
+		);
+	});
+
 	it('uses edge reveal when the viewport is too narrow for pinned artifacts', async () => {
 		mockWindowSizeState.width.value = 900;
 		thread.messages = [
@@ -459,38 +581,6 @@ describe('InstanceAiThreadView', () => {
 			thread.producedArtifacts = new Map([
 				[workflowId, { type: 'workflow', id: workflowId, name: workflowName }],
 			]) as typeof thread.producedArtifacts;
-		}
-
-		// Drives useCanvasPreview's auto-open watcher so the preview tab is
-		// selected and the WorkflowPreview stub mounts (otherwise `v-if`
-		// keeps it unrendered and `workflowPreviewEmit` is never captured).
-		function openPreviewForBuild(workflowId = 'wf-1') {
-			thread.messages.push({
-				id: 'msg-build',
-				role: 'assistant',
-				content: '',
-				reasoning: '',
-				isStreaming: false,
-				createdAt: '2026-04-01T00:00:00.000Z',
-				agentTree: {
-					agentId: 'agent-1',
-					role: 'orchestrator',
-					status: 'completed',
-					textContent: '',
-					reasoning: '',
-					timeline: [],
-					children: [],
-					toolCalls: [
-						{
-							toolCallId: 'tc-build',
-							toolName: 'build-workflow',
-							args: {},
-							isLoading: false,
-							result: { success: true, workflowId },
-						},
-					],
-				},
-			} as never);
 		}
 
 		async function emitFailure(report: WorkflowFailuresReport = failureReport) {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowPreview.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiWorkflowPreview.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h } from 'vue';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+import { createThreadComponentRenderer } from './createThreadComponentRenderer';
+import InstanceAiWorkflowPreview from '../components/InstanceAiWorkflowPreview.vue';
+
+vi.mock('@/app/composables/useTelemetry', () => ({
+	useTelemetry: () => ({ track: vi.fn() }),
+}));
+
+const WorkflowCanvasHostStub = defineComponent({
+	name: 'WorkflowCanvasHost',
+	props: {
+		workflowId: { type: String, required: true },
+		refreshKey: { type: Number, default: 0 },
+	},
+	setup(props, { expose }) {
+		expose({ requestFitView: vi.fn() });
+
+		return () =>
+			h(
+				'div',
+				{
+					'data-test-id': 'workflow-canvas-host-stub',
+					'data-workflow-id': props.workflowId,
+				},
+				[],
+			);
+	},
+});
+
+describe('InstanceAiWorkflowPreview', () => {
+	let pinia: ReturnType<typeof createTestingPinia>;
+	let renderPreview: ReturnType<
+		typeof createThreadComponentRenderer<typeof InstanceAiWorkflowPreview>
+	>;
+
+	beforeEach(() => {
+		pinia = createTestingPinia({ stubActions: false });
+		setActivePinia(pinia);
+
+		renderPreview = createThreadComponentRenderer(InstanceAiWorkflowPreview, {
+			pinia,
+			props: {
+				workflowId: 'workflow-1',
+				refreshKey: 0,
+			},
+			global: {
+				stubs: {
+					WorkflowCanvasHost: WorkflowCanvasHostStub,
+				},
+			},
+		});
+	});
+
+	afterEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('renders the workflow canvas host for the selected workflow', () => {
+		const { getByTestId } = renderPreview();
+
+		expect(getByTestId('workflow-canvas-host-stub')).toHaveAttribute(
+			'data-workflow-id',
+			'workflow-1',
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Suppress sticky editor error toasts only for workflow executions that Instance AI starts via its `executions(action="run")` tool.

The regression came from the direct-mounted workflow artifact preview replacing the old iframe `WorkflowPreview`. Instance AI executions could again surface sticky editor error toasts such as “Problem in node …”, even though the failure is already handled in the Instance AI thread UI.

The fix keeps the canvas decoupled from this decision:

- `InstanceAiThreadView` records an execution id from an `executionStarted` push event only when the thread currently has an active `executions` tool call with `action: "run"` for the same `workflowId`.
- The generic execution push handler asks an injected `ExecutionErrorToastSuppression` context whether that specific execution id should skip its error toast.
- Manual/user-triggered executions in the Instance AI preview are not recorded, so their error toasts still show.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-423

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
