### PR TITLE
fix: Use UUID thread IDs for Instance AI evals (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/__tests__/runner-thread-id.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/__tests__/runner-thread-id.test.ts
@@ -1,0 +1,40 @@
+import { vi } from 'vitest';
+
+import type { N8nClient } from '../clients/n8n-client';
+import type { EvalLogger } from '../harness/logger';
+import { buildWorkflow } from '../harness/runner';
+
+const silentLogger: EvalLogger = {
+	info: () => {},
+	verbose: () => {},
+	success: () => {},
+	warn: () => {},
+	error: () => {},
+	isVerbose: false,
+};
+
+const uuidV4Pattern = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe('buildWorkflow thread IDs', () => {
+	it('uses UUID thread IDs accepted by the instance-ai thread endpoint', async () => {
+		let capturedThreadId = '';
+		const client = {
+			ensureThread: vi.fn(async (threadId: string) => {
+				capturedThreadId = threadId;
+				await Promise.resolve();
+				throw new Error('stop after ensureThread');
+			}),
+		} as unknown as N8nClient;
+
+		await buildWorkflow({
+			client,
+			conversation: [{ role: 'user', text: 'build a workflow' }],
+			preRunWorkflowIds: new Set(),
+			claimedWorkflowIds: new Set(),
+			logger: silentLogger,
+		});
+
+		expect(client.ensureThread).toHaveBeenCalledTimes(1);
+		expect(capturedThreadId).toMatch(uuidV4Pattern);
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/computer-use/chat.ts
+++ b/packages/@n8n/instance-ai/evaluations/computer-use/chat.ts
@@ -42,7 +42,7 @@ export interface RunChatOptions {
  */
 export async function runChat(options: RunChatOptions): Promise<ScenarioTrace> {
 	const { client, prompt, timeoutMs, logger } = options;
-	const threadId = `cu-eval-${crypto.randomUUID()}`;
+	const threadId = crypto.randomUUID();
 	const startTime = Date.now();
 
 	const abortController = new AbortController();

--- a/packages/@n8n/instance-ai/evaluations/harness/runner.ts
+++ b/packages/@n8n/instance-ai/evaluations/harness/runner.ts
@@ -299,7 +299,7 @@ function isMultiTurnConversation(conversation: ConversationTurn[]): boolean {
 export async function buildWorkflow(config: BuildWorkflowConfig): Promise<BuildResult> {
 	const { client, conversation, logger } = config;
 	const openingMessage = conversation[0]?.text ?? '';
-	const threadId = `eval-${crypto.randomUUID()}`;
+	const threadId = crypto.randomUUID();
 	const startTime = Date.now();
 	const timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 


### PR DESCRIPTION
## Summary

Instance AI workflow evaluations were creating threads with `eval-`-prefixed IDs, but the `/rest/instance-ai/threads` endpoint now validates provided `threadId` values as UUIDs. This updates the workflow and computer-use eval harnesses to generate plain UUID thread IDs so eval setup can create threads successfully.

This also adds a regression test that asserts `buildWorkflow()` passes a UUID to `ensureThread()`.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
