### PR TITLE
test: Wait for canvas readiness in editor entry composers and guard raw navigation (no-changelog)

### DIFF
--- a/packages/testing/janitor/README.md
+++ b/packages/testing/janitor/README.md
@@ -436,6 +436,34 @@ test('gets workflows', async ({ api }) => {
 });
 ```
 
+#### `no-raw-editor-navigation`
+
+**Severity:** error
+
+Tests must not navigate to the workflow editor with a raw `page.goto()`. The
+editor renders a full-screen loading overlay (`node-view-loader`) while it
+boots; `page.goto()` resolves before that overlay clears, so a test that
+navigates raw and then clicks a canvas control hits a button Playwright reports
+as "stable" while the overlay silently intercepts the click — the action hangs
+until it times out. Entry composers (`n8n.start.fromImportedWorkflow()`,
+`n8n.start.fromBlankCanvas()`) own the readiness wait, so navigation must go
+through them. Only editor routes (`/workflow/<id>`, `/workflow/new`) are
+flagged; the workflow list (`/workflows`) is not.
+
+```typescript
+// Bad - Raw navigation to the editor, canvas may still be covered by the loader
+test('opens workflow', async ({ n8n }) => {
+  await n8n.page.goto(`/workflow/${workflowId}`);
+  await n8n.canvas.clickZoomToFitButton(); // can hang on the loading overlay
+});
+
+// Good - Entry composer waits for the canvas to be ready
+test('opens workflow', async ({ n8n }) => {
+  await n8n.start.fromImportedWorkflow('my-workflow.json');
+  await n8n.canvas.clickZoomToFitButton();
+});
+```
+
 ### Code Quality Rules
 
 #### `dead-code`

--- a/packages/testing/janitor/src/core/tcr-executor.ts
+++ b/packages/testing/janitor/src/core/tcr-executor.ts
@@ -17,6 +17,7 @@ import { BoundaryProtectionRule } from '../rules/boundary-protection.rule.js';
 import { DeadCodeRule } from '../rules/dead-code.rule.js';
 import { DeduplicationRule } from '../rules/deduplication.rule.js';
 import { NoPageInFlowRule } from '../rules/no-page-in-flow.rule.js';
+import { NoRawEditorNavigationRule } from '../rules/no-raw-editor-navigation.rule.js';
 import { ScopeLockdownRule } from '../rules/scope-lockdown.rule.js';
 import { SelectorPurityRule } from '../rules/selector-purity.rule.js';
 import { TestDataHygieneRule } from '../rules/test-data-hygiene.rule.js';
@@ -386,6 +387,7 @@ export class TcrExecutor {
 		runner.registerRule(new DeadCodeRule());
 		runner.registerRule(new DeduplicationRule());
 		runner.registerRule(new TestDataHygieneRule());
+		runner.registerRule(new NoRawEditorNavigationRule());
 		return runner;
 	}
 

--- a/packages/testing/janitor/src/index.ts
+++ b/packages/testing/janitor/src/index.ts
@@ -206,6 +206,7 @@ import { DeduplicationRule } from './rules/deduplication.rule.js';
 import { DuplicateLogicRule } from './rules/duplicate-logic.rule.js';
 import { NoDirectPageInstantiationRule } from './rules/no-direct-page-instantiation.rule.js';
 import { NoPageInFlowRule } from './rules/no-page-in-flow.rule.js';
+import { NoRawEditorNavigationRule } from './rules/no-raw-editor-navigation.rule.js';
 import { ScopeLockdownRule } from './rules/scope-lockdown.rule.js';
 import { SelectorPurityRule } from './rules/selector-purity.rule.js';
 import { TestDataHygieneRule } from './rules/test-data-hygiene.rule.js';
@@ -223,6 +224,7 @@ export function createDefaultRunner(): RuleRunner {
 	runner.registerRule(new TestDataHygieneRule());
 	runner.registerRule(new DuplicateLogicRule());
 	runner.registerRule(new NoDirectPageInstantiationRule());
+	runner.registerRule(new NoRawEditorNavigationRule());
 	return runner;
 }
 

--- a/packages/testing/janitor/src/rules/index.ts
+++ b/packages/testing/janitor/src/rules/index.ts
@@ -8,6 +8,7 @@ export { DeduplicationRule } from './deduplication.rule.js';
 export { TestDataHygieneRule } from './test-data-hygiene.rule.js';
 export { DuplicateLogicRule } from './duplicate-logic.rule.js';
 export { NoDirectPageInstantiationRule } from './no-direct-page-instantiation.rule.js';
+export { NoRawEditorNavigationRule } from './no-raw-editor-navigation.rule.js';
 
 // Re-export types for convenience
 export type { Violation, RuleResult, RuleConfig } from '../types.js';

--- a/packages/testing/janitor/src/rules/no-raw-editor-navigation.rule.test.ts
+++ b/packages/testing/janitor/src/rules/no-raw-editor-navigation.rule.test.ts
@@ -1,0 +1,104 @@
+import { describe } from 'vitest';
+
+import { NoRawEditorNavigationRule } from './no-raw-editor-navigation.rule.js';
+import { test, expect } from '../test/fixtures.js';
+
+describe('NoRawEditorNavigationRule', () => {
+	const rule = new NoRawEditorNavigationRule();
+
+	test('flags raw page.goto to an editor route with a workflow id', ({ project, createFile }) => {
+		const file = createFile(
+			'/tests/e2e/example.spec.ts',
+			`
+test('opens workflow', async ({ n8n }) => {
+	await n8n.page.goto(\`/workflow/\${workflowId}\`);
+});
+`,
+		);
+
+		const violations = rule.analyzeProject(project, [file]);
+
+		expect(violations).toHaveLength(1);
+		expect(violations[0].message).toContain('Raw navigation to the workflow editor');
+		expect(violations[0].suggestion).toContain('fromImportedWorkflow');
+	});
+
+	test('flags raw page.goto to the new workflow route', ({ project, createFile }) => {
+		const file = createFile(
+			'/tests/e2e/example.spec.ts',
+			`
+test('blank canvas', async ({ page }) => {
+	await page.goto('/workflow/new');
+});
+`,
+		);
+
+		const violations = rule.analyzeProject(project, [file]);
+
+		expect(violations).toHaveLength(1);
+	});
+
+	test('flags navigation via the NEW_WORKFLOW_PAGE constant', ({ project, createFile }) => {
+		const file = createFile(
+			'/tests/e2e/example.spec.ts',
+			`
+test('blank canvas', async ({ n8n }) => {
+	await n8n.page.goto(ROUTES.NEW_WORKFLOW_PAGE);
+});
+`,
+		);
+
+		const violations = rule.analyzeProject(project, [file]);
+
+		expect(violations).toHaveLength(1);
+	});
+
+	test('does not flag the workflow list routes', ({ project, createFile }) => {
+		const file = createFile(
+			'/tests/e2e/example.spec.ts',
+			`
+test('lists', async ({ n8n }) => {
+	await n8n.page.goto('/workflows');
+	await n8n.page.goto('/home/workflows');
+	await n8n.page.goto(\`projects/\${projectId}/workflows\`);
+	await n8n.page.goto('/workflows/demo/diff');
+});
+`,
+		);
+
+		const violations = rule.analyzeProject(project, [file]);
+
+		expect(violations).toHaveLength(0);
+	});
+
+	test('does not flag navigation through entry composers', ({ project, createFile }) => {
+		const file = createFile(
+			'/tests/e2e/example.spec.ts',
+			`
+test('imports', async ({ n8n }) => {
+	await n8n.start.fromImportedWorkflow('workflow/file.json');
+});
+`,
+		);
+
+		const violations = rule.analyzeProject(project, [file]);
+
+		expect(violations).toHaveLength(0);
+	});
+
+	test('reports correct line number', ({ project, createFile }) => {
+		const file = createFile(
+			'/tests/e2e/example.spec.ts',
+			`test('x', async ({ page }) => {
+	// line 2
+	await page.goto('/workflow/123'); // line 3
+});
+`,
+		);
+
+		const violations = rule.analyzeProject(project, [file]);
+
+		expect(violations).toHaveLength(1);
+		expect(violations[0].line).toBe(3);
+	});
+});

--- a/packages/testing/janitor/src/rules/no-raw-editor-navigation.rule.ts
+++ b/packages/testing/janitor/src/rules/no-raw-editor-navigation.rule.ts
@@ -1,0 +1,118 @@
+import { AstRule } from '@n8n/rules-engine/ast';
+import type { AstProjectConfig } from '@n8n/rules-engine/ast';
+import { SyntaxKind, type Project, type SourceFile, type CallExpression } from 'ts-morph';
+
+import { getConfig, ruleAllows } from '../config.js';
+import type { Violation } from '../types.js';
+import { truncateText } from '../utils/ast-helpers.js';
+
+/**
+ * No Raw Editor Navigation Rule
+ *
+ * Tests must not navigate to the workflow editor with a raw `page.goto()`.
+ *
+ * The editor renders a full-screen `node-view-loader` overlay while the
+ * workflow loads. `page.goto()` resolves on the `load` event, before that
+ * overlay clears, so a test that navigates raw and then interacts with the
+ * canvas hits a button that Playwright reports as "stable" while the overlay
+ * silently intercepts the click — the action then hangs until it times out.
+ *
+ * Entry composers (`n8n.start.fromImportedWorkflow()`,
+ * `n8n.start.fromBlankCanvas()`) own the readiness wait
+ * (`canvas.waitForCanvasReady()`), so navigation must go through them.
+ *
+ * Matches editor routes only (`/workflow/<id>`, `/workflow/new`); the workflow
+ * list (`/workflows`, `/home/workflows`) is deliberately not flagged.
+ *
+ * Violations:
+ * - page.goto('/workflow/123')
+ * - this.page.goto(`/workflow/${id}`)
+ * - n8n.page.goto(ROUTES.NEW_WORKFLOW_PAGE)
+ */
+export class NoRawEditorNavigationRule extends AstRule<{ rootDir: string }> {
+	readonly id = 'no-raw-editor-navigation';
+	readonly name = 'No Raw Editor Navigation';
+	readonly description =
+		'Tests must navigate to the workflow editor via entry composers, not raw page.goto()';
+	readonly severity = 'error' as const;
+
+	/** Editor routes carry the canvas loader; the list routes do not. */
+	private static readonly EDITOR_ROUTE = /workflow\//;
+	private static readonly NEW_WORKFLOW_CONSTANT = /NEW_WORKFLOW_PAGE/;
+
+	getTargetGlobs(): string[] {
+		return getConfig().patterns.tests;
+	}
+
+	protected projectConfig(): AstProjectConfig {
+		return { packages: ['.'], spec: { globs: this.getTargetGlobs() } };
+	}
+
+	analyze(context: { rootDir: string }): Violation[] {
+		return this.projects(context).flatMap(({ project }) => this.analyzeProject(project));
+	}
+
+	analyzeProject(project: Project, files: SourceFile[] = project.getSourceFiles()): Violation[] {
+		const violations: Violation[] = [];
+
+		for (const file of files) {
+			const calls = file.getDescendantsOfKind(SyntaxKind.CallExpression);
+
+			for (const call of calls) {
+				if (!this.isPageGoto(call)) {
+					continue;
+				}
+
+				const [firstArg] = call.getArguments();
+				if (!firstArg) {
+					continue;
+				}
+
+				const argText = firstArg.getText();
+				if (!this.isEditorRoute(argText)) {
+					continue;
+				}
+
+				const callText = call.getText();
+				if (ruleAllows(this.id, callText)) {
+					continue;
+				}
+
+				violations.push(
+					this.fileViolation(
+						file,
+						call.getStartLineNumber(),
+						call.getStart() - call.getStartLinePos(),
+						`Raw navigation to the workflow editor: ${truncateText(callText, 60)}`,
+						'Use n8n.start.fromImportedWorkflow() or n8n.start.fromBlankCanvas() so the canvas loader is awaited before interacting',
+					),
+				);
+			}
+		}
+
+		return violations;
+	}
+
+	/** True for `page.goto`, `this.page.goto`, or `<fixture>.page.goto`. */
+	private isPageGoto(call: CallExpression): boolean {
+		const expr = call.getExpression();
+		if (expr.getKind() !== SyntaxKind.PropertyAccessExpression) {
+			return false;
+		}
+
+		const propAccess = expr.asKindOrThrow(SyntaxKind.PropertyAccessExpression);
+		if (propAccess.getName() !== 'goto') {
+			return false;
+		}
+
+		const objectText = propAccess.getExpression().getText();
+		return objectText === 'page' || /(^|\.)page$/.test(objectText);
+	}
+
+	private isEditorRoute(argText: string): boolean {
+		return (
+			NoRawEditorNavigationRule.EDITOR_ROUTE.test(argText) ||
+			NoRawEditorNavigationRule.NEW_WORKFLOW_CONSTANT.test(argText)
+		);
+	}
+}

--- a/packages/testing/playwright/.janitor-baseline.json
+++ b/packages/testing/playwright/.janitor-baseline.json
@@ -1,7 +1,7 @@
 {
 	"version": 1,
 	"generated": "2026-05-25T15:20:35.251Z",
-	"totalViolations": 412,
+	"totalViolations": 435,
 	"violations": {
 		"pages/AIAssistantPage.ts": [
 			{
@@ -491,6 +491,24 @@
 				"line": 126,
 				"message": "Raw API call detected: fetch(",
 				"hash": "eb977c9c5bb7"
+			},
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 24,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto('/workflow/new')",
+				"hash": "994c98dcd129"
+			},
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 102,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto('/workflow/new')",
+				"hash": "994c98dcd129"
+			},
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 150,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto('/workflow/new')",
+				"hash": "994c98dcd129"
 			}
 		],
 		"tests/e2e/ai/hitl-for-tools.spec.ts": [
@@ -577,6 +595,36 @@
 				"line": 119,
 				"message": "Direct page locator call: n8n.page.getByText('Task aborted')",
 				"hash": "6ee85a61151a"
+			},
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 48,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto('/workflow/new')",
+				"hash": "a499a217bb1e"
+			},
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 56,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto('/workflow/new')",
+				"hash": "a499a217bb1e"
+			},
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 74,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto('/workflow/new')",
+				"hash": "a499a217bb1e"
+			},
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 93,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto('/workflow/new')",
+				"hash": "a499a217bb1e"
+			},
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 107,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto('/workflow/new')",
+				"hash": "a499a217bb1e"
 			}
 		],
 		"tests/e2e/api/wait-form-resume.spec.ts": [
@@ -887,6 +935,18 @@
 				"line": 326,
 				"message": "Chained locator call in test: formPage.getByText('This worked')",
 				"hash": "28200563c463"
+			},
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 190,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto(`/workflow/${workflowId}`)",
+				"hash": "6720dfdb4c5d"
+			},
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 304,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto(`/workflow/${workflowId}`)",
+				"hash": "6720dfdb4c5d"
 			}
 		],
 		"tests/e2e/nodes/send-and-wait.spec.ts": [
@@ -2639,6 +2699,100 @@
 				"line": 44,
 				"message": "Direct page instantiation: new InstanceAiPage(threadPage)",
 				"hash": "99e5606866b2"
+			}
+		],
+		"tests/e2e/ai/assistant-basic.spec.ts": [
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 33,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto('/workflow/new')",
+				"hash": "e6d03454a502"
+			},
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 43,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto('/workflow/new')",
+				"hash": "e6d03454a502"
+			},
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 66,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto('/workflow/new')",
+				"hash": "e6d03454a502"
+			},
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 199,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto('/workflow/new')",
+				"hash": "e6d03454a502"
+			},
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 257,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto('/workflow/new')",
+				"hash": "e6d03454a502"
+			},
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 278,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto('/workflow/new')",
+				"hash": "e6d03454a502"
+			}
+		],
+		"tests/e2e/ai/assistant-support-chat.spec.ts": [
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 27,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto('/workflow/new')",
+				"hash": "b027466aeb23"
+			}
+		],
+		"tests/e2e/nodes/email-send-node.spec.ts": [
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 77,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto(`/workflow/${workflowId}`)",
+				"hash": "888bc0a82e21"
+			}
+		],
+		"tests/e2e/nodes/kafka-nodes.spec.ts": [
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 94,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto(`/workflow/${workflowId}`)",
+				"hash": "fda6b212bcdb"
+			}
+		],
+		"tests/performance/canvas/canvas-execution.spec.ts": [
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 112,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto(`/workflow/${workflowId}`)",
+				"hash": "8abdbe84c922"
+			}
+		],
+		"tests/performance/canvas/canvas-interactions.spec.ts": [
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 52,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto(`/workflow/${workflowId}`)",
+				"hash": "66d9fb632834"
+			}
+		],
+		"tests/performance/canvas/canvas-load.spec.ts": [
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 48,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto(`/workflow/${workflowId}`)",
+				"hash": "9c2ed8cbab2a"
+			}
+		],
+		"tests/e2e/workflows/editor/routing.spec.ts": [
+			{
+				"rule": "no-raw-editor-navigation",
+				"line": 110,
+				"message": "Raw navigation to the workflow editor: n8n.page.goto(`/workflow/${workflowId}?new=true`)",
+				"hash": "c42880a071b0"
 			}
 		]
 	}

--- a/packages/testing/playwright/AGENTS.md
+++ b/packages/testing/playwright/AGENTS.md
@@ -63,6 +63,7 @@ Tests → Flows/Composables → Page Objects → Components → Playwright API
 | `dead-code` | Unused public methods in page objects |
 | `deduplication` | Same selector defined in multiple files |
 | `duplicate-logic` | Copy-pasted code across tests/pages (AST fingerprinting) |
+| `no-raw-editor-navigation` | Raw `page.goto()` to a `/workflow/` editor route in tests (use `n8n.start.*` so the canvas loader is awaited) |
 
 ### Commands
 

--- a/packages/testing/playwright/composables/TestEntryComposer.ts
+++ b/packages/testing/playwright/composables/TestEntryComposer.ts
@@ -24,8 +24,9 @@ export class TestEntryComposer {
 	 */
 	async fromBlankCanvas() {
 		await this.n8n.navigate.toWorkflow('new');
-		// Verify we're on canvas
-		await this.n8n.canvas.canvasPane().isVisible();
+		// Wait for the canvas loader to clear before returning so tests don't
+		// interact with a canvas still covered by the full-screen loader.
+		await this.n8n.canvas.waitForBlankCanvasReady();
 	}
 
 	/**
@@ -42,7 +43,7 @@ export class TestEntryComposer {
 
 		const projectId = response.id;
 		await this.n8n.page.goto(`workflow/new?projectId=${projectId}`);
-		await this.n8n.canvas.canvasPane().isVisible();
+		await this.n8n.canvas.waitForBlankCanvasReady();
 		return projectId;
 	}
 
@@ -60,6 +61,11 @@ export class TestEntryComposer {
 	async fromImportedWorkflow(workflowFile: string) {
 		const workflowImportResult = await this.n8n.api.workflows.importWorkflowFromFile(workflowFile);
 		await this.n8n.page.goto(`workflow/${workflowImportResult.workflowId}`);
+		// Wait for the canvas loading overlay to clear and the imported nodes to
+		// render before returning, so tests don't interact with a canvas that is
+		// still covered by the full-screen loader.
+		await this.n8n.canvas.waitForCanvasReady();
+		await this.n8n.canvas.getCanvasNodes().first().waitFor({ state: 'visible' });
 		return workflowImportResult;
 	}
 

--- a/packages/testing/playwright/pages/CanvasPage.ts
+++ b/packages/testing/playwright/pages/CanvasPage.ts
@@ -549,10 +549,24 @@ export class CanvasPage extends BasePage {
 
 	// Actions
 
-	async waitForBlankCanvasReady(): Promise<void> {
+	/**
+	 * Wait for the workflow canvas to finish loading and become interactive.
+	 *
+	 * While the editor loads, `LoadingView` renders a full-screen overlay
+	 * (`node-view-loader`) on top of the canvas. The canvas controls (e.g.
+	 * zoom-to-fit) are already in the DOM and report as stable, but the overlay
+	 * intercepts pointer events, so clicking before it clears hangs until the
+	 * action times out. Always wait for the canvas to be ready before
+	 * interacting with it after a navigation.
+	 */
+	async waitForCanvasReady(): Promise<void> {
 		await expect(this.canvasPane()).toBeVisible();
 		await expect(this.getNodeViewLoader()).toBeHidden();
 		await expect(this.getLoadingMask()).toBeHidden();
+	}
+
+	async waitForBlankCanvasReady(): Promise<void> {
+		await this.waitForCanvasReady();
 		await expect(this.getChoicePrompt()).toBeVisible();
 	}
 

--- a/packages/testing/playwright/pages/CanvasPage.ts
+++ b/packages/testing/playwright/pages/CanvasPage.ts
@@ -567,7 +567,10 @@ export class CanvasPage extends BasePage {
 
 	async waitForBlankCanvasReady(): Promise<void> {
 		await this.waitForCanvasReady();
-		await expect(this.getChoicePrompt()).toBeVisible();
+		// A blank canvas shows the AI choice prompt when AI Builder is enabled,
+		// otherwise the default add-first-step button. Accept either so this works
+		// in both environments.
+		await expect(this.getChoicePrompt().or(this.getCanvasPlusButton())).toBeVisible();
 	}
 
 	async addInitialNodeToCanvas(nodeName: string): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes an E2E flake where tests that navigate to the workflow editor click a canvas control before the canvas is interactive.

**Root cause:** the editor renders a full-screen `node-view-loader` overlay (`LoadingView.vue`, `position:absolute; width/height:100%`) while a workflow loads. `page.goto()` resolves on the `load` event — before that overlay clears. An entry composer that returned immediately let the test interact with a canvas still covered by the loader: a click on e.g. `zoom-to-fit` finds a button Playwright reports as *visible, enabled and stable*, but the overlay silently intercepts the pointer events, so the click hangs until the 20s action timeout. On a heavy AI workflow on a 2-vCPU multi-main runner the loader stays up past 20s, so all 3 retries fail; lighter workflows render fast enough to pass, which is why it presents as a flake. ([failing run](https://github.com/n8n-io/n8n/actions/runs/27284019860/job/80588236946) — `langchain-vectorstores.spec.ts`.)

### Central fix
- `CanvasPage.waitForCanvasReady()` — waits for the canvas pane to be visible and the `node-view-loader` + loading mask to be hidden. `waitForBlankCanvasReady()` now reuses it.
- `fromImportedWorkflow()` awaits `waitForCanvasReady()` + the first imported node before returning.
- `fromBlankCanvas()` / `fromNewProjectBlankCanvas()` now use `waitForBlankCanvasReady()` instead of the non-awaiting `canvasPane().isVisible()` (which returned a discarded boolean and waited for nothing).

This hardens every `n8n.start.*` caller centrally.

### Prevention — new janitor rule `no-raw-editor-navigation`
A central fix only protects tests that go through the entry composers. ~23 specs still navigate to the editor with a raw `page.goto('/workflow/<id>')`, bypassing the readiness wait — exactly the sites that re-introduce this flake. The new rule (error severity) flags raw `page.goto()` to editor routes (`/workflow/<id>`, `/workflow/new`, `NEW_WORKFLOW_PAGE`) in specs and points authors at `n8n.start.*`. The workflow list (`/workflows`, `/home/workflows`) is deliberately not flagged.

The 23 existing sites are recorded in `.janitor-baseline.json`, so they're tracked but only **new** violations fail CI. Migrating them is follow-up (some navigate to API-created workflows and need a readiness-aware `navigate.toWorkflow(id)` helper first).

## How to test

```bash
# Rule unit tests
pnpm --filter=@n8n/playwright-janitor test src/rules/no-raw-editor-navigation.rule.test.ts

# Rule fires on real editor-route navigations (23), skips list routes
cd packages/testing/playwright && pnpm janitor --rule=no-raw-editor-navigation --ignore-baseline

# Full janitor passes with the baseline active
cd packages/testing/playwright && pnpm janitor

# Typecheck
pnpm --filter=n8n-playwright typecheck
```

The flaky spec to verify the fix against: `packages/testing/playwright/tests/e2e/ai/langchain-vectorstores.spec.ts` (`should render runItems for sub-nodes and allow switching between them`).

## Related Linear tickets, Github issues, and Community forum posts

_None — surfaced from CI flake RCA._

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included (janitor rule unit tests; the readiness waits are covered by the re-enabled E2E specs).
- [ ] PR Labeled with backport label if needed.

> 🤖 PR Summary generated by AI