### PR TITLE
perf(editor): Defer node-graph telemetry computation and debounce NDV pagination events

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.test.ts
@@ -139,6 +139,11 @@ vi.mock('@/app/composables/useTelemetry', () => {
 	};
 });
 
+// Run idle-deferred work (e.g. node-graph telemetry payloads) synchronously
+vi.mock('@/app/utils/idleUtils', () => ({
+	runWhenIdle: (fn: () => void) => fn(),
+}));
+
 vi.mock('@/app/composables/useToast', () => {
 	const showMessage = vi.fn();
 	const showError = vi.fn();

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -132,6 +132,7 @@ import { computed, nextTick, ref, type DeepReadonly } from 'vue';
 import { useUniqueNodeName } from '@/app/composables/useUniqueNodeName';
 import { useBuilderStore } from '@/features/ai/assistant/builder.store';
 import { isPresent, tryToParseNumber } from '@/app/utils/typesUtils';
+import { runWhenIdle } from '@/app/utils/idleUtils';
 import { ensureNodePosition, sanitizeConnections } from '@/app/utils/workflowUtils';
 import { useProjectsStore } from '@/features/collaboration/projects/projects.store';
 import type { CanvasLayoutEvent } from '@/features/workflows/canvas/composables/useCanvasLayout';
@@ -2887,8 +2888,11 @@ export function useCanvasOperations() {
 
 			removeUnknownCredentials(workflowData);
 
-			try {
-				if (trackEvents) {
+			if (trackEvents) {
+				// Building the node-graph payload walks the entire imported workflow, which
+				// is expensive on large workflows — keep it off the interaction path.
+				// `runWhenIdle` also swallows errors: if telemetry fails, don't throw.
+				runWhenIdle(() => {
 					const nodeGraph = JSON.stringify(
 						TelemetryHelpers.generateNodesGraph(
 							workflowData as IWorkflowBase,
@@ -2921,9 +2925,7 @@ export function useCanvasOperations() {
 							node_graph_string: nodeGraph,
 						});
 					}
-				}
-			} catch {
-				// If telemetry fails, don't throw an error
+				});
 			}
 
 			// Fix the node position as it could be totally offscreen

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/executionFinished.ts
@@ -34,6 +34,7 @@ import {
 	getExecutionErrorToastConfiguration,
 } from '@/features/execution/executions/executions.utils';
 import { getTriggerNodeServiceName } from '@/app/utils/nodeTypesUtils';
+import { runWhenIdle } from '@/app/utils/idleUtils';
 import type { ExecutionFinished } from '@n8n/api-types/push/execution';
 import { useI18n } from '@n8n/i18n';
 import type {
@@ -353,37 +354,41 @@ export function handleExecutionFinishedWithErrorOrCanceled(
 	) {
 		const error = runExecutionData.resultData.error as ExpressionError;
 
-		const workflowData = workflowDocumentStore.serialize();
-		const eventData: IDataObject = {
-			caused_by_credential: false,
-			error_message: error.description,
-			error_title: error.message,
-			error_type: error.context.type,
-			node_graph_string: JSON.stringify(
-				TelemetryHelpers.generateNodesGraph(
-					workflowData as IWorkflowBase,
-					workflowHelpers.getNodeTypes(),
-				).nodeGraph,
-			),
-			workflow_id: workflowDocumentStore.workflowId,
-		};
+		// Building the node-graph payload serializes and walks the entire workflow,
+		// which is expensive on large workflows — keep it off the execution hot path.
+		runWhenIdle(() => {
+			const workflowData = workflowDocumentStore.serialize();
+			const eventData: IDataObject = {
+				caused_by_credential: false,
+				error_message: error.description,
+				error_title: error.message,
+				error_type: error.context.type,
+				node_graph_string: JSON.stringify(
+					TelemetryHelpers.generateNodesGraph(
+						workflowData as IWorkflowBase,
+						workflowHelpers.getNodeTypes(),
+					).nodeGraph,
+				),
+				workflow_id: workflowDocumentStore.workflowId,
+			};
 
-		if (
-			error.context.nodeCause &&
-			['paired_item_no_info', 'paired_item_invalid_info'].includes(error.context.type as string)
-		) {
-			const node = workflowDocumentStore.getNodeByName(error.context.nodeCause as string);
+			if (
+				error.context.nodeCause &&
+				['paired_item_no_info', 'paired_item_invalid_info'].includes(error.context.type as string)
+			) {
+				const node = workflowDocumentStore.getNodeByName(error.context.nodeCause as string);
 
-			if (node) {
-				eventData.is_pinned = !!workflowDocumentStore.pinnedDataByNodeName?.[node.name];
-				eventData.mode = node.parameters.mode;
-				eventData.node_type = node.type;
-				eventData.operation = node.parameters.operation;
-				eventData.resource = node.parameters.resource;
+				if (node) {
+					eventData.is_pinned = !!workflowDocumentStore.pinnedDataByNodeName?.[node.name];
+					eventData.mode = node.parameters.mode;
+					eventData.node_type = node.type;
+					eventData.operation = node.parameters.operation;
+					eventData.resource = node.parameters.resource;
+				}
 			}
-		}
 
-		telemetry.track('Instance FE emitted paired item error', eventData);
+			telemetry.track('Instance FE emitted paired item error', eventData);
+		});
 	}
 
 	if (execution.status === 'canceled') {

--- a/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/trackNodeExecution.ts
+++ b/packages/frontend/editor-ui/src/app/composables/usePushConnection/handlers/trackNodeExecution.ts
@@ -7,6 +7,7 @@ import {
 	useWorkflowDocumentStore,
 } from '@/app/stores/workflowDocument.store';
 import { TelemetryHelpers } from 'n8n-workflow';
+import { runWhenIdle } from '@/app/utils/idleUtils';
 
 export async function trackNodeExecution(
 	pushData: PushPayload<'nodeExecuteAfter'>,
@@ -15,25 +16,30 @@ export async function trackNodeExecution(
 	const nodeName = pushData.nodeName;
 
 	if (pushData.data.error) {
-		const telemetry = useTelemetry();
-		const workflowHelpers = useWorkflowHelpers();
-		const settingsStore = useSettingsStore();
-		const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
-		const node = workflowDocumentStore.getNodeByName(nodeName);
-		telemetry.track('Manual exec errored', {
-			error_title: pushData.data.error.message,
-			node_type: node?.type,
-			node_type_version: node?.typeVersion,
-			node_id: node?.id,
-			node_graph_string: JSON.stringify(
-				TelemetryHelpers.generateNodesGraph(
-					workflowDocumentStore.serialize(),
-					workflowHelpers.getNodeTypes(),
-					{
-						isCloudDeployment: settingsStore.isCloudDeployment,
-					},
-				).nodeGraph,
-			),
+		const error = pushData.data.error;
+		// Building the node-graph payload serializes and walks the entire workflow,
+		// which is expensive on large workflows — keep it off the execution hot path.
+		runWhenIdle(() => {
+			const telemetry = useTelemetry();
+			const workflowHelpers = useWorkflowHelpers();
+			const settingsStore = useSettingsStore();
+			const workflowDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(workflowId));
+			const node = workflowDocumentStore.getNodeByName(nodeName);
+			telemetry.track('Manual exec errored', {
+				error_title: error.message,
+				node_type: node?.type,
+				node_type_version: node?.typeVersion,
+				node_id: node?.id,
+				node_graph_string: JSON.stringify(
+					TelemetryHelpers.generateNodesGraph(
+						workflowDocumentStore.serialize(),
+						workflowHelpers.getNodeTypes(),
+						{
+							isCloudDeployment: settingsStore.isCloudDeployment,
+						},
+					).nodeGraph,
+				),
+			});
 		});
 	}
 }

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.test.ts
@@ -196,6 +196,11 @@ vi.mock('@/app/composables/useTelemetry', () => ({
 	useTelemetry: vi.fn().mockReturnValue({ track: vi.fn() }),
 }));
 
+// Run idle-deferred work (e.g. node-graph telemetry payloads) synchronously
+vi.mock('@/app/utils/idleUtils', () => ({
+	runWhenIdle: (fn: () => void) => fn(),
+}));
+
 vi.mock('@n8n/i18n', () => ({
 	i18n: { baseText: vi.fn().mockImplementation((key) => key) },
 	useI18n: vi.fn().mockReturnValue({ baseText: vi.fn().mockImplementation((key) => key) }),

--- a/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useRunWorkflow.ts
@@ -48,6 +48,7 @@ import { useExternalHooks } from '@/app/composables/useExternalHooks';
 import { useWorkflowHelpers } from '@/app/composables/useWorkflowHelpers';
 import type { useRouter } from 'vue-router';
 import { isEmpty } from '@/app/utils/typesUtils';
+import { runWhenIdle } from '@/app/utils/idleUtils';
 import { useI18n } from '@n8n/i18n';
 import get from 'lodash/get';
 import { useExecutionsStore } from '@/features/execution/executions/executions.store';
@@ -609,20 +610,24 @@ export function useRunWorkflow(useRunWorkflowOpts: {
 	}
 
 	async function runEntireWorkflow(source: 'node' | 'main', triggerNode?: string) {
-		const workflowData = workflowDocumentStore.value.serialize();
-		const telemetryPayload = {
-			workflow_id: workflowDocumentStore.value.workflowId,
-			node_graph_string: JSON.stringify(
-				TelemetryHelpers.generateNodesGraph(
-					workflowData as IWorkflowBase,
-					workflowHelpers.getNodeTypes(),
-					{ isCloudDeployment: settingsStore.isCloudDeployment },
-				).nodeGraph,
-			),
-			button_type: source,
-		};
-		telemetry.track('User clicked execute workflow button', telemetryPayload);
-		void externalHooks.run('nodeView.onRunWorkflow', telemetryPayload);
+		// Building the node-graph payload serializes and walks the entire workflow,
+		// which is expensive on large workflows — keep it off the interaction path.
+		runWhenIdle(() => {
+			const workflowData = workflowDocumentStore.value.serialize();
+			const telemetryPayload = {
+				workflow_id: workflowDocumentStore.value.workflowId,
+				node_graph_string: JSON.stringify(
+					TelemetryHelpers.generateNodesGraph(
+						workflowData as IWorkflowBase,
+						workflowHelpers.getNodeTypes(),
+						{ isCloudDeployment: settingsStore.isCloudDeployment },
+					).nodeGraph,
+				),
+				button_type: source,
+			};
+			telemetry.track('User clicked execute workflow button', telemetryPayload);
+			void externalHooks.run('nodeView.onRunWorkflow', telemetryPayload);
+		});
 
 		let resolvedTriggerNode = triggerNode ?? workflowExecutionState.value.selectedTriggerNodeName;
 

--- a/packages/frontend/editor-ui/src/app/utils/idleUtils.test.ts
+++ b/packages/frontend/editor-ui/src/app/utils/idleUtils.test.ts
@@ -1,0 +1,62 @@
+import { DEBOUNCE_TIME } from '@/app/constants';
+import { runWhenIdle } from '@/app/utils/idleUtils';
+
+describe('runWhenIdle', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals();
+		vi.useRealTimers();
+	});
+
+	it('should run the callback via requestIdleCallback when available', () => {
+		const requestIdleCallback = vi.fn((callback: IdleRequestCallback) => {
+			callback({ didTimeout: false, timeRemaining: () => 50 } as IdleDeadline);
+			return 1;
+		});
+		vi.stubGlobal('requestIdleCallback', requestIdleCallback);
+		const fn = vi.fn();
+
+		runWhenIdle(fn, { timeout: 1234 });
+
+		expect(requestIdleCallback).toHaveBeenCalledWith(expect.any(Function), { timeout: 1234 });
+		expect(fn).toHaveBeenCalledTimes(1);
+	});
+
+	it('should use the telemetry batch debounce time as the default timeout', () => {
+		const requestIdleCallback = vi.fn();
+		vi.stubGlobal('requestIdleCallback', requestIdleCallback);
+
+		runWhenIdle(vi.fn());
+
+		expect(requestIdleCallback).toHaveBeenCalledWith(expect.any(Function), {
+			timeout: DEBOUNCE_TIME.TELEMETRY.BATCH,
+		});
+	});
+
+	it('should fall back to a macrotask when requestIdleCallback is unavailable', () => {
+		vi.stubGlobal('requestIdleCallback', undefined);
+		vi.useFakeTimers();
+		const fn = vi.fn();
+
+		runWhenIdle(fn);
+
+		expect(fn).not.toHaveBeenCalled();
+		vi.runAllTimers();
+		expect(fn).toHaveBeenCalledTimes(1);
+	});
+
+	it('should swallow errors thrown by the callback', () => {
+		vi.stubGlobal(
+			'requestIdleCallback',
+			vi.fn((callback: IdleRequestCallback) => {
+				callback({ didTimeout: false, timeRemaining: () => 50 } as IdleDeadline);
+				return 1;
+			}),
+		);
+
+		expect(() =>
+			runWhenIdle(() => {
+				throw new Error('boom');
+			}),
+		).not.toThrow();
+	});
+});

--- a/packages/frontend/editor-ui/src/app/utils/idleUtils.ts
+++ b/packages/frontend/editor-ui/src/app/utils/idleUtils.ts
@@ -1,0 +1,30 @@
+import { DEBOUNCE_TIME } from '@/app/constants';
+
+/**
+ * Runs `fn` when the main thread is idle (via `requestIdleCallback`), falling
+ * back to a macrotask in environments without `requestIdleCallback` support
+ * (Safari < 18, jsdom).
+ *
+ * Intended for non-critical work, e.g. computing telemetry payloads, so it
+ * stays off the interaction path. Because of that:
+ * - errors thrown by `fn` are swallowed
+ * - `fn` may never run if the tab is closed before the callback fires
+ *
+ * `timeout` guarantees `fn` runs within that many milliseconds even if the
+ * main thread never goes idle.
+ */
+export function runWhenIdle(fn: () => void, { timeout = DEBOUNCE_TIME.TELEMETRY.BATCH } = {}) {
+	const run = () => {
+		try {
+			fn();
+		} catch {
+			// non-critical work, don't propagate errors
+		}
+	};
+
+	if (typeof window.requestIdleCallback === 'function') {
+		window.requestIdleCallback(run, { timeout });
+	} else {
+		setTimeout(run, 0);
+	}
+}

--- a/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/runData/components/RunData.vue
@@ -31,6 +31,8 @@ import {
 	CORE_NODES_CATEGORY,
 	DATA_EDITING_DOCS_URL,
 	DATA_PINNING_DOCS_URL,
+	DEBOUNCE_TIME,
+	getDebounceTime,
 	HTML_NODE_TYPE,
 	LOCAL_STORAGE_PIN_DATA_DISCOVERY_CANVAS_FLAG,
 	LOCAL_STORAGE_PIN_DATA_DISCOVERY_NDV_FLAG,
@@ -72,7 +74,7 @@ import isEqual from 'lodash/isEqual';
 import isObject from 'lodash/isObject';
 import { useRoute, useRouter } from 'vue-router';
 import { useSchemaPreviewStore } from '@/features/ndv/runData/schemaPreview.store';
-import { asyncComputed } from '@vueuse/core';
+import { asyncComputed, useDebounceFn } from '@vueuse/core';
 import ViewSubExecution from '@/features/execution/executions/components/ViewSubExecution.vue';
 import RunDataItemCount from './RunDataItemCount.vue';
 import RunDataDisplayModeSelect from './RunDataDisplayModeSelect.vue';
@@ -1148,8 +1150,9 @@ function unlinkRun() {
 	emit('unlinkRun');
 }
 
-function onCurrentPageChange(value: number) {
-	currentPage.value = value;
+// Debounced so rapidly paging through items emits a single event with the
+// final state instead of one event per click.
+const trackCurrentPageChange = useDebounceFn(() => {
 	telemetry.track('User changed ndv page', {
 		node_type: activeNode.value?.type,
 		workflow_id: workflowId.value,
@@ -1159,6 +1162,11 @@ function onCurrentPageChange(value: number) {
 		page_size: pageSize.value,
 		items_total: dataCount.value,
 	});
+}, getDebounceTime(DEBOUNCE_TIME.TELEMETRY.TRACK));
+
+function onCurrentPageChange(value: number) {
+	currentPage.value = value;
+	void trackCurrentPageChange();
 }
 
 function resetCurrentPageIfTooFar() {
@@ -1168,11 +1176,9 @@ function resetCurrentPageIfTooFar() {
 	}
 }
 
-function onPageSizeChange(newPageSize: number) {
-	pageSize.value = newPageSize;
-
-	resetCurrentPageIfTooFar();
-
+// Debounced so rapidly switching page sizes emits a single event with the
+// final state instead of one event per change.
+const trackPageSizeChange = useDebounceFn(() => {
 	telemetry.track('User changed ndv page size', {
 		node_type: activeNode.value?.type,
 		workflow_id: workflowId.value,
@@ -1182,6 +1188,14 @@ function onPageSizeChange(newPageSize: number) {
 		page_size: pageSize.value,
 		items_total: dataCount.value,
 	});
+}, getDebounceTime(DEBOUNCE_TIME.TELEMETRY.TRACK));
+
+function onPageSizeChange(newPageSize: number) {
+	pageSize.value = newPageSize;
+
+	resetCurrentPageIfTooFar();
+
+	void trackPageSizeChange();
 }
 
 function onDisplayModeChange(newDisplayMode: IRunDataDisplayMode) {


### PR DESCRIPTION
## Summary

Keeps expensive telemetry payload computation off the editor's interaction path.

**Defer node-graph payload computation** — `TelemetryHelpers.generateNodesGraph()` + `workflowDocumentStore.serialize()` + `JSON.stringify` walk every node and connection in the workflow and previously ran synchronously inside user interactions. A new `runWhenIdle` util (`requestIdleCallback` with a `setTimeout` fallback, errors swallowed, 2s timeout ceiling via `DEBOUNCE_TIME.TELEMETRY.BATCH`) now defers the payload build + `track` call at all 4 call sites:

- `useRunWorkflow.runEntireWorkflow` — 'User clicked execute workflow button' (defers the shared `externalHooks.run('nodeView.onRunWorkflow')` call together with it, same payload)
- `usePushConnection/handlers/trackNodeExecution` — 'Manual exec errored'
- `usePushConnection/handlers/executionFinished` — 'Instance FE emitted paired item error'
- `useCanvasOperations.addImportedNodesToWorkflow` — 'User pasted nodes' / 'User duplicated nodes' / 'User imported workflow' (the previous `try {} catch {}` wrapper is replaced by `runWhenIdle`'s built-in error swallowing)

**Debounce NDV pagination telemetry** — 'User changed ndv page' and 'User changed ndv page size' (`RunData.vue`) now use `useDebounceFn` + `DEBOUNCE_TIME.TELEMETRY.TRACK` (1s), so rapidly paging emits one event with the final state instead of one per click.

**Caveats (accepted for telemetry):** deferred events may be lost if the tab closes within the idle window; timestamps can shift by up to ~2s; payloads snapshot state at idle time (e.g. pasted-node positions are nudged on-screen before the callback fires — topology is unchanged).

**Audited and intentionally not debounced:** 'User switched parameter mode' (deliberate toggle, payload shared with an `externalHooks` call), 'User moved parameters pane' / 'User dragged data for mapping' (fire once on drag end), list search/filter telemetry (already debounced via `refDebounced`/`callDebounced`).

**Follow-up candidates (not in this PR):**
- De-reactify `workflowObject` (`useWorkflowDocumentWorkflowObject.ts` stores the runtime `Workflow` in a deep `ref`; `shallowRef` + `markRaw` + `triggerRef` in the sync mutators was designed and consumer-audited as safe — worth its own PR so reactivity regressions bisect independently of transport changes).
- Cap `node_graph_string` payload size (also mitigates the beacon 64KB single-event limit from #32140).
- Product-reviewed event volume reduction: 412 `.track(` call sites, every event double-sent to PostHog (autocapture also on), `page()` on every router navigation.
- Web worker for telemetry: skipped deliberately — with beacon batching (#32140) the SDK's network work is already off the critical path, and payload computation can't move to a worker without first serializing the same data on the main thread, which is the expensive part.

## How to test

Unit tests:
- `cd packages/frontend/editor-ui && pnpm test src/app/utils/idleUtils.test.ts src/app/composables/useRunWorkflow.test.ts src/app/composables/useCanvasOperations.test.ts src/app/composables/usePushConnection/handlers/executionFinished.test.ts src/features/ndv/runData/components/RunData.test.ts`

Manual:
1. Open a large workflow (100+ nodes), DevTools → Performance with CPU throttling.
2. Click Execute workflow: the long `generateNodesGraph` task no longer runs inside the click interaction span; the 'User clicked execute workflow button' event still fires within ~2s.
3. Paste a large selection of nodes: same behavior for 'User pasted nodes'.
4. In the NDV output panel, click rapidly through pages: a single 'User changed ndv page' event fires ~1s after the last click, with the final page in the payload.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-912

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)