### PR TITLE
feat(AWS): Add Asia Pacific (Taipei) ap-east-2 region

### DIFF
--- a/packages/nodes-base/credentials/common/aws/types.ts
+++ b/packages/nodes-base/credentials/common/aws/types.ts
@@ -20,6 +20,11 @@ export const regions: RegionData[] = [
 		location: 'Hong Kong',
 	},
 	{
+		name: 'ap-east-2',
+		displayName: 'Asia Pacific',
+		location: 'Taipei',
+	},
+	{
 		name: 'ap-south-1',
 		displayName: 'Asia Pacific',
 		location: 'Mumbai',

--- a/packages/nodes-base/credentials/common/aws/utils.test.ts
+++ b/packages/nodes-base/credentials/common/aws/utils.test.ts
@@ -748,6 +748,7 @@ describe('assertSupportedAwsRegion', () => {
 		['us-east-1'],
 		['eu-west-1'],
 		['ap-southeast-2'],
+		['ap-east-2'],
 		['cn-north-1'],
 		['us-gov-west-1'],
 		['eu-central-2'],


### PR DESCRIPTION
## Summary

Adds the **`ap-east-2` (Asia Pacific – Taipei)** region to the shared AWS credential region list (`packages/nodes-base/credentials/common/aws/types.ts`).

This region backs the dropdown for the `aws` credential, so it was previously impossible to select Taipei in the **AWS S3 node** and every other node that uses the shared AWS credential (Textract, Transcribe, SES, SNS, SQS, etc.).

Because `assertSupportedAwsRegion` validates the chosen region against this same list, `ap-east-2` could not be used at all — not even by setting the region via an expression, which now throws `Unsupported AWS region`.

The dropdown options (`descriptions.ts`), the `AWSRegion` type, and the runtime allow-list (`SUPPORTED_AWS_REGIONS`) are all derived from this single `regions` array, so adding one entry is sufficient and keeps everything in sync.

## How to test

1. Create / edit an **AWS** credential (e.g. the one used by the AWS S3 node).
2. Open the **Region** dropdown.
3. Verify **`Asia Pacific (Taipei) - ap-east-2`** is now selectable.
4. With the region set to `ap-east-2`, run an AWS S3 operation and confirm the request is signed against `s3.ap-east-2.amazonaws.com` and no `Unsupported AWS region` error is thrown.

Unit test added in `credentials/common/aws/utils.test.ts` asserting `assertSupportedAwsRegion('ap-east-2')` does not throw.

## Related Linear tickets, Github issues, and Community forum posts

Community contribution — no existing Linear ticket or GitHub issue. `ap-east-2` is a generally-available AWS region (Asia Pacific, Taipei) that was simply missing from n8n's hardcoded region list.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
