### PR TITLE
fix(core): add execution_status tag to continueErrorOutput items

### DIFF
--- a/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute.test.ts
@@ -1622,7 +1622,7 @@ describe('WorkflowExecute', () => {
 						pairedItem: { item: 0, input: 0 },
 					},
 					{
-						json: { regularData: 'success' },
+						json: { regularData: 'success', execution_status: 'success' },
 						pairedItem: { item: 1, input: 0 },
 					},
 				],
@@ -1632,10 +1632,13 @@ describe('WorkflowExecute', () => {
 
 			expect(nodeSuccessData[0]).toEqual([
 				{
-					json: { additionalData: 'preserved', error: 'Test error' },
+					json: { additionalData: 'preserved', error: 'Test error', execution_status: 'success' },
 					pairedItem: { item: 0, input: 0 },
 				},
-				{ json: { regularData: 'success' }, pairedItem: { item: 1, input: 0 } },
+				{
+					json: { regularData: 'success', execution_status: 'success' },
+					pairedItem: { item: 1, input: 0 },
+				},
 			]);
 			expect(nodeSuccessData[1]).toEqual([]);
 		});
@@ -1662,6 +1665,7 @@ describe('WorkflowExecute', () => {
 						error: 'Error occurred',
 						message: 'Error details',
 						someData: 'test',
+						execution_status: 'error',
 					},
 					pairedItem: { item: 0, input: 0 },
 				},
@@ -1686,7 +1690,7 @@ describe('WorkflowExecute', () => {
 			expect(nodeSuccessData[0]).toEqual([]);
 			expect(nodeSuccessData[1]).toEqual([
 				{
-					json: { someData: 'test', error: 'Test error' },
+					json: { someData: 'test', error: 'Test error', execution_status: 'error' },
 					pairedItem: [
 						{ item: 0, input: 0 },
 						{ item: 1, input: 1 },
@@ -1699,11 +1703,11 @@ describe('WorkflowExecute', () => {
 			const nodeSuccessData: INodeExecutionData[][] = [
 				[
 					{
-						json: { error: 'Error 1', data: 'preserved1' },
+						json: { error: 'Error 1', data: 'preserved1', execution_status: 'success' },
 						pairedItem: { item: 0, input: 0 },
 					},
 					{
-						json: { error: 'Error 2', data: 'preserved2' },
+						json: { error: 'Error 2', data: 'preserved2', execution_status: 'success' },
 						pairedItem: { item: 1, input: 0 },
 					},
 				],
@@ -1714,11 +1718,11 @@ describe('WorkflowExecute', () => {
 			expect(nodeSuccessData[1]).toEqual([]);
 			expect(nodeSuccessData[0]).toEqual([
 				{
-					json: { error: 'Error 1', data: 'preserved1' },
+					json: { error: 'Error 1', data: 'preserved1', execution_status: 'success' },
 					pairedItem: { item: 0, input: 0 },
 				},
 				{
-					json: { error: 'Error 2', data: 'preserved2' },
+					json: { error: 'Error 2', data: 'preserved2', execution_status: 'success' },
 					pairedItem: { item: 1, input: 0 },
 				},
 			]);
@@ -1742,7 +1746,7 @@ describe('WorkflowExecute', () => {
 			expect(nodeSuccessData[0]).toEqual([]);
 			expect(nodeSuccessData[1]).toEqual([
 				{
-					json: { someData: 'test', error: 'Test error' },
+					json: { someData: 'test', error: 'Test error', execution_status: 'error' },
 					pairedItem: [
 						{ item: 0, input: 0 },
 						{ item: 1, input: 1 },
@@ -1760,8 +1764,100 @@ describe('WorkflowExecute', () => {
 
 			expect(nodeSuccessData[0]).toEqual([]);
 			expect(nodeSuccessData[1]).toEqual([
-				{ json: {}, error: { message: 'Test error' } as NodeApiError },
+				{ json: { execution_status: 'error' }, error: { message: 'Test error' } as NodeApiError },
 			]);
+		});
+
+		test('should not overwrite existing execution_status field', () => {
+			const nodeSuccessData: INodeExecutionData[][] = [
+				[
+					{
+						json: { execution_status: 'custom_value', regularData: 'test' },
+						pairedItem: { item: 0, input: 0 },
+					},
+				],
+			];
+
+			workflowExecute.handleNodeErrorOutput(workflow, executionData, nodeSuccessData, 0);
+			expect(nodeSuccessData[0][0].json.execution_status).toBe('custom_value');
+		});
+
+		test('should not overwrite execution_status from paired item data', () => {
+			const nodeSuccessData: INodeExecutionData[][] = [
+				[
+					{
+						json: { error: 'Test error' },
+						pairedItem: { item: 0, input: 0 },
+					},
+				],
+			];
+
+			const customRunExecutionData = createRunExecutionData({
+				resultData: {
+					runData: {
+						previousNode: [
+							{
+								data: {
+									main: [[{ json: { execution_status: 'custom_value' } }]],
+								},
+								source: [],
+								startTime: 0,
+								executionIndex: 0,
+								executionTime: 0,
+							},
+						],
+					},
+				},
+			});
+
+			const customWorkflowExecute = new WorkflowExecute(
+				mock<IWorkflowExecuteAdditionalData>({
+					webhookWaitingBaseUrl: 'http://localhost:5678/webhook-waiting',
+					formWaitingBaseUrl: 'http://localhost:5678/form-waiting',
+				}),
+				'manual',
+				customRunExecutionData,
+			);
+
+			customWorkflowExecute.handleNodeErrorOutput(workflow, executionData, nodeSuccessData, 0);
+
+			expect(nodeSuccessData[1][0].json.execution_status).toBe('custom_value');
+		});
+
+		test('should tag execution_status as "error" on error items', () => {
+			const nodeSuccessData: INodeExecutionData[][] = [
+				[
+					{
+						json: { error: 'Test error' },
+						pairedItem: { item: 0, input: 0 },
+					},
+					{
+						json: { regularData: 'success' },
+						pairedItem: { item: 1, input: 0 },
+					},
+				],
+			];
+
+			workflowExecute.handleNodeErrorOutput(workflow, executionData, nodeSuccessData, 0);
+
+			expect(nodeSuccessData[0][0].json.execution_status).toBe('success');
+			expect(nodeSuccessData[1][0].json.execution_status).toBe('error');
+		});
+
+		test('should tag execution_status as "success" when no error items exist', () => {
+			const nodeSuccessData: INodeExecutionData[][] = [
+				[
+					{
+						json: { regularData: 'all good' },
+						pairedItem: { item: 0, input: 0 },
+					},
+				],
+			];
+
+			workflowExecute.handleNodeErrorOutput(workflow, executionData, nodeSuccessData, 0);
+
+			expect(nodeSuccessData[0][0].json.execution_status).toBe('success');
+			expect(nodeSuccessData[1]).toHaveLength(0);
 		});
 	});
 

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -2697,7 +2697,14 @@ export class WorkflowExecute {
 
 					if (executionData.source === null || pairedItemData === undefined) {
 						// Source data is missing for some reason so we can not figure out the item
-						errorItems.push(item);
+						errorItems.push({
+							...item,
+							// json: {
+							// 	...item.json,
+							// 	...(!('execution_status' in item.json) && { execution_status: 'error' }),
+							// },
+							json: this.addExecutionStatus(item.json, 'error'),
+						});
 					} else {
 						const pairedItemInputIndex = pairedItemData.input || 0;
 
@@ -2710,19 +2717,28 @@ export class WorkflowExecute {
 						);
 
 						if (constPairedItem === null) {
-							errorItems.push(item);
+							errorItems.push({
+								...item,
+								json: this.addExecutionStatus(item.json, 'error'),
+							});
 						} else {
+							const pairedJson = constPairedItem.json ?? {};
 							errorItems.push({
 								...item,
 								json: {
-									...constPairedItem.json,
+									...pairedJson,
 									...item.json,
+									...(!('execution_status' in item.json) &&
+										!('execution_status' in pairedJson) && { execution_status: 'error' }),
 								},
 							});
 						}
 					}
 				} else {
-					successItems.push(item);
+					successItems.push({
+						...item,
+						json: this.addExecutionStatus(item.json, 'success'),
+					});
 				}
 			}
 
@@ -2820,6 +2836,15 @@ export class WorkflowExecute {
 				}
 			});
 		});
+	}
+
+	private addExecutionStatus(json: IDataObject, status: 'success' | 'error'): IDataObject {
+		return {
+			...json,
+			...(!('execution_status' in json) && {
+				execution_status: status,
+			}),
+		};
 	}
 
 	private get isCancelled() {

--- a/packages/core/test/helpers/constants.ts
+++ b/packages/core/test/helpers/constants.ts
@@ -5071,12 +5071,14 @@ export const v1WorkflowExecuteTests: WorkflowTestData[] = [
 							{
 								name: 'foo',
 								value: 'bar',
+								execution_status: 'success',
 							},
 						],
 						[
 							{
 								name: 'bar',
 								value: 'baz',
+								execution_status: 'success',
 							},
 						],
 						[],


### PR DESCRIPTION
## Summary

When a node uses `continueErrorOutput`, items are routed to success or error output pins by `handleNodeErrorOutput`. However, nothing in the item data indicated which branch was taken. Downstream nodes (e.g. Switch) had no way to distinguish execution path.

Fixes #29334

## Changes

- Inject `execution_status: 'success' | 'error'` onto `item.json` inside `handleNodeErrorOutput` at all push sites
- Guard against overwriting existing user-controlled `execution_status` fields using `in` checks on both `item.json` and `constPairedItem.json`
- Extract tagging logic into private `addExecutionStatus` helper method
- Update existing test assertions to reflect new output shape
- Add new tests covering success tagging, error tagging, and preservation of existing `execution_status` values

## How to test

1. Create a workflow: Manual Trigger → HTTP Request (continueErrorOutput) → No Op (pin 0) + No Op (pin 1)
2. Set HTTP URL to `https://httpbin.org/status/500`
3. Run → check error pin output → confirm `execution_status: "error"` is present
4. Set HTTP URL to `https://httpbin.org/status/200`
5. Run → check success pin output → confirm `execution_status: "success"` is present

## Related issues

#29334