### PR TITLE
feat(Telegram Node): Add rich message and message draft operations

### DIFF
--- a/packages/nodes-base/nodes/Telegram/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Telegram/GenericFunctions.ts
@@ -120,6 +120,18 @@ export function addAdditionalFields(
 	Object.assign(body, additionalFields);
 
 	// Add the reply markup
+	addReplyMarkup.call(this, body, index);
+}
+
+/**
+ * Build the `reply_markup` field from the node's reply markup parameters
+ *
+ * @param {IDataObject} body The body object to add the reply markup to
+ * @param {number} index The index of the item
+ */
+export function addReplyMarkup(this: IExecuteFunctions, body: IDataObject, index: number) {
+	const operation = this.getNodeParameter('operation', index);
+
 	let replyMarkupOption = '';
 	if (operation !== 'sendMediaGroup') {
 		replyMarkupOption = this.getNodeParameter('replyMarkup', index) as string;

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -18,6 +18,7 @@ import type { Readable } from 'stream';
 
 import {
 	addAdditionalFields,
+	addReplyMarkup,
 	apiRequest,
 	createSendAndWaitMessageBody,
 	getPropertyName,
@@ -1210,6 +1211,7 @@ export class Telegram implements INodeType {
 							'sendDocument',
 							'sendMessage',
 							'sendPhoto',
+							'sendRichMessage',
 							'sendSticker',
 							'sendVideo',
 							'sendAudio',
@@ -1886,7 +1888,7 @@ export class Telegram implements INodeType {
 								value: 'HTML',
 							},
 						],
-						default: 'MarkdownV2',
+						default: 'HTML',
 						description: 'How to parse the text',
 					},
 				],
@@ -1909,7 +1911,7 @@ export class Telegram implements INodeType {
 						value: 'html',
 					},
 				],
-				default: 'markdown',
+				default: 'html',
 				displayOptions: {
 					show: {
 						operation: ['sendRichMessage', 'sendRichMessageDraft'],
@@ -2398,27 +2400,28 @@ export class Telegram implements INodeType {
 
 						const format = this.getNodeParameter('richFormat', i) as string;
 						const content = this.getNodeParameter('richMessageText', i) as string;
-						const additionalFields = this.getNodeParameter('additionalFields', i);
+						const { is_rtl, skip_entity_detection, ...rest } = this.getNodeParameter(
+							'additionalFields',
+							i,
+						) as IDataObject;
 
 						// InputRichMessage requires exactly one of `html` or `markdown`
-						const richMessage: IDataObject = {};
-						if (format === 'html') {
-							richMessage.html = content;
-						} else {
-							richMessage.markdown = content;
+						const richMessage: IDataObject =
+							format === 'html' ? { html: content } : { markdown: content };
+						if (is_rtl !== undefined) {
+							richMessage.is_rtl = is_rtl;
 						}
-
-						if (additionalFields.is_rtl !== undefined) {
-							richMessage.is_rtl = additionalFields.is_rtl;
-							delete additionalFields.is_rtl;
-						}
-						if (additionalFields.skip_entity_detection !== undefined) {
-							richMessage.skip_entity_detection = additionalFields.skip_entity_detection;
-							delete additionalFields.skip_entity_detection;
+						if (skip_entity_detection !== undefined) {
+							richMessage.skip_entity_detection = skip_entity_detection;
 						}
 
 						body.rich_message = richMessage;
-						Object.assign(body, additionalFields);
+						Object.assign(body, rest);
+
+						// sendRichMessage supports reply_markup; the draft endpoint does not
+						if (operation === 'sendRichMessage') {
+							addReplyMarkup.call(this, body, i);
+						}
 					}
 				} else {
 					throw new NodeOperationError(this.getNode(), `The resource "${resource}" is not known!`, {

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -1817,7 +1817,7 @@ export class Telegram implements INodeType {
 				displayName: 'Draft ID',
 				name: 'draftId',
 				type: 'number',
-				default: 0,
+				default: 1,
 				displayOptions: {
 					show: {
 						operation: ['sendMessageDraft', 'sendRichMessageDraft'],
@@ -2365,8 +2365,15 @@ export class Telegram implements INodeType {
 
 						endpoint = 'sendMessageDraft';
 
+						const draftId = this.getNodeParameter('draftId', i) as number;
+						if (!draftId) {
+							throw new NodeOperationError(this.getNode(), 'Draft ID must be non-zero', {
+								itemIndex: i,
+							});
+						}
+
 						body.chat_id = this.getNodeParameter('chatId', i) as string;
-						body.draft_id = this.getNodeParameter('draftId', i) as number;
+						body.draft_id = draftId;
 						body.text = this.getNodeParameter('text', i, '') as string;
 
 						const additionalFields = this.getNodeParameter('additionalFields', i);
@@ -2381,7 +2388,13 @@ export class Telegram implements INodeType {
 						body.chat_id = this.getNodeParameter('chatId', i) as string;
 
 						if (operation === 'sendRichMessageDraft') {
-							body.draft_id = this.getNodeParameter('draftId', i) as number;
+							const draftId = this.getNodeParameter('draftId', i) as number;
+							if (!draftId) {
+								throw new NodeOperationError(this.getNode(), 'Draft ID must be non-zero', {
+									itemIndex: i,
+								});
+							}
+							body.draft_id = draftId;
 						}
 
 						const format = this.getNodeParameter('richFormat', i) as string;

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -1198,6 +1198,52 @@ export class Telegram implements INodeType {
 			},
 
 			// ----------------------------------
+			//   message:sendRichMessage/sendRichMessageDraft
+			// ----------------------------------
+			{
+				displayName: 'Format',
+				name: 'richFormat',
+				type: 'options',
+				options: [
+					{
+						name: 'Markdown',
+						value: 'markdown',
+					},
+					{
+						name: 'HTML',
+						value: 'html',
+					},
+				],
+				default: 'html',
+				displayOptions: {
+					show: {
+						operation: ['sendRichMessage', 'sendRichMessageDraft'],
+						resource: ['message'],
+					},
+				},
+				description: 'Which formatting syntax the rich message content uses',
+			},
+			{
+				displayName: 'Rich Message',
+				name: 'richMessageText',
+				type: 'string',
+				typeOptions: {
+					rows: 6,
+				},
+				default: '',
+				required: true,
+				displayOptions: {
+					show: {
+						operation: ['sendRichMessage', 'sendRichMessageDraft'],
+						resource: ['message'],
+					},
+				},
+				description:
+					'Content of the rich message, written in the selected Markdown or HTML syntax. Supports headings, lists, tables, block quotes, media, collapsible blocks and more.',
+				hint: 'Limits: up to 32768 characters, 500 blocks and 50 media attachments',
+			},
+
+			// ----------------------------------
 			//         message:editMessageText/sendAnimation/sendAudio/sendLocation/sendMessage/sendPhoto/sendSticker/sendVideo
 			// ----------------------------------
 
@@ -1895,50 +1941,8 @@ export class Telegram implements INodeType {
 			},
 
 			// ----------------------------------
-			//   message:sendRichMessage/sendRichMessageDraft
+			//   message:sendRichMessage/sendRichMessageDraft additional fields
 			// ----------------------------------
-			{
-				displayName: 'Format',
-				name: 'richFormat',
-				type: 'options',
-				options: [
-					{
-						name: 'Markdown',
-						value: 'markdown',
-					},
-					{
-						name: 'HTML',
-						value: 'html',
-					},
-				],
-				default: 'html',
-				displayOptions: {
-					show: {
-						operation: ['sendRichMessage', 'sendRichMessageDraft'],
-						resource: ['message'],
-					},
-				},
-				description: 'Which formatting syntax the rich message content uses',
-			},
-			{
-				displayName: 'Rich Message',
-				name: 'richMessageText',
-				type: 'string',
-				typeOptions: {
-					rows: 6,
-				},
-				default: '',
-				required: true,
-				displayOptions: {
-					show: {
-						operation: ['sendRichMessage', 'sendRichMessageDraft'],
-						resource: ['message'],
-					},
-				},
-				description:
-					'Content of the rich message, written in the selected Markdown or HTML syntax. Supports headings, lists, tables, block quotes, media, collapsible blocks and more.',
-				hint: 'Limits: up to 32768 characters, 500 blocks and 50 media attachments',
-			},
 			{
 				displayName: 'Additional Fields',
 				name: 'additionalFields',
@@ -2400,10 +2404,8 @@ export class Telegram implements INodeType {
 
 						const format = this.getNodeParameter('richFormat', i) as string;
 						const content = this.getNodeParameter('richMessageText', i) as string;
-						const { is_rtl, skip_entity_detection, ...rest } = this.getNodeParameter(
-							'additionalFields',
-							i,
-						) as IDataObject;
+						const additionalFields = this.getNodeParameter('additionalFields', i) as IDataObject;
+						const { is_rtl, skip_entity_detection } = additionalFields;
 
 						// InputRichMessage requires exactly one of `html` or `markdown`
 						const richMessage: IDataObject =
@@ -2416,9 +2418,22 @@ export class Telegram implements INodeType {
 						}
 
 						body.rich_message = richMessage;
-						Object.assign(body, rest);
 
-						// sendRichMessage supports reply_markup; the draft endpoint does not
+						// Assign only the fields consumed by the sendRichMessage API
+						if (additionalFields.disable_notification !== undefined) {
+							body.disable_notification = additionalFields.disable_notification;
+						}
+						if (additionalFields.protect_content !== undefined) {
+							body.protect_content = additionalFields.protect_content;
+						}
+						if (additionalFields.message_thread_id !== undefined) {
+							body.message_thread_id = additionalFields.message_thread_id;
+						}
+						if (additionalFields.message_effect_id !== undefined) {
+							body.message_effect_id = additionalFields.message_effect_id;
+						}
+
+						// sendRichMessage supports reply_markup; the draft endpoints do not
 						if (operation === 'sendRichMessage') {
 							addReplyMarkup.call(this, body, i);
 						}

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -1846,8 +1846,7 @@ export class Telegram implements INodeType {
 						resource: ['message'],
 					},
 				},
-				description:
-					'Text of the message, 0-4096 characters. Leave empty to show a “Thinking…” placeholder.',
+				description: 'Text of the message draft, 0-4096 characters',
 			},
 			{
 				displayName: 'Additional Fields',
@@ -1887,7 +1886,7 @@ export class Telegram implements INodeType {
 								value: 'HTML',
 							},
 						],
-						default: 'HTML',
+						default: 'MarkdownV2',
 						description: 'How to parse the text',
 					},
 				],

--- a/packages/nodes-base/nodes/Telegram/Telegram.node.ts
+++ b/packages/nodes-base/nodes/Telegram/Telegram.node.ts
@@ -285,6 +285,25 @@ export class Telegram implements INodeType {
 						action: 'Send a text message',
 					},
 					{
+						name: 'Send Message Draft',
+						value: 'sendMessageDraft',
+						description: 'Stream a partial message preview while it is being generated',
+						action: 'Send a message draft',
+					},
+					{
+						name: 'Send Rich Message',
+						value: 'sendRichMessage',
+						description:
+							'Send a richly formatted message with headings, lists, tables, media and more',
+						action: 'Send a rich message',
+					},
+					{
+						name: 'Send Rich Message Draft',
+						value: 'sendRichMessageDraft',
+						description: 'Stream a partial rich message preview while it is being generated',
+						action: 'Send a rich message draft',
+					},
+					{
 						name: 'Send and Wait for Response',
 						value: SEND_AND_WAIT_OPERATION,
 						description: 'Send a message and wait for response',
@@ -344,8 +363,11 @@ export class Telegram implements INodeType {
 							'sendDocument',
 							'sendLocation',
 							'sendMessage',
+							'sendMessageDraft',
 							'sendMediaGroup',
 							'sendPhoto',
+							'sendRichMessage',
+							'sendRichMessageDraft',
 							'sendSticker',
 							'sendVideo',
 							'unpinChatMessage',
@@ -1787,6 +1809,211 @@ export class Telegram implements INodeType {
 					},
 				],
 			},
+
+			// ----------------------------------
+			//   message:sendMessageDraft/sendRichMessageDraft
+			// ----------------------------------
+			{
+				displayName: 'Draft ID',
+				name: 'draftId',
+				type: 'number',
+				default: 0,
+				displayOptions: {
+					show: {
+						operation: ['sendMessageDraft', 'sendRichMessageDraft'],
+						resource: ['message'],
+					},
+				},
+				required: true,
+				description:
+					'Unique identifier of the message draft; must be non-zero. Updates streamed with the same draft ID are animated.',
+			},
+
+			// ----------------------------------
+			//         message:sendMessageDraft
+			// ----------------------------------
+			{
+				displayName: 'Text',
+				name: 'text',
+				type: 'string',
+				typeOptions: {
+					rows: 5,
+				},
+				default: '',
+				displayOptions: {
+					show: {
+						operation: ['sendMessageDraft'],
+						resource: ['message'],
+					},
+				},
+				description:
+					'Text of the message, 0-4096 characters. Leave empty to show a “Thinking…” placeholder.',
+			},
+			{
+				displayName: 'Additional Fields',
+				name: 'additionalFields',
+				type: 'collection',
+				placeholder: 'Add Field',
+				displayOptions: {
+					show: {
+						operation: ['sendMessageDraft'],
+						resource: ['message'],
+					},
+				},
+				default: {},
+				options: [
+					{
+						displayName: 'Message Thread ID',
+						name: 'message_thread_id',
+						type: 'number',
+						default: 0,
+						description: 'The unique identifier of the forum topic',
+					},
+					{
+						displayName: 'Parse Mode',
+						name: 'parse_mode',
+						type: 'options',
+						options: [
+							{
+								name: 'Markdown (Legacy)',
+								value: 'Markdown',
+							},
+							{
+								name: 'MarkdownV2',
+								value: 'MarkdownV2',
+							},
+							{
+								name: 'HTML',
+								value: 'HTML',
+							},
+						],
+						default: 'HTML',
+						description: 'How to parse the text',
+					},
+				],
+			},
+
+			// ----------------------------------
+			//   message:sendRichMessage/sendRichMessageDraft
+			// ----------------------------------
+			{
+				displayName: 'Format',
+				name: 'richFormat',
+				type: 'options',
+				options: [
+					{
+						name: 'Markdown',
+						value: 'markdown',
+					},
+					{
+						name: 'HTML',
+						value: 'html',
+					},
+				],
+				default: 'markdown',
+				displayOptions: {
+					show: {
+						operation: ['sendRichMessage', 'sendRichMessageDraft'],
+						resource: ['message'],
+					},
+				},
+				description: 'Which formatting syntax the rich message content uses',
+			},
+			{
+				displayName: 'Rich Message',
+				name: 'richMessageText',
+				type: 'string',
+				typeOptions: {
+					rows: 6,
+				},
+				default: '',
+				required: true,
+				displayOptions: {
+					show: {
+						operation: ['sendRichMessage', 'sendRichMessageDraft'],
+						resource: ['message'],
+					},
+				},
+				description:
+					'Content of the rich message, written in the selected Markdown or HTML syntax. Supports headings, lists, tables, block quotes, media, collapsible blocks and more.',
+				hint: 'Limits: up to 32768 characters, 500 blocks and 50 media attachments',
+			},
+			{
+				displayName: 'Additional Fields',
+				name: 'additionalFields',
+				type: 'collection',
+				placeholder: 'Add Field',
+				displayOptions: {
+					show: {
+						operation: ['sendRichMessage', 'sendRichMessageDraft'],
+						resource: ['message'],
+					},
+				},
+				default: {},
+				options: [
+					{
+						displayName: 'Disable Notification',
+						name: 'disable_notification',
+						type: 'boolean',
+						default: false,
+						displayOptions: {
+							show: {
+								'/operation': ['sendRichMessage'],
+							},
+						},
+						description:
+							'Whether to send the message silently. Users will receive a notification with no sound.',
+					},
+					{
+						displayName: 'Message Effect ID',
+						name: 'message_effect_id',
+						type: 'string',
+						default: '',
+						displayOptions: {
+							show: {
+								'/operation': ['sendRichMessage'],
+							},
+						},
+						description:
+							'Unique identifier of the message effect to be added to the message; for private chats only',
+					},
+					{
+						displayName: 'Message Thread ID',
+						name: 'message_thread_id',
+						type: 'number',
+						default: 0,
+						description: 'The unique identifier of the forum topic',
+					},
+					{
+						displayName: 'Protect Content',
+						name: 'protect_content',
+						type: 'boolean',
+						default: false,
+						displayOptions: {
+							show: {
+								'/operation': ['sendRichMessage'],
+							},
+						},
+						description:
+							'Whether to protect the contents of the sent message from forwarding and saving',
+					},
+					{
+						displayName: 'Right-to-Left',
+						name: 'is_rtl',
+						type: 'boolean',
+						default: false,
+						description: 'Whether the rich message must be shown right-to-left',
+					},
+					{
+						displayName: 'Skip Entity Detection',
+						name: 'skip_entity_detection',
+						type: 'boolean',
+						default: false,
+						description:
+							'Whether to skip automatic detection of entities such as URLs, emails, mentions, hashtags and phone numbers',
+					},
+				],
+			},
 			...getSendAndWaitProperties(
 				[
 					{
@@ -2131,6 +2358,55 @@ export class Telegram implements INodeType {
 
 						// Add additional fields and replyMarkup
 						addAdditionalFields.call(this, body, i);
+					} else if (operation === 'sendMessageDraft') {
+						// ----------------------------------
+						//        message:sendMessageDraft
+						// ----------------------------------
+
+						endpoint = 'sendMessageDraft';
+
+						body.chat_id = this.getNodeParameter('chatId', i) as string;
+						body.draft_id = this.getNodeParameter('draftId', i) as number;
+						body.text = this.getNodeParameter('text', i, '') as string;
+
+						const additionalFields = this.getNodeParameter('additionalFields', i);
+						Object.assign(body, additionalFields);
+					} else if (operation === 'sendRichMessage' || operation === 'sendRichMessageDraft') {
+						// ----------------------------------------------
+						//   message:sendRichMessage/sendRichMessageDraft
+						// ----------------------------------------------
+
+						endpoint = operation;
+
+						body.chat_id = this.getNodeParameter('chatId', i) as string;
+
+						if (operation === 'sendRichMessageDraft') {
+							body.draft_id = this.getNodeParameter('draftId', i) as number;
+						}
+
+						const format = this.getNodeParameter('richFormat', i) as string;
+						const content = this.getNodeParameter('richMessageText', i) as string;
+						const additionalFields = this.getNodeParameter('additionalFields', i);
+
+						// InputRichMessage requires exactly one of `html` or `markdown`
+						const richMessage: IDataObject = {};
+						if (format === 'html') {
+							richMessage.html = content;
+						} else {
+							richMessage.markdown = content;
+						}
+
+						if (additionalFields.is_rtl !== undefined) {
+							richMessage.is_rtl = additionalFields.is_rtl;
+							delete additionalFields.is_rtl;
+						}
+						if (additionalFields.skip_entity_detection !== undefined) {
+							richMessage.skip_entity_detection = additionalFields.skip_entity_detection;
+							delete additionalFields.skip_entity_detection;
+						}
+
+						body.rich_message = richMessage;
+						Object.assign(body, additionalFields);
 					}
 				} else {
 					throw new NodeOperationError(this.getNode(), `The resource "${resource}" is not known!`, {

--- a/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
@@ -824,6 +824,35 @@ describe('Telegram node', () => {
 				{},
 			);
 		});
+
+		it('should throw when the draft ID is zero', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((p) => {
+				switch (p) {
+					case 'resource':
+						return 'message';
+					case 'operation':
+						return 'sendMessageDraft';
+					case 'binaryData':
+						return false;
+					case 'chatId':
+						return '123456789';
+					case 'draftId':
+						return 0;
+					case 'text':
+						return 'hello';
+					case 'additionalFields':
+						return {};
+					default:
+						return undefined;
+				}
+			});
+			executeFunctionsMock.continueOnFail.mockReturnValue(false);
+
+			await expect(node.execute.call(executeFunctionsMock)).rejects.toThrow(
+				'Draft ID must be non-zero',
+			);
+			expect(apiRequestSpy).not.toHaveBeenCalled();
+		});
 	});
 
 	describe('message:sendRichMessage', () => {

--- a/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
@@ -873,6 +873,8 @@ describe('Telegram node', () => {
 						return '# Title\n\nBody';
 					case 'additionalFields':
 						return { is_rtl: true, disable_notification: true, message_thread_id: 5 };
+					case 'replyMarkup':
+						return 'none';
 					default:
 						return undefined;
 				}
@@ -911,6 +913,8 @@ describe('Telegram node', () => {
 						return '<b>Hello</b>';
 					case 'additionalFields':
 						return { skip_entity_detection: true };
+					case 'replyMarkup':
+						return 'none';
 					default:
 						return undefined;
 				}
@@ -925,6 +929,57 @@ describe('Telegram node', () => {
 				{
 					chat_id: '123',
 					rich_message: { html: '<b>Hello</b>', skip_entity_detection: true },
+				},
+				{},
+			);
+		});
+
+		it('should attach reply_markup with an inline keyboard', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((p) => {
+				switch (p) {
+					case 'resource':
+						return 'message';
+					case 'operation':
+						return 'sendRichMessage';
+					case 'binaryData':
+						return false;
+					case 'chatId':
+						return '123';
+					case 'richFormat':
+						return 'html';
+					case 'richMessageText':
+						return '<b>Hi</b>';
+					case 'additionalFields':
+						return {};
+					case 'replyMarkup':
+						return 'inlineKeyboard';
+					case 'inlineKeyboard':
+						return {
+							rows: [
+								{
+									row: {
+										buttons: [{ text: 'Open', additionalFields: { url: 'https://n8n.io' } }],
+									},
+								},
+							],
+						};
+					default:
+						return undefined;
+				}
+			});
+			apiRequestSpy.mockResolvedValue([{ ok: true, result: { message_id: 5 } }]);
+
+			await node.execute.call(executeFunctionsMock);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				'POST',
+				'sendRichMessage',
+				{
+					chat_id: '123',
+					rich_message: { html: '<b>Hi</b>' },
+					reply_markup: {
+						inline_keyboard: [[{ text: 'Open', url: 'https://n8n.io' }]],
+					},
 				},
 				{},
 			);

--- a/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
@@ -792,7 +792,7 @@ describe('Telegram node', () => {
 			);
 		});
 
-		it('should send an empty text to show the Thinking placeholder', async () => {
+		it('should allow an empty text in the draft', async () => {
 			executeFunctionsMock.getNodeParameter.mockImplementation((p) => {
 				switch (p) {
 					case 'resource':

--- a/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/Telegram.node.test.ts
@@ -751,4 +751,195 @@ describe('Telegram node', () => {
 			expectChatId(3, 'chat-id-2');
 		});
 	});
+
+	describe('message:sendMessageDraft', () => {
+		it('should send the draft with chat_id, draft_id, text and additional fields', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((p) => {
+				switch (p) {
+					case 'resource':
+						return 'message';
+					case 'operation':
+						return 'sendMessageDraft';
+					case 'binaryData':
+						return false;
+					case 'chatId':
+						return '123456789';
+					case 'draftId':
+						return 42;
+					case 'text':
+						return 'Generating an answer';
+					case 'additionalFields':
+						return { parse_mode: 'HTML', message_thread_id: 7 };
+					default:
+						return undefined;
+				}
+			});
+			apiRequestSpy.mockResolvedValue([{ ok: true, result: true }]);
+
+			await node.execute.call(executeFunctionsMock);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				'POST',
+				'sendMessageDraft',
+				{
+					chat_id: '123456789',
+					draft_id: 42,
+					text: 'Generating an answer',
+					parse_mode: 'HTML',
+					message_thread_id: 7,
+				},
+				{},
+			);
+		});
+
+		it('should send an empty text to show the Thinking placeholder', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((p) => {
+				switch (p) {
+					case 'resource':
+						return 'message';
+					case 'operation':
+						return 'sendMessageDraft';
+					case 'binaryData':
+						return false;
+					case 'chatId':
+						return '123456789';
+					case 'draftId':
+						return 1;
+					case 'text':
+						return '';
+					case 'additionalFields':
+						return {};
+					default:
+						return undefined;
+				}
+			});
+			apiRequestSpy.mockResolvedValue([{ ok: true, result: true }]);
+
+			await node.execute.call(executeFunctionsMock);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				'POST',
+				'sendMessageDraft',
+				{ chat_id: '123456789', draft_id: 1, text: '' },
+				{},
+			);
+		});
+	});
+
+	describe('message:sendRichMessage', () => {
+		it('should wrap markdown content in rich_message and merge send options', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((p) => {
+				switch (p) {
+					case 'resource':
+						return 'message';
+					case 'operation':
+						return 'sendRichMessage';
+					case 'binaryData':
+						return false;
+					case 'chatId':
+						return '@channel';
+					case 'richFormat':
+						return 'markdown';
+					case 'richMessageText':
+						return '# Title\n\nBody';
+					case 'additionalFields':
+						return { is_rtl: true, disable_notification: true, message_thread_id: 5 };
+					default:
+						return undefined;
+				}
+			});
+			apiRequestSpy.mockResolvedValue([{ ok: true, result: { message_id: 99 } }]);
+
+			await node.execute.call(executeFunctionsMock);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				'POST',
+				'sendRichMessage',
+				{
+					chat_id: '@channel',
+					rich_message: { markdown: '# Title\n\nBody', is_rtl: true },
+					disable_notification: true,
+					message_thread_id: 5,
+				},
+				{},
+			);
+		});
+
+		it('should use the html field when the format is HTML', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((p) => {
+				switch (p) {
+					case 'resource':
+						return 'message';
+					case 'operation':
+						return 'sendRichMessage';
+					case 'binaryData':
+						return false;
+					case 'chatId':
+						return '123';
+					case 'richFormat':
+						return 'html';
+					case 'richMessageText':
+						return '<b>Hello</b>';
+					case 'additionalFields':
+						return { skip_entity_detection: true };
+					default:
+						return undefined;
+				}
+			});
+			apiRequestSpy.mockResolvedValue([{ ok: true, result: { message_id: 100 } }]);
+
+			await node.execute.call(executeFunctionsMock);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				'POST',
+				'sendRichMessage',
+				{
+					chat_id: '123',
+					rich_message: { html: '<b>Hello</b>', skip_entity_detection: true },
+				},
+				{},
+			);
+		});
+	});
+
+	describe('message:sendRichMessageDraft', () => {
+		it('should stream the rich message with chat_id and draft_id', async () => {
+			executeFunctionsMock.getNodeParameter.mockImplementation((p) => {
+				switch (p) {
+					case 'resource':
+						return 'message';
+					case 'operation':
+						return 'sendRichMessageDraft';
+					case 'binaryData':
+						return false;
+					case 'chatId':
+						return '123456789';
+					case 'draftId':
+						return 7;
+					case 'richFormat':
+						return 'markdown';
+					case 'richMessageText':
+						return '## Streaming';
+					case 'additionalFields':
+						return {};
+					default:
+						return undefined;
+				}
+			});
+			apiRequestSpy.mockResolvedValue([{ ok: true, result: true }]);
+
+			await node.execute.call(executeFunctionsMock);
+
+			expect(apiRequestSpy).toHaveBeenCalledWith(
+				'POST',
+				'sendRichMessageDraft',
+				{
+					chat_id: '123456789',
+					draft_id: 7,
+					rich_message: { markdown: '## Streaming' },
+				},
+				{},
+			);
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Adds three new **Message** operations to the Telegram node, surfacing recent Telegram Bot API capabilities that the node didn't expose before:

- **Send Message Draft** (`sendMessageDraft`) — streams a partial text message to a user while a reply is being generated (the live "generating…" effect). Passing an empty text shows Telegram's built-in "Thinking…" placeholder.
- **Send Rich Message** (`sendRichMessage`) — sends structured, richly formatted content (headings, lists, tables, media, block quotes, collapsible blocks, and more) using Markdown or HTML rich formatting.
- **Send Rich Message Draft** (`sendRichMessageDraft`) — streams a partial rich message preview.

**Implementation notes**

- Rich content is supplied via `InputRichMessage`, which requires exactly one of `html` or `markdown`, plus optional `is_rtl` and `skip_entity_detection`. The node exposes a **Format** selector (Markdown/HTML) and a single **Rich Message** content field, so users don't hand-build the `RichText`/`RichBlock` object tree.
- All three operations reuse the existing **Chat ID** parameter and the node's additional-fields pattern (`parse_mode`, `message_thread_id`, `disable_notification`, `protect_content`, `message_effect_id`).
- The two draft operations share a single **Draft ID** field.
- Purely additive (new entries in the Message operation dropdown), so no node version bump is required.

**Bot API references:** `sendMessageDraft` (Bot API 9.3, available to all bots since 9.5); `sendRichMessage` / `sendRichMessageDraft` (Bot API 10.1).

## How to test

1. Add a **Telegram** node with valid bot credentials.
2. **Send Message Draft** — Resource = Message, Operation = Send Message Draft. Set **Chat ID** to a private chat, **Draft ID** to a non-zero integer, and **Text**. Execute: the recipient sees a streamed draft preview. Leave **Text** empty to see the "Thinking…" placeholder. (Drafts are an ephemeral ~30s preview; send a normal **Send Message** afterwards to persist the final message.)
3. **Send Rich Message** — Operation = Send Rich Message, Format = Markdown, content e.g.:

   ```
   # Report

   - **Item one**
   - Item two

   > A quote
   ```

   Execute: the message renders with rich formatting. Switch **Format** to HTML to send HTML rich content.
4. **Send Rich Message Draft** — as above but with a **Draft ID**, to stream a partial rich message.

Run the unit tests:

```
cd packages/nodes-base && pnpm test Telegram.node.test.ts
```

They assert the request endpoint and body for each new operation.

## Related Linear tickets, Github issues, and Community forum posts

_None._

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
