### PR TITLE
fix(editor): Show data redaction upgrade prompt on unlicensed instances

### DIFF
--- a/packages/frontend/editor-ui/src/Interface.ts
+++ b/packages/frontend/editor-ui/src/Interface.ts
@@ -889,6 +889,7 @@ export type CloudUpdateLinkSourceType =
 	| 'chat-hub'
 	| 'empty-state-builder-prompt'
 	| 'instance-ai'
+	| 'data-redaction'
 	| 'workflow-settings';
 
 export type UTMCampaign =

--- a/packages/frontend/editor-ui/src/features/settings/security/DataRedactionSection.vue
+++ b/packages/frontend/editor-ui/src/features/settings/security/DataRedactionSection.vue
@@ -146,7 +146,7 @@ function onSelectFloor(value: SelectValue | undefined) {
 }
 
 function goToUpgrade() {
-	void pageRedirectionHelper.goToUpgrade('settings-users', 'upgrade-users');
+	void pageRedirectionHelper.goToUpgrade('data-redaction', 'upgrade-data-redaction');
 }
 </script>
 

--- a/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.test.ts
@@ -787,5 +787,49 @@ describe('SecuritySettings', () => {
 				);
 			});
 		});
+
+		describe('when security settings endpoint is unlicensed (403)', () => {
+			beforeEach(() => {
+				enableRedactionEnforcementFlag(true);
+				settingsStore.isEnterpriseFeatureEnabled[EnterpriseEditionFeature.DataRedaction] = false;
+				// Reproduce the 403: useAsyncState keeps state === undefined.
+				getSecuritySettings.mockRejectedValue(new Error('Forbidden'));
+			});
+
+			it('should still render the data redaction section when the endpoint 403s', async () => {
+				const { getByTestId } = renderView();
+
+				await waitFor(() => {
+					expect(getByTestId('enable-redaction-enforcement')).toBeInTheDocument();
+				});
+
+				expect(getByTestId('enable-redaction-enforcement')).toHaveClass('is-disabled');
+			});
+
+			it('should show the Upgrade badges and disabled scope dropdown when endpoint 403s', async () => {
+				const { getByTestId, getAllByText } = renderView();
+
+				await waitFor(() => {
+					expect(getByTestId('enable-redaction-enforcement')).toBeInTheDocument();
+				});
+
+				expect(getByTestId('redaction-enforcement-scope-row')).toBeInTheDocument();
+				expect(getByTestId('redaction-enforcement-scope-select')).toHaveAttribute('data-disabled');
+				// One badge on the toggle row, one on the scope row.
+				expect(getAllByText('Upgrade').length).toBeGreaterThanOrEqual(2);
+				// Defaults to floor 'off' when state never resolves.
+				expect(getByTestId('redaction-enforcement-summary')).toHaveTextContent('No executions');
+			});
+
+			it('should not show an error toast when the endpoint 403s', async () => {
+				const { getByTestId } = renderView();
+
+				await waitFor(() => {
+					expect(getByTestId('enable-redaction-enforcement')).toBeInTheDocument();
+				});
+
+				expect(showError).not.toHaveBeenCalled();
+			});
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.vue
+++ b/packages/frontend/editor-ui/src/features/settings/security/SecuritySettings.vue
@@ -68,7 +68,7 @@ function goToUpgrade() {
 	void pageRedirectionHelper.goToUpgrade('settings-users', 'upgrade-users');
 }
 
-const { state } = useAsyncState(async () => {
+const { state, isReady, error } = useAsyncState(async () => {
 	const settings = await securitySettingsApi.getSecuritySettings(rootStore.restApiContext);
 	return {
 		personalSpacePublishing: settings.personalSpacePublishing,
@@ -82,6 +82,13 @@ const { state } = useAsyncState(async () => {
 }, undefined);
 
 const isManagedByEnv = computed(() => state.value?.managedByEnv ?? false);
+
+// The security settings endpoint is gated by an enterprise license and 403s on
+// unlicensed instances, leaving `state` undefined. The data redaction section
+// still needs to render so the licensed-feature upgrade prompt is reachable, so
+// we render once the request settles (resolved or failed) rather than waiting
+// for a defined `state`.
+const isSecuritySettingsSettled = computed(() => isReady.value || error.value !== undefined);
 
 async function updatePersonalSpaceSetting(
 	key: 'personalSpacePublishing' | 'personalSpaceSharing',
@@ -238,8 +245,8 @@ const sharingCountText = computed(() => {
 		</div>
 
 		<DataRedactionSection
-			v-if="isRedactionEnforcementFlagEnabled && state !== undefined"
-			:initial-floor="state.initialRedactionFloor"
+			v-if="isRedactionEnforcementFlagEnabled && isSecuritySettingsSettled"
+			:initial-floor="state?.initialRedactionFloor ?? 'off'"
 			:managed-by-env="isManagedByEnv"
 		/>
 


### PR DESCRIPTION
## Summary

On instances without the `dataRedaction` Enterprise feature, the **Data redaction** section in Settings → Security & policies did not render at all — no Upgrade badge, no disabled controls, no upsell. The intended `EnterpriseEdition` fallback (disabled toggle/select + "Upgrade now" tooltip) was unreachable, blocking the upgrade-prompt path before GA.

**Root cause:** `SecuritySettings.vue` gated the section with `v-if="isRedactionEnforcementFlagEnabled && state !== undefined"`. `state` is loaded from `GET /rest/settings/security`, which is guarded by `@Licensed('feat:personalSpacePolicy')` and returns 403 on unlicensed instances. So `state` stayed `undefined` and the whole section was hidden — visibility was wrongly coupled to (a) the `personalSpacePolicy` endpoint gate rather than the `dataRedaction` feature, and (b) the API state resolving.

**Fix (frontend only):**
- Gate the section on whether the request has **settled** (resolved *or* errored) instead of on `state` being defined: `v-if="isRedactionEnforcementFlagEnabled && isSecuritySettingsSettled"`, where `isSecuritySettingsSettled = isReady || error !== undefined` (derived from `useAsyncState`).
- Make the floor prop null-safe: `:initial-floor="state?.initialRedactionFloor ?? 'off'"`.

`DataRedactionSection.vue` is unchanged — it is already self-contained: `isLicensed` reads the correct `EnterpriseEditionFeature.DataRedaction` (independent of `state`), and its `EnterpriseEdition` `#fallback` already renders disabled controls + Upgrade badge + tooltip.

> Note: gating on *settled* (rather than the literal "render unconditionally" from the ticket's Option A) is deliberate — `DataRedactionSection` snapshots `initialFloor` into a non-reactive ref at mount, so the section must mount only once the request has settled to capture the real floor on the success path. No server-side change is needed; the endpoint's license gate is correct for the data it returns.
>
> The sibling **Personal Space** section intentionally keeps its existing `v-if="state !== undefined"` inner guards (it hides its toggles on 403). Aligning it onto the same "render-on-settle" pattern is out of scope here.

## How to test

1. On an instance **without** the `dataRedaction` license (with `N8N_ENV_FEAT_REDACTION_ENFORCEMENT` set), open **Settings → Security & policies**.
   - The Data redaction section is visible with an **Upgrade** badge and disabled toggle + scope select (matching the 2FA / Personal Space fallback), with an "Upgrade now" tooltip.
2. On a **licensed** instance, the section behaves exactly as before (no regression) — the stored floor is reflected.
3. With `N8N_ENV_FEAT_REDACTION_ENFORCEMENT` unset, the section stays hidden.

Automated: `pnpm --filter n8n-editor-ui test SecuritySettings` (43/43 pass; 3 new regression tests cover the 403/unlicensed path, including no error toast on the swallowed 403).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-38

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI