### PR TITLE
fix(API): Enforce the redaction floor when creating workflows

### DIFF
--- a/packages/cli/src/modules/redaction/__tests__/redaction-enforcement.service.test.ts
+++ b/packages/cli/src/modules/redaction/__tests__/redaction-enforcement.service.test.ts
@@ -93,4 +93,41 @@ describe('RedactionEnforcementService', () => {
 			await expect(service.assertPolicyChangeAllowed(undefined, 'all')).resolves.toBeUndefined();
 		});
 	});
+
+	describe('assertNewPolicyAllowed()', () => {
+		test('allows when no policy is supplied (left for the create service to seed)', async () => {
+			const service = createService('production');
+			await expect(service.assertNewPolicyAllowed(undefined)).resolves.toBeUndefined();
+		});
+
+		test.each<WorkflowSettings.RedactionPolicy>(['non-manual', 'all'])(
+			'allows %s which meets the production floor',
+			async (incoming) => {
+				const service = createService('production');
+				await expect(service.assertNewPolicyAllowed(incoming)).resolves.toBeUndefined();
+			},
+		);
+
+		test.each<WorkflowSettings.RedactionPolicy>(['none', 'manual-only'])(
+			'rejects %s which is weaker than the production floor',
+			async (incoming) => {
+				const service = createService('production');
+				await expect(service.assertNewPolicyAllowed(incoming)).rejects.toThrow(
+					UnprocessableRequestError,
+				);
+			},
+		);
+
+		test('allows a below-floor policy when the floor is off', async () => {
+			const service = createService('off');
+			await expect(service.assertNewPolicyAllowed('none')).resolves.toBeUndefined();
+		});
+
+		test('error message names the floor as the reason', async () => {
+			const service = createService('production');
+			await expect(service.assertNewPolicyAllowed('none')).rejects.toThrow(
+				'Workflow redaction policy cannot be weaker than the instance floor.',
+			);
+		});
+	});
 });

--- a/packages/cli/src/modules/redaction/redaction-enforcement.service.ts
+++ b/packages/cli/src/modules/redaction/redaction-enforcement.service.ts
@@ -36,4 +36,20 @@ export class RedactionEnforcementService {
 			throw new UnprocessableRequestError(REDACTION_FLOOR_VIOLATION_MESSAGE);
 		}
 	}
+
+	/**
+	 * Create-time counterpart to {@link assertPolicyChangeAllowed}: a new workflow
+	 * has no prior policy, so a create is modelled as a change from `undefined` to
+	 * the supplied policy. Rejects a supplied policy weaker than the floor.
+	 *
+	 * Used by the public API, which treats a supplied policy as explicit intent —
+	 * the editor instead materialises 'none' as its default toggle state and seeds
+	 * below-floor values up to the floor (see WorkflowCreationService), so this is
+	 * deliberately not applied to editor-originated creates.
+	 */
+	async assertNewPolicyAllowed(
+		incomingPolicy: WorkflowSettings.RedactionPolicy | undefined,
+	): Promise<void> {
+		await this.assertPolicyChangeAllowed(undefined, incomingPolicy);
+	}
 }

--- a/packages/cli/src/public-api/v1/handlers/workflows/__tests__/workflows.service.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/__tests__/workflows.service.test.ts
@@ -4,26 +4,32 @@ import { WorkflowEntity } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
 
-import { createWorkflow } from '../workflows.service';
-
+import { UnprocessableRequestError } from '@/errors/response-errors/unprocessable.error';
+import { RedactionEnforcementService } from '@/modules/redaction/redaction-enforcement.service';
 import { WorkflowCreationService } from '@/workflows/workflow-creation.service';
+
+import { createWorkflow } from '../workflows.service';
 
 describe('createWorkflow (public API)', () => {
 	const user = mock<User>({ id: 'user-id' });
 	const workflowCreationService = mock<WorkflowCreationService>();
+	const redactionEnforcementService = mock<RedactionEnforcementService>();
 
-	const baseBody = (): WorkflowEntity & { projectId?: string } =>
+	const baseBody = (
+		settings: WorkflowEntity['settings'] = {},
+	): WorkflowEntity & { projectId?: string } =>
 		Object.assign(new WorkflowEntity(), {
 			name: 'Test Workflow',
 			nodes: [],
 			connections: {},
-			settings: {},
+			settings,
 		});
 
 	beforeEach(() => {
 		jest.clearAllMocks();
 		jest.spyOn(Container, 'get').mockImplementation((serviceClass) => {
 			if (serviceClass === WorkflowCreationService) return workflowCreationService;
+			if (serviceClass === RedactionEnforcementService) return redactionEnforcementService;
 			return mock();
 		});
 	});
@@ -42,5 +48,27 @@ describe('createWorkflow (public API)', () => {
 		expect(opts).toEqual({ projectId: 'proj-1', publicApi: true, source: 'api' });
 		expect('projectId' in (workflowArg as object)).toBe(false);
 		expect(workflowArg.name).toBe('Test Workflow');
+	});
+
+	it('asserts the supplied redaction policy against the floor before creating', async () => {
+		workflowCreationService.createWorkflow.mockResolvedValue(mock<WorkflowEntity>());
+
+		await createWorkflow(user, baseBody({ redactionPolicy: 'none' }));
+
+		expect(redactionEnforcementService.assertNewPolicyAllowed).toHaveBeenCalledWith('none');
+	});
+
+	it('rejects and does not create when the supplied policy is below the floor', async () => {
+		redactionEnforcementService.assertNewPolicyAllowed.mockRejectedValue(
+			new UnprocessableRequestError(
+				'Workflow redaction policy cannot be weaker than the instance floor.',
+			),
+		);
+
+		await expect(createWorkflow(user, baseBody({ redactionPolicy: 'none' }))).rejects.toThrow(
+			UnprocessableRequestError,
+		);
+
+		expect(workflowCreationService.createWorkflow).not.toHaveBeenCalled();
 	});
 });

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml
@@ -62,9 +62,11 @@ properties:
       - `all`: Redact all executions (manual and production).
 
       When the instance has a redaction floor configured, the policy must be equal to
-      or stricter than the floor. Requests that supply a policy weaker than the
-      instance floor are rejected with 422, on both create and update. Omitting this
-      field when creating a workflow seeds it to the instance floor instead.
+      or stricter than the floor. A policy weaker than the floor is rejected with 422
+      on create, and on update when it changes the stored policy; an unchanged
+      pre-existing below-floor policy is preserved (the floor is not applied
+      retroactively). Omitting this field when creating a workflow seeds it to the
+      instance floor instead.
     example: non-manual
   availableInMCP:
     type: boolean

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/schemas/workflowSettings.yml
@@ -62,8 +62,9 @@ properties:
       - `all`: Redact all executions (manual and production).
 
       When the instance has a redaction floor configured, the policy must be equal to
-      or stricter than the floor. Requests that would weaken the policy below the
-      instance floor are rejected with 422.
+      or stricter than the floor. Requests that supply a policy weaker than the
+      instance floor are rejected with 422, on both create and update. Omitting this
+      field when creating a workflow seeds it to the instance floor instead.
     example: non-manual
   availableInMCP:
     type: boolean

--- a/packages/cli/src/public-api/v1/handlers/workflows/workflows.service.ts
+++ b/packages/cli/src/public-api/v1/handlers/workflows/workflows.service.ts
@@ -11,6 +11,7 @@ import { Container } from '@n8n/di';
 import { PROJECT_OWNER_ROLE_SLUG, type Scope } from '@n8n/permissions';
 
 import { License } from '@/license';
+import { RedactionEnforcementService } from '@/modules/redaction/redaction-enforcement.service';
 import { WorkflowCreationService } from '@/workflows/workflow-creation.service';
 import { WorkflowSharingService } from '@/workflows/workflow-sharing.service';
 
@@ -65,6 +66,14 @@ export async function createWorkflow(
 ): Promise<WorkflowEntity> {
 	const { projectId, ...rest } = body;
 	const workflow = Object.assign(new WorkflowEntity(), rest);
+
+	// A policy supplied via the API is explicit intent, so a below-floor value is
+	// rejected (422) rather than silently seeded up to the floor — matching the
+	// update endpoint. An absent policy is left for WorkflowCreationService to seed.
+	await Container.get(RedactionEnforcementService).assertNewPolicyAllowed(
+		workflow.settings?.redactionPolicy,
+	);
+
 	return await Container.get(WorkflowCreationService).createWorkflow(user, workflow, {
 		projectId,
 		publicApi: true,

--- a/packages/cli/test/integration/public-api/workflows.test.ts
+++ b/packages/cli/test/integration/public-api/workflows.test.ts
@@ -1667,11 +1667,17 @@ describe('POST /workflows redaction floor enforcement', () => {
 		});
 
 	beforeEach(() => {
-		// Floor = Production; spy survives the global restoreMocks reset by being set per-test.
+		// Floor = Production, with data redaction licensed so accepted policies are
+		// persisted/seeded rather than stripped on save. The spy survives the global
+		// restoreMocks reset by being set per-test.
+		license.enable('feat:dataRedaction');
 		jest
 			.spyOn(Container.get(InstanceRedactionEnforcementService), 'get')
 			.mockResolvedValue('production');
 	});
+
+	const savedRedactionPolicy = async (workflowId: string) =>
+		(await workflowRepository.findOneBy({ id: workflowId }))?.settings?.redactionPolicy;
 
 	test('rejects a workflow whose redaction policy is weaker than the floor with 422', async () => {
 		const response = await postWorkflow({ redactionPolicy: 'none' });
@@ -1682,16 +1688,18 @@ describe('POST /workflows redaction floor enforcement', () => {
 		);
 	});
 
-	test('accepts a workflow that omits the redaction policy', async () => {
+	test('seeds the floor policy when the redaction policy is omitted', async () => {
 		const response = await postWorkflow({ executionOrder: 'v1' });
 
 		expect(response.statusCode).toBe(200);
+		expect(await savedRedactionPolicy(response.body.id)).toBe('non-manual');
 	});
 
-	test('accepts a workflow whose redaction policy meets the floor', async () => {
+	test('persists a redaction policy that exceeds the floor', async () => {
 		const response = await postWorkflow({ redactionPolicy: 'all' });
 
 		expect(response.statusCode).toBe(200);
+		expect(await savedRedactionPolicy(response.body.id)).toBe('all');
 	});
 
 	test('rejects manual-only, which does not redact production, with 422', async () => {
@@ -1700,10 +1708,11 @@ describe('POST /workflows redaction floor enforcement', () => {
 		expect(response.statusCode).toBe(422);
 	});
 
-	test('accepts non-manual, which exactly meets the production floor', async () => {
+	test('persists non-manual, which exactly meets the production floor', async () => {
 		const response = await postWorkflow({ redactionPolicy: 'non-manual' });
 
 		expect(response.statusCode).toBe(200);
+		expect(await savedRedactionPolicy(response.body.id)).toBe('non-manual');
 	});
 });
 
@@ -1727,10 +1736,14 @@ describe('PUT /workflows/:id redaction floor enforcement', () => {
 		});
 
 	beforeEach(() => {
+		license.enable('feat:dataRedaction');
 		jest
 			.spyOn(Container.get(InstanceRedactionEnforcementService), 'get')
 			.mockResolvedValue('production');
 	});
+
+	const savedRedactionPolicy = async (workflowId: string) =>
+		(await workflowRepository.findOneBy({ id: workflowId }))?.settings?.redactionPolicy;
 
 	// Parity with POST: the update endpoint already enforced the floor; these prove the
 	// two endpoints reject and accept the same payloads (the ticket's consistency claim).
@@ -1743,6 +1756,7 @@ describe('PUT /workflows/:id redaction floor enforcement', () => {
 		expect(response.body.message).toBe(
 			'Workflow redaction policy cannot be weaker than the instance floor.',
 		);
+		expect(await savedRedactionPolicy(workflow.id)).toBeUndefined();
 	});
 
 	test('rejects manual-only, which does not redact production, with 422', async () => {
@@ -1753,20 +1767,23 @@ describe('PUT /workflows/:id redaction floor enforcement', () => {
 		expect(response.statusCode).toBe(422);
 	});
 
-	test('accepts an update that omits the redaction policy', async () => {
+	test('does not seed a redaction policy when the update omits it', async () => {
 		const workflow = await createWorkflowWithHistory({}, owner);
 
 		const response = await putWorkflow(workflow.id, { executionOrder: 'v1' });
 
 		expect(response.statusCode).toBe(200);
+		// Unlike create, update never seeds — an absent field leaves the policy unset.
+		expect(await savedRedactionPolicy(workflow.id)).toBeUndefined();
 	});
 
-	test('accepts a redaction policy that meets the floor', async () => {
+	test('persists a redaction policy that meets the floor', async () => {
 		const workflow = await createWorkflowWithHistory({}, owner);
 
 		const response = await putWorkflow(workflow.id, { redactionPolicy: 'all' });
 
 		expect(response.statusCode).toBe(200);
+		expect(await savedRedactionPolicy(workflow.id)).toBe('all');
 	});
 });
 

--- a/packages/cli/test/integration/public-api/workflows.test.ts
+++ b/packages/cli/test/integration/public-api/workflows.test.ts
@@ -33,6 +33,7 @@ import * as utils from '../shared/utils/';
 import { ActiveWorkflowManager } from '@/active-workflow-manager';
 import { STARTING_NODES } from '@/constants';
 import { ExecutionService } from '@/executions/execution.service';
+import { InstanceRedactionEnforcementService } from '@/modules/redaction/instance-redaction-enforcement.service';
 import { ProjectService } from '@/services/project.service.ee';
 import { Telemetry } from '@/telemetry';
 
@@ -1644,6 +1645,128 @@ describe('POST /workflows', () => {
 		const found = response.body.nodes.find((node: INode) => STARTING_NODES.includes(node.type));
 
 		expect(found).toBeUndefined();
+	});
+});
+
+describe('POST /workflows redaction floor enforcement', () => {
+	const redactionTrigger = {
+		id: 'uuid-redaction',
+		parameters: {},
+		name: 'Start',
+		type: 'n8n-nodes-base.manualTrigger',
+		typeVersion: 1,
+		position: [240, 300],
+	} as const;
+
+	const postWorkflow = async (settings: Record<string, unknown>) =>
+		await authOwnerAgent.post('/workflows').send({
+			name: 'redaction-floor',
+			nodes: [redactionTrigger],
+			connections: {},
+			settings,
+		});
+
+	beforeEach(() => {
+		// Floor = Production; spy survives the global restoreMocks reset by being set per-test.
+		jest
+			.spyOn(Container.get(InstanceRedactionEnforcementService), 'get')
+			.mockResolvedValue('production');
+	});
+
+	test('rejects a workflow whose redaction policy is weaker than the floor with 422', async () => {
+		const response = await postWorkflow({ redactionPolicy: 'none' });
+
+		expect(response.statusCode).toBe(422);
+		expect(response.body.message).toBe(
+			'Workflow redaction policy cannot be weaker than the instance floor.',
+		);
+	});
+
+	test('accepts a workflow that omits the redaction policy', async () => {
+		const response = await postWorkflow({ executionOrder: 'v1' });
+
+		expect(response.statusCode).toBe(200);
+	});
+
+	test('accepts a workflow whose redaction policy meets the floor', async () => {
+		const response = await postWorkflow({ redactionPolicy: 'all' });
+
+		expect(response.statusCode).toBe(200);
+	});
+
+	test('rejects manual-only, which does not redact production, with 422', async () => {
+		const response = await postWorkflow({ redactionPolicy: 'manual-only' });
+
+		expect(response.statusCode).toBe(422);
+	});
+
+	test('accepts non-manual, which exactly meets the production floor', async () => {
+		const response = await postWorkflow({ redactionPolicy: 'non-manual' });
+
+		expect(response.statusCode).toBe(200);
+	});
+});
+
+describe('PUT /workflows/:id redaction floor enforcement', () => {
+	const redactionTrigger = {
+		id: 'uuid-redaction',
+		parameters: {},
+		name: 'Start',
+		type: 'n8n-nodes-base.manualTrigger',
+		typeVersion: 1,
+		position: [240, 300],
+	} as const;
+
+	const putWorkflow = async (id: string, settings: Record<string, unknown>) =>
+		await authOwnerAgent.put(`/workflows/${id}`).send({
+			name: 'redaction-floor',
+			nodes: [redactionTrigger],
+			connections: {},
+			staticData: null,
+			settings,
+		});
+
+	beforeEach(() => {
+		jest
+			.spyOn(Container.get(InstanceRedactionEnforcementService), 'get')
+			.mockResolvedValue('production');
+	});
+
+	// Parity with POST: the update endpoint already enforced the floor; these prove the
+	// two endpoints reject and accept the same payloads (the ticket's consistency claim).
+	test('rejects a sub-floor redaction policy with 422', async () => {
+		const workflow = await createWorkflowWithHistory({}, owner);
+
+		const response = await putWorkflow(workflow.id, { redactionPolicy: 'none' });
+
+		expect(response.statusCode).toBe(422);
+		expect(response.body.message).toBe(
+			'Workflow redaction policy cannot be weaker than the instance floor.',
+		);
+	});
+
+	test('rejects manual-only, which does not redact production, with 422', async () => {
+		const workflow = await createWorkflowWithHistory({}, owner);
+
+		const response = await putWorkflow(workflow.id, { redactionPolicy: 'manual-only' });
+
+		expect(response.statusCode).toBe(422);
+	});
+
+	test('accepts an update that omits the redaction policy', async () => {
+		const workflow = await createWorkflowWithHistory({}, owner);
+
+		const response = await putWorkflow(workflow.id, { executionOrder: 'v1' });
+
+		expect(response.statusCode).toBe(200);
+	});
+
+	test('accepts a redaction policy that meets the floor', async () => {
+		const workflow = await createWorkflowWithHistory({}, owner);
+
+		const response = await putWorkflow(workflow.id, { redactionPolicy: 'all' });
+
+		expect(response.statusCode).toBe(200);
 	});
 });
 


### PR DESCRIPTION
fix(API): Enforce the redaction floor when creating workflows

## Summary

The public API behaved differently for **create** vs **update** when a workflow's
`redactionPolicy` was weaker than the instance redaction floor:

| Endpoint | Payload (`floor = production`) | Before | After |
| --- | --- | --- | --- |
| `POST /api/v1/workflows` | `settings.redactionPolicy: "none"` | **200** — silently seeded to `non-manual` | **422** — rejected |
| `PUT /api/v1/workflows/:id` | `settings.redactionPolicy: "none"` | **422** — rejected | **422** — rejected (unchanged) |

Create silently coerced an explicit below-floor value up to the floor, while update
rejected the same payload with `422 "Workflow redaction policy cannot be weaker than
the instance floor."`. This PR normalises the two so the public API is consistent.

**Behaviour now (public API create):**

- **Policy omitted** → seeded up to the floor (unchanged). A blank field is a default,
  not explicit intent, so it is raised to the floor rather than rejected.
- **Policy supplied but below the floor** → **`422`** with the same message as update.
  An explicitly-supplied value is treated as explicit intent.
- **Policy meets or exceeds the floor** → accepted unchanged.
- **Floor is `off` / instance unlicensed** → nothing to enforce; any value is accepted.

### Where the check lives — and why

The check is added at the **public API boundary**
(`public-api/v1/handlers/workflows/workflows.service.ts`), not in the shared
`WorkflowCreationService`:

- It reuses the **same** `RedactionEnforcementService` floor check as the update
  endpoint (new `assertNewPolicyAllowed()` delegates to the existing
  `assertPolicyChangeAllowed()`), so create and update share one source of truth.
- The core `WorkflowCreationService` is **unchanged**, so the editor, MCP, internal
  REST, and the **n8n-packages import pipeline** keep their seed/coerce behaviour. The
  `publicApi` flag is also set by the import pipeline, so enforcing inside the service
  would have made package imports reject bundled below-floor workflows — undesirable.

### Editor is unaffected (building experience)

The editor never sends a below-floor policy on create:

- If the user never opens **Workflow Settings**, `redactionPolicy` is omitted entirely
  (no frontend default sets it) → the backend seeds it to the floor.
- If the user opens **Workflow Settings** while a floor applies, the redaction toggles
  are **locked to the floor** and coerced to "Redact", so the materialised policy
  always meets the floor.

Only a client that hand-builds the request (i.e. a genuine public API caller) can send
an explicit below-floor value, which is exactly (and only) what this change rejects.

## How to test

**Prerequisites**

1. Enable the redaction-enforcement feature flag and start n8n with an enterprise dev
   license that includes **Data Redaction**:
   ```bash
   export N8N_ENV_FEAT_REDACTION_ENFORCEMENT=true
   pnpm start   # or your usual dev startup
   ```
2. In the UI, go to **Settings → Security → Data Redaction** and set the instance floor
   to **Production**.
3. Create a public API key in **Settings → n8n API** and export it:
   ```bash
   export N8N_API_KEY="<your key>"
   export N8N_URL="http://localhost:5678"
   ```

**1. Create with a below-floor policy is now rejected (the fix)**
```bash
curl -i -X POST "$N8N_URL/api/v1/workflows" \
  -H "X-N8N-API-KEY: $N8N_API_KEY" -H "Content-Type: application/json" \
  -d '{"name":"redaction-test","nodes":[],"connections":{},"settings":{"redactionPolicy":"none"}}'
```
Expect **`HTTP/1.1 422`** and body
`{"message":"Workflow redaction policy cannot be weaker than the instance floor."}`.
(Before this PR: `200`, persisted as `non-manual`.)

**2. Create with the policy omitted is seeded to the floor (unchanged)**
```bash
curl -i -X POST "$N8N_URL/api/v1/workflows" \
  -H "X-N8N-API-KEY: $N8N_API_KEY" -H "Content-Type: application/json" \
  -d '{"name":"redaction-test","nodes":[],"connections":{},"settings":{}}'
```
Expect **`200`**; the response's `settings.redactionPolicy` is `non-manual` (seeded).

**3. Create with a policy that meets the floor (unchanged)**
```bash
curl -i -X POST "$N8N_URL/api/v1/workflows" \
  -H "X-N8N-API-KEY: $N8N_API_KEY" -H "Content-Type: application/json" \
  -d '{"name":"redaction-test","nodes":[],"connections":{},"settings":{"redactionPolicy":"all"}}'
```
Expect **`200`**, persisted as `all`. (`manual-only` should return **`422`** — it does not
redact production; `non-manual` should return **`200`**.)

**4. Update parity — confirm consistency**

Create a workflow (step 2 or 3), then update it with a below-floor policy:
```bash
curl -i -X PUT "$N8N_URL/api/v1/workflows/<id>" \
  -H "X-N8N-API-KEY: $N8N_API_KEY" -H "Content-Type: application/json" \
  -d '{"name":"redaction-test","nodes":[],"connections":{},"settings":{"redactionPolicy":"none"}}'
```
Expect **`422`** — identical to create. POST and PUT now behave the same.

**5. Editor is unaffected (building experience)**

- Create a new workflow in the editor and save **without** opening Settings → saves fine;
  the persisted policy is `non-manual` (seeded to the floor).
- Open **Workflow Settings**: the **Production** redaction control is locked to "Redact"
  with a floor notice; you cannot lower it below the floor.

**6. Floor `off`**

Set the floor back to **Off** and repeat step 1 → expect **`200`** (nothing to enforce).

**Automated tests**
```bash
cd packages/cli
pnpm jest src/modules/redaction/__tests__/redaction-enforcement.service.test.ts
pnpm jest src/public-api/v1/handlers/workflows/__tests__/workflows.service.test.ts
pnpm jest test/integration/public-api/workflows.test.ts -t "redaction floor enforcement"
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-39

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- The public API OpenAPI `redactionPolicy` description is updated in this PR; the published API reference (ENT-25) may need a corresponding note. -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to ...` (only if this needs backporting).
