### PR TITLE
perf(editor): Gate render-type dirtiness reads through per-node projection (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { computed, effectScope } from 'vue';
+import { computed, effectScope, ref } from 'vue';
 import { setActivePinia, createPinia } from 'pinia';
 import type { INode } from 'n8n-workflow';
 import type { INodeUi } from '@/Interface';
@@ -16,6 +16,11 @@ import {
 } from '@/app/stores/workflowDocument.store';
 import { useWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
 import { useExecutionDataStore, createExecutionDataId } from '@/app/stores/executionData.store';
+import {
+	CanvasNodeDirtiness,
+	type CanvasNodeDefaultRender,
+	type CanvasNodeDirtinessType,
+} from '@/features/workflows/canvas/canvas.types';
 import { useWorkflowDocumentRenderData } from './useWorkflowDocumentRenderData';
 
 const TEST_TRIGGER_NODE_TYPE = 'n8n-nodes-base.testTrigger';
@@ -24,13 +29,21 @@ const TEST_TRIGGER_NODE_TYPE = 'n8n-nodes-base.testTrigger';
 // stores that aren't needed to exercise renderData's wiring. The actual
 // workflowDocument / workflowExecutionState stores stay real so reconciliation
 // off `onNodesChange` is genuinely tested.
+// Both consts below are only dereferenced when the mocked composables are
+// *called* (inside tests, after this module's body has initialized), so the
+// references are safe under vi.mock hoisting.
+const dirtinessByNameOverride = ref<Record<string, CanvasNodeDirtinessType | undefined>>({});
+const isConfigNodeSpy = vi.fn((..._args: unknown[]) => false);
+
 vi.mock('@/app/composables/useNodeDirtiness', () => ({
-	useNodeDirtiness: vi.fn(() => ({ dirtinessByName: computed(() => ({})) })),
+	useNodeDirtiness: vi.fn(() => ({
+		dirtinessByName: computed(() => dirtinessByNameOverride.value),
+	})),
 }));
 
 vi.mock('@/app/stores/nodeTypes.store', () => ({
 	useNodeTypesStore: vi.fn(() => ({
-		isConfigNode: () => false,
+		isConfigNode: isConfigNodeSpy,
 		isConfigurableNode: () => false,
 		isTriggerNode: (type: string) => type === 'n8n-nodes-base.testTrigger',
 		getNodeType: (type: string) =>
@@ -489,5 +502,58 @@ describe('useWorkflowDocumentRenderData — lifecycle', () => {
 
 		doc.unpinNodeData('Alpha');
 		expect(hasPinnedData.value).toBe(false);
+	});
+});
+
+describe('useWorkflowDocumentRenderData — per-node dirtiness gating', () => {
+	beforeEach(() => {
+		setActivePinia(createPinia());
+		dirtinessByNameOverride.value = {};
+	});
+
+	it('propagates a node dirtiness change into its render type options', () => {
+		const { docId } = setupWorkflow('wf-dirtiness-propagate', [{ id: 'a', name: 'Alpha' }]);
+		const { renderData } = createRenderData(docId);
+		const renderA = () => renderData.renderTypeByNodeId.get('a')?.value as CanvasNodeDefaultRender;
+
+		expect(renderA().options.dirtiness).toBeUndefined();
+
+		dirtinessByNameOverride.value = { Alpha: CanvasNodeDirtiness.PARAMETERS_UPDATED };
+		expect(renderA().options.dirtiness).toBe(CanvasNodeDirtiness.PARAMETERS_UPDATED);
+
+		dirtinessByNameOverride.value = {};
+		expect(renderA().options.dirtiness).toBeUndefined();
+	});
+
+	it('does not re-evaluate render types of nodes whose dirtiness is unchanged', () => {
+		const { docId } = setupWorkflow('wf-dirtiness-isolation', [
+			{ id: 'a', name: 'Alpha' },
+			{ id: 'b', name: 'Beta' },
+		]);
+		const { renderData } = createRenderData(docId);
+
+		const initialA = renderData.renderTypeByNodeId.get('a')?.value;
+		const initialB = renderData.renderTypeByNodeId.get('b')?.value;
+		// `isConfigNode` runs once per default-render-type evaluation with the
+		// node as its second argument, so calls attribute evaluations per node.
+		const betaEvaluations = () =>
+			isConfigNodeSpy.mock.calls.filter((call) => (call[1] as INodeUi).id === 'b').length;
+		const betaEvaluationsBefore = betaEvaluations();
+
+		dirtinessByNameOverride.value = { Alpha: CanvasNodeDirtiness.PARAMETERS_UPDATED };
+
+		// Alpha's dirtiness changed: its entry re-evaluates to a new value.
+		const updatedA = renderData.renderTypeByNodeId.get('a')?.value;
+		expect(updatedA).not.toBe(initialA);
+		expect((updatedA as CanvasNodeDefaultRender).options.dirtiness).toBe(
+			CanvasNodeDirtiness.PARAMETERS_UPDATED,
+		);
+
+		// Beta's dirtiness is unchanged: identity is kept AND — the actual
+		// regression guard, since the render entry's isEqual gate alone would
+		// preserve identity even after a wasted re-evaluation — its compute
+		// body never re-ran.
+		expect(renderData.renderTypeByNodeId.get('b')?.value).toBe(initialB);
+		expect(betaEvaluations()).toBe(betaEvaluationsBefore);
 	});
 });

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument/useWorkflowDocumentRenderData.ts
@@ -27,6 +27,7 @@ import type {
 	CanvasNodeChoicePromptRender,
 	CanvasNodeData,
 	CanvasNodeDefaultRender,
+	CanvasNodeDirtinessType,
 	CanvasNodeStickyNoteRender,
 } from '@/features/workflows/canvas/canvas.types';
 import { CanvasNodeRenderType } from '@/features/workflows/canvas/canvas.types';
@@ -87,6 +88,9 @@ export function useWorkflowDocumentRenderData(workflowDocumentId: WorkflowDocume
 	);
 	const tooltipByNodeId = shallowReactive(new Map<string, ComputedRef<string | undefined>>());
 	const hasIssuesByNodeId = shallowReactive(new Map<string, ComputedRef<boolean>>());
+	const dirtinessByNodeId = shallowReactive(
+		new Map<string, ComputedRef<CanvasNodeDirtinessType | undefined>>(),
+	);
 	const renderTypeByNodeId = shallowReactive(
 		new Map<string, ComputedRef<CanvasNodeData['render']>>(),
 	);
@@ -279,7 +283,7 @@ export function useWorkflowDocumentRenderData(workflowDocumentId: WorkflowDocume
 					node.typeVersion,
 				),
 				tooltip,
-				dirtiness: dirtinessByName.value[node.name],
+				dirtiness: dirtinessByNodeId.get(node.id)?.value,
 				icon,
 				placeholder: node.placeholder,
 			},
@@ -329,6 +333,20 @@ export function useWorkflowDocumentRenderData(workflowDocumentId: WorkflowDocume
 				nodeId,
 				structuralComputed(() => computeHasIssues(nodeId)),
 			);
+			// Per-node projection of `dirtinessByName` — one whole-workflow
+			// computed that returns a fresh Record on every recompute (run data,
+			// undo stack, parameter metadata). Reading it directly from the
+			// render-type computeds would re-evaluate every entry on any of those
+			// changes; this gate (default `Object.is` — values are enum-or-
+			// undefined) confines that to entries whose node's value changed.
+			// Registered before `renderTypeByNodeId`, which reads it.
+			dirtinessByNodeId.set(
+				nodeId,
+				structuralComputed(() => {
+					const node = getNode(nodeId);
+					return node ? dirtinessByName.value[node.name] : undefined;
+				}),
+			);
 			renderTypeByNodeId.set(
 				nodeId,
 				structuralComputed(() => computeRenderType(nodeId), isEqual),
@@ -346,6 +364,7 @@ export function useWorkflowDocumentRenderData(workflowDocumentId: WorkflowDocume
 		simulatedNodeTypeDescriptionByNodeId.delete(nodeId);
 		tooltipByNodeId.delete(nodeId);
 		hasIssuesByNodeId.delete(nodeId);
+		dirtinessByNodeId.delete(nodeId);
 		renderTypeByNodeId.delete(nodeId);
 	}
 


### PR DESCRIPTION
## Summary

Adds a per-node `dirtinessByNodeId` computed projection between the shared `dirtinessByName` map and the per-node `renderTypeByNodeId` computeds. Previously, every render-type computed read directly from the whole-workflow `dirtinessByName` record, which meant any dirtiness-triggering change (run data, undo stack, parameter metadata) caused every node's render type to re-evaluate. The new per-node gate uses `structuralComputed` (with default `Object.is`) so a dirtiness change for one node only re-evaluates that node's render-type computed.

## How to test

1. Open a workflow with several nodes in the editor.
2. Edit parameters on one node; observe that only the affected node's render type (dirty indicator) updates.
3. Run the workflow and confirm execution state and dirty indicators behave correctly across all nodes.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3388/gate-render-type-dirtiness-reads-through-per-node-projection

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!-- **Remember, the title automatically goes into the changelog. Use `(no-changelog)` otherwise.** -->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!-- A bug is not considered fixed, unless a test is added to prevent it from happening again. A feature is not complete without tests. -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI