### PR TITLE
fix: Improve desktop assistant promote, setup, and permission flows (no-changelog)

### DIFF
--- a/packages/@n8n/computer-use/src/gateway-client.test.ts
+++ b/packages/@n8n/computer-use/src/gateway-client.test.ts
@@ -151,14 +151,14 @@ describe('GatewayClient.checkPermissions', () => {
 			expect(session.alwaysAllow).not.toHaveBeenCalled();
 		});
 
-		it('allowForSession — allows the specific resource for the session', async () => {
+		it('allowForSession — allows the whole tool group for the session', async () => {
 			const session = makeSession();
 			const confirmResourceAccess = vi.fn().mockResolvedValue('allowForSession');
 			const client = makeClient(session, confirmResourceAccess);
 
 			await client['dispatchToolCall']('test_tool', {});
 
-			expect(session.allowForSession).toHaveBeenCalledWith('shell', 'npm install');
+			expect(session.allowForSession).toHaveBeenCalledWith('shell');
 			expect(session.setPermissions).not.toHaveBeenCalled();
 		});
 
@@ -253,7 +253,7 @@ describe('GatewayClient.checkPermissions', () => {
 			// Simulate the agent sending back _confirmation=allowForSession
 			await client['dispatchToolCall']('test_tool', { _confirmation: 'allowForSession' });
 
-			expect(session.allowForSession).toHaveBeenCalledWith('shell', 'npm install');
+			expect(session.allowForSession).toHaveBeenCalledWith('shell');
 			expect(confirmResourceAccess).not.toHaveBeenCalled();
 		});
 	});

--- a/packages/@n8n/computer-use/src/gateway-client.ts
+++ b/packages/@n8n/computer-use/src/gateway-client.ts
@@ -559,7 +559,7 @@ export class GatewayClient {
 				case 'allowOnce':
 					break;
 				case 'allowForSession':
-					session.allowForSession(resource.toolGroup, resource.resource);
+					session.allowForSession(resource.toolGroup);
 					break;
 				case 'alwaysAllow':
 					session.alwaysAllow(resource.toolGroup, resource.resource);

--- a/packages/@n8n/computer-use/src/gateway-session.test.ts
+++ b/packages/@n8n/computer-use/src/gateway-session.test.ts
@@ -198,13 +198,13 @@ describe('GatewaySession', () => {
 			expect(session.check('shell', 'npm')).toBe('deny');
 		});
 
-		it('returns allow for a session-allowed resource', () => {
+		it('returns allow for a session-allowed group', () => {
 			const store = makeStore();
 			const session = new GatewaySession(
 				{ permissions: buildDefaultPermissions({ shell: 'ask' }), dir: '/' },
 				store as unknown as SettingsStore,
 			);
-			session.allowForSession('shell', 'npm');
+			session.allowForSession('shell');
 			expect(session.check('shell', 'npm')).toBe('allow');
 		});
 
@@ -288,7 +288,7 @@ describe('GatewaySession', () => {
 				{ permissions: buildDefaultPermissions({ shell: 'ask' }), dir: '/' },
 				store as unknown as SettingsStore,
 			);
-			session.allowForSession('shell', 'npm');
+			session.allowForSession('shell');
 			expect(session.check('shell', 'npm')).toBe('allow');
 			session.clearSession();
 			expect(session.check('shell', 'npm')).toBe('ask');
@@ -300,8 +300,29 @@ describe('GatewaySession', () => {
 				{ permissions: buildDefaultPermissions({ shell: 'ask', browser: 'ask' }), dir: '/' },
 				store as unknown as SettingsStore,
 			);
-			session.allowForSession('shell', 'npm');
+			session.allowForSession('shell');
 			expect(session.check('browser', 'npm')).toBe('ask');
+		});
+
+		it('session allow covers other resources in the same group (coarse, per run)', () => {
+			const store = makeStore();
+			const session = new GatewaySession(
+				{
+					permissions: buildDefaultPermissions({
+						filesystemRead: 'allow',
+						filesystemWrite: 'ask',
+					}),
+					dir: '/',
+				},
+				store as unknown as SettingsStore,
+			);
+			// One approval for a single write should cover the whole run's writes,
+			// even to distinct destination paths.
+			session.allowForSession('filesystemWrite');
+			expect(session.check('filesystemWrite', '/home/user/Desktop/a.png')).toBe('allow');
+			expect(session.check('filesystemWrite', '/home/user/Desktop/Screenshots/b.png')).toBe(
+				'allow',
+			);
 		});
 	});
 

--- a/packages/@n8n/computer-use/src/gateway-session.ts
+++ b/packages/@n8n/computer-use/src/gateway-session.ts
@@ -13,7 +13,7 @@ import type { SettingsStore } from './settings-store';
 export class GatewaySession {
 	private _dir: string;
 	private _permissions: Record<ToolGroup, PermissionMode>;
-	private readonly sessionAllows: Map<ToolGroup, Set<string>> = new Map();
+	private readonly sessionAllowedGroups: Set<ToolGroup> = new Set();
 	private readonly _secretsBuffer: Map<string, Map<string, string>> = new Map();
 
 	constructor(
@@ -67,10 +67,10 @@ export class GatewaySession {
 	/**
 	 * Check the effective permission for a resource.
 	 * Evaluation order:
-	 *  1. Persistent deny list  → 'deny'  (takes absolute priority even in Allow mode)
-	 *  2. Persistent allow list → 'allow'
-	 *  3. Session allow set     → 'allow'
-	 *  4. Group mode            → via getGroupMode() (includes cross-group constraints)
+	 *  1. Persistent deny list   → 'deny'  (takes absolute priority even in Allow mode)
+	 *  2. Persistent allow list  → 'allow'
+	 *  3. Session-allowed group  → 'allow'
+	 *  4. Group mode             → via getGroupMode() (includes cross-group constraints)
 	 */
 	check(toolGroup: ToolGroup, resource: string): PermissionMode {
 		// Self-protection: prevent tools from accessing the gateway settings directory
@@ -84,7 +84,7 @@ export class GatewaySession {
 		const rp = this.settingsStore.getResourcePermissions(toolGroup);
 		if (rp.deny.includes(resource)) return 'deny';
 		if (rp.allow.includes(resource)) return 'allow';
-		if (this.hasSessionAllow(toolGroup, resource)) return 'allow';
+		if (this.hasSessionAllow(toolGroup)) return 'allow';
 		return this.getGroupMode(toolGroup);
 	}
 
@@ -92,17 +92,20 @@ export class GatewaySession {
 	// Session-scoped allow rules
 	// ---------------------------------------------------------------------------
 
-	allowForSession(toolGroup: ToolGroup, resource: string): void {
-		let set = this.sessionAllows.get(toolGroup);
-		if (!set) {
-			set = new Set();
-			this.sessionAllows.set(toolGroup, set);
-		}
-		set.add(resource);
+	/**
+	 * Grant a whole tool group for the rest of the session. Deliberately coarser
+	 * than the persistent per-resource allow list: "allow for session" is the
+	 * user consenting to this kind of access for the run (e.g. organizing many
+	 * files writes to many distinct paths), so we don't re-prompt per resource.
+	 * The persistent deny list and settings self-protection still take priority
+	 * in check(). Cleared by clearSession().
+	 */
+	allowForSession(toolGroup: ToolGroup): void {
+		this.sessionAllowedGroups.add(toolGroup);
 	}
 
 	clearSession(): void {
-		this.sessionAllows.clear();
+		this.sessionAllowedGroups.clear();
 		this._secretsBuffer.clear();
 	}
 
@@ -152,8 +155,8 @@ export class GatewaySession {
 	// Private helpers
 	// ---------------------------------------------------------------------------
 
-	private hasSessionAllow(toolGroup: ToolGroup, resource: string): boolean {
-		return this.sessionAllows.get(toolGroup)?.has(resource) ?? false;
+	private hasSessionAllow(toolGroup: ToolGroup): boolean {
+		return this.sessionAllowedGroups.has(toolGroup);
 	}
 }
 

--- a/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.desktop-assistant.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.desktop-assistant.test.ts
@@ -72,4 +72,17 @@ describe('getDesktopAssistantProfile — extra tools', () => {
 		expect(getDesktopAssistantProfile('desktop-assistant-promote').preloadGatewayTools).toBe(false);
 		expect(getDesktopAssistantProfile(undefined).preloadGatewayTools).toBe(false);
 	});
+
+	it('suppresses interactive setup for every desktop mode but not regular chat', () => {
+		expect(getDesktopAssistantProfile('desktop-assistant-one-shot').suppressInteractiveSetup).toBe(
+			true,
+		);
+		expect(getDesktopAssistantProfile('desktop-assistant-promote').suppressInteractiveSetup).toBe(
+			true,
+		);
+		expect(getDesktopAssistantProfile('desktop-assistant-edit').suppressInteractiveSetup).toBe(
+			true,
+		);
+		expect(getDesktopAssistantProfile(undefined).suppressInteractiveSetup).toBe(false);
+	});
 });

--- a/packages/@n8n/instance-ai/src/agent/desktop-assistant-profile.ts
+++ b/packages/@n8n/instance-ai/src/agent/desktop-assistant-profile.ts
@@ -76,13 +76,18 @@ ${FIRE_AND_FORGET_RULES} One exception in this mode: step 2 of the procedure req
 
 This thread contains a task you already executed via device (computer-use) tool calls. Build exactly one workflow (via the workflow-builder skill) that fulfils the user's request every time it runs — **the request, not the artifacts of this particular run**. Follow these steps in order:
 
-1. **Classify before building.** Look at every value in the recorded tool arguments and ask where it came from. Values the user specified (or that follow mechanically from the request) are safe to replay literally. Content **you authored** because the request only named a *kind* of content is not — a future run must generate it fresh. If **any** value must be generated fresh, the whole task classifies as \`generate-fresh\`.
-2. **Output your verdict** as a single line of text immediately before building — \`replay: exact\` or \`replay: generate-fresh\`, plus a one-clause reason.
+1. **Classify before building.** For every value in the recorded tool arguments, ask where it came from:
+   - **From the request** — the user specified it, or it follows mechanically from the request (e.g. a folder name or a path they named). Safe to replay literally.
+   - **Discovered at run time** — read out of the current system state during the run: a directory listing, search result, file read, or what was on screen, where an earlier call produced the value and later calls consumed it. These differ on every run; the recorded values are a snapshot, not a script. Tell-tale signal: a read/list/search call (\`get_file_tree\`, \`list_files\`, \`search_files\`, \`read_file\`, a screenshot) whose output drives the arguments of the calls after it.
+   - **Authored by you** — the request named only a *kind* of content, so you wrote the content itself; a future run must generate it fresh.
+
+   If **every** value is from the request, the task is \`exact\`. If **any** value was discovered at run time **or** authored by you, the task is \`dynamic\` — a fixed list of the recorded calls cannot reproduce the request, so the workflow has to decide at run time.
+2. **Output your verdict** as a single line of text immediately before building — \`replay: exact\` or \`replay: dynamic\`, plus a one-clause reason.
 3. **Build the matching shape:**
    - \`replay: exact\` → Manual Trigger → one \`@n8n/n8n-nodes-langchain.computerUse\` node per recorded call, in order — \`tool\` resourceLocator (mode \`id\`) set to the tool name that was called, \`inputMode: json\`, \`jsonInput\` set to the literal arguments used.
-   - \`replay: generate-fresh\` → Manual Trigger → AI Agent node (prompted with the user's task) with \`@n8n/n8n-nodes-langchain.toolComputerUse\` attached as its tool, plus a chat model sub-node. Bind the chat model's credential per the credential rule below.
+   - \`replay: dynamic\` → Manual Trigger → AI Agent node (prompted with the user's task, and told to inspect the current state — list/search/read as needed — and act on whatever it finds) with \`@n8n/n8n-nodes-langchain.toolComputerUse\` attached as its tool, plus a chat model sub-node. Bind the chat model's credential per the credential rule below.
 
-Examples of the classification: "create a folder called Receipts on my desktop" — fully specified by the request; \`replay: exact\`. "Add an inspiring quote to my notes" — the request names a *kind* of content, not the content itself; \`replay: generate-fresh\`. "Write me a short bio and save it" — authored once as a fixed artifact the user keeps; \`replay: exact\` is fine.
+Examples of the classification: "create a folder called Receipts on my desktop" — fully specified by the request; \`replay: exact\`. "Organize the files on my desktop into subfolders by type" — the run listed the desktop and moved whichever files were there, but a future run faces different files; \`replay: dynamic\`. "Add an inspiring quote to my notes" — the request names a *kind* of content, not the content itself; \`replay: dynamic\`. "Write me a short bio and save it" — authored once as a fixed artifact the user keeps; \`replay: exact\` is fine.
 
 Additional rules:
 

--- a/packages/@n8n/instance-ai/src/agent/desktop-assistant-profile.ts
+++ b/packages/@n8n/instance-ai/src/agent/desktop-assistant-profile.ts
@@ -44,6 +44,14 @@ export interface DesktopAssistantProfile {
 	 * blind first (a burst of tool errors at run start).
 	 */
 	preloadGatewayTools: boolean;
+	/**
+	 * Auto-defer credential/parameter setup instead of suspending on it. Desktop
+	 * runs are fire-and-forget with no surface to answer a "configure
+	 * credentials" prompt — suspending there hangs the run. With this set, the
+	 * `workflows`/`credentials` setup actions skip the suspend and the workflow
+	 * is saved credential-less, surfacing in the desktop app's "Action needed".
+	 */
+	suppressInteractiveSetup: boolean;
 }
 
 /** Shared preamble: both desktop modes run headless, so text output is waste. */
@@ -91,7 +99,7 @@ Examples of the classification: "create a folder called Receipts on my desktop" 
 
 Additional rules:
 
-- **There is no credential-setup step after this build** — the workflow must be runnable exactly as saved. List the user's credentials (\`credentials(action="list")\`) and bind a concrete existing credential on every node that needs one, using \`newCredential('Name', 'id')\` with the real id — never the id-less form, which defers to a setup phase this surface does not have. When several credentials match, pick the most plausible one rather than leaving the node unbound. Only leave a credential unset when the user has none of a matching type (Computer Use nodes' \`deviceConnectionApi\` is filled in automatically in that case).
+- **There is no credential-setup step after this build** — the workflow must be runnable exactly as saved. List the user's credentials (\`credentials(action="list")\`) and bind a concrete existing credential on every node that needs one, using \`newCredential('Name', 'id')\` with the real id — never the id-less form, which defers to a setup phase this surface does not have. When several credentials match, pick the most plausible one rather than leaving the node unbound. Only leave a credential unset when the user has none of a matching type (Computer Use nodes' \`deviceConnectionApi\` is filled in automatically in that case). When you do leave a credential unset, do NOT call the setup action — save the workflow as-is; it will surface in the desktop app for the user to connect the credential later.
 - The user's request in this thread may end with appended context lines (\`Currently looking at:\`, \`URL:\`, \`Path:\`, \`Selected text:\`). They capture what was on screen when the task ran — context, not requirements. Use them to disambiguate the request; do not bake them into the workflow unless the request itself depends on them.
 - Set the workflow \`name\` to a short plain-text label naming the task, not the run: 3–8 words, present tense (\`"Archive old downloads"\`), never a past-tense report (\`"Archived 12 files"\`). If the user's prompt provided a name, use it (correcting tense if needed).
 - If the original intent is ambiguous or requires context you do not have, stop without producing a workflow — no low-quality stubs.
@@ -123,12 +131,28 @@ export function getDesktopAssistantProfile(
 				promptSection: ONE_SHOT_PROMPT_SECTION,
 				extraTools: [createReportDesktopTaskOutcomeTool()],
 				preloadGatewayTools: true,
+				suppressInteractiveSetup: true,
 			};
 		case 'desktop-assistant-promote':
-			return { promptSection: PROMOTE_PROMPT_SECTION, extraTools: [], preloadGatewayTools: false };
+			return {
+				promptSection: PROMOTE_PROMPT_SECTION,
+				extraTools: [],
+				preloadGatewayTools: false,
+				suppressInteractiveSetup: true,
+			};
 		case 'desktop-assistant-edit':
-			return { promptSection: EDIT_PROMPT_SECTION, extraTools: [], preloadGatewayTools: false };
+			return {
+				promptSection: EDIT_PROMPT_SECTION,
+				extraTools: [],
+				preloadGatewayTools: false,
+				suppressInteractiveSetup: true,
+			};
 		case undefined:
-			return { promptSection: '', extraTools: [], preloadGatewayTools: false };
+			return {
+				promptSection: '',
+				extraTools: [],
+				preloadGatewayTools: false,
+				suppressInteractiveSetup: false,
+			};
 	}
 }

--- a/packages/@n8n/instance-ai/src/agent/instance-agent.ts
+++ b/packages/@n8n/instance-ai/src/agent/instance-agent.ts
@@ -55,9 +55,22 @@ export async function createInstanceAgent(options: CreateInstanceAgentOptions): 
 		memoryConfig,
 	} = options;
 
+	// The desktop-assistant profile is the single owner of which extra tools a run
+	// gets (e.g. the outcome report), which tool groups are pinned out of deferred
+	// search, and whether interactive setup auto-defers.
+	const desktopProfile = getDesktopAssistantProfile(options.promptMode);
+
+	// Desktop runs have no surface to answer a "configure credentials" suspend, so
+	// thread the flag onto the context the domain tools capture — setup auto-defers
+	// rather than hanging the run.
+	const toolContext = {
+		...context,
+		suppressInteractiveSetup: desktopProfile.suppressInteractiveSetup,
+	};
+
 	// Build native n8n domain tools (context captured via closures — per-run)
-	const domainTools = createAllTools(context);
-	const orchestratorDomainTools = createOrchestratorDomainTools(context);
+	const domainTools = createAllTools(toolContext);
+	const orchestratorDomainTools = createOrchestratorDomainTools(toolContext);
 
 	// Load MCP tools (cached by config hash inside the manager — only spawns
 	// processes / opens connections on first call or config change).
@@ -83,9 +96,6 @@ export async function createInstanceAgent(options: CreateInstanceAgentOptions): 
 		? createOrchestrationTools(orchestrationContext)
 		: createToolRegistry();
 
-	// The desktop-assistant profile is the single owner of which extra tools a run
-	// gets (e.g. the outcome report) and which tool groups are pinned out of deferred search.
-	const desktopProfile = getDesktopAssistantProfile(options.promptMode);
 	const desktopProfileTools = createToolRegistryFromTools(desktopProfile.extraTools);
 
 	// Keep MCP tools from shadowing domain or orchestration tools during object composition.

--- a/packages/@n8n/instance-ai/src/tools/__tests__/credentials.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/credentials.tool.test.ts
@@ -557,6 +557,27 @@ describe('credentials tool', () => {
 	// ── setup ───────────────────────────────────────────────────────────────
 
 	describe('setup action', () => {
+		it('defers without suspending when the run has no interactive setup surface', async () => {
+			const context = createMockContext({ suppressInteractiveSetup: true });
+			const suspendFn = vi.fn();
+			const tool = createCredentialsTool(context);
+
+			const result = await executeTool(
+				tool,
+				{
+					action: 'setup' as const,
+					credentials: [{ credentialType: 'slackApi', reason: 'For sending messages' }],
+				},
+				suspendCtx(suspendFn),
+			);
+
+			expect(result).toEqual(
+				expect.objectContaining({ success: true, deferred: true, reason: expect.any(String) }),
+			);
+			expect(suspendFn).not.toHaveBeenCalled();
+			expect(context.credentialService.list).not.toHaveBeenCalled();
+		});
+
 		it('should suspend with credentialRequests on first call', async () => {
 			const existingCreds: CredentialSummary[] = [
 				{ id: 'c1', name: 'Existing Slack', type: 'slackApi' },

--- a/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/__tests__/workflows.tool.test.ts
@@ -191,6 +191,45 @@ describe('workflows tool', () => {
 		});
 	});
 
+	describe('setup action — suppressInteractiveSetup', () => {
+		it('defers without suspending when the run has no interactive setup surface', async () => {
+			const context = createMockContext({ suppressInteractiveSetup: true });
+			const suspend = vi.fn();
+			const tool = createWorkflowsTool(context, 'full');
+
+			const result = await executeTool(
+				tool,
+				{ action: 'setup', workflowId: 'w1' } as never,
+				{ suspend, resumeData: undefined } as never,
+			);
+
+			expect(result).toEqual(
+				expect.objectContaining({ success: true, deferred: true, reason: expect.any(String) }),
+			);
+			expect(suspend).not.toHaveBeenCalled();
+			expect(analyzeWorkflow).not.toHaveBeenCalled();
+		});
+
+		it('still suspends for setup when the flag is absent', async () => {
+			const context = createMockContext();
+			vi.mocked(analyzeWorkflow).mockResolvedValueOnce([
+				{ node: { name: 'n1' }, credentialType: 'openAiApi' },
+			] as never);
+			const suspend = vi.fn();
+			const tool = createWorkflowsTool(context, 'full');
+
+			await executeTool(
+				tool,
+				{ action: 'setup', workflowId: 'w1' } as never,
+				{ suspend, resumeData: undefined } as never,
+			);
+
+			expect(suspend).toHaveBeenCalledWith(
+				expect.objectContaining({ message: 'Configure credentials for your workflow' }),
+			);
+		});
+	});
+
 	describe('version actions', () => {
 		it('should support version actions when listVersions exists', async () => {
 			const context = createMockContext();

--- a/packages/@n8n/instance-ai/src/tools/credentials.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/credentials.tool.ts
@@ -347,6 +347,19 @@ async function handleSetup(
 		};
 	}
 
+	// Headless runs (desktop assistant) have no surface to answer a setup prompt.
+	// Defer instead of suspending; the user connects credentials later from the
+	// desktop app's "Action needed".
+	if (context.suppressInteractiveSetup) {
+		return {
+			success: true,
+			deferred: true,
+			reason:
+				'Setup deferred: this run has no interactive setup surface. Continue without ' +
+				'credentials and let the user connect them from "Action needed".',
+		};
+	}
+
 	// State 1: First call — look up existing credentials per type and suspend
 	if (resumeData === undefined || resumeData === null) {
 		const credentialRequests = await Promise.all(

--- a/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows.tool.ts
@@ -491,6 +491,19 @@ async function handleSetup(
 
 	const resumeData = ctx.resumeData;
 
+	// Headless runs (desktop assistant) have no surface to answer a setup prompt.
+	// Defer instead of suspending: the workflow is already saved, so it surfaces
+	// credential-less in the desktop app's "Action needed" for the user to connect.
+	if (context.suppressInteractiveSetup) {
+		return {
+			success: true,
+			deferred: true,
+			reason:
+				'Setup deferred: this run has no interactive setup surface. The workflow is saved; ' +
+				'the user connects any remaining credentials from "Action needed".',
+		};
+	}
+
 	// State 1: Analyze workflow and suspend for user setup
 	if (resumeData === undefined || resumeData === null) {
 		const setupRequests = await analyzeWorkflow(context, input.workflowId);

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -738,6 +738,10 @@ export interface InstanceAiContext {
 	localGatewayStatus?: LocalGatewayStatus;
 	/** Per-action HITL permission overrides. When absent, tools default to requiring approval. */
 	permissions?: InstanceAiPermissions;
+	/** When set, credential/parameter setup actions auto-defer instead of suspending.
+	 *  Desktop-assistant runs are fire-and-forget with no surface to answer a setup
+	 *  prompt; suspending there would hang the run. See `DesktopAssistantProfile`. */
+	suppressInteractiveSetup?: boolean;
 	/** When set, `runWorkflow: 'always_allow'` only short-circuits HITL approval for these workflow IDs.
 	 *  Used by checkpoint follow-up runs to scope the override to the workflows the checkpoint is
 	 *  verifying — `executions(action="run")` on any other workflow still requires user approval. */

--- a/packages/@n8n/local-gateway/src/main/settings-store.test.ts
+++ b/packages/@n8n/local-gateway/src/main/settings-store.test.ts
@@ -86,6 +86,14 @@ describe('SettingsStore (Electron)', () => {
 		expect(config.permissions.browser).toBe('deny');
 	});
 
+	it('grants read but asks per write when the filesystem toggle is on', () => {
+		const store = new SettingsStore();
+		store.set({ filesystemEnabled: true });
+		const config = store.toGatewayConfig();
+		expect(config.permissions.filesystemRead).toBe('allow');
+		expect(config.permissions.filesystemWrite).toBe('ask');
+	});
+
 	it('defaults permissionConfirmation to instance and forwards a persisted client mode', () => {
 		const store = new SettingsStore();
 		expect(store.toGatewayConfig().permissionConfirmation).toBe('instance');

--- a/packages/@n8n/local-gateway/src/main/settings-store.ts
+++ b/packages/@n8n/local-gateway/src/main/settings-store.ts
@@ -70,12 +70,14 @@ export class SettingsStore {
 			browser: {
 				defaultBrowser: 'chrome',
 			},
-			// Toggle-on means allow: the app's settings toggles are the user's
-			// explicit consent, and 'ask' would suspend fire-and-forget one-shot
-			// runs on a confirmation the desktop surface cannot answer.
+			// Toggle-on grants read access outright (non-destructive), but writes
+			// still ask per resource: the toggle is consent to reach the
+			// filesystem, not blanket consent to mutate it. The suspend surfaces
+			// as a permission prompt on the task thread (watched app-wide), so
+			// even fire-and-forget one-shot runs can answer it.
 			permissions: {
 				filesystemRead: s.filesystemEnabled ? 'allow' : 'deny',
-				filesystemWrite: s.filesystemEnabled ? 'allow' : 'deny',
+				filesystemWrite: s.filesystemEnabled ? 'ask' : 'deny',
 				shell: s.shellEnabled ? 'allow' : 'deny',
 				computer: s.screenshotEnabled || s.mouseKeyboardEnabled ? 'allow' : 'deny',
 				browser: s.browserEnabled ? 'allow' : 'deny',

--- a/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.helpers.ts
+++ b/packages/cli/src/modules/instance-ai/desktop-assistant/desktop-assistant.helpers.ts
@@ -87,7 +87,7 @@ function isTextPart(part: unknown): part is { type: 'text'; text: string } {
 export function composePromoteMessage(originalPrompt: string, name: string | undefined): string {
 	const trimmedName = name?.trim();
 	const naming = trimmedName ? ` Name it "${trimmedName}".` : '';
-	return `Turn the task from this thread into a repeatable workflow. Decide first, from the original request below: must a future run reproduce the recorded results exactly, or generate content fresh? The recorded tool calls show what was done, not necessarily what should be replayed literally.${naming} The original request:\n\n${originalPrompt}`;
+	return `Turn the task from this thread into a repeatable workflow. Decide first, from the original request below: can a fixed list of the recorded steps reproduce the request on every future run, or must the workflow inspect the current state (what files/items are there now) or generate content fresh each time? The recorded tool calls are a snapshot of one run, not necessarily a script to replay literally.${naming} The original request:\n\n${originalPrompt}`;
 }
 
 // ── Recommendations ──────────────────────────────────────────────────────────

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -67,7 +67,7 @@
 	"desktopAssistant.tasks.error": "Couldn't load tasks",
 	"desktopAssistant.tasks.retry": "Try again",
 	"desktopAssistant.tasks.settingUp": "Setting up the workflow…",
-	"desktopAssistant.tasks.setupFailed": "Couldn't finish setting this up",
+	"desktopAssistant.tasks.setupFailed": "Couldn't finish setting up the workflow",
 	"desktopAssistant.tasks.dismiss": "Dismiss",
 	"desktopAssistant.sections.recommended": "Recommended tasks",
 	"desktopAssistant.recommendations.suggested": "Suggested",

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -66,7 +66,7 @@
 	"desktopAssistant.tasks.empty": "No tasks yet",
 	"desktopAssistant.tasks.error": "Couldn't load tasks",
 	"desktopAssistant.tasks.retry": "Try again",
-	"desktopAssistant.tasks.settingUp": "Setting it up…",
+	"desktopAssistant.tasks.settingUp": "Setting up the workflow…",
 	"desktopAssistant.tasks.setupFailed": "Couldn't finish setting this up",
 	"desktopAssistant.tasks.dismiss": "Dismiss",
 	"desktopAssistant.sections.recommended": "Recommended tasks",


### PR DESCRIPTION
## Summary

A batch of fixes to the desktop assistant's **promote-to-workflow** and **device permission** flows, found while testing one-shot tasks and promotion end-to-end.

**Promote output quality**
- **Classify data-dependent tasks as dynamic.** Promote previously classified every task into a binary (request-specified → literal `computerUse` replay, vs authored content → AI Agent). A task whose arguments were *discovered at run time* (e.g. a directory listing feeding per-file `move`s) fit neither bucket and defaulted to a literal, non-rerunnable chain (one hardcoded `move` per file present during recording). Added a third value-origin ("discovered at run time") that routes such tasks to the dynamic AI-Agent shape, so the workflow re-discovers state on every run.
- **Copy:** clearer promote progress subtitle ("Setting up the workflow…") and setup-failed text.

**Device permission model**
- **Prompt for confirmation on filesystem writes.** The desktop app collapsed filesystem access into one toggle mapped to `allow` for both reads and writes, so `move`/`delete`/`write` ran without confirmation. Writes now map to `ask` (reads stay `allow`); the suspend surfaces as a permission prompt on the task thread (watched app-wide), so one-shot runs can answer it.
- **Scope "Allow for session" to the whole tool group.** Session-allow was keyed by exact resource path, so organizing many files re-prompted per file. One approval now covers the run; the persistent deny list and settings self-protection still take priority.

**Promote hang fix**
- **Auto-defer credential setup in desktop-assistant runs.** Promoting a workflow that needs a credential the user lacks hung forever on "Setting it up…": the builder mocked the credential, the workflow loop routed to the `workflows`/`credentials` setup action, and that suspended on a "Configure credentials" prompt the fire-and-forget desktop surface never renders, so `finalizePromotedWorkflow` never ran. A `suppressInteractiveSetup` profile flag (true for all desktop modes) now short-circuits both setup actions to the existing "deferred" outcome. The workflow is already saved, so the run finishes, finalize runs, and the credential-less workflow surfaces in the desktop app under **Action needed** with a Connect CTA. Editor/chat runs are unaffected.

## How to test

1. From the desktop assistant, run a one-shot task that inspects state then acts, e.g. *"Organize the files on my Desktop into subfolders by type"*. Confirm the **filesystem write** prompt appears (it no longer runs writes silently), and that **Allow for session** lets the rest of the run proceed without re-prompting per file.
2. Promote the task. Confirm the generated workflow is the **dynamic** shape (Manual Trigger → AI Agent + `toolComputerUse` + chat model), not a chain of literal `move` nodes.
3. Promote a task whose workflow needs a credential you do **not** have (e.g. an OpenAI chat model with no `openAiApi` credential). Confirm the promote run **finishes** (no "Setting it up…" hang) and the workflow appears under **Action needed** with a **Connect** CTA opening the Set up tab — instead of suspending invisibly.
4. Regression: promoting a fully-specified task (*"create a folder called Receipts"*) still produces an exact literal-replay workflow; a regular editor/chat build still shows the interactive setup card.

Unit tests: `cd packages/@n8n/instance-ai && pnpm test system-prompt.desktop-assistant workflows.tool credentials.tool` and `cd packages/@n8n/computer-use && pnpm test gateway-session gateway-client` and `cd packages/@n8n/local-gateway && pnpm test settings-store`.

## Related Linear tickets, Github issues, and Community forum posts

_None._

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI