### PR TITLE
refactor(core): Drop redundant top-level spread in in-isolate jmespath

### DIFF
--- a/packages/@n8n/expression-runtime/src/runtime/jmespath.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/jmespath.ts
@@ -47,7 +47,14 @@ const unsafeJmespathPropertyPattern = new RegExp(
  * Behavioural parity with the host wrapper:
  *   - Throws `ExpressionError` (same name) when args are wrong.
  *   - Rejects queries that contain unsafe property tokens.
- *   - Spreads non-array, non-null objects to drop proxies at the top level.
+ *
+ * Unlike the host wrapper, this version does NOT spread `data` before
+ * querying. Host-side, the top-level spread exists to strip proxies off
+ * the data before handing it to jmespath; in-isolate that is a no-op
+ * (nested values stay lazy proxies either way, and the isolate boundary
+ * already prevents host-object leakage), while spreading a lazy proxy
+ * (e.g. `$json`) would cost one synchronous host roundtrip per top-level
+ * key before the query even runs.
  *
  * Note on lazy proxies: when `data` is a lazy proxy (e.g. `$json`), each
  * property access during `jmespath.search` triggers a synchronous host
@@ -69,10 +76,5 @@ export function jmesPath(data: unknown, query: string): unknown {
 		);
 	}
 
-	if (data !== null && !Array.isArray(data) && typeof data === 'object') {
-		return jmespath.search({ ...(data as Record<string, unknown>) }, query);
-	}
-
-	// Array or null — pass through to jmespath which accepts both
 	return jmespath.search(data as never, query);
 }

--- a/packages/@n8n/expression-runtime/src/runtime/jmespath.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/jmespath.ts
@@ -36,25 +36,26 @@ const unsafeJmespathPropertyPattern = new RegExp(
 /**
  * In-isolate `$jmespath` / `$jmesPath` implementation.
  *
- * Mirrors the host-side wrapper in `packages/workflow/src/workflow-data-proxy.ts`
- * so that expressions resolve `$jmespath` from the in-isolate runtime via
- * Tournament's polyfill. `$jmespath` is a pure utility — it takes its
- * data as an argument and runs a query on it, with no need for host
- * context. Keeping it in-isolate means it does not appear as a
- * host-callable on the bridge, which shrinks the host-callable surface
- * the isolate can reach.
+ * In-isolate counterpart of the host-side wrapper in
+ * `packages/workflow/src/workflow-data-proxy.ts`, so that expressions
+ * resolve `$jmespath` from the in-isolate runtime via Tournament's
+ * polyfill. `$jmespath` is a pure utility — it takes its data as an
+ * argument and runs a query on it, with no need for host context.
+ * Keeping it in-isolate means it does not appear as a host-callable on
+ * the bridge, which shrinks the host-callable surface the isolate can
+ * reach.
  *
- * Behavioural parity with the host wrapper:
+ * Relationship to the host wrapper — same observable contract,
+ * deliberately different internals:
  *   - Throws `ExpressionError` (same name) when args are wrong.
  *   - Rejects queries that contain unsafe property tokens.
- *
- * Unlike the host wrapper, this version does NOT spread `data` before
- * querying. Host-side, the top-level spread exists to strip proxies off
- * the data before handing it to jmespath; in-isolate that is a no-op
- * (nested values stay lazy proxies either way, and the isolate boundary
- * already prevents host-object leakage), while spreading a lazy proxy
- * (e.g. `$json`) would cost one synchronous host roundtrip per top-level
- * key before the query even runs.
+ *   - Does NOT spread `data` before querying. Host-side, the top-level
+ *     spread exists to strip proxies off the data before handing it to
+ *     jmespath; in-isolate that is a no-op (nested values stay lazy
+ *     proxies either way, and the isolate boundary already prevents
+ *     host-object leakage), while spreading a lazy proxy (e.g. `$json`)
+ *     would cost one synchronous host roundtrip per top-level key
+ *     before the query even runs.
  *
  * Note on lazy proxies: when `data` is a lazy proxy (e.g. `$json`), each
  * property access during `jmespath.search` triggers a synchronous host


### PR DESCRIPTION
## Summary

Removes the top-level object spread from the in-isolate `$jmespath` implementation (`packages/@n8n/expression-runtime/src/runtime/jmespath.ts`), passing `data` directly to `jmespath.search`.

**Why the spread existed:** it mirrored the host-side wrapper in `packages/workflow/src/workflow-data-proxy.ts`, where spreading strips proxies off the data at the top level before handing it to jmespath. That host-side spread is load-bearing for the legacy engine and is untouched by this PR.

**Why it is a no-op in-isolate:** nested values remain lazy proxies either way, and the isolate boundary already prevents host-object leakage — so the spread provided no isolation benefit inside the isolate.

**What it cost:** when `data` is a lazy proxy (e.g. `$json`), spreading iterates every top-level key, triggering one synchronous host roundtrip (`getValueAtPath`) per key on every `$jmespath` invocation, before the query even runs. Passing the proxy directly lets `jmespath.search` touch only the keys the query actually needs.

With the spread gone, both branches of the surrounding `if` were identical, so they are collapsed into a single `jmespath.search(data, query)` call. The docstring is updated to explain why the in-isolate version deliberately does not spread.

## How to test

No behaviour change — existing dual-engine parity tests are the regression net:

- `pnpm --filter @n8n/expression-runtime build` (rebuilds the IIFE bundle the isolate loads)
- `pnpm --filter @n8n/expression-runtime test` — 339 passing
- `pnpm --filter=n8n-workflow test test/expression.test.ts test/workflow-data-proxy.test.ts` — 710 passing (covers `$jmespath` parity across both engines, including security-token rejection and proxy behaviour)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2982

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!-- existing dual-engine parity tests cover this path; no new behaviour to test -->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI