### PR TITLE
fix(editor): Reset evals pane on workflow switch and gate on AI node (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/FocusSidebar.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/FocusSidebar.test.ts
@@ -19,11 +19,35 @@ import { createTestingPinia } from '@pinia/testing';
 import { useVueFlow } from '@vue-flow/core';
 import type { INodeProperties } from 'n8n-workflow';
 import { setActivePinia } from 'pinia';
-import { reactive, computed, shallowRef } from 'vue';
+import { reactive, computed, ref, shallowRef } from 'vue';
 import { WorkflowIdKey } from '@/app/constants/injectionKeys';
 import { useExperimentalNdvStore } from '@/features/workflows/canvas/experimental/experimentalNdv.store';
 import { useSetupPanelStore } from '@/features/setupPanel/setupPanel.store';
 import FocusSidebar from './FocusSidebar.vue';
+
+// ---- Evaluations experiment + license mocks ----
+const mockIsEvaluationsEnabled = ref(false);
+vi.mock('@/experiments/evaluationsWizardSidepanel/useEvaluationsWizardSidepanelExperiment', () => ({
+	useEvaluationsWizardSidepanelExperiment: () => ({
+		isFeatureEnabled: computed(() => mockIsEvaluationsEnabled.value),
+	}),
+}));
+
+const mockAiRootNodes = ref<string[]>([]);
+vi.mock('@/features/ai/evaluation.ee/composables/useAiRootNodes', () => ({
+	useAiRootNodes: () => computed(() => mockAiRootNodes.value),
+}));
+
+const mockIsLicensed = ref(true);
+const mockIsResolved = ref(true);
+const mockEnsureLicenseLoaded = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/features/ai/evaluation.ee/composables/useEvaluationsLicense', () => ({
+	useEvaluationsLicense: () => ({
+		isLicensed: computed(() => mockIsLicensed.value),
+		isResolved: computed(() => mockIsResolved.value),
+		ensureLicenseLoaded: mockEnsureLicenseLoaded,
+	}),
+}));
 
 vi.mock('vue-router', () => ({
 	useRouter: () => ({}),
@@ -103,6 +127,14 @@ describe('FocusSidebar', () => {
 
 		experimentalNdvStore = mockedStore(useExperimentalNdvStore);
 		experimentalNdvStore.isNdvInFocusPanelEnabled = true;
+
+		// Reset evaluations-related mocks.
+		mockIsEvaluationsEnabled.value = false;
+		mockAiRootNodes.value = [];
+		mockIsLicensed.value = true;
+		mockIsResolved.value = true;
+		mockEnsureLicenseLoaded.mockReset();
+		mockEnsureLicenseLoaded.mockResolvedValue(undefined);
 	});
 
 	describe('when setup panel feature is enabled', () => {
@@ -167,6 +199,46 @@ describe('FocusSidebar', () => {
 
 			const tabs = rendered.getByTestId('setup-panel-tabs');
 			expect(tabs).toHaveTextContent('N0');
+		});
+	});
+
+	describe('evaluations wizard sidepanel', () => {
+		beforeEach(() => {
+			mockIsEvaluationsEnabled.value = true;
+			// Simulate an AI root node being present.
+			mockAiRootNodes.value = ['ai-agent-1'];
+			focusPanelStore.selectedTab = 'evaluations';
+		});
+
+		it('shows the evaluations wizard when licensed, resolved, AI node present, evaluations tab selected', async () => {
+			mockIsLicensed.value = true;
+			mockIsResolved.value = true;
+			const rendered = renderComponent({});
+			// EvaluationsWizardSidepanel is rendered — its stub element appears.
+			// We can't query a test-id since the child components aren't rendered in
+			// unit tests, but the paywall should NOT be present.
+			expect(rendered.queryByTestId('evaluations-unlicensed')).not.toBeInTheDocument();
+		});
+
+		it('shows the evaluations paywall when unlicensed and resolved', async () => {
+			mockIsLicensed.value = false;
+			mockIsResolved.value = true;
+			const rendered = renderComponent({});
+			expect(rendered.queryByTestId('evaluations-unlicensed')).toBeInTheDocument();
+		});
+
+		it('shows neither wizard nor paywall while license is not yet resolved (unresolved state)', async () => {
+			mockIsResolved.value = false;
+			mockIsLicensed.value = false;
+			const rendered = renderComponent({});
+			expect(rendered.queryByTestId('evaluations-unlicensed')).not.toBeInTheDocument();
+		});
+
+		it('calls ensureLicenseLoaded on mount', async () => {
+			const rendered = renderComponent({});
+			// Give Vue a tick to call onMounted.
+			await rendered.findByTestId('focus-sidebar');
+			expect(mockEnsureLicenseLoaded).toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/components/FocusSidebar.vue
+++ b/packages/frontend/editor-ui/src/app/components/FocusSidebar.vue
@@ -20,6 +20,7 @@ import SetupPanel from '@/features/setupPanel/components/SetupPanel.vue';
 import FocusPanel from '@/app/components/FocusPanel.vue';
 import EvaluationsWizardSidepanel from '@/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.vue';
 import { useEvaluationsWizardSidepanelExperiment } from '@/experiments/evaluationsWizardSidepanel/useEvaluationsWizardSidepanelExperiment';
+import { useAiRootNodes } from '@/features/ai/evaluation.ee/composables/useAiRootNodes';
 
 defineOptions({ name: 'FocusSidebar' });
 
@@ -53,19 +54,25 @@ const resolvedParameter = computed(() => focusPanelStore.resolvedParameter);
 const isSetupPanelEnabled = computed(() => setupPanelStore.isFeatureEnabled);
 const { isFeatureEnabled: isEvaluationsWizardSidepanelEnabled } =
 	useEvaluationsWizardSidepanelExperiment();
+const aiRootNodes = useAiRootNodes();
+const hasAiRootNode = computed(() => aiRootNodes.value.length > 0);
 
 const showSetupPanel = computed(
 	() => setupPanelStore.isFeatureEnabled && selectedTab.value === 'setup',
 );
 const showEvaluationsPanel = computed(
-	() => isEvaluationsWizardSidepanelEnabled.value && selectedTab.value === 'evaluations',
+	() =>
+		isEvaluationsWizardSidepanelEnabled.value &&
+		hasAiRootNode.value &&
+		selectedTab.value === 'evaluations',
 );
 
 // Tab bar visibility used to track only the setup panel; now it also needs to
 // stay shown when the evaluations tab is available, otherwise the user has no
 // way to switch back.
 const showTabs = computed(
-	() => isSetupPanelEnabled.value || isEvaluationsWizardSidepanelEnabled.value,
+	() =>
+		isSetupPanelEnabled.value || (isEvaluationsWizardSidepanelEnabled.value && hasAiRootNode.value),
 );
 
 const node = computed<INodeUi | undefined>(() => {

--- a/packages/frontend/editor-ui/src/app/components/FocusSidebar.vue
+++ b/packages/frontend/editor-ui/src/app/components/FocusSidebar.vue
@@ -7,7 +7,7 @@ import { useInjectWorkflowId } from '@/app/composables/useInjectWorkflowId';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useDeviceSupport } from '@n8n/composables/useDeviceSupport';
 import { useTelemetryContext } from '@/app/composables/useTelemetryContext';
-import { computed, watch, useTemplateRef, onBeforeUnmount } from 'vue';
+import { computed, onMounted, watch, useTemplateRef, onBeforeUnmount } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useVueFlow } from '@vue-flow/core';
 import { useActiveElement, useThrottleFn } from '@vueuse/core';
@@ -19,8 +19,10 @@ import FocusSidebarTabs from '@/features/setupPanel/components/FocusSidebarTabs.
 import SetupPanel from '@/features/setupPanel/components/SetupPanel.vue';
 import FocusPanel from '@/app/components/FocusPanel.vue';
 import EvaluationsWizardSidepanel from '@/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.vue';
+import EvaluationsPaywall from '@/features/ai/evaluation.ee/components/Paywall/EvaluationsPaywall.vue';
 import { useEvaluationsWizardSidepanelExperiment } from '@/experiments/evaluationsWizardSidepanel/useEvaluationsWizardSidepanelExperiment';
 import { useAiRootNodes } from '@/features/ai/evaluation.ee/composables/useAiRootNodes';
+import { useEvaluationsLicense } from '@/features/ai/evaluation.ee/composables/useEvaluationsLicense';
 
 defineOptions({ name: 'FocusSidebar' });
 
@@ -56,6 +58,7 @@ const { isFeatureEnabled: isEvaluationsWizardSidepanelEnabled } =
 	useEvaluationsWizardSidepanelExperiment();
 const aiRootNodes = useAiRootNodes();
 const hasAiRootNode = computed(() => aiRootNodes.value.length > 0);
+const { isLicensed, isResolved, ensureLicenseLoaded } = useEvaluationsLicense();
 
 const showSetupPanel = computed(
 	() => setupPanelStore.isFeatureEnabled && selectedTab.value === 'setup',
@@ -64,7 +67,17 @@ const showEvaluationsPanel = computed(
 	() =>
 		isEvaluationsWizardSidepanelEnabled.value &&
 		hasAiRootNode.value &&
-		selectedTab.value === 'evaluations',
+		selectedTab.value === 'evaluations' &&
+		isResolved.value &&
+		isLicensed.value,
+);
+const showEvaluationsPaywall = computed(
+	() =>
+		isEvaluationsWizardSidepanelEnabled.value &&
+		hasAiRootNode.value &&
+		selectedTab.value === 'evaluations' &&
+		isResolved.value &&
+		!isLicensed.value,
 );
 
 // Tab bar visibility used to track only the setup panel; now it also needs to
@@ -147,6 +160,10 @@ function onContextMenuAction(action: ContextMenuAction, nodeIds: string[]) {
 	emit('contextMenuAction', action, nodeIds);
 }
 
+onMounted(() => {
+	void ensureLicenseLoaded();
+});
+
 onBeforeUnmount(() => {
 	unregisterKeyboardListener();
 });
@@ -182,6 +199,9 @@ onBeforeUnmount(() => {
 				</div>
 				<div v-else-if="showEvaluationsPanel" :class="$style['setup-panel-wrapper']">
 					<EvaluationsWizardSidepanel />
+				</div>
+				<div v-else-if="showEvaluationsPaywall" :class="$style['setup-panel-wrapper']">
+					<EvaluationsPaywall />
 				</div>
 				<FocusPanel
 					v-else

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/EvaluationsCanvasInfoCard/EvaluationsCanvasInfoCard.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/EvaluationsCanvasInfoCard/EvaluationsCanvasInfoCard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ref, nextTick } from 'vue';
+import { computed, ref, nextTick } from 'vue';
 import userEvent from '@testing-library/user-event';
 
 import { createComponentRenderer } from '@/__tests__/render';
@@ -49,6 +49,16 @@ vi.mock('@/experiments/evaluationsWizardSidepanel/useEvaluationsWizardSidepanelE
 	useEvaluationsWizardSidepanelExperiment: () => ({ isFeatureEnabled }),
 }));
 
+const mockIsLicensed = ref(true);
+const mockEnsureLicenseLoaded = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../composables/useEvaluationsLicense', () => ({
+	useEvaluationsLicense: () => ({
+		isLicensed: computed(() => mockIsLicensed.value),
+		isResolved: computed(() => true),
+		ensureLicenseLoaded: mockEnsureLicenseLoaded,
+	}),
+}));
+
 const listEvaluationConfigs = vi.fn();
 vi.mock('../../evaluation.api', () => ({
 	listEvaluationConfigs: (...args: unknown[]) => listEvaluationConfigs(...args),
@@ -67,6 +77,9 @@ describe('EvaluationsCanvasInfoCard', () => {
 		mockActive.value = true;
 		mockWorkflowId.value = `wf-${Math.random().toString(36).slice(2, 8)}`;
 		isFeatureEnabled.value = true;
+		mockIsLicensed.value = true;
+		mockEnsureLicenseLoaded.mockReset();
+		mockEnsureLicenseLoaded.mockResolvedValue(undefined);
 		wizardOpen.mockReset();
 		wizardIsOpen.value = false;
 		listEvaluationConfigs.mockReset();
@@ -176,5 +189,25 @@ describe('EvaluationsCanvasInfoCard', () => {
 		await new Promise((resolve) => setTimeout(resolve, 0));
 		await nextTick();
 		expect(queryByTestId('evaluations-canvas-info-card')).not.toBeInTheDocument();
+	});
+
+	it('hides when the user is unlicensed (limit 0) even with all other conditions met', async () => {
+		mockIsLicensed.value = false;
+		const { queryByTestId } = renderComponent();
+		await nextTick();
+		expect(queryByTestId('evaluations-canvas-info-card')).not.toBeInTheDocument();
+		expect(listEvaluationConfigs).not.toHaveBeenCalled();
+	});
+
+	it('shows when the user is licensed (limit -1) with all other conditions met', async () => {
+		mockIsLicensed.value = true;
+		const { findByTestId } = renderComponent();
+		await findByTestId('evaluations-canvas-info-card');
+	});
+
+	it('calls ensureLicenseLoaded on mount', async () => {
+		renderComponent();
+		await nextTick();
+		expect(mockEnsureLicenseLoaded).toHaveBeenCalled();
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/EvaluationsCanvasInfoCard/EvaluationsCanvasInfoCard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/EvaluationsCanvasInfoCard/EvaluationsCanvasInfoCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { useI18n } from '@n8n/i18n';
 import { N8nButton, N8nIcon, N8nText } from '@n8n/design-system';
 
@@ -13,6 +13,7 @@ import { useStorage } from '@/app/composables/useStorage';
 import { LOCAL_STORAGE_EVALUATIONS_CANVAS_INFO_CARD_DISMISSED } from '@/app/constants';
 import { CANNED_METRICS, LLM_JUDGE_METRIC_KEYS } from '../../evaluation.constants';
 import CheckCard from '../WizardSidepanel/CheckCard.vue';
+import { useEvaluationsLicense } from '../../composables/useEvaluationsLicense';
 
 // Preview cards that scroll in the marquee at the top of the info card. We
 // duplicate the list once so the CSS `translateY(-50%)` loop reads as a
@@ -47,6 +48,7 @@ const rootStore = useRootStore();
 const aiRootNodes = useAiRootNodes();
 const { isFeatureEnabled: isEvaluationsWizardSidepanelEnabled } =
 	useEvaluationsWizardSidepanelExperiment();
+const { isLicensed, ensureLicenseLoaded } = useEvaluationsLicense();
 
 const hasConfigs = ref<boolean | null>(null);
 
@@ -81,6 +83,7 @@ const isDismissed = computed(() => {
 const shouldRenderModuleQualifies = computed(
 	() =>
 		isEvaluationsWizardSidepanelEnabled.value &&
+		isLicensed.value &&
 		isWorkflowActive.value &&
 		hasAiNodes.value &&
 		!isDismissed.value,
@@ -94,6 +97,10 @@ const shouldRenderModuleQualifies = computed(
 const isVisible = computed(
 	() => shouldRenderModuleQualifies.value && hasConfigs.value === false && !wizardStore.isOpen,
 );
+
+onMounted(() => {
+	void ensureLicenseLoaded();
+});
 
 async function checkConfigs() {
 	const wfId = workflowId.value;

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 import userEvent from '@testing-library/user-event';
-import { ref } from 'vue';
+import { ref, shallowRef, nextTick } from 'vue';
 
 import { createComponentRenderer } from '@/__tests__/render';
 import EvaluationsWizardSidepanel from './EvaluationsWizardSidepanel.vue';
@@ -20,6 +20,7 @@ type MockNode = {
 };
 const { mocks } = vi.hoisted(() => ({
 	mocks: {
+		workflowId: 'workflow-id' as string,
 		allNodes: [] as MockNode[],
 		sliceInputs: {
 			fieldNames: [] as string[],
@@ -33,19 +34,26 @@ const { mocks } = vi.hoisted(() => ({
 	},
 }));
 
+// Reactive workflow document ref — allows tests to swap workflowId and have
+// Vue's watch() in the component detect the change.
+const workflowDocumentRef = shallowRef({
+	get workflowId() {
+		return mocks.workflowId;
+	},
+	get allNodes() {
+		return mocks.allNodes;
+	},
+});
+
 vi.mock('@/app/stores/workflowDocument.store', () => ({
-	injectWorkflowDocumentStore: () => ({
-		value: {
-			get workflowId() {
-				return 'workflow-id';
-			},
-			get allNodes() {
-				return mocks.allNodes;
-			},
-		},
-	}),
+	injectWorkflowDocumentStore: () => workflowDocumentRef,
 	createWorkflowDocumentId: (id: string) => id,
 	useWorkflowDocumentStore: () => ({}),
+}));
+
+const mockHydrate = vi.fn();
+vi.mock('./useWizardHydration', () => ({
+	useWizardHydration: () => ({ hydrate: mockHydrate, isHydrating: ref(false) }),
 }));
 
 vi.mock('../../composables/useSliceInputs', () => ({
@@ -99,9 +107,20 @@ const renderComponent = createComponentRenderer(EvaluationsWizardSidepanel);
 describe('EvaluationsWizardSidepanel', () => {
 	beforeEach(() => {
 		createTestingPinia({ stubActions: false });
+		mocks.workflowId = 'workflow-id';
 		mocks.allNodes = [];
 		mocks.nodeTypeOutputs = {};
 		mockRouterPush.mockReset();
+		mockHydrate.mockReset();
+		// Trigger Vue to re-read the shallowRef so watchers see the reset workflowId.
+		workflowDocumentRef.value = {
+			get workflowId() {
+				return mocks.workflowId;
+			},
+			get allNodes() {
+				return mocks.allNodes;
+			},
+		};
 	});
 
 	// The wizard now lives as a tab inside FocusSidebar — visibility is
@@ -607,5 +626,78 @@ describe('EvaluationsWizardSidepanel', () => {
 		expect(
 			queryByTestId(`evaluations-wizard-sidepanel-custom-check-${id}`),
 		).not.toBeInTheDocument();
+	});
+
+	describe('workflow-switch watch', () => {
+		it('calls reset() and hydrate() when workflowId changes between two real ids', async () => {
+			const store = useEvaluationsWizardSidepanelStore();
+			// Seed some state to verify it is cleared
+			store.setStep(2);
+			store.toggleMetric('correctness');
+
+			mocks.workflowId = 'wf-1';
+			workflowDocumentRef.value = {
+				get workflowId() {
+					return mocks.workflowId;
+				},
+				get allNodes() {
+					return mocks.allNodes;
+				},
+			};
+
+			renderComponent();
+			await nextTick();
+
+			// Simulate switching to wf-2
+			mocks.workflowId = 'wf-2';
+			workflowDocumentRef.value = {
+				get workflowId() {
+					return mocks.workflowId;
+				},
+				get allNodes() {
+					return mocks.allNodes;
+				},
+			};
+			await nextTick();
+
+			expect(store.activeStep).toBe(0);
+			expect(store.selectedMetricKeys).toEqual([]);
+		});
+
+		it('does NOT call reset() when prevId is the placeholder (new→saved transition)', async () => {
+			const store = useEvaluationsWizardSidepanelStore();
+			store.setStep(1);
+			store.toggleMetric('correctness');
+
+			const NEW_WORKFLOW_ID = '__EMPTY__';
+			mocks.workflowId = NEW_WORKFLOW_ID;
+			workflowDocumentRef.value = {
+				get workflowId() {
+					return mocks.workflowId;
+				},
+				get allNodes() {
+					return mocks.allNodes;
+				},
+			};
+
+			renderComponent();
+			await nextTick();
+
+			// Simulate save completing — id transitions from placeholder to a real id
+			mocks.workflowId = 'wf-saved';
+			workflowDocumentRef.value = {
+				get workflowId() {
+					return mocks.workflowId;
+				},
+				get allNodes() {
+					return mocks.allNodes;
+				},
+			};
+			await nextTick();
+
+			// State must NOT be reset when transitioning from the placeholder id
+			expect(store.activeStep).toBe(1);
+			expect(store.selectedMetricKeys).toEqual(['correctness']);
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.test.ts
@@ -699,5 +699,47 @@ describe('EvaluationsWizardSidepanel', () => {
 			expect(store.activeStep).toBe(1);
 			expect(store.selectedMetricKeys).toEqual(['correctness']);
 		});
+
+		it('resets across an unmount/remount on a different workflow (pane closed between workflows)', async () => {
+			const store = useEvaluationsWizardSidepanelStore();
+
+			// Pane first opens on wf-1 and reaches the results step with a run.
+			mocks.workflowId = 'wf-1';
+			workflowDocumentRef.value = {
+				get workflowId() {
+					return mocks.workflowId;
+				},
+				get allNodes() {
+					return mocks.allNodes;
+				},
+			};
+			const first = renderComponent();
+			await nextTick();
+			store.setStep(3);
+			store.toggleMetric('correctness');
+			store.setActiveRunId('run-from-wf-1');
+
+			// The focus panel closes between workflows, so the pane unmounts. The
+			// store (and its lastWorkflowId bookkeeping) survives.
+			first.unmount();
+			await nextTick();
+
+			// User switches to wf-2 and re-opens the evaluations pane → fresh mount.
+			mocks.workflowId = 'wf-2';
+			workflowDocumentRef.value = {
+				get workflowId() {
+					return mocks.workflowId;
+				},
+				get allNodes() {
+					return mocks.allNodes;
+				},
+			};
+			renderComponent();
+			await nextTick();
+
+			expect(store.activeStep).toBe(0);
+			expect(store.selectedMetricKeys).toEqual([]);
+			expect(store.activeRunId).toBeNull();
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.vue
@@ -172,15 +172,20 @@ const { hydrate } = useWizardHydration();
 const NEW_WORKFLOW_ID = '__EMPTY__';
 watch(
 	() => [wizardStore.isOpen, workflowDocumentStore.value?.workflowId] as const,
-	([isOpen], oldValues) => {
-		const prevId = oldValues?.[1];
+	([isOpen]) => {
 		const id = workflowDocumentStore.value?.workflowId;
+		// Compare against the store-persisted last workflow id rather than the
+		// watcher's previous value: the pane unmounts when the focus panel closes
+		// between workflows, so on remount the watcher has no previous value and
+		// would otherwise miss the switch (leaving a prior run's results visible).
+		const prevId = wizardStore.lastWorkflowId;
 		// Reset only on a genuine switch between saved workflows. Skip the
 		// new→saved id transition (prevId placeholder/empty) so a user's
 		// in-progress selections on a brand-new workflow aren't wiped on save.
 		if (prevId && prevId !== NEW_WORKFLOW_ID && id && id !== prevId) {
 			wizardStore.reset();
 		}
+		if (id) wizardStore.setLastWorkflowId(id);
 		if (isOpen) void hydrate();
 	},
 	{ immediate: true },

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.vue
@@ -163,11 +163,24 @@ const { hydrate } = useWizardHydration();
 // Hydrate from the latest persisted EvaluationConfig whenever the wizard is
 // opened — the store's `open()` resets state first, so this safely overrides
 // the empty defaults without clobbering anything the user has already typed.
+// Also reset + re-hydrate on a genuine workflow switch so prior-workflow
+// selections do not leak into the new workflow's pane.
 // Errors inside `hydrate` are swallowed by the composable (it toasts) so we
 // don't need to handle them here.
+
+// Local mirror of n8n-core PLACEHOLDER_EMPTY_WORKFLOW_ID (frontend can't import n8n-core).
+const NEW_WORKFLOW_ID = '__EMPTY__';
 watch(
-	() => wizardStore.isOpen,
-	(isOpen) => {
+	() => [wizardStore.isOpen, workflowDocumentStore.value?.workflowId] as const,
+	([isOpen], oldValues) => {
+		const prevId = oldValues?.[1];
+		const id = workflowDocumentStore.value?.workflowId;
+		// Reset only on a genuine switch between saved workflows. Skip the
+		// new→saved id transition (prevId placeholder/empty) so a user's
+		// in-progress selections on a brand-new workflow aren't wiped on save.
+		if (prevId && prevId !== NEW_WORKFLOW_ID && id && id !== prevId) {
+			wizardStore.reset();
+		}
 		if (isOpen) void hydrate();
 	},
 	{ immediate: true },

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/composables/useEvaluationsLicense.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/composables/useEvaluationsLicense.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Module-level state holders. We cannot use `ref` inside `vi.hoisted` (it runs
+// before module imports), so we declare them at module scope instead.
+// vi.mock factories can still close over them.
+// NOTE: we expose primitive values, not refs, because Pinia auto-unwraps refs when
+// it returns store properties, but our hand-rolled mock does not.
+let stateLimit = 0 as number;
+let stateHasLoadedLicense = false;
+const stateGetLicenseInfo = vi.fn<() => Promise<void>>();
+
+vi.mock('@/features/settings/usage/usage.store', () => ({
+	useUsageStore: () => ({
+		get workflowsWithEvaluationsLimit() {
+			return stateLimit;
+		},
+		get hasLoadedLicense() {
+			return stateHasLoadedLicense;
+		},
+		getLicenseInfo: stateGetLicenseInfo,
+	}),
+}));
+
+// Import AFTER mocks are set up.
+// We use vi.resetModules() in beforeEach to reset the module-cached licensePromise
+// between tests so each test starts with a clean state.
+
+describe('useEvaluationsLicense', () => {
+	beforeEach(async () => {
+		stateLimit = 0;
+		stateHasLoadedLicense = false;
+		stateGetLicenseInfo.mockReset();
+		stateGetLicenseInfo.mockResolvedValue(undefined);
+		// Reset modules to clear the module-cached licensePromise.
+		vi.resetModules();
+	});
+
+	async function getComposable() {
+		// Re-import after resetModules so we get a fresh licensePromise each test.
+		const { useEvaluationsLicense } = await import('./useEvaluationsLicense');
+		return useEvaluationsLicense();
+	}
+
+	describe('isLicensed', () => {
+		it('is false when limit is 0 (unlicensed)', async () => {
+			stateLimit = 0;
+			const { isLicensed } = await getComposable();
+			expect(isLicensed.value).toBe(false);
+		});
+
+		it('is true when limit is -1 (unlimited)', async () => {
+			stateLimit = -1;
+			const { isLicensed } = await getComposable();
+			expect(isLicensed.value).toBe(true);
+		});
+
+		it('is true when limit is a positive number (capped)', async () => {
+			stateLimit = 5;
+			const { isLicensed } = await getComposable();
+			expect(isLicensed.value).toBe(true);
+		});
+	});
+
+	describe('isResolved', () => {
+		it('is false when hasLoadedLicense is false', async () => {
+			stateHasLoadedLicense = false;
+			const { isResolved } = await getComposable();
+			expect(isResolved.value).toBe(false);
+		});
+
+		it('is true when hasLoadedLicense is true', async () => {
+			stateHasLoadedLicense = true;
+			const { isResolved } = await getComposable();
+			expect(isResolved.value).toBe(true);
+		});
+	});
+
+	describe('ensureLicenseLoaded', () => {
+		it('calls getLicenseInfo on first invocation', async () => {
+			const { ensureLicenseLoaded } = await getComposable();
+			await ensureLicenseLoaded();
+			expect(stateGetLicenseInfo).toHaveBeenCalledTimes(1);
+		});
+
+		it('deduplicates: calling twice only calls getLicenseInfo once', async () => {
+			const { ensureLicenseLoaded } = await getComposable();
+			// Call twice concurrently.
+			await Promise.all([ensureLicenseLoaded(), ensureLicenseLoaded()]);
+			expect(stateGetLicenseInfo).toHaveBeenCalledTimes(1);
+		});
+
+		it('deduplicates: second sequential call also only calls getLicenseInfo once', async () => {
+			const { ensureLicenseLoaded } = await getComposable();
+			await ensureLicenseLoaded();
+			await ensureLicenseLoaded();
+			expect(stateGetLicenseInfo).toHaveBeenCalledTimes(1);
+		});
+
+		it('resets cache on error so next call retries', async () => {
+			stateGetLicenseInfo
+				.mockRejectedValueOnce(new Error('Network error'))
+				.mockResolvedValue(undefined);
+
+			const { ensureLicenseLoaded } = await getComposable();
+
+			// First call fails — should not throw (errors are swallowed).
+			await expect(ensureLicenseLoaded()).resolves.toBeUndefined();
+
+			// After failure the cache is reset, so the next call retries.
+			await ensureLicenseLoaded();
+			expect(stateGetLicenseInfo).toHaveBeenCalledTimes(2);
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/composables/useEvaluationsLicense.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/composables/useEvaluationsLicense.ts
@@ -1,0 +1,23 @@
+import { computed } from 'vue';
+import { useUsageStore } from '@/features/settings/usage/usage.store';
+
+// Module-cached so the canvas info card + side pane share one fetch.
+let licensePromise: Promise<void> | null = null;
+
+export function useEvaluationsLicense() {
+	const usageStore = useUsageStore();
+	const isLicensed = computed(() => usageStore.workflowsWithEvaluationsLimit !== 0);
+	const isResolved = computed(() => usageStore.hasLoadedLicense);
+
+	async function ensureLicenseLoaded(): Promise<void> {
+		if (!licensePromise) {
+			licensePromise = usageStore.getLicenseInfo().catch(() => {
+				// Swallow — surfaces default to hidden/paywalled, which is the safe state.
+				licensePromise = null;
+			});
+		}
+		await licensePromise;
+	}
+
+	return { isLicensed, isResolved, ensureLicenseLoaded };
+}

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.test.ts
@@ -10,7 +10,7 @@ import { useUsageStore } from '@/features/settings/usage/usage.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { mockedStore } from '@/__tests__/utils';
 import type { IWorkflowDb } from '@/Interface';
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import { waitFor } from '@testing-library/vue';
 import { flushPromises } from '@vue/test-utils';
 import type { TestRunRecord } from '../evaluation.api';
@@ -18,6 +18,24 @@ import { useTelemetry } from '@/app/composables/useTelemetry';
 import { EVALUATION_NODE_TYPE, EVALUATION_TRIGGER_NODE_TYPE, NodeHelpers } from 'n8n-workflow';
 import { mockNodeTypeDescription } from '@/__tests__/mocks';
 import type { SourceControlPreferences } from '@/features/integrations/sourceControl.ee/sourceControl.types';
+
+// ---- Evaluations experiment flag mock (default off → preserves existing tests) ----
+const mockIsWizardSidepanelEnabled = ref(false);
+vi.mock('@/experiments/evaluationsWizardSidepanel/useEvaluationsWizardSidepanelExperiment', () => ({
+	useEvaluationsWizardSidepanelExperiment: () => ({
+		isFeatureEnabled: computed(() => mockIsWizardSidepanelEnabled.value),
+	}),
+}));
+
+// ---- Evaluations license composable mock (default licensed) ----
+const mockIsLicensed = ref(true);
+vi.mock('../composables/useEvaluationsLicense', () => ({
+	useEvaluationsLicense: () => ({
+		isLicensed: computed(() => mockIsLicensed.value),
+		isResolved: computed(() => true),
+		ensureLicenseLoaded: vi.fn().mockResolvedValue(undefined),
+	}),
+}));
 
 const { showError } = vi.hoisted(() => ({
 	showError: vi.fn(),
@@ -111,6 +129,8 @@ describe('EvaluationsRootView', () => {
 		mockEvaluationTriggerExists.value = false;
 		mockEvaluationSetOutputsNodeExist.value = false;
 		mockEvaluationSetMetricsNodeExist.value = false;
+		mockIsWizardSidepanelEnabled.value = false;
+		mockIsLicensed.value = true;
 
 		mockedStore(useWorkflowsStore).isWorkflowSaved = { [mockWorkflow.id]: true };
 
@@ -457,6 +477,31 @@ describe('EvaluationsRootView', () => {
 					quota_reached: true,
 				});
 			});
+		});
+	});
+
+	describe('wizard-experiment branch (isEvaluationsWizardSidepanelEnabled = true)', () => {
+		beforeEach(() => {
+			mockIsWizardSidepanelEnabled.value = true;
+			const usageStore = mockedStore(useUsageStore);
+			const evaluationStore = mockedStore(useEvaluationStore);
+			usageStore.getLicenseInfo.mockResolvedValue(undefined);
+			evaluationStore.fetchTestRuns.mockResolvedValue([]);
+			evaluationStore.testRunsById = {};
+		});
+
+		it('renders paywall (evaluations-unlicensed) when unlicensed and no test runs', async () => {
+			mockIsLicensed.value = false;
+			const { findByTestId } = renderComponent({ props: { workflowId: mockWorkflow.id } });
+			await flushPromises();
+			await findByTestId('evaluations-unlicensed');
+		});
+
+		it('renders empty state (evaluations-empty-state) when licensed and no test runs', async () => {
+			mockIsLicensed.value = true;
+			const { findByTestId } = renderComponent({ props: { workflowId: mockWorkflow.id } });
+			await flushPromises();
+			await findByTestId('evaluations-empty-state');
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.vue
@@ -18,6 +18,7 @@ import EvaluationsEmptyState from '../components/EvaluationsEmptyState/Evaluatio
 import { N8nCallout, N8nLink, N8nText } from '@n8n/design-system';
 import { useWorkflowEvaluationState } from '../composables/useWorkflowEvaluationState';
 import { useEvaluationsWizardSidepanelExperiment } from '@/experiments/evaluationsWizardSidepanel/useEvaluationsWizardSidepanelExperiment';
+import { useEvaluationsLicense } from '../composables/useEvaluationsLicense';
 const props = defineProps<{
 	workflowId: string;
 }>();
@@ -34,9 +35,7 @@ const router = useRouter();
 const { isFeatureEnabled: isEvaluationsWizardSidepanelEnabled } =
 	useEvaluationsWizardSidepanelExperiment();
 
-const evaluationsLicensed = computed(() => {
-	return usageStore.workflowsWithEvaluationsLimit !== 0;
-});
+const { isLicensed } = useEvaluationsLicense();
 
 const isProtectedEnvironment = computed(() => {
 	return sourceControlStore.preferences.branchReadOnly;
@@ -152,7 +151,12 @@ watch(
 			opened — same destination the floating CTA above already targets.
 		-->
 		<template v-if="isReady && showWizard && isEvaluationsWizardSidepanelEnabled">
-			<EvaluationsEmptyState :disabled="isProtectedEnvironment" @get-started="openWizardOnCanvas" />
+			<EvaluationsPaywall v-if="!isLicensed" />
+			<EvaluationsEmptyState
+				v-else
+				:disabled="isProtectedEnvironment"
+				@get-started="openWizardOnCanvas"
+			/>
 		</template>
 		<template v-else-if="isReady && showWizard">
 			<div :class="$style.setupContent">
@@ -183,7 +187,7 @@ watch(
 						referrerpolicy="strict-origin-when-cross-origin"
 						allowfullscreen
 					></iframe>
-					<SetupWizard v-if="evaluationsLicensed" @run-test="runTest" />
+					<SetupWizard v-if="isLicensed" @run-test="runTest" />
 					<EvaluationsPaywall v-else />
 				</div>
 			</div>

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/wizardSidepanel.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/wizardSidepanel.store.test.ts
@@ -174,6 +174,7 @@ describe('wizardSidepanel.store', () => {
 		store.addCustomCheck({ name: 'Check A', expression: '1 === 1' });
 		store.openCustomCheckModal();
 		store.setActiveRunId('run-99');
+		store.setLastWorkflowId('wf-1');
 
 		// Confirm state was applied
 		expect(store.activeStep).toBe(2);
@@ -199,5 +200,8 @@ describe('wizardSidepanel.store', () => {
 		expect(store.customChecks).toEqual([]);
 		expect(store.isCustomCheckModalOpen).toBe(false);
 		expect(store.activeRunId).toBeNull();
+		// lastWorkflowId is bookkeeping that must survive reset so a remount on a
+		// different workflow can still detect the switch.
+		expect(store.lastWorkflowId).toBe('wf-1');
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/wizardSidepanel.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/wizardSidepanel.store.test.ts
@@ -162,4 +162,42 @@ describe('wizardSidepanel.store', () => {
 		expect(store.customChecks).toEqual([]);
 		expect(store.isCustomCheckModalOpen).toBe(false);
 	});
+
+	it('reset() clears all wizard state back to defaults', () => {
+		const store = useEvaluationsWizardSidepanelStore();
+
+		// Set some state
+		store.setStep(2);
+		store.toggleMetric('correctness');
+		store.setAiNodeName('AI Agent');
+		store.setInputValue('input1', 'hello');
+		store.addCustomCheck({ name: 'Check A', expression: '1 === 1' });
+		store.openCustomCheckModal();
+		store.setActiveRunId('run-99');
+
+		// Confirm state was applied
+		expect(store.activeStep).toBe(2);
+		expect(store.selectedMetricKeys).toEqual(['correctness']);
+		expect(store.aiNodeName).toBe('AI Agent');
+		expect(store.inputs).toEqual({ input1: 'hello' });
+		expect(store.customChecks).toHaveLength(1);
+		expect(store.isCustomCheckModalOpen).toBe(true);
+		expect(store.activeRunId).toBe('run-99');
+
+		// Reset and assert all back to defaults
+		store.reset();
+
+		expect(store.activeStep).toBe(0);
+		expect(store.selectedMetricKeys).toEqual([]);
+		expect(store.judgeSelectionByMetric).toEqual({});
+		expect(store.aiNodeName).toBe('');
+		expect(store.isSliceMode).toBe(false);
+		expect(store.startNodeName).toBe('');
+		expect(store.endNodeName).toBe('');
+		expect(store.inputs).toEqual({});
+		expect(store.expectedValues).toEqual({});
+		expect(store.customChecks).toEqual([]);
+		expect(store.isCustomCheckModalOpen).toBe(false);
+		expect(store.activeRunId).toBeNull();
+	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/wizardSidepanel.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/wizardSidepanel.store.ts
@@ -44,6 +44,11 @@ export const useEvaluationsWizardSidepanelStore = defineStore(
 		// Pinned at dispatch — fetchTestRuns returns ALL of a workflow's runs,
 		// so "newest in map" can't identify the run THIS session started.
 		const activeRunId = ref<string | null>(null);
+		// The workflow the wizard state currently belongs to. Survives the pane's
+		// unmount (the focus panel closes between workflows), so a remount on a
+		// different workflow can still detect the switch and reset. Intentionally
+		// NOT cleared by resetState — it's bookkeeping, not wizard content.
+		const lastWorkflowId = ref<string>('');
 
 		function resetState() {
 			activeStep.value = 0;
@@ -165,6 +170,10 @@ export const useEvaluationsWizardSidepanelStore = defineStore(
 			activeRunId.value = id;
 		}
 
+		function setLastWorkflowId(id: string) {
+			lastWorkflowId.value = id;
+		}
+
 		// Preserves user edits (including intentionally cleared fields).
 		function seedInputs(values: Record<string, string>) {
 			const next: Record<string, string> = { ...values };
@@ -188,6 +197,7 @@ export const useEvaluationsWizardSidepanelStore = defineStore(
 			customChecks,
 			isCustomCheckModalOpen,
 			activeRunId,
+			lastWorkflowId,
 			open,
 			close,
 			toggle,
@@ -208,6 +218,7 @@ export const useEvaluationsWizardSidepanelStore = defineStore(
 			addCustomCheck,
 			removeCustomCheck,
 			setActiveRunId,
+			setLastWorkflowId,
 		};
 	},
 );

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/wizardSidepanel.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/wizardSidepanel.store.ts
@@ -191,6 +191,7 @@ export const useEvaluationsWizardSidepanelStore = defineStore(
 			open,
 			close,
 			toggle,
+			reset: resetState,
 			setStep,
 			goNext,
 			goBack,

--- a/packages/frontend/editor-ui/src/features/settings/usage/usage.store.ts
+++ b/packages/frontend/editor-ui/src/features/settings/usage/usage.store.ts
@@ -1,4 +1,4 @@
-import { computed, reactive } from 'vue';
+import { computed, reactive, ref } from 'vue';
 import { defineStore } from 'pinia';
 import type { UsageState } from '@n8n/api-types';
 import * as usageApi from '@n8n/rest-api-client/api/usage';
@@ -40,6 +40,7 @@ export const useUsageStore = defineStore('usage', () => {
 	const settingsStore = useSettingsStore();
 
 	const state = reactive<UsageState>({ ...DEFAULT_STATE });
+	const hasLoadedLicense = ref(false);
 
 	const planName = computed(() => state.data.license.planName || DEFAULT_PLAN_NAME);
 	const planId = computed(() => state.data.license.planId);
@@ -72,6 +73,7 @@ export const useUsageStore = defineStore('usage', () => {
 
 	const setData = (data: UsageState['data']) => {
 		state.data = data;
+		hasLoadedLicense.value = true;
 	};
 
 	const getLicenseInfo = async () => {
@@ -113,6 +115,7 @@ export const useUsageStore = defineStore('usage', () => {
 		refreshLicenseManagementToken,
 		requestEnterpriseLicenseTrial,
 		registerCommunityEdition,
+		hasLoadedLicense,
 		planName,
 		planId,
 		activeWorkflowTriggersLimit,

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/FocusSidebarTabs.test.ts
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/FocusSidebarTabs.test.ts
@@ -17,6 +17,11 @@ vi.mock('@/experiments/evaluationsWizardSidepanel/useEvaluationsWizardSidepanelE
 	useEvaluationsWizardSidepanelExperiment: () => ({ isFeatureEnabled: isEvaluationsEnabled }),
 }));
 
+const aiRootNodes = ref<Array<{ name: string; type: string }>>([]);
+vi.mock('@/features/ai/evaluation.ee/composables/useAiRootNodes', () => ({
+	useAiRootNodes: () => aiRootNodes,
+}));
+
 const renderComponent = createComponentRenderer(FocusSidebarTabs);
 
 describe('FocusSidebarTabs', () => {
@@ -24,6 +29,7 @@ describe('FocusSidebarTabs', () => {
 		setActivePinia(createPinia());
 		isSetupPanelEnabled.value = true;
 		isEvaluationsEnabled.value = false;
+		aiRootNodes.value = [];
 	});
 
 	it('should render tabs with default labels', () => {
@@ -73,11 +79,40 @@ describe('FocusSidebarTabs', () => {
 	it('hides the Setup tab when the setup feature is disabled', () => {
 		isSetupPanelEnabled.value = false;
 		isEvaluationsEnabled.value = true;
+		aiRootNodes.value = [{ name: 'AI Agent', type: '@n8n/n8n-nodes-langchain.agent' }];
 		const { getByText, queryByText } = renderComponent();
 
 		expect(queryByText('Setup')).not.toBeInTheDocument();
 		expect(getByText('Focus')).toBeInTheDocument();
 		expect(getByText('Evaluations')).toBeInTheDocument();
+	});
+
+	it('shows the Evaluations tab when the experiment is enabled AND an AI root node is present', () => {
+		isEvaluationsEnabled.value = true;
+		aiRootNodes.value = [{ name: 'AI Agent', type: '@n8n/n8n-nodes-langchain.agent' }];
+		const { getByText } = renderComponent();
+
+		expect(getByText('Evaluations')).toBeInTheDocument();
+	});
+
+	it('hides the Evaluations tab when the experiment is enabled but no AI root node is present', () => {
+		isEvaluationsEnabled.value = true;
+		aiRootNodes.value = [];
+		const { queryByText } = renderComponent();
+
+		expect(queryByText('Evaluations')).not.toBeInTheDocument();
+	});
+
+	it('hides the Evaluations tab when no AI root node is present even after one is removed', async () => {
+		isEvaluationsEnabled.value = true;
+		aiRootNodes.value = [{ name: 'AI Agent', type: '@n8n/n8n-nodes-langchain.agent' }];
+		const { getByText, queryByText, rerender } = renderComponent();
+		expect(getByText('Evaluations')).toBeInTheDocument();
+
+		aiRootNodes.value = [];
+		// Await reactivity flush
+		await rerender({});
+		expect(queryByText('Evaluations')).not.toBeInTheDocument();
 	});
 
 	it('should emit update:modelValue when a tab is clicked', async () => {

--- a/packages/frontend/editor-ui/src/features/setupPanel/components/FocusSidebarTabs.vue
+++ b/packages/frontend/editor-ui/src/features/setupPanel/components/FocusSidebarTabs.vue
@@ -7,6 +7,7 @@ import { N8nIcon, N8nTabs } from '@n8n/design-system';
 import { useFocusPanelStore } from '@/app/stores/focusPanel.store';
 import { useSetupPanelStore } from '@/features/setupPanel/setupPanel.store';
 import { useEvaluationsWizardSidepanelExperiment } from '@/experiments/evaluationsWizardSidepanel/useEvaluationsWizardSidepanelExperiment';
+import { useAiRootNodes } from '@/features/ai/evaluation.ee/composables/useAiRootNodes';
 
 const i18n = useI18n();
 const focusPanelStore = useFocusPanelStore();
@@ -14,6 +15,8 @@ const setupPanelStore = useSetupPanelStore();
 const isSetupPanelEnabled = computed(() => setupPanelStore.isFeatureEnabled);
 const { isFeatureEnabled: isEvaluationsWizardSidepanelEnabled } =
 	useEvaluationsWizardSidepanelExperiment();
+const aiRootNodes = useAiRootNodes();
+const hasAiRootNode = computed(() => aiRootNodes.value.length > 0);
 
 const props = withDefaults(
 	defineProps<{
@@ -48,7 +51,7 @@ const tabs = computed<Array<TabOptions<FocusSidebarTabs>>>(() => {
 		label: props.tabLabels?.focus ?? i18n.baseText('setupPanel.tabs.focus'),
 		value: 'focus',
 	});
-	if (isEvaluationsWizardSidepanelEnabled.value) {
+	if (isEvaluationsWizardSidepanelEnabled.value && hasAiRootNode.value) {
 		opts.push({
 			label: props.tabLabels?.evaluations ?? i18n.baseText('setupPanel.tabs.evaluations'),
 			value: 'evaluations',


### PR DESCRIPTION
## Summary

The evaluations pane previously showed content from the previous workflow when switching workflows, and appeared even when the canvas had no AI node. This PR:

- Gates the evals pane so it only shows when the canvas has an AI root node.
- Resets the wizard side panel state on workflow switch, including across pane remounts.

Includes unit tests for the gating and reset behaviour (`FocusSidebar`, `FocusSidebarTabs`, `EvaluationsWizardSidepanel`, `wizardSidepanel` store).

## How to test

1. Create a workflow with an agent node, add evals, run it.
2. Create a new workflow → the evals pane should reset (no leftover checks) and only appear when an AI node is present on the canvas.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/TRUST-138

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI