### PR TITLE
fix(editor): Preserve loaded options value when navigating between nodes

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.test.ts
@@ -6,7 +6,7 @@ import { fireEvent, waitFor } from '@testing-library/vue';
 import { useNDVStore } from '@/features/ndv/shared/ndv.store';
 import * as workflowHelpers from '@/app/composables/useWorkflowHelpers';
 import { flushPromises } from '@vue/test-utils';
-import { shallowRef } from 'vue';
+import { nextTick, shallowRef } from 'vue';
 import {
 	injectWorkflowDocumentStore,
 	useWorkflowDocumentStore,
@@ -170,6 +170,40 @@ describe('ParameterInputList', () => {
 			}),
 		).not.toThrow();
 		await flushPromises();
+	});
+
+	it('remounts parameter inputs when navigating between nodes that share a parameter name', async () => {
+		// Same-named fields on two nodes used to reuse the input instance on
+		// navigation, which silently dropped the saved value (#31626).
+		const sharedParameters: INodeProperties[] = [
+			{
+				displayName: 'Category',
+				name: 'category',
+				type: 'options',
+				default: '',
+				options: [],
+				typeOptions: { loadOptionsMethod: 'getCategories' },
+			},
+		];
+		const nodeValues = { parameters: { category: '' } };
+
+		const firstNode: INodeUi = { ...TEST_NODE_NO_ISSUES, id: 'node-a', name: 'Node A' };
+		const secondNode: INodeUi = { ...TEST_NODE_NO_ISSUES, id: 'node-b', name: 'Node B' };
+
+		ndvStore.activeNode = firstNode;
+		const { getByTestId } = renderComponent({
+			props: { parameters: sharedParameters, nodeValues },
+		});
+		await flushPromises();
+
+		const beforeInput = getByTestId('parameter-input');
+
+		ndvStore.activeNode = secondNode;
+		await nextTick();
+		await flushPromises();
+
+		// A fresh DOM node means the input remounted rather than carrying over.
+		expect(getByTestId('parameter-input')).not.toBe(beforeInput);
 	});
 
 	it('renders fixed collection inputs correctly', async () => {

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
@@ -923,6 +923,7 @@ watch(
 				></N8nIconButton>
 
 				<ParameterInputFull
+					:key="node?.name"
 					:parameter="item.parameter"
 					:hide-issues="hiddenIssuesInputs.includes(item.parameter.name)"
 					:value="getParameterValue(item.parameter.name)"


### PR DESCRIPTION
## Summary

When two connected nodes both expose a parameter with the same name e.g. a
`type: options` field populated via `loadOptionsMethod`  navigating from one to
the other with the NDV floating "next node" button (without closing the NDV)
silently cleared the saved value. Dependent fields (`loadOptionsDependsOn`,
including resource mappers) were cleared along with it, and the node then failed
to execute. The loss was real, not just visual: the parameter was missing
entirely from the copied node JSON.

The parameter rows are keyed only by parameter name, so when two nodes share a
field name Vue reuses the `ParameterInputFull` instance across navigation instead
of remounting it. The reused instance keeps the previous node's remote options
and its credentials watcher fires on the node switch, resetting the value to its
default (which is then pruned on save).

This keys `ParameterInputFull` by the active node, so it remounts on node
navigation and reloads its options for the newly focused node the same pattern
already used for `ResourceMapper` in this component.

## How to test

1. Use two nodes that each expose a parameter with the same name, populated via
   `loadOptionsMethod` (a resource-mapper / `loadOptionsDependsOn` dependent
   field makes it clearer).
2. Connect them directly, configure and save both.
3. Open the first node, then click the floating "next node" button to move to the
   second without closing the NDV.
4. The second node's value is preserved (before this change it was cleared).

## Related Linear tickets, Github issues, and Community forum posts

Fixes #31626

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.