### PR TITLE
feat: Add OAuth2 authentication for Form node

### DIFF
--- a/packages/cli/src/auth/__tests__/auth-service-browser-id-whitelist.test.ts
+++ b/packages/cli/src/auth/__tests__/auth-service-browser-id-whitelist.test.ts
@@ -48,6 +48,7 @@ describe('AuthService Browser ID Whitelist', () => {
 
 			expect(skipEndpoints).toContain('/rest/oauth1-credential/callback');
 			expect(skipEndpoints).toContain('/rest/oauth2-credential/callback');
+			expect(skipEndpoints).toContain('/rest/oauth2-credential/webhook-callback');
 		});
 	});
 });

--- a/packages/cli/src/auth/auth.service.ts
+++ b/packages/cli/src/auth/auth.service.ts
@@ -83,6 +83,7 @@ export class AuthService {
 			// oAuth callback urls aren't called by the frontend. therefore we can't send custom header on these requests
 			`/${restEndpoint}/oauth1-credential/callback`,
 			`/${restEndpoint}/oauth2-credential/callback`,
+			`/${restEndpoint}/oauth2-credential/webhook-callback`,
 
 			// Skip browser ID check for type files
 			'/types/nodes.json',

--- a/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth2-credential.controller.test.ts
@@ -15,6 +15,12 @@ import { OAuthJweServiceProxy } from '@/oauth/oauth-jwe-service.proxy';
 jest.mock('axios');
 jest.mock('@n8n/client-oauth2');
 jest.mock('pkce-challenge');
+jest.mock('n8n-core', () => ({
+	...jest.requireActual('n8n-core'),
+	verifyWebhookOAuth2State: jest.fn(),
+	isFormHtmlSandboxingDisabled: jest.fn(() => false),
+	getHtmlSandboxCSP: jest.fn(() => 'sandbox-csp-stub'),
+}));
 
 describe('OAuth2CredentialController', () => {
 	const oauthService = mockInstance(OauthService);
@@ -944,6 +950,120 @@ describe('OAuth2CredentialController', () => {
 				'Token exchange failed',
 				undefined,
 			);
+		});
+	});
+
+	describe('handleWebhookOAuth2Callback', () => {
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		const n8nCore = require('n8n-core') as {
+			verifyWebhookOAuth2State: jest.Mock;
+			isFormHtmlSandboxingDisabled: jest.Mock;
+		};
+
+		beforeEach(() => {
+			n8nCore.verifyWebhookOAuth2State.mockReset();
+			n8nCore.isFormHtmlSandboxingDisabled.mockReset().mockReturnValue(false);
+		});
+
+		const buildReq = (query: Record<string, string>) => {
+			const req = mock<OAuthRequest.OAuth2Credential.Callback>();
+			req.query = query as OAuthRequest.OAuth2Credential.Callback['query'];
+			return req;
+		};
+
+		it('redirects to the return URL with _oauth_code and _oauth_state appended on success', async () => {
+			n8nCore.verifyWebhookOAuth2State.mockReturnValue({ returnUrl: '/form/test?foo=bar' });
+			const res = mock<Response>();
+			const req = buildReq({ code: 'auth_code', state: 'enc.state' });
+
+			await controller.handleWebhookOAuth2Callback(req, res);
+
+			expect(res.redirect).toHaveBeenCalledWith(
+				'/form/test?foo=bar&_oauth_code=auth_code&_oauth_state=enc.state',
+			);
+			expect(res.render).not.toHaveBeenCalled();
+		});
+
+		it('sets the sandbox CSP header on the redirect response', async () => {
+			n8nCore.verifyWebhookOAuth2State.mockReturnValue({ returnUrl: '/form/test' });
+			const res = mock<Response>();
+			const req = buildReq({ code: 'auth_code', state: 'enc.state' });
+
+			await controller.handleWebhookOAuth2Callback(req, res);
+
+			expect(res.setHeader).toHaveBeenCalledWith('Content-Security-Policy', 'sandbox-csp-stub');
+		});
+
+		it('omits the CSP header when form HTML sandboxing is disabled', async () => {
+			n8nCore.isFormHtmlSandboxingDisabled.mockReturnValue(true);
+			n8nCore.verifyWebhookOAuth2State.mockReturnValue({ returnUrl: '/form/test' });
+			const res = mock<Response>();
+			const req = buildReq({ code: 'auth_code', state: 'enc.state' });
+
+			await controller.handleWebhookOAuth2Callback(req, res);
+
+			expect(res.setHeader).not.toHaveBeenCalledWith('Content-Security-Policy', expect.anything());
+		});
+
+		it('renders the error template when the provider returns an error', async () => {
+			n8nCore.verifyWebhookOAuth2State.mockReturnValue({ returnUrl: '/form/test' });
+			const res = mock<Response>();
+			const req = buildReq({
+				state: 'enc.state',
+				error: 'access_denied',
+				error_description: 'User denied access',
+			});
+
+			await controller.handleWebhookOAuth2Callback(req, res);
+
+			expect(res.render).toHaveBeenCalledWith('webhook-oauth-error', {
+				errorCode: 'access_denied',
+				errorDescription: 'User denied access',
+				returnUrl: '/form/test',
+			});
+			expect(res.redirect).not.toHaveBeenCalled();
+		});
+
+		it('renders the error template when code is missing', async () => {
+			const res = mock<Response>();
+			const req = buildReq({ state: 'enc.state' });
+
+			await controller.handleWebhookOAuth2Callback(req, res);
+
+			expect(res.render).toHaveBeenCalledWith('webhook-oauth-error', {
+				errorCode: 'invalid_request',
+				errorDescription: 'Missing required OAuth2 parameters.',
+				returnUrl: null,
+			});
+		});
+
+		it('renders the error template when state is missing', async () => {
+			const res = mock<Response>();
+			const req = buildReq({ code: 'auth_code' });
+
+			await controller.handleWebhookOAuth2Callback(req, res);
+
+			expect(res.render).toHaveBeenCalledWith('webhook-oauth-error', {
+				errorCode: 'invalid_request',
+				errorDescription: 'Missing required OAuth2 parameters.',
+				returnUrl: null,
+			});
+		});
+
+		it('renders the error template when state is invalid or expired', async () => {
+			n8nCore.verifyWebhookOAuth2State.mockReturnValue(null);
+			const res = mock<Response>();
+			const req = buildReq({ code: 'auth_code', state: 'bad.state' });
+
+			await controller.handleWebhookOAuth2Callback(req, res);
+
+			expect(res.render).toHaveBeenCalledWith('webhook-oauth-error', {
+				errorCode: 'invalid_state',
+				errorDescription:
+					'The login link has expired or is invalid. Please return to the form and try again.',
+				returnUrl: null,
+			});
+			expect(res.redirect).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
@@ -6,7 +6,11 @@ import { Response } from 'express';
 import omit from 'lodash/omit';
 import set from 'lodash/set';
 import split from 'lodash/split';
-import { verifyWebhookOAuth2State } from 'n8n-core';
+import {
+	getHtmlSandboxCSP,
+	isFormHtmlSandboxingDisabled,
+	verifyWebhookOAuth2State,
+} from 'n8n-core';
 import type { ICredentialDataDecryptedObject, IDataObject } from 'n8n-workflow';
 import { ensureError, jsonParse, jsonStringify } from 'n8n-workflow';
 
@@ -159,12 +163,16 @@ export class OAuth2CredentialController {
 	/** Callback endpoint for webhook-scoped OAuth2 authentication (form / webhook nodes) */
 	@Get('/webhook-callback', { usesTemplates: true, allowUnauthenticated: true })
 	async handleWebhookOAuth2Callback(req: OAuthRequest.OAuth2Credential.Callback, res: Response) {
+		if (!isFormHtmlSandboxingDisabled()) {
+			res.setHeader('Content-Security-Policy', getHtmlSandboxCSP());
+		}
+
 		const { code, state, error, error_description } = req.query as Record<string, string>;
 
 		// Provider returned an error (e.g. user denied access)
 		if (error) {
 			const decoded = state ? verifyWebhookOAuth2State(state) : null;
-			return res.render('webhook-oauth-error', {
+			return this.renderWebhookOAuth2Error(res, {
 				errorCode: error,
 				errorDescription: error_description ?? null,
 				returnUrl: decoded?.returnUrl ?? null,
@@ -172,7 +180,7 @@ export class OAuth2CredentialController {
 		}
 
 		if (!code || !state) {
-			return res.render('webhook-oauth-error', {
+			return this.renderWebhookOAuth2Error(res, {
 				errorCode: 'invalid_request',
 				errorDescription: 'Missing required OAuth2 parameters.',
 				returnUrl: null,
@@ -181,7 +189,7 @@ export class OAuth2CredentialController {
 
 		const decoded = verifyWebhookOAuth2State(state);
 		if (!decoded) {
-			return res.render('webhook-oauth-error', {
+			return this.renderWebhookOAuth2Error(res, {
 				errorCode: 'invalid_state',
 				errorDescription:
 					'The login link has expired or is invalid. Please return to the form and try again.',
@@ -194,6 +202,13 @@ export class OAuth2CredentialController {
 		// Pass the original state back so the form node can recover the PKCE code_verifier.
 		returnUrl.searchParams.set('_oauth_state', state);
 		return res.redirect(`${returnUrl.pathname}${returnUrl.search}${returnUrl.hash}`);
+	}
+
+	private renderWebhookOAuth2Error(
+		res: Response,
+		data: { errorCode: string; errorDescription: string | null; returnUrl: string | null },
+	) {
+		return res.render('webhook-oauth-error', data);
 	}
 
 	private convertCredentialToOptions(credential: OAuth2CredentialData): ClientOAuth2Options {

--- a/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth2-credential.controller.ts
@@ -6,6 +6,7 @@ import { Response } from 'express';
 import omit from 'lodash/omit';
 import set from 'lodash/set';
 import split from 'lodash/split';
+import { verifyWebhookOAuth2State } from 'n8n-core';
 import type { ICredentialDataDecryptedObject, IDataObject } from 'n8n-workflow';
 import { ensureError, jsonParse, jsonStringify } from 'n8n-workflow';
 
@@ -153,6 +154,46 @@ export class OAuth2CredentialController {
 				'body' in error ? jsonStringify(error.body) : undefined,
 			);
 		}
+	}
+
+	/** Callback endpoint for webhook-scoped OAuth2 authentication (form / webhook nodes) */
+	@Get('/webhook-callback', { usesTemplates: true, allowUnauthenticated: true })
+	async handleWebhookOAuth2Callback(req: OAuthRequest.OAuth2Credential.Callback, res: Response) {
+		const { code, state, error, error_description } = req.query as Record<string, string>;
+
+		// Provider returned an error (e.g. user denied access)
+		if (error) {
+			const decoded = state ? verifyWebhookOAuth2State(state) : null;
+			return res.render('webhook-oauth-error', {
+				errorCode: error,
+				errorDescription: error_description ?? null,
+				returnUrl: decoded?.returnUrl ?? null,
+			});
+		}
+
+		if (!code || !state) {
+			return res.render('webhook-oauth-error', {
+				errorCode: 'invalid_request',
+				errorDescription: 'Missing required OAuth2 parameters.',
+				returnUrl: null,
+			});
+		}
+
+		const decoded = verifyWebhookOAuth2State(state);
+		if (!decoded) {
+			return res.render('webhook-oauth-error', {
+				errorCode: 'invalid_state',
+				errorDescription:
+					'The login link has expired or is invalid. Please return to the form and try again.',
+				returnUrl: null,
+			});
+		}
+
+		const returnUrl = new URL(decoded.returnUrl, 'http://placeholder.invalid');
+		returnUrl.searchParams.set('_oauth_code', code);
+		// Pass the original state back so the form node can recover the PKCE code_verifier.
+		returnUrl.searchParams.set('_oauth_state', state);
+		return res.redirect(`${returnUrl.pathname}${returnUrl.search}${returnUrl.hash}`);
 	}
 
 	private convertCredentialToOptions(credential: OAuth2CredentialData): ClientOAuth2Options {

--- a/packages/cli/templates/form-trigger.handlebars
+++ b/packages/cli/templates/form-trigger.handlebars
@@ -499,7 +499,7 @@
 
 	<body>
 		{{#if canonicalFormUrl}}
-			<script>history.replaceState(null, '', '{{canonicalFormUrl}}');</script>
+			<script data-url="{{canonicalFormUrl}}">history.replaceState(null, '', document.currentScript.dataset.url);</script>
 		{{/if}}
 		<div class='container'>
 			<section>

--- a/packages/cli/templates/form-trigger.handlebars
+++ b/packages/cli/templates/form-trigger.handlebars
@@ -123,6 +123,33 @@
 				margin-bottom: var(--margin-bottom-card);
 			}
 
+			.logged-in-banner {
+				padding: 12px 16px;
+				background-color: #f0f4ff;
+				border: 1px solid #dbdfe7;
+				border-radius: var(--border-radius-card);
+				margin-bottom: var(--margin-bottom-card);
+				font-size: var(--font-size-paragraph);
+				color: var(--color-label);
+				text-align: left;
+				line-height: 1.5;
+				display: flex;
+				align-items: center;
+				gap: 12px;
+			}
+			.logged-in-banner-picture {
+				width: 32px;
+				height: 32px;
+				border-radius: 50%;
+				flex-shrink: 0;
+				object-fit: cover;
+			}
+			.logged-in-banner a {
+				color: var(--color-html-link);
+				text-decoration: none;
+			}
+			.logged-in-banner a:hover { text-decoration: underline; }
+
 			.n8n-link {
 				padding-bottom: var(--padding-container-top);
 			}
@@ -471,6 +498,9 @@
 	</head>
 
 	<body>
+		{{#if canonicalFormUrl}}
+			<script>history.replaceState(null, '', '{{canonicalFormUrl}}');</script>
+		{{/if}}
 		<div class='container'>
 			<section>
 				{{#if testRun}}
@@ -478,6 +508,19 @@
 						<p>This is a test version of your form</p>
 					</div>
 					<hr>
+				{{/if}}
+
+				{{#if displayLoggedInBanner}}
+					{{#if oauthUser}}
+					<div class="logged-in-banner">
+						{{#if oauthUser.picture}}
+						<img class="logged-in-banner-picture" src="{{oauthUser.picture}}" alt="" referrerpolicy="no-referrer" />
+						{{/if}}
+						<div>
+							Logged in as <strong>{{oauthUser.firstName}}</strong>{{#if oauthUser.email}} ({{oauthUser.email}}){{/if}}{{#if reAuthUrl}} — not you? <a href="{{reAuthUrl}}">Log out</a>{{/if}}
+						</div>
+					</div>
+					{{/if}}
 				{{/if}}
 
 				<form class='card' action='#' method='POST' name='n8n-form' id='n8n-form' novalidate>

--- a/packages/cli/templates/webhook-oauth-error.handlebars
+++ b/packages/cli/templates/webhook-oauth-error.handlebars
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+		<link rel="icon" type="image/png" href="https://n8n.io/favicon.ico" />
+		<link href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300..800;1,300..800&display=swap" rel="stylesheet" />
+		<title>Authentication Error</title>
+		<style>
+			* { box-sizing: border-box; margin: 0; padding: 0; }
+			body {
+				font-family: "Open Sans", sans-serif;
+				font-size: 14px;
+				color: #333638;
+				background: #f9f9f9;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				min-height: 100vh;
+				padding: 24px;
+			}
+			.card {
+				background: #fff;
+				border-radius: 8px;
+				box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+				padding: 40px 32px;
+				max-width: 480px;
+				width: 100%;
+				text-align: center;
+			}
+			.icon { font-size: 40px; margin-bottom: 16px; }
+			h1 { font-size: 20px; font-weight: 600; margin-bottom: 8px; }
+			.description {
+				font-size: 14px;
+				color: #666;
+				margin-bottom: 24px;
+				line-height: 1.5;
+			}
+			.return-link {
+				display: inline-block;
+				padding: 10px 20px;
+				background: #ff6d5a;
+				color: #fff;
+				border-radius: 4px;
+				text-decoration: none;
+				font-size: 14px;
+				font-weight: 600;
+			}
+			.return-link:hover { background: #e55a47; }
+		</style>
+	</head>
+	<body>
+		<div class="card">
+			<div class="icon">&#x26A0;&#xFE0F;</div>
+			<h1>Authentication failed</h1>
+			<p class="description">
+				{{#if errorDescription}}
+					{{errorDescription}}
+				{{else if errorCode}}
+					An error occurred during login ({{errorCode}}). Please try again.
+				{{else}}
+					An unexpected error occurred during login. Please try again.
+				{{/if}}
+			</p>
+			{{#if returnUrl}}
+			<a class="return-link" href="{{returnUrl}}">Return to form</a>
+			{{/if}}
+		</div>
+	</body>
+</html>

--- a/packages/core/src/execution-engine/node-execution-context/index.ts
+++ b/packages/core/src/execution-engine/node-execution-context/index.ts
@@ -18,3 +18,9 @@ export { parseRequestObject } from './utils/request-helper-functions';
 export { returnJsonArray } from './utils/return-json-array';
 export { resolveSourceOverwrite } from './utils/resolve-source-overwrite';
 export * from './utils/binary-helper-functions';
+export {
+	createWebhookOAuth2State,
+	generatePKCECodeChallenge,
+	generatePKCECodeVerifier,
+	verifyWebhookOAuth2State,
+} from './utils/webhook-oauth2-helpers';

--- a/packages/core/src/execution-engine/node-execution-context/utils/webhook-oauth2-helpers.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/webhook-oauth2-helpers.ts
@@ -18,7 +18,7 @@ type WebhookOAuth2StatePayload = z.infer<typeof webhookOAuth2StateSchema>;
 export function createWebhookOAuth2State(returnUrl: string, codeVerifier?: string): string {
 	const payload: WebhookOAuth2StatePayload = { returnUrl, iat: Date.now() };
 	if (codeVerifier) payload.cv = codeVerifier;
-	return Container.get(Cipher).encrypt(JSON.stringify(payload));
+	return Container.get(Cipher).encryptDEKWithInstanceKey(JSON.stringify(payload));
 }
 
 /** Decrypt and validate the OAuth2 state. Returns null if invalid, tampered, or expired. */
@@ -26,7 +26,7 @@ export function verifyWebhookOAuth2State(
 	state: string,
 ): { returnUrl: string; codeVerifier?: string } | null {
 	try {
-		const plaintext = Container.get(Cipher).decrypt(state);
+		const plaintext = Container.get(Cipher).decryptDEKWithInstanceKey(state);
 		const payload = webhookOAuth2StateSchema.parse(JSON.parse(plaintext));
 		if (Date.now() - payload.iat > STATE_TTL_MS) return null;
 		return { returnUrl: payload.returnUrl, codeVerifier: payload.cv };

--- a/packages/core/src/execution-engine/node-execution-context/utils/webhook-oauth2-helpers.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/webhook-oauth2-helpers.ts
@@ -1,0 +1,44 @@
+import { Container } from '@n8n/di';
+import { createHash, randomBytes } from 'crypto';
+import { z } from 'zod';
+
+import { Cipher } from '../../../encryption/cipher';
+
+const STATE_TTL_MS = 5 * 60 * 1000;
+
+const webhookOAuth2StateSchema = z.object({
+	returnUrl: z.string(),
+	iat: z.number(),
+	cv: z.string().optional(),
+});
+
+type WebhookOAuth2StatePayload = z.infer<typeof webhookOAuth2StateSchema>;
+
+/** Encrypt OAuth2 state carrying the form's return URL and optional PKCE code_verifier. */
+export function createWebhookOAuth2State(returnUrl: string, codeVerifier?: string): string {
+	const payload: WebhookOAuth2StatePayload = { returnUrl, iat: Date.now() };
+	if (codeVerifier) payload.cv = codeVerifier;
+	return Container.get(Cipher).encrypt(JSON.stringify(payload));
+}
+
+/** Decrypt and validate the OAuth2 state. Returns null if invalid, tampered, or expired. */
+export function verifyWebhookOAuth2State(
+	state: string,
+): { returnUrl: string; codeVerifier?: string } | null {
+	try {
+		const plaintext = Container.get(Cipher).decrypt(state);
+		const payload = webhookOAuth2StateSchema.parse(JSON.parse(plaintext));
+		if (Date.now() - payload.iat > STATE_TTL_MS) return null;
+		return { returnUrl: payload.returnUrl, codeVerifier: payload.cv };
+	} catch {
+		return null;
+	}
+}
+
+export function generatePKCECodeVerifier(): string {
+	return randomBytes(32).toString('base64url');
+}
+
+export function generatePKCECodeChallenge(verifier: string): string {
+	return createHash('sha256').update(verifier).digest('base64url');
+}

--- a/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
@@ -194,7 +194,8 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 
 		// Recover code_verifier from the state param (present for PKCE flows).
 		const rawState = (req.query as Record<string, string>)['_oauth_state'];
-		const codeVerifier = rawState ? verifyWebhookOAuth2State(rawState)?.codeVerifier : undefined;
+		const state = rawState ? verifyWebhookOAuth2State(rawState) : undefined;
+		const codeVerifier = state?.codeVerifier;
 
 		const oAuth = new ClientOAuth2({
 			clientId: credentials.clientId as string,

--- a/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
@@ -152,7 +152,7 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 
 	async buildWebhookOAuth2RedirectUrl(): Promise<string> {
 		const req = this.assertHttpRequest();
-		const credentials = await this.getCredentials('webhookOAuth2Authentication');
+		const credentials = await this.getCredentials('webhookOAuth2Api');
 		const returnUrl = req.originalUrl;
 		const callbackUrl = `${this.additionalData.restApiUrl}/oauth2-credential/webhook-callback`;
 
@@ -189,7 +189,7 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 
 	async exchangeOAuth2Code(code: string): Promise<IFormUser> {
 		const req = this.assertHttpRequest();
-		const credentials = await this.getCredentials('webhookOAuth2Authentication');
+		const credentials = await this.getCredentials('webhookOAuth2Api');
 		const callbackUrl = `${this.additionalData.restApiUrl}/oauth2-credential/webhook-callback`;
 
 		// Recover code_verifier from the state param (present for PKCE flows).

--- a/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
@@ -1,10 +1,13 @@
+import { ClientOAuth2 } from '@n8n/client-oauth2';
 import type { Request, Response } from 'express';
+import jwt from 'jsonwebtoken';
 import type {
 	AINodeConnectionType,
 	CloseFunction,
 	ICredentialDataDecryptedObject,
 	IDataObject,
 	IExecuteData,
+	IFormUser,
 	INode,
 	INodeExecutionData,
 	IRunExecutionData,
@@ -25,6 +28,13 @@ import { getInputConnectionData } from './utils/get-input-connection-data';
 import { getRequestHelperFunctions } from './utils/request-helper-functions';
 import { returnJsonArray } from './utils/return-json-array';
 import { getNodeWebhookUrl } from './utils/webhook-helper-functions';
+import {
+	createWebhookOAuth2State,
+	generatePKCECodeChallenge,
+	generatePKCECodeVerifier,
+	verifyWebhookOAuth2State,
+} from './utils/webhook-oauth2-helpers';
+
 export class WebhookContext extends NodeExecutionContext implements IWebhookFunctions {
 	readonly helpers: IWebhookFunctions['helpers'];
 
@@ -138,6 +148,89 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 			throw new ApplicationError('Cookie auth validation is not available');
 		}
 		return await this.additionalData.validateCookieAuth(cookieValue);
+	}
+
+	async buildWebhookOAuth2RedirectUrl(): Promise<string> {
+		const req = this.assertHttpRequest();
+		const credentials = await this.getCredentials('webhookOAuth2Authentication');
+		const returnUrl = req.originalUrl;
+		const callbackUrl = `${this.additionalData.restApiUrl}/oauth2-credential/webhook-callback`;
+
+		const isPkce = credentials.grantType === 'pkce';
+		let codeVerifier: string | undefined;
+		const queryAdditions: Record<string, string> = {};
+		if (isPkce) {
+			codeVerifier = generatePKCECodeVerifier();
+			queryAdditions.code_challenge = generatePKCECodeChallenge(codeVerifier);
+			queryAdditions.code_challenge_method = 'S256';
+		}
+
+		const state = createWebhookOAuth2State(returnUrl, codeVerifier);
+
+		const oAuth = new ClientOAuth2({
+			clientId: credentials.clientId as string,
+			clientSecret: (credentials.clientSecret as string) || undefined,
+			authorizationUri: credentials.authUrl as string,
+			accessTokenUri: credentials.accessTokenUrl as string,
+			redirectUri: callbackUrl,
+			scopes: (credentials.scope as string).split(' ').filter(Boolean),
+		});
+
+		const authUri = oAuth.code.getUri({ state, query: queryAdditions });
+
+		if ((req.query as Record<string, string>)['_oauth_reauth'] === '1') {
+			const url = new URL(authUri);
+			url.searchParams.set('prompt', 'login');
+			return url.toString();
+		}
+
+		return authUri;
+	}
+
+	async exchangeOAuth2Code(code: string): Promise<IFormUser> {
+		const req = this.assertHttpRequest();
+		const credentials = await this.getCredentials('webhookOAuth2Authentication');
+		const callbackUrl = `${this.additionalData.restApiUrl}/oauth2-credential/webhook-callback`;
+
+		// Recover code_verifier from the state param (present for PKCE flows).
+		const rawState = (req.query as Record<string, string>)['_oauth_state'];
+		const codeVerifier = rawState ? verifyWebhookOAuth2State(rawState)?.codeVerifier : undefined;
+
+		const oAuth = new ClientOAuth2({
+			clientId: credentials.clientId as string,
+			clientSecret: (credentials.clientSecret as string) || undefined,
+			authorizationUri: credentials.authUrl as string,
+			accessTokenUri: credentials.accessTokenUrl as string,
+			redirectUri: callbackUrl,
+			scopes: (credentials.scope as string).split(' ').filter(Boolean),
+		});
+
+		const tokenCallbackUrl = `${callbackUrl}?code=${encodeURIComponent(code)}`;
+		const token = await oAuth.code.getToken(
+			tokenCallbackUrl,
+			codeVerifier ? { body: { code_verifier: codeVerifier } } : {},
+		);
+
+		// Extract user info from id_token (present when openid scope was granted).
+		const idToken = (token.data as Record<string, string>).id_token;
+		if (!idToken) {
+			return { id: '', email: '', firstName: '', lastName: '' };
+		}
+
+		const decoded = jwt.decode(idToken);
+		if (!decoded || typeof decoded === 'string') {
+			return { id: '', email: '', firstName: '', lastName: '' };
+		}
+		const claims = decoded as Record<string, unknown>;
+
+		const sub = typeof claims.sub === 'string' ? claims.sub : '';
+		const email = typeof claims.email === 'string' ? claims.email : '';
+		const name = typeof claims.name === 'string' ? claims.name : '';
+		const picture = typeof claims.picture === 'string' ? claims.picture : undefined;
+		const emailVerified =
+			typeof claims.email_verified === 'boolean' ? claims.email_verified : undefined;
+
+		return { id: sub, email, firstName: name, lastName: '', picture, emailVerified };
 	}
 
 	async getInputConnectionData(

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.vue
@@ -177,6 +177,12 @@ const isGoogleOAuthType = computed(
 );
 
 const oAuthCallbackUrl = computed(() => {
+	// Webhook OAuth2 credentials use a dedicated callback that bridges the provider
+	// back to the form/webhook URL — not the regular credential-token callback.
+	if (credentialTypeName.value === 'webhookOAuth2Authentication') {
+		const oauth2Url = rootStore.OAuthCallbackUrls['oauth2' as keyof {}] as string | undefined;
+		return oauth2Url?.replace(/\/callback$/, '/webhook-callback') ?? '';
+	}
 	const oauthType =
 		credentialTypeName.value === 'oAuth2Api' || props.parentTypes.includes('oAuth2Api')
 			? 'oauth2'

--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialConfig.vue
@@ -179,7 +179,7 @@ const isGoogleOAuthType = computed(
 const oAuthCallbackUrl = computed(() => {
 	// Webhook OAuth2 credentials use a dedicated callback that bridges the provider
 	// back to the form/webhook URL — not the regular credential-token callback.
-	if (credentialTypeName.value === 'webhookOAuth2Authentication') {
+	if (credentialTypeName.value === 'webhookOAuth2Api') {
 		const oauth2Url = rootStore.OAuthCallbackUrls['oauth2' as keyof {}] as string | undefined;
 		return oauth2Url?.replace(/\/callback$/, '/webhook-callback') ?? '';
 	}

--- a/packages/nodes-base/credentials/WebhookOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/WebhookOAuth2Api.credentials.ts
@@ -1,9 +1,11 @@
 import type { ICredentialType, Icon, INodeProperties } from 'n8n-workflow';
 
-export class WebhookOAuth2Authentication implements ICredentialType {
-	name = 'webhookOAuth2Authentication';
+export class WebhookOAuth2Api implements ICredentialType {
+	name = 'webhookOAuth2Api';
 
-	displayName = 'Webhook OAuth2 Authentication';
+	displayName = 'Webhook OAuth2 API';
+
+	documentationUrl = 'https://docs.n8n.io/api/authentication/';
 
 	icon: Icon = 'node:n8n-nodes-base.formTrigger';
 

--- a/packages/nodes-base/credentials/WebhookOAuth2Authentication.credentials.ts
+++ b/packages/nodes-base/credentials/WebhookOAuth2Authentication.credentials.ts
@@ -1,0 +1,48 @@
+import type { ICredentialType, INodeProperties } from 'n8n-workflow';
+
+export class WebhookOAuth2Authentication implements ICredentialType {
+	name = 'webhookOAuth2Authentication';
+
+	displayName = 'Webhook OAuth2 Authentication';
+
+	extends = ['oAuth2Api'];
+
+	properties: INodeProperties[] = [
+		{
+			displayName: 'Client Secret',
+			name: 'clientSecret',
+			type: 'string',
+			typeOptions: { password: true },
+			default: '',
+			displayOptions: {
+				hide: {
+					grantType: ['pkce'],
+				},
+			},
+		},
+		{
+			displayName: 'Scope',
+			name: 'scope',
+			type: 'string',
+			default: 'openid profile email',
+			description:
+				'Include <code>openid profile email</code> to display user information in the "Logged in As" banner. Without <code>openid</code> no user data can be retrieved.',
+		},
+		// Hidden fields: inherited from oAuth2Api but not applicable here.
+		// Token requests always use the Authorization header — there's no UI path that needs `body` mode.
+		{
+			displayName: 'Authentication',
+			name: 'authentication',
+			type: 'hidden',
+			default: 'header',
+		},
+		// Domain restrictions only apply to credentials reused in HTTP Request nodes.
+		// This credential authenticates form visitors; it doesn't make outbound HTTP requests on a user's behalf.
+		{
+			displayName: 'Allowed HTTP Request Domains',
+			name: 'allowedHttpRequestDomains',
+			type: 'hidden',
+			default: 'none',
+		},
+	];
+}

--- a/packages/nodes-base/credentials/WebhookOAuth2Authentication.credentials.ts
+++ b/packages/nodes-base/credentials/WebhookOAuth2Authentication.credentials.ts
@@ -1,9 +1,11 @@
-import type { ICredentialType, INodeProperties } from 'n8n-workflow';
+import type { ICredentialType, Icon, INodeProperties } from 'n8n-workflow';
 
 export class WebhookOAuth2Authentication implements ICredentialType {
 	name = 'webhookOAuth2Authentication';
 
 	displayName = 'Webhook OAuth2 Authentication';
+
+	icon: Icon = 'node:n8n-nodes-base.formTrigger';
 
 	extends = ['oAuth2Api'];
 

--- a/packages/nodes-base/credentials/WebhookOAuth2Authentication.credentials.ts
+++ b/packages/nodes-base/credentials/WebhookOAuth2Authentication.credentials.ts
@@ -9,15 +9,42 @@ export class WebhookOAuth2Authentication implements ICredentialType {
 
 	properties: INodeProperties[] = [
 		{
+			displayName: 'Grant Type',
+			name: 'grantType',
+			type: 'options',
+			options: [
+				{
+					name: 'Authorization Code',
+					value: 'authorizationCode',
+				},
+				{
+					name: 'PKCE',
+					value: 'pkce',
+				},
+			],
+			default: 'authorizationCode',
+		},
+		{
 			displayName: 'Client Secret',
 			name: 'clientSecret',
 			type: 'string',
 			typeOptions: { password: true },
 			default: '',
+			required: true,
 			displayOptions: {
-				hide: {
-					grantType: ['pkce'],
-				},
+				hide: { grantType: ['pkce'] },
+			},
+		},
+		{
+			displayName: 'Client Secret',
+			name: 'clientSecret',
+			type: 'string',
+			typeOptions: { password: true },
+			default: '',
+			description:
+				'Optional for public clients (native/mobile/SPA apps). Required by some providers even with PKCE — e.g. Google "Web application" clients.',
+			displayOptions: {
+				show: { grantType: ['pkce'] },
 			},
 		},
 		{
@@ -28,16 +55,12 @@ export class WebhookOAuth2Authentication implements ICredentialType {
 			description:
 				'Include <code>openid profile email</code> to display user information in the "Logged in As" banner. Without <code>openid</code> no user data can be retrieved.',
 		},
-		// Hidden fields: inherited from oAuth2Api but not applicable here.
-		// Token requests always use the Authorization header — there's no UI path that needs `body` mode.
 		{
 			displayName: 'Authentication',
 			name: 'authentication',
 			type: 'hidden',
 			default: 'header',
 		},
-		// Domain restrictions only apply to credentials reused in HTTP Request nodes.
-		// This credential authenticates form visitors; it doesn't make outbound HTTP requests on a user's behalf.
 		{
 			displayName: 'Allowed HTTP Request Domains',
 			name: 'allowedHttpRequestDomains',

--- a/packages/nodes-base/nodes/Form/FormTrigger.node.ts
+++ b/packages/nodes-base/nodes/Form/FormTrigger.node.ts
@@ -13,7 +13,7 @@ export class FormTrigger extends VersionedNodeType {
 			iconColor: 'teal',
 			group: ['trigger'],
 			description: 'Generate webforms in n8n and pass their responses to the workflow',
-			defaultVersion: 2.6,
+			defaultVersion: 2.7,
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
@@ -25,6 +25,7 @@ export class FormTrigger extends VersionedNodeType {
 			2.4: new FormTriggerV2(baseDescription),
 			2.5: new FormTriggerV2(baseDescription),
 			2.6: new FormTriggerV2(baseDescription),
+			2.7: new FormTriggerV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/Form/interfaces.ts
+++ b/packages/nodes-base/nodes/Form/interfaces.ts
@@ -1,4 +1,4 @@
-import type { GenericValue } from 'n8n-workflow';
+import type { GenericValue, IFormUser } from 'n8n-workflow';
 
 export type FormField = {
 	id: string;
@@ -49,6 +49,10 @@ export type FormTriggerData = {
 	buttonLabel?: string;
 	dangerousCustomCss?: string;
 	authToken?: string;
+	oauthUser?: Pick<IFormUser, 'email' | 'firstName' | 'picture' | 'emailVerified'>;
+	displayLoggedInBanner?: boolean;
+	reAuthUrl?: string;
+	canonicalFormUrl?: string;
 };
 
 export const FORM_TRIGGER_AUTHENTICATION_PROPERTY = 'authentication';

--- a/packages/nodes-base/nodes/Form/test/FormTriggerV2.node.test.ts
+++ b/packages/nodes-base/nodes/Form/test/FormTriggerV2.node.test.ts
@@ -51,31 +51,39 @@ describe('FormTrigger', () => {
 		}
 	});
 
-	it('should expose n8nUserAuth option only on typeVersion >= 2.6', () => {
+	it('should gate n8nUserAuth to >= 2.6 and webhookOAuth2 to >= 2.7', () => {
 		const formTriggerV2 = new FormTriggerV2({
 			displayName: 'n8n Form Trigger',
 			name: 'formTrigger',
 			group: ['trigger'],
 			description: 'Generate webforms in n8n and pass their responses to the workflow',
-			defaultVersion: 2.6,
+			defaultVersion: 2.7,
 		});
 
 		const authParams = formTriggerV2.description.properties.filter(
 			(property) => property.name === FORM_TRIGGER_AUTHENTICATION_PROPERTY,
 		) as VersionedAuthParam[];
 
-		expect(authParams).toHaveLength(2);
+		const versionShow = (param: VersionedAuthParam) =>
+			param.displayOptions?.show?.['@version']?.[0];
+		const versionCnd = (param: VersionedAuthParam) => {
+			const entry = versionShow(param);
+			return typeof entry === 'object' ? entry._cnd : undefined;
+		};
+		const optionValues = (param: VersionedAuthParam | undefined) =>
+			(param?.options ?? []).map((o) => o.value);
 
-		const versionCnd = (param: VersionedAuthParam) =>
-			param.displayOptions?.show?.['@version']?.[0]?._cnd;
-		const legacyAuth = authParams.find((p) => versionCnd(p)?.lte === 2.5);
-		const v26Auth = authParams.find((p) => versionCnd(p)?.gte === 2.6);
+		const legacyAuth = optionValues(authParams.find((p) => versionCnd(p)?.lte === 2.5));
+		const v26Auth = optionValues(authParams.find((p) => versionShow(p) === 2.6));
+		const v27Auth = optionValues(authParams.find((p) => versionCnd(p)?.gte === 2.7));
 
-		const legacyValues = (legacyAuth?.options ?? []).map((o) => o.value).sort();
-		const v26Values = (v26Auth?.options ?? []).map((o) => o.value).sort();
+		expect(legacyAuth).not.toContain('n8nUserAuth');
+		expect(v26Auth).toContain('n8nUserAuth');
+		expect(v27Auth).toContain('n8nUserAuth');
 
-		expect(legacyValues).toEqual(['basicAuth', 'none']);
-		expect(v26Values).toEqual(['basicAuth', 'n8nUserAuth', 'none']);
+		expect(legacyAuth).not.toContain('webhookOAuth2');
+		expect(v26Auth).not.toContain('webhookOAuth2');
+		expect(v27Auth).toContain('webhookOAuth2');
 	});
 
 	it('should render a form template with correct fields', async () => {

--- a/packages/nodes-base/nodes/Form/test/utils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/utils.test.ts
@@ -991,6 +991,102 @@ describe('FormTrigger, formWebhook', () => {
 			expect(json.user).toBeUndefined();
 		});
 	});
+
+	describe('webhookOAuth2', () => {
+		const formFields: FormFieldsParameter = [
+			{ fieldLabel: 'Name', fieldType: 'text', requiredField: true },
+		];
+		const formUser = {
+			id: 'sub-1',
+			email: 'user@example.com',
+			firstName: 'Test User',
+			lastName: '',
+			picture: 'https://example.com/avatar.png',
+			emailVerified: true,
+		};
+
+		const setupContext = (
+			ctx: ReturnType<typeof mock<IWebhookFunctions>>,
+			originalUrl: string,
+			query: Record<string, string>,
+		) => {
+			const render = jest.fn();
+			const status = jest.fn(() => ({ send: jest.fn() })) as any;
+			const redirect = jest.fn();
+
+			ctx.getNode.mockReturnValue({ typeVersion: 2.7, id: 'node-1', webhookId: 'wh-1' } as INode);
+			ctx.getNodeParameter.calledWith('options').mockReturnValue({});
+			ctx.getNodeParameter.calledWith('formTitle').mockReturnValue('Test Form');
+			ctx.getNodeParameter.calledWith('formDescription').mockReturnValue('Test Description');
+			ctx.getNodeParameter.calledWith('responseMode').mockReturnValue('onReceived');
+			ctx.getNodeParameter.calledWith('authentication').mockReturnValue('webhookOAuth2');
+			ctx.getNodeParameter.calledWith('formFields.values').mockReturnValue(formFields);
+			ctx.getRequestObject.mockReturnValue({
+				method: 'GET',
+				originalUrl,
+				query,
+				headers: { host: 'localhost:5678' },
+				protocol: 'http',
+				ips: [],
+				ip: '127.0.0.1',
+			} as never);
+			ctx.getResponseObject.mockReturnValue({
+				render,
+				redirect,
+				status,
+				setHeader: jest.fn(),
+				writeHead: jest.fn(),
+				end: jest.fn(),
+			} as never);
+			ctx.getMode.mockReturnValue('manual');
+			ctx.getInstanceId.mockReturnValue('instanceId');
+			ctx.getChildNodes.mockReturnValue([]);
+
+			return { render, redirect };
+		};
+
+		beforeEach(() => {
+			jest.clearAllMocks();
+		});
+
+		it('exchanges the code and renders with a canonical URL that strips the OAuth params', async () => {
+			const ctx = mock<IWebhookFunctions>();
+			const { render } = setupContext(
+				ctx,
+				'/form/test?foo=bar&_oauth_code=abc123&_oauth_state=enc.state',
+				{ foo: 'bar', _oauth_code: 'abc123', _oauth_state: 'enc.state' },
+			);
+			ctx.exchangeOAuth2Code.mockResolvedValue(formUser);
+
+			await formWebhook(ctx);
+
+			expect(ctx.exchangeOAuth2Code).toHaveBeenCalledWith('abc123');
+			expect(render).toHaveBeenCalledWith(
+				'form-trigger',
+				expect.objectContaining({
+					canonicalFormUrl: '/form/test?foo=bar',
+					oauthUser: {
+						email: 'user@example.com',
+						firstName: 'Test User',
+						picture: 'https://example.com/avatar.png',
+						emailVerified: true,
+					},
+				}),
+			);
+		});
+
+		it('redirects to the OAuth provider on GET without an _oauth_code', async () => {
+			const ctx = mock<IWebhookFunctions>();
+			const { redirect } = setupContext(ctx, '/form/test', {});
+			ctx.buildWebhookOAuth2RedirectUrl.mockResolvedValue('https://provider.example.com/auth?...');
+
+			const result = await formWebhook(ctx);
+
+			expect(ctx.buildWebhookOAuth2RedirectUrl).toHaveBeenCalled();
+			expect(redirect).toHaveBeenCalledWith('https://provider.example.com/auth?...');
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+	});
 });
 
 describe('FormTrigger, prepareFormData', () => {
@@ -1286,6 +1382,39 @@ describe('FormTrigger, prepareFormData', () => {
 			{ id: 'option1_field-1', label: 'Blue' },
 			{ id: 'option2_field-1', label: 'Green' },
 		]);
+	});
+
+	it('passes webhookOAuth2 banner and canonical URL fields through to template data', () => {
+		const result = prepareFormData({
+			formTitle: 'Test Form',
+			formDescription: 'desc',
+			formSubmittedText: undefined,
+			redirectUrl: undefined,
+			formFields: [],
+			testRun: false,
+			query: {},
+			oauthUser: {
+				email: 'user@example.com',
+				firstName: 'Test User',
+				picture: 'https://example.com/avatar.png',
+				emailVerified: true,
+			},
+			displayLoggedInBanner: true,
+			reAuthUrl: '/form/test?_oauth_reauth=1',
+			canonicalFormUrl: '/form/test',
+		});
+
+		expect(result).toMatchObject({
+			oauthUser: {
+				email: 'user@example.com',
+				firstName: 'Test User',
+				picture: 'https://example.com/avatar.png',
+				emailVerified: true,
+			},
+			displayLoggedInBanner: true,
+			reAuthUrl: '/form/test?_oauth_reauth=1',
+			canonicalFormUrl: '/form/test',
+		});
 	});
 });
 

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -849,9 +849,12 @@ export async function formWebhook(
 					// Strip the one-shot OAuth params from the URL on the client (via
 					// history.replaceState) so a page reload re-enters the OAuth flow
 					// cleanly instead of trying to reuse an already-spent code.
+					// `_oauth_reauth` is also removed — otherwise the next reload would
+					// force `prompt=login` again, locking the user in a re-auth loop.
 					const cleanUrl = new URL(req.originalUrl, 'http://placeholder.invalid');
 					cleanUrl.searchParams.delete('_oauth_code');
 					cleanUrl.searchParams.delete('_oauth_state');
+					cleanUrl.searchParams.delete('_oauth_reauth');
 					canonicalFormUrl = `${cleanUrl.pathname}${cleanUrl.search}${cleanUrl.hash}`;
 				} else {
 					const redirectUrl = await context.buildWebhookOAuth2RedirectUrl();

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -6,6 +6,7 @@ import jwt from 'jsonwebtoken';
 import { DateTime } from 'luxon';
 import { getHtmlSandboxCSP, InstanceSettings, isFormHtmlSandboxingDisabled } from 'n8n-core';
 import type {
+	IFormUser,
 	INode,
 	INodeExecutionData,
 	IUser,
@@ -53,6 +54,8 @@ type FormUserAuthClaims = {
 	lastName: string;
 	nid: string;
 	wid: string;
+	picture?: string;
+	emailVerified?: boolean;
 };
 
 function isFormUserAuthClaims(value: unknown): value is FormUserAuthClaims {
@@ -230,6 +233,10 @@ export function prepareFormData({
 	customCss,
 	nodeVersion,
 	authToken,
+	oauthUser,
+	displayLoggedInBanner,
+	reAuthUrl,
+	canonicalFormUrl,
 }: {
 	formTitle: string;
 	formDescription: string;
@@ -246,6 +253,10 @@ export function prepareFormData({
 	customCss?: string;
 	nodeVersion?: number;
 	authToken?: string;
+	oauthUser?: Pick<IFormUser, 'email' | 'firstName' | 'picture' | 'emailVerified'>;
+	displayLoggedInBanner?: boolean;
+	reAuthUrl?: string;
+	canonicalFormUrl?: string;
 }) {
 	const utm_campaign = instanceId ? `&utm_campaign=${instanceId}` : '';
 	const n8nWebsiteLink = `https://n8n.io/?utm_source=n8n-internal&utm_medium=form-trigger${utm_campaign}`;
@@ -268,6 +279,10 @@ export function prepareFormData({
 		buttonLabel,
 		dangerousCustomCss: sanitizeCustomCss(customCss),
 		authToken,
+		oauthUser,
+		displayLoggedInBanner,
+		reAuthUrl,
+		canonicalFormUrl,
 	};
 
 	if (redirectUrl) {
@@ -552,6 +567,10 @@ export function renderForm({
 	buttonLabel,
 	customCss,
 	authToken,
+	oauthUser,
+	displayLoggedInBanner,
+	reAuthUrl,
+	canonicalFormUrl,
 }: {
 	context: IWebhookFunctions;
 	res: Response;
@@ -566,6 +585,10 @@ export function renderForm({
 	buttonLabel?: string;
 	customCss?: string;
 	authToken?: string;
+	oauthUser?: Pick<IFormUser, 'email' | 'firstName' | 'picture' | 'emailVerified'>;
+	displayLoggedInBanner?: boolean;
+	reAuthUrl?: string;
+	canonicalFormUrl?: string;
 }) {
 	const instanceId = context.getInstanceId();
 
@@ -608,6 +631,10 @@ export function renderForm({
 		customCss,
 		nodeVersion: context.getNode().typeVersion,
 		authToken,
+		oauthUser,
+		displayLoggedInBanner,
+		reAuthUrl,
+		canonicalFormUrl,
 	});
 
 	if (!isFormHtmlSandboxingDisabled()) {
@@ -658,7 +685,7 @@ export const isFormConnected = (nodes: NodeTypeAndVersion[]) => {
  * preventing replay across forms. Signed with HS256 using the instance's
  * hmac signature secret.
  */
-export function generateFormUserAuthToken(node: INode, user: IUser): string {
+export function generateFormUserAuthToken(node: INode, user: IUser | IFormUser): string {
 	const secret = Container.get(InstanceSettings).hmacSignatureSecret;
 	const payload: FormUserAuthClaims = {
 		sub: user.id,
@@ -667,6 +694,8 @@ export function generateFormUserAuthToken(node: INode, user: IUser): string {
 		lastName: user.lastName,
 		nid: node.id,
 		wid: node.webhookId ?? '',
+		picture: (user as IFormUser).picture,
+		emailVerified: (user as IFormUser).emailVerified,
 	};
 	return jwt.sign(payload, secret, {
 		algorithm: 'HS256',
@@ -679,7 +708,7 @@ export function generateFormUserAuthToken(node: INode, user: IUser): string {
  * encoded user on success or `null` on any failure (bad format, expired,
  * wrong signature, wrong node). The caller decides how to surface the failure.
  */
-export function verifyFormUserAuthToken(token: string, node: INode): IUser | null {
+export function verifyFormUserAuthToken(token: string, node: INode): IFormUser | null {
 	const secret = Container.get(InstanceSettings).hmacSignatureSecret;
 	let claims: unknown;
 	try {
@@ -695,6 +724,8 @@ export function verifyFormUserAuthToken(token: string, node: INode): IUser | nul
 		email: claims.email,
 		firstName: claims.firstName,
 		lastName: claims.lastName,
+		picture: claims.picture,
+		emailVerified: claims.emailVerified,
 	};
 }
 
@@ -794,12 +825,48 @@ export async function formWebhook(
 	}
 
 	const authentication = (context.getNodeParameter(authProperty) as string) ?? 'none';
-	let authedUser: IUser | undefined;
+	let authedUser: IFormUser | undefined;
+	let oauthUser: Pick<IFormUser, 'email' | 'firstName' | 'picture' | 'emailVerified'> | undefined;
+	let canonicalFormUrl: string | undefined;
 	if (node.typeVersion > 1) {
 		if (authentication === 'n8nUserAuth') {
 			const user = await authenticateFormUserOrRespond(context);
 			if (!user) return { noWebhookResponse: true };
 			authedUser = user;
+		} else if (authentication === 'webhookOAuth2') {
+			const method = req.method.toUpperCase();
+			if (method === 'GET') {
+				const code = (req.query as Record<string, string>)['_oauth_code'];
+				if (code) {
+					const formUser = await context.exchangeOAuth2Code(code);
+					authedUser = formUser;
+					oauthUser = {
+						email: formUser.email,
+						firstName: formUser.firstName,
+						picture: formUser.picture,
+						emailVerified: formUser.emailVerified,
+					};
+					// Strip the one-shot OAuth params from the URL on the client (via
+					// history.replaceState) so a page reload re-enters the OAuth flow
+					// cleanly instead of trying to reuse an already-spent code.
+					const cleanUrl = new URL(req.originalUrl, 'http://placeholder.invalid');
+					cleanUrl.searchParams.delete('_oauth_code');
+					cleanUrl.searchParams.delete('_oauth_state');
+					canonicalFormUrl = `${cleanUrl.pathname}${cleanUrl.search}${cleanUrl.hash}`;
+				} else {
+					const redirectUrl = await context.buildWebhookOAuth2RedirectUrl();
+					res.redirect(redirectUrl);
+					return { noWebhookResponse: true };
+				}
+			} else {
+				const token = req.headers['x-auth-token'];
+				const user = typeof token === 'string' ? verifyFormUserAuthToken(token, node) : null;
+				if (!user) {
+					res.status(401).send();
+					return { noWebhookResponse: true };
+				}
+				authedUser = user;
+			}
 		} else {
 			try {
 				await validateWebhookAuthentication(context, authProperty);
@@ -882,10 +949,21 @@ export async function formWebhook(
 				// (null origin + SameSite=Lax). Embed an HMAC token so the
 				// POST handler can re-authenticate the user.
 				authToken = generateFormUserAuthToken(node, authedUser);
+			} else if (authentication === 'webhookOAuth2' && authedUser) {
+				authToken = generateFormUserAuthToken(node, authedUser);
 			} else {
 				authToken = await generateFormPostBasicAuthToken(context, authProperty);
 			}
 		}
+
+		const displayLoggedInBanner =
+			authentication === 'webhookOAuth2'
+				? ((context.getNodeParameter('options', {}) as { displayLoggedInBanner?: boolean })
+						.displayLoggedInBanner ?? true)
+				: undefined;
+
+		const reAuthUrl =
+			authentication === 'webhookOAuth2' ? `${req.path}?_oauth_reauth=1` : undefined;
 
 		renderForm({
 			context,
@@ -901,6 +979,10 @@ export async function formWebhook(
 			buttonLabel,
 			customCss: options.customCss,
 			authToken,
+			oauthUser,
+			displayLoggedInBanner,
+			reAuthUrl,
+			canonicalFormUrl,
 		});
 
 		return {
@@ -920,8 +1002,21 @@ export async function formWebhook(
 		formFields,
 		mode,
 		useWorkflowTimezone,
-		userForOutput,
+		authentication === 'webhookOAuth2' ? undefined : userForOutput,
 	);
+
+	if (authentication === 'webhookOAuth2' && authedUser) {
+		const userOutputField = (options as { userOutputField?: string }).userOutputField ?? 'user';
+		if (userOutputField) {
+			returnItem.json[userOutputField] = {
+				sub: authedUser.id,
+				email: authedUser.email,
+				name: authedUser.firstName,
+				picture: authedUser.picture,
+				emailVerified: authedUser.emailVerified,
+			};
+		}
+	}
 
 	return {
 		webhookResponse: { status: 200 },

--- a/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
+++ b/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
@@ -93,7 +93,7 @@ const descriptionV2: INodeTypeDescription = {
 			},
 		},
 		{
-			name: 'webhookOAuth2Authentication',
+			name: 'webhookOAuth2Api',
 			required: true,
 			displayOptions: {
 				show: {

--- a/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
+++ b/packages/nodes-base/nodes/Form/v2/FormTriggerV2.node.ts
@@ -41,7 +41,7 @@ const descriptionV2: INodeTypeDescription = {
 	group: ['trigger'],
 	// since trigger and node are sharing descriptions and logic we need to sync the versions
 	// and keep them aligned in both nodes
-	version: [2, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6],
+	version: [2, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7],
 	description: 'Generate webforms in n8n and pass their responses to the workflow',
 	defaults: {
 		name: 'On form submission',
@@ -92,6 +92,15 @@ const descriptionV2: INodeTypeDescription = {
 				},
 			},
 		},
+		{
+			name: 'webhookOAuth2Authentication',
+			required: true,
+			displayOptions: {
+				show: {
+					[FORM_TRIGGER_AUTHENTICATION_PROPERTY]: ['webhookOAuth2'],
+				},
+			},
+		},
 	],
 	properties: [
 		{
@@ -136,7 +145,39 @@ const descriptionV2: INodeTypeDescription = {
 				},
 			],
 			default: 'none',
-			displayOptions: { show: { '@version': [{ _cnd: { gte: 2.6 } }] } },
+			displayOptions: { show: { '@version': [2.6] } },
+			builderHint: {
+				propertyHint:
+					"Default to 'none'. n8n exposes inbound trigger URLs publicly by design. Only select an authentication method when the user explicitly asks to authenticate inbound traffic.",
+			},
+		},
+		{
+			displayName: 'Authentication',
+			name: FORM_TRIGGER_AUTHENTICATION_PROPERTY,
+			type: 'options',
+			options: [
+				{
+					name: 'Basic Auth',
+					value: 'basicAuth',
+				},
+				{
+					// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
+					name: 'n8n User Auth',
+					value: 'n8nUserAuth',
+					description: 'Require user to be logged in with their n8n account',
+				},
+				{
+					name: 'OAuth2 (External Provider)',
+					value: 'webhookOAuth2',
+					description: 'Authenticate form users via an external OAuth2 provider',
+				},
+				{
+					name: 'None',
+					value: 'none',
+				},
+			],
+			default: 'none',
+			displayOptions: { show: { '@version': [{ _cnd: { gte: 2.7 } }] } },
 			builderHint: {
 				propertyHint:
 					"Default to 'none'. n8n exposes inbound trigger URLs publicly by design. Only select an authentication method when the user explicitly asks to authenticate inbound traffic.",
@@ -219,6 +260,34 @@ const descriptionV2: INodeTypeDescription = {
 						show: {
 							'/authentication': ['n8nUserAuth'],
 							'@version': [{ _cnd: { gte: 2.6 } }],
+						},
+					},
+				},
+				{
+					displayName: 'Display "Logged in As" Banner',
+					name: 'displayLoggedInBanner',
+					type: 'boolean',
+					default: true,
+					description:
+						"Whether to show the authenticated user's name and email at the top of the form",
+					displayOptions: {
+						show: {
+							'/authentication': ['webhookOAuth2'],
+							'@version': [{ _cnd: { gte: 2.7 } }],
+						},
+					},
+				},
+				{
+					displayName: 'User Output Field',
+					name: 'userOutputField',
+					type: 'string',
+					default: 'user',
+					description:
+						"Name of the output field to add the authenticated user's data to (sub, email, name, picture, emailVerified). Leave empty to omit.",
+					displayOptions: {
+						show: {
+							'/authentication': ['webhookOAuth2'],
+							'@version': [{ _cnd: { gte: 2.7 } }],
 						},
 					},
 				},

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -399,6 +399,7 @@
       "dist/credentials/VonageApi.credentials.js",
       "dist/credentials/VenafiTlsProtectCloudApi.credentials.js",
       "dist/credentials/VenafiTlsProtectDatacenterApi.credentials.js",
+      "dist/credentials/WebhookOAuth2Authentication.credentials.js",
       "dist/credentials/WebflowApi.credentials.js",
       "dist/credentials/WebflowOAuth2Api.credentials.js",
       "dist/credentials/WekanApi.credentials.js",

--- a/packages/nodes-base/package.json
+++ b/packages/nodes-base/package.json
@@ -399,7 +399,7 @@
       "dist/credentials/VonageApi.credentials.js",
       "dist/credentials/VenafiTlsProtectCloudApi.credentials.js",
       "dist/credentials/VenafiTlsProtectDatacenterApi.credentials.js",
-      "dist/credentials/WebhookOAuth2Authentication.credentials.js",
+      "dist/credentials/WebhookOAuth2Api.credentials.js",
       "dist/credentials/WebflowApi.credentials.js",
       "dist/credentials/WebflowOAuth2Api.credentials.js",
       "dist/credentials/WekanApi.credentials.js",

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -146,6 +146,11 @@ export interface IUser {
 	lastName: string;
 }
 
+export interface IFormUser extends IUser {
+	picture?: string;
+	emailVerified?: boolean;
+}
+
 export type ProjectSharingData = {
 	id: string;
 	name: string | null;
@@ -1368,6 +1373,8 @@ export interface IWebhookFunctions extends FunctionsBaseWithRequiredKeys<'getMod
 	getResponseObject(): express.Response;
 	getWebhookName(): string;
 	validateCookieAuth(cookieValue: string): Promise<IUser>;
+	buildWebhookOAuth2RedirectUrl(): Promise<string>;
+	exchangeOAuth2Code(code: string): Promise<IFormUser>;
 	nodeHelpers: NodeHelperFunctions;
 	helpers: RequestHelperFunctions & BaseHelperFunctions & BinaryHelperFunctions;
 }


### PR DESCRIPTION
## Summary

Implements OAuth2 user authentication for forms. Adds a new `OAuth2` credential type which can be used for forms. Reuses some logic introduced by #30539. Allows gating the form behind OAuth2 authentication and also passes user data to the workflow. The implementation is done in a way that it can be reused for webhooks by adding code exchange there.

<img width="713" height="594" alt="Bildschirmfoto 2026-06-04 um 12 08 20" src="https://github.com/user-attachments/assets/2af7a2d4-e610-4d58-b073-faadd7938ddf" />

<img width="525" height="489" alt="Bildschirmfoto 2026-06-04 um 12 07 27" src="https://github.com/user-attachments/assets/a6cfbbed-5d01-4a1c-85be-2758a66908c1" />

### Technical details

Supports client id + secret and PCKE flows. Also supports client id + secret + PCKE (Google always requires the client secret for web apps even when using PCKE).

Since forms are rendered with `sandbox` CSP header they don't have access to any cookies or session/local storage. The authentication with oauth works similarly to how SPAs do it: user logs in, n8n verifies login though code/token exchange, retrieves user data and generates an internal signed token that is valid for one hour and is used to submit the form.

Technical flow: User opens n8n form -> form redirects to identity provider auth url with an encrypted state parameter -> user logs in and is redirected to `/rest/oauth2-credential/webhook-callback` (
Sets the same CSP headers in the form auth callback as in the form to prevent XSS injections) -> this endpoint validates oauth and state parameters and redirects back to original form passing the state and code -> form does code exchange, generates an internal auth token and renders. It also updates the url through browser history api to remove the oauth parameters, otherwise the user would see an error because code was already used for exchange.

<details>
<summary>Auth flow diagram</summary>

```mermaid
sequenceDiagram
    autonumber
    actor User as User (Browser)
    participant Form as Form Trigger<br/>(formWebhook)
    participant Ctx as WebhookContext<br/>helpers
    participant Provider as OAuth2 Provider<br/>(Google, Keycloak, …)
    participant CLI as n8n CLI<br/>/rest/oauth2-credential/<br/>webhook-callback

    Note over User,Form: 1) First visit — no auth yet

    User->>Form: GET /form/abc
    Form->>Ctx: buildWebhookOAuth2RedirectUrl()
    Note right of Ctx: • read credential<br/>• if PKCE: generate code_verifier + challenge<br/>• encrypt state {returnUrl, code_verifier}<br/>  using instance Cipher
    Ctx-->>Form: authorization URL
    Form-->>User: 302 → Provider

    User->>Provider: GET /authorize?...&state=…&code_challenge=…
    Provider-->>User: Login + consent
    User->>Provider: Submit credentials
    Provider-->>User: 302 → /rest/oauth2-credential/webhook-callback?code=…&state=…

    Note over User,CLI: 2) Provider hands control back to n8n

    User->>CLI: GET /webhook-callback?code=…&state=…
    Note right of CLI: • decrypt + validate state<br/>  (TTL 5 min, integrity via Cipher)<br/>• on failure → render<br/>  webhook-oauth-error template
    CLI-->>User: 302 → /form/abc?_oauth_code=…&_oauth_state=…

    Note over User,Form: 3) Code exchange + render form

    User->>Form: GET /form/abc?_oauth_code=…&_oauth_state=…
    Form->>Ctx: exchangeOAuth2Code(code)
    Note right of Ctx: • read credential<br/>• decrypt state → recover code_verifier<br/>• ClientOAuth2.code.getToken<br/>  (PKCE: code_verifier in body)<br/>• jwt.decode(id_token) → {sub, email, name, picture}
    Ctx-->>Form: IFormUser
    Form->>Form: generateFormUserAuthToken(node, user)<br/>(HS256, 1h TTL, bound to node + webhook)
    Form-->>User: 200 — render form-trigger.handlebars<br/>+ "Logged in as …" banner<br/>+ history.replaceState(canonicalFormUrl)

    Note over User: 4) Browser cleans URL — reload is now safe

    User->>Form: POST /form/abc<br/>headers: x-auth-token: <jwt><br/>body: form fields
    Form->>Form: verifyFormUserAuthToken(token, node)
    Note right of Form: includes user data in workflow<br/>output under `userOutputField`
    Form-->>User: 200
```
</details>

## How to test

1. create an app at some identity provider that can be used for authentication. Pay attention to set the correct redirect url, you can see it when creating form credentials. For local testing data from `Dimitri's google oauth for local env` can be used
2. create a workflow with a form (use the attached one)
3. run the form
4. success

<details>
<summary>Example workflow</summary>

```json
{
  "nodes": [
    {
      "parameters": {
        "operation": "completion",
        "completionTitle": "Data received",
        "completionMessage": "=Thank you  {{ $json.user.name }}, we have received your data.",
        "options": {}
      },
      "type": "n8n-nodes-base.form",
      "typeVersion": 2.5,
      "position": [
        208,
        0
      ],
      "id": "fbf1f6b7-b732-4cbb-a4cb-05fba5c4ae36",
      "name": "Form",
      "webhookId": "e60a5ba6-e32a-4764-89ce-5730025ab29e"
    },
    {
      "parameters": {
        "authentication": "webhookOAuth2",
        "formTitle": "Hello?",
        "formDescription": "Let's explore OAuth logic for forms",
        "formFields": {
          "values": [
            {
              "fieldLabel": "What do you think?"
            }
          ]
        },
        "options": {}
      },
      "type": "n8n-nodes-base.formTrigger",
      "typeVersion": 2.7,
      "position": [
        -16,
        0
      ],
      "id": "002c4b8b-0462-43d1-8d9a-7a7eedb7aaad",
      "name": "On form submission",
      "webhookId": "a1615ee2-ae85-46e8-bcdf-8ebeb1459fb6",
      "credentials": {
        "webhookOAuth2Authentication": {
          "id": "qK0wOIGooaPtfhIN",
          "name": "google Webhook Authentication account"
        }
      }
    }
  ],
  "connections": {
    "On form submission": {
      "main": [
        [
          {
            "node": "Form",
            "type": "main",
            "index": 0
          }
        ]
      ]
    }
  },
  "pinData": {},
  "meta": {
    "templateCredsSetupCompleted": true,
    "instanceId": "acd7615bcc3af421bbd7517e305cc16505176a6a47045dbe39e25d904c940573"
  }
}
```
</details>

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
