### PR TITLE
fix(core): Add explicit file count and size limits to multipart form parsing

### DIFF
--- a/packages/@n8n/config/src/configs/endpoints.config.ts
+++ b/packages/@n8n/config/src/configs/endpoints.config.ts
@@ -91,6 +91,10 @@ export class EndpointsConfig {
 	@Env('N8N_FORMDATA_FILE_SIZE_MAX')
 	formDataFileSizeMax: number = 200;
 
+	/** Maximum number of files accepted in a single multipart/form-data webhook payload. */
+	@Env('N8N_FORMDATA_FILE_COUNT_MAX')
+	formDataFileCountMax: number = 1000;
+
 	@Nested
 	metrics: PrometheusMetricsConfig;
 

--- a/packages/cli/src/webhooks/__tests__/webhook-form-data.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-form-data.test.ts
@@ -85,7 +85,7 @@ describe('webhook-form-data', () => {
 		});
 
 		it('should parse fields from the multipart form data', async () => {
-			const parseFn = createMultiFormDataParser(1);
+			const parseFn = createMultiFormDataParser(1, 1000);
 
 			await testServer
 				.sendRequestToHandler(async (req) => {
@@ -105,7 +105,7 @@ describe('webhook-form-data', () => {
 		});
 
 		it('should parse text/plain file from the multipart form data', async () => {
-			const parseFn = createMultiFormDataParser(1);
+			const parseFn = createMultiFormDataParser(1, 1000);
 
 			await testServer
 				.sendRequestToHandler(async (req) => {
@@ -131,7 +131,7 @@ describe('webhook-form-data', () => {
 		});
 
 		it('should parse multiple files and fields from the multipart form data', async () => {
-			const parseFn = createMultiFormDataParser(1);
+			const parseFn = createMultiFormDataParser(1, 1000);
 
 			await testServer
 				.sendRequestToHandler(async (req) => {
@@ -166,7 +166,7 @@ describe('webhook-form-data', () => {
 
 		it('should reject with an error when file exceeds maxFileSize', async () => {
 			const oneByteInMb = 1 / 1024 / 1024;
-			const parseFn = createMultiFormDataParser(oneByteInMb);
+			const parseFn = createMultiFormDataParser(oneByteInMb, 1000);
 
 			await testServer
 				.sendRequestToHandler(async (req) => {
@@ -183,7 +183,7 @@ describe('webhook-form-data', () => {
 			// error instead of silently returning empty data.
 			const twoKbData = Buffer.alloc(2 * 1024, 'x');
 			const oneKbInMb = 1 / 1024;
-			const parseFn = createMultiFormDataParser(oneKbInMb);
+			const parseFn = createMultiFormDataParser(oneKbInMb, 1000);
 
 			await testServer
 				.sendRequestToHandler(async (req) => {
@@ -194,6 +194,22 @@ describe('webhook-form-data', () => {
 					});
 				})
 				.attach('file', twoKbData, 'large-upload.bin');
+
+			testServer.assertHasBeenCalled();
+		});
+
+		it('should reject when the number of files exceeds maxFiles', async () => {
+			// Each part opens a temp file before any size check, so the count must be
+			// bounded explicitly — formidable's default maxFiles is Infinity.
+			const parseFn = createMultiFormDataParser(1, 2);
+
+			await testServer
+				.sendRequestToHandler(async (req) => {
+					await expect(parseFn(req)).rejects.toThrow(/maxFiles/);
+				})
+				.attach('file1', oneKbData, 'a.txt')
+				.attach('file2', oneKbData, 'b.txt')
+				.attach('file3', oneKbData, 'c.txt');
 
 			testServer.assertHasBeenCalled();
 		});

--- a/packages/cli/src/webhooks/webhook-form-data.ts
+++ b/packages/cli/src/webhooks/webhook-form-data.ts
@@ -13,17 +13,27 @@ const normalizeFormData = <T>(values: Record<string, T | T[]>) => {
 /**
  * Creates a function that parses the multipart form data into the request's `body` property
  */
-export const createMultiFormDataParser = (maxFormDataSizeInMb: number) => {
+export const createMultiFormDataParser = (maxFormDataSizeInMb: number, maxFiles: number) => {
 	return async function parseMultipartFormData(req: IncomingMessage): Promise<{
 		data: formidable.Fields;
 		files: formidable.Files;
 	}> {
 		const { encoding } = req;
 
+		const maxFileSize = maxFormDataSizeInMb * 1024 * 1024;
+
 		const form = formidable({
 			multiples: true,
 			encoding: encoding as formidable.BufferEncoding,
-			maxFileSize: maxFormDataSizeInMb * 1024 * 1024,
+			maxFileSize,
+			// formidable defaults `maxFiles` to Infinity and only enforces a count
+			// when it is finite, so set an explicit cap. Without it, a request with a
+			// very large number of parts opens a temp file per part before any size
+			// check runs.
+			maxFiles,
+			// formidable defaults `maxTotalFileSize` to `maxFileSize`; set it explicitly
+			// so the aggregate budget across all parts is clear at the call site.
+			maxTotalFileSize: maxFileSize,
 			// TODO: pass a custom `fileWriteStreamHandler` to create binary data files directly
 		});
 

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -296,8 +296,8 @@ export const handleFormRedirectionCase = (
 	return data;
 };
 
-const { formDataFileSizeMax } = Container.get(GlobalConfig).endpoints;
-const parseFormData = createMultiFormDataParser(formDataFileSizeMax);
+const { formDataFileSizeMax, formDataFileCountMax } = Container.get(GlobalConfig).endpoints;
+const parseFormData = createMultiFormDataParser(formDataFileSizeMax, formDataFileCountMax);
 
 export function setupResponseNodePromise(
 	responsePromise: IDeferredPromise<IN8nHttpFullResponse>,


### PR DESCRIPTION
## Summary

n8n's multipart/form-data parser (`createMultiFormDataParser` in
`packages/cli/src/webhooks/webhook-form-data.ts`) sets `maxFileSize` but not
`maxFiles` or `maxTotalFileSize`. With formidable's defaults (`maxFiles` is
`Infinity`, and the per-request count check is skipped when `maxFiles === Infinity`),
a single multipart request to a Form/Webhook endpoint can contain an unbounded
number of parts, each opening a temporary file before size validation.

This change adds explicit, conservative limits:
- a configurable file-count cap (`N8N_FORMDATA_FILE_COUNT_MAX`, default `1000`),
  surfaced via the endpoints config;
- `maxFiles` and `maxTotalFileSize` passed through to the parser;
- tests updated to the new options, plus a case asserting the parser rejects
  requests that exceed the file-count limit.

Behaviour is unchanged for normal form submissions — the limits only bound
pathological inputs, and the defaults are overridable.

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.

> **Note on local verification:** I was unable to run the test suite locally —
> the workspace dependency install did not complete on a throttled network
> (`jest` was never linked). The added case is written against the existing
> `webhook-form-data` test harness (same `TestServer`/`supertest` pattern as the
> surrounding `maxFileSize`/total-size tests) and asserts the parser rejects a
> request exceeding the file-count limit with formidable's `options.maxFiles (N)
> exceeded` error. I'm relying on CI to execute it; happy to adjust if it needs
> tweaks. (I've intentionally left the "I have run this code" box unchecked
> rather than claim a local run I didn't perform.)
