### PR TITLE
feat: Point desktop assistant Connect CTA to the workflow Set up tab (no-changelog)

### DIFF
--- a/packages/@n8n/local-gateway/src/main/instance-api.test.ts
+++ b/packages/@n8n/local-gateway/src/main/instance-api.test.ts
@@ -236,4 +236,13 @@ describe('InstanceApi', () => {
 			expect(new InstanceApi(makeOAuth({ instanceUrl: null })).workflowUrl('wf-1')).toBeNull();
 		});
 	});
+
+	describe('workflowSetupUrl', () => {
+		it('builds the editor url with the setup panel pre-opened, or null when signed out', () => {
+			expect(new InstanceApi(makeOAuth()).workflowSetupUrl('wf-1')).toBe(
+				'https://n.example/workflow/wf-1?action=openSetup',
+			);
+			expect(new InstanceApi(makeOAuth({ instanceUrl: null })).workflowSetupUrl('wf-1')).toBeNull();
+		});
+	});
 });

--- a/packages/@n8n/local-gateway/src/main/instance-api.ts
+++ b/packages/@n8n/local-gateway/src/main/instance-api.ts
@@ -264,10 +264,10 @@ export class InstanceApi {
 		return `${instanceUrl}/workflow/${encodeURIComponent(workflowId)}/executions/${encodeURIComponent(executionId)}`;
 	}
 
-	/** The instance's credentials overview page, or `null` when signed out. */
-	credentialsUrl(): string | null {
-		const { instanceUrl } = this.oauthFlow.getStatus();
-		return instanceUrl ? `${instanceUrl}/home/credentials` : null;
+	/** Editor URL for a workflow with the Set up panel pre-opened, or `null` when signed out. */
+	workflowSetupUrl(workflowId: string): string | null {
+		const url = this.workflowUrl(workflowId);
+		return url ? `${url}?action=openSetup` : null;
 	}
 
 	/** Every n8n REST endpoint wraps its payload in a `data` key; peel it off. */

--- a/packages/@n8n/local-gateway/src/main/ipc-handlers.ts
+++ b/packages/@n8n/local-gateway/src/main/ipc-handlers.ts
@@ -240,9 +240,9 @@ export function registerIpcHandlers({
 		},
 	);
 
-	ipcMain.handle('tasks:openCredentials', async (): Promise<void> => {
-		logger.debug('IPC tasks:openCredentials');
-		const url = instanceApi.credentialsUrl();
+	ipcMain.handle('tasks:openWorkflowSetup', async (_event, workflowId: string): Promise<void> => {
+		logger.debug('IPC tasks:openWorkflowSetup', { workflowId });
+		const url = instanceApi.workflowSetupUrl(workflowId);
 		if (url) await openExternal(url);
 	});
 

--- a/packages/@n8n/local-gateway/src/main/preload.ts
+++ b/packages/@n8n/local-gateway/src/main/preload.ts
@@ -93,8 +93,8 @@ const electronApi: ElectronApi = {
 			error?: string;
 		}>),
 
-	openCredentials: async (): Promise<void> => {
-		await ipcRenderer.invoke('tasks:openCredentials');
+	openWorkflowSetup: async (workflowId: string): Promise<void> => {
+		await ipcRenderer.invoke('tasks:openWorkflowSetup', workflowId);
 	},
 
 	getHistory: async (

--- a/packages/@n8n/local-gateway/src/renderer/views/TaskDetailView.vue
+++ b/packages/@n8n/local-gateway/src/renderer/views/TaskDetailView.vue
@@ -127,7 +127,7 @@ function viewInN8n() {
 }
 
 function connect() {
-	void window.electronAPI.openCredentials();
+	void window.electronAPI.openWorkflowSetup(props.card.workflowId);
 }
 </script>
 

--- a/packages/@n8n/local-gateway/src/shared/types.ts
+++ b/packages/@n8n/local-gateway/src/shared/types.ts
@@ -148,8 +148,8 @@ export interface ElectronApi {
 	) => Promise<DesktopAssistantApplyEditsResponse>;
 	/** Archive the task's workflow (soft delete — it drops out of the task list). */
 	deleteTask: (workflowId: string) => Promise<{ ok: boolean; error?: string }>;
-	/** Open the instance's credentials page in the browser (Connect CTA). */
-	openCredentials: () => Promise<void>;
+	/** Open the task's workflow with the Set up panel pre-opened in the browser (Connect CTA). */
+	openWorkflowSetup: (workflowId: string) => Promise<void>;
 	getHistory: (params?: DesktopAssistantHistoryParams) => Promise<DesktopAssistantHistoryResponse>;
 	openExecution: (workflowId: string, executionId: string) => Promise<void>;
 	getTimeSaved: () => Promise<DesktopAssistantTimeSaved>;

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -3629,5 +3629,6 @@ export function useCanvasOperations() {
 		fitView,
 		openWorkflowTemplate,
 		openWorkflowTemplateFromJSON,
+		openSetupPanelIfEnabled,
 	};
 }

--- a/packages/frontend/editor-ui/src/app/views/NodeView.vue
+++ b/packages/frontend/editor-ui/src/app/views/NodeView.vue
@@ -266,6 +266,7 @@ const {
 	startChat,
 	addNodesAndConnections,
 	fitView,
+	openSetupPanelIfEnabled,
 } = useCanvasOperations();
 const { extractWorkflow } = useWorkflowExtraction();
 
@@ -369,6 +370,8 @@ function initializeRoute() {
 			source: 'empty_state',
 		});
 		evaluationsWizardSidepanelStore.open(0);
+	} else if (route.query.action === 'openSetup') {
+		openSetupPanelIfEnabled();
 	}
 
 	// Handle debug mode event binding (data loading is handled by WorkflowLayout)


### PR DESCRIPTION
## Summary

In the desktop assistant's **task detail view**, when a task needs a credential, the **"Connect _{service}_"** button used to open the instance's generic credentials list (`/home/credentials`). That page is just a flat list of every credential — it doesn't tell the user _which_ credential this task needs or where to wire it up, so it's a dead end for the "finish setting this task up" intent.

This PR points that button at the **task's own workflow** with the **Set up** sidebar tab pre-activated, so the user lands directly on the actionable setup checklist for that specific workflow.

**Editor-UI — new deep-link (`?action=openSetup`)**
- `useCanvasOperations.ts` — exported the existing `openSetupPanelIfEnabled()` (already encapsulates the `069_setup_panel` experiment check → opens the focus panel + selects the `setup` tab).
- `NodeView.vue` — `initializeRoute()` now dispatches `action=openSetup` to that helper, reusing the existing `action` query-param pattern.
- When the experiment is off, the helper no-ops, so the user simply lands on the workflow canvas (with red credential badges on the affected nodes) — still far more targeted than the generic list.

**Desktop app (`@n8n/local-gateway`)**
- `instance-api.ts` — added `workflowSetupUrl()` (reuses `workflowUrl()` + `?action=openSetup`); removed the now-unused `credentialsUrl()`.
- `ipc-handlers.ts`, `preload.ts`, `shared/types.ts` — replaced the `openCredentials` IPC path with `openWorkflowSetup(workflowId)`.
- `TaskDetailView.vue` — `connect()` now calls `openWorkflowSetup(props.card.workflowId)`.

"View in n8n" still opens the plain workflow without the param — only the credential CTA deep-links to Set up.

## How to test

1. **Deep-link (editor-ui), experiment ON:** with `069_setup_panel` enabled, open `/workflow/<id>?action=openSetup` → the focus panel opens with the **Set up** tab active and the credential checklist shown.
2. **Deep-link, experiment OFF:** same URL with the experiment off → the workflow loads normally, no panel forced open; affected nodes show their credential badges.
3. **Desktop end-to-end:** in the desktop app, open a task that needs a credential (`variant: 'actionNeeded'`, non-empty `connectionsNeeded`) and click **"Connect _{service}_"** → the browser opens that task's workflow editor at `?action=openSetup` with the Set up tab active.
4. **Regression:** confirm "View in n8n" still opens the plain workflow (no Set up param).

Static checks: `pnpm --filter n8n-editor-ui typecheck`, `pnpm --filter @n8n/local-gateway typecheck`, and `@n8n/local-gateway` tests (175 passing, incl. a new `workflowSetupUrl` test).

## Related Linear tickets, Github issues, and Community forum posts

<!-- No Linear ticket — part of the personal-automation desktop assistant effort. -->

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI