### PR TITLE
test: Add timeout and retry around Postgres testDb.init()

### DIFF
--- a/packages/@n8n/backend-test-utils/src/test-db.ts
+++ b/packages/@n8n/backend-test-utils/src/test-db.ts
@@ -13,6 +13,29 @@ let testDbName: string | undefined;
 let originalDatabase: string | undefined;
 
 /**
+ * Per-attempt deadline for the Postgres init steps (create the test DB and
+ * connect to it). Comfortably below the 30s testcontainers hook timeout so a
+ * stalled connection or a blocked `CREATE DATABASE` fails fast with an
+ * actionable error and gets retried, instead of silently eating the whole
+ * hook budget and surfacing as an opaque "Exceeded timeout of a hook".
+ */
+const PG_INIT_STEP_TIMEOUT_MS = 20_000;
+const PG_INIT_MAX_ATTEMPTS = 3;
+
+/** Reject if `operation` doesn't settle within `ms`, with a labelled error. */
+async function withTimeout<T>(operation: Promise<T>, ms: number, label: string): Promise<T> {
+	let timer: NodeJS.Timeout | undefined;
+	const timeout = new Promise<never>((_, reject) => {
+		timer = setTimeout(() => reject(new Error(`${label} did not complete within ${ms}ms`)), ms);
+	});
+	try {
+		return await Promise.race([operation, timeout]);
+	} finally {
+		if (timer) clearTimeout(timer);
+	}
+}
+
+/**
  * Generate options for a bootstrap DB connection, to create and drop test databases.
  */
 export const getBootstrapDBOptions = (): DataSourceOptions => {
@@ -40,35 +63,97 @@ export async function init() {
 
 	const globalConfig = Container.get(GlobalConfig);
 	const dbType = globalConfig.database.type;
-	testDbName = `${testDbPrefix}${randomString(6, 10).toLowerCase()}_${Date.now()}`;
 
 	const templateDb = dbType === 'postgresdb' ? process.env.N8N_TEST_TEMPLATE_DB : undefined;
 
 	if (dbType === 'postgresdb') {
 		originalDatabase = globalConfig.database.postgresdb.database;
-		const bootstrapPostgres = await new Connection(getBootstrapDBOptions()).initialize();
-		if (templateDb) {
-			await bootstrapPostgres.query(`CREATE DATABASE ${testDbName} TEMPLATE ${templateDb}`);
-		} else {
-			await bootstrapPostgres.query(`CREATE DATABASE ${testDbName}`);
-		}
-		await bootstrapPostgres.destroy();
-
-		globalConfig.database.postgresdb.database = testDbName;
-	}
-
-	const dbConnection = Container.get(DbConnection);
-	await dbConnection.init();
-
-	if (templateDb) {
-		// Template already carries migrations + seeded roles — just mark state.
-		dbConnection.connectionState.migrated = true;
+		// Creating the per-file test DB and opening its connection are the steps
+		// that can stall under parallel workers (a blocked `CREATE DATABASE ...
+		// TEMPLATE` contending for the template, or a DataSource that never
+		// connects). Bound each attempt and retry with a fresh DB name so a
+		// transient stall recovers instead of timing out the whole hook.
+		await initPostgresWithRetry(templateDb);
 	} else {
+		testDbName = `${testDbPrefix}${randomString(6, 10).toLowerCase()}_${Date.now()}`;
+		const dbConnection = Container.get(DbConnection);
+		await dbConnection.init();
 		await dbConnection.migrate();
 		await Container.get(AuthRolesService).init();
 	}
 
 	isInitialized = true;
+}
+
+/**
+ * Postgres-only: create the per-file test DB (optionally cloning a template)
+ * and open its connection, each step bounded by a timeout and retried with a
+ * fresh DB name. Throws the last error if every attempt fails.
+ */
+async function initPostgresWithRetry(templateDb: string | undefined): Promise<void> {
+	let lastError: unknown;
+
+	for (let attempt = 1; attempt <= PG_INIT_MAX_ATTEMPTS; attempt++) {
+		const candidateDbName = `${testDbPrefix}${randomString(6, 10).toLowerCase()}_${Date.now()}`;
+
+		try {
+			const bootstrapPostgres = await withTimeout(
+				new Connection(getBootstrapDBOptions()).initialize(),
+				PG_INIT_STEP_TIMEOUT_MS,
+				'Bootstrap Postgres connection',
+			);
+			try {
+				const createQuery = templateDb
+					? `CREATE DATABASE ${candidateDbName} TEMPLATE ${templateDb}`
+					: `CREATE DATABASE ${candidateDbName}`;
+				await withTimeout(
+					bootstrapPostgres.query(createQuery),
+					PG_INIT_STEP_TIMEOUT_MS,
+					`CREATE DATABASE ${candidateDbName}`,
+				);
+			} finally {
+				await bootstrapPostgres.destroy();
+			}
+
+			testDbName = candidateDbName;
+			// Re-fetch GlobalConfig from the container each attempt: a prior
+			// failed attempt's Container.reset() invalidates any earlier handle.
+			Container.get(GlobalConfig).database.postgresdb.database = testDbName;
+
+			const dbConnection = Container.get(DbConnection);
+			await withTimeout(
+				dbConnection.init(),
+				PG_INIT_STEP_TIMEOUT_MS,
+				`Open connection to test DB ${testDbName}`,
+			);
+
+			if (templateDb) {
+				// Template already carries migrations + seeded roles — just mark state.
+				dbConnection.connectionState.migrated = true;
+			} else {
+				await dbConnection.migrate();
+				await Container.get(AuthRolesService).init();
+			}
+
+			return;
+		} catch (error) {
+			lastError = error;
+			console.warn(
+				`testDb.init() attempt ${attempt}/${PG_INIT_MAX_ATTEMPTS} failed:`,
+				error instanceof Error ? error.message : error,
+			);
+			// Drop DI singletons (incl. a half-initialized DbConnection/DataSource)
+			// so the next attempt rebuilds the whole chain from scratch.
+			Container.reset();
+			testDbName = undefined;
+		}
+	}
+
+	throw new Error(
+		`testDb.init() failed after ${PG_INIT_MAX_ATTEMPTS} attempts: ${
+			lastError instanceof Error ? lastError.message : String(lastError)
+		}`,
+	);
 }
 
 /**


### PR DESCRIPTION
## Summary

The shared `setupTestServer` `beforeAll` calls `testDb.init()`, which has been timing out the 30s testcontainers hook intermittently on CI (most often surfaced by `mcp-api-key.service.public-api-disabled`, but the flake is infrastructural — any of the ~101 suites using `setupTestServer` can hit it).

On the Postgres path, `init()` creates a per-file test DB (cloning a template via `CREATE DATABASE ... TEMPLATE`) and opens its connection. Under parallel workers these steps can stall — a contended template clone, or a DataSource that never connects (the lifecycle flagged in `terminate()`'s own comment) combined with `DB_POSTGRESDB_POOL_SIZE=1`. The stall silently consumed the full hook budget and surfaced as an opaque `"Exceeded timeout of a hook"`.

This wraps each Postgres init step (`CREATE DATABASE`, connection open) with a 20s timeout and retries with a fresh DB name (up to 3 attempts), resetting DI singletons between attempts. A transient stall now recovers; a persistent one fails fast with an actionable error instead of eating the whole 30s hook. The happy path is unchanged (no extra `Container.reset()` unless an attempt fails), and the SQLite path is untouched.

## How to test

Postgres integration suite (CI testcontainers path) should pass as before; the change only adds bounded retries on top of the existing init flow.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/DEVP-430

Regression window: PR #31778. Sibling flaky `beforeAll` timeout: DEVP-376.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

