### PR TITLE
perf(editor): Use sendBeacon and idle callbacks for telemetry

### DIFF
--- a/packages/cli/src/controllers/__tests__/telemetry.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/telemetry.controller.test.ts
@@ -5,6 +5,11 @@ import { Container } from '@n8n/di';
 import type { NextFunction, Response } from 'express';
 import { mock } from 'jest-mock-extended';
 
+type ProxyRequest = {
+	removeHeader: jest.Mock;
+	setHeader: jest.Mock;
+	write: jest.Mock;
+};
 type ProxyResponse = { headers: Record<string, string> };
 type ProxyErrorResponse = {
 	headersSent?: boolean;
@@ -13,7 +18,7 @@ type ProxyErrorResponse = {
 };
 type ProxyOptions = {
 	on?: {
-		proxyReq?: (proxyReq: { removeHeader: jest.Mock }, req: AuthenticatedRequest) => void;
+		proxyReq?: (proxyReq: ProxyRequest, req: AuthenticatedRequest) => void;
 		proxyRes?: (proxyRes: ProxyResponse) => void;
 		error?: (error: Error, req: AuthenticatedRequest, res: ProxyErrorResponse) => void;
 	};
@@ -63,8 +68,16 @@ function createResponse() {
 	return res as unknown as jest.Mocked<Response>;
 }
 
-function createRequest(headers: Record<string, string> = {}) {
-	return { headers } as AuthenticatedRequest;
+function createRequest(headers: Record<string, string> = {}, body?: unknown) {
+	return { headers, body } as AuthenticatedRequest;
+}
+
+function createProxyRequest(): ProxyRequest {
+	return {
+		removeHeader: jest.fn(),
+		setHeader: jest.fn(),
+		write: jest.fn(),
+	};
 }
 
 function getProxyOptions() {
@@ -128,15 +141,41 @@ describe('TelemetryController', () => {
 		expect(mockProxy).toHaveBeenCalledWith(req, res, next);
 	});
 
+	it('applies CORS before proxying beacon batch calls', async () => {
+		const controller = createController();
+		const req = createRequest();
+		const res = createResponse();
+		const next = jest.fn() as NextFunction;
+
+		await controller.batch(req, res, next);
+
+		expect(res.setHeader).toHaveBeenCalledWith('Access-Control-Allow-Origin', '*');
+		expect(mockProxy).toHaveBeenCalledWith(req, res, next);
+	});
+
 	it('keeps proxy request body handling and strips cookies', () => {
 		createController();
-		const proxyReq = { removeHeader: jest.fn() };
+		const proxyReq = createProxyRequest();
 		const req = createRequest();
 
 		getProxyOptions().on?.proxyReq?.(proxyReq, req);
 
 		expect(proxyReq.removeHeader).toHaveBeenCalledWith('cookie');
 		expect(mockFixRequestBody).toHaveBeenCalledWith(proxyReq, req);
+	});
+
+	it('re-writes string request bodies to the proxied request', () => {
+		createController();
+		const proxyReq = createProxyRequest();
+		const body = JSON.stringify({ batch: [{ event: 'test' }] });
+		const req = createRequest({}, body);
+
+		getProxyOptions().on?.proxyReq?.(proxyReq, req);
+
+		expect(proxyReq.removeHeader).toHaveBeenCalledWith('cookie');
+		expect(proxyReq.setHeader).toHaveBeenCalledWith('content-length', Buffer.byteLength(body));
+		expect(proxyReq.write).toHaveBeenCalledWith(body);
+		expect(mockFixRequestBody).not.toHaveBeenCalled();
 	});
 
 	it('normalizes upstream CORS headers on proxied responses', () => {

--- a/packages/cli/src/controllers/telemetry.controller.ts
+++ b/packages/cli/src/controllers/telemetry.controller.ts
@@ -18,13 +18,14 @@ export class TelemetryController {
 			on: {
 				proxyReq: (proxyReq, req) => {
 					proxyReq.removeHeader('cookie');
-					if (typeof req.body === 'string' && req.body.length > 0) {
+					const body = 'body' in req ? req.body : undefined;
+					if (typeof body === 'string' && body.length > 0) {
 						// `text/plain` payloads (e.g. `sendBeacon` batches) are parsed into a
 						// string by our body parser, which also consumes the request stream.
 						// `fixRequestBody` only re-writes json/urlencoded/multipart bodies, so
 						// re-write string bodies explicitly to keep the proxied request intact.
-						proxyReq.setHeader('content-length', Buffer.byteLength(req.body));
-						proxyReq.write(req.body);
+						proxyReq.setHeader('content-length', Buffer.byteLength(body));
+						proxyReq.write(body);
 						return;
 					}
 					fixRequestBody(proxyReq, req);

--- a/packages/cli/src/controllers/telemetry.controller.ts
+++ b/packages/cli/src/controllers/telemetry.controller.ts
@@ -18,6 +18,15 @@ export class TelemetryController {
 			on: {
 				proxyReq: (proxyReq, req) => {
 					proxyReq.removeHeader('cookie');
+					if (typeof req.body === 'string' && req.body.length > 0) {
+						// `text/plain` payloads (e.g. `sendBeacon` batches) are parsed into a
+						// string by our body parser, which also consumes the request stream.
+						// `fixRequestBody` only re-writes json/urlencoded/multipart bodies, so
+						// re-write string bodies explicitly to keep the proxied request intact.
+						proxyReq.setHeader('content-length', Buffer.byteLength(req.body));
+						proxyReq.write(req.body);
+						return;
+					}
 					fixRequestBody(proxyReq, req);
 					return;
 				},
@@ -94,6 +103,19 @@ export class TelemetryController {
 	// cookie-stripped, rate-limited, and proxies only to the fixed diagnostics target.
 	@Post('/proxy/:version/page', { skipAuth: true, ipRateLimit: { limit: 50, windowMs: 60_000 } })
 	async page(req: AuthenticatedRequest, res: Response, next: NextFunction) {
+		this.applyCors(req, res);
+		await this.proxy(req, res, next);
+	}
+
+	// Public telemetry passthrough: no scope decorator. The endpoint is unauthenticated,
+	// cookie-stripped, rate-limited, and proxies only to the fixed diagnostics target.
+	// Used by the RudderStack SDK in beacon mode, which sends event batches to
+	// `<dataPlaneUrl>/beacon/v1/batch` via `navigator.sendBeacon`.
+	@Post('/proxy/beacon/:version/batch', {
+		skipAuth: true,
+		ipRateLimit: { limit: 100, windowMs: 60_000 },
+	})
+	async batch(req: AuthenticatedRequest, res: Response, next: NextFunction) {
 		this.applyCors(req, res);
 		await this.proxy(req, res, next);
 	}

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -139,6 +139,11 @@ vi.mock('@/app/composables/useTelemetry', () => {
 	};
 });
 
+// Run idle-deferred work (e.g. node-graph telemetry payloads) synchronously
+vi.mock('@/app/utils/idleUtils', () => ({
+	runWhenIdle: (fn: () => void) => fn(),
+}));
+
 vi.mock('@/app/composables/useToast', () => {
 	const showMessage = vi.fn();
 	const showError = vi.fn();

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -132,6 +132,7 @@ import { computed, nextTick, ref, type DeepReadonly } from 'vue';
 import { useUniqueNodeName } from '@/app/composables/useUniqueNodeName';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 import { isPresent, tryToParseNumber } from '@/app/utils/typesUtils';
+import { runWhenIdle } from '@/app/utils/idleUtils';
 import { ensureNodePosition, sanitizeConnections } from '@/app/utils/workflowUtils';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import type { CanvasLayoutEvent } from '@/features/workflows/canvas/composables/useCanvasLayout';
@@ -2887,8 +2888,11 @@ export function useCanvasOperations() {
 
 			removeUnknownCredentials(workflowData);
 
-			try {
-				if (trackEvents) {
+			if (trackEvents) {
+				// Building the node-graph payload walks the entire imported workflow, which
+				// is expensive on large workflows — keep it off the interaction path.
+				// `runWhenIdle` also swallows errors: if telemetry fails, don't throw.
+				runWhenIdle(() => {
 					const nodeGraph = JSON.stringify(
 						TelemetryHelpers.generateNodesGraph(
 							workflowData as IWorkflowBase,
@@ -2921,9 +2925,7 @@ export function useCanvasOperations() {
 							node_graph_string: nodeGraph,
 						});
 					}
-				}
-			} catch {
-				// If telemetry fails, don't throw an error
+				});
 			}
 
 			// Fix the node position as it could be totally offscreen

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -34,6 +34,7 @@ import {
 	getExecutionErrorToastConfiguration,
 } from '@/features/execution/executions/executions.utils';
 import { getTriggerNodeServiceName } from '@/app/utils/nodeTypesUtils';
+import { runWhenIdle } from '@/app/utils/idleUtils';
 import type { ExecutionFinished } from '@n8n/api-types/push/execution';
 import { useI18n } from '@n8n/i18n';
 import type {
@@ -353,37 +354,41 @@ export function handleExecutionFinishedWithErrorOrCanceled(
 	) {
 		const error = runExecutionData.resultData.error as ExpressionError;
 
-		const workflowData = workflowDocumentStore.serialize();
-		const eventData: IDataObject = {
-			caused_by_credential: false,
-			error_message: error.description,
-			error_title: error.message,
-			error_type: error.context.type,
-			node_graph_string: JSON.stringify(
-				TelemetryHelpers.generateNodesGraph(
-					workflowData as IWorkflowBase,
-					workflowHelpers.getNodeTypes(),
-				).nodeGraph,
-			),
-			workflow_id: workflowDocumentStore.workflowId,
-		};
+		// Building the node-graph payload serializes and walks the entire workflow,
+		// which is expensive on large workflows — keep it off the execution hot path.
+		runWhenIdle(() => {
+			const workflowData = workflowDocumentStore.serialize();
+			const eventData: IDataObject = {
+				caused_by_credential: false,
+				error_message: error.description,
+				error_title: error.message,
+				error_type: error.context.type,
+				node_graph_string: JSON.stringify(
+					TelemetryHelpers.generateNodesGraph(
+						workflowData as IWorkflowBase,
+						workflowHelpers.getNodeTypes(),
+					).nodeGraph,
+				),
+				workflow_id: workflowDocumentStore.workflowId,
+			};
 
-		if (
-			error.context.nodeCause &&
-			['paired_item_no_info', 'paired_item_invalid_info'].includes(error.context.type as string)
-		) {
-			const node = workflowDocumentStore.getNodeByName(error.context.nodeCause as string);
+			if (
+				error.context.nodeCause &&
+				['paired_item_no_info', 'paired_item_invalid_info'].includes(error.context.type as string)
+			) {
+				const node = workflowDocumentStore.getNodeByName(error.context.nodeCause as string);
 
-			if (node) {
-				eventData.is_pinned = !!workflowDocumentStore.pinnedDataByNodeName?.[node.name];
-				eventData.mode = node.parameters.mode;
-				eventData.node_type = node.type;
-				eventData.operation = node.parameters.operation;
-				eventData.resource = node.parameters.resource;
+				if (node) {
+					eventData.is_pinned = !!workflowDocumentStore.pinnedDataByNodeName?.[node.name];
+					eventData.mode = node.parameters.mode;
+					eventData.node_type = node.type;
+					eventData.operation = node.parameters.operation;
+					eventData.resource = node.parameters.resource;
+				}
 			}
-		}
 
-		telemetry.track('Instance FE emitted paired item error', eventData);
+			telemetry.track('Instance FE emitted paired item error', eventData);
+		});
 	}
 
 	if (execution.status === 'canceled') {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/trackNodeExecution.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/trackNodeExecution.ts
@@ -7,6 +7,7 @@ import {
 	useWorkflowDocumentStore,
 } from '@/app/stores/workflowDocument.store';
 import { TelemetryHelpers } from 'n8n-workflow';
+import { runWhenIdle } from '@/app/utils/idleUtils';
 
 export async function trackNodeExecution(
 	pushData: PushPayload<'nodeExecuteAfter'>,
@@ -15,25 +16,30 @@ export async function trackNodeExecution(
 	const nodeName = pushData.nodeName;
 
 	if (pushData.data.error) {
-		const telemetry = useTelemetry();
-		const workflowHelpers = useWorkflowHelpers();
-		const settingsStore = useSettingsStore();
-		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
-		const node = workflowDocumentStore.getNodeByName(nodeName);
-		telemetry.track('Manual exec errored', {
-			error_title: pushData.data.error.message,
-			node_type: node?.type,
-			node_type_version: node?.typeVersion,
-			node_id: node?.id,
-			node_graph_string: JSON.stringify(
-				TelemetryHelpers.generateNodesGraph(
-					workflowDocumentStore.serialize(),
-					workflowHelpers.getNodeTypes(),
-					{
-						isCloudDeployment: settingsStore.isCloudDeployment,
-					},
-				).nodeGraph,
-			),
+		const error = pushData.data.error;
+		// Building the node-graph payload serializes and walks the entire workflow,
+		// which is expensive on large workflows — keep it off the execution hot path.
+		runWhenIdle(() => {
+			const telemetry = useTelemetry();
+			const workflowHelpers = useWorkflowHelpers();
+			const settingsStore = useSettingsStore();
+			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+			const node = workflowDocumentStore.getNodeByName(nodeName);
+			telemetry.track('Manual exec errored', {
+				error_title: error.message,
+				node_type: node?.type,
+				node_type_version: node?.typeVersion,
+				node_id: node?.id,
+				node_graph_string: JSON.stringify(
+					TelemetryHelpers.generateNodesGraph(
+						workflowDocumentStore.serialize(),
+						workflowHelpers.getNodeTypes(),
+						{
+							isCloudDeployment: settingsStore.isCloudDeployment,
+						},
+					).nodeGraph,
+				),
+			});
 		});
 	}
 }

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
@@ -196,6 +196,11 @@ vi.mock('@/app/composables/useTelemetry', () => ({
 	useTelemetry: vi.fn().mockReturnValue({ track: vi.fn() }),
 }));
 
+// Run idle-deferred work (e.g. node-graph telemetry payloads) synchronously
+vi.mock('@/app/utils/idleUtils', () => ({
+	runWhenIdle: (fn: () => void) => fn(),
+}));
+
 vi.mock('@n8n/i18n', () => ({
 	i18n: { baseText: vi.fn().mockImplementation((key) => key) },
 	useI18n: vi.fn().mockReturnValue({ baseText: vi.fn().mockImplementation((key) => key) }),

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
@@ -48,6 +48,7 @@ import { useExternalHooks } from '@/app/composables/useExternalHooks';
 import { useWorkflowHelpers } from '@/app/composables/useWorkflowHelpers';
 import type { useRouter } from 'vue-router';
 import { isEmpty } from '@/app/utils/typesUtils';
+import { runWhenIdle } from '@/app/utils/idleUtils';
 import { useI18n } from '@n8n/i18n';
 import get from 'lodash/get';
 import { useExecutionsStore } from '@/features/execution/executions/executions.store';
@@ -609,20 +610,24 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 	}
 
 	async function runEntireWorkflow(source: 'node' | 'main', triggerNode?: string) {
-		const workflowData = workflowDocumentStore.value.serialize();
-		const telemetryPayload = {
-			workflow_id: workflowDocumentStore.value.workflowId,
-			node_graph_string: JSON.stringify(
-				TelemetryHelpers.generateNodesGraph(
-					workflowData as IWorkflowBase,
-					workflowHelpers.getNodeTypes(),
-					{ isCloudDeployment: settingsStore.isCloudDeployment },
-				).nodeGraph,
-			),
-			button_type: source,
-		};
-		telemetry.track('User clicked execute workflow button', telemetryPayload);
-		void externalHooks.run('nodeView.onRunWorkflow', telemetryPayload);
+		// Building the node-graph payload serializes and walks the entire workflow,
+		// which is expensive on large workflows — keep it off the interaction path.
+		runWhenIdle(() => {
+			const workflowData = workflowDocumentStore.value.serialize();
+			const telemetryPayload = {
+				workflow_id: workflowDocumentStore.value.workflowId,
+				node_graph_string: JSON.stringify(
+					TelemetryHelpers.generateNodesGraph(
+						workflowData as IWorkflowBase,
+						workflowHelpers.getNodeTypes(),
+						{ isCloudDeployment: settingsStore.isCloudDeployment },
+					).nodeGraph,
+				),
+				button_type: source,
+			};
+			telemetry.track('User clicked execute workflow button', telemetryPayload);
+			void externalHooks.run('nodeView.onRunWorkflow', telemetryPayload);
+		});
 
 		let resolvedTriggerNode = triggerNode ?? workflowExecutionState.value.selectedTriggerNodeName;
 

--- a/packages/frontend/editor-ui/src/app/plugins/telemetry.test.ts
+++ b/packages/frontend/editor-ui/src/app/plugins/telemetry.test.ts
@@ -184,6 +184,51 @@ describe('telemetry', () => {
 		});
 	});
 
+	describe('init', () => {
+		it('should load RudderStack with beacon transport enabled', () => {
+			const rudderanalyticsBackup = window.rudderanalytics;
+			window.rudderanalytics = undefined as unknown as typeof window.rudderanalytics;
+
+			try {
+				const freshTelemetry = new Telemetry();
+				freshTelemetry.init(
+					{
+						enabled: true,
+						config: {
+							proxy: 'https://proxy.test',
+							key: 'test-key',
+							sourceConfig: 'https://source-config.test',
+							url: '',
+						},
+					},
+					{ versionCli: '1', instanceId: '1' },
+				);
+
+				// before the SDK script loads, calls are queued as [method, ...args] tuples
+				const loadCall = Array.from(window.rudderanalytics as unknown as unknown[][]).find(
+					(call) => Array.isArray(call) && call[0] === 'load',
+				);
+				expect(loadCall).toEqual([
+					'load',
+					'test-key',
+					'https://proxy.test',
+					{
+						integrations: { All: false },
+						loadIntegration: false,
+						configUrl: 'https://source-config.test',
+						useBeacon: true,
+						beaconQueueOptions: {
+							maxItems: 10,
+							flushQueueInterval: 10_000,
+						},
+					},
+				]);
+			} finally {
+				window.rudderanalytics = rudderanalyticsBackup;
+			}
+		});
+	});
+
 	describe('track function', () => {
 		it('should call Rudderstack track method with correct parameters', () => {
 			const trackFunction = vi.spyOn(window.rudderanalytics, 'track');

--- a/packages/frontend/editor-ui/src/app/plugins/telemetry/index.ts
+++ b/packages/frontend/editor-ui/src/app/plugins/telemetry/index.ts
@@ -61,6 +61,17 @@ export class Telemetry {
 			integrations: { All: false },
 			loadIntegration: false,
 			configUrl: sourceConfig,
+			// Batch events and send them via `navigator.sendBeacon` to keep telemetry
+			// network work off the critical path. Falls back to per-event XHR in
+			// browsers without `sendBeacon` support.
+			useBeacon: true,
+			beaconQueueOptions: {
+				// Flush when 10 events are queued (SDK default)
+				maxItems: 10,
+				// Flush at least every 10s. The SDK default (10 minutes) is too lossy:
+				// the queue is in-memory only and is not flushed on page unload.
+				flushQueueInterval: 10_000,
+			},
 		});
 
 		this.identify({ instanceId, userId, versionCli, projectId, userRole });

--- a/packages/frontend/editor-ui/src/app/utils/idleUtils.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/idleUtils.test.ts
@@ -1,0 +1,62 @@
+import { DEBOUNCE_TIME } from '@/app/constants';
+import { runWhenIdle } from '@/app/utils/idleUtils';
+
+describe('runWhenIdle', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.useRealTimers();
+	});
+
+	it('should run the callback via requestIdleCallback when available', () => {
+		const requestIdleCallback = vi.fn((callback: IdleRequestCallback) => {
+			callback({ didTimeout: false, timeRemaining: () => 50 } as IdleDeadline);
+			return 1;
+		});
+		vi.stubGlobal('requestIdleCallback', requestIdleCallback);
+		const fn = vi.fn();
+
+		runWhenIdle(fn, { timeout: 1234 });
+
+		expect(requestIdleCallback).toHaveBeenCalledWith(expect.any(Function), { timeout: 1234 });
+		expect(fn).toHaveBeenCalledTimes(1);
+	});
+
+	it('should use the telemetry batch debounce time as the default timeout', () => {
+		const requestIdleCallback = vi.fn();
+		vi.stubGlobal('requestIdleCallback', requestIdleCallback);
+
+		runWhenIdle(vi.fn());
+
+		expect(requestIdleCallback).toHaveBeenCalledWith(expect.any(Function), {
+			timeout: DEBOUNCE_TIME.TELEMETRY.BATCH,
+		});
+	});
+
+	it('should fall back to a macrotask when requestIdleCallback is unavailable', () => {
+		vi.stubGlobal('requestIdleCallback', undefined);
+		vi.useFakeTimers();
+		const fn = vi.fn();
+
+		runWhenIdle(fn);
+
+		expect(fn).not.toHaveBeenCalled();
+		vi.runAllTimers();
+		expect(fn).toHaveBeenCalledTimes(1);
+	});
+
+	it('should swallow errors thrown by the callback', () => {
+		vi.stubGlobal(
+			'requestIdleCallback',
+			vi.fn((callback: IdleRequestCallback) => {
+				callback({ didTimeout: false, timeRemaining: () => 50 } as IdleDeadline);
+				return 1;
+			}),
+		);
+
+		expect(() =>
+			runWhenIdle(() => {
+				throw new Error('boom');
+			}),
+		).not.toThrow();
+	});
+});

--- a/packages/frontend/editor-ui/src/app/utils/idleUtils.ts
+++ b/packages/frontend/editor-ui/src/app/utils/idleUtils.ts
@@ -1,0 +1,30 @@
+import { DEBOUNCE_TIME } from '@/app/constants';
+
+/**
+ * Runs `fn` when the main thread is idle (via `requestIdleCallback`), falling
+ * back to a macrotask in environments without `requestIdleCallback` support
+ * (Safari < 18, jsdom).
+ *
+ * Intended for non-critical work, e.g. computing telemetry payloads, so it
+ * stays off the interaction path. Because of that:
+ * - errors thrown by `fn` are swallowed
+ * - `fn` may never run if the tab is closed before the callback fires
+ *
+ * `timeout` guarantees `fn` runs within that many milliseconds even if the
+ * main thread never goes idle.
+ */
+export function runWhenIdle(fn: () => void, { timeout = DEBOUNCE_TIME.TELEMETRY.BATCH } = {}) {
+	const run = () => {
+		try {
+			fn();
+		} catch {
+			// non-critical work, don't propagate errors
+		}
+	};
+
+	if (typeof window.requestIdleCallback === 'function') {
+		window.requestIdleCallback(run, { timeout });
+	} else {
+		setTimeout(run, 0);
+	}
+}

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
@@ -31,6 +31,8 @@ import {
 	CORE_NODES_CATEGORY,
 	DATA_EDITING_DOCS_URL,
 	DATA_PINNING_DOCS_URL,
+	DEBOUNCE_TIME,
+	getDebounceTime,
 	HTML_NODE_TYPE,
 	LOCAL_STORAGE_PIN_DATA_DISCOVERY_CANVAS_FLAG,
 	LOCAL_STORAGE_PIN_DATA_DISCOVERY_NDV_FLAG,
@@ -72,7 +74,7 @@ import isEqual from 'lodash/isEqual';
 import isObject from 'lodash/isObject';
 import { useRoute, useRouter } from 'vue-router';
 import { useSchemaPreviewStore } from '@/features/ndv/runData/schemaPreview.store';
-import { asyncComputed } from '@vueuse/core';
+import { asyncComputed, useDebounceFn } from '@vueuse/core';
 import ViewSubExecution from '@/features/execution/executions/components/ViewSubExecution.vue';
 import RunDataItemCount from './RunDataItemCount.vue';
 import RunDataDisplayModeSelect from './RunDataDisplayModeSelect.vue';
@@ -1148,8 +1150,9 @@ function unlinkRun() {
 	emit('unlinkRun');
 }
 
-function onCurrentPageChange(value: number) {
-	currentPage.value = value;
+// Debounced so rapidly paging through items emits a single event with the
+// final state instead of one event per click.
+const trackCurrentPageChange = useDebounceFn(() => {
 	telemetry.track('User changed ndv page', {
 		node_type: activeNode.value?.type,
 		workflow_id: workflowId.value,
@@ -1159,6 +1162,11 @@ function onCurrentPageChange(value: number) {
 		page_size: pageSize.value,
 		items_total: dataCount.value,
 	});
+}, getDebounceTime(DEBOUNCE_TIME.TELEMETRY.TRACK));
+
+function onCurrentPageChange(value: number) {
+	currentPage.value = value;
+	void trackCurrentPageChange();
 }
 
 function resetCurrentPageIfTooFar() {
@@ -1168,11 +1176,9 @@ function resetCurrentPageIfTooFar() {
 	}
 }
 
-function onPageSizeChange(newPageSize: number) {
-	pageSize.value = newPageSize;
-
-	resetCurrentPageIfTooFar();
-
+// Debounced so rapidly switching page sizes emits a single event with the
+// final state instead of one event per change.
+const trackPageSizeChange = useDebounceFn(() => {
 	telemetry.track('User changed ndv page size', {
 		node_type: activeNode.value?.type,
 		workflow_id: workflowId.value,
@@ -1182,6 +1188,14 @@ function onPageSizeChange(newPageSize: number) {
 		page_size: pageSize.value,
 		items_total: dataCount.value,
 	});
+}, getDebounceTime(DEBOUNCE_TIME.TELEMETRY.TRACK));
+
+function onPageSizeChange(newPageSize: number) {
+	pageSize.value = newPageSize;
+
+	resetCurrentPageIfTooFar();
+
+	void trackPageSizeChange();
 }
 
 function onDisplayModeChange(newDisplayMode: IRunDataDisplayMode) {


### PR DESCRIPTION
## Summary

Moves telemetry work off the critical interaction and execution paths in two ways:

1. **`navigator.sendBeacon` for network delivery** — configures the RudderStack SDK to batch events and send them via `sendBeacon` (10-event queue, flushed every 10 s). This keeps telemetry XHRs off the critical path. A new `/rest/telemetry/proxy/beacon/:version/batch` passthrough endpoint is added to the backend to accept the `text/plain` bodies that `sendBeacon` sends, and the proxy is fixed to re-stream string bodies (which `fixRequestBody` skips).

2. **`requestIdleCallback` for payload computation** — node-graph serialisation (walking + serialising the full workflow) is now deferred via a new `runWhenIdle` utility (`requestIdleCallback` with a `setTimeout` fallback). Applied to three telemetry call-sites: "User clicked execute workflow button", "Manual exec errored", and "Instance FE emitted paired item error".

## How to test

1. Open a workflow with several nodes.
2. Click **Execute workflow** — the UI should respond immediately with no jank; the telemetry event fires after the browser goes idle.
3. Trigger a node error — same expectation.
4. Check the Network panel: telemetry batches should now appear as `sendBeacon` requests to `/rest/telemetry/proxy/beacon/v1/batch` rather than individual XHRs to the dataplane URL.
5. Disable `navigator.sendBeacon` in DevTools (override `window.sendBeacon = undefined`) and verify telemetry still works via XHR fallback.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-912

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

---
🤖 PR Summary generated by AI