### PR TITLE
refactor(core): Extract TriggerExecutionContextFactory from ActiveWorkflowManager (no-changelog)

### DIFF
--- a/packages/cli/src/__tests__/active-workflow-manager.test.ts
+++ b/packages/cli/src/__tests__/active-workflow-manager.test.ts
@@ -32,6 +32,7 @@ import type { Push } from '@/push';
 import type { Publisher } from '@/scaling/pubsub/publisher.service';
 import type { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
 import type { WorkflowStaticDataService } from '@/workflows/workflow-static-data.service';
+import { TriggerExecutionContextFactory } from '@/workflows/triggers/trigger-execution-context.factory';
 
 describe('ActiveWorkflowManager', () => {
 	let activeWorkflowManager: ActiveWorkflowManager;
@@ -47,12 +48,9 @@ describe('ActiveWorkflowManager', () => {
 			mock(),
 			mock(),
 			mock(),
-			mock(),
 			nodeTypes,
 			mock(),
 			workflowRepository,
-			mock(),
-			mock(),
 			mock(),
 			mock(),
 			mock(),
@@ -60,9 +58,7 @@ describe('ActiveWorkflowManager', () => {
 			mock(),
 			workflowsConfig,
 			mock(),
-			mock(),
-			mock(),
-			mock(),
+			mock<TriggerExecutionContextFactory>(),
 			mock(),
 		);
 	});
@@ -225,12 +221,9 @@ describe('ActiveWorkflowManager', () => {
 				mock(),
 				mock(),
 				mock(),
-				mock(),
 				nodeTypes,
 				mock(),
 				workflowRepository,
-				mock(),
-				mock(),
 				mock(),
 				mock(),
 				mock(),
@@ -238,9 +231,7 @@ describe('ActiveWorkflowManager', () => {
 				publisher,
 				mock(),
 				push,
-				mock(),
-				mock(),
-				mock(),
+				mock<TriggerExecutionContextFactory>(),
 				mock(),
 			);
 		});
@@ -375,6 +366,8 @@ describe('ActiveWorkflowManager', () => {
 		const executionService = mock<ExecutionService>();
 		let scopedLogger: Logger;
 
+		let factory: TriggerExecutionContextFactory;
+
 		beforeEach(() => {
 			jest.clearAllMocks();
 			workflowStaticDataService.saveStaticData.mockResolvedValue(undefined);
@@ -386,28 +379,35 @@ describe('ActiveWorkflowManager', () => {
 			scopedLogger = mock<Logger>();
 			const rootLogger = mock<Logger>({ scoped: jest.fn().mockReturnValue(scopedLogger) });
 
-			activeWorkflowManager = new ActiveWorkflowManager(
+			factory = new TriggerExecutionContextFactory(
 				rootLogger,
-				mock(),
-				activeWorkflowTriggers,
-				mock(),
-				mock(),
-				nodeTypes,
-				mock(),
-				workflowRepository,
-				activationErrorsService,
+				mock(), // errorReporter
+				mock(), // activeExecutions
+				eventService,
 				executionService,
 				workflowStaticDataService,
-				mock(),
 				workflowExecutionService,
+				mock(), // storageConfig
+				mock(), // workflowPublishedDataService
+			);
+
+			activeWorkflowManager = new ActiveWorkflowManager(
+				rootLogger,
+				mock(), // errorReporter
+				activeWorkflowTriggers,
+				mock(), // externalHooks
+				nodeTypes,
+				mock(), // webhookService
+				workflowRepository,
+				activationErrorsService,
+				workflowStaticDataService,
+				mock(), // activeWorkflowsService
 				instanceSettings,
-				mock(),
+				mock(), // publisher
 				workflowsConfig,
-				mock(),
-				eventService,
-				mock(),
-				mock(),
-				mock(),
+				mock(), // push
+				factory,
+				mock(), // eventBus
 			);
 		});
 
@@ -606,7 +606,7 @@ describe('ActiveWorkflowManager', () => {
 				const executionError = mock<ExecutionError>();
 
 				const executeErrorWorkflowSpy = jest
-					.spyOn(activeWorkflowManager, 'executeErrorWorkflow')
+					.spyOn(factory, 'executeErrorWorkflow')
 					.mockImplementation(() => {});
 
 				const getTriggerFunctions = activeWorkflowManager.getExecuteTriggerFunctions(
@@ -808,12 +808,9 @@ describe('ActiveWorkflowManager', () => {
 				mock(),
 				realActiveWorkflowTriggers,
 				mock(),
-				mock(),
 				nodeTypes,
 				mock(),
 				workflowRepository,
-				mock(),
-				mock(),
 				mock(),
 				mock(),
 				mock(),
@@ -821,9 +818,7 @@ describe('ActiveWorkflowManager', () => {
 				mock(),
 				workflowsConfig,
 				mock(),
-				mock(),
-				mock(),
-				mock(),
+				mock<TriggerExecutionContextFactory>(),
 				mock(),
 			);
 		});

--- a/packages/cli/src/active-workflow-manager.ts
+++ b/packages/cli/src/active-workflow-manager.ts
@@ -16,20 +16,13 @@ import {
 	ActiveWorkflowTriggers,
 	ErrorReporter,
 	InstanceSettings,
-	PollContext,
-	StorageConfig,
-	TriggerContext,
 	type IGetExecutePollFunctions,
 	type IGetExecuteTriggerFunctions,
 } from 'n8n-core';
 import type {
 	ExecutionError,
 	IConnections,
-	IDeferredPromise,
-	IExecuteResponsePromiseData,
 	INode,
-	INodeExecutionData,
-	IRun,
 	IWorkflowBase,
 	IWorkflowExecuteAdditionalData,
 	WorkflowActivateMode,
@@ -44,18 +37,12 @@ import {
 	UnexpectedError,
 	IsolateError,
 	ensureError,
-	createRunExecutionData,
 	validateWorkflowHasTriggerLikeNode,
 } from 'n8n-workflow';
 import { strict } from 'node:assert';
 
 import { ActivationErrorsService } from '@/activation-errors.service';
-import { DuplicateExecutionError } from '@/errors/duplicate-execution.error';
 import { MessageEventBus } from '@/eventbus/message-event-bus/message-event-bus';
-import { ActiveExecutions } from '@/active-executions';
-import { EventService } from '@/events/event.service';
-import { executeErrorWorkflow } from '@/execution-lifecycle/execute-error-workflow';
-import { ExecutionService } from '@/executions/execution.service';
 import { ExternalHooks } from '@/external-hooks';
 import { NodeTypes } from '@/node-types';
 import { Push } from '@/push';
@@ -65,9 +52,8 @@ import { ActiveWorkflowsService } from '@/services/active-workflows.service';
 import * as WebhookHelpers from '@/webhooks/webhook-helpers';
 import { WebhookService } from '@/webhooks/webhook.service';
 import * as WorkflowExecuteAdditionalData from '@/workflow-execute-additional-data';
-import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
-import { WorkflowPublishedDataService } from '@/workflows/workflow-published-data.service';
 import { WorkflowStaticDataService } from '@/workflows/workflow-static-data.service';
+import { TriggerExecutionContextFactory } from '@/workflows/triggers/trigger-execution-context.factory';
 import { getErrorDescription, getErrorNodeId } from '@/workflows/utils';
 import { formatWorkflow } from '@/workflows/workflow.formatter';
 
@@ -86,23 +72,18 @@ export class ActiveWorkflowManager {
 		private readonly logger: Logger,
 		private readonly errorReporter: ErrorReporter,
 		private readonly activeWorkflowTriggers: ActiveWorkflowTriggers,
-		private readonly activeExecutions: ActiveExecutions,
 		private readonly externalHooks: ExternalHooks,
 		private readonly nodeTypes: NodeTypes,
 		private readonly webhookService: WebhookService,
 		private readonly workflowRepository: WorkflowRepository,
 		private readonly activationErrorsService: ActivationErrorsService,
-		private readonly executionService: ExecutionService,
 		private readonly workflowStaticDataService: WorkflowStaticDataService,
 		private readonly activeWorkflowsService: ActiveWorkflowsService,
-		private readonly workflowExecutionService: WorkflowExecutionService,
 		private readonly instanceSettings: InstanceSettings,
 		private readonly publisher: Publisher,
 		private readonly workflowsConfig: WorkflowsConfig,
 		private readonly push: Push,
-		private readonly eventService: EventService,
-		private readonly storageConfig: StorageConfig,
-		private readonly workflowPublishedDataService: WorkflowPublishedDataService,
+		private readonly triggerExecutionContextFactory: TriggerExecutionContextFactory,
 		private readonly eventBus: MessageEventBus,
 	) {
 		this.logger = this.logger.scoped(['workflow-activation']);
@@ -341,58 +322,15 @@ export class ActiveWorkflowManager {
 		additionalData: IWorkflowExecuteAdditionalData,
 		mode: WorkflowExecuteMode,
 		activation: WorkflowActivateMode,
-		// TODO(CAT-3202): this callback lets us switch between reading from
-		// the in-memory workflowData (flag off) and the workflow published data
-		// service (flag on). Once the feature flag is removed, we'll call the
-		// service directly and this parameter will go away.
 		resolveWorkflowData: () => Promise<IWorkflowBase>,
 	): IGetExecutePollFunctions {
-		return (workflow: Workflow, node: INode) => {
-			const __emit = (
-				data: INodeExecutionData[][],
-				responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>,
-				donePromise?: IDeferredPromise<IRun | undefined>,
-			) => {
-				this.logger.debug(`Received event to trigger execution for workflow "${workflow.name}"`);
-				void this.workflowStaticDataService.saveStaticData(workflow);
-
-				// TODO(CAT-3202): resolves workflow data via callback so we
-				// can feature-flag between in-memory data and the published data
-				// service. Once the flag is removed, we'll call the service directly.
-				const executePromise = resolveWorkflowData().then(
-					async (freshWorkflowData) =>
-						await this.workflowExecutionService.runWorkflow(
-							freshWorkflowData,
-							node,
-							data,
-							additionalData,
-							mode,
-							responsePromise,
-						),
-				);
-
-				if (donePromise) {
-					void executePromise.then((executionId) => {
-						this.activeExecutions
-							.getPostExecutePromise(executionId)
-							.then(donePromise.resolve)
-							.catch(donePromise.reject);
-					});
-				} else {
-					void executePromise.catch((error: Error) => this.logger.error(error.message, { error }));
-				}
-			};
-
-			const __emitError = (error: ExecutionError) => {
-				void this.executionService
-					.createErrorExecution(error, node, workflowData, workflow, mode)
-					.then(() => {
-						this.executeErrorWorkflow(error, workflowData, mode);
-					});
-			};
-
-			return new PollContext(workflow, node, additionalData, mode, activation, __emit, __emitError);
-		};
+		return this.triggerExecutionContextFactory.getExecutePollFunctions(
+			workflowData,
+			additionalData,
+			mode,
+			activation,
+			resolveWorkflowData,
+		);
 	}
 
 	/**
@@ -404,180 +342,41 @@ export class ActiveWorkflowManager {
 		additionalData: IWorkflowExecuteAdditionalData,
 		mode: WorkflowExecuteMode,
 		activation: WorkflowActivateMode,
-		// TODO(CAT-3202): this callback lets us switch between reading from
-		// the in-memory workflowData (flag off) and the workflow published data
-		// service (flag on). Once the feature flag is removed, we'll call the
-		// service directly and this parameter will go away.
 		resolveWorkflowData: () => Promise<IWorkflowBase>,
 	): IGetExecuteTriggerFunctions {
-		return (workflow: Workflow, node: INode) => {
-			const emit = (
-				data: INodeExecutionData[][],
-				responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>,
-				donePromise?: IDeferredPromise<IRun | undefined>,
-				deduplicationKey?: string,
-			) => {
-				this.logger.debug(`Received trigger for workflow "${workflow.name}"`);
-				void this.workflowStaticDataService.saveStaticData(workflow);
-
-				// TODO(CAT-3202): resolves workflow data via callback so we
-				// can feature-flag between in-memory data and the published data
-				// service. Once the flag is removed, we'll call the service directly.
-				const executePromise = resolveWorkflowData()
-					.then(
-						async (freshWorkflowData) =>
-							await this.workflowExecutionService.runWorkflow(
-								freshWorkflowData,
-								node,
-								data,
-								additionalData,
-								mode,
-								responsePromise,
-								deduplicationKey,
-							),
-					)
-					.catch((error: unknown) => {
-						if (error instanceof DuplicateExecutionError) {
-							const context = {
-								workflowId: workflowData.id,
-								nodeId: node.id,
-								deduplicationKey: error.deduplicationKey,
-							};
-							this.logger.warn('Scheduled execution skipped: duplicate deduplication key', context);
-							this.errorReporter.warn(error, { extra: context, shouldBeLogged: false });
-							return undefined;
-						}
-						throw error;
-					});
-
-				void executePromise.then((executionId) => {
-					// `executionId` is undefined when the catch above swallowed a
-					// duplicate scheduled execution; nothing ran, so nothing to emit.
-					if (executionId === undefined) return;
-					this.eventService.emit('workflow-executed', {
-						workflowId: workflowData.id,
-						workflowName: workflowData.name,
-						executionId,
-						source: 'trigger',
-					});
-				});
-
-				if (donePromise) {
-					void executePromise.then((executionId) => {
-						// Same as above: a duplicate scheduled execution was skipped,
-						// so resolve with undefined and don't wait on a non-existent run.
-						if (executionId === undefined) {
-							donePromise.resolve(undefined);
-							return;
-						}
-						this.activeExecutions
-							.getPostExecutePromise(executionId)
-							.then(donePromise.resolve)
-							.catch(donePromise.reject);
-					});
-				} else {
-					executePromise.catch((error: Error) => this.logger.error(error.message, { error }));
-				}
-			};
-			const emitError = (error: Error): void => {
+		return this.triggerExecutionContextFactory.getExecuteTriggerFunctions(
+			workflowData,
+			additionalData,
+			mode,
+			activation,
+			resolveWorkflowData,
+			(error, node, wd, m, act) => {
 				this.logger.info(
-					`The trigger node "${node.name}" of workflow "${workflowData.name}" failed with the error: "${error.message}". Will try to reactivate.`,
+					`The trigger node "${node.name}" of workflow "${wd.name}" failed with the error: "${error.message}". Will try to reactivate.`,
 					{
 						nodeName: node.name,
-						workflowId: workflowData.id,
-						workflowName: workflowData.name,
+						workflowId: wd.id,
+						workflowName: wd.name,
 					},
 				);
-
-				// Remove the workflow as "active"
-
-				void this.activeWorkflowTriggers.remove(workflowData.id);
-
-				void this.activationErrorsService.register(workflowData.id, error.message);
-
-				// Run Error Workflow if defined
+				void this.activeWorkflowTriggers.remove(wd.id);
+				void this.activationErrorsService.register(wd.id, error.message);
 				const activationError = new WorkflowActivationError(
 					`There was a problem with the trigger node "${node.name}", for that reason did the workflow had to be deactivated`,
 					{ cause: error, node },
 				);
-				this.executeErrorWorkflow(activationError, workflowData, mode);
-
-				this.addQueuedWorkflowActivation(activation, workflowData as WorkflowEntity);
-			};
-
-			const saveFailedExecution = (error: ExecutionError) => {
-				this.logger.info(
-					`The trigger node "${node.name}" of workflow "${workflowData.name}" reported the error: "${error.message}". Saving to failed executions`,
-					{
-						nodeName: node.name,
-						workflowId: workflowData.id,
-						workflowName: workflowData.name,
-					},
-				);
-				void this.executionService
-					.createErrorExecution(error, node, workflowData, workflow, mode)
-					.then(() => {
-						this.executeErrorWorkflow(error, workflowData, mode);
-					});
-			};
-			return new TriggerContext(
-				workflow,
-				node,
-				additionalData,
-				mode,
-				activation,
-				emit,
-				emitError,
-				saveFailedExecution,
-			);
-		};
+				this.executeErrorWorkflow(activationError, wd, m);
+				this.addQueuedWorkflowActivation(act, wd as WorkflowEntity);
+			},
+		);
 	}
 
 	executeErrorWorkflow(
 		error: ExecutionError,
 		workflowData: IWorkflowBase,
 		mode: WorkflowExecuteMode,
-	) {
-		const fullRunData: IRun = {
-			data: createRunExecutionData({
-				resultData: {
-					error,
-					runData: {},
-				},
-			}),
-			finished: false,
-			mode,
-			startedAt: new Date(),
-			stoppedAt: new Date(),
-			status: 'running',
-			storedAt: this.storageConfig.modeTag,
-		};
-
-		executeErrorWorkflow(workflowData, fullRunData, mode);
-	}
-
-	/**
-	 * Load the published workflow nodes/connections from the
-	 * `workflow_published_version` table. The passed-in workflow is used
-	 * for all other fields (staticData, settings, etc.).
-	 *
-	 * TODO: Add error handling / fallback strategy for transient DB failures.
-	 */
-	private async loadPublishedWorkflowData(
-		initialWorkflowData: IWorkflowDb,
-	): Promise<IWorkflowBase> {
-		const publishedData = await this.workflowPublishedDataService.getPublishedWorkflowData(
-			initialWorkflowData.id,
-		);
-
-		if (!publishedData) {
-			throw new UnexpectedError('Published version not found for workflow', {
-				extra: { workflowId: initialWorkflowData.id },
-			});
-		}
-
-		const { nodes, connections } = publishedData.publishedVersion;
-		return { ...initialWorkflowData, nodes, connections };
+	): void {
+		this.triggerExecutionContextFactory.executeErrorWorkflow(error, workflowData, mode);
 	}
 
 	private isActivationInProgress = false;
@@ -829,7 +628,8 @@ export class ActiveWorkflowManager {
 				// removed/disabled triggers in a new workflow version are deactivated before
 				// updating the published version.
 				const resolveWorkflowData = this.workflowsConfig.useWorkflowPublicationService
-					? async () => await this.loadPublishedWorkflowData(dbWorkflow)
+					? async () =>
+							await this.triggerExecutionContextFactory.loadPublishedWorkflowData(dbWorkflow)
 					: async () => dbWorkflow as IWorkflowBase;
 
 				if (shouldAddNonWebhookTriggers) {
@@ -929,7 +729,8 @@ export class ActiveWorkflowManager {
 
 			if (this.shouldAddNonWebhookTriggers()) {
 				const resolveWorkflowData = this.workflowsConfig.useWorkflowPublicationService
-					? async () => await this.loadPublishedWorkflowData(dbWorkflow)
+					? async () =>
+							await this.triggerExecutionContextFactory.loadPublishedWorkflowData(dbWorkflow)
 					: async () => dbWorkflow as IWorkflowBase;
 
 				await this.addNonWebhookTriggers(dbWorkflow, workflow, {

--- a/packages/cli/src/active-workflow-manager.ts
+++ b/packages/cli/src/active-workflow-manager.ts
@@ -350,23 +350,29 @@ export class ActiveWorkflowManager {
 			mode,
 			activation,
 			resolveWorkflowData,
-			(error, node, wd, m, act) => {
+			({
+				error,
+				node,
+				workflowData: failedWorkflowData,
+				mode: failureMode,
+				activation: failureActivation,
+			}) => {
 				this.logger.info(
-					`The trigger node "${node.name}" of workflow "${wd.name}" failed with the error: "${error.message}". Will try to reactivate.`,
+					`The trigger node "${node.name}" of workflow "${failedWorkflowData.name}" failed with the error: "${error.message}". Will try to reactivate.`,
 					{
 						nodeName: node.name,
-						workflowId: wd.id,
-						workflowName: wd.name,
+						workflowId: failedWorkflowData.id,
+						workflowName: failedWorkflowData.name,
 					},
 				);
-				void this.activeWorkflowTriggers.remove(wd.id);
-				void this.activationErrorsService.register(wd.id, error.message);
+				void this.activeWorkflowTriggers.remove(failedWorkflowData.id);
+				void this.activationErrorsService.register(failedWorkflowData.id, error.message);
 				const activationError = new WorkflowActivationError(
 					`There was a problem with the trigger node "${node.name}", for that reason did the workflow had to be deactivated`,
 					{ cause: error, node },
 				);
-				this.executeErrorWorkflow(activationError, wd, m);
-				this.addQueuedWorkflowActivation(act, wd as WorkflowEntity);
+				this.executeErrorWorkflow(activationError, failedWorkflowData, failureMode);
+				this.addQueuedWorkflowActivation(failureActivation, failedWorkflowData as WorkflowEntity);
 			},
 		);
 	}

--- a/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
@@ -14,7 +14,8 @@ import type {
 	WorkflowActivateMode,
 	WorkflowExecuteMode,
 } from 'n8n-workflow';
-import { createDeferredPromise, sleep, UnexpectedError, Workflow } from 'n8n-workflow';
+import { createDeferredPromise, sleep, UnexpectedError } from 'n8n-workflow';
+import type { Workflow } from 'n8n-workflow';
 
 import type { ActiveExecutions } from '@/active-executions';
 import { DuplicateExecutionError } from '@/errors/duplicate-execution.error';
@@ -225,7 +226,7 @@ describe('TriggerExecutionContextFactory', () => {
 
 		describe('emitError', () => {
 			test('delegates to the injected onTriggerFailure callback', () => {
-				const onTriggerFailure = jest.fn<void, Parameters<TriggerFailureHandler>>();
+				const onTriggerFailure = jest.fn<() => void, Parameters<TriggerFailureHandler>>();
 				const workflowData = mock<WorkflowEntity>({ id: 'wf-1', name: 'Test Workflow' });
 				const additionalData = mock<IWorkflowExecuteAdditionalData>();
 				const mode: WorkflowExecuteMode = 'trigger';

--- a/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/trigger-execution-context.factory.test.ts
@@ -1,0 +1,449 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import type { Logger } from '@n8n/backend-common';
+import type { WorkflowEntity, WorkflowHistory } from '@n8n/db';
+import { mock } from 'jest-mock-extended';
+import type { ErrorReporter, StorageConfig } from 'n8n-core';
+import type {
+	ExecutionError,
+	IConnections,
+	INode,
+	INodeExecutionData,
+	IRun,
+	IWorkflowBase,
+	IWorkflowExecuteAdditionalData,
+	WorkflowActivateMode,
+	WorkflowExecuteMode,
+} from 'n8n-workflow';
+import { createDeferredPromise, sleep, UnexpectedError, Workflow } from 'n8n-workflow';
+
+import type { ActiveExecutions } from '@/active-executions';
+import { DuplicateExecutionError } from '@/errors/duplicate-execution.error';
+import type { EventService } from '@/events/event.service';
+import { executeErrorWorkflow } from '@/execution-lifecycle/execute-error-workflow';
+import type { ExecutionService } from '@/executions/execution.service';
+import type { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
+import type { WorkflowPublishedDataService } from '@/workflows/workflow-published-data.service';
+import type { WorkflowStaticDataService } from '@/workflows/workflow-static-data.service';
+import {
+	TriggerExecutionContextFactory,
+	type TriggerFailureHandler,
+} from '../trigger-execution-context.factory';
+
+jest.mock('@/execution-lifecycle/execute-error-workflow');
+
+describe('TriggerExecutionContextFactory', () => {
+	const workflowStaticDataService = mock<WorkflowStaticDataService>();
+	const workflowExecutionService = mock<WorkflowExecutionService>();
+	const eventService = mock<EventService>();
+	const executionService = mock<ExecutionService>();
+	const activeExecutions = mock<ActiveExecutions>();
+	const workflowPublishedDataService = mock<WorkflowPublishedDataService>();
+	const storageConfig = mock<StorageConfig>({ modeTag: 'db' }) as unknown as StorageConfig;
+
+	let factory: TriggerExecutionContextFactory;
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		workflowStaticDataService.saveStaticData.mockResolvedValue(undefined);
+		workflowExecutionService.runWorkflow.mockResolvedValue('exec-123');
+		executionService.createErrorExecution.mockResolvedValue(undefined);
+
+		const scopedLogger = mock<Logger>();
+		const rootLogger = mock<Logger>({ scoped: jest.fn().mockReturnValue(scopedLogger) });
+
+		factory = new TriggerExecutionContextFactory(
+			rootLogger,
+			mock<ErrorReporter>(),
+			activeExecutions,
+			eventService,
+			executionService,
+			workflowStaticDataService,
+			workflowExecutionService,
+			storageConfig,
+			workflowPublishedDataService,
+		);
+	});
+
+	describe('getExecuteTriggerFunctions', () => {
+		describe('emit', () => {
+			test('saves static data, runs workflow, and emits workflow-executed', async () => {
+				const workflowData = mock<WorkflowEntity>({ id: 'wf-1', name: 'Test Workflow' });
+				const additionalData = mock<IWorkflowExecuteAdditionalData>();
+				const mode: WorkflowExecuteMode = 'trigger';
+				const activation: WorkflowActivateMode = 'activate';
+				const workflow = mock<Workflow>({ name: 'Test Workflow' });
+				const node = mock<INode>({ name: 'Trigger Node' });
+				const triggerData: INodeExecutionData[][] = [[]];
+
+				const getTriggerFunctions = factory.getExecuteTriggerFunctions(
+					workflowData,
+					additionalData,
+					mode,
+					activation,
+					async () => workflowData,
+					jest.fn(),
+				);
+				const context = getTriggerFunctions(workflow, node, additionalData, mode, activation);
+
+				context.emit(triggerData);
+				await sleep(0);
+
+				expect(workflowStaticDataService.saveStaticData).toHaveBeenCalledWith(workflow);
+				expect(workflowExecutionService.runWorkflow).toHaveBeenCalledWith(
+					workflowData,
+					node,
+					triggerData,
+					additionalData,
+					mode,
+					undefined,
+					undefined,
+				);
+				expect(eventService.emit).toHaveBeenCalledWith('workflow-executed', {
+					workflowId: workflowData.id,
+					workflowName: workflowData.name,
+					executionId: 'exec-123',
+					source: 'trigger',
+				});
+			});
+
+			test('forwards deduplicationKey to runWorkflow', async () => {
+				const workflowData = mock<WorkflowEntity>({ id: 'wf-1', name: 'Test Workflow' });
+				const additionalData = mock<IWorkflowExecuteAdditionalData>();
+				const mode: WorkflowExecuteMode = 'trigger';
+				const activation: WorkflowActivateMode = 'activate';
+				const workflow = mock<Workflow>({ name: 'Test Workflow' });
+				const node = mock<INode>({ name: 'Trigger Node', id: 'node-1' });
+
+				const getTriggerFunctions = factory.getExecuteTriggerFunctions(
+					workflowData,
+					additionalData,
+					mode,
+					activation,
+					async () => workflowData,
+					jest.fn(),
+				);
+				const context = getTriggerFunctions(workflow, node, additionalData, mode, activation);
+
+				context.emit([[]], undefined, undefined, 'wf-1:node-1:1700000000000');
+				await sleep(0);
+
+				expect(workflowExecutionService.runWorkflow).toHaveBeenCalledWith(
+					workflowData,
+					node,
+					[[]],
+					additionalData,
+					mode,
+					undefined,
+					'wf-1:node-1:1700000000000',
+				);
+			});
+
+			test('resolves donePromise via getPostExecutePromise', async () => {
+				const workflowData = mock<WorkflowEntity>({ id: 'wf-1', name: 'Test Workflow' });
+				const additionalData = mock<IWorkflowExecuteAdditionalData>();
+				const mode: WorkflowExecuteMode = 'trigger';
+				const activation: WorkflowActivateMode = 'activate';
+				const workflow = mock<Workflow>({ name: 'Test Workflow' });
+				const node = mock<INode>({ name: 'Trigger Node' });
+				const runResult = mock<IRun>();
+				activeExecutions.getPostExecutePromise.mockResolvedValue(runResult);
+
+				const getTriggerFunctions = factory.getExecuteTriggerFunctions(
+					workflowData,
+					additionalData,
+					mode,
+					activation,
+					async () => workflowData,
+					jest.fn(),
+				);
+				const context = getTriggerFunctions(workflow, node, additionalData, mode, activation);
+				const donePromise = createDeferredPromise<IRun>();
+
+				context.emit([[]], undefined, donePromise);
+				await sleep(0);
+
+				expect(activeExecutions.getPostExecutePromise).toHaveBeenCalledWith('exec-123');
+				await expect(donePromise.promise).resolves.toBe(runResult);
+			});
+
+			test('does not emit workflow-executed on DuplicateExecutionError', async () => {
+				workflowExecutionService.runWorkflow.mockRejectedValueOnce(
+					new DuplicateExecutionError('wf-1:node-1:1700000000000'),
+				);
+
+				const workflowData = mock<WorkflowEntity>({ id: 'wf-1', name: 'Test Workflow' });
+				const additionalData = mock<IWorkflowExecuteAdditionalData>();
+				const mode: WorkflowExecuteMode = 'trigger';
+				const activation: WorkflowActivateMode = 'activate';
+				const workflow = mock<Workflow>({ name: 'Test Workflow' });
+				const node = mock<INode>({ name: 'Trigger Node', id: 'node-1' });
+
+				const getTriggerFunctions = factory.getExecuteTriggerFunctions(
+					workflowData,
+					additionalData,
+					mode,
+					activation,
+					async () => workflowData,
+					jest.fn(),
+				);
+				const context = getTriggerFunctions(workflow, node, additionalData, mode, activation);
+
+				context.emit([[]], undefined, undefined, 'wf-1:node-1:1700000000000');
+				await sleep(0);
+
+				expect(eventService.emit).not.toHaveBeenCalled();
+			});
+
+			test('resolves donePromise with undefined on DuplicateExecutionError', async () => {
+				workflowExecutionService.runWorkflow.mockRejectedValueOnce(
+					new DuplicateExecutionError('wf-1:node-1:1700000000000'),
+				);
+
+				const workflowData = mock<WorkflowEntity>({ id: 'wf-1', name: 'Test Workflow' });
+				const additionalData = mock<IWorkflowExecuteAdditionalData>();
+				const mode: WorkflowExecuteMode = 'trigger';
+				const activation: WorkflowActivateMode = 'activate';
+				const workflow = mock<Workflow>({ name: 'Test Workflow' });
+				const node = mock<INode>({ name: 'Trigger Node', id: 'node-1' });
+
+				const getTriggerFunctions = factory.getExecuteTriggerFunctions(
+					workflowData,
+					additionalData,
+					mode,
+					activation,
+					async () => workflowData,
+					jest.fn(),
+				);
+				const context = getTriggerFunctions(workflow, node, additionalData, mode, activation);
+				const donePromise = createDeferredPromise<IRun>();
+
+				context.emit([[]], undefined, donePromise, 'wf-1:node-1:1700000000000');
+
+				await expect(donePromise.promise).resolves.toBeUndefined();
+			});
+		});
+
+		describe('emitError', () => {
+			test('delegates to the injected onTriggerFailure callback', () => {
+				const onTriggerFailure = jest.fn<void, Parameters<TriggerFailureHandler>>();
+				const workflowData = mock<WorkflowEntity>({ id: 'wf-1', name: 'Test Workflow' });
+				const additionalData = mock<IWorkflowExecuteAdditionalData>();
+				const mode: WorkflowExecuteMode = 'trigger';
+				const activation: WorkflowActivateMode = 'activate';
+				const workflow = mock<Workflow>({ name: 'Test Workflow' });
+				const node = mock<INode>({ name: 'Trigger Node' });
+
+				const getTriggerFunctions = factory.getExecuteTriggerFunctions(
+					workflowData,
+					additionalData,
+					mode,
+					activation,
+					async () => workflowData,
+					onTriggerFailure,
+				);
+				const context = getTriggerFunctions(workflow, node, additionalData, mode, activation);
+
+				const error = new Error('Trigger connection failed');
+				context.emitError(error);
+
+				expect(onTriggerFailure).toHaveBeenCalledWith({
+					error,
+					node,
+					workflowData,
+					mode,
+					activation,
+				});
+			});
+		});
+
+		describe('saveFailedExecution', () => {
+			test('calls createErrorExecution then executeErrorWorkflow', async () => {
+				const executeErrorWorkflowSpy = jest
+					.spyOn(factory, 'executeErrorWorkflow')
+					.mockImplementation(() => {});
+
+				const workflowData = mock<WorkflowEntity>({ id: 'wf-1', name: 'Test Workflow' });
+				const additionalData = mock<IWorkflowExecuteAdditionalData>();
+				const mode: WorkflowExecuteMode = 'trigger';
+				const activation: WorkflowActivateMode = 'activate';
+				const workflow = mock<Workflow>({ name: 'Test Workflow' });
+				const node = mock<INode>({ name: 'Trigger Node' });
+
+				const getTriggerFunctions = factory.getExecuteTriggerFunctions(
+					workflowData,
+					additionalData,
+					mode,
+					activation,
+					async () => workflowData,
+					jest.fn(),
+				);
+				const context = getTriggerFunctions(workflow, node, additionalData, mode, activation);
+				const executionError = mock<ExecutionError>();
+
+				context.saveFailedExecution(executionError);
+				await sleep(0);
+
+				expect(executionService.createErrorExecution).toHaveBeenCalledWith(
+					executionError,
+					node,
+					workflowData,
+					workflow,
+					mode,
+				);
+				expect(executeErrorWorkflowSpy).toHaveBeenCalledWith(executionError, workflowData, mode);
+			});
+		});
+	});
+
+	describe('getExecutePollFunctions', () => {
+		describe('__emit', () => {
+			test('saves static data and runs workflow', async () => {
+				const workflowData = mock<WorkflowEntity>({ id: 'wf-1', name: 'Test Workflow' });
+				const additionalData = mock<IWorkflowExecuteAdditionalData>();
+				const mode: WorkflowExecuteMode = 'trigger';
+				const activation: WorkflowActivateMode = 'activate';
+				const workflow = mock<Workflow>({ id: 'wf-1', name: 'Test Workflow' });
+				const node = mock<INode>({ name: 'Poll Node' });
+				const pollData: INodeExecutionData[][] = [[{ json: {} }]];
+
+				const getPollFunctions = factory.getExecutePollFunctions(
+					workflowData,
+					additionalData,
+					mode,
+					activation,
+					async () => workflowData,
+				);
+				const context = getPollFunctions(workflow, node, additionalData, mode, activation);
+
+				context.__emit(pollData);
+				await sleep(0);
+
+				expect(workflowStaticDataService.saveStaticData).toHaveBeenCalledWith(workflow);
+				expect(workflowExecutionService.runWorkflow).toHaveBeenCalledWith(
+					workflowData,
+					node,
+					pollData,
+					additionalData,
+					mode,
+					undefined,
+				);
+			});
+
+			test('resolves donePromise via getPostExecutePromise', async () => {
+				const runResult = mock<IRun>();
+				activeExecutions.getPostExecutePromise.mockResolvedValue(runResult);
+
+				const workflowData = mock<WorkflowEntity>({ id: 'wf-1', name: 'Test Workflow' });
+				const additionalData = mock<IWorkflowExecuteAdditionalData>();
+				const mode: WorkflowExecuteMode = 'trigger';
+				const activation: WorkflowActivateMode = 'activate';
+				const workflow = mock<Workflow>({ id: 'wf-1', name: 'Test Workflow' });
+				const node = mock<INode>({ name: 'Poll Node' });
+
+				const getPollFunctions = factory.getExecutePollFunctions(
+					workflowData,
+					additionalData,
+					mode,
+					activation,
+					async () => workflowData,
+				);
+				const context = getPollFunctions(workflow, node, additionalData, mode, activation);
+				const donePromise = createDeferredPromise<IRun>();
+
+				context.__emit([[]], undefined, donePromise);
+				await sleep(0);
+
+				expect(activeExecutions.getPostExecutePromise).toHaveBeenCalledWith('exec-123');
+				await expect(donePromise.promise).resolves.toBe(runResult);
+			});
+		});
+
+		describe('__emitError', () => {
+			test('calls createErrorExecution then executeErrorWorkflow', async () => {
+				const executeErrorWorkflowSpy = jest
+					.spyOn(factory, 'executeErrorWorkflow')
+					.mockImplementation(() => {});
+
+				const workflowData = mock<WorkflowEntity>({ id: 'wf-1', name: 'Test Workflow' });
+				const additionalData = mock<IWorkflowExecuteAdditionalData>();
+				const mode: WorkflowExecuteMode = 'trigger';
+				const activation: WorkflowActivateMode = 'activate';
+				const workflow = mock<Workflow>({ id: 'wf-1', name: 'Test Workflow' });
+				const node = mock<INode>({ name: 'Poll Node' });
+
+				const getPollFunctions = factory.getExecutePollFunctions(
+					workflowData,
+					additionalData,
+					mode,
+					activation,
+					async () => workflowData,
+				);
+				const context = getPollFunctions(workflow, node, additionalData, mode, activation);
+				const executionError = mock<ExecutionError>();
+
+				context.__emitError(executionError);
+				await sleep(0);
+
+				expect(executionService.createErrorExecution).toHaveBeenCalledWith(
+					executionError,
+					node,
+					workflowData,
+					workflow,
+					mode,
+				);
+				expect(executeErrorWorkflowSpy).toHaveBeenCalledWith(executionError, workflowData, mode);
+			});
+		});
+	});
+
+	describe('executeErrorWorkflow', () => {
+		test('calls the standalone function with a correctly shaped IRun', () => {
+			const workflowData = mock<IWorkflowBase>();
+			const error = mock<ExecutionError>();
+			const mode: WorkflowExecuteMode = 'trigger';
+
+			factory.executeErrorWorkflow(error, workflowData, mode);
+
+			expect(executeErrorWorkflow).toHaveBeenCalledWith(
+				workflowData,
+				expect.objectContaining({
+					mode,
+					finished: false,
+					status: 'running',
+					storedAt: 'db',
+				}),
+				mode,
+			);
+		});
+	});
+
+	describe('loadPublishedWorkflowData', () => {
+		test('returns IWorkflowBase with nodes and connections from the published version', async () => {
+			const publishedNodes: INode[] = [{ id: 'n1' } as INode];
+			const publishedConnections: IConnections = {};
+			const initialWorkflowData = mock<WorkflowEntity>({ id: 'wf-1' });
+
+			workflowPublishedDataService.getPublishedWorkflowData.mockResolvedValue({
+				workflow: mock<WorkflowEntity>(),
+				publishedVersion: {
+					nodes: publishedNodes,
+					connections: publishedConnections,
+				} as WorkflowHistory,
+			});
+
+			const result = await factory.loadPublishedWorkflowData(initialWorkflowData);
+
+			expect(result.nodes).toBe(publishedNodes);
+			expect(result.connections).toBe(publishedConnections);
+		});
+
+		test('throws UnexpectedError when the service returns null', async () => {
+			const initialWorkflowData = mock<WorkflowEntity>({ id: 'wf-1' });
+			workflowPublishedDataService.getPublishedWorkflowData.mockResolvedValue(null);
+
+			await expect(factory.loadPublishedWorkflowData(initialWorkflowData)).rejects.toThrow(
+				UnexpectedError,
+			);
+		});
+	});
+});

--- a/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
+++ b/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
@@ -33,14 +33,24 @@ import { WorkflowPublishedDataService } from '@/workflows/workflow-published-dat
 import { WorkflowStaticDataService } from '@/workflows/workflow-static-data.service';
 import type { IWorkflowDb } from '@n8n/db';
 
-export type TriggerFailureHandler = (
-	error: Error,
-	node: INode,
-	workflowData: IWorkflowDb,
-	mode: WorkflowExecuteMode,
-	activation: WorkflowActivateMode,
-) => void;
+export type TriggerFailureHandler = (opts: {
+	error: Error;
+	node: INode;
+	workflowData: IWorkflowDb;
+	mode: WorkflowExecuteMode;
+	activation: WorkflowActivateMode;
+}) => void;
 
+/**
+ * Builds the execution-context functions (`IGetExecuteTriggerFunctions` /
+ * `IGetExecutePollFunctions`) that n8n-core uses to wire up active and poll
+ * triggers. Owns the emit logic (dedup handling, donePromise resolution,
+ * `workflow-executed` event emission, static-data saves) and the
+ * `executeErrorWorkflow` wrapper. Path-specific failure behaviour (e.g.
+ * removing a trigger from the registry and queuing a reactivation) is
+ * injected via `onTriggerFailure` so this class stays agnostic of the
+ * caller's activation strategy.
+ */
 @Service()
 export class TriggerExecutionContextFactory {
 	constructor(
@@ -144,7 +154,7 @@ export class TriggerExecutionContextFactory {
 			};
 
 			const emitError = (error: Error): void => {
-				onTriggerFailure(error, node, workflowData, mode, activation);
+				onTriggerFailure({ error, node, workflowData, mode, activation });
 			};
 
 			const saveFailedExecution = (error: ExecutionError) => {

--- a/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
+++ b/packages/cli/src/workflows/triggers/trigger-execution-context.factory.ts
@@ -1,0 +1,286 @@
+import { Logger } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+import {
+	ErrorReporter,
+	PollContext,
+	StorageConfig,
+	TriggerContext,
+	type IGetExecutePollFunctions,
+	type IGetExecuteTriggerFunctions,
+} from 'n8n-core';
+
+import { ActiveExecutions } from '@/active-executions';
+import type {
+	ExecutionError,
+	IDeferredPromise,
+	IExecuteResponsePromiseData,
+	INode,
+	INodeExecutionData,
+	IRun,
+	IWorkflowBase,
+	IWorkflowExecuteAdditionalData,
+	WorkflowActivateMode,
+	WorkflowExecuteMode,
+} from 'n8n-workflow';
+import { Workflow, UnexpectedError, createRunExecutionData } from 'n8n-workflow';
+
+import { DuplicateExecutionError } from '@/errors/duplicate-execution.error';
+import { EventService } from '@/events/event.service';
+import { executeErrorWorkflow } from '@/execution-lifecycle/execute-error-workflow';
+import { ExecutionService } from '@/executions/execution.service';
+import { WorkflowExecutionService } from '@/workflows/workflow-execution.service';
+import { WorkflowPublishedDataService } from '@/workflows/workflow-published-data.service';
+import { WorkflowStaticDataService } from '@/workflows/workflow-static-data.service';
+import type { IWorkflowDb } from '@n8n/db';
+
+export type TriggerFailureHandler = (
+	error: Error,
+	node: INode,
+	workflowData: IWorkflowDb,
+	mode: WorkflowExecuteMode,
+	activation: WorkflowActivateMode,
+) => void;
+
+@Service()
+export class TriggerExecutionContextFactory {
+	constructor(
+		private logger: Logger,
+		private readonly errorReporter: ErrorReporter,
+		private readonly activeExecutions: ActiveExecutions,
+		private readonly eventService: EventService,
+		private readonly executionService: ExecutionService,
+		private readonly workflowStaticDataService: WorkflowStaticDataService,
+		private readonly workflowExecutionService: WorkflowExecutionService,
+		private readonly storageConfig: StorageConfig,
+		private readonly workflowPublishedDataService: WorkflowPublishedDataService,
+	) {
+		this.logger = this.logger.scoped(['workflow-activation']);
+	}
+
+	/**
+	 * Return trigger function which gets the global functions from n8n-core
+	 * and overwrites the emit to be able to start it in subprocess
+	 */
+	getExecuteTriggerFunctions(
+		workflowData: IWorkflowDb,
+		additionalData: IWorkflowExecuteAdditionalData,
+		mode: WorkflowExecuteMode,
+		activation: WorkflowActivateMode,
+		// TODO(CAT-3202): this callback lets us switch between reading from
+		// the in-memory workflowData (flag off) and the workflow published data
+		// service (flag on). Once the feature flag is removed, we'll call the
+		// service directly and this parameter will go away.
+		resolveWorkflowData: () => Promise<IWorkflowBase>,
+		onTriggerFailure: TriggerFailureHandler,
+	): IGetExecuteTriggerFunctions {
+		return (workflow: Workflow, node: INode) => {
+			const emit = (
+				data: INodeExecutionData[][],
+				responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>,
+				donePromise?: IDeferredPromise<IRun | undefined>,
+				deduplicationKey?: string,
+			) => {
+				this.logger.debug(`Received trigger for workflow "${workflow.name}"`);
+				void this.workflowStaticDataService.saveStaticData(workflow);
+
+				// TODO(CAT-3202): resolves workflow data via callback so we
+				// can feature-flag between in-memory data and the published data
+				// service. Once the flag is removed, we'll call the service directly.
+				const executePromise = resolveWorkflowData()
+					.then(
+						async (freshWorkflowData) =>
+							await this.workflowExecutionService.runWorkflow(
+								freshWorkflowData,
+								node,
+								data,
+								additionalData,
+								mode,
+								responsePromise,
+								deduplicationKey,
+							),
+					)
+					.catch((error: unknown) => {
+						if (error instanceof DuplicateExecutionError) {
+							const context = {
+								workflowId: workflowData.id,
+								nodeId: node.id,
+								deduplicationKey: error.deduplicationKey,
+							};
+							this.logger.warn('Scheduled execution skipped: duplicate deduplication key', context);
+							this.errorReporter.warn(error, { extra: context, shouldBeLogged: false });
+							return undefined;
+						}
+						throw error;
+					});
+
+				void executePromise.then((executionId) => {
+					// `executionId` is undefined when the catch above swallowed a
+					// duplicate scheduled execution; nothing ran, so nothing to emit.
+					if (executionId === undefined) return;
+					this.eventService.emit('workflow-executed', {
+						workflowId: workflowData.id,
+						workflowName: workflowData.name,
+						executionId,
+						source: 'trigger',
+					});
+				});
+
+				if (donePromise) {
+					void executePromise.then((executionId) => {
+						// Same as above: a duplicate scheduled execution was skipped,
+						// so resolve with undefined and don't wait on a non-existent run.
+						if (executionId === undefined) {
+							donePromise.resolve(undefined);
+							return;
+						}
+						this.activeExecutions
+							.getPostExecutePromise(executionId)
+							.then(donePromise.resolve)
+							.catch(donePromise.reject);
+					});
+				} else {
+					executePromise.catch((error: Error) => this.logger.error(error.message, { error }));
+				}
+			};
+
+			const emitError = (error: Error): void => {
+				onTriggerFailure(error, node, workflowData, mode, activation);
+			};
+
+			const saveFailedExecution = (error: ExecutionError) => {
+				this.logger.info(
+					`The trigger node "${node.name}" of workflow "${workflowData.name}" reported the error: "${error.message}". Saving to failed executions`,
+					{
+						nodeName: node.name,
+						workflowId: workflowData.id,
+						workflowName: workflowData.name,
+					},
+				);
+				void this.executionService
+					.createErrorExecution(error, node, workflowData, workflow, mode)
+					.then(() => {
+						this.executeErrorWorkflow(error, workflowData, mode);
+					});
+			};
+
+			return new TriggerContext(
+				workflow,
+				node,
+				additionalData,
+				mode,
+				activation,
+				emit,
+				emitError,
+				saveFailedExecution,
+			);
+		};
+	}
+
+	/**
+	 * Return poll function which gets the global functions from n8n-core
+	 * and overwrites the emit to be able to start it in subprocess
+	 */
+	getExecutePollFunctions(
+		workflowData: IWorkflowDb,
+		additionalData: IWorkflowExecuteAdditionalData,
+		mode: WorkflowExecuteMode,
+		activation: WorkflowActivateMode,
+		// TODO(CAT-3202): this callback lets us switch between reading from
+		// the in-memory workflowData (flag off) and the workflow published data
+		// service (flag on). Once the feature flag is removed, we'll call the
+		// service directly and this parameter will go away.
+		resolveWorkflowData: () => Promise<IWorkflowBase>,
+	): IGetExecutePollFunctions {
+		return (workflow: Workflow, node: INode) => {
+			const __emit = (
+				data: INodeExecutionData[][],
+				responsePromise?: IDeferredPromise<IExecuteResponsePromiseData>,
+				donePromise?: IDeferredPromise<IRun | undefined>,
+			) => {
+				this.logger.debug(`Received event to trigger execution for workflow "${workflow.name}"`);
+				void this.workflowStaticDataService.saveStaticData(workflow);
+
+				// TODO(CAT-3202): resolves workflow data via callback so we
+				// can feature-flag between in-memory data and the published data
+				// service. Once the flag is removed, we'll call the service directly.
+				const executePromise = resolveWorkflowData().then(
+					async (freshWorkflowData) =>
+						await this.workflowExecutionService.runWorkflow(
+							freshWorkflowData,
+							node,
+							data,
+							additionalData,
+							mode,
+							responsePromise,
+						),
+				);
+
+				if (donePromise) {
+					void executePromise.then((executionId) => {
+						this.activeExecutions
+							.getPostExecutePromise(executionId)
+							.then(donePromise.resolve)
+							.catch(donePromise.reject);
+					});
+				} else {
+					void executePromise.catch((error: Error) => this.logger.error(error.message, { error }));
+				}
+			};
+
+			const __emitError = (error: ExecutionError) => {
+				void this.executionService
+					.createErrorExecution(error, node, workflowData, workflow, mode)
+					.then(() => {
+						this.executeErrorWorkflow(error, workflowData, mode);
+					});
+			};
+
+			return new PollContext(workflow, node, additionalData, mode, activation, __emit, __emitError);
+		};
+	}
+
+	executeErrorWorkflow(
+		error: ExecutionError,
+		workflowData: IWorkflowBase,
+		mode: WorkflowExecuteMode,
+	): void {
+		const fullRunData: IRun = {
+			data: createRunExecutionData({
+				resultData: {
+					error,
+					runData: {},
+				},
+			}),
+			finished: false,
+			mode,
+			startedAt: new Date(),
+			stoppedAt: new Date(),
+			status: 'running',
+			storedAt: this.storageConfig.modeTag,
+		};
+
+		executeErrorWorkflow(workflowData, fullRunData, mode);
+	}
+
+	/**
+	 * Load the published workflow nodes/connections from the
+	 * `workflow_published_version` table. The passed-in workflow is used
+	 * for all other fields (staticData, settings, etc.).
+	 *
+	 * TODO: Add error handling / fallback strategy for transient DB failures.
+	 */
+	async loadPublishedWorkflowData(initialWorkflowData: IWorkflowDb): Promise<IWorkflowBase> {
+		const publishedData = await this.workflowPublishedDataService.getPublishedWorkflowData(
+			initialWorkflowData.id,
+		);
+
+		if (!publishedData) {
+			throw new UnexpectedError('Published version not found for workflow', {
+				extra: { workflowId: initialWorkflowData.id },
+			});
+		}
+
+		const { nodes, connections } = publishedData.publishedVersion;
+		return { ...initialWorkflowData, nodes, connections };
+	}
+}


### PR DESCRIPTION
## Summary

PR 1/X on overhauling the trigger lifecycle during activation

Extracts construction of trigger functions (`getExecuteTriggerFunctions`, `getExecutePollFunctions`, `executeErrorWorkflow`, and `loadPublishedWorkflowData`) from `ActiveWorkflowManager` into `TriggerExecutionContextFactory` service. `ActiveWorkflowManager`. Pure extraction, no behaviour change under either flag state.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3395

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] Tests included.
