### PR TITLE
feat(DeepSeek Chat Model Node): Add reasoning effort option

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatDeepSeek/LmChatDeepSeek.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatDeepSeek/LmChatDeepSeek.node.ts
@@ -179,6 +179,32 @@ export class LmChatDeepSeek implements INodeType {
 						type: 'number',
 					},
 					{
+						displayName: 'Reasoning Effort',
+						name: 'reasoningEffort',
+						default: 'medium',
+						description:
+							'Controls how much reasoning the model performs. Applies to reasoning-capable models (e.g. deepseek-reasoner); lower values favor speed and fewer tokens, higher values favor more complete reasoning.',
+						type: 'options',
+						options: [
+							{
+								name: 'Low',
+								value: 'low',
+								description: 'Favors speed and economical token usage',
+							},
+							{
+								name: 'Medium',
+								value: 'medium',
+								description: 'Balance between speed and reasoning accuracy',
+							},
+							{
+								name: 'High',
+								value: 'high',
+								description:
+									'Favors more complete reasoning at the cost of more tokens generated and slower responses',
+							},
+						],
+					},
+					{
 						displayName: 'Sampling Temperature',
 						name: 'temperature',
 						default: 0.7,
@@ -229,6 +255,7 @@ export class LmChatDeepSeek implements INodeType {
 			temperature?: number;
 			topP?: number;
 			responseFormat?: 'text' | 'json_object';
+			reasoningEffort?: 'low' | 'medium' | 'high';
 		};
 
 		const timeout = options.timeout;
@@ -250,11 +277,15 @@ export class LmChatDeepSeek implements INodeType {
 			maxRetries: options.maxRetries ?? 2,
 			configuration,
 			callbacks: [new N8nLlmTracing(this)],
-			modelKwargs: options.responseFormat
-				? {
-						response_format: { type: options.responseFormat },
-					}
-				: undefined,
+			modelKwargs:
+				options.responseFormat || options.reasoningEffort
+					? {
+							...(options.responseFormat
+								? { response_format: { type: options.responseFormat } }
+								: {}),
+							...(options.reasoningEffort ? { reasoning_effort: options.reasoningEffort } : {}),
+						}
+					: undefined,
 			onFailedAttempt: makeN8nLlmFailedAttemptHandler(this, openAiFailedAttemptHandler),
 		});
 

--- a/packages/@n8n/nodes-langchain/nodes/llms/LmChatDeepSeek/test/LmChatDeepSeek.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LmChatDeepSeek/test/LmChatDeepSeek.node.test.ts
@@ -1,0 +1,116 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/unbound-method */
+import { ChatOpenAI } from '@langchain/openai';
+import { makeN8nLlmFailedAttemptHandler, getProxyAgent } from '@n8n/ai-utilities';
+import { createMockExecuteFunction } from 'n8n-nodes-base/test/nodes/Helpers';
+import type { INode, ISupplyDataFunctions } from 'n8n-workflow';
+import type { Mocked } from 'vitest';
+
+import { LmChatDeepSeek } from '../LmChatDeepSeek.node';
+
+vi.mock('@langchain/openai');
+vi.mock('@n8n/ai-utilities');
+
+const MockedChatOpenAI = vi.mocked(ChatOpenAI);
+const mockedMakeN8nLlmFailedAttemptHandler = vi.mocked(makeN8nLlmFailedAttemptHandler);
+const mockedGetProxyAgent = vi.mocked(getProxyAgent);
+
+describe('LmChatDeepSeek', () => {
+	let node: LmChatDeepSeek;
+
+	const mockNodeDef: INode = {
+		id: '1',
+		name: 'DeepSeek Chat Model',
+		typeVersion: 1,
+		type: 'n8n-nodes-langchain.lmChatDeepSeek',
+		position: [0, 0],
+		parameters: {},
+	};
+
+	const setupMockContext = (options: Record<string, unknown> = {}, model = 'deepseek-chat') => {
+		const ctx = createMockExecuteFunction<ISupplyDataFunctions>(
+			{},
+			mockNodeDef,
+		) as Mocked<ISupplyDataFunctions>;
+
+		ctx.getCredentials = vi.fn().mockResolvedValue({
+			apiKey: 'test-key',
+			url: 'https://api.deepseek.com',
+		});
+		ctx.getNode = vi.fn().mockReturnValue(mockNodeDef);
+		ctx.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+			if (paramName === 'model') return model;
+			if (paramName === 'options') return options;
+			return undefined;
+		});
+
+		mockedMakeN8nLlmFailedAttemptHandler.mockReturnValue(vi.fn());
+		mockedGetProxyAgent.mockReturnValue({} as any);
+		return ctx;
+	};
+
+	beforeEach(() => {
+		node = new LmChatDeepSeek();
+		vi.clearAllMocks();
+	});
+
+	describe('supplyData', () => {
+		it('creates ChatOpenAI from deepSeekApi credentials with no extra modelKwargs by default', async () => {
+			const ctx = setupMockContext();
+
+			const result = await node.supplyData.call(ctx, 0);
+
+			expect(ctx.getCredentials).toHaveBeenCalledWith('deepSeekApi');
+			expect(MockedChatOpenAI).toHaveBeenCalledWith(
+				expect.objectContaining({
+					apiKey: 'test-key',
+					model: 'deepseek-chat',
+					modelKwargs: undefined,
+				}),
+			);
+			expect(result).toEqual({ response: expect.any(Object) });
+		});
+
+		it('sets response_format in modelKwargs when responseFormat is provided', async () => {
+			const ctx = setupMockContext({ responseFormat: 'json_object' });
+
+			await node.supplyData.call(ctx, 0);
+
+			expect(MockedChatOpenAI).toHaveBeenCalledWith(
+				expect.objectContaining({
+					modelKwargs: { response_format: { type: 'json_object' } },
+				}),
+			);
+		});
+
+		it('sets reasoning_effort in modelKwargs when reasoningEffort is provided', async () => {
+			const ctx = setupMockContext({ reasoningEffort: 'high' }, 'deepseek-reasoner');
+
+			await node.supplyData.call(ctx, 0);
+
+			expect(MockedChatOpenAI).toHaveBeenCalledWith(
+				expect.objectContaining({
+					modelKwargs: { reasoning_effort: 'high' },
+				}),
+			);
+		});
+
+		it('includes both response_format and reasoning_effort when both are provided', async () => {
+			const ctx = setupMockContext(
+				{ responseFormat: 'json_object', reasoningEffort: 'low' },
+				'deepseek-reasoner',
+			);
+
+			await node.supplyData.call(ctx, 0);
+
+			expect(MockedChatOpenAI).toHaveBeenCalledWith(
+				expect.objectContaining({
+					modelKwargs: {
+						response_format: { type: 'json_object' },
+						reasoning_effort: 'low',
+					},
+				}),
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

DeepSeek's V4 models take a `reasoning_effort` parameter (`low` / `medium` / `high`) to control how much the model reasons, but the node had no way to set it.

This adds a **Reasoning Effort** option to the DeepSeek Chat Model node. It's opt-in — the value is only sent when you add the option, so existing workflows are unaffected. It's passed through `modelKwargs` alongside the existing `response_format`, which is how `@langchain/openai` forwards extra params to the API.

**How to test**
1. Add a DeepSeek Chat Model node and connect DeepSeek credentials.
2. Open **Options → Add Option → Reasoning Effort** and pick `low` / `medium` / `high`.
3. Run it against a reasoning-capable model (e.g. `deepseek-reasoner`) and confirm the request carries `reasoning_effort`.
4. Leave the option off and confirm the request is unchanged (no `reasoning_effort` sent).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/GHC-8117
#29652

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)