### PR TITLE
fix(core): Insights page shows paywall for licensed users due to posthog init failing [1.x backport]

### DIFF
--- a/packages/frontend/editor-ui/public/static/posthog.init.js
+++ b/packages/frontend/editor-ui/public/static/posthog.init.js
@@ -27,7 +27,7 @@
 						return u.toString(1) + '.people (stub)';
 					},
 					o =
-						'capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag onFeatureFlags reloadFeatureFlags'.split(
+						'capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled getFeatureFlag onFeatureFlags reloadFeatureFlags group'.split(
 							' ',
 						),
 					n = 0;

--- a/packages/frontend/editor-ui/src/app/init.test.ts
+++ b/packages/frontend/editor-ui/src/app/init.test.ts
@@ -8,6 +8,7 @@ import { useSettingsStore } from '@/app/stores/settings.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { useSSOStore } from '@/features/settings/sso/sso.store';
 import { useUsersStore } from '@/features/settings/users/users.store';
+import { usePostHog } from '@/app/stores/posthog.store';
 import { useVersionsStore } from '@/app/stores/versions.store';
 import { useBannersStore } from '@/features/shared/banners/banners.store';
 import type { Cloud, CurrentUserResponse } from '@n8n/rest-api-client';
@@ -149,6 +150,21 @@ describe('Init', () => {
 					oidc: false,
 				},
 			});
+		});
+
+		it('should still call getModuleSettings if postHogStore.init throws', async () => {
+			const postHogStore = mockedStore(usePostHog);
+			vi.spyOn(postHogStore, 'init').mockImplementation(() => {
+				throw new Error('PostHog init failed');
+			});
+
+			usersStore.registerLoginHook.mockImplementation(async (hook) => {
+				await hook(mock<CurrentUserResponse>({ id: 'userId', role: 'global:member' }));
+			});
+
+			await initializeCore();
+
+			expect(settingsStore.getModuleSettings).toHaveBeenCalled();
 		});
 	});
 

--- a/packages/frontend/editor-ui/src/app/init.ts
+++ b/packages/frontend/editor-ui/src/app/init.ts
@@ -225,7 +225,12 @@ function registerAuthenticationHooks() {
 
 		RBACStore.setGlobalScopes(user.globalScopes ?? []);
 		telemetry.identify(rootStore.instanceId, user.id, rootStore.versionCli);
-		postHogStore.init(user.featureFlags);
+		try {
+			postHogStore.init(user.featureFlags);
+		} catch (e) {
+			// don't let posthog failing prevent further function calls
+			console.error(e);
+		}
 		npsSurveyStore.setupNpsSurveyOnLogin(user.id, user.settings);
 		void settingsStore.getModuleSettings();
 		void bannersStore.loadDynamicBanners();


### PR DESCRIPTION
## Summary

This PR applies the changes from https://github.com/n8n-io/n8n/pull/31406 on 1.x

## Related Linear tickets, Github issues, and Community forum posts

closes LIGO-695

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
