### PR TITLE
feat: Extend HITL input telemetry to cover the planning step (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.builderAskedForInput.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.builderAskedForInput.test.ts
@@ -1,0 +1,130 @@
+import type { z as zType } from 'zod';
+
+// Manual mocks — must be declared before any imports that touch the mocked modules.
+jest.mock('@n8n/instance-ai', () => {
+	const { z } = jest.requireActual<{ z: typeof zType }>('zod');
+	return {
+		McpClientManager: class {
+			disconnect = jest.fn();
+		},
+		createDomainAccessTracker: jest.fn(),
+		createSandbox: jest.fn(),
+		createWorkspace: jest.fn(),
+		createLazyRuntimeWorkspace: jest.fn(),
+		createLazyWorkspaceRuntimeSkillSource: jest.fn(({ source }) => source),
+		setupSandboxWorkspace: jest.fn(),
+		loadInstanceAiRuntimeSkillSource: jest.fn(() => ({
+			registry: { skillsHash: 'runtime-skills-hash', skills: [] },
+			loadSkill: jest.fn(),
+		})),
+		workflowBuildOutcomeSchema: z.object({}),
+		handleBuildOutcome: jest.fn(),
+		handleVerificationVerdict: jest.fn(),
+		createInstanceAgent: jest.fn(),
+		createAllTools: jest.fn(),
+	};
+});
+
+import { InstanceAiService } from '../instance-ai.service';
+
+/**
+ * `trackConfirmationRequest` emits the 'Builder asked for input' telemetry event.
+ * It classifies the input `type` and counts the relevant `num_steps`, and — for
+ * plan reviews — distinguishes the first plan in a thread from later revisions
+ * via the per-thread `planRequestsByThread` counter.
+ */
+describe('InstanceAiService — "Builder asked for input" telemetry', () => {
+	type Internals = {
+		planRequestsByThread: Map<string, number>;
+		telemetry: { track: jest.Mock };
+		trackConfirmationRequest: (
+			threadId: string,
+			confirmationEvent: { payload: Record<string, unknown> },
+		) => void;
+	};
+
+	function makeService(): Internals {
+		// Bypass the constructor — we only exercise the counter map and telemetry.
+		const service = Object.create(InstanceAiService.prototype) as unknown as Internals;
+		service.planRequestsByThread = new Map<string, number>();
+		service.telemetry = { track: jest.fn() };
+		return service;
+	}
+
+	function askedForInputCalls(service: Internals): Array<Record<string, unknown>> {
+		return service.telemetry.track.mock.calls
+			.filter(([event]) => event === 'Builder asked for input')
+			.map(([, payload]) => payload as Record<string, unknown>);
+	}
+
+	it('marks the first plan review in a thread as first_plan and counts plan items', () => {
+		const service = makeService();
+
+		service.trackConfirmationRequest('thread-a', {
+			payload: { inputType: 'plan-review', planItems: [{}, {}, {}] },
+		});
+
+		expect(service.telemetry.track).toHaveBeenCalledWith(
+			'Builder asked for input',
+			expect.objectContaining({ thread_id: 'thread-a', type: 'first_plan', num_steps: 3 }),
+		);
+	});
+
+	it('marks later plan reviews in the same thread as revised_plan', () => {
+		const service = makeService();
+
+		service.trackConfirmationRequest('thread-a', {
+			payload: { inputType: 'plan-review', planItems: [{}] },
+		});
+		service.trackConfirmationRequest('thread-a', {
+			payload: { inputType: 'plan-review', planItems: [{}, {}] },
+		});
+
+		const calls = askedForInputCalls(service);
+		expect(calls).toHaveLength(2);
+		expect(calls[0]).toMatchObject({ type: 'first_plan', num_steps: 1 });
+		expect(calls[1]).toMatchObject({ type: 'revised_plan', num_steps: 2 });
+	});
+
+	it('counts plans per thread independently', () => {
+		const service = makeService();
+
+		service.trackConfirmationRequest('thread-a', {
+			payload: { inputType: 'plan-review', planItems: [{}] },
+		});
+		service.trackConfirmationRequest('thread-b', {
+			payload: { inputType: 'plan-review', planItems: [{}] },
+		});
+
+		const calls = askedForInputCalls(service);
+		expect(calls[0]).toMatchObject({ thread_id: 'thread-a', type: 'first_plan' });
+		expect(calls[1]).toMatchObject({ thread_id: 'thread-b', type: 'first_plan' });
+	});
+
+	it('passes non-plan input types through unchanged and counts their steps', () => {
+		const service = makeService();
+
+		service.trackConfirmationRequest('thread-a', {
+			payload: { inputType: 'questions', questions: [{}, {}] },
+		});
+
+		expect(service.telemetry.track).toHaveBeenCalledWith(
+			'Builder asked for input',
+			expect.objectContaining({ type: 'questions', num_steps: 2 }),
+		);
+		expect(service.planRequestsByThread.has('thread-a')).toBe(false);
+	});
+
+	it('derives setup type from setupRequests when no inputType is present', () => {
+		const service = makeService();
+
+		service.trackConfirmationRequest('thread-a', {
+			payload: { setupRequests: [{}, {}, {}] },
+		});
+
+		expect(service.telemetry.track).toHaveBeenCalledWith(
+			'Builder asked for input',
+			expect.objectContaining({ type: 'setup', num_steps: 3 }),
+		);
+	});
+});

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.threadPushRef.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.threadPushRef.test.ts
@@ -66,6 +66,7 @@ describe('InstanceAiService — threadPushRef lifetime', () => {
 		// dependencies clearThreadState reaches.
 		type Internals = {
 			threadPushRef: Map<string, string>;
+			planRequestsByThread: Map<string, number>;
 			runState: { clearThread: jest.Mock };
 			backgroundTasks: { cancelThread: jest.Mock };
 			creditedThreads: Map<string, unknown>;
@@ -83,6 +84,7 @@ describe('InstanceAiService — threadPushRef lifetime', () => {
 		const service = Object.create(InstanceAiService.prototype) as unknown as Internals;
 
 		service.threadPushRef = new Map<string, string>([['thread-a', 'push-ref-a']]);
+		service.planRequestsByThread = new Map<string, number>([['thread-a', 2]]);
 		service.runState = {
 			clearThread: jest.fn(() => ({ active: undefined, suspended: undefined })),
 		};
@@ -101,6 +103,7 @@ describe('InstanceAiService — threadPushRef lifetime', () => {
 		await service.clearThreadState('thread-a');
 
 		expect(service.threadPushRef.has('thread-a')).toBe(false);
+		expect(service.planRequestsByThread.has('thread-a')).toBe(false);
 	});
 
 	it('startRun overwrites the threadPushRef entry on each new run', () => {

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -550,6 +550,9 @@ export class InstanceAiService {
 	/** Tracks the iframe pushRef per thread for live execution push events. */
 	private readonly threadPushRef = new Map<string, string>();
 
+	/** Counts plan-review confirmations per thread, to tell the first plan apart from later revisions. */
+	private readonly planRequestsByThread = new Map<string, number>();
+
 	/** Per-thread promise chain that serializes schedulePlannedTasks calls. */
 	private readonly schedulerLocks = new Map<string, Promise<void>>();
 
@@ -2003,6 +2006,7 @@ export class InstanceAiService {
 		this.schedulerLocks.delete(threadId);
 		this.domainAccessTrackersByThread.delete(threadId);
 		this.threadPushRef.delete(threadId);
+		this.planRequestsByThread.delete(threadId);
 		this.deleteTraceContextsForThread(threadId);
 		await this.destroySandbox(threadId);
 		await this.reapAiTemporaryForThreadCleanup(threadId);
@@ -5540,6 +5544,17 @@ export class InstanceAiService {
 			numSteps = payload.setupRequests.length;
 		} else if (Array.isArray(payload.credentialRequests)) {
 			numSteps = payload.credentialRequests.length;
+		}
+
+		if (inputType === 'plan-review') {
+			// Tell the first plan in a thread apart from later revisions the user asked
+			// for. The per-thread counter is cleared on thread cleanup.
+			const planCount = (this.planRequestsByThread.get(threadId) ?? 0) + 1;
+			this.planRequestsByThread.set(threadId, planCount);
+			type = planCount === 1 ? 'first_plan' : 'revised_plan';
+			if (Array.isArray(payload.planItems)) {
+				numSteps = payload.planItems.length;
+			}
 		}
 
 		this.telemetry.track('Builder asked for input', {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
@@ -518,6 +518,7 @@ function handleSubmit(message: string, attachments?: InstanceAiAttachment[]) {
 			skipped_inputs: [],
 			num_tasks: planEdit.taskCount,
 			feedback: scrubSecretsInText(message),
+			plan_feedback_type: 'changes_requested',
 		});
 		thread.markPlanUpdatePending(planEdit.requestId);
 		void thread

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiThreadView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiThreadView.test.ts
@@ -587,7 +587,10 @@ describe('InstanceAiThreadView', () => {
 
 		expect(telemetryTrackSpy).toHaveBeenCalledWith(
 			'User finished providing input',
-			expect.objectContaining({ feedback: 'use [REDACTED] to call the API' }),
+			expect.objectContaining({
+				feedback: 'use [REDACTED] to call the API',
+				plan_feedback_type: 'changes_requested',
+			}),
 		);
 		expect(thread.confirmAction).toHaveBeenCalledWith('req-plan', {
 			kind: 'approval',

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/AgentTimeline.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/AgentTimeline.vue
@@ -175,6 +175,7 @@ function handlePlanApprove(tc: InstanceAiToolCallState) {
 		],
 		skipped_inputs: [],
 		num_tasks: getPlanTasks(tc).length,
+		plan_feedback_type: 'accept',
 	});
 
 	thread.resolveConfirmation(requestId, 'approved');
@@ -214,6 +215,7 @@ function handlePlanDeny(tc: InstanceAiToolCallState) {
 		],
 		skipped_inputs: [],
 		num_tasks: numTasks,
+		plan_feedback_type: 'deny',
 	});
 
 	if (thread.activePlanEdit?.requestId === requestId) {

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiConfirmationPanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiConfirmationPanel.vue
@@ -366,7 +366,7 @@ function handlePlanApprove(conf: InstanceAiConfirmation, numTasks: number) {
 		conf,
 		[{ label: 'plan', options: [...PLAN_REVIEW_OPTIONS], option_chosen: 'approve' }],
 		[],
-		{ num_tasks: numTasks },
+		{ num_tasks: numTasks, plan_feedback_type: 'accept' },
 	);
 	thread.resolveConfirmation(conf.requestId, 'approved');
 	void thread.confirmAction(conf.requestId, { kind: 'approval', approved: true });
@@ -385,7 +385,7 @@ function handlePlanDeny(conf: InstanceAiConfirmation, numTasks: number) {
 		conf,
 		[{ label: 'plan', options: [...PLAN_REVIEW_OPTIONS], option_chosen: 'deny' }],
 		[],
-		{ num_tasks: numTasks },
+		{ num_tasks: numTasks, plan_feedback_type: 'deny' },
 	);
 	thread.resolveConfirmation(conf.requestId, 'denied');
 	void thread.confirmAction(conf.requestId, { kind: 'planDeny' });


### PR DESCRIPTION
## Summary

Extends the HITL (human-in-the-loop) input telemetry to measure the **planning** step, per [INS-401](https://linear.app/n8n/issue/INS-401).

**Backend — `Builder asked for input`** (`instance-ai.service.ts`, `trackConfirmationRequest`):
- Plan-review confirmations are now reported as **`first_plan`** vs **`revised_plan`**, using a per-thread counter (`planRequestsByThread`, cleared on thread cleanup). Previously every plan was reported with `type: 'plan-review'`.
- **`num_steps`** now counts the plan's `planItems` for plan reviews (it was hard-coded to `1` for plans; other types are unchanged).

**Frontend — `User finished providing input`** (`AgentTimeline.vue`, `InstanceAiThreadView.vue`):
- Adds **`plan_feedback_type`** to the three plan-review events: `approve → accept`, `deny → deny`, `ask-for-edits → changes_requested`.

## How to test

1. In Instance AI, ask the builder for something that triggers a plan. The backend emits `Builder asked for input` with `type: 'first_plan'` and `num_steps` = number of plan steps.
2. Ask for edits → the builder submits a new plan → next `Builder asked for input` is `type: 'revised_plan'`.
3. Approve / deny / ask-for-edits the plan → `User finished providing input` carries `plan_feedback_type: 'accept' | 'deny' | 'changes_requested'`.

Unit tests: `instance-ai.service.builderAskedForInput.test.ts` (BE, 5 cases — first/revised, per-thread isolation, num_steps, non-plan passthrough) and the extended `InstanceAiThreadView.test.ts` (FE, `changes_requested`).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-401

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
