### PR TITLE
fix(workflow-sdk): point generate-types export to dist

### DIFF
--- a/packages/@n8n/workflow-sdk/package.json
+++ b/packages/@n8n/workflow-sdk/package.json
@@ -9,8 +9,8 @@
     },
     "./package.json": "./package.json",
     "./scripts/generate-types": {
-      "types": "./src/generate-types/generate-types.ts",
-      "default": "./src/generate-types/generate-types.ts"
+      "types": "./dist/generate-types/generate-types.d.ts",
+      "default": "./dist/generate-types/generate-types.js"
     },
     "./dist/generate-types/generate-types": {
       "default": "./dist/generate-types/generate-types.js"
@@ -61,7 +61,7 @@
     "code-to-json": "npx tsx src/cli/index.ts code-to-json"
   },
   "main": "dist/index.js",
-  "module": "src/index.ts",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "typesVersions": {
     "*": {


### PR DESCRIPTION
## Summary

Fixes the `@n8n/workflow-sdk/scripts/generate-types` package export so it points at files that are actually included in the published package.

The package currently publishes only `dist/**/*`, but the `./scripts/generate-types` export points at `./src/generate-types/generate-types.ts`, and the legacy `module` field points at `src/index.ts`. Those `src` files are not present in the npm tarball, so consumers cannot resolve that public subpath from an installed package.

## Verification

Reproduced against the published package:

```bash
npm install @n8n/workflow-sdk@0.18.2 typescript@latest
node --input-type=module -e "import('@n8n/workflow-sdk/scripts/generate-types').catch(e => { console.error(e.code, e.message); process.exit(2) })"
```

This fails with `ERR_MODULE_NOT_FOUND` because Node resolves to `node_modules/@n8n/workflow-sdk/src/generate-types/generate-types.ts`, which is not included in the package.

Validated the fixed metadata against the published tarball contents:

```bash
npm pack @n8n/workflow-sdk@0.18.2 --dry-run --json
```

The tarball includes:

- `dist/generate-types/generate-types.js`
- `dist/generate-types/generate-types.d.ts`
- `dist/index.js`

and does not include:

- `src/generate-types/generate-types.ts`
- `src/index.ts`

I also verified that the patched export resolves to `dist/generate-types/generate-types.js` in a clean install layout.
