### PR TITLE
fix(editor): Improve API key scopes select-all accessibility

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -3295,7 +3295,7 @@
 	"settings.api.view.modal.done.button": "Done",
 	"settings.api.view.modal.save.button": "Save",
 	"settings.api.scopes.placeholder": "Select",
-	"settings.api.scopes.selectAll": "Select All",
+	"settings.api.scopes.selectAll": "Select all scopes",
 	"settings.api.scopes.label": "Scopes",
 	"settings.version": "Version",
 	"settings.usageAndPlan.title": "Usage and plan",

--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyScopes.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyScopes.test.ts
@@ -1,0 +1,45 @@
+import { createComponentRenderer } from '@/__tests__/render';
+import userEvent from '@testing-library/user-event';
+
+import ApiKeyScopes from './ApiKeyScopes.vue';
+
+const availableScopes = ['user:create', 'user:list'];
+
+const renderComponent = createComponentRenderer(ApiKeyScopes, {
+	props: {
+		modelValue: ['user:create'],
+		availableScopes,
+	},
+});
+
+describe('ApiKeyScopes', () => {
+	it('renders select-all as a standalone checkbox outside the scopes select', async () => {
+		const { emitted, getByRole, getByTestId } = renderComponent();
+
+		const selectAllCheckbox = getByRole('checkbox', { name: /select all scopes/i });
+		const scopesSelect = getByTestId('scopes-select');
+
+		expect(selectAllCheckbox).toBeInTheDocument();
+		expect(scopesSelect).not.toContainElement(selectAllCheckbox);
+
+		await userEvent.click(selectAllCheckbox);
+
+		expect(emitted('update:modelValue')).toContainEqual([availableScopes]);
+	});
+
+	it('clears all scopes when the standalone select-all checkbox is unchecked', async () => {
+		const { emitted, getByRole } = renderComponent({
+			props: {
+				modelValue: availableScopes,
+			},
+		});
+
+		const selectAllCheckbox = getByRole('checkbox', { name: /select all scopes/i });
+
+		expect(selectAllCheckbox).toBeChecked();
+
+		await userEvent.click(selectAllCheckbox);
+
+		expect(emitted('update:modelValue')).toContainEqual([[]]);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyScopes.vue
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyScopes.vue
@@ -23,9 +23,19 @@ const selectedScopes = ref(props.modelValue);
 
 const i18n = useI18n();
 
-const checkAll = ref(false);
-const indeterminate = ref(false);
 const popperContainer = ref(null);
+
+const allScopesSelected = computed(() => {
+	return (
+		props.availableScopes.length > 0 && selectedScopes.value.length === props.availableScopes.length
+	);
+});
+
+const indeterminate = computed(() => {
+	return (
+		selectedScopes.value.length > 0 && selectedScopes.value.length < props.availableScopes.length
+	);
+});
 
 const groupedScopes = computed(() => {
 	const groups = {};
@@ -46,31 +56,25 @@ const groupedScopes = computed(() => {
 });
 
 watch(selectedScopes, (newValue) => {
-	if (newValue.length === props.availableScopes.length) {
-		indeterminate.value = false;
-		checkAll.value = true;
-	} else if (newValue.length > 0) {
-		indeterminate.value = true;
-	} else if (newValue.length === 0) {
-		indeterminate.value = false;
-		checkAll.value = false;
-	}
 	emit('update:modelValue', newValue);
 });
 
-watch(checkAll, (newValue) => {
-	if (newValue) {
-		selectedScopes.value = props.availableScopes;
-	} else {
-		selectedScopes.value = [];
-	}
-});
+function onSelectAllScopes(shouldSelectAll) {
+	selectedScopes.value = shouldSelectAll ? [...props.availableScopes] : [];
+}
 </script>
 
 <template>
 	<div :class="$style['api-key-scopes']">
 		<div ref="popperContainer"></div>
 		<N8nInputLabel :label="i18n.baseText('settings.api.scopes.label')" color="text-dark">
+			<N8nCheckbox
+				:model-value="allScopesSelected"
+				:class="$style['scopes-checkbox']"
+				:indeterminate="indeterminate"
+				:label="i18n.baseText('settings.api.scopes.selectAll')"
+				@update:model-value="onSelectAllScopes"
+			/>
 			<ElSelect
 				v-model="selectedScopes"
 				data-test-id="scopes-select"
@@ -84,15 +88,6 @@ watch(checkAll, (newValue) => {
 				:placeholder="i18n.baseText('settings.api.scopes.placeholder')"
 				:append-to="popperContainer"
 			>
-				<template #header>
-					<N8nCheckbox
-						v-model="checkAll"
-						:class="$style['scopes-checkbox']"
-						:indeterminate="indeterminate"
-						:label="i18n.baseText('settings.api.scopes.selectAll')"
-					/>
-				</template>
-
 				<template v-for="(actions, resource) in groupedScopes" :key="resource">
 					<ElOptionGroup :label="capitalCase(resource).toUpperCase()">
 						<ElOption
@@ -151,7 +146,7 @@ watch(checkAll, (newValue) => {
 
 .scopes-checkbox {
 	display: flex;
-	margin-left: var(--spacing--2xs);
+	margin-bottom: var(--spacing--2xs);
 }
 
 .scopes-dropdown-container :global(.el-select-group__wrap::after) {


### PR DESCRIPTION
## Summary

Moves the API key scopes select-all control out of the multi-select dropdown and renders it as a standalone checkbox. This avoids nesting a checkbox inside the combobox/listbox popup and makes the control easier for screen readers such as NVDA to discover and operate.

Closes #31821

## How to test

1. Start n8n locally.
2. Set up or log into an owner account.
3. Go to Settings > API Keys.
4. Click Create API Key.
5. Navigate to the Scopes section with a screen reader.
6. Confirm “Select all scopes” is announced as a standalone checkbox.
7. Toggle it on and off and confirm all scopes are selected or cleared.

Manual testing:

- Verified locally with NVDA on Windows.

Automated checks run:

- `pnpm test src/features/settings/apiKeys/components/ApiKeyScopes.test.ts`
- `pnpm test src/features/settings/apiKeys/components/ApiKeyCreateOrEditModal.test.ts`
- `pnpm typecheck`
- scoped lint/stylelint checks

## Related Linear tickets, Github issues, and Community forum posts

Closes #31821

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created. Not applicable: this is a small editor accessibility fix with no docs changes.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
