### PR TITLE
feat(core): Make it possible to run sandboxes as ephemeral (no-changelog)

### DIFF
--- a/packages/@n8n/agents/src/__tests__/workspace/sandbox/create-workspace.test.ts
+++ b/packages/@n8n/agents/src/__tests__/workspace/sandbox/create-workspace.test.ts
@@ -39,6 +39,40 @@ describe('createSandbox', () => {
 		expect(result?.provider).toBe('daytona');
 	});
 
+	it('passes ephemeral through to the DaytonaSandbox', async () => {
+		const config: SandboxConfig = {
+			enabled: true,
+			provider: 'daytona',
+			daytonaApiUrl: 'https://api.daytona.io',
+			daytonaApiKey: 'test-key',
+			ephemeral: true,
+			timeout: 60_000,
+		};
+
+		const result = await createSandbox(config);
+
+		expect(result).toBeInstanceOf(DaytonaSandbox);
+		expect((result as unknown as { options: { ephemeral?: boolean } }).options.ephemeral).toBe(
+			true,
+		);
+	});
+
+	it('omits ephemeral from the DaytonaSandbox when not configured', async () => {
+		const config: SandboxConfig = {
+			enabled: true,
+			provider: 'daytona',
+			daytonaApiUrl: 'https://api.daytona.io',
+			daytonaApiKey: 'test-key',
+			timeout: 60_000,
+		};
+
+		const result = await createSandbox(config);
+
+		expect(
+			(result as unknown as { options: { ephemeral?: boolean } }).options.ephemeral,
+		).toBeUndefined();
+	});
+
 	it('passes getAuthToken through to DaytonaSandbox in proxy mode', async () => {
 		const getAuthToken = vi.fn().mockResolvedValue('jwt-token-123');
 		const config: SandboxConfig = {

--- a/packages/@n8n/agents/src/workspace/sandbox/create-workspace.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/create-workspace.ts
@@ -36,6 +36,7 @@ function buildSandbox(
 			logger,
 			apiUrl: config.daytonaApiUrl,
 			labels: config.labels,
+			...(config.ephemeral !== undefined ? { ephemeral: config.ephemeral } : {}),
 			...(config.image ? { image: config.image } : {}),
 			...(config.snapshot ? { snapshot: config.snapshot } : {}),
 			language: 'typescript',

--- a/packages/@n8n/agents/src/workspace/sandbox/types.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/types.ts
@@ -72,6 +72,11 @@ export interface DaytonaSandboxConfig extends SandboxConfigBase {
 	daytonaApiKey?: string;
 	image?: CreateSandboxFromImageParams['image'];
 	snapshot?: string;
+	/**
+	 * When true, Daytona auto-deletes the sandbox when it stops (instead of leaving it
+	 * stopped). Used for throwaway sandboxes (e.g. eval runs) so they don't accumulate.
+	 */
+	ephemeral?: boolean;
 	createTimeoutSeconds?: number;
 	getAuthToken?: () => Promise<string>;
 	refreshSkewMs?: number;

--- a/packages/@n8n/config/src/configs/instance-ai.config.ts
+++ b/packages/@n8n/config/src/configs/instance-ai.config.ts
@@ -73,6 +73,13 @@ export class InstanceAiConfig {
 	sandboxNamePrefix: string = '';
 
 	/**
+	 * When true, Daytona sandboxes are created ephemeral (auto-deleted on stop) instead of
+	 * lingering stopped. Intended for throwaway eval instances so sandboxes don't accumulate.
+	 */
+	@Env('N8N_INSTANCE_AI_SANDBOX_EPHEMERAL')
+	sandboxEphemeral: boolean = false;
+
+	/**
 	 * Skew (milliseconds) used to proactively refresh the Daytona proxy JWT before it expires.
 	 * Refresh fires when the cached token's remaining lifetime falls below this threshold.
 	 * Only used in proxy mode (when a `getAuthToken` callback is configured); ignored for static API keys.

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -298,6 +298,7 @@ describe('GlobalConfig', () => {
 			n8nSandboxServiceApiKey: '',
 			sandboxTimeout: 300000,
 			sandboxNamePrefix: '',
+			sandboxEphemeral: false,
 			daytonaTokenRefreshSkewMs: 300_000,
 			builderSandboxTtlMs: 900_000,
 			braveSearchApiKey: '',

--- a/packages/@n8n/instance-ai/docs/configuration.md
+++ b/packages/@n8n/instance-ai/docs/configuration.md
@@ -65,6 +65,7 @@ When no search provider is available, the `web-search` action is disabled. `fetc
 | `N8N_INSTANCE_AI_SANDBOX_IMAGE` | string | `daytonaio/sandbox:0.5.0` | Docker image for the Daytona sandbox. |
 | `N8N_INSTANCE_AI_SANDBOX_TIMEOUT` | number | `300000` | Default command timeout in the sandbox (milliseconds). |
 | `N8N_INSTANCE_AI_SANDBOX_NAME_PREFIX` | string | `''` | Prefix prepended to every Daytona sandbox name (e.g. `eval-baseline-daily`). Also surfaced as a `name_prefix` label. Empty in production. |
+| `N8N_INSTANCE_AI_SANDBOX_EPHEMERAL` | boolean | `false` | When true, Daytona sandboxes are created ephemeral (auto-deleted on stop) instead of lingering stopped. Intended for throwaway eval instances so sandboxes don't accumulate. |
 
 When sandbox is enabled, the builder agent writes TypeScript to
 `~/workspace/src/workflow.ts`, runs `tsc` for validation, and uses

--- a/packages/@n8n/instance-ai/docs/sandboxing.md
+++ b/packages/@n8n/instance-ai/docs/sandboxing.md
@@ -247,3 +247,4 @@ If any step fails, the agent reads the error output, fixes the code, and retries
 | `N8N_INSTANCE_AI_SANDBOX_IMAGE` | `daytonaio/sandbox:0.5.0` | Base container image for Daytona |
 | `N8N_INSTANCE_AI_SANDBOX_TIMEOUT` | `300000` | Command timeout in milliseconds |
 | `N8N_INSTANCE_AI_SANDBOX_NAME_PREFIX` | — | Prefix for every Daytona sandbox name (e.g. `eval-baseline-daily`). Also added as a `name_prefix` label. Empty in production. |
+| `N8N_INSTANCE_AI_SANDBOX_EPHEMERAL` | `false` | Create Daytona sandboxes ephemeral (auto-deleted on stop) instead of lingering stopped. Intended for throwaway eval instances so sandboxes don't accumulate. |

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -3052,3 +3052,58 @@ describe('InstanceAiService — deterministic workflow setup follow-up', () => {
 		expect(records['wi-1'].state.setupRoutingClaimId).toBeUndefined();
 	});
 });
+
+describe('getSandboxConfigFromEnv', () => {
+	type SandboxConfigService = {
+		instanceAiConfig: {
+			sandboxEnabled: boolean;
+			sandboxProvider: string;
+			daytonaApiUrl: string;
+			daytonaApiKey: string;
+			sandboxImage: string;
+			sandboxTimeout: number;
+			sandboxNamePrefix: string;
+			sandboxEphemeral: boolean;
+			daytonaTokenRefreshSkewMs: number;
+		};
+		getSandboxConfigFromEnv: () => SandboxConfig;
+	};
+
+	function createSandboxConfigService(
+		overrides: Partial<SandboxConfigService['instanceAiConfig']>,
+	): SandboxConfigService {
+		const service = Object.create(InstanceAiService.prototype) as SandboxConfigService;
+		service.instanceAiConfig = {
+			sandboxEnabled: true,
+			sandboxProvider: 'daytona',
+			daytonaApiUrl: 'https://api.daytona.io',
+			daytonaApiKey: 'key',
+			sandboxImage: 'img',
+			sandboxTimeout: 1000,
+			sandboxNamePrefix: '',
+			sandboxEphemeral: false,
+			daytonaTokenRefreshSkewMs: 1000,
+			...overrides,
+		};
+		return service;
+	}
+
+	it('marks daytona sandboxes ephemeral when the env flag is set', () => {
+		const service = createSandboxConfigService({ sandboxEphemeral: true });
+
+		expect(service.getSandboxConfigFromEnv()).toMatchObject({
+			enabled: true,
+			provider: 'daytona',
+			ephemeral: true,
+		});
+	});
+
+	it('keeps daytona sandboxes non-ephemeral by default', () => {
+		const service = createSandboxConfigService({ sandboxEphemeral: false });
+
+		expect(service.getSandboxConfigFromEnv()).toMatchObject({
+			provider: 'daytona',
+			ephemeral: false,
+		});
+	});
+});

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -728,6 +728,7 @@ export class InstanceAiService {
 			sandboxImage,
 			sandboxTimeout,
 			sandboxNamePrefix,
+			sandboxEphemeral,
 			daytonaTokenRefreshSkewMs,
 		} = this.instanceAiConfig;
 		const provider = normalizeSandboxProvider(sandboxProvider);
@@ -749,6 +750,7 @@ export class InstanceAiService {
 				n8nVersion: N8N_VERSION || undefined,
 				timeout: sandboxTimeout,
 				namePrefix: sandboxNamePrefix || undefined,
+				ephemeral: sandboxEphemeral,
 				refreshSkewMs: daytonaTokenRefreshSkewMs,
 			};
 		}


### PR DESCRIPTION
## Summary

Add `N8N_INSTANCE_AI_SANDBOX_EPHEMERAL` setting that when enabled makes the instance create sandboxes in ephemeral mode.

We should use this when running evals using Daytona sandboxes locally to not exhaust our daytona resources.

## How to test

Set `N8N_INSTANCE_AI_SANDBOX_EPHEMERAL=true` and check the lifecycle settings of the sandbox that gets created - it should receive `Auto-delete: On stop`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-476/sandbox-lifetime-investigation

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
