### PR TITLE
fix(core): Guide workflow builder to handle list-shaped HTTP responses (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/evaluations/data/workflows/trading-bot-http-array-normalization.json
+++ b/packages/@n8n/instance-ai/evaluations/data/workflows/trading-bot-http-array-normalization.json
@@ -1,0 +1,48 @@
+{
+	"conversation": [
+		{
+			"role": "user",
+			"text": "You are an expert n8n workflow architect and AI systems designer.\n\nI want you to build a complete production-ready n8n workflow for an AI-powered trading signal bot that sends high-probability trade signals to Telegram.\n\nIMPORTANT REQUIREMENTS:\n- Use modular multi-agent architecture\n- Each agent must be a separate logical node (AI or function node)\n- Output must be structured JSON at every stage\n- Workflow must be scalable and clean\n\nSYSTEM GOAL:\nAnalyze live market data and generate high-quality"
+		},
+		{
+			"role": "assistant",
+			"text": "Where should the live market data come from, and where do the signals go?"
+		},
+		{
+			"role": "user",
+			"text": "Pull OHLCV candles from the Binance klines REST API (GET https://api.binance.com/api/v3/klines) via an HTTP Request node, normalize them, compute indicators, and send the final signal to Telegram. Binance returns a JSON array of candle rows, so the normalize step has to handle every candle, not just the first one."
+		}
+	],
+	"complexity": "complex",
+	"tags": [
+		"build",
+		"http-request",
+		"binance",
+		"array-normalization",
+		"code-node",
+		"telegram",
+		"trading-bot"
+	],
+	"executionScenarios": [
+		{
+			"name": "happy-path-multi-candle-array",
+			"description": "Binance klines HTTP Request returns a multi-row candle array; normalization handles every row and a non-HOLD signal reaches Telegram.",
+			"dataSetup": "Assume Binance, Telegram, and any AI-model credentials are present (mocked). The HTTP Request to GET https://api.binance.com/api/v3/klines returns Binance's real shape: a JSON array of candle rows, each row an array like [1700000000000, '42000.00', '42500.00', '41800.00', '42300.00', '120.5', ...], totaling 250 rows with a clear upward close progression toward the end. The Telegram sendMessage call returns { ok: true, result: { message_id: 9001 } }.",
+			"successCriteria": "Judge primarily on the Normalize OHLCV Code node's output: it must consume all 250 candle rows from the HTTP Request array (e.g. via $input.all() or iterating the response rows), NOT just the first row. Its output must contain a candle series of ~250 rows with non-null numeric open/high/low/close/volume and a non-null current price (not NaN/null). If the workflow runs to completion, the Telegram sendMessage message text additionally contains a concrete signal value (e.g. 'BUY', 'SELL', or 'HOLD') derived from the computed indicators; treat a missing or null signal as a failure."
+		},
+		{
+			"name": "array-shape-hidden-by-single-item-mock",
+			"description": "LOAD-BEARING: the array-vs-single bug must surface under a real multi-row response even though a single-item fixture would have passed verification.",
+			"dataSetup": "Assume credentials are mocked. The HTTP Request to the Binance klines endpoint returns the REAL array shape: a JSON array of 250 candle rows (each row an array of OHLCV fields). Critically do NOT replay a single-item fixture — inject the full multi-row array so any $input.first()/single-item assumption is exercised. Telegram sendMessage returns { ok: true, result: { message_id: 9002 } }.",
+			"successCriteria": "Judge on the Normalize OHLCV node's output when the 250-row Binance array is fed in: its candle series must have ~250 rows with populated (non-null) OHLCV values and a non-null current price — it must NOT collapse to a single row, a handful of rows, or NaN/null values, which is what happens when the node maps over $input.first().json instead of $input.all(). A collapsed or null series is a failure even if the workflow otherwise completes. If indicators are computed and reach Telegram, the message must reflect the multi-row data rather than a perpetual HOLD forced by null inputs."
+		},
+		{
+			"name": "empty-klines-response",
+			"description": "Binance returns an empty candle array — the workflow degrades cleanly instead of erroring.",
+			"dataSetup": "Assume credentials are mocked. The HTTP Request to the Binance klines endpoint returns an empty JSON array []. Telegram sendMessage, if called, returns { ok: true, result: { message_id: 9003 } }.",
+			"successCriteria": "The workflow handles the empty array without throwing. The Normalize OHLCV node yields zero rows / no indicators, and either no Telegram message is sent or a Telegram message is sent that explicitly indicates no data / no signal — the workflow completes cleanly with no unhandled error."
+		}
+	],
+	"triggerType": "schedule",
+	"messageBudget": 4
+}

--- a/packages/@n8n/instance-ai/knowledge-base/reference/workflow-builder-guardrails.md
+++ b/packages/@n8n/instance-ai/knowledge-base/reference/workflow-builder-guardrails.md
@@ -49,6 +49,14 @@ that must process every row, read `$input.all().map(i => i.json)` (or iterate
 the items) instead of mapping over `$input.first().json`, which would only see
 the first record and produce null/empty downstream values.
 
+When a downstream node must reason over the whole collection at once — a single
+AI Agent analysing a series, an indicator/metric computed across all rows, a
+summary, or a structured-output parser expecting one object — first aggregate
+the split items into a single item with a Code node (`return [{ json: { rows:
+$input.all().map(i => i.json) } }]`) and feed that one item in. A single-shot
+Agent or output parser wired directly to N split items runs once per row and
+produces malformed or unparseable output.
+
 For one digest, ranking, summary, count, or report, aggregate first and send one
 final item. For one action per source record, keep the stream itemized. Use
 `executeOnce: true` only for shared-context reads, report construction,

--- a/packages/@n8n/instance-ai/knowledge-base/reference/workflow-builder-guardrails.md
+++ b/packages/@n8n/instance-ai/knowledge-base/reference/workflow-builder-guardrails.md
@@ -42,6 +42,13 @@ upserting, or posting, check the actual item shape. Preserve itemized flow or
 split arrays into one item per record; do not collapse to no work because
 `$input.first().json` is a single object.
 
+A top-level array response (for example Binance klines, list endpoints, search
+results) is split by the HTTP Request node into one item per element, so
+`$input.first().json` is a single element, not the whole array. In a Code node
+that must process every row, read `$input.all().map(i => i.json)` (or iterate
+the items) instead of mapping over `$input.first().json`, which would only see
+the first record and produce null/empty downstream values.
+
 For one digest, ranking, summary, count, or report, aggregate first and send one
 final item. For one action per source record, keep the stream itemized. Use
 `executeOnce: true` only for shared-context reads, report construction,

--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -396,6 +396,11 @@ column names.
   later referenced by `$json` expressions, including optional trigger fields
   used in filters (for example Slack `subtype`, `bot_id`, `text`, `user`, `ts`,
   `channel`). Missing optional fields make expression-path validation fail.
+- Match real cardinality in mock `output`. When a node's real response is a
+  collection (HTTP list endpoints, search results, a top-level array such as
+  Binance klines), declare at least two items so single-item assumptions like
+  `$input.first()` break during verification instead of on the user's first
+  run. A single-item mock hides array-vs-single bugs.
 
 Use this import shape unless the task needs fewer symbols:
 


### PR DESCRIPTION
## Summary

When the workflow builder generated a workflow that fetched a **top-level array** HTTP response (e.g. Binance klines), it normalized the data with `$input.first().json`. The HTTP Request node splits a top-level array into one item per element, so `$input.first()` only sees the first record — a 250-row candle response collapsed to a single row, producing null/`NaN` downstream values (the trading bot emitted a perpetual HOLD). Verification did not catch it because it replayed a single-item mock that masked the real array shape.

This PR addresses both the builder behavior and the verification blind spot via prompt/KB guidance, plus a regression eval case:

- **Builder guidance** (`workflow-builder-guardrails.md`): a top-level array response is split into one item per element, so a Code node that must process every row should read `$input.all().map(i => i.json)`, not map over `$input.first().json`.
- **Aggregation guidance** (same file): when a downstream node must reason over the whole collection at once (a single-shot AI Agent, an indicator computed across all rows, a structured-output parser), aggregate the split items into one item first — otherwise the agent/parser runs once per row and emits unparseable output.
- **Mock cardinality rule** (`workflow-builder/SKILL.md`): mock `output()` for collections must declare ≥2 items so single-item assumptions like `$input.first()` break during verification instead of on the user's first run.
- **Regression eval** (`trading-bot-http-array-normalization.json`): asserts the analysis step consumes the full multi-row array rather than collapsing on `$input.first()`.

## How to test

1. Run the Instance AI eval for the new case:
   ```bash
   cd packages/@n8n/instance-ai
   dotenvx run -f ../../../.env.local -- pnpm eval:instance-ai --filter trading-bot --keep-workflows
   ```
2. Inspect the built workflow's analysis Code node — it should read `const klines = $input.all();` and map over every item (not `$input.first()`).

Verified locally: post-change builds emit `$input.all()` over the full candle series and aggregate before the single-shot signal agent; the empty-array scenario passes.

> Note: the two multi-row execution scenarios currently hit a transient `fetch failed` in the eval mock-execution layer (a separate harness reliability issue, not addressed here), so the fix is confirmed by direct inspection of the built workflow rather than a green scenario.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-514

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.