### PR TITLE
fix(editor): Remove 'Building your agent' loading state and go straight to full-page builder

### DIFF
--- a/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
+++ b/packages/frontend/editor-ui/src/features/agents/__tests__/AgentBuilderView.test.ts
@@ -245,7 +245,7 @@ vi.mock('@n8n/i18n', () => ({
 vi.setConfig({ testTimeout: 30_000 });
 
 /** Shared stubs used by both mount helpers. */
-async function renderView() {
+async function renderView({ waitForAsyncSetup = true }: { waitForAsyncSetup?: boolean } = {}) {
 	const { default: AgentBuilderView } = await import('../views/AgentBuilderView.vue');
 	const pinia = createPinia();
 	setActivePinia(pinia);
@@ -255,7 +255,7 @@ async function renderView() {
 			stubs: commonStubs,
 		},
 	});
-	await flushPromises();
+	if (waitForAsyncSetup) await flushPromises();
 	return wrapper;
 }
 
@@ -677,6 +677,76 @@ describe('AgentBuilderView — three-column shell', () => {
 		const wrapper = await renderView();
 
 		expect(wrapper.find('[data-testid="agent-build-chat-full-width-toggle"]').exists()).toBe(true);
+	});
+
+	it('renders seeded initial builds from the URL as full-width before async initialization settles', async () => {
+		routeQuery.prompt = 'Build a recruiting agent';
+		routeQuery.expandBuildChat = 'true';
+
+		const wrapper = await renderView({ waitForAsyncSetup: false });
+
+		const chatColumn = wrapper.findComponent({ name: 'AgentBuilderChatColumn' });
+		expect(chatColumn.props('isFullWidth')).toBe(true);
+		expect(wrapper.find('[data-testid="agent-builder-editor-column"]').exists()).toBe(false);
+
+		await flushPromises();
+	});
+
+	it('auto-expands seeded initial builds from the URL and clears the query flag', async () => {
+		routeQuery.prompt = 'Build a recruiting agent';
+		routeQuery.expandBuildChat = 'true';
+
+		const wrapper = await renderView();
+
+		const chatColumn = wrapper.findComponent({ name: 'AgentBuilderChatColumn' });
+		expect(chatColumn.props('isFullWidth')).toBe(true);
+		expect(wrapper.find('[data-testid="agent-builder-editor-column"]').exists()).toBe(false);
+		expect(routerReplace).toHaveBeenCalledWith({
+			query: { prompt: undefined, expandBuildChat: undefined },
+		});
+	});
+
+	it('keeps an auto-expanded initial build open on config updates before build completion', async () => {
+		routeQuery.prompt = 'Build a recruiting agent';
+		routeQuery.expandBuildChat = 'true';
+		const wrapper = await renderView();
+
+		wrapper.findComponent({ name: 'AgentBuilderChatColumn' }).vm.$emit('config-updated');
+		await flushPromises();
+
+		expect(wrapper.findComponent({ name: 'AgentBuilderChatColumn' }).props('isFullWidth')).toBe(
+			true,
+		);
+		expect(wrapper.find('[data-testid="agent-builder-editor-column"]').exists()).toBe(false);
+	});
+
+	it('collapses an auto-expanded initial build when the build finishes with written config', async () => {
+		routeQuery.prompt = 'Build a recruiting agent';
+		routeQuery.expandBuildChat = 'true';
+		const wrapper = await renderView();
+
+		wrapper.findComponent({ name: 'AgentBuilderChatColumn' }).vm.$emit('build-done');
+		await flushPromises();
+
+		expect(wrapper.findComponent({ name: 'AgentBuilderChatColumn' }).props('isFullWidth')).toBe(
+			false,
+		);
+		expect(wrapper.find('[data-testid="agent-builder-editor-column"]').exists()).toBe(true);
+	});
+
+	it('mounts the editor enabled when the initial build completion collapses the chat', async () => {
+		routeQuery.prompt = 'Build a recruiting agent';
+		routeQuery.expandBuildChat = 'true';
+		const wrapper = await renderView();
+		const chatColumn = wrapper.findComponent({ name: 'AgentBuilderChatColumn' });
+
+		chatColumn.vm.$emit('update:streaming', true);
+		chatColumn.vm.$emit('build-done');
+		await flushPromises();
+
+		expect(
+			wrapper.findComponent({ name: 'AgentBuilderEditorColumn' }).props('isBuildChatStreaming'),
+		).toBe(false);
 	});
 
 	it('does not render the old Build/Test toggle inside the chat input footer', async () => {

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderChatColumn.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentBuilderChatColumn.vue
@@ -32,6 +32,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
 	'config-updated': [];
+	'build-done': [];
 	'update:streaming': [streaming: boolean];
 	'update:tools': [tools: AgentJsonToolRef[]];
 	'update:mcp-servers': [mcpServers: AgentJsonMcpServerConfig[]];
@@ -91,6 +92,7 @@ const sharedInputDraft = ref('');
 				:can-edit-agent="canEditAgent"
 				:before-send="beforeBuildSend"
 				@config-updated="emit('config-updated')"
+				@build-done="emit('build-done')"
 				@update:streaming="emit('update:streaming', $event)"
 			>
 				<template v-if="canEditAgent" #above-input>

--- a/packages/frontend/editor-ui/src/features/agents/components/AgentChatPanel.vue
+++ b/packages/frontend/editor-ui/src/features/agents/components/AgentChatPanel.vue
@@ -43,6 +43,7 @@ const emit = defineEmits<{
 	codeUpdated: [];
 	codeDelta: [delta: string];
 	configUpdated: [];
+	buildDone: [];
 	'update:streaming': [streaming: boolean];
 	'update:inputDraft': [value: string];
 	'continue-loaded': [count: number];
@@ -86,6 +87,7 @@ const {
 	onCodeUpdated: () => emit('codeUpdated'),
 	onCodeDelta: (d) => emit('codeDelta', d),
 	onConfigUpdated: () => emit('configUpdated'),
+	onBuildDone: () => emit('buildDone'),
 	onHistoryLoaded: (count) => {
 		if (props.continueSessionId) emit('continue-loaded', count);
 	},

--- a/packages/frontend/editor-ui/src/features/agents/composables/useAgentChatStream.ts
+++ b/packages/frontend/editor-ui/src/features/agents/composables/useAgentChatStream.ts
@@ -1,4 +1,4 @@
-import { ref, reactive, computed, type Ref } from 'vue';
+import { ref, reactive, computed, nextTick, type Ref } from 'vue';
 import { useI18n } from '@n8n/i18n';
 import { useRootStore } from '@n8n/stores/useRootStore';
 import type {
@@ -45,6 +45,7 @@ export interface UseAgentChatStreamParams {
 	onCodeUpdated?: () => void;
 	onCodeDelta?: (delta: string) => void;
 	onConfigUpdated?: () => void;
+	onBuildDone?: () => void;
 	onHistoryLoaded?: (count: number) => void;
 }
 
@@ -418,11 +419,13 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 		return undefined;
 	}
 
-	async function consumeStream(response: Response, session: StreamSession): Promise<void> {
-		if (!response.body) return;
+	async function consumeStream(response: Response, session: StreamSession): Promise<boolean> {
+		if (!response.body) return false;
 		const reader = response.body.getReader();
 		const decoder = new TextDecoder();
 		let buffer = '';
+
+		let doneSeen = false;
 
 		try {
 			readerLoop: while (true) {
@@ -442,21 +445,26 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 						continue;
 					}
 					const result = handleEvent(event, session);
-					if (result?.done) break readerLoop;
+					if (result?.done) {
+						doneSeen = true;
+						break readerLoop;
+					}
 				}
 			}
 		} finally {
 			reader.releaseLock();
 		}
+
+		return doneSeen;
 	}
 
 	function finalizeStream(session: StreamSession): void {
 		for (const msg of session.minted) {
 			if (msg.status === CHAT_MESSAGE_STATUS.STREAMING) msg.status = CHAT_MESSAGE_STATUS.SUCCESS;
 		}
-		if (params.endpoint.value === 'build' && session.builderMutated) {
-			params.onConfigUpdated?.();
-		}
+
+		if (params.endpoint.value !== 'build') return;
+		if (session.builderMutated) params.onConfigUpdated?.();
 	}
 
 	async function postAndConsume(
@@ -473,6 +481,7 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 		const controller = new AbortController();
 		abortController.value = controller;
 		let transportFailed = false;
+		let doneSeen = false;
 
 		try {
 			const browserId = localStorage.getItem('n8n-browserId') ?? '';
@@ -496,7 +505,7 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 				return { ok: false };
 			}
 
-			await consumeStream(response, session);
+			doneSeen = await consumeStream(response, session);
 			finalizeStream(session);
 		} catch (e) {
 			if (e instanceof DOMException && e.name === 'AbortError') {
@@ -517,6 +526,11 @@ export function useAgentChatStream(params: UseAgentChatStreamParams) {
 		} finally {
 			abortController.value = null;
 			isStreaming.value = false;
+		}
+
+		if (params.endpoint.value === 'build' && doneSeen) {
+			await nextTick();
+			params.onBuildDone?.();
 		}
 
 		return { ok: !transportFailed && !session.errorEmitted };

--- a/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/AgentBuilderView.vue
@@ -155,7 +155,13 @@ const connectedTriggers = ref<string[]>([]);
 const tasksReloadKey = ref(0);
 const builderContainer = useTemplateRef<HTMLElement>('builderContainer');
 const versionHistoryPanel = useTemplateRef<{ refresh: () => Promise<void> }>('versionHistoryPanel');
-const isChatFullWidth = ref(false);
+function shouldAutoExpandInitialBuild(): boolean {
+	return Boolean(route.query.prompt) && route.query.expandBuildChat === 'true';
+}
+
+const shouldStartWithExpandedBuildChat = shouldAutoExpandInitialBuild();
+const isChatFullWidth = ref(shouldStartWithExpandedBuildChat);
+const shouldCollapseChatAfterInitialBuild = ref(shouldStartWithExpandedBuildChat);
 const executionsCount = computed(() => sessionsStore.threads.length);
 const { activeMainTab, mainTabOptions, executionsDescription } = useAgentBuilderMainTabs({
 	executionsCount,
@@ -656,6 +662,13 @@ async function onConfigUpdated() {
 	builderTelemetry.trackTasksChanged();
 }
 
+function onBuildDone() {
+	isBuildChatStreaming.value = false;
+	if (!shouldCollapseChatAfterInitialBuild.value) return;
+	isChatFullWidth.value = false;
+	shouldCollapseChatAfterInitialBuild.value = false;
+}
+
 const headerActions = computed(() =>
 	canDeleteAgent.value
 		? [{ id: 'delete', label: locale.baseText('agents.builder.deleteAgent') }]
@@ -781,7 +794,13 @@ async function initialize() {
 	// into the build chat.
 	const prompt = route.query.prompt as string | undefined;
 	if (prompt) {
-		void router.replace({ query: { ...route.query, prompt: undefined } });
+		if (shouldAutoExpandInitialBuild()) {
+			isChatFullWidth.value = true;
+			shouldCollapseChatAfterInitialBuild.value = true;
+		}
+		void router.replace({
+			query: { ...route.query, prompt: undefined, expandBuildChat: undefined },
+		});
 		startChat(prompt);
 	}
 
@@ -1203,6 +1222,7 @@ function onPreviewBreadcrumbSelect(item: PathItem) {
 					:can-edit-agent="canEditAgent"
 					:before-build-send="flushAutosave"
 					@config-updated="onConfigUpdated"
+					@build-done="onBuildDone"
 					@update:streaming="onBuildChatStreamingChange"
 					@update:tools="onQuickActionAddTool"
 					@update:mcp-servers="onQuickActionAddMcpServers"

--- a/packages/frontend/editor-ui/src/features/agents/views/NewAgentView.vue
+++ b/packages/frontend/editor-ui/src/features/agents/views/NewAgentView.vue
@@ -15,7 +15,6 @@ import { useAgentBuilderStatus } from '../composables/useAgentBuilderStatus';
 import { useAgentTelemetry } from '../composables/useAgentTelemetry';
 import { buildAgentConfigFingerprint } from '../composables/agentTelemetry.utils';
 import { upsertProjectAgentsListCache } from '../composables/useProjectAgentsList';
-import AgentBuilderProgress from '../components/AgentBuilderProgress.vue';
 import AgentBuilderUnconfiguredEmptyState from '../components/AgentBuilderUnconfiguredEmptyState.vue';
 
 const router = useRouter();
@@ -59,10 +58,6 @@ onMounted(async () => {
 		}
 	}
 });
-// When set, we've created the agent and the progress overlay is streaming
-// the build. We only route into the builder once the stream reports `done`.
-const building = ref<{ agentId: string; message: string } | null>(null);
-
 interface SuggestionTemplate {
 	icon: string;
 	name: string;
@@ -243,22 +238,15 @@ async function submitDescription() {
 		} catch {
 			// Swallow — telemetry is best-effort and must not block the build.
 		}
-		// Hand off to the progress overlay; it streams `/build` and fires `done`
-		// once the agent is ready, at which point we route into the builder.
-		building.value = { agentId: agent.id, message };
+		void router.push({
+			name: AGENT_BUILDER_VIEW,
+			params: { projectId: projectId.value, agentId: agent.id },
+			query: { prompt: message, expandBuildChat: 'true' },
+		});
 	} catch (e) {
 		isCreating.value = false;
 		throw e;
 	}
-}
-
-function onBuildDone() {
-	const target = building.value;
-	if (!target) return;
-	void router.push({
-		name: AGENT_BUILDER_VIEW,
-		params: { projectId: projectId.value, agentId: target.agentId },
-	});
 }
 
 function selectSuggestion(suggestion: SuggestionTemplate) {
@@ -273,81 +261,69 @@ function selectSuggestion(suggestion: SuggestionTemplate) {
 	<div :class="$style.page">
 		<AgentBuilderUnconfiguredEmptyState v-if="statusLoaded && !isBuilderConfigured" />
 		<template v-else-if="statusLoaded">
-			<Transition name="building-overlay">
-				<div v-if="building" :class="$style.buildingOverlay">
-					<AgentBuilderProgress
-						:project-id="projectId"
-						:agent-id="building.agentId"
-						:initial-message="building.message"
-						@done="onBuildDone"
+			<div :class="$style.content">
+				<div :class="$style.topBar">
+					<N8nButton
+						:label="i18n.baseText('agents.new.startBlank')"
+						variant="ghost"
+						size="medium"
+						icon="file"
+						:loading="isCreating"
+						data-testid="create-blank-agent"
+						@click="createBlank"
 					/>
 				</div>
-			</Transition>
-			<Transition name="new-agent-content">
-				<div v-if="!building" :class="$style.content">
-					<div :class="$style.topBar">
-						<N8nButton
-							:label="i18n.baseText('agents.new.startBlank')"
-							variant="ghost"
-							size="medium"
-							icon="file"
-							:loading="isCreating"
-							data-testid="create-blank-agent"
-							@click="createBlank"
+
+				<div :class="$style.center">
+					<h1 :class="$style.heading">{{ heading }}</h1>
+
+					<div :class="$style.inputWrapper">
+						<ChatInputBase
+							ref="chatInputRef"
+							v-model="inputText"
+							:placeholder="i18n.baseText('agents.new.description.placeholder')"
+							:is-streaming="false"
+							:can-submit="inputText.trim().length > 0 && !isCreating"
+							:show-voice="true"
+							:show-attach="false"
+							@submit="submitDescription"
 						/>
 					</div>
 
-					<div :class="$style.center">
-						<h1 :class="$style.heading">{{ heading }}</h1>
+					<div :class="$style.suggestions">
+						<N8nText :class="$style.suggestionsLabel" tag="h3" size="medium" bold>
+							{{ i18n.baseText('agents.new.templates.label') }}
+						</N8nText>
 
-						<div :class="$style.inputWrapper">
-							<ChatInputBase
-								ref="chatInputRef"
-								v-model="inputText"
-								:placeholder="i18n.baseText('agents.new.description.placeholder')"
-								:is-streaming="false"
-								:can-submit="inputText.trim().length > 0 && !isCreating"
-								:show-voice="true"
-								:show-attach="false"
-								@submit="submitDescription"
-							/>
-						</div>
-
-						<div :class="$style.suggestions">
-							<N8nText :class="$style.suggestionsLabel" tag="h3" size="medium" bold>
-								{{ i18n.baseText('agents.new.templates.label') }}
-							</N8nText>
-
-							<div :class="$style.suggestionGrid">
-								<button
-									v-for="(suggestion, index) in suggestions"
-									:key="suggestion.name"
-									type="button"
-									:class="$style.suggestionCard"
-									:style="{ '--suggestion-index': index }"
-									data-testid="agent-suggestion-card"
-									@click="selectSuggestion(suggestion)"
-								>
-									<div :class="$style.suggestionHeader">
-										<span :class="$style.suggestionIcon">{{ suggestion.icon }}</span>
-										<N8nText tag="span" bold size="small" :class="$style.suggestionName">
-											{{ suggestion.name }}
-										</N8nText>
-									</div>
-									<N8nText
-										tag="span"
-										size="small"
-										color="text-light"
-										:class="$style.suggestionDescription"
-									>
-										{{ suggestion.description }}
+						<div :class="$style.suggestionGrid">
+							<button
+								v-for="(suggestion, index) in suggestions"
+								:key="suggestion.name"
+								type="button"
+								:class="$style.suggestionCard"
+								:style="{ '--suggestion-index': index }"
+								data-testid="agent-suggestion-card"
+								@click="selectSuggestion(suggestion)"
+							>
+								<div :class="$style.suggestionHeader">
+									<span :class="$style.suggestionIcon">{{ suggestion.icon }}</span>
+									<N8nText tag="span" bold size="small" :class="$style.suggestionName">
+										{{ suggestion.name }}
 									</N8nText>
-								</button>
-							</div>
+								</div>
+								<N8nText
+									tag="span"
+									size="small"
+									color="text-light"
+									:class="$style.suggestionDescription"
+								>
+									{{ suggestion.description }}
+								</N8nText>
+							</button>
 						</div>
 					</div>
 				</div>
-			</Transition>
+			</div>
 		</template>
 	</div>
 </template>
@@ -361,43 +337,11 @@ function selectSuggestion(suggestion: SuggestionTemplate) {
 	width: 100%;
 }
 
-.buildingOverlay {
-	position: absolute;
-	inset: 0;
-	z-index: 10;
-	display: flex;
-	background: var(--color--background--light-3);
-	backdrop-filter: blur(4px);
-	pointer-events: all;
-}
-
 .content {
 	flex: 1;
 	display: flex;
 	flex-direction: column;
 	min-height: 0;
-}
-
-:global(.building-overlay-enter-active) {
-	transition: opacity calc(var(--duration--base) * 1.5) var(--easing--ease-out)
-		calc(var(--duration--base) / 3);
-}
-
-:global(.building-overlay-enter-from) {
-	opacity: 0;
-}
-
-:global(.new-agent-content-leave-active) {
-	transition:
-		opacity var(--duration--base) var(--easing--ease-out),
-		filter var(--duration--base) var(--easing--ease-out),
-		transform var(--duration--base) var(--easing--ease-out);
-}
-
-:global(.new-agent-content-leave-to) {
-	opacity: 0;
-	filter: blur(3px);
-	transform: translateY(calc(-1 * var(--spacing--xs)));
 }
 
 .topBar {
@@ -557,11 +501,6 @@ function selectSuggestion(suggestion: SuggestionTemplate) {
 	.suggestions,
 	.suggestionCard {
 		animation: none;
-	}
-
-	:global(.building-overlay-enter-active),
-	:global(.new-agent-content-leave-active) {
-		transition: none;
 	}
 }
 </style>


### PR DESCRIPTION
## Summary

This PR removes the interim “building your agent” overlay from the new agent flow. After submitting an initial prompt, users are routed directly into the agent builder with the build chat expanded while the initial build stream runs.

- Removes `building` state and UI from `NewAgentView.vue`
-  Passes `expandBuildChat` in URL to `AgentBuilderView` so chat is full expanded on mount
- Emits build completion from the `useAgentChatStream` after the build stream reports done
- Fires `onBuildDone` which collapses chat and makes config UI enabled
- Adds coverage for the initial expanded build state and collapse behavior

https://cleanshot.com/share/RZcxpRdL

## How to test

1. Start the editor UI.
2. Open the new agent page.
3. Enter a prompt and submit it.
4. Confirm you are routed directly to the agent builder instead of seeing a separate loading/building overlay.
5. Confirm the build chat is expanded while the initial build runs and collapses after completion.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/AGENT-173

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported) 