### PR TITLE
feat(editor): Add telemetry to config evals wizard (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -364,6 +364,10 @@ function initializeRoute() {
 		route.query.action === 'openEvaluationsWizard' &&
 		isEvaluationsWizardSidepanelEnabled.value
 	) {
+		telemetry.track('User opened evaluations wizard', {
+			workflow_id: workflowId.value,
+			source: 'empty_state',
+		});
 		evaluationsWizardSidepanelStore.open(0);
 	}
 

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/EvaluationsCanvasInfoCard/EvaluationsCanvasInfoCard.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/EvaluationsCanvasInfoCard/EvaluationsCanvasInfoCard.test.ts
@@ -49,6 +49,11 @@ vi.mock('@/experiments/evaluationsWizardSidepanel/useEvaluationsWizardSidepanelE
 	useEvaluationsWizardSidepanelExperiment: () => ({ isFeatureEnabled }),
 }));
 
+const trackMock = vi.fn();
+vi.mock('@/app/composables/useTelemetry', () => ({
+	useTelemetry: () => ({ track: trackMock }),
+}));
+
 const mockIsLicensed = ref(true);
 const mockEnsureLicenseLoaded = vi.fn().mockResolvedValue(undefined);
 vi.mock('../../composables/useEvaluationsLicense', () => ({
@@ -81,6 +86,7 @@ describe('EvaluationsCanvasInfoCard', () => {
 		mockEnsureLicenseLoaded.mockReset();
 		mockEnsureLicenseLoaded.mockResolvedValue(undefined);
 		wizardOpen.mockReset();
+		trackMock.mockReset();
 		wizardIsOpen.value = false;
 		listEvaluationConfigs.mockReset();
 		listEvaluationConfigs.mockResolvedValue([]);
@@ -147,6 +153,17 @@ describe('EvaluationsCanvasInfoCard', () => {
 		const setupBtn = await findByTestId('evaluations-canvas-info-card-setup');
 		await userEvent.click(setupBtn);
 		expect(wizardOpen).toHaveBeenCalledWith(0);
+	});
+
+	it('tracks "User opened evaluations wizard" with the canvas_info_card source on setup CTA', async () => {
+		const wfId = mockWorkflowId.value;
+		const { findByTestId } = renderComponent();
+		const setupBtn = await findByTestId('evaluations-canvas-info-card-setup');
+		await userEvent.click(setupBtn);
+		expect(trackMock).toHaveBeenCalledWith('User opened evaluations wizard', {
+			workflow_id: wfId,
+			source: 'canvas_info_card',
+		});
 	});
 
 	it('hides while the evaluations wizard is already open', async () => {

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/EvaluationsCanvasInfoCard/EvaluationsCanvasInfoCard.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/EvaluationsCanvasInfoCard/EvaluationsCanvasInfoCard.vue
@@ -3,6 +3,7 @@ import { computed, onMounted, ref, watch } from 'vue';
 import { useI18n } from '@n8n/i18n';
 import { N8nButton, N8nIcon, N8nText } from '@n8n/design-system';
 
+import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useEvaluationsWizardSidepanelExperiment } from '@/experiments/evaluationsWizardSidepanel/useEvaluationsWizardSidepanelExperiment';
 import { useEvaluationsWizardSidepanelStore } from '../../wizardSidepanel.store';
 import { useAiRootNodes } from '../../composables/useAiRootNodes';
@@ -42,6 +43,7 @@ const marqueeMetrics = computed(() =>
 // nature of evaluation configs.
 
 const locale = useI18n();
+const telemetry = useTelemetry();
 const wizardStore = useEvaluationsWizardSidepanelStore();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const rootStore = useRootStore();
@@ -172,6 +174,10 @@ function dismiss() {
 }
 
 function openWizard() {
+	telemetry.track('User opened evaluations wizard', {
+		workflow_id: workflowId.value,
+		source: 'canvas_info_card',
+	});
 	wizardStore.open(0);
 }
 </script>

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.test.ts
@@ -90,6 +90,11 @@ vi.mock('@/app/composables/useRunWorkflow', () => ({
 	}),
 }));
 
+const trackMock = vi.fn();
+vi.mock('@/app/composables/useTelemetry', () => ({
+	useTelemetry: () => ({ track: trackMock }),
+}));
+
 const mockRouterPush = vi.fn();
 vi.mock('vue-router', async (importOriginal) => {
 	const actual = (await importOriginal()) as Record<string, unknown>;
@@ -112,6 +117,7 @@ describe('EvaluationsWizardSidepanel', () => {
 		mocks.sliceInputs = { fieldNames: [], values: {}, hasExecution: true };
 		mockRouterPush.mockReset();
 		mockHydrate.mockReset();
+		trackMock.mockReset();
 		// Trigger Vue to re-read the shallowRef so watchers see the reset workflowId.
 		workflowDocumentRef.value = {
 			get workflowId() {
@@ -610,6 +616,79 @@ describe('EvaluationsWizardSidepanel', () => {
 		// A per-check result card and one expandable case row render from the run data.
 		expect(getByTestId('evaluations-wizard-sidepanel-result-card-correctness')).toBeInTheDocument();
 		expect(getByTestId('evaluations-wizard-sidepanel-case-1')).toBeInTheDocument();
+	});
+
+	it('tracks "User viewed evaluation results" once when a finished run renders on step 3', async () => {
+		const store = useEvaluationsWizardSidepanelStore();
+		const evalStore = useEvaluationStore();
+		store.open(3);
+		store.selectedMetricKeys = ['correctness'];
+		evalStore.testRunsById = {
+			'run-1': {
+				id: 'run-1',
+				workflowId: 'workflow-id',
+				status: 'success',
+				metrics: { correctness: 0.9 },
+				createdAt: '',
+				updatedAt: '',
+				runAt: '',
+				completedAt: '',
+			},
+		};
+		evalStore.testCaseExecutionsById = {
+			'case-1': {
+				id: 'case-1',
+				testRunId: 'run-1',
+				executionId: null,
+				status: 'success',
+				createdAt: '',
+				updatedAt: '',
+				runAt: null,
+				runIndex: 0,
+				metrics: { correctness: 4 },
+				inputs: { expectedAnswer: 'hi' },
+				outputs: { output: 'hello' },
+			},
+		};
+
+		renderComponent();
+		await nextTick();
+
+		const resultsEvents = trackMock.mock.calls.filter(
+			([event]) => event === 'User viewed evaluation results',
+		);
+		expect(resultsEvents).toHaveLength(1);
+		expect(resultsEvents[0][1]).toEqual({
+			workflow_id: 'workflow-id',
+			run_id: 'run-1',
+			test_case_count: 1,
+			metric_count: 1,
+		});
+	});
+
+	it('does not track evaluation results while the run is still in progress on step 3', async () => {
+		const store = useEvaluationsWizardSidepanelStore();
+		const evalStore = useEvaluationStore();
+		store.open(3);
+		store.selectedMetricKeys = ['correctness'];
+		evalStore.testRunsById = {
+			'run-1': {
+				id: 'run-1',
+				workflowId: 'workflow-id',
+				status: 'running',
+				createdAt: '',
+				updatedAt: '',
+				runAt: '',
+				completedAt: null,
+			},
+		};
+
+		renderComponent();
+		await nextTick();
+
+		expect(
+			trackMock.mock.calls.filter(([event]) => event === 'User viewed evaluation results'),
+		).toHaveLength(0);
 	});
 
 	it('shows "View Results" button on step 3 and closes the wizard on click', async () => {

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.vue
@@ -6,6 +6,8 @@ import { useRouter } from 'vue-router';
 import { useI18n } from '@n8n/i18n';
 import { N8nButton, N8nIcon, N8nText } from '@n8n/design-system';
 
+import { useTelemetry } from '@/app/composables/useTelemetry';
+
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import { useExecutionsStore } from '@/features/execution/executions/executions.store';
@@ -47,6 +49,7 @@ import { VIEWS } from '@/app/constants/navigation';
 const wizardStore = useEvaluationsWizardSidepanelStore();
 const locale = useI18n();
 const router = useRouter();
+const telemetry = useTelemetry();
 const workflowDocumentStore = injectWorkflowDocumentStore();
 const workflowsStore = useWorkflowsStore();
 const executionsStore = useExecutionsStore();
@@ -333,6 +336,26 @@ const showLoadingState = computed(
 	() => isRunning.value || (activeStep.value === 3 && !latestRun.value),
 );
 
+// Fire once per run when the results step settles on a finished run, so the
+// "view detailed results" navigation isn't the only signal that a user saw
+// their scores inline. Deduped by run id so the watcher re-firing (poll
+// updates, case prefetch) doesn't emit repeats.
+const trackedResultsRunId = ref<string | null>(null);
+watch(
+	[activeStep, latestRun, showLoadingState],
+	([step, run, loading]) => {
+		if (step !== 3 || loading || !run || trackedResultsRunId.value === run.id) return;
+		trackedResultsRunId.value = run.id;
+		telemetry.track('User viewed evaluation results', {
+			workflow_id: workflowDocumentStore.value?.workflowId,
+			run_id: run.id,
+			test_case_count: latestRunCases.value.length,
+			metric_count: getUserDefinedMetricNames(run.metrics).length,
+		});
+	},
+	{ immediate: true },
+);
+
 // step0Complete: system chosen (node or slice)
 const step0Complete = computed(() => {
 	if (isSliceMode.value) {
@@ -403,7 +426,7 @@ async function handleNext() {
 		return;
 	}
 	if (current === 2) {
-		const ok = await persistAndDispatch();
+		const ok = await persistAndDispatch('initial');
 		if (!ok) return;
 		wizardStore.goNext();
 	}
@@ -418,7 +441,7 @@ function handleBack() {
 }
 
 async function handleRunAgain() {
-	await persistAndDispatch();
+	await persistAndDispatch('run_again');
 }
 
 function handleViewResults() {

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/useWizardPersistence.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/useWizardPersistence.ts
@@ -4,6 +4,7 @@ import { getParentNodes, mapConnectionsByDestination } from 'n8n-workflow';
 
 import { useEvaluationsWizardSidepanelStore } from '../../wizardSidepanel.store';
 import { useToast } from '@/app/composables/useToast';
+import { useTelemetry } from '@/app/composables/useTelemetry';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
@@ -40,12 +41,19 @@ export function useWizardPersistence() {
 	const rootStore = useRootStore();
 	const toast = useToast();
 	const locale = useI18n();
+	const telemetry = useTelemetry();
 	const sliceInputs = useSliceInputs();
 	const evaluationStore = useEvaluationStore();
 
 	const isPersisting = ref(false);
 
-	async function persistAndDispatch(): Promise<boolean> {
+	/**
+	 * @param trigger Whether this is the initial run from the wizard's setup
+	 * flow ('initial') or a re-run from the results step ('run_again').
+	 */
+	async function persistAndDispatch(
+		trigger: 'initial' | 'run_again' = 'initial',
+	): Promise<boolean> {
 		if (isPersisting.value) return false;
 
 		const wf = workflowDocumentStore.value;
@@ -185,6 +193,14 @@ export function useWizardPersistence() {
 				compileFromConfig: true,
 			});
 			wizardStore.setActiveRunId(dispatched?.testRunId ?? null);
+			telemetry.track('User ran evaluation', {
+				workflow_id: workflowId,
+				run_id: dispatched?.testRunId ?? null,
+				metric_count: wizardStore.selectedMetricKeys.length,
+				custom_check_count: wizardStore.customChecks.length,
+				slice_mode: wizardStore.isSliceMode,
+				trigger,
+			});
 			await evaluationStore.fetchTestRuns(workflowId);
 			return true;
 		} catch (error) {


### PR DESCRIPTION
## Summary

Adds frontend telemetry to the **Config Evals wizard** funnel, covering the three journey moments called out in [TRUST-125](https://linear.app/n8n/issue/TRUST-125): create a test case → run the eval → see the results.

### Events added

| Event | Fired when | Params |
|---|---|---|
| `User opened evaluations wizard` | Wizard opened from an entry point | `workflow_id`, `source` (`canvas_info_card` \| `empty_state`) |
| `User ran evaluation` | Eval dispatched (creates the test case + run) | `workflow_id`, `run_id`, `metric_count`, `custom_check_count`, `slice_mode`, `trigger` (`initial` \| `run_again`) |
| `User viewed evaluation results` | Step-3 results settle on a finished run (deduped per run id) | `workflow_id`, `run_id`, `test_case_count`, `metric_count` |

Event names follow the existing convention (`User viewed run detail`, `User viewed tests tab`); params use snake_case.

## Review / Testing

- New unit tests assert the opened-wizard event (canvas info card) and the viewed-results event (fires once on a finished run, not while running).
- `pnpm typecheck` and ESLint are clean.

## Follow-up

- The Telemetry Notion DB still needs the three new rows added under `Related to feature: Evaluations` (per the ticket A/C).

https://linear.app/n8n/issue/TRUST-125

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
