### PR TITLE
feat(JWT Node): Support custom header claims for the Sign operation

### DIFF
--- a/packages/nodes-base/nodes/Jwt/Jwt.node.ts
+++ b/packages/nodes-base/nodes/Jwt/Jwt.node.ts
@@ -185,6 +185,24 @@ export class Jwt implements INodeType {
 				},
 			},
 			{
+				displayName: 'Header Claims (JSON)',
+				name: 'headerClaims',
+				type: 'json',
+				default: '{}',
+				description:
+					'Custom claims to add to the JWT header, such as a certificate thumbprint (x5t) or key ID (kid). These are merged with the auto-generated header, and values set here take precedence. Useful for building Microsoft Entra certificate client assertions.',
+				validateType: 'object',
+				ignoreValidationDuringExecution: true,
+				typeOptions: {
+					rows: 5,
+				},
+				displayOptions: {
+					show: {
+						operation: ['sign'],
+					},
+				},
+			},
+			{
 				displayName: 'Token',
 				name: 'token',
 				type: 'string',
@@ -390,10 +408,23 @@ export class Jwt implements INodeType {
 						secretOrPrivateKey = formatPrivateKey(credentials.privateKey);
 					}
 
+					const algorithm = options.algorithm ?? credentials.algorithm;
+
 					const signingOptions: jwt.SignOptions = {
-						algorithm: options.algorithm ?? credentials.algorithm,
+						algorithm,
 					};
 					if (options.kid) signingOptions.keyid = options.kid;
+
+					const headerClaims = parseJsonParameter(
+						this.getNodeParameter('headerClaims', itemIndex, {}) as IDataObject,
+						this.getNode(),
+						itemIndex,
+					);
+					if (Object.keys(headerClaims).length > 0) {
+						const header: jwt.JwtHeader = { alg: algorithm };
+						Object.assign(header, headerClaims);
+						signingOptions.header = header;
+					}
 
 					const token = jwt.sign(payload, secretOrPrivateKey, signingOptions);
 

--- a/packages/nodes-base/nodes/Jwt/test/Jwt.node.test.ts
+++ b/packages/nodes-base/nodes/Jwt/test/Jwt.node.test.ts
@@ -1,4 +1,11 @@
 import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import { generateKeyPairSync } from 'crypto';
+import { mockDeep } from 'jest-mock-extended';
+import jwt from 'jsonwebtoken';
+import type { IExecuteFunctions } from 'n8n-workflow';
+import { NodeOperationError } from 'n8n-workflow';
+
+import { Jwt } from '../Jwt.node';
 
 const credentials = {
 	jwtAuth: {
@@ -10,4 +17,145 @@ const credentials = {
 
 describe('Test Jwt Node', () => {
 	new NodeTestHarness().setupTests({ credentials });
+});
+
+describe('JWT Node - custom header claims', () => {
+	const passphraseCredentials = {
+		keyType: 'passphrase' as const,
+		secret: 'baz',
+		algorithm: 'HS256' as const,
+	};
+
+	const setupExecuteFunctions = (
+		params: Record<string, unknown>,
+		creds: Record<string, unknown>,
+	) => {
+		const ctx = mockDeep<IExecuteFunctions>();
+		ctx.getInputData.mockReturnValue([{ json: {} }]);
+		ctx.continueOnFail.mockReturnValue(false);
+		ctx.getNode.mockReturnValue({
+			id: 'jwt-node',
+			name: 'JWT',
+			type: 'n8n-nodes-base.jwt',
+			typeVersion: 1,
+			position: [0, 0],
+			parameters: {},
+		});
+		ctx.getCredentials.mockResolvedValue(creds);
+		ctx.getNodeParameter.mockImplementation(
+			(name: string, _itemIndex?: number, fallback?: unknown) =>
+				(params[name] ?? fallback) as never,
+		);
+		return ctx;
+	};
+
+	const signToken = async (params: Record<string, unknown>, creds: Record<string, unknown>) => {
+		const ctx = setupExecuteFunctions(params, creds);
+		const result = await new Jwt().execute.call(ctx);
+		return (result[0][0].json as { token: string }).token;
+	};
+
+	it('carries a custom RS256 header with x5t (Microsoft Entra client assertion shape)', async () => {
+		const { privateKey, publicKey } = generateKeyPairSync('rsa', {
+			modulusLength: 2048,
+			publicKeyEncoding: { type: 'spki', format: 'pem' },
+			privateKeyEncoding: { type: 'pkcs8', format: 'pem' },
+		});
+
+		const token = await signToken(
+			{
+				operation: 'sign',
+				useJson: true,
+				claimsJson: JSON.stringify({
+					aud: 'https://login.microsoftonline.com/contoso/oauth2/v2.0/token',
+					iss: 'client-id',
+					sub: 'client-id',
+					jti: 'unique-assertion-id',
+				}),
+				headerClaims: JSON.stringify({ x5t: 'aB3cDeThumbprint', typ: 'JWT' }),
+				options: {},
+			},
+			{ keyType: 'pemKey', privateKey, publicKey, algorithm: 'RS256' },
+		);
+
+		// Exact match: the client assertion header must contain only the intended claims
+		// (alg + typ + x5t) and no stray fields such as kid.
+		const decoded = jwt.decode(token, { complete: true });
+		expect(decoded?.header).toEqual({
+			alg: 'RS256',
+			typ: 'JWT',
+			x5t: 'aB3cDeThumbprint',
+		});
+
+		// The signature is a valid RS256 assertion verifiable with the matching public key
+		const verified = jwt.verify(token, publicKey, { algorithms: ['RS256'] }) as jwt.JwtPayload;
+		expect(verified.aud).toBe('https://login.microsoftonline.com/contoso/oauth2/v2.0/token');
+		expect(verified.sub).toBe('client-id');
+	});
+
+	it('lets explicit header claims take precedence over the auto-generated kid and typ', async () => {
+		const token = await signToken(
+			{
+				operation: 'sign',
+				useJson: false,
+				claims: { subject: 'test' },
+				headerClaims: JSON.stringify({ kid: 'header-kid', typ: 'at+jwt' }),
+				options: { kid: 'option-kid' },
+			},
+			passphraseCredentials,
+		);
+
+		const decoded = jwt.decode(token, { complete: true });
+		expect(decoded?.header.kid).toBe('header-kid');
+		expect(decoded?.header.typ).toBe('at+jwt');
+		expect(decoded?.header.alg).toBe('HS256');
+	});
+
+	it('still applies the kid option when the custom header omits kid', async () => {
+		const token = await signToken(
+			{
+				operation: 'sign',
+				useJson: false,
+				claims: { subject: 'test' },
+				headerClaims: JSON.stringify({ x5t: 'thumbprint' }),
+				options: { kid: 'option-kid' },
+			},
+			passphraseCredentials,
+		);
+
+		const decoded = jwt.decode(token, { complete: true });
+		expect(decoded?.header.kid).toBe('option-kid');
+		expect(decoded?.header.x5t).toBe('thumbprint');
+	});
+
+	it('leaves the header unchanged when headerClaims is empty (existing workflows unaffected)', async () => {
+		const token = await signToken(
+			{
+				operation: 'sign',
+				useJson: false,
+				claims: { subject: 'test' },
+				headerClaims: '{}',
+				options: {},
+			},
+			passphraseCredentials,
+		);
+
+		const decoded = jwt.decode(token, { complete: true });
+		expect(decoded?.header).toEqual({ alg: 'HS256', typ: 'JWT' });
+	});
+
+	it('throws a NodeOperationError when headerClaims is not a JSON object', async () => {
+		const ctx = setupExecuteFunctions(
+			{
+				operation: 'sign',
+				useJson: false,
+				claims: { subject: 'test' },
+				headerClaims: '[1, 2, 3]',
+				options: {},
+			},
+			passphraseCredentials,
+		);
+
+		await expect(new Jwt().execute.call(ctx)).rejects.toThrow(NodeOperationError);
+	});
 });

--- a/packages/nodes-base/nodes/Jwt/test/jwt.workflow.json
+++ b/packages/nodes-base/nodes/Jwt/test/jwt.workflow.json
@@ -355,6 +355,89 @@
 			"type": "n8n-nodes-base.set",
 			"typeVersion": 3.3,
 			"position": [580, 1360]
+		},
+		{
+			"parameters": {
+				"claims": {
+					"audience": "test",
+					"issuer": "test",
+					"jwtid": "123",
+					"subject": "test"
+				},
+				"headerClaims": "{\n  \"x5t\": \"abc123thumbprint\",\n  \"kid\": \"header-kid\"\n}",
+				"options": {
+					"kid": "option-kid"
+				}
+			},
+			"id": "7c1e9a64-2f3b-4a51-9d2e-6f0b1c8d4e10",
+			"name": "Sign with custom header",
+			"type": "n8n-nodes-base.jwt",
+			"typeVersion": 1,
+			"position": [120, 1720],
+			"credentials": {
+				"jwtAuth": {
+					"id": "kDnfvqrCBJvtlX3o",
+					"name": "JWT Auth account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"operation": "decode",
+				"token": "={{ $json.token }}",
+				"options": {
+					"complete": true
+				}
+			},
+			"id": "b5d8f217-3a4c-4e62-8c1f-9a2b3c4d5e60",
+			"name": "Decode4",
+			"type": "n8n-nodes-base.jwt",
+			"typeVersion": 1,
+			"position": [380, 1720],
+			"credentials": {
+				"jwtAuth": {
+					"id": "kDnfvqrCBJvtlX3o",
+					"name": "JWT Auth account"
+				}
+			}
+		},
+		{
+			"parameters": {
+				"assignments": {
+					"assignments": [
+						{
+							"id": "a1b2c3d4-0001-4001-8001-000000000001",
+							"name": "header.alg",
+							"value": "={{ $json.header.alg }}",
+							"type": "string"
+						},
+						{
+							"id": "a1b2c3d4-0002-4002-8002-000000000002",
+							"name": "header.typ",
+							"value": "={{ $json.header.typ }}",
+							"type": "string"
+						},
+						{
+							"id": "a1b2c3d4-0003-4003-8003-000000000003",
+							"name": "header.kid",
+							"value": "={{ $json.header.kid }}",
+							"type": "string"
+						},
+						{
+							"id": "a1b2c3d4-0004-4004-8004-000000000004",
+							"name": "header.x5t",
+							"value": "={{ $json.header.x5t }}",
+							"type": "string"
+						}
+					]
+				},
+				"options": {}
+			},
+			"id": "c9e0f1a2-4b5c-4d6e-9f70-1a2b3c4d5e70",
+			"name": "Decode4 Output",
+			"type": "n8n-nodes-base.set",
+			"typeVersion": 3.3,
+			"position": [580, 1720]
 		}
 	],
 	"pinData": {
@@ -423,6 +506,18 @@
 					}
 				}
 			}
+		],
+		"Decode4 Output": [
+			{
+				"json": {
+					"header": {
+						"alg": "HS256",
+						"typ": "JWT",
+						"kid": "header-kid",
+						"x5t": "abc123thumbprint"
+					}
+				}
+			}
 		]
 	},
 	"connections": {
@@ -441,6 +536,11 @@
 					},
 					{
 						"node": "Sign with kid",
+						"type": "main",
+						"index": 0
+					},
+					{
+						"node": "Sign with custom header",
 						"type": "main",
 						"index": 0
 					}
@@ -555,6 +655,28 @@
 				[
 					{
 						"node": "Verify3 Output",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Sign with custom header": {
+			"main": [
+				[
+					{
+						"node": "Decode4",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		},
+		"Decode4": {
+			"main": [
+				[
+					{
+						"node": "Decode4 Output",
 						"type": "main",
 						"index": 0
 					}


### PR DESCRIPTION

## Summary

The **JWT node** lets you sign a payload, but it never exposed the JWT **header**. That made it impossible to hand-build certain tokens — most notably a **Microsoft Entra (Azure AD) certificate client assertion**, where the header must carry the certificate identifier (`x5t` thumbprint, or `kid`) alongside `alg`/`typ`.

This PR adds an optional **`Header Claims (JSON)`** field to the **Sign** operation. Whatever you put there is merged into the JWT header, and **explicit values take precedence** over the auto-generated `alg` / `typ` / `kid`.

- Set any header parameter: `x5t`, `x5t#S256`, `x5c`, `kid`, `typ`, `alg`, …
- Empty (`{}`, the default) → **no behavioural change**, so existing workflows are untouched.
- Native certificate support in the Microsoft credential is tracked separately; this is the interim, node-level enabler.

**Header before vs. after**

```jsonc
// Before — Sign always produced:
{ "alg": "RS256", "typ": "JWT" }

// After — with Header Claims (JSON) = { "x5t": "aB3c…", "typ": "JWT" }:
{ "alg": "RS256", "typ": "JWT", "x5t": "aB3c…" }   // valid Entra client-assertion header
```

### Screenshots

<!-- 👇 add UI screenshots here -->

**New `Header Claims (JSON)` field on the Sign operation:**

<img width="1856" height="939" alt="image" src="https://github.com/user-attachments/assets/1992f9e2-1de8-4c8b-aa6b-7eacb202cf36" />

## How to test

### Automated

```bash
cd packages/nodes-base && pnpm test Jwt
```

Covers: the custom header appears in the output, explicit header values win over the `Key ID` option, the `Key ID` option still applies when the header omits `kid`, an empty value is a no-op, an RS256 + `x5t` token verifies against its public key, and a non-object header is rejected with a clear error.

### Manual (in the editor)

1. Create a **JWT Auth** credential. For the Entra shape, choose **PEM Key**, paste an **RSA private key**, and set **Algorithm = RS256**.
2. Add a **JWT** node, **Operation = Sign**.
3. Turn on **Use JSON to Build Payload** and enter standard claims, e.g.:
   ```json
   {
     "aud": "https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token",
     "iss": "<client-id>",
     "sub": "<client-id>",
     "jti": "<unique-guid>",
     "exp": 1999999999,
     "nbf": 1700000000
   }
   ```
4. In **Header Claims (JSON)**, add the certificate identifier:
   ```json
   { "x5t": "<base64url SHA-1 cert thumbprint>", "typ": "JWT" }
   ```
5. Execute, then feed `={{ $json.token }}` into a second **JWT** node with **Operation = Decode** and **Return Additional Info = ON**. Confirm the decoded **header** contains `alg: RS256`, `typ: JWT`, and your `x5t`.

### Manual (end-to-end against Microsoft Entra)

This is the acceptance check that can only be done against the live endpoint:

1. Use the signed JWT from step 4 as the `client_assertion` in a token request:
   ```bash
   curl -X POST "https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token" \
     -d "grant_type=client_credentials" \
     -d "client_id=<client-id>" \
     -d "scope=https://graph.microsoft.com/.default" \
     -d "client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer" \
     -d "client_assertion=<the-signed-jwt>"
   ```
2. Expect a `200` with an `access_token` (the certificate must be registered on the app registration, and `x5t` must match its SHA-1 thumbprint).

### Example workflow

> Attach the RS256 **JWT Auth** credential to both JWT nodes after importing.

```json
{
  "name": "JWT custom header demo",
  "nodes": [
    { "parameters": {}, "id": "a0000000-0000-4000-8000-000000000001", "name": "When clicking 'Execute workflow'", "type": "n8n-nodes-base.manualTrigger", "typeVersion": 1, "position": [0, 0] },
    { "parameters": { "useJson": true, "claimsJson": "{\n  \"aud\": \"https://login.microsoftonline.com/<tenant-id>/oauth2/v2.0/token\",\n  \"iss\": \"<client-id>\",\n  \"sub\": \"<client-id>\",\n  \"jti\": \"unique-guid\"\n}", "headerClaims": "{\n  \"x5t\": \"<base64url-thumbprint>\",\n  \"typ\": \"JWT\"\n}", "options": {} }, "id": "a0000000-0000-4000-8000-000000000002", "name": "Sign client assertion", "type": "n8n-nodes-base.jwt", "typeVersion": 1, "position": [220, 0] },
    { "parameters": { "operation": "decode", "token": "={{ $json.token }}", "options": { "complete": true } }, "id": "a0000000-0000-4000-8000-000000000003", "name": "Decode", "type": "n8n-nodes-base.jwt", "typeVersion": 1, "position": [440, 0] }
  ],
  "connections": {
    "When clicking 'Execute workflow'": { "main": [[{ "node": "Sign client assertion", "type": "main", "index": 0 }]] },
    "Sign client assertion": { "main": [[{ "node": "Decode", "type": "main", "index": 0 }]] }
  },
  "settings": { "executionOrder": "v1" }
}
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-29

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
