### PR TITLE
fix(editor): Copy only selected markdown editor text

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditor.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/MarkdownEditor.test.ts
@@ -246,6 +246,46 @@ describe('components/N8nMarkdownEditor', () => {
 		);
 	});
 
+	it('copies only the selected editor content as markdown', async () => {
+		const { wrapper, editor } = await renderEditor(
+			['# Heading', '', '**Bold text**', '', '- List item 1', '- List item 2'].join('\n'),
+		);
+		const textbox = getEditorElement(wrapper.container) as HTMLElement;
+		const clipboardData = {
+			setData: vi.fn(),
+			getData: vi.fn(),
+			clearData: vi.fn(),
+		};
+		const copyEvent = new Event('copy', { bubbles: true, cancelable: true });
+		let selectionRange: { from: number; to: number } | undefined;
+
+		editor.state.doc.descendants((node, position) => {
+			if (!node.isText || !node.text) return true;
+
+			const textIndex = node.text.indexOf('Bold text');
+
+			if (textIndex === -1) return true;
+
+			selectionRange = {
+				from: position + textIndex,
+				to: position + textIndex + 'Bold text'.length,
+			};
+
+			return false;
+		});
+
+		if (!selectionRange) throw new Error('Expected to find text selection range');
+
+		editor.commands.setTextSelection(selectionRange);
+		Object.defineProperty(copyEvent, 'clipboardData', {
+			value: clipboardData,
+		});
+
+		await fireEvent(textbox, copyEvent);
+
+		expect(clipboardData.setData).toHaveBeenCalledWith('text/plain', '**Bold text**');
+	});
+
 	it('pastes markdown content into the editor', async () => {
 		const { wrapper, editor } = await renderEditor('');
 		const textbox = getEditorElement(wrapper.container) as HTMLElement;

--- a/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/markdownEditorUtils.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nMarkdownEditor/markdownEditorUtils.ts
@@ -1,4 +1,4 @@
-import type { Content, Editor } from '@tiptap/core';
+import type { Content, Editor, JSONContent } from '@tiptap/core';
 
 const emptyEditorContent: Content = {
 	type: 'doc',
@@ -42,10 +42,27 @@ export const isSelectionInsideNode = (editor: Editor, nodeName: string) => {
 	return false;
 };
 
+const isJsonContent = (value: unknown): value is JSONContent =>
+	typeof value === 'object' && value !== null && 'type' in value;
+
+const isJsonContentArray = (value: unknown): value is JSONContent[] =>
+	Array.isArray(value) && value.every(isJsonContent);
+
+const getSelectionMarkdown = (editor: Editor) => {
+	const selectedContent: unknown = editor.state.selection.content().content.toJSON();
+
+	if (!isJsonContentArray(selectedContent) || !editor.markdown) return '';
+
+	return editor.markdown.serialize({
+		type: 'doc',
+		content: selectedContent,
+	});
+};
+
 export const copyMarkdown = (editor: Editor, event: ClipboardEvent) => {
 	if (!event.clipboardData || editor.state.selection.empty) return false;
 
-	event.clipboardData.setData('text/plain', editor.getMarkdown());
+	event.clipboardData.setData('text/plain', getSelectionMarkdown(editor));
 	event.preventDefault();
 
 	return true;


### PR DESCRIPTION
## Summary
The markdown editor was copying the entire document when the user copied a non-empty selection because `editor.getMarkdown()` serialized the whole document rather than the selected slice.

- Replace the copy behaviour to serialize only the ProseMirror selection by adding `getSelectionMarkdown` which extracts the selection slice and uses `editor.markdown.serialize(...)`.
- Update `copyMarkdown` in `markdownEditorUtils.ts` to use the new selection serializer instead of `editor.getMarkdown()`.
- Add a regression test in `MarkdownEditor.test.ts` that selects a portion of the content and asserts the clipboard receives only the selected Markdown.

### How to test
- Goto MarkdownEditor in any agent or [here](https://2b22bba0.n8n-8h2.pages.dev/?path=/docs/core-markdown-editor--docs)
- Select a line of text and copy it
- Paste somewhere else and confirm it only pastes that line of text

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)