### PR TITLE
test(core): Add e2e baseline for the instance MCP OAuth server (no-changelog)

### DIFF
--- a/packages/testing/playwright/services/api-helper.ts
+++ b/packages/testing/playwright/services/api-helper.ts
@@ -20,6 +20,7 @@ import { CredentialApiHelper } from './credential-api-helper';
 import { DynamicCredentialApiHelper } from './dynamic-credential-api-helper';
 import { ExternalSecretsApiHelper } from './external-secrets-api-helper';
 import { McpApiHelper } from './mcp-api-helper';
+import { McpOAuthApiHelper } from './mcp-oauth-api-helper';
 import { ProjectApiHelper } from './project-api-helper';
 import { PublicApiHelper } from './public-api-helper';
 import { RoleApiHelper } from './role-api-helper';
@@ -67,6 +68,7 @@ export class ApiHelpers {
 	workflows: WorkflowApiHelper;
 	webhooks: WebhookApiHelper;
 	mcp: McpApiHelper;
+	mcpOAuth: McpOAuthApiHelper;
 	projects: ProjectApiHelper;
 	credentials: CredentialApiHelper;
 	dynamicCredentials: DynamicCredentialApiHelper;
@@ -84,6 +86,7 @@ export class ApiHelpers {
 		this.workflows = new WorkflowApiHelper(this);
 		this.webhooks = new WebhookApiHelper(this);
 		this.mcp = new McpApiHelper(this);
+		this.mcpOAuth = new McpOAuthApiHelper(this);
 		this.projects = new ProjectApiHelper(this);
 		this.credentials = new CredentialApiHelper(this);
 		this.dynamicCredentials = new DynamicCredentialApiHelper(this);

--- a/packages/testing/playwright/services/mcp-oauth-api-helper.ts
+++ b/packages/testing/playwright/services/mcp-oauth-api-helper.ts
@@ -1,0 +1,314 @@
+import type { APIResponse } from '@playwright/test';
+import { createHash, randomBytes } from 'node:crypto';
+
+import type { ApiHelpers } from './api-helper';
+
+export interface OAuthAuthorizationServerMetadata {
+	issuer: string;
+	authorization_endpoint: string;
+	token_endpoint: string;
+	registration_endpoint: string;
+	revocation_endpoint: string;
+	response_types_supported: string[];
+	grant_types_supported: string[];
+	token_endpoint_auth_methods_supported: string[];
+	code_challenge_methods_supported: string[];
+	scopes_supported: string[];
+}
+
+export interface OAuthProtectedResourceMetadata {
+	resource: string;
+	bearer_methods_supported: string[];
+	authorization_servers: string[];
+	scopes_supported: string[];
+}
+
+export interface RegisteredOAuthClient {
+	client_id: string;
+	client_secret?: string;
+	client_name: string;
+	redirect_uris: string[];
+	grant_types: string[];
+	token_endpoint_auth_method: string;
+}
+
+export interface OAuthTokenResponse {
+	access_token: string;
+	token_type: string;
+	expires_in: number;
+	refresh_token: string;
+}
+
+export interface PkcePair {
+	codeVerifier: string;
+	codeChallenge: string;
+}
+
+export interface AuthorizationCodeFlowResult {
+	client: RegisteredOAuthClient;
+	tokens: OAuthTokenResponse;
+	redirectUri: string;
+	resource: string;
+}
+
+const DEFAULT_REDIRECT_URI = 'http://localhost:3000/callback';
+
+/**
+ * Helper for the instance-MCP OAuth server (DCR, authorize → consent → token
+ * with PKCE, discovery, refresh, revoke).
+ *
+ * Routes hit:
+ * - `/.well-known/oauth-authorization-server` (RFC 8414)
+ * - `/.well-known/oauth-protected-resource/mcp-server/http` (RFC 9728)
+ * - `/mcp-oauth/{register,authorize,token,revoke}`
+ * - `/consent/{details,approve}`
+ *
+ * The shared `api.request` context carries both the signed-in user cookie and the
+ * `n8n-oauth-session` cookie that `authorize` sets, so the consent calls are
+ * authenticated as the current user without extra plumbing.
+ */
+export class McpOAuthApiHelper {
+	constructor(private readonly api: ApiHelpers) {}
+
+	/** Generate an RFC 7636 PKCE pair (S256). */
+	createPkcePair(): PkcePair {
+		const codeVerifier = base64UrlEncode(randomBytes(32));
+		const codeChallenge = base64UrlEncode(createHash('sha256').update(codeVerifier).digest());
+		return { codeVerifier, codeChallenge };
+	}
+
+	// ===== Discovery =====
+
+	async getAuthorizationServerMetadataResponse(): Promise<APIResponse> {
+		return await this.api.request.get('/.well-known/oauth-authorization-server');
+	}
+
+	async getAuthorizationServerMetadata(): Promise<OAuthAuthorizationServerMetadata> {
+		const response = await this.getAuthorizationServerMetadataResponse();
+		return (await response.json()) as OAuthAuthorizationServerMetadata;
+	}
+
+	async optionsAuthorizationServerMetadata(): Promise<APIResponse> {
+		return await this.api.request.fetch('/.well-known/oauth-authorization-server', {
+			method: 'OPTIONS',
+		});
+	}
+
+	async getProtectedResourceMetadataResponse(): Promise<APIResponse> {
+		return await this.api.request.get('/.well-known/oauth-protected-resource/mcp-server/http');
+	}
+
+	async getProtectedResourceMetadata(): Promise<OAuthProtectedResourceMetadata> {
+		const response = await this.getProtectedResourceMetadataResponse();
+		return (await response.json()) as OAuthProtectedResourceMetadata;
+	}
+
+	/** Canonical RFC 8707 resource indicator advertised by the instance. */
+	async getCanonicalResourceUrl(): Promise<string> {
+		const metadata = await this.getProtectedResourceMetadata();
+		return metadata.resource;
+	}
+
+	// ===== Dynamic Client Registration =====
+
+	async registerClientResponse(
+		overrides: Partial<{
+			client_name: string;
+			redirect_uris: string[];
+			grant_types: string[];
+			token_endpoint_auth_method: string;
+		}> = {},
+	): Promise<APIResponse> {
+		return await this.api.request.post('/mcp-oauth/register', {
+			data: {
+				client_name: 'e2e-oauth-client',
+				redirect_uris: [DEFAULT_REDIRECT_URI],
+				grant_types: ['authorization_code', 'refresh_token'],
+				token_endpoint_auth_method: 'none',
+				...overrides,
+			},
+		});
+	}
+
+	async registerClient(
+		overrides?: Parameters<McpOAuthApiHelper['registerClientResponse']>[0],
+	): Promise<RegisteredOAuthClient> {
+		const response = await this.registerClientResponse(overrides);
+		return (await response.json()) as RegisteredOAuthClient;
+	}
+
+	// ===== Authorize / consent =====
+
+	/**
+	 * Start the authorization flow. Returns the raw response WITHOUT following the
+	 * redirect, so the caller can read the `Location` header. The `n8n-oauth-session`
+	 * cookie is stored on the request context as a side effect.
+	 */
+	async authorize(params: {
+		clientId: string;
+		codeChallenge: string;
+		redirectUri?: string;
+		state?: string;
+		resource?: string;
+		scope?: string;
+	}): Promise<APIResponse> {
+		const query = new URLSearchParams({
+			response_type: 'code',
+			client_id: params.clientId,
+			redirect_uri: params.redirectUri ?? DEFAULT_REDIRECT_URI,
+			code_challenge: params.codeChallenge,
+			code_challenge_method: 'S256',
+		});
+		if (params.state) query.set('state', params.state);
+		if (params.resource) query.set('resource', params.resource);
+		if (params.scope) query.set('scope', params.scope);
+
+		return await this.api.request.get(`/mcp-oauth/authorize?${query.toString()}`, {
+			maxRedirects: 0,
+		});
+	}
+
+	async getConsentDetailsResponse(): Promise<APIResponse> {
+		return await this.api.request.get('/rest/consent/details');
+	}
+
+	async getConsentDetails(): Promise<{ clientName: string; clientId: string }> {
+		const response = await this.getConsentDetailsResponse();
+		const body = (await response.json()) as { data: { clientName: string; clientId: string } };
+		return body.data;
+	}
+
+	async approveConsentResponse(approved: boolean): Promise<APIResponse> {
+		return await this.api.request.post('/rest/consent/approve', {
+			data: { approved },
+		});
+	}
+
+	/** Approve or deny consent. Returns the redirect URL carrying `code`/`error`. */
+	async submitConsent(approved: boolean): Promise<string> {
+		const response = await this.approveConsentResponse(approved);
+		const body = (await response.json()) as { data: { redirectUrl: string } };
+		return body.data.redirectUrl;
+	}
+
+	// ===== Token endpoint =====
+
+	async exchangeAuthorizationCodeResponse(params: {
+		code: string;
+		clientId: string;
+		codeVerifier: string;
+		redirectUri?: string;
+		resource?: string;
+	}): Promise<APIResponse> {
+		const form: Record<string, string> = {
+			grant_type: 'authorization_code',
+			code: params.code,
+			client_id: params.clientId,
+			code_verifier: params.codeVerifier,
+			redirect_uri: params.redirectUri ?? DEFAULT_REDIRECT_URI,
+		};
+		if (params.resource) form.resource = params.resource;
+		return await this.api.request.post('/mcp-oauth/token', { form });
+	}
+
+	async exchangeAuthorizationCode(
+		params: Parameters<McpOAuthApiHelper['exchangeAuthorizationCodeResponse']>[0],
+	): Promise<OAuthTokenResponse> {
+		const response = await this.exchangeAuthorizationCodeResponse(params);
+		return (await response.json()) as OAuthTokenResponse;
+	}
+
+	async refreshTokenResponse(params: {
+		refreshToken: string;
+		clientId: string;
+		resource?: string;
+	}): Promise<APIResponse> {
+		const form: Record<string, string> = {
+			grant_type: 'refresh_token',
+			refresh_token: params.refreshToken,
+			client_id: params.clientId,
+		};
+		if (params.resource) form.resource = params.resource;
+		return await this.api.request.post('/mcp-oauth/token', { form });
+	}
+
+	async refreshToken(
+		params: Parameters<McpOAuthApiHelper['refreshTokenResponse']>[0],
+	): Promise<OAuthTokenResponse> {
+		const response = await this.refreshTokenResponse(params);
+		return (await response.json()) as OAuthTokenResponse;
+	}
+
+	async revokeTokenResponse(params: {
+		token: string;
+		clientId: string;
+		tokenTypeHint?: 'access_token' | 'refresh_token';
+	}): Promise<APIResponse> {
+		const form: Record<string, string> = {
+			token: params.token,
+			client_id: params.clientId,
+		};
+		if (params.tokenTypeHint) form.token_type_hint = params.tokenTypeHint;
+		return await this.api.request.post('/mcp-oauth/revoke', { form });
+	}
+
+	// ===== High-level orchestration =====
+
+	/**
+	 * Run the full authorization-code + PKCE flow end-to-end (DCR → authorize →
+	 * consent approve → token exchange) and return the issued tokens.
+	 *
+	 * Must run on a request context that is signed in as an n8n user (the consent
+	 * endpoints require it). The default `api` fixture is signed in as owner.
+	 */
+	async completeAuthorizationCodeFlow(
+		options: { resource?: string; state?: string } = {},
+	): Promise<AuthorizationCodeFlowResult> {
+		const client = await this.registerClient();
+		const { codeVerifier, codeChallenge } = this.createPkcePair();
+		const redirectUri = client.redirect_uris[0];
+		const state = options.state ?? `state-${Math.random().toString(36).slice(2)}`;
+
+		const authorizeResponse = await this.authorize({
+			clientId: client.client_id,
+			codeChallenge,
+			redirectUri,
+			state,
+			resource: options.resource,
+		});
+
+		if (authorizeResponse.status() !== 302) {
+			throw new Error(
+				`Expected authorize to redirect to consent, got ${authorizeResponse.status()}: ${await authorizeResponse.text()}`,
+			);
+		}
+
+		const redirectUrl = await this.submitConsent(true);
+		const code = extractQueryParam(redirectUrl, 'code');
+		if (!code) {
+			throw new Error(`Authorization redirect did not contain a code: ${redirectUrl}`);
+		}
+
+		const tokens = await this.exchangeAuthorizationCode({
+			code,
+			clientId: client.client_id,
+			codeVerifier,
+			redirectUri,
+			resource: options.resource,
+		});
+
+		return { client, tokens, redirectUri, resource: options.resource ?? '' };
+	}
+}
+
+function base64UrlEncode(buffer: Buffer): string {
+	return buffer.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+function extractQueryParam(url: string, param: string): string | null {
+	try {
+		return new URL(url).searchParams.get(param);
+	} catch {
+		return null;
+	}
+}

--- a/packages/testing/playwright/tests/e2e/mcp/mcp-oauth.spec.ts
+++ b/packages/testing/playwright/tests/e2e/mcp/mcp-oauth.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect } from '../../../fixtures/base';
 
+// Both this spec and mcp-service.spec.ts toggle the instance-global MCP access
+// setting. In container runs this gives the OAuth spec its own worker/container
+// so the two files cannot race each other's `setMcpAccess` calls. (Local runs
+// against a shared N8N_BASE_URL ignore this — run the two files sequentially.)
+test.use({ capability: { env: { TEST_ISOLATION: 'mcp-oauth' } } });
+
 /**
  * E2E baseline for the instance MCP OAuth server.
  *

--- a/packages/testing/playwright/tests/e2e/mcp/mcp-oauth.spec.ts
+++ b/packages/testing/playwright/tests/e2e/mcp/mcp-oauth.spec.ts
@@ -1,0 +1,250 @@
+import { test, expect } from '../../../fixtures/base';
+
+/**
+ * E2E baseline for the instance MCP OAuth server.
+ *
+ * The existing mcp-service.spec.ts only exercises the API-key auth path. This
+ * spec locks in the OAuth server behaviour — discovery documents (RFC 8414 +
+ * RFC 9728), Dynamic Client Registration, the authorize → consent → token flow
+ * with PKCE, refresh/revoke, the MCP-disabled gate, and using an OAuth bearer
+ * token against /mcp-server/http.
+ *
+ * It exists as a regression net for the upcoming extraction of the OAuth server
+ * into a shared `oauth-server` module (IAM-797): the payloads asserted here must
+ * stay byte-identical across that move.
+ *
+ * The default `api` fixture is signed in as owner, so the consent endpoints
+ * (which require an authenticated n8n user) work without extra plumbing.
+ */
+test.describe(
+	'MCP OAuth Server',
+	{
+		annotation: [{ type: 'owner', description: 'IAM' }],
+	},
+	() => {
+		// `setMcpAccess` toggles instance-global state, so run serially to avoid
+		// the "access disabled" test racing with the OAuth-flow tests.
+		test.describe.configure({ mode: 'serial' });
+
+		test.beforeEach(async ({ api }) => {
+			await api.setMcpAccess(true);
+		});
+
+		test.describe('Discovery', () => {
+			test('should expose RFC 8414 authorization-server metadata', async ({ api }) => {
+				const response = await api.mcpOAuth.getAuthorizationServerMetadataResponse();
+				expect(response.status()).toBe(200);
+				// Discovery is served cross-origin for browser-based MCP clients.
+				expect(response.headers()['access-control-allow-origin']).toBe('*');
+
+				const metadata = (await response.json()) as Awaited<
+					ReturnType<typeof api.mcpOAuth.getAuthorizationServerMetadata>
+				>;
+
+				expect(metadata.issuer).toBeTruthy();
+				expect(metadata.authorization_endpoint).toBe(`${metadata.issuer}/mcp-oauth/authorize`);
+				expect(metadata.token_endpoint).toBe(`${metadata.issuer}/mcp-oauth/token`);
+				expect(metadata.registration_endpoint).toBe(`${metadata.issuer}/mcp-oauth/register`);
+				expect(metadata.revocation_endpoint).toBe(`${metadata.issuer}/mcp-oauth/revoke`);
+				expect(metadata.response_types_supported).toEqual(['code']);
+				expect(metadata.grant_types_supported).toEqual(['authorization_code', 'refresh_token']);
+				expect(metadata.token_endpoint_auth_methods_supported).toEqual([
+					'none',
+					'client_secret_post',
+					'client_secret_basic',
+				]);
+				expect(metadata.code_challenge_methods_supported).toEqual(['S256']);
+				expect(metadata.scopes_supported.length).toBeGreaterThan(0);
+			});
+
+			test('should answer CORS preflight for authorization-server metadata', async ({ api }) => {
+				const response = await api.mcpOAuth.optionsAuthorizationServerMetadata();
+
+				expect(response.status()).toBe(204);
+			});
+
+			test('should expose RFC 9728 protected-resource metadata', async ({ api }) => {
+				const metadata = await api.mcpOAuth.getProtectedResourceMetadata();
+
+				expect(metadata.resource).toMatch(/\/mcp-server\/http$/);
+				expect(metadata.bearer_methods_supported).toEqual(['header']);
+				expect(metadata.authorization_servers.length).toBeGreaterThan(0);
+				expect(metadata.scopes_supported.length).toBeGreaterThan(0);
+			});
+
+			test('should advertise the resource that matches the authorization server issuer', async ({
+				api,
+			}) => {
+				const asMetadata = await api.mcpOAuth.getAuthorizationServerMetadata();
+				const resourceMetadata = await api.mcpOAuth.getProtectedResourceMetadata();
+
+				expect(resourceMetadata.resource).toBe(`${asMetadata.issuer}/mcp-server/http`);
+				expect(resourceMetadata.authorization_servers).toContain(asMetadata.issuer);
+			});
+		});
+
+		test.describe('Dynamic Client Registration', () => {
+			test('should register a public client and return its id', async ({ api }) => {
+				const response = await api.mcpOAuth.registerClientResponse();
+
+				expect(response.status()).toBeLessThan(300);
+
+				const client = await response.json();
+				expect(client.client_id).toBeTruthy();
+				expect(client.redirect_uris).toContain('http://localhost:3000/callback');
+				expect(client.grant_types).toEqual(['authorization_code', 'refresh_token']);
+			});
+
+			test('should reject registration without redirect_uris', async ({ api }) => {
+				const response = await api.mcpOAuth.registerClientResponse({ redirect_uris: [] });
+
+				expect(response.status()).toBeGreaterThanOrEqual(400);
+			});
+		});
+
+		test.describe('Authorization code flow', () => {
+			test('should mint an access token via authorize → consent → token', async ({ api }) => {
+				const { tokens } = await api.mcpOAuth.completeAuthorizationCodeFlow();
+
+				expect(tokens.access_token).toBeTruthy();
+				expect(tokens.refresh_token).toBeTruthy();
+				expect(tokens.token_type).toBe('Bearer');
+				expect(tokens.expires_in).toBeGreaterThan(0);
+			});
+
+			test('should accept the issued OAuth token against /mcp-server/http', async ({ api }) => {
+				const { tokens } = await api.mcpOAuth.completeAuthorizationCodeFlow();
+
+				const message = api.mcp.createMessage('tools/list');
+				const response = await api.mcp.internalMcpSendMessage(tokens.access_token, message);
+
+				expect(response.status()).toBeLessThan(300);
+			});
+
+			test('should redirect to consent and expose the client name', async ({ api }) => {
+				const client = await api.mcpOAuth.registerClient();
+				const { codeChallenge } = api.mcpOAuth.createPkcePair();
+
+				const authorizeResponse = await api.mcpOAuth.authorize({
+					clientId: client.client_id,
+					codeChallenge,
+				});
+
+				expect(authorizeResponse.status()).toBe(302);
+				expect(authorizeResponse.headers().location).toBe('/oauth/consent');
+
+				const details = await api.mcpOAuth.getConsentDetails();
+				expect(details.clientId).toBe(client.client_id);
+				expect(details.clientName).toBe(client.client_name);
+			});
+
+			test('should redirect with access_denied when consent is denied', async ({ api }) => {
+				const client = await api.mcpOAuth.registerClient();
+				const { codeChallenge } = api.mcpOAuth.createPkcePair();
+
+				await api.mcpOAuth.authorize({
+					clientId: client.client_id,
+					codeChallenge,
+					state: 'denied-state',
+				});
+
+				const redirectUrl = await api.mcpOAuth.submitConsent(false);
+
+				const url = new URL(redirectUrl);
+				expect(url.searchParams.get('error')).toBe('access_denied');
+				expect(url.searchParams.get('state')).toBe('denied-state');
+			});
+
+			test('should reject an authorization code reused at the token endpoint', async ({ api }) => {
+				const client = await api.mcpOAuth.registerClient();
+				const { codeVerifier, codeChallenge } = api.mcpOAuth.createPkcePair();
+
+				await api.mcpOAuth.authorize({ clientId: client.client_id, codeChallenge });
+				const redirectUrl = await api.mcpOAuth.submitConsent(true);
+				const code = new URL(redirectUrl).searchParams.get('code')!;
+
+				const first = await api.mcpOAuth.exchangeAuthorizationCodeResponse({
+					code,
+					clientId: client.client_id,
+					codeVerifier,
+				});
+				expect(first.status()).toBeLessThan(300);
+
+				const second = await api.mcpOAuth.exchangeAuthorizationCodeResponse({
+					code,
+					clientId: client.client_id,
+					codeVerifier,
+				});
+				expect(second.status()).toBeGreaterThanOrEqual(400);
+			});
+
+			test('should reject an authorization request with a mismatched resource indicator', async ({
+				api,
+			}) => {
+				const client = await api.mcpOAuth.registerClient();
+				const { codeChallenge } = api.mcpOAuth.createPkcePair();
+
+				const response = await api.mcpOAuth.authorize({
+					clientId: client.client_id,
+					codeChallenge,
+					resource: 'https://attacker.example.com/mcp-server/http',
+				});
+
+				expect(response.status()).toBe(400);
+				const body = await response.json();
+				expect(body.error).toBe('invalid_target');
+			});
+		});
+
+		test.describe('Refresh and revoke', () => {
+			test('should rotate tokens with a refresh token', async ({ api }) => {
+				const { client, tokens } = await api.mcpOAuth.completeAuthorizationCodeFlow();
+
+				const rotated = await api.mcpOAuth.refreshToken({
+					refreshToken: tokens.refresh_token,
+					clientId: client.client_id,
+				});
+
+				expect(rotated.access_token).toBeTruthy();
+				expect(rotated.refresh_token).toBeTruthy();
+				expect(rotated.access_token).not.toBe(tokens.access_token);
+				expect(rotated.refresh_token).not.toBe(tokens.refresh_token);
+			});
+
+			test('should reject a revoked access token at /mcp-server/http', async ({ api }) => {
+				const { client, tokens } = await api.mcpOAuth.completeAuthorizationCodeFlow();
+
+				const message = api.mcp.createMessage('tools/list');
+				const before = await api.mcp.internalMcpSendMessage(tokens.access_token, message);
+				expect(before.status()).toBeLessThan(300);
+
+				const revoke = await api.mcpOAuth.revokeTokenResponse({
+					token: tokens.access_token,
+					clientId: client.client_id,
+					tokenTypeHint: 'access_token',
+				});
+				expect(revoke.status()).toBeLessThan(300);
+
+				const after = await api.mcp.internalMcpSendMessage(tokens.access_token, message);
+				expect(after.status()).toBe(401);
+			});
+		});
+
+		test.describe('MCP access gate', () => {
+			test('should reject OAuth endpoints when MCP access is disabled', async ({ api }) => {
+				// The next test's beforeEach re-enables access, so no explicit restore needed.
+				await api.setMcpAccess(false);
+
+				const registerResponse = await api.mcpOAuth.registerClientResponse();
+				expect(registerResponse.status()).toBe(403);
+
+				const { codeChallenge } = api.mcpOAuth.createPkcePair();
+				const authorizeResponse = await api.mcpOAuth.authorize({
+					clientId: 'any-client',
+					codeChallenge,
+				});
+				expect(authorizeResponse.status()).toBe(403);
+			});
+		});
+	},
+);


### PR DESCRIPTION
## Summary

Adds an API-level Playwright e2e spec for the **instance MCP OAuth server**, which until now had **no e2e coverage** — `mcp-service.spec.ts` only exercised the API-key auth path.

The spec covers:
- **Discovery** — RFC 8414 authorization-server metadata, RFC 9728 protected-resource metadata, cross-consistency, and CORS on discovery.
- **Dynamic Client Registration** — public client registration + validation.
- **Authorization-code flow with PKCE** — `authorize` → consent → `token`, then using the issued OAuth bearer token against `/mcp-server/http`; consent denial; authorization-code single-use; RFC 8707 resource-indicator validation.
- **Refresh & revoke** — refresh-token rotation; revoked access token rejected at `/mcp-server/http`.
- **MCP-disabled gate** — OAuth endpoints return 403 when MCP access is off.

It adds a `McpOAuthApiHelper` (`api.mcpOAuth`) following the existing `api-helper` patterns (DCR, PKCE, authorize, consent, token, refresh, revoke + a full-flow orchestrator).

**Why now:** this is the regression net for the upcoming extraction of the OAuth server into a shared `oauth-server` cli module ([IAM-797](https://linear.app/n8n/issue/IAM-797)). That refactor is "no behaviour change" — discovery payloads and the DCR/authorize/token/revoke flow must stay identical — so locking in the current behaviour first lets the refactor PR prove parity. Landing it on its own branch keeps the baseline reviewable independently of the refactor.

## How to test

```bash
pnpm --filter=n8n-playwright test:local:isolated tests/e2e/mcp/mcp-oauth.spec.ts
```

All 15 tests pass locally against an isolated n8n instance.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-797

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)