### PR TITLE
fix(editor): Send only credential id when authorizing OAuth credentials

### DIFF
--- a/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/CredentialEdit/CredentialEdit.vue
@@ -1272,9 +1272,10 @@ async function oAuthCredentialAuthorize() {
 	const types = parentTypes.value;
 
 	try {
-		// We exclude sharedWithProjects because it's not needed for the authorization and it causes the request to be too large
-		const { sharedWithProjects, ...sanitizedCredData } = credentialData.value;
-		const credData = { id: credential.id, ...sanitizedCredData };
+		// The authorization endpoints only need the credential id; the backend re-fetches the
+		// stored credential by id. Sending more (homeProject, scopes, etc.) bloats the GET query
+		// string and can exceed proxy header size limits.
+		const credData = { id: credential.id };
 
 		if (credentialTypeName.value === 'oAuth2Api' || types.includes('oAuth2Api')) {
 			if (isValidCredentialResponse(credData)) {

--- a/packages/frontend/editor-ui/src/features/credentials/credentials.api.test.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/credentials.api.test.ts
@@ -1,0 +1,53 @@
+import { makeRestApiRequest } from '@n8n/rest-api-client';
+import type { IRestApiContext } from '@n8n/rest-api-client';
+
+import { oAuth1CredentialAuthorize, oAuth2CredentialAuthorize } from './credentials.api';
+import type { ICredentialsResponse } from './credentials.types';
+
+vi.mock('@n8n/rest-api-client', () => ({
+	makeRestApiRequest: vi.fn(),
+}));
+
+const makeRestApiRequestMock = vi.mocked(makeRestApiRequest);
+
+const context: IRestApiContext = { baseUrl: '/rest', pushRef: 'push-ref' };
+
+// A credential as returned by the list/edit endpoints, carrying the large fields
+// (homeProject, scopes, sharedWithProjects) that previously bloated the auth GET URL.
+const credential = {
+	id: 'cred-1',
+	name: 'My OAuth credential',
+	type: 'oAuth2Api',
+	homeProject: {
+		id: 'project-1',
+		name: 'Big team project',
+		type: 'team',
+		scopes: Array.from({ length: 120 }, (_, i) => `scope:${i}`),
+	},
+	scopes: Array.from({ length: 120 }, (_, i) => `scope:${i}`),
+	sharedWithProjects: [{ id: 'project-2', name: 'Another project' }],
+	data: { clientId: 'abc', clientSecret: 'secret' },
+} as unknown as ICredentialsResponse;
+
+describe('credentials.api OAuth authorization', () => {
+	beforeEach(() => {
+		makeRestApiRequestMock.mockReset();
+		makeRestApiRequestMock.mockResolvedValue('https://example.com/auth');
+	});
+
+	it('oAuth2CredentialAuthorize sends only the credential id', async () => {
+		await oAuth2CredentialAuthorize(context, credential);
+
+		expect(makeRestApiRequestMock).toHaveBeenCalledWith(context, 'GET', '/oauth2-credential/auth', {
+			id: 'cred-1',
+		});
+	});
+
+	it('oAuth1CredentialAuthorize sends only the credential id', async () => {
+		await oAuth1CredentialAuthorize(context, credential);
+
+		expect(makeRestApiRequestMock).toHaveBeenCalledWith(context, 'GET', '/oauth1-credential/auth', {
+			id: 'cred-1',
+		});
+	});
+});

--- a/packages/frontend/editor-ui/src/features/credentials/credentials.api.ts
+++ b/packages/frontend/editor-ui/src/features/credentials/credentials.api.ts
@@ -124,12 +124,10 @@ export async function oAuth1CredentialAuthorize(
 	context: IRestApiContext,
 	data: ICredentialsResponse,
 ): Promise<string> {
-	return await makeRestApiRequest(
-		context,
-		'GET',
-		'/oauth1-credential/auth',
-		data as unknown as IDataObject,
-	);
+	// Only the credential id is needed: the backend re-fetches the stored credential by id.
+	// Sending the full object inflates the GET query string (homeProject, scopes, etc.) and
+	// can push the request past proxy header size limits (HTTP 431).
+	return await makeRestApiRequest(context, 'GET', '/oauth1-credential/auth', { id: data.id });
 }
 
 // Get OAuth2 Authorization URL using the stored credentials
@@ -137,12 +135,10 @@ export async function oAuth2CredentialAuthorize(
 	context: IRestApiContext,
 	data: ICredentialsResponse,
 ): Promise<string> {
-	return await makeRestApiRequest(
-		context,
-		'GET',
-		'/oauth2-credential/auth',
-		data as unknown as IDataObject,
-	);
+	// Only the credential id is needed: the backend re-fetches the stored credential by id.
+	// Sending the full object inflates the GET query string (homeProject, scopes, etc.) and
+	// can push the request past proxy header size limits (HTTP 431).
+	return await makeRestApiRequest(context, 'GET', '/oauth2-credential/auth', { id: data.id });
 }
 
 export async function testCredential(


### PR DESCRIPTION
## Summary

The OAuth authorize endpoints (`/oauth1-credential/auth` and `/oauth2-credential/auth`) only read the credential `id` and re-fetch the stored credential from the database, but the editor was serializing the entire credential object into the GET query string — so nested fields like `homeProject` and `scopes` could push the URL past proxy header size limits and return **HTTP 431** on large-scope projects. This narrows the request to `{ id }` at the API layer so every caller (credential editor, credential card, OAuth composable, quick-connect) is covered, and removes the now-obsolete partial `sharedWithProjects` workaround. The issue affects any OAuth1/OAuth2 node, not just Salesforce.

## How to test

1. Create an OAuth2 (or OAuth1) credential inside a team project that has a large RBAC scope list.
2. Click "Connect"/authorize and inspect the request to `/rest/oauth2-credential/auth` in the network tab.
3. The query string should contain only `id=<credentialId>` (previously it also carried `homeProject`, `scopes`, etc.), and authorization should complete without a 431.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-525

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI