### PR TITLE
feat: Publish desktop assistant workflows when built or edited (no-changelog)

### DIFF
--- a/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.service.test.ts
@@ -20,6 +20,7 @@ import type { NodeTypes } from '@/node-types';
 import type { ProjectService } from '@/services/project.service.ee';
 import type { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import type { WorkflowSharingService } from '@/workflows/workflow-sharing.service';
+import type { WorkflowService } from '@/workflows/workflow.service';
 
 import { DESKTOP_ASSISTANT_TAG } from '../constants';
 import { DesktopAssistantService } from '../desktop-assistant.service';
@@ -32,6 +33,10 @@ function makeService() {
 	const instanceAiService = mock<InstanceAiService>();
 	const memoryService = mock<InstanceAiMemoryService>();
 	const eventBus = mock<InProcessEventBus>();
+	// Default: subscribing returns a no-op unsubscribe so build-outcome listeners
+	// (promote, edit, one-shot) get a real cleanup fn. Tests that drive the bus
+	// override this with mockImplementation to capture the handler.
+	eventBus.subscribe.mockReturnValue(() => {});
 	const workflowRepository = mock<WorkflowRepository>();
 	const workflowFinderService = mock<WorkflowFinderService>();
 	const workflowSharingService = mock<WorkflowSharingService>();
@@ -46,6 +51,7 @@ function makeService() {
 	const projectService = mock<ProjectService>();
 	const nodeTypes = mock<NodeTypes>();
 	const credentialTypes = mock<CredentialTypes>();
+	const workflowService = mock<WorkflowService>();
 
 	const service = new DesktopAssistantService(
 		logger,
@@ -64,6 +70,7 @@ function makeService() {
 		projectService,
 		nodeTypes,
 		credentialTypes,
+		workflowService,
 	);
 
 	return {
@@ -84,6 +91,7 @@ function makeService() {
 		projectService,
 		nodeTypes,
 		credentialTypes,
+		workflowService,
 	};
 }
 
@@ -152,6 +160,146 @@ describe('DesktopAssistantService.triggerTask', () => {
 		expect(forwardedAttachments).toBe(attachments);
 		expect(message).toContain('Currently looking at: Finder — Downloads');
 		expect(message).toContain('Path: /Users/me/Downloads');
+	});
+});
+
+describe('DesktopAssistantService.triggerTask publishing', () => {
+	/**
+	 * Run a one-shot task and emit a legacy planned-task build outcome for the
+	 * given workflow, with `workflowRepository.findOne` returning `workflow` for
+	 * the activation guard's node lookup.
+	 */
+	async function triggerAndBuild(
+		ctx: ReturnType<typeof makeService>,
+		workflow: Record<string, unknown> | null,
+	) {
+		ctx.projectService.getPersonalProject.mockResolvedValue({ id: 'proj-1' } as never);
+		ctx.memoryService.ensureThread.mockResolvedValue({
+			thread: {
+				id: 't',
+				resourceId: USER.id,
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+			},
+			created: true,
+		});
+		ctx.instanceAiService.startRun.mockReturnValue('run-os');
+		ctx.workflowRepository.findOne.mockResolvedValue(workflow as never);
+
+		let handler: ((e: StoredEvent) => void) | undefined;
+		ctx.eventBus.subscribe.mockImplementation((_threadId, h) => {
+			handler = h;
+			return () => {};
+		});
+
+		await ctx.service.triggerTask(USER, { prompt: 'every morning email me the news' });
+		expect(handler).toBeDefined();
+
+		handler!({
+			id: 7,
+			event: {
+				type: 'tasks-update',
+				runId: 'r-1',
+				agentId: 'orchestrator',
+				payload: {
+					tasks: {
+						tasks: [{ id: 'task-build', description: 'Build the workflow', status: 'done' }],
+					},
+					planItems: [
+						{
+							id: 'task-build',
+							title: 'Build the workflow',
+							kind: 'build-workflow',
+							spec: 'spec',
+							deps: [],
+							workflowId: 'wf-built',
+						},
+					],
+				},
+			},
+		} as unknown as StoredEvent);
+
+		for (let i = 0; i < 5; i++) await new Promise((resolve) => setImmediate(resolve));
+	}
+
+	test('publishes a runnable workflow built by a one-shot task', async () => {
+		const ctx = makeService();
+		await triggerAndBuild(ctx, {
+			id: 'wf-built',
+			nodes: [
+				{
+					name: 'Schedule',
+					type: 'n8n-nodes-base.scheduleTrigger',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+			],
+		});
+
+		expect(ctx.workflowService.activateWorkflow).toHaveBeenCalledWith(USER, 'wf-built', {
+			source: 'n8n-ai',
+		});
+	});
+
+	test('does NOT publish a one-shot workflow that is missing credentials', async () => {
+		const ctx = makeService();
+		ctx.nodeTypes.getByNameAndVersion.mockReturnValue({
+			description: { properties: [], credentials: [{ name: 'gmailOAuth2' }] },
+		} as never);
+		await triggerAndBuild(ctx, {
+			id: 'wf-built',
+			nodes: [
+				{
+					name: 'Gmail',
+					type: 'n8n-nodes-base.gmail',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+			],
+		});
+
+		expect(ctx.workflowService.activateWorkflow).not.toHaveBeenCalled();
+	});
+
+	test('does nothing when a one-shot task builds no workflow', async () => {
+		const ctx = makeService();
+		ctx.projectService.getPersonalProject.mockResolvedValue({ id: 'proj-1' } as never);
+		ctx.memoryService.ensureThread.mockResolvedValue({
+			thread: {
+				id: 't',
+				resourceId: USER.id,
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+			},
+			created: true,
+		});
+		ctx.instanceAiService.startRun.mockReturnValue('run-os');
+		// No build outcome persisted for the run.
+		ctx.memoryService.getThreadMetadata.mockResolvedValue(undefined);
+
+		let handler: ((e: StoredEvent) => void) | undefined;
+		ctx.eventBus.subscribe.mockImplementation((_threadId, h) => {
+			handler = h;
+			return () => {};
+		});
+
+		await ctx.service.triggerTask(USER, { prompt: 'rename my desktop files' });
+
+		handler!({
+			id: 9,
+			event: {
+				type: 'run-finish',
+				runId: 'run-os',
+				agentId: 'orchestrator',
+				payload: { status: 'completed' },
+			},
+		} as unknown as StoredEvent);
+
+		for (let i = 0; i < 5; i++) await new Promise((resolve) => setImmediate(resolve));
+
+		expect(ctx.workflowService.activateWorkflow).not.toHaveBeenCalled();
 	});
 });
 
@@ -569,6 +717,152 @@ describe('DesktopAssistantService.promoteThread', () => {
 		expect(ctx.workflowTagMappingRepository.insert).not.toHaveBeenCalled();
 		expect(ctx.workflowRepository.update).not.toHaveBeenCalled();
 		expect(ctx.memoryService.updateThread).not.toHaveBeenCalled();
+	});
+
+	/**
+	 * Drive a promote through to its post-build finalisation via the legacy
+	 * planned-task path, with `workflowRepository.findOne` returning `workflow`
+	 * for both the meta write and the activation guard's node lookup.
+	 */
+	async function promoteAndFinalise(
+		ctx: ReturnType<typeof makeService>,
+		workflow: Record<string, unknown>,
+	) {
+		ctx.memoryService.checkThreadOwnership.mockResolvedValue('owned');
+		ctx.memoryService.getThreadMetadata.mockResolvedValue(undefined);
+		ctx.memoryService.getThreadMessages.mockResolvedValue({
+			threadId: 't-1',
+			messages: [
+				{
+					id: 'm-1',
+					role: 'user',
+					content: 'every morning email me the news',
+					type: 'text',
+					createdAt: new Date().toISOString(),
+				},
+			],
+		});
+		ctx.instanceAiService.startRun.mockReturnValue('run-promote');
+		ctx.tagRepository.findOne.mockResolvedValue(null);
+		ctx.tagRepository.create.mockReturnValue({ name: DESKTOP_ASSISTANT_TAG } as never);
+		ctx.tagRepository.save.mockResolvedValue({
+			id: 'tag-da',
+			name: DESKTOP_ASSISTANT_TAG,
+		} as never);
+		ctx.workflowTagMappingRepository.findOne.mockResolvedValue(null);
+		ctx.workflowRepository.findOne.mockResolvedValue(workflow as never);
+
+		let handler: ((e: StoredEvent) => void) | undefined;
+		ctx.eventBus.subscribe.mockImplementation((_threadId, h) => {
+			handler = h;
+			return () => {};
+		});
+
+		await ctx.service.promoteThread(USER, { threadId: 't-1' });
+
+		handler!({
+			id: 7,
+			event: {
+				type: 'tasks-update',
+				runId: 'r-1',
+				agentId: 'orchestrator',
+				payload: {
+					tasks: {
+						tasks: [{ id: 'task-build', description: 'Build the workflow', status: 'done' }],
+					},
+					planItems: [
+						{
+							id: 'task-build',
+							title: 'Build the workflow',
+							kind: 'build-workflow',
+							spec: 'spec',
+							deps: [],
+							workflowId: 'wf-new',
+						},
+					],
+				},
+			},
+		} as unknown as StoredEvent);
+
+		// Drain the async finalise + activation chain.
+		for (let i = 0; i < 5; i++) await new Promise((resolve) => setImmediate(resolve));
+	}
+
+	test('auto-publishes a runnable promoted workflow (all credentials connected)', async () => {
+		const ctx = makeService();
+		// Default nodeTypes mock yields no node requiring credential setup, so the
+		// workflow counts as runnable.
+		await promoteAndFinalise(ctx, {
+			id: 'wf-new',
+			meta: {},
+			nodes: [
+				{
+					name: 'Schedule',
+					type: 'n8n-nodes-base.scheduleTrigger',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+			],
+		});
+
+		expect(ctx.workflowService.activateWorkflow).toHaveBeenCalledWith(USER, 'wf-new', {
+			source: 'n8n-ai',
+		});
+	});
+
+	test('does NOT auto-publish a promoted workflow that is missing credentials', async () => {
+		const ctx = makeService();
+		// A node with no credentials slot whose type declares a required credential
+		// => surfaces as "needs setup", so we leave it as a draft.
+		ctx.nodeTypes.getByNameAndVersion.mockReturnValue({
+			description: { properties: [], credentials: [{ name: 'gmailOAuth2' }] },
+		} as never);
+		await promoteAndFinalise(ctx, {
+			id: 'wf-new',
+			meta: {},
+			nodes: [
+				{
+					name: 'Gmail',
+					type: 'n8n-nodes-base.gmail',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+			],
+		});
+
+		expect(ctx.workflowService.activateWorkflow).not.toHaveBeenCalled();
+		// Tagging + finalisation still happened.
+		expect(ctx.workflowTagMappingRepository.insert).toHaveBeenCalled();
+		expect(ctx.memoryService.updateThread).toHaveBeenCalled();
+	});
+
+	test('swallows an activation failure (e.g. manual-only workflow) and still finalises', async () => {
+		const ctx = makeService();
+		ctx.workflowService.activateWorkflow.mockRejectedValue(
+			new Error('has no node to start the workflow'),
+		);
+		await promoteAndFinalise(ctx, {
+			id: 'wf-new',
+			meta: {},
+			nodes: [
+				{
+					name: 'Manual',
+					type: 'n8n-nodes-base.manualTrigger',
+					typeVersion: 1,
+					position: [0, 0],
+					parameters: {},
+				},
+			],
+		});
+
+		expect(ctx.workflowService.activateWorkflow).toHaveBeenCalled();
+		// Failure is best-effort: the promote still finalised.
+		expect(ctx.workflowTagMappingRepository.insert).toHaveBeenCalled();
+		expect(ctx.memoryService.updateThread).toHaveBeenCalledWith('t-1', {
+			metadata: { promotedWorkflowId: 'wf-new' },
+		});
 	});
 });
 
@@ -1131,5 +1425,90 @@ describe('DesktopAssistantService.applyTaskEdits', () => {
 		expect(options).toEqual({ promptMode: 'desktop-assistant-edit' });
 		expect(result).toMatchObject({ runId: 'run-9' });
 		expect(result.threadId).toBeDefined();
+	});
+
+	test('re-publishes the edited version when the workflow was already active', async () => {
+		const ctx = makeService();
+		ctx.workflowFinderService.findWorkflowForUser.mockResolvedValue(
+			workflowWith({ activeVersionId: 'v1' }),
+		);
+		ctx.projectService.getPersonalProject.mockResolvedValue({ id: 'proj-1' } as never);
+		ctx.instanceAiService.startRun.mockReturnValue('run-9');
+		// After the edit, the workflow's draft has advanced to v2.
+		ctx.workflowRepository.findOne.mockResolvedValue({ id: 'wf-1', versionId: 'v2' } as never);
+
+		let handler: ((e: StoredEvent) => void) | undefined;
+		ctx.eventBus.subscribe.mockImplementation((_threadId, h) => {
+			handler = h;
+			return () => {};
+		});
+
+		const { threadId } = await ctx.service.applyTaskEdits(USER, 'wf-1', { changes: CHANGES });
+		expect(ctx.eventBus.subscribe).toHaveBeenCalledWith(threadId, expect.any(Function));
+		expect(handler).toBeDefined();
+
+		handler!({
+			id: 9,
+			event: {
+				type: 'run-finish',
+				runId: 'run-9',
+				agentId: 'orchestrator',
+				payload: { status: 'completed' },
+			},
+		} as unknown as StoredEvent);
+
+		for (let i = 0; i < 5; i++) await new Promise((resolve) => setImmediate(resolve));
+
+		expect(ctx.workflowService.activateWorkflow).toHaveBeenCalledWith(USER, 'wf-1', {
+			versionId: 'v2',
+			source: 'n8n-ai',
+		});
+	});
+
+	test('does NOT subscribe or re-publish when the workflow was not active', async () => {
+		const ctx = makeService();
+		// No activeVersionId => inactive; its edit takes effect on the next run.
+		ctx.workflowFinderService.findWorkflowForUser.mockResolvedValue(workflowWith());
+		ctx.projectService.getPersonalProject.mockResolvedValue({ id: 'proj-1' } as never);
+		ctx.instanceAiService.startRun.mockReturnValue('run-9');
+
+		await ctx.service.applyTaskEdits(USER, 'wf-1', { changes: CHANGES });
+
+		expect(ctx.eventBus.subscribe).not.toHaveBeenCalled();
+		expect(ctx.workflowService.activateWorkflow).not.toHaveBeenCalled();
+	});
+
+	test('swallows a re-publish failure on run-finish', async () => {
+		const ctx = makeService();
+		ctx.workflowFinderService.findWorkflowForUser.mockResolvedValue(
+			workflowWith({ activeVersionId: 'v1' }),
+		);
+		ctx.projectService.getPersonalProject.mockResolvedValue({ id: 'proj-1' } as never);
+		ctx.instanceAiService.startRun.mockReturnValue('run-9');
+		ctx.workflowRepository.findOne.mockResolvedValue({ id: 'wf-1', versionId: 'v2' } as never);
+		ctx.workflowService.activateWorkflow.mockRejectedValue(new Error('validation failed'));
+
+		let handler: ((e: StoredEvent) => void) | undefined;
+		ctx.eventBus.subscribe.mockImplementation((_threadId, h) => {
+			handler = h;
+			return () => {};
+		});
+
+		await ctx.service.applyTaskEdits(USER, 'wf-1', { changes: CHANGES });
+
+		handler!({
+			id: 9,
+			event: {
+				type: 'run-finish',
+				runId: 'run-9',
+				agentId: 'orchestrator',
+				payload: { status: 'completed' },
+			},
+		} as unknown as StoredEvent);
+
+		for (let i = 0; i < 5; i++) await new Promise((resolve) => setImmediate(resolve));
+
+		// Attempted, rejected, and swallowed — no unhandled rejection.
+		expect(ctx.workflowService.activateWorkflow).toHaveBeenCalled();
 	});
 });

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
@@ -37,6 +37,7 @@ import { NodeTypes } from '@/node-types';
 import { ProjectService } from '@/services/project.service.ee';
 import { WorkflowFinderService } from '@/workflows/workflow-finder.service';
 import { WorkflowSharingService } from '@/workflows/workflow-sharing.service';
+import { WorkflowService } from '@/workflows/workflow.service';
 
 import {
 	DESKTOP_ASSISTANT_TAG,
@@ -75,7 +76,9 @@ import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { ForbiddenError } from '@/errors/response-errors/forbidden.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 
-const PROMOTE_FINALIZE_TIMEOUT_MS = 5 * 60 * 1000;
+/** Upper bound on how long a build-outcome listener (promote, edit, one-shot)
+ * stays subscribed, so a stalled run never leaks a subscription. */
+const BUILD_FINALIZE_TIMEOUT_MS = 5 * 60 * 1000;
 
 /** Statuses we treat as a failure worth surfacing an error message for. `canceled`
  * is excluded — a user-stopped run has no meaningful error. */
@@ -174,6 +177,7 @@ export class DesktopAssistantService {
 		private readonly projectService: ProjectService,
 		private readonly nodeTypes: NodeTypes,
 		private readonly credentialTypes: CredentialTypes,
+		private readonly workflowService: WorkflowService,
 	) {}
 
 	// ── tasks list ───────────────────────────────────────────────────────────
@@ -349,6 +353,23 @@ export class DesktopAssistantService {
 			undefined,
 			{ promptMode: 'desktop-assistant-one-shot' },
 		);
+
+		// A one-shot task may build a scheduled/recurring workflow (the prompt
+		// implies one). When it does, publish it so it runs on its own — same
+		// runnable guard as promote. Most one-shots are ad-hoc and build nothing,
+		// in which case the listener simply unsubscribes. Subscribe AFTER startRun
+		// so the listener scopes itself to this run.
+		const cleanup = this.subscribeForBuildOutcome(user, threadId, runId, (workflowId) => {
+			this.activateWorkflowIfRunnable(user, workflowId).catch((error: unknown) => {
+				this.logger.debug('One-shot workflow not auto-published', {
+					threadId,
+					workflowId,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			});
+		});
+		setTimeout(cleanup, BUILD_FINALIZE_TIMEOUT_MS).unref();
+
 		return { threadId, runId };
 	}
 
@@ -533,6 +554,11 @@ export class DesktopAssistantService {
 			seenParamIds.add(change.paramId);
 		}
 
+		// Only a workflow that is already published has a running version the edit
+		// must catch up to. Inactive and manual-trigger workflows run their current
+		// draft on the next execution, so the edit already takes effect for them.
+		const wasActive = Boolean(workflow.activeVersionId);
+
 		const threadId = randomUUID();
 		const projectId = await this.resolvePersonalProjectId(user);
 		await this.memoryService.ensureThread(user.id, threadId, projectId);
@@ -547,7 +573,61 @@ export class DesktopAssistantService {
 			undefined,
 			{ promptMode: 'desktop-assistant-edit' },
 		);
+
+		if (wasActive) {
+			// Subscribe AFTER we have the runId so the listener scopes itself to this
+			// exact run. When it finishes, re-publish so the running schedule/webhook
+			// picks up the edited version instead of the stale one.
+			const cleanup = this.subscribeForEditPublish(user, threadId, runId, workflowId);
+			setTimeout(cleanup, BUILD_FINALIZE_TIMEOUT_MS).unref();
+		}
+
 		return { threadId, runId };
+	}
+
+	/**
+	 * Listen for an edit run finishing and re-point the workflow's published
+	 * version at the freshly-saved draft, so an already-active workflow runs the
+	 * edited version rather than the one pinned before the edit. Best-effort: the
+	 * promise is fire-and-forget and failures (e.g. a now-invalid workflow) are
+	 * logged, not surfaced — the edit itself already succeeded.
+	 */
+	private subscribeForEditPublish(
+		user: User,
+		threadId: string,
+		runId: string,
+		workflowId: string,
+	): () => void {
+		let handled = false;
+		const unsubscribe = this.eventBus.subscribe(threadId, (storedEvent: StoredEvent) => {
+			if (handled) return;
+			const ev = storedEvent.event;
+			if (ev.type !== 'run-finish') return;
+			if (ev.runId !== runId) return;
+			handled = true;
+			unsubscribe();
+			this.republishEditedWorkflow(user, workflowId).catch((error: unknown) => {
+				this.logger.debug('Edited workflow not re-published', {
+					workflowId,
+					reason: error instanceof Error ? error.message : String(error),
+				});
+			});
+		});
+		return unsubscribe;
+	}
+
+	private async republishEditedWorkflow(user: User, workflowId: string): Promise<void> {
+		const updated = await this.workflowRepository.findOne({
+			where: { id: workflowId },
+			select: ['id', 'versionId'],
+		});
+		if (!updated) return;
+		// Re-point activeVersionId at the current draft. No-op-safe if the agent
+		// made no change (the version is unchanged and already active).
+		await this.workflowService.activateWorkflow(user, workflowId, {
+			versionId: updated.versionId,
+			source: 'n8n-ai',
+		});
 	}
 
 	// ── promote thread ──────────────────────────────────────────────────────
@@ -599,17 +679,27 @@ export class DesktopAssistantService {
 		// the exact run we just kicked off. `subscribe` is synchronous and
 		// `startRun` only registers the run; it doesn't dispatch any events on
 		// the bus before this line runs.
-		const cleanup = this.subscribeForBuildOutcome(user, body.threadId, runId);
+		const cleanup = this.subscribeForBuildOutcome(user, body.threadId, runId, (workflowId) => {
+			this.finalizePromotedWorkflow(user, body.threadId, workflowId).catch((error: unknown) => {
+				this.logger.warn('Failed to finalise promoted workflow', {
+					threadId: body.threadId,
+					workflowId,
+					error: error instanceof Error ? error.message : String(error),
+				});
+			});
+		});
 
 		// Hard-cap the listener so a stalled run does not leak a subscription.
-		setTimeout(cleanup, PROMOTE_FINALIZE_TIMEOUT_MS).unref();
+		setTimeout(cleanup, BUILD_FINALIZE_TIMEOUT_MS).unref();
 
 		return { status: 'building', threadId: body.threadId, runId };
 	}
 
 	/**
-	 * Listen for the promote run finishing, then resolve which workflow it
-	 * produced.
+	 * Listen for a build run finishing, resolve which workflow it produced, and
+	 * hand that workflowId to `onWorkflowBuilt`. Used by both promote (to tag +
+	 * activate the new workflow) and the one-shot path (to activate a workflow the
+	 * task happened to build). The callback fires at most once.
 	 *
 	 * We watch two signals because the orchestrator has more than one build
 	 * path:
@@ -623,20 +713,20 @@ export class DesktopAssistantService {
 	 *     fallback so we cover whichever path the orchestrator picks.
 	 *
 	 * Whichever signal fires first wins; both go through the same `handled`
-	 * gate so we only finalise once.
+	 * gate so we only act once. A run that finishes without building a workflow
+	 * (common for ad-hoc one-shot tasks) just unsubscribes without calling back.
 	 */
-	private subscribeForBuildOutcome(user: User, threadId: string, runId: string): () => void {
+	private subscribeForBuildOutcome(
+		user: User,
+		threadId: string,
+		runId: string,
+		onWorkflowBuilt: (workflowId: string) => void,
+	): () => void {
 		let handled = false;
 		const finalise = (workflowId: string) => {
 			handled = true;
 			unsubscribe();
-			this.finalizePromotedWorkflow(threadId, workflowId).catch((error: unknown) => {
-				this.logger.warn('Failed to finalise promoted workflow', {
-					threadId,
-					workflowId,
-					error: error instanceof Error ? error.message : String(error),
-				});
-			});
+			onWorkflowBuilt(workflowId);
 		};
 
 		const unsubscribe = this.eventBus.subscribe(threadId, (storedEvent: StoredEvent) => {
@@ -662,16 +752,17 @@ export class DesktopAssistantService {
 					if (handled) return;
 					const workflowId = extractWorkflowLoopBuildOutcome(metadata, runId);
 					if (!workflowId) {
-						this.logger.warn('Promote run finished without a successful build outcome', {
-							threadId,
-							runId,
-						});
+						// No workflow built (ad-hoc task, or a failed/ambiguous build). The
+						// run is over, so stop listening rather than wait out the timeout.
+						handled = true;
+						unsubscribe();
+						this.logger.debug('Build run finished without a workflow', { threadId, runId });
 						return;
 					}
 					finalise(workflowId);
 				})
 				.catch((error: unknown) => {
-					this.logger.warn('Failed to read promote thread metadata at run-finish', {
+					this.logger.warn('Failed to read build thread metadata at run-finish', {
 						threadId,
 						runId,
 						error: error instanceof Error ? error.message : String(error),
@@ -681,12 +772,47 @@ export class DesktopAssistantService {
 		return unsubscribe;
 	}
 
-	private async finalizePromotedWorkflow(threadId: string, workflowId: string): Promise<void> {
+	private async finalizePromotedWorkflow(
+		user: User,
+		threadId: string,
+		workflowId: string,
+	): Promise<void> {
 		await this.applyDesktopAssistantTag(workflowId);
 		await this.writeDesktopAssistantMeta(workflowId, threadId);
 		await this.memoryService.updateThread(threadId, {
 			metadata: { [PROMOTED_WORKFLOW_ID_KEY]: workflowId },
 		});
+		await this.activateWorkflowIfRunnable(user, workflowId);
+	}
+
+	/**
+	 * Publish a freshly-built workflow so it starts running immediately — but only
+	 * when it's actually runnable: every required credential is already connected.
+	 * A workflow missing a credential is left as a draft so it surfaces in
+	 * "Action needed" instead of failing on every scheduled run.
+	 *
+	 * Activation itself rejects manual-trigger-only workflows ("no node to start"),
+	 * so those stay as ready-to-run drafts. All failures are best-effort: the build
+	 * already succeeded, so we log and move on rather than surface an error. Shared
+	 * by the promote and one-shot build paths.
+	 */
+	private async activateWorkflowIfRunnable(user: User, workflowId: string): Promise<void> {
+		const workflow = await this.workflowRepository.findOne({
+			where: { id: workflowId },
+			select: ['id', 'nodes'],
+		});
+		if (!workflow) return;
+		if (computeNodesRequiringCredentialSetup(workflow.nodes ?? [], this.nodeTypes).size > 0) {
+			return;
+		}
+		try {
+			await this.workflowService.activateWorkflow(user, workflowId, { source: 'n8n-ai' });
+		} catch (error) {
+			this.logger.debug('Built workflow not auto-published', {
+				workflowId,
+				reason: error instanceof Error ? error.message : String(error),
+			});
+		}
 	}
 
 	private async applyDesktopAssistantTag(workflowId: string): Promise<void> {


### PR DESCRIPTION
## Summary

In the desktop assistant ("Look gateway"), workflows built or edited by the assistant were saved as **drafts** but never published, so they never actually ran. n8n separates a workflow's current draft (`versionId`) from its published/running version (`activeVersionId`); building or updating only touched the draft.

This wires deterministic, runnable-guarded publishing into the three desktop-assistant paths that mutate workflows:

- **One-shot task** (`triggerTask`, the path the desktop app actually uses today): when a task builds a scheduled/recurring workflow, it is published automatically once the run finishes. Ad-hoc tasks that build nothing are unaffected (the listener just unsubscribes).
- **Promote thread** (`promoteThread`): the promoted workflow is published on finalisation.
- **Apply edits** (`applyTaskEdits`): an edit to an **already-active** workflow re-points the running version at the freshly-saved draft so the schedule/webhook picks up the change. Inactive/manual workflows are untouched (they already run their draft on the next execution).

**Runnable guard:** a workflow is only auto-published when every required credential is already connected. Workflows missing credentials stay as drafts and surface in "Action needed"; manual-trigger-only workflows can't be activated and are left as ready-to-run drafts. All activation is best-effort — failures are logged, never surfaced, so the build/edit itself always succeeds.

Implementation notes:
- `subscribeForBuildOutcome` is now generic (takes an `onWorkflowBuilt` callback) and shared by promote and one-shot; it detects the built workflow via both the workflow-loop metadata (`run-finish`) and the legacy planned-task (`tasks-update`) signals.
- `activateWorkflowIfRunnable` is the shared runnable-guarded publish helper.
- Renamed the listener timeout constant to `BUILD_FINALIZE_TIMEOUT_MS` since it now guards promote, edit, and one-shot listeners.

Out of scope (deferred): re-publishing a draft after the user connects its missing credentials, and wiring the still-stubbed `TaskDraftView`/`TaskSetupView` UI to the backend.

## How to test

Against a running instance with the desktop assistant:

1. **One-shot build → live:** with a relevant credential already connected (e.g. Gmail), ask the assistant for a scheduled task ("every morning email me X"). After the run finishes, the workflow appears under **Upcoming** (active) — check `workflow_entity.activeVersionId` is set.
2. **One-shot, missing credential:** ask for a scheduled task whose integration is not connected. It stays a draft under **Action needed** (`activeVersionId` is null).
3. **Edit a live workflow:** edit an active autonomous workflow's schedule via the task detail view; after the run finishes, `activeVersionId` equals the new `versionId` and the next scheduled run uses the edited config.
4. **Edit a manual/inactive workflow:** stays inactive; the edit still applies on the next manual run.

Unit coverage: `cd packages/cli && pnpm test desktop-assistant.service` (56 tests, including the new one-shot/promote/edit publishing cases).

## Related Linear tickets, Github issues, and Community forum posts

<!-- No Linear ticket linked yet — part of the personal-automation desktop assistant initiative. -->

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported).

🤖 PR Summary generated by AI