### PR TITLE
fix(Anthropic Chat Model Node): Add Timeout option and stop capping requests at undici's 300s default

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/LmChatAnthropic.node.ts
@@ -442,6 +442,13 @@ export class LmChatAnthropic implements INodeType {
 						description:
 							'Whether the model should stream its response over Server-Sent Events instead of returning a single non-streamed payload. Final output shape is unchanged.',
 					},
+					{
+						displayName: 'Timeout',
+						name: 'timeout',
+						default: 360000,
+						description: 'Maximum amount of time a request is allowed to take in milliseconds',
+						type: 'number',
+					},
 				],
 			},
 		],
@@ -478,6 +485,7 @@ export class LmChatAnthropic implements INodeType {
 			thinkingMode?: 'disabled' | 'adaptive' | 'manual';
 			effort?: 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 			streaming?: boolean;
+			timeout?: number;
 		};
 
 		const isOpus47Model = modelName.startsWith('claude-opus-4-7');
@@ -541,13 +549,19 @@ export class LmChatAnthropic implements INodeType {
 			};
 		};
 
+		const timeout = options.timeout;
 		const clientOptions: {
 			fetchOptions?: { dispatcher: ReturnType<typeof getProxyAgent> };
 			defaultHeaders?: Record<string, string>;
+			timeout?: number;
 		} = {
 			fetchOptions: {
-				dispatcher: getProxyAgent(baseURL),
+				dispatcher: getProxyAgent(baseURL, {
+					headersTimeout: timeout,
+					bodyTimeout: timeout,
+				}),
 			},
+			...(timeout !== undefined && { timeout }),
 		};
 
 		if (

--- a/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/llms/LMChatAnthropic/test/LmChatAnthropic.test.ts
@@ -225,6 +225,50 @@ describe('LmChatAnthropic', () => {
 			);
 		});
 
+		it('should configure a proxy agent with default timeouts when timeout option is not set', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return {};
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(mockedGetProxyAgent).toHaveBeenCalledWith('https://api.anthropic.com', {
+				headersTimeout: undefined,
+				bodyTimeout: undefined,
+			});
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					clientOptions: expect.not.objectContaining({ timeout: expect.anything() }),
+				}),
+			);
+		});
+
+		it('should pass the timeout option to the proxy agent and client options', async () => {
+			const mockContext = setupMockContext();
+
+			mockContext.getNodeParameter = vi.fn().mockImplementation((paramName: string) => {
+				if (paramName === 'model.value') return 'claude-sonnet-4-20250514';
+				if (paramName === 'options') return { timeout: 600000 };
+				return undefined;
+			});
+
+			await lmChatAnthropic.supplyData.call(mockContext, 0);
+
+			expect(mockedGetProxyAgent).toHaveBeenCalledWith('https://api.anthropic.com', {
+				headersTimeout: 600000,
+				bodyTimeout: 600000,
+			});
+			expect(MockedChatAnthropic).toHaveBeenCalledWith(
+				expect.objectContaining({
+					clientOptions: expect.objectContaining({ timeout: 600000 }),
+				}),
+			);
+		});
+
 		it('should default streaming to false when option is omitted', async () => {
 			const mockContext = setupMockContext();
 


### PR DESCRIPTION
## Summary

The Anthropic Chat Model node calls `getProxyAgent(baseURL)` without timeout options. When no HTTP proxy is configured, `getProxyAgent` returns `undefined`, so `fetch` falls back to undici's global dispatcher — whose default `headersTimeout`/`bodyTimeout` is **300 seconds**. Any Anthropic request that takes longer than 5 minutes (large contexts, extended thinking, big `max_tokens`) fails with a headers timeout, and neither `N8N_AI_TIMEOUT_MAX` nor any node setting can change it.

Most other LLM nodes (OpenAI, DeepSeek, Minimax, Moonshot, xAI Grok, OpenRouter, Vercel AI Gateway, Alibaba Cloud, Nvidia, Lemonade, and the Ollama chat model via `proxyFetch`) already pass timeout options to `getProxyAgent`, which makes it always construct an agent honoring `N8N_AI_TIMEOUT_MAX` (default 1 hour). This PR brings the Anthropic node to parity:

- `getProxyAgent(baseURL, { headersTimeout: timeout, bodyTimeout: timeout })` — so the transport layer always gets a properly configured agent. When no timeout is set, `getProxyAgent` falls back to `N8N_AI_TIMEOUT_MAX` / 1 hour, same as the other nodes.
- Adds the standard **Timeout** option (same field as DeepSeek/Minimax/Moonshot/Vercel AI Gateway) to the node's Options collection. When set, it is also passed to the Anthropic SDK via `clientOptions.timeout` so the SDK enforces the total request timeout.

Resulting behavior:

| Configuration | Effective limit on `master` | Effective limit with this PR |
|---|---|---|
| Default (no Timeout option) | **300s** (undici global dispatcher) | 10 min (`@anthropic-ai/sdk` default; transport layer allows `N8N_AI_TIMEOUT_MAX` / 1h) |
| Timeout option set | **min(300s, value)** | the configured value, enforced at both the SDK and transport layers |

No behavior change for requests that complete in under 5 minutes. Existing workflows keep working; they just stop failing at the 300s mark.

## How to test

1. Create a workflow with an AI Agent (or Basic LLM Chain) using the Anthropic Chat Model node.
2. Configure a request that takes longer than 300 seconds (e.g. Claude Opus 4.6 with manual thinking, `thinkingBudget` 30000+, large `maxTokensToSample`, and a prompt that requires a long answer — or simply point the credential's base URL at a mock server that delays the response by >300s).
3. On `master`: the request fails after ~300s with a fetch/headers timeout.
4. With this PR: the request completes (default ceiling becomes the Anthropic SDK's own 10-minute timeout; the transport layer allows up to `N8N_AI_TIMEOUT_MAX`, 1 hour). Setting the new **Timeout** option enforces the configured value at both the transport layer and the Anthropic SDK.

Unit tests cover both paths: default (timeout-capable agent constructed with `N8N_AI_TIMEOUT_MAX` fallback, no SDK timeout override) and explicit Timeout option (propagated to both `getProxyAgent` and `clientOptions.timeout`).

## Related Linear tickets, Github issues, and Community forum posts

fixes #25360 (for the Anthropic node; the same root cause affects other nodes that still call one-arg `getProxyAgent`: `LmChatGroq`, `LMChatOpenAi/methods/loadModels.ts`)

Root-cause analysis: https://github.com/n8n-io/n8n/issues/25360 (comment from 2026-05-13 describing the `getProxyAgent` no-proxy/no-timeoutOptions path returning `undefined`)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
