### PR TITLE
fix(editor): Dispose diff-side execution-state stores with their documents (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiff.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiff.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ref, computed } from 'vue';
+import { ref, computed, effectScope, nextTick } from 'vue';
 import { mapConnections, useWorkflowDiff } from './useWorkflowDiff';
 import type { CanvasConnection, CanvasNode } from '@/features/workflows/canvas/canvas.types';
 import type { ExecutionOutputMap } from '@/app/types/executionData';
 import type { INodeUi, IWorkflowDb } from '@/Interface';
 import { NodeDiffStatus, type IConnections } from 'n8n-workflow';
 import { useCanvasMapping } from '@/features/workflows/canvas/composables/useCanvasMapping';
+import { disposeWorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import { disposeWorkflowExecutionStateStore } from '@/app/stores/workflowExecutionState.store';
 
 // Mock modules at top level
 vi.mock('@/app/stores/workflows.store', () => ({
@@ -27,7 +29,9 @@ const mockDocumentStore = vi.hoisted(() => ({
 }));
 vi.mock('@/app/stores/workflowDocument.store', () => ({
 	useWorkflowDocumentStore: () => mockDocumentStore,
-	createWorkflowDocumentId: vi.fn().mockReturnValue('test-id'),
+	createWorkflowDocumentId: vi.fn(
+		(workflowId: string, version: string = 'latest') => `${workflowId}@${version}`,
+	),
 	disposeWorkflowDocumentStore: vi.fn(),
 }));
 
@@ -41,9 +45,11 @@ vi.mock('@/app/stores/workflowDocument/useWorkflowDocumentRenderData', async () 
 });
 
 vi.mock('@/app/stores/workflowExecutionState.store', () => ({
-	useWorkflowExecutionStateStore: () => ({
+	useWorkflowExecutionStateStore: vi.fn((id: string) => ({
+		$id: id,
 		activeExecutionIssuesByNodeName: new Map(),
-	}),
+	})),
+	disposeWorkflowExecutionStateStore: vi.fn(),
 }));
 
 vi.mock('@/app/stores/nodeTypes.store', () => ({
@@ -450,6 +456,62 @@ describe('useWorkflowDiff', () => {
 
 			expect(canvasNodes[0].id).toBeDefined();
 			expect(hydratedNodes[0].id).toBe(canvasNodes[0].id);
+		});
+
+		it('disposes the execution-state store of the previous document when the diffed workflow changes', async () => {
+			const sourceWorkflowRef = ref<IWorkflowDb | undefined>(createMockWorkflow('source'));
+
+			useWorkflowDiff(sourceWorkflowRef, undefined);
+
+			expect(disposeWorkflowExecutionStateStore).not.toHaveBeenCalled();
+
+			sourceWorkflowRef.value = { ...createMockWorkflow('source'), versionId: 'version-2' };
+			await nextTick();
+
+			expect(disposeWorkflowExecutionStateStore).toHaveBeenCalledTimes(1);
+			expect(disposeWorkflowExecutionStateStore).toHaveBeenCalledWith(
+				expect.objectContaining({ $id: 'source@version-1' }),
+			);
+		});
+
+		it('disposes the execution-state stores of both sides on dispose', () => {
+			const scope = effectScope();
+			scope.run(() => {
+				useWorkflowDiff(createMockWorkflow('source'), createMockWorkflow('target'));
+			});
+
+			expect(disposeWorkflowExecutionStateStore).not.toHaveBeenCalled();
+
+			scope.stop();
+
+			expect(disposeWorkflowExecutionStateStore).toHaveBeenCalledTimes(2);
+			expect(disposeWorkflowExecutionStateStore).toHaveBeenCalledWith(
+				expect.objectContaining({ $id: 'source@version-1' }),
+			);
+			expect(disposeWorkflowExecutionStateStore).toHaveBeenCalledWith(
+				expect.objectContaining({ $id: 'target@version-1' }),
+			);
+			expect(disposeWorkflowDocumentStore).toHaveBeenCalledTimes(2);
+		});
+
+		it('disposes the execution-state store before recreating it when a versionless document id is reused', async () => {
+			const versionlessWorkflow = {
+				...createMockWorkflow('source'),
+				versionId: undefined,
+			} as unknown as IWorkflowDb;
+			const sourceWorkflowRef = ref<IWorkflowDb | undefined>(versionlessWorkflow);
+
+			useWorkflowDiff(sourceWorkflowRef, undefined);
+
+			sourceWorkflowRef.value = { ...versionlessWorkflow, name: 'Updated Workflow' };
+			await nextTick();
+
+			// Without a versionId both renders share the `source@diff-source` document id;
+			// the stale execution-state store must be disposed, not resurrected.
+			expect(disposeWorkflowExecutionStateStore).toHaveBeenCalledTimes(1);
+			expect(disposeWorkflowExecutionStateStore).toHaveBeenCalledWith(
+				expect.objectContaining({ $id: 'source@diff-source' }),
+			);
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiff.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/workflowDiff/useWorkflowDiff.ts
@@ -21,7 +21,12 @@ import {
 	useWorkflowDocumentStore,
 	createWorkflowDocumentId,
 	disposeWorkflowDocumentStore,
+	type WorkflowDocumentId,
 } from '@/app/stores/workflowDocument.store';
+import {
+	useWorkflowExecutionStateStore,
+	disposeWorkflowExecutionStateStore,
+} from '@/app/stores/workflowExecutionState.store';
 import { useWorkflowDocumentRenderData } from '@/app/stores/workflowDocument/useWorkflowDocumentRenderData';
 import {
 	createEmptyCanvasRenderData,
@@ -121,18 +126,32 @@ function createDiffRenderData(
 ) {
 	const renderData = shallowRef<CanvasRenderData>(createEmptyCanvasRenderData());
 	let workflowDocumentStore: ReturnType<typeof useWorkflowDocumentStore> | null = null;
+	// Document id of the stores this side currently owns.
+	let currentDocumentId: WorkflowDocumentId | null = null;
 	// `useWorkflowDocumentRenderData` is side-effectful; own its scope so it can
 	// be torn down when the diffed workflow changes or this side disposes.
 	let renderDataScope: EffectScope | undefined;
+
+	function disposeStores() {
+		renderDataScope?.stop();
+		renderDataScope = undefined;
+		if (currentDocumentId) {
+			// Render data created an execution-state store keyed by this document id;
+			// dispose it with the document store so neither outlives the diff side.
+			disposeWorkflowExecutionStateStore(useWorkflowExecutionStateStore(currentDocumentId));
+			currentDocumentId = null;
+		}
+		if (workflowDocumentStore) {
+			disposeWorkflowDocumentStore(workflowDocumentStore);
+			workflowDocumentStore = null;
+		}
+	}
 
 	watchEffect(() => {
 		const wf = workflowRef.value;
 		if (!wf?.id) return;
 
-		if (workflowDocumentStore) {
-			disposeWorkflowDocumentStore(workflowDocumentStore);
-		}
-		renderDataScope?.stop();
+		disposeStores();
 
 		const versionId = wf.versionId ?? `diff-${side}`;
 		const docId = createWorkflowDocumentId(wf.id, versionId);
@@ -147,22 +166,14 @@ function createDiffRenderData(
 			nodes: workflowNodes.value.map((node) => ({ ...node })),
 			versionId,
 		} as IWorkflowDb);
+		currentDocumentId = docId;
 		renderDataScope = effectScope(true);
 		renderDataScope.run(() => {
 			renderData.value = useWorkflowDocumentRenderData(docId);
 		});
 	});
 
-	function dispose() {
-		renderDataScope?.stop();
-		renderDataScope = undefined;
-		if (workflowDocumentStore) {
-			disposeWorkflowDocumentStore(workflowDocumentStore);
-			workflowDocumentStore = null;
-		}
-	}
-
-	return { renderData, dispose };
+	return { renderData, dispose: disposeStores };
 }
 
 export const useWorkflowDiff = (


### PR DESCRIPTION
## Summary

`createDiffRenderData` in `useWorkflowDiff.ts` creates an ephemeral Pinia execution-state store (via `useWorkflowDocumentRenderData`) for each diff side, but previously disposed only the document store — leaving one `WORKFLOW_EXECUTION_STATES/<id>@<versionId>` store leaked per diffed version, retaining the disposed document store's full object graph. For versionless workflows the document id is reused (`<id>@diff-source`), meaning re-opening a diff would resurrect a stale store with a dead node-change subscription.

The fix tracks the current document id in `createDiffRenderData` and disposes the execution-state store together with the document store in both the `watchEffect` re-run path and `dispose()`, ordered: stop render-data scope → `disposeWorkflowExecutionStateStore` → `disposeWorkflowDocumentStore`. The main-canvas path (`WorkflowCanvas.vue` / `resetWorkspace`) is unchanged.

## How to test

1. Open a workflow diff (e.g. via Source Control push modal or workflow version history) and switch between several diffed versions
2. In Vue DevTools → Pinia, verify no stale `WORKFLOW_EXECUTION_STATES/...` entries accumulate after switching versions
3. For a workflow without a `versionId`, close and re-open the diff and confirm the canvas still renders node states correctly (running maps reconcile)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3386

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI