### PR TITLE
fix: Hand off workflow setup prompts from desktop chat to the web UI (no-changelog)

### DIFF
--- a/packages/@n8n/local-gateway/src/renderer/components/ChatMessages.vue
+++ b/packages/@n8n/local-gateway/src/renderer/components/ChatMessages.vue
@@ -3,6 +3,8 @@ import { N8nButton, N8nMarkdown, N8nSpinner, N8nText } from '@n8n/design-system'
 import { useI18n } from '@n8n/i18n';
 import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue';
 
+import AssistantButton from './AssistantButton.vue';
+
 import { createChatThreadState, type ChatMessage, type ChatThreadState } from '../chat/chat-thread';
 import { markChatThreadVisible } from '../chat/visible-chat-threads';
 import {
@@ -11,9 +13,10 @@ import {
 	permissionPromptState,
 	respondToPrompt,
 } from '../permissions/permission-prompt-store';
-import type {
-	InstancePermissionPrompt,
-	PromptResponse,
+import {
+	isChatAnswerable,
+	type InstancePermissionPrompt,
+	type PromptResponse,
 } from '../permissions/prompt-classification';
 import { getThreadClient, type ThreadListener } from '../services/thread-client';
 
@@ -115,6 +118,11 @@ function promptContent(prompt: InstancePermissionPrompt): string {
 	}
 	if (parts.length === 0) parts.push(prompt.message);
 	return parts.join('\n\n');
+}
+
+/** Hand a prompt the chat can't answer (e.g. credential setup) off to the web UI. */
+async function openPromptInWebUi(prompt: InstancePermissionPrompt) {
+	await respondToPrompt(prompt.id, { kind: 'openInWebUi' });
 }
 
 function answerResponse(prompt: InstancePermissionPrompt, text: string): PromptResponse {
@@ -242,7 +250,10 @@ onBeforeUnmount(() => {
 			</template>
 
 			<!-- The agent's pending requests (e.g. clarifying questions), shown as
-			     assistant messages; answering one moves it into the transcript above. -->
+			     assistant messages; answering one moves it into the transcript above.
+			     Requests the composer can't answer as text (credential/workflow setup,
+			     plan review) get a handoff to the web UI instead — without it the
+			     locked composer would dead-end the thread. -->
 			<div
 				v-for="prompt in pendingPrompts"
 				:key="prompt.id"
@@ -250,6 +261,24 @@ onBeforeUnmount(() => {
 				data-testid="chat-pending-prompt"
 			>
 				<N8nMarkdown :content="promptContent(prompt)" />
+				<template v-if="!isChatAnswerable(prompt)">
+					<div :class="$style.externalHint">
+						{{ i18n.baseText('desktopAssistant.permissions.externalHint') }}
+					</div>
+					<div v-if="permissionPromptState.failedIds.has(prompt.id)" :class="$style.promptError">
+						{{ i18n.baseText('desktopAssistant.permissions.submitFailed') }}
+					</div>
+					<div :class="$style.promptActions">
+						<AssistantButton
+							variant="solid"
+							:disabled="permissionPromptState.respondingIds.has(prompt.id)"
+							data-testid="chat-prompt-open-in-web-ui"
+							@click="openPromptInWebUi(prompt)"
+						>
+							{{ i18n.baseText('desktopAssistant.permissions.openInInstanceAi') }}
+						</AssistantButton>
+					</div>
+				</template>
 			</div>
 
 			<div v-if="sendError" :class="$style.sendError" role="alert">
@@ -338,5 +367,22 @@ onBeforeUnmount(() => {
 	align-self: center;
 	font-size: 12px;
 	color: var(--da-red);
+}
+
+.externalHint {
+	margin-top: var(--spacing--xs);
+	font-size: 12px;
+	color: var(--da-subtler);
+}
+
+.promptError {
+	margin-top: var(--spacing--2xs);
+	font-size: 12px;
+	color: var(--da-red);
+}
+
+.promptActions {
+	display: flex;
+	margin-top: var(--spacing--xs);
 }
 </style>


### PR DESCRIPTION
## Summary

When a desktop assistant run suspends on a `workflows(action="setup")` confirmation (credential/workflow setup), the desktop chat transcript dead-ends: the prompt renders as plain assistant text ("Configure credentials for your workflow") while the composer locks — and there is no way to act on it.

The "Open in n8n" handoff added for the chat tab in #32197 lives on the floating `PermissionPromptCard`, but external prompts are deliberately omitted from the floating stack whenever the thread's transcript is visible — and external prompts auto-open the slide-up chat, so for setup prompts the button never appears on any surface.

This PR adds the same handoff inline in the chat transcript (`ChatMessages.vue`, shared by both the chat tab and the slide-up overlay): pending external prompts the composer cannot answer as free text now render the existing "This needs the full n8n editor…" hint plus an **Open in n8n** button wired to the existing `openInWebUi` → `assistant:openThread` IPC path. Chat-answerable prompts (questions / text input) keep their current inline-answer behavior. The prompt intentionally stays pending after the handoff; it clears via the live `tool-result`/`run-finish` events once setup is resolved in the web UI.

No new i18n strings, no main-process or shared-type changes.

## How to test

1. Run a local instance and the desktop app, sign in.
2. From the desktop composer, ask for a workflow that needs credentials (e.g. "Send me an email notification when this Notion document changes") and let the build promote it to a workflow.
3. When the run suspends on setup, the chat slides up showing "Configure credentials for your workflow" — previously inert text with a locked composer.
4. Expect the hint "This needs the full n8n editor — open the conversation there to finish." and an **Open in n8n** button below the prompt; clicking it opens `<instance>/instance-ai/<threadId>` in the browser with the rich setup panel.
5. Complete (or skip) setup in the web UI — the suspended run resumes and the desktop prompt + composer lock clear via the live thread events.

## Related Linear tickets, Github issues, and Community forum posts

Hackmation project — no ticket.

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32229">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->