### PR TITLE
fix(editor): Truncate long API key labels in settings table

### DIFF
--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyLabelCell.vue
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyLabelCell.vue
@@ -1,0 +1,66 @@
+<script lang="ts" setup>
+import { onBeforeUnmount, onMounted, ref } from 'vue';
+import { N8nText, N8nTooltip } from '@n8n/design-system';
+
+defineProps<{
+	label: string;
+	apiKey: string;
+}>();
+
+const labelEl = ref<HTMLElement | null>(null);
+const isOverflowing = ref(false);
+
+let observer: ResizeObserver | null = null;
+
+const update = () => {
+	const el = labelEl.value;
+	if (!el) return;
+	isOverflowing.value = el.scrollWidth > el.clientWidth;
+};
+
+onMounted(() => {
+	update();
+	if (labelEl.value && typeof ResizeObserver !== 'undefined') {
+		observer = new ResizeObserver(update);
+		observer.observe(labelEl.value);
+	}
+});
+
+onBeforeUnmount(() => {
+	observer?.disconnect();
+});
+</script>
+
+<template>
+	<div :class="$style.cell">
+		<N8nTooltip :content="label" placement="top" :show-after="500" :disabled="!isOverflowing">
+			<span ref="labelEl" :class="$style.label">
+				<N8nText bold>{{ label }}</N8nText>
+			</span>
+		</N8nTooltip>
+		<N8nText size="small" color="text-light" :class="$style.redacted">
+			{{ apiKey }}
+		</N8nText>
+	</div>
+</template>
+
+<style lang="scss" module>
+.cell {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--5xs);
+	min-width: 0;
+}
+
+.label {
+	display: block;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	min-width: 0;
+}
+
+.redacted {
+	font-family: var(--font-family--monospace);
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyLabelCell.vue
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyLabelCell.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
-import { onBeforeUnmount, onMounted, ref } from 'vue';
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue';
 import { N8nText, N8nTooltip } from '@n8n/design-system';
 
-defineProps<{
+const props = defineProps<{
 	label: string;
 	apiKey: string;
 }>();
@@ -25,6 +25,8 @@ onMounted(() => {
 		observer.observe(labelEl.value);
 	}
 });
+
+watch(() => props.label, update, { flush: 'post' });
 
 onBeforeUnmount(() => {
 	observer?.disconnect();

--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyLabelCell.vue
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyLabelCell.vue
@@ -20,7 +20,7 @@ const update = () => {
 
 onMounted(() => {
 	update();
-	if (labelEl.value && typeof ResizeObserver !== 'undefined') {
+	if (labelEl.value) {
 		observer = new ResizeObserver(update);
 		observer.observe(labelEl.value);
 	}
@@ -33,7 +33,12 @@ onBeforeUnmount(() => {
 
 <template>
 	<div :class="$style.cell">
-		<N8nTooltip :content="label" placement="top" :show-after="500" :disabled="!isOverflowing">
+		<N8nTooltip
+			:content="label"
+			:show-after="500"
+			:disabled="!isOverflowing"
+			:content-class="$style.tooltip"
+		>
 			<span ref="labelEl" :class="$style.label">
 				<N8nText bold>{{ label }}</N8nText>
 			</span>
@@ -62,5 +67,10 @@ onBeforeUnmount(() => {
 
 .redacted {
 	font-family: var(--font-family--monospace);
+}
+
+:global(.n8n-tooltip).tooltip {
+	max-width: none;
+	white-space: nowrap;
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyTable.vue
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyTable.vue
@@ -6,6 +6,7 @@ import type { ApiKey } from '@n8n/api-types';
 import type { TableHeader, TableOptions } from '@n8n/design-system/components/N8nDataTableServer';
 import { N8nButton, N8nDataTableServer, N8nText } from '@n8n/design-system';
 
+import ApiKeyLabelCell from './ApiKeyLabelCell.vue';
 import ApiKeyOwnerCell from './ApiKeyOwnerCell.vue';
 import ApiKeyScopesCell from './ApiKeyScopesCell.vue';
 
@@ -55,7 +56,7 @@ const rows = computed(() => props.apiKeys);
 // `resize: false` everywhere — these columns are fixed-shape and the resizer
 // handle otherwise highlights on every header hover.
 const headers = ref<Array<TableHeader<ApiKey>>>([
-	{ title: i18n.baseText('settings.api.columns.name'), key: 'label', resize: false },
+	{ title: i18n.baseText('settings.api.columns.name'), key: 'label', width: 280, resize: false },
 	{
 		title: i18n.baseText('settings.api.columns.owner'),
 		key: 'owner',
@@ -100,12 +101,7 @@ const headers = ref<Array<TableHeader<ApiKey>>>([
 			@click:row="onRowClick"
 		>
 			<template #[`item.label`]="{ item }">
-				<div :class="$style.name">
-					<N8nText bold>{{ item.label }}</N8nText>
-					<N8nText size="small" color="text-light" :class="$style.redacted">
-						{{ item.apiKey }}
-					</N8nText>
-				</div>
+				<ApiKeyLabelCell :label="item.label" :api-key="item.apiKey" />
 			</template>
 			<template #[`item.owner`]="{ item }">
 				<ApiKeyOwnerCell v-if="item.owner" :owner="item.owner" :is-current-user="isOwn(item)" />
@@ -145,17 +141,6 @@ const headers = ref<Array<TableHeader<ApiKey>>>([
 </template>
 
 <style lang="scss" module>
-.name {
-	display: flex;
-	flex-direction: column;
-	gap: var(--spacing--5xs);
-	min-width: 0;
-}
-
-.redacted {
-	font-family: var(--font-family--monospace);
-}
-
 .rowActions {
 	display: flex;
 	gap: var(--spacing--2xs);


### PR DESCRIPTION
## Summary

The Name column in the API keys settings table renders inconsistent row heights when labels wrap across multiple lines. This sets the Name column to a fixed 280px width, truncates the label with an ellipsis, and shows the full label in a tooltip on hover.

The tooltip is only enabled when the label actually overflows the column. Each row tracks its own overflow state with a `ResizeObserver`, so the tooltip turns on/off as the viewport changes.

The masked API key text below the label is short by design and is left as-is.

## How to test

1. Go to **Settings → API**.
2. Create API keys with a mix of short and long labels (try a 60+ character label such as `Flood The Youtube | admin@n8n.io`).
3. Confirm rows are uniformly tall regardless of label length.
4. Hover a long label and verify the full text appears in a tooltip after a short delay.
5. Hover a short label and verify no tooltip appears.
6. Resize the window narrower so previously-fitting labels start to clip; the tooltip should turn on for the newly-clipped rows. Widen it again and the tooltip should turn off.

## Demo

<img width="800" height="439" alt="CleanShot 2026-06-12 at 09 05 12" src="https://github.com/user-attachments/assets/bd055f48-b350-4f36-b121-49e5379ce06d" />

## Related Linear tickets, Github issues, and Community forum posts

<!-- add Linear ticket link if available -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32232">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

