### PR TITLE
feat(Microsoft OneDrive Node): Support the generic Microsoft OAuth2 credential

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/OneDrive/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/GenericFunctions.ts
@@ -10,6 +10,18 @@ import type {
 } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
 
+/**
+ * Resolves which credential type the node is configured to use. Defaults to the
+ * node-specific `microsoftOneDriveOAuth2Api` so existing workflows (and nodes
+ * without the `authentication` selector) keep working unchanged, while allowing
+ * the generic `microsoftOAuth2Api` (Graph) credential to be selected.
+ */
+export function getOneDriveCredentialType(
+	this: IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions,
+): string {
+	return (this.getNodeParameter('authentication', 0) as string) || 'microsoftOneDriveOAuth2Api';
+}
+
 export async function microsoftApiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions,
 	method: IHttpRequestMethods,
@@ -21,7 +33,8 @@ export async function microsoftApiRequest(
 	headers: IDataObject = {},
 	option: IDataObject = { json: true },
 ): Promise<any> {
-	const credentials = await this.getCredentials('microsoftOneDriveOAuth2Api');
+	const credentialType = getOneDriveCredentialType.call(this);
+	const credentials = await this.getCredentials(credentialType);
 	const baseUrl = (
 		typeof credentials.graphApiBaseUrl === 'string' && credentials.graphApiBaseUrl !== ''
 			? credentials.graphApiBaseUrl
@@ -47,7 +60,7 @@ export async function microsoftApiRequest(
 		if (Object.keys(body as IDataObject).length === 0) {
 			delete options.body;
 		}
-		return await this.helpers.requestOAuth2.call(this, 'microsoftOneDriveOAuth2Api', options);
+		return await this.helpers.requestOAuth2.call(this, credentialType, options);
 	} catch (error) {
 		throw new NodeApiError(this.getNode(), error as JsonObject);
 	}
@@ -151,7 +164,7 @@ export async function getPath(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions,
 	itemId: string,
 ): Promise<string> {
-	const credentials = await this.getCredentials('microsoftOneDriveOAuth2Api');
+	const credentials = await this.getCredentials(getOneDriveCredentialType.call(this));
 	const baseUrl = (
 		typeof credentials.graphApiBaseUrl === 'string' && credentials.graphApiBaseUrl !== ''
 			? credentials.graphApiBaseUrl

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDrive.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDrive.node.ts
@@ -33,9 +33,42 @@ export class MicrosoftOneDrive implements INodeType {
 			{
 				name: 'microsoftOneDriveOAuth2Api',
 				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['microsoftOneDriveOAuth2Api'],
+					},
+				},
+			},
+			{
+				name: 'microsoftOAuth2Api',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['microsoftOAuth2Api'],
+					},
+				},
 			},
 		],
 		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				noDataExpression: true,
+				options: [
+					{
+						name: 'OneDrive OAuth2',
+						value: 'microsoftOneDriveOAuth2Api',
+					},
+					{
+						name: 'Microsoft OAuth2 (Graph)',
+						value: 'microsoftOAuth2Api',
+						description:
+							'Generic Microsoft Graph credential. Enable the scopes this node needs (e.g. Files.ReadWrite.All) on the credential.',
+					},
+				],
+				default: 'microsoftOneDriveOAuth2Api',
+			},
 			{
 				displayName: 'Resource',
 				name: 'resource',

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDriveTrigger.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDriveTrigger.node.ts
@@ -8,7 +8,12 @@ import {
 	NodeConnectionTypes,
 } from 'n8n-workflow';
 
-import { getPath, microsoftApiRequest, microsoftApiRequestAllItemsDelta } from './GenericFunctions';
+import {
+	getOneDriveCredentialType,
+	getPath,
+	microsoftApiRequest,
+	microsoftApiRequestAllItemsDelta,
+} from './GenericFunctions';
 import { triggerDescription } from './TriggerDescription';
 
 export class MicrosoftOneDriveTrigger implements INodeType {
@@ -27,12 +32,47 @@ export class MicrosoftOneDriveTrigger implements INodeType {
 			{
 				name: 'microsoftOneDriveOAuth2Api',
 				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['microsoftOneDriveOAuth2Api'],
+					},
+				},
+			},
+			{
+				name: 'microsoftOAuth2Api',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['microsoftOAuth2Api'],
+					},
+				},
 			},
 		],
 		polling: true,
 		inputs: [],
 		outputs: [NodeConnectionTypes.Main],
-		properties: [...triggerDescription],
+		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				noDataExpression: true,
+				options: [
+					{
+						name: 'OneDrive OAuth2',
+						value: 'microsoftOneDriveOAuth2Api',
+					},
+					{
+						name: 'Microsoft OAuth2 (Graph)',
+						value: 'microsoftOAuth2Api',
+						description:
+							'Generic Microsoft Graph credential. Enable the scopes this node needs (e.g. Files.ReadWrite.All) on the credential.',
+					},
+				],
+				default: 'microsoftOneDriveOAuth2Api',
+			},
+			...triggerDescription,
+		],
 	};
 
 	methods = {
@@ -43,7 +83,7 @@ export class MicrosoftOneDriveTrigger implements INodeType {
 		const workflowData = this.getWorkflowStaticData('node');
 		let responseData: IDataObject[];
 
-		const credentials = await this.getCredentials('microsoftOneDriveOAuth2Api');
+		const credentials = await this.getCredentials(getOneDriveCredentialType.call(this));
 		const baseUrl = (
 			typeof credentials.graphApiBaseUrl === 'string' && credentials.graphApiBaseUrl !== ''
 				? credentials.graphApiBaseUrl

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/test/GenericFunctions.test.ts
@@ -211,6 +211,52 @@ describe('Microsoft OneDrive GenericFunctions', () => {
 		});
 	});
 
+	describe('credential type selection', () => {
+		beforeEach(() => {
+			mockRequestOAuth2.mockResolvedValue({ data: 'test' });
+			mockExecuteFunctions.getCredentials.mockResolvedValue({
+				oauthTokenData: { access_token: 'test-access-token' },
+			});
+		});
+
+		it('should use the generic microsoftOAuth2Api credential when selected', async () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
+
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/drive');
+
+			expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith('microsoftOAuth2Api');
+			expect(mockRequestOAuth2).toHaveBeenCalledWith('microsoftOAuth2Api', expect.anything());
+		});
+
+		it('should use the microsoftOneDriveOAuth2Api credential when selected', async () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftOneDriveOAuth2Api');
+
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/drive');
+
+			expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith(
+				'microsoftOneDriveOAuth2Api',
+			);
+			expect(mockRequestOAuth2).toHaveBeenCalledWith(
+				'microsoftOneDriveOAuth2Api',
+				expect.anything(),
+			);
+		});
+
+		it('should fall back to microsoftOneDriveOAuth2Api when authentication is not set', async () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue(undefined);
+
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/drive');
+
+			expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith(
+				'microsoftOneDriveOAuth2Api',
+			);
+			expect(mockRequestOAuth2).toHaveBeenCalledWith(
+				'microsoftOneDriveOAuth2Api',
+				expect.anything(),
+			);
+		});
+	});
+
 	describe('getPath', () => {
 		describe('graphApiBaseUrl from credentials', () => {
 			it('should use base URL from credentials', async () => {


### PR DESCRIPTION
## Summary

The Microsoft OneDrive node and trigger now accept the generic **Microsoft OAuth2 API** (`microsoftOAuth2Api`) credential in addition to the existing node-specific `microsoftOneDriveOAuth2Api` credential. This lets users drive OneDrive with a single, reusable Microsoft Graph credential (carrying the right scopes, e.g. `Files.ReadWrite.All`) instead of a OneDrive-only credential — the first step toward sharing one Graph credential across the Microsoft 365 nodes.

An `Authentication` selector on the node/trigger chooses between the two credentials. The option values are the credential names, and a resolver (`getOneDriveCredentialType`) routes every request through the selected credential. It **defaults to `microsoftOneDriveOAuth2Api`**, so existing workflows are unaffected.

## How to test

1. Create a **Microsoft OAuth2 API** credential (generic), setting the **Scope** field to include `Files.ReadWrite.All` (plus `openid offline_access`).
2. Add a **Microsoft OneDrive** node, set **Authentication → Microsoft OAuth2 (Graph)**, and select the credential above.
3. Run a representative operation (e.g. `File: Upload` to a valid folder, or `File: Get`) — it should succeed.
4. Switch **Authentication → OneDrive OAuth2** with an existing `microsoftOneDriveOAuth2Api` credential and confirm it still works unchanged.
5. `cd packages/nodes-base && pnpm test OneDrive` — all tests pass (incl. new credential-selection cases).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-43

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI