### PR TITLE
chore: Create a lightweight version of pnpm reset

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,10 +60,11 @@ tail -n 20 build.log
 ```
 
 If build outputs or the turbo cache are stale (e.g. after switching branches
-or worktrees) but dependencies haven't changed, use `pnpm reset --light` for a
-fast recovery: it cleans build outputs and force-rebuilds (keeping
-`node_modules` and untracked files), rather than the full `pnpm reset` which
-also wipes untracked files and reinstalls dependencies.
+or worktrees) but dependencies haven't changed, use `pnpm reset` (lightweight
+by default) for a fast recovery: it cleans build outputs and force-rebuilds
+(keeping `node_modules` and untracked files). If that doesn't fix your issue,
+use `pnpm reset --full`, which also wipes untracked files and reinstalls
+dependencies.
 
 ### Testing
 - `pnpm test` - Run all tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,12 @@ You can inspect the last few lines of the build log file to check for errors:
 tail -n 20 build.log
 ```
 
+If build outputs or the turbo cache are stale (e.g. after switching branches
+or worktrees) but dependencies haven't changed, use `pnpm reset --light` for a
+fast recovery: it cleans build outputs and force-rebuilds (keeping
+`node_modules` and untracked files), rather than the full `pnpm reset` which
+also wipes untracked files and reinstalls dependencies.
+
 ### Testing
 - `pnpm test` - Run all tests
 - `pnpm test:affected` - Runs tests based on what has changed since the last

--- a/packages/@n8n/agents/tsconfig.build.json
+++ b/packages/@n8n/agents/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["src/**/__tests__/**"]

--- a/packages/@n8n/agents/tsconfig.json
+++ b/packages/@n8n/agents/tsconfig.json
@@ -1,8 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"types": ["node", "vitest/globals"],
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
+		"types": ["node", "vitest/globals"]
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["dist/**/*", "node_modules/**/*"]

--- a/packages/@n8n/ai-node-sdk/tsconfig.build.cjs.json
+++ b/packages/@n8n/ai-node-sdk/tsconfig.build.cjs.json
@@ -3,7 +3,6 @@
 	"compilerOptions": {
 		"rootDir": "src",
 		"outDir": "dist/cjs",
-		"tsBuildInfoFile": "dist/cjs/typecheck.tsbuildinfo",
 		"declaration": true
 	},
 	"include": ["src/**/*.ts"],

--- a/packages/@n8n/ai-node-sdk/tsconfig.build.json
+++ b/packages/@n8n/ai-node-sdk/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["src/**/__tests__/**", "src/**/*.test.ts"]

--- a/packages/@n8n/ai-node-sdk/tsconfig.json
+++ b/packages/@n8n/ai-node-sdk/tsconfig.json
@@ -4,8 +4,7 @@
 		"@n8n/typescript-config/tsconfig.backend.json"
 	],
 	"compilerOptions": {
-		"types": ["node", "vitest/globals"],
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
+		"types": ["node", "vitest/globals"]
 	},
 	"include": ["src/**/*.ts"]
 }

--- a/packages/@n8n/ai-utilities/tsconfig.json
+++ b/packages/@n8n/ai-utilities/tsconfig.json
@@ -8,7 +8,6 @@
 			"src/*": ["./src/*"],
 			"src": ["./src"]
 		},
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
 		"types": ["node", "vitest/globals"]

--- a/packages/@n8n/ai-workflow-builder.ee/tsconfig.build.json
+++ b/packages/@n8n/ai-workflow-builder.ee/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["src/**/__tests__/**", "src/**/test-utils/**", "**/*.test.ts"]

--- a/packages/@n8n/ai-workflow-builder.ee/tsconfig.json
+++ b/packages/@n8n/ai-workflow-builder.ee/tsconfig.json
@@ -11,7 +11,6 @@
 		"paths": {
 			"@/*": ["./src/*"]
 		},
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"types": ["node", "vitest/globals"]
 	},
 	"include": ["src/**/*.ts", "test/**/*.ts", "evaluations/**/*.ts", "scripts/**/*.ts"]

--- a/packages/@n8n/api-types/tsconfig.build.json
+++ b/packages/@n8n/api-types/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["src/**/__tests__/**"]

--- a/packages/@n8n/api-types/tsconfig.json
+++ b/packages/@n8n/api-types/tsconfig.json
@@ -1,8 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"types": ["node", "vitest/globals"],
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
+		"types": ["node", "vitest/globals"]
 	},
 	"include": ["src/**/*.ts"],
 	"references": [

--- a/packages/@n8n/backend-common/tsconfig.build.json
+++ b/packages/@n8n/backend-common/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["src/**/__tests__/**"]

--- a/packages/@n8n/backend-common/tsconfig.json
+++ b/packages/@n8n/backend-common/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
 		"types": ["node", "vitest/globals"],
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"experimentalDecorators": true,
 		"emitDecoratorMetadata": true
 	},

--- a/packages/@n8n/backend-test-utils/tsconfig.build.json
+++ b/packages/@n8n/backend-test-utils/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["src/**/__tests__/**"]

--- a/packages/@n8n/backend-test-utils/tsconfig.json
+++ b/packages/@n8n/backend-test-utils/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
 		"types": ["node", "jest"],
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"experimentalDecorators": true,
 		"emitDecoratorMetadata": true
 	},

--- a/packages/@n8n/benchmark/tsconfig.build.json
+++ b/packages/@n8n/benchmark/tsconfig.build.json
@@ -2,8 +2,7 @@
 	"extends": ["./tsconfig.json", "@n8n/typescript-config/tsconfig.build.json"],
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"]
 }

--- a/packages/@n8n/chat-hub/tsconfig.build.json
+++ b/packages/@n8n/chat-hub/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["src/**/__tests__/**", "src/**/*.test.ts"]

--- a/packages/@n8n/chat-hub/tsconfig.json
+++ b/packages/@n8n/chat-hub/tsconfig.json
@@ -1,8 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"types": ["node", "vitest/globals"],
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
+		"types": ["node", "vitest/globals"]
 	},
 	"include": ["src/**/*.ts"],
 	"references": [{ "path": "../api-types/tsconfig.build.json" }]

--- a/packages/@n8n/cli/tsconfig.build.json
+++ b/packages/@n8n/cli/tsconfig.build.json
@@ -4,8 +4,7 @@
 		"composite": true,
 		"rootDir": "src",
 		"outDir": "dist",
-		"declaration": true,
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"declaration": true
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["src/**/__tests__/**", "src/**/*.test.ts"]

--- a/packages/@n8n/client-oauth2/tsconfig.build.json
+++ b/packages/@n8n/client-oauth2/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["test/**"]

--- a/packages/@n8n/client-oauth2/tsconfig.json
+++ b/packages/@n8n/client-oauth2/tsconfig.json
@@ -4,8 +4,7 @@
 		"types": ["node", "vitest/globals"],
 		"paths": {
 			"@/*": ["./src/*"]
-		},
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
+		}
 	},
 	"include": ["src/**/*.ts", "test/**/*.ts"]
 }

--- a/packages/@n8n/codemirror-lang-sql/tsconfig.build.json
+++ b/packages/@n8n/codemirror-lang-sql/tsconfig.build.json
@@ -2,8 +2,7 @@
 	"extends": ["./tsconfig.json", "@n8n/typescript-config/tsconfig.build.json"],
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["test/**"]

--- a/packages/@n8n/codemirror-lang-sql/tsconfig.json
+++ b/packages/@n8n/codemirror-lang-sql/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
 		"rootDir": ".",
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"types": ["node", "jest"]
 	},
 	"include": ["src/**/*.ts", "test/**/*.ts"]

--- a/packages/@n8n/codemirror-lang/tsconfig.build.json
+++ b/packages/@n8n/codemirror-lang/tsconfig.build.json
@@ -2,8 +2,7 @@
 	"extends": ["./tsconfig.json", "@n8n/typescript-config/tsconfig.build.json"],
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["test/**"]

--- a/packages/@n8n/codemirror-lang/tsconfig.json
+++ b/packages/@n8n/codemirror-lang/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
 		"rootDir": ".",
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"types": ["node", "jest"]
 	},
 	"include": ["src/**/*.ts", "test/**/*.ts"]

--- a/packages/@n8n/computer-use/tsconfig.build.json
+++ b/packages/@n8n/computer-use/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["src/**/__tests__/**", "src/**/__mocks__/**", "src/**/*.test.ts", "src/**/*.spec.ts"]

--- a/packages/@n8n/computer-use/tsconfig.json
+++ b/packages/@n8n/computer-use/tsconfig.json
@@ -1,8 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"types": ["node", "vitest/globals"],
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
+		"types": ["node", "vitest/globals"]
 	},
 	"include": ["src/**/*.ts"]
 }

--- a/packages/@n8n/config/tsconfig.build.json
+++ b/packages/@n8n/config/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["test/**", "src/**/__tests__/**"]

--- a/packages/@n8n/config/tsconfig.json
+++ b/packages/@n8n/config/tsconfig.json
@@ -4,8 +4,7 @@
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
 		"strictPropertyInitialization": false,
-		"types": ["node", "vitest/globals"],
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
+		"types": ["node", "vitest/globals"]
 	},
 	"include": ["src/**/*.ts", "test/**/*.ts"],
 	"references": [{ "path": "../di/tsconfig.build.json" }]

--- a/packages/@n8n/constants/tsconfig.build.json
+++ b/packages/@n8n/constants/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"]
 }

--- a/packages/@n8n/constants/tsconfig.json
+++ b/packages/@n8n/constants/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
 		"types": ["node", "jest"],
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"experimentalDecorators": true,
 		"emitDecoratorMetadata": true
 	},

--- a/packages/@n8n/crdt/tsconfig.build.json
+++ b/packages/@n8n/crdt/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["src/**/*.test.ts", "src/__tests__/**"]

--- a/packages/@n8n/crdt/tsconfig.json
+++ b/packages/@n8n/crdt/tsconfig.json
@@ -1,8 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"types": ["node", "vitest/globals"],
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
+		"types": ["node", "vitest/globals"]
 	},
 	"include": ["src/**/*.ts"]
 }

--- a/packages/@n8n/db/tsconfig.build.json
+++ b/packages/@n8n/db/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["src/**/__tests__/**", "src/**/*.test.ts", "src/**/*.spec.ts"]

--- a/packages/@n8n/db/tsconfig.json
+++ b/packages/@n8n/db/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
 		"types": ["node", "vitest/globals"],
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"experimentalDecorators": true,
 		"emitDecoratorMetadata": true,
 

--- a/packages/@n8n/decorators/tsconfig.build.json
+++ b/packages/@n8n/decorators/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["src/**/__tests__/**"]

--- a/packages/@n8n/decorators/tsconfig.json
+++ b/packages/@n8n/decorators/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
 		"types": ["node", "vitest/globals"],
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"experimentalDecorators": true,
 		"emitDecoratorMetadata": true
 	},

--- a/packages/@n8n/di/tsconfig.build.json
+++ b/packages/@n8n/di/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["src/**/__tests__/**"]

--- a/packages/@n8n/di/tsconfig.json
+++ b/packages/@n8n/di/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
 		"types": ["node", "vitest/globals"],
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"experimentalDecorators": true,
 		"emitDecoratorMetadata": true
 	},

--- a/packages/@n8n/engine/tsconfig.build.json
+++ b/packages/@n8n/engine/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["src/**/__tests__/**", "**/*.test.ts"]

--- a/packages/@n8n/engine/tsconfig.json
+++ b/packages/@n8n/engine/tsconfig.json
@@ -7,7 +7,6 @@
 		"target": "es2023",
 		"lib": ["es2023"],
 		"types": ["node"],
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"experimentalDecorators": true,
 		"emitDecoratorMetadata": true
 	},

--- a/packages/@n8n/errors/tsconfig.build.json
+++ b/packages/@n8n/errors/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["src/**/__tests__/**"]

--- a/packages/@n8n/errors/tsconfig.json
+++ b/packages/@n8n/errors/tsconfig.json
@@ -2,7 +2,6 @@
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
 		"types": ["node", "jest"],
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"experimentalDecorators": true,
 		"emitDecoratorMetadata": true
 	},

--- a/packages/@n8n/expression-runtime/tsconfig.build.cjs.json
+++ b/packages/@n8n/expression-runtime/tsconfig.build.cjs.json
@@ -2,8 +2,7 @@
 	"extends": ["./tsconfig.json", "@n8n/typescript-config/modern/tsconfig.cjs.json"],
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "dist/cjs",
-		"tsBuildInfoFile": "dist/cjs/build.tsbuildinfo"
+		"outDir": "dist/cjs"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["node_modules", "dist", "src/**/__tests__/**"]

--- a/packages/@n8n/extension-sdk/tsconfig.backend.json
+++ b/packages/@n8n/extension-sdk/tsconfig.backend.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"declaration": true,
-		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.backend.tsbuildinfo"
+		"tsBuildInfoFile": "${configDir}/dist/backend.tsbuildinfo"
 	},
 	"include": ["src/backend/**/*.ts"]
 }

--- a/packages/@n8n/extension-sdk/tsconfig.common.json
+++ b/packages/@n8n/extension-sdk/tsconfig.common.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"declaration": true,
-		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.backend.tsbuildinfo"
+		"tsBuildInfoFile": "${configDir}/dist/common.tsbuildinfo"
 	},
 	"include": ["src/*.ts"]
 }

--- a/packages/@n8n/extension-sdk/tsconfig.frontend.json
+++ b/packages/@n8n/extension-sdk/tsconfig.frontend.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"declaration": true,
-		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.frontend.tsbuildinfo"
+		"tsBuildInfoFile": "${configDir}/dist/frontend.tsbuildinfo"
 	},
 	"include": ["src/frontend/**/*.ts", "src/frontend/**/*.vue"]
 }

--- a/packages/@n8n/imap/tsconfig.build.json
+++ b/packages/@n8n/imap/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["src/**/*.test.ts"]

--- a/packages/@n8n/imap/tsconfig.json
+++ b/packages/@n8n/imap/tsconfig.json
@@ -1,8 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"types": ["node", "vite/client", "vitest/globals"],
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
+		"types": ["node", "vite/client", "vitest/globals"]
 	},
 	"include": ["src/**/*.ts"]
 }

--- a/packages/@n8n/instance-ai/tsconfig.build.json
+++ b/packages/@n8n/instance-ai/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["src/**/__tests__/**", "src/**/test-utils/**", "**/*.test.ts"]

--- a/packages/@n8n/instance-ai/tsconfig.json
+++ b/packages/@n8n/instance-ai/tsconfig.json
@@ -11,7 +11,6 @@
 		"paths": {
 			"@/*": ["./src/*"]
 		},
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"types": ["node", "vitest/globals"]
 	},
 	"include": ["src/**/*.ts"]

--- a/packages/@n8n/local-gateway/tsconfig.json
+++ b/packages/@n8n/local-gateway/tsconfig.json
@@ -5,8 +5,7 @@
 		"types": ["node", "vitest/globals"],
 		"lib": ["es2021", "dom"],
 		"moduleResolution": "nodenext",
-		"module": "nodenext",
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
+		"module": "nodenext"
 	},
 	"include": ["src/**/*.ts"]
 }

--- a/packages/@n8n/mcp-apps/tsconfig.build.json
+++ b/packages/@n8n/mcp-apps/tsconfig.build.json
@@ -6,8 +6,7 @@
 		"moduleResolution": "node",
 		"noEmit": false,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/server/**/*.ts", "src/apps-manifest.ts", "src/telemetry-contract.ts"],
 	"exclude": ["src/**/*.test.ts"]

--- a/packages/@n8n/mcp-browser/tsconfig.build.json
+++ b/packages/@n8n/mcp-browser/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["src/**/__tests__/**", "src/**/*.test.ts", "src/**/test-helpers.ts"]

--- a/packages/@n8n/mcp-browser/tsconfig.json
+++ b/packages/@n8n/mcp-browser/tsconfig.json
@@ -1,8 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"types": ["node", "vitest/globals"],
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
+		"types": ["node", "vitest/globals"]
 	},
 	"include": ["src/**/*.ts"]
 }

--- a/packages/@n8n/node-cli/tsconfig.build.json
+++ b/packages/@n8n/node-cli/tsconfig.build.json
@@ -4,8 +4,7 @@
 		"composite": true,
 		"rootDir": "src",
 		"outDir": "dist",
-		"declaration": true,
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"declaration": true
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": [

--- a/packages/@n8n/nodes-langchain/tsconfig.json
+++ b/packages/@n8n/nodes-langchain/tsconfig.json
@@ -8,7 +8,6 @@
 			"@utils/*": ["./utils/*"],
 			"@nodes-testing/*": ["../../core/nodes-testing/*"]
 		},
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
 		"types": ["node", "vitest/globals"],

--- a/packages/@n8n/permissions/tsconfig.build.json
+++ b/packages/@n8n/permissions/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["src/**/__tests__/**"]

--- a/packages/@n8n/permissions/tsconfig.json
+++ b/packages/@n8n/permissions/tsconfig.json
@@ -4,8 +4,7 @@
 		"types": ["node", "vitest/globals"],
 		"paths": {
 			"@/*": ["./src/*"]
-		},
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
+		}
 	},
 	"include": ["src/**/*.ts"]
 }

--- a/packages/@n8n/syslog-client/tsconfig.build.json
+++ b/packages/@n8n/syslog-client/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["test/**", "src/**/__tests__/**"]

--- a/packages/@n8n/syslog-client/tsconfig.json
+++ b/packages/@n8n/syslog-client/tsconfig.json
@@ -4,8 +4,7 @@
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
 		"strictPropertyInitialization": false,
-		"types": ["node", "vitest/globals"],
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
+		"types": ["node", "vitest/globals"]
 	},
 	"include": ["src/**/*.ts", "test/**/*.ts"],
 	"references": [{ "path": "../di/tsconfig.build.json" }]

--- a/packages/@n8n/task-runner/tsconfig.build.json
+++ b/packages/@n8n/task-runner/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["src/**/__tests__/**"]

--- a/packages/@n8n/task-runner/tsconfig.json
+++ b/packages/@n8n/task-runner/tsconfig.json
@@ -9,8 +9,7 @@
 		"types": ["node", "vitest/globals"],
 		"paths": {
 			"@/*": ["./src/*"]
-		},
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
+		}
 	},
 	"include": ["src/**/*.ts"]
 }

--- a/packages/@n8n/tournament/tsconfig.json
+++ b/packages/@n8n/tournament/tsconfig.json
@@ -20,6 +20,7 @@
 		"declaration": true,
 		"sourceMap": true,
 		"skipLibCheck": true,
+		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"types": ["node", "vitest/globals"]
 	},
 	"include": ["src/**/*.ts", "test/**/*.ts"],

--- a/packages/@n8n/typescript-config/modern/tsconfig.cjs.json
+++ b/packages/@n8n/typescript-config/modern/tsconfig.cjs.json
@@ -5,6 +5,7 @@
 		"module": "umd",
 		"moduleResolution": "node",
 		"verbatimModuleSyntax": false,
-		"resolveJsonModule": false
+		"resolveJsonModule": false,
+		"tsBuildInfoFile": "${configDir}/dist/cjs/build.tsbuildinfo"
 	}
 }

--- a/packages/@n8n/typescript-config/modern/tsconfig.json
+++ b/packages/@n8n/typescript-config/modern/tsconfig.json
@@ -24,6 +24,7 @@
 		"composite": true,
 		"declarationMap": true,
 		"sourceMap": true,
+		"tsBuildInfoFile": "${configDir}/dist/typecheck.tsbuildinfo",
 
 		"lib": ["es2022", "dom", "dom.iterable"]
 	}

--- a/packages/@n8n/typescript-config/tsconfig.build.json
+++ b/packages/@n8n/typescript-config/tsconfig.build.json
@@ -3,7 +3,8 @@
 		"types": ["node"],
 		"noUnusedLocals": false,
 		"noUnusedParameters": false,
-		"declaration": true
+		"declaration": true,
+		"tsBuildInfoFile": "${configDir}/dist/build.tsbuildinfo"
 	},
 	"tsc-alias": {
 		"replacers": {

--- a/packages/@n8n/typescript-config/tsconfig.common.json
+++ b/packages/@n8n/typescript-config/tsconfig.common.json
@@ -22,7 +22,7 @@
 		"declaration": false,
 		"sourceMap": true,
 		"skipLibCheck": true,
-		"tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
+		"tsBuildInfoFile": "${configDir}/dist/typecheck.tsbuildinfo"
 	},
 	"files": ["../../../node_modules/jest-expect-message/types/index.d.ts"]
 }

--- a/packages/@n8n/typescript-config/tsconfig.common.json
+++ b/packages/@n8n/typescript-config/tsconfig.common.json
@@ -21,7 +21,8 @@
 		"incremental": true,
 		"declaration": false,
 		"sourceMap": true,
-		"skipLibCheck": true
+		"skipLibCheck": true,
+		"tsBuildInfoFile": "dist/tsconfig.tsbuildinfo"
 	},
 	"files": ["../../../node_modules/jest-expect-message/types/index.d.ts"]
 }

--- a/packages/@n8n/vitest-config/tsconfig.build.json
+++ b/packages/@n8n/vitest-config/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": ".",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["**/*.ts"],
 	"exclude": ["dist", "**/*.test.ts"]

--- a/packages/@n8n/vitest-config/tsconfig.json
+++ b/packages/@n8n/vitest-config/tsconfig.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"types": ["node"],
 		"module": "ESNext",
-		"moduleResolution": "bundler",
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
+		"moduleResolution": "bundler"
 	},
 	"include": ["**/*.ts"],
 	"exclude": ["dist"]

--- a/packages/@n8n/workflow-sdk/tsconfig.build.json
+++ b/packages/@n8n/workflow-sdk/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["src/**/__tests__/**", "src/**/*.test.ts"]

--- a/packages/@n8n/workflow-sdk/tsconfig.json
+++ b/packages/@n8n/workflow-sdk/tsconfig.json
@@ -1,8 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"types": ["node", "vitest/globals"],
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
+		"types": ["node", "vitest/globals"]
 	},
 	"include": ["src/**/*.ts"],
 	"references": [{ "path": "../../workflow/tsconfig.build.esm.json" }]

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -2,8 +2,7 @@
 	"extends": ["./tsconfig.json", "@n8n/typescript-config/tsconfig.build.json"],
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["test/**", "src/**/__tests__/**"]

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -12,7 +12,6 @@
 			"@test/*": ["./test/shared/*"],
 			"@test-integration/*": ["./test/integration/shared/*"]
 		},
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"strict": true,
 		"strictFunctionTypes": false,
 		"strictPropertyInitialization": false,

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"composite": true,
 		"rootDir": "src",
-		"outDir": "dist",
-		"tsBuildInfoFile": "dist/build.tsbuildinfo"
+		"outDir": "dist"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["test/**", "src/**/__tests__/**"]

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -9,7 +9,6 @@
 			"@/*": ["./src/*"],
 			"@test/*": ["./test/*"]
 		},
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,
 		"types": ["node", "vitest/globals"],

--- a/packages/extensions/insights/tsconfig.backend.json
+++ b/packages/extensions/insights/tsconfig.backend.json
@@ -1,7 +1,6 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.common.json",
 	"compilerOptions": {
-		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
 		"moduleResolution": "bundler",
 		"module": "esnext"
 	},

--- a/packages/extensions/insights/tsconfig.frontend.json
+++ b/packages/extensions/insights/tsconfig.frontend.json
@@ -1,7 +1,7 @@
 {
 	"extends": "@vue/tsconfig/tsconfig.dom.json",
 	"compilerOptions": {
-		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo"
+		"tsBuildInfoFile": "dist/tsconfig.app.tsbuildinfo"
 	},
 	"include": ["src/frontend/**/*.ts", "src/frontend/**/*.vue"]
 }

--- a/packages/extensions/insights/tsconfig.vite.json
+++ b/packages/extensions/insights/tsconfig.vite.json
@@ -13,7 +13,8 @@
 		"noUnusedLocals": true,
 		"noUnusedParameters": true,
 		"noFallthroughCasesInSwitch": true,
-		"noUncheckedSideEffectImports": true
+		"noUncheckedSideEffectImports": true,
+		"tsBuildInfoFile": "dist/tsconfig.vite.tsbuildinfo"
 	},
 	"include": ["vite.config.ts", "tsdown.config.ts"]
 }

--- a/packages/extensions/insights/tsconfig.vite.json
+++ b/packages/extensions/insights/tsconfig.vite.json
@@ -1,7 +1,6 @@
 {
 	"compilerOptions": {
 		"composite": true,
-		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
 		"target": "ES2022",
 		"lib": ["ES2023"],
 		"module": "ESNext",

--- a/packages/frontend/@n8n/storybook/tsconfig.app.json
+++ b/packages/frontend/@n8n/storybook/tsconfig.app.json
@@ -1,7 +1,7 @@
 {
 	"extends": "@n8n/typescript-config/tsconfig.frontend.json",
 	"compilerOptions": {
-		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+		"tsBuildInfoFile": "./dist/tsconfig.app.tsbuildinfo",
 		"rootDirs": [".", "../composables/src"],
 		"noEmit": true,
 		"moduleResolution": "bundler",

--- a/packages/frontend/@n8n/storybook/tsconfig.node.json
+++ b/packages/frontend/@n8n/storybook/tsconfig.node.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+		"tsBuildInfoFile": "./dist/tsconfig.node.tsbuildinfo",
 		"target": "ES2023",
 		"lib": ["ES2023"],
 		"module": "ESNext",

--- a/packages/frontend/editor-ui/vite.config.mts
+++ b/packages/frontend/editor-ui/vite.config.mts
@@ -221,7 +221,7 @@ export default mergeConfig(
 		base: publicPath,
 		envPrefix: ['VUE', 'N8N_ENV_FEAT'],
 		css: {
-			preprocessorMaxWorkers: true,
+			preprocessorMaxWorkers: 2,
 			preprocessorOptions: {
 				scss: {
 					additionalData: [

--- a/packages/node-dev/tsconfig.json
+++ b/packages/node-dev/tsconfig.json
@@ -6,7 +6,6 @@
 	"compilerOptions": {
 		"outDir": "dist",
 		"preserveSymlinks": true,
-		"tsBuildInfoFile": "dist/build.tsbuildinfo",
 		// TODO: remove all options below this line
 		"useUnknownInCatchVariables": false
 	},

--- a/packages/nodes-base/tsconfig.build.cjs.json
+++ b/packages/nodes-base/tsconfig.build.cjs.json
@@ -2,8 +2,7 @@
 	"extends": ["./tsconfig.json", "@n8n/typescript-config/modern/tsconfig.cjs.json"],
 	"compilerOptions": {
 		"outDir": "dist",
-		"module": "commonjs",
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo"
+		"module": "commonjs"
 	},
 	"include": [
 		"credentials/**/*.ts",

--- a/packages/nodes-base/tsconfig.json
+++ b/packages/nodes-base/tsconfig.json
@@ -7,7 +7,6 @@
 			"@utils/*": ["./utils/*"],
 			"@nodes-testing/*": ["../core/nodes-testing/*"]
 		},
-		"tsBuildInfoFile": "dist/typecheck.tsbuildinfo",
 
 		"emitDecoratorMetadata": true,
 		"experimentalDecorators": true,

--- a/packages/workflow/tsconfig.build.cjs.json
+++ b/packages/workflow/tsconfig.build.cjs.json
@@ -2,8 +2,7 @@
 	"extends": ["./tsconfig.json", "@n8n/typescript-config/modern/tsconfig.cjs.json"],
 	"compilerOptions": {
 		"rootDir": "src",
-		"outDir": "dist/cjs",
-		"tsBuildInfoFile": "dist/cjs/typecheck.tsbuildinfo"
+		"outDir": "dist/cjs"
 	},
 	"include": ["src/**/*.ts"],
 	"exclude": ["node_modules"]

--- a/scripts/reset.mjs
+++ b/scripts/reset.mjs
@@ -4,6 +4,36 @@ import { $, argv, echo, fs } from 'zx';
 $.verbose = true;
 process.env.FORCE_COLOR = '1';
 
+// `--light` (`-l`): only refresh build outputs/caches. Keeps node_modules and
+// all untracked files, skips the confirmation prompt. Use this when build
+// outputs or the turbo cache are stale (e.g. after switching branches or
+// worktrees) but dependencies haven't changed. `--no-install` skips the
+// dependency reconcile step.
+const light = argv.light || argv.l;
+
+if (light) {
+	const runInstall = argv.install !== false;
+
+	echo(
+		'⚡ Lightweight reset: keeping node_modules and untracked files, refreshing build outputs only.',
+	);
+
+	echo('🧹 Cleaning build outputs (dist, .turbo)...');
+	await $`pnpm clean`;
+
+	if (runInstall) {
+		echo('⏬ Reconciling dependencies (pnpm install)...');
+		await $`pnpm install`;
+	}
+
+	// TURBO_FORCE ignores the local artifact cache (node_modules/.cache/turbo),
+	// which `pnpm clean` does not remove, so a stale cache can't be served.
+	echo('🏗️ Force-rebuilding (TURBO_FORCE)...');
+	await $({ env: { ...process.env, TURBO_FORCE: 'true' } })`pnpm build --concurrency=50%`;
+
+	process.exit(0);
+}
+
 const excludePatterns = ['/.vscode/', '/.idea/', '.env', '/.claude/'];
 const excludeFlags = excludePatterns.map((exclude) => ['-e', exclude]).flat();
 

--- a/scripts/reset.mjs
+++ b/scripts/reset.mjs
@@ -76,5 +76,10 @@ fs.removeSync('node_modules');
 echo('⏬ Running pnpm install...');
 await $`pnpm install`;
 
-echo(`🏗️ Running pnpm build (--max-old-space-size=${mem})...`);
-await $({ env: buildEnv })`pnpm build`;
+echo(`🏗️ Running pnpm build (--max-ole-space-size=${mem})...`);
+const res = await $({ env: buildEnv })`pnpm build`;
+if (!res.ok) {
+	// Build failed on the initial full-repo build, most likely due to dart-sass being evicted.
+	// Re-trigger build, already built items are fast-tracked by turbo cache, and building continues
+	await $`pnpm build`;
+}

--- a/scripts/reset.mjs
+++ b/scripts/reset.mjs
@@ -11,6 +11,22 @@ process.env.FORCE_COLOR = '1';
 // dependency reconcile step.
 const light = argv.light || argv.l;
 
+// `--mem <MB>` raises the V8 old-space cap for each build process via
+// NODE_OPTIONS, which turbo passes through to the per-package builds. Bump it if
+// a build runs out of memory (e.g. the JS `sass` compiler). Default 8192.
+// Note: this only helps JS-heap OOMs — native `sass-embedded` compilation runs
+// in a separate Dart process that this limit does not bound; if that OOMs,
+// lower build concurrency or add system memory instead.
+const mem = argv.mem ? Number(argv.mem) : 8192;
+if (!Number.isInteger(mem) || mem <= 0) {
+	echo('❌ --mem must be a positive integer (MB)');
+	process.exit(1);
+}
+const nodeOptions = process.env.NODE_OPTIONS
+	? `${process.env.NODE_OPTIONS} --max-old-space-size=${mem}`
+	: `--max-old-space-size=${mem}`;
+const buildEnv = { ...process.env, TURBO_FORCE: 'true', NODE_OPTIONS: nodeOptions };
+
 if (light) {
 	const runInstall = argv.install !== false;
 
@@ -28,8 +44,8 @@ if (light) {
 
 	// TURBO_FORCE ignores the local artifact cache (node_modules/.cache/turbo),
 	// which `pnpm clean` does not remove, so a stale cache can't be served.
-	echo('🏗️ Force-rebuilding (TURBO_FORCE)...');
-	await $({ env: { ...process.env, TURBO_FORCE: 'true' } })`pnpm build --concurrency=50%`;
+	echo(`🏗️ Force-rebuilding (TURBO_FORCE, --max-old-space-size=${mem})...`);
+	await $({ env: buildEnv })`pnpm build`;
 
 	process.exit(0);
 }
@@ -60,5 +76,5 @@ fs.removeSync('node_modules');
 echo('⏬ Running pnpm install...');
 await $`pnpm install`;
 
-echo('🏗️ Running pnpm build...');
-await $`pnpm build --concurrency=50%`;
+echo(`🏗️ Running pnpm build (--max-old-space-size=${mem})...`);
+await $({ env: buildEnv })`pnpm build ${buildArgs}`;

--- a/scripts/reset.mjs
+++ b/scripts/reset.mjs
@@ -1,16 +1,22 @@
-// Resets the repository by deleting all untracked files except for few exceptions.
+// Resets the repository's build state. Lightweight by default (refresh build
+// outputs/caches only); pass `--full` to also delete all untracked files
+// (except a few exceptions) and reinstall dependencies.
 import { $, argv, echo, fs } from 'zx';
 
 let failedOnce = false;
 $.verbose = true;
 process.env.FORCE_COLOR = '1';
 
-// `--light` (`-l`): only refresh build outputs/caches. Keeps node_modules and
-// all untracked files, skips the confirmation prompt. Use this when build
-// outputs or the turbo cache are stale (e.g. after switching branches or
-// worktrees) but dependencies haven't changed. `--no-install` skips the
-// dependency reconcile step.
-const light = argv.light || argv.l;
+// By default this runs the lightweight reset: only refresh build
+// outputs/caches. Keeps node_modules and all untracked files, skips the
+// confirmation prompt. Use this when build outputs or the turbo cache are
+// stale (e.g. after switching branches or worktrees) but dependencies haven't
+// changed. `--no-install` skips the dependency reconcile step.
+//
+// `--full`: the heavy reset. Deletes all untracked files (except a few
+// exceptions), wipes node_modules, reinstalls dependencies, then rebuilds.
+// Reach for this only when the lightweight reset didn't fix your issue.
+const full = argv.full;
 
 // `--mem <MB>` raises the V8 old-space cap for each build process via
 // NODE_OPTIONS, which turbo passes through to the per-package builds. Bump it if
@@ -39,7 +45,7 @@ async function buildWithSingleRetry() {
 	}
 }
 
-if (light) {
+if (!full) {
 	const runInstall = argv.install !== false;
 
 	echo(
@@ -62,6 +68,12 @@ if (light) {
 	if (failedOnce) {
 		console.log("🟢 The build script failed once, but was able to recover successfully.")
 	}
+
+	echo('');
+	echo('✅ Lightweight reset done!');
+	echo(
+		"💡 Still seeing issues? Run `pnpm reset --full` for a full reset (wipes untracked files & node_modules, then reinstalls and rebuilds).",
+	);
 	process.exit(0);
 }
 const excludePatterns = ['/.vscode/', '/.idea/', '.env', '/.claude/'];

--- a/scripts/reset.mjs
+++ b/scripts/reset.mjs
@@ -1,6 +1,7 @@
 // Resets the repository by deleting all untracked files except for few exceptions.
 import { $, argv, echo, fs } from 'zx';
 
+let failedOnce = false;
 $.verbose = true;
 process.env.FORCE_COLOR = '1';
 
@@ -28,11 +29,13 @@ const nodeOptions = process.env.NODE_OPTIONS
 const buildEnv = { ...process.env, TURBO_FORCE: 'true', NODE_OPTIONS: nodeOptions };
 
 async function buildWithSingleRetry() {
-	const res = await $({ env: buildEnv })`pnpm build`;
-	if (!res.ok) {
+	const res = await $({ env: buildEnv })`pnpm build`.nothrow();
+	if (res.exitCode !== 0) {
+		failedOnce = true;
 		// Build failed on the initial full-repo build, most likely due to dart-sass being evicted.
 		// Re-trigger build, already built items are fast-tracked by turbo cache, and building continues
-		await $`pnpm build`;
+		console.log("! Build failed, most likely due to memory pressure. Retrying build");
+		await $({ env: buildEnv })`pnpm build`;
 	}
 }
 
@@ -56,6 +59,9 @@ if (light) {
 	echo(`🏗️ Force-rebuilding (TURBO_FORCE, --max-old-space-size=${mem})...`);
 	await buildWithSingleRetry();
 
+	if (failedOnce) {
+		console.log("🟢 The build script failed once, but was able to recover successfully.")
+	}
 	process.exit(0);
 }
 const excludePatterns = ['/.vscode/', '/.idea/', '.env', '/.claude/'];
@@ -84,5 +90,10 @@ fs.removeSync('node_modules');
 echo('⏬ Running pnpm install...');
 await $`pnpm install`;
 
-echo(`🏗️ Running pnpm build (--max-ole-space-size=${mem})...`);
+echo(`🏗️ Running pnpm build (--max-old-space-size=${mem})...`);
 await buildWithSingleRetry();
+
+console.log("✅ pnpm reset done!")
+if (failedOnce) {
+	console.log("🟢 The build script failed once, but was able to recover successfully.")
+}

--- a/scripts/reset.mjs
+++ b/scripts/reset.mjs
@@ -17,7 +17,7 @@ const light = argv.light || argv.l;
 // a build runs out of memory (e.g. the JS `sass` compiler). Default 8192.
 // Note: this only helps JS-heap OOMs — native `sass-embedded` compilation runs
 // in a separate Dart process that this limit does not bound; if that OOMs,
-// lower build concurrency or add system memory instead.
+// lower build concurrency or a better orchestration is needed.
 const mem = argv.mem ? Number(argv.mem) : 8192;
 if (!Number.isInteger(mem) || mem <= 0) {
 	echo('❌ --mem must be a positive integer (MB)');

--- a/scripts/reset.mjs
+++ b/scripts/reset.mjs
@@ -60,9 +60,7 @@ if (!full) {
 		await $`pnpm install`;
 	}
 
-	// TURBO_FORCE ignores the local artifact cache (node_modules/.cache/turbo),
-	// which `pnpm clean` does not remove, so a stale cache can't be served.
-	echo(`🏗️ Force-rebuilding (TURBO_FORCE, --max-old-space-size=${mem})...`);
+	echo(`🏗️ Rebuilding (--max-old-space-size=${mem})...`);
 	await buildWithSingleRetry();
 
 	if (failedOnce) {

--- a/scripts/reset.mjs
+++ b/scripts/reset.mjs
@@ -27,6 +27,15 @@ const nodeOptions = process.env.NODE_OPTIONS
 	: `--max-old-space-size=${mem}`;
 const buildEnv = { ...process.env, TURBO_FORCE: 'true', NODE_OPTIONS: nodeOptions };
 
+async function buildWithSingleRetry() {
+	const res = await $({ env: buildEnv })`pnpm build`;
+	if (!res.ok) {
+		// Build failed on the initial full-repo build, most likely due to dart-sass being evicted.
+		// Re-trigger build, already built items are fast-tracked by turbo cache, and building continues
+		await $`pnpm build`;
+	}
+}
+
 if (light) {
 	const runInstall = argv.install !== false;
 
@@ -45,11 +54,10 @@ if (light) {
 	// TURBO_FORCE ignores the local artifact cache (node_modules/.cache/turbo),
 	// which `pnpm clean` does not remove, so a stale cache can't be served.
 	echo(`🏗️ Force-rebuilding (TURBO_FORCE, --max-old-space-size=${mem})...`);
-	await $({ env: buildEnv })`pnpm build`;
+	await buildWithSingleRetry();
 
 	process.exit(0);
 }
-
 const excludePatterns = ['/.vscode/', '/.idea/', '.env', '/.claude/'];
 const excludeFlags = excludePatterns.map((exclude) => ['-e', exclude]).flat();
 
@@ -77,9 +85,4 @@ echo('⏬ Running pnpm install...');
 await $`pnpm install`;
 
 echo(`🏗️ Running pnpm build (--max-ole-space-size=${mem})...`);
-const res = await $({ env: buildEnv })`pnpm build`;
-if (!res.ok) {
-	// Build failed on the initial full-repo build, most likely due to dart-sass being evicted.
-	// Re-trigger build, already built items are fast-tracked by turbo cache, and building continues
-	await $`pnpm build`;
-}
+await buildWithSingleRetry();

--- a/scripts/reset.mjs
+++ b/scripts/reset.mjs
@@ -26,7 +26,7 @@ if (!Number.isInteger(mem) || mem <= 0) {
 const nodeOptions = process.env.NODE_OPTIONS
 	? `${process.env.NODE_OPTIONS} --max-old-space-size=${mem}`
 	: `--max-old-space-size=${mem}`;
-const buildEnv = { ...process.env, TURBO_FORCE: 'true', NODE_OPTIONS: nodeOptions };
+const buildEnv = { ...process.env, NODE_OPTIONS: nodeOptions };
 
 async function buildWithSingleRetry() {
 	const res = await $({ env: buildEnv })`pnpm build`.nothrow();

--- a/scripts/reset.mjs
+++ b/scripts/reset.mjs
@@ -77,4 +77,4 @@ echo('⏬ Running pnpm install...');
 await $`pnpm install`;
 
 echo(`🏗️ Running pnpm build (--max-old-space-size=${mem})...`);
-await $({ env: buildEnv })`pnpm build ${buildArgs}`;
+await $({ env: buildEnv })`pnpm build`;


### PR DESCRIPTION
## Summary

> [!NOTE]
> This PR started off as a pnpm reset optimization but ended up also fixing real issues in our tsBuildInfo files.
> Large part of this PR is tsconfig changes, that all aim to consolidate tsBuildInfoFile locations to the same directory

### The aim

Introduce a light variant of `pnpm reset` to trial if our main problems around pnpm resetting are solely from stale build outputs or if they actually arise from turbo cache getting confused between branches.

### What the PR contains

1. `pnpm reset` optimizations - Changed default action to a lighter version, with a suggestion to run the original full reset if needed
2. `pnpm reset --full` mode
3. tsBuildInfoFile optimizations. Moving all the build info to build output directories for cleanup, moving them away from root levels and node_modules.

---

The current `pnpm reset` does the following:

1. ensure-zx — if node_modules/.bin/zx is missing, runs a frozen-lockfile root install just to get zx
2. Confirmation prompt — warns it'll delete untracked files; skippable with --force/-f
3. git clean -fxd excluding /.vscode/, /.idea/, .env, /.claude/ — nukes all untracked files: every node_modules, every dist, every .turbo cache, build logs, generated files
4. fs.removeSync('node_modules') — belt-and-suspenders for the root node_modules
5. pnpm install — full dependency reinstall from scratch
6. pnpm build --concurrency=50% — fully cold rebuild of all ~61 packages

This is often overkill for the most common issues we use it for. The usual need is to clear stale built artifacts. 

### Solution

This PR introduces a new default "light" mode to `pnpm reset` which skips the most I/O heavy operation of `npm install`-ing everything from scratch. This operation was what took the most time, while usually was something that wasn't needed: our dependencies don't move that fast.

It did also clear out the `node_modules/.cache/turbo` directory, but turbo should be able to distinquish when cache misses happen so we should be able to trust it.

The light version only runs the following

1. `pnpm clean` to run the `clean` command in each package in the monorepo
2. (opt-outable) `pnpm install` to make sure deps are up to date
3. Runs `pnpm build` - Hitting cache where applicable

### TSBuildInfo

Some of the packages were not being completely cleaned by `pnpm clean` due to their tsBuildInfo files being ourside of the `dist` directory. Set the default location to be inside dist to help in cleanup. Affected packages:

- `./packages/testing/rules-engine/tsconfig.build.tsbuildinfo`
- `./packages/testing/test-impact/tsconfig.tsbuildinfo`
- `./packages/testing/janitor/tsconfig.tsbuildinfo`
- `./packages/testing/code-health/tsconfig.build.tsbuildinfo`
- `./packages/@n8n/eslint-plugin-community-nodes/tsconfig.build.tsbuildinfo`
- `./packages/@n8n/eslint-config/tsconfig.tsbuildinfo`


### What this PR does not resolve

The native dart-sass child process gets SIGKILLed by macOS under memory pressure because a full monorepo rebuild makes turbo recompile all ~60 packages at once (several heavy vite/sass builds plus many tsc builds) and then crashes with write EPIPE when it tries to write to the dead compiler's stdin.

This was however improved with a single-pass retry to trust the second run pulls from cache the successful runs and finishes up the rest.

## How to test

Run the example commands and see green builds

```bash
pnpm reset
```


```bash
pnpm reset --no-install
```

## Time saved:

Speedups on a new macbook without running anything but chrome instanes + music on the background, so no heavy processes. A real use case would have more heavy processes, meaning slower numbers.

```bash
time pnpm reset --full
```

> npm reset  301.51s user 162.89s system 220% cpu 3:30.74 total


```bash
time pnpm reset
```

> pnpm reset --light  19.85s user 27.44s system 261% cpu 18.097 total

> [!Note]
> This is a trial branch for the `pnpm reset` command that is to be iterated depending on engineer feedback. 

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
