### PR TITLE
feat: Remember last instance URL and add settings sign-out in the desktop app (no-changelog)

### DIFF
--- a/packages/@n8n/local-gateway/src/main/instance-api.test.ts
+++ b/packages/@n8n/local-gateway/src/main/instance-api.test.ts
@@ -21,6 +21,7 @@ function makeOAuth(opts: { instanceUrl?: string | null; token?: string | null } 
 		getStatus: () => ({
 			state: 'signedIn',
 			instanceUrl: opts.instanceUrl === undefined ? 'https://n.example' : opts.instanceUrl,
+			lastInstanceUrl: null,
 			error: null,
 		}),
 		getValidAccessToken: vi.fn().mockResolvedValue(opts.token === undefined ? 'tok' : opts.token),

--- a/packages/@n8n/local-gateway/src/main/oauth/oauth-flow.test.ts
+++ b/packages/@n8n/local-gateway/src/main/oauth/oauth-flow.test.ts
@@ -1,0 +1,125 @@
+vi.mock('@n8n/computer-use/logger', () => ({
+	logger: {
+		debug: vi.fn(),
+		warn: vi.fn(),
+		error: vi.fn(),
+	},
+}));
+
+vi.mock('./oauth-client', async () => {
+	const actual = await vi.importActual<typeof oauthClientModule>('./oauth-client');
+	return {
+		...actual,
+		discover: vi.fn(),
+		exchangeCode: vi.fn(),
+		refreshTokens: vi.fn(),
+		buildAuthorizeUrl: vi.fn(() => 'https://auth.example/authorize'),
+	};
+});
+
+import type * as oauthClientModule from './oauth-client';
+import { buildAuthorizeUrl, discover, exchangeCode } from './oauth-client';
+import { OAuthFlow } from './oauth-flow';
+import type { PersistedSession, TokenStore } from './token-store';
+
+const METADATA = {
+	authorization_endpoint: 'https://auth.example/authorize',
+	token_endpoint: 'https://auth.example/token',
+};
+
+/** In-memory TokenStore double mirroring the real keep-lastInstanceUrl-on-clear semantics. */
+function makeStore(initialLastInstanceUrl: string | null = null): TokenStore {
+	let session: PersistedSession | null = null;
+	let lastInstanceUrl = initialLastInstanceUrl;
+	return {
+		getSession: () => session,
+		setSession: (next: PersistedSession) => {
+			session = next;
+		},
+		clearSession: () => {
+			session = null;
+		},
+		getLastInstanceUrl: () => lastInstanceUrl,
+		setLastInstanceUrl: (url: string) => {
+			lastInstanceUrl = url;
+		},
+	} as unknown as TokenStore;
+}
+
+function makeFlow(store: TokenStore): OAuthFlow {
+	return new OAuthFlow({ store, openExternal: vi.fn().mockResolvedValue(undefined) });
+}
+
+/** Run the browser round-trip: signIn, then the deep-link callback with the matching state. */
+async function completeSignIn(flow: OAuthFlow, instanceUrl: string): Promise<void> {
+	vi.mocked(discover).mockResolvedValue(METADATA);
+	vi.mocked(exchangeCode).mockResolvedValue({ access_token: 'token', expires_in: 3600 });
+
+	await flow.signIn(instanceUrl);
+	const [, authorizeParams] = vi.mocked(buildAuthorizeUrl).mock.calls.at(-1)!;
+	await flow.handleCallback({ code: 'auth-code', state: authorizeParams.state });
+}
+
+describe('OAuthFlow lastInstanceUrl', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('remembers the instance URL after a successful sign-in', async () => {
+		const store = makeStore();
+		const flow = makeFlow(store);
+
+		await completeSignIn(flow, 'https://workspace.app.n8n.cloud');
+
+		expect(store.getLastInstanceUrl()).toBe('https://workspace.app.n8n.cloud');
+		expect(flow.getStatus()).toEqual({
+			state: 'signedIn',
+			instanceUrl: 'https://workspace.app.n8n.cloud',
+			lastInstanceUrl: 'https://workspace.app.n8n.cloud',
+			error: null,
+		});
+	});
+
+	it('keeps the remembered URL in the signedOut status after sign-out', async () => {
+		const store = makeStore();
+		const flow = makeFlow(store);
+		await completeSignIn(flow, 'https://workspace.app.n8n.cloud');
+
+		const emitted = vi.fn();
+		flow.on('authStatusChanged', emitted);
+		flow.signOut();
+
+		expect(store.getSession()).toBeNull();
+		expect(emitted).toHaveBeenCalledWith({
+			state: 'signedOut',
+			instanceUrl: null,
+			lastInstanceUrl: 'https://workspace.app.n8n.cloud',
+			error: null,
+		});
+	});
+
+	it('does not overwrite the remembered URL when authorization fails', async () => {
+		const store = makeStore('https://old.example');
+		const flow = makeFlow(store);
+		vi.mocked(discover).mockRejectedValue(new Error('discovery failed'));
+
+		await expect(flow.signIn('https://new.example')).rejects.toThrow('discovery failed');
+
+		expect(store.getLastInstanceUrl()).toBe('https://old.example');
+		expect(flow.getStatus()).toMatchObject({
+			state: 'error',
+			lastInstanceUrl: 'https://old.example',
+		});
+	});
+
+	it('exposes the remembered URL on startup without a session', () => {
+		const flow = makeFlow(makeStore('https://workspace.app.n8n.cloud'));
+
+		expect(flow.getStatus()).toEqual({
+			state: 'signedOut',
+			instanceUrl: null,
+			lastInstanceUrl: 'https://workspace.app.n8n.cloud',
+			error: null,
+		});
+	});
+});

--- a/packages/@n8n/local-gateway/src/main/oauth/oauth-flow.ts
+++ b/packages/@n8n/local-gateway/src/main/oauth/oauth-flow.ts
@@ -57,9 +57,11 @@ export class OAuthFlow extends EventEmitter<OAuthFlowEvents> {
 		this.now = deps.now ?? (() => Date.now());
 
 		const session = this.store.getSession();
-		this.status = session
-			? { state: 'signedIn', instanceUrl: session.instanceUrl, error: null }
-			: { state: 'signedOut', instanceUrl: null, error: null };
+		this.status = this.withLastInstanceUrl(
+			session
+				? { state: 'signedIn', instanceUrl: session.instanceUrl, error: null }
+				: { state: 'signedOut', instanceUrl: null, error: null },
+		);
 	}
 
 	getStatus(): AuthStatus {
@@ -165,6 +167,8 @@ export class OAuthFlow extends EventEmitter<OAuthFlowEvents> {
 			refreshToken: tokens.refresh_token ?? previousRefreshToken,
 			expiresAt: tokens.expires_in ? this.now() + tokens.expires_in * 1000 : undefined,
 		});
+		// Remembered separately from the session so it survives sign-out and prefills the form.
+		this.store.setLastInstanceUrl(instanceUrl);
 	}
 
 	private failAuthorization(error: unknown): void {
@@ -174,9 +178,14 @@ export class OAuthFlow extends EventEmitter<OAuthFlowEvents> {
 		this.setStatus({ state: 'error', instanceUrl: this.status.instanceUrl, error: message });
 	}
 
-	private setStatus(status: AuthStatus): void {
-		this.status = status;
-		this.emit('authStatusChanged', status);
+	private setStatus(status: Omit<AuthStatus, 'lastInstanceUrl'>): void {
+		this.status = this.withLastInstanceUrl(status);
+		this.emit('authStatusChanged', this.status);
+	}
+
+	/** Every emitted status carries the remembered URL, read fresh in case `persist` just updated it. */
+	private withLastInstanceUrl(status: Omit<AuthStatus, 'lastInstanceUrl'>): AuthStatus {
+		return { ...status, lastInstanceUrl: this.store.getLastInstanceUrl() };
 	}
 }
 

--- a/packages/@n8n/local-gateway/src/main/oauth/token-store.test.ts
+++ b/packages/@n8n/local-gateway/src/main/oauth/token-store.test.ts
@@ -1,0 +1,57 @@
+vi.mock('electron', () => ({
+	safeStorage: {
+		isEncryptionAvailable: vi.fn((): boolean => false),
+	},
+}));
+
+// Explicit factory rather than an auto-mock: auto-mocking imports the real `electron-store`,
+// which transitively loads the real `electron` runtime.
+vi.mock('electron-store', () => ({
+	default: vi.fn(),
+}));
+
+import Store from 'electron-store';
+import type { MockedClass } from 'vitest';
+
+import { TokenStore } from './token-store';
+
+const MockStore = Store as MockedClass<typeof Store>;
+
+describe('TokenStore', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		// `new Store(...)` in source: the implementation must be constructable, so use a
+		// regular function rather than an arrow (Vitest does `new impl()`).
+		MockStore.mockImplementation(function () {
+			const data: Record<string, unknown> = {};
+			return {
+				get: (key: string) => data[key],
+				set: (key: string, val: unknown) => {
+					data[key] = val;
+				},
+				delete: (key: string) => {
+					delete data[key];
+				},
+			} as unknown as InstanceType<typeof Store>;
+		});
+	});
+
+	it('round-trips lastInstanceUrl', () => {
+		const store = new TokenStore();
+		expect(store.getLastInstanceUrl()).toBeNull();
+
+		store.setLastInstanceUrl('https://workspace.app.n8n.cloud');
+		expect(store.getLastInstanceUrl()).toBe('https://workspace.app.n8n.cloud');
+	});
+
+	it('keeps lastInstanceUrl when the session is cleared', () => {
+		const store = new TokenStore();
+		store.setSession({ instanceUrl: 'https://workspace.app.n8n.cloud', accessToken: 'token' });
+		store.setLastInstanceUrl('https://workspace.app.n8n.cloud');
+
+		store.clearSession();
+
+		expect(store.getSession()).toBeNull();
+		expect(store.getLastInstanceUrl()).toBe('https://workspace.app.n8n.cloud');
+	});
+});

--- a/packages/@n8n/local-gateway/src/main/oauth/token-store.ts
+++ b/packages/@n8n/local-gateway/src/main/oauth/token-store.ts
@@ -13,6 +13,8 @@ export interface PersistedSession {
 interface OAuthStoreSchema {
 	/** The active session, JSON-serialized and (when available) safeStorage-encrypted. */
 	session?: string;
+	/** Last successfully signed-in instance URL. Plaintext: it's not a secret, and it must outlive the session. */
+	lastInstanceUrl?: string;
 }
 
 /**
@@ -37,8 +39,17 @@ export class TokenStore {
 		this.store.set('session', encrypt(JSON.stringify(session)));
 	}
 
+	/** Deliberately keeps `lastInstanceUrl`, so the sign-in form can prefill after sign-out. */
 	clearSession(): void {
 		this.store.delete('session');
+	}
+
+	getLastInstanceUrl(): string | null {
+		return this.store.get('lastInstanceUrl') ?? null;
+	}
+
+	setLastInstanceUrl(instanceUrl: string): void {
+		this.store.set('lastInstanceUrl', instanceUrl);
 	}
 }
 

--- a/packages/@n8n/local-gateway/src/renderer/App.vue
+++ b/packages/@n8n/local-gateway/src/renderer/App.vue
@@ -7,7 +7,12 @@ import SignInView from './views/SignInView.vue';
 
 import type { AuthStatus } from '../shared/types';
 
-const auth = ref<AuthStatus>({ state: 'signedOut', instanceUrl: null, error: null });
+const auth = ref<AuthStatus>({
+	state: 'signedOut',
+	instanceUrl: null,
+	lastInstanceUrl: null,
+	error: null,
+});
 
 onMounted(async () => {
 	// Subscribe before fetching the initial status so a transition emitted while we await can't slip

--- a/packages/@n8n/local-gateway/src/renderer/App.vue
+++ b/packages/@n8n/local-gateway/src/renderer/App.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
-import { onMounted, ref } from 'vue';
+import { onMounted, ref, watch } from 'vue';
 
 import AppHeader from './components/AppHeader.vue';
 import HomeView from './views/HomeView.vue';
+import SettingsView from './views/SettingsView.vue';
 import SignInView from './views/SignInView.vue';
 
 import type { AuthStatus } from '../shared/types';
@@ -25,13 +26,27 @@ onMounted(async () => {
 	const initial = await window.electronAPI.getAuthStatus();
 	if (!receivedEvent) auth.value = initial;
 });
+
+const showSettings = ref(false);
+
+// Leaving the signed-in state (sign-out, token expiry) always lands on the sign-in
+// view; reset so settings isn't unexpectedly open again after the next sign-in.
+watch(
+	() => auth.value.state,
+	(state) => {
+		if (state !== 'signedIn') showSettings.value = false;
+	},
+);
 </script>
 
 <template>
 	<div :class="$style.app">
-		<AppHeader :state="auth.state" />
+		<AppHeader :state="auth.state" @open-settings="showSettings = !showSettings" />
 		<div :class="$style.content">
-			<HomeView v-if="auth.state === 'signedIn'" />
+			<template v-if="auth.state === 'signedIn'">
+				<SettingsView v-if="showSettings" :status="auth" @close="showSettings = false" />
+				<HomeView v-else />
+			</template>
 			<SignInView v-else :status="auth" />
 		</div>
 	</div>

--- a/packages/@n8n/local-gateway/src/renderer/components/AppHeader.vue
+++ b/packages/@n8n/local-gateway/src/renderer/components/AppHeader.vue
@@ -37,6 +37,7 @@ const STATUS_CLASS: Record<AuthState, string> = {
 				<N8nText size="small" color="text-light">{{ STATUS_LABEL[state] }}</N8nText>
 			</span>
 			<N8nIconButton
+				v-if="state === 'signedIn'"
 				icon="settings"
 				variant="ghost"
 				size="small"

--- a/packages/@n8n/local-gateway/src/renderer/components/AppHeader.vue
+++ b/packages/@n8n/local-gateway/src/renderer/components/AppHeader.vue
@@ -7,6 +7,8 @@ import type { AuthState } from '../../shared/types';
 // connection once that is wired up.
 defineProps<{ state: AuthState }>();
 
+const emit = defineEmits<{ openSettings: [] }>();
+
 const STATUS_LABEL: Record<AuthState, string> = {
 	signedIn: 'Connected',
 	authorizing: 'Connecting…',
@@ -34,7 +36,14 @@ const STATUS_CLASS: Record<AuthState, string> = {
 				<span :class="[$style.dot, $style[STATUS_CLASS[state]]]" />
 				<N8nText size="small" color="text-light">{{ STATUS_LABEL[state] }}</N8nText>
 			</span>
-			<N8nIconButton icon="settings" variant="ghost" size="small" aria-label="Settings" />
+			<N8nIconButton
+				icon="settings"
+				variant="ghost"
+				size="small"
+				aria-label="Settings"
+				data-testid="header-settings"
+				@click="emit('openSettings')"
+			/>
 		</div>
 	</header>
 </template>

--- a/packages/@n8n/local-gateway/src/renderer/views/SettingsView.vue
+++ b/packages/@n8n/local-gateway/src/renderer/views/SettingsView.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { N8nButton, N8nHeading, N8nIconButton, N8nText } from '@n8n/design-system';
+import { ref } from 'vue';
+
+import type { AuthStatus } from '../../shared/types';
+
+defineProps<{ status: AuthStatus }>();
+
+const emit = defineEmits<{ close: [] }>();
+
+const signingOut = ref(false);
+
+async function signOut() {
+	if (signingOut.value) return;
+	signingOut.value = true;
+	try {
+		// The resulting signedOut status arrives via onAuthStatusChanged and swaps the view.
+		await window.electronAPI.signOut();
+	} finally {
+		signingOut.value = false;
+	}
+}
+</script>
+
+<template>
+	<main :class="$style.container">
+		<div :class="$style.titleRow">
+			<N8nIconButton
+				icon="arrow-left"
+				variant="ghost"
+				size="small"
+				aria-label="Back"
+				data-testid="settings-back"
+				@click="emit('close')"
+			/>
+			<N8nHeading tag="h1" size="large" bold>Settings</N8nHeading>
+		</div>
+
+		<section :class="$style.section" aria-labelledby="settings-account-heading">
+			<N8nHeading id="settings-account-heading" tag="h2" size="small" bold>Account</N8nHeading>
+			<div :class="$style.row">
+				<div :class="$style.rowText">
+					<N8nText>Signed in</N8nText>
+					<N8nText v-if="status.instanceUrl" size="small" color="text-light">
+						{{ status.instanceUrl }}
+					</N8nText>
+				</div>
+				<N8nButton
+					variant="outline"
+					:loading="signingOut"
+					data-testid="settings-sign-out"
+					@click="signOut"
+				>
+					Sign out
+				</N8nButton>
+			</div>
+		</section>
+	</main>
+</template>
+
+<style module>
+.container {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--lg);
+	padding: var(--spacing--md) var(--spacing--md) var(--spacing--xl);
+}
+
+.titleRow {
+	display: flex;
+	align-items: center;
+	gap: var(--spacing--2xs);
+}
+
+.section {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--xs);
+}
+
+.row {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: var(--spacing--sm);
+	padding: var(--spacing--xs) var(--spacing--sm);
+	border: 1px solid var(--da-border);
+	border-radius: var(--da-radius);
+}
+
+.rowText {
+	display: flex;
+	flex-direction: column;
+	min-width: 0;
+}
+
+.rowText > * {
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+</style>

--- a/packages/@n8n/local-gateway/src/renderer/views/SignInView.vue
+++ b/packages/@n8n/local-gateway/src/renderer/views/SignInView.vue
@@ -1,17 +1,32 @@
 <script setup lang="ts">
 import { N8nButton, N8nHeading, N8nInput, N8nText } from '@n8n/design-system';
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 
+import { CLOUD_SUFFIX, toSignInPrefill } from './sign-in-prefill';
 import type { AuthStatus } from '../../shared/types';
 
 const props = defineProps<{ status: AuthStatus }>();
-
-const CLOUD_SUFFIX = '.app.n8n.cloud';
 
 const useCustomUrl = ref(false);
 const slug = ref('');
 const customUrl = ref('');
 const submitting = ref(false);
+
+// Prefill from the last signed-in instance. A watcher rather than initial ref values:
+// the initial auth status is fetched async, so the remembered URL can arrive after
+// mount. Never clobber anything the user has already typed.
+watch(
+	() => props.status.lastInstanceUrl,
+	(lastInstanceUrl) => {
+		if (slug.value || customUrl.value) return;
+		const prefill = toSignInPrefill(lastInstanceUrl);
+		if (!prefill) return;
+		useCustomUrl.value = prefill.kind === 'custom';
+		if (prefill.kind === 'cloud') slug.value = prefill.slug;
+		else customUrl.value = prefill.url;
+	},
+	{ immediate: true },
+);
 
 /** The fully-qualified instance URL, composed from whichever input mode is active. */
 const instanceUrl = computed(() =>

--- a/packages/@n8n/local-gateway/src/renderer/views/sign-in-prefill.test.ts
+++ b/packages/@n8n/local-gateway/src/renderer/views/sign-in-prefill.test.ts
@@ -1,0 +1,44 @@
+// Explicit vitest imports: the renderer tsconfig deliberately has `types: []`,
+// so the vitest globals are not ambiently typed here.
+import { describe, expect, it } from 'vitest';
+
+import { toSignInPrefill } from './sign-in-prefill';
+
+describe('toSignInPrefill', () => {
+	it('returns null when no URL is remembered', () => {
+		expect(toSignInPrefill(null)).toBeNull();
+		expect(toSignInPrefill('')).toBeNull();
+	});
+
+	it('extracts the slug from a cloud instance URL', () => {
+		expect(toSignInPrefill('https://my-workspace.app.n8n.cloud')).toEqual({
+			kind: 'cloud',
+			slug: 'my-workspace',
+		});
+	});
+
+	it('returns a self-hosted URL as custom', () => {
+		expect(toSignInPrefill('https://n8n.example.com')).toEqual({
+			kind: 'custom',
+			url: 'https://n8n.example.com',
+		});
+	});
+
+	it('treats lookalike URLs that do not fit the slug field as custom', () => {
+		// Nested subdomain: the slug input only holds a single label.
+		expect(toSignInPrefill('https://a.b.app.n8n.cloud')).toEqual({
+			kind: 'custom',
+			url: 'https://a.b.app.n8n.cloud',
+		});
+		// Plain http never composes back from the cloud field (it hardcodes https).
+		expect(toSignInPrefill('http://my.app.n8n.cloud')).toEqual({
+			kind: 'custom',
+			url: 'http://my.app.n8n.cloud',
+		});
+		// Suffix-only URL would leave an empty slug.
+		expect(toSignInPrefill('https://.app.n8n.cloud')).toEqual({
+			kind: 'custom',
+			url: 'https://.app.n8n.cloud',
+		});
+	});
+});

--- a/packages/@n8n/local-gateway/src/renderer/views/sign-in-prefill.ts
+++ b/packages/@n8n/local-gateway/src/renderer/views/sign-in-prefill.ts
@@ -1,0 +1,19 @@
+export const CLOUD_SUFFIX = '.app.n8n.cloud';
+
+const HTTPS_PREFIX = 'https://';
+
+export type SignInPrefill = { kind: 'cloud'; slug: string } | { kind: 'custom'; url: string };
+
+/**
+ * Decompose a remembered instance URL into the sign-in form's two input modes:
+ * a bare cloud slug when the URL is exactly `https://<slug>.app.n8n.cloud`,
+ * the full URL in custom mode otherwise.
+ */
+export function toSignInPrefill(instanceUrl: string | null): SignInPrefill | null {
+	if (!instanceUrl) return null;
+	if (instanceUrl.startsWith(HTTPS_PREFIX) && instanceUrl.endsWith(CLOUD_SUFFIX)) {
+		const slug = instanceUrl.slice(HTTPS_PREFIX.length, -CLOUD_SUFFIX.length);
+		if (slug && !slug.includes('.') && !slug.includes('/')) return { kind: 'cloud', slug };
+	}
+	return { kind: 'custom', url: instanceUrl };
+}

--- a/packages/@n8n/local-gateway/src/shared/types.ts
+++ b/packages/@n8n/local-gateway/src/shared/types.ts
@@ -71,6 +71,8 @@ export interface AuthStatus {
 	state: AuthState;
 	/** The instance the user is signing in to / signed in to, when known. */
 	instanceUrl: string | null;
+	/** The last successfully signed-in instance URL; survives sign-out and app relaunch. */
+	lastInstanceUrl: string | null;
 	/** Human-readable error, set when `state === 'error'`. */
 	error: string | null;
 }


### PR DESCRIPTION
## Summary

- The desktop app now remembers the last successfully signed-in instance URL and prefills the sign-in form after sign-out. Cloud URLs (`https://<slug>.app.n8n.cloud`) prefill the slug field; anything else prefills custom-URL mode. The URL is stored in the oauth electron-store outside the encrypted session, so it survives sign-out and app relaunch. It is only written on successful token exchange, so failed attempts never overwrite it.
- Adds a Settings view, opened from the existing header gear, with an Account section showing the connected instance and a **Sign out** button. Sign-out was previously not reachable from the UI.

<img width="445" height="648" alt="image" src="https://github.com/user-attachments/assets/980eeb0f-737c-4e21-9d84-b842f255f350" />

## How to test

1. `pnpm --filter @n8n/local-gateway build && pnpm --filter @n8n/local-gateway start`
2. Sign in to an instance (cloud slug or custom URL).
3. Open Settings via the header gear → **Sign out**.
4. The sign-in form comes back with the slug/URL prefilled.
5. Quit and relaunch the app: still prefilled. Typing before the status loads is never clobbered.

Unit tests cover the token store (URL survives `clearSession`), the OAuth flow (persist on success, keep on sign-out, no overwrite on failed auth, exposed on startup), and the URL decomposition edge cases.

## Related Linear tickets, Github issues, and Community forum posts

Hackmation project work on the desktop assistant (no ticket).

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.
