### PR TITLE
fix(mcp): include workflow tags in get_workflow_details

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/get-workflow-details.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/get-workflow-details.tool.test.ts
@@ -1,5 +1,6 @@
 import { mockInstance } from '@n8n/backend-test-utils';
-import { User } from '@n8n/db';
+import { User, type TagEntity } from '@n8n/db';
+import { mock } from 'jest-mock-extended';
 
 import { createWorkflow } from './mock.utils';
 import { getWorkflowDetails, createWorkflowDetailsTool } from '../tools/get-workflow-details.tool';
@@ -140,6 +141,53 @@ describe('get-workflow-details MCP tool', () => {
 
 			expect(payload.workflow.activeVersion).toBeNull();
 			expect(payload.workflow.activeVersionId).toBeNull();
+		});
+
+		test('returns tags for workflows with assigned tags', async () => {
+			const workflow = createWorkflow({
+				activeVersionId: null,
+				tags: [mock<TagEntity>({ id: 'tag-1', name: 'bug-test', createdAt: new Date() })],
+			});
+			const workflowFinderService = mockInstance(WorkflowFinderService, {
+				findWorkflowForUser: jest.fn().mockResolvedValue(workflow),
+			});
+			const credentialsService = mockInstance(CredentialsService, {});
+			const endpoints = { webhook: 'webhook', webhookTest: 'webhook-test' };
+
+			const payload = await getWorkflowDetails(
+				user,
+				baseWebhookUrl,
+				workflowFinderService,
+				credentialsService,
+				endpoints,
+				roleService,
+				projectService,
+				{ workflowId: 'wf-1' },
+			);
+
+			expect(payload.workflow.tags).toEqual([{ id: 'tag-1', name: 'bug-test' }]);
+		});
+
+		test('returns empty tags array for workflows with no tags', async () => {
+			const workflow = createWorkflow({ activeVersionId: null, tags: [] });
+			const workflowFinderService = mockInstance(WorkflowFinderService, {
+				findWorkflowForUser: jest.fn().mockResolvedValue(workflow),
+			});
+			const credentialsService = mockInstance(CredentialsService, {});
+			const endpoints = { webhook: 'webhook', webhookTest: 'webhook-test' };
+
+			const payload = await getWorkflowDetails(
+				user,
+				baseWebhookUrl,
+				workflowFinderService,
+				credentialsService,
+				endpoints,
+				roleService,
+				projectService,
+				{ workflowId: 'wf-1' },
+			);
+
+			expect(payload.workflow.tags).toEqual([]);
 		});
 	});
 });

--- a/packages/cli/src/modules/mcp/__tests__/workflow-validation.utils.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/workflow-validation.utils.test.ts
@@ -122,6 +122,24 @@ describe('getMcpWorkflow', () => {
 
 			expect(findWorkflowForUser).toHaveBeenCalledWith('wf-1', user, ['workflow:publish'], {
 				includeActiveVersion: true,
+				includeTags: undefined,
+			});
+		});
+
+		test('passes includeTags option to workflowFinderService', async () => {
+			const workflow = createWorkflow({ settings: { availableInMCP: true } });
+			const findWorkflowForUser = jest.fn().mockResolvedValue(workflow);
+			const workflowFinderService = mockInstance(WorkflowFinderService, {
+				findWorkflowForUser,
+			});
+
+			await getMcpWorkflow('wf-1', user, ['workflow:read'], workflowFinderService, {
+				includeTags: true,
+			});
+
+			expect(findWorkflowForUser).toHaveBeenCalledWith('wf-1', user, ['workflow:read'], {
+				includeActiveVersion: undefined,
+				includeTags: true,
 			});
 		});
 	});

--- a/packages/cli/src/modules/mcp/tools/get-workflow-details.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/get-workflow-details.tool.ts
@@ -116,7 +116,7 @@ export async function getWorkflowDetails(
 		user,
 		['workflow:read'],
 		workflowFinderService,
-		{ includeActiveVersion: true },
+		{ includeActiveVersion: true, includeTags: true },
 	);
 
 	// Compute user scopes for this workflow

--- a/packages/cli/src/modules/mcp/tools/workflow-validation.utils.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-validation.utils.ts
@@ -39,6 +39,7 @@ export type FoundWorkflow = NonNullable<
 
 export type GetMcpWorkflowOptions = {
 	includeActiveVersion?: boolean;
+	includeTags?: boolean;
 };
 
 /**
@@ -56,6 +57,7 @@ export async function getMcpWorkflow(
 ): Promise<FoundWorkflow> {
 	const workflow = await workflowFinderService.findWorkflowForUser(workflowId, user, scopes, {
 		includeActiveVersion: options?.includeActiveVersion,
+		includeTags: options?.includeTags,
 	});
 
 	if (!workflow) {


### PR DESCRIPTION
## Summary

Fixes an issue where the `get_workflow_details` MCP tool returned an empty `tags` array even when tags were assigned to the workflow.

Root cause:

* `getWorkflowDetails()` includes workflow tags in the response payload.
* However, `getMcpWorkflow()` did not request tags from `WorkflowFinderService`.
* As a result, workflow tags were never loaded and MCP clients always received an empty array.

This PR:

* Adds `includeTags` to `GetMcpWorkflowOptions`
* Forwards `includeTags` to `WorkflowFinderService.findWorkflowForUser()`
* Requests tags when retrieving workflow details
* Adds tests covering tag retrieval and option forwarding

The MCP tool documentation already specifies that `workflow.tags` should be returned by `get_workflow_details`, so this change restores the expected behavior.

## How to test

1. Enable Instance-level MCP.
2. Create or select a workflow.
3. Enable **Available in MCP** for the workflow.
4. Create and assign a tag to the workflow.
5. Verify the workflow contains the tag via the REST API:

```bash
curl http://localhost:5678/api/v1/workflows/<WORKFLOW_ID> \
  -H "X-N8N-API-KEY: <API_KEY>"
```

6. Generate an MCP API key.
7. Call `get_workflow_details` through the MCP endpoint:

```bash
curl -X POST http://localhost:5678/mcp-server/http \
  -H "Authorization: Bearer <MCP_API_KEY>" \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{
    "jsonrpc":"2.0",
    "id":1,
    "method":"tools/call",
    "params":{
      "name":"get_workflow_details",
      "arguments":{
        "workflowId":"<WORKFLOW_ID>"
      }
    }
  }'
```

8. Verify the response contains the assigned tags:

```json
"tags": [
  {
    "id": "<tag-id>",
    "name": "<tag-name>"
  }
]
```

9. Run tests:

```bash
cd packages/cli

pnpm test workflow-validation.utils.test.ts
pnpm test get-workflow-details.tool.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

Fixes #31825

Issue: https://github.com/n8n-io/n8n/issues/31825

## Review / Merge checklist

* [x] I have seen this code, I have run this code, and I take responsibility for this code.
* [x] PR title and summary are descriptive.
* [ ] Docs updated or follow-up ticket created.
* [x] Tests included.
* [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if applicable).

<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
