### PR TITLE
feat(GSuiteAdmin): add Get Many Members operation to Groups

### DIFF
--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/GSuiteAdmin.node.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/GSuiteAdmin.node.ts
@@ -377,6 +377,46 @@ export class GSuiteAdmin implements INodeType {
 						}
 					}
 
+					//https://developers.google.com/admin-sdk/directory/reference/rest/v1/members/list
+					if (operation === 'getMembers') {
+						const groupId = this.getNodeParameter('groupId', i, undefined, {
+							extractValue: true,
+						}) as string;
+						const returnAll = this.getNodeParameter('returnAll', i);
+						const options = this.getNodeParameter('options', i, {}) as {
+							includeDerivedMembership?: boolean;
+							roles?: string[];
+						};
+
+						if (options.includeDerivedMembership) {
+							qs.includeDerivedMembership = true;
+						}
+						if (options.roles?.length) {
+							qs.roles = options.roles.join(',');
+						}
+
+						if (returnAll) {
+							responseData = await googleApiRequestAllItems.call(
+								this,
+								'members',
+								'GET',
+								`/directory/v1/groups/${groupId}/members`,
+								{},
+								qs,
+							);
+						} else {
+							qs.maxResults = this.getNodeParameter('limit', i);
+							responseData = await googleApiRequest.call(
+								this,
+								'GET',
+								`/directory/v1/groups/${groupId}/members`,
+								{},
+								qs,
+							);
+							responseData = responseData.members ?? [];
+						}
+					}
+
 					//https://developers.google.com/admin-sdk/directory/v1/reference/groups/update
 					if (operation === 'update') {
 						const groupId = this.getNodeParameter('groupId', i, undefined, {

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/GroupDescription.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/GroupDescription.ts
@@ -37,6 +37,12 @@ export const groupOperations: INodeProperties[] = [
 				action: 'Get many groups',
 			},
 			{
+				name: 'Get Many Members',
+				value: 'getMembers',
+				description: 'Get many members of a group',
+				action: 'Get many members of a group',
+			},
+			{
 				name: 'Update',
 				value: 'update',
 				description: 'Update a group',
@@ -61,7 +67,7 @@ export const groupFields: INodeProperties[] = [
 		description: 'Select the group to perform the operation on',
 		displayOptions: {
 			show: {
-				operation: ['delete', 'get', 'update'],
+				operation: ['delete', 'get', 'getMembers', 'update'],
 				resource: ['group'],
 			},
 		},
@@ -273,6 +279,85 @@ export const groupFields: INodeProperties[] = [
 						description: 'Sort order direction',
 					},
 				],
+			},
+		],
+	},
+
+	/* -------------------------------------------------------------------------- */
+	/*                                 group:getMembers                           */
+	/* -------------------------------------------------------------------------- */
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		displayOptions: {
+			show: {
+				operation: ['getMembers'],
+				resource: ['group'],
+			},
+		},
+		default: false,
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		displayOptions: {
+			show: {
+				operation: ['getMembers'],
+				resource: ['group'],
+				returnAll: [false],
+			},
+		},
+		typeOptions: {
+			minValue: 1,
+			maxValue: 200,
+		},
+		default: 100,
+		description: 'Max number of results to return',
+	},
+	{
+		displayName: 'Options',
+		name: 'options',
+		type: 'collection',
+		placeholder: 'Add Option',
+		default: {},
+		displayOptions: {
+			show: {
+				operation: ['getMembers'],
+				resource: ['group'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Include Derived Membership',
+				name: 'includeDerivedMembership',
+				type: 'boolean',
+				default: false,
+				description:
+					'Whether to list indirect group memberships. When true, members of nested groups are also returned.',
+			},
+			{
+				displayName: 'Roles',
+				name: 'roles',
+				type: 'multiOptions',
+				options: [
+					{
+						name: 'Manager',
+						value: 'MANAGER',
+					},
+					{
+						name: 'Member',
+						value: 'MEMBER',
+					},
+					{
+						name: 'Owner',
+						value: 'OWNER',
+					},
+				],
+				default: [],
+				description: 'Filter results to members with these roles. Leave empty to return all roles.',
 			},
 		],
 	},

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/__schema__/v1.0.0/group/getMembers.json
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/__schema__/v1.0.0/group/getMembers.json
@@ -1,0 +1,30 @@
+{
+	"type": "object",
+	"properties": {
+		"delivery_settings": {
+			"type": "string"
+		},
+		"email": {
+			"type": "string"
+		},
+		"etag": {
+			"type": "string"
+		},
+		"id": {
+			"type": "string"
+		},
+		"kind": {
+			"type": "string"
+		},
+		"role": {
+			"type": "string"
+		},
+		"status": {
+			"type": "string"
+		},
+		"type": {
+			"type": "string"
+		}
+	},
+	"version": 3
+}

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/group/getMembers.test.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/group/getMembers.test.ts
@@ -1,0 +1,43 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+describe('Google GSuiteAdmin Node - Get Many Members', () => {
+	beforeEach(() => {
+		nock.disableNetConnect();
+		nock('https://www.googleapis.com/admin')
+			.get('/directory/v1/groups/01x0gk373c9z46j/members')
+			.query({
+				maxResults: '100',
+			})
+			.reply(200, {
+				kind: 'admin#directory#members',
+				etag: '"test_etag"',
+				members: [
+					{
+						kind: 'admin#directory#member',
+						etag: '"example"',
+						id: '123456789',
+						email: 'alice@example.com',
+						role: 'OWNER',
+						type: 'USER',
+						status: 'ACTIVE',
+						delivery_settings: 'ALL_MAIL',
+					},
+					{
+						kind: 'admin#directory#member',
+						etag: '"example2"',
+						id: '987654321',
+						email: 'bob@example.com',
+						role: 'MEMBER',
+						type: 'USER',
+						status: 'ACTIVE',
+						delivery_settings: 'ALL_MAIL',
+					},
+				],
+			});
+	});
+
+	new NodeTestHarness().setupTests({
+		workflowFiles: ['getMembers.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/group/getMembers.workflow.json
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/group/getMembers.workflow.json
@@ -1,0 +1,77 @@
+{
+	"nodes": [
+		{
+			"parameters": {},
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [120, 700],
+			"id": "0e76b314-4994-4141-975f-9614c6094c80",
+			"name": "When clicking 'Execute workflow'"
+		},
+		{
+			"parameters": {
+				"resource": "group",
+				"operation": "getMembers",
+				"groupId": {
+					"__rl": true,
+					"value": "01x0gk373c9z46j",
+					"mode": "GroupId"
+				},
+				"returnAll": true,
+				"options": {}
+			},
+			"type": "n8n-nodes-base.gSuiteAdmin",
+			"typeVersion": 1,
+			"position": [100, 1120],
+			"id": "30263040-3578-4ce6-b19c-f665b85ca301",
+			"name": "Get Many Members",
+			"credentials": {
+				"gSuiteAdminOAuth2Api": {
+					"id": "OXfPMaggXFJ0RLkw",
+					"name": "Google Workspace Admin account"
+				}
+			}
+		}
+	],
+	"connections": {
+		"When clicking 'Execute workflow'": {
+			"main": [
+				[
+					{
+						"node": "Get Many Members",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"pinData": {
+		"Get Many Members": [
+			{
+				"json": {
+					"kind": "admin#directory#member",
+					"etag": "\"example\"",
+					"id": "123456789",
+					"email": "alice@example.com",
+					"role": "OWNER",
+					"type": "USER",
+					"status": "ACTIVE",
+					"delivery_settings": "ALL_MAIL"
+				}
+			},
+			{
+				"json": {
+					"kind": "admin#directory#member",
+					"etag": "\"example2\"",
+					"id": "987654321",
+					"email": "bob@example.com",
+					"role": "MEMBER",
+					"type": "USER",
+					"status": "ACTIVE",
+					"delivery_settings": "ALL_MAIL"
+				}
+			}
+		]
+	}
+}


### PR DESCRIPTION
## Summary

Add GetManyMembers operation to Google Workspace groups.
It's implement this [call API](https://developers.google.com/workspace/admin/directory/v1/guides/manage-group-members?hl=fr#get_all_members).

## How to test

Just launch n8n, create a GSuiteAdmin node and choice GeManyMembers

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. -> n8n-io/n8n-docs#4756
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
