### PR TITLE
refactor(core): Move TypedEmitter from @n8n/cli to @n8n/backend-common (no-changelog)

### DIFF
--- a/packages/@n8n/backend-common/src/__tests__/typed-emitter.test.ts
+++ b/packages/@n8n/backend-common/src/__tests__/typed-emitter.test.ts
@@ -1,0 +1,72 @@
+import { TypedEmitter } from '../typed-emitter';
+
+type TestEvents = {
+	ping: { value: number };
+};
+
+describe('TypedEmitter', () => {
+	describe('debouncedEmit', () => {
+		beforeEach(() => {
+			vi.useFakeTimers();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		it('should emit after the debounce delay', () => {
+			const emitter = new (class extends TypedEmitter<TestEvents> {
+				trigger(value: number) {
+					this.debouncedEmit('ping', { value });
+				}
+			})();
+			const listener = vi.fn();
+			emitter.on('ping', listener);
+
+			emitter.trigger(1);
+			expect(listener).not.toHaveBeenCalled();
+
+			vi.advanceTimersByTime(300);
+			expect(listener).toHaveBeenCalledOnce();
+			expect(listener).toHaveBeenCalledWith({ value: 1 });
+		});
+
+		it('should debounce multiple calls within the delay window', () => {
+			const emitter = new (class extends TypedEmitter<TestEvents> {
+				trigger(value: number) {
+					this.debouncedEmit('ping', { value });
+				}
+			})();
+			const listener = vi.fn();
+			emitter.on('ping', listener);
+
+			emitter.trigger(1);
+			emitter.trigger(2);
+			emitter.trigger(3);
+
+			vi.advanceTimersByTime(300);
+
+			expect(listener).toHaveBeenCalledOnce();
+			expect(listener).toHaveBeenCalledWith({ value: 3 });
+		});
+
+		it('should emit again after a second call following the delay', () => {
+			const emitter = new (class extends TypedEmitter<TestEvents> {
+				trigger(value: number) {
+					this.debouncedEmit('ping', { value });
+				}
+			})();
+			const listener = vi.fn();
+			emitter.on('ping', listener);
+
+			emitter.trigger(1);
+			vi.advanceTimersByTime(300);
+			expect(listener).toHaveBeenCalledOnce();
+
+			emitter.trigger(2);
+			vi.advanceTimersByTime(300);
+			expect(listener).toHaveBeenCalledTimes(2);
+			expect(listener).toHaveBeenLastCalledWith({ value: 2 });
+		});
+	});
+});

--- a/packages/@n8n/backend-common/src/index.ts
+++ b/packages/@n8n/backend-common/src/index.ts
@@ -11,3 +11,4 @@ export { isContainedWithin, safeJoinPath } from './utils/path-util';
 export { assertDir, exists } from './utils/fs';
 export { parseFlatted } from './utils/parse-flatted';
 export { CliParser } from './cli-parser';
+export { TypedEmitter } from './typed-emitter';

--- a/packages/@n8n/backend-common/src/typed-emitter.ts
+++ b/packages/@n8n/backend-common/src/typed-emitter.ts
@@ -1,4 +1,3 @@
-import debounce from 'lodash/debounce';
 import { EventEmitter } from 'node:events';
 
 type Payloads<ListenerMap> = {
@@ -8,7 +7,9 @@ type Payloads<ListenerMap> = {
 type Listener<Payload> = (payload: Payload) => void;
 
 export class TypedEmitter<ListenerMap extends Payloads<ListenerMap>> extends EventEmitter {
-	private debounceWait = 300; // milliseconds
+	private readonly debounceWait = 300; // milliseconds
+
+	private debouncedEmitTimer: NodeJS.Timeout | undefined;
 
 	override on<EventName extends keyof ListenerMap & string>(
 		eventName: EventName,
@@ -38,11 +39,11 @@ export class TypedEmitter<ListenerMap extends Payloads<ListenerMap>> extends Eve
 		return super.emit(eventName, payload);
 	}
 
-	protected debouncedEmit = debounce(
-		<EventName extends keyof ListenerMap & string>(
-			eventName: EventName,
-			payload?: ListenerMap[EventName],
-		) => super.emit(eventName, payload),
-		this.debounceWait,
-	);
+	protected debouncedEmit<EventName extends keyof ListenerMap & string>(
+		eventName: EventName,
+		payload?: ListenerMap[EventName],
+	) {
+		clearTimeout(this.debouncedEmitTimer);
+		this.debouncedEmitTimer = setTimeout(() => this.emit(eventName, payload), this.debounceWait);
+	}
 }

--- a/packages/cli/src/concurrency/concurrency-queue.ts
+++ b/packages/cli/src/concurrency/concurrency-queue.ts
@@ -1,6 +1,5 @@
+import { TypedEmitter } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
-
-import { TypedEmitter } from '@/typed-emitter';
 
 type ConcurrencyEvents = {
 	'execution-throttled': { executionId: string };

--- a/packages/cli/src/events/event.service.ts
+++ b/packages/cli/src/events/event.service.ts
@@ -1,6 +1,5 @@
+import { TypedEmitter } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
-
-import { TypedEmitter } from '@/typed-emitter';
 
 import type { AiEventMap } from './maps/ai.event-map';
 import type { ExecutionDataEventMap } from './maps/execution-data.event-map';

--- a/packages/cli/src/push/abstract.push.ts
+++ b/packages/cli/src/push/abstract.push.ts
@@ -1,12 +1,11 @@
 import type { PushMessage } from '@n8n/api-types';
-import { Logger } from '@n8n/backend-common';
+import { Logger, TypedEmitter } from '@n8n/backend-common';
 import type { User } from '@n8n/db';
 import { Service } from '@n8n/di';
 import { ErrorReporter } from 'n8n-core';
 import { assert, jsonStringify } from 'n8n-workflow';
 
 import type { OnPushMessage } from '@/push/types';
-import { TypedEmitter } from '@/typed-emitter';
 
 export interface AbstractPushEvents {
 	message: OnPushMessage;

--- a/packages/cli/src/push/index.ts
+++ b/packages/cli/src/push/index.ts
@@ -1,5 +1,5 @@
 import type { PushMessage } from '@n8n/api-types';
-import { inProduction, Logger } from '@n8n/backend-common';
+import { inProduction, Logger, TypedEmitter } from '@n8n/backend-common';
 import type { User } from '@n8n/db';
 import { OnPubSubEvent, OnShutdown } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
@@ -13,10 +13,11 @@ import { Server as WSServer } from 'ws';
 
 import { AuthService } from '@/auth/auth.service';
 import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { InternalServerError } from '@/errors/response-errors/internal-server.error';
 import { Publisher } from '@/scaling/pubsub/publisher.service';
-import { TypedEmitter } from '@/typed-emitter';
 
 import { validateOriginHeaders } from './origin-validator';
+import { isPushResponse, isSSEPushRequest, isWebSocketPushRequest } from './push-helpers';
 import { PushConfig } from './push.config';
 import { SSEPush } from './sse.push';
 import {
@@ -26,8 +27,6 @@ import {
 	type WebSocketPushRequest,
 } from './types';
 import { WebSocketPush } from './websocket.push';
-import { isPushResponse, isSSEPushRequest, isWebSocketPushRequest } from './push-helpers';
-import { InternalServerError } from '@/errors/response-errors/internal-server.error';
 
 type PushEvents = {
 	editorUiConnected: string;

--- a/packages/cli/src/scaling/multi-main-setup.ee.ts
+++ b/packages/cli/src/scaling/multi-main-setup.ee.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@n8n/backend-common';
+import { Logger, TypedEmitter } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
 import { MultiMainMetadata } from '@n8n/decorators';
@@ -7,7 +7,6 @@ import { ErrorReporter, InstanceSettings } from 'n8n-core';
 import assert from 'node:assert';
 
 import { LeaderElectionClient } from '@/scaling/leader-election-client';
-import { TypedEmitter } from '@/typed-emitter';
 
 type MultiMainEvents = {
 	/**

--- a/packages/cli/src/scaling/pubsub/pubsub.eventbus.ts
+++ b/packages/cli/src/scaling/pubsub/pubsub.eventbus.ts
@@ -1,6 +1,5 @@
+import { TypedEmitter } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
-
-import { TypedEmitter } from '@/typed-emitter';
 
 import type { PubSubEventMap } from './pubsub.event-map';
 

--- a/packages/cli/src/services/__tests__/import.service.test.ts
+++ b/packages/cli/src/services/__tests__/import.service.test.ts
@@ -18,6 +18,7 @@ jest.mock('@/utils/compression.util');
 
 jest.mock('@n8n/backend-common', () => ({
 	safeJoinPath: jest.fn(),
+	TypedEmitter: class {},
 }));
 
 // Mock @n8n/db

--- a/packages/cli/src/services/cache/cache.service.ts
+++ b/packages/cli/src/services/cache/cache.service.ts
@@ -1,3 +1,4 @@
+import { TypedEmitter } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
 import { Container, Service } from '@n8n/di';
@@ -12,7 +13,6 @@ import type {
 	MaybeHash,
 	Hash,
 } from '@/services/cache/cache.types';
-import { TypedEmitter } from '@/typed-emitter';
 import { isObject } from '@/utils';
 
 type CacheEvents = {

--- a/packages/cli/src/services/redis-client.service.ts
+++ b/packages/cli/src/services/redis-client.service.ts
@@ -1,11 +1,9 @@
-import { inTest, Logger } from '@n8n/backend-common';
+import { inTest, Logger, TypedEmitter } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
 import { Debounce } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import ioRedis from 'ioredis';
 import type { Cluster, ClusterOptions, RedisOptions } from 'ioredis';
-
-import { TypedEmitter } from '@/typed-emitter';
 
 import type { RedisClientType } from '../scaling/redis/redis.types';
 

--- a/packages/cli/src/services/workflow-statistics.service.ts
+++ b/packages/cli/src/services/workflow-statistics.service.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@n8n/backend-common';
+import { Logger, TypedEmitter } from '@n8n/backend-common';
 import {
 	SettingsRepository,
 	StatisticsNames,
@@ -16,7 +16,6 @@ import type {
 
 import { EventService } from '@/events/event.service';
 import { UserService } from '@/services/user.service';
-import { TypedEmitter } from '@/typed-emitter';
 
 import { OwnershipService } from './ownership.service';
 

--- a/packages/cli/src/task-runners/__tests__/sliding-window-signal.test.ts
+++ b/packages/cli/src/task-runners/__tests__/sliding-window-signal.test.ts
@@ -1,4 +1,5 @@
-import { TypedEmitter } from '../../typed-emitter';
+import { TypedEmitter } from '@n8n/backend-common';
+
 import { SlidingWindowSignal } from '../sliding-window-signal';
 
 type TestEventMap = {

--- a/packages/cli/src/task-runners/sliding-window-signal.ts
+++ b/packages/cli/src/task-runners/sliding-window-signal.ts
@@ -1,4 +1,4 @@
-import type { TypedEmitter } from '../typed-emitter';
+import type { TypedEmitter } from '@n8n/backend-common';
 
 export type SlidingWindowSignalOpts = {
 	windowSizeInMs?: number;

--- a/packages/cli/src/task-runners/task-runner-lifecycle-events.ts
+++ b/packages/cli/src/task-runners/task-runner-lifecycle-events.ts
@@ -1,6 +1,5 @@
+import { TypedEmitter } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
-
-import { TypedEmitter } from '@/typed-emitter';
 
 type TaskRunnerLifecycleEventMap = {
 	'runner:failed-heartbeat-check': never;

--- a/packages/cli/src/task-runners/task-runner-process-base.ts
+++ b/packages/cli/src/task-runners/task-runner-process-base.ts
@@ -1,11 +1,9 @@
-import { Logger } from '@n8n/backend-common';
+import { Logger, TypedEmitter } from '@n8n/backend-common';
 import { LogScope, TaskRunnersConfig } from '@n8n/config';
 import { OnShutdown } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
-
-import { TypedEmitter } from '@/typed-emitter';
 
 import { forwardToLogger } from './forward-to-logger';
 import { TaskBrokerAuthService } from './task-broker/auth/task-broker-auth.service';

--- a/packages/cli/src/task-runners/task-runner-process-restart-loop-detector.ts
+++ b/packages/cli/src/task-runners/task-runner-process-restart-loop-detector.ts
@@ -1,7 +1,7 @@
+import { TypedEmitter } from '@n8n/backend-common';
 import { Time } from '@n8n/constants';
 
 import { TaskRunnerRestartLoopError } from '@/task-runners/errors/task-runner-restart-loop-error';
-import { TypedEmitter } from '@/typed-emitter';
 
 import type { TaskRunnerProcessBase } from './task-runner-process-base';
 


### PR DESCRIPTION
## Summary

Moves `TypedEmitter` from `packages/cli` to `@n8n/backend-common`.

Why: to make it available to shared backend packages without introducing a `cli` dependency.

Changes:
- Moved `TypedEmitter` class to `packages/@n8n`
- Removed the dependency to `lodash`(it was for a single call to `debounce`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3359

This is a prerequisite for CAT-2392 and CAT-2393 (exposing DNS cache and SSRF protection metrics via PrometheusMetricsService from services outside the CLI package).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.