### PR TITLE
test: Stabilize flaky resource locator dropdown e2e test

### DIFF
--- a/packages/testing/playwright/pages/NodeDetailsViewPage.ts
+++ b/packages/testing/playwright/pages/NodeDetailsViewPage.ts
@@ -961,11 +961,27 @@ export class NodeDetailsViewPage extends BasePage {
 	}
 
 	/**
-	 * Opens a resource locator dropdown for a given parameter
+	 * The open dropdown for a resource locator parameter. Rendered inline (not
+	 * teleported), so it is scoped to the parameter's container and is only
+	 * present once the dropdown is actually open.
+	 * @param paramName - The parameter name for the resource locator
+	 */
+	getResourceLocatorDropdown(paramName: string) {
+		return this.getResourceLocator(paramName).locator('[data-state="open"][role="dialog"]');
+	}
+
+	/**
+	 * Opens a resource locator dropdown for a given parameter.
+	 *
+	 * Opening can race with transient popups (e.g. a focused expression editor)
+	 * intercepting the click, so the click is retried until the dropdown renders.
 	 * @param paramName - The parameter name for the resource locator
 	 */
 	async openResourceLocator(paramName: string): Promise<void> {
 		await this.getResourceLocator(paramName).waitFor({ state: 'visible' });
-		await this.getResourceLocatorInput(paramName).click();
+		await expect(async () => {
+			await this.getResourceLocatorInput(paramName).click({ timeout: 2000 });
+			await expect(this.getResourceLocatorDropdown(paramName)).toBeVisible({ timeout: 2000 });
+		}).toPass({ timeout: 15000 });
 	}
 }

--- a/packages/testing/playwright/tests/e2e/workflows/editor/ndv/resource-locator.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/editor/ndv/resource-locator.spec.ts
@@ -35,7 +35,7 @@ test.describe(
 
 			await expect(n8n.ndv.getResourceLocator('documentId')).toBeVisible();
 
-			await n8n.ndv.getResourceLocatorInput('documentId').click();
+			await n8n.ndv.openResourceLocator('documentId');
 
 			await expect(n8n.ndv.getResourceLocatorErrorMessage('documentId')).toContainText(
 				NO_CREDENTIALS_MESSAGE,
@@ -50,7 +50,7 @@ test.describe(
 
 			await expect(n8n.ndv.getResourceLocator('documentId')).toBeVisible();
 
-			await n8n.ndv.getResourceLocatorInput('documentId').click();
+			await n8n.ndv.openResourceLocator('documentId');
 
 			await expect(n8n.ndv.getResourceLocatorErrorMessage('documentId')).toContainText(
 				NO_CREDENTIALS_MESSAGE,
@@ -90,7 +90,7 @@ test.describe(
 			const closeButton = n8n.page.locator('.el-message-box').locator('button:has-text("Close")');
 			await closeButton.click();
 
-			await n8n.ndv.getResourceLocatorInput('documentId').click();
+			await n8n.ndv.openResourceLocator('documentId');
 
 			await expect(n8n.ndv.getResourceLocatorErrorMessage('documentId')).toContainText(
 				INVALID_CREDENTIALS_MESSAGE,
@@ -101,7 +101,7 @@ test.describe(
 			await n8n.canvas.addNode('GitHub', { closeNDV: false, trigger: 'On pull request' });
 
 			await expect(n8n.ndv.getResourceLocator('owner')).toBeVisible();
-			await n8n.ndv.getResourceLocatorInput('owner').click();
+			await n8n.ndv.openResourceLocator('owner');
 
 			await expect(n8n.ndv.getResourceLocatorErrorMessage('owner')).toContainText(
 				NO_CREDENTIALS_MESSAGE,
@@ -123,12 +123,8 @@ test.describe(
 		test('should retrieve list options when other params throw errors', async ({ n8n }) => {
 			await n8n.canvas.addNode(E2E_TEST_NODE_NAME, { closeNDV: false, action: 'Resource Locator' });
 
-			await n8n.ndv.getResourceLocatorInput('rlc').click();
-
-			await expect(n8n.ndv.getResourceLocatorItems().first()).toBeVisible();
-			const visiblePopper = n8n.ndv.getVisiblePopper();
-			await expect(visiblePopper).toHaveCount(1);
-			await expect(visiblePopper.getByTestId('rlc-item')).toHaveCount(5);
+			await n8n.ndv.openResourceLocator('rlc');
+			await expect(n8n.ndv.getResourceLocatorItems()).toHaveCount(5);
 
 			await n8n.ndv.setInvalidExpression({ fieldName: 'fieldId' });
 
@@ -137,12 +133,9 @@ test.describe(
 			// wait for the expression to be evaluated and show the error
 			await expect(n8n.ndv.getParameterInputHint()).toContainText('ERROR');
 
-			await n8n.ndv.getResourceLocatorInput('rlc').click();
-
-			await expect(n8n.ndv.getResourceLocatorItems().first()).toBeVisible();
-			const visiblePopperAfter = n8n.ndv.getVisiblePopper();
-			await expect(visiblePopperAfter).toHaveCount(1);
-			await expect(visiblePopperAfter.getByTestId('rlc-item')).toHaveCount(5);
+			// The list options must still load despite the sibling parameter error.
+			await n8n.ndv.openResourceLocator('rlc');
+			await expect(n8n.ndv.getResourceLocatorItems()).toHaveCount(5);
 		});
 	},
 );


### PR DESCRIPTION
## Summary

The e2e test `resource-locator.spec.ts › should retrieve list options when other params throw errors` was flaky (~2/3 failure rate within a single job; failed [E2E / Shard 6 run 27301008790](https://github.com/n8n-io/n8n/actions/runs/27301008790/job/80647921526)).

Two layered causes:

1. **Fragile open** — the test opened the resource locator with a single, non-retried `getResourceLocatorInput('rlc').click()`. On the *reopen* (after injecting an invalid expression into a sibling param), the click raced with the lingering expression-editor popup, which intermittently intercepted it so the dropdown never opened.
2. **Fragile assertion** — `expect(getVisiblePopper()).toHaveCount(1)` then drilling `getByTestId('rlc-item')` off it. "The visible popper" is ambiguous when multiple poppers coexist; it even passed against the *wrong* popper, giving false confidence.

The underlying feature works correctly — the frontend resolves non-required sibling params to `null` (catching their expression errors), so the search request always succeeds. This was purely a UI-interaction race in the test.

### Changes
- **Harden the shared `openResourceLocator()` page-object helper** (`NodeDetailsViewPage.ts`) to retry the open click until the dropdown actually renders (`expect(...).toPass()`), with a short per-click timeout so an intercepted click fails fast and retries. This fixes the interception/race class for **every** resource-locator open repo-wide.
- Add `getResourceLocatorDropdown(paramName)` returning the inline (non-teleported) `[data-state="open"][role="dialog"]` content scoped to the parameter — a reliable "is open" signal that also holds for error/empty states.
- Migrate this spec's raw opens to the helper and assert on the well-scoped `getResourceLocatorItems()` instead of the ambiguous `getVisiblePopper()`.

## How to test

Run the resource locator e2e spec; it should pass consistently:

```bash
pnpm --filter=n8n-playwright test:local tests/e2e/workflows/editor/ndv/resource-locator.spec.ts
```

`pnpm lint`, `pnpm typecheck`, and `pnpm janitor` on the changed files all pass.

## Related Linear tickets, Github issues, and Community forum posts

<!-- No Linear ticket. -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI