### PR TITLE
fix(editor): Agent builder progress log lines visual glitches

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderProgress.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderProgress.test.ts
@@ -1,0 +1,151 @@
+import { waitFor } from '@testing-library/vue';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { AgentSseEvent } from '@n8n/api-types';
+
+import { createComponentRenderer } from '@/__tests__/render';
+
+import AgentBuilderProgress from '../components/AgentBuilderProgress.vue';
+
+vi.mock('@n8n/stores/useRootStore', () => ({
+	useRootStore: () => ({ restApiContext: { baseUrl: 'http://localhost:5678' } }),
+}));
+
+vi.mock('@n8n/i18n', () => {
+	const i18n = { baseText: (key: string) => key };
+	return { useI18n: () => i18n, i18n, i18nInstance: { install: vi.fn() } };
+});
+
+/** Build a `Response` whose body streams the given events as SSE `data:` lines. */
+function makeSseResponse(events: AgentSseEvent[]): Response {
+	const encoder = new TextEncoder();
+	const stream = new ReadableStream<Uint8Array>({
+		start(controller) {
+			for (const ev of events) {
+				controller.enqueue(encoder.encode(`data: ${JSON.stringify(ev)}\n\n`));
+			}
+			controller.close();
+		},
+	});
+	return new Response(stream, {
+		status: 200,
+		headers: { 'Content-Type': 'text/event-stream' },
+	});
+}
+
+/** Build a `Response` whose SSE body is fed manually via the returned `push`/`close`. */
+function makeControlledSseResponse() {
+	const encoder = new TextEncoder();
+	let controller!: ReadableStreamDefaultController<Uint8Array>;
+	const stream = new ReadableStream<Uint8Array>({
+		start(c) {
+			controller = c;
+		},
+	});
+	return {
+		response: new Response(stream, {
+			status: 200,
+			headers: { 'Content-Type': 'text/event-stream' },
+		}),
+		push(ev: AgentSseEvent) {
+			controller.enqueue(encoder.encode(`data: ${JSON.stringify(ev)}\n\n`));
+		},
+		close() {
+			controller.close();
+		},
+	};
+}
+
+/** Each `tool-call` event pushes exactly one `→ Tool N` line into the log. */
+function toolCallEvents(count: number): AgentSseEvent[] {
+	return Array.from({ length: count }, (_, i) => ({
+		type: 'tool-call' as const,
+		toolCallId: `tc-${i}`,
+		toolName: `tool_${i}`,
+		input: {},
+	}));
+}
+
+const renderComponent = createComponentRenderer(AgentBuilderProgress, {
+	props: { projectId: 'p1', agentId: 'a1', initialMessage: 'build me an agent' },
+});
+
+const getLogBox = (container: Element) => container.querySelector('[aria-live="polite"]');
+
+describe('AgentBuilderProgress — log box top fade', () => {
+	let originalFetch: typeof fetch;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		vi.restoreAllMocks();
+	});
+
+	it('keeps the first log line fully visible (no top fade) while no lines have been dropped', async () => {
+		// 7 lines = MAX_LINES exactly — at capacity but nothing dropped yet
+		globalThis.fetch = vi.fn(async () =>
+			makeSseResponse([...toolCallEvents(7), { type: 'done' }]),
+		) as typeof fetch;
+
+		const { container, emitted } = renderComponent();
+		await waitFor(() => expect(emitted()).toHaveProperty('done'));
+
+		const logBox = getLogBox(container);
+		expect(logBox).not.toBeNull();
+		expect(logBox?.querySelectorAll('.line')).toHaveLength(7);
+		expect(logBox?.className).toContain('logBox');
+		expect(logBox?.className).not.toContain('logBoxFaded');
+	});
+
+	it('applies the top fade once older lines are dropped from the log', async () => {
+		// 9 lines > MAX_LINES — the two oldest get dropped
+		globalThis.fetch = vi.fn(async () =>
+			makeSseResponse([...toolCallEvents(9), { type: 'done' }]),
+		) as typeof fetch;
+
+		const { container, emitted } = renderComponent();
+		await waitFor(() => expect(emitted()).toHaveProperty('done'));
+
+		const logBox = getLogBox(container);
+		expect(logBox).not.toBeNull();
+		await waitFor(() => expect(logBox?.querySelectorAll('.line')).toHaveLength(7));
+		// Oldest surviving line is tool_2 — tool_0 and tool_1 were dropped
+		expect(logBox?.textContent).not.toContain('Tool 0');
+		expect(logBox?.textContent).toContain('Tool 2');
+		expect(logBox?.className).toContain('logBoxFaded');
+	});
+
+	it('keeps DOM nodes of surviving lines stable when the log window slides', async () => {
+		// Guards the TransitionGroup keys: with unstable keys every trim
+		// recreates all rows, so they leave + re-enter and briefly stack on top
+		// of each other (position: absolute during leave).
+		const sse = makeControlledSseResponse();
+		globalThis.fetch = vi.fn(async () => sse.response) as typeof fetch;
+
+		const { container } = renderComponent();
+		for (const ev of toolCallEvents(7)) sse.push(ev);
+
+		const logBox = getLogBox(container);
+		await waitFor(() => expect(logBox?.querySelectorAll('.line')).toHaveLength(7));
+		const survivor = [...(logBox?.querySelectorAll('.line') ?? [])].find((el) =>
+			el.textContent?.includes('Tool 6'),
+		);
+		expect(survivor).toBeDefined();
+
+		// Two more lines slide the window: tool_0 and tool_1 get dropped
+		sse.push({ type: 'tool-call', toolCallId: 'tc-7', toolName: 'tool_7', input: {} });
+		sse.push({ type: 'tool-call', toolCallId: 'tc-8', toolName: 'tool_8', input: {} });
+		sse.push({ type: 'done' });
+		sse.close();
+
+		await waitFor(() => expect(logBox?.textContent).toContain('Tool 8'));
+		await waitFor(() => expect(logBox?.textContent).not.toContain('Tool 0'));
+
+		const survivorAfter = [...(logBox?.querySelectorAll('.line') ?? [])].find((el) =>
+			el.textContent?.includes('Tool 6'),
+		);
+		expect(survivorAfter).toBe(survivor);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderProgress.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderProgress.vue
@@ -22,16 +22,28 @@ const i18n = useI18n();
 const rootStore = useRootStore();
 
 const MAX_LINES = 7;
-const logLines = ref<string[]>([]);
+
+interface LogLine {
+	id: number;
+	text: string;
+}
+
+// Stable per-line ids keep TransitionGroup keys constant as the window
+// slides, so surviving lines move instead of leaving + re-entering (which
+// would briefly stack them all at the top via `position: absolute`).
+let nextLineId = 0;
+const logLines = ref<LogLine[]>([]);
+const hasDroppedLines = ref(false);
 const isStreaming = ref(false);
 const hasError = ref(false);
 
 function pushLine(line: string) {
 	const trimmed = line.replace(/\s+/g, ' ').trim();
 	if (!trimmed) return;
-	logLines.value.push(trimmed);
+	logLines.value.push({ id: nextLineId++, text: trimmed });
 	if (logLines.value.length > MAX_LINES) {
 		logLines.value = logLines.value.slice(-MAX_LINES);
+		hasDroppedLines.value = true;
 	}
 }
 
@@ -191,10 +203,10 @@ onMounted(() => {
 				}}
 			</N8nText>
 
-			<div :class="$style.logBox" aria-live="polite">
+			<div :class="[$style.logBox, hasDroppedLines && $style.logBoxFaded]" aria-live="polite">
 				<TransitionGroup name="builder-line" tag="div" :class="$style.logInner">
-					<div v-for="(line, i) in logLines" :key="line + i" :class="$style.line">
-						{{ line }}
+					<div v-for="line in logLines" :key="line.id" :class="$style.line">
+						{{ line.text }}
 					</div>
 				</TransitionGroup>
 			</div>
@@ -328,7 +340,11 @@ onMounted(() => {
 	max-height: 140px;
 	overflow: hidden;
 	position: relative;
-	/* Soft fade at the top so older lines visually dissolve */
+}
+
+/* Soft fade at the top so older lines visually dissolve, applied only once
+   the log is at capacity and older lines are being dropped */
+.logBoxFaded {
 	mask-image: linear-gradient(to bottom, transparent 0, black 32px, black 100%);
 	-webkit-mask-image: linear-gradient(to bottom, transparent 0, black 32px, black 100%);
 }
@@ -352,7 +368,8 @@ onMounted(() => {
 }
 
 :global(.builder-line-enter-active),
-:global(.builder-line-leave-active) {
+:global(.builder-line-leave-active),
+:global(.builder-line-move) {
 	transition:
 		opacity 200ms ease,
 		transform 200ms ease;
@@ -366,6 +383,10 @@ onMounted(() => {
 	transform: translateY(-4px);
 }
 :global(.builder-line-leave-active) {
+	/* Span the full row while out of flow so text-align: center keeps the
+	   leaving line centered instead of shrinking to fit at the left edge */
 	position: absolute;
+	left: 0;
+	width: 100%;
 }
 </style>


### PR DESCRIPTION
## Summary

Fixes three visual glitches in the "Building your agent…" progress screen's streaming activity log (`AgentBuilderProgress.vue`):

1. **First log line always half-visible.** The top-fade `mask-image` on the log box was applied unconditionally, so the first line was always ghosted. The fade is now only kicks in once older lines are actually dropped from the log window.
2. **All lines briefly stacked/garbled when the log window slides.** The `v-for` key was `line + i` (content + index), so every trim changed every key — `TransitionGroup` treated all rows as removed + re-inserted, and `position: absolute` on leave collapsed them all to the top, overlapping for the duration of the transition. Lines now carry a stable monotonic id used as the key, so surviving lines FLIP-move (via a new `builder-line-move` transition) and only dropped lines leave.
3. **Leaving line jumped to the left edge while fading out.** Once `position: absolute`, the line stopped being a stretched flex child and shrank to fit at the container's left edge. Leaving lines now get `left: 0; width: 100%` so `text-align: center` keeps them centered.

## How to test

1. Create a new agent in a project and submit an initial build prompt to reach the "Building your agent…" screen.
2. While fewer than 8 log lines have streamed, the first line is fully visible (no grey/ghosted top row).
3. Once more lines stream in and the window slides, the top fade appears, lines glide up smoothly without stacking/garbling, and the dissolving top line stays horizontally centered.

Unit tests in `AgentBuilderProgress.test.ts` cover the fade-class toggling and DOM-node stability of surviving lines (each verified red→green against the unfixed component).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-233

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)