### PR TITLE
feat(editor): Extend per-editor overrides to execution toasts and canvas AI entry points (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useEditorContext.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useEditorContext.ts
@@ -13,6 +13,9 @@ import { useSettingsStore } from '@/app/stores/settings.store';
  * `readOnly` is a direct flag — `true` forces the canvas read-only. When no host
  * provides the key, AI features fall back to their store values and the canvas
  * is editable (`readOnly` is `false`).
+ * `executionSuccessToasts` / `executionErrorToasts` are direct flags too — each
+ * `true` (the default) shows that class of execution result toast; an explicit
+ * `false` from the host suppresses it.
  */
 export function useEditorContext() {
 	const settings = useSettingsStore();
@@ -42,5 +45,9 @@ export function useEditorContext() {
 		aiBuilder: featureEnabled('aiBuilder'),
 		askAi: featureEnabled('askAi'),
 		readOnly: computed(() => enabledFeatures?.value?.readOnly === true),
+		executionSuccessToasts: computed(
+			() => enabledFeatures?.value?.executionSuccessToasts !== false,
+		),
+		executionErrorToasts: computed(() => enabledFeatures?.value?.executionErrorToasts !== false),
 	};
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -60,7 +60,7 @@ export type SimplifiedExecution = Pick<
  * Handles the 'executionFinished' event, which happens when a workflow execution is finished.
  */
 export async function executionFinished({ data }: ExecutionFinished, options: PushHandlerOptions) {
-	const { documentId } = options;
+	const { documentId, suppressExecutionSuccessToasts, suppressExecutionErrorToasts } = options;
 	const workflowsListStore = useWorkflowsListStore();
 	const uiStore = useUIStore();
 	const aiTemplatesStarterCollectionStore = useAITemplatesStarterCollectionStore();
@@ -134,7 +134,12 @@ export async function executionFinished({ data }: ExecutionFinished, options: Pu
 	let successToastAlreadyShown = false;
 
 	if (data.status === 'success') {
-		handleExecutionFinishedWithSuccessOrOther(documentId, data.status, successToastAlreadyShown);
+		handleExecutionFinishedWithSuccessOrOther(
+			documentId,
+			data.status,
+			successToastAlreadyShown,
+			suppressExecutionSuccessToasts,
+		);
 		successToastAlreadyShown = true;
 	}
 
@@ -157,12 +162,18 @@ export async function executionFinished({ data }: ExecutionFinished, options: Pu
 	if (execution.data?.waitTill !== undefined) {
 		handleExecutionFinishedWithWaitTill(data.workflowId, options);
 	} else if (execution.status === 'error' || execution.status === 'canceled') {
-		handleExecutionFinishedWithErrorOrCanceled(execution, runExecutionData, documentId);
+		handleExecutionFinishedWithErrorOrCanceled(
+			execution,
+			runExecutionData,
+			documentId,
+			suppressExecutionErrorToasts,
+		);
 	} else {
 		handleExecutionFinishedWithSuccessOrOther(
 			documentId,
 			execution.status,
 			successToastAlreadyShown,
+			suppressExecutionSuccessToasts,
 		);
 	}
 
@@ -325,6 +336,7 @@ export function handleExecutionFinishedWithErrorOrCanceled(
 	execution: SimplifiedExecution,
 	runExecutionData: IRunExecutionData,
 	documentId: WorkflowDocumentId,
+	suppressToasts = false,
 ) {
 	const toast = useToast();
 	const i18n = useI18n();
@@ -376,17 +388,21 @@ export function handleExecutionFinishedWithErrorOrCanceled(
 
 	if (execution.status === 'canceled') {
 		// Do not show the error message if the workflow got canceled
-		toast.showMessage({
-			title: i18n.baseText('nodeView.showMessage.stopExecutionTry.title'),
-			type: 'success',
-		});
+		if (!suppressToasts) {
+			toast.showMessage({
+				title: i18n.baseText('nodeView.showMessage.stopExecutionTry.title'),
+				type: 'success',
+			});
+		}
 	} else if (execution.data?.resultData.error) {
-		const { message, title } = getExecutionErrorToastConfiguration({
-			error: execution.data.resultData.error,
-			lastNodeExecuted: execution.data?.resultData.lastNodeExecuted,
-		});
+		if (!suppressToasts) {
+			const { message, title } = getExecutionErrorToastConfiguration({
+				error: execution.data.resultData.error,
+				lastNodeExecuted: execution.data?.resultData.lastNodeExecuted,
+			});
 
-		toast.showMessage({ title, message, type: 'error', duration: 0 });
+			toast.showMessage({ title, message, type: 'error', duration: 0 });
+		}
 
 		useBuilderStore().incrementManualExecutionStats('error');
 	}
@@ -403,15 +419,18 @@ function handleExecutionFinishedSuccessfully(
 	workflowName: string,
 	message: string,
 	documentId: WorkflowDocumentId,
+	suppressToasts = false,
 ) {
 	const toast = useToast();
 
 	useDocumentTitle().setDocumentTitle(workflowName, 'IDLE');
 	useWorkflowExecutionStateStore(documentId).setActiveExecutionId(undefined);
-	toast.showMessage({
-		title: message,
-		type: 'success',
-	});
+	if (!suppressToasts) {
+		toast.showMessage({
+			title: message,
+			type: 'success',
+		});
+	}
 }
 
 /**
@@ -421,6 +440,7 @@ export function handleExecutionFinishedWithSuccessOrOther(
 	documentId: WorkflowDocumentId,
 	executionStatus: ExecutionStatus,
 	successToastAlreadyShown: boolean,
+	suppressToasts = false,
 ) {
 	const workflowsStore = useWorkflowsStore();
 	const toast = useToast();
@@ -440,30 +460,35 @@ export function handleExecutionFinishedWithSuccessOrOther(
 			workflowExecution.data?.resultData?.runData?.[workflowExecution.executedNode];
 
 		if (nodeType?.polling && !nodeOutput) {
-			toast.showMessage({
-				title: i18n.baseText('pushConnection.pollingNode.dataNotFound', {
-					interpolate: {
-						service: getTriggerNodeServiceName(nodeType),
-					},
-				}),
-				message: i18n.baseText('pushConnection.pollingNode.dataNotFound.message', {
-					interpolate: {
-						service: getTriggerNodeServiceName(nodeType),
-					},
-				}),
-				type: 'success',
-			});
+			if (!suppressToasts) {
+				toast.showMessage({
+					title: i18n.baseText('pushConnection.pollingNode.dataNotFound', {
+						interpolate: {
+							service: getTriggerNodeServiceName(nodeType),
+						},
+					}),
+					message: i18n.baseText('pushConnection.pollingNode.dataNotFound.message', {
+						interpolate: {
+							service: getTriggerNodeServiceName(nodeType),
+						},
+					}),
+					type: 'success',
+				});
+			}
 		} else if (!nodeOutput && !successToastAlreadyShown) {
-			toast.showMessage({
-				title: i18n.baseText('pushConnection.nodeNotExecuted'),
-				message: i18n.baseText('pushConnection.nodeNotExecuted.message'),
-				type: 'warning',
-			});
+			if (!suppressToasts) {
+				toast.showMessage({
+					title: i18n.baseText('pushConnection.nodeNotExecuted'),
+					message: i18n.baseText('pushConnection.nodeNotExecuted.message'),
+					type: 'warning',
+				});
+			}
 		} else if (!successToastAlreadyShown) {
 			handleExecutionFinishedSuccessfully(
 				workflowName,
 				i18n.baseText('pushConnection.nodeExecutedSuccessfully'),
 				documentId,
+				suppressToasts,
 			);
 		}
 	} else if (!successToastAlreadyShown) {
@@ -471,6 +496,7 @@ export function handleExecutionFinishedWithSuccessOrOther(
 			workflowName,
 			i18n.baseText('pushConnection.workflowExecutedSuccessfully'),
 			documentId,
+			suppressToasts,
 		);
 	}
 

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionRecovered.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionRecovered.ts
@@ -15,7 +15,7 @@ export async function executionRecovered(
 	{ data }: ExecutionRecovered,
 	options: PushHandlerOptions,
 ) {
-	const { documentId } = options;
+	const { documentId, suppressExecutionSuccessToasts, suppressExecutionErrorToasts } = options;
 	const workflowExecutionStateStore = useWorkflowExecutionStateStore(documentId);
 	const uiStore = useUIStore();
 
@@ -40,9 +40,19 @@ export async function executionRecovered(
 	if (execution.data?.waitTill !== undefined) {
 		handleExecutionFinishedWithWaitTill(execution.workflowId ?? '', options);
 	} else if (execution.status === 'error' || execution.status === 'canceled') {
-		handleExecutionFinishedWithErrorOrCanceled(execution, runExecutionData, documentId);
+		handleExecutionFinishedWithErrorOrCanceled(
+			execution,
+			runExecutionData,
+			documentId,
+			suppressExecutionErrorToasts,
+		);
 	} else {
-		handleExecutionFinishedWithSuccessOrOther(documentId, execution.status, false);
+		handleExecutionFinishedWithSuccessOrOther(
+			documentId,
+			execution.status,
+			false,
+			suppressExecutionSuccessToasts,
+		);
 	}
 
 	setRunExecutionData(execution, runExecutionData, documentId);

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/types.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/types.ts
@@ -12,8 +12,14 @@ import type { WorkflowDocumentId } from '@/app/stores/workflowDocument.store';
  * - `router` is only needed by handlers that re-run or save the workflow
  *   (`useRunWorkflow` / `useWorkflowSaving`), which cannot call `useRouter()`
  *   from an async, non-setup context.
+ * - `suppressExecutionSuccessToasts` / `suppressExecutionErrorToasts` are `true`
+ *   when the editor host hides that class of workflow execution result toast —
+ *   resolved from the editor context at event time. Hosts like the Instance AI
+ *   preview set them so results surface only in their own UI.
  */
 export interface PushHandlerOptions {
 	router: Router;
 	documentId: WorkflowDocumentId;
+	suppressExecutionSuccessToasts?: boolean;
+	suppressExecutionErrorToasts?: boolean;
 }

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/usePushConnection.ts
@@ -25,12 +25,17 @@ import {
 } from '@/app/composables/usePushConnection/handlers';
 import type { PushHandlerOptions } from '@/app/composables/usePushConnection/handlers/types';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import { useEditorContext } from '@/app/composables/useEditorContext';
 import { createEventQueue } from '@n8n/utils/event-queue';
 import type { useRouter } from 'vue-router';
 
 export function usePushConnection({ router }: { router: ReturnType<typeof useRouter> }) {
 	const pushStore = usePushConnectionStore();
 	const workflowDocumentStore = injectWorkflowDocumentStore();
+	// Resolved once at setup (inject is only valid here); read per event below.
+	// A host can opt this editor out of success and/or error execution result
+	// toasts (e.g. the Instance AI preview, which shows results in its own UI).
+	const { executionSuccessToasts, executionErrorToasts } = useEditorContext();
 
 	const { enqueue } = createEventQueue<PushMessage>(processEvent);
 
@@ -57,6 +62,8 @@ export function usePushConnection({ router }: { router: ReturnType<typeof useRou
 		const options: PushHandlerOptions = {
 			router,
 			documentId: workflowDocumentStore.value.documentId,
+			suppressExecutionSuccessToasts: !executionSuccessToasts.value,
+			suppressExecutionErrorToasts: !executionErrorToasts.value,
 		};
 
 		switch (event.type) {

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
@@ -22,7 +22,7 @@ import {
 	BINARY_MODE_COMBINED,
 } from 'n8n-workflow';
 import { retry } from '@n8n/utils/retry';
-import { computed, type Ref } from 'vue';
+import { computed, getCurrentInstance, type Ref } from 'vue';
 
 import { useToast } from '@/app/composables/useToast';
 import { useNodeHelpers } from '@/app/composables/useNodeHelpers';
@@ -61,6 +61,7 @@ import { chatEventBus } from '@n8n/chat/event-buses';
 import { useAgentRequestStore } from '@n8n/stores/useAgentRequestStore';
 import { useWorkflowSaving } from './useWorkflowSaving';
 import { useDocumentTitle } from './useDocumentTitle';
+import { useEditorContext } from './useEditorContext';
 import { useChat } from '@n8n/chat/composables';
 import type { WorkflowObjectAccessors } from '../types';
 
@@ -92,6 +93,12 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 		useWorkflowExecutionStateStore(workflowDocumentStore.value.documentId),
 	);
 	const nodeHelpers = useNodeHelpers();
+
+	// Editor hosts (e.g. the Instance AI artifact preview) can suppress execution
+	// error toasts for their embedded editor. Resolved at setup; `inject` can't
+	// run in the async, non-setup callers (push handlers), so fall back to
+	// showing toasts when there is no active component instance.
+	const editorContext = getCurrentInstance() ? useEditorContext() : undefined;
 	const workflowSaving = useWorkflowSaving({
 		router: useRunWorkflowOpts.router,
 	});
@@ -468,7 +475,9 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 			console.error(error);
 			workflowExecutionState.value.setWorkflowExecutionData(null);
 			useDocumentTitle().setDocumentTitle(workflowDocumentStore.value.name, 'ERROR');
-			toast.showError(error, i18n.baseText('workflowRun.showError.title'));
+			if (editorContext?.executionErrorToasts.value !== false) {
+				toast.showError(error, i18n.baseText('workflowRun.showError.title'));
+			}
 			return undefined;
 		}
 	}

--- a/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
+++ b/packages/frontend/editor-ui/src/app/constants/injectionKeys.ts
@@ -43,11 +43,18 @@ export type EditorFeature = 'aiAssistant' | 'aiBuilder' | 'askAi';
  * (`false` = superseded/off; omitted or `true` falls back to the editor's own
  * gating, and a `true` can never grant a feature the instance disabled).
  * `readOnly` is a direct state flag — `true` forces the canvas read-only on top
- * of the editor's own gating. Provided by editor hosts that supersede
- * capabilities — e.g. the Instance AI preview.
+ * of the editor's own gating. `executionSuccessToasts` / `executionErrorToasts`
+ * are direct state flags too — both shown by default; an explicit `false`
+ * suppresses that class of workflow execution result toast for this editor
+ * (mirrors the old iframe `suppressNotifications` / `allowErrorNotifications`
+ * knobs, but scoped per editor instead of via the shared UI store). Hosts that
+ * surface results in their own UI — e.g. the Instance AI preview — set them.
+ * Provided by editor hosts that supersede capabilities.
  */
 export type EditorEnabledFeatures = Partial<Record<EditorFeature, boolean>> & {
 	readOnly?: boolean;
+	executionSuccessToasts?: boolean;
+	executionErrorToasts?: boolean;
 };
 export const EditorEnabledFeaturesKey: InjectionKey<Readonly<Ref<EditorEnabledFeatures>>> =
 	Symbol('EditorEnabledFeatures');

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiThreadView.vue
@@ -52,7 +52,7 @@ import CreditWarningBanner from '@/features/ai/assistant/components/Agent/Credit
 import InstanceAiWorkflowPreview, {
 	type WorkflowFailuresReport,
 } from './components/InstanceAiWorkflowPreview.vue';
-import { buildFixWithAiPrompt, IS_FIX_WITH_AI_OFFER_ENABLED } from './fixWithAi';
+import { buildFixWithAiPrompt } from './fixWithAi';
 import InstanceAiDataTablePreview from './components/InstanceAiDataTablePreview.vue';
 import { TabsRoot } from 'reka-ui';
 
@@ -100,7 +100,6 @@ const isChatInProgress = computed(
 );
 
 const activeFixWithAiOffer = computed(() => {
-	if (!IS_FIX_WITH_AI_OFFER_ENABLED) return null;
 	const run = failedRun.value;
 	if (!run) return null;
 	if (run.executionId === dismissedExecutionId.value) return null;
@@ -574,7 +573,6 @@ function dismissFixWithAiOffer() {
 }
 
 function handleWorkflowFailures(report: WorkflowFailuresReport) {
-	if (!IS_FIX_WITH_AI_OFFER_ENABLED) return;
 	failedRun.value = report;
 }
 </script>
@@ -700,18 +698,16 @@ function handleWorkflowFailures(report: WorkflowFailuresReport) {
 									 input slot below instead - see `hasFloatingConfirmation`. -->
 								<InstanceAiConfirmationPanel kind="inline" />
 
-								<template v-if="IS_FIX_WITH_AI_OFFER_ENABLED">
-									<Transition name="confirmation-slide">
-										<InstanceAiFixWithAiPanel
-											v-if="activeFixWithAiOffer"
-											:node-name="activeFixWithAiOffer.errors[0].nodeName"
-											:error-message="activeFixWithAiOffer.errors[0].errorMessage"
-											:failed-count="activeFixWithAiOffer.errors.length"
-											@fix-with-ai="handleFixWithAiFromOffer"
-											@dismiss="dismissFixWithAiOffer"
-										/>
-									</Transition>
-								</template>
+								<Transition name="confirmation-slide">
+									<InstanceAiFixWithAiPanel
+										v-if="activeFixWithAiOffer"
+										:node-name="activeFixWithAiOffer.errors[0].nodeName"
+										:error-message="activeFixWithAiOffer.errors[0].errorMessage"
+										:failed-count="activeFixWithAiOffer.errors.length"
+										@fix-with-ai="handleFixWithAiFromOffer"
+										@dismiss="dismissFixWithAiOffer"
+									/>
+								</Transition>
 								<!-- Live activity indicator. Sits at the very end of the
 									 conversation flow — below any pending questions/confirmations
 									 and not pinned above the input — so it trails the active

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiThreadView.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/__tests__/InstanceAiThreadView.test.ts
@@ -501,8 +501,7 @@ describe('InstanceAiThreadView', () => {
 		expect(getByTestId('instance-ai-artifacts-sidebar-slot')).toBeInTheDocument();
 	});
 
-	// Re-enable when IS_FIX_WITH_AI_OFFER_ENABLED is true (INS-407).
-	describe.skip('Fix with AI card', () => {
+	describe('Fix with AI card', () => {
 		const failureReport: WorkflowFailuresReport = {
 			workflowId: 'wf-1',
 			executionId: 'exec-1',

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowPreview.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowPreview.vue
@@ -1,16 +1,20 @@
 <script lang="ts" setup>
 import { computed, onBeforeUnmount, provide, useTemplateRef } from 'vue';
 import type { InstanceAiAgentNode } from '@n8n/api-types';
+import { nodeIssuesToString, type IRunData } from 'n8n-workflow';
 import WorkflowCanvasHost from '@/app/components/WorkflowCanvasHost.vue';
 import {
 	EditorEnabledFeaturesKey,
 	type EditorEnabledFeatures,
 } from '@/app/constants/injectionKeys';
 import { usePushConnectionStore } from '@/app/stores/pushConnection.store';
-import { createWorkflowDocumentId } from '@/app/stores/workflowDocument.store';
+import {
+	createWorkflowDocumentId,
+	useWorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
 import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
 import { createExecutionDataId, useExecutionDataStore } from '@/app/stores/executionData.store';
-import { IS_FIX_WITH_AI_OFFER_ENABLED, type FixWithAiError } from '../fixWithAi';
+import type { FixWithAiError } from '../fixWithAi';
 import { useThread } from '../instanceAi.store';
 
 export interface WorkflowFailuresReport {
@@ -67,8 +71,54 @@ const removeExecutionStartedListener = pushStore.addEventListener((event) => {
 
 // On executionFinished with errors, surface a structured failures report so
 // InstanceAiThreadView can offer "Fix with AI". This used to come via
-// postMessage from the iframe (useReportWorkflowFailuresToParent); now we
-// read the per-execution data store directly.
+// postMessage from the iframe (useReportWorkflowFailuresToParent); now we read
+// the per-execution data directly.
+
+function collectNodeErrors(runData: IRunData | null | undefined): FixWithAiError[] {
+	const errors: FixWithAiError[] = [];
+	for (const [nodeName, tasks] of Object.entries(runData ?? {})) {
+		const error = tasks?.at(-1)?.error;
+		if (!error) continue;
+		const description = error.description ? ` (${error.description})` : '';
+		errors.push({ nodeName, errorMessage: `${error.message ?? 'Unknown error'}${description}` });
+	}
+	return errors;
+}
+
+// A pre-execution validation abort ("The 'X' node has issues — Parameter Y
+// required") executes no nodes, so it leaves no live error. But the FE has
+// already validated the workflow with the same NodeHelpers the backend aborts
+// on, so the failing node's issues are already on the document store — read
+// them synchronously instead of round-tripping for the execution.
+function collectValidationIssues(workflowId: string): FixWithAiError[] {
+	const docStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+	const errors: FixWithAiError[] = [];
+	for (const node of docStore.allNodes) {
+		if (!node.issues) continue;
+		const messages = nodeIssuesToString(node.issues, node);
+		if (messages.length === 0) continue;
+		errors.push({ nodeName: node.name, errorMessage: messages.join(' ') });
+	}
+	return errors;
+}
+
+function reportWorkflowFailures(executionId: string, workflowId: string) {
+	// Node-level runtime errors stream into the store live during the run, so
+	// they're already present when it finishes.
+	const execStore = useExecutionDataStore(createExecutionDataId(executionId));
+	let errors = collectNodeErrors(execStore.executionRunData);
+
+	// A pre-execution validation abort runs no nodes, so there's no live error —
+	// but the FE has already validated the workflow, so read the failing node's
+	// issues straight from the document store (see collectValidationIssues).
+	if (errors.length === 0) {
+		errors = collectValidationIssues(workflowId);
+	}
+
+	if (errors.length === 0) return;
+	emit('workflow-failures', { workflowId, executionId, errors });
+}
+
 const removeExecutionFinishedListener = pushStore.addEventListener((event) => {
 	if (event.type !== 'executionFinished') return;
 	if (event.data.workflowId !== props.workflowId) return;
@@ -77,29 +127,7 @@ const removeExecutionFinishedListener = pushStore.addEventListener((event) => {
 	// workflow itself (source 'instance_ai'), it already sees the errors in its
 	// tool result and fixes them on its own.
 	if (event.data.source === 'instance_ai') return;
-
-	const execStore = useExecutionDataStore(createExecutionDataId(event.data.executionId));
-	const runData = execStore.executionRunData;
-	if (!runData) return;
-
-	const errors: FixWithAiError[] = [];
-	for (const [nodeName, tasks] of Object.entries(runData)) {
-		const error = tasks?.at(-1)?.error;
-		if (!error) continue;
-		const description = error.description ? ` (${error.description})` : '';
-		errors.push({
-			nodeName,
-			errorMessage: `${error.message ?? 'Unknown error'}${description}`,
-		});
-	}
-	if (errors.length === 0) return;
-	if (!IS_FIX_WITH_AI_OFFER_ENABLED) return;
-
-	emit('workflow-failures', {
-		workflowId: event.data.workflowId,
-		executionId: event.data.executionId,
-		errors,
-	});
+	reportWorkflowFailures(event.data.executionId, event.data.workflowId);
 });
 
 onBeforeUnmount(() => {
@@ -166,14 +194,19 @@ const isAgentEditingThisWorkflow = computed(() => {
 });
 
 // Per-editor host overrides for the embedded editor. Instance AI supersedes the
-// standalone AI helpers (`false`), and forces the canvas read-only while a
-// workflow-builder agent is mutating this workflow. NodeView derives its
-// read-only state from these via useEditorContext().
+// standalone AI helpers (`false`), forces the canvas read-only while a
+// workflow-builder agent is mutating this workflow, and suppresses workflow
+// execution result toasts (success + error) — the agent surfaces run outcomes
+// in the thread UI, so the canvas would only duplicate them. NodeView derives
+// its read-only state from these via useEditorContext(); usePushConnection
+// reads the toast flags to gate execution result notifications.
 const enabledFeatures = computed<EditorEnabledFeatures>(() => ({
 	aiAssistant: false,
 	aiBuilder: false,
 	askAi: false,
 	readOnly: isAgentEditingThisWorkflow.value,
+	executionSuccessToasts: false,
+	executionErrorToasts: false,
 }));
 provide(EditorEnabledFeaturesKey, enabledFeatures);
 </script>

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowPreview.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/components/InstanceAiWorkflowPreview.vue
@@ -122,7 +122,10 @@ function reportWorkflowFailures(executionId: string, workflowId: string) {
 const removeExecutionFinishedListener = pushStore.addEventListener((event) => {
 	if (event.type !== 'executionFinished') return;
 	if (event.data.workflowId !== props.workflowId) return;
-	if (event.data.status === 'success') return;
+	// Only genuine failures. Anything else — success, but also canceled — must
+	// not fall through to collectValidationIssues(), which would show a
+	// misleading Fix with AI card right after the user stopped a run.
+	if (event.data.status !== 'error' && event.data.status !== 'crashed') return;
 	// Only offer "Fix with AI" for human-initiated runs. When the agent ran the
 	// workflow itself (source 'instance_ai'), it already sees the errors in its
 	// tool result and fixes them on its own.

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/fixWithAi.ts
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/fixWithAi.ts
@@ -1,11 +1,5 @@
 import { useI18n } from '@n8n/i18n';
 
-/**
- * Temporary kill-switch for the execution-failure "Fix with AI" card in Instance AI.
- * Re-enable once agent vs user run gating is in place (INS-407).
- */
-export const IS_FIX_WITH_AI_OFFER_ENABLED = false;
-
 export interface FixWithAiError {
 	nodeName: string;
 	errorMessage: string;

--- a/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenu.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenu.test.ts
@@ -12,6 +12,7 @@ import { createPinia, setActivePinia } from 'pinia';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import { useFocusedNodesStore } from '@/features/ai/assistant/focusedNodes.store';
 import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
@@ -22,6 +23,23 @@ vi.mock('@/app/stores/workflowDocument.store', async (importOriginal) => ({
 	...(await importOriginal()),
 	injectWorkflowDocumentStore: vi.fn(),
 }));
+
+// useContextMenuItems resolves per-editor host overrides via inject, which is
+// unavailable in this non-component harness — stub it with mutable flags.
+const editorContextFlags = vi.hoisted(() => ({ aiAssistant: true, aiBuilder: true }));
+vi.mock('@/app/composables/useEditorContext', async () => {
+	const { computed } = await import('vue');
+	return {
+		useEditorContext: () => ({
+			aiAssistant: computed(() => editorContextFlags.aiAssistant),
+			aiBuilder: computed(() => editorContextFlags.aiBuilder),
+			askAi: computed(() => true),
+			readOnly: computed(() => false),
+			executionSuccessToasts: computed(() => true),
+			executionErrorToasts: computed(() => true),
+		}),
+	};
+});
 import {
 	EXECUTE_WORKFLOW_NODE_TYPE,
 	NodeConnectionTypes,
@@ -45,6 +63,7 @@ describe('useContextMenu', () => {
 	let uiStore: ReturnType<typeof useUIStore>;
 	let workflowsStore: ReturnType<typeof useWorkflowsStore>;
 	let workflowDocumentStore: ReturnType<typeof useWorkflowDocumentStore>;
+	let focusedNodesStore: ReturnType<typeof useFocusedNodesStore>;
 	const nodes = [nodeFactory(), nodeFactory(), nodeFactory()];
 	const selectedNodes = nodes.slice(0, 2);
 	const testWorkflowId = 'test-workflow-id';
@@ -58,6 +77,8 @@ describe('useContextMenu', () => {
 
 		uiStore = useUIStore();
 		vi.spyOn(uiStore, 'isReadOnlyView', 'get').mockReturnValue(false);
+
+		focusedNodesStore = useFocusedNodesStore();
 
 		workflowsStore = useWorkflowsStore();
 		workflowsStore.setWorkflowId(testWorkflowId);
@@ -76,6 +97,31 @@ describe('useContextMenu', () => {
 	});
 
 	const mockEvent = new MouseEvent('contextmenu', { clientX: 500, clientY: 300 });
+
+	describe('focus_ai_on_selected gating', () => {
+		beforeEach(() => {
+			editorContextFlags.aiAssistant = true;
+			editorContextFlags.aiBuilder = true;
+			vi.spyOn(focusedNodesStore, 'isFeatureEnabled', 'get').mockReturnValue(true);
+		});
+
+		it('shows "Focus AI on selected" when the focused-nodes feature is on and AI is available', () => {
+			const { open, actions } = useContextMenu();
+			open(mockEvent, { source: 'canvas', nodeIds: selectedNodes.map((n) => n.id) });
+
+			expect(actions.value.some((action) => action.id === 'focus_ai_on_selected')).toBe(true);
+		});
+
+		it('hides "Focus AI on selected" when the editor host disables AI', () => {
+			editorContextFlags.aiAssistant = false;
+			editorContextFlags.aiBuilder = false;
+
+			const { open, actions } = useContextMenu();
+			open(mockEvent, { source: 'canvas', nodeIds: selectedNodes.map((n) => n.id) });
+
+			expect(actions.value.some((action) => action.id === 'focus_ai_on_selected')).toBe(false);
+		});
+	});
 
 	it('should support opening and closing (default = right click on canvas)', () => {
 		const { open, close, isOpen, actions, position, target, targetNodeIds } = useContextMenu();

--- a/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenuItems.ts
+++ b/packages/frontend/editor-ui/src/features/shared/contextMenu/composables/useContextMenuItems.ts
@@ -6,7 +6,6 @@ import {
 } from '@/app/constants';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { useSourceControlStore } from '@/features/integrations/sourceControl.ee/sourceControl.store';
-import { useSettingsStore } from '@/app/stores/settings.store';
 import { useUIStore } from '@/app/stores/ui.store';
 import { useCollaborationStore } from '@/features/collaboration/collaboration/collaboration.store';
 import { useFocusedNodesStore } from '@/features/ai/assistant/focusedNodes.store';
@@ -16,6 +15,7 @@ import type { INode, INodeTypeDescription } from 'n8n-workflow';
 import { NodeHelpers, WEBHOOK_NODE_TYPE } from 'n8n-workflow';
 import { computed, type ComputedRef } from 'vue';
 import { isPresent } from '@/app/utils/typesUtils';
+import { useEditorContext } from '@/app/composables/useEditorContext';
 import { usePinnedData } from '@/app/composables/usePinnedData';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 
@@ -57,13 +57,17 @@ type Item = ActionDropdownItem<ContextMenuAction>;
 
 export function useContextMenuItems(targetNodeIds: ComputedRef<string[]>): ComputedRef<Item[]> {
 	const uiStore = useUIStore();
-	const settingsStore = useSettingsStore();
 	const nodeTypesStore = useNodeTypesStore();
 	const workflowDocumentStore = injectWorkflowDocumentStore();
 	const sourceControlStore = useSourceControlStore();
 	const collaborationStore = useCollaborationStore();
 	const focusedNodesStore = useFocusedNodesStore();
 	const i18n = useI18n();
+
+	// Per-editor host overrides (already ANDed with the instance-wide store
+	// flags) — e.g. the Instance AI artifact preview supersedes the AI
+	// capabilities of its embedded editor, which must hide the AI actions.
+	const { aiAssistant, aiBuilder } = useEditorContext();
 
 	const workflowPermissions = computed(
 		() => getResourcePermissions(workflowDocumentStore?.value?.scopes).workflow,
@@ -177,7 +181,7 @@ export function useContextMenuItems(targetNodeIds: ComputedRef<string[]>): Compu
 
 		const aiActions: Item[] = [
 			!onlyStickies &&
-				settingsStore.isAiAssistantOrBuilderEnabled &&
+				(aiAssistant.value || aiBuilder.value) &&
 				focusedNodesStore.isFeatureEnabled && {
 					id: 'focus_ai_on_selected',
 					divided: true,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.test.ts
@@ -1,14 +1,19 @@
+import { ref } from 'vue';
 import { screen, waitFor } from '@testing-library/vue';
 import userEvent from '@testing-library/user-event';
+import { createTestingPinia } from '@pinia/testing';
 import CanvasNodeToolbar from './CanvasNodeToolbar.vue';
 import { createComponentRenderer } from '@/__tests__/render';
-import { getTooltip, hoverTooltipTrigger } from '@/__tests__/utils';
+import { getTooltip, hoverTooltipTrigger, mockedStore } from '@/__tests__/utils';
 import {
 	createCanvasNodeProvide,
 	createCanvasProvide,
 } from '@/features/workflows/canvas/__tests__/utils';
 import { CanvasNodeRenderType } from '../../../canvas.types';
 import { createPinia, setActivePinia, type Pinia } from 'pinia';
+import { EditorEnabledFeaturesKey } from '@/app/constants/injectionKeys';
+import { useFocusedNodesStore } from '@/features/ai/assistant/focusedNodes.store';
+import { useSettingsStore } from '@/app/stores/settings.store';
 
 vi.mock('@/features/workflows/canvas/canvas.utils', async (importOriginal) => ({
 	...(await importOriginal<typeof import('@/features/workflows/canvas/canvas.utils')>()),
@@ -275,6 +280,51 @@ describe('CanvasNodeToolbar', () => {
 		await userEvent.hover(toolbar);
 
 		expect(toolbar).toHaveClass('forceVisible');
+	});
+
+	describe('Add to AI button', () => {
+		// The focused-nodes experiment and the instance-wide AI flags gate the
+		// button; enable both so only the per-editor host override varies.
+		const setupAiStores = () => {
+			const testingPinia = createTestingPinia();
+			setActivePinia(testingPinia);
+			mockedStore(useFocusedNodesStore).isFeatureEnabled = true;
+			mockedStore(useSettingsStore).isAiAssistantEnabled = true;
+			return testingPinia;
+		};
+
+		it('should show when the focused-nodes feature is on and no host restricts AI', () => {
+			const { getByTestId } = renderComponent({
+				pinia: setupAiStores(),
+				global: {
+					provide: {
+						...createCanvasNodeProvide(),
+						...createCanvasProvide(),
+					},
+				},
+			});
+
+			expect(getByTestId('add-to-ai-button')).toBeInTheDocument();
+		});
+
+		it('should hide when the editor host disables AI (per-editor override)', () => {
+			const { queryByTestId } = renderComponent({
+				pinia: setupAiStores(),
+				global: {
+					provide: {
+						...createCanvasNodeProvide(),
+						...createCanvasProvide(),
+						[EditorEnabledFeaturesKey]: ref({
+							aiAssistant: false,
+							aiBuilder: false,
+							askAi: false,
+						}),
+					},
+				},
+			});
+
+			expect(queryByTestId('add-to-ai-button')).not.toBeInTheDocument();
+		});
 	});
 
 	it('should have "forceVisible" class when sticky color picker is visible', async () => {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.vue
@@ -4,6 +4,7 @@ import { useI18n } from '@n8n/i18n';
 import { useCanvasNode } from '../../../composables/useCanvasNode';
 import { CanvasNodeRenderType } from '../../../canvas.types';
 import { useCanvas } from '../../../composables/useCanvas';
+import { useEditorContext } from '@/app/composables/useEditorContext';
 import { useNodeTypesStore } from '@/app/stores/nodeTypes.store';
 import { injectWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import { useExperimentalNdvStore } from '../../../experimental/experimentalNdv.store';
@@ -46,6 +47,10 @@ const nodeTypesStore = useNodeTypesStore();
 const experimentalNdvStore = useExperimentalNdvStore();
 const focusedNodesStore = useFocusedNodesStore();
 
+// Per-editor host overrides — e.g. the Instance AI artifact preview supersedes
+// the AI capabilities of its embedded editor, which must hide this entry point.
+const { aiAssistant, aiBuilder } = useEditorContext();
+
 const node = computed(() =>
 	name.value ? workflowDocumentStore?.value?.getNodeByName(name.value) : null,
 );
@@ -82,7 +87,12 @@ const isDeleteNodeVisible = computed(() => !props.readOnly);
 
 const isFocusNodeVisible = computed(() => experimentalNdvStore.isZoomedViewEnabled);
 
-const isAddToAiVisible = computed(() => !props.readOnly && focusedNodesStore.isFeatureEnabled);
+// Feeds the builder side panel, so mirror the context menu's
+// assistant-or-builder semantics on top of the focused-nodes experiment.
+const isAddToAiVisible = computed(
+	() =>
+		!props.readOnly && focusedNodesStore.isFeatureEnabled && (aiAssistant.value || aiBuilder.value),
+);
 
 const isStickyNoteChangeColorVisible = computed(
 	() => !props.readOnly && render.value.type === CanvasNodeRenderType.StickyNote,

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeChoicePrompt.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeChoicePrompt.test.ts
@@ -1,0 +1,75 @@
+import { computed, ref } from 'vue';
+import { createTestingPinia } from '@pinia/testing';
+import { setActivePinia } from 'pinia';
+import CanvasNodeChoicePrompt from './CanvasNodeChoicePrompt.vue';
+import { createComponentRenderer } from '@/__tests__/render';
+import { mockedStore } from '@/__tests__/utils';
+import { useSettingsStore } from '@/app/stores/settings.store';
+import { EditorEnabledFeaturesKey, WorkflowIdKey } from '@/app/constants/injectionKeys';
+
+vi.mock('vue-router', () => ({
+	useRouter: () => ({ push: vi.fn() }),
+	useRoute: () => ({ params: {}, name: '' }),
+	RouterLink: { template: '<a><slot /></a>' },
+}));
+
+vi.mock('@/experiments/utils', async (importOriginal) => ({
+	...(await importOriginal<typeof import('@/experiments/utils')>()),
+	isExtraTemplateLinksExperimentEnabled: () => false,
+}));
+
+const renderComponent = createComponentRenderer(CanvasNodeChoicePrompt, {
+	global: {
+		provide: {
+			[WorkflowIdKey]: computed(() => 'wf-1'),
+		},
+	},
+});
+
+describe('CanvasNodeChoicePrompt', () => {
+	const setupStores = ({ isAiBuilderEnabled }: { isAiBuilderEnabled: boolean }) => {
+		const testingPinia = createTestingPinia();
+		setActivePinia(testingPinia);
+		mockedStore(useSettingsStore).isAiBuilderEnabled = isAiBuilderEnabled;
+		return testingPinia;
+	};
+
+	it('shows the Build with AI option when the AI builder is available', () => {
+		const { getByTestId } = renderComponent({
+			pinia: setupStores({ isAiBuilderEnabled: true }),
+		});
+
+		expect(getByTestId('canvas-add-first-step-button')).toBeInTheDocument();
+		expect(getByTestId('canvas-build-with-ai-button')).toBeInTheDocument();
+	});
+
+	it('hides the Build with AI option when the editor host disables the AI builder', () => {
+		// NOTE: no `merge: true` — lodash merge drops Symbol keys, which would
+		// silently discard the EditorEnabledFeaturesKey provide. The default
+		// (spread) path preserves symbols and the renderer-level provide.
+		const { getByTestId, queryByTestId } = renderComponent({
+			pinia: setupStores({ isAiBuilderEnabled: true }),
+			global: {
+				provide: {
+					[EditorEnabledFeaturesKey]: ref({
+						aiAssistant: false,
+						aiBuilder: false,
+						askAi: false,
+					}),
+				},
+			},
+		});
+
+		expect(getByTestId('canvas-add-first-step-button')).toBeInTheDocument();
+		expect(queryByTestId('canvas-build-with-ai-button')).not.toBeInTheDocument();
+	});
+
+	it('hides the Build with AI option when the instance has the AI builder disabled', () => {
+		const { getByTestId, queryByTestId } = renderComponent({
+			pinia: setupStores({ isAiBuilderEnabled: false }),
+		});
+
+		expect(getByTestId('canvas-add-first-step-button')).toBeInTheDocument();
+		expect(queryByTestId('canvas-build-with-ai-button')).not.toBeInTheDocument();
+	});
+});

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeChoicePrompt.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeChoicePrompt.vue
@@ -14,6 +14,7 @@ import { computed } from 'vue';
 import { useRouter } from 'vue-router';
 import { N8nIcon, N8nLink } from '@n8n/design-system';
 import { useAssistantStore } from '@/features/ai/assistant/assistant.store';
+import { useEditorContext } from '@/app/composables/useEditorContext';
 import { useWorkflowId } from '@/app/composables/useWorkflowId';
 
 const nodeCreatorStore = useNodeCreatorStore();
@@ -28,6 +29,11 @@ const workflowId = useWorkflowId();
 const isChatWindowOpen = computed(
 	() => chatPanelStore.isOpen && chatPanelStore.isBuilderModeActive,
 );
+
+// AI builder availability: the instance-wide flag ANDed with any per-editor
+// host override — e.g. the Instance AI artifact preview supersedes the AI
+// capabilities of its embedded editor.
+const { aiBuilder } = useEditorContext();
 
 const templatesLinkEnabled = computed(() => {
 	return isExtraTemplateLinksExperimentEnabled() && settingsStore.isTemplatesEnabled;
@@ -97,26 +103,28 @@ async function onClickTemplatesLink() {
 			</p>
 		</div>
 
-		<!-- Or Divider -->
-		<div :class="$style.orDivider">
-			<span :class="$style.orText">{{ i18n.baseText('generic.or') }}</span>
-		</div>
-
-		<!-- Build with AI Button -->
-		<div :class="$style.option">
-			<div :class="[$style.selectedButtonHighlight, { [$style.highlighted]: isChatWindowOpen }]">
-				<button
-					:class="[$style.button]"
-					data-test-id="canvas-build-with-ai-button"
-					@mousedown.stop.prevent="onBuildWithAIClick"
-				>
-					<N8nIcon icon="wand-sparkles" color="foreground-xdark" :size="40" />
-				</button>
+		<template v-if="aiBuilder">
+			<!-- Or Divider -->
+			<div :class="$style.orDivider">
+				<span :class="$style.orText">{{ i18n.baseText('generic.or') }}</span>
 			</div>
-			<p :class="$style.label">
-				{{ i18n.baseText('aiAssistant.builder.canvasPrompt.buildWithAI') }}
-			</p>
-		</div>
+
+			<!-- Build with AI Button -->
+			<div :class="$style.option">
+				<div :class="[$style.selectedButtonHighlight, { [$style.highlighted]: isChatWindowOpen }]">
+					<button
+						:class="[$style.button]"
+						data-test-id="canvas-build-with-ai-button"
+						@mousedown.stop.prevent="onBuildWithAIClick"
+					>
+						<N8nIcon icon="wand-sparkles" color="foreground-xdark" :size="40" />
+					</button>
+				</div>
+				<p :class="$style.label">
+					{{ i18n.baseText('aiAssistant.builder.canvasPrompt.buildWithAI') }}
+				</p>
+			</div>
+		</template>
 	</div>
 </template>
 


### PR DESCRIPTION
## Summary

Follow-up to #31899 (per-editor capability overrides for the AI workflow preview). Three pieces:

**1. Editor hosts can suppress execution result toasts.**
Adds `executionSuccessToasts` / `executionErrorToasts` to the per-editor host overrides (`EditorEnabledFeaturesKey`) — the per-editor equivalent of the old iframe `suppressNotifications` / `allowErrorNotifications` knobs, which were a global UI-store flag and therefore can't be reused now that the artifact shares stores with the main editor. `usePushConnection` resolves the flags from `useEditorContext()` and threads them into the `executionFinished` / `executionRecovered` toast helpers; `useRunWorkflow` gates its run-rejection toast the same way (falling back to shown in non-setup callers where `inject` can't resolve). Only the `toast.showMessage` calls are gated — titles, stats and run-data handling keep running.

**2. The Instance AI artifact surfaces run failures via Fix with AI instead of toasts.**
- The artifact preview sets both toast overrides to `false`: the agent reports run outcomes in the thread UI, so editor toasts only duplicated them.
- Removes the `IS_FIX_WITH_AI_OFFER_ENABLED` kill-switch: the agent-vs-user run gating it was waiting for (`source === 'instance_ai'`, INS-407) is in place. The skipped "Fix with AI card" tests are re-enabled.
- Detects **pre-execution validation aborts** ("The 'X' node has issues — Parameter Y is required"), which run zero nodes and therefore leave no live node error to detect. The failing node's issues are read synchronously from the workflow document store using the same `nodeIssuesToString` the backend's `WorkflowHasIssuesError` is built from — no execution fetch, no global `workflows.store`.

**3. Canvas-level AI entry points honor the overrides.**
#31899 covered the NDV / node-creator / credential AI buttons but missed three canvas-level entry points, all reachable from the artifact preview, where they would open the legacy assistant/builder side panel on top of the Instance AI view:
- Canvas node toolbar **"Add to AI"** — now also requires the editor context's assistant-or-builder capability.
- Context menu **"Focus AI on selected"** — instance-wide `settingsStore.isAiAssistantOrBuilderEnabled` replaced with the editor-context equivalent (which already ANDs the store flags, so standalone editors are unchanged).
- Empty-canvas **"Build with AI"** — gated on the editor context's `aiBuilder`. ⚠️ Previously unconditional, so this also hides it in standalone editors when the instance has the AI builder disabled — believed correct, but it is a behavior change beyond the artifact view.

The new toolbar test provides `EditorEnabledFeaturesKey` for real (no mocks) to confirm `inject` reaches VueFlow-rendered node components.

## How to test

In an Instance AI thread that produced a workflow artifact, with the agent idle:
1. Run the workflow from the artifact canvas with a misconfigured node (e.g. required parameter empty) → no "Problem running workflow" toast; the **Fix with AI** card appears naming the failing node and issues.
2. Run a workflow that fails at runtime → no error toast; Fix with AI card appears. Successful run → no success toast.
3. Hover a node → no "Add to AI" toolbar button. Right-click a node → no "Focus AI on selected". Empty previewed workflow → no "Build with AI" option.
4. In a standalone editor (`/workflow/:id`), confirm toasts and all three AI entry points still behave as before (entry points shown when the focused-nodes experiment / AI flags are on).

Unit tests:
```bash
cd packages/frontend/editor-ui
pnpm vitest run \
  src/app/composables/usePushConnection \
  src/app/composables/useRunWorkflow.test.ts \
  src/features/ai/instanceAi/__tests__/InstanceAiThreadView.test.ts \
  src/features/workflows/canvas/components/elements/nodes/CanvasNodeToolbar.test.ts \
  src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeChoicePrompt.test.ts \
  src/features/shared/contextMenu/composables/useContextMenu.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

- Follow-up to #31899
- https://linear.app/n8n/issue/INS-407 (Fix with AI re-enable)
- Closes #31716

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI