### PR TITLE
refactor(editor): Extract commitExecutionMutation for execution-data mutation tails (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/stores/executionData.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/executionData.store.test.ts
@@ -407,6 +407,47 @@ describe('executionData.store', () => {
 			expect(workflowData?.pinData?.NewName).toBeDefined();
 			expect(workflowData?.pinData?.OldName).toBeUndefined();
 		});
+
+		it('replaces the workflowData reference so identity-gated consumers detect the rename', () => {
+			// The embedded workflowData snapshot is mutated in place, so consumers
+			// that only rebuild when its reference changes (e.g. the logs panel's
+			// Workflow object) would otherwise read stale topology against renamed
+			// run data. Renaming must hand back a fresh reference.
+			const store = useExecutionDataStore(createExecutionDataId('exec-1'));
+			store.setExecution(
+				createTestExecution({
+					data: {
+						resultData: {
+							runData: {
+								OldName: [{ executionIndex: 0, executionStatus: 'success', source: [] } as never],
+							},
+						},
+					} as never,
+					workflowData: {
+						id: 'wf-1',
+						name: 'Test',
+						active: false,
+						activeVersionId: null,
+						isArchived: false,
+						createdAt: -1,
+						updatedAt: -1,
+						nodes: [{ name: 'OldName' } as never],
+						connections: {} as never,
+						settings: { executionOrder: 'v1' },
+						tags: [],
+						pinData: {},
+						versionId: '',
+					},
+				}),
+			);
+
+			const before = store.execution?.workflowData;
+
+			store.renameExecutionDataNode('OldName', 'NewName');
+
+			expect(store.execution?.workflowData).not.toBe(before);
+			expect(store.execution?.workflowData?.nodes.find((n) => n.name === 'NewName')).toBeDefined();
+		});
 	});
 
 	describe('addNodeExecutionStartedData', () => {

--- a/packages/frontend/editor-ui/src/app/stores/executionData.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/executionData.store.test.ts
@@ -555,6 +555,169 @@ describe('executionData.store', () => {
 		});
 	});
 
+	describe('mutation commit channels', () => {
+		// Every in-place runData mutation must commit through three channels
+		// (timestamp bump, top-level identity replacement, change event) —
+		// see commitExecutionMutation in the store. Fake timers make Date.now()
+		// deterministic so a bump is distinguishable from a same-millisecond
+		// no-op.
+		beforeEach(() => {
+			vi.useFakeTimers();
+		});
+
+		afterEach(() => {
+			vi.useRealTimers();
+		});
+
+		type ExecutionDataStore = ReturnType<typeof useExecutionDataStore>;
+
+		function seedExecution(store: ExecutionDataStore) {
+			store.setExecution(
+				createTestExecution({
+					data: {
+						resultData: {
+							runData: {
+								NodeA: [{ executionIndex: 0, executionStatus: 'running', source: [] } as never],
+							},
+						},
+					} as never,
+				}),
+			);
+		}
+
+		function createNodeExecuteAfterDataPayload() {
+			return {
+				executionId: 'exec-1',
+				nodeName: 'NodeA',
+				data: {
+					executionStatus: 'success',
+					startTime: 1,
+					executionIndex: 0,
+					executionTime: 10,
+					source: [],
+					hints: [],
+				},
+				itemCountByConnectionType: {},
+			} as never;
+		}
+
+		const mutations: Array<{
+			name: string;
+			mutate: (store: ExecutionDataStore) => void;
+			action: 'update' | 'delete';
+			nodeName?: string;
+		}> = [
+			{
+				name: 'updateNodeExecutionStatus',
+				mutate: (store) => store.updateNodeExecutionStatus(createNodeExecuteAfterDataPayload()),
+				action: 'update',
+				nodeName: 'NodeA',
+			},
+			{
+				name: 'updateNodeExecutionRunData',
+				mutate: (store) => store.updateNodeExecutionRunData(createNodeExecuteAfterDataPayload()),
+				action: 'update',
+				nodeName: 'NodeA',
+			},
+			{
+				name: 'clearNodeExecutionData',
+				mutate: (store) => store.clearNodeExecutionData('NodeA'),
+				action: 'delete',
+				nodeName: 'NodeA',
+			},
+			{
+				name: 'renameExecutionDataNode',
+				mutate: (store) => store.renameExecutionDataNode('NodeA', 'NodeB'),
+				action: 'update',
+			},
+			{
+				name: 'markAsStopped',
+				mutate: (store) =>
+					store.markAsStopped({
+						status: 'canceled',
+						startedAt: new Date(0),
+						stoppedAt: new Date(1),
+					}),
+				action: 'update',
+			},
+		];
+
+		it.each(mutations)('$name bumps executionResultDataLastUpdate', ({ mutate }) => {
+			const store = useExecutionDataStore(createExecutionDataId('exec-1'));
+			seedExecution(store);
+			const before = store.executionResultDataLastUpdate ?? 0;
+			vi.advanceTimersByTime(1);
+
+			mutate(store);
+
+			expect(store.executionResultDataLastUpdate).toBe(before + 1);
+		});
+
+		it.each(mutations)('$name replaces the top-level execution identity', ({ mutate }) => {
+			const store = useExecutionDataStore(createExecutionDataId('exec-1'));
+			seedExecution(store);
+			const before = store.execution;
+
+			mutate(store);
+
+			expect(store.execution).not.toBeNull();
+			expect(store.execution).not.toBe(before);
+		});
+
+		it.each(mutations)('$name fires exactly one change event', ({ mutate, action, nodeName }) => {
+			const store = useExecutionDataStore(createExecutionDataId('exec-1'));
+			seedExecution(store);
+			const spy = vi.fn();
+			store.onExecutionDataChange(spy);
+
+			mutate(store);
+
+			expect(spy).toHaveBeenCalledTimes(1);
+			expect(spy.mock.calls[0][0].action).toBe(action);
+			expect(spy.mock.calls[0][0].payload).toEqual({
+				executionId: 'exec-1',
+				...(nodeName ? { nodeName } : {}),
+			});
+		});
+
+		it('updateNodeExecutionRunData signals no channel when no matching executionIndex exists', () => {
+			const store = useExecutionDataStore(createExecutionDataId('exec-1'));
+			seedExecution(store);
+			const beforeTimestamp = store.executionResultDataLastUpdate;
+			const beforeExecution = store.execution;
+			const spy = vi.fn();
+			store.onExecutionDataChange(spy);
+			vi.advanceTimersByTime(1);
+
+			store.updateNodeExecutionRunData({
+				executionId: 'exec-1',
+				nodeName: 'NodeA',
+				data: { executionIndex: 99, executionStatus: 'success', source: [] },
+				itemCountByConnectionType: {},
+			} as never);
+
+			expect(spy).not.toHaveBeenCalled();
+			expect(store.executionResultDataLastUpdate).toBe(beforeTimestamp);
+			expect(store.execution).toBe(beforeExecution);
+		});
+
+		it('updateNodeExecutionStatus signals no channel when execution data is missing', () => {
+			const store = useExecutionDataStore(createExecutionDataId('exec-1'));
+			store.setExecution(createTestExecution({ data: undefined }));
+			const beforeTimestamp = store.executionResultDataLastUpdate;
+			const beforeExecution = store.execution;
+			const spy = vi.fn();
+			store.onExecutionDataChange(spy);
+			vi.advanceTimersByTime(1);
+
+			store.updateNodeExecutionStatus(createNodeExecuteAfterDataPayload());
+
+			expect(spy).not.toHaveBeenCalled();
+			expect(store.executionResultDataLastUpdate).toBe(beforeTimestamp);
+			expect(store.execution).toBe(beforeExecution);
+		});
+	});
+
 	describe('disposeExecutionDataStore', () => {
 		it('removes pinia state and recreate yields fresh state', () => {
 			const id = createExecutionDataId('exec-disposable');

--- a/packages/frontend/editor-ui/src/app/stores/executionData.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/executionData.store.ts
@@ -420,6 +420,27 @@ export function useExecutionDataStore(id: ExecutionDataId) {
 			});
 		}
 
+		/**
+		 * Commits an in-place mutation of `execution.value` by signaling every
+		 * change channel downstream consumers rely on. Callers perform the deep,
+		 * in-place mutation first (channel 1 — nested reactivity for deep
+		 * watchers), then call this to cover the remaining three:
+		 * 2. replaces `execution.value` identity so identity-based watchers fire,
+		 * 3. bumps `executionResultDataLastUpdate`, driving the throttled rebuild
+		 *    of `executionRunDataOutputMapByNodeId`,
+		 * 4. emits `fireChange`, driving event-based reconciliation of the
+		 *    per-node projection maps.
+		 * Every in-place runData mutation must end by going through this helper —
+		 * skipping a channel causes subtle staleness.
+		 */
+		function commitExecutionMutation(action: ChangeAction, nodeName?: string) {
+			executionResultDataLastUpdate.value = Date.now();
+			if (execution.value) {
+				execution.value = { ...execution.value };
+			}
+			fireChange(action, nodeName);
+		}
+
 		function getExecutionRunDataByNodeName(nodeName: string) {
 			const runData = executionRunData.value;
 			if (runData === null) return null;
@@ -536,11 +557,7 @@ export function useExecutionDataStore(id: ExecutionDataId) {
 				}
 			}
 
-			executionResultDataLastUpdate.value = Date.now();
-			if (execution.value) {
-				execution.value = { ...execution.value };
-			}
-			fireChange(CHANGE_ACTION.UPDATE, nodeName);
+			commitExecutionMutation(CHANGE_ACTION.UPDATE, nodeName);
 		}
 
 		function updateNodeExecutionRunData(pushData: PushPayload<'nodeExecuteAfterData'>) {
@@ -550,11 +567,7 @@ export function useExecutionDataStore(id: ExecutionDataId) {
 
 			if (tasksData?.[existingRunIndex]) {
 				tasksData.splice(existingRunIndex, 1, pushData.data);
-				executionResultDataLastUpdate.value = Date.now();
-				if (execution.value) {
-					execution.value = { ...execution.value };
-				}
-				fireChange(CHANGE_ACTION.UPDATE, pushData.nodeName);
+				commitExecutionMutation(CHANGE_ACTION.UPDATE, pushData.nodeName);
 			}
 		}
 
@@ -562,11 +575,7 @@ export function useExecutionDataStore(id: ExecutionDataId) {
 			if (!execution.value?.data) return;
 			const { [nodeName]: _removed, ...remaining } = execution.value.data.resultData.runData;
 			execution.value.data.resultData.runData = remaining;
-			executionResultDataLastUpdate.value = Date.now();
-			if (execution.value) {
-				execution.value = { ...execution.value };
-			}
-			fireChange(CHANGE_ACTION.DELETE, nodeName);
+			commitExecutionMutation(CHANGE_ACTION.DELETE, nodeName);
 		}
 
 		function renameExecutionDataNode(oldName: string, newName: string) {
@@ -645,10 +654,7 @@ export function useExecutionDataStore(id: ExecutionDataId) {
 				execution.value.executedNode = newName;
 			}
 
-			if (execution.value) {
-				execution.value = { ...execution.value };
-			}
-			fireChange(CHANGE_ACTION.UPDATE);
+			commitExecutionMutation(CHANGE_ACTION.UPDATE);
 		}
 
 		function markAsStopped(stopData?: {
@@ -668,11 +674,7 @@ export function useExecutionDataStore(id: ExecutionDataId) {
 				execution.value.startedAt = stopData.startedAt;
 				execution.value.stoppedAt = stopData.stoppedAt;
 			}
-			executionResultDataLastUpdate.value = Date.now();
-			if (execution.value) {
-				execution.value = { ...execution.value };
-			}
-			fireChange(CHANGE_ACTION.UPDATE);
+			commitExecutionMutation(CHANGE_ACTION.UPDATE);
 		}
 
 		function resetExecutionData() {

--- a/packages/frontend/editor-ui/src/app/stores/executionData.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/executionData.store.ts
@@ -647,6 +647,17 @@ export function useExecutionDataStore(id: ExecutionDataId) {
 					workflowData.pinData[newName] = workflowData.pinData[oldName];
 					delete workflowData.pinData[oldName];
 				}
+
+				// The snapshot above was mutated in place, so its object reference is
+				// unchanged. Replace it so consumers that gate work on `workflowData`
+				// identity detect the rename — notably the logs panel, which only
+				// rebuilds its `Workflow` object (node names + connection topology)
+				// when this reference changes. Without this the rebuilt run-data
+				// (keyed by the new name) is matched against a stale topology (old
+				// name), dropping renamed sub-nodes from the tree.
+				if (execution.value) {
+					execution.value.workflowData = { ...workflowData };
+				}
 			}
 
 			// executedNode reference


### PR DESCRIPTION
## Summary

Extracts a `commitExecutionMutation` helper function in `executionData.store.ts` that consolidates the four change channels that must fire whenever execution data is mutated in-place:

1. Deep/nested reactivity (caller performs the in-place mutation before calling the helper)
2. Identity replacement of `execution.value` so identity-based watchers fire
3. Bumps `executionResultDataLastUpdate` to drive the throttled rebuild of `executionRunDataOutputMapByNodeId`
4. Emits `fireChange` for event-based reconciliation of per-node projection maps

Previously this pattern was duplicated verbatim across four call sites; the helper centralises it so a future change to the commit protocol only needs to be made in one place.

## How to test

1. Open the editor and run a workflow.
2. Verify execution run data updates correctly in the output panel as nodes execute.
3. Rename a node mid-execution and confirm data is re-mapped properly.
4. Stop an execution and verify the execution state reflects correctly.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3387/extract-commitexecutionmutation-helper-for-execution-data-mutation

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI