### PR TITLE
feat: Add a Chat tab to the personal automation desktop app (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/dto/desktop-assistant/__tests__/desktop-assistant-chat-thread-request.dto.test.ts
+++ b/packages/@n8n/api-types/src/dto/desktop-assistant/__tests__/desktop-assistant-chat-thread-request.dto.test.ts
@@ -1,0 +1,25 @@
+import { DesktopAssistantChatThreadRequestDto } from '../desktop-assistant-chat-thread-request.dto';
+
+describe('DesktopAssistantChatThreadRequestDto', () => {
+	describe('Valid requests', () => {
+		test('empty body (server generates the id) validates', () => {
+			const result = DesktopAssistantChatThreadRequestDto.safeParse({});
+			expect(result.success).toBe(true);
+		});
+
+		test('a valid uuid threadId validates', () => {
+			const result = DesktopAssistantChatThreadRequestDto.safeParse({
+				threadId: '4d49ba31-32c9-4ccb-8606-626e9087b417',
+			});
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe('Invalid requests', () => {
+		test('a non-uuid threadId fails', () => {
+			const result = DesktopAssistantChatThreadRequestDto.safeParse({ threadId: 'not-a-uuid' });
+			expect(result.success).toBe(false);
+			expect(result.error?.issues[0].path).toEqual(['threadId']);
+		});
+	});
+});

--- a/packages/@n8n/api-types/src/dto/desktop-assistant/desktop-assistant-chat-thread-request.dto.ts
+++ b/packages/@n8n/api-types/src/dto/desktop-assistant/desktop-assistant-chat-thread-request.dto.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+import { Z } from '../../zod-class';
+
+/**
+ * Request body for `POST /desktop-assistant/chat-thread` — ensures a fresh
+ * Instance AI chat thread exists (in the caller's personal project) so the
+ * desktop chat view can open it before the first message is sent. The id is
+ * generated server-side; an optional one may be supplied for symmetry/testing.
+ */
+export class DesktopAssistantChatThreadRequestDto extends Z.class({
+	threadId: z.string().uuid().optional(),
+}) {}
+
+export type DesktopAssistantChatThreadRequest = z.infer<
+	typeof DesktopAssistantChatThreadRequestDto.schema
+>;
+
+export interface DesktopAssistantChatThreadResponse {
+	threadId: string;
+}

--- a/packages/@n8n/api-types/src/dto/index.ts
+++ b/packages/@n8n/api-types/src/dto/index.ts
@@ -43,6 +43,11 @@ export {
 	type DesktopAssistantPromoteRequest,
 	type DesktopAssistantPromoteResponse,
 } from './desktop-assistant/desktop-assistant-promote-request.dto';
+export {
+	DesktopAssistantChatThreadRequestDto,
+	type DesktopAssistantChatThreadRequest,
+	type DesktopAssistantChatThreadResponse,
+} from './desktop-assistant/desktop-assistant-chat-thread-request.dto';
 export type {
 	DesktopAssistantTasksResponse,
 	DesktopAssistantTaskCard,

--- a/packages/@n8n/local-gateway/src/main/instance-api.test.ts
+++ b/packages/@n8n/local-gateway/src/main/instance-api.test.ts
@@ -252,6 +252,27 @@ describe('InstanceApi', () => {
 		});
 	});
 
+	describe('createChatThread', () => {
+		it('POSTs to the chat-thread endpoint and unwraps the thread id', async () => {
+			mockFetch.mockResolvedValue(jsonResponse({ data: { threadId: 't-chat' } }));
+
+			const result = await new InstanceApi(makeOAuth()).createChatThread();
+
+			const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+			expect(url).toBe('https://n.example/rest/desktop-assistant/chat-thread');
+			expect(init.method).toBe('POST');
+			expect(init.body).toBe('{}');
+			expect((init.headers as Record<string, string>).authorization).toBe('Bearer tok');
+			expect(result).toEqual({ threadId: 't-chat' });
+		});
+
+		it('throws InstanceApiError on a non-ok response', async () => {
+			mockFetch.mockResolvedValue(jsonResponse({ message: 'nope' }, { ok: false, status: 500 }));
+
+			await expect(new InstanceApi(makeOAuth()).createChatThread()).rejects.toThrow();
+		});
+	});
+
 	describe('workflowUrl', () => {
 		it('builds the editor url, or null when signed out', () => {
 			expect(new InstanceApi(makeOAuth()).workflowUrl('wf-1')).toBe(

--- a/packages/@n8n/local-gateway/src/main/instance-api.ts
+++ b/packages/@n8n/local-gateway/src/main/instance-api.ts
@@ -1,6 +1,7 @@
 import type {
 	DesktopAssistantApplyEditsRequest,
 	DesktopAssistantApplyEditsResponse,
+	DesktopAssistantChatThreadResponse,
 	DesktopAssistantHistoryResponse,
 	DesktopAssistantPromoteRequest,
 	DesktopAssistantPromoteResponse,
@@ -256,6 +257,21 @@ export class InstanceApi {
 			body: JSON.stringify(body),
 		});
 		return await this.unwrap<DesktopAssistantPromoteResponse>(response);
+	}
+
+	/**
+	 * `POST /rest/desktop-assistant/chat-thread` — ensure a fresh chat thread in
+	 * the user's personal project and return its id. The renderer opens this
+	 * thread before the first message so the snapshot fetch resolves.
+	 */
+	async createChatThread(): Promise<DesktopAssistantChatThreadResponse> {
+		const response = await this.authedFetch('/desktop-assistant/chat-thread', {
+			method: 'POST',
+			// eslint-disable-next-line @typescript-eslint/naming-convention -- HTTP header name
+			headers: { 'content-type': 'application/json' },
+			body: JSON.stringify({}),
+		});
+		return await this.unwrap<DesktopAssistantChatThreadResponse>(response);
 	}
 
 	/** `GET /rest/instance-ai/threads/:threadId/messages` — the thread's stored messages plus the `nextEventId` SSE cursor. */

--- a/packages/@n8n/local-gateway/src/main/ipc-handlers.test.ts
+++ b/packages/@n8n/local-gateway/src/main/ipc-handlers.test.ts
@@ -384,6 +384,41 @@ describe('registerIpcHandlers', () => {
 		expect(result).toEqual({ ok: true, threadId: 't-1', runId: 'r-1' });
 	});
 
+	it('assistant:createChatThread returns the ensured thread id', async () => {
+		const instanceApi = {
+			getTasks: vi.fn(),
+			runWorkflow: vi.fn(),
+			workflowUrl: vi.fn(),
+			getHistory: vi.fn(),
+			executionUrl: vi.fn(),
+			getTimeSaved: vi.fn(),
+			createChatThread: vi.fn().mockResolvedValue({ threadId: 't-chat' }),
+		};
+		register({ instanceApi });
+
+		const result = await getRegisteredHandler('assistant:createChatThread')();
+
+		expect(instanceApi.createChatThread).toHaveBeenCalled();
+		expect(result).toEqual({ ok: true, threadId: 't-chat' });
+	});
+
+	it('assistant:createChatThread surfaces a failure as { ok: false }', async () => {
+		const instanceApi = {
+			getTasks: vi.fn(),
+			runWorkflow: vi.fn(),
+			workflowUrl: vi.fn(),
+			getHistory: vi.fn(),
+			executionUrl: vi.fn(),
+			getTimeSaved: vi.fn(),
+			createChatThread: vi.fn().mockRejectedValue(new InstanceApiError('boom', 500)),
+		};
+		register({ instanceApi });
+
+		const result = await getRegisteredHandler('assistant:createChatThread')();
+
+		expect(result).toEqual({ ok: false, error: 'boom' });
+	});
+
 	it('permissions:get returns the mac permission status', async () => {
 		const status = {
 			supported: true,

--- a/packages/@n8n/local-gateway/src/main/ipc-handlers.ts
+++ b/packages/@n8n/local-gateway/src/main/ipc-handlers.ts
@@ -19,6 +19,7 @@ import type {
 	AuthStatus,
 	ConfirmThreadResult,
 	CreateAssistantTaskResult,
+	CreateChatThreadResult,
 	DesktopAssistantApplyEditsRequest,
 	DesktopAssistantApplyEditsResponse,
 	DesktopAssistantHistoryParams,
@@ -233,6 +234,18 @@ export function registerIpcHandlers({
 			}
 		},
 	);
+
+	ipcMain.handle('assistant:createChatThread', async (): Promise<CreateChatThreadResult> => {
+		logger.debug('IPC assistant:createChatThread');
+		try {
+			const { threadId } = await instanceApi.createChatThread();
+			return { ok: true, threadId };
+		} catch (error) {
+			const message = ipcErrorMessage(error);
+			logger.error('IPC assistant:createChatThread failed', { error: message });
+			return { ok: false, error: message };
+		}
+	});
 
 	ipcMain.handle(
 		'assistant:promote',

--- a/packages/@n8n/local-gateway/src/main/preload.ts
+++ b/packages/@n8n/local-gateway/src/main/preload.ts
@@ -5,6 +5,7 @@ import type {
 	AuthStatus,
 	ConfirmThreadResult,
 	CreateAssistantTaskResult,
+	CreateChatThreadResult,
 	DesktopAssistantApplyEditsRequest,
 	DesktopAssistantApplyEditsResponse,
 	DesktopAssistantHistoryParams,
@@ -76,6 +77,9 @@ const electronApi: ElectronApi = {
 		body: DesktopAssistantTaskRequest,
 	): Promise<CreateAssistantTaskResult> =>
 		await (ipcRenderer.invoke('assistant:createTask', body) as Promise<CreateAssistantTaskResult>),
+
+	createChatThread: async (): Promise<CreateChatThreadResult> =>
+		await (ipcRenderer.invoke('assistant:createChatThread') as Promise<CreateChatThreadResult>),
 
 	promoteAssistantThread: async (
 		threadId: string,

--- a/packages/@n8n/local-gateway/src/renderer/components/AppHeader.vue
+++ b/packages/@n8n/local-gateway/src/renderer/components/AppHeader.vue
@@ -2,7 +2,6 @@
 import { N8nIcon, N8nLogo } from '@n8n/design-system';
 
 import { activeViewTitle } from '../app/view-title';
-import { openChat } from '../chat/chat-overlay';
 
 import type { AuthState } from '../../shared/types';
 
@@ -13,10 +12,6 @@ defineProps<{
 }>();
 
 const emit = defineEmits<{ openSettings: [] }>();
-
-// TEMPORARY: invisible button next to the brand opens the chat overlay for manual
-// testing until the composer flow calls openChat. Remove together with the button.
-const DEV_CHAT_THREAD_ID = '4d49ba31-32c9-4ccb-8606-626e9087b417';
 
 const STATUS_LABEL: Record<AuthState, string> = {
 	signedIn: 'Connected',
@@ -52,14 +47,6 @@ const DOT_CLASS: Record<AuthState, string> = {
 		<div v-else :class="$style.brand">
 			<N8nLogo size="small" :collapsed="true" />
 			<span :class="$style.brandLabel">Assistant</span>
-			<!-- TEMPORARY chat-overlay test trigger: button-sized, but no icon or border. -->
-			<button
-				type="button"
-				:class="$style.iconBtn"
-				aria-label="Open chat (dev)"
-				data-testid="header-dev-chat"
-				@click="openChat(DEV_CHAT_THREAD_ID)"
-			/>
 		</div>
 
 		<div :class="$style.actions">

--- a/packages/@n8n/local-gateway/src/renderer/components/ChatView.vue
+++ b/packages/@n8n/local-gateway/src/renderer/components/ChatView.vue
@@ -1,0 +1,74 @@
+<script setup lang="ts">
+import { useI18n } from '@n8n/i18n';
+import { computed, ref } from 'vue';
+
+import ChatMessages from './ChatMessages.vue';
+import ComposerField from './ComposerField.vue';
+
+import { hasBlockingPromptForThread } from '../permissions/permission-prompt-store';
+
+// Inline chat for one thread, rendered inside the home tab panel (the slide-up
+// overlay flow lives in ChatPanel.vue). Driven entirely by the `threadId` prop —
+// no overlay state, no view-title/back-button coupling.
+const props = defineProps<{ threadId: string }>();
+
+const i18n = useI18n();
+
+const text = ref('');
+const messagesRef = ref<InstanceType<typeof ChatMessages> | null>(null);
+
+// A pending confirmation suspends the run server-side (posting would 409);
+// refuse input and say why via the placeholder.
+const suspended = computed(() => hasBlockingPromptForThread(props.threadId));
+
+const placeholder = computed(() =>
+	i18n.baseText(
+		suspended.value
+			? 'desktopAssistant.permissions.suspendedPlaceholder'
+			: 'desktopAssistant.chat.placeholder',
+	),
+);
+
+async function submit() {
+	const value = text.value.trim();
+	if (!value || messagesRef.value?.busy || suspended.value) return;
+	text.value = '';
+	await messagesRef.value?.send(value);
+}
+</script>
+
+<template>
+	<div :class="$style.chat">
+		<!-- Keyed by thread: starting a new chat remounts the transcript (fresh load +
+		     listener lifecycle). -->
+		<ChatMessages :key="threadId" ref="messagesRef" :thread-id="threadId" />
+
+		<div :class="$style.composer">
+			<!-- Stays enabled while the agent works (disabling would steal focus); submit() simply refuses while busy. -->
+			<ComposerField
+				v-model="text"
+				:busy="messagesRef?.busy"
+				:placeholder="placeholder"
+				:input-aria-label="i18n.baseText('desktopAssistant.chat.inputAriaLabel')"
+				:send-aria-label="i18n.baseText('desktopAssistant.chat.send')"
+				@submit="submit"
+			/>
+		</div>
+	</div>
+</template>
+
+<style module>
+.chat {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	min-height: 0;
+	background: var(--da-surface);
+}
+
+.composer {
+	padding: var(--spacing--xs);
+	background: var(--da-bg);
+	border-top: 1px solid var(--da-border);
+}
+</style>

--- a/packages/@n8n/local-gateway/src/renderer/views/HomeView.vue
+++ b/packages/@n8n/local-gateway/src/renderer/views/HomeView.vue
@@ -1,28 +1,59 @@
 <script setup lang="ts">
-import { N8nIcon, N8nInput } from '@n8n/design-system';
+import { N8nButton, N8nIcon, N8nInput, N8nSpinner, N8nText } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import { computed, onMounted, ref } from 'vue';
 
 import HistoryView from './HistoryView.vue';
 import TasksView from './TasksView.vue';
+import ChatView from '../components/ChatView.vue';
 import TaskComposer from '../components/TaskComposer.vue';
 
 import { useTaskSearch } from '../assistant/use-task-search';
 
-type Tab = 'tasks' | 'history';
+type Tab = 'tasks' | 'history' | 'chat';
 
 const i18n = useI18n();
 const activeTab = ref<Tab>('tasks');
+
+// Chat is a real tab, but each selection starts a fresh thread (no resume). The
+// thread is ensured server-side before ChatView opens it, so its snapshot fetch
+// resolves instead of 404-ing on an unborn thread.
+const chatThreadId = ref<string | null>(null);
+const chatCreating = ref(false);
+const chatError = ref(false);
+
+async function startNewChat() {
+	// Dedupe concurrent creates (rapid clicks / arrow-key roving) into one thread.
+	if (chatCreating.value) return;
+	chatCreating.value = true;
+	chatError.value = false;
+	chatThreadId.value = null;
+	try {
+		const result = await window.electronAPI.createChatThread();
+		if (result.ok && result.threadId) {
+			chatThreadId.value = result.threadId;
+		} else {
+			chatError.value = true;
+			console.error('Failed to create chat thread', result.error);
+		}
+	} catch (error) {
+		chatError.value = true;
+		console.error('Failed to create chat thread', error);
+	} finally {
+		chatCreating.value = false;
+	}
+}
 
 // Search is tasks-scoped: the field only shows on the Tasks tab, and the query
 // is passed down to TasksView for client-side filtering.
 const search = useTaskSearch();
 const searchVisible = computed(() => search.open.value && activeTab.value === 'tasks');
 
-/** Search lives in the shared tab bar but only filters Tasks. From History,
- *  clicking it jumps to Tasks and opens the field; from Tasks it toggles. */
+/** Search lives in the shared tab bar but only filters Tasks. From any other
+ *  tab (History, Chat), clicking it jumps to Tasks and opens the field; from
+ *  Tasks it toggles. */
 function onSearchIconClick() {
-	if (activeTab.value === 'history') {
+	if (activeTab.value !== 'tasks') {
 		selectTab('tasks');
 		search.openSearch();
 		return;
@@ -44,10 +75,14 @@ function runPrompt(prompt: string) {
 
 const TABS: Array<{
 	id: Tab;
-	labelKey: 'desktopAssistant.tabs.tasks' | 'desktopAssistant.tabs.history';
+	labelKey:
+		| 'desktopAssistant.tabs.tasks'
+		| 'desktopAssistant.tabs.history'
+		| 'desktopAssistant.tabs.chat';
 }> = [
 	{ id: 'tasks', labelKey: 'desktopAssistant.tabs.tasks' },
 	{ id: 'history', labelKey: 'desktopAssistant.tabs.history' },
+	{ id: 'chat', labelKey: 'desktopAssistant.tabs.chat' },
 ];
 
 // Refs to the tab buttons, so arrow keys can move focus along with selection
@@ -56,6 +91,8 @@ const tabRefs = ref<HTMLButtonElement[]>([]);
 
 function selectTab(id: Tab) {
 	activeTab.value = id;
+	// Selecting Chat always begins a fresh conversation.
+	if (id === 'chat') void startNewChat();
 }
 
 /** Left/Right arrow + Home/End move selection and focus between tabs. */
@@ -167,7 +204,24 @@ onMounted(() => {
 				@executed="activeTab = 'history'"
 				@run-prompt="runPrompt"
 			/>
-			<HistoryView v-else />
+			<HistoryView v-else-if="activeTab === 'history'" />
+			<template v-else>
+				<div v-if="chatError" :class="$style.chatState" role="alert">
+					<N8nText color="text-light" size="small">{{
+						i18n.baseText('desktopAssistant.chat.error')
+					}}</N8nText>
+					<N8nButton variant="outline" size="small" @click="startNewChat">{{
+						i18n.baseText('desktopAssistant.chat.retry')
+					}}</N8nButton>
+				</div>
+				<div v-else-if="!chatThreadId" :class="$style.chatState" role="status" aria-live="polite">
+					<N8nSpinner aria-hidden="true" />
+					<N8nText color="text-light" size="small">{{
+						i18n.baseText('desktopAssistant.chat.loading')
+					}}</N8nText>
+				</div>
+				<ChatView v-else :thread-id="chatThreadId" />
+			</template>
 		</div>
 
 		<!-- The composer is pinned below the scrollable list, only on the Tasks tab.
@@ -297,5 +351,16 @@ onMounted(() => {
 .content:focus-visible {
 	outline: var(--da-focus-ring);
 	outline-offset: calc(-1 * var(--da-focus-ring-offset));
+}
+
+/* Centered loading/error state shown while a chat thread is being created. */
+.chatState {
+	display: flex;
+	flex: 1;
+	flex-direction: column;
+	gap: var(--spacing--2xs);
+	align-items: center;
+	justify-content: center;
+	padding: var(--spacing--xl) var(--spacing--md);
 }
 </style>

--- a/packages/@n8n/local-gateway/src/shared/types.ts
+++ b/packages/@n8n/local-gateway/src/shared/types.ts
@@ -147,6 +147,13 @@ export interface CreateAssistantTaskResult {
 	error?: string;
 }
 
+/** Result of ensuring a fresh Instance AI chat thread for the desktop chat view. */
+export interface CreateChatThreadResult {
+	ok: boolean;
+	threadId?: string;
+	error?: string;
+}
+
 /**
  * Result of asking the instance to promote a thread into a saved workflow.
  * Idempotent: `building` while the build runs, `done` (with `workflowId`)
@@ -199,6 +206,8 @@ export interface ElectronApi {
 	runTask: (workflowId: string) => Promise<RunTaskResult>;
 	/** Start a one-shot assistant task run with the prompt + detected context. */
 	createAssistantTask: (body: DesktopAssistantTaskRequest) => Promise<CreateAssistantTaskResult>;
+	/** Ensure a fresh Instance AI chat thread (in the personal project); returns its id. */
+	createChatThread: () => Promise<CreateChatThreadResult>;
 	promoteAssistantThread: (
 		threadId: string,
 		name?: string,

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.controller.test.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.controller.test.ts
@@ -47,6 +47,10 @@ describe('DesktopAssistantController', () => {
 			expect(scopeOf('getHistory')).toEqual({ scope: 'instanceAi:message', globalOnly: true });
 			expect(scopeOf('getTaskDetail')).toEqual({ scope: 'instanceAi:message', globalOnly: true });
 			expect(scopeOf('applyTaskEdits')).toEqual({ scope: 'instanceAi:message', globalOnly: true });
+			expect(scopeOf('createChatThread')).toEqual({
+				scope: 'instanceAi:message',
+				globalOnly: true,
+			});
 		});
 	});
 
@@ -91,6 +95,12 @@ describe('DesktopAssistantController', () => {
 					changes: [{ paramId: 'p1', from: 'a', to: 'b' }],
 				}),
 			).rejects.toBeInstanceOf(ForbiddenError);
+		});
+
+		test('createChatThread throws ForbiddenError', async () => {
+			await expect(controller.createChatThread(req, null, {})).rejects.toBeInstanceOf(
+				ForbiddenError,
+			);
 		});
 	});
 
@@ -155,6 +165,13 @@ describe('DesktopAssistantController', () => {
 			const result = await controller.applyTaskEdits(req, null, 'wf-1', body);
 			expect(service.applyTaskEdits).toHaveBeenCalledWith(user, 'wf-1', body);
 			expect(result).toEqual({ threadId: 't-1', runId: 'r-1' });
+		});
+
+		test('createChatThread forwards the optional id to the service', async () => {
+			service.createChatThread.mockResolvedValue({ threadId: 't-chat' });
+			const result = await controller.createChatThread(req, null, { threadId: 't-chat' });
+			expect(service.createChatThread).toHaveBeenCalledWith(user, 't-chat');
+			expect(result).toEqual({ threadId: 't-chat' });
 		});
 
 		test('getHistory forwards the validated cursor query to the service', async () => {

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/__tests__/desktop-assistant.service.test.ts
@@ -166,6 +166,56 @@ describe('DesktopAssistantService.triggerTask', () => {
 	});
 });
 
+describe('DesktopAssistantService.createChatThread', () => {
+	function mockEnsuredThread(ctx: ReturnType<typeof makeService>) {
+		ctx.projectService.getPersonalProject.mockResolvedValue({ id: 'proj-1' } as never);
+		ctx.memoryService.ensureThread.mockResolvedValue({
+			thread: {
+				id: 't',
+				resourceId: USER.id,
+				createdAt: new Date().toISOString(),
+				updatedAt: new Date().toISOString(),
+			},
+			created: true,
+		});
+	}
+
+	test('ensures a desktop-tagged thread in the personal project without starting a run', async () => {
+		const ctx = makeService();
+		mockEnsuredThread(ctx);
+
+		const result = await ctx.service.createChatThread(USER);
+
+		expect(ctx.projectService.getPersonalProject).toHaveBeenCalledWith(USER);
+		expect(ctx.memoryService.ensureThread).toHaveBeenCalledTimes(1);
+		const [userId, threadId, projectId, metadata] = ctx.memoryService.ensureThread.mock.calls[0];
+		expect(userId).toBe(USER.id);
+		expect(projectId).toBe('proj-1');
+		expect(metadata).toEqual({ source: 'desktop-assistant' });
+		expect(result.threadId).toBe(threadId);
+		expect(ctx.instanceAiService.startRun).not.toHaveBeenCalled();
+	});
+
+	test('honors a supplied thread id', async () => {
+		const ctx = makeService();
+		mockEnsuredThread(ctx);
+
+		const result = await ctx.service.createChatThread(USER, 'chat-1');
+
+		expect(result.threadId).toBe('chat-1');
+		const [, threadId] = ctx.memoryService.ensureThread.mock.calls[0];
+		expect(threadId).toBe('chat-1');
+	});
+
+	test('throws BadRequestError when the user has no personal project', async () => {
+		const ctx = makeService();
+		ctx.projectService.getPersonalProject.mockResolvedValue(null as never);
+
+		await expect(ctx.service.createChatThread(USER)).rejects.toBeInstanceOf(BadRequestError);
+		expect(ctx.memoryService.ensureThread).not.toHaveBeenCalled();
+	});
+});
+
 describe('DesktopAssistantService.triggerTask publishing', () => {
 	/**
 	 * Run a one-shot task and emit a legacy planned-task build outcome for the

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.controller.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.controller.ts
@@ -3,8 +3,10 @@ import {
 	DesktopAssistantHistoryQueryDto,
 	DesktopAssistantPromoteRequestDto,
 	DesktopAssistantRecommendationsRequestDto,
+	DesktopAssistantChatThreadRequestDto,
 	DesktopAssistantTaskRequestDto,
 	type DesktopAssistantApplyEditsResponse,
+	type DesktopAssistantChatThreadResponse,
 	type DesktopAssistantHistoryResponse,
 	type DesktopAssistantPromoteResponse,
 	type DesktopAssistantRecommendationsResponse,
@@ -92,6 +94,17 @@ export class DesktopAssistantController {
 	): Promise<DesktopAssistantRecommendationsResponse> {
 		this.requireEnabled();
 		return await this.desktopAssistantService.getRecommendations(req.user, body);
+	}
+
+	@Post('/chat-thread')
+	@GlobalScope('instanceAi:message')
+	async createChatThread(
+		req: AuthenticatedRequest,
+		_res: unknown,
+		@Body body: DesktopAssistantChatThreadRequestDto,
+	): Promise<DesktopAssistantChatThreadResponse> {
+		this.requireEnabled();
+		return await this.desktopAssistantService.createChatThread(req.user, body.threadId);
 	}
 
 	@Post('/promote-thread')

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.service.ts
@@ -356,6 +356,23 @@ export class DesktopAssistantService {
 		return map;
 	}
 
+	// ── chat ─────────────────────────────────────────────────────────────────
+
+	/**
+	 * Ensure a fresh chat thread exists in the user's personal project and return
+	 * its id. The desktop chat view opens this thread before the first message,
+	 * so its message-snapshot fetch resolves instead of 404-ing on an unborn
+	 * thread. Tagged desktop-originated like every other desktop-assistant thread.
+	 */
+	async createChatThread(user: User, threadId?: string): Promise<{ threadId: string }> {
+		const id = threadId ?? randomUUID();
+		const projectId = await this.resolvePersonalProjectId(user);
+		await this.memoryService.ensureThread(user.id, id, projectId, {
+			[THREAD_SOURCE_METADATA_KEY]: DESKTOP_ASSISTANT_THREAD_SOURCE,
+		});
+		return { threadId: id };
+	}
+
 	// ── one-shot task ────────────────────────────────────────────────────────
 
 	async triggerTask(

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -39,6 +39,7 @@
 	},
 	"desktopAssistant.tabs.tasks": "Tasks",
 	"desktopAssistant.tabs.history": "History",
+	"desktopAssistant.tabs.chat": "Chat",
 	"desktopAssistant.chat.title": "Chat",
 	"desktopAssistant.chat.back": "Back",
 	"desktopAssistant.chat.placeholder": "Ask anything…",


### PR DESCRIPTION
## Summary

Adds a third **Chat** tab to the desktop assistant home screen, alongside **Tasks** and **History**. Selecting Chat starts a brand-new Instance AI conversation the user can chat with — a fresh thread every time the tab is selected (no resume).

The chat building blocks already existed (`ChatMessages`, `ComposerField`, `thread-client`, the main-process `ThreadService`), but only wired to a temporary dev button as a slide-up overlay. This change renders the chat **inline inside the tab panel** (like Tasks/History) and removes the dev button.

Because `GET /instance-ai/threads/:threadId/messages` 404s for a thread that doesn't exist yet — and `ChatMessages` fetches that snapshot before listening — the thread is ensured up front via a small new endpoint that binds it to the user's personal project (mirroring the proven editor-ui flow and every other desktop-assistant flow).

**What's included:**
- **Backend** — `POST /desktop-assistant/chat-thread` resolves the personal project and ensures a fresh, desktop-tagged thread, returning `{ threadId }` (new `DesktopAssistantChatThreadRequestDto` in `@n8n/api-types`).
- **Main/IPC** — `InstanceApi.createChatThread` → `assistant:createChatThread` handler → preload `createChatThread()` bridge.
- **Renderer** — `chat` added as a real tab in `HomeView` (keeps `role="tab"` + roving-tabindex a11y); new inline `ChatView.vue`; loading/error+retry states while the thread is created. Removed the temporary dev chat button from `AppHeader`.
- The tab-bar search icon now also works from the Chat tab (jumps to Tasks and opens the search field, like it does from History).

## How to test

1. Rebuild `@n8n/api-types` and `cli`, then run the desktop app (`pnpm dev` + `pnpm start` in `packages/@n8n/local-gateway`) against a signed-in instance.
2. On Home, a third **Chat** tab appears. Click it → the tab panel shows an empty chat ("No messages yet") with a composer at the bottom.
3. Send a message → optimistic user bubble + streamed assistant reply (confirms `chat/:threadId` + SSE work on the new thread).
4. Switch to Tasks/History and back to Chat → a fresh, empty thread each time (each selection hits `/desktop-assistant/chat-thread` with a new id; no resumed history).
5. Keyboard: arrow keys move among the three tabs; Enter/Space on Chat opens a new chat.
6. From the Chat tab, click the search icon → it navigates to Tasks and opens the search input.

Automated coverage: controller (scope + disabled + delegation), service (ensure-in-personal-project, supplied id, no-personal-project error, no run started), DTO validation, `InstanceApi` fetch, and IPC success/failure. `pnpm typecheck` + `pnpm lint` pass in `@n8n/api-types`, `cli`, and `@n8n/local-gateway`.

## Related Linear tickets, Github issues, and Community forum posts

n/a — internal hackweek feature, part of the personal-automation desktop app initiative.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI