### PR TITLE
test(core): Stabilize task broker rate-limit test against timing flakes (no-changelog)

### DIFF
--- a/packages/cli/test/integration/task-runners/task-broker-server.test.ts
+++ b/packages/cli/test/integration/task-runners/task-broker-server.test.ts
@@ -1,4 +1,5 @@
 import http from 'node:http';
+import request from 'supertest';
 
 import { setupBrokerTestServer } from '@test-integration/utils/task-broker-test-server';
 
@@ -63,12 +64,21 @@ describe('TaskBrokerServer', () => {
 
 	describe('/runners/auth', () => {
 		it('should return 429 when too many requests are made', async () => {
-			await agent.post('/runners/auth').send({ token: 'invalid' }).expect(403);
-			await agent.post('/runners/auth').send({ token: 'invalid' }).expect(403);
-			await agent.post('/runners/auth').send({ token: 'invalid' }).expect(403);
-			await agent.post('/runners/auth').send({ token: 'invalid' }).expect(403);
-			await agent.post('/runners/auth').send({ token: 'invalid' }).expect(403);
-			await agent.post('/runners/auth').send({ token: 'invalid' }).expect(429);
+			// The rate limiter allows 5 requests per 1s window. Fire all requests
+			// concurrently so they land within the same window — sending them
+			// sequentially can exceed 1s on a slow runner, resetting the counter.
+			// Each request uses its own connection (not the shared keep-alive
+			// agent) so a rate-limited response can't reset a sibling request.
+			const responses = await Promise.all(
+				Array.from(
+					{ length: 6 },
+					async () => await request(server.app).post('/runners/auth').send({ token: 'invalid' }),
+				),
+			);
+
+			const statusCodes = responses.map((res) => res.status);
+			expect(statusCodes.filter((code) => code === 403)).toHaveLength(5);
+			expect(statusCodes.filter((code) => code === 429)).toHaveLength(1);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

The integration test `TaskBrokerServer › /runners/auth › should return 429 when too many requests are made` is flaky in CI (seen failing as `expected 429 "Too Many Requests", got 403 "Forbidden"`).

**Root cause:** The `/runners/auth` endpoint is rate-limited with `express-rate-limit` (`windowMs: 1000`, `limit: 5`). The test fired 6 **sequential** awaited HTTP round-trips, expecting the 6th to be rejected with 429. On a loaded/slow runner the cumulative latency of those round-trips can exceed the 1-second fixed window, so the counter resets and the 6th request lands in a fresh window, returning 403 instead of 429.

**Fix:** Fire the 6 requests concurrently with `Promise.all` so they all fall inside the same window, and assert on the response distribution (5× 403, 1× 429) rather than positional ordering. Each request uses its own connection (`request(server.app)`) rather than the shared keep-alive supertest agent, so a rate-limited response can't reset a sibling request mid-flight (which caused `ECONNRESET` in an interim attempt).

No production code changed — test-only stabilization.

## How to test

Run the test repeatedly; it should pass consistently:

```bash
cd packages/cli
for i in $(seq 1 5); do pnpm test test/integration/task-runners/task-broker-server.test.ts; done
```

## Related Linear tickets, Github issues, and Community forum posts

N/A — CI flake observed on an unrelated PR run.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI