### PR TITLE
fix(editor): Stop showing deleted resources in dependency pill

### DIFF
--- a/packages/cli/src/modules/workflow-index/workflow-dependency-query.service.ts
+++ b/packages/cli/src/modules/workflow-index/workflow-dependency-query.service.ts
@@ -87,42 +87,65 @@ export class WorkflowDependencyQueryService {
 			this.filterByAccess([...maps.allDtIds], 'dataTable', user),
 		]);
 
-		// Only enrich names for accessible resources
+		// Load all referenced resources (not just accessible ones) so that ids whose
+		// resource has been deleted — the index may still reference them — can be
+		// dropped instead of being reported as inaccessible.
 		const [credentials, workflows, dataTables] = await Promise.all([
-			accessibleCredIds.length > 0
+			maps.allCredIds.size > 0
 				? this.credentialsRepository.find({
-						where: { id: In(accessibleCredIds) },
+						where: { id: In([...maps.allCredIds]) },
 						select: ['id', 'name'],
 					})
 				: [],
-			accessibleWfIds.length > 0
+			maps.allWfIds.size > 0
 				? this.workflowRepository.find({
-						where: { id: In(accessibleWfIds) },
+						where: { id: In([...maps.allWfIds]) },
 						select: ['id', 'name'],
 					})
 				: [],
-			accessibleDtIds.length > 0
+			maps.allDtIds.size > 0
 				? this.dataTableRepository.find({
-						where: { id: In(accessibleDtIds) },
+						where: { id: In([...maps.allDtIds]) },
 						select: ['id', 'name', 'projectId'],
 					})
 				: [],
 		]);
 
+		const accessibleWfIdSet = new Set(accessibleWfIds);
+		const accessibleCredIdSet = new Set(accessibleCredIds);
+		const accessibleDtIdSet = new Set(accessibleDtIds);
+
 		const wfNames = new Map<string, string>();
 		const credNames = new Map<string, string>();
 		const dtNames = new Map<string, { name: string; projectId: string }>();
+		const existingWfIds = new Set<string>();
+		const existingCredIds = new Set<string>();
+		const existingDtIds = new Set<string>();
 
-		for (const c of credentials) credNames.set(c.id, c.name ?? c.id);
-		for (const w of workflows) wfNames.set(w.id, w.name ?? w.id);
-		for (const dt of dataTables)
-			dtNames.set(dt.id, { name: dt.name ?? dt.id, projectId: dt.projectId });
+		for (const c of credentials) {
+			existingCredIds.add(c.id);
+			if (accessibleCredIdSet.has(c.id)) credNames.set(c.id, c.name ?? c.id);
+		}
+		for (const w of workflows) {
+			existingWfIds.add(w.id);
+			if (accessibleWfIdSet.has(w.id)) wfNames.set(w.id, w.name ?? w.id);
+		}
+		for (const dt of dataTables) {
+			existingDtIds.add(dt.id);
+			if (accessibleDtIdSet.has(dt.id))
+				dtNames.set(dt.id, { name: dt.name ?? dt.id, projectId: dt.projectId });
+		}
 
-		return this.buildEnrichedResult(accessibleInputIds, maps, {
-			wfNames,
-			credNames,
-			dtNames,
-		});
+		return this.buildEnrichedResult(
+			accessibleInputIds,
+			maps,
+			{
+				wfNames,
+				credNames,
+				dtNames,
+			},
+			{ existingWfIds, existingCredIds, existingDtIds },
+		);
 	}
 
 	private async loadDepsForResources(
@@ -201,7 +224,10 @@ export class WorkflowDependencyQueryService {
 		};
 	}
 
-	/** Build enriched result — only includes accessible deps, counts inaccessible ones. */
+	/**
+	 * Build enriched result — only includes accessible deps, counts existing but
+	 * inaccessible ones, and drops ids whose resource no longer exists.
+	 */
 	private buildEnrichedResult(
 		resourceIds: string[],
 		maps: RawDepMaps,
@@ -209,6 +235,11 @@ export class WorkflowDependencyQueryService {
 			wfNames: Map<string, string>;
 			credNames: Map<string, string>;
 			dtNames: Map<string, { name: string; projectId: string }>;
+		},
+		existing: {
+			existingWfIds: Set<string>;
+			existingCredIds: Set<string>;
+			existingDtIds: Set<string>;
 		},
 	): DependenciesBatchResponse {
 		const result: DependenciesBatchResponse = {};
@@ -220,9 +251,11 @@ export class WorkflowDependencyQueryService {
 			const resolve = (
 				ids: Set<string> | undefined,
 				nameMap: Map<string, string>,
+				existingIds: Set<string>,
 				type: ResolvedDependency['type'],
 			) => {
 				for (const id of ids ?? []) {
+					if (!existingIds.has(id)) continue;
 					const name = nameMap.get(id);
 					if (name !== undefined) {
 						dependencies.push({ id, name, type });
@@ -232,13 +265,39 @@ export class WorkflowDependencyQueryService {
 				}
 			};
 
-			resolve(maps.subMap.get(resourceId), accessMaps.wfNames, 'workflowCall');
-			resolve(maps.parentMap.get(resourceId), accessMaps.wfNames, 'workflowParent');
-			resolve(maps.errorWfMap.get(resourceId), accessMaps.wfNames, 'errorWorkflow');
-			resolve(maps.errorWfParentMap.get(resourceId), accessMaps.wfNames, 'errorWorkflowParent');
-			resolve(maps.credMap.get(resourceId), accessMaps.credNames, 'credentialId');
+			resolve(
+				maps.subMap.get(resourceId),
+				accessMaps.wfNames,
+				existing.existingWfIds,
+				'workflowCall',
+			);
+			resolve(
+				maps.parentMap.get(resourceId),
+				accessMaps.wfNames,
+				existing.existingWfIds,
+				'workflowParent',
+			);
+			resolve(
+				maps.errorWfMap.get(resourceId),
+				accessMaps.wfNames,
+				existing.existingWfIds,
+				'errorWorkflow',
+			);
+			resolve(
+				maps.errorWfParentMap.get(resourceId),
+				accessMaps.wfNames,
+				existing.existingWfIds,
+				'errorWorkflowParent',
+			);
+			resolve(
+				maps.credMap.get(resourceId),
+				accessMaps.credNames,
+				existing.existingCredIds,
+				'credentialId',
+			);
 
 			for (const id of maps.dtMap.get(resourceId) ?? []) {
+				if (!existing.existingDtIds.has(id)) continue;
 				const dt = accessMaps.dtNames.get(id);
 				if (dt) {
 					dependencies.push({ id, name: dt.name, type: 'dataTableId', projectId: dt.projectId });

--- a/packages/cli/test/integration/workflows/workflow-dependency.controller.test.ts
+++ b/packages/cli/test/integration/workflows/workflow-dependency.controller.test.ts
@@ -333,6 +333,69 @@ describe('POST /workflow-dependencies/details', () => {
 		});
 	});
 
+	it('should drop dependencies referencing deleted resources instead of counting them as inaccessible', async () => {
+		const owner = await createOwner();
+		const member = await createMember();
+
+		const memberWorkflow = await createWorkflow({}, member);
+		const memberCred = await saveCredential(randomCredentialPayload(), {
+			user: member,
+			role: 'credential:owner',
+		});
+		const ownerCred = await saveCredential(randomCredentialPayload(), {
+			user: owner,
+			role: 'credential:owner',
+		});
+
+		// One accessible credential, one existing but inaccessible credential,
+		// and one index entry left behind by a deleted credential
+		await seedDep(memberWorkflow.id, 'credentialId', memberCred.id);
+		await seedDep(memberWorkflow.id, 'credentialId', ownerCred.id);
+		await seedDep(memberWorkflow.id, 'credentialId', 'deleted-cred-id');
+
+		const resp = await testServer
+			.authAgentFor(member)
+			.post('/workflow-dependencies/details')
+			.send({
+				resourceIds: [memberWorkflow.id],
+				resourceType: 'workflow',
+			});
+
+		expect(resp.statusCode).toBe(200);
+		const result = resp.body.data[memberWorkflow.id];
+		expect(result.dependencies).toHaveLength(1);
+		expect(result.dependencies[0]).toMatchObject({ id: memberCred.id, type: 'credentialId' });
+		expect(result.inaccessibleCount).toBe(1);
+	});
+
+	it('should drop workflow call dependencies referencing deleted workflows', async () => {
+		const owner = await createOwner();
+
+		const workflow = await createWorkflow({ name: 'Main WF' }, owner);
+		const subWorkflow = await createWorkflow({ name: 'Sub WF' }, owner);
+
+		await seedDep(workflow.id, 'workflowCall', subWorkflow.id);
+		await seedDep(workflow.id, 'workflowCall', 'deleted-wf-id');
+
+		const resp = await testServer
+			.authAgentFor(owner)
+			.post('/workflow-dependencies/details')
+			.send({
+				resourceIds: [workflow.id],
+				resourceType: 'workflow',
+			});
+
+		expect(resp.statusCode).toBe(200);
+		const result = resp.body.data[workflow.id];
+		expect(result.dependencies).toHaveLength(1);
+		expect(result.dependencies[0]).toMatchObject({
+			id: subWorkflow.id,
+			name: 'Sub WF',
+			type: 'workflowCall',
+		});
+		expect(result.inaccessibleCount).toBe(0);
+	});
+
 	it('should return details for a shared workflow', async () => {
 		const owner = await createOwner();
 		const member = await createMember();

--- a/packages/frontend/editor-ui/src/app/components/DependencyPill.test.ts
+++ b/packages/frontend/editor-ui/src/app/components/DependencyPill.test.ts
@@ -29,10 +29,11 @@ let mockDepsResult:
 	  }
 	| undefined;
 
+const fetchDependenciesMock = vi.fn();
 vi.mock('@/app/composables/useDependencies', () => ({
 	useDependencies: () => ({
 		getDependencies: () => mockDepsResult,
-		fetchDependencies: vi.fn(),
+		fetchDependencies: fetchDependenciesMock,
 		getTotalCount: () => 0,
 	}),
 }));
@@ -282,6 +283,36 @@ describe('DependencyPill', () => {
 		capturedOpenHandler?.(false);
 
 		expect(telemetryTrackMock).not.toHaveBeenCalled();
+	});
+
+	it('should fetch dependencies when dropdown opens', () => {
+		renderComponent({ props: defaultProps });
+
+		capturedOpenHandler?.(true);
+
+		expect(fetchDependenciesMock).toHaveBeenCalledWith(['wf-test'], 'workflow');
+	});
+
+	it('should refetch dependencies on every open even when already cached', async () => {
+		mockDepsResult = createDepsResult();
+		renderComponent({ props: defaultProps });
+
+		capturedOpenHandler?.(true);
+		await vi.waitFor(() => expect(fetchDependenciesMock).toHaveBeenCalledTimes(1));
+		// Let the first toggle handler finish so the loading flag resets
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		capturedOpenHandler?.(false);
+		capturedOpenHandler?.(true);
+		await vi.waitFor(() => expect(fetchDependenciesMock).toHaveBeenCalledTimes(2));
+	});
+
+	it('should not fetch dependencies when dropdown closes', () => {
+		renderComponent({ props: defaultProps });
+
+		capturedOpenHandler?.(false);
+
+		expect(fetchDependenciesMock).not.toHaveBeenCalled();
 	});
 
 	it('should include inaccessible count in badge total', () => {

--- a/packages/frontend/editor-ui/src/app/components/DependencyPill.vue
+++ b/packages/frontend/editor-ui/src/app/components/DependencyPill.vue
@@ -48,8 +48,6 @@ const tooltipText = computed(() =>
 	i18n.baseText(`workflows.dependencies.tooltip.${props.resourceType}` satisfies BaseTextKey),
 );
 
-const hasFullDeps = computed(() => depsResult.value !== undefined);
-
 const showSearch = computed(
 	() => (depsResult.value?.dependencies.length ?? 0) >= MIN_ITEMS_FOR_SEARCH,
 );
@@ -191,7 +189,9 @@ async function onDropdownToggle(open: boolean) {
 			dependency_count: effectiveCount.value,
 		});
 
-		if (!hasFullDeps.value && !isLoadingDetails.value) {
+		// Always refetch on open — cached entries may be stale (e.g. a credential
+		// deleted since the last fetch)
+		if (!isLoadingDetails.value) {
 			isLoadingDetails.value = true;
 			await loadDetails();
 			isLoadingDetails.value = false;


### PR DESCRIPTION
## Summary

When a credential (or other resource) is deleted, its row can linger in the `workflow_dependency` index, so the dependency pill on workflow cards kept showing it — clicking it then failed with a "not found" error. This PR makes the dependency details query drop index entries whose resource no longer exists (instead of reporting them as inaccessible, which is now reserved for resources that exist but the user can't read), and makes the dependency pill refetch dependencies on every open instead of reusing its module-level cache.

## How to test

1. Go to the workflow list and open the credential/dependency icon on a workflow card that uses a credential.
2. Click the credential and delete it from the modal.
3. Open the pill again — the deleted credential no longer appears and is not counted as "not accessible to you".

Covered by new integration tests (deleted credential and deleted sub-workflow references are dropped while inaccessible ones still count) and new component tests (dependencies are refetched on every dropdown open).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ADO-5377

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)