### PR TITLE
feat(editor): Filter non-applicable evaluation checks (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/checkFilters.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/checkFilters.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+
+import { CANNED_METRICS } from './evaluation.constants';
+import { getVisibleChecks } from './checkFilters';
+
+describe('getVisibleChecks', () => {
+	it('excludes toolsUsed when sliceCanHaveTools is false', () => {
+		const visible = getVisibleChecks(CANNED_METRICS, { sliceCanHaveTools: false });
+		expect(visible.map((m) => m.key)).not.toContain('toolsUsed');
+	});
+
+	it('includes all other four checks when sliceCanHaveTools is false', () => {
+		const visible = getVisibleChecks(CANNED_METRICS, { sliceCanHaveTools: false });
+		expect(visible.map((m) => m.key)).toContain('correctness');
+		expect(visible.map((m) => m.key)).toContain('helpfulness');
+		expect(visible.map((m) => m.key)).toContain('stringSimilarity');
+		expect(visible.map((m) => m.key)).toContain('categorization');
+		expect(visible).toHaveLength(CANNED_METRICS.length - 1);
+	});
+
+	it('includes all five checks when sliceCanHaveTools is true', () => {
+		const visible = getVisibleChecks(CANNED_METRICS, { sliceCanHaveTools: true });
+		expect(visible.map((m) => m.key)).toContain('toolsUsed');
+		expect(visible).toHaveLength(CANNED_METRICS.length);
+	});
+
+	it('never removes correctness, helpfulness, stringSimilarity, or categorization regardless of context', () => {
+		const ctx = { sliceCanHaveTools: false };
+		const visible = getVisibleChecks(CANNED_METRICS, ctx);
+		const keys = visible.map((m) => m.key);
+		expect(keys).toContain('correctness');
+		expect(keys).toContain('helpfulness');
+		expect(keys).toContain('stringSimilarity');
+		expect(keys).toContain('categorization');
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/checkFilters.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/checkFilters.ts
@@ -1,0 +1,22 @@
+import type { CannedMetric, CannedMetricKey } from './evaluation.constants';
+
+export interface CheckFilterContext {
+	// Whether the evaluated slice's root (end) node can accept tool connections.
+	sliceCanHaveTools: boolean;
+	// Extend with more workflow-derived facts as new filters are added.
+}
+
+// A filter returns true to KEEP the check. Add new predicates to this array.
+export type CheckFilter = (metric: CannedMetric, ctx: CheckFilterContext) => boolean;
+
+export const CHECK_FILTERS: CheckFilter[] = [
+	// Tool Usage is only meaningful when the evaluated node can use tools.
+	(metric, ctx) => metric.key !== ('toolsUsed' satisfies CannedMetricKey) || ctx.sliceCanHaveTools,
+];
+
+export function getVisibleChecks(
+	metrics: readonly CannedMetric[],
+	ctx: CheckFilterContext,
+): CannedMetric[] {
+	return metrics.filter((metric) => CHECK_FILTERS.every((filter) => filter(metric, ctx)));
+}

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.test.ts
@@ -30,6 +30,8 @@ const { mocks } = vi.hoisted(() => ({
 		// matches the default test pinia behaviour — `isSubNodeType` then treats
 		// the node as non-sub and the slice picker shows it.
 		nodeTypeOutputs: {} as Record<string, string[]>,
+		// Controls what useNodeToolCapability returns for the end node.
+		endNodeCanHaveTools: false,
 	},
 }));
 
@@ -83,6 +85,12 @@ vi.mock('@/app/composables/useRunWorkflow', () => ({
 	}),
 }));
 
+vi.mock('../../composables/useNodeToolCapability', () => ({
+	useNodeToolCapability: () => ({
+		nodeCanHaveTools: (_name: string) => mocks.endNodeCanHaveTools,
+	}),
+}));
+
 const mockRouterPush = vi.fn();
 vi.mock('vue-router', async (importOriginal) => {
 	const actual = (await importOriginal()) as Record<string, unknown>;
@@ -101,6 +109,7 @@ describe('EvaluationsWizardSidepanel', () => {
 		createTestingPinia({ stubActions: false });
 		mocks.allNodes = [];
 		mocks.nodeTypeOutputs = {};
+		mocks.endNodeCanHaveTools = false;
 		mockRouterPush.mockReset();
 	});
 
@@ -215,14 +224,52 @@ describe('EvaluationsWizardSidepanel', () => {
 		expect(docHtml).not.toContain('OpenAI Chat Model');
 	});
 
-	it('renders every canned metric option on step 1 (Setup Checks)', () => {
+	it('renders every canned metric option on step 1 when end node can have tools', () => {
 		const store = useEvaluationsWizardSidepanelStore();
 		store.open(1);
+		mocks.endNodeCanHaveTools = true;
 
 		const { getByTestId } = renderComponent();
 		for (const metric of CANNED_METRICS) {
 			expect(getByTestId(`evaluations-wizard-sidepanel-metric-${metric.key}`)).toBeInTheDocument();
 		}
+	});
+
+	it('hides the toolsUsed check card on step 1 when end node cannot have tools', () => {
+		const store = useEvaluationsWizardSidepanelStore();
+		store.open(1);
+		mocks.endNodeCanHaveTools = false;
+
+		const { queryByTestId, getByTestId } = renderComponent();
+		expect(queryByTestId('evaluations-wizard-sidepanel-metric-toolsUsed')).not.toBeInTheDocument();
+		// All other checks remain visible.
+		expect(getByTestId('evaluations-wizard-sidepanel-metric-correctness')).toBeInTheDocument();
+		expect(getByTestId('evaluations-wizard-sidepanel-metric-helpfulness')).toBeInTheDocument();
+		expect(getByTestId('evaluations-wizard-sidepanel-metric-stringSimilarity')).toBeInTheDocument();
+		expect(getByTestId('evaluations-wizard-sidepanel-metric-categorization')).toBeInTheDocument();
+	});
+
+	it('prunes toolsUsed from selectedMetricKeys when the end node loses tool capability', async () => {
+		const store = useEvaluationsWizardSidepanelStore();
+		store.open(1);
+		// Start with toolsUsed selected and node that can have tools.
+		mocks.endNodeCanHaveTools = true;
+		store.selectedMetricKeys = ['correctness', 'toolsUsed'];
+
+		renderComponent();
+		await nextTick();
+
+		// Now simulate end node losing tool capability.
+		mocks.endNodeCanHaveTools = false;
+		// The visibleChecks computed in the component is derived from the mock via
+		// useNodeToolCapability. Trigger re-evaluation by changing the aiNodeName
+		// (which triggers sliceEndNodeName and then visibleChecks).
+		store.setAiNodeName('BasicLLM');
+		await nextTick();
+
+		// toolsUsed should be removed from selectedMetricKeys.
+		expect(store.selectedMetricKeys).not.toContain('toolsUsed');
+		expect(store.selectedMetricKeys).toContain('correctness');
 	});
 
 	it('toggles selection when a check card is clicked on step 1', async () => {

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.vue
@@ -34,6 +34,8 @@ import {
 import { useSliceInputs } from '../../composables/useSliceInputs';
 import { useAiRootNodes } from '../../composables/useAiRootNodes';
 import { useDefaultJudgeSelection } from '../../composables/useDefaultJudgeSelection';
+import { useNodeToolCapability } from '../../composables/useNodeToolCapability';
+import { getVisibleChecks } from '../../checkFilters';
 import { useWizardPersistence } from './useWizardPersistence';
 import { useWizardHydration } from './useWizardHydration';
 import CheckCard from './CheckCard.vue';
@@ -93,6 +95,11 @@ watch(
 const agentsResponse = computed(() => chatStore.agents);
 const cannedMetrics = computed(() => CANNED_METRICS);
 const aiRootNodes = useAiRootNodes();
+const { nodeCanHaveTools } = useNodeToolCapability();
+const sliceCanHaveTools = computed(() => nodeCanHaveTools(sliceEndNodeName.value));
+const visibleChecks = computed(() =>
+	getVisibleChecks(CANNED_METRICS, { sliceCanHaveTools: sliceCanHaveTools.value }),
+);
 const defaultJudgeSelection = useDefaultJudgeSelection();
 
 // Watching judgeSelectionByMetric so a hydrate that drops some keys still
@@ -388,6 +395,16 @@ function metricScorePercent(key: string): number {
 	return Number.isFinite(parsed) ? Math.max(0, Math.min(100, parsed)) : 0;
 }
 
+// Prune any selectedMetricKey that is no longer in visibleChecks so a hidden
+// metric can't be persisted or dispatched.
+watch(visibleChecks, (visible) => {
+	const visibleKeys = new Set(visible.map((m) => m.key));
+	const pruned = selectedMetricKeys.value.filter((k) => visibleKeys.has(k));
+	if (pruned.length !== selectedMetricKeys.value.length) {
+		wizardStore.setSelectedMetricKeys(pruned);
+	}
+});
+
 async function handleNext() {
 	const current = activeStep.value;
 	if (current === 0) {
@@ -459,7 +476,7 @@ function handleViewResults() {
 
 			<section v-if="activeStep === 1" :class="$style.section">
 				<ul :class="$style.checkList">
-					<li v-for="metric in cannedMetrics" :key="metric.key">
+					<li v-for="metric in visibleChecks" :key="metric.key">
 						<CheckCard
 							:icon="metric.icon"
 							:icon-bg="metric.tileBg"

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/composables/useNodeToolCapability.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/composables/useNodeToolCapability.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { NodeConnectionTypes } from 'n8n-workflow';
+
+import { useNodeToolCapability } from './useNodeToolCapability';
+
+// Hoisted mutable state — avoids module-scope reactive refs surviving teardown.
+const state = vi.hoisted(() => ({
+	wfNode: null as { type: string; typeVersion: number } | null,
+	nodeType: null as object | null,
+	resolvedInputTypes: [] as string[],
+	throwOnGetInputs: false,
+}));
+
+vi.mock('@/app/stores/workflowDocument.store', () => ({
+	injectWorkflowDocumentStore: () => ({
+		value: {
+			getNodeByName: (_name: string) => state.wfNode,
+			getExpressionHandler: () => ({}),
+		},
+	}),
+}));
+
+vi.mock('@/app/stores/nodeTypes.store', () => ({
+	useNodeTypesStore: () => ({
+		getNodeType: (_type: string, _version?: number) => state.nodeType,
+	}),
+}));
+
+vi.mock('n8n-workflow', async (importOriginal) => {
+	const actual = (await importOriginal()) as Record<string, unknown>;
+	return {
+		...actual,
+		NodeHelpers: {
+			...(actual.NodeHelpers as Record<string, unknown>),
+			getNodeInputs: () => {
+				if (state.throwOnGetInputs) throw new Error('expression resolution failed');
+				return state.resolvedInputTypes;
+			},
+			getConnectionTypes: (inputs: string[]) => inputs,
+		},
+	};
+});
+
+describe('useNodeToolCapability', () => {
+	beforeEach(() => {
+		state.wfNode = null;
+		state.nodeType = null;
+		state.resolvedInputTypes = [];
+		state.throwOnGetInputs = false;
+	});
+
+	it('returns false for an empty node name', () => {
+		const { nodeCanHaveTools } = useNodeToolCapability();
+		expect(nodeCanHaveTools('')).toBe(false);
+	});
+
+	it('returns false when the node is not found in the workflow', () => {
+		state.wfNode = null;
+		const { nodeCanHaveTools } = useNodeToolCapability();
+		expect(nodeCanHaveTools('NonExistentNode')).toBe(false);
+	});
+
+	it('returns false when the node type is not found', () => {
+		state.wfNode = { type: '@n8n/n8n-nodes-langchain.agent', typeVersion: 1 };
+		state.nodeType = null;
+		const { nodeCanHaveTools } = useNodeToolCapability();
+		expect(nodeCanHaveTools('AI Agent')).toBe(false);
+	});
+
+	it('returns true when resolved inputs include AiTool', () => {
+		state.wfNode = { type: '@n8n/n8n-nodes-langchain.agent', typeVersion: 1 };
+		state.nodeType = { name: 'Agent' };
+		state.resolvedInputTypes = [NodeConnectionTypes.AiTool, NodeConnectionTypes.Main];
+		const { nodeCanHaveTools } = useNodeToolCapability();
+		expect(nodeCanHaveTools('AI Agent')).toBe(true);
+	});
+
+	it('returns false when resolved inputs do not include AiTool', () => {
+		state.wfNode = { type: '@n8n/n8n-nodes-langchain.chainLlm', typeVersion: 1 };
+		state.nodeType = { name: 'Basic LLM Chain' };
+		state.resolvedInputTypes = [NodeConnectionTypes.Main, NodeConnectionTypes.AiLanguageModel];
+		const { nodeCanHaveTools } = useNodeToolCapability();
+		expect(nodeCanHaveTools('Basic LLM Chain')).toBe(false);
+	});
+
+	it('returns false (and does not throw) when getNodeInputs throws', () => {
+		state.wfNode = { type: '@n8n/n8n-nodes-langchain.agent', typeVersion: 1 };
+		state.nodeType = { name: 'Agent' };
+		state.throwOnGetInputs = true;
+
+		const { nodeCanHaveTools } = useNodeToolCapability();
+		expect(nodeCanHaveTools('AI Agent')).toBe(false);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/composables/useNodeToolCapability.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/composables/useNodeToolCapability.ts
@@ -1,0 +1,27 @@
+import { NodeHelpers, NodeConnectionTypes } from 'n8n-workflow';
+
+import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
+
+export function useNodeToolCapability() {
+	const workflowDocumentStore = injectWorkflowDocumentStore();
+	const nodeTypesStore = useNodeTypesStore();
+
+	function nodeCanHaveTools(nodeName: string): boolean {
+		if (!nodeName) return false;
+		try {
+			const wfNode = workflowDocumentStore.value?.getNodeByName(nodeName);
+			if (!wfNode) return false;
+			const nodeType = nodeTypesStore.getNodeType(wfNode.type, wfNode.typeVersion);
+			if (!nodeType) return false;
+			const expression = workflowDocumentStore.value.getExpressionHandler();
+			const inputs = NodeHelpers.getNodeInputs({ expression }, wfNode, nodeType);
+			const types = NodeHelpers.getConnectionTypes(inputs);
+			return types.includes(NodeConnectionTypes.AiTool);
+		} catch {
+			return false;
+		}
+	}
+
+	return { nodeCanHaveTools };
+}

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/wizardSidepanel.store.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/wizardSidepanel.store.ts
@@ -109,6 +109,10 @@ export const useEvaluationsWizardSidepanelStore = defineStore(
 			}
 		}
 
+		function setSelectedMetricKeys(keys: CannedMetricKey[]) {
+			selectedMetricKeys.value = keys;
+		}
+
 		function setJudgeSelection(key: CannedMetricKey, selection: JudgeSelection | undefined) {
 			if (selection === undefined) {
 				const next = { ...judgeSelectionByMetric.value };
@@ -195,6 +199,7 @@ export const useEvaluationsWizardSidepanelStore = defineStore(
 			goNext,
 			goBack,
 			toggleMetric,
+			setSelectedMetricKeys,
 			setJudgeSelection,
 			setAiNodeName,
 			enterSliceMode,


### PR DESCRIPTION
## Summary

Filters out evaluation checks that don't apply to the selected system. In particular, the **Tool Usage** check is hidden when the chosen node has no tools connected. Adds `checkFilters` and a `useNodeToolCapability` composable to determine applicability, wired into the wizard side panel.

## How to test

1. Open the evals wizard on a workflow with an AI node that has **no tools** connected → confirm the *Tool Usage* check is not offered.
2. Connect a tool to the node → confirm *Tool Usage* now appears in the checks list.

## Related Linear tickets, Github issues, and Community forum posts

_No Linear ticket._

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI