### PR TITLE
fix(core): Remove `(latest)` tags from models in agent models catalog (no-changelog)

### DIFF
--- a/packages/@n8n/agents/src/sdk/__tests__/catalog.test.ts
+++ b/packages/@n8n/agents/src/sdk/__tests__/catalog.test.ts
@@ -70,4 +70,58 @@ describe('fetchProviderCatalog', () => {
 		expect(catalog.azure).toBeUndefined();
 		expect(catalog['azure-cognitive-services']).toBeUndefined();
 	});
+
+	it('strips the "(latest)" suffix from model names and drops duplicate pinned snapshots', async () => {
+		const fetchMock = vi.fn().mockResolvedValue({
+			ok: true,
+			json: async () =>
+				await Promise.resolve({
+					anthropic: {
+						id: 'anthropic',
+						name: 'Anthropic',
+						models: {
+							'claude-opus-4-5': {
+								id: 'claude-opus-4-5',
+								name: 'Claude Opus 4.5 (latest)',
+							},
+							'claude-opus-4-5-20251101': {
+								id: 'claude-opus-4-5-20251101',
+								name: 'Claude Opus 4.5',
+							},
+							'claude-opus-4-8': {
+								id: 'claude-opus-4-8',
+								name: 'Claude Opus 4.8',
+							},
+							'claude-3-5-haiku-latest': {
+								id: 'claude-3-5-haiku-latest',
+								name: 'Claude Haiku 3.5 (latest)',
+							},
+						},
+					},
+					google: {
+						id: 'google',
+						name: 'Google',
+						models: {
+							'gemini-flash-latest': {
+								id: 'gemini-flash-latest',
+								name: 'Gemini Flash Latest',
+							},
+						},
+					},
+				}),
+		});
+		global.fetch = fetchMock as typeof fetch;
+
+		const catalog = await fetchProviderCatalog();
+
+		// Alias keeps its id but loses the "(latest)" tag
+		expect(catalog.anthropic.models['claude-opus-4-5'].name).toBe('Claude Opus 4.5');
+		expect(catalog.anthropic.models['claude-3-5-haiku-latest'].name).toBe('Claude Haiku 3.5');
+		// Pinned snapshot with the same name as an alias is dropped
+		expect(catalog.anthropic.models['claude-opus-4-5-20251101']).toBeUndefined();
+		// Models without a same-named alias are untouched
+		expect(catalog.anthropic.models['claude-opus-4-8'].name).toBe('Claude Opus 4.8');
+		// Only the parenthesized suffix is stripped, not other "latest" naming
+		expect(catalog.google.models['gemini-flash-latest'].name).toBe('Gemini Flash Latest');
+	});
 });

--- a/packages/@n8n/agents/src/sdk/catalog.ts
+++ b/packages/@n8n/agents/src/sdk/catalog.ts
@@ -82,6 +82,33 @@ function toAgentProviderId(modelsDevProviderId: string): string {
 	return MODELS_DEV_PROVIDER_ALIASES[modelsDevProviderId] ?? modelsDevProviderId;
 }
 
+const LATEST_NAME_SUFFIX = /\s*\(latest\)$/i;
+
+/**
+ * models.dev names versionless alias models with a " (latest)" suffix
+ * (e.g. `claude-opus-4-5` → "Claude Opus 4.5 (latest)"), which quickly goes
+ * stale as newer models ship. Strip the suffix from every model name, and when
+ * a pinned snapshot shares the resulting name with an alias (e.g.
+ * `claude-opus-4-5-20251101` "Claude Opus 4.5"), drop the snapshot so the
+ * alias is the single entry for that model.
+ */
+function normalizeLatestModelNames(models: Record<string, ModelInfo>): void {
+	const aliasNames = new Set<string>();
+	for (const model of Object.values(models)) {
+		if (LATEST_NAME_SUFFIX.test(model.name)) {
+			aliasNames.add(model.name.replace(LATEST_NAME_SUFFIX, ''));
+		}
+	}
+
+	for (const [modelId, model] of Object.entries(models)) {
+		if (LATEST_NAME_SUFFIX.test(model.name)) {
+			model.name = model.name.replace(LATEST_NAME_SUFFIX, '');
+		} else if (aliasNames.has(model.name)) {
+			delete models[modelId];
+		}
+	}
+}
+
 /**
  * Fetch the provider/model catalog from models.dev.
  *
@@ -144,6 +171,10 @@ export async function fetchProviderCatalog(): Promise<ProviderCatalog> {
 				...models,
 			},
 		};
+	}
+
+	for (const provider of Object.values(catalog)) {
+		normalizeLatestModelNames(provider.models);
 	}
 
 	return catalog;


### PR DESCRIPTION
## Summary 

We previously listed multiple versions of models, e.g. if there is an older version of Opus 4.6 we would list it twice with one marked as latest. This was confusing as you would expect this to mean its the latest model available.

Removed this tag and older models as they shouldn't be used (generally will be phased out).

<img width="816" height="1430" alt="image" src="https://github.com/user-attachments/assets/d3209ddd-7d0b-43f3-917b-20b671c8bd6f" />

## Related Linear tickets, Github issues, and Community forum posts

Addresses: https://linear.app/n8n/issue/AGENT-229/bug-incorrect-latest-label-in-model-selector

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
