### PR TITLE
fix: Computer use disconnect status on client stop

### DIFF
--- a/packages/@n8n/computer-use/src/cli.ts
+++ b/packages/@n8n/computer-use/src/cli.ts
@@ -215,11 +215,14 @@ async function main(
 		confirmResourceAccess: makeConfirmResourceAccess(parsed.nonInteractive, parsed.autoConfirm),
 	});
 
+	let shutdownPromise: Promise<void> | null = null;
 	const shutdown = () => {
-		logger.info('Shutting down');
-		void Promise.all([client.disconnect(), session.flush()]).finally(() => {
-			process.exit(0);
-		});
+		shutdownPromise ??= (async () => {
+			logger.info('Shutting down');
+			await Promise.all([client.disconnect(), session.flush()]).finally(() => {
+				process.exit(0);
+			});
+		})();
 	};
 	process.on('SIGINT', shutdown);
 	process.on('SIGTERM', shutdown);

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.controller.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.controller.test.ts
@@ -1002,6 +1002,72 @@ describe('InstanceAiController', () => {
 
 			expect(gatewayService.clearDisconnectTimer).toHaveBeenCalledWith(USER_ID);
 		});
+
+		describe('connection cleanup', () => {
+			const unsubscribeRequest = jest.fn();
+			const unsubscribeDisconnect = jest.fn();
+
+			/** Open the SSE stream and return the handlers registered on res events. */
+			const openStream = async () => {
+				gatewayService.getUserIdForApiKey.mockReturnValue(USER_ID);
+				const gateway = mock<LocalGateway>({ isConnected: true });
+				gateway.onRequest.mockReturnValue(unsubscribeRequest);
+				gateway.onDisconnect.mockReturnValue(unsubscribeDisconnect);
+				gatewayService.getLocalGateway.mockReturnValue(gateway);
+
+				const res = makeFlushableRes();
+				await controller.gatewayEvents(makeGatewayReq('session-key'), res);
+
+				const handlerFor = (event: string) =>
+					(res.once as jest.Mock).mock.calls.find(([name]) => name === event)?.[1] as
+						| (() => void)
+						| undefined;
+				return { onClose: handlerFor('close'), onFinish: handlerFor('finish') };
+			};
+
+			it("should start the disconnect grace timer on res 'close'", async () => {
+				// Client-drop detection must hang off res 'close' — req 'close' tracks the
+				// request message (already complete for a GET) and res 'finish' only fires
+				// on server-initiated end, so neither fires when the daemon dies.
+				const { onClose } = await openStream();
+				expect(onClose).toBeDefined();
+
+				onClose!();
+
+				expect(gatewayService.startDisconnectTimer).toHaveBeenCalledWith(
+					USER_ID,
+					expect.any(Function),
+				);
+				expect(unsubscribeRequest).toHaveBeenCalledTimes(1);
+				expect(unsubscribeDisconnect).toHaveBeenCalledTimes(1);
+			});
+
+			it('should push disconnected state when the grace timer fires', async () => {
+				const { onClose } = await openStream();
+
+				onClose!();
+				const [, onTimerFired] = gatewayService.startDisconnectTimer.mock.calls[0];
+				onTimerFired();
+
+				expect(push.sendToUsers).toHaveBeenCalledWith(
+					{
+						type: 'instanceAiGatewayStateChanged',
+						data: { connected: false, directory: null, hostIdentifier: null, toolCategories: [] },
+					},
+					[USER_ID],
+				);
+			});
+
+			it("should run cleanup only once when both 'close' and 'finish' fire", async () => {
+				const { onClose, onFinish } = await openStream();
+
+				onClose!();
+				onFinish!();
+
+				expect(gatewayService.startDisconnectTimer).toHaveBeenCalledTimes(1);
+				expect(unsubscribeRequest).toHaveBeenCalledTimes(1);
+			});
+		});
 	});
 
 	describe('gatewayResponse', () => {

--- a/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.controller.ts
@@ -714,7 +714,7 @@ export class InstanceAiController {
 				);
 			});
 		};
-		req.once('close', cleanup);
+		res.once('close', cleanup);
 		res.once('finish', cleanup);
 	}
 


### PR DESCRIPTION
## Summary

Fixes the Computer Use status in AI Assistant when Computer Use is stopped/disconnected client side. Addresses two bugs:
- Race condition in computer-use shutdown: when running through `npx xxx` the `SIGINT` handler is fired twice, this leads to a race condition
  - the shutdown handler is executed twice, `client.disconnect` stores a disconnected flag before calling the disconnect endpoint. on second execution of the shutdown handler if the promise is resolved before the first run completes the http disconnect, the shutdown request will not reach the server
- `req.once('close',...)` in AI Assistant is never fired when the socket is closed, so it's basically dead code

Reference
`res` `close` event: https://nodejs.org/api/http.html#event-close-2
> "Indicates that the response is completed, or its underlying connection was terminated prematurely (before the response completion)."

`req` `close` event: https://nodejs.org/api/http.html#event-close-3

> "Emitted when the request has been completed."

For the long-running events request the req.close is never fired

## How to test

### Fast test
1. run the fixed branch locally
2. connect computer-use, confirm that it is connected in AI Assistant
3. stop computer-use via `cmd+c`
4. observe that the `disconnected` message is printed in terminal where computer-use was run
5. observe that the status is `disconnected` in AI Assistant

### Long test

The problem is fixed in two places: client and server. Run currently released `computer-use` via `npx` with a currently released cloud instance to reproduce the problem (due to the race condition it could work correctly or not, so try multiple times)

Run fixed n8n version with `npx @n8n/computer-use xxx` or fixed local `computer-use` with a cloud instance to confirm that the disconnect is fired reliably in both cases.


## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-4986/i-shut-down-cli-manually-but-instance-ai-connection-status-still-shows


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
