### PR TITLE
refactor(core): Replace core ApplicationError throws

### DIFF
--- a/packages/core/src/credentials.ts
+++ b/packages/core/src/credentials.ts
@@ -1,7 +1,7 @@
 import { isObjectLiteral } from '@n8n/backend-common';
 import { Container } from '@n8n/di';
 import type { ICredentialDataDecryptedObject, ICredentialsEncrypted } from 'n8n-workflow';
-import { ApplicationError, ICredentials, jsonParse } from 'n8n-workflow';
+import { ApplicationError, ICredentials, jsonParse, UserError } from 'n8n-workflow';
 import * as a from 'node:assert';
 
 import { CREDENTIAL_ERRORS } from '@/constants';
@@ -71,7 +71,7 @@ export class Credentials<
 	 */
 	getDataToSave(): ICredentialsEncrypted {
 		if (this.data === undefined) {
-			throw new ApplicationError('No credentials were set to save.');
+			throw new UserError('No credentials were set to save.');
 		}
 
 		return {

--- a/packages/core/src/credentials.ts
+++ b/packages/core/src/credentials.ts
@@ -1,7 +1,7 @@
 import { isObjectLiteral } from '@n8n/backend-common';
 import { Container } from '@n8n/di';
 import type { ICredentialDataDecryptedObject, ICredentialsEncrypted } from 'n8n-workflow';
-import { ApplicationError, ICredentials, jsonParse, UserError } from 'n8n-workflow';
+import { ApplicationError, ICredentials, jsonParse, UnexpectedError } from 'n8n-workflow';
 import * as a from 'node:assert';
 
 import { CREDENTIAL_ERRORS } from '@/constants';
@@ -71,7 +71,7 @@ export class Credentials<
 	 */
 	getDataToSave(): ICredentialsEncrypted {
 		if (this.data === undefined) {
-			throw new UserError('No credentials were set to save.');
+			throw new UnexpectedError('No credentials were set to save.');
 		}
 
 		return {

--- a/packages/core/src/execution-engine/__tests__/triggers-and-pollers.test.ts
+++ b/packages/core/src/execution-engine/__tests__/triggers-and-pollers.test.ts
@@ -1,4 +1,4 @@
-import { ApplicationError } from '@n8n/errors';
+import { UnexpectedError } from 'n8n-workflow';
 import type {
 	Workflow,
 	INode,
@@ -49,7 +49,7 @@ describe('TriggersAndPollers', () => {
 			);
 
 		it('should throw error if node type does not have trigger function', async () => {
-			await expect(runTriggerHelper()).rejects.toThrow(ApplicationError);
+			await expect(runTriggerHelper()).rejects.toThrow(UnexpectedError);
 		});
 
 		it('should call trigger function in regular mode', async () => {
@@ -120,7 +120,7 @@ describe('TriggersAndPollers', () => {
 			await triggersAndPollers.runPollFunction(workflow, node, pollFunctions);
 
 		it('should throw error if node type does not have poll function', async () => {
-			await expect(runPollHelper()).rejects.toThrow(ApplicationError);
+			await expect(runPollHelper()).rejects.toThrow(UnexpectedError);
 		});
 
 		it('should call poll function and return result', async () => {

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-run-node.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-run-node.test.ts
@@ -532,7 +532,7 @@ describe('WorkflowExecute.runNode - Real Implementation', () => {
 			expect(closeFunction2).toHaveBeenCalled();
 		});
 
-		it('should throw ApplicationError when close function throws non-Error object', async () => {
+		it('should throw UnexpectedError when close function throws non-Error object', async () => {
 			const mockData = [[{ json: { result: 'test' } }]];
 			const closeFunction1 = vi.fn().mockResolvedValue(undefined);
 			const closeFunction2 = vi.fn().mockRejectedValue('String error'); // Non-Error object to trigger line 1247

--- a/packages/core/src/execution-engine/__tests__/workflow-execute-run-node.test.ts
+++ b/packages/core/src/execution-engine/__tests__/workflow-execute-run-node.test.ts
@@ -78,7 +78,13 @@ import type {
 	IWorkflowExecuteAdditionalData,
 	Workflow,
 } from 'n8n-workflow';
-import { NodeApiError, NodeOperationError, Node, createRunExecutionData } from 'n8n-workflow';
+import {
+	NodeApiError,
+	NodeOperationError,
+	Node,
+	createRunExecutionData,
+	UnexpectedError,
+} from 'n8n-workflow';
 import type { Mock, Mocked, MockedClass } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
@@ -565,16 +571,17 @@ describe('WorkflowExecute.runNode - Real Implementation', () => {
 				),
 			);
 
-			await expect(
-				workflowExecute.runNode(
-					mockWorkflow,
-					mockExecutionData,
-					mockRunExecutionData,
-					0,
-					mockAdditionalData,
-					'manual',
-				),
-			).rejects.toThrow("Error on execution node's close function(s)");
+			const promise = workflowExecute.runNode(
+				mockWorkflow,
+				mockExecutionData,
+				mockRunExecutionData,
+				0,
+				mockAdditionalData,
+				'manual',
+			);
+
+			await expect(promise).rejects.toThrow(UnexpectedError);
+			await expect(promise).rejects.toThrow("Error on execution node's close function(s)");
 
 			expect(closeFunction1).toHaveBeenCalled();
 			expect(closeFunction2).toHaveBeenCalled();

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/execute-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/execute-context.test.ts
@@ -13,7 +13,7 @@ import type {
 	ICredentialDataDecryptedObject,
 	WorkflowExpression,
 } from 'n8n-workflow';
-import { ApplicationError, ExpressionError, NodeConnectionTypes } from 'n8n-workflow';
+import { UnexpectedError, ExpressionError, NodeConnectionTypes } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import type { ExecutionLifecycleHooks } from '@/execution-engine/execution-lifecycle-hooks';
@@ -126,7 +126,7 @@ describe('ExecuteContext', () => {
 			const inputIndex = 2;
 
 			expect(() => executeContext.getInputData(inputIndex, connectionType)).toThrow(
-				ApplicationError,
+				UnexpectedError,
 			);
 		});
 
@@ -134,7 +134,7 @@ describe('ExecuteContext', () => {
 			inputData.main[inputIndex] = null;
 
 			expect(() => executeContext.getInputData(inputIndex, connectionType)).toThrow(
-				ApplicationError,
+				UnexpectedError,
 			);
 		});
 	});

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/execute-single-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/execute-single-context.test.ts
@@ -13,7 +13,7 @@ import type {
 	ICredentialDataDecryptedObject,
 	WorkflowExpression,
 } from 'n8n-workflow';
-import { ApplicationError, NodeConnectionTypes } from 'n8n-workflow';
+import { UnexpectedError, NodeConnectionTypes } from 'n8n-workflow';
 import { mock } from 'vitest-mock-extended';
 
 import { describeCommonTests } from './shared-tests';
@@ -118,7 +118,7 @@ describe('ExecuteSingleContext', () => {
 			const inputIndex = 1;
 
 			expect(() => executeSingleContext.getInputData(inputIndex, connectionType)).toThrow(
-				ApplicationError,
+				UnexpectedError,
 			);
 		});
 
@@ -126,7 +126,7 @@ describe('ExecuteSingleContext', () => {
 			inputData.main[inputIndex] = null;
 
 			expect(() => executeSingleContext.getInputData(inputIndex, connectionType)).toThrow(
-				ApplicationError,
+				UnexpectedError,
 			);
 		});
 
@@ -134,7 +134,7 @@ describe('ExecuteSingleContext', () => {
 			delete inputData.main[inputIndex]![itemIndex];
 
 			expect(() => executeSingleContext.getInputData(inputIndex, connectionType)).toThrow(
-				ApplicationError,
+				UnexpectedError,
 			);
 		});
 	});

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/hook-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/hook-context.test.ts
@@ -1,4 +1,4 @@
-import { ApplicationError } from '@n8n/errors';
+import { UnexpectedError } from 'n8n-workflow';
 import type {
 	ICredentialDataDecryptedObject,
 	ICredentialsHelper,
@@ -134,7 +134,7 @@ describe('HookContext', () => {
 				activation,
 			);
 
-			expect(() => hookContextWithoutWebhookData.getWebhookName()).toThrow(ApplicationError);
+			expect(() => hookContextWithoutWebhookData.getWebhookName()).toThrow(UnexpectedError);
 		});
 	});
 

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/shared-tests.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/shared-tests.ts
@@ -15,7 +15,7 @@ import type {
 	IExecuteWorkflowInfo,
 	IExecutionContext,
 } from 'n8n-workflow';
-import { ApplicationError, NodeHelpers, WAIT_INDEFINITELY } from 'n8n-workflow';
+import { UnexpectedError, NodeHelpers, WAIT_INDEFINITELY } from 'n8n-workflow';
 import { captor, mock, type MockProxy } from 'vitest-mock-extended';
 
 import { BinaryDataService } from '@/binary-data/binary-data.service';
@@ -210,7 +210,7 @@ export const describeCommonTests = (
 		it('should throw an error if the source data is missing', () => {
 			executeData.source = null;
 
-			expect(() => context.getInputSourceData()).toThrow(ApplicationError);
+			expect(() => context.getInputSourceData()).toThrow(UnexpectedError);
 		});
 	});
 

--- a/packages/core/src/execution-engine/node-execution-context/__tests__/supply-data-context.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/__tests__/supply-data-context.test.ts
@@ -16,7 +16,7 @@ import type {
 	WorkflowExpression,
 } from 'n8n-workflow';
 import {
-	ApplicationError,
+	UnexpectedError,
 	createRunExecutionData,
 	ManualExecutionCancelledError,
 	NodeConnectionTypes,
@@ -128,7 +128,7 @@ describe('SupplyDataContext', () => {
 			const inputIndex = 2;
 
 			expect(() => supplyDataContext.getInputData(inputIndex, connectionType)).toThrow(
-				ApplicationError,
+				UnexpectedError,
 			);
 		});
 
@@ -136,7 +136,7 @@ describe('SupplyDataContext', () => {
 			inputData.main[inputIndex] = null;
 
 			expect(() => supplyDataContext.getInputData(inputIndex, connectionType)).toThrow(
-				ApplicationError,
+				UnexpectedError,
 			);
 		});
 	});

--- a/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/base-execute-context.ts
@@ -26,7 +26,7 @@ import type {
 	IExecuteFunctions,
 } from 'n8n-workflow';
 import {
-	ApplicationError,
+	UnexpectedError,
 	OperationalError,
 	NodeHelpers,
 	NodeConnectionTypes,
@@ -187,14 +187,14 @@ export class BaseExecuteContext extends NodeExecutionContext {
 	protected getInputItems(inputIndex: number, connectionType: NodeConnectionType) {
 		const inputData = this.inputData[connectionType];
 		if (inputData.length < inputIndex) {
-			throw new ApplicationError('Could not get input with given index', {
+			throw new UnexpectedError('Could not get input with given index', {
 				extra: { inputIndex, connectionType },
 			});
 		}
 
 		const allItems = inputData[inputIndex] as INodeExecutionData[] | null | undefined;
 		if (allItems === null) {
-			throw new ApplicationError('Input index was not set', {
+			throw new UnexpectedError('Input index was not set', {
 				extra: { inputIndex, connectionType },
 			});
 		}
@@ -205,7 +205,7 @@ export class BaseExecuteContext extends NodeExecutionContext {
 	getInputSourceData(inputIndex = 0, connectionType = NodeConnectionTypes.Main): ISourceData {
 		if (this.executeData?.source === null) {
 			// Should never happen as n8n sets it automatically
-			throw new ApplicationError('Source data is missing');
+			throw new UnexpectedError('Source data is missing');
 		}
 		return this.executeData.source[connectionType][inputIndex]!;
 	}

--- a/packages/core/src/execution-engine/node-execution-context/execute-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/execute-context.ts
@@ -20,7 +20,7 @@ import type {
 	EngineResponse,
 } from 'n8n-workflow';
 import {
-	ApplicationError,
+	UnexpectedError,
 	createDeferredPromise,
 	jsonParse,
 	NodeConnectionTypes,
@@ -234,12 +234,12 @@ export class ExecuteContext extends BaseExecuteContext implements IExecuteFuncti
 
 	/** @deprecated use ISupplyDataFunctions.addInputData */
 	addInputData(): { index: number } {
-		throw new ApplicationError('addInputData should not be called on IExecuteFunctions');
+		throw new UnexpectedError('addInputData should not be called on IExecuteFunctions');
 	}
 
 	/** @deprecated use ISupplyDataFunctions.addOutputData */
 	addOutputData(): void {
-		throw new ApplicationError('addOutputData should not be called on IExecuteFunctions');
+		throw new UnexpectedError('addOutputData should not be called on IExecuteFunctions');
 	}
 
 	getParentCallbackManager(): CallbackManager | undefined {

--- a/packages/core/src/execution-engine/node-execution-context/execute-single-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/execute-single-context.ts
@@ -12,7 +12,7 @@ import type {
 	IExecuteData,
 	IDataObject,
 } from 'n8n-workflow';
-import { ApplicationError, createDeferredPromise, NodeConnectionTypes } from 'n8n-workflow';
+import { UnexpectedError, createDeferredPromise, NodeConnectionTypes } from 'n8n-workflow';
 
 import { BaseExecuteContext } from './base-execute-context';
 import {
@@ -104,7 +104,7 @@ export class ExecuteSingleContext extends BaseExecuteContext implements IExecute
 
 		const data = allItems?.[this.itemIndex];
 		if (data === undefined) {
-			throw new ApplicationError('Value of input with given index was not set', {
+			throw new UnexpectedError('Value of input with given index was not set', {
 				extra: { inputIndex, connectionType, itemIndex: this.itemIndex },
 			});
 		}

--- a/packages/core/src/execution-engine/node-execution-context/hook-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/hook-context.ts
@@ -1,4 +1,4 @@
-import { ApplicationError } from '@n8n/errors';
+import { UnexpectedError } from 'n8n-workflow';
 import type {
 	ICredentialDataDecryptedObject,
 	INode,
@@ -53,7 +53,7 @@ export class HookContext extends NodeExecutionContext implements IHookFunctions 
 
 	getWebhookName(): string {
 		if (this.webhookData === undefined) {
-			throw new ApplicationError('Only supported in webhook functions');
+			throw new UnexpectedError('Only supported in webhook functions');
 		}
 		return this.webhookData.webhookDescription.name;
 	}

--- a/packages/core/src/execution-engine/node-execution-context/node-execution-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/node-execution-context.ts
@@ -26,13 +26,13 @@ import type {
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
 import {
-	ApplicationError,
+	UnexpectedError,
 	CHAT_TRIGGER_NODE_TYPE,
 	deepCopy,
 	ExpressionError,
 	NodeHelpers,
 	NodeOperationError,
-	UnexpectedError,
+	UserError,
 } from 'n8n-workflow';
 
 import { FULL_ACCESS_NODE_TYPES, WAITING_TOKEN_QUERY_PARAM } from '@/constants';
@@ -68,7 +68,7 @@ export abstract class NodeExecutionContext implements Omit<FunctionsBase, 'getCr
 	@Memoized
 	get customData(): IWorkflowExecutionCustomData {
 		if (!this.runExecutionData) {
-			throw new ApplicationError(
+			throw new UnexpectedError(
 				'Cannot access customData: runExecutionData is not available in this context',
 			);
 		}
@@ -503,7 +503,7 @@ export abstract class NodeExecutionContext implements Omit<FunctionsBase, 'getCr
 		const value = get(node.parameters, parameterName, fallbackValue);
 
 		if (value === undefined) {
-			throw new ApplicationError(`Could not get parameter "${parameterName}"`, {
+			throw new UserError(`Could not get parameter "${parameterName}"`, {
 				extra: { parameterName },
 			});
 		}

--- a/packages/core/src/execution-engine/node-execution-context/poll-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/poll-context.ts
@@ -7,7 +7,7 @@ import type {
 	WorkflowActivateMode,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
-import { ApplicationError, createDeferredPromise } from 'n8n-workflow';
+import { UnexpectedError, createDeferredPromise } from 'n8n-workflow';
 
 import { NodeExecutionContext } from './node-execution-context';
 import { getBinaryHelperFunctions } from './utils/binary-helper-functions';
@@ -16,11 +16,11 @@ import { returnJsonArray } from './utils/return-json-array';
 import { getSchedulingFunctions } from './utils/scheduling-helper-functions';
 
 const throwOnEmit = () => {
-	throw new ApplicationError('Overwrite PollContext.__emit function');
+	throw new UnexpectedError('Overwrite PollContext.__emit function');
 };
 
 const throwOnEmitError = () => {
-	throw new ApplicationError('Overwrite PollContext.__emitError function');
+	throw new UnexpectedError('Overwrite PollContext.__emitError function');
 };
 
 export class PollContext extends NodeExecutionContext implements IPollFunctions {

--- a/packages/core/src/execution-engine/node-execution-context/trigger-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/trigger-context.ts
@@ -7,7 +7,7 @@ import type {
 	WorkflowActivateMode,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
-import { ApplicationError, createDeferredPromise } from 'n8n-workflow';
+import { UnexpectedError, createDeferredPromise } from 'n8n-workflow';
 
 import { NodeExecutionContext } from './node-execution-context';
 import { getBinaryHelperFunctions } from './utils/binary-helper-functions';
@@ -17,15 +17,15 @@ import { getSchedulingFunctions } from './utils/scheduling-helper-functions';
 import { getSSHTunnelFunctions } from './utils/ssh-tunnel-helper-functions';
 
 const throwOnEmit = () => {
-	throw new ApplicationError('Overwrite TriggerContext.emit function');
+	throw new UnexpectedError('Overwrite TriggerContext.emit function');
 };
 
 const throwOnEmitError = () => {
-	throw new ApplicationError('Overwrite TriggerContext.emitError function');
+	throw new UnexpectedError('Overwrite TriggerContext.emitError function');
 };
 
 const throwOnSaveFailedExecution = () => {
-	throw new ApplicationError('Overwrite TriggerContext.saveFailedExecution function');
+	throw new UnexpectedError('Overwrite TriggerContext.saveFailedExecution function');
 };
 
 export class TriggerContext extends NodeExecutionContext implements ITriggerFunctions {

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/normalize-items.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/normalize-items.test.ts
@@ -1,4 +1,4 @@
-import { ApplicationError } from '@n8n/errors';
+import { UserError } from 'n8n-workflow';
 import type { IBinaryData, INodeExecutionData } from 'n8n-workflow';
 
 import { normalizeItems } from '../normalize-items';
@@ -104,7 +104,7 @@ describe('normalizeItems', () => {
 			},
 		];
 		test.each(errorTests)('$description', ({ input }) => {
-			expect(() => normalizeItems(input)).toThrow(ApplicationError);
+			expect(() => normalizeItems(input)).toThrow(UserError);
 			expect(() => normalizeItems(input)).toThrow('Inconsistent item format');
 		});
 	});

--- a/packages/core/src/execution-engine/node-execution-context/utils/binary-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/binary-helper-functions.ts
@@ -17,7 +17,7 @@ import type {
 import {
 	NodeOperationError,
 	fileTypeFromMimeType,
-	ApplicationError,
+	UserError,
 	UnexpectedError,
 	isBinaryValue,
 	BINARY_MODE_COMBINED,
@@ -368,6 +368,6 @@ export const getBinaryHelperFunctions = (
 	setBinaryDataBuffer: async (data, binaryData) =>
 		await setBinaryDataBuffer(data, binaryData, workflowId, executionId!),
 	copyBinaryFile: async () => {
-		throw new ApplicationError('`copyBinaryFile` has been removed. Please upgrade this node.');
+		throw new UserError('`copyBinaryFile` has been removed. Please upgrade this node.');
 	},
 });

--- a/packages/core/src/execution-engine/node-execution-context/utils/extract-value.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/extract-value.ts
@@ -141,7 +141,7 @@ function extractValueFilter(
 	}
 
 	if (property.extractValue?.type) {
-		throw new UnexpectedError(
+		throw new UserError(
 			`Property "${parameterName}" has an invalid extractValue type. Filter parameters only support extractValue: true`,
 			{ extra: { parameter: parameterName } },
 		);

--- a/packages/core/src/execution-engine/node-execution-context/utils/extract-value.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/extract-value.ts
@@ -1,6 +1,7 @@
 import get from 'lodash/get';
 import {
-	ApplicationError,
+	UnexpectedError,
+	UserError,
 	LoggerProxy,
 	NodeHelpers,
 	NodeOperationError,
@@ -54,14 +55,14 @@ function findPropertyFromParameterName(
 			property = findProp(param, property.values);
 			currentParamPath += `.${param}`;
 		} else {
-			throw new ApplicationError('Could not find property', { extra: { parameterName } });
+			throw new UserError('Could not find property', { extra: { parameterName } });
 		}
 		if (!property) {
-			throw new ApplicationError('Could not find property', { extra: { parameterName } });
+			throw new UserError('Could not find property', { extra: { parameterName } });
 		}
 	}
 	if (!property) {
-		throw new ApplicationError('Could not find property', { extra: { parameterName } });
+		throw new UserError('Could not find property', { extra: { parameterName } });
 	}
 
 	return property;
@@ -114,14 +115,13 @@ function extractValueRLC(
 		LoggerProxy.error(
 			`Only strings can be passed to extractValue. Parameter "${parameterName}" passed "${typeName}"`,
 		);
-		throw new ApplicationError(
-			"ERROR: This parameter's value is invalid. Please enter a valid mode.",
-			{ extra: { parameter: property.displayName, modeProp: modeProp.displayName } },
-		);
+		throw new UserError("ERROR: This parameter's value is invalid. Please enter a valid mode.", {
+			extra: { parameter: property.displayName, modeProp: modeProp.displayName },
+		});
 	}
 
 	if (modeProp.extractValue.type !== 'regex') {
-		throw new ApplicationError('Property with unknown `extractValue`', {
+		throw new UnexpectedError('Property with unknown `extractValue`', {
 			extra: { parameter: parameterName, extractValueType: modeProp.extractValue.type },
 		});
 	}
@@ -141,7 +141,7 @@ function extractValueFilter(
 	}
 
 	if (property.extractValue?.type) {
-		throw new ApplicationError(
+		throw new UnexpectedError(
 			`Property "${parameterName}" has an invalid extractValue type. Filter parameters only support extractValue: true`,
 			{ extra: { parameter: parameterName } },
 		);
@@ -169,13 +169,13 @@ function extractValueOther(
 		LoggerProxy.error(
 			`Only strings can be passed to extractValue. Parameter "${parameterName}" passed "${typeName}"`,
 		);
-		throw new ApplicationError("This parameter's value is invalid", {
+		throw new UserError("This parameter's value is invalid", {
 			extra: { parameter: property.displayName },
 		});
 	}
 
 	if (property.extractValue.type !== 'regex') {
-		throw new ApplicationError('Property with unknown `extractValue`', {
+		throw new UnexpectedError('Property with unknown `extractValue`', {
 			extra: { parameter: parameterName, extractValueType: property.extractValue.type },
 		});
 	}

--- a/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/get-input-connection-data.ts
@@ -23,7 +23,7 @@ import type {
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
 import {
-	ApplicationError,
+	UnexpectedError,
 	ExecutionBaseError,
 	NodeConnectionTypes,
 	NodeOperationError,
@@ -486,7 +486,7 @@ export async function getInputConnectionData(
 				});
 				nodes.push(supplyData);
 			} else {
-				throw new ApplicationError('Node does not have a `supplyData` method defined', {
+				throw new UnexpectedError('Node does not have a `supplyData` method defined', {
 					extra: { nodeName: connectedNode.name },
 				});
 			}

--- a/packages/core/src/execution-engine/node-execution-context/utils/normalize-items.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/normalize-items.ts
@@ -1,4 +1,4 @@
-import { ApplicationError } from '@n8n/errors';
+import { UserError } from 'n8n-workflow';
 import type { INodeExecutionData, IDataObject } from 'n8n-workflow';
 
 /**
@@ -18,7 +18,7 @@ export function normalizeItems(
 		return executionData;
 
 	if (executionData.some((item) => typeof item === 'object' && 'json' in item)) {
-		throw new ApplicationError('Inconsistent item format');
+		throw new UserError('Inconsistent item format');
 	}
 
 	if (executionData.every((item) => typeof item === 'object' && 'binary' in item)) {
@@ -38,7 +38,7 @@ export function normalizeItems(
 	}
 
 	if (executionData.some((item) => typeof item === 'object' && 'binary' in item)) {
-		throw new ApplicationError('Inconsistent item format');
+		throw new UserError('Inconsistent item format');
 	}
 
 	return executionData.map((item) => {

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/__tests__/oauth.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/__tests__/oauth.test.ts
@@ -661,7 +661,7 @@ describe('requestOAuth2 - client credentials initial token fetch', () => {
 		);
 	});
 
-	test('should throw ApplicationError with clear message when token acquisition fails', async () => {
+	test('should throw OperationalError with clear message when token acquisition fails', async () => {
 		mockThis.getCredentials.mockResolvedValue({
 			clientId: 'client-id',
 			clientSecret: 'wrong-secret',

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/__tests__/oauth.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/__tests__/oauth.test.ts
@@ -1,5 +1,5 @@
 import type { IAllExecuteFunctions, INode, IWorkflowExecuteAdditionalData } from 'n8n-workflow';
-import { UserError } from 'n8n-workflow';
+import { OperationalError, UserError } from 'n8n-workflow';
 import nock from 'nock';
 import { mockDeep } from 'vitest-mock-extended';
 
@@ -680,17 +680,18 @@ describe('requestOAuth2 - client credentials initial token fetch', () => {
 				{ 'content-type': 'application/json' },
 			);
 
-		await expect(
-			requestOAuth2.call(
-				mockThis,
-				'testOAuth2',
-				{ method: 'GET', url: `${baseUrl}/data` },
-				mockNode,
-				mockAdditionalData,
-				undefined,
-				true,
-			),
-		).rejects.toThrow('Failed to acquire OAuth2 access token');
+		const promise = requestOAuth2.call(
+			mockThis,
+			'testOAuth2',
+			{ method: 'GET', url: `${baseUrl}/data` },
+			mockNode,
+			mockAdditionalData,
+			undefined,
+			true,
+		);
+
+		await expect(promise).rejects.toThrow(OperationalError);
+		await expect(promise).rejects.toThrow('Failed to acquire OAuth2 access token');
 	});
 });
 

--- a/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/oauth.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/request-helpers/oauth.ts
@@ -26,7 +26,7 @@ import type {
 	IWorkflowExecuteAdditionalData,
 	Logger as WorkflowLogger,
 } from 'n8n-workflow';
-import { ApplicationError, jsonParse, NodeOperationError } from 'n8n-workflow';
+import { OperationalError, jsonParse, NodeOperationError, UserError } from 'n8n-workflow';
 import type { Token } from 'oauth-1.0a';
 import clientOAuth1 from 'oauth-1.0a';
 
@@ -187,7 +187,7 @@ async function refreshOrFetchToken(ctx: RefreshOAuth2TokenContext): Promise<Clie
 	}
 
 	if (!node.credentials?.[credentialsType]) {
-		throw new ApplicationError('Node does not have credential type', {
+		throw new UserError('Node does not have credential type', {
 			extra: { nodeName: node.name, credentialType: credentialsType },
 		});
 	}
@@ -228,7 +228,7 @@ export async function requestOAuth2(
 
 	// Only the OAuth2 with authorization code grant needs connection
 	if (credentials.grantType === 'authorizationCode' && credentials.oauthTokenData === undefined) {
-		throw new ApplicationError('OAuth credentials not connected');
+		throw new UserError('OAuth credentials not connected');
 	}
 
 	const oAuthClient = createOAuth2Client(credentials);
@@ -246,14 +246,14 @@ export async function requestOAuth2(
 			tokenResult = await oAuthClient.credentials.getToken();
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
-			throw new ApplicationError(`Failed to acquire OAuth2 access token: ${message}`, {
+			throw new OperationalError(`Failed to acquire OAuth2 access token: ${message}`, {
 				cause: error,
 			});
 		}
 		const { data } = tokenResult;
 		// Find the credentials
 		if (!node.credentials?.[credentialsType]) {
-			throw new ApplicationError('Node does not have credential type', {
+			throw new UserError('Node does not have credential type', {
 				extra: { nodeName: node.name },
 				tags: { credentialType: credentialsType },
 			});
@@ -381,11 +381,11 @@ export async function requestOAuth1(
 	const credentials = await this.getCredentials(credentialsType);
 
 	if (credentials === undefined) {
-		throw new ApplicationError('No credentials were returned');
+		throw new UserError('No credentials were returned');
 	}
 
 	if (credentials.oauthTokenData === undefined) {
-		throw new ApplicationError('OAuth credentials not connected');
+		throw new UserError('OAuth credentials not connected');
 	}
 
 	const oauth = new clientOAuth1({
@@ -453,7 +453,7 @@ export async function refreshOAuth2Token(
 		credentialsType,
 	)) as unknown as OAuth2CredentialData;
 	if (credentials.grantType === 'authorizationCode' && credentials.oauthTokenData === undefined) {
-		throw new ApplicationError('OAuth credentials not connected');
+		throw new UserError('OAuth credentials not connected');
 	}
 
 	const oAuthClient = createOAuth2Client(credentials);

--- a/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
@@ -17,7 +17,7 @@ import type {
 	Workflow,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
-import { ApplicationError, createDeferredPromise, createEmptyRunExecutionData } from 'n8n-workflow';
+import { UnexpectedError, createDeferredPromise, createEmptyRunExecutionData } from 'n8n-workflow';
 
 import { NodeExecutionContext } from './node-execution-context';
 import { copyBinaryFile, getBinaryHelperFunctions } from './utils/binary-helper-functions';
@@ -105,7 +105,7 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 
 	getResponseObject(): Response {
 		if (this.additionalData.httpResponse === undefined) {
-			throw new ApplicationError('Response is missing');
+			throw new UnexpectedError('Response is missing');
 		}
 		return this.additionalData.httpResponse;
 	}
@@ -113,7 +113,7 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 	private assertHttpRequest() {
 		const { httpRequest } = this.additionalData;
 		if (httpRequest === undefined) {
-			throw new ApplicationError('Request is missing');
+			throw new UnexpectedError('Request is missing');
 		}
 		return httpRequest;
 	}
@@ -135,7 +135,7 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 
 	async validateCookieAuth(cookieValue: string): Promise<IUser> {
 		if (!this.additionalData.validateCookieAuth) {
-			throw new ApplicationError('Cookie auth validation is not available');
+			throw new UnexpectedError('Cookie auth validation is not available');
 		}
 		return await this.additionalData.validateCookieAuth(cookieValue);
 	}

--- a/packages/core/src/execution-engine/triggers-and-pollers.ts
+++ b/packages/core/src/execution-engine/triggers-and-pollers.ts
@@ -1,5 +1,5 @@
 import { Service } from '@n8n/di';
-import { ApplicationError } from '@n8n/errors';
+import { UnexpectedError } from 'n8n-workflow';
 import type {
 	Workflow,
 	INode,
@@ -36,7 +36,7 @@ export class TriggersAndPollers {
 		const nodeType = workflow.nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
 
 		if (!nodeType.trigger) {
-			throw new ApplicationError('Node type does not have a trigger function defined', {
+			throw new UnexpectedError('Node type does not have a trigger function defined', {
 				extra: { nodeName: node.name },
 				tags: { nodeType: node.type },
 			});
@@ -100,7 +100,7 @@ export class TriggersAndPollers {
 		const nodeType = workflow.nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
 
 		if (!nodeType.poll) {
-			throw new ApplicationError('Node type does not have a poll function defined', {
+			throw new UnexpectedError('Node type does not have a poll function defined', {
 				extra: { nodeName: node.name },
 				tags: { nodeType: node.type },
 			});

--- a/packages/core/src/execution-engine/workflow-execute.ts
+++ b/packages/core/src/execution-engine/workflow-execute.ts
@@ -140,7 +140,7 @@ export class WorkflowExecute {
 		startNode = startNode || workflow.getStartNode(destinationNode?.nodeName);
 
 		if (startNode === undefined) {
-			throw new ApplicationError('No node to start the workflow from could be found');
+			throw new UserError('No node to start the workflow from could be found');
 		}
 
 		// If a destination node is given we only run the direct parent nodes and no others
@@ -1076,7 +1076,7 @@ export class WorkflowExecute {
 						closingError =
 							closingErrors[0] instanceof Error
 								? closingErrors[0]
-								: new ApplicationError("Error on execution node's close function(s)", {
+								: new UnexpectedError("Error on execution node's close function(s)", {
 										extra: { nodeName: node.name },
 										tags: { nodeType: node.type },
 										cause: closingErrors,
@@ -1358,7 +1358,7 @@ export class WorkflowExecute {
 		}
 
 		if (nodeType.supplyData) {
-			throw new ApplicationError(
+			throw new UnexpectedError(
 				`The node "${node.type}" has a "supplyData" method but no "execute" method.`,
 			);
 		}
@@ -1679,9 +1679,7 @@ export class WorkflowExecute {
 
 					currentExecutionTry = `${executionNode.name}:${runIndex}`;
 					if (currentExecutionTry === lastExecutionTry) {
-						throw new ApplicationError(
-							'Stopped execution because it seems to be in an endless loop',
-						);
+						throw new UserError('Stopped execution because it seems to be in an endless loop');
 					}
 
 					if (
@@ -2168,7 +2166,7 @@ export class WorkflowExecute {
 									outputIndex
 								] ?? []) {
 									if (!Object.hasOwn(workflow.nodes, connectionData.node)) {
-										throw new ApplicationError('Destination node not found', {
+										throw new UnexpectedError('Destination node not found', {
 											extra: {
 												sourceNodeName: executionNode.name,
 												destinationNodeName: connectionData.node,

--- a/packages/core/src/instance-settings/instance-settings.ts
+++ b/packages/core/src/instance-settings/instance-settings.ts
@@ -4,7 +4,7 @@ import type { InstanceRole, InstanceType } from '@n8n/constants';
 import { Memoized } from '@n8n/decorators';
 import { Service } from '@n8n/di';
 import { createHash, randomBytes } from 'crypto';
-import { ApplicationError, jsonParse, ALPHABET, toResult } from 'n8n-workflow';
+import { UserError, jsonParse, ALPHABET, toResult } from 'n8n-workflow';
 import { customAlphabet } from 'nanoid';
 import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
@@ -271,7 +271,7 @@ export class InstanceSettings {
 			const { encryptionKey, tunnelSubdomain, fsStorageMigrated } = settings;
 
 			if (encryptionKeyFromEnv && encryptionKey !== encryptionKeyFromEnv) {
-				throw new ApplicationError(
+				throw new UserError(
 					`Mismatching encryption keys. The encryption key in the settings file ${this.settingsFile} does not match the N8N_ENCRYPTION_KEY env var. Please make sure both keys match. More information: https://docs.n8n.io/hosting/environment-variables/configuration-methods/#encryption-key`,
 				);
 			}

--- a/packages/core/src/nodes-loader/directory-loader.ts
+++ b/packages/core/src/nodes-loader/directory-loader.ts
@@ -17,7 +17,7 @@ import type {
 	KnownNodesAndCredentials,
 	NodeLoader,
 } from 'n8n-workflow';
-import { ApplicationError, isExpression, isSubNodeType, UnexpectedError } from 'n8n-workflow';
+import { isExpression, isSubNodeType, UnexpectedError, UserError } from 'n8n-workflow';
 import { realpathSync } from 'node:fs';
 import * as path from 'path';
 
@@ -154,10 +154,9 @@ export abstract class DirectoryLoader implements NodeLoader {
 			return loadClassInIsolation<T>(filePath, className);
 		} catch (error) {
 			throw error instanceof TypeError
-				? new ApplicationError(
-						'Class could not be found. Please check if the class is named correctly.',
-						{ extra: { className } },
-					)
+				? new UserError('Class could not be found. Please check if the class is named correctly.', {
+						extra: { className },
+					})
 				: error;
 		}
 	}
@@ -196,7 +195,7 @@ export abstract class DirectoryLoader implements NodeLoader {
 			nodeVersion = tempNode.currentVersion;
 
 			if (currentVersionNode.hasOwnProperty('executeSingle')) {
-				throw new ApplicationError(
+				throw new UserError(
 					'"executeSingle" has been removed. Please update the code of this node to use "execute" instead.',
 					{ extra: { nodeType } },
 				);

--- a/packages/core/src/nodes-loader/package-directory-loader.ts
+++ b/packages/core/src/nodes-loader/package-directory-loader.ts
@@ -1,4 +1,4 @@
-import { ApplicationError, jsonParse } from 'n8n-workflow';
+import { UserError, jsonParse } from 'n8n-workflow';
 import { readFileSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 
@@ -87,7 +87,7 @@ export class PackageDirectoryLoader extends DirectoryLoader {
 		try {
 			return jsonParse<T>(fileString);
 		} catch (error) {
-			throw new ApplicationError('Failed to parse JSON', { extra: { filePath } });
+			throw new UserError('Failed to parse JSON', { extra: { filePath } });
 		}
 	}
 

--- a/packages/core/src/nodes-loader/package-directory-loader.ts
+++ b/packages/core/src/nodes-loader/package-directory-loader.ts
@@ -87,7 +87,7 @@ export class PackageDirectoryLoader extends DirectoryLoader {
 		try {
 			return jsonParse<T>(fileString);
 		} catch (error) {
-			throw new UserError('Failed to parse JSON', { extra: { filePath } });
+			throw new UserError('Failed to parse JSON', { cause: error, extra: { filePath } });
 		}
 	}
 


### PR DESCRIPTION
### Motivation

- [x] I have seen this code, I have run this code, and I take responsibility for this code.

- Replace deprecated `ApplicationError` usage across `packages/core/src` to use `UserError`, `OperationalError`, and `UnexpectedError` following the CAT-3245 decision guide. 
- Map failures to appropriate semantics: bad user/config input → `UserError`, transient network/HTTP/db issues → `OperationalError`, and invariant/should-never-happen branches → `UnexpectedError`.

### Description

- Replaced `throw new ApplicationError(...)` with `UserError`, `OperationalError`, or `UnexpectedError` in core runtime files and helpers, and updated corresponding imports. 
- Key files changed include `extract-value.ts`, `request-helpers/oauth.ts`, `workflow-execute.ts`, node execution contexts (`base-execute-context.ts`, `execute-context.ts`, `execute-single-context.ts`, `hook-context.ts`, `poll-context.ts`, `trigger-context.ts`), node loader helpers, binary helpers, and related utilities (28 files touched). 
- Updated unit tests to assert the new error classes where behaviour semantics changed. 
- Ensured (search-verified) there are no remaining non-test `throw new ApplicationError(...)` occurrences under `packages/core/src`.

### Testing

- Built helper packages with `pnpm --filter @n8n/eslint-config build` and `pnpm --filter @n8n/vitest-config build`, both completed successfully. 
- Ran TypeScript checks with `pnpm typecheck` in `packages/core`, which succeeded. 
- Ran `eslint` over the changed files (`pnpm exec eslint --quiet <changed files>`), which passed for the modified fileset. 
- Executed the targeted unit test selection with `pnpm test` for the affected suites (e.g. `src/execution-engine/__tests__/triggers-and-pollers.test.ts`, `src/execution-engine/node-execution-context/__tests__/execute-single-context.test.ts`, `src/execution-engine/node-execution-context/__tests__/execute-context.test.ts`, `src/execution-engine/node-execution-context/__tests__/supply-data-context.test.ts`, `src/execution-engine/node-execution-context/__tests__/hook-context.test.ts`, `src/execution-engine/node-execution-context/utils/__tests__/normalize-items.test.ts`, `src/execution-engine/node-execution-context/utils/request-helpers/__tests__/oauth.test.ts`, `src/execution-engine/__tests__/workflow-execute-run-node.test.ts`), and those targeted suites passed. 
- A full package-wide `pnpm test` run encountered environment-sensitive failures (proxy/SSRF related tests) and was terminated; these failures are not regressions introduced by this change and are due to test-environment network/proxy constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2902dd5a5c832e87972ead412f742e)