### PR TITLE
fix(editor): Skip external-secrets fetch on Community Edition

### DIFF
--- a/packages/frontend/editor-ui/src/features/integrations/externalSecrets.ee/externalSecrets.ee.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/externalSecrets.ee/externalSecrets.ee.store.test.ts
@@ -165,6 +165,14 @@ const setModuleSettings = (settings: {
 	mockModuleSettings['external-secrets'] = settings;
 };
 
+// Simulates an EE instance where the external-secrets module is loaded but no
+// beta feature flags are active. This is the "legacy" mode that uses the global endpoints.
+const setLegacyMode = () => {
+	mockModuleSettings['external-secrets'] = {};
+};
+
+// Simulates Community Edition, where the external-secrets module is not registered
+// at all, so `moduleSettings['external-secrets']` is absent.
 const clearModuleSettings = () => {
 	delete mockModuleSettings['external-secrets'];
 };
@@ -179,8 +187,8 @@ describe('externalSecretsStore', () => {
 		vi.clearAllMocks();
 		mockProjectsStore.myProjects = [];
 		mockProjectsStore.currentProject = null;
-		// Reset to defaults
-		clearModuleSettings();
+		// Reset to defaults: EE module loaded, legacy mode (no beta feature flags)
+		setLegacyMode();
 		setHasPermission(true);
 	});
 
@@ -225,7 +233,7 @@ describe('externalSecretsStore', () => {
 
 	describe('secretsAsObject', () => {
 		it('should only contain the global secrets if forProjects is disabled', () => {
-			clearModuleSettings();
+			setLegacyMode();
 			const store = useExternalSecretsStore();
 			store.state.secrets = mockGlobalSecrets;
 			store.state.projectSecrets = mockProjectSecrets;
@@ -266,8 +274,8 @@ describe('externalSecretsStore', () => {
 	});
 
 	describe('fetchGlobalSecrets()', () => {
-		it('should use legacy endpoint when no module settings', async () => {
-			clearModuleSettings();
+		it('should use legacy endpoint in legacy mode (module loaded, no feature flags)', async () => {
+			setLegacyMode();
 			setHasPermission(true);
 			getExternalSecrets.mockResolvedValue(mockGlobalSecrets);
 			const store = useExternalSecretsStore();
@@ -280,8 +288,21 @@ describe('externalSecretsStore', () => {
 			expect(store.state.secrets).toEqual(mockGlobalSecrets);
 		});
 
-		it('should not fetch when user lacks permission and no module settings', async () => {
+		it('should not fetch on Community Edition (external-secrets module absent)', async () => {
 			clearModuleSettings();
+			setHasPermission(true);
+			const store = useExternalSecretsStore();
+
+			await store.fetchGlobalSecrets();
+
+			expect(getExternalSecrets).not.toHaveBeenCalled();
+			expect(getGlobalExternalSecrets).not.toHaveBeenCalled();
+			expect(getGlobalExternalSecretsForProject).not.toHaveBeenCalled();
+			expect(store.state.secrets).toEqual({});
+		});
+
+		it('should not fetch when user lacks permission in legacy mode', async () => {
+			setLegacyMode();
 			setHasPermission(false);
 			const store = useExternalSecretsStore();
 
@@ -346,7 +367,7 @@ describe('externalSecretsStore', () => {
 		});
 
 		it('should set secrets to empty object on API error (legacy path)', async () => {
-			clearModuleSettings();
+			setLegacyMode();
 			setHasPermission(true);
 			getExternalSecrets.mockRejectedValue(new Error('API Error'));
 			const store = useExternalSecretsStore();
@@ -380,7 +401,7 @@ describe('externalSecretsStore', () => {
 
 	describe('fetchProjectSecrets()', () => {
 		it('should leave state.projectSecrets as empty object if forProjects is disabled', async () => {
-			clearModuleSettings();
+			setLegacyMode();
 			setHasPermission(true);
 			getProjectExternalSecrets.mockResolvedValue(mockProjectSecrets);
 			const store = useExternalSecretsStore();
@@ -486,6 +507,19 @@ describe('externalSecretsStore', () => {
 			);
 			expect(getProjectExternalSecrets).not.toHaveBeenCalled();
 		});
+
+		it('should not call any secrets endpoint on Community Edition (module absent)', async () => {
+			clearModuleSettings();
+			mockProjectsStore.personalProject = { id: 'personal-123' };
+			const store = useExternalSecretsStore();
+
+			await store.fetchSecretsForProject('team-456');
+
+			expect(getExternalSecrets).not.toHaveBeenCalled();
+			expect(getGlobalExternalSecrets).not.toHaveBeenCalled();
+			expect(getGlobalExternalSecretsForProject).not.toHaveBeenCalled();
+			expect(getProjectExternalSecrets).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('reloadProvider()', () => {
@@ -529,7 +563,7 @@ describe('externalSecretsStore', () => {
 
 	describe('updateProviderConnected()', () => {
 		it('should connect provider and refetch secrets in legacy mode', async () => {
-			clearModuleSettings();
+			setLegacyMode();
 			connectProvider.mockResolvedValue(undefined);
 			getExternalSecrets.mockResolvedValue(mockGlobalSecrets);
 			setHasPermission(true);
@@ -558,7 +592,7 @@ describe('externalSecretsStore', () => {
 
 	describe('updateProvider()', () => {
 		it('should update provider and refetch secrets in legacy mode', async () => {
-			clearModuleSettings();
+			setLegacyMode();
 			updateProvider.mockResolvedValue(undefined);
 			getExternalSecrets.mockResolvedValue(mockGlobalSecrets);
 			setHasPermission(true);

--- a/packages/frontend/editor-ui/src/features/integrations/externalSecrets.ee/externalSecrets.ee.store.ts
+++ b/packages/frontend/editor-ui/src/features/integrations/externalSecrets.ee/externalSecrets.ee.store.ts
@@ -84,6 +84,7 @@ export const useExternalSecretsStore = defineStore('externalSecrets', () => {
 	// Used to decide whether to fetch secrets via legacy/global methods rather than project-scoped APIs.
 	const isLegacyMode = computed(
 		() =>
+			isEnterpriseExternalSecretsEnabled.value &&
 			!externalSecretsModuleSettings.value?.roleBasedAccess &&
 			!externalSecretsModuleSettings.value?.forProjects &&
 			!externalSecretsModuleSettings.value?.multipleConnections,
@@ -153,9 +154,14 @@ export const useExternalSecretsStore = defineStore('externalSecrets', () => {
 	}
 
 	async function fetchGlobalSecrets(projectId?: string) {
+		// Community Edition does not register the external-secrets module, so
+		// `moduleSettings['external-secrets']` is absent. Skip the fetch entirely
+		// to avoid calling the EE-only endpoint (which 404s on CE). Everything
+		// below assumes EE with the module loaded.
 		const moduleConfig = externalSecretsModuleSettings.value;
+		if (!moduleConfig) return;
 
-		if (moduleConfig?.roleBasedAccess) {
+		if (moduleConfig.roleBasedAccess) {
 			// In principle when roleBasedAccess is enabled, projectId is always provided
 			if (!projectId) {
 				return;
@@ -165,7 +171,7 @@ export const useExternalSecretsStore = defineStore('externalSecrets', () => {
 			return;
 		}
 
-		if (moduleConfig?.forProjects || moduleConfig?.multipleConnections) {
+		if (moduleConfig.forProjects || moduleConfig.multipleConnections) {
 			await fetchMultiConnectionsGlobalSecrets();
 			return;
 		}
@@ -174,7 +180,10 @@ export const useExternalSecretsStore = defineStore('externalSecrets', () => {
 	}
 
 	async function fetchProjectSecrets(projectId: string) {
-		if (!externalSecretsModuleSettings.value?.forProjects) {
+		// Community Edition: external-secrets module is absent, so there is nothing to fetch.
+		if (!externalSecretsModuleSettings.value) return;
+
+		if (!externalSecretsModuleSettings.value.forProjects) {
 			// project-scoped secrets are still under development. Only available behind feature flag
 			return;
 		}
@@ -206,6 +215,9 @@ export const useExternalSecretsStore = defineStore('externalSecrets', () => {
 	}
 
 	async function fetchSecretsForProject(projectId: string) {
+		// Community Edition: external-secrets module is absent, so there is nothing to fetch.
+		if (!externalSecretsModuleSettings.value) return;
+
 		await Promise.all([fetchGlobalSecrets(projectId), fetchProjectSecrets(projectId)]);
 	}
 


### PR DESCRIPTION
## Summary

On Community Edition the `external-secrets` module is not registered, so `moduleSettings['external-secrets']` is absent. When the credential edit modal opens it triggers a secrets fetch, and the store could still issue a request to the EE-only `/rest/external-secrets/secrets` endpoint, which returns **404** and logs a noisy error in the console (see #31098).

This PR gates the secrets fetch on the presence of the external-secrets module settings (the canonical CE signal) so **no request is made on CE**, and tightens `isLegacyMode` so it cannot evaluate to `true` on CE.

### Changes
- Add an early return on `!externalSecretsModuleSettings.value` to `fetchSecretsForProject`, `fetchGlobalSecrets`, and `fetchProjectSecrets`.
- Require `isEnterpriseExternalSecretsEnabled` in `isLegacyMode`.
- Tests: distinguish **legacy EE mode** (module loaded, no beta flags) from **Community Edition** (module absent), and add coverage asserting no secrets endpoint is called on CE.

> **Scope note:** This is intentionally narrow — it only removes the spurious CE 404. It is **not** a fix for the reported OAuth2 credential form *freeze*. The freeze is Chromium-only (Firefox is unaffected) and reproduces across many versions, so it is almost certainly a separate render/main-thread/browser-extension issue; the 404 is a caught, async error and cannot block the main thread. The underlying issue should stay open pending a Chromium reproduction.

## Related
- Relates to: https://github.com/n8n-io/n8n/issues/31098

## Review / Merge checklist
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)