### PR TITLE
chore: Fix pnpm reset by limiting concurrency

### DIFF
--- a/scripts/reset.mjs
+++ b/scripts/reset.mjs
@@ -31,4 +31,4 @@ echo('⏬ Running pnpm install...');
 await $`pnpm install`;
 
 echo('🏗️ Running pnpm build...');
-await $`pnpm build`;
+await $`pnpm build --concurrency=50%`;


### PR DESCRIPTION
## Summary

The dart-sass process kept OOMing due to `pnpm reset` causing turbo to build the whole project in parallel. Limit the parallelism a bit to prevent OOMing and keeping the builds stable. Builds for a `pnpm reset` process decrease a bit in speed for the increased stability.

**New macbook:**
reset: 2 min 15 sec
build: 1 min 10 sec


This fix is to prevent crashes during resets. Further investigation into making reset more stable / resetting less frequent in a follow-up PR

## How to test


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
