### PR TITLE
fix(core): Ensure insights compaction runs in multi-main setups

### DIFF
--- a/packages/@n8n/db/src/services/__tests__/db-lock.service.test.ts
+++ b/packages/@n8n/db/src/services/__tests__/db-lock.service.test.ts
@@ -8,7 +8,8 @@ import { DbLockService } from '../db-lock.service';
 
 describe('DbLockService', () => {
 	const mockTx = mock<EntityManager>();
-	const dataSource = mock<DataSource>();
+	const mockManager = mock<EntityManager>();
+	const dataSource = mock<DataSource>({ manager: mockManager });
 	const databaseConfig = mock<DatabaseConfig>();
 
 	const transactionMock = jest.fn<Promise<unknown>, [(tx: EntityManager) => Promise<unknown>]>();
@@ -18,7 +19,7 @@ describe('DbLockService', () => {
 	beforeEach(() => {
 		jest.resetAllMocks();
 		transactionMock.mockImplementation(async (fn) => await fn(mockTx));
-		dataSource.manager.transaction = transactionMock as never;
+		mockManager.transaction = transactionMock as never;
 		mockTx.query.mockResolvedValue([]);
 		service = new DbLockService(dataSource, databaseConfig);
 	});
@@ -43,7 +44,8 @@ describe('DbLockService', () => {
 
 			expect(result).toBe('result');
 			expect(mockTx.query).not.toHaveBeenCalled();
-			expect(fn).toHaveBeenCalledWith(mockTx);
+			expect(transactionMock).not.toHaveBeenCalled();
+			expect(fn).toHaveBeenCalledWith(mockManager);
 		});
 
 		it('should set lock_timeout when timeoutMs is provided', async () => {
@@ -146,7 +148,8 @@ describe('DbLockService', () => {
 
 			expect(result).toBe('result');
 			expect(mockTx.query).not.toHaveBeenCalled();
-			expect(fn).toHaveBeenCalledWith(mockTx);
+			expect(transactionMock).not.toHaveBeenCalled();
+			expect(fn).toHaveBeenCalledWith(mockManager);
 		});
 	});
 

--- a/packages/@n8n/db/src/services/db-lock.service.ts
+++ b/packages/@n8n/db/src/services/db-lock.service.ts
@@ -12,6 +12,7 @@ import { OperationalError } from 'n8n-workflow';
 export const enum DbLock {
 	AUTH_ROLES_SYNC = 1001,
 	TRUSTED_KEY_REFRESH = 1002,
+	INSIGHTS_COMPACTION = 1003,
 	/** Reserved for integration tests — never use in production code */
 	TEST = 9999,
 }
@@ -104,7 +105,10 @@ export class DbLockService {
 		if (this.databaseConfig.type !== 'postgresdb') {
 			const release = await this.acquireLock(lockId, options?.timeoutMs);
 			try {
-				return await this.dataSource.manager.transaction(async (tx) => await fn(tx));
+				// SQLite has no advisory locks; the in-process mutex serializes callers.
+				// Do not wrap fn in a transaction here — long-running callbacks that open
+				// their own transactions would deadlock on nested SQLite transactions.
+				return await fn(this.dataSource.manager);
 			} finally {
 				release();
 			}
@@ -141,7 +145,8 @@ export class DbLockService {
 		if (this.databaseConfig.type !== 'postgresdb') {
 			const release = this.tryAcquireLock(lockId);
 			try {
-				return await this.dataSource.manager.transaction(async (tx) => await fn(tx));
+				// See withLock: mutex-only on SQLite, no outer transaction.
+				return await fn(this.dataSource.manager);
 			} finally {
 				release();
 			}

--- a/packages/cli/src/modules/insights/__tests__/insights-compaction.service.integration.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-compaction.service.integration.test.ts
@@ -1,3 +1,4 @@
+import type { Logger } from '@n8n/backend-common';
 import {
 	mockLogger,
 	createTeamProject,
@@ -5,11 +6,11 @@ import {
 	testDb,
 	testModules,
 } from '@n8n/backend-test-utils';
-import type { Logger } from '@n8n/backend-common';
-import type { WorkflowEntity } from '@n8n/db';
+import type { DbLockService, WorkflowEntity } from '@n8n/db';
 import { Container } from '@n8n/di';
-import { mock } from 'jest-mock-extended';
+import { mock, type MockProxy } from 'jest-mock-extended';
 import { DateTime } from 'luxon';
+import { OperationalError } from 'n8n-workflow';
 
 import { InsightsRawRepository } from '@/modules/insights/database/repositories/insights-raw.repository';
 
@@ -23,6 +24,24 @@ import type { PeriodUnit } from '../database/entities/insights-shared';
 import { InsightsByPeriodRepository } from '../database/repositories/insights-by-period.repository';
 import { InsightsCompactionService } from '../insights-compaction.service';
 import { InsightsConfig } from '../insights.config';
+
+/** A DbLockService mock that serializes runs like the SQLite in-process mutex. */
+function dbLockServiceWithInProcessLock(): MockProxy<DbLockService> {
+	const dbLockService = mock<DbLockService>();
+	let isHeld = false;
+	dbLockService.tryWithLock.mockImplementation(async (lockId, fn) => {
+		if (isHeld) {
+			throw new OperationalError(`DbLock ${lockId} is already held by another process`);
+		}
+		isHeld = true;
+		try {
+			return await fn(undefined as never);
+		} finally {
+			isHeld = false;
+		}
+	});
+	return dbLockService;
+}
 
 type CompactionConfig = Pick<
 	InsightsConfig,
@@ -378,6 +397,7 @@ describe('compaction', () => {
 					compactionIntervalMinutes: 60,
 				}),
 				mockLogger(),
+				mock<DbLockService>(),
 			);
 			// spy on the compactInsights method to check if it's called
 			const compactInsightsSpy = jest.spyOn(insightsCompactionService, 'compactInsights');
@@ -385,12 +405,16 @@ describe('compaction', () => {
 			try {
 				insightsCompactionService.startCompactionTimer();
 
+				// ASSERT
+				// runs once immediately on becoming leader (leading edge)
+				expect(compactInsightsSpy).toHaveBeenCalledTimes(1);
+
 				// ACT
-				// advance by 1 hour and 1 minute
+				// advance by 1 hour and 1 minute -> one more scheduled run
 				jest.advanceTimersByTime(1000 * 60 * 61);
 
 				// ASSERT
-				expect(compactInsightsSpy).toHaveBeenCalledTimes(1);
+				expect(compactInsightsSpy).toHaveBeenCalledTimes(2);
 			} finally {
 				insightsCompactionService.stopCompactionTimer();
 				jest.useRealTimers();
@@ -398,7 +422,7 @@ describe('compaction', () => {
 		});
 	});
 
-	describe('compactInsights in-memory run guard', () => {
+	describe('compactInsights lock guard', () => {
 		test('skips a concurrent run and accepts another run after the active one finishes', async () => {
 			// ARRANGE
 			const logger = mock<Logger>({ scoped: jest.fn().mockReturnThis() });
@@ -412,6 +436,7 @@ describe('compaction', () => {
 					compactionMaxRuntimeSeconds: 0,
 				}),
 				logger,
+				dbLockServiceWithInProcessLock(),
 			);
 
 			let resolveRawToHour!: (numberOfCompactedRawData: number) => void;
@@ -433,7 +458,7 @@ describe('compaction', () => {
 
 			// ASSERT
 			expect(logger.debug).toHaveBeenCalledWith(
-				'Skipping insights compaction because another compaction run is active',
+				'Skipping insights compaction because another run already holds the lock',
 			);
 
 			resolveRawToHour(0);
@@ -456,6 +481,7 @@ describe('compaction', () => {
 					compactionMaxRuntimeSeconds: 0,
 				}),
 				logger,
+				dbLockServiceWithInProcessLock(),
 			);
 			const rawToHourSpy = jest
 				.spyOn(insightsCompactionService, 'compactRawToHour')

--- a/packages/cli/src/modules/insights/__tests__/insights-compaction.service.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights-compaction.service.test.ts
@@ -1,0 +1,105 @@
+import { mockLogger } from '@n8n/backend-test-utils';
+import { Time } from '@n8n/constants';
+import type { DbLockService } from '@n8n/db';
+import { DbLock } from '@n8n/db';
+import type { MockProxy } from 'jest-mock-extended';
+import { mock } from 'jest-mock-extended';
+import { OperationalError } from 'n8n-workflow';
+
+import type { InsightsByPeriodRepository } from '../database/repositories/insights-by-period.repository';
+import type { InsightsRawRepository } from '../database/repositories/insights-raw.repository';
+import { InsightsCompactionService } from '../insights-compaction.service';
+import { InsightsConfig } from '../insights.config';
+
+type WithPrivateRun = { runCompaction: () => Promise<void> };
+
+describe('InsightsCompactionService', () => {
+	let config: InsightsConfig;
+	let dbLockService: MockProxy<DbLockService>;
+	let service: InsightsCompactionService;
+
+	beforeEach(() => {
+		jest.useFakeTimers();
+		config = new InsightsConfig();
+		config.compactionIntervalMinutes = 60;
+		dbLockService = mock<DbLockService>();
+		// By default, behave as if the lock is free: run the protected section.
+		dbLockService.tryWithLock.mockImplementation(async (_id, fn) => await fn(undefined as never));
+		service = new InsightsCompactionService(
+			mock<InsightsByPeriodRepository>(),
+			mock<InsightsRawRepository>(),
+			config,
+			mockLogger(),
+			dbLockService,
+		);
+	});
+
+	afterEach(() => {
+		service.stopCompactionTimer();
+		jest.useRealTimers();
+		jest.restoreAllMocks();
+		jest.clearAllMocks();
+	});
+
+	describe('compaction runs at least once per leadership period', () => {
+		test('runs a compaction promptly when becoming leader, not only after a full interval', () => {
+			const compactSpy = jest.spyOn(service, 'compactInsights').mockResolvedValue(undefined);
+
+			// Simulates @OnLeaderTakeover starting the timer.
+			service.startCompactionTimer();
+
+			// A fresh leader must compact promptly. Without a leading-edge run the
+			// first compaction is deferred a full interval, so this would be 0.
+			expect(compactSpy).toHaveBeenCalledTimes(1);
+		});
+
+		test('still compacts when leadership changes faster than the compaction interval', () => {
+			const compactSpy = jest.spyOn(service, 'compactInsights').mockResolvedValue(undefined);
+			const intervalMs = config.compactionIntervalMinutes * Time.minutes.toMilliseconds;
+
+			// Repeated takeover/stepdown, each shorter than one compaction interval.
+			for (let i = 0; i < 5; i++) {
+				service.startCompactionTimer(); // @OnLeaderTakeover
+				jest.advanceTimersByTime(intervalMs * 0.5);
+				service.stopCompactionTimer(); // @OnLeaderStepdown
+			}
+
+			// The interval is cleared and recreated on every takeover, so it never
+			// reaches its first tick. At least one run should still have happened.
+			expect(compactSpy).toHaveBeenCalled();
+		});
+	});
+
+	describe('cross-instance locking', () => {
+		test('runs the compaction body under the shared compaction lock', async () => {
+			const runSpy = jest
+				.spyOn(service as unknown as WithPrivateRun, 'runCompaction')
+				.mockResolvedValue(undefined);
+
+			await service.compactInsights();
+
+			expect(dbLockService.tryWithLock).toHaveBeenCalledWith(
+				DbLock.INSIGHTS_COMPACTION,
+				expect.any(Function),
+			);
+			expect(runSpy).toHaveBeenCalledTimes(1);
+		});
+
+		test('skips the run when another instance already holds the lock', async () => {
+			const runSpy = jest.spyOn(service as unknown as WithPrivateRun, 'runCompaction');
+			dbLockService.tryWithLock.mockRejectedValue(
+				new OperationalError('DbLock 1003 is already held by another process'),
+			);
+
+			// A held lock must not surface as an error; the run is simply skipped.
+			await expect(service.compactInsights()).resolves.toBeUndefined();
+			expect(runSpy).not.toHaveBeenCalled();
+		});
+
+		test('rethrows unexpected errors raised during compaction', async () => {
+			dbLockService.tryWithLock.mockRejectedValue(new Error('database unavailable'));
+
+			await expect(service.compactInsights()).rejects.toThrow('database unavailable');
+		});
+	});
+});

--- a/packages/cli/src/modules/insights/insights-compaction.service.ts
+++ b/packages/cli/src/modules/insights/insights-compaction.service.ts
@@ -1,7 +1,8 @@
 import { Logger } from '@n8n/backend-common';
 import { Time } from '@n8n/constants';
+import { DbLock, DbLockService } from '@n8n/db';
 import { Service } from '@n8n/di';
-import { sleep } from 'n8n-workflow';
+import { OperationalError, sleep } from 'n8n-workflow';
 
 import { InsightsByPeriodRepository } from './database/repositories/insights-by-period.repository';
 import { InsightsRawRepository } from './database/repositories/insights-raw.repository';
@@ -23,13 +24,12 @@ type CompactionStopReason = 'max-batches' | 'max-runtime';
 export class InsightsCompactionService {
 	private compactInsightsTimer: NodeJS.Timeout | undefined;
 
-	private isCompactionRunning = false;
-
 	constructor(
 		private readonly insightsByPeriodRepository: InsightsByPeriodRepository,
 		private readonly insightsRawRepository: InsightsRawRepository,
 		private readonly insightsConfig: InsightsConfig,
 		private readonly logger: Logger,
+		private readonly dbLockService: DbLockService,
 	) {
 		this.logger = this.logger.scoped('insights');
 	}
@@ -40,6 +40,11 @@ export class InsightsCompactionService {
 			async () => await this.compactInsights(),
 			this.insightsConfig.compactionIntervalMinutes * Time.minutes.toMilliseconds,
 		);
+		// Run once immediately so a leader compacts promptly. `setInterval` only
+		// fires after a full interval, and the timer is cleared and recreated on
+		// every leadership change; without a leading-edge run, an instance whose
+		// leadership turns over faster than the interval would never compact.
+		void this.compactInsights();
 		this.logger.debug('Started compaction timer');
 	}
 
@@ -52,51 +57,63 @@ export class InsightsCompactionService {
 	}
 
 	async compactInsights() {
-		if (this.isCompactionRunning) {
-			this.logger.debug('Skipping insights compaction because another compaction run is active');
-			return;
-		}
-
-		this.isCompactionRunning = true;
-
 		try {
-			const runState: CompactionRunState = {
-				startedAt: Date.now(),
-				batchesProcessed: 0,
-				rowsCompacted: 0,
-			};
-
-			const stoppedAfterRawToHour = await this.compactStage({
-				stageName: 'raw-to-hour',
-				beforeBatchMessage: 'Compacting raw data to hourly aggregates',
-				afterBatchMessage: (rowsCompacted) =>
-					`Compacted ${rowsCompacted} raw data to hourly aggregates`,
-				compactBatch: this.compactRawToHour.bind(this),
-				runState,
-			});
-			if (stoppedAfterRawToHour) return;
-
-			const stoppedAfterHourToDay = await this.compactStage({
-				stageName: 'hour-to-day',
-				beforeBatchMessage: 'Compacting hourly data to daily aggregates',
-				afterBatchMessage: (rowsCompacted) =>
-					`Compacted ${rowsCompacted} hourly data to daily aggregates`,
-				compactBatch: this.compactHourToDay.bind(this),
-				runState,
-			});
-			if (stoppedAfterHourToDay) return;
-
-			await this.compactStage({
-				stageName: 'day-to-week',
-				beforeBatchMessage: 'Compacting daily data to weekly aggregates',
-				afterBatchMessage: (rowsCompacted) =>
-					`Compacted ${rowsCompacted} daily data to weekly aggregates`,
-				compactBatch: this.compactDayToWeek.bind(this),
-				runState,
-			});
-		} finally {
-			this.isCompactionRunning = false;
+			// Serialize compaction runs. In multi-main setups a re-election can
+			// briefly overlap an outgoing leader's in-flight run with the incoming
+			// leader's run; both would select the same raw rows and the dedup upsert
+			// (`value = value + excluded.value`) would double-count. The lock is held
+			// for as long as this run, so any other run — on this instance or another
+			// — fails fast and skips rather than running concurrently.
+			await this.dbLockService.tryWithLock(
+				DbLock.INSIGHTS_COMPACTION,
+				async () => await this.runCompaction(),
+			);
+		} catch (error) {
+			if (error instanceof OperationalError) {
+				this.logger.debug(
+					'Skipping insights compaction because another run already holds the lock',
+				);
+				return;
+			}
+			throw error;
 		}
+	}
+
+	private async runCompaction() {
+		const runState: CompactionRunState = {
+			startedAt: Date.now(),
+			batchesProcessed: 0,
+			rowsCompacted: 0,
+		};
+
+		const stoppedAfterRawToHour = await this.compactStage({
+			stageName: 'raw-to-hour',
+			beforeBatchMessage: 'Compacting raw data to hourly aggregates',
+			afterBatchMessage: (rowsCompacted) =>
+				`Compacted ${rowsCompacted} raw data to hourly aggregates`,
+			compactBatch: this.compactRawToHour.bind(this),
+			runState,
+		});
+		if (stoppedAfterRawToHour) return;
+
+		const stoppedAfterHourToDay = await this.compactStage({
+			stageName: 'hour-to-day',
+			beforeBatchMessage: 'Compacting hourly data to daily aggregates',
+			afterBatchMessage: (rowsCompacted) =>
+				`Compacted ${rowsCompacted} hourly data to daily aggregates`,
+			compactBatch: this.compactHourToDay.bind(this),
+			runState,
+		});
+		if (stoppedAfterHourToDay) return;
+
+		await this.compactStage({
+			stageName: 'day-to-week',
+			beforeBatchMessage: 'Compacting daily data to weekly aggregates',
+			afterBatchMessage: (rowsCompacted) =>
+				`Compacted ${rowsCompacted} daily data to weekly aggregates`,
+			compactBatch: this.compactDayToWeek.bind(this),
+			runState,
+		});
 	}
 
 	private async compactStage({

--- a/packages/cli/test/integration/database/services/db-lock.service.test.ts
+++ b/packages/cli/test/integration/database/services/db-lock.service.test.ts
@@ -39,10 +39,16 @@ afterAll(async () => {
 
 describe('DbLockService', () => {
 	describe('withLock', () => {
-		it('should execute the callback inside a transaction', async () => {
+		it('should execute the callback with an entity manager', async () => {
 			const result = await dbLockService.withLock(DbLock.TEST, async (tx) => {
 				expect(tx).toBeDefined();
-				expect(tx.queryRunner).toBeDefined();
+				if (isPostgres) {
+					// Postgres: fn runs inside the lock-holding transaction.
+					expect(tx.queryRunner).toBeDefined();
+				} else {
+					// SQLite: fn receives the default manager; callers open their own transactions.
+					expect(tx.queryRunner).toBeUndefined();
+				}
 				return 'done';
 			});
 


### PR DESCRIPTION
## Summary

https://www.loom.com/share/40056be2688b4e03a685280d50ad20a5

In multi-main (queue mode) setups, the Insights section could come up **blank** after the main leader changed.

**Root cause:** insights compaction is gated on leadership — `startCompactionTimer()` is called on `@OnLeaderTakeover` and `stopCompactionTimer()` on `@OnLeaderStepdown`. The timer was a bare `setInterval` with **no leading-edge run**, and `setInterval` is cleared and recreated from zero on every leadership change. So if leadership turned over faster than `N8N_INSIGHTS_COMPACTION_INTERVAL_MINUTES` (default 60 min) — rolling deploys, failovers, restarts — the interval never reached its first tick and **compaction never ran**. Raw events kept being collected but were never aggregated into `insights_by_period`, which is the table the Insights UI reads → blank UI.

This PR makes two changes:

1. **Leading-edge run** — `startCompactionTimer()` now runs one compaction immediately when an instance becomes leader, in addition to scheduling the interval. A fresh leader compacts promptly regardless of how often leadership changes.

2. **Cross-instance lock** — because a re-election can briefly overlap an outgoing leader's in-flight run with the incoming leader's leading-edge run, `compactInsights()` is now serialized with `DbLockService.tryWithLock(DbLock.INSIGHTS_COMPACTION, …)` (Postgres advisory lock / in-process mutex on SQLite). Without this, two instances could select the same raw rows and the dedup upsert (`value = value + excluded.value`) would **double-count** insights. A second concurrent run now fails fast and skips.

The now-redundant in-memory `isCompactionRunning` flag was removed — `tryWithLock` already serializes runs within a single process (SQLite mutex / Postgres advisory lock across pooled connections).

### Behavior on leadership change

| Behavior on leadership change | Stops? |
| --- | --- |
| Future scheduled compactions on old leader | Yes |
| In-flight compaction on old leader | No — runs to completion |
| New leader starting compaction | Yes, immediately (may skip if lock held) |

### How to test

- Run a multi-main setup (queue mode + `N8N_MULTI_MAIN_SETUP_ENABLED=true`, shared Postgres + Redis, two mains).
- With a short `N8N_INSIGHTS_COMPACTION_INTERVAL_MINUTES`, force repeated leader changes and confirm `insights_by_period` is populated and the Insights UI is no longer blank.
- Automated: `pnpm --filter n8n test insights-compaction.service` (unit + integration) and `pnpm --filter @n8n/db test db-lock.service`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-285

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI