### PR TITLE
fix(ai-builder): Send projectId when creating eval threads (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
+++ b/packages/@n8n/instance-ai/evaluations/clients/n8n-client.ts
@@ -137,12 +137,13 @@ export class N8nClient {
 
 	/**
 	 * Ensure a conversation thread exists before sending chat messages.
-	 * POST /rest/instance-ai/threads body: { threadId }
+	 * POST /rest/instance-ai/threads body: { threadId, projectId }
 	 */
 	async ensureThread(threadId: string): Promise<void> {
+		const projectId = await this.getPersonalProjectId();
 		await this.fetch('/rest/instance-ai/threads', {
 			method: 'POST',
-			body: { threadId },
+			body: { threadId, projectId },
 		});
 	}
 


### PR DESCRIPTION
## Summary

`POST /rest/instance-ai/threads` now **requires a `projectId`** in its body, but the eval client's `ensureThread` only sent `{ threadId }` — so **every Instance AI eval build fails at thread creation** with:

```
Build failed: POST /rest/instance-ai/threads failed (400):
{"code":"invalid_type","expected":"string","received":"undefined","path":["projectId"],"message":"Required"}
```

This leaves the **workflow-eval and discovery-eval pipelines red on master** (both create a thread per build via this client).

**Fix:** `ensureThread` now sends the authenticated user's personal `projectId`, fetched via the client's existing `getPersonalProjectId()` helper (`GET /rest/projects/personal`).

## How to test

Run any Instance AI eval against a current master backend (which enforces `projectId`):

```bash
cd packages/@n8n/instance-ai
dotenvx run -f ../../../.env.local -- pnpm eval:instance-ai --filter airtable-split-to-slack --iterations 1
```

- **Before:** every build → `400 … projectId Required` → 0%.
- **After:** builds proceed normally.

Verified locally on master (n8n-sandbox): `airtable-split-to-slack` went **0% (2/2 `build_failure`, 400) → 100% (2/2 pass)**.

## Notes

Surfaced while smoke-testing master ahead of merging it into the build-expectations branch (https://linear.app/n8n/issue/TRUST-148 / #31787).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. _(eval client has no unit-test harness; verified via the eval run above.)_
- [ ] PR Labeled with `Backport to Beta`/`Backport to Stable`/`Backport to v1` (if urgent fix needing backport).
