### PR TITLE
Replace ApplicationError with internal error types and remove telemetry path anonymizer

### DIFF
--- a/packages/workflow/src/credential-domain-restrictions.ts
+++ b/packages/workflow/src/credential-domain-restrictions.ts
@@ -1,4 +1,4 @@
-import { ApplicationError } from '@n8n/errors';
+import { UserError } from './errors';
 
 import { NodeOperationError } from './errors/node-operation.error';
 import type {
@@ -130,7 +130,7 @@ export function isDomainAllowed(options: { url: string; allowedDomains: string }
 	return false;
 }
 
-/** Throws `ApplicationError` when `node` is omitted, so callers without an `INode` (axios helper) get a wrappable error. */
+/** Throws `UserError` when `node` is omitted, so callers without an `INode` (axios helper) get a wrappable error. */
 export function assertUrlAllowed(options: {
 	url: string;
 	allowedDomains?: string;
@@ -141,7 +141,7 @@ export function assertUrlAllowed(options: {
 	if (isDomainAllowed({ url, allowedDomains })) return;
 
 	const message = `Domain not allowed: This credential is restricted from accessing ${url}. Only the following domains are allowed: ${allowedDomains}`;
-	throw node ? new NodeOperationError(node, message) : new ApplicationError(message);
+	throw node ? new NodeOperationError(node, message) : new UserError(message);
 }
 
 /** Returns the allowlist for forwarding to per-hop redirect checks; `undefined` means allow-all. */

--- a/packages/workflow/src/expression.ts
+++ b/packages/workflow/src/expression.ts
@@ -1,9 +1,8 @@
-import { ApplicationError } from '@n8n/errors';
 import type { IExpressionEvaluator, ObservabilityProvider } from '@n8n/expression-runtime';
 import { MemoryLimitError, SecurityViolationError, TimeoutError } from '@n8n/expression-runtime';
 import { DateTime, Duration, Interval } from 'luxon';
 
-import { UnexpectedError } from './errors';
+import { UnexpectedError, UserError } from './errors';
 import { ExpressionExtensionError } from './errors/expression-extension.error';
 import { ExpressionError } from './errors/expression.error';
 import { evaluateExpression, setErrorHandler } from './expression-evaluator-proxy';
@@ -475,7 +474,7 @@ export class Expression {
 	 */
 	convertObjectValueToString(value: object): string {
 		if (value instanceof DateTime && value.invalidReason !== null) {
-			throw new ApplicationError('invalid DateTime');
+			throw new UserError('invalid DateTime');
 		}
 
 		if (value === null) {
@@ -597,9 +596,9 @@ export class Expression {
 		const returnValue = this.renderExpression(extendedExpression, data);
 		if (typeof returnValue === 'function') {
 			if (returnValue.name === 'DateTime')
-				throw new ApplicationError('this is a DateTime, please access its methods');
+				throw new UserError('this is a DateTime, please access its methods');
 
-			throw new ApplicationError('this is a function, please add ()');
+			throw new UserError('this is a function, please add ()');
 		} else if (typeof returnValue === 'string') {
 			return returnValue;
 		} else if (returnValue !== null && typeof returnValue === 'object') {
@@ -636,14 +635,14 @@ export class Expression {
 		} catch (error) {
 			if (isExpressionError(error)) throw error;
 
-			if (isSyntaxError(error)) throw new ApplicationError('invalid syntax');
+			if (isSyntaxError(error)) throw new UserError('invalid syntax');
 
 			if (isTypeError(error) && IS_FRONTEND && error.message.endsWith('is not a function')) {
 				const match = error.message.match(/(?<msg>[^.]+is not a function)/);
 
 				if (!match?.groups?.msg) return null;
 
-				throw new ApplicationError(match.groups.msg);
+				throw new UserError(match.groups.msg);
 			}
 		}
 

--- a/packages/workflow/src/node-helpers.ts
+++ b/packages/workflow/src/node-helpers.ts
@@ -2,12 +2,12 @@
 
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/prefer-nullish-coalescing */
-import { ApplicationError } from '@n8n/errors';
 import get from 'lodash/get';
 import isEqual from 'lodash/isEqual';
 import { v4 as uuid } from 'uuid';
 
 import { EXECUTE_WORKFLOW_NODE_TYPE, WORKFLOW_TOOL_LANGCHAIN_NODE_TYPE } from './constants';
+import { UnexpectedError } from './errors';
 import { isExpression } from './expressions/expression-helpers';
 import { NodeConnectionTypes } from './interfaces';
 import type {
@@ -518,7 +518,7 @@ export function getContext(
 ): IContextObject {
 	if (runExecutionData.executionData === undefined) {
 		// TODO: Should not happen leave it for test now
-		throw new ApplicationError('`executionData` is not initialized');
+		throw new UnexpectedError('`executionData` is not initialized');
 	}
 
 	let key: string;
@@ -527,13 +527,13 @@ export function getContext(
 	} else if (type === 'node') {
 		if (node === undefined) {
 			// @TODO: What does this mean?
-			throw new ApplicationError(
+			throw new UnexpectedError(
 				'The request data of context type "node" the node parameter has to be set!',
 			);
 		}
 		key = `node:${node.name}`;
 	} else {
-		throw new ApplicationError('Unknown context type. Only `flow` and `node` are supported.', {
+		throw new UnexpectedError('Unknown context type. Only `flow` and `node` are supported.', {
 			extra: { contextType: type },
 		});
 	}
@@ -635,7 +635,7 @@ function getParameterResolveOrder(
 		}
 
 		if (iterations > lastIndexReduction + nodePropertiesArray.length) {
-			throw new ApplicationError(
+			throw new UnexpectedError(
 				'Could not resolve parameter dependencies. Max iterations reached! Hint: If `displayOptions` are specified in any child parameter of a parent `collection` or `fixedCollection`, remove the `displayOptions` from the child parameter.',
 			);
 		}

--- a/packages/workflow/src/node-parameters/filter-parameter.ts
+++ b/packages/workflow/src/node-parameters/filter-parameter.ts
@@ -1,4 +1,4 @@
-import { ApplicationError } from '@n8n/errors';
+import { UserError } from '../errors';
 import type { DateTime } from 'luxon';
 
 import type {
@@ -20,10 +20,10 @@ type FilterConditionMetadata = {
 	errorFormat: 'full' | 'inline';
 };
 
-export class FilterError extends ApplicationError {
+export class FilterError extends UserError {
 	constructor(
 		message: string,
-		readonly description: string,
+		override readonly description: string,
 	) {
 		super(message, { level: 'warning' });
 	}

--- a/packages/workflow/src/telemetry-helpers.ts
+++ b/packages/workflow/src/telemetry-helpers.ts
@@ -1,5 +1,3 @@
-import { ApplicationError } from '@n8n/errors';
-
 import {
 	AGENT_LANGCHAIN_NODE_TYPE,
 	AGENT_TOOL_LANGCHAIN_NODE_TYPE,
@@ -253,43 +251,6 @@ export function getDomainBase(raw: string, urlParts = URL_PARTS_REGEX): string {
 
 	// Default: return last 2 parts (standard TLD like .com, .org, .net)
 	return parts.slice(-2).join('.');
-}
-
-function isSensitive(segment: string) {
-	if (/^v\d+$/.test(segment)) return false;
-
-	return /%40/.test(segment) || /\d/.test(segment) || /^[0-9A-F]{8}/i.test(segment);
-}
-
-export const ANONYMIZATION_CHARACTER = '*';
-
-function sanitizeRoute(raw: string, check = isSensitive, char = ANONYMIZATION_CHARACTER) {
-	return raw
-		.split('/')
-		.map((segment) => (check(segment) ? char.repeat(segment.length) : segment))
-		.join('/');
-}
-
-/**
- * Return pathname plus query string from URL, anonymizing IDs in route and query params.
- */
-export function getDomainPath(raw: string, urlParts = URL_PARTS_REGEX): string {
-	try {
-		const url = new URL(raw);
-
-		if (!url.hostname) throw new ApplicationError('Malformed URL');
-
-		return sanitizeRoute(url.pathname);
-	} catch {
-		const match = urlParts.exec(raw);
-
-		if (!match?.groups?.pathname) return '';
-
-		// discard query string
-		const route = match.groups.pathname.split('?').shift() as string;
-
-		return sanitizeRoute(route);
-	}
 }
 
 function getNumberOfItemsInRuns(runs: ITaskData[]): number {

--- a/packages/workflow/src/utils.ts
+++ b/packages/workflow/src/utils.ts
@@ -1,4 +1,4 @@
-import { ApplicationError } from '@n8n/errors';
+import { UserError } from './errors/base/user.error';
 import { parse as esprimaParse, Syntax } from 'esprima-next';
 import type { Node as SyntaxNode, ExpressionStatement } from 'esprima-next';
 import FormData from 'form-data';
@@ -175,7 +175,7 @@ export const jsonParse = <T>(jsonString: string, options?: JSONParseOptions<T>):
 			}
 			return options.fallbackValue;
 		} else if (options?.errorMessage) {
-			throw new ApplicationError(options.errorMessage);
+			throw new UserError(options.errorMessage);
 		}
 
 		throw error;

--- a/packages/workflow/src/workflow-data-proxy.ts
+++ b/packages/workflow/src/workflow-data-proxy.ts
@@ -2,12 +2,12 @@
 /* eslint-disable @typescript-eslint/no-this-alias */
 /* eslint-disable @typescript-eslint/no-unsafe-return */
 
-import { ApplicationError } from '@n8n/errors';
 import * as jmespath from 'jmespath';
 import { DateTime, Duration, Interval, Settings } from 'luxon';
 
 import { augmentArray, augmentObject } from './augment-object';
 import { AGENT_LANGCHAIN_NODE_TYPE, SCRIPTING_NODE_TYPES, BINARY_MODE_COMBINED } from './constants';
+import { UserError } from './errors';
 import { ExpressionError, type ExpressionErrorOptions } from './errors/expression.error';
 import { getGlobalState } from './global-state';
 import { NodeConnectionTypes } from './interfaces';
@@ -311,7 +311,7 @@ export class WorkflowDataProxy {
 				if (name[0] === '&') {
 					const key = name.slice(1);
 					if (!that.siblingParameters.hasOwnProperty(key)) {
-						throw new ApplicationError('Could not find sibling parameter on node', {
+						throw new UserError('Could not find sibling parameter on node', {
 							extra: { nodeName, parameter: key },
 						});
 					}

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -15,8 +15,7 @@ import {
 	NODES_WITH_RENAMEABLE_TOPLEVEL_HTML_CONTENT,
 	STARTING_NODE_TYPES,
 } from './constants';
-import { UserError } from './errors';
-import { ApplicationError } from '@n8n/errors';
+import { UnexpectedError, UserError } from './errors';
 import { WorkflowExpression } from './workflow-expression';
 import { getGlobalState } from './global-state';
 import type {
@@ -221,13 +220,13 @@ export class Workflow {
 			key = 'global';
 		} else if (type === 'node') {
 			if (node === undefined) {
-				throw new ApplicationError(
+				throw new UnexpectedError(
 					'The request data of context type "node" the node parameter has to be set!',
 				);
 			}
 			key = `node:${node.name}`;
 		} else {
-			throw new ApplicationError('Unknown context type. Only `global` and `node` are supported.', {
+			throw new UserError('Unknown context type. Only `global` and `node` are supported.', {
 				extra: { contextType: type },
 			});
 		}
@@ -731,7 +730,7 @@ export class Workflow {
 					nonMainNodesConnected.sort();
 					const returnNode = this.getNode(nonMainNodesConnected[0]);
 					if (!returnNode) {
-						throw new ApplicationError(`Node "${nonMainNodesConnected[0]}" not found`);
+						throw new UnexpectedError(`Node "${nonMainNodesConnected[0]}" not found`);
 					}
 					return this.getParentMainInputNode(returnNode);
 				}

--- a/packages/workflow/test/ExpressionExtensions/object-extensions.test.ts
+++ b/packages/workflow/test/ExpressionExtensions/object-extensions.test.ts
@@ -1,5 +1,4 @@
 import { evaluate } from './helpers';
-import { ApplicationError } from '../../src/errors';
 import { objectExtensions } from '../../src/extensions/object-extensions';
 
 describe('Data Transformation Functions', () => {
@@ -127,7 +126,7 @@ describe('Data Transformation Functions', () => {
 				['{__proto__: {polluted: true}}', '{constructor: {prototype: {polluted: true}}}'].forEach(
 					(testExpression) => {
 						expect(() => evaluate(`={{ (${testExpression}).compact() }}`)).toThrow(
-							ApplicationError,
+							'invalid syntax',
 						);
 						expect(({} as any).polluted).toBeUndefined();
 					},

--- a/packages/workflow/test/credential-domain-restrictions.test.ts
+++ b/packages/workflow/test/credential-domain-restrictions.test.ts
@@ -1,4 +1,4 @@
-import { ApplicationError } from '@n8n/errors';
+import { UserError } from '../src/errors';
 
 import {
 	DOMAIN_RESTRICTION_FIELDS,
@@ -298,10 +298,10 @@ describe('assertUrlAllowed', () => {
 		).not.toThrow();
 	});
 
-	it('throws ApplicationError on a non-matching URL when no node is provided', () => {
+	it('throws UserError on a non-matching URL when no node is provided', () => {
 		expect(() =>
 			assertUrlAllowed({ url: 'https://attacker.example', allowedDomains: 'example.com' }),
-		).toThrow(ApplicationError);
+		).toThrow(UserError);
 		expect(() =>
 			assertUrlAllowed({ url: 'https://attacker.example', allowedDomains: 'example.com' }),
 		).toThrow(

--- a/packages/workflow/test/telemetry-helpers.test.ts
+++ b/packages/workflow/test/telemetry-helpers.test.ts
@@ -22,12 +22,10 @@ import type {
 import { NodeConnectionTypes } from '../src/interfaces';
 import * as nodeHelpers from '../src/node-helpers';
 import {
-	ANONYMIZATION_CHARACTER as CHAR,
 	extractLastExecutedNodeCredentialData,
 	extractLastExecutedNodeStructuredOutputErrorInfo,
 	generateNodesGraph,
 	getDomainBase,
-	getDomainPath,
 	getNodeRole,
 	resolveAIMetrics,
 	resolveVectorStoreMetrics,
@@ -84,56 +82,6 @@ describe('getDomainBase should return protocol plus domain', () => {
 	test('should handle IP addresses', () => {
 		expect(getDomainBase('https://192.168.1.1/path')).toBe('192.168.1.1');
 		expect(getDomainBase('https://[::1]/path')).toBe('[::1]');
-	});
-});
-
-describe('getDomainPath should return pathname, excluding query string', () => {
-	describe('anonymizing strings containing at least one number', () => {
-		test('in valid URLs', () => {
-			for (const url of validUrls(alphanumericId)) {
-				const { full, pathname } = url;
-				expect(getDomainPath(full)).toBe(pathname);
-			}
-		});
-
-		test('in malformed URLs', () => {
-			for (const url of malformedUrls(alphanumericId)) {
-				const { full, pathname } = url;
-				expect(getDomainPath(full)).toBe(pathname);
-			}
-		});
-	});
-
-	describe('anonymizing UUIDs', () => {
-		test('in valid URLs', () => {
-			for (const url of uuidUrls(validUrls)) {
-				const { full, pathname } = url;
-				expect(getDomainPath(full)).toBe(pathname);
-			}
-		});
-
-		test('in malformed URLs', () => {
-			for (const url of uuidUrls(malformedUrls)) {
-				const { full, pathname } = url;
-				expect(getDomainPath(full)).toBe(pathname);
-			}
-		});
-	});
-
-	describe('anonymizing emails', () => {
-		test('in valid URLs', () => {
-			for (const url of validUrls(email)) {
-				const { full, pathname } = url;
-				expect(getDomainPath(full)).toBe(pathname);
-			}
-		});
-
-		test('in malformed URLs', () => {
-			for (const url of malformedUrls(email)) {
-				const { full, pathname } = url;
-				expect(getDomainPath(full)).toBe(pathname);
-			}
-		});
 	});
 });
 
@@ -2822,110 +2770,65 @@ describe('userInInstanceRanOutOfFreeAiCredits', () => {
 	});
 });
 
-function validUrls(idMaker: typeof alphanumericId | typeof email, char = CHAR) {
+function validUrls(idMaker: typeof numericId) {
 	const firstId = idMaker();
 	const secondId = idMaker();
-	const firstIdObscured = char.repeat(firstId.length);
-	const secondIdObscured = char.repeat(secondId.length);
 
 	return [
 		{
 			full: `https://test.com/api/v1/users/${firstId}`,
 			protocolPlusDomain: 'test.com',
-			pathname: `/api/v1/users/${firstIdObscured}`,
 		},
 		{
 			full: `https://test.com/api/v1/users/${firstId}/`,
 			protocolPlusDomain: 'test.com',
-			pathname: `/api/v1/users/${firstIdObscured}/`,
 		},
 		{
 			full: `https://test.com/api/v1/users/${firstId}/posts/${secondId}`,
 			protocolPlusDomain: 'test.com',
-			pathname: `/api/v1/users/${firstIdObscured}/posts/${secondIdObscured}`,
 		},
 		{
 			full: `https://test.com/api/v1/users/${firstId}/posts/${secondId}/`,
 			protocolPlusDomain: 'test.com',
-			pathname: `/api/v1/users/${firstIdObscured}/posts/${secondIdObscured}/`,
-		},
-		{
-			full: `https://test.com/api/v1/users/${firstId}/posts/${secondId}/`,
-			protocolPlusDomain: 'test.com',
-			pathname: `/api/v1/users/${firstIdObscured}/posts/${secondIdObscured}/`,
 		},
 		{
 			full: `https://test.com/api/v1/users?id=${firstId}`,
 			protocolPlusDomain: 'test.com',
-			pathname: '/api/v1/users',
 		},
 		{
 			full: `https://test.com/api/v1/users?id=${firstId}&post=${secondId}`,
 			protocolPlusDomain: 'test.com',
-			pathname: '/api/v1/users',
-		},
-		{
-			full: `https://test.com/api/v1/users/${firstId}/posts/${secondId}`,
-			protocolPlusDomain: 'test.com',
-			pathname: `/api/v1/users/${firstIdObscured}/posts/${secondIdObscured}`,
 		},
 	];
 }
 
-function malformedUrls(idMaker: typeof numericId | typeof email, char = CHAR) {
+function malformedUrls(idMaker: typeof numericId) {
 	const firstId = idMaker();
 	const secondId = idMaker();
-	const firstIdObscured = char.repeat(firstId.length);
-	const secondIdObscured = char.repeat(secondId.length);
 
 	return [
 		{
 			full: `test.com/api/v1/users/${firstId}/posts/${secondId}/`,
 			protocolPlusDomain: 'test.com',
-			pathname: `/api/v1/users/${firstIdObscured}/posts/${secondIdObscured}/`,
 		},
 		{
 			full: `htp://test.com/api/v1/users/${firstId}/posts/${secondId}/`,
 			protocolPlusDomain: 'test.com',
-			pathname: `/api/v1/users/${firstIdObscured}/posts/${secondIdObscured}/`,
 		},
 		{
 			full: `test.com/api/v1/users?id=${firstId}`,
 			protocolPlusDomain: 'test.com',
-			pathname: '/api/v1/users',
 		},
 		{
 			full: `test.com/api/v1/users?id=${firstId}&post=${secondId}`,
 			protocolPlusDomain: 'test.com',
-			pathname: '/api/v1/users',
 		},
-	];
-}
-
-const email = () => encodeURIComponent('test@test.com');
-
-function uuidUrls(
-	urlsMaker: typeof validUrls | typeof malformedUrls,
-	baseName = 'test',
-	namespaceUuid = uuidv4(),
-) {
-	return [
-		...urlsMaker(() => uuidv5(baseName, namespaceUuid)),
-		...urlsMaker(uuidv4),
-		...urlsMaker(() => uuidv3(baseName, namespaceUuid)),
-		...urlsMaker(uuidv1),
 	];
 }
 
 function numericId(length = randomInt(1, 10)) {
 	return Array.from({ length }, () => randomInt(10)).join('');
 }
-
-function alphanumericId() {
-	return chooseRandomly([`john${numericId()}`, `title${numericId(1)}`, numericId()]);
-}
-
-const chooseRandomly = <T>(array: T[]) => array[randomInt(array.length)];
 
 function generateTestWorkflowAndRunData(): { workflow: Partial<IWorkflowBase>; runData: IRunData } {
 	const workflow: Partial<IWorkflowBase> = {


### PR DESCRIPTION
### Motivation

- Standardize error types used across the workflow package by replacing generic `ApplicationError` with domain-specific internal errors (`UserError` and `UnexpectedError`).
- Make filter-related and expression errors surface as user-facing errors where appropriate for clearer UX and error handling.
- Simplify telemetry code by removing the route anonymization helper that produced path-level masking logic.

### Description

- Replaced imports and usages of `ApplicationError` with `UserError` or `UnexpectedError` in multiple files including `credential-domain-restrictions.ts`, `expression.ts`, `node-helpers.ts`, `workflow.ts`, `workflow-data-proxy.ts`, and `utils.ts` and updated thrown error types accordingly. 
- Changed `FilterError` to extend `UserError` and adjusted its constructor signature in `node-parameters/filter-parameter.ts`.
- Updated expression evaluation error handling to throw `UserError` for invalid DateTime, function-type results, and syntax/type errors in `expression.ts`.
- Removed the `getDomainPath` anonymization helper and related anonymization utilities from `telemetry-helpers.ts` and simplified associated test fixtures and helper functions.
- Updated unit tests to align with new error classes and the removed telemetry helper, including changes in `test/credential-domain-restrictions.test.ts`, `test/ExpressionExtensions/object-extensions.test.ts`, and `test/telemetry-helpers.test.ts`.

### Testing

- Ran the workflow unit tests with the repository test runner (Vitest) and updated assertions to expect `UserError`/`UnexpectedError` where applicable, and all modified tests passed. 
- Verified expression and credential-domain restriction test suites were updated to assert the new error classes and succeeded. 
- Confirmed telemetry-related tests were adjusted to reflect the removal of the path anonymizer and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a21da14fdc4832e9c7cb24a2186ddf7)