### PR TITLE
fix(core): Invalidate cached redaction floor across mains on change

### DIFF
--- a/packages/@n8n/decorators/src/pubsub/pubsub-metadata.ts
+++ b/packages/@n8n/decorators/src/pubsub/pubsub-metadata.ts
@@ -32,7 +32,8 @@ export type PubSubEventName =
 	| 'cancel-collection'
 	| 'agent-chat-integration-changed'
 	| 'agent-config-changed'
-	| 'agent-tasks-changed';
+	| 'agent-tasks-changed'
+	| 'redaction-floor-changed';
 
 export type PubSubEventFilter =
 	| {

--- a/packages/cli/src/modules/redaction/__tests__/instance-redaction-enforcement.service.test.ts
+++ b/packages/cli/src/modules/redaction/__tests__/instance-redaction-enforcement.service.test.ts
@@ -1,9 +1,11 @@
 import { REDACTION_FLOOR_DEFAULT, type RedactionFloor } from '@n8n/api-types';
 import type { Logger } from '@n8n/backend-common';
+import type { GlobalConfig } from '@n8n/config';
 import type { Settings, SettingsRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 import { OperationalError, UserError } from 'n8n-workflow';
 
+import type { Publisher } from '@/scaling/pubsub/publisher.service';
 import type { CacheService } from '@/services/cache/cache.service';
 
 import { InstanceRedactionEnforcementService } from '../instance-redaction-enforcement.service';
@@ -20,6 +22,22 @@ describe('InstanceRedactionEnforcementService', () => {
 	let settingsRepository: SettingsRepository;
 	const cacheService = mock<CacheService>();
 	const logger = mock<Logger>();
+	const publisher = mock<Publisher>();
+	const globalConfig = mock<GlobalConfig>();
+
+	const enableMultiMain = () => {
+		Object.defineProperty(globalConfig, 'multiMainSetup', {
+			value: { enabled: true },
+			configurable: true,
+		});
+	};
+
+	const disableMultiMain = () => {
+		Object.defineProperty(globalConfig, 'multiMainSetup', {
+			value: { enabled: false },
+			configurable: true,
+		});
+	};
 
 	const enableFlag = () => {
 		process.env[N8N_ENV_FEAT_REDACTION_ENFORCEMENT] = 'true';
@@ -49,7 +67,16 @@ describe('InstanceRedactionEnforcementService', () => {
 		upsert = jest.fn();
 		settingsRepository = { findByKey, upsert } as unknown as SettingsRepository;
 
-		service = new InstanceRedactionEnforcementService(settingsRepository, cacheService, logger);
+		disableMultiMain();
+		publisher.publishCommand.mockResolvedValue(undefined);
+
+		service = new InstanceRedactionEnforcementService(
+			settingsRepository,
+			cacheService,
+			logger,
+			publisher,
+			globalConfig,
+		);
 	});
 
 	afterEach(() => {
@@ -176,6 +203,69 @@ describe('InstanceRedactionEnforcementService', () => {
 				expect(upsert).not.toHaveBeenCalled();
 				expect(cacheService.set).not.toHaveBeenCalled();
 			});
+
+			it('publishes redaction-floor-changed when multi-main is enabled', async () => {
+				enableMultiMain();
+
+				await service.set('production');
+
+				expect(publisher.publishCommand).toHaveBeenCalledWith({
+					command: 'redaction-floor-changed',
+				});
+			});
+
+			it('does not broadcast when multi-main is disabled', async () => {
+				disableMultiMain();
+
+				await service.set('production');
+
+				expect(publisher.publishCommand).not.toHaveBeenCalled();
+			});
+
+			it('swallows publisher failures so the update keeps succeeding, and logs a warning', async () => {
+				enableMultiMain();
+				publisher.publishCommand.mockRejectedValueOnce(new Error('redis is down'));
+
+				await expect(service.set('production')).resolves.toBeUndefined();
+				// Allow the fire-and-forget catch handler to run.
+				await Promise.resolve();
+				expect(logger.warn).toHaveBeenCalledWith(
+					'[InstanceRedactionEnforcementService] Failed to publish redaction-floor-changed',
+					expect.objectContaining({ error: 'redis is down' }),
+				);
+			});
+		});
+	});
+
+	describe('handleRedactionFloorChanged', () => {
+		it('deletes the local cache key without re-publishing — no broadcast loop', async () => {
+			enableMultiMain();
+
+			await service.handleRedactionFloorChanged();
+
+			expect(cacheService.delete).toHaveBeenCalledWith(KEY);
+			expect(publisher.publishCommand).not.toHaveBeenCalled();
+		});
+
+		it('re-reads the floor from the DB on the next get after the key is dropped', async () => {
+			enableFlag();
+			const stored: RedactionFloor = 'all';
+
+			await service.handleRedactionFloorChanged();
+			expect(cacheService.delete).toHaveBeenCalledWith(KEY);
+
+			simulateCacheMiss();
+			findByKey.mockResolvedValueOnce(
+				mock<Settings>({
+					key: KEY,
+					value: JSON.stringify(stored),
+					loadOnStartup: true,
+				}),
+			);
+
+			await expect(service.get()).resolves.toBe(stored);
+			expect(findByKey).toHaveBeenCalledWith(KEY);
+			expect(cacheService.set).toHaveBeenCalledWith(KEY, JSON.stringify(stored));
 		});
 	});
 });

--- a/packages/cli/src/modules/redaction/__tests__/instance-redaction-enforcement.service.test.ts
+++ b/packages/cli/src/modules/redaction/__tests__/instance-redaction-enforcement.service.test.ts
@@ -5,6 +5,7 @@ import type { Settings, SettingsRepository } from '@n8n/db';
 import { mock } from 'jest-mock-extended';
 import { OperationalError, UserError } from 'n8n-workflow';
 
+import { SELF_SEND_COMMANDS } from '@/scaling/constants';
 import type { Publisher } from '@/scaling/pubsub/publisher.service';
 import type { CacheService } from '@/services/cache/cache.service';
 
@@ -229,6 +230,12 @@ describe('InstanceRedactionEnforcementService', () => {
 				await expect(service.set('production')).resolves.toBeUndefined();
 				// Allow the fire-and-forget catch handler to run.
 				await Promise.resolve();
+				// The update still persisted and re-cached despite the publish failure.
+				expect(upsert).toHaveBeenCalledWith(
+					{ key: KEY, value: JSON.stringify('production'), loadOnStartup: true },
+					['key'],
+				);
+				expect(cacheService.set).toHaveBeenCalledWith(KEY, JSON.stringify('production'));
 				expect(logger.warn).toHaveBeenCalledWith(
 					'[InstanceRedactionEnforcementService] Failed to publish redaction-floor-changed',
 					expect.objectContaining({ error: 'redis is down' }),
@@ -247,25 +254,57 @@ describe('InstanceRedactionEnforcementService', () => {
 			expect(publisher.publishCommand).not.toHaveBeenCalled();
 		});
 
-		it('re-reads the floor from the DB on the next get after the key is dropped', async () => {
+		it('delete causes the next get to miss and re-read the new value from the DB', async () => {
 			enableFlag();
-			const stored: RedactionFloor = 'all';
 
-			await service.handleRedactionFloorChanged();
-			expect(cacheService.delete).toHaveBeenCalledWith(KEY);
+			// Stateful in-memory cache so the delete — not the test harness — is what
+			// forces the subsequent read to miss. The test fails if the handler stops
+			// calling cacheService.delete.
+			const store = new Map<string, string>();
+			cacheService.set.mockImplementation(async (key, value) => {
+				store.set(key, value as string);
+			});
+			cacheService.delete.mockImplementation(async (key) => {
+				store.delete(key);
+			});
+			cacheService.get.mockImplementation(async (key, opts) => {
+				if (store.has(key)) return store.get(key);
+				const refreshed = (await opts!.refreshFn!(key)) as string;
+				store.set(key, refreshed);
+				return refreshed;
+			});
 
-			simulateCacheMiss();
-			findByKey.mockResolvedValueOnce(
+			// Seed a STALE value and confirm reads hit it.
+			const stale: RedactionFloor = 'off';
+			await cacheService.set(KEY, JSON.stringify(stale));
+			await expect(service.get()).resolves.toBe(stale);
+			expect(findByKey).not.toHaveBeenCalled();
+
+			// A peer main reports a change; the DB now holds the NEW value.
+			const updated: RedactionFloor = 'production';
+			findByKey.mockResolvedValue(
 				mock<Settings>({
 					key: KEY,
-					value: JSON.stringify(stored),
+					value: JSON.stringify(updated),
 					loadOnStartup: true,
 				}),
 			);
 
-			await expect(service.get()).resolves.toBe(stored);
+			await service.handleRedactionFloorChanged();
+			expect(cacheService.delete).toHaveBeenCalledWith(KEY);
+
+			// The dropped key makes the next read miss → refreshFn → DB → re-cache.
+			await expect(service.get()).resolves.toBe(updated);
 			expect(findByKey).toHaveBeenCalledWith(KEY);
-			expect(cacheService.set).toHaveBeenCalledWith(KEY, JSON.stringify(stored));
+			// The refreshFn re-cached the fresh value via the (stateful) cache.
+			expect(store.get(KEY)).toBe(JSON.stringify(updated));
+		});
+
+		it('relies on redaction-floor-changed not being a self-send command', () => {
+			// The originating main already updates its own cache synchronously in
+			// set(); if this command became self-send, that main would also delete
+			// its freshly written cache entry on receipt.
+			expect(SELF_SEND_COMMANDS.has('redaction-floor-changed')).toBe(false);
 		});
 	});
 });

--- a/packages/cli/src/modules/redaction/instance-redaction-enforcement.service.ts
+++ b/packages/cli/src/modules/redaction/instance-redaction-enforcement.service.ts
@@ -1,9 +1,12 @@
 import { REDACTION_FLOOR_DEFAULT, redactionFloorSchema, type RedactionFloor } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
+import { GlobalConfig } from '@n8n/config';
 import { SettingsRepository } from '@n8n/db';
+import { OnPubSubEvent } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import { OperationalError, UserError } from 'n8n-workflow';
 
+import { Publisher } from '@/scaling/pubsub/publisher.service';
 import { CacheService } from '@/services/cache/cache.service';
 
 import { isRedactionEnforcementEnabled } from './redaction-enforcement.feature-flag';
@@ -16,6 +19,8 @@ export class InstanceRedactionEnforcementService {
 		private readonly settingsRepository: SettingsRepository,
 		private readonly cacheService: CacheService,
 		private readonly logger: Logger,
+		private readonly publisher: Publisher,
+		private readonly globalConfig: GlobalConfig,
 	) {}
 
 	/**
@@ -57,6 +62,27 @@ export class InstanceRedactionEnforcementService {
 		]);
 
 		await this.cacheService.set(KEY, serialized);
+
+		if (this.globalConfig.multiMainSetup.enabled) {
+			void this.publisher.publishCommand({ command: 'redaction-floor-changed' }).catch((error) => {
+				this.logger.warn(
+					'[InstanceRedactionEnforcementService] Failed to publish redaction-floor-changed',
+					{
+						error: error instanceof Error ? error.message : String(error),
+					},
+				);
+			});
+		}
+	}
+
+	/**
+	 * Drop the locally cached redaction floor when a peer main reports a change.
+	 * Next read re-loads from the DB. Does not re-publish — the originating main
+	 * already updated its own cache synchronously in set().
+	 */
+	@OnPubSubEvent('redaction-floor-changed', { instanceType: 'main' })
+	async handleRedactionFloorChanged(): Promise<void> {
+		await this.cacheService.delete(KEY);
 	}
 
 	private async loadFromDatabase(): Promise<string> {

--- a/packages/cli/src/modules/redaction/redaction.module.ts
+++ b/packages/cli/src/modules/redaction/redaction.module.ts
@@ -8,6 +8,14 @@ import { ExecutionRedactionServiceProxy } from '@/executions/execution-redaction
 export class RedactionModule implements ModuleInterface {
 	async init() {
 		await import('./redaction-context-hook');
+
+		// Importing the service here registers its @OnPubSubEvent handler with the
+		// pubsub metadata before PubSubRegistry.init() wires up the listeners.
+		const { InstanceRedactionEnforcementService } = await import(
+			'./instance-redaction-enforcement.service'
+		);
+		Container.get(InstanceRedactionEnforcementService);
+
 		const { ExecutionRedactionService } = await import('./executions/execution-redaction.service');
 		const executionRedactionService = Container.get(ExecutionRedactionService);
 		await executionRedactionService.init();

--- a/packages/cli/src/modules/redaction/redaction.module.ts
+++ b/packages/cli/src/modules/redaction/redaction.module.ts
@@ -11,10 +11,10 @@ export class RedactionModule implements ModuleInterface {
 
 		// Importing the service here registers its @OnPubSubEvent handler with the
 		// pubsub metadata before PubSubRegistry.init() wires up the listeners.
-		const { InstanceRedactionEnforcementService } = await import(
-			'./instance-redaction-enforcement.service'
-		);
-		Container.get(InstanceRedactionEnforcementService);
+		// The decorator runs at class-evaluation (import) time, so the import
+		// side-effect alone is sufficient — the registry instantiates the handler
+		// lazily on event receipt, so we must not eagerly resolve it here.
+		await import('./instance-redaction-enforcement.service');
 
 		const { ExecutionRedactionService } = await import('./executions/execution-redaction.service');
 		const executionRedactionService = Container.get(ExecutionRedactionService);

--- a/packages/cli/src/scaling/pubsub/pubsub.event-map.ts
+++ b/packages/cli/src/scaling/pubsub/pubsub.event-map.ts
@@ -232,6 +232,18 @@ export type PubSubCommandMap = {
 	};
 
 	// #endregion
+
+	// #region Redaction
+
+	/**
+	 * Drop the cached instance redaction floor across main instances.
+	 * Published by the main that handled a redaction-floor update after the new
+	 * value is persisted; every other main clears its local cache key so the next
+	 * read re-loads the current value from the DB.
+	 */
+	'redaction-floor-changed': never;
+
+	// #endregion
 };
 
 export type PubSubWorkerResponseMap = {

--- a/packages/cli/src/scaling/pubsub/pubsub.event-map.ts
+++ b/packages/cli/src/scaling/pubsub/pubsub.event-map.ts
@@ -240,6 +240,9 @@ export type PubSubCommandMap = {
 	 * Published by the main that handled a redaction-floor update after the new
 	 * value is persisted; every other main clears its local cache key so the next
 	 * read re-loads the current value from the DB.
+	 *
+	 * Must NOT be added to SELF_SEND_COMMANDS: the originating main already
+	 * updates its own cache synchronously in set().
 	 */
 	'redaction-floor-changed': never;
 

--- a/packages/cli/src/scaling/pubsub/pubsub.types.ts
+++ b/packages/cli/src/scaling/pubsub/pubsub.types.ts
@@ -69,6 +69,7 @@ export namespace PubSub {
 		export type AgentChatIntegrationChanged = ToCommand<'agent-chat-integration-changed'>;
 		export type AgentConfigChanged = ToCommand<'agent-config-changed'>;
 		export type AgentTasksChanged = ToCommand<'agent-tasks-changed'>;
+		export type RedactionFloorChanged = ToCommand<'redaction-floor-changed'>;
 	}
 
 	/** Command sent via the `n8n.commands` pubsub channel. */
@@ -101,7 +102,8 @@ export namespace PubSub {
 		| Commands.CancelCollection
 		| Commands.AgentChatIntegrationChanged
 		| Commands.AgentConfigChanged
-		| Commands.AgentTasksChanged;
+		| Commands.AgentTasksChanged
+		| Commands.RedactionFloorChanged;
 
 	// ----------------------------------
 	//         worker responses


### PR DESCRIPTION
## Summary

The instance redaction floor is cached per main instance. When an admin changed the floor on one main, peer mains kept serving their **stale** cached value until the cache TTL expired — so a workflow editor connected to a different main saw the old floor (lock state / seeded policy) in the Workflow Settings drawer until a hard page reload.

This only manifests under **multi-main with a non-shared (in-memory) cache backend**. With the default `auto` backend, multi-main resolves to a shared Redis cache (already consistent), and single-main is a single process — neither is affected. The frontend already re-fetches the floor on every drawer open (since #31229), so the stale value originated on the backend, not the client.

Fix, mirroring the existing `agent-config-changed` mechanism:
- New `redaction-floor-changed` pubsub command (empty payload).
- `InstanceRedactionEnforcementService.set()` broadcasts it after persisting + updating its own cache, guarded on `multiMainSetup.enabled`, fire-and-forget (a publish failure is logged, never thrown — the DB write is the source of truth and the cache TTL remains the fallback).
- An `@OnPubSubEvent('redaction-floor-changed', { instanceType: 'main' })` handler deletes the local cache key on peer mains, so the next read re-loads the current value from the DB.
- Handler registration is made explicit in `RedactionModule.init()` to guard against future import-graph drift.

No frontend change, no DB migration, no api-types schema change.

## How to test

Automated: `cd packages/cli && pnpm test src/modules/redaction/__tests__/instance-redaction-enforcement.service.test.ts` (15 passing — publish/no-publish by topology, handler deletes the cache key, a delete causes the next read to miss and re-load the new value from the DB, publish failures are swallowed while persistence still succeeds, and the command stays excluded from self-send).

Manual (requires the repro topology): run n8n in multi-main queue mode with `N8N_CACHE_BACKEND=memory` and the redaction enforcement flag enabled. As admin on main A, change the instance floor. As an editor whose session is pinned to main B, open the Workflow Settings drawer — it now reflects the new floor without a page reload.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-37

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI