### PR TITLE
feat(httpRequest Node): Add option to request uncompressed responses

### DIFF
--- a/packages/nodes-base/nodes/HttpRequest/V3/Description.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/Description.ts
@@ -746,6 +746,15 @@ A user saying "API key" or "header auth" usually means httpBearerAuth only when 
 					'Whether to download the response even if SSL certificate validation is not possible',
 			},
 			{
+				displayName: 'Request Uncompressed Response',
+				name: 'requestUncompressedResponse',
+				type: 'boolean',
+				noDataExpression: true,
+				default: false,
+				description:
+					'Whether to disable response compression by sending "Accept-Encoding: identity". Enable this when a server returns HTTP parse errors despite returning a valid response.',
+			},
+			{
 				displayName: 'Array Format in Query Parameters',
 				name: 'queryParameterArrays',
 				type: 'options',

--- a/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
+++ b/packages/nodes-base/nodes/HttpRequest/V3/HttpRequestV3.node.ts
@@ -296,6 +296,7 @@ export class HttpRequestV3 implements INodeType {
 					proxy,
 					timeout,
 					allowUnauthorizedCerts,
+					requestUncompressedResponse,
 					queryParameterArrays,
 					response,
 					lowercaseHeaders,
@@ -305,6 +306,7 @@ export class HttpRequestV3 implements INodeType {
 					proxy: string;
 					timeout: number;
 					allowUnauthorizedCerts: boolean;
+					requestUncompressedResponse?: boolean;
 					queryParameterArrays: 'indices' | 'brackets' | 'repeat';
 					response: {
 						response: {
@@ -611,6 +613,16 @@ export class HttpRequestV3 implements INodeType {
 					} else {
 						requestOptions.headers!.accept =
 							'application/json,text/html,application/xhtml+xml,application/xml,text/*;q=0.9, image/*;q=0.8, */*;q=0.7';
+					}
+				}
+
+				if (requestUncompressedResponse) {
+					const headers = requestOptions.headers!;
+					const hasAcceptEncoding = Object.keys(headers).some(
+						(k) => k.toLowerCase() === 'accept-encoding',
+					);
+					if (!hasAcceptEncoding) {
+						headers['Accept-Encoding'] = 'identity';
 					}
 				}
 


### PR DESCRIPTION
## Summary

This is a draft fix for a suspected root cause of n8n-io/n8n#29131.

Adds a new **"Request Uncompressed Response"** option to the HTTP Request node's Options section. When enabled, it injects `Accept-Encoding: identity` into the request headers (unless the user has already set one), telling the server to send an uncompressed response body.

**Suspected root cause:** axios (used internally by n8n) automatically adds `Accept-Encoding: gzip, deflate, br` to every outgoing request. Some servers (e.g. HansaWorld Standard ERP) respond with a gzip-compressed body but set `Content-Length` to the uncompressed size — a server-side bug. This mismatch causes llhttp to raise a parse error (`HPE_INVALID_CONSTANT` / `aborted` depending on Node.js version) that surfaces as a node failure. Plain `curl` and `http.request` are unaffected because they do not advertise gzip encoding by default.

**Fix:** Enabling this option suppresses gzip negotiation for the affected request. The server responds with plain uncompressed data and a correct `Content-Length`, avoiding the parse error entirely.

**Scope of change:** Two files in the HTTP Request node only. No changes to core packages. The option defaults to `false`, so all existing workflows are unaffected.

## Related Linear tickets, Github issues, and Community forum posts

closes https://github.com/n8n-io/n8n/issues/29131

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
