### PR TITLE
ci: Run stable branch removal every monday

### DIFF
--- a/.github/workflows/clean-stale-branches.yml
+++ b/.github/workflows/clean-stale-branches.yml
@@ -1,8 +1,8 @@
 name: 'Util: Clean Stale Branches'
 
 on:
-  # schedule:
-  #   - cron: "0 0 * * *" # Everyday at midnight
+  schedule:
+    - cron: "0 10 * * 1" # Every monday
   workflow_dispatch:
     inputs:
       dry-run:
@@ -40,6 +40,6 @@ jobs:
       - name: Clean stale branches
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          STALE_DAYS: ${{ inputs.days }}
-          EXCLUDE_BRANCHES: ${{ inputs.exclude }}
+          STALE_DAYS: ${{ inputs.days || '100' }}
+          EXCLUDE_BRANCHES: ${{ inputs.exclude || '' }}
         run: node .github/scripts/stale/clean-stale-branches.mjs --days="$STALE_DAYS" ${{ !inputs.dry-run && '--execute' || '--dry-run' }}


### PR DESCRIPTION
## Summary

Enable cron step on stale branch removal to run every monday.


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
