### PR TITLE
feat(core): Add output redactor guardrail for instance AI use

### DIFF
--- a/packages/@n8n/agents/src/index.ts
+++ b/packages/@n8n/agents/src/index.ts
@@ -5,6 +5,7 @@ export type {
 	BuiltMemory,
 	BuiltEpisodicMemoryStore,
 	BuiltGuardrail,
+	PiiDetectionType,
 	BuiltEval,
 	RunOptions,
 	AgentResult,
@@ -111,6 +112,7 @@ export {
 	StreamingRedactor,
 	resolvePatterns,
 	passesLuhn,
+	SUPPORTED_PII_CATEGORIES,
 } from './sdk/guardrails';
 export type {
 	RedactionOptions,

--- a/packages/@n8n/agents/src/index.ts
+++ b/packages/@n8n/agents/src/index.ts
@@ -103,6 +103,22 @@ export type { Cancellation } from './sdk/cancellation';
 export { Tool, wrapToolForApproval } from './sdk/tool';
 export { Memory } from './sdk/memory';
 export { Guardrail } from './sdk/guardrail';
+export {
+	redactText,
+	redactDeep,
+	redactionOptionsFromGuardrail,
+	DEFAULT_PLACEHOLDER,
+	StreamingRedactor,
+	resolvePatterns,
+	passesLuhn,
+} from './sdk/guardrails';
+export type {
+	RedactionOptions,
+	RedactionResult,
+	DeepRedactionResult,
+	RedactionCategory,
+	RedactionPattern,
+} from './sdk/guardrails';
 export { Eval } from './sdk/eval';
 export { evaluate } from './sdk/evaluate';
 export type { DatasetRow, EvaluateConfig } from './sdk/evaluate';

--- a/packages/@n8n/agents/src/sdk/__tests__/guardrails.test.ts
+++ b/packages/@n8n/agents/src/sdk/__tests__/guardrails.test.ts
@@ -40,6 +40,11 @@ describe('redactText', () => {
 			const { text } = redactText(input, { secrets: false });
 			expect(text).toBe(input);
 		});
+
+		it('uses a custom placeholder', () => {
+			const { text } = redactText('key sk-ant-api03-aaaaaaaaaaaaaaaa', { placeholder: '###' });
+			expect(text).toBe('key ###');
+		});
 	});
 
 	describe('PII', () => {
@@ -69,8 +74,8 @@ describe('redactText', () => {
 			expect(matches).toEqual([]);
 		});
 
-		it('redacts an SSN', () => {
-			const { text } = redactText('ssn 123-45-6789', { detect: ['ssn'] });
+		it('redacts a US SSN', () => {
+			const { text } = redactText('ssn 123-45-6789', { detect: ['ssn-us'] });
 			expect(text).toBe('ssn [REDACTED]');
 		});
 	});
@@ -80,11 +85,11 @@ describe('redactText', () => {
 			const guardrail = new Guardrail('pii')
 				.type('pii')
 				.strategy('redact')
-				.detect(['email', 'ssn'])
+				.detect(['email', 'ssn-us'])
 				.build();
 			expect(redactionOptionsFromGuardrail(guardrail)).toEqual({
 				secrets: false,
-				detect: ['email', 'ssn'],
+				detect: ['email', 'ssn-us'],
 			});
 		});
 	});
@@ -121,6 +126,16 @@ describe('StreamingRedactor', () => {
 		out += redactor.push('example.com bye').text;
 		out += redactor.flush().text;
 		expect(out).toBe('mail [REDACTED] bye');
+	});
+
+	it('redacts a spaced credit card that straddles the holdback boundary', () => {
+		const redactor = new StreamingRedactor({ detect: ['credit-card'] }, HOLDBACK);
+		let out = '';
+		out += redactor.push('card 4111 1111 ').text;
+		out += redactor.push('1111 1111 done here').text;
+		out += redactor.flush().text;
+		expect(out).toBe('card [REDACTED] done here');
+		expect(out).not.toContain('4111');
 	});
 
 	it('passes through non-sensitive streamed prose intact', () => {

--- a/packages/@n8n/agents/src/sdk/__tests__/guardrails.test.ts
+++ b/packages/@n8n/agents/src/sdk/__tests__/guardrails.test.ts
@@ -1,0 +1,150 @@
+import { Guardrail } from '../guardrail';
+import { passesLuhn } from '../guardrails/patterns';
+import { redactText, redactionOptionsFromGuardrail } from '../guardrails/redactor';
+import { StreamingRedactor } from '../guardrails/streaming-redactor';
+
+// A Luhn-valid test card number (Visa test PAN).
+const VALID_CARD = '4111111111111111';
+// Same length, not Luhn-valid.
+const INVALID_CARD = '4111111111111112';
+
+describe('redactText', () => {
+	describe('secrets', () => {
+		it('redacts an Anthropic-style key', () => {
+			const { text, matches } = redactText('use sk-ant-api03-aaaaaaaaaaaaaaaa now');
+			expect(text).toBe('use [REDACTED] now');
+			expect(matches).toEqual([{ category: 'secret' }]);
+		});
+
+		it('redacts a bearer token', () => {
+			const { text } = redactText('Authorization: Bearer abc.def-ghi_jkl/mno=');
+			expect(text).toContain('[REDACTED]');
+			expect(text).not.toContain('abc.def');
+		});
+
+		it('leaves non-sensitive prose untouched', () => {
+			const input = 'The workflow ran successfully and produced 42 items.';
+			const { text, matches } = redactText(input);
+			expect(text).toBe(input);
+			expect(matches).toEqual([]);
+		});
+
+		it('is idempotent', () => {
+			const once = redactText('key sk-ant-api03-aaaaaaaaaaaaaaaa').text;
+			const twice = redactText(once).text;
+			expect(twice).toBe(once);
+		});
+
+		it('can be disabled', () => {
+			const input = 'key sk-ant-api03-aaaaaaaaaaaaaaaa';
+			const { text } = redactText(input, { secrets: false });
+			expect(text).toBe(input);
+		});
+	});
+
+	describe('PII', () => {
+		it('does not scan PII unless requested', () => {
+			const input = 'reach me at jane@example.com';
+			expect(redactText(input).text).toBe(input);
+		});
+
+		it('redacts an email when detect includes email', () => {
+			const { text, matches } = redactText('reach me at jane@example.com', {
+				detect: ['email'],
+			});
+			expect(text).toBe('reach me at [REDACTED]');
+			expect(matches).toEqual([{ category: 'email' }]);
+		});
+
+		it('redacts a Luhn-valid credit card', () => {
+			const { text, matches } = redactText(`card ${VALID_CARD}`, { detect: ['credit-card'] });
+			expect(text).toBe('card [REDACTED]');
+			expect(matches).toEqual([{ category: 'credit-card' }]);
+		});
+
+		it('does not redact a Luhn-invalid number', () => {
+			const input = `card ${INVALID_CARD}`;
+			const { text, matches } = redactText(input, { detect: ['credit-card'] });
+			expect(text).toBe(input);
+			expect(matches).toEqual([]);
+		});
+
+		it('redacts an SSN', () => {
+			const { text } = redactText('ssn 123-45-6789', { detect: ['ssn'] });
+			expect(text).toBe('ssn [REDACTED]');
+		});
+	});
+
+	describe('redactionOptionsFromGuardrail', () => {
+		it('maps a pii guardrail to detect types without secrets', () => {
+			const guardrail = new Guardrail('pii')
+				.type('pii')
+				.strategy('redact')
+				.detect(['email', 'ssn'])
+				.build();
+			expect(redactionOptionsFromGuardrail(guardrail)).toEqual({
+				secrets: false,
+				detect: ['email', 'ssn'],
+			});
+		});
+	});
+});
+
+describe('passesLuhn', () => {
+	it('accepts a valid card with separators', () => {
+		expect(passesLuhn('4111 1111 1111 1111')).toBe(true);
+	});
+
+	it('rejects too-short input', () => {
+		expect(passesLuhn('411111')).toBe(false);
+	});
+});
+
+describe('StreamingRedactor', () => {
+	// Small holdback keeps the tests readable while exercising the same logic.
+	const HOLDBACK = 8;
+
+	it('redacts a secret split across two deltas', () => {
+		const redactor = new StreamingRedactor({}, HOLDBACK);
+		let out = '';
+		out += redactor.push('here is sk-ant-').text;
+		out += redactor.push('api03-aaaaaaaaaaaaaaaa done now').text;
+		out += redactor.flush().text;
+		expect(out).toBe('here is [REDACTED] done now');
+		expect(out).not.toContain('sk-ant-');
+	});
+
+	it('redacts an email split across deltas', () => {
+		const redactor = new StreamingRedactor({ detect: ['email'] }, HOLDBACK);
+		let out = '';
+		out += redactor.push('mail jane@').text;
+		out += redactor.push('example.com bye').text;
+		out += redactor.flush().text;
+		expect(out).toBe('mail [REDACTED] bye');
+	});
+
+	it('passes through non-sensitive streamed prose intact', () => {
+		const redactor = new StreamingRedactor({}, HOLDBACK);
+		const parts = ['Hello ', 'there, ', 'this is ', 'all fine.'];
+		let out = '';
+		for (const part of parts) out += redactor.push(part).text;
+		out += redactor.flush().text;
+		expect(out).toBe('Hello there, this is all fine.');
+	});
+
+	it('emits nothing before the holdback fills and flushes the remainder', () => {
+		const redactor = new StreamingRedactor({}, HOLDBACK);
+		expect(redactor.push('short').text).toBe('');
+		expect(redactor.flush().text).toBe('short');
+	});
+
+	it('reports one match for a secret across the whole stream', () => {
+		const redactor = new StreamingRedactor({}, HOLDBACK);
+		const matches = [
+			...redactor.push('token sk-ant-').matches,
+			...redactor.push('api03-aaaaaaaaaaaaaaaa end').matches,
+			...redactor.flush().matches,
+		];
+		expect(matches).toEqual([{ category: 'secret' }]);
+	});
+});

--- a/packages/@n8n/agents/src/sdk/guardrails/index.ts
+++ b/packages/@n8n/agents/src/sdk/guardrails/index.ts
@@ -1,0 +1,10 @@
+export {
+	redactText,
+	redactDeep,
+	redactionOptionsFromGuardrail,
+	DEFAULT_PLACEHOLDER,
+} from './redactor';
+export type { RedactionOptions, RedactionResult, DeepRedactionResult } from './redactor';
+export { StreamingRedactor } from './streaming-redactor';
+export { resolvePatterns, passesLuhn } from './patterns';
+export type { RedactionCategory, RedactionPattern } from './patterns';

--- a/packages/@n8n/agents/src/sdk/guardrails/index.ts
+++ b/packages/@n8n/agents/src/sdk/guardrails/index.ts
@@ -6,5 +6,5 @@ export {
 } from './redactor';
 export type { RedactionOptions, RedactionResult, DeepRedactionResult } from './redactor';
 export { StreamingRedactor } from './streaming-redactor';
-export { resolvePatterns, passesLuhn } from './patterns';
+export { resolvePatterns, passesLuhn, SUPPORTED_PII_CATEGORIES } from './patterns';
 export type { RedactionCategory, RedactionPattern } from './patterns';

--- a/packages/@n8n/agents/src/sdk/guardrails/patterns.ts
+++ b/packages/@n8n/agents/src/sdk/guardrails/patterns.ts
@@ -71,8 +71,11 @@ const PII_PATTERNS: Readonly<Record<PiiDetectionType, RedactionPattern | undefin
 		flags: 'g',
 		validate: passesLuhn,
 	},
-	ssn: {
-		category: 'ssn',
+	'ssn-us': {
+		category: 'ssn-us',
+		// US Social Security Number, dashed form only (123-45-6789). Bare 9-digit
+		// runs are intentionally not matched (too false-positive-prone). Per-country
+		// national IDs each get their own `ssn-<cc>` category (e.g. a future `ssn-uk`).
 		source: '\\b\\d{3}-\\d{2}-\\d{4}\\b',
 		flags: 'g',
 	},
@@ -80,6 +83,16 @@ const PII_PATTERNS: Readonly<Record<PiiDetectionType, RedactionPattern | undefin
 	phone: undefined,
 	address: undefined,
 };
+
+/**
+ * PII categories that actually have a detection pattern today. `phone` and
+ * `address` are part of {@link PiiDetectionType} but not yet implemented, so
+ * they are excluded here — callers should treat this as the source of truth
+ * for what redaction can detect.
+ */
+export const SUPPORTED_PII_CATEGORIES: PiiDetectionType[] = (
+	Object.keys(PII_PATTERNS) as PiiDetectionType[]
+).filter((type) => PII_PATTERNS[type] !== undefined);
 
 /** Resolve the active pattern set for the given options. */
 export function resolvePatterns(opts: {

--- a/packages/@n8n/agents/src/sdk/guardrails/patterns.ts
+++ b/packages/@n8n/agents/src/sdk/guardrails/patterns.ts
@@ -1,0 +1,96 @@
+import { SECRET_VALUE_PATTERNS } from '@n8n/utils';
+
+import type { PiiDetectionType } from '../../types';
+
+/**
+ * A category attached to every redaction match so callers can log *what kind*
+ * of sensitive content was removed without ever handling the value itself.
+ * `'secret'` covers credential/token patterns; the rest mirror the SDK's
+ * {@link PiiDetectionType} vocabulary.
+ */
+export type RedactionCategory = 'secret' | PiiDetectionType;
+
+export interface RedactionPattern {
+	readonly category: RedactionCategory;
+	/** Source of a global regex matching the sensitive value. */
+	readonly source: string;
+	/** Flags for the regex — always includes `g`. */
+	readonly flags: string;
+	/**
+	 * Optional gate: a candidate match is only redacted when this returns
+	 * `true`. Used to suppress false positives (e.g. Luhn check for cards).
+	 */
+	readonly validate?: (match: string) => boolean;
+}
+
+/**
+ * Secret/credential patterns, sourced from `@n8n/utils` so there is a single
+ * place that defines what a credential looks like across the codebase.
+ */
+const SECRET_PATTERNS: readonly RedactionPattern[] = SECRET_VALUE_PATTERNS.map((re) => ({
+	category: 'secret',
+	source: re.source,
+	// Ensure a global flag so the redactor can replace every occurrence.
+	flags: re.flags.includes('g') ? re.flags : `${re.flags}g`,
+}));
+
+/** Luhn checksum — used to keep credit-card redaction from firing on any long digit run. */
+export function passesLuhn(candidate: string): boolean {
+	const digits = candidate.replace(/\D/g, '');
+	if (digits.length < 13 || digits.length > 19) return false;
+
+	let sum = 0;
+	let double = false;
+	for (let i = digits.length - 1; i >= 0; i--) {
+		let digit = digits.charCodeAt(i) - 48;
+		if (double) {
+			digit *= 2;
+			if (digit > 9) digit -= 9;
+		}
+		sum += digit;
+		double = !double;
+	}
+	return sum % 10 === 0;
+}
+
+/**
+ * Conservative, high-confidence PII patterns. Phone numbers and physical
+ * addresses are intentionally omitted — they are too false-positive-prone for
+ * free-form agent prose. New {@link PiiDetectionType} categories slot in here.
+ */
+const PII_PATTERNS: Readonly<Record<PiiDetectionType, RedactionPattern | undefined>> = {
+	email: {
+		category: 'email',
+		source: '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}',
+		flags: 'g',
+	},
+	'credit-card': {
+		category: 'credit-card',
+		// 13-19 digits, optionally grouped by single spaces or dashes.
+		source: '\\b\\d(?:[ -]?\\d){12,18}\\b',
+		flags: 'g',
+		validate: passesLuhn,
+	},
+	ssn: {
+		category: 'ssn',
+		source: '\\b\\d{3}-\\d{2}-\\d{4}\\b',
+		flags: 'g',
+	},
+	// Deferred — too noisy for prose; declared so the type stays exhaustive.
+	phone: undefined,
+	address: undefined,
+};
+
+/** Resolve the active pattern set for the given options. */
+export function resolvePatterns(opts: {
+	secrets: boolean;
+	detect: readonly PiiDetectionType[];
+}): RedactionPattern[] {
+	const patterns: RedactionPattern[] = [];
+	if (opts.secrets) patterns.push(...SECRET_PATTERNS);
+	for (const type of opts.detect) {
+		const pattern = PII_PATTERNS[type];
+		if (pattern) patterns.push(pattern);
+	}
+	return patterns;
+}

--- a/packages/@n8n/agents/src/sdk/guardrails/patterns.ts
+++ b/packages/@n8n/agents/src/sdk/guardrails/patterns.ts
@@ -12,15 +12,22 @@ export type RedactionCategory = 'secret' | PiiDetectionType;
 
 export interface RedactionPattern {
 	readonly category: RedactionCategory;
-	/** Source of a global regex matching the sensitive value. */
-	readonly source: string;
-	/** Flags for the regex — always includes `g`. */
-	readonly flags: string;
+	/**
+	 * Precompiled regex matching the sensitive value. Always global — the
+	 * redactor relies on `g` both for replace-all and for the `exec` scan loop.
+	 * Compiled once at module load; callers reset `lastIndex` before reuse.
+	 */
+	readonly regex: RegExp;
 	/**
 	 * Optional gate: a candidate match is only redacted when this returns
 	 * `true`. Used to suppress false positives (e.g. Luhn check for cards).
 	 */
 	readonly validate?: (match: string) => boolean;
+}
+
+/** Compile a global regex once, adding the `g` flag if the source omits it. */
+function globalRegex(source: string, flags = ''): RegExp {
+	return new RegExp(source, flags.includes('g') ? flags : `${flags}g`);
 }
 
 /**
@@ -29,9 +36,7 @@ export interface RedactionPattern {
  */
 const SECRET_PATTERNS: readonly RedactionPattern[] = SECRET_VALUE_PATTERNS.map((re) => ({
 	category: 'secret',
-	source: re.source,
-	// Ensure a global flag so the redactor can replace every occurrence.
-	flags: re.flags.includes('g') ? re.flags : `${re.flags}g`,
+	regex: globalRegex(re.source, re.flags),
 }));
 
 /** Luhn checksum — used to keep credit-card redaction from firing on any long digit run. */
@@ -61,14 +66,12 @@ export function passesLuhn(candidate: string): boolean {
 const PII_PATTERNS: Readonly<Record<PiiDetectionType, RedactionPattern | undefined>> = {
 	email: {
 		category: 'email',
-		source: '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}',
-		flags: 'g',
+		regex: /[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g,
 	},
 	'credit-card': {
 		category: 'credit-card',
 		// 13-19 digits, optionally grouped by single spaces or dashes.
-		source: '\\b\\d(?:[ -]?\\d){12,18}\\b',
-		flags: 'g',
+		regex: /\b\d(?:[ -]?\d){12,18}\b/g,
 		validate: passesLuhn,
 	},
 	'ssn-us': {
@@ -76,8 +79,7 @@ const PII_PATTERNS: Readonly<Record<PiiDetectionType, RedactionPattern | undefin
 		// US Social Security Number, dashed form only (123-45-6789). Bare 9-digit
 		// runs are intentionally not matched (too false-positive-prone). Per-country
 		// national IDs each get their own `ssn-<cc>` category (e.g. a future `ssn-uk`).
-		source: '\\b\\d{3}-\\d{2}-\\d{4}\\b',
-		flags: 'g',
+		regex: /\b\d{3}-\d{2}-\d{4}\b/g,
 	},
 	// Deferred — too noisy for prose; declared so the type stays exhaustive.
 	phone: undefined,

--- a/packages/@n8n/agents/src/sdk/guardrails/redactor.ts
+++ b/packages/@n8n/agents/src/sdk/guardrails/redactor.ts
@@ -47,9 +47,9 @@ export function redactText(input: string, opts: RedactionOptions = {}): Redactio
 	let text = input;
 
 	for (const pattern of patterns) {
-		// Fresh regex per pass so `lastIndex` never leaks across calls.
-		const regex = new RegExp(pattern.source, pattern.flags);
-		text = text.replace(regex, (match) => {
+		// `replace` with a global regex scans from 0 and resets lastIndex, so the
+		// shared precompiled regex is safe to reuse across calls.
+		text = text.replace(pattern.regex, (match) => {
 			if (pattern.validate && !pattern.validate(match)) return match;
 			matches.push({ category: pattern.category });
 			return placeholder;
@@ -75,7 +75,10 @@ export function findMatchRanges(
 
 	const ranges: Array<[number, number]> = [];
 	for (const pattern of patterns) {
-		const regex = new RegExp(pattern.source, pattern.flags);
+		const { regex } = pattern;
+		// Reset before the scan loop; reusing the shared global regex is safe
+		// because usage is synchronous and the loop always runs to completion.
+		regex.lastIndex = 0;
 		let match: RegExpExecArray | null;
 		while ((match = regex.exec(input)) !== null) {
 			if (match[0].length === 0) {

--- a/packages/@n8n/agents/src/sdk/guardrails/redactor.ts
+++ b/packages/@n8n/agents/src/sdk/guardrails/redactor.ts
@@ -59,6 +59,36 @@ export function redactText(input: string, opts: RedactionOptions = {}): Redactio
 	return { text, matches };
 }
 
+/**
+ * Find the `[start, end)` ranges of every (validated) match in `input`. Used by
+ * the streaming redactor to avoid emitting through the middle of a complete
+ * match that contains internal whitespace (e.g. a spaced credit-card number).
+ */
+export function findMatchRanges(
+	input: string,
+	opts: RedactionOptions = {},
+): Array<[number, number]> {
+	const patterns = resolvePatterns({
+		secrets: opts.secrets ?? true,
+		detect: opts.detect ?? [],
+	});
+
+	const ranges: Array<[number, number]> = [];
+	for (const pattern of patterns) {
+		const regex = new RegExp(pattern.source, pattern.flags);
+		let match: RegExpExecArray | null;
+		while ((match = regex.exec(input)) !== null) {
+			if (match[0].length === 0) {
+				regex.lastIndex++;
+				continue;
+			}
+			if (pattern.validate && !pattern.validate(match[0])) continue;
+			ranges.push([match.index, match.index + match[0].length]);
+		}
+	}
+	return ranges;
+}
+
 const MAX_DEEP_DEPTH = 8;
 
 export interface DeepRedactionResult {

--- a/packages/@n8n/agents/src/sdk/guardrails/redactor.ts
+++ b/packages/@n8n/agents/src/sdk/guardrails/redactor.ts
@@ -1,0 +1,109 @@
+import type { RedactionCategory } from './patterns';
+import { resolvePatterns } from './patterns';
+import type { BuiltGuardrail, PiiDetectionType } from '../../types';
+
+export const DEFAULT_PLACEHOLDER = '[REDACTED]';
+
+export interface RedactionOptions {
+	/** Scan for credential/secret patterns. Defaults to `true`. */
+	secrets?: boolean;
+	/** PII categories to scan for. Defaults to none. */
+	detect?: readonly PiiDetectionType[];
+	/** Replacement text for a match. Defaults to `[REDACTED]`. */
+	placeholder?: string;
+}
+
+export interface RedactionResult {
+	/** The input with every detected match replaced by the placeholder. */
+	text: string;
+	/** One entry per replaced match (category only — never the value). */
+	matches: Array<{ category: RedactionCategory }>;
+}
+
+/**
+ * Map an `@n8n/agents` {@link BuiltGuardrail} to redaction options, so a future
+ * `.outputGuardrail()` runtime enforcement can drive this engine directly.
+ */
+export function redactionOptionsFromGuardrail(guardrail: BuiltGuardrail): RedactionOptions {
+	const detect = guardrail._config.detectionTypes;
+	return {
+		secrets: guardrail.guardType === 'pii' ? false : true,
+		detect: Array.isArray(detect) ? (detect as PiiDetectionType[]) : [],
+	};
+}
+
+/**
+ * Redact secret/PII patterns from a complete string. Pure and idempotent —
+ * already-redacted placeholders are left untouched by the underlying patterns.
+ */
+export function redactText(input: string, opts: RedactionOptions = {}): RedactionResult {
+	const placeholder = opts.placeholder ?? DEFAULT_PLACEHOLDER;
+	const patterns = resolvePatterns({
+		secrets: opts.secrets ?? true,
+		detect: opts.detect ?? [],
+	});
+
+	const matches: Array<{ category: RedactionCategory }> = [];
+	let text = input;
+
+	for (const pattern of patterns) {
+		// Fresh regex per pass so `lastIndex` never leaks across calls.
+		const regex = new RegExp(pattern.source, pattern.flags);
+		text = text.replace(regex, (match) => {
+			if (pattern.validate && !pattern.validate(match)) return match;
+			matches.push({ category: pattern.category });
+			return placeholder;
+		});
+	}
+
+	return { text, matches };
+}
+
+const MAX_DEEP_DEPTH = 8;
+
+export interface DeepRedactionResult {
+	value: unknown;
+	matches: Array<{ category: RedactionCategory }>;
+}
+
+/**
+ * Recursively redact string values inside an arbitrary JSON-like value
+ * (tool results, structured payloads). Object keys are left intact; only
+ * string values are scanned. Recursion is depth-bounded as a cheap guard
+ * against pathological/cyclic structures.
+ */
+export function redactDeep(
+	value: unknown,
+	opts: RedactionOptions = {},
+	depth = 0,
+): DeepRedactionResult {
+	if (typeof value === 'string') {
+		const { text, matches } = redactText(value, opts);
+		return { value: text, matches };
+	}
+
+	if (depth >= MAX_DEEP_DEPTH) return { value, matches: [] };
+
+	if (Array.isArray(value)) {
+		const matches: Array<{ category: RedactionCategory }> = [];
+		const next = value.map((item) => {
+			const result = redactDeep(item, opts, depth + 1);
+			matches.push(...result.matches);
+			return result.value;
+		});
+		return { value: next, matches };
+	}
+
+	if (value !== null && typeof value === 'object') {
+		const matches: Array<{ category: RedactionCategory }> = [];
+		const next: Record<string, unknown> = {};
+		for (const [key, item] of Object.entries(value)) {
+			const result = redactDeep(item, opts, depth + 1);
+			matches.push(...result.matches);
+			next[key] = result.value;
+		}
+		return { value: next, matches };
+	}
+
+	return { value, matches: [] };
+}

--- a/packages/@n8n/agents/src/sdk/guardrails/streaming-redactor.ts
+++ b/packages/@n8n/agents/src/sdk/guardrails/streaming-redactor.ts
@@ -1,5 +1,5 @@
 import type { RedactionOptions, RedactionResult } from './redactor';
-import { redactText } from './redactor';
+import { findMatchRanges, redactText } from './redactor';
 
 /**
  * How many trailing characters to hold back before emitting.
@@ -56,6 +56,13 @@ export class StreamingRedactor {
 		let cut = target;
 		while (cut > 0 && !WHITESPACE.test(this.buffer[cut - 1])) {
 			cut -= 1;
+		}
+
+		// Never emit through the middle of a complete match. A match with internal
+		// whitespace (e.g. a spaced credit-card number) can straddle the cut; pull
+		// the boundary back to its start so it stays buffered and is redacted whole.
+		for (const [start, end] of findMatchRanges(this.buffer, this.options)) {
+			if (start < cut && end > cut) cut = start;
 		}
 
 		if (cut === 0) {

--- a/packages/@n8n/agents/src/sdk/guardrails/streaming-redactor.ts
+++ b/packages/@n8n/agents/src/sdk/guardrails/streaming-redactor.ts
@@ -1,0 +1,78 @@
+import type { RedactionOptions, RedactionResult } from './redactor';
+import { redactText } from './redactor';
+
+/**
+ * How many trailing characters to hold back before emitting.
+ *
+ * The cut-at-whitespace rule below already guarantees no *contiguous* token is
+ * ever split across a chunk boundary (a segment always ends after whitespace,
+ * so every word lands wholly on one side). That alone catches the dominant
+ * leak — an echoed API key/JWT/token — at any holdback value.
+ *
+ * The holdback only adds margin for *multi-word* patterns (`Bearer <token>`,
+ * `key = value`): it keeps the trailing context buffered long enough for such
+ * a pattern to complete before it is emitted. Kept small so streaming output
+ * stays responsive; a multi-word secret longer than this that lands exactly on
+ * the emit boundary may not be caught (its contiguous value still is, via the
+ * standalone secret patterns). Configurable via the constructor.
+ */
+const DEFAULT_HOLDBACK = 32;
+
+const WHITESPACE = /\s/;
+
+/**
+ * Redacts secret/PII patterns from a *streamed* text channel where the text
+ * arrives in arbitrary fragments. Per-channel state: construct one per logical
+ * stream (e.g. one for `text-delta`, one for `reasoning-delta`).
+ *
+ * Guarantees no partial token is emitted across a chunk boundary: text is only
+ * released up to the last whitespace at or before `length - holdback`, so any
+ * contiguous token (or short multi-word pattern) stays buffered until it is
+ * fully present. Call {@link flush} at end-of-stream to release the remainder.
+ */
+export class StreamingRedactor {
+	private buffer = '';
+
+	private readonly holdback: number;
+
+	constructor(
+		private readonly options: RedactionOptions = {},
+		holdback: number = DEFAULT_HOLDBACK,
+	) {
+		this.holdback = Math.max(0, holdback);
+	}
+
+	/** Feed the next fragment; returns the redacted text safe to emit now. */
+	push(delta: string): RedactionResult {
+		this.buffer += delta;
+
+		if (this.buffer.length <= this.holdback) {
+			return { text: '', matches: [] };
+		}
+
+		// Cut at the last whitespace at or before the holdback boundary so a
+		// token straddling the boundary stays whole in the buffer.
+		const target = this.buffer.length - this.holdback;
+		let cut = target;
+		while (cut > 0 && !WHITESPACE.test(this.buffer[cut - 1])) {
+			cut -= 1;
+		}
+
+		if (cut === 0) {
+			// No safe boundary yet — keep everything buffered.
+			return { text: '', matches: [] };
+		}
+
+		const segment = this.buffer.slice(0, cut);
+		this.buffer = this.buffer.slice(cut);
+		return redactText(segment, this.options);
+	}
+
+	/** Release and redact any buffered remainder. Call once at end-of-stream. */
+	flush(): RedactionResult {
+		const remainder = this.buffer;
+		this.buffer = '';
+		if (!remainder) return { text: '', matches: [] };
+		return redactText(remainder, this.options);
+	}
+}

--- a/packages/@n8n/agents/src/types/sdk/guardrail.ts
+++ b/packages/@n8n/agents/src/types/sdk/guardrail.ts
@@ -1,6 +1,6 @@
 export type GuardrailType = 'pii' | 'prompt-injection' | 'moderation' | 'custom';
 export type GuardrailStrategy = 'block' | 'redact' | 'warn';
-export type PiiDetectionType = 'email' | 'phone' | 'credit-card' | 'ssn' | 'address';
+export type PiiDetectionType = 'email' | 'phone' | 'credit-card' | 'ssn-us' | 'address';
 
 export interface BuiltGuardrail {
 	readonly name: string;

--- a/packages/@n8n/config/src/configs/instance-ai.config.ts
+++ b/packages/@n8n/config/src/configs/instance-ai.config.ts
@@ -111,4 +111,20 @@ export class InstanceAiConfig {
 	/** Timeout in milliseconds for HITL confirmation requests. 0 = no timeout. */
 	@Env('N8N_INSTANCE_AI_CONFIRMATION_TIMEOUT')
 	confirmationTimeout: number = 24 * Time.hours.toMilliseconds;
+
+	/** Scan and redact secrets/PII from agent output before it reaches the user. */
+	@Env('N8N_INSTANCE_AI_OUTPUT_REDACTION_ENABLED')
+	outputRedactionEnabled: boolean = true;
+
+	/** Redact credential/secret patterns from agent output. Applies only when output redaction is enabled. */
+	@Env('N8N_INSTANCE_AI_OUTPUT_REDACTION_SECRETS')
+	outputRedactionSecrets: boolean = true;
+
+	/** Comma-separated PII categories to redact from agent output. Available: email, credit-card, ssn-us. Empty = no PII scanning. */
+	@Env('N8N_INSTANCE_AI_OUTPUT_REDACTION_PII')
+	outputRedactionPii: string = 'credit-card';
+
+	/** Replacement text substituted for each redacted match in agent output. */
+	@Env('N8N_INSTANCE_AI_OUTPUT_REDACTION_PLACEHOLDER')
+	outputRedactionPlaceholder: string = '[REDACTED]';
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -306,6 +306,10 @@ describe('GlobalConfig', () => {
 			pruneInterval: 3_600_000,
 			snapshotRetention: 86_400_000,
 			confirmationTimeout: 86_400_000,
+			outputRedactionEnabled: true,
+			outputRedactionSecrets: true,
+			outputRedactionPii: 'credit-card',
+			outputRedactionPlaceholder: '[REDACTED]',
 		},
 		queue: {
 			health: {

--- a/packages/@n8n/instance-ai/docs/configuration.md
+++ b/packages/@n8n/instance-ai/docs/configuration.md
@@ -91,6 +91,26 @@ Observer and Reflector use the same model as the orchestrator agent (see `@n8n/a
 | `N8N_INSTANCE_AI_SNAPSHOT_RETENTION` | number | `86400000` | Retention period in ms for orphaned workflow snapshots before pruning. |
 | `N8N_INSTANCE_AI_CONFIRMATION_TIMEOUT` | number | `86400000` | Timeout in ms for HITL confirmation requests. 0 = no timeout. |
 
+### Output Filtering
+
+Agent output is scanned for secrets/PII and redacted before it reaches the user.
+The scan covers streamed assistant text, reasoning, and tool results/errors, for
+both the orchestrator and delegated sub-agents. A filtering event (categories
+and counts only — never the values) is logged whenever a redaction occurs.
+
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `N8N_INSTANCE_AI_OUTPUT_REDACTION_ENABLED` | boolean | `true` | Master switch. When `false`, output passes through untouched. |
+| `N8N_INSTANCE_AI_OUTPUT_REDACTION_SECRETS` | boolean | `true` | Redact credential/secret patterns (API keys, tokens, auth headers, `key=value` pairs). |
+| `N8N_INSTANCE_AI_OUTPUT_REDACTION_PII` | string | `credit-card` | Comma-separated PII categories to redact. Available: `email`, `credit-card` (Luhn-validated), `ssn-us` (US Social Security Number, dashed `123-45-6789` form). Defaults to `credit-card` only; `email`/`ssn-us` are implemented but off by default pending review of false-positive rates. Empty = no PII scanning. Unrecognized values are ignored. Per-country national IDs each use their own `ssn-<cc>` category (e.g. a future `ssn-uk`). |
+| `N8N_INSTANCE_AI_OUTPUT_REDACTION_PLACEHOLDER` | string | `[REDACTED]` | Replacement text substituted for each redacted match. |
+
+Secret detection is conservative by design — it matches well-known token shapes
+and explicit `key=value`/JSON secret fields, not arbitrary opaque strings, to
+avoid mangling normal output. The `PiiDetectionType` API also reserves `phone`
+and `address`, but those have no detection pattern yet — setting them has no
+effect (they were deferred as too false-positive-prone for free-form prose).
+
 ## Enabling / Disabling
 
 The module is **enabled** when `N8N_INSTANCE_AI_MODEL` is set to a non-empty value.
@@ -151,47 +171,40 @@ Runtime behavior:
 N8N_INSTANCE_AI_MODEL=anthropic/claude-opus-4-8
 
 # With MCP servers
-N8N_INSTANCE_AI_MODEL=anthropic/claude-opus-4-8
 N8N_INSTANCE_AI_MCP_SERVERS="my-tools=https://mcp.example.com/sse"
 
 # With SearXNG (free, self-hosted search)
-N8N_INSTANCE_AI_MODEL=anthropic/claude-opus-4-8
 N8N_INSTANCE_AI_SEARXNG_URL=http://searxng:8080
 
 # With Brave Search (paid API, takes priority over SearXNG)
-N8N_INSTANCE_AI_MODEL=anthropic/claude-opus-4-8
 INSTANCE_AI_BRAVE_SEARCH_API_KEY=BSA-xxx
 
 # With sandbox (n8n sandbox service)
 # CI can start it with:
 # pnpm tsx packages/testing/containers/start-sandbox.ts --network n8n-eval-net
-N8N_INSTANCE_AI_MODEL=anthropic/claude-sonnet-4-5
 N8N_INSTANCE_AI_SANDBOX_ENABLED=true
 N8N_INSTANCE_AI_SANDBOX_PROVIDER=n8n-sandbox
 N8N_SANDBOX_SERVICE_URL=https://sandbox.example.com
 N8N_SANDBOX_SERVICE_API_KEY=sandbox-key
 
 # With sandbox (Daytona — explicit provider)
-N8N_INSTANCE_AI_MODEL=anthropic/claude-opus-4-8
 N8N_INSTANCE_AI_SANDBOX_ENABLED=true
 N8N_INSTANCE_AI_SANDBOX_PROVIDER=daytona
 DAYTONA_API_URL=https://app.daytona.io/api
 DAYTONA_API_KEY=dtn_xxx
 
 # With filesystem gateway (user runs daemon on their machine)
-N8N_INSTANCE_AI_MODEL=anthropic/claude-opus-4-8
 N8N_INSTANCE_AI_GATEWAY_API_KEY=my-secret-key
 # User runs: npx @n8n/computer-use
 
 # With custom OpenAI-compatible endpoint (e.g. LM Studio, Ollama)
-N8N_INSTANCE_AI_MODEL=custom/llama-3.1-70b
 N8N_INSTANCE_AI_MODEL_URL=http://localhost:1234/v1
 
-# Full configuration with observational memory tuning
-N8N_INSTANCE_AI_MODEL=anthropic/claude-opus-4-8
-N8N_INSTANCE_AI_MCP_SERVERS="github=https://mcp.github.com/sse"
-N8N_INSTANCE_AI_MAX_STEPS=50
-N8N_INSTANCE_AI_MAX_LOOP_ITERATIONS=10
+# Output filtering — secrets + email only, with a custom placeholder
+N8N_INSTANCE_AI_OUTPUT_REDACTION_PII=email
+N8N_INSTANCE_AI_OUTPUT_REDACTION_PLACEHOLDER=‹redacted›
+
+# Observational memory tuning
 N8N_INSTANCE_AI_OBSERVER_MESSAGE_TOKENS=30000
 ```
 

--- a/packages/@n8n/instance-ai/src/runtime/resumable-stream-executor.ts
+++ b/packages/@n8n/instance-ai/src/runtime/resumable-stream-executor.ts
@@ -1,4 +1,4 @@
-import type { StreamResult } from '@n8n/agents';
+import type { RedactionOptions, StreamResult } from '@n8n/agents';
 import type { InstanceAiEvent } from '@n8n/api-types';
 
 import type { InstanceAiEventBus } from '../event-bus';
@@ -31,6 +31,8 @@ export interface ResumableStreamContext {
 	signal: AbortSignal;
 	logger: Logger;
 	onActivity?: () => void;
+	/** Output-redaction policy: omit for the safe default, or `false` to disable. */
+	outputRedaction?: RedactionOptions | false;
 }
 
 export interface ManualSuspensionControl {
@@ -196,6 +198,7 @@ export async function executeResumableStream(
 		threadId: options.context.threadId,
 		runId: options.context.runId,
 		agentId: options.context.agentId,
+		options: options.context.outputRedaction,
 	});
 
 	let currentResponseId: string | undefined;

--- a/packages/@n8n/instance-ai/src/runtime/resumable-stream-executor.ts
+++ b/packages/@n8n/instance-ai/src/runtime/resumable-stream-executor.ts
@@ -4,6 +4,7 @@ import type { InstanceAiEvent } from '@n8n/api-types';
 import type { InstanceAiEventBus } from '../event-bus';
 import type { Logger } from '../logger';
 import { mapAgentChunkToEvent } from '../stream/map-chunk';
+import { OutputRedactor } from '../stream/output-redaction';
 import { WorkSummaryAccumulator, type WorkSummary } from '../stream/work-summary-accumulator';
 import { parseSuspension, resumeAgentStream } from '../utils/stream-helpers';
 import type { SuspensionInfo } from '../utils/stream-helpers';
@@ -190,6 +191,12 @@ export async function executeResumableStream(
 	let activeAgentRunId = options.stream.runId ?? options.initialAgentRunId ?? '';
 	let text = options.stream.text;
 	const workSummaryAccumulator = new WorkSummaryAccumulator();
+	const outputRedactor = new OutputRedactor({
+		logger: options.context.logger,
+		threadId: options.context.threadId,
+		runId: options.context.runId,
+		agentId: options.context.agentId,
+	});
 
 	let currentResponseId: string | undefined;
 	let nativeStepIndex = 0;
@@ -246,13 +253,19 @@ export async function executeResumableStream(
 				hasError = true;
 			}
 
-			const event = mapAgentChunkToEvent(
+			const mappedEvent = mapAgentChunkToEvent(
 				options.context.runId,
 				options.context.agentId,
 				chunk,
 				currentResponseId,
 			);
-			if (event) {
+
+			// Scan/redact secrets & PII before events reach the user. Buffered
+			// delta text is released here at structural boundaries, so this may
+			// expand into several events (or none, while text is held back).
+			const events = mappedEvent ? outputRedactor.processEvent(mappedEvent) : [];
+
+			for (const event of events) {
 				workSummaryAccumulator.observe(event);
 				let shouldPublishEvent = true;
 
@@ -285,6 +298,11 @@ export async function executeResumableStream(
 				publishCorrections(options.context, corrections);
 				drainedCorrectionsForResume.push(...corrections);
 			}
+		}
+
+		for (const flushed of outputRedactor.flush()) {
+			workSummaryAccumulator.observe(flushed);
+			options.context.eventBus.publish(options.context.threadId, flushed);
 		}
 
 		if (options.context.signal.aborted) {

--- a/packages/@n8n/instance-ai/src/runtime/stream-runner.ts
+++ b/packages/@n8n/instance-ai/src/runtime/stream-runner.ts
@@ -1,3 +1,4 @@
+import type { RedactionOptions } from '@n8n/agents';
 import type { InstanceAiEvent } from '@n8n/api-types';
 
 import type { InstanceAiEventBus } from '../event-bus';
@@ -24,6 +25,8 @@ export interface StreamRunOptions {
 	eventBus: InstanceAiEventBus;
 	logger: Logger;
 	onActivity?: () => void;
+	/** Output-redaction policy: omit for the safe default, or `false` to disable. */
+	outputRedaction?: RedactionOptions | false;
 }
 
 export interface StreamRunResult {
@@ -75,6 +78,7 @@ async function consumeStream(
 			signal: options.signal,
 			logger: options.logger,
 			onActivity: options.onActivity,
+			outputRedaction: options.outputRedaction,
 		},
 		control: { mode: 'manual' },
 		initialAgentRunId: options.agentRunId,

--- a/packages/@n8n/instance-ai/src/stream/__tests__/output-redaction.test.ts
+++ b/packages/@n8n/instance-ai/src/stream/__tests__/output-redaction.test.ts
@@ -81,6 +81,25 @@ describe('OutputRedactor', () => {
 		expect(emitted[0]).toMatchObject({ type: 'text-delta', responseId: 'run-1:step:1' });
 	});
 
+	it('redacts secrets nested inside tool-call args', () => {
+		const redactor = createRedactor();
+		const event: InstanceAiEvent = {
+			type: 'tool-call',
+			runId: 'run-1',
+			agentId: 'agent-1',
+			payload: {
+				toolCallId: 'tc-1',
+				toolName: 'http_request',
+				args: { headers: { authorization: 'Bearer abcdef1234567890' } },
+			},
+		};
+		const [out] = redactor.processEvent(event);
+		expect(JSON.stringify(out)).toContain('[REDACTED]');
+		expect(JSON.stringify(out)).not.toContain('abcdef1234567890');
+		// Identifier fields are preserved.
+		expect(out).toMatchObject({ payload: { toolCallId: 'tc-1', toolName: 'http_request' } });
+	});
+
 	it('redacts secrets nested inside a tool-result', () => {
 		const redactor = createRedactor();
 		const event: InstanceAiEvent = {

--- a/packages/@n8n/instance-ai/src/stream/__tests__/output-redaction.test.ts
+++ b/packages/@n8n/instance-ai/src/stream/__tests__/output-redaction.test.ts
@@ -119,6 +119,16 @@ describe('OutputRedactor', () => {
 						options: ['Reply-to jane@example.com', 'Skip'],
 					},
 				],
+				tasks: { tasks: [{ id: 't1', description: 'Email jane@example.com', status: 'todo' }] },
+				planItems: [
+					{
+						id: 'p1',
+						title: 'Notify jane@example.com',
+						kind: 'task',
+						spec: 'Send to jane@example.com',
+						deps: [],
+					},
+				],
 			},
 		};
 
@@ -126,6 +136,7 @@ describe('OutputRedactor', () => {
 		const serialized = JSON.stringify(out);
 		expect(serialized).not.toContain('jane@example.com');
 		expect(serialized).toContain('[REDACTED]');
+		// Control/identifier fields are preserved so suspend/resume keeps working.
 		expect(out).toMatchObject({ payload: { requestId: 'req-1', toolCallId: 'tc-1' } });
 	});
 

--- a/packages/@n8n/instance-ai/src/stream/__tests__/output-redaction.test.ts
+++ b/packages/@n8n/instance-ai/src/stream/__tests__/output-redaction.test.ts
@@ -97,6 +97,38 @@ describe('OutputRedactor', () => {
 		expect(JSON.stringify(out)).not.toContain('abcdef1234567890');
 	});
 
+	it('redacts confirmation card display text', () => {
+		const redactor = createRedactor(createLogger(), { detect: ['email'] });
+		const event: InstanceAiEvent = {
+			type: 'confirmation-request',
+			runId: 'run-1',
+			agentId: 'agent-1',
+			payload: {
+				requestId: 'req-1',
+				toolCallId: 'tc-1',
+				toolName: 'ask',
+				args: {},
+				severity: 'warning',
+				message: 'What to do with jane@example.com?',
+				introMessage: 'I noticed jane@example.com in your request.',
+				questions: [
+					{
+						id: 'q1',
+						question: 'Where should jane@example.com be used?',
+						type: 'single',
+						options: ['Reply-to jane@example.com', 'Skip'],
+					},
+				],
+			},
+		};
+
+		const [out] = redactor.processEvent(event);
+		const serialized = JSON.stringify(out);
+		expect(serialized).not.toContain('jane@example.com');
+		expect(serialized).toContain('[REDACTED]');
+		expect(out).toMatchObject({ payload: { requestId: 'req-1', toolCallId: 'tc-1' } });
+	});
+
 	it('logs a filtering summary with category counts and no values', () => {
 		const logger = createLogger();
 		const redactor = createRedactor(logger, { secrets: true, detect: ['email'] });

--- a/packages/@n8n/instance-ai/src/stream/__tests__/output-redaction.test.ts
+++ b/packages/@n8n/instance-ai/src/stream/__tests__/output-redaction.test.ts
@@ -1,3 +1,4 @@
+import type { RedactionOptions } from '@n8n/agents';
 import type { InstanceAiEvent } from '@n8n/api-types';
 
 import type { Logger } from '../../logger';
@@ -7,8 +8,14 @@ function createLogger() {
 	return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as unknown as Logger;
 }
 
-function createRedactor(logger = createLogger()) {
-	return new OutputRedactor({ logger, threadId: 'thread-1', runId: 'run-1', agentId: 'agent-1' });
+function createRedactor(logger = createLogger(), options?: RedactionOptions | false) {
+	return new OutputRedactor({
+		logger,
+		threadId: 'thread-1',
+		runId: 'run-1',
+		agentId: 'agent-1',
+		...(options !== undefined ? { options } : {}),
+	});
 }
 
 function textDelta(text: string): InstanceAiEvent {
@@ -32,13 +39,23 @@ describe('OutputRedactor', () => {
 		expect(out).not.toContain('sk-ant-');
 	});
 
-	it('redacts a conservative PII email', () => {
-		const redactor = createRedactor();
+	it('redacts a PII email when the email category is enabled', () => {
+		const redactor = createRedactor(createLogger(), { detect: ['email'] });
 		const emitted = [
 			...redactor.processEvent(textDelta('email me at jane@example.com ok')),
 			...redactor.flush(),
 		];
 		expect(collectText(emitted)).toBe('email me at [REDACTED] ok');
+	});
+
+	it('redacts credit cards by default but leaves email untouched', () => {
+		const redactor = createRedactor();
+		const emitted = [
+			...redactor.processEvent(textDelta('card 4111 1111 1111 1111 mail jane@example.com')),
+			...redactor.flush(),
+		];
+		const out = collectText(emitted);
+		expect(out).toBe('card [REDACTED] mail jane@example.com');
 	});
 
 	it('passes non-sensitive prose through unchanged', () => {
@@ -82,7 +99,7 @@ describe('OutputRedactor', () => {
 
 	it('logs a filtering summary with category counts and no values', () => {
 		const logger = createLogger();
-		const redactor = createRedactor(logger);
+		const redactor = createRedactor(logger, { secrets: true, detect: ['email'] });
 		redactor.processEvent(
 			textDelta('key sk-ant-api03-aaaaaaaaaaaaaaaa and mail jane@example.com here'),
 		);
@@ -109,5 +126,32 @@ describe('OutputRedactor', () => {
 		redactor.processEvent(textDelta('all clear, nothing sensitive here at all'));
 		redactor.flush();
 		expect(logger.info).not.toHaveBeenCalled();
+	});
+
+	describe('when disabled (options: false)', () => {
+		function createDisabled(logger = createLogger()) {
+			return new OutputRedactor({
+				logger,
+				threadId: 'thread-1',
+				runId: 'run-1',
+				agentId: 'agent-1',
+				options: false,
+			});
+		}
+
+		it('passes events through untouched, including secrets', () => {
+			const redactor = createDisabled();
+			const input = textDelta('your key is sk-ant-api03-aaaaaaaaaaaaaaaa here');
+			const emitted = [...redactor.processEvent(input), ...redactor.flush()];
+			expect(emitted).toEqual([input]);
+		});
+
+		it('does not log a filtering summary', () => {
+			const logger = createLogger();
+			const redactor = createDisabled(logger);
+			redactor.processEvent(textDelta('key sk-ant-api03-aaaaaaaaaaaaaaaa'));
+			redactor.flush();
+			expect(logger.info).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/packages/@n8n/instance-ai/src/stream/__tests__/output-redaction.test.ts
+++ b/packages/@n8n/instance-ai/src/stream/__tests__/output-redaction.test.ts
@@ -1,0 +1,113 @@
+import type { InstanceAiEvent } from '@n8n/api-types';
+
+import type { Logger } from '../../logger';
+import { OutputRedactor } from '../output-redaction';
+
+function createLogger() {
+	return { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() } as unknown as Logger;
+}
+
+function createRedactor(logger = createLogger()) {
+	return new OutputRedactor({ logger, threadId: 'thread-1', runId: 'run-1', agentId: 'agent-1' });
+}
+
+function textDelta(text: string): InstanceAiEvent {
+	return { type: 'text-delta', runId: 'run-1', agentId: 'agent-1', payload: { text } };
+}
+
+function collectText(events: InstanceAiEvent[]): string {
+	return events.map((e) => ('payload' in e && 'text' in e.payload ? e.payload.text : '')).join('');
+}
+
+describe('OutputRedactor', () => {
+	it('redacts a secret split across two text deltas', () => {
+		const redactor = createRedactor();
+		const emitted = [
+			...redactor.processEvent(textDelta('your key is sk-ant-')),
+			...redactor.processEvent(textDelta('api03-aaaaaaaaaaaaaaaa, keep it safe')),
+			...redactor.flush(),
+		];
+		const out = collectText(emitted);
+		expect(out).toBe('your key is [REDACTED], keep it safe');
+		expect(out).not.toContain('sk-ant-');
+	});
+
+	it('redacts a conservative PII email', () => {
+		const redactor = createRedactor();
+		const emitted = [
+			...redactor.processEvent(textDelta('email me at jane@example.com ok')),
+			...redactor.flush(),
+		];
+		expect(collectText(emitted)).toBe('email me at [REDACTED] ok');
+	});
+
+	it('passes non-sensitive prose through unchanged', () => {
+		const redactor = createRedactor();
+		const text = 'The workflow completed and produced three items successfully.';
+		const emitted = [...redactor.processEvent(textDelta(text)), ...redactor.flush()];
+		expect(collectText(emitted)).toBe(text);
+	});
+
+	it('preserves responseId on flushed delta text', () => {
+		const redactor = createRedactor();
+		const emitted = [
+			...redactor.processEvent({
+				type: 'text-delta',
+				runId: 'run-1',
+				agentId: 'agent-1',
+				responseId: 'run-1:step:1',
+				payload: { text: 'hello there' },
+			}),
+			...redactor.flush(),
+		];
+		expect(emitted).toHaveLength(1);
+		expect(emitted[0]).toMatchObject({ type: 'text-delta', responseId: 'run-1:step:1' });
+	});
+
+	it('redacts secrets nested inside a tool-result', () => {
+		const redactor = createRedactor();
+		const event: InstanceAiEvent = {
+			type: 'tool-result',
+			runId: 'run-1',
+			agentId: 'agent-1',
+			payload: {
+				toolCallId: 'tc-1',
+				result: { headers: { authorization: 'Bearer abcdef1234567890' } },
+			},
+		};
+		const [out] = redactor.processEvent(event);
+		expect(JSON.stringify(out)).toContain('[REDACTED]');
+		expect(JSON.stringify(out)).not.toContain('abcdef1234567890');
+	});
+
+	it('logs a filtering summary with category counts and no values', () => {
+		const logger = createLogger();
+		const redactor = createRedactor(logger);
+		redactor.processEvent(
+			textDelta('key sk-ant-api03-aaaaaaaaaaaaaaaa and mail jane@example.com here'),
+		);
+		redactor.flush();
+
+		expect(logger.info).toHaveBeenCalledWith(
+			'Instance AI redacted sensitive content from agent output',
+			expect.objectContaining({
+				threadId: 'thread-1',
+				runId: 'run-1',
+				agentId: 'agent-1',
+				count: 2,
+				categories: { secret: 1, email: 1 },
+			}),
+		);
+		const meta = vi.mocked(logger.info).mock.calls[0][1];
+		expect(JSON.stringify(meta)).not.toContain('sk-ant-');
+		expect(JSON.stringify(meta)).not.toContain('jane@example.com');
+	});
+
+	it('does not log when nothing is redacted', () => {
+		const logger = createLogger();
+		const redactor = createRedactor(logger);
+		redactor.processEvent(textDelta('all clear, nothing sensitive here at all'));
+		redactor.flush();
+		expect(logger.info).not.toHaveBeenCalled();
+	});
+});

--- a/packages/@n8n/instance-ai/src/stream/consume-with-hitl.ts
+++ b/packages/@n8n/instance-ai/src/stream/consume-with-hitl.ts
@@ -1,3 +1,4 @@
+import type { RedactionOptions } from '@n8n/agents';
 import type { InstanceAiEvent } from '@n8n/api-types';
 
 import type { InstanceAiEventBus } from '../event-bus/event-bus.interface';
@@ -33,6 +34,8 @@ export interface ConsumeWithHitlOptions {
 	resumeOptions?: Record<string, unknown>;
 	/** Native agent persistence owner for suspended sub-agent state. */
 	persistence?: { threadId: string; resourceId: string };
+	/** Output-redaction policy: omit for the safe default, or `false` to disable. */
+	outputRedaction?: RedactionOptions | false;
 }
 
 export interface ConsumeWithHitlResult {
@@ -89,6 +92,7 @@ export async function consumeStreamWithHitl(
 			eventBus: options.eventBus,
 			signal: options.abortSignal,
 			logger: options.logger,
+			outputRedaction: options.outputRedaction,
 		},
 		control: {
 			mode: 'auto',
@@ -122,6 +126,8 @@ export interface ConsumeStreamCascadingOptions {
 	logger: Logger;
 	threadId: string;
 	abortSignal: AbortSignal;
+	/** Output-redaction policy: omit for the safe default, or `false` to disable. */
+	outputRedaction?: RedactionOptions | false;
 }
 
 export type ConsumeStreamCascadingResult =
@@ -168,6 +174,7 @@ export async function consumeStreamCascading(
 			eventBus: options.eventBus,
 			signal: options.abortSignal,
 			logger: options.logger,
+			outputRedaction: options.outputRedaction,
 		},
 		control: { mode: 'manual' },
 	});

--- a/packages/@n8n/instance-ai/src/stream/output-redaction.ts
+++ b/packages/@n8n/instance-ai/src/stream/output-redaction.ts
@@ -11,12 +11,15 @@ import type { Logger } from '../logger';
 
 /**
  * Default output-filtering policy for Instance AI: redact known credential/
- * secret patterns plus high-confidence PII. `block`/`warn` strategies are
- * supported by the engine but not yet surfaced here.
+ * secret patterns plus credit-card numbers. Other PII categories (`email`,
+ * `ssn-us`) are implemented but off by default until we decide which to enable.
+ *
+ * Instance AI always redacts matches. The SDK's `GuardrailStrategy` also defines
+ * `block` and `warn`, but those are not implemented here.
  */
 export const DEFAULT_OUTPUT_REDACTION_OPTIONS: RedactionOptions = {
 	secrets: true,
-	detect: ['email', 'credit-card', 'ssn'],
+	detect: ['credit-card'],
 };
 
 interface OutputRedactorContext {
@@ -24,7 +27,11 @@ interface OutputRedactorContext {
 	threadId: string;
 	runId: string;
 	agentId: string;
-	options?: RedactionOptions;
+	/**
+	 * Redaction policy: omit for the safe default, pass options to customise, or
+	 * `false` to disable scanning entirely (events pass through untouched).
+	 */
+	options?: RedactionOptions | false;
 }
 
 type DeltaType = 'text-delta' | 'reasoning-delta';
@@ -51,6 +58,8 @@ interface Channel {
  * stream segment ends to release any remainder and log a filtering summary.
  */
 export class OutputRedactor {
+	private readonly enabled: boolean;
+
 	private readonly options: RedactionOptions;
 
 	private readonly text: Channel;
@@ -60,13 +69,19 @@ export class OutputRedactor {
 	private matches: RedactionCategory[] = [];
 
 	constructor(private readonly context: OutputRedactorContext) {
-		this.options = context.options ?? DEFAULT_OUTPUT_REDACTION_OPTIONS;
+		this.enabled = context.options !== false;
+		// When disabled the options are unused; default keeps the type concrete.
+		this.options =
+			context.options === false || context.options === undefined
+				? DEFAULT_OUTPUT_REDACTION_OPTIONS
+				: context.options;
 		this.text = { type: 'text-delta', redactor: new StreamingRedactor(this.options) };
 		this.reasoning = { type: 'reasoning-delta', redactor: new StreamingRedactor(this.options) };
 	}
 
 	/** Redact an outgoing event; returns the ordered events that should be published. */
 	processEvent(event: InstanceAiEvent): InstanceAiEvent[] {
+		if (!this.enabled) return [event];
 		if (event.type === 'text-delta') return this.processDelta(event, this.text);
 		if (event.type === 'reasoning-delta') return this.processDelta(event, this.reasoning);
 
@@ -80,6 +95,7 @@ export class OutputRedactor {
 
 	/** Release buffered text for both channels and log a filtering summary. Call at segment end. */
 	flush(): InstanceAiEvent[] {
+		if (!this.enabled) return [];
 		const events = [...this.drainChannel(this.reasoning), ...this.drainChannel(this.text)];
 		this.logSummary();
 		return events;

--- a/packages/@n8n/instance-ai/src/stream/output-redaction.ts
+++ b/packages/@n8n/instance-ai/src/stream/output-redaction.ts
@@ -1,0 +1,155 @@
+import {
+	StreamingRedactor,
+	redactText,
+	redactDeep,
+	type RedactionCategory,
+	type RedactionOptions,
+} from '@n8n/agents';
+import type { InstanceAiEvent } from '@n8n/api-types';
+
+import type { Logger } from '../logger';
+
+/**
+ * Default output-filtering policy for Instance AI: redact known credential/
+ * secret patterns plus high-confidence PII. `block`/`warn` strategies are
+ * supported by the engine but not yet surfaced here.
+ */
+export const DEFAULT_OUTPUT_REDACTION_OPTIONS: RedactionOptions = {
+	secrets: true,
+	detect: ['email', 'credit-card', 'ssn'],
+};
+
+interface OutputRedactorContext {
+	logger: Logger;
+	threadId: string;
+	runId: string;
+	agentId: string;
+	options?: RedactionOptions;
+}
+
+type DeltaType = 'text-delta' | 'reasoning-delta';
+
+interface Channel {
+	readonly type: DeltaType;
+	readonly redactor: StreamingRedactor;
+	responseId?: string;
+}
+
+/**
+ * Scans agent output events for secrets/PII before they reach the user and
+ * redacts matches in place.
+ *
+ * Text/reasoning deltas are streamed through a holdback-buffered redactor so a
+ * secret split across chunk boundaries is caught. Buffered text is released
+ * (with its original `responseId`) whenever a structural event (tool call,
+ * result, …) or a new step boundary arrives — secrets never span those
+ * boundaries — so event ordering and step grouping are preserved. Tool
+ * results/errors are redacted one-shot.
+ *
+ * One instance per run. Call {@link processEvent} on each mapped event; it
+ * returns the ordered events to publish. Call {@link flush} when the active
+ * stream segment ends to release any remainder and log a filtering summary.
+ */
+export class OutputRedactor {
+	private readonly options: RedactionOptions;
+
+	private readonly text: Channel;
+
+	private readonly reasoning: Channel;
+
+	private matches: RedactionCategory[] = [];
+
+	constructor(private readonly context: OutputRedactorContext) {
+		this.options = context.options ?? DEFAULT_OUTPUT_REDACTION_OPTIONS;
+		this.text = { type: 'text-delta', redactor: new StreamingRedactor(this.options) };
+		this.reasoning = { type: 'reasoning-delta', redactor: new StreamingRedactor(this.options) };
+	}
+
+	/** Redact an outgoing event; returns the ordered events that should be published. */
+	processEvent(event: InstanceAiEvent): InstanceAiEvent[] {
+		if (event.type === 'text-delta') return this.processDelta(event, this.text);
+		if (event.type === 'reasoning-delta') return this.processDelta(event, this.reasoning);
+
+		// Structural event: release any buffered text first so ordering is kept.
+		return [
+			...this.drainChannel(this.reasoning),
+			...this.drainChannel(this.text),
+			this.redactStructural(event),
+		];
+	}
+
+	/** Release buffered text for both channels and log a filtering summary. Call at segment end. */
+	flush(): InstanceAiEvent[] {
+		const events = [...this.drainChannel(this.reasoning), ...this.drainChannel(this.text)];
+		this.logSummary();
+		return events;
+	}
+
+	private processDelta(
+		event: Extract<InstanceAiEvent, { type: DeltaType }>,
+		channel: Channel,
+	): InstanceAiEvent[] {
+		const events: InstanceAiEvent[] = [];
+		// A new step: release the previous step's text under its own responseId.
+		if (channel.responseId !== undefined && channel.responseId !== event.responseId) {
+			events.push(...this.drainChannel(channel));
+		}
+		channel.responseId = event.responseId;
+
+		const { text, matches } = channel.redactor.push(event.payload.text);
+		this.recordMatches(matches);
+		if (text) events.push(this.makeDelta(channel, text));
+		return events;
+	}
+
+	private drainChannel(channel: Channel): InstanceAiEvent[] {
+		const { text, matches } = channel.redactor.flush();
+		this.recordMatches(matches);
+		return text ? [this.makeDelta(channel, text)] : [];
+	}
+
+	private makeDelta(channel: Channel, text: string): InstanceAiEvent {
+		return {
+			type: channel.type,
+			runId: this.context.runId,
+			agentId: this.context.agentId,
+			...(channel.responseId ? { responseId: channel.responseId } : {}),
+			payload: { text },
+		};
+	}
+
+	private redactStructural(event: InstanceAiEvent): InstanceAiEvent {
+		if (event.type === 'tool-result') {
+			const { value, matches } = redactDeep(event.payload.result, this.options);
+			this.recordMatches(matches);
+			return { ...event, payload: { ...event.payload, result: value } };
+		}
+		if (event.type === 'tool-error') {
+			const { text, matches } = redactText(event.payload.error, this.options);
+			this.recordMatches(matches);
+			return { ...event, payload: { ...event.payload, error: text } };
+		}
+		return event;
+	}
+
+	private recordMatches(matches: Array<{ category: RedactionCategory }>): void {
+		for (const match of matches) this.matches.push(match.category);
+	}
+
+	/** Emit a single filtering-event log per segment — categories and counts only, never values. */
+	private logSummary(): void {
+		if (this.matches.length === 0) return;
+		const categories: Partial<Record<RedactionCategory, number>> = {};
+		for (const category of this.matches) {
+			categories[category] = (categories[category] ?? 0) + 1;
+		}
+		this.context.logger.info('Instance AI redacted sensitive content from agent output', {
+			threadId: this.context.threadId,
+			runId: this.context.runId,
+			agentId: this.context.agentId,
+			count: this.matches.length,
+			categories,
+		});
+		this.matches = [];
+	}
+}

--- a/packages/@n8n/instance-ai/src/stream/output-redaction.ts
+++ b/packages/@n8n/instance-ai/src/stream/output-redaction.ts
@@ -154,9 +154,10 @@ export class OutputRedactor {
 
 	/**
 	 * Redact the human-readable text of a HITL confirmation card (message, intro,
-	 * and question/option labels). Control and identifier fields — `requestId`,
-	 * `toolCallId`, `inputType`, `credentialRequests`, etc. — are left untouched
-	 * so suspend/resume routing keeps working.
+	 * question/option labels, and task/plan-item descriptions). Control and
+	 * identifier fields — `requestId`, `toolCallId`, `inputType`,
+	 * `credentialRequests`, task `id`/`status`, plan `kind`/`deps`, etc. — are
+	 * left untouched so suspend/resume routing keeps working.
 	 */
 	private redactConfirmation(
 		event: Extract<InstanceAiEvent, { type: 'confirmation-request' }>,
@@ -168,6 +169,23 @@ export class OutputRedactor {
 			...(question.options ? { options: question.options.map((o) => this.redactString(o)) } : {}),
 		}));
 
+		const tasks = payload.tasks
+			? {
+					...payload.tasks,
+					tasks: payload.tasks.tasks.map((task) => ({
+						...task,
+						description: this.redactString(task.description),
+						...(task.detail ? { detail: this.redactString(task.detail) } : {}),
+					})),
+				}
+			: undefined;
+
+		const planItems = payload.planItems?.map((item) => ({
+			...item,
+			title: this.redactString(item.title),
+			spec: this.redactString(item.spec),
+		}));
+
 		return {
 			...event,
 			payload: {
@@ -175,6 +193,8 @@ export class OutputRedactor {
 				message: this.redactString(payload.message),
 				...(payload.introMessage ? { introMessage: this.redactString(payload.introMessage) } : {}),
 				...(questions ? { questions } : {}),
+				...(tasks ? { tasks } : {}),
+				...(planItems ? { planItems } : {}),
 			},
 		};
 	}

--- a/packages/@n8n/instance-ai/src/stream/output-redaction.ts
+++ b/packages/@n8n/instance-ai/src/stream/output-redaction.ts
@@ -8,6 +8,7 @@ import {
 import type { InstanceAiEvent } from '@n8n/api-types';
 
 import type { Logger } from '../logger';
+import { isRecord } from '../utils/stream-helpers';
 
 /**
  * Default output-filtering policy for Instance AI: redact known credential/
@@ -135,6 +136,16 @@ export class OutputRedactor {
 	}
 
 	private redactStructural(event: InstanceAiEvent): InstanceAiEvent {
+		if (event.type === 'tool-call') {
+			// Redact the model-generated args shown in the UI. This only touches the
+			// event payload, not the actual tool invocation (handled by the runtime).
+			const { value, matches } = redactDeep(event.payload.args, this.options);
+			this.recordMatches(matches);
+			return {
+				...event,
+				payload: { ...event.payload, args: isRecord(value) ? value : event.payload.args },
+			};
+		}
 		if (event.type === 'tool-result') {
 			const { value, matches } = redactDeep(event.payload.result, this.options);
 			this.recordMatches(matches);

--- a/packages/@n8n/instance-ai/src/stream/output-redaction.ts
+++ b/packages/@n8n/instance-ai/src/stream/output-redaction.ts
@@ -141,11 +141,48 @@ export class OutputRedactor {
 			return { ...event, payload: { ...event.payload, result: value } };
 		}
 		if (event.type === 'tool-error') {
-			const { text, matches } = redactText(event.payload.error, this.options);
-			this.recordMatches(matches);
-			return { ...event, payload: { ...event.payload, error: text } };
+			return {
+				...event,
+				payload: { ...event.payload, error: this.redactString(event.payload.error) },
+			};
+		}
+		if (event.type === 'confirmation-request') {
+			return this.redactConfirmation(event);
 		}
 		return event;
+	}
+
+	/**
+	 * Redact the human-readable text of a HITL confirmation card (message, intro,
+	 * and question/option labels). Control and identifier fields — `requestId`,
+	 * `toolCallId`, `inputType`, `credentialRequests`, etc. — are left untouched
+	 * so suspend/resume routing keeps working.
+	 */
+	private redactConfirmation(
+		event: Extract<InstanceAiEvent, { type: 'confirmation-request' }>,
+	): InstanceAiEvent {
+		const payload = event.payload;
+		const questions = payload.questions?.map((question) => ({
+			...question,
+			question: this.redactString(question.question),
+			...(question.options ? { options: question.options.map((o) => this.redactString(o)) } : {}),
+		}));
+
+		return {
+			...event,
+			payload: {
+				...payload,
+				message: this.redactString(payload.message),
+				...(payload.introMessage ? { introMessage: this.redactString(payload.introMessage) } : {}),
+				...(questions ? { questions } : {}),
+			},
+		};
+	}
+
+	private redactString(text: string): string {
+		const { text: redacted, matches } = redactText(text, this.options);
+		this.recordMatches(matches);
+		return redacted;
 	}
 
 	private recordMatches(matches: Array<{ category: RedactionCategory }>): void {

--- a/packages/@n8n/instance-ai/src/tools/orchestration/delegate.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/delegate.tool.ts
@@ -354,6 +354,7 @@ export function createDelegateTool(context: OrchestrationContext) {
 						eventBus: context.eventBus,
 						logger: context.logger,
 						threadId: context.threadId,
+						outputRedaction: context.outputRedaction,
 						abortSignal: context.abortSignal,
 						waitForConfirmation: context.waitForConfirmation,
 						maxIterations,

--- a/packages/@n8n/instance-ai/src/tools/orchestration/delegate.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/delegate.tool.ts
@@ -202,6 +202,7 @@ export async function startDetachedDelegateTask(
 					eventBus: context.eventBus,
 					logger: context.logger,
 					threadId: context.threadId,
+					outputRedaction: context.outputRedaction,
 					abortSignal: signal,
 					waitForConfirmation: context.waitForConfirmation,
 					drainCorrections,

--- a/packages/@n8n/instance-ai/src/tools/orchestration/eval-setup-agent.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/eval-setup-agent.tool.ts
@@ -187,6 +187,7 @@ export function startEvalSetupAgentTask(
 					eventBus: context.eventBus,
 					logger: context.logger,
 					threadId: context.threadId,
+					outputRedaction: context.outputRedaction,
 					abortSignal: signal,
 					waitForConfirmation: context.waitForConfirmation,
 					drainCorrections,

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -4,6 +4,7 @@ import type {
 	BuiltMemory,
 	BuiltTool,
 	CheckpointStore,
+	RedactionOptions,
 	RuntimeSkillSource,
 	ModelConfig as NativeModelConfig,
 	Telemetry,
@@ -1212,6 +1213,8 @@ export interface OrchestrationContext {
 	subAgentMaxSteps: number;
 	eventBus: InstanceAiEventBus;
 	logger: Logger;
+	/** Output-redaction policy for sub-agent streams: omit for the safe default, or `false` to disable. */
+	outputRedaction?: RedactionOptions | false;
 	trackTelemetry?: (eventName: string, properties: Record<string, GenericValue>) => void;
 	domainTools: InstanceAiToolRegistry;
 	abortSignal: AbortSignal;

--- a/packages/@n8n/utils/src/scrub-secrets.ts
+++ b/packages/@n8n/utils/src/scrub-secrets.ts
@@ -12,10 +12,10 @@
  * positives on file paths, IDs, or base64 payloads would make the output
  * unreadable.
  */
-const SECRET_KEYS =
+export const SECRET_KEYS =
 	'password|passwd|secret|credentials?|api[_-]?key|authorization|access[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?token|auth[_-]?token';
 
-const SECRET_VALUE_PATTERNS: readonly RegExp[] = [
+export const SECRET_VALUE_PATTERNS: readonly RegExp[] = [
 	// Authorization-header substrings: `Bearer <token>`, `Basic <token>`, `Token <token>`
 	/\b(?:Bearer|Basic|Token)\s+[A-Za-z0-9._~+/=-]{12,}/gi,
 	// OpenAI / Anthropic API keys

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -709,6 +709,12 @@ type TerminalGuardOrderServiceInternals = {
 	liveness: { consumeRunTimeout: jest.Mock };
 	telemetry: { track: jest.Mock };
 	logger: { warn: jest.Mock; error: jest.Mock };
+	instanceAiConfig: {
+		outputRedactionEnabled: boolean;
+		outputRedactionSecrets: boolean;
+		outputRedactionPii: string;
+		outputRedactionPlaceholder: string;
+	};
 	traceContextsByRunId: Map<string, { threadId: string; messageGroupId?: string }>;
 	threadPushRef: Map<string, string>;
 	finalizeRunTracing: jest.Mock;
@@ -781,6 +787,12 @@ function createTerminalGuardOrderService(): TerminalGuardOrderServiceInternals {
 	service.liveness = { consumeRunTimeout: jest.fn(() => ({ timedOut: false })) };
 	service.telemetry = { track: jest.fn() };
 	service.logger = { warn: jest.fn(), error: jest.fn() };
+	service.instanceAiConfig = {
+		outputRedactionEnabled: true,
+		outputRedactionSecrets: true,
+		outputRedactionPii: 'credit-card',
+		outputRedactionPlaceholder: '[REDACTED]',
+	};
 	service.traceContextsByRunId = new Map([
 		['run-1', { threadId: 'thread-a', messageGroupId: 'group-1' }],
 	]);

--- a/packages/cli/src/modules/instance-ai/__tests__/output-redaction-config.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/output-redaction-config.test.ts
@@ -1,0 +1,61 @@
+import type { InstanceAiConfig } from '@n8n/config';
+
+import { resolveOutputRedaction } from '../output-redaction-config';
+
+function config(overrides: Partial<InstanceAiConfig> = {}): InstanceAiConfig {
+	return {
+		outputRedactionEnabled: true,
+		outputRedactionSecrets: true,
+		outputRedactionPii: 'email,credit-card,ssn-us',
+		outputRedactionPlaceholder: '[REDACTED]',
+		...overrides,
+	} as InstanceAiConfig;
+}
+
+describe('resolveOutputRedaction', () => {
+	it('returns false when disabled', () => {
+		expect(resolveOutputRedaction(config({ outputRedactionEnabled: false }))).toBe(false);
+	});
+
+	it('maps secrets, PII categories, and placeholder from config', () => {
+		expect(resolveOutputRedaction(config())).toEqual({
+			secrets: true,
+			detect: ['email', 'credit-card', 'ssn-us'],
+			placeholder: '[REDACTED]',
+		});
+	});
+
+	it('trims and drops unknown PII categories', () => {
+		expect(resolveOutputRedaction(config({ outputRedactionPii: 'email, bogus , ssn-us' }))).toEqual(
+			{
+				secrets: true,
+				detect: ['email', 'ssn-us'],
+				placeholder: '[REDACTED]',
+			},
+		);
+	});
+
+	it('drops not-yet-implemented categories (phone, address)', () => {
+		expect(
+			resolveOutputRedaction(config({ outputRedactionPii: 'email,phone,address,ssn-us' })),
+		).toMatchObject({ detect: ['email', 'ssn-us'] });
+	});
+
+	it('honors the secrets toggle and an empty PII list', () => {
+		expect(
+			resolveOutputRedaction(config({ outputRedactionSecrets: false, outputRedactionPii: '' })),
+		).toEqual({ secrets: false, detect: [], placeholder: '[REDACTED]' });
+	});
+
+	it('uses a custom placeholder', () => {
+		expect(resolveOutputRedaction(config({ outputRedactionPlaceholder: '***' }))).toMatchObject({
+			placeholder: '***',
+		});
+	});
+
+	it('omits the placeholder when configured blank (engine default applies)', () => {
+		expect(resolveOutputRedaction(config({ outputRedactionPlaceholder: '' }))).not.toHaveProperty(
+			'placeholder',
+		);
+	});
+});

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -4203,6 +4203,7 @@ export class InstanceAiService {
 								eventBus: this.eventBus,
 								logger: this.logger,
 								onActivity: () => this.runState.touchActiveRun(threadId),
+								outputRedaction: resolveOutputRedaction(this.instanceAiConfig),
 							},
 						);
 					})
@@ -5214,6 +5215,7 @@ export class InstanceAiService {
 								logger: this.logger,
 								agentRunId: opts.agentRunId,
 								onActivity: () => this.runState.touchActiveRun(opts.threadId),
+								outputRedaction: resolveOutputRedaction(this.instanceAiConfig),
 							},
 						);
 					})

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -98,6 +98,7 @@ import { InstanceAiGatewayService } from './instance-ai-gateway.service';
 import { InstanceAiMemoryService } from './instance-ai-memory.service';
 import { InstanceAiSettingsService } from './instance-ai-settings.service';
 import { InstanceAiAdapterService } from './instance-ai.adapter.service';
+import { resolveOutputRedaction } from './output-redaction-config';
 import { AUTO_FOLLOW_UP_MESSAGE } from './internal-messages';
 import { INSTANCE_AI_RUN_TIMEOUT_REASON, InstanceAiLivenessService } from './liveness';
 import { InstanceAiMcpRegistryService } from './mcp';
@@ -3094,6 +3095,7 @@ export class InstanceAiService {
 			subAgentMaxSteps: this.instanceAiConfig.subAgentMaxSteps,
 			eventBus: this.eventBus,
 			logger: this.logger,
+			outputRedaction: resolveOutputRedaction(this.instanceAiConfig),
 			trackTelemetry: (eventName, properties) => {
 				this.telemetry.track(eventName, properties);
 			},
@@ -4226,6 +4228,7 @@ export class InstanceAiService {
 							eventBus: this.eventBus,
 							logger: this.logger,
 							onActivity: () => this.runState.touchActiveRun(threadId),
+							outputRedaction: resolveOutputRedaction(this.instanceAiConfig),
 						},
 					);
 			if (result.status === 'suspended') {
@@ -5231,6 +5234,7 @@ export class InstanceAiService {
 							logger: this.logger,
 							agentRunId: opts.agentRunId,
 							onActivity: () => this.runState.touchActiveRun(opts.threadId),
+							outputRedaction: resolveOutputRedaction(this.instanceAiConfig),
 						},
 					);
 

--- a/packages/cli/src/modules/instance-ai/output-redaction-config.ts
+++ b/packages/cli/src/modules/instance-ai/output-redaction-config.ts
@@ -1,0 +1,29 @@
+import {
+	SUPPORTED_PII_CATEGORIES,
+	type PiiDetectionType,
+	type RedactionOptions,
+} from '@n8n/agents';
+import type { InstanceAiConfig } from '@n8n/config';
+
+/**
+ * Resolve the Instance AI output-redaction policy from env config.
+ * Returns `false` when disabled so the redactor passes events through untouched.
+ */
+export function resolveOutputRedaction(config: InstanceAiConfig): RedactionOptions | false {
+	if (!config.outputRedactionEnabled) return false;
+
+	const detect = config.outputRedactionPii
+		.split(',')
+		.map((value) => value.trim())
+		.filter((value): value is PiiDetectionType =>
+			(SUPPORTED_PII_CATEGORIES as readonly string[]).includes(value),
+		);
+
+	const placeholder = config.outputRedactionPlaceholder;
+	return {
+		secrets: config.outputRedactionSecrets,
+		detect,
+		// Fall back to the engine default when configured blank.
+		...(placeholder ? { placeholder } : {}),
+	};
+}


### PR DESCRIPTION
## Summary

Implements **output filtering** for Instance AI: agent-produced output is scanned for secrets/PII and redacted before it reaches the user, and filtering events are logged.

Previously credential safety was structural (secrets never decrypted into workflow JSON; eval bodies sanitized before the LLM), but there was no pass that scanned the agent's own free-form output. This adds one.

### Reusable engine in `@n8n/agents`

A new guardrail redaction engine lives next to the existing (stub) `Guardrail` API, so both Instance AI and the modern agents feature (both built on `@n8n/agents`) can use it, and a future `.outputGuardrail()` runtime wiring can call straight into it.

- **`redactText` / `redactDeep`** — one-shot redaction for complete strings and structured (tool-result) values.
- **`StreamingRedactor`** — stateful, holdback-buffered redaction for token-by-token streams. A secret split across deltas (`sk-ant-` then the rest) is caught; the cut-at-whitespace rule plus a full-buffer match scan ensure a match (incl. spaced credit-card numbers) is never emitted half-redacted.
- **Secret patterns** are sourced from `@n8n/utils` (`scrubSecretsInText`) as the single source of truth.
- PII patterns are conservative and high-confidence: `email`, `credit-card` (Luhn-validated), `ssn-us`. `phone`/`address` are reserved in `PiiDetectionType` but not implemented (setting them is a no-op). 
  - **Note**: These PII patterns are mostly PoC placeholders for now, we need to figure out what we actually want - the focus of this PR is on the secrets. `credit-card` is enabled by default.

### Wired into Instance AI

Redaction is applied in the per-run stream loop (`resumable-stream-executor.ts`) for the orchestrator **and** delegated sub-agents:

- Streamed `text-delta` / `reasoning-delta` (step/ordering and `responseId` preserved — buffered text is released whole at structural boundaries).
- `tool-call` args (UI display only — the actual tool invocation is unaffected) and `tool-result` / `tool-error` payloads.
- HITL **confirmation card** display text (`message`, `introMessage`, question/option labels, and `tasks`/`planItems` titles)
- A filtering event is logged on redaction — **categories and counts only, never the values**.

### Configurable via env

| Variable | Default | Description |
|---|---|---|
| `N8N_INSTANCE_AI_OUTPUT_REDACTION_ENABLED` | `true` | Master switch; `false` = events pass through untouched. |
| `N8N_INSTANCE_AI_OUTPUT_REDACTION_SECRETS` | `true` | Redact credential/secret patterns. |
| `N8N_INSTANCE_AI_OUTPUT_REDACTION_PII` | `credit-card` | Comma-separated PII categories (`email`, `credit-card`, `ssn-us`). Empty = none. |
| `N8N_INSTANCE_AI_OUTPUT_REDACTION_PLACEHOLDER` | `[REDACTED]` | Replacement text. |

The primary target is **secrets infiltration**; PII defaults to `credit-card` only while we evaluate false-positive rates for the others. `block`/`warn` guardrail strategies are not implemented — Instance AI always redacts.

### Scope notes

Redaction is applied to agent output that flows through the live event stream (`executeResumableStream`): assistant/reasoning deltas, tool results/errors, and HITL confirmation cards (including `tasks`/`planItems` display text), for both the orchestrator and delegated sub-agents (sync and detached).

**Out of scope — follow-ups:**

- **Telemetry/tracing payloads are not redacted.** `result.text` and the detached sub-agent `agent-completed` result are used for telemetry/tracing/trace outputs without passing through the redactor. This is deliberately deferred because it is non-trivial:
  - `result.text` is **dual-purpose** — besides tracing it is fed back into the model (sub-agent results return to the parent via the delegate tool) and persisted to memory/reloaded into context. So it can't be redacted at the source without corrupting agent reasoning; redaction must happen per-egress at the trace sinks only.
  - Telemetry likely warrants a **stricter, full-PII policy** than the user-facing default (which defaults to `credit-card` only), since traces persist and may leave the instance (e.g. LangSmith). That needs its own policy/config rather than reusing `outputRedaction`.
- **Some direct-publish egress paths bypass the redactor:** `tasks-update` events (model-generated, user-visible) and identifier fields the model can set.
- A future change may **centralise** redaction at the Instance AI event-publication/result boundary so new paths are covered by default (no single clean seam exists today — and the dual-use of `result.text` is why a naive central hook is unsafe).
- Wiring `.outputGuardrail()` enforcement into the `@n8n/agents` runtime, and surfacing `block`/`warn` in the UI, are also out of scope.

## How to test

1. Set `N8N_INSTANCE_AI_MODEL` and start n8n with Instance AI enabled.
2. Ask the agent to echo a fake secret, e.g. `sk-ant-api03-xxxxxxxxxxxxxxxx`, or a Luhn-valid test card `4111 1111 1111 1111`.
3. Confirm the streamed reply (and any tool output / HITL question) shows `[REDACTED]` in place of the value, and the server logs `Instance AI redacted sensitive content from agent output` with category counts (no values).
4. Toggle `N8N_INSTANCE_AI_OUTPUT_REDACTION_ENABLED=false` and confirm output passes through untouched.

Automated: `pnpm --filter @n8n/agents test guardrails`, `pnpm --filter @n8n/instance-ai test output-redaction`, `pnpm --filter n8n test output-redaction-config`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-464

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. <!-- env vars documented in packages/@n8n/instance-ai/docs/configuration.md -->
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


