### PR TITLE
test(core): Align MCP OAuth API test setup

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/mcp.auth.consent.controller.api.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.auth.consent.controller.api.test.ts
@@ -60,6 +60,7 @@ describe('GET /rest/consent/details', () => {
 		expect(response.body.data).toEqual({
 			clientName: 'Test OAuth Client',
 			clientId: 'test-client-id',
+			scopes: ['tool:listWorkflows', 'tool:getWorkflowDetails'],
 		});
 	});
 

--- a/packages/cli/src/modules/mcp/__tests__/mcp.settings.controller.api.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp.settings.controller.api.test.ts
@@ -23,7 +23,7 @@ import { createFolder } from '@test-integration/db/folders';
 import { createMember, createOwner, createUser } from '@test-integration/db/users';
 import { setupTestServer } from '@test-integration/utils';
 
-const testServer = setupTestServer({ endpointGroups: ['mcp'] });
+const testServer = setupTestServer({ endpointGroups: ['mcp'], modules: ['mcp'] });
 
 let owner: User;
 let member: User;


### PR DESCRIPTION
## Summary

Aligns the MCP OAuth API tests with the OAuth client seeding and consent response shape on the hackmation personal automation branch.

This updates the MCP settings API suite to initialize the MCP module/entities consistently with the other MCP API suites, and updates the consent details assertion to include default MCP tool scopes.

## How to test

From `packages/cli`:

```bash
pnpm test src/modules/mcp/__tests__/mcp.settings.controller.api.test.ts src/modules/mcp/__tests__/mcp.auth.consent.controller.api.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

Unblocks backend unit test failures observed on https://github.com/n8n-io/n8n/pull/32035.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI