### PR TITLE
fix: Pre-approve workflow edits for desktop assistant edit runs (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.desktop-assistant.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.desktop-assistant.test.ts
@@ -84,6 +84,17 @@ describe('getDesktopAssistantProfile — extra tools', () => {
 		expect(getDesktopAssistantProfile(undefined).preloadGatewayTools).toBe(false);
 	});
 
+	it('pre-approves workflow edits for edit mode only', () => {
+		expect(getDesktopAssistantProfile('desktop-assistant-edit').preApproveWorkflowEdits).toBe(true);
+		expect(getDesktopAssistantProfile('desktop-assistant-one-shot').preApproveWorkflowEdits).toBe(
+			false,
+		);
+		expect(getDesktopAssistantProfile('desktop-assistant-promote').preApproveWorkflowEdits).toBe(
+			false,
+		);
+		expect(getDesktopAssistantProfile(undefined).preApproveWorkflowEdits).toBe(false);
+	});
+
 	it('suppresses interactive setup for every desktop mode but not regular chat', () => {
 		expect(getDesktopAssistantProfile('desktop-assistant-one-shot').suppressInteractiveSetup).toBe(
 			true,

--- a/packages/@n8n/instance-ai/src/agent/desktop-assistant-profile.ts
+++ b/packages/@n8n/instance-ai/src/agent/desktop-assistant-profile.ts
@@ -66,6 +66,13 @@ export interface DesktopAssistantProfile {
 	 * is saved credential-less, surfacing in the desktop app's "Action needed".
 	 */
 	suppressInteractiveSetup: boolean;
+	/**
+	 * Skip the HITL "Edit <workflow>?" confirmation on `build-workflow` updates.
+	 * Edit-mode runs are launched from the task detail view after the user picked
+	 * the exact changes and pressed Done — that interaction is the approval, and
+	 * the run has no surface to answer a suspend (it would hang until timeout).
+	 */
+	preApproveWorkflowEdits: boolean;
 }
 
 /** Shared preamble: both desktop modes run headless, so text output is waste. */
@@ -176,6 +183,7 @@ export function getDesktopAssistantProfile(
 				],
 				preloadGatewayTools: true,
 				suppressInteractiveSetup: true,
+				preApproveWorkflowEdits: false,
 			};
 		case 'desktop-assistant-promote':
 			return {
@@ -183,6 +191,7 @@ export function getDesktopAssistantProfile(
 				extraTools: [createReportPromoteOutcomeTool({ memory: deps.memory })],
 				preloadGatewayTools: false,
 				suppressInteractiveSetup: true,
+				preApproveWorkflowEdits: false,
 			};
 		case 'desktop-assistant-edit':
 			return {
@@ -190,6 +199,7 @@ export function getDesktopAssistantProfile(
 				extraTools: [],
 				preloadGatewayTools: false,
 				suppressInteractiveSetup: true,
+				preApproveWorkflowEdits: true,
 			};
 		case undefined:
 			return {
@@ -197,6 +207,7 @@ export function getDesktopAssistantProfile(
 				extraTools: [],
 				preloadGatewayTools: false,
 				suppressInteractiveSetup: false,
+				preApproveWorkflowEdits: false,
 			};
 	}
 }

--- a/packages/@n8n/instance-ai/src/agent/instance-agent.ts
+++ b/packages/@n8n/instance-ai/src/agent/instance-agent.ts
@@ -62,12 +62,14 @@ export async function createInstanceAgent(options: CreateInstanceAgentOptions): 
 		memory: options.memory,
 	});
 
-	// Desktop runs have no surface to answer a "configure credentials" suspend, so
-	// thread the flag onto the context the domain tools capture — setup auto-defers
-	// rather than hanging the run.
+	// Desktop runs have no surface to answer a "configure credentials" or
+	// "edit workflow?" suspend, so thread the profile flags onto the context the
+	// domain tools capture — setup auto-defers and pre-approved edits skip the
+	// confirmation rather than hanging the run.
 	const toolContext = {
 		...context,
 		suppressInteractiveSetup: desktopProfile.suppressInteractiveSetup,
+		workflowEditsPreApproved: desktopProfile.preApproveWorkflowEdits,
 	};
 
 	// Build native n8n domain tools (context captured via closures — per-run)

--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
@@ -349,6 +349,61 @@ describe('createBuildWorkflowTool', () => {
 		);
 	});
 
+	it('updates existing workflows without suspending when edits are pre-approved on the context', async () => {
+		const suspend = vi.fn();
+		const context = {
+			userId: 'user-1',
+			runId: 'run-1',
+			workflowService: {
+				updateFromWorkflowJSON: vi.fn(async () => await Promise.resolve({ id: 'wf-1' })),
+				clearAiTemporary: vi.fn(async () => await Promise.resolve()),
+			},
+			credentialService: {},
+			nodeService: {},
+			dataTableService: {},
+			executionService: {},
+			workflowEditsPreApproved: true,
+			permissions: { updateWorkflow: 'require_approval' },
+			logger: { warn: vi.fn() },
+		} as unknown as InstanceAiContext;
+
+		const tool = createBuildWorkflowTool(context);
+		const result = await executeTool(
+			tool,
+			{ workflowId: 'wf-1', code: 'workflow code' },
+			{ suspend },
+		);
+
+		expect(result).toMatchObject({ success: true, workflowId: 'wf-1' });
+		expect(suspend).not.toHaveBeenCalled();
+		expect(context.workflowService.updateFromWorkflowJSON).toHaveBeenCalledWith(
+			'wf-1',
+			expect.objectContaining({ name: 'Generated workflow' }),
+			undefined,
+		);
+	});
+
+	it('still blocks pre-approved edits when the admin policy blocks workflow updates', async () => {
+		const suspend = vi.fn();
+		const context = {
+			workflowService: {
+				updateFromWorkflowJSON: vi.fn(),
+			},
+			workflowEditsPreApproved: true,
+			permissions: { updateWorkflow: 'blocked' },
+		} as unknown as InstanceAiContext;
+
+		const result = await executeTool(
+			createBuildWorkflowTool(context),
+			{ workflowId: 'wf-1', code: 'workflow code' },
+			{ suspend },
+		);
+
+		expect(result).toMatchObject({ success: false, errors: ['Action blocked by admin'] });
+		expect(suspend).not.toHaveBeenCalled();
+		expect(context.workflowService.updateFromWorkflowJSON).not.toHaveBeenCalled();
+	});
+
 	it('allows new workflow builds during post-plan follow-up repairs', async () => {
 		const reportBuildOutcome = vi.fn(
 			async () => await Promise.resolve({ type: 'verify' as const, workflowId: 'wf-1' }),

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -402,6 +402,7 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 			if (
 				input.workflowId &&
 				!isApprovedBuildContext(context) &&
+				!context.workflowEditsPreApproved &&
 				context.permissions?.updateWorkflow !== 'always_allow'
 			) {
 				if (ctx.resumeData && !ctx.resumeData.approved) {

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -742,6 +742,10 @@ export interface InstanceAiContext {
 	 *  Desktop-assistant runs are fire-and-forget with no surface to answer a setup
 	 *  prompt; suspending there would hang the run. See `DesktopAssistantProfile`. */
 	suppressInteractiveSetup?: boolean;
+	/** When set, `build-workflow` updates to existing workflows skip the HITL edit
+	 *  confirmation. Set for desktop-assistant edit runs, where the user already
+	 *  approved the exact changes in the task detail view. See `DesktopAssistantProfile`. */
+	workflowEditsPreApproved?: boolean;
 	/** When set, `runWorkflow: 'always_allow'` only short-circuits HITL approval for these workflow IDs.
 	 *  Used by checkpoint follow-up runs to scope the override to the workflows the checkpoint is
 	 *  verifying — `executions(action="run")` on any other workflow still requires user approval. */

--- a/packages/@n8n/local-gateway/package.json
+++ b/packages/@n8n/local-gateway/package.json
@@ -2,6 +2,7 @@
   "name": "@n8n/local-gateway",
   "version": "0.1.0",
   "description": "n8n Assistant desktop app",
+  "author": "n8n GmbH <hello@n8n.io>",
   "private": true,
   "main": "dist/main/index.js",
   "scripts": {
@@ -21,17 +22,15 @@
     "test:dev": "vitest --silent=false"
   },
   "dependencies": {
-    "@n8n/api-types": "workspace:*",
     "@n8n/computer-use": "workspace:*",
-    "@n8n/design-system": "workspace:*",
-    "@n8n/i18n": "workspace:*",
-    "electron-store": "^8.2.0",
-    "eventsource": "^3.0.6",
-    "vue": "catalog:frontend"
+    "electron-store": "^8.2.0"
   },
   "devDependencies": {
     "@electron/rebuild": "^4.0.4",
     "@iconify/json": "^2.2.349",
+    "@n8n/api-types": "workspace:*",
+    "@n8n/design-system": "workspace:*",
+    "@n8n/i18n": "workspace:*",
     "@n8n/eslint-config": "workspace:*",
     "@n8n/typescript-config": "workspace:*",
     "@n8n/vitest-config": "workspace:*",
@@ -40,13 +39,15 @@
     "@vitest/coverage-v8": "catalog:",
     "electron": "^41.3.0",
     "electron-builder": "^26.9.0",
+    "eventsource": "^3.0.6",
     "rimraf": "catalog:",
     "sass-embedded": "catalog:",
     "unplugin-icons": "catalog:frontend",
     "vite": "catalog:",
     "vite-plugin-electron": "catalog:",
     "vite-svg-loader": "catalog:frontend",
-    "vitest": "catalog:"
+    "vitest": "catalog:",
+    "vue": "catalog:frontend"
   },
   "license": "LicenseRef-n8n-sustainable-use"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2115,27 +2115,12 @@ importers:
 
   packages/@n8n/local-gateway:
     dependencies:
-      '@n8n/api-types':
-        specifier: workspace:*
-        version: link:../api-types
       '@n8n/computer-use':
         specifier: workspace:*
         version: link:../computer-use
-      '@n8n/design-system':
-        specifier: workspace:*
-        version: link:../../frontend/@n8n/design-system
-      '@n8n/i18n':
-        specifier: workspace:*
-        version: link:../../frontend/@n8n/i18n
       electron-store:
         specifier: ^8.2.0
         version: 8.2.0
-      eventsource:
-        specifier: ^3.0.6
-        version: 3.0.6
-      vue:
-        specifier: catalog:frontend
-        version: 3.5.26(typescript@6.0.2)
     devDependencies:
       '@electron/rebuild':
         specifier: ^4.0.4
@@ -2143,9 +2128,18 @@ importers:
       '@iconify/json':
         specifier: ^2.2.349
         version: 2.2.354
+      '@n8n/api-types':
+        specifier: workspace:*
+        version: link:../api-types
+      '@n8n/design-system':
+        specifier: workspace:*
+        version: link:../../frontend/@n8n/design-system
       '@n8n/eslint-config':
         specifier: workspace:*
         version: link:../eslint-config
+      '@n8n/i18n':
+        specifier: workspace:*
+        version: link:../../frontend/@n8n/i18n
       '@n8n/typescript-config':
         specifier: workspace:*
         version: link:../typescript-config
@@ -2167,6 +2161,9 @@ importers:
       electron-builder:
         specifier: ^26.9.0
         version: 26.9.0(electron-builder-squirrel-windows@26.9.0)
+      eventsource:
+        specifier: ^3.0.6
+        version: 3.0.6
       rimraf:
         specifier: 'catalog:'
         version: 6.0.1
@@ -2188,6 +2185,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.1(@opentelemetry/api@1.9.0)(@types/node@20.19.41)(@vitest/browser-playwright@4.0.16)(jsdom@23.0.1(bufferutil@4.0.9)(utf-8-validate@5.0.10))(vite@8.0.2(@types/node@20.19.41)(esbuild@0.25.10)(jiti@2.6.1)(sass-embedded@1.98.0)(sass@1.98.0)(terser@5.16.1)(tsx@4.19.3)(yaml@2.8.3))
+      vue:
+        specifier: catalog:frontend
+        version: 3.5.26(typescript@6.0.2)
 
   packages/@n8n/mcp-apps:
     dependencies:
@@ -21024,8 +21024,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.3.3:
-    resolution: {integrity: sha512-x4nsFpy5Pe8fqPzp/5vkTPeTTDBpAx4WVtV47Ejt0+2FQrq4pRRsJs7JmYRqMFzTu/LW+pCWEjQ3YVCkPV7f9g==}
+  vue-component-type-helpers@3.3.4:
+    resolution: {integrity: sha512-joip1uZTaQR0nD23N400gIdJ7xY+WiiiMA/BCKz842gvGBknqDQAzklUvDEhqFvvrhQY8S2ZANBMu4X70VMFGw==}
 
   vue-demi@0.14.10:
     resolution: {integrity: sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==}
@@ -28394,7 +28394,7 @@ snapshots:
       storybook: 10.1.11(@testing-library/dom@10.4.0)(bufferutil@4.0.9)(prettier@3.6.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(utf-8-validate@5.0.10)
       type-fest: 2.19.0
       vue: 3.5.26(typescript@6.0.2)
-      vue-component-type-helpers: 3.3.3
+      vue-component-type-helpers: 3.3.4
 
   '@stryker-mutator/api@9.6.1':
     dependencies:
@@ -41116,7 +41116,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.3.3: {}
+  vue-component-type-helpers@3.3.4: {}
 
   vue-demi@0.14.10(vue@3.5.26(typescript@6.0.2)):
     dependencies:


### PR DESCRIPTION
## Summary

**Commit 1 — edit runs no longer hang on an invisible confirmation.** Applying a change from the desktop app's task detail edit view never went through: the `desktop-assistant-edit` run called `build-workflow` on the existing workflow, which suspended with the HITL "Edit \<workflow\>?" confirmation. The edit view only waits for `run-finish` (120s timeout) and never surfaces confirmations, so the run hung until the view gave up — the workflow was never updated and the suspended confirmation lingered in `instance_ai_pending_confirmations` until its 24h expiry.

The edit run is launched *because* the user picked exact from→to changes and pressed Done — that interaction is the approval. So edit-mode runs now pre-approve workflow updates, mirroring the existing `suppressInteractiveSetup` wiring:

- `DesktopAssistantProfile.preApproveWorkflowEdits` — `true` for `desktop-assistant-edit` only (one-shot confirmations surface via the composer's prompt watcher; promote only creates new workflows).
- Threaded onto the tool context as `InstanceAiContext.workflowEditsPreApproved` in `createInstanceAgent`.
- `build-workflow` skips the suspend when set. The admin `blocked` policy still short-circuits first, and edits from regular chat still require the confirmation.

**Commit 2 — `dist:mac` bundling works again.** Renderer-only packages (`@n8n/api-types`, `@n8n/design-system`, `@n8n/i18n`, `vue`, `eventsource`) move from `dependencies` to `devDependencies` — vite bundles them into the renderer, and electron-builder chokes on packing workspace deps into the app. Only true runtime deps (`@n8n/computer-use`, `electron-store`) remain, and the `author` field electron-builder requires is added.

## How to test

1. Open a desktop-assistant task's detail view, edit a param chip (e.g. schedule 10am → 8am), press Done → the run finishes within seconds, the view refetches with the new value, and no `suspended` row appears in `instance_ai_pending_confirmations`.
2. Regression: ask the assistant in regular chat (web UI) to edit an existing workflow → the "Edit \<workflow\>?" confirmation still appears.
3. Bundling: `pnpm --filter @n8n/local-gateway dist:mac` completes and produces a working app bundle.

Unit: `pnpm test build-workflow.tool` and `pnpm test system-prompt.desktop-assistant` in `packages/@n8n/instance-ai`.

## Related Linear tickets, Github issues, and Community forum posts

Hackmation: personal automation desktop app (no ticket).

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32210">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->