### PR TITLE
feat: Surface one-shot task deliverables on the desktop assistant done card (no-changelog)

### DIFF
--- a/packages/@n8n/api-types/src/dto/desktop-assistant/desktop-assistant-task-outcome.dto.ts
+++ b/packages/@n8n/api-types/src/dto/desktop-assistant/desktop-assistant-task-outcome.dto.ts
@@ -13,6 +13,12 @@ export interface DesktopAssistantTaskOutcome {
 	title: string;
 	/** One-sentence description of what was done (or why nothing was). */
 	summary: string;
+	/**
+	 * The task's actual output, as markdown, when the deliverable is information
+	 * the user asked for — a summary, an answer, extracted data. Absent for
+	 * pure-action tasks whose result is a side effect on the system.
+	 */
+	details?: string;
 	/** Single emoji that captures the task; becomes the saved workflow's icon. */
 	icon?: string;
 	/** Present when `success` is false — a user-readable reason. */

--- a/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.desktop-assistant.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.desktop-assistant.test.ts
@@ -24,6 +24,11 @@ describe('getSystemPrompt — desktop-assistant promptMode variants', () => {
 		expect(prompt).toContain('report-desktop-task-outcome');
 	});
 
+	it('one-shot mode references the details field the done card renders', () => {
+		const prompt = getSystemPrompt({ promptMode: 'desktop-assistant-one-shot' });
+		expect(prompt).toContain('`details`');
+	});
+
 	it('promote mode references the node types and credential the build must emit', () => {
 		const prompt = getSystemPrompt({ promptMode: 'desktop-assistant-promote' });
 		expect(prompt).toMatch(/Desktop Assistant.+Promote/i);

--- a/packages/@n8n/instance-ai/src/agent/desktop-assistant-profile.ts
+++ b/packages/@n8n/instance-ai/src/agent/desktop-assistant-profile.ts
@@ -56,7 +56,7 @@ export interface DesktopAssistantProfile {
 
 /** Shared preamble: both desktop modes run headless, so text output is waste. */
 const FIRE_AND_FORGET_RULES =
-	"This run is fire-and-forget from the n8n desktop assistant. The user never sees any text you write — only tool calls and the run lifecycle reach the UI. Output tool calls only: no greetings, narration, progress commentary, or summaries, and no follow-up questions (the user cannot answer them). If you want to explain what you're about to do, just do it instead.";
+	"This run is fire-and-forget from the n8n desktop assistant. The user never sees any text you write — only tool calls and the run lifecycle reach the UI. Output tool calls only: no greetings, narration, or progress commentary, and no follow-up questions (the user cannot answer them). If you want to explain what you're about to do, just do it instead.";
 
 const ONE_SHOT_PROMPT_SECTION = `
 ## Desktop Assistant — One-Shot Task
@@ -72,6 +72,7 @@ ${FIRE_AND_FORGET_RULES}
 
 - Every run MUST end with exactly one \`report-desktop-task-outcome\` call, as the final tool call — including when declining; it is how you stop.
 - Success: \`success: true\`, a plain-text \`title\` naming the task as a repeatable action (3–8 words, present tense, no emoji — \`"Sort desktop screenshots"\`, never \`"Sorted 12 screenshots"\`), a one-sentence \`summary\`, and an \`icon\` (a single emoji capturing the task).
+- Deliverable: when the request asks for information — a summary, an answer to a question, extracted data — the outcome card is the only thing the user ever sees, so the full deliverable MUST go in \`details\` as markdown; a deliverable not in \`details\` is lost. Keep it under ~300 words unless the request calls for more. Omit \`details\` when the result is an action on the system (files moved, message sent) rather than information.
 - Decline/failure: \`success: false\` plus \`title\`, \`summary\`, and a user-readable \`failureReason\`.
 `;
 

--- a/packages/@n8n/instance-ai/src/tools/orchestration/report-desktop-task-outcome.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/orchestration/report-desktop-task-outcome.tool.ts
@@ -20,6 +20,12 @@ const inputSchema = sanitizeInputSchema(
 				'Short human label naming the task as a repeatable action, 3-8 words, suitable as a workflow name. Present tense ("Sort desktop screenshots"), never a past-tense report of the run ("Sorted 12 screenshots"). Plain text — no emoji',
 			),
 		summary: z.string().describe('One sentence describing what was done (or why nothing was done)'),
+		details: z
+			.string()
+			.optional()
+			.describe(
+				"The task's actual output, in markdown, when the deliverable is information the user asked for — a summary, an answer, extracted data. This field is the only channel that reaches the user, so include the full deliverable. Keep it under ~300 words unless the request calls for more. Omit for pure-action tasks whose result is a side effect on the system",
+			),
 		icon: z
 			.string()
 			.optional()

--- a/packages/@n8n/local-gateway/src/renderer/assistant/run-watcher.test.ts
+++ b/packages/@n8n/local-gateway/src/renderer/assistant/run-watcher.test.ts
@@ -1,0 +1,128 @@
+// Explicit vitest imports: the renderer tsconfig deliberately has `types: []`,
+// so the vitest globals are not ambiently typed here.
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { watchAssistantRun } from './run-watcher';
+import type { InstanceAiEvent } from '../../shared/types';
+
+// `watchAssistantRun` subscribes through the singleton thread client; capture
+// its listeners so tests can drive the event stream directly.
+const clientState = vi.hoisted(() => ({
+	listeners: [] as Array<(event: InstanceAiEvent) => void>,
+}));
+
+vi.mock('../services/thread-client', () => ({
+	getThreadClient: () => ({
+		listen: (_threadId: string, listener: (event: InstanceAiEvent) => void) => {
+			clientState.listeners.push(listener);
+		},
+		unlisten: vi.fn(),
+	}),
+}));
+
+function emit(event: InstanceAiEvent) {
+	for (const listener of [...clientState.listeners]) listener(event);
+}
+
+function outcomeCall(runId: string, args: Record<string, unknown>): InstanceAiEvent {
+	return {
+		type: 'tool-call',
+		runId,
+		agentId: 'root',
+		payload: { toolName: 'report-desktop-task-outcome', args },
+	} as InstanceAiEvent;
+}
+
+function runFinish(runId: string, status = 'completed'): InstanceAiEvent {
+	return { type: 'run-finish', runId, agentId: 'root', payload: { status } } as InstanceAiEvent;
+}
+
+const VALID_ARGS = {
+	success: true,
+	title: 'Summarize PDF document',
+	summary: 'Read the PDF and summarized it.',
+};
+
+describe('watchAssistantRun — outcome parsing', () => {
+	beforeEach(() => {
+		clientState.listeners.length = 0;
+	});
+
+	it('returns the parsed outcome of a completed run', async () => {
+		const result = watchAssistantRun('thread-1', 'run-1');
+		emit(outcomeCall('run-1', { ...VALID_ARGS, icon: '📄' }));
+		emit(runFinish('run-1'));
+
+		await expect(result).resolves.toEqual({
+			ok: true,
+			status: 'success',
+			tookAction: false,
+			outcome: { ...VALID_ARGS, icon: '📄', details: undefined, failureReason: undefined },
+			error: undefined,
+		});
+	});
+
+	it('passes details through to the outcome', async () => {
+		const result = watchAssistantRun('thread-1', 'run-1');
+		emit(outcomeCall('run-1', { ...VALID_ARGS, details: '**Key points**\n\n- Revenue grew' }));
+		emit(runFinish('run-1'));
+
+		await expect(result).resolves.toMatchObject({
+			outcome: { details: '**Key points**\n\n- Revenue grew' },
+		});
+	});
+
+	it('drops a malformed or blank details value without invalidating the outcome', async () => {
+		const result = watchAssistantRun('thread-1', 'run-1');
+		emit(outcomeCall('run-1', { ...VALID_ARGS, details: 42 }));
+		emit(runFinish('run-1'));
+
+		const run = await result;
+		expect(run.outcome?.title).toBe(VALID_ARGS.title);
+		expect(run.outcome?.details).toBeUndefined();
+
+		clientState.listeners.length = 0;
+		const blankResult = watchAssistantRun('thread-1', 'run-2');
+		emit(outcomeCall('run-2', { ...VALID_ARGS, details: '   ' }));
+		emit(runFinish('run-2'));
+
+		const blankRun = await blankResult;
+		expect(blankRun.outcome?.title).toBe(VALID_ARGS.title);
+		expect(blankRun.outcome?.details).toBeUndefined();
+	});
+
+	it('discards an outcome report missing its required fields', async () => {
+		const result = watchAssistantRun('thread-1', 'run-1');
+		emit(outcomeCall('run-1', { success: true, summary: 'No title given' }));
+		emit(runFinish('run-1'));
+
+		await expect(result).resolves.toMatchObject({ ok: true, outcome: undefined });
+	});
+
+	it('counts other tool calls as action but not the outcome report itself', async () => {
+		const result = watchAssistantRun('thread-1', 'run-1');
+		emit({
+			type: 'tool-call',
+			runId: 'run-1',
+			agentId: 'root',
+			payload: { toolName: 'read_file', args: {} },
+		} as InstanceAiEvent);
+		emit(outcomeCall('run-1', VALID_ARGS));
+		emit(runFinish('run-1'));
+
+		await expect(result).resolves.toMatchObject({ tookAction: true });
+	});
+
+	it('ignores events from other runs', async () => {
+		const result = watchAssistantRun('thread-1', 'run-1');
+		emit(outcomeCall('other-run', { ...VALID_ARGS, details: 'not ours' }));
+		emit(runFinish('other-run'));
+		emit(runFinish('run-1', 'failed'));
+
+		await expect(result).resolves.toMatchObject({
+			ok: false,
+			status: 'error',
+			outcome: undefined,
+		});
+	});
+});

--- a/packages/@n8n/local-gateway/src/renderer/assistant/run-watcher.ts
+++ b/packages/@n8n/local-gateway/src/renderer/assistant/run-watcher.ts
@@ -36,9 +36,11 @@ function parseOutcome(args: Record<string, unknown>): DesktopAssistantTaskOutcom
 		return undefined;
 	}
 	if (failureReason !== undefined && typeof failureReason !== 'string') return undefined;
-	// A malformed icon doesn't invalidate the report — it just gets dropped.
+	// A malformed icon or details value doesn't invalidate the report — it just gets dropped.
 	const icon = typeof args.icon === 'string' && args.icon.trim() ? args.icon.trim() : undefined;
-	return { success, title, summary, icon, failureReason };
+	const details =
+		typeof args.details === 'string' && args.details.trim() ? args.details : undefined;
+	return { success, title, summary, icon, details, failureReason };
 }
 
 /**

--- a/packages/@n8n/local-gateway/src/renderer/components/TaskComposer.vue
+++ b/packages/@n8n/local-gateway/src/renderer/components/TaskComposer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { N8nIcon, N8nTooltip } from '@n8n/design-system';
+import { N8nIcon, N8nMarkdown, N8nTooltip } from '@n8n/design-system';
 import { useI18n } from '@n8n/i18n';
 import { computed, nextTick, onMounted, ref, watch } from 'vue';
 
@@ -21,14 +21,23 @@ type ComposerState = 'idle' | 'thinking' | 'doing';
  * The card shown above the input once a run finishes:
  * - `done`: the assistant did the thing — offer to keep it as a saved task.
  *   `label` is the agent's outcome title (or the truncated prompt) and doubles
- *   as the workflow name when the task is kept.
+ *   as the workflow name when the task is kept. `details` is the task's actual
+ *   output (markdown) for information deliverables — a summary, an answer —
+ *   and this card is the only place the user ever sees it.
  * - `handoff`: the run finished but the task wasn't done (declined, ambiguous,
  *   or failed per the agent's own outcome report) — point the user to the
  *   instance UI; `message` is the agent's failure reason when it gave one.
  * - `error`: the run errored, timed out, or was canceled.
  */
 type ResultCard =
-	| { kind: 'done'; threadId: string; label: string; icon?: string }
+	| {
+			kind: 'done';
+			threadId: string;
+			label: string;
+			icon?: string;
+			summary?: string;
+			details?: string;
+	  }
 	| { kind: 'handoff'; message?: string }
 	| { kind: 'error'; message: string };
 
@@ -159,6 +168,8 @@ async function submit(prompt?: string) {
 				threadId: created.threadId,
 				label: run.outcome.title,
 				icon: run.outcome.icon,
+				summary: run.outcome.summary,
+				details: run.outcome.details,
 			});
 		} else if (run.outcome) {
 			showResult({ kind: 'handoff', message: run.outcome.failureReason });
@@ -260,7 +271,18 @@ defineExpose({ submit });
 							<N8nIcon icon="x" :size="14" aria-hidden="true" />
 						</button>
 					</div>
-					<div :class="$style.resultBody">
+					<div :class="[$style.resultBody, $style.doneBody]">
+						<div v-if="resultCard.summary" :class="$style.resultMessage">
+							{{ resultCard.summary }}
+						</div>
+						<div
+							v-if="resultCard.details"
+							:class="$style.detailsScroll"
+							tabindex="0"
+							:aria-label="i18n.baseText('desktopAssistant.composer.resultDetailsAriaLabel')"
+						>
+							<N8nMarkdown :content="resultCard.details" />
+						</div>
 						<div :class="$style.resultMessage">
 							{{ i18n.baseText('desktopAssistant.composer.keepPrompt') }}
 						</div>
@@ -433,6 +455,7 @@ defineExpose({ submit });
 
 .resultHeader {
 	display: flex;
+	flex-shrink: 0;
 	align-items: center;
 	gap: var(--spacing--2xs);
 	padding: 10px var(--spacing--xs);
@@ -506,9 +529,52 @@ defineExpose({ submit });
 	margin-top: var(--spacing--xs);
 }
 
-/* Done variant: green accents. */
+/* Done variant: green accents. A flex column capped near the window height so
+   an information deliverable (the details block) can take all the spare room
+   while the header, summary, and keep-prompt/actions stay visible. */
 .doneCard {
+	display: flex;
+	flex-direction: column;
+	max-height: calc(100vh - 200px);
 	border: 1px solid rgba(63, 207, 142, 0.45);
+}
+
+.doneBody {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--2xs);
+	min-height: 0;
+}
+
+/* Only the details region absorbs the height cap; everything else keeps its size. */
+.doneBody > :not(.detailsScroll) {
+	flex-shrink: 0;
+}
+
+.detailsScroll {
+	flex: 1;
+	min-height: 0;
+	padding: var(--spacing--2xs) var(--spacing--xs);
+	overflow-y: auto;
+	overflow-wrap: anywhere;
+	font-size: 12px;
+	color: var(--da-text);
+	background: var(--da-surface);
+	border: 1px solid var(--da-border);
+	border-radius: 7px;
+	/* N8nMarkdown colors its text, code blocks, and blockquotes with design-system
+	   tokens that default to the light theme (dark on dark here); pin them to the
+	   assistant palette. */
+	--color--text: var(--da-text);
+	--color--text--shade-1: var(--da-text);
+	--color--background: var(--da-surface-2);
+	--border-color: var(--da-border-strong);
+	--color--primary: var(--da-accent);
+}
+
+.detailsScroll:focus-visible {
+	outline: var(--da-focus-ring);
+	outline-offset: var(--da-focus-ring-offset);
 }
 
 .doneHeader {

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -93,6 +93,7 @@
 	"desktopAssistant.composer.handoffMessage": "This one needs more than I can do from here — it might be recurring, need extra setup, or be out of scope. Open your n8n instance to set it up there.",
 	"desktopAssistant.composer.errorTitle": "Something went wrong",
 	"desktopAssistant.composer.errorFallback": "I couldn't finish that. Please try again.",
+	"desktopAssistant.composer.resultDetailsAriaLabel": "Task result",
 	"desktopAssistant.composer.keepPrompt": "Want me to keep this so you can run it again any time?",
 	"desktopAssistant.composer.noThanks": "No thanks",
 	"desktopAssistant.composer.saveAsReady": "Save as ready to run",


### PR DESCRIPTION
## Summary

In the desktop assistant's one-shot flow ("Summarize this PDF" via the context picker), the actual deliverable of information tasks never reached the user: the one-shot system prompt forbade text output, the `report-desktop-task-outcome` report only carried a one-sentence "what was done" summary, and the Done card rendered just the outcome title. The run would read the PDF, summarize it — and the summary was lost.

This PR routes the deliverable through the outcome report and renders it on the Done card:

- **Outcome contract**: `report-desktop-task-outcome` gains an optional `details` field — the task's actual output as markdown when the deliverable is information (a summary, an answer, extracted data) rather than a side effect on the system. Added to the tool's zod schema and the `DesktopAssistantTaskOutcome` DTO.
- **One-shot prompt**: removed the contradicting "no summaries" wording from the fire-and-forget rules and added an "Ending the run" bullet requiring the full deliverable in `details` for information requests, since the outcome card is the only thing the user ever sees.
- **run-watcher**: parses `details` defensively like `icon` — a malformed value is dropped without invalidating the rest of the report.
- **Done card** (`TaskComposer.vue`): now shows the outcome's one-sentence summary plus `details` rendered with `N8nMarkdown` in a keyboard-focusable scroll region. The card becomes a flex column capped near the window height, so the details block takes all spare room while the header and keep-prompt/actions stay visible. Pure-action tasks (no `details`) keep the compact card unchanged; handoff and error cards are untouched.

Note: the rendered markdown is agent-authored and can include content read from the user's documents — same exposure class as the existing `N8nMarkdown` use in the chat tab.

## How to test

1. Run the desktop app against an instance with instance-ai enabled.
2. Open a PDF, open the assistant, select the PDF in the context picker, and click the "Summarize this PDF" chip → the Done card should show a one-sentence summary plus the scrollable markdown summary; long content scrolls while the header and Save/No-thanks buttons stay pinned.
3. Run a pure-action task ("create a folder called Test on my desktop") → Done card looks like before, no details block.
4. Ask something ambiguous/recurring → handoff card unchanged.

Unit: `pnpm test run-watcher` in `packages/@n8n/local-gateway` (new suite), `pnpm test system-prompt.desktop-assistant` in `packages/@n8n/instance-ai`.

## Related Linear tickets, Github issues, and Community forum posts

Hackmation: personal automation desktop app (no ticket).

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI