### PR TITLE
chore(core): Add dev mode for sandbox materialization and snapshot

### DIFF
--- a/packages/@n8n/config/src/configs/instance-ai.config.ts
+++ b/packages/@n8n/config/src/configs/instance-ai.config.ts
@@ -73,6 +73,22 @@ export class InstanceAiConfig {
 	sandboxNamePrefix: string = '';
 
 	/**
+	 * Dev only. Skip pre-built Daytona snapshots and always materialize the declarative
+	 * image at runtime. Useful when iterating on skills, knowledge base, or image contents.
+	 * Ignored unless the sandbox provider is `daytona`.
+	 */
+	@Env('N8N_INSTANCE_AI_DAYTONA_RUNTIME_MATERIALIZE')
+	daytonaRuntimeMaterialize: boolean = false;
+
+	/**
+	 * Dev only. Override the Daytona snapshot name used at sandbox creation
+	 * (e.g. `n8n/instance-ai:dev-local`). Pair with `build-snapshot.cjs --snapshot-name`
+	 * to regenerate the snapshot manually. Ignored unless the sandbox provider is `daytona`.
+	 */
+	@Env('N8N_INSTANCE_AI_DAYTONA_SNAPSHOT_NAME')
+	daytonaSnapshotName: string = '';
+
+	/**
 	 * Skew (milliseconds) used to proactively refresh the Daytona proxy JWT before it expires.
 	 * Refresh fires when the cached token's remaining lifetime falls below this threshold.
 	 * Only used in proxy mode (when a `getAuthToken` callback is configured); ignored for static API keys.

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -298,6 +298,8 @@ describe('GlobalConfig', () => {
 			n8nSandboxServiceApiKey: '',
 			sandboxTimeout: 300000,
 			sandboxNamePrefix: '',
+			daytonaRuntimeMaterialize: false,
+			daytonaSnapshotName: '',
 			daytonaTokenRefreshSkewMs: 300_000,
 			builderSandboxTtlMs: 900_000,
 			braveSearchApiKey: '',

--- a/packages/@n8n/instance-ai/docs/configuration.md
+++ b/packages/@n8n/instance-ai/docs/configuration.md
@@ -65,6 +65,8 @@ When no search provider is available, the `web-search` action is disabled. `fetc
 | `N8N_INSTANCE_AI_SANDBOX_IMAGE` | string | `daytonaio/sandbox:0.5.0` | Docker image for the Daytona sandbox. |
 | `N8N_INSTANCE_AI_SANDBOX_TIMEOUT` | number | `300000` | Default command timeout in the sandbox (milliseconds). |
 | `N8N_INSTANCE_AI_SANDBOX_NAME_PREFIX` | string | `''` | Prefix prepended to every Daytona sandbox name (e.g. `eval-baseline-daily`). Also surfaced as a `name_prefix` label. Empty in production. |
+| `N8N_INSTANCE_AI_DAYTONA_RUNTIME_MATERIALIZE` | boolean | `false` | **Dev only.** Skip pre-built Daytona snapshots and always materialize the declarative image at runtime. Useful when iterating on skills or image contents. Ignored unless the provider is `daytona`. |
+| `N8N_INSTANCE_AI_DAYTONA_SNAPSHOT_NAME` | string | `''` | **Dev only.** Override the version-derived Daytona snapshot name (e.g. `n8n/instance-ai:dev-local`). Pair with `build-snapshot.cjs --snapshot-name` to regenerate manually. Ignored unless the provider is `daytona`. |
 
 When sandbox is enabled, the builder agent writes TypeScript to
 `~/workspace/src/workflow.ts`, runs `tsc` for validation, and uses

--- a/packages/@n8n/instance-ai/docs/sandboxing.md
+++ b/packages/@n8n/instance-ai/docs/sandboxing.md
@@ -247,3 +247,5 @@ If any step fails, the agent reads the error output, fixes the code, and retries
 | `N8N_INSTANCE_AI_SANDBOX_IMAGE` | `daytonaio/sandbox:0.5.0` | Base container image for Daytona |
 | `N8N_INSTANCE_AI_SANDBOX_TIMEOUT` | `300000` | Command timeout in milliseconds |
 | `N8N_INSTANCE_AI_SANDBOX_NAME_PREFIX` | — | Prefix for every Daytona sandbox name (e.g. `eval-baseline-daily`). Also added as a `name_prefix` label. Empty in production. |
+| `N8N_INSTANCE_AI_DAYTONA_RUNTIME_MATERIALIZE` | `false` | Dev only: skip snapshots, always build from the declarative image |
+| `N8N_INSTANCE_AI_DAYTONA_SNAPSHOT_NAME` | — | Dev only: override snapshot name used at sandbox creation |

--- a/packages/@n8n/instance-ai/scripts/build-snapshot.cjs
+++ b/packages/@n8n/instance-ai/scripts/build-snapshot.cjs
@@ -24,18 +24,28 @@
  *
  * Usage:
  *   node packages/@n8n/instance-ai/scripts/build-snapshot.cjs --version 1.123.0
+ *   node packages/@n8n/instance-ai/scripts/build-snapshot.cjs --version 1.123.0 --snapshot-name n8n/instance-ai:dev-local
  */
 
 const { Daytona } = require('@daytonaio/sdk');
 const { SnapshotManager } = require('@n8n/instance-ai');
 
-function parseVersion(argv) {
-	const flagIdx = argv.indexOf('--version');
+function parseFlagValue(argv, flag) {
+	const flagIdx = argv.indexOf(flag);
 	if (flagIdx !== -1 && argv[flagIdx + 1]) return argv[flagIdx + 1];
+	const prefix = `${flag}=`;
 	for (const arg of argv) {
-		if (arg.startsWith('--version=')) return arg.slice('--version='.length);
+		if (arg.startsWith(prefix)) return arg.slice(prefix.length);
 	}
-	return process.env.N8N_VERSION;
+	return undefined;
+}
+
+function parseVersion(argv) {
+	return parseFlagValue(argv, '--version') ?? process.env.N8N_VERSION;
+}
+
+function parseSnapshotName(argv) {
+	return parseFlagValue(argv, '--snapshot-name') ?? process.env.N8N_INSTANCE_AI_DAYTONA_SNAPSHOT_NAME;
 }
 
 const consoleLogger = {
@@ -59,6 +69,7 @@ async function main() {
 	}
 	const apiUrl = process.env.DAYTONA_API_URL || undefined;
 
+	const snapshotName = parseSnapshotName(process.argv.slice(2));
 	const daytona = new Daytona({ apiKey, apiUrl });
 	const baseImage = process.env.SANDBOX_IMAGE || undefined;
 	const manager = new SnapshotManager(baseImage, consoleLogger, version);
@@ -66,6 +77,7 @@ async function main() {
 	const name = await manager.createSnapshot(daytona, {
 		timeout: 1800,
 		onLogs: (chunk) => process.stdout.write(`${chunk}\n`),
+		...(snapshotName ? { name: snapshotName } : {}),
 	});
 
 	consoleLogger.info('Snapshot ready', { name });

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/create-workspace.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/create-workspace.test.ts
@@ -207,6 +207,99 @@ describe('createSandbox', () => {
 		expect(mockSnapshotManagerConstructor).toHaveBeenCalledWith(undefined, logger, '1.2.3');
 	});
 
+	it('skips snapshot when runtime materialization is forced in proxy mode', async () => {
+		const getAuthToken = vi.fn().mockResolvedValue('jwt-token');
+		const config: SandboxConfig = {
+			enabled: true,
+			provider: 'daytona',
+			daytonaApiUrl: 'https://proxy.example.com',
+			getAuthToken,
+			image: 'node:20',
+			n8nVersion: '1.2.3',
+		};
+
+		await createSandbox(config, {
+			logger,
+			errorReporter,
+			useSnapshotFallback: true,
+			runtimeMaterialize: true,
+		});
+
+		expect(mockSnapshotName).not.toHaveBeenCalled();
+		const sharedConfig = mockCreateSharedSandbox.mock.calls[0][0] as DaytonaSandboxConfig;
+		expect(sharedConfig.snapshot).toBeUndefined();
+	});
+
+	it('prefers runtime materialization over a custom snapshot name and warns', async () => {
+		const config: SandboxConfig = {
+			enabled: true,
+			provider: 'daytona',
+			daytonaApiUrl: 'https://api.daytona.io',
+			daytonaApiKey: 'test-key',
+			image: 'node:20',
+			n8nVersion: '1.2.3',
+		};
+
+		await createSandbox(config, {
+			logger,
+			errorReporter,
+			useSnapshotFallback: true,
+			runtimeMaterialize: true,
+			snapshotName: 'n8n/instance-ai:dev-local',
+		});
+
+		const sharedConfig = mockCreateSharedSandbox.mock.calls[0][0] as DaytonaSandboxConfig;
+		expect(sharedConfig.snapshot).toBeUndefined();
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining('runtime materialization'),
+			expect.objectContaining({ snapshotName: 'n8n/instance-ai:dev-local' }),
+		);
+	});
+
+	it('uses an explicit snapshot name override in proxy mode', async () => {
+		const getAuthToken = vi.fn().mockResolvedValue('jwt-token');
+		const config: SandboxConfig = {
+			enabled: true,
+			provider: 'daytona',
+			daytonaApiUrl: 'https://proxy.example.com',
+			getAuthToken,
+			image: 'node:20',
+			n8nVersion: '1.2.3',
+		};
+
+		await createSandbox(config, {
+			logger,
+			errorReporter,
+			useSnapshotFallback: true,
+			snapshotName: 'n8n/instance-ai:dev-local',
+		});
+
+		expect(mockSnapshotName).not.toHaveBeenCalled();
+		const sharedConfig = mockCreateSharedSandbox.mock.calls[0][0] as DaytonaSandboxConfig;
+		expect(sharedConfig.snapshot).toBe('n8n/instance-ai:dev-local');
+	});
+
+	it('uses an explicit snapshot name override in direct mode', async () => {
+		const config: SandboxConfig = {
+			enabled: true,
+			provider: 'daytona',
+			daytonaApiUrl: 'https://api.daytona.io',
+			daytonaApiKey: 'test-key',
+			image: 'node:20',
+			n8nVersion: '1.2.3',
+		};
+
+		await createSandbox(config, {
+			logger,
+			errorReporter,
+			useSnapshotFallback: true,
+			snapshotName: 'n8n/instance-ai:dev-local',
+		});
+
+		const sharedConfig = mockCreateSharedSandbox.mock.calls[0][0] as DaytonaSandboxConfig;
+		expect(sharedConfig.snapshot).toBe('n8n/instance-ai:dev-local');
+	});
+
 	it('prepares snapshot and image in Daytona proxy snapshot fallback mode', async () => {
 		const getAuthToken = vi.fn().mockResolvedValue('jwt-token');
 		const config: SandboxConfig = {

--- a/packages/@n8n/instance-ai/src/workspace/__tests__/snapshot-manager.test.ts
+++ b/packages/@n8n/instance-ai/src/workspace/__tests__/snapshot-manager.test.ts
@@ -299,8 +299,33 @@ describe('SnapshotManager.createSnapshot', () => {
 		const manager = new SnapshotManager(undefined, NOOP_LOGGER, undefined);
 		const daytona = makeFakeDaytona();
 
-		await expect(manager.createSnapshot(daytona as never)).rejects.toThrow();
+		await expect(manager.createSnapshot(daytona as never)).rejects.toThrow(
+			'SnapshotManager: n8nVersion is required to derive a snapshot name',
+		);
 		expect(daytona.snapshot.create).not.toHaveBeenCalled();
+	});
+
+	it('throws when an explicit snapshot name override is empty', async () => {
+		const manager = new SnapshotManager(undefined, NOOP_LOGGER, '1.123.0');
+		const daytona = makeFakeDaytona();
+
+		await expect(manager.createSnapshot(daytona as never, { name: '' })).rejects.toThrow(
+			'SnapshotManager: explicit snapshot name must not be empty',
+		);
+		expect(daytona.snapshot.create).not.toHaveBeenCalled();
+	});
+
+	it('creates a snapshot with an explicit name override', async () => {
+		const manager = new SnapshotManager(undefined, NOOP_LOGGER, '1.123.0');
+		const daytona = makeFakeDaytona();
+		daytona.snapshot.create.mockResolvedValue({ name: 'n8n/instance-ai:dev-local' });
+
+		const result = await manager.createSnapshot(daytona as never, {
+			name: 'n8n/instance-ai:dev-local',
+		});
+
+		expect(result).toBe('n8n/instance-ai:dev-local');
+		expect(daytona.snapshot.create.mock.calls[0][0].name).toBe('n8n/instance-ai:dev-local');
 	});
 
 	it('forwards options to daytona.snapshot.create', async () => {

--- a/packages/@n8n/instance-ai/src/workspace/create-workspace.ts
+++ b/packages/@n8n/instance-ai/src/workspace/create-workspace.ts
@@ -32,6 +32,10 @@ export { type SandboxInstance, type SandboxProvider };
 
 export interface InstanceAiCreateSandboxOptions extends CreateSandboxOptions {
 	useSnapshotFallback?: boolean;
+	/** Dev mode: Skip pre-built snapshots and materialize the declarative image at runtime. */
+	runtimeMaterialize?: boolean;
+	/** Dev mode: Override the version-derived Daytona snapshot name. */
+	snapshotName?: string;
 }
 
 const NOOP_LOGGER: Logger = {
@@ -61,6 +65,28 @@ function toSharedDaytonaSandboxConfig(
 	delete sharedConfig.n8nVersion;
 	delete sharedConfig.namePrefix;
 	return sharedConfig;
+}
+
+function resolveSnapshotName(
+	options: InstanceAiCreateSandboxOptions,
+	snapshotManager: SnapshotManager,
+	isProxyMode: boolean,
+	logger: Logger,
+): string | undefined {
+	if (options.runtimeMaterialize) {
+		if (options.snapshotName) {
+			logger.warn(
+				'Both runtime materialization and a custom snapshot name are set; ignoring the snapshot name and materializing the image at runtime.',
+				{ snapshotName: options.snapshotName },
+			);
+		}
+		return undefined;
+	}
+
+	if (options.snapshotName) return options.snapshotName;
+	if (isProxyMode) return snapshotManager.snapshotName() ?? undefined;
+
+	return undefined;
 }
 
 function toSharedSandboxConfig(config: InstanceAiSandboxConfig): SharedSandboxConfig {
@@ -95,8 +121,12 @@ export async function createSandbox(
 		config.n8nVersion,
 	);
 
-	const isProxyMode = config.getAuthToken !== undefined;
-	const snapshot = isProxyMode ? (snapshotManager.snapshotName() ?? undefined) : undefined;
+	const snapshot = resolveSnapshotName(
+		options,
+		snapshotManager,
+		config.getAuthToken !== undefined,
+		logger,
+	);
 	const image = await snapshotManager.ensureImage();
 
 	return await createSharedSandbox(

--- a/packages/@n8n/instance-ai/src/workspace/snapshot-manager.ts
+++ b/packages/@n8n/instance-ai/src/workspace/snapshot-manager.ts
@@ -33,6 +33,8 @@ import { loadInstanceAiRuntimeSkillSource } from '../skills/runtime-skills';
 export interface CreateSnapshotOptions {
 	timeout?: number;
 	onLogs?: (chunk: string) => void;
+	/** Dev mode: Override the version-derived snapshot name */
+	name?: string;
 }
 
 const DAYTONA_WORKSPACE_BAKE_ROOT = '/tmp/n8n-workspace-bake';
@@ -114,22 +116,32 @@ export class SnapshotManager {
 	}
 
 	/**
-	 * Create the versioned Daytona snapshot for the configured n8n version.
+	 * Create a Daytona snapshot. By default uses the versioned name derived
+	 * from the configured n8n version; pass `options.name` to override it
+	 * (e.g. `build-snapshot.cjs --snapshot-name` for manual dev regeneration).
 	 * Treats 409 / "already exists" as success — re-runs against the same
-	 * version are idempotent. Throws on transient or unexpected errors so
+	 * name are idempotent. Throws on transient or unexpected errors so
 	 * callers can decide whether to retry, fall back, or fail loudly.
 	 *
 	 * Single source of truth for snapshot creation in the CI release pipeline
 	 * (`scripts/build-snapshot.cjs`). Runtime never calls this.
 	 */
 	async createSnapshot(daytona: Daytona, options?: CreateSnapshotOptions): Promise<string> {
-		const name = this.snapshotName();
-		if (!name) {
+		const { name: nameOverride, ...createOptions } = options ?? {};
+
+		if (nameOverride !== undefined && !nameOverride) {
+			throw new Error('SnapshotManager: explicit snapshot name must not be empty');
+		}
+
+		const version = this.n8nVersion;
+		if (nameOverride === undefined && !version) {
 			throw new Error('SnapshotManager: n8nVersion is required to derive a snapshot name');
 		}
 
+		const name = nameOverride ?? `n8n/instance-ai:${version}`;
+
 		try {
-			await daytona.snapshot.create({ name, image: await this.ensureImage() }, options);
+			await daytona.snapshot.create({ name, image: await this.ensureImage() }, createOptions);
 			this.logger.info('Created versioned Daytona snapshot', { name });
 			return name;
 		} catch (error) {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -543,7 +543,11 @@ type WorkspaceServiceInternals = {
 	sandboxes: Map<string, unknown>;
 	sandboxCreations: Map<string, Promise<unknown>>;
 	resolveSandboxConfig: jest.MockedFunction<(user: User) => Promise<SandboxConfig>>;
-	instanceAiConfig?: { builderSandboxTtlMs?: number };
+	instanceAiConfig: {
+		builderSandboxTtlMs?: number;
+		daytonaRuntimeMaterialize?: boolean;
+		daytonaSnapshotName?: string;
+	};
 	sandboxTtlMs: number;
 	getOrCreateWorkspace: (
 		threadId: string,
@@ -869,6 +873,7 @@ describe('InstanceAiService — runtime workspace setup', () => {
 		service.sandboxes = new Map();
 		service.sandboxCreations = new Map();
 		service.resolveSandboxConfig = jest.fn(async (_user: User) => daytonaSandboxConfig);
+		service.instanceAiConfig = {};
 
 		let resolveSandbox!: (sandbox: unknown) => void;
 		const sandboxPromise = new Promise((resolve) => {
@@ -961,6 +966,7 @@ describe('InstanceAiService — runtime workspace setup', () => {
 			...daytonaSandboxConfig,
 			namePrefix: 'Acme Eval',
 		}));
+		service.instanceAiConfig = {};
 		const sandbox = { id: 'sandbox-1' };
 		const workspace = {
 			init: jest.fn(async () => {}),
@@ -993,6 +999,7 @@ describe('InstanceAiService — runtime workspace setup', () => {
 		service.sandboxes = new Map();
 		service.sandboxCreations = new Map();
 		service.resolveSandboxConfig = jest.fn(async (_user: User) => daytonaSandboxConfig);
+		service.instanceAiConfig = {};
 
 		const sandbox = { id: 'sandbox-1' };
 		const workspace = {
@@ -1026,6 +1033,7 @@ describe('InstanceAiService — runtime workspace setup', () => {
 		service.sandboxes = new Map();
 		service.sandboxCreations = new Map();
 		service.resolveSandboxConfig = jest.fn(async (_user: User) => daytonaSandboxConfig);
+		service.instanceAiConfig = {};
 
 		const sandbox = { id: 'sandbox-1' };
 		const workspace = {

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -864,10 +864,13 @@ export class InstanceAiService {
 		const config = withThreadScopedSandboxIdentity(await this.resolveSandboxConfig(user), threadId);
 		if (!config.enabled) return undefined;
 
+		const { daytonaRuntimeMaterialize, daytonaSnapshotName } = this.instanceAiConfig;
 		const sandbox = await createSandbox(config, {
 			logger: this.logger,
 			errorReporter: this.errorReporter,
 			useSnapshotFallback: true,
+			runtimeMaterialize: daytonaRuntimeMaterialize,
+			...(daytonaSnapshotName ? { snapshotName: daytonaSnapshotName } : {}),
 		});
 		const workspace = createWorkspace(sandbox);
 		if (!sandbox || !workspace) return undefined;


### PR DESCRIPTION
## Summary

Open up options to test daytona sandbox locally by:
1. Enabling runtime materialization
2. Enabling name for snapshot to create in

## Related Linear tickets, Github issues, and Community forum posts

RESOLVES INS-475

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
