### PR TITLE
fix: Replace DHI base image with standard Docker Hub node alpine

### DIFF
--- a/.github/workflows/build-base-image.yml
+++ b/.github/workflows/build-base-image.yml
@@ -25,9 +25,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Node 26 requires alpine 3.23 on DHI (3.22 pairing isn't published).
-        # While we're on alpine 3.22 awaiting NODE-4184 (graphicsmagick → sharp
-        # migration that unblocks 3.23), Node 26 base builds can't succeed.
+        # Node 26 requires alpine 3.23. While we're on alpine 3.22 awaiting
+        # NODE-4184 (graphicsmagick → sharp migration that unblocks 3.23),
+        # Node 26 base builds can't succeed.
         # Restore '26' to this matrix once 3.23 is back.
         node_version: ['22', '24.15.0']
     steps:
@@ -39,11 +39,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Login to DHI Registry (for pulling base images)
+      - name: Login to DockerHub (for pulling base images)
         uses: ./.github/actions/docker-registry-login
         with:
           login-ghcr: 'false'
-          login-dhi: 'true'
+          login-dockerhub: 'true'
           dockerhub-username: ${{ secrets.DOCKER_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
 

--- a/.github/workflows/docker-build-smoke.yml
+++ b/.github/workflows/docker-build-smoke.yml
@@ -33,11 +33,11 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Login to DHI Registry (for base image)
+      - name: Login to DockerHub (for pulling base image)
         uses: ./.github/actions/docker-registry-login
         with:
           login-ghcr: 'false'
-          login-dhi: 'true'
+          login-dockerhub: 'true'
           dockerhub-username: ${{ secrets.DOCKER_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
 

--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -2,7 +2,7 @@ ARG NODE_VERSION=24.15.0
 
 # Pinned to multi-arch index digest (linux/amd64 + linux/arm64) for reproducible builds.
 # Bump the digest together with the tag when updating the base image.
-FROM dhi.io/node:24.15.0-alpine3.22-dev@sha256:a7eead704e9bd2d7a4c1b52cf595848f180365eba7c15a185ce1c3a690c1a19d
+FROM node:24.15.0-alpine3.22@sha256:b689d4005875ae167178471a7a622ec2909459a3bbb32277260be1971af7a99f
 
 ARG NODE_VERSION
 
@@ -31,7 +31,4 @@ RUN apk add --no-cache busybox-binsh && \
     apk del apk-tools
 
 WORKDIR /home/node
-# DHI images use a non-standard global npm path, so we need to set NODE_PATH
-# to allow externally installed npm packages to be found by require()
-ENV NODE_PATH=/opt/nodejs/node-v${NODE_VERSION}/lib/node_modules
 EXPOSE 5678/tcp

--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -10,7 +10,7 @@ ARG NODE_VERSION
 RUN apk add --no-cache busybox-binsh && \
     # Install fonts
     apk --no-cache add --virtual .build-deps-fonts msttcorefonts-installer fontconfig && \
-    for i in 1 2 3; do update-ms-fonts && break; echo "update-ms-fonts attempt $i failed, retrying..."; sleep 5; done && \
+    update-ms-fonts && \
     fc-cache -f && \
     apk del .build-deps-fonts && \
     find /usr/share/fonts/truetype/msttcorefonts/ -type l -exec unlink {} \; && \

--- a/docker/images/n8n-base/Dockerfile
+++ b/docker/images/n8n-base/Dockerfile
@@ -10,7 +10,7 @@ ARG NODE_VERSION
 RUN apk add --no-cache busybox-binsh && \
     # Install fonts
     apk --no-cache add --virtual .build-deps-fonts msttcorefonts-installer fontconfig && \
-    update-ms-fonts && \
+    for i in 1 2 3; do update-ms-fonts && break; echo "update-ms-fonts attempt $i failed, retrying..."; sleep 5; done && \
     fc-cache -f && \
     apk del .build-deps-fonts && \
     find /usr/share/fonts/truetype/msttcorefonts/ -type l -exec unlink {} \; && \

--- a/docker/images/n8n/Dockerfile
+++ b/docker/images/n8n/Dockerfile
@@ -24,7 +24,7 @@ RUN apk add --no-cache python3 make g++ && \
 # base change, so a base rebuild does not reach this image until the digest is
 # manually re-pinned here. Bump the digest together with the tag whenever the base
 # image is intentionally updated.
-FROM n8nio/base:24.15.0@sha256:dade45d8a974e72bccbf57c13bc684b5dbb2f73e0ca7c837739e439de7b91aa9
+FROM n8nio/base:24.15.0@sha256:04445a68859db3bdd7de2f2a036e790e6d2d564266e0b0b1f3cba34c0a66e331
 
 ARG N8N_VERSION
 ARG N8N_RELEASE_TYPE=dev


### PR DESCRIPTION
## Summary

Switches the `n8n-base` Dockerfile from the DHI (`dhi.io`) node image to the standard Docker Hub `node:24.15.0-alpine3.22` image. The `dhi.io` registry is currently causing image pull failures in production (layer count mismatch + auth errors), breaking cloud instance deployments.

Changes:
- `docker/images/n8n-base/Dockerfile`: `FROM dhi.io/node:24.15.0-alpine3.22-dev` → `FROM node:24.15.0-alpine3.22` using the existing multi-arch digest already pinned in the n8n/Dockerfile builder stage. Removes the DHI-specific `NODE_PATH` override (standard node images use `/usr/local/lib/node_modules` which Node resolves automatically).
- `build-base-image.yml`: DHI login → DockerHub login for pulling base images.
- `docker-build-smoke.yml`: DHI login → DockerHub login for pulling base images.

## How to test

The smoke test (`Docker Build Smoke Test`) and base image build (`Build: Base Image`) CI jobs will trigger automatically on this PR. Both jobs previously logged into DHI to pull the base image — they now use DockerHub credentials instead.

Once both pass, `n8nio/base` can be rebuilt and re-pinned in `docker/images/n8n/Dockerfile` line 27.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Incident: DHI registry pulling image "n8n:2.26.0" - layer count mismatch + 401 on dhi.io -->

## Review / Merge checklist
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI