### PR TITLE
fix(core): Delete orphaned per-user entries on unshare and membership changes

### DIFF
--- a/packages/@n8n/db/src/repositories/shared-credentials.repository.ts
+++ b/packages/@n8n/db/src/repositories/shared-credentials.repository.ts
@@ -147,6 +147,42 @@ export class SharedCredentialsRepository extends Repository<SharedCredentials> {
 	}
 
 	/**
+	 * Given a list of `(credentialId, userId)` pairs, returns the subset that
+	 * still retains `scope` on the credential through a project membership path:
+	 *
+	 *   SharedCredentials (credential ↔ project)
+	 *     ← ProjectRelation (project ↔ user, project role must grant `scope`)
+	 */
+	async findPairsWithCredentialAccess(
+		pairs: Array<{ credentialId: string; userId: string }>,
+		scope: Scope,
+		credentialRoles: string[],
+		trx?: EntityManager,
+	): Promise<Array<{ credentialId: string; userId: string }>> {
+		if (pairs.length === 0 || credentialRoles.length === 0) return [];
+
+		const manager = trx ?? this.manager;
+		const credentialIds = [...new Set(pairs.map((p) => p.credentialId))];
+		const userIds = [...new Set(pairs.map((p) => p.userId))];
+
+		const rows = await manager
+			.createQueryBuilder(SharedCredentials, 'sc')
+			.select(['sc.credentialsId AS "credentialId"', 'pr.userId AS "userId"'])
+			.distinct(true)
+			.innerJoin(ProjectRelation, 'pr', 'pr.projectId = sc.projectId')
+			.innerJoin('pr.role', 'pr_role')
+			.innerJoin('pr_role.scopes', 'pr_scope')
+			.where('sc.credentialsId IN (:...credentialIds)', { credentialIds })
+			.andWhere('pr.userId IN (:...userIds)', { userIds })
+			.andWhere('pr_scope.slug = :scope', { scope })
+			.andWhere('sc.role IN (:...credentialRoles)', { credentialRoles })
+			.getRawMany<{ credentialId: string; userId: string }>();
+
+		const requested = new Set(pairs.map((p) => `${p.credentialId}|${p.userId}`));
+		return rows.filter((r) => requested.has(`${r.credentialId}|${r.userId}`));
+	}
+
+	/**
 	 * Build a subquery that returns credential IDs based on sharing permissions.
 	 * This replicates the logic from CredentialsFinderService but as a subquery.
 	 *

--- a/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
+++ b/packages/cli/src/credentials/__tests__/credentials.controller.test.ts
@@ -83,6 +83,7 @@ describe('CredentialsController', () => {
 		mock(),
 		eventService,
 		credentialsFinderService,
+		mock(), // connectionStatusProxy
 	);
 
 	let req: AuthenticatedRequest;

--- a/packages/cli/src/credentials/credential-connection-status-provider.interface.ts
+++ b/packages/cli/src/credentials/credential-connection-status-provider.interface.ts
@@ -33,4 +33,11 @@ export interface ICredentialConnectionStatusProvider {
 	 * Deletes all per-user entries for the given credential. Used when toggling Private→Static.
 	 */
 	deleteAllUserEntries(credentialId: string, em?: EntityManager): Promise<void>;
+
+	/**
+	 * Re-evaluates access for the given users and deletes all their per-user
+	 * entries (across all resolvers) for any credential where they no longer
+	 * hold `credential:update`.
+	 */
+	cleanupOrphanedEntriesForUsers(userIds: string[], em?: EntityManager): Promise<void>;
 }

--- a/packages/cli/src/credentials/credential-connection-status-proxy.ts
+++ b/packages/cli/src/credentials/credential-connection-status-proxy.ts
@@ -32,4 +32,9 @@ export class CredentialConnectionStatusProxy implements ICredentialConnectionSta
 		if (!this.provider) return;
 		await this.provider.deleteAllUserEntries(credentialId, em);
 	}
+
+	async cleanupOrphanedEntriesForUsers(userIds: string[], em?: EntityManager): Promise<void> {
+		if (!this.provider || userIds.length === 0) return;
+		await this.provider.cleanupOrphanedEntriesForUsers(userIds, em);
+	}
 }

--- a/packages/cli/src/credentials/credentials.controller.ts
+++ b/packages/cli/src/credentials/credentials.controller.ts
@@ -31,6 +31,7 @@ import { In } from '@n8n/typeorm';
 import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
 import { z } from 'zod';
 
+import { CredentialConnectionStatusProxy } from './credential-connection-status-proxy';
 import { CredentialsFinderService } from './credentials-finder.service';
 import { CredentialsService } from './credentials.service';
 import { EnterpriseCredentialsService } from './credentials.service.ee';
@@ -62,6 +63,7 @@ export class CredentialsController {
 		private readonly projectRelationRepository: ProjectRelationRepository,
 		private readonly eventService: EventService,
 		private readonly credentialsFinderService: CredentialsFinderService,
+		private readonly connectionStatusProxy: CredentialConnectionStatusProxy,
 	) {}
 
 	@Get('/', { middlewares: listQueryMiddleware })
@@ -399,6 +401,12 @@ export class CredentialsController {
 			}
 		}
 
+		const unsharedProjectMembers =
+			toUnshare.length > 0
+				? await this.projectRelationRepository.findBy({ projectId: In(toUnshare) })
+				: [];
+		const affectedUserIds = [...new Set(unsharedProjectMembers.map((pr) => pr.userId))];
+
 		let amountRemoved: number | null = null;
 		let newShareeIds: string[] = [];
 
@@ -417,6 +425,7 @@ export class CredentialsController {
 
 			if (deleteResult.affected) {
 				amountRemoved = deleteResult.affected;
+				await this.connectionStatusProxy.cleanupOrphanedEntriesForUsers(affectedUserIds, trx);
 			}
 
 			newShareeIds = toShare;

--- a/packages/cli/src/modules/dynamic-credentials.ee/database/repositories/dynamic-credential-user-entry.repository.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/database/repositories/dynamic-credential-user-entry.repository.ts
@@ -1,4 +1,7 @@
 import { Service } from '@n8n/di';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
+import type { EntityManager } from '@n8n/typeorm';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { DataSource, Repository } from '@n8n/typeorm';
 
 import { DynamicCredentialUserEntry } from '../entities/dynamic-credential-user-entry';
@@ -7,5 +10,27 @@ import { DynamicCredentialUserEntry } from '../entities/dynamic-credential-user-
 export class DynamicCredentialUserEntryRepository extends Repository<DynamicCredentialUserEntry> {
 	constructor(dataSource: DataSource) {
 		super(DynamicCredentialUserEntry, dataSource.manager);
+	}
+
+	async deleteByPairs(
+		pairs: Array<{ credentialId: string; userId: string }>,
+		em: EntityManager,
+	): Promise<void> {
+		if (pairs.length === 0) return;
+
+		const whereClauses = pairs.map((_, i) => `(credentialId = :cid${i} AND userId = :uid${i})`);
+		const params = Object.fromEntries(
+			pairs.flatMap(({ credentialId, userId }, i) => [
+				[`cid${i}`, credentialId],
+				[`uid${i}`, userId],
+			]),
+		);
+
+		await em
+			.createQueryBuilder()
+			.delete()
+			.from(DynamicCredentialUserEntry)
+			.where(whereClauses.join(' OR '), params)
+			.execute();
 	}
 }

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-connection-status.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/credential-connection-status.service.test.ts
@@ -1,0 +1,197 @@
+import type { SharedCredentialsRepository, User, UserRepository } from '@n8n/db';
+import type { EntityManager } from '@n8n/typeorm';
+import { mock } from 'jest-mock-extended';
+
+import type { RoleService } from '@/services/role.service';
+
+import { DynamicCredentialUserEntry } from '../../database/entities/dynamic-credential-user-entry';
+import type { DynamicCredentialUserEntryRepository } from '../../database/repositories/dynamic-credential-user-entry.repository';
+import { CredentialConnectionStatusService } from '../credential-connection-status.service';
+
+/** Build a minimal User-shaped object that satisfies `hasGlobalScope`. */
+const makeUser = (id: string, globalScopes: string[] = []): User =>
+	({ id, role: { scopes: globalScopes.map((slug) => ({ slug })) } }) as unknown as User;
+
+const makeEntry = (credentialId: string, userId: string): DynamicCredentialUserEntry => {
+	const e = new DynamicCredentialUserEntry();
+	e.credentialId = credentialId;
+	e.userId = userId;
+	return e;
+};
+
+describe('CredentialConnectionStatusService', () => {
+	const repository = mock<DynamicCredentialUserEntryRepository>();
+	const userRepository = mock<UserRepository>();
+	const sharedCredentialsRepository = mock<SharedCredentialsRepository>();
+	const roleService = mock<RoleService>();
+	const em = mock<EntityManager>();
+
+	const service = new CredentialConnectionStatusService(
+		repository,
+		userRepository,
+		sharedCredentialsRepository,
+		roleService,
+	);
+
+	const CRED_ID = 'cred-1';
+	const VALID_CRED_ROLES = ['credential:owner', 'credential:user'];
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		roleService.rolesWithScope.mockResolvedValue(VALID_CRED_ROLES);
+	});
+
+	// ─────────────────────────── early-exit guards ────────────────────────────
+
+	describe('cleanupOrphanedEntriesForUsers', () => {
+		it('is a no-op when userIds is empty', async () => {
+			await service.cleanupOrphanedEntriesForUsers([], em);
+
+			expect(em.find).not.toHaveBeenCalled();
+			expect(repository.deleteByPairs).not.toHaveBeenCalled();
+		});
+
+		it('is a no-op when no entries exist for the given users', async () => {
+			em.find.mockResolvedValueOnce([]);
+
+			await service.cleanupOrphanedEntriesForUsers(['user-1'], em);
+
+			expect(repository.deleteByPairs).not.toHaveBeenCalled();
+		});
+	});
+
+	// ───────────── selectOrphanedPairs — decision matrix ─────────────────────
+
+	describe('selectOrphanedPairs (via cleanupOrphanedEntriesForUsers)', () => {
+		it('marks pair as orphaned when the user has been deleted from the DB', async () => {
+			// ARRANGE
+			em.find.mockResolvedValueOnce([makeEntry(CRED_ID, 'deleted-user')]);
+			userRepository.find.mockResolvedValueOnce([]); // user no longer exists
+
+			// ACT
+			await service.cleanupOrphanedEntriesForUsers(['deleted-user'], em);
+
+			// ASSERT — deleted user → always orphaned
+			expect(repository.deleteByPairs).toHaveBeenCalledWith(
+				[{ credentialId: CRED_ID, userId: 'deleted-user' }],
+				em,
+			);
+		});
+
+		it('retains pair for a global admin (has credential:update in global role scopes)', async () => {
+			// ARRANGE
+			const admin = makeUser('admin-1', ['credential:update']);
+			em.find.mockResolvedValueOnce([makeEntry(CRED_ID, 'admin-1')]);
+			userRepository.find.mockResolvedValueOnce([admin]);
+			// Even if the project check returned nothing, admin is retained in-memory
+			sharedCredentialsRepository.findPairsWithCredentialAccess.mockResolvedValueOnce([]);
+
+			// ACT
+			await service.cleanupOrphanedEntriesForUsers(['admin-1'], em);
+
+			// ASSERT — hasGlobalScope is true → pair retained → nothing deleted
+			expect(repository.deleteByPairs).not.toHaveBeenCalled();
+		});
+
+		it('retains pair for a member who still has project-level credential:update', async () => {
+			// ARRANGE
+			const member = makeUser('member-1'); // no global scope
+			em.find.mockResolvedValueOnce([makeEntry(CRED_ID, 'member-1')]);
+			userRepository.find.mockResolvedValueOnce([member]);
+			// DB check confirms the project path is still alive
+			sharedCredentialsRepository.findPairsWithCredentialAccess.mockResolvedValueOnce([
+				{ credentialId: CRED_ID, userId: 'member-1' },
+			]);
+
+			// ACT
+			await service.cleanupOrphanedEntriesForUsers(['member-1'], em);
+
+			// ASSERT — project path still valid → pair retained
+			expect(repository.deleteByPairs).not.toHaveBeenCalled();
+		});
+
+		it('deletes pair for a member who lost all credential:update access paths', async () => {
+			// ARRANGE
+			const member = makeUser('member-1'); // no global scope
+			em.find.mockResolvedValueOnce([makeEntry(CRED_ID, 'member-1')]);
+			userRepository.find.mockResolvedValueOnce([member]);
+			// No retained pairs — member was unshared / removed / role downgraded
+			sharedCredentialsRepository.findPairsWithCredentialAccess.mockResolvedValueOnce([]);
+
+			// ACT
+			await service.cleanupOrphanedEntriesForUsers(['member-1'], em);
+
+			// ASSERT — no access path survives → pair is orphaned
+			expect(repository.deleteByPairs).toHaveBeenCalledWith(
+				[{ credentialId: CRED_ID, userId: 'member-1' }],
+				em,
+			);
+		});
+
+		it('retains pair for a multi-path consumer when at least one project path survives', async () => {
+			// ARRANGE — user has entries for the same credential under two resolvers;
+			// deduplication in deleteOrphanedPairs collapses them to one logical pair.
+			const member = makeUser('member-1');
+			em.find.mockResolvedValueOnce([
+				makeEntry(CRED_ID, 'member-1'), // resolver A
+				makeEntry(CRED_ID, 'member-1'), // resolver B (duplicate pair)
+			]);
+			userRepository.find.mockResolvedValueOnce([member]);
+			// One project path was removed, but the second survives
+			sharedCredentialsRepository.findPairsWithCredentialAccess.mockResolvedValueOnce([
+				{ credentialId: CRED_ID, userId: 'member-1' },
+			]);
+
+			// ACT
+			await service.cleanupOrphanedEntriesForUsers(['member-1'], em);
+
+			// ASSERT — surviving path keeps the entry
+			expect(repository.deleteByPairs).not.toHaveBeenCalled();
+		});
+
+		it('handles mixed batch: deletes orphaned pair and retains the one with access', async () => {
+			// ARRANGE
+			const lostMember = makeUser('user-lost');
+			const activeMember = makeUser('user-active');
+			const CRED_A = 'cred-a';
+			const CRED_B = 'cred-b';
+
+			em.find.mockResolvedValueOnce([
+				makeEntry(CRED_A, 'user-lost'),
+				makeEntry(CRED_B, 'user-active'),
+			]);
+			userRepository.find.mockResolvedValueOnce([lostMember, activeMember]);
+			// Only user-active retains access
+			sharedCredentialsRepository.findPairsWithCredentialAccess.mockResolvedValueOnce([
+				{ credentialId: CRED_B, userId: 'user-active' },
+			]);
+
+			// ACT
+			await service.cleanupOrphanedEntriesForUsers(['user-lost', 'user-active'], em);
+
+			// ASSERT — only the orphaned pair is deleted
+			expect(repository.deleteByPairs).toHaveBeenCalledWith(
+				[{ credentialId: CRED_A, userId: 'user-lost' }],
+				em,
+			);
+		});
+	});
+
+	describe('deleteOrphanedPairs — DB check scope', () => {
+		it('skips the project DB check when every user has been deleted', async () => {
+			// ARRANGE — no user record in DB → pairsToCheck is empty → DB query skipped
+			em.find.mockResolvedValueOnce([makeEntry(CRED_ID, 'ghost-user')]);
+			userRepository.find.mockResolvedValueOnce([]);
+
+			// ACT
+			await service.cleanupOrphanedEntriesForUsers(['ghost-user'], em);
+
+			// ASSERT
+			expect(sharedCredentialsRepository.findPairsWithCredentialAccess).not.toHaveBeenCalled();
+			expect(repository.deleteByPairs).toHaveBeenCalledWith(
+				[{ credentialId: CRED_ID, userId: 'ghost-user' }],
+				em,
+			);
+		});
+	});
+});

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/credential-connection-status.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/credential-connection-status.service.ts
@@ -1,13 +1,21 @@
+import { In, SharedCredentialsRepository, UserRepository, type User } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { In } from '@n8n/db';
+import { hasGlobalScope } from '@n8n/permissions';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import type { EntityManager } from '@n8n/typeorm';
 
 import type { ICredentialConnectionStatusProvider } from '@/credentials/credential-connection-status-provider.interface';
+import { RoleService } from '@/services/role.service';
 
 import { SYSTEM_RESOLVER_ID } from '../constants';
 import { DynamicCredentialUserEntry } from '../database/entities/dynamic-credential-user-entry';
 import { DynamicCredentialUserEntryRepository } from '../database/repositories/dynamic-credential-user-entry.repository';
+
+type CredentialUserPair = { credentialId: string; userId: string };
+
+const CREDENTIAL_RETAIN_SCOPE = 'credential:update' as const;
+
+const keyOf = (pair: CredentialUserPair) => `${pair.credentialId}|${pair.userId}`;
 
 /**
  * Returns the set of credential ids for which a given user has a per-user
@@ -23,7 +31,12 @@ import { DynamicCredentialUserEntryRepository } from '../database/repositories/d
  */
 @Service()
 export class CredentialConnectionStatusService implements ICredentialConnectionStatusProvider {
-	constructor(private readonly repository: DynamicCredentialUserEntryRepository) {}
+	constructor(
+		private readonly repository: DynamicCredentialUserEntryRepository,
+		private readonly userRepository: UserRepository,
+		private readonly sharedCredentialsRepository: SharedCredentialsRepository,
+		private readonly roleService: RoleService,
+	) {}
 
 	async findConnectedCredentialIds(userId: string, credentialIds: string[]): Promise<Set<string>> {
 		if (credentialIds.length === 0) return new Set();
@@ -62,5 +75,77 @@ export class CredentialConnectionStatusService implements ICredentialConnectionS
 	async deleteAllUserEntries(credentialId: string, em?: EntityManager): Promise<void> {
 		const manager = em ?? this.repository.manager;
 		await manager.delete(DynamicCredentialUserEntry, { credentialId });
+	}
+
+	async cleanupOrphanedEntriesForUsers(userIds: string[], em?: EntityManager): Promise<void> {
+		if (userIds.length === 0) return;
+
+		const manager = em ?? this.repository.manager;
+
+		const entries = await manager.find(DynamicCredentialUserEntry, {
+			select: ['credentialId', 'userId'],
+			where: { userId: In(userIds) },
+		});
+
+		if (entries.length === 0) return;
+
+		const pairs = entries.map((e) => ({ credentialId: e.credentialId, userId: e.userId }));
+		await this.deleteOrphanedPairs(pairs, manager);
+	}
+
+	/**
+	 * Deletes ALL per-user entries (across all resolvers) for each
+	 * (credentialId, userId) pair whose user no longer holds `credential:update`
+	 * on the credential.
+	 */
+	private async deleteOrphanedPairs(pairs: CredentialUserPair[], em: EntityManager): Promise<void> {
+		if (pairs.length === 0) return;
+
+		const uniquePairs = [...new Map(pairs.map((p) => [keyOf(p), p])).values()];
+
+		const users = await this.userRepository.find({
+			where: { id: In(uniquePairs.map((p) => p.userId)) },
+			relations: { role: { scopes: true } },
+		});
+		const userById = new Map(users.map((u) => [u.id, u]));
+
+		const pairsToCheck = uniquePairs.filter((p) => userById.has(p.userId));
+
+		let projectRetainedKeys = new Set<string>();
+		if (pairsToCheck.length > 0) {
+			// Credential roles that carry credential:update — served from the role
+			const validCredRoles = await this.roleService.rolesWithScope(
+				'credential',
+				CREDENTIAL_RETAIN_SCOPE,
+			);
+			const projectRetained = await this.sharedCredentialsRepository.findPairsWithCredentialAccess(
+				pairsToCheck,
+				CREDENTIAL_RETAIN_SCOPE,
+				validCredRoles,
+				em,
+			);
+			projectRetainedKeys = new Set(projectRetained.map(keyOf));
+		}
+
+		const toDelete = this.selectOrphanedPairs(uniquePairs, userById, projectRetainedKeys);
+		if (toDelete.length > 0) {
+			await this.repository.deleteByPairs(toDelete, em);
+		}
+	}
+
+	/**
+	 * A pair is orphaned unless the user retains `credential:update`.
+	 */
+	private selectOrphanedPairs(
+		pairs: CredentialUserPair[],
+		userById: Map<string, User>,
+		projectRetainedKeys: Set<string>,
+	): CredentialUserPair[] {
+		return pairs.filter((pair) => {
+			const user = userById.get(pair.userId);
+			if (!user) return true;
+			if (hasGlobalScope(user, CREDENTIAL_RETAIN_SCOPE)) return false;
+			return !projectRetainedKeys.has(keyOf(pair));
+		});
 	}
 }

--- a/packages/cli/src/services/__tests__/project.service.ee.test.ts
+++ b/packages/cli/src/services/__tests__/project.service.ee.test.ts
@@ -7,6 +7,7 @@ import {
 	type SharedWorkflowRepository,
 	type ProjectRelationRepository,
 	type SharedCredentials,
+	ProjectRelation as ProjectRelationEntity,
 	PROJECT_ADMIN_ROLE,
 	PROJECT_VIEWER_ROLE,
 } from '@n8n/db';
@@ -440,7 +441,14 @@ describe('ProjectService', () => {
 			{ userId: 'user2', role: { slug: 'project:viewer' } },
 		];
 
+		let mockProxy: jest.Mocked<ICredentialConnectionStatusProvider>;
+
 		beforeEach(() => {
+			mockProxy = mock<ICredentialConnectionStatusProvider>();
+			Object.defineProperty(projectService, 'connectionStatusProxy', {
+				configurable: true,
+				get: async () => mockProxy,
+			});
 			manager.transaction.mockImplementation(async (arg1: unknown, arg2?: unknown) => {
 				const runInTransaction = (arg2 ?? arg1) as (
 					entityManager: EntityManager,
@@ -466,10 +474,12 @@ describe('ProjectService', () => {
 				relations: { projectRelations: { role: true } },
 			});
 
-			expect(projectRelationRepository.update).toHaveBeenCalledWith(
+			expect(manager.update).toHaveBeenCalledWith(
+				ProjectRelationEntity,
 				{ projectId, userId: 'user2' },
 				{ role: { slug: 'project:admin' } },
 			);
+			expect(mockProxy.cleanupOrphanedEntriesForUsers).toHaveBeenCalledWith(['user2'], manager);
 		});
 
 		it('should throw if the user is not part of the project', async () => {

--- a/packages/cli/src/services/__tests__/project.service.ee.test.ts
+++ b/packages/cli/src/services/__tests__/project.service.ee.test.ts
@@ -8,11 +8,13 @@ import {
 	type ProjectRelationRepository,
 	type SharedCredentials,
 	PROJECT_ADMIN_ROLE,
+	PROJECT_VIEWER_ROLE,
 } from '@n8n/db';
 import { PROJECT_OWNER_ROLE_SLUG } from '@n8n/permissions';
 import type { EntityManager } from '@n8n/typeorm';
 import { mock } from 'jest-mock-extended';
 
+import type { ICredentialConnectionStatusProvider } from '@/credentials/credential-connection-status-provider.interface';
 import type { AgentKnowledgeService } from '@/modules/agents/agent-knowledge.service';
 import type { AgentRepository } from '@/modules/agents/repositories/agent.repository';
 
@@ -199,6 +201,159 @@ describe('ProjectService', () => {
 				]),
 			).resolves.not.toThrow();
 		});
+
+		describe('cleanup for orphaned credential entries', () => {
+			let mockProxy: jest.Mocked<ICredentialConnectionStatusProvider>;
+
+			beforeEach(() => {
+				mockProxy = mock<ICredentialConnectionStatusProvider>();
+				Object.defineProperty(projectService, 'connectionStatusProxy', {
+					configurable: true,
+					get: async () => mockProxy,
+				});
+			});
+
+			it('calls cleanupOrphanedEntriesForUsers with the IDs of removed members', async () => {
+				// ARRANGE — project has two members; incoming relations keep only user1
+				projectRepository.findOne.mockResolvedValueOnce(
+					mock<Project>({
+						id: projectId,
+						type: 'team',
+						projectRelations: [
+							{ userId: 'user1', role: PROJECT_ADMIN_ROLE },
+							{ userId: 'user2', role: PROJECT_VIEWER_ROLE },
+						],
+					}),
+				);
+				roleService.isRoleLicensed.mockReturnValue(true);
+
+				// ACT
+				await projectService.syncProjectRelations(projectId, [
+					{ userId: 'user1', role: 'project:admin' },
+				]);
+
+				// ASSERT — user2 was removed → cleanup must run for user2
+				expect(mockProxy.cleanupOrphanedEntriesForUsers).toHaveBeenCalledWith(['user2'], manager);
+			});
+
+			it('calls cleanupOrphanedEntriesForUsers with union of removed and role-changed IDs', async () => {
+				// ARRANGE — user2 removed, user3 role changed
+				projectRepository.findOne.mockResolvedValueOnce(
+					mock<Project>({
+						id: projectId,
+						type: 'team',
+						projectRelations: [
+							{ userId: 'user1', role: PROJECT_ADMIN_ROLE },
+							{ userId: 'user2', role: PROJECT_VIEWER_ROLE },
+							{ userId: 'user3', role: PROJECT_VIEWER_ROLE },
+						],
+					}),
+				);
+				roleService.isRoleLicensed.mockReturnValue(true);
+
+				// ACT — user2 dropped, user3 role changed viewer → admin
+				await projectService.syncProjectRelations(projectId, [
+					{ userId: 'user1', role: 'project:admin' },
+					{ userId: 'user3', role: 'project:admin' },
+				]);
+
+				// ASSERT — both user2 (removed) and user3 (role changed) are in the set
+				expect(mockProxy.cleanupOrphanedEntriesForUsers).toHaveBeenCalledWith(
+					expect.arrayContaining(['user2', 'user3']),
+					manager,
+				);
+				const [affectedIds] = mockProxy.cleanupOrphanedEntriesForUsers.mock.calls[0] as [
+					string[],
+					EntityManager,
+				];
+				expect(affectedIds).toHaveLength(2);
+			});
+
+			it('does not call cleanupOrphanedEntriesForUsers when no members are affected', async () => {
+				// ARRANGE — incoming relations are identical to current ones
+				projectRepository.findOne.mockResolvedValueOnce(
+					mock<Project>({
+						id: projectId,
+						type: 'team',
+						projectRelations: [
+							{ userId: 'user1', role: PROJECT_ADMIN_ROLE },
+							{ userId: 'user2', role: PROJECT_VIEWER_ROLE },
+						],
+					}),
+				);
+				roleService.isRoleLicensed.mockReturnValue(true);
+
+				// ACT — no changes; same users, same roles
+				await projectService.syncProjectRelations(projectId, [
+					{ userId: 'user1', role: 'project:admin' },
+					{ userId: 'user2', role: 'project:viewer' },
+				]);
+
+				// ASSERT — no affected users → cleanup must not be called
+				expect(mockProxy.cleanupOrphanedEntriesForUsers).not.toHaveBeenCalled();
+			});
+		});
+	});
+
+	describe('deleteUserFromProject', () => {
+		let mockProxy: jest.Mocked<ICredentialConnectionStatusProvider>;
+
+		beforeEach(() => {
+			mockProxy = mock<ICredentialConnectionStatusProvider>();
+			Object.defineProperty(projectService, 'connectionStatusProxy', {
+				configurable: true,
+				get: async () => mockProxy,
+			});
+			manager.transaction.mockImplementation(async (arg1: unknown, arg2?: unknown) => {
+				const runInTransaction = (arg2 ?? arg1) as (
+					entityManager: EntityManager,
+				) => Promise<unknown>;
+				return await runInTransaction(manager);
+			});
+		});
+
+		it('calls cleanupOrphanedEntriesForUsers with the removed userId', async () => {
+			// ARRANGE
+			const projectId = 'proj-1';
+			const userId = 'user-to-remove';
+			projectRepository.findOne.mockResolvedValueOnce(
+				mock<Project>({
+					id: projectId,
+					type: 'team',
+					projectRelations: [
+						{ userId, role: PROJECT_VIEWER_ROLE },
+						{ userId: 'owner', role: PROJECT_ADMIN_ROLE },
+					],
+				}),
+			);
+
+			// ACT
+			await projectService.deleteUserFromProject(projectId, userId);
+
+			// ASSERT — member removed → cleanup must run inside the same transaction
+			expect(mockProxy.cleanupOrphanedEntriesForUsers).toHaveBeenCalledWith([userId], manager);
+		});
+
+		it('throws when trying to remove the project owner', async () => {
+			// ARRANGE
+			const projectId = 'proj-1';
+			const ownerId = 'owner-user';
+			projectRepository.findOne.mockResolvedValueOnce(
+				mock<Project>({
+					id: projectId,
+					type: 'team',
+					projectRelations: [
+						{ userId: ownerId, role: { ...PROJECT_ADMIN_ROLE, slug: PROJECT_OWNER_ROLE_SLUG } },
+					],
+				}),
+			);
+
+			// ACT & ASSERT
+			await expect(projectService.deleteUserFromProject(projectId, ownerId)).rejects.toThrow(
+				'Project owner cannot be removed from the project',
+			);
+			expect(mockProxy.cleanupOrphanedEntriesForUsers).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('updateProject', () => {
@@ -359,9 +514,9 @@ describe('ProjectService', () => {
 	});
 
 	describe('deleteProject', () => {
-		it('cleans agent knowledge files before project deletion cascades agent files', async () => {
-			const user = { id: 'user-1', role: { scopes: [{ slug: 'project:delete' }] } } as any;
-			const project = mock<Project>({ id: 'project-1', type: 'team' });
+		const user = { id: 'user-1', role: { scopes: [{ slug: 'project:delete' }] } } as any;
+
+		beforeEach(() => {
 			Object.defineProperty(projectService, 'workflowService', {
 				configurable: true,
 				get: async () => ({ delete: jest.fn() }),
@@ -370,6 +525,66 @@ describe('ProjectService', () => {
 				configurable: true,
 				get: async () => ({ delete: jest.fn() }),
 			});
+		});
+
+		it('calls cleanupOrphanedEntriesForUsers with member IDs after project is deleted', async () => {
+			// ARRANGE
+			const project = mock<Project>({ id: 'project-1', type: 'team' });
+			const mockProxy = mock<ICredentialConnectionStatusProvider>();
+			Object.defineProperty(projectService, 'connectionStatusProxy', {
+				configurable: true,
+				get: async () => mockProxy,
+			});
+			manager.findOne.mockResolvedValueOnce(project);
+			projectRepository.remove.mockResolvedValueOnce(project);
+			sharedWorkflowRepository.find.mockResolvedValueOnce([]);
+			sharedCredentialsRepository.find.mockResolvedValueOnce([]);
+			moduleRegistry.isActive.mockReturnValue(false);
+			// Two members in the project
+			projectRelationRepository.findBy.mockResolvedValueOnce([
+				{ userId: 'member-1' },
+				{ userId: 'member-2' },
+			] as never);
+
+			// ACT
+			await projectService.deleteProject(user, project.id);
+
+			// ASSERT — project removed first, then cleanup for former members
+			expect(projectRepository.remove).toHaveBeenCalledWith(project);
+			expect(mockProxy.cleanupOrphanedEntriesForUsers).toHaveBeenCalledWith([
+				'member-1',
+				'member-2',
+			]);
+			expect(projectRepository.remove.mock.invocationCallOrder[0]).toBeLessThan(
+				mockProxy.cleanupOrphanedEntriesForUsers.mock.invocationCallOrder[0],
+			);
+		});
+
+		it('skips credential cleanup when the project had no members', async () => {
+			// ARRANGE
+			const project = mock<Project>({ id: 'project-1', type: 'team' });
+			const mockProxy = mock<ICredentialConnectionStatusProvider>();
+			Object.defineProperty(projectService, 'connectionStatusProxy', {
+				configurable: true,
+				get: async () => mockProxy,
+			});
+			manager.findOne.mockResolvedValueOnce(project);
+			projectRepository.remove.mockResolvedValueOnce(project);
+			sharedWorkflowRepository.find.mockResolvedValueOnce([]);
+			sharedCredentialsRepository.find.mockResolvedValueOnce([]);
+			moduleRegistry.isActive.mockReturnValue(false);
+			projectRelationRepository.findBy.mockResolvedValueOnce([]);
+
+			// ACT
+			await projectService.deleteProject(user, project.id);
+
+			// ASSERT — no members → cleanup must not be called
+			expect(projectRepository.remove).toHaveBeenCalledWith(project);
+			expect(mockProxy.cleanupOrphanedEntriesForUsers).not.toHaveBeenCalled();
+		});
+
+		it('cleans agent knowledge files before project deletion cascades agent files', async () => {
+			const project = mock<Project>({ id: 'project-1', type: 'team' });
 			Object.defineProperty(projectService, 'agentRepository', {
 				configurable: true,
 				get: async () => agentRepository,
@@ -383,6 +598,7 @@ describe('ProjectService', () => {
 			sharedWorkflowRepository.find.mockResolvedValueOnce([]);
 			sharedCredentialsRepository.find.mockResolvedValueOnce([]);
 			moduleRegistry.isActive.mockImplementation((moduleName) => moduleName === 'agents');
+			projectRelationRepository.findBy.mockResolvedValueOnce([]);
 			agentRepository.findByProjectId.mockResolvedValueOnce([
 				{ id: 'agent-1' },
 				{ id: 'agent-2' },
@@ -399,21 +615,13 @@ describe('ProjectService', () => {
 		});
 
 		it('skips agent knowledge cleanup when the agents module is inactive', async () => {
-			const user = { id: 'user-1', role: { scopes: [{ slug: 'project:delete' }] } } as any;
 			const project = mock<Project>({ id: 'project-1', type: 'team' });
-			Object.defineProperty(projectService, 'workflowService', {
-				configurable: true,
-				get: async () => ({ delete: jest.fn() }),
-			});
-			Object.defineProperty(projectService, 'credentialsService', {
-				configurable: true,
-				get: async () => ({ delete: jest.fn() }),
-			});
 			manager.findOne.mockResolvedValueOnce(project);
 			projectRepository.remove.mockResolvedValueOnce(project);
 			sharedWorkflowRepository.find.mockResolvedValueOnce([]);
 			sharedCredentialsRepository.find.mockResolvedValueOnce([]);
 			moduleRegistry.isActive.mockReturnValue(false);
+			projectRelationRepository.findBy.mockResolvedValueOnce([]);
 
 			await projectService.deleteProject(user, project.id);
 

--- a/packages/cli/src/services/project.service.ee.ts
+++ b/packages/cli/src/services/project.service.ee.ts
@@ -119,6 +119,12 @@ export class ProjectService {
 		);
 	}
 
+	private get connectionStatusProxy() {
+		return import('@/credentials/credential-connection-status-proxy').then(
+			({ CredentialConnectionStatusProxy }) => Container.get(CredentialConnectionStatusProxy),
+		);
+	}
+
 	async deleteProject(
 		user: User,
 		projectId: string,
@@ -232,11 +238,22 @@ export class ProjectService {
 			}
 		}
 
+		// Capture member user IDs before the project (and its relations) are removed,
+		// so we can clean up orphaned per-user credential entries afterward.
+		const projectMembers = await this.projectRelationRepository.findBy({ projectId: project.id });
+		const memberUserIds = projectMembers.map((pr) => pr.userId);
+
 		// 9. delete project
 		await this.projectRepository.remove(project);
 
 		// 10. delete project relations
 		// Cascading deletes take care of this.
+
+		// 11. delete orphaned per-user credential entries for former members
+		if (memberUserIds.length > 0) {
+			const proxy = await this.connectionStatusProxy;
+			await proxy.cleanupOrphanedEntriesForUsers(memberUserIds);
+		}
 	}
 
 	/**
@@ -400,9 +417,32 @@ export class ProjectService {
 			'project',
 		);
 
+		const incomingByUserId = new Map(relations.map((r) => [r.userId, r.role]));
+
+		const removedUserIds = project.projectRelations
+			.filter((r) => !incomingByUserId.has(r.userId))
+			.map((r) => r.userId);
+
+		// Users whose role slug changed — a downgrade may strip credential:update,
+		// so their per-user credential entries must be re-evaluated too.
+		const roleChangedUserIds = project.projectRelations
+			.filter((r) => {
+				const newRole = incomingByUserId.get(r.userId);
+				return newRole !== undefined && newRole !== r.role.slug;
+			})
+			.map((r) => r.userId);
+
+		const affectedUserIds = [...new Set([...removedUserIds, ...roleChangedUserIds])];
+
+		const proxy = await this.connectionStatusProxy;
+
 		await this.projectRelationRepository.manager.transaction(async (em) => {
 			await this.pruneRelations(em, project);
 			await this.addManyRelations(em, project, relations);
+
+			if (affectedUserIds.length > 0) {
+				await proxy.cleanupOrphanedEntriesForUsers(affectedUserIds, em);
+			}
 		});
 
 		const newRelations = relations.filter(
@@ -547,7 +587,12 @@ export class ProjectService {
 			throw new ForbiddenError('Project owner cannot be removed from the project');
 		}
 
-		await this.projectRelationRepository.delete({ projectId: project.id, userId });
+		const proxy = await this.connectionStatusProxy;
+
+		await this.projectRelationRepository.manager.transaction(async (em) => {
+			await em.delete(ProjectRelation, { projectId: project.id, userId });
+			await proxy.cleanupOrphanedEntriesForUsers([userId], em);
+		});
 	}
 
 	async changeUserRoleInProject(projectId: string, userId: string, role: AssignableProjectRole) {
@@ -575,6 +620,9 @@ export class ProjectService {
 		}
 
 		await this.projectRelationRepository.update({ projectId, userId }, { role: { slug: role } });
+
+		const proxy = await this.connectionStatusProxy;
+		await proxy.cleanupOrphanedEntriesForUsers([userId]);
 	}
 
 	async pruneRelations(em: EntityManager, project: Project) {

--- a/packages/cli/src/services/project.service.ee.ts
+++ b/packages/cli/src/services/project.service.ee.ts
@@ -619,10 +619,12 @@ export class ProjectService {
 			throw new UnlicensedProjectRoleError(role);
 		}
 
-		await this.projectRelationRepository.update({ projectId, userId }, { role: { slug: role } });
-
 		const proxy = await this.connectionStatusProxy;
-		await proxy.cleanupOrphanedEntriesForUsers([userId]);
+
+		await this.projectRelationRepository.manager.transaction(async (em) => {
+			await em.update(ProjectRelation, { projectId, userId }, { role: { slug: role } });
+			await proxy.cleanupOrphanedEntriesForUsers([userId], em);
+		});
 	}
 
 	async pruneRelations(em: EntityManager, project: Project) {


### PR DESCRIPTION
## Summary

<!--
Describe what the PR does.
Photos and videos are recommended.
-->

Adds automatic cleanup of per-user OAuth connections (DynamicCredentialUserEntry rows) when a user's access to a credential is revoked — via unsharing, project membership removal, role downgrade, or project deletion.

**Background**
`DynamicCredentialUserEntry` rows store encrypted per-user OAuth tokens for resolvable credentials. Previously, these rows were only removed when the credential, user, or resolver was hard-deleted (DB-level cascades). A consumer-project user who connected and then lost access would retain both their encrypted token on disk and a live token at the OAuth provider.

**Changes**
`cleanupOrphanedEntriesForUsers` now runs inside the existing transactions for all access-change events and re-evaluates whether each affected user still has sufficient access, deleting any entries where they don't:

- Credential unshared — credentials.controller.ts shareCredentials
- User removed from a project — project.service.ee.ts deleteUserFromProject
- Project members synced (removals and role changes) — project.service.ee.ts syncProjectRelations
- Role changed — project.service.ee.ts changeUserRoleInProject
- Project deleted — project.service.ee.ts deleteProject
The minimum permission required to retain a connection is `credential:update` (Editor role or above). Users with only Viewer access (`credential:read`) will have their private connections cleaned up when that becomes their highest role. Users with Editor-level access through at least one remaining path are unaffected. Owner-project users are always unaffected.

**Edge case / known limitation**
`credential:update` is an intentional interim threshold. A Viewer technically has enough read access to benefit from a credential, but the current permission model has no finer-grained "connect" scope. A follow-up ticket will investigate adding a dedicated `credential:connect` permission or expanding Viewer to "view + use".

**Safety note**
The `cleanupOrphanedEntriesForUsers` call on the unshare path is kept in place as a safety net despite the fact that sharing functionality was disabled.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
https://linear.app/n8n/issue/IAM-721/


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
