### PR TITLE
fix(core): Remove user:enforceMfa from public API key scopes

### DIFF
--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -81,7 +81,7 @@ export const API_KEY_RESOURCES = {
 	variable: ['create', 'update', 'delete', 'list'] as const,
 	securityAudit: ['generate'] as const,
 	project: ['create', 'update', 'delete', 'list'] as const,
-	user: ['read', 'list', 'create', 'changeRole', 'delete', 'enforceMfa'] as const,
+	user: ['read', 'list', 'create', 'changeRole', 'delete'] as const,
 	execution: ['delete', 'read', 'retry', 'list', 'get', 'stop'] as const,
 	credential: ['create', 'read', 'update', 'move', 'delete', 'list'] as const,
 	sourceControl: ['pull'] as const,

--- a/packages/@n8n/permissions/src/public-api-permissions.ee.ts
+++ b/packages/@n8n/permissions/src/public-api-permissions.ee.ts
@@ -12,7 +12,6 @@ export const OWNER_API_KEY_SCOPES: ApiKeyScope[] = [
 	'user:create',
 	'user:changeRole',
 	'user:delete',
-	'user:enforceMfa',
 	'sourceControl:pull',
 	'securityAudit:generate',
 	'project:create',


### PR DESCRIPTION
## Summary

The `user:enforceMfa` scope appeared in the Public API key scope picker (Settings → n8n API → Create an API key → Scopes), but no `/api/v1/...` endpoint actually consumed it. Selecting it on a Public API key had no effect.

This drops `user:enforceMfa` from the public API key scope list and removes it from `API_KEY_RESOURCES`. The scope remains a global scope (`GLOBAL_SCOPES`), since the internal `POST /rest/mfa/enforce-mfa` endpoint (used by the **Settings → Security → "Enforce MFA"** toggle) still gates on it via `@GlobalScope('user:enforceMfa')`.

## How to test

1. Sign in as an owner.
2. Go to **Settings → n8n API → Create an API key**.
3. Open the **Scopes** picker.
4. Confirm `user:enforceMfa` is no longer listed.
5. Confirm `Settings → Security → "Enforce MFA"` still works (the internal REST endpoint is unaffected).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-696/userenforcemfa-api-scope-is-exposed-publicly-but-has-no-public

Docs follow-up: the reserved-scope note for `user:enforceMfa` on `/api/authentication/#api-scopes` can be removed once this lands (referenced by [DOC-1957](https://linear.app/n8n/issue/DOC-1957/document-api-key-scopes-and-their-definitions) / n8n-io/n8n-docs#4659).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32223">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

