### PR TITLE
test(core): Stop Redis retryStrategy from exiting the process under test

### DIFF
--- a/packages/cli/src/services/__tests__/redis-client.service.test.ts
+++ b/packages/cli/src/services/__tests__/redis-client.service.test.ts
@@ -7,6 +7,14 @@ import { RedisClientService } from '@/services/redis-client.service';
 
 type EventHandler = (...args: unknown[]) => void;
 
+/**
+ * The service disables process exit under test by default. Re-enable it so the
+ * cumulative-timeout accounting tests can assert on the exit decision.
+ */
+const enableExitOnRedisUnreachable = (service: RedisClientService) => {
+	(service as unknown as { exitOnRedisUnreachable: boolean }).exitOnRedisUnreachable = true;
+};
+
 jest.mock('ioredis', () => {
 	return jest.fn().mockImplementation(() => {
 		return {
@@ -129,6 +137,7 @@ describe('RedisClientService', () => {
 			const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
 
 			const service = new RedisClientService(logger, globalConfig);
+			enableExitOnRedisUnreachable(service);
 			service.createClient({ type: 'client(bull)' });
 			service.createClient({ type: 'subscriber(bull)' });
 
@@ -168,6 +177,7 @@ describe('RedisClientService', () => {
 			const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
 
 			const service = new RedisClientService(logger, globalConfig);
+			enableExitOnRedisUnreachable(service);
 			service.createClient({ type: 'client(bull)' });
 			service.createClient({ type: 'subscriber(bull)' });
 
@@ -219,6 +229,7 @@ describe('RedisClientService', () => {
 			const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
 
 			const service = new RedisClientService(logger, globalConfig);
+			enableExitOnRedisUnreachable(service);
 			service.createClient({ type: 'client(bull)' });
 
 			const mockClient = mockedRedis.mock.results[0].value;
@@ -240,6 +251,29 @@ describe('RedisClientService', () => {
 
 			// Disconnect window 2: drop at 25s, within 30s of the last failed retry.
 			dateNowSpy.mockReturnValue(T0 + 25_000);
+			retryStrategy();
+
+			expect(exitSpy).not.toHaveBeenCalled();
+
+			dateNowSpy.mockRestore();
+			exitSpy.mockRestore();
+		});
+
+		it('should not exit the process under test even when the timeout is exceeded', () => {
+			const T0 = 1_700_000_000_000;
+			const dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(T0);
+			const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+
+			// No enableExitOnRedisUnreachable() — exercise the default test behaviour.
+			const service = new RedisClientService(logger, globalConfig);
+			service.createClient({ type: 'client(bull)' });
+
+			const retryStrategy = mockedRedis.mock.calls[0][0].retryStrategy as () => number;
+
+			// Fail continuously well past the timeout threshold.
+			dateNowSpy.mockReturnValue(T0 + 1_000);
+			retryStrategy();
+			dateNowSpy.mockReturnValue(T0 + 12_001);
 			retryStrategy();
 
 			expect(exitSpy).not.toHaveBeenCalled();

--- a/packages/cli/src/services/redis-client.service.ts
+++ b/packages/cli/src/services/redis-client.service.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@n8n/backend-common';
+import { inTest, Logger } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { Debounce } from '@n8n/decorators';
 import { Service } from '@n8n/di';
@@ -42,6 +42,13 @@ export class RedisClientService extends TypedEmitter<RedisEventMap> {
 
 	/** Whether any client has lost connection to Redis. */
 	private lostConnection = false;
+
+	/**
+	 * Whether to exit the process when Redis stays unreachable past the timeout.
+	 * Disabled under test so a client that can never reach Redis (e.g. no Redis
+	 * in DB-test runs) does not call `process.exit` and kill the test worker.
+	 */
+	private readonly exitOnRedisUnreachable = !inTest;
 
 	constructor(
 		private readonly logger: Logger,
@@ -243,8 +250,10 @@ export class RedisClientService extends TypedEmitter<RedisEventMap> {
 				if (cumulativeTimeout > this.config.maxTimeout) {
 					const maxTimeout = Math.round(this.config.maxTimeout / 1000) + 's';
 					this.logger.error(`Unable to connect to Redis after trying to connect for ${maxTimeout}`);
-					this.logger.error('Exiting process due to Redis connection error');
-					process.exit(1);
+					if (this.exitOnRedisUnreachable) {
+						this.logger.error('Exiting process due to Redis connection error');
+						process.exit(1);
+					}
 				}
 			}
 


### PR DESCRIPTION
## Summary

>[!NOTE]
> Fix authored by Claude

`packages/cli/src/services/redis-client.service.ts`'s `retryStrategy` calls `process.exit(1)` once its cumulative reconnect time exceeds `bull.redis.timeoutThreshold`. Under Jest this kills the worker process hosting whichever test happens to be running, surfacing as an unrelated failure:

```
process.exit called with "1"
  at services/redis-client.service.ts
A worker process has failed to exit gracefully
```

This is the **top recurring flake in DB Tests / Postgres 16** (~33% of failures over 14 days, several in the merge queue). `task-broker-server.test.ts` is the most frequent victim purely because of where it sits in the worker's run order — it never touches Redis itself. The real cause is a library calling `process.exit` from inside the test runner: a client that can never reach Redis (no Redis in DB-test runs) accumulates retry time and trips the budget mid-test.

## Change

Gate the `process.exit(1)` behind `exitOnRedisUnreachable`, which is disabled under test (`!inTest`). In production behaviour is unchanged — the process still exits so the orchestrator can restart it with a fresh connection. Under test, the client just keeps returning the retry interval and the worker is no longer killed.

The cumulative-timeout accounting is untouched and still fully covered: the existing tests re-enable the exit flag to assert on the decision, and a new test verifies the default test behaviour does not exit even past the threshold.

## Routing

Filed under Developer Platform as the CI-flake owner, but `redis-client.service.ts` is owned by **Catalysts** — requesting review from @n8n-io/catalysts. The most recent change to this file (#29377, CAT-2721) introduced the per-client cumulative-timeout accounting that this flake rides on.

https://linear.app/n8n/issue/DEVP-408

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)