### PR TITLE
test: impact selector demo — code change (DO NOT MERGE)

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/ChainLLM/ChainLlm.node.ts
@@ -1,3 +1,4 @@
+// E2E impact-selector demo — DO NOT MERGE (verifies scoped selection)
 import type {
 	IExecuteFunctions,
 	INodeExecutionData,


### PR DESCRIPTION
Stacked on #31928. Changes one mapped source file (`ChainLlm.node.ts`) to verify the impact selector emits a **scoped** matrix (~2 specs) rather than broad. Do not merge — verification only.