### PR TITLE
ci: Always bump cli and always create patch on dispatch

### DIFF
--- a/.github/scripts/bump-versions.mjs
+++ b/.github/scripts/bump-versions.mjs
@@ -260,6 +260,8 @@ async function bumpVersions() {
 
 	propagateDirtyTransitively(packageMap, depsByPackage);
 
+	// Always mark the `cli` package as dirty, so it's version always gets incremented
+	packageMap["n8n"].isDirty = true;
 	// Keep the monorepo version up to date with the released version
 	packageMap['monorepo-root'].version = packageMap['n8n'].version;
 

--- a/.github/workflows/release-create-patch-pr.yml
+++ b/.github/workflows/release-create-patch-pr.yml
@@ -46,7 +46,7 @@ jobs:
   skip-release-pr:
     name: Skip release PR (no new commits)
     needs: [determine-version-info]
-    if: needs.determine-version-info.outputs.should_update != 'true'
+    if: needs.determine-version-info.outputs.should_update != 'true' && github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - name: Log skip reason
@@ -55,7 +55,7 @@ jobs:
   create-release-pr:
     name: Create release PR
     needs: [determine-version-info]
-    if: needs.determine-version-info.outputs.should_update == 'true'
+    if: needs.determine-version-info.outputs.should_update == 'true' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/release-create-pr.yml
     secrets: inherit
     with:


### PR DESCRIPTION
## Summary

Since the `cli` package is the one we upload to npm as `n8n`, a patch release needs to always bump it. The only situation where this doesn't happen is when we release only chore/ci style changes. This was causing manual work every time we needed to patch up our release pipeline / ci and trigger a new release.

This change always makes sure the version gets incremented on the `cli` package, as well as allows us to trigger patch releases, even if there are not "actionable" changes in the patch pipeline (commits without `ci:`) prefix.

## How to test


## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
