### PR TITLE
fix: Exclude the macOS screenshot overlay from the desktop assistant context picker (no-changelog)

### DIFF
--- a/packages/@n8n/local-gateway/src/main/context-detector.test.ts
+++ b/packages/@n8n/local-gateway/src/main/context-detector.test.ts
@@ -1,0 +1,62 @@
+import type { DetectedContext } from '@n8n/computer-use/context';
+
+const { mockDetectOpenContexts } = vi.hoisted(() => ({ mockDetectOpenContexts: vi.fn() }));
+
+vi.mock('@n8n/computer-use/context', () => ({
+	detectOpenContexts: mockDetectOpenContexts,
+	captureScreenshotAttachment: vi.fn(),
+}));
+
+vi.mock('@n8n/computer-use/logger', () => ({
+	logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('electron', () => ({
+	app: { getName: vi.fn(() => 'n8n Assistant') },
+}));
+
+import { ContextDetector } from './context-detector';
+
+function ctx(overrides: Partial<DetectedContext>): DetectedContext {
+	return { kind: 'other', ...overrides };
+}
+
+describe('ContextDetector', () => {
+	beforeEach(() => mockDetectOpenContexts.mockReset());
+
+	describe('refresh', () => {
+		it('filters out the macOS screenshot UI overlay but keeps a screenshot file opened in Preview', async () => {
+			mockDetectOpenContexts.mockResolvedValue([
+				// The floating "Bildschirmfoto" overlay — frontmost, but not real context.
+				ctx({
+					app: 'Bildschirmfoto',
+					bundleId: 'com.apple.screencaptureui',
+					windowTitle: 'Bildschirmfoto',
+				}),
+				// A screenshot file open in Preview: same-looking title, but a real window to keep.
+				ctx({
+					kind: 'file',
+					app: 'Vorschau',
+					bundleId: 'com.apple.Preview',
+					windowTitle: 'Screenshot 2026-06-11.png',
+				}),
+			]);
+
+			const options = await new ContextDetector().refresh();
+
+			expect(options.map((o) => o.bundleId)).toEqual(['com.apple.Preview']);
+		});
+
+		it('filters out our own window and other system overlays', async () => {
+			mockDetectOpenContexts.mockResolvedValue([
+				ctx({ app: 'n8n Assistant', bundleId: 'io.n8n.gateway' }),
+				ctx({ app: 'Control Center', bundleId: 'com.apple.controlcenter' }),
+				ctx({ kind: 'browser', app: 'Google Chrome', bundleId: 'com.google.Chrome' }),
+			]);
+
+			const options = await new ContextDetector().refresh();
+
+			expect(options.map((o) => o.bundleId)).toEqual(['com.google.Chrome']);
+		});
+	});
+});

--- a/packages/@n8n/local-gateway/src/main/context-detector.ts
+++ b/packages/@n8n/local-gateway/src/main/context-detector.ts
@@ -36,6 +36,12 @@ export class ContextDetector extends EventEmitter {
 		'com.apple.dock',
 		'com.apple.Spotlight',
 		'com.apple.WindowManager',
+		// macOS screenshot UI — its floating preview thumbnail ("Bildschirmfoto")
+		// is a high-level overlay that get-windows reports as frontmost, so it
+		// otherwise lands at the top of the picker. Matched by bundle id only: a
+		// screenshot *file* opened in Preview is a real window we want to keep, and
+		// its window title (e.g. "Screenshot 2026-…") must not be filtered.
+		'com.apple.screencaptureui',
 	]);
 	private static readonly EXCLUDED_APP_NAMES = new Set([
 		'wispr flow',


### PR DESCRIPTION
## Summary

In the desktop assistant's context picker, the **top entry was always "Bildschirmfoto"** (the macOS Screenshot UI). It isn't a generic "use my screen" option — it's a real system window owned by `com.apple.screencaptureui` (the floating screenshot preview / capture overlay). Because that overlay floats at a high window level, `get-windows` reports it as frontmost, so it landed at position 0 of the front-to-back picker and pushed the window the user actually cares about down the list.

This adds `com.apple.screencaptureui` to `ContextDetector`'s `EXCLUDED_BUNDLE_IDS`, alongside the system overlays already filtered (Notification Center, Control Center, Spotlight, …).

**Bundle-id-only, deliberately:** the exclusion matches by bundle id, not app name. A screenshot _file_ opened in Preview is a legitimate window we want to keep — its window title looks like "Screenshot 2026-…" but its app/bundle id is Preview's, so it's unaffected. The system bundle id is locale-independent, so no localized-name fallback is needed.

## How to test

1. On macOS, take a screenshot (e.g. ⌘⇧4) so the floating "Bildschirmfoto"/"Screenshot" preview thumbnail is on screen.
2. Open the desktop assistant — the picker no longer lists the screenshot overlay; the frontmost _real_ window is at the top.
3. Open a screenshot PNG in Preview and reopen the picker — that Preview window still appears (file context preserved).

Covered by `context-detector.test.ts`: the screenshot overlay is filtered while a screenshot opened in Preview is kept; our own window and other system overlays are still filtered.

## Related Linear tickets, Github issues, and Community forum posts

<!-- No Linear ticket — part of the personal-automation desktop assistant effort. -->

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI