### PR TITLE
ci: Add flag to force gzip compression

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -143,9 +143,9 @@ jobs:
           platforms: ${{ matrix.docker_platform }}
           provenance: false # Disabled - using SLSA L3 generator for isolated provenance
           sbom: false # Disabled - BuildKit's syft SBOM under-resolves npm licenses; the sbom-attestation job attests an enriched, license-gated CycloneDX SBOM instead
-          push: ${{ needs.determine-build-context.outputs.push_enabled == 'true' }}
+          push: ${{ inputs.force_gzip_compression != true && needs.determine-build-context.outputs.push_enabled == 'true' }}
           tags: ${{ steps.determine-tags.outputs.n8n_tags }}
-          outputs: ${{ inputs.force_gzip_compression == true && 'type=image,compression=gzip,force-compression=true' || '' }}
+          outputs: ${{ inputs.force_gzip_compression == true && format('type=image,push={0},compression=gzip,force-compression=true', needs.determine-build-context.outputs.push_enabled) || '' }}
 
       - name: Build and push task runners Docker image (Alpine)
         id: build-runners
@@ -160,9 +160,9 @@ jobs:
           platforms: ${{ matrix.docker_platform }}
           provenance: false # Disabled - using SLSA L3 generator for isolated provenance
           sbom: false # Disabled - BuildKit's syft SBOM under-resolves npm licenses; the sbom-attestation job attests an enriched, license-gated CycloneDX SBOM instead
-          push: ${{ needs.determine-build-context.outputs.push_enabled == 'true' }}
+          push: ${{ inputs.force_gzip_compression != true && needs.determine-build-context.outputs.push_enabled == 'true' }}
           tags: ${{ steps.determine-tags.outputs.runners_tags }}
-          outputs: ${{ inputs.force_gzip_compression == true && 'type=image,compression=gzip,force-compression=true' || '' }}
+          outputs: ${{ inputs.force_gzip_compression == true && format('type=image,push={0},compression=gzip,force-compression=true', needs.determine-build-context.outputs.push_enabled) || '' }}
 
       - name: Build and push task runners Docker image (distroless)
         id: build-runners-distroless
@@ -177,9 +177,9 @@ jobs:
           platforms: ${{ matrix.docker_platform }}
           provenance: false # Disabled - using SLSA L3 generator for isolated provenance
           sbom: false # Disabled - BuildKit's syft SBOM under-resolves npm licenses; the sbom-attestation job attests an enriched, license-gated CycloneDX SBOM instead
-          push: ${{ needs.determine-build-context.outputs.push_enabled == 'true' }}
+          push: ${{ inputs.force_gzip_compression != true && needs.determine-build-context.outputs.push_enabled == 'true' }}
           tags: ${{ steps.determine-tags.outputs.runners_distroless_tags }}
-          outputs: ${{ inputs.force_gzip_compression == true && 'type=image,compression=gzip,force-compression=true' || '' }}
+          outputs: ${{ inputs.force_gzip_compression == true && format('type=image,push={0},compression=gzip,force-compression=true', needs.determine-build-context.outputs.push_enabled) || '' }}
 
   create_multi_arch_manifest:
     name: Create Multi-Arch Manifest

--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -41,6 +41,11 @@ on:
         description: 'URL to call after the build is successful'
         required: false
         type: string
+      force_gzip_compression:
+        description: 'Force gzip compression on image layers (for compatibility with older containerd versions)'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   determine-build-context:
@@ -140,6 +145,7 @@ jobs:
           sbom: false # Disabled - BuildKit's syft SBOM under-resolves npm licenses; the sbom-attestation job attests an enriched, license-gated CycloneDX SBOM instead
           push: ${{ needs.determine-build-context.outputs.push_enabled == 'true' }}
           tags: ${{ steps.determine-tags.outputs.n8n_tags }}
+          outputs: ${{ inputs.force_gzip_compression == true && 'type=image,compression=gzip,force-compression=true' || '' }}
 
       - name: Build and push task runners Docker image (Alpine)
         id: build-runners
@@ -156,6 +162,7 @@ jobs:
           sbom: false # Disabled - BuildKit's syft SBOM under-resolves npm licenses; the sbom-attestation job attests an enriched, license-gated CycloneDX SBOM instead
           push: ${{ needs.determine-build-context.outputs.push_enabled == 'true' }}
           tags: ${{ steps.determine-tags.outputs.runners_tags }}
+          outputs: ${{ inputs.force_gzip_compression == true && 'type=image,compression=gzip,force-compression=true' || '' }}
 
       - name: Build and push task runners Docker image (distroless)
         id: build-runners-distroless
@@ -172,6 +179,7 @@ jobs:
           sbom: false # Disabled - BuildKit's syft SBOM under-resolves npm licenses; the sbom-attestation job attests an enriched, license-gated CycloneDX SBOM instead
           push: ${{ needs.determine-build-context.outputs.push_enabled == 'true' }}
           tags: ${{ steps.determine-tags.outputs.runners_distroless_tags }}
+          outputs: ${{ inputs.force_gzip_compression == true && 'type=image,compression=gzip,force-compression=true' || '' }}
 
   create_multi_arch_manifest:
     name: Create Multi-Arch Manifest


### PR DESCRIPTION


## Summary

We've been observing that image pulling on our test servers is failing. See https://n8nio.slack.com/archives/C0APV2RNSFP/p1780995648333049
With this change, we can rule out whether it's related to zstd compression.

The new `force_gzip_compression` will be set to true in our nathan workflow.

## Related Linear tickets, Github issues, and Community forum posts

Relates to LIGO-699


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
