### PR TITLE
refactor(core): Assert typed-RPC registry completeness at compile time

### DIFF
--- a/packages/@n8n/expression-runtime/src/runtime/context.ts
+++ b/packages/@n8n/expression-runtime/src/runtime/context.ts
@@ -27,7 +27,8 @@ const SafeURIError = createSafeErrorSubclass(URIError);
  * the bridge dispatches on. Single source of truth for the synthetic proxy's
  * `get`/`has` traps and the `sendNodeMethod` envelope builder. Adding a new
  * `getNode*` schema to `BridgeMessage` lets you wire a new method here in
- * one place; `satisfies` catches typos in the discriminator string.
+ * one place; `satisfies` catches typos in the discriminator string and the
+ * completeness assertions below catch omissions.
  */
 const NODE_RPC_TYPES = {
 	first: 'getNodeFirst',
@@ -46,6 +47,41 @@ const INPUT_RPC_TYPES = {
 	all: 'getInputAll',
 } as const satisfies Record<string, BridgeMessage['type']>;
 type InputRpcType = (typeof INPUT_RPC_TYPES)[keyof typeof INPUT_RPC_TYPES];
+
+/**
+ * Completeness assertions for the registries above.
+ *
+ * `satisfies` on the maps catches typos in the discriminator strings but not
+ * omissions: a new `getNode*` / `getInput*` schema added to `BridgeMessage`
+ * without a registry entry would compile fine and silently fall through to
+ * the lazy-proxy delegation path. These assertions close that gap — when a
+ * discriminator is missing from a registry's values, the corresponding
+ * `AllRouted` type resolves to `never` and the `true` assignment fails to
+ * compile, pointing here.
+ *
+ * The paired-item cluster (`getNodePairedItem` / `getNodeItemMatching` /
+ * `getNodeItem`) is exempt: those three have divergent call signatures
+ * (`.item` is a getter, the other two are methods taking an item index), so
+ * they are wired as dedicated trap branches inside `target.$` rather than
+ * through the registry.
+ */
+type PairedItemRpcType = Extract<
+	BridgeMessage['type'],
+	'getNodePairedItem' | 'getNodeItemMatching' | 'getNodeItem'
+>;
+type AllRouted<All extends string, Routed extends string> = [Exclude<All, Routed>] extends [never]
+	? true
+	: never;
+const allNodeRpcsRouted: AllRouted<
+	Exclude<Extract<BridgeMessage['type'], `getNode${string}`>, PairedItemRpcType>,
+	NodeRpcType
+> = true;
+void allNodeRpcsRouted;
+const allInputRpcsRouted: AllRouted<
+	Extract<BridgeMessage['type'], `getInput${string}`>,
+	InputRpcType
+> = true;
+void allInputRpcsRouted;
 
 // ============================================================================
 // Build Context Function


### PR DESCRIPTION
## Summary

Adds compile-time completeness assertions for the typed-RPC registries in the in-isolate runtime context. ~37 lines, type-level only, zero runtime change.

### Problem

`NODE_RPC_TYPES` / `INPUT_RPC_TYPES` map proxy property names (`first`, `last`, `all`) to typed-RPC discriminators. Their `satisfies Record<string, BridgeMessage['type']>` annotation catches **typos** in the discriminator strings, but not **omissions**: adding a new `getNode*` / `getInput*` schema to the `BridgeMessage` union without a registry entry compiles fine, and the new property silently falls through to the lazy-proxy delegation path (which resolves function-typed values to `undefined`).

### Fix

Type-level assertions after the registries: `AllRouted<All, Routed>` resolves to `never` when any discriminator extracted from `BridgeMessage` (by `getNode`/`getInput` prefix) is missing from a registry's values, so the `const ...: AllRouted<...> = true` assignment fails compilation at the assertion site.

The paired-item cluster (`getNodePairedItem` / `getNodeItemMatching` / `getNodeItem`) is exempt via an `Extract`-tied carve-out: those three are wired as dedicated trap branches (divergent call signatures — `.item` is a getter), not through the registry. Because the carve-out names are `Extract`ed from the union, renaming or removing one of those schemas still surfaces as a compile error.

The registries themselves are untouched — same shape, same readability, byte-identical runtime behavior.

### Verification

- Negative compile probe: a temporary fake `getNodeFake` schema in `bridgeMessageSchema` fails compilation twice — at the host dispatcher's exhaustiveness check (`isolated-vm-bridge.ts:479`) and at the new assertion (`context.ts:75: Type 'true' is not assignable to type 'never'`). Probe reverted, not committed.
- `pnpm --filter @n8n/expression-runtime test` — 339 passed.
- `pnpm --filter=n8n-workflow test test/expression.test.ts test/workflow-data-proxy.test.ts` — 710 passed (legacy + vm engines).
- Typecheck clean.

## Related Linear tickets, Github issues, and Community forum posts

- Linear: https://linear.app/n8n/issue/CAT-2982

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Docs updated or follow-up ticket created. _(N/A — type-level only, no behavior change.)_
- [x] Tests included. _(Existing suites are the regression net; the completeness check is itself a compile-time test.)_
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
- N/A — I have notified the Product Manager _(internal refactor, no user-facing change)_

🤖 PR Summary generated by AI
