### PR TITLE
ci: Remove SafeChain skip from node setup

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -104,7 +104,6 @@ runs:
         key: safe-chain-1.5.7-${{ runner.os }}-${{ runner.arch }}
 
     - name: Install Aikido SafeChain
-      if: steps.cache-safe-chain.outputs.cache-hit != 'true'
       run: |
         VERSION="1.5.7"
         EXPECTED_SHA256="07ab512fd8795ce41b2275be369aced4c9a93cc7bca9b397951507891a955239"


### PR DESCRIPTION
## Summary

https://github.com/n8n-io/n8n/pull/31890 introduced a regression in safechain setup, causing breakage in CI jobs hitting the cache.

### Analysis summary from claude

#### Why it's broken 

The "Install Aikido SafeChain" step does 2 distinct things:

1. Download the binary into ~/.safechain/bin
2. Activate it by running the binary's setup-ci subcommand which sets up the shims in the PATH instead of shell aliases

#### Link to flakes

Before #31890, every job ran setup-ci, so SafeChain activation was uniform. After it, activation depends on cache hit/miss, which depends on timing, the fanout's first-wave cache race, and 7-day cache eviction. Behavior is now  non-deterministic across jobs and runs — some jobs install with the SafeChain shims active, some without — which is the classic signature of "more flakes." It  also conflates cache-hit == true with "fully set up," so a job that cached only a binary (e.g. a prior run interrupted mid-setup-ci) looks healthy but is mis-wired, and the skipped install never repairs it.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
