### PR TITLE
fix(core): Update mcp tool schemas (no-changelog)

### DIFF
--- a/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
@@ -20,6 +20,20 @@ import { resolveNodeWebhookIds } from '@/workflow-helpers';
 import type { WorkflowCreationService } from '@/workflows/workflow-creation.service';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 
+const MAX_WORKFLOW_DESCRIPTION_LENGTH = 255;
+
+function normalizeWorkflowDescription(description?: string) {
+	if (!description) return { description: undefined, truncated: false };
+	if (description.length <= MAX_WORKFLOW_DESCRIPTION_LENGTH) {
+		return { description, truncated: false };
+	}
+
+	return {
+		description: description.slice(0, MAX_WORKFLOW_DESCRIPTION_LENGTH),
+		truncated: true,
+	};
+}
+
 const inputSchema = {
 	code: z
 		.string()
@@ -39,11 +53,8 @@ const inputSchema = {
 		.describe('Optional workflow name. If not provided, uses the name from the code.'),
 	description: z
 		.string()
-		.max(255)
 		.optional()
-		.describe(
-			'Short workflow description summarizing what it does (1-2 sentences, max 255 chars).',
-		),
+		.describe('Workflow description. Longer text is shortened to 255 chars before saving.'),
 	projectId: z
 		.string()
 		.optional()
@@ -175,6 +186,8 @@ export const createCreateWorkflowFromCodeTool = (
 			const result = await handler.parseAndValidate(strippedCode);
 
 			const workflowJson = result.workflow;
+			const { description: workflowDescription, truncated: descriptionTruncated } =
+				normalizeWorkflowDescription(description);
 
 			const invalidToolSourceResponse = buildInvalidAiToolSourceErrorResponse(
 				workflowJson,
@@ -188,7 +201,7 @@ export const createCreateWorkflowFromCodeTool = (
 			newWorkflow = new WorkflowEntity();
 			Object.assign(newWorkflow, {
 				name: name ?? workflowJson.name ?? 'Untitled Workflow',
-				...(description ? { description } : {}),
+				...(workflowDescription ? { description: workflowDescription } : {}),
 				nodes: workflowJson.nodes,
 				connections: workflowJson.connections,
 				settings: { ...workflowJson.settings, executionOrder: 'v1', availableInMCP: true },
@@ -246,6 +259,15 @@ export const createCreateWorkflowFromCodeTool = (
 			};
 			telemetry.track(USER_CALLED_MCP_TOOL_EVENT, telemetryPayload);
 
+			const notes = [
+				descriptionTruncated
+					? `Workflow description was shortened to ${MAX_WORKFLOW_DESCRIPTION_LENGTH} characters.`
+					: undefined,
+				skippedHttpNodes.length
+					? `HTTP Request nodes (${skippedHttpNodes.join(', ')}) were skipped during credential auto-assignment. Their credentials must be configured manually.`
+					: undefined,
+			].filter((note): note is string => note !== undefined);
+
 			const output = {
 				workflowId: savedWorkflow.id,
 				name: savedWorkflow.name,
@@ -257,9 +279,7 @@ export const createCreateWorkflowFromCodeTool = (
 					name: landingProject.name,
 					type: landingProject.type,
 				},
-				note: skippedHttpNodes.length
-					? `HTTP Request nodes (${skippedHttpNodes.join(', ')}) were skipped during credential auto-assignment. Their credentials must be configured manually.`
-					: undefined,
+				note: notes.length ? notes.join(' ') : undefined,
 			};
 
 			return {

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/get-workflow-node-types.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/get-workflow-node-types.tool.ts
@@ -9,7 +9,7 @@ import type { Telemetry } from '@/telemetry';
 
 import { CODE_BUILDER_GET_NODE_TYPES_TOOL } from './constants';
 
-const nodeIdWithDiscriminators = z.object({
+const nodeRequestSchema = z.object({
 	nodeId: z.string().describe('The node type ID (e.g. "n8n-nodes-base.gmail")'),
 	version: z.string().optional().describe('Specific version (e.g. "2.1")'),
 	resource: z.string().optional().describe('Resource discriminator (e.g. "message")'),
@@ -19,10 +19,10 @@ const nodeIdWithDiscriminators = z.object({
 
 const inputSchema = {
 	nodeIds: z
-		.array(z.union([z.string(), nodeIdWithDiscriminators]))
+		.array(nodeRequestSchema)
 		.min(1)
 		.describe(
-			'Node IDs to get type definitions for. Use plain strings for simple nodes, or objects with discriminators from search results.',
+			'Node type requests to get definitions for. Always pass an array of objects, even for a single node. Include discriminators from search_nodes results when available.',
 		),
 } satisfies z.ZodRawShape;
 
@@ -30,15 +30,7 @@ const outputSchema = {
 	definitions: z.string().describe('TypeScript type definitions for the requested nodes'),
 } satisfies z.ZodRawShape;
 
-type NodeRequest =
-	| string
-	| {
-			nodeId: string;
-			version?: string;
-			resource?: string;
-			operation?: string;
-			mode?: string;
-	  };
+type NodeRequest = z.infer<typeof nodeRequestSchema>;
 
 /**
  * MCP tool that retrieves TypeScript type definitions for n8n nodes.
@@ -52,7 +44,7 @@ export const createGetWorkflowNodeTypesTool = (
 	name: CODE_BUILDER_GET_NODE_TYPES_TOOL.toolName,
 	config: {
 		description:
-			'Get TypeScript type definitions for n8n nodes. Returns exact parameter names and structures. MUST be called before writing workflow code — guessing parameter names creates invalid workflows. Include discriminators (resource/operation/mode) from search results.',
+			'Get TypeScript type definitions for n8n nodes. Returns exact parameter names and structures. MUST be called before writing workflow code — guessing parameter names creates invalid workflows. Pass nodeIds as an array of objects like { nodeId: "n8n-nodes-base.gmail" }. Include discriminators (resource/operation/mode) from search_nodes results.',
 		inputSchema,
 		outputSchema,
 		annotations: {

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/mcp-instructions.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/mcp-instructions.ts
@@ -39,7 +39,7 @@ To build n8n workflows, follow these steps in order:
 
 7. Validate: Call ${CODE_BUILDER_VALIDATE_TOOL.toolName} with your full code. Fix any errors and re-validate until valid.
 
-8. Create: Call ${MCP_CREATE_WORKFLOW_FROM_CODE_TOOL.toolName} with the validated code to save the workflow to n8n. Include a short \`description\` (1-2 sentences) summarizing what the workflow does — this helps users find and understand their workflows.
+8. Create: Call ${MCP_CREATE_WORKFLOW_FROM_CODE_TOOL.toolName} with the validated code to save the workflow to n8n. Include a short \`description\` (1-2 sentences, max 255 chars) summarizing what the workflow does — this helps users find and understand their workflows.
 
 9. Update: Call ${MCP_UPDATE_WORKFLOW_TOOL.toolName} with the workflow ID and a list of operations (addNode, removeNode, updateNodeParameters, setNodeParameter, renameNode, addConnection, removeConnection, setNodeCredential, setNodePosition, setNodeDisabled, setNodeSettings, setWorkflowMetadata). The whole batch is atomic: if any op fails the workflow is unchanged. To modify an existing node's configuration, use updateNodeParameters or setNodeParameter — do NOT use removeNode followed by addNode for the same node, as this disconnects any attached sub-nodes (LLM models, memory, tools) and they will not be re-attached automatically. Use setNodeSettings to change a node's execution behavior (onError, retryOnFail, maxTries, waitBetweenTries, alwaysOutputData, executeOnce); for sub-nodes (LLM model, memory, tools) this is the only way to set onError, because the canvas UI does not expose that setting for them.
 

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/search-workflow-nodes.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/search-workflow-nodes.tool.ts
@@ -36,7 +36,7 @@ export const createSearchWorkflowNodesTool = (
 	name: CODE_BUILDER_SEARCH_NODES_TOOL.toolName,
 	config: {
 		description:
-			'Search for n8n nodes by service name, trigger type, or utility function. Returns node IDs, discriminators (resource/operation/mode), and related nodes needed for get_workflow_node_types.',
+			'Search for n8n nodes by service name, trigger type, or utility function. Returns node IDs, discriminators (resource/operation/mode), and related nodes needed for get_node_types.',
 		inputSchema,
 		outputSchema,
 		annotations: {

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -31,6 +31,110 @@ import { getMcpWorkflow } from '../workflow-validation.utils';
 
 const MAX_OPERATIONS_PER_CALL = 100;
 
+const operationTypeSchema = z.enum([
+	'updateNodeParameters',
+	'setNodeParameter',
+	'addNode',
+	'removeNode',
+	'renameNode',
+	'addConnection',
+	'removeConnection',
+	'setNodeCredential',
+	'setNodePosition',
+	'setNodeDisabled',
+	'setNodeSettings',
+	'setWorkflowMetadata',
+]);
+
+const positionInputSchema = z.array(z.number()).length(2).describe('Canvas [x, y].');
+
+const credentialsInputSchema = z.record(
+	z.string(),
+	z.object({ id: z.string().optional(), name: z.string() }),
+);
+
+const nodeInputSchema = z.object({
+	name: z.string().describe('Unique node name.'),
+	type: z.string().describe('Node type, e.g. "n8n-nodes-base.set".'),
+	typeVersion: z.number(),
+	parameters: z.record(z.string(), z.unknown()).optional(),
+	position: positionInputSchema.optional(),
+	credentials: credentialsInputSchema.optional(),
+	disabled: z.boolean().optional(),
+	notes: z.string().optional(),
+	id: z.string().optional(),
+});
+
+const nodeSettingsInputSchema = z.object({
+	onError: z
+		.enum(['stopWorkflow', 'continueRegularOutput', 'continueErrorOutput'])
+		.optional()
+		.describe('Error behavior.'),
+	retryOnFail: z.boolean().optional(),
+	maxTries: z.number().int().min(2).max(5).optional(),
+	waitBetweenTries: z.number().int().min(0).max(5000).optional(),
+	alwaysOutputData: z.boolean().optional(),
+	executeOnce: z.boolean().optional(),
+});
+
+const operationInputSchema = z
+	.object({
+		type: operationTypeSchema.describe('Operation type.'),
+		nodeName: z.string().optional().describe('For node-targeted ops.'),
+		node: nodeInputSchema.optional().describe('For addNode.'),
+		parameters: z.record(z.string(), z.unknown()).optional().describe('For updateNodeParameters.'),
+		replace: z.boolean().optional().describe('For updateNodeParameters; default false.'),
+		path: z.string().min(2).optional().describe('For setNodeParameter; JSON Pointer path.'),
+		value: z.unknown().optional().describe('For setNodeParameter.'),
+		oldName: z.string().optional().describe('For renameNode.'),
+		newName: z.string().optional().describe('For renameNode.'),
+		source: z.string().optional().describe('For connection ops.'),
+		target: z.string().optional().describe('For connection ops.'),
+		sourceIndex: z
+			.number()
+			.int()
+			.nonnegative()
+			.optional()
+			.describe('For connection ops; default 0.'),
+		targetIndex: z
+			.number()
+			.int()
+			.nonnegative()
+			.optional()
+			.describe('For connection ops; default 0.'),
+		connectionType: z.string().optional().describe('For connection ops; default "main".'),
+		credentialKey: z.string().optional().describe('For setNodeCredential.'),
+		credentialId: z.string().optional().describe('For setNodeCredential.'),
+		credentialName: z.string().optional().describe('For setNodeCredential.'),
+		position: positionInputSchema.optional().describe('For setNodePosition.'),
+		disabled: z.boolean().optional().describe('For setNodeDisabled.'),
+		settings: nodeSettingsInputSchema.optional().describe('For setNodeSettings.'),
+		name: z.string().max(128).optional().describe('Only used for setWorkflowMetadata.'),
+		description: z.string().max(255).optional().describe('Only used for setWorkflowMetadata.'),
+	})
+	.describe('Workflow update operation. Provide fields matching type.');
+
+type OperationInput = { type: z.infer<typeof operationTypeSchema>; [key: string]: unknown };
+
+const strictOperationsSchema = z.array(partialUpdateOperationSchema);
+
+function parseStrictOperations(operations: OperationInput[]): PartialUpdateOperation[] {
+	const parsed = strictOperationsSchema.safeParse(operations);
+	if (parsed.success) return parsed.data;
+
+	const details = parsed.error.issues
+		.map(({ path, message }) => {
+			const [index, ...rest] = path;
+			if (typeof index === 'number') {
+				return `operation ${index}${rest.length ? `.${rest.join('.')}` : ''}: ${message}`;
+			}
+			return `${path.length ? path.join('.') : 'operations'}: ${message}`;
+		})
+		.join('; ');
+
+	throw new Error(`Invalid operations: ${details}`);
+}
+
 // Renames are followed so the key matches the node's name in the post-apply
 // workflow.
 function collectTouchedNodes(operations: PartialUpdateOperation[]): Map<string, number> {
@@ -59,22 +163,20 @@ function collectTouchedNodes(operations: PartialUpdateOperation[]): Map<string, 
 	return touched;
 }
 
-const inputSchema = {
+const inputSchema: z.ZodRawShape = {
 	workflowId: z.string().describe('The ID of the workflow to update.'),
 	skillsUsed: z
 		.array(z.string())
 		.optional()
-		.describe(
-			'Names of n8n skills (lowercase kebab-case identifiers) used by the MCP client to produce this workflow update call. Server-side normalization will trim, lowercase, dedupe, and drop entries that are not valid skill identifiers.',
-		),
+		.describe('n8n skill IDs used for this update; normalized server-side.'),
 	operations: z
-		.array(partialUpdateOperationSchema)
+		.array(operationInputSchema)
 		.min(1)
 		.max(MAX_OPERATIONS_PER_CALL)
 		.describe(
-			`Ordered list of operations to apply (max ${MAX_OPERATIONS_PER_CALL}). Operations are applied atomically: if any operation fails (e.g. node not found, duplicate name), the whole batch is rejected and no changes are saved.`,
+			`Ordered operations to apply atomically (max ${MAX_OPERATIONS_PER_CALL}). If any op fails, nothing is saved.`,
 		),
-} satisfies z.ZodRawShape;
+};
 
 const outputSchema = {
 	workflowId: z.string(),
@@ -130,7 +232,7 @@ export const createUpdateWorkflowTool = (
 	name: MCP_UPDATE_WORKFLOW_TOOL.toolName,
 	config: {
 		description:
-			'Apply a small list of operations to an existing workflow (see the operations input schema for the supported op types). The whole batch is atomic: if any op fails the workflow is left unchanged. If you used n8n skills while preparing this update, pass their identifiers in skillsUsed.',
+			'Atomically update an existing workflow with operation objects. Pass skillsUsed if n8n skills were used.',
 		inputSchema,
 		outputSchema,
 		annotations: {
@@ -148,7 +250,7 @@ export const createUpdateWorkflowTool = (
 	}: {
 		workflowId: string;
 		skillsUsed?: string[];
-		operations: PartialUpdateOperation[];
+		operations: OperationInput[];
 	}) => {
 		const sanitizedSkillsUsed = sanitizeSkillsUsed(skillsUsed);
 		const telemetryPayload: UserCalledMCPToolEventPayload = {
@@ -163,6 +265,7 @@ export const createUpdateWorkflowTool = (
 		};
 
 		try {
+			const strictOperations = parseStrictOperations(operations);
 			const existingWorkflow = await getMcpWorkflow(
 				workflowId,
 				user,
@@ -172,14 +275,14 @@ export const createUpdateWorkflowTool = (
 
 			await collaborationService.ensureWorkflowEditable(existingWorkflow.id);
 
-			const result = applyOperations(toWorkflowSlice(existingWorkflow), operations);
+			const result = applyOperations(toWorkflowSlice(existingWorkflow), strictOperations);
 
 			if (!result.success) {
 				throw new Error(result.error);
 			}
 
 			const credentialCheck = await validateCredentialReferences(
-				operations,
+				strictOperations,
 				existingWorkflow,
 				user,
 				credentialsService,
@@ -205,7 +308,7 @@ export const createUpdateWorkflowTool = (
 
 			const dataTableCheck = await validateDataTableReferencesForUpdate(
 				result.workflow.nodes,
-				collectTouchedNodes(operations),
+				collectTouchedNodes(strictOperations),
 				workflowProjectId,
 				dataTableOps,
 			);
@@ -284,7 +387,7 @@ export const createUpdateWorkflowTool = (
 				name: updatedWorkflow.name,
 				nodeCount: updatedWorkflow.nodes.length,
 				url: workflowUrl,
-				appliedOperations: operations.length,
+				appliedOperations: strictOperations.length,
 				autoAssignedCredentials: credentialAssignments,
 				validationWarnings,
 				note: skippedHttpNodes.length


### PR DESCRIPTION
## Summary
- Update tool schemas to make them more clear (see [ticket description](https://linear.app/n8n/issue/ADO-5390/chatgpt-connector-resolve-mcp-validation-errors-for-tool-parameters))
- Update wrong tool name in MCP instructions
- Make sure workflow descriptions are clamped to DB limit

## How to test
1. Attach MCP client to n8n instance
2. Make sure create/update tools work as expected

## Related Linear tickets, Github issues, and Community forum posts
Closes ADO-5390


## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
