### PR TITLE
test(core): Stabilize flaky task broker rate-limit test (no-changelog)

### DIFF
--- a/packages/cli/test/integration/task-runners/task-broker-server.test.ts
+++ b/packages/cli/test/integration/task-runners/task-broker-server.test.ts
@@ -50,15 +50,15 @@ describe('TaskBrokerServer', () => {
 			});
 
 		it('should return 429 when too many upgrade requests are made', async () => {
-			// First 5 should be allowed (will fail auth with 401, but not rate-limited)
-			for (let i = 0; i < 5; i++) {
-				const status = await sendUpgradeRequest();
-				expect(status).toBe(401);
-			}
+			// The rate limiter allows 5 requests per 1s window. Fire all requests
+			// concurrently so they land within the same window — sending them
+			// sequentially can exceed 1s on a slow runner, resetting the counter.
+			// Each request uses its own connection (not the shared keep-alive
+			// agent) so a rate-limited response can't reset a sibling request.
+			const responseStatusCodes = await Promise.all(Array.from({ length: 6 }, sendUpgradeRequest));
 
-			// 6th should be rate-limited
-			const status = await sendUpgradeRequest();
-			expect(status).toBe(429);
+			expect(responseStatusCodes.filter((code) => code === 401)).toHaveLength(5);
+			expect(responseStatusCodes.filter((code) => code === 429)).toHaveLength(1);
 		});
 	});
 


### PR DESCRIPTION
## Summary

Stabilizes the flaky `/runners/_ws` rate-limit integration test in `task-broker-server.test.ts`, following the same approach already applied to the `/runners/auth` test.

The rate limiter allows 5 requests per 1-second window. The test previously sent 6 upgrade requests sequentially and expected the 6th to be rate-limited, but on a slow CI runner the sequential requests could take longer than 1 second, resetting the rate-limit window and causing the 6th request to return 401 instead of 429.

The test now fires all 6 requests concurrently with `Promise.all` so they land within the same window, and asserts on the distribution of status codes (five 401s and one 429) instead of relying on request order. Each request uses its own connection rather than the shared keep-alive agent, so a rate-limited response can't tear down a sibling request's connection.

## How to test

```bash
cd packages/cli
pnpm test test/integration/task-runners/task-broker-server.test.ts
```

All 3 tests pass.

## Related Linear tickets, Github issues, and Community forum posts

-

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

