### PR TITLE
feat(core): Add safe axios factory and enforce it for outbound HTTP

### DIFF
--- a/packages/@n8n/eslint-config/src/rules/index.ts
+++ b/packages/@n8n/eslint-config/src/rules/index.ts
@@ -18,6 +18,7 @@ import { NoInternalPackageImportRule } from './no-internal-package-import.js';
 import { NoImportEnterpriseEditionRule } from './no-import-enterprise-edition.js';
 import { NoTypeOnlyImportInDiRule } from './no-type-only-import-in-di.js';
 import { NoErrorInstanceInToThrowRule } from './no-error-instance-in-to-throw.js';
+import { NoUnprotectedAxiosRule } from './no-unprotected-axios.js';
 
 export const rules = {
 	'no-uncaught-json-parse': NoUncaughtJsonParseRule,
@@ -39,4 +40,5 @@ export const rules = {
 	'no-import-enterprise-edition': NoImportEnterpriseEditionRule,
 	'no-type-only-import-in-di': NoTypeOnlyImportInDiRule,
 	'no-error-instance-in-to-throw': NoErrorInstanceInToThrowRule,
+	'no-unprotected-axios': NoUnprotectedAxiosRule,
 } satisfies Record<string, AnyRuleModule>;

--- a/packages/@n8n/eslint-config/src/rules/no-unprotected-axios.test.ts
+++ b/packages/@n8n/eslint-config/src/rules/no-unprotected-axios.test.ts
@@ -1,0 +1,58 @@
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import { NoUnprotectedAxiosRule } from './no-unprotected-axios.js';
+
+const ruleTester = new RuleTester();
+
+ruleTester.run('no-unprotected-axios', NoUnprotectedAxiosRule, {
+	valid: [
+		// Type-only imports never make requests.
+		{ code: "import type { AxiosInstance } from 'axios';" },
+		{ code: "import { type AxiosRequestConfig } from 'axios';" },
+		// Non-request members are allowed (error handling, type guards, helpers).
+		{ code: "import axios from 'axios'; const isErr = axios.isAxiosError(error);" },
+		{ code: "import axios from 'axios'; const uri = axios.getUri(config);" },
+		// Instances created elsewhere (e.g. the factory) are not the raw default export.
+		{ code: "const client = factory.create(); await client.get('https://example.com');" },
+		// Unrelated identifiers named like methods.
+		{ code: "import axios from 'axios'; const x = obj.get('key');" },
+		// Files matched by the `allow` option are exempt (e.g. the factory itself).
+		{
+			code: "import axios from 'axios'; const client = axios.create();",
+			filename: '/repo/packages/cli/src/services/ssrf/safe-axios.factory.ts',
+			options: [{ allow: ['safe-axios.factory'] }],
+		},
+	],
+
+	invalid: [
+		{
+			code: "import axios from 'axios'; await axios.get('https://example.com');",
+			errors: [{ messageId: 'useFactory', data: { member: 'get' } }],
+		},
+		{
+			code: "import axios from 'axios'; await axios.post(url, body);",
+			errors: [{ messageId: 'useFactory', data: { member: 'post' } }],
+		},
+		{
+			code: "import axios from 'axios'; const client = axios.create({ baseURL });",
+			errors: [{ messageId: 'useFactory', data: { member: 'create' } }],
+		},
+		{
+			code: "import axios from 'axios'; await axios.request(config);",
+			errors: [{ messageId: 'useFactory', data: { member: 'request' } }],
+		},
+		{
+			code: "import axios from 'axios'; await axios(config);",
+			errors: [{ messageId: 'useFactory', data: { member: 'axios' } }],
+		},
+		// Renamed default import is still tracked.
+		{
+			code: "import http from 'axios'; await http.get('https://example.com');",
+			errors: [{ messageId: 'useFactory', data: { member: 'get' } }],
+		},
+		// Namespace import is still tracked.
+		{
+			code: "import * as axios from 'axios'; await axios.get('https://example.com');",
+			errors: [{ messageId: 'useFactory', data: { member: 'get' } }],
+		},
+	],
+});

--- a/packages/@n8n/eslint-config/src/rules/no-unprotected-axios.ts
+++ b/packages/@n8n/eslint-config/src/rules/no-unprotected-axios.ts
@@ -1,0 +1,105 @@
+import { ESLintUtils, type TSESTree } from '@typescript-eslint/utils';
+
+/**
+ * Axios members that initiate an outbound HTTP request (or build a request
+ * instance). Using these on the raw `axios` import bypasses SSRF protection.
+ * Non-request members such as `isAxiosError`, `AxiosError`, `AxiosHeaders` and
+ * `getUri` are intentionally excluded.
+ */
+const REQUEST_MEMBERS = new Set([
+	'create',
+	'request',
+	'get',
+	'delete',
+	'head',
+	'options',
+	'post',
+	'put',
+	'patch',
+	'postForm',
+	'putForm',
+	'patchForm',
+	'all',
+]);
+
+type Options = [{ allow?: string[] }];
+
+export const NoUnprotectedAxiosRule = ESLintUtils.RuleCreator.withoutDocs<Options, 'useFactory'>({
+	meta: {
+		type: 'problem',
+		docs: {
+			description:
+				'Disallow using the raw `axios` import for HTTP requests. Use `SafeAxiosFactory.create()` so outbound requests are protected against SSRF, or `createUnsafe()` for trusted, hardcoded endpoints.',
+		},
+		messages: {
+			useFactory:
+				'Do not call `axios.{{member}}` directly — it bypasses SSRF protection. Inject `SafeAxiosFactory` and use `create()` (or `createUnsafe()` for trusted, hardcoded endpoints). If this call is intentionally unprotected, disable this rule on the line with a justifying comment.',
+		},
+		schema: [
+			{
+				type: 'object',
+				properties: {
+					allow: {
+						type: 'array',
+						items: { type: 'string' },
+						description: 'Filename substrings that are exempt from this rule.',
+					},
+				},
+				additionalProperties: false,
+			},
+		],
+	},
+	defaultOptions: [{ allow: [] }],
+	create(context, [options]) {
+		const allow = options?.allow ?? [];
+		if (allow.some((pattern) => context.filename.includes(pattern))) {
+			return {};
+		}
+
+		// Local names bound to a *value* import of the axios default/namespace export.
+		const axiosNames = new Set<string>();
+
+		return {
+			ImportDeclaration(node) {
+				if (node.source.value !== 'axios') return;
+				// `import type ... from 'axios'` is types-only and safe.
+				if (node.importKind === 'type') return;
+
+				for (const specifier of node.specifiers) {
+					if (
+						specifier.type === 'ImportDefaultSpecifier' ||
+						specifier.type === 'ImportNamespaceSpecifier'
+					) {
+						axiosNames.add(specifier.local.name);
+					}
+				}
+			},
+
+			// `axios.get(...)`, `axios.create(...)`, etc.
+			'MemberExpression[object.type="Identifier"]'(node: TSESTree.MemberExpression) {
+				const object = node.object as TSESTree.Identifier;
+				if (!axiosNames.has(object.name)) return;
+				if (node.property.type !== 'Identifier') return;
+				if (!REQUEST_MEMBERS.has(node.property.name)) return;
+
+				context.report({
+					node,
+					messageId: 'useFactory',
+					data: { member: node.property.name },
+				});
+			},
+
+			// `axios(config)` — calling the default export directly.
+			'CallExpression[callee.type="Identifier"]'(node: TSESTree.CallExpression) {
+				const callee = node.callee as TSESTree.Identifier;
+				if (!axiosNames.has(callee.name)) return;
+
+				context.report({
+					node,
+					messageId: 'useFactory',
+					data: { member: callee.name },
+				});
+			},
+		};
+	},
+});

--- a/packages/cli/eslint.config.mjs
+++ b/packages/cli/eslint.config.mjs
@@ -134,4 +134,18 @@ export default defineConfig(
 			'n8n-local-rules/no-constructor-in-backend-module': 'error',
 		},
 	},
+	{
+		// Outbound HTTP must go through SafeAxiosFactory so it is SSRF-protected.
+		// The factory itself is the one place allowed to touch the raw axios export.
+		// Currently `warn` while existing call sites are migrated; tighten to `error`
+		// once they are all either moved to the factory or explicitly marked unsafe.
+		files: ['./src/**/*.ts'],
+		ignores: ['./src/**/__tests__/**/*.ts', './test/**/*.ts'],
+		rules: {
+			'n8n-local-rules/no-unprotected-axios': [
+				'warn',
+				{ allow: ['services/ssrf/safe-axios.factory'] },
+			],
+		},
+	},
 );

--- a/packages/cli/src/controllers/oauth/__tests__/oauth1-credential.controller.test.ts
+++ b/packages/cli/src/controllers/oauth/__tests__/oauth1-credential.controller.test.ts
@@ -3,15 +3,12 @@ import { mockInstance } from '@n8n/backend-test-utils';
 import { type CredentialsEntity, type User } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
-import axios from 'axios';
 import type { Response } from 'express';
 import { OAuth1CredentialController } from '@/controllers/oauth/oauth1-credential.controller';
 import { EventService } from '@/events/event.service';
 import type { OAuthRequest } from '@/requests';
 import { OauthService } from '@/oauth/oauth.service';
 import { ExternalHooks } from '@/external-hooks';
-
-jest.mock('axios');
 
 describe('OAuth1CredentialController', () => {
 	const oauthService = mockInstance(OauthService);
@@ -111,9 +108,10 @@ describe('OAuth1CredentialController', () => {
 				{ accessTokenUrl: 'https://example.domain/oauth/access_token' },
 				mockState,
 			]);
-			jest
-				.mocked(axios.post)
-				.mockResolvedValueOnce({ data: 'oauth_token=token&oauth_token_secret=secret' } as any);
+			oauthService.exchangeOAuth1Token.mockResolvedValueOnce({
+				oauth_token: 'token',
+				oauth_token_secret: 'secret',
+			});
 
 			await controller.handleCallback(req, res);
 			// @ts-ignore
@@ -156,9 +154,10 @@ describe('OAuth1CredentialController', () => {
 				{ accessTokenUrl: 'https://example.domain/oauth/access_token' },
 				mockState,
 			]);
-			jest
-				.mocked(axios.post)
-				.mockResolvedValueOnce({ data: 'oauth_token=token&oauth_token_secret=secret' } as any);
+			oauthService.exchangeOAuth1Token.mockResolvedValueOnce({
+				oauth_token: 'token',
+				oauth_token_secret: 'secret',
+			});
 			oauthService.saveDynamicCredential.mockResolvedValueOnce(undefined);
 
 			await controller.handleCallback(dynamicReq, res);
@@ -211,9 +210,10 @@ describe('OAuth1CredentialController', () => {
 				{ accessTokenUrl: 'https://example.domain/oauth/access_token' },
 				mockState,
 			]);
-			jest
-				.mocked(axios.post)
-				.mockResolvedValueOnce({ data: 'oauth_token=token&oauth_token_secret=secret' } as any);
+			oauthService.exchangeOAuth1Token.mockResolvedValueOnce({
+				oauth_token: 'token',
+				oauth_token_secret: 'secret',
+			});
 			oauthService.saveDynamicCredential.mockResolvedValueOnce(undefined);
 
 			await controller.handleCallback(dynamicReq, res);
@@ -250,9 +250,10 @@ describe('OAuth1CredentialController', () => {
 				{ accessTokenUrl: 'https://example.domain/oauth/access_token' },
 				mockState,
 			]);
-			jest
-				.mocked(axios.post)
-				.mockResolvedValueOnce({ data: 'oauth_token=token&oauth_token_secret=secret' } as any);
+			oauthService.exchangeOAuth1Token.mockResolvedValueOnce({
+				oauth_token: 'token',
+				oauth_token_secret: 'secret',
+			});
 
 			await controller.handleCallback(dynamicReq, res);
 
@@ -288,9 +289,10 @@ describe('OAuth1CredentialController', () => {
 				{ accessTokenUrl: 'https://example.domain/oauth/access_token' },
 				mockState,
 			]);
-			jest
-				.mocked(axios.post)
-				.mockResolvedValueOnce({ data: 'oauth_token=token&oauth_token_secret=secret' } as any);
+			oauthService.exchangeOAuth1Token.mockResolvedValueOnce({
+				oauth_token: 'token',
+				oauth_token_secret: 'secret',
+			});
 
 			await controller.handleCallback(dynamicReq, res);
 
@@ -327,9 +329,10 @@ describe('OAuth1CredentialController', () => {
 				{ accessTokenUrl: 'https://example.domain/oauth/access_token' },
 				mockState,
 			]);
-			jest
-				.mocked(axios.post)
-				.mockResolvedValueOnce({ data: 'oauth_token=token&oauth_token_secret=secret' } as any);
+			oauthService.exchangeOAuth1Token.mockResolvedValueOnce({
+				oauth_token: 'token',
+				oauth_token_secret: 'secret',
+			});
 
 			await controller.handleCallback(dynamicReq, res);
 
@@ -364,9 +367,10 @@ describe('OAuth1CredentialController', () => {
 				{ accessTokenUrl: 'https://example.domain/oauth/access_token' },
 				mockState,
 			]);
-			jest
-				.mocked(axios.post)
-				.mockResolvedValueOnce({ data: 'oauth_token=token&oauth_token_secret=secret' } as any);
+			oauthService.exchangeOAuth1Token.mockResolvedValueOnce({
+				oauth_token: 'token',
+				oauth_token_secret: 'secret',
+			});
 
 			await controller.handleCallback(undefinedOriginReq, res);
 

--- a/packages/cli/src/controllers/oauth/oauth1-credential.controller.ts
+++ b/packages/cli/src/controllers/oauth/oauth1-credential.controller.ts
@@ -1,6 +1,5 @@
 import { Logger } from '@n8n/backend-common';
 import { Get, RestController } from '@n8n/decorators';
-import axios from 'axios';
 import { Response } from 'express';
 import { ensureError, jsonStringify } from 'n8n-workflow';
 
@@ -49,18 +48,10 @@ export class OAuth1CredentialController {
 			const [credential, _, oauthCredentials, state] =
 				await this.oauthService.resolveCredential<OAuth1CredentialData>(req);
 
-			// Form URL encoded body https://datatracker.ietf.org/doc/html/rfc5849#section-3.5.2
-			const oauthToken = await axios.post<string>(
+			const oauthTokenData = await this.oauthService.exchangeOAuth1Token(
 				oauthCredentials.accessTokenUrl,
 				{ oauth_token, oauth_verifier },
-				{ headers: { 'content-type': 'application/x-www-form-urlencoded' } },
 			);
-
-			// Response comes as x-www-form-urlencoded string so convert it to JSON
-
-			const paramParser = new URLSearchParams(oauthToken.data);
-
-			const oauthTokenData = Object.fromEntries(paramParser.entries());
 
 			if (!state.origin || state.origin === 'static-credential') {
 				await this.oauthService.encryptAndSaveData(credential, { oauthTokenData }, ['csrfSecret']);

--- a/packages/cli/src/modules/community-packages/npm-utils.ts
+++ b/packages/cli/src/modules/community-packages/npm-utils.ts
@@ -265,6 +265,7 @@ export async function executeNpmRequest<T = unknown>(
 	LoggerProxy.debug('Executing npm registry request', { url, headers: redactedHeaders, timeout });
 
 	try {
+		// eslint-disable-next-line n8n-local-rules/no-unprotected-axios -- Community package registries are admin-configured and commonly self-hosted on internal networks; intentionally not SSRF-protected
 		const { data } = await axios.get<T>(url, {
 			timeout,
 			headers: Object.keys(headers).length > 0 ? headers : undefined,

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-introspection-identifier.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-introspection-identifier.test.ts
@@ -1,9 +1,10 @@
 import { mockLogger } from '@n8n/backend-test-utils';
 import { Time } from '@n8n/constants';
-import axios from 'axios';
+import axios, { type AxiosInstance } from 'axios';
 import { mock } from 'jest-mock-extended';
 
 import type { CacheService } from '@/services/cache/cache.service';
+import type { SafeAxiosFactory } from '@/services/ssrf/safe-axios.factory';
 
 import { IdentifierValidationError } from '../identifier-interface';
 import { OAuth2TokenIntrospectionIdentifier } from '../oauth2-introspection-identifier';
@@ -14,6 +15,7 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 describe('OAuth2TokenIntrospectionIdentifier', () => {
 	const logger = mockLogger();
 	const cache = mock<CacheService>();
+	const safeAxiosFactory = mock<SafeAxiosFactory>();
 	let identifier: OAuth2TokenIntrospectionIdentifier;
 
 	const validOptions = {
@@ -45,7 +47,8 @@ describe('OAuth2TokenIntrospectionIdentifier', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
-		identifier = new OAuth2TokenIntrospectionIdentifier(logger, cache);
+		safeAxiosFactory.create.mockReturnValue(mockedAxios as unknown as AxiosInstance);
+		identifier = new OAuth2TokenIntrospectionIdentifier(logger, cache, safeAxiosFactory);
 		cache.get.mockResolvedValue(undefined);
 		cache.set.mockResolvedValue();
 	});

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-userinfo-identifier.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/oauth2-userinfo-identifier.test.ts
@@ -1,9 +1,10 @@
 import { mockLogger } from '@n8n/backend-test-utils';
 import { Time } from '@n8n/constants';
-import axios from 'axios';
+import axios, { type AxiosInstance } from 'axios';
 import { mock } from 'jest-mock-extended';
 
 import type { CacheService } from '@/services/cache/cache.service';
+import type { SafeAxiosFactory } from '@/services/ssrf/safe-axios.factory';
 
 import { IdentifierValidationError } from '../identifier-interface';
 import { OAuth2UserInfoIdentifier } from '../oauth2-userinfo-identifier';
@@ -14,6 +15,7 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 describe('OAuth2UserInfoIdentifier', () => {
 	const logger = mockLogger();
 	const cache = mock<CacheService>();
+	const safeAxiosFactory = mock<SafeAxiosFactory>();
 	let identifier: OAuth2UserInfoIdentifier;
 
 	const validOptions = {
@@ -40,7 +42,8 @@ describe('OAuth2UserInfoIdentifier', () => {
 
 	beforeEach(() => {
 		jest.clearAllMocks();
-		identifier = new OAuth2UserInfoIdentifier(logger, cache);
+		safeAxiosFactory.create.mockReturnValue(mockedAxios as unknown as AxiosInstance);
+		identifier = new OAuth2UserInfoIdentifier(logger, cache, safeAxiosFactory);
 		cache.get.mockResolvedValue(undefined);
 		cache.set.mockResolvedValue();
 	});

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-introspection-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-introspection-identifier.ts
@@ -1,11 +1,12 @@
 import { Logger } from '@n8n/backend-common';
 import { Time } from '@n8n/constants';
 import { Service } from '@n8n/di';
-import axios from 'axios';
+import type { AxiosInstance } from 'axios';
 import type { ICredentialContext } from 'n8n-workflow';
 import { z } from 'zod';
 
 import { CacheService } from '@/services/cache/cache.service';
+import { SafeAxiosFactory } from '@/services/ssrf/safe-axios.factory';
 
 import { IdentifierValidationError, ITokenIdentifier } from './identifier-interface';
 import { OAuth2OptionsSchema, sha256 } from './oauth2-utils';
@@ -62,10 +63,15 @@ const CACHE_PREFIX = 'oauth2-introspection-identifier';
 
 @Service()
 export class OAuth2TokenIntrospectionIdentifier implements ITokenIdentifier {
+	private readonly httpClient: AxiosInstance;
+
 	constructor(
 		private readonly logger: Logger,
 		private readonly cache: CacheService,
-	) {}
+		safeAxiosFactory: SafeAxiosFactory,
+	) {
+		this.httpClient = safeAxiosFactory.create();
+	}
 
 	async validateOptions(identifierOptions: Record<string, unknown>): Promise<void> {
 		const options = this.parseOptions(identifierOptions);
@@ -158,7 +164,7 @@ export class OAuth2TokenIntrospectionIdentifier implements ITokenIdentifier {
 			}
 		}
 
-		const response = await axios.get(options.metadataUri, {
+		const response = await this.httpClient.get(options.metadataUri, {
 			validateStatus: () => true,
 			timeout: 10 * Time.seconds.toMilliseconds,
 		});
@@ -254,7 +260,7 @@ export class OAuth2TokenIntrospectionIdentifier implements ITokenIdentifier {
 			...authParams,
 		});
 
-		const response = await axios.post(metadata.introspection_endpoint, params, {
+		const response = await this.httpClient.post(metadata.introspection_endpoint, params, {
 			headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...authHeaders },
 			validateStatus: () => true,
 			timeout: 10 * Time.seconds.toMilliseconds,

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-userinfo-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/oauth2-userinfo-identifier.ts
@@ -1,11 +1,12 @@
 import { Logger } from '@n8n/backend-common';
 import { Time } from '@n8n/constants';
 import { Service } from '@n8n/di';
-import axios from 'axios';
+import type { AxiosInstance } from 'axios';
 import type { ICredentialContext } from 'n8n-workflow';
 import { z } from 'zod';
 
 import { CacheService } from '@/services/cache/cache.service';
+import { SafeAxiosFactory } from '@/services/ssrf/safe-axios.factory';
 
 import { IdentifierValidationError, ITokenIdentifier } from './identifier-interface';
 import { OAuth2OptionsSchema, sha256 } from './oauth2-utils';
@@ -44,10 +45,15 @@ const CACHE_PREFIX = 'oauth2-userinfo-identifier';
 
 @Service()
 export class OAuth2UserInfoIdentifier implements ITokenIdentifier {
+	private readonly httpClient: AxiosInstance;
+
 	constructor(
 		private readonly logger: Logger,
 		private readonly cache: CacheService,
-	) {}
+		safeAxiosFactory: SafeAxiosFactory,
+	) {
+		this.httpClient = safeAxiosFactory.create();
+	}
 
 	async validateOptions(identifierOptions: Record<string, unknown>): Promise<void> {
 		const options = this.parseOptions(identifierOptions);
@@ -126,7 +132,7 @@ export class OAuth2UserInfoIdentifier implements ITokenIdentifier {
 			}
 		}
 
-		const response = await axios.get(options.metadataUri, {
+		const response = await this.httpClient.get(options.metadataUri, {
 			validateStatus: () => true,
 			timeout: 10 * Time.seconds.toMilliseconds,
 		});
@@ -166,7 +172,7 @@ export class OAuth2UserInfoIdentifier implements ITokenIdentifier {
 		options: OAuth2UserInfoOptions,
 		context: ICredentialContext,
 	): Promise<{ subject: string; ttl?: number }> {
-		const response = await axios.get(metadata.userinfo_endpoint, {
+		const response = await this.httpClient.get(metadata.userinfo_endpoint, {
 			headers: { authorization: `Bearer ${context.identity}` },
 			validateStatus: () => true,
 			timeout: 10 * Time.seconds.toMilliseconds,

--- a/packages/cli/src/modules/external-secrets.ee/providers/vault.ts
+++ b/packages/cli/src/modules/external-secrets.ee/providers/vault.ts
@@ -271,6 +271,7 @@ export class VaultProvider extends SecretsProvider {
 
 		const baseURL = new URL(this.settings.url);
 
+		// eslint-disable-next-line n8n-local-rules/no-unprotected-axios -- HashiCorp Vault is admin-configured infrastructure that commonly runs on a private/internal address; intentionally not SSRF-protected
 		this.#http = axios.create({ baseURL: baseURL.toString() });
 		if (this.settings.namespace) {
 			this.#http.interceptors.request.use((config) => {

--- a/packages/cli/src/modules/log-streaming.ee/destinations/message-event-bus-destination-webhook.ee.ts
+++ b/packages/cli/src/modules/log-streaming.ee/destinations/message-event-bus-destination-webhook.ee.ts
@@ -109,6 +109,7 @@ export class MessageEventBusDestinationWebhook
 
 		const axiosSetting = this.buildAxiosSetting(options);
 
+		// eslint-disable-next-line n8n-local-rules/no-unprotected-axios -- Log-streaming webhook destinations are admin-configured and may legitimately point to internal collectors; intentionally not SSRF-protected
 		this.axiosInstance = axios.create(axiosSetting);
 
 		this.logger.debug(`MessageEventBusDestinationWebhook with id ${this.getId()} initialized`);

--- a/packages/cli/src/modules/sso-saml/saml.service.ee.ts
+++ b/packages/cli/src/modules/sso-saml/saml.service.ee.ts
@@ -692,6 +692,7 @@ export class SamlService {
 			);
 			const httpAgent = createHttpProxyAgent(null, url);
 
+			// eslint-disable-next-line n8n-local-rules/no-unprotected-axios -- SAML IdP metadata URLs are admin-configured and may legitimately point to internal hosts; intentionally not SSRF-protected
 			const response = await axios.get(url, {
 				httpsAgent,
 				httpAgent,

--- a/packages/cli/src/oauth/__tests__/oauth.service.test.ts
+++ b/packages/cli/src/oauth/__tests__/oauth.service.test.ts
@@ -5,6 +5,7 @@ import { GlobalConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
 import type { AuthenticatedRequest, CredentialsEntity, ICredentialsDb, User } from '@n8n/db';
 import { CredentialsRepository } from '@n8n/db';
+import type { AxiosInstance } from 'axios';
 import type { Request, Response } from 'express';
 import { mock } from 'jest-mock-extended';
 import type { Cipher } from 'n8n-core';
@@ -31,11 +32,11 @@ import {
 	type OAuth1CredentialData,
 } from '@/oauth/oauth.service';
 import type { OAuthRequest } from '@/requests';
+import { SafeAxiosFactory } from '@/services/ssrf/safe-axios.factory';
 import { UrlService } from '@/services/url.service';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 
 jest.mock('@/workflow-execute-additional-data');
-jest.mock('axios');
 jest.mock('@n8n/client-oauth2');
 jest.mock('pkce-challenge');
 
@@ -53,8 +54,10 @@ describe('OauthService', () => {
 	const oauthJweServiceProxy = mockInstance(OAuthJweServiceProxy);
 	const browserBindingService = mockInstance(OAuthBrowserBindingService);
 	const eventService = mockInstance(EventService);
+	const safeAxiosFactory = mockInstance(SafeAxiosFactory);
 
 	let service: OauthService;
+	let httpClientMock: { get: jest.Mock; post: jest.Mock; request: jest.Mock };
 
 	const timestamp = 1706750625678;
 	jest.useFakeTimers({ advanceTimers: true });
@@ -71,10 +74,9 @@ describe('OauthService', () => {
 			.mockResolvedValue(mock<IWorkflowExecuteAdditionalData>());
 		externalHooks.run.mockResolvedValue(undefined);
 
-		// Setup axios mock
-		const axios = require('axios');
-		axios.get = jest.fn();
-		axios.post = jest.fn();
+		// Setup the SSRF-protected http client mock returned by the factory
+		httpClientMock = { get: jest.fn(), post: jest.fn(), request: jest.fn() };
+		safeAxiosFactory.create.mockReturnValue(httpClientMock as unknown as AxiosInstance);
 
 		cipher.encryptV2.mockImplementation(async (data: string | object) => {
 			const plaintext = typeof data === 'string' ? data : JSON.stringify(data);
@@ -98,6 +100,7 @@ describe('OauthService', () => {
 			oauthJweServiceProxy,
 			browserBindingService,
 			eventService,
+			safeAxiosFactory,
 		);
 	});
 
@@ -1783,7 +1786,7 @@ describe('OauthService', () => {
 		});
 
 		it('should handle dynamic client registration with root-level server URL', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
 			const mockGetUri = jest.fn().mockReturnValue({
 				toString: () =>
@@ -1845,7 +1848,7 @@ describe('OauthService', () => {
 				}),
 			);
 			// JWE fields are only added behind both feature gates (flag + jweEnabled).
-			const dcrPayload = (axios.post as jest.Mock).mock.calls[0][1];
+			const dcrPayload = axios.post.mock.calls[0][1];
 			expect(dcrPayload).not.toHaveProperty('jwks_uri');
 			expect(dcrPayload).not.toHaveProperty('id_token_encrypted_response_alg');
 			expect(dcrPayload).not.toHaveProperty('id_token_encrypted_response_enc');
@@ -1868,7 +1871,7 @@ describe('OauthService', () => {
 		});
 
 		it('should throw BadRequestError when OAuth2 server metadata is invalid', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const credential = mock<CredentialsEntity>({ id: '1', type: 'googleOAuth2Api' });
 			const oauthCredentials = {
 				serverUrl: 'https://example.domain',
@@ -1897,7 +1900,7 @@ describe('OauthService', () => {
 		});
 
 		it('should throw BadRequestError when client registration response is invalid', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
 			jest.mocked(ClientOAuth2).mockImplementation(() => ({}) as any);
 
@@ -1940,7 +1943,7 @@ describe('OauthService', () => {
 		});
 
 		it('should handle dynamic client registration with client_secret_post authentication', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
 			const mockGetUri = jest.fn().mockReturnValue({
 				toString: () =>
@@ -2123,7 +2126,7 @@ describe('OauthService', () => {
 
 	describe('generateAOauth2AuthUri with DCR and RFC 8414 compliance', () => {
 		it('should insert .well-known between host and path per RFC 8414', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
 			const mockGetUri = jest.fn().mockReturnValue({
 				toString: () =>
@@ -2180,7 +2183,7 @@ describe('OauthService', () => {
 		});
 
 		it('should handle root-level issuer URLs (no path)', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
 			const mockGetUri = jest.fn().mockReturnValue({
 				toString: () =>
@@ -2236,7 +2239,7 @@ describe('OauthService', () => {
 		});
 
 		it('should handle issuer URLs with trailing slashes', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
 			const mockGetUri = jest.fn().mockReturnValue({
 				toString: () => 'https://example.domain/authorize?client_id=test_id',
@@ -2288,7 +2291,7 @@ describe('OauthService', () => {
 		});
 
 		it('should handle multi-segment paths correctly', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
 			const mockGetUri = jest.fn().mockReturnValue({
 				toString: () => 'https://oauth.example.com/authorize?client_id=test_id',
@@ -2340,7 +2343,7 @@ describe('OauthService', () => {
 		});
 
 		it('should fall back to OpenID Connect path insertion when RFC 8414 fails', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
 			const mockGetUri = jest.fn().mockReturnValue({
 				toString: () => 'https://example.domain/authorize?client_id=test_id',
@@ -2407,7 +2410,7 @@ describe('OauthService', () => {
 		});
 
 		it('should fall back to OpenID Connect path appending when first two fail', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
 			const mockGetUri = jest.fn().mockReturnValue({
 				toString: () => 'https://example.domain/authorize?client_id=test_id',
@@ -2479,7 +2482,7 @@ describe('OauthService', () => {
 		});
 
 		it('should fall back to origin-only discovery when path-aware variants fail (Atlassian MCP)', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
 			const mockGetUri = jest.fn().mockReturnValue({
 				toString: () => 'https://mcp.atlassian.com/authorize?client_id=test_id',
@@ -2553,7 +2556,7 @@ describe('OauthService', () => {
 		});
 
 		it('should throw error when all discovery endpoints fail', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const credential = mock<CredentialsEntity>({ id: '1', type: 'oAuth2Api' });
 			const oauthCredentials = {
 				serverUrl: 'https://example.domain/issuer1',
@@ -2586,7 +2589,7 @@ describe('OauthService', () => {
 		});
 
 		it('should discover authorization server via protected resource metadata (MCP flow)', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
 			const mockGetUri = jest.fn().mockReturnValue({
 				toString: () => 'https://auth.example.com/authorize?client_id=test_id',
@@ -2660,7 +2663,7 @@ describe('OauthService', () => {
 		});
 
 		it('should fall back to direct authorization server discovery when protected resource fails', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
 			const mockGetUri = jest.fn().mockReturnValue({
 				toString: () => 'https://example.domain/authorize?client_id=test_id',
@@ -2730,7 +2733,7 @@ describe('OauthService', () => {
 		});
 
 		it('should handle Smithery MCP server with path-specific protected resource discovery', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
 			const mockGetUri = jest.fn().mockReturnValue({
 				toString: () => 'https://auth.smithery.ai/authorize?client_id=test_id',
@@ -2801,7 +2804,7 @@ describe('OauthService', () => {
 		});
 
 		it('should handle Notion MCP server with root protected resource discovery', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
 			const mockGetUri = jest.fn().mockReturnValue({
 				toString: () => 'https://mcp.notion.com/authorize?client_id=test_id',
@@ -2879,7 +2882,7 @@ describe('OauthService', () => {
 		});
 
 		it('should handle VEED.io with fallback to authorization server discovery', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
 			const mockGetUri = jest.fn().mockReturnValue({
 				toString: () => 'https://www.veed.io/authorize?client_id=test_id',
@@ -2949,7 +2952,7 @@ describe('OauthService', () => {
 		});
 
 		it('should reject malicious authorization server URL from protected resource (SSRF protection)', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const credential = mock<CredentialsEntity>({ id: '1', type: 'mcpOAuth2Api' });
 			const oauthCredentials = {
 				serverUrl: 'https://malicious-mcp.example.com/mcp',
@@ -2981,7 +2984,7 @@ describe('OauthService', () => {
 		});
 
 		it('should succeed when server advertises only authorization_code without refresh_token', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
 			const mockGetUri = jest.fn().mockReturnValue({
 				toString: () => 'https://login.commonroom.io/authorize?client_id=test_id',
@@ -3037,7 +3040,7 @@ describe('OauthService', () => {
 		});
 
 		it('should not produce double /.well-known/ paths when authorization server URL already contains /.well-known/', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const { ClientOAuth2 } = await import('@n8n/client-oauth2');
 			const mockGetUri = jest.fn().mockReturnValue({
 				toString: () => 'https://example.domain/authorize?client_id=test_id',
@@ -3090,7 +3093,7 @@ describe('OauthService', () => {
 			});
 
 			// Verify the discovery URL used is the root-level one (no double /.well-known/)
-			const authServerDiscoveryCall = (axios.get as jest.Mock).mock.calls[2]; // after 2 protected resource calls
+			const authServerDiscoveryCall = axios.get.mock.calls[2]; // after 2 protected resource calls
 			expect(authServerDiscoveryCall[0]).not.toContain(
 				'/.well-known/openid-configuration/.well-known/',
 			);
@@ -3125,7 +3128,7 @@ describe('OauthService', () => {
 
 	describe('generateAOauth2AuthUri with DCR and JWE fields', () => {
 		beforeEach(() => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			jest.mocked(axios.get).mockResolvedValue({
 				data: {
 					authorization_endpoint: 'https://example.domain/oauth2/auth',
@@ -3174,8 +3177,8 @@ describe('OauthService', () => {
 				userId: 'user-id',
 			});
 
-			const axios = require('axios');
-			return (axios.post as jest.Mock).mock.calls[0][1];
+			const axios = httpClientMock;
+			return axios.post.mock.calls[0][1];
 		}
 
 		it.each([
@@ -3250,7 +3253,7 @@ describe('OauthService', () => {
 
 	describe('generateAOauth1AuthUri', () => {
 		it('should generate auth URI for OAuth1 credential', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const credential = mock<CredentialsEntity>({ id: '1', type: 'twitterOAuth1Api' });
 			const oauthCredentials: OAuth1CredentialData = {
 				consumerKey: 'consumer_key',
@@ -3305,7 +3308,7 @@ describe('OauthService', () => {
 		});
 
 		it('should generate auth URI with different signature methods', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const credential = mock<CredentialsEntity>({ id: '1', type: 'twitterOAuth1Api' });
 			const oauthCredentials: OAuth1CredentialData = {
 				consumerKey: 'consumer_key',
@@ -3333,7 +3336,7 @@ describe('OauthService', () => {
 		});
 
 		it('should handle request token URL errors', async () => {
-			const axios = require('axios');
+			const axios = httpClientMock;
 			const credential = mock<CredentialsEntity>({ id: '1', type: 'twitterOAuth1Api' });
 			const oauthCredentials: OAuth1CredentialData = {
 				consumerKey: 'consumer_key',

--- a/packages/cli/src/oauth/oauth.service.ts
+++ b/packages/cli/src/oauth/oauth.service.ts
@@ -21,6 +21,7 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import type { OAuthRequest } from '@/requests';
 import { validateOAuthUrl } from '@/oauth/validate-oauth-url';
+import { SafeAxiosFactory } from '@/services/ssrf/safe-axios.factory';
 import { UrlService } from '@/services/url.service';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
 import {
@@ -31,7 +32,7 @@ import {
 	type OAuth2CredentialData,
 	type OAuth2GrantType,
 } from '@n8n/client-oauth2';
-import axios from 'axios';
+import type { AxiosInstance, AxiosRequestConfig } from 'axios';
 import {
 	oAuthAuthorizationServerMetadataSchema,
 	dynamicClientRegistrationResponseSchema,
@@ -40,7 +41,6 @@ import pkceChallenge from 'pkce-challenge';
 import * as qs from 'querystring';
 import split from 'lodash/split';
 import { ExternalHooks } from '@/external-hooks';
-import type { AxiosRequestConfig } from 'axios';
 import { createHmac } from 'crypto';
 import type { RequestOptions } from 'oauth-1.0a';
 import clientOAuth1 from 'oauth-1.0a';
@@ -83,7 +83,13 @@ export class OauthService {
 		private readonly oauthJweServiceProxy: OAuthJweServiceProxy,
 		private readonly browserBindingService: OAuthBrowserBindingService,
 		private readonly eventService: EventService,
-	) {}
+		safeAxiosFactory: SafeAxiosFactory,
+	) {
+		this.httpClient = safeAxiosFactory.create();
+	}
+
+	/** SSRF-protected axios instance for outbound OAuth provider requests. */
+	private readonly httpClient: AxiosInstance;
 
 	private validateOAuthUrlOrThrow(url: string): void {
 		try {
@@ -634,7 +640,7 @@ export class OauthService {
 					// Validate each URL before making request (defense-in-depth)
 					this.validateOAuthUrlOrThrow(url);
 
-					const response = await axios.get<unknown>(url, {
+					const response = await this.httpClient.get<unknown>(url, {
 						validateStatus: (status) => status === 200,
 					});
 					data = response.data;
@@ -702,7 +708,7 @@ export class OauthService {
 
 			await this.externalHooks.run('oauth2.dynamicClientRegistration', [registerPayload]);
 
-			const { data: registerResult } = await axios.post<unknown>(
+			const { data: registerResult } = await this.httpClient.post<unknown>(
 				registration_endpoint,
 				registerPayload,
 			);
@@ -820,7 +826,7 @@ export class OauthService {
 			},
 		};
 
-		const { data: response } = await axios.request(axiosConfig);
+		const { data: response } = await this.httpClient.request(axiosConfig);
 
 		// Response comes as x-www-form-urlencoded string so convert it to JSON
 		if (typeof response !== 'string') {
@@ -848,6 +854,24 @@ export class OauthService {
 		});
 
 		return returnUri;
+	}
+
+	/**
+	 * Exchanges an OAuth1 verifier for an access token at the credential's
+	 * access token endpoint. Returns the parsed token data.
+	 */
+	async exchangeOAuth1Token(
+		accessTokenUrl: string,
+		params: { oauth_token: string; oauth_verifier: string },
+	): Promise<Record<string, string>> {
+		// Form URL encoded body https://datatracker.ietf.org/doc/html/rfc5849#section-3.5.2
+		const { data } = await this.httpClient.post<string>(accessTokenUrl, params, {
+			headers: { 'content-type': 'application/x-www-form-urlencoded' },
+		});
+
+		// Response comes as x-www-form-urlencoded string so convert it to JSON
+		const paramParser = new URLSearchParams(data);
+		return Object.fromEntries(paramParser.entries());
 	}
 
 	private convertCredentialToOptions(credential: OAuth2CredentialData): ClientOAuth2Options {
@@ -909,7 +933,7 @@ export class OauthService {
 				// Validate each URL before making request (defense-in-depth)
 				this.validateOAuthUrlOrThrow(discoveryUrl);
 
-				const { data } = await axios.get(discoveryUrl, {
+				const { data } = await this.httpClient.get(discoveryUrl, {
 					validateStatus: (status) => status === 200,
 				});
 

--- a/packages/cli/src/services/ssrf/__tests__/safe-axios.factory.test.ts
+++ b/packages/cli/src/services/ssrf/__tests__/safe-axios.factory.test.ts
@@ -1,0 +1,151 @@
+import { SsrfProtectionConfig } from '@n8n/config';
+import type { AxiosInstance, AxiosRequestConfig } from 'axios';
+import { mock } from 'jest-mock-extended';
+import { createResultError, createResultOk } from 'n8n-workflow';
+
+import { SafeAxiosFactory } from '../safe-axios.factory';
+import type { SsrfProtectionService } from '../ssrf-protection.service';
+
+function createConfig(overrides: Partial<SsrfProtectionConfig> = {}): SsrfProtectionConfig {
+	const config = new SsrfProtectionConfig();
+	Object.assign(config, overrides);
+	return config;
+}
+
+/** Accesses the registered request interceptor's fulfilled handler. */
+function getRequestInterceptor(instance: AxiosInstance) {
+	const manager = instance.interceptors.request as unknown as {
+		handlers: Array<{
+			fulfilled: (config: AxiosRequestConfig) => Promise<AxiosRequestConfig>;
+		} | null>;
+	};
+	return manager.handlers.filter((handler) => handler !== null);
+}
+
+describe('SafeAxiosFactory', () => {
+	const ssrfProtectionService = mock<SsrfProtectionService>();
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('create', () => {
+		it('registers a request interceptor when protection is enabled', () => {
+			const factory = new SafeAxiosFactory(
+				createConfig({ enabled: true }),
+				ssrfProtectionService,
+			);
+
+			const instance = factory.create();
+
+			expect(getRequestInterceptor(instance)).toHaveLength(1);
+		});
+
+		it('does not register a request interceptor when protection is disabled', () => {
+			const factory = new SafeAxiosFactory(
+				createConfig({ enabled: false }),
+				ssrfProtectionService,
+			);
+
+			const instance = factory.create();
+
+			expect(getRequestInterceptor(instance)).toHaveLength(0);
+		});
+
+		it('rejects the request when the target URL is blocked', async () => {
+			const factory = new SafeAxiosFactory(
+				createConfig({ enabled: true }),
+				ssrfProtectionService,
+			);
+			const error = new Error('blocked');
+			ssrfProtectionService.validateUrl.mockResolvedValue(createResultError(error));
+
+			const instance = factory.create();
+			const [interceptor] = getRequestInterceptor(instance);
+			const config: AxiosRequestConfig = { url: 'http://169.254.169.254/latest' };
+
+			await expect(interceptor.fulfilled(config)).rejects.toBe(error);
+			expect(ssrfProtectionService.validateUrl).toHaveBeenCalledWith(
+				'http://169.254.169.254/latest',
+			);
+		});
+
+		it('applies secure agents to the request config when the URL is allowed', async () => {
+			const factory = new SafeAxiosFactory(
+				createConfig({ enabled: true }),
+				ssrfProtectionService,
+			);
+			ssrfProtectionService.validateUrl.mockResolvedValue(createResultOk(undefined));
+			ssrfProtectionService.createSecureLookup.mockReturnValue(jest.fn());
+
+			const instance = factory.create();
+			const [interceptor] = getRequestInterceptor(instance);
+			const config: AxiosRequestConfig = { url: 'https://example.com/api' };
+
+			const result = await interceptor.fulfilled(config);
+
+			expect(result.httpsAgent).toBeDefined();
+			expect(result.httpAgent).toBeDefined();
+			expect(ssrfProtectionService.createSecureLookup).toHaveBeenCalled();
+		});
+	});
+
+	describe('createUnsafe', () => {
+		it('does not register the protection interceptor', () => {
+			const factory = new SafeAxiosFactory(
+				createConfig({ enabled: true }),
+				ssrfProtectionService,
+			);
+
+			const instance = factory.createUnsafe();
+
+			expect(getRequestInterceptor(instance)).toHaveLength(0);
+		});
+	});
+
+	describe('validateUrl', () => {
+		it('resolves without consulting the service when protection is disabled', async () => {
+			const factory = new SafeAxiosFactory(
+				createConfig({ enabled: false }),
+				ssrfProtectionService,
+			);
+
+			await expect(factory.validateUrl('http://10.0.0.1')).resolves.toBeUndefined();
+			expect(ssrfProtectionService.validateUrl).not.toHaveBeenCalled();
+		});
+
+		it('throws when the service reports the URL as blocked', async () => {
+			const factory = new SafeAxiosFactory(
+				createConfig({ enabled: true }),
+				ssrfProtectionService,
+			);
+			const error = new Error('blocked');
+			ssrfProtectionService.validateUrl.mockResolvedValue(createResultError(error));
+
+			await expect(factory.validateUrl('http://10.0.0.1')).rejects.toBe(error);
+		});
+	});
+
+	describe('secureLookup', () => {
+		it('returns undefined when protection is disabled', () => {
+			const factory = new SafeAxiosFactory(
+				createConfig({ enabled: false }),
+				ssrfProtectionService,
+			);
+
+			expect(factory.secureLookup()).toBeUndefined();
+			expect(ssrfProtectionService.createSecureLookup).not.toHaveBeenCalled();
+		});
+
+		it('returns the secure lookup function when protection is enabled', () => {
+			const factory = new SafeAxiosFactory(
+				createConfig({ enabled: true }),
+				ssrfProtectionService,
+			);
+			const lookup = jest.fn();
+			ssrfProtectionService.createSecureLookup.mockReturnValue(lookup);
+
+			expect(factory.secureLookup()).toBe(lookup);
+		});
+	});
+});

--- a/packages/cli/src/services/ssrf/safe-axios.factory.ts
+++ b/packages/cli/src/services/ssrf/safe-axios.factory.ts
@@ -1,0 +1,100 @@
+import { SsrfProtectionConfig } from '@n8n/config';
+import { Service } from '@n8n/di';
+import type { AxiosInstance, AxiosRequestConfig, CreateAxiosDefaults } from 'axios';
+import axios from 'axios';
+import { applyAxiosSsrfProtection } from 'n8n-core';
+import type { LookupFunction } from 'node:net';
+
+import { SsrfProtectionService } from './ssrf-protection.service';
+
+/**
+ * Factory for axios instances that are protected against Server-Side Request
+ * Forgery (SSRF) by default.
+ *
+ * Prefer {@link create} for any outbound HTTP call whose target is influenced
+ * by user input (credentials, workflow data, admin-configured URLs, etc.).
+ *
+ * {@link createUnsafe} is an explicit opt-out for calls to trusted, hardcoded,
+ * n8n-controlled endpoints where protection is unnecessary. Reach for it only
+ * when you can justify why the target can never be attacker-controlled.
+ */
+@Service()
+export class SafeAxiosFactory {
+	constructor(
+		private readonly ssrfConfig: SsrfProtectionConfig,
+		private readonly ssrfProtectionService: SsrfProtectionService,
+	) {}
+
+	/**
+	 * Creates an axios instance with SSRF protection applied (when
+	 * `N8N_SSRF_PROTECTION_ENABLED` is set). Each outbound request is validated
+	 * against the configured allow/block lists before being sent, and resolved
+	 * IPs are re-validated at connection time to defeat DNS rebinding.
+	 */
+	create(defaults?: CreateAxiosDefaults): AxiosInstance {
+		const instance = axios.create(defaults);
+		if (this.ssrfConfig.enabled) {
+			this.protect(instance);
+		}
+		return instance;
+	}
+
+	/**
+	 * Creates a plain axios instance WITHOUT SSRF protection.
+	 *
+	 * Only use for requests to trusted, hardcoded, n8n-controlled endpoints
+	 * (e.g. the n8n license server). Never use it for any target that can be
+	 * influenced by user input.
+	 */
+	createUnsafe(defaults?: CreateAxiosDefaults): AxiosInstance {
+		return axios.create(defaults);
+	}
+
+	/**
+	 * Validates a URL against SSRF protection rules without performing a
+	 * request. Returns immediately when protection is disabled. Throws if the
+	 * URL resolves to a blocked address.
+	 */
+	async validateUrl(url: string | URL): Promise<void> {
+		if (!this.ssrfConfig.enabled) return;
+		const result = await this.ssrfProtectionService.validateUrl(url);
+		if (!result.ok) throw result.error;
+	}
+
+	/**
+	 * Returns a TOCTOU-safe DNS lookup function to embed into custom HTTP(S)
+	 * agents (e.g. proxy- or TLS-customized agents), or `undefined` when
+	 * protection is disabled. Pair it with {@link validateUrl} for a pre-flight
+	 * check on callsites that cannot use {@link create}.
+	 */
+	secureLookup(): LookupFunction | undefined {
+		return this.ssrfConfig.enabled
+			? this.ssrfProtectionService.createSecureLookup()
+			: undefined;
+	}
+
+	private protect(instance: AxiosInstance): void {
+		instance.interceptors.request.use(async (config) => {
+			await this.validateRequestUrl(config);
+			applyAxiosSsrfProtection(config, this.ssrfProtectionService);
+			return config;
+		});
+	}
+
+	private async validateRequestUrl(config: AxiosRequestConfig): Promise<void> {
+		const url = this.resolveUrl(config);
+		if (!url) return;
+		const result = await this.ssrfProtectionService.validateUrl(url);
+		if (!result.ok) throw result.error;
+	}
+
+	private resolveUrl(config: AxiosRequestConfig): string | undefined {
+		const { url, baseURL } = config;
+		if (!url && !baseURL) return undefined;
+		try {
+			return baseURL ? new URL(url ?? '', baseURL).href : url;
+		} catch {
+			return url ?? baseURL;
+		}
+	}
+}

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/axios-utils.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/axios-utils.ts
@@ -286,6 +286,43 @@ export function buildTargetUrl(url?: string, baseURL?: string): string | undefin
 	}
 }
 
+/**
+ * Applies SSRF protection to an arbitrary axios request config in-place.
+ *
+ * Use this to harden axios instances created outside the node request helpers
+ * (e.g. via `axios.create()` or one-off `axios(config)` calls). It wires:
+ * - a secure DNS lookup into the request agents, so resolved IPs are validated
+ *   at connection time (defeats TOCTOU / DNS-rebinding)
+ * - a `beforeRedirect` guard that re-validates redirect targets
+ *
+ * Pre-request URL validation (`ssrfBridge.validateUrl`) should be performed
+ * separately by the caller, as it is asynchronous.
+ *
+ * Existing agents on the config are respected and not overwritten.
+ */
+export function applyAxiosSsrfProtection(
+	config: AxiosRequestConfig,
+	ssrfBridge: SsrfBridge,
+): void {
+	const targetUrl = buildTargetUrl(config.url, config.baseURL);
+	if (!targetUrl) return;
+
+	const proxyConfig = config.proxy === false ? undefined : config.proxy;
+	const agentOptions: AgentOptions = {};
+	const secureLookup = ssrfBridge.createSecureLookup();
+
+	setAxiosAgents(config, agentOptions, proxyConfig, secureLookup);
+
+	config.beforeRedirect = getBeforeRedirectFn(
+		agentOptions,
+		config,
+		proxyConfig,
+		true,
+		undefined,
+		ssrfBridge,
+	);
+}
+
 /** Sets `httpAgent` and `httpsAgent` on an axios config, respecting proxy and SSRF settings. */
 export function setAxiosAgents(
 	config: AxiosRequestConfig,

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/index.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/index.ts
@@ -1,4 +1,5 @@
 export {
+	applyAxiosSsrfProtection,
 	createFormDataObject,
 	digestAuthAxiosConfig,
 	generateContentLengthHeader,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export * from './nodes-loader';
 export * from './utils';
 export * from './http-proxy';
 export { WorkflowHasIssuesError } from './errors/workflow-has-issues.error';
+export { applyAxiosSsrfProtection } from './execution-engine/node-execution-context/utils/request-helpers';
 export * from './observability';
 
 export type * from './interfaces';


### PR DESCRIPTION
## Summary

> Draft — foundation + first migration batch. Outbound HTTP is being routed through a single, protected axios factory so that requests to user/credential-influenced targets are validated by default, with explicit, reviewable opt-outs for trusted or admin-configured endpoints.

**What this adds**

- **`SafeAxiosFactory`** (`packages/cli/src/services/ssrf/`): a DI service that builds axios instances with outbound-request protection applied by default:
  - pre-request URL validation against the configured allow/block lists,
  - a TOCTOU-safe DNS lookup wired into the request agents (resolved IPs are re-checked at connect time),
  - redirect guarding.
  - `createUnsafe()` is an explicit opt-out for trusted, hardcoded endpoints.
  - All behaviour is gated on `N8N_SSRF_PROTECTION_ENABLED`; with it off the factory returns a plain axios instance, so default behaviour is unchanged.
- **`applyAxiosSsrfProtection()`** in `n8n-core`, reusing the existing request-helper agent/redirect logic so there is a single implementation, exported for the cli to consume.
- **`no-unprotected-axios`** ESLint rule (`@n8n/eslint-config`): flags raw `axios.get/post/create/...` usage so new outbound calls go through the factory. Wired into the cli as a **warning** for now (it surfaces the remaining call sites without breaking the build); intended to be tightened to `error` once the migration is complete.

**Migrated to the factory**

- OAuth service (metadata discovery, dynamic client registration, OAuth1 request/access token) and the OAuth1 credential controller.
- Dynamic-credential `oauth2-introspection` and `oauth2-userinfo` resolvers.

**Intentional opt-outs (documented inline with justifications)**

These targets are either hardcoded n8n endpoints or admin-configured infrastructure that legitimately resolves to internal/private hosts, so protecting them by default would break common deployments (admins can still allowlist via `N8N_SSRF_ALLOWED_*`):

- SAML IdP metadata fetch
- Log-streaming webhook destination
- HashiCorp Vault external-secrets provider
- Community package registry requests

**Still to do (tracked, not in this draft)**

- Route the templates host calls (`dynamic-templates`, `strapi-utils`) through the factory.
- Add justified opt-outs for the remaining hardcoded constants (`license`, `firecrawl`, telemetry, version-notifications, package-status check).
- Flip `no-unprotected-axios` from `warn` to `error`.

**Testing**

- New unit tests for `SafeAxiosFactory` and the `no-unprotected-axios` rule.
- Updated unit tests for the migrated OAuth / credential-resolver code.
- `typecheck` passes for the affected packages; targeted test suites pass locally. Full `build` / `lint` / test to be confirmed in CI.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
