### PR TITLE
feat(core): Add backend endpoints for the personal-automation desktop app

### DIFF
--- a/packages/@n8n/api-types/src/dto/desktop-assistant/desktop-assistant-promote-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/desktop-assistant/desktop-assistant-promote-request.dto.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+
+/**
+ * Request body for `POST /desktop-assistant/promote-thread` — materialises
+ * an Instance AI thread into a real, editable workflow via the workflow
+ * builder. Idempotent on the thread metadata (`promotedWorkflowId`).
+ */
+export class DesktopAssistantPromoteRequestDto extends Z.class({
+	threadId: z.string().trim().min(1),
+	name: z.string().trim().min(1).max(128).optional(),
+}) {}
+
+export type DesktopAssistantPromoteRequest = z.infer<
+	typeof DesktopAssistantPromoteRequestDto.schema
+>;
+
+export type DesktopAssistantPromoteResponse =
+	| {
+			/** First-time promote: a build run was kicked off. The desktop client
+			 * subscribes to `/instance-ai/events/:threadId` and waits for the
+			 * workflow.created signal carried on that SSE stream. */
+			status: 'building';
+			threadId: string;
+			runId: string;
+	  }
+	| {
+			/** Idempotent hit: a previous promote already produced a workflow
+			 * for this thread and the workflow is still accessible to the
+			 * caller. The desktop client can deep-link to the workflow directly. */
+			status: 'done';
+			threadId: string;
+			workflowId: string;
+	  };

--- a/packages/@n8n/api-types/src/dto/desktop-assistant/desktop-assistant-task-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/desktop-assistant/desktop-assistant-task-request.dto.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+
+/**
+ * Request body for `POST /desktop-assistant/task` — the one-shot trigger
+ * fired from the desktop assistant. No `timeZone` here: one-shot tasks
+ * don't need scheduling; cron/schedule timezone only matters for the
+ * promote-thread path, where it is read from the user's profile.
+ */
+export class DesktopAssistantTaskRequestDto extends Z.class({
+	prompt: z.string().trim().min(1).max(8000),
+	context: z
+		.object({
+			selectedText: z.string().max(8000).optional(),
+			appHint: z.string().max(255).optional(),
+		})
+		.optional(),
+}) {}
+
+export type DesktopAssistantTaskRequest = z.infer<typeof DesktopAssistantTaskRequestDto.schema>;
+
+export interface DesktopAssistantTaskResponse {
+	threadId: string;
+	runId: string;
+}

--- a/packages/@n8n/api-types/src/dto/desktop-assistant/desktop-assistant-tasks-response.dto.ts
+++ b/packages/@n8n/api-types/src/dto/desktop-assistant/desktop-assistant-tasks-response.dto.ts
@@ -1,0 +1,41 @@
+import type { ExecutionStatus } from 'n8n-workflow';
+
+/**
+ * Response shape for `GET /desktop-assistant/tasks`. The controller
+ * classifies the user's accessible workflows into three buckets that the
+ * desktop assistant UI renders. A workflow appears in at most one bucket;
+ * precedence is `actionNeeded > upcoming > readyToRun`.
+ */
+export interface DesktopAssistantTasksResponse {
+	actionNeeded: DesktopAssistantTaskCard[];
+	upcoming: DesktopAssistantTaskCard[];
+	readyToRun: DesktopAssistantTaskCard[];
+}
+
+export interface DesktopAssistantTaskCard {
+	workflowId: string;
+	name: string;
+	/** Bucket-specific description rendered under the workflow name. */
+	description: string;
+	icon: DesktopAssistantTaskIcon;
+	trigger: DesktopAssistantTriggerSummary;
+	source: 'desktop-assistant' | 'user-built';
+	active: boolean;
+	lastExecution?: {
+		id: string;
+		status: ExecutionStatus;
+		startedAt: string;
+	};
+	/** True when any node uses a local computer-use capability. */
+	runsLocally: boolean;
+}
+
+export type DesktopAssistantTriggerSummary =
+	| { kind: 'manual' }
+	| { kind: 'schedule'; nextRunAt: string | null }
+	| { kind: 'poll' | 'webhook'; sourceLabel: string }
+	| { kind: 'other' };
+
+export type DesktopAssistantTaskIcon =
+	| { type: 'emoji'; value: string }
+	| { type: 'node'; nodeType: string };

--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -32,6 +32,23 @@ export {
 	type InstanceAiResourceDecision,
 } from './instance-ai/instance-ai-confirm-request.dto';
 export { InstanceAiFeedbackRequestDto } from './instance-ai/instance-ai-feedback-request.dto';
+
+export {
+	DesktopAssistantTaskRequestDto,
+	type DesktopAssistantTaskRequest,
+	type DesktopAssistantTaskResponse,
+} from './desktop-assistant/desktop-assistant-task-request.dto';
+export {
+	DesktopAssistantPromoteRequestDto,
+	type DesktopAssistantPromoteRequest,
+	type DesktopAssistantPromoteResponse,
+} from './desktop-assistant/desktop-assistant-promote-request.dto';
+export type {
+	DesktopAssistantTasksResponse,
+	DesktopAssistantTaskCard,
+	DesktopAssistantTriggerSummary,
+	DesktopAssistantTaskIcon,
+} from './desktop-assistant/desktop-assistant-tasks-response.dto';
 export { InstanceAiRenameThreadRequestDto } from './instance-ai/instance-ai-rename-thread-request.dto';
 export { InstanceAiMcpCreateConnectionRequestDto } from './instance-ai/instance-ai-mcp-create-connection-request.dto';
 export { InstanceAiMcpUpdateConnectionRequestDto } from './instance-ai/instance-ai-mcp-update-connection-request.dto';

--- a/packages/@n8n/db/src/entities/types-db.ts
+++ b/packages/@n8n/db/src/entities/types-db.ts
@@ -199,7 +199,9 @@ export namespace ExecutionSummaries {
 		retryOf: string;
 		retrySuccessId: string;
 		status: ExecutionStatus[];
-		workflowId: string;
+		/** Single workflow id, or a list of workflow ids (used by BFF endpoints
+		 * that pre-resolve a marker like a tag to a set of workflow ids). */
+		workflowId: string | string[];
 		waitTill: boolean;
 		metadata: Array<{ key: string; value: string; exactMatch?: boolean }>;
 		startedAfter: string;

--- a/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
@@ -523,6 +523,72 @@ describe('ExecutionRepository', () => {
 				{ type: 'execution', executionId: '1', workflowId },
 			]);
 		});
+
+		describe('workflowId filter (array form)', () => {
+			function captureAndWhereCalls() {
+				const calls: Array<[unknown, unknown?]> = [];
+				const qb: SelectQueryBuilder<ExecutionEntity> = mock<SelectQueryBuilder<ExecutionEntity>>({
+					select: vi.fn().mockReturnThis(),
+					andWhere: vi.fn((fragment: unknown, params?: unknown) => {
+						calls.push([fragment, params]);
+						return qb;
+					}),
+					getMany: vi.fn().mockResolvedValue([]),
+				});
+				vi.spyOn(executionRepository, 'createQueryBuilder').mockReturnValue(qb);
+				return calls;
+			}
+
+			test('produces an IN (:...filterWorkflowIds) fragment when given an array', async () => {
+				const calls = captureAndWhereCalls();
+
+				await executionRepository.deleteExecutionsByFilter({
+					filters: { workflowId: ['wf-a', 'wf-b'] },
+					accessibleWorkflowIds: ['wf-a', 'wf-b'],
+					deleteConditions: { deleteBefore: new Date() },
+				});
+
+				const filterCall = calls.find(
+					([fragment]) =>
+						typeof fragment === 'string' &&
+						fragment.includes('execution.workflowId IN (:...filterWorkflowIds)'),
+				);
+				expect(filterCall).toBeDefined();
+				expect(filterCall?.[1]).toEqual({ filterWorkflowIds: ['wf-a', 'wf-b'] });
+			});
+
+			test('short-circuits when given an empty array', async () => {
+				const calls = captureAndWhereCalls();
+
+				await executionRepository.deleteExecutionsByFilter({
+					filters: { workflowId: [] },
+					accessibleWorkflowIds: ['wf-a'],
+					deleteConditions: { deleteBefore: new Date() },
+				});
+
+				const shortCircuit = calls.find(
+					([fragment]) => typeof fragment === 'string' && fragment === '1 = 0',
+				);
+				expect(shortCircuit).toBeDefined();
+			});
+
+			test('falls back to a simple equality when given a string', async () => {
+				const calls = captureAndWhereCalls();
+
+				await executionRepository.deleteExecutionsByFilter({
+					filters: { workflowId: 'wf-a' },
+					accessibleWorkflowIds: ['wf-a'],
+					deleteConditions: { deleteBefore: new Date() },
+				});
+
+				const objectCall = calls.find(
+					([fragment]) =>
+						fragment !== null && typeof fragment === 'object' && 'workflowId' in fragment,
+				);
+				expect(objectCall).toBeDefined();
+				expect((objectCall?.[0] as { workflowId: string }).workflowId).toBe('wf-a');
+			});
+		});
 	});
 
 	describe('updateExistingExecution', () => {

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -74,7 +74,13 @@ export interface IGetExecutionsQueryFilter {
 	retryOf?: string;
 	retrySuccessId?: string;
 	status?: ExecutionStatus[];
-	workflowId?: string;
+	/**
+	 * Restrict the result to a single workflow id, or to a set of workflow ids.
+	 * The set form is used by BFF endpoints that resolve a marker (e.g. a tag)
+	 * to a list of workflow ids and then query executions across that list in
+	 * one round-trip.
+	 */
+	workflowId?: string | string[];
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	waitTill?: FindOperator<any> | boolean;
 	metadata?: Array<{ key: string; value: string; exactMatch?: boolean }>;
@@ -127,10 +133,22 @@ function parseFiltersToQueryBuilder(
 			),
 		});
 	}
-	if (filters?.workflowId) {
-		qb.andWhere({
-			workflowId: filters.workflowId,
-		});
+	if (filters?.workflowId !== undefined) {
+		if (Array.isArray(filters.workflowId)) {
+			if (filters.workflowId.length === 0) {
+				// Empty set means "no accessible matches" — short-circuit the result set
+				// instead of producing an invalid `IN ()` fragment.
+				qb.andWhere('1 = 0');
+			} else {
+				qb.andWhere('execution.workflowId IN (:...filterWorkflowIds)', {
+					filterWorkflowIds: filters.workflowId,
+				});
+			}
+		} else {
+			qb.andWhere({
+				workflowId: filters.workflowId,
+			});
+		}
 	}
 }
 
@@ -979,7 +997,19 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 
 		if (status) qb.andWhere('execution.status IN (:...status)', { status });
 		if (finished) qb.andWhere({ finished });
-		if (workflowId) qb.andWhere({ workflowId });
+		if (workflowId !== undefined) {
+			if (Array.isArray(workflowId)) {
+				if (workflowId.length === 0) {
+					qb.andWhere('1 = 0');
+				} else {
+					qb.andWhere('execution.workflowId IN (:...rangeWorkflowIds)', {
+						rangeWorkflowIds: workflowId,
+					});
+				}
+			} else {
+				qb.andWhere({ workflowId });
+			}
+		}
 		if (startedBefore) qb.andWhere({ startedAt: lessThanOrEqual(startedBefore) });
 		if (startedAfter) qb.andWhere({ startedAt: moreThanOrEqual(startedAfter) });
 

--- a/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.desktop-assistant.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.desktop-assistant.test.ts
@@ -3,11 +3,15 @@
  *
  * These tests pin the contract that the desktop assistant relies on:
  * - One-shot mode tells the orchestrator to run fire-and-forget (no follow-up
- *   questions, emit events only, hand off when ambiguous).
- * - Promote mode tells the orchestrator to build a workflow and pick an emoji.
+ *   questions, no conversational output, stop on ambiguity).
+ * - Promote mode tells the orchestrator to build a workflow and pick a short
+ *   descriptive name that starts with a representative emoji.
  *
  * The wording is intentionally not pinned exactly; we assert the protected
- * concepts survive copy edits but intent-shifting edits fail loudly.
+ * concepts survive copy edits but intent-shifting edits fail loudly. The
+ * desktop assistant no longer subscribes to derived `gate-chosen` /
+ * `workflow.created` / `handoff-to-editor` events — those references were
+ * removed from the prompts when the abstraction layer was dropped.
  */
 
 import { getSystemPrompt } from '../system-prompt';
@@ -35,12 +39,19 @@ describe('getSystemPrompt — desktop-assistant promptMode variants', () => {
 			expect(prompt).toMatch(/do not produce conversational output/i);
 		});
 
-		it('directs ambiguous requests to handoff-to-editor', () => {
-			expect(prompt).toMatch(/handoff-to-editor/i);
+		it('instructs the orchestrator to stop without producing a result when ambiguous', () => {
+			expect(prompt).toMatch(/stop without producing a result/i);
 		});
 
-		it('references the gate-chosen signal', () => {
-			expect(prompt).toMatch(/gate-chosen/i);
+		it('does not reference dropped derived events', () => {
+			expect(prompt).not.toMatch(/gate-chosen/i);
+			expect(prompt).not.toMatch(/workflow\.created/i);
+			expect(prompt).not.toMatch(/handoff-to-editor/i);
+		});
+
+		it('instructs an emoji-prefixed workflow name on the recurring build path', () => {
+			expect(prompt).toMatch(/short descriptive label/i);
+			expect(prompt).toMatch(/starts with a single emoji/i);
 		});
 	});
 
@@ -51,9 +62,9 @@ describe('getSystemPrompt — desktop-assistant promptMode variants', () => {
 			expect(prompt).toMatch(/Desktop Assistant.+Promote/i);
 		});
 
-		it('asks the orchestrator to pick an emoji icon', () => {
-			expect(prompt).toMatch(/emoji/i);
-			expect(prompt).toMatch(/icon/i);
+		it('instructs an emoji-prefixed workflow name', () => {
+			expect(prompt).toMatch(/short descriptive label/i);
+			expect(prompt).toMatch(/starts with a single emoji/i);
 		});
 
 		it('forbids follow-up questions', () => {
@@ -64,8 +75,14 @@ describe('getSystemPrompt — desktop-assistant promptMode variants', () => {
 			expect(prompt).toMatch(/workflow-builder/i);
 		});
 
-		it('directs ambiguous requests to handoff-to-editor', () => {
-			expect(prompt).toMatch(/handoff-to-editor/i);
+		it('instructs the orchestrator to stop without producing a workflow when ambiguous', () => {
+			expect(prompt).toMatch(/stop without producing a workflow/i);
+		});
+
+		it('does not reference dropped derived events', () => {
+			expect(prompt).not.toMatch(/gate-chosen/i);
+			expect(prompt).not.toMatch(/workflow\.created/i);
+			expect(prompt).not.toMatch(/handoff-to-editor/i);
 		});
 	});
 

--- a/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.desktop-assistant.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.desktop-assistant.test.ts
@@ -35,8 +35,15 @@ describe('getSystemPrompt — desktop-assistant promptMode variants', () => {
 			expect(prompt).toMatch(/do not ask follow-up questions/i);
 		});
 
-		it('forbids conversational output', () => {
-			expect(prompt).toMatch(/do not produce conversational output/i);
+		it('forbids conversational output and tells the model text is not shown to the user', () => {
+			expect(prompt).toMatch(/output tool calls only/i);
+			expect(prompt).toMatch(/does not read any text content/i);
+		});
+
+		it('enumerates specific forbidden conversational patterns', () => {
+			expect(prompt).toMatch(/greetings/i);
+			expect(prompt).toMatch(/narration/i);
+			expect(prompt).toMatch(/summaries/i);
 		});
 
 		it('instructs the orchestrator to stop without producing a result when ambiguous', () => {
@@ -77,6 +84,11 @@ describe('getSystemPrompt — desktop-assistant promptMode variants', () => {
 
 		it('instructs the orchestrator to stop without producing a workflow when ambiguous', () => {
 			expect(prompt).toMatch(/stop without producing a workflow/i);
+		});
+
+		it('forbids conversational output and tells the model text is not shown to the user', () => {
+			expect(prompt).toMatch(/output tool calls only/i);
+			expect(prompt).toMatch(/does not read any text content/i);
 		});
 
 		it('does not reference dropped derived events', () => {

--- a/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.desktop-assistant.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.desktop-assistant.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Prompt-mode variants for the desktop assistant entry points.
+ *
+ * These tests pin the contract that the desktop assistant relies on:
+ * - One-shot mode tells the orchestrator to run fire-and-forget (no follow-up
+ *   questions, emit events only, hand off when ambiguous).
+ * - Promote mode tells the orchestrator to build a workflow and pick an emoji.
+ *
+ * The wording is intentionally not pinned exactly; we assert the protected
+ * concepts survive copy edits but intent-shifting edits fail loudly.
+ */
+
+import { getSystemPrompt } from '../system-prompt';
+
+describe('getSystemPrompt — desktop-assistant promptMode variants', () => {
+	describe('default behaviour', () => {
+		it('omits the desktop-assistant section when no promptMode is set', () => {
+			const prompt = getSystemPrompt({});
+			expect(prompt).not.toMatch(/Desktop Assistant/i);
+		});
+	});
+
+	describe('promptMode: desktop-assistant-one-shot', () => {
+		const prompt = getSystemPrompt({ promptMode: 'desktop-assistant-one-shot' });
+
+		it('declares the one-shot section', () => {
+			expect(prompt).toMatch(/Desktop Assistant.+One-Shot/i);
+		});
+
+		it('forbids follow-up questions', () => {
+			expect(prompt).toMatch(/do not ask follow-up questions/i);
+		});
+
+		it('forbids conversational output', () => {
+			expect(prompt).toMatch(/do not produce conversational output/i);
+		});
+
+		it('directs ambiguous requests to handoff-to-editor', () => {
+			expect(prompt).toMatch(/handoff-to-editor/i);
+		});
+
+		it('references the gate-chosen signal', () => {
+			expect(prompt).toMatch(/gate-chosen/i);
+		});
+	});
+
+	describe('promptMode: desktop-assistant-promote', () => {
+		const prompt = getSystemPrompt({ promptMode: 'desktop-assistant-promote' });
+
+		it('declares the promote section', () => {
+			expect(prompt).toMatch(/Desktop Assistant.+Promote/i);
+		});
+
+		it('asks the orchestrator to pick an emoji icon', () => {
+			expect(prompt).toMatch(/emoji/i);
+			expect(prompt).toMatch(/icon/i);
+		});
+
+		it('forbids follow-up questions', () => {
+			expect(prompt).toMatch(/do not ask follow-up questions/i);
+		});
+
+		it('references the workflow-builder skill', () => {
+			expect(prompt).toMatch(/workflow-builder/i);
+		});
+
+		it('directs ambiguous requests to handoff-to-editor', () => {
+			expect(prompt).toMatch(/handoff-to-editor/i);
+		});
+	});
+
+	describe('isolation between modes', () => {
+		it('promote mode does not include one-shot-only wording', () => {
+			const promotePrompt = getSystemPrompt({ promptMode: 'desktop-assistant-promote' });
+			expect(promotePrompt).not.toMatch(/One-Shot Task/i);
+		});
+
+		it('one-shot mode does not include promote-only wording', () => {
+			const oneShotPrompt = getSystemPrompt({ promptMode: 'desktop-assistant-one-shot' });
+			expect(oneShotPrompt).not.toMatch(/Promote To Workflow/i);
+		});
+	});
+});

--- a/packages/@n8n/instance-ai/src/agent/instance-agent.ts
+++ b/packages/@n8n/instance-ai/src/agent/instance-agent.ts
@@ -139,6 +139,7 @@ export async function createInstanceAgent(options: CreateInstanceAgentOptions): 
 			orchestrationContext?.workspace && orchestrationContext.workspaceRoot
 				? orchestrationContext.workspaceRoot
 				: undefined,
+		promptMode: options.promptMode,
 	});
 
 	const telemetry = orchestrationContext?.tracing?.getTelemetry?.({

--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -5,6 +5,19 @@ import { SECRET_ASK_GUARDRAIL } from './credential-guardrails.prompt';
 import { getSandboxWorkspaceSection, UNTRUSTED_CONTENT_DOCTRINE } from './shared-prompts';
 import type { LocalGatewayStatus } from '../types';
 
+/**
+ * Optional prompt-mode override used by the desktop-assistant entry points.
+ *
+ * - `desktop-assistant-one-shot` — ad-hoc task triggered from the desktop app.
+ *   The orchestrator must run fire-and-forget: no follow-up questions, no
+ *   conversational output, fall back to a handoff-to-editor signal when the
+ *   request is too ambiguous to act on.
+ * - `desktop-assistant-promote` — promotion of an existing Instance AI thread
+ *   into a real, editable workflow. Same fire-and-forget rules apply, plus
+ *   the orchestrator is asked to pick a single emoji icon for the workflow.
+ */
+export type DesktopAssistantPromptMode = 'desktop-assistant-one-shot' | 'desktop-assistant-promote';
+
 interface SystemPromptOptions {
 	webhookBaseUrl?: string;
 	formBaseUrl?: string;
@@ -20,6 +33,39 @@ interface SystemPromptOptions {
 	projectId?: string;
 	/** Absolute or host-relative sandbox workspace root for `<workspace_root>` paths in prompts. */
 	workspaceRoot?: string;
+	/** When set, prepend a prompt-mode override for the desktop-assistant entry points. */
+	promptMode?: DesktopAssistantPromptMode;
+}
+
+function getDesktopAssistantPromptSection(promptMode?: DesktopAssistantPromptMode): string {
+	if (!promptMode) return '';
+	if (promptMode === 'desktop-assistant-one-shot') {
+		return `
+## Desktop Assistant — One-Shot Task
+
+You are running as a one-shot task triggered from the n8n desktop assistant. The user is not watching a chat; they expect the task to either complete or be handed off to the editor without further input.
+
+- Do NOT produce conversational output. Do NOT write summaries, greetings, or acknowledgements.
+- Do NOT ask follow-up questions. The user cannot answer them in this surface.
+- If the request is unambiguous and within your capabilities, execute it directly using the appropriate tools, and emit a \`gate-chosen\` signal first (\`gate: 'one-shot'\`) with a short rationale.
+- If the request implies a recurring or scheduled workflow, emit \`gate-chosen\` (\`gate: 'recurring'\`) and build the workflow via the workflow-builder. Pick reasonable defaults; do not ask for parameters.
+- If the request is ambiguous, too complex, or requires context you do not have, emit \`handoff-to-editor\` immediately with a one-line \`reason\`. Do not attempt partial work.
+
+The SSE event stream is the user-visible surface; text content in the assistant message is ignored.
+`;
+	}
+	// 'desktop-assistant-promote'
+	return `
+## Desktop Assistant — Promote To Workflow
+
+You are promoting an existing thread into a real, editable n8n workflow on behalf of the desktop assistant.
+
+- Build the workflow directly via the workflow-builder skill. Do NOT ask follow-up questions.
+- Pick a single emoji that represents the workflow's purpose and include it in the \`workflow.created\` event payload as \`icon\`.
+- If the original intent is ambiguous or requires context you do not have, emit \`handoff-to-editor\` immediately with a one-line \`reason\` instead of producing a low-quality stub.
+- Do NOT produce conversational output. Do NOT write summaries, greetings, or acknowledgements.
+- The thread already contains the user's original prompt; ground the build on that prompt.
+`;
 }
 
 export function getDateTimeSection(timeZone?: string): string {
@@ -112,9 +158,11 @@ export function getSystemPrompt(options: SystemPromptOptions = {}): string {
 		branchReadOnly,
 		projectId,
 		workspaceRoot,
+		promptMode,
 	} = options;
 
 	return `You are the n8n Instance Agent — an AI assistant embedded in an n8n instance. You help users build, run, debug, and manage workflows through natural language.
+${getDesktopAssistantPromptSection(promptMode)}
 ${getDateTimeSection(timeZone)}
 ${webhookBaseUrl && formBaseUrl ? getInstanceInfoSection(webhookBaseUrl, formBaseUrl) : ''}
 ${workspaceRoot ? `\n${getSandboxWorkspaceSection(workspaceRoot)}\n` : ''}

--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -45,26 +45,39 @@ function getDesktopAssistantPromptSection(promptMode?: DesktopAssistantPromptMod
 		return `
 ## Desktop Assistant — One-Shot Task
 
-You are running as a one-shot task triggered from the n8n desktop assistant. The user is not watching a chat; they expect the task to either complete on its own or end without further input.
+This run is fire-and-forget from the n8n desktop assistant. **The user does not read any text content you produce.** Only tool calls, tool results, and the run lifecycle are surfaced in the UI. Any text you write is wasted tokens that the user never sees.
 
-- Do NOT produce conversational output. Do NOT write summaries, greetings, or acknowledgements.
-- Do NOT ask follow-up questions. The user cannot answer them in this surface.
-- If the request is unambiguous and within your capabilities, execute it directly using the appropriate tools.
+### Output rules (strict)
+
+- Output tool calls only. Do not write text content between tool calls.
+- Specifically forbidden patterns: greetings ("I'll help you...", "Sure!", "Of course!"), narration ("Let me check...", "Now I'll...", "First, I'll..."), filler acknowledgements ("Got it.", "Perfect!", "Great!"), running commentary ("Found N files."), and end-of-task summaries ("Done!", "I've successfully...", listings of what changed).
+- Do not ask follow-up questions. The user cannot answer them in this surface.
+- If you find yourself wanting to explain what you're about to do, just do it. The tool calls themselves are the explanation.
+
+### Execution rules
+
+- If the request is unambiguous and within your capabilities, execute it using the appropriate tools.
 - If the request implies a recurring or scheduled workflow, build it via the workflow-builder skill. Pick reasonable defaults; do not ask for parameters. When you create the workflow, set its \`name\` to a short descriptive label (3–8 words) that starts with a single emoji representing the workflow's purpose. Examples: \`"🍌 Daily banana prices email"\`, \`"💬 Slack alerts for Stripe refunds"\`, \`"📅 Weekly backup of Notion"\`.
-- If the request is ambiguous, too complex, or requires context you do not have, stop without producing a result. Do not attempt partial work. The user will open the editor.
+- If the request is ambiguous, too complex, or requires context you do not have, stop without producing a result. Do not attempt partial work — the user will open the editor.
 `;
 	}
 	// 'desktop-assistant-promote'
 	return `
 ## Desktop Assistant — Promote To Workflow
 
-You are promoting an existing thread into a real, editable n8n workflow on behalf of the desktop assistant.
+This run is fire-and-forget from the n8n desktop assistant. **The user does not read any text content you produce.** Only tool calls, tool results, and the run lifecycle are surfaced in the UI. Any text you write is wasted tokens that the user never sees.
 
-- Build the workflow directly via the workflow-builder skill. Do NOT ask follow-up questions.
+### Output rules (strict)
+
+- Output tool calls only. Do not write text content between tool calls.
+- Specifically forbidden patterns: greetings ("I'll promote this...", "Sure!"), narration ("Let me build...", "Now I'll set up..."), filler acknowledgements ("Got it.", "Perfect!"), and end-of-task summaries ("Done! I've created the workflow.").
+- Do not ask follow-up questions. The user cannot answer them in this surface.
+
+### Execution rules
+
+- Build the workflow directly via the workflow-builder skill, grounded on the user's original prompt already present in the thread.
 - When you create the workflow, set its \`name\` to a short descriptive label (3–8 words) that starts with a single emoji representing the workflow's purpose. Examples: \`"🍌 Daily banana prices email"\`, \`"💬 Slack alerts for Stripe refunds"\`, \`"📅 Weekly backup of Notion"\`. If the user's prompt already provided a name, use that name and prepend a fitting emoji.
 - If the original intent is ambiguous or requires context you do not have, stop without producing a workflow. Do not produce a low-quality stub.
-- Do NOT produce conversational output. Do NOT write summaries, greetings, or acknowledgements.
-- The thread already contains the user's original prompt; ground the build on that prompt.
 `;
 }
 

--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -9,12 +9,14 @@ import type { LocalGatewayStatus } from '../types';
  * Optional prompt-mode override used by the desktop-assistant entry points.
  *
  * - `desktop-assistant-one-shot` — ad-hoc task triggered from the desktop app.
- *   The orchestrator must run fire-and-forget: no follow-up questions, no
- *   conversational output, fall back to a handoff-to-editor signal when the
- *   request is too ambiguous to act on.
+ *   The orchestrator runs fire-and-forget: no follow-up questions, no
+ *   conversational output, and stops without producing a result when the
+ *   request is too ambiguous to act on (the desktop client will surface a
+ *   handoff card based on the absence of progress).
  * - `desktop-assistant-promote` — promotion of an existing Instance AI thread
  *   into a real, editable workflow. Same fire-and-forget rules apply, plus
- *   the orchestrator is asked to pick a single emoji icon for the workflow.
+ *   the orchestrator picks a short descriptive workflow name that starts
+ *   with a single representative emoji.
  */
 export type DesktopAssistantPromptMode = 'desktop-assistant-one-shot' | 'desktop-assistant-promote';
 
@@ -43,15 +45,13 @@ function getDesktopAssistantPromptSection(promptMode?: DesktopAssistantPromptMod
 		return `
 ## Desktop Assistant — One-Shot Task
 
-You are running as a one-shot task triggered from the n8n desktop assistant. The user is not watching a chat; they expect the task to either complete or be handed off to the editor without further input.
+You are running as a one-shot task triggered from the n8n desktop assistant. The user is not watching a chat; they expect the task to either complete on its own or end without further input.
 
 - Do NOT produce conversational output. Do NOT write summaries, greetings, or acknowledgements.
 - Do NOT ask follow-up questions. The user cannot answer them in this surface.
-- If the request is unambiguous and within your capabilities, execute it directly using the appropriate tools, and emit a \`gate-chosen\` signal first (\`gate: 'one-shot'\`) with a short rationale.
-- If the request implies a recurring or scheduled workflow, emit \`gate-chosen\` (\`gate: 'recurring'\`) and build the workflow via the workflow-builder. Pick reasonable defaults; do not ask for parameters.
-- If the request is ambiguous, too complex, or requires context you do not have, emit \`handoff-to-editor\` immediately with a one-line \`reason\`. Do not attempt partial work.
-
-The SSE event stream is the user-visible surface; text content in the assistant message is ignored.
+- If the request is unambiguous and within your capabilities, execute it directly using the appropriate tools.
+- If the request implies a recurring or scheduled workflow, build it via the workflow-builder skill. Pick reasonable defaults; do not ask for parameters. When you create the workflow, set its \`name\` to a short descriptive label (3–8 words) that starts with a single emoji representing the workflow's purpose. Examples: \`"🍌 Daily banana prices email"\`, \`"💬 Slack alerts for Stripe refunds"\`, \`"📅 Weekly backup of Notion"\`.
+- If the request is ambiguous, too complex, or requires context you do not have, stop without producing a result. Do not attempt partial work. The user will open the editor.
 `;
 	}
 	// 'desktop-assistant-promote'
@@ -61,8 +61,8 @@ The SSE event stream is the user-visible surface; text content in the assistant 
 You are promoting an existing thread into a real, editable n8n workflow on behalf of the desktop assistant.
 
 - Build the workflow directly via the workflow-builder skill. Do NOT ask follow-up questions.
-- Pick a single emoji that represents the workflow's purpose and include it in the \`workflow.created\` event payload as \`icon\`.
-- If the original intent is ambiguous or requires context you do not have, emit \`handoff-to-editor\` immediately with a one-line \`reason\` instead of producing a low-quality stub.
+- When you create the workflow, set its \`name\` to a short descriptive label (3–8 words) that starts with a single emoji representing the workflow's purpose. Examples: \`"🍌 Daily banana prices email"\`, \`"💬 Slack alerts for Stripe refunds"\`, \`"📅 Weekly backup of Notion"\`. If the user's prompt already provided a name, use that name and prepend a fitting emoji.
+- If the original intent is ambiguous or requires context you do not have, stop without producing a workflow. Do not produce a low-quality stub.
 - Do NOT produce conversational output. Do NOT write summaries, greetings, or acknowledgements.
 - The thread already contains the user's original prompt; ground the build on that prompt.
 `;

--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -178,6 +178,7 @@ const loadValidateAttachments = lazyModule(
 );
 
 export { MAX_STEPS } from './constants/max-steps';
+export type { DesktopAssistantPromptMode } from './agent/system-prompt';
 export type {
 	AgentDbMessage,
 	AgentMessage,

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -29,6 +29,7 @@ import type {
 // Service interfaces — dependency inversion so the package stays decoupled from n8n internals.
 // The backend module provides concrete implementations via InstanceAiAdapterService.
 
+import type { DesktopAssistantPromptMode } from './agent/system-prompt';
 import type { DomainAccessTracker } from './domain-access/domain-access-tracker';
 import type { InstanceAiEventBus } from './event-bus/event-bus.interface';
 import type { Logger } from './logger';
@@ -1336,4 +1337,6 @@ export interface CreateInstanceAgentOptions {
 	disableDeferredTools?: boolean;
 	/** IANA time zone for the current user (e.g. "Europe/Helsinki"). Falls back to instance default. */
 	timeZone?: string;
+	/** Optional prompt-mode override used by the desktop-assistant entry points. */
+	promptMode?: DesktopAssistantPromptMode;
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -162,6 +162,7 @@
     "convict": "6.2.5",
     "cookie-parser": "1.4.7",
     "cron": "catalog:",
+    "cron-parser": "catalog:",
     "csv-parse": "catalog:",
     "csrf": "3.1.0",
     "dotenv": "17.2.3",

--- a/packages/cli/src/executions/execution.service.ts
+++ b/packages/cli/src/executions/execution.service.ts
@@ -75,7 +75,13 @@ export const schemaGetExecutionsQueryFilter = {
 			items: { type: 'string' },
 		},
 		waitTill: { type: 'boolean' },
-		workflowId: { anyOf: [{ type: 'integer' }, { type: 'string' }] },
+		workflowId: {
+			anyOf: [
+				{ type: 'integer' },
+				{ type: 'string' },
+				{ type: 'array', items: { type: 'string' } },
+			],
+		},
 		metadata: { type: 'array', items: { $ref: '#/$defs/metadata' } },
 		startedAfter: { type: 'date-time' },
 		startedBefore: { type: 'date-time' },

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.classifier.test.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.classifier.test.ts
@@ -261,6 +261,26 @@ describe('classifyWorkflowsForDesktopAssistant — bucketing rules', () => {
 		expect(result.readyToRun).toHaveLength(0);
 	});
 
+	test('multi-trigger workflow [manualTrigger, scheduleTrigger] uses the autonomous trigger for classification', () => {
+		const result = classifyWorkflowsForDesktopAssistant([
+			input({
+				workflowId: 'wf-multi',
+				active: true,
+				nodes: [
+					node({ type: MANUAL_TYPE }),
+					node({
+						type: SCHEDULE_TYPE,
+						parameters: { rule: { interval: [{ triggerAtHour: 9 }] } },
+					}),
+				],
+				tags: [],
+			}),
+		]);
+		expect(result.upcoming).toHaveLength(1);
+		expect(result.upcoming[0].trigger.kind).toBe('schedule');
+		expect(result.readyToRun).toHaveLength(0);
+	});
+
 	test('an active user-built webhook workflow goes to upcoming (autonomous trigger; readyToRun is for manually-triggered workflows)', () => {
 		const result = classifyWorkflowsForDesktopAssistant([
 			input({

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.classifier.test.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.classifier.test.ts
@@ -109,7 +109,7 @@ describe('classifyWorkflowsForDesktopAssistant — bucketing rules', () => {
 		expect(result.readyToRun[0].source).toBe('user-built');
 	});
 
-	test('webhook trigger, untagged → readyToRun (user-built), not in da buckets', () => {
+	test('webhook trigger, untagged, active → upcoming (autonomous trigger, regardless of source)', () => {
 		const result = classifyWorkflowsForDesktopAssistant([
 			input({
 				workflowId: 'wf-1',
@@ -118,10 +118,11 @@ describe('classifyWorkflowsForDesktopAssistant — bucketing rules', () => {
 				tags: [],
 			}),
 		]);
-		expect(result.readyToRun).toHaveLength(1);
-		expect(result.readyToRun[0].source).toBe('user-built');
+		expect(result.upcoming).toHaveLength(1);
+		expect(result.upcoming[0].source).toBe('user-built');
+		expect(result.upcoming[0].trigger.kind).toBe('webhook');
 		expect(result.actionNeeded).toHaveLength(0);
-		expect(result.upcoming).toHaveLength(0);
+		expect(result.readyToRun).toHaveLength(0);
 	});
 
 	test('precedence: actionNeeded beats upcoming when both apply via missing credential', () => {
@@ -222,7 +223,7 @@ describe('classifyWorkflowsForDesktopAssistant — bucketing rules', () => {
 		expect(result.readyToRun).toHaveLength(0);
 	});
 
-	test('an active user-built webhook workflow stays in readyToRun (no time-based preview)', () => {
+	test('an active user-built webhook workflow goes to upcoming (autonomous trigger; readyToRun is for manually-triggered workflows)', () => {
 		const result = classifyWorkflowsForDesktopAssistant([
 			input({
 				workflowId: 'wf-user-webhook',
@@ -231,9 +232,10 @@ describe('classifyWorkflowsForDesktopAssistant — bucketing rules', () => {
 				tags: [],
 			}),
 		]);
-		expect(result.readyToRun).toHaveLength(1);
-		expect(result.readyToRun[0].source).toBe('user-built');
-		expect(result.upcoming).toHaveLength(0);
+		expect(result.upcoming).toHaveLength(1);
+		expect(result.upcoming[0].source).toBe('user-built');
+		expect(result.upcoming[0].trigger.kind).toBe('webhook');
+		expect(result.readyToRun).toHaveLength(0);
 	});
 
 	test('disabled nodes do not contribute missing credentials to actionNeeded', () => {

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.classifier.test.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.classifier.test.ts
@@ -295,14 +295,89 @@ describe('classifier derivations — exported helpers', () => {
 			expect(result).toBeNull();
 		});
 
-		test('returns null for non-cronExpression interval modes', () => {
+		test('returns null for sub-minute interval modes (seconds/minutes are not 5-field cron expressible)', () => {
+			expect(
+				deriveNextRunAt(
+					node({
+						type: SCHEDULE_TYPE,
+						parameters: { rule: { interval: [{ field: 'minutes', minutesInterval: 5 }] } },
+					}),
+				),
+			).toBeNull();
+			expect(
+				deriveNextRunAt(
+					node({
+						type: SCHEDULE_TYPE,
+						parameters: { rule: { interval: [{ field: 'seconds', secondsInterval: 30 }] } },
+					}),
+				),
+			).toBeNull();
+		});
+
+		test('returns ISO string for structured "days" interval (default field, triggerAtHour only)', () => {
 			const result = deriveNextRunAt(
 				node({
 					type: SCHEDULE_TYPE,
-					parameters: { rule: { interval: [{ field: 'minutes', minutesInterval: 5 }] } },
+					parameters: { rule: { interval: [{ triggerAtHour: 7 }] } },
 				}),
+				{ now: new Date('2024-06-01T00:00:00Z'), timezone: 'UTC' },
 			);
-			expect(result).toBeNull();
+			// Default field='days', triggerAtHour=7, triggerAtMinute=0
+			// → cron '0 7 */1 * *' → next run is today at 07:00 UTC
+			expect(result).toBe('2024-06-01T07:00:00.000Z');
+		});
+
+		test('returns ISO string for explicit "days" interval with triggerAtMinute', () => {
+			const result = deriveNextRunAt(
+				node({
+					type: SCHEDULE_TYPE,
+					parameters: {
+						rule: {
+							interval: [{ field: 'days', daysInterval: 1, triggerAtHour: 9, triggerAtMinute: 30 }],
+						},
+					},
+				}),
+				{ now: new Date('2024-06-01T00:00:00Z'), timezone: 'UTC' },
+			);
+			expect(result).toBe('2024-06-01T09:30:00.000Z');
+		});
+
+		test('returns ISO string for "hours" interval with step', () => {
+			const result = deriveNextRunAt(
+				node({
+					type: SCHEDULE_TYPE,
+					parameters: {
+						rule: { interval: [{ field: 'hours', hoursInterval: 4, triggerAtMinute: 15 }] },
+					},
+				}),
+				{ now: new Date('2024-06-01T01:00:00Z'), timezone: 'UTC' },
+			);
+			// cron '15 */4 * * *' → next match after 01:00 is 04:15
+			expect(result).toBe('2024-06-01T04:15:00.000Z');
+		});
+
+		test('returns ISO string for "weeks" interval with triggerAtDayOfWeek list', () => {
+			// 2024-06-01 is a Saturday (cron weekday 6)
+			const result = deriveNextRunAt(
+				node({
+					type: SCHEDULE_TYPE,
+					parameters: {
+						rule: {
+							interval: [
+								{
+									field: 'weeks',
+									triggerAtHour: 9,
+									triggerAtMinute: 0,
+									triggerAtDayOfWeek: [1, 3, 5],
+								},
+							],
+						},
+					},
+				}),
+				{ now: new Date('2024-06-01T00:00:00Z'), timezone: 'UTC' },
+			);
+			// Next Mon/Wed/Fri at 09:00 UTC after Sat 2024-06-01 is Mon 2024-06-03
+			expect(result).toBe('2024-06-03T09:00:00.000Z');
 		});
 
 		test('returns null for an invalid cron expression', () => {

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.classifier.test.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.classifier.test.ts
@@ -144,6 +144,83 @@ describe('classifyWorkflowsForDesktopAssistant — bucketing rules', () => {
 		expect(result.actionNeeded[0].description).toBe('Gmail needs credential');
 	});
 
+	test('user-built workflow with a missing credential surfaces in actionNeeded (not gated on the desktop-assistant tag)', () => {
+		const result = classifyWorkflowsForDesktopAssistant([
+			input({
+				workflowId: 'wf-user-built',
+				active: true,
+				nodes: [
+					node({
+						type: GMAIL_TRIGGER_TYPE,
+						credentials: { gmailOAuth2: { id: 'cred-missing', name: 'Gmail account' } },
+					}),
+				],
+				tags: [],
+				accessibleCredentialIds: new Set<string>(),
+			}),
+		]);
+		expect(result.actionNeeded).toHaveLength(1);
+		expect(result.actionNeeded[0].workflowId).toBe('wf-user-built');
+		expect(result.actionNeeded[0].source).toBe('user-built');
+		expect(result.actionNeeded[0].description).toBe('Gmail needs credential');
+		expect(result.readyToRun).toHaveLength(0);
+	});
+
+	test('a credential slot with no id picked counts as "needs credential"', () => {
+		const result = classifyWorkflowsForDesktopAssistant([
+			input({
+				workflowId: 'wf-unconfigured',
+				active: true,
+				nodes: [
+					node({
+						type: GMAIL_TRIGGER_TYPE,
+						// Slot exists on the node but no credential was ever picked.
+						credentials: { gmailOAuth2: { id: '', name: '' } },
+					}),
+				],
+				tags: [],
+				accessibleCredentialIds: new Set<string>(),
+			}),
+		]);
+		expect(result.actionNeeded).toHaveLength(1);
+		expect(result.actionNeeded[0].description).toBe('Gmail needs credential');
+	});
+
+	test('a user-built workflow that is intentionally inactive is NOT flagged for activation (only credentials matter)', () => {
+		const result = classifyWorkflowsForDesktopAssistant([
+			input({
+				workflowId: 'wf-template',
+				active: false,
+				nodes: [
+					node({ type: SCHEDULE_TYPE, parameters: { rule: { interval: [{ field: 'days' }] } } }),
+				],
+				tags: [],
+			}),
+		]);
+		expect(result.actionNeeded).toHaveLength(0);
+		expect(result.readyToRun).toHaveLength(1);
+	});
+
+	test('disabled nodes do not contribute missing credentials to actionNeeded', () => {
+		const result = classifyWorkflowsForDesktopAssistant([
+			input({
+				workflowId: 'wf-disabled-gmail',
+				active: true,
+				nodes: [
+					node({ type: MANUAL_TYPE }),
+					node({
+						type: GMAIL_TRIGGER_TYPE,
+						disabled: true,
+						credentials: { gmailOAuth2: { id: '', name: '' } },
+					}),
+				],
+				tags: [],
+			}),
+		]);
+		expect(result.actionNeeded).toHaveLength(0);
+		expect(result.readyToRun).toHaveLength(1);
+	});
+
 	test('runsLocally: workflow with a computerUse.* node → true', () => {
 		const result = classifyWorkflowsForDesktopAssistant([
 			input({

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.classifier.test.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.classifier.test.ts
@@ -451,7 +451,7 @@ describe('classifier derivations — exported helpers', () => {
 			expect(result).toBe('2024-06-01T04:15:00.000Z');
 		});
 
-		test('returns ISO string for "weeks" interval with triggerAtDayOfWeek list', () => {
+		test('returns ISO string for "weeks" interval with triggerAtDay list', () => {
 			// 2024-06-01 is a Saturday (cron weekday 6)
 			const result = deriveNextRunAt(
 				node({
@@ -463,7 +463,7 @@ describe('classifier derivations — exported helpers', () => {
 									field: 'weeks',
 									triggerAtHour: 9,
 									triggerAtMinute: 0,
-									triggerAtDayOfWeek: [1, 3, 5],
+									triggerAtDay: [1, 3, 5],
 								},
 							],
 						},

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.classifier.test.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.classifier.test.ts
@@ -1,0 +1,255 @@
+import type { INode } from 'n8n-workflow';
+
+import { DESKTOP_ASSISTANT_TAG } from '../constants';
+import {
+	classifyWorkflowsForDesktopAssistant,
+	deriveNextRunAt,
+	deriveSourceLabel,
+} from '../desktop-assistant.classifier';
+import type { ClassifierInput } from '../desktop-assistant.classifier';
+
+const SCHEDULE_TYPE = 'n8n-nodes-base.scheduleTrigger';
+const MANUAL_TYPE = 'n8n-nodes-base.manualTrigger';
+const WEBHOOK_TYPE = 'n8n-nodes-base.webhook';
+const GMAIL_TRIGGER_TYPE = 'n8n-nodes-base.gmailTrigger';
+
+function node(partial: Partial<INode> & { type: string }): INode {
+	return {
+		id: partial.id ?? `node-${partial.type}`,
+		name: partial.name ?? partial.type,
+		type: partial.type,
+		typeVersion: partial.typeVersion ?? 1,
+		position: partial.position ?? [0, 0],
+		parameters: partial.parameters ?? {},
+		credentials: partial.credentials,
+		disabled: partial.disabled,
+	};
+}
+
+function input(partial: Partial<ClassifierInput> & { workflowId: string }): ClassifierInput {
+	return {
+		workflowId: partial.workflowId,
+		name: partial.name ?? `Workflow ${partial.workflowId}`,
+		active: partial.active ?? true,
+		nodes: partial.nodes ?? [node({ type: MANUAL_TYPE })],
+		tags: partial.tags ?? [],
+		settings: partial.settings,
+		lastExecution: partial.lastExecution,
+		emojiIcon: partial.emojiIcon,
+		accessibleCredentialIds: partial.accessibleCredentialIds ?? new Set<string>(),
+	};
+}
+
+describe('classifyWorkflowsForDesktopAssistant — bucketing rules', () => {
+	test('schedule trigger, inactive, tagged → actionNeeded', () => {
+		const result = classifyWorkflowsForDesktopAssistant([
+			input({
+				workflowId: 'wf-1',
+				active: false,
+				nodes: [
+					node({
+						type: SCHEDULE_TYPE,
+						parameters: {
+							rule: { interval: [{ field: 'cronExpression', expression: '0 7 * * 6' }] },
+						},
+					}),
+				],
+				tags: [{ name: DESKTOP_ASSISTANT_TAG }],
+			}),
+		]);
+		expect(result.actionNeeded.map((c) => c.workflowId)).toEqual(['wf-1']);
+		expect(result.upcoming).toHaveLength(0);
+		expect(result.readyToRun).toHaveLength(0);
+		expect(result.actionNeeded[0].description).toBe('Activation required');
+	});
+
+	test('schedule trigger, active, tagged → upcoming', () => {
+		const result = classifyWorkflowsForDesktopAssistant([
+			input({
+				workflowId: 'wf-1',
+				active: true,
+				nodes: [
+					node({
+						type: SCHEDULE_TYPE,
+						parameters: {
+							rule: { interval: [{ field: 'cronExpression', expression: '0 7 * * 6' }] },
+						},
+					}),
+				],
+				tags: [{ name: DESKTOP_ASSISTANT_TAG }],
+			}),
+		]);
+		expect(result.upcoming).toHaveLength(1);
+		expect(result.upcoming[0].source).toBe('desktop-assistant');
+		expect(result.upcoming[0].trigger.kind).toBe('schedule');
+	});
+
+	test('manual trigger, tagged → readyToRun with desktop-assistant source', () => {
+		const result = classifyWorkflowsForDesktopAssistant([
+			input({
+				workflowId: 'wf-1',
+				nodes: [node({ type: MANUAL_TYPE })],
+				tags: [{ name: DESKTOP_ASSISTANT_TAG }],
+			}),
+		]);
+		expect(result.readyToRun).toHaveLength(1);
+		expect(result.readyToRun[0].source).toBe('desktop-assistant');
+		expect(result.readyToRun[0].trigger.kind).toBe('manual');
+	});
+
+	test('manual trigger, untagged → readyToRun with user-built source', () => {
+		const result = classifyWorkflowsForDesktopAssistant([
+			input({
+				workflowId: 'wf-1',
+				nodes: [node({ type: MANUAL_TYPE })],
+				tags: [],
+			}),
+		]);
+		expect(result.readyToRun).toHaveLength(1);
+		expect(result.readyToRun[0].source).toBe('user-built');
+	});
+
+	test('webhook trigger, untagged → readyToRun (user-built), not in da buckets', () => {
+		const result = classifyWorkflowsForDesktopAssistant([
+			input({
+				workflowId: 'wf-1',
+				active: true,
+				nodes: [node({ type: WEBHOOK_TYPE })],
+				tags: [],
+			}),
+		]);
+		expect(result.readyToRun).toHaveLength(1);
+		expect(result.readyToRun[0].source).toBe('user-built');
+		expect(result.actionNeeded).toHaveLength(0);
+		expect(result.upcoming).toHaveLength(0);
+	});
+
+	test('precedence: actionNeeded beats upcoming when both apply via missing credential', () => {
+		const result = classifyWorkflowsForDesktopAssistant([
+			input({
+				workflowId: 'wf-1',
+				active: true,
+				nodes: [
+					node({
+						type: GMAIL_TRIGGER_TYPE,
+						credentials: { gmailOAuth2: { id: 'cred-missing', name: 'Gmail account' } },
+					}),
+				],
+				tags: [{ name: DESKTOP_ASSISTANT_TAG }],
+				accessibleCredentialIds: new Set<string>(),
+			}),
+		]);
+		expect(result.actionNeeded).toHaveLength(1);
+		expect(result.upcoming).toHaveLength(0);
+		expect(result.actionNeeded[0].description).toBe('Gmail needs credential');
+	});
+
+	test('runsLocally: workflow with a computerUse.* node → true', () => {
+		const result = classifyWorkflowsForDesktopAssistant([
+			input({
+				workflowId: 'wf-1',
+				nodes: [
+					node({ type: MANUAL_TYPE }),
+					node({ type: 'n8n-nodes-base.computerUseClick', name: 'click' }),
+				],
+				tags: [{ name: DESKTOP_ASSISTANT_TAG }],
+			}),
+		]);
+		expect(result.readyToRun[0].runsLocally).toBe(true);
+	});
+
+	test('runsLocally: vanilla workflow → false', () => {
+		const result = classifyWorkflowsForDesktopAssistant([
+			input({
+				workflowId: 'wf-1',
+				nodes: [node({ type: MANUAL_TYPE }), node({ type: 'n8n-nodes-base.set' })],
+				tags: [{ name: DESKTOP_ASSISTANT_TAG }],
+			}),
+		]);
+		expect(result.readyToRun[0].runsLocally).toBe(false);
+	});
+
+	test('icon: emoji from meta overrides node icon', () => {
+		const result = classifyWorkflowsForDesktopAssistant([
+			input({
+				workflowId: 'wf-1',
+				nodes: [node({ type: MANUAL_TYPE }), node({ type: 'n8n-nodes-base.set' })],
+				tags: [{ name: DESKTOP_ASSISTANT_TAG }],
+				emojiIcon: '🍌',
+			}),
+		]);
+		expect(result.readyToRun[0].icon).toEqual({ type: 'emoji', value: '🍌' });
+	});
+
+	test('icon: falls back to first non-trigger node type', () => {
+		const result = classifyWorkflowsForDesktopAssistant([
+			input({
+				workflowId: 'wf-1',
+				nodes: [node({ type: MANUAL_TYPE }), node({ type: 'n8n-nodes-base.set' })],
+				tags: [{ name: DESKTOP_ASSISTANT_TAG }],
+			}),
+		]);
+		expect(result.readyToRun[0].icon).toEqual({
+			type: 'node',
+			nodeType: 'n8n-nodes-base.set',
+		});
+	});
+});
+
+describe('classifier derivations — exported helpers', () => {
+	describe('deriveNextRunAt', () => {
+		test('returns ISO string for a known cron expression', () => {
+			const result = deriveNextRunAt(
+				node({
+					type: SCHEDULE_TYPE,
+					parameters: {
+						rule: { interval: [{ field: 'cronExpression', expression: '0 7 * * 6' }] },
+					},
+				}),
+				{ now: new Date('2024-06-01T00:00:00Z'), timezone: 'UTC' },
+			);
+			expect(result).not.toBeNull();
+			// 2024-06-01 is a Saturday, so the next run is today at 07:00 UTC
+			expect(result).toBe('2024-06-01T07:00:00.000Z');
+		});
+
+		test('returns null when the interval is missing', () => {
+			const result = deriveNextRunAt(node({ type: SCHEDULE_TYPE, parameters: {} }));
+			expect(result).toBeNull();
+		});
+
+		test('returns null for non-cronExpression interval modes', () => {
+			const result = deriveNextRunAt(
+				node({
+					type: SCHEDULE_TYPE,
+					parameters: { rule: { interval: [{ field: 'minutes', minutesInterval: 5 }] } },
+				}),
+			);
+			expect(result).toBeNull();
+		});
+
+		test('returns null for an invalid cron expression', () => {
+			const result = deriveNextRunAt(
+				node({
+					type: SCHEDULE_TYPE,
+					parameters: { rule: { interval: [{ field: 'cronExpression', expression: 'nope' }] } },
+				}),
+			);
+			expect(result).toBeNull();
+		});
+	});
+
+	describe('deriveSourceLabel', () => {
+		test('strips a trailing "Trigger" and produces "On new <thing> message"', () => {
+			expect(deriveSourceLabel('Gmail Trigger')).toBe('On new gmail message');
+		});
+
+		test('handles a multi-word service name', () => {
+			expect(deriveSourceLabel('Google Sheets Trigger')).toBe('On new google sheets message');
+		});
+
+		test('does not require a trailing Trigger word', () => {
+			expect(deriveSourceLabel('Webhook')).toBe('On new webhook message');
+		});
+	});
+});

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.classifier.test.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.classifier.test.ts
@@ -37,6 +37,7 @@ function input(partial: Partial<ClassifierInput> & { workflowId: string }): Clas
 		lastExecution: partial.lastExecution,
 		emojiIcon: partial.emojiIcon,
 		accessibleCredentialIds: partial.accessibleCredentialIds ?? new Set<string>(),
+		nodesRequiringCredentialSetup: partial.nodesRequiringCredentialSetup,
 	};
 }
 
@@ -200,6 +201,27 @@ describe('classifyWorkflowsForDesktopAssistant — bucketing rules', () => {
 		]);
 		expect(result.actionNeeded).toHaveLength(0);
 		expect(result.readyToRun).toHaveLength(1);
+	});
+
+	test('a node whose type requires credentials but has no credentials field at all surfaces in actionNeeded via service hint', () => {
+		const result = classifyWorkflowsForDesktopAssistant([
+			input({
+				workflowId: 'wf-gmail-no-slot',
+				active: false,
+				nodes: [
+					node({
+						name: 'Gmail Trigger',
+						type: GMAIL_TRIGGER_TYPE,
+						// no credentials field at all
+					}),
+				],
+				tags: [],
+				nodesRequiringCredentialSetup: new Set<string>(['Gmail Trigger']),
+			}),
+		]);
+		expect(result.actionNeeded).toHaveLength(1);
+		expect(result.actionNeeded[0].workflowId).toBe('wf-gmail-no-slot');
+		expect(result.actionNeeded[0].description).toBe('Gmail needs credential');
 	});
 
 	test('an active user-built schedule workflow goes to upcoming (not gated on the desktop-assistant tag)', () => {

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.classifier.test.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.classifier.test.ts
@@ -188,10 +188,10 @@ describe('classifyWorkflowsForDesktopAssistant — bucketing rules', () => {
 		expect(result.actionNeeded[0].description).toBe('Gmail needs credential');
 	});
 
-	test('a user-built workflow that is intentionally inactive is NOT flagged for activation (only credentials matter)', () => {
+	test('an inactive user-built schedule workflow lands in actionNeeded (autonomous trigger is dormant, regardless of source)', () => {
 		const result = classifyWorkflowsForDesktopAssistant([
 			input({
-				workflowId: 'wf-template',
+				workflowId: 'wf-paused-schedule',
 				active: false,
 				nodes: [
 					node({ type: SCHEDULE_TYPE, parameters: { rule: { interval: [{ field: 'days' }] } } }),
@@ -199,8 +199,24 @@ describe('classifyWorkflowsForDesktopAssistant — bucketing rules', () => {
 				tags: [],
 			}),
 		]);
+		expect(result.actionNeeded).toHaveLength(1);
+		expect(result.actionNeeded[0].source).toBe('user-built');
+		expect(result.actionNeeded[0].description).toBe('Activation required');
+		expect(result.readyToRun).toHaveLength(0);
+	});
+
+	test('an inactive user-built MANUAL workflow stays in readyToRun (manual is normally inactive; not nagged)', () => {
+		const result = classifyWorkflowsForDesktopAssistant([
+			input({
+				workflowId: 'wf-manual-draft',
+				active: false,
+				nodes: [node({ type: MANUAL_TYPE })],
+				tags: [],
+			}),
+		]);
 		expect(result.actionNeeded).toHaveLength(0);
 		expect(result.readyToRun).toHaveLength(1);
+		expect(result.readyToRun[0].source).toBe('user-built');
 	});
 
 	test('a node whose type requires credentials but has no credentials field at all surfaces in actionNeeded via service hint', () => {

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.classifier.test.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.classifier.test.ts
@@ -201,6 +201,41 @@ describe('classifyWorkflowsForDesktopAssistant — bucketing rules', () => {
 		expect(result.readyToRun).toHaveLength(1);
 	});
 
+	test('an active user-built schedule workflow goes to upcoming (not gated on the desktop-assistant tag)', () => {
+		const result = classifyWorkflowsForDesktopAssistant([
+			input({
+				workflowId: 'wf-user-schedule',
+				active: true,
+				nodes: [
+					node({
+						type: SCHEDULE_TYPE,
+						parameters: { rule: { interval: [{ triggerAtHour: 7 }] } },
+					}),
+				],
+				tags: [],
+			}),
+		]);
+		expect(result.upcoming).toHaveLength(1);
+		expect(result.upcoming[0].workflowId).toBe('wf-user-schedule');
+		expect(result.upcoming[0].source).toBe('user-built');
+		expect(result.upcoming[0].trigger.kind).toBe('schedule');
+		expect(result.readyToRun).toHaveLength(0);
+	});
+
+	test('an active user-built webhook workflow stays in readyToRun (no time-based preview)', () => {
+		const result = classifyWorkflowsForDesktopAssistant([
+			input({
+				workflowId: 'wf-user-webhook',
+				active: true,
+				nodes: [node({ type: WEBHOOK_TYPE })],
+				tags: [],
+			}),
+		]);
+		expect(result.readyToRun).toHaveLength(1);
+		expect(result.readyToRun[0].source).toBe('user-built');
+		expect(result.upcoming).toHaveLength(0);
+	});
+
 	test('disabled nodes do not contribute missing credentials to actionNeeded', () => {
 		const result = classifyWorkflowsForDesktopAssistant([
 			input({

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.controller.test.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.controller.test.ts
@@ -1,0 +1,114 @@
+import type { AuthenticatedRequest, User } from '@n8n/db';
+import { ControllerRegistryMetadata } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+import type { Scope } from '@n8n/permissions';
+import { mock } from 'jest-mock-extended';
+
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+
+import { DesktopAssistantController } from '../desktop-assistant.controller';
+import type { DesktopAssistantService } from '../desktop-assistant.service';
+import type { InstanceAiSettingsService } from '../../instance-ai-settings.service';
+
+const routeMetadata = Container.get(ControllerRegistryMetadata);
+
+function scopeOf(handlerName: string): { scope: Scope; globalOnly: boolean } | undefined {
+	const route = routeMetadata.getRouteMetadata(
+		DesktopAssistantController as unknown as Parameters<typeof routeMetadata.getRouteMetadata>[0],
+		handlerName,
+	);
+	return route.accessScope;
+}
+
+describe('DesktopAssistantController', () => {
+	const service = mock<DesktopAssistantService>();
+	const settingsService = mock<InstanceAiSettingsService>();
+	const controller = new DesktopAssistantController(service, settingsService);
+	const user = mock<User>({ id: 'user-1' });
+	const req = mock<AuthenticatedRequest>({ user });
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		settingsService.isInstanceAiEnabled.mockReturnValue(true);
+	});
+
+	describe('access scopes', () => {
+		test('every handler is guarded by instanceAi:message', () => {
+			expect(scopeOf('getTasks')).toEqual({ scope: 'instanceAi:message', globalOnly: true });
+			expect(scopeOf('triggerTask')).toEqual({ scope: 'instanceAi:message', globalOnly: true });
+			expect(scopeOf('promoteThread')).toEqual({
+				scope: 'instanceAi:message',
+				globalOnly: true,
+			});
+			expect(scopeOf('getHistory')).toEqual({ scope: 'instanceAi:message', globalOnly: true });
+		});
+	});
+
+	describe('Instance AI disabled', () => {
+		beforeEach(() => settingsService.isInstanceAiEnabled.mockReturnValue(false));
+
+		test('getTasks throws ForbiddenError', async () => {
+			await expect(controller.getTasks(req)).rejects.toBeInstanceOf(ForbiddenError);
+		});
+
+		test('triggerTask throws ForbiddenError', async () => {
+			await expect(controller.triggerTask(req, null, { prompt: 'hi' })).rejects.toBeInstanceOf(
+				ForbiddenError,
+			);
+		});
+
+		test('promoteThread throws ForbiddenError', async () => {
+			await expect(controller.promoteThread(req, null, { threadId: 't-1' })).rejects.toBeInstanceOf(
+				ForbiddenError,
+			);
+		});
+
+		test('getHistory throws ForbiddenError', async () => {
+			await expect(controller.getHistory(req, null, {})).rejects.toBeInstanceOf(ForbiddenError);
+		});
+	});
+
+	describe('happy path delegation', () => {
+		test('getTasks calls the service with the requesting user', async () => {
+			service.getTasks.mockResolvedValue({
+				actionNeeded: [],
+				upcoming: [],
+				readyToRun: [],
+			});
+			await controller.getTasks(req);
+			expect(service.getTasks).toHaveBeenCalledWith(user);
+		});
+
+		test('triggerTask forwards the body to the service', async () => {
+			service.triggerTask.mockResolvedValue({ threadId: 't-new', runId: 'r-new' });
+			const result = await controller.triggerTask(req, null, {
+				prompt: 'rename desktop files',
+			});
+			expect(service.triggerTask).toHaveBeenCalledWith(user, {
+				prompt: 'rename desktop files',
+			});
+			expect(result).toEqual({ threadId: 't-new', runId: 'r-new' });
+		});
+
+		test('promoteThread forwards the body to the service', async () => {
+			service.promoteThread.mockResolvedValue({
+				status: 'building',
+				threadId: 't-1',
+				runId: 'r-1',
+			});
+			const result = await controller.promoteThread(req, null, { threadId: 't-1' });
+			expect(service.promoteThread).toHaveBeenCalledWith(user, { threadId: 't-1' });
+			expect(result).toEqual({ status: 'building', threadId: 't-1', runId: 'r-1' });
+		});
+
+		test('getHistory parses the limit query param', async () => {
+			service.getHistory.mockResolvedValue({ results: [], count: 0, estimated: false });
+			await controller.getHistory(req, null, { limit: '50', firstId: 'a', lastId: 'z' });
+			expect(service.getHistory).toHaveBeenCalledWith(user, {
+				limit: 50,
+				firstId: 'a',
+				lastId: 'z',
+			});
+		});
+	});
+});

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.service.test.ts
@@ -249,6 +249,118 @@ describe('DesktopAssistantService.promoteThread', () => {
 		});
 	});
 
+	test('on a run-finish for the promote run, reads workflow-loop metadata and finalises the workflow', async () => {
+		const ctx = makeService();
+		ctx.memoryService.checkThreadOwnership.mockResolvedValue('owned');
+		ctx.memoryService.getThreadMetadata
+			.mockResolvedValueOnce(undefined) // initial idempotency check
+			.mockResolvedValueOnce({
+				// metadata read after run-finish — workflow-loop persisted outcome
+				instanceAiWorkflowLoop: {
+					wi_xyz: {
+						state: { runId: 'run-promote', workflowId: 'wf-loop' },
+						lastBuildOutcome: {
+							runId: 'run-promote',
+							submitted: true,
+							workflowId: 'wf-loop',
+						},
+					},
+				},
+			});
+		ctx.memoryService.getThreadMessages.mockResolvedValue({
+			threadId: 't-1',
+			messages: [
+				{
+					id: 'm-1',
+					role: 'user',
+					content: 'rename files',
+					type: 'text',
+					createdAt: new Date().toISOString(),
+				},
+			],
+		});
+		ctx.instanceAiService.startRun.mockReturnValue('run-promote');
+		ctx.tagRepository.findOne.mockResolvedValue(null);
+		ctx.tagRepository.create.mockReturnValue({ name: DESKTOP_ASSISTANT_TAG } as never);
+		ctx.tagRepository.save.mockResolvedValue({
+			id: 'tag-da',
+			name: DESKTOP_ASSISTANT_TAG,
+		} as never);
+		ctx.workflowTagMappingRepository.findOne.mockResolvedValue(null);
+		ctx.workflowRepository.findOne.mockResolvedValue({ id: 'wf-loop', meta: {} } as never);
+
+		let handler: ((e: StoredEvent) => void) | undefined;
+		ctx.eventBus.subscribe.mockImplementation((_threadId, h) => {
+			handler = h;
+			return () => {};
+		});
+
+		await ctx.service.promoteThread(USER, { threadId: 't-1' });
+
+		handler!({
+			id: 9,
+			event: {
+				type: 'run-finish',
+				runId: 'run-promote',
+				agentId: 'orchestrator',
+				payload: { status: 'completed' },
+			},
+		} as unknown as StoredEvent);
+
+		// Drain the metadata read + finalise chain
+		for (let i = 0; i < 5; i++) await new Promise((resolve) => setImmediate(resolve));
+
+		expect(ctx.workflowTagMappingRepository.insert).toHaveBeenCalledWith({
+			workflowId: 'wf-loop',
+			tagId: 'tag-da',
+		});
+		expect(ctx.memoryService.updateThread).toHaveBeenCalledWith('t-1', {
+			metadata: { promotedWorkflowId: 'wf-loop' },
+		});
+	});
+
+	test('run-finish for an UNRELATED runId does not fire the hook', async () => {
+		const ctx = makeService();
+		ctx.memoryService.checkThreadOwnership.mockResolvedValue('owned');
+		ctx.memoryService.getThreadMetadata.mockResolvedValue(undefined);
+		ctx.memoryService.getThreadMessages.mockResolvedValue({
+			threadId: 't-1',
+			messages: [
+				{
+					id: 'm-1',
+					role: 'user',
+					content: 'rename files',
+					type: 'text',
+					createdAt: new Date().toISOString(),
+				},
+			],
+		});
+		ctx.instanceAiService.startRun.mockReturnValue('run-promote');
+
+		let handler: ((e: StoredEvent) => void) | undefined;
+		ctx.eventBus.subscribe.mockImplementation((_threadId, h) => {
+			handler = h;
+			return () => {};
+		});
+
+		await ctx.service.promoteThread(USER, { threadId: 't-1' });
+
+		handler!({
+			id: 9,
+			event: {
+				type: 'run-finish',
+				runId: 'run-something-else',
+				agentId: 'orchestrator',
+				payload: { status: 'completed' },
+			},
+		} as unknown as StoredEvent);
+
+		for (let i = 0; i < 5; i++) await new Promise((resolve) => setImmediate(resolve));
+
+		expect(ctx.workflowTagMappingRepository.insert).not.toHaveBeenCalled();
+		expect(ctx.workflowRepository.update).not.toHaveBeenCalled();
+	});
+
 	test('does not fire the post-build hook for an in-flight build-workflow task (workflowId allocated but not yet done)', async () => {
 		const ctx = makeService();
 		ctx.memoryService.checkThreadOwnership.mockResolvedValue('owned');

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.service.test.ts
@@ -1,0 +1,292 @@
+import type { User } from '@n8n/db';
+import type {
+	ExecutionRepository,
+	TagRepository,
+	WorkflowRepository,
+	WorkflowTagMappingRepository,
+} from '@n8n/db';
+import type { Logger } from '@n8n/backend-common';
+import type { StoredEvent } from '@n8n/instance-ai';
+import { mock } from 'jest-mock-extended';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+import type { CredentialsFinderService } from '@/credentials/credentials-finder.service';
+import type { ExecutionService } from '@/executions/execution.service';
+import type { ProjectService } from '@/services/project.service.ee';
+import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+import type { WorkflowSharingService } from '@/workflows/workflow-sharing.service';
+
+import { DESKTOP_ASSISTANT_TAG } from '../constants';
+import { DesktopAssistantService } from '../desktop-assistant.service';
+import type { InProcessEventBus } from '../../event-bus/in-process-event-bus';
+import type { InstanceAiMemoryService } from '../../instance-ai-memory.service';
+import type { InstanceAiService } from '../../instance-ai.service';
+
+function makeService() {
+	const logger = mock<Logger>();
+	const instanceAiService = mock<InstanceAiService>();
+	const memoryService = mock<InstanceAiMemoryService>();
+	const eventBus = mock<InProcessEventBus>();
+	const workflowRepository = mock<WorkflowRepository>();
+	const workflowFinderService = mock<WorkflowFinderService>();
+	const workflowSharingService = mock<WorkflowSharingService>();
+	const tagRepository = mock<TagRepository>();
+	const workflowTagMappingRepository = mock<WorkflowTagMappingRepository>();
+	const credentialsFinderService = mock<CredentialsFinderService>();
+	const executionService = mock<ExecutionService>();
+	const executionRepository = mock<ExecutionRepository>();
+	const projectService = mock<ProjectService>();
+
+	const service = new DesktopAssistantService(
+		logger,
+		instanceAiService,
+		memoryService,
+		eventBus,
+		workflowRepository,
+		workflowFinderService,
+		workflowSharingService,
+		tagRepository,
+		workflowTagMappingRepository,
+		credentialsFinderService,
+		executionService,
+		executionRepository,
+		projectService,
+	);
+
+	return {
+		service,
+		logger,
+		instanceAiService,
+		memoryService,
+		eventBus,
+		workflowRepository,
+		workflowFinderService,
+		workflowSharingService,
+		tagRepository,
+		workflowTagMappingRepository,
+		credentialsFinderService,
+		executionService,
+		executionRepository,
+		projectService,
+	};
+}
+
+const USER: User = mock<User>({ id: 'user-1' });
+
+describe('DesktopAssistantService.triggerTask', () => {
+	test('rejects an empty prompt with BadRequestError', async () => {
+		const { service } = makeService();
+		await expect(service.triggerTask(USER, { prompt: '   ' })).rejects.toBeInstanceOf(
+			BadRequestError,
+		);
+	});
+
+	test('starts a run with the one-shot prompt mode and returns { threadId, runId }', async () => {
+		const ctx = makeService();
+		ctx.projectService.getPersonalProject.mockResolvedValue({ id: 'proj-1' } as never);
+		ctx.memoryService.ensureThread.mockResolvedValue({
+			thread: {
+				id: 't',
+				resourceId: USER.id,
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+			},
+			created: true,
+		});
+		ctx.instanceAiService.startRun.mockReturnValue('run-123');
+
+		const result = await ctx.service.triggerTask(USER, { prompt: 'rename desktop files' });
+
+		expect(ctx.memoryService.ensureThread).toHaveBeenCalledTimes(1);
+		const [calledUser, , message, , , , options] = ctx.instanceAiService.startRun.mock.calls[0];
+		expect(calledUser).toBe(USER);
+		expect(message).toContain('rename desktop files');
+		expect(options).toEqual({ promptMode: 'desktop-assistant-one-shot' });
+		expect(result).toMatchObject({ runId: 'run-123' });
+		expect(result.threadId).toBeDefined();
+	});
+});
+
+describe('DesktopAssistantService.promoteThread', () => {
+	const body = { threadId: 't-1' };
+
+	test('denies access for not_found threads (NotFoundError)', async () => {
+		const ctx = makeService();
+		ctx.memoryService.checkThreadOwnership.mockResolvedValue('not_found');
+		await expect(ctx.service.promoteThread(USER, body)).rejects.toBeInstanceOf(NotFoundError);
+	});
+
+	test('denies access for cross-user threads (ForbiddenError)', async () => {
+		const ctx = makeService();
+		ctx.memoryService.checkThreadOwnership.mockResolvedValue('other_user');
+		await expect(ctx.service.promoteThread(USER, body)).rejects.toBeInstanceOf(ForbiddenError);
+	});
+
+	test('returns { status: done, workflowId } when promoted workflow is still accessible', async () => {
+		const ctx = makeService();
+		ctx.memoryService.checkThreadOwnership.mockResolvedValue('owned');
+		ctx.memoryService.getThreadMetadata.mockResolvedValue({ promotedWorkflowId: 'wf-99' });
+		ctx.workflowSharingService.getSharedWorkflowIds.mockResolvedValue(['wf-99', 'wf-1']);
+
+		const result = await ctx.service.promoteThread(USER, body);
+
+		expect(result).toEqual({ status: 'done', threadId: 't-1', workflowId: 'wf-99' });
+		expect(ctx.instanceAiService.startRun).not.toHaveBeenCalled();
+	});
+
+	test('first call: returns { status: building, runId } and subscribes to the bus', async () => {
+		const ctx = makeService();
+		ctx.memoryService.checkThreadOwnership.mockResolvedValue('owned');
+		ctx.memoryService.getThreadMetadata.mockResolvedValue(undefined);
+		ctx.memoryService.getThreadMessages.mockResolvedValue({
+			threadId: 't-1',
+			messages: [
+				{
+					id: 'm-1',
+					role: 'user',
+					content: 'rename desktop files to banana',
+					type: 'text',
+					createdAt: new Date().toISOString(),
+				},
+			],
+		});
+		ctx.instanceAiService.startRun.mockReturnValue('run-promote');
+		const unsubscribe = jest.fn();
+		ctx.eventBus.subscribe.mockReturnValue(unsubscribe);
+
+		const result = await ctx.service.promoteThread(USER, { threadId: 't-1', name: 'Banana' });
+
+		expect(ctx.eventBus.subscribe).toHaveBeenCalledWith('t-1', expect.any(Function));
+		expect(ctx.instanceAiService.startRun).toHaveBeenCalled();
+		const [, , message, , , , options] = ctx.instanceAiService.startRun.mock.calls[0];
+		expect(message).toContain('Banana');
+		expect(message).toContain('rename desktop files');
+		expect(options).toEqual({ promptMode: 'desktop-assistant-promote' });
+		expect(result).toEqual({ status: 'building', threadId: 't-1', runId: 'run-promote' });
+	});
+
+	test('on a tool-result with workflowId, the post-build hook tags the workflow and writes meta', async () => {
+		const ctx = makeService();
+		ctx.memoryService.checkThreadOwnership.mockResolvedValue('owned');
+		ctx.memoryService.getThreadMetadata.mockResolvedValue(undefined);
+		ctx.memoryService.getThreadMessages.mockResolvedValue({
+			threadId: 't-1',
+			messages: [
+				{
+					id: 'm-1',
+					role: 'user',
+					content: 'rename files',
+					type: 'text',
+					createdAt: new Date().toISOString(),
+				},
+			],
+		});
+		ctx.instanceAiService.startRun.mockReturnValue('run-promote');
+		ctx.tagRepository.findOne.mockResolvedValue(null);
+		ctx.tagRepository.create.mockReturnValue({ name: DESKTOP_ASSISTANT_TAG } as never);
+		ctx.tagRepository.save.mockResolvedValue({
+			id: 'tag-da',
+			name: DESKTOP_ASSISTANT_TAG,
+		} as never);
+		ctx.workflowTagMappingRepository.findOne.mockResolvedValue(null);
+		ctx.workflowRepository.findOne.mockResolvedValue({ id: 'wf-new', meta: {} } as never);
+
+		let handler: ((e: StoredEvent) => void) | undefined;
+		ctx.eventBus.subscribe.mockImplementation((_threadId, h) => {
+			handler = h;
+			return () => {};
+		});
+
+		await ctx.service.promoteThread(USER, { threadId: 't-1' });
+		expect(handler).toBeDefined();
+
+		// Synthesise a tool-result event from the build-workflow tool
+		handler!({
+			id: 7,
+			event: {
+				type: 'tool-result',
+				runId: 'r-1',
+				agentId: 'orchestrator',
+				payload: {
+					toolCallId: 'tc-1',
+					result: { submitted: true, workflowId: 'wf-new' },
+				},
+			},
+		} as unknown as StoredEvent);
+
+		// Allow the async finalize chain to drain
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(ctx.workflowTagMappingRepository.insert).toHaveBeenCalledWith({
+			workflowId: 'wf-new',
+			tagId: 'tag-da',
+		});
+		expect(ctx.workflowRepository.update).toHaveBeenCalledWith(
+			'wf-new',
+			expect.objectContaining({
+				meta: expect.objectContaining({
+					desktopAssistant: expect.objectContaining({ promotedFromThreadId: 't-1' }),
+				}),
+			}),
+		);
+		expect(ctx.memoryService.updateThread).toHaveBeenCalledWith('t-1', {
+			metadata: { promotedWorkflowId: 'wf-new' },
+		});
+	});
+});
+
+describe('DesktopAssistantService.getHistory', () => {
+	test('returns empty when the desktop-assistant tag has never been created', async () => {
+		const ctx = makeService();
+		ctx.workflowSharingService.getSharedWorkflowIds.mockResolvedValue(['wf-1']);
+		ctx.tagRepository.findOne.mockResolvedValue(null);
+
+		const result = await ctx.service.getHistory(USER, {});
+
+		expect(result).toEqual({ results: [], estimated: false, count: 0 });
+		expect(ctx.executionService.findRangeWithCount).not.toHaveBeenCalled();
+	});
+
+	test('passes the intersected workflow ids to the executions service', async () => {
+		const ctx = makeService();
+		ctx.workflowSharingService.getSharedWorkflowIds.mockResolvedValue(['wf-1', 'wf-2']);
+		ctx.tagRepository.findOne.mockResolvedValue({
+			id: 'tag-da',
+			name: DESKTOP_ASSISTANT_TAG,
+		} as never);
+		ctx.workflowTagMappingRepository.find.mockResolvedValue([{ workflowId: 'wf-1' } as never]);
+		ctx.executionService.buildSharingOptions.mockResolvedValue({});
+		ctx.executionService.findRangeWithCount.mockResolvedValue({
+			results: [],
+			count: 0,
+			estimated: false,
+		});
+
+		await ctx.service.getHistory(USER, { limit: 10 });
+
+		expect(ctx.executionService.findRangeWithCount).toHaveBeenCalledWith(
+			expect.objectContaining({
+				kind: 'range',
+				workflowId: ['wf-1'],
+				range: expect.objectContaining({ limit: 10 }),
+			}),
+		);
+	});
+
+	test('skips the executions query when nothing is both accessible and tagged', async () => {
+		const ctx = makeService();
+		ctx.workflowSharingService.getSharedWorkflowIds.mockResolvedValue(['wf-1']);
+		ctx.tagRepository.findOne.mockResolvedValue({
+			id: 'tag-da',
+			name: DESKTOP_ASSISTANT_TAG,
+		} as never);
+		ctx.workflowTagMappingRepository.find.mockResolvedValue([]);
+
+		const result = await ctx.service.getHistory(USER, {});
+
+		expect(result).toEqual({ results: [], estimated: false, count: 0 });
+		expect(ctx.executionService.findRangeWithCount).not.toHaveBeenCalled();
+	});
+});

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.service.test.ts
@@ -167,7 +167,7 @@ describe('DesktopAssistantService.promoteThread', () => {
 		expect(result).toEqual({ status: 'building', threadId: 't-1', runId: 'run-promote' });
 	});
 
-	test('on a tool-result with workflowId, the post-build hook tags the workflow and writes meta', async () => {
+	test('on a tasks-update with a completed build-workflow planned task, the post-build hook tags the workflow and writes meta', async () => {
 		const ctx = makeService();
 		ctx.memoryService.checkThreadOwnership.mockResolvedValue('owned');
 		ctx.memoryService.getThreadMetadata.mockResolvedValue(undefined);
@@ -202,16 +202,29 @@ describe('DesktopAssistantService.promoteThread', () => {
 		await ctx.service.promoteThread(USER, { threadId: 't-1' });
 		expect(handler).toBeDefined();
 
-		// Synthesise a tool-result event from the build-workflow tool
+		// Sub-agent planned-task completion is signalled on the parent thread
+		// via a tasks-update whose planItems carry the workflowId and whose
+		// tasks array reports the matching task as done.
 		handler!({
 			id: 7,
 			event: {
-				type: 'tool-result',
+				type: 'tasks-update',
 				runId: 'r-1',
 				agentId: 'orchestrator',
 				payload: {
-					toolCallId: 'tc-1',
-					result: { submitted: true, workflowId: 'wf-new' },
+					tasks: {
+						tasks: [{ id: 'task-build', description: 'Build the workflow', status: 'done' }],
+					},
+					planItems: [
+						{
+							id: 'task-build',
+							title: 'Build the workflow',
+							kind: 'build-workflow',
+							spec: 'spec',
+							deps: [],
+							workflowId: 'wf-new',
+						},
+					],
 				},
 			},
 		} as unknown as StoredEvent);
@@ -234,6 +247,63 @@ describe('DesktopAssistantService.promoteThread', () => {
 		expect(ctx.memoryService.updateThread).toHaveBeenCalledWith('t-1', {
 			metadata: { promotedWorkflowId: 'wf-new' },
 		});
+	});
+
+	test('does not fire the post-build hook for an in-flight build-workflow task (workflowId allocated but not yet done)', async () => {
+		const ctx = makeService();
+		ctx.memoryService.checkThreadOwnership.mockResolvedValue('owned');
+		ctx.memoryService.getThreadMetadata.mockResolvedValue(undefined);
+		ctx.memoryService.getThreadMessages.mockResolvedValue({
+			threadId: 't-1',
+			messages: [
+				{
+					id: 'm-1',
+					role: 'user',
+					content: 'rename files',
+					type: 'text',
+					createdAt: new Date().toISOString(),
+				},
+			],
+		});
+		ctx.instanceAiService.startRun.mockReturnValue('run-promote');
+
+		let handler: ((e: StoredEvent) => void) | undefined;
+		ctx.eventBus.subscribe.mockImplementation((_threadId, h) => {
+			handler = h;
+			return () => {};
+		});
+
+		await ctx.service.promoteThread(USER, { threadId: 't-1' });
+
+		handler!({
+			id: 7,
+			event: {
+				type: 'tasks-update',
+				runId: 'r-1',
+				agentId: 'orchestrator',
+				payload: {
+					tasks: {
+						tasks: [{ id: 'task-build', description: 'Build the workflow', status: 'in_progress' }],
+					},
+					planItems: [
+						{
+							id: 'task-build',
+							title: 'Build the workflow',
+							kind: 'build-workflow',
+							spec: 'spec',
+							deps: [],
+							workflowId: 'wf-new',
+						},
+					],
+				},
+			},
+		} as unknown as StoredEvent);
+
+		await new Promise((resolve) => setImmediate(resolve));
+
+		expect(ctx.workflowTagMappingRepository.insert).not.toHaveBeenCalled();
+		expect(ctx.workflowRepository.update).not.toHaveBeenCalled();
+		expect(ctx.memoryService.updateThread).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.service.test.ts
@@ -424,10 +424,9 @@ describe('DesktopAssistantService.promoteThread', () => {
 });
 
 describe('DesktopAssistantService.getHistory', () => {
-	test('returns empty when the desktop-assistant tag has never been created', async () => {
+	test('returns empty when the user has no accessible workflows', async () => {
 		const ctx = makeService();
-		ctx.workflowSharingService.getSharedWorkflowIds.mockResolvedValue(['wf-1']);
-		ctx.tagRepository.findOne.mockResolvedValue(null);
+		ctx.workflowSharingService.getSharedWorkflowIds.mockResolvedValue([]);
 
 		const result = await ctx.service.getHistory(USER, {});
 
@@ -435,15 +434,13 @@ describe('DesktopAssistantService.getHistory', () => {
 		expect(ctx.executionService.findRangeWithCount).not.toHaveBeenCalled();
 	});
 
-	test('passes the intersected workflow ids to the executions service', async () => {
+	test('passes ALL accessible (non-archived) workflow ids to the executions service', async () => {
 		const ctx = makeService();
 		ctx.workflowSharingService.getSharedWorkflowIds.mockResolvedValue(['wf-1', 'wf-2']);
-		ctx.tagRepository.findOne.mockResolvedValue({
-			id: 'tag-da',
-			name: DESKTOP_ASSISTANT_TAG,
-		} as never);
-		ctx.workflowTagMappingRepository.find.mockResolvedValue([{ workflowId: 'wf-1' } as never]);
-		ctx.workflowRepository.find.mockResolvedValue([{ id: 'wf-1' } as never]);
+		ctx.workflowRepository.find.mockResolvedValue([
+			{ id: 'wf-1' } as never,
+			{ id: 'wf-2' } as never,
+		]);
 		ctx.executionService.buildSharingOptions.mockResolvedValue({});
 		ctx.executionService.findRangeWithCount.mockResolvedValue({
 			results: [],
@@ -456,23 +453,15 @@ describe('DesktopAssistantService.getHistory', () => {
 		expect(ctx.executionService.findRangeWithCount).toHaveBeenCalledWith(
 			expect.objectContaining({
 				kind: 'range',
-				workflowId: ['wf-1'],
+				workflowId: ['wf-1', 'wf-2'],
 				range: expect.objectContaining({ limit: 10 }),
 			}),
 		);
 	});
 
-	test('drops archived workflows from the executions query (history view skips archived)', async () => {
+	test('drops archived workflows from the executions query', async () => {
 		const ctx = makeService();
 		ctx.workflowSharingService.getSharedWorkflowIds.mockResolvedValue(['wf-1', 'wf-archived']);
-		ctx.tagRepository.findOne.mockResolvedValue({
-			id: 'tag-da',
-			name: DESKTOP_ASSISTANT_TAG,
-		} as never);
-		ctx.workflowTagMappingRepository.find.mockResolvedValue([
-			{ workflowId: 'wf-1' } as never,
-			{ workflowId: 'wf-archived' } as never,
-		]);
 		// repository.find with isArchived: false only returns the live one
 		ctx.workflowRepository.find.mockResolvedValue([{ id: 'wf-1' } as never]);
 		ctx.executionService.buildSharingOptions.mockResolvedValue({});
@@ -494,16 +483,9 @@ describe('DesktopAssistantService.getHistory', () => {
 		);
 	});
 
-	test('skips the executions query when every tagged workflow is archived', async () => {
+	test('skips the executions query when every accessible workflow is archived', async () => {
 		const ctx = makeService();
 		ctx.workflowSharingService.getSharedWorkflowIds.mockResolvedValue(['wf-archived']);
-		ctx.tagRepository.findOne.mockResolvedValue({
-			id: 'tag-da',
-			name: DESKTOP_ASSISTANT_TAG,
-		} as never);
-		ctx.workflowTagMappingRepository.find.mockResolvedValue([
-			{ workflowId: 'wf-archived' } as never,
-		]);
 		ctx.workflowRepository.find.mockResolvedValue([]);
 
 		const result = await ctx.service.getHistory(USER, {});
@@ -512,18 +494,24 @@ describe('DesktopAssistantService.getHistory', () => {
 		expect(ctx.executionService.findRangeWithCount).not.toHaveBeenCalled();
 	});
 
-	test('skips the executions query when nothing is both accessible and tagged', async () => {
+	test('does NOT filter on the desktop-assistant tag (history covers all workflows)', async () => {
 		const ctx = makeService();
-		ctx.workflowSharingService.getSharedWorkflowIds.mockResolvedValue(['wf-1']);
-		ctx.tagRepository.findOne.mockResolvedValue({
-			id: 'tag-da',
-			name: DESKTOP_ASSISTANT_TAG,
-		} as never);
-		ctx.workflowTagMappingRepository.find.mockResolvedValue([]);
+		ctx.workflowSharingService.getSharedWorkflowIds.mockResolvedValue(['wf-untagged']);
+		ctx.workflowRepository.find.mockResolvedValue([{ id: 'wf-untagged' } as never]);
+		ctx.executionService.buildSharingOptions.mockResolvedValue({});
+		ctx.executionService.findRangeWithCount.mockResolvedValue({
+			results: [],
+			count: 0,
+			estimated: false,
+		});
 
-		const result = await ctx.service.getHistory(USER, {});
+		await ctx.service.getHistory(USER, {});
 
-		expect(result).toEqual({ results: [], estimated: false, count: 0 });
-		expect(ctx.executionService.findRangeWithCount).not.toHaveBeenCalled();
+		// Pin that we don't go anywhere near the tag tables.
+		expect(ctx.tagRepository.findOne).not.toHaveBeenCalled();
+		expect(ctx.workflowTagMappingRepository.find).not.toHaveBeenCalled();
+		expect(ctx.executionService.findRangeWithCount).toHaveBeenCalledWith(
+			expect.objectContaining({ workflowId: ['wf-untagged'] }),
+		);
 	});
 });

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.service.test.ts
@@ -439,6 +439,7 @@ describe('DesktopAssistantService.getHistory', () => {
 			name: DESKTOP_ASSISTANT_TAG,
 		} as never);
 		ctx.workflowTagMappingRepository.find.mockResolvedValue([{ workflowId: 'wf-1' } as never]);
+		ctx.workflowRepository.find.mockResolvedValue([{ id: 'wf-1' } as never]);
 		ctx.executionService.buildSharingOptions.mockResolvedValue({});
 		ctx.executionService.findRangeWithCount.mockResolvedValue({
 			results: [],
@@ -455,6 +456,56 @@ describe('DesktopAssistantService.getHistory', () => {
 				range: expect.objectContaining({ limit: 10 }),
 			}),
 		);
+	});
+
+	test('drops archived workflows from the executions query (history view skips archived)', async () => {
+		const ctx = makeService();
+		ctx.workflowSharingService.getSharedWorkflowIds.mockResolvedValue(['wf-1', 'wf-archived']);
+		ctx.tagRepository.findOne.mockResolvedValue({
+			id: 'tag-da',
+			name: DESKTOP_ASSISTANT_TAG,
+		} as never);
+		ctx.workflowTagMappingRepository.find.mockResolvedValue([
+			{ workflowId: 'wf-1' } as never,
+			{ workflowId: 'wf-archived' } as never,
+		]);
+		// repository.find with isArchived: false only returns the live one
+		ctx.workflowRepository.find.mockResolvedValue([{ id: 'wf-1' } as never]);
+		ctx.executionService.buildSharingOptions.mockResolvedValue({});
+		ctx.executionService.findRangeWithCount.mockResolvedValue({
+			results: [],
+			count: 0,
+			estimated: false,
+		});
+
+		await ctx.service.getHistory(USER, {});
+
+		expect(ctx.workflowRepository.find).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: expect.objectContaining({ isArchived: false }),
+			}),
+		);
+		expect(ctx.executionService.findRangeWithCount).toHaveBeenCalledWith(
+			expect.objectContaining({ workflowId: ['wf-1'] }),
+		);
+	});
+
+	test('skips the executions query when every tagged workflow is archived', async () => {
+		const ctx = makeService();
+		ctx.workflowSharingService.getSharedWorkflowIds.mockResolvedValue(['wf-archived']);
+		ctx.tagRepository.findOne.mockResolvedValue({
+			id: 'tag-da',
+			name: DESKTOP_ASSISTANT_TAG,
+		} as never);
+		ctx.workflowTagMappingRepository.find.mockResolvedValue([
+			{ workflowId: 'wf-archived' } as never,
+		]);
+		ctx.workflowRepository.find.mockResolvedValue([]);
+
+		const result = await ctx.service.getHistory(USER, {});
+
+		expect(result).toEqual({ results: [], estimated: false, count: 0 });
+		expect(ctx.executionService.findRangeWithCount).not.toHaveBeenCalled();
 	});
 
 	test('skips the executions query when nothing is both accessible and tagged', async () => {

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.service.test.ts
@@ -14,6 +14,7 @@ import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import type { CredentialsFinderService } from '@/credentials/credentials-finder.service';
 import type { ExecutionService } from '@/executions/execution.service';
+import type { NodeTypes } from '@/node-types';
 import type { ProjectService } from '@/services/project.service.ee';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import type { WorkflowSharingService } from '@/workflows/workflow-sharing.service';
@@ -38,6 +39,7 @@ function makeService() {
 	const executionService = mock<ExecutionService>();
 	const executionRepository = mock<ExecutionRepository>();
 	const projectService = mock<ProjectService>();
+	const nodeTypes = mock<NodeTypes>();
 
 	const service = new DesktopAssistantService(
 		logger,
@@ -53,6 +55,7 @@ function makeService() {
 		executionService,
 		executionRepository,
 		projectService,
+		nodeTypes,
 	);
 
 	return {
@@ -70,6 +73,7 @@ function makeService() {
 		executionService,
 		executionRepository,
 		projectService,
+		nodeTypes,
 	};
 }
 

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/split-leading-emoji.test.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/split-leading-emoji.test.ts
@@ -1,4 +1,4 @@
-import { splitLeadingEmoji } from '../desktop-assistant.service';
+import { splitLeadingEmoji } from '../desktop-assistant.helpers';
 
 describe('splitLeadingEmoji', () => {
 	test('extracts a single emoji and trims the trailing space', () => {

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/split-leading-emoji.test.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/split-leading-emoji.test.ts
@@ -1,0 +1,47 @@
+import { splitLeadingEmoji } from '../desktop-assistant.service';
+
+describe('splitLeadingEmoji', () => {
+	test('extracts a single emoji and trims the trailing space', () => {
+		expect(splitLeadingEmoji('🍌 Daily banana prices')).toEqual({
+			emoji: '🍌',
+			rest: 'Daily banana prices',
+		});
+	});
+
+	test('extracts a multi-codepoint ZWJ sequence as one emoji', () => {
+		expect(splitLeadingEmoji('👨‍💻 Coding assistant')).toEqual({
+			emoji: '👨\u200d💻',
+			rest: 'Coding assistant',
+		});
+	});
+
+	test('leaves plain text strings untouched', () => {
+		expect(splitLeadingEmoji('Daily banana prices')).toEqual({
+			rest: 'Daily banana prices',
+		});
+	});
+
+	test('treats numbers and symbols as plain text, not emoji', () => {
+		expect(splitLeadingEmoji('12 weekly reports')).toEqual({ rest: '12 weekly reports' });
+		expect(splitLeadingEmoji('#alerts pipeline')).toEqual({ rest: '#alerts pipeline' });
+	});
+
+	test('does not require a space after the emoji', () => {
+		expect(splitLeadingEmoji('🍌Banana')).toEqual({ emoji: '🍌', rest: 'Banana' });
+	});
+
+	test('returns the emoji alone with an empty rest when the input has nothing after it', () => {
+		expect(splitLeadingEmoji('🍌')).toEqual({ emoji: '🍌', rest: '' });
+	});
+
+	test('handles variation-selector-16 (emoji presentation) on warning-style glyphs', () => {
+		const input = '⚠️ Action needed';
+		const { emoji, rest } = splitLeadingEmoji(input);
+		expect(emoji).toMatch(/⚠/);
+		expect(rest).toBe('Action needed');
+	});
+
+	test('does not mistake leading whitespace for an emoji', () => {
+		expect(splitLeadingEmoji('   🍌 Banana')).toEqual({ rest: '   🍌 Banana' });
+	});
+});

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/split-leading-emoji.test.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/split-leading-emoji.test.ts
@@ -44,4 +44,25 @@ describe('splitLeadingEmoji', () => {
 	test('does not mistake leading whitespace for an emoji', () => {
 		expect(splitLeadingEmoji('   🍌 Banana')).toEqual({ rest: '   🍌 Banana' });
 	});
+
+	test('extracts a base emoji + skin-tone modifier as one cluster', () => {
+		expect(splitLeadingEmoji('👍🏽 Banana')).toEqual({
+			emoji: '👍🏽',
+			rest: 'Banana',
+		});
+	});
+
+	test('extracts a flag sequence (paired regional indicators)', () => {
+		expect(splitLeadingEmoji('🇩🇪 Banana')).toEqual({
+			emoji: '🇩🇪',
+			rest: 'Banana',
+		});
+	});
+
+	test('extracts a ZWJ sequence whose base carries a skin-tone modifier', () => {
+		expect(splitLeadingEmoji('👨🏽‍💻 Coding')).toEqual({
+			emoji: '👨🏽‍💻',
+			rest: 'Coding',
+		});
+	});
 });

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/constants.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/constants.ts
@@ -1,0 +1,18 @@
+/**
+ * Reserved tag name used as the marker for desktop-assistant-promoted
+ * workflows. The tag is created on first use via {@link TagRepository}
+ * and is applied through the existing `workflow-tag-mapping` table.
+ *
+ * The tag is the source of truth for "is this a desktop-assistant
+ * workflow"; idempotency for `POST /desktop-assistant/promote-thread`
+ * keys on Instance AI thread metadata (`promotedWorkflowId`), not on
+ * the tag, so a user removing the tag in the canvas does not cause a
+ * duplicate promote.
+ */
+export const DESKTOP_ASSISTANT_TAG = 'desktop-assistant';
+
+/** Thread metadata key set after a successful promote. */
+export const PROMOTED_WORKFLOW_ID_KEY = 'promotedWorkflowId';
+
+/** Reverse pointer written on the workflow's meta JSON column. */
+export const PROMOTED_FROM_THREAD_ID_KEY = 'promotedFromThreadId';

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.classifier.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.classifier.ts
@@ -1,0 +1,298 @@
+import type {
+	DesktopAssistantTaskCard,
+	DesktopAssistantTaskIcon,
+	DesktopAssistantTasksResponse,
+	DesktopAssistantTriggerSummary,
+} from '@n8n/api-types';
+import type { ExecutionSummary, INode } from 'n8n-workflow';
+import type cronParserTypes from 'cron-parser';
+
+import { DESKTOP_ASSISTANT_TAG } from './constants';
+
+/**
+ * Input shape — a minimal projection of the workflow + last execution that
+ * the classifier needs. The service layer is responsible for assembling
+ * this from `WorkflowRepository`, `ExecutionService`, and the user's
+ * accessible credential set.
+ */
+export interface ClassifierInput {
+	workflowId: string;
+	name: string;
+	active: boolean;
+	nodes: INode[];
+	tags: Array<{ name: string }>;
+	settings?: { timezone?: string };
+	lastExecution?: { id: string; status: ExecutionSummary['status']; startedAt: string };
+	/** Optional emoji icon stored on a workflow promoted by the desktop assistant. */
+	emojiIcon?: string;
+	/** Ids of credentials the requesting user can access. Used to flag actionNeeded. */
+	accessibleCredentialIds: ReadonlySet<string>;
+}
+
+/** Node-type prefixes that count as "runs locally" via computer-use. */
+const LOCAL_NODE_TYPE_PREFIXES = ['n8n-nodes-base.computerUse', 'n8n-nodes-base.localFileTrigger'];
+
+const SCHEDULE_TRIGGER_TYPE = 'n8n-nodes-base.scheduleTrigger';
+const MANUAL_TRIGGER_TYPE = 'n8n-nodes-base.manualTrigger';
+const WEBHOOK_TRIGGER_TYPE = 'n8n-nodes-base.webhook';
+
+const TRIGGER_TYPE_SUFFIXES = ['Trigger', 'trigger'];
+
+/**
+ * Loose poll-trigger heuristic. Real polling triggers in `n8n-nodes-base`
+ * all end in "Trigger" and are not the schedule/webhook/manual trigger
+ * (e.g. `gmailTrigger`, `googleSheetsTrigger`). Used by the classifier
+ * to detect "On new X" trigger semantics for description text.
+ */
+function isPollOrWebhookTrigger(node: INode | undefined): boolean {
+	if (!node) return false;
+	if (node.type === SCHEDULE_TRIGGER_TYPE || node.type === MANUAL_TRIGGER_TYPE) return false;
+	if (node.type === WEBHOOK_TRIGGER_TYPE) return true;
+	return TRIGGER_TYPE_SUFFIXES.some((suffix) => node.type.endsWith(suffix));
+}
+
+function findFirstTrigger(nodes: INode[]): INode | undefined {
+	return nodes.find((node) => {
+		if (node.disabled) return false;
+		return (
+			node.type === SCHEDULE_TRIGGER_TYPE ||
+			node.type === MANUAL_TRIGGER_TYPE ||
+			node.type === WEBHOOK_TRIGGER_TYPE ||
+			TRIGGER_TYPE_SUFFIXES.some((suffix) => node.type.endsWith(suffix))
+		);
+	});
+}
+
+function hasDesktopAssistantTag(tags: Array<{ name: string }>): boolean {
+	return tags.some((t) => t.name === DESKTOP_ASSISTANT_TAG);
+}
+
+function runsLocally(nodes: INode[]): boolean {
+	return nodes.some((node) =>
+		LOCAL_NODE_TYPE_PREFIXES.some((prefix) => node.type.startsWith(prefix)),
+	);
+}
+
+/**
+ * Strip the trailing " Trigger" word (case-insensitive) and lowercase the
+ * rest, so a node displayName of `"Gmail Trigger"` produces the label
+ * `"On new gmail message"`.
+ *
+ * Exported for unit testing.
+ */
+export function deriveSourceLabel(displayName: string): string {
+	const stripped = displayName.replace(/\s+trigger\s*$/i, '').trim();
+	const lower = stripped.toLowerCase();
+	return `On new ${lower} message`;
+}
+
+/**
+ * Compute the next run time for a schedule trigger node. Only the
+ * `cronExpression` mode is supported; other interval forms return null
+ * (the classifier treats null as "ambiguous, fall through to no preview").
+ *
+ * Exported for unit testing.
+ */
+export function deriveNextRunAt(
+	node: INode,
+	options: { timezone?: string; now?: Date } = {},
+): string | null {
+	const interval = node.parameters?.rule;
+	if (
+		!interval ||
+		typeof interval !== 'object' ||
+		!('interval' in interval) ||
+		!Array.isArray((interval as { interval: unknown[] }).interval)
+	) {
+		return null;
+	}
+	const entries = (interval as { interval: Array<Record<string, unknown>> }).interval;
+	const first = entries[0];
+	if (!first || first.field !== 'cronExpression') return null;
+	const expression = first.expression;
+	if (typeof expression !== 'string' || expression.trim().length === 0) return null;
+
+	// Lazy-load: cron-parser is only needed for desktop-assistant tasks
+	// classification; avoid pulling it into the boot path for every cli build.
+	let cronParser: typeof cronParserTypes;
+	try {
+		// eslint-disable-next-line @typescript-eslint/no-require-imports
+		cronParser = require('cron-parser') as typeof cronParserTypes;
+	} catch {
+		return null;
+	}
+	try {
+		const it = cronParser.parseExpression(expression, {
+			currentDate: options.now ?? new Date(),
+			tz: options.timezone,
+		});
+		return it.next().toDate().toISOString();
+	} catch {
+		return null;
+	}
+}
+
+function deriveIcon(emojiIcon: string | undefined, nodes: INode[]): DesktopAssistantTaskIcon {
+	if (emojiIcon && emojiIcon.length > 0) {
+		return { type: 'emoji', value: emojiIcon };
+	}
+	const firstNonTrigger = nodes.find((node) => {
+		if (node.disabled) return false;
+		if (node.type === MANUAL_TRIGGER_TYPE) return false;
+		if (node.type === SCHEDULE_TRIGGER_TYPE) return false;
+		if (node.type === WEBHOOK_TRIGGER_TYPE) return false;
+		return !TRIGGER_TYPE_SUFFIXES.some((suffix) => node.type.endsWith(suffix));
+	});
+	const trigger = findFirstTrigger(nodes);
+	const nodeType = firstNonTrigger?.type ?? trigger?.type ?? 'n8n-nodes-base.noOp';
+	return { type: 'node', nodeType };
+}
+
+function deriveTriggerSummary(
+	trigger: INode | undefined,
+	settings: ClassifierInput['settings'],
+): DesktopAssistantTriggerSummary {
+	if (!trigger) return { kind: 'other' };
+	if (trigger.type === MANUAL_TRIGGER_TYPE) return { kind: 'manual' };
+	if (trigger.type === SCHEDULE_TRIGGER_TYPE) {
+		return {
+			kind: 'schedule',
+			nextRunAt: deriveNextRunAt(trigger, { timezone: settings?.timezone }),
+		};
+	}
+	if (isPollOrWebhookTrigger(trigger)) {
+		const kind = trigger.type === WEBHOOK_TRIGGER_TYPE ? 'webhook' : 'poll';
+		const displayName = humanizeNodeTypeName(trigger.type);
+		return { kind, sourceLabel: deriveSourceLabel(displayName) };
+	}
+	return { kind: 'other' };
+}
+
+/**
+ * Derive a display-name-shaped label from a node type id when the real
+ * displayName is not available to the classifier (the classifier is pure
+ * and has no access to the node types service).
+ *
+ * `n8n-nodes-base.gmailTrigger` → `Gmail Trigger`.
+ */
+function humanizeNodeTypeName(nodeType: string): string {
+	const tail = nodeType.split('.').pop() ?? nodeType;
+	// Split camelCase / PascalCase, capitalise each word
+	const words = tail.replace(/([a-z0-9])([A-Z])/g, '$1 $2').split(/\s+/);
+	return words
+		.filter((w) => w.length > 0)
+		.map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+		.join(' ');
+}
+
+function findMissingCredentialNode(
+	input: ClassifierInput,
+): { node: INode; serviceName: string } | undefined {
+	for (const node of input.nodes) {
+		if (node.disabled) continue;
+		if (!node.credentials) continue;
+		for (const slot of Object.values(node.credentials)) {
+			if (!slot?.id) continue; // Unconfigured credentials are not "missing" in the BFF sense
+			if (!input.accessibleCredentialIds.has(slot.id)) {
+				return { node, serviceName: humanizeNodeTypeName(node.type) };
+			}
+		}
+	}
+	return undefined;
+}
+
+function deriveDescription(
+	bucket: 'actionNeeded' | 'upcoming' | 'readyToRun',
+	trigger: INode | undefined,
+	summary: DesktopAssistantTriggerSummary,
+	missingCredential: { serviceName: string } | undefined,
+): string {
+	if (bucket === 'actionNeeded') {
+		if (missingCredential) {
+			// Strip a trailing " Trigger" so we get "Gmail needs credential", not
+			// "Gmail Trigger needs credential".
+			const service = missingCredential.serviceName.replace(/\s+Trigger\s*$/i, '');
+			return `${service} needs credential`;
+		}
+		return 'Activation required';
+	}
+	if (bucket === 'upcoming') {
+		if (summary.kind !== 'schedule' || summary.nextRunAt === null) {
+			return 'Recurring task';
+		}
+		return `Next run at ${summary.nextRunAt}`;
+	}
+	// readyToRun
+	if (summary.kind === 'poll' || summary.kind === 'webhook') {
+		return summary.sourceLabel;
+	}
+	if (trigger?.type === MANUAL_TRIGGER_TYPE) return '';
+	return '';
+}
+
+function classifyOne(input: ClassifierInput): {
+	bucket: 'actionNeeded' | 'upcoming' | 'readyToRun' | null;
+	card: DesktopAssistantTaskCard;
+} {
+	const trigger = findFirstTrigger(input.nodes);
+	const summary = deriveTriggerSummary(trigger, input.settings);
+	const tagged = hasDesktopAssistantTag(input.tags);
+	const missingCredential = findMissingCredentialNode(input);
+
+	let bucket: 'actionNeeded' | 'upcoming' | 'readyToRun' | null = null;
+
+	const isScheduleOrPoll =
+		summary.kind === 'schedule' || summary.kind === 'poll' || summary.kind === 'webhook';
+
+	if (tagged && (missingCredential || (!input.active && isScheduleOrPoll))) {
+		bucket = 'actionNeeded';
+	} else if (tagged && input.active && isScheduleOrPoll) {
+		bucket = 'upcoming';
+	} else if (tagged && trigger?.type === MANUAL_TRIGGER_TYPE) {
+		bucket = 'readyToRun';
+	} else if (!tagged) {
+		// User-built fallback — surfaces in readyToRun
+		bucket = 'readyToRun';
+	}
+
+	const description =
+		bucket === null ? '' : deriveDescription(bucket, trigger, summary, missingCredential);
+
+	const card: DesktopAssistantTaskCard = {
+		workflowId: input.workflowId,
+		name: input.name,
+		description,
+		icon: deriveIcon(input.emojiIcon, input.nodes),
+		trigger: summary,
+		source: tagged ? 'desktop-assistant' : 'user-built',
+		active: input.active,
+		runsLocally: runsLocally(input.nodes),
+	};
+	if (input.lastExecution) {
+		card.lastExecution = input.lastExecution;
+	}
+
+	return { bucket, card };
+}
+
+/**
+ * Classify all workflows accessible to the requesting user into the three
+ * buckets the desktop assistant UI renders. A workflow appears in at most
+ * one bucket; precedence is `actionNeeded > upcoming > readyToRun`. Pure;
+ * no DI, no I/O — all input data is gathered by the service layer.
+ */
+export function classifyWorkflowsForDesktopAssistant(
+	inputs: ClassifierInput[],
+): DesktopAssistantTasksResponse {
+	const result: DesktopAssistantTasksResponse = {
+		actionNeeded: [],
+		upcoming: [],
+		readyToRun: [],
+	};
+	for (const input of inputs) {
+		const { bucket, card } = classifyOne(input);
+		if (bucket === null) continue;
+		result[bucket].push(card);
+	}
+	return result;
+}

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.classifier.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.classifier.ts
@@ -139,8 +139,10 @@ export function toCronExpression(entry: Record<string, unknown> | undefined): st
 		return `${minute} ${hour} */${step} * *`;
 	}
 	if (field === 'weeks') {
-		const weekdays = Array.isArray(entry.triggerAtDayOfWeek)
-			? (entry.triggerAtDayOfWeek as unknown[]).filter((d) => typeof d === 'number').join(',')
+		// n8n's Schedule Trigger stores the selected weekdays under `triggerAtDay`
+		// (verified in packages/nodes-base/nodes/Schedule/test/GenericFunctions.test.ts).
+		const weekdays = Array.isArray(entry.triggerAtDay)
+			? (entry.triggerAtDay as unknown[]).filter((d) => typeof d === 'number').join(',')
 			: '*';
 		return `${minute} ${hour} * * ${weekdays || '*'}`;
 	}

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.classifier.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.classifier.ts
@@ -301,16 +301,28 @@ function classifyOne(input: ClassifierInput): {
 	const isScheduleOrPoll =
 		summary.kind === 'schedule' || summary.kind === 'poll' || summary.kind === 'webhook';
 
-	// Missing credentials block execution regardless of source: a user-built
-	// workflow with an unconfigured Gmail node belongs in actionNeeded just
-	// as much as a desktop-assistant-promoted one. Activation-required only
-	// fires for desktop-assistant workflows — plenty of user-built workflows
-	// are intentionally inactive (templates, drafts) and shouldn't be nagged.
+	// Bucketing precedence:
+	//  1. Missing credentials block execution regardless of source: a user-built
+	//     workflow with an unconfigured Gmail node belongs in actionNeeded just
+	//     as much as a desktop-assistant-promoted one.
+	//  2. Activation-required is desktop-assistant-only — plenty of user-built
+	//     workflows are intentionally inactive (templates, drafts) and shouldn't
+	//     be nagged.
+	//  3. Active schedule/poll workflows go to upcoming regardless of source.
+	//     These have time-based "next run" semantics that are valuable to
+	//     surface for the user-built case too. Webhook workflows are kept
+	//     tag-gated since they have no time preview and would spam upcoming
+	//     with every user-built webhook.
+	//  4. Tagged manual-trigger workflows go to readyToRun.
+	//  5. Everything else user-built falls through to readyToRun.
+	const isTimeBasedRecurring = summary.kind === 'schedule' || summary.kind === 'poll';
 	if (missingCredential) {
 		bucket = 'actionNeeded';
 	} else if (tagged && !input.active && isScheduleOrPoll) {
 		bucket = 'actionNeeded';
-	} else if (tagged && input.active && isScheduleOrPoll) {
+	} else if (input.active && isTimeBasedRecurring) {
+		bucket = 'upcoming';
+	} else if (tagged && input.active && summary.kind === 'webhook') {
 		bucket = 'upcoming';
 	} else if (tagged && trigger?.type === MANUAL_TRIGGER_TYPE) {
 		bucket = 'readyToRun';

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.classifier.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.classifier.ts
@@ -27,6 +27,12 @@ export interface ClassifierInput {
 	emojiIcon?: string;
 	/** Ids of credentials the requesting user can access. Used to flag actionNeeded. */
 	accessibleCredentialIds: ReadonlySet<string>;
+	/** Names of nodes whose type declares required credentials but whose workflow
+	 *  JSON has no populated credential slot at all. Pre-computed by the service
+	 *  via node-type description introspection (mirroring the workflow-builder's
+	 *  setup analysis primitives) because the classifier itself has no
+	 *  `NodeTypes` dependency. */
+	nodesRequiringCredentialSetup?: ReadonlySet<string>;
 }
 
 /** Node-type prefixes that count as "runs locally" via computer-use. */
@@ -238,18 +244,26 @@ function findMissingCredentialNode(
 ): { node: INode; serviceName: string } | undefined {
 	for (const node of input.nodes) {
 		if (node.disabled) continue;
+
+		// (a) Service-side hint: the node's TYPE declares a required credential
+		//     (via node-types description) but the workflow JSON has no slot
+		//     populated at all. This catches workflows the user (or AI) built
+		//     without ever picking a credential — the canvas would show a red
+		//     badge but the workflow JSON has no `credentials` field on the node.
+		if (input.nodesRequiringCredentialSetup?.has(node.name)) {
+			return { node, serviceName: humanizeNodeTypeName(node.type) };
+		}
+
 		if (!node.credentials) continue;
 		for (const slot of Object.values(node.credentials)) {
 			if (!slot) continue;
-			// A credential slot is "needs setup" when either:
-			//  (a) no id is bound to it (the node was created/imported but no
-			//      credential was ever picked), or
-			//  (b) the bound id is not accessible to the requesting user (the
-			//      credential was deleted, or was unshared from this user).
-			// Both block execution and both deserve the same desktop card.
+			// (b) Slot exists but no id is bound (the node was created with a
+			//     placeholder credentials field but no actual credential picked).
 			if (typeof slot.id !== 'string' || slot.id.length === 0) {
 				return { node, serviceName: humanizeNodeTypeName(node.type) };
 			}
+			// (c) Slot has an id but the credential isn't accessible to the
+			//     requesting user (deleted, or unshared from them).
 			if (!input.accessibleCredentialIds.has(slot.id)) {
 				return { node, serviceName: humanizeNodeTypeName(node.type) };
 			}

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.classifier.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.classifier.ts
@@ -308,21 +308,17 @@ function classifyOne(input: ClassifierInput): {
 	//  2. Activation-required is desktop-assistant-only — plenty of user-built
 	//     workflows are intentionally inactive (templates, drafts) and shouldn't
 	//     be nagged.
-	//  3. Active schedule/poll workflows go to upcoming regardless of source.
-	//     These have time-based "next run" semantics that are valuable to
-	//     surface for the user-built case too. Webhook workflows are kept
-	//     tag-gated since they have no time preview and would spam upcoming
-	//     with every user-built webhook.
+	//  3. Active autonomous-trigger workflows (schedule/poll/webhook) go to
+	//     upcoming regardless of source. readyToRun is reserved for
+	//     manually-triggered workflows; anything that fires on its own —
+	//     time-based or webhook-driven — belongs in upcoming.
 	//  4. Tagged manual-trigger workflows go to readyToRun.
 	//  5. Everything else user-built falls through to readyToRun.
-	const isTimeBasedRecurring = summary.kind === 'schedule' || summary.kind === 'poll';
 	if (missingCredential) {
 		bucket = 'actionNeeded';
 	} else if (tagged && !input.active && isScheduleOrPoll) {
 		bucket = 'actionNeeded';
-	} else if (input.active && isTimeBasedRecurring) {
-		bucket = 'upcoming';
-	} else if (tagged && input.active && summary.kind === 'webhook') {
+	} else if (input.active && isScheduleOrPoll) {
 		bucket = 'upcoming';
 	} else if (tagged && trigger?.type === MANUAL_TRIGGER_TYPE) {
 		bucket = 'readyToRun';

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.classifier.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.classifier.ts
@@ -66,7 +66,7 @@ function isPollOrWebhookTrigger(node: INode | undefined): boolean {
 }
 
 function findFirstTrigger(nodes: INode[]): INode | undefined {
-	return nodes.find((node) => {
+	const triggers = nodes.filter((node) => {
 		if (node.disabled) return false;
 		return (
 			node.type === SCHEDULE_TRIGGER_TYPE ||
@@ -75,6 +75,13 @@ function findFirstTrigger(nodes: INode[]): INode | undefined {
 			TRIGGER_TYPE_SUFFIXES.some((suffix) => node.type.endsWith(suffix))
 		);
 	});
+	if (triggers.length === 0) return undefined;
+	// A workflow that has BOTH a manual trigger and an autonomous one (schedule/
+	// poll/webhook) is usually a recurring workflow with manual as a debugging
+	// entry point, not the other way around. Prefer the autonomous trigger so
+	// the classifier puts the workflow in the right bucket (upcoming / action-
+	// needed) instead of readyToRun.
+	return triggers.find((t) => t.type !== MANUAL_TRIGGER_TYPE) ?? triggers[0];
 }
 
 function hasDesktopAssistantTag(tags: Array<{ name: string }>): boolean {

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.classifier.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.classifier.ts
@@ -192,7 +192,16 @@ function findMissingCredentialNode(
 		if (node.disabled) continue;
 		if (!node.credentials) continue;
 		for (const slot of Object.values(node.credentials)) {
-			if (!slot?.id) continue; // Unconfigured credentials are not "missing" in the BFF sense
+			if (!slot) continue;
+			// A credential slot is "needs setup" when either:
+			//  (a) no id is bound to it (the node was created/imported but no
+			//      credential was ever picked), or
+			//  (b) the bound id is not accessible to the requesting user (the
+			//      credential was deleted, or was unshared from this user).
+			// Both block execution and both deserve the same desktop card.
+			if (typeof slot.id !== 'string' || slot.id.length === 0) {
+				return { node, serviceName: humanizeNodeTypeName(node.type) };
+			}
 			if (!input.accessibleCredentialIds.has(slot.id)) {
 				return { node, serviceName: humanizeNodeTypeName(node.type) };
 			}
@@ -244,7 +253,14 @@ function classifyOne(input: ClassifierInput): {
 	const isScheduleOrPoll =
 		summary.kind === 'schedule' || summary.kind === 'poll' || summary.kind === 'webhook';
 
-	if (tagged && (missingCredential || (!input.active && isScheduleOrPoll))) {
+	// Missing credentials block execution regardless of source: a user-built
+	// workflow with an unconfigured Gmail node belongs in actionNeeded just
+	// as much as a desktop-assistant-promoted one. Activation-required only
+	// fires for desktop-assistant workflows — plenty of user-built workflows
+	// are intentionally inactive (templates, drafts) and shouldn't be nagged.
+	if (missingCredential) {
+		bucket = 'actionNeeded';
+	} else if (tagged && !input.active && isScheduleOrPoll) {
 		bucket = 'actionNeeded';
 	} else if (tagged && input.active && isScheduleOrPoll) {
 		bucket = 'upcoming';

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.classifier.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.classifier.ts
@@ -87,9 +87,59 @@ export function deriveSourceLabel(displayName: string): string {
 }
 
 /**
- * Compute the next run time for a schedule trigger node. Only the
- * `cronExpression` mode is supported; other interval forms return null
- * (the classifier treats null as "ambiguous, fall through to no preview").
+ * Translate the first entry of a Schedule Trigger node's `rule.interval`
+ * array into a 5-field cron expression. Supports the structured forms n8n's
+ * Schedule Trigger UI produces (`field: 'days' | 'weeks' | 'months' | 'hours' | 'cronExpression'`,
+ * plus default 'days' when `field` is omitted) and rejects sub-minute
+ * granularities (`seconds`/`minutes`) since they're not expressible in
+ * 5-field cron and the BFF preview only needs minute-resolution.
+ *
+ * Returns null when the entry is missing, malformed, or sub-minute.
+ */
+export function toCronExpression(entry: Record<string, unknown> | undefined): string | null {
+	if (!entry) return null;
+	const field = typeof entry.field === 'string' ? entry.field : 'days';
+
+	if (field === 'cronExpression') {
+		const expr = entry.expression;
+		return typeof expr === 'string' && expr.trim().length > 0 ? expr.trim() : null;
+	}
+
+	// Sub-minute granularities are not expressible in 5-field cron.
+	if (field === 'seconds' || field === 'minutes') return null;
+
+	const minute = typeof entry.triggerAtMinute === 'number' ? entry.triggerAtMinute : 0;
+	const hour = typeof entry.triggerAtHour === 'number' ? entry.triggerAtHour : 0;
+
+	if (field === 'hours') {
+		const step = typeof entry.hoursInterval === 'number' ? entry.hoursInterval : 1;
+		return `${minute} */${step} * * *`;
+	}
+	if (field === 'days') {
+		const step = typeof entry.daysInterval === 'number' ? entry.daysInterval : 1;
+		return `${minute} ${hour} */${step} * *`;
+	}
+	if (field === 'weeks') {
+		const weekdays = Array.isArray(entry.triggerAtDayOfWeek)
+			? (entry.triggerAtDayOfWeek as unknown[]).filter((d) => typeof d === 'number').join(',')
+			: '*';
+		return `${minute} ${hour} * * ${weekdays || '*'}`;
+	}
+	if (field === 'months') {
+		const step = typeof entry.monthsInterval === 'number' ? entry.monthsInterval : 1;
+		const dayOfMonth =
+			typeof entry.triggerAtDayOfMonth === 'number' ? entry.triggerAtDayOfMonth : 1;
+		return `${minute} ${hour} ${dayOfMonth} */${step} *`;
+	}
+	return null;
+}
+
+/**
+ * Compute the next run time for a schedule trigger node. Supports n8n's
+ * structured rule forms (`field: 'days' | 'weeks' | 'months' | 'hours' | 'cronExpression'`)
+ * via {@link toCronExpression}. Sub-minute granularities and malformed
+ * inputs return null (the classifier treats null as "ambiguous, fall
+ * through to no preview").
  *
  * Exported for unit testing.
  */
@@ -97,20 +147,18 @@ export function deriveNextRunAt(
 	node: INode,
 	options: { timezone?: string; now?: Date } = {},
 ): string | null {
-	const interval = node.parameters?.rule;
+	const rule = node.parameters?.rule;
 	if (
-		!interval ||
-		typeof interval !== 'object' ||
-		!('interval' in interval) ||
-		!Array.isArray((interval as { interval: unknown[] }).interval)
+		!rule ||
+		typeof rule !== 'object' ||
+		!('interval' in rule) ||
+		!Array.isArray((rule as { interval: unknown[] }).interval)
 	) {
 		return null;
 	}
-	const entries = (interval as { interval: Array<Record<string, unknown>> }).interval;
-	const first = entries[0];
-	if (!first || first.field !== 'cronExpression') return null;
-	const expression = first.expression;
-	if (typeof expression !== 'string' || expression.trim().length === 0) return null;
+	const entries = (rule as { interval: Array<Record<string, unknown>> }).interval;
+	const expression = toCronExpression(entries[0]);
+	if (!expression) return null;
 
 	// Lazy-load: cron-parser is only needed for desktop-assistant tasks
 	// classification; avoid pulling it into the boot path for every cli build.

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.classifier.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.classifier.ts
@@ -318,21 +318,21 @@ function classifyOne(input: ClassifierInput): {
 		summary.kind === 'schedule' || summary.kind === 'poll' || summary.kind === 'webhook';
 
 	// Bucketing precedence:
-	//  1. Missing credentials block execution regardless of source: a user-built
-	//     workflow with an unconfigured Gmail node belongs in actionNeeded just
-	//     as much as a desktop-assistant-promoted one.
-	//  2. Activation-required is desktop-assistant-only — plenty of user-built
-	//     workflows are intentionally inactive (templates, drafts) and shouldn't
-	//     be nagged.
-	//  3. Active autonomous-trigger workflows (schedule/poll/webhook) go to
-	//     upcoming regardless of source. readyToRun is reserved for
-	//     manually-triggered workflows; anything that fires on its own —
-	//     time-based or webhook-driven — belongs in upcoming.
+	//  1. Missing credentials block execution regardless of source.
+	//  2. Inactive autonomous-trigger workflows (schedule/poll/webhook) go to
+	//     actionNeeded — they were intended to run on their own but their
+	//     trigger is dormant. Manual-trigger workflows are excluded because
+	//     'inactive' is their normal resting state (the user fires them on
+	//     demand).
+	//  3. Active autonomous-trigger workflows go to upcoming regardless of
+	//     source. readyToRun is reserved for manually-triggered workflows;
+	//     anything that fires on its own — time-based or webhook-driven —
+	//     belongs in upcoming.
 	//  4. Tagged manual-trigger workflows go to readyToRun.
 	//  5. Everything else user-built falls through to readyToRun.
 	if (missingCredential) {
 		bucket = 'actionNeeded';
-	} else if (tagged && !input.active && isScheduleOrPoll) {
+	} else if (!input.active && isScheduleOrPoll) {
 		bucket = 'actionNeeded';
 	} else if (input.active && isScheduleOrPoll) {
 		bucket = 'upcoming';

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.classifier.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.classifier.ts
@@ -44,6 +44,14 @@ const WEBHOOK_TRIGGER_TYPE = 'n8n-nodes-base.webhook';
 
 const TRIGGER_TYPE_SUFFIXES = ['Trigger', 'trigger'];
 
+type Bucket = 'actionNeeded' | 'upcoming' | 'readyToRun';
+
+/** Strip a trailing " Trigger" word (case-insensitive). Used to turn
+ *  display names like "Gmail Trigger" into the service name "Gmail". */
+function stripTriggerSuffix(displayName: string): string {
+	return displayName.replace(/\s+trigger\s*$/i, '').trim();
+}
+
 /**
  * Loose poll-trigger heuristic. Real polling triggers in `n8n-nodes-base`
  * all end in "Trigger" and are not the schedule/webhook/manual trigger
@@ -87,9 +95,7 @@ function runsLocally(nodes: INode[]): boolean {
  * Exported for unit testing.
  */
 export function deriveSourceLabel(displayName: string): string {
-	const stripped = displayName.replace(/\s+trigger\s*$/i, '').trim();
-	const lower = stripped.toLowerCase();
-	return `On new ${lower} message`;
+	return `On new ${stripTriggerSuffix(displayName).toLowerCase()} message`;
 }
 
 /**
@@ -273,17 +279,13 @@ function findMissingCredentialNode(
 }
 
 function deriveDescription(
-	bucket: 'actionNeeded' | 'upcoming' | 'readyToRun',
-	trigger: INode | undefined,
+	bucket: Bucket,
 	summary: DesktopAssistantTriggerSummary,
 	missingCredential: { serviceName: string } | undefined,
 ): string {
 	if (bucket === 'actionNeeded') {
 		if (missingCredential) {
-			// Strip a trailing " Trigger" so we get "Gmail needs credential", not
-			// "Gmail Trigger needs credential".
-			const service = missingCredential.serviceName.replace(/\s+Trigger\s*$/i, '');
-			return `${service} needs credential`;
+			return `${stripTriggerSuffix(missingCredential.serviceName)} needs credential`;
 		}
 		return 'Activation required';
 	}
@@ -293,16 +295,16 @@ function deriveDescription(
 		}
 		return `Next run at ${summary.nextRunAt}`;
 	}
-	// readyToRun
+	// readyToRun — manual and "other" triggers have no useful one-liner; only
+	// poll/webhook surface their source label.
 	if (summary.kind === 'poll' || summary.kind === 'webhook') {
 		return summary.sourceLabel;
 	}
-	if (trigger?.type === MANUAL_TRIGGER_TYPE) return '';
 	return '';
 }
 
 function classifyOne(input: ClassifierInput): {
-	bucket: 'actionNeeded' | 'upcoming' | 'readyToRun' | null;
+	bucket: Bucket | null;
 	card: DesktopAssistantTaskCard;
 } {
 	const trigger = findFirstTrigger(input.nodes);
@@ -310,7 +312,7 @@ function classifyOne(input: ClassifierInput): {
 	const tagged = hasDesktopAssistantTag(input.tags);
 	const missingCredential = findMissingCredentialNode(input);
 
-	let bucket: 'actionNeeded' | 'upcoming' | 'readyToRun' | null = null;
+	let bucket: Bucket | null = null;
 
 	const isScheduleOrPoll =
 		summary.kind === 'schedule' || summary.kind === 'poll' || summary.kind === 'webhook';
@@ -341,8 +343,7 @@ function classifyOne(input: ClassifierInput): {
 		bucket = 'readyToRun';
 	}
 
-	const description =
-		bucket === null ? '' : deriveDescription(bucket, trigger, summary, missingCredential);
+	const description = bucket === null ? '' : deriveDescription(bucket, summary, missingCredential);
 
 	const card: DesktopAssistantTaskCard = {
 		workflowId: input.workflowId,

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.controller.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.controller.ts
@@ -1,0 +1,82 @@
+import {
+	DesktopAssistantPromoteRequestDto,
+	DesktopAssistantTaskRequestDto,
+	type DesktopAssistantPromoteResponse,
+	type DesktopAssistantTaskResponse,
+	type DesktopAssistantTasksResponse,
+} from '@n8n/api-types';
+import type { AuthenticatedRequest } from '@n8n/db';
+import { Body, Get, GlobalScope, Post, Query, RestController } from '@n8n/decorators';
+
+import { DesktopAssistantService } from './desktop-assistant.service';
+
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+
+import { InstanceAiSettingsService } from '../instance-ai-settings.service';
+
+/**
+ * REST surface for the n8n personal-automation desktop assistant.
+ *
+ * All routes are gated by the same `instanceAi:message` scope as the rest of
+ * the instance-ai module and by an explicit Instance-AI-enabled check, so
+ * the desktop assistant can never come online without Instance AI itself
+ * being enabled on the instance.
+ */
+@RestController('/desktop-assistant')
+export class DesktopAssistantController {
+	constructor(
+		private readonly desktopAssistantService: DesktopAssistantService,
+		private readonly settingsService: InstanceAiSettingsService,
+	) {}
+
+	private requireEnabled(): void {
+		if (!this.settingsService.isInstanceAiEnabled()) {
+			throw new ForbiddenError('Instance AI is disabled');
+		}
+	}
+
+	@Get('/tasks')
+	@GlobalScope('instanceAi:message')
+	async getTasks(req: AuthenticatedRequest): Promise<DesktopAssistantTasksResponse> {
+		this.requireEnabled();
+		return await this.desktopAssistantService.getTasks(req.user);
+	}
+
+	@Post('/task')
+	@GlobalScope('instanceAi:message')
+	async triggerTask(
+		req: AuthenticatedRequest,
+		_res: unknown,
+		@Body body: DesktopAssistantTaskRequestDto,
+	): Promise<DesktopAssistantTaskResponse> {
+		this.requireEnabled();
+		return await this.desktopAssistantService.triggerTask(req.user, body);
+	}
+
+	@Post('/promote-thread')
+	@GlobalScope('instanceAi:message')
+	async promoteThread(
+		req: AuthenticatedRequest,
+		_res: unknown,
+		@Body body: DesktopAssistantPromoteRequestDto,
+	): Promise<DesktopAssistantPromoteResponse> {
+		this.requireEnabled();
+		return await this.desktopAssistantService.promoteThread(req.user, body);
+	}
+
+	@Get('/history')
+	@GlobalScope('instanceAi:message')
+	async getHistory(
+		req: AuthenticatedRequest,
+		_res: unknown,
+		@Query query: { limit?: string; firstId?: string; lastId?: string },
+	) {
+		this.requireEnabled();
+		const parsedLimit = query.limit ? Number.parseInt(query.limit, 10) : undefined;
+		return await this.desktopAssistantService.getHistory(req.user, {
+			limit: Number.isFinite(parsedLimit) ? parsedLimit : undefined,
+			firstId: query.firstId,
+			lastId: query.lastId,
+		});
+	}
+}

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.helpers.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.helpers.ts
@@ -1,0 +1,150 @@
+/**
+ * Pure helpers extracted from `desktop-assistant.service.ts`. Nothing here
+ * touches DI or the database — these are deterministic functions over
+ * request payloads, workflow JSON, and stored event-bus state.
+ */
+import type { DesktopAssistantTaskRequest } from '@n8n/api-types';
+import type { StoredEvent } from '@n8n/instance-ai';
+
+import type { PROMOTED_FROM_THREAD_ID_KEY } from './constants';
+
+// ── Message composition ─────────────────────────────────────────────────────
+
+/** Compose the one-shot task message that gets handed to Instance AI. */
+export function composeOneShotMessage(body: DesktopAssistantTaskRequest): string {
+	const lines: string[] = [body.prompt.trim()];
+	if (body.context?.appHint) {
+		lines.push('', `Currently looking at: ${body.context.appHint}`);
+	}
+	if (body.context?.selectedText) {
+		lines.push('', 'Selected text:', '```', body.context.selectedText, '```');
+	}
+	return lines.join('\n');
+}
+
+/** Compose the promote-thread message: grounds the build on the original
+ *  prompt and nudges the model to pick a short, emoji-led workflow name. */
+export function composePromoteMessage(originalPrompt: string, name: string | undefined): string {
+	const trimmedName = name?.trim();
+	const intro = trimmedName
+		? `Promote this idea into a real workflow. Use the name "${trimmedName}" (prepend a fitting emoji if it does not already start with one):`
+		: 'Promote this idea into a real workflow. Pick a short descriptive name for it as part of the build, and start that name with a single emoji that captures what the workflow does:';
+	return `${intro}\n\n${originalPrompt}`;
+}
+
+// ── Display helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Extract a leading emoji cluster from a string. Returns `{ emoji, rest }` where
+ * `rest` has the emoji and any following whitespace stripped. If the string does
+ * not start with an emoji, `emoji` is `undefined` and `rest` is the original
+ * input.
+ *
+ * Supports common cases including zero-width-joiner sequences (e.g. 👨‍💻)
+ * and emoji-variation selectors. We intentionally keep the regex narrow to
+ * `Extended_Pictographic` so plain text starting with a number or symbol is not
+ * mistaken for an emoji.
+ */
+export function splitLeadingEmoji(input: string): { emoji?: string; rest: string } {
+	const match = input.match(
+		/^(\p{Extended_Pictographic}(?:\u200d\p{Extended_Pictographic})*\uFE0F?)\s*/u,
+	);
+	if (!match) return { rest: input };
+	return { emoji: match[1], rest: input.slice(match[0].length) };
+}
+
+/** Clamp a user-supplied history `limit` into a sane bounded range. */
+export function clampLimit(limit: number | undefined): number {
+	if (!limit || limit < 1) return 20;
+	if (limit > 100) return 100;
+	return limit;
+}
+
+// ── workflow_entity.meta.desktopAssistant ────────────────────────────────────
+
+export interface StoredDesktopAssistantMeta {
+	icon?: string;
+	[PROMOTED_FROM_THREAD_ID_KEY]?: string;
+}
+
+/** Read the optional `meta.desktopAssistant` blob written to `workflow_entity.meta`
+ *  by the promote post-build hook. Returns `undefined` for any missing or
+ *  malformed shape so callers don't need their own type guards. */
+export function readDesktopAssistantMeta(meta: unknown): StoredDesktopAssistantMeta | undefined {
+	if (!meta || typeof meta !== 'object') return undefined;
+	const candidate = (meta as { desktopAssistant?: unknown }).desktopAssistant;
+	if (!candidate || typeof candidate !== 'object') return undefined;
+	return candidate as StoredDesktopAssistantMeta;
+}
+
+// ── Build-outcome extraction (two orchestrator paths) ────────────────────────
+
+/**
+ * Inspect a stored SSE event and return the workflow id of a completed
+ * build-workflow planned task, or undefined otherwise.
+ *
+ * The `build-workflow` tool runs in a sub-agent / planned-task context, so
+ * its `tool-result` event is published on the sub-agent's thread, NOT on the
+ * parent promote thread. The signal that DOES reach the parent thread is
+ * `tasks-update`: each carries `planItems[]` where the build-workflow planned
+ * task has its `workflowId` populated, and the matching entry in `tasks[]`
+ * moves to status `'done'`. We require BOTH — a populated `workflowId` AND
+ * a `done` status — to avoid acting on an in-flight task that already has its
+ * id slot allocated.
+ */
+export function extractBuiltWorkflowId(storedEvent: StoredEvent): string | undefined {
+	const ev = storedEvent.event;
+	if (ev.type !== 'tasks-update') return undefined;
+	const payload = ev.payload as {
+		tasks?: { tasks?: Array<{ id?: unknown; status?: unknown }> };
+		planItems?: Array<{ id?: unknown; kind?: unknown; workflowId?: unknown }>;
+	};
+	const planItems = payload.planItems;
+	const taskList = payload.tasks?.tasks;
+	if (!Array.isArray(planItems) || !Array.isArray(taskList)) return undefined;
+
+	const doneTaskIds = new Set<string>();
+	for (const task of taskList) {
+		if (typeof task.id === 'string' && task.status === 'done') doneTaskIds.add(task.id);
+	}
+
+	for (const item of planItems) {
+		if (item.kind !== 'build-workflow') continue;
+		if (typeof item.workflowId !== 'string') continue;
+		if (typeof item.id !== 'string') continue;
+		if (!doneTaskIds.has(item.id)) continue;
+		return item.workflowId;
+	}
+	return undefined;
+}
+
+/**
+ * Read the workflow id produced by a workflow-loop build for the given run
+ * from `thread.metadata.instanceAiWorkflowLoop`. The workflow loop persists
+ * a `lastBuildOutcome` per work item; we pick the one whose `runId` matches
+ * the promote run we kicked off and that was successfully submitted.
+ *
+ * Returns `undefined` when no such outcome exists (e.g. the run finished
+ * without ever invoking the workflow builder, the build failed, or the
+ * metadata structure changed under us).
+ */
+export function extractWorkflowLoopBuildOutcome(
+	metadata: unknown,
+	runId: string,
+): string | undefined {
+	if (!metadata || typeof metadata !== 'object') return undefined;
+	const loop = (metadata as { instanceAiWorkflowLoop?: unknown }).instanceAiWorkflowLoop;
+	if (!loop || typeof loop !== 'object') return undefined;
+	for (const workItem of Object.values(loop as Record<string, unknown>)) {
+		if (!workItem || typeof workItem !== 'object') continue;
+		const outcome = (workItem as { lastBuildOutcome?: unknown }).lastBuildOutcome;
+		if (!outcome || typeof outcome !== 'object') continue;
+		const o = outcome as { runId?: unknown; submitted?: unknown; workflowId?: unknown };
+		if (o.runId !== runId) continue;
+		if (o.submitted !== true) continue;
+		if (typeof o.workflowId === 'string' && o.workflowId.length > 0) {
+			return o.workflowId;
+		}
+	}
+	return undefined;
+}

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.helpers.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.helpers.ts
@@ -40,17 +40,24 @@ export function composePromoteMessage(originalPrompt: string, name: string | und
  * not start with an emoji, `emoji` is `undefined` and `rest` is the original
  * input.
  *
- * Supports common cases including zero-width-joiner sequences (e.g. 👨‍💻)
- * and emoji-variation selectors. We intentionally keep the regex narrow to
- * `Extended_Pictographic` so plain text starting with a number or symbol is not
- * mistaken for an emoji.
+ * Handles:
+ *  - Plain pictographics (🍌)
+ *  - Variation-selector-16 presentation (⚠️)
+ *  - Skin-tone modifiers attached without ZWJ (👍🏽)
+ *  - ZWJ sequences with optional modifiers (👨‍💻, 👨🏽‍💻)
+ *  - Flag sequences as pairs of Regional_Indicator codepoints (🇩🇪)
+ *
+ * Intentionally narrow to emoji classes so plain text starting with a number
+ * or punctuation is not mistaken for an emoji.
  */
+const LEADING_EMOJI_REGEX =
+	/^(?:\p{Regional_Indicator}\p{Regional_Indicator}|\p{Extended_Pictographic}(?:\p{Emoji_Modifier}|\uFE0F)?(?:\u200d\p{Extended_Pictographic}(?:\p{Emoji_Modifier}|\uFE0F)?)*)\s*/u;
+
 export function splitLeadingEmoji(input: string): { emoji?: string; rest: string } {
-	const match = input.match(
-		/^(\p{Extended_Pictographic}(?:\u200d\p{Extended_Pictographic})*\uFE0F?)\s*/u,
-	);
+	const match = input.match(LEADING_EMOJI_REGEX);
 	if (!match) return { rest: input };
-	return { emoji: match[1], rest: input.slice(match[0].length) };
+	const emoji = match[0].replace(/\s+$/, '');
+	return { emoji, rest: input.slice(match[0].length) };
 }
 
 /** Clamp a user-supplied history `limit` into a sane bounded range. */

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
@@ -55,6 +55,12 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
 const PROMOTE_FINALIZE_TIMEOUT_MS = 5 * 60 * 1000;
 
+const EMPTY_HISTORY = Object.freeze({
+	results: [],
+	estimated: false,
+	count: 0,
+} satisfies Awaited<ReturnType<ExecutionService['findRangeWithCount']>>);
+
 /**
  * BFF for the n8n personal-automation desktop assistant.
  *
@@ -209,9 +215,8 @@ export class DesktopAssistantService {
 		user: User,
 		body: DesktopAssistantTaskRequest,
 	): Promise<DesktopAssistantTaskResponse> {
-		if (!body.prompt || body.prompt.trim().length === 0) {
-			throw new BadRequestError('A non-empty prompt is required');
-		}
+		// The DTO already enforces a non-empty trimmed prompt via Zod; no
+		// redundant validation needed here.
 		const threadId = randomUUID();
 		const projectId = await this.resolvePersonalProjectId(user);
 		await this.memoryService.ensureThread(user.id, threadId, projectId);
@@ -309,7 +314,7 @@ export class DesktopAssistantService {
 		const finalise = (workflowId: string) => {
 			handled = true;
 			unsubscribe();
-			this.finalizePromotedWorkflow(user, threadId, workflowId).catch((error: unknown) => {
+			this.finalizePromotedWorkflow(threadId, workflowId).catch((error: unknown) => {
 				this.logger.warn('Failed to finalise promoted workflow', {
 					threadId,
 					workflowId,
@@ -360,11 +365,7 @@ export class DesktopAssistantService {
 		return unsubscribe;
 	}
 
-	private async finalizePromotedWorkflow(
-		_user: User,
-		threadId: string,
-		workflowId: string,
-	): Promise<void> {
+	private async finalizePromotedWorkflow(threadId: string, workflowId: string): Promise<void> {
 		await this.applyDesktopAssistantTag(workflowId);
 		await this.writeDesktopAssistantMeta(workflowId, threadId);
 		await this.memoryService.updateThread(threadId, {
@@ -456,9 +457,7 @@ export class DesktopAssistantService {
 		const accessibleWorkflowIds = await this.workflowSharingService.getSharedWorkflowIds(user, {
 			scopes: ['workflow:read'],
 		});
-		if (accessibleWorkflowIds.length === 0 || tagId === null) {
-			return { results: [], estimated: false, count: 0 };
-		}
+		if (accessibleWorkflowIds.length === 0 || tagId === null) return EMPTY_HISTORY;
 
 		const taggedWorkflowIds = await this.workflowTagMappingRepository
 			.find({
@@ -467,9 +466,7 @@ export class DesktopAssistantService {
 			})
 			.then((rows) => rows.map((r) => r.workflowId));
 
-		if (taggedWorkflowIds.length === 0) {
-			return { results: [], estimated: false, count: 0 };
-		}
+		if (taggedWorkflowIds.length === 0) return EMPTY_HISTORY;
 
 		// Skip executions of archived workflows — if the user archived a
 		// desktop-assistant workflow it should drop out of the history view too.
@@ -478,9 +475,7 @@ export class DesktopAssistantService {
 			select: { id: true },
 		});
 		const liveTaggedWorkflowIds = liveTaggedRows.map((row) => row.id);
-		if (liveTaggedWorkflowIds.length === 0) {
-			return { results: [], estimated: false, count: 0 };
-		}
+		if (liveTaggedWorkflowIds.length === 0) return EMPTY_HISTORY;
 
 		const sharingOptions = await this.executionService.buildSharingOptions('workflow:read');
 		return await this.executionService.findRangeWithCount({

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
@@ -448,17 +448,40 @@ function readDesktopAssistantMeta(meta: unknown): StoredDesktopAssistantMeta | u
 }
 
 /**
- * Inspect a stored SSE event and return the workflow id of a successful
- * build-workflow outcome, or undefined otherwise.
+ * Inspect a stored SSE event and return the workflow id of a completed
+ * build-workflow planned task, or undefined otherwise.
+ *
+ * The `build-workflow` tool runs in a sub-agent / planned-task context, so
+ * its `tool-result` event is published on the sub-agent's thread, NOT on the
+ * parent promote thread. The signal that DOES reach the parent thread is
+ * `tasks-update`: each carries `planItems[]` where the build-workflow planned
+ * task has its `workflowId` populated, and the matching entry in `tasks[]`
+ * moves to status `'done'`. We require BOTH — a populated `workflowId` AND
+ * a `done` status — to avoid acting on an in-flight task that already has its
+ * id slot allocated.
  */
 function extractBuiltWorkflowId(storedEvent: StoredEvent): string | undefined {
 	const ev = storedEvent.event;
-	if (ev.type !== 'tool-result') return undefined;
-	const payload = ev.payload as { result?: unknown };
-	const result = payload.result;
-	if (!result || typeof result !== 'object') return undefined;
-	const rec = result as Record<string, unknown>;
-	if (rec.submitted !== true) return undefined;
-	if (typeof rec.workflowId !== 'string') return undefined;
-	return rec.workflowId;
+	if (ev.type !== 'tasks-update') return undefined;
+	const payload = ev.payload as {
+		tasks?: { tasks?: Array<{ id?: unknown; status?: unknown }> };
+		planItems?: Array<{ id?: unknown; kind?: unknown; workflowId?: unknown }>;
+	};
+	const planItems = payload.planItems;
+	const taskList = payload.tasks?.tasks;
+	if (!Array.isArray(planItems) || !Array.isArray(taskList)) return undefined;
+
+	const doneTaskIds = new Set<string>();
+	for (const task of taskList) {
+		if (typeof task.id === 'string' && task.status === 'done') doneTaskIds.add(task.id);
+	}
+
+	for (const item of planItems) {
+		if (item.kind !== 'build-workflow') continue;
+		if (typeof item.workflowId !== 'string') continue;
+		if (typeof item.id !== 'string') continue;
+		if (!doneTaskIds.has(item.id)) continue;
+		return item.workflowId;
+	}
+	return undefined;
 }

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
@@ -1,0 +1,464 @@
+import type {
+	DesktopAssistantPromoteRequest,
+	DesktopAssistantPromoteResponse,
+	DesktopAssistantTaskRequest,
+	DesktopAssistantTaskResponse,
+	DesktopAssistantTasksResponse,
+} from '@n8n/api-types';
+import { Logger } from '@n8n/backend-common';
+import type { User } from '@n8n/db';
+import {
+	ExecutionRepository,
+	TagRepository,
+	WorkflowRepository,
+	WorkflowTagMappingRepository,
+} from '@n8n/db';
+import { Service } from '@n8n/di';
+import type { StoredEvent } from '@n8n/instance-ai';
+// eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
+import { In } from '@n8n/typeorm';
+import type { ExecutionStatus } from 'n8n-workflow';
+import { randomUUID } from 'node:crypto';
+
+import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
+import { ExecutionService } from '@/executions/execution.service';
+import { ProjectService } from '@/services/project.service.ee';
+import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
+import { WorkflowSharingService } from '@/workflows/workflow-sharing.service';
+
+import {
+	DESKTOP_ASSISTANT_TAG,
+	PROMOTED_FROM_THREAD_ID_KEY,
+	PROMOTED_WORKFLOW_ID_KEY,
+} from './constants';
+import { classifyWorkflowsForDesktopAssistant } from './desktop-assistant.classifier';
+import type { ClassifierInput } from './desktop-assistant.classifier';
+
+import { InProcessEventBus } from '../event-bus/in-process-event-bus';
+import { InstanceAiMemoryService } from '../instance-ai-memory.service';
+import { InstanceAiService } from '../instance-ai.service';
+
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
+import { NotFoundError } from '@/errors/response-errors/not-found.error';
+
+const PROMOTE_FINALIZE_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * BFF for the n8n personal-automation desktop assistant.
+ *
+ * Responsibilities:
+ * - Classify the user's accessible workflows into the three desktop assistant
+ *   buckets (actionNeeded / upcoming / readyToRun).
+ * - Trigger a one-shot Instance AI run with the desktop-assistant prompt mode.
+ * - Promote an Instance AI thread into a real, editable workflow by handing
+ *   the thread's original intent back to the workflow builder.
+ * - Surface the execution history for desktop-assistant-tagged workflows.
+ *
+ * All endpoints are gated by the Instance AI feature flag at the controller
+ * layer; this service assumes the gate has been checked.
+ */
+@Service()
+export class DesktopAssistantService {
+	/** Memoised id of the `desktop-assistant` tag. Null when the tag has not
+	 * been created yet on this instance. Refreshed lazily on first access
+	 * and after a successful promote. */
+	private desktopAssistantTagId: string | null = null;
+
+	constructor(
+		private readonly logger: Logger,
+		private readonly instanceAiService: InstanceAiService,
+		private readonly memoryService: InstanceAiMemoryService,
+		private readonly eventBus: InProcessEventBus,
+		private readonly workflowRepository: WorkflowRepository,
+		private readonly workflowFinderService: WorkflowFinderService,
+		private readonly workflowSharingService: WorkflowSharingService,
+		private readonly tagRepository: TagRepository,
+		private readonly workflowTagMappingRepository: WorkflowTagMappingRepository,
+		private readonly credentialsFinderService: CredentialsFinderService,
+		private readonly executionService: ExecutionService,
+		private readonly executionRepository: ExecutionRepository,
+		private readonly projectService: ProjectService,
+	) {}
+
+	// ── tasks list ───────────────────────────────────────────────────────────
+
+	async getTasks(user: User): Promise<DesktopAssistantTasksResponse> {
+		const accessibleWorkflowIds = await this.workflowSharingService.getSharedWorkflowIds(user, {
+			scopes: ['workflow:read'],
+		});
+		if (accessibleWorkflowIds.length === 0) {
+			return { actionNeeded: [], upcoming: [], readyToRun: [] };
+		}
+
+		const workflows = await this.workflowFinderService.findWorkflowsByIdsForUser(
+			accessibleWorkflowIds,
+			user,
+			['workflow:read'],
+		);
+
+		// Fetch tags for each workflow in one round-trip via the join column.
+		const workflowsWithTags = await this.workflowRepository.find({
+			where: { id: In(accessibleWorkflowIds) },
+			relations: { tags: true },
+			select: { id: true, tags: { name: true } },
+		});
+		const tagsByWorkflowId = new Map<string, Array<{ name: string }>>();
+		for (const wf of workflowsWithTags) {
+			tagsByWorkflowId.set(
+				wf.id,
+				(wf.tags ?? []).map((t) => ({ name: t.name })),
+			);
+		}
+
+		const credentials = await this.credentialsFinderService.findCredentialsForUser(user, [
+			'credential:read',
+		]);
+		const accessibleCredentialIds = new Set(credentials.map((c) => c.id));
+
+		const lastExecutionByWorkflowId =
+			await this.fetchLastExecutionByWorkflowId(accessibleWorkflowIds);
+
+		const inputs: ClassifierInput[] = workflows.map((workflow) => {
+			const emojiIcon = readDesktopAssistantMeta(workflow.meta)?.icon;
+			const lastExec = lastExecutionByWorkflowId.get(workflow.id);
+			return {
+				workflowId: workflow.id,
+				name: workflow.name,
+				active: workflow.active,
+				nodes: workflow.nodes,
+				tags: tagsByWorkflowId.get(workflow.id) ?? [],
+				settings: { timezone: workflow.settings?.timezone },
+				lastExecution: lastExec
+					? {
+							id: lastExec.id,
+							status: lastExec.status,
+							startedAt: lastExec.startedAt,
+						}
+					: undefined,
+				emojiIcon,
+				accessibleCredentialIds,
+			};
+		});
+
+		return classifyWorkflowsForDesktopAssistant(inputs);
+	}
+
+	private async fetchLastExecutionByWorkflowId(
+		workflowIds: string[],
+	): Promise<Map<string, { id: string; status: ExecutionStatus; startedAt: string }>> {
+		const map = new Map<string, { id: string; status: ExecutionStatus; startedAt: string }>();
+		if (workflowIds.length === 0) return map;
+
+		// Pull the latest execution per workflow with a single bounded query.
+		// We over-fetch (20 per workflow) and reduce; sufficient for the BFF
+		// surface, avoids one query per workflow.
+		const rows = await this.executionRepository.find({
+			where: { workflowId: In(workflowIds) },
+			order: { startedAt: 'DESC' },
+			take: workflowIds.length * 5,
+			select: { id: true, workflowId: true, status: true, startedAt: true },
+		});
+
+		for (const row of rows) {
+			if (!row.startedAt) continue;
+			if (map.has(row.workflowId)) continue;
+			map.set(row.workflowId, {
+				id: row.id,
+				status: row.status,
+				startedAt: row.startedAt.toISOString(),
+			});
+		}
+		return map;
+	}
+
+	// ── one-shot task ────────────────────────────────────────────────────────
+
+	async triggerTask(
+		user: User,
+		body: DesktopAssistantTaskRequest,
+	): Promise<DesktopAssistantTaskResponse> {
+		if (!body.prompt || body.prompt.trim().length === 0) {
+			throw new BadRequestError('A non-empty prompt is required');
+		}
+		const threadId = randomUUID();
+		const projectId = await this.resolvePersonalProjectId(user);
+		await this.memoryService.ensureThread(user.id, threadId, projectId);
+
+		const composedMessage = composeOneShotMessage(body);
+		const runId = this.instanceAiService.startRun(
+			user,
+			threadId,
+			composedMessage,
+			undefined,
+			undefined,
+			undefined,
+			{ promptMode: 'desktop-assistant-one-shot' },
+		);
+		return { threadId, runId };
+	}
+
+	// ── promote thread ──────────────────────────────────────────────────────
+
+	async promoteThread(
+		user: User,
+		body: DesktopAssistantPromoteRequest,
+	): Promise<DesktopAssistantPromoteResponse> {
+		const ownership = await this.memoryService.checkThreadOwnership(user.id, body.threadId);
+		if (ownership === 'not_found') {
+			throw new NotFoundError(`Thread ${body.threadId} not found`);
+		}
+		if (ownership === 'other_user') {
+			throw new ForbiddenError('Not authorized for this thread');
+		}
+
+		// Idempotency: if a previous promote completed and produced a workflow
+		// the caller can still access, return the done envelope.
+		const existing = await this.readPromotedWorkflowId(user.id, body.threadId);
+		if (existing) {
+			const accessible = await this.workflowSharingService.getSharedWorkflowIds(user, {
+				scopes: ['workflow:read'],
+			});
+			if (accessible.includes(existing)) {
+				return {
+					status: 'done',
+					threadId: body.threadId,
+					workflowId: existing,
+				};
+			}
+			// The previously-promoted workflow is gone or not accessible — fall
+			// through and rebuild.
+		}
+
+		const originalPrompt = await this.recoverOriginalPrompt(body.threadId);
+		const buildPrompt = composePromoteMessage(originalPrompt, body.name);
+
+		// Subscribe BEFORE starting the run so we don't miss a fast build that
+		// emits its tool-result before we wire up the listener.
+		const cleanup = this.subscribeForBuildOutcome(user, body.threadId);
+
+		const runId = this.instanceAiService.startRun(
+			user,
+			body.threadId,
+			buildPrompt,
+			undefined,
+			undefined,
+			undefined,
+			{ promptMode: 'desktop-assistant-promote' },
+		);
+
+		// Hard-cap the listener so a stalled run does not leak a subscription.
+		setTimeout(cleanup, PROMOTE_FINALIZE_TIMEOUT_MS).unref();
+
+		return { status: 'building', threadId: body.threadId, runId };
+	}
+
+	private subscribeForBuildOutcome(user: User, threadId: string): () => void {
+		let handled = false;
+		const unsubscribe = this.eventBus.subscribe(threadId, (storedEvent: StoredEvent) => {
+			if (handled) return;
+			const built = extractBuiltWorkflowId(storedEvent);
+			if (!built) return;
+			handled = true;
+			unsubscribe();
+			this.finalizePromotedWorkflow(user, threadId, built).catch((error: unknown) => {
+				this.logger.warn('Failed to finalise promoted workflow', {
+					threadId,
+					workflowId: built,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			});
+		});
+		return unsubscribe;
+	}
+
+	private async finalizePromotedWorkflow(
+		_user: User,
+		threadId: string,
+		workflowId: string,
+	): Promise<void> {
+		await this.applyDesktopAssistantTag(workflowId);
+		await this.writeDesktopAssistantMeta(workflowId, threadId);
+		await this.memoryService.updateThread(threadId, {
+			metadata: { [PROMOTED_WORKFLOW_ID_KEY]: workflowId },
+		});
+	}
+
+	private async applyDesktopAssistantTag(workflowId: string): Promise<void> {
+		const tagId = await this.getOrCreateDesktopAssistantTagId();
+		const existing = await this.workflowTagMappingRepository.findOne({
+			where: { workflowId, tagId },
+		});
+		if (existing) return;
+		await this.workflowTagMappingRepository.insert({ workflowId, tagId });
+	}
+
+	private async writeDesktopAssistantMeta(workflowId: string, threadId: string): Promise<void> {
+		const workflow = await this.workflowRepository.findOne({
+			where: { id: workflowId },
+			select: ['id', 'meta'],
+		});
+		if (!workflow) return;
+		const existing = readDesktopAssistantMeta(workflow.meta) ?? {};
+		const nextMeta = {
+			...(workflow.meta ?? {}),
+			desktopAssistant: {
+				...existing,
+				[PROMOTED_FROM_THREAD_ID_KEY]: threadId,
+			},
+		};
+		await this.workflowRepository.update(workflowId, { meta: nextMeta });
+	}
+
+	private async getOrCreateDesktopAssistantTagId(): Promise<string> {
+		if (this.desktopAssistantTagId) return this.desktopAssistantTagId;
+		const existing = await this.tagRepository.findOne({
+			where: { name: DESKTOP_ASSISTANT_TAG },
+		});
+		if (existing) {
+			this.desktopAssistantTagId = existing.id;
+			return existing.id;
+		}
+		const created = this.tagRepository.create({ name: DESKTOP_ASSISTANT_TAG });
+		const saved = await this.tagRepository.save(created);
+		this.desktopAssistantTagId = saved.id;
+		return saved.id;
+	}
+
+	private async readPromotedWorkflowId(
+		userId: string,
+		threadId: string,
+	): Promise<string | undefined> {
+		const metadata = await this.memoryService.getThreadMetadata(userId, threadId);
+		const v = metadata?.[PROMOTED_WORKFLOW_ID_KEY];
+		return typeof v === 'string' ? v : undefined;
+	}
+
+	private async recoverOriginalPrompt(threadId: string): Promise<string> {
+		const messages = await this.memoryService.getThreadMessages('', threadId, {
+			limit: 50,
+			page: 0,
+		});
+		const firstUser = messages.messages.find((m) => m.role === 'user');
+		if (!firstUser) {
+			throw new BadRequestError(`Thread ${threadId} has no user message to promote`);
+		}
+		if (typeof firstUser.content === 'string') return firstUser.content;
+		// Best-effort: flatten content parts into a single string for the build prompt.
+		return JSON.stringify(firstUser.content);
+	}
+
+	private async resolvePersonalProjectId(user: User): Promise<string> {
+		// `ensureThread` requires a projectId; the desktop assistant always runs
+		// in the user's personal project.
+		const project = await this.projectService.getPersonalProject(user);
+		if (!project) {
+			throw new BadRequestError('No personal project available for this user');
+		}
+		return project.id;
+	}
+
+	// ── history ─────────────────────────────────────────────────────────────
+
+	async getHistory(
+		user: User,
+		query: { limit?: number; firstId?: string; lastId?: string },
+	): Promise<Awaited<ReturnType<ExecutionService['findRangeWithCount']>>> {
+		const tagId = await this.tryReadDesktopAssistantTagId();
+		const accessibleWorkflowIds = await this.workflowSharingService.getSharedWorkflowIds(user, {
+			scopes: ['workflow:read'],
+		});
+		if (accessibleWorkflowIds.length === 0 || tagId === null) {
+			return { results: [], estimated: false, count: 0 };
+		}
+
+		const taggedWorkflowIds = await this.workflowTagMappingRepository
+			.find({
+				where: { tagId, workflowId: In(accessibleWorkflowIds) },
+				select: { workflowId: true },
+			})
+			.then((rows) => rows.map((r) => r.workflowId));
+
+		if (taggedWorkflowIds.length === 0) {
+			return { results: [], estimated: false, count: 0 };
+		}
+
+		const sharingOptions = await this.executionService.buildSharingOptions('workflow:read');
+		return await this.executionService.findRangeWithCount({
+			kind: 'range',
+			user,
+			sharingOptions,
+			workflowId: taggedWorkflowIds,
+			range: {
+				limit: clampLimit(query.limit),
+				firstId: query.firstId,
+				lastId: query.lastId,
+			},
+			order: { startedAt: 'DESC' },
+		});
+	}
+
+	private async tryReadDesktopAssistantTagId(): Promise<string | null> {
+		if (this.desktopAssistantTagId) return this.desktopAssistantTagId;
+		const tag = await this.tagRepository.findOne({
+			where: { name: DESKTOP_ASSISTANT_TAG },
+		});
+		this.desktopAssistantTagId = tag?.id ?? null;
+		return this.desktopAssistantTagId;
+	}
+}
+
+// ── helpers ─────────────────────────────────────────────────────────────────
+
+function composeOneShotMessage(body: DesktopAssistantTaskRequest): string {
+	const lines: string[] = [body.prompt.trim()];
+	if (body.context?.appHint) {
+		lines.push('', `Currently looking at: ${body.context.appHint}`);
+	}
+	if (body.context?.selectedText) {
+		lines.push('', 'Selected text:', '```', body.context.selectedText, '```');
+	}
+	return lines.join('\n');
+}
+
+function composePromoteMessage(originalPrompt: string, name: string | undefined): string {
+	const trimmedName = name?.trim();
+	const intro = trimmedName
+		? `Promote this idea into a real workflow named "${trimmedName}":`
+		: 'Promote this idea into a real workflow:';
+	return `${intro}\n\n${originalPrompt}`;
+}
+
+function clampLimit(limit: number | undefined): number {
+	if (!limit || limit < 1) return 20;
+	if (limit > 100) return 100;
+	return limit;
+}
+
+interface StoredDesktopAssistantMeta {
+	icon?: string;
+	[PROMOTED_FROM_THREAD_ID_KEY]?: string;
+}
+
+function readDesktopAssistantMeta(meta: unknown): StoredDesktopAssistantMeta | undefined {
+	if (!meta || typeof meta !== 'object') return undefined;
+	const candidate = (meta as { desktopAssistant?: unknown }).desktopAssistant;
+	if (!candidate || typeof candidate !== 'object') return undefined;
+	return candidate as StoredDesktopAssistantMeta;
+}
+
+/**
+ * Inspect a stored SSE event and return the workflow id of a successful
+ * build-workflow outcome, or undefined otherwise.
+ */
+function extractBuiltWorkflowId(storedEvent: StoredEvent): string | undefined {
+	const ev = storedEvent.event;
+	if (ev.type !== 'tool-result') return undefined;
+	const payload = ev.payload as { result?: unknown };
+	const result = payload.result;
+	if (!result || typeof result !== 'object') return undefined;
+	const rec = result as Record<string, unknown>;
+	if (rec.submitted !== true) return undefined;
+	if (typeof rec.workflowId !== 'string') return undefined;
+	return rec.workflowId;
+}

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
@@ -34,6 +34,15 @@ import {
 } from './constants';
 import { classifyWorkflowsForDesktopAssistant } from './desktop-assistant.classifier';
 import type { ClassifierInput } from './desktop-assistant.classifier';
+import {
+	clampLimit,
+	composeOneShotMessage,
+	composePromoteMessage,
+	extractBuiltWorkflowId,
+	extractWorkflowLoopBuildOutcome,
+	readDesktopAssistantMeta,
+	splitLeadingEmoji,
+} from './desktop-assistant.helpers';
 import { computeNodesRequiringCredentialSetup } from './node-credential-requirements';
 
 import { InProcessEventBus } from '../event-bus/in-process-event-bus';
@@ -496,132 +505,4 @@ export class DesktopAssistantService {
 		this.desktopAssistantTagId = tag?.id ?? null;
 		return this.desktopAssistantTagId;
 	}
-}
-
-// ── helpers ─────────────────────────────────────────────────────────────────
-
-function composeOneShotMessage(body: DesktopAssistantTaskRequest): string {
-	const lines: string[] = [body.prompt.trim()];
-	if (body.context?.appHint) {
-		lines.push('', `Currently looking at: ${body.context.appHint}`);
-	}
-	if (body.context?.selectedText) {
-		lines.push('', 'Selected text:', '```', body.context.selectedText, '```');
-	}
-	return lines.join('\n');
-}
-
-function composePromoteMessage(originalPrompt: string, name: string | undefined): string {
-	const trimmedName = name?.trim();
-	const intro = trimmedName
-		? `Promote this idea into a real workflow. Use the name "${trimmedName}" (prepend a fitting emoji if it does not already start with one):`
-		: 'Promote this idea into a real workflow. Pick a short descriptive name for it as part of the build, and start that name with a single emoji that captures what the workflow does:';
-	return `${intro}\n\n${originalPrompt}`;
-}
-
-/**
- * Extract a leading emoji cluster from a string. Returns `{ emoji, rest }` where
- * `rest` has the emoji and any following whitespace stripped. If the string does
- * not start with an emoji, `emoji` is `undefined` and `rest` is the original
- * input.
- *
- * Supports common cases including zero-width-joiner sequences (e.g. 👨‍💻)
- * and emoji-variation selectors. We intentionally keep the regex narrow to
- * `Extended_Pictographic` so plain text starting with a number or symbol is not
- * mistaken for an emoji.
- */
-export function splitLeadingEmoji(input: string): { emoji?: string; rest: string } {
-	const match = input.match(
-		/^(\p{Extended_Pictographic}(?:\u200d\p{Extended_Pictographic})*\uFE0F?)\s*/u,
-	);
-	if (!match) return { rest: input };
-	return { emoji: match[1], rest: input.slice(match[0].length) };
-}
-
-function clampLimit(limit: number | undefined): number {
-	if (!limit || limit < 1) return 20;
-	if (limit > 100) return 100;
-	return limit;
-}
-
-interface StoredDesktopAssistantMeta {
-	icon?: string;
-	[PROMOTED_FROM_THREAD_ID_KEY]?: string;
-}
-
-function readDesktopAssistantMeta(meta: unknown): StoredDesktopAssistantMeta | undefined {
-	if (!meta || typeof meta !== 'object') return undefined;
-	const candidate = (meta as { desktopAssistant?: unknown }).desktopAssistant;
-	if (!candidate || typeof candidate !== 'object') return undefined;
-	return candidate as StoredDesktopAssistantMeta;
-}
-
-/**
- * Inspect a stored SSE event and return the workflow id of a completed
- * build-workflow planned task, or undefined otherwise.
- *
- * The `build-workflow` tool runs in a sub-agent / planned-task context, so
- * its `tool-result` event is published on the sub-agent's thread, NOT on the
- * parent promote thread. The signal that DOES reach the parent thread is
- * `tasks-update`: each carries `planItems[]` where the build-workflow planned
- * task has its `workflowId` populated, and the matching entry in `tasks[]`
- * moves to status `'done'`. We require BOTH — a populated `workflowId` AND
- * a `done` status — to avoid acting on an in-flight task that already has its
- * id slot allocated.
- */
-/**
- * Read the workflow id produced by a workflow-loop build for the given run
- * from `thread.metadata.instanceAiWorkflowLoop`. The workflow loop persists
- * a `lastBuildOutcome` per work item; we pick the one whose `runId` matches
- * the promote run we kicked off and that was successfully submitted.
- *
- * Returns `undefined` when no such outcome exists (e.g. the run finished
- * without ever invoking the workflow builder, the build failed, or the
- * metadata structure changed under us).
- */
-export function extractWorkflowLoopBuildOutcome(
-	metadata: unknown,
-	runId: string,
-): string | undefined {
-	if (!metadata || typeof metadata !== 'object') return undefined;
-	const loop = (metadata as { instanceAiWorkflowLoop?: unknown }).instanceAiWorkflowLoop;
-	if (!loop || typeof loop !== 'object') return undefined;
-	for (const workItem of Object.values(loop as Record<string, unknown>)) {
-		if (!workItem || typeof workItem !== 'object') continue;
-		const outcome = (workItem as { lastBuildOutcome?: unknown }).lastBuildOutcome;
-		if (!outcome || typeof outcome !== 'object') continue;
-		const o = outcome as { runId?: unknown; submitted?: unknown; workflowId?: unknown };
-		if (o.runId !== runId) continue;
-		if (o.submitted !== true) continue;
-		if (typeof o.workflowId === 'string' && o.workflowId.length > 0) {
-			return o.workflowId;
-		}
-	}
-	return undefined;
-}
-
-function extractBuiltWorkflowId(storedEvent: StoredEvent): string | undefined {
-	const ev = storedEvent.event;
-	if (ev.type !== 'tasks-update') return undefined;
-	const payload = ev.payload as {
-		tasks?: { tasks?: Array<{ id?: unknown; status?: unknown }> };
-		planItems?: Array<{ id?: unknown; kind?: unknown; workflowId?: unknown }>;
-	};
-	const planItems = payload.planItems;
-	const taskList = payload.tasks?.tasks;
-	if (!Array.isArray(planItems) || !Array.isArray(taskList)) return undefined;
-
-	const doneTaskIds = new Set<string>();
-	for (const task of taskList) {
-		if (typeof task.id === 'string' && task.status === 'done') doneTaskIds.add(task.id);
-	}
-
-	for (const item of planItems) {
-		if (item.kind !== 'build-workflow') continue;
-		if (typeof item.workflowId !== 'string') continue;
-		if (typeof item.id !== 'string') continue;
-		if (!doneTaskIds.has(item.id)) continue;
-		return item.workflowId;
-	}
-	return undefined;
 }

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
@@ -453,36 +453,26 @@ export class DesktopAssistantService {
 		user: User,
 		query: { limit?: number; firstId?: string; lastId?: string },
 	): Promise<Awaited<ReturnType<ExecutionService['findRangeWithCount']>>> {
-		const tagId = await this.tryReadDesktopAssistantTagId();
 		const accessibleWorkflowIds = await this.workflowSharingService.getSharedWorkflowIds(user, {
 			scopes: ['workflow:read'],
 		});
-		if (accessibleWorkflowIds.length === 0 || tagId === null) return EMPTY_HISTORY;
+		if (accessibleWorkflowIds.length === 0) return EMPTY_HISTORY;
 
-		const taggedWorkflowIds = await this.workflowTagMappingRepository
-			.find({
-				where: { tagId, workflowId: In(accessibleWorkflowIds) },
-				select: { workflowId: true },
-			})
-			.then((rows) => rows.map((r) => r.workflowId));
-
-		if (taggedWorkflowIds.length === 0) return EMPTY_HISTORY;
-
-		// Skip executions of archived workflows — if the user archived a
-		// desktop-assistant workflow it should drop out of the history view too.
-		const liveTaggedRows = await this.workflowRepository.find({
-			where: { id: In(taggedWorkflowIds), isArchived: false },
+		// Skip executions of archived workflows. Archive is a user signal of
+		// "I'm done with this"; their runs should drop out of the history view.
+		const liveRows = await this.workflowRepository.find({
+			where: { id: In(accessibleWorkflowIds), isArchived: false },
 			select: { id: true },
 		});
-		const liveTaggedWorkflowIds = liveTaggedRows.map((row) => row.id);
-		if (liveTaggedWorkflowIds.length === 0) return EMPTY_HISTORY;
+		const liveWorkflowIds = liveRows.map((row) => row.id);
+		if (liveWorkflowIds.length === 0) return EMPTY_HISTORY;
 
 		const sharingOptions = await this.executionService.buildSharingOptions('workflow:read');
 		return await this.executionService.findRangeWithCount({
 			kind: 'range',
 			user,
 			sharingOptions,
-			workflowId: liveTaggedWorkflowIds,
+			workflowId: liveWorkflowIds,
 			range: {
 				limit: clampLimit(query.limit),
 				firstId: query.firstId,
@@ -490,14 +480,5 @@ export class DesktopAssistantService {
 			},
 			order: { startedAt: 'DESC' },
 		});
-	}
-
-	private async tryReadDesktopAssistantTagId(): Promise<string | null> {
-		if (this.desktopAssistantTagId) return this.desktopAssistantTagId;
-		const tag = await this.tagRepository.findOne({
-			where: { name: DESKTOP_ASSISTANT_TAG },
-		});
-		this.desktopAssistantTagId = tag?.id ?? null;
-		return this.desktopAssistantTagId;
 	}
 }

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
@@ -17,14 +17,7 @@ import { Service } from '@n8n/di';
 import type { StoredEvent } from '@n8n/instance-ai';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In } from '@n8n/typeorm';
-import type {
-	ExecutionStatus,
-	INode,
-	INodeCredentialDescription,
-	INodeParameters,
-	INodeTypeDescription,
-} from 'n8n-workflow';
-import { NodeHelpers } from 'n8n-workflow';
+import type { ExecutionStatus } from 'n8n-workflow';
 import { randomUUID } from 'node:crypto';
 
 import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
@@ -41,6 +34,7 @@ import {
 } from './constants';
 import { classifyWorkflowsForDesktopAssistant } from './desktop-assistant.classifier';
 import type { ClassifierInput } from './desktop-assistant.classifier';
+import { computeNodesRequiringCredentialSetup } from './node-credential-requirements';
 
 import { InProcessEventBus } from '../event-bus/in-process-event-bus';
 import { InstanceAiMemoryService } from '../instance-ai-memory.service';
@@ -162,99 +156,14 @@ export class DesktopAssistantService {
 					: undefined,
 				emojiIcon: metaIcon ?? nameEmoji,
 				accessibleCredentialIds,
-				nodesRequiringCredentialSetup: this.computeNodesRequiringCredentialSetup(workflow.nodes),
+				nodesRequiringCredentialSetup: computeNodesRequiringCredentialSetup(
+					workflow.nodes,
+					this.nodeTypes,
+				),
 			};
 		});
 
 		return classifyWorkflowsForDesktopAssistant(inputs);
-	}
-
-	/**
-	 * Identify nodes whose type declares required credentials but whose workflow
-	 * JSON has no populated credential slot. Reuses the same primitives the
-	 * workflow-builder's `setup-workflow.service.ts` analysis is built on —
-	 * `INodeTypeDescription.credentials` filtered by `NodeHelpers.displayParameter`
-	 * against the current parameters — but stays synchronous and avoids the
-	 * heavier `buildSetupRequests` pipeline (parameter issues, credential cache,
-	 * testability checks). For the BFF classifier we just need the "missing
-	 * setup" signal.
-	 *
-	 * The existing slot-based detection (empty `slot.id` or inaccessible
-	 * credential) continues to live in the classifier itself; this complements
-	 * it by catching the case where the node has no `credentials` field at all
-	 * (a workflow imported / built without ever picking a credential).
-	 */
-	private computeNodesRequiringCredentialSetup(nodes: INode[]): Set<string> {
-		const result = new Set<string>();
-		for (const node of nodes) {
-			if (node.disabled) continue;
-			// If any credential slot already exists, the classifier's slot-based
-			// check handles whether it's populated correctly.
-			if (node.credentials && Object.keys(node.credentials).length > 0) continue;
-
-			const description = this.tryGetNodeDescription(node);
-			if (!description) continue;
-			if (!Array.isArray(description.credentials) || description.credentials.length === 0) continue;
-
-			// Resolve defaults from the description before evaluating displayOptions.
-			// Many nodes (e.g. Gmail Trigger) gate their credentials on parameters
-			// whose values come from the description's default rather than being
-			// stored on the workflow JSON. Mirrors `resolveDisplayedDefaults` in
-			// the adapter service's getNodeCredentialTypes.
-			const resolvedParameters = this.resolveParametersWithDefaults(node, description);
-			const nodeWithDefaults: INode = { ...node, parameters: resolvedParameters };
-
-			const hasRequired = description.credentials.some((credentialDesc) =>
-				this.nodeRequiresCredential(credentialDesc, nodeWithDefaults, description),
-			);
-			if (hasRequired) result.add(node.name);
-		}
-		return result;
-	}
-
-	private tryGetNodeDescription(node: INode): INodeTypeDescription | undefined {
-		try {
-			return this.nodeTypes.getByNameAndVersion(node.type, node.typeVersion).description;
-		} catch {
-			return undefined;
-		}
-	}
-
-	private resolveParametersWithDefaults(
-		node: INode,
-		description: INodeTypeDescription,
-	): INodeParameters {
-		const parameters: INodeParameters = node.parameters ?? {};
-		try {
-			const resolved = NodeHelpers.getNodeParameters(
-				description.properties,
-				parameters,
-				true,
-				false,
-				node,
-				description,
-			);
-			return resolved ?? parameters;
-		} catch {
-			return parameters;
-		}
-	}
-
-	private nodeRequiresCredential(
-		credentialDesc: INodeCredentialDescription,
-		node: INode,
-		description: INodeTypeDescription,
-	): boolean {
-		if (credentialDesc.required === false) return false;
-		if (!credentialDesc.displayOptions) return true;
-		try {
-			return NodeHelpers.displayParameter(node.parameters, credentialDesc, node, description);
-		} catch {
-			// If displayOptions evaluation throws (malformed parameters etc.),
-			// be conservative and treat the credential as required so the user
-			// is nudged to inspect it.
-			return true;
-		}
 	}
 
 	private async fetchLastExecutionByWorkflowId(

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
@@ -120,11 +120,18 @@ export class DesktopAssistantService {
 			await this.fetchLastExecutionByWorkflowId(accessibleWorkflowIds);
 
 		const inputs: ClassifierInput[] = workflows.map((workflow) => {
-			const emojiIcon = readDesktopAssistantMeta(workflow.meta)?.icon;
+			// Icon priority: explicit `meta.desktopAssistant.icon` wins, then any
+			// leading emoji the orchestrator put on the workflow name (the
+			// `desktop-assistant-promote` and recurring one-shot prompts both
+			// instruct picking one), then the classifier falls back to a node-type
+			// icon. The display name strips the leading emoji so the desktop card
+			// shows it once, in the icon slot.
+			const metaIcon = readDesktopAssistantMeta(workflow.meta)?.icon;
+			const { emoji: nameEmoji, rest: displayName } = splitLeadingEmoji(workflow.name);
 			const lastExec = lastExecutionByWorkflowId.get(workflow.id);
 			return {
 				workflowId: workflow.id,
-				name: workflow.name,
+				name: displayName || workflow.name,
 				active: workflow.active,
 				nodes: workflow.nodes,
 				tags: tagsByWorkflowId.get(workflow.id) ?? [],
@@ -136,7 +143,7 @@ export class DesktopAssistantService {
 							startedAt: lastExec.startedAt,
 						}
 					: undefined,
-				emojiIcon,
+				emojiIcon: metaIcon ?? nameEmoji,
 				accessibleCredentialIds,
 			};
 		});
@@ -424,9 +431,28 @@ function composeOneShotMessage(body: DesktopAssistantTaskRequest): string {
 function composePromoteMessage(originalPrompt: string, name: string | undefined): string {
 	const trimmedName = name?.trim();
 	const intro = trimmedName
-		? `Promote this idea into a real workflow named "${trimmedName}":`
-		: 'Promote this idea into a real workflow:';
+		? `Promote this idea into a real workflow. Use the name "${trimmedName}" (prepend a fitting emoji if it does not already start with one):`
+		: 'Promote this idea into a real workflow. Pick a short descriptive name for it as part of the build, and start that name with a single emoji that captures what the workflow does:';
 	return `${intro}\n\n${originalPrompt}`;
+}
+
+/**
+ * Extract a leading emoji cluster from a string. Returns `{ emoji, rest }` where
+ * `rest` has the emoji and any following whitespace stripped. If the string does
+ * not start with an emoji, `emoji` is `undefined` and `rest` is the original
+ * input.
+ *
+ * Supports common cases including zero-width-joiner sequences (e.g. 👨‍💻)
+ * and emoji-variation selectors. We intentionally keep the regex narrow to
+ * `Extended_Pictographic` so plain text starting with a number or symbol is not
+ * mistaken for an emoji.
+ */
+export function splitLeadingEmoji(input: string): { emoji?: string; rest: string } {
+	const match = input.match(
+		/^(\p{Extended_Pictographic}(?:\u200d\p{Extended_Pictographic})*\uFE0F?)\s*/u,
+	);
+	if (!match) return { rest: input };
+	return { emoji: match[1], rest: input.slice(match[0].length) };
 }
 
 function clampLimit(limit: number | undefined): number {

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
@@ -240,10 +240,6 @@ export class DesktopAssistantService {
 		const originalPrompt = await this.recoverOriginalPrompt(body.threadId);
 		const buildPrompt = composePromoteMessage(originalPrompt, body.name);
 
-		// Subscribe BEFORE starting the run so we don't miss a fast build that
-		// emits its tool-result before we wire up the listener.
-		const cleanup = this.subscribeForBuildOutcome(user, body.threadId);
-
 		const runId = this.instanceAiService.startRun(
 			user,
 			body.threadId,
@@ -254,27 +250,88 @@ export class DesktopAssistantService {
 			{ promptMode: 'desktop-assistant-promote' },
 		);
 
+		// Subscribe AFTER we have the runId so the listener can scope itself to
+		// the exact run we just kicked off. `subscribe` is synchronous and
+		// `startRun` only registers the run; it doesn't dispatch any events on
+		// the bus before this line runs.
+		const cleanup = this.subscribeForBuildOutcome(user, body.threadId, runId);
+
 		// Hard-cap the listener so a stalled run does not leak a subscription.
 		setTimeout(cleanup, PROMOTE_FINALIZE_TIMEOUT_MS).unref();
 
 		return { status: 'building', threadId: body.threadId, runId };
 	}
 
-	private subscribeForBuildOutcome(user: User, threadId: string): () => void {
+	/**
+	 * Listen for the promote run finishing, then resolve which workflow it
+	 * produced.
+	 *
+	 * We watch two signals because the orchestrator has more than one build
+	 * path:
+	 *  1. The `instanceAiWorkflowLoop` (newer) persists its outcome to
+	 *     `thread.metadata.instanceAiWorkflowLoop[*].lastBuildOutcome` and
+	 *     emits a plain `run-finish` event — no per-build planItem on the
+	 *     parent thread. We read the persisted outcome at run-finish.
+	 *  2. The older planned-task path (still used by some builds) emits
+	 *     `tasks-update` with a `kind: 'build-workflow'` planItem completing.
+	 *     This is the legacy `extractBuiltWorkflowId` heuristic; kept as a
+	 *     fallback so we cover whichever path the orchestrator picks.
+	 *
+	 * Whichever signal fires first wins; both go through the same `handled`
+	 * gate so we only finalise once.
+	 */
+	private subscribeForBuildOutcome(user: User, threadId: string, runId: string): () => void {
 		let handled = false;
-		const unsubscribe = this.eventBus.subscribe(threadId, (storedEvent: StoredEvent) => {
-			if (handled) return;
-			const built = extractBuiltWorkflowId(storedEvent);
-			if (!built) return;
+		const finalise = (workflowId: string) => {
 			handled = true;
 			unsubscribe();
-			this.finalizePromotedWorkflow(user, threadId, built).catch((error: unknown) => {
+			this.finalizePromotedWorkflow(user, threadId, workflowId).catch((error: unknown) => {
 				this.logger.warn('Failed to finalise promoted workflow', {
 					threadId,
-					workflowId: built,
+					workflowId,
 					error: error instanceof Error ? error.message : String(error),
 				});
 			});
+		};
+
+		const unsubscribe = this.eventBus.subscribe(threadId, (storedEvent: StoredEvent) => {
+			if (handled) return;
+
+			// Fallback: legacy planned-task build emits its outcome inline.
+			const plannedTaskBuilt = extractBuiltWorkflowId(storedEvent);
+			if (plannedTaskBuilt) {
+				finalise(plannedTaskBuilt);
+				return;
+			}
+
+			// Primary: workflow-loop builds only surface via thread metadata at
+			// run-finish. Match on the runId we kicked off so we don't react to
+			// unrelated runs that happen to share the thread.
+			const ev = storedEvent.event;
+			if (ev.type !== 'run-finish') return;
+			if (ev.runId !== runId) return;
+
+			void this.memoryService
+				.getThreadMetadata(user.id, threadId)
+				.then((metadata) => {
+					if (handled) return;
+					const workflowId = extractWorkflowLoopBuildOutcome(metadata, runId);
+					if (!workflowId) {
+						this.logger.warn('Promote run finished without a successful build outcome', {
+							threadId,
+							runId,
+						});
+						return;
+					}
+					finalise(workflowId);
+				})
+				.catch((error: unknown) => {
+					this.logger.warn('Failed to read promote thread metadata at run-finish', {
+						threadId,
+						runId,
+						error: error instanceof Error ? error.message : String(error),
+					});
+				});
 		});
 		return unsubscribe;
 	}
@@ -486,6 +543,37 @@ function readDesktopAssistantMeta(meta: unknown): StoredDesktopAssistantMeta | u
  * a `done` status — to avoid acting on an in-flight task that already has its
  * id slot allocated.
  */
+/**
+ * Read the workflow id produced by a workflow-loop build for the given run
+ * from `thread.metadata.instanceAiWorkflowLoop`. The workflow loop persists
+ * a `lastBuildOutcome` per work item; we pick the one whose `runId` matches
+ * the promote run we kicked off and that was successfully submitted.
+ *
+ * Returns `undefined` when no such outcome exists (e.g. the run finished
+ * without ever invoking the workflow builder, the build failed, or the
+ * metadata structure changed under us).
+ */
+export function extractWorkflowLoopBuildOutcome(
+	metadata: unknown,
+	runId: string,
+): string | undefined {
+	if (!metadata || typeof metadata !== 'object') return undefined;
+	const loop = (metadata as { instanceAiWorkflowLoop?: unknown }).instanceAiWorkflowLoop;
+	if (!loop || typeof loop !== 'object') return undefined;
+	for (const workItem of Object.values(loop as Record<string, unknown>)) {
+		if (!workItem || typeof workItem !== 'object') continue;
+		const outcome = (workItem as { lastBuildOutcome?: unknown }).lastBuildOutcome;
+		if (!outcome || typeof outcome !== 'object') continue;
+		const o = outcome as { runId?: unknown; submitted?: unknown; workflowId?: unknown };
+		if (o.runId !== runId) continue;
+		if (o.submitted !== true) continue;
+		if (typeof o.workflowId === 'string' && o.workflowId.length > 0) {
+			return o.workflowId;
+		}
+	}
+	return undefined;
+}
+
 function extractBuiltWorkflowId(storedEvent: StoredEvent): string | undefined {
 	const ev = storedEvent.event;
 	if (ev.type !== 'tasks-update') return undefined;

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
@@ -17,11 +17,18 @@ import { Service } from '@n8n/di';
 import type { StoredEvent } from '@n8n/instance-ai';
 // eslint-disable-next-line n8n-local-rules/misplaced-n8n-typeorm-import
 import { In } from '@n8n/typeorm';
-import type { ExecutionStatus } from 'n8n-workflow';
+import type {
+	ExecutionStatus,
+	INode,
+	INodeCredentialDescription,
+	INodeTypeDescription,
+} from 'n8n-workflow';
+import { NodeHelpers } from 'n8n-workflow';
 import { randomUUID } from 'node:crypto';
 
 import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
 import { ExecutionService } from '@/executions/execution.service';
+import { NodeTypes } from '@/node-types';
 import { ProjectService } from '@/services/project.service.ee';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { WorkflowSharingService } from '@/workflows/workflow-sharing.service';
@@ -79,6 +86,7 @@ export class DesktopAssistantService {
 		private readonly executionService: ExecutionService,
 		private readonly executionRepository: ExecutionRepository,
 		private readonly projectService: ProjectService,
+		private readonly nodeTypes: NodeTypes,
 	) {}
 
 	// ── tasks list ───────────────────────────────────────────────────────────
@@ -153,10 +161,71 @@ export class DesktopAssistantService {
 					: undefined,
 				emojiIcon: metaIcon ?? nameEmoji,
 				accessibleCredentialIds,
+				nodesRequiringCredentialSetup: this.computeNodesRequiringCredentialSetup(workflow.nodes),
 			};
 		});
 
 		return classifyWorkflowsForDesktopAssistant(inputs);
+	}
+
+	/**
+	 * Identify nodes whose type declares required credentials but whose workflow
+	 * JSON has no populated credential slot. Reuses the same primitives the
+	 * workflow-builder's `setup-workflow.service.ts` analysis is built on —
+	 * `INodeTypeDescription.credentials` filtered by `NodeHelpers.displayParameter`
+	 * against the current parameters — but stays synchronous and avoids the
+	 * heavier `buildSetupRequests` pipeline (parameter issues, credential cache,
+	 * testability checks). For the BFF classifier we just need the "missing
+	 * setup" signal.
+	 *
+	 * The existing slot-based detection (empty `slot.id` or inaccessible
+	 * credential) continues to live in the classifier itself; this complements
+	 * it by catching the case where the node has no `credentials` field at all
+	 * (a workflow imported / built without ever picking a credential).
+	 */
+	private computeNodesRequiringCredentialSetup(nodes: INode[]): Set<string> {
+		const result = new Set<string>();
+		for (const node of nodes) {
+			if (node.disabled) continue;
+			// If any credential slot already exists, the classifier's slot-based
+			// check handles whether it's populated correctly.
+			if (node.credentials && Object.keys(node.credentials).length > 0) continue;
+
+			const description = this.tryGetNodeDescription(node);
+			if (!description) continue;
+			if (!Array.isArray(description.credentials) || description.credentials.length === 0) continue;
+
+			const hasRequired = description.credentials.some((credentialDesc) =>
+				this.nodeRequiresCredential(credentialDesc, node, description),
+			);
+			if (hasRequired) result.add(node.name);
+		}
+		return result;
+	}
+
+	private tryGetNodeDescription(node: INode): INodeTypeDescription | undefined {
+		try {
+			return this.nodeTypes.getByNameAndVersion(node.type, node.typeVersion).description;
+		} catch {
+			return undefined;
+		}
+	}
+
+	private nodeRequiresCredential(
+		credentialDesc: INodeCredentialDescription,
+		node: INode,
+		description: INodeTypeDescription,
+	): boolean {
+		if (credentialDesc.required === false) return false;
+		if (!credentialDesc.displayOptions) return true;
+		try {
+			return NodeHelpers.displayParameter(node.parameters, credentialDesc, node, description);
+		} catch {
+			// If displayOptions evaluation throws (malformed parameters etc.),
+			// be conservative and treat the credential as required so the user
+			// is nudged to inspect it.
+			return true;
+		}
 	}
 
 	private async fetchLastExecutionByWorkflowId(

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
@@ -21,6 +21,7 @@ import type {
 	ExecutionStatus,
 	INode,
 	INodeCredentialDescription,
+	INodeParameters,
 	INodeTypeDescription,
 } from 'n8n-workflow';
 import { NodeHelpers } from 'n8n-workflow';
@@ -195,8 +196,16 @@ export class DesktopAssistantService {
 			if (!description) continue;
 			if (!Array.isArray(description.credentials) || description.credentials.length === 0) continue;
 
+			// Resolve defaults from the description before evaluating displayOptions.
+			// Many nodes (e.g. Gmail Trigger) gate their credentials on parameters
+			// whose values come from the description's default rather than being
+			// stored on the workflow JSON. Mirrors `resolveDisplayedDefaults` in
+			// the adapter service's getNodeCredentialTypes.
+			const resolvedParameters = this.resolveParametersWithDefaults(node, description);
+			const nodeWithDefaults: INode = { ...node, parameters: resolvedParameters };
+
 			const hasRequired = description.credentials.some((credentialDesc) =>
-				this.nodeRequiresCredential(credentialDesc, node, description),
+				this.nodeRequiresCredential(credentialDesc, nodeWithDefaults, description),
 			);
 			if (hasRequired) result.add(node.name);
 		}
@@ -208,6 +217,26 @@ export class DesktopAssistantService {
 			return this.nodeTypes.getByNameAndVersion(node.type, node.typeVersion).description;
 		} catch {
 			return undefined;
+		}
+	}
+
+	private resolveParametersWithDefaults(
+		node: INode,
+		description: INodeTypeDescription,
+	): INodeParameters {
+		const parameters: INodeParameters = node.parameters ?? {};
+		try {
+			const resolved = NodeHelpers.getNodeParameters(
+				description.properties,
+				parameters,
+				true,
+				false,
+				node,
+				description,
+			);
+			return resolved ?? parameters;
+		} catch {
+			return parameters;
 		}
 	}
 

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
@@ -91,15 +91,24 @@ export class DesktopAssistantService {
 			return { actionNeeded: [], upcoming: [], readyToRun: [] };
 		}
 
-		const workflows = await this.workflowFinderService.findWorkflowsByIdsForUser(
+		// Filter archived workflows out of the desktop assistant view. Archive is a
+		// user signal of "I'm done with this"; it should not surface in the
+		// always-on assistant card. workflowFinderService doesn't filter for us,
+		// so we drop archived rows after the share check.
+		const sharedWorkflows = await this.workflowFinderService.findWorkflowsByIdsForUser(
 			accessibleWorkflowIds,
 			user,
 			['workflow:read'],
 		);
+		const workflows = sharedWorkflows.filter((wf) => !wf.isArchived);
+		const liveWorkflowIds = workflows.map((wf) => wf.id);
+		if (liveWorkflowIds.length === 0) {
+			return { actionNeeded: [], upcoming: [], readyToRun: [] };
+		}
 
 		// Fetch tags for each workflow in one round-trip via the join column.
 		const workflowsWithTags = await this.workflowRepository.find({
-			where: { id: In(accessibleWorkflowIds) },
+			where: { id: In(liveWorkflowIds) },
 			relations: { tags: true },
 			select: { id: true, tags: { name: true } },
 		});
@@ -116,8 +125,7 @@ export class DesktopAssistantService {
 		]);
 		const accessibleCredentialIds = new Set(credentials.map((c) => c.id));
 
-		const lastExecutionByWorkflowId =
-			await this.fetchLastExecutionByWorkflowId(accessibleWorkflowIds);
+		const lastExecutionByWorkflowId = await this.fetchLastExecutionByWorkflowId(liveWorkflowIds);
 
 		const inputs: ClassifierInput[] = workflows.map((workflow) => {
 			// Icon priority: explicit `meta.desktopAssistant.icon` wins, then any
@@ -447,12 +455,23 @@ export class DesktopAssistantService {
 			return { results: [], estimated: false, count: 0 };
 		}
 
+		// Skip executions of archived workflows — if the user archived a
+		// desktop-assistant workflow it should drop out of the history view too.
+		const liveTaggedRows = await this.workflowRepository.find({
+			where: { id: In(taggedWorkflowIds), isArchived: false },
+			select: { id: true },
+		});
+		const liveTaggedWorkflowIds = liveTaggedRows.map((row) => row.id);
+		if (liveTaggedWorkflowIds.length === 0) {
+			return { results: [], estimated: false, count: 0 };
+		}
+
 		const sharingOptions = await this.executionService.buildSharingOptions('workflow:read');
 		return await this.executionService.findRangeWithCount({
 			kind: 'range',
 			user,
 			sharingOptions,
-			workflowId: taggedWorkflowIds,
+			workflowId: liveTaggedWorkflowIds,
 			range: {
 				limit: clampLimit(query.limit),
 				firstId: query.firstId,

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/node-credential-requirements.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/node-credential-requirements.ts
@@ -1,0 +1,109 @@
+/**
+ * Detect nodes whose type declares required credentials but whose workflow
+ * JSON has no populated credential slot at all.
+ *
+ * Reuses the same primitives the workflow-builder's `setup-workflow.service.ts`
+ * analysis is built on — `INodeTypeDescription.credentials` filtered by
+ * `NodeHelpers.displayParameter` against parameters resolved with their
+ * description defaults. Stays synchronous and skips the heavier
+ * `buildSetupRequests` pipeline (parameter issues, credential cache,
+ * testability checks). For the BFF classifier we just need the
+ * "missing setup" signal.
+ *
+ * The existing slot-based detection (empty `slot.id` or inaccessible
+ * credential) lives in the classifier itself; this complements it by
+ * catching the case where the node has no `credentials` field at all
+ * (a workflow imported / built without ever picking a credential).
+ */
+import type {
+	INode,
+	INodeCredentialDescription,
+	INodeParameters,
+	INodeTypeDescription,
+	INodeTypes,
+} from 'n8n-workflow';
+import { NodeHelpers } from 'n8n-workflow';
+
+/**
+ * Walk a workflow's nodes and return the names of those that have no
+ * `credentials` field populated but whose type description declares a
+ * required credential matching the node's current parameters.
+ */
+export function computeNodesRequiringCredentialSetup(
+	nodes: INode[],
+	nodeTypes: INodeTypes,
+): Set<string> {
+	const result = new Set<string>();
+	for (const node of nodes) {
+		if (node.disabled) continue;
+		// If any credential slot already exists, the classifier's slot-based
+		// check handles whether it's populated correctly.
+		if (node.credentials && Object.keys(node.credentials).length > 0) continue;
+
+		const description = tryGetNodeDescription(node, nodeTypes);
+		if (!description) continue;
+		if (!Array.isArray(description.credentials) || description.credentials.length === 0) continue;
+
+		// Resolve defaults from the description before evaluating displayOptions.
+		// Many nodes (e.g. Gmail Trigger) gate their credentials on parameters
+		// whose values come from the description's default rather than being
+		// stored on the workflow JSON. Mirrors `resolveDisplayedDefaults` in
+		// the adapter service's getNodeCredentialTypes.
+		const resolvedParameters = resolveParametersWithDefaults(node, description);
+		const nodeWithDefaults: INode = { ...node, parameters: resolvedParameters };
+
+		const hasRequired = description.credentials.some((credentialDesc) =>
+			nodeRequiresCredential(credentialDesc, nodeWithDefaults, description),
+		);
+		if (hasRequired) result.add(node.name);
+	}
+	return result;
+}
+
+function tryGetNodeDescription(
+	node: INode,
+	nodeTypes: INodeTypes,
+): INodeTypeDescription | undefined {
+	try {
+		return nodeTypes.getByNameAndVersion(node.type, node.typeVersion).description;
+	} catch {
+		return undefined;
+	}
+}
+
+function resolveParametersWithDefaults(
+	node: INode,
+	description: INodeTypeDescription,
+): INodeParameters {
+	const parameters: INodeParameters = node.parameters ?? {};
+	try {
+		const resolved = NodeHelpers.getNodeParameters(
+			description.properties,
+			parameters,
+			true,
+			false,
+			node,
+			description,
+		);
+		return resolved ?? parameters;
+	} catch {
+		return parameters;
+	}
+}
+
+function nodeRequiresCredential(
+	credentialDesc: INodeCredentialDescription,
+	node: INode,
+	description: INodeTypeDescription,
+): boolean {
+	if (credentialDesc.required === false) return false;
+	if (!credentialDesc.displayOptions) return true;
+	try {
+		return NodeHelpers.displayParameter(node.parameters, credentialDesc, node, description);
+	} catch {
+		// If displayOptions evaluation throws (malformed parameters etc.),
+		// be conservative and treat the credential as required so the user
+		// is nudged to inspect it.
+		return true;
+	}
+}

--- a/packages/cli/src/modules/instance-ai/instance-ai.module.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.module.ts
@@ -20,6 +20,7 @@ export class InstanceAiModule implements ModuleInterface {
 		await Container.get(InstanceAiSettingsService).loadFromDb();
 		await import('./instance-ai.controller');
 		await import('./mcp/instance-ai-mcp-connection.controller');
+		await import('./desktop-assistant/desktop-assistant.controller');
 
 		if (process.env.E2E_TESTS === 'true' && process.env.NODE_ENV !== 'production') {
 			await import('./instance-ai-test.controller');

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -84,6 +84,7 @@ import {
 	type TerminalResponseDecision,
 	type TerminalResponseStatus,
 	type WorkflowBuildOutcome,
+	type DesktopAssistantPromptMode,
 	type WorkflowLoopWorkItemRecord,
 	type WorkflowSetupRoutingClaim,
 	type WorkflowTaskService,
@@ -1585,6 +1586,7 @@ export class InstanceAiService {
 		attachments?: InstanceAiAttachment[],
 		timeZone?: string,
 		pushRef?: string,
+		options?: { promptMode?: DesktopAssistantPromptMode },
 	): string {
 		this.liveness.clearThreadState(threadId);
 		const { runId, abortController, messageGroupId } = this.runState.startRun({
@@ -1626,6 +1628,8 @@ export class InstanceAiService {
 			false,
 			undefined,
 			undefined,
+			undefined,
+			options?.promptMode,
 		);
 
 		return runId;
@@ -4012,6 +4016,7 @@ export class InstanceAiService {
 		checkpoint?: { isCheckpointFollowUp: true; checkpointTaskId: string },
 		resumeReason?: OrchestratorResumeReason,
 		plannedBuild?: PlannedBuildFollowUp,
+		promptMode?: DesktopAssistantPromptMode,
 	): Promise<void> {
 		// Read once at the top so the streamInput builder + (if any later
 		// retry) see the same view of restart-recovery metadata.
@@ -4327,6 +4332,7 @@ export class InstanceAiService {
 				memory,
 				checkpointStore: this.checkpointStore,
 				timeZone: timeZone ?? this.defaultTimeZone,
+				promptMode,
 			});
 
 			const result = tracing

--- a/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
+++ b/packages/frontend/editor-ui/src/features/credentials/components/NodeCredentials.vue
@@ -22,7 +22,7 @@ import { useToast } from '@/app/composables/useToast';
 import TitledList from '@/app/components/TitledList.vue';
 import { useI18n } from '@n8n/i18n';
 import { useTelemetry } from '@/app/composables/useTelemetry';
-import { CREDENTIAL_ONLY_NODE_PREFIX, WORKFLOW_SETTINGS_MODAL_KEY } from '@/app/constants';
+import { CREDENTIAL_ONLY_NODE_PREFIX } from '@/app/constants';
 import { INSTANCE_AI_COMPUTER_USE_SETUP_MODAL_KEY } from '@/app/constants/modals';
 import { ndvEventBus } from '@/features/ndv/shared/ndv.eventBus';
 import { useCredentialsStore } from '../credentials.store';

--- a/packages/nodes-base/credentials/DeviceConnectionApi.credentials.ts
+++ b/packages/nodes-base/credentials/DeviceConnectionApi.credentials.ts
@@ -5,6 +5,8 @@ export class DeviceConnectionApi implements ICredentialType {
 
 	displayName = 'Device Connection';
 
+	documentationUrl = 'deviceconnection';
+
 	icon: Icon = 'node:@n8n/n8n-nodes-langchain.computerUse';
 
 	properties: INodeProperties[] = [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -237,6 +237,9 @@ catalogs:
     cron:
       specifier: 4.4.0
       version: 4.4.0
+    cron-parser:
+      specifier: 4.9.0
+      version: 4.9.0
     csv-parse:
       specifier: 6.2.1
       version: 6.2.1
@@ -3184,6 +3187,9 @@ importers:
       cron:
         specifier: 'catalog:'
         version: 4.4.0
+      cron-parser:
+        specifier: 'catalog:'
+        version: 4.9.0
       csrf:
         specifier: 3.1.0
         version: 3.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -93,6 +93,7 @@ catalog:
   chat: ^4.28.1
   chokidar: 4.0.3
   cron: 4.4.0
+  cron-parser: 4.9.0
   csv-parse: 6.2.1
   eslint: 9.29.0
   eslint-plugin-oxlint: ^1.61.0


### PR DESCRIPTION
## Summary

Adds the backend (BFF) for the **personal-automation desktop app** — a tray-anchored Electron assistant where users type a prompt and Instance AI either runs it as a one-shot or builds a workflow. This PR ships the **server side**: REST endpoints, Instance-AI prompt-mode integration, the workflow classifier that powers the desktop's three lists, and the persistence/lookup machinery the desktop reads on each poll.

The desktop app itself (Vue UI, Electron shell, IPC) lives in `@n8n/local-gateway` and is a follow-up.

### What's in this PR

Four REST endpoints under `/desktop-assistant` (internal REST, cookie auth, gated by `@GlobalScope('instanceAi:message')` and the existing Instance-AI-enabled check):

| Endpoint | Purpose |
|---|---|
| `GET  /desktop-assistant/tasks` | Classifies the user's accessible workflows into `actionNeeded` / `upcoming` / `readyToRun` buckets. Computes per-card icon (emoji from name or node-type), trigger summary (with `nextRunAt` for schedule, `sourceLabel` for poll/webhook), `runsLocally` flag, and last-execution row. |
| `POST /desktop-assistant/task` | Fire-and-forget one-shot trigger. Spins up an Instance AI thread, calls `startRun(...)` with the new `desktop-assistant-one-shot` prompt mode, returns `{ threadId, runId }`. The desktop subscribes to `/instance-ai/events/:threadId` for the rest. |
| `POST /desktop-assistant/promote-thread` | Hands a thread's original prompt to the workflow-builder under `desktop-assistant-promote`. Idempotent on `meta.desktopAssistant.promotedFromThreadId`. Tags the resulting workflow `desktop-assistant` so the desktop can identify saved tasks. |
| `GET  /desktop-assistant/history` | Executions of every workflow the user can `workflow:read`, minus archived. Cursor pagination via existing `ExecutionService.findRangeWithCount`. |

**Instance-AI prompt modes** (`@n8n/instance-ai`):

- `desktop-assistant-one-shot` — strict no-conversational rules (no greetings, no narration, no summaries), instructs the model to either execute via tools or stop without producing a result.
- `desktop-assistant-promote` — workflow-builder-only path, instructs picking a short descriptive name prefixed by a representative emoji (e.g. `"🍌 Daily banana prices"`).
- Default chat is unaffected; `promptMode` is an optional `startRun` arg.

**Classifier** (`desktop-assistant.classifier.ts`):

- Missing credentials → `actionNeeded` for any source (detected via slot inspection + node-type description introspection that covers the no-slot case for nodes like Gmail Trigger whose authentication parameter defaults are gated by displayOptions).
- Inactive schedule/poll/webhook → `actionNeeded` (autonomous trigger is dormant).
- Active schedule/poll → `upcoming` with `nextRunAt` (cron-parser over n8n's structured rule.interval shapes).
- Active webhook → `upcoming` (autonomous trigger).
- Manual triggers → `readyToRun`.
- `source: 'desktop-assistant' | 'user-built'` derived from the tag.

**Promote post-build hook** — listens on the in-process event bus for the run we kicked off and detects build completion via either of two signals (legacy `tasks-update` planned-task heuristic + the newer `instanceAiWorkflowLoop` thread-metadata path), then applies the tag, writes `meta.desktopAssistant.promotedFromThreadId`, and updates thread metadata with `promotedWorkflowId`. 5-minute cap.

**DB filter widening** (`@n8n/db`): `IGetExecutionsQueryFilter.workflowId` accepts `string | string[]` and the query builder emits `IN (:...ids)` when an array. Used by `/history`; independently useful for any caller.

### Module layout

```
packages/cli/src/modules/instance-ai/desktop-assistant/
  constants.ts                            # tag + meta key constants
  desktop-assistant.controller.ts         # 4 REST handlers (~80 lines)
  desktop-assistant.service.ts            # orchestration + DI (~500 lines)
  desktop-assistant.classifier.ts         # pure classifier (~390 lines)
  desktop-assistant.helpers.ts            # pure helpers (compose messages, split-emoji, meta read, build-outcome extraction)
  node-credential-requirements.ts         # node-type credential introspection
  __tests__/*                              # 61 tests
```

### Reading order if you want it

The branch is intentionally not squashed; commits each tell a small story. If you'd rather read the unified diff, scroll to "Files changed" and skip the commit list.

**Start with:**
- `feat(core): add /desktop-assistant tasks, task, promote, history endpoints` — main surface
- `feat(core): add desktop-assistant prompt mode variants` — Instance-AI integration
- `refactor(core): extract pure helpers from DesktopAssistantService` — final file layout

**Skim:**
- The `fix:` commits between endpoints and refactors are bucket-rule iterations made while testing against real workflows. End state in the unified diff is what matters.

## How to test

A bash test helper lives at `plans/personal-automation-desktop/test-desktop-assistant.sh` (gitignored; ask if you want a copy). For curl-only verification:

```bash
# 0. Setup
BASE_URL="http://localhost:5678"
COOKIE_JAR=$(mktemp)
curl -sS -c "$COOKIE_JAR" -b "$COOKIE_JAR" \
  -H 'Content-Type: application/json' \
  -X POST "$BASE_URL/rest/login" \
  -d '{"emailOrLdapLoginId":"owner@example.com","password":"…"}' | jq

# 1. Tasks list
curl -sS -b "$COOKIE_JAR" "$BASE_URL/rest/desktop-assistant/tasks" | jq '.data'

# 2. Trigger a one-shot
TASK=$(curl -sS -b "$COOKIE_JAR" -H 'Content-Type: application/json' \
  -X POST "$BASE_URL/rest/desktop-assistant/task" \
  -d '{"prompt":"Rename everything on my Desktop to banana"}')
THREAD_ID=$(echo "$TASK" | jq -r '.data.threadId')

# 3. Watch the SSE
curl -sS -N -b "$COOKIE_JAR" \
  -H 'Accept: text/event-stream' \
  "$BASE_URL/rest/instance-ai/events/$THREAD_ID"

# 4. Promote
curl -sS -b "$COOKIE_JAR" -H 'Content-Type: application/json' \
  -X POST "$BASE_URL/rest/desktop-assistant/promote-thread" \
  -d "{\"threadId\":\"$THREAD_ID\"}" | jq '.data'

# 5. History
curl -sS -b "$COOKIE_JAR" "$BASE_URL/rest/desktop-assistant/history?limit=20" | jq '.data'
```

Expected for a fresh promote: the response transitions from `{ status: 'building', runId }` on first call to `{ status: 'done', workflowId }` once the build finishes; the resulting workflow appears in `/tasks` with `source: 'desktop-assistant'` and (when the model picked an emoji) `icon: { type: 'emoji', value: '🍌' }`.

### Automated tests

```bash
cd packages/cli && pnpm test src/modules/instance-ai/desktop-assistant
# → 4 suites / 61 tests
cd packages/@n8n/instance-ai && pnpm test system-prompt
# → 3 files / 60 tests
cd packages/@n8n/db && pnpm test execution.repository
```

Typecheck + lint clean across `cli`, `@n8n/instance-ai`, `@n8n/db`, `@n8n/api-types`.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Add the Linear ticket URL here when known -->

Part of the hackweek "personal automation desktop" workstream.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI
