### PR TITLE
fix(core): Prevent workflow builder from making HTTP requests in Code nodes (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/code-node-no-http-requests.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/code-node-no-http-requests.test.ts
@@ -100,6 +100,19 @@ describe('codeNodeNoHttpRequests', () => {
 		expect(result.comment).toContain('requests');
 	});
 
+	it('fails when a Python Code node imports urllib via from-import', async () => {
+		const workflow = workflowWithCodeNode({
+			language: 'python',
+			pythonCode:
+				"from urllib.request import urlopen\nres = urlopen('https://api.example.com')\nreturn res.read()",
+		});
+
+		const result = await codeNodeNoHttpRequests.run(workflow, { prompt: 'Call an API' });
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('urllib');
+	});
+
 	it('ignores code of the inactive language', async () => {
 		const workflow = workflowWithCodeNode({
 			language: 'python',

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/code-node-no-http-requests.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/code-node-no-http-requests.test.ts
@@ -87,6 +87,31 @@ describe('codeNodeNoHttpRequests', () => {
 		expect(result.comment).toContain('requests');
 	});
 
+	it('fails when a Python Code node uses a from-import of an HTTP library', async () => {
+		const workflow = workflowWithCodeNode({
+			language: 'pythonNative',
+			pythonCode:
+				"from requests import get\nres = get('https://api.example.com')\nreturn res.json()",
+		});
+
+		const result = await codeNodeNoHttpRequests.run(workflow, { prompt: 'Call an API' });
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('requests');
+	});
+
+	it('ignores code of the inactive language', async () => {
+		const workflow = workflowWithCodeNode({
+			language: 'python',
+			jsCode: "const res = await fetch('https://api.example.com');\nreturn await res.json();",
+			pythonCode: 'return [item.json for item in _input.all()]',
+		});
+
+		const result = await codeNodeNoHttpRequests.run(workflow, { prompt: 'Process data' });
+
+		expect(result).toEqual({ pass: true });
+	});
+
 	it('passes when Code nodes only transform data', async () => {
 		const workflow = workflowWithCodeNode({
 			mode: 'runOnceForAllItems',

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/code-node-no-http-requests.test.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/code-node-no-http-requests.test.ts
@@ -1,0 +1,136 @@
+import { codeNodeNoHttpRequests } from './code-node-no-http-requests';
+import type { WorkflowResponse } from '../../clients/n8n-client';
+
+function workflowWithCodeNode(parameters: Record<string, unknown>): WorkflowResponse {
+	return {
+		id: 'wf-1',
+		name: 'Code HTTP test',
+		active: false,
+		nodes: [
+			{
+				name: 'Manual Trigger',
+				type: 'n8n-nodes-base.manualTrigger',
+				parameters: {},
+			},
+			{
+				name: 'Code',
+				type: 'n8n-nodes-base.code',
+				parameters,
+			},
+		],
+		connections: {
+			'Manual Trigger': {
+				main: [[{ node: 'Code', type: 'main', index: 0 }]],
+			},
+		},
+	};
+}
+
+describe('codeNodeNoHttpRequests', () => {
+	it('fails when a Code node uses fetch()', async () => {
+		const workflow = workflowWithCodeNode({
+			mode: 'runOnceForAllItems',
+			jsCode: "const res = await fetch('https://api.example.com/items');\nreturn await res.json();",
+		});
+
+		const result = await codeNodeNoHttpRequests.run(workflow, { prompt: 'Fetch items' });
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('fetch()');
+		expect(result.comment).toContain('HTTP Request node');
+	});
+
+	it('fails when a Code node uses axios', async () => {
+		const workflow = workflowWithCodeNode({
+			jsCode:
+				"const axios = require('axios');\nconst res = await axios.get(url);\nreturn res.data;",
+		});
+
+		const result = await codeNodeNoHttpRequests.run(workflow, { prompt: 'Call an API' });
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('axios');
+	});
+
+	it('fails when a Code node requires the http module', async () => {
+		const workflow = workflowWithCodeNode({
+			jsCode: "const https = require('https');\nreturn [];",
+		});
+
+		const result = await codeNodeNoHttpRequests.run(workflow, { prompt: 'Call an API' });
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('require of an HTTP module');
+	});
+
+	it('fails when a Code node uses this.helpers.httpRequest', async () => {
+		const workflow = workflowWithCodeNode({
+			jsCode: 'const res = await this.helpers.httpRequest({ url });\nreturn [{ json: res }];',
+		});
+
+		const result = await codeNodeNoHttpRequests.run(workflow, { prompt: 'Call an API' });
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('this.helpers.httpRequest');
+	});
+
+	it('fails when a Python Code node uses requests', async () => {
+		const workflow = workflowWithCodeNode({
+			language: 'python',
+			pythonCode:
+				"import requests\nres = requests.get('https://api.example.com')\nreturn res.json()",
+		});
+
+		const result = await codeNodeNoHttpRequests.run(workflow, { prompt: 'Call an API' });
+
+		expect(result.pass).toBe(false);
+		expect(result.comment).toContain('requests');
+	});
+
+	it('passes when Code nodes only transform data', async () => {
+		const workflow = workflowWithCodeNode({
+			mode: 'runOnceForAllItems',
+			jsCode:
+				'const items = $input.all();\nreturn items.map((item) => ({ json: { ...item.json, processed: true } }));',
+		});
+
+		const result = await codeNodeNoHttpRequests.run(workflow, { prompt: 'Process data' });
+
+		expect(result).toEqual({ pass: true });
+	});
+
+	it('does not flag comments mentioning fetched data', async () => {
+		const workflow = workflowWithCodeNode({
+			jsCode: '// transform the data fetched by the HTTP Request node\nreturn $input.all();',
+		});
+
+		const result = await codeNodeNoHttpRequests.run(workflow, { prompt: 'Process data' });
+
+		expect(result).toEqual({ pass: true });
+	});
+
+	it('reports N/A when the workflow has no Code nodes', async () => {
+		const workflow: WorkflowResponse = {
+			id: 'wf-2',
+			name: 'No code',
+			active: false,
+			nodes: [
+				{
+					name: 'Manual Trigger',
+					type: 'n8n-nodes-base.manualTrigger',
+					parameters: {},
+				},
+				{
+					name: 'HTTP Request',
+					type: 'n8n-nodes-base.httpRequest',
+					parameters: { url: 'https://api.example.com' },
+				},
+			],
+			connections: {},
+		};
+
+		const result = await codeNodeNoHttpRequests.run(workflow, { prompt: 'Call an API' });
+
+		expect(result).toEqual({ pass: true, applicable: false });
+	});
+});

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/code-node-no-http-requests.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/code-node-no-http-requests.ts
@@ -1,0 +1,68 @@
+import type { WorkflowNodeResponse } from '../../clients/n8n-client';
+import type { BinaryCheck } from '../types';
+
+const CODE_NODE_TYPE = 'n8n-nodes-base.code';
+
+const HTTP_CODE_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
+	{ pattern: /\bfetch\s*\(/, label: 'fetch()' },
+	{ pattern: /\bXMLHttpRequest\b/, label: 'XMLHttpRequest' },
+	{ pattern: /\baxios\s*[.(]/, label: 'axios' },
+	{ pattern: /\bthis\.helpers\.httpRequest/, label: 'this.helpers.httpRequest' },
+	{
+		pattern:
+			/require\s*\(\s*['"`](?:node:)?(?:https?|node-fetch|axios|got|undici|superagent|request)['"`]\s*\)/,
+		label: 'require of an HTTP module',
+	},
+	{ pattern: /\burllib\./, label: 'urllib' },
+	{
+		pattern:
+			/(?:^|\n)\s*import\s+requests\b|\brequests\.(?:get|post|put|patch|delete|head|request)\s*\(/,
+		label: 'requests',
+	},
+	{ pattern: /\bhttpx\s*[.(]/, label: 'httpx' },
+	{ pattern: /\bhttp\.client\b/, label: 'http.client' },
+	{ pattern: /\baiohttp\./, label: 'aiohttp' },
+];
+
+function isCodeNode(node: WorkflowNodeResponse): boolean {
+	return node.type === CODE_NODE_TYPE;
+}
+
+function getCodeText(node: WorkflowNodeResponse): string {
+	const { jsCode, pythonCode } = node.parameters ?? {};
+	return [jsCode, pythonCode]
+		.filter((value): value is string => typeof value === 'string')
+		.join('\n');
+}
+
+export const codeNodeNoHttpRequests: BinaryCheck = {
+	name: 'code_node_no_http_requests',
+	description:
+		'Code nodes do not hand-roll HTTP requests — the sandbox has no network access (fetch/axios/require fail at runtime); HTTP calls belong in the HTTP Request node',
+	kind: 'deterministic',
+	dimension: 'nodes_craftsmanship',
+	run(workflow) {
+		const codeNodes = (workflow.nodes ?? []).filter(isCodeNode);
+		if (codeNodes.length === 0) return { pass: true, applicable: false };
+
+		const issues: string[] = [];
+		for (const node of codeNodes) {
+			const code = getCodeText(node);
+			if (!code) continue;
+
+			const matched = HTTP_CODE_PATTERNS.filter(({ pattern }) => pattern.test(code)).map(
+				({ label }) => label,
+			);
+			if (matched.length > 0) {
+				issues.push(
+					`"${node.name}" makes HTTP requests in code (${matched.join(', ')}) — use the HTTP Request node instead`,
+				);
+			}
+		}
+
+		return {
+			pass: issues.length === 0,
+			...(issues.length > 0 ? { comment: issues.join('; ') } : {}),
+		};
+	},
+};

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/code-node-no-http-requests.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/code-node-no-http-requests.ts
@@ -13,7 +13,11 @@ const HTTP_CODE_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
 			/require\s*\(\s*['"`](?:node:)?(?:https?|node-fetch|axios|got|undici|superagent|request)['"`]\s*\)/,
 		label: 'require of an HTTP module',
 	},
-	{ pattern: /\burllib\./, label: 'urllib' },
+	{
+		pattern:
+			/\burllib\.|(?:^|\n)\s*(?:import\s+urllib(?:\.\w+)*\b|from\s+urllib(?:\.\w+)*\s+import\b)/,
+		label: 'urllib',
+	},
 	{
 		pattern:
 			/(?:^|\n)\s*(?:import\s+requests\b|from\s+requests(?:\.\w+)*\s+import\b)|\brequests\.(?:get|post|put|patch|delete|head|request)\s*\(/,

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/code-node-no-http-requests.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/code-node-no-http-requests.ts
@@ -16,12 +16,12 @@ const HTTP_CODE_PATTERNS: Array<{ pattern: RegExp; label: string }> = [
 	{ pattern: /\burllib\./, label: 'urllib' },
 	{
 		pattern:
-			/(?:^|\n)\s*import\s+requests\b|\brequests\.(?:get|post|put|patch|delete|head|request)\s*\(/,
+			/(?:^|\n)\s*(?:import\s+requests\b|from\s+requests(?:\.\w+)*\s+import\b)|\brequests\.(?:get|post|put|patch|delete|head|request)\s*\(/,
 		label: 'requests',
 	},
-	{ pattern: /\bhttpx\s*[.(]/, label: 'httpx' },
-	{ pattern: /\bhttp\.client\b/, label: 'http.client' },
-	{ pattern: /\baiohttp\./, label: 'aiohttp' },
+	{ pattern: /\bhttpx\s*[.(]|(?:^|\n)\s*from\s+httpx(?:\.\w+)*\s+import\b/, label: 'httpx' },
+	{ pattern: /\bhttp\.client\b|(?:^|\n)\s*from\s+http\.client\s+import\b/, label: 'http.client' },
+	{ pattern: /\baiohttp\.|(?:^|\n)\s*from\s+aiohttp(?:\.\w+)*\s+import\b/, label: 'aiohttp' },
 ];
 
 function isCodeNode(node: WorkflowNodeResponse): boolean {
@@ -29,10 +29,9 @@ function isCodeNode(node: WorkflowNodeResponse): boolean {
 }
 
 function getCodeText(node: WorkflowNodeResponse): string {
-	const { jsCode, pythonCode } = node.parameters ?? {};
-	return [jsCode, pythonCode]
-		.filter((value): value is string => typeof value === 'string')
-		.join('\n');
+	const { jsCode, pythonCode, language } = node.parameters ?? {};
+	const activeCode = language === 'python' || language === 'pythonNative' ? pythonCode : jsCode;
+	return typeof activeCode === 'string' ? activeCode : '';
 }
 
 export const codeNodeNoHttpRequests: BinaryCheck = {

--- a/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/index.ts
+++ b/packages/@n8n/instance-ai/evaluations/binaryChecks/checks/index.ts
@@ -8,6 +8,7 @@ import type { BinaryCheck } from '../types';
 import { agentHasDynamicPrompt } from './agent-has-dynamic-prompt';
 import { agentHasLanguageModel } from './agent-has-language-model';
 import { allNodesConnected } from './all-nodes-connected';
+import { codeNodeNoHttpRequests } from './code-node-no-http-requests';
 import { correctNodeOperations } from './correct-node-operations';
 import { descriptiveNodeNames } from './descriptive-node-names';
 import { expressionsReferenceExistingNodes } from './expressions-reference-existing-nodes';
@@ -76,6 +77,7 @@ export const AI_NODES_CHECKS: BinaryCheck[] = [
 
 export const NODES_CRAFTSMANSHIP_CHECKS: BinaryCheck[] = [
 	noUnnecessaryCodeNodes,
+	codeNodeNoHttpRequests,
 	descriptiveNodeNames,
 	responseMatchesWorkflowChanges,
 ];

--- a/packages/@n8n/instance-ai/evaluations/data/subagent/code-node-http-fetch.json
+++ b/packages/@n8n/instance-ai/evaluations/data/subagent/code-node-http-fetch.json
@@ -1,0 +1,4 @@
+{
+	"id": "code-node-http-fetch",
+	"prompt": "Build a workflow that runs manually and uses a Code node to fetch the JSON from https://api.example.com/v1/products with fetch(), then keeps only the products with a price above 100. Configure all nodes completely and don't ask me for credentials — I'll set them up later."
+}

--- a/packages/@n8n/instance-ai/knowledge-base/reference/workflow-builder-guardrails.md
+++ b/packages/@n8n/instance-ai/knowledge-base/reference/workflow-builder-guardrails.md
@@ -75,6 +75,11 @@ Code nodes run in a restricted runtime. Do not `require()` or `import`
 unavailable modules such as `luxon` or `openai`; use JavaScript `Date`, `Intl`,
 `$now`, `$today`, existing workflow data, or dedicated AI nodes.
 
+Code nodes have no network access. `fetch()`, `axios`, `XMLHttpRequest`, and
+`require` of http modules all fail at runtime, in JavaScript and Python alike.
+Make every HTTP/API call with the HTTP Request node and transform its output in
+the Code node, even when the user asks to fetch inside a Code node.
+
 Keep embedded Code node source parseable after saving. Avoid nested template
 literals, raw newlines inside quoted strings, and escape-heavy regex literals.
 Prefer arrays joined with a runtime separator such as

--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -370,6 +370,11 @@ column names.
   (`expr()`). Full allowed/forbidden list:
   `knowledge-base/reference/workflow-sdk-language.md`.
 
+- Code nodes have NO network access at runtime: `fetch()`, `axios`,
+  `XMLHttpRequest`, and `require` of http modules all fail in the sandbox. Make
+  every HTTP/API call with the HTTP Request node and transform its output in a
+  Code node, even when the user asks to fetch inside a Code node.
+
 - Use `@n8n/workflow-sdk`.
 - Do not specify node positions. They are auto-calculated by the layout engine.
 - Use `expr('{{ $json.field }}')` for n8n expressions. Variables must be inside

--- a/packages/nodes-base/nodes/Code/Code.node.ts
+++ b/packages/nodes-base/nodes/Code/Code.node.ts
@@ -45,8 +45,13 @@ export class Code implements INodeType {
 		outputs: [NodeConnectionTypes.Main],
 		builderHint: {
 			searchHint:
-				'Use Code node as a LAST RESORT — it runs in a sandboxed environment and is slower than native nodes. Code node is ONLY appropriate for complex multi-step algorithms that cannot be expressed in single expressions, or operations requiring complex data structures.',
+				'Use Code node as a LAST RESORT — it runs in a sandboxed environment and is slower than native nodes. Code node is ONLY appropriate for complex multi-step algorithms that cannot be expressed in single expressions, or operations requiring complex data structures. The sandbox has NO network access: fetch(), axios, XMLHttpRequest and require of http modules are unavailable and FAIL at runtime. NEVER make HTTP requests in a Code node — use the HTTP Request node and process its output instead.',
 			relatedNodes: [
+				{
+					nodeType: 'n8n-nodes-base.httpRequest',
+					relationHint:
+						'Use this instead for ANY HTTP/API call — the Code node sandbox cannot make network requests',
+				},
 				{
 					nodeType: 'n8n-nodes-base.set',
 					relationHint:

--- a/packages/nodes-base/nodes/Code/descriptions/JavascriptCodeDescription.ts
+++ b/packages/nodes-base/nodes/Code/descriptions/JavascriptCodeDescription.ts
@@ -12,6 +12,10 @@ const commonDescription: INodeProperties = {
 	description:
 		'JavaScript code to execute.<br><br>Tip: You can use luxon vars like <code>$today</code> for dates and <code>$jmespath</code> for querying JSON structures. <a href="https://docs.n8n.io/nodes/n8n-nodes-base.function">Learn more</a>.',
 	noDataExpression: true,
+	builderHint: {
+		propertyHint:
+			'The sandbox has NO network access: fetch(), axios, XMLHttpRequest and require of http modules are unavailable and fail at runtime. NEVER make HTTP requests here — use the HTTP Request node and process its output in this node instead.',
+	},
 };
 
 const v1Properties: INodeProperties[] = [

--- a/packages/nodes-base/nodes/Code/descriptions/PythonCodeDescription.ts
+++ b/packages/nodes-base/nodes/Code/descriptions/PythonCodeDescription.ts
@@ -12,6 +12,10 @@ const commonDescription: INodeProperties = {
 	description:
 		'Python code to execute.<br><br>Tip: You can use built-in methods and variables like <code>_today</code> for dates and <code>_jmespath</code> for querying JSON structures. <a href="https://docs.n8n.io/code/builtin/">Learn more</a>.',
 	noDataExpression: true,
+	builderHint: {
+		propertyHint:
+			'The sandbox has NO network access: requests, urllib, httpx and other HTTP libraries are unavailable and fail at runtime. NEVER make HTTP requests here — use the HTTP Request node and process its output in this node instead.',
+	},
 };
 
 const PRINT_INSTRUCTION =


### PR DESCRIPTION
## Summary

The AI workflow builder commonly assumed the Code node can make HTTP requests (`fetch()`, `axios`), producing workflows that fail at runtime — the Code node sandbox has no network access (no `fetch`/network globals in the task-runner VM, `require` of http modules blocked by default).

Fix (guidance, eval-driven):

- **Workflow-builder skill** (`skills/workflow-builder/SKILL.md`): new SDK Code Rule — Code nodes have no network access; make every HTTP/API call with the HTTP Request node, even when the user asks to fetch inside a Code node. This is the load-bearing change.
- **KB guardrails** (`knowledge-base/reference/workflow-builder-guardrails.md`): same rule in the Code-node section the builder reads for every Code-node build.
- **builderHints** (defense in depth): property-level `propertyHint` on `jsCode`/`pythonCode` (lands as `@builderHint` in generated node type defs) plus node-level `searchHint` and an `httpRequest` `relatedNodes` entry on the Code node.

Eval coverage:

- New deterministic binary check `code_node_no_http_requests` (dimension `nodes_craftsmanship`) flagging `fetch(`, `axios`, `XMLHttpRequest`, `require` of http modules, `this.helpers.httpRequest`, and Python `requests`/`urllib`/`httpx`/`aiohttp` in Code nodes — runs on every subagent eval.
- New subagent fixture `code-node-http-fetch` that tempts the builder into HTTP-in-Code.
- Unit tests for the check.

EDD verification (live orchestrator builds, anthropic/claude-sonnet-4-5):

| Phase | Runs | `code_node_no_http_requests` | Built workflow |
|---|---|---|---|
| Pre-fix | 3/3 | fail | manualTrigger → Code (`fetch()` inside) |
| builderHints only | 0/2 | fail | unchanged behavior |
| Skill + KB + hints | 4/4 | pass | manualTrigger → HTTP Request → Code |

## How to test

1. `cd packages/@n8n/instance-ai && pnpm vitest run evaluations/binaryChecks/checks/code-node-no-http-requests.test.ts`
2. With a local instance running (see `evaluations/README.md`): `pnpm eval:subagent --filter code-node-http --verbose` — the build should use an HTTP Request node and `code_node_no_http_requests` should pass.
3. Prompt Instance AI with "Build a workflow that runs manually and uses a Code node to fetch JSON from <url> with fetch()" — the builder should use an HTTP Request node and explain why.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-495

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
