### PR TITLE
feat(core): Add telemetry foundation for `mcp-apps` (no-changelog)

### DIFF
--- a/packages/@n8n/mcp-apps/src/server/apps/workflow-preview.test.ts
+++ b/packages/@n8n/mcp-apps/src/server/apps/workflow-preview.test.ts
@@ -100,6 +100,29 @@ describe('registerWorkflowPreviewApp', () => {
 		expect(csp?.connectDomains).toEqual([instanceOrigin]);
 	});
 
+	it('omits telemetry CSP domains when no instance origin is provided', async () => {
+		registerWorkflowPreviewApp(
+			{
+				resource: (
+					name: string,
+					uri: string,
+					metadata: Record<string, unknown>,
+					callback: ResourceCallback,
+				) => {
+					captured = { name, uri, metadata, callback };
+					return undefined as never;
+				},
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any,
+			{ telemetry },
+		);
+
+		const { _meta } = (await captured.callback()).contents[0];
+		const csp = _meta?.ui?.csp;
+		expect(csp?.resourceDomains).toEqual([]);
+		expect(csp?.connectDomains).toEqual([]);
+	});
+
 	it('injects the telemetry runtime config into the HTML', async () => {
 		const { text } = (await captured.callback()).contents[0];
 		expect(text).toContain(`window.${MCP_APP_TELEMETRY_GLOBAL}=`);

--- a/packages/@n8n/mcp-apps/src/server/apps/workflow-preview.test.ts
+++ b/packages/@n8n/mcp-apps/src/server/apps/workflow-preview.test.ts
@@ -3,15 +3,28 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { registerWorkflowPreviewApp } from './workflow-preview';
 import { RESOURCE_MIME_TYPE, WORKFLOW_PREVIEW_APP_URI } from '../constants';
 import { loadAppHtml } from '../resource-loader';
+import { MCP_APP_TELEMETRY_GLOBAL, type McpAppTelemetryConfig } from '../telemetry-config';
 
 vi.mock('../resource-loader', () => ({
-	// eslint-disable-next-line @typescript-eslint/require-await
-	loadAppHtml: vi.fn(async (fileName: string) => `<html data-file="${fileName}">stub</html>`),
+	loadAppHtml: vi.fn(
+		// eslint-disable-next-line @typescript-eslint/require-await
+		async (fileName: string) =>
+			`<!doctype html><html><head data-file="${fileName}"></head><body>stub</body></html>`,
+	),
 }));
 
-type ResourceCallback = () => Promise<{
-	contents: Array<{ uri: string; mimeType: string; text: string }>;
-}>;
+type ResourceContent = {
+	uri: string;
+	mimeType: string;
+	text: string;
+	_meta?: {
+		ui?: {
+			csp?: { resourceDomains?: string[]; connectDomains?: string[] };
+		};
+	};
+};
+
+type ResourceCallback = () => Promise<{ contents: ResourceContent[] }>;
 
 type CapturedResource = {
 	name: string;
@@ -20,23 +33,42 @@ type CapturedResource = {
 	callback: ResourceCallback;
 };
 
+const telemetry: McpAppTelemetryConfig = {
+	enabled: true,
+	writeKey: 'test-write-key',
+	dataPlaneUrl: 'https://n8n.example.com/rest/telemetry/proxy',
+	configUrl: 'https://n8n.example.com/rest/telemetry/rudderstack',
+	instanceId: 'instance-123',
+	versionCli: '1.2.3',
+};
+const instanceOrigin = 'https://n8n.example.com';
+
 describe('registerWorkflowPreviewApp', () => {
 	let captured: CapturedResource;
+	let onResourceRead: ReturnType<typeof vi.fn>;
 
 	beforeEach(() => {
 		captured = undefined as unknown as CapturedResource;
-		registerWorkflowPreviewApp({
-			resource: (
-				name: string,
-				uri: string,
-				metadata: Record<string, unknown>,
-				callback: ResourceCallback,
-			) => {
-				captured = { name, uri, metadata, callback };
-				return undefined as never;
+		onResourceRead = vi.fn();
+		registerWorkflowPreviewApp(
+			{
+				resource: (
+					name: string,
+					uri: string,
+					metadata: Record<string, unknown>,
+					callback: ResourceCallback,
+				) => {
+					captured = { name, uri, metadata, callback };
+					return undefined as never;
+				},
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			} as any,
+			{
+				instanceOrigin,
+				telemetry,
+				onResourceRead: onResourceRead as () => void,
 			},
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		} as any);
+		);
 	});
 
 	afterEach(() => {
@@ -59,5 +91,34 @@ describe('registerWorkflowPreviewApp', () => {
 		expect(content.mimeType).toBe(RESOURCE_MIME_TYPE);
 		expect(content.text).toContain('<html');
 		expect(loadAppHtml).toHaveBeenCalledWith('workflow-preview.html');
+	});
+
+	it('declares CSP for the RudderStack CDN and the instance origin', async () => {
+		const { _meta } = (await captured.callback()).contents[0];
+		const csp = _meta?.ui?.csp;
+		expect(csp?.resourceDomains).toEqual(['https://cdn-rs.n8n.io']);
+		expect(csp?.connectDomains).toEqual([instanceOrigin]);
+	});
+
+	it('injects the telemetry runtime config into the HTML', async () => {
+		const { text } = (await captured.callback()).contents[0];
+		expect(text).toContain(`window.${MCP_APP_TELEMETRY_GLOBAL}=`);
+		expect(text).toContain('"writeKey":"test-write-key"');
+		expect(text).toContain('"instanceId":"instance-123"');
+	});
+
+	it('invokes onResourceRead when the resource is served', async () => {
+		await captured.callback();
+		expect(onResourceRead).toHaveBeenCalledTimes(1);
+	});
+
+	it('still serves the app HTML when onResourceRead throws', async () => {
+		onResourceRead.mockImplementation(() => {
+			throw new Error('telemetry boom');
+		});
+
+		const result = await captured.callback();
+
+		expect(result.contents[0].text).toContain('<html');
 	});
 });

--- a/packages/@n8n/mcp-apps/src/server/apps/workflow-preview.ts
+++ b/packages/@n8n/mcp-apps/src/server/apps/workflow-preview.ts
@@ -2,8 +2,27 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 import { RESOURCE_MIME_TYPE, WORKFLOW_PREVIEW_APP_URI } from '../constants';
 import { loadAppHtml } from '../resource-loader';
+import {
+	injectTelemetryConfig,
+	RUDDERSTACK_CDN_ORIGIN,
+	type McpAppTelemetryConfig,
+} from '../telemetry-config';
 
-export function registerWorkflowPreviewApp(server: Pick<McpServer, 'resource'>): void {
+export interface RegisterWorkflowPreviewAppOptions {
+	/** Origin allowed for telemetry egress via CSP `connect-src`. */
+	instanceOrigin: string;
+	/** Front-end telemetry runtime config injected into the app HTML. */
+	telemetry: McpAppTelemetryConfig;
+	/** Called when the host reads the app HTML to render it. */
+	onResourceRead?: () => void;
+}
+
+export function registerWorkflowPreviewApp(
+	server: Pick<McpServer, 'resource'>,
+	options: RegisterWorkflowPreviewAppOptions,
+): void {
+	const { instanceOrigin, telemetry, onResourceRead } = options;
+
 	server.resource(
 		'workflow-preview',
 		WORKFLOW_PREVIEW_APP_URI,
@@ -11,14 +30,32 @@ export function registerWorkflowPreviewApp(server: Pick<McpServer, 'resource'>):
 			description: 'Loading UI shown after creating a workflow from code',
 			mimeType: RESOURCE_MIME_TYPE,
 		},
-		async () => ({
-			contents: [
-				{
-					uri: WORKFLOW_PREVIEW_APP_URI,
-					mimeType: RESOURCE_MIME_TYPE,
-					text: await loadAppHtml('workflow-preview.html'),
-				},
-			],
-		}),
+		async () => {
+			const html = await loadAppHtml('workflow-preview.html');
+
+			try {
+				onResourceRead?.();
+			} catch {
+				// Telemetry must never break serving the app resource.
+			}
+
+			return {
+				contents: [
+					{
+						uri: WORKFLOW_PREVIEW_APP_URI,
+						mimeType: RESOURCE_MIME_TYPE,
+						text: injectTelemetryConfig(html, telemetry),
+						_meta: {
+							ui: {
+								csp: {
+									resourceDomains: [RUDDERSTACK_CDN_ORIGIN],
+									connectDomains: [instanceOrigin],
+								},
+							},
+						},
+					},
+				],
+			};
+		},
 	);
 }

--- a/packages/@n8n/mcp-apps/src/server/apps/workflow-preview.ts
+++ b/packages/@n8n/mcp-apps/src/server/apps/workflow-preview.ts
@@ -10,7 +10,7 @@ import {
 
 export interface RegisterWorkflowPreviewAppOptions {
 	/** Origin allowed for telemetry egress via CSP `connect-src`. */
-	instanceOrigin: string;
+	instanceOrigin?: string;
 	/** Front-end telemetry runtime config injected into the app HTML. */
 	telemetry: McpAppTelemetryConfig;
 	/** Called when the host reads the app HTML to render it. */
@@ -22,6 +22,12 @@ export function registerWorkflowPreviewApp(
 	options: RegisterWorkflowPreviewAppOptions,
 ): void {
 	const { instanceOrigin, telemetry, onResourceRead } = options;
+	const telemetryCsp = instanceOrigin
+		? {
+				resourceDomains: [RUDDERSTACK_CDN_ORIGIN],
+				connectDomains: [instanceOrigin],
+			}
+		: { resourceDomains: [], connectDomains: [] };
 
 	server.resource(
 		'workflow-preview',
@@ -47,10 +53,7 @@ export function registerWorkflowPreviewApp(
 						text: injectTelemetryConfig(html, telemetry),
 						_meta: {
 							ui: {
-								csp: {
-									resourceDomains: [RUDDERSTACK_CDN_ORIGIN],
-									connectDomains: [instanceOrigin],
-								},
+								csp: telemetryCsp,
 							},
 						},
 					},

--- a/packages/@n8n/mcp-apps/src/server/index.ts
+++ b/packages/@n8n/mcp-apps/src/server/index.ts
@@ -4,4 +4,13 @@ export {
 	WORKFLOW_PREVIEW_APP_URI,
 } from './constants';
 export { registerMcpAppTool, type McpAppToolConfig } from './register-mcp-app-tool';
-export { registerWorkflowPreviewApp } from './apps/workflow-preview';
+export {
+	registerWorkflowPreviewApp,
+	type RegisterWorkflowPreviewAppOptions,
+} from './apps/workflow-preview';
+export {
+	injectTelemetryConfig,
+	MCP_APP_TELEMETRY_GLOBAL,
+	RUDDERSTACK_CDN_ORIGIN,
+	type McpAppTelemetryConfig,
+} from './telemetry-config';

--- a/packages/@n8n/mcp-apps/src/server/telemetry-config.test.ts
+++ b/packages/@n8n/mcp-apps/src/server/telemetry-config.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+	injectTelemetryConfig,
+	MCP_APP_TELEMETRY_GLOBAL,
+	type McpAppTelemetryConfig,
+} from './telemetry-config';
+
+const config: McpAppTelemetryConfig = {
+	enabled: true,
+	writeKey: 'wk',
+	dataPlaneUrl: 'https://n8n.example.com/rest/telemetry/proxy',
+	configUrl: 'https://n8n.example.com/rest/telemetry/rudderstack',
+	instanceId: 'inst',
+	versionCli: '1.0.0',
+};
+
+describe('injectTelemetryConfig', () => {
+	it('injects the config global right after <head>, before existing head content', () => {
+		const html = '<!doctype html><html><head><title>n8n</title></head><body></body></html>';
+		const out = injectTelemetryConfig(html, config);
+
+		expect(out).toContain(`<head><script>window.${MCP_APP_TELEMETRY_GLOBAL}=`);
+		expect(out).toContain('"instanceId":"inst"');
+		expect(out.indexOf(MCP_APP_TELEMETRY_GLOBAL)).toBeLessThan(out.indexOf('<title>'));
+	});
+
+	it('escapes "<" so values cannot break out of the script context', () => {
+		const out = injectTelemetryConfig('<head></head>', {
+			...config,
+			writeKey: '</script><script>alert(1)</script>',
+		});
+
+		expect(out).not.toContain('</script><script>alert(1)');
+		expect(out).toContain('\\u003c/script>');
+	});
+
+	it('falls back to prepending when there is no <head>', () => {
+		const out = injectTelemetryConfig('<body>no head</body>', config);
+		expect(out.startsWith(`<script>window.${MCP_APP_TELEMETRY_GLOBAL}=`)).toBe(true);
+	});
+});

--- a/packages/@n8n/mcp-apps/src/server/telemetry-config.test.ts
+++ b/packages/@n8n/mcp-apps/src/server/telemetry-config.test.ts
@@ -35,6 +35,16 @@ describe('injectTelemetryConfig', () => {
 		expect(out).toContain('\\u003c/script>');
 	});
 
+	it('escapes JavaScript line and paragraph separators in string values', () => {
+		const out = injectTelemetryConfig('<head></head>', {
+			...config,
+			instanceId: 'line\u2028paragraph\u2029separator',
+		});
+
+		expect(out).toContain('line\\u2028paragraph\\u2029separator');
+		expect(out).not.toContain('line\u2028paragraph\u2029separator');
+	});
+
 	it('falls back to prepending when there is no <head>', () => {
 		const out = injectTelemetryConfig('<body>no head</body>', config);
 		expect(out.startsWith(`<script>window.${MCP_APP_TELEMETRY_GLOBAL}=`)).toBe(true);

--- a/packages/@n8n/mcp-apps/src/server/telemetry-config.ts
+++ b/packages/@n8n/mcp-apps/src/server/telemetry-config.ts
@@ -11,7 +11,10 @@ export {
  * `<` is escaped in serialized JSON so values cannot break out of the script.
  */
 export function injectTelemetryConfig(html: string, config: McpAppTelemetryConfig): string {
-	const serialized = JSON.stringify(config).replace(/</g, '\\u003c');
+	const serialized = JSON.stringify(config)
+		.replace(/</g, '\\u003c')
+		.replace(/\u2028/g, '\\u2028')
+		.replace(/\u2029/g, '\\u2029');
 	const tag = `<script>window.${MCP_APP_TELEMETRY_GLOBAL}=${serialized};</script>`;
 
 	const headMatch = /<head[^>]*>/i.exec(html);

--- a/packages/@n8n/mcp-apps/src/server/telemetry-config.ts
+++ b/packages/@n8n/mcp-apps/src/server/telemetry-config.ts
@@ -1,0 +1,24 @@
+import { MCP_APP_TELEMETRY_GLOBAL, type McpAppTelemetryConfig } from '../telemetry-contract';
+
+export {
+	MCP_APP_TELEMETRY_GLOBAL,
+	RUDDERSTACK_CDN_ORIGIN,
+	type McpAppTelemetryConfig,
+} from '../telemetry-contract';
+
+/**
+ * Inject the telemetry runtime config into app HTML before the app bundle runs.
+ * `<` is escaped in serialized JSON so values cannot break out of the script.
+ */
+export function injectTelemetryConfig(html: string, config: McpAppTelemetryConfig): string {
+	const serialized = JSON.stringify(config).replace(/</g, '\\u003c');
+	const tag = `<script>window.${MCP_APP_TELEMETRY_GLOBAL}=${serialized};</script>`;
+
+	const headMatch = /<head[^>]*>/i.exec(html);
+	if (headMatch) {
+		const insertAt = headMatch.index + headMatch[0].length;
+		return `${html.slice(0, insertAt)}${tag}${html.slice(insertAt)}`;
+	}
+
+	return `${tag}${html}`;
+}

--- a/packages/@n8n/mcp-apps/src/telemetry-contract.ts
+++ b/packages/@n8n/mcp-apps/src/telemetry-contract.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared contract between the server-side config injector and MCP app UIs.
+ *
+ * Keeping these values in one neutral module ensures the injected global name,
+ * config shape, and CDN origin cannot drift between the server and browser
+ * builds.
+ */
+
+/** Global the MCP app UI reads its RudderStack runtime config from. */
+export const MCP_APP_TELEMETRY_GLOBAL = '__N8N_MCP_TELEMETRY__';
+
+/** Origin the RudderStack browser SDK script is loaded from. */
+export const RUDDERSTACK_CDN_ORIGIN = 'https://cdn-rs.n8n.io';
+
+/**
+ * Front-end telemetry runtime config injected into an MCP app's HTML.
+ *
+ * Intentionally instance-level only. User-level telemetry belongs in event
+ * payloads emitted by the app, not in the served HTML.
+ */
+export interface McpAppTelemetryConfig {
+	/** Whether diagnostics are enabled. When false the UI must not load RudderStack. */
+	enabled: boolean;
+	/** RudderStack write key. */
+	writeKey: string;
+	/** Data plane URL proxied through the n8n instance. */
+	dataPlaneUrl: string;
+	/** Source config URL proxied through the n8n instance. */
+	configUrl: string;
+	/** Instance ID, used for event enrichment. */
+	instanceId: string;
+	/** n8n version, used for event enrichment. */
+	versionCli: string;
+}

--- a/packages/@n8n/mcp-apps/tsconfig.build.json
+++ b/packages/@n8n/mcp-apps/tsconfig.build.json
@@ -9,6 +9,6 @@
 		"outDir": "dist",
 		"tsBuildInfoFile": "dist/build.tsbuildinfo"
 	},
-	"include": ["src/server/**/*.ts", "src/apps-manifest.ts"],
+	"include": ["src/server/**/*.ts", "src/apps-manifest.ts", "src/telemetry-contract.ts"],
 	"exclude": ["src/**/*.test.ts"]
 }

--- a/packages/cli/src/controllers/__tests__/telemetry.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/telemetry.controller.test.ts
@@ -1,0 +1,199 @@
+import type { GlobalConfig } from '@n8n/config';
+import type { AuthenticatedRequest } from '@n8n/db';
+import { ControllerRegistryMetadata } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+import type { NextFunction, Response } from 'express';
+import { mock } from 'jest-mock-extended';
+
+type ProxyResponse = { headers: Record<string, string> };
+type ProxyErrorResponse = {
+	headersSent?: boolean;
+	writeHead: jest.Mock;
+	end: jest.Mock;
+};
+type ProxyOptions = {
+	on?: {
+		proxyReq?: (proxyReq: { removeHeader: jest.Mock }, req: AuthenticatedRequest) => void;
+		proxyRes?: (proxyRes: ProxyResponse) => void;
+		error?: (error: Error, req: AuthenticatedRequest, res: ProxyErrorResponse) => void;
+	};
+};
+
+const mockProxy = jest.fn();
+const mockFixRequestBody = jest.fn();
+let mockProxyOptions: ProxyOptions | undefined;
+
+jest.mock('http-proxy-middleware', () => ({
+	createProxyMiddleware: jest.fn((options: ProxyOptions) => {
+		mockProxyOptions = options;
+		return mockProxy;
+	}),
+	fixRequestBody: mockFixRequestBody,
+}));
+
+import { TelemetryController } from '../telemetry.controller';
+
+const metadata = Container.get(ControllerRegistryMetadata).getControllerMetadata(
+	TelemetryController as never,
+);
+const routeCases = Array.from(metadata.routes.entries()).map(([handlerName, route]) => ({
+	handlerName,
+	route,
+}));
+
+function createController() {
+	return new TelemetryController(
+		mock<GlobalConfig>({
+			diagnostics: {
+				frontendConfig: 'test-key;https://telemetry.n8n.io',
+			},
+		}),
+	);
+}
+
+function createResponse() {
+	const res = {
+		setHeader: jest.fn(),
+		removeHeader: jest.fn(),
+		status: jest.fn(),
+		end: jest.fn(),
+		json: jest.fn(),
+	};
+	res.status.mockReturnValue(res);
+	return res as unknown as jest.Mocked<Response>;
+}
+
+function createRequest(headers: Record<string, string> = {}) {
+	return { headers } as AuthenticatedRequest;
+}
+
+function getProxyOptions() {
+	if (!mockProxyOptions) throw new Error('Proxy options were not captured');
+	return mockProxyOptions;
+}
+
+describe('TelemetryController route access', () => {
+	it.each(routeCases)('$handlerName is unauthenticated and ungated', ({ route }) => {
+		expect(route.skipAuth).toBe(true);
+		expect(route.accessScope).toBeUndefined();
+	});
+});
+
+describe('TelemetryController', () => {
+	const originalFetch = global.fetch;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockProxy.mockResolvedValue(undefined);
+		mockProxyOptions = undefined;
+	});
+
+	afterEach(() => {
+		global.fetch = originalFetch;
+	});
+
+	it('responds to proxy preflight requests with permissive reflected CORS headers', () => {
+		const controller = createController();
+		const req = createRequest({
+			'access-control-request-headers': 'content-type,authorization,anonymousid',
+		});
+		const res = createResponse();
+
+		controller.proxyPreflight(req, res);
+
+		expect(res.setHeader).toHaveBeenCalledWith('Access-Control-Allow-Origin', '*');
+		expect(res.setHeader).toHaveBeenCalledWith(
+			'Access-Control-Allow-Methods',
+			'GET, POST, OPTIONS',
+		);
+		expect(res.setHeader).toHaveBeenCalledWith(
+			'Access-Control-Allow-Headers',
+			'content-type,authorization,anonymousid',
+		);
+		expect(res.setHeader).toHaveBeenCalledWith('Access-Control-Max-Age', '600');
+		expect(res.removeHeader).toHaveBeenCalledWith('Access-Control-Allow-Credentials');
+		expect(res.status).toHaveBeenCalledWith(204);
+		expect(res.end).toHaveBeenCalled();
+	});
+
+	it('applies CORS before proxying track calls', async () => {
+		const controller = createController();
+		const req = createRequest();
+		const res = createResponse();
+		const next = jest.fn() as NextFunction;
+
+		await controller.track(req, res, next);
+
+		expect(res.setHeader).toHaveBeenCalledWith('Access-Control-Allow-Origin', '*');
+		expect(mockProxy).toHaveBeenCalledWith(req, res, next);
+	});
+
+	it('keeps proxy request body handling and strips cookies', () => {
+		createController();
+		const proxyReq = { removeHeader: jest.fn() };
+		const req = createRequest();
+
+		getProxyOptions().on?.proxyReq?.(proxyReq, req);
+
+		expect(proxyReq.removeHeader).toHaveBeenCalledWith('cookie');
+		expect(mockFixRequestBody).toHaveBeenCalledWith(proxyReq, req);
+	});
+
+	it('normalizes upstream CORS headers on proxied responses', () => {
+		createController();
+		const proxyRes: ProxyResponse = {
+			headers: {
+				'access-control-allow-origin': 'https://upstream.example.com',
+				'access-control-allow-credentials': 'true',
+				'access-control-allow-methods': 'POST',
+				'access-control-allow-headers': 'authorization',
+				'access-control-expose-headers': 'x-test',
+				'x-test': 'kept',
+			},
+		};
+
+		getProxyOptions().on?.proxyRes?.(proxyRes);
+
+		expect(proxyRes.headers).toEqual({
+			'access-control-allow-origin': '*',
+			'x-test': 'kept',
+		});
+	});
+
+	it('returns CORS on proxy errors', () => {
+		createController();
+		const req = createRequest();
+		const res: ProxyErrorResponse = {
+			headersSent: false,
+			writeHead: jest.fn(),
+			end: jest.fn(),
+		};
+
+		getProxyOptions().on?.error?.(new Error('upstream unavailable'), req, res);
+
+		expect(res.writeHead).toHaveBeenCalledWith(502, {
+			'Access-Control-Allow-Origin': '*',
+		});
+		expect(res.end).toHaveBeenCalledWith('Bad Gateway');
+	});
+
+	it('applies CORS while serving RudderStack source config', async () => {
+		const controller = createController();
+		const req = createRequest();
+		const res = createResponse();
+		global.fetch = jest.fn().mockResolvedValue({
+			ok: true,
+			json: jest.fn().mockResolvedValue({ source: 'config' }),
+		}) as unknown as typeof fetch;
+
+		await controller.sourceConfig(req, res);
+
+		expect(res.setHeader).toHaveBeenCalledWith('Access-Control-Allow-Origin', '*');
+		expect(global.fetch).toHaveBeenCalledWith('https://api-rs.n8n.io/sourceConfig', {
+			headers: {
+				authorization: `Basic ${btoa('test-key:')}`,
+			},
+		});
+		expect(res.json).toHaveBeenCalledWith({ source: 'config' });
+	});
+});

--- a/packages/cli/src/controllers/telemetry.controller.ts
+++ b/packages/cli/src/controllers/telemetry.controller.ts
@@ -1,6 +1,6 @@
 import { GlobalConfig } from '@n8n/config';
 import { AuthenticatedRequest } from '@n8n/db';
-import { Get, Post, RestController } from '@n8n/decorators';
+import { Get, Options, Post, RestController } from '@n8n/decorators';
 import { NextFunction, Response } from 'express';
 import { createProxyMiddleware, fixRequestBody } from 'http-proxy-middleware';
 
@@ -21,33 +21,105 @@ export class TelemetryController {
 					fixRequestBody(proxyReq, req);
 					return;
 				},
+				proxyRes: (proxyRes) => {
+					// MCP app UIs call this cross-origin from sandboxed iframes. Upstream
+					// may set CORS headers too, so normalize to one permissive value.
+					for (const header of [
+						'access-control-allow-origin',
+						'access-control-allow-credentials',
+						'access-control-allow-methods',
+						'access-control-allow-headers',
+						'access-control-expose-headers',
+					]) {
+						delete proxyRes.headers[header];
+					}
+					proxyRes.headers['access-control-allow-origin'] = '*';
+				},
+				error: (_error, _req, res) => {
+					if ('writeHead' in res && !res.headersSent) {
+						res.writeHead(502, { 'Access-Control-Allow-Origin': '*' });
+						res.end('Bad Gateway');
+					}
+				},
 			},
 		});
 	}
 
+	private applyCors(req: AuthenticatedRequest, res: Response) {
+		res.setHeader('Access-Control-Allow-Origin', '*');
+		res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+
+		const requestedHeaders = req.headers['access-control-request-headers'];
+		res.setHeader(
+			'Access-Control-Allow-Headers',
+			typeof requestedHeaders === 'string' && requestedHeaders.length > 0
+				? requestedHeaders
+				: 'Content-Type, Authorization, anonymousId',
+		);
+		res.setHeader('Access-Control-Max-Age', '600');
+		res.removeHeader('Access-Control-Allow-Credentials');
+	}
+
+	// Public telemetry passthrough: no scope decorator. The endpoint is unauthenticated,
+	// cookie-stripped, rate-limited, and proxies only to the fixed diagnostics target.
+	@Options('/proxy/:version/:action', {
+		skipAuth: true,
+		ipRateLimit: { limit: 100, windowMs: 60_000 },
+	})
+	proxyPreflight(req: AuthenticatedRequest, res: Response) {
+		this.applyCors(req, res);
+		res.status(204).end();
+	}
+
+	// Public telemetry passthrough: no scope decorator. The endpoint is unauthenticated,
+	// cookie-stripped, rate-limited, and proxies only to the fixed diagnostics target.
 	@Post('/proxy/:version/track', { skipAuth: true, ipRateLimit: { limit: 100, windowMs: 60_000 } })
 	async track(req: AuthenticatedRequest, res: Response, next: NextFunction) {
+		this.applyCors(req, res);
 		await this.proxy(req, res, next);
 	}
 
+	// Public telemetry passthrough: no scope decorator. The endpoint is unauthenticated,
+	// cookie-stripped, rate-limited, and proxies only to the fixed diagnostics target.
 	@Post('/proxy/:version/identify', {
 		skipAuth: true,
 		ipRateLimit: { limit: 100, windowMs: 60_000 },
 	})
 	async identify(req: AuthenticatedRequest, res: Response, next: NextFunction) {
+		this.applyCors(req, res);
 		await this.proxy(req, res, next);
 	}
 
+	// Public telemetry passthrough: no scope decorator. The endpoint is unauthenticated,
+	// cookie-stripped, rate-limited, and proxies only to the fixed diagnostics target.
 	@Post('/proxy/:version/page', { skipAuth: true, ipRateLimit: { limit: 50, windowMs: 60_000 } })
 	async page(req: AuthenticatedRequest, res: Response, next: NextFunction) {
+		this.applyCors(req, res);
 		await this.proxy(req, res, next);
 	}
+
+	// Public RudderStack SDK source-config passthrough: no scope decorator. It uses
+	// the instance write key server-side and returns only the SDK config.
+	@Options('/rudderstack/sourceConfig', {
+		skipAuth: true,
+		ipRateLimit: { limit: 50, windowMs: 60_000 },
+		usesTemplates: true,
+	})
+	sourceConfigPreflight(req: AuthenticatedRequest, res: Response) {
+		this.applyCors(req, res);
+		res.status(204).end();
+	}
+
+	// Public RudderStack SDK source-config passthrough: no scope decorator. It uses
+	// the instance write key server-side and returns only the SDK config.
 	@Get('/rudderstack/sourceConfig', {
 		skipAuth: true,
 		ipRateLimit: { limit: 50, windowMs: 60_000 },
 		usesTemplates: true,
 	})
-	async sourceConfig(_: Request, res: Response) {
+	async sourceConfig(req: AuthenticatedRequest, res: Response) {
+		this.applyCors(req, res);
+
 		const response = await fetch('https://api-rs.n8n.io/sourceConfig', {
 			headers: {
 				authorization:

--- a/packages/cli/src/modules/mcp/__tests__/mcp.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.service.test.ts
@@ -489,6 +489,7 @@ describe('McpService', () => {
 			// the boolean and focus on `getServer`'s tool-registration behavior.
 			type BuildServiceOpts = {
 				builderEnabled?: boolean;
+				diagnosticsEnabled?: boolean;
 				instanceBaseUrl?: string;
 				postHogClient?: jest.Mocked<PostHogClient>;
 				telemetry?: jest.Mocked<Telemetry>;
@@ -496,6 +497,7 @@ describe('McpService', () => {
 
 			const buildService = ({
 				builderEnabled = true,
+				diagnosticsEnabled = true,
 				instanceBaseUrl = 'https://n8n.test',
 				postHogClient = mockInstance(PostHogClient),
 				telemetry = mockInstance(Telemetry),
@@ -520,7 +522,7 @@ describe('McpService', () => {
 							mcpBuilderEnabled: builderEnabled,
 						},
 						diagnostics: {
-							enabled: true,
+							enabled: diagnosticsEnabled,
 							frontendConfig: 'test-key;https://telemetry.n8n.io',
 						},
 					}),
@@ -591,6 +593,35 @@ describe('McpService', () => {
 
 				// The service trusts the caller's resolution and never falls back to PostHog.
 				expect(postHogClient.getFeatureFlags).not.toHaveBeenCalled();
+			});
+
+			it('does not inject write key or telemetry URLs when diagnostics are disabled', async () => {
+				const user = Object.assign(new User(), { id: 'user-1' });
+				const service = buildService({ diagnosticsEnabled: false });
+
+				await service.getServer(user, true);
+
+				const [, appOptions] = (registerWorkflowPreviewApp as jest.Mock).mock.calls[0] as [
+					unknown,
+					{
+						instanceOrigin?: string;
+						telemetry: {
+							enabled: boolean;
+							writeKey: string;
+							dataPlaneUrl: string;
+							configUrl: string;
+						};
+					},
+				];
+				expect(appOptions.instanceOrigin).toBeUndefined();
+				expect(appOptions.telemetry).toEqual(
+					expect.objectContaining({
+						enabled: false,
+						writeKey: '',
+						dataPlaneUrl: '',
+						configUrl: '',
+					}),
+				);
 			});
 
 			it('disables app telemetry when the telemetry proxy URL is invalid', async () => {

--- a/packages/cli/src/modules/mcp/__tests__/mcp.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.service.test.ts
@@ -489,17 +489,19 @@ describe('McpService', () => {
 			// the boolean and focus on `getServer`'s tool-registration behavior.
 			type BuildServiceOpts = {
 				builderEnabled?: boolean;
+				instanceBaseUrl?: string;
 				postHogClient?: jest.Mocked<PostHogClient>;
 				telemetry?: jest.Mocked<Telemetry>;
 			};
 
 			const buildService = ({
 				builderEnabled = true,
+				instanceBaseUrl = 'https://n8n.test',
 				postHogClient = mockInstance(PostHogClient),
 				telemetry = mockInstance(Telemetry),
 			}: BuildServiceOpts = {}) => {
 				const urlService = mockInstance(UrlService);
-				(urlService.getInstanceBaseUrl as jest.Mock).mockReturnValue('https://n8n.test');
+				(urlService.getInstanceBaseUrl as jest.Mock).mockReturnValue(instanceBaseUrl);
 
 				return new McpService(
 					mockLogger(),
@@ -589,6 +591,35 @@ describe('McpService', () => {
 
 				// The service trusts the caller's resolution and never falls back to PostHog.
 				expect(postHogClient.getFeatureFlags).not.toHaveBeenCalled();
+			});
+
+			it('disables app telemetry when the telemetry proxy URL is invalid', async () => {
+				const user = Object.assign(new User(), { id: 'user-1' });
+				const service = buildService({ instanceBaseUrl: 'not-a-url' });
+
+				await expect(service.getServer(user, true)).resolves.toBeDefined();
+
+				const [, appOptions] = (registerWorkflowPreviewApp as jest.Mock).mock.calls[0] as [
+					unknown,
+					{
+						instanceOrigin?: string;
+						telemetry: {
+							enabled: boolean;
+							writeKey: string;
+							dataPlaneUrl: string;
+							configUrl: string;
+						};
+					},
+				];
+				expect(appOptions.instanceOrigin).toBeUndefined();
+				expect(appOptions.telemetry).toEqual(
+					expect.objectContaining({
+						enabled: false,
+						writeKey: '',
+						dataPlaneUrl: '',
+						configUrl: '',
+					}),
+				);
 			});
 
 			it('tracks render requested when the preview resource is read', async () => {

--- a/packages/cli/src/modules/mcp/__tests__/mcp.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.service.test.ts
@@ -29,6 +29,7 @@ import {
 
 import { MCP_APPS_FLAG, MCP_APPS_VARIANT_CONTROL, MCP_APPS_VARIANT_ENABLED } from '@n8n/api-types';
 
+import { MCP_PREVIEW_RENDER_REQUESTED_EVENT } from '../mcp.constants';
 import { McpService } from '../mcp.service';
 import { NodeCatalogService } from '@/node-catalog';
 
@@ -62,6 +63,7 @@ describe('McpService', () => {
 		});
 		instanceSettings = mockInstance(InstanceSettings, {
 			hostId: 'test-host-id',
+			instanceId: 'test-instance-id',
 		});
 		logger = mockLogger();
 
@@ -488,29 +490,39 @@ describe('McpService', () => {
 			type BuildServiceOpts = {
 				builderEnabled?: boolean;
 				postHogClient?: jest.Mocked<PostHogClient>;
+				telemetry?: jest.Mocked<Telemetry>;
 			};
 
 			const buildService = ({
 				builderEnabled = true,
 				postHogClient = mockInstance(PostHogClient),
-			}: BuildServiceOpts = {}) =>
-				new McpService(
+				telemetry = mockInstance(Telemetry),
+			}: BuildServiceOpts = {}) => {
+				const urlService = mockInstance(UrlService);
+				(urlService.getInstanceBaseUrl as jest.Mock).mockReturnValue('https://n8n.test');
+
+				return new McpService(
 					mockLogger(),
 					executionsConfig,
 					instanceSettings,
 					mockInstance(WorkflowFinderService),
 					mockInstance(WorkflowService),
-					mockInstance(UrlService),
+					urlService,
 					mockInstance(CredentialsService),
 					activeExecutions,
 					mockInstance(GlobalConfig, {
 						endpoints: {
 							webhook: '/webhook',
 							webhookTest: '/webhook-test',
+							rest: 'rest',
 							mcpBuilderEnabled: builderEnabled,
 						},
+						diagnostics: {
+							enabled: true,
+							frontendConfig: 'test-key;https://telemetry.n8n.io',
+						},
 					}),
-					mockInstance(Telemetry),
+					telemetry,
 					mockInstance(WorkflowRunner),
 					mockInstance(RoleService),
 					mockInstance(ProjectService),
@@ -526,6 +538,7 @@ describe('McpService', () => {
 					mockInstance(CollaborationService),
 					postHogClient,
 				);
+			};
 
 			beforeEach(() => {
 				(registerWorkflowPreviewApp as jest.Mock).mockClear();
@@ -543,6 +556,32 @@ describe('McpService', () => {
 				expect(registerWorkflowPreviewApp).toHaveBeenCalledTimes(1);
 				expect(registerMcpAppTool).toHaveBeenCalledTimes(1);
 
+				const [, appOptions] = (registerWorkflowPreviewApp as jest.Mock).mock.calls[0] as [
+					unknown,
+					{
+						instanceOrigin: string;
+						telemetry: {
+							enabled: boolean;
+							writeKey: string;
+							dataPlaneUrl: string;
+							configUrl: string;
+							instanceId: string;
+							versionCli: string;
+						};
+					},
+				];
+				expect(appOptions.instanceOrigin).toBe('https://n8n.test');
+				expect(appOptions.telemetry).toEqual(
+					expect.objectContaining({
+						enabled: true,
+						writeKey: 'test-key',
+						dataPlaneUrl: 'https://n8n.test/rest/telemetry/proxy',
+						configUrl: 'https://n8n.test/rest/telemetry/rudderstack',
+						instanceId: 'test-instance-id',
+						versionCli: expect.any(String),
+					}),
+				);
+
 				const [, toolName, toolConfig] = (registerMcpAppTool as jest.Mock).mock.calls[0];
 				expect(typeof toolName).toBe('string');
 				const meta = (toolConfig as { _meta: { ui: { resourceUri: string } } })._meta;
@@ -550,6 +589,24 @@ describe('McpService', () => {
 
 				// The service trusts the caller's resolution and never falls back to PostHog.
 				expect(postHogClient.getFeatureFlags).not.toHaveBeenCalled();
+			});
+
+			it('tracks render requested when the preview resource is read', async () => {
+				const user = Object.assign(new User(), { id: 'user-1' });
+				const telemetry = mockInstance(Telemetry);
+
+				const service = buildService({ telemetry });
+				await service.getServer(user, true);
+
+				const [, appOptions] = (registerWorkflowPreviewApp as jest.Mock).mock.calls[0] as [
+					unknown,
+					{ onResourceRead: () => void },
+				];
+				appOptions.onResourceRead();
+
+				expect(telemetry.track).toHaveBeenCalledWith(MCP_PREVIEW_RENDER_REQUESTED_EVENT, {
+					user_id: 'user-1',
+				});
 			});
 
 			it('does not register MCP apps when `mcpAppsEnabled` is false', async () => {

--- a/packages/cli/src/modules/mcp/mcp.constants.ts
+++ b/packages/cli/src/modules/mcp/mcp.constants.ts
@@ -8,6 +8,7 @@ import {
 
 export const USER_CONNECTED_TO_MCP_EVENT = 'User connected to MCP server';
 export const USER_CALLED_MCP_TOOL_EVENT = 'User called mcp tool';
+export const MCP_PREVIEW_RENDER_REQUESTED_EVENT = 'MCP App preview render requested';
 
 export const UNAUTHORIZED_ERROR_MESSAGE = 'Unauthorized';
 export const INTERNAL_SERVER_ERROR_MESSAGE = 'Internal server error';

--- a/packages/cli/src/modules/mcp/mcp.constants.ts
+++ b/packages/cli/src/modules/mcp/mcp.constants.ts
@@ -6,10 +6,17 @@ import {
 	WEBHOOK_NODE_TYPE,
 } from 'n8n-workflow';
 
+/**
+ * TELEMETRY EVENTS - backend
+ * Frontend events are defined in @n8n/mcp-apps package
+ */
 export const USER_CONNECTED_TO_MCP_EVENT = 'User connected to MCP server';
 export const USER_CALLED_MCP_TOOL_EVENT = 'User called mcp tool';
 export const MCP_PREVIEW_RENDER_REQUESTED_EVENT = 'MCP App preview render requested';
 
+/**
+ * Message constants
+ */
 export const UNAUTHORIZED_ERROR_MESSAGE = 'Unauthorized';
 export const INTERNAL_SERVER_ERROR_MESSAGE = 'Internal server error';
 export const MCP_ACCESS_DISABLED_ERROR_MESSAGE = 'MCP access is disabled';

--- a/packages/cli/src/modules/mcp/mcp.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.service.ts
@@ -14,6 +14,7 @@ import {
 	registerMcpAppTool,
 	registerWorkflowPreviewApp,
 	WORKFLOW_PREVIEW_APP_URI,
+	type McpAppTelemetryConfig,
 } from '@n8n/mcp-apps/server';
 import { InstanceSettings } from 'n8n-core';
 import {
@@ -57,6 +58,7 @@ import { NodeCatalogService } from '@/node-catalog';
 
 import { ActiveExecutions } from '@/active-executions';
 import { CollaborationService } from '@/collaboration/collaboration.service';
+import { N8N_VERSION } from '@/constants';
 import { CredentialsService } from '@/credentials/credentials.service';
 import { DataTableProxyService } from '@/modules/data-table/data-table-proxy.service';
 import { NodeTypes } from '@/node-types';
@@ -69,6 +71,7 @@ import { WorkflowRunner } from '@/workflow-runner';
 import { WorkflowCreationService } from '@/workflows/workflow-creation.service';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { WorkflowService } from '@/workflows/workflow.service';
+import { MCP_PREVIEW_RENDER_REQUESTED_EVENT } from './mcp.constants';
 import type { McpAppsTelemetryVariant } from './mcp.types';
 import { createPrepareTestPinDataTool } from './tools/prepare-workflow-pin-data.tool';
 import { createTestWorkflowTool } from './tools/test-workflow.tool';
@@ -99,7 +102,7 @@ export class McpService {
 	constructor(
 		private readonly logger: Logger,
 		private readonly executionsConfig: ExecutionsConfig,
-		_instanceSettings: InstanceSettings,
+		private readonly instanceSettings: InstanceSettings,
 		private readonly workflowFinderService: WorkflowFinderService,
 		private readonly workflowService: WorkflowService,
 		private readonly urlService: UrlService,
@@ -135,6 +138,27 @@ export class McpService {
 		if (raw === MCP_APPS_VARIANT_ENABLED) return { enabled: true, variant: 'variant' };
 		if (raw === MCP_APPS_VARIANT_CONTROL) return { enabled: false, variant: 'control' };
 		return { enabled: false, variant: 'unassigned' };
+	}
+
+	/**
+	 * Builds the instance-level telemetry config injected into MCP app UIs.
+	 * Mirrors the front-end telemetry settings: RudderStack data plane and source
+	 * config requests go through the instance telemetry proxy.
+	 */
+	private buildMcpAppTelemetryConfig(): McpAppTelemetryConfig {
+		const instanceBaseUrl = this.urlService.getInstanceBaseUrl();
+		const restEndpoint = this.globalConfig.endpoints.rest;
+		const { enabled, frontendConfig } = this.globalConfig.diagnostics;
+		const [writeKey] = frontendConfig.split(';');
+
+		return {
+			enabled,
+			writeKey: writeKey ?? '',
+			dataPlaneUrl: `${instanceBaseUrl}/${restEndpoint}/telemetry/proxy`,
+			configUrl: `${instanceBaseUrl}/${restEndpoint}/telemetry/rudderstack`,
+			instanceId: this.instanceSettings.instanceId,
+			versionCli: N8N_VERSION,
+		};
 	}
 
 	async getServer(user: User, mcpAppsEnabled: boolean) {
@@ -392,7 +416,14 @@ export class McpService {
 		);
 
 		if (mcpAppsEnabled) {
-			registerWorkflowPreviewApp(server);
+			const appTelemetry = this.buildMcpAppTelemetryConfig();
+			registerWorkflowPreviewApp(server, {
+				instanceOrigin: new URL(appTelemetry.dataPlaneUrl).origin,
+				telemetry: appTelemetry,
+				onResourceRead: () => {
+					this.telemetry.track(MCP_PREVIEW_RENDER_REQUESTED_EVENT, { user_id: user.id });
+				},
+			});
 			registerMcpAppTool(
 				server,
 				createTool.name,

--- a/packages/cli/src/modules/mcp/mcp.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.service.ts
@@ -151,9 +151,20 @@ export class McpService {
 	 * config requests go through the instance telemetry proxy.
 	 */
 	private buildMcpAppTelemetryConfig(): McpAppTelemetryResolution {
+		const { enabled, frontendConfig } = this.globalConfig.diagnostics;
+		const disabledTelemetry: McpAppTelemetryConfig = {
+			enabled: false,
+			writeKey: '',
+			dataPlaneUrl: '',
+			configUrl: '',
+			instanceId: this.instanceSettings.instanceId,
+			versionCli: N8N_VERSION,
+		};
+
+		if (!enabled) return { telemetry: disabledTelemetry };
+
 		const instanceBaseUrl = this.urlService.getInstanceBaseUrl();
 		const restEndpoint = this.globalConfig.endpoints.rest;
-		const { enabled, frontendConfig } = this.globalConfig.diagnostics;
 		const [writeKey] = frontendConfig.split(';');
 
 		const telemetry: McpAppTelemetryConfig = {
@@ -173,13 +184,7 @@ export class McpService {
 			});
 
 			return {
-				telemetry: {
-					...telemetry,
-					enabled: false,
-					writeKey: '',
-					dataPlaneUrl: '',
-					configUrl: '',
-				},
+				telemetry: disabledTelemetry,
 			};
 		}
 	}

--- a/packages/cli/src/modules/mcp/mcp.service.ts
+++ b/packages/cli/src/modules/mcp/mcp.service.ts
@@ -91,6 +91,11 @@ export type McpAppsResolution = {
 	variant: McpAppsTelemetryVariant;
 };
 
+type McpAppTelemetryResolution = {
+	telemetry: McpAppTelemetryConfig;
+	instanceOrigin?: string;
+};
+
 @Service()
 export class McpService {
 	/**
@@ -145,13 +150,13 @@ export class McpService {
 	 * Mirrors the front-end telemetry settings: RudderStack data plane and source
 	 * config requests go through the instance telemetry proxy.
 	 */
-	private buildMcpAppTelemetryConfig(): McpAppTelemetryConfig {
+	private buildMcpAppTelemetryConfig(): McpAppTelemetryResolution {
 		const instanceBaseUrl = this.urlService.getInstanceBaseUrl();
 		const restEndpoint = this.globalConfig.endpoints.rest;
 		const { enabled, frontendConfig } = this.globalConfig.diagnostics;
 		const [writeKey] = frontendConfig.split(';');
 
-		return {
+		const telemetry: McpAppTelemetryConfig = {
 			enabled,
 			writeKey: writeKey ?? '',
 			dataPlaneUrl: `${instanceBaseUrl}/${restEndpoint}/telemetry/proxy`,
@@ -159,6 +164,24 @@ export class McpService {
 			instanceId: this.instanceSettings.instanceId,
 			versionCli: N8N_VERSION,
 		};
+
+		try {
+			return { telemetry, instanceOrigin: new URL(telemetry.dataPlaneUrl).origin };
+		} catch {
+			this.logger.warn('Disabling MCP app telemetry because telemetry proxy URL is invalid', {
+				dataPlaneUrl: telemetry.dataPlaneUrl,
+			});
+
+			return {
+				telemetry: {
+					...telemetry,
+					enabled: false,
+					writeKey: '',
+					dataPlaneUrl: '',
+					configUrl: '',
+				},
+			};
+		}
 	}
 
 	async getServer(user: User, mcpAppsEnabled: boolean) {
@@ -418,8 +441,8 @@ export class McpService {
 		if (mcpAppsEnabled) {
 			const appTelemetry = this.buildMcpAppTelemetryConfig();
 			registerWorkflowPreviewApp(server, {
-				instanceOrigin: new URL(appTelemetry.dataPlaneUrl).origin,
-				telemetry: appTelemetry,
+				instanceOrigin: appTelemetry.instanceOrigin,
+				telemetry: appTelemetry.telemetry,
 				onResourceRead: () => {
 					this.telemetry.track(MCP_PREVIEW_RENDER_REQUESTED_EVENT, { user_id: user.id });
 				},


### PR DESCRIPTION
## Summary
This is Part 1 for adding telemetry to `mcp-apps` project.

This PR adds backend/server foundation for MCP app telemetry.

- Injects instance-level telemetry config into MCP app HTML
- Declares telemetry CSP requirements for the workflow preview app
- Adds CORS/preflight support for sandboxed MCP app telemetry calls through the existing telemetry proxy
- Tracks backend `MCP App preview render requested` when the app resource is read
- Adds focused tests for telemetry proxy behavior, config injection, CSP metadata, and MCP service wiring

In Part 2, we'll add front-end runtime events after merging #31647

### About updated CORS headers
Security: the telemetry proxy remains unauthenticated and fixed-target, but CORS is limited to the MCP app’s required sandboxed iframe origin (`Origin: null`) and the preflight allow-list only includes the RudderStack SDK headers we need. We also strip credential-bearing headers before proxying so third-party sites cannot use the instance as a credentialed telemetry relay.

I'll test more strict header setup in Part 2, when I can make sure front-end events are still emitted. Main thing for now is that we don't break existing telemetry

## How to test

1. Run n8n with `N8N_MCP_APPS_ENABLED=true`
2. Connect mcp client that supports mcp-apps (e.g. MCP Jam)
3. Test if `MCP App preview render requested` event is sent from `mcp.service` when app loads

## Related Linear tickets, Github issues, and Community forum posts
Closes ADO-5358


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
