### PR TITLE
test(editor): Track canvas re-render counts in performance benchmarks (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/dev/render-tracker.test.ts
+++ b/packages/frontend/editor-ui/src/app/dev/render-tracker.test.ts
@@ -1,0 +1,78 @@
+import { createApp, defineComponent, h, nextTick, ref } from 'vue';
+import { installRenderTracker, RENDER_TRACKING_STORAGE_KEY } from '@/app/dev/render-tracker';
+
+/**
+ * Mount a root whose render does NOT depend on `value`, so only the child
+ * re-renders when `value` changes (the root effect never re-runs). This isolates
+ * the count to a single component per change.
+ */
+function mountAppWithChild() {
+	const value = ref(0);
+	const TrackedChild = defineComponent({
+		name: 'TrackedChild',
+		setup() {
+			return () => h('div', value.value);
+		},
+	});
+	const app = createApp({ render: () => h(TrackedChild) });
+	installRenderTracker(app);
+	app.mount(document.createElement('div'));
+	return { app, value };
+}
+
+describe('installRenderTracker', () => {
+	afterEach(() => {
+		localStorage.clear();
+		delete window.n8nRenderTracker;
+	});
+
+	it('does nothing when the tracking flag is absent', () => {
+		const app = createApp({ render: () => null });
+		installRenderTracker(app);
+		expect(window.n8nRenderTracker).toBeUndefined();
+	});
+
+	it('counts re-renders within a start/stop window but not the initial mount', async () => {
+		localStorage.setItem(RENDER_TRACKING_STORAGE_KEY, 'true');
+		const { app, value } = mountAppWithChild();
+		const tracker = window.n8nRenderTracker;
+		expect(tracker).toBeDefined();
+
+		// Initial mount must not be counted.
+		tracker!.start();
+		expect(tracker!.total).toBe(0);
+
+		value.value += 1;
+		await nextTick();
+		value.value += 1;
+		await nextTick();
+
+		const snapshot = tracker!.snapshot();
+		expect(snapshot.total).toBe(2);
+		expect(snapshot.byComponent.TrackedChild).toBe(2);
+
+		app.unmount();
+	});
+
+	it('does not count while stopped', async () => {
+		localStorage.setItem(RENDER_TRACKING_STORAGE_KEY, 'true');
+		const { app, value } = mountAppWithChild();
+		const tracker = window.n8nRenderTracker;
+
+		// Defaults to disabled — re-renders before start() are ignored.
+		value.value += 1;
+		await nextTick();
+		expect(tracker!.total).toBe(0);
+
+		tracker!.start();
+		value.value += 1;
+		await nextTick();
+		tracker!.stop();
+		value.value += 1;
+		await nextTick();
+
+		expect(tracker!.snapshot().total).toBe(1);
+
+		app.unmount();
+	});
+});

--- a/packages/frontend/editor-ui/src/app/dev/render-tracker.ts
+++ b/packages/frontend/editor-ui/src/app/dev/render-tracker.ts
@@ -1,0 +1,101 @@
+import type { App, ComponentPublicInstance } from 'vue';
+
+/**
+ * localStorage key that switches on app-wide component re-render counting.
+ *
+ * Set by the canvas performance benchmark (packages/testing/playwright) before
+ * the SPA boots. Real users never set it, so the global mixin below is never
+ * installed in normal use and the feature carries no runtime cost for them.
+ */
+export const RENDER_TRACKING_STORAGE_KEY = 'N8N_RENDER_TRACKING';
+
+export interface RenderTrackerSnapshot {
+	/** Total component re-renders counted in the current window. */
+	total: number;
+	/** Re-renders broken down by component name (best-effort; for diagnosis). */
+	byComponent: Record<string, number>;
+}
+
+export interface RenderTracker {
+	/** While false the mixin hook returns immediately and counts nothing. */
+	enabled: boolean;
+	total: number;
+	byComponent: Record<string, number>;
+	/** Zero the counters and begin counting (opens a fresh measurement window). */
+	start: () => void;
+	/** Stop counting. Leaves the counts intact for a final read. */
+	stop: () => void;
+	/** Read the current counts without mutating them. */
+	snapshot: () => RenderTrackerSnapshot;
+}
+
+declare global {
+	interface Window {
+		n8nRenderTracker?: RenderTracker;
+	}
+}
+
+function isTrackingEnabled(): boolean {
+	try {
+		return window.localStorage?.getItem(RENDER_TRACKING_STORAGE_KEY) === 'true';
+	} catch {
+		// localStorage access can throw in locked-down browser contexts.
+		return false;
+	}
+}
+
+function resolveComponentName(instance: ComponentPublicInstance): string {
+	// `<script setup>` SFCs expose the filename-derived name as `__name`
+	// (preserved in production builds); explicitly-named components use `name`.
+	const options = instance.$options as { name?: string; __name?: string };
+	return options.name ?? options.__name ?? 'Anonymous';
+}
+
+/**
+ * Install an app-wide component re-render counter, gated behind the
+ * {@link RENDER_TRACKING_STORAGE_KEY} localStorage flag.
+ *
+ * A global mixin's `beforeUpdate` hook fires exactly once per component
+ * re-render — it is not called on the initial mount — so counting these
+ * invocations yields an accurate app-wide re-render count. The benchmark uses
+ * it to measure how many re-renders an execution or a canvas change triggers; a
+ * high count for a given interaction is a reactivity-thrash signal.
+ *
+ * No-op unless the flag is set, so it is safe to call unconditionally from
+ * `main.ts`.
+ */
+export function installRenderTracker(app: App): void {
+	if (!isTrackingEnabled()) return;
+
+	const tracker: RenderTracker = {
+		// Starts disabled: counting only happens inside an explicit start()/stop()
+		// window opened by the benchmark, so unrelated measurements (e.g. frame
+		// stats during pan/zoom) aren't charged for the per-update hook beyond a
+		// single boolean check.
+		enabled: false,
+		total: 0,
+		byComponent: {},
+		start() {
+			this.total = 0;
+			this.byComponent = {};
+			this.enabled = true;
+		},
+		stop() {
+			this.enabled = false;
+		},
+		snapshot() {
+			return { total: this.total, byComponent: { ...this.byComponent } };
+		},
+	};
+
+	window.n8nRenderTracker = tracker;
+
+	app.mixin({
+		beforeUpdate(this: ComponentPublicInstance) {
+			if (!tracker.enabled) return;
+			tracker.total += 1;
+			const name = resolveComponentName(this);
+			tracker.byComponent[name] = (tracker.byComponent[name] ?? 0) + 1;
+		},
+	});
+}

--- a/packages/frontend/editor-ui/src/main.ts
+++ b/packages/frontend/editor-ui/src/main.ts
@@ -28,6 +28,7 @@ import { createPinia, PiniaVuePlugin } from 'pinia';
 import { ChartJSPlugin } from '@/app/plugins/chartjs';
 import { SentryPlugin } from '@/app/plugins/sentry';
 import { registerModuleRoutes } from '@/app/moduleInitializer/moduleInitializer';
+import { installRenderTracker } from '@/app/dev/render-tracker';
 
 import type { VueScanOptions } from 'z-vue-scan';
 
@@ -49,6 +50,12 @@ app.use(pinia);
 app.use(router);
 app.use(i18nInstance);
 app.use(ChartJSPlugin);
+
+// Opt-in component re-render counter for the canvas performance benchmark.
+// No-op unless the N8N_RENDER_TRACKING localStorage flag is set, so it is
+// inert for real users. Must run before mount so the mixin covers every
+// component.
+installRenderTracker(app);
 
 if (import.meta.env.VUE_SCAN) {
 	const { default: VueScan } = await import('z-vue-scan');

--- a/packages/testing/playwright/scripts/canvas-perf-sentinels.mjs
+++ b/packages/testing/playwright/scripts/canvas-perf-sentinels.mjs
@@ -40,6 +40,17 @@ const SENTINELS = [
 		max: 600,
 		note: '>600MB browser heap on L = canvas leak suspected',
 	},
+	// Re-render counts are near-deterministic (driven by graph structure, not
+	// wall-clock), so this gate is far tighter than the timing/heap ones above:
+	// ~2x the observed S-tier baseline (~3.5k). Gated at S because that's the
+	// tier with a measured baseline and the one that always runs; a value this
+	// high means a reactivity loop / runaway re-render, not normal variance.
+	// Add M/L equivalents once those tiers have a baseline.
+	{
+		metric: 'canvas-rerender-exec-heavy-S',
+		max: 7_000,
+		note: '>7k re-renders on a 30-node heavy execution = reactivity thrash / runaway re-render',
+	},
 ];
 
 function findResultsPath() {

--- a/packages/testing/playwright/tests/performance/README.md
+++ b/packages/testing/playwright/tests/performance/README.md
@@ -256,8 +256,8 @@ the tier ceiling here.
 | Spec file                     | Metrics emitted (per tier `S/M/L`)                                                                                                                                                                                                                              |
 | ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `canvas-load.spec.ts`         | `canvas-cold-load-{tier}-ms`, `canvas-server-heap-{tier}-mb`, `canvas-server-rss-{tier}-mb`, `canvas-browser-heap-{tier}-mb`, `canvas-dom-nodes-{tier}`, `canvas-layout-duration-{tier}-ms`, `canvas-script-duration-{tier}-ms`                                 |
-| `canvas-interactions.spec.ts` | `canvas-zoom-frame-p95-{tier}-ms`, `canvas-pan-frame-p95-{tier}-ms`, `canvas-pan-longtask-count-{tier}`, `canvas-drag-response-{tier}-ms`, `canvas-move-multi-{tier}-ms`, `canvas-duplicate-{tier}-ms`, `canvas-ndv-open-{tier}-ms`, `canvas-tidy-up-{tier}-ms` |
-| `canvas-execution.spec.ts`    | `canvas-exec-{small,medium,heavy}-{tier}-ms`, `canvas-exec-render-{slug}-{tier}-ms`, `canvas-post-exec-{browser,server}-heap-{tier}-mb`, `canvas-exec-pin-bytes-{tier}-{slug}`                                                                                  |
+| `canvas-interactions.spec.ts` | `canvas-zoom-frame-p95-{tier}-ms`, `canvas-pan-frame-p95-{tier}-ms`, `canvas-pan-longtask-count-{tier}`, `canvas-drag-response-{tier}-ms`, `canvas-move-multi-{tier}-ms`, `canvas-duplicate-{tier}-ms`, `canvas-ndv-open-{tier}-ms`, `canvas-tidy-up-{tier}-ms`, `canvas-rerender-drag-{tier}`, `canvas-rerender-move-{tier}` |
+| `canvas-execution.spec.ts`    | `canvas-exec-{small,medium,heavy}-{tier}-ms`, `canvas-exec-render-{slug}-{tier}-ms`, `canvas-rerender-exec-{slug}-{tier}`, `canvas-post-exec-{browser,server}-heap-{tier}-mb`, `canvas-exec-pin-bytes-{tier}-{slug}`                                            |
 
 Iteration count is tuned per spec to balance precision vs. budget:
 
@@ -274,6 +274,31 @@ Browser-side metrics use Chromium CDP (`Performance.getMetrics` +
 Frame stats use a RAF loop wrapped around the interaction plus
 `PerformanceObserver({ type: 'longtask' })` for main-thread blocking.
 
+#### Re-render counts
+
+`canvas-rerender-*` metrics count how many Vue component re-renders an
+interaction triggers — a complement to the wall-clock timings. Two interactions
+that take the same time can differ wildly in re-render count, and a count that
+balloons as a workflow grows is a reactivity-thrash signal (the canvas
+re-rendering far more than the change required) that timing alone hides.
+
+The count comes from a tiny, opt-in tracker in editor-ui
+(`src/app/dev/render-tracker.ts`): a global mixin whose `beforeUpdate` hook —
+which fires once per component re-render, never on the initial mount —
+increments a counter exposed on `window.n8nRenderTracker`. It is gated
+behind the `N8N_RENDER_TRACKING` localStorage flag and installs **nothing**
+unless the flag is set, so it carries no cost for real users and none for the
+other benchmark specs.
+
+The `render-stats.ts` helper drives it: `enableRenderTracking(page)` sets the
+flag via `addInitScript` **before** the first navigation (so the mixin is
+installed on boot), then `startRenderTracking` / `readRenderStats` bracket the
+measured action. Counting only happens inside that window, so the frame-stat
+measurements (pan / zoom) aren't charged for it. `total` is the headline metric
+(robust regardless of production name-mangling); the per-component breakdown
+(top re-renderers after the heavy-concentrated execution) is logged in the
+execution report for diagnosis.
+
 ### Storage and regression detection
 
 - **Trend dashboards**: `attachMetric` routes to Currents.dev project `O9BJaN`
@@ -282,10 +307,15 @@ Frame stats use a RAF loop wrapped around the interaction plus
   14-day rolling baseline (same channel as `memory-heap-used-baseline`).
 - **Catastrophic sentinel**: `scripts/canvas-perf-sentinels.mjs` runs after
   the nightly job, parses `test-results.json`, and fails the job on hard
-  breaches (cold load > 30s at M, pan p95 > 100ms, etc.). Thresholds live at
-  the top of the script and are intentionally loose — wall-clock variance
-  in browser e2e is 15–30%, so soft regressions are caught by trends, not
-  gates.
+  breaches (cold load > 30s at M, pan p95 > 100ms, re-renders > 7k on the S
+  heavy execution, etc.). Thresholds live at the top of the script and are
+  intentionally loose — wall-clock variance in browser e2e is 15–30%, so soft
+  regressions are caught by trends, not gates. The `canvas-rerender-*` gate is
+  the exception: re-render counts are near-deterministic (driven by graph
+  structure, not wall-clock), so its threshold sits ~2× the observed baseline
+  rather than the ~10× the timing gates allow — only a reactivity loop / runaway
+  re-render trips it. It's gated at S because that's the tier with a measured
+  baseline and the one that always runs; add M/L once those are baselined.
 
 ### When it runs
 

--- a/packages/testing/playwright/tests/performance/canvas/canvas-execution.spec.ts
+++ b/packages/testing/playwright/tests/performance/canvas/canvas-execution.spec.ts
@@ -8,6 +8,13 @@ import {
 	readHeapLimitOnce,
 	type PostExecHeap,
 } from './helpers/post-exec-heap';
+import {
+	enableRenderTracking,
+	isRenderTrackingActive,
+	readRenderStats,
+	startRenderTracking,
+	type RenderStats,
+} from './helpers/render-stats';
 import { buildExecutionReportSections, fmt, firstDefined, formatReport } from './helpers/report';
 import { test, expect } from '../../../fixtures/base';
 import { attachMetric, measurePerformance } from '../../../utils/performance-helper';
@@ -67,10 +74,15 @@ test.describe(
 				test.setTimeout(TIER_TIMEOUT_MS[tier]);
 				await n8n.page.setViewportSize({ width: 1536, height: 960 });
 				await n8n.page.emulateMedia({ reducedMotion: 'reduce' });
+				// Arm the re-render counter before the first navigation so editor-ui
+				// installs the tracking mixin on boot.
+				await enableRenderTracking(n8n.page);
 
 				const execRows: string[][] = [];
 				let v8HeapLimitGb: number | null = null;
 				let postExecHeap: PostExecHeap | null = null;
+				const renderStatsByScenario: Partial<Record<'small' | 'medium' | 'heavy', RenderStats>> =
+					{};
 
 				for (const scenario of SCENARIOS) {
 					const slug = METRIC_SLUG[scenario];
@@ -99,6 +111,10 @@ test.describe(
 					await expect(n8n.page).toHaveURL(/\/workflows$/);
 					await n8n.page.goto(`/workflow/${workflowId}`);
 					await waitForCanvasReady(n8n.page, flowNodes, stickyNotes);
+
+					// Fail loudly if the flag didn't take, rather than silently reporting 0
+					// re-renders for the rest of the test.
+					expect(await isRenderTrackingActive(n8n.page)).toBe(true);
 
 					// Read the actual V8 heap limit once per page. We run at Chromium's
 					// default launch (no heap flag); the reported limit is ~4 GB — V8's
@@ -129,7 +145,10 @@ test.describe(
 					// the canvas once the run completes. Pinned and success badges are mutually
 					// exclusive (pinned wins), so we count the union via
 					// `getAllNodeExecutedIndicators()` — every traversed node lands in one bucket
-					// or the other.
+					// or the other. The same pass is wrapped in the re-render counter so the
+					// component-update cost of applying run data is captured alongside the
+					// wall-clock render time, without paying for an extra execution.
+					await startRenderTracking(n8n.page);
 					const renderMs = await measurePerformance(
 						n8n.page,
 						`render-${tier}-${slug}`,
@@ -141,11 +160,20 @@ test.describe(
 							);
 						},
 					);
+					const renderStats = await readRenderStats(n8n.page);
+					renderStatsByScenario[slug] = renderStats;
 					await attachMetric(
 						testInfo,
 						`canvas-exec-render-${slug}-${tier}-ms`,
 						renderMs,
 						'ms',
+						dimensions,
+					);
+					await attachMetric(
+						testInfo,
+						`canvas-rerender-exec-${slug}-${tier}`,
+						renderStats.total,
+						'count',
 						dimensions,
 					);
 
@@ -169,9 +197,13 @@ test.describe(
 						fmt.bytes(pinnedDataBytes),
 						fmt.ms(medianBy(execSamples, (sample) => sample)),
 						fmt.ms(renderMs),
+						fmt.count(renderStats.total),
 					]);
 
 					expect(medianBy(execSamples, (sample) => sample)).toBeGreaterThan(0);
+					// An execution paints status across every node, so it must re-render
+					// components — a zero here means tracking silently broke.
+					expect(renderStats.total).toBeGreaterThan(0);
 
 					// Reclaim what Chromium will let us free before mounting the next scenario.
 					// Each L-tier mount allocates ~230 MB; without this, the tab crashes after
@@ -182,7 +214,12 @@ test.describe(
 				console.log(
 					formatReport(
 						`Canvas Execution Benchmark — ${tier} tier`,
-						buildExecutionReportSections({ v8HeapLimitGb, execRows, postExecHeap }),
+						buildExecutionReportSections({
+							v8HeapLimitGb,
+							execRows,
+							postExecHeap,
+							heavyRenderStats: renderStatsByScenario.heavy,
+						}),
 					),
 				);
 			});

--- a/packages/testing/playwright/tests/performance/canvas/canvas-interactions.spec.ts
+++ b/packages/testing/playwright/tests/performance/canvas/canvas-interactions.spec.ts
@@ -2,6 +2,12 @@ import { TIER_CONFIG, buildCanvasBenchmarkWorkflow, type Tier } from './fixtures
 import { waitForCanvasReady } from './helpers/canvas-ready';
 import { captureFrameStats } from './helpers/frame-stats';
 import { medianBy, withWarmup } from './helpers/iterate';
+import {
+	enableRenderTracking,
+	isRenderTrackingActive,
+	readRenderStats,
+	startRenderTracking,
+} from './helpers/render-stats';
 import { fmt, formatReport } from './helpers/report';
 import { test, expect } from '../../../fixtures/base';
 import { attachMetric, measurePerformance } from '../../../utils/performance-helper';
@@ -39,9 +45,13 @@ test.describe(
 
 				await n8n.page.setViewportSize({ width: 1536, height: 960 });
 				await n8n.page.emulateMedia({ reducedMotion: 'reduce' });
+				// Arm the re-render counter before navigating so editor-ui installs the
+				// tracking mixin on boot.
+				await enableRenderTracking(n8n.page);
 
 				await n8n.page.goto(`/workflow/${workflowId}`);
 				await waitForCanvasReady(n8n.page, flowNodes, stickyNotes);
+				expect(await isRenderTrackingActive(n8n.page)).toBe(true);
 				await n8n.canvas.clickZoomToFitButton();
 
 				const dimensions = { tier };
@@ -88,38 +98,58 @@ test.describe(
 
 				await n8n.canvas.clickZoomToFitButton();
 
-				// Drag a single node — measure mousedown→up wall-clock. Undo between iterations.
+				// Drag a single node — measure mousedown→up wall-clock plus the component
+				// re-renders the move triggers. Undo between iterations.
 				const dragSamples = await withWarmup(ITERATIONS, async (iteration) => {
 					const dragName = sampleNodeNames[iteration % sampleNodeNames.length];
+					await startRenderTracking(n8n.page);
 					const ms = await measurePerformance(n8n.page, `drag-${tier}-${iteration}`, async () => {
 						await n8n.canvas.dragNodeToRelativePosition(dragName, 60, 40);
 					});
+					const renders = (await readRenderStats(n8n.page)).total;
 					await n8n.canvas.hitUndo();
-					return ms;
+					return { ms, renders };
 				});
 				await attachMetric(
 					testInfo,
 					`canvas-drag-response-${tier}-ms`,
-					medianBy(dragSamples, (sample) => sample),
+					medianBy(dragSamples, (sample) => sample.ms),
 					'ms',
+					dimensions,
+				);
+				await attachMetric(
+					testInfo,
+					`canvas-rerender-drag-${tier}`,
+					medianBy(dragSamples, (sample) => sample.renders),
+					'count',
 					dimensions,
 				);
 
 				// Multi-node move via keyboard nudge. Select-all → arrow key bursts → undo.
+				// Counts re-renders across every selected node as they shift together.
 				const moveSamples = await withWarmup(ITERATIONS, async () => {
 					await n8n.canvas.selectAll();
+					await startRenderTracking(n8n.page);
 					const ms = await measurePerformance(n8n.page, `move-${tier}`, async () => {
 						await n8n.canvas.nudgeSelectedNodes('right', 5);
 					});
+					const renders = (await readRenderStats(n8n.page)).total;
 					await n8n.canvas.hitUndo();
 					await n8n.canvas.deselectAll();
-					return ms;
+					return { ms, renders };
 				});
 				await attachMetric(
 					testInfo,
 					`canvas-move-multi-${tier}-ms`,
-					medianBy(moveSamples, (sample) => sample),
+					medianBy(moveSamples, (sample) => sample.ms),
 					'ms',
+					dimensions,
+				);
+				await attachMetric(
+					testInfo,
+					`canvas-rerender-move-${tier}`,
+					medianBy(moveSamples, (sample) => sample.renders),
+					'count',
 					dimensions,
 				);
 
@@ -193,11 +223,11 @@ test.describe(
 							rows: [
 								{
 									label: 'Drag response',
-									value: fmt.ms(medianBy(dragSamples, (sample) => sample)),
+									value: fmt.ms(medianBy(dragSamples, (sample) => sample.ms)),
 								},
 								{
 									label: 'Multi-node move',
-									value: fmt.ms(medianBy(moveSamples, (sample) => sample)),
+									value: fmt.ms(medianBy(moveSamples, (sample) => sample.ms)),
 								},
 								{
 									label: 'Duplicate',
@@ -207,11 +237,26 @@ test.describe(
 								{ label: 'Tidy up', value: fmt.ms(tidyMs) },
 							],
 						},
+						{
+							heading: 'Re-renders (canvas changes)',
+							rows: [
+								{
+									label: 'Drag node',
+									value: fmt.count(medianBy(dragSamples, (sample) => sample.renders)),
+								},
+								{
+									label: 'Multi-node move',
+									value: fmt.count(medianBy(moveSamples, (sample) => sample.renders)),
+								},
+							],
+						},
 					]),
 				);
 
 				expect(medianBy(panSamples, (sample) => sample.p95FrameMs)).toBeGreaterThan(0);
-				expect(medianBy(dragSamples, (sample) => sample)).toBeGreaterThan(0);
+				expect(medianBy(dragSamples, (sample) => sample.ms)).toBeGreaterThan(0);
+				// Moving a node must re-render it — a zero means tracking silently broke.
+				expect(medianBy(dragSamples, (sample) => sample.renders)).toBeGreaterThan(0);
 			});
 		}
 	},

--- a/packages/testing/playwright/tests/performance/canvas/helpers/render-stats.ts
+++ b/packages/testing/playwright/tests/performance/canvas/helpers/render-stats.ts
@@ -1,0 +1,67 @@
+import type { Page } from '@playwright/test';
+
+export interface RenderStats {
+	/** Total component re-renders counted during the measured window. */
+	total: number;
+	/** Re-renders broken down by component name (best-effort; for diagnosis). */
+	byComponent: Record<string, number>;
+}
+
+/**
+ * localStorage flag that switches on editor-ui's render-count tracker
+ * (see packages/frontend/editor-ui/src/app/dev/render-tracker.ts). Kept in sync
+ * with `RENDER_TRACKING_STORAGE_KEY` there.
+ */
+const RENDER_TRACKING_STORAGE_KEY = 'N8N_RENDER_TRACKING';
+
+interface WindowWithRenderTracker {
+	n8nRenderTracker?: {
+		start: () => void;
+		stop: () => void;
+		snapshot: () => RenderStats;
+	};
+}
+
+/**
+ * Arm editor-ui's render tracker for this page. The flag must be in localStorage
+ * before `main.ts` reads it on boot, so call this BEFORE navigating to the
+ * workflow. `addInitScript` re-applies on every navigation, so a single call
+ * covers all subsequent `goto`s on the page.
+ */
+export async function enableRenderTracking(page: Page): Promise<void> {
+	await page.addInitScript((key) => {
+		window.localStorage.setItem(key, 'true');
+	}, RENDER_TRACKING_STORAGE_KEY);
+}
+
+/** True once the tracker is installed — i.e. the flag took on boot. */
+export async function isRenderTrackingActive(page: Page): Promise<boolean> {
+	return await page.evaluate(() => Boolean((window as WindowWithRenderTracker).n8nRenderTracker));
+}
+
+/** Reset the counters and begin a measurement window. */
+export async function startRenderTracking(page: Page): Promise<void> {
+	await page.evaluate(() => (window as WindowWithRenderTracker).n8nRenderTracker?.start());
+}
+
+/**
+ * Flush Vue's queued updates plus one paint so post-action re-renders settle,
+ * then read and freeze the counts. Pair with {@link startRenderTracking} when
+ * the measured action also needs to be timed separately (the RAF flush here
+ * would otherwise inflate that timing).
+ */
+export async function readRenderStats(page: Page): Promise<RenderStats> {
+	await page.evaluate(
+		async () =>
+			await new Promise<void>((resolve) =>
+				requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+			),
+	);
+	return await page.evaluate(() => {
+		const tracker = (window as WindowWithRenderTracker).n8nRenderTracker;
+		if (!tracker) return { total: 0, byComponent: {} };
+		const snapshot = tracker.snapshot();
+		tracker.stop();
+		return snapshot;
+	});
+}

--- a/packages/testing/playwright/tests/performance/canvas/helpers/report.ts
+++ b/packages/testing/playwright/tests/performance/canvas/helpers/report.ts
@@ -58,6 +58,21 @@ export const fmt = {
 };
 
 /**
+ * Turn a render tracker's per-component map into the top-N re-rendering
+ * components, formatted as report rows. Returns an empty list for an empty
+ * map so callers can spread it without branching.
+ */
+export function topComponentRows(
+	byComponent: Record<string, number>,
+	limit = 6,
+): Array<{ label: string; value: string }> {
+	return Object.entries(byComponent)
+		.sort(([, a], [, b]) => b - a)
+		.slice(0, limit)
+		.map(([name, count]) => ({ label: name, value: fmt.count(count) }));
+}
+
+/**
  * Pick the first non-nullish argument. Used to fold "this value or the
  * previous one" assignments out of test bodies so they don't trip
  * playwright/no-conditional-in-test.
@@ -78,14 +93,16 @@ export function buildExecutionReportSections(args: {
 	v8HeapLimitGb: number | null;
 	execRows: string[][];
 	postExecHeap: { server: number; browser: number } | null;
+	heavyRenderStats?: { byComponent: Record<string, number> } | null;
 }): ReportSection[] {
 	const v8Value = args.v8HeapLimitGb === null ? 'n/a' : fmt.gb(args.v8HeapLimitGb);
 	const sections: ReportSection[] = [
 		{ heading: 'Browser', rows: [{ label: 'V8 heap limit', value: v8Value }] },
 		{
 			heading: 'Executions',
-			rows: formatTable(['Scenario', 'Pin bytes', 'Exec', 'Render'], args.execRows, [
+			rows: formatTable(['Scenario', 'Pin bytes', 'Exec', 'Render', 'Re-renders'], args.execRows, [
 				'left',
+				'right',
 				'right',
 				'right',
 				'right',
@@ -99,6 +116,13 @@ export function buildExecutionReportSections(args: {
 				{ label: 'Server', value: fmt.mb(args.postExecHeap.server) },
 				{ label: 'Browser', value: fmt.mb(args.postExecHeap.browser) },
 			],
+		});
+	}
+	const topRenderComponents = topComponentRows(args.heavyRenderStats?.byComponent ?? {}, 10);
+	if (topRenderComponents.length > 0) {
+		sections.push({
+			heading: 'Top 10 re-rendering components (after heavy-concentrated)',
+			rows: topRenderComponents,
 		});
 	}
 	return sections;


### PR DESCRIPTION
## Summary

Adds an **opt-in component re-render counter** to surface reactivity thrash that wall-clock timings hide. A tiny editor-ui dev tracker (`src/app/dev/render-tracker.ts`) installs a global mixin whose `beforeUpdate` hook counts re-renders, gated entirely behind the `N8N_RENDER_TRACKING` localStorage flag so it is inert (and zero-cost) for real users. The canvas execution and interaction benchmarks arm it before boot and bracket measured actions, emitting new `canvas-rerender-*` metrics (drag, multi-node move, and per-scenario execution) plus a top-re-renderer breakdown in the execution report. A tight `canvas-perf-sentinels` gate (~2× baseline, far stricter than the loose timing gates) fails the nightly job on a runaway re-render in the S heavy execution.

## How to test

1. `pnpm --filter n8n-editor-ui test src/app/dev/render-tracker.test.ts` — unit coverage for the tracker (no-op without flag, counts only within start/stop window, never on initial mount).
2. Run the canvas perf specs and confirm `canvas-rerender-*` metrics appear and `isRenderTrackingActive` passes.

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI