### PR TITLE
ci: Fold DB schema docs check into the DB Tests job (no-changelog)

### DIFF
--- a/.claude/plugins/n8n/skills/db-migrations/SKILL.md
+++ b/.claude/plugins/n8n/skills/db-migrations/SKILL.md
@@ -123,7 +123,7 @@ Run through this before requesting review. Each item is a real, recurring review
 - [ ] **One logical change per migration**; split unrelated table changes into separate files. — [Don't combine independent schema changes](#dont-combine-independent-schema-changes)
 - [ ] **`up()` / `down()` reads as a list of intentions.** If either body grows past a screen or mixes schema operations with a multi-statement raw-SQL data move, extract the data move into a `private async` method on the same class (e.g. `private async backfillFromX(ctx)`). The top-level should orchestrate, not implement.
 - [ ] **Precedent is the bar to fix, not perpetuate.** When the checklist conflicts with what an older migration does (e.g. redundant `.primary.notNull`, hand-quoted identifiers, missing `.comment()`), the checklist wins for new code — don't copy the violation forward. Note the old occurrences in the PR if you spotted them.
-- [ ] **Regenerated the schema docs** with `pnpm db:schema:docs` and committed the `docs/generated/` changes. The `schema-docs-check` CI job fails on stale docs. — [Schema documentation](#schema-documentation)
+- [ ] **Regenerated the schema docs** with `pnpm db:schema:docs` and committed the `docs/generated/` changes. The DB Tests CI job fails on stale docs. — [Schema documentation](#schema-documentation)
 
 Treat the checklist as a floor, not a ceiling.
 If any item fails, fix it before opening review.
@@ -791,7 +791,7 @@ Regenerate and commit them alongside your migration:
 
 ```sh
 pnpm db:schema:docs    # rewrites docs/generated/ — requires Docker (and `brew install tbls` locally)
-pnpm db:schema:check   # verify only; what the schema-docs-check CI job runs
+pnpm db:schema:check   # verify only; what the DB Tests CI job runs
 ```
 
-The `schema-docs-check` CI job fails the PR when the committed docs don't match the migrations. Don't hand-edit anything under `docs/generated/` — it's overwritten on every regeneration.
+The DB Tests CI job fails the PR when the committed docs don't match the migrations (each matrix leg verifies its own database). Don't hand-edit anything under `docs/generated/` — it's overwritten on every regeneration.

--- a/.github/workflows/ci-pull-requests.yml
+++ b/.github/workflows/ci-pull-requests.yml
@@ -307,26 +307,6 @@ jobs:
     with:
       ref: ${{ needs.install-and-build.outputs.commit_sha }}
 
-  schema-docs-check:
-    name: DB Schema Docs Check
-    if: needs.install-and-build.outputs.db == 'true'
-    runs-on: ${{ vars.RUNNER_PROVIDER == 'github' && 'ubuntu-latest' || 'blacksmith-4vcpu-ubuntu-2204' }}
-    needs: install-and-build
-    steps:
-      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b # v1
-        with:
-          ref: ${{ needs.install-and-build.outputs.commit_sha }}
-
-      - name: Setup Node.js
-        uses: ./.github/actions/setup-nodejs
-        with:
-          build-command: pnpm turbo run build --filter=@n8n/db
-
-      # Regenerates the schema docs (sqlite + postgres-in-a-container) and fails
-      # if they differ from what's committed. tbls runs as a Docker image in CI.
-      - name: Verify schema docs are up to date
-        run: pnpm --filter=@n8n/db schema:check
-
   performance:
     name: Performance
     needs: install-and-build
@@ -401,7 +381,6 @@ jobs:
         e2e,
         dev-server-smoke,
         db-tests,
-        schema-docs-check,
         performance,
         security-checks,
         workflow-scripts,

--- a/.github/workflows/test-db-reusable.yml
+++ b/.github/workflows/test-db-reusable.yml
@@ -24,6 +24,7 @@ jobs:
             runner: blacksmith-4vcpu-ubuntu-2204
             test-cmd: pnpm test:sqlite
             migration-cmd: pnpm test:sqlite:migrations
+            schema-check-cmd: pnpm --filter=@n8n/db schema:check:sqlite
             collectCoverage: 'false'
           - name: Postgres 16
             # 4vcpu is enough since persistent-worker + template-DB make PG16
@@ -33,6 +34,7 @@ jobs:
             runner: blacksmith-4vcpu-ubuntu-2204
             test-cmd: pnpm test:postgres:integration:tc
             migration-cmd: pnpm test:postgres:migrations:tc
+            schema-check-cmd: pnpm --filter=@n8n/db schema:check:postgres
             TEST_IMAGE_POSTGRES: 'postgres:16'
             collectCoverage: 'true'
     env:
@@ -57,6 +59,12 @@ jobs:
         if: matrix.migration-cmd != ''
         working-directory: packages/cli
         run: ${{ matrix.migration-cmd }}
+
+      # Regenerates the schema docs for this leg's database (sqlite temp file /
+      # postgres testcontainer) and fails if they differ from what's committed.
+      # tbls runs as a Docker image in CI.
+      - name: Verify schema docs are up to date
+        run: ${{ matrix.schema-check-cmd }}
 
       - name: Upload coverage to Codecov
         if: env.COVERAGE_ENABLED == 'true'


### PR DESCRIPTION
## Summary

Follow-up to #32069 ([review comment](https://github.com/n8n-io/n8n/pull/32069#discussion_r3395540443)). That PR added a standalone `schema-docs-check` CI job to verify the committed DB schema docs stay in sync with the migrations. The reviewer noted the check itself runs in <20s and suggested rolling it into the existing DB tests rather than spinning up a dedicated job (which re-checks out and re-builds `@n8n/db`).

This moves the schema docs check into the **DB Tests** reusable workflow (`test-db-reusable.yml`). Each matrix leg now verifies the database type it's already set up for:

- **SQLite Pooled** leg → `pnpm --filter=@n8n/db schema:check:sqlite`
- **Postgres 16** leg → `pnpm --filter=@n8n/db schema:check:postgres`

The standalone `schema-docs-check` job is removed from `ci-pull-requests.yml` and dropped from `required-checks`. This reuses the build/cache already present in the DB Tests job, splits the check across the two legs (so the added wall-clock per leg is ~10s), and keeps schema-drift detection as a required gate.

## How to test

1. Scaffold a throwaway schema-changing migration, e.g. `pnpm --filter=@n8n/db migration:new TmpAddCol --folder=common`, add a column, and push — the **DB Tests / SQLite Pooled** and **Postgres 16** legs fail at the "Verify schema docs are up to date" step with the unified diff and a "run `pnpm db:schema:docs`" message. Revert.
2. On a clean checkout, both legs pass the schema step (docs are idempotent against current migrations).
3. Confirm no `DB Schema Docs Check` job appears in the checks list.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3408

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

