### PR TITLE
feat(core): Expose SSRF protection check outcomes as Prometheus metrics

### DIFF
--- a/packages/@n8n/config/src/configs/endpoints.config.ts
+++ b/packages/@n8n/config/src/configs/endpoints.config.ts
@@ -83,6 +83,10 @@ export class PrometheusMetricsConfig {
 	/** Whether to include metrics for execution data reads and writes. */
 	@Env('N8N_METRICS_INCLUDE_EXECUTION_DATA_METRICS')
 	includeExecutionDataMetrics: boolean = false;
+
+	/** Whether to include metrics for SSRF protection checks. */
+	@Env('N8N_METRICS_INCLUDE_SSRF_METRICS')
+	includeSsrfMetrics: boolean = false;
 }
 
 @Config

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -237,6 +237,7 @@ describe('GlobalConfig', () => {
 				includeWorkflowStatistics: false,
 				workflowStatisticsInterval: 300,
 				includeExecutionDataMetrics: false,
+				includeSsrfMetrics: false,
 			},
 			additionalNonUIRoutes: '',
 			disableProductionWebhooksOnMainProcess: false,

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -14,6 +14,7 @@ import { PrometheusMetricsService } from '../prometheus/prometheus.service';
 import type { PrometheusPssMetricsService } from '../prometheus/pss-metrics.service';
 import type { PrometheusQueueMetricsService } from '../prometheus/queue-metrics.service';
 import type { PrometheusRouteMetricsService } from '../prometheus/route-metrics.service';
+import type { PrometheusSsrfMetricsService } from '../prometheus/ssrf-metrics.service';
 import type { PrometheusTokenExchangeMetricsService } from '../prometheus/token-exchange-metrics.service';
 import type { PrometheusVersionMetricsService } from '../prometheus/version-metrics.service';
 import type { PrometheusWorkflowExecutionDurationMetricsService } from '../prometheus/workflow-execution-duration-metrics.service';
@@ -38,6 +39,7 @@ describe('PrometheusMetricsService', () => {
 	let version: jest.Mocked<PrometheusVersionMetricsService>;
 	let defaultMetrics: jest.Mocked<PrometheusDefaultMetricsService>;
 	let tokenExchange: jest.Mocked<PrometheusTokenExchangeMetricsService>;
+	let ssrf: jest.Mocked<PrometheusSsrfMetricsService>;
 
 	let service: PrometheusMetricsService;
 
@@ -57,6 +59,7 @@ describe('PrometheusMetricsService', () => {
 			version,
 			defaultMetrics,
 			tokenExchange,
+			ssrf,
 		);
 
 	beforeEach(() => {
@@ -83,6 +86,7 @@ describe('PrometheusMetricsService', () => {
 		version = mock<PrometheusVersionMetricsService>({ enabled: true });
 		defaultMetrics = mock<PrometheusDefaultMetricsService>({ enabled: true });
 		tokenExchange = mock<PrometheusTokenExchangeMetricsService>({ enabled: true });
+		ssrf = mock<PrometheusSsrfMetricsService>({ enabled: true });
 
 		service = buildService();
 	});
@@ -108,6 +112,7 @@ describe('PrometheusMetricsService', () => {
 			expect(version.init).toHaveBeenCalledWith(app);
 			expect(defaultMetrics.init).toHaveBeenCalledWith(app);
 			expect(tokenExchange.init).toHaveBeenCalledWith(app);
+			expect(ssrf.init).toHaveBeenCalledWith(app);
 		});
 
 		it('should NOT call init on disabled collectors', () => {

--- a/packages/cli/src/metrics/prometheus/__tests__/ssrf-metrics.service.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/ssrf-metrics.service.test.ts
@@ -1,5 +1,5 @@
 import { mockInstance } from '@n8n/backend-test-utils';
-import { PrometheusMetricsConfig } from '@n8n/config';
+import { PrometheusMetricsConfig, SsrfProtectionConfig } from '@n8n/config';
 import type { SsrfProtectionService } from 'n8n-core';
 import promClient from 'prom-client';
 
@@ -13,6 +13,10 @@ describe('PrometheusSsrfMetricsService', () => {
 		includeSsrfMetrics: true,
 	});
 
+	const ssrfConfig = mockInstance(SsrfProtectionConfig, {
+		enabled: true,
+	});
+
 	const ssrfEvents = { on: jest.fn() };
 	const ssrfProtectionService = {
 		events: ssrfEvents,
@@ -24,7 +28,8 @@ describe('PrometheusSsrfMetricsService', () => {
 
 	beforeEach(() => {
 		Object.assign(config, { prefix: 'n8n_', includeSsrfMetrics: true });
-		service = new PrometheusSsrfMetricsService(ssrfProtectionService, config);
+		Object.assign(ssrfConfig, { enabled: true });
+		service = new PrometheusSsrfMetricsService(ssrfProtectionService, config, ssrfConfig);
 		mockCounterInc = jest.fn();
 		mockHistogramObserve = jest.fn();
 		promClient.Counter.prototype.inc = mockCounterInc;
@@ -41,13 +46,21 @@ describe('PrometheusSsrfMetricsService', () => {
 	}
 
 	describe('enabled', () => {
-		it('should be true when includeSsrfMetrics is true', () => {
+		it('should be true when includeSsrfMetrics and SSRF protection are both enabled', () => {
 			config.includeSsrfMetrics = true;
+			ssrfConfig.enabled = true;
 			expect(service.enabled).toBe(true);
 		});
 
 		it('should be false when includeSsrfMetrics is false', () => {
 			config.includeSsrfMetrics = false;
+			ssrfConfig.enabled = true;
+			expect(service.enabled).toBe(false);
+		});
+
+		it('should be false when SSRF protection is disabled', () => {
+			config.includeSsrfMetrics = true;
+			ssrfConfig.enabled = false;
 			expect(service.enabled).toBe(false);
 		});
 	});

--- a/packages/cli/src/metrics/prometheus/__tests__/ssrf-metrics.service.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/ssrf-metrics.service.test.ts
@@ -1,0 +1,166 @@
+import { mockInstance } from '@n8n/backend-test-utils';
+import { PrometheusMetricsConfig } from '@n8n/config';
+import type { SsrfProtectionService } from 'n8n-core';
+import promClient from 'prom-client';
+
+import { PrometheusSsrfMetricsService } from '../ssrf-metrics.service';
+
+jest.mock('prom-client');
+
+describe('PrometheusSsrfMetricsService', () => {
+	const config = mockInstance(PrometheusMetricsConfig, {
+		prefix: 'n8n_',
+		includeSsrfMetrics: true,
+	});
+
+	const ssrfEvents = { on: jest.fn() };
+	const ssrfProtectionService = {
+		events: ssrfEvents,
+	} as unknown as SsrfProtectionService;
+
+	let service: PrometheusSsrfMetricsService;
+	let mockCounterInc: jest.Mock;
+	let mockHistogramObserve: jest.Mock;
+
+	beforeEach(() => {
+		Object.assign(config, { prefix: 'n8n_', includeSsrfMetrics: true });
+		service = new PrometheusSsrfMetricsService(ssrfProtectionService, config);
+		mockCounterInc = jest.fn();
+		mockHistogramObserve = jest.fn();
+		promClient.Counter.prototype.inc = mockCounterInc;
+		promClient.Histogram.prototype.observe = mockHistogramObserve;
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	function getEventsHandler(eventName: string) {
+		const calls = ssrfEvents.on.mock.calls as Array<[string, (...args: unknown[]) => void]>;
+		return calls.find((c) => c[0] === eventName)?.[1];
+	}
+
+	describe('enabled', () => {
+		it('should be true when includeSsrfMetrics is true', () => {
+			config.includeSsrfMetrics = true;
+			expect(service.enabled).toBe(true);
+		});
+
+		it('should be false when includeSsrfMetrics is false', () => {
+			config.includeSsrfMetrics = false;
+			expect(service.enabled).toBe(false);
+		});
+	});
+
+	describe('init', () => {
+		it('should create ssrf_requests_total counter with outcome and phase labels', () => {
+			service.init();
+
+			expect(promClient.Counter).toHaveBeenCalledWith({
+				name: 'n8n_ssrf_requests_total',
+				help: 'Total number of SSRF checks by outcome and phase.',
+				labelNames: ['outcome', 'phase'],
+			});
+		});
+
+		it('should create ssrf_blocked_by_reason_total counter with phase and reason labels', () => {
+			service.init();
+
+			expect(promClient.Counter).toHaveBeenCalledWith({
+				name: 'n8n_ssrf_blocked_by_reason_total',
+				help: 'Total number of blocked SSRF checks by phase and reason.',
+				labelNames: ['phase', 'reason'],
+			});
+		});
+
+		it('should create ssrf_request_duration_seconds histogram with correct config', () => {
+			service.init();
+
+			expect(promClient.Histogram).toHaveBeenCalledWith(
+				expect.objectContaining({
+					name: 'n8n_ssrf_request_duration_seconds',
+					help: 'Duration of SSRF checks in seconds.',
+					labelNames: ['outcome', 'phase'],
+				}),
+			);
+		});
+
+		it('should apply custom prefix to metric names', () => {
+			config.prefix = 'myapp_';
+			service.init();
+
+			expect(promClient.Counter).toHaveBeenCalledWith(
+				expect.objectContaining({ name: 'myapp_ssrf_requests_total' }),
+			);
+			expect(promClient.Counter).toHaveBeenCalledWith(
+				expect.objectContaining({ name: 'myapp_ssrf_blocked_by_reason_total' }),
+			);
+			expect(promClient.Histogram).toHaveBeenCalledWith(
+				expect.objectContaining({ name: 'myapp_ssrf_request_duration_seconds' }),
+			);
+		});
+
+		it('should register listeners for ssrf.blocked and ssrf.allowed', () => {
+			service.init();
+
+			expect(ssrfEvents.on).toHaveBeenCalledWith('ssrf.blocked', expect.any(Function));
+			expect(ssrfEvents.on).toHaveBeenCalledWith('ssrf.allowed', expect.any(Function));
+		});
+
+		describe('ssrf.blocked handler', () => {
+			it('should increment requests counter with outcome and phase', () => {
+				service.init();
+				const handler = getEventsHandler('ssrf.blocked')!;
+
+				handler({ phase: 'pre_flight', reason: 'blocked_ip', durationMs: 10 });
+
+				expect(mockCounterInc).toHaveBeenCalledWith({ outcome: 'blocked', phase: 'pre_flight' });
+			});
+
+			it('should increment blocked_by_reason counter with phase and reason', () => {
+				service.init();
+				const handler = getEventsHandler('ssrf.blocked')!;
+
+				handler({ phase: 'pre_flight', reason: 'blocked_ip', durationMs: 10 });
+
+				expect(mockCounterInc).toHaveBeenCalledWith({ phase: 'pre_flight', reason: 'blocked_ip' });
+			});
+
+			it('should observe histogram with duration converted to seconds', () => {
+				service.init();
+				const handler = getEventsHandler('ssrf.blocked')!;
+
+				handler({ phase: 'connect_time', reason: 'dns_error', durationMs: 250 });
+
+				expect(mockHistogramObserve).toHaveBeenCalledWith(
+					{ outcome: 'blocked', phase: 'connect_time' },
+					0.25,
+				);
+			});
+		});
+
+		describe('ssrf.allowed handler', () => {
+			it('should increment requests counter with outcome and phase only', () => {
+				service.init();
+				const handler = getEventsHandler('ssrf.allowed')!;
+
+				handler({ phase: 'redirect', durationMs: 5 });
+
+				expect(mockCounterInc).toHaveBeenCalledWith({ outcome: 'allowed', phase: 'redirect' });
+				expect(mockCounterInc).toHaveBeenCalledTimes(1);
+			});
+
+			it('should observe histogram with duration converted to seconds', () => {
+				service.init();
+				const handler = getEventsHandler('ssrf.allowed')!;
+
+				handler({ phase: 'pre_flight', durationMs: 100 });
+
+				expect(mockHistogramObserve).toHaveBeenCalledWith(
+					{ outcome: 'allowed', phase: 'pre_flight' },
+					0.1,
+				);
+			});
+		});
+	});
+});

--- a/packages/cli/src/metrics/prometheus/__tests__/ssrf-metrics.service.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/ssrf-metrics.service.test.ts
@@ -66,34 +66,34 @@ describe('PrometheusSsrfMetricsService', () => {
 	});
 
 	describe('init', () => {
-		it('should create ssrf_requests_total counter with outcome and phase labels', () => {
+		it('should create ssrf_checks_total counter with result and phase labels', () => {
 			service.init();
 
 			expect(promClient.Counter).toHaveBeenCalledWith({
-				name: 'n8n_ssrf_requests_total',
-				help: 'Total number of SSRF checks by outcome and phase.',
-				labelNames: ['outcome', 'phase'],
+				name: 'n8n_ssrf_checks_total',
+				help: 'Total number of SSRF checks by result and phase.',
+				labelNames: ['result', 'phase'],
 			});
 		});
 
-		it('should create ssrf_blocked_by_reason_total counter with phase and reason labels', () => {
+		it('should create ssrf_blocked_checks_total counter with phase and reason labels', () => {
 			service.init();
 
 			expect(promClient.Counter).toHaveBeenCalledWith({
-				name: 'n8n_ssrf_blocked_by_reason_total',
+				name: 'n8n_ssrf_blocked_checks_total',
 				help: 'Total number of blocked SSRF checks by phase and reason.',
 				labelNames: ['phase', 'reason'],
 			});
 		});
 
-		it('should create ssrf_request_duration_seconds histogram with correct config', () => {
+		it('should create ssrf_check_duration_seconds histogram with correct config', () => {
 			service.init();
 
 			expect(promClient.Histogram).toHaveBeenCalledWith(
 				expect.objectContaining({
-					name: 'n8n_ssrf_request_duration_seconds',
+					name: 'n8n_ssrf_check_duration_seconds',
 					help: 'Duration of SSRF checks in seconds.',
-					labelNames: ['outcome', 'phase'],
+					labelNames: ['result', 'phase'],
 				}),
 			);
 		});
@@ -103,13 +103,13 @@ describe('PrometheusSsrfMetricsService', () => {
 			service.init();
 
 			expect(promClient.Counter).toHaveBeenCalledWith(
-				expect.objectContaining({ name: 'myapp_ssrf_requests_total' }),
+				expect.objectContaining({ name: 'myapp_ssrf_checks_total' }),
 			);
 			expect(promClient.Counter).toHaveBeenCalledWith(
-				expect.objectContaining({ name: 'myapp_ssrf_blocked_by_reason_total' }),
+				expect.objectContaining({ name: 'myapp_ssrf_blocked_checks_total' }),
 			);
 			expect(promClient.Histogram).toHaveBeenCalledWith(
-				expect.objectContaining({ name: 'myapp_ssrf_request_duration_seconds' }),
+				expect.objectContaining({ name: 'myapp_ssrf_check_duration_seconds' }),
 			);
 		});
 
@@ -121,13 +121,13 @@ describe('PrometheusSsrfMetricsService', () => {
 		});
 
 		describe('ssrf.blocked handler', () => {
-			it('should increment requests counter with outcome and phase', () => {
+			it('should increment checks counter with result and phase', () => {
 				service.init();
 				const handler = getEventsHandler('ssrf.blocked')!;
 
 				handler({ phase: 'pre_flight', reason: 'blocked_ip', durationMs: 10 });
 
-				expect(mockCounterInc).toHaveBeenCalledWith({ outcome: 'blocked', phase: 'pre_flight' });
+				expect(mockCounterInc).toHaveBeenCalledWith({ result: 'blocked', phase: 'pre_flight' });
 			});
 
 			it('should increment blocked_by_reason counter with phase and reason', () => {
@@ -146,20 +146,20 @@ describe('PrometheusSsrfMetricsService', () => {
 				handler({ phase: 'connect_time', reason: 'dns_error', durationMs: 250 });
 
 				expect(mockHistogramObserve).toHaveBeenCalledWith(
-					{ outcome: 'blocked', phase: 'connect_time' },
+					{ result: 'blocked', phase: 'connect_time' },
 					0.25,
 				);
 			});
 		});
 
 		describe('ssrf.allowed handler', () => {
-			it('should increment requests counter with outcome and phase only', () => {
+			it('should increment checks counter with result and phase only', () => {
 				service.init();
 				const handler = getEventsHandler('ssrf.allowed')!;
 
 				handler({ phase: 'redirect', durationMs: 5 });
 
-				expect(mockCounterInc).toHaveBeenCalledWith({ outcome: 'allowed', phase: 'redirect' });
+				expect(mockCounterInc).toHaveBeenCalledWith({ result: 'allowed', phase: 'redirect' });
 				expect(mockCounterInc).toHaveBeenCalledTimes(1);
 			});
 
@@ -170,7 +170,7 @@ describe('PrometheusSsrfMetricsService', () => {
 				handler({ phase: 'pre_flight', durationMs: 100 });
 
 				expect(mockHistogramObserve).toHaveBeenCalledWith(
-					{ outcome: 'allowed', phase: 'pre_flight' },
+					{ result: 'allowed', phase: 'pre_flight' },
 					0.1,
 				);
 			});

--- a/packages/cli/src/metrics/prometheus/prometheus.service.ts
+++ b/packages/cli/src/metrics/prometheus/prometheus.service.ts
@@ -13,6 +13,7 @@ import { PrometheusInstanceRoleMetricsService } from './instance-role-metrics.se
 import { PrometheusPssMetricsService } from './pss-metrics.service';
 import { PrometheusQueueMetricsService } from './queue-metrics.service';
 import { PrometheusRouteMetricsService } from './route-metrics.service';
+import { PrometheusSsrfMetricsService } from './ssrf-metrics.service';
 import { PrometheusTokenExchangeMetricsService } from './token-exchange-metrics.service';
 import { PrometheusVersionMetricsService } from './version-metrics.service';
 import { PrometheusWorkflowExecutionDurationMetricsService } from './workflow-execution-duration-metrics.service';
@@ -39,6 +40,7 @@ export class PrometheusMetricsService {
 		version: PrometheusVersionMetricsService,
 		defaultMetrics: PrometheusDefaultMetricsService,
 		tokenExchange: PrometheusTokenExchangeMetricsService,
+		ssrf: PrometheusSsrfMetricsService,
 	) {
 		this.logger = logger.scoped('metrics');
 		this.collectors = [
@@ -55,6 +57,7 @@ export class PrometheusMetricsService {
 			version,
 			defaultMetrics,
 			tokenExchange,
+			ssrf,
 		];
 	}
 

--- a/packages/cli/src/metrics/prometheus/ssrf-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/ssrf-metrics.service.ts
@@ -7,8 +7,11 @@ import type { PrometheusMetricsCollector } from './base';
 import { DURATION_BUCKETS_SECONDS } from './constant';
 
 /**
- * Tracks SSRF check outcomes as counters and duration as a histogram.
- * Registers: `n8n_ssrf_requests_total`, `n8n_ssrf_request_duration_seconds`.
+ * Tracks SSRF check results as counters and duration as a histogram.
+ * Registers:
+ * - `n8n_ssrf_checks_total`
+ * - `n8n_ssrf_blocked_checks_total`
+ * - `n8n_ssrf_check_duration_seconds`
  */
 @Service()
 export class PrometheusSsrfMetricsService implements PrometheusMetricsCollector {
@@ -23,34 +26,34 @@ export class PrometheusSsrfMetricsService implements PrometheusMetricsCollector 
 	}
 
 	init() {
-		const requestsCounter = new promClient.Counter({
-			name: `${this.config.prefix}ssrf_requests_total`,
-			help: 'Total number of SSRF checks by outcome and phase.',
-			labelNames: ['outcome', 'phase'],
+		const checksCounter = new promClient.Counter({
+			name: `${this.config.prefix}ssrf_checks_total`,
+			help: 'Total number of SSRF checks by result and phase.',
+			labelNames: ['result', 'phase'],
 		});
 
-		const blockedByReasonCounter = new promClient.Counter({
-			name: `${this.config.prefix}ssrf_blocked_by_reason_total`,
+		const blockedCounter = new promClient.Counter({
+			name: `${this.config.prefix}ssrf_blocked_checks_total`,
 			help: 'Total number of blocked SSRF checks by phase and reason.',
 			labelNames: ['phase', 'reason'],
 		});
 
-		const histogram = new promClient.Histogram({
-			name: `${this.config.prefix}ssrf_request_duration_seconds`,
+		const durationHistogram = new promClient.Histogram({
+			name: `${this.config.prefix}ssrf_check_duration_seconds`,
 			help: 'Duration of SSRF checks in seconds.',
-			labelNames: ['outcome', 'phase'],
+			labelNames: ['result', 'phase'],
 			buckets: DURATION_BUCKETS_SECONDS,
 		});
 
 		this.ssrfProtectionService.events.on('ssrf.blocked', ({ phase, reason, durationMs }) => {
-			requestsCounter.inc({ outcome: 'blocked', phase });
-			blockedByReasonCounter.inc({ phase, reason });
-			histogram.observe({ outcome: 'blocked', phase }, durationMs / 1000);
+			checksCounter.inc({ result: 'blocked', phase });
+			blockedCounter.inc({ phase, reason });
+			durationHistogram.observe({ result: 'blocked', phase }, durationMs / 1000);
 		});
 
 		this.ssrfProtectionService.events.on('ssrf.allowed', ({ phase, durationMs }) => {
-			requestsCounter.inc({ outcome: 'allowed', phase });
-			histogram.observe({ outcome: 'allowed', phase }, durationMs / 1000);
+			checksCounter.inc({ result: 'allowed', phase });
+			durationHistogram.observe({ result: 'allowed', phase }, durationMs / 1000);
 		});
 	}
 }

--- a/packages/cli/src/metrics/prometheus/ssrf-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/ssrf-metrics.service.ts
@@ -1,0 +1,55 @@
+import { PrometheusMetricsConfig } from '@n8n/config';
+import { Service } from '@n8n/di';
+import { SsrfProtectionService } from 'n8n-core';
+import promClient from 'prom-client';
+
+import type { PrometheusMetricsCollector } from './base';
+import { DURATION_BUCKETS_SECONDS } from './constant';
+
+/**
+ * Tracks SSRF check outcomes as counters and duration as a histogram.
+ * Registers: `n8n_ssrf_requests_total`, `n8n_ssrf_request_duration_seconds`.
+ */
+@Service()
+export class PrometheusSsrfMetricsService implements PrometheusMetricsCollector {
+	constructor(
+		private readonly ssrfProtectionService: SsrfProtectionService,
+		private readonly config: PrometheusMetricsConfig,
+	) {}
+
+	get enabled(): boolean {
+		return this.config.includeSsrfMetrics;
+	}
+
+	init() {
+		const requestsCounter = new promClient.Counter({
+			name: `${this.config.prefix}ssrf_requests_total`,
+			help: 'Total number of SSRF checks by outcome and phase.',
+			labelNames: ['outcome', 'phase'],
+		});
+
+		const blockedByReasonCounter = new promClient.Counter({
+			name: `${this.config.prefix}ssrf_blocked_by_reason_total`,
+			help: 'Total number of blocked SSRF checks by phase and reason.',
+			labelNames: ['phase', 'reason'],
+		});
+
+		const histogram = new promClient.Histogram({
+			name: `${this.config.prefix}ssrf_request_duration_seconds`,
+			help: 'Duration of SSRF checks in seconds.',
+			labelNames: ['outcome', 'phase'],
+			buckets: DURATION_BUCKETS_SECONDS,
+		});
+
+		this.ssrfProtectionService.events.on('ssrf.blocked', ({ phase, reason, durationMs }) => {
+			requestsCounter.inc({ outcome: 'blocked', phase });
+			blockedByReasonCounter.inc({ phase, reason });
+			histogram.observe({ outcome: 'blocked', phase }, durationMs / 1000);
+		});
+
+		this.ssrfProtectionService.events.on('ssrf.allowed', ({ phase, durationMs }) => {
+			requestsCounter.inc({ outcome: 'allowed', phase });
+			histogram.observe({ outcome: 'allowed', phase }, durationMs / 1000);
+		});
+	}
+}

--- a/packages/cli/src/metrics/prometheus/ssrf-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/ssrf-metrics.service.ts
@@ -1,4 +1,4 @@
-import { PrometheusMetricsConfig } from '@n8n/config';
+import { PrometheusMetricsConfig, SsrfProtectionConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 import { SsrfProtectionService } from 'n8n-core';
 import promClient from 'prom-client';
@@ -15,10 +15,11 @@ export class PrometheusSsrfMetricsService implements PrometheusMetricsCollector 
 	constructor(
 		private readonly ssrfProtectionService: SsrfProtectionService,
 		private readonly config: PrometheusMetricsConfig,
+		private readonly ssrfConfig: SsrfProtectionConfig,
 	) {}
 
 	get enabled(): boolean {
-		return this.config.includeSsrfMetrics;
+		return this.config.includeSsrfMetrics && this.ssrfConfig.enabled;
 	}
 
 	init() {

--- a/packages/core/src/ssrf/__tests__/ssrf-protection.service.test.ts
+++ b/packages/core/src/ssrf/__tests__/ssrf-protection.service.test.ts
@@ -693,7 +693,7 @@ describe('SsrfProtectionService', () => {
 			expect(() => service.validateRedirectSync('http://127.0.0.1/admin')).toThrow();
 
 			expect(blocked).toHaveBeenCalledWith(
-				expect.objectContaining({ phase: 'redirect', reason: 'blocked_redirect' }),
+				expect.objectContaining({ phase: 'redirect', reason: 'blocked_ip' }),
 			);
 		});
 	});

--- a/packages/core/src/ssrf/__tests__/ssrf-protection.service.test.ts
+++ b/packages/core/src/ssrf/__tests__/ssrf-protection.service.test.ts
@@ -629,4 +629,72 @@ describe('SsrfProtectionService', () => {
 			);
 		});
 	});
+
+	describe('events', () => {
+		it('should emit ssrf.allowed for an allowed URL', async () => {
+			const dnsResolver = createMockDnsResolver();
+			dnsResolver.lookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }]);
+			const { service } = createService({}, dnsResolver);
+			const allowed = vi.fn();
+			service.events.on('ssrf.allowed', allowed);
+
+			await service.validateUrl('http://example.com/');
+
+			expect(allowed).toHaveBeenCalledWith(
+				expect.objectContaining({ phase: 'pre_flight', durationMs: expect.any(Number) }),
+			);
+		});
+
+		it('should emit ssrf.blocked with reason blocked_ip for a blocked URL', async () => {
+			const { service } = createService();
+			const blocked = vi.fn();
+			service.events.on('ssrf.blocked', blocked);
+
+			await service.validateUrl('http://127.0.0.1/');
+
+			expect(blocked).toHaveBeenCalledWith(
+				expect.objectContaining({ phase: 'pre_flight', reason: 'blocked_ip' }),
+			);
+		});
+
+		it('should emit ssrf.blocked with reason invalid_url for an unparseable URL', async () => {
+			const { service } = createService();
+			const blocked = vi.fn();
+			service.events.on('ssrf.blocked', blocked);
+
+			await service.validateUrl('not a url');
+
+			expect(blocked).toHaveBeenCalledWith(
+				expect.objectContaining({ phase: 'pre_flight', reason: 'invalid_url' }),
+			);
+		});
+
+		it('should emit ssrf.blocked with reason dns_error when DNS resolution rejects', async () => {
+			const dnsResolver = createMockDnsResolver();
+			dnsResolver.lookup.mockRejectedValue(new Error('ENOTFOUND'));
+			const { service } = createService({}, dnsResolver);
+			const blocked = vi.fn();
+			service.events.on('ssrf.blocked', blocked);
+
+			await expect(service.validateUrl('http://nonexistent.example.com/')).rejects.toThrow(
+				'ENOTFOUND',
+			);
+
+			expect(blocked).toHaveBeenCalledWith(
+				expect.objectContaining({ phase: 'pre_flight', reason: 'dns_error' }),
+			);
+		});
+
+		it('should emit ssrf.blocked with reason blocked_redirect for a blocked redirect', () => {
+			const { service } = createService();
+			const blocked = vi.fn();
+			service.events.on('ssrf.blocked', blocked);
+
+			expect(() => service.validateRedirectSync('http://127.0.0.1/admin')).toThrow();
+
+			expect(blocked).toHaveBeenCalledWith(
+				expect.objectContaining({ phase: 'redirect', reason: 'blocked_redirect' }),
+			);
+		});
+	});
 });

--- a/packages/core/src/ssrf/__tests__/ssrf-protection.service.test.ts
+++ b/packages/core/src/ssrf/__tests__/ssrf-protection.service.test.ts
@@ -685,7 +685,7 @@ describe('SsrfProtectionService', () => {
 			);
 		});
 
-		it('should emit ssrf.blocked with reason blocked_redirect for a blocked redirect', () => {
+		it('should emit ssrf.blocked with reason blocked_ip for a blocked redirect', () => {
 			const { service } = createService();
 			const blocked = vi.fn();
 			service.events.on('ssrf.blocked', blocked);

--- a/packages/core/src/ssrf/index.ts
+++ b/packages/core/src/ssrf/index.ts
@@ -2,4 +2,4 @@ export { DnsResolver } from './dns-resolver';
 export type { DnsLookupOptions } from './dns-resolver';
 export { SsrfBlockedIpError } from './ssrf-blocked-ip.error';
 export { SsrfProtectionService } from './ssrf-protection.service';
-export type { SsrfBridge, SsrfCheckResult } from './ssrf-protection.service';
+export type { SsrfBridge, SsrfCheckResult, SsrfEventMap } from './ssrf-protection.service';

--- a/packages/core/src/ssrf/ssrf-protection.service.ts
+++ b/packages/core/src/ssrf/ssrf-protection.service.ts
@@ -264,7 +264,7 @@ export class SsrfProtectionService implements SsrfBridge {
 		fn: () => Result<T, Error> | Promise<Result<T, Error>>,
 	): Result<T, Error> | Promise<Result<T, Error>> {
 		const start = performance.now();
-		const outcome = fn();
+		const result = fn();
 
 		const emitAndReturn = (result: Result<T, Error>): Result<T, Error> => {
 			const durationMs = performance.now() - start;
@@ -273,7 +273,7 @@ export class SsrfProtectionService implements SsrfBridge {
 			} else {
 				this.events.emit('ssrf.blocked', {
 					phase,
-					reason: this.toReason(result.error, phase),
+					reason: this.toReason(result.error),
 					durationMs,
 				});
 			}
@@ -285,15 +285,12 @@ export class SsrfProtectionService implements SsrfBridge {
 			throw error;
 		};
 
-		return outcome instanceof Promise
-			? outcome.then(emitAndReturn, emitAndRethrow)
-			: emitAndReturn(outcome);
+		return result instanceof Promise
+			? result.then(emitAndReturn, emitAndRethrow)
+			: emitAndReturn(result);
 	}
 
-	private toReason(error: Error, phase: SsrfPhase): string {
-		if (phase === 'redirect') {
-			return 'blocked_redirect';
-		}
+	private toReason(error: Error): string {
 		if (error instanceof SsrfBlockedIpError) {
 			return 'blocked_ip';
 		}

--- a/packages/core/src/ssrf/ssrf-protection.service.ts
+++ b/packages/core/src/ssrf/ssrf-protection.service.ts
@@ -280,7 +280,14 @@ export class SsrfProtectionService implements SsrfBridge {
 			return result;
 		};
 
-		return outcome instanceof Promise ? outcome.then(emitAndReturn) : emitAndReturn(outcome);
+		const emitAndRethrow = (error: unknown): never => {
+			emitAndReturn(createResultError(ensureError(error)));
+			throw error;
+		};
+
+		return outcome instanceof Promise
+			? outcome.then(emitAndReturn, emitAndRethrow)
+			: emitAndReturn(outcome);
 	}
 
 	private toReason(error: Error, phase: SsrfPhase): string {

--- a/packages/core/src/ssrf/ssrf-protection.service.ts
+++ b/packages/core/src/ssrf/ssrf-protection.service.ts
@@ -1,4 +1,4 @@
-import { Logger } from '@n8n/backend-common';
+import { Logger, TypedEmitter } from '@n8n/backend-common';
 import { SsrfProtectionConfig } from '@n8n/config';
 import { Service } from '@n8n/di';
 import { createResultError, createResultOk, ensureError, Result } from 'n8n-workflow';
@@ -13,6 +13,24 @@ import { buildIpRangeList } from './ip-range-builder';
 import { SsrfBlockedIpError } from './ssrf-blocked-ip.error';
 
 export type SsrfCheckResult = Result<void, Error>;
+
+type SsrfBlockedPayload = { phase: SsrfPhase; reason: string; durationMs: number };
+type SsrfAllowedPayload = { phase: SsrfPhase; durationMs: number };
+
+/**
+ * The lifecycle stage at which an SSRF check was performed.
+ * - `pre_flight`: DNS-based check run before the request is sent
+ * - `connect_time`: DNS-based check run at actual socket connection
+ * - `redirect`: synchronous IP check run when an HTTP redirect is followed
+ */
+type SsrfPhase = 'pre_flight' | 'connect_time' | 'redirect';
+
+export type SsrfEventMap = {
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	'ssrf.blocked': SsrfBlockedPayload;
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	'ssrf.allowed': SsrfAllowedPayload;
+};
 
 export interface SsrfBridge {
 	validateIp(ip: string): SsrfCheckResult;
@@ -35,6 +53,8 @@ type LookAndValidateResult = Result<LookupAddress[], Error>;
  */
 @Service()
 export class SsrfProtectionService implements SsrfBridge {
+	readonly events = new TypedEmitter<SsrfEventMap>();
+
 	private readonly logger: Logger;
 
 	private readonly blockedIps: BlockList;
@@ -76,17 +96,19 @@ export class SsrfProtectionService implements SsrfBridge {
 	async validateUrl(url: string | URL): Promise<SsrfCheckResult> {
 		const parsed = this.tryParseUrl(url);
 		if (!parsed) {
+			this.events.emit('ssrf.blocked', {
+				phase: 'pre_flight',
+				reason: 'invalid_url',
+				durationMs: 0,
+			});
 			return createResultError(new Error(`Invalid URL: ${String(url)}`));
 		}
 
-		const { hostname } = parsed;
-
-		const result = await this.lookupAndValidate(hostname, { all: true });
-		if (!result.ok) {
-			return result;
-		}
-
-		return createResultOk(undefined);
+		const result = await this.withEvents(
+			'pre_flight',
+			async () => await this.lookupAndValidate(parsed.hostname, { all: true }),
+		);
+		return result.ok ? createResultOk(undefined) : result;
 	}
 
 	/**
@@ -152,7 +174,7 @@ export class SsrfProtectionService implements SsrfBridge {
 
 		const cleanIp = this.normalizeIpInHostname(hostname);
 		if (isIP(cleanIp)) {
-			const result = this.validateIp(cleanIp);
+			const result = this.withEvents('redirect', () => this.validateIp(cleanIp));
 			if (!result.ok) {
 				throw result.error;
 			}
@@ -174,7 +196,10 @@ export class SsrfProtectionService implements SsrfBridge {
 		hostname: string,
 		options: LookupOptions,
 	): Promise<LookupAddress[]> {
-		const result = await this.lookupAndValidate(hostname, options);
+		const result = await this.withEvents(
+			'connect_time',
+			async () => await this.lookupAndValidate(hostname, options),
+		);
 		if (!result.ok) {
 			throw result.error;
 		}
@@ -226,6 +251,46 @@ export class SsrfProtectionService implements SsrfBridge {
 		}
 
 		return createResultOk(resolved);
+	}
+
+	/** Runs `fn` and emits `ssrf.allowed` or `ssrf.blocked` based on the result. */
+	private withEvents<T>(phase: SsrfPhase, fn: () => Result<T, Error>): Result<T, Error>;
+	private withEvents<T>(
+		phase: SsrfPhase,
+		fn: () => Promise<Result<T, Error>>,
+	): Promise<Result<T, Error>>;
+	private withEvents<T>(
+		phase: SsrfPhase,
+		fn: () => Result<T, Error> | Promise<Result<T, Error>>,
+	): Result<T, Error> | Promise<Result<T, Error>> {
+		const start = performance.now();
+		const outcome = fn();
+
+		const emitAndReturn = (result: Result<T, Error>): Result<T, Error> => {
+			const durationMs = performance.now() - start;
+			if (result.ok) {
+				this.events.emit('ssrf.allowed', { phase, durationMs });
+			} else {
+				this.events.emit('ssrf.blocked', {
+					phase,
+					reason: this.toReason(result.error, phase),
+					durationMs,
+				});
+			}
+			return result;
+		};
+
+		return outcome instanceof Promise ? outcome.then(emitAndReturn) : emitAndReturn(outcome);
+	}
+
+	private toReason(error: Error, phase: SsrfPhase): string {
+		if (phase === 'redirect') {
+			return 'blocked_redirect';
+		}
+		if (error instanceof SsrfBlockedIpError) {
+			return 'blocked_ip';
+		}
+		return 'dns_error';
 	}
 
 	private tryParseUrl(url: string | URL): URL | null {


### PR DESCRIPTION
## Summary

Adds Prometheus metrics for SSRF protection check.

**Metrics registered when enabled:**

| Metric | Type | Labels |
|--------|------|--------|
| `n8n_ssrf_checks_total` | Counter | `result`, `phase` |
| `n8n_ssrf_blocked_checks_total` | Counter | `phase`, `reason` |
| `n8n_ssrf_check_duration_seconds` | Histogram | `result`, `phase` |

Label values:
- `phase`: `pre_flight`, `connect_time`, `redirect`
- `result`: `allowed`, `blocked`
- `reason` (blocked only): `blocked_ip`, `dns_error`, `invalid_url`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2393

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.