### PR TITLE
fix(core): Preserve verification failure in budget-exhausted blocked responses

### DIFF
--- a/packages/@n8n/instance-ai/src/workflow-loop/__tests__/workflow-loop-controller.test.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/__tests__/workflow-loop-controller.test.ts
@@ -708,6 +708,34 @@ describe('retry policy', () => {
 		});
 	});
 
+	it('preserves the concrete verdict failure in the budget-exhausted blocked reason', () => {
+		const state = makeState({
+			phase: 'verifying',
+			workflowId: 'wf_123',
+			successfulSubmitSeen: true,
+			postSubmitRemediationSubmitsUsed: 2,
+		});
+
+		const { action } = handleVerificationVerdict(
+			state,
+			[],
+			makeVerdict({
+				verdict: 'needs_rebuild',
+				summary: 'HTTP Request node returned 401 Unauthorized',
+				diagnosis: 'The Authorization header is missing the bearer token',
+				failureSignature: 'http:401',
+			}),
+		);
+
+		expect(action.type).toBe('blocked');
+		if (action.type !== 'blocked') throw new Error('expected blocked action');
+		// The concrete failure must survive alongside the budget-exhaustion guidance.
+		expect(action.reason).toContain('HTTP Request node returned 401 Unauthorized');
+		expect(action.reason).toContain('The Authorization header is missing the bearer token');
+		expect(action.reason).toContain('Signature: http:401');
+		expect(action.reason).toContain('repair budget is exhausted');
+	});
+
 	it('blocks non-editable remediation immediately and preserves workflow id', () => {
 		const state = makeState({
 			phase: 'verifying',

--- a/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-controller.ts
+++ b/packages/@n8n/instance-ai/src/workflow-loop/workflow-loop-controller.ts
@@ -406,6 +406,15 @@ function escalateToRepair(
 				'The workflow was saved, but the automatic repair budget is exhausted. Stop editing and explain the blocker to the user.',
 		});
 		applyRemediationToAttempt(attempt, blockedRemediation);
+		// Lead the blocked reason with the concrete verification failure, then the
+		// budget-exhaustion guidance. The guidance alone ("repair budget exhausted,
+		// stop editing") tells the agent *what to do next* but buries *what went
+		// wrong* — the agent needs the latter to explain the real blocker to the
+		// user. Fall back to guidance only when the verdict carries no failure text.
+		const failureDetail = describeVerificationFailure(verdict);
+		const reason = failureDetail
+			? `${failureDetail} ${blockedRemediation.guidance}`
+			: blockedRemediation.guidance;
 		return {
 			state: {
 				...state,
@@ -417,7 +426,7 @@ function escalateToRepair(
 			},
 			action: {
 				type: 'blocked',
-				reason: blockedRemediation.guidance,
+				reason,
 			},
 			attempt,
 		};
@@ -466,6 +475,22 @@ function applyRemediationToAttempt(
 	attempt.remediationCategory = remediation.category;
 	attempt.remediationShouldEdit = remediation.shouldEdit;
 	attempt.remediationGuidance = remediation.guidance;
+}
+
+/**
+ * Compose a concise, human-readable description of *what* a verification verdict
+ * found, so blocked actions can surface the concrete failure rather than only
+ * generic remediation guidance. `summary` is always present; `diagnosis` and
+ * `failureSignature` are appended when they add information.
+ */
+function describeVerificationFailure(verdict: VerificationResult): string {
+	return [
+		verdict.summary,
+		verdict.diagnosis && verdict.diagnosis !== verdict.summary ? verdict.diagnosis : '',
+		verdict.failureSignature ? `Signature: ${verdict.failureSignature}` : '',
+	]
+		.filter(Boolean)
+		.join('. ');
 }
 
 /**


### PR DESCRIPTION
## Summary

The original issue https://github.com/n8n-io/n8n/pull/31297 wanted to address is gone due to refactoring, but we still appear to lose the reason on budget exhaustion - include it to the message.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
