### PR TITLE
fix(editor): Mute Never expiration in API keys table

### DIFF
--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyTable.vue
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyTable.vue
@@ -114,7 +114,9 @@ const headers = ref<Array<TableHeader<ApiKey>>>([
 				<ApiKeyScopesCell :api-key="item" @open="emit('open-scopes', $event)" />
 			</template>
 			<template #[`item.expiresAt`]="{ item }">
-				<N8nText>{{ formatExpiration(item.expiresAt) }}</N8nText>
+				<N8nText :color="item.expiresAt ? undefined : 'text-light'">
+					{{ formatExpiration(item.expiresAt) }}
+				</N8nText>
 			</template>
 			<template #[`item.lastUsedAt`]="{ item }">
 				<N8nText :color="item.lastUsedAt ? undefined : 'text-light'">


### PR DESCRIPTION
## Summary

The API keys settings table uses the muted `text-light` color when the **Last used** column shows *Never*, but the **Expiration** column was rendering *Never* in default text color, so the two columns looked inconsistent.

This applies the same `text-light` color to the Expiration cell when `expiresAt` is null, matching the Last used cell.

## How to test

1. Open Settings → API.
2. Create an API key with no expiration.
3. In the API keys table, confirm the *Never* values in both **Expiration** and **Last used** render in the same muted color.

## Related Linear tickets, Github issues, and Community forum posts



## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32224">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

