### PR TITLE
fix(chat): Guard runData access in getMessage against missing node run data

### DIFF
--- a/packages/cli/src/chat/__tests__/utils.test.ts
+++ b/packages/cli/src/chat/__tests__/utils.test.ts
@@ -139,6 +139,32 @@ describe('getMessage', () => {
 		expect(result).toBeUndefined();
 	});
 
+	it('should return undefined without throwing when runData is undefined', () => {
+		const execution = createMockExecution({
+			data: {
+				resultData: {
+					lastNodeExecuted: 'TestNode',
+					runData: undefined,
+				},
+			},
+		});
+		expect(() => getMessage(execution)).not.toThrow();
+		expect(getMessage(execution)).toBeUndefined();
+	});
+
+	it('should return undefined without throwing when runData has no entry for lastNodeExecuted', () => {
+		const execution = createMockExecution({
+			data: {
+				resultData: {
+					lastNodeExecuted: 'TestNode',
+					runData: { OtherNode: [] },
+				},
+			},
+		});
+		expect(() => getMessage(execution)).not.toThrow();
+		expect(getMessage(execution)).toBeUndefined();
+	});
+
 	it('should return undefined when nodeExecutionData is undefined', () => {
 		const execution = createMockExecution({
 			data: {

--- a/packages/cli/src/chat/utils.ts
+++ b/packages/cli/src/chat/utils.ts
@@ -111,8 +111,10 @@ export function getMessage(execution: IExecutionResponse) {
 		return getToolExecutorSendMessage(execution.data);
 	}
 
-	const runIndex = execution.data.resultData.runData[lastNodeExecuted].length - 1;
-	const data = execution.data.resultData.runData[lastNodeExecuted][runIndex]?.data;
+	const nodeRunData = execution.data.resultData.runData?.[lastNodeExecuted];
+	if (!nodeRunData?.length) return undefined;
+	const runIndex = nodeRunData.length - 1;
+	const data = nodeRunData[runIndex]?.data;
 	const outputs = data?.main ?? data?.[AI_TOOL];
 
 	// Check all main output branches for a message


### PR DESCRIPTION
## Summary

`getMessage()` accessed `runData[lastNodeExecuted]` without checking the key exists. In corrupted or partially-written execution states `runData` can be `undefined` or missing that entry, causing a `TypeError` that aborts the chat response. This adds a guard returning `undefined` when there is no run data.

Same class of issue as #29513; this guards the **chat response** path instead.

Adds a test.

## Related Linear tickets, Github issues, and Community forum posts

Related to #22030. Same class of fix as #29513.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
