### PR TITLE
fix(API): Make conditional credential fields optional instead of forbidden

### DIFF
--- a/packages/cli/src/public-api/types.ts
+++ b/packages/cli/src/public-api/types.ts
@@ -238,12 +238,10 @@ export type OffsetPagination = PaginationBase & { offset: number; numberOfTotalR
 export type CursorPagination = PaginationBase & { lastId: string; numberOfNextRecords: number };
 export interface IRequired {
 	required?: string[];
-	not?: { required?: string[] };
 }
 export interface IDependency {
-	if?: { properties: {} };
+	if?: { properties: {}; required?: string[] };
 	then?: { allOf: IRequired[] };
-	else?: { allOf: IRequired[] };
 }
 
 export interface IJsonSchema {

--- a/packages/cli/src/public-api/v1/handlers/credentials/__tests__/credentials.service.test.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/__tests__/credentials.service.test.ts
@@ -2,6 +2,7 @@ import type { CredentialsEntity, Project, SharedCredentials, User } from '@n8n/d
 import { CredentialsRepository, GLOBAL_OWNER_ROLE, GLOBAL_MEMBER_ROLE } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { mock } from 'jest-mock-extended';
+import { validate, type Schema } from 'jsonschema';
 import { Cipher, CipherAes256GCM, CipherAes256CBC, EncryptionKeyProxy } from 'n8n-core';
 import type { InstanceSettings } from 'n8n-core';
 import type { GenericValue, IDataObject, INodeProperties } from 'n8n-workflow';
@@ -120,6 +121,7 @@ describe('CredentialsService', () => {
 				{
 					name: 'secret',
 					type: 'string',
+					required: true,
 					displayName: 'Secret',
 					default: '',
 					displayOptions: {
@@ -131,6 +133,7 @@ describe('CredentialsService', () => {
 				{
 					name: 'privateKey',
 					type: 'string',
+					required: true,
 					displayName: 'Private Key',
 					default: '',
 					displayOptions: {
@@ -142,6 +145,7 @@ describe('CredentialsService', () => {
 				{
 					name: 'publicKey',
 					type: 'string',
+					required: true,
 					displayName: 'Public Key',
 					default: '',
 					displayOptions: {
@@ -235,6 +239,7 @@ describe('CredentialsService', () => {
 				{
 					name: 'username',
 					type: 'string',
+					required: true,
 					displayName: 'Username',
 					default: '',
 					displayOptions: {
@@ -246,6 +251,7 @@ describe('CredentialsService', () => {
 				{
 					name: 'password',
 					type: 'string',
+					required: true,
 					displayName: 'Password',
 					default: '',
 					displayOptions: {
@@ -257,6 +263,7 @@ describe('CredentialsService', () => {
 				{
 					name: 'clientId',
 					type: 'string',
+					required: true,
 					displayName: 'Client ID',
 					default: '',
 					displayOptions: {
@@ -297,6 +304,7 @@ describe('CredentialsService', () => {
 				{
 					name: 'createField',
 					type: 'string',
+					required: true,
 					displayName: 'Create Field',
 					default: '',
 					displayOptions: {
@@ -308,6 +316,7 @@ describe('CredentialsService', () => {
 				{
 					name: 'updateField',
 					type: 'string',
+					required: true,
 					displayName: 'Update Field',
 					default: '',
 					displayOptions: {
@@ -319,6 +328,7 @@ describe('CredentialsService', () => {
 				{
 					name: 'deleteField',
 					type: 'string',
+					required: true,
 					displayName: 'Delete Field',
 					default: '',
 					displayOptions: {
@@ -369,6 +379,7 @@ describe('CredentialsService', () => {
 				{
 					name: 'field3',
 					type: 'string',
+					required: true,
 					displayName: 'Field 3',
 					default: '',
 					displayOptions: {
@@ -408,10 +419,68 @@ describe('CredentialsService', () => {
 
 			// then block requires field3 when field2 === false
 			expect(condition.then?.allOf.some((req: any) => req.required?.includes('field3'))).toBe(true);
-			// else block forbids field3 when field2 !== false
-			expect(
-				condition.else?.allOf.some((notReq: any) => notReq.not?.required?.includes('field3')),
-			).toBe(true);
+			// no else block: hidden fields are optional, not forbidden
+			expect((condition as any).else).toBeUndefined();
+		});
+
+		it('should not forbid conditional fields belonging to inactive conditions', () => {
+			// Mirrors the mongoDb scenario: two fields depend on the same options field
+			// but with different values. A payload that includes both the active
+			// and the inactive conditional field must validate.
+			const properties: INodeProperties[] = [
+				{
+					name: 'configurationType',
+					type: 'options',
+					options: [
+						{ value: 'connectionString', name: 'Connection String' },
+						{ value: 'values', name: 'Values' },
+					],
+					displayName: 'Configuration Type',
+					default: 'values',
+				},
+				{
+					name: 'connectionString',
+					type: 'string',
+					required: true,
+					displayName: 'Connection String',
+					default: '',
+					displayOptions: { show: { configurationType: ['connectionString'] } },
+				},
+				{
+					name: 'host',
+					type: 'string',
+					required: true,
+					displayName: 'Host',
+					default: '',
+					displayOptions: { show: { configurationType: ['values'] } },
+				},
+			];
+
+			const schema = toJsonSchema(properties);
+
+			// No `not: { required }` anywhere in the generated schema
+			expect(JSON.stringify(schema)).not.toContain('"not"');
+
+			// A payload using connectionString but also carrying the inactive `host` field
+			// must be accepted.
+			const connectionStringPayload = {
+				configurationType: 'connectionString',
+				connectionString: 'mongodb://localhost:27017/mydb',
+				host: 'localhost',
+			};
+			expect(validate(connectionStringPayload, schema as unknown as Schema).valid).toBe(true);
+
+			// And the reverse direction.
+			const valuesPayload = {
+				configurationType: 'values',
+				host: 'localhost',
+				connectionString: 'mongodb://localhost:27017/mydb',
+			};
+			expect(validate(valuesPayload, schema as unknown as Schema).valid).toBe(true);
+
+			// Required fields are still enforced via the `then` block.
+			const missingRequired = { configurationType: 'values' };
+			expect(validate(missingRequired, schema as unknown as Schema).valid).toBe(false);
 		});
 	});
 

--- a/packages/cli/src/public-api/v1/handlers/credentials/credentials.service.ts
+++ b/packages/cli/src/public-api/v1/handlers/credentials/credentials.service.ts
@@ -439,28 +439,36 @@ export function toJsonSchema(properties: INodeProperties[]): IDataObject {
 						properties: {
 							[dependantName]: conditionalValue,
 						},
+						// Require the controlling field in the `if` so the condition only
+						// matches when it is actually present and equal. Without this, an
+						// absent controlling field makes `properties` vacuously true and the
+						// `then` block would fire unexpectedly.
+						required: [dependantName],
 					},
 					then: {
-						allOf: [],
-					},
-					else: {
 						allOf: [],
 					},
 				};
 				resolveProperties.push(dependencyKey);
 			}
 
-			propertyRequiredDependencies[dependencyKey].then?.allOf.push({ required: [property.name] });
-			propertyRequiredDependencies[dependencyKey].else?.allOf.push({
-				not: { required: [property.name] },
-			});
-			// remove global required
+			// Only enforce a field as required when the credential actually marks it `required`.
+			if (property.required) {
+				propertyRequiredDependencies[dependencyKey].then?.allOf.push({
+					required: [property.name],
+				});
+			}
+			// Requiredness is now conditional, so drop it from the global required list.
 			requiredFields = requiredFields.filter((field) => field !== property.name);
 		}
 	});
 	Object.assign(jsonSchema, { required: requiredFields });
 
-	jsonSchema.allOf = Object.values(propertyRequiredDependencies);
+	// Drop conditionals that ended up with no required fields, so credentials whose
+	// conditional fields are all optional produce no `allOf` constraints.
+	jsonSchema.allOf = Object.values(propertyRequiredDependencies).filter(
+		(dependency) => (dependency.then?.allOf.length ?? 0) > 0,
+	);
 
 	if (!jsonSchema.allOf.length) {
 		delete jsonSchema.allOf;


### PR DESCRIPTION
## Summary

The `GET /api/v1/credentials/schema/{credentialType}` endpoint was generating a JSON Schema that made conditional fields behave incorrectly on `POST`/`PATCH /api/v1/credentials`, causing valid payloads to be rejected with 400 errors.
Three bugs were fixed in `toJsonSchema()`:
- **`else` block removed.** The generated schema contained `else: { not: { required: [...] } }`, which in JSON Schema means "this field must be absent". Fields not required by the active condition should simply be optional, not forbidden.
- **`then` block now only requires fields marked `required: true`.** Previously every conditionally-shown field was unconditionally added to `required`, even when the credential definition did not mark it required. For example, MongoDB's `host` field has a default value and is not required, but the old schema demanded it.
- **`if` now requires the controlling field to be present.** Without `required: [controllerField]` in the `if`, an absent controlling field makes the `properties` constraint vacuously true and the `then` block fires unexpectedly (e.g. omitting `tls` would trigger a demand for `ca`, `cert`, `key`, `passphrase`).

Conditional blocks whose `then` ends up empty (no required fields) are pruned entirely, so credentials with all-optional conditional fields (e.g. `mongoDb`) produce no `allOf` constraints at all.

The fix is backward-compatible: all previously valid payloads continue to validate; only wrongly-rejected payloads now pass.


## How to test

```bash
BASE_URL="http://localhost:5678"
API_KEY="<your-api-key>"
# 1. Inspect schema — no `not` blocks should appear
curl -s -H "X-N8N-API-KEY: $API_KEY" \
  "$BASE_URL/api/v1/credentials/schema/mongoDb" | jq '.allOf'
# Expected: null (no allOf at all)
# 2. values mode with extra inactive fields — should return 200
curl -s -X POST \
  -H "X-N8N-API-KEY: $API_KEY" -H "Content-Type: application/json" \
  -d '{"name":"Test Mongo","type":"mongoDb","data":{"configurationType":"values","host":"localhost","port":27017,"database":"mydb","connectionString":"mongodb://localhost:27017/mydb"}}' \
  "$BASE_URL/api/v1/credentials" | jq .
# 3. Minimal payload — should return 200 (host optional, defaults to localhost)
curl -s -X POST \
  -H "X-N8N-API-KEY: $API_KEY" -H "Content-Type: application/json" \
  -d '{"name":"Test Mongo minimal","type":"mongoDb","data":{"configurationType":"values"}}' \
  "$BASE_URL/api/v1/credentials" | jq .
# 4. Unknown field — should still return 400
curl -s -X POST \
  -H "X-N8N-API-KEY: $API_KEY" -H "Content-Type: application/json" \
  -d '{"name":"Test Mongo bogus","type":"mongoDb","data":{"configurationType":"values","unknownField":"x"}}' \
  "$BASE_URL/api/v1/credentials" | jq .
# 5. Credential with genuinely required field missing — should return 400
curl -s -X POST \
  -H "X-N8N-API-KEY: $API_KEY" -H "Content-Type: application/json" \
  -d '{"name":"Test Odoo broken","type":"odooApiKeyApi","data":{"url":"https://my-org.odoo.com"}}' \
  "$BASE_URL/api/v1/credentials" | jq .
```

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
https://linear.app/n8n/issue/IAM-743/


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
