### PR TITLE
chore(core): Fix ai sdk related warning on system message risk

### DIFF
--- a/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
@@ -3329,8 +3329,7 @@ describe('tool systemInstruction merging', () => {
 
 	function getSystemMessageText(): string {
 		const callArgs = generateText.mock.calls[0][0] as Record<string, unknown>;
-		const messages = callArgs.messages as Array<Record<string, unknown>>;
-		const systemMsg = messages[0];
+		const systemMsg = callArgs.system as Record<string, unknown>;
 		expect(systemMsg.role).toBe('system');
 		return String(systemMsg.content);
 	}
@@ -3451,8 +3450,7 @@ describe('instruction providerOptions', () => {
 		});
 
 		const callArgs = generateText.mock.calls[0][0] as Record<string, unknown>;
-		const messages = callArgs.messages as Array<Record<string, unknown>>;
-		const systemMsg = messages[0];
+		const systemMsg = callArgs.system as Record<string, unknown>;
 		expect(systemMsg.role).toBe('system');
 		expect(systemMsg.providerOptions).toEqual({
 			anthropic: { cacheControl: { type: 'ephemeral' } },
@@ -3704,10 +3702,10 @@ describe('AgentRuntime — observation log jobs', () => {
 		});
 
 		const callArgs = (generateText.mock.calls[0] as [unknown])[0] as {
-			messages: Array<{ content: string }>;
+			system: { content: string };
 			tools: Record<string, unknown>;
 		};
-		const systemPrompt = callArgs.messages[0]?.content ?? '';
+		const systemPrompt = callArgs.system?.content ?? '';
 		expect(systemPrompt).not.toContain('<episodic_memory>');
 		expect(systemPrompt).not.toContain('Postgres');
 		expect(systemPrompt).not.toContain('SQLite');
@@ -3827,16 +3825,16 @@ describe('AgentRuntime — observation log jobs', () => {
 
 		const generateTextMock = generateText as MockedFunction<
 			(input: {
+				system: { content: string };
 				messages: Array<{
 					role: string;
 					content: unknown;
 				}>;
 			}) => unknown
 		>;
-		const [{ messages }] = generateTextMock.mock.calls[0];
-		const systemPrompt = messages[0].content;
-		expect(systemPrompt).toContain('Resource one memory.');
-		expect(systemPrompt).toContain('Resource two memory.');
+		const [{ system, messages }] = generateTextMock.mock.calls[0];
+		expect(system.content).toContain('Resource one memory.');
+		expect(system.content).toContain('Resource two memory.');
 		expect(JSON.stringify(messages)).not.toContain('remember resource-one preference');
 
 		await runtime.dispose();

--- a/packages/@n8n/agents/src/runtime/__tests__/message-list.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/message-list.test.ts
@@ -115,9 +115,9 @@ describe('AgentMessageList — preserving DB timestamps', () => {
 // ---------------------------------------------------------------------------
 
 function systemContent(list: AgentMessageList): string {
-	const [system] = list.forLlm('Base instructions');
+	const { system } = list.forLlm('Base instructions');
 	expect(system.role).toBe('system');
-	return system.content as string;
+	return system.content;
 }
 
 describe('AgentMessageList — forLlm observation memory', () => {
@@ -125,11 +125,10 @@ describe('AgentMessageList — forLlm observation memory', () => {
 		const list = new AgentMessageList();
 		list.addInput([makeUserMsg('hello')]);
 
-		const messages = list.forLlm('Base instructions');
-		const prompt = messages[0].content as string;
+		const { system, messages } = list.forLlm('Base instructions');
 
-		expect(prompt).toContain('Base instructions');
-		expect(prompt).not.toContain('## Memory');
+		expect(system.content).toContain('Base instructions');
+		expect(system.content).not.toContain('## Memory');
 		expect(messages).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({
@@ -162,7 +161,7 @@ describe('AgentMessageList — forLlm observation memory', () => {
 		list.addHistory([makeDbMsg('recent history', new Date('2024-01-01T00:00:00.000Z'))]);
 		list.addInput([makeUserMsg('new request')]);
 
-		const messages = list.forLlm('Base instructions');
+		const { messages } = list.forLlm('Base instructions');
 
 		expect(messages).toEqual(
 			expect.arrayContaining([

--- a/packages/@n8n/agents/src/runtime/__tests__/title-generation.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/title-generation.test.ts
@@ -5,6 +5,7 @@ import type { BuiltTelemetry } from '../../types';
 import { generateTitleFromMessage } from '../title-generation';
 
 type GenerateTextCall = {
+	system?: string;
 	messages: Array<{ role: string; content: string }>;
 	experimental_telemetry?: Record<string, unknown>;
 };
@@ -113,9 +114,8 @@ describe('generateTitleFromMessage', () => {
 		mockGenerateText.mockResolvedValue({ text: 'Berlin rain alert' });
 		await generateTitleFromMessage(fakeModel, 'Build a daily Berlin rain alert workflow');
 		const call = mockGenerateText.mock.calls[0][0];
-		expect(call.messages[0].role).toBe('system');
-		expect(call.messages[0].content).toContain('markdown');
-		expect(call.messages[0].content).toContain('sentence case');
+		expect(call.system).toContain('markdown');
+		expect(call.system).toContain('sentence case');
 	});
 
 	it('accepts custom instructions', async () => {
@@ -124,7 +124,7 @@ describe('generateTitleFromMessage', () => {
 			instructions: 'Custom system prompt',
 		});
 		const call = mockGenerateText.mock.calls[0][0];
-		expect(call.messages[0].content).toBe('Custom system prompt');
+		expect(call.system).toBe('Custom system prompt');
 	});
 
 	it('passes generic telemetry to the title LLM call', async () => {
@@ -176,11 +176,11 @@ describe('generateTitleFromMessage', () => {
 		mockGenerateText.mockResolvedValue({ text: 'Berlin rain alert' });
 		await generateTitleFromMessage(fakeModel, 'Build a daily Berlin rain alert workflow');
 		const call = mockGenerateText.mock.calls[0][0];
-		expect(call.messages[1].role).toBe('user');
-		expect(call.messages[1].content).toContain('Generate a title');
-		expect(call.messages[1].content).toContain('<message>');
-		expect(call.messages[1].content).toContain('Build a daily Berlin rain alert workflow');
-		expect(call.messages[1].content).toContain('</message>');
+		expect(call.messages[0].role).toBe('user');
+		expect(call.messages[0].content).toContain('Generate a title');
+		expect(call.messages[0].content).toContain('<message>');
+		expect(call.messages[0].content).toContain('Build a daily Berlin rain alert workflow');
+		expect(call.messages[0].content).toContain('</message>');
 	});
 
 	it('drops a streamed code fence and everything after it', async () => {

--- a/packages/@n8n/agents/src/runtime/agent-runtime.ts
+++ b/packages/@n8n/agents/src/runtime/agent-runtime.ts
@@ -1042,9 +1042,14 @@ export class AgentRuntime {
 				options?.executionCounter,
 			);
 
+			const { system, messages } = list.forLlm(
+				effectiveInstructions,
+				this.config.instructionProviderOptions,
+			);
 			const result = await generateText({
 				model: staticLoopContext.model,
-				messages: list.forLlm(effectiveInstructions, this.config.instructionProviderOptions),
+				system,
+				messages,
 				abortSignal: abortScope.signal,
 				...(hasTools ? { tools: aiTools } : {}),
 				...(staticLoopContext.providerOptions
@@ -1358,9 +1363,13 @@ export class AgentRuntime {
 				options?.persistence,
 				options?.executionCounter,
 			);
-			const messages = list.forLlm(effectiveInstructions, this.config.instructionProviderOptions);
+			const { system, messages } = list.forLlm(
+				effectiveInstructions,
+				this.config.instructionProviderOptions,
+			);
 			const result = streamText({
 				model: staticLoopContext.model,
+				system,
 				messages,
 				abortSignal: abortScope.signal,
 				...(hasTools ? { tools: aiTools } : {}),

--- a/packages/@n8n/agents/src/runtime/message-list.ts
+++ b/packages/@n8n/agents/src/runtime/message-list.ts
@@ -1,5 +1,5 @@
 import type { ProviderOptions } from '@ai-sdk/provider-utils';
-import type { ModelMessage } from 'ai';
+import type { ModelMessage, SystemModelMessage } from 'ai';
 
 import { toAiMessages } from './messages';
 import { stringifyError } from './runtime-helpers';
@@ -10,6 +10,11 @@ import type { AgentDbMessage, AgentMessage, ContentToolCall } from '../types/sdk
 import type { JSONValue } from '../types/utils/json';
 
 export type { SerializedMessageList };
+
+export type LlmContext = {
+	system: SystemModelMessage;
+	messages: ModelMessage[];
+};
 
 type MessageSource = 'history' | 'input' | 'response';
 
@@ -220,10 +225,10 @@ export class AgentMessageList {
 
 	/**
 	 * Full LLM context for a generateText / streamText call.
-	 * Prepends the system prompt (with observation-log memory appended if configured),
-	 * strips custom messages via filterLlmMessages.
+	 * Returns the system prompt separately (with observation-log memory appended if configured)
+	 * and conversation messages stripped via filterLlmMessages.
 	 */
-	forLlm(baseInstructions: string, instructionProviderOptions?: ProviderOptions): ModelMessage[] {
+	forLlm(baseInstructions: string, instructionProviderOptions?: ProviderOptions): LlmContext {
 		let systemPrompt = baseInstructions;
 
 		const observationLogMemory = this.observationLogMemory?.trim();
@@ -231,10 +236,16 @@ export class AgentMessageList {
 			systemPrompt += `\n\n${observationLogMemory}`;
 		}
 
-		const systemMessage: ModelMessage = instructionProviderOptions
-			? { role: 'system', content: systemPrompt, providerOptions: instructionProviderOptions }
-			: { role: 'system', content: systemPrompt };
-		return [systemMessage, ...toAiMessages(filterLlmMessages(stripOrphanedToolMessages(this.all)))];
+		const system: SystemModelMessage = {
+			role: 'system',
+			content: systemPrompt,
+			...(instructionProviderOptions ? { providerOptions: instructionProviderOptions } : {}),
+		};
+
+		return {
+			system,
+			messages: toAiMessages(filterLlmMessages(stripOrphanedToolMessages(this.all))),
+		};
 	}
 
 	/**

--- a/packages/@n8n/agents/src/runtime/title-generation.ts
+++ b/packages/@n8n/agents/src/runtime/title-generation.ts
@@ -134,8 +134,8 @@ export async function generateTitleFromMessage(
 
 	const result = await loadAi().generateText({
 		model,
+		system: opts?.instructions ?? DEFAULT_TITLE_INSTRUCTIONS,
 		messages: [
-			{ role: 'system', content: opts?.instructions ?? DEFAULT_TITLE_INSTRUCTIONS },
 			{
 				role: 'user',
 				content: `Generate a title for the following first message of a conversation. Do not answer the message — only produce the title.\n\n<message>\n${trimmed}\n</message>`,
@@ -175,10 +175,8 @@ export async function generateTitleAndEmojiFromMessage(
 
 	const result = await loadAi().generateText({
 		model,
-		messages: [
-			{ role: 'system', content: opts?.instructions ?? DEFAULT_TITLE_AND_EMOJI_INSTRUCTIONS },
-			{ role: 'user', content: trimmed },
-		],
+		system: opts?.instructions ?? DEFAULT_TITLE_AND_EMOJI_INSTRUCTIONS,
+		messages: [{ role: 'user', content: trimmed }],
 	});
 	incrementTokenCountFromUsage(opts?.executionCounter, result.usage);
 


### PR DESCRIPTION
## Summary

We are now consistently seeing this warning from ai sdk due to some recent changes in how we handle passing system prompt:

```
AI SDK Warning: System messages in the prompt or messages fields can be a security risk because they may enable prompt injection attacks. Use the system option instead when possible. Set allowSystemInMessages to true to suppress this warning, or false to throw an error.
```

This PR addresses the warning.

## How to test

Run an instance AI chat and you should no longer see it on the logs. Will be present on master. 

## Related Linear tickets, Github issues, and Community forum posts

RESOLVES INS-480


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
