### PR TITLE
fix(core): Throw a clear error for $evaluateExpression in the Code node under secure mode

### DIFF
--- a/packages/cli/test/integration/task-runners/js-task-runner-execution.integration.test.ts
+++ b/packages/cli/test/integration/task-runners/js-task-runner-execution.integration.test.ts
@@ -212,6 +212,27 @@ describe('JS TaskRunner execution on internal mode', () => {
 				result: { hello: 'world' },
 			});
 		});
+
+		// CAT-3208 / GH #24307: secure-mode task runners disable code generation
+		// (--disallow-code-generation-from-strings) and freeze Object.prototype, so
+		// expressions can't be evaluated inside the Code node. $evaluateExpression
+		// must surface a clear, actionable error instead of crashing with
+		// "Cannot assign to read only property '__lookupGetter__'" or silently
+		// returning null.
+		it('should throw a clear error for $evaluateExpression in the Code node', async () => {
+			// Act
+			const result = await runTaskWithCode("return { val: $evaluateExpression('{{ 1 + 1 }}') }");
+
+			// Assert
+			expect(result).toEqual({
+				ok: false,
+				error: expect.objectContaining({
+					message: expect.stringContaining(
+						'in the Code node while task runners run in secure mode',
+					),
+				}),
+			});
+		});
 	});
 
 	describe('Internal and external libs', () => {

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -374,10 +374,23 @@ export class Expression {
 		data.Reflect = {};
 		data.Proxy = {};
 
-		data.__lookupGetter__ = undefined;
-		data.__lookupSetter__ = undefined;
-		data.__defineGetter__ = undefined;
-		data.__defineSetter__ = undefined;
+		// These four names are inherited from `Object.prototype`. In the secure-mode
+		// task-runner sandbox `Object.prototype` is frozen, so plain assignment walks
+		// the prototype chain to the now read-only inherited property and throws in
+		// strict mode. Define them as own properties to overwrite them safely.
+		for (const key of [
+			'__lookupGetter__',
+			'__lookupSetter__',
+			'__defineGetter__',
+			'__defineSetter__',
+		]) {
+			Object.defineProperty(data, key, {
+				value: undefined,
+				writable: true,
+				enumerable: true,
+				configurable: true,
+			});
+		}
 
 		// Deprecated
 		data.escape = {};

--- a/packages/workflow/src/workflow-data-proxy.ts
+++ b/packages/workflow/src/workflow-data-proxy.ts
@@ -52,6 +52,26 @@ const PAIRED_ITEM_METHOD = {
 
 type PairedItemMethod = (typeof PAIRED_ITEM_METHOD)[keyof typeof PAIRED_ITEM_METHOD];
 
+/**
+ * Whether the runtime can compile expressions. The expression engine compiles
+ * expressions via `new Function`, which throws when the process is started with
+ * `--disallow-code-generation-from-strings` — as the secure-mode task runner is.
+ * This is a process-wide invariant, so we probe once and cache the result.
+ */
+let codeGenerationAllowed: boolean | undefined;
+const isCodeGenerationAllowed = (): boolean => {
+	if (codeGenerationAllowed === undefined) {
+		try {
+			// eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+			new Function('return 1');
+			codeGenerationAllowed = true;
+		} catch {
+			codeGenerationAllowed = false;
+		}
+	}
+	return codeGenerationAllowed;
+};
+
 export class WorkflowDataProxy {
 	private runExecutionData: IRunExecutionData | null;
 
@@ -1496,6 +1516,15 @@ export class WorkflowDataProxy {
 				that.envProviderState ?? createEnvProviderState(),
 			),
 			$evaluateExpression: (expression: string, itemIndex?: number) => {
+				if (!isCodeGenerationAllowed()) {
+					throw new ExpressionError(
+						"$evaluateExpression can't be used in the Code node while task runners run in secure mode",
+						{
+							description:
+								'Secure-mode task runners disable evaluating strings as code, which expressions rely on. Evaluate the expression in a node field instead, for example an Edit Fields (Set) node before the Code node.',
+						},
+					);
+				}
 				itemIndex = itemIndex || that.itemIndex;
 				return that.workflow.expression.getParameterValue(
 					`=${expression}`,


### PR DESCRIPTION
## Summary

`$evaluateExpression()` inside the **Code node** has never worked under the default **secure-mode task runner** in n8n v2. It returned `null` (v2.3.4) and from v2.3.6 onward threw the cryptic `TypeError: Cannot assign to read only property '__lookupGetter__' of object '#<Object>'`.

**Why it can't work in secure mode:** the secure runner starts the process with `--disallow-code-generation-from-strings` and freezes `Object.prototype`. The expression engine compiles expressions via `new Function`, which is disallowed there, so the expression can't be evaluated. Separately, `Expression.initializeGlobalContext` crashed while building the sandbox denylist against the frozen prototype.

This PR doesn't try to make `$evaluateExpression` evaluate in secure mode (that's not possible with the current engine). Instead it replaces the cryptic crash / silent `null` with a **clear, actionable error**:

- `$evaluateExpression` now probes once whether code generation is available and, if not, throws an `ExpressionError`:
  > $evaluateExpression can't be used in the Code node while task runners run in secure mode
  >
  > Secure-mode task runners disable evaluating strings as code, which expressions rely on. Evaluate the expression in a node field instead, for example an Edit Fields (Set) node before the Code node.
- `Expression.initializeGlobalContext` now defines the inherited `__lookupGetter__` / `__lookupSetter__` / `__defineGetter__` / `__defineSetter__` names as **own** properties via `Object.defineProperty`, so it no longer crashes on a frozen `Object.prototype`. In the edge case of an external-mode runner that freezes prototypes but allows code generation, `$evaluateExpression` then actually works.

The check tests the real capability (`new Function`) rather than the V8 error string or the task-runner "secure mode" config, so it's robust to V8 message changes and to internal/external-mode divergence.

### How to test

Run a Code node (Run Once for All Items, JavaScript) with:
```js
return [{ json: { responseText: $evaluateExpression('{{ 1 + 1 }}') } }]
```
With default settings (task runners, secure mode), it now fails with the clear error above instead of a cryptic `TypeError`/silent `null`.

Automated coverage: a real-process integration test (`packages/cli/test/integration/task-runners/js-task-runner-execution.integration.test.ts`) spawns a secure-mode runner and asserts the clear error. The full `packages/workflow` suite passes under both the legacy and vm engines.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3208

fixes #24307

Docs: the v2.0 breaking changes page is updated to document this behaviour and the workarounds — n8n-io/n8n-docs#4809

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI