### PR TITLE
perf(editor): Send telemetry events in batches via sendBeacon

### DIFF
--- a/packages/cli/src/controllers/__tests__/telemetry.controller.test.ts
+++ b/packages/cli/src/controllers/__tests__/telemetry.controller.test.ts
@@ -5,6 +5,11 @@ import { Container } from '@n8n/di';
 import type { NextFunction, Response } from 'express';
 import { mock } from 'jest-mock-extended';
 
+type ProxyRequest = {
+	removeHeader: jest.Mock;
+	setHeader: jest.Mock;
+	write: jest.Mock;
+};
 type ProxyResponse = { headers: Record<string, string> };
 type ProxyErrorResponse = {
 	headersSent?: boolean;
@@ -13,7 +18,7 @@ type ProxyErrorResponse = {
 };
 type ProxyOptions = {
 	on?: {
-		proxyReq?: (proxyReq: { removeHeader: jest.Mock }, req: AuthenticatedRequest) => void;
+		proxyReq?: (proxyReq: ProxyRequest, req: AuthenticatedRequest) => void;
 		proxyRes?: (proxyRes: ProxyResponse) => void;
 		error?: (error: Error, req: AuthenticatedRequest, res: ProxyErrorResponse) => void;
 	};
@@ -63,8 +68,16 @@ function createResponse() {
 	return res as unknown as jest.Mocked<Response>;
 }
 
-function createRequest(headers: Record<string, string> = {}) {
-	return { headers } as AuthenticatedRequest;
+function createRequest(headers: Record<string, string> = {}, body?: unknown) {
+	return { headers, body } as AuthenticatedRequest;
+}
+
+function createProxyRequest(): ProxyRequest {
+	return {
+		removeHeader: jest.fn(),
+		setHeader: jest.fn(),
+		write: jest.fn(),
+	};
 }
 
 function getProxyOptions() {
@@ -128,15 +141,41 @@ describe('TelemetryController', () => {
 		expect(mockProxy).toHaveBeenCalledWith(req, res, next);
 	});
 
+	it('applies CORS before proxying beacon batch calls', async () => {
+		const controller = createController();
+		const req = createRequest();
+		const res = createResponse();
+		const next = jest.fn() as NextFunction;
+
+		await controller.batch(req, res, next);
+
+		expect(res.setHeader).toHaveBeenCalledWith('Access-Control-Allow-Origin', '*');
+		expect(mockProxy).toHaveBeenCalledWith(req, res, next);
+	});
+
 	it('keeps proxy request body handling and strips cookies', () => {
 		createController();
-		const proxyReq = { removeHeader: jest.fn() };
+		const proxyReq = createProxyRequest();
 		const req = createRequest();
 
 		getProxyOptions().on?.proxyReq?.(proxyReq, req);
 
 		expect(proxyReq.removeHeader).toHaveBeenCalledWith('cookie');
 		expect(mockFixRequestBody).toHaveBeenCalledWith(proxyReq, req);
+	});
+
+	it('re-writes string request bodies to the proxied request', () => {
+		createController();
+		const proxyReq = createProxyRequest();
+		const body = JSON.stringify({ batch: [{ event: 'test' }] });
+		const req = createRequest({}, body);
+
+		getProxyOptions().on?.proxyReq?.(proxyReq, req);
+
+		expect(proxyReq.removeHeader).toHaveBeenCalledWith('cookie');
+		expect(proxyReq.setHeader).toHaveBeenCalledWith('content-length', Buffer.byteLength(body));
+		expect(proxyReq.write).toHaveBeenCalledWith(body);
+		expect(mockFixRequestBody).not.toHaveBeenCalled();
 	});
 
 	it('normalizes upstream CORS headers on proxied responses', () => {

--- a/packages/cli/src/controllers/telemetry.controller.ts
+++ b/packages/cli/src/controllers/telemetry.controller.ts
@@ -18,6 +18,16 @@ export class TelemetryController {
 			on: {
 				proxyReq: (proxyReq, req) => {
 					proxyReq.removeHeader('cookie');
+					const body = 'body' in req ? req.body : undefined;
+					if (typeof body === 'string' && body.length > 0) {
+						// `text/plain` payloads (e.g. `sendBeacon` batches) are parsed into a
+						// string by our body parser, which also consumes the request stream.
+						// `fixRequestBody` only re-writes json/urlencoded/multipart bodies, so
+						// re-write string bodies explicitly to keep the proxied request intact.
+						proxyReq.setHeader('content-length', Buffer.byteLength(body));
+						proxyReq.write(body);
+						return;
+					}
 					fixRequestBody(proxyReq, req);
 					return;
 				},
@@ -94,6 +104,19 @@ export class TelemetryController {
 	// cookie-stripped, rate-limited, and proxies only to the fixed diagnostics target.
 	@Post('/proxy/:version/page', { skipAuth: true, ipRateLimit: { limit: 50, windowMs: 60_000 } })
 	async page(req: AuthenticatedRequest, res: Response, next: NextFunction) {
+		this.applyCors(req, res);
+		await this.proxy(req, res, next);
+	}
+
+	// Public telemetry passthrough: no scope decorator. The endpoint is unauthenticated,
+	// cookie-stripped, rate-limited, and proxies only to the fixed diagnostics target.
+	// Used by the RudderStack SDK in beacon mode, which sends event batches to
+	// `<dataPlaneUrl>/beacon/v1/batch` via `navigator.sendBeacon`.
+	@Post('/proxy/beacon/:version/batch', {
+		skipAuth: true,
+		ipRateLimit: { limit: 100, windowMs: 60_000 },
+	})
+	async batch(req: AuthenticatedRequest, res: Response, next: NextFunction) {
 		this.applyCors(req, res);
 		await this.proxy(req, res, next);
 	}

--- a/packages/frontend/editor-ui/src/app/plugins/telemetry.test.ts
+++ b/packages/frontend/editor-ui/src/app/plugins/telemetry.test.ts
@@ -184,6 +184,51 @@ describe('telemetry', () => {
 		});
 	});
 
+	describe('init', () => {
+		it('should load RudderStack with beacon transport enabled', () => {
+			const rudderanalyticsBackup = window.rudderanalytics;
+			window.rudderanalytics = undefined as unknown as typeof window.rudderanalytics;
+
+			try {
+				const freshTelemetry = new Telemetry();
+				freshTelemetry.init(
+					{
+						enabled: true,
+						config: {
+							proxy: 'https://proxy.test',
+							key: 'test-key',
+							sourceConfig: 'https://source-config.test',
+							url: '',
+						},
+					},
+					{ versionCli: '1', instanceId: '1' },
+				);
+
+				// before the SDK script loads, calls are queued as [method, ...args] tuples
+				const loadCall = Array.from(window.rudderanalytics as unknown as unknown[][]).find(
+					(call) => Array.isArray(call) && call[0] === 'load',
+				);
+				expect(loadCall).toEqual([
+					'load',
+					'test-key',
+					'https://proxy.test',
+					{
+						integrations: { All: false },
+						loadIntegration: false,
+						configUrl: 'https://source-config.test',
+						useBeacon: true,
+						beaconQueueOptions: {
+							maxItems: 10,
+							flushQueueInterval: 10_000,
+						},
+					},
+				]);
+			} finally {
+				window.rudderanalytics = rudderanalyticsBackup;
+			}
+		});
+	});
+
 	describe('track function', () => {
 		it('should call Rudderstack track method with correct parameters', () => {
 			const trackFunction = vi.spyOn(window.rudderanalytics, 'track');

--- a/packages/frontend/editor-ui/src/app/plugins/telemetry/index.ts
+++ b/packages/frontend/editor-ui/src/app/plugins/telemetry/index.ts
@@ -61,6 +61,17 @@ export class Telemetry {
 			integrations: { All: false },
 			loadIntegration: false,
 			configUrl: sourceConfig,
+			// Batch events and send them via `navigator.sendBeacon` to keep telemetry
+			// network work off the critical path. Falls back to per-event XHR in
+			// browsers without `sendBeacon` support.
+			useBeacon: true,
+			beaconQueueOptions: {
+				// Flush when 10 events are queued (SDK default)
+				maxItems: 10,
+				// Flush at least every 10s. The SDK default (10 minutes) is too lossy:
+				// the queue is in-memory only and is not flushed on page unload.
+				flushQueueInterval: 10_000,
+			},
 		});
 
 		this.identify({ instanceId, userId, versionCli, projectId, userRole });


### PR DESCRIPTION
## Summary

Enables the RudderStack JS SDK beacon transport for frontend telemetry, so events are batched and sent via `navigator.sendBeacon` instead of one XHR request per `track`/`page`/`identify` call.

**Frontend** (`packages/frontend/editor-ui/src/app/plugins/telemetry/index.ts`):
- Pass `useBeacon: true` + `beaconQueueOptions: { maxItems: 10, flushQueueInterval: 10_000 }` to `rudderanalytics.load()`. The hosted SDK bundle natively supports this (verified against `cdn-rs.n8n.io/v1/ra.min.js`) and falls back to per-event XHR in browsers without `sendBeacon`.

**Backend** (`packages/cli/src/controllers/telemetry.controller.ts`):
- New `POST /rest/telemetry/proxy/beacon/:version/batch` passthrough route — in beacon mode the SDK posts batches to `<dataPlaneUrl>/beacon/v1/batch`, which previously had no proxy route (events would 404). Same security posture as the existing track route: unauthenticated, cookie-stripped, IP-rate-limited, fixed upstream target.
- Forward string request bodies explicitly in the `proxyReq` handler: the SDK sends batches as a `text/plain` Blob, which our body parser reads into a string after consuming the request stream, and `fixRequestBody` from `http-proxy-middleware@3.0.5` only re-writes json/urlencoded/multipart bodies — without this the proxied request would go upstream with no body.

**Trade-offs (accepted for telemetry):**
- Events sitting in the in-memory beacon queue are lost if the tab closes before a flush — the SDK has no page-unload flush hook, hence the 10s `flushQueueInterval` (SDK default is 10 minutes) to bound the loss window.
- `sendBeacon` rejects payloads > ~64KB; the SDK flushes early as the batch grows, but a single event above the cap is dropped with a debug log. Relevant only to very large `node_graph_string` payloads (rare); a payload size cap is a candidate follow-up.

## How to test

Unit tests:
- `cd packages/cli && pnpm test telemetry.controller` — batch route registration, CORS, string-body forwarding, cookie stripping
- `cd packages/frontend/editor-ui && pnpm test src/app/plugins/telemetry.test.ts` — beacon load options

Manual:
1. Run n8n with diagnostics enabled (`N8N_DIAGNOSTICS_ENABLED=true` and `N8N_DIAGNOSTICS_CONFIG_FRONTEND` set to `key;dataPlaneUrl`).
2. Open the editor and interact (navigate, open NDV, run a workflow).
3. In DevTools → Network, telemetry now leaves as `POST /rest/telemetry/proxy/beacon/v1/batch` (type `ping`/`beacon`) with `{"batch":[…]}` payloads of up to 10 events, instead of individual `/proxy/v1/track` XHRs. Requests flush at the latest every 10s.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-912

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)