### PR TITLE
feat: Allow oauth token based auth for computer-use

### DIFF
--- a/packages/@n8n/computer-use/src/gateway-client.test.ts
+++ b/packages/@n8n/computer-use/src/gateway-client.test.ts
@@ -320,3 +320,100 @@ describe('GatewayClient.uploadCapabilities', () => {
 		await expect(promise).rejects.toThrow(/Failed to upload capabilities: 500/);
 	});
 });
+
+describe('GatewayClient auth headers', () => {
+	const originalFetch = global.fetch;
+
+	beforeEach(() => {
+		global.fetch = vi.fn();
+	});
+
+	afterEach(() => {
+		global.fetch = originalFetch;
+	});
+
+	function prime(client: GatewayClient): GatewayClient {
+		// Bypass tool discovery — uploadCapabilities only needs definitions to exist.
+		// @ts-expect-error — accessing private field for testing
+		client.allDefinitions = [];
+		// @ts-expect-error — accessing private field for testing
+		client.activeToolCategories = [];
+		return client;
+	}
+
+	function mockInitResponse(data: { ok: boolean; sessionKey?: string } = { ok: true }): void {
+		(global.fetch as Mock).mockResolvedValueOnce({
+			ok: true,
+			status: 200,
+			text: vi.fn().mockResolvedValue(''),
+			json: vi.fn().mockResolvedValue({ data }),
+		});
+	}
+
+	function lastRequestHeaders(): Headers {
+		const calls = (global.fetch as Mock).mock.calls;
+		const lastCall = calls[calls.length - 1] as [string, { headers: Headers }];
+		return lastCall[1].headers;
+	}
+
+	it('legacy mode sends the X-Gateway-Key header', async () => {
+		mockInitResponse();
+		const client = prime(
+			new GatewayClient({
+				url: 'http://localhost:5678',
+				apiKey: 'legacy-key',
+				config: makeConfig(),
+				session: makeSession(),
+				confirmResourceAccess: vi.fn(),
+			}),
+		);
+
+		await client['uploadCapabilities']();
+
+		const headers = lastRequestHeaders();
+		expect(headers.get('X-Gateway-Key')).toBe('legacy-key');
+		expect(headers.get('Authorization')).toBeNull();
+	});
+
+	it('OAuth mode sends Authorization: Bearer and no X-Gateway-Key', async () => {
+		mockInitResponse();
+		const client = prime(
+			new GatewayClient({
+				url: 'http://localhost:5678',
+				getAuthToken: async () => await Promise.resolve('access-tok'),
+				config: makeConfig(),
+				session: makeSession(),
+				confirmResourceAccess: vi.fn(),
+			}),
+		);
+
+		await client['uploadCapabilities']();
+
+		const headers = lastRequestHeaders();
+		expect(headers.get('Authorization')).toBe('Bearer access-tok');
+		expect(headers.get('X-Gateway-Key')).toBeNull();
+	});
+
+	it('OAuth mode ignores a server-issued session key and uses a fresh token per request', async () => {
+		// Server tries to hand back a session key — OAuth mode must not adopt it.
+		mockInitResponse({ ok: true, sessionKey: 'sess-should-be-ignored' });
+		let calls = 0;
+		const client = prime(
+			new GatewayClient({
+				url: 'http://localhost:5678',
+				getAuthToken: async () => await Promise.resolve(`tok-${++calls}`),
+				config: makeConfig(),
+				session: makeSession(),
+				confirmResourceAccess: vi.fn(),
+			}),
+		);
+
+		await client['uploadCapabilities'](); // tok-1
+		mockInitResponse();
+		await client['postResponse']('req-1', { content: [] }); // tok-2
+
+		const headers = lastRequestHeaders();
+		expect(headers.get('Authorization')).toBe('Bearer tok-2');
+		expect(headers.get('X-Gateway-Key')).toBeNull();
+	});
+});

--- a/packages/@n8n/computer-use/src/gateway-client.ts
+++ b/packages/@n8n/computer-use/src/gateway-client.ts
@@ -52,9 +52,8 @@ function tagCategory(defs: ToolDefinition[], category: string): ToolDefinition[]
 	return defs;
 }
 
-export interface GatewayClientOptions {
+export type GatewayClientOptions = {
 	url: string;
-	apiKey: string;
 	/** Non-permission config (browser, shell, logLevel, etc.) */
 	config: GatewayConfig;
 	/** Permissions + dir + session rules for this connection. */
@@ -64,7 +63,20 @@ export interface GatewayClientOptions {
 	onPersistentFailure?: () => void;
 	/** Called after disconnect() has finished tearing down the client. */
 	onDisconnected?: () => void;
-}
+} & (
+	| {
+			// Legacy gateway pairing/session key, sent as `X-Gateway-Key`. Used by the standalone CLI.
+			apiKey: string;
+			// Token for OAuth mode
+			getAuthToken?: never;
+	  }
+	| {
+			// Legacy gateway pairing/session key, sent as `X-Gateway-Key`. Used by the standalone CLI.
+			apiKey?: never;
+			// Token for OAuth mode
+			getAuthToken: () => Promise<string>;
+	  }
+);
 
 interface FilesystemRequestEvent {
 	type: 'filesystem-request';
@@ -115,7 +127,19 @@ export class GatewayClient {
 
 	/** Session key when the server has upgraded the pairing token; otherwise the original token. */
 	private get apiKey(): string {
-		return this.sessionKey ?? this.options.apiKey;
+		return this.sessionKey ?? this.options.apiKey ?? '';
+	}
+
+	/**
+	 * Set the auth header for a gateway request. OAuth mode (`getAuthToken`) sends a fresh
+	 * `Authorization: Bearer` token; legacy mode sends the `X-Gateway-Key` pairing/session key.
+	 */
+	private async applyAuthHeaders(headers: Headers): Promise<void> {
+		if (this.options.getAuthToken) {
+			headers.set('Authorization', `Bearer ${await this.options.getAuthToken()}`);
+		} else {
+			headers.set('X-Gateway-Key', this.apiKey);
+		}
 	}
 
 	private get dir(): string {
@@ -160,7 +184,7 @@ export class GatewayClient {
 				const url = `${this.options.url}/rest/instance-ai/gateway/disconnect`;
 				const headers = new Headers();
 				headers.set('Content-Type', 'application/json');
-				headers.set('X-Gateway-Key', this.apiKey);
+				await this.applyAuthHeaders(headers);
 				const response = await fetch(url, {
 					method: 'POST',
 					headers,
@@ -299,7 +323,7 @@ export class GatewayClient {
 		const url = `${this.options.url}/rest/instance-ai/gateway/init`;
 		const headers = new Headers();
 		headers.set('Content-Type', 'application/json');
-		headers.set('X-Gateway-Key', this.apiKey);
+		await this.applyAuthHeaders(headers);
 		const response = await fetch(url, {
 			method: 'POST',
 			headers,
@@ -319,10 +343,11 @@ export class GatewayClient {
 			throw new Error(`Failed to upload capabilities: ${response.status} ${text}`);
 		}
 
-		// If the server returned a session key, switch to it for all subsequent requests
+		// Legacy mode only: if the server returned a session key, switch to it for all subsequent
+		// requests. In OAuth mode the access token (via getAuthToken) is the credential.
 		// n8n wraps controller responses in { data: ... }
 		const body = (await response.json()) as { data: { ok: boolean; sessionKey?: string } };
-		if (body.data.sessionKey) {
+		if (!this.options.getAuthToken && body.data.sessionKey) {
 			this.sessionKey = body.data.sessionKey;
 			logger.debug('Pairing token consumed, switched to session key');
 		}
@@ -333,12 +358,11 @@ export class GatewayClient {
 	private connectSSE(): void {
 		const url = `${this.options.url}/rest/instance-ai/gateway/events`;
 
-		logger.debug('Connecting to gateway', { keyPrefix: this.apiKey.slice(0, 8) });
-		const apiKey = this.apiKey;
+		logger.debug('Connecting to gateway');
 		this.eventSource = new EventSource(url, {
 			fetch: async (input, init) => {
 				const headers = new Headers(init?.headers);
-				headers.set('X-Gateway-Key', apiKey);
+				await this.applyAuthHeaders(headers);
 				return await fetch(input, { ...init, headers });
 			},
 		});
@@ -456,7 +480,6 @@ export class GatewayClient {
 		const typedArgs: unknown = def.inputSchema.parse(cleanArgs);
 		const session = this.options.session;
 		const instanceUrl = this.options.url;
-		const gatewayKey = this.apiKey;
 		const context = {
 			dir: this.dir,
 			secretsBuffer: {
@@ -468,7 +491,7 @@ export class GatewayClient {
 				const url = `${instanceUrl}/rest/instance-ai/gateway/credentials`;
 				const headers = new Headers();
 				headers.set('Content-Type', 'application/json');
-				headers.set('X-Gateway-Key', gatewayKey);
+				await this.applyAuthHeaders(headers);
 				const res = await fetch(url, {
 					method: 'POST',
 					headers,
@@ -549,7 +572,7 @@ export class GatewayClient {
 		try {
 			const headers = new Headers();
 			headers.set('Content-Type', 'application/json');
-			headers.set('X-Gateway-Key', this.apiKey);
+			await this.applyAuthHeaders(headers);
 			const response = await fetch(url, {
 				method: 'POST',
 				headers,

--- a/packages/@n8n/local-gateway/src/main/daemon-controller.test.ts
+++ b/packages/@n8n/local-gateway/src/main/daemon-controller.test.ts
@@ -6,7 +6,7 @@ const mockSessionFlush = vi.fn();
 
 type GatewayClientOptions = {
 	url: string;
-	apiKey: string;
+	getAuthToken: () => Promise<string>;
 	onPersistentFailure?: () => void;
 	onDisconnected?: () => void;
 };
@@ -72,6 +72,9 @@ const BASE_CONFIG: GatewayConfig = {
 	permissionConfirmation: 'instance',
 };
 
+/** Stand-in for the OAuth token provider the app wires into `connect`. */
+const authToken = async () => await Promise.resolve('gw_token');
+
 /** Fire-and-forget `void closeCurrentConnection()` chains multiple async steps; flush past microtasks */
 async function settleNextTurn(): Promise<void> {
 	await new Promise<void>((resolve) => setImmediate(resolve));
@@ -108,7 +111,7 @@ describe('DaemonController', () => {
 
 	it('connects and updates snapshot state', async () => {
 		const controller = new DaemonController();
-		await controller.connect(BASE_CONFIG, 'https://example.n8n.cloud', 'gw_token');
+		await controller.connect(BASE_CONFIG, 'https://example.n8n.cloud', authToken);
 
 		const snapshot = controller.getSnapshot();
 		expect(snapshot.status).toBe('connected');
@@ -116,9 +119,18 @@ describe('DaemonController', () => {
 		expect(snapshot.lastError).toBeNull();
 	});
 
+	it('forwards the auth-token provider to the gateway client', async () => {
+		const controller = new DaemonController();
+		const getAuthToken = async () => await Promise.resolve('bearer-token');
+		await controller.connect(BASE_CONFIG, 'https://example.n8n.cloud', getAuthToken);
+
+		expect(gateway.lastOptions?.getAuthToken).toBe(getAuthToken);
+		await expect(gateway.lastOptions?.getAuthToken?.()).resolves.toBe('bearer-token');
+	});
+
 	it('normalizes trailing slash on URL', async () => {
 		const controller = new DaemonController();
-		await controller.connect(BASE_CONFIG, 'https://example.n8n.cloud/', 'gw_token');
+		await controller.connect(BASE_CONFIG, 'https://example.n8n.cloud/', authToken);
 		expect(controller.getSnapshot().connectedUrl).toBe('https://example.n8n.cloud');
 	});
 
@@ -127,7 +139,7 @@ describe('DaemonController', () => {
 		mockStart.mockRejectedValueOnce(new Error('connect failed'));
 
 		await expect(
-			controller.connect(BASE_CONFIG, 'https://example.n8n.cloud', 'gw_token'),
+			controller.connect(BASE_CONFIG, 'https://example.n8n.cloud', authToken),
 		).rejects.toThrow('connect failed');
 
 		const snapshot = controller.getSnapshot();
@@ -141,14 +153,14 @@ describe('DaemonController', () => {
 		mockStart.mockRejectedValueOnce('string failure');
 
 		await expect(
-			controller.connect(BASE_CONFIG, 'https://example.n8n.cloud', 'gw_token'),
+			controller.connect(BASE_CONFIG, 'https://example.n8n.cloud', authToken),
 		).rejects.toThrow('string failure');
 		expect(controller.getSnapshot().lastError).toBe('string failure');
 	});
 
 	it('disconnects and clears connected state', async () => {
 		const controller = new DaemonController();
-		await controller.connect(BASE_CONFIG, 'https://example.n8n.cloud', 'gw_token');
+		await controller.connect(BASE_CONFIG, 'https://example.n8n.cloud', authToken);
 		await controller.disconnect();
 
 		const snapshot = controller.getSnapshot();
@@ -160,15 +172,15 @@ describe('DaemonController', () => {
 
 	it('calls stop on previous client when connecting again', async () => {
 		const controller = new DaemonController();
-		await controller.connect(BASE_CONFIG, 'https://a.example', 't1');
-		await controller.connect(BASE_CONFIG, 'https://b.example', 't2');
+		await controller.connect(BASE_CONFIG, 'https://a.example', authToken);
+		await controller.connect(BASE_CONFIG, 'https://b.example', authToken);
 		expect(mockStop).toHaveBeenCalled();
 		expect(mockStart).toHaveBeenCalledTimes(2);
 	});
 
 	it('sets error state when gateway signals persistent auth failure', async () => {
 		const controller = new DaemonController();
-		await controller.connect(BASE_CONFIG, 'https://example.n8n.cloud', 'gw_token');
+		await controller.connect(BASE_CONFIG, 'https://example.n8n.cloud', authToken);
 		gateway.lastOptions?.onPersistentFailure?.();
 
 		await settleNextTurn();
@@ -182,7 +194,7 @@ describe('DaemonController', () => {
 
 	it('sets disconnected state when gateway signals disconnect', async () => {
 		const controller = new DaemonController();
-		await controller.connect(BASE_CONFIG, 'https://example.n8n.cloud', 'gw_token');
+		await controller.connect(BASE_CONFIG, 'https://example.n8n.cloud', authToken);
 		gateway.lastOptions?.onDisconnected?.();
 
 		await settleNextTurn();

--- a/packages/@n8n/local-gateway/src/main/daemon-controller.ts
+++ b/packages/@n8n/local-gateway/src/main/daemon-controller.ts
@@ -68,9 +68,13 @@ export class DaemonController extends EventEmitter<DaemonControllerEvents> {
 		}
 	}
 
-	async connect(config: GatewayConfig, url: string, apiKey: string): Promise<void> {
+	async connect(
+		config: GatewayConfig,
+		url: string,
+		getAuthToken: () => Promise<string>,
+	): Promise<void> {
 		const normalizedUrl = url.replace(/\/$/, '');
-		logger.debug('Direct gateway connect requested', { url: normalizedUrl });
+		logger.debug('Gateway connect requested', { url: normalizedUrl });
 
 		this.setStatus('connecting');
 		this._lastError = null;
@@ -81,7 +85,7 @@ export class DaemonController extends EventEmitter<DaemonControllerEvents> {
 		const session = new GatewaySession(defaults, store);
 		const client = new GatewayClient({
 			url: normalizedUrl,
-			apiKey,
+			getAuthToken,
 			config,
 			session,
 			confirmResourceAccess: () => 'denyOnce',

--- a/packages/@n8n/local-gateway/src/main/index.ts
+++ b/packages/@n8n/local-gateway/src/main/index.ts
@@ -11,6 +11,7 @@ import { TokenStore } from './oauth/token-store';
 import { SettingsStore } from './settings-store';
 import { createTray } from './tray';
 import { APP_URL_SCHEME } from '../shared/constants';
+import type { AuthStatus } from '../shared/types';
 
 // Windows: required for proper taskbar/notification grouping
 if (process.platform === 'win32') {
@@ -54,6 +55,32 @@ if (!app.requestSingleInstanceLock()) {
 				await controller.disconnect();
 			}
 
+			/**
+			 * Connect computer-use to the signed-in n8n instance. The token provider returns a valid
+			 * (refreshed) OAuth access token, which the gateway client sends as `Authorization: Bearer`.
+			 */
+			async function connectGateway(instanceUrl: string): Promise<void> {
+				const config = settingsStore.toGatewayConfig();
+				await controller.connect(config, instanceUrl, async () => {
+					const token = await oauthFlow.getValidAccessToken();
+					if (!token) throw new Error('Not signed in to n8n');
+					return token;
+				});
+			}
+
+			/** Bring the gateway connection in line with the current auth state. */
+			function syncGatewayConnection(status: AuthStatus): void {
+				if (status.state === 'signedIn' && status.instanceUrl) {
+					void connectGateway(status.instanceUrl).catch((error: unknown) => {
+						logger.error('Gateway connect failed', {
+							error: error instanceof Error ? error.message : String(error),
+						});
+					});
+				} else if (status.state === 'signedOut') {
+					void disconnectGateway().catch(() => {});
+				}
+			}
+
 			registerIpcHandlers(controller, settingsStore, disconnectGateway, oauthFlow);
 
 			controller.on('statusChanged', (snapshot) => {
@@ -62,6 +89,8 @@ if (!app.requestSingleInstanceLock()) {
 
 			oauthFlow.on('authStatusChanged', (status) => {
 				notifyMainWindow('authStatusChanged', status);
+				// Connect computer-use on sign-in; tear it down on sign-out.
+				syncGatewayConnection(status);
 				// The window auto-hid on blur when the system browser opened — bring it back so the
 				// user sees the result (the signed-in view, or a sign-in error).
 				if (status.state === 'signedIn' || status.state === 'error') {
@@ -102,6 +131,9 @@ if (!app.requestSingleInstanceLock()) {
 
 			// Cold start: handle an OAuth redirect passed in argv (Windows/Linux deep link).
 			handleOAuthDeepLinkFromArgv(process.argv);
+
+			// Persisted session: reconnect the gateway on launch if already signed in.
+			syncGatewayConnection(oauthFlow.getStatus());
 
 			// The window opens only from the tray — nothing to auto-open on launch.
 

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.controller.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.controller.test.ts
@@ -24,6 +24,10 @@ jest.mock('../eval/execution.service', () => ({
 	EvalExecutionService: jest.fn(),
 }));
 
+// Lazily imported by the gateway OAuth path; stub so the dynamic import resolves to a class
+// the Container.get spy can match.
+jest.mock('@/modules/mcp/mcp-oauth-token.service', () => ({ McpOAuthTokenService: class {} }));
+
 import type {
 	InstanceAiAdminSettingsUpdateRequest,
 	InstanceAiSendMessageRequest,
@@ -64,6 +68,7 @@ import type { InstanceAiMemoryService } from '../instance-ai-memory.service';
 import type { InstanceAiSettingsService } from '../instance-ai-settings.service';
 import { InstanceAiController } from '../instance-ai.controller';
 import type { InstanceAiService } from '../instance-ai.service';
+import { McpOAuthTokenService } from '@/modules/mcp/mcp-oauth-token.service';
 
 const USER_ID = 'user-1';
 const THREAD_ID = 'thread-1';
@@ -874,6 +879,14 @@ describe('InstanceAiController', () => {
 		const makeGatewayReq = (key: string | undefined, body: unknown) =>
 			({ headers: key ? { 'x-gateway-key': key } : {}, body }) as unknown as Request;
 
+		beforeEach(() => {
+			// init now enables computer-use for the user: admin-level gating must allow it, and the
+			// per-user flag is already enabled (so no preference write on the happy path).
+			settingsService.isAgentEnabled.mockReturnValue(true);
+			settingsService.isLocalGatewayDisabled.mockReturnValue(false);
+			settingsService.isLocalGatewayDisabledForUser.mockResolvedValue(false);
+		});
+
 		it('should have no access scope (skipAuth)', () => {
 			expect(scopeOf('gatewayInit')).toBeUndefined();
 		});
@@ -957,6 +970,84 @@ describe('InstanceAiController', () => {
 				}),
 			).rejects.toThrow(ForbiddenError);
 		});
+
+		it('enables computer-use for the user when their per-user flag is off', async () => {
+			const user = mock<User>({ id: USER_ID });
+			gatewayService.getUserIdForApiKey.mockReturnValue(USER_ID);
+			gatewayService.consumePairingToken.mockReturnValue(null);
+			settingsService.isLocalGatewayDisabledForUser.mockResolvedValue(true);
+			userRepository.findOne.mockResolvedValue(user);
+			const gatewayReq = makeGatewayReq('session-key', { rootPath: '/tmp' });
+
+			await controller.gatewayInit(gatewayReq, res, {
+				rootPath: '/tmp',
+				tools: [],
+				toolCategories: [],
+			});
+
+			expect(settingsService.updateUserPreferences).toHaveBeenCalledWith(user, {
+				localGatewayDisabled: false,
+			});
+			expect(gatewayService.initGateway).toHaveBeenCalledWith(USER_ID, expect.anything());
+		});
+
+		it('does not write user preferences when computer-use is already enabled', async () => {
+			gatewayService.getUserIdForApiKey.mockReturnValue(USER_ID);
+			gatewayService.consumePairingToken.mockReturnValue(null);
+			const gatewayReq = makeGatewayReq('session-key', { rootPath: '/tmp' });
+
+			await controller.gatewayInit(gatewayReq, res, {
+				rootPath: '/tmp',
+				tools: [],
+				toolCategories: [],
+			});
+
+			expect(settingsService.updateUserPreferences).not.toHaveBeenCalled();
+		});
+
+		it('does not write user preferences for the static env-var key', async () => {
+			gatewayService.consumePairingToken.mockReturnValue(null);
+			const gatewayReq = makeGatewayReq('static-key', { rootPath: '/tmp' });
+
+			await controller.gatewayInit(gatewayReq, res, {
+				rootPath: '/tmp',
+				tools: [],
+				toolCategories: [],
+			});
+
+			expect(settingsService.updateUserPreferences).not.toHaveBeenCalled();
+		});
+
+		it('rejects init when Instance AI is disabled instance-wide', async () => {
+			settingsService.isAgentEnabled.mockReturnValue(false);
+			gatewayService.getUserIdForApiKey.mockReturnValue(USER_ID);
+			const gatewayReq = makeGatewayReq('session-key', { rootPath: '/tmp' });
+
+			await expect(
+				controller.gatewayInit(gatewayReq, res, {
+					rootPath: '/tmp',
+					tools: [],
+					toolCategories: [],
+				}),
+			).rejects.toThrow(ForbiddenError);
+			expect(gatewayService.initGateway).not.toHaveBeenCalled();
+			expect(settingsService.updateUserPreferences).not.toHaveBeenCalled();
+		});
+
+		it('rejects init when the gateway is disabled instance-wide', async () => {
+			settingsService.isLocalGatewayDisabled.mockReturnValue(true);
+			gatewayService.getUserIdForApiKey.mockReturnValue(USER_ID);
+			const gatewayReq = makeGatewayReq('session-key', { rootPath: '/tmp' });
+
+			await expect(
+				controller.gatewayInit(gatewayReq, res, {
+					rootPath: '/tmp',
+					tools: [],
+					toolCategories: [],
+				}),
+			).rejects.toThrow(ForbiddenError);
+			expect(gatewayService.initGateway).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('gatewayEvents', () => {
@@ -1012,12 +1103,12 @@ describe('InstanceAiController', () => {
 			expect(scopeOf('gatewayResponse')).toBeUndefined();
 		});
 
-		it('should resolve gateway request', () => {
+		it('should resolve gateway request', async () => {
 			gatewayService.getUserIdForApiKey.mockReturnValue(USER_ID);
 			gatewayService.resolveGatewayRequest.mockReturnValue(true);
 			const gatewayReq = makeGatewayReq('session-key', { result: { content: [] } });
 
-			const result = controller.gatewayResponse(gatewayReq, res, 'req-1', {
+			const result = await controller.gatewayResponse(gatewayReq, res, 'req-1', {
 				result: { content: [] },
 			});
 
@@ -1030,14 +1121,14 @@ describe('InstanceAiController', () => {
 			);
 		});
 
-		it('should throw NotFoundError when request not found', () => {
+		it('should throw NotFoundError when request not found', async () => {
 			gatewayService.getUserIdForApiKey.mockReturnValue(USER_ID);
 			gatewayService.resolveGatewayRequest.mockReturnValue(false);
 			const gatewayReq = makeGatewayReq('session-key', { result: { content: [] } });
 
-			expect(() =>
+			await expect(
 				controller.gatewayResponse(gatewayReq, res, 'req-1', { result: { content: [] } }),
-			).toThrow(NotFoundError);
+			).rejects.toThrow(NotFoundError);
 		});
 	});
 
@@ -1046,13 +1137,13 @@ describe('InstanceAiController', () => {
 			expect(scopeOf('gatewayDisconnect')).toBeUndefined();
 		});
 
-		it('should disconnect gateway and send push notification', () => {
+		it('should disconnect gateway and send push notification', async () => {
 			gatewayService.getUserIdForApiKey.mockReturnValue(USER_ID);
 			const gatewayReq = {
 				headers: { 'x-gateway-key': 'session-key' },
 			} as unknown as Request;
 
-			const result = controller.gatewayDisconnect(gatewayReq);
+			const result = await controller.gatewayDisconnect(gatewayReq);
 
 			expect(result).toEqual({ ok: true });
 			expect(gatewayService.clearDisconnectTimer).toHaveBeenCalledWith(USER_ID);
@@ -1176,7 +1267,7 @@ describe('InstanceAiController', () => {
 	});
 
 	describe('getGatewayKeyHeader', () => {
-		it('should extract first element from array header', () => {
+		it('should extract first element from array header', async () => {
 			gatewayService.getUserIdForApiKey.mockReturnValue(USER_ID);
 			gatewayService.resolveGatewayRequest.mockReturnValue(true);
 			const gatewayReq = {
@@ -1184,10 +1275,68 @@ describe('InstanceAiController', () => {
 				body: { result: { content: [] } },
 			} as unknown as Request;
 
-			controller.gatewayResponse(gatewayReq, res, 'req-1', { result: { content: [] } });
+			await controller.gatewayResponse(gatewayReq, res, 'req-1', { result: { content: [] } });
 
 			// validateGatewayApiKey receives 'key1' (the first element)
 			expect(gatewayService.getUserIdForApiKey).toHaveBeenCalledWith('key1');
+		});
+	});
+
+	describe('resolveGatewayUserId (OAuth bearer)', () => {
+		const actualContainerGet = Container.get.bind(Container);
+		let containerGetSpy: jest.SpyInstance;
+		const tokenService = {
+			verifyOAuthAccessToken: jest.fn(),
+			getCanonicalResourceUrl: jest.fn().mockReturnValue('http://localhost:5678/mcp-server/http'),
+		};
+
+		beforeEach(() => {
+			containerGetSpy = jest
+				.spyOn(Container, 'get')
+				.mockImplementation((cls: unknown) =>
+					cls === McpOAuthTokenService ? tokenService : actualContainerGet(cls as never),
+				);
+		});
+
+		afterEach(() => {
+			containerGetSpy.mockRestore();
+		});
+
+		const bearerReq = (token: string) =>
+			({ headers: { authorization: `Bearer ${token}` } }) as unknown as Request;
+
+		it('resolves the user from a valid OAuth token with the gateway scope', async () => {
+			tokenService.verifyOAuthAccessToken.mockResolvedValue({
+				user: { id: 'oauth-user' },
+				scopes: ['instanceAi:gateway', 'instanceAi:message'],
+			});
+
+			await controller.gatewayDisconnect(bearerReq('oauth-access-token'));
+
+			expect(gatewayService.disconnectGateway).toHaveBeenCalledWith('oauth-user');
+			// OAuth tokens are self-contained — no X-Gateway-Key reverse lookup.
+			expect(gatewayService.getUserIdForApiKey).not.toHaveBeenCalled();
+		});
+
+		it('rejects an OAuth token lacking the instanceAi:gateway scope', async () => {
+			tokenService.verifyOAuthAccessToken.mockResolvedValue({
+				user: { id: 'oauth-user' },
+				scopes: ['instanceAi:message'],
+			});
+
+			await expect(controller.gatewayDisconnect(bearerReq('scoped-out-token'))).rejects.toThrow(
+				ForbiddenError,
+			);
+		});
+
+		it('falls back to the X-Gateway-Key path when there is no bearer token', async () => {
+			gatewayService.getUserIdForApiKey.mockReturnValue(USER_ID);
+			const gatewayReq = { headers: { 'x-gateway-key': 'session-key' } } as unknown as Request;
+
+			await controller.gatewayDisconnect(gatewayReq);
+
+			expect(tokenService.verifyOAuthAccessToken).not.toHaveBeenCalled();
+			expect(gatewayService.disconnectGateway).toHaveBeenCalledWith(USER_ID);
 		});
 	});
 });

--- a/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
@@ -19,6 +19,7 @@ import {
 import type { InstanceAiAgentNode } from '@n8n/api-types';
 import { ModuleRegistry } from '@n8n/backend-common';
 import { GlobalConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
 import { AuthenticatedRequest, User, UserRepository } from '@n8n/db';
 import {
 	RestController,
@@ -656,7 +657,7 @@ export class InstanceAiController {
 
 	@Get('/gateway/events', { usesTemplates: true, skipAuth: true })
 	async gatewayEvents(req: Request, res: FlushableResponse) {
-		const userId = this.validateGatewayApiKey(this.getGatewayKeyHeader(req));
+		const { userId } = await this.resolveGatewayUserId(req);
 		await this.assertGatewayEnabled(userId);
 
 		const gateway = this.gatewayService.getLocalGateway(userId);
@@ -721,9 +722,9 @@ export class InstanceAiController {
 
 	@Post('/gateway/init', { skipAuth: true })
 	async gatewayInit(req: Request, _res: Response, @Body payload: InstanceAiGatewayCapabilitiesDto) {
-		const key = this.getGatewayKeyHeader(req);
-		const userId = this.validateGatewayApiKey(key);
-		await this.assertGatewayEnabled(userId);
+		const { userId, viaOAuth } = await this.resolveGatewayUserId(req);
+		// Connecting from the app enables computer-use for the user — no manual toggle in the n8n UI.
+		await this.ensureGatewayEnabledForUser(userId);
 
 		this.gatewayService.initGateway(userId, payload);
 
@@ -745,17 +746,21 @@ export class InstanceAiController {
 			this.instanceAiService.ensureDeviceCredential(userId, payload.hostIdentifier ?? null),
 		).catch(() => {});
 
-		// Try to consume a pairing token and upgrade to a session key
-		const sessionKey = key ? this.gatewayService.consumePairingToken(userId, key) : null;
-		if (sessionKey) {
-			return { ok: true, sessionKey };
+		// Legacy pairing path only: consume the one-time pairing token and upgrade to a session key.
+		// OAuth clients authenticate with the access token itself, so there is no session key to issue.
+		if (!viaOAuth) {
+			const key = this.getGatewayKeyHeader(req);
+			const sessionKey = key ? this.gatewayService.consumePairingToken(userId, key) : null;
+			if (sessionKey) {
+				return { ok: true, sessionKey };
+			}
 		}
 		return { ok: true };
 	}
 
 	@Post('/gateway/disconnect', { skipAuth: true })
-	gatewayDisconnect(req: Request) {
-		const userId = this.validateGatewayApiKey(this.getGatewayKeyHeader(req));
+	async gatewayDisconnect(req: Request) {
+		const { userId } = await this.resolveGatewayUserId(req);
 
 		this.gatewayService.clearDisconnectTimer(userId);
 		this.gatewayService.disconnectGateway(userId);
@@ -771,13 +776,13 @@ export class InstanceAiController {
 	}
 
 	@Post('/gateway/response/:requestId', { skipAuth: true })
-	gatewayResponse(
+	async gatewayResponse(
 		req: Request,
 		_res: Response,
 		@Param('requestId') requestId: string,
 		@Body payload: InstanceAiFilesystemResponseDto,
 	) {
-		const userId = this.validateGatewayApiKey(this.getGatewayKeyHeader(req));
+		const { userId } = await this.resolveGatewayUserId(req);
 
 		const resolved = this.gatewayService.resolveGatewayRequest(
 			userId,
@@ -797,7 +802,7 @@ export class InstanceAiController {
 		_res: Response,
 		@Body payload: InstanceAiGatewayCreateCredentialDto,
 	) {
-		const user = await this.resolveGatewayUser(this.getGatewayKeyHeader(req));
+		const user = await this.resolveGatewayUser(req);
 		await this.assertGatewayEnabled(user.id);
 		const credential = await this.credentialsService.createUnmanagedCredential(payload, user);
 		return { credentialId: credential.id };
@@ -940,6 +945,57 @@ export class InstanceAiController {
 	}
 
 	/**
+	 * Enable the local gateway (computer-use) for this user on connect, so desktop-app users never
+	 * have to toggle it in the n8n UI. Admin-level disable (Instance AI off, or the gateway turned
+	 * off instance-wide) is not overridable; the per-user preference is flipped on when needed.
+	 */
+	private async ensureGatewayEnabledForUser(userId: string): Promise<void> {
+		if (!this.settingsService.isAgentEnabled() || this.settingsService.isLocalGatewayDisabled()) {
+			throw new ForbiddenError('Local gateway is disabled');
+		}
+		// The static env-gateway key has no associated user preferences to flip.
+		if (userId === 'env-gateway') return;
+		if (!(await this.settingsService.isLocalGatewayDisabledForUser(userId))) return;
+
+		const user = await this.userRepository.findOne({ where: { id: userId }, relations: ['role'] });
+		if (!user) throw new ForbiddenError('Invalid API key');
+		await this.settingsService.updateUserPreferences(user, { localGatewayDisabled: false });
+	}
+
+	/** Extract a Bearer token from the Authorization header (case-insensitive scheme). */
+	private extractBearerToken(req: Request): string | undefined {
+		const match = req.headers.authorization?.match(/^Bearer\s+(.+)$/i);
+		return match ? match[1].trim() : undefined;
+	}
+
+	/**
+	 * Resolve the user a gateway request authenticates as. Accepts either an OAuth2 access token
+	 * (`Authorization: Bearer`, scope `instanceAi:gateway`) — used by the desktop app — or the
+	 * legacy `X-Gateway-Key` pairing/session key — used by the standalone computer-use CLI.
+	 *
+	 * The MCP module owns OAuth verification, so it's resolved lazily to avoid a static import.
+	 */
+	private async resolveGatewayUserId(req: Request): Promise<{ userId: string; viaOAuth: boolean }> {
+		const bearer = this.extractBearerToken(req);
+		if (bearer) {
+			const { McpOAuthTokenService } = await import('@/modules/mcp/mcp-oauth-token.service');
+			const tokenService = Container.get(McpOAuthTokenService);
+			const result = await tokenService.verifyOAuthAccessToken(
+				bearer,
+				tokenService.getCanonicalResourceUrl(),
+			);
+			if (result.user) {
+				if (!result.scopes?.includes('instanceAi:gateway')) {
+					throw new ForbiddenError('OAuth token lacks the required instanceAi:gateway scope');
+				}
+				return { userId: result.user.id, viaOAuth: true };
+			}
+			// Bearer present but not a valid OAuth token — fall through to the gateway-key path.
+		}
+		return { userId: this.validateGatewayApiKey(this.getGatewayKeyHeader(req)), viaOAuth: false };
+	}
+
+	/**
 	 * Safely extract and validate the x-gateway-key header value.
 	 * Headers can be string | string[] | undefined — take only the first value
 	 * and validate against the shared gateway key schema.
@@ -981,8 +1037,8 @@ export class InstanceAiController {
 	 * Resolve a gateway API key to its associated User. Requires a user-scoped
 	 * key — the static env-var key (which has no associated DB user) is rejected.
 	 */
-	private async resolveGatewayUser(key: string | undefined): Promise<User> {
-		const userId = this.validateGatewayApiKey(key);
+	private async resolveGatewayUser(req: Request): Promise<User> {
+		const { userId } = await this.resolveGatewayUserId(req);
 		if (userId === 'env-gateway') {
 			throw new ForbiddenError('Credential creation requires a user-scoped gateway key');
 		}

--- a/packages/frontend/editor-ui/src/app/views/OAuthConsentView.test.ts
+++ b/packages/frontend/editor-ui/src/app/views/OAuthConsentView.test.ts
@@ -4,10 +4,21 @@ import { useConsentStore } from '@/app/stores/consent.store';
 import OAuthConsentView from '@/app/views/OAuthConsentView.vue';
 import { createTestingPinia } from '@pinia/testing';
 import userEvent from '@testing-library/user-event';
+import * as consentApi from '@n8n/rest-api-client/api/consent';
 
 vi.mock('@n8n/rest-api-client/api/consent');
 
 const renderComponent = createComponentRenderer(OAuthConsentView);
+
+// The localized label each known scope must render — mirrors `oauth.consentView.scope.*` in en.json.
+const KNOWN_SCOPE_LABELS: Record<string, string> = {
+	'instanceAi:message': 'Chat with the AI Assistant on your behalf',
+	'instanceAi:gateway': 'Run local automation tools on your machine',
+	'workflow:read': 'View your workflows',
+	'workflow:execute': 'Execute workflows on your behalf',
+	'execution:read': 'View workflow execution details',
+	'execution:list': 'List your workflow executions',
+};
 
 let locationHrefSpy: ReturnType<typeof vi.spyOn>;
 
@@ -74,5 +85,36 @@ describe('OAuthConsentView', () => {
 
 		expect(consentStore.approveConsent).toHaveBeenCalledWith(true);
 		expect(window.location.href).toBe(redirectUrl);
+	});
+
+	it('renders the localized label for every known scope, not the raw slug', async () => {
+		const scopes = Object.keys(KNOWN_SCOPE_LABELS);
+		vi.mocked(consentApi.getConsentDetails).mockResolvedValue({
+			clientName: 'Test MCP Client',
+			clientId: 'test-client-id',
+			scopes,
+		});
+
+		const { getByText, queryByText } = renderComponent();
+		await waitAllPromises();
+
+		for (const [scope, label] of Object.entries(KNOWN_SCOPE_LABELS)) {
+			expect(getByText(label)).toBeInTheDocument();
+			// The raw slug must never leak through for a mapped scope.
+			expect(queryByText(scope)).not.toBeInTheDocument();
+		}
+	});
+
+	it('falls back to the raw scope slug when no translation exists', async () => {
+		vi.mocked(consentApi.getConsentDetails).mockResolvedValue({
+			clientName: 'Test MCP Client',
+			clientId: 'test-client-id',
+			scopes: ['some:unmappedScope'],
+		});
+
+		const { getByText } = renderComponent();
+		await waitAllPromises();
+
+		expect(getByText('some:unmappedScope')).toBeInTheDocument();
 	});
 });

--- a/packages/frontend/editor-ui/src/app/views/OAuthConsentView.vue
+++ b/packages/frontend/editor-ui/src/app/views/OAuthConsentView.vue
@@ -27,7 +27,8 @@ const clentDetails = computed<ConsentDetails | null>(() => consentStore.consentD
 const permissionLabels = computed<string[]>(() =>
 	(clentDetails.value?.scopes ?? []).map((scope) => {
 		const key = `oauth.consentView.scope.${scope}`;
-		return i18n.exists(key) ? i18n.baseText(key as BaseTextKey) : scope;
+		const label = i18n.baseText(key as BaseTextKey);
+		return label === key ? scope : label;
 	}),
 );
 


### PR DESCRIPTION
## Summary

Implements usage of oauth tokens inside computer use / local-gateway native app. Fixes scopes localization

## How to test

1. Start n8n instance locally with mcp and instance ai enabled.
2. Start `local-gateway` app and login
3. Open instance ai (existing thread or write a new message) and observe that computer use is connected

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
