### PR TITLE
feat(core): Add package export/import commands to the CLI client (no-changelog)

### DIFF
--- a/packages/@n8n/cli/README.md
+++ b/packages/@n8n/cli/README.md
@@ -61,6 +61,7 @@ n8n-cli --url=https://my-n8n.app.n8n.cloud --api-key=n8n_api_xxxxx workflow list
 | `user` | `list`, `get` |
 | `config` | `set-url`, `set-api-key`, `show` |
 | `source-control` | `pull` |
+| `package` | `export`, `import` _(beta)_ |
 | `skill` | `install` |
 | `audit` | _(top-level)_ |
 | `login` / `logout` | _(top-level)_ |

--- a/packages/@n8n/cli/docs/commands/package.md
+++ b/packages/@n8n/cli/docs/commands/package.md
@@ -1,0 +1,48 @@
+# package
+
+Export and import workflows as portable n8n packages (`.n8np` archives).
+
+> **Beta — disabled by default.** These commands call beta endpoints that the
+> target instance must opt into with `N8N_PUBLIC_API_PACKAGES_ENABLED=true`, and
+> the n8n Packages feature must be licensed. While disabled, the instance returns
+> `404` and the CLI prints a hint explaining how to enable it.
+
+## `package export`
+
+Export one or more workflows into a gzipped `.n8np` archive written to disk.
+
+```bash
+n8n-cli package export --workflow-id=abc --output=export.n8np
+n8n-cli package export -w abc -w def -o team.n8np
+```
+
+| Flag | Description |
+|------|-------------|
+| `-w, --workflow-id` | Workflow ID to include. Repeat the flag to export several. (required) |
+| `-o, --output` | File to write the package to. Defaults to `export.n8np`. |
+
+Requires the API key to hold the `workflow:export` scope.
+
+## `package import`
+
+Import a `.n8np` archive into a project.
+
+```bash
+n8n-cli package import --file=export.n8np --conflict-policy=fail
+n8n-cli package import --file=export.n8np --project=<id> --conflict-policy=new-version
+```
+
+| Flag | Description |
+|------|-------------|
+| `--file` | Path to the `.n8np` package file. (required) |
+| `--conflict-policy` | What to do when a workflow already exists by source ID: `new-version`, `fail`, or `skip`. (required) |
+| `--project` | Target project ID. Defaults to your personal project. |
+| `--folder` | Target folder ID within the project. Defaults to the project root. |
+| `--workflow-id-policy` | Whether imported workflows keep their source ID (`source`) or receive a new one (`new`). |
+| `--credential-matching-mode` | How credential references are matched on the target instance (`id-only`). |
+| `--credential-missing-mode` | What to do when a referenced credential cannot be resolved (`must-preexist`). |
+
+Requires the API key to hold the `workflow:import` scope. When the import is
+blocked — for example by a workflow conflict under `--conflict-policy=fail`, or
+by a credential that does not exist on the target instance — the command exits
+non-zero and lists the blocking issues.

--- a/packages/@n8n/cli/package.json
+++ b/packages/@n8n/cli/package.json
@@ -66,6 +66,9 @@
       "source-control": {
         "description": "Pull changes from the configured source control provider"
       },
+      "package": {
+        "description": "Export and import workflows as n8n packages (beta)"
+      },
       "skill": {
         "description": "Install n8n CLI skills for AI coding agents"
       }

--- a/packages/@n8n/cli/src/__tests__/client.test.ts
+++ b/packages/@n8n/cli/src/__tests__/client.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { ApiError, N8nClient } from '../client';
+
+function jsonResponse(status: number, body: unknown): Response {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		statusText: '',
+		headers: new Headers([['content-type', 'application/json']]),
+		json: vi.fn().mockResolvedValue(body),
+		text: vi.fn().mockResolvedValue(JSON.stringify(body)),
+		arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(0)),
+	} as unknown as Response;
+}
+
+function binaryResponse(status: number, bytes: Uint8Array): Response {
+	return {
+		ok: status >= 200 && status < 300,
+		status,
+		statusText: '',
+		headers: new Headers([['content-type', 'application/gzip']]),
+		json: vi.fn().mockRejectedValue(new Error('not json')),
+		text: vi.fn().mockResolvedValue(''),
+		arrayBuffer: vi
+			.fn()
+			.mockResolvedValue(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)),
+	} as unknown as Response;
+}
+
+describe('N8nClient packages', () => {
+	const fetchMock = vi.fn();
+	let client: N8nClient;
+
+	beforeEach(() => {
+		vi.stubGlobal('fetch', fetchMock);
+		fetchMock.mockReset();
+		client = new N8nClient({ baseUrl: 'https://n8n.example.com', apiKey: 'test-key' });
+	});
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+
+	describe('exportPackage', () => {
+		it('posts the workflow IDs as JSON and returns the archive bytes', async () => {
+			fetchMock.mockResolvedValue(binaryResponse(200, new Uint8Array([1, 2, 3])));
+
+			const result = await client.exportPackage(['a', 'b']);
+
+			expect(Buffer.isBuffer(result)).toBe(true);
+			expect(result.equals(Buffer.from([1, 2, 3]))).toBe(true);
+
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe('https://n8n.example.com/api/v1/n8n-packages/export');
+			expect(init.body).toBe(JSON.stringify({ workflowIds: ['a', 'b'] }));
+		});
+	});
+
+	describe('importPackage', () => {
+		it('sends a multipart body with the file and non-empty fields', async () => {
+			fetchMock.mockResolvedValue(jsonResponse(200, { workflows: [], bindings: {} }));
+
+			await client.importPackage(
+				{ buffer: Buffer.from('package-bytes'), filename: 'export.n8np' },
+				{
+					workflowConflictPolicy: 'fail',
+					projectId: 'proj-1',
+					folderId: '',
+					workflowIdPolicy: 'new',
+					credentialMatchingMode: undefined,
+				},
+			);
+
+			const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe('https://n8n.example.com/api/v1/n8n-packages/import');
+			expect(init.body).toBeInstanceOf(FormData);
+
+			const form = init.body as FormData;
+			expect(form.get('workflowConflictPolicy')).toBe('fail');
+			expect(form.get('projectId')).toBe('proj-1');
+			expect(form.get('workflowIdPolicy')).toBe('new');
+			// Empty/undefined fields are omitted entirely.
+			expect(form.has('folderId')).toBe(false);
+			expect(form.has('credentialMatchingMode')).toBe(false);
+
+			const pkg = form.get('package');
+			expect(pkg).toBeInstanceOf(Blob);
+			expect((pkg as File).name).toBe('export.n8np');
+
+			// Multipart requests must not carry the default JSON content type;
+			// fetch fills in multipart/form-data with its own boundary.
+			expect((init.headers as Headers).get('content-type')).toBeNull();
+		});
+
+		it('throws an ApiError that preserves the blocking-issue details', async () => {
+			const body = {
+				message: 'Import blocked',
+				issues: [
+					{
+						type: 'workflow-conflict',
+						name: 'Flow',
+						sourceWorkflowId: 's1',
+						existingWorkflowId: 'e1',
+					},
+				],
+			};
+			fetchMock.mockResolvedValue(jsonResponse(409, body));
+
+			const error = await client
+				.importPackage(
+					{ buffer: Buffer.from('p'), filename: 'x.n8np' },
+					{ workflowConflictPolicy: 'fail' },
+				)
+				.catch((e: unknown) => e);
+
+			expect(error).toBeInstanceOf(ApiError);
+			expect((error as ApiError).statusCode).toBe(409);
+			expect((error as ApiError).message).toBe('Import blocked');
+			expect((error as ApiError).details).toEqual(body);
+		});
+	});
+});

--- a/packages/@n8n/cli/src/__tests__/package-error.test.ts
+++ b/packages/@n8n/cli/src/__tests__/package-error.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+
+import { ApiError } from '../client';
+import { toPackagesError } from '../commands/package/shared';
+
+describe('toPackagesError', () => {
+	it('returns non-ApiError values unchanged', () => {
+		const error = new Error('boom');
+		expect(toPackagesError(error)).toBe(error);
+	});
+
+	it('adds a beta-enablement hint for a 404', () => {
+		const result = toPackagesError(new ApiError(404, 'Not Found'));
+
+		expect(result).toBeInstanceOf(ApiError);
+		expect((result as ApiError).statusCode).toBe(404);
+		expect((result as ApiError).hint).toContain('N8N_PUBLIC_API_PACKAGES_ENABLED=true');
+	});
+
+	it('lists workflow-conflict issues for a 409', () => {
+		const result = toPackagesError(
+			new ApiError(409, 'Import blocked', undefined, {
+				issues: [
+					{
+						type: 'workflow-conflict',
+						name: 'Flow',
+						sourceWorkflowId: 's1',
+						existingWorkflowId: 'e1',
+					},
+				],
+			}),
+		);
+
+		const hint = (result as ApiError).hint ?? '';
+		expect(hint).toContain('Blocking issues:');
+		expect(hint).toContain('workflow "Flow"');
+		expect(hint).toContain('e1');
+	});
+
+	it('lists credential-unresolved issues for a 422', () => {
+		const result = toPackagesError(
+			new ApiError(422, 'Import blocked', undefined, {
+				issues: [
+					{
+						type: 'credential-unresolved',
+						kind: 'not_found',
+						sourceId: 'c1',
+						usedByWorkflows: ['w1', 'w2'],
+					},
+				],
+			}),
+		);
+
+		const hint = (result as ApiError).hint ?? '';
+		expect(hint).toContain('credential c1 unresolved (not_found)');
+		expect(hint).toContain('w1, w2');
+	});
+
+	it('leaves other ApiErrors without issue details unchanged', () => {
+		const error = new ApiError(400, 'Bad request');
+		expect(toPackagesError(error)).toBe(error);
+	});
+});

--- a/packages/@n8n/cli/src/__tests__/package-export.test.ts
+++ b/packages/@n8n/cli/src/__tests__/package-export.test.ts
@@ -1,0 +1,43 @@
+import type { Config } from '@oclif/core';
+import * as fs from 'node:fs';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import type { N8nClient } from '../client';
+import PackageExport from '../commands/package/export';
+
+vi.mock('node:fs');
+
+const mockedWriteFileSync = vi.mocked(fs.writeFileSync);
+
+/** The command methods we stub to isolate the file-writing behaviour from oclif/networking. */
+interface ExportInternals {
+	parse: () => Promise<{ flags: { workflowId: string[]; output: string } }>;
+	getClient: () => N8nClient;
+	succeed: () => void;
+}
+
+describe('package export command', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('writes the bytes returned by the client to the --output path', async () => {
+		const archive = Buffer.from([1, 2, 3]);
+		const exportPackage = vi.fn().mockResolvedValue(archive);
+
+		const command = new PackageExport([], {} as Config);
+		const internals = command as unknown as ExportInternals;
+		// Bypass oclif arg parsing, connection setup, and the success/exit path; the
+		// behaviour under test is purely that the client's bytes land at flags.output.
+		vi.spyOn(internals, 'parse').mockResolvedValue({
+			flags: { workflowId: ['wf-1', 'wf-2'], output: '/tmp/team.n8np' },
+		});
+		vi.spyOn(internals, 'getClient').mockReturnValue({ exportPackage } as unknown as N8nClient);
+		vi.spyOn(internals, 'succeed').mockImplementation(() => {});
+
+		await command.run();
+
+		expect(exportPackage).toHaveBeenCalledWith(['wf-1', 'wf-2']);
+		expect(mockedWriteFileSync).toHaveBeenCalledWith('/tmp/team.n8np', archive);
+	});
+});

--- a/packages/@n8n/cli/src/client.ts
+++ b/packages/@n8n/cli/src/client.ts
@@ -9,11 +9,21 @@ export interface ClientOptions {
 	debug?: (message: string) => void;
 }
 
+export interface ImportPackageFields {
+	projectId?: string;
+	folderId?: string;
+	credentialMatchingMode?: string;
+	credentialMissingMode?: string;
+	workflowConflictPolicy: string;
+	workflowIdPolicy?: string;
+}
+
 export class ApiError extends Error {
 	constructor(
 		readonly statusCode: number,
 		message: string,
 		readonly hint?: string,
+		readonly details?: unknown,
 	) {
 		super(message);
 		this.name = 'ApiError';
@@ -47,7 +57,12 @@ export class N8nClient {
 	private async request<T>(
 		method: string,
 		path: string,
-		options: { body?: unknown; query?: Record<string, string> } = {},
+		options: {
+			body?: unknown;
+			query?: Record<string, string>;
+			formData?: FormData;
+			responseType?: 'json' | 'binary';
+		} = {},
 	): Promise<T> {
 		const url = new URL(`${this.baseUrl}${path}`);
 		if (options.query) {
@@ -59,13 +74,18 @@ export class N8nClient {
 		this.debug?.(`→ ${method} ${url}`);
 		const start = Date.now();
 
+		const headers = new Headers(this.headers);
+		let body: BodyInit | undefined;
+		if (options.formData) {
+			headers.delete('Content-Type');
+			body = options.formData;
+		} else if (options.body !== undefined) {
+			body = JSON.stringify(options.body);
+		}
+
 		let response: Response;
 		try {
-			response = await fetch(url.toString(), {
-				method,
-				headers: this.headers,
-				body: options.body ? JSON.stringify(options.body) : undefined,
-			});
+			response = await fetch(url.toString(), { method, headers, body });
 		} catch (error) {
 			const msg = error instanceof Error ? error.message : String(error);
 			this.debug?.(`✗ Connection failed (${Date.now() - start}ms): ${msg}`);
@@ -78,18 +98,11 @@ export class N8nClient {
 
 		this.debug?.(`← ${response.status} ${response.statusText} (${Date.now() - start}ms)`);
 
-		if (response.status === 204) {
-			return undefined as T;
-		}
-
-		const contentType = response.headers.get('content-type') ?? '';
-		const isJson = contentType.includes('application/json');
-		const data: unknown = isJson ? await response.json() : await response.text();
-
 		if (!response.ok) {
+			const errorBody = await this.readBody(response);
 			const message =
-				typeof data === 'object' && data !== null && 'message' in data
-					? String((data as Record<string, unknown>).message)
+				typeof errorBody === 'object' && errorBody !== null && 'message' in errorBody
+					? String((errorBody as Record<string, unknown>).message)
 					: `Request failed (${response.status})`;
 			const hint =
 				response.status === 401
@@ -97,10 +110,23 @@ export class N8nClient {
 					: response.status === 404
 						? 'Resource not found. Verify the ID is correct.'
 						: undefined;
-			throw new ApiError(response.status, message, hint);
+			throw new ApiError(response.status, message, hint, errorBody);
 		}
 
-		return data as T;
+		if (response.status === 204) {
+			return undefined as T;
+		}
+
+		if (options.responseType === 'binary') {
+			return Buffer.from(await response.arrayBuffer()) as T;
+		}
+
+		return (await this.readBody(response)) as T;
+	}
+
+	private async readBody(response: Response): Promise<unknown> {
+		const contentType = response.headers.get('content-type') ?? '';
+		return contentType.includes('application/json') ? await response.json() : await response.text();
 	}
 
 	private async get<T>(path: string, query?: Record<string, string>): Promise<T> {
@@ -390,6 +416,29 @@ export class N8nClient {
 	async sourceControlPull(options: { force?: boolean } = {}) {
 		return await this.post<Record<string, unknown>>('/source-control/pull', {
 			force: options.force ?? false,
+		});
+	}
+
+	// ─── Packages (beta) ───────────────────────────────────────────
+
+	async exportPackage(workflowIds: string[]): Promise<Buffer> {
+		return await this.request<Buffer>('POST', '/n8n-packages/export', {
+			body: { workflowIds },
+			responseType: 'binary',
+		});
+	}
+
+	async importPackage(
+		file: { buffer: Buffer; filename: string },
+		fields: ImportPackageFields,
+	): Promise<Record<string, unknown>> {
+		const form = new FormData();
+		form.append('package', new Blob([new Uint8Array(file.buffer)]), file.filename);
+		for (const [key, value] of Object.entries(fields)) {
+			if (typeof value === 'string' && value !== '') form.append(key, value);
+		}
+		return await this.request<Record<string, unknown>>('POST', '/n8n-packages/import', {
+			formData: form,
 		});
 	}
 

--- a/packages/@n8n/cli/src/commands/package/export.ts
+++ b/packages/@n8n/cli/src/commands/package/export.ts
@@ -1,0 +1,48 @@
+import { Flags } from '@oclif/core';
+import * as fs from 'node:fs';
+
+import { toPackagesError } from './shared';
+import { BaseCommand } from '../../base-command';
+
+export default class PackageExport extends BaseCommand {
+	static override description = 'Export workflows as an n8n package (.n8np)';
+
+	static override examples = [
+		'<%= config.bin %> package export --workflow-id=abc --output=export.n8np',
+		'<%= config.bin %> package export -w abc -w def -o team.n8np',
+	];
+
+	static override flags = {
+		...BaseCommand.baseFlags,
+		workflowId: Flags.string({
+			char: 'w',
+			description: 'Workflow ID to include (repeat for multiple)',
+			multiple: true,
+			required: true,
+			aliases: ['workflow-id'],
+		}),
+		output: Flags.string({
+			char: 'o',
+			description: 'File to write the package to',
+			default: 'export.n8np',
+		}),
+	};
+
+	async run(): Promise<void> {
+		const { flags } = await this.parse(PackageExport);
+		await this.execute(async () => {
+			const client = this.getClient(flags);
+			let archive: Buffer;
+			try {
+				archive = await client.exportPackage(flags.workflowId);
+			} catch (error) {
+				throw toPackagesError(error);
+			}
+			fs.writeFileSync(flags.output, archive);
+			this.succeed(`Exported ${flags.workflowId.length} workflow(s) to ${flags.output}`, flags, {
+				output: flags.output,
+				workflowIds: flags.workflowId,
+			});
+		});
+	}
+}

--- a/packages/@n8n/cli/src/commands/package/import.ts
+++ b/packages/@n8n/cli/src/commands/package/import.ts
@@ -1,0 +1,77 @@
+import { Flags } from '@oclif/core';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { toPackagesError } from './shared';
+import { BaseCommand } from '../../base-command';
+
+export default class PackageImport extends BaseCommand {
+	static override description = 'Import an n8n package (.n8np) into a project';
+
+	static override examples = [
+		'<%= config.bin %> package import --file=export.n8np --conflict-policy=fail',
+		'<%= config.bin %> package import --file=export.n8np --project=<id> --conflict-policy=new-version',
+	];
+
+	static override flags = {
+		...BaseCommand.baseFlags,
+		file: Flags.string({ description: 'Path to the .n8np package file', required: true }),
+		project: Flags.string({
+			description: 'Target project ID (defaults to your personal project)',
+		}),
+		folder: Flags.string({
+			description: 'Target folder ID within the project (defaults to the project root)',
+		}),
+		conflictPolicy: Flags.string({
+			description: 'What to do when a workflow already exists in the target project',
+			options: ['new-version', 'fail', 'skip'],
+			required: true,
+			aliases: ['conflict-policy'],
+		}),
+		workflowIdPolicy: Flags.string({
+			description: 'Whether imported workflows keep their source ID or receive a new one',
+			options: ['new', 'source'],
+			aliases: ['workflow-id-policy'],
+		}),
+		credentialMatchingMode: Flags.string({
+			description: 'How credential references are matched on the target instance',
+			options: ['id-only'],
+			aliases: ['credential-matching-mode'],
+		}),
+		credentialMissingMode: Flags.string({
+			description: 'What to do when a referenced credential cannot be resolved',
+			options: ['must-preexist'],
+			aliases: ['credential-missing-mode'],
+		}),
+	};
+
+	async run(): Promise<void> {
+		const { flags } = await this.parse(PackageImport);
+
+		if (!fs.existsSync(flags.file)) {
+			this.error(`File not found: ${flags.file}`);
+		}
+
+		await this.execute(async () => {
+			const buffer = fs.readFileSync(flags.file);
+			const client = this.getClient(flags);
+			let result: Record<string, unknown>;
+			try {
+				result = await client.importPackage(
+					{ buffer, filename: path.basename(flags.file) },
+					{
+						projectId: flags.project,
+						folderId: flags.folder,
+						workflowConflictPolicy: flags.conflictPolicy,
+						workflowIdPolicy: flags.workflowIdPolicy,
+						credentialMatchingMode: flags.credentialMatchingMode,
+						credentialMissingMode: flags.credentialMissingMode,
+					},
+				);
+			} catch (error) {
+				throw toPackagesError(error);
+			}
+			this.output(result, flags);
+		});
+	}
+}

--- a/packages/@n8n/cli/src/commands/package/shared.ts
+++ b/packages/@n8n/cli/src/commands/package/shared.ts
@@ -1,0 +1,46 @@
+import { ApiError } from '../../client';
+
+const BETA_HINT =
+	'The n8n Packages API is beta and disabled by default. Enable it on the instance with ' +
+	'N8N_PUBLIC_API_PACKAGES_ENABLED=true (requires the n8n Packages license).';
+
+type BlockingIssue =
+	| {
+			type: 'workflow-conflict';
+			sourceWorkflowId: string;
+			existingWorkflowId: string;
+			name: string;
+	  }
+	| { type: 'credential-unresolved'; kind: string; sourceId: string; usedByWorkflows: string[] };
+
+function formatIssue(issue: unknown): string {
+	if (typeof issue !== 'object' || issue === null) return JSON.stringify(issue);
+	const it = issue as Partial<BlockingIssue> & Record<string, unknown>;
+	if (it.type === 'workflow-conflict') {
+		return `workflow "${it.name}" (source ${it.sourceWorkflowId}) already exists as ${it.existingWorkflowId}`;
+	}
+	if (it.type === 'credential-unresolved') {
+		const usedBy = Array.isArray(it.usedByWorkflows) ? it.usedByWorkflows.join(', ') : '';
+		return `credential ${it.sourceId} unresolved (${it.kind}), used by workflow(s) ${usedBy}`;
+	}
+	return JSON.stringify(issue);
+}
+
+function issuesHint(details: unknown): string | undefined {
+	if (typeof details !== 'object' || details === null) return undefined;
+	const issues = (details as { issues?: unknown }).issues;
+	if (!Array.isArray(issues) || issues.length === 0) return undefined;
+	return ['Blocking issues:', ...issues.map((issue) => `  - ${formatIssue(issue)}`)].join('\n');
+}
+
+export function toPackagesError(error: unknown): unknown {
+	if (!(error instanceof ApiError)) return error;
+	if (error.statusCode === 404) {
+		return new ApiError(error.statusCode, error.message, BETA_HINT, error.details);
+	}
+	const hint = issuesHint(error.details);
+	if (hint) {
+		return new ApiError(error.statusCode, error.message, hint, error.details);
+	}
+	return error;
+}

--- a/packages/@n8n/cli/src/index.ts
+++ b/packages/@n8n/cli/src/index.ts
@@ -24,6 +24,8 @@ import ExecutionRetry from './commands/execution/retry';
 import ExecutionStop from './commands/execution/stop';
 import Login from './commands/login';
 import Logout from './commands/logout';
+import PackageExport from './commands/package/export';
+import PackageImport from './commands/package/import';
 import ProjectAddMember from './commands/project/add-member';
 import ProjectCreate from './commands/project/create';
 import ProjectDelete from './commands/project/delete';
@@ -120,6 +122,9 @@ export const commands = {
 	'skill:install': SkillInstall,
 
 	'source-control:pull': SourceControlPull,
+
+	'package:export': PackageExport,
+	'package:import': PackageImport,
 
 	audit: Audit,
 };

--- a/packages/cli/src/modules/n8n-packages/CLAUDE.md
+++ b/packages/cli/src/modules/n8n-packages/CLAUDE.md
@@ -1,0 +1,72 @@
+# n8n-packages module — Agent Guidelines
+
+This module powers package **import/export** (`.n8np`). The feature is
+**public-API-first; the CLI wraps the API.** A single import/export option
+therefore lives in up to four layers across three packages.
+
+## ⚠️ Propagate new properties through every layer
+
+**When you add, rename, or remove a property on the import or export request,
+carry it through all four layers below.** A property that stops at the module
+is invisible to public-API and CLI users — and an out-of-date OpenAPI spec or
+CLI flag is a silent bug, not a compile error.
+
+```mermaid
+flowchart LR
+  M["1. Module<br/>(this package)"] --> D["2. DTO<br/>@n8n/api-types"]
+  D --> A["3. Public API<br/>handler + OpenAPI spec"]
+  A --> C["4. CLI<br/>@n8n/cli"]
+```
+
+### Adding an IMPORT property
+
+1. **Module** (here)
+   - `n8n-packages.types.ts` — add the field to `ImportPackageRequest`
+     (or `ImportWorkflowProperties` / `ImportCredentialProperties`). For a new
+     enum, add a `XxxPolicy` / `XxxMode` const **and** its derived type
+     (follow `WorkflowIdPolicy`). New single-value modes are RFC seams — keep
+     the function-table convention (`workflow-conflict-policy.ts` etc.), don't
+     add handler classes for pure logic.
+   - Implement the behaviour (e.g. `entities/workflow/workflow-importer.ts`)
+     and thread it through `n8n-packages.service.ts` `importPackage`.
+2. **DTO** — `@n8n/api-types/src/dto/packages/import-package-request.dto.ts`
+   - Add the field to `ImportPackageRequestDto` (zod), **and** add its name to
+     `IMPORT_PACKAGE_REQUEST_FORM_FIELDS` (multipart text fields).
+   - Update `__tests__/import-package-request.dto.test.ts`.
+3. **Public API** — `packages/cli/src/public-api/v1/handlers/n8n-packages/`
+   - `n8n-packages.handler.ts` — pass `payload.data.<field>` into the service.
+   - `spec/paths/n8n-packages.import.yml` — add the property to the inline
+     `multipart/form-data` request schema (type/enum/description; update
+     `required` if needed). **Easy to forget — the spec is hand-written.**
+4. **CLI** — `packages/@n8n/cli/`
+   - `src/client.ts` — add to `ImportPackageFields`.
+   - `src/commands/package/import.ts` — add a `Flags.string({...})` (with a
+     kebab-case alias) and pass it into `client.importPackage(...)`.
+   - `docs/commands/package.md` + the `README.md` flag table.
+
+### Adding an EXPORT property
+
+1. **Module** — `n8n-packages.types.ts` `ExportWorkflowsRequest`; implement in
+   `n8n-packages.service.ts` `exportWorkflows` (+ `io/` writer or
+   `entities/*/` exporter as needed).
+2. **DTO** — `@n8n/api-types/src/dto/packages/export-workflows-request.dto.ts`
+   (`ExportWorkflowsRequestDto`, zod).
+3. **Public API** — `n8n-packages.handler.ts` `exportWorkflows` reads from
+   `payload.data`; update the **separate** schema file
+   `spec/schemas/exportWorkflowsRequest.yml` (export's request schema is a
+   `$ref`, unlike import's inline schema).
+4. **CLI** — `src/client.ts` `exportPackage(...)`,
+   `src/commands/package/export.ts` flag, and the docs/README.
+
+## Reference: the `workflowIdPolicy` change
+
+The in-tree addition of `workflowIdPolicy` is the canonical example — it landed
+in the module types + importer, the DTO (+ form-fields list), the handler, and
+the CLI. Grep `workflowIdPolicy` to see every site a new import knob must touch.
+
+## More context
+
+See the module structure and import-pipeline flow notes in the root
+`AGENTS.md` and the package import/export RFC. Licensed behind
+`feat:n8nPackages`; the public-API endpoints are beta and gated by
+`N8N_PUBLIC_API_PACKAGES_ENABLED`.


### PR DESCRIPTION
## Summary

Adds `package:export` and `package:import` commands to the new cli client
https://www.loom.com/share/3f9f99fe64504f06a1531b584a8268a7

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-692

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. <!-- CLI docs added in-repo (docs/commands/package.md); n8n-docs not yet updated (beta). -->
- [x] Tests included.
- [ ] PR Labeled with Backport to Beta / Stable / v1 (if urgent fix needing backport)
