### PR TITLE
fix(editor): Hide template setup button once setup is complete

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.test.ts
@@ -130,6 +130,7 @@ describe('SetupWorkflowCredentialsButton', () => {
 	it('disables button when setup panel feature is enabled and setup sidebar is open', () => {
 		const workflowWithNodes = {
 			...EMPTY_WORKFLOW,
+			meta: { templateId: '2722', templateCredsSetupCompleted: false },
 			nodes: [
 				{
 					id: '1',
@@ -143,6 +144,7 @@ describe('SetupWorkflowCredentialsButton', () => {
 		};
 		workflowsStore.workflowId = workflowWithNodes.id;
 		setWorkflowDocumentStoreState(workflowWithNodes.meta, workflowWithNodes.nodes);
+		mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(false);
 		setupPanelStore.isFeatureEnabled = true;
 		focusPanelStore.focusPanelActive = true;
 		focusPanelStore.selectedTab = 'setup';
@@ -154,6 +156,7 @@ describe('SetupWorkflowCredentialsButton', () => {
 	it('does not disable button when setup panel feature is enabled but sidebar is closed', () => {
 		const workflowWithNodes = {
 			...EMPTY_WORKFLOW,
+			meta: { templateId: '2722', templateCredsSetupCompleted: false },
 			nodes: [
 				{
 					id: '1',
@@ -167,6 +170,7 @@ describe('SetupWorkflowCredentialsButton', () => {
 		};
 		workflowsStore.workflowId = workflowWithNodes.id;
 		setWorkflowDocumentStoreState(workflowWithNodes.meta, workflowWithNodes.nodes);
+		mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(false);
 		setupPanelStore.isFeatureEnabled = true;
 		focusPanelStore.focusPanelActive = false;
 
@@ -246,6 +250,56 @@ describe('SetupWorkflowCredentialsButton', () => {
 		expect(readyToRunStore.isReadyToRunTemplateId).toHaveBeenCalledWith(
 			'ready-to-run-ai-workflow-v5',
 		);
+	});
+
+	describe('button visibility with setup panel feature enabled', () => {
+		const workflowWithNodes = {
+			...EMPTY_WORKFLOW,
+			meta: { templateId: '2722', templateCredsSetupCompleted: false },
+			nodes: [
+				{
+					id: '1',
+					name: 'OpenAI Model',
+					type: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
+					typeVersion: 1,
+					position: [0, 0] as [number, number],
+					parameters: {},
+				},
+			],
+		};
+
+		it('hides the button once all credentials are filled', () => {
+			workflowsStore.workflowId = workflowWithNodes.id;
+			setWorkflowDocumentStoreState(workflowWithNodes.meta, workflowWithNodes.nodes);
+			setupPanelStore.isFeatureEnabled = true;
+			mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(true);
+
+			const { queryByTestId } = renderComponent();
+			expect(queryByTestId('setup-credentials-button')).toBeNull();
+		});
+
+		it('hides the button when template setup is already completed', () => {
+			workflowsStore.workflowId = workflowWithNodes.id;
+			setWorkflowDocumentStoreState(
+				{ templateId: '2722', templateCredsSetupCompleted: true },
+				workflowWithNodes.nodes,
+			);
+			setupPanelStore.isFeatureEnabled = true;
+			mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(false);
+
+			const { queryByTestId } = renderComponent();
+			expect(queryByTestId('setup-credentials-button')).toBeNull();
+		});
+
+		it('shows the button while credentials are still missing', () => {
+			workflowsStore.workflowId = workflowWithNodes.id;
+			setWorkflowDocumentStoreState(workflowWithNodes.meta, workflowWithNodes.nodes);
+			setupPanelStore.isFeatureEnabled = true;
+			mockDoesNodeHaveAllCredentialsFilled.mockReturnValue(false);
+
+			const { getByTestId } = renderComponent();
+			expect(getByTestId('setup-credentials-button')).toBeVisible();
+		});
 	});
 
 	describe('modal auto-open on mount', () => {

--- a/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/components/SetupWorkflowCredentialsButton.vue
@@ -63,7 +63,7 @@ const showButton = computed(() => {
 	}
 
 	if (isSetupPanelFeatureEnabled.value) {
-		return (workflowDocumentStore?.value?.allNodes ?? []).length > 0;
+		return (workflowDocumentStore?.value?.allNodes ?? []).length > 0 && !allCredentialsFilled.value;
 	}
 
 	if (isTemplateSetupCompleted.value) {


### PR DESCRIPTION
## Summary

The **"Set up template"** button (✨) on the canvas never disappeared on workflows created from — or duplicated from — a template, even after the user added the required credentials and refreshed the page, leaving no way to dismiss it.

Root cause: in `SetupWorkflowCredentialsButton.vue`, when the `069_setup_panel` experiment is enabled, `showButton` returned `true` for **any** workflow with a `meta.templateId` and at least one node, ignoring credential/completion state entirely. The non-experiment branch already hid the button once `allCredentialsFilled` (which also covers the persisted `templateCredsSetupCompleted` flag and the "no nodes" case).

The fix gates the setup-panel branch on `!allCredentialsFilled`, so the button now hides once all node credentials are present or setup is marked complete — and stays hidden across refreshes — matching the non-experiment behaviour.

```diff
 	if (isSetupPanelFeatureEnabled.value) {
-		return (workflowDocumentStore?.value?.allNodes ?? []).length > 0;
+		return (workflowDocumentStore?.value?.allNodes ?? []).length > 0 && !allCredentialsFilled.value;
 	}
```


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5015

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI