### PR TITLE
fix(core): Enforce API key scope/endpoint parity in public API

### DIFF
--- a/packages/@n8n/permissions/src/__tests__/types.test.ts
+++ b/packages/@n8n/permissions/src/__tests__/types.test.ts
@@ -10,7 +10,6 @@ describe('ApiKeyScope', () => {
 			'credential:delete',
 			'credential:move',
 			'execution:delete',
-			'execution:get',
 			'execution:list',
 			'execution:read',
 			'project:create',

--- a/packages/@n8n/permissions/src/constants.ee.ts
+++ b/packages/@n8n/permissions/src/constants.ee.ts
@@ -83,7 +83,7 @@ export const API_KEY_RESOURCES = {
 	securityAudit: ['generate'] as const,
 	project: ['create', 'update', 'delete', 'list'] as const,
 	user: ['read', 'list', 'create', 'changeRole', 'delete'] as const,
-	execution: ['delete', 'read', 'retry', 'list', 'get', 'stop'] as const,
+	execution: ['delete', 'read', 'retry', 'list', 'stop'] as const,
 	credential: ['create', 'read', 'update', 'move', 'delete', 'list'] as const,
 	sourceControl: ['pull'] as const,
 	workflowTags: ['update', 'list'] as const,

--- a/packages/cli/src/public-api/v1/__tests__/scope-parity.test.ts
+++ b/packages/cli/src/public-api/v1/__tests__/scope-parity.test.ts
@@ -1,0 +1,118 @@
+import { API_KEY_RESOURCES, type ApiKeyScope } from '@n8n/permissions';
+import type * as nodeFs from 'node:fs';
+import path from 'node:path';
+import { parse as parseYaml } from 'yaml';
+
+import type { ScopeTaggedMiddleware } from '../shared/middlewares/global.middleware';
+
+jest.unmock('node:fs');
+const { readdirSync, readFileSync, statSync } = jest.requireActual<typeof nodeFs>('node:fs');
+
+const PUBLIC_API_ROOT = path.resolve(__dirname, '..', '..');
+
+const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete'] as const;
+
+type Method = (typeof HTTP_METHODS)[number];
+
+type YamlOperation = {
+	file: string;
+	method: Method;
+	operationId: string;
+	handlerPath: string;
+	requiredScope: string;
+};
+
+function walkYamlPaths(root: string): string[] {
+	const out: string[] = [];
+	for (const entry of readdirSync(root)) {
+		const full = path.join(root, entry);
+		const s = statSync(full);
+		if (s.isDirectory()) {
+			out.push(...walkYamlPaths(full));
+		} else if (entry.endsWith('.yml') && full.includes(`${path.sep}paths${path.sep}`)) {
+			out.push(full);
+		}
+	}
+	return out;
+}
+
+function collectYamlOperations(): YamlOperation[] {
+	const handlersRoot = path.join(PUBLIC_API_ROOT, 'v1', 'handlers');
+	const files = walkYamlPaths(handlersRoot);
+	const ops: YamlOperation[] = [];
+	for (const file of files) {
+		const doc = parseYaml(readFileSync(file, 'utf8')) as Record<string, unknown>;
+		for (const method of HTTP_METHODS) {
+			const op = doc[method] as Record<string, unknown> | undefined;
+			if (!op) continue;
+			const operationId = op['x-eov-operation-id'] as string | undefined;
+			const handlerPath = op['x-eov-operation-handler'] as string | undefined;
+			const requiredScope = op['x-required-scope'] as string | undefined;
+			if (!operationId || !handlerPath) continue;
+			ops.push({
+				file,
+				method,
+				operationId,
+				handlerPath,
+				requiredScope: requiredScope ?? '<missing>',
+			});
+		}
+	}
+	return ops;
+}
+
+function loadHandlerScope(handlerPath: string, operationId: string): ApiKeyScope | undefined {
+	const resolved = path.join(PUBLIC_API_ROOT, `${handlerPath}.ts`);
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	const mod = require(resolved) as Record<string, unknown[]>;
+	const middlewares = mod[operationId];
+	if (!Array.isArray(middlewares)) return undefined;
+	for (const mw of middlewares) {
+		if (typeof mw !== 'function') continue;
+		const scope = (mw as Partial<ScopeTaggedMiddleware>).__apiKeyScope;
+		if (scope) return scope;
+	}
+	return undefined;
+}
+
+describe('Public API scope parity', () => {
+	const yamlOps = collectYamlOperations();
+
+	test('every path YAML method declares x-required-scope', () => {
+		const missing = yamlOps.filter((op) => op.requiredScope === '<missing>');
+		expect(
+			missing.map((m) => `${path.relative(PUBLIC_API_ROOT, m.file)} ${m.method} ${m.operationId}`),
+		).toEqual([]);
+	});
+
+	test('every x-required-scope matches the handler middleware __apiKeyScope', () => {
+		const mismatches: string[] = [];
+		for (const op of yamlOps) {
+			if (op.requiredScope === '<missing>') continue;
+			const handlerScope = loadHandlerScope(op.handlerPath, op.operationId);
+			const expected = op.requiredScope === 'none' ? undefined : op.requiredScope;
+			if (handlerScope !== expected) {
+				mismatches.push(
+					`${op.operationId}: YAML says "${op.requiredScope}", handler tag is "${
+						handlerScope ?? 'none'
+					}"`,
+				);
+			}
+		}
+		expect(mismatches).toEqual([]);
+	});
+
+	test('every API key scope in API_KEY_RESOURCES is consumed by at least one endpoint', () => {
+		const consumed = new Set(
+			yamlOps.map((op) => op.requiredScope).filter((s) => s !== 'none' && s !== '<missing>'),
+		);
+		const declared = new Set<string>();
+		for (const [resource, operations] of Object.entries(API_KEY_RESOURCES)) {
+			for (const operation of operations) {
+				declared.add(`${resource}:${operation}`);
+			}
+		}
+		const orphans = [...declared].filter((scope) => !consumed.has(scope));
+		expect(orphans).toEqual([]);
+	});
+});

--- a/packages/cli/src/public-api/v1/__tests__/scope-parity.test.ts
+++ b/packages/cli/src/public-api/v1/__tests__/scope-parity.test.ts
@@ -1,60 +1,46 @@
+import RefParser from '@apidevtools/json-schema-ref-parser';
 import { API_KEY_RESOURCES, type ApiKeyScope } from '@n8n/permissions';
-import type * as nodeFs from 'node:fs';
 import path from 'node:path';
-import { parse as parseYaml } from 'yaml';
 
 import type { ScopeTaggedMiddleware } from '../shared/middlewares/global.middleware';
 
 jest.unmock('node:fs');
-const { readdirSync, readFileSync, statSync } = jest.requireActual<typeof nodeFs>('node:fs');
 
 const PUBLIC_API_ROOT = path.resolve(__dirname, '..', '..');
+const OPENAPI_SPEC_PATH = path.join(PUBLIC_API_ROOT, 'v1', 'openapi.yml');
 
 const HTTP_METHODS = ['get', 'post', 'put', 'patch', 'delete'] as const;
 
 type Method = (typeof HTTP_METHODS)[number];
 
-type YamlOperation = {
-	file: string;
+type Operation = {
+	pathStr: string;
 	method: Method;
 	operationId: string;
 	handlerPath: string;
 	requiredScope: string | null;
 };
 
-function walkYamlPaths(root: string): string[] {
-	const out: string[] = [];
-	for (const entry of readdirSync(root)) {
-		const full = path.join(root, entry);
-		const s = statSync(full);
-		if (s.isDirectory()) {
-			out.push(...walkYamlPaths(full));
-		} else if (entry.endsWith('.yml') && full.includes(`${path.sep}paths${path.sep}`)) {
-			out.push(full);
-		}
-	}
-	return out;
-}
+type RawOperation = {
+	'x-eov-operation-id'?: string;
+	'x-eov-operation-handler'?: string;
+	'x-required-scope'?: string;
+};
 
-function collectYamlOperations(): YamlOperation[] {
-	const handlersRoot = path.join(PUBLIC_API_ROOT, 'v1', 'handlers');
-	const files = walkYamlPaths(handlersRoot);
-	const ops: YamlOperation[] = [];
-	for (const file of files) {
-		const doc = parseYaml(readFileSync(file, 'utf8')) as Record<string, unknown>;
+async function loadOperations(): Promise<Operation[]> {
+	const spec = await RefParser.dereference(OPENAPI_SPEC_PATH);
+	const paths = (spec as { paths?: Record<string, Record<string, RawOperation>> }).paths ?? {};
+	const ops: Operation[] = [];
+	for (const [pathStr, methods] of Object.entries(paths)) {
 		for (const method of HTTP_METHODS) {
-			const op = doc[method] as Record<string, unknown> | undefined;
-			if (!op) continue;
-			const operationId = op['x-eov-operation-id'] as string | undefined;
-			const handlerPath = op['x-eov-operation-handler'] as string | undefined;
-			const requiredScope = op['x-required-scope'] as string | undefined;
-			if (!operationId || !handlerPath) continue;
+			const op = methods[method];
+			if (!op?.['x-eov-operation-id'] || !op?.['x-eov-operation-handler']) continue;
 			ops.push({
-				file,
+				pathStr,
 				method,
-				operationId,
-				handlerPath,
-				requiredScope: requiredScope ?? null,
+				operationId: op['x-eov-operation-id'],
+				handlerPath: op['x-eov-operation-handler'],
+				requiredScope: op['x-required-scope'] ?? null,
 			});
 		}
 	}
@@ -76,24 +62,26 @@ function loadHandlerScope(handlerPath: string, operationId: string): ApiKeyScope
 }
 
 describe('Public API scope parity', () => {
-	const yamlOps = collectYamlOperations();
+	let ops: Operation[];
 
-	test('every path YAML method declares x-required-scope', () => {
-		const missing = yamlOps.filter((op) => op.requiredScope === null);
-		expect(
-			missing.map((m) => `${path.relative(PUBLIC_API_ROOT, m.file)} ${m.method} ${m.operationId}`),
-		).toEqual([]);
+	beforeAll(async () => {
+		ops = await loadOperations();
+	});
+
+	test('every operation declares x-required-scope', () => {
+		const missing = ops.filter((op) => op.requiredScope === null);
+		expect(missing.map((m) => `${m.method.toUpperCase()} ${m.pathStr}`)).toEqual([]);
 	});
 
 	test('every x-required-scope matches the handler middleware __apiKeyScope', () => {
 		const mismatches: string[] = [];
-		for (const op of yamlOps) {
+		for (const op of ops) {
 			if (op.requiredScope === null) continue;
 			const handlerScope = loadHandlerScope(op.handlerPath, op.operationId);
 			const expected = op.requiredScope === 'none' ? undefined : op.requiredScope;
 			if (handlerScope !== expected) {
 				mismatches.push(
-					`${op.operationId}: YAML says "${op.requiredScope}", handler tag is "${
+					`${op.method.toUpperCase()} ${op.pathStr}: YAML says "${op.requiredScope}", handler tag is "${
 						handlerScope ?? 'none'
 					}"`,
 				);
@@ -104,7 +92,7 @@ describe('Public API scope parity', () => {
 
 	test('every API key scope in API_KEY_RESOURCES is consumed by at least one endpoint', () => {
 		const consumed = new Set(
-			yamlOps.map((op) => op.requiredScope).filter((s): s is string => s !== null && s !== 'none'),
+			ops.map((op) => op.requiredScope).filter((s): s is string => s !== null && s !== 'none'),
 		);
 		const declared = new Set<string>();
 		for (const [resource, operations] of Object.entries(API_KEY_RESOURCES)) {

--- a/packages/cli/src/public-api/v1/__tests__/scope-parity.test.ts
+++ b/packages/cli/src/public-api/v1/__tests__/scope-parity.test.ts
@@ -19,7 +19,7 @@ type YamlOperation = {
 	method: Method;
 	operationId: string;
 	handlerPath: string;
-	requiredScope: string;
+	requiredScope: string | null;
 };
 
 function walkYamlPaths(root: string): string[] {
@@ -54,7 +54,7 @@ function collectYamlOperations(): YamlOperation[] {
 				method,
 				operationId,
 				handlerPath,
-				requiredScope: requiredScope ?? '<missing>',
+				requiredScope: requiredScope ?? null,
 			});
 		}
 	}
@@ -79,7 +79,7 @@ describe('Public API scope parity', () => {
 	const yamlOps = collectYamlOperations();
 
 	test('every path YAML method declares x-required-scope', () => {
-		const missing = yamlOps.filter((op) => op.requiredScope === '<missing>');
+		const missing = yamlOps.filter((op) => op.requiredScope === null);
 		expect(
 			missing.map((m) => `${path.relative(PUBLIC_API_ROOT, m.file)} ${m.method} ${m.operationId}`),
 		).toEqual([]);
@@ -88,7 +88,7 @@ describe('Public API scope parity', () => {
 	test('every x-required-scope matches the handler middleware __apiKeyScope', () => {
 		const mismatches: string[] = [];
 		for (const op of yamlOps) {
-			if (op.requiredScope === '<missing>') continue;
+			if (op.requiredScope === null) continue;
 			const handlerScope = loadHandlerScope(op.handlerPath, op.operationId);
 			const expected = op.requiredScope === 'none' ? undefined : op.requiredScope;
 			if (handlerScope !== expected) {
@@ -104,7 +104,7 @@ describe('Public API scope parity', () => {
 
 	test('every API key scope in API_KEY_RESOURCES is consumed by at least one endpoint', () => {
 		const consumed = new Set(
-			yamlOps.map((op) => op.requiredScope).filter((s) => s !== 'none' && s !== '<missing>'),
+			yamlOps.map((op) => op.requiredScope).filter((s): s is string => s !== null && s !== 'none'),
 		);
 		const declared = new Set<string>();
 		for (const [resource, operations] of Object.entries(API_KEY_RESOURCES)) {

--- a/packages/cli/src/public-api/v1/handlers/audit/spec/paths/audit.yml
+++ b/packages/cli/src/public-api/v1/handlers/audit/spec/paths/audit.yml
@@ -1,5 +1,6 @@
 post:
   x-eov-operation-id: generateAudit
+  x-required-scope: securityAudit:generate
   x-eov-operation-handler: v1/handlers/audit/audit.handler
   tags:
     - Audit

--- a/packages/cli/src/public-api/v1/handlers/community-packages/spec/paths/community-packages.packageName.yml
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/spec/paths/community-packages.packageName.yml
@@ -1,5 +1,6 @@
 patch:
   x-eov-operation-id: updatePackage
+  x-required-scope: communityPackage:update
   x-eov-operation-handler: v1/handlers/community-packages/community-packages.handler
   tags:
     - CommunityPackage
@@ -46,6 +47,7 @@ patch:
     - ApiKeyAuth: []
 delete:
   x-eov-operation-id: uninstallPackage
+  x-required-scope: communityPackage:uninstall
   x-eov-operation-handler: v1/handlers/community-packages/community-packages.handler
   tags:
     - CommunityPackage

--- a/packages/cli/src/public-api/v1/handlers/community-packages/spec/paths/community-packages.yml
+++ b/packages/cli/src/public-api/v1/handlers/community-packages/spec/paths/community-packages.yml
@@ -1,5 +1,6 @@
 post:
   x-eov-operation-id: installPackage
+  x-required-scope: communityPackage:install
   x-eov-operation-handler: v1/handlers/community-packages/community-packages.handler
   tags:
     - CommunityPackage
@@ -27,6 +28,7 @@ post:
     - ApiKeyAuth: []
 get:
   x-eov-operation-id: getInstalledPackages
+  x-required-scope: communityPackage:list
   x-eov-operation-handler: v1/handlers/community-packages/community-packages.handler
   tags:
     - CommunityPackage

--- a/packages/cli/src/public-api/v1/handlers/credentials/spec/paths/credentials.id.test.yml
+++ b/packages/cli/src/public-api/v1/handlers/credentials/spec/paths/credentials.id.test.yml
@@ -1,5 +1,6 @@
 post:
   x-eov-operation-id: testCredential
+  x-required-scope: credential:read
   x-eov-operation-handler: v1/handlers/credentials/credentials.handler
   tags:
     - Credential

--- a/packages/cli/src/public-api/v1/handlers/credentials/spec/paths/credentials.id.transfer.yml
+++ b/packages/cli/src/public-api/v1/handlers/credentials/spec/paths/credentials.id.transfer.yml
@@ -1,5 +1,6 @@
 put:
   x-eov-operation-id: transferCredential
+  x-required-scope: credential:move
   x-eov-operation-handler: v1/handlers/credentials/credentials.handler
   tags:
     - Credential

--- a/packages/cli/src/public-api/v1/handlers/credentials/spec/paths/credentials.id.yml
+++ b/packages/cli/src/public-api/v1/handlers/credentials/spec/paths/credentials.id.yml
@@ -1,5 +1,6 @@
 get:
   x-eov-operation-id: getCredential
+  x-required-scope: credential:read
   x-eov-operation-handler: v1/handlers/credentials/credentials.handler
   tags:
     - Credential
@@ -28,6 +29,7 @@ get:
       $ref: '../../../../shared/spec/responses/notFound.yml'
 patch:
   x-eov-operation-id: updateCredential
+  x-required-scope: credential:update
   x-eov-operation-handler: v1/handlers/credentials/credentials.handler
   tags:
     - Credential
@@ -63,6 +65,7 @@ patch:
       $ref: '../../../../shared/spec/responses/notFound.yml'
 delete:
   x-eov-operation-id: deleteCredential
+  x-required-scope: credential:delete
   x-eov-operation-handler: v1/handlers/credentials/credentials.handler
   tags:
     - Credential

--- a/packages/cli/src/public-api/v1/handlers/credentials/spec/paths/credentials.schema.id.yml
+++ b/packages/cli/src/public-api/v1/handlers/credentials/spec/paths/credentials.schema.id.yml
@@ -1,5 +1,6 @@
 get:
   x-eov-operation-id: getCredentialType
+  x-required-scope: none
   x-eov-operation-handler: v1/handlers/credentials/credentials.handler
   tags:
     - Credential

--- a/packages/cli/src/public-api/v1/handlers/credentials/spec/paths/credentials.yml
+++ b/packages/cli/src/public-api/v1/handlers/credentials/spec/paths/credentials.yml
@@ -1,6 +1,7 @@
 get:
   operationId: getCredentials
   x-eov-operation-id: getCredentials
+  x-required-scope: credential:list
   x-eov-operation-handler: v1/handlers/credentials/credentials.handler
   tags:
     - Credential
@@ -21,6 +22,7 @@ get:
 post:
   operationId: createCredential
   x-eov-operation-id: createCredential
+  x-required-scope: credential:create
   x-eov-operation-handler: v1/handlers/credentials/credentials.handler
   tags:
     - Credential

--- a/packages/cli/src/public-api/v1/handlers/data-tables/spec/paths/data-tables.dataTableId.columns.columnId.yml
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/spec/paths/data-tables.dataTableId.columns.columnId.yml
@@ -1,5 +1,6 @@
 delete:
   x-eov-operation-id: deleteDataTableColumn
+  x-required-scope: dataTableColumn:delete
   x-eov-operation-handler: v1/handlers/data-tables/data-tables.columns.handler
   tags:
     - DataTable
@@ -21,6 +22,7 @@ delete:
 
 patch:
   x-eov-operation-id: updateDataTableColumn
+  x-required-scope: dataTableColumn:update
   x-eov-operation-handler: v1/handlers/data-tables/data-tables.columns.handler
   tags:
     - DataTable

--- a/packages/cli/src/public-api/v1/handlers/data-tables/spec/paths/data-tables.dataTableId.columns.yml
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/spec/paths/data-tables.dataTableId.columns.yml
@@ -1,5 +1,6 @@
 get:
   x-eov-operation-id: listDataTableColumns
+  x-required-scope: dataTableColumn:read
   x-eov-operation-handler: v1/handlers/data-tables/data-tables.columns.handler
   tags:
     - DataTable
@@ -26,6 +27,7 @@ get:
 
 post:
   x-eov-operation-id: createDataTableColumn
+  x-required-scope: dataTableColumn:create
   x-eov-operation-handler: v1/handlers/data-tables/data-tables.columns.handler
   tags:
     - DataTable

--- a/packages/cli/src/public-api/v1/handlers/data-tables/spec/paths/data-tables.dataTableId.rows.delete.yml
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/spec/paths/data-tables.dataTableId.rows.delete.yml
@@ -1,5 +1,6 @@
 delete:
   x-eov-operation-id: deleteDataTableRows
+  x-required-scope: dataTableRow:delete
   x-eov-operation-handler: v1/handlers/data-tables/data-tables.rows.handler
   tags:
     - DataTable

--- a/packages/cli/src/public-api/v1/handlers/data-tables/spec/paths/data-tables.dataTableId.rows.update.yml
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/spec/paths/data-tables.dataTableId.rows.update.yml
@@ -1,5 +1,6 @@
 patch:
   x-eov-operation-id: updateDataTableRows
+  x-required-scope: dataTableRow:update
   x-eov-operation-handler: v1/handlers/data-tables/data-tables.rows.handler
   tags:
     - DataTable

--- a/packages/cli/src/public-api/v1/handlers/data-tables/spec/paths/data-tables.dataTableId.rows.upsert.yml
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/spec/paths/data-tables.dataTableId.rows.upsert.yml
@@ -1,5 +1,6 @@
 post:
   x-eov-operation-id: upsertDataTableRow
+  x-required-scope: dataTableRow:upsert
   x-eov-operation-handler: v1/handlers/data-tables/data-tables.rows.handler
   tags:
     - DataTable

--- a/packages/cli/src/public-api/v1/handlers/data-tables/spec/paths/data-tables.dataTableId.rows.yml
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/spec/paths/data-tables.dataTableId.rows.yml
@@ -1,5 +1,6 @@
 get:
   x-eov-operation-id: getDataTableRows
+  x-required-scope: dataTableRow:read
   x-eov-operation-handler: v1/handlers/data-tables/data-tables.rows.handler
   tags:
     - DataTable
@@ -46,6 +47,7 @@ get:
 
 post:
   x-eov-operation-id: insertDataTableRows
+  x-required-scope: dataTableRow:create
   x-eov-operation-handler: v1/handlers/data-tables/data-tables.rows.handler
   tags:
     - DataTable

--- a/packages/cli/src/public-api/v1/handlers/data-tables/spec/paths/data-tables.dataTableId.yml
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/spec/paths/data-tables.dataTableId.yml
@@ -1,5 +1,6 @@
 get:
   x-eov-operation-id: getDataTable
+  x-required-scope: dataTable:read
   x-eov-operation-handler: v1/handlers/data-tables/data-tables.handler
   tags:
     - DataTable
@@ -24,6 +25,7 @@ get:
 
 patch:
   x-eov-operation-id: updateDataTable
+  x-required-scope: dataTable:update
   x-eov-operation-handler: v1/handlers/data-tables/data-tables.handler
   tags:
     - DataTable
@@ -60,6 +62,7 @@ patch:
 
 delete:
   x-eov-operation-id: deleteDataTable
+  x-required-scope: dataTable:delete
   x-eov-operation-handler: v1/handlers/data-tables/data-tables.handler
   tags:
     - DataTable

--- a/packages/cli/src/public-api/v1/handlers/data-tables/spec/paths/data-tables.yml
+++ b/packages/cli/src/public-api/v1/handlers/data-tables/spec/paths/data-tables.yml
@@ -1,5 +1,6 @@
 get:
   x-eov-operation-id: listDataTables
+  x-required-scope: dataTable:list
   x-eov-operation-handler: v1/handlers/data-tables/data-tables.handler
   tags:
     - DataTable
@@ -38,6 +39,7 @@ get:
 
 post:
   x-eov-operation-id: createDataTable
+  x-required-scope: dataTable:create
   x-eov-operation-handler: v1/handlers/data-tables/data-tables.handler
   tags:
     - DataTable

--- a/packages/cli/src/public-api/v1/handlers/discover/spec/paths/discover.yml
+++ b/packages/cli/src/public-api/v1/handlers/discover/spec/paths/discover.yml
@@ -1,5 +1,6 @@
 get:
   x-eov-operation-id: getDiscover
+  x-required-scope: none
   x-eov-operation-handler: v1/handlers/discover/discover.handler
   tags:
     - Discover

--- a/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.id.retry.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.id.retry.yml
@@ -1,5 +1,6 @@
 post:
   x-eov-operation-id: retryExecution
+  x-required-scope: execution:retry
   x-eov-operation-handler: v1/handlers/executions/executions.handler
   tags:
     - Execution

--- a/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.id.stop.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.id.stop.yml
@@ -1,5 +1,6 @@
 post:
   x-eov-operation-id: stopExecution
+  x-required-scope: execution:stop
   x-eov-operation-handler: v1/handlers/executions/executions.handler
   tags:
     - Execution

--- a/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.id.tags.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.id.tags.yml
@@ -1,5 +1,6 @@
 get:
   x-eov-operation-id: getExecutionTags
+  x-required-scope: executionTags:list
   x-eov-operation-handler: v1/handlers/executions/executions.handler
   tags:
     - Execution
@@ -20,6 +21,7 @@ get:
       $ref: '../../../../shared/spec/responses/notFound.yml'
 put:
   x-eov-operation-id: updateExecutionTags
+  x-required-scope: executionTags:update
   x-eov-operation-handler: v1/handlers/executions/executions.handler
   tags:
     - Execution

--- a/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.id.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.id.yml
@@ -1,5 +1,6 @@
 get:
   x-eov-operation-id: getExecution
+  x-required-scope: execution:read
   x-eov-operation-handler: v1/handlers/executions/executions.handler
   tags:
     - Execution
@@ -24,6 +25,7 @@ get:
       $ref: '../../../../shared/spec/responses/notFound.yml'
 delete:
   x-eov-operation-id: deleteExecution
+  x-required-scope: execution:delete
   x-eov-operation-handler: v1/handlers/executions/executions.handler
   tags:
     - Execution

--- a/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.stop.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.stop.yml
@@ -1,5 +1,6 @@
 post:
   x-eov-operation-id: stopManyExecutions
+  x-required-scope: execution:stop
   x-eov-operation-handler: v1/handlers/executions/executions.handler
   tags:
     - Execution

--- a/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.yml
+++ b/packages/cli/src/public-api/v1/handlers/executions/spec/paths/executions.yml
@@ -1,5 +1,6 @@
 get:
   x-eov-operation-id: getExecutions
+  x-required-scope: execution:list
   x-eov-operation-handler: v1/handlers/executions/executions.handler
   tags:
     - Execution

--- a/packages/cli/src/public-api/v1/handlers/folders/spec/paths/folders.folderId.yml
+++ b/packages/cli/src/public-api/v1/handlers/folders/spec/paths/folders.folderId.yml
@@ -1,5 +1,6 @@
 delete:
   x-eov-operation-id: deleteFolder
+  x-required-scope: folder:delete
   x-eov-operation-handler: v1/handlers/folders/folders.handler
   tags:
     - Folders
@@ -37,6 +38,7 @@ delete:
       $ref: '../../../../shared/spec/responses/notFound.yml'
 get:
   x-eov-operation-id: getFolder
+  x-required-scope: folder:read
   x-eov-operation-handler: v1/handlers/folders/folders.handler
   tags:
     - Folders
@@ -94,6 +96,7 @@ get:
       $ref: '../../../../shared/spec/responses/notFound.yml'
 patch:
   x-eov-operation-id: updateFolder
+  x-required-scope: folder:update
   x-eov-operation-handler: v1/handlers/folders/folders.handler
   tags:
     - Folders

--- a/packages/cli/src/public-api/v1/handlers/folders/spec/paths/folders.yml
+++ b/packages/cli/src/public-api/v1/handlers/folders/spec/paths/folders.yml
@@ -1,5 +1,6 @@
 post:
   x-eov-operation-id: createFolder
+  x-required-scope: folder:create
   x-eov-operation-handler: v1/handlers/folders/folders.handler
   tags:
     - Folders
@@ -36,6 +37,7 @@ post:
       $ref: '../../../../shared/spec/responses/notFound.yml'
 get:
   x-eov-operation-id: getFolders
+  x-required-scope: folder:list
   x-eov-operation-handler: v1/handlers/folders/folders.handler
   tags:
     - Folders

--- a/packages/cli/src/public-api/v1/handlers/insights/spec/paths/insights.yml
+++ b/packages/cli/src/public-api/v1/handlers/insights/spec/paths/insights.yml
@@ -1,5 +1,6 @@
 get:
   x-eov-operation-id: getInsightsSummary
+  x-required-scope: insights:read
   x-eov-operation-handler: v1/handlers/insights/insights.handler
   tags:
     - Insights

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/paths/n8n-packages.export.yml
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/paths/n8n-packages.export.yml
@@ -1,5 +1,6 @@
 post:
   x-eov-operation-id: exportWorkflows
+  x-required-scope: workflow:export
   x-eov-operation-handler: v1/handlers/n8n-packages/n8n-packages.handler
   tags:
     - N8nPackage

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/paths/n8n-packages.import.yml
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/paths/n8n-packages.import.yml
@@ -1,5 +1,6 @@
 post:
   x-eov-operation-id: importPackage
+  x-required-scope: workflow:import
   x-eov-operation-handler: v1/handlers/n8n-packages/n8n-packages.handler
   tags:
     - N8nPackage

--- a/packages/cli/src/public-api/v1/handlers/projects/spec/paths/projects.projectId.users.userId.yml
+++ b/packages/cli/src/public-api/v1/handlers/projects/spec/paths/projects.projectId.users.userId.yml
@@ -1,5 +1,6 @@
 delete:
   x-eov-operation-id: deleteUserFromProject
+  x-required-scope: project:update
   x-eov-operation-handler: v1/handlers/projects/projects.handler
   tags:
     - Projects
@@ -29,6 +30,7 @@ delete:
       $ref: '../../../../shared/spec/responses/notFound.yml'
 patch:
   x-eov-operation-id: changeUserRoleInProject
+  x-required-scope: project:update
   x-eov-operation-handler: v1/handlers/projects/projects.handler
   tags:
     - Projects

--- a/packages/cli/src/public-api/v1/handlers/projects/spec/paths/projects.projectId.users.yml
+++ b/packages/cli/src/public-api/v1/handlers/projects/spec/paths/projects.projectId.users.yml
@@ -1,5 +1,6 @@
 get:
   x-eov-operation-id: getProjectUsers
+  x-required-scope: user:list
   x-eov-operation-handler: v1/handlers/projects/projects.handler
   tags:
     - Projects
@@ -29,6 +30,7 @@ get:
       $ref: '../../../../shared/spec/responses/notFound.yml'
 post:
   x-eov-operation-id: addUsersToProject
+  x-required-scope: project:update
   x-eov-operation-handler: v1/handlers/projects/projects.handler
   tags:
     - Projects

--- a/packages/cli/src/public-api/v1/handlers/projects/spec/paths/projects.projectId.yml
+++ b/packages/cli/src/public-api/v1/handlers/projects/spec/paths/projects.projectId.yml
@@ -1,5 +1,6 @@
 delete:
   x-eov-operation-id: deleteProject
+  x-required-scope: project:delete
   x-eov-operation-handler: v1/handlers/projects/projects.handler
   tags:
     - Projects
@@ -23,6 +24,7 @@ delete:
       $ref: '../../../../shared/spec/responses/notFound.yml'
 put:
   x-eov-operation-id: updateProject
+  x-required-scope: project:update
   x-eov-operation-handler: v1/handlers/projects/projects.handler
   tags:
     - Projects

--- a/packages/cli/src/public-api/v1/handlers/projects/spec/paths/projects.yml
+++ b/packages/cli/src/public-api/v1/handlers/projects/spec/paths/projects.yml
@@ -1,5 +1,6 @@
 post:
   x-eov-operation-id: createProject
+  x-required-scope: project:create
   x-eov-operation-handler: v1/handlers/projects/projects.handler
   tags:
     - Projects
@@ -21,6 +22,7 @@ post:
       $ref: '../../../../shared/spec/responses/unauthorized.yml'
 get:
   x-eov-operation-id: getProjects
+  x-required-scope: project:list
   x-eov-operation-handler: v1/handlers/projects/projects.handler
   tags:
     - Projects

--- a/packages/cli/src/public-api/v1/handlers/source-control/spec/paths/sourceControl.yml
+++ b/packages/cli/src/public-api/v1/handlers/source-control/spec/paths/sourceControl.yml
@@ -1,5 +1,6 @@
 post:
   x-eov-operation-id: pull
+  x-required-scope: sourceControl:pull
   x-eov-operation-handler: v1/handlers/source-control/source-control.handler
   tags:
     - SourceControl

--- a/packages/cli/src/public-api/v1/handlers/tags/spec/paths/tags.id.yml
+++ b/packages/cli/src/public-api/v1/handlers/tags/spec/paths/tags.id.yml
@@ -1,5 +1,6 @@
 get:
   x-eov-operation-id: getTag
+  x-required-scope: tag:read
   x-eov-operation-handler: v1/handlers/tags/tags.handler
   tags:
     - Tags
@@ -20,6 +21,7 @@ get:
       $ref: '../../../../shared/spec/responses/notFound.yml'
 delete:
   x-eov-operation-id: deleteTag
+  x-required-scope: tag:delete
   x-eov-operation-handler: v1/handlers/tags/tags.handler
   tags:
     - Tags
@@ -42,6 +44,7 @@ delete:
       $ref: '../../../../shared/spec/responses/notFound.yml'
 put:
   x-eov-operation-id: updateTag
+  x-required-scope: tag:update
   x-eov-operation-handler: v1/handlers/tags/tags.handler
   tags:
     - Tags

--- a/packages/cli/src/public-api/v1/handlers/tags/spec/paths/tags.yml
+++ b/packages/cli/src/public-api/v1/handlers/tags/spec/paths/tags.yml
@@ -1,5 +1,6 @@
 post:
   x-eov-operation-id: createTag
+  x-required-scope: tag:create
   x-eov-operation-handler: v1/handlers/tags/tags.handler
   tags:
     - Tags
@@ -27,6 +28,7 @@ post:
       $ref: '../../../../shared/spec/responses/unauthorized.yml'
 get:
   x-eov-operation-id: getTags
+  x-required-scope: tag:list
   x-eov-operation-handler: v1/handlers/tags/tags.handler
   tags:
     - Tags

--- a/packages/cli/src/public-api/v1/handlers/users/spec/paths/users.id.role.yml
+++ b/packages/cli/src/public-api/v1/handlers/users/spec/paths/users.id.role.yml
@@ -1,5 +1,6 @@
 patch:
   x-eov-operation-id: changeRole
+  x-required-scope: user:changeRole
   x-eov-operation-handler: v1/handlers/users/users.handler.ee
   tags:
     - User

--- a/packages/cli/src/public-api/v1/handlers/users/spec/paths/users.id.yml
+++ b/packages/cli/src/public-api/v1/handlers/users/spec/paths/users.id.yml
@@ -1,5 +1,6 @@
 get:
   x-eov-operation-id: getUser
+  x-required-scope: user:read
   x-eov-operation-handler: v1/handlers/users/users.handler.ee
   tags:
     - User
@@ -19,6 +20,7 @@ get:
       $ref: '../../../../shared/spec/responses/unauthorized.yml'
 delete:
   x-eov-operation-id: deleteUser
+  x-required-scope: user:delete
   x-eov-operation-handler: v1/handlers/users/users.handler.ee
   tags:
     - User

--- a/packages/cli/src/public-api/v1/handlers/users/spec/paths/users.yml
+++ b/packages/cli/src/public-api/v1/handlers/users/spec/paths/users.yml
@@ -1,5 +1,6 @@
 get:
   x-eov-operation-id: getUsers
+  x-required-scope: user:list
   x-eov-operation-handler: v1/handlers/users/users.handler.ee
   tags:
     - User
@@ -29,6 +30,7 @@ get:
       $ref: '../../../../shared/spec/responses/unauthorized.yml'
 post:
   x-eov-operation-id: createUser
+  x-required-scope: user:create
   x-eov-operation-handler: v1/handlers/users/users.handler.ee
   tags:
     - User

--- a/packages/cli/src/public-api/v1/handlers/variables/spec/paths/variables.id.yml
+++ b/packages/cli/src/public-api/v1/handlers/variables/spec/paths/variables.id.yml
@@ -1,5 +1,6 @@
 delete:
   x-eov-operation-id: deleteVariable
+  x-required-scope: variable:delete
   x-eov-operation-handler: v1/handlers/variables/variables.handler
   tags:
     - Variables
@@ -17,6 +18,7 @@ delete:
 
 put:
   x-eov-operation-id: updateVariable
+  x-required-scope: variable:update
   x-eov-operation-handler: v1/handlers/variables/variables.handler
   tags:
     - Variables

--- a/packages/cli/src/public-api/v1/handlers/variables/spec/paths/variables.yml
+++ b/packages/cli/src/public-api/v1/handlers/variables/spec/paths/variables.yml
@@ -1,5 +1,6 @@
 post:
   x-eov-operation-id: createVariable
+  x-required-scope: variable:create
   x-eov-operation-handler: v1/handlers/variables/variables.handler
   tags:
     - Variables
@@ -21,6 +22,7 @@ post:
       $ref: '../../../../shared/spec/responses/unauthorized.yml'
 get:
   x-eov-operation-id: getVariables
+  x-required-scope: variable:list
   x-eov-operation-handler: v1/handlers/variables/variables.handler
   tags:
     - Variables

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.activate.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.activate.yml
@@ -1,5 +1,6 @@
 post:
   x-eov-operation-id: activateWorkflow
+  x-required-scope: workflow:activate
   x-eov-operation-handler: v1/handlers/workflows/workflows.handler
   tags:
     - Workflow

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.archive.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.archive.yml
@@ -1,5 +1,6 @@
 post:
   x-eov-operation-id: archiveWorkflow
+  x-required-scope: workflow:delete
   x-eov-operation-handler: v1/handlers/workflows/workflows.handler
   tags:
     - Workflow

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.deactivate.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.deactivate.yml
@@ -1,5 +1,6 @@
 post:
   x-eov-operation-id: deactivateWorkflow
+  x-required-scope: workflow:deactivate
   x-eov-operation-handler: v1/handlers/workflows/workflows.handler
   tags:
     - Workflow

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.tags.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.tags.yml
@@ -1,5 +1,6 @@
 get:
   x-eov-operation-id: getWorkflowTags
+  x-required-scope: workflowTags:list
   x-eov-operation-handler: v1/handlers/workflows/workflows.handler
   tags:
     - Workflow
@@ -22,6 +23,7 @@ get:
       $ref: '../../../../shared/spec/responses/notFound.yml'
 put:
   x-eov-operation-id: updateWorkflowTags
+  x-required-scope: workflowTags:update
   x-eov-operation-handler: v1/handlers/workflows/workflows.handler
   tags:
     - Workflow
@@ -34,7 +36,7 @@ put:
     content:
       application/json:
         schema:
-            $ref: '../schemas/tagIds.yml'
+          $ref: '../schemas/tagIds.yml'
     required: true
   responses:
     '200':

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.transfer.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.transfer.yml
@@ -1,5 +1,6 @@
 put:
   x-eov-operation-id: transferWorkflow
+  x-required-scope: workflow:move
   x-eov-operation-handler: v1/handlers/workflows/workflows.handler
   tags:
     - Workflow

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.unarchive.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.unarchive.yml
@@ -1,5 +1,6 @@
 post:
   x-eov-operation-id: unarchiveWorkflow
+  x-required-scope: workflow:delete
   x-eov-operation-handler: v1/handlers/workflows/workflows.handler
   tags:
     - Workflow

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.versionId.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.versionId.yml
@@ -1,5 +1,6 @@
 get:
   x-eov-operation-id: getWorkflowVersion
+  x-required-scope: workflow:read
   x-eov-operation-handler: v1/handlers/workflows/workflows.handler
   tags:
     - Workflow

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.id.yml
@@ -1,5 +1,6 @@
 get:
   x-eov-operation-id: getWorkflow
+  x-required-scope: workflow:read
   x-eov-operation-handler: v1/handlers/workflows/workflows.handler
   tags:
     - Workflow
@@ -27,6 +28,7 @@ get:
       $ref: '../../../../shared/spec/responses/notFound.yml'
 delete:
   x-eov-operation-id: deleteWorkflow
+  x-required-scope: workflow:delete
   x-eov-operation-handler: v1/handlers/workflows/workflows.handler
   tags:
     - Workflow
@@ -47,6 +49,7 @@ delete:
       $ref: '../../../../shared/spec/responses/notFound.yml'
 put:
   x-eov-operation-id: updateWorkflow
+  x-required-scope: workflow:update
   x-eov-operation-handler: v1/handlers/workflows/workflows.handler
   tags:
     - Workflow

--- a/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.yml
+++ b/packages/cli/src/public-api/v1/handlers/workflows/spec/paths/workflows.yml
@@ -1,5 +1,6 @@
 post:
   x-eov-operation-id: createWorkflow
+  x-required-scope: workflow:create
   x-eov-operation-handler: v1/handlers/workflows/workflows.handler
   tags:
     - Workflow
@@ -29,6 +30,7 @@ post:
       $ref: '../../../../shared/spec/responses/notFound.yml'
 get:
   x-eov-operation-id: getWorkflows
+  x-required-scope: workflow:list
   x-eov-operation-handler: v1/handlers/workflows/workflows.handler
   tags:
     - Workflow


### PR DESCRIPTION
## Summary

Prevents IAM-696-class bugs (an API key scope exposed in the picker with no public endpoint to back it). Stacks on top of #32223.

- Adds `x-required-scope` to every `/api/v1` path YAML so the OpenAPI spec self-documents the required API-key scope per endpoint (including `none` for unauthenticated-shape endpoints like `GET /credentials/schema/{id}` and `GET /discover`).
- Adds a unit test (`scope-parity.test.ts`) asserting three invariants:
  1. Every YAML method declares `x-required-scope`.
  2. The YAML scope matches the `__apiKeyScope` tag attached at runtime by `publicApiScope(...)` / `apiKeyHasScopeWithGlobalScopeFallback(...)` — catches drift between spec and middleware.
  3. Every value in `API_KEY_RESOURCES` is consumed by at least one public endpoint. This is the structural fix for IAM-696: future scope additions without an endpoint fail CI.
- The orphan check uncovered one pre-existing case: `execution:get` was declared in `API_KEY_RESOURCES.execution` but no handler used it. Removed it so the parity test reflects reality.

## How to test

```
cd packages/cli
pnpm test src/public-api/v1/__tests__/scope-parity.test.ts
```

Smoke test the regression guard locally by either re-adding `'user:enforceMfa'` to `OWNER_API_KEY_SCOPES` + `API_KEY_RESOURCES.user`, or re-adding `'get'` to `API_KEY_RESOURCES.execution` — the third test should fail with the orphan listed.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-696/userenforcemfa-api-scope-is-exposed-publicly-but-has-no-public

Stacked on #32223 — review/merge that first.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32231">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

