### PR TITLE
fix(core): Keep Instance AI builder sandboxes thread-scoped and non-ephemeral

### DIFF
--- a/packages/@n8n/instance-ai/src/workspace/__tests__/create-workspace.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/create-workspace.test.ts
@@ -47,7 +47,6 @@ describe('createSandbox', () => {
 				language: 'typescript',
 				timeout: 60_000,
 				createTimeoutSeconds: 900,
-				ephemeral: true,
 			}),
 		);
 	});
@@ -70,7 +69,6 @@ describe('createSandbox', () => {
 		expect(getPrivateOptions(result)).toEqual(
 			expect.objectContaining({
 				createTimeoutSeconds: 300,
-				ephemeral: true,
 				labels: {
 					'n8n-builder': 'instance-ai-thread-thread-1',
 					thread_id: 'thread-1',

--- a/packages/@n8n/instance-ai/src/workspace/create-workspace.ts
+++ b/packages/@n8n/instance-ai/src/workspace/create-workspace.ts
@@ -120,7 +120,6 @@ export async function createSandbox(
 			labels: config.labels,
 			...(image ? { image } : {}),
 			...(snapshot ? { snapshot } : {}),
-			ephemeral: true,
 			language: 'typescript',
 			timeout: config.timeout ?? 300_000,
 			createTimeoutSeconds: config.createTimeoutSeconds ?? 300,

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -525,7 +525,6 @@ type WorkspaceServiceInternals = {
 		threadId: string,
 		user: User,
 		context: InstanceAiContext,
-		runId?: string,
 	) => Promise<unknown>;
 };
 
@@ -947,21 +946,15 @@ describe('InstanceAiService — runtime workspace setup', () => {
 		(createWorkspace as jest.Mock).mockReturnValue(workspace);
 		(setupSandboxWorkspace as jest.Mock).mockResolvedValue(undefined);
 
-		await service.getOrCreateWorkspace(
-			'thread-1',
-			fakeUser,
-			{} as InstanceAiContext,
-			'run_123456789',
-		);
+		await service.getOrCreateWorkspace('thread-1', fakeUser, {} as InstanceAiContext);
 
 		expect(createSandbox).toHaveBeenCalledWith(
 			expect.objectContaining({
-				id: 'acme-eval-run-1234-instance-ai-thread-thread-1',
-				name: 'acme-eval-run-1234-instance-ai-thread-thread-1',
+				id: 'acme-eval-instance-ai-thread-thread-1',
+				name: 'acme-eval-instance-ai-thread-thread-1',
 				labels: expect.objectContaining({
 					'n8n-builder': 'instance-ai-thread-thread-1',
 					name_prefix: 'Acme-Eval',
-					run_id: 'run_123456789',
 					thread_id: 'thread-1',
 				}),
 			}),
@@ -1173,11 +1166,10 @@ describe('InstanceAiService — runtime workspace setup', () => {
 		expect(createSandbox).toHaveBeenCalledTimes(1);
 		expect(createSandbox).toHaveBeenCalledWith(
 			expect.objectContaining({
-				id: 'run-1-instance-ai-thread-thread-1',
-				name: 'run-1-instance-ai-thread-thread-1',
+				id: 'instance-ai-thread-thread-1',
+				name: 'instance-ai-thread-thread-1',
 				labels: expect.objectContaining({
 					'n8n-builder': 'instance-ai-thread-thread-1',
-					run_id: 'run-1',
 					thread_id: 'thread-1',
 				}),
 			}),

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -181,7 +181,6 @@ type RuntimeSandboxEntry = {
 const SANDBOX_NAME_MAX_LEN = 63;
 const SANDBOX_LABEL_MAX_LEN = 63;
 const NAME_PREFIX_SLUG_MAX_LEN = 24;
-const SHORT_RUN_ID_LEN = 8;
 const DEFAULT_SANDBOX_TTL_MS = 15 * 60 * 1000;
 
 function slugifySandboxName(value: string, maxLen: number): string {
@@ -204,19 +203,11 @@ function getThreadScopedSandboxName(threadId: string): string {
 	return `instance-ai-thread-${threadId}`;
 }
 
-function buildThreadScopedSandboxName(
-	threadId: string,
-	namePrefix: string | undefined,
-	runId: string | undefined,
-): string {
+function buildThreadScopedSandboxName(threadId: string, namePrefix: string | undefined): string {
 	const parts: string[] = [];
 	if (namePrefix) {
 		const prefixSlug = slugifySandboxName(namePrefix, NAME_PREFIX_SLUG_MAX_LEN);
 		if (prefixSlug) parts.push(prefixSlug);
-	}
-	if (runId) {
-		const runSlug = slugifySandboxName(runId, SHORT_RUN_ID_LEN);
-		if (runSlug) parts.push(runSlug);
 	}
 	const threadSlug = slugifySandboxName(getThreadScopedSandboxName(threadId), SANDBOX_NAME_MAX_LEN);
 	if (threadSlug) parts.push(threadSlug);
@@ -228,7 +219,6 @@ function buildThreadScopedSandboxName(
 function buildThreadScopedSandboxLabels(
 	threadId: string,
 	namePrefix: string | undefined,
-	runId: string | undefined,
 ): Record<string, string> {
 	const baseName = getThreadScopedSandboxName(threadId);
 	const labels: Record<string, string> = {
@@ -236,24 +226,19 @@ function buildThreadScopedSandboxLabels(
 		thread_id: slugifySandboxLabel(threadId, SANDBOX_LABEL_MAX_LEN),
 	};
 	if (namePrefix) labels.name_prefix = slugifySandboxLabel(namePrefix, SANDBOX_LABEL_MAX_LEN);
-	if (runId) labels.run_id = slugifySandboxLabel(runId, SANDBOX_LABEL_MAX_LEN);
 	return labels;
 }
 
-function withThreadScopedSandboxIdentity(
-	config: SandboxConfig,
-	threadId: string,
-	runId?: string,
-): SandboxConfig {
+function withThreadScopedSandboxIdentity(config: SandboxConfig, threadId: string): SandboxConfig {
 	if (!config.enabled || config.provider !== 'daytona') return config;
 
-	const name = buildThreadScopedSandboxName(threadId, config.namePrefix, runId);
+	const name = buildThreadScopedSandboxName(threadId, config.namePrefix);
 	return {
 		...config,
 		id: name,
 		name,
 		labels: {
-			...buildThreadScopedSandboxLabels(threadId, config.namePrefix, runId),
+			...buildThreadScopedSandboxLabels(threadId, config.namePrefix),
 			...config.labels,
 		},
 	};
@@ -797,7 +782,6 @@ export class InstanceAiService {
 	private async getOrCreateWorkspaceEntry(
 		threadId: string,
 		user: User,
-		runId?: string,
 	): Promise<RuntimeSandboxEntry | undefined> {
 		const existing = this.sandboxes.get(threadId);
 		if (existing) {
@@ -812,7 +796,7 @@ export class InstanceAiService {
 		const pending = this.sandboxCreations.get(threadId);
 		if (pending) return await pending;
 
-		const creation = this.createWorkspaceEntry(threadId, user, runId);
+		const creation = this.createWorkspaceEntry(threadId, user);
 		this.sandboxCreations.set(threadId, creation);
 		try {
 			return await creation;
@@ -826,9 +810,8 @@ export class InstanceAiService {
 		threadId: string,
 		user: User,
 		context: InstanceAiContext,
-		runId?: string,
 	): Promise<RuntimeSandboxEntry | undefined> {
-		const entry = await this.getOrCreateWorkspaceEntry(threadId, user, runId);
+		const entry = await this.getOrCreateWorkspaceEntry(threadId, user);
 		if (entry) await this.ensureWorkspaceSetup(entry, context);
 		return entry;
 	}
@@ -853,13 +836,8 @@ export class InstanceAiService {
 	private async createWorkspaceEntry(
 		threadId: string,
 		user: User,
-		runId?: string,
 	): Promise<RuntimeSandboxEntry | undefined> {
-		const config = withThreadScopedSandboxIdentity(
-			await this.resolveSandboxConfig(user),
-			threadId,
-			runId,
-		);
+		const config = withThreadScopedSandboxIdentity(await this.resolveSandboxConfig(user), threadId);
 		if (!config.enabled) return undefined;
 
 		const sandbox = await createSandbox(config, {
@@ -3066,7 +3044,7 @@ export class InstanceAiService {
 
 				let sandboxEntryPromise: Promise<RuntimeSandboxEntry | undefined> | undefined;
 				const getSandboxEntry = async () => {
-					sandboxEntryPromise ??= this.getOrCreateWorkspaceEntry(threadId, user, runId).catch(
+					sandboxEntryPromise ??= this.getOrCreateWorkspaceEntry(threadId, user).catch(
 						(error: unknown) => {
 							sandboxEntryPromise = undefined;
 							throw error;
@@ -3076,7 +3054,7 @@ export class InstanceAiService {
 					return await sandboxEntryPromise;
 				};
 				const getSetupSandboxEntry = async () => {
-					return await this.getOrCreateWorkspace(threadId, user, context, runId);
+					return await this.getOrCreateWorkspace(threadId, user, context);
 				};
 
 				const scopeWorkspaceForAgent = async (


### PR DESCRIPTION
## Summary

Daytona sandboxes were accidentally turned ephemeral in #30838, and given run specific prefixes. This rolls back those changes.

This alone isn't enough for fully fixing the issue, I'm following this up with changes to Daytona sandbox recovery handling, as on some operations we'd get errors and report "Something went wrong" when actually the sandbox just had been stopped while waiting for the next command & it can still be recovered. But doing that in another PR as I need to verify that fix works (and need 15mins of wait time between attempts)

## How to test

Start n8n with the proxy mode on and start a thread. Check the sandbox that gets created for your thread - it shouldn't have `run-xxxx-` prefix and its lifecycle should not have auto-delete on stop, it should remain stopped after 15mins of inactivity.

You can also try waiting for 15mins and continuing the thread - but before the second fix lands that will still fail in some cases (like plan approval).

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

https://github.com/n8n-io/n8n/pull/new/ins-433-sandbox-restart-failed

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
