### PR TITLE
fix(nodes-base): Fix execute context binding in Wait, Form, and Peekalink nodes (#31513)

### DIFF
--- a/packages/nodes-base/nodes/Form/Form.node.ts
+++ b/packages/nodes-base/nodes/Form/Form.node.ts
@@ -450,7 +450,7 @@ export class Form extends Node {
 		}
 
 		const parentNodes = context.getParentNodes(context.getNode().name);
-		const hasFormTrigger = parentNodes.some((node) => node.type === FORM_TRIGGER_NODE_TYPE);
+		const hasFormTrigger = parentNodes.some((node: import('n8n-workflow').INode) => node.type === FORM_TRIGGER_NODE_TYPE);
 
 		if (!hasFormTrigger) {
 			throw new NodeOperationError(
@@ -460,7 +460,7 @@ export class Form extends Node {
 		}
 
 		const childNodes = context.getChildNodes(context.getNode().name);
-		const hasNextPage = childNodes.some((node) => node.type === FORM_NODE_TYPE);
+		const hasNextPage = childNodes.some((node: import('n8n-workflow').INode) => node.type === FORM_NODE_TYPE);
 
 		if (operation === 'completion' && hasNextPage) {
 			throw new NodeOperationError(

--- a/packages/nodes-base/nodes/Form/Form.node.ts
+++ b/packages/nodes-base/nodes/Form/Form.node.ts
@@ -434,7 +434,15 @@ export class Form extends Node {
 		};
 	}
 
-	async execute(context: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+	async execute(
+		this: IExecuteFunctions | Form,
+		contextOrResponse?: IExecuteFunctions | import('n8n-workflow').EngineResponse,
+	): Promise<INodeExecutionData[][]> {
+		const context =
+			contextOrResponse && 'getNodeParameter' in contextOrResponse
+				? (contextOrResponse as IExecuteFunctions)
+				: (this as unknown as IExecuteFunctions);
+
 		const operation = context.getNodeParameter('operation', 0);
 
 		if (operation === 'completion') {

--- a/packages/nodes-base/nodes/Peekalink/Peekalink.node.ts
+++ b/packages/nodes-base/nodes/Peekalink/Peekalink.node.ts
@@ -79,7 +79,7 @@ export class Peekalink extends Node {
 		const operation = context.getNodeParameter('operation', 0) as Operation;
 
 		const returnData = await Promise.all(
-			items.map(async (_, i) => {
+			items.map(async (_: import('n8n-workflow').INodeExecutionData, i: number) => {
 				try {
 					const link = context.getNodeParameter('url', i) as string;
 					// eslint-disable-next-line @typescript-eslint/no-unsafe-return

--- a/packages/nodes-base/nodes/Peekalink/Peekalink.node.ts
+++ b/packages/nodes-base/nodes/Peekalink/Peekalink.node.ts
@@ -66,7 +66,15 @@ export class Peekalink extends Node {
 		],
 	};
 
-	async execute(context: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+	async execute(
+		this: IExecuteFunctions | Peekalink,
+		contextOrResponse?: IExecuteFunctions | import('n8n-workflow').EngineResponse,
+	): Promise<INodeExecutionData[][]> {
+		const context =
+			contextOrResponse && 'getNodeParameter' in contextOrResponse
+				? (contextOrResponse as IExecuteFunctions)
+				: (this as unknown as IExecuteFunctions);
+
 		const items = context.getInputData();
 		const operation = context.getNodeParameter('operation', 0) as Operation;
 

--- a/packages/nodes-base/nodes/Wait/Wait.node.ts
+++ b/packages/nodes-base/nodes/Wait/Wait.node.ts
@@ -506,7 +506,7 @@ export class Wait extends Webhook {
 
 	async execute(
 		this: IExecuteFunctions | Wait,
-		contextOrResponse?: IExecuteFunctions | EngineResponse,
+		contextOrResponse?: IExecuteFunctions | import('n8n-workflow').EngineResponse,
 	): Promise<INodeExecutionData[][]> {
 		const context =
 			contextOrResponse && 'getNodeParameter' in contextOrResponse
@@ -527,7 +527,7 @@ export class Wait extends Webhook {
 				context.setMetadata({ resumeFormUrl });
 
 				const parentNodes = context.getParentNodes(context.getNode().name);
-				hasFormTrigger = parentNodes.some((node) => node.type === FORM_TRIGGER_NODE_TYPE);
+				hasFormTrigger = parentNodes.some((node: import('n8n-workflow').INode) => node.type === FORM_TRIGGER_NODE_TYPE);
 			}
 
 			if (resume === 'webhook') {
@@ -536,7 +536,7 @@ export class Wait extends Webhook {
 				context.setMetadata({ resumeUrl });
 			}
 
-			const returnData = await this.configureAndPutToWait(context);
+			const returnData = await configureAndPutToWait(context);
 
 			if (resume === 'form' && hasFormTrigger) {
 				context.sendResponse({
@@ -614,10 +614,11 @@ export class Wait extends Webhook {
 		}
 
 		// If longer than 65 seconds put execution to wait
-		return await this.putToWait(context, waitTill);
+		return await putToWait(context, waitTill);
 	}
+}
 
-	private async configureAndPutToWait(context: IExecuteFunctions) {
+async function configureAndPutToWait(context: IExecuteFunctions) {
 		let waitTill = WAIT_INDEFINITELY;
 		const limitWaitTime = context.getNodeParameter('limitWaitTime', 0);
 
@@ -645,11 +646,10 @@ export class Wait extends Webhook {
 			}
 		}
 
-		return await this.putToWait(context, waitTill);
-	}
+		return await putToWait(context, waitTill);
+}
 
-	private async putToWait(context: IExecuteFunctions, waitTill: Date) {
-		await context.putExecutionToWait(waitTill);
-		return [context.getInputData()];
-	}
+async function putToWait(context: IExecuteFunctions, waitTill: Date) {
+	await context.putExecutionToWait(waitTill);
+	return [context.getInputData()];
 }

--- a/packages/nodes-base/nodes/Wait/Wait.node.ts
+++ b/packages/nodes-base/nodes/Wait/Wait.node.ts
@@ -504,7 +504,15 @@ export class Wait extends Webhook {
 		return await super.webhook(context);
 	}
 
-	async execute(context: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+	async execute(
+		this: IExecuteFunctions | Wait,
+		contextOrResponse?: IExecuteFunctions | EngineResponse,
+	): Promise<INodeExecutionData[][]> {
+		const context =
+			contextOrResponse && 'getNodeParameter' in contextOrResponse
+				? (contextOrResponse as IExecuteFunctions)
+				: (this as unknown as IExecuteFunctions);
+
 		const resume = context.getNodeParameter('resume', 0) as string;
 
 		if (['webhook', 'form'].includes(resume)) {


### PR DESCRIPTION
## Problem
Fixes #31513 (and implicitly protects `Form` and `Peekalink` nodes from the same issue).

When n8n is installed in a way that causes `n8n-workflow` module duplication (e.g., via global `npm install` where package versions slightly mismatch), the `nodeType instanceof Node` check inside `WorkflowExecute.executeNode` evaluates to `false`. 

Because of this, the core execution engine falls back to calling `nodeType.execute.call(context, subNodeExecutionResults)`. Since `Wait`, `Form`, and `Peekalink` expected the `context` to be passed as the *first parameter* instead of bound to `this`, `context` ended up being assigned the `subNodeExecutionResults` object. This caused crashes later down the line such as `context.getNodeParameter is not a function`.

## Solution
Updated the method signatures for `execute` in `Wait`, `Form`, and `Peekalink` to be resilient against the `instanceof Node` evaluation failure. The methods now dynamically check if `contextOrResponse` has execution context methods, falling back to `this` as the context if executed via `.call()`. 

Additionally:
- Moved `configureAndPutToWait` and `putToWait` to be standalone functions in `Wait.node.ts` to allow execution decoupled from the `this` class instance.
- Patched implicit TypeScript `any` typings that surfaced during the structural changes.
