### PR TITLE
fix(core): Resume Instance AI sandboxes that were stopped or deleted while idle

### DIFF
--- a/packages/@n8n/agents/src/workspace/sandbox/base-sandbox.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/base-sandbox.ts
@@ -107,11 +107,15 @@ export abstract class BaseSandbox implements WorkspaceSandbox {
 	 * re-runs the provider's `start()`. Used to recover when the remote sandbox
 	 * was stopped/deleted out from under us (the in-memory status is stale).
 	 * No-op once destroyed/destroying — those are terminal.
+	 *
+	 * Intentionally does NOT touch `startPromise`: clearing it would let a
+	 * concurrent caller bypass the single-flight start dedupe in `_start()` and
+	 * launch a second start. A start that is genuinely in flight will be awaited
+	 * (and deduped) by the next `_start()`.
 	 */
 	protected markNeedsStart(): void {
 		if (this.status === 'destroyed' || this.status === 'destroying') return;
 		this.status = 'pending';
-		this.startPromise = undefined;
 	}
 
 	async ensureRunning(): Promise<void> {

--- a/packages/@n8n/agents/src/workspace/sandbox/base-sandbox.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/base-sandbox.ts
@@ -102,6 +102,18 @@ export abstract class BaseSandbox implements WorkspaceSandbox {
 		}
 	}
 
+	/**
+	 * Drop the cached "running" state so the next `ensureRunning()`/`_start()`
+	 * re-runs the provider's `start()`. Used to recover when the remote sandbox
+	 * was stopped/deleted out from under us (the in-memory status is stale).
+	 * No-op once destroyed/destroying — those are terminal.
+	 */
+	protected markNeedsStart(): void {
+		if (this.status === 'destroyed' || this.status === 'destroying') return;
+		this.status = 'pending';
+		this.startPromise = undefined;
+	}
+
 	async ensureRunning(): Promise<void> {
 		if (this.status === 'destroyed') {
 			throw new Error(`Sandbox "${this.name}" has been destroyed`);

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/daytona-sandbox.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/daytona-sandbox.test.ts
@@ -515,6 +515,20 @@ describe('DaytonaSandbox (remote sandbox gone during refetch)', () => {
 		expect(clientLog.every((c) => c.create.mock.calls.length === 0)).toBe(true);
 	});
 
+	it('executeCommand() does not recover from a failed (error) state', async () => {
+		// A non-running but non-recoverable state (error/build_failed/transient) must not
+		// trigger a resume/recreate — only stopped/archived/gone are recoverable.
+		const failing = makeMockSandbox('sb-stale', 'started');
+		failing.process.executeCommand = vi.fn().mockRejectedValue(new Error('boom'));
+		const probeError = makeMockSandbox('sb-probe', 'error');
+		queuedGetResults.push(failing, probeError);
+
+		const sandbox = new DaytonaSandbox({ name: 'thread-1', apiKey: 'key' });
+
+		await expect(sandbox.executeCommand('echo', ['hi'])).rejects.toThrow(/boom/i);
+		expect(clientLog.every((c) => c.create.mock.calls.length === 0)).toBe(true);
+	});
+
 	it('executeCommand() retries recovery at most once', async () => {
 		const sandbox = await startAndStageRemoteGone();
 

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/daytona-sandbox.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/daytona-sandbox.test.ts
@@ -32,6 +32,7 @@ interface DaytonaClientLog {
 const {
 	clientLog,
 	queuedGetErrors,
+	queuedGetResults,
 	queuedCreateResults,
 	makeMockSandbox,
 	Daytona,
@@ -43,6 +44,7 @@ const {
 	let nextClientId = 1;
 	let nextSandboxId = 1;
 	const queuedGetErrors: Error[] = [];
+	const queuedGetResults: MockSandbox[] = [];
 	const queuedCreateResults: Array<MockSandbox | Error> = [];
 
 	function makeMockSandbox(id: string, state = 'started'): MockSandbox {
@@ -85,6 +87,10 @@ const {
 				const queued = queuedGetErrors.shift();
 				if (queued !== undefined) {
 					return await Promise.reject(queued);
+				}
+				const queuedResult = queuedGetResults.shift();
+				if (queuedResult !== undefined) {
+					return await Promise.resolve(queuedResult);
 				}
 				return await Promise.resolve(makeMockSandbox(`sb-${id}-${nextSandboxId++}`));
 			});
@@ -137,12 +143,14 @@ const {
 		nextClientId = 1;
 		nextSandboxId = 1;
 		queuedGetErrors.length = 0;
+		queuedGetResults.length = 0;
 		queuedCreateResults.length = 0;
 	}
 
 	return {
 		clientLog,
 		queuedGetErrors,
+		queuedGetResults,
 		queuedCreateResults,
 		makeMockSandbox,
 		Daytona,
@@ -157,6 +165,7 @@ vi.mock('../lazy-daytona', () => ({
 }));
 
 import type { ErrorReporter, Logger } from '../../logger';
+import { DaytonaFilesystem } from '../daytona-filesystem';
 import { DaytonaSandbox } from '../daytona-sandbox';
 
 function base64url(input: string): string {
@@ -431,8 +440,101 @@ describe('DaytonaSandbox (remote sandbox gone during refetch)', () => {
 		await expect(sandbox.destroy()).resolves.toBeUndefined();
 	});
 
-	it('executeCommand() propagates NotFound rather than NPE-ing on a silently-cleared cache', async () => {
+	it('executeCommand() recovers by recreating the sandbox when the remote was deleted', async () => {
 		const sandbox = await startAndStageRemoteGone();
-		await expect(sandbox.executeCommand('echo', ['hi'])).rejects.toThrow(/not found/i);
+		// The remote stays gone: the recovery's findExistingSandbox() lookup also 404s, so
+		// it falls through to creating a fresh sandbox.
+		queueNotFound();
+
+		// The staged refetch throws NotFound (a 404 short-circuits as recoverable); recovery
+		// resets the handle and re-runs start() → findExistingSandbox() → create.
+		const result = await sandbox.executeCommand('echo', ['hi']);
+
+		expect(result.success).toBe(true);
+		expect(result.stdout).toBe('ok');
+		expect(clientLog.some((c) => c.create.mock.calls.length > 0)).toBe(true);
+	});
+
+	it('executeCommand() recovers a stopped remote from its state, even on a 403', async () => {
+		// Direct mode (static key) — no JWT rotation, so recovery cannot rely on the
+		// getDaytona refetch; it must come from the state probe in recoverAndRetry.
+		const failing = makeMockSandbox('sb-stale', 'started');
+		// A stopped/unreachable container surfaces as "Endpoint not allowed; 403" (which also
+		// looks like an auth error). Recovery must be driven by the probed remote state, not
+		// by the error code — otherwise this 403 is misread as auth and never recovers.
+		failing.process.executeCommand = vi
+			.fn()
+			.mockRejectedValue(new DaytonaError('Endpoint not allowed', 403));
+		const probeStopped = makeMockSandbox('sb-probe', 'stopped');
+		const resumed = makeMockSandbox('sb-resumed', 'stopped');
+		// get order: start() → failing; isRecoverable probe → stopped; retry start() → resumed.
+		queuedGetResults.push(failing, probeStopped, resumed);
+
+		const sandbox = new DaytonaSandbox({ name: 'thread-1', apiKey: 'key' });
+		const result = await sandbox.executeCommand('echo', ['resumed']);
+
+		expect(result.success).toBe(true);
+		expect(resumed.start).toHaveBeenCalled();
+	});
+
+	it('executeCommand() does not recover when auth is genuinely failing', async () => {
+		vi.useFakeTimers().setSystemTime(new Date(1_700_000_000_000));
+		const getAuthToken = vi.fn<(...args: []) => Promise<string>>().mockImplementation(async () => {
+			await Promise.resolve();
+			return makeJwt(Date.now() + HOUR_MS);
+		});
+		const sandbox = new DaytonaSandbox({ name: 'thread-1', getAuthToken });
+		await sandbox.start();
+
+		vi.setSystemTime(new Date(Date.now() + HOUR_MS - SKEW_MS + 1));
+		// Both the op's refetch and the recovery probe fail auth — the probe can't confirm a
+		// not-running state, so the original error propagates and nothing is recreated.
+		queuedGetErrors.push(
+			new DaytonaError('unauthorized', 401),
+			new DaytonaError('unauthorized', 401),
+		);
+
+		await expect(sandbox.executeCommand('echo', ['hi'])).rejects.toThrow(/unauthorized/i);
+		expect(clientLog.every((c) => c.create.mock.calls.length === 0)).toBe(true);
+	});
+
+	it('executeCommand() propagates when the remote is still running (no false recovery)', async () => {
+		// op fails but the probe finds the sandbox healthy → original error must surface.
+		const healthy = makeMockSandbox('sb-healthy', 'started');
+		healthy.process.executeCommand = vi
+			.fn()
+			.mockRejectedValue(new Error('genuine command failure'));
+		const probeStarted = makeMockSandbox('sb-probe', 'started');
+		queuedGetResults.push(healthy, probeStarted);
+
+		const sandbox = new DaytonaSandbox({ name: 'thread-1', apiKey: 'key' });
+
+		await expect(sandbox.executeCommand('echo', ['hi'])).rejects.toThrow(
+			/genuine command failure/i,
+		);
+		expect(clientLog.every((c) => c.create.mock.calls.length === 0)).toBe(true);
+	});
+
+	it('executeCommand() retries recovery at most once', async () => {
+		const sandbox = await startAndStageRemoteGone();
+
+		// The recovery retry also fails: findExistingSandbox() get → NotFound (→ create) and
+		// the create rejects. The second failure propagates instead of looping.
+		queueNotFound();
+		queuedCreateResults.push(new Error('create failed'));
+
+		await expect(sandbox.executeCommand('echo', ['hi'])).rejects.toThrow(/create failed/i);
+	});
+
+	it('DaytonaFilesystem reuses the same recovery when the remote was deleted', async () => {
+		const sandbox = await startAndStageRemoteGone();
+		// findExistingSandbox() lookup also 404s during recovery → create a fresh sandbox.
+		queueNotFound();
+		const filesystem = new DaytonaFilesystem(sandbox);
+
+		// readFile() → withFilesystem() → recoverAndRetry: the staged NotFound triggers a
+		// reset + recreate, then the op runs against the fresh fs handle.
+		await expect(filesystem.readFile('/workspace/file.txt')).resolves.toBeUndefined();
+		expect(clientLog.some((c) => c.create.mock.calls.length > 0)).toBe(true);
 	});
 });

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/daytona-sandbox.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/daytona-sandbox.test.ts
@@ -551,4 +551,46 @@ describe('DaytonaSandbox (remote sandbox gone during refetch)', () => {
 		await expect(filesystem.readFile('/workspace/file.txt')).resolves.toBeUndefined();
 		expect(clientLog.some((c) => c.create.mock.calls.length > 0)).toBe(true);
 	});
+
+	it('DaytonaFilesystem.exists() recovers a stopped sandbox instead of reporting missing', async () => {
+		// getFileDetails on a stopped sandbox fails with a non-404 — it must bubble to
+		// recovery, not be swallowed as "file does not exist".
+		const failing = makeMockSandbox('sb-stale', 'started');
+		failing.fs.getFileDetails = vi
+			.fn()
+			.mockRejectedValue(new DaytonaError('Endpoint not allowed', 403));
+		const probeStopped = makeMockSandbox('sb-probe', 'stopped');
+		const resumed = makeMockSandbox('sb-resumed', 'stopped');
+		queuedGetResults.push(failing, probeStopped, resumed);
+
+		const sandbox = new DaytonaSandbox({ name: 'thread-1', apiKey: 'key' });
+		const filesystem = new DaytonaFilesystem(sandbox);
+
+		await expect(filesystem.exists('/workspace/marker')).resolves.toBe(true);
+		expect(resumed.start).toHaveBeenCalled();
+	});
+
+	it('DaytonaFilesystem.exists() returns false for a genuine 404 without recovering', async () => {
+		const handle = makeMockSandbox('sb-1', 'started');
+		handle.fs.getFileDetails = vi.fn().mockRejectedValue(new DaytonaError('file not found', 404));
+		queuedGetResults.push(handle);
+
+		const sandbox = new DaytonaSandbox({ name: 'thread-1', apiKey: 'key' });
+		const filesystem = new DaytonaFilesystem(sandbox);
+
+		await expect(filesystem.exists('/workspace/missing')).resolves.toBe(false);
+		expect(clientLog.every((c) => c.create.mock.calls.length === 0)).toBe(true);
+	});
+
+	it('DaytonaFilesystem.appendFile() treats a genuine 404 as an empty file', async () => {
+		const handle = makeMockSandbox('sb-1', 'started');
+		handle.fs.downloadFile = vi.fn().mockRejectedValue(new DaytonaError('file not found', 404));
+		queuedGetResults.push(handle);
+
+		const sandbox = new DaytonaSandbox({ name: 'thread-1', apiKey: 'key' });
+		const filesystem = new DaytonaFilesystem(sandbox);
+
+		await filesystem.appendFile('/workspace/log.txt', 'entry');
+		expect(handle.fs.uploadFile).toHaveBeenCalled();
+	});
 });

--- a/packages/@n8n/instance-ai/src/workspace/daytona-filesystem.ts
+++ b/packages/@n8n/instance-ai/src/workspace/daytona-filesystem.ts
@@ -79,7 +79,10 @@ export class DaytonaFilesystem extends BaseFilesystem {
 			let existing: Buffer;
 			try {
 				existing = await fs.downloadFile(path);
-			} catch {
+			} catch (error) {
+				// Only a genuinely missing file means "start empty". Sandbox/provider errors
+				// (e.g. a stopped sandbox) must bubble up so withFilesystem() can recover.
+				if (!isDaytona404(error)) throw error;
 				existing = Buffer.alloc(0);
 			}
 			const append =
@@ -128,8 +131,12 @@ export class DaytonaFilesystem extends BaseFilesystem {
 			try {
 				await fs.getFileDetails(path);
 				return true;
-			} catch {
-				return false;
+			} catch (error) {
+				// A genuine 404 means the file is absent. Sandbox/provider errors (e.g. a
+				// stopped sandbox) must bubble up so withFilesystem() can recover instead of
+				// silently reporting the file as missing.
+				if (isDaytona404(error)) return false;
+				throw error;
 			}
 		});
 	}

--- a/packages/@n8n/instance-ai/src/workspace/daytona-filesystem.ts
+++ b/packages/@n8n/instance-ai/src/workspace/daytona-filesystem.ts
@@ -23,6 +23,8 @@ import { BaseFilesystem } from '@n8n/agents';
 
 import type { DaytonaSandbox } from './daytona-sandbox';
 
+type DaytonaFsHandle = Parameters<Parameters<DaytonaSandbox['withFilesystem']>[0]>[0];
+
 /**
  * A native agents filesystem implementation that delegates to the Daytona SDK's
  * sandbox.instance.fs API for all file operations.
@@ -38,123 +40,120 @@ export class DaytonaFilesystem extends BaseFilesystem {
 		this.id = `daytona-fs-${sandbox.id}`;
 	}
 
-	private get fs() {
-		return this.sandbox.instance.fs;
-	}
-
-	private async prepare(): Promise<void> {
-		// `ensureAuthFresh()` triggers a proactive JWT refresh + sandbox refetch if the
-		// cached client is near expiry, so `this.fs` (bound to the underlying Sandbox)
-		// points at a client with valid auth.
+	/**
+	 * Run a filesystem op against the live Daytona handle. `withFilesystem()` ensures the
+	 * sandbox is running with fresh auth and recovers once if the remote was stopped or
+	 * deleted while idle, so callers never touch a stale `fs` handle directly.
+	 */
+	private async withFs<T>(op: (fs: DaytonaFsHandle) => Promise<T>): Promise<T> {
 		await this.ensureReady();
-		await this.sandbox.ensureAuthFresh();
+		return await this.sandbox.withFilesystem(op);
 	}
 
 	async readFile(path: string, options?: ReadOptions): Promise<string | Buffer> {
-		await this.prepare();
-		const buffer = await this.fs.downloadFile(path);
-		if (options?.encoding) {
-			return buffer.toString(options.encoding);
-		}
-		return buffer;
+		return await this.withFs(async (fs) => {
+			const buffer = await fs.downloadFile(path);
+			if (options?.encoding) {
+				return buffer.toString(options.encoding);
+			}
+			return buffer;
+		});
 	}
 
 	async writeFile(path: string, content: FileContent, options?: WriteOptions): Promise<void> {
-		await this.prepare();
-		if (options?.recursive) {
-			const dir = path.substring(0, path.lastIndexOf('/'));
-			if (dir) {
-				await this.fs.createFolder(dir, '755');
+		await this.withFs(async (fs) => {
+			if (options?.recursive) {
+				const dir = path.substring(0, path.lastIndexOf('/'));
+				if (dir) {
+					await fs.createFolder(dir, '755');
+				}
 			}
-		}
-		const buffer =
-			typeof content === 'string' ? Buffer.from(content, 'utf-8') : Buffer.from(content);
-		await this.fs.uploadFile(buffer, path);
+			const buffer =
+				typeof content === 'string' ? Buffer.from(content, 'utf-8') : Buffer.from(content);
+			await fs.uploadFile(buffer, path);
+		});
 	}
 
 	async appendFile(path: string, content: FileContent): Promise<void> {
-		await this.prepare();
-		let existing: Buffer;
-		try {
-			existing = await this.fs.downloadFile(path);
-		} catch {
-			existing = Buffer.alloc(0);
-		}
-		const append =
-			typeof content === 'string' ? Buffer.from(content, 'utf-8') : Buffer.from(content);
-		await this.fs.uploadFile(Buffer.concat([existing, append]), path);
+		await this.withFs(async (fs) => {
+			let existing: Buffer;
+			try {
+				existing = await fs.downloadFile(path);
+			} catch {
+				existing = Buffer.alloc(0);
+			}
+			const append =
+				typeof content === 'string' ? Buffer.from(content, 'utf-8') : Buffer.from(content);
+			await fs.uploadFile(Buffer.concat([existing, append]), path);
+		});
 	}
 
 	async deleteFile(path: string, options?: RemoveOptions): Promise<void> {
-		await this.prepare();
-		await this.fs.deleteFile(path, options?.recursive);
+		await this.withFs(async (fs) => await fs.deleteFile(path, options?.recursive));
 	}
 
 	async copyFile(src: string, dest: string, _options?: CopyOptions): Promise<void> {
-		await this.prepare();
-		const content = await this.fs.downloadFile(src);
-		await this.fs.uploadFile(content, dest);
+		await this.withFs(async (fs) => {
+			const content = await fs.downloadFile(src);
+			await fs.uploadFile(content, dest);
+		});
 	}
 
 	async moveFile(src: string, dest: string, _options?: CopyOptions): Promise<void> {
-		await this.prepare();
-		await this.fs.moveFiles(src, dest);
+		await this.withFs(async (fs) => await fs.moveFiles(src, dest));
 	}
 
-	async mkdir(path: string, options?: { recursive?: boolean }): Promise<void> {
-		await this.prepare();
-		if (options?.recursive) {
-			// createFolder with mode '755' creates intermediate dirs
-			await this.fs.createFolder(path, '755');
-		} else {
-			await this.fs.createFolder(path, '755');
-		}
+	async mkdir(path: string, _options?: { recursive?: boolean }): Promise<void> {
+		// createFolder with mode '755' creates intermediate dirs
+		await this.withFs(async (fs) => await fs.createFolder(path, '755'));
 	}
 
 	async rmdir(path: string, options?: RemoveOptions): Promise<void> {
-		await this.prepare();
-		await this.fs.deleteFile(path, options?.recursive ?? false);
+		await this.withFs(async (fs) => await fs.deleteFile(path, options?.recursive ?? false));
 	}
 
 	async readdir(path: string, _options?: ListOptions): Promise<FileEntry[]> {
-		await this.prepare();
-		const files = await this.fs.listFiles(path);
-		return files.map((f) => ({
-			name: f.name ?? '',
-			type: f.isDir ? ('directory' as const) : ('file' as const),
-			size: f.size,
-		}));
+		return await this.withFs(async (fs) => {
+			const files = await fs.listFiles(path);
+			return files.map((f) => ({
+				name: f.name ?? '',
+				type: f.isDir ? ('directory' as const) : ('file' as const),
+				size: f.size,
+			}));
+		});
 	}
 
 	async exists(path: string): Promise<boolean> {
-		await this.prepare();
-		try {
-			await this.fs.getFileDetails(path);
-			return true;
-		} catch {
-			return false;
-		}
+		return await this.withFs(async (fs) => {
+			try {
+				await fs.getFileDetails(path);
+				return true;
+			} catch {
+				return false;
+			}
+		});
 	}
 
 	async stat(path: string): Promise<FileStat> {
-		await this.prepare();
-		let info;
-		try {
-			info = await this.fs.getFileDetails(path);
-		} catch (error: unknown) {
-			if (isDaytona404(error)) {
-				throw new DaytonaFileNotFoundError(path);
+		return await this.withFs(async (fs) => {
+			let info;
+			try {
+				info = await fs.getFileDetails(path);
+			} catch (error: unknown) {
+				if (isDaytona404(error)) {
+					throw new DaytonaFileNotFoundError(path);
+				}
+				throw error;
 			}
-			throw error;
-		}
-		return {
-			name: info.name ?? path.split('/').pop() ?? '',
-			path,
-			type: info.isDir ? 'directory' : 'file',
-			size: info.size ?? 0,
-			createdAt: new Date(info.modTime ?? 0),
-			modifiedAt: new Date(info.modTime ?? 0),
-		};
+			return {
+				name: info.name ?? path.split('/').pop() ?? '',
+				path,
+				type: info.isDir ? 'directory' : 'file',
+				size: info.size ?? 0,
+				createdAt: new Date(info.modTime ?? 0),
+				modifiedAt: new Date(info.modTime ?? 0),
+			};
+		});
 	}
 }
 

--- a/packages/@n8n/instance-ai/src/workspace/daytona-sandbox.ts
+++ b/packages/@n8n/instance-ai/src/workspace/daytona-sandbox.ts
@@ -22,10 +22,27 @@ import { loadDaytona } from './lazy-daytona';
 import type { ErrorReporter, Logger } from '../logger';
 
 const SANDBOX_STATE_STARTED = 'started';
+const SANDBOX_STATE_STOPPED = 'stopped';
+const SANDBOX_STATE_ARCHIVED = 'archived';
 const SANDBOX_STATE_DESTROYED = 'destroyed';
 const SANDBOX_STATE_DESTROYING = 'destroying';
 const SANDBOX_STATE_ERROR = 'error';
 const SANDBOX_STATE_BUILD_FAILED = 'build_failed';
+
+/**
+ * States a failed operation may recover from by resuming the sandbox: an idle sandbox that
+ * Daytona auto-stopped, or one that was auto-archived. `start()` brings both back to
+ * 'started'. Deliberately narrow — it excludes:
+ *  - transient states (creating/starting/stopping/resizing/pending_build): a reset+restart
+ *    would race the in-flight transition;
+ *  - failed states (error/build_failed): those can be silently deleted and recreated, which
+ *    we don't want to trigger off an unrelated operation failure.
+ * Deletion is handled separately as a `DaytonaNotFoundError` fast-path.
+ */
+const RECOVERABLE_SANDBOX_STATES: ReadonlySet<string> = new Set([
+	SANDBOX_STATE_STOPPED,
+	SANDBOX_STATE_ARCHIVED,
+]);
 
 export interface DaytonaSandboxOptions {
 	id?: string;
@@ -302,8 +319,10 @@ export class DaytonaSandbox extends BaseSandbox {
 	 * isn't a reliable signal: a stopped container returns a 400 from the toolbox, a deleted
 	 * one is 404, auth is 401/403, and transport/proxy conditions vary. Instead we consult
 	 * the authoritative state via the management API — which responds even when the container
-	 * is stopped — and recover only when the sandbox is genuinely gone or not `started`.
-	 * Otherwise we propagate the original error so real failures aren't masked.
+	 * is stopped — and recover only when the sandbox is gone, or in an explicitly recoverable
+	 * state ({@link RECOVERABLE_SANDBOX_STATES}: stopped/archived). Any other state (running,
+	 * a transient transition, or a failed build) propagates the original error so we neither
+	 * mask real failures nor recreate a sandbox off an unrelated error.
 	 *
 	 * A genuine auth failure is handled implicitly: the probe's own `get()` fails too (it
 	 * uses the same credentials), so we fall through to `false` and never recreate.
@@ -313,7 +332,7 @@ export class DaytonaSandbox extends BaseSandbox {
 		try {
 			const client = await this.auth.getClient();
 			const remote = await client.get(this.sandboxName);
-			return Boolean(remote.state) && remote.state !== SANDBOX_STATE_STARTED;
+			return remote.state !== undefined && RECOVERABLE_SANDBOX_STATES.has(remote.state);
 		} catch (probeError) {
 			// Gone entirely → recreate; anything else (incl. auth) → don't mask the original.
 			return isSandboxGone(probeError);

--- a/packages/@n8n/instance-ai/src/workspace/daytona-sandbox.ts
+++ b/packages/@n8n/instance-ai/src/workspace/daytona-sandbox.ts
@@ -108,6 +108,7 @@ export class DaytonaSandbox extends BaseSandbox {
 	private lastClientGeneration = -1;
 	private sandbox?: Sandbox;
 	private workingDirectory?: string;
+	private recoveryPromise?: Promise<void>;
 
 	constructor(private readonly options: DaytonaSandboxOptions = {}) {
 		super();
@@ -330,9 +331,24 @@ export class DaytonaSandbox extends BaseSandbox {
 			return await op();
 		} catch (error) {
 			if (!(await this.isRecoverable(error))) throw error;
-			this.resetLocalHandle();
+			await this.recover();
 			return await op();
 		}
+	}
+
+	/**
+	 * Reset the stale handle and bring the sandbox back to 'started'. Serialized via
+	 * {@link recoveryPromise} so concurrent failed operations share a single resume/recreate
+	 * rather than racing multiple start flows.
+	 */
+	private async recover(): Promise<void> {
+		this.recoveryPromise ??= (async () => {
+			this.resetLocalHandle();
+			await this.ensureRunning();
+		})().finally(() => {
+			this.recoveryPromise = undefined;
+		});
+		await this.recoveryPromise;
 	}
 
 	private async findExistingSandbox(client: Daytona): Promise<Sandbox | null> {

--- a/packages/@n8n/instance-ai/src/workspace/daytona-sandbox.ts
+++ b/packages/@n8n/instance-ai/src/workspace/daytona-sandbox.ts
@@ -340,10 +340,15 @@ export class DaytonaSandbox extends BaseSandbox {
 	}
 
 	/**
-	 * Run a sandbox operation, recovering once if the remote was stopped/deleted out from
-	 * under us. On a recoverable failure the local handle is reset and the operation is
-	 * retried through the normal start path (resume stopped / recreate gone). Retries at
-	 * most once to avoid loops; a second failure propagates.
+	 * Run a sandbox operation, recovering once if the remote was stopped/archived/deleted out
+	 * from under us. On a recoverable failure the sandbox is resumed (or recreated if gone) and
+	 * the operation is retried exactly once; a second failure propagates.
+	 *
+	 * Replaying the operation is safe because recovery only triggers when the probe confirms
+	 * the remote was NOT running (stopped/archived/gone — see {@link isRecoverable}). In those
+	 * states the toolbox/exec request never reached a live container, so it could not have
+	 * partially executed. Operations on a running sandbox are never retried — their error
+	 * propagates untouched.
 	 */
 	private async recoverAndRetry<T>(op: () => Promise<T>): Promise<T> {
 		try {

--- a/packages/@n8n/instance-ai/src/workspace/daytona-sandbox.ts
+++ b/packages/@n8n/instance-ai/src/workspace/daytona-sandbox.ts
@@ -182,28 +182,44 @@ export class DaytonaSandbox extends BaseSandbox {
 		args: string[] = [],
 		options?: ExecuteCommandOptions,
 	): Promise<CommandResult> {
-		await this.ensureRunning();
-		await this.ensureAuthFresh();
-		const startedAt = Date.now();
-		const fullCommand = toShellCommand(command, args);
-		const result = await this.instance.process.executeCommand(
-			fullCommand,
-			options?.cwd,
-			this.compactEnv(options?.env),
-			Math.ceil((options?.timeout ?? this.timeout) / 1000),
-		);
-		const stdout = result.artifacts?.stdout ?? result.result ?? '';
-		if (stdout) options?.onStdout?.(stdout);
+		return await this.recoverAndRetry(async () => {
+			await this.ensureRunning();
+			await this.ensureAuthFresh();
+			const startedAt = Date.now();
+			const fullCommand = toShellCommand(command, args);
+			const result = await this.instance.process.executeCommand(
+				fullCommand,
+				options?.cwd,
+				this.compactEnv(options?.env),
+				Math.ceil((options?.timeout ?? this.timeout) / 1000),
+			);
+			const stdout = result.artifacts?.stdout ?? result.result ?? '';
+			if (stdout) options?.onStdout?.(stdout);
 
-		return {
-			command,
-			args,
-			success: result.exitCode === 0,
-			exitCode: result.exitCode,
-			stdout,
-			stderr: '',
-			executionTimeMs: Date.now() - startedAt,
-		};
+			return {
+				command,
+				args,
+				success: result.exitCode === 0,
+				exitCode: result.exitCode,
+				stdout,
+				stderr: '',
+				executionTimeMs: Date.now() - startedAt,
+			};
+		});
+	}
+
+	/**
+	 * Run a filesystem operation against the live Daytona FileSystem handle, ensuring the
+	 * sandbox is running with fresh auth first, and recovering once if the remote was
+	 * stopped/deleted while idle. Lets `DaytonaFilesystem` reuse the same recovery as
+	 * `executeCommand` without reaching into private state.
+	 */
+	async withFilesystem<T>(op: (fs: Sandbox['fs']) => Promise<T>): Promise<T> {
+		return await this.recoverAndRetry(async () => {
+			await this.ensureRunning();
+			await this.ensureAuthFresh();
+			return await op(this.instance.fs);
+		});
 	}
 
 	/**
@@ -264,6 +280,59 @@ export class DaytonaSandbox extends BaseSandbox {
 		}
 		this.lastClientGeneration = generation;
 		return client;
+	}
+
+	/**
+	 * Drop the in-memory handle so the next `ensureRunning()`/`start()` re-resolves the
+	 * remote (resume if stopped, recreate if gone). The stale `status: 'running'` is the
+	 * reason a resume is otherwise skipped after a long idle.
+	 */
+	private resetLocalHandle(): void {
+		this.sandbox = undefined;
+		this.lastClientGeneration = -1;
+		this.workingDirectory = undefined;
+		this.markNeedsStart();
+	}
+
+	/**
+	 * Whether a failed operation can be recovered by re-resolving the remote.
+	 *
+	 * We don't infer "sandbox unusable" from the failed op's error code, because the code
+	 * isn't a reliable signal: a stopped container returns a 400 from the toolbox, a deleted
+	 * one is 404, auth is 401/403, and transport/proxy conditions vary. Instead we consult
+	 * the authoritative state via the management API — which responds even when the container
+	 * is stopped — and recover only when the sandbox is genuinely gone or not `started`.
+	 * Otherwise we propagate the original error so real failures aren't masked.
+	 *
+	 * A genuine auth failure is handled implicitly: the probe's own `get()` fails too (it
+	 * uses the same credentials), so we fall through to `false` and never recreate.
+	 */
+	private async isRecoverable(error: unknown): Promise<boolean> {
+		if (isSandboxGone(error)) return true;
+		try {
+			const client = await this.auth.getClient();
+			const remote = await client.get(this.sandboxName);
+			return Boolean(remote.state) && remote.state !== SANDBOX_STATE_STARTED;
+		} catch (probeError) {
+			// Gone entirely → recreate; anything else (incl. auth) → don't mask the original.
+			return isSandboxGone(probeError);
+		}
+	}
+
+	/**
+	 * Run a sandbox operation, recovering once if the remote was stopped/deleted out from
+	 * under us. On a recoverable failure the local handle is reset and the operation is
+	 * retried through the normal start path (resume stopped / recreate gone). Retries at
+	 * most once to avoid loops; a second failure propagates.
+	 */
+	private async recoverAndRetry<T>(op: () => Promise<T>): Promise<T> {
+		try {
+			return await op();
+		} catch (error) {
+			if (!(await this.isRecoverable(error))) throw error;
+			this.resetLocalHandle();
+			return await op();
+		}
 	}
 
 	private async findExistingSandbox(client: Daytona): Promise<Sandbox | null> {


### PR DESCRIPTION
## Summary

Continuation to https://github.com/n8n-io/n8n/pull/31745.

Our Daytona sandbox resume handling needed some work. If the sandbox was stopped while waiting for something like a HITL confirmation on a plan, on resume without this logic the first calls would fail, and and error would be surfaced to the user. The sandbox status doesn't update when the sandbox gets auto stopped, so it gets out of sync.

Added a mechanism to recover from the suspended sandboxes by marking the sandbox for needing to start, we already had the logic to call .start() on the sandbox but proxy wasn't allowing it, so https://github.com/n8n-io/ai-assistant-service/pull/408 changes that.

With this I was able to successfully recover auto-suspended sandboxes in various scenarios without user-facing errors.

## How to test

Have a proxy setup, with ai-assistant that allows the /start endpoint (a local one from that feature branch?).
Start a thread, ask it to build a workflow, have it pause on planning
Wait for 15 minutes or stop the related sandbox manually on daytona UI
Approve the plan -> the sandbox that was stopped should continue without visible error.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-433/sandbox-restart-failed

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
