### PR TITLE
fix: correct typos in node definitions and comments

### DIFF
--- a/packages/nodes-base/nodes/Autopilot/Autopilot.node.ts
+++ b/packages/nodes-base/nodes/Autopilot/Autopilot.node.ts
@@ -304,11 +304,11 @@ export class Autopilot implements INodeType {
 				returnData.push(...executionData);
 			} catch (error) {
 				if (this.continueOnFail()) {
-					const exectionErrorWithMetaData = this.helpers.constructExecutionMetaData(
+					const executionErrorWithMetaData = this.helpers.constructExecutionMetaData(
 						[{ json: { error: error.message } }],
 						{ itemData: { item: i } },
 					);
-					responseData.push(...exectionErrorWithMetaData);
+					responseData.push(...executionErrorWithMetaData);
 					continue;
 				}
 

--- a/packages/nodes-base/nodes/Cortex/ResponderDescription.ts
+++ b/packages/nodes-base/nodes/Cortex/ResponderDescription.ts
@@ -69,7 +69,7 @@ export const responderFields: INodeProperties[] = [
 		type: 'boolean',
 		default: false,
 		// eslint-disable-next-line n8n-nodes-base/node-param-description-boolean-without-whether
-		description: 'Choose between providing JSON object or seperated attributes',
+		description: 'Choose between providing JSON object or separated attributes',
 		displayOptions: {
 			show: {
 				resource: ['responder'],

--- a/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
+++ b/packages/nodes-base/nodes/Gitlab/GitlabTrigger.node.ts
@@ -205,7 +205,7 @@ export class GitlabTrigger implements INodeType {
 						return false;
 					}
 
-					// Some error occured
+					// Some error occurred
 					throw error;
 				}
 

--- a/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
+++ b/packages/nodes-base/nodes/GraphQL/GraphQL.node.ts
@@ -571,10 +571,10 @@ export class GraphQL implements INodeType {
 				const errorData = this.helpers.returnJsonArray({
 					error: error.message,
 				});
-				const exectionErrorWithMetaData = this.helpers.constructExecutionMetaData(errorData, {
+				const executionErrorWithMetaData = this.helpers.constructExecutionMetaData(errorData, {
 					itemData: { item: itemIndex },
 				});
-				returnItems.push(...exectionErrorWithMetaData);
+				returnItems.push(...executionErrorWithMetaData);
 			}
 		}
 		return [returnItems];

--- a/packages/nodes-base/nodes/Keap/EmailDescription.ts
+++ b/packages/nodes-base/nodes/Keap/EmailDescription.ts
@@ -308,7 +308,7 @@ export const emailFields: INodeProperties[] = [
 			},
 		},
 		default: '',
-		description: 'Contact IDs to receive the email. Multiple can be added seperated by comma.',
+		description: 'Contact IDs to receive the email. Multiple can be added separated by comma.',
 	},
 	{
 		displayName: 'Subject',

--- a/packages/nodes-base/nodes/Stripe/StripeTrigger.node.ts
+++ b/packages/nodes-base/nodes/Stripe/StripeTrigger.node.ts
@@ -877,7 +877,7 @@ export class StripeTrigger implements INodeType {
 						return false;
 					}
 
-					// Some error occured
+					// Some error occurred
 					throw error;
 				}
 


### PR DESCRIPTION
## Summary

This PR fixes several spelling mistakes found across node definitions and source code comments.

## Changes

| File | Before | After |
|------|--------|-------|
| `Cortex/ResponderDescription.ts` | seperated | separated |
| `Keap/EmailDescription.ts` | seperated | separated |
| `Gitlab/GitlabTrigger.node.ts` | occured | occurred |
| `Stripe/StripeTrigger.node.ts` | occured | occurred |
| `GraphQL/GraphQL.node.ts` | exectionErrorWithMetaData | executionErrorWithMetaData |
| `Autopilot/Autopilot.node.ts` | exectionErrorWithMetaData | executionErrorWithMetaData |

## Checklist

- [x] Changes are limited to typo fixes only
- [x] No functional changes
- [x] Variable renames are consistent (declaration and all usages updated)