### PR TITLE
feat(core): Auto delete archived sandboxes and support configuring archive/delete TTL (no-changelog)

### DIFF
--- a/packages/@n8n/agents/src/__tests__/workspace/sandbox/create-workspace.test.ts
+++ b/packages/@n8n/agents/src/__tests__/workspace/sandbox/create-workspace.test.ts
@@ -57,6 +57,28 @@ describe('createSandbox', () => {
 		);
 	});
 
+	it('passes archive and delete intervals through to the DaytonaSandbox', async () => {
+		const config: SandboxConfig = {
+			enabled: true,
+			provider: 'daytona',
+			daytonaApiUrl: 'https://api.daytona.io',
+			daytonaApiKey: 'test-key',
+			autoArchiveInterval: 1440,
+			autoDeleteInterval: 43_200,
+			timeout: 60_000,
+		};
+
+		const result = await createSandbox(config);
+
+		expect(
+			(
+				result as unknown as {
+					options: { autoArchiveInterval?: number; autoDeleteInterval?: number };
+				}
+			).options,
+		).toMatchObject({ autoArchiveInterval: 1440, autoDeleteInterval: 43_200 });
+	});
+
 	it('omits ephemeral from the DaytonaSandbox when not configured', async () => {
 		const config: SandboxConfig = {
 			enabled: true,

--- a/packages/@n8n/agents/src/__tests__/workspace/sandbox/create-workspace.test.ts
+++ b/packages/@n8n/agents/src/__tests__/workspace/sandbox/create-workspace.test.ts
@@ -57,12 +57,13 @@ describe('createSandbox', () => {
 		);
 	});
 
-	it('passes archive and delete intervals through to the DaytonaSandbox', async () => {
+	it('passes stop, archive and delete intervals through to the DaytonaSandbox', async () => {
 		const config: SandboxConfig = {
 			enabled: true,
 			provider: 'daytona',
 			daytonaApiUrl: 'https://api.daytona.io',
 			daytonaApiKey: 'test-key',
+			autoStopInterval: 30,
 			autoArchiveInterval: 1440,
 			autoDeleteInterval: 43_200,
 			timeout: 60_000,
@@ -73,10 +74,18 @@ describe('createSandbox', () => {
 		expect(
 			(
 				result as unknown as {
-					options: { autoArchiveInterval?: number; autoDeleteInterval?: number };
+					options: {
+						autoStopInterval?: number;
+						autoArchiveInterval?: number;
+						autoDeleteInterval?: number;
+					};
 				}
 			).options,
-		).toMatchObject({ autoArchiveInterval: 1440, autoDeleteInterval: 43_200 });
+		).toMatchObject({
+			autoStopInterval: 30,
+			autoArchiveInterval: 1440,
+			autoDeleteInterval: 43_200,
+		});
 	});
 
 	it('omits ephemeral from the DaytonaSandbox when not configured', async () => {

--- a/packages/@n8n/agents/src/workspace/sandbox/create-workspace.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/create-workspace.ts
@@ -37,6 +37,12 @@ function buildSandbox(
 			apiUrl: config.daytonaApiUrl,
 			labels: config.labels,
 			...(config.ephemeral !== undefined ? { ephemeral: config.ephemeral } : {}),
+			...(config.autoArchiveInterval !== undefined
+				? { autoArchiveInterval: config.autoArchiveInterval }
+				: {}),
+			...(config.autoDeleteInterval !== undefined
+				? { autoDeleteInterval: config.autoDeleteInterval }
+				: {}),
 			...(config.image ? { image: config.image } : {}),
 			...(config.snapshot ? { snapshot: config.snapshot } : {}),
 			language: 'typescript',

--- a/packages/@n8n/agents/src/workspace/sandbox/create-workspace.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/create-workspace.ts
@@ -37,6 +37,9 @@ function buildSandbox(
 			apiUrl: config.daytonaApiUrl,
 			labels: config.labels,
 			...(config.ephemeral !== undefined ? { ephemeral: config.ephemeral } : {}),
+			...(config.autoStopInterval !== undefined
+				? { autoStopInterval: config.autoStopInterval }
+				: {}),
 			...(config.autoArchiveInterval !== undefined
 				? { autoArchiveInterval: config.autoArchiveInterval }
 				: {}),

--- a/packages/@n8n/agents/src/workspace/sandbox/types.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/types.ts
@@ -78,6 +78,7 @@ export interface DaytonaSandboxConfig extends SandboxConfigBase {
 	 * Overrides {@link autoDeleteInterval} (Daytona forces it to 0 when ephemeral).
 	 */
 	ephemeral?: boolean;
+	autoStopInterval?: number;
 	autoArchiveInterval?: number;
 	autoDeleteInterval?: number;
 	createTimeoutSeconds?: number;

--- a/packages/@n8n/agents/src/workspace/sandbox/types.ts
+++ b/packages/@n8n/agents/src/workspace/sandbox/types.ts
@@ -75,8 +75,11 @@ export interface DaytonaSandboxConfig extends SandboxConfigBase {
 	/**
 	 * When true, Daytona auto-deletes the sandbox when it stops (instead of leaving it
 	 * stopped). Used for throwaway sandboxes (e.g. eval runs) so they don't accumulate.
+	 * Overrides {@link autoDeleteInterval} (Daytona forces it to 0 when ephemeral).
 	 */
 	ephemeral?: boolean;
+	autoArchiveInterval?: number;
+	autoDeleteInterval?: number;
 	createTimeoutSeconds?: number;
 	getAuthToken?: () => Promise<string>;
 	refreshSkewMs?: number;

--- a/packages/@n8n/config/src/configs/instance-ai.config.ts
+++ b/packages/@n8n/config/src/configs/instance-ai.config.ts
@@ -80,6 +80,13 @@ export class InstanceAiConfig {
 	sandboxEphemeral: boolean = false;
 
 	/**
+	 * Minutes an idle Daytona sandbox waits before it is stopped. Default 15 minutes.
+	 * `0` disables auto-stop (the sandbox stays running).
+	 */
+	@Env('N8N_INSTANCE_AI_SANDBOX_AUTO_STOP_MINUTES')
+	sandboxAutoStopMinutes: number = 15;
+
+	/**
 	 * Minutes a stopped Daytona sandbox waits before it is archived to cold storage.
 	 * Default 7 days. `0` uses Daytona's maximum interval.
 	 */

--- a/packages/@n8n/config/src/configs/instance-ai.config.ts
+++ b/packages/@n8n/config/src/configs/instance-ai.config.ts
@@ -80,6 +80,20 @@ export class InstanceAiConfig {
 	sandboxEphemeral: boolean = false;
 
 	/**
+	 * Minutes a stopped Daytona sandbox waits before it is archived to cold storage.
+	 * Default 7 days. `0` uses Daytona's maximum interval.
+	 */
+	@Env('N8N_INSTANCE_AI_SANDBOX_AUTO_ARCHIVE_MINUTES')
+	sandboxAutoArchiveMinutes: number = 7 * 24 * 60;
+
+	/**
+	 * Minutes a stopped Daytona sandbox waits before it is deleted. Default 30 days. A negative
+	 * value disables auto-delete; `0` deletes on stop. Ignored when {@link sandboxEphemeral} is true.
+	 */
+	@Env('N8N_INSTANCE_AI_SANDBOX_AUTO_DELETE_MINUTES')
+	sandboxAutoDeleteMinutes: number = 30 * 24 * 60;
+
+	/**
 	 * Skew (milliseconds) used to proactively refresh the Daytona proxy JWT before it expires.
 	 * Refresh fires when the cached token's remaining lifetime falls below this threshold.
 	 * Only used in proxy mode (when a `getAuthToken` callback is configured); ignored for static API keys.

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -299,6 +299,7 @@ describe('GlobalConfig', () => {
 			sandboxTimeout: 300000,
 			sandboxNamePrefix: '',
 			sandboxEphemeral: false,
+			sandboxAutoStopMinutes: 15,
 			sandboxAutoArchiveMinutes: 10_080,
 			sandboxAutoDeleteMinutes: 43_200,
 			daytonaTokenRefreshSkewMs: 300_000,

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -299,6 +299,8 @@ describe('GlobalConfig', () => {
 			sandboxTimeout: 300000,
 			sandboxNamePrefix: '',
 			sandboxEphemeral: false,
+			sandboxAutoArchiveMinutes: 10_080,
+			sandboxAutoDeleteMinutes: 43_200,
 			daytonaTokenRefreshSkewMs: 300_000,
 			builderSandboxTtlMs: 900_000,
 			braveSearchApiKey: '',

--- a/packages/@n8n/instance-ai/docs/configuration.md
+++ b/packages/@n8n/instance-ai/docs/configuration.md
@@ -66,6 +66,7 @@ When no search provider is available, the `web-search` action is disabled. `fetc
 | `N8N_INSTANCE_AI_SANDBOX_TIMEOUT` | number | `300000` | Default command timeout in the sandbox (milliseconds). |
 | `N8N_INSTANCE_AI_SANDBOX_NAME_PREFIX` | string | `''` | Prefix prepended to every Daytona sandbox name (e.g. `eval-baseline-daily`). Also surfaced as a `name_prefix` label. Empty in production. |
 | `N8N_INSTANCE_AI_SANDBOX_EPHEMERAL` | boolean | `false` | When true, Daytona sandboxes are created ephemeral (auto-deleted on stop) instead of lingering stopped. Intended for throwaway eval instances so sandboxes don't accumulate. |
+| `N8N_INSTANCE_AI_SANDBOX_AUTO_STOP_MINUTES` | number | `15` | Minutes an idle Daytona sandbox waits before being stopped. `0` disables auto-stop. |
 | `N8N_INSTANCE_AI_SANDBOX_AUTO_ARCHIVE_MINUTES` | number | `10080` (7 days) | Minutes a stopped Daytona sandbox waits before being archived to cold storage. `0` uses Daytona's maximum interval. |
 | `N8N_INSTANCE_AI_SANDBOX_AUTO_DELETE_MINUTES` | number | `43200` (30 days) | Minutes a stopped Daytona sandbox waits before being deleted. Negative disables auto-delete; `0` deletes on stop. Ignored when `N8N_INSTANCE_AI_SANDBOX_EPHEMERAL` is true. |
 

--- a/packages/@n8n/instance-ai/docs/configuration.md
+++ b/packages/@n8n/instance-ai/docs/configuration.md
@@ -66,6 +66,8 @@ When no search provider is available, the `web-search` action is disabled. `fetc
 | `N8N_INSTANCE_AI_SANDBOX_TIMEOUT` | number | `300000` | Default command timeout in the sandbox (milliseconds). |
 | `N8N_INSTANCE_AI_SANDBOX_NAME_PREFIX` | string | `''` | Prefix prepended to every Daytona sandbox name (e.g. `eval-baseline-daily`). Also surfaced as a `name_prefix` label. Empty in production. |
 | `N8N_INSTANCE_AI_SANDBOX_EPHEMERAL` | boolean | `false` | When true, Daytona sandboxes are created ephemeral (auto-deleted on stop) instead of lingering stopped. Intended for throwaway eval instances so sandboxes don't accumulate. |
+| `N8N_INSTANCE_AI_SANDBOX_AUTO_ARCHIVE_MINUTES` | number | `10080` (7 days) | Minutes a stopped Daytona sandbox waits before being archived to cold storage. `0` uses Daytona's maximum interval. |
+| `N8N_INSTANCE_AI_SANDBOX_AUTO_DELETE_MINUTES` | number | `43200` (30 days) | Minutes a stopped Daytona sandbox waits before being deleted. Negative disables auto-delete; `0` deletes on stop. Ignored when `N8N_INSTANCE_AI_SANDBOX_EPHEMERAL` is true. |
 
 When sandbox is enabled, the builder agent writes TypeScript to
 `~/workspace/src/workflow.ts`, runs `tsc` for validation, and uses

--- a/packages/@n8n/instance-ai/docs/sandboxing.md
+++ b/packages/@n8n/instance-ai/docs/sandboxing.md
@@ -248,5 +248,6 @@ If any step fails, the agent reads the error output, fixes the code, and retries
 | `N8N_INSTANCE_AI_SANDBOX_TIMEOUT` | `300000` | Command timeout in milliseconds |
 | `N8N_INSTANCE_AI_SANDBOX_NAME_PREFIX` | — | Prefix for every Daytona sandbox name (e.g. `eval-baseline-daily`). Also added as a `name_prefix` label. Empty in production. |
 | `N8N_INSTANCE_AI_SANDBOX_EPHEMERAL` | `false` | Create Daytona sandboxes ephemeral (auto-deleted on stop) instead of lingering stopped. Intended for throwaway eval instances so sandboxes don't accumulate. |
+| `N8N_INSTANCE_AI_SANDBOX_AUTO_STOP_MINUTES` | `15` | Minutes an idle sandbox waits before Daytona stops it. `0` = disabled (stays running). |
 | `N8N_INSTANCE_AI_SANDBOX_AUTO_ARCHIVE_MINUTES` | `10080` (7 days) | Minutes a stopped sandbox waits before Daytona archives it to cold storage. `0` = Daytona's max interval. |
 | `N8N_INSTANCE_AI_SANDBOX_AUTO_DELETE_MINUTES` | `43200` (30 days) | Minutes a stopped sandbox waits before Daytona deletes it. Negative = disabled; `0` = on stop. Ignored when `N8N_INSTANCE_AI_SANDBOX_EPHEMERAL` is true. |

--- a/packages/@n8n/instance-ai/docs/sandboxing.md
+++ b/packages/@n8n/instance-ai/docs/sandboxing.md
@@ -248,3 +248,5 @@ If any step fails, the agent reads the error output, fixes the code, and retries
 | `N8N_INSTANCE_AI_SANDBOX_TIMEOUT` | `300000` | Command timeout in milliseconds |
 | `N8N_INSTANCE_AI_SANDBOX_NAME_PREFIX` | — | Prefix for every Daytona sandbox name (e.g. `eval-baseline-daily`). Also added as a `name_prefix` label. Empty in production. |
 | `N8N_INSTANCE_AI_SANDBOX_EPHEMERAL` | `false` | Create Daytona sandboxes ephemeral (auto-deleted on stop) instead of lingering stopped. Intended for throwaway eval instances so sandboxes don't accumulate. |
+| `N8N_INSTANCE_AI_SANDBOX_AUTO_ARCHIVE_MINUTES` | `10080` (7 days) | Minutes a stopped sandbox waits before Daytona archives it to cold storage. `0` = Daytona's max interval. |
+| `N8N_INSTANCE_AI_SANDBOX_AUTO_DELETE_MINUTES` | `43200` (30 days) | Minutes a stopped sandbox waits before Daytona deletes it. Negative = disabled; `0` = on stop. Ignored when `N8N_INSTANCE_AI_SANDBOX_EPHEMERAL` is true. |

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -3064,6 +3064,7 @@ describe('getSandboxConfigFromEnv', () => {
 			sandboxTimeout: number;
 			sandboxNamePrefix: string;
 			sandboxEphemeral: boolean;
+			sandboxAutoStopMinutes: number;
 			sandboxAutoArchiveMinutes: number;
 			sandboxAutoDeleteMinutes: number;
 			daytonaTokenRefreshSkewMs: number;
@@ -3084,6 +3085,7 @@ describe('getSandboxConfigFromEnv', () => {
 			sandboxTimeout: 1000,
 			sandboxNamePrefix: '',
 			sandboxEphemeral: false,
+			sandboxAutoStopMinutes: 15,
 			sandboxAutoArchiveMinutes: 10_080,
 			sandboxAutoDeleteMinutes: 43_200,
 			daytonaTokenRefreshSkewMs: 1000,
@@ -3111,15 +3113,17 @@ describe('getSandboxConfigFromEnv', () => {
 		});
 	});
 
-	it('forwards archive and delete intervals for non-ephemeral sandboxes', () => {
+	it('forwards stop, archive and delete intervals for non-ephemeral sandboxes', () => {
 		const service = createSandboxConfigService({
 			sandboxEphemeral: false,
+			sandboxAutoStopMinutes: 30,
 			sandboxAutoArchiveMinutes: 1440,
 			sandboxAutoDeleteMinutes: 43_200,
 		});
 
 		expect(service.getSandboxConfigFromEnv()).toMatchObject({
 			provider: 'daytona',
+			autoStopInterval: 30,
 			autoArchiveInterval: 1440,
 			autoDeleteInterval: 43_200,
 		});

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.service.test.ts
@@ -3064,6 +3064,8 @@ describe('getSandboxConfigFromEnv', () => {
 			sandboxTimeout: number;
 			sandboxNamePrefix: string;
 			sandboxEphemeral: boolean;
+			sandboxAutoArchiveMinutes: number;
+			sandboxAutoDeleteMinutes: number;
 			daytonaTokenRefreshSkewMs: number;
 		};
 		getSandboxConfigFromEnv: () => SandboxConfig;
@@ -3082,6 +3084,8 @@ describe('getSandboxConfigFromEnv', () => {
 			sandboxTimeout: 1000,
 			sandboxNamePrefix: '',
 			sandboxEphemeral: false,
+			sandboxAutoArchiveMinutes: 10_080,
+			sandboxAutoDeleteMinutes: 43_200,
 			daytonaTokenRefreshSkewMs: 1000,
 			...overrides,
 		};
@@ -3105,5 +3109,31 @@ describe('getSandboxConfigFromEnv', () => {
 			provider: 'daytona',
 			ephemeral: false,
 		});
+	});
+
+	it('forwards archive and delete intervals for non-ephemeral sandboxes', () => {
+		const service = createSandboxConfigService({
+			sandboxEphemeral: false,
+			sandboxAutoArchiveMinutes: 1440,
+			sandboxAutoDeleteMinutes: 43_200,
+		});
+
+		expect(service.getSandboxConfigFromEnv()).toMatchObject({
+			provider: 'daytona',
+			autoArchiveInterval: 1440,
+			autoDeleteInterval: 43_200,
+		});
+	});
+
+	it('omits the delete interval for ephemeral sandboxes so Daytona deletes on stop', () => {
+		const service = createSandboxConfigService({
+			sandboxEphemeral: true,
+			sandboxAutoDeleteMinutes: 43_200,
+		});
+
+		const config = service.getSandboxConfigFromEnv();
+
+		expect(config).toMatchObject({ provider: 'daytona', ephemeral: true });
+		expect((config as { autoDeleteInterval?: number }).autoDeleteInterval).toBeUndefined();
 	});
 });

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -729,6 +729,8 @@ export class InstanceAiService {
 			sandboxTimeout,
 			sandboxNamePrefix,
 			sandboxEphemeral,
+			sandboxAutoArchiveMinutes,
+			sandboxAutoDeleteMinutes,
 			daytonaTokenRefreshSkewMs,
 		} = this.instanceAiConfig;
 		const provider = normalizeSandboxProvider(sandboxProvider);
@@ -751,6 +753,10 @@ export class InstanceAiService {
 				timeout: sandboxTimeout,
 				namePrefix: sandboxNamePrefix || undefined,
 				ephemeral: sandboxEphemeral,
+				autoArchiveInterval: sandboxAutoArchiveMinutes,
+				// Ephemeral sandboxes delete on stop; Daytona forces autoDeleteInterval to 0 and warns
+				// if we also pass a non-zero value, so leave it unset on the ephemeral path.
+				autoDeleteInterval: sandboxEphemeral ? undefined : sandboxAutoDeleteMinutes,
 				refreshSkewMs: daytonaTokenRefreshSkewMs,
 			};
 		}

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -729,6 +729,7 @@ export class InstanceAiService {
 			sandboxTimeout,
 			sandboxNamePrefix,
 			sandboxEphemeral,
+			sandboxAutoStopMinutes,
 			sandboxAutoArchiveMinutes,
 			sandboxAutoDeleteMinutes,
 			daytonaTokenRefreshSkewMs,
@@ -753,6 +754,7 @@ export class InstanceAiService {
 				timeout: sandboxTimeout,
 				namePrefix: sandboxNamePrefix || undefined,
 				ephemeral: sandboxEphemeral,
+				autoStopInterval: sandboxAutoStopMinutes,
 				autoArchiveInterval: sandboxAutoArchiveMinutes,
 				// Ephemeral sandboxes delete on stop; Daytona forces autoDeleteInterval to 0 and warns
 				// if we also pass a non-zero value, so leave it unset on the ephemeral path.


### PR DESCRIPTION
## Summary

Instead of using the defaults, auto-stop / auto-archive / auto-delete after
- auto-stop after 15 mins
- auto-archive after 7 days
- auto-delete after 30 days (was **never**)

and make those configurable through env, cause why not, but lets hope we don't need to touch those.
Daytona stops biling after auto-archive and moves the sandboxes to cold storage, but I don't think we want to keep them around forever, cluttering our sandboxes.

## How to test

Set `N8N_INSTANCE_AI_SANDBOX_AUTO_ARCHIVE_MINUTES` / `N8N_INSTANCE_AI_SANDBOX_AUTO_DELETE_MINUTES` / `N8N_INSTANCE_AI_SANDBOX_AUTO_STOP_MINUTES` and check the lifecycle settings of the sandboxes that get created.

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
