### PR TITLE
fix(core): Disable iAI e2e tests temporarily

### DIFF
--- a/packages/testing/playwright/playwright-projects.ts
+++ b/packages/testing/playwright/playwright-projects.ts
@@ -29,6 +29,9 @@ const CONTAINER_ONLY = new RegExp(
 // network calls. Used by `pnpm test:local:isolated` and similar workflows.
 const ALLOW_CONTAINER_ONLY = process.env.PLAYWRIGHT_ALLOW_CONTAINER_ONLY === 'true';
 
+/** TODO: Temporarily disable all instance ai e2e tests. Re-enable when ready. */
+const INSTANCE_AI_E2E_IGNORE = '**/instance-ai/**';
+
 const CONTAINER_CONFIGS: Array<{ name: string; config: N8NConfig }> = [
 	{ name: 'sqlite', config: {} },
 	{ name: 'postgres', config: { postgres: true } },
@@ -217,6 +220,7 @@ export function getProjects(): Project[] {
 		projects.push({
 			name: 'e2e',
 			testDir: './tests/e2e',
+			testIgnore: INSTANCE_AI_E2E_IGNORE,
 			grepInvert: ALLOW_CONTAINER_ONLY ? undefined : CONTAINER_ONLY,
 			fullyParallel: true,
 			use: { baseURL: getFrontendUrl() },
@@ -236,6 +240,7 @@ export function getProjects(): Project[] {
 				{
 					name: `${name}:e2e`,
 					testDir: './tests/e2e',
+					testIgnore: INSTANCE_AI_E2E_IGNORE,
 					timeout: name === 'sqlite' ? 60000 : 180000, // 60 seconds for sqlite container test, 180 for other modes to allow startup
 					fullyParallel: true,
 					use: { containerConfig: config },
@@ -254,6 +259,7 @@ export function getProjects(): Project[] {
 		projects.push({
 			name: 'coverage',
 			testDir: './tests/e2e',
+			testIgnore: INSTANCE_AI_E2E_IGNORE,
 			timeout: 60000,
 			fullyParallel: true,
 			use: { containerConfig: {} },


### PR DESCRIPTION
## Summary

Temporarily disables iAI e2e tests until we can get them to a point where they are reliable on CI. cc @jeanpaul 

## Related Linear tickets, Github issues, and Community forum posts

RESOLVES https://linear.app/n8n/issue/INS-448/disable-instance-ai-e2e-tests

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
