### PR TITLE
fix(editor): Skip orphan pin cleanup when deleted node has no pinned data (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.test.ts
@@ -431,6 +431,19 @@ describe('getPinDataSize', () => {
 			expect(pinData.pinnedDataByNodeName.value.Other).toBeDefined();
 		});
 
+		it('skips cleanup when the deleted node has no pinned data', () => {
+			const { pinData, fire } = createPinDataWithNodesChange();
+			pinData.pinNodeData('Other', [{ json: { y: 2 } }] as INodeExecutionData[]);
+			const hookSpy = vi.fn();
+			pinData.onPinnedDataChange(hookSpy);
+			const before = pinData.pinnedDataByNodeName.value;
+
+			fire({ action: CHANGE_ACTION.DELETE, payload: { id: 'node-id-1', name: 'Target' } });
+
+			expect(hookSpy).not.toHaveBeenCalled();
+			expect(pinData.pinnedDataByNodeName.value).toBe(before);
+		});
+
 		it('does nothing when DELETE has no node name (removeAllNodes)', () => {
 			const { pinData, fire } = createPinDataWithNodesChange();
 			pinData.pinNodeData('Target', [{ json: { x: 1 } }] as INodeExecutionData[]);

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentPinData.ts
@@ -227,7 +227,10 @@ export function useWorkflowDocumentPinData(deps: WorkflowDocumentPinDataDeps) {
 				// useWorkflowDocumentNodes via an injected `unpinNodeData` dep;
 				// pulling it into the pinData subscriber means nodes doesn't need
 				// to know about pinData at all (breaks the construction cycle).
-				if (payload.name) applyUnpin(payload.name);
+				// Skipped when the node has no pinned data: unpinning unconditionally
+				// would replace the pin-data object identity (dirtying every computed
+				// that reads it) and fire a spurious DELETE pin event.
+				if (payload.name && pinnedDataByNodeName.value[payload.name]) applyUnpin(payload.name);
 				break;
 			}
 			case CHANGE_ACTION.SET: {


### PR DESCRIPTION
## Summary

When a node is deleted that has no pinned data, the previous code would unconditionally call `applyUnpin`, which replaces the pin-data object identity even when nothing needs to change. This unnecessarily dirtied every computed property reading pin data and fired a spurious DELETE pin event. The fix guards the call with a check for the node's existence in `pinnedDataByNodeName`.

## How to test

1. Open a workflow with at least two nodes, one of which has pinned data (e.g. "Node A" pinned, "Node B" not pinned).
2. Delete "Node B" (the node with no pinned data).
3. Verify that "Node A"'s pinned data is unaffected and no spurious pin-change events are triggered (no unintended re-renders or state changes).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3385/bug-deleting-unpinned-node-triggers-spurious-pin-data-updates

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

---
🤖 PR Summary generated by AI