### PR TITLE
fix(Form Node): Allow single quotes in form trigger node names

### DIFF
--- a/packages/nodes-base/nodes/Form/Form.node.ts
+++ b/packages/nodes-base/nodes/Form/Form.node.ts
@@ -375,7 +375,7 @@ export class Form extends Node {
 		) as boolean | undefined;
 		const userForOutput = triggerIncludeUser === false ? undefined : authResult.authedUser;
 
-		const mode = context.evaluateExpression(`{{ $('${trigger.name}').first().json.formMode }}`) as
+		const mode = context.evaluateExpression(`{{ ${triggerRef}.first().json.formMode }}`) as
 			| 'test'
 			| 'production';
 
@@ -413,7 +413,7 @@ export class Form extends Node {
 		}
 
 		let useWorkflowTimezone = context.evaluateExpression(
-			`{{ $('${trigger.name}').params.options?.useWorkflowTimezone }}`,
+			`{{ ${triggerRef}.params.options?.useWorkflowTimezone }}`,
 		) as boolean;
 
 		if (useWorkflowTimezone === undefined && trigger?.typeVersion > 2) {

--- a/packages/nodes-base/nodes/Form/test/formCompletionUtils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/formCompletionUtils.test.ts
@@ -181,7 +181,7 @@ describe('formCompletionUtils', () => {
 				return params[parameterName];
 			});
 			mockWebhookFunctions.evaluateExpression.mockImplementation((expression) => {
-				if (expression === `{{ $('${trigger.name}').params.formTitle }}`) {
+				if (expression === `{{ $(${JSON.stringify(trigger.name)}).params.formTitle }}`) {
 					return "={{ $workflow.name.split('-')[0].trim() }}";
 				}
 				if (expression === "{{ $workflow.name.split('-')[0].trim() }}") return 'MyForm';
@@ -295,9 +295,9 @@ describe('formCompletionUtils', () => {
 			for (const parentNodes of parentNodesTestCases) {
 				mockWebhookFunctions.getParentNodes.mockReturnValueOnce(parentNodes);
 				mockWebhookFunctions.evaluateExpression.mockImplementation((arg) => {
-					if (arg === `{{ $('${nodeNameWithFileToDownload}').first().binary }}`) {
+					if (arg === `{{ $(${JSON.stringify(nodeNameWithFileToDownload)}).first().binary }}`) {
 						return expectedBinaryResponse;
-					} else if (arg === `{{ $('${nodeNameWithFile}').first().binary }}`) {
+					} else if (arg === `{{ $(${JSON.stringify(nodeNameWithFile)}).first().binary }}`) {
 						return { someData: {} };
 					} else {
 						return undefined;
@@ -357,9 +357,9 @@ describe('formCompletionUtils', () => {
 			for (const parentNodes of parentNodesTestCases) {
 				mockWebhookFunctions.getParentNodes.mockReturnValueOnce(parentNodes);
 				mockWebhookFunctions.evaluateExpression.mockImplementation((arg) => {
-					if (arg === `{{ $('${nodeNameWithFileToDownload}').first().binary }}`) {
+					if (arg === `{{ $(${JSON.stringify(nodeNameWithFileToDownload)}).first().binary }}`) {
 						return expectedBinaryResponse;
-					} else if (arg === `{{ $('${nodeNameWithFile}').first().binary }}`) {
+					} else if (arg === `{{ $(${JSON.stringify(nodeNameWithFile)}).first().binary }}`) {
 						return { someData: {} };
 					} else {
 						return undefined;
@@ -515,7 +515,7 @@ describe('formCompletionUtils', () => {
 
 			mockWebhookFunctions.getParentNodes.mockReturnValueOnce(parentNodesWithMultipleBinaryFiles);
 			mockWebhookFunctions.evaluateExpression.mockImplementation((arg) => {
-				if (arg === `{{ $('${nodeNameWithFile}').first().binary }}`) {
+				if (arg === `{{ $(${JSON.stringify(nodeNameWithFile)}).first().binary }}`) {
 					return expectedBinaryResponse;
 				} else {
 					return notExpectedBinaryResponse;

--- a/packages/nodes-base/nodes/Form/test/formNodeUtils.test.ts
+++ b/packages/nodes-base/nodes/Form/test/formNodeUtils.test.ts
@@ -177,7 +177,7 @@ describe('formNodeUtils', () => {
 		const triggerName = 'triggerName';
 		webhookFunctions.evaluateExpression.mockImplementation((expression) => {
 			// The trigger stores the raw, unresolved expression string in its params.
-			if (expression === `{{ $('${triggerName}').params.formTitle }}`) {
+			if (expression === `{{ $(${JSON.stringify(triggerName)}).params.formTitle }}`) {
 				return "={{ $workflow.name.split('-')[0].trim() }}";
 			}
 			if (expression === "{{ $workflow.name.split('-')[0].trim() }}") {
@@ -209,7 +209,7 @@ describe('formNodeUtils', () => {
 		const triggerName = 'triggerName';
 		webhookFunctions.evaluateExpression.mockImplementation((expression) => {
 			// The trigger stores the raw, unresolved expression string in its params.
-			if (expression === `{{ $('${triggerName}').params.options?.buttonLabel }}`) {
+			if (expression === `{{ $(${JSON.stringify(triggerName)}).params.options?.buttonLabel }}`) {
 				return '={{ $workflow.name }}';
 			}
 			if (expression === '{{ $workflow.name }}') {
@@ -294,7 +294,7 @@ describe('formNodeUtils', () => {
 			webhookFunctions.getParentNodes.mockReturnValue(parentNodes);
 
 			webhookFunctions.evaluateExpression
-				.calledWith(`{{ $('${formTrigger1.name}').first() }}`)
+				.calledWith(`{{ $(${JSON.stringify(formTrigger1.name)}).first() }}`)
 				.mockReturnValue('success');
 
 			const result = getFormTriggerNode(webhookFunctions);
@@ -302,7 +302,7 @@ describe('formNodeUtils', () => {
 			expect(result).toBe(formTrigger1);
 			expect(webhookFunctions.getParentNodes).toHaveBeenCalledWith('currentNode');
 			expect(webhookFunctions.evaluateExpression).toHaveBeenCalledWith(
-				`{{ $('${formTrigger1.name}').first() }}`,
+				`{{ $(${JSON.stringify(formTrigger1.name)}).first() }}`,
 			);
 		});
 
@@ -324,22 +324,22 @@ describe('formNodeUtils', () => {
 			webhookFunctions.getParentNodes.mockReturnValue(parentNodes);
 
 			webhookFunctions.evaluateExpression
-				.calledWith(`{{ $('${formTrigger1.name}').first() }}`)
+				.calledWith(`{{ $(${JSON.stringify(formTrigger1.name)}).first() }}`)
 				.mockImplementation(() => {
 					throw new Error('Evaluation failed');
 				});
 			webhookFunctions.evaluateExpression
-				.calledWith(`{{ $('${formTrigger2.name}').first() }}`)
+				.calledWith(`{{ $(${JSON.stringify(formTrigger2.name)}).first() }}`)
 				.mockReturnValue('success');
 
 			const result = getFormTriggerNode(webhookFunctions);
 
 			expect(result).toBe(formTrigger2);
 			expect(webhookFunctions.evaluateExpression).toHaveBeenCalledWith(
-				`{{ $('${formTrigger1.name}').first() }}`,
+				`{{ $(${JSON.stringify(formTrigger1.name)}).first() }}`,
 			);
 			expect(webhookFunctions.evaluateExpression).toHaveBeenCalledWith(
-				`{{ $('${formTrigger2.name}').first() }}`,
+				`{{ $(${JSON.stringify(formTrigger2.name)}).first() }}`,
 			);
 		});
 
@@ -387,10 +387,10 @@ describe('formNodeUtils', () => {
 			);
 
 			expect(webhookFunctions.evaluateExpression).toHaveBeenCalledWith(
-				`{{ $('${formTrigger1.name}').first() }}`,
+				`{{ $(${JSON.stringify(formTrigger1.name)}).first() }}`,
 			);
 			expect(webhookFunctions.evaluateExpression).toHaveBeenCalledWith(
-				`{{ $('${formTrigger2.name}').first() }}`,
+				`{{ $(${JSON.stringify(formTrigger2.name)}).first() }}`,
 			);
 		});
 
@@ -427,7 +427,7 @@ describe('formNodeUtils', () => {
 			webhookFunctions.getParentNodes.mockReturnValue(parentNodes);
 
 			webhookFunctions.evaluateExpression
-				.calledWith(`{{ $('${formTrigger.name}').first() }}`)
+				.calledWith(`{{ $(${JSON.stringify(formTrigger.name)}).first() }}`)
 				.mockReturnValue('success');
 
 			const result = getFormTriggerNode(webhookFunctions);
@@ -435,8 +435,32 @@ describe('formNodeUtils', () => {
 			expect(result).toBe(formTrigger);
 			expect(webhookFunctions.evaluateExpression).toHaveBeenCalledTimes(1);
 			expect(webhookFunctions.evaluateExpression).toHaveBeenCalledWith(
-				`{{ $('${formTrigger.name}').first() }}`,
+				`{{ $(${JSON.stringify(formTrigger.name)}).first() }}`,
 			);
+		});
+
+		it('should escape special characters in trigger node names', () => {
+			// Regression for #31773 — single quotes in node names used to break the
+			// expression string and surface as "Workflow could not be started".
+			const formTrigger: NodeTypeAndVersion = {
+				name: "My Form's Trigger",
+				type: FORM_TRIGGER_NODE_TYPE,
+				typeVersion: 1,
+				disabled: false,
+			};
+
+			webhookFunctions.getParentNodes.mockReturnValue([formTrigger]);
+
+			const expectedExpression = `{{ $(${JSON.stringify(formTrigger.name)}).first() }}`;
+			webhookFunctions.evaluateExpression.calledWith(expectedExpression).mockReturnValue('success');
+
+			const result = getFormTriggerNode(webhookFunctions);
+
+			expect(result).toBe(formTrigger);
+			expect(webhookFunctions.evaluateExpression).toHaveBeenCalledWith(expectedExpression);
+			// Sanity: the embedded JS string literal must contain the unescaped quote
+			// so the n8n expression evaluator parses it as a valid string.
+			expect(expectedExpression).toContain('"My Form\'s Trigger"');
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Form/utils/formCompletionUtils.ts
+++ b/packages/nodes-base/nodes/Form/utils/formCompletionUtils.ts
@@ -20,7 +20,10 @@ import {
 } from './utils';
 
 const getBinaryDataFromNode = (context: IWebhookFunctions, nodeName: string): IDataObject => {
-	return context.evaluateExpression(`{{ $('${nodeName}').first().binary }}`) as IDataObject;
+	// JSON.stringify produces a properly-escaped JS string literal so a node name
+	// containing `'`, `\`, or `${}` can't break out of the expression.
+	const nodeRef = `$(${JSON.stringify(nodeName)})`;
+	return context.evaluateExpression(`{{ ${nodeRef}.first().binary }}`) as IDataObject;
 };
 
 export const binaryResponse = async (
@@ -72,13 +75,17 @@ export const renderFormCompletion = async (
 		| 'returnBinary';
 	const binary = respondWith === 'returnBinary' ? await binaryResponse(context) : '';
 
+	// JSON.stringify produces a properly-escaped JS string literal so a trigger
+	// name containing `'`, `\`, or `${}` can't break out of the expression.
+	const triggerRef = `$(${JSON.stringify(trigger?.name ?? '')})`;
+
 	let title = options.formTitle;
 	if (!title) {
-		title = context.evaluateExpression(`{{ $('${trigger?.name}').params.formTitle }}`) as string;
+		title = context.evaluateExpression(`{{ ${triggerRef}.params.formTitle }}`) as string;
 		title = resolveRawData(context, title);
 	}
 	const appendAttribution = context.evaluateExpression(
-		`{{ $('${trigger?.name}').params.options?.appendAttribution === false ? false : true }}`,
+		`{{ ${triggerRef}.params.options?.appendAttribution === false ? false : true }}`,
 	) as boolean;
 
 	if (respondWith !== 'redirect' && !isFormHtmlSandboxingDisabled()) {

--- a/packages/nodes-base/nodes/Form/utils/formNodeUtils.ts
+++ b/packages/nodes-base/nodes/Form/utils/formNodeUtils.ts
@@ -32,9 +32,13 @@ export const renderFormNode = async (
 		customCss?: string;
 	};
 
+	// JSON.stringify produces a properly-escaped JS string literal so a trigger
+	// name containing `'`, `\`, or `${}` can't break out of the expression.
+	const triggerRef = `$(${JSON.stringify(trigger?.name ?? '')})`;
+
 	let title = options.formTitle;
 	if (!title) {
-		title = context.evaluateExpression(`{{ $('${trigger?.name}').params.formTitle }}`) as string;
+		title = context.evaluateExpression(`{{ ${triggerRef}.params.formTitle }}`) as string;
 		title = resolveRawData(context, title);
 	}
 
@@ -43,14 +47,13 @@ export const renderFormNode = async (
 	let buttonLabel = options.buttonLabel;
 	if (!buttonLabel) {
 		buttonLabel =
-			(context.evaluateExpression(
-				`{{ $('${trigger?.name}').params.options?.buttonLabel }}`,
-			) as string) || 'Submit';
+			(context.evaluateExpression(`{{ ${triggerRef}.params.options?.buttonLabel }}`) as string) ||
+			'Submit';
 		buttonLabel = resolveRawData(context, buttonLabel);
 	}
 
 	const appendAttribution = context.evaluateExpression(
-		`{{ $('${trigger?.name}').params.options?.appendAttribution === false ? false : true }}`,
+		`{{ ${triggerRef}.params.options?.appendAttribution === false ? false : true }}`,
 	) as boolean;
 
 	// Embed the form auth token so subsequent POSTs can re-authenticate the
@@ -103,7 +106,8 @@ export function getFormTriggerNode(context: IWebhookFunctions): NodeTypeAndVersi
 
 	for (const trigger of formTriggers) {
 		try {
-			context.evaluateExpression(`{{ $('${trigger.name}').first() }}`);
+			const triggerRef = `$(${JSON.stringify(trigger.name)})`;
+			context.evaluateExpression(`{{ ${triggerRef}.first() }}`);
 		} catch (error) {
 			continue;
 		}

--- a/packages/nodes-base/nodes/Form/utils/utils.ts
+++ b/packages/nodes-base/nodes/Form/utils/utils.ts
@@ -581,8 +581,12 @@ export function renderForm({
 			(node) => node.type === FORM_TRIGGER_NODE_TYPE,
 		) as NodeTypeAndVersion;
 		try {
+			// JSON.stringify produces a properly-escaped JS string literal so a
+			// trigger name containing `'`, `\`, or `${}` can't break out of the
+			// expression.
+			const triggerRef = `$(${JSON.stringify(trigger?.name ?? '')})`;
 			const triggerQueryParameters = context.evaluateExpression(
-				`{{ $('${trigger?.name}').first().json.formQueryParameters }}`,
+				`{{ ${triggerRef}.first().json.formQueryParameters }}`,
 			) as IDataObject;
 
 			if (triggerQueryParameters) {


### PR DESCRIPTION
## Summary

When the Form Trigger node's name contained a single quote, the form's second page failed to load with:

> Workflow Form Error: Workflow could not be started!

The Form node references the trigger by interpolating its name into a single-quoted JS string inside an n8n expression, e.g. ``$('${trigger.name}')``. A name like ``My Form's Trigger`` produced a malformed expression that the evaluator couldn't parse, and the error bubbled up from `webhook-helpers.ts` as the generic "could not be started" message.

The same file (`Form.node.ts`) already had the safe pattern for the auth gate added earlier:

```ts
// JSON.stringify produces a properly-escaped JS string literal, so an
// adversarial trigger node name containing `'`, `\`, or `${}` can't
// break out of the expression.
const triggerRef = `$(${JSON.stringify(trigger.name)})`;
```

This PR just applies that same pattern to the remaining call sites in `Form.node.ts` and the render/util helpers (`formCompletionUtils.ts`, `formNodeUtils.ts`, `utils.ts`) so the fix is consistent.

## How to test

1. Create a workflow with `Form Trigger` → `Form (page)` → `Form (completion)`
2. Rename the Form Trigger to something containing a single quote, e.g. ``My Form's Trigger``
3. Execute the workflow and open the public form URL
4. **Before:** page 1 renders, submitting it lands on the error page with "Workflow could not be started"
5. **After:** both pages render and the workflow completes normally

A regression test for `getFormTriggerNode` with a quoted name is included in `formNodeUtils.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

#31773


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with \`Backport to Beta\`, \`Backport to Stable\`, or \`Backport to v1\`