### PR TITLE
chore(core): Implement e2e tests for MCP OAuth endpoints

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/mcp-oauth-authorization-code.service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp-oauth-authorization-code.service.test.ts
@@ -1,3 +1,4 @@
+import { InvalidGrantError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import { mockInstance } from '@n8n/backend-test-utils';
 import { mock } from 'jest-mock-extended';
 
@@ -100,7 +101,7 @@ describe('McpOAuthAuthorizationCodeService', () => {
 
 			await expect(
 				service.findAndValidateAuthorizationCode('invalid-code', 'client-123'),
-			).rejects.toThrow('invalid_grant');
+			).rejects.toThrow(InvalidGrantError);
 		});
 
 		it('should throw error and remove when authorization code expired', async () => {
@@ -115,7 +116,7 @@ describe('McpOAuthAuthorizationCodeService', () => {
 
 			await expect(
 				service.findAndValidateAuthorizationCode('code-123', 'client-123'),
-			).rejects.toThrow('invalid_grant');
+			).rejects.toThrow(InvalidGrantError);
 
 			expect(authorizationCodeRepository.remove).toHaveBeenCalledWith(authRecord);
 		});
@@ -162,7 +163,7 @@ describe('McpOAuthAuthorizationCodeService', () => {
 
 			await expect(
 				service.validateAndConsumeAuthorizationCode('code-123', 'client-123'),
-			).rejects.toThrow('invalid_grant');
+			).rejects.toThrow(InvalidGrantError);
 		});
 
 		it('should throw error when redirect URI mismatch', async () => {
@@ -227,7 +228,7 @@ describe('McpOAuthAuthorizationCodeService', () => {
 			authorizationCodeRepository.findOne.mockResolvedValue(null);
 
 			await expect(service.getCodeChallenge('invalid-code', 'client-123')).rejects.toThrow(
-				'invalid_grant',
+				InvalidGrantError,
 			);
 		});
 
@@ -235,7 +236,7 @@ describe('McpOAuthAuthorizationCodeService', () => {
 			authorizationCodeRepository.findOne.mockResolvedValue(null);
 
 			await expect(service.getCodeChallenge('code-123', 'client-123')).rejects.toThrow(
-				'invalid_grant',
+				InvalidGrantError,
 			);
 			expect(authorizationCodeRepository.findOne).toHaveBeenCalledWith({
 				where: { code: 'code-123', clientId: 'client-123', used: false },

--- a/packages/cli/src/modules/mcp/__tests__/mcp-oauth-service.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/mcp-oauth-service.test.ts
@@ -1,9 +1,12 @@
+import {
+	InvalidGrantError,
+	InvalidTargetError,
+} from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import { Logger } from '@n8n/backend-common';
 import { mockInstance } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
 import type { Response } from 'express';
 import { mock } from 'jest-mock-extended';
-import { OAuthError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 
 import type { AuthorizationCode } from '../database/entities/oauth-authorization-code.entity';
 import type { OAuthClient } from '../database/entities/oauth-client.entity';
@@ -517,7 +520,7 @@ describe('McpOAuthService', () => {
 
 			authorizationCodeService.findAuthorizationCode.mockResolvedValue(authRecord);
 			authorizationCodeService.markAuthorizationCodeAsUsed.mockImplementation(async () => {
-				throw new OAuthError('invalid_grant', 'Authorization code already used');
+				throw new InvalidGrantError('Authorization code already used');
 			});
 
 			await expect(
@@ -527,7 +530,7 @@ describe('McpOAuthService', () => {
 					'verifier-123',
 					'https://example.com/callback',
 				),
-			).rejects.toThrow('invalid_grant');
+			).rejects.toThrow(InvalidGrantError);
 		});
 	});
 
@@ -618,7 +621,7 @@ describe('McpOAuthService', () => {
 					['read'],
 					new URL('https://attacker.example.com/mcp-server/http'),
 				),
-			).rejects.toThrow('invalid_target');
+			).rejects.toThrow(InvalidTargetError);
 		});
 
 		it('should normalize a trailing-slash resource before passing it to token rotation', async () => {

--- a/packages/cli/src/modules/mcp/mcp-oauth-authorization-code.service.ts
+++ b/packages/cli/src/modules/mcp/mcp-oauth-authorization-code.service.ts
@@ -1,10 +1,10 @@
+import { InvalidGrantError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import { Time } from '@n8n/constants';
 import { Service } from '@n8n/di';
 import { randomBytes } from 'node:crypto';
 
 import type { AuthorizationCode } from './database/entities/oauth-authorization-code.entity';
 import { AuthorizationCodeRepository } from './database/repositories/oauth-authorization-code.repository';
-import { OAuthError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 
 /**
  * Handles OAuth 2.1 authorization code lifecycle for MCP server
@@ -62,12 +62,12 @@ export class McpOAuthAuthorizationCodeService {
 		});
 
 		if (!authRecord) {
-			throw new OAuthError('invalid_grant', 'Invalid authorization code');
+			throw new InvalidGrantError('Invalid authorization code');
 		}
 
 		if (authRecord.expiresAt < Date.now()) {
 			await this.authorizationCodeRepository.remove(authRecord);
-			throw new OAuthError('invalid_grant', 'Authorization code expired');
+			throw new InvalidGrantError('Authorization code expired');
 		}
 
 		return authRecord;
@@ -124,7 +124,7 @@ export class McpOAuthAuthorizationCodeService {
 
 		const numAffected = result.affected ?? 0;
 		if (numAffected < 1) {
-			throw new OAuthError('invalid_grant', 'Authorization code already used');
+			throw new InvalidGrantError('Authorization code already used');
 		}
 
 		authRecord.used = true;
@@ -141,7 +141,7 @@ export class McpOAuthAuthorizationCodeService {
 
 		const numAffected = result.affected ?? 0;
 		if (numAffected < 1) {
-			throw new OAuthError('invalid_grant', 'Authorization code already used');
+			throw new InvalidGrantError('Authorization code already used');
 		}
 	}
 
@@ -150,7 +150,7 @@ export class McpOAuthAuthorizationCodeService {
 	async getCodeChallenge(authorizationCode: string, clientId: string): Promise<string> {
 		const authRecord = await this.findAuthorizationCode(authorizationCode, clientId);
 		if (!authRecord) {
-			throw new OAuthError('invalid_grant', 'Invalid authorization code');
+			throw new InvalidGrantError('Invalid authorization code');
 		}
 		return authRecord.codeChallenge;
 	}

--- a/packages/cli/src/modules/mcp/mcp-oauth-service.ts
+++ b/packages/cli/src/modules/mcp/mcp-oauth-service.ts
@@ -1,9 +1,12 @@
 import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients';
+import {
+	InvalidGrantError,
+	InvalidTargetError,
+} from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import type {
 	AuthorizationParams,
 	OAuthServerProvider,
 } from '@modelcontextprotocol/sdk/server/auth/provider';
-import { OAuthError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types';
 import type {
 	OAuthClientInformationFull,
@@ -220,7 +223,7 @@ export class McpOAuthService implements OAuthServerProvider {
 		);
 
 		if (!authRecord) {
-			throw new OAuthError('invalid_grant', 'Invalid authorization code');
+			throw new InvalidGrantError('Invalid authorization code');
 		}
 
 		const resourceStr = resource?.toString();
@@ -376,13 +379,14 @@ export class McpOAuthService implements OAuthServerProvider {
 	}
 }
 
-// Per RFC 8707 §3.2 the error code MUST be 'invalid_target'. Don't change to 'invalid_resource':
-// it isn't in the registered OAuth error set and compliant MCP clients will fail the negotiation.
-class InvalidResourceIndicatorError extends OAuthError {
+// Per RFC 8707 §3.2 the error code MUST be 'invalid_target' (provided by InvalidTargetError's
+// static errorCode). Don't change to 'invalid_resource': it isn't in the registered OAuth error
+// set and compliant MCP clients will fail the negotiation.
+class InvalidResourceIndicatorError extends InvalidTargetError {
 	constructor(
 		readonly resource: string,
 		readonly expectedResource: string,
 	) {
-		super('invalid_target', 'Invalid resource indicator');
+		super('Invalid resource indicator');
 	}
 }

--- a/packages/cli/src/modules/mcp/mcp-oauth-token.service.ts
+++ b/packages/cli/src/modules/mcp/mcp-oauth-token.service.ts
@@ -1,3 +1,4 @@
+import { InvalidGrantError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
 import { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types';
 import { OAuthTokens } from '@modelcontextprotocol/sdk/shared/auth';
 import { Logger } from '@n8n/backend-common';
@@ -117,8 +118,10 @@ export class McpOAuthTokenService {
 				},
 			});
 
+			// InvalidGrantError so the SDK token handler responds 400 invalid_grant (RFC 6749 §5.2)
+			// instead of 500 server_error, letting clients fall back to re-authorization.
 			if (!refreshTokenRecord) {
-				throw new Error('Invalid refresh token');
+				throw new InvalidGrantError('Invalid refresh token');
 			}
 
 			const result = await trx.delete(RefreshToken, {
@@ -129,7 +132,7 @@ export class McpOAuthTokenService {
 
 			const numAffected = result.affected ?? 0;
 			if (numAffected < 1) {
-				throw new Error('Invalid refresh token');
+				throw new InvalidGrantError('Invalid refresh token');
 			}
 
 			const { accessToken, refreshToken: newRefreshToken } = this.generateTokenPair(

--- a/packages/testing/playwright/pages/OAuthConsentPage.ts
+++ b/packages/testing/playwright/pages/OAuthConsentPage.ts
@@ -1,0 +1,21 @@
+import { BasePage } from './BasePage';
+
+/**
+ * OAuth consent screen shown at /oauth/consent during the MCP OAuth
+ * authorization flow. The flow is entered by navigating the browser to the
+ * /mcp-oauth/authorize URL, which redirects here.
+ */
+export class OAuthConsentPage extends BasePage {
+	/** Enter the flow by navigating to the /mcp-oauth/authorize URL, which redirects here. */
+	async goto(authorizeUrl: string) {
+		await this.page.goto(authorizeUrl);
+	}
+
+	getConsentContent() {
+		return this.page.getByTestId('consent-content');
+	}
+
+	async allow() {
+		await this.clickByTestId('consent-allow-button');
+	}
+}

--- a/packages/testing/playwright/pages/n8nPage.ts
+++ b/packages/testing/playwright/pages/n8nPage.ts
@@ -28,6 +28,7 @@ import { MfaLoginPage } from './MfaLoginPage';
 import { MfaSetupModal } from './MfaSetupModal';
 import { NodeDetailsViewPage } from './NodeDetailsViewPage';
 import { NpsSurveyPage } from './NpsSurveyPage';
+import { OAuthConsentPage } from './OAuthConsentPage';
 import { ProjectSettingsPage } from './ProjectSettingsPage';
 import { SecretsProviderSettingsPage } from './SecretsProviderSettingsPage';
 import { SettingsEnvironmentPage } from './SettingsEnvironmentPage';
@@ -87,6 +88,7 @@ export class n8nPage {
 	readonly mfaLogin: MfaLoginPage;
 	readonly ndv: NodeDetailsViewPage;
 	readonly npsSurvey: NpsSurveyPage;
+	readonly oauthConsent: OAuthConsentPage;
 	readonly projectSettings: ProjectSettingsPage;
 	readonly settingsPersonal: SettingsPersonalPage;
 	readonly settingsLogStreaming: SettingsLogStreamingPage;
@@ -167,6 +169,7 @@ export class n8nPage {
 		this.mfaLogin = new MfaLoginPage(page);
 		this.ndv = new NodeDetailsViewPage(page);
 		this.npsSurvey = new NpsSurveyPage(page);
+		this.oauthConsent = new OAuthConsentPage(page);
 		this.projectSettings = new ProjectSettingsPage(page);
 		this.settingsPersonal = new SettingsPersonalPage(page);
 		this.settingsLogStreaming = new SettingsLogStreamingPage(page);

--- a/packages/testing/playwright/services/api-helper.ts
+++ b/packages/testing/playwright/services/api-helper.ts
@@ -20,6 +20,7 @@ import { CredentialApiHelper } from './credential-api-helper';
 import { DynamicCredentialApiHelper } from './dynamic-credential-api-helper';
 import { ExternalSecretsApiHelper } from './external-secrets-api-helper';
 import { McpApiHelper } from './mcp-api-helper';
+import { McpOAuthApiHelper } from './mcp-oauth-api-helper';
 import { ProjectApiHelper } from './project-api-helper';
 import { PublicApiHelper } from './public-api-helper';
 import { RoleApiHelper } from './role-api-helper';
@@ -67,6 +68,7 @@ export class ApiHelpers {
 	workflows: WorkflowApiHelper;
 	webhooks: WebhookApiHelper;
 	mcp: McpApiHelper;
+	mcpOauth: McpOAuthApiHelper;
 	projects: ProjectApiHelper;
 	credentials: CredentialApiHelper;
 	dynamicCredentials: DynamicCredentialApiHelper;
@@ -84,6 +86,7 @@ export class ApiHelpers {
 		this.workflows = new WorkflowApiHelper(this);
 		this.webhooks = new WebhookApiHelper(this);
 		this.mcp = new McpApiHelper(this);
+		this.mcpOauth = new McpOAuthApiHelper(this);
 		this.projects = new ProjectApiHelper(this);
 		this.credentials = new CredentialApiHelper(this);
 		this.dynamicCredentials = new DynamicCredentialApiHelper(this);

--- a/packages/testing/playwright/services/mcp-oauth-api-helper.ts
+++ b/packages/testing/playwright/services/mcp-oauth-api-helper.ts
@@ -1,0 +1,248 @@
+import type { APIResponse } from '@playwright/test';
+import { createHash, randomBytes } from 'node:crypto';
+
+import type { ApiHelpers } from './api-helper';
+import { TestError } from '../Types';
+
+export interface PkcePair {
+	verifier: string;
+	challenge: string;
+}
+
+export interface OAuthClientRegistration {
+	client_name: string;
+	redirect_uris: string[];
+	grant_types: string[];
+	token_endpoint_auth_method: string;
+}
+
+export interface RegisteredOAuthClient extends OAuthClientRegistration {
+	client_id: string;
+	client_secret?: string;
+}
+
+export interface OAuthTokens {
+	access_token: string;
+	token_type: string;
+	expires_in: number;
+	refresh_token: string;
+}
+
+export interface AuthorizationFlowResult {
+	client: RegisteredOAuthClient;
+	tokens: OAuthTokens;
+	pkce: PkcePair;
+	redirectUri: string;
+	state: string;
+}
+
+/**
+ * Helper for the instance-level MCP OAuth2 server (authorization code + PKCE flow).
+ *
+ * Endpoint layout:
+ * - Discovery, register, authorize, token and revoke are root-level (no /rest prefix).
+ * - Consent endpoints are REST controllers (/rest/consent/*) and require the
+ *   authenticated user's session cookie plus the OAuth session cookie set by
+ *   the authorize redirect. Both live in this request context's cookie jar.
+ */
+export class McpOAuthApiHelper {
+	constructor(private readonly api: ApiHelpers) {}
+
+	/** Generates a PKCE verifier and its S256 challenge (RFC 7636). */
+	createPkcePair(): PkcePair {
+		const verifier = randomBytes(32).toString('base64url');
+		const challenge = createHash('sha256').update(verifier).digest('base64url');
+		return { verifier, challenge };
+	}
+
+	async getAuthorizationServerMetadata(): Promise<APIResponse> {
+		return await this.api.request.get('/.well-known/oauth-authorization-server');
+	}
+
+	async getProtectedResourceMetadata(): Promise<APIResponse> {
+		return await this.api.request.get('/.well-known/oauth-protected-resource/mcp-server/http');
+	}
+
+	/** Dynamic client registration (RFC 7591). Unauthenticated. */
+	async registerClient(registration: OAuthClientRegistration): Promise<APIResponse> {
+		return await this.api.request.post('/mcp-oauth/register', { data: registration });
+	}
+
+	async registerClientOrFail(
+		registration: OAuthClientRegistration,
+	): Promise<RegisteredOAuthClient> {
+		const response = await this.registerClient(registration);
+		if (response.status() !== 201) {
+			throw new TestError(
+				`Failed to register OAuth client: ${response.status()} ${await response.text()}`,
+			);
+		}
+		return (await response.json()) as RegisteredOAuthClient;
+	}
+
+	buildAuthorizeUrl(params: {
+		clientId: string;
+		redirectUri: string;
+		challenge: string;
+		state?: string;
+		resource?: string;
+	}): string {
+		const query = new URLSearchParams({
+			client_id: params.clientId,
+			redirect_uri: params.redirectUri,
+			response_type: 'code',
+			code_challenge: params.challenge,
+			code_challenge_method: 'S256',
+			...(params.state && { state: params.state }),
+			...(params.resource && { resource: params.resource }),
+		});
+		return `/mcp-oauth/authorize?${query.toString()}`;
+	}
+
+	/**
+	 * Starts the authorization flow. Does not follow the redirect so tests can
+	 * assert on it. The OAuth session cookie from the response is stored in the
+	 * request context's cookie jar for the subsequent consent calls.
+	 */
+	async authorize(params: {
+		clientId: string;
+		redirectUri: string;
+		challenge: string;
+		state?: string;
+		resource?: string;
+	}): Promise<APIResponse> {
+		return await this.api.request.get(this.buildAuthorizeUrl(params), { maxRedirects: 0 });
+	}
+
+	/** Requires a signed-in user and a pending OAuth session (see authorize). */
+	async getConsentDetails(): Promise<APIResponse> {
+		return await this.api.request.get('/rest/consent/details');
+	}
+
+	/** Requires a signed-in user and a pending OAuth session (see authorize). */
+	async approveConsent(approved: boolean): Promise<APIResponse> {
+		return await this.api.request.post('/rest/consent/approve', { data: { approved } });
+	}
+
+	/**
+	 * Approves or denies the pending consent and returns the redirect URL the
+	 * client would be sent back to (carrying either the code or the error).
+	 */
+	async submitConsentOrFail(approved: boolean): Promise<URL> {
+		const response = await this.approveConsent(approved);
+		if (!response.ok()) {
+			throw new TestError(
+				`Failed to submit consent: ${response.status()} ${await response.text()}`,
+			);
+		}
+		const body = (await response.json()) as { data: { redirectUrl: string } };
+		return new URL(body.data.redirectUrl);
+	}
+
+	/** Token endpoint expects application/x-www-form-urlencoded (RFC 6749). */
+	async exchangeAuthorizationCode(params: {
+		code: string;
+		clientId: string;
+		codeVerifier: string;
+		redirectUri: string;
+		resource?: string;
+	}): Promise<APIResponse> {
+		return await this.api.request.post('/mcp-oauth/token', {
+			form: {
+				grant_type: 'authorization_code',
+				code: params.code,
+				client_id: params.clientId,
+				code_verifier: params.codeVerifier,
+				redirect_uri: params.redirectUri,
+				...(params.resource && { resource: params.resource }),
+			},
+		});
+	}
+
+	async exchangeAuthorizationCodeOrFail(params: {
+		code: string;
+		clientId: string;
+		codeVerifier: string;
+		redirectUri: string;
+		resource?: string;
+	}): Promise<OAuthTokens> {
+		const response = await this.exchangeAuthorizationCode(params);
+		if (!response.ok()) {
+			throw new TestError(
+				`Failed to exchange authorization code: ${response.status()} ${await response.text()}`,
+			);
+		}
+		return (await response.json()) as OAuthTokens;
+	}
+
+	async refreshToken(params: { refreshToken: string; clientId: string }): Promise<APIResponse> {
+		return await this.api.request.post('/mcp-oauth/token', {
+			form: {
+				grant_type: 'refresh_token',
+				refresh_token: params.refreshToken,
+				client_id: params.clientId,
+			},
+		});
+	}
+
+	async revokeToken(params: {
+		token: string;
+		clientId: string;
+		tokenTypeHint?: 'access_token' | 'refresh_token';
+	}): Promise<APIResponse> {
+		return await this.api.request.post('/mcp-oauth/revoke', {
+			form: {
+				token: params.token,
+				client_id: params.clientId,
+				...(params.tokenTypeHint && { token_type_hint: params.tokenTypeHint }),
+			},
+		});
+	}
+
+	/**
+	 * Runs the full authorization code + PKCE flow for the signed-in user:
+	 * register client → authorize → approve consent → exchange code for tokens.
+	 */
+	async completeAuthorizationCodeFlow(options?: {
+		clientName?: string;
+		redirectUri?: string;
+	}): Promise<AuthorizationFlowResult> {
+		const redirectUri = options?.redirectUri ?? 'https://example.com/callback';
+		const state = randomBytes(16).toString('hex');
+		const pkce = this.createPkcePair();
+
+		const client = await this.registerClientOrFail({
+			client_name: options?.clientName ?? 'n8n e2e OAuth client',
+			redirect_uris: [redirectUri],
+			grant_types: ['authorization_code', 'refresh_token'],
+			token_endpoint_auth_method: 'none',
+		});
+
+		const authorizeResponse = await this.authorize({
+			clientId: client.client_id,
+			redirectUri,
+			challenge: pkce.challenge,
+			state,
+		});
+		if (authorizeResponse.status() !== 302) {
+			throw new TestError(
+				`Authorize did not redirect to consent: ${authorizeResponse.status()} ${await authorizeResponse.text()}`,
+			);
+		}
+
+		const callbackUrl = await this.submitConsentOrFail(true);
+		const code = callbackUrl.searchParams.get('code');
+		if (!code) {
+			throw new TestError(`Consent approval returned no authorization code: ${callbackUrl.href}`);
+		}
+
+		const tokens = await this.exchangeAuthorizationCodeOrFail({
+			code,
+			clientId: client.client_id,
+			codeVerifier: pkce.verifier,
+			redirectUri,
+		});
+
+		return { client, tokens, pkce, redirectUri, state };
+	}
+}

--- a/packages/testing/playwright/tests/e2e/mcp/mcp-oauth.spec.ts
+++ b/packages/testing/playwright/tests/e2e/mcp/mcp-oauth.spec.ts
@@ -1,0 +1,425 @@
+import { nanoid } from 'nanoid';
+
+import { test, expect } from '../../../fixtures/base';
+
+/**
+ * E2E tests for the instance-level MCP OAuth2 server.
+ *
+ * Baseline coverage for the full authorization code + PKCE flow before the
+ * OAuth server is extracted into a reusable package (for the MCP Trigger
+ * node). The per-endpoint validation logic is already covered by integration
+ * tests in packages/cli/src/modules/mcp/__tests__; these tests focus on the
+ * cross-endpoint glue that only exists on a running instance:
+ *
+ *   discovery → dynamic client registration → /mcp-oauth/authorize (session
+ *   cookie + redirect) → consent (REST + UI) → code exchange with PKCE →
+ *   authenticated /mcp-server/http calls → refresh rotation → revocation.
+ *
+ * NOTE: Tests run serially because MCP access (`setMcpAccess`) is
+ * instance-global state, same as mcp-service.spec.ts.
+ */
+
+const CALLBACK_PATH = 'mcp-oauth-e2e-callback';
+
+test.describe(
+	'MCP OAuth',
+	{
+		annotation: [{ type: 'owner', description: 'AI' }],
+	},
+	() => {
+		test.describe.configure({ mode: 'serial' });
+
+		test.beforeEach(async ({ api }) => {
+			await api.setMcpAccess(true);
+		});
+
+		test.describe('Discovery', () => {
+			test('should expose authorization server metadata with CORS for external clients', async ({
+				api,
+			}) => {
+				const response = await api.mcpOauth.getAuthorizationServerMetadata();
+
+				expect(response.status()).toBe(200);
+				expect(response.headers()['access-control-allow-origin']).toBe('*');
+
+				const metadata = await response.json();
+				expect(metadata.authorization_endpoint).toBe(`${metadata.issuer}/mcp-oauth/authorize`);
+				expect(metadata.token_endpoint).toBe(`${metadata.issuer}/mcp-oauth/token`);
+				expect(metadata.registration_endpoint).toBe(`${metadata.issuer}/mcp-oauth/register`);
+				expect(metadata.revocation_endpoint).toBe(`${metadata.issuer}/mcp-oauth/revoke`);
+				expect(metadata.response_types_supported).toEqual(['code']);
+				expect(metadata.grant_types_supported).toEqual(['authorization_code', 'refresh_token']);
+				expect(metadata.code_challenge_methods_supported).toEqual(['S256']);
+			});
+
+			test('should expose protected resource metadata pointing at the MCP server', async ({
+				api,
+			}) => {
+				const response = await api.mcpOauth.getProtectedResourceMetadata();
+
+				expect(response.status()).toBe(200);
+				expect(response.headers()['access-control-allow-origin']).toBe('*');
+
+				const metadata = await response.json();
+				expect(metadata.resource).toMatch(/\/mcp-server\/http$/);
+				expect(metadata.bearer_methods_supported).toEqual(['header']);
+				expect(metadata.authorization_servers).toHaveLength(1);
+			});
+		});
+
+		test.describe('Authorization code flow', () => {
+			test('should complete the full PKCE flow and grant access to the MCP server', async ({
+				api,
+			}) => {
+				const redirectUri = 'https://example.com/callback';
+				const state = nanoid();
+				const pkce = api.mcpOauth.createPkcePair();
+
+				const client = await api.mcpOauth.registerClientOrFail({
+					client_name: `e2e OAuth client ${nanoid(8)}`,
+					redirect_uris: [redirectUri],
+					grant_types: ['authorization_code', 'refresh_token'],
+					token_endpoint_auth_method: 'none',
+				});
+				expect(client.client_id).toBeTruthy();
+
+				// Authorize redirects to the consent page and sets the OAuth session cookie
+				const authorizeResponse = await api.mcpOauth.authorize({
+					clientId: client.client_id,
+					redirectUri,
+					challenge: pkce.challenge,
+					state,
+				});
+				expect(authorizeResponse.status()).toBe(302);
+				expect(authorizeResponse.headers().location).toBe('/oauth/consent');
+
+				// The consent page can resolve the pending session to the client name
+				const detailsResponse = await api.mcpOauth.getConsentDetails();
+				expect(detailsResponse.ok()).toBe(true);
+				const details = await detailsResponse.json();
+				expect(details.data.clientName).toBe(client.client_name);
+				expect(details.data.clientId).toBe(client.client_id);
+
+				// Approving returns the client callback URL with code and state
+				const callbackUrl = await api.mcpOauth.submitConsentOrFail(true);
+				expect(callbackUrl.href).toContain(redirectUri);
+				expect(callbackUrl.searchParams.get('state')).toBe(state);
+				const code = callbackUrl.searchParams.get('code');
+				expect(code).toBeTruthy();
+
+				// Exchange the code for tokens with the PKCE verifier
+				const tokens = await api.mcpOauth.exchangeAuthorizationCodeOrFail({
+					code: code!,
+					clientId: client.client_id,
+					codeVerifier: pkce.verifier,
+					redirectUri,
+				});
+				expect(tokens.token_type).toBe('Bearer');
+				expect(tokens.access_token).toBeTruthy();
+				expect(tokens.refresh_token).toBeTruthy();
+				expect(tokens.expires_in).toBeGreaterThan(0);
+
+				// The access token authenticates against the MCP server endpoint
+				const message = api.mcp.createMessage('tools/list');
+				const mcpResponse = await api.mcp.internalMcpSendMessageNoAuth(message, {
+					Authorization: `Bearer ${tokens.access_token}`,
+				});
+				expect(mcpResponse.status()).toBeLessThan(300);
+			});
+
+			test('should redirect back with access_denied when the user denies consent', async ({
+				api,
+			}) => {
+				const redirectUri = 'https://example.com/callback';
+				const state = nanoid();
+				const pkce = api.mcpOauth.createPkcePair();
+
+				const client = await api.mcpOauth.registerClientOrFail({
+					client_name: `e2e OAuth client ${nanoid(8)}`,
+					redirect_uris: [redirectUri],
+					grant_types: ['authorization_code'],
+					token_endpoint_auth_method: 'none',
+				});
+
+				const authorizeResponse = await api.mcpOauth.authorize({
+					clientId: client.client_id,
+					redirectUri,
+					challenge: pkce.challenge,
+					state,
+				});
+				expect(authorizeResponse.status()).toBe(302);
+
+				const callbackUrl = await api.mcpOauth.submitConsentOrFail(false);
+				expect(callbackUrl.searchParams.get('error')).toBe('access_denied');
+				expect(callbackUrl.searchParams.get('code')).toBeNull();
+				expect(callbackUrl.searchParams.get('state')).toBe(state);
+			});
+
+			test('should reject consent endpoints without a pending OAuth session', async ({ api }) => {
+				const response = await api.mcpOauth.getConsentDetails();
+
+				expect(response.status()).toBe(400);
+			});
+
+			test('should reject token exchange with an incorrect PKCE code verifier', async ({ api }) => {
+				const redirectUri = 'https://example.com/callback';
+				const pkce = api.mcpOauth.createPkcePair();
+
+				const client = await api.mcpOauth.registerClientOrFail({
+					client_name: `e2e OAuth client ${nanoid(8)}`,
+					redirect_uris: [redirectUri],
+					grant_types: ['authorization_code'],
+					token_endpoint_auth_method: 'none',
+				});
+
+				await api.mcpOauth.authorize({
+					clientId: client.client_id,
+					redirectUri,
+					challenge: pkce.challenge,
+				});
+				const callbackUrl = await api.mcpOauth.submitConsentOrFail(true);
+				const code = callbackUrl.searchParams.get('code')!;
+
+				const wrongVerifier = api.mcpOauth.createPkcePair().verifier;
+				const response = await api.mcpOauth.exchangeAuthorizationCode({
+					code,
+					clientId: client.client_id,
+					codeVerifier: wrongVerifier,
+					redirectUri,
+				});
+
+				expect(response.status()).toBe(400);
+				const body = await response.json();
+				expect(body.error).toBe('invalid_grant');
+			});
+
+			test('should reject reuse of an authorization code', async ({ api }) => {
+				const redirectUri = 'https://example.com/callback';
+				const pkce = api.mcpOauth.createPkcePair();
+
+				const client = await api.mcpOauth.registerClientOrFail({
+					client_name: `e2e OAuth client ${nanoid(8)}`,
+					redirect_uris: [redirectUri],
+					grant_types: ['authorization_code'],
+					token_endpoint_auth_method: 'none',
+				});
+
+				await api.mcpOauth.authorize({
+					clientId: client.client_id,
+					redirectUri,
+					challenge: pkce.challenge,
+				});
+				const callbackUrl = await api.mcpOauth.submitConsentOrFail(true);
+				const code = callbackUrl.searchParams.get('code')!;
+
+				const exchangeParams = {
+					code,
+					clientId: client.client_id,
+					codeVerifier: pkce.verifier,
+					redirectUri,
+				};
+
+				const firstExchange = await api.mcpOauth.exchangeAuthorizationCode(exchangeParams);
+				expect(firstExchange.ok()).toBe(true);
+
+				const replayExchange = await api.mcpOauth.exchangeAuthorizationCode(exchangeParams);
+				expect(replayExchange.status()).toBe(400);
+				const body = await replayExchange.json();
+				expect(body.error).toBe('invalid_grant');
+			});
+
+			test('should reject token exchange with a non-canonical resource indicator', async ({
+				api,
+			}) => {
+				const redirectUri = 'https://example.com/callback';
+				const pkce = api.mcpOauth.createPkcePair();
+
+				const client = await api.mcpOauth.registerClientOrFail({
+					client_name: `e2e OAuth client ${nanoid(8)}`,
+					redirect_uris: [redirectUri],
+					grant_types: ['authorization_code'],
+					token_endpoint_auth_method: 'none',
+				});
+
+				await api.mcpOauth.authorize({
+					clientId: client.client_id,
+					redirectUri,
+					challenge: pkce.challenge,
+				});
+				const callbackUrl = await api.mcpOauth.submitConsentOrFail(true);
+				const code = callbackUrl.searchParams.get('code')!;
+
+				const response = await api.mcpOauth.exchangeAuthorizationCode({
+					code,
+					clientId: client.client_id,
+					codeVerifier: pkce.verifier,
+					redirectUri,
+					resource: 'https://attacker.example.com/mcp-server/http',
+				});
+
+				expect(response.status()).toBe(400);
+				const body = await response.json();
+				expect(body.error).toBe('invalid_target');
+			});
+		});
+
+		test.describe('Refresh tokens', () => {
+			test('should rotate the refresh token and invalidate the previous one', async ({ api }) => {
+				const { client, tokens } = await api.mcpOauth.completeAuthorizationCodeFlow();
+
+				const refreshResponse = await api.mcpOauth.refreshToken({
+					refreshToken: tokens.refresh_token,
+					clientId: client.client_id,
+				});
+				expect(refreshResponse.ok()).toBe(true);
+				const rotatedTokens = await refreshResponse.json();
+				expect(rotatedTokens.access_token).toBeTruthy();
+				expect(rotatedTokens.refresh_token).toBeTruthy();
+				expect(rotatedTokens.refresh_token).not.toBe(tokens.refresh_token);
+
+				// The rotated access token authenticates against the MCP server
+				const message = api.mcp.createMessage('tools/list');
+				const mcpResponse = await api.mcp.internalMcpSendMessageNoAuth(message, {
+					Authorization: `Bearer ${rotatedTokens.access_token}`,
+				});
+				expect(mcpResponse.status()).toBeLessThan(300);
+
+				// The previous refresh token is single-use and now rejected
+				const reusedRefreshResponse = await api.mcpOauth.refreshToken({
+					refreshToken: tokens.refresh_token,
+					clientId: client.client_id,
+				});
+				expect(reusedRefreshResponse.status()).toBe(400);
+			});
+		});
+
+		test.describe('Revocation', () => {
+			test('should reject MCP requests with a revoked access token', async ({ api }) => {
+				const { client, tokens } = await api.mcpOauth.completeAuthorizationCodeFlow();
+
+				const message = api.mcp.createMessage('tools/list');
+				const beforeRevoke = await api.mcp.internalMcpSendMessageNoAuth(message, {
+					Authorization: `Bearer ${tokens.access_token}`,
+				});
+				expect(beforeRevoke.status()).toBeLessThan(300);
+
+				const revokeResponse = await api.mcpOauth.revokeToken({
+					token: tokens.access_token,
+					clientId: client.client_id,
+					tokenTypeHint: 'access_token',
+				});
+				expect(revokeResponse.ok()).toBe(true);
+
+				const afterRevoke = await api.mcp.internalMcpSendMessageNoAuth(message, {
+					Authorization: `Bearer ${tokens.access_token}`,
+				});
+				expect(afterRevoke.status()).toBe(401);
+			});
+
+			test('should succeed silently when revoking an unknown token', async ({ api }) => {
+				const { client } = await api.mcpOauth.completeAuthorizationCodeFlow();
+
+				// RFC 7009: revocation of an unknown token is not an error
+				const response = await api.mcpOauth.revokeToken({
+					token: 'unknown-token',
+					clientId: client.client_id,
+				});
+
+				expect(response.ok()).toBe(true);
+			});
+		});
+
+		test.describe('MCP access disabled', () => {
+			test.beforeEach(async ({ api }) => {
+				await api.setMcpAccess(false);
+			});
+
+			test.afterEach(async ({ api }) => {
+				await api.setMcpAccess(true);
+			});
+
+			test('should block OAuth endpoints when MCP access is disabled', async ({ api }) => {
+				const responses = await Promise.all([
+					api.mcpOauth.registerClient({
+						client_name: `e2e OAuth client ${nanoid(8)}`,
+						redirect_uris: ['https://example.com/callback'],
+						grant_types: ['authorization_code'],
+						token_endpoint_auth_method: 'none',
+					}),
+					api.mcpOauth.authorize({
+						clientId: 'any-client',
+						redirectUri: 'https://example.com/callback',
+						challenge: api.mcpOauth.createPkcePair().challenge,
+					}),
+					api.mcpOauth.exchangeAuthorizationCode({
+						code: 'any-code',
+						clientId: 'any-client',
+						codeVerifier: 'any-verifier',
+						redirectUri: 'https://example.com/callback',
+					}),
+				]);
+
+				for (const response of responses) {
+					expect(response.status()).toBe(403);
+				}
+			});
+		});
+
+		test.describe('Consent screen', () => {
+			test('should let the user approve access from the consent screen', async ({ n8n, api }) => {
+				const redirectUri = `http://localhost/${CALLBACK_PATH}`;
+				const state = nanoid();
+				const pkce = api.mcpOauth.createPkcePair();
+
+				const client = await api.mcpOauth.registerClientOrFail({
+					client_name: `e2e consent client ${nanoid(8)}`,
+					redirect_uris: [redirectUri],
+					grant_types: ['authorization_code', 'refresh_token'],
+					token_endpoint_auth_method: 'none',
+				});
+
+				// Intercept the client callback so the browser redirect resolves
+				await n8n.page.route(`**/${CALLBACK_PATH}*`, async (route) => {
+					await route.fulfill({
+						status: 200,
+						contentType: 'text/html',
+						body: '<html><body>OAuth callback received</body></html>',
+					});
+				});
+
+				await n8n.oauthConsent.goto(
+					api.mcpOauth.buildAuthorizeUrl({
+						clientId: client.client_id,
+						redirectUri,
+						challenge: pkce.challenge,
+						state,
+					}),
+				);
+
+				await expect(n8n.oauthConsent.getConsentContent()).toBeVisible();
+				await expect(n8n.oauthConsent.getConsentContent()).toContainText(client.client_name);
+
+				await n8n.oauthConsent.allow();
+				await n8n.page.waitForURL(`**/${CALLBACK_PATH}*`);
+
+				const callbackUrl = new URL(n8n.page.url());
+				expect(callbackUrl.searchParams.get('state')).toBe(state);
+				const code = callbackUrl.searchParams.get('code');
+				expect(code).toBeTruthy();
+
+				const tokens = await api.mcpOauth.exchangeAuthorizationCodeOrFail({
+					code: code!,
+					clientId: client.client_id,
+					codeVerifier: pkce.verifier,
+					redirectUri,
+				});
+
+				const message = api.mcp.createMessage('tools/list');
+				const mcpResponse = await api.mcp.internalMcpSendMessageNoAuth(message, {
+					Authorization: `Bearer ${tokens.access_token}`,
+				});
+				expect(mcpResponse.status()).toBeLessThan(300);
+			});
+		});
+	},
+);


### PR DESCRIPTION
## Summary

Adds a baseline of e2e tests for the MCP instance OAuth2 flow, ahead of extracting the OAuth server from the MCP instance module into a reusable package for the MCP Trigger node. The per-endpoint validation is already covered by integration tests in `packages/cli/src/modules/mcp/__tests__`; what was missing — and what the extraction is most likely to break — is the cross-endpoint glue that only exists on a running instance. The new spec (`tests/e2e/mcp/mcp-oauth.spec.ts`, 13 tests) pins:

- **Discovery**: `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource/mcp-server/http` metadata + CORS
- **Full authorization code + PKCE flow (API-driven)**: dynamic client registration → authorize (302 → `/oauth/consent` + session cookie) → consent approval → code exchange → authenticated `tools/list` call against `/mcp-server/http`
- **Full flow through the real consent screen (browser-driven)**: consent UI shows the client name, Allow redirects back to the client callback with code + state
- **Negative paths**: consent denial (`access_denied`), wrong PKCE verifier, authorization code replay, non-canonical resource indicator (RFC 8707), consent endpoints without a pending session, all endpoints blocked when MCP access is disabled
- **Refresh token rotation** (old refresh token single-use) and **revocation** (revoked access token rejected with 401; unknown-token revocation succeeds silently per RFC 7009)

Supporting test infra: new `api.mcpOauth` helper (`services/mcp-oauth-api-helper.ts`) with PKCE generation and a `completeAuthorizationCodeFlow()` composite, and an `OAuthConsentPage` page object.

### Bug found and fixed while writing the baseline

The MCP SDK's `OAuthError` constructor signature is `(message, errorUri)` — the OAuth error code on the wire comes from a static `errorCode` on its subclasses. The module constructed the base class as `OAuthError('invalid_grant', description)` (7 call sites), so error responses were missing the RFC 6749-required `error` field, meaning compliant clients couldn't detect `invalid_grant` to fall back to re-authorization. Additionally, invalid refresh tokens threw a plain `Error`, which the SDK token handler surfaces as **500 server_error** instead of **400 invalid_grant**.

Fixed by using the `InvalidGrantError` / `InvalidTargetError` subclasses. Fixing this before the extraction prevents shipping the non-compliant error contract into the reusable package.

## How to test

- `pnpm --filter=n8n-playwright test:local:isolated tests/e2e/mcp/mcp-oauth.spec.ts` — 13/13 pass
- `pnpm --filter=n8n-playwright test:local:isolated tests/e2e/mcp/mcp-service.spec.ts` — 26/26 pass (no regression from the error-class change)
- `pnpm test src/modules/mcp` in `packages/cli` — unit + integration tests pass

Manual check of the fix: complete an OAuth flow against a local instance, then re-POST the same authorization code to `/mcp-oauth/token` — the response now contains `"error": "invalid_grant"`; an invalid refresh token now returns 400 instead of 500.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-807

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
