### PR TITLE
feat: Scope E2E impact selection for dependency + uncovered changes (no-changelog)

### DIFF
--- a/packages/testing/janitor/src/cli.ts
+++ b/packages/testing/janitor/src/cli.ts
@@ -16,7 +16,13 @@
  * invoked from any package via `pnpm exec janitor ...`.
  */
 
-import { encodeImpactMap, buildImpactMap, distributeShards, selectTests } from '@n8n/test-impact';
+import {
+	encodeImpactMap,
+	buildImpactMap,
+	distributeShards,
+	selectTests,
+	changedRuntimeDepsFromManifests,
+} from '@n8n/test-impact';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -689,10 +695,13 @@ function runSelect(options: CliOptions): void {
 	// devDependency-only classifier can drop a devDep-only lockfile change.
 	// No base (local dev) → omit manifests → conservative (keep lockfile broad).
 	const manifests = options.baseRef ? readManifestDiffs(changedFiles, options.baseRef) : undefined;
-	// Only parse the (large) lockfile when a manifest actually changed — that's
-	// the only case the dep-graph selector (389) can act on.
+	// Only parse the (large) lockfile when a RUNTIME dependency actually changed —
+	// the only case the dep-graph selector (389) acts on. A devDep-only manifest
+	// change would parse it for nothing.
 	const lockfileImporters =
-		manifests && Object.keys(manifests).length > 0 ? readLockfileImporters() : undefined;
+		manifests && changedRuntimeDepsFromManifests(manifests).length > 0
+			? readLockfileImporters()
+			: undefined;
 	const result = selectTests({
 		changedFiles,
 		mapFile: options.mapFile,

--- a/packages/testing/janitor/src/cli.ts
+++ b/packages/testing/janitor/src/cli.ts
@@ -72,6 +72,7 @@ import {
 	formatMethodUsageIndexJSON,
 } from './core/method-usage-analyzer.js';
 import { createProject } from './core/project-loader.js';
+import { readManifestDiffs } from './core/read-manifest-diffs.js';
 import { toJSON, toConsole } from './core/reporter.js';
 import { filterToFailedSpecs } from './core/retry-filter.js';
 import { computeScope, formatScope } from './core/scope-analyzer.js';
@@ -682,10 +683,16 @@ function runMergeCoverage(options: CliOptions): void {
 /** select: changed files + impact map → spec list (JSON). I/O wrapper
  *  around {@link selectTests}, where the fail-open safety contract lives. */
 function runSelect(options: CliOptions): void {
+	const changedFiles = readChangedFiles(options) ?? [];
+	// With a base ref, read each changed package.json before/after so the
+	// devDependency-only classifier can drop a devDep-only lockfile change.
+	// No base (local dev) → omit manifests → conservative (keep lockfile broad).
+	const manifests = options.baseRef ? readManifestDiffs(changedFiles, options.baseRef) : undefined;
 	const result = selectTests({
-		changedFiles: readChangedFiles(options) ?? [],
+		changedFiles,
 		mapFile: options.mapFile,
 		allSpecsFile: options.allSpecsFile,
+		manifests,
 	});
 	console.log(JSON.stringify(result));
 }

--- a/packages/testing/janitor/src/cli.ts
+++ b/packages/testing/janitor/src/cli.ts
@@ -72,6 +72,7 @@ import {
 	formatMethodUsageIndexJSON,
 } from './core/method-usage-analyzer.js';
 import { createProject } from './core/project-loader.js';
+import { readLockfileImporters } from './core/read-lockfile-importers.js';
 import { readManifestDiffs } from './core/read-manifest-diffs.js';
 import { toJSON, toConsole } from './core/reporter.js';
 import { filterToFailedSpecs } from './core/retry-filter.js';
@@ -688,11 +689,16 @@ function runSelect(options: CliOptions): void {
 	// devDependency-only classifier can drop a devDep-only lockfile change.
 	// No base (local dev) → omit manifests → conservative (keep lockfile broad).
 	const manifests = options.baseRef ? readManifestDiffs(changedFiles, options.baseRef) : undefined;
+	// Only parse the (large) lockfile when a manifest actually changed — that's
+	// the only case the dep-graph selector (389) can act on.
+	const lockfileImporters =
+		manifests && Object.keys(manifests).length > 0 ? readLockfileImporters() : undefined;
 	const result = selectTests({
 		changedFiles,
 		mapFile: options.mapFile,
 		allSpecsFile: options.allSpecsFile,
 		manifests,
+		lockfileImporters,
 	});
 	console.log(JSON.stringify(result));
 }

--- a/packages/testing/janitor/src/core/ast-diff-analyzer.ts
+++ b/packages/testing/janitor/src/core/ast-diff-analyzer.ts
@@ -5,11 +5,11 @@
  * identifying exactly which methods were added, removed, or modified.
  */
 
-import { execFileSync } from 'node:child_process';
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
-import * as path from 'node:path';
 import { Project, type SourceFile } from 'ts-morph';
+
+import { getFileAtRef } from '../utils/git-operations.js';
 
 export interface MethodChange {
 	className: string;
@@ -25,34 +25,9 @@ export interface FileDiffResult {
 	parseTimeMs: number;
 }
 
-/**
- * Get the git root directory
- */
-function getGitRoot(): string {
-	return execFileSync('git', ['rev-parse', '--show-toplevel'], {
-		encoding: 'utf-8',
-	}).trim();
-}
-
-/**
- * Get file content from git at a specific ref
- */
+/** Content of a file at a git ref (shared impl in git-operations). */
 function getGitFileContent(filePath: string, ref: string = 'HEAD'): string | null {
-	try {
-		// Resolve to absolute path
-		const absolutePath = path.resolve(filePath);
-
-		// Get git root and make path relative to it
-		const gitRoot = getGitRoot();
-		const relativePath = path.relative(gitRoot, absolutePath);
-
-		return execFileSync('git', ['show', `${ref}:${relativePath}`], {
-			encoding: 'utf-8',
-			stdio: ['pipe', 'pipe', 'pipe'],
-		});
-	} catch {
-		return null; // File doesn't exist at that ref
-	}
+	return getFileAtRef(filePath, ref);
 }
 
 /**

--- a/packages/testing/janitor/src/core/read-lockfile-importers.ts
+++ b/packages/testing/janitor/src/core/read-lockfile-importers.ts
@@ -1,7 +1,7 @@
 /**
  * Parse pnpm-lock.yaml's `importers` section into the
  * `@n8n/test-impact` dep-graph selector's input: each workspace package dir
- * mapped to the *runtime* dependency names it declares (DEVP-389).
+ * mapped to the *runtime* dependency names it declares.
  *
  * devDependencies are excluded — a devDep can't reach the runtime bundle, so it
  * has no business widening a runtime-dep walk. Any failure (missing/unparseable

--- a/packages/testing/janitor/src/core/read-lockfile-importers.ts
+++ b/packages/testing/janitor/src/core/read-lockfile-importers.ts
@@ -8,13 +8,12 @@
  * lockfile) returns `{}`, which makes the dep-graph selector contribute nothing
  * (the change then resolves through the coverage map alone — fail-open).
  */
+import { RUNTIME_SECTIONS } from '@n8n/test-impact';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { parse } from 'yaml';
 
 import { getGitRoot } from '../utils/git-operations.js';
-
-const RUNTIME_SECTIONS = ['dependencies', 'optionalDependencies', 'peerDependencies'] as const;
 
 type ImporterSections = Record<string, Record<string, unknown> | undefined>;
 

--- a/packages/testing/janitor/src/core/read-lockfile-importers.ts
+++ b/packages/testing/janitor/src/core/read-lockfile-importers.ts
@@ -1,0 +1,48 @@
+/**
+ * Parse pnpm-lock.yaml's `importers` section into the
+ * `@n8n/test-impact` dep-graph selector's input: each workspace package dir
+ * mapped to the *runtime* dependency names it declares (DEVP-389).
+ *
+ * devDependencies are excluded — a devDep can't reach the runtime bundle, so it
+ * has no business widening a runtime-dep walk. Any failure (missing/unparseable
+ * lockfile) returns `{}`, which makes the dep-graph selector contribute nothing
+ * (the change then resolves through the coverage map alone — fail-open).
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { parse } from 'yaml';
+
+const RUNTIME_SECTIONS = ['dependencies', 'optionalDependencies', 'peerDependencies'] as const;
+
+type ImporterSections = Record<string, Record<string, unknown> | undefined>;
+
+function gitToplevel(): string {
+	try {
+		return execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim();
+	} catch {
+		return process.cwd();
+	}
+}
+
+export function readLockfileImporters(): Record<string, string[]> {
+	const lockPath = join(gitToplevel(), 'pnpm-lock.yaml');
+	if (!existsSync(lockPath)) return {};
+	let doc: { importers?: Record<string, ImporterSections> };
+	try {
+		doc = parse(readFileSync(lockPath, 'utf8')) as typeof doc;
+	} catch {
+		return {};
+	}
+	const importers = doc?.importers ?? {};
+	const out: Record<string, string[]> = {};
+	for (const [dir, sections] of Object.entries(importers)) {
+		const names = new Set<string>();
+		for (const section of RUNTIME_SECTIONS) {
+			const deps = sections?.[section];
+			if (deps) for (const name of Object.keys(deps)) names.add(name);
+		}
+		out[dir] = [...names];
+	}
+	return out;
+}

--- a/packages/testing/janitor/src/core/read-lockfile-importers.ts
+++ b/packages/testing/janitor/src/core/read-lockfile-importers.ts
@@ -8,25 +8,18 @@
  * lockfile) returns `{}`, which makes the dep-graph selector contribute nothing
  * (the change then resolves through the coverage map alone — fail-open).
  */
-import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { parse } from 'yaml';
+
+import { getGitRoot } from '../utils/git-operations.js';
 
 const RUNTIME_SECTIONS = ['dependencies', 'optionalDependencies', 'peerDependencies'] as const;
 
 type ImporterSections = Record<string, Record<string, unknown> | undefined>;
 
-function gitToplevel(): string {
-	try {
-		return execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim();
-	} catch {
-		return process.cwd();
-	}
-}
-
 export function readLockfileImporters(): Record<string, string[]> {
-	const lockPath = join(gitToplevel(), 'pnpm-lock.yaml');
+	const lockPath = join(getGitRoot(process.cwd()), 'pnpm-lock.yaml');
 	if (!existsSync(lockPath)) return {};
 	let doc: { importers?: Record<string, ImporterSections> };
 	try {

--- a/packages/testing/janitor/src/core/read-manifest-diffs.ts
+++ b/packages/testing/janitor/src/core/read-manifest-diffs.ts
@@ -3,25 +3,12 @@
  * devDependency classifier. Any read failure → '' so the classifier stays
  * conservative (an unreadable manifest is treated as a non-devDep change, kept).
  */
-import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { getGitRoot } from '../utils/git-operations.js';
+import { getFileAtRef, getGitRoot } from '../utils/git-operations.js';
 
 const isManifest = (file: string): boolean => /(^|\/)package\.json$/.test(file);
-
-const showAtRef = (root: string, ref: string, file: string): string => {
-	try {
-		return execFileSync('git', ['show', `${ref}:${file}`], {
-			cwd: root,
-			encoding: 'utf8',
-			stdio: ['ignore', 'pipe', 'ignore'],
-		});
-	} catch {
-		return '';
-	}
-};
 
 export function readManifestDiffs(
 	changedFiles: string[],
@@ -34,7 +21,7 @@ export function readManifestDiffs(
 	for (const file of manifests) {
 		const abs = join(root, file);
 		out[file] = {
-			before: showAtRef(root, baseRef, file),
+			before: getFileAtRef(file, baseRef) ?? '',
 			after: existsSync(abs) ? readFileSync(abs, 'utf8') : '',
 		};
 	}

--- a/packages/testing/janitor/src/core/read-manifest-diffs.ts
+++ b/packages/testing/janitor/src/core/read-manifest-diffs.ts
@@ -1,0 +1,55 @@
+/**
+ * Read the before/after content of each changed package.json, for the
+ * `@n8n/test-impact` devDependency-only classifier. Pure git I/O, no AST.
+ *
+ *  - before: the manifest at `baseRef` ('' if it didn't exist there → the
+ *            classifier treats it as an empty manifest);
+ *  - after:  the working-tree manifest ('' if deleted).
+ *
+ * Every failure degrades to '' so the classifier stays conservative — a manifest
+ * it can't read is treated as a non-devDep change and kept in selection.
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const isManifest = (file: string): boolean => /(^|\/)package\.json$/.test(file);
+
+function gitToplevel(): string {
+	try {
+		return execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim();
+	} catch {
+		return process.cwd();
+	}
+}
+
+export function readManifestDiffs(
+	changedFiles: string[],
+	baseRef: string,
+): Record<string, { before: string; after: string }> {
+	const manifests = changedFiles.filter(isManifest);
+	if (manifests.length === 0) return {};
+	const root = gitToplevel();
+	const out: Record<string, { before: string; after: string }> = {};
+	for (const file of manifests) {
+		let before = '';
+		try {
+			before = execFileSync('git', ['show', `${baseRef}:${file}`], {
+				cwd: root,
+				encoding: 'utf8',
+				stdio: ['ignore', 'pipe', 'ignore'],
+			});
+		} catch {
+			before = '';
+		}
+		let after = '';
+		try {
+			const abs = join(root, file);
+			if (existsSync(abs)) after = readFileSync(abs, 'utf8');
+		} catch {
+			after = '';
+		}
+		out[file] = { before, after };
+	}
+	return out;
+}

--- a/packages/testing/janitor/src/core/read-manifest-diffs.ts
+++ b/packages/testing/janitor/src/core/read-manifest-diffs.ts
@@ -1,27 +1,27 @@
 /**
- * Read the before/after content of each changed package.json, for the
- * `@n8n/test-impact` devDependency-only classifier. Pure git I/O, no AST.
- *
- *  - before: the manifest at `baseRef` ('' if it didn't exist there → the
- *            classifier treats it as an empty manifest);
- *  - after:  the working-tree manifest ('' if deleted).
- *
- * Every failure degrades to '' so the classifier stays conservative — a manifest
- * it can't read is treated as a non-devDep change and kept in selection.
+ * before/after content of each changed package.json, for the `@n8n/test-impact`
+ * devDependency classifier. Any read failure → '' so the classifier stays
+ * conservative (an unreadable manifest is treated as a non-devDep change, kept).
  */
 import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { getGitRoot } from '../utils/git-operations.js';
+
 const isManifest = (file: string): boolean => /(^|\/)package\.json$/.test(file);
 
-function gitToplevel(): string {
+const showAtRef = (root: string, ref: string, file: string): string => {
 	try {
-		return execFileSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).trim();
+		return execFileSync('git', ['show', `${ref}:${file}`], {
+			cwd: root,
+			encoding: 'utf8',
+			stdio: ['ignore', 'pipe', 'ignore'],
+		});
 	} catch {
-		return process.cwd();
+		return '';
 	}
-}
+};
 
 export function readManifestDiffs(
 	changedFiles: string[],
@@ -29,27 +29,14 @@ export function readManifestDiffs(
 ): Record<string, { before: string; after: string }> {
 	const manifests = changedFiles.filter(isManifest);
 	if (manifests.length === 0) return {};
-	const root = gitToplevel();
+	const root = getGitRoot(process.cwd());
 	const out: Record<string, { before: string; after: string }> = {};
 	for (const file of manifests) {
-		let before = '';
-		try {
-			before = execFileSync('git', ['show', `${baseRef}:${file}`], {
-				cwd: root,
-				encoding: 'utf8',
-				stdio: ['ignore', 'pipe', 'ignore'],
-			});
-		} catch {
-			before = '';
-		}
-		let after = '';
-		try {
-			const abs = join(root, file);
-			if (existsSync(abs)) after = readFileSync(abs, 'utf8');
-		} catch {
-			after = '';
-		}
-		out[file] = { before, after };
+		const abs = join(root, file);
+		out[file] = {
+			before: showAtRef(root, baseRef, file),
+			after: existsSync(abs) ? readFileSync(abs, 'utf8') : '',
+		};
 	}
 	return out;
 }

--- a/packages/testing/janitor/src/core/read-manifest-diffs.ts
+++ b/packages/testing/janitor/src/core/read-manifest-diffs.ts
@@ -10,6 +10,16 @@ import { getFileAtRef, getGitRoot } from '../utils/git-operations.js';
 
 const isManifest = (file: string): boolean => /(^|\/)package\.json$/.test(file);
 
+/** Read the working-tree file, or '' on any failure (missing, unreadable, or a
+ *  TOCTOU delete between the existsSync check and the read). */
+function readWorkingTree(abs: string): string {
+	try {
+		return existsSync(abs) ? readFileSync(abs, 'utf8') : '';
+	} catch {
+		return '';
+	}
+}
+
 export function readManifestDiffs(
 	changedFiles: string[],
 	baseRef: string,
@@ -22,7 +32,7 @@ export function readManifestDiffs(
 		const abs = join(root, file);
 		out[file] = {
 			before: getFileAtRef(file, baseRef) ?? '',
-			after: existsSync(abs) ? readFileSync(abs, 'utf8') : '',
+			after: readWorkingTree(abs),
 		};
 	}
 	return out;

--- a/packages/testing/janitor/src/utils/git-operations.ts
+++ b/packages/testing/janitor/src/utils/git-operations.ts
@@ -24,6 +24,19 @@ export function getGitRoot(cwd: string): string {
 	}
 }
 
+/** Content of `filePath` at git `ref`, or null if it doesn't exist there. */
+export function getFileAtRef(filePath: string, ref: string): string | null {
+	try {
+		const relativePath = path.relative(getGitRoot(process.cwd()), path.resolve(filePath));
+		return execFileSync('git', ['show', `${ref}:${relativePath}`], {
+			encoding: 'utf-8',
+			stdio: ['ignore', 'pipe', 'ignore'],
+		});
+	} catch {
+		return null;
+	}
+}
+
 export function parseGitStatus(
 	output: string,
 	gitRoot: string,

--- a/packages/testing/playwright/scripts/distribute-tests.mjs
+++ b/packages/testing/playwright/scripts/distribute-tests.mjs
@@ -94,13 +94,16 @@ function partitionFiles(filesCsv) {
  *
  * Any thrown error from the wrapper is caught and treated as broad — fail-open.
  */
-function selectV8Specs(externalFiles) {
+function selectV8Specs(externalFiles, base) {
 	if (externalFiles.length === 0)
 		return { broad: false, specs: new Set(), reason: 'no app-source changes' };
 	try {
 		const out = execFileSync('node', [SELECT_AFFECTED_E2E, ...externalFiles], {
 			encoding: 'utf-8',
 			stdio: ['pipe', 'pipe', 'inherit'],
+			// Pass the merge-base so `select` can read changed package.json
+			// before/after and drop a devDependency-only lockfile change.
+			env: { ...process.env, BASE_REF: base ?? '' },
 		});
 		const parsed = JSON.parse(out);
 		if (parsed.mode === 'broad') {
@@ -194,7 +197,7 @@ function getOrchestration(numShards, options = {}) {
  */
 function resolveImpactAllowlist(filesCsv, base) {
 	const { internal, external } = partitionFiles(filesCsv);
-	const v8 = selectV8Specs(external);
+	const v8 = selectV8Specs(external, base);
 	const ast = selectAstSpecs(internal, base);
 
 	// Fail-open: either bails → broad wins. Run everything.

--- a/packages/testing/playwright/scripts/distribute-tests.mjs
+++ b/packages/testing/playwright/scripts/distribute-tests.mjs
@@ -112,6 +112,15 @@ function selectV8Specs(externalFiles, base) {
 				reason: parsed.failOpen ?? `unmapped: ${(parsed.unmapped ?? []).join(', ')}`,
 			};
 		}
+		// Coverage-gap alarm: changes with no E2E that verifies them aren't run
+		// (unit + the sanity spec are the net) — but surface the gap, don't hide it.
+		if (parsed.uncovered?.length) {
+			const sample = parsed.uncovered.slice(0, 5).join(', ');
+			const more = parsed.uncovered.length > 5 ? `, +${parsed.uncovered.length - 5} more` : '';
+			console.error(
+				`  ⚠ ${parsed.uncovered.length} changed file(s) have no E2E coverage — not run, relying on unit + sanity: ${sample}${more}`,
+			);
+		}
 		return { broad: false, specs: new Set(parsed.specs ?? []) };
 	} catch (error) {
 		return { broad: true, reason: `select-e2e failed: ${String(error)}` };

--- a/packages/testing/playwright/scripts/select-affected-e2e.mjs
+++ b/packages/testing/playwright/scripts/select-affected-e2e.mjs
@@ -53,20 +53,30 @@ export function resolveMapPath(opts = {}) {
  * can be tested without spawning a subprocess. If `mapPath` is null we omit
  * `--map`, which makes select-e2e fail open to broad.
  *
- * @param {{ changedFiles: string, mapPath: string | null, allSpecs?: string }} input
+ * `base` (the merge-base git ref) lets `select` read changed package.json
+ * before/after so a devDependency-only lockfile change drops out of selection.
+ * Omitted → `select` keeps the conservative (broad) behaviour for dep changes.
+ *
+ * @param {{ changedFiles: string, mapPath: string | null, allSpecs?: string, base?: string }} input
  * @returns {string[]}
  */
-export function buildArgs({ changedFiles, mapPath, allSpecs }) {
+export function buildArgs({ changedFiles, mapPath, allSpecs, base }) {
 	const args = ['select', `--changed-files=${changedFiles}`];
 	if (mapPath) args.push(`--map=${mapPath}`);
 	if (allSpecs) args.push(`--all-specs=${allSpecs}`);
+	if (base) args.push(`--base=${base}`);
 	return args;
 }
 
 function runAsScript() {
 	const changedFiles = process.argv.slice(2).join(',') || process.env.CHANGED_FILES || '';
 	const mapPath = resolveMapPath();
-	const args = buildArgs({ changedFiles, mapPath, allSpecs: process.env.ALL_SPECS_FILE });
+	const args = buildArgs({
+		changedFiles,
+		mapPath,
+		allSpecs: process.env.ALL_SPECS_FILE,
+		base: process.env.BASE_REF,
+	});
 	const out = execFileSync('node', [JANITOR_CLI, ...args], { encoding: 'utf-8' });
 	process.stdout.write(out);
 }

--- a/packages/testing/test-impact/src/changes.test.ts
+++ b/packages/testing/test-impact/src/changes.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 
-import { isNonImpactful, filterImpactfulChanges } from './changes.js';
+import {
+	isNonImpactful,
+	filterImpactfulChanges,
+	classifyManifestChange,
+	dropDevDepOnlyDeps,
+} from './changes.js';
 
 describe('isNonImpactful', () => {
 	it.each([
@@ -65,5 +70,71 @@ describe('filterImpactfulChanges', () => {
 	it('is a no-op when nothing is ignored', () => {
 		const files = ['packages/cli/src/a.ts', 'pnpm-lock.yaml', 'docker/Dockerfile'];
 		expect(filterImpactfulChanges(files)).toEqual(files);
+	});
+});
+
+const pkg = (deps = {}, devDeps = {}, extra = {}) =>
+	JSON.stringify({ name: 'x', dependencies: deps, devDependencies: devDeps, ...extra });
+
+describe('classifyManifestChange', () => {
+	it('runtime when a dependencies version moves', () => {
+		expect(classifyManifestChange(pkg({ axios: '1.0.0' }), pkg({ axios: '1.1.0' }))).toBe(
+			'runtime',
+		);
+	});
+	it('runtime when a runtime dep is added', () => {
+		expect(classifyManifestChange(pkg(), pkg({ lodash: '4.0.0' }))).toBe('runtime');
+	});
+	it('runtime for peer/optional dependency changes', () => {
+		const before = JSON.stringify({ peerDependencies: { react: '18' } });
+		const after = JSON.stringify({ peerDependencies: { react: '19' } });
+		expect(classifyManifestChange(before, after)).toBe('runtime');
+	});
+	it('devDep-only when only devDependencies move', () => {
+		expect(
+			classifyManifestChange(
+				pkg({ axios: '1' }, { vitest: '1' }),
+				pkg({ axios: '1' }, { vitest: '2' }),
+			),
+		).toBe('devDep-only');
+	});
+	it('none when no dependency section changes', () => {
+		expect(
+			classifyManifestChange(pkg({}, {}, { version: '1.0.0' }), pkg({}, {}, { version: '1.0.1' })),
+		).toBe('none');
+	});
+	it('does not throw on unparseable content', () => {
+		expect(classifyManifestChange('not json', pkg({}, { vitest: '1' }))).toBe('devDep-only');
+	});
+});
+
+describe('dropDevDepOnlyDeps (safety-critical)', () => {
+	const diff = (before: string, after: string) => ({ before, after });
+	const devOnly = diff(pkg({}, { vitest: '1' }), pkg({}, { vitest: '2' }));
+	const runtime = diff(pkg({ axios: '1' }), pkg({ axios: '2' }));
+
+	it('drops lockfile + manifest when the change is devDep-only', () => {
+		const files = ['pnpm-lock.yaml', 'packages/cli/package.json', 'packages/cli/src/a.ts'];
+		expect(dropDevDepOnlyDeps(files, { 'packages/cli/package.json': devOnly })).toEqual([
+			'packages/cli/src/a.ts',
+		]);
+	});
+	it('KEEPS everything when a runtime dependency changed', () => {
+		const files = ['pnpm-lock.yaml', 'packages/cli/package.json'];
+		expect(dropDevDepOnlyDeps(files, { 'packages/cli/package.json': runtime })).toEqual(files);
+	});
+	it('KEEPS when a changed manifest has no supplied diff (conservative → runtime)', () => {
+		const files = ['pnpm-lock.yaml', 'packages/cli/package.json'];
+		expect(dropDevDepOnlyDeps(files, {})).toEqual(files);
+	});
+	it('KEEPS a lockfile-only (transitive) bump with no changed manifest', () => {
+		const files = ['pnpm-lock.yaml', 'packages/cli/src/a.ts'];
+		expect(dropDevDepOnlyDeps(files, {})).toEqual(files);
+	});
+	it('mixed devDep-only + runtime manifests → keeps all', () => {
+		const files = ['pnpm-lock.yaml', 'a/package.json', 'b/package.json'];
+		expect(
+			dropDevDepOnlyDeps(files, { 'a/package.json': devOnly, 'b/package.json': runtime }),
+		).toEqual(files);
 	});
 });

--- a/packages/testing/test-impact/src/changes.test.ts
+++ b/packages/testing/test-impact/src/changes.test.ts
@@ -81,6 +81,7 @@ describe('forcesBroad', () => {
 		'packages/testing/containers/services/n8n.ts',
 		'packages/cli/Dockerfile',
 		'Dockerfile.dev',
+		'packages/cli/worker.Dockerfile',
 	])('treats %s as runtime-defining (force broad)', (file) => {
 		expect(forcesBroad(file)).toBe(true);
 	});

--- a/packages/testing/test-impact/src/changes.test.ts
+++ b/packages/testing/test-impact/src/changes.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 import {
 	isNonImpactful,
 	filterImpactfulChanges,
+	forcesBroad,
 	classifyManifestChange,
 	dropDevDepOnlyDeps,
 } from './changes.js';
@@ -70,6 +71,26 @@ describe('filterImpactfulChanges', () => {
 	it('is a no-op when nothing is ignored', () => {
 		const files = ['packages/cli/src/a.ts', 'pnpm-lock.yaml', 'docker/Dockerfile'];
 		expect(filterImpactfulChanges(files)).toEqual(files);
+	});
+});
+
+describe('forcesBroad', () => {
+	it.each([
+		'docker/images/n8n/Dockerfile',
+		'docker/compose/base.yml',
+		'packages/testing/containers/services/n8n.ts',
+		'packages/cli/Dockerfile',
+		'Dockerfile.dev',
+	])('treats %s as runtime-defining (force broad)', (file) => {
+		expect(forcesBroad(file)).toBe(true);
+	});
+
+	it.each([
+		'packages/cli/src/server.ts',
+		'packages/testing/playwright/tests/e2e/x.spec.ts',
+		'packages/nodes-base/nodes/If/If.node.ts',
+	])('does not force broad for %s', (file) => {
+		expect(forcesBroad(file)).toBe(false);
 	});
 });
 

--- a/packages/testing/test-impact/src/changes.test.ts
+++ b/packages/testing/test-impact/src/changes.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+
+import { isNonImpactful, filterImpactfulChanges } from './changes.js';
+
+describe('isNonImpactful', () => {
+	it.each([
+		'.claude/skills/foo.md',
+		'.claude/agents/bar.json',
+		'.vscode/settings.json',
+		'.idea/workspace.xml',
+		'.editorconfig',
+		'.gitattributes',
+		'README.mdx',
+		'packages/cli/CHANGELOG.md',
+		'LICENSE',
+		'cspell.json',
+		'packages/x/project-words.dic',
+		'docs/images/diagram.png',
+		'assets/logo.svg',
+		'scripts/release/build.mjs',
+		'turbo.json',
+		'tsconfig.json',
+		'packages/cli/tsconfig.build.json',
+		'biome.jsonc',
+		'packages/testing/test-impact/jest.config.ts',
+		'.eslintrc.js',
+	])('treats %s as non-impactful', (file) => {
+		expect(isNonImpactful(file)).toBe(true);
+	});
+
+	it.each([
+		// Real product source — must NOT be ignored
+		'packages/nodes-base/nodes/If/If.node.ts',
+		'packages/frontend/editor-ui/src/App.vue',
+		// Surgical: real *.json source data is NOT a "config file"
+		'packages/nodes-base/nodes/Slack/Slack.node.json',
+		'packages/@n8n/i18n/src/locales/en.json',
+		// Dependency changes — handled by devDep classifier / dep-graph, not ignored
+		'pnpm-lock.yaml',
+		'packages/cli/package.json',
+		// Container + patches affect runtime / a dependency — never ignored
+		'docker/images/n8n/Dockerfile',
+		'patches/some-dep.patch',
+	])('treats %s as impactful', (file) => {
+		expect(isNonImpactful(file)).toBe(false);
+	});
+});
+
+describe('filterImpactfulChanges', () => {
+	it('drops non-impactful paths, keeps real source', () => {
+		expect(
+			filterImpactfulChanges([
+				'packages/nodes-base/nodes/If/If.node.ts',
+				'.claude/skills/x.md',
+				'scripts/y.mjs',
+				'turbo.json',
+			]),
+		).toEqual(['packages/nodes-base/nodes/If/If.node.ts']);
+	});
+
+	it('returns empty when every change is non-impactful (→ caller skips)', () => {
+		expect(filterImpactfulChanges(['.claude/x.md', 'scripts/y.mjs', '.editorconfig'])).toEqual([]);
+	});
+
+	it('is a no-op when nothing is ignored', () => {
+		const files = ['packages/cli/src/a.ts', 'pnpm-lock.yaml', 'docker/Dockerfile'];
+		expect(filterImpactfulChanges(files)).toEqual(files);
+	});
+});

--- a/packages/testing/test-impact/src/changes.ts
+++ b/packages/testing/test-impact/src/changes.ts
@@ -51,6 +51,23 @@ export function filterImpactfulChanges(files: string[]): string[] {
 	return files.filter((file) => !isNonImpactful(file));
 }
 
+/**
+ * Paths that define the runtime the WHOLE E2E suite executes in — the container
+ * image and the container harness. The coverage map can't attribute these (a
+ * change here can reach any spec), so they force a broad run rather than being
+ * declared uncovered. This is a small, low-churn set, so broad is cheap here.
+ */
+const FORCES_BROAD: Array<(f: string) => boolean> = [
+	(f) => f.startsWith('docker/'),
+	(f) => /(^|\/)Dockerfile(\.|$)/.test(f),
+	(f) => f.startsWith('packages/testing/containers/'),
+];
+
+/** True if a changed file defines the E2E runtime → the whole suite must run. */
+export function forcesBroad(file: string): boolean {
+	return FORCES_BROAD.some((matches) => matches(file));
+}
+
 /** A package.json change classified by which dependency sections moved. */
 export type ManifestChangeKind = 'runtime' | 'devDep-only' | 'none';
 

--- a/packages/testing/test-impact/src/changes.ts
+++ b/packages/testing/test-impact/src/changes.ts
@@ -1,0 +1,52 @@
+/**
+ * Classify changed files for impact selection.
+ *
+ * Some changed paths cannot affect the runtime the E2E suite exercises — repo
+ * tooling, docs, editor config. Left in the changed-set they have no map entry,
+ * so they hit the unmapped → broad fallback and drag an otherwise-scoped PR to
+ * the full suite. Dropping them before selection is a pure win: they can't run
+ * a real test regardless, so we only ever decline to run things that can't run.
+ *
+ * SURGICAL by design: only *named* config files are ignored — never all
+ * `*.json` / `*.yaml`, because node descriptions, i18n catalogues and test
+ * fixtures are real source data the map legitimately keys on.
+ *
+ * NOT ignored (deliberately): `docker`/Dockerfiles (define the container the
+ * E2E suite runs in), `pnpm-lock.yaml`/`package.json` (dependency changes —
+ * handled by the devDep classifier / dep-graph selector), and `patches/**`
+ * (edits a dependency's code = a dependency change).
+ */
+
+const NON_IMPACTFUL: Array<(f: string) => boolean> = [
+	// Agent / editor / repo tooling
+	(f) => f.startsWith('.claude/'),
+	(f) => /^\.(vscode|idea)\//.test(f),
+	(f) =>
+		/(^|\/)\.(editorconfig|gitattributes|gitignore|npmrc|nvmrc|prettierignore|eslintignore)$/.test(
+			f,
+		),
+	// Docs + dictionaries + doc assets
+	(f) => /\.mdx?$/.test(f) || /(^|\/)(LICENSE|CHANGELOG\.md)$/.test(f),
+	(f) => /cspell|\.dic$/i.test(f),
+	(f) => /^(docs|assets)\/.*\.(png|jpe?g|gif|svg|webp)$/.test(f),
+	// Repo automation scripts (not shipped, not exercised by E2E)
+	(f) => f.startsWith('scripts/'),
+	// Named build / lint / test-runner config (NOT all json/yaml)
+	(f) =>
+		/(^|\/)(turbo\.json|tsconfig([.\w-]*)\.json|biome\.jsonc?|jest\.config\.[cm]?[jt]s|\.eslintrc[\w.]*|\.prettierrc[\w.]*)$/.test(
+			f,
+		),
+];
+
+/** True if a changed file cannot affect the runtime the E2E suite exercises. */
+export function isNonImpactful(file: string): boolean {
+	return NON_IMPACTFUL.some((matches) => matches(file));
+}
+
+/**
+ * Drop non-impactful paths from a changed-file set so they don't force a broad
+ * selection. Apply this once, at the entry, before any selector sees the files.
+ */
+export function filterImpactfulChanges(files: string[]): string[] {
+	return files.filter((file) => !isNonImpactful(file));
+}

--- a/packages/testing/test-impact/src/changes.ts
+++ b/packages/testing/test-impact/src/changes.ts
@@ -123,7 +123,7 @@ export function classifyManifestChange(before: string, after: string): ManifestC
 
 /**
  * Names of the *runtime* dependencies (dependencies / optional / peer) that
- * changed between two manifests — the input to the dep-graph selector (389),
+ * changed between two manifests — the input to the dep-graph selector,
  * which walks each name to the workspace packages that declare it. devDeps are
  * excluded (they can't reach the runtime bundle).
  */

--- a/packages/testing/test-impact/src/changes.ts
+++ b/packages/testing/test-impact/src/changes.ts
@@ -65,13 +65,23 @@ function parseManifest(raw: string): ManifestJson {
 	}
 }
 
-function sectionChanged(before: ManifestJson, after: ManifestJson, section: string): boolean {
+/** Dependency names added / removed / version-changed in one manifest section. */
+function changedKeysInSection(
+	before: ManifestJson,
+	after: ManifestJson,
+	section: string,
+): string[] {
 	const b = before[section] ?? {};
 	const a = after[section] ?? {};
+	const changed: string[] = [];
 	for (const key of new Set([...Object.keys(b), ...Object.keys(a)])) {
-		if (b[key] !== a[key]) return true;
+		if (b[key] !== a[key]) changed.push(key);
 	}
-	return false;
+	return changed;
+}
+
+function sectionChanged(before: ManifestJson, after: ManifestJson, section: string): boolean {
+	return changedKeysInSection(before, after, section).length > 0;
 }
 
 /**
@@ -89,8 +99,40 @@ export function classifyManifestChange(before: string, after: string): ManifestC
 	return sectionChanged(b, a, 'devDependencies') ? 'devDep-only' : 'none';
 }
 
+/**
+ * Names of the *runtime* dependencies (dependencies / optional / peer) that
+ * changed between two manifests — the input to the dep-graph selector (389),
+ * which walks each name to the workspace packages that declare it. devDeps are
+ * excluded (they can't reach the runtime bundle).
+ */
+export function changedRuntimeDeps(before: string, after: string): string[] {
+	const b = parseManifest(before);
+	const a = parseManifest(after);
+	const names = new Set<string>();
+	for (const section of RUNTIME_SECTIONS) {
+		for (const name of changedKeysInSection(b, a, section)) names.add(name);
+	}
+	return [...names];
+}
+
+/** {@link changedRuntimeDeps} unioned across every changed manifest. */
+export function changedRuntimeDepsFromManifests(
+	manifests: Record<string, { before: string; after: string }>,
+): string[] {
+	const names = new Set<string>();
+	for (const { before, after } of Object.values(manifests)) {
+		for (const name of changedRuntimeDeps(before, after)) names.add(name);
+	}
+	return [...names];
+}
+
 const isManifest = (f: string): boolean => /(^|\/)package\.json$/.test(f);
 const isLockfile = (f: string): boolean => f === 'pnpm-lock.yaml';
+
+/** Remove the lockfile + every package.json from a changed-file set. */
+export function stripDependencyFiles(files: string[]): string[] {
+	return files.filter((f) => !isLockfile(f) && !isManifest(f));
+}
 
 /**
  * Drop the lockfile + manifests from a changed-file set when the dependency
@@ -114,5 +156,5 @@ export function dropDevDepOnlyDeps(
 	);
 	if (kinds.includes('runtime')) return files;
 	if (!kinds.includes('devDep-only')) return files;
-	return files.filter((f) => !isLockfile(f) && !isManifest(f));
+	return stripDependencyFiles(files);
 }

--- a/packages/testing/test-impact/src/changes.ts
+++ b/packages/testing/test-impact/src/changes.ts
@@ -59,7 +59,7 @@ export function filterImpactfulChanges(files: string[]): string[] {
  */
 const FORCES_BROAD: Array<(f: string) => boolean> = [
 	(f) => f.startsWith('docker/'),
-	(f) => /(^|\/)Dockerfile(\.|$)/.test(f),
+	(f) => /(^|\/)Dockerfile(\.|$)|\.Dockerfile$/.test(f),
 	(f) => f.startsWith('packages/testing/containers/'),
 ];
 
@@ -72,7 +72,12 @@ export function forcesBroad(file: string): boolean {
 export type ManifestChangeKind = 'runtime' | 'devDep-only' | 'none';
 
 type ManifestJson = Record<string, Record<string, string> | undefined>;
-const RUNTIME_SECTIONS = ['dependencies', 'optionalDependencies', 'peerDependencies'] as const;
+/** package.json sections whose changes can reach the runtime bundle. */
+export const RUNTIME_SECTIONS = [
+	'dependencies',
+	'optionalDependencies',
+	'peerDependencies',
+] as const;
 
 function parseManifest(raw: string): ManifestJson {
 	try {

--- a/packages/testing/test-impact/src/changes.ts
+++ b/packages/testing/test-impact/src/changes.ts
@@ -50,3 +50,69 @@ export function isNonImpactful(file: string): boolean {
 export function filterImpactfulChanges(files: string[]): string[] {
 	return files.filter((file) => !isNonImpactful(file));
 }
+
+/** A package.json change classified by which dependency sections moved. */
+export type ManifestChangeKind = 'runtime' | 'devDep-only' | 'none';
+
+type ManifestJson = Record<string, Record<string, string> | undefined>;
+const RUNTIME_SECTIONS = ['dependencies', 'optionalDependencies', 'peerDependencies'] as const;
+
+function parseManifest(raw: string): ManifestJson {
+	try {
+		return JSON.parse(raw) as ManifestJson;
+	} catch {
+		return {};
+	}
+}
+
+function sectionChanged(before: ManifestJson, after: ManifestJson, section: string): boolean {
+	const b = before[section] ?? {};
+	const a = after[section] ?? {};
+	for (const key of new Set([...Object.keys(b), ...Object.keys(a)])) {
+		if (b[key] !== a[key]) return true;
+	}
+	return false;
+}
+
+/**
+ * Classify a package.json change by the dependency sections it touched:
+ *  - `runtime`     — a runtime section (dependencies / optional / peer) moved, so
+ *                    it can reach the bundle the E2E suite exercises.
+ *  - `devDep-only` — only devDependencies moved → cannot reach the runtime bundle.
+ *  - `none`        — no dependency section moved (scripts / version / engines / …).
+ * Unparseable content is treated as an empty manifest.
+ */
+export function classifyManifestChange(before: string, after: string): ManifestChangeKind {
+	const b = parseManifest(before);
+	const a = parseManifest(after);
+	if (RUNTIME_SECTIONS.some((s) => sectionChanged(b, a, s))) return 'runtime';
+	return sectionChanged(b, a, 'devDependencies') ? 'devDep-only' : 'none';
+}
+
+const isManifest = (f: string): boolean => /(^|\/)package\.json$/.test(f);
+const isLockfile = (f: string): boolean => f === 'pnpm-lock.yaml';
+
+/**
+ * Drop the lockfile + manifests from a changed-file set when the dependency
+ * change is provably devDependencies-only — a devDep can't reach the runtime
+ * bundle, so it must not force broad. `manifests` maps each changed package.json
+ * path to its before/after content (the caller reads these from git).
+ *
+ * Conservative by construction — never drops without positive evidence:
+ *  - any runtime-section change → keep everything (real dep change);
+ *  - a changed package.json with no supplied diff → treated as runtime;
+ *  - a lockfile change with no changed package.json at all (transitive bump) → kept.
+ */
+export function dropDevDepOnlyDeps(
+	files: string[],
+	manifests: Record<string, { before: string; after: string }>,
+): string[] {
+	const changedManifests = files.filter(isManifest);
+	if (changedManifests.length === 0) return files;
+	const kinds = changedManifests.map((f) =>
+		manifests[f] ? classifyManifestChange(manifests[f].before, manifests[f].after) : 'runtime',
+	);
+	if (kinds.includes('runtime')) return files;
+	if (!kinds.includes('devDep-only')) return files;
+	return files.filter((f) => !isLockfile(f) && !isManifest(f));
+}

--- a/packages/testing/test-impact/src/dep-graph.test.ts
+++ b/packages/testing/test-impact/src/dep-graph.test.ts
@@ -95,6 +95,17 @@ describe('DependencyGraphStrategy', () => {
 		expect(r.specs).toEqual(['tests/e2e/a.spec.ts', 'tests/e2e/b.spec.ts']);
 	});
 
+	// A mix of an attributable dep and an unattributable one must go broad: scoping
+	// to just the attributable dep would silently drop the dep we can't attribute.
+	it('fails open to broad when any changed dep is unattributable', () => {
+		const r = new DependencyGraphStrategy(map, importers, ['axios', 'left-pad'], {
+			allSpecs: ['tests/e2e/a.spec.ts', 'tests/e2e/b.spec.ts'],
+		}).resolve();
+		expect(r.mode).toBe('broad');
+		expect(r.specs).toEqual(['tests/e2e/a.spec.ts', 'tests/e2e/b.spec.ts']);
+		expect(r.unmapped).toEqual(['left-pad']);
+	});
+
 	it('contributes nothing when there are no changed deps', () => {
 		const r = new DependencyGraphStrategy(map, importers, []).resolve();
 		expect(r).toEqual({ specs: [], unmapped: [], mode: 'scoped' });

--- a/packages/testing/test-impact/src/dep-graph.test.ts
+++ b/packages/testing/test-impact/src/dep-graph.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+	changedRuntimeDeps,
+	changedRuntimeDepsFromManifests,
+	stripDependencyFiles,
+} from './changes.js';
+import { dependentDirs } from './dep-graph.js';
+import type { ImpactMap } from './impact-map.js';
+import { DependencyGraphStrategy } from './select/dep-graph-strategy.js';
+
+const pkg = (deps = {}, devDeps = {}, peer = {}) =>
+	JSON.stringify({ dependencies: deps, devDependencies: devDeps, peerDependencies: peer });
+
+describe('changedRuntimeDeps', () => {
+	it('returns the runtime dep whose version moved', () => {
+		expect(changedRuntimeDeps(pkg({ axios: '1.0.0' }), pkg({ axios: '1.1.0' }))).toEqual(['axios']);
+	});
+	it('includes added and removed runtime deps', () => {
+		expect(changedRuntimeDeps(pkg({ a: '1' }), pkg({ b: '1' })).sort()).toEqual(['a', 'b']);
+	});
+	it('counts peer dependency changes as runtime', () => {
+		expect(changedRuntimeDeps(pkg({}, {}, { react: '18' }), pkg({}, {}, { react: '19' }))).toEqual([
+			'react',
+		]);
+	});
+	it('excludes devDependency changes', () => {
+		expect(changedRuntimeDeps(pkg({}, { vitest: '1' }), pkg({}, { vitest: '2' }))).toEqual([]);
+	});
+});
+
+describe('changedRuntimeDepsFromManifests', () => {
+	it('unions runtime deps across manifests, de-duplicated', () => {
+		const manifests = {
+			'a/package.json': { before: pkg({ axios: '1' }), after: pkg({ axios: '2' }) },
+			'b/package.json': {
+				before: pkg({ axios: '1', ms: '1' }),
+				after: pkg({ axios: '1', ms: '2' }),
+			},
+		};
+		expect(changedRuntimeDepsFromManifests(manifests).sort()).toEqual(['axios', 'ms']);
+	});
+});
+
+describe('stripDependencyFiles', () => {
+	it('removes the lockfile and every package.json, keeps source', () => {
+		expect(
+			stripDependencyFiles([
+				'pnpm-lock.yaml',
+				'packages/cli/package.json',
+				'packages/cli/src/a.ts',
+			]),
+		).toEqual(['packages/cli/src/a.ts']);
+	});
+});
+
+describe('dependentDirs', () => {
+	const importers = {
+		'packages/cli': ['axios', 'express'],
+		'packages/@n8n/nodes-langchain': ['@aws-sdk/client-bedrock-runtime'],
+		'packages/core': ['axios'],
+	};
+	it('returns every workspace dir declaring any of the deps, sorted', () => {
+		expect(dependentDirs(['axios'], importers)).toEqual(['packages/cli', 'packages/core']);
+	});
+	it('returns [] for a dep no workspace package declares (transitive)', () => {
+		expect(dependentDirs(['left-pad'], importers)).toEqual([]);
+	});
+});
+
+describe('DependencyGraphStrategy', () => {
+	// leaf is covered by one spec; cli by another.
+	const map: ImpactMap = {
+		'packages/@n8n/nodes-langchain/src/index.ts': { '0': ['tests/e2e/langchain.spec.ts'] },
+		'packages/cli/src/server.ts': { '0': ['tests/e2e/server.spec.ts'] },
+	};
+	const importers = {
+		'packages/@n8n/nodes-langchain': ['@aws-sdk/client-bedrock-runtime'],
+		'packages/cli': ['axios'],
+	};
+
+	it('scopes a leaf-only dep to that package’s specs', () => {
+		const r = new DependencyGraphStrategy(map, importers, [
+			'@aws-sdk/client-bedrock-runtime',
+		]).resolve();
+		expect(r.mode).toBe('scoped');
+		expect(r.specs).toEqual(['tests/e2e/langchain.spec.ts']);
+	});
+
+	it('fails open to broad when no workspace package declares the dep', () => {
+		const r = new DependencyGraphStrategy(map, importers, ['left-pad'], {
+			allSpecs: ['tests/e2e/a.spec.ts', 'tests/e2e/b.spec.ts'],
+		}).resolve();
+		expect(r.mode).toBe('broad');
+		expect(r.specs).toEqual(['tests/e2e/a.spec.ts', 'tests/e2e/b.spec.ts']);
+	});
+
+	it('contributes nothing when there are no changed deps', () => {
+		const r = new DependencyGraphStrategy(map, importers, []).resolve();
+		expect(r).toEqual({ specs: [], unmapped: [], mode: 'scoped' });
+	});
+});

--- a/packages/testing/test-impact/src/dep-graph.ts
+++ b/packages/testing/test-impact/src/dep-graph.ts
@@ -1,0 +1,31 @@
+/**
+ * Workspace dependency-graph walk for the dep-graph selector (DEVP-389).
+ *
+ * A changed dependency isn't a source file, so the coverage map has no entry for
+ * it and a dep bump fails open to broad. This walks the other way: a changed dep
+ * name → the workspace packages that declare it → (via the coverage map) the
+ * specs that exercise those packages. A dep used only by a leaf package then
+ * scopes to that leaf instead of running the whole suite.
+ *
+ * Pure: the caller supplies `importers` — each workspace package dir mapped to
+ * the runtime dependency names it declares (parsed from pnpm-lock.yaml's
+ * `importers` section). No subprocess, no yaml dependency here.
+ */
+
+/** Map of workspace package dir → the runtime dependency names it declares. */
+export type WorkspaceImporters = Record<string, string[]>;
+
+/**
+ * The workspace package dirs that declare any of `deps`. These are the *direct*
+ * importers (a dep declared in their package.json). A purely transitive dep —
+ * declared by no workspace package — yields `[]`, which the caller treats as
+ * "can't attribute → broad".
+ */
+export function dependentDirs(deps: string[], importers: WorkspaceImporters): string[] {
+	const wanted = new Set(deps);
+	const dirs: string[] = [];
+	for (const [dir, declared] of Object.entries(importers)) {
+		if (declared.some((name) => wanted.has(name))) dirs.push(dir);
+	}
+	return dirs.sort();
+}

--- a/packages/testing/test-impact/src/dep-graph.ts
+++ b/packages/testing/test-impact/src/dep-graph.ts
@@ -1,5 +1,5 @@
 /**
- * dep-graph selector (DEVP-389): a changed dependency has no coverage-map entry,
+ * dep-graph selector: a changed dependency has no coverage-map entry,
  * so instead of failing open to broad we walk it to the workspace packages that
  * declare it → their specs (via the map). Pure — the caller supplies `importers`
  * (dir → declared runtime deps), parsed from pnpm-lock.yaml elsewhere.

--- a/packages/testing/test-impact/src/dep-graph.ts
+++ b/packages/testing/test-impact/src/dep-graph.ts
@@ -1,26 +1,15 @@
 /**
- * Workspace dependency-graph walk for the dep-graph selector (DEVP-389).
- *
- * A changed dependency isn't a source file, so the coverage map has no entry for
- * it and a dep bump fails open to broad. This walks the other way: a changed dep
- * name → the workspace packages that declare it → (via the coverage map) the
- * specs that exercise those packages. A dep used only by a leaf package then
- * scopes to that leaf instead of running the whole suite.
- *
- * Pure: the caller supplies `importers` — each workspace package dir mapped to
- * the runtime dependency names it declares (parsed from pnpm-lock.yaml's
- * `importers` section). No subprocess, no yaml dependency here.
+ * dep-graph selector (DEVP-389): a changed dependency has no coverage-map entry,
+ * so instead of failing open to broad we walk it to the workspace packages that
+ * declare it → their specs (via the map). Pure — the caller supplies `importers`
+ * (dir → declared runtime deps), parsed from pnpm-lock.yaml elsewhere.
  */
 
-/** Map of workspace package dir → the runtime dependency names it declares. */
+/** Workspace package dir → the runtime dependency names it declares. */
 export type WorkspaceImporters = Record<string, string[]>;
 
-/**
- * The workspace package dirs that declare any of `deps`. These are the *direct*
- * importers (a dep declared in their package.json). A purely transitive dep —
- * declared by no workspace package — yields `[]`, which the caller treats as
- * "can't attribute → broad".
- */
+/** Dirs declaring any of `deps`. A transitive dep (declared by none) → [], which
+ *  the caller treats as "can't attribute → broad". */
 export function dependentDirs(deps: string[], importers: WorkspaceImporters): string[] {
 	const wanted = new Set(deps);
 	const dirs: string[] = [];

--- a/packages/testing/test-impact/src/impact-map.test.ts
+++ b/packages/testing/test-impact/src/impact-map.test.ts
@@ -528,3 +528,33 @@ describe('parseLcov hardening', () => {
 		expect(b.fns).toEqual([{ name: 'shared', line: 0, hits: 2 }]);
 	});
 });
+
+describe('resolveImpact — onUncovered: declare', () => {
+	const map: ImpactMap = {
+		'packages/cli/src/known.ts': { '0': ['tests/e2e/a.spec.ts'] },
+	};
+
+	it('declares an unmapped file instead of forcing broad', () => {
+		const r = resolveImpact(
+			[{ file: 'packages/cli/src/known.ts' }, { file: 'packages/new/src/x.ts' }],
+			map,
+			{ onUncovered: 'declare' },
+		);
+		expect(r.mode).toBe('scoped');
+		expect(r.specs).toEqual(['tests/e2e/a.spec.ts']);
+		expect(r.uncovered).toEqual(['packages/new/src/x.ts']);
+	});
+
+	it('does NOT climb under declare (the sibling-fallback theater is off)', () => {
+		// known.ts is covered; sibling.ts shares its dir. With siblingFallback it
+		// would climb to a.spec.ts; under declare it is reported uncovered instead.
+		const r = resolveImpact([{ file: 'packages/cli/src/sibling.ts' }], map, {
+			onUncovered: 'declare',
+			siblingFallback: true,
+		});
+		expect(r.mode).toBe('scoped');
+		expect(r.specs).toEqual([]);
+		expect(r.uncovered).toEqual(['packages/cli/src/sibling.ts']);
+		expect(r.viaSibling).toBeUndefined();
+	});
+});

--- a/packages/testing/test-impact/src/impact-map.ts
+++ b/packages/testing/test-impact/src/impact-map.ts
@@ -278,6 +278,10 @@ export interface ResolveResult {
 	/** Unmapped files resolved to their nearest covered ancestor directory's specs
 	 *  (sibling fallback). Scoped, not broad. */
 	viaSibling?: string[];
+	/** Changed files with no covering spec, under `onUncovered: 'declare'`: the
+	 *  change has no E2E that verifies it. NOT run (running unrelated specs would
+	 *  be theater) — surfaced as a coverage gap; unit + the sanity spec are the net. */
+	uncovered?: string[];
 	mode: 'scoped' | 'broad';
 }
 
@@ -333,20 +337,35 @@ function buildDirIndex(map: ImpactMap): Map<string, Set<string>> {
  * specs). Only a file with NO covered ancestor at all still forces broad.
  * Deliberate trade: a new file is assumed exercised by the specs that exercise
  * its directory — a sound superset in practice, far cheaper than the whole suite.
+ *
+ * UNCOVERED (`opts.onUncovered`): what to do with a file that has no direct map
+ * entry (and no sibling ancestor). `'broad'` (default) forces the whole suite —
+ * the original fail-open. `'declare'` instead records it in `uncovered` and
+ * selects nothing for it: if no spec exercises the change, running unrelated
+ * specs verifies nothing (theater) and only slows the loop. The change is still
+ * covered by its unit tests + the always-on sanity spec; the gap is surfaced.
+ * Reserve `'broad'` for genuine fail-open (an unusable map) — the caller decides.
  */
 export function resolveImpact(
 	changed: ChangedFile[],
 	map: ImpactMap,
-	opts: { allSpecs?: string[]; siblingFallback?: boolean } = {},
+	opts: { allSpecs?: string[]; siblingFallback?: boolean; onUncovered?: 'broad' | 'declare' } = {},
 ): ResolveResult {
 	const specs = new Set<string>();
 	const unmapped: string[] = [];
 	const viaSibling: string[] = [];
-	const dirIndex = opts.siblingFallback ? buildDirIndex(map) : undefined;
+	const uncovered: string[] = [];
+	const declare = opts.onUncovered === 'declare';
+	const dirIndex = opts.siblingFallback && !declare ? buildDirIndex(map) : undefined;
 
 	for (const { file, lines } of changed) {
 		const fileMap = map[file];
 		if (!fileMap) {
+			if (declare) {
+				// No spec covers this change → don't run theater; surface the gap.
+				uncovered.push(file);
+				continue;
+			}
 			if (dirIndex) {
 				let resolved: Set<string> | undefined;
 				for (let dir = parentDir(file); dir !== '' && !resolved; dir = parentDir(dir)) {
@@ -396,6 +415,7 @@ export function resolveImpact(
 		specs: [...specs].sort(),
 		unmapped,
 		...(viaSibling.length ? { viaSibling } : {}),
+		...(uncovered.length ? { uncovered } : {}),
 		mode,
 	};
 }

--- a/packages/testing/test-impact/src/index.ts
+++ b/packages/testing/test-impact/src/index.ts
@@ -14,11 +14,16 @@ export {
 	filterImpactfulChanges,
 	classifyManifestChange,
 	dropDevDepOnlyDeps,
+	changedRuntimeDeps,
+	changedRuntimeDepsFromManifests,
+	stripDependencyFiles,
 	type ManifestChangeKind,
 } from './changes.js';
+export { dependentDirs, type WorkspaceImporters } from './dep-graph.js';
 export type { DiscoveredSpec } from './types.js';
 
 // Strategy + Pipeline selection layer.
 export type { SelectionStrategy } from './select/strategy.js';
 export { CoverageMapStrategy } from './select/coverage-map-strategy.js';
+export { DependencyGraphStrategy } from './select/dep-graph-strategy.js';
 export { selectImpactedTests } from './select/pipeline.js';

--- a/packages/testing/test-impact/src/index.ts
+++ b/packages/testing/test-impact/src/index.ts
@@ -18,6 +18,7 @@ export {
 	changedRuntimeDeps,
 	changedRuntimeDepsFromManifests,
 	stripDependencyFiles,
+	RUNTIME_SECTIONS,
 	type ManifestChangeKind,
 } from './changes.js';
 export { dependentDirs, type WorkspaceImporters } from './dep-graph.js';

--- a/packages/testing/test-impact/src/index.ts
+++ b/packages/testing/test-impact/src/index.ts
@@ -9,6 +9,7 @@ export * from './impact-map.js';
 export * from './shard-distributor.js';
 export * from './select.js';
 export * from './map-build.js';
+export { isNonImpactful, filterImpactfulChanges } from './changes.js';
 export type { DiscoveredSpec } from './types.js';
 
 // Strategy + Pipeline selection layer.

--- a/packages/testing/test-impact/src/index.ts
+++ b/packages/testing/test-impact/src/index.ts
@@ -9,7 +9,13 @@ export * from './impact-map.js';
 export * from './shard-distributor.js';
 export * from './select.js';
 export * from './map-build.js';
-export { isNonImpactful, filterImpactfulChanges } from './changes.js';
+export {
+	isNonImpactful,
+	filterImpactfulChanges,
+	classifyManifestChange,
+	dropDevDepOnlyDeps,
+	type ManifestChangeKind,
+} from './changes.js';
 export type { DiscoveredSpec } from './types.js';
 
 // Strategy + Pipeline selection layer.

--- a/packages/testing/test-impact/src/index.ts
+++ b/packages/testing/test-impact/src/index.ts
@@ -12,6 +12,7 @@ export * from './map-build.js';
 export {
 	isNonImpactful,
 	filterImpactfulChanges,
+	forcesBroad,
 	classifyManifestChange,
 	dropDevDepOnlyDeps,
 	changedRuntimeDeps,

--- a/packages/testing/test-impact/src/select.test.ts
+++ b/packages/testing/test-impact/src/select.test.ts
@@ -65,10 +65,10 @@ describe('selectTests — fail-open contract', () => {
 		expect(result.specs).toEqual([...ALL_SPECS].sort());
 	});
 
-	// THE COLLAPSE: empty map → every changed file is unmapped → resolveImpact
-	// returns broad. If a refactor ever makes resolveImpact({}, …) return scoped/
-	// empty, every other test still passes — this one fails. That is the point.
-	it('empty map {} → broad (the fail-open collapse)', () => {
+	// THE COLLAPSE: an empty map carries no coverage data — a build/data failure.
+	// It must fail open to broad, NOT declare every change uncovered and skip E2E.
+	// If a refactor ever makes an empty map resolve scoped/empty, this fails. The point.
+	it('empty map {} → broad via fail-open (no coverage data)', () => {
 		const mapPath = path.join(tempDir, 'empty.json');
 		fs.writeFileSync(mapPath, '{}');
 		const result = selectTests({
@@ -77,10 +77,9 @@ describe('selectTests — fail-open contract', () => {
 			allSpecsFile: writeAllSpecs(ALL_SPECS.join('\n')),
 		});
 		expect(result.mode).toBe('broad');
-		// File was loaded successfully — no failOpen reason. The broad comes from
-		// resolveImpact's DEFAULT-BROAD rule (changed file absent from the map).
-		expect(result.failOpen).toBeUndefined();
-		expect(result.unmapped).toEqual(['packages/cli/src/x.ts']);
+		// An empty map is now an explicit fail-open (infra/data failure), not a
+		// silent broad from per-file unmapped — so it carries a reason.
+		expect(result.failOpen).toBe('empty map (no coverage data)');
 		expect(result.specs).toEqual([...ALL_SPECS].sort());
 	});
 
@@ -99,6 +98,40 @@ describe('selectTests — fail-open contract', () => {
 		expect(result.mode).toBe('scoped');
 		expect(result.failOpen).toBeUndefined();
 		expect(result.specs).toEqual(['tests/e2e/a.spec.ts']);
+	});
+
+	// verify-or-declare: a HEALTHY map with no entry for the change is a coverage
+	// gap, not an infra failure → declare it uncovered (surfaced, not run), never
+	// broad. Distinct from the empty-map / no-map fail-open cases above.
+	it('healthy map + unmapped source file → scoped + uncovered, not broad', () => {
+		const map: ImpactMap = { 'packages/cli/src/x.ts': { '10': ['tests/e2e/a.spec.ts'] } };
+		const mapPath = path.join(tempDir, 'map.json');
+		fs.writeFileSync(mapPath, JSON.stringify(map));
+		const result = selectTests({
+			changedFiles: ['packages/nodes-base/nodes/Markdown/Markdown.node.ts'],
+			mapFile: mapPath,
+			allSpecsFile: writeAllSpecs(ALL_SPECS.join('\n')),
+		});
+		expect(result.mode).toBe('scoped');
+		expect(result.specs).toEqual([]);
+		expect(result.uncovered).toEqual(['packages/nodes-base/nodes/Markdown/Markdown.node.ts']);
+		expect(result.failOpen).toBeUndefined();
+	});
+
+	// A dependency change we cannot attribute (lockfile bump, no manifest diff to
+	// classify, no importers walk) must stay broad — NOT be declared uncovered and
+	// skipped. A dep can reach anything; only source files are declared uncovered.
+	it('unattributable dependency change (lockfile only) → broad, not uncovered', () => {
+		const map: ImpactMap = { 'packages/cli/src/x.ts': { '10': ['tests/e2e/a.spec.ts'] } };
+		const mapPath = path.join(tempDir, 'map-dep.json');
+		fs.writeFileSync(mapPath, JSON.stringify(map));
+		const result = selectTests({
+			changedFiles: ['pnpm-lock.yaml'],
+			mapFile: mapPath,
+			allSpecsFile: writeAllSpecs(ALL_SPECS.join('\n')),
+		});
+		expect(result.mode).toBe('broad');
+		expect(result.specs).toEqual([...ALL_SPECS].sort());
 	});
 
 	describe('--all-specs parsing', () => {

--- a/packages/testing/test-impact/src/select.test.ts
+++ b/packages/testing/test-impact/src/select.test.ts
@@ -134,6 +134,44 @@ describe('selectTests — fail-open contract', () => {
 		expect(result.specs).toEqual([...ALL_SPECS].sort());
 	});
 
+	it('package.json change with NO dependency change (version) → uncovered, not broad', () => {
+		const map: ImpactMap = { 'packages/cli/src/x.ts': { '10': ['tests/e2e/a.spec.ts'] } };
+		const mapPath = path.join(tempDir, 'map-ver.json');
+		fs.writeFileSync(mapPath, JSON.stringify(map));
+		const result = selectTests({
+			changedFiles: ['packages/cli/package.json'],
+			mapFile: mapPath,
+			allSpecsFile: writeAllSpecs(ALL_SPECS.join('\n')),
+			manifests: {
+				'packages/cli/package.json': {
+					before: JSON.stringify({ version: '1.0.0', dependencies: { axios: '1' } }),
+					after: JSON.stringify({ version: '1.0.1', dependencies: { axios: '1' } }),
+				},
+			},
+		});
+		expect(result.mode).toBe('scoped');
+		expect(result.specs).toEqual([]);
+		expect(result.uncovered).toEqual(['packages/cli/package.json']);
+	});
+
+	it('runtime-dep manifest change with no importers data → broad (cannot scope)', () => {
+		const map: ImpactMap = { 'packages/cli/src/x.ts': { '10': ['tests/e2e/a.spec.ts'] } };
+		const mapPath = path.join(tempDir, 'map-rt.json');
+		fs.writeFileSync(mapPath, JSON.stringify(map));
+		const result = selectTests({
+			changedFiles: ['packages/cli/package.json'],
+			mapFile: mapPath,
+			allSpecsFile: writeAllSpecs(ALL_SPECS.join('\n')),
+			manifests: {
+				'packages/cli/package.json': {
+					before: JSON.stringify({ dependencies: { axios: '1.0.0' } }),
+					after: JSON.stringify({ dependencies: { axios: '2.0.0' } }),
+				},
+			},
+		});
+		expect(result.mode).toBe('broad');
+	});
+
 	describe('--all-specs parsing', () => {
 		const triggerBroad = (allSpecsFile: string) =>
 			selectTests({

--- a/packages/testing/test-impact/src/select.test.ts
+++ b/packages/testing/test-impact/src/select.test.ts
@@ -167,6 +167,21 @@ describe('selectTests — fail-open contract', () => {
 		expect(result.uncovered).toEqual(['packages/cli/package.json']);
 	});
 
+	// No manifest metadata (e.g. local dev with no base ref) → can't classify the
+	// package.json change → conservative broad, never silently declared uncovered.
+	it('package.json change with no manifest metadata → broad (cannot classify)', () => {
+		const map: ImpactMap = { 'packages/cli/src/x.ts': { '10': ['tests/e2e/a.spec.ts'] } };
+		const mapPath = path.join(tempDir, 'map-nomanifest.json');
+		fs.writeFileSync(mapPath, JSON.stringify(map));
+		const result = selectTests({
+			changedFiles: ['packages/cli/package.json'],
+			mapFile: mapPath,
+			allSpecsFile: writeAllSpecs(ALL_SPECS.join('\n')),
+		});
+		expect(result.mode).toBe('broad');
+		expect(result.specs).toEqual([...ALL_SPECS].sort());
+	});
+
 	it('runtime-dep manifest change with no importers data → broad (cannot scope)', () => {
 		const map: ImpactMap = { 'packages/cli/src/x.ts': { '10': ['tests/e2e/a.spec.ts'] } };
 		const mapPath = path.join(tempDir, 'map-rt.json');

--- a/packages/testing/test-impact/src/select.test.ts
+++ b/packages/testing/test-impact/src/select.test.ts
@@ -134,6 +134,19 @@ describe('selectTests — fail-open contract', () => {
 		expect(result.specs).toEqual([...ALL_SPECS].sort());
 	});
 
+	it('runtime-defining change (Dockerfile) → broad, never declared uncovered', () => {
+		const map: ImpactMap = { 'packages/cli/src/x.ts': { '10': ['tests/e2e/a.spec.ts'] } };
+		const mapPath = path.join(tempDir, 'map-docker.json');
+		fs.writeFileSync(mapPath, JSON.stringify(map));
+		const result = selectTests({
+			changedFiles: ['docker/images/n8n/Dockerfile'],
+			mapFile: mapPath,
+			allSpecsFile: writeAllSpecs(ALL_SPECS.join('\n')),
+		});
+		expect(result.mode).toBe('broad');
+		expect(result.specs).toEqual([...ALL_SPECS].sort());
+	});
+
 	it('package.json change with NO dependency change (version) → uncovered, not broad', () => {
 		const map: ImpactMap = { 'packages/cli/src/x.ts': { '10': ['tests/e2e/a.spec.ts'] } };
 		const mapPath = path.join(tempDir, 'map-ver.json');

--- a/packages/testing/test-impact/src/select.ts
+++ b/packages/testing/test-impact/src/select.ts
@@ -12,7 +12,7 @@
 
 import * as fs from 'node:fs';
 
-import { filterImpactfulChanges } from './changes.js';
+import { dropDevDepOnlyDeps, filterImpactfulChanges } from './changes.js';
 import {
 	type ImpactMap,
 	type InternedImpactMap,
@@ -29,6 +29,11 @@ export interface SelectTestsInput {
 	mapFile?: string;
 	/** Path to a newline/comma separated list of every known spec. */
 	allSpecsFile?: string;
+	/** before/after content of each changed package.json (caller reads from git),
+	 *  keyed by path. When supplied, a devDependencies-only manifest change drops
+	 *  the lockfile + manifests from selection — a devDep can't reach the runtime
+	 *  bundle the E2E suite exercises. */
+	manifests?: Record<string, { before: string; after: string }>;
 }
 
 export interface SelectTestsResult extends ResolveResult {
@@ -71,7 +76,9 @@ export function selectTests(input: SelectTestsInput): SelectTestsResult {
 	// Drop non-impactful paths (repo tooling / docs / named config) up front so
 	// they never trip the unmapped→broad fallback. A change that's *only* such
 	// files yields an empty set → scoped/0 → the caller skips E2E.
-	const changed = filterImpactfulChanges(input.changedFiles).map((file) => ({ file }));
+	let impactful = filterImpactfulChanges(input.changedFiles);
+	if (input.manifests) impactful = dropDevDepOnlyDeps(impactful, input.manifests);
+	const changed = impactful.map((file) => ({ file }));
 	// The live V8 selection runs through the pipeline as the single selection
 	// mechanism; the AST / dep-graph selectors join this array later. Sibling
 	// fallback scopes a new/unmapped file to its nearest covered directory.

--- a/packages/testing/test-impact/src/select.ts
+++ b/packages/testing/test-impact/src/select.ts
@@ -12,7 +12,13 @@
 
 import * as fs from 'node:fs';
 
-import { dropDevDepOnlyDeps, filterImpactfulChanges } from './changes.js';
+import {
+	changedRuntimeDepsFromManifests,
+	dropDevDepOnlyDeps,
+	filterImpactfulChanges,
+	stripDependencyFiles,
+} from './changes.js';
+import type { WorkspaceImporters } from './dep-graph.js';
 import {
 	type ImpactMap,
 	type InternedImpactMap,
@@ -20,7 +26,9 @@ import {
 	decodeImpactMap,
 } from './impact-map.js';
 import { CoverageMapStrategy } from './select/coverage-map-strategy.js';
+import { DependencyGraphStrategy } from './select/dep-graph-strategy.js';
 import { selectImpactedTests } from './select/pipeline.js';
+import type { SelectionStrategy } from './select/strategy.js';
 
 export interface SelectTestsInput {
 	/** Changed files (file paths). */
@@ -34,6 +42,11 @@ export interface SelectTestsInput {
 	 *  the lockfile + manifests from selection — a devDep can't reach the runtime
 	 *  bundle the E2E suite exercises. */
 	manifests?: Record<string, { before: string; after: string }>;
+	/** Workspace package dir → runtime dependency names it declares (parsed from
+	 *  pnpm-lock.yaml's `importers`). With `manifests`, a changed runtime dep is
+	 *  walked to its declaring packages and scoped via the map (DEVP-389) instead
+	 *  of forcing broad. */
+	lockfileImporters?: WorkspaceImporters;
 }
 
 export interface SelectTestsResult extends ResolveResult {
@@ -78,12 +91,28 @@ export function selectTests(input: SelectTestsInput): SelectTestsResult {
 	// files yields an empty set → scoped/0 → the caller skips E2E.
 	let impactful = filterImpactfulChanges(input.changedFiles);
 	if (input.manifests) impactful = dropDevDepOnlyDeps(impactful, input.manifests);
-	const changed = impactful.map((file) => ({ file }));
-	// The live V8 selection runs through the pipeline as the single selection
-	// mechanism; the AST / dep-graph selectors join this array later. Sibling
-	// fallback scopes a new/unmapped file to its nearest covered directory.
-	const result = selectImpactedTests(changed, [
-		new CoverageMapStrategy(map, { allSpecs, siblingFallback: true }),
-	]);
+
+	// Runtime dependency changes (389): hand the changed deps to the dep-graph
+	// selector — it walks them to their declaring packages and scopes via the
+	// map — and drop the dep files from the coverage path so they don't force
+	// broad. The coverage map still handles any co-changed source files.
+	const strategies: SelectionStrategy[] = [];
+	if (input.lockfileImporters && input.manifests) {
+		const runtimeDeps = changedRuntimeDepsFromManifests(input.manifests);
+		if (runtimeDeps.length > 0) {
+			impactful = stripDependencyFiles(impactful);
+			strategies.push(
+				new DependencyGraphStrategy(map, input.lockfileImporters, runtimeDeps, { allSpecs }),
+			);
+		}
+	}
+	// Sibling fallback scopes a new/unmapped source file to its nearest covered
+	// directory. The AST selector joins this array in a later phase.
+	strategies.unshift(new CoverageMapStrategy(map, { allSpecs, siblingFallback: true }));
+
+	const result = selectImpactedTests(
+		impactful.map((file) => ({ file })),
+		strategies,
+	);
 	return { ...result, failOpen };
 }

--- a/packages/testing/test-impact/src/select.ts
+++ b/packages/testing/test-impact/src/select.ts
@@ -70,6 +70,10 @@ function loadMap(mapFile: string | undefined): { map: ImpactMap; failOpen?: stri
 		const isInterned =
 			typeof parsed === 'object' && parsed !== null && 'specs' in parsed && 'files' in parsed;
 		const map = isInterned ? decodeImpactMap(parsed as InternedImpactMap) : (parsed as ImpactMap);
+		// An empty map carries no coverage data — a build/data failure, not a set
+		// of genuinely-uncovered changes. Flag it as fail-open so selection runs
+		// broad rather than declaring every change uncovered and skipping E2E.
+		if (Object.keys(map).length === 0) return { map, failOpen: 'empty map (no coverage data)' };
 		return { map };
 	} catch (error) {
 		return { map: {}, failOpen: `unreadable map: ${String(error)}` };
@@ -86,16 +90,22 @@ export function selectTests(input: SelectTestsInput): SelectTestsResult {
 		? parseSpecList(fs.readFileSync(input.allSpecsFile, 'utf8'))
 		: undefined;
 	const { map, failOpen } = loadMap(input.mapFile);
-	// Drop non-impactful paths (repo tooling / docs / named config) up front so
-	// they never trip the unmapped→broad fallback. A change that's *only* such
-	// files yields an empty set → scoped/0 → the caller skips E2E.
+	// Drop non-impactful paths (repo tooling / docs / named config) up front.
 	let impactful = filterImpactfulChanges(input.changedFiles);
+
+	// Genuine fail-open: an UNUSABLE map is an infrastructure failure, not a
+	// coverage gap → run everything. This is distinct from a healthy map that
+	// simply has no entry for a change (declared uncovered below, not run).
+	if (failOpen) {
+		return { specs: allSpecs ?? [], unmapped: impactful, mode: 'broad', failOpen };
+	}
+
 	if (input.manifests) impactful = dropDevDepOnlyDeps(impactful, input.manifests);
 
 	// Runtime dependency changes (389): hand the changed deps to the dep-graph
 	// selector — it walks them to their declaring packages and scopes via the
-	// map — and drop the dep files from the coverage path so they don't force
-	// broad. The coverage map still handles any co-changed source files.
+	// map — and drop the dep files from the coverage path. The dep-graph keeps
+	// its sibling climb: a dep IS exercised by the specs covering its package.
 	const strategies: SelectionStrategy[] = [];
 	if (input.lockfileImporters && input.manifests) {
 		const runtimeDeps = changedRuntimeDepsFromManifests(input.manifests);
@@ -106,13 +116,22 @@ export function selectTests(input: SelectTestsInput): SelectTestsResult {
 			);
 		}
 	}
-	// Sibling fallback scopes a new/unmapped source file to its nearest covered
-	// directory. The AST selector joins this array in a later phase.
-	strategies.unshift(new CoverageMapStrategy(map, { allSpecs, siblingFallback: true }));
+	// A dependency file still present here is one neither the devDep drop (388)
+	// nor the dep-graph walk (389) could attribute — e.g. a transitive lockfile
+	// bump with no manifest. We can't scope it, and must NEVER declare a dep
+	// change merely "uncovered" (it could affect anything) → conservatively broad.
+	if (stripDependencyFiles(impactful).length !== impactful.length) {
+		return { specs: allSpecs ?? [], unmapped: impactful, mode: 'broad' };
+	}
 
-	const result = selectImpactedTests(
+	// Coverage map for source files: a file with no covering spec is DECLARED
+	// uncovered (surfaced as a gap, not run) rather than climbing to its package
+	// and running unrelated specs — that verifies nothing and slows the loop.
+	// Unit tests + the always-on sanity spec are the net for uncovered changes.
+	strategies.unshift(new CoverageMapStrategy(map, { allSpecs, onUncovered: 'declare' }));
+
+	return selectImpactedTests(
 		impactful.map((file) => ({ file })),
 		strategies,
 	);
-	return { ...result, failOpen };
 }

--- a/packages/testing/test-impact/src/select.ts
+++ b/packages/testing/test-impact/src/select.ts
@@ -17,6 +17,7 @@ import {
 	classifyManifestChange,
 	dropDevDepOnlyDeps,
 	filterImpactfulChanges,
+	forcesBroad,
 	stripDependencyFiles,
 } from './changes.js';
 import type { WorkspaceImporters } from './dep-graph.js';
@@ -99,6 +100,14 @@ export function selectTests(input: SelectTestsInput): SelectTestsResult {
 	// simply has no entry for a change (declared uncovered below, not run).
 	if (failOpen) {
 		return { specs: allSpecs ?? [], unmapped: impactful, mode: 'broad', failOpen };
+	}
+
+	// Runtime-defining changes (the container image / harness) affect every spec
+	// and aren't in the coverage map → run the whole suite rather than declaring
+	// them uncovered. Small, low-churn set, so broad is cheap here.
+	const forcing = impactful.filter(forcesBroad);
+	if (forcing.length > 0) {
+		return { specs: allSpecs ?? [], unmapped: forcing, mode: 'broad' };
 	}
 
 	if (input.manifests) impactful = dropDevDepOnlyDeps(impactful, input.manifests);

--- a/packages/testing/test-impact/src/select.ts
+++ b/packages/testing/test-impact/src/select.ts
@@ -46,7 +46,7 @@ export interface SelectTestsInput {
 	manifests?: Record<string, { before: string; after: string }>;
 	/** Workspace package dir → runtime dependency names it declares (parsed from
 	 *  pnpm-lock.yaml's `importers`). With `manifests`, a changed runtime dep is
-	 *  walked to its declaring packages and scoped via the map (DEVP-389) instead
+	 *  walked to its declaring packages and scoped via the map instead
 	 *  of forcing broad. */
 	lockfileImporters?: WorkspaceImporters;
 }
@@ -113,7 +113,7 @@ export function selectTests(input: SelectTestsInput): SelectTestsResult {
 	// devDependency-only change can't reach the runtime bundle → dropped.
 	if (input.manifests) impactful = dropDevDepOnlyDeps(impactful, input.manifests);
 
-	// Runtime-dep change: walk it to the packages that declare it (389) and drop
+	// Runtime-dep change: walk it to the packages that declare it and drop
 	// the dep files from the coverage path.
 	const strategies: SelectionStrategy[] = [];
 	if (input.lockfileImporters && input.manifests) {

--- a/packages/testing/test-impact/src/select.ts
+++ b/packages/testing/test-impact/src/select.ts
@@ -14,6 +14,7 @@ import * as fs from 'node:fs';
 
 import {
 	changedRuntimeDepsFromManifests,
+	classifyManifestChange,
 	dropDevDepOnlyDeps,
 	filterImpactfulChanges,
 	stripDependencyFiles,
@@ -116,11 +117,21 @@ export function selectTests(input: SelectTestsInput): SelectTestsResult {
 			);
 		}
 	}
-	// A dependency file still present here is one neither the devDep drop (388)
-	// nor the dep-graph walk (389) could attribute — e.g. a transitive lockfile
-	// bump with no manifest. We can't scope it, and must NEVER declare a dep
-	// change merely "uncovered" (it could affect anything) → conservatively broad.
-	if (stripDependencyFiles(impactful).length !== impactful.length) {
+	// An unattributable dependency CHANGE stays conservatively broad — we can't
+	// scope it and must never declare a dep change merely "uncovered" (it could
+	// affect anything). That means: a lockfile bump (a definitive dep-version
+	// signal we couldn't scope), or a runtime-manifest change the dep-graph didn't
+	// strip (e.g. a transitive dep declared by no importer). A package.json change
+	// that is NOT a dependency change (version / scripts / exports / devDep) is not
+	// a dep signal — it falls through and is declared uncovered like any source.
+	const lockfileRemains = impactful.includes('pnpm-lock.yaml');
+	const unscopedRuntimeManifest = impactful.some(
+		(f) =>
+			/(^|\/)package\.json$/.test(f) &&
+			input.manifests?.[f] &&
+			classifyManifestChange(input.manifests[f].before, input.manifests[f].after) === 'runtime',
+	);
+	if (lockfileRemains || unscopedRuntimeManifest) {
 		return { specs: allSpecs ?? [], unmapped: impactful, mode: 'broad' };
 	}
 

--- a/packages/testing/test-impact/src/select.ts
+++ b/packages/testing/test-impact/src/select.ts
@@ -12,6 +12,7 @@
 
 import * as fs from 'node:fs';
 
+import { filterImpactfulChanges } from './changes.js';
 import {
 	type ImpactMap,
 	type InternedImpactMap,
@@ -67,7 +68,10 @@ export function selectTests(input: SelectTestsInput): SelectTestsResult {
 		? parseSpecList(fs.readFileSync(input.allSpecsFile, 'utf8'))
 		: undefined;
 	const { map, failOpen } = loadMap(input.mapFile);
-	const changed = input.changedFiles.map((file) => ({ file }));
+	// Drop non-impactful paths (repo tooling / docs / named config) up front so
+	// they never trip the unmapped→broad fallback. A change that's *only* such
+	// files yields an empty set → scoped/0 → the caller skips E2E.
+	const changed = filterImpactfulChanges(input.changedFiles).map((file) => ({ file }));
 	// The live V8 selection runs through the pipeline as the single selection
 	// mechanism; the AST / dep-graph selectors join this array later. Sibling
 	// fallback scopes a new/unmapped file to its nearest covered directory.

--- a/packages/testing/test-impact/src/select.ts
+++ b/packages/testing/test-impact/src/select.ts
@@ -119,6 +119,13 @@ export function selectTests(input: SelectTestsInput): SelectTestsResult {
 	if (input.lockfileImporters && input.manifests) {
 		const runtimeDeps = changedRuntimeDepsFromManifests(input.manifests);
 		if (runtimeDeps.length > 0) {
+			// Stripping the lockfile is intentional: the dep-graph scopes each changed
+			// declared dep to its importers, which covers that dep's transitive subtree
+			// (the subtree is reached only THROUGH the dep). What it does NOT cover is
+			// UNRELATED transitive churn co-occurring in the same lockfile (e.g. a
+			// `pnpm dedupe` alongside the bump) — the deferred transitive-closure case,
+			// backstopped by the nightly full E2E run. A lockfile-only change (no
+			// manifest) never reaches here and stays broad.
 			impactful = stripDependencyFiles(impactful);
 			strategies.push(
 				new DependencyGraphStrategy(map, input.lockfileImporters, runtimeDeps, { allSpecs }),

--- a/packages/testing/test-impact/src/select.ts
+++ b/packages/testing/test-impact/src/select.ts
@@ -83,39 +83,38 @@ function loadMap(mapFile: string | undefined): { map: ImpactMap; failOpen?: stri
 }
 
 /**
- * Resolve changed files against the impact map, biased to OVER-select. With an
- * empty/missing map every changed file is "unmapped" → {@link resolveImpact}
- * returns `mode: 'broad'`, so fail-open falls out of the same code path.
+ * Resolve changed files → the specs that must run. Routes each change to one of
+ * three outcomes: BROAD (infra failure, runtime-defining change, or an
+ * unattributable dependency), SCOPED (mapped source / attributable dep), or
+ * declared UNCOVERED (no covering spec → not run; unit + sanity are the net).
  */
 export function selectTests(input: SelectTestsInput): SelectTestsResult {
 	const allSpecs = input.allSpecsFile
 		? parseSpecList(fs.readFileSync(input.allSpecsFile, 'utf8'))
 		: undefined;
 	const { map, failOpen } = loadMap(input.mapFile);
-	// Drop non-impactful paths (repo tooling / docs / named config) up front.
+	const broad = (files: string[]): SelectTestsResult => ({
+		specs: allSpecs ?? [],
+		unmapped: files,
+		mode: 'broad',
+		...(failOpen ? { failOpen } : {}),
+	});
+
 	let impactful = filterImpactfulChanges(input.changedFiles);
 
-	// Genuine fail-open: an UNUSABLE map is an infrastructure failure, not a
-	// coverage gap → run everything. This is distinct from a healthy map that
-	// simply has no entry for a change (declared uncovered below, not run).
-	if (failOpen) {
-		return { specs: allSpecs ?? [], unmapped: impactful, mode: 'broad', failOpen };
-	}
+	// Fail-open: an unusable/empty map is an infra failure, not a coverage gap.
+	if (failOpen) return broad(impactful);
 
-	// Runtime-defining changes (the container image / harness) affect every spec
-	// and aren't in the coverage map → run the whole suite rather than declaring
-	// them uncovered. Small, low-churn set, so broad is cheap here.
+	// Container image / harness changes define the runtime for EVERY spec and
+	// aren't in the map → run the suite (low-churn, so broad is cheap).
 	const forcing = impactful.filter(forcesBroad);
-	if (forcing.length > 0) {
-		return { specs: allSpecs ?? [], unmapped: forcing, mode: 'broad' };
-	}
+	if (forcing.length > 0) return broad(forcing);
 
+	// devDependency-only change can't reach the runtime bundle → dropped.
 	if (input.manifests) impactful = dropDevDepOnlyDeps(impactful, input.manifests);
 
-	// Runtime dependency changes (389): hand the changed deps to the dep-graph
-	// selector — it walks them to their declaring packages and scopes via the
-	// map — and drop the dep files from the coverage path. The dep-graph keeps
-	// its sibling climb: a dep IS exercised by the specs covering its package.
+	// Runtime-dep change: walk it to the packages that declare it (389) and drop
+	// the dep files from the coverage path.
 	const strategies: SelectionStrategy[] = [];
 	if (input.lockfileImporters && input.manifests) {
 		const runtimeDeps = changedRuntimeDepsFromManifests(input.manifests);
@@ -126,13 +125,10 @@ export function selectTests(input: SelectTestsInput): SelectTestsResult {
 			);
 		}
 	}
-	// An unattributable dependency CHANGE stays conservatively broad — we can't
-	// scope it and must never declare a dep change merely "uncovered" (it could
-	// affect anything). That means: a lockfile bump (a definitive dep-version
-	// signal we couldn't scope), or a runtime-manifest change the dep-graph didn't
-	// strip (e.g. a transitive dep declared by no importer). A package.json change
-	// that is NOT a dependency change (version / scripts / exports / devDep) is not
-	// a dep signal — it falls through and is declared uncovered like any source.
+
+	// A dep change the walk couldn't scope stays broad (never declared uncovered):
+	// a lockfile bump, or a runtime manifest still present. A non-dep manifest
+	// change (version / scripts) falls through and is declared like source.
 	const lockfileRemains = impactful.includes('pnpm-lock.yaml');
 	const unscopedRuntimeManifest = impactful.some(
 		(f) =>
@@ -140,14 +136,10 @@ export function selectTests(input: SelectTestsInput): SelectTestsResult {
 			input.manifests?.[f] &&
 			classifyManifestChange(input.manifests[f].before, input.manifests[f].after) === 'runtime',
 	);
-	if (lockfileRemains || unscopedRuntimeManifest) {
-		return { specs: allSpecs ?? [], unmapped: impactful, mode: 'broad' };
-	}
+	if (lockfileRemains || unscopedRuntimeManifest) return broad(impactful);
 
-	// Coverage map for source files: a file with no covering spec is DECLARED
-	// uncovered (surfaced as a gap, not run) rather than climbing to its package
-	// and running unrelated specs — that verifies nothing and slows the loop.
-	// Unit tests + the always-on sanity spec are the net for uncovered changes.
+	// Source files: no covering spec → declared uncovered (surfaced, not run);
+	// running its package's specs verifies nothing.
 	strategies.unshift(new CoverageMapStrategy(map, { allSpecs, onUncovered: 'declare' }));
 
 	return selectImpactedTests(

--- a/packages/testing/test-impact/src/select.ts
+++ b/packages/testing/test-impact/src/select.ts
@@ -134,15 +134,17 @@ export function selectTests(input: SelectTestsInput): SelectTestsResult {
 	}
 
 	// A dep change the walk couldn't scope stays broad (never declared uncovered):
-	// a lockfile bump, or a runtime manifest still present. A non-dep manifest
+	// a lockfile bump, or a runtime manifest still present. A package.json with no
+	// manifest metadata (e.g. local dev with no base ref) can't be classified, so
+	// it's treated conservatively as runtime → broad. A classified non-dep manifest
 	// change (version / scripts) falls through and is declared like source.
 	const lockfileRemains = impactful.includes('pnpm-lock.yaml');
-	const unscopedRuntimeManifest = impactful.some(
-		(f) =>
-			/(^|\/)package\.json$/.test(f) &&
-			input.manifests?.[f] &&
-			classifyManifestChange(input.manifests[f].before, input.manifests[f].after) === 'runtime',
-	);
+	const unscopedRuntimeManifest = impactful.some((f) => {
+		if (!/(^|\/)package\.json$/.test(f)) return false;
+		const manifest = input.manifests?.[f];
+		if (!manifest) return true;
+		return classifyManifestChange(manifest.before, manifest.after) === 'runtime';
+	});
 	if (lockfileRemains || unscopedRuntimeManifest) return broad(impactful);
 
 	// Source files: no covering spec → declared uncovered (surfaced, not run);

--- a/packages/testing/test-impact/src/select/coverage-map-strategy.ts
+++ b/packages/testing/test-impact/src/select/coverage-map-strategy.ts
@@ -13,7 +13,11 @@ export class CoverageMapStrategy implements SelectionStrategy {
 
 	constructor(
 		private readonly map: ImpactMap,
-		private readonly opts: { allSpecs?: string[]; siblingFallback?: boolean } = {},
+		private readonly opts: {
+			allSpecs?: string[];
+			siblingFallback?: boolean;
+			onUncovered?: 'broad' | 'declare';
+		} = {},
 	) {}
 
 	resolve(changed: ChangedFile[]): ResolveResult {

--- a/packages/testing/test-impact/src/select/dep-graph-strategy.ts
+++ b/packages/testing/test-impact/src/select/dep-graph-strategy.ts
@@ -26,6 +26,8 @@ export class DependencyGraphStrategy implements SelectionStrategy {
 		const dirs = dependentDirs(this.changedDeps, this.importers);
 		if (dirs.length === 0) {
 			// No workspace package declares the changed dep → can't attribute → broad.
+			// `unmapped` carries the dep NAMES here (not file paths) purely for the
+			// broad-reason diagnostic; broad mode runs everything regardless.
 			return {
 				specs: this.opts.allSpecs ?? [],
 				unmapped: this.changedDeps,

--- a/packages/testing/test-impact/src/select/dep-graph-strategy.ts
+++ b/packages/testing/test-impact/src/select/dep-graph-strategy.ts
@@ -1,0 +1,52 @@
+import { dependentDirs, type WorkspaceImporters } from '../dep-graph.js';
+import type { ImpactMap, ResolveResult } from '../impact-map.js';
+import { resolveImpact } from '../impact-map.js';
+import type { SelectionStrategy } from './strategy.js';
+
+/**
+ * Selection for runtime dependency changes (DEVP-389): each changed runtime dep
+ * is walked to the workspace packages that declare it, then those package dirs
+ * are resolved through the coverage map (via sibling fallback) to the specs that
+ * exercise them.
+ *
+ * Fail-open: if a changed dep is declared by no workspace package (a purely
+ * transitive bump we can't attribute), it returns `mode: 'broad'` so the
+ * pipeline runs everything. Resolves the precomputed `changedDeps` — the
+ * `changed` files argument is unused (the deps already came from the manifest
+ * diffs the caller classified).
+ */
+export class DependencyGraphStrategy implements SelectionStrategy {
+	readonly name = 'dep-graph';
+
+	constructor(
+		private readonly map: ImpactMap,
+		private readonly importers: WorkspaceImporters,
+		private readonly changedDeps: string[],
+		private readonly opts: { allSpecs?: string[] } = {},
+	) {}
+
+	resolve(): ResolveResult {
+		if (this.changedDeps.length === 0) {
+			return { specs: [], unmapped: [], mode: 'scoped' };
+		}
+		const dirs = dependentDirs(this.changedDeps, this.importers);
+		if (dirs.length === 0) {
+			// No workspace package declares the changed dep → can't attribute → broad.
+			return {
+				specs: this.opts.allSpecs ?? [],
+				unmapped: this.changedDeps,
+				mode: 'broad',
+			};
+		}
+		// Resolve each dependent package dir through the map. A package.json path
+		// has no own map entry, so sibling fallback scopes it to the specs covering
+		// that package's files.
+		const synthetic = dirs.map((dir) => ({
+			file: dir === '.' ? 'package.json' : `${dir}/package.json`,
+		}));
+		return resolveImpact(synthetic, this.map, {
+			allSpecs: this.opts.allSpecs,
+			siblingFallback: true,
+		});
+	}
+}

--- a/packages/testing/test-impact/src/select/dep-graph-strategy.ts
+++ b/packages/testing/test-impact/src/select/dep-graph-strategy.ts
@@ -4,16 +4,10 @@ import { resolveImpact } from '../impact-map.js';
 import type { SelectionStrategy } from './strategy.js';
 
 /**
- * Selection for runtime dependency changes (DEVP-389): each changed runtime dep
- * is walked to the workspace packages that declare it, then those package dirs
- * are resolved through the coverage map (via sibling fallback) to the specs that
- * exercise them.
- *
- * Fail-open: if a changed dep is declared by no workspace package (a purely
- * transitive bump we can't attribute), it returns `mode: 'broad'` so the
- * pipeline runs everything. Resolves the precomputed `changedDeps` — the
- * `changed` files argument is unused (the deps already came from the manifest
- * diffs the caller classified).
+ * Runtime-dependency selection (DEVP-389): walk each changed dep to the packages
+ * that declare it, then resolve those package dirs through the map. A dep no
+ * workspace package declares (purely transitive) → broad (can't attribute).
+ * Resolves the precomputed `changedDeps`; the `changed` arg is unused.
  */
 export class DependencyGraphStrategy implements SelectionStrategy {
 	readonly name = 'dep-graph';

--- a/packages/testing/test-impact/src/select/dep-graph-strategy.ts
+++ b/packages/testing/test-impact/src/select/dep-graph-strategy.ts
@@ -23,17 +23,23 @@ export class DependencyGraphStrategy implements SelectionStrategy {
 		if (this.changedDeps.length === 0) {
 			return { specs: [], unmapped: [], mode: 'scoped' };
 		}
-		const dirs = dependentDirs(this.changedDeps, this.importers);
-		if (dirs.length === 0) {
-			// No workspace package declares the changed dep → can't attribute → broad.
-			// `unmapped` carries the dep NAMES here (not file paths) purely for the
-			// broad-reason diagnostic; broad mode runs everything regardless.
+		// Any changed dep that no workspace package declares (purely transitive)
+		// can't be attributed → broad. A MIXED change must go broad too: scoping to
+		// just the attributable deps would silently drop the unattributable ones.
+		// `unmapped` carries the dep NAMES here (not file paths) purely for the
+		// broad-reason diagnostic; broad mode runs everything regardless.
+		const declared = new Set(Object.values(this.importers).flat());
+		const unattributable = this.changedDeps.filter((dep) => !declared.has(dep));
+		if (unattributable.length > 0) {
 			return {
 				specs: this.opts.allSpecs ?? [],
-				unmapped: this.changedDeps,
+				unmapped: unattributable,
 				mode: 'broad',
 			};
 		}
+		// Every changed dep is declared by at least one importer, so the walk
+		// always resolves to at least those dirs.
+		const dirs = dependentDirs(this.changedDeps, this.importers);
 		// Resolve each dependent package dir through the map. A package.json path
 		// has no own map entry, so sibling fallback scopes it to the specs covering
 		// that package's files.

--- a/packages/testing/test-impact/src/select/dep-graph-strategy.ts
+++ b/packages/testing/test-impact/src/select/dep-graph-strategy.ts
@@ -4,7 +4,7 @@ import { resolveImpact } from '../impact-map.js';
 import type { SelectionStrategy } from './strategy.js';
 
 /**
- * Runtime-dependency selection (DEVP-389): walk each changed dep to the packages
+ * Runtime-dependency selection: walk each changed dep to the packages
  * that declare it, then resolve those package dirs through the map. A dep no
  * workspace package declares (purely transitive) → broad (can't attribute).
  * Resolves the precomputed `changedDeps`; the `changed` arg is unused.

--- a/packages/testing/test-impact/src/select/pipeline.ts
+++ b/packages/testing/test-impact/src/select/pipeline.ts
@@ -19,6 +19,7 @@ export function selectImpactedTests(
 	const specs = new Set<string>();
 	const unmapped = new Set<string>();
 	const viaSibling = new Set<string>();
+	const uncovered = new Set<string>();
 
 	for (const selector of selectors) {
 		const result = selector.resolve(changed);
@@ -26,6 +27,7 @@ export function selectImpactedTests(
 		for (const spec of result.specs) specs.add(spec);
 		for (const file of result.unmapped) unmapped.add(file);
 		for (const file of result.viaSibling ?? []) viaSibling.add(file);
+		for (const file of result.uncovered ?? []) uncovered.add(file);
 	}
 
 	return {
@@ -33,5 +35,6 @@ export function selectImpactedTests(
 		unmapped: [...unmapped],
 		mode: 'scoped',
 		...(viaSibling.size ? { viaSibling: [...viaSibling] } : {}),
+		...(uncovered.size ? { uncovered: [...uncovered] } : {}),
 	};
 }


### PR DESCRIPTION
Extends the E2E impact selector (`@n8n/test-impact`) so more change types resolve to a precise spec set instead of the full suite.

## What changed
- **Non-impactful paths** (docs, `.claude/`, `scripts/`, named build/lint config) are dropped before selection.
- **devDependency-only** lockfile/manifest changes are dropped (can't reach the runtime bundle).
- **Runtime dependency changes** are scoped via the workspace graph: the changed dep is walked through `pnpm-lock.yaml` importers to the packages that declare it, then to their specs.
- **Source files with no covering spec** are declared *uncovered* — selected for nothing rather than running unrelated specs. They remain covered by their unit tests + the sanity spec, and by the full nightly E2E run.
- **Runtime-defining changes** (`docker/**`, any `Dockerfile`, `packages/testing/containers/**`) force broad — they define the container the suite runs in.
- **Fail-open preserved:** a missing / unreadable / empty map runs broad.

The merge-base is threaded `distribute-tests → select-affected-e2e → janitor select` so the dependency classifiers run in CI. No workflow YAML change.

## Selection outcomes
| Change | Result |
|---|---|
| mapped source | scoped to its specs |
| source, no coverage | uncovered → skip (unit + sanity + nightly) |
| devDep-only bump | skip |
| runtime dep → covered package(s) | scoped |
| runtime dep → transitive / lockfile-only | broad |
| docker / Dockerfile / containers | broad |
| missing/empty/unreadable map | broad |

## Tests
`@n8n/test-impact` 136 · `@n8n/playwright-janitor` 372 · playwright scripts 17.

## Out of scope (follow-up)
Transitive-dependency closure (a `pnpm why`-style walk) to scope the residual broad set.

Refs: https://linear.app/n8n/issue/DEVP-388 · https://linear.app/n8n/issue/DEVP-389
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
