### PR TITLE
ci: Restore sbom: true to maintain OCI manifest index format

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -142,7 +142,7 @@ jobs:
             N8N_RELEASE_TYPE=${{ needs.determine-build-context.outputs.release_type }}
           platforms: ${{ matrix.docker_platform }}
           provenance: false # Disabled - using SLSA L3 generator for isolated provenance
-          sbom: false # Disabled - BuildKit's syft SBOM under-resolves npm licenses; the sbom-attestation job attests an enriched, license-gated CycloneDX SBOM instead
+          sbom: true
           push: ${{ inputs.force_gzip_compression != true && needs.determine-build-context.outputs.push_enabled == 'true' }}
           tags: ${{ steps.determine-tags.outputs.n8n_tags }}
           outputs: ${{ inputs.force_gzip_compression == true && format('type=image,push={0},compression=gzip,force-compression=true', needs.determine-build-context.outputs.push_enabled) || '' }}
@@ -159,7 +159,7 @@ jobs:
             N8N_RELEASE_TYPE=${{ needs.determine-build-context.outputs.release_type }}
           platforms: ${{ matrix.docker_platform }}
           provenance: false # Disabled - using SLSA L3 generator for isolated provenance
-          sbom: false # Disabled - BuildKit's syft SBOM under-resolves npm licenses; the sbom-attestation job attests an enriched, license-gated CycloneDX SBOM instead
+          sbom: true
           push: ${{ inputs.force_gzip_compression != true && needs.determine-build-context.outputs.push_enabled == 'true' }}
           tags: ${{ steps.determine-tags.outputs.runners_tags }}
           outputs: ${{ inputs.force_gzip_compression == true && format('type=image,push={0},compression=gzip,force-compression=true', needs.determine-build-context.outputs.push_enabled) || '' }}
@@ -176,7 +176,7 @@ jobs:
             N8N_RELEASE_TYPE=${{ needs.determine-build-context.outputs.release_type }}
           platforms: ${{ matrix.docker_platform }}
           provenance: false # Disabled - using SLSA L3 generator for isolated provenance
-          sbom: false # Disabled - BuildKit's syft SBOM under-resolves npm licenses; the sbom-attestation job attests an enriched, license-gated CycloneDX SBOM instead
+          sbom: true
           push: ${{ inputs.force_gzip_compression != true && needs.determine-build-context.outputs.push_enabled == 'true' }}
           tags: ${{ steps.determine-tags.outputs.runners_distroless_tags }}
           outputs: ${{ inputs.force_gzip_compression == true && format('type=image,push={0},compression=gzip,force-compression=true', needs.determine-build-context.outputs.push_enabled) || '' }}


### PR DESCRIPTION
## Summary

Restores `sbom: true` on all three `build-push-action` steps (n8n, runners, runners-distroless).

When `sbom: false`, BuildKit stops using the OCI referrers API and falls back to Docker manifest list format (`application/vnd.docker.distribution.manifest.list.v2+json`). This caused older containerd versions on AKS to misidentify attestation manifests as image manifests, producing a `number of layers and diffIDs don't match` error and `ImagePullBackOff` for 2.26.0.

Restoring `sbom: true` forces OCI manifest index format (`application/vnd.oci.image.index.v1+json`), matching 2.25.6 and earlier. The enriched cosign-attested SBOM from the `sbom-attestation` job remains and can be applied on top of the release asset independently.

## How to test

Merge and trigger a patch release build. Verify the manifest media type is `application/vnd.oci.image.index.v1+json`.

## Related Linear tickets, Github issues, and Community forum posts

<!-- Incident: 2.26.0 ImagePullBackOff on AKS - layer count mismatch caused by manifest format regression -->

## Review / Merge checklist
- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI