### PR TITLE
fix: point ./scripts/generate-types export to built dist files

### DIFF
--- a/packages/@n8n/workflow-sdk/package.json
+++ b/packages/@n8n/workflow-sdk/package.json
@@ -9,8 +9,8 @@
     },
     "./package.json": "./package.json",
     "./scripts/generate-types": {
-      "types": "./src/generate-types/generate-types.ts",
-      "default": "./src/generate-types/generate-types.ts"
+      "types": "./dist/generate-types/generate-types.d.ts",
+      "default": "./dist/generate-types/generate-types.js"
     },
     "./dist/generate-types/generate-types": {
       "default": "./dist/generate-types/generate-types.js"


### PR DESCRIPTION
Fixes @n8n/workflow-sdk subpath export "./scripts/generate-types" which pointed to source TypeScript files not included in the published npm package.

**Changes:**
- `exports[./scripts/generate-types]` now points to `./dist/generate-types/generate-types.js` (default) and `./dist/generate-types/generate-types.d.ts` (types)

**Background:**
The package only includes `dist/**/*` in `files`, so the source `.ts` files were never published. The built `.js` and `.d.ts` files already exist at `dist/generate-types/`.

**Validation:**
- `npm pack --dry-run --ignore-scripts --json` (verifies exports resolve to included files)
- `git diff --check`

Fixes n8n-io/n8n#31980, charles-openclaw/charles-microbounties#684

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32187?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

