### PR TITLE
fix(core): Preserve Anthropic thinking blocks with empty text in agent tool round-trips

### DIFF
--- a/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/buildSteps.ts
@@ -137,8 +137,11 @@ function buildMessageContent(
 ): string | Array<ThinkingContentBlock | RedactedThinkingContentBlock | ToolUseContentBlock> {
 	const { thinkingContent, thinkingType, thinkingSignature } = providerMetadata;
 
-	// Anthropic thinking mode: build content blocks
-	if (thinkingContent && thinkingType) {
+	// Anthropic thinking mode: build content blocks.
+	// thinkingContent may be an empty string (thinking display "omitted", the default on
+	// Claude Fable 5, Mythos 5, and Opus 4.7+): the signature still carries the encrypted
+	// reasoning, so the thinking block must be rebuilt rather than degraded to a string.
+	if (thinkingContent !== undefined && thinkingType) {
 		return buildAnthropicContentBlocks(
 			thinkingContent,
 			thinkingType,

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/createEngineRequests.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/createEngineRequests.ts
@@ -153,7 +153,7 @@ function extractThinkingMetadata(
 					}
 				}
 
-				if (thoughtSignature || thinkingContent) break;
+				if (thoughtSignature || thinkingContent !== undefined) break;
 			}
 		}
 	}
@@ -163,7 +163,11 @@ function extractThinkingMetadata(
 		result.google = { thoughtSignature };
 	}
 
-	if (thinkingContent && thinkingType) {
+	// Note: thinkingContent may be an empty string. Models that omit thinking text
+	// (e.g. thinking display "omitted", the default on Claude Fable 5, Mythos 5, and
+	// Opus 4.7+) return thinking blocks with an empty `thinking` field whose `signature`
+	// still carries the encrypted reasoning — the block must be preserved and replayed.
+	if (thinkingContent !== undefined && thinkingType) {
 		result.anthropic = {
 			thinkingContent,
 			thinkingType,

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/buildSteps.test.ts
@@ -820,6 +820,65 @@ describe('buildSteps', () => {
 			});
 		});
 
+		it('should reconstruct thinking blocks with empty thinking text (display "omitted")', () => {
+			// Models with thinking display "omitted" (the default on Claude Fable 5 and
+			// Opus 4.7+) return thinking blocks with empty text but a real signature.
+			// The rebuilt assistant turn must contain the thinking block, not degrade
+			// to plain string content (which loses the signature and breaks the replay).
+			const response: EngineResponse<RequestResponseMetadata> = {
+				actionResponses: [
+					{
+						action: {
+							actionType: 'ExecutionNodeAction',
+							nodeName: 'Calculator',
+							input: {
+								id: 'call_omitted_1',
+								input: { expression: '2+2' },
+							},
+							type: NodeConnectionTypes.AiTool,
+							id: 'call_omitted_1',
+							metadata: {
+								itemIndex: 0,
+								anthropic: {
+									thinkingContent: '',
+									thinkingType: 'thinking',
+									thinkingSignature: 'encrypted_signature_abc',
+								},
+							},
+						},
+						data: {
+							data: {
+								ai_tool: [[{ json: { result: '4' } }]],
+							},
+							executionTime: 0,
+							startTime: 0,
+							executionIndex: 0,
+							source: [],
+						},
+					},
+				],
+				metadata: {},
+			};
+
+			const result = buildSteps(response, itemIndex);
+
+			expect(result).toHaveLength(1);
+			const message = result[0].action.messageLog![0];
+			const content = message.content;
+			expect(Array.isArray(content)).toBe(true);
+			expect(content).toHaveLength(2);
+			expect(content[0]).toEqual({
+				type: 'thinking',
+				thinking: '',
+				signature: 'encrypted_signature_abc',
+			});
+			expect(content[1]).toMatchObject({
+				type: 'tool_use',
+				id: 'call_omitted_1',
+				name: 'Calculator',
+			});
+		});
+
 		it('should reconstruct AIMessage with redacted_thinking content blocks', () => {
 			const response: EngineResponse<RequestResponseMetadata> = {
 				actionResponses: [

--- a/packages/@n8n/nodes-langchain/utils/agent-execution/test/createEngineRequests.test.ts
+++ b/packages/@n8n/nodes-langchain/utils/agent-execution/test/createEngineRequests.test.ts
@@ -631,6 +631,47 @@ describe('createEngineRequests', () => {
 			expect(result[0].metadata.anthropic?.thinkingSignature).toBe('test_signature_123');
 		});
 
+		it('should preserve thinking blocks with empty thinking text (display "omitted")', async () => {
+			// Models with thinking display "omitted" (the default on Claude Fable 5 and
+			// Opus 4.7+) return thinking blocks whose `thinking` field is an empty string
+			// while `signature` carries the encrypted reasoning. The block (and especially
+			// the signature) must survive the engine round-trip.
+			const tools = [createMockTool('calculator', { sourceNodeName: 'Calculator' })];
+
+			const toolCalls: ToolCallRequest[] = [
+				{
+					tool: 'calculator',
+					toolInput: { expression: '2+2' },
+					toolCallId: 'call_omitted_1',
+					messageLog: [
+						{
+							content: [
+								{
+									type: 'thinking',
+									thinking: '',
+									signature: 'encrypted_signature_abc',
+								},
+								{
+									type: 'tool_use',
+									id: 'call_omitted_1',
+									name: 'calculator',
+									input: { expression: '2+2' },
+								},
+							],
+						},
+					],
+				},
+			];
+
+			const result = createEngineRequests(toolCalls, 0, tools);
+
+			expect(result).toHaveLength(1);
+			expect(result[0].metadata.anthropic).toBeDefined();
+			expect(result[0].metadata.anthropic?.thinkingContent).toBe('');
+			expect(result[0].metadata.anthropic?.thinkingType).toBe('thinking');
+			expect(result[0].metadata.anthropic?.thinkingSignature).toBe('encrypted_signature_abc');
+		});
+
 		it('should extract redacted_thinking content from Anthropic message', async () => {
 			const tools = [createMockTool('search', { sourceNodeName: 'Search' })];
 


### PR DESCRIPTION
## Summary

Any AI Agent (Tools Agent) that has tools attached returns `{"output": ""}` — with every node green — when the model is **Claude Fable 5** (`claude-fable-5`, released 2026-06-09). Tool-less agents on the same model work fine. The failing runs take only 4–6 seconds.

Root cause: models with thinking display `"omitted"` — **the default on Claude Fable 5, Claude Mythos 5, Claude Opus 4.8, and Claude Opus 4.7** per [Anthropic's adaptive-thinking docs](https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking#controlling-thinking-display) — return thinking blocks whose `thinking` field is an **empty string**, while the `signature` field still carries the encrypted reasoning. Anthropic requires these blocks to be passed back unchanged when continuing a tool-use conversation.

Two falsy checks (`if (thinkingContent && thinkingType)`) treat the empty string as "no thinking" during the engine tool round-trip:

- `utils/agent-execution/createEngineRequests.ts` (`extractThinkingMetadata`) — drops the thinking block **and its signature** from the action metadata;
- `utils/agent-execution/buildSteps.ts` (`buildMessageContent`) — degrades the rebuilt assistant turn to plain string content (`"Calling X with input: ..."`).

The follow-up request after the tool call therefore reaches the API without the thinking block it expects, the model responds with a contentless 200, and `handleAgentFinishOutput` falls through to `output = ''`. No error is raised anywhere.

The fix treats empty-string thinking text as present (`!== undefined`), so the block — critically, its signature — survives the round-trip. (`isThinkingBlock` already accepts empty strings via `typeof block.thinking === 'string'`; only these two conditions discarded them.) A matching `!== undefined` is applied to the early-`break` condition in the messageLog scan for consistency.

## How to test

1. Create a workflow: Manual/Webhook Trigger → **AI Agent** with one trivial tool (e.g. a Code tool that echoes its input) and an Anthropic Chat Model sub-node set to `claude-fable-5` (typeVersion 1.5, Thinking Mode "Adaptive").
2. Prompt it with something that forces a tool call, e.g. "Call the tool with input 'ping', then summarize the result."
3. On `master`: the agent finishes green in a few seconds with empty output (`{"output": ""}`); the model's second call receives a degraded conversation (prior assistant turn is plain text, no thinking block).
4. With this PR: the thinking block (empty text + signature) is replayed correctly and the agent returns real output.

Unit tests added in both test suites pin the regression (they fail on `master`):
- `createEngineRequests.test.ts`: thinking block with `thinking: ''` + signature → metadata preserved.
- `buildSteps.test.ts`: same metadata → rebuilt content is `[thinking, tool_use]` blocks (not the string fallback).

Observed in production (n8n 2.20.6, self-hosted): research agent with tools on `claude-fable-5` returned empty output in 4–6s on every run (two model calls, both HTTP 200, both with empty generation text); identical agent config on `claude-opus-4-7` works, and a tool-less agent on `claude-fable-5` works (168s, full output). The same code path is unchanged on current `master`.

## Related Linear tickets, Github issues, and Community forum posts

Related to the broader Claude Fable 5 / Opus 4.8 support surface: thinking display `"omitted"` is the default on these models, so this affects every Tools Agent + Fable 5 combination out of the box.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
