### PR TITLE
test(core): Stabilize flaky task runner restart integration test (no-changelog)

### DIFF
--- a/packages/cli/test/integration/task-runners/task-runner-process.test.ts
+++ b/packages/cli/test/integration/task-runners/task-runner-process.test.ts
@@ -8,6 +8,11 @@ import { retryUntil } from '@test-integration/retry-until';
 import { setupBrokerTestServer } from '@test-integration/utils/task-broker-test-server';
 
 describe('TaskRunnerProcess', () => {
+	// Restarting the runner spawns a fresh `node` child process and waits for the
+	// full WebSocket handshake. Under CI load this can take longer than the default
+	// per-test timeout, so give this spawn-heavy suite extra headroom.
+	jest.setTimeout(30_000);
+
 	const { config, server: taskRunnerServer } = setupBrokerTestServer({
 		mode: 'internal',
 	});
@@ -79,8 +84,10 @@ describe('TaskRunnerProcess', () => {
 		await runnerProcess.runPromise;
 
 		// Assert
-		// Wait until the runner has connected again
-		await retryUntil(() => expect(getNumConnectedRunners()).toBe(1));
+		// Wait until the runner has connected again. Restarting spawns a fresh
+		// child process and re-runs the WebSocket handshake, which is slower and
+		// more load-sensitive than the initial connect, so allow a longer window.
+		await retryUntil(() => expect(getNumConnectedRunners()).toBe(1), { timeoutMs: 15_000 });
 		expect(getNumConnectedRunners()).toBe(1);
 		expect(getNumRegisteredRunners()).toBe(1);
 		expect(runnerProcess.pid).not.toBe(processId);


### PR DESCRIPTION
## Summary

The integration test `TaskRunnerProcess › should restart the task runner if it exits` (`packages/cli/test/integration/task-runners/task-runner-process.test.ts`) is flaky in CI:

```
expect(received).toBe(expected) // Object.is equality
Expected: 1
Received: 0
  83 |     await retryUntil(() => expect(getNumConnectedRunners()).toBe(1));
```

**Root cause:** after SIGKILLing the runner, the test polls `runnerConnections.size` until the auto-restart reconnects. The restart spawns a fresh `node` child process and must complete the full WebSocket handshake (`broker:inforequest` → `runner:info`) before the connection is counted — but it only got the default 5s `retryUntil` window, inside the suite's 10s per-test `testTimeout`. Under CI load a second node spawn plus handshake can exceed 5s, so the count is still `0` when the deadline hits. There is no logic bug in the restart path; the deadline was simply too tight and load-sensitive.

**Fix (test-only, no production behavior change):**
- `jest.setTimeout(30_000)` for this spawn-heavy suite (matching the precedent set by the migration tests at 20s).
- A generous explicit `{ timeoutMs: 15_000 }` ceiling on the reconnection `retryUntil`. `retryUntil` resolves the instant the condition is met, so this costs nothing on the happy path — it only raises the ceiling for slow CI runs.

## How to test

```bash
cd packages/cli
pnpm test test/integration/task-runners/task-runner-process.test.ts
```

All 4 tests pass; `should restart the task runner if it exits` completes in ~1.4s locally and now has ample headroom under CI load.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3407

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI