### PR TITLE
fix(ai-builder): Get the agent-with-notion-mcp eval case running (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/data/workflows/agent-with-notion-mcp.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/agent-with-notion-mcp.json
@@ -1,8 +1,13 @@
 {
-	"prompt": "Build a workflow with a chat-triggered AI agent that can search my Notion workspace to answer questions about ongoing projects. The agent should use the Notion connection from n8n's built-in service connections (the one optimized for agent tool use), not the standard Notion action node. Configure all nodes as completely as possible and don't ask me for credentials, I'll set them up later.",
+	"conversation": [
+		{
+			"role": "user",
+			"text": "Build a workflow with a chat-triggered AI agent that can search my Notion workspace to answer questions about ongoing projects. The agent should use the Notion connection from n8n's built-in service connections (the one optimized for agent tool use), not the standard Notion action node. Configure all nodes as completely as possible and don't ask me for credentials, I'll set them up later."
+		}
+	],
 	"complexity": "medium",
 	"tags": ["build", "agent", "ai-tool", "mcp-registry", "notion"],
-	"scenarios": [
+	"executionScenarios": [
 		{
 			"name": "happy-path",
 			"description": "User asks about a project; agent uses the Notion MCP registry node to find the answer",

--- a/packages/cli/src/modules/instance-ai/eval/workflow-analysis.ts
+++ b/packages/cli/src/modules/instance-ai/eval/workflow-analysis.ts
@@ -69,6 +69,11 @@ function isVendorLlmSubNode(nodeType: string): boolean {
 	return nodeType.startsWith('@n8n/n8n-nodes-langchain.lm');
 }
 
+/** MCP registry nodes talk via the MCP SDK's own transport, not n8n's HTTP helper — the mock can't reach them, so their root must stay pinned. */
+function isMcpRegistryNode(nodeType: string): boolean {
+	return nodeType.startsWith('@n8n/mcp-registry.');
+}
+
 /** Non-empty `options.baseURL` on the LangChain OpenAI node beats credentials.url — credential rewrite isn't enough. */
 function hasUnsafeBaseUrlOverride(node: INode): boolean {
 	if (node.type === '@n8n/n8n-nodes-langchain.lmChatOpenAi') {
@@ -495,6 +500,7 @@ function categorizeSubNodeIncompatibility(
 	sharedSupportedSubNodes: Set<string>,
 ): AutoPinReason | null {
 	if (PROTOCOL_BINARY_SUB_NODE_TYPES.has(sourceNode.type)) return 'protocol_binary';
+	if (isMcpRegistryNode(sourceNode.type)) return 'protocol_binary';
 	if (SUPPORTED_VENDOR_LLM_SUB_NODE_TYPES.has(sourceNode.type)) {
 		if (sharedSupportedSubNodes.has(sourceNode.name)) return 'shared_vendor_llm_subnode';
 		return hasUnsafeBaseUrlOverride(sourceNode) ? 'unsafe_baseurl_override' : null;


### PR DESCRIPTION
## Summary

Gets the `agent-with-notion-mcp` eval case actually running again. Two parts:

1. **Schema conversion** — the case (added in #30774) used the legacy `prompt` / `scenarios` shape. The loader validates every file in `data/workflows/` up-front and throws on the first invalid one, so this single file aborted **every** Instance AI eval run (any `--tier` / `--filter`). Converted to `conversation` / `executionScenarios`, content preserved verbatim.

2. **Pin MCP-registry-rooted agents in mock execution** — MCP registry nodes (`@n8n/mcp-registry.*`) connect through the MCP SDK's own transport, not n8n's HTTP request helper, so the eval mock layer can't intercept them. They're now classified as protocol-binary, so their root agent stays **pinned** (LLM-generated output) instead of running for real. Without this, the agent executed and the MCP tool threw `No MCP OAuth2 credential type found` (it needs an attached OAuth2 credential) before any mockable call. This mirrors how DB-backed memory and vector-store sub-nodes are already handled.

## How to test

`pnpm --filter @n8n/instance-ai eval:instance-ai --filter agent-with-notion-mcp` — the corpus now loads and the case **passes** (verified locally: builds chat-trigger → Agent → Notion MCP-registry node wired as `ai_tool`; agent pinned; scenario PASS). Full execution also relies on the `threadId` uuid fix in #31787.

## Related

Follow-up to #30774.

cc @BerniWittmann — heads up on the gotcha: the eval loader is fail-fast across the whole corpus, so one mis-shaped test-case file takes the entire suite down with it.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!-- repairs + exercises an existing eval test case -->

