### PR TITLE
fix(editor): Open sticky note color picker from context menu

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nPopover/Popover.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nPopover/Popover.test.ts
@@ -141,6 +141,51 @@ describe('N8nPopover', () => {
 			expect(popover.contains(document.activeElement)).toBe(false);
 		});
 
+		it('should dismiss when focus moves outside by default', async () => {
+			const externalInput = document.createElement('input');
+			document.body.appendChild(externalInput);
+
+			const wrapper = render(N8nPopover, {
+				props: { open: true },
+				slots: {
+					trigger: '<button>trigger</button>',
+					content: '<input />',
+				},
+			});
+			const popover = await wrapper.findByRole('dialog');
+			expect(popover.contains(document.activeElement)).toBe(true);
+
+			externalInput.focus();
+
+			await waitFor(() => expect(wrapper.emitted()['update:open']).toContainEqual([false]));
+
+			externalInput.remove();
+		});
+
+		it('should not dismiss when focus moves outside and dismissOnFocusOutside is false', async () => {
+			const externalInput = document.createElement('input');
+			document.body.appendChild(externalInput);
+
+			const wrapper = render(N8nPopover, {
+				props: { open: true, dismissOnFocusOutside: false },
+				slots: {
+					trigger: '<button>trigger</button>',
+					content: '<input />',
+				},
+			});
+			const popover = await wrapper.findByRole('dialog');
+			expect(popover.contains(document.activeElement)).toBe(true);
+
+			externalInput.focus();
+
+			// Allow Reka's focus-outside detection (which awaits a couple of ticks) to run
+			await new Promise((resolve) => setTimeout(resolve, 20));
+
+			expect(wrapper.emitted()['update:open'] ?? []).not.toContainEqual([false]);
+
+			externalInput.remove();
+		});
+
 		it('should suppress focus restore on close when suppressAutoFocus is true', async () => {
 			const triggerHandle = document.createElement('button');
 			triggerHandle.textContent = 'trigger';

--- a/packages/frontend/@n8n/design-system/src/components/N8nPopover/Popover.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nPopover/Popover.vue
@@ -46,6 +46,14 @@ interface Props
 	 */
 	suppressAutoFocus?: boolean;
 	/**
+	 * Whether the popover should dismiss when focus moves outside of it.
+	 * Set to `false` when the popover is opened programmatically right as
+	 * another layer (e.g. a context menu) closes and restores focus elsewhere,
+	 * which would otherwise dismiss the popover immediately. Pointer and escape
+	 * dismissal are unaffected.
+	 */
+	dismissOnFocusOutside?: boolean;
+	/**
 	 * Scrollbar visibility behavior
 	 */
 	scrollType?: 'auto' | 'always' | 'scroll' | 'hover';
@@ -94,6 +102,7 @@ const props = withDefaults(defineProps<Props>(), {
 	sideFlip: undefined,
 	collisionPadding: 5,
 	suppressAutoFocus: false,
+	dismissOnFocusOutside: true,
 	zIndex: 999,
 	showArrow: false,
 	teleported: true,
@@ -125,6 +134,18 @@ function handleCloseAutoFocus(e: Event) {
 function handleOutsideInteraction(e: PointerDownOutsideEvent | FocusOutsideEvent) {
 	const target = e.target as HTMLElement | null;
 	if (target?.closest('.el-popper, .el-select-dropdown')) {
+		e.preventDefault();
+	}
+}
+
+/**
+ * Prevents focus-outside dismissal when the consumer opts out. Reka emits this
+ * before the dismiss check, so calling preventDefault keeps the popover open
+ * when focus moves away (e.g. a closing context menu restoring focus), while
+ * leaving pointer-down-outside and escape dismissal intact.
+ */
+function handleFocusOutside(e: FocusOutsideEvent) {
+	if (!props.dismissOnFocusOutside) {
 		e.preventDefault();
 	}
 }
@@ -164,6 +185,7 @@ watch(
 				@close-auto-focus="handleCloseAutoFocus"
 				@pointer-down-outside="handleOutsideInteraction"
 				@interact-outside="handleOutsideInteraction"
+				@focus-outside="handleFocusOutside"
 			>
 				<N8nScrollArea
 					v-if="enableScrolling"

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/toolbar/CanvasNodeStickyColorSelector.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/toolbar/CanvasNodeStickyColorSelector.test.ts
@@ -1,9 +1,13 @@
 import { fireEvent, screen, waitFor } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
+import { createEventBus } from '@n8n/utils/event-bus';
 import CanvasNodeStickyColorSelector from './CanvasNodeStickyColorSelector.vue';
 import { createComponentRenderer } from '@/__tests__/render';
 import { createCanvasNodeProvide } from '@/features/workflows/canvas/__tests__/utils';
-import { CanvasNodeRenderType } from '@/features/workflows/canvas/canvas.types';
+import {
+	CanvasNodeRenderType,
+	type CanvasNodeEventBusEvents,
+} from '@/features/workflows/canvas/canvas.types';
 
 const renderComponent = createComponentRenderer(CanvasNodeStickyColorSelector);
 
@@ -40,6 +44,36 @@ describe('CanvasNodeStickyColorSelector', () => {
 
 		expect(emitted()).toHaveProperty('update');
 		expect(emitted().update[0]).toEqual([3]);
+	});
+
+	describe('opening via the "update:sticky:color" event (context menu)', () => {
+		it('should open the popover, deferred to a later tick so the closing context menu does not dismiss it', async () => {
+			vi.useFakeTimers();
+			try {
+				const eventBus = createEventBus<CanvasNodeEventBusEvents>();
+				renderComponent({
+					global: {
+						provide: {
+							...createCanvasNodeProvide({ eventBus }),
+						},
+					},
+				});
+
+				eventBus.emit('update:sticky:color');
+
+				// The open must be deferred — opening synchronously while the context
+				// menu is still tearing down lets its focus restoration dismiss the popover.
+				expect(screen.queryAllByTestId('color')).toHaveLength(0);
+
+				await vi.runAllTimersAsync();
+			} finally {
+				vi.useRealTimers();
+			}
+
+			await waitFor(() => {
+				expect(screen.getAllByTestId('color')).toHaveLength(7);
+			});
+		});
 	});
 
 	describe('custom color picker', () => {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/toolbar/CanvasNodeStickyColorSelector.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/toolbar/CanvasNodeStickyColorSelector.vue
@@ -17,6 +17,7 @@ const { render, eventBus } = useCanvasNode();
 const renderOptions = computed(() => render.value.options as CanvasNodeStickyNoteRender['options']);
 
 const autoHideTimeout = ref<NodeJS.Timeout | null>(null);
+const showPopoverTimeout = ref<NodeJS.Timeout | null>(null);
 
 const colors = computed(() => Array.from({ length: 7 }).map((_, index) => index + 1));
 
@@ -25,11 +26,26 @@ const isPopoverVisible = defineModel<boolean>('visible');
 const colorInputRef = ref<HTMLInputElement | null>(null);
 
 function hidePopover() {
+	if (showPopoverTimeout.value) {
+		clearTimeout(showPopoverTimeout.value);
+		showPopoverTimeout.value = null;
+	}
 	isPopoverVisible.value = false;
 }
 
 function showPopover() {
-	isPopoverVisible.value = true;
+	// Triggered by the context menu's "Change color" action. The menu is a Reka
+	// dismissable layer that closes and restores focus elsewhere as it tears down.
+	// Defer the open so it happens after the menu has closed (avoids overlapping
+	// layers); `dismiss-on-focus-outside="false"` on the popover then keeps it
+	// open against the menu's focus restoration, which fires slightly later.
+	if (showPopoverTimeout.value) {
+		clearTimeout(showPopoverTimeout.value);
+	}
+	showPopoverTimeout.value = setTimeout(() => {
+		isPopoverVisible.value = true;
+		showPopoverTimeout.value = null;
+	}, 0);
 }
 
 function changeColor(index: number) {
@@ -69,6 +85,12 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
 	eventBus.value?.off('update:sticky:color', showPopover);
+	if (showPopoverTimeout.value) {
+		clearTimeout(showPopoverTimeout.value);
+	}
+	if (autoHideTimeout.value) {
+		clearTimeout(autoHideTimeout.value);
+	}
 });
 </script>
 
@@ -80,6 +102,7 @@ onBeforeUnmount(() => {
 			width="auto"
 			:content-class="$style.popover"
 			:enable-scrolling="false"
+			:dismiss-on-focus-outside="false"
 			@before-enter="onMouseEnter"
 			@after-leave="onMouseLeave"
 		>


### PR DESCRIPTION
## Summary

The right-click **"Change color"** action on a sticky note did nothing — the color panel never appeared. The action opens the color popover programmatically while the Reka context menu is closing, and the menu restores focus to an element outside the popover, which Reka treats as a focus-outside interaction and dismisses the popover immediately. This adds an opt-in `dismissOnFocusOutside` prop to `N8nPopover` (default `true`, so no change anywhere else) that lets the sticky color popover keep pointer-down-outside and Escape dismissal while ignoring focus-outside dismissal, and defers opening it until the context menu has finished closing.

## How to test

1. Open a workflow and add a sticky note.
2. Right-click the sticky note to open the context menu.
3. Click **Change color** → the color picker popover now appears and selecting a swatch (or a custom color) updates the sticky.
4. Verify the toolbar palette-icon picker still works, and that clicking outside / pressing Escape still closes the popover.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5365

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI