### PR TITLE
docs: fix 'seperate' typo in AI node binary field descriptions

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/document/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/document/analyze.operation.ts
@@ -54,7 +54,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the document(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the document(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],

--- a/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/image/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/Anthropic/actions/image/analyze.operation.ts
@@ -53,7 +53,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the image(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the image(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/audio/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/audio/analyze.operation.ts
@@ -53,7 +53,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the audio(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the audio(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/audio/transcribe.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/audio/transcribe.operation.ts
@@ -50,7 +50,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the audio(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the audio(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/document/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/document/analyze.operation.ts
@@ -54,7 +54,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the document(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the document(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],

--- a/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/video/analyze.operation.ts
+++ b/packages/@n8n/nodes-langchain/nodes/vendors/GoogleGemini/actions/video/analyze.operation.ts
@@ -53,7 +53,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'e.g. data',
 		hint: 'The name of the input field containing the binary file data to be processed',
 		description:
-			'Name of the binary field(s) which contains the video(s), seperate multiple field names with commas',
+			'Name of the binary field(s) which contains the video(s), separate multiple field names with commas',
 		displayOptions: {
 			show: {
 				inputType: ['binary'],


### PR DESCRIPTION
## Summary

The description of the `Input Data Field Name(s)` parameter shown in the n8n UI for several AI vendor actions contains the misspelling `seperate` instead of `separate`. This PR fixes the typo in all six affected files.

## Files changed

**Google Gemini**
- `actions/audio/analyze.operation.ts`
- `actions/audio/transcribe.operation.ts`
- `actions/document/analyze.operation.ts`
- `actions/video/analyze.operation.ts`

**Anthropic**
- `actions/document/analyze.operation.ts`
- `actions/image/analyze.operation.ts`

## Before

> Name of the binary field(s) which contains the audio(s), **seperate** multiple field names with commas

## After

> Name of the binary field(s) which contains the audio(s), **separate** multiple field names with commas

## Checklist

- [x] I have followed the contributing guidelines
- [x] Changes are limited to fixing the described typo
- [x] No functional code changes