### PR TITLE
fix(editor): Show correct project in workflow breadcrumb for projectId links

### DIFF
--- a/packages/frontend/editor-ui/src/features/collaboration/projects/projects.store.test.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/projects.store.test.ts
@@ -3,14 +3,24 @@ import { reactive } from 'vue';
 import { vi } from 'vitest';
 import { useProjectsStore } from './projects.store';
 import * as projectsApi from './projects.api';
-import type { Project, ProjectListItem } from './projects.types';
+import type { Project, ProjectListItem, ProjectType } from './projects.types';
 import { ProjectTypes } from './projects.types';
 import type { ProjectRole, Scope } from '@n8n/permissions';
 
+type MockRoute = {
+	params: Record<string, string>;
+	query: Record<string, string>;
+	path: string;
+};
+
 // Minimal router mock to satisfy useRoute usage in the store
+const { mockRoute } = vi.hoisted(() => ({
+	mockRoute: { params: {}, query: {}, path: '' } as MockRoute,
+}));
+
 vi.mock('vue-router', async (importOriginal) => ({
 	...(await importOriginal()),
-	useRoute: () => reactive({ params: {}, query: {}, path: '' }),
+	useRoute: () => reactive(mockRoute),
 }));
 
 vi.mock('./projects.api', () => ({
@@ -219,5 +229,108 @@ describe('useProjectsStore.updateProject (partial payloads)', () => {
 		);
 		expect(mockedProjectsApi.getProject).toHaveBeenCalledWith(expect.anything(), 'p1');
 		expect(store.currentProject?.relations.length).toBe(0);
+	});
+});
+
+describe('useProjectsStore.setProjectNavActiveIdByWorkflowHomeProject', () => {
+	const route = reactive(mockRoute);
+
+	beforeEach(() => {
+		setActivePinia(createPinia());
+		vi.clearAllMocks();
+		route.params = {};
+		route.query = {};
+		route.path = '';
+	});
+
+	const now = new Date().toISOString();
+	const makeProject = (id: string, type: ProjectType = ProjectTypes.Team): Project => ({
+		id,
+		name: `Project ${id}`,
+		description: null,
+		icon: { type: 'icon', value: 'layers' },
+		type,
+		createdAt: now,
+		updatedAt: now,
+		relations: [],
+		scopes: [] as Scope[],
+	});
+
+	const makeStore = () => {
+		const store = useProjectsStore();
+		store.personalProject = makeProject('personal-1', ProjectTypes.Personal);
+		return store;
+	};
+
+	it('fetches the workflow home project when none is loaded', async () => {
+		const store = makeStore();
+		const teamProject = makeProject('team-1');
+		mockedProjectsApi.getProject.mockResolvedValue(teamProject);
+
+		await store.setProjectNavActiveIdByWorkflowHomeProject(teamProject);
+
+		expect(mockedProjectsApi.getProject).toHaveBeenCalledWith(expect.anything(), 'team-1');
+		expect(store.currentProject?.id).toBe('team-1');
+		expect(store.projectNavActiveId).toBe('team-1');
+	});
+
+	it('fetches the workflow home project even when the route has a projectId query param', async () => {
+		route.query = { projectId: 'team-1' };
+		const store = makeStore();
+		const teamProject = makeProject('team-1');
+		mockedProjectsApi.getProject.mockResolvedValue(teamProject);
+
+		await store.setProjectNavActiveIdByWorkflowHomeProject(teamProject);
+
+		expect(mockedProjectsApi.getProject).toHaveBeenCalledWith(expect.anything(), 'team-1');
+		expect(store.currentProject?.id).toBe('team-1');
+	});
+
+	it('replaces a previously loaded project that does not match the workflow home project', async () => {
+		const store = makeStore();
+		store.currentProject = makeProject('team-2');
+		const teamProject = makeProject('team-1');
+		mockedProjectsApi.getProject.mockResolvedValue(teamProject);
+
+		await store.setProjectNavActiveIdByWorkflowHomeProject(teamProject);
+
+		expect(mockedProjectsApi.getProject).toHaveBeenCalledWith(expect.anything(), 'team-1');
+		expect(store.currentProject?.id).toBe('team-1');
+	});
+
+	it('does not refetch when the workflow home project is already loaded', async () => {
+		const store = makeStore();
+		store.currentProject = makeProject('team-1');
+
+		await store.setProjectNavActiveIdByWorkflowHomeProject(makeProject('team-1'));
+
+		expect(mockedProjectsApi.getProject).not.toHaveBeenCalled();
+		expect(store.currentProject?.id).toBe('team-1');
+	});
+
+	it('sets the personal project as current for own personal workflows', async () => {
+		route.query = { projectId: 'personal-1' };
+		const store = makeStore();
+
+		await store.setProjectNavActiveIdByWorkflowHomeProject(
+			makeProject('personal-1', ProjectTypes.Personal),
+		);
+
+		expect(mockedProjectsApi.getProject).not.toHaveBeenCalled();
+		expect(store.currentProject?.id).toBe('personal-1');
+		expect(store.projectNavActiveId).toBe('personal-1');
+	});
+
+	it('marks workflows shared with the user as shared context', async () => {
+		const store = makeStore();
+
+		await store.setProjectNavActiveIdByWorkflowHomeProject(
+			makeProject('other-personal', ProjectTypes.Personal),
+			[makeProject('personal-1', ProjectTypes.Personal)],
+		);
+
+		expect(mockedProjectsApi.getProject).not.toHaveBeenCalled();
+		expect(store.currentProject).toBeNull();
+		expect(store.projectNavActiveId).toBe('shared');
 	});
 });

--- a/packages/frontend/editor-ui/src/features/collaboration/projects/projects.store.ts
+++ b/packages/frontend/editor-ui/src/features/collaboration/projects/projects.store.ts
@@ -254,8 +254,10 @@ export const useProjectsStore = defineStore(STORES.PROJECTS, () => {
 
 		// Handle team projects
 		projectNavActiveId.value = workflowHomeProject?.id ?? null;
-		if (workflowHomeProject?.id && !currentProjectId.value) {
-			await getProject(workflowHomeProject?.id);
+		// Compare against the loaded project, not currentProjectId: a `?projectId=` query param
+		// makes currentProjectId truthy without currentProject ever being fetched
+		if (workflowHomeProject?.id && currentProject.value?.id !== workflowHomeProject.id) {
+			await getProject(workflowHomeProject.id);
 		}
 	};
 


### PR DESCRIPTION
## Summary

Opening a workflow via a URL containing a `?projectId=` query param on a fresh page load showed "Personal" in the canvas breadcrumb instead of the workflow's actual project. The team-project branch of `setProjectNavActiveIdByWorkflowHomeProject` skipped fetching the workflow's home project whenever `currentProjectId` was truthy — but that computed falls back to `route.query.projectId`, so the query param suppressed the fetch while `currentProject` was still unset, and the breadcrumb fell back to the viewer's personal project. The guard now compares against the actually loaded project (`currentProject.value?.id !== workflowHomeProject.id`), which also corrects the stale case where a different project was previously loaded, while still skipping the refetch when the right project is already in the store.

## How to test

1. As user A, create a team project and a workflow inside it, then copy the workflow URL including the `?projectId=...` query param.
2. As a different user with access (e.g. instance owner), open that URL in a fresh tab — the breadcrumb should show the team project name instead of "Personal".
3. Unit tests: `pnpm test src/features/collaboration/projects/projects.store.test.ts` in `packages/frontend/editor-ui` (the new query-param regression tests fail without the store change).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5399

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)