### PR TITLE
feat(telemetry): link backend events to session recordings via tracing headers

### DIFF
--- a/packages/cli/src/posthog/__tests__/posthog.test.ts
+++ b/packages/cli/src/posthog/__tests__/posthog.test.ts
@@ -1,9 +1,10 @@
 import { mockInstance } from '@n8n/backend-test-utils';
 import type { GlobalConfig } from '@n8n/config';
+import type { Application } from 'express';
 import { mock } from 'jest-mock-extended';
 import { InstanceSettings } from 'n8n-core';
 import type { FeatureFlags } from 'n8n-workflow';
-import { PostHog } from 'posthog-node';
+import { PostHog, setupExpressRequestContext } from 'posthog-node';
 
 import { PostHogClient } from '@/posthog';
 
@@ -100,6 +101,31 @@ describe('PostHog', () => {
 				$group_set: properties,
 			},
 			groups: { company: instanceId },
+		});
+	});
+
+	describe('setupExpressContext', () => {
+		it('registers the Express request context middleware when initialised', async () => {
+			const app = mock<Application>();
+
+			const ph = new PostHogClient(instanceSettings, globalConfig);
+			await ph.init();
+
+			await ph.setupExpressContext(app);
+
+			expect(setupExpressRequestContext).toHaveBeenCalledWith(expect.any(PostHog), app);
+		});
+
+		it('no-ops when diagnostics are disabled', async () => {
+			globalConfig.diagnostics.enabled = false;
+			const app = mock<Application>();
+
+			const ph = new PostHogClient(instanceSettings, globalConfig);
+			await ph.init();
+
+			await ph.setupExpressContext(app);
+
+			expect(setupExpressRequestContext).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/posthog/index.ts
+++ b/packages/cli/src/posthog/index.ts
@@ -2,6 +2,7 @@ import { EVAL_COLLECTIONS_FLAG } from '@n8n/api-types';
 import { GlobalConfig } from '@n8n/config';
 import type { PublicUser } from '@n8n/db';
 import { Service } from '@n8n/di';
+import type { Application } from 'express';
 import { InstanceSettings } from 'n8n-core';
 import type { FeatureFlags, ITelemetryTrackProperties } from 'n8n-workflow';
 import type { PostHog, FeatureFlagEvaluations } from 'posthog-node';
@@ -46,6 +47,23 @@ export class PostHogClient {
 		if (this.postHog) {
 			return await this.postHog.shutdown();
 		}
+	}
+
+	/**
+	 * Registers PostHog's Express request-context middleware on the given app so
+	 * that events captured during a request automatically inherit the session and
+	 * distinct ID from the incoming `x-posthog-session-id` / `x-posthog-distinct-id`
+	 * headers. The frontend SDK attaches these headers via its `tracing_headers`
+	 * config (see the editor-ui PostHog store). This is what lets backend-captured
+	 * events be filtered against session recordings.
+	 *
+	 * No-ops when diagnostics are disabled (PostHog not initialised). Must be
+	 * called after `init()` and before request handlers are registered.
+	 */
+	async setupExpressContext(app: Application): Promise<void> {
+		if (!this.postHog) return;
+		const { setupExpressRequestContext } = await import('posthog-node');
+		setupExpressRequestContext(this.postHog, app);
 	}
 
 	track(payload: { userId: string; event: string; properties: ITelemetryTrackProperties }): void {

--- a/packages/cli/src/server.ts
+++ b/packages/cli/src/server.ts
@@ -169,6 +169,12 @@ export class Server extends AbstractServer {
 
 		await this.postHogClient.init();
 
+		// Wire PostHog request context so events captured during a request inherit
+		// the frontend session and distinct ID from incoming tracing headers.
+		// Registered here (after init, before ControllerRegistry.activate below) so
+		// it wraps the REST routes the editor-ui calls.
+		await this.postHogClient.setupExpressContext(this.app);
+
 		const publicApiEndpoint = this.globalConfig.publicApi.path;
 
 		// Register auth strategies in priority order. The registry evaluates them

--- a/packages/frontend/editor-ui/src/app/stores/posthog.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/posthog.store.test.ts
@@ -164,6 +164,18 @@ describe('Posthog store', () => {
 			);
 		});
 
+		it('configures tracing headers for the instance host', () => {
+			const posthog = usePostHog();
+			posthog.init();
+
+			expect(window.posthog?.init).toHaveBeenCalledWith(
+				DEFAULT_POSTHOG_SETTINGS.apiKey,
+				expect.objectContaining({
+					tracing_headers: [window.location.hostname],
+				}),
+			);
+		});
+
 		it('should identify user', () => {
 			const posthog = usePostHog();
 			posthog.init();

--- a/packages/frontend/editor-ui/src/app/stores/posthog.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/posthog.store.ts
@@ -185,6 +185,9 @@ export const usePostHog = defineStore('posthog', () => {
 			session_recording: {
 				maskAllInputs: false,
 			},
+			// Attach session/distinct ID tracing headers to same-origin API calls so
+			// backend-captured events can be linked to and filtered by session recordings.
+			tracing_headers: [window.location.hostname],
 		};
 
 		if (evaluatedFeatureFlags && Object.keys(evaluatedFeatureFlags).length) {


### PR DESCRIPTION
## Summary

n8n captures events from both the frontend (posthog-js) and the backend (posthog-node). Today, backend-captured events can't be used to filter session recordings in PostHog, because they have no `$session_id` — the backend never sees the browser session. This wires the frontend session and distinct ID through to backend events so they can be linked to and filtered by session recordings.

## Changes

- **Frontend (`editor-ui`):** set posthog-js `tracing_headers` to the instance host so the SDK attaches `X-POSTHOG-SESSION-ID` / `X-POSTHOG-DISTINCT-ID` to same-origin API calls.
- **Backend (`cli`):** add a small `PostHogClient.setupExpressContext()` that registers PostHog's built-in `setupExpressRequestContext` helper (posthog-node >= 5.31.0; this repo is on 5.33.4), wired in `Server.configure()` after PostHog init and before the controllers mount. Events captured during a request then inherit the session and distinct ID from the incoming headers. No existing `posthog.capture()` calls change.

## Notes

- `tracing_headers` is set to `window.location.hostname`, so the headers attach same-origin only (the editor calling its own n8n backend) and never leak to third parties. If you'd prefer an explicit allowlist or a config-derived host (e.g. for deployments where the editor and REST API are served from different hostnames), that's a small change — happy to adjust.
- Scoped to the main server only; webhook and worker processes are untouched since they have no browser session to attribute.
- Reference: https://posthog.com/docs/libraries/node#add-request-context-to-express

## Testing

- Backend unit tests for `setupExpressContext` (registers the middleware when PostHog is enabled, no-ops when diagnostics are off).
- Frontend store test asserting `tracing_headers` is configured on init.
