### PR TITLE
test: Fail benchmark scripts when a bench has no valid measurements

### DIFF
--- a/packages/testing/performance/scripts/check-regression.mjs
+++ b/packages/testing/performance/scripts/check-regression.mjs
@@ -44,6 +44,25 @@ for (const file of baseline.files) {
 	}
 }
 
+// Check for failed benchmarks (no valid measurements)
+let hasFailed = false;
+for (const file of current.files) {
+	for (const group of file.groups) {
+		for (const bench of group.benchmarks) {
+			if (bench.hz === undefined || !isFinite(bench.hz)) {
+				console.error(
+					`❌ Benchmark failed (no valid measurements): ${group.fullName} > ${bench.name}`,
+				);
+				hasFailed = true;
+			}
+		}
+	}
+}
+if (hasFailed) {
+	console.error('\n❌ FAILED: One or more benchmarks did not produce valid results\n');
+	process.exit(1);
+}
+
 // Compare results
 const results = [];
 let hasRegression = false;

--- a/packages/testing/performance/scripts/save-baseline.mjs
+++ b/packages/testing/performance/scripts/save-baseline.mjs
@@ -38,6 +38,27 @@ if (!existsSync(resultsPath)) {
 // Load and sanitize paths
 const results = JSON.parse(readFileSync(resultsPath, 'utf-8'));
 
+// Check for failed benchmarks before saving as baseline
+let hasFailed = false;
+for (const file of results.files) {
+	for (const group of file.groups) {
+		for (const bench of group.benchmarks) {
+			if (bench.hz === undefined || !isFinite(bench.hz)) {
+				console.error(
+					`❌ Benchmark failed (no valid measurements): ${group.fullName} > ${bench.name}`,
+				);
+				hasFailed = true;
+			}
+		}
+	}
+}
+if (hasFailed) {
+	console.error(
+		'\n❌ Refusing to save baseline: one or more benchmarks did not produce valid results\n',
+	);
+	process.exit(1);
+}
+
 for (const file of results.files) {
 	// Convert absolute path to relative
 	if (file.filepath) {


### PR DESCRIPTION
## Summary

A benchmark that produces no valid measurements (e.g. it throws during warmup) ends up with an `undefined` or non-finite `hz` in the vitest bench JSON output. Previously:

- `check-regression.mjs` silently passed such runs — a broken benchmark could never be flagged as a regression.
- `save-baseline.mjs` happily saved the broken results as the new baseline.

Both scripts now fail loudly (exit 1) and name the offending benchmark before any comparison or baseline write happens.

## How to test

Drop a `baseline.json` and a `benchmark-results.json` into `packages/testing/performance/profiles/` where one bench entry has no `hz`, then run `node scripts/check-regression.mjs` from `packages/testing/performance/` — it exits 1 with `❌ Benchmark failed (no valid measurements): <group> > <bench>`. With valid `hz` values it compares as before. The same fixture makes `save-baseline.mjs` refuse to write `baseline.json`.

## Related Linear tickets, Github issues, and Community forum posts

Part of the expression isolation production readiness work: https://linear.app/n8n/project/expression-isolation-production-readiness-c9423b5669c2/issues

Salvaged from an abandoned phase-11a branch (`8e70429f80`) whose other changes were superseded by master.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)