### PR TITLE
ci: Add db schema docs check to pre-commit hooks (no-changelog)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -40,6 +40,17 @@ pre-commit:
       skip:
         - merge
         - rebase
+    db_schema_check:
+      glob: 'packages/@n8n/db/src/migrations/{common,postgresdb,sqlite}/*.ts'
+      run: |
+        if command -v tbls >/dev/null 2>&1; then
+          pnpm run db:schema:check:sqlite
+        else
+          echo "tbls not installed (brew install tbls) — skipping db schema check"
+        fi
+      skip:
+        - merge
+        - rebase
     playwright_janitor:
       glob: 'packages/testing/playwright/**/*.ts'
       run: |

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "test:affected": "turbo run test --affected --concurrency=1",
     "db:schema:docs": "turbo run build --filter=@n8n/db && pnpm --filter=@n8n/db schema:docs",
     "db:schema:check": "turbo run build --filter=@n8n/db && pnpm --filter=@n8n/db schema:check",
+    "db:schema:check:sqlite": "turbo run build --filter=@n8n/db && pnpm --filter=@n8n/db schema:check:sqlite",
     "test:with:docker": "pnpm --filter=n8n-playwright test:container:standard",
     "test:show:report": "pnpm --filter=n8n-playwright exec playwright show-report",
     "watch": "turbo run watch --concurrency=64",


### PR DESCRIPTION
## Summary

Adds a `pre-commit` git hook (via lefthook) that runs the sqlite DB schema docs check **only when a database migration is staged**.

- A new `db_schema_check` command in `lefthook.yml` is globbed to `packages/@n8n/db/src/migrations/{common,postgresdb,sqlite}/*.ts`. Lefthook's `glob` means the command is a successful no-op on commits that don't touch migrations, and only runs when a migration file is staged.
- It runs a new sqlite-only root script `db:schema:check:sqlite` (mirrors the existing `db:schema:check`), keeping commit time down by skipping the heavier postgres testcontainer + diff (CI still runs the full both-DB check).
- The command is guarded by `command -v tbls`: if `tbls` isn't installed locally, it prints an install hint and exits 0 rather than failing the commit. It also skips on `merge`/`rebase`, consistent with the other pre-commit commands.

This catches schema-doc drift at commit time, before it reaches CI.

## How to test

1. Ensure `tbls` is installed (`brew install tbls`).
2. Stage a migration file under `packages/@n8n/db/src/migrations/**` and commit — the `db_schema_check` command runs (`turbo` builds `@n8n/db`, runs migrations, diffs the sqlite schema docs).
   - If the schema docs are up to date, the commit proceeds.
   - If they drift, the commit is blocked until `pnpm db:schema:docs` is regenerated.
3. Commit without staging any migration → the command is skipped (`no matching staged files`), no overhead.
4. Without `tbls` on PATH → the command prints an install hint and the commit proceeds.

Verified locally with a throwaway migration: the hook fired and passed (~10s) when a migration was staged, and skipped instantly (0.15s) when none was.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3415

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32221">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

