### PR TITLE
fix: improve grammar in NocoDB node descriptions

### DIFF
--- a/packages/nodes-base/nodes/NocoDB/v2/actions/linkrows/link.operation.ts
+++ b/packages/nodes-base/nodes/NocoDB/v2/actions/linkrows/link.operation.ts
@@ -23,7 +23,7 @@ export const description: INodeProperties[] = updateDisplayOptions(
 			type: 'string',
 			default: '',
 			required: true,
-			description: 'The ID of record in table',
+			description: 'The ID of the record in the table',
 		},
 		{
 			displayName: 'Link Field Name or ID',
@@ -52,7 +52,7 @@ export const description: INodeProperties[] = updateDisplayOptions(
 			],
 			required: true,
 			description:
-				'Name of the fields of type \'link\' that will be uploaded. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+				'Name of the field of type \'link\' to use. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 		},
 		{
 			displayName: 'Linked Row ID Value',
@@ -63,7 +63,7 @@ export const description: INodeProperties[] = updateDisplayOptions(
 			},
 			default: [],
 			required: true,
-			description: 'The ID of record in table',
+			description: 'The ID of the record in the table',
 		},
 	],
 );

--- a/packages/nodes-base/nodes/NocoDB/v2/actions/linkrows/list.operation.ts
+++ b/packages/nodes-base/nodes/NocoDB/v2/actions/linkrows/list.operation.ts
@@ -23,7 +23,7 @@ export const description: INodeProperties[] = updateDisplayOptions(
 			type: 'string',
 			default: '',
 			required: true,
-			description: 'The ID of record in table',
+			description: 'The ID of the record in the table',
 		},
 		{
 			displayName: 'Link Field Name or ID',
@@ -52,7 +52,7 @@ export const description: INodeProperties[] = updateDisplayOptions(
 			],
 			required: true,
 			description:
-				'Name of the fields of type \'link\' that will be uploaded. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+				'Name of the field of type \'link\' to use. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 		},
 		{
 			displayName: 'Return All',

--- a/packages/nodes-base/nodes/NocoDB/v2/actions/linkrows/unlink.operation.ts
+++ b/packages/nodes-base/nodes/NocoDB/v2/actions/linkrows/unlink.operation.ts
@@ -23,7 +23,7 @@ export const description: INodeProperties[] = updateDisplayOptions(
 			type: 'string',
 			default: '',
 			required: true,
-			description: 'The ID of record in table',
+			description: 'The ID of the record in the table',
 		},
 		{
 			displayName: 'Link Field Name or ID',
@@ -52,7 +52,7 @@ export const description: INodeProperties[] = updateDisplayOptions(
 			],
 			required: true,
 			description:
-				'Name of the fields of type \'link\' that will be uploaded. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+				'Name of the field of type \'link\' to use. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 		},
 		{
 			displayName: 'Linked Row ID Value',
@@ -63,7 +63,7 @@ export const description: INodeProperties[] = updateDisplayOptions(
 			},
 			default: [],
 			required: true,
-			description: 'The ID of record in table',
+			description: 'The ID of the record in the table',
 		},
 	],
 );

--- a/packages/nodes-base/nodes/NocoDB/v2/actions/rows/upload.operation.ts
+++ b/packages/nodes-base/nodes/NocoDB/v2/actions/rows/upload.operation.ts
@@ -76,7 +76,7 @@ export const description: INodeProperties[] = updateDisplayOptions(
 			],
 			required: true,
 			description:
-				'Name of the fields of type \'attachment\' that will be uploaded. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+				'Name of the field of type \'attachment\' that will be uploaded. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 		},
 		{
 			displayName: 'Upload Field Name or ID',
@@ -110,7 +110,7 @@ export const description: INodeProperties[] = updateDisplayOptions(
 			],
 			required: true,
 			description:
-				'Name of the fields of type \'attachment\' that will be uploaded. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+				'Name of the field of type \'attachment\' that will be uploaded. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
 		},
 		{
 			displayName: 'Filename',
@@ -151,7 +151,7 @@ export const description: INodeProperties[] = updateDisplayOptions(
 					uploadMode: ['base64'],
 				},
 			},
-			description: 'Base64 value of file that will be upload',
+			description: 'Base64 value of the file that will be uploaded',
 		},
 		{
 			displayName: 'File Url',


### PR DESCRIPTION
## Summary

This PR fixes several grammar issues in the NocoDB v2 node parameter descriptions, improving clarity for users configuring the node.

## Changes

### Missing articles
- `'The ID of record in table'` → `'The ID of the record in the table'` (5 occurrences across list, link, and unlink operations)

### Singular/plural mismatch
- `'Name of the fields of type...'` → `'Name of the field of type...'` (each parameter refers to a single field, not multiple)

### Incorrect operation description
- Link field descriptions said "that will be uploaded" which is incorrect for link/unlink/list operations → changed to "to use"

### Grammar fix
- `'Base64 value of file that will be upload'` → `'Base64 value of the file that will be uploaded'`

## Files changed
- `packages/nodes-base/nodes/NocoDB/v2/actions/linkrows/list.operation.ts`
- `packages/nodes-base/nodes/NocoDB/v2/actions/linkrows/link.operation.ts`
- `packages/nodes-base/nodes/NocoDB/v2/actions/linkrows/unlink.operation.ts`
- `packages/nodes-base/nodes/NocoDB/v2/actions/rows/upload.operation.ts`

## Checklist
- [x] Description-only changes, no functional impact
- [x] Consistent with existing n8n description style