### PR TITLE
fix(instance-ai): Set task status to 'cancelled' in BackgroundTaskManager.cancelAll()

### DIFF
--- a/packages/@n8n/instance-ai/src/runtime/__tests__/background-task-manager.test.ts
+++ b/packages/@n8n/instance-ai/src/runtime/__tests__/background-task-manager.test.ts
@@ -663,6 +663,7 @@ describe('BackgroundTaskManager', () => {
 			const cancelled = manager.cancelAll();
 
 			expect(cancelled).toHaveLength(2);
+			expect(cancelled.every((t) => t.status === 'cancelled')).toBe(true);
 			expect(manager.getRunningTasks('thread-1')).toHaveLength(0);
 			expect(manager.getRunningTasks('thread-2')).toHaveLength(0);
 		});

--- a/packages/@n8n/instance-ai/src/runtime/background-task-manager.ts
+++ b/packages/@n8n/instance-ai/src/runtime/background-task-manager.ts
@@ -231,6 +231,7 @@ export class BackgroundTaskManager {
 		const cancelled: ManagedBackgroundTask[] = [];
 		for (const [taskId, task] of this.tasks) {
 			task.abortController.abort();
+			task.status = 'cancelled';
 			cancelled.push(task);
 			this.tasks.delete(taskId);
 			this.releaseDedupeIndices(task);


### PR DESCRIPTION
## Summary

`cancelTask()` and `cancelThread()` both mark returned tasks as `'cancelled'`, but `cancelAll()` returned them with a stale `'running'` status. This aligns the three sibling cancellation methods so every cancelled task reports `'cancelled'`, guarding against any future caller that reads `task.status` after cancellation.

Adds a test asserting every task returned from `cancelAll()` reports `'cancelled'`.

Mirrors community contribution #31764 by @davidangularme.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-470

Original community PR: #31764

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.