### PR TITLE
feat(editor): Gate evaluations surfaces behind the evaluations license (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/components/FocusSidebar.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/FocusSidebar.test.ts
@@ -19,11 +19,35 @@ import { createTestingPinia } from '@pinia/testing';
 import { useVueFlow } from '@vue-flow/core';
 import type { INodeProperties } from 'n8n-workflow';
 import { setActivePinia } from 'pinia';
-import { reactive, computed, shallowRef } from 'vue';
+import { reactive, computed, ref, shallowRef } from 'vue';
 import { WorkflowIdKey } from '@/app/constants/injectionKeys';
 import { useExperimentalNdvStore } from '@/features/workflows/canvas/experimental/experimentalNdv.store';
 import { useSetupPanelStore } from '@/features/setupPanel/setupPanel.store';
 import FocusSidebar from './FocusSidebar.vue';
+
+// ---- Evaluations experiment + license mocks ----
+const mockIsEvaluationsEnabled = ref(false);
+vi.mock('@/experiments/evaluationsWizardSidepanel/useEvaluationsWizardSidepanelExperiment', () => ({
+	useEvaluationsWizardSidepanelExperiment: () => ({
+		isFeatureEnabled: computed(() => mockIsEvaluationsEnabled.value),
+	}),
+}));
+
+const mockAiRootNodes = ref<string[]>([]);
+vi.mock('@/features/ai/evaluation.ee/composables/useAiRootNodes', () => ({
+	useAiRootNodes: () => computed(() => mockAiRootNodes.value),
+}));
+
+const mockIsLicensed = ref(true);
+const mockIsResolved = ref(true);
+const mockEnsureLicenseLoaded = vi.fn().mockResolvedValue(undefined);
+vi.mock('@/features/ai/evaluation.ee/composables/useEvaluationsLicense', () => ({
+	useEvaluationsLicense: () => ({
+		isLicensed: computed(() => mockIsLicensed.value),
+		isResolved: computed(() => mockIsResolved.value),
+		ensureLicenseLoaded: mockEnsureLicenseLoaded,
+	}),
+}));
 
 vi.mock('vue-router', () => ({
 	useRouter: () => ({}),
@@ -103,6 +127,14 @@ describe('FocusSidebar', () => {
 
 		experimentalNdvStore = mockedStore(useExperimentalNdvStore);
 		experimentalNdvStore.isNdvInFocusPanelEnabled = true;
+
+		// Reset evaluations-related mocks.
+		mockIsEvaluationsEnabled.value = false;
+		mockAiRootNodes.value = [];
+		mockIsLicensed.value = true;
+		mockIsResolved.value = true;
+		mockEnsureLicenseLoaded.mockReset();
+		mockEnsureLicenseLoaded.mockResolvedValue(undefined);
 	});
 
 	describe('when setup panel feature is enabled', () => {
@@ -167,6 +199,46 @@ describe('FocusSidebar', () => {
 
 			const tabs = rendered.getByTestId('setup-panel-tabs');
 			expect(tabs).toHaveTextContent('N0');
+		});
+	});
+
+	describe('evaluations wizard sidepanel', () => {
+		beforeEach(() => {
+			mockIsEvaluationsEnabled.value = true;
+			// Simulate an AI root node being present.
+			mockAiRootNodes.value = ['ai-agent-1'];
+			focusPanelStore.selectedTab = 'evaluations';
+		});
+
+		it('shows the evaluations wizard when licensed, resolved, AI node present, evaluations tab selected', async () => {
+			mockIsLicensed.value = true;
+			mockIsResolved.value = true;
+			const rendered = renderComponent({});
+			// EvaluationsWizardSidepanel is rendered — its stub element appears.
+			// We can't query a test-id since the child components aren't rendered in
+			// unit tests, but the paywall should NOT be present.
+			expect(rendered.queryByTestId('evaluations-unlicensed')).not.toBeInTheDocument();
+		});
+
+		it('shows the evaluations paywall when unlicensed and resolved', async () => {
+			mockIsLicensed.value = false;
+			mockIsResolved.value = true;
+			const rendered = renderComponent({});
+			expect(rendered.queryByTestId('evaluations-unlicensed')).toBeInTheDocument();
+		});
+
+		it('shows neither wizard nor paywall while license is not yet resolved (unresolved state)', async () => {
+			mockIsResolved.value = false;
+			mockIsLicensed.value = false;
+			const rendered = renderComponent({});
+			expect(rendered.queryByTestId('evaluations-unlicensed')).not.toBeInTheDocument();
+		});
+
+		it('calls ensureLicenseLoaded on mount', async () => {
+			const rendered = renderComponent({});
+			// Give Vue a tick to call onMounted.
+			await rendered.findByTestId('focus-sidebar');
+			expect(mockEnsureLicenseLoaded).toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/app/components/FocusSidebar.vue
+++ b/packages/frontend/editor-ui/src/app/components/FocusSidebar.vue
@@ -7,7 +7,7 @@ import { useInjectWorkflowId } from '@/app/composables/useInjectWorkflowId';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useDeviceSupport } from '@n8n/composables/useDeviceSupport';
 import { useTelemetryContext } from '@/app/composables/useTelemetryContext';
-import { computed, watch, useTemplateRef, onBeforeUnmount } from 'vue';
+import { computed, onMounted, watch, useTemplateRef, onBeforeUnmount } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useVueFlow } from '@vue-flow/core';
 import { useActiveElement, useThrottleFn } from '@vueuse/core';
@@ -19,8 +19,10 @@ import FocusSidebarTabs from '@/features/setupPanel/components/FocusSidebarTabs.
 import SetupPanel from '@/features/setupPanel/components/SetupPanel.vue';
 import FocusPanel from '@/app/components/FocusPanel.vue';
 import EvaluationsWizardSidepanel from '@/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.vue';
+import EvaluationsPaywall from '@/features/ai/evaluation.ee/components/Paywall/EvaluationsPaywall.vue';
 import { useEvaluationsWizardSidepanelExperiment } from '@/experiments/evaluationsWizardSidepanel/useEvaluationsWizardSidepanelExperiment';
 import { useAiRootNodes } from '@/features/ai/evaluation.ee/composables/useAiRootNodes';
+import { useEvaluationsLicense } from '@/features/ai/evaluation.ee/composables/useEvaluationsLicense';
 
 defineOptions({ name: 'FocusSidebar' });
 
@@ -56,6 +58,7 @@ const { isFeatureEnabled: isEvaluationsWizardSidepanelEnabled } =
 	useEvaluationsWizardSidepanelExperiment();
 const aiRootNodes = useAiRootNodes();
 const hasAiRootNode = computed(() => aiRootNodes.value.length > 0);
+const { isLicensed, isResolved, ensureLicenseLoaded } = useEvaluationsLicense();
 
 const showSetupPanel = computed(
 	() => setupPanelStore.isFeatureEnabled && selectedTab.value === 'setup',
@@ -64,7 +67,17 @@ const showEvaluationsPanel = computed(
 	() =>
 		isEvaluationsWizardSidepanelEnabled.value &&
 		hasAiRootNode.value &&
-		selectedTab.value === 'evaluations',
+		selectedTab.value === 'evaluations' &&
+		isResolved.value &&
+		isLicensed.value,
+);
+const showEvaluationsPaywall = computed(
+	() =>
+		isEvaluationsWizardSidepanelEnabled.value &&
+		hasAiRootNode.value &&
+		selectedTab.value === 'evaluations' &&
+		isResolved.value &&
+		!isLicensed.value,
 );
 
 // Tab bar visibility used to track only the setup panel; now it also needs to
@@ -147,6 +160,10 @@ function onContextMenuAction(action: ContextMenuAction, nodeIds: string[]) {
 	emit('contextMenuAction', action, nodeIds);
 }
 
+onMounted(() => {
+	void ensureLicenseLoaded();
+});
+
 onBeforeUnmount(() => {
 	unregisterKeyboardListener();
 });
@@ -182,6 +199,9 @@ onBeforeUnmount(() => {
 				</div>
 				<div v-else-if="showEvaluationsPanel" :class="$style['setup-panel-wrapper']">
 					<EvaluationsWizardSidepanel />
+				</div>
+				<div v-else-if="showEvaluationsPaywall" :class="$style['setup-panel-wrapper']">
+					<EvaluationsPaywall />
 				</div>
 				<FocusPanel
 					v-else

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/EvaluationsCanvasInfoCard/EvaluationsCanvasInfoCard.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/EvaluationsCanvasInfoCard/EvaluationsCanvasInfoCard.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ref, nextTick } from 'vue';
+import { computed, ref, nextTick } from 'vue';
 import userEvent from '@testing-library/user-event';
 
 import { createComponentRenderer } from '@/__tests__/render';
@@ -49,6 +49,16 @@ vi.mock('@/experiments/evaluationsWizardSidepanel/useEvaluationsWizardSidepanelE
 	useEvaluationsWizardSidepanelExperiment: () => ({ isFeatureEnabled }),
 }));
 
+const mockIsLicensed = ref(true);
+const mockEnsureLicenseLoaded = vi.fn().mockResolvedValue(undefined);
+vi.mock('../../composables/useEvaluationsLicense', () => ({
+	useEvaluationsLicense: () => ({
+		isLicensed: computed(() => mockIsLicensed.value),
+		isResolved: computed(() => true),
+		ensureLicenseLoaded: mockEnsureLicenseLoaded,
+	}),
+}));
+
 const listEvaluationConfigs = vi.fn();
 vi.mock('../../evaluation.api', () => ({
 	listEvaluationConfigs: (...args: unknown[]) => listEvaluationConfigs(...args),
@@ -67,6 +77,9 @@ describe('EvaluationsCanvasInfoCard', () => {
 		mockActive.value = true;
 		mockWorkflowId.value = `wf-${Math.random().toString(36).slice(2, 8)}`;
 		isFeatureEnabled.value = true;
+		mockIsLicensed.value = true;
+		mockEnsureLicenseLoaded.mockReset();
+		mockEnsureLicenseLoaded.mockResolvedValue(undefined);
 		wizardOpen.mockReset();
 		wizardIsOpen.value = false;
 		listEvaluationConfigs.mockReset();
@@ -176,5 +189,25 @@ describe('EvaluationsCanvasInfoCard', () => {
 		await new Promise((resolve) => setTimeout(resolve, 0));
 		await nextTick();
 		expect(queryByTestId('evaluations-canvas-info-card')).not.toBeInTheDocument();
+	});
+
+	it('hides when the user is unlicensed (limit 0) even with all other conditions met', async () => {
+		mockIsLicensed.value = false;
+		const { queryByTestId } = renderComponent();
+		await nextTick();
+		expect(queryByTestId('evaluations-canvas-info-card')).not.toBeInTheDocument();
+		expect(listEvaluationConfigs).not.toHaveBeenCalled();
+	});
+
+	it('shows when the user is licensed (limit -1) with all other conditions met', async () => {
+		mockIsLicensed.value = true;
+		const { findByTestId } = renderComponent();
+		await findByTestId('evaluations-canvas-info-card');
+	});
+
+	it('calls ensureLicenseLoaded on mount', async () => {
+		renderComponent();
+		await nextTick();
+		expect(mockEnsureLicenseLoaded).toHaveBeenCalled();
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/EvaluationsCanvasInfoCard/EvaluationsCanvasInfoCard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/EvaluationsCanvasInfoCard/EvaluationsCanvasInfoCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 import { useI18n } from '@n8n/i18n';
 import { N8nButton, N8nIcon, N8nText } from '@n8n/design-system';
 
@@ -13,6 +13,7 @@ import { useStorage } from '@/app/composables/useStorage';
 import { LOCAL_STORAGE_EVALUATIONS_CANVAS_INFO_CARD_DISMISSED } from '@/app/constants';
 import { CANNED_METRICS, LLM_JUDGE_METRIC_KEYS } from '../../evaluation.constants';
 import CheckCard from '../WizardSidepanel/CheckCard.vue';
+import { useEvaluationsLicense } from '../../composables/useEvaluationsLicense';
 
 // Preview cards that scroll in the marquee at the top of the info card. We
 // duplicate the list once so the CSS `translateY(-50%)` loop reads as a
@@ -47,6 +48,7 @@ const rootStore = useRootStore();
 const aiRootNodes = useAiRootNodes();
 const { isFeatureEnabled: isEvaluationsWizardSidepanelEnabled } =
 	useEvaluationsWizardSidepanelExperiment();
+const { isLicensed, ensureLicenseLoaded } = useEvaluationsLicense();
 
 const hasConfigs = ref<boolean | null>(null);
 
@@ -81,6 +83,7 @@ const isDismissed = computed(() => {
 const shouldRenderModuleQualifies = computed(
 	() =>
 		isEvaluationsWizardSidepanelEnabled.value &&
+		isLicensed.value &&
 		isWorkflowActive.value &&
 		hasAiNodes.value &&
 		!isDismissed.value,
@@ -94,6 +97,10 @@ const shouldRenderModuleQualifies = computed(
 const isVisible = computed(
 	() => shouldRenderModuleQualifies.value && hasConfigs.value === false && !wizardStore.isOpen,
 );
+
+onMounted(() => {
+	void ensureLicenseLoaded();
+});
 
 async function checkConfigs() {
 	const wfId = workflowId.value;

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/composables/useEvaluationsLicense.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/composables/useEvaluationsLicense.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Module-level state holders. We cannot use `ref` inside `vi.hoisted` (it runs
+// before module imports), so we declare them at module scope instead.
+// vi.mock factories can still close over them.
+// NOTE: we expose primitive values, not refs, because Pinia auto-unwraps refs when
+// it returns store properties, but our hand-rolled mock does not.
+let stateLimit = 0 as number;
+let stateHasLoadedLicense = false;
+const stateGetLicenseInfo = vi.fn<() => Promise<void>>();
+
+vi.mock('@/features/settings/usage/usage.store', () => ({
+	useUsageStore: () => ({
+		get workflowsWithEvaluationsLimit() {
+			return stateLimit;
+		},
+		get hasLoadedLicense() {
+			return stateHasLoadedLicense;
+		},
+		getLicenseInfo: stateGetLicenseInfo,
+	}),
+}));
+
+// Import AFTER mocks are set up.
+// We use vi.resetModules() in beforeEach to reset the module-cached licensePromise
+// between tests so each test starts with a clean state.
+
+describe('useEvaluationsLicense', () => {
+	beforeEach(async () => {
+		stateLimit = 0;
+		stateHasLoadedLicense = false;
+		stateGetLicenseInfo.mockReset();
+		stateGetLicenseInfo.mockResolvedValue(undefined);
+		// Reset modules to clear the module-cached licensePromise.
+		vi.resetModules();
+	});
+
+	async function getComposable() {
+		// Re-import after resetModules so we get a fresh licensePromise each test.
+		const { useEvaluationsLicense } = await import('./useEvaluationsLicense');
+		return useEvaluationsLicense();
+	}
+
+	describe('isLicensed', () => {
+		it('is false when limit is 0 (unlicensed)', async () => {
+			stateLimit = 0;
+			const { isLicensed } = await getComposable();
+			expect(isLicensed.value).toBe(false);
+		});
+
+		it('is true when limit is -1 (unlimited)', async () => {
+			stateLimit = -1;
+			const { isLicensed } = await getComposable();
+			expect(isLicensed.value).toBe(true);
+		});
+
+		it('is true when limit is a positive number (capped)', async () => {
+			stateLimit = 5;
+			const { isLicensed } = await getComposable();
+			expect(isLicensed.value).toBe(true);
+		});
+	});
+
+	describe('isResolved', () => {
+		it('is false when hasLoadedLicense is false', async () => {
+			stateHasLoadedLicense = false;
+			const { isResolved } = await getComposable();
+			expect(isResolved.value).toBe(false);
+		});
+
+		it('is true when hasLoadedLicense is true', async () => {
+			stateHasLoadedLicense = true;
+			const { isResolved } = await getComposable();
+			expect(isResolved.value).toBe(true);
+		});
+	});
+
+	describe('ensureLicenseLoaded', () => {
+		it('calls getLicenseInfo on first invocation', async () => {
+			const { ensureLicenseLoaded } = await getComposable();
+			await ensureLicenseLoaded();
+			expect(stateGetLicenseInfo).toHaveBeenCalledTimes(1);
+		});
+
+		it('deduplicates: calling twice only calls getLicenseInfo once', async () => {
+			const { ensureLicenseLoaded } = await getComposable();
+			// Call twice concurrently.
+			await Promise.all([ensureLicenseLoaded(), ensureLicenseLoaded()]);
+			expect(stateGetLicenseInfo).toHaveBeenCalledTimes(1);
+		});
+
+		it('deduplicates: second sequential call also only calls getLicenseInfo once', async () => {
+			const { ensureLicenseLoaded } = await getComposable();
+			await ensureLicenseLoaded();
+			await ensureLicenseLoaded();
+			expect(stateGetLicenseInfo).toHaveBeenCalledTimes(1);
+		});
+
+		it('resets cache on error so next call retries', async () => {
+			stateGetLicenseInfo
+				.mockRejectedValueOnce(new Error('Network error'))
+				.mockResolvedValue(undefined);
+
+			const { ensureLicenseLoaded } = await getComposable();
+
+			// First call fails — should not throw (errors are swallowed).
+			await expect(ensureLicenseLoaded()).resolves.toBeUndefined();
+
+			// After failure the cache is reset, so the next call retries.
+			await ensureLicenseLoaded();
+			expect(stateGetLicenseInfo).toHaveBeenCalledTimes(2);
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/composables/useEvaluationsLicense.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/composables/useEvaluationsLicense.ts
@@ -1,0 +1,23 @@
+import { computed } from 'vue';
+import { useUsageStore } from '@/features/settings/usage/usage.store';
+
+// Module-cached so the canvas info card + side pane share one fetch.
+let licensePromise: Promise<void> | null = null;
+
+export function useEvaluationsLicense() {
+	const usageStore = useUsageStore();
+	const isLicensed = computed(() => usageStore.workflowsWithEvaluationsLimit !== 0);
+	const isResolved = computed(() => usageStore.hasLoadedLicense);
+
+	async function ensureLicenseLoaded(): Promise<void> {
+		if (!licensePromise) {
+			licensePromise = usageStore.getLicenseInfo().catch(() => {
+				// Swallow — surfaces default to hidden/paywalled, which is the safe state.
+				licensePromise = null;
+			});
+		}
+		await licensePromise;
+	}
+
+	return { isLicensed, isResolved, ensureLicenseLoaded };
+}

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.test.ts
@@ -10,7 +10,7 @@ import { useUsageStore } from '@/features/settings/usage/usage.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { mockedStore } from '@/__tests__/utils';
 import type { IWorkflowDb } from '@/Interface';
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 import { waitFor } from '@testing-library/vue';
 import { flushPromises } from '@vue/test-utils';
 import type { TestRunRecord } from '../evaluation.api';
@@ -18,6 +18,24 @@ import { useTelemetry } from '@/app/composables/useTelemetry';
 import { EVALUATION_NODE_TYPE, EVALUATION_TRIGGER_NODE_TYPE, NodeHelpers } from 'n8n-workflow';
 import { mockNodeTypeDescription } from '@/__tests__/mocks';
 import type { SourceControlPreferences } from '@/features/integrations/sourceControl.ee/sourceControl.types';
+
+// ---- Evaluations experiment flag mock (default off → preserves existing tests) ----
+const mockIsWizardSidepanelEnabled = ref(false);
+vi.mock('@/experiments/evaluationsWizardSidepanel/useEvaluationsWizardSidepanelExperiment', () => ({
+	useEvaluationsWizardSidepanelExperiment: () => ({
+		isFeatureEnabled: computed(() => mockIsWizardSidepanelEnabled.value),
+	}),
+}));
+
+// ---- Evaluations license composable mock (default licensed) ----
+const mockIsLicensed = ref(true);
+vi.mock('../composables/useEvaluationsLicense', () => ({
+	useEvaluationsLicense: () => ({
+		isLicensed: computed(() => mockIsLicensed.value),
+		isResolved: computed(() => true),
+		ensureLicenseLoaded: vi.fn().mockResolvedValue(undefined),
+	}),
+}));
 
 const { showError } = vi.hoisted(() => ({
 	showError: vi.fn(),
@@ -111,6 +129,8 @@ describe('EvaluationsRootView', () => {
 		mockEvaluationTriggerExists.value = false;
 		mockEvaluationSetOutputsNodeExist.value = false;
 		mockEvaluationSetMetricsNodeExist.value = false;
+		mockIsWizardSidepanelEnabled.value = false;
+		mockIsLicensed.value = true;
 
 		mockedStore(useWorkflowsStore).isWorkflowSaved = { [mockWorkflow.id]: true };
 
@@ -457,6 +477,31 @@ describe('EvaluationsRootView', () => {
 					quota_reached: true,
 				});
 			});
+		});
+	});
+
+	describe('wizard-experiment branch (isEvaluationsWizardSidepanelEnabled = true)', () => {
+		beforeEach(() => {
+			mockIsWizardSidepanelEnabled.value = true;
+			const usageStore = mockedStore(useUsageStore);
+			const evaluationStore = mockedStore(useEvaluationStore);
+			usageStore.getLicenseInfo.mockResolvedValue(undefined);
+			evaluationStore.fetchTestRuns.mockResolvedValue([]);
+			evaluationStore.testRunsById = {};
+		});
+
+		it('renders paywall (evaluations-unlicensed) when unlicensed and no test runs', async () => {
+			mockIsLicensed.value = false;
+			const { findByTestId } = renderComponent({ props: { workflowId: mockWorkflow.id } });
+			await flushPromises();
+			await findByTestId('evaluations-unlicensed');
+		});
+
+		it('renders empty state (evaluations-empty-state) when licensed and no test runs', async () => {
+			mockIsLicensed.value = true;
+			const { findByTestId } = renderComponent({ props: { workflowId: mockWorkflow.id } });
+			await flushPromises();
+			await findByTestId('evaluations-empty-state');
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/views/EvaluationsRootView.vue
@@ -18,6 +18,7 @@ import EvaluationsEmptyState from '../components/EvaluationsEmptyState/Evaluatio
 import { N8nCallout, N8nLink, N8nText } from '@n8n/design-system';
 import { useWorkflowEvaluationState } from '../composables/useWorkflowEvaluationState';
 import { useEvaluationsWizardSidepanelExperiment } from '@/experiments/evaluationsWizardSidepanel/useEvaluationsWizardSidepanelExperiment';
+import { useEvaluationsLicense } from '../composables/useEvaluationsLicense';
 const props = defineProps<{
 	workflowId: string;
 }>();
@@ -34,9 +35,7 @@ const router = useRouter();
 const { isFeatureEnabled: isEvaluationsWizardSidepanelEnabled } =
 	useEvaluationsWizardSidepanelExperiment();
 
-const evaluationsLicensed = computed(() => {
-	return usageStore.workflowsWithEvaluationsLimit !== 0;
-});
+const { isLicensed } = useEvaluationsLicense();
 
 const isProtectedEnvironment = computed(() => {
 	return sourceControlStore.preferences.branchReadOnly;
@@ -152,7 +151,12 @@ watch(
 			opened — same destination the floating CTA above already targets.
 		-->
 		<template v-if="isReady && showWizard && isEvaluationsWizardSidepanelEnabled">
-			<EvaluationsEmptyState :disabled="isProtectedEnvironment" @get-started="openWizardOnCanvas" />
+			<EvaluationsPaywall v-if="!isLicensed" />
+			<EvaluationsEmptyState
+				v-else
+				:disabled="isProtectedEnvironment"
+				@get-started="openWizardOnCanvas"
+			/>
 		</template>
 		<template v-else-if="isReady && showWizard">
 			<div :class="$style.setupContent">
@@ -183,7 +187,7 @@ watch(
 						referrerpolicy="strict-origin-when-cross-origin"
 						allowfullscreen
 					></iframe>
-					<SetupWizard v-if="evaluationsLicensed" @run-test="runTest" />
+					<SetupWizard v-if="isLicensed" @run-test="runTest" />
 					<EvaluationsPaywall v-else />
 				</div>
 			</div>

--- a/packages/frontend/editor-ui/src/features/settings/usage/usage.store.ts
+++ b/packages/frontend/editor-ui/src/features/settings/usage/usage.store.ts
@@ -1,4 +1,4 @@
-import { computed, reactive } from 'vue';
+import { computed, reactive, ref } from 'vue';
 import { defineStore } from 'pinia';
 import type { UsageState } from '@n8n/api-types';
 import * as usageApi from '@n8n/rest-api-client/api/usage';
@@ -40,6 +40,7 @@ export const useUsageStore = defineStore('usage', () => {
 	const settingsStore = useSettingsStore();
 
 	const state = reactive<UsageState>({ ...DEFAULT_STATE });
+	const hasLoadedLicense = ref(false);
 
 	const planName = computed(() => state.data.license.planName || DEFAULT_PLAN_NAME);
 	const planId = computed(() => state.data.license.planId);
@@ -72,6 +73,7 @@ export const useUsageStore = defineStore('usage', () => {
 
 	const setData = (data: UsageState['data']) => {
 		state.data = data;
+		hasLoadedLicense.value = true;
 	};
 
 	const getLicenseInfo = async () => {
@@ -113,6 +115,7 @@ export const useUsageStore = defineStore('usage', () => {
 		refreshLicenseManagementToken,
 		requestEnterpriseLicenseTrial,
 		registerCommunityEdition,
+		hasLoadedLicense,
 		planName,
 		planId,
 		activeWorkflowTriggersLimit,


### PR DESCRIPTION
## Summary

Gates the evaluations surfaces (wizard side panel, canvas info card, root view) behind the evaluations license, showing a paywall when unlicensed. Adds a `useEvaluationsLicense` composable and an `EvaluationsPaywall` component, and reads license state from the usage store.

> **Note:** This PR is **stacked on [#31840 (TRUST-138)](https://github.com/n8n-io/n8n/pull/31840)** — its `FocusSidebar` changes build on the AI-node gating introduced there. Base it on `master` once #31840 merges. Review only the top commit.

## How to test

1. On an instance **without** the evaluations license, open the Evaluations tab for a workflow with an AI node → the paywall is shown instead of the wizard.
2. With the license enabled → the evaluations surfaces render as normal.

## Related Linear tickets, Github issues, and Community forum posts

_No Linear ticket._

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI