### PR TITLE
fix(core): Surface a final response when a builder follow-up completes silently

### DIFF
--- a/packages/@n8n/instance-ai/src/runtime/__tests__/terminal-response-guard.test.ts
+++ b/packages/@n8n/instance-ai/src/runtime/__tests__/terminal-response-guard.test.ts
@@ -42,6 +42,15 @@ function childText(): InstanceAiEvent {
 	};
 }
 
+function toolCall(): InstanceAiEvent {
+	return {
+		type: 'tool-call',
+		runId,
+		agentId: rootAgentId,
+		payload: { toolCallId: 'tc-1', toolName: 'build_workflow', args: {} },
+	};
+}
+
 function previousRunRootText(): InstanceAiEvent {
 	return {
 		type: 'text-delta',
@@ -90,8 +99,8 @@ describe('InstanceAiTerminalResponseGuard', () => {
 		});
 	});
 
-	it('does not emit completed fallback when silence is expected', () => {
-		const decision = guard().evaluateTerminal([runStart()], 'completed', {
+	it('does not emit completed fallback when silence is expected and an agent already produced text', () => {
+		const decision = guard().evaluateTerminal([runStart(), childText()], 'completed', {
 			workSummary: { totalToolCalls: 3, totalToolErrors: 0, toolCalls: [] },
 			suppressCompletedFallback: true,
 		});
@@ -99,6 +108,26 @@ describe('InstanceAiTerminalResponseGuard', () => {
 		expect(decision.action).toBe('none');
 		expect(decision.reason).toBe('completed-silent-suppressed');
 		expect(decision.event).toBeUndefined();
+	});
+
+	it('emits fallback for a suppressed completed run that produced no text', () => {
+		const decision = guard().evaluateTerminal([runStart()], 'completed', {
+			suppressCompletedFallback: true,
+		});
+
+		expect(decision.action).toBe('emit');
+		expect(decision.reason).toBe('completed-silent');
+		expect(decision.event?.type).toBe('text-delta');
+	});
+
+	it('emits fallback for a suppressed completed run that only made internal tool calls', () => {
+		const decision = guard().evaluateTerminal([runStart(), toolCall()], 'completed', {
+			suppressCompletedFallback: true,
+		});
+
+		expect(decision.action).toBe('emit');
+		expect(decision.reason).toBe('completed-silent');
+		expect(decision.event?.type).toBe('text-delta');
 	});
 
 	it('does not emit completed fallback when the message group already has root text', () => {

--- a/packages/@n8n/instance-ai/src/runtime/terminal-response-guard.ts
+++ b/packages/@n8n/instance-ai/src/runtime/terminal-response-guard.ts
@@ -109,7 +109,8 @@ export class InstanceAiTerminalResponseGuard {
 					reason: 'already-visible',
 				};
 			}
-			if (options.suppressCompletedFallback) {
+			// Only suppress when some agent already produced text; a turn with no text at all must still emit.
+			if (options.suppressCompletedFallback && visibility.hasAgentText) {
 				return {
 					status,
 					visibilitySource: 'none',
@@ -206,12 +207,15 @@ export class InstanceAiTerminalResponseGuard {
 		hasRootError: boolean;
 		hasMessageGroupRootText: boolean;
 		hasCurrentRunFallback: boolean;
+		hasAgentText: boolean;
 	} {
 		const currentRunEvents = events.filter((event) => event.runId === this.options.runId);
 		return {
 			hasRootText: currentRunEvents.some(
 				(event) => event.agentId === this.options.rootAgentId && hasText(event),
 			),
+			// Any agent's text this run. Tool calls don't count — internal calls (e.g. complete-checkpoint) aren't a visible answer.
+			hasAgentText: currentRunEvents.some((event) => hasText(event)),
 			hasRootError: currentRunEvents.some(
 				(event) => event.agentId === this.options.rootAgentId && event.type === 'error',
 			),


### PR DESCRIPTION
## Summary

A user builds a workflow, then sends a follow-up "change this" request. The builder does extensive background work but the user is left with **no visible response** — an empty turn (INS-483, ~25% repro on 2.25.5/2.25.6).

Root cause is in the terminal-response guard. For checkpoint / planned-build follow-up runs the service sets `suppressCompletedFallback: true` so that *intermediate* runs in a multi-run interaction don't each emit a generic closing line. But the guard reaches that branch **only after it has already proven there is no root text and no message-group text** (those cases return earlier as `already-visible`). So when the branch fired it suppressed the fallback even when **no agent produced any text at all**, resolving the turn silently.

The fix scopes suppression to runs where **some agent already produced text**. Tool calls do **not** count as a visible response — internal calls (e.g. `complete-checkpoint`) aren't an answer. A completed run with no text now always emits the fallback so the turn carries a non-null assistant response; runs where a sub-agent produced text stay quiet, so this does not reintroduce the closing-line spam the flag was added to prevent.

### Confirmed against the production trace

I pulled the LangSmith trace for thread `5c776833-f0b1-4c35-ac48-d3a77f48b63d` (37 turns). Exactly one turn completed with no response — run `00000000-0000-0000-5235-d0c4e171f6f4` (`orchestrator_resume`, `final_status: completed`, output `{runId, status}` with no `response`). It is a **checkpoint follow-up**: after the user deferred workflow setup, the orchestrator ran two LLM calls that emitted **only tool calls** (`workflows[setup]`, `complete-checkpoint`) and **no text**, then completed silently.

```
chain:orchestrator (resume after deferred setup)
  tool:workflows[setup]     -> { deferred: true }   (user skipped setup)
  llm:orchestrator          -> empty (only tool calls)
  tool:complete-checkpoint  -> internal bookkeeping
  llm:orchestrator          -> empty (only tool calls)
-> output { runId, status: "completed" }            (no response -> blank turn)
```

This is exactly the `suppressCompletedFallback` checkpoint path. Note it made tool calls but no text, which is why "agent text" (not "any tool call") is the correct signal — a tool-call-based check would have left this trace unfixed.

## How to test

Unit:

```bash
cd packages/@n8n/instance-ai
pnpm vitest run src/runtime/__tests__/terminal-response-guard.test.ts
```

New / updated coverage in `terminal-response-guard.test.ts`:
- suppressed completed run with **no text** → emits a fallback (`action: 'emit'`)
- suppressed completed run that **only made internal tool calls** (mirrors the trace) → emits a fallback
- suppressed completed run where an **agent already produced text** → stays silent (`completed-silent-suppressed`)

Manual: build a workflow, send a follow-up that ends on a checkpoint where you defer setup. The assistant turn should always show a response, never a blank turn.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-483/workflow-fails-to-build-after-additional-user-request

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
