### PR TITLE
docs: fix duplicate words in node descriptions and comments

### DIFF
--- a/packages/nodes-base/nodes/Filter/V1/FilterV1.node.ts
+++ b/packages/nodes-base/nodes/Filter/V1/FilterV1.node.ts
@@ -364,7 +364,7 @@ export class FilterV1 implements INodeType {
 			if (combineConditions === 'AND') {
 				returnDataTrue.push(item);
 			} else {
-				// If the operation is "OR" it means the the item did not match any condition.
+				// If the operation is "OR" it means the item did not match any condition.
 				returnDataFalse.push(item);
 			}
 		}

--- a/packages/nodes-base/nodes/If/V1/IfV1.node.ts
+++ b/packages/nodes-base/nodes/If/V1/IfV1.node.ts
@@ -476,7 +476,7 @@ export class IfV1 implements INodeType {
 				// so it passes.
 				returnDataTrue.push(item);
 			} else {
-				// If the operation is "any" it means the the item did not match any condition.
+				// If the operation is "any" it means the item did not match any condition.
 				returnDataFalse.push(item);
 			}
 		}

--- a/packages/nodes-base/nodes/Postgres/v1/PostgresV1.node.ts
+++ b/packages/nodes-base/nodes/Postgres/v1/PostgresV1.node.ts
@@ -305,7 +305,7 @@ export class PostgresV1 implements INodeType {
 				try {
 					const { db } = await configurePostgres.call(this, credentials, {});
 
-					// Acquires a new connection that can be used to to run multiple
+					// Acquires a new connection that can be used to run multiple
 					// queries on the same connection and must be released again
 					// manually.
 					connection = await db.connect();

--- a/packages/nodes-base/nodes/Taiga/descriptions/UserStoryDescription.ts
+++ b/packages/nodes-base/nodes/Taiga/descriptions/UserStoryDescription.ts
@@ -455,7 +455,7 @@ export const userStoryFields: INodeProperties[] = [
 				},
 				default: '',
 				description:
-					'ID of the user to assign the the user story to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+					'ID of the user to assign the user story to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 			},
 			{
 				displayName: 'Backlog Order',

--- a/packages/nodes-base/nodes/Zulip/StreamDescription.ts
+++ b/packages/nodes-base/nodes/Zulip/StreamDescription.ts
@@ -94,7 +94,7 @@ export const streamFields: INodeProperties[] = [
 		},
 		required: true,
 		description:
-			'A list of dictionaries containing the the key name and value specifying the name of the stream to subscribe. If the stream does not exist a new stream is created.',
+			'A list of dictionaries containing the key name and value specifying the name of the stream to subscribe. If the stream does not exist a new stream is created.',
 		typeOptions: {
 			multipleValues: true,
 		},


### PR DESCRIPTION
## Summary

This PR fixes several instances of duplicated words (e.g. "the the", "to to") in node parameter descriptions and inline comments across `nodes-base`. These typos degrade readability of the UI text shown to users as well as the source comments.

## Changes

| File | Before | After |
| --- | --- | --- |
| `nodes/Taiga/descriptions/UserStoryDescription.ts` | "ID of the user to assign **the the** user story to…" | "ID of the user to assign **the** user story to…" |
| `nodes/Zulip/StreamDescription.ts` | "…containing **the the** key name and value…" | "…containing **the** key name and value…" |
| `nodes/If/V1/IfV1.node.ts` | "…it means **the the** item did not match…" | "…it means **the** item did not match…" |
| `nodes/Filter/V1/FilterV1.node.ts` | "…it means **the the** item did not match…" | "…it means **the** item did not match…" |
| `nodes/Postgres/v1/PostgresV1.node.ts` | "…that can be used **to to** run multiple…" | "…that can be used **to** run multiple…" |

## Checklist

- [x] I have followed the contributing guidelines
- [x] My code changes are limited to the described fix
- [x] I have tested locally (changes are text-only and do not affect logic)
- [x] I have updated the documentation/comments accordingly