### PR TITLE
feat: Add discovery-driven OAuth2 client to the local-gateway app (no-changelog)

### DIFF
--- a/packages/@n8n/local-gateway/eslint.config.mjs
+++ b/packages/@n8n/local-gateway/eslint.config.mjs
@@ -2,7 +2,7 @@ import { defineConfig, globalIgnores } from 'eslint/config';
 import { nodeConfig } from '@n8n/eslint-config/node';
 
 export default defineConfig(
-	globalIgnores(['electron-builder.config.js','scripts/**']),
+	globalIgnores(['electron-builder.config.js', 'scripts/**', 'vite.renderer.config.mts']),
 	nodeConfig,
 	{
 		rules: {

--- a/packages/@n8n/local-gateway/src/main/connect-payload.ts
+++ b/packages/@n8n/local-gateway/src/main/connect-payload.ts
@@ -1,10 +1,11 @@
+import { APP_URL_SCHEME } from '../shared/constants';
 import type { ConnectPayload } from '../shared/types';
 
-/** Registered with the OS for deeplinks (`n8n-computer-use://…`). */
-export const DEEP_LINK_PROTOCOL = 'n8n-computer-use';
+/** Registered with the OS for deeplinks (`n8n://…`). Alias of the shared app scheme. */
+export const DEEP_LINK_PROTOCOL = APP_URL_SCHEME;
 
 /**
- * Parses `n8n-computer-use://connect?url=…&token=…`. Host must be `connect`. Requires non-empty `token=` after trim.
+ * Parses `n8n://connect?url=…&token=…`. Host must be `connect`. Requires non-empty `token=` after trim.
  */
 export function parseConnectPayload(value: string): ConnectPayload | null {
 	let parsed: URL;

--- a/packages/@n8n/local-gateway/src/main/index.ts
+++ b/packages/@n8n/local-gateway/src/main/index.ts
@@ -1,5 +1,5 @@
 import { configure, logger } from '@n8n/computer-use/logger';
-import { app } from 'electron';
+import { app, shell } from 'electron';
 import * as path from 'node:path';
 
 import { assertConnectOriginAllowed } from './connect-origin';
@@ -7,13 +7,16 @@ import {
 	deepLinkProtocolsInArgv,
 	parseConnectPayload,
 	parseConnectPayloadFromArgv,
-	DEEP_LINK_PROTOCOL,
 } from './connect-payload';
 import { DaemonController } from './daemon-controller';
 import { registerIpcHandlers } from './ipc-handlers';
+import { parseOAuthCallback } from './oauth/oauth-callback';
+import { OAuthFlow } from './oauth/oauth-flow';
+import { TokenStore } from './oauth/token-store';
 import { SettingsStore } from './settings-store';
 import { openSettingsWindow, notifySettingsWindow } from './settings-window';
 import { createTray } from './tray';
+import { APP_URL_SCHEME } from '../shared/constants';
 import type { ConnectPayload } from '../shared/types';
 
 // Windows: required for proper taskbar/notification grouping
@@ -36,13 +39,20 @@ if (!app.requestSingleInstanceLock()) {
 				app.dock?.hide();
 			}
 
-			app.setAsDefaultProtocolClient(DEEP_LINK_PROTOCOL);
+			// Register our custom scheme so the OS routes `<scheme>://…` deep links (OAuth redirect) here.
+			app.setAsDefaultProtocolClient(APP_URL_SCHEME);
 
 			const settingsStore = new SettingsStore();
 			configure({ level: settingsStore.get().logLevel });
 			logger.info('n8n Gateway starting');
 
 			const controller = new DaemonController();
+			const oauthFlow = new OAuthFlow({
+				store: new TokenStore(),
+				openExternal: async (url) => {
+					await shell.openExternal(url);
+				},
+			});
 
 			const preloadPath = path.join(__dirname, 'preload.js');
 			const rendererPath = path.join(__dirname, '..', 'renderer', 'index.html');
@@ -74,11 +84,28 @@ if (!app.requestSingleInstanceLock()) {
 				});
 			}
 
-			registerIpcHandlers(controller, settingsStore, disconnectGateway);
+			registerIpcHandlers(controller, settingsStore, disconnectGateway, oauthFlow);
 
 			controller.on('statusChanged', (snapshot) => {
 				notifySettingsWindow('statusChanged', snapshot);
 			});
+
+			oauthFlow.on('authStatusChanged', (status) => {
+				notifySettingsWindow('authStatusChanged', status);
+			});
+
+			/** Route an OAuth redirect deep link to the flow. Returns true if it was one. */
+			function handleOAuthDeepLink(url: string): boolean {
+				const oauthCallback = parseOAuthCallback(url);
+				if (!oauthCallback) return false;
+				logger.info('Handling OAuth callback deep link');
+				void oauthFlow.handleCallback(oauthCallback);
+				return true;
+			}
+
+			function handleOAuthDeepLinkFromArgv(argv: string[]): boolean {
+				return argv.some((arg) => handleOAuthDeepLink(arg));
+			}
 
 			createTray(
 				controller,
@@ -101,21 +128,24 @@ if (!app.requestSingleInstanceLock()) {
 				},
 			);
 
-			const payloadFromArgs = parseConnectPayloadFromArgv(process.argv);
-			if (payloadFromArgs) {
-				handleConnectPayload(payloadFromArgs);
-			} else if (deepLinkProtocolsInArgv(process.argv)) {
-				logger.warn(
-					'Deep link present in argv but payload invalid (e.g. missing token); skipping startup connect',
-				);
+			if (!handleOAuthDeepLinkFromArgv(process.argv)) {
+				const payloadFromArgs = parseConnectPayloadFromArgv(process.argv);
+				if (payloadFromArgs) {
+					handleConnectPayload(payloadFromArgs);
+				} else if (deepLinkProtocolsInArgv(process.argv)) {
+					logger.warn(
+						'Deep link present in argv but payload invalid (e.g. missing token); skipping startup connect',
+					);
+				}
 			}
 
-			// macOS — `open-url`: Fires when the OS hands the app a `n8n-computer-use://…` URL (browser, another app,
+			// macOS — `open-url`: Fires when the OS hands the app a `n8n://…` URL (browser, another app,
 			// or “Open” from Finder). Runs for a process that is already running and also after launch when the app
 			// was opened via the protocol; cold starts may still receive the URL in `process.argv` — we parse that
 			// above so both paths are covered.
 			app.on('open-url', (event, url) => {
 				event.preventDefault();
+				if (handleOAuthDeepLink(url)) return;
 				const payload = parseConnectPayload(url);
 				if (!payload) return;
 				handleConnectPayload(payload);
@@ -126,6 +156,7 @@ if (!app.requestSingleInstanceLock()) {
 			// failed); this event receives that second process’s `argv`, which often includes the deeplink the OS
 			// passed to the new launch, so we connect from here instead of argv-only startup parsing.
 			app.on('second-instance', (_event, argv) => {
+				if (handleOAuthDeepLinkFromArgv(argv)) return;
 				const payload = parseConnectPayloadFromArgv(argv);
 				if (!payload) return;
 				handleConnectPayload(payload);

--- a/packages/@n8n/local-gateway/src/main/ipc-handlers.ts
+++ b/packages/@n8n/local-gateway/src/main/ipc-handlers.ts
@@ -2,14 +2,42 @@ import { configure, logger } from '@n8n/computer-use/logger';
 import { ipcMain } from 'electron';
 
 import type { DaemonController } from './daemon-controller';
+import type { OAuthFlow } from './oauth/oauth-flow';
 import type { AppSettings, SettingsStore } from './settings-store';
+import type { AuthStatus } from '../shared/types';
 
 export function registerIpcHandlers(
 	controller: DaemonController,
 	settingsStore: SettingsStore,
 	/** Tears down the local gateway connection (Electron app). */
 	disconnectGateway: () => Promise<void>,
+	oauthFlow: OAuthFlow,
 ): void {
+	ipcMain.handle(
+		'oauth:signIn',
+		async (_event, instanceUrl: string): Promise<{ ok: boolean; error?: string }> => {
+			logger.debug('IPC oauth:signIn', { instanceUrl });
+			try {
+				await oauthFlow.signIn(instanceUrl);
+				return { ok: true };
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				return { ok: false, error: message };
+			}
+		},
+	);
+
+	ipcMain.handle('oauth:getStatus', (): AuthStatus => {
+		logger.debug('IPC oauth:getStatus');
+		return oauthFlow.getStatus();
+	});
+
+	ipcMain.handle('oauth:signOut', (): { ok: boolean } => {
+		logger.debug('IPC oauth:signOut');
+		oauthFlow.signOut();
+		return { ok: true };
+	});
+
 	ipcMain.handle('settings:get', (): AppSettings => {
 		logger.debug('IPC settings:get');
 		return settingsStore.get();

--- a/packages/@n8n/local-gateway/src/main/oauth/oauth-callback.ts
+++ b/packages/@n8n/local-gateway/src/main/oauth/oauth-callback.ts
@@ -1,0 +1,51 @@
+import { OAUTH_CONFIG } from './oauth-config';
+
+/** Parsed result of an OAuth redirect deep link. */
+export interface OAuthCallback {
+	/** Authorization code (present on success). */
+	code?: string;
+	/** Echoed `state`; verified against the pending request before use. */
+	state: string | null;
+	/** OAuth error code (RFC 6749 §4.1.2.1), e.g. `access_denied`. */
+	error?: string;
+	errorDescription?: string;
+}
+
+/**
+ * Parse a `n8n://callback?...` OAuth redirect deep link. Returns `null` for
+ * any URL that isn't an OAuth callback (e.g. the legacy `connect` deep link), so
+ * the dispatcher can fall through to other handlers.
+ */
+export function parseOAuthCallback(rawUrl: string): OAuthCallback | null {
+	let url: URL;
+	let expected: URL;
+	try {
+		url = new URL(rawUrl);
+		expected = new URL(OAUTH_CONFIG.redirectUri);
+	} catch {
+		return null;
+	}
+
+	if (url.protocol !== expected.protocol || url.hostname !== expected.hostname) return null;
+
+	const params = url.searchParams;
+	const state = params.get('state');
+
+	const error = params.get('error');
+	if (error) {
+		return { state, error, errorDescription: params.get('error_description') ?? undefined };
+	}
+
+	const code = params.get('code');
+	if (!code) {
+		// The URL matched our redirect URI but carries neither a code nor an error, so it's a
+		// malformed callback — surface it as a failed authorization rather than silently dropping it.
+		return {
+			state,
+			error: 'invalid_callback',
+			errorDescription: 'OAuth callback was missing both code and error parameters',
+		};
+	}
+
+	return { code, state };
+}

--- a/packages/@n8n/local-gateway/src/main/oauth/oauth-client.ts
+++ b/packages/@n8n/local-gateway/src/main/oauth/oauth-client.ts
@@ -1,0 +1,137 @@
+import { OAUTH_CONFIG } from './oauth-config';
+
+/** Abort external OAuth requests that stall, so the sign-in flow can't hang indefinitely. */
+const REQUEST_TIMEOUT_MS = 15_000;
+
+/** Subset of RFC 8414 authorization-server metadata this client relies on. */
+export interface AuthServerMetadata {
+	authorization_endpoint: string;
+	token_endpoint: string;
+	scopes_supported?: string[];
+	code_challenge_methods_supported?: string[];
+}
+
+/** RFC 6749 §5.1 token response (the fields we use). */
+export interface OAuthTokens {
+	access_token: string;
+	refresh_token?: string;
+	expires_in?: number;
+	token_type?: string;
+}
+
+/** A typed OAuth error carrying the RFC 6749 §5.2 `error` code (e.g. `invalid_grant`). */
+export class OAuthError extends Error {
+	constructor(
+		readonly code: string,
+		description?: string,
+	) {
+		super(description ? `${code}: ${description}` : code);
+		this.name = 'OAuthError';
+	}
+}
+
+interface AuthorizeUrlParams {
+	codeChallenge: string;
+	state: string;
+	scopes: string[];
+}
+
+interface ExchangeCodeParams {
+	code: string;
+	codeVerifier: string;
+}
+
+/** Fetch the authorization-server metadata document for an instance (RFC 8414). */
+export async function discover(baseUrl: string): Promise<AuthServerMetadata> {
+	const response = await fetchWithTimeout(`${baseUrl}${OAUTH_CONFIG.discoveryPath}`, {
+		headers: { accept: 'application/json' },
+	});
+	if (!response.ok) {
+		throw new OAuthError('discovery_failed', `${response.status} from ${baseUrl}`);
+	}
+	return (await response.json()) as AuthServerMetadata;
+}
+
+/** Build the authorization-request URL the user opens in their browser (no `resource`: the
+ * server fixes the token audience and bounds access by the scope ceiling). */
+export function buildAuthorizeUrl(
+	metadata: AuthServerMetadata,
+	params: AuthorizeUrlParams,
+): string {
+	const url = new URL(metadata.authorization_endpoint);
+	// Set our params individually so any query component the AS already put on its
+	// authorization_endpoint (RFC 6749 §3.1) is retained rather than overwritten.
+	const requestParams: Record<string, string> = {
+		response_type: 'code',
+		client_id: OAUTH_CONFIG.clientId,
+		redirect_uri: OAUTH_CONFIG.redirectUri,
+		code_challenge: params.codeChallenge,
+		code_challenge_method: 'S256',
+		state: params.state,
+		scope: params.scopes.join(' '),
+	};
+	for (const [key, value] of Object.entries(requestParams)) {
+		url.searchParams.set(key, value);
+	}
+	return url.toString();
+}
+
+/** Exchange an authorization code for tokens (authorization_code grant). */
+export async function exchangeCode(
+	metadata: AuthServerMetadata,
+	params: ExchangeCodeParams,
+): Promise<OAuthTokens> {
+	return await postToken(metadata.token_endpoint, {
+		grant_type: 'authorization_code',
+		code: params.code,
+		code_verifier: params.codeVerifier,
+		client_id: OAUTH_CONFIG.clientId,
+		redirect_uri: OAUTH_CONFIG.redirectUri,
+	});
+}
+
+/** Mint a fresh access token from a refresh token (refresh_token grant, rotating). */
+export async function refreshTokens(
+	metadata: AuthServerMetadata,
+	refreshToken: string,
+): Promise<OAuthTokens> {
+	return await postToken(metadata.token_endpoint, {
+		grant_type: 'refresh_token',
+		refresh_token: refreshToken,
+		client_id: OAUTH_CONFIG.clientId,
+	});
+}
+
+async function postToken(endpoint: string, fields: Record<string, string>): Promise<OAuthTokens> {
+	const response = await fetchWithTimeout(endpoint, {
+		method: 'POST',
+		headers: {
+			// eslint-disable-next-line @typescript-eslint/naming-convention -- HTTP header name
+			'content-type': 'application/x-www-form-urlencoded',
+			accept: 'application/json',
+		},
+		body: new URLSearchParams(fields).toString(),
+	});
+
+	const body = (await response.json().catch(() => ({}))) as Partial<OAuthTokens> & {
+		error?: string;
+		error_description?: string;
+	};
+
+	if (!response.ok || !body.access_token) {
+		throw new OAuthError(body.error ?? 'token_request_failed', body.error_description);
+	}
+
+	return body as OAuthTokens;
+}
+
+/** `fetch` with a hard timeout, normalizing network/timeout failures to `OAuthError`. */
+async function fetchWithTimeout(url: string, init: RequestInit = {}): Promise<Response> {
+	try {
+		return await fetch(url, { ...init, signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) });
+	} catch (error) {
+		const isTimeout = error instanceof DOMException && error.name === 'TimeoutError';
+		const reason = error instanceof Error ? error.message : String(error);
+		throw new OAuthError(isTimeout ? 'request_timeout' : 'network_error', reason);
+	}
+}

--- a/packages/@n8n/local-gateway/src/main/oauth/oauth-config.ts
+++ b/packages/@n8n/local-gateway/src/main/oauth/oauth-config.ts
@@ -1,0 +1,32 @@
+import { APP_URL_SCHEME } from '../../shared/constants';
+
+/**
+ * Single source of truth for the OAuth client. The flow is discovery-driven
+ * (RFC 8414), so endpoints are never hardcoded — only the values intrinsic to
+ * this desktop app live here. These mirror the backend's seeded first-party
+ * client (see `McpOAuthConfig` / the personal-automation `oauth-e2e.md` spec).
+ */
+export const OAUTH_CONFIG = {
+	/** RFC 8414 authorization-server metadata path, appended to the instance base URL. */
+	discoveryPath: '/.well-known/oauth-authorization-server',
+
+	/**
+	 * Seeded first-party public client id. No Dynamic Client Registration: the
+	 * backend pre-seeds this client, so we ship a stable id.
+	 */
+	clientId: 'n8n-app',
+
+	/**
+	 * Custom-scheme redirect the OS routes back to this app. The backend client's
+	 * registered `redirectUris` must contain this exact string (matched verbatim),
+	 * so the seeded `n8n-app` client needs `n8n://callback` registered for it.
+	 */
+	redirectUri: `${APP_URL_SCHEME}://callback`,
+
+	/**
+	 * Scopes requested at sign-in. The server grants `requested ∩ the user's real
+	 * permissions` and stamps the result into the token's `scope` claim.
+	 * `instanceAi:gateway` is what gates the local-gateway endpoints.
+	 */
+	scopes: ['instanceAi:gateway', 'instanceAi:message', 'workflow:read', 'workflow:execute'],
+} as const;

--- a/packages/@n8n/local-gateway/src/main/oauth/oauth-flow.ts
+++ b/packages/@n8n/local-gateway/src/main/oauth/oauth-flow.ts
@@ -1,0 +1,186 @@
+import { logger } from '@n8n/computer-use/logger';
+import { EventEmitter } from 'node:events';
+
+import type { OAuthCallback } from './oauth-callback';
+import {
+	buildAuthorizeUrl,
+	discover,
+	exchangeCode,
+	OAuthError,
+	refreshTokens,
+	type AuthServerMetadata,
+	type OAuthTokens,
+} from './oauth-client';
+import { OAUTH_CONFIG } from './oauth-config';
+import { createCodeVerifier, createState, deriveCodeChallenge } from './pkce';
+import type { TokenStore } from './token-store';
+import type { AuthStatus } from '../../shared/types';
+
+/** Refresh proactively this long before the access token's reported expiry. */
+const EXPIRY_SKEW_MS = 60_000;
+
+interface PendingAuthorization {
+	state: string;
+	codeVerifier: string;
+	instanceUrl: string;
+	metadata: AuthServerMetadata;
+}
+
+interface OAuthFlowEvents {
+	authStatusChanged: [status: AuthStatus];
+}
+
+export interface OAuthFlowDeps {
+	store: TokenStore;
+	/** Opens a URL in the user's default browser (e.g. shell.openExternal). */
+	openExternal: (url: string) => Promise<void>;
+	/** Injected so time is explicit (and overridable); defaults to Date.now. */
+	now?: () => number;
+}
+
+/**
+ * Drives the OAuth2 authorization-code + PKCE flow for a public native client.
+ * Side effects (browser, persistence, clock) are injected; the rest is a small
+ * state machine that emits `authStatusChanged` as the user signs in/out.
+ */
+export class OAuthFlow extends EventEmitter<OAuthFlowEvents> {
+	private readonly store: TokenStore;
+	private readonly openExternal: (url: string) => Promise<void>;
+	private readonly now: () => number;
+	private pending: PendingAuthorization | null = null;
+	private status: AuthStatus;
+
+	constructor(deps: OAuthFlowDeps) {
+		super();
+		this.store = deps.store;
+		this.openExternal = deps.openExternal;
+		this.now = deps.now ?? (() => Date.now());
+
+		const session = this.store.getSession();
+		this.status = session
+			? { state: 'signedIn', instanceUrl: session.instanceUrl, error: null }
+			: { state: 'signedOut', instanceUrl: null, error: null };
+	}
+
+	getStatus(): AuthStatus {
+		return this.status;
+	}
+
+	/** Begin sign-in: discover the AS, then open the system browser to the authorize URL. */
+	async signIn(rawInstanceUrl: string): Promise<void> {
+		const instanceUrl = normalizeBaseUrl(rawInstanceUrl);
+		this.setStatus({ state: 'authorizing', instanceUrl, error: null });
+
+		try {
+			const metadata = await discover(instanceUrl);
+			const codeVerifier = createCodeVerifier();
+			const state = createState();
+			this.pending = { state, codeVerifier, instanceUrl, metadata };
+
+			await this.openExternal(
+				buildAuthorizeUrl(metadata, {
+					codeChallenge: deriveCodeChallenge(codeVerifier),
+					state,
+					scopes: [...OAUTH_CONFIG.scopes],
+				}),
+			);
+		} catch (error) {
+			// Record the failed state for listeners, and rethrow so the `oauth:signIn`
+			// caller learns startup failed instead of seeing a misleading success.
+			this.failAuthorization(error);
+			throw error;
+		}
+	}
+
+	/** Handle the redirect deep link: verify `state`, exchange the code, persist tokens. */
+	async handleCallback(oauthCallback: OAuthCallback): Promise<void> {
+		const pending = this.pending;
+		if (!pending) {
+			logger.warn('Received OAuth callback with no pending authorization');
+			return;
+		}
+		if (oauthCallback.state !== pending.state) {
+			this.failAuthorization(new OAuthError('state_mismatch', 'Callback state did not match'));
+			return;
+		}
+		this.pending = null;
+
+		if (oauthCallback.error || !oauthCallback.code) {
+			this.failAuthorization(
+				new OAuthError(oauthCallback.error ?? 'invalid_callback', oauthCallback.errorDescription),
+			);
+			return;
+		}
+
+		try {
+			const tokens = await exchangeCode(pending.metadata, {
+				code: oauthCallback.code,
+				codeVerifier: pending.codeVerifier,
+			});
+			this.persist(pending.instanceUrl, tokens);
+			this.setStatus({ state: 'signedIn', instanceUrl: pending.instanceUrl, error: null });
+		} catch (error) {
+			this.failAuthorization(error);
+		}
+	}
+
+	/**
+	 * Return a usable access token, refreshing when expired (or when `force`d). Returns `null`
+	 * when there is no session or the refresh grant fails — the caller routes back to sign-in.
+	 */
+	async getValidAccessToken({ force = false }: { force?: boolean } = {}): Promise<string | null> {
+		const session = this.store.getSession();
+		if (!session) return null;
+
+		const stillFresh =
+			session.expiresAt === undefined || session.expiresAt - this.now() > EXPIRY_SKEW_MS;
+		if (!force && stillFresh) return session.accessToken;
+		if (!session.refreshToken) return stillFresh ? session.accessToken : null;
+
+		try {
+			const metadata = await discover(session.instanceUrl);
+			const tokens = await refreshTokens(metadata, session.refreshToken);
+			this.persist(session.instanceUrl, tokens, session.refreshToken);
+			return tokens.access_token;
+		} catch (error) {
+			if (error instanceof OAuthError && error.code === 'invalid_grant') {
+				this.store.clearSession();
+				this.setStatus({ state: 'signedOut', instanceUrl: null, error: null });
+			}
+			return null;
+		}
+	}
+
+	signOut(): void {
+		// Drop any in-flight authorization too, so a late callback can't re-authenticate after logout.
+		this.pending = null;
+		this.store.clearSession();
+		this.setStatus({ state: 'signedOut', instanceUrl: null, error: null });
+	}
+
+	private persist(instanceUrl: string, tokens: OAuthTokens, previousRefreshToken?: string): void {
+		this.store.setSession({
+			instanceUrl,
+			accessToken: tokens.access_token,
+			refreshToken: tokens.refresh_token ?? previousRefreshToken,
+			expiresAt: tokens.expires_in ? this.now() + tokens.expires_in * 1000 : undefined,
+		});
+	}
+
+	private failAuthorization(error: unknown): void {
+		this.pending = null;
+		const message = error instanceof Error ? error.message : String(error);
+		logger.error('OAuth authorization failed', { error: message });
+		this.setStatus({ state: 'error', instanceUrl: this.status.instanceUrl, error: message });
+	}
+
+	private setStatus(status: AuthStatus): void {
+		this.status = status;
+		this.emit('authStatusChanged', status);
+	}
+}
+
+/** Trim whitespace and trailing slashes so the base URL composes cleanly. */
+function normalizeBaseUrl(rawUrl: string): string {
+	return rawUrl.trim().replace(/\/+$/, '');
+}

--- a/packages/@n8n/local-gateway/src/main/oauth/pkce.ts
+++ b/packages/@n8n/local-gateway/src/main/oauth/pkce.ts
@@ -1,0 +1,21 @@
+import { createHash, randomBytes } from 'node:crypto';
+
+/**
+ * PKCE (RFC 7636) + CSRF helpers. Pure functions — no shared state, so each
+ * authorization attempt gets its own independent verifier/challenge/state.
+ */
+
+/** A high-entropy `code_verifier` (43 chars, base64url — within the RFC's 43–128 range). */
+export function createCodeVerifier(): string {
+	return randomBytes(32).toString('base64url');
+}
+
+/** The S256 `code_challenge` for a given verifier: base64url(SHA-256(verifier)). */
+export function deriveCodeChallenge(verifier: string): string {
+	return createHash('sha256').update(verifier).digest('base64url');
+}
+
+/** An opaque `state` value used to bind the callback to the request (CSRF defense). */
+export function createState(): string {
+	return randomBytes(16).toString('base64url');
+}

--- a/packages/@n8n/local-gateway/src/main/oauth/token-store.ts
+++ b/packages/@n8n/local-gateway/src/main/oauth/token-store.ts
@@ -1,0 +1,57 @@
+import { safeStorage } from 'electron';
+import Store from 'electron-store';
+
+/** The persisted, signed-in session. Token fields are encrypted at rest when possible. */
+export interface PersistedSession {
+	instanceUrl: string;
+	accessToken: string;
+	refreshToken?: string;
+	/** Access-token expiry as epoch milliseconds, when the server reported `expires_in`. */
+	expiresAt?: number;
+}
+
+interface OAuthStoreSchema {
+	/** The active session, JSON-serialized and (when available) safeStorage-encrypted. */
+	session?: string;
+}
+
+/**
+ * Persists the active OAuth session via electron-store. Tokens are wrapped with
+ * the OS keychain (`safeStorage`) when encryption is available, falling back to
+ * plaintext otherwise. No client registry: the client id is a seeded constant.
+ */
+export class TokenStore {
+	private readonly store = new Store<OAuthStoreSchema>({ name: 'oauth' });
+
+	getSession(): PersistedSession | null {
+		const raw = this.store.get('session');
+		if (!raw) return null;
+		try {
+			return JSON.parse(decrypt(raw)) as PersistedSession;
+		} catch {
+			return null;
+		}
+	}
+
+	setSession(session: PersistedSession): void {
+		this.store.set('session', encrypt(JSON.stringify(session)));
+	}
+
+	clearSession(): void {
+		this.store.delete('session');
+	}
+}
+
+/** Prefix marking a value as safeStorage-encrypted base64 (vs plaintext fallback). */
+const ENCRYPTED_PREFIX = 'enc:';
+
+function encrypt(value: string): string {
+	if (!safeStorage.isEncryptionAvailable()) return value;
+	return ENCRYPTED_PREFIX + safeStorage.encryptString(value).toString('base64');
+}
+
+function decrypt(value: string): string {
+	if (!value.startsWith(ENCRYPTED_PREFIX)) return value;
+	const buffer = Buffer.from(value.slice(ENCRYPTED_PREFIX.length), 'base64');
+	return safeStorage.decryptString(buffer);
+}

--- a/packages/@n8n/local-gateway/src/main/preload.ts
+++ b/packages/@n8n/local-gateway/src/main/preload.ts
@@ -1,8 +1,24 @@
 import { contextBridge, ipcRenderer } from 'electron';
 
-import type { AppSettings, StatusSnapshot } from '../shared/types';
+import type { AppSettings, AuthStatus, StatusSnapshot } from '../shared/types';
 
 contextBridge.exposeInMainWorld('electronAPI', {
+	signIn: async (instanceUrl: string): Promise<{ ok: boolean; error?: string }> =>
+		await (ipcRenderer.invoke('oauth:signIn', instanceUrl) as Promise<{
+			ok: boolean;
+			error?: string;
+		}>),
+
+	getAuthStatus: async (): Promise<AuthStatus> =>
+		await (ipcRenderer.invoke('oauth:getStatus') as Promise<AuthStatus>),
+
+	signOut: async (): Promise<{ ok: boolean }> =>
+		await (ipcRenderer.invoke('oauth:signOut') as Promise<{ ok: boolean }>),
+
+	onAuthStatusChanged: (onChangeCallback: (status: AuthStatus) => void): void => {
+		ipcRenderer.on('authStatusChanged', (_event, status: AuthStatus) => onChangeCallback(status));
+	},
+
 	getSettings: async (): Promise<AppSettings> =>
 		await (ipcRenderer.invoke('settings:get') as Promise<AppSettings>),
 

--- a/packages/@n8n/local-gateway/src/renderer/tsconfig.json
+++ b/packages/@n8n/local-gateway/src/renderer/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"extends": "../../tsconfig.renderer.json",
+	"compilerOptions": {
+		"strict": true
+	},
+	"include": ["**/*.ts", "../shared/**/*.ts"]
+}

--- a/packages/@n8n/local-gateway/src/renderer/vite-env.d.ts
+++ b/packages/@n8n/local-gateway/src/renderer/vite-env.d.ts
@@ -4,5 +4,7 @@ declare module '*.vue' {
 	import type { DefineComponent } from 'vue';
 
 	const component: DefineComponent<Record<string, unknown>, Record<string, unknown>, unknown>;
+	// Vue SFCs are consumed via default import; the shim must mirror that.
+	// eslint-disable-next-line import-x/no-default-export
 	export default component;
 }

--- a/packages/@n8n/local-gateway/src/shared/constants.ts
+++ b/packages/@n8n/local-gateway/src/shared/constants.ts
@@ -1,0 +1,6 @@
+/**
+ * Custom URI scheme registered with the OS for this app's deep links (the OAuth
+ * redirect, and historically the connect hand-off). Single source of truth —
+ * reused by the OAuth config, the deep-link parsers, and OS protocol registration.
+ */
+export const APP_URL_SCHEME = 'n8n';

--- a/packages/@n8n/local-gateway/src/shared/types.ts
+++ b/packages/@n8n/local-gateway/src/shared/types.ts
@@ -24,3 +24,13 @@ export interface ConnectPayload {
 	url: string;
 	apiKey?: string;
 }
+
+export type AuthState = 'signedOut' | 'authorizing' | 'signedIn' | 'error';
+
+export interface AuthStatus {
+	state: AuthState;
+	/** The instance the user is signing in to / signed in to, when known. */
+	instanceUrl: string | null;
+	/** Human-readable error, set when `state === 'error'`. */
+	error: string | null;
+}

--- a/packages/@n8n/local-gateway/tsconfig.json
+++ b/packages/@n8n/local-gateway/tsconfig.json
@@ -8,5 +8,6 @@
 		"module": "nodenext",
 		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
 	},
-	"include": ["src/**/*.ts"]
+	"include": ["src/**/*.ts"],
+	"exclude": ["src/renderer/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

Adds a spec-compliant, **discovery-driven OAuth 2.1 + PKCE** client to the local-gateway **main process** (no renderer changes). The app can sign in to an n8n instance, persist tokens, and refresh them. It does **not** connect the gateway — that's intentionally out of scope for this stack.

- `oauth/` module of small, mostly-pure units: PKCE (`S256`), RFC 8414 metadata discovery, authorize-URL build, code + refresh token exchange (RFC 6749 / 6750), redirect-callback parsing
- `OAuthFlow` orchestrator: `signIn()` opens the **system browser** (RFC 8252), `handleCallback()` verifies `state` and exchanges the code, `getValidAccessToken({ force })` refreshes before expiry
- Token persistence via `electron-store`, values wrapped with Electron `safeStorage` when available
- IPC: `oauth:signIn` / `oauth:getStatus` / `oauth:signOut`, plus an `authStatusChanged` push to the renderer
- All endpoints + scopes are read from discovery — **backend-agnostic**; validated against the OAuth backend in #31979

Stack: **2 / 3**.

## How to test

The client is exercised through the UI in PR 3/3. Standalone:
1. `pnpm --filter @n8n/local-gateway typecheck`
2. `pnpm --filter @n8n/local-gateway build`

## Related Linear tickets, Github issues, and Community forum posts

OAuth backend: https://github.com/n8n-io/n8n/pull/31979
<!-- Add Linear ticket: https://linear.app/n8n/issue/[TICKET-ID] -->

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive.
- [ ] Tests included. <!-- Intentionally omitted: experimental hackweek app. -->
