### PR TITLE
ci: Align instance AI eval workflow with main CI docker image build (no-changelog)

### DIFF
--- a/.github/workflows/ci-instance-ai-evals.yml
+++ b/.github/workflows/ci-instance-ai-evals.yml
@@ -46,7 +46,10 @@ jobs:
       (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
     uses: ./.github/workflows/test-evals-instance-ai.yml
     with:
-      branch: ${{ inputs.branch || github.head_ref || github.ref_name }}
+      # On PR events github.sha is the merge commit, so the eval tests the
+      # merged state (like e2e) and the checkout matches the key under which
+      # prepare-docker publishes the docker image cache.
+      branch: ${{ inputs.branch || github.sha }}
       # PR events default to `pr`; dispatch defaults to `full`.
       tier: ${{ inputs.tier || 'pr' }}
       sandbox-provider: ${{ inputs.sandbox-provider || 'n8n-sandbox' }}

--- a/.github/workflows/test-evals-instance-ai.yml
+++ b/.github/workflows/test-evals-instance-ai.yml
@@ -85,17 +85,11 @@ jobs:
         with:
           build-command: 'pnpm build'
 
-      # Cache populated by prepare-docker; fallback covers PRs that only touch this workflow file.
+      # Cache populated by prepare-docker; on a miss (e.g. fresh PR-open runs
+      # that outpace prepare-docker) the action itself falls back to a rebuild
+      # via build-n8n-docker.
       - name: Load n8n Docker image
-        id: load-image
-        continue-on-error: true
         uses: ./.github/actions/load-n8n-docker
-
-      - name: Build Docker image (fallback on cache miss)
-        if: steps.load-image.outcome == 'failure'
-        run: pnpm build:docker
-        env:
-          INCLUDE_TEST_CONTROLLER: 'true'
 
       - name: Start sandbox service
         if: ${{ inputs.sandbox-provider == 'n8n-sandbox' }}
@@ -108,7 +102,8 @@ jobs:
           N8N_LICENSE_CERT: ${{ secrets.N8N_LICENSE_CERT }}
           N8N_ENCRYPTION_KEY: ${{ secrets.N8N_ENCRYPTION_KEY }}
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
-          SANDBOX_NAME_PREFIX: evals-ci-${{ inputs.branch || github.ref_name }}
+          # Prefer head_ref: inputs.branch may be a merge ref (refs/pull/N/merge).
+          SANDBOX_NAME_PREFIX: evals-ci-${{ github.head_ref || inputs.branch || github.ref_name }}
           SANDBOX_PROVIDER: ${{ inputs.sandbox-provider || 'n8n-sandbox' }}
         run: |
           # Build provider-specific env args


### PR DESCRIPTION
## Summary

Follow-up to #32093, cleaning up how the Instance AI eval workflow obtains its docker image:

- **Check out the PR merge commit instead of the branch tip.** `ci-instance-ai-evals.yml` now passes `github.sha` (the merge commit on PR events) as the ref, matching what every other CI job tests. This also fixes a subtle cache inconsistency: the eval job's fallback rebuild saves its image under the merge-SHA cache key (`n8n-docker-image-standard-<sha>`), and since GHA cache keys are first-write-wins, a branch-tip-built image could previously win the race and become the image the e2e shards restore and test against.
- **Remove the dead workflow-level rebuild fallback.** `load-n8n-docker` already falls back to `build-n8n-docker` internally on a cache miss, so the inline `pnpm build:docker` step (and the `continue-on-error` that fed it) never fires — and it was the only place duplicating the image recipe outside the shared `build-n8n-docker` composite. With it gone, a genuine build failure now fails the job at the load step instead of limping on to a confusing container-boot error.
- **Keep sandbox names readable**: `SANDBOX_NAME_PREFIX` now prefers `github.head_ref` so Daytona sandboxes keep the branch name rather than a merge ref.

## How to test

Trigger `CI: Instance AI Evals` on a PR:
- the checkout resolves to the merge commit (matches `github.sha` in the run)
- on cache miss the rebuild happens inside the "Load n8n Docker image" step; no separate fallback step exists
- with the Daytona provider, sandbox names still use the branch name

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #32093.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [ ] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)