### PR TITLE
fix(core): Stabilize public API test logging (no-changelog)

### DIFF
--- a/packages/cli/src/public-api/index.ts
+++ b/packages/cli/src/public-api/index.ts
@@ -77,18 +77,19 @@ function createLazyValidatorMiddleware(
 					'express-openapi-validator'
 				);
 
+				const authStrategyRegistry = Container.get(AuthStrategyRegistry);
+				const eventService = Container.get(EventService);
+				const lastActiveAtService = Container.get(LastActiveAtService);
+				const logger = Container.get(Logger);
+
 				const authenticate = async (req: AuthenticatedRequest) => {
-					const authenticated = await Container.get(AuthStrategyRegistry).authenticate(req);
+					const authenticated = await authStrategyRegistry.authenticate(req);
 
 					if (authenticated) {
-						Container.get(LastActiveAtService)
-							.updateLastActiveIfStale(req.user.id)
-							.catch((error: unknown) => {
-								Container.get(Logger).error('Failed to update last active timestamp', {
-									error,
-								});
-							});
-						Container.get(EventService).emit('public-api-invoked', {
+						lastActiveAtService.updateLastActiveIfStale(req.user.id).catch((error: unknown) => {
+							logger.error('Failed to update last active timestamp', { error });
+						});
+						eventService.emit('public-api-invoked', {
 							userId: req.user.id,
 							path: req.path,
 							method: req.method,

--- a/packages/cli/test/integration/shared/utils/test-server.ts
+++ b/packages/cli/test/integration/shared/utils/test-server.ts
@@ -1,4 +1,4 @@
-import { LicenseState, ModuleRegistry } from '@n8n/backend-common';
+import { LicenseState, Logger, ModuleRegistry } from '@n8n/backend-common';
 import { mockInstance, mockLogger, testModules, testDb } from '@n8n/backend-test-utils';
 import { GlobalConfig } from '@n8n/config';
 import type { APIRequest, User } from '@n8n/db';
@@ -110,7 +110,7 @@ export const setupTestServer = ({
 	});
 
 	// Mock all telemetry and logging
-	mockLogger();
+	Container.set(Logger, mockLogger());
 	mockInstance(PostHogClient);
 	mockInstance(Push);
 	mockInstance(Telemetry);


### PR DESCRIPTION
## Summary

Stabilizes public API integration-test teardown by resolving the auth registry, event service, last-active service, and logger when the lazy validator middleware initializes, so late async logging does not resolve services from a reset DI container. Registers the shared integration test server logger mock in DI instead of creating an unused mock.

## How to test

- `pnpm test:integration -- test/integration/dynamic-credentials.ee/my-connection.api.test.ts --runInBand`
- `pnpm test:integration -- test/integration/public-api/discover.test.ts --runInBand`
- `JEST_WORKER_IDLE_MEMORY_LIMIT='' pnpm test:integration -- test/integration/public-api/discover.test.ts test/integration/dynamic-credentials.ee/my-connection.api.test.ts --runInBand`
- `pnpm typecheck`
- `pnpm exec eslint src/public-api/index.ts test/integration/shared/utils/test-server.ts --quiet`

## Related Linear tickets, Github issues, and Community forum posts

N/A

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI