### PR TITLE
feat(GSuiteAdmin): Add missing user attributes to create and update

### DIFF
--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/GSuiteAdmin.node.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/GSuiteAdmin.node.ts
@@ -10,7 +10,7 @@ import type {
 import { NodeConnectionTypes, NodeOperationError, setSafeObjectProperty } from 'n8n-workflow';
 
 import { deviceFields, deviceOperations } from './DeviceDescription';
-import { googleApiRequest, googleApiRequestAllItems } from './GenericFunctions';
+import { googleApiRequest, googleApiRequestAllItems, mapUserExtraFields } from './GenericFunctions';
 import { groupFields, groupOperations } from './GroupDescription';
 import { searchDevices, searchGroups, searchUsers } from './SearchFunctions';
 import { userFields, userOperations } from './UserDescription';
@@ -536,6 +536,8 @@ export class GSuiteAdmin implements INodeType {
 							}
 						}
 
+						mapUserExtraFields(additionalFields as IDataObject, body);
+
 						responseData = await googleApiRequest.call(
 							this,
 							'POST',
@@ -728,17 +730,7 @@ export class GSuiteAdmin implements INodeType {
 						}) as string;
 						const updateFields = this.getNodeParameter('updateFields', i);
 
-						const body: {
-							name?: { givenName?: string; familyName?: string };
-							emails?: IDataObject[];
-							primaryEmail?: string;
-							phones?: IDataObject[];
-							suspended?: boolean;
-							roles?: { [key: string]: boolean };
-							customSchemas?: IDataObject;
-							password?: string;
-							changePasswordAtNextLogin?: boolean;
-						} = {};
+						const body: IDataObject = {};
 
 						if (updateFields.password) {
 							body.password = updateFields.password as string;
@@ -748,14 +740,15 @@ export class GSuiteAdmin implements INodeType {
 							body.changePasswordAtNextLogin = updateFields.changePasswordAtNextLogin as boolean;
 						}
 
+						const name: { givenName?: string; familyName?: string } = {};
 						if (updateFields.firstName) {
-							body.name ??= {};
-							body.name.givenName = updateFields.firstName as string;
+							name.givenName = updateFields.firstName as string;
 						}
-
 						if (updateFields.lastName) {
-							body.name ??= {};
-							body.name.familyName = updateFields.lastName as string;
+							name.familyName = updateFields.lastName as string;
+						}
+						if (Object.keys(name).length > 0) {
+							body.name = name;
 						}
 
 						if (updateFields.phoneUi) {
@@ -826,6 +819,8 @@ export class GSuiteAdmin implements INodeType {
 								body.customSchemas = customSchemas;
 							}
 						}
+
+						mapUserExtraFields(updateFields as IDataObject, body);
 
 						responseData = await googleApiRequest.call(
 							this,

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/GSuiteAdmin.node.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/GSuiteAdmin.node.ts
@@ -122,7 +122,7 @@ export class GSuiteAdmin implements INodeType {
 
 				for (const unit of orgUnits.organizationUnits) {
 					returnData.push({
-						name: unit.name,
+						name: unit.orgUnitPath,
 						value: unit.orgUnitPath,
 					});
 				}

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/GenericFunctions.ts
@@ -44,6 +44,55 @@ export async function googleApiRequest(
 	}
 }
 
+/**
+ * Maps the shared writable User attributes (defined in `userExtraFields` in
+ * UserDescription.ts) from a create/update collection onto the request body.
+ * See https://developers.google.com/workspace/admin/directory/reference/rest/v1/users
+ */
+export function mapUserExtraFields(fields: IDataObject, body: IDataObject): void {
+	if (fields.orgUnitPath) {
+		body.orgUnitPath = fields.orgUnitPath;
+	}
+	if (fields.recoveryEmail) {
+		body.recoveryEmail = fields.recoveryEmail;
+	}
+	if (fields.recoveryPhone) {
+		body.recoveryPhone = fields.recoveryPhone;
+	}
+	if (fields.includeInGlobalAddressList !== undefined) {
+		body.includeInGlobalAddressList = fields.includeInGlobalAddressList;
+	}
+	if (fields.ipWhitelisted !== undefined) {
+		body.ipWhitelisted = fields.ipWhitelisted;
+	}
+
+	// Single-object fixedCollections
+	if (fields.genderUi) {
+		body.gender = (fields.genderUi as IDataObject).genderValues;
+	}
+	if (fields.notesUi) {
+		body.notes = (fields.notesUi as IDataObject).notesValues;
+	}
+
+	// Array fixedCollections: unwrap the `*Values` wrapper into the API array
+	const arrayMappings: Array<[string, string, string]> = [
+		['organizationUi', 'organizationValues', 'organizations'],
+		['addressesUi', 'addressesValues', 'addresses'],
+		['relationsUi', 'relationsValues', 'relations'],
+		['externalIdsUi', 'externalIdsValues', 'externalIds'],
+		['languagesUi', 'languagesValues', 'languages'],
+		['websitesUi', 'websitesValues', 'websites'],
+		['imsUi', 'imsValues', 'ims'],
+		['keywordsUi', 'keywordsValues', 'keywords'],
+		['locationsUi', 'locationsValues', 'locations'],
+	];
+	for (const [uiKey, valuesKey, bodyKey] of arrayMappings) {
+		if (fields[uiKey]) {
+			body[bodyKey] = (fields[uiKey] as IDataObject)[valuesKey];
+		}
+	}
+}
+
 export async function googleApiRequestAllItems(
 	this: IExecuteFunctions | ILoadOptionsFunctions,
 	propertyName: string,

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/GenericFunctions.ts
@@ -85,6 +85,7 @@ export function mapUserExtraFields(fields: IDataObject, body: IDataObject): void
 		['imsUi', 'imsValues', 'ims'],
 		['keywordsUi', 'keywordsValues', 'keywords'],
 		['locationsUi', 'locationsValues', 'locations'],
+		['posixAccountsUi', 'posixAccountsValues', 'posixAccounts'],
 	];
 	for (const [uiKey, valuesKey, bodyKey] of arrayMappings) {
 		if (fields[uiKey]) {

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/GenericFunctions.ts
@@ -86,11 +86,23 @@ export function mapUserExtraFields(fields: IDataObject, body: IDataObject): void
 		['keywordsUi', 'keywordsValues', 'keywords'],
 		['locationsUi', 'locationsValues', 'locations'],
 		['posixAccountsUi', 'posixAccountsValues', 'posixAccounts'],
+		['sshPublicKeysUi', 'sshPublicKeysValues', 'sshPublicKeys'],
 	];
 	for (const [uiKey, valuesKey, bodyKey] of arrayMappings) {
 		if (fields[uiKey]) {
 			body[bodyKey] = (fields[uiKey] as IDataObject)[valuesKey];
 		}
+	}
+
+	// sshPublicKeys: omit expirationTimeUsec when unset (0) so keys don't expire at epoch
+	if (Array.isArray(body.sshPublicKeys)) {
+		body.sshPublicKeys = (body.sshPublicKeys as IDataObject[]).map((entry) => {
+			if (!entry.expirationTimeUsec) {
+				const { expirationTimeUsec, ...rest } = entry;
+				return rest;
+			}
+			return entry;
+		});
 	}
 }
 

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/GenericFunctions.ts
@@ -104,6 +104,17 @@ export function mapUserExtraFields(fields: IDataObject, body: IDataObject): void
 			return entry;
 		});
 	}
+
+	// organizations: omit fullTimeEquivalent when unset (0) so a blank field doesn't set 0% FTE
+	if (Array.isArray(body.organizations)) {
+		body.organizations = (body.organizations as IDataObject[]).map((entry) => {
+			if (!entry.fullTimeEquivalent) {
+				const { fullTimeEquivalent, ...rest } = entry;
+				return rest;
+			}
+			return entry;
+		});
+	}
 }
 
 export async function googleApiRequestAllItems(

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/UserDescription.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/UserDescription.ts
@@ -58,6 +58,675 @@ const rolesOptions = [
 	},
 ];
 
+const customTypeField = (typeFieldName: string): INodeProperties => ({
+	displayName: 'Custom Type',
+	name: 'customType',
+	type: 'string',
+	default: '',
+	displayOptions: {
+		show: {
+			[typeFieldName]: ['custom'],
+		},
+	},
+	description: 'Free-form value used when Type is set to Custom',
+});
+
+const primaryField: INodeProperties = {
+	displayName: 'Primary',
+	name: 'primary',
+	type: 'boolean',
+	default: false,
+	description: 'Whether this is the primary entry for the user',
+};
+
+// Writable User attributes shared between the create and update operations.
+// See https://developers.google.com/workspace/admin/directory/reference/rest/v1/users
+export const userExtraFields: INodeProperties[] = [
+	{
+		displayName: 'Org Unit Path Name or ID',
+		name: 'orgUnitPath',
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getOrgUnits',
+		},
+		default: '',
+		description:
+			'The full path of the organizational unit the user belongs to. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+	},
+	{
+		displayName: 'Recovery Email',
+		name: 'recoveryEmail',
+		type: 'string',
+		default: '',
+		placeholder: 'e.g. recovery@example.com',
+		description: "The user's recovery email address",
+	},
+	{
+		displayName: 'Recovery Phone',
+		name: 'recoveryPhone',
+		type: 'string',
+		default: '',
+		placeholder: 'e.g. +12025550123',
+		description:
+			'The recovery phone of the user. Must be in E.164 format, starting with the plus sign (+).',
+	},
+	{
+		displayName: 'Include in Global Address List',
+		name: 'includeInGlobalAddressList',
+		type: 'boolean',
+		default: true,
+		description: 'Whether the user is included in the global address list',
+	},
+	{
+		displayName: 'IP Whitelisted',
+		name: 'ipWhitelisted',
+		type: 'boolean',
+		default: false,
+		description: 'Whether the user is exempt from login challenges from untrusted IP addresses',
+	},
+	{
+		displayName: 'Gender',
+		name: 'genderUi',
+		type: 'fixedCollection',
+		placeholder: 'Add Gender',
+		default: {},
+		options: [
+			{
+				name: 'genderValues',
+				displayName: 'Gender',
+				values: [
+					{
+						displayName: 'Type',
+						name: 'type',
+						type: 'options',
+						options: [
+							{ name: 'Custom', value: 'custom' },
+							{ name: 'Female', value: 'female' },
+							{ name: 'Male', value: 'male' },
+							{ name: 'Other', value: 'other' },
+							{ name: 'Unknown', value: 'unknown' },
+						],
+						default: 'unknown',
+					},
+					customTypeField('type'),
+					{
+						displayName: 'Address Me As',
+						name: 'addressMeAs',
+						type: 'string',
+						default: '',
+						description:
+							'A human-readable string describing how to refer to the user, for example "he/him/his" or "they/them/their"',
+					},
+				],
+			},
+		],
+	},
+	{
+		displayName: 'Notes',
+		name: 'notesUi',
+		type: 'fixedCollection',
+		placeholder: 'Add Notes',
+		default: {},
+		options: [
+			{
+				name: 'notesValues',
+				displayName: 'Notes',
+				values: [
+					{
+						displayName: 'Content Type',
+						name: 'contentType',
+						type: 'options',
+						options: [
+							{ name: 'HTML', value: 'text_html' },
+							{ name: 'Plain Text', value: 'text_plain' },
+						],
+						default: 'text_plain',
+					},
+					{
+						displayName: 'Value',
+						name: 'value',
+						type: 'string',
+						typeOptions: {
+							rows: 2,
+						},
+						default: '',
+						description: 'Contents of the notes',
+					},
+				],
+			},
+		],
+	},
+	{
+		displayName: 'Organizations',
+		name: 'organizationUi',
+		type: 'fixedCollection',
+		placeholder: 'Add Organization',
+		typeOptions: {
+			multipleValues: true,
+		},
+		default: {},
+		options: [
+			{
+				name: 'organizationValues',
+				displayName: 'Organization',
+				values: [
+					{
+						displayName: 'Name',
+						name: 'name',
+						type: 'string',
+						default: '',
+						description: 'The name of the organization',
+					},
+					{
+						displayName: 'Title',
+						name: 'title',
+						type: 'string',
+						default: '',
+						description:
+							"The user's title within the organization, for example 'member' or 'engineer'",
+					},
+					{
+						displayName: 'Type',
+						name: 'type',
+						type: 'options',
+						options: [
+							{ name: 'Custom', value: 'custom' },
+							{ name: 'Domain Only', value: 'domain_only' },
+							{ name: 'Other', value: 'other' },
+							{ name: 'School', value: 'school' },
+							{ name: 'Work', value: 'work' },
+						],
+						default: 'work',
+					},
+					customTypeField('type'),
+					{
+						displayName: 'Department',
+						name: 'department',
+						type: 'string',
+						default: '',
+						description: 'Specifies the department within the organization',
+					},
+					{
+						displayName: 'Cost Center',
+						name: 'costCenter',
+						type: 'string',
+						default: '',
+						description: "The cost center of the user's organization",
+					},
+					{
+						displayName: 'Description',
+						name: 'description',
+						type: 'string',
+						default: '',
+						description: 'The description of the organization',
+					},
+					{
+						displayName: 'Domain',
+						name: 'domain',
+						type: 'string',
+						default: '',
+						description: 'The domain the organization belongs to',
+					},
+					{
+						displayName: 'Location',
+						name: 'location',
+						type: 'string',
+						default: '',
+						description: 'The physical location of the organization',
+					},
+					{
+						displayName: 'Symbol',
+						name: 'symbol',
+						type: 'string',
+						default: '',
+						description: 'Text string symbol of the organization',
+					},
+					primaryField,
+				],
+			},
+		],
+	},
+	{
+		displayName: 'Addresses',
+		name: 'addressesUi',
+		type: 'fixedCollection',
+		placeholder: 'Add Address',
+		typeOptions: {
+			multipleValues: true,
+		},
+		default: {},
+		options: [
+			{
+				name: 'addressesValues',
+				displayName: 'Address',
+				values: [
+					{
+						displayName: 'Type',
+						name: 'type',
+						type: 'options',
+						options: [
+							{ name: 'Custom', value: 'custom' },
+							{ name: 'Home', value: 'home' },
+							{ name: 'Other', value: 'other' },
+							{ name: 'Work', value: 'work' },
+						],
+						default: 'home',
+					},
+					customTypeField('type'),
+					{
+						displayName: 'Street Address',
+						name: 'streetAddress',
+						type: 'string',
+						default: '',
+					},
+					{
+						displayName: 'PO Box',
+						name: 'poBox',
+						type: 'string',
+						default: '',
+					},
+					{
+						displayName: 'Extended Address',
+						name: 'extendedAddress',
+						type: 'string',
+						default: '',
+						description: 'For example, the apartment or suite number',
+					},
+					{
+						displayName: 'Locality',
+						name: 'locality',
+						type: 'string',
+						default: '',
+						description: 'The town or city of the address',
+					},
+					{
+						displayName: 'Region',
+						name: 'region',
+						type: 'string',
+						default: '',
+						description: 'The abbreviated province or state',
+					},
+					{
+						displayName: 'Postal Code',
+						name: 'postalCode',
+						type: 'string',
+						default: '',
+					},
+					{
+						displayName: 'Country',
+						name: 'country',
+						type: 'string',
+						default: '',
+					},
+					{
+						displayName: 'Country Code',
+						name: 'countryCode',
+						type: 'string',
+						default: '',
+						description: 'The ISO 3166-1 country code of the address',
+					},
+					primaryField,
+				],
+			},
+		],
+	},
+	{
+		displayName: 'Relations',
+		name: 'relationsUi',
+		type: 'fixedCollection',
+		placeholder: 'Add Relation',
+		typeOptions: {
+			multipleValues: true,
+		},
+		default: {},
+		options: [
+			{
+				name: 'relationsValues',
+				displayName: 'Relation',
+				values: [
+					{
+						displayName: 'Type',
+						name: 'type',
+						type: 'options',
+						options: [
+							{ name: 'Admin Assistant', value: 'admin_assistant' },
+							{ name: 'Assistant', value: 'assistant' },
+							{ name: 'Brother', value: 'brother' },
+							{ name: 'Child', value: 'child' },
+							{ name: 'Custom', value: 'custom' },
+							{ name: 'Domestic Partner', value: 'domestic_partner' },
+							{ name: 'Dotted Line Manager', value: 'dotted_line_manager' },
+							{ name: 'Exec Assistant', value: 'exec_assistant' },
+							{ name: 'Father', value: 'father' },
+							{ name: 'Friend', value: 'friend' },
+							{ name: 'Manager', value: 'manager' },
+							{ name: 'Mother', value: 'mother' },
+							{ name: 'Parent', value: 'parent' },
+							{ name: 'Partner', value: 'partner' },
+							{ name: 'Referred By', value: 'referred_by' },
+							{ name: 'Relative', value: 'relative' },
+							{ name: 'Sister', value: 'sister' },
+							{ name: 'Spouse', value: 'spouse' },
+						],
+						default: 'manager',
+					},
+					customTypeField('type'),
+					{
+						displayName: 'Value',
+						name: 'value',
+						type: 'string',
+						default: '',
+						description: 'The email address or name of the related person',
+					},
+				],
+			},
+		],
+	},
+	{
+		displayName: 'External IDs',
+		name: 'externalIdsUi',
+		type: 'fixedCollection',
+		placeholder: 'Add External ID',
+		typeOptions: {
+			multipleValues: true,
+		},
+		default: {},
+		options: [
+			{
+				name: 'externalIdsValues',
+				displayName: 'External ID',
+				values: [
+					{
+						displayName: 'Type',
+						name: 'type',
+						type: 'options',
+						options: [
+							{ name: 'Account', value: 'account' },
+							{ name: 'Custom', value: 'custom' },
+							{ name: 'Customer', value: 'customer' },
+							{ name: 'Login ID', value: 'login_id' },
+							{ name: 'Network', value: 'network' },
+							{ name: 'Organization', value: 'organization' },
+						],
+						default: 'account',
+					},
+					customTypeField('type'),
+					{
+						displayName: 'Value',
+						name: 'value',
+						type: 'string',
+						default: '',
+						description: 'The value of the external ID',
+					},
+				],
+			},
+		],
+	},
+	{
+		displayName: 'Languages',
+		name: 'languagesUi',
+		type: 'fixedCollection',
+		placeholder: 'Add Language',
+		typeOptions: {
+			multipleValues: true,
+		},
+		default: {},
+		options: [
+			{
+				name: 'languagesValues',
+				displayName: 'Language',
+				values: [
+					{
+						displayName: 'Language Code',
+						name: 'languageCode',
+						type: 'string',
+						default: '',
+						placeholder: 'e.g. en-US',
+						description:
+							'The language code, following the BCP 47 standard. Leave empty and use Custom Language for unsupported languages.',
+					},
+					{
+						displayName: 'Custom Language',
+						name: 'customLanguage',
+						type: 'string',
+						default: '',
+						description: 'A free-form name for a language not supported by a language code',
+					},
+					{
+						displayName: 'Preference',
+						name: 'preference',
+						type: 'options',
+						options: [
+							{ name: 'Not Preferred', value: 'not_preferred' },
+							{ name: 'Preferred', value: 'preferred' },
+						],
+						default: 'preferred',
+						description:
+							'Whether this language is preferred. Only applies when Language Code is set.',
+					},
+				],
+			},
+		],
+	},
+	{
+		displayName: 'Websites',
+		name: 'websitesUi',
+		type: 'fixedCollection',
+		placeholder: 'Add Website',
+		typeOptions: {
+			multipleValues: true,
+		},
+		default: {},
+		options: [
+			{
+				name: 'websitesValues',
+				displayName: 'Website',
+				values: [
+					{
+						displayName: 'Type',
+						name: 'type',
+						type: 'options',
+						options: [
+							{ name: 'App Install Page', value: 'app_install_page' },
+							{ name: 'Blog', value: 'blog' },
+							{ name: 'Custom', value: 'custom' },
+							{ name: 'FTP', value: 'ftp' },
+							{ name: 'Home', value: 'home' },
+							{ name: 'Home Page', value: 'home_page' },
+							{ name: 'Other', value: 'other' },
+							{ name: 'Profile', value: 'profile' },
+							{ name: 'Reservations', value: 'reservations' },
+							{ name: 'Resume', value: 'resume' },
+							{ name: 'Work', value: 'work' },
+						],
+						default: 'home',
+					},
+					customTypeField('type'),
+					{
+						displayName: 'Value',
+						name: 'value',
+						type: 'string',
+						default: '',
+						placeholder: 'e.g. https://example.com',
+						description: 'The URL of the website',
+					},
+					primaryField,
+				],
+			},
+		],
+	},
+	{
+		displayName: 'IMs',
+		name: 'imsUi',
+		type: 'fixedCollection',
+		placeholder: 'Add IM',
+		typeOptions: {
+			multipleValues: true,
+		},
+		default: {},
+		options: [
+			{
+				name: 'imsValues',
+				displayName: 'IM',
+				values: [
+					{
+						displayName: 'Type',
+						name: 'type',
+						type: 'options',
+						options: [
+							{ name: 'Custom', value: 'custom' },
+							{ name: 'Home', value: 'home' },
+							{ name: 'Other', value: 'other' },
+							{ name: 'Work', value: 'work' },
+						],
+						default: 'home',
+					},
+					customTypeField('type'),
+					{
+						displayName: 'Protocol',
+						name: 'protocol',
+						type: 'options',
+						options: [
+							{ name: 'AIM', value: 'aim' },
+							{ name: 'Custom Protocol', value: 'custom_protocol' },
+							{ name: 'Google Talk', value: 'gtalk' },
+							{ name: 'ICQ', value: 'icq' },
+							{ name: 'Jabber', value: 'jabber' },
+							{ name: 'MSN', value: 'msn' },
+							{ name: 'Net Meeting', value: 'net_meeting' },
+							{ name: 'QQ', value: 'qq' },
+							{ name: 'Skype', value: 'skype' },
+							{ name: 'Yahoo', value: 'yahoo' },
+						],
+						default: 'gtalk',
+					},
+					{
+						displayName: 'Custom Protocol',
+						name: 'customProtocol',
+						type: 'string',
+						default: '',
+						displayOptions: {
+							show: {
+								protocol: ['custom_protocol'],
+							},
+						},
+						description: 'Free-form protocol value used when Protocol is set to Custom Protocol',
+					},
+					{
+						displayName: 'IM',
+						name: 'im',
+						type: 'string',
+						default: '',
+						description: "The user's IM network ID",
+					},
+					primaryField,
+				],
+			},
+		],
+	},
+	{
+		displayName: 'Keywords',
+		name: 'keywordsUi',
+		type: 'fixedCollection',
+		placeholder: 'Add Keyword',
+		typeOptions: {
+			multipleValues: true,
+		},
+		default: {},
+		options: [
+			{
+				name: 'keywordsValues',
+				displayName: 'Keyword',
+				values: [
+					{
+						displayName: 'Type',
+						name: 'type',
+						type: 'options',
+						options: [
+							{ name: 'Custom', value: 'custom' },
+							{ name: 'Mission', value: 'mission' },
+							{ name: 'Occupation', value: 'occupation' },
+							{ name: 'Outlook', value: 'outlook' },
+						],
+						default: 'occupation',
+					},
+					customTypeField('type'),
+					{
+						displayName: 'Value',
+						name: 'value',
+						type: 'string',
+						default: '',
+						description: 'Keyword value',
+					},
+				],
+			},
+		],
+	},
+	{
+		displayName: 'Locations',
+		name: 'locationsUi',
+		type: 'fixedCollection',
+		placeholder: 'Add Location',
+		typeOptions: {
+			multipleValues: true,
+		},
+		default: {},
+		options: [
+			{
+				name: 'locationsValues',
+				displayName: 'Location',
+				values: [
+					{
+						displayName: 'Type',
+						name: 'type',
+						type: 'options',
+						options: [
+							{ name: 'Custom', value: 'custom' },
+							{ name: 'Default', value: 'default' },
+							{ name: 'Desk', value: 'desk' },
+						],
+						default: 'desk',
+					},
+					customTypeField('type'),
+					{
+						displayName: 'Area',
+						name: 'area',
+						type: 'string',
+						default: '',
+						description: 'Textual location, for example "Mountain View, CA" or "Near Seattle"',
+					},
+					{
+						displayName: 'Building ID',
+						name: 'buildingId',
+						type: 'string',
+						default: '',
+						description: 'Building identifier',
+					},
+					{
+						displayName: 'Floor Name',
+						name: 'floorName',
+						type: 'string',
+						default: '',
+					},
+					{
+						displayName: 'Floor Section',
+						name: 'floorSection',
+						type: 'string',
+						default: '',
+					},
+					{
+						displayName: 'Desk Code',
+						name: 'deskCode',
+						type: 'string',
+						default: '',
+						description: 'Most specific textual code of individual desk location',
+					},
+				],
+			},
+		],
+	},
+];
+
 export const userOperations: INodeProperties[] = [
 	{
 		displayName: 'Operation',
@@ -534,6 +1203,7 @@ export const userFields: INodeProperties[] = [
 					},
 				],
 			},
+			...userExtraFields,
 		],
 	},
 
@@ -1228,6 +1898,7 @@ export const userFields: INodeProperties[] = [
 					},
 				],
 			},
+			...userExtraFields,
 		],
 	},
 ];

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/UserDescription.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/UserDescription.ts
@@ -140,7 +140,6 @@ export const userExtraFields: INodeProperties[] = [
 						name: 'type',
 						type: 'options',
 						options: [
-							{ name: 'Custom', value: 'custom' },
 							{ name: 'Female', value: 'female' },
 							{ name: 'Male', value: 'male' },
 							{ name: 'Other', value: 'other' },
@@ -148,7 +147,13 @@ export const userExtraFields: INodeProperties[] = [
 						],
 						default: 'unknown',
 					},
-					customTypeField('type'),
+					{
+						displayName: 'Custom Gender',
+						name: 'customGender',
+						type: 'string',
+						default: '',
+						description: 'A free-form gender value (can be set regardless of Type)',
+					},
 					{
 						displayName: 'Address Me As',
 						name: 'addressMeAs',

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/UserDescription.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/UserDescription.ts
@@ -79,6 +79,283 @@ const primaryField: INodeProperties = {
 	description: 'Whether this is the primary entry for the user',
 };
 
+// Fields shared between the create (`additionalFields`) and update (`updateFields`) collections.
+const changePasswordField: INodeProperties = {
+	displayName: 'Change Password at Next Login',
+	name: 'changePasswordAtNextLogin',
+	type: 'boolean',
+	default: false,
+	description: 'Whether the user is forced to change their password at next login',
+};
+
+const phonesField: INodeProperties = {
+	displayName: 'Phones',
+	name: 'phoneUi',
+	placeholder: 'Add Phone',
+	type: 'fixedCollection',
+	typeOptions: {
+		multipleValues: true,
+	},
+	default: {},
+	options: [
+		{
+			name: 'phoneValues',
+			displayName: 'Phone',
+			values: [
+				{
+					displayName: 'Type',
+					name: 'type',
+					type: 'options',
+					options: [
+						{ name: 'Assistant', value: 'assistant' },
+						{ name: 'Callback', value: 'callback' },
+						{ name: 'Car', value: 'car' },
+						{ name: 'Company Main', value: 'company_main' },
+						{ name: 'Custom', value: 'custom' },
+						{ name: 'Grand Central', value: 'grand_central' },
+						{ name: 'Home', value: 'home' },
+						{ name: 'Home Fax', value: 'home_fax' },
+						{ name: 'ISDN', value: 'isdn' },
+						{ name: 'Main', value: 'main' },
+						{ name: 'Mobile', value: 'mobile' },
+						{ name: 'Other', value: 'other' },
+						{ name: 'Other Fax', value: 'other_fax' },
+						{ name: 'Pager', value: 'pager' },
+						{ name: 'Radio', value: 'radio' },
+						{ name: 'Telex', value: 'telex' },
+						{ name: 'TTY TDD', value: 'tty_tdd' },
+						{ name: 'Work', value: 'work' },
+						{ name: 'Work Fax', value: 'work_fax' },
+						{ name: 'Work Mobile', value: 'work_mobile' },
+						{ name: 'Work Pager', value: 'work_pager' },
+					],
+					default: 'work',
+					description: 'The type of phone number',
+				},
+				customTypeField('type'),
+				{
+					displayName: 'Phone Number',
+					name: 'value',
+					type: 'string',
+					default: '',
+					placeholder: 'e.g. +1234567890',
+				},
+				{
+					displayName: 'Primary',
+					name: 'primary',
+					type: 'boolean',
+					default: false,
+					description:
+						"Whether this is the user's primary phone number. A user may only have one primary phone number.",
+				},
+			],
+		},
+	],
+};
+
+const secondaryEmailsField: INodeProperties = {
+	displayName: 'Secondary Emails',
+	name: 'emailUi',
+	placeholder: 'Add Email',
+	type: 'fixedCollection',
+	typeOptions: {
+		multipleValues: true,
+	},
+	default: {},
+	options: [
+		{
+			name: 'emailValues',
+			displayName: 'Email',
+			values: [
+				{
+					displayName: 'Type',
+					name: 'type',
+					type: 'options',
+					options: [
+						{ name: 'Home', value: 'home' },
+						{ name: 'Work', value: 'work' },
+						{ name: 'Other', value: 'other' },
+					],
+					default: 'work',
+					description: 'The type of the email account',
+				},
+				customTypeField('type'),
+				{
+					displayName: 'Email',
+					name: 'address',
+					type: 'string',
+					default: '',
+					placeholder: 'e.g. john.doe.work@example.com',
+				},
+			],
+		},
+	],
+};
+
+const rolesField: INodeProperties = {
+	displayName: 'Roles',
+	name: 'roles',
+	type: 'multiOptions',
+	default: [],
+	description: 'Select the roles you want to assign to the user',
+	options: rolesOptions,
+};
+
+const customFieldsField: INodeProperties = {
+	displayName: 'Custom Fields',
+	name: 'customFields',
+	placeholder: 'Add or Edit Custom Fields',
+	type: 'fixedCollection',
+	typeOptions: {
+		multipleValues: true,
+	},
+	default: {},
+	description: 'Allows editing and adding of custom fields',
+	options: [
+		{
+			name: 'fieldValues',
+			displayName: 'Field',
+			values: [
+				{
+					displayName: 'Schema Name or ID',
+					name: 'schemaName',
+					type: 'options',
+					typeOptions: {
+						loadOptionsMethod: 'getSchemas',
+					},
+					default: '',
+					description:
+						'Select the schema to use for custom fields. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+				},
+				{
+					displayName: 'Field Name or ID',
+					name: 'fieldName',
+					type: 'string',
+					default: '',
+					required: true,
+					description: 'Enter a field name from the selected schema',
+				},
+				{
+					displayName: 'Value',
+					name: 'value',
+					type: 'string',
+					default: '',
+					required: true,
+					description: 'Provide a value for the selected field',
+				},
+			],
+		},
+	],
+};
+
+// Output/projection fields shared between the get and getAll operations.
+const userOutputFields = (operation: 'get' | 'getAll'): INodeProperties[] => [
+	{
+		displayName: 'Output',
+		name: 'output',
+		type: 'options',
+		required: true,
+		default: 'simplified',
+		displayOptions: {
+			show: {
+				operation: [operation],
+				resource: ['user'],
+			},
+		},
+		options: [
+			{
+				name: 'Simplified',
+				value: 'simplified',
+				description:
+					'Only return specific fields: kind, ID, primaryEmail, name (with subfields), isAdmin, lastLoginTime, creationTime, and suspended',
+			},
+			{
+				name: 'Raw',
+				value: 'raw',
+				description: 'Return all fields from the API response',
+			},
+			{
+				name: 'Select Included Fields',
+				value: 'select',
+				description: 'Choose specific fields to include',
+			},
+		],
+	},
+	{
+		displayName: 'Fields',
+		name: 'fields',
+		type: 'multiOptions',
+		default: [],
+		displayOptions: {
+			show: {
+				output: ['select'],
+				operation: [operation],
+				resource: ['user'],
+			},
+		},
+		options: [
+			{ name: 'Creation Time', value: 'creationTime' },
+			{ name: 'Is Admin', value: 'isAdmin' },
+			{ name: 'Kind', value: 'kind' },
+			{ name: 'Last Login Time', value: 'lastLoginTime' },
+			{ name: 'Name', value: 'name' },
+			{ name: 'Primary Email', value: 'primaryEmail' },
+			{ name: 'Suspended', value: 'suspended' },
+		],
+		description: 'Fields to include in the response when "Select Included Fields" is chosen',
+	},
+	{
+		displayName: 'Custom Fields',
+		name: 'projection',
+		type: 'options',
+		required: true,
+		options: [
+			{
+				name: "Don't Include",
+				value: 'basic',
+				description: 'Do not include any custom fields for the user',
+			},
+			{
+				name: 'Custom',
+				value: 'custom',
+				description: 'Include custom fields from schemas requested in Custom Schema Names or IDs',
+			},
+			{
+				name: 'Include All',
+				value: 'full',
+				description: 'Include all fields associated with this user',
+			},
+		],
+		default: 'basic',
+		displayOptions: {
+			show: {
+				operation: [operation],
+				resource: ['user'],
+			},
+		},
+		description: 'What subset of fields to fetch for this user',
+	},
+	{
+		displayName: 'Custom Schema Names or IDs',
+		name: 'customFieldMask',
+		type: 'multiOptions',
+		required: true,
+		displayOptions: {
+			show: {
+				operation: [operation],
+				resource: ['user'],
+				'/projection': ['custom'],
+			},
+		},
+		typeOptions: {
+			loadOptionsMethod: 'getSchemas',
+		},
+		default: [],
+		description:
+			'A comma-separated list of schema names. All fields from these schemas are fetched. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
+	},
+];
+
 // Writable User attributes shared between the create and update operations.
 // See https://developers.google.com/workspace/admin/directory/reference/rest/v1/users
 export const userExtraFields: INodeProperties[] = [
@@ -247,7 +524,7 @@ export const userExtraFields: INodeProperties[] = [
 						name: 'customType',
 						type: 'string',
 						default: '',
-						description: 'A free-form type.',
+						description: 'A free-form type',
 					},
 					{
 						displayName: 'Department',
@@ -983,238 +1260,11 @@ export const userFields: INodeProperties[] = [
 			},
 		},
 		options: [
-			{
-				displayName: 'Change Password at Next Login',
-				name: 'changePasswordAtNextLogin',
-				type: 'boolean',
-				default: false,
-				description: 'Whether the user is forced to change their password at next login',
-			},
-			{
-				displayName: 'Phones',
-				name: 'phoneUi',
-				placeholder: 'Add Phone',
-				type: 'fixedCollection',
-				typeOptions: {
-					multipleValues: true,
-				},
-				default: {},
-				options: [
-					{
-						name: 'phoneValues',
-						displayName: 'Phone',
-						values: [
-							{
-								displayName: 'Type',
-								name: 'type',
-								type: 'options',
-								options: [
-									{
-										name: 'Assistant',
-										value: 'assistant',
-									},
-									{
-										name: 'Callback',
-										value: 'callback',
-									},
-									{
-										name: 'Car',
-										value: 'car',
-									},
-									{
-										name: 'Company Main',
-										value: 'company_main',
-									},
-									{
-										name: 'Custom',
-										value: 'custom',
-									},
-									{
-										name: 'Grand Central',
-										value: 'grand_central',
-									},
-									{
-										name: 'Home',
-										value: 'home',
-									},
-									{
-										name: 'Home Fax',
-										value: 'home_fax',
-									},
-									{
-										name: 'ISDN',
-										value: 'isdn',
-									},
-									{
-										name: 'Main',
-										value: 'main',
-									},
-									{
-										name: 'Mobile',
-										value: 'mobile',
-									},
-									{
-										name: 'Other',
-										value: 'other',
-									},
-									{
-										name: 'Other Fax',
-										value: 'other_fax',
-									},
-									{
-										name: 'Pager',
-										value: 'pager',
-									},
-									{
-										name: 'Radio',
-										value: 'radio',
-									},
-									{
-										name: 'Telex',
-										value: 'telex',
-									},
-									{
-										name: 'TTY TDD',
-										value: 'tty_tdd',
-									},
-									{
-										name: 'Work',
-										value: 'work',
-									},
-									{
-										name: 'Work Fax',
-										value: 'work_fax',
-									},
-									{
-										name: 'Work Mobile',
-										value: 'work_mobile',
-									},
-									{
-										name: 'Work Pager',
-										value: 'work_pager',
-									},
-								],
-								default: 'work',
-								description: 'The type of phone number',
-							},
-							customTypeField('type'),
-							{
-								displayName: 'Phone Number',
-								name: 'value',
-								type: 'string',
-								default: '',
-							},
-							{
-								displayName: 'Primary',
-								name: 'primary',
-								type: 'boolean',
-								default: false,
-								description: "Whether this is the user's primary phone number",
-							},
-						],
-					},
-				],
-			},
-			{
-				displayName: 'Secondary Emails',
-				name: 'emailUi',
-				placeholder: 'Add Email',
-				type: 'fixedCollection',
-				typeOptions: {
-					multipleValues: true,
-				},
-				default: {},
-				options: [
-					{
-						name: 'emailValues',
-						displayName: 'Email',
-						values: [
-							{
-								displayName: 'Type',
-								name: 'type',
-								type: 'options',
-								options: [
-									{
-										name: 'Home',
-										value: 'home',
-									},
-									{
-										name: 'Work',
-										value: 'work',
-									},
-									{
-										name: 'Other',
-										value: 'other',
-									},
-								],
-								default: 'work',
-								description: 'The type of the email account',
-							},
-							customTypeField('type'),
-							{
-								displayName: 'Email',
-								name: 'address',
-								type: 'string',
-								default: '',
-							},
-						],
-					},
-				],
-			},
-			{
-				displayName: 'Roles',
-				name: 'roles',
-				type: 'multiOptions',
-				default: [],
-				description: 'Select the roles you want to assign to the user',
-				options: rolesOptions,
-			},
-			{
-				displayName: 'Custom Fields',
-				name: 'customFields',
-				placeholder: 'Add or Edit Custom Fields',
-				type: 'fixedCollection',
-				typeOptions: {
-					multipleValues: true,
-				},
-				default: {},
-				description: 'Allows editing and adding of custom fields',
-				options: [
-					{
-						name: 'fieldValues',
-						displayName: 'Field',
-						values: [
-							{
-								displayName: 'Schema Name or ID',
-								name: 'schemaName',
-								type: 'options',
-								typeOptions: {
-									loadOptionsMethod: 'getSchemas',
-								},
-								default: '',
-								description:
-									'Select the schema to use for custom fields. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
-							},
-							{
-								displayName: 'Field Name or ID',
-								name: 'fieldName',
-								type: 'string',
-								default: '',
-								required: true,
-								description: 'Enter a field name from the selected schema',
-							},
-							{
-								displayName: 'Value',
-								name: 'value',
-								type: 'string',
-								default: '',
-								required: true,
-								description: 'Provide a value for the selected field',
-							},
-						],
-					},
-				],
-			},
+			changePasswordField,
+			phonesField,
+			secondaryEmailsField,
+			rolesField,
+			customFieldsField,
 			...userExtraFields,
 		],
 	},
@@ -1222,131 +1272,7 @@ export const userFields: INodeProperties[] = [
 	/* -------------------------------------------------------------------------- */
 	/*                                 user:get                                   */
 	/* -------------------------------------------------------------------------- */
-	{
-		displayName: 'Output',
-		name: 'output',
-		type: 'options',
-		required: true,
-		default: 'simplified',
-		displayOptions: {
-			show: {
-				operation: ['get'],
-				resource: ['user'],
-			},
-		},
-		options: [
-			{
-				name: 'Simplified',
-				value: 'simplified',
-				description:
-					'Only return specific fields: kind, ID, primaryEmail, name (with subfields), isAdmin, lastLoginTime, creationTime, and suspended',
-			},
-			{
-				name: 'Raw',
-				value: 'raw',
-				description: 'Return all fields from the API response',
-			},
-			{
-				name: 'Select Included Fields',
-				value: 'select',
-				description: 'Choose specific fields to include',
-			},
-		],
-	},
-	{
-		displayName: 'Fields',
-		name: 'fields',
-		type: 'multiOptions',
-		default: [],
-		displayOptions: {
-			show: {
-				output: ['select'],
-				operation: ['get'],
-				resource: ['user'],
-			},
-		},
-		options: [
-			{
-				name: 'Creation Time',
-				value: 'creationTime',
-			},
-			{
-				name: 'Is Admin',
-				value: 'isAdmin',
-			},
-			{
-				name: 'Kind',
-				value: 'kind',
-			},
-			{
-				name: 'Last Login Time',
-				value: 'lastLoginTime',
-			},
-			{
-				name: 'Name',
-				value: 'name',
-			},
-			{
-				name: 'Primary Email',
-				value: 'primaryEmail',
-			},
-			{
-				name: 'Suspended',
-				value: 'suspended',
-			},
-		],
-		description: 'Fields to include in the response when "Select Included Fields" is chosen',
-	},
-	{
-		displayName: 'Custom Fields',
-		name: 'projection',
-		type: 'options',
-		required: true,
-		options: [
-			{
-				name: "Don't Include",
-				value: 'basic',
-				description: 'Do not include any custom fields for the user',
-			},
-			{
-				name: 'Custom',
-				value: 'custom',
-				description: 'Include custom fields from schemas requested in Custom Schema Names or IDs',
-			},
-			{
-				name: 'Include All',
-				value: 'full',
-				description: 'Include all fields associated with this user',
-			},
-		],
-		default: 'basic',
-		displayOptions: {
-			show: {
-				operation: ['get'],
-				resource: ['user'],
-			},
-		},
-		description: 'What subset of fields to fetch for this user',
-	},
-	{
-		displayName: 'Custom Schema Names or IDs',
-		name: 'customFieldMask',
-		type: 'multiOptions',
-		required: true,
-		displayOptions: {
-			show: {
-				operation: ['get'],
-				resource: ['user'],
-				'/projection': ['custom'],
-			},
-		},
-		typeOptions: {
-			loadOptionsMethod: 'getSchemas',
-		},
-		default: [],
-		description:
-			'A comma-separated list of schema names. All fields from these schemas are fetched. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
-	},
+	...userOutputFields('get'),
 
 	/* -------------------------------------------------------------------------- */
 	/*                                 user:getAll                                */
@@ -1382,131 +1308,7 @@ export const userFields: INodeProperties[] = [
 		default: 100,
 		description: 'Max number of results to return',
 	},
-	{
-		displayName: 'Output',
-		name: 'output',
-		type: 'options',
-		required: true,
-		default: 'simplified',
-		displayOptions: {
-			show: {
-				operation: ['getAll'],
-				resource: ['user'],
-			},
-		},
-		options: [
-			{
-				name: 'Simplified',
-				value: 'simplified',
-				description:
-					'Only return specific fields: kind, ID, primaryEmail, name (with subfields), isAdmin, lastLoginTime, creationTime, and suspended',
-			},
-			{
-				name: 'Raw',
-				value: 'raw',
-				description: 'Return all fields from the API response',
-			},
-			{
-				name: 'Select Included Fields',
-				value: 'select',
-				description: 'Choose specific fields to include',
-			},
-		],
-	},
-	{
-		displayName: 'Fields',
-		name: 'fields',
-		type: 'multiOptions',
-		default: [],
-		displayOptions: {
-			show: {
-				output: ['select'],
-				operation: ['getAll'],
-				resource: ['user'],
-			},
-		},
-		options: [
-			{
-				name: 'Creation Time',
-				value: 'creationTime',
-			},
-			{
-				name: 'Is Admin',
-				value: 'isAdmin',
-			},
-			{
-				name: 'Kind',
-				value: 'kind',
-			},
-			{
-				name: 'Last Login Time',
-				value: 'lastLoginTime',
-			},
-			{
-				name: 'Name',
-				value: 'name',
-			},
-			{
-				name: 'Primary Email',
-				value: 'primaryEmail',
-			},
-			{
-				name: 'Suspended',
-				value: 'suspended',
-			},
-		],
-		description: 'Fields to include in the response when "Select Included Fields" is chosen',
-	},
-	{
-		displayName: 'Custom Fields',
-		name: 'projection',
-		type: 'options',
-		required: true,
-		displayOptions: {
-			show: {
-				operation: ['getAll'],
-				resource: ['user'],
-			},
-		},
-		options: [
-			{
-				name: "Don't Include",
-				value: 'basic',
-				description: 'Do not include any custom fields for the user',
-			},
-			{
-				name: 'Custom',
-				value: 'custom',
-				description: 'Include custom fields from schemas requested in Custom Schema Names or IDs',
-			},
-			{
-				name: 'Include All',
-				value: 'full',
-				description: 'Include all fields associated with this user',
-			},
-		],
-		default: 'basic',
-		description: 'What subset of fields to fetch for this user',
-	},
-	{
-		displayName: 'Custom Schema Names or IDs',
-		name: 'customFieldMask',
-		type: 'multiOptions',
-		required: true,
-		displayOptions: {
-			show: {
-				operation: ['getAll'],
-				resource: ['user'],
-				'/projection': ['custom'],
-			},
-		},
-		typeOptions: {
-			loadOptionsMethod: 'getSchemas',
-		},
-		default: [],
-		description:
-			'A comma-separated list of schema names. All fields from these schemas are fetched. Choose from the list, or specify IDs using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
-	},
+	...userOutputFields('getAll'),
 	{
 		displayName: 'Filter',
 		name: 'filter',
@@ -1644,13 +1446,7 @@ export const userFields: INodeProperties[] = [
 				description:
 					'Whether to set the user as suspended. If set to OFF, the user will be reactivated. If not added, the status will remain unchanged.',
 			},
-			{
-				displayName: 'Change Password at Next Login',
-				name: 'changePasswordAtNextLogin',
-				type: 'boolean',
-				default: false,
-				description: 'Whether the user is forced to change their password at next login',
-			},
+			changePasswordField,
 			{
 				displayName: 'First Name',
 				name: 'firstName',
@@ -1675,133 +1471,7 @@ export const userFields: INodeProperties[] = [
 				description:
 					'Stores the password for the user account. A minimum of 8 characters is required. The maximum length is 100 characters.',
 			},
-			{
-				displayName: 'Phones',
-				name: 'phoneUi',
-				placeholder: 'Add Phone',
-				type: 'fixedCollection',
-				typeOptions: {
-					multipleValues: true,
-				},
-				default: {},
-				options: [
-					{
-						name: 'phoneValues',
-						displayName: 'Phone',
-						values: [
-							{
-								displayName: 'Type',
-								name: 'type',
-								type: 'options',
-								options: [
-									{
-										name: 'Assistant',
-										value: 'assistant',
-									},
-									{
-										name: 'Callback',
-										value: 'callback',
-									},
-									{
-										name: 'Car',
-										value: 'car',
-									},
-									{
-										name: 'Company Main',
-										value: 'company_main',
-									},
-									{
-										name: 'Custom',
-										value: 'custom',
-									},
-									{
-										name: 'Grand Central',
-										value: 'grand_central',
-									},
-									{
-										name: 'Home',
-										value: 'home',
-									},
-									{
-										name: 'Home Fax',
-										value: 'home_fax',
-									},
-									{
-										name: 'ISDN',
-										value: 'isdn',
-									},
-									{
-										name: 'Main',
-										value: 'main',
-									},
-									{
-										name: 'Mobile',
-										value: 'mobile',
-									},
-									{
-										name: 'Other',
-										value: 'other',
-									},
-									{
-										name: 'Other Fax',
-										value: 'other_fax',
-									},
-									{
-										name: 'Pager',
-										value: 'pager',
-									},
-									{
-										name: 'Radio',
-										value: 'radio',
-									},
-									{
-										name: 'Telex',
-										value: 'telex',
-									},
-									{
-										name: 'TTY TDD',
-										value: 'tty_tdd',
-									},
-									{
-										name: 'Work',
-										value: 'work',
-									},
-									{
-										name: 'Work Fax',
-										value: 'work_fax',
-									},
-									{
-										name: 'Work Mobile',
-										value: 'work_mobile',
-									},
-									{
-										name: 'Work Pager',
-										value: 'work_pager',
-									},
-								],
-								default: 'work',
-								description: 'The type of phone number',
-							},
-							customTypeField('type'),
-							{
-								displayName: 'Phone Number',
-								name: 'value',
-								type: 'string',
-								default: '',
-								placeholder: 'e.g. +1234567890',
-							},
-							{
-								displayName: 'Primary',
-								name: 'primary',
-								type: 'boolean',
-								default: false,
-								description:
-									"Whether this is the user's primary phone number. A user may only have one primary phone number.",
-							},
-						],
-					},
-				],
-			},
+			phonesField,
 			{
 				displayName: 'Primary Email',
 				name: 'primaryEmail',
@@ -1811,107 +1481,9 @@ export const userFields: INodeProperties[] = [
 				description:
 					"The user's primary email address. This property is required in a request to create a user account. The primaryEmail must be unique and cannot be an alias of another user.",
 			},
-			{
-				displayName: 'Secondary Emails',
-				name: 'emailUi',
-				placeholder: 'Add Email',
-				type: 'fixedCollection',
-				typeOptions: {
-					multipleValues: true,
-				},
-				default: {},
-				options: [
-					{
-						name: 'emailValues',
-						displayName: 'Email',
-						values: [
-							{
-								displayName: 'Type',
-								name: 'type',
-								type: 'options',
-								options: [
-									{
-										name: 'Home',
-										value: 'home',
-									},
-									{
-										name: 'Work',
-										value: 'work',
-									},
-									{
-										name: 'Other',
-										value: 'other',
-									},
-								],
-								default: 'work',
-								description: 'The type of the email account',
-							},
-							customTypeField('type'),
-							{
-								displayName: 'Email',
-								name: 'address',
-								type: 'string',
-								default: '',
-								placeholder: 'e.g. john.doe.work@example.com',
-							},
-						],
-					},
-				],
-			},
-			{
-				displayName: 'Roles',
-				name: 'roles',
-				type: 'multiOptions',
-				default: [],
-				description: 'Select the roles you want to assign to the user',
-				options: rolesOptions,
-			},
-			{
-				displayName: 'Custom Fields',
-				name: 'customFields',
-				placeholder: 'Add or Edit Custom Fields',
-				type: 'fixedCollection',
-				typeOptions: {
-					multipleValues: true,
-				},
-				default: {},
-				description: 'Allows editing and adding of custom fields',
-				options: [
-					{
-						name: 'fieldValues',
-						displayName: 'Field',
-						values: [
-							{
-								displayName: 'Schema Name or ID',
-								name: 'schemaName',
-								type: 'options',
-								typeOptions: {
-									loadOptionsMethod: 'getSchemas',
-								},
-								default: '',
-								description:
-									'Select the schema to use for custom fields. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code/expressions/">expression</a>.',
-							},
-							{
-								displayName: 'Field Name or ID',
-								name: 'fieldName',
-								type: 'string',
-								default: '',
-								required: true,
-								description: 'Enter a field name from the selected schema',
-							},
-							{
-								displayName: 'Value',
-								name: 'value',
-								type: 'string',
-								default: '',
-								required: true,
-								description: 'Provide a value for the selected field',
-							},
-						],
-					},
-				],
-			},
+			secondaryEmailsField,
+			rolesField,
+			customFieldsField,
 			...userExtraFields,
 		],
 	},

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/UserDescription.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/UserDescription.ts
@@ -1012,6 +1012,93 @@ export const userExtraFields: INodeProperties[] = [
 			},
 		],
 	},
+	{
+		displayName: 'POSIX Accounts',
+		name: 'posixAccountsUi',
+		type: 'fixedCollection',
+		placeholder: 'Add POSIX Account',
+		typeOptions: {
+			multipleValues: true,
+		},
+		default: {},
+		options: [
+			{
+				name: 'posixAccountsValues',
+				displayName: 'POSIX Account',
+				values: [
+					{
+						displayName: 'Username',
+						name: 'username',
+						type: 'string',
+						default: '',
+						description: 'The username of the account',
+					},
+					{
+						displayName: 'UID',
+						name: 'uid',
+						type: 'number',
+						default: 0,
+						description: 'The POSIX compliant user ID',
+					},
+					{
+						displayName: 'GID',
+						name: 'gid',
+						type: 'number',
+						default: 0,
+						description: 'The default group ID',
+					},
+					{
+						displayName: 'Home Directory',
+						name: 'homeDirectory',
+						type: 'string',
+						default: '',
+						description: 'The path to the home directory for this account',
+					},
+					{
+						displayName: 'Shell',
+						name: 'shell',
+						type: 'string',
+						default: '',
+						description: 'The path to the login shell for this account',
+					},
+					{
+						displayName: 'GECOS',
+						name: 'gecos',
+						type: 'string',
+						default: '',
+						description: 'The GECOS (user information) for this account',
+					},
+					{
+						displayName: 'System ID',
+						name: 'systemId',
+						type: 'string',
+						default: '',
+						description: 'System identifier for which account username or UID apply to',
+					},
+					{
+						displayName: 'Account ID',
+						name: 'accountId',
+						type: 'string',
+						default: '',
+						description: 'A POSIX account field identifier',
+					},
+					{
+						displayName: 'Operating System Type',
+						name: 'operatingSystemType',
+						type: 'options',
+						options: [
+							{ name: 'Linux', value: 'linux' },
+							{ name: 'Unspecified', value: 'unspecified' },
+							{ name: 'Windows', value: 'windows' },
+						],
+						default: 'linux',
+						description: 'The operating system type for this account',
+					},
+					primaryField,
+				],
+			},
+		],
+	},
 ];
 
 export const userOperations: INodeProperties[] = [

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/UserDescription.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/UserDescription.ts
@@ -568,6 +568,14 @@ export const userExtraFields: INodeProperties[] = [
 						default: '',
 						description: 'Text string symbol of the organization',
 					},
+					{
+						displayName: 'Full-Time Equivalent',
+						name: 'fullTimeEquivalent',
+						type: 'number',
+						default: 0,
+						description:
+							'The full-time equivalent millipercent within the organization (100000 = 100%). Leave 0 to omit.',
+					},
 					primaryField,
 				],
 			},

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/UserDescription.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/UserDescription.ts
@@ -1099,6 +1099,38 @@ export const userExtraFields: INodeProperties[] = [
 			},
 		],
 	},
+	{
+		displayName: 'SSH Public Keys',
+		name: 'sshPublicKeysUi',
+		type: 'fixedCollection',
+		placeholder: 'Add SSH Public Key',
+		typeOptions: {
+			multipleValues: true,
+		},
+		default: {},
+		options: [
+			{
+				name: 'sshPublicKeysValues',
+				displayName: 'SSH Public Key',
+				values: [
+					{
+						displayName: 'Key',
+						name: 'key',
+						type: 'string',
+						default: '',
+						description: 'The SSH public key',
+					},
+					{
+						displayName: 'Expiration Time (Usec)',
+						name: 'expirationTimeUsec',
+						type: 'number',
+						default: 0,
+						description: 'Expiration time in microseconds since epoch. Leave 0 for no expiration.',
+					},
+				],
+			},
+		],
+	},
 ];
 
 export const userOperations: INodeProperties[] = [

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/UserDescription.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/UserDescription.ts
@@ -235,7 +235,6 @@ export const userExtraFields: INodeProperties[] = [
 						name: 'type',
 						type: 'options',
 						options: [
-							{ name: 'Custom', value: 'custom' },
 							{ name: 'Domain Only', value: 'domain_only' },
 							{ name: 'Other', value: 'other' },
 							{ name: 'School', value: 'school' },
@@ -243,7 +242,13 @@ export const userExtraFields: INodeProperties[] = [
 						],
 						default: 'work',
 					},
-					customTypeField('type'),
+					{
+						displayName: 'Custom Type',
+						name: 'customType',
+						type: 'string',
+						default: '',
+						description: 'A free-form type.',
+					},
 					{
 						displayName: 'Department',
 						name: 'department',
@@ -1092,6 +1097,7 @@ export const userFields: INodeProperties[] = [
 								default: 'work',
 								description: 'The type of phone number',
 							},
+							customTypeField('type'),
 							{
 								displayName: 'Phone Number',
 								name: 'value',
@@ -1144,6 +1150,7 @@ export const userFields: INodeProperties[] = [
 								default: 'work',
 								description: 'The type of the email account',
 							},
+							customTypeField('type'),
 							{
 								displayName: 'Email',
 								name: 'address',
@@ -1775,6 +1782,7 @@ export const userFields: INodeProperties[] = [
 								default: 'work',
 								description: 'The type of phone number',
 							},
+							customTypeField('type'),
 							{
 								displayName: 'Phone Number',
 								name: 'value',
@@ -1838,6 +1846,7 @@ export const userFields: INodeProperties[] = [
 								default: 'work',
 								description: 'The type of the email account',
 							},
+							customTypeField('type'),
 							{
 								displayName: 'Email',
 								name: 'address',

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/GSuiteAdmin.node.test.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/GSuiteAdmin.node.test.ts
@@ -16,6 +16,7 @@ vi.mock('../GenericFunctions', () => ({
 	})),
 	googleApiRequest: vi.fn(),
 	googleApiRequestAllItems: vi.fn(),
+	mapUserExtraFields: vi.fn(),
 }));
 
 const node = new GSuiteAdmin();

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/GSuiteAdmin.node.test.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/GSuiteAdmin.node.test.ts
@@ -103,8 +103,8 @@ describe('GSuiteAdmin Node - loadOptions', () => {
 
 			const result = await node.methods.loadOptions.getOrgUnits.call(mockThis);
 			expect(result).toEqual([
-				{ name: 'Engineering', value: '/engineering' },
-				{ name: 'HR', value: '/hr' },
+				{ name: '/engineering', value: '/engineering' },
+				{ name: '/hr', value: '/hr' },
 			]);
 		});
 	});

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/GenericFunctions.test.ts
@@ -1,7 +1,7 @@
-import type { IExecuteFunctions, ILoadOptionsFunctions } from 'n8n-workflow';
+import type { IDataObject, IExecuteFunctions, ILoadOptionsFunctions } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
 
-import { googleApiRequest, googleApiRequestAllItems } from '../GenericFunctions';
+import { googleApiRequest, googleApiRequestAllItems, mapUserExtraFields } from '../GenericFunctions';
 import type { Mock } from 'vitest';
 
 describe('Google GSuiteAdmin Node', () => {
@@ -170,5 +170,76 @@ describe('Google GSuiteAdmin Node', () => {
 
 		expect(mockContext.getNode).toHaveBeenCalled();
 		expect(mockContext.helpers.httpRequestWithAuthentication).toHaveBeenCalledTimes(1);
+	});
+
+	describe('mapUserExtraFields', () => {
+		it('should map scalar attributes onto the body', () => {
+			const body: IDataObject = {};
+
+			mapUserExtraFields(
+				{
+					orgUnitPath: '/Sales',
+					recoveryEmail: 'recovery@example.com',
+					recoveryPhone: '+12025550123',
+					includeInGlobalAddressList: false,
+					ipWhitelisted: true,
+				},
+				body,
+			);
+
+			expect(body).toEqual({
+				orgUnitPath: '/Sales',
+				recoveryEmail: 'recovery@example.com',
+				recoveryPhone: '+12025550123',
+				includeInGlobalAddressList: false,
+				ipWhitelisted: true,
+			});
+		});
+
+		it('should unwrap single-object fixedCollections (gender, notes)', () => {
+			const body: IDataObject = {};
+
+			mapUserExtraFields(
+				{
+					genderUi: { genderValues: { type: 'custom', customGender: 'non-binary' } },
+					notesUi: { notesValues: { contentType: 'text_plain', value: 'A note' } },
+				},
+				body,
+			);
+
+			expect(body).toEqual({
+				gender: { type: 'custom', customGender: 'non-binary' },
+				notes: { contentType: 'text_plain', value: 'A note' },
+			});
+		});
+
+		it('should unwrap array fixedCollections into API arrays', () => {
+			const body: IDataObject = {};
+
+			mapUserExtraFields(
+				{
+					organizationUi: {
+						organizationValues: [{ name: 'Acme', title: 'Engineer', type: 'work' }],
+					},
+					relationsUi: { relationsValues: [{ type: 'manager', value: 'boss@example.com' }] },
+					addressesUi: { addressesValues: [{ type: 'home', locality: 'Berlin' }] },
+				},
+				body,
+			);
+
+			expect(body).toEqual({
+				organizations: [{ name: 'Acme', title: 'Engineer', type: 'work' }],
+				relations: [{ type: 'manager', value: 'boss@example.com' }],
+				addresses: [{ type: 'home', locality: 'Berlin' }],
+			});
+		});
+
+		it('should not set keys for omitted fields', () => {
+			const body: IDataObject = {};
+
+			mapUserExtraFields({}, body);
+
+			expect(body).toEqual({});
+		});
 	});
 });

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/GenericFunctions.test.ts
@@ -201,14 +201,14 @@ describe('Google GSuiteAdmin Node', () => {
 
 			mapUserExtraFields(
 				{
-					genderUi: { genderValues: { type: 'custom', customGender: 'non-binary' } },
+					genderUi: { genderValues: { type: 'unknown', customGender: 'non-binary' } },
 					notesUi: { notesValues: { contentType: 'text_plain', value: 'A note' } },
 				},
 				body,
 			);
 
 			expect(body).toEqual({
-				gender: { type: 'custom', customGender: 'non-binary' },
+				gender: { type: 'unknown', customGender: 'non-binary' },
 				notes: { contentType: 'text_plain', value: 'A note' },
 			});
 		});

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/GenericFunctions.test.ts
@@ -1,7 +1,11 @@
 import type { IDataObject, IExecuteFunctions, ILoadOptionsFunctions } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
 
-import { googleApiRequest, googleApiRequestAllItems, mapUserExtraFields } from '../GenericFunctions';
+import {
+	googleApiRequest,
+	googleApiRequestAllItems,
+	mapUserExtraFields,
+} from '../GenericFunctions';
 import type { Mock } from 'vitest';
 
 describe('Google GSuiteAdmin Node', () => {
@@ -231,6 +235,43 @@ describe('Google GSuiteAdmin Node', () => {
 				organizations: [{ name: 'Acme', title: 'Engineer', type: 'work' }],
 				relations: [{ type: 'manager', value: 'boss@example.com' }],
 				addresses: [{ type: 'home', locality: 'Berlin' }],
+			});
+		});
+
+		it('should unwrap posixAccounts into the API array', () => {
+			const body: IDataObject = {};
+
+			mapUserExtraFields(
+				{
+					posixAccountsUi: {
+						posixAccountsValues: [
+							{
+								username: 'jdoe',
+								uid: 1001,
+								gid: 1001,
+								homeDirectory: '/home/jdoe',
+								shell: '/bin/bash',
+								operatingSystemType: 'linux',
+								primary: true,
+							},
+						],
+					},
+				},
+				body,
+			);
+
+			expect(body).toEqual({
+				posixAccounts: [
+					{
+						username: 'jdoe',
+						uid: 1001,
+						gid: 1001,
+						homeDirectory: '/home/jdoe',
+						shell: '/bin/bash',
+						operatingSystemType: 'linux',
+						primary: true,
+					},
+				],
 			});
 		});
 

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/GenericFunctions.test.ts
@@ -275,6 +275,46 @@ describe('Google GSuiteAdmin Node', () => {
 			});
 		});
 
+		it('should unwrap sshPublicKeys into the API array', () => {
+			const body: IDataObject = {};
+
+			mapUserExtraFields(
+				{
+					sshPublicKeysUi: {
+						sshPublicKeysValues: [{ key: 'ssh-rsa AAAA', expirationTimeUsec: 1893456000000000 }],
+					},
+				},
+				body,
+			);
+
+			expect(body).toEqual({
+				sshPublicKeys: [{ key: 'ssh-rsa AAAA', expirationTimeUsec: 1893456000000000 }],
+			});
+		});
+
+		it('should drop expirationTimeUsec from sshPublicKeys when unset (0)', () => {
+			const body: IDataObject = {};
+
+			mapUserExtraFields(
+				{
+					sshPublicKeysUi: {
+						sshPublicKeysValues: [
+							{ key: 'ssh-rsa AAAA', expirationTimeUsec: 0 },
+							{ key: 'ssh-ed25519 BBBB', expirationTimeUsec: 1893456000000000 },
+						],
+					},
+				},
+				body,
+			);
+
+			expect(body).toEqual({
+				sshPublicKeys: [
+					{ key: 'ssh-rsa AAAA' },
+					{ key: 'ssh-ed25519 BBBB', expirationTimeUsec: 1893456000000000 },
+				],
+			});
+		});
+
 		it('should not set keys for omitted fields', () => {
 			const body: IDataObject = {};
 

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/GenericFunctions.test.ts
@@ -315,6 +315,26 @@ describe('Google GSuiteAdmin Node', () => {
 			});
 		});
 
+		it('should drop fullTimeEquivalent from organizations when unset (0)', () => {
+			const body: IDataObject = {};
+
+			mapUserExtraFields(
+				{
+					organizationUi: {
+						organizationValues: [
+							{ name: 'Acme', fullTimeEquivalent: 0 },
+							{ name: 'Globex', fullTimeEquivalent: 100000 },
+						],
+					},
+				},
+				body,
+			);
+
+			expect(body).toEqual({
+				organizations: [{ name: 'Acme' }, { name: 'Globex', fullTimeEquivalent: 100000 }],
+			});
+		});
+
 		it('should not set keys for omitted fields', () => {
 			const body: IDataObject = {};
 

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/create.workflow.json
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/create.workflow.json
@@ -32,6 +32,17 @@
 						]
 					},
 					"roles": ["groupsAdmin"],
+					"orgUnitPath": "/Sales",
+					"recoveryEmail": "recovery@example.com",
+					"organizationUi": {
+						"organizationValues": [
+							{
+								"name": "Acme",
+								"title": "Engineer",
+								"type": "work"
+							}
+						]
+					},
 					"customFields": {
 						"fieldValues": [
 							{

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/create.workflow.json
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/create.workflow.json
@@ -39,7 +39,8 @@
 							{
 								"name": "Acme",
 								"title": "Engineer",
-								"type": "work"
+								"type": "work",
+								"fullTimeEquivalent": 100000
 							}
 						]
 					},

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/create.workflow.json
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/create.workflow.json
@@ -53,6 +53,14 @@
 							}
 						]
 					},
+					"sshPublicKeysUi": {
+						"sshPublicKeysValues": [
+							{
+								"key": "ssh-rsa AAAA",
+								"expirationTimeUsec": 1893456000000000
+							}
+						]
+					},
 					"customFields": {
 						"fieldValues": [
 							{

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/create.workflow.json
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/create.workflow.json
@@ -43,6 +43,16 @@
 							}
 						]
 					},
+					"posixAccountsUi": {
+						"posixAccountsValues": [
+							{
+								"username": "jdoe",
+								"uid": 1001,
+								"operatingSystemType": "linux",
+								"primary": true
+							}
+						]
+					},
 					"customFields": {
 						"fieldValues": [
 							{

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/update.test.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/update.test.ts
@@ -25,6 +25,28 @@ describe('Google GSuiteAdmin Node - Update User', () => {
 						type: 'home',
 					},
 				],
+				orgUnitPath: '/Sales',
+				recoveryEmail: 'recovery@example.com',
+				organizations: [
+					{
+						name: 'Acme',
+						title: 'Engineer',
+						type: 'work',
+						department: '',
+						costCenter: '',
+						description: '',
+						domain: '',
+						location: '',
+						symbol: '',
+						primary: true,
+					},
+				],
+				relations: [
+					{
+						type: 'manager',
+						value: 'boss@example.com',
+					},
+				],
 			})
 			.reply(200, {
 				kind: 'admin#directory#user',

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/update.test.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/update.test.ts
@@ -62,6 +62,12 @@ describe('Google GSuiteAdmin Node - Update User', () => {
 						primary: true,
 					},
 				],
+				sshPublicKeys: [
+					{
+						key: 'ssh-rsa AAAA',
+						expirationTimeUsec: 1893456000000000,
+					},
+				],
 			})
 			.reply(200, {
 				kind: 'admin#directory#user',

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/update.test.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/update.test.ts
@@ -39,6 +39,7 @@ describe('Google GSuiteAdmin Node - Update User', () => {
 						domain: '',
 						location: '',
 						symbol: '',
+						fullTimeEquivalent: 100000,
 						primary: true,
 					},
 				],

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/update.test.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/update.test.ts
@@ -32,6 +32,7 @@ describe('Google GSuiteAdmin Node - Update User', () => {
 						name: 'Acme',
 						title: 'Engineer',
 						type: 'work',
+						customType: '',
 						department: '',
 						costCenter: '',
 						description: '',

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/update.test.ts
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/update.test.ts
@@ -48,6 +48,20 @@ describe('Google GSuiteAdmin Node - Update User', () => {
 						value: 'boss@example.com',
 					},
 				],
+				posixAccounts: [
+					{
+						username: 'jdoe',
+						uid: 1001,
+						gid: 1001,
+						homeDirectory: '/home/jdoe',
+						shell: '/bin/bash',
+						gecos: 'John Doe',
+						systemId: 'sys1',
+						accountId: 'acc1',
+						operatingSystemType: 'linux',
+						primary: true,
+					},
+				],
 			})
 			.reply(200, {
 				kind: 'admin#directory#user',

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/update.workflow.json
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/update.workflow.json
@@ -38,6 +38,26 @@
 								"address": "newone@example.com"
 							}
 						]
+					},
+					"orgUnitPath": "/Sales",
+					"recoveryEmail": "recovery@example.com",
+					"organizationUi": {
+						"organizationValues": [
+							{
+								"name": "Acme",
+								"title": "Engineer",
+								"type": "work",
+								"primary": true
+							}
+						]
+					},
+					"relationsUi": {
+						"relationsValues": [
+							{
+								"type": "manager",
+								"value": "boss@example.com"
+							}
+						]
 					}
 				}
 			},

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/update.workflow.json
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/update.workflow.json
@@ -74,6 +74,14 @@
 								"primary": true
 							}
 						]
+					},
+					"sshPublicKeysUi": {
+						"sshPublicKeysValues": [
+							{
+								"key": "ssh-rsa AAAA",
+								"expirationTimeUsec": 1893456000000000
+							}
+						]
 					}
 				}
 			},

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/update.workflow.json
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/update.workflow.json
@@ -58,6 +58,22 @@
 								"value": "boss@example.com"
 							}
 						]
+					},
+					"posixAccountsUi": {
+						"posixAccountsValues": [
+							{
+								"username": "jdoe",
+								"uid": 1001,
+								"gid": 1001,
+								"homeDirectory": "/home/jdoe",
+								"shell": "/bin/bash",
+								"gecos": "John Doe",
+								"systemId": "sys1",
+								"accountId": "acc1",
+								"operatingSystemType": "linux",
+								"primary": true
+							}
+						]
 					}
 				}
 			},

--- a/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/update.workflow.json
+++ b/packages/nodes-base/nodes/Google/GSuiteAdmin/test/user/update.workflow.json
@@ -47,6 +47,7 @@
 								"name": "Acme",
 								"title": "Engineer",
 								"type": "work",
+								"fullTimeEquivalent": 100000,
 								"primary": true
 							}
 						]


### PR DESCRIPTION
## Summary

Extends the **Google Workspace Admin** node so the `user: create` and
`user: update` operations can write the full set of user attributes supported
by the Google Directory API, not just name/email/phone/roles.

Newly writable attributes:

- `orgUnitPath`, `recoveryEmail`, `recoveryPhone`
- `includeInGlobalAddressList`, `ipWhitelisted`
- `gender`, `notes`
- `organizations`, `addresses`, `relations`, `externalIds`, `languages`, `websites`, `ims`, `keywords`, `locations`

A shared `mapUserExtraFields()` helper (in `GenericFunctions.ts`) maps these
fields onto the request body and is reused by both create and update, so the
two operations stay in sync.

Ref: https://developers.google.com/workspace/admin/directory/reference/rest/v1/users

## How to test

1. Add Google Workspace Admin (OAuth2) credentials.
2. **Create**: Resource *User* → Operation *Create*. Under additional fields, set e.g. Org Unit Path, Recovery Email, Gender, an Address and an Organization. Execute and confirm the created user reflects all values.
3. **Update**: Resource *User* → Operation *Update* on that user; change the recovery phone, add a website/language, toggle Include in Global Address List. Confirm the update persists.

Automated coverage: `pnpm --filter n8n-nodes-base test nodes/Google/GSuiteAdmin` (see `GenericFunctions.test.ts`, `user/update.test.ts` and the workflow JSON fixtures).

## Related Linear tickets, Github issues, and Community forum posts

None.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with backport label (n/a — feature, not urgent fix).
