### PR TITLE
fix(core): Scope MCP OAuth client deletion to the caller

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/mcp-oauth-service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp-oauth-service.test.ts
@@ -5,8 +5,11 @@ import type { Response } from 'express';
 import { mock } from 'jest-mock-extended';
 import { OAuthError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 
-import type { AuthorizationCode } from '../database/entities/oauth-authorization-code.entity';
-import type { OAuthClient } from '../database/entities/oauth-client.entity';
+import { AccessToken } from '../database/entities/oauth-access-token.entity';
+import { AuthorizationCode } from '../database/entities/oauth-authorization-code.entity';
+import { OAuthClient } from '../database/entities/oauth-client.entity';
+import { RefreshToken } from '../database/entities/oauth-refresh-token.entity';
+import { UserConsent } from '../database/entities/oauth-user-consent.entity';
 import { OAuthClientRepository } from '../database/repositories/oauth-client.repository';
 import { UserConsentRepository } from '../database/repositories/oauth-user-consent.repository';
 import { McpOAuthAuthorizationCodeService } from '../mcp-oauth-authorization-code.service';
@@ -676,48 +679,71 @@ describe('McpOAuthService', () => {
 	});
 
 	describe('deleteClient', () => {
-		it('should delete client when user has consent', async () => {
-			const client = {
-				id: 'client-123',
-				name: 'Test Client',
-			} as OAuthClient;
+		const setupTransactionMock = (remainingConsents: number) => {
+			const entityManager = {
+				delete: jest.fn().mockResolvedValue({}),
+				count: jest.fn().mockResolvedValue(remainingConsents),
+			};
+			(userConsentRepository as any).manager = {
+				transaction: jest.fn().mockImplementation(async (cb: any) => await cb(entityManager)),
+			};
+			return entityManager;
+		};
 
-			oauthClientRepository.findOne.mockResolvedValue(client);
+		it("should revoke only the caller's consent and tokens, and GC the client when no consents remain", async () => {
 			userConsentRepository.findOneBy.mockResolvedValue({
 				userId: 'user-456',
 				clientId: 'client-123',
 			} as any);
-			oauthClientRepository.delete.mockResolvedValue({} as any);
+			const em = setupTransactionMock(0);
 
 			await service.deleteClient('client-123', 'user-456');
 
-			expect(oauthClientRepository.delete).toHaveBeenCalledWith({ id: 'client-123' });
+			expect(em.delete).toHaveBeenCalledWith(UserConsent, {
+				userId: 'user-456',
+				clientId: 'client-123',
+			});
+			expect(em.delete).toHaveBeenCalledWith(AccessToken, {
+				userId: 'user-456',
+				clientId: 'client-123',
+			});
+			expect(em.delete).toHaveBeenCalledWith(RefreshToken, {
+				userId: 'user-456',
+				clientId: 'client-123',
+			});
+			expect(em.delete).toHaveBeenCalledWith(AuthorizationCode, {
+				userId: 'user-456',
+				clientId: 'client-123',
+			});
+			expect(em.count).toHaveBeenCalledWith(UserConsent, { where: { clientId: 'client-123' } });
+			expect(em.delete).toHaveBeenCalledWith(OAuthClient, { id: 'client-123' });
 		});
 
-		it('should throw when client does not exist', async () => {
-			oauthClientRepository.findOne.mockResolvedValue(null);
+		it('should not delete the shared OAuthClient row when another user still has consent', async () => {
+			userConsentRepository.findOneBy.mockResolvedValue({
+				userId: 'user-b',
+				clientId: 'shared-client',
+			} as any);
+			const em = setupTransactionMock(1);
 
-			await expect(service.deleteClient('nonexistent', 'user-456')).rejects.toThrow(
-				'OAuth client with ID nonexistent not found',
-			);
+			await service.deleteClient('shared-client', 'user-b');
 
-			expect(oauthClientRepository.delete).not.toHaveBeenCalled();
+			expect(em.delete).toHaveBeenCalledWith(UserConsent, {
+				userId: 'user-b',
+				clientId: 'shared-client',
+			});
+			expect(em.delete).not.toHaveBeenCalledWith(OAuthClient, expect.anything());
 		});
 
-		it('should throw when user has no consent for the client', async () => {
-			const client = {
-				id: 'client-123',
-				name: 'Test Client',
-			} as OAuthClient;
-
-			oauthClientRepository.findOne.mockResolvedValue(client);
+		it('should throw when the caller has no consent for the client', async () => {
 			userConsentRepository.findOneBy.mockResolvedValue(null);
+			const em = setupTransactionMock(0);
 
 			await expect(service.deleteClient('client-123', 'other-user')).rejects.toThrow(
 				'OAuth client with ID client-123 not found',
 			);
 
-			expect(oauthClientRepository.delete).not.toHaveBeenCalled();
+			expect(em.delete).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/modules/mcp/__tests__/mcp.oauth-clients.controller.api.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.oauth-clients.controller.api.test.ts
@@ -174,4 +174,49 @@ describe('DELETE /rest/mcp/oauth-clients/:clientId', () => {
 
 		expect(response.statusCode).toBe(404);
 	});
+
+	test('should keep the shared OAuth client and other users access intact when one of two consenters revokes', async () => {
+		const client = await oauthClientRepository.save({
+			id: 'shared-client-id',
+			name: 'Shared Client',
+			redirectUris: ['https://example.com/callback'],
+			grantTypes: ['authorization_code'],
+			tokenEndpointAuthMethod: 'none',
+		});
+
+		await userConsentRepository.save({
+			userId: owner.id,
+			clientId: client.id,
+			grantedAt: Date.now(),
+		});
+		await userConsentRepository.save({
+			userId: member.id,
+			clientId: client.id,
+			grantedAt: Date.now(),
+		});
+
+		const response = await testServer
+			.authAgentFor(member)
+			.delete(`/mcp/oauth-clients/${client.id}`);
+
+		expect(response.statusCode).toBe(200);
+
+		// Shared client row must remain — another user still relies on it.
+		const sharedClient = await oauthClientRepository.findOneBy({ id: client.id });
+		expect(sharedClient).not.toBeNull();
+
+		// Owner's consent must remain untouched.
+		const ownerConsent = await userConsentRepository.findOneBy({
+			userId: owner.id,
+			clientId: client.id,
+		});
+		expect(ownerConsent).not.toBeNull();
+
+		// Member's consent must be gone.
+		const memberConsent = await userConsentRepository.findOneBy({
+			userId: member.id,
+			clientId: client.id,
+		});
+		expect(memberConsent).toBeNull();
+	});
 });

--- a/packages/cli/src/modules/mcp/mcp-oauth-service.ts
+++ b/packages/cli/src/modules/mcp/mcp-oauth-service.ts
@@ -15,7 +15,11 @@ import { GlobalConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 import type { Response } from 'express';
 
+import { AccessToken } from './database/entities/oauth-access-token.entity';
+import { AuthorizationCode } from './database/entities/oauth-authorization-code.entity';
 import { OAuthClient } from './database/entities/oauth-client.entity';
+import { RefreshToken } from './database/entities/oauth-refresh-token.entity';
+import { UserConsent } from './database/entities/oauth-user-consent.entity';
 import { OAuthClientRepository } from './database/repositories/oauth-client.repository';
 import { UserConsentRepository } from './database/repositories/oauth-user-consent.repository';
 import { McpOAuthAuthorizationCodeService } from './mcp-oauth-authorization-code.service';
@@ -346,33 +350,32 @@ export class McpOAuthService implements OAuthServerProvider {
 	}
 
 	/**
-	 * Delete an OAuth client and all related data.
-	 * Verifies that the requesting user has a consent relationship with the client.
+	 * Revoke the caller's access to an OAuth client by deleting their consent,
+	 * tokens, and authorization codes for it. The global client row is only
+	 * deleted once no consents remain for it: MCP OAuth clients have no owner
+	 * field and are shared across every user that has consented to them.
 	 */
 	async deleteClient(clientId: string, userId: string): Promise<void> {
-		// First check if the client exists
-		const client = await this.oauthClientRepository.findOne({
-			where: { id: clientId },
-		});
-
-		if (!client) {
-			throw new Error(`OAuth client with ID ${clientId} not found`);
-		}
-
-		// Verify the requesting user has a consent relationship with this client
 		const consent = await this.userConsentRepository.findOneBy({ clientId, userId });
 		if (!consent) {
 			throw new Error(`OAuth client with ID ${clientId} not found`);
 		}
 
-		this.logger.info('Deleting OAuth client and related data', { clientId });
+		this.logger.info('Revoking user access to OAuth client', { clientId, userId });
 
-		await this.oauthClientRepository.delete({ id: clientId });
+		await this.userConsentRepository.manager.transaction(async (em) => {
+			await em.delete(UserConsent, { userId, clientId });
+			await em.delete(AccessToken, { userId, clientId });
+			await em.delete(RefreshToken, { userId, clientId });
+			await em.delete(AuthorizationCode, { userId, clientId });
 
-		this.logger.info('OAuth client deleted successfully', {
-			clientId,
-			clientName: client.name,
+			const remainingConsents = await em.count(UserConsent, { where: { clientId } });
+			if (remainingConsents === 0) {
+				await em.delete(OAuthClient, { id: clientId });
+			}
 		});
+
+		this.logger.info('OAuth client access revoked', { clientId, userId });
 	}
 }
 


### PR DESCRIPTION
## Summary

`DELETE /rest/mcp/oauth-clients/:clientId` now deletes only the caller's consent, access tokens, refresh tokens, and authorization codes for the client. The shared `oauth_clients` row is removed only once no consents remain for it.

MCP OAuth clients are globally registered objects with no owner field, and many users can independently consent to the same client. The endpoint backs the "Revoke access" action in the MCP access settings, so revoke matches the UI: per-user, not global.

## How to test

1. Two users (A and B) consent to the same MCP OAuth client.
2. As B, `DELETE /rest/mcp/oauth-clients/<shared-client-id>` returns 200.
3. The `oauth_clients` row still exists; A's `oauth_user_consents` row, access tokens, refresh tokens, and authorization codes are untouched.
4. B's rows for that `clientId` are gone.
5. As A, revoke as well: the now-orphaned `oauth_clients` row is garbage-collected.

## Review / Merge checklist

- [x] Tests included (unit + integration covering the two-consenters case).