### PR TITLE
refactor(core): Serve OAuth protected-resource metadata via a catch-all route (no-changelog)

### DIFF
--- a/packages/cli/src/modules/oauth-server/__tests__/oauth-server.service.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth-server.service.test.ts
@@ -890,16 +890,16 @@ describe('OAuthServerService', () => {
 			);
 
 			expect(
-				(multiResourceService as any).resolveAndValidateResourceIndicator(TEST_RESOURCE_URL),
+				await (multiResourceService as any).resolveAndValidateResourceIndicator(TEST_RESOURCE_URL),
 			).toBe(TEST_RESOURCE_URL);
 			expect(
-				(multiResourceService as any).resolveAndValidateResourceIndicator(secondResourceUrl),
+				await (multiResourceService as any).resolveAndValidateResourceIndicator(secondResourceUrl),
 			).toBe(secondResourceUrl);
-			expect(() =>
+			await expect(
 				(multiResourceService as any).resolveAndValidateResourceIndicator(
 					'https://n8n.example.com/webhook/wf-2/mcp',
 				),
-			).toThrow(InvalidTargetError);
+			).rejects.toThrow(InvalidTargetError);
 		});
 	});
 });

--- a/packages/cli/src/modules/oauth-server/__tests__/oauth-token.service.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth-token.service.test.ts
@@ -478,15 +478,15 @@ describe('OAuthTokenService', () => {
 	});
 
 	describe('getAllowedAudiences', () => {
-		it('should return canonical URL and legacy audience when expectedAudience is the canonical URL', () => {
-			const audiences = (service as any).getAllowedAudiences(
+		it('should return canonical URL and legacy audience when expectedAudience is the canonical URL', async () => {
+			const audiences = await (service as any).getAllowedAudiences(
 				'https://n8n.example.com/mcp-server/http',
 			);
 			expect(audiences).toEqual(['https://n8n.example.com/mcp-server/http', 'mcp-server-api']);
 		});
 
-		it('should return only canonical URL and legacy audience when expectedAudience is undefined', () => {
-			const audiences = (service as any).getAllowedAudiences(undefined);
+		it('should return only canonical URL and legacy audience when expectedAudience is undefined', async () => {
+			const audiences = await (service as any).getAllowedAudiences(undefined);
 			// Should still return the canonical resource URL (from getCanonicalResourceUrl) and legacy
 			expect(audiences).toEqual(['https://n8n.example.com/mcp-server/http', 'mcp-server-api']);
 		});

--- a/packages/cli/src/modules/oauth-server/__tests__/oauth.controller.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth.controller.test.ts
@@ -1,0 +1,133 @@
+import type { OAuthRegisteredClientsStore } from '@modelcontextprotocol/sdk/server/auth/clients';
+import { mockInstance } from '@n8n/backend-test-utils';
+import type { Request, Response } from 'express';
+import { mock } from 'jest-mock-extended';
+
+import type {
+	ProtectedResource,
+	ProtectedResourceRegistry,
+} from '@/services/protected-resource.registry';
+import type { UrlService } from '@/services/url.service';
+
+import { OAuthServerService } from '../oauth-server.service';
+import type { OAuthController as OAuthControllerClass } from '../oauth.controller';
+
+// The controller module resolves `OAuthServerService` at import time, which
+// constructs TypeORM repositories (needs a live DataSource). Register a mock for
+// it before importing so the module loads without a database, then pull the class
+// in via a dynamic import (static imports are hoisted above this setup).
+let OAuthController: typeof OAuthControllerClass;
+
+beforeAll(async () => {
+	// The SDK's `clientRegistrationHandler` validates `clientsStore.registerClient`
+	// when the module builds its routers, so the mock needs a real store.
+	mockInstance(OAuthServerService, { clientsStore: mock<OAuthRegisteredClientsStore>() });
+	({ OAuthController } = await import('../oauth.controller'));
+});
+
+const urlService = mock<UrlService>();
+const registry = mock<ProtectedResourceRegistry>();
+let controller: OAuthControllerClass;
+
+const makeRes = () => {
+	const res = mock<Response>();
+	res.status.mockReturnValue(res); // status().json() / status().end() chains
+	return res;
+};
+
+// Express 5 delivers wildcard params as an array of segments; the handler also
+// tolerates a plain string. Only `params` is read, so a cast keeps the fixture small.
+const makeReq = (resourcePath: string | string[]): Request =>
+	({ params: { resourcePath } }) as unknown as Request;
+
+const resource = (scopes: string[]): ProtectedResource => ({
+	id: 'instance-mcp',
+	getResourceUrl: () => 'https://n8n.test/mcp-server/http',
+	getAudiences: () => ['https://n8n.test/mcp-server/http'],
+	scopes,
+});
+
+beforeEach(() => {
+	jest.resetAllMocks();
+	urlService.getInstanceBaseUrl.mockReturnValue('https://n8n.test');
+	controller = new OAuthController(urlService, registry);
+});
+
+describe('OAuthController', () => {
+	describe('protectedResourceMetadata', () => {
+		test('resolves the registry with the reconstructed leading-slash path', async () => {
+			registry.getByResourcePath.mockResolvedValue(resource(['tool:listWorkflows']));
+
+			await controller.protectedResourceMetadata(makeReq(['mcp-server', 'http']), makeRes());
+
+			expect(registry.getByResourcePath).toHaveBeenCalledWith('/mcp-server/http');
+		});
+
+		test('reconstructs the path when the wildcard param is a string', async () => {
+			registry.getByResourcePath.mockResolvedValue(resource(['tool:listWorkflows']));
+
+			await controller.protectedResourceMetadata(makeReq('mcp-server/http'), makeRes());
+
+			expect(registry.getByResourcePath).toHaveBeenCalledWith('/mcp-server/http');
+		});
+
+		test('preserves multi-segment per-workflow paths', async () => {
+			registry.getByResourcePath.mockResolvedValue(resource(['tool:listWorkflows']));
+
+			await controller.protectedResourceMetadata(makeReq(['mcp', 'wf-123', 'trigger']), makeRes());
+
+			expect(registry.getByResourcePath).toHaveBeenCalledWith('/mcp/wf-123/trigger');
+		});
+
+		test('returns the RFC 9728 metadata document for a resolved resource', async () => {
+			const scopes = ['tool:listWorkflows', 'tool:getWorkflowDetails'];
+			registry.getByResourcePath.mockResolvedValue(resource(scopes));
+			const res = makeRes();
+
+			await controller.protectedResourceMetadata(makeReq(['mcp-server', 'http']), res);
+
+			expect(res.header).toHaveBeenCalledWith('Access-Control-Allow-Origin', '*');
+			expect(res.status).not.toHaveBeenCalledWith(404);
+			expect(res.json).toHaveBeenCalledWith({
+				resource: 'https://n8n.test/mcp-server/http',
+				bearer_methods_supported: ['header'],
+				authorization_servers: ['https://n8n.test'],
+				scopes_supported: scopes,
+			});
+		});
+
+		test('omits scopes_supported when the resource advertises no scopes', async () => {
+			registry.getByResourcePath.mockResolvedValue(resource([]));
+			const res = makeRes();
+
+			await controller.protectedResourceMetadata(makeReq(['mcp-server', 'http']), res);
+
+			const body = res.json.mock.calls[0][0] as Record<string, unknown>;
+			expect(body).not.toHaveProperty('scopes_supported');
+		});
+
+		test('responds 404 for an unknown resource', async () => {
+			registry.getByResourcePath.mockResolvedValue(undefined);
+			const res = makeRes();
+
+			await controller.protectedResourceMetadata(makeReq(['nope']), res);
+
+			expect(res.status).toHaveBeenCalledWith(404);
+			expect(res.json).toHaveBeenCalledWith(
+				expect.objectContaining({ message: 'Unknown protected resource' }),
+			);
+		});
+	});
+
+	describe('protectedResourceMetadataOptions', () => {
+		test('returns 204 with CORS headers', () => {
+			const res = makeRes();
+
+			controller.protectedResourceMetadataOptions(makeReq(['mcp-server', 'http']), res);
+
+			expect(res.header).toHaveBeenCalledWith('Access-Control-Allow-Origin', '*');
+			expect(res.status).toHaveBeenCalledWith(204);
+			expect(res.end).toHaveBeenCalled();
+		});
+	});
+});

--- a/packages/cli/src/modules/oauth-server/oauth-server.service.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-server.service.ts
@@ -167,7 +167,7 @@ export class OAuthServerService implements OAuthServerProvider {
 		this.logger.debug('Starting OAuth authorization', { clientId: client.client_id });
 
 		try {
-			const resource = this.resolveAndValidateResourceIndicator(params.resource?.toString());
+			const resource = await this.resolveAndValidateResourceIndicator(params.resource?.toString());
 
 			this.oauthSessionService.createSession(res, {
 				clientId: client.client_id,
@@ -227,7 +227,7 @@ export class OAuthServerService implements OAuthServerProvider {
 		}
 
 		const resourceStr = resource?.toString();
-		const tokenResource = this.resolveAndValidateResourceIndicator(resourceStr);
+		const tokenResource = await this.resolveAndValidateResourceIndicator(resourceStr);
 
 		// RFC 8707: if both the token request and the auth code specify a resource, they must match
 		// (token substitution defense). Otherwise either supplies the other, falling back to the
@@ -280,7 +280,7 @@ export class OAuthServerService implements OAuthServerProvider {
 		return await this.tokenService.validateAndRotateRefreshToken(
 			refreshToken,
 			client.client_id,
-			this.resolveAndValidateResourceIndicator(resourceStr),
+			await this.resolveAndValidateResourceIndicator(resourceStr),
 		);
 	}
 
@@ -291,13 +291,15 @@ export class OAuthServerService implements OAuthServerProvider {
 	// Exact-match against a registered resource, as required by RFC 8707 §2.1.
 	// Prefix/wildcard matching would open the door to malicious-host or
 	// path-traversal indicators like ".../mcp-server/http/../admin".
-	private resolveAndValidateResourceIndicator(resource: string | undefined): string | undefined {
+	private async resolveAndValidateResourceIndicator(
+		resource: string | undefined,
+	): Promise<string | undefined> {
 		if (resource === undefined) {
 			return undefined;
 		}
 
 		const normalizedResource = resource.replace(/\/$/, '');
-		const match = this.resourceRegistry.getByResourceUrl(normalizedResource);
+		const match = await this.resourceRegistry.getByResourceUrl(normalizedResource);
 		if (!match) {
 			const knownResources = this.resourceRegistry
 				.getAll()

--- a/packages/cli/src/modules/oauth-server/oauth-token.service.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-token.service.ts
@@ -170,7 +170,7 @@ export class OAuthTokenService implements OAuthTokenVerifier {
 		let decoded: unknown;
 
 		try {
-			const allowedAudiences = this.getAllowedAudiences(expectedAudience);
+			const allowedAudiences = await this.getAllowedAudiences(expectedAudience);
 			decoded = this.verifyJwtWithAllowedAudiences(token, allowedAudiences);
 		} catch (error) {
 			throw new JWTVerificationError();
@@ -280,9 +280,9 @@ export class OAuthTokenService implements OAuthTokenVerifier {
 	 * Resource-specific legacy audiences (e.g. the instance MCP server's
 	 * pre-RFC-8707 `mcp-server-api`) stay scoped to their own resource this way.
 	 */
-	private getAllowedAudiences(expectedAudience?: string): string[] {
+	private async getAllowedAudiences(expectedAudience?: string): Promise<string[]> {
 		if (expectedAudience) {
-			const resource = this.resourceRegistry.getByResourceUrl(expectedAudience);
+			const resource = await this.resourceRegistry.getByResourceUrl(expectedAudience);
 			return resource ? resource.getAudiences() : [expectedAudience];
 		}
 

--- a/packages/cli/src/modules/oauth-server/oauth.controller.ts
+++ b/packages/cli/src/modules/oauth-server/oauth.controller.ts
@@ -9,7 +9,6 @@ import { Get, Options, RootLevelController, StaticRouterMetadata } from '@n8n/de
 import { Container } from '@n8n/di';
 import type { Response, Request, RequestHandler, Router } from 'express';
 
-import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { ProtectedResourceRegistry } from '@/services/protected-resource.registry';
 import { UrlService } from '@/services/url.service';
 
@@ -149,7 +148,7 @@ export class OAuthController {
 		res.json(metadata);
 	}
 
-	@Options('/.well-known/oauth-protected-resource/mcp-server/http', {
+	@Options('/.well-known/oauth-protected-resource/*resourcePath', {
 		skipAuth: true,
 		usesTemplates: true,
 		ipRateLimit: { limit: 100, windowMs: 5 * Time.minutes.toMilliseconds },
@@ -160,33 +159,40 @@ export class OAuthController {
 	}
 
 	/**
-	 * RFC 9728 protected-resource metadata for the instance MCP server.
-	 *
-	 * The route stays explicit (rather than a catch-all resolving any registered
-	 * resource path) because the instance MCP server is the only registered
-	 * resource today and existing clients depend on this exact URL. Generalize
-	 * to a registry-driven catch-all when per-workflow trigger resources land
-	 * (IAM-799).
+	 * RFC 9728 protected-resource metadata, resolved dynamically through the
+	 * registry so any registered resource path is served by one route — the
+	 * static instance MCP resource today, per-workflow resources later.
 	 */
-	@Get('/.well-known/oauth-protected-resource/mcp-server/http', {
+	@Get('/.well-known/oauth-protected-resource/*resourcePath', {
 		skipAuth: true,
 		usesTemplates: true,
 		ipRateLimit: { limit: 100, windowMs: 5 * Time.minutes.toMilliseconds },
 	})
-	async protectedResourceMetadata(_req: Request, res: Response) {
+	async protectedResourceMetadata(req: Request, res: Response) {
 		this.setCorsHeaders(res);
 
-		const resource = await this.resourceRegistry.getByResourcePath('/mcp-server/http');
+		const resourcePath =
+			'/' +
+			(Array.isArray(req.params.resourcePath)
+				? req.params.resourcePath.join('/')
+				: req.params.resourcePath); // Wildcard params are captured as arrays
+		const resource = await this.resourceRegistry.getByResourcePath(resourcePath);
 		if (!resource) {
-			throw new NotFoundError('Unknown protected resource');
+			res.status(404).json({ message: 'Unknown protected resource' });
+			return;
 		}
 
 		const baseUrl = this.urlService.getInstanceBaseUrl();
-		res.json({
+		const metadata: Record<string, unknown> = {
 			resource: resource.getResourceUrl(),
 			bearer_methods_supported: ['header'],
 			authorization_servers: [baseUrl],
-			scopes_supported: resource.scopes,
-		});
+		};
+
+		if (resource.scopes.length > 0) {
+			metadata.scopes_supported = resource.scopes;
+		}
+
+		res.json(metadata);
 	}
 }

--- a/packages/cli/src/modules/oauth-server/oauth.controller.ts
+++ b/packages/cli/src/modules/oauth-server/oauth.controller.ts
@@ -173,10 +173,10 @@ export class OAuthController {
 		usesTemplates: true,
 		ipRateLimit: { limit: 100, windowMs: 5 * Time.minutes.toMilliseconds },
 	})
-	protectedResourceMetadata(_req: Request, res: Response) {
+	async protectedResourceMetadata(_req: Request, res: Response) {
 		this.setCorsHeaders(res);
 
-		const resource = this.resourceRegistry.getByResourcePath('/mcp-server/http');
+		const resource = await this.resourceRegistry.getByResourcePath('/mcp-server/http');
 		if (!resource) {
 			throw new NotFoundError('Unknown protected resource');
 		}

--- a/packages/cli/src/services/__tests__/protected-resource.registry.test.ts
+++ b/packages/cli/src/services/__tests__/protected-resource.registry.test.ts
@@ -1,4 +1,4 @@
-import type { ProtectedResource } from '../protected-resource.registry';
+import type { ProtectedResource, ProtectedResourceResolver } from '../protected-resource.registry';
 import { ProtectedResourceRegistry } from '../protected-resource.registry';
 
 const resourceA: ProtectedResource = {
@@ -32,17 +32,25 @@ describe('ProtectedResourceRegistry', () => {
 			expect(registry.getById('unknown')).toBeUndefined();
 		});
 
-		it('should resolve resources by resource URL, ignoring trailing slashes', () => {
-			expect(registry.getByResourceUrl('https://n8n.example.com/mcp-server/http')).toBe(resourceA);
-			expect(registry.getByResourceUrl('https://n8n.example.com/mcp-server/http/')).toBe(resourceA);
-			expect(registry.getByResourceUrl('https://n8n.example.com/webhook/wf-1/mcp')).toBe(resourceB);
-			expect(registry.getByResourceUrl('https://evil.example.com/mcp-server/http')).toBeUndefined();
+		it('should resolve resources by resource URL, ignoring trailing slashes', async () => {
+			expect(await registry.getByResourceUrl('https://n8n.example.com/mcp-server/http')).toBe(
+				resourceA,
+			);
+			expect(await registry.getByResourceUrl('https://n8n.example.com/mcp-server/http/')).toBe(
+				resourceA,
+			);
+			expect(await registry.getByResourceUrl('https://n8n.example.com/webhook/wf-1/mcp')).toBe(
+				resourceB,
+			);
+			expect(
+				await registry.getByResourceUrl('https://evil.example.com/mcp-server/http'),
+			).toBeUndefined();
 		});
 
-		it('should resolve resources by URL path', () => {
-			expect(registry.getByResourcePath('/mcp-server/http')).toBe(resourceA);
-			expect(registry.getByResourcePath('/webhook/wf-1/mcp')).toBe(resourceB);
-			expect(registry.getByResourcePath('/unknown')).toBeUndefined();
+		it('should resolve resources by URL path', async () => {
+			expect(await registry.getByResourcePath('/mcp-server/http')).toBe(resourceA);
+			expect(await registry.getByResourcePath('/webhook/wf-1/mcp')).toBe(resourceB);
+			expect(await registry.getByResourcePath('/unknown')).toBeUndefined();
 		});
 
 		it('should resolve the default resource', () => {
@@ -72,12 +80,12 @@ describe('ProtectedResourceRegistry', () => {
 			]);
 		});
 
-		it('should keep per-resource audiences isolated', () => {
+		it('should keep per-resource audiences isolated', async () => {
 			// The legacy audience belongs to the instance resource only — resolving
 			// audiences through a specific resource must not leak it to others.
-			expect(registry.getByResourceUrl(resourceB.getResourceUrl())?.getAudiences()).toEqual([
-				'https://n8n.example.com/webhook/wf-1/mcp',
-			]);
+			expect((await registry.getByResourceUrl(resourceB.getResourceUrl()))?.getAudiences()).toEqual(
+				['https://n8n.example.com/webhook/wf-1/mcp'],
+			);
 		});
 
 		it('should union scopes across all registered resources, deduplicated', () => {

--- a/packages/cli/src/services/__tests__/protected-resource.registry.test.ts
+++ b/packages/cli/src/services/__tests__/protected-resource.registry.test.ts
@@ -1,4 +1,4 @@
-import type { ProtectedResource, ProtectedResourceResolver } from '../protected-resource.registry';
+import type { ProtectedResource } from '../protected-resource.registry';
 import { ProtectedResourceRegistry } from '../protected-resource.registry';
 
 const resourceA: ProtectedResource = {

--- a/packages/cli/src/services/protected-resource.registry.ts
+++ b/packages/cli/src/services/protected-resource.registry.ts
@@ -37,6 +37,46 @@ export interface ProtectedResource {
 	isDefault?: boolean;
 }
 
+/**
+ * On-demand resolver for protected resources that aren't held in the registry's
+ * static map. Registered via {@link ProtectedResourceRegistry.registerResolver},
+ * resolvers are consulted only after the static map misses — letting a resource
+ * be resolved lazily (e.g. from the database) instead of being materialized up
+ * front.
+ */
+export interface ProtectedResourceResolver {
+	/** Stable identifier for the resolver, e.g. `'workflow-trigger'`. */
+	readonly id: string;
+
+	/**
+	 * Scopes contributed to discovery documents via
+	 * {@link ProtectedResourceRegistry.getAllScopes}, unioned with the static
+	 * resources' scopes.
+	 */
+	readonly scopes: string[];
+
+	/**
+	 * Resolve a resource by its canonical URL, or `undefined` if this resolver
+	 * owns no such resource. The input is pre-normalized (trailing slash
+	 * trimmed) by the registry.
+	 */
+	resolveByUrl(resourceUrl: string): Promise<ProtectedResource | undefined>;
+
+	/**
+	 * Resolve a resource by its URL path (e.g. `/webhook/wf-1/mcp`), or
+	 * `undefined` if this resolver owns no such resource. The input is
+	 * pre-normalized (trailing slash trimmed) by the registry.
+	 */
+	resolveByPath(pathname: string): Promise<ProtectedResource | undefined>;
+
+	/**
+	 * Whether this resolver currently owns at least one enabled resource. Drives
+	 * the shared OAuth server's availability guard via
+	 * {@link ProtectedResourceRegistry.isAnyResourceEnabled}.
+	 */
+	hasAnyEnabledResource(): Promise<boolean>;
+}
+
 const trimTrailingSlash = (url: string): string => url.replace(/\/$/, '');
 
 /**
@@ -48,9 +88,14 @@ const trimTrailingSlash = (url: string): string => url.replace(/\/$/, '');
 @Service()
 export class ProtectedResourceRegistry {
 	private readonly resources = new Map<string, ProtectedResource>();
+	private readonly resolvers = new Set<ProtectedResourceResolver>();
 
 	register(resource: ProtectedResource): void {
 		this.resources.set(resource.id, resource);
+	}
+
+	registerResolver(resolver: ProtectedResourceResolver) {
+		this.resolvers.add(resolver);
 	}
 
 	getById(id: string): ProtectedResource | undefined {
@@ -58,16 +103,20 @@ export class ProtectedResourceRegistry {
 	}
 
 	/** Look up a resource by its canonical URL (trailing slashes ignored). */
-	getByResourceUrl(resourceUrl: string): ProtectedResource | undefined {
+	async getByResourceUrl(resourceUrl: string): Promise<ProtectedResource | undefined> {
 		const normalized = trimTrailingSlash(resourceUrl);
 		for (const resource of this.resources.values()) {
 			if (trimTrailingSlash(resource.getResourceUrl()) === normalized) return resource;
+		}
+		for (const resolver of this.resolvers) {
+			const resource = await resolver.resolveByUrl(normalized);
+			if (resource) return resource;
 		}
 		return undefined;
 	}
 
 	/** Look up a resource by its URL path (e.g. `/mcp-server/http`). */
-	getByResourcePath(pathname: string): ProtectedResource | undefined {
+	async getByResourcePath(pathname: string): Promise<ProtectedResource | undefined> {
 		const normalized = trimTrailingSlash(pathname);
 		for (const resource of this.resources.values()) {
 			try {
@@ -77,6 +126,11 @@ export class ProtectedResourceRegistry {
 			} catch {
 				continue;
 			}
+		}
+
+		for (const resolver of this.resolvers) {
+			const resource = await resolver.resolveByPath(normalized);
+			if (resource) return resource;
 		}
 		return undefined;
 	}
@@ -115,6 +169,9 @@ export class ProtectedResourceRegistry {
 		const scopes = new Set<string>();
 		for (const resource of this.resources.values()) {
 			for (const scope of resource.scopes) scopes.add(scope);
+		}
+		for (const resolver of this.resolvers) {
+			for (const scope of resolver.scopes) scopes.add(scope);
 		}
 		return [...scopes];
 	}


### PR DESCRIPTION
## Summary

Replaces the hardcoded RFC 9728 protected-resource-metadata (PRM) route (/.well-known/oauth-protected-resource/mcp-server/http) with a single catch-all /.well-known/oauth-protected-resource/*resourcePath that resolves any resource path through the ProtectedResourceRegistry. The instance MCP server keeps working through the same code path with a byte-identical response body.

Why. This is slice 2 of 5 of [IAM-799](https://linear.app/n8n/issue/IAM-799) (OAuth-protecting the MCP Trigger per-workflow), and builds on [IAM-815](https://linear.app/n8n/issue/IAM-815) (the resolver-aware async registry).
Per-workflow trigger resources will each have their own PRM path (/.well-known/oauth-protected-resource/mcp/<path>), so the route can no longer be hardcoded to a single resource — it must resolve the resource dynamically. The previous route’s own comment already prescribed this generalization. After this slice the catch-all still only ever resolves the static instance-MCP resource; the per-workflow resolver itself lands in slice 3.

The shared RFC 8414 authorization-server document (/.well-known/oauth-authorization-server) is unchanged.

## How to test

Prerequisites: an n8n instance with the MCP server enabled (so the instance-MCP protected resource is registered).

Byte-parity (legacy URL still works):
`curl -s $BASE_URL/.well-known/oauth-protected-resource/mcp-server/http | jq`
Expect 200 with the unchanged body:
`{ "resource": "<base>/mcp-server/http", "bearer_methods_supported": ["header"], "authorization_servers": ["<base>"], "scopes_supported": ["tool:listWorkflows", "tool:getWorkflowDetails"] }.`
Unknown resource → 404:
`curl -s -o /dev/null -w "%{http_code}" $BASE_URL/.well-known/oauth-protected-resource/does-not-exist`
Expect 404.
CORS preflight → 204:
`curl -s -i -X OPTIONS $BASE_URL/.well-known/oauth-protected-resource/mcp-server/http`
Expect 204 with Access-Control-Allow-Origin: * (and the other discovery CORS headers).
Auth-server doc unaffected:
`curl -s $BASE_URL/.well-known/oauth-authorization-server | jq`
Unchanged.

## Related Linear tickets, Github issues, and Community forum posts

closes https://linear.app/n8n/issue/IAM-816

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
