### PR TITLE
feat(core): Add instance settings env telemetry

### DIFF
--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -2154,14 +2154,14 @@ describe('TelemetryEventRelay', () => {
 			);
 			expect(telemetry.identify).toHaveBeenCalledWith(
 				expect.not.objectContaining({
-					instance_settings: expect.anything(),
+					settings_managed_by_env_vars: expect.anything(),
 				}),
 			);
 			expect(telemetry.track).toHaveBeenCalledWith(
 				'Instance started',
 				expect.objectContaining({
 					earliest_workflow_created: firstWorkflow.createdAt,
-					instance_settings: {
+					settings_managed_by_env_vars: {
 						owner_managed_by_env: true,
 						sso_managed_by_env: true,
 						security_policy_managed_by_env: true,
@@ -2204,7 +2204,7 @@ describe('TelemetryEventRelay', () => {
 			expect(telemetry.track).toHaveBeenCalledWith(
 				'Instance started',
 				expect.objectContaining({
-					instance_settings: {
+					settings_managed_by_env_vars: {
 						owner_managed_by_env: true,
 						sso_managed_by_env: true,
 						security_policy_managed_by_env: true,
@@ -2216,13 +2216,13 @@ describe('TelemetryEventRelay', () => {
 			);
 			expect(telemetry.identify).toHaveBeenCalledWith(
 				expect.not.objectContaining({
-					instance_settings: expect.anything(),
+					settings_managed_by_env_vars: expect.anything(),
 				}),
 			);
 			expect(telemetry.groupIdentify).toHaveBeenCalledWith(
 				expect.objectContaining({
 					traits: expect.not.objectContaining({
-						instance_settings: expect.anything(),
+						settings_managed_by_env_vars: expect.anything(),
 					}),
 				}),
 			);

--- a/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
+++ b/packages/cli/src/events/__tests__/telemetry-event-relay.test.ts
@@ -36,6 +36,15 @@ import type { Telemetry } from '@/telemetry';
 
 const flushPromises = async () => await new Promise((resolve) => setImmediate(resolve));
 
+const getDefaultInstanceSettingsLoaderConfig = () => ({
+	ownerManagedByEnv: false,
+	ssoManagedByEnv: false,
+	securityPolicyManagedByEnv: false,
+	logStreamingManagedByEnv: false,
+	mcpManagedByEnv: false,
+	communityPackagesManagedByEnv: false,
+});
+
 describe('TelemetryEventRelay', () => {
 	const telemetry = mock<Telemetry>({
 		sanitizeTelemetryProperties: jest.fn((data) => data),
@@ -104,6 +113,7 @@ describe('TelemetryEventRelay', () => {
 		database: {
 			type: 'sqlite',
 		},
+		instanceSettingsLoader: getDefaultInstanceSettingsLoaderConfig(),
 	});
 	const binaryDataConfig = mock<BinaryDataConfig>({
 		mode: 'default',
@@ -143,6 +153,7 @@ describe('TelemetryEventRelay', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 		globalConfig.diagnostics.enabled = true;
+		Object.assign(globalConfig.instanceSettingsLoader, getDefaultInstanceSettingsLoaderConfig());
 		const otelConfig = Container.get(OtelConfig);
 		otelConfig.enabled = false;
 		otelConfig.includeNodeSpans = true;
@@ -2083,6 +2094,14 @@ describe('TelemetryEventRelay', () => {
 		it('should track on `server-started` event', async () => {
 			const firstWorkflow = mock<WorkflowEntity>({ createdAt: new Date() });
 			workflowRepository.findOne.mockResolvedValue(firstWorkflow);
+			Object.assign(globalConfig.instanceSettingsLoader, {
+				ownerManagedByEnv: true,
+				ssoManagedByEnv: true,
+				securityPolicyManagedByEnv: true,
+				logStreamingManagedByEnv: true,
+				mcpManagedByEnv: true,
+				communityPackagesManagedByEnv: true,
+			});
 
 			eventService.emit('server-started');
 
@@ -2133,10 +2152,23 @@ describe('TelemetryEventRelay', () => {
 					otel: expect.anything(),
 				}),
 			);
+			expect(telemetry.identify).toHaveBeenCalledWith(
+				expect.not.objectContaining({
+					instance_settings: expect.anything(),
+				}),
+			);
 			expect(telemetry.track).toHaveBeenCalledWith(
 				'Instance started',
 				expect.objectContaining({
 					earliest_workflow_created: firstWorkflow.createdAt,
+					instance_settings: {
+						owner_managed_by_env: true,
+						sso_managed_by_env: true,
+						security_policy_managed_by_env: true,
+						log_streaming_managed_by_env: true,
+						mcp_managed_by_env: true,
+						community_packages_managed_by_env: true,
+					},
 					metrics: {
 						metrics_enabled: true,
 						metrics_category_default: true,
@@ -2152,6 +2184,90 @@ describe('TelemetryEventRelay', () => {
 					},
 				}),
 			);
+		});
+
+		it('should track instance settings env management on `server-started` event', async () => {
+			workflowRepository.findOne.mockResolvedValue(null);
+			Object.assign(globalConfig.instanceSettingsLoader, {
+				ownerManagedByEnv: true,
+				ssoManagedByEnv: true,
+				securityPolicyManagedByEnv: true,
+				logStreamingManagedByEnv: true,
+				mcpManagedByEnv: true,
+				communityPackagesManagedByEnv: true,
+			});
+
+			eventService.emit('server-started');
+
+			await flushPromises();
+
+			expect(telemetry.track).toHaveBeenCalledWith(
+				'Instance started',
+				expect.objectContaining({
+					instance_settings: {
+						owner_managed_by_env: true,
+						sso_managed_by_env: true,
+						security_policy_managed_by_env: true,
+						log_streaming_managed_by_env: true,
+						mcp_managed_by_env: true,
+						community_packages_managed_by_env: true,
+					},
+				}),
+			);
+			expect(telemetry.identify).toHaveBeenCalledWith(
+				expect.not.objectContaining({
+					instance_settings: expect.anything(),
+				}),
+			);
+			expect(telemetry.groupIdentify).toHaveBeenCalledWith(
+				expect.objectContaining({
+					traits: expect.not.objectContaining({
+						instance_settings: expect.anything(),
+					}),
+				}),
+			);
+		});
+
+		it('should not include sensitive instance settings loader values in startup telemetry', async () => {
+			workflowRepository.findOne.mockResolvedValue(null);
+			Object.assign(globalConfig.instanceSettingsLoader, {
+				ownerManagedByEnv: true,
+				ownerEmail: 'owner@example.com',
+				ownerPasswordHash: '$2b$12$012345678901234567890u012345678901234567890123456789012',
+				ssoManagedByEnv: true,
+				oidcClientId: 'oidc-client-id',
+				oidcClientSecret: 'oidc-client-secret',
+				oidcDiscoveryEndpoint: 'https://idp.example.com/.well-known/openid-configuration',
+				samlMetadata: '<EntityDescriptor entityID="sensitive-idp" />',
+				samlMetadataUrl: 'https://idp.example.com/metadata',
+				logStreamingManagedByEnv: true,
+				logStreamingDestinations: '[{"type":"webhook","url":"https://hooks.example.com/audit"}]',
+				mcpManagedByEnv: true,
+				mcpAccessEnabled: true,
+				communityPackagesManagedByEnv: true,
+				communityPackages: '[{"name":"n8n-nodes-sensitive","version":"1.2.3"}]',
+			});
+
+			eventService.emit('server-started');
+
+			await flushPromises();
+
+			const startupEvent = telemetry.track.mock.calls.find(
+				([eventName]) => eventName === 'Instance started',
+			);
+			expect(startupEvent).toBeDefined();
+			if (!startupEvent) throw new Error('Expected Instance started telemetry event');
+
+			const telemetryPayload = JSON.stringify(startupEvent[1]);
+
+			expect(telemetryPayload).not.toContain('owner@example.com');
+			expect(telemetryPayload).not.toContain('$2b$12$012345678901234567890u');
+			expect(telemetryPayload).not.toContain('oidc-client-id');
+			expect(telemetryPayload).not.toContain('oidc-client-secret');
+			expect(telemetryPayload).not.toContain('idp.example.com');
+			expect(telemetryPayload).not.toContain('sensitive-idp');
+			expect(telemetryPayload).not.toContain('hooks.example.com');
+			expect(telemetryPayload).not.toContain('n8n-nodes-sensitive');
 		});
 
 		it('should track OTEL startup configuration on `server-started` event', async () => {

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -1238,6 +1238,7 @@ export class TelemetryEventRelay extends EventRelay {
 	private async serverStarted() {
 		const cpus = os.cpus();
 		const otel = await this.getOtelTelemetryInfo();
+		const instanceSettings = this.getInstanceSettingsTelemetryInfo();
 
 		const isS3Selected = this.binaryDataConfig.mode === 's3';
 		const isS3Available = this.binaryDataConfig.availableModes.includes('s3');
@@ -1364,6 +1365,7 @@ export class TelemetryEventRelay extends EventRelay {
 			...info,
 			earliest_workflow_created: firstWorkflow?.createdAt,
 			otel,
+			instance_settings: instanceSettings,
 		});
 	}
 
@@ -1374,6 +1376,19 @@ export class TelemetryEventRelay extends EventRelay {
 		return {
 			enabled: otelConfig.enabled,
 			include_node_spans: otelConfig.includeNodeSpans,
+		};
+	}
+
+	private getInstanceSettingsTelemetryInfo() {
+		const config = this.globalConfig.instanceSettingsLoader;
+
+		return {
+			owner_managed_by_env: config.ownerManagedByEnv,
+			sso_managed_by_env: config.ssoManagedByEnv,
+			security_policy_managed_by_env: config.securityPolicyManagedByEnv,
+			log_streaming_managed_by_env: config.logStreamingManagedByEnv,
+			mcp_managed_by_env: config.mcpManagedByEnv,
+			community_packages_managed_by_env: config.communityPackagesManagedByEnv,
 		};
 	}
 

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -1238,7 +1238,7 @@ export class TelemetryEventRelay extends EventRelay {
 	private async serverStarted() {
 		const cpus = os.cpus();
 		const otel = await this.getOtelTelemetryInfo();
-		const instanceSettings = this.getInstanceSettingsTelemetryInfo();
+		const settingsManagedByEnvVars = this.getSettingsManagedByEnvVarsTelemetryInfo();
 
 		const isS3Selected = this.binaryDataConfig.mode === 's3';
 		const isS3Available = this.binaryDataConfig.availableModes.includes('s3');
@@ -1365,7 +1365,7 @@ export class TelemetryEventRelay extends EventRelay {
 			...info,
 			earliest_workflow_created: firstWorkflow?.createdAt,
 			otel,
-			instance_settings: instanceSettings,
+			settings_managed_by_env_vars: settingsManagedByEnvVars,
 		});
 	}
 
@@ -1379,7 +1379,7 @@ export class TelemetryEventRelay extends EventRelay {
 		};
 	}
 
-	private getInstanceSettingsTelemetryInfo() {
+	private getSettingsManagedByEnvVarsTelemetryInfo() {
 		const config = this.globalConfig.instanceSettingsLoader;
 
 		return {


### PR DESCRIPTION
## Summary

[video demo](https://www.loom.com/share/693c4fe7522a4a42a05ba8738fc63200) 

Adds grouped `instance_settings` startup telemetry to report which instance settings areas are managed by environment variables, without sending configured values.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-638

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI