### PR TITLE
fix(core): Prevent SSH tunnel cleanup timer from keeping the process alive (no-changelog)

### DIFF
--- a/packages/core/src/execution-engine/__tests__/ssh-clients-manager.test.ts
+++ b/packages/core/src/execution-engine/__tests__/ssh-clients-manager.test.ts
@@ -40,6 +40,12 @@ afterEach(() => {
 	sshClientsManager.onShutdown();
 });
 
+it('should not keep the process alive for the stale-connection cleanup timer', () => {
+	const { cleanupTimer } = sshClientsManager as unknown as { cleanupTimer: NodeJS.Timeout };
+
+	expect(cleanupTimer.hasRef()).toBe(false);
+});
+
 describe('getClient', () => {
 	it('should create a new SSH client', async () => {
 		const client = await sshClientsManager.getClient(credentials);

--- a/packages/core/src/execution-engine/ssh-clients-manager.ts
+++ b/packages/core/src/execution-engine/ssh-clients-manager.ts
@@ -65,8 +65,12 @@ export class SSHClientsManager {
 		// Close all SSH connections when the process exits
 		process.on('exit', () => this.onShutdown());
 
-		// Regularly close stale SSH connections
-		this.cleanupTimer = setInterval(() => this.cleanupStaleConnections(), 60 * 1000);
+		// Regularly close stale SSH connections. Unref'd so this housekeeping
+		// timer never keeps the process alive on its own: the manager is created
+		// by every workflow execution, and a referenced interval would block
+		// process exit until SIGKILL (e.g. single-file integration test runs
+		// hang after the run completes).
+		this.cleanupTimer = setInterval(() => this.cleanupStaleConnections(), 60 * 1000).unref();
 
 		this.logger = logger.scoped('ssh-client');
 	}


### PR DESCRIPTION
## Summary

`SSHClientsManager` starts a 60s stale-connection cleanup `setInterval` in its constructor, and the manager is instantiated by every workflow execution — `getSSHTunnelFunctions()` is eagerly spread into every node execution context's `helpers`. The interval was referenced, so once any workflow ran, the Node event loop could never drain on its own. The only cleanup is wired to `process.on('exit')`, which is circular: the interval itself prevents exit.

**Visible symptom:** any workflow-executing integration test run in-band (postgres config, `--detectOpenHandles`, or a single-file run without `JEST_WORKER_IDLE_MEMORY_LIMIT`) finishes green and then hangs with *"Jest did not exit one second after the test run has completed"*. Worker-pool runs mask it because jest force-terminates child workers — which is why CI is unaffected.

**Fix:** `.unref()` the interval — a housekeeping timer should never be the thing keeping the process alive. `onShutdown()` still clears it.

**Verification:**
- New unit test asserts the timer is unref'd.
- `packages/cli` `test/integration/execution-context-propagation.test.ts` (a pre-existing workflow-executing suite) run in-band: previously hung after passing, now exits cleanly.

Found while reviewing #31927 (the new wait-error-propagation integration test surfaced the hang; the leak itself predates that PR — the interval was added in 879114b572).

## Related Linear tickets, Github issues, and Community forum posts

Discovered during review of https://linear.app/n8n/issue/CAT-3263

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)