### PR TITLE
feat(Microsoft Excel 365 Node): Support workbooks in shared and SharePoint document libraries

### DIFF
--- a/packages/nodes-base/credentials/MicrosoftExcelOAuth2Api.credentials.ts
+++ b/packages/nodes-base/credentials/MicrosoftExcelOAuth2Api.credentials.ts
@@ -1,7 +1,13 @@
 import type { ICredentialType, INodeProperties } from 'n8n-workflow';
 
 //https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-permissions-and-consent
-const defaultScopes = ['openid', 'offline_access', 'Files.ReadWrite'];
+// Files.ReadWrite.All grants read and write to every file the user can access,
+// including shared and SharePoint document libraries (not just personal OneDrive),
+// and satisfies the tenant-wide /search/query used to list workbooks. This is an
+// admin-consent scope; that is acceptable for this node because it enables reading
+// and writing workbooks wherever they live. Existing credentials keep working for
+// OneDrive on the old token and need a one-time reconnect to reach shared/SharePoint.
+const defaultScopes = ['openid', 'offline_access', 'Files.ReadWrite.All'];
 
 export class MicrosoftExcelOAuth2Api implements ICredentialType {
 	name = 'microsoftExcelOAuth2Api';

--- a/packages/nodes-base/credentials/test/MicrosoftExcelOAuth2Api.credentials.test.ts
+++ b/packages/nodes-base/credentials/test/MicrosoftExcelOAuth2Api.credentials.test.ts
@@ -5,7 +5,8 @@ import { MicrosoftExcelOAuth2Api } from '../MicrosoftExcelOAuth2Api.credentials'
 
 describe('MicrosoftExcelOAuth2Api Credential', () => {
 	const microsoftExcelOAuth2Api = new MicrosoftExcelOAuth2Api();
-	const defaultScopes = ['openid', 'offline_access', 'Files.ReadWrite'];
+	const defaultScopes = ['openid', 'offline_access', 'Files.ReadWrite.All'];
+	const defaultScopesString = defaultScopes.join(' ');
 
 	// Shared OAuth2 configuration
 	const baseUrl = 'https://login.microsoftonline.com';
@@ -62,7 +63,7 @@ describe('MicrosoftExcelOAuth2Api Credential', () => {
 		const enabledScopesProperty = microsoftExcelOAuth2Api.properties.find(
 			(p) => p.name === 'enabledScopes',
 		);
-		expect(enabledScopesProperty?.default).toBe('openid offline_access Files.ReadWrite');
+		expect(enabledScopesProperty?.default).toBe(defaultScopesString);
 	});
 
 	describe('OAuth2 flow with default scopes', () => {
@@ -84,7 +85,7 @@ describe('MicrosoftExcelOAuth2Api Credential', () => {
 			const oauthClient = createOAuthClient(defaultScopes);
 			const token = await oauthClient.code.getToken(redirectUri + `?code=${code}`);
 
-			expect(token.data.scope).toBe('openid offline_access Files.ReadWrite');
+			expect(token.data.scope).toBe(defaultScopesString);
 		});
 	});
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/MicrosoftExcel.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/MicrosoftExcel.node.ts
@@ -13,7 +13,7 @@ export class MicrosoftExcel extends VersionedNodeType {
 			group: ['input'],
 			subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 			description: 'Consume Microsoft Excel API',
-			defaultVersion: 2.2,
+			defaultVersion: 2.3,
 		};
 
 		const nodeVersions: IVersionedNodeType['nodeVersions'] = {
@@ -21,6 +21,7 @@ export class MicrosoftExcel extends VersionedNodeType {
 			2: new MicrosoftExcelV2(baseDescription),
 			2.1: new MicrosoftExcelV2(baseDescription),
 			2.2: new MicrosoftExcelV2(baseDescription),
+			2.3: new MicrosoftExcelV2(baseDescription),
 		};
 
 		super(nodeVersions, baseDescription);

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/common.descriptions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/common.descriptions.test.ts
@@ -1,0 +1,49 @@
+import type { INodePropertyModeValidation } from 'n8n-workflow';
+
+import { workbookRLC, workbookSourceOption } from '../../v2/actions/common.descriptions';
+
+describe('Microsoft Excel V2 - workbook Source option', () => {
+	it('is a single "Source" dropdown for the options collection', () => {
+		expect(workbookSourceOption.name).toBe('workbookSource');
+		expect(workbookSourceOption.type).toBe('options');
+		expect(workbookSourceOption.displayName).toBe('Source');
+	});
+
+	it('offers the OneDrive, SharePoint and Everything sources', () => {
+		const values = (workbookSourceOption.options as Array<{ value: string }>).map(
+			(option) => option.value,
+		);
+		expect(values).toEqual(['all', 'oneDrive', 'sharePoint']);
+	});
+
+	it('is not version-gated itself (the effective default is resolved in code)', () => {
+		expect(workbookSourceOption.displayOptions).toBeUndefined();
+	});
+});
+
+describe('Microsoft Excel V2 - workbook resource locator By-ID validation', () => {
+	const idMode = workbookRLC.modes?.find((mode) => mode.name === 'id');
+	const validation = idMode?.validation?.[0] as INodePropertyModeValidation;
+	const regexStr = (validation.properties as { regex: string }).regex;
+
+	// n8n anchors resource-locator validation regexes with ^...$ (node-helpers.ts),
+	// so replicate that here to test the effective validation behaviour.
+	const isValid = (value: string) => new RegExp(`^${regexStr}$`).test(value);
+
+	it('accepts a typical alphanumeric workbook ID', () => {
+		expect(isValid('016LYZ3HQLTTXHTQCNKVCZDNMBGHYD3ROY')).toBe(true);
+	});
+
+	it('accepts workbook IDs containing - and _', () => {
+		expect(isValid('01ABC-DEF_123')).toBe(true);
+	});
+
+	it('accepts a composite "driveId/itemId" value from search results', () => {
+		expect(isValid('b!aW0DNIreC0OqxM8L/016LYZ3HV5VLDXAMOGS5H3BVPJ7NHIY6PC')).toBe(true);
+	});
+
+	it('rejects empty or single-character input', () => {
+		expect(isValid('')).toBe(false);
+		expect(isValid('a')).toBe(false);
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/helpers/errorHandling.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/helpers/errorHandling.test.ts
@@ -1,0 +1,57 @@
+import { mapMicrosoftApiError } from '../../../v2/helpers/errorHandling';
+
+describe('mapMicrosoftApiError', () => {
+	it('maps SharePoint license errors to a license message', () => {
+		const result = mapMicrosoftApiError({
+			statusCode: 403,
+			error: { code: 'accessDenied', message: 'SharePoint License required' },
+		});
+		expect(result?.message).toContain('missing a required license');
+	});
+
+	it('maps access-denied (403) to a permissions message', () => {
+		const result = mapMicrosoftApiError({
+			statusCode: 403,
+			error: { code: 'accessDenied', message: 'Access denied' },
+		});
+		expect(result?.message).toContain('missing the required permissions');
+	});
+
+	it('maps invalid auth token (401) to a permissions message', () => {
+		const result = mapMicrosoftApiError({ statusCode: 401, message: 'InvalidAuthenticationToken' });
+		expect(result?.message).toContain('missing the required permissions');
+	});
+
+	it('prioritises the license message over the generic permissions one', () => {
+		const result = mapMicrosoftApiError({
+			statusCode: 403,
+			error: { message: 'A SharePoint license is required' },
+		});
+		expect(result?.description).toContain('license');
+	});
+
+	it('returns undefined for unrelated errors', () => {
+		expect(
+			mapMicrosoftApiError({ statusCode: 500, message: 'Internal server error' }),
+		).toBeUndefined();
+		expect(
+			mapMicrosoftApiError({ statusCode: 404, error: { code: 'itemNotFound' } }),
+		).toBeUndefined();
+	});
+
+	it('does not mislabel a non-auth error that merely mentions "license"', () => {
+		expect(
+			mapMicrosoftApiError({
+				statusCode: 404,
+				error: { code: 'itemNotFound', message: 'The resource could not be found: License.xlsx' },
+			}),
+		).toBeUndefined();
+	});
+
+	it('maps an auth failure by Graph error code when no status code is present', () => {
+		const result = mapMicrosoftApiError({
+			error: { code: 'accessDenied', message: 'Access denied' },
+		});
+		expect(result?.message).toContain('missing the required permissions');
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/helpers/workbookSource.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/helpers/workbookSource.test.ts
@@ -1,0 +1,104 @@
+import { mock } from 'jest-mock-extended';
+import type { ILoadOptionsFunctions } from 'n8n-workflow';
+
+import { fetchWorkbookList, resolveWorkbookSource } from '../../../v2/helpers/workbookSource';
+import { microsoftApiRequest } from '../../../v2/transport';
+
+jest.mock('../../../v2/transport', () => ({
+	microsoftApiRequest: jest.fn(),
+}));
+
+describe('resolveWorkbookSource', () => {
+	it('uses the explicit source when one is set', () => {
+		expect(resolveWorkbookSource('sharePoint', 2.3)).toBe('sharePoint');
+		expect(resolveWorkbookSource('oneDrive', 2.3)).toBe('oneDrive');
+	});
+
+	it('defaults to OneDrive for existing nodes (< 2.3) when unset', () => {
+		expect(resolveWorkbookSource(undefined, 2)).toBe('oneDrive');
+		expect(resolveWorkbookSource('', 2.2)).toBe('oneDrive');
+	});
+
+	it('defaults to Everything for new nodes (>= 2.3) when unset', () => {
+		expect(resolveWorkbookSource(undefined, 2.3)).toBe('all');
+		expect(resolveWorkbookSource(undefined, 3)).toBe('all');
+	});
+});
+
+function searchResponse(
+	hits: Array<{ id: string; name: string; webUrl?: string; driveId?: string }>,
+) {
+	return {
+		value: [
+			{
+				hitsContainers: [
+					{
+						moreResultsAvailable: false,
+						hits: hits.map((h) => ({
+							resource: {
+								id: h.id,
+								name: h.name,
+								webUrl: h.webUrl,
+								parentReference: h.driveId ? { driveId: h.driveId } : {},
+							},
+						})),
+					},
+				],
+			},
+		],
+	};
+}
+
+describe('fetchWorkbookList', () => {
+	const ctx = mock<ILoadOptionsFunctions>();
+	const mockRequest = microsoftApiRequest as jest.MockedFunction<typeof microsoftApiRequest>;
+
+	beforeEach(() => mockRequest.mockReset());
+
+	it('oneDrive: searches the personal drive root and returns bare ids', async () => {
+		mockRequest.mockResolvedValue({ value: [{ id: '1', name: 'B.xlsx', webUrl: 'u' }] });
+
+		const { items } = await fetchWorkbookList.call(ctx, 'oneDrive');
+
+		expect(mockRequest).toHaveBeenCalledWith(
+			'GET',
+			"/drive/root/search(q='.xlsx OR .xlsm OR .xltx OR .xltm')",
+			undefined,
+			{ select: 'id,name,webUrl', $top: 100 },
+		);
+		expect(items[0]).toMatchObject({ id: '1', driveId: '', name: 'B.xlsx' });
+	});
+
+	it('sharePoint: keeps team-site hits and drops personal-OneDrive hits', async () => {
+		mockRequest.mockResolvedValue(
+			searchResponse([
+				{
+					id: 's1',
+					name: 'Team.xlsx',
+					webUrl: 'https://contoso.sharepoint.com/sites/x/Team.xlsx',
+					driveId: 'd1',
+				},
+				{
+					id: 'p1',
+					name: 'Mine.xlsx',
+					webUrl: 'https://contoso-my.sharepoint.com/personal/u/Mine.xlsx',
+					driveId: 'd2',
+				},
+			]),
+		);
+
+		const { items } = await fetchWorkbookList.call(ctx, 'sharePoint');
+
+		expect(items.map((item) => item.id)).toEqual(['s1']);
+	});
+
+	it('all: returns every Excel hit as a composite driveId/itemId', async () => {
+		mockRequest.mockResolvedValue(
+			searchResponse([{ id: '10', name: 'Any.xlsx', webUrl: 'u', driveId: 'd9' }]),
+		);
+
+		const { items } = await fetchWorkbookList.call(ctx, 'all');
+
+		expect(items).toEqual([expect.objectContaining({ id: '10', driveId: 'd9', name: 'Any.xlsx' })]);
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/methods/listSearch.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/methods/listSearch.test.ts
@@ -1,0 +1,166 @@
+import { mock } from 'jest-mock-extended';
+import type { ILoadOptionsFunctions, INode } from 'n8n-workflow';
+
+import { searchWorkbooks, getWorksheetsList } from '../../../v2/methods/listSearch';
+import { microsoftApiRequest } from '../../../v2/transport';
+
+jest.mock('../../../v2/transport', () => ({
+	microsoftApiRequest: jest.fn(),
+}));
+
+const TYPE_QUERY = '(filetype:xlsx OR filetype:xlsm OR filetype:xltx OR filetype:xltm)';
+
+function searchResponse(
+	hits: Array<{ id: string; name: string; webUrl?: string; driveId?: string }>,
+) {
+	return {
+		value: [
+			{
+				hitsContainers: [
+					{
+						moreResultsAvailable: false,
+						hits: hits.map((h) => ({
+							resource: {
+								id: h.id,
+								name: h.name,
+								webUrl: h.webUrl,
+								parentReference: h.driveId ? { driveId: h.driveId } : {},
+							},
+						})),
+					},
+				],
+			},
+		],
+	};
+}
+
+describe('Microsoft Excel V2 - listSearch', () => {
+	let mockContext: ILoadOptionsFunctions;
+	const mockMicrosoftApiRequest = microsoftApiRequest as jest.MockedFunction<
+		typeof microsoftApiRequest
+	>;
+	const mockGetNodeParameter = jest.fn();
+
+	beforeEach(() => {
+		mockContext = mock<ILoadOptionsFunctions>({ getNodeParameter: mockGetNodeParameter });
+		mockMicrosoftApiRequest.mockReset();
+		mockGetNodeParameter.mockReset();
+	});
+
+	describe('searchWorkbooks', () => {
+		// Source lives inside the operation's options collection; build a context whose
+		// collection params and node version mirror that.
+		function pickerContext(params: Record<string, unknown>, typeVersion = 2.3) {
+			const getNodeParameter = jest.fn();
+			getNodeParameter.mockImplementation((name: string, fallback?: unknown) =>
+				name in params ? params[name] : fallback,
+			);
+			return mock<ILoadOptionsFunctions>({
+				getNodeParameter,
+				getNode: jest.fn().mockReturnValue(mock<INode>({ typeVersion })),
+			});
+		}
+
+		it('lists personal OneDrive with bare-id values when Source is OneDrive', async () => {
+			mockMicrosoftApiRequest.mockResolvedValue({
+				value: [
+					{ id: '1', name: 'Book.xlsx', webUrl: 'https://example/book' },
+					{ id: '2', name: 'notes.txt' },
+				],
+			});
+
+			const result = await searchWorkbooks.call(
+				pickerContext({ options: { workbookSource: 'oneDrive' } }),
+			);
+
+			expect(mockMicrosoftApiRequest).toHaveBeenCalledWith(
+				'GET',
+				"/drive/root/search(q='.xlsx OR .xlsm OR .xltx OR .xltm')",
+				undefined,
+				{ select: 'id,name,webUrl', $top: 100 },
+			);
+			expect(result.results).toEqual([{ name: 'Book', value: '1', url: 'https://example/book' }]);
+		});
+
+		it('searches all drives with composite values when Source is Everything', async () => {
+			mockMicrosoftApiRequest.mockResolvedValue(
+				searchResponse([
+					{ id: '10', name: 'Team.xlsx', webUrl: 'https://example/team', driveId: 'drive1' },
+				]),
+			);
+
+			const result = await searchWorkbooks.call(
+				pickerContext({ filters: { workbookSource: 'all' } }),
+			);
+
+			expect(mockMicrosoftApiRequest).toHaveBeenCalledWith('POST', '/search/query', {
+				requests: [
+					{ entityTypes: ['driveItem'], query: { queryString: TYPE_QUERY }, from: 0, size: 100 },
+				],
+			});
+			expect(result.results).toEqual([
+				{ name: 'Team', value: 'drive1/10', url: 'https://example/team' },
+			]);
+		});
+
+		it('defaults to OneDrive when Source is unset on an existing node (< 2.3)', async () => {
+			mockMicrosoftApiRequest.mockResolvedValue({ value: [] });
+
+			await searchWorkbooks.call(pickerContext({}, 2));
+
+			expect(mockMicrosoftApiRequest).toHaveBeenCalledWith(
+				'GET',
+				"/drive/root/search(q='.xlsx OR .xlsm OR .xltx OR .xltm')",
+				undefined,
+				{ select: 'id,name,webUrl', $top: 100 },
+			);
+		});
+
+		it('defaults to Everything when Source is unset on a new node (>= 2.3)', async () => {
+			mockMicrosoftApiRequest.mockResolvedValue(searchResponse([]));
+
+			await searchWorkbooks.call(pickerContext({}, 2.3));
+
+			expect(mockMicrosoftApiRequest).toHaveBeenCalledWith(
+				'POST',
+				'/search/query',
+				expect.objectContaining({
+					requests: [
+						{ entityTypes: ['driveItem'], query: { queryString: TYPE_QUERY }, from: 0, size: 100 },
+					],
+				}),
+			);
+		});
+	});
+
+	describe('getWorksheetsList', () => {
+		it('addresses the workbook in its own drive (driveId/itemId value)', async () => {
+			mockGetNodeParameter.mockReturnValueOnce({ value: 'drive9/wb1', cachedResultUrl: '' });
+			mockMicrosoftApiRequest.mockResolvedValue({ value: [{ id: 's1', name: 'Sheet1' }] });
+
+			const result = await getWorksheetsList.call(mockContext);
+
+			expect(mockMicrosoftApiRequest).toHaveBeenCalledWith(
+				'GET',
+				'/drives/drive9/items/wb1/workbook/worksheets',
+				undefined,
+				{ select: 'id,name' },
+			);
+			expect(result.results).toEqual([{ name: 'Sheet1', value: 's1', url: undefined }]);
+		});
+
+		it('falls back to personal OneDrive for a bare workbook id', async () => {
+			mockGetNodeParameter.mockReturnValueOnce({ value: 'wb2', cachedResultUrl: '' });
+			mockMicrosoftApiRequest.mockResolvedValue({ value: [] });
+
+			await getWorksheetsList.call(mockContext);
+
+			expect(mockMicrosoftApiRequest).toHaveBeenCalledWith(
+				'GET',
+				'/drive/items/wb2/workbook/worksheets',
+				undefined,
+				{ select: 'id,name' },
+			);
+		});
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/getAll.everything.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/getAll.everything.test.ts
@@ -1,0 +1,38 @@
+import { NodeTestHarness } from '@nodes-testing/node-test-harness';
+import nock from 'nock';
+
+import { credentials } from '../../../credentials';
+
+describe('Test MicrosoftExcelV2, workbook => getAll (v2.3 default Source = Everything)', () => {
+	// A 2.3 node leaves Source unset, so it defaults to "Everything" and queries
+	// Microsoft Search (POST /search/query) instead of the personal-OneDrive endpoint.
+	nock('https://graph.microsoft.com/v1.0')
+		.post('/search/query')
+		.reply(200, {
+			value: [
+				{
+					hitsContainers: [
+						{
+							moreResultsAvailable: false,
+							hits: [
+								{
+									resource: {
+										'@odata.type': '#microsoft.graph.driveItem',
+										id: '01EVERYTHING',
+										name: 'Quarterly.xlsx',
+										webUrl: 'https://contoso.sharepoint.com/sites/finance/Quarterly.xlsx',
+										parentReference: { driveId: 'b!financeDrive' },
+									},
+								},
+							],
+						},
+					],
+				},
+			],
+		});
+
+	new NodeTestHarness().setupTests({
+		credentials,
+		workflowFiles: ['getAll.everything.workflow.json'],
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/getAll.everything.workflow.json
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/getAll.everything.workflow.json
@@ -1,0 +1,59 @@
+{
+	"name": "Get Workbooks v2.3 default",
+	"nodes": [
+		{
+			"parameters": {},
+			"id": "1b2c3d4e-0000-4000-8000-000000000001",
+			"name": "When clicking \"Execute Workflow\"",
+			"type": "n8n-nodes-base.manualTrigger",
+			"typeVersion": 1,
+			"position": [380, 140]
+		},
+		{
+			"parameters": {
+				"limit": 2
+			},
+			"id": "1b2c3d4e-0000-4000-8000-000000000002",
+			"name": "Microsoft Excel 365",
+			"type": "n8n-nodes-base.microsoftExcel",
+			"typeVersion": 2.3,
+			"position": [860, 140],
+			"credentials": {
+				"microsoftExcelOAuth2Api": {
+					"id": "70",
+					"name": "Microsoft Excel account"
+				}
+			}
+		}
+	],
+	"pinData": {
+		"Microsoft Excel 365": [
+			{
+				"json": {
+					"@odata.type": "#microsoft.graph.driveItem",
+					"id": "01EVERYTHING",
+					"name": "Quarterly.xlsx",
+					"webUrl": "https://contoso.sharepoint.com/sites/finance/Quarterly.xlsx",
+					"parentReference": {
+						"driveId": "b!financeDrive"
+					}
+				}
+			}
+		]
+	},
+	"connections": {
+		"When clicking \"Execute Workflow\"": {
+			"main": [
+				[
+					{
+						"node": "Microsoft Excel 365",
+						"type": "main",
+						"index": 0
+					}
+				]
+			]
+		}
+	},
+	"active": false,
+	"settings": {}
+}

--- a/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/getAll.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/test/v2/node/workbook/getAll.test.ts
@@ -4,6 +4,9 @@ import nock from 'nock';
 import { credentials } from '../../../credentials';
 
 describe('Test MicrosoftExcelV2, workbook => getAll', () => {
+	// This workflow pins typeVersion 2, whose default Source is "OneDrive (Personal)",
+	// so it keeps using the original personal-OneDrive endpoint. New nodes (>= 2.3)
+	// default to "Everything" and query Microsoft Search instead (see getAll.everything.test.ts).
 	nock('https://graph.microsoft.com/v1.0/me')
 		.get("/drive/root/search(q='.xlsx')?%24select=name&%24top=2")
 		.reply(200, {

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/common.descriptions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/common.descriptions.ts
@@ -1,4 +1,53 @@
-import type { INodeProperties } from 'n8n-workflow';
+import type { INodeProperties, INodePropertyOptions } from 'n8n-workflow';
+
+const WORKBOOK_SOURCE_OPTIONS: INodePropertyOptions[] = [
+	{
+		name: 'Everything',
+		value: 'all',
+		description:
+			'Search across your OneDrive plus the shared and SharePoint files you can access (returns the most relevant matches, so very large libraries may not list every file)',
+	},
+	{
+		name: 'OneDrive (Personal)',
+		value: 'oneDrive',
+		description: 'Only the files in your own OneDrive',
+	},
+	{
+		name: 'SharePoint Sites',
+		value: 'sharePoint',
+		description:
+			'Search the SharePoint document libraries you can access (returns the most relevant matches, so very large libraries may not list every file)',
+	},
+];
+
+const workbookSourceDescription =
+	'Where to look for workbooks. Leave on OneDrive for your own files, or pick a wider source to reach shared and SharePoint workbooks.';
+
+// A single option meant to live inside an operation's collapsible options
+// collection. It is intentionally not version-gated: when it is left unset the
+// effective default is decided in code by node version (see resolveWorkbookSource),
+// so existing nodes (< 2.3) keep listing the user's own OneDrive while new nodes
+// (>= 2.3) search everything.
+export const workbookSourceOption: INodeProperties = {
+	displayName: 'Source',
+	name: 'workbookSource',
+	type: 'options',
+	default: 'all',
+	description: workbookSourceDescription,
+	options: WORKBOOK_SOURCE_OPTIONS,
+};
+
+// Ready-made "Options" collection holding just the Source option, for operations
+// that have no existing options/filters collection to nest it in. Operations that
+// already have one nest `workbookSourceOption` directly instead.
+export const workbookSourceCollection: INodeProperties = {
+	displayName: 'Options',
+	name: 'options',
+	type: 'collection',
+	placeholder: 'Add option',
+	default: {},
+	options: [workbookSourceOption],
+};
 
 export const workbookRLC: INodeProperties = {
 	displayName: 'Workbook',
@@ -23,8 +72,13 @@ export const workbookRLC: INodeProperties = {
 			validation: [
 				{
 					type: 'regex',
+					// n8n anchors this pattern with ^...$ (see node-helpers.ts), so it must
+					// cover every character a workbook value can contain: a Graph drive-item
+					// ID, plus the "/" that separates the drive id in From-List/search values
+					// (e.g. "{driveId}/{itemId}"). The previous `[a-zA-Z0-9]{2,}` rejected
+					// valid IDs containing - or _ (the expression-mode workaround skipped it).
 					properties: {
-						regex: '[a-zA-Z0-9]{2,}',
+						regex: '[a-zA-Z0-9!._=/-]{2,}',
 						errorMessage: 'Not a valid Workbook ID',
 					},
 				},

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/table/addTable.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/table/addTable.operation.ts
@@ -7,8 +7,9 @@ import type {
 
 import { updateDisplayOptions } from '@utils/utilities';
 
+import { parseWorkbook } from '../../helpers/utils';
 import { microsoftApiRequest } from '../../transport';
-import { workbookRLC, worksheetRLC } from '../common.descriptions';
+import { workbookRLC, workbookSourceCollection, worksheetRLC } from '../common.descriptions';
 
 const properties: INodeProperties[] = [
 	workbookRLC,
@@ -52,6 +53,7 @@ const properties: INodeProperties[] = [
 		description:
 			'Whether the range has column labels. When this property set to false Excel will automatically generate header shifting the data down by one row.',
 	},
+	workbookSourceCollection,
 ];
 
 const displayOptions = {
@@ -72,9 +74,10 @@ export async function execute(
 
 	for (let i = 0; i < items.length; i++) {
 		try {
-			const workbookId = this.getNodeParameter('workbook', i, undefined, {
+			const workbookValue = this.getNodeParameter('workbook', i, undefined, {
 				extractValue: true,
 			}) as string;
+			const { root, workbookId } = parseWorkbook(workbookValue);
 
 			const worksheetId = this.getNodeParameter('worksheet', i, undefined, {
 				extractValue: true,
@@ -89,7 +92,7 @@ export async function execute(
 				const { address } = await microsoftApiRequest.call(
 					this,
 					'GET',
-					`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/usedRange`,
+					`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/usedRange`,
 					undefined,
 					{
 						select: 'address',
@@ -103,7 +106,7 @@ export async function execute(
 			const responseData = await microsoftApiRequest.call(
 				this,
 				'POST',
-				`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/add`,
+				`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/add`,
 				{
 					address: range,
 					hasHeaders,

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/table/append.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/table/append.operation.ts
@@ -8,9 +8,9 @@ import type {
 import { generatePairedItemData, processJsonInput, updateDisplayOptions } from '@utils/utilities';
 
 import type { ExcelResponse } from '../../helpers/interfaces';
-import { prepareOutput } from '../../helpers/utils';
+import { parseWorkbook, prepareOutput } from '../../helpers/utils';
 import { microsoftApiRequest } from '../../transport';
-import { tableRLC, workbookRLC, worksheetRLC } from '../common.descriptions';
+import { tableRLC, workbookRLC, workbookSourceOption, worksheetRLC } from '../common.descriptions';
 
 const properties: INodeProperties[] = [
 	workbookRLC,
@@ -103,6 +103,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'Add option',
 		default: {},
 		options: [
+			workbookSourceOption,
 			{
 				displayName: 'Index',
 				name: 'index',
@@ -159,9 +160,10 @@ export async function execute(
 	try {
 		// TODO: At some point it should be possible to use item dependent parameters.
 		//       Is however important to then not make one separate request each.
-		const workbookId = this.getNodeParameter('workbook', 0, undefined, {
+		const workbookValue = this.getNodeParameter('workbook', 0, undefined, {
 			extractValue: true,
 		}) as string;
+		const { root, workbookId } = parseWorkbook(workbookValue);
 
 		const worksheetId = this.getNodeParameter('worksheet', 0, undefined, {
 			extractValue: true,
@@ -177,7 +179,7 @@ export async function execute(
 		const columnsData = await microsoftApiRequest.call(
 			this,
 			'GET',
-			`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}/columns`,
+			`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}/columns`,
 			{},
 		);
 		const columnsRow = columnsData.value.map((column: IDataObject) => column.name);
@@ -240,13 +242,13 @@ export async function execute(
 		const { id } = await microsoftApiRequest.call(
 			this,
 			'POST',
-			`/drive/items/${workbookId}/workbook/createSession`,
+			`${root}/items/${workbookId}/workbook/createSession`,
 			{ persistChanges: true },
 		);
 		const responseData = await microsoftApiRequest.call(
 			this,
 			'POST',
-			`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}/rows/add`,
+			`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}/rows/add`,
 			body,
 			{},
 			'',
@@ -255,7 +257,7 @@ export async function execute(
 		await microsoftApiRequest.call(
 			this,
 			'POST',
-			`/drive/items/${workbookId}/workbook/closeSession`,
+			`${root}/items/${workbookId}/workbook/closeSession`,
 			{},
 			{},
 			'',

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/table/convertToRange.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/table/convertToRange.operation.ts
@@ -7,10 +7,21 @@ import type {
 
 import { updateDisplayOptions } from '@utils/utilities';
 
+import { parseWorkbook } from '../../helpers/utils';
 import { microsoftApiRequest } from '../../transport';
-import { tableRLC, workbookRLC, worksheetRLC } from '../common.descriptions';
+import {
+	tableRLC,
+	workbookRLC,
+	workbookSourceCollection,
+	worksheetRLC,
+} from '../common.descriptions';
 
-const properties: INodeProperties[] = [workbookRLC, worksheetRLC, tableRLC];
+const properties: INodeProperties[] = [
+	workbookRLC,
+	worksheetRLC,
+	tableRLC,
+	workbookSourceCollection,
+];
 
 const displayOptions = {
 	show: {
@@ -29,9 +40,10 @@ export async function execute(
 
 	for (let i = 0; i < items.length; i++) {
 		try {
-			const workbookId = this.getNodeParameter('workbook', i, undefined, {
+			const workbookValue = this.getNodeParameter('workbook', i, undefined, {
 				extractValue: true,
 			}) as string;
+			const { root, workbookId } = parseWorkbook(workbookValue);
 
 			const worksheetId = this.getNodeParameter('worksheet', i, undefined, {
 				extractValue: true,
@@ -44,7 +56,7 @@ export async function execute(
 			const responseData = await microsoftApiRequest.call(
 				this,
 				'POST',
-				`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}/convertToRange`,
+				`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}/convertToRange`,
 			);
 
 			const executionData = this.helpers.constructExecutionMetaData(

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/table/deleteTable.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/table/deleteTable.operation.ts
@@ -2,10 +2,21 @@ import type { IExecuteFunctions, INodeExecutionData, INodeProperties } from 'n8n
 
 import { updateDisplayOptions } from '@utils/utilities';
 
+import { parseWorkbook } from '../../helpers/utils';
 import { microsoftApiRequest } from '../../transport';
-import { tableRLC, workbookRLC, worksheetRLC } from '../common.descriptions';
+import {
+	tableRLC,
+	workbookRLC,
+	workbookSourceCollection,
+	worksheetRLC,
+} from '../common.descriptions';
 
-const properties: INodeProperties[] = [workbookRLC, worksheetRLC, tableRLC];
+const properties: INodeProperties[] = [
+	workbookRLC,
+	worksheetRLC,
+	tableRLC,
+	workbookSourceCollection,
+];
 
 const displayOptions = {
 	show: {
@@ -24,9 +35,10 @@ export async function execute(
 
 	for (let i = 0; i < items.length; i++) {
 		try {
-			const workbookId = this.getNodeParameter('workbook', i, undefined, {
+			const workbookValue = this.getNodeParameter('workbook', i, undefined, {
 				extractValue: true,
 			}) as string;
+			const { root, workbookId } = parseWorkbook(workbookValue);
 
 			const worksheetId = this.getNodeParameter('worksheet', i, undefined, {
 				extractValue: true,
@@ -39,7 +51,7 @@ export async function execute(
 			await microsoftApiRequest.call(
 				this,
 				'DELETE',
-				`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}`,
+				`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}`,
 			);
 
 			const executionData = this.helpers.constructExecutionMetaData(

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/table/getColumns.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/table/getColumns.operation.ts
@@ -7,8 +7,9 @@ import type {
 
 import { updateDisplayOptions } from '@utils/utilities';
 
+import { parseWorkbook } from '../../helpers/utils';
 import { microsoftApiRequest, microsoftApiRequestAllItemsSkip } from '../../transport';
-import { tableRLC, workbookRLC, worksheetRLC } from '../common.descriptions';
+import { tableRLC, workbookRLC, workbookSourceOption, worksheetRLC } from '../common.descriptions';
 
 const properties: INodeProperties[] = [
 	workbookRLC,
@@ -69,6 +70,7 @@ const properties: INodeProperties[] = [
 			},
 		},
 		options: [
+			workbookSourceOption,
 			{
 				displayName: 'Fields',
 				name: 'fields',
@@ -99,9 +101,10 @@ export async function execute(
 	for (let i = 0; i < items.length; i++) {
 		try {
 			const qs: IDataObject = {};
-			const workbookId = this.getNodeParameter('workbook', i, undefined, {
+			const workbookValue = this.getNodeParameter('workbook', i, undefined, {
 				extractValue: true,
 			}) as string;
+			const { root, workbookId } = parseWorkbook(workbookValue);
 
 			const worksheetId = this.getNodeParameter('worksheet', i, undefined, {
 				extractValue: true,
@@ -126,7 +129,7 @@ export async function execute(
 					this,
 					'value',
 					'GET',
-					`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}/columns`,
+					`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}/columns`,
 					{},
 					qs,
 				);
@@ -135,7 +138,7 @@ export async function execute(
 				responseData = await microsoftApiRequest.call(
 					this,
 					'GET',
-					`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}/columns`,
+					`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}/columns`,
 					{},
 					qs,
 				);

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/table/getRows.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/table/getRows.operation.ts
@@ -7,8 +7,9 @@ import type {
 
 import { updateDisplayOptions } from '@utils/utilities';
 
+import { parseWorkbook } from '../../helpers/utils';
 import { microsoftApiRequest, microsoftApiRequestAllItemsSkip } from '../../transport';
-import { tableRLC, workbookRLC, worksheetRLC } from '../common.descriptions';
+import { tableRLC, workbookRLC, workbookSourceOption, worksheetRLC } from '../common.descriptions';
 
 const properties: INodeProperties[] = [
 	workbookRLC,
@@ -64,6 +65,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'Add Filter',
 		default: {},
 		options: [
+			workbookSourceOption,
 			{
 				displayName: 'Fields',
 				name: 'fields',
@@ -116,9 +118,10 @@ export async function execute(
 	for (let i = 0; i < items.length; i++) {
 		const qs: IDataObject = {};
 		try {
-			const workbookId = this.getNodeParameter('workbook', i, undefined, {
+			const workbookValue = this.getNodeParameter('workbook', i, undefined, {
 				extractValue: true,
 			}) as string;
+			const { root, workbookId } = parseWorkbook(workbookValue);
 
 			const worksheetId = this.getNodeParameter('worksheet', i, undefined, {
 				extractValue: true,
@@ -144,7 +147,7 @@ export async function execute(
 					this,
 					'value',
 					'GET',
-					`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}/rows`,
+					`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}/rows`,
 					{},
 					qs,
 				);
@@ -154,7 +157,7 @@ export async function execute(
 				responseData = await microsoftApiRequest.call(
 					this,
 					'GET',
-					`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}/rows`,
+					`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}/rows`,
 					{},
 					rowsQs,
 				);
@@ -168,7 +171,7 @@ export async function execute(
 					this,
 					'value',
 					'GET',
-					`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}/columns`,
+					`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}/columns`,
 					{},
 					columnsQs,
 				);

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/table/lookup.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/table/lookup.operation.ts
@@ -9,8 +9,9 @@ import { NodeApiError } from 'n8n-workflow';
 
 import { updateDisplayOptions } from '@utils/utilities';
 
+import { parseWorkbook } from '../../helpers/utils';
 import { microsoftApiRequestAllItemsSkip } from '../../transport';
-import { tableRLC, workbookRLC, worksheetRLC } from '../common.descriptions';
+import { tableRLC, workbookRLC, workbookSourceOption, worksheetRLC } from '../common.descriptions';
 
 const properties: INodeProperties[] = [
 	workbookRLC,
@@ -41,6 +42,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'Add option',
 		default: {},
 		options: [
+			workbookSourceOption,
 			{
 				displayName: 'Return All Matches',
 				name: 'returnAllMatches',
@@ -72,9 +74,10 @@ export async function execute(
 	for (let i = 0; i < items.length; i++) {
 		const qs: IDataObject = {};
 		try {
-			const workbookId = this.getNodeParameter('workbook', i, undefined, {
+			const workbookValue = this.getNodeParameter('workbook', i, undefined, {
 				extractValue: true,
 			}) as string;
+			const { root, workbookId } = parseWorkbook(workbookValue);
 
 			const worksheetId = this.getNodeParameter('worksheet', i, undefined, {
 				extractValue: true,
@@ -92,7 +95,7 @@ export async function execute(
 				this,
 				'value',
 				'GET',
-				`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}/rows`,
+				`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}/rows`,
 				{},
 				{},
 			);
@@ -103,7 +106,7 @@ export async function execute(
 				this,
 				'value',
 				'GET',
-				`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}/columns`,
+				`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}/columns`,
 				{},
 				qs,
 			);

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/versionDescription.ts
@@ -10,7 +10,7 @@ export const versionDescription: INodeTypeDescription = {
 	name: 'microsoftExcel',
 	icon: 'file:excel.svg',
 	group: ['input'],
-	version: [2, 2.1, 2.2],
+	version: [2, 2.1, 2.2, 2.3],
 	subtitle: '={{$parameter["operation"] + ": " + $parameter["resource"]}}',
 	description: 'Consume Microsoft Excel API',
 	defaults: {

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/workbook/addWorksheet.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/workbook/addWorksheet.operation.ts
@@ -7,8 +7,9 @@ import type {
 
 import { updateDisplayOptions } from '@utils/utilities';
 
+import { parseWorkbook } from '../../helpers/utils';
 import { microsoftApiRequest } from '../../transport';
-import { workbookRLC } from '../common.descriptions';
+import { workbookRLC, workbookSourceOption } from '../common.descriptions';
 
 const properties: INodeProperties[] = [
 	workbookRLC,
@@ -19,6 +20,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'Add option',
 		default: {},
 		options: [
+			workbookSourceOption,
 			{
 				displayName: 'Name',
 				name: 'name',
@@ -49,9 +51,10 @@ export async function execute(
 
 	for (let i = 0; i < items.length; i++) {
 		try {
-			const workbookId = this.getNodeParameter('workbook', i, undefined, {
+			const workbookValue = this.getNodeParameter('workbook', i, undefined, {
 				extractValue: true,
 			}) as string;
+			const { root, workbookId } = parseWorkbook(workbookValue);
 
 			const additionalFields = this.getNodeParameter('additionalFields', i);
 			const body: IDataObject = {};
@@ -61,13 +64,13 @@ export async function execute(
 			const { id } = await microsoftApiRequest.call(
 				this,
 				'POST',
-				`/drive/items/${workbookId}/workbook/createSession`,
+				`${root}/items/${workbookId}/workbook/createSession`,
 				{ persistChanges: true },
 			);
 			const responseData = await microsoftApiRequest.call(
 				this,
 				'POST',
-				`/drive/items/${workbookId}/workbook/worksheets/add`,
+				`${root}/items/${workbookId}/workbook/worksheets/add`,
 				body,
 				{},
 				'',
@@ -76,7 +79,7 @@ export async function execute(
 			await microsoftApiRequest.call(
 				this,
 				'POST',
-				`/drive/items/${workbookId}/workbook/closeSession`,
+				`${root}/items/${workbookId}/workbook/closeSession`,
 				{},
 				{},
 				'',

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/workbook/deleteWorkbook.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/workbook/deleteWorkbook.operation.ts
@@ -3,10 +3,11 @@ import { NodeOperationError } from 'n8n-workflow';
 
 import { updateDisplayOptions } from '@utils/utilities';
 
+import { parseWorkbook } from '../../helpers/utils';
 import { microsoftApiRequest } from '../../transport';
-import { workbookRLC } from '../common.descriptions';
+import { workbookRLC, workbookSourceCollection } from '../common.descriptions';
 
-const properties: INodeProperties[] = [workbookRLC];
+const properties: INodeProperties[] = [workbookRLC, workbookSourceCollection];
 
 const displayOptions = {
 	show: {
@@ -24,12 +25,13 @@ export async function execute(
 
 	for (let i = 0; i < items.length; i++) {
 		try {
-			const workbookId = this.getNodeParameter('workbook', i, undefined, {
+			const workbookValue = this.getNodeParameter('workbook', i, undefined, {
 				extractValue: true,
 			}) as string;
+			const { root, workbookId } = parseWorkbook(workbookValue);
 
 			try {
-				await microsoftApiRequest.call(this, 'DELETE', `/drive/items/${workbookId}`);
+				await microsoftApiRequest.call(this, 'DELETE', `${root}/items/${workbookId}`);
 			} catch (error) {
 				if (error?.description.includes('Lock token does not match existing lock')) {
 					const errorDescription =

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/workbook/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/workbook/getAll.operation.ts
@@ -7,7 +7,12 @@ import type {
 
 import { updateDisplayOptions } from '@utils/utilities';
 
-import { microsoftApiRequest, microsoftApiRequestAllItems } from '../../transport';
+import {
+	collectWorkbooksFromSearch,
+	fetchPersonalOneDriveWorkbooks,
+	resolveWorkbookSource,
+} from '../../helpers/workbookSource';
+import { workbookSourceOption } from '../common.descriptions';
 
 const properties: INodeProperties[] = [
 	{
@@ -16,6 +21,18 @@ const properties: INodeProperties[] = [
 		type: 'boolean',
 		default: false,
 		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName:
+			'"Return All" can return a very large number of files, especially when Source is set to "Everything" on a large organization. Consider setting a limit instead.',
+		name: 'returnAllNotice',
+		type: 'notice',
+		default: '',
+		displayOptions: {
+			show: {
+				returnAll: [true],
+			},
+		},
 	},
 	{
 		displayName: 'Limit',
@@ -40,6 +57,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'Add Filter',
 		default: {},
 		options: [
+			workbookSourceOption,
 			{
 				displayName: 'Fields',
 				name: 'fields',
@@ -68,49 +86,22 @@ export async function execute(
 
 	for (let i = 0; i < items.length; i++) {
 		try {
-			const returnAll = this.getNodeParameter('returnAll', i);
-			const filters = this.getNodeParameter('filters', i);
-			const qs: IDataObject = {};
-			if (filters.fields) {
-				qs.$select = filters.fields;
-			}
-			let responseData;
-			if (returnAll) {
-				responseData = await microsoftApiRequestAllItems.call(
-					this,
-					'value',
-					'GET',
-					"/drive/root/search(q='.xlsx')",
-					{},
-					qs,
-				);
-			} else {
-				qs.$top = this.getNodeParameter('limit', i);
-				responseData = await microsoftApiRequest.call(
-					this,
-					'GET',
-					"/drive/root/search(q='.xlsx')",
-					{},
-					qs,
-				);
-				responseData = responseData.value;
-			}
+			const returnAll = this.getNodeParameter('returnAll', i) as boolean;
+			const filters = this.getNodeParameter('filters', i) as IDataObject;
+			const limit = returnAll ? Infinity : (this.getNodeParameter('limit', i) as number);
+			const source = resolveWorkbookSource(filters.workbookSource, this.getNode().typeVersion ?? 0);
+			const fields = filters.fields as string | undefined;
 
-			if (Array.isArray(responseData)) {
-				const executionData = this.helpers.constructExecutionMetaData(
-					this.helpers.returnJsonArray(responseData),
-					{ itemData: { item: i } },
-				);
+			const workbooks =
+				source === 'oneDrive'
+					? await fetchPersonalOneDriveWorkbooks.call(this, { returnAll, limit, fields })
+					: await collectWorkbooksFromSearch.call(this, source, { limit, fields });
 
-				returnData.push(...executionData);
-			} else if (responseData !== undefined) {
-				const executionData = this.helpers.constructExecutionMetaData(
-					this.helpers.returnJsonArray(responseData as IDataObject),
-					{ itemData: { item: i } },
-				);
-
-				returnData.push(...executionData);
-			}
+			const executionData = this.helpers.constructExecutionMetaData(
+				this.helpers.returnJsonArray(workbooks),
+				{ itemData: { item: i } },
+			);
+			returnData.push(...executionData);
 		} catch (error) {
 			if (this.continueOnFail()) {
 				const executionErrorData = this.helpers.constructExecutionMetaData(

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/append.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/append.operation.ts
@@ -9,9 +9,9 @@ import {
 import { processJsonInput, updateDisplayOptions } from '@utils/utilities';
 
 import type { ExcelResponse } from '../../helpers/interfaces';
-import { findAppendRange, prepareOutput } from '../../helpers/utils';
+import { findAppendRange, parseWorkbook, prepareOutput } from '../../helpers/utils';
 import { microsoftApiRequest } from '../../transport';
-import { workbookRLC, worksheetRLC } from '../common.descriptions';
+import { workbookRLC, workbookSourceOption, worksheetRLC } from '../common.descriptions';
 
 const properties: INodeProperties[] = [
 	workbookRLC,
@@ -102,6 +102,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'Add option',
 		default: {},
 		options: [
+			workbookSourceOption,
 			{
 				displayName: 'RAW Data',
 				name: 'rawData',
@@ -145,9 +146,10 @@ export async function execute(
 
 	const nodeVersion = this.getNode().typeVersion;
 
-	const workbookId = this.getNodeParameter('workbook', 0, undefined, {
+	const workbookValue = this.getNodeParameter('workbook', 0, undefined, {
 		extractValue: true,
 	}) as string;
+	const { root, workbookId } = parseWorkbook(workbookValue);
 
 	const worksheetId = this.getNodeParameter('worksheet', 0, undefined, {
 		extractValue: true,
@@ -158,7 +160,7 @@ export async function execute(
 	const worksheetData = await microsoftApiRequest.call(
 		this,
 		'GET',
-		`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/usedRange`,
+		`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/usedRange`,
 	);
 
 	let values: string[][] = [];
@@ -252,7 +254,7 @@ export async function execute(
 	const responseData: ExcelResponse = await microsoftApiRequest.call(
 		this,
 		'PATCH',
-		`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/range(address='${range}')`,
+		`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/range(address='${range}')`,
 		{ values },
 	);
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/clear.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/clear.operation.ts
@@ -2,8 +2,9 @@ import type { INodeExecutionData, IExecuteFunctions, INodeProperties } from 'n8n
 
 import { updateDisplayOptions } from '@utils/utilities';
 
+import { parseWorkbook } from '../../helpers/utils';
 import { microsoftApiRequest } from '../../transport';
-import { workbookRLC, worksheetRLC } from '../common.descriptions';
+import { workbookRLC, workbookSourceCollection, worksheetRLC } from '../common.descriptions';
 
 const properties: INodeProperties[] = [
 	workbookRLC,
@@ -52,6 +53,7 @@ const properties: INodeProperties[] = [
 		description: 'The sheet range that would be cleared, specified using a A1-style notation',
 		hint: 'Leave blank for entire worksheet',
 	},
+	workbookSourceCollection,
 ];
 
 const displayOptions = {
@@ -71,9 +73,10 @@ export async function execute(
 
 	for (let i = 0; i < items.length; i++) {
 		try {
-			const workbookId = this.getNodeParameter('workbook', i, undefined, {
+			const workbookValue = this.getNodeParameter('workbook', i, undefined, {
 				extractValue: true,
 			}) as string;
+			const { root, workbookId } = parseWorkbook(workbookValue);
 
 			const worksheetId = this.getNodeParameter('worksheet', i, undefined, {
 				extractValue: true,
@@ -86,7 +89,7 @@ export async function execute(
 				await microsoftApiRequest.call(
 					this,
 					'POST',
-					`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/range/clear`,
+					`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/range/clear`,
 					{ applyTo },
 				);
 			} else {
@@ -94,7 +97,7 @@ export async function execute(
 				await microsoftApiRequest.call(
 					this,
 					'POST',
-					`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/range(address='${range}')/clear`,
+					`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/range(address='${range}')/clear`,
 					{ applyTo },
 				);
 			}

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/deleteWorksheet.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/deleteWorksheet.operation.ts
@@ -2,10 +2,11 @@ import type { INodeExecutionData, IExecuteFunctions, INodeProperties } from 'n8n
 
 import { updateDisplayOptions } from '@utils/utilities';
 
+import { parseWorkbook } from '../../helpers/utils';
 import { microsoftApiRequest } from '../../transport';
-import { workbookRLC, worksheetRLC } from '../common.descriptions';
+import { workbookRLC, workbookSourceCollection, worksheetRLC } from '../common.descriptions';
 
-const properties: INodeProperties[] = [workbookRLC, worksheetRLC];
+const properties: INodeProperties[] = [workbookRLC, worksheetRLC, workbookSourceCollection];
 
 const displayOptions = {
 	show: {
@@ -24,9 +25,10 @@ export async function execute(
 
 	for (let i = 0; i < items.length; i++) {
 		try {
-			const workbookId = this.getNodeParameter('workbook', i, undefined, {
+			const workbookValue = this.getNodeParameter('workbook', i, undefined, {
 				extractValue: true,
 			}) as string;
+			const { root, workbookId } = parseWorkbook(workbookValue);
 
 			const worksheetId = this.getNodeParameter('worksheet', i, undefined, {
 				extractValue: true,
@@ -35,7 +37,7 @@ export async function execute(
 			await microsoftApiRequest.call(
 				this,
 				'DELETE',
-				`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}`,
+				`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}`,
 			);
 
 			const executionData = this.helpers.constructExecutionMetaData(

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/getAll.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/getAll.operation.ts
@@ -7,8 +7,9 @@ import type {
 
 import { updateDisplayOptions } from '@utils/utilities';
 
+import { parseWorkbook } from '../../helpers/utils';
 import { microsoftApiRequest, microsoftApiRequestAllItems } from '../../transport';
-import { workbookRLC } from '../common.descriptions';
+import { workbookRLC, workbookSourceOption } from '../common.descriptions';
 
 const properties: INodeProperties[] = [
 	workbookRLC,
@@ -42,6 +43,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'Add Filter',
 		default: {},
 		options: [
+			workbookSourceOption,
 			{
 				displayName: 'Fields',
 				name: 'fields',
@@ -73,9 +75,10 @@ export async function execute(
 		const qs: IDataObject = {};
 		try {
 			const returnAll = this.getNodeParameter('returnAll', i);
-			const workbookId = this.getNodeParameter('workbook', i, undefined, {
+			const workbookValue = this.getNodeParameter('workbook', i, undefined, {
 				extractValue: true,
 			}) as string;
+			const { root, workbookId } = parseWorkbook(workbookValue);
 			const filters = this.getNodeParameter('filters', i);
 			if (filters.fields) {
 				qs.$select = filters.fields;
@@ -87,7 +90,7 @@ export async function execute(
 					this,
 					'value',
 					'GET',
-					`/drive/items/${workbookId}/workbook/worksheets`,
+					`${root}/items/${workbookId}/workbook/worksheets`,
 					{},
 					qs,
 				);
@@ -96,7 +99,7 @@ export async function execute(
 				responseData = await microsoftApiRequest.call(
 					this,
 					'GET',
-					`/drive/items/${workbookId}/workbook/worksheets`,
+					`${root}/items/${workbookId}/workbook/worksheets`,
 					{},
 					qs,
 				);

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/readRows.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/readRows.operation.ts
@@ -8,9 +8,9 @@ import type {
 import { updateDisplayOptions } from '@utils/utilities';
 
 import type { ExcelResponse } from '../../helpers/interfaces';
-import { checkRange, prepareOutput } from '../../helpers/utils';
+import { checkRange, parseWorkbook, prepareOutput } from '../../helpers/utils';
 import { microsoftApiRequest } from '../../transport';
-import { workbookRLC, worksheetRLC } from '../common.descriptions';
+import { workbookRLC, workbookSourceOption, worksheetRLC } from '../common.descriptions';
 
 const properties: INodeProperties[] = [
 	workbookRLC,
@@ -75,6 +75,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'Add option',
 		default: {},
 		options: [
+			workbookSourceOption,
 			{
 				displayName: 'RAW Data',
 				name: 'rawData',
@@ -132,9 +133,10 @@ export async function execute(
 	for (let i = 0; i < items.length; i++) {
 		const qs: IDataObject = {};
 		try {
-			const workbookId = this.getNodeParameter('workbook', i, undefined, {
+			const workbookValue = this.getNodeParameter('workbook', i, undefined, {
 				extractValue: true,
 			}) as string;
+			const { root, workbookId } = parseWorkbook(workbookValue);
 
 			const worksheetId = this.getNodeParameter('worksheet', i, undefined, {
 				extractValue: true,
@@ -156,7 +158,7 @@ export async function execute(
 				responseData = await microsoftApiRequest.call(
 					this,
 					'GET',
-					`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/range(address='${range}')`,
+					`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/range(address='${range}')`,
 					{},
 					qs,
 				);
@@ -164,7 +166,7 @@ export async function execute(
 				responseData = await microsoftApiRequest.call(
 					this,
 					'GET',
-					`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/usedRange`,
+					`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/usedRange`,
 					{},
 					qs,
 				);

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/update.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/update.operation.ts
@@ -11,12 +11,13 @@ import { generatePairedItemData, processJsonInput, updateDisplayOptions } from '
 import type { ExcelResponse, UpdateSummary } from '../../helpers/interfaces';
 import {
 	checkRange,
+	parseWorkbook,
 	prepareOutput,
 	updateByAutoMaping,
 	updateByDefinedValues,
 } from '../../helpers/utils';
 import { microsoftApiRequest } from '../../transport';
-import { workbookRLC, worksheetRLC } from '../common.descriptions';
+import { workbookRLC, workbookSourceOption, worksheetRLC } from '../common.descriptions';
 
 const properties: INodeProperties[] = [
 	workbookRLC,
@@ -176,6 +177,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'Add option',
 		default: {},
 		options: [
+			workbookSourceOption,
 			{
 				displayName: 'RAW Data',
 				name: 'rawData',
@@ -252,9 +254,10 @@ export async function execute(
 			qs.$select = options.fields;
 		}
 
-		const workbookId = this.getNodeParameter('workbook', 0, undefined, {
+		const workbookValue = this.getNodeParameter('workbook', 0, undefined, {
 			extractValue: true,
 		}) as string;
+		const { root, workbookId } = parseWorkbook(workbookValue);
 
 		const worksheetId = this.getNodeParameter('worksheet', 0, undefined, {
 			extractValue: true,
@@ -271,7 +274,7 @@ export async function execute(
 			worksheetData = await microsoftApiRequest.call(
 				this,
 				'PATCH',
-				`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/range(address='${range}')`,
+				`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/range(address='${range}')`,
 			);
 		}
 
@@ -285,7 +288,7 @@ export async function execute(
 			worksheetData = await microsoftApiRequest.call(
 				this,
 				'GET',
-				`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/usedRange`,
+				`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/usedRange`,
 				undefined,
 				query,
 			);
@@ -302,7 +305,7 @@ export async function execute(
 			responseData = await microsoftApiRequest.call(
 				this,
 				'PATCH',
-				`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/range(address='${range}')`,
+				`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/range(address='${range}')`,
 				{ values },
 				qs,
 			);
@@ -359,7 +362,7 @@ export async function execute(
 			responseData = await microsoftApiRequest.call(
 				this,
 				'PATCH',
-				`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/range(address='${range}')`,
+				`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/range(address='${range}')`,
 				{ values: updateSummary.updatedData },
 			);
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/upsert.operation.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/actions/worksheet/upsert.operation.ts
@@ -12,12 +12,13 @@ import type { ExcelResponse, UpdateSummary } from '../../helpers/interfaces';
 import {
 	checkRange,
 	parseAddress,
+	parseWorkbook,
 	prepareOutput,
 	updateByAutoMaping,
 	updateByDefinedValues,
 } from '../../helpers/utils';
 import { microsoftApiRequest } from '../../transport';
-import { workbookRLC, worksheetRLC } from '../common.descriptions';
+import { workbookRLC, workbookSourceOption, worksheetRLC } from '../common.descriptions';
 
 const properties: INodeProperties[] = [
 	workbookRLC,
@@ -141,6 +142,7 @@ const properties: INodeProperties[] = [
 		placeholder: 'Add option',
 		default: {},
 		options: [
+			workbookSourceOption,
 			{
 				displayName: 'Append After Selected Range',
 				name: 'appendAfterSelectedRange',
@@ -204,9 +206,10 @@ export async function execute(
 	const nodeVersion = this.getNode().typeVersion;
 
 	try {
-		const workbookId = this.getNodeParameter('workbook', 0, undefined, {
+		const workbookValue = this.getNodeParameter('workbook', 0, undefined, {
 			extractValue: true,
 		}) as string;
+		const { root, workbookId } = parseWorkbook(workbookValue);
 
 		const worksheetId = this.getNodeParameter('worksheet', 0, undefined, {
 			extractValue: true,
@@ -223,7 +226,7 @@ export async function execute(
 			worksheetData = await microsoftApiRequest.call(
 				this,
 				'PATCH',
-				`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/range(address='${range}')`,
+				`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/range(address='${range}')`,
 			);
 		}
 
@@ -237,7 +240,7 @@ export async function execute(
 			worksheetData = await microsoftApiRequest.call(
 				this,
 				'GET',
-				`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/usedRange`,
+				`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/usedRange`,
 				undefined,
 				query,
 			);
@@ -254,7 +257,7 @@ export async function execute(
 			responseData = await microsoftApiRequest.call(
 				this,
 				'PATCH',
-				`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/range(address='${range}')`,
+				`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/range(address='${range}')`,
 				{ values },
 			);
 		}
@@ -348,7 +351,7 @@ export async function execute(
 				const { address } = await microsoftApiRequest.call(
 					this,
 					'GET',
-					`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/usedRange`,
+					`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/usedRange`,
 					undefined,
 					{ select: 'address' },
 				);
@@ -364,7 +367,7 @@ export async function execute(
 		responseData = await microsoftApiRequest.call(
 			this,
 			'PATCH',
-			`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/range(address='${range}')`,
+			`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/range(address='${range}')`,
 			{ values: updateSummary.updatedData },
 		);
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/helpers/errorHandling.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/helpers/errorHandling.ts
@@ -1,0 +1,75 @@
+type MappedError = {
+	message: string;
+	description: string;
+};
+
+type GraphErrorShape = { code?: unknown; message?: unknown };
+
+// Graph error codes that indicate an auth/permission failure, used as a fallback
+// when the HTTP status code isn't present on the thrown error.
+const AUTH_ERROR_CODES = [
+	'accessdenied',
+	'unauthenticated',
+	'invalidauthenticationtoken',
+	'authorization_requestdenied',
+];
+
+/**
+ * Pull the structured Microsoft Graph error `{ code, message }` out of the thrown
+ * error. Graph returns `{ error: { code, message } }` and n8n attaches the parsed
+ * body on the error's `error` property, so the Graph object can sit at
+ * `error.error.error`, `error.error`, or the top level. Only these structured fields
+ * are read, never a free-text dump of the whole error, so an arbitrary value such as
+ * a workbook filename can never leak into the matching.
+ */
+function readGraphError(error: unknown): { code: string; message: string } {
+	const toLower = (value: unknown) => (typeof value === 'string' ? value.toLowerCase() : '');
+	const err = error as { error?: { error?: GraphErrorShape } & GraphErrorShape } & GraphErrorShape;
+
+	const candidates: Array<GraphErrorShape | undefined> = [err?.error?.error, err?.error, err];
+	for (const candidate of candidates) {
+		if (
+			candidate &&
+			(typeof candidate.code === 'string' || typeof candidate.message === 'string')
+		) {
+			return { code: toLower(candidate.code), message: toLower(candidate.message) };
+		}
+	}
+	return { code: '', message: '' };
+}
+
+/**
+ * Translate the most common Microsoft Graph auth failures into clear, actionable
+ * messages. Without this, a missing-permission or licensing problem surfaces as a
+ * generic API error (or, for listings, a silently empty result), which gives the
+ * user nothing to act on.
+ *
+ * Only genuine auth failures are mapped: an HTTP 401/403, or a Graph auth error code.
+ * Everything else (404, 400, throttling, network errors) returns `undefined` so the
+ * caller falls back to the default `NodeApiError`. Matching keys off the status and
+ * the structured error fields rather than the error text, so an unrelated failure
+ * that merely mentions "license" (e.g. a 404 for a workbook named "License.xlsx") is
+ * never mislabelled.
+ */
+export function mapMicrosoftApiError(error: unknown): MappedError | undefined {
+	const err = error as { statusCode?: number; httpCode?: number | string };
+	const status = Number(err?.statusCode ?? err?.httpCode);
+	const { code, message } = readGraphError(error);
+
+	const isAuthFailure = status === 401 || status === 403 || AUTH_ERROR_CODES.includes(code);
+	if (!isAuthFailure) return undefined;
+
+	if (message.includes('license')) {
+		return {
+			message: 'This Microsoft 365 account is missing a required license',
+			description:
+				'Listing or opening these workbooks needs a license that includes SharePoint/OneDrive for this account. Ask your Microsoft 365 administrator to assign one, then try again.',
+		};
+	}
+
+	return {
+		message: 'The connected Microsoft account is missing the required permissions',
+		description:
+			'Reconnect this credential to grant access to shared and SharePoint files. The Excel node now needs the Files.ReadWrite.All permission, which a Microsoft 365 administrator may have to consent to.',
+	};
+}

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/helpers/utils.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/helpers/utils.ts
@@ -7,6 +7,26 @@ import type { ExcelResponse, SheetData, UpdateSummary } from './interfaces';
 
 export const CELL_REGEX = /([a-zA-Z]{1,10})([0-9]{0,10})/;
 
+/**
+ * Resolve a workbook resource-locator value into its Graph drive base and item id.
+ *
+ * Search results encode the value as `"{driveId}/{itemId}"` so a workbook can be
+ * opened in whatever drive it lives in (personal OneDrive, a shared drive, or a
+ * SharePoint document library). A bare id (an old saved workflow, or a By-ID value
+ * typed without a drive) falls back to the signed-in user's OneDrive (`/drive`,
+ * which the transport scopes to `/me`), so existing workflows keep working.
+ */
+export function parseWorkbook(workbookValue: string): { root: string; workbookId: string } {
+	const separatorIndex = workbookValue.indexOf('/');
+	if (separatorIndex === -1) {
+		return { root: '/drive', workbookId: workbookValue };
+	}
+	return {
+		root: `/drives/${workbookValue.slice(0, separatorIndex)}`,
+		workbookId: workbookValue.slice(separatorIndex + 1),
+	};
+}
+
 type PrepareOutputConfig = {
 	rawData: boolean;
 	dataProperty?: string;

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/helpers/workbookSource.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/helpers/workbookSource.ts
@@ -1,0 +1,225 @@
+import type { IDataObject, IExecuteFunctions, ILoadOptionsFunctions } from 'n8n-workflow';
+import { isSafeObjectProperty } from 'n8n-workflow';
+
+import { microsoftApiRequest, microsoftApiRequestAllItems } from '../transport';
+
+export const WORKBOOK_FILE_EXTENSIONS = ['.xlsx', '.xlsm', '.xltx', '.xltm'];
+const FILE_TYPE_QUERY = '(filetype:xlsx OR filetype:xlsm OR filetype:xltx OR filetype:xltm)';
+
+/** A workbook found in some drive. `driveId` is empty for the user's own OneDrive. */
+export type WorkbookListItem = {
+	id: string;
+	driveId: string;
+	name: string;
+	webUrl?: string;
+	/** The raw Graph object, returned as-is by the Get Workbooks operation. */
+	resource: IDataObject;
+};
+
+function isExcelName(name: unknown): name is string {
+	return (
+		typeof name === 'string' &&
+		WORKBOOK_FILE_EXTENSIONS.some((extension) => name.toLowerCase().endsWith(extension))
+	);
+}
+
+export function stripWorkbookExtension(name: string): string {
+	for (const extension of WORKBOOK_FILE_EXTENSIONS) {
+		if (name.toLowerCase().endsWith(extension)) {
+			return name.slice(0, -extension.length);
+		}
+	}
+	return name;
+}
+
+/** The node version from which new workbook nodes default to searching everywhere. */
+const EVERYTHING_DEFAULT_VERSION = 2.3;
+
+/**
+ * Decide which Source to use. The Source lives in the collapsible options, so most
+ * nodes leave it unset; the effective default is then chosen by node version.
+ * Existing nodes (< 2.3) keep listing the user's own OneDrive, exactly as before,
+ * while new nodes default to searching everywhere.
+ */
+export function resolveWorkbookSource(explicit: unknown, typeVersion: number): string {
+	if (typeof explicit === 'string' && explicit !== '') return explicit;
+	return typeVersion >= EVERYTHING_DEFAULT_VERSION ? 'all' : 'oneDrive';
+}
+
+/**
+ * Read the Source the workbook picker should list. It sits inside whichever options
+ * collection the current operation has, so check each known collection name.
+ */
+export function getWorkbookSourceForPicker(ctx: ILoadOptionsFunctions): string {
+	for (const collection of ['options', 'filters', 'additionalFields']) {
+		let value: IDataObject = {};
+		try {
+			value = (ctx.getNodeParameter(collection, {}) ?? {}) as IDataObject;
+		} catch {
+			continue;
+		}
+		if (typeof value === 'object' && typeof value.workbookSource === 'string') {
+			return value.workbookSource;
+		}
+	}
+	return resolveWorkbookSource(undefined, ctx.getNode().typeVersion ?? 0);
+}
+
+/**
+ * List workbooks for the chosen Source. `oneDrive` reproduces the original
+ * personal-OneDrive search (plain item id, resolved to /me/drive downstream); the
+ * other sources are found via Microsoft Search and return items keyed by their own
+ * drive so the value can carry "{driveId}/{itemId}".
+ */
+export async function fetchWorkbookList(
+	this: IExecuteFunctions | ILoadOptionsFunctions,
+	source: string,
+	opts: { filter?: string; paginationToken?: string; size?: number } = {},
+): Promise<{ items: WorkbookListItem[]; paginationToken?: string }> {
+	const { filter, paginationToken, size = 100 } = opts;
+
+	if (source === 'sharePoint' || source === 'all') {
+		const from = paginationToken ? Number(paginationToken) : 0;
+		const queryString = filter ? `${filter} ${FILE_TYPE_QUERY}` : FILE_TYPE_QUERY;
+
+		const response: IDataObject = await microsoftApiRequest.call(this, 'POST', '/search/query', {
+			requests: [{ entityTypes: ['driveItem'], query: { queryString }, from, size }],
+		});
+
+		const hitsContainer = (
+			(((response.value as IDataObject[]) ?? [])[0] as IDataObject)?.hitsContainers as IDataObject[]
+		)?.[0] as IDataObject | undefined;
+		const rawHits = (hitsContainer?.hits as IDataObject[]) ?? [];
+
+		const items = rawHits
+			.map((hit) => hit.resource as IDataObject)
+			.filter((resource) => isExcelName(resource?.name))
+			.filter((resource) => {
+				if (source !== 'sharePoint') return true;
+				// SharePoint sites only: drop personal-OneDrive hits, whose web URL is
+				// served from the "-my.sharepoint.com" host.
+				const webUrl = ((resource.webUrl as string) ?? '').toLowerCase();
+				return webUrl.includes('.sharepoint.com') && !webUrl.includes('-my.sharepoint.com');
+			})
+			.map((resource) => ({
+				id: resource.id as string,
+				driveId: ((resource.parentReference as IDataObject)?.driveId ?? '') as string,
+				name: resource.name as string,
+				webUrl: resource.webUrl as string | undefined,
+				resource,
+			}));
+
+		const moreAvailable = hitsContainer?.moreResultsAvailable === true;
+		return { items, paginationToken: moreAvailable ? String(from + rawHits.length) : undefined };
+	}
+
+	// oneDrive (default): the original personal-OneDrive search.
+	const q = filter || WORKBOOK_FILE_EXTENSIONS.join(' OR ');
+	const response: IDataObject = paginationToken
+		? await microsoftApiRequest.call(this, 'GET', '', undefined, undefined, paginationToken)
+		: await microsoftApiRequest.call(this, 'GET', `/drive/root/search(q='${q}')`, undefined, {
+				select: 'id,name,webUrl',
+				$top: size,
+			});
+
+	const items = ((response.value as IDataObject[]) ?? [])
+		.filter((resource) => isExcelName(resource.name))
+		.map((resource) => ({
+			id: resource.id as string,
+			driveId: '',
+			name: resource.name as string,
+			webUrl: resource.webUrl as string | undefined,
+			resource,
+		}));
+
+	return { items, paginationToken: response['@odata.nextLink'] as string | undefined };
+}
+
+// The personal-OneDrive listing keeps the node's original behavior byte for byte
+// (`.xlsx` only, $select-based field projection). It deliberately does NOT reuse
+// fetchWorkbookList's oneDrive branch above, which searches all workbook extensions
+// and projects fields differently, so existing workflows keep seeing the same output.
+const PERSONAL_ONEDRIVE_SEARCH = "/drive/root/search(q='.xlsx')";
+
+/** Keep only the requested top-level fields (safe against prototype-polluting keys). */
+function projectFields(resource: IDataObject, fields: string[]): IDataObject {
+	const projected: IDataObject = {};
+	for (const field of fields) {
+		if (isSafeObjectProperty(field) && field in resource) {
+			projected[field] = resource[field];
+		}
+	}
+	return projected;
+}
+
+/** Parse the comma-separated "Fields" filter into a trimmed list (undefined when unset). */
+function parseFieldList(fields: unknown): string[] | undefined {
+	if (typeof fields !== 'string' || fields === '') return undefined;
+	return fields
+		.split(',')
+		.map((field) => field.trim())
+		.filter((field) => field !== '');
+}
+
+/**
+ * List workbooks from the user's personal OneDrive for the Get Workbooks operation
+ * (the node's original behavior).
+ */
+export async function fetchPersonalOneDriveWorkbooks(
+	this: IExecuteFunctions,
+	options: { returnAll: boolean; limit: number; fields?: string },
+): Promise<IDataObject[]> {
+	const qs: IDataObject = {};
+	if (options.fields) {
+		qs.$select = options.fields;
+	}
+
+	if (options.returnAll) {
+		return (await microsoftApiRequestAllItems.call(
+			this,
+			'value',
+			'GET',
+			PERSONAL_ONEDRIVE_SEARCH,
+			{},
+			qs,
+		)) as IDataObject[];
+	}
+
+	qs.$top = options.limit;
+	const responseData = await microsoftApiRequest.call(
+		this,
+		'GET',
+		PERSONAL_ONEDRIVE_SEARCH,
+		{},
+		qs,
+	);
+	return (responseData.value as IDataObject[]) ?? [];
+}
+
+/**
+ * List workbooks for a wider source (SharePoint / Everything) for the Get Workbooks
+ * operation, paging through Microsoft Search until the limit is reached.
+ */
+export async function collectWorkbooksFromSearch(
+	this: IExecuteFunctions,
+	source: string,
+	options: { limit: number; fields?: string },
+): Promise<IDataObject[]> {
+	const fields = parseFieldList(options.fields);
+	const workbooks: IDataObject[] = [];
+
+	let paginationToken: string | undefined;
+	do {
+		const { items, paginationToken: next } = await fetchWorkbookList.call(this, source, {
+			paginationToken,
+			size: 100,
+		});
+		for (const item of items) {
+			workbooks.push(fields ? projectFields(item.resource, fields) : item.resource);
+			if (workbooks.length >= options.limit) break;
+		}
+		paginationToken = next;
+	} while (paginationToken && workbooks.length < options.limit);
+
+	return workbooks;
+}

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/methods/listSearch.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/methods/listSearch.ts
@@ -5,6 +5,12 @@ import type {
 	INodeListSearchResult,
 } from 'n8n-workflow';
 
+import { parseWorkbook } from '../helpers/utils';
+import {
+	fetchWorkbookList,
+	getWorkbookSourceForPicker,
+	stripWorkbookExtension,
+} from '../helpers/workbookSource';
 import { microsoftApiRequest } from '../transport';
 
 export async function searchWorkbooks(
@@ -12,56 +18,24 @@ export async function searchWorkbooks(
 	filter?: string,
 	paginationToken?: string,
 ): Promise<INodeListSearchResult> {
-	const fileExtensions = ['.xlsx', '.xlsm', '.xlst'];
-	const extensionFilter = fileExtensions.join(' OR ');
+	// Source lives in the operation's collapsible options. When left unset it falls
+	// back to the node-version default (OneDrive for existing nodes, everywhere for new).
+	const source = getWorkbookSourceForPicker(this);
 
-	const q = filter || extensionFilter;
-
-	let response: IDataObject = {};
-
-	if (paginationToken) {
-		response = await microsoftApiRequest.call(
-			this,
-			'GET',
-			'',
-			undefined,
-			undefined,
-			paginationToken, // paginationToken contains the full URL
-		);
-	} else {
-		response = await microsoftApiRequest.call(
-			this,
-			'GET',
-			`/drive/root/search(q='${q}')`,
-			undefined,
-			{
-				select: 'id,name,webUrl',
-				$top: 100,
-			},
-		);
-	}
-
-	if (response.value && filter) {
-		response.value = (response.value as IDataObject[]).filter((workbook: IDataObject) => {
-			return fileExtensions.some((extension) => (workbook.name as string).includes(extension));
-		});
-	}
+	const { items, paginationToken: nextToken } = await fetchWorkbookList.call(this, source, {
+		filter,
+		paginationToken,
+	});
 
 	return {
-		results: (response.value as IDataObject[]).map((workbook: IDataObject) => {
-			for (const extension of fileExtensions) {
-				if ((workbook.name as string).includes(extension)) {
-					workbook.name = (workbook.name as string).replace(extension, '');
-					break;
-				}
-			}
-			return {
-				name: workbook.name as string,
-				value: workbook.id as string,
-				url: workbook.webUrl as string,
-			};
-		}),
-		paginationToken: response['@odata.nextLink'],
+		results: items.map((item) => ({
+			name: stripWorkbookExtension(item.name),
+			// Non-personal workbooks live in another drive, so the value carries it as
+			// "{driveId}/{itemId}". Personal OneDrive keeps a bare id (-> /me/drive).
+			value: item.driveId ? `${item.driveId}/${item.id}` : item.id,
+			url: item.webUrl,
+		})),
+		paginationToken: nextToken,
 	};
 }
 
@@ -69,19 +43,17 @@ export async function getWorksheetsList(
 	this: ILoadOptionsFunctions,
 ): Promise<INodeListSearchResult> {
 	const workbookRLC = this.getNodeParameter('workbook') as IDataObject;
-	const workbookId = workbookRLC.value as string;
+	const { root, workbookId } = parseWorkbook(workbookRLC.value as string);
 	let workbookURL = (workbookRLC.cachedResultUrl as string) ?? '';
 
 	if (workbookURL.includes('1drv.ms')) {
 		workbookURL = `https://onedrive.live.com/edit.aspx?resid=${workbookId}`;
 	}
 
-	let response: IDataObject = {};
-
-	response = await microsoftApiRequest.call(
+	const response = await microsoftApiRequest.call(
 		this,
 		'GET',
-		`/drive/items/${workbookId}/workbook/worksheets`,
+		`${root}/items/${workbookId}/workbook/worksheets`,
 		undefined,
 		{
 			select: 'id,name',
@@ -103,7 +75,7 @@ export async function getWorksheetTables(
 	this: ILoadOptionsFunctions,
 ): Promise<INodeListSearchResult> {
 	const workbookRLC = this.getNodeParameter('workbook') as IDataObject;
-	const workbookId = workbookRLC.value as string;
+	const { root, workbookId } = parseWorkbook(workbookRLC.value as string);
 	let workbookURL = (workbookRLC.cachedResultUrl as string) ?? '';
 
 	if (workbookURL.includes('1drv.ms')) {
@@ -114,12 +86,10 @@ export async function getWorksheetTables(
 		extractValue: true,
 	}) as string;
 
-	let response: IDataObject = {};
-
-	response = await microsoftApiRequest.call(
+	const response = await microsoftApiRequest.call(
 		this,
 		'GET',
-		`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/tables`,
+		`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/tables`,
 		undefined,
 	);
 
@@ -132,7 +102,7 @@ export async function getWorksheetTables(
 		const { address } = await microsoftApiRequest.call(
 			this,
 			'GET',
-			`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${value}/range`,
+			`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${value}/range`,
 			undefined,
 			{
 				select: 'address',

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/methods/loadOptions.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/methods/loadOptions.ts
@@ -1,14 +1,14 @@
 import type { IDataObject, ILoadOptionsFunctions, INodePropertyOptions } from 'n8n-workflow';
 
+import { parseAddress, parseWorkbook } from '../helpers/utils';
 import { microsoftApiRequest } from '../transport';
-import { parseAddress } from '../helpers/utils';
 
 export async function getWorksheetColumnRow(
 	this: ILoadOptionsFunctions,
 ): Promise<INodePropertyOptions[]> {
-	const workbookId = this.getNodeParameter('workbook', undefined, {
-		extractValue: true,
-	}) as string;
+	const { root, workbookId } = parseWorkbook(
+		this.getNodeParameter('workbook', undefined, { extractValue: true }) as string,
+	);
 
 	const worksheetId = this.getNodeParameter('worksheet', undefined, {
 		extractValue: true,
@@ -21,7 +21,7 @@ export async function getWorksheetColumnRow(
 		const worksheetData = await microsoftApiRequest.call(
 			this,
 			'GET',
-			`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/usedRange`,
+			`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/usedRange`,
 			undefined,
 			{ select: 'values' },
 		);
@@ -34,7 +34,7 @@ export async function getWorksheetColumnRow(
 		const worksheetData = await microsoftApiRequest.call(
 			this,
 			'PATCH',
-			`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/range(address='${range}')`,
+			`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/range(address='${range}')`,
 			{ select: 'values' },
 		);
 
@@ -62,9 +62,9 @@ export async function getWorksheetColumnRowSkipColumnToMatchOn(
 export async function getTableColumns(
 	this: ILoadOptionsFunctions,
 ): Promise<INodePropertyOptions[]> {
-	const workbookId = this.getNodeParameter('workbook', undefined, {
-		extractValue: true,
-	}) as string;
+	const { root, workbookId } = parseWorkbook(
+		this.getNodeParameter('workbook', undefined, { extractValue: true }) as string,
+	);
 
 	const worksheetId = this.getNodeParameter('worksheet', undefined, {
 		extractValue: true,
@@ -77,7 +77,7 @@ export async function getTableColumns(
 	const response = await microsoftApiRequest.call(
 		this,
 		'GET',
-		`/drive/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}/columns`,
+		`${root}/items/${workbookId}/workbook/worksheets/${worksheetId}/tables/${tableId}/columns`,
 		{},
 	);
 

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/test/transport/index.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/test/transport/index.test.ts
@@ -206,5 +206,66 @@ describe('Microsoft Excel Transport', () => {
 				);
 			});
 		});
+
+		describe('resource path scoping', () => {
+			beforeEach(() => {
+				mockRequestOAuth2.mockResolvedValue({ data: 'test' });
+				mockExecuteFunctions.getCredentials.mockResolvedValue({
+					oauthTokenData: { access_token: 'test-access-token' },
+				});
+			});
+
+			it('should scope personal-drive resources under /me', async () => {
+				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/drive/root/search');
+
+				expect(mockRequestOAuth2).toHaveBeenCalledWith(
+					'microsoftExcelOAuth2Api',
+					expect.objectContaining({
+						uri: 'https://graph.microsoft.com/v1.0/me/drive/root/search',
+					}),
+				);
+			});
+
+			it('should not nest /drives/{id} resources under /me', async () => {
+				await microsoftApiRequest.call(
+					mockExecuteFunctions,
+					'GET',
+					'/drives/drive-id/items/item-id/workbook/worksheets',
+				);
+
+				expect(mockRequestOAuth2).toHaveBeenCalledWith(
+					'microsoftExcelOAuth2Api',
+					expect.objectContaining({
+						uri: 'https://graph.microsoft.com/v1.0/drives/drive-id/items/item-id/workbook/worksheets',
+					}),
+				);
+			});
+
+			it('should not nest /sites resources under /me', async () => {
+				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/sites');
+
+				expect(mockRequestOAuth2).toHaveBeenCalledWith(
+					'microsoftExcelOAuth2Api',
+					expect.objectContaining({
+						uri: 'https://graph.microsoft.com/v1.0/sites',
+					}),
+				);
+			});
+
+			it('should not nest /sites/{id}/drive resources under /me', async () => {
+				await microsoftApiRequest.call(
+					mockExecuteFunctions,
+					'GET',
+					'/sites/site-id/drive/root/search',
+				);
+
+				expect(mockRequestOAuth2).toHaveBeenCalledWith(
+					'microsoftExcelOAuth2Api',
+					expect.objectContaining({
+						uri: 'https://graph.microsoft.com/v1.0/sites/site-id/drive/root/search',
+					}),
+				);
+			});
+		});
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Excel/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Excel/v2/transport/index.ts
@@ -8,6 +8,21 @@ import type {
 } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
 
+import { mapMicrosoftApiError } from '../helpers/errorHandling';
+
+// Resources whose path is an absolute Graph path and must NOT be nested under the
+// signed-in user's `/me` context: a specific drive (`/drives/...`), a SharePoint
+// site (`/sites/...`), or tenant-wide search (`/search/...`). Everything else stays
+// scoped to `/me`, so existing personal-OneDrive calls (e.g. `/drive/...`) are
+// unchanged. Note `/drive` (personal) is intentionally not in this list, only `/drives`.
+const ABSOLUTE_GRAPH_PREFIXES = ['/drives', '/sites', '/search'];
+
+function isAbsoluteGraphResource(resource: string): boolean {
+	return ABSOLUTE_GRAPH_PREFIXES.some(
+		(prefix) => resource === prefix || resource.startsWith(`${prefix}/`),
+	);
+}
+
 export async function microsoftApiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions,
 	method: IHttpRequestMethods,
@@ -23,6 +38,7 @@ export async function microsoftApiRequest(
 			? credentials.graphApiBaseUrl
 			: 'https://graph.microsoft.com'
 	).replace(/\/+$/, '');
+	const scope = isAbsoluteGraphResource(resource) ? '' : '/me';
 	const options: IRequestOptions = {
 		headers: {
 			'Content-Type': 'application/json',
@@ -30,7 +46,7 @@ export async function microsoftApiRequest(
 		method,
 		body,
 		qs,
-		uri: uri || `${baseUrl}/v1.0/me${resource}`,
+		uri: uri || `${baseUrl}/v1.0${scope}${resource}`,
 		json: true,
 	};
 	try {
@@ -39,7 +55,10 @@ export async function microsoftApiRequest(
 		}
 		return await this.helpers.requestOAuth2.call(this, 'microsoftExcelOAuth2Api', options);
 	} catch (error) {
-		throw new NodeApiError(this.getNode(), error as JsonObject);
+		// Surface actionable guidance for permission/licensing failures; fall back
+		// to the default parsing for everything else.
+		const mappedError = mapMicrosoftApiError(error);
+		throw new NodeApiError(this.getNode(), error as JsonObject, mappedError);
 	}
 }
 


### PR DESCRIPTION
## Summary

The Microsoft Excel 365 node could only see workbooks in the signed-in user's **personal OneDrive**. Workbooks stored in **shared or SharePoint document libraries** never appeared, so the workbook list came back empty for many users whose files live in SharePoint team sites.

This PR adds a **Source** option to every workbook operation (on both the regular node and the tool) so you can choose where to look for workbooks:

- **OneDrive (Personal)** the user's own files (the original behaviour).
- **SharePoint Sites** workbooks in the SharePoint document libraries the user can access, via **Microsoft Search**.
- **Everything** the user's OneDrive plus the shared and SharePoint files they can access, in one **Microsoft Search** query (this also surfaces files other people have shared with them).

What this means in practice:

- The workbook picker and the **Get Workbooks** operation both honour the chosen Source. **Reading and writing** sheets, tables and rows works for shared/SharePoint workbooks too, not just personal-OneDrive ones.
- **Source lives in each operation's options** (the collapsible "Add option" section), so it stays out of the way for the common case.
- **Backward compatible by node version.** Source is left unset by default and the effective default is decided by version: existing nodes keep listing **personal OneDrive** so saved workflows behave exactly as before, while newly added nodes default to **Everything**.
- Microsoft Search returns the most relevant matches rather than a full enumeration, so very large libraries may not list every file. The Get Workbooks "Return All" option warns about large result sets.
- **"By ID" (fixed) mode** now accepts the composite `{driveId}/{itemId}` values that search returns (and IDs containing `-` or `_`, which it previously rejected).
- Permission and licensing failures now show a **clear, actionable message** instead of a silent empty list.

The credential's Microsoft Graph scope changes from `Files.ReadWrite` to **`Files.ReadWrite.All`** (read and write to every file the user can access). A Microsoft 365 administrator may need to consent, and existing credentials need to be **reconnected once** to pick up the new scope.

## How to test

1. Connect a Microsoft Excel credential, or reconnect an existing one so it picks up the new scope (a Microsoft 365 admin may need to consent).
2. Add a **Microsoft Excel 365** node, Resource = **Workbook**, Operation = **Get Many**, and run it. A newly added node defaults Source to **Everything**, so the list spans OneDrive and SharePoint. Expand the operation's **options** to switch Source between OneDrive (Personal), SharePoint Sites and Everything.
3. Pick a SharePoint-stored workbook, set Resource = **Sheet**, Operation = **Read Rows**, choose a sheet, and run it. The rows are returned. Try a write operation (for example **Append**) on the same workbook to confirm writes work too.
4. Confirm an existing node added before this change still defaults to **personal OneDrive** and lists and reads exactly as before.

Verified end to end against a test tenant: each Source returns the expected workbooks (personal OneDrive, a SharePoint team site, and both together via Everything), and reading/writing a SharePoint workbook resolves its drive correctly.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-2

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
