### PR TITLE
feat: route hard-coded-URL community nodes through the AI Gateway (Hack Week)

### DIFF
--- a/packages/@n8n/api-types/src/dto/ai/ai-gateway-config-response.dto.ts
+++ b/packages/@n8n/api-types/src/dto/ai/ai-gateway-config-response.dto.ts
@@ -4,15 +4,35 @@ import { Z } from '../../zod-class';
 
 const aiGatewayProviderConfigEntryShape = {
 	gatewayPath: z.string(),
-	urlField: z.string(),
+	/**
+	 * Credential field that holds the provider base URL. Optional: community nodes
+	 * that hard-code their base URL (and never read it from the credential) omit this.
+	 */
+	urlField: z.string().optional(),
 	apiKeyField: z.string(),
+	/**
+	 * Provider hosts (e.g. `api.browserbase.com`) whose outbound HTTP traffic should be
+	 * rerouted to the gateway at the request level. Used for nodes that hard-code their
+	 * base URL instead of reading it from the credential, so a `urlField` override alone
+	 * cannot redirect them.
+	 */
+	hosts: z.array(z.string()).optional(),
 };
 
 export class AiGatewayProviderConfigEntry extends Z.class(aiGatewayProviderConfigEntryShape) {}
 
+// A provider must be redirectable by at least one mechanism: a credential `urlField`
+// (Layer 1, for nodes that read their base URL from the credential) or `hosts`
+// (Layer 2, HTTP-level rewrite). An entry with neither would be a silent no-op.
+const aiGatewayProviderConfigEntry = z
+	.object(aiGatewayProviderConfigEntryShape)
+	.refine((entry) => Boolean(entry.urlField) || (entry.hosts?.length ?? 0) > 0, {
+		message: 'Provider config must define either "urlField" or "hosts".',
+	});
+
 export class AiGatewayConfigDto extends Z.class({
 	nodes: z.array(z.string()),
 	credentialTypes: z.array(z.string()),
-	providerConfig: z.record(z.object(aiGatewayProviderConfigEntryShape)),
+	providerConfig: z.record(aiGatewayProviderConfigEntry),
 	supportedActions: z.record(z.record(z.array(z.string()))).optional(),
 }) {}

--- a/packages/@n8n/api-types/src/dto/ai/ai-gateway-config-response.dto.ts
+++ b/packages/@n8n/api-types/src/dto/ai/ai-gateway-config-response.dto.ts
@@ -11,12 +11,15 @@ const aiGatewayProviderConfigEntryShape = {
 	urlField: z.string().optional(),
 	apiKeyField: z.string(),
 	/**
-	 * Provider hosts (e.g. `api.browserbase.com`) whose outbound HTTP traffic should be
-	 * rerouted to the gateway at the request level. Used for nodes that hard-code their
-	 * base URL instead of reading it from the credential, so a `urlField` override alone
-	 * cannot redirect them.
+	 * Maps a provider host to the gateway path segment that proxies it, e.g.
+	 * `{ 'api.browserbase.com': '/v1/gateway/browserbase' }`. Used for nodes that
+	 * hard-code their base URL (so a `urlField` override cannot redirect them): the
+	 * HTTP-level rewriter looks up the request's host here and rebuilds the URL against
+	 * the mapped gateway path, preserving the original path and query. A single provider
+	 * may span multiple hosts that route to different segments (e.g. Browserbase REST vs
+	 * Stagehand), which is why this is a map rather than a flat host list.
 	 */
-	hosts: z.array(z.string()).optional(),
+	hosts: z.record(z.string()).optional(),
 };
 
 export class AiGatewayProviderConfigEntry extends Z.class(aiGatewayProviderConfigEntryShape) {}
@@ -26,7 +29,7 @@ export class AiGatewayProviderConfigEntry extends Z.class(aiGatewayProviderConfi
 // (Layer 2, HTTP-level rewrite). An entry with neither would be a silent no-op.
 const aiGatewayProviderConfigEntry = z
 	.object(aiGatewayProviderConfigEntryShape)
-	.refine((entry) => Boolean(entry.urlField) || (entry.hosts?.length ?? 0) > 0, {
+	.refine((entry) => Boolean(entry.urlField) || Object.keys(entry.hosts ?? {}).length > 0, {
 		message: 'Provider config must define either "urlField" or "hosts".',
 	});
 

--- a/packages/cli/src/services/__tests__/ai-gateway.service.test.ts
+++ b/packages/cli/src/services/__tests__/ai-gateway.service.test.ts
@@ -2,6 +2,7 @@ import type { GlobalConfig } from '@n8n/config';
 import type { LicenseState } from '@n8n/backend-common';
 import { mock } from 'jest-mock-extended';
 import type { InstanceSettings } from 'n8n-core';
+import type { INode, IWorkflowExecuteAdditionalData } from 'n8n-workflow';
 import { UserError } from 'n8n-workflow';
 
 import { N8N_VERSION, AI_ASSISTANT_SDK_VERSION } from '@/constants';
@@ -175,6 +176,33 @@ describe('AiGatewayService', () => {
 				apiKey: 'mock-jwt-token',
 				host: `${BASE_URL}/v1/gateway/google`,
 			});
+		});
+
+		it('omits the URL field for providers that have no urlField (community nodes)', async () => {
+			const noUrlConfig = {
+				...MOCK_GATEWAY_CONFIG,
+				providerConfig: {
+					browserbaseApi: {
+						gatewayPath: '/v1/gateway/browserbase',
+						apiKeyField: 'browserbaseApiKey',
+						hosts: ['api.browserbase.com'],
+					},
+				},
+			};
+			fetchMock
+				.mockResolvedValueOnce({ ok: true, json: jest.fn().mockResolvedValue(noUrlConfig) })
+				.mockResolvedValueOnce({
+					ok: true,
+					json: jest.fn().mockResolvedValue({ token: 'mock-jwt-token', expiresIn: 3600 }),
+				});
+			const service = makeService();
+
+			const result = await service.getSyntheticCredential({
+				credentialType: 'browserbaseApi',
+				userId: USER_ID,
+			});
+
+			expect(result).toEqual({ browserbaseApiKey: 'mock-jwt-token' });
 		});
 
 		it('fetches token from gateway with HeadersMetadataDto headers and licenseCert body', async () => {
@@ -773,6 +801,162 @@ describe('AiGatewayService', () => {
 				(c[0] as string).includes('/v1/gateway/credentials'),
 			);
 			expect(credentialsCalls).toHaveLength(1);
+		});
+	});
+
+	describe('buildHttpRewriter()', () => {
+		const REWRITE_CONFIG = {
+			...MOCK_GATEWAY_CONFIG,
+			providerConfig: {
+				...MOCK_GATEWAY_CONFIG.providerConfig,
+				browserbaseApi: {
+					gatewayPath: '/v1/gateway/browserbase',
+					apiKeyField: 'browserbaseApiKey',
+					hosts: ['api.browserbase.com', 'api.stagehand.browserbase.com'],
+				},
+			},
+		};
+
+		function mockRewriteConfigThenToken(token = 'jwt-1') {
+			fetchMock
+				.mockResolvedValueOnce({ ok: true, json: jest.fn().mockResolvedValue(REWRITE_CONFIG) })
+				.mockResolvedValueOnce({
+					ok: true,
+					json: jest.fn().mockResolvedValue({ token, expiresIn: 3600 }),
+				});
+		}
+
+		const managedNode = {
+			credentials: { browserbaseApi: { id: 'c1', name: 'BB', __aiGatewayManaged: true } },
+		} as unknown as INode;
+
+		const additionalData = (overrides: Partial<IWorkflowExecuteAdditionalData> = {}) =>
+			({ userId: USER_ID, ...overrides }) as IWorkflowExecuteAdditionalData;
+
+		it('rewrites a managed-node request to a host-preserving proxy URL and injects Bearer auth', async () => {
+			mockRewriteConfigThenToken('jwt-1');
+			const service = makeService();
+			const rewriter = service.buildHttpRewriter(additionalData());
+
+			const result = await rewriter(
+				{
+					method: 'POST',
+					url: 'https://api.browserbase.com/v1/fetch',
+					headers: { 'x-bb-api-key': 'jwt-1' },
+				},
+				managedNode,
+			);
+
+			expect(result).toEqual({
+				method: 'POST',
+				url: `${BASE_URL}/v1/gateway/proxy/api.browserbase.com/v1/fetch`,
+				baseURL: undefined,
+				headers: { 'x-bb-api-key': 'jwt-1', Authorization: 'Bearer jwt-1' },
+			});
+		});
+
+		it('matches the host case-insensitively', async () => {
+			mockRewriteConfigThenToken();
+			const service = makeService();
+			const rewriter = service.buildHttpRewriter(additionalData());
+
+			const result = await rewriter(
+				{ method: 'GET', url: 'https://API.Browserbase.com/v1/fetch' },
+				managedNode,
+			);
+
+			expect(result?.url).toBe(`${BASE_URL}/v1/gateway/proxy/api.browserbase.com/v1/fetch`);
+		});
+
+		it('preserves the query string when rewriting', async () => {
+			mockRewriteConfigThenToken();
+			const service = makeService();
+			const rewriter = service.buildHttpRewriter(additionalData());
+
+			const result = await rewriter(
+				{ method: 'GET', url: 'https://api.stagehand.browserbase.com/v1/sessions?live=true' },
+				managedNode,
+			);
+
+			expect(result?.url).toBe(
+				`${BASE_URL}/v1/gateway/proxy/api.stagehand.browserbase.com/v1/sessions?live=true`,
+			);
+		});
+
+		it('embeds execution context in the proxy path when executionId and workflowId are present', async () => {
+			mockRewriteConfigThenToken();
+			const service = makeService();
+			const rewriter = service.buildHttpRewriter(
+				additionalData({ executionId: '29021', workflowId: 'R9JFXwkUCL1jZBuw' }),
+			);
+
+			const result = await rewriter(
+				{ method: 'POST', url: 'https://api.browserbase.com/v1/fetch' },
+				managedNode,
+			);
+
+			expect(result?.url).toBe(
+				`${BASE_URL}/v1/gateway/proxy/exec/29021/R9JFXwkUCL1jZBuw/api.browserbase.com/v1/fetch`,
+			);
+		});
+
+		it('resolves a relative url against baseURL before matching the host', async () => {
+			mockRewriteConfigThenToken();
+			const service = makeService();
+			const rewriter = service.buildHttpRewriter(additionalData());
+
+			const result = await rewriter(
+				{ method: 'GET', baseURL: 'https://api.browserbase.com', url: '/v1/fetch' },
+				managedNode,
+			);
+
+			expect(result?.url).toBe(`${BASE_URL}/v1/gateway/proxy/api.browserbase.com/v1/fetch`);
+			expect(result?.baseURL).toBeUndefined();
+		});
+
+		it('leaves the request untouched when the node has no gateway-managed credential', async () => {
+			const service = makeService();
+			const unmanagedNode = {
+				credentials: { browserbaseApi: { id: 'c1', name: 'BB' } },
+			} as unknown as INode;
+			const rewriter = service.buildHttpRewriter(additionalData());
+
+			const result = await rewriter(
+				{ method: 'POST', url: 'https://api.browserbase.com/v1/fetch' },
+				unmanagedNode,
+			);
+
+			expect(result).toBeUndefined();
+			expect(fetchMock).not.toHaveBeenCalled();
+		});
+
+		it('leaves the request untouched when the target host is not a managed provider host', async () => {
+			fetchMock.mockResolvedValueOnce({
+				ok: true,
+				json: jest.fn().mockResolvedValue(REWRITE_CONFIG),
+			});
+			const service = makeService();
+			const rewriter = service.buildHttpRewriter(additionalData());
+
+			const result = await rewriter(
+				{ method: 'GET', url: 'https://example.com/whatever' },
+				managedNode,
+			);
+
+			expect(result).toBeUndefined();
+		});
+
+		it('leaves the request untouched when the node has no credentials', async () => {
+			const service = makeService();
+			const rewriter = service.buildHttpRewriter(additionalData());
+
+			const result = await rewriter(
+				{ method: 'GET', url: 'https://api.browserbase.com/v1/fetch' },
+				{} as unknown as INode,
+			);
+
+			expect(result).toBeUndefined();
+			expect(fetchMock).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/cli/src/services/__tests__/ai-gateway.service.test.ts
+++ b/packages/cli/src/services/__tests__/ai-gateway.service.test.ts
@@ -185,7 +185,7 @@ describe('AiGatewayService', () => {
 					browserbaseApi: {
 						gatewayPath: '/v1/gateway/browserbase',
 						apiKeyField: 'browserbaseApiKey',
-						hosts: ['api.browserbase.com'],
+						hosts: { 'api.browserbase.com': '/v1/gateway/browserbase' },
 					},
 				},
 			};
@@ -812,7 +812,10 @@ describe('AiGatewayService', () => {
 				browserbaseApi: {
 					gatewayPath: '/v1/gateway/browserbase',
 					apiKeyField: 'browserbaseApiKey',
-					hosts: ['api.browserbase.com', 'api.stagehand.browserbase.com'],
+					hosts: {
+						'api.browserbase.com': '/v1/gateway/browserbase',
+						'api.stagehand.browserbase.com': '/v1/gateway/browserbaseStagehand',
+					},
 				},
 			},
 		};
@@ -849,7 +852,7 @@ describe('AiGatewayService', () => {
 
 			expect(result).toEqual({
 				method: 'POST',
-				url: `${BASE_URL}/v1/gateway/proxy/api.browserbase.com/v1/fetch`,
+				url: `${BASE_URL}/v1/gateway/browserbase/v1/fetch`,
 				baseURL: undefined,
 				headers: { 'x-bb-api-key': 'jwt-1', Authorization: 'Bearer jwt-1' },
 			});
@@ -865,7 +868,7 @@ describe('AiGatewayService', () => {
 				managedNode,
 			);
 
-			expect(result?.url).toBe(`${BASE_URL}/v1/gateway/proxy/api.browserbase.com/v1/fetch`);
+			expect(result?.url).toBe(`${BASE_URL}/v1/gateway/browserbase/v1/fetch`);
 		});
 
 		it('preserves the query string when rewriting', async () => {
@@ -878,9 +881,7 @@ describe('AiGatewayService', () => {
 				managedNode,
 			);
 
-			expect(result?.url).toBe(
-				`${BASE_URL}/v1/gateway/proxy/api.stagehand.browserbase.com/v1/sessions?live=true`,
-			);
+			expect(result?.url).toBe(`${BASE_URL}/v1/gateway/browserbaseStagehand/v1/sessions?live=true`);
 		});
 
 		it('embeds execution context in the proxy path when executionId and workflowId are present', async () => {
@@ -896,7 +897,7 @@ describe('AiGatewayService', () => {
 			);
 
 			expect(result?.url).toBe(
-				`${BASE_URL}/v1/gateway/proxy/exec/29021/R9JFXwkUCL1jZBuw/api.browserbase.com/v1/fetch`,
+				`${BASE_URL}/v1/gateway/exec/29021/R9JFXwkUCL1jZBuw/browserbase/v1/fetch`,
 			);
 		});
 
@@ -910,7 +911,7 @@ describe('AiGatewayService', () => {
 				managedNode,
 			);
 
-			expect(result?.url).toBe(`${BASE_URL}/v1/gateway/proxy/api.browserbase.com/v1/fetch`);
+			expect(result?.url).toBe(`${BASE_URL}/v1/gateway/browserbase/v1/fetch`);
 			expect(result?.baseURL).toBeUndefined();
 		});
 

--- a/packages/cli/src/services/ai-gateway.service.ts
+++ b/packages/cli/src/services/ai-gateway.service.ts
@@ -4,7 +4,13 @@ import { LICENSE_FEATURES } from '@n8n/constants';
 import { Service } from '@n8n/di';
 import { UserRepository } from '@n8n/db';
 import { InstanceSettings } from 'n8n-core';
-import type { ICredentialDataDecryptedObject } from 'n8n-workflow';
+import type { GatewayHttpRewriter } from 'n8n-core';
+import type {
+	ICredentialDataDecryptedObject,
+	IHttpRequestOptions,
+	INode,
+	IWorkflowExecuteAdditionalData,
+} from 'n8n-workflow';
 import { UserError } from 'n8n-workflow';
 import type { AiGatewayConfigDto, AiGatewayUsageResponse } from '@n8n/api-types';
 
@@ -39,6 +45,8 @@ export class AiGatewayService {
 	private static readonly CONFIG_TTL_MS = 60 * 60 * 1000; // 1 hour
 
 	private static readonly GATEWAY_PATH_PREFIX = '/v1/gateway';
+
+	private static readonly PROXY_PATH_PREFIX = '/v1/gateway/proxy';
 
 	constructor(
 		private readonly globalConfig: GlobalConfig,
@@ -121,15 +129,119 @@ export class AiGatewayService {
 			throw new UserError('Failed to obtain a valid AI Gateway token.');
 		}
 
-		const gatewayUrl = this.buildGatewayUrl(baseUrl, providerConfig.gatewayPath, {
-			executionId,
-			workflowId,
-		});
-
-		return {
+		const credential: ICredentialDataDecryptedObject = {
 			[providerConfig.apiKeyField]: jwt,
-			[providerConfig.urlField]: gatewayUrl,
 		};
+
+		// Community nodes that hard-code their base URL have no `urlField`; they are
+		// redirected at the HTTP layer instead (see `buildHttpRewriter`).
+		if (providerConfig.urlField) {
+			credential[providerConfig.urlField] = this.buildGatewayUrl(
+				baseUrl,
+				providerConfig.gatewayPath,
+				{ executionId, workflowId },
+			);
+		}
+
+		return credential;
+	}
+
+	/**
+	 * Builds the HTTP-layer rewriter installed on `additionalData` for executions.
+	 * Reroutes outbound requests from gateway-managed nodes whose target host is a
+	 * managed provider host (per gateway config `providerConfig[type].hosts`) through
+	 * the gateway, injecting a `Bearer` token. This covers nodes that hard-code their
+	 * base URL and so cannot be redirected via a credential `urlField` override.
+	 *
+	 * The returned closure reads `userId`/`workflowId`/`projectId`/`executionId` from
+	 * the captured `additionalData` at request time (they are populated by then).
+	 */
+	buildHttpRewriter(additionalData: IWorkflowExecuteAdditionalData): GatewayHttpRewriter {
+		return async (requestOptions: IHttpRequestOptions, node: INode) => {
+			const managedTypes = this.getManagedCredentialTypes(node);
+			if (managedTypes.length === 0) return undefined;
+
+			const targetUrl = this.resolveRequestUrl(requestOptions);
+			if (!targetUrl) return undefined;
+
+			// Match on hostname (port- and case-insensitive) against the configured hosts.
+			let hostname: string;
+			try {
+				hostname = new URL(targetUrl).hostname;
+			} catch {
+				return undefined;
+			}
+
+			const config = await this.getGatewayConfig();
+			const matches = managedTypes.some((type) =>
+				config.providerConfig[type]?.hosts?.includes(hostname),
+			);
+			if (!matches) return undefined;
+
+			// From here the request is destined for a managed host: fail closed. If the
+			// gateway/token is unavailable we throw rather than pass through, so a managed
+			// node never silently leaks traffic (and its real key) to the real provider.
+			const baseUrl = this.requireBaseUrl();
+			const { userId, workflowId, projectId, executionId } = additionalData;
+			const resolvedUserId = await this.resolveUserId({ userId, workflowId, projectId });
+			if (!resolvedUserId) {
+				throw new UserError('Failed to resolve user for AI Gateway attribution.');
+			}
+			const jwt = await this.getOrFetchToken(resolvedUserId);
+			if (!jwt) {
+				throw new UserError('Failed to obtain a valid AI Gateway token.');
+			}
+
+			return {
+				...requestOptions,
+				baseURL: undefined,
+				url: this.buildProxyUrl(baseUrl, targetUrl, { executionId, workflowId }),
+				headers: {
+					...requestOptions.headers,
+					Authorization: `Bearer ${jwt}`,
+				},
+			};
+		};
+	}
+
+	private getManagedCredentialTypes(node: INode): string[] {
+		const credentials = node.credentials;
+		if (!credentials) return [];
+		return Object.entries(credentials)
+			.filter(([, details]) => details?.__aiGatewayManaged)
+			.map(([type]) => type);
+	}
+
+	private resolveRequestUrl(requestOptions: IHttpRequestOptions): string | undefined {
+		const { url, baseURL } = requestOptions;
+		if (baseURL) {
+			try {
+				return new URL(url ?? '', baseURL).toString();
+			} catch {
+				return undefined;
+			}
+		}
+		return url || undefined;
+	}
+
+	/**
+	 * Builds a host-preserving proxy URL. The original host and path are embedded after
+	 * the proxy prefix so the gateway can route to the correct upstream and inject the
+	 * real provider credentials. Embeds execution context for attribution when available.
+	 *
+	 * Example: `https://api.browserbase.com/v1/fetch`
+	 *   → `<base>/v1/gateway/proxy/api.browserbase.com/v1/fetch`
+	 *   → with context: `<base>/v1/gateway/proxy/exec/<execId>/<wfId>/api.browserbase.com/v1/fetch`
+	 */
+	private buildProxyUrl(
+		baseUrl: string,
+		targetUrl: string,
+		context: { executionId?: string; workflowId?: string },
+	): string {
+		const parsed = new URL(targetUrl);
+		const hostAndPath = `${parsed.host}${parsed.pathname}`;
+		const prefix = this.withExecPrefix(AiGatewayService.PROXY_PATH_PREFIX, context);
+		return `${baseUrl}${prefix}/${hostAndPath}${parsed.search}`;
 	}
 
 	/**
@@ -215,9 +327,23 @@ export class AiGatewayService {
 				return `${baseUrl}${gatewayPath}`;
 			}
 			const providerSuffix = gatewayPath.slice(AiGatewayService.GATEWAY_PATH_PREFIX.length);
-			return `${baseUrl}${AiGatewayService.GATEWAY_PATH_PREFIX}/exec/${encodeURIComponent(context.executionId)}/${encodeURIComponent(context.workflowId)}${providerSuffix}`;
+			return `${baseUrl}${this.withExecPrefix(AiGatewayService.GATEWAY_PATH_PREFIX, context)}${providerSuffix}`;
 		}
 		return `${baseUrl}${gatewayPath}`;
+	}
+
+	/**
+	 * Appends an `/exec/:executionId/:workflowId` segment to a gateway path prefix when
+	 * both IDs are present. The gateway's URL-rewriting middleware strips this segment
+	 * before proxying upstream; it exists purely so the gateway can record both IDs in
+	 * usage metadata. Returns the prefix unchanged when either ID is missing.
+	 */
+	private withExecPrefix(
+		prefix: string,
+		context: { executionId?: string; workflowId?: string },
+	): string {
+		if (!context.executionId || !context.workflowId) return prefix;
+		return `${prefix}/exec/${encodeURIComponent(context.executionId)}/${encodeURIComponent(context.workflowId)}`;
 	}
 
 	private requireBaseUrl(): string {

--- a/packages/cli/src/services/ai-gateway.service.ts
+++ b/packages/cli/src/services/ai-gateway.service.ts
@@ -46,8 +46,6 @@ export class AiGatewayService {
 
 	private static readonly GATEWAY_PATH_PREFIX = '/v1/gateway';
 
-	private static readonly PROXY_PATH_PREFIX = '/v1/gateway/proxy';
-
 	constructor(
 		private readonly globalConfig: GlobalConfig,
 		private readonly license: License,
@@ -173,10 +171,10 @@ export class AiGatewayService {
 			}
 
 			const config = await this.getGatewayConfig();
-			const matches = managedTypes.some((type) =>
-				config.providerConfig[type]?.hosts?.includes(hostname),
-			);
-			if (!matches) return undefined;
+			const gatewayPath = managedTypes
+				.map((type) => config.providerConfig[type]?.hosts?.[hostname])
+				.find((path): path is string => Boolean(path));
+			if (!gatewayPath) return undefined;
 
 			// From here the request is destined for a managed host: fail closed. If the
 			// gateway/token is unavailable we throw rather than pass through, so a managed
@@ -195,7 +193,7 @@ export class AiGatewayService {
 			return {
 				...requestOptions,
 				baseURL: undefined,
-				url: this.buildProxyUrl(baseUrl, targetUrl, { executionId, workflowId }),
+				url: this.buildProxyUrl(baseUrl, gatewayPath, targetUrl, { executionId, workflowId }),
 				headers: {
 					...requestOptions.headers,
 					Authorization: `Bearer ${jwt}`,
@@ -225,23 +223,24 @@ export class AiGatewayService {
 	}
 
 	/**
-	 * Builds a host-preserving proxy URL. The original host and path are embedded after
-	 * the proxy prefix so the gateway can route to the correct upstream and inject the
-	 * real provider credentials. Embeds execution context for attribution when available.
+	 * Builds the gateway proxy URL for a hard-coded-URL node by mapping the request's
+	 * host to its gateway path segment (from `providerConfig[type].hosts`) and
+	 * appending the original request path and query. Reuses `buildGatewayUrl` so the
+	 * exec-attribution prefix is constructed identically to the credential path.
 	 *
-	 * Example: `https://api.browserbase.com/v1/fetch`
-	 *   → `<base>/v1/gateway/proxy/api.browserbase.com/v1/fetch`
-	 *   → with context: `<base>/v1/gateway/proxy/exec/<execId>/<wfId>/api.browserbase.com/v1/fetch`
+	 * Example: host `api.stagehand.browserbase.com` → `/v1/gateway/browserbaseStagehand`,
+	 *   request `…/v1/sessions/start`
+	 *   → `<base>/v1/gateway/browserbaseStagehand/v1/sessions/start`
+	 *   → with context: `<base>/v1/gateway/exec/<execId>/<wfId>/browserbaseStagehand/v1/sessions/start`
 	 */
 	private buildProxyUrl(
 		baseUrl: string,
+		gatewayPath: string,
 		targetUrl: string,
 		context: { executionId?: string; workflowId?: string },
 	): string {
 		const parsed = new URL(targetUrl);
-		const hostAndPath = `${parsed.host}${parsed.pathname}`;
-		const prefix = this.withExecPrefix(AiGatewayService.PROXY_PATH_PREFIX, context);
-		return `${baseUrl}${prefix}/${hostAndPath}${parsed.search}`;
+		return `${this.buildGatewayUrl(baseUrl, gatewayPath, context)}${parsed.pathname}${parsed.search}`;
 	}
 
 	/**

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 
 import type { PushMessage, PushType } from '@n8n/api-types';
-import { Logger, ModuleRegistry } from '@n8n/backend-common';
+import { LicenseState, Logger, ModuleRegistry } from '@n8n/backend-common';
 import { ExecutionsConfig, GlobalConfig, SsrfProtectionConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
 import { ExecutionRepository, WorkflowRepository } from '@n8n/db';
@@ -56,6 +56,7 @@ import {
 import type { UpdateExecutionPayload } from '@/interfaces';
 import { NodeTypes } from '@/node-types';
 import { Push } from '@/push';
+import { AiGatewayService } from '@/services/ai-gateway.service';
 import { UrlService } from '@/services/url.service';
 import { TaskRequester } from '@/task-runners/task-managers/task-requester';
 import { findSubworkflowStart } from '@/utils';
@@ -739,6 +740,14 @@ export async function getBase({
 	const ssrfConfig = Container.get(SsrfProtectionConfig);
 	if (ssrfConfig.enabled) {
 		additionalData.ssrfBridge = Container.get(SsrfProtectionService);
+	}
+
+	// Reroute outbound HTTP from gateway-managed nodes (incl. community nodes that
+	// hard-code their base URL) through the AI Gateway. Reads userId/workflowId/
+	// projectId/executionId from `additionalData` at request time.
+	if (Container.get(LicenseState).isAiGatewayLicensed()) {
+		additionalData.gatewayHttpRewriter =
+			Container.get(AiGatewayService).buildHttpRewriter(additionalData);
 	}
 
 	for (const [moduleName, moduleContext] of Container.get(ModuleRegistry).context.entries()) {

--- a/packages/core/src/execution-engine/index.ts
+++ b/packages/core/src/execution-engine/index.ts
@@ -30,6 +30,20 @@ export type EvalLlmMockHandler = (
 	node: INode,
 ) => Promise<EvalMockHttpResponse | undefined>;
 
+/**
+ * Rewrites an outbound HTTP request so it is proxied through the n8n AI Gateway.
+ * Receives the request options and the executing node. Returns rewritten request
+ * options (new URL + auth) when the node is gateway-managed and the request targets
+ * a managed provider host, or `undefined` to leave the request untouched.
+ *
+ * Enables gateway support for nodes (including community nodes) that hard-code their
+ * base URL and therefore cannot be redirected via a credential `urlField` override.
+ */
+export type GatewayHttpRewriter = (
+	requestOptions: IHttpRequestOptions,
+	node: INode,
+) => Promise<IHttpRequestOptions | undefined>;
+
 declare module 'n8n-workflow' {
 	interface IWorkflowExecuteAdditionalData {
 		hooks?: ExecutionLifecycleHooks;
@@ -49,6 +63,11 @@ declare module 'n8n-workflow' {
 		 * Only set by the eval execution service — never present in normal executions.
 		 */
 		evalLlmMockHandler?: EvalLlmMockHandler;
+		/**
+		 * Reroutes outbound HTTP requests from gateway-managed nodes through the AI Gateway.
+		 * Set only when the AI Gateway is licensed; absent otherwise.
+		 */
+		gatewayHttpRewriter?: GatewayHttpRewriter;
 		'data-table'?: { dataTableProxyProvider: DataTableProxyProvider };
 		'dynamic-credentials'?: { credentialCheckProxy: DynamicCredentialCheckProxyProvider };
 		'oauth-jwe'?: { oauthJweProxyProvider: OauthJweProxyProvider };

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/factory.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/factory.ts
@@ -76,6 +76,10 @@ export const getRequestHelperFunctions = (
 				);
 				if (evalMockResponse !== undefined) return evalMockResponse;
 			}
+			if (additionalData.gatewayHttpRewriter) {
+				const rewritten = await additionalData.gatewayHttpRewriter(requestOptions, node);
+				if (rewritten) requestOptions = rewritten;
+			}
 			if (additionalData.otel?.injectTraceHeaders) {
 				requestOptions.headers ??= {};
 				additionalData.otel.injectTraceHeaders(
@@ -149,6 +153,25 @@ export const getRequestHelperFunctions = (
 					'legacy',
 				);
 				if (evalMockResponse !== undefined) return evalMockResponse;
+			}
+			if (additionalData.gatewayHttpRewriter) {
+				const rewritten = await additionalData.gatewayHttpRewriter(
+					normalizeLegacyRequest(uriOrObject, options),
+					node,
+				);
+				if (rewritten?.url) {
+					if (typeof uriOrObject === 'string') {
+						uriOrObject = rewritten.url;
+						options = { ...options, headers: rewritten.headers };
+					} else {
+						uriOrObject = {
+							...uriOrObject,
+							uri: rewritten.url,
+							url: rewritten.url,
+							headers: rewritten.headers,
+						};
+					}
+				}
 			}
 			if (additionalData.otel?.injectTraceHeaders) {
 				const target = typeof uriOrObject === 'string' ? (options ??= {}) : uriOrObject;


### PR DESCRIPTION
> ⚠️ **Hack Week experiment — not intended for `main`.**
>
> **Author recommendation:** rather than carrying this generic HTTP-level override in
> core, I'd prefer we introduce an **acceptance requirement** that community nodes
> expose their base URL / host via the credential in order to be "n8n Connect
> compliant". That keeps the redirect on the existing, well-understood credential
> path (Layer 1) and avoids a request-level rewrite living in the core HTTP helpers.
> This PR exists to prove the mechanism works end-to-end for nodes that don't yet do
> that (e.g. Browserbase), not as the proposed long-term solution.

## Why this exists

The AI Gateway ("n8n connect") runs a node through n8n's managed proxy by
**rewriting the credential** (Layer 1): a `__aiGatewayManaged` credential is swapped
for a synthetic one whose `urlField` points at the gateway and whose `apiKeyField`
holds a short-lived JWT. This only works for nodes that **read their base URL from
the credential** (e.g. OpenAI reads `credentials.url`).

Many community nodes — Browserbase, for example — **hard-code the base URL** as a
module constant and call `helpers.httpRequest({ url })` directly, so a credential
`urlField` override never reaches them.

This PR adds a second interception layer (Layer 2): an **HTTP-layer rewriter** that
reroutes outbound requests regardless of how the node builds them.

## The two layers

- **Layer 1 — credential rewrite** (existing): redirects nodes that read their base
  URL from the credential. `AiGatewayService.getSyntheticCredential`.
- **Layer 2 — HTTP rewrite** (this PR): redirects nodes that hard-code the base URL.
  `AiGatewayService.buildHttpRewriter`, invoked from the request-helper factory.

For a hard-coded-URL node only Layer 2 redirects traffic; Layer 1 still supplies the
JWT in `apiKeyField` so the node doesn't send a real key upstream.

## Request flow

\`\`\`
https://api.browserbase.com/v1/fetch
  → <base>/v1/gateway/proxy/api.browserbase.com/v1/fetch
  → with exec context:
    <base>/v1/gateway/proxy/exec/<executionId>/<workflowId>/api.browserbase.com/v1/fetch
\`\`\`

plus an injected \`Authorization: Bearer <jwt>\` header. The original host is preserved
in the path so the gateway can route to the correct upstream without per-host config.

## Coverage

Layer 2 hooks the two raw outbound helpers: \`helpers.httpRequest\` (modern) and
\`helpers.request\` (legacy axios). Credential-auth helpers
(\`httpRequestWithAuthentication\`, OAuth flows) are intentionally **not** hooked —
those nodes read their URL/auth from the credential, so Layer 1 covers them. Host
matching is by \`URL.hostname\` (port/case-insensitive). Once a request is bound for a
managed host, Layer 2 **fails closed** (throws rather than leaking to the real
provider). The rewriter is only installed when \`isAiGatewayLicensed()\`.

## Config shape

\`providerConfig\` gains two optional fields, with a refine enforcing that each provider
defines at least one redirect mechanism:

\`\`\`ts
browserbaseApi: {
  gatewayPath: '/v1/gateway/browserbase',
  apiKeyField: 'browserbaseApiKey',
  hosts: ['api.browserbase.com', 'api.stagehand.browserbase.com'],
  // urlField omitted — the node never reads a URL from the credential
}
\`\`\`

## Backend contract (out of repo)

The AI assistant gateway must serve
\`/v1/gateway/proxy/[exec/:executionId/:workflowId/]<host>/<path...>\`: validate the
Bearer JWT, strip the prefix, inject the real provider credentials, and proxy to
\`https://<host>/<path>\`.

## Tests

- \`packages/cli/src/services/__tests__/ai-gateway.service.test.ts\` — managed rewrite,
  query preservation, exec-context path, baseURL+relative resolution, case-insensitive
  host match, and pass-through cases (unmanaged node, unknown host, no credentials).

Made with [Cursor](https://cursor.com)