### PR TITLE
chore(core): Tag sandbox snapshot to release

### DIFF
--- a/packages/@n8n/instance-ai/scripts/build-snapshot.cjs
+++ b/packages/@n8n/instance-ai/scripts/build-snapshot.cjs
@@ -5,16 +5,15 @@
  * Run from the n8n release pipeline (see
  * `.github/workflows/release-build-daytona-snapshot.yml`). Authenticates
  * with a static Daytona admin API key supplied via env vars and creates
- * the snapshot named `n8n/instance-ai:<version>-<setupHash>` from the same image
+ * the snapshot named `n8n/instance-ai:<version>` from the same image
  * descriptor used by the runtime fallback path. Re-runs against the same
  * version are idempotent — "already exists" is treated as success.
  *
- * The runtime never calls `snapshot.create` through the sandbox proxy in
- * cloud mode; CI is the only producer of cloud snapshots.
+ * The runtime never calls `snapshot.create`; CI is the only producer of
+ * versioned snapshots.
  *
  * The actual create-with-already-exists logic lives in
- * `SnapshotManager.createSnapshot` so the runtime (direct mode) and CI
- * share a single implementation.
+ * `SnapshotManager.createSnapshot`.
  *
  * CommonJS so Node resolves the package via `main: dist/index.js` instead
  * of the bundler-only `module: src/index.ts` entry.

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/create-workspace.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/create-workspace.test.ts
@@ -6,43 +6,29 @@ const {
 	mockCreateSharedSandbox,
 	mockCreateFilesystem,
 	mockSnapshotManagerConstructor,
-	mockEnsureSnapshot,
+	mockSnapshotName,
 	mockEnsureImage,
-	mockDaytonaConstructor,
 } = vi.hoisted(() => ({
 	mockCreateSharedSandbox: vi.fn(),
 	mockCreateFilesystem: vi.fn(),
 	mockSnapshotManagerConstructor: vi.fn(),
-	mockEnsureSnapshot: vi.fn(),
+	mockSnapshotName: vi.fn(),
 	mockEnsureImage: vi.fn(),
-	mockDaytonaConstructor: vi.fn(),
 }));
 
 vi.mock('@n8n/agents/sandbox', async (importOriginal) => ({
 	...(await importOriginal<typeof SharedSandboxMod>()),
 	createSandbox: mockCreateSharedSandbox,
 	createFilesystem: mockCreateFilesystem,
-	loadDaytona: () => ({
-		Daytona: class {
-			constructor(config: unknown) {
-				mockDaytonaConstructor(config);
-			}
-		},
-	}),
 }));
 
 vi.mock('../snapshot-manager', () => ({
 	SnapshotManager: class {
-		constructor(
-			baseImage: string | undefined,
-			logger: unknown,
-			n8nVersion: string | undefined,
-			errorReporter: unknown,
-		) {
-			mockSnapshotManagerConstructor(baseImage, logger, n8nVersion, errorReporter);
+		constructor(baseImage: string | undefined, logger: unknown, n8nVersion: string | undefined) {
+			mockSnapshotManagerConstructor(baseImage, logger, n8nVersion);
 		}
 
-		ensureSnapshot = mockEnsureSnapshot;
+		snapshotName = mockSnapshotName;
 		ensureImage = mockEnsureImage;
 	},
 }));
@@ -96,7 +82,7 @@ describe('createSandbox', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
 		mockCreateSharedSandbox.mockResolvedValue(sandbox);
-		mockEnsureSnapshot.mockResolvedValue('snapshot-name');
+		mockSnapshotName.mockReturnValue('n8n/instance-ai:1.2.3');
 		mockEnsureImage.mockResolvedValue({ dockerfile: 'FROM node:20' });
 	});
 
@@ -152,7 +138,7 @@ describe('createSandbox', () => {
 		});
 	});
 
-	it('prepares snapshot and image in Daytona direct snapshot fallback mode', async () => {
+	it('prepares image in direct Daytona snapshot fallback mode without a versioned snapshot', async () => {
 		const config: SandboxConfig = {
 			enabled: true,
 			provider: 'daytona',
@@ -169,17 +155,8 @@ describe('createSandbox', () => {
 
 		await expect(createSandbox(config, options)).resolves.toBe(sandbox);
 
-		expect(mockSnapshotManagerConstructor).toHaveBeenCalledWith(
-			'node:20',
-			logger,
-			'1.2.3',
-			errorReporter,
-		);
-		expect(mockDaytonaConstructor).toHaveBeenCalledWith({
-			apiKey: 'test-key',
-			apiUrl: 'https://api.daytona.io',
-		});
-		expect(mockEnsureSnapshot).toHaveBeenCalledWith(expect.any(Object), 'direct');
+		expect(mockSnapshotManagerConstructor).toHaveBeenCalledWith('node:20', logger, '1.2.3');
+		expect(mockSnapshotName).not.toHaveBeenCalled();
 		expect(mockEnsureImage).toHaveBeenCalledWith();
 		const sharedConfig = mockCreateSharedSandbox.mock.calls[0][0] as DaytonaSandboxConfig;
 		expect(mockCreateSharedSandbox).toHaveBeenCalledWith(
@@ -193,7 +170,6 @@ describe('createSandbox', () => {
 				labels: {
 					'n8n-instance-ai-sandbox-id': sharedConfig.id,
 				},
-				snapshot: 'snapshot-name',
 			},
 			{ logger, errorReporter },
 		);
@@ -213,7 +189,6 @@ describe('createSandbox', () => {
 			undefined,
 			expect.anything(),
 			'1.2.3',
-			undefined,
 		);
 	});
 
@@ -229,12 +204,7 @@ describe('createSandbox', () => {
 
 		await createSandbox(config, { logger, useSnapshotFallback: true });
 
-		expect(mockSnapshotManagerConstructor).toHaveBeenCalledWith(
-			undefined,
-			logger,
-			'1.2.3',
-			undefined,
-		);
+		expect(mockSnapshotManagerConstructor).toHaveBeenCalledWith(undefined, logger, '1.2.3');
 	});
 
 	it('prepares snapshot and image in Daytona proxy snapshot fallback mode', async () => {
@@ -256,8 +226,7 @@ describe('createSandbox', () => {
 			}),
 		).resolves.toBe(sandbox);
 
-		expect(mockDaytonaConstructor).not.toHaveBeenCalled();
-		expect(mockEnsureSnapshot).toHaveBeenCalledWith(undefined, 'proxy');
+		expect(mockSnapshotName).toHaveBeenCalledWith();
 		expect(mockEnsureImage).toHaveBeenCalledWith();
 		const sharedConfig = mockCreateSharedSandbox.mock.calls[0][0] as DaytonaSandboxConfig;
 		expect(mockCreateSharedSandbox).toHaveBeenCalledWith(
@@ -271,7 +240,7 @@ describe('createSandbox', () => {
 				labels: {
 					'n8n-instance-ai-sandbox-id': sharedConfig.id,
 				},
-				snapshot: 'snapshot-name',
+				snapshot: 'n8n/instance-ai:1.2.3',
 			},
 			{ logger, errorReporter },
 		);

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/snapshot-image-context.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/snapshot-image-context.test.ts
@@ -53,6 +53,22 @@ describe('snapshot-image-context', () => {
 		);
 	});
 
+	it('removes stale files when reusing a cache-keyed staging directory', async () => {
+		const cacheKey = 'cccccccccccc-dddddddddddd';
+		const filesWithExtra = new Map([
+			[`${WORKSPACE_ROOT}/package.json`, '{"name":"a"}'],
+			[`${WORKSPACE_ROOT}/skills/removed/SKILL.md`, '# Removed'],
+		]);
+		const filesWithoutExtra = new Map([[`${WORKSPACE_ROOT}/package.json`, '{"name":"b"}']]);
+
+		const first = await stageWorkspaceFilesForImage(filesWithExtra, WORKSPACE_ROOT, cacheKey);
+		const second = await stageWorkspaceFilesForImage(filesWithoutExtra, WORKSPACE_ROOT, cacheKey);
+		tempDirs.push(first.stagingDir);
+
+		expect(second.stagingDir).toBe(first.stagingDir);
+		await expect(access(join(first.stagingDir, 'skills/removed/SKILL.md'))).rejects.toThrow();
+	});
+
 	it('disposeSnapshotImageContext removes the staging directory', async () => {
 		const files = new Map([[`${WORKSPACE_ROOT}/build.mjs`, 'export {};']]);
 		const { stagingDir } = await stageWorkspaceFilesForImage(files, WORKSPACE_ROOT);

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/snapshot-manager.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/snapshot-manager.test.ts
@@ -71,7 +71,7 @@ import { join } from 'node:path';
 import type { Logger } from '../../logger';
 import { SnapshotManager } from '../snapshot-manager';
 
-const SNAPSHOT_NAME_PATTERN = /^n8n\/instance-ai:1\.123\.0-[a-f0-9]{12}-[a-f0-9]{12}$/;
+const SNAPSHOT_NAME = 'n8n/instance-ai:1.123.0';
 const SKILLS_HASH_A = 'aaaaaaaaaaaa';
 const SKILLS_HASH_B = 'bbbbbbbbbbbb';
 
@@ -141,13 +141,6 @@ function makeFakeDaytona(): FakeDaytona {
 	};
 }
 
-async function knowledgeBaseHash(): Promise<string> {
-	const { buildKnowledgeBaseWorkspaceBundle } = await import(
-		'../../knowledge-base/materialize-knowledge-base'
-	);
-	return (await buildKnowledgeBaseWorkspaceBundle({ root: '/home/daytona/workspace' })).contentHash;
-}
-
 describe('SnapshotManager.ensureImage', () => {
 	it('stages workspace files and builds a small COPY-based Daytona image descriptor', async () => {
 		const manager = new SnapshotManager(undefined, NOOP_LOGGER, '1.123.0');
@@ -164,6 +157,7 @@ describe('SnapshotManager.ensureImage', () => {
 
 		const stagingDir = image.contextList[0]?.sourcePath;
 		expect(stagingDir).toBeDefined();
+		expect(stagingDir).toContain('n8n-snapshot-context-1.123.0');
 		await expect(
 			readFile(join(stagingDir, 'skills/data-table-manager/SKILL.md'), 'utf-8'),
 		).resolves.toContain('data-table');
@@ -190,37 +184,43 @@ describe('SnapshotManager.ensureImage', () => {
 		).resolves.toBeDefined();
 	});
 
-	it('changes the snapshot suffix when the runtime skills hash changes', async () => {
+	it('uses a content-hash cache key when no n8n version is configured', async () => {
+		const manager = new SnapshotManager(undefined, NOOP_LOGGER, undefined);
+
+		const image = await manager.ensureImage();
+		const stagingDir = image.contextList[0]?.sourcePath;
+
+		expect(stagingDir).toBeDefined();
+		expect(stagingDir).not.toContain('n8n-snapshot-context-temp-');
+		expect(stagingDir).toMatch(/n8n-snapshot-context-.+-/);
+	});
+
+	it('uses the same snapshot name regardless of runtime skills hash', async () => {
 		const daytonaA = makeFakeDaytona();
 		const daytonaB = makeFakeDaytona();
-		daytonaA.snapshot.create.mockResolvedValue({ name: 'ignored-a' });
-		daytonaB.snapshot.create.mockResolvedValue({ name: 'ignored-b' });
+		daytonaA.snapshot.create.mockResolvedValue({ name: SNAPSHOT_NAME });
+		daytonaB.snapshot.create.mockResolvedValue({ name: SNAPSHOT_NAME });
 		const managerA = new SnapshotManager(
 			undefined,
 			NOOP_LOGGER,
 			'1.123.0',
-			undefined,
 			createRuntimeSkillSource(SKILLS_HASH_A),
 		);
 		const managerB = new SnapshotManager(
 			undefined,
 			NOOP_LOGGER,
 			'1.123.0',
-			undefined,
 			createRuntimeSkillSource(SKILLS_HASH_B),
 		);
 
 		const snapshotA = await managerA.createSnapshot(daytonaA as never);
 		const snapshotB = await managerB.createSnapshot(daytonaB as never);
 
-		expect(snapshotA).toMatch(SNAPSHOT_NAME_PATTERN);
-		expect(snapshotB).toMatch(SNAPSHOT_NAME_PATTERN);
-		expect(snapshotA).toBe(`n8n/instance-ai:1.123.0-${SKILLS_HASH_A}-${await knowledgeBaseHash()}`);
-		expect(snapshotB).toBe(`n8n/instance-ai:1.123.0-${SKILLS_HASH_B}-${await knowledgeBaseHash()}`);
-		expect(snapshotA).not.toBe(snapshotB);
+		expect(snapshotA).toBe(SNAPSHOT_NAME);
+		expect(snapshotB).toBe(SNAPSHOT_NAME);
 	});
 
-	it('keeps the snapshot suffix stable when the base image changes', async () => {
+	it('keeps the snapshot name stable when the base image changes', async () => {
 		const daytonaA = makeFakeDaytona();
 		const daytonaB = makeFakeDaytona();
 		daytonaA.snapshot.create.mockResolvedValue({ name: 'ignored-a' });
@@ -229,22 +229,20 @@ describe('SnapshotManager.ensureImage', () => {
 			'daytonaio/sandbox:0.5.0',
 			NOOP_LOGGER,
 			'1.123.0',
-			undefined,
 			createRuntimeSkillSource(SKILLS_HASH_A),
 		);
 		const managerB = new SnapshotManager(
 			'node:24',
 			NOOP_LOGGER,
 			'1.123.0',
-			undefined,
 			createRuntimeSkillSource(SKILLS_HASH_A),
 		);
 
 		const snapshotA = await managerA.createSnapshot(daytonaA as never);
 		const snapshotB = await managerB.createSnapshot(daytonaB as never);
 
-		expect(snapshotA).toBe(`n8n/instance-ai:1.123.0-${SKILLS_HASH_A}-${await knowledgeBaseHash()}`);
-		expect(snapshotB).toBe(snapshotA);
+		expect(snapshotA).toBe(SNAPSHOT_NAME);
+		expect(snapshotB).toBe(SNAPSHOT_NAME);
 		expect(daytonaA.snapshot.create.mock.calls[0][0].image.dockerfile).toContain(
 			'FROM daytonaio/sandbox:0.5.0',
 		);
@@ -260,10 +258,10 @@ describe('SnapshotManager.createSnapshot', () => {
 
 		const result = await manager.createSnapshot(daytona as never);
 
-		expect(result).toMatch(SNAPSHOT_NAME_PATTERN);
+		expect(result).toBe(SNAPSHOT_NAME);
 		expect(daytona.snapshot.create).toHaveBeenCalledTimes(1);
 		const callArgs = daytona.snapshot.create.mock.calls[0][0];
-		expect(callArgs.name).toMatch(SNAPSHOT_NAME_PATTERN);
+		expect(callArgs.name).toBe(SNAPSHOT_NAME);
 		expect(callArgs.image).toBeDefined();
 	});
 
@@ -274,7 +272,7 @@ describe('SnapshotManager.createSnapshot', () => {
 
 		const result = await manager.createSnapshot(daytona as never);
 
-		expect(result).toMatch(SNAPSHOT_NAME_PATTERN);
+		expect(result).toBe(SNAPSHOT_NAME);
 	});
 
 	it('treats messages mentioning "already exists" as success', async () => {
@@ -286,7 +284,7 @@ describe('SnapshotManager.createSnapshot', () => {
 
 		const result = await manager.createSnapshot(daytona as never);
 
-		expect(result).toMatch(SNAPSHOT_NAME_PATTERN);
+		expect(result).toBe(SNAPSHOT_NAME);
 	});
 
 	it('throws on transient errors', async () => {
@@ -314,135 +312,21 @@ describe('SnapshotManager.createSnapshot', () => {
 		await manager.createSnapshot(daytona as never, { timeout: 1800, onLogs });
 
 		const [snapshotParams, options] = daytona.snapshot.create.mock.calls[0];
-		expect(snapshotParams.name).toMatch(SNAPSHOT_NAME_PATTERN);
+		expect(snapshotParams.name).toBe(SNAPSHOT_NAME);
 		expect(options).toMatchObject({ timeout: 1800, onLogs });
 	});
 });
 
-describe('SnapshotManager.ensureSnapshot', () => {
-	describe('when no version is provided', () => {
-		it('returns null without calling daytona', async () => {
-			const manager = new SnapshotManager(undefined, NOOP_LOGGER, undefined);
-			const daytona = makeFakeDaytona();
+describe('SnapshotManager.snapshotName', () => {
+	it('returns null when no version is configured', () => {
+		const manager = new SnapshotManager(undefined, NOOP_LOGGER, undefined);
 
-			const result = await manager.ensureSnapshot(daytona as never, 'direct');
-
-			expect(result).toBeNull();
-			expect(daytona.snapshot.get).not.toHaveBeenCalled();
-			expect(daytona.snapshot.create).not.toHaveBeenCalled();
-		});
-
-		it('returns null in proxy mode without calling daytona', async () => {
-			const manager = new SnapshotManager(undefined, NOOP_LOGGER, undefined);
-			const daytona = makeFakeDaytona();
-
-			const result = await manager.ensureSnapshot(daytona as never, 'proxy');
-
-			expect(result).toBeNull();
-			expect(daytona.snapshot.get).not.toHaveBeenCalled();
-		});
+		expect(manager.snapshotName()).toBeNull();
 	});
 
-	describe('proxy mode', () => {
-		it('returns the snapshot name without calling daytona', async () => {
-			const manager = new SnapshotManager(undefined, NOOP_LOGGER, '1.123.0');
-			const daytona = makeFakeDaytona();
+	it('returns the versioned snapshot name', () => {
+		const manager = new SnapshotManager(undefined, NOOP_LOGGER, '1.123.0');
 
-			const result = await manager.ensureSnapshot(daytona as never, 'proxy');
-
-			expect(result).toMatch(SNAPSHOT_NAME_PATTERN);
-			expect(daytona.snapshot.get).not.toHaveBeenCalled();
-			expect(daytona.snapshot.create).not.toHaveBeenCalled();
-		});
-	});
-
-	describe('direct mode', () => {
-		it('optimistically creates and returns the snapshot name', async () => {
-			const manager = new SnapshotManager(undefined, NOOP_LOGGER, '1.123.0');
-			const daytona = makeFakeDaytona();
-			daytona.snapshot.create.mockResolvedValue({ name: 'n8n/instance-ai:1.123.0' });
-
-			const result = await manager.ensureSnapshot(daytona as never, 'direct');
-
-			expect(result).toMatch(SNAPSHOT_NAME_PATTERN);
-			expect(daytona.snapshot.create).toHaveBeenCalledTimes(1);
-			expect(daytona.snapshot.get).not.toHaveBeenCalled();
-		});
-
-		it('treats 409 conflict as success', async () => {
-			const manager = new SnapshotManager(undefined, NOOP_LOGGER, '1.123.0');
-			const daytona = makeFakeDaytona();
-			daytona.snapshot.create.mockRejectedValue(new DaytonaError('already exists', 409));
-
-			const result = await manager.ensureSnapshot(daytona as never, 'direct');
-
-			expect(result).toMatch(SNAPSHOT_NAME_PATTERN);
-		});
-
-		it('returns null and clears memoization on transient errors', async () => {
-			const manager = new SnapshotManager(undefined, NOOP_LOGGER, '1.123.0');
-			const daytona = makeFakeDaytona();
-			daytona.snapshot.create
-				.mockRejectedValueOnce(new DaytonaError('upstream 500', 500))
-				.mockResolvedValueOnce({ name: 'n8n/instance-ai:1.123.0' });
-
-			const first = await manager.ensureSnapshot(daytona as never, 'direct');
-			const second = await manager.ensureSnapshot(daytona as never, 'direct');
-
-			expect(first).toBeNull();
-			expect(second).toMatch(SNAPSHOT_NAME_PATTERN);
-			expect(daytona.snapshot.create).toHaveBeenCalledTimes(2);
-		});
-
-		it('memoizes a successful create — does not call create twice', async () => {
-			const manager = new SnapshotManager(undefined, NOOP_LOGGER, '1.123.0');
-			const daytona = makeFakeDaytona();
-			daytona.snapshot.create.mockResolvedValue({ name: 'n8n/instance-ai:1.123.0' });
-
-			await manager.ensureSnapshot(daytona as never, 'direct');
-			const second = await manager.ensureSnapshot(daytona as never, 'direct');
-
-			expect(second).toMatch(SNAPSHOT_NAME_PATTERN);
-			expect(daytona.snapshot.create).toHaveBeenCalledTimes(1);
-		});
-
-		it('reports transient failures via the error reporter', async () => {
-			const errorReporter = { error: vi.fn() };
-			const manager = new SnapshotManager(undefined, NOOP_LOGGER, '1.123.0', errorReporter);
-			const daytona = makeFakeDaytona();
-			const error = new DaytonaError('upstream 500', 500);
-			daytona.snapshot.create.mockRejectedValue(error);
-
-			await manager.ensureSnapshot(daytona as never, 'direct');
-
-			expect(errorReporter.error).toHaveBeenCalledWith(
-				error,
-				expect.objectContaining({
-					tags: expect.objectContaining({ component: 'snapshot-manager' }) as unknown,
-				}),
-			);
-		});
-
-		it('does not report when create succeeds', async () => {
-			const errorReporter = { error: vi.fn() };
-			const manager = new SnapshotManager(undefined, NOOP_LOGGER, '1.123.0', errorReporter);
-			const daytona = makeFakeDaytona();
-			daytona.snapshot.create.mockResolvedValue({ name: 'n8n/instance-ai:1.123.0' });
-
-			await manager.ensureSnapshot(daytona as never, 'direct');
-
-			expect(errorReporter.error).not.toHaveBeenCalled();
-		});
-
-		it('does not report 409/already-exists as an error', async () => {
-			const errorReporter = { error: vi.fn() };
-			const manager = new SnapshotManager(undefined, NOOP_LOGGER, '1.123.0', errorReporter);
-			const daytona = makeFakeDaytona();
-			daytona.snapshot.create.mockRejectedValue(new DaytonaError('already exists', 409));
-
-			await manager.ensureSnapshot(daytona as never, 'direct');
-
-			expect(errorReporter.error).not.toHaveBeenCalled();
-		});
+		expect(manager.snapshotName()).toBe(SNAPSHOT_NAME);
 	});
 });

--- a/packages/@n8n/instance-ai/src/workspace/create-workspace.ts
+++ b/packages/@n8n/instance-ai/src/workspace/create-workspace.ts
@@ -9,7 +9,6 @@ import {
 	type SandboxConfig as SharedSandboxConfig,
 	type SandboxInstance,
 	type SandboxProvider,
-	loadDaytona,
 } from '@n8n/agents/sandbox';
 import { randomUUID } from 'node:crypto';
 
@@ -89,25 +88,15 @@ export async function createSandbox(
 		});
 	}
 
-	const mode = config.getAuthToken ? 'proxy' : 'direct';
 	const logger = options.logger ?? config.logger ?? NOOP_LOGGER;
 	const snapshotManager = new SnapshotManager(
 		typeof config.image === 'string' ? config.image : undefined,
 		logger,
 		config.n8nVersion,
-		options.errorReporter,
 	);
 
-	const snapshot =
-		mode === 'direct'
-			? await snapshotManager.ensureSnapshot(
-					new (loadDaytona().Daytona)({
-						apiKey: config.daytonaApiKey,
-						apiUrl: config.daytonaApiUrl,
-					}),
-					mode,
-				)
-			: await snapshotManager.ensureSnapshot(undefined, mode);
+	const isProxyMode = config.getAuthToken !== undefined;
+	const snapshot = isProxyMode ? (snapshotManager.snapshotName() ?? undefined) : undefined;
 	const image = await snapshotManager.ensureImage();
 
 	return await createSharedSandbox(

--- a/packages/@n8n/instance-ai/src/workspace/snapshot-image-context.ts
+++ b/packages/@n8n/instance-ai/src/workspace/snapshot-image-context.ts
@@ -35,6 +35,7 @@ export async function stageWorkspaceFilesForImage(
 	if (cacheKey) {
 		stagingDir = join(tmpdir(), `${SNAPSHOT_CONTEXT_PREFIX}${cacheKey}`);
 
+		await rm(stagingDir, { recursive: true, force: true });
 		await mkdir(stagingDir, { recursive: true });
 	} else {
 		stagingDir = await mkdtemp(join(tmpdir(), `${SNAPSHOT_CONTEXT_PREFIX}temp-`));

--- a/packages/@n8n/instance-ai/src/workspace/snapshot-manager.ts
+++ b/packages/@n8n/instance-ai/src/workspace/snapshot-manager.ts
@@ -1,18 +1,12 @@
 /**
  * Prepares and caches a Daytona Image descriptor with config files,
  * node_modules, and runtime skills pre-installed, and resolves a versioned
- * named snapshot (`n8n/instance-ai:<n8nVersion>-<skillsHash>-<knowledgeBaseHash>`) for sandbox
- * creation.
+ * named snapshot (`n8n/instance-ai:<n8nVersion>`) for sandbox creation.
  *
- * Two strategies for `ensureSnapshot`:
- * - 'direct' mode (self-hosted): optimistic create via `snapshot.create`.
- *   Treats a 409 / "already exists" response as success. Any other failure
- *   is reported (when an `errorReporter` is wired) and the manager falls
- *   back to declarative image so the next request retries the create.
- * - 'proxy' mode (cloud): trusts CI to have published the snapshot for
- *   this version and returns the name without an upstream call. The
- *   sandbox-create request validates existence; missing-snapshot failures
- *   surface there with a discriminable Daytona error.
+ * `snapshotName` derives the versioned snapshot name for the running n8n
+ * version. CI is the producer of snapshots
+ * (see `scripts/build-snapshot.cjs`); the sandbox-create request validates
+ * existence and falls back to the declarative image when missing.
  *
  * The node-types catalog is NOT baked into the image (too large for API body limit).
  * It's written to each sandbox after creation via the filesystem API.
@@ -26,7 +20,7 @@ import {
 	buildKnowledgeBaseWorkspaceBundle,
 	type KnowledgeBaseWorkspaceBundle,
 } from '../knowledge-base/materialize-knowledge-base';
-import type { ErrorReporter, Logger } from '../logger';
+import type { Logger } from '../logger';
 import {
 	BuilderTemplatesService,
 	builderTemplatesOptionsFromEnv,
@@ -36,8 +30,6 @@ import { disposeSnapshotImageContext, stageWorkspaceFilesForImage } from './snap
 import { buildRuntimeSkillWorkspaceBundle } from '../skills/materialize-runtime-skills';
 import { loadInstanceAiRuntimeSkillSource } from '../skills/runtime-skills';
 
-export type SnapshotMode = 'direct' | 'proxy';
-
 export interface CreateSnapshotOptions {
 	timeout?: number;
 	onLogs?: (chunk: string) => void;
@@ -45,9 +37,6 @@ export interface CreateSnapshotOptions {
 
 const DAYTONA_WORKSPACE_BAKE_ROOT = '/tmp/n8n-workspace-bake';
 const SNAPSHOT_WORKSPACE_LAYOUT_DIRS = ['src', 'chunks', 'node-types'] as const;
-const EMPTY_RUNTIME_SKILLS_HASH = '000000000000';
-const EMPTY_KNOWLEDGE_BASE_HASH = '000000000000';
-
 function isAlreadyExistsError(error: unknown): error is TDaytonaError {
 	const { DaytonaError } = loadDaytona();
 	if (!(error instanceof DaytonaError)) return false;
@@ -57,10 +46,6 @@ function isAlreadyExistsError(error: unknown): error is TDaytonaError {
 
 export class SnapshotManager {
 	private cachedImage: Promise<Image> | null = null;
-
-	private snapshotPromise: Promise<string | null> | null = null;
-
-	private snapshotSuffixPromise: Promise<string> | null = null;
 
 	private runtimeSkillBundlePromise: ReturnType<typeof buildRuntimeSkillWorkspaceBundle> | null =
 		null;
@@ -73,7 +58,6 @@ export class SnapshotManager {
 		private readonly baseImage: string | undefined,
 		private readonly logger: Logger,
 		private readonly n8nVersion: string | undefined,
-		private readonly errorReporter?: ErrorReporter,
 		private readonly runtimeSkillSource?: RuntimeSkillSource,
 		private readonly templatesService?: BuilderTemplatesService,
 	) {}
@@ -88,7 +72,8 @@ export class SnapshotManager {
 		const base = this.baseImage ?? 'daytonaio/sandbox:0.5.0';
 		const runtimeSkillBundle = await this.runtimeSkillBundle();
 		const knowledgeBaseBundle = await this.knowledgeBaseBundle();
-		const cacheKey = await this.snapshotSuffix();
+		const cacheKey =
+			this.n8nVersion ?? `${runtimeSkillBundle?.skillsHash}-${knowledgeBaseBundle.contentHash}`;
 
 		const workspaceFiles = new Map<string, string>([
 			...(runtimeSkillBundle?.files ?? []),
@@ -134,12 +119,14 @@ export class SnapshotManager {
 	 * version are idempotent. Throws on transient or unexpected errors so
 	 * callers can decide whether to retry, fall back, or fail loudly.
 	 *
-	 * Single source of truth for snapshot creation across:
-	 * - Runtime direct mode (lazy create on first builder invocation)
-	 * - CI release pipeline (`scripts/build-snapshot.cjs`)
+	 * Single source of truth for snapshot creation in the CI release pipeline
+	 * (`scripts/build-snapshot.cjs`). Runtime never calls this.
 	 */
 	async createSnapshot(daytona: Daytona, options?: CreateSnapshotOptions): Promise<string> {
-		const name = await this.snapshotName();
+		const name = this.snapshotName();
+		if (!name) {
+			throw new Error('SnapshotManager: n8nVersion is required to derive a snapshot name');
+		}
 
 		try {
 			await daytona.snapshot.create({ name, image: await this.ensureImage() }, options);
@@ -155,54 +142,13 @@ export class SnapshotManager {
 	}
 
 	/**
-	 * Resolve the named snapshot for the running n8n version, returning the
-	 * snapshot name if it can be used, or null if the caller should fall back
-	 * to the declarative image.
-	 *
-	 * - 'proxy': returns the name without an upstream call. CI is the only
-	 *   producer of cloud snapshots; trusting the name keeps the proxy
-	 *   surface minimal (no `snapshot.get` allow-list needed). Existence is
-	 *   validated implicitly by the subsequent `daytona.create({ snapshot })`.
-	 * - 'direct': lazy-creates the snapshot via `createSnapshot`, memoized
-	 *   per process. On transient failure, clears the memo so the next
-	 *   request retries, and reports the error.
+	 * Derive the versioned snapshot name for the running n8n version, or null
+	 * when no version is configured. Existence is validated implicitly by the
+	 * subsequent `daytona.create({ snapshot })`.
 	 */
-	async ensureSnapshot(daytona: Daytona | undefined, mode: SnapshotMode): Promise<string | null> {
+	snapshotName(): string | null {
 		if (!this.n8nVersion) return null;
-		const name = await this.snapshotName();
-
-		if (mode === 'proxy') return name;
-		if (!daytona) {
-			throw new Error('SnapshotManager: Daytona client is required to create a snapshot');
-		}
-
-		this.snapshotPromise ??= this.createSnapshot(daytona).catch((error) => {
-			this.errorReporter?.error(error, {
-				tags: { component: 'snapshot-manager', operation: 'create-snapshot' },
-				extra: { snapshotName: name },
-			});
-			this.logger.warn('Failed to create versioned snapshot; using declarative image', {
-				name,
-				error: error instanceof Error ? error.message : String(error),
-			});
-			return null;
-		});
-
-		const result = await this.snapshotPromise;
-		if (result === null) this.snapshotPromise = null;
-		return result;
-	}
-
-	private async snapshotSuffix(): Promise<string> {
-		this.snapshotSuffixPromise ??= (async () => {
-			const runtimeSkillBundle = await this.runtimeSkillBundle();
-			const knowledgeBaseBundle = await this.knowledgeBaseBundle();
-			const skillsHash = runtimeSkillBundle?.skillsHash ?? EMPTY_RUNTIME_SKILLS_HASH;
-			const knowledgeBaseHash = knowledgeBaseBundle.contentHash ?? EMPTY_KNOWLEDGE_BASE_HASH;
-			return `${skillsHash}-${knowledgeBaseHash}`;
-		})();
-
-		return await this.snapshotSuffixPromise;
+		return `n8n/instance-ai:${this.n8nVersion}`;
 	}
 
 	private async runtimeSkillBundle(): ReturnType<typeof buildRuntimeSkillWorkspaceBundle> {
@@ -233,19 +179,10 @@ export class SnapshotManager {
 		});
 	}
 
-	private async snapshotName(): Promise<string> {
-		if (!this.n8nVersion) {
-			throw new Error('SnapshotManager: n8nVersion is required to derive a snapshot name');
-		}
-		return `n8n/instance-ai:${this.n8nVersion}-${await this.snapshotSuffix()}`;
-	}
-
 	/** Invalidate cached image (e.g., when base image changes). */
 	invalidate(): void {
 		const stagingDir = this.stagingDir;
 		this.cachedImage = null;
-		this.snapshotPromise = null;
-		this.snapshotSuffixPromise = null;
 		this.runtimeSkillBundlePromise = null;
 		this.knowledgeBaseBundlePromise = null;
 		this.stagingDir = null;


### PR DESCRIPTION
## Summary

Currently snapshots are created based on hash of files we add in from kb and skills. This sets it to the version number of n8n

## Related Linear tickets, Github issues, and Community forum posts
RESOLVES INS-473

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
