### PR TITLE
fix: correct spelling mistakes in node descriptions and comments

### DIFF
--- a/packages/nodes-base/nodes/Cortex/ResponderDescription.ts
+++ b/packages/nodes-base/nodes/Cortex/ResponderDescription.ts
@@ -69,7 +69,7 @@ export const responderFields: INodeProperties[] = [
 		type: 'boolean',
 		default: false,
 		// eslint-disable-next-line n8n-nodes-base/node-param-description-boolean-without-whether
-		description: 'Choose between providing JSON object or seperated attributes',
+		description: 'Choose between providing JSON object or separated attributes',
 		displayOptions: {
 			show: {
 				resource: ['responder'],

--- a/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
@@ -205,7 +205,7 @@ export class GitlabTrigger implements INodeType {
 						return false;
 					}
 
-					// Some error occured
+					// Some error occurred
 					throw error;
 				}
 

--- a/packages/nodes-base/nodes/InvoiceNinja/ExpenseDescription.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/ExpenseDescription.ts
@@ -231,7 +231,7 @@ export const expenseFields: INodeProperties[] = [
 						value: 22,
 					},
 					{
-						name: 'Swich',
+						name: 'Switch',
 						value: 23,
 					},
 					{

--- a/packages/nodes-base/nodes/InvoiceNinja/PaymentDescription.ts
+++ b/packages/nodes-base/nodes/InvoiceNinja/PaymentDescription.ts
@@ -205,7 +205,7 @@ export const paymentFields: INodeProperties[] = [
 						value: 22,
 					},
 					{
-						name: 'Swich',
+						name: 'Switch',
 						value: 23,
 					},
 					{

--- a/packages/nodes-base/nodes/Keap/EmailDescription.ts
+++ b/packages/nodes-base/nodes/Keap/EmailDescription.ts
@@ -308,7 +308,7 @@ export const emailFields: INodeProperties[] = [
 			},
 		},
 		default: '',
-		description: 'Contact IDs to receive the email. Multiple can be added seperated by comma.',
+		description: 'Contact IDs to receive the email. Multiple can be added separated by comma.',
 	},
 	{
 		displayName: 'Subject',

--- a/packages/nodes-base/nodes/Stripe/StripeTrigger.node.ts
+++ b/packages/nodes-base/nodes/Stripe/StripeTrigger.node.ts
@@ -877,7 +877,7 @@ export class StripeTrigger implements INodeType {
 						return false;
 					}
 
-					// Some error occured
+					// Some error occurred
 					throw error;
 				}
 


### PR DESCRIPTION
## Summary

This PR fixes a handful of common spelling mistakes that appear in user-facing node parameter descriptions and source comments.

## Changes

| File | Correction |
| --- | --- |
| `nodes/InvoiceNinja/PaymentDescription.ts` | `Swich` → `Switch` (payment type ID 23) |
| `nodes/InvoiceNinja/ExpenseDescription.ts` | `Swich` → `Switch` (payment type ID 23) |
| `nodes/Cortex/ResponderDescription.ts` | `seperated` → `separated` |
| `nodes/Keap/EmailDescription.ts` | `seperated` → `separated` |
| `nodes/Gitlab/GitlabTrigger.node.ts` | `occured` → `occurred` |
| `nodes/Stripe/StripeTrigger.node.ts` | `occured` → `occurred` |

## Notes

- The `Swich` typo is particularly visible because it appears as an option label in the InvoiceNinja payment type dropdown. The same list already contains a correctly-spelled `Switch` entry in another section, so this aligns the spelling across the two payment-type option lists.
- These corrections are text-only and do not change any logic.

## Checklist

- [x] I have followed the contributing guidelines
- [x] My code changes are limited to the described fix
- [x] I have tested locally (changes are text-only and do not affect logic)