### PR TITLE
chore: Bump @n8n_io/ai-assistant-sdk to 1.21.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,8 +124,8 @@ catalogs:
       specifier: 0.3.20-17
       version: 0.3.20-17
     '@n8n_io/ai-assistant-sdk':
-      specifier: 1.21.0
-      version: 1.21.0
+      specifier: 1.21.1
+      version: 1.21.1
     '@openrouter/ai-sdk-provider':
       specifier: ^2.8.0
       version: 2.9.0
@@ -972,7 +972,7 @@ importers:
         version: link:../workflow-sdk
       '@n8n_io/ai-assistant-sdk':
         specifier: 'catalog:'
-        version: 1.21.0
+        version: 1.21.1
       axios:
         specifier: 1.16.1
         version: 1.16.1(debug@4.4.3)
@@ -3163,7 +3163,7 @@ importers:
         version: link:../@n8n/workflow-sdk
       '@n8n_io/ai-assistant-sdk':
         specifier: 'catalog:'
-        version: 1.21.0
+        version: 1.21.1
       '@n8n_io/license-sdk':
         specifier: 2.25.0
         version: 2.25.0
@@ -8535,8 +8535,8 @@ packages:
       sqlite3:
         optional: true
 
-  '@n8n_io/ai-assistant-sdk@1.21.0':
-    resolution: {integrity: sha512-reF4A3CvGw4hr61xss0gO9YXOs/c5O8nwmoL91Neu2j6aENtuqmYeZ7UT4v0IvjuiO/IJJtUsASWkVQJNCpN6A==}
+  '@n8n_io/ai-assistant-sdk@1.21.1':
+    resolution: {integrity: sha512-Bb18Cv6VeX3eqPF1DLN48ZqjTzUoWuskO0opVOwCrDESZUAQWWhG54enKsggXzhAdYh8XnqmO7RphN4t8ZwxHQ==}
     engines: {node: '>=20.15', pnpm: '>=8.14'}
 
   '@n8n_io/license-sdk@2.25.0':
@@ -25866,7 +25866,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@n8n_io/ai-assistant-sdk@1.21.0': {}
+  '@n8n_io/ai-assistant-sdk@1.21.1': {}
 
   '@n8n_io/license-sdk@2.25.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,7 +50,7 @@ catalog:
   '@modelcontextprotocol/ext-apps': 1.3.2
   '@modelcontextprotocol/sdk': 1.26.0
   '@n8n/typeorm': 0.3.20-17
-  '@n8n_io/ai-assistant-sdk': 1.21.0
+  '@n8n_io/ai-assistant-sdk': 1.21.1
   '@openrouter/ai-sdk-provider': ^2.8.0
   '@rudderstack/rudder-sdk-node': 3.0.5
   '@sentry/node': ^10.55.0


### PR DESCRIPTION
## Summary

Bumps the `@n8n_io/ai-assistant-sdk` catalog dependency from `1.21.0` to `1.21.1`, updating `pnpm-workspace.yaml` and the corresponding `pnpm-lock.yaml` entries.

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/AI-2484/community-issue-issue-with-ai-service
- https://linear.app/n8n/issue/AI-2181/responseerror-unexpected-token-doctype-is-not-valid-json
- https://github.com/n8n-io/n8n/issues/30643

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32211">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

