### PR TITLE
test(ci): Backend scoping assessment (DEVP-393, do not merge)

### DIFF
--- a/packages/nodes-base/nodes/If/If.node.ts
+++ b/packages/nodes-base/nodes/If/If.node.ts
@@ -27,3 +27,5 @@ export class If extends VersionedNodeType {
 		super(nodeVersions, baseDescription);
 	}
 }
+
+// DEVP-393 scoping assessment (backend) — no-op change to observe E2E selection. Do not merge.


### PR DESCRIPTION
**Assessment PR — do not merge.** Stacked on #31869 (frontend assessment) → #31868 (extraction).

A single no-op comment in `If.node.ts` (a mapped backend node). Its diff vs its base is just this one backend file, so the impact selector — via the extracted `@n8n/test-impact` — should scope it **tight** (locally measured: `If.node.ts` → 7 specs).

Expectation: a handful of shards, **not** broad — demonstrating backend impact scoping (DEVP-370) works end-to-end through the extracted package. Contrast with the near-broad frontend stack (#31869).