### PR TITLE
feat(core): Expose DNS cache metrics via PrometheusMetricsService

### DIFF
--- a/packages/@n8n/config/src/configs/endpoints.config.ts
+++ b/packages/@n8n/config/src/configs/endpoints.config.ts
@@ -87,6 +87,10 @@ export class PrometheusMetricsConfig {
 	/** Whether to include metrics for SSRF protection checks. */
 	@Env('N8N_METRICS_INCLUDE_SSRF_METRICS')
 	includeSsrfMetrics: boolean = false;
+
+	/** Whether to include metrics for the DNS cache (currently only used by SSRF protection). */
+	@Env('N8N_METRICS_INCLUDE_DNS_CACHE_METRICS')
+	includeDnsCacheMetrics: boolean = false;
 }
 
 @Config

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -238,6 +238,7 @@ describe('GlobalConfig', () => {
 				workflowStatisticsInterval: 300,
 				includeExecutionDataMetrics: false,
 				includeSsrfMetrics: false,
+				includeDnsCacheMetrics: false,
 			},
 			additionalNonUIRoutes: '',
 			disableProductionWebhooksOnMainProcess: false,

--- a/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
+++ b/packages/cli/src/metrics/__tests__/prometheus-metrics.service.test.ts
@@ -7,6 +7,7 @@ import promClient from 'prom-client';
 import type { PrometheusActiveWorkflowMetricsService } from '../prometheus/active-workflow-metrics.service';
 import type { PrometheusCacheMetricsService } from '../prometheus/cache-metrics.service';
 import type { PrometheusDefaultMetricsService } from '../prometheus/default-metrics.service';
+import type { PrometheusDnsCacheMetricsService } from '../prometheus/dns-cache-metrics.service';
 import type { PrometheusEventBusMetricsService } from '../prometheus/event-bus-metrics.service';
 import type { PrometheusExecutionDataMetricsService } from '../prometheus/execution-data-metrics.service';
 import type { PrometheusInstanceRoleMetricsService } from '../prometheus/instance-role-metrics.service';
@@ -40,6 +41,7 @@ describe('PrometheusMetricsService', () => {
 	let defaultMetrics: jest.Mocked<PrometheusDefaultMetricsService>;
 	let tokenExchange: jest.Mocked<PrometheusTokenExchangeMetricsService>;
 	let ssrf: jest.Mocked<PrometheusSsrfMetricsService>;
+	let dnsCache: jest.Mocked<PrometheusDnsCacheMetricsService>;
 
 	let service: PrometheusMetricsService;
 
@@ -60,6 +62,7 @@ describe('PrometheusMetricsService', () => {
 			defaultMetrics,
 			tokenExchange,
 			ssrf,
+			dnsCache,
 		);
 
 	beforeEach(() => {
@@ -87,6 +90,7 @@ describe('PrometheusMetricsService', () => {
 		defaultMetrics = mock<PrometheusDefaultMetricsService>({ enabled: true });
 		tokenExchange = mock<PrometheusTokenExchangeMetricsService>({ enabled: true });
 		ssrf = mock<PrometheusSsrfMetricsService>({ enabled: true });
+		dnsCache = mock<PrometheusDnsCacheMetricsService>({ enabled: true });
 
 		service = buildService();
 	});
@@ -113,6 +117,7 @@ describe('PrometheusMetricsService', () => {
 			expect(defaultMetrics.init).toHaveBeenCalledWith(app);
 			expect(tokenExchange.init).toHaveBeenCalledWith(app);
 			expect(ssrf.init).toHaveBeenCalledWith(app);
+			expect(dnsCache.init).toHaveBeenCalledWith(app);
 		});
 
 		it('should NOT call init on disabled collectors', () => {

--- a/packages/cli/src/metrics/prometheus/__tests__/dns-cache-metrics.service.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/dns-cache-metrics.service.test.ts
@@ -140,7 +140,7 @@ describe('PrometheusDnsCacheMetricsService', () => {
 			const handler = getEventsHandler('hit');
 			expect(handler).toBeDefined();
 			handler!();
-			expect(mockCounterInc).toHaveBeenCalled();
+			expect(mockCounterInc).toHaveBeenCalledWith(1);
 		});
 
 		it('should register a listener for miss that increments the misses counter', () => {
@@ -149,7 +149,7 @@ describe('PrometheusDnsCacheMetricsService', () => {
 			const handler = getEventsHandler('miss');
 			expect(handler).toBeDefined();
 			handler!();
-			expect(mockCounterInc).toHaveBeenCalled();
+			expect(mockCounterInc).toHaveBeenCalledWith(1);
 		});
 
 		it('should register a listener for eviction that increments the evictions counter', () => {
@@ -158,7 +158,7 @@ describe('PrometheusDnsCacheMetricsService', () => {
 			const handler = getEventsHandler('eviction');
 			expect(handler).toBeDefined();
 			handler!();
-			expect(mockCounterInc).toHaveBeenCalled();
+			expect(mockCounterInc).toHaveBeenCalledWith(1);
 		});
 
 		it('should pass collect function that reads current cache size to the gauge', () => {

--- a/packages/cli/src/metrics/prometheus/__tests__/dns-cache-metrics.service.test.ts
+++ b/packages/cli/src/metrics/prometheus/__tests__/dns-cache-metrics.service.test.ts
@@ -1,0 +1,177 @@
+import { mockInstance } from '@n8n/backend-test-utils';
+import { PrometheusMetricsConfig, SsrfProtectionConfig } from '@n8n/config';
+import type { InMemoryDnsCache } from 'n8n-core';
+import promClient from 'prom-client';
+
+import { PrometheusDnsCacheMetricsService } from '../dns-cache-metrics.service';
+
+jest.mock('prom-client');
+
+describe('PrometheusDnsCacheMetricsService', () => {
+	const config = mockInstance(PrometheusMetricsConfig, {
+		prefix: 'n8n_',
+		includeDnsCacheMetrics: true,
+	});
+
+	const ssrfConfig = mockInstance(SsrfProtectionConfig, {
+		enabled: true,
+	});
+
+	const dnsEvents = { on: jest.fn() };
+	let cacheSizeValue = 0;
+	const dnsCache = {
+		events: dnsEvents,
+		get size() {
+			return cacheSizeValue;
+		},
+	} as unknown as InMemoryDnsCache;
+
+	let service: PrometheusDnsCacheMetricsService;
+	let mockCounterInc: jest.Mock;
+	let mockGaugeSet: jest.Mock;
+
+	beforeEach(() => {
+		Object.assign(config, { prefix: 'n8n_', includeDnsCacheMetrics: true });
+		Object.assign(ssrfConfig, { enabled: true });
+		cacheSizeValue = 0;
+		service = new PrometheusDnsCacheMetricsService(dnsCache, config, ssrfConfig);
+		mockCounterInc = jest.fn();
+		mockGaugeSet = jest.fn();
+		promClient.Counter.prototype.inc = mockCounterInc;
+		promClient.Gauge.prototype.set = mockGaugeSet;
+	});
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	function getEventsHandler(eventName: string) {
+		const calls = dnsEvents.on.mock.calls as Array<[string, (...args: unknown[]) => void]>;
+		return calls.find((c) => c[0] === eventName)?.[1];
+	}
+
+	describe('enabled', () => {
+		it('should be true when includeDnsCacheMetrics and SSRF protection are both enabled', () => {
+			config.includeDnsCacheMetrics = true;
+			ssrfConfig.enabled = true;
+			expect(service.enabled).toBe(true);
+		});
+
+		it('should be false when includeDnsCacheMetrics is false', () => {
+			config.includeDnsCacheMetrics = false;
+			ssrfConfig.enabled = true;
+			expect(service.enabled).toBe(false);
+		});
+
+		it('should be false when SSRF protection is disabled', () => {
+			config.includeDnsCacheMetrics = true;
+			ssrfConfig.enabled = false;
+			expect(service.enabled).toBe(false);
+		});
+	});
+
+	describe('init', () => {
+		it('should create ssrf_dns_cache_hits_total counter', () => {
+			service.init();
+
+			expect(promClient.Counter).toHaveBeenCalledWith({
+				name: 'n8n_ssrf_dns_cache_hits_total',
+				help: 'Total number of DNS cache hits.',
+			});
+		});
+
+		it('should create ssrf_dns_cache_misses_total counter', () => {
+			service.init();
+
+			expect(promClient.Counter).toHaveBeenCalledWith({
+				name: 'n8n_ssrf_dns_cache_misses_total',
+				help: 'Total number of DNS cache misses.',
+			});
+		});
+
+		it('should create ssrf_dns_cache_evictions_total counter', () => {
+			service.init();
+
+			expect(promClient.Counter).toHaveBeenCalledWith({
+				name: 'n8n_ssrf_dns_cache_evictions_total',
+				help: 'Total number of DNS cache evictions.',
+			});
+		});
+
+		it('should seed all 3 counters at 0', () => {
+			service.init();
+
+			expect(mockCounterInc).toHaveBeenCalledWith(0);
+			expect(mockCounterInc).toHaveBeenCalledTimes(3);
+		});
+
+		it('should create ssrf_dns_cache_size gauge', () => {
+			service.init();
+
+			expect(promClient.Gauge).toHaveBeenCalledWith(
+				expect.objectContaining({
+					name: 'n8n_ssrf_dns_cache_size',
+					help: 'Current number of entries in the DNS cache.',
+				}),
+			);
+		});
+
+		it('should apply custom prefix to metric names', () => {
+			config.prefix = 'myapp_';
+			service.init();
+
+			expect(promClient.Counter).toHaveBeenCalledWith(
+				expect.objectContaining({ name: 'myapp_ssrf_dns_cache_hits_total' }),
+			);
+			expect(promClient.Counter).toHaveBeenCalledWith(
+				expect.objectContaining({ name: 'myapp_ssrf_dns_cache_misses_total' }),
+			);
+			expect(promClient.Counter).toHaveBeenCalledWith(
+				expect.objectContaining({ name: 'myapp_ssrf_dns_cache_evictions_total' }),
+			);
+			expect(promClient.Gauge).toHaveBeenCalledWith(
+				expect.objectContaining({ name: 'myapp_ssrf_dns_cache_size' }),
+			);
+		});
+
+		it('should register a listener for hit that increments the hits counter', () => {
+			service.init();
+
+			const handler = getEventsHandler('hit');
+			expect(handler).toBeDefined();
+			handler!();
+			expect(mockCounterInc).toHaveBeenCalled();
+		});
+
+		it('should register a listener for miss that increments the misses counter', () => {
+			service.init();
+
+			const handler = getEventsHandler('miss');
+			expect(handler).toBeDefined();
+			handler!();
+			expect(mockCounterInc).toHaveBeenCalled();
+		});
+
+		it('should register a listener for eviction that increments the evictions counter', () => {
+			service.init();
+
+			const handler = getEventsHandler('eviction');
+			expect(handler).toBeDefined();
+			handler!();
+			expect(mockCounterInc).toHaveBeenCalled();
+		});
+
+		it('should pass collect function that reads current cache size to the gauge', () => {
+			service.init();
+
+			const gaugeOptions = (promClient.Gauge as jest.Mock).mock.calls[0][0] as {
+				collect: () => void;
+			};
+			expect(typeof gaugeOptions.collect).toBe('function');
+
+			cacheSizeValue = 42;
+			gaugeOptions.collect.call({ set: mockGaugeSet });
+			expect(mockGaugeSet).toHaveBeenCalledWith(42);
+		});
+	});
+});

--- a/packages/cli/src/metrics/prometheus/dns-cache-metrics.service.ts
+++ b/packages/cli/src/metrics/prometheus/dns-cache-metrics.service.ts
@@ -1,0 +1,56 @@
+import { PrometheusMetricsConfig, SsrfProtectionConfig } from '@n8n/config';
+import { Service } from '@n8n/di';
+import { InMemoryDnsCache } from 'n8n-core';
+import promClient from 'prom-client';
+
+import type { PrometheusMetricsCollector } from './base';
+
+/**
+ * Tracks DNS cache performance as counters and a gauge.
+ * Only registered when SSRF protection is enabled.
+ *
+ * Registers:
+ * - `n8n_ssrf_dns_cache_hits_total`: DNS cache hits
+ * - `n8n_ssrf_dns_cache_misses_total`: DNS cache misses
+ * - `n8n_ssrf_dns_cache_evictions_total`: LRU evictions due to capacity pressure
+ * - `n8n_ssrf_dns_cache_size`: current number of entries in the cache
+ */
+@Service()
+export class PrometheusDnsCacheMetricsService implements PrometheusMetricsCollector {
+	constructor(
+		private readonly dnsCache: InMemoryDnsCache,
+		private readonly config: PrometheusMetricsConfig,
+		private readonly ssrfConfig: SsrfProtectionConfig,
+	) {}
+
+	get enabled(): boolean {
+		return this.config.includeDnsCacheMetrics && this.ssrfConfig.enabled;
+	}
+
+	init() {
+		this.initializeCounter('hit', 'hits');
+		this.initializeCounter('miss', 'misses');
+		this.initializeCounter('eviction', 'evictions');
+
+		const dnsCache = this.dnsCache;
+		new promClient.Gauge({
+			name: `${this.config.prefix}ssrf_dns_cache_size`,
+			help: 'Current number of entries in the DNS cache.',
+			collect() {
+				this.set(dnsCache.size);
+			},
+		});
+	}
+
+	private initializeCounter(
+		eventName: Parameters<InMemoryDnsCache['events']['on']>[0],
+		kind: string,
+	) {
+		const counter = new promClient.Counter({
+			name: `${this.config.prefix}ssrf_dns_cache_${kind}_total`,
+			help: `Total number of DNS cache ${kind}.`,
+		});
+		counter.inc(0);
+		this.dnsCache.events.on(eventName, () => counter.inc(1));
+	}
+}

--- a/packages/cli/src/metrics/prometheus/prometheus.service.ts
+++ b/packages/cli/src/metrics/prometheus/prometheus.service.ts
@@ -7,6 +7,7 @@ import { PrometheusActiveWorkflowMetricsService } from './active-workflow-metric
 import type { PrometheusMetricsCollector } from './base';
 import { PrometheusCacheMetricsService } from './cache-metrics.service';
 import { PrometheusDefaultMetricsService } from './default-metrics.service';
+import { PrometheusDnsCacheMetricsService } from './dns-cache-metrics.service';
 import { PrometheusEventBusMetricsService } from './event-bus-metrics.service';
 import { PrometheusExecutionDataMetricsService } from './execution-data-metrics.service';
 import { PrometheusInstanceRoleMetricsService } from './instance-role-metrics.service';
@@ -41,6 +42,7 @@ export class PrometheusMetricsService {
 		defaultMetrics: PrometheusDefaultMetricsService,
 		tokenExchange: PrometheusTokenExchangeMetricsService,
 		ssrf: PrometheusSsrfMetricsService,
+		dnsCache: PrometheusDnsCacheMetricsService,
 	) {
 		this.logger = logger.scoped('metrics');
 		this.collectors = [
@@ -58,6 +60,7 @@ export class PrometheusMetricsService {
 			defaultMetrics,
 			tokenExchange,
 			ssrf,
+			dnsCache,
 		];
 	}
 

--- a/packages/core/src/ssrf/__tests__/in-memory-dns-cache.service.test.ts
+++ b/packages/core/src/ssrf/__tests__/in-memory-dns-cache.service.test.ts
@@ -123,4 +123,67 @@ describe('InMemoryDnsCache', () => {
 			expect(await cache.get('other.com')).toBeUndefined();
 		});
 	});
+
+	describe('size', () => {
+		it('should return 0 before the cache is initialised', () => {
+			const cache = new InMemoryDnsCache(createConfig());
+
+			expect(cache.size).toBe(0);
+		});
+
+		it('should reflect the number of entries after sets', async () => {
+			const cache = new InMemoryDnsCache(createConfig());
+
+			await cache.set('a.example.com', [addr('1.1.1.1')], 300);
+			await cache.set('b.example.com', [addr('2.2.2.2')], 300);
+
+			expect(cache.size).toBe(2);
+		});
+	});
+
+	describe('events', () => {
+		it('should emit hit when get returns a cached entry', async () => {
+			const cache = new InMemoryDnsCache(createConfig());
+			const hitSpy = vi.fn();
+			cache.events.on('hit', hitSpy);
+
+			await cache.set('example.com', [addr('1.1.1.1')], 300);
+			await cache.get('example.com');
+
+			expect(hitSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('should emit miss when get returns undefined', async () => {
+			const cache = new InMemoryDnsCache(createConfig());
+			const missSpy = vi.fn();
+			cache.events.on('miss', missSpy);
+
+			await cache.get('unknown.example.com');
+
+			expect(missSpy).toHaveBeenCalledTimes(1);
+		});
+
+		it('should emit eviction with post-eviction size when an entry is evicted due to LRU capacity pressure', async () => {
+			// Each entry (~37 bytes) — maxSize=40 fits only one entry
+			const cache = new InMemoryDnsCache(createConfig({ dnsCacheMaxSize: 40 }));
+			const evictionSpy = vi.fn();
+			cache.events.on('eviction', evictionSpy);
+
+			await cache.set('first.example.com', [addr('1.1.1.1')], 300);
+			await cache.set('second.example.com', [addr('2.2.2.2')], 300);
+
+			expect(evictionSpy).toHaveBeenCalledTimes(1);
+			expect(evictionSpy).toHaveBeenCalledWith({ size: 1 });
+		});
+
+		it('should not emit eviction when no entry is evicted', async () => {
+			const cache = new InMemoryDnsCache(createConfig());
+			const evictionSpy = vi.fn();
+			cache.events.on('eviction', evictionSpy);
+
+			await cache.set('example.com', [addr('1.1.1.1')], 300);
+
+			expect(evictionSpy).not.toHaveBeenCalled();
+		});
+	});
 });

--- a/packages/core/src/ssrf/in-memory-dns-cache.service.ts
+++ b/packages/core/src/ssrf/in-memory-dns-cache.service.ts
@@ -1,3 +1,4 @@
+import { TypedEmitter } from '@n8n/backend-common';
 import { SsrfProtectionConfig } from '@n8n/config';
 import { Time } from '@n8n/constants';
 import { Service } from '@n8n/di';
@@ -5,7 +6,13 @@ import type { MemoryCache } from 'cache-manager';
 import { caching } from 'cache-manager';
 import { jsonStringify } from 'n8n-workflow';
 import assert from 'node:assert';
-import { LookupAddress } from 'node:dns';
+import type { LookupAddress } from 'node:dns';
+
+export type DnsCacheEventMap = {
+	hit: undefined;
+	miss: undefined;
+	eviction: { size: number };
+};
 
 /**
  * In-memory DNS cache backed by LRU eviction and per-entry TTL.
@@ -13,6 +20,8 @@ import { LookupAddress } from 'node:dns';
 @Service()
 export class InMemoryDnsCache {
 	private cache: MemoryCache | undefined;
+
+	readonly events = new TypedEmitter<DnsCacheEventMap>();
 
 	constructor(private readonly ssrfConfig: SsrfProtectionConfig) {}
 
@@ -28,15 +37,28 @@ export class InMemoryDnsCache {
 				sizeCalculation,
 				ttl: 0,
 				ttlResolution: 0,
+				dispose: (_value, _key, reason) => {
+					if (reason === 'evict') {
+						// dispose fires before the entry is removed from the size counter,
+						// so subtract 1 to report the post-eviction size.
+						this.events.emit('eviction', { size: Math.max(this.size - 1, 0) });
+					}
+				},
 			});
 		}
 
 		return this.cache;
 	}
 
+	get size(): number {
+		return this.cache?.store?.size ?? 0;
+	}
+
 	async get(hostname: string): Promise<LookupAddress[] | undefined> {
 		const cache = await this.ensureCache();
-		return await cache.get<LookupAddress[]>(hostname);
+		const result = await cache.get<LookupAddress[]>(hostname);
+		this.events.emit(result !== undefined ? 'hit' : 'miss');
+		return result;
 	}
 
 	/**

--- a/packages/core/src/ssrf/index.ts
+++ b/packages/core/src/ssrf/index.ts
@@ -1,5 +1,7 @@
 export { DnsResolver } from './dns-resolver';
 export type { DnsLookupOptions } from './dns-resolver';
+export { InMemoryDnsCache } from './in-memory-dns-cache.service';
+export type { DnsCacheEventMap } from './in-memory-dns-cache.service';
 export { SsrfBlockedIpError } from './ssrf-blocked-ip.error';
 export { SsrfProtectionService } from './ssrf-protection.service';
 export type { SsrfBridge, SsrfCheckResult, SsrfEventMap } from './ssrf-protection.service';


### PR DESCRIPTION
## Summary

Adds Prometheus metrics for the in-memory DNS cache used by SSRF protection.
Similar to https://github.com/n8n-io/n8n/pull/32004

**New metrics** (all prefixed with `N8N_METRICS_PREFIX`, default `n8n_`):

| Metric | Type | Description |
|--------|------|-------------|
| `n8n_ssrf_dns_cache_hits_total` | Counter | DNS cache hits |
| `n8n_ssrf_dns_cache_misses_total` | Counter | DNS cache misses |
| `n8n_ssrf_dns_cache_evictions_total` | Counter | LRU evictions due to capacity pressure |
| `n8n_ssrf_dns_cache_size` | Gauge | Current number of entries in the cache |

Cache hit rate can be derived as `hits / (hits + misses)`.

**Configuration**: Opt-in via `N8N_METRICS_INCLUDE_DNS_CACHE_METRICS=true`

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2392

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.