### PR TITLE
test(ci): Frontend scoping assessment (DEVP-393, do not merge)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
@@ -1112,3 +1112,5 @@ export function useNodeHelpers() {
 		getDefaultNodeName,
 	};
 }
+
+// DEVP-393 scoping assessment (frontend) — no-op change to observe E2E selection. Do not merge.


### PR DESCRIPTION
**Assessment PR — do not merge.** Stacked on #31868 (the `@n8n/test-impact` extraction).

A single no-op comment in a frontend file (`useNodeHelpers.ts`) so CI's impact selector — now served by the extracted `@n8n/test-impact` package — scopes it. Read the **"Generate shard matrix"** step to see the decision.

Expectation: frontend hub files sit near-broad (~80–99% of specs), so this should scope *large* — demonstrating the FE ceiling (the case DEVP-390 function-level resolution targets). Contrast with the backend stack PR.