### PR TITLE
feat: Reduces delay in displaying AI Assistant workflow preview examples

### DIFF
--- a/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/components/WorkflowPreviewSuggestions.vue
+++ b/packages/frontend/editor-ui/src/experiments/instanceAiWorkflowPreviewSuggestions/components/WorkflowPreviewSuggestions.vue
@@ -5,7 +5,7 @@ import { onUnmounted, ref } from 'vue';
 import { useTelemetry } from '@/app/composables/useTelemetry';
 import { type WorkflowPreviewSuggestion } from '../suggestions';
 
-const PREVIEW_HOVER_DELAY_MS = 300;
+const PREVIEW_HOVER_DELAY_MS = 30;
 
 const props = defineProps<{
 	suggestions: readonly WorkflowPreviewSuggestion[];

--- a/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiEmptyView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/instanceAi/InstanceAiEmptyView.vue
@@ -312,8 +312,8 @@ async function handleSubmit(message: string, attachments?: InstanceAiAttachment[
 
 :global(.workflow-preview-fade-enter-active) {
 	transition:
-		opacity 0.25s ease,
-		transform 0.25s ease;
+		opacity 0.08s ease-out,
+		transform 0.08s ease-out;
 }
 
 :global(.workflow-preview-fade-leave-active) {


### PR DESCRIPTION
## Summary

Reduces the delay in displaying workflow preview examples on button hover ([AIA Onboarding v3](https://app.notion.com/p/n8n/AIA-v3-Suggestions-workflow-preview-and-outcome-3615b6e0c94f801d9784e6f409502c94#3615b6e0c94f80ec8ae6d430479ada34) experiment)

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

