### PR TITLE
fix(editor): Correct string comparison scores in config evals (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.vue
@@ -24,7 +24,12 @@ import { useChatStore } from '@/features/ai/chatHub/chat.store';
 import { useChatCredentials } from '@/features/ai/chatHub/composables/useChatCredentials';
 import { isLlmProviderModel } from '@/features/ai/chatHub/chat.utils';
 import ModelSelector from '@/features/ai/chatHub/components/ModelSelector.vue';
-import { formatMetricPercent, formatDuration, formatTokens } from '../../evaluation.utils';
+import {
+	formatMetricPercent,
+	formatDuration,
+	formatTokens,
+	extractAnswerText,
+} from '../../evaluation.utils';
 import {
 	CANNED_METRICS,
 	LLM_JUDGE_METRIC_KEYS,
@@ -212,7 +217,7 @@ const latestRunOutputText = computed(() => {
 	const runData = execution.data?.resultData?.runData;
 	const firstItem = runData?.[endName]?.[0]?.data?.main?.[0]?.[0]?.json;
 	if (firstItem === undefined) return undefined;
-	return formatOutputValue(firstItem);
+	return formatOutputValue(extractAnswerText(firstItem));
 });
 
 async function loadExecutionForCase(caseId: string, executionId: string) {

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/composables/buildEvaluationConfigDto.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/composables/buildEvaluationConfigDto.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from 'vitest';
+import { buildEvaluationConfigDto } from './buildEvaluationConfigDto';
+import type { BuildDtoInput } from './buildEvaluationConfigDto';
+
+const BASE_INPUT: BuildDtoInput = {
+	workflowName: 'My Workflow',
+	upstreamNodeName: 'Eval Trigger',
+	startNodeName: 'Start',
+	endNodeName: 'End',
+	inputFieldNames: ['query'],
+	selectedMetrics: [],
+	judgeSelectionByMetric: {},
+	customChecks: [],
+	dataTableId: 'table-123',
+};
+
+// The upstream node column expression form expected for expectedAnswer.
+const EXPECTED_ANSWER_EXPR = `={{ $('Eval Trigger').first().json[${JSON.stringify('expectedAnswer')}] }}`;
+
+// The endAnswer expression form expected for actualAnswer in string-comparison metrics.
+const END_ANSWER_EXPR = `={{ (() => { const j = $('End').first().json; if (j === null || j === undefined) return ''; if (typeof j !== 'object') return String(j); const p = j.output ?? j.text ?? j.response; if (p !== undefined && p !== null) return typeof p === 'object' ? JSON.stringify(p) : String(p); const ks = Object.keys(j); if (ks.length === 1) { const o = j[ks[0]]; return typeof o === 'object' && o !== null ? JSON.stringify(o) : String(o); } return JSON.stringify(j); })() }}`;
+
+// The legacy full-stringify form that must NOT be used for these metrics.
+const END_OUTPUT_AS_STRING = `={{ JSON.stringify($('End').first().json) }}`;
+
+describe('buildEvaluationConfigDto', () => {
+	describe('stringSimilarity metric', () => {
+		const input: BuildDtoInput = {
+			...BASE_INPUT,
+			selectedMetrics: ['stringSimilarity'],
+		};
+
+		it('returns ok: true', () => {
+			const result = buildEvaluationConfigDto(input);
+			expect(result.ok).toBe(true);
+		});
+
+		it('produces a string_similarity metric type', () => {
+			const result = buildEvaluationConfigDto(input);
+			if (!result.ok) throw new Error('Expected ok result');
+			expect(result.dto.metrics).toHaveLength(1);
+			expect(result.dto.metrics[0].type).toBe('string_similarity');
+		});
+
+		it('uses the extracted endAnswer expression for actualAnswer', () => {
+			const result = buildEvaluationConfigDto(input);
+			if (!result.ok) throw new Error('Expected ok result');
+			const metric = result.dto.metrics[0];
+			if (metric.type !== 'string_similarity') throw new Error('Wrong type');
+			expect(metric.config.inputs.actualAnswer).toBe(END_ANSWER_EXPR);
+		});
+
+		it('does NOT use the full JSON.stringify form for actualAnswer', () => {
+			const result = buildEvaluationConfigDto(input);
+			if (!result.ok) throw new Error('Expected ok result');
+			const metric = result.dto.metrics[0];
+			if (metric.type !== 'string_similarity') throw new Error('Wrong type');
+			expect(metric.config.inputs.actualAnswer).not.toBe(END_OUTPUT_AS_STRING);
+		});
+
+		it('uses the dataset column expression for expectedAnswer', () => {
+			const result = buildEvaluationConfigDto(input);
+			if (!result.ok) throw new Error('Expected ok result');
+			const metric = result.dto.metrics[0];
+			if (metric.type !== 'string_similarity') throw new Error('Wrong type');
+			expect(metric.config.inputs.expectedAnswer).toBe(EXPECTED_ANSWER_EXPR);
+		});
+
+		it('includes .output ?? in actualAnswer expression', () => {
+			const result = buildEvaluationConfigDto(input);
+			if (!result.ok) throw new Error('Expected ok result');
+			const metric = result.dto.metrics[0];
+			if (metric.type !== 'string_similarity') throw new Error('Wrong type');
+			expect(metric.config.inputs.actualAnswer).toContain('.output ??');
+		});
+
+		it('includes a single-key object fallback in actualAnswer expression', () => {
+			const result = buildEvaluationConfigDto(input);
+			if (!result.ok) throw new Error('Expected ok result');
+			const metric = result.dto.metrics[0];
+			if (metric.type !== 'string_similarity') throw new Error('Wrong type');
+			expect(metric.config.inputs.actualAnswer).toContain('Object.keys(j)');
+			expect(metric.config.inputs.actualAnswer).toContain('ks.length === 1');
+		});
+
+		it('JSON.stringifies object-valued preferred fields (no [object Object])', () => {
+			const result = buildEvaluationConfigDto(input);
+			if (!result.ok) throw new Error('Expected ok result');
+			const metric = result.dto.metrics[0];
+			if (metric.type !== 'string_similarity') throw new Error('Wrong type');
+			expect(metric.config.inputs.actualAnswer).toContain(
+				"typeof p === 'object' ? JSON.stringify(p) : String(p)",
+			);
+		});
+	});
+
+	describe('categorization metric', () => {
+		const input: BuildDtoInput = {
+			...BASE_INPUT,
+			selectedMetrics: ['categorization'],
+		};
+
+		it('returns ok: true', () => {
+			const result = buildEvaluationConfigDto(input);
+			expect(result.ok).toBe(true);
+		});
+
+		it('produces a categorization metric type', () => {
+			const result = buildEvaluationConfigDto(input);
+			if (!result.ok) throw new Error('Expected ok result');
+			expect(result.dto.metrics).toHaveLength(1);
+			expect(result.dto.metrics[0].type).toBe('categorization');
+		});
+
+		it('uses the extracted endAnswer expression for actualAnswer', () => {
+			const result = buildEvaluationConfigDto(input);
+			if (!result.ok) throw new Error('Expected ok result');
+			const metric = result.dto.metrics[0];
+			if (metric.type !== 'categorization') throw new Error('Wrong type');
+			expect(metric.config.inputs.actualAnswer).toBe(END_ANSWER_EXPR);
+		});
+
+		it('does NOT use the full JSON.stringify form for actualAnswer', () => {
+			const result = buildEvaluationConfigDto(input);
+			if (!result.ok) throw new Error('Expected ok result');
+			const metric = result.dto.metrics[0];
+			if (metric.type !== 'categorization') throw new Error('Wrong type');
+			expect(metric.config.inputs.actualAnswer).not.toBe(END_OUTPUT_AS_STRING);
+		});
+
+		it('uses the dataset column expression for expectedAnswer', () => {
+			const result = buildEvaluationConfigDto(input);
+			if (!result.ok) throw new Error('Expected ok result');
+			const metric = result.dto.metrics[0];
+			if (metric.type !== 'categorization') throw new Error('Wrong type');
+			expect(metric.config.inputs.expectedAnswer).toBe(EXPECTED_ANSWER_EXPR);
+		});
+	});
+
+	describe('node name escaping in endAnswer', () => {
+		it('escapes single quotes in the end node name', () => {
+			const input: BuildDtoInput = {
+				...BASE_INPUT,
+				endNodeName: "Customer's End",
+				selectedMetrics: ['stringSimilarity'],
+			};
+			const result = buildEvaluationConfigDto(input);
+			if (!result.ok) throw new Error('Expected ok result');
+			const metric = result.dto.metrics[0];
+			if (metric.type !== 'string_similarity') throw new Error('Wrong type');
+			expect(metric.config.inputs.actualAnswer).toContain("Customer\\'s End");
+		});
+	});
+
+	describe('returns ok: false', () => {
+		it('when no metrics are selected', () => {
+			const result = buildEvaluationConfigDto({ ...BASE_INPUT, selectedMetrics: [] });
+			expect(result.ok).toBe(false);
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/composables/buildEvaluationConfigDto.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/composables/buildEvaluationConfigDto.ts
@@ -88,6 +88,12 @@ function buildMetric(key: CannedMetricKey, name: string, input: BuildDtoInput): 
 		`={{ $('${upstream}').first().json[${JSON.stringify(col)}] }}`;
 	const endOutputAsString = `={{ JSON.stringify($('${endNode}').first().json) }}`;
 
+	// Mirror of extractAnswerText() in evaluation.utils.ts — keep the two in sync.
+	// Prefer output > text > response; else single-key value; else JSON.stringify.
+	// Object values are JSON.stringified (not coerced to "[object Object]") so the
+	// runtime score matches the previewed answer exactly.
+	const endAnswer = `={{ (() => { const j = $('${endNode}').first().json; if (j === null || j === undefined) return ''; if (typeof j !== 'object') return String(j); const p = j.output ?? j.text ?? j.response; if (p !== undefined && p !== null) return typeof p === 'object' ? JSON.stringify(p) : String(p); const ks = Object.keys(j); if (ks.length === 1) { const o = j[ks[0]]; return typeof o === 'object' && o !== null ? JSON.stringify(o) : String(o); } return JSON.stringify(j); })() }}`;
+
 	if (LLM_JUDGE_METRIC_KEYS.has(key)) {
 		const selection = input.judgeSelectionByMetric[key];
 		if (!selection) {
@@ -161,7 +167,7 @@ function buildMetric(key: CannedMetricKey, name: string, input: BuildDtoInput): 
 				type: 'string_similarity',
 				config: {
 					inputs: {
-						actualAnswer: endOutputAsString,
+						actualAnswer: endAnswer,
 						expectedAnswer: datasetCol('expectedAnswer'),
 					},
 				},
@@ -177,7 +183,7 @@ function buildMetric(key: CannedMetricKey, name: string, input: BuildDtoInput): 
 				type: 'categorization',
 				config: {
 					inputs: {
-						actualAnswer: endOutputAsString,
+						actualAnswer: endAnswer,
 						expectedAnswer: datasetCol('expectedAnswer'),
 					},
 				},

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/evaluation.utils.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/evaluation.utils.test.ts
@@ -4,6 +4,7 @@ import {
 	applyCachedVisibility,
 	computeDelta,
 	computeDurationMs,
+	extractAnswerText,
 	formatDeltaPercent,
 	formatDuration,
 	formatMetricLabel,
@@ -1428,6 +1429,42 @@ describe('utils', () => {
 			expect(getMetricCategory('customMetrics')).toBe('custom');
 			expect(getMetricCategory(undefined)).toBe('custom');
 			expect(getMetricCategory('madeUpType')).toBe('custom');
+		});
+	});
+
+	describe('extractAnswerText', () => {
+		it('returns null as empty string', () => {
+			expect(extractAnswerText(null)).toBe('');
+		});
+		it('returns undefined as empty string', () => {
+			expect(extractAnswerText(undefined)).toBe('');
+		});
+		it('converts a number primitive to a string', () => {
+			expect(extractAnswerText(42)).toBe('42');
+		});
+		it('passes a string primitive through unchanged', () => {
+			expect(extractAnswerText('hi')).toBe('hi');
+		});
+		it('extracts the output field when present', () => {
+			expect(extractAnswerText({ output: 'Paris' })).toBe('Paris');
+		});
+		it('falls back to text when output is absent', () => {
+			expect(extractAnswerText({ text: 'x' })).toBe('x');
+		});
+		it('falls back to response when output and text are absent', () => {
+			expect(extractAnswerText({ response: 'y' })).toBe('y');
+		});
+		it('JSON.stringifies a preferred field that is itself an object', () => {
+			expect(extractAnswerText({ output: { a: 1 } })).toBe('{"a":1}');
+		});
+		it('uses the single key value when no preferred field exists', () => {
+			expect(extractAnswerText({ answer: 'z' })).toBe('z');
+		});
+		it('JSON.stringifies the whole object for multi-key non-preferred objects', () => {
+			expect(extractAnswerText({ a: 1, b: 2 })).toBe(JSON.stringify({ a: 1, b: 2 }));
+		});
+		it('JSON.stringifies a single-key value that is itself an object', () => {
+			expect(extractAnswerText({ nested: { x: 1 } })).toBe('{"x":1}');
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/evaluation.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/evaluation.utils.ts
@@ -3,6 +3,30 @@ import type { JsonValue } from 'n8n-workflow';
 import type { TestCaseExecutionRecord, TestRunRecord } from './evaluation.api';
 import type { TestTableColumn } from './components/shared/TestTableBase.vue';
 
+/**
+ * Extract a human-readable answer string from an end-node output value.
+ *
+ * Priority: `output` > `text` > `response` > single-key object value > JSON.stringify.
+ * Primitives pass through as String(value); null/undefined → ''.
+ *
+ * Keep in sync with the `endAnswer` n8n expression in buildEvaluationConfigDto.ts.
+ */
+export function extractAnswerText(json: unknown): string {
+	if (json === null || json === undefined) return '';
+	if (typeof json !== 'object') return String(json);
+	const preferred =
+		Reflect.get(json, 'output') ?? Reflect.get(json, 'text') ?? Reflect.get(json, 'response');
+	if (preferred !== undefined && preferred !== null) {
+		return typeof preferred === 'object' ? JSON.stringify(preferred) : String(preferred);
+	}
+	const keys = Object.keys(json);
+	if (keys.length === 1) {
+		const only = Reflect.get(json, keys[0]);
+		return typeof only === 'object' && only !== null ? JSON.stringify(only) : String(only);
+	}
+	return JSON.stringify(json);
+}
+
 export type Column =
 	| {
 			key: string;


### PR DESCRIPTION
## Summary

String comparison checks run via the config evals produced incorrect scores. This corrects the score calculation in `buildEvaluationConfigDto` and the shared evaluation utils, with regression tests covering the comparison logic.

## How to test

1. Open a workflow with an AI node and set up a config eval with a **string comparison** check.
2. Run the evaluation.
3. Confirm the resulting scores match the expected pass/fail for matching vs. non-matching strings.

See the Loom in the Linear ticket for the original repro.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-143

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI