### PR TITLE
refactor(core): Make the protected-resource registry resolver-aware (no-changelog)

### DIFF
--- a/packages/cli/src/modules/oauth-server/__tests__/oauth-server.service.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth-server.service.test.ts
@@ -890,16 +890,16 @@ describe('OAuthServerService', () => {
 			);
 
 			expect(
-				(multiResourceService as any).resolveAndValidateResourceIndicator(TEST_RESOURCE_URL),
+				await (multiResourceService as any).resolveAndValidateResourceIndicator(TEST_RESOURCE_URL),
 			).toBe(TEST_RESOURCE_URL);
 			expect(
-				(multiResourceService as any).resolveAndValidateResourceIndicator(secondResourceUrl),
+				await (multiResourceService as any).resolveAndValidateResourceIndicator(secondResourceUrl),
 			).toBe(secondResourceUrl);
-			expect(() =>
+			await expect(
 				(multiResourceService as any).resolveAndValidateResourceIndicator(
 					'https://n8n.example.com/webhook/wf-2/mcp',
 				),
-			).toThrow(InvalidTargetError);
+			).rejects.toThrow(InvalidTargetError);
 		});
 	});
 });

--- a/packages/cli/src/modules/oauth-server/__tests__/oauth-token.service.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth-token.service.test.ts
@@ -478,15 +478,15 @@ describe('OAuthTokenService', () => {
 	});
 
 	describe('getAllowedAudiences', () => {
-		it('should return canonical URL and legacy audience when expectedAudience is the canonical URL', () => {
-			const audiences = (service as any).getAllowedAudiences(
+		it('should return canonical URL and legacy audience when expectedAudience is the canonical URL', async () => {
+			const audiences = await (service as any).getAllowedAudiences(
 				'https://n8n.example.com/mcp-server/http',
 			);
 			expect(audiences).toEqual(['https://n8n.example.com/mcp-server/http', 'mcp-server-api']);
 		});
 
-		it('should return only canonical URL and legacy audience when expectedAudience is undefined', () => {
-			const audiences = (service as any).getAllowedAudiences(undefined);
+		it('should return only canonical URL and legacy audience when expectedAudience is undefined', async () => {
+			const audiences = await (service as any).getAllowedAudiences(undefined);
 			// Should still return the canonical resource URL (from getCanonicalResourceUrl) and legacy
 			expect(audiences).toEqual(['https://n8n.example.com/mcp-server/http', 'mcp-server-api']);
 		});

--- a/packages/cli/src/modules/oauth-server/oauth-server.service.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-server.service.ts
@@ -167,7 +167,7 @@ export class OAuthServerService implements OAuthServerProvider {
 		this.logger.debug('Starting OAuth authorization', { clientId: client.client_id });
 
 		try {
-			const resource = this.resolveAndValidateResourceIndicator(params.resource?.toString());
+			const resource = await this.resolveAndValidateResourceIndicator(params.resource?.toString());
 
 			this.oauthSessionService.createSession(res, {
 				clientId: client.client_id,
@@ -227,7 +227,7 @@ export class OAuthServerService implements OAuthServerProvider {
 		}
 
 		const resourceStr = resource?.toString();
-		const tokenResource = this.resolveAndValidateResourceIndicator(resourceStr);
+		const tokenResource = await this.resolveAndValidateResourceIndicator(resourceStr);
 
 		// RFC 8707: if both the token request and the auth code specify a resource, they must match
 		// (token substitution defense). Otherwise either supplies the other, falling back to the
@@ -280,7 +280,7 @@ export class OAuthServerService implements OAuthServerProvider {
 		return await this.tokenService.validateAndRotateRefreshToken(
 			refreshToken,
 			client.client_id,
-			this.resolveAndValidateResourceIndicator(resourceStr),
+			await this.resolveAndValidateResourceIndicator(resourceStr),
 		);
 	}
 
@@ -291,13 +291,15 @@ export class OAuthServerService implements OAuthServerProvider {
 	// Exact-match against a registered resource, as required by RFC 8707 §2.1.
 	// Prefix/wildcard matching would open the door to malicious-host or
 	// path-traversal indicators like ".../mcp-server/http/../admin".
-	private resolveAndValidateResourceIndicator(resource: string | undefined): string | undefined {
+	private async resolveAndValidateResourceIndicator(
+		resource: string | undefined,
+	): Promise<string | undefined> {
 		if (resource === undefined) {
 			return undefined;
 		}
 
 		const normalizedResource = resource.replace(/\/$/, '');
-		const match = this.resourceRegistry.getByResourceUrl(normalizedResource);
+		const match = await this.resourceRegistry.getByResourceUrl(normalizedResource);
 		if (!match) {
 			const knownResources = this.resourceRegistry
 				.getAll()

--- a/packages/cli/src/modules/oauth-server/oauth-token.service.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-token.service.ts
@@ -170,7 +170,7 @@ export class OAuthTokenService implements OAuthTokenVerifier {
 		let decoded: unknown;
 
 		try {
-			const allowedAudiences = this.getAllowedAudiences(expectedAudience);
+			const allowedAudiences = await this.getAllowedAudiences(expectedAudience);
 			decoded = this.verifyJwtWithAllowedAudiences(token, allowedAudiences);
 		} catch (error) {
 			throw new JWTVerificationError();
@@ -280,9 +280,9 @@ export class OAuthTokenService implements OAuthTokenVerifier {
 	 * Resource-specific legacy audiences (e.g. the instance MCP server's
 	 * pre-RFC-8707 `mcp-server-api`) stay scoped to their own resource this way.
 	 */
-	private getAllowedAudiences(expectedAudience?: string): string[] {
+	private async getAllowedAudiences(expectedAudience?: string): Promise<string[]> {
 		if (expectedAudience) {
-			const resource = this.resourceRegistry.getByResourceUrl(expectedAudience);
+			const resource = await this.resourceRegistry.getByResourceUrl(expectedAudience);
 			return resource ? resource.getAudiences() : [expectedAudience];
 		}
 

--- a/packages/cli/src/modules/oauth-server/oauth.controller.ts
+++ b/packages/cli/src/modules/oauth-server/oauth.controller.ts
@@ -192,10 +192,10 @@ export class OAuthController {
 		usesTemplates: true,
 		ipRateLimit: { limit: 100, windowMs: 5 * Time.minutes.toMilliseconds },
 	})
-	protectedResourceMetadata(_req: Request, res: Response) {
+	async protectedResourceMetadata(_req: Request, res: Response) {
 		this.setCorsHeaders(res);
 
-		const resource = this.resourceRegistry.getByResourcePath('/mcp-server/http');
+		const resource = await this.resourceRegistry.getByResourcePath('/mcp-server/http');
 		if (!resource) {
 			throw new NotFoundError('Unknown protected resource');
 		}

--- a/packages/cli/src/services/__tests__/protected-resource.registry.test.ts
+++ b/packages/cli/src/services/__tests__/protected-resource.registry.test.ts
@@ -1,4 +1,4 @@
-import type { ProtectedResource } from '../protected-resource.registry';
+import type { ProtectedResource, ProtectedResourceResolver } from '../protected-resource.registry';
 import { ProtectedResourceRegistry } from '../protected-resource.registry';
 
 const resourceA: ProtectedResource = {
@@ -32,17 +32,25 @@ describe('ProtectedResourceRegistry', () => {
 			expect(registry.getById('unknown')).toBeUndefined();
 		});
 
-		it('should resolve resources by resource URL, ignoring trailing slashes', () => {
-			expect(registry.getByResourceUrl('https://n8n.example.com/mcp-server/http')).toBe(resourceA);
-			expect(registry.getByResourceUrl('https://n8n.example.com/mcp-server/http/')).toBe(resourceA);
-			expect(registry.getByResourceUrl('https://n8n.example.com/webhook/wf-1/mcp')).toBe(resourceB);
-			expect(registry.getByResourceUrl('https://evil.example.com/mcp-server/http')).toBeUndefined();
+		it('should resolve resources by resource URL, ignoring trailing slashes', async () => {
+			expect(await registry.getByResourceUrl('https://n8n.example.com/mcp-server/http')).toBe(
+				resourceA,
+			);
+			expect(await registry.getByResourceUrl('https://n8n.example.com/mcp-server/http/')).toBe(
+				resourceA,
+			);
+			expect(await registry.getByResourceUrl('https://n8n.example.com/webhook/wf-1/mcp')).toBe(
+				resourceB,
+			);
+			expect(
+				await registry.getByResourceUrl('https://evil.example.com/mcp-server/http'),
+			).toBeUndefined();
 		});
 
-		it('should resolve resources by URL path', () => {
-			expect(registry.getByResourcePath('/mcp-server/http')).toBe(resourceA);
-			expect(registry.getByResourcePath('/webhook/wf-1/mcp')).toBe(resourceB);
-			expect(registry.getByResourcePath('/unknown')).toBeUndefined();
+		it('should resolve resources by URL path', async () => {
+			expect(await registry.getByResourcePath('/mcp-server/http')).toBe(resourceA);
+			expect(await registry.getByResourcePath('/webhook/wf-1/mcp')).toBe(resourceB);
+			expect(await registry.getByResourcePath('/unknown')).toBeUndefined();
 		});
 
 		it('should resolve the default resource', () => {
@@ -72,12 +80,12 @@ describe('ProtectedResourceRegistry', () => {
 			]);
 		});
 
-		it('should keep per-resource audiences isolated', () => {
+		it('should keep per-resource audiences isolated', async () => {
 			// The legacy audience belongs to the instance resource only — resolving
 			// audiences through a specific resource must not leak it to others.
-			expect(registry.getByResourceUrl(resourceB.getResourceUrl())?.getAudiences()).toEqual([
-				'https://n8n.example.com/webhook/wf-1/mcp',
-			]);
+			expect((await registry.getByResourceUrl(resourceB.getResourceUrl()))?.getAudiences()).toEqual(
+				['https://n8n.example.com/webhook/wf-1/mcp'],
+			);
 		});
 
 		it('should union scopes across all registered resources, deduplicated', () => {
@@ -109,6 +117,100 @@ describe('ProtectedResourceRegistry', () => {
 			const gated = new ProtectedResourceRegistry();
 			gated.register({ ...resourceA, isEnabled: async () => false });
 			gated.register({ ...resourceB, isEnabled: async () => true });
+			expect(await gated.isAnyResourceEnabled()).toBe(true);
+		});
+	});
+
+	describe('resolvers', () => {
+		// A resource reachable only through a resolver — its URL/path is absent
+		// from the static map registered in beforeEach.
+		const resolvedResource: ProtectedResource = {
+			id: 'resolved-trigger',
+			getResourceUrl: () => 'https://n8n.example.com/webhook/wf-9/mcp',
+			getAudiences: () => ['https://n8n.example.com/webhook/wf-9/mcp'],
+			scopes: ['workflow:execute'],
+		};
+
+		const makeResolver = (): jest.Mocked<ProtectedResourceResolver> => ({
+			id: 'db-resolver',
+			// Overlaps a static scope and adds a resolver-only one.
+			scopes: ['tool:listWorkflows', 'tool:resolvedOnly'],
+			resolveByUrl: jest.fn().mockResolvedValue(undefined),
+			resolveByPath: jest.fn().mockResolvedValue(undefined),
+			hasAnyEnabledResource: jest.fn().mockResolvedValue(false),
+		});
+
+		it('should not consult resolvers when the static map matches by URL', async () => {
+			const resolver = makeResolver();
+			registry.registerResolver(resolver);
+
+			expect(await registry.getByResourceUrl('https://n8n.example.com/mcp-server/http')).toBe(
+				resourceA,
+			);
+			expect(resolver.resolveByUrl).not.toHaveBeenCalled();
+		});
+
+		it('should not consult resolvers when the static map matches by path', async () => {
+			const resolver = makeResolver();
+			registry.registerResolver(resolver);
+
+			expect(await registry.getByResourcePath('/mcp-server/http')).toBe(resourceA);
+			expect(resolver.resolveByPath).not.toHaveBeenCalled();
+		});
+
+		it('should consult the resolver on a static URL miss and return its result', async () => {
+			const resolver = makeResolver();
+			resolver.resolveByUrl.mockResolvedValue(resolvedResource);
+			registry.registerResolver(resolver);
+
+			expect(await registry.getByResourceUrl('https://n8n.example.com/webhook/wf-9/mcp')).toBe(
+				resolvedResource,
+			);
+			expect(resolver.resolveByUrl).toHaveBeenCalledWith(
+				'https://n8n.example.com/webhook/wf-9/mcp',
+			);
+		});
+
+		it('should pass the resolver the trailing-slash-trimmed URL', async () => {
+			const resolver = makeResolver();
+			resolver.resolveByUrl.mockResolvedValue(resolvedResource);
+			registry.registerResolver(resolver);
+
+			expect(await registry.getByResourceUrl('https://n8n.example.com/webhook/wf-9/mcp/')).toBe(
+				resolvedResource,
+			);
+			expect(resolver.resolveByUrl).toHaveBeenCalledWith(
+				'https://n8n.example.com/webhook/wf-9/mcp',
+			);
+		});
+
+		it('should consult the resolver on a static path miss and return its result', async () => {
+			const resolver = makeResolver();
+			resolver.resolveByPath.mockResolvedValue(resolvedResource);
+			registry.registerResolver(resolver);
+
+			expect(await registry.getByResourcePath('/webhook/wf-9/mcp')).toBe(resolvedResource);
+			expect(resolver.resolveByPath).toHaveBeenCalledWith('/webhook/wf-9/mcp');
+		});
+
+		it('should union resolver scopes into getAllScopes, deduplicated', () => {
+			registry.registerResolver(makeResolver());
+
+			expect(registry.getAllScopes()).toEqual([
+				'tool:listWorkflows',
+				'tool:getWorkflowDetails',
+				'workflow:execute',
+				'tool:resolvedOnly',
+			]);
+		});
+
+		it('should report enabled when only a resolver has an enabled resource', async () => {
+			const gated = new ProtectedResourceRegistry();
+			gated.register({ ...resourceA, isEnabled: async () => false });
+			const resolver = makeResolver();
+			resolver.hasAnyEnabledResource.mockResolvedValue(true);
+			gated.registerResolver(resolver);
+
 			expect(await gated.isAnyResourceEnabled()).toBe(true);
 		});
 	});

--- a/packages/cli/src/services/protected-resource.registry.ts
+++ b/packages/cli/src/services/protected-resource.registry.ts
@@ -44,6 +44,46 @@ export interface ProtectedResource {
 	isDefault?: boolean;
 }
 
+/**
+ * On-demand resolver for protected resources that aren't held in the registry's
+ * static map. Registered via {@link ProtectedResourceRegistry.registerResolver},
+ * resolvers are consulted only after the static map misses — letting a resource
+ * be resolved lazily (e.g. from the database) instead of being materialized up
+ * front.
+ */
+export interface ProtectedResourceResolver {
+	/** Stable identifier for the resolver, e.g. `'workflow-trigger'`. */
+	readonly id: string;
+
+	/**
+	 * Scopes contributed to discovery documents via
+	 * {@link ProtectedResourceRegistry.getAllScopes}, unioned with the static
+	 * resources' scopes.
+	 */
+	readonly scopes: string[];
+
+	/**
+	 * Resolve a resource by its canonical URL, or `undefined` if this resolver
+	 * owns no such resource. The input is pre-normalized (trailing slash
+	 * trimmed) by the registry.
+	 */
+	resolveByUrl(resourceUrl: string): Promise<ProtectedResource | undefined>;
+
+	/**
+	 * Resolve a resource by its URL path (e.g. `/webhook/wf-1/mcp`), or
+	 * `undefined` if this resolver owns no such resource. The input is
+	 * pre-normalized (trailing slash trimmed) by the registry.
+	 */
+	resolveByPath(pathname: string): Promise<ProtectedResource | undefined>;
+
+	/**
+	 * Whether this resolver currently owns at least one enabled resource. Drives
+	 * the shared OAuth server's availability guard via
+	 * {@link ProtectedResourceRegistry.isAnyResourceEnabled}.
+	 */
+	hasAnyEnabledResource(): Promise<boolean>;
+}
+
 const trimTrailingSlash = (url: string): string => url.replace(/\/$/, '');
 
 /**
@@ -55,9 +95,14 @@ const trimTrailingSlash = (url: string): string => url.replace(/\/$/, '');
 @Service()
 export class ProtectedResourceRegistry {
 	private readonly resources = new Map<string, ProtectedResource>();
+	private readonly resolvers = new Set<ProtectedResourceResolver>();
 
 	register(resource: ProtectedResource): void {
 		this.resources.set(resource.id, resource);
+	}
+
+	registerResolver(resolver: ProtectedResourceResolver) {
+		this.resolvers.add(resolver);
 	}
 
 	getById(id: string): ProtectedResource | undefined {
@@ -65,16 +110,20 @@ export class ProtectedResourceRegistry {
 	}
 
 	/** Look up a resource by its canonical URL (trailing slashes ignored). */
-	getByResourceUrl(resourceUrl: string): ProtectedResource | undefined {
+	async getByResourceUrl(resourceUrl: string): Promise<ProtectedResource | undefined> {
 		const normalized = trimTrailingSlash(resourceUrl);
 		for (const resource of this.resources.values()) {
 			if (trimTrailingSlash(resource.getResourceUrl()) === normalized) return resource;
+		}
+		for (const resolver of this.resolvers) {
+			const resource = await resolver.resolveByUrl(normalized);
+			if (resource) return resource;
 		}
 		return undefined;
 	}
 
 	/** Look up a resource by its URL path (e.g. `/mcp-server/http`). */
-	getByResourcePath(pathname: string): ProtectedResource | undefined {
+	async getByResourcePath(pathname: string): Promise<ProtectedResource | undefined> {
 		const normalized = trimTrailingSlash(pathname);
 		for (const resource of this.resources.values()) {
 			try {
@@ -84,6 +133,11 @@ export class ProtectedResourceRegistry {
 			} catch {
 				continue;
 			}
+		}
+
+		for (const resolver of this.resolvers) {
+			const resource = await resolver.resolveByPath(normalized);
+			if (resource) return resource;
 		}
 		return undefined;
 	}
@@ -123,6 +177,9 @@ export class ProtectedResourceRegistry {
 		for (const resource of this.resources.values()) {
 			for (const scope of resource.scopes) scopes.add(scope);
 		}
+		for (const resolver of this.resolvers) {
+			for (const scope of resolver.scopes) scopes.add(scope);
+		}
 		return [...scopes];
 	}
 
@@ -133,6 +190,9 @@ export class ProtectedResourceRegistry {
 	async isAnyResourceEnabled(): Promise<boolean> {
 		for (const resource of this.resources.values()) {
 			if (!resource.isEnabled || (await resource.isEnabled())) return true;
+		}
+		for (const resolver of this.resolvers) {
+			if (await resolver.hasAnyEnabledResource()) return true;
 		}
 		return false;
 	}


### PR DESCRIPTION
## Summary

Extends ProtectedResourceRegistry from a static in-memory Map into a two-tier lookup: the static map is scanned first (instance MCP, unchanged), then a list of registered async resolvers that can resolve a protected resource on demand. No resolver is registered in this PR, so behavior is identical to today — this is pure, independently-revertable infrastructure.

Why. This is Slice 1 of 5 of [IAM-799](https://linear.app/n8n/issue/IAM-799), which will make every active n8nOAuth2 MCP-trigger workflow its own OAuth 2.1 protected resource. Those resources are resolved declaratively from the existing webhook_entity source of truth rather than materialized into a new table, so the registry’s URL/path lookups must be able to consult a DB-backed resolver — which means they have to become async. Landing that cross-cutting async change to the token-verification hot path on its own keeps it small and reviewable, separate from the resolver implementation and route changes that follow in Slices 2–5. It builds directly on [IAM-797](https://linear.app/n8n/issue/IAM-797) (#32018), which extracted the shared OAuth server.

## How to test

This is a behavior-neutral refactor with no resolver registered, so there is no observable behavior change to exercise manually — the contract is “byte-identical to before.” Coverage is via automated tests:

```
cd packages/cli
pnpm typecheck
pnpm test src/services/__tests__/protected-resource.registry.test.ts src/modules/oauth-server
```
Expected: all green (registry suite = 20 tests; oauth-server module suite unchanged in behavior). The new registry tests prove the resolver tier: a static hit short-circuits before any resolver is consulted; on a static miss the resolver is awaited (with normalized input) and its result returned; getAllScopes() unions resolver scopes (deduplicated); and isAnyResourceEnabled() returns true when only a resolver reports enabled.


## Related Linear tickets, Github issues, and Community forum posts

closes  https://linear.app/n8n/issue/IAM-815

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
