### PR TITLE
fix: Use NodeOperationError instead of Error in NocoDB operations

### DIFF
--- a/packages/nodes-base/nodes/NocoDB/v2/actions/linkrows/link.operation.ts
+++ b/packages/nodes-base/nodes/NocoDB/v2/actions/linkrows/link.operation.ts
@@ -6,7 +6,7 @@ import type {
 	INodeProperties,
 	JsonObject,
 } from 'n8n-workflow';
-import { NodeApiError, updateDisplayOptions } from 'n8n-workflow';
+import { NodeApiError, NodeOperationError, updateDisplayOptions } from 'n8n-workflow';
 
 import { apiRequest } from '../../transport';
 
@@ -100,7 +100,7 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 			body = [];
 
 			if (!linkIds?.length) {
-				throw new Error('Linked Row ID Value cannot be empty');
+				throw new NodeOperationError(this.getNode(), 'Linked Row ID Value cannot be empty');
 			}
 			for (const linkId of linkIds) {
 				// if it comes from expression (input)

--- a/packages/nodes-base/nodes/NocoDB/v2/actions/linkrows/unlink.operation.ts
+++ b/packages/nodes-base/nodes/NocoDB/v2/actions/linkrows/unlink.operation.ts
@@ -6,7 +6,7 @@ import type {
 	INodeProperties,
 	JsonObject,
 } from 'n8n-workflow';
-import { NodeApiError, updateDisplayOptions } from 'n8n-workflow';
+import { NodeApiError, NodeOperationError, updateDisplayOptions } from 'n8n-workflow';
 
 import { apiRequest } from '../../transport';
 
@@ -99,7 +99,7 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 			}) as IDataObject[];
 
 			if (!linkIds?.length) {
-				throw new Error('Linked Row ID Value cannot be empty');
+				throw new NodeOperationError(this.getNode(), 'Linked Row ID Value cannot be empty');
 			}
 
 			requestMethod = 'DELETE';

--- a/packages/nodes-base/nodes/NocoDB/v2/actions/rows/upload.operation.ts
+++ b/packages/nodes-base/nodes/NocoDB/v2/actions/rows/upload.operation.ts
@@ -6,7 +6,7 @@ import type {
 	INodeProperties,
 	JsonObject,
 } from 'n8n-workflow';
-import { NodeApiError, updateDisplayOptions } from 'n8n-workflow';
+import { NodeApiError, NodeOperationError, updateDisplayOptions } from 'n8n-workflow';
 
 import { JSONSafeParse } from '../../helpers';
 import { apiRequest } from '../../transport';
@@ -233,7 +233,7 @@ export async function execute(this: IExecuteFunctions): Promise<INodeExecutionDa
 				if (field && typeof field === 'string') {
 					field = JSONSafeParse<IDataObject[]>(field);
 					if (field && !Array.isArray(field)) {
-						throw new Error('Attachment value need to be an array');
+						throw new NodeOperationError(this.getNode(), 'Attachment value needs to be an array');
 					}
 				}
 


### PR DESCRIPTION
## Summary

This PR replaces generic `throw new Error()` with `throw new NodeOperationError()` in the NocoDB v2 node operations. Using `NodeOperationError` is the recommended pattern in n8n nodes as it:

- Properly attributes the error to the specific node in the workflow
- Displays the error message correctly in the n8n UI
- Provides better error context for debugging
- Is consistent with the NocoDB v1 node which already uses `NodeOperationError`

## Changes

| File | Change |
|------|--------|
| `upload.operation.ts` | `throw new Error('Attachment value need to be an array')` → `throw new NodeOperationError(this.getNode(), 'Attachment value needs to be an array')` |
| `link.operation.ts` | `throw new Error('Linked Row ID Value cannot be empty')` → `throw new NodeOperationError(this.getNode(), 'Linked Row ID Value cannot be empty')` |
| `unlink.operation.ts` | `throw new Error('Linked Row ID Value cannot be empty')` → `throw new NodeOperationError(this.getNode(), 'Linked Row ID Value cannot be empty')` |

Also fixed a minor grammar issue: "need to be" → "needs to be".

## Checklist
- [x] Uses n8n's recommended error handling pattern
- [x] Consistent with NocoDB v1 node implementation
- [x] No functional behavior change (same error messages)