### PR TITLE
ci: Skip duplicate Turborepo cache server in nested setup-nodejs (no-changelog)

### DIFF
--- a/.github/actions/setup-nodejs/action.yml
+++ b/.github/actions/setup-nodejs/action.yml
@@ -211,7 +211,21 @@ runs:
         if-no-files-found: ignore
         retention-days: 7
 
+    # When setup-nodejs is nested inside another setup-nodejs invocation
+    # (e.g. load-n8n-docker's rebuild fallback → build-n8n-docker), a turbo
+    # cache server is already running and its TURBO_API env is already
+    # exported, so the nested builds can just use it. Starting a second
+    # server overwrites TURBOGHA_PORT, which both post-runs then read: the
+    # first post shuts the second server down, and the other post fails the
+    # job with a bare `fetch failed` — and the first server's caches are
+    # never saved.
+    - name: Check for running Turborepo cache server
+      id: turbo-server
+      shell: bash
+      run: echo "running=${TURBOGHA_PORT:+true}" >> "$GITHUB_OUTPUT"
+
     - name: Configure Turborepo Cache
+      if: steps.turbo-server.outputs.running != 'true'
       uses: rharkor/caching-for-turbo@5d14fba18e450c09393333cfd4242e8b3cb455a6 # v2.4.2
       with:
         server-port: 0


### PR DESCRIPTION
## Summary

`setup-nodejs` can run twice in one job: once as the explicit "Setup Environment" step, and again nested inside `load-n8n-docker`'s rebuild fallback (`load-n8n-docker` → `build-n8n-docker` → `setup-nodejs`). Each invocation starts its own `rharkor/caching-for-turbo` server and exports `TURBOGHA_PORT`, the second overwriting the first.

Post-actions run in reverse order, and both turbo post-runs read the same (overwritten) `TURBOGHA_PORT`: the first post saves the second server's caches and shuts it down, then the second post fails the job with a bare `Error: fetch failed` against the dead server. The first server's turbo artifacts (the main `pnpm build`) are never saved at all.

This hits the Instance AI evals workflow on **every** PR-triggered run (its docker image cache is never warm at PR open, so the rebuild fallback always fires — e.g. [this run](https://github.com/n8n-io/n8n/actions/runs/27311408268/job/80682195435?pr=32054)), and is latent in every other `load-n8n-docker` consumer whenever the image cache is evicted.

Fix: before starting the turbo cache server, check whether `TURBOGHA_PORT` is already exported and skip the step if so. The nested builds transparently reuse the outer server via the already-exported `TURBO_API`/`TURBO_TOKEN` env, and the single server's post-run saves everything once.

## How to test

Trigger a run of `CI: Instance AI Evals` on a PR (or any job where `load-n8n-docker` falls back to a rebuild) and verify:
- only one "Server is now up and running on port ..." appears in the job log
- "Post Setup Environment" succeeds and saves the turbo caches from both builds

## Related Linear tickets, Github issues, and Community forum posts

n/a — surfaced while debugging consistently-red `Post Setup Environment` steps on instance-ai eval runs.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)