### PR TITLE
fix(core): Return wrong-credentials error instead of SSO error on failed login

### DIFF
--- a/packages/cli/src/controllers/__tests__/auth.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/auth.controller.test.ts
@@ -189,6 +189,33 @@ describe('AuthController', () => {
 			);
 			expect(authService.issueCookie).toHaveBeenCalledWith(res, member, false, '1');
 		});
+
+		it('should return a "wrong credentials" error, not the SSO error, when the password is wrong while SSO is enabled', async () => {
+			const body = mock<LoginRequestDto>({
+				emailOrLdapLoginId: 'user@example.com',
+				password: 'wrong-password',
+			});
+
+			const req = mock<AuthenticatedRequest>({
+				body,
+				browserId: '1',
+			});
+
+			const res = mock<Response>();
+
+			// Wrong password (or unknown user): the email handler resolves to undefined,
+			// so the SSO restriction must not swallow it into the "log in with SSO" message.
+			emailAuthHandler.handleLogin.mockResolvedValue(undefined);
+			config.set('userManagement.authenticationMethod', 'saml');
+
+			// Act & Assert
+
+			await expect(controller.login(req, res, body)).rejects.toThrowError(
+				new AuthError('Wrong username or password. Do you have caps lock on?'),
+			);
+
+			expect(authService.issueCookie).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('resolveSignupToken', () => {

--- a/packages/cli/src/controllers/auth.controller.ts
+++ b/packages/cli/src/controllers/auth.controller.ts
@@ -113,10 +113,16 @@ export class AuthController {
 	}
 
 	private validateSsoRestrictions(preliminaryUser: User | undefined): void {
+		// No eligible user (unknown email or wrong password) means the password
+		// check already failed. Defer to the password flow so it surfaces a proper
+		// "wrong credentials" error instead of the misleading "log in with SSO"
+		// message - the SSO restriction only applies to a real, authenticated user.
+		if (!preliminaryUser) return;
+
 		const shouldBlockSsoUser =
 			(isSamlCurrentAuthenticationMethod() || isOidcCurrentAuthenticationMethod()) &&
-			preliminaryUser?.role.slug !== GLOBAL_OWNER_ROLE.slug &&
-			!preliminaryUser?.settings?.allowSSOManualLogin;
+			preliminaryUser.role.slug !== GLOBAL_OWNER_ROLE.slug &&
+			!preliminaryUser.settings?.allowSSOManualLogin;
 
 		if (shouldBlockSsoUser) {
 			throw new AuthError('SSO is enabled, please log in with SSO');


### PR DESCRIPTION
## Summary

When SSO (SAML/OIDC) is enabled, a wrong password on the manual-login form returned `SSO is enabled, please log in with SSO` instead of the normal wrong-credentials error.

`EmailAuthHandler.handleLogin` returns `undefined` for a wrong password, and `validateSsoRestrictions` treated that `undefined` user as a blocked SSO user (all of its conditions are true for `undefined`), so it threw the SSO error before the wrong-credentials path ran. This was misleading for accounts that are actually allowed to log in manually (`allowSSOManualLogin = true`) — a mistyped password looked like an SSO policy block.

The fix skips the SSO restriction check when there is no eligible user, so a failed password falls through to the existing `Wrong username or password. Do you have caps lock on?` error. A user who is genuinely restricted from manual login (real account, correct password, no `allowSSOManualLogin`) is still blocked exactly as before.

## How to test

```
pnpm --filter n8n test src/controllers/__tests__/auth.controller.test.ts
```

Added a regression test covering a wrong password while SSO is enabled. It fails on the old behaviour (returns the SSO error) and passes with the fix.

Fixes #31818
