### PR TITLE
fix(core): Polyfill DOMMatrix for CLI PDF parsing

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -149,6 +149,7 @@
     "@parcel/watcher": "^2.5.1",
     "@rudderstack/rudder-sdk-node": "catalog:",
     "@sentry/node": "catalog:sentry",
+    "@thednp/dommatrix": "^2.0.12",
     "aws4": "1.11.0",
     "axios": "catalog:",
     "bcryptjs": "2.4.3",

--- a/packages/cli/src/modules/agents/__tests__/agent-knowledge.service.test.ts
+++ b/packages/cli/src/modules/agents/__tests__/agent-knowledge.service.test.ts
@@ -18,13 +18,20 @@ jest.unmock('node:fs/promises');
 
 const mockGetText = jest.fn<Promise<{ text: string; total: number }>, []>();
 const mockDestroy = jest.fn<Promise<void>, []>();
+const mockPDFParse = jest.fn().mockImplementation(() => ({
+	getText: mockGetText,
+	destroy: mockDestroy,
+}));
+const MockDOMMatrix = class DOMMatrixMock {};
 
 jest.mock('pdf-parse', () => ({
 	__esModule: true,
-	PDFParse: jest.fn().mockImplementation(() => ({
-		getText: mockGetText,
-		destroy: mockDestroy,
-	})),
+	PDFParse: mockPDFParse,
+}));
+
+jest.mock('@thednp/dommatrix', () => ({
+	__esModule: true,
+	default: MockDOMMatrix,
 }));
 
 jest.mock('@n8n/utils', () => ({
@@ -77,6 +84,7 @@ describe('AgentKnowledgeService', () => {
 		jest.mocked(generateNanoId).mockReset().mockReturnValue('file-1');
 		mockGetText.mockReset();
 		mockDestroy.mockReset().mockResolvedValue(undefined);
+		mockPDFParse.mockClear();
 
 		service = new AgentKnowledgeService(agentRepository, agentFileRepository, binaryDataService);
 	});
@@ -343,6 +351,34 @@ describe('AgentKnowledgeService', () => {
 			fileSizeBytes: 19,
 		});
 		expect(mockDestroy).toHaveBeenCalledTimes(1);
+	});
+
+	it('polyfills DOMMatrix before parsing PDFs when missing from Node globals', async () => {
+		agentRepository.findByIdAndProjectId.mockResolvedValue({ id: agentId, projectId } as never);
+		mockGetText.mockResolvedValue({ text: 'Extracted PDF text', total: 1 });
+
+		const previousDomMatrix = Reflect.get(globalThis, 'DOMMatrix');
+		Reflect.deleteProperty(globalThis, 'DOMMatrix');
+
+		try {
+			await service.uploadFiles(agentId, projectId, [
+				makeMulterFile({
+					originalname: 'document.pdf',
+					mimetype: 'application/pdf',
+					buffer: Buffer.from('%PDF original bytes'),
+					size: 19,
+				}),
+			]);
+
+			expect(mockPDFParse).toHaveBeenCalledTimes(1);
+			expect(Reflect.get(globalThis, 'DOMMatrix')).toBe(MockDOMMatrix);
+		} finally {
+			if (previousDomMatrix === undefined) {
+				Reflect.deleteProperty(globalThis, 'DOMMatrix');
+			} else {
+				Reflect.set(globalThis, 'DOMMatrix', previousDomMatrix);
+			}
+		}
 	});
 
 	it('rejects PDFs with no extractable text', async () => {

--- a/packages/cli/src/modules/agents/agent-knowledge.service.ts
+++ b/packages/cli/src/modules/agents/agent-knowledge.service.ts
@@ -53,6 +53,15 @@ const MAX_AGENT_FILE_METADATA_LENGTH = 255;
 const MAX_WORKSPACE_FILES = 2_000;
 const MAX_WORKSPACE_BYTES = 2 * 1024 * 1024 * 1024;
 
+async function ensureDomMatrixPolyfill() {
+	// pdf-parse v2 is backed by pdfjs-dist, which expects a `DOMMatrix` global
+	// that Node.js does not provide.
+	if (typeof Reflect.get(globalThis, 'DOMMatrix') === 'undefined') {
+		const { default: DOMMatrix } = await import('@thednp/dommatrix');
+		Reflect.set(globalThis, 'DOMMatrix', DOMMatrix);
+	}
+}
+
 @Service()
 export class AgentKnowledgeService {
 	constructor(
@@ -333,6 +342,8 @@ export class AgentKnowledgeService {
 	}
 
 	private async extractPdfText(fileName: string, buffer: Buffer) {
+		await ensureDomMatrixPolyfill();
+
 		const { PDFParse } = await import('pdf-parse');
 		const parser = new PDFParse({ data: buffer });
 		try {

--- a/packages/cli/src/modules/instance-ai/web-research/__tests__/fetch-and-extract.test.ts
+++ b/packages/cli/src/modules/instance-ai/web-research/__tests__/fetch-and-extract.test.ts
@@ -10,6 +10,26 @@ import { SsrfProtectionService } from '@/services/ssrf/ssrf-protection.service';
 
 import { fetchAndExtract } from '../fetch-and-extract';
 
+const mockPdfGetText = jest.fn<Promise<{ text: string; total: number }>, []>();
+const mockPdfGetInfo = jest.fn<Promise<{ info?: { Title?: unknown } }>, []>();
+const mockPdfDestroy = jest.fn<Promise<void>, []>();
+const mockPDFParse = jest.fn().mockImplementation(() => ({
+	getText: mockPdfGetText,
+	getInfo: mockPdfGetInfo,
+	destroy: mockPdfDestroy,
+}));
+const MockDOMMatrix = class DOMMatrixMock {};
+
+jest.mock('pdf-parse', () => ({
+	__esModule: true,
+	PDFParse: mockPDFParse,
+}));
+
+jest.mock('@thednp/dommatrix', () => ({
+	__esModule: true,
+	default: MockDOMMatrix,
+}));
+
 function createSsrfMock(): jest.Mocked<SsrfBridge> {
 	const ssrf = mock<SsrfBridge>();
 	ssrf.validateUrl.mockResolvedValue(createResultOk(undefined));
@@ -61,6 +81,10 @@ describe('fetchAndExtract', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		ssrf = createSsrfMock();
+		mockPdfGetText.mockReset();
+		mockPdfGetInfo.mockReset();
+		mockPdfDestroy.mockReset().mockResolvedValue(undefined);
+		mockPDFParse.mockClear();
 	});
 
 	afterAll(() => {
@@ -122,6 +146,32 @@ describe('fetchAndExtract', () => {
 
 		expect(result.content).toBe(text);
 		expect(result.truncated).toBe(false);
+	});
+
+	it('polyfills DOMMatrix before parsing PDF responses when missing from Node globals', async () => {
+		mockPdfGetText.mockResolvedValue({ text: 'Extracted PDF text', total: 1 });
+		mockPdfGetInfo.mockResolvedValue({ info: { Title: 'Doc' } });
+		globalThis.fetch = jest
+			.fn()
+			.mockResolvedValue(createMockResponse('%PDF', { contentType: 'application/pdf' }));
+
+		const previousDomMatrix = Reflect.get(globalThis, 'DOMMatrix');
+		Reflect.deleteProperty(globalThis, 'DOMMatrix');
+
+		try {
+			const result = await fetchAndExtract('https://example.com/file.pdf', { ssrf });
+
+			expect(mockPDFParse).toHaveBeenCalledTimes(1);
+			expect(result.content).toBe('Extracted PDF text');
+			expect(Reflect.get(globalThis, 'DOMMatrix')).toBe(MockDOMMatrix);
+			expect(mockPdfDestroy).toHaveBeenCalledTimes(1);
+		} finally {
+			if (previousDomMatrix === undefined) {
+				Reflect.deleteProperty(globalThis, 'DOMMatrix');
+			} else {
+				Reflect.set(globalThis, 'DOMMatrix', previousDomMatrix);
+			}
+		}
 	});
 
 	it('truncates content exceeding maxContentLength', async () => {

--- a/packages/cli/src/modules/instance-ai/web-research/fetch-and-extract.ts
+++ b/packages/cli/src/modules/instance-ai/web-research/fetch-and-extract.ts
@@ -49,6 +49,15 @@ const MAX_RESPONSE_BYTES = 5 * 1024 * 1024; // 5 MB
 const DEFAULT_MAX_CONTENT_LENGTH = 30_000;
 const MAX_REDIRECTS = 10;
 
+async function ensureDomMatrixPolyfill() {
+	// pdf-parse v2 is backed by pdfjs-dist, which expects a `DOMMatrix` global
+	// that Node.js does not provide.
+	if (typeof Reflect.get(globalThis, 'DOMMatrix') === 'undefined') {
+		const { default: DOMMatrix } = await import('@thednp/dommatrix');
+		Reflect.set(globalThis, 'DOMMatrix', DOMMatrix);
+	}
+}
+
 export interface FetchAndExtractOptions {
 	maxContentLength?: number;
 	maxResponseBytes?: number;
@@ -262,6 +271,8 @@ async function extractPdf(
 	body: Buffer,
 	maxContentLength: number,
 ): Promise<FetchedPage> {
+	await ensureDomMatrixPolyfill();
+
 	// Dynamic import to avoid loading pdf-parse unless needed
 	const { PDFParse } = await import('pdf-parse');
 	const parser = new PDFParse({ data: body });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3123,6 +3123,9 @@ importers:
       '@sentry/node':
         specifier: catalog:sentry
         version: 10.55.0(@opentelemetry/exporter-trace-otlp-http@0.217.0(@opentelemetry/api@1.9.0))
+      '@thednp/dommatrix':
+        specifier: ^2.0.12
+        version: 2.0.12
       aws4:
         specifier: 1.11.0
         version: 1.11.0


### PR DESCRIPTION
## Summary

- Add a DOMMatrix polyfill guard before PDF parsing in CLI agent knowledge ingestion
- Add the same DOMMatrix polyfill guard in CLI instance-ai web research PDF extraction path
- Add @thednp/dommatrix as an explicit dependency in packages/cli

## How to test

1. Trigger agent knowledge PDF upload/ingestion with a PDF file
2. Trigger instance-ai web research on a PDF URL
3. Confirm parsing succeeds and no "DOMMatrix is not defined" error appears

Note: Local verification commands were not run in this environment because pnpm/corepack are unavailable in PATH.

## Related Linear tickets, Github issues, and Community forum posts

- N/A

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](https://github.com/n8n-io/n8n/blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported).

## 🤖 PR Summary generated by AI

This PR fixes a Node.js runtime compatibility gap introduced by the pdf-parse v2/pdfjs-dist stack by ensuring DOMMatrix is polyfilled on CLI PDF parsing paths before parser initialization.
