### PR TITLE
feat(editor): Add pagination to MCP workflows table

### DIFF
--- a/packages/frontend/editor-ui/src/app/stores/workflowsList.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowsList.store.ts
@@ -90,7 +90,7 @@ export const useWorkflowsListStore = defineStore(STORES.WORKFLOWS_LIST, () => {
 	}
 
 	// Methods - Fetching
-	async function fetchWorkflowsPage(
+	async function fetchWorkflowsPageWithCount(
 		projectId?: string,
 		page = 1,
 		pageSize = DEFAULT_WORKFLOW_PAGE_SIZE,
@@ -106,7 +106,7 @@ export const useWorkflowsListStore = defineStore(STORES.WORKFLOWS_LIST, () => {
 		} = {},
 		includeFolders = false,
 		onlySharedWithMe = false,
-	): Promise<WorkflowListResource[]> {
+	): Promise<{ data: WorkflowListResource[]; count: number }> {
 		const filter = { ...filters, projectId };
 		const options = {
 			skip: (page - 1) * pageSize,
@@ -135,6 +135,35 @@ export const useWorkflowsListStore = defineStore(STORES.WORKFLOWS_LIST, () => {
 					versionId: '',
 				});
 			});
+		return { data, count };
+	}
+
+	async function fetchWorkflowsPage(
+		projectId?: string,
+		page = 1,
+		pageSize = DEFAULT_WORKFLOW_PAGE_SIZE,
+		sortBy?: string,
+		filters: {
+			query?: string;
+			tags?: string[];
+			active?: boolean;
+			isArchived?: boolean;
+			parentFolderId?: string;
+			availableInMCP?: boolean;
+			triggerNodeTypes?: string[];
+		} = {},
+		includeFolders = false,
+		onlySharedWithMe = false,
+	): Promise<WorkflowListResource[]> {
+		const { data } = await fetchWorkflowsPageWithCount(
+			projectId,
+			page,
+			pageSize,
+			sortBy,
+			filters,
+			includeFolders,
+			onlySharedWithMe,
+		);
 		return data;
 	}
 
@@ -270,6 +299,7 @@ export const useWorkflowsListStore = defineStore(STORES.WORKFLOWS_LIST, () => {
 		setWorkflowInactiveInCache,
 
 		// Fetching
+		fetchWorkflowsPageWithCount,
 		fetchWorkflowsPage,
 		searchWorkflows,
 		fetchAllWorkflows,

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/SettingsMCPView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/SettingsMCPView.test.ts
@@ -12,6 +12,7 @@ import { useUIStore } from '@/app/stores/ui.store';
 import type { FrontendSettings } from '@n8n/api-types';
 import { MCP_CONNECT_WORKFLOWS_MODAL_KEY } from '@/features/ai/mcpAccess/mcp.constants';
 import { createWorkflow } from '@/features/ai/mcpAccess/mcp.test.utils';
+import type { WorkflowListItem } from '@/Interface';
 
 vi.mock('vue-router', async (importOriginal) => ({
 	...(await importOriginal()),
@@ -57,7 +58,8 @@ const createComponent = createComponentRenderer(SettingsMCPView, {
 			},
 			WorkflowsTable: {
 				inheritAttrs: true,
-				template: '<div>Workflows Table</div>',
+				template:
+					'<div><button data-test-id="workflows-table-page-2" @click="$emit(\'update:options\', { page: 1, itemsPerPage: 10, sortBy: [] })">Page 2</button>Workflows Table</div>',
 			},
 			OAuthClientsTable: {
 				inheritAttrs: true,
@@ -77,6 +79,8 @@ const clickTab = async (container: Element, tabTestId: string) => {
 		await userEvent.click(clickableTab);
 	}
 };
+
+const workflowPage = (data: WorkflowListItem[] = []) => ({ data, count: data.length });
 
 describe('SettingsMCPView', () => {
 	beforeEach(() => {
@@ -98,6 +102,7 @@ describe('SettingsMCPView', () => {
 		};
 
 		mcpStore.getAllOAuthClients.mockResolvedValue([]);
+		mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue(workflowPage());
 	});
 
 	afterEach(() => {
@@ -124,7 +129,7 @@ describe('SettingsMCPView', () => {
 					mcpManagedByEnv: false,
 				},
 			};
-			mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue([]);
+			mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue(workflowPage());
 		});
 
 		it('should render enabled section when MCP access is enabled', async () => {
@@ -171,7 +176,7 @@ describe('SettingsMCPView', () => {
 					mcpManagedByEnv: false,
 				},
 			};
-			mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue([]);
+			mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue(workflowPage());
 			mcpStore.setMcpAccessEnabled.mockResolvedValue(false);
 
 			const { getByTestId } = createComponent({ pinia });
@@ -185,7 +190,7 @@ describe('SettingsMCPView', () => {
 
 		it('should fetch workflows and oauth clients after enabling MCP', async () => {
 			mcpStore.setMcpAccessEnabled.mockResolvedValue(true);
-			mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue([]);
+			mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue(workflowPage());
 			mcpStore.getAllOAuthClients.mockResolvedValue([]);
 
 			const { getByTestId } = createComponent({ pinia });
@@ -207,7 +212,7 @@ describe('SettingsMCPView', () => {
 					mcpManagedByEnv: false,
 				},
 			};
-			mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue([]);
+			mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue(workflowPage());
 			mcpStore.getAllOAuthClients.mockResolvedValue([]);
 		});
 
@@ -341,7 +346,7 @@ describe('SettingsMCPView', () => {
 					mcpManagedByEnv: false,
 				},
 			};
-			mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue([]);
+			mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue(workflowPage());
 			mcpStore.getAllOAuthClients.mockResolvedValue([]);
 		});
 
@@ -386,6 +391,43 @@ describe('SettingsMCPView', () => {
 		});
 	});
 
+	describe('Workflow pagination', () => {
+		beforeEach(() => {
+			settingsStore.moduleSettings = {
+				mcp: {
+					mcpAccessEnabled: true,
+					mcpManagedByEnv: false,
+				},
+			};
+			mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue(
+				workflowPage([createWorkflow({ id: '1', name: 'Workflow 1' })]),
+			);
+		});
+
+		it('should fetch the first workflow page on mount', async () => {
+			createComponent({ pinia });
+
+			await waitFor(() => {
+				expect(mcpStore.fetchWorkflowsAvailableForMCP).toHaveBeenCalledWith(1, 10);
+			});
+		});
+
+		it('should fetch the selected workflow page when table options change', async () => {
+			const { getByTestId } = createComponent({ pinia });
+
+			await waitFor(() => {
+				expect(mcpStore.fetchWorkflowsAvailableForMCP).toHaveBeenCalledWith(1, 10);
+			});
+			mcpStore.fetchWorkflowsAvailableForMCP.mockClear();
+
+			await userEvent.click(getByTestId('workflows-table-page-2'));
+
+			await waitFor(() => {
+				expect(mcpStore.fetchWorkflowsAvailableForMCP).toHaveBeenCalledWith(2, 10);
+			});
+		});
+	});
+
 	describe('Connect Workflows button', () => {
 		beforeEach(() => {
 			settingsStore.moduleSettings = {
@@ -397,7 +439,7 @@ describe('SettingsMCPView', () => {
 		});
 
 		it('should not show Connect Workflows button when there are no workflows', async () => {
-			mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue([]);
+			mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue(workflowPage());
 
 			const { queryByTestId } = createComponent({ pinia });
 			await nextTick();
@@ -408,10 +450,12 @@ describe('SettingsMCPView', () => {
 		});
 
 		it('should show Connect Workflows button when there are workflows', async () => {
-			mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue([
-				createWorkflow({ id: '1', name: 'Workflow 1' }),
-				createWorkflow({ id: '2', name: 'Workflow 2' }),
-			]);
+			mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue(
+				workflowPage([
+					createWorkflow({ id: '1', name: 'Workflow 1' }),
+					createWorkflow({ id: '2', name: 'Workflow 2' }),
+				]),
+			);
 
 			const { getByTestId } = createComponent({ pinia });
 			await nextTick();
@@ -422,9 +466,9 @@ describe('SettingsMCPView', () => {
 		});
 
 		it('should not show Connect Workflows button when on OAuth tab', async () => {
-			mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue([
-				createWorkflow({ id: '1', name: 'Workflow 1' }),
-			]);
+			mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue(
+				workflowPage([createWorkflow({ id: '1', name: 'Workflow 1' })]),
+			);
 			mcpStore.getAllOAuthClients.mockResolvedValue([]);
 
 			const { queryByTestId, getByTestId, container } = createComponent({ pinia });
@@ -444,9 +488,9 @@ describe('SettingsMCPView', () => {
 		});
 
 		it('should open Connect Workflows modal when button is clicked', async () => {
-			mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue([
-				createWorkflow({ id: '1', name: 'Workflow 1' }),
-			]);
+			mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue(
+				workflowPage([createWorkflow({ id: '1', name: 'Workflow 1' })]),
+			);
 
 			const { getByTestId } = createComponent({ pinia });
 			await nextTick();
@@ -477,7 +521,7 @@ describe('SettingsMCPView', () => {
 					mcpManagedByEnv: false,
 				},
 			};
-			mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue([]);
+			mcpStore.fetchWorkflowsAvailableForMCP.mockResolvedValue(workflowPage());
 			mcpStore.getInstanceClientStats.mockResolvedValue(null);
 		});
 

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/SettingsMCPView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/SettingsMCPView.test.ts
@@ -59,7 +59,7 @@ const createComponent = createComponentRenderer(SettingsMCPView, {
 			WorkflowsTable: {
 				inheritAttrs: true,
 				template:
-					'<div><button data-test-id="workflows-table-page-2" @click="$emit(\'update:options\', { page: 1, itemsPerPage: 10, sortBy: [] })">Page 2</button>Workflows Table</div>',
+					'<div><button data-test-id="workflows-table-page-2" @click="$emit(\'update:options\', { page: 1, itemsPerPage: 10, sortBy: [] })">Page 2</button><button data-test-id="workflows-table-page-size-50" @click="$emit(\'update:options\', { page: 3, itemsPerPage: 50, sortBy: [] })">Page size 50</button>Workflows Table</div>',
 			},
 			OAuthClientsTable: {
 				inheritAttrs: true,
@@ -424,6 +424,21 @@ describe('SettingsMCPView', () => {
 
 			await waitFor(() => {
 				expect(mcpStore.fetchWorkflowsAvailableForMCP).toHaveBeenCalledWith(2, 10);
+			});
+		});
+
+		it('should reset to first page when workflow table page size changes', async () => {
+			const { getByTestId } = createComponent({ pinia });
+
+			await waitFor(() => {
+				expect(mcpStore.fetchWorkflowsAvailableForMCP).toHaveBeenCalledWith(1, 10);
+			});
+			mcpStore.fetchWorkflowsAvailableForMCP.mockClear();
+
+			await userEvent.click(getByTestId('workflows-table-page-size-50'));
+
+			await waitFor(() => {
+				expect(mcpStore.fetchWorkflowsAvailableForMCP).toHaveBeenCalledWith(1, 50);
 			});
 		});
 	});

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/SettingsMCPView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/SettingsMCPView.vue
@@ -67,6 +67,7 @@ const workflowsTableState = ref<TableOptions>({
 	itemsPerPage: 10,
 	sortBy: [],
 });
+const workflowsTableItemsPerPage = ref(workflowsTableState.value.itemsPerPage);
 
 const oAuthClientsLoading = ref(false);
 const connectedOAuthClients = ref<OAuthClientResponseDto[]>([]);
@@ -202,7 +203,9 @@ const onRefreshWorkflows = async () => {
 };
 
 const onWorkflowsTableUpdate = async (options: TableOptions) => {
-	workflowsTableState.value = options;
+	const pageSizeChanged = options.itemsPerPage !== workflowsTableItemsPerPage.value;
+	workflowsTableState.value = { ...options, page: pageSizeChanged ? 0 : options.page };
+	workflowsTableItemsPerPage.value = options.itemsPerPage;
 	await fetchAvailableWorkflows();
 };
 

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/SettingsMCPView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/SettingsMCPView.vue
@@ -31,6 +31,7 @@ import { useMcp } from '@/features/ai/mcpAccess/composables/useMcp';
 import type { OAuthClientResponseDto } from '@n8n/api-types';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { WORKFLOW_DESCRIPTION_MODAL_KEY } from '@/app/constants';
+import type { TableOptions } from '@n8n/design-system/components/N8nDataTableServer';
 
 type MCPTabs = 'workflows' | 'oauth';
 
@@ -60,6 +61,12 @@ const tabs = ref<Array<TabOptions<MCPTabs>>>([
 
 const workflowsLoading = ref(false);
 const availableWorkflows = ref<WorkflowListItem[]>([]);
+const availableWorkflowsTotal = ref(0);
+const workflowsTableState = ref<TableOptions>({
+	page: 0,
+	itemsPerPage: 10,
+	sortBy: [],
+});
 
 const oAuthClientsLoading = ref(false);
 const connectedOAuthClients = ref<OAuthClientResponseDto[]>([]);
@@ -84,7 +91,7 @@ const instanceCapacityNoticeContent = computed(() => {
 });
 
 const showConnectWorkflowsButton = computed(() => {
-	return selectedTab.value === 'workflows' && availableWorkflows.value.length > 0;
+	return selectedTab.value === 'workflows' && availableWorkflowsTotal.value > 0;
 });
 
 const onTabSelected = async (tab: MCPTabs) => {
@@ -120,9 +127,10 @@ const onToggleWorkflowMCPAccess = async (workflowId: string, isEnabled: boolean)
 	try {
 		await mcpStore.toggleWorkflowMcpAccess(workflowId, isEnabled);
 		if (isEnabled) {
+			workflowsTableState.value = { ...workflowsTableState.value, page: 0 };
 			await fetchAvailableWorkflows();
 		} else {
-			availableWorkflows.value = availableWorkflows.value.filter((w) => w.id !== workflowId);
+			await fetchAvailableWorkflows();
 		}
 	} catch (error) {
 		toast.showError(error, i18n.baseText('workflowSettings.toggleMCP.error.title'));
@@ -160,8 +168,26 @@ const onTableRefresh = async () => {
 const fetchAvailableWorkflows = async () => {
 	workflowsLoading.value = true;
 	try {
-		const workflows = await mcpStore.fetchWorkflowsAvailableForMCP(1, 200);
-		availableWorkflows.value = workflows;
+		const response = await mcpStore.fetchWorkflowsAvailableForMCP(
+			workflowsTableState.value.page + 1,
+			workflowsTableState.value.itemsPerPage,
+		);
+		if (response.data.length === 0 && response.count > 0 && workflowsTableState.value.page > 0) {
+			const maxPage = Math.max(
+				0,
+				Math.ceil(response.count / workflowsTableState.value.itemsPerPage) - 1,
+			);
+			workflowsTableState.value = { ...workflowsTableState.value, page: maxPage };
+			const clampedResponse = await mcpStore.fetchWorkflowsAvailableForMCP(
+				workflowsTableState.value.page + 1,
+				workflowsTableState.value.itemsPerPage,
+			);
+			availableWorkflows.value = clampedResponse.data;
+			availableWorkflowsTotal.value = clampedResponse.count;
+			return;
+		}
+		availableWorkflows.value = response.data;
+		availableWorkflowsTotal.value = response.count;
 	} catch (error) {
 		toast.showError(error, i18n.baseText('workflows.list.error.fetching'));
 	} finally {
@@ -172,6 +198,11 @@ const fetchAvailableWorkflows = async () => {
 };
 
 const onRefreshWorkflows = async () => {
+	await fetchAvailableWorkflows();
+};
+
+const onWorkflowsTableUpdate = async (options: TableOptions) => {
+	workflowsTableState.value = options;
 	await fetchAvailableWorkflows();
 };
 
@@ -306,12 +337,15 @@ onMounted(async () => {
 			<main>
 				<WorkflowsTable
 					v-if="selectedTab === 'workflows'"
+					v-model:table-options="workflowsTableState"
 					:data-test-id="'mcp-workflow-table'"
 					:workflows="availableWorkflows"
+					:total-count="availableWorkflowsTotal"
 					:loading="workflowsLoading"
 					@remove-mcp-access="(workflow) => onToggleWorkflowMCPAccess(workflow.id, false)"
 					@connect-workflows="openConnectWorkflowsModal"
 					@update-description="onUpdateDescription"
+					@update:options="onWorkflowsTableUpdate"
 					@refresh="onRefreshWorkflows"
 				/>
 				<OAuthClientsTable

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/components/tabs/WorkflowsTable.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/components/tabs/WorkflowsTable.test.ts
@@ -1,4 +1,4 @@
-import { within } from '@testing-library/vue';
+import { waitFor, within } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
 import { createComponentRenderer } from '@/__tests__/render';
 import WorkflowsTable from '@/features/ai/mcpAccess/components/tabs/WorkflowsTable.vue';
@@ -60,6 +60,44 @@ describe('WorkflowsTable', () => {
 
 			expect(container.querySelector('.n8n-loading')).toBeInTheDocument();
 			expect(queryByTestId('mcp-workflow-table')).not.toBeInTheDocument();
+		});
+	});
+
+	describe('Pagination', () => {
+		const createWorkflows = (count: number) =>
+			Array.from({ length: count }, (_, index) =>
+				createWorkflow({ id: `workflow-${index + 1}`, name: `Workflow ${index + 1}` }),
+			);
+
+		it('should render pagination when total count exceeds page size', () => {
+			const { getByTestId } = createComponent({
+				props: {
+					workflows: createWorkflows(10),
+					totalCount: 11,
+					loading: false,
+				},
+			});
+
+			expect(getByTestId('pagination')).toBeVisible();
+		});
+
+		it('should emit table options when page changes', async () => {
+			const { getByTestId, emitted } = createComponent({
+				props: {
+					workflows: createWorkflows(10),
+					totalCount: 20,
+					loading: false,
+				},
+			});
+
+			await userEvent.click(within(getByTestId('pagination')).getByLabelText('page 2'));
+
+			await waitFor(() => {
+				expect(emitted('update:options')).toBeTruthy();
+			});
+			expect(emitted('update:options').at(-1)).toEqual([
+				expect.objectContaining({ page: 1, itemsPerPage: 10 }),
+			]);
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/components/tabs/WorkflowsTable.vue
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/components/tabs/WorkflowsTable.vue
@@ -264,6 +264,12 @@ const onConnectClick = () => {
 }
 
 .workflow-table {
+	margin-bottom: var(--spacing--sm);
+
+	:global(.table-scroll) {
+		overflow-y: hidden;
+	}
+
 	tr:last-child {
 		border-bottom: none !important;
 	}

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/components/tabs/WorkflowsTable.vue
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/components/tabs/WorkflowsTable.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import { useI18n } from '@n8n/i18n';
 import type { WorkflowListItem, UserAction } from '@/Interface';
-import { type TableHeader } from '@n8n/design-system/components/N8nDataTableServer';
+import type { TableHeader, TableOptions } from '@n8n/design-system/components/N8nDataTableServer';
 import {
 	N8nActionToggle,
 	N8nButton,
@@ -21,18 +21,51 @@ import { getResourcePermissions } from '@n8n/permissions';
 
 type Props = {
 	workflows: WorkflowListItem[];
+	totalCount?: number;
 	loading: boolean;
 };
 
 const props = defineProps<Props>();
 
+const tableOptions = defineModel<TableOptions>('tableOptions', {
+	default: () => ({
+		page: 0,
+		itemsPerPage: 10,
+		sortBy: [],
+	}),
+});
+
+const tablePage = computed({
+	get: () => tableOptions.value.page,
+	set: (page: number) => {
+		tableOptions.value = { ...tableOptions.value, page };
+	},
+});
+
+const tableItemsPerPage = computed({
+	get: () => tableOptions.value.itemsPerPage,
+	set: (itemsPerPage: number) => {
+		tableOptions.value = { ...tableOptions.value, itemsPerPage };
+	},
+});
+
+const tableSortBy = computed({
+	get: () => tableOptions.value.sortBy,
+	set: (sortBy: TableOptions['sortBy']) => {
+		tableOptions.value = { ...tableOptions.value, sortBy };
+	},
+});
+
 const emit = defineEmits<{
 	removeMcpAccess: [workflow: WorkflowListItem];
 	connectWorkflows: [];
 	updateDescription: [workflow: WorkflowListItem];
+	'update:options': [payload: TableOptions];
 }>();
 
 const i18n = useI18n();
+
+const itemsLength = computed(() => props.totalCount ?? props.workflows.length);
 
 const tableHeaders = ref<Array<TableHeader<WorkflowListItem>>>([
 	{
@@ -110,20 +143,25 @@ const onConnectClick = () => {
 </script>
 
 <template>
-	<div :class="$style['workflow-table-container']">
+	<div>
 		<div v-if="props.loading">
 			<N8nLoading :loading="props.loading" variant="h1" class="mb-l" />
 			<N8nLoading :loading="props.loading" variant="p" :rows="5" :shrink-last="false" />
 		</div>
 		<div v-else class="mt-s mb-xl">
 			<N8nDataTableServer
+				v-model:sort-by="tableSortBy"
+				v-model:page="tablePage"
+				v-model:items-per-page="tableItemsPerPage"
 				:class="$style['workflow-table']"
 				data-test-id="mcp-workflow-table"
 				:headers="tableHeaders"
 				:items="props.workflows"
-				:items-length="props.workflows.length"
+				:items-length="itemsLength"
+				:page-sizes="[10, 25, 50]"
+				@update:options="emit('update:options', $event)"
 			>
-				<template v-if="props.workflows.length === 0" #cover>
+				<template v-if="itemsLength === 0" #cover>
 					<div :class="$style['empty-state']">
 						<N8nText data-test-id="mcp-workflow-table-empty-state" size="large" color="text-base">
 							{{ i18n.baseText('settings.mcp.workflows.table.empty.title') }}
@@ -219,12 +257,6 @@ const onConnectClick = () => {
 </template>
 
 <style module lang="scss">
-.workflow-table-container {
-	:global(.table-pagination) {
-		display: none;
-	}
-}
-
 .header {
 	display: flex;
 	justify-content: space-between;

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/mcp.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/mcp.store.test.ts
@@ -4,6 +4,7 @@ import { setActivePinia, createPinia } from 'pinia';
 import * as mcpApi from './mcp.api';
 import { useMCPStore } from './mcp.store';
 import { useWorkflowsListStore } from '@/app/stores/workflowsList.store';
+import { createWorkflow } from './mcp.test.utils';
 
 const { mockWorkflowDocumentStore } = vi.hoisted(() => ({
 	mockWorkflowDocumentStore: {
@@ -35,6 +36,32 @@ describe('mcp.store', () => {
 		setActivePinia(createPinia());
 		store = useMCPStore();
 		workflowsListStore = useWorkflowsListStore();
+	});
+
+	describe('fetchWorkflowsAvailableForMCP', () => {
+		it('returns paginated workflows and total count', async () => {
+			const workflow = createWorkflow({ id: 'wf-1' });
+			const fetchSpy = vi
+				.spyOn(workflowsListStore, 'fetchWorkflowsPageWithCount')
+				.mockResolvedValue({
+					data: [workflow],
+					count: 11,
+				});
+
+			await expect(store.fetchWorkflowsAvailableForMCP(2, 25)).resolves.toEqual({
+				data: [workflow],
+				count: 11,
+			});
+			expect(fetchSpy).toHaveBeenCalledWith(
+				undefined,
+				2,
+				25,
+				'updatedAt:desc',
+				{ isArchived: false, availableInMCP: true },
+				false,
+				false,
+			);
+		});
 	});
 
 	describe('toggleWorkflowMcpAccess', () => {

--- a/packages/frontend/editor-ui/src/features/ai/mcpAccess/mcp.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/mcpAccess/mcp.store.ts
@@ -46,17 +46,17 @@ export const useMCPStore = defineStore(MCP_STORE, () => {
 	async function fetchWorkflowsAvailableForMCP(
 		page = 1,
 		pageSize = 50,
-	): Promise<WorkflowListItem[]> {
-		const workflows = await workflowsListStore.fetchWorkflowsPage(
+	): Promise<{ data: WorkflowListItem[]; count: number }> {
+		const { data, count } = await workflowsListStore.fetchWorkflowsPageWithCount(
 			undefined, // projectId
 			page,
 			pageSize,
 			'updatedAt:desc',
 			{ isArchived: false, availableInMCP: true },
 			false, // includeFolders
-			false, // includeAllVersions
+			false, // onlySharedWithMe
 		);
-		return workflows.filter(isWorkflowListItem);
+		return { data: data.filter(isWorkflowListItem), count };
 	}
 
 	async function setMcpAccessEnabled(enabled: boolean): Promise<boolean> {


### PR DESCRIPTION
## Summary
Workflows table in the MCP settings page was lacking pagination. More importantly, since the request was capped at 200, this made workflows pass that to be unaccessible.

**BEFORE**:
<img width="358" height="846" alt="image" src="https://github.com/user-attachments/assets/666e7d41-2dc7-4a87-9939-563b14201f5a" />


**AFTER**:
<img width="1107" height="760" alt="image" src="https://github.com/user-attachments/assets/eb6bc5a2-89b6-41e4-b124-ef6ace3a0a57" />


## How to test
1. Run n8n from this branch
2. Check the table in `/settings/mcp`

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
