### PR TITLE
feat(core): Reconcile publication records to the desired version (no-changelog)

### DIFF
--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-applier.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-applier.test.ts
@@ -99,7 +99,7 @@ describe('WorkflowPublicationApplier', () => {
 		workflowPublishedVersionRepository.setPublishedVersion.mockResolvedValue(undefined);
 		workflowHistoryRepository.findOneBy.mockResolvedValue(newVersion);
 		workflowTriggerActivator.getEnabledTriggerNodes.mockReturnValue([]);
-		workflowTriggerActivator.getUnregisteredLiveTriggerNodeIds.mockReturnValue(new Set());
+		workflowTriggerActivator.getUnregisteredNonWebhookTriggerNodeIds.mockReturnValue(new Set());
 		workflowTriggerActivator.activate.mockResolvedValue(undefined);
 		workflowTriggerActivator.deactivate.mockResolvedValue(undefined);
 		workflowTriggerActivator.updateTriggerCount.mockResolvedValue(undefined);
@@ -171,17 +171,19 @@ describe('WorkflowPublicationApplier', () => {
 		);
 	});
 
-	test('reconciles by registering desired live triggers missing from memory', async () => {
+	test('reconciles by registering desired non-webhook triggers missing from memory', async () => {
 		// Same version on both sides: a pure version diff is empty, but a live
 		// trigger is not actually registered, so it must be re-added.
 		const trigger = triggerNode('a');
 		setTriggerSets([trigger], [{ ...trigger }]);
-		workflowTriggerActivator.getUnregisteredLiveTriggerNodeIds.mockReturnValue(new Set(['a']));
+		workflowTriggerActivator.getUnregisteredNonWebhookTriggerNodeIds.mockReturnValue(
+			new Set(['a']),
+		);
 
 		const result = await applier.apply(makeRecord());
 
 		expect(result).toEqual({ type: 'completed' });
-		expect(workflowTriggerActivator.getUnregisteredLiveTriggerNodeIds).toHaveBeenCalledWith(
+		expect(workflowTriggerActivator.getUnregisteredNonWebhookTriggerNodeIds).toHaveBeenCalledWith(
 			'wf-1',
 			[trigger],
 		);
@@ -193,10 +195,10 @@ describe('WorkflowPublicationApplier', () => {
 		);
 	});
 
-	test('is a no-op when the version is unchanged and all live triggers are registered', async () => {
+	test('is a no-op when the version is unchanged and all non-webhook triggers are registered', async () => {
 		const trigger = triggerNode('a');
 		setTriggerSets([trigger], [{ ...trigger }]);
-		workflowTriggerActivator.getUnregisteredLiveTriggerNodeIds.mockReturnValue(new Set());
+		workflowTriggerActivator.getUnregisteredNonWebhookTriggerNodeIds.mockReturnValue(new Set());
 
 		const result = await applier.apply(makeRecord());
 

--- a/packages/cli/src/workflows/publication/__tests__/workflow-publication-applier.test.ts
+++ b/packages/cli/src/workflows/publication/__tests__/workflow-publication-applier.test.ts
@@ -99,6 +99,7 @@ describe('WorkflowPublicationApplier', () => {
 		workflowPublishedVersionRepository.setPublishedVersion.mockResolvedValue(undefined);
 		workflowHistoryRepository.findOneBy.mockResolvedValue(newVersion);
 		workflowTriggerActivator.getEnabledTriggerNodes.mockReturnValue([]);
+		workflowTriggerActivator.getUnregisteredLiveTriggerNodeIds.mockReturnValue(new Set());
 		workflowTriggerActivator.activate.mockResolvedValue(undefined);
 		workflowTriggerActivator.deactivate.mockResolvedValue(undefined);
 		workflowTriggerActivator.updateTriggerCount.mockResolvedValue(undefined);
@@ -164,6 +165,44 @@ describe('WorkflowPublicationApplier', () => {
 			newVersion,
 			new Set(['b']),
 		);
+		expect(workflowPublishedVersionRepository.setPublishedVersion).toHaveBeenCalledWith(
+			'wf-1',
+			'v-2',
+		);
+	});
+
+	test('reconciles by registering desired live triggers missing from memory', async () => {
+		// Same version on both sides: a pure version diff is empty, but a live
+		// trigger is not actually registered, so it must be re-added.
+		const trigger = triggerNode('a');
+		setTriggerSets([trigger], [{ ...trigger }]);
+		workflowTriggerActivator.getUnregisteredLiveTriggerNodeIds.mockReturnValue(new Set(['a']));
+
+		const result = await applier.apply(makeRecord());
+
+		expect(result).toEqual({ type: 'completed' });
+		expect(workflowTriggerActivator.getUnregisteredLiveTriggerNodeIds).toHaveBeenCalledWith(
+			'wf-1',
+			[trigger],
+		);
+		expect(workflowTriggerActivator.deactivate).not.toHaveBeenCalled();
+		expect(workflowTriggerActivator.activate).toHaveBeenCalledWith(
+			expect.objectContaining({ id: 'wf-1' }),
+			newVersion,
+			new Set(['a']),
+		);
+	});
+
+	test('is a no-op when the version is unchanged and all live triggers are registered', async () => {
+		const trigger = triggerNode('a');
+		setTriggerSets([trigger], [{ ...trigger }]);
+		workflowTriggerActivator.getUnregisteredLiveTriggerNodeIds.mockReturnValue(new Set());
+
+		const result = await applier.apply(makeRecord());
+
+		expect(result).toEqual({ type: 'completed' });
+		expect(workflowTriggerActivator.activate).not.toHaveBeenCalled();
+		expect(workflowTriggerActivator.deactivate).not.toHaveBeenCalled();
 		expect(workflowPublishedVersionRepository.setPublishedVersion).toHaveBeenCalledWith(
 			'wf-1',
 			'v-2',

--- a/packages/cli/src/workflows/publication/workflow-publication-applier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-applier.ts
@@ -63,10 +63,20 @@ export class WorkflowPublicationApplier {
 
 		if (!newVersion) return { type: 'version-missing' };
 
-		const { toAdd, toRemove } = computeTriggerDiff(
-			this.workflowTriggerActivator.getEnabledTriggerNodes(oldVersion),
-			this.workflowTriggerActivator.getEnabledTriggerNodes(newVersion),
+		const oldTriggerNodes = this.workflowTriggerActivator.getEnabledTriggerNodes(oldVersion);
+		const desiredTriggerNodes = this.workflowTriggerActivator.getEnabledTriggerNodes(newVersion);
+
+		const { toAdd, toRemove } = computeTriggerDiff(oldTriggerNodes, desiredTriggerNodes);
+
+		// A record means "reconcile to this version", not "apply edge old→new", so
+		// augment the version diff with actual local state: re-enqueueing the same
+		// version (startup, retry, crash recovery) must re-register the desired live
+		// triggers that aren't actually running, which a pure version diff misses.
+		const unregistered = this.workflowTriggerActivator.getUnregisteredLiveTriggerNodeIds(
+			record.workflowId,
+			desiredTriggerNodes,
 		);
+		for (const nodeId of unregistered) toAdd.add(nodeId);
 
 		// No trigger changed: advance the published version and finish. Unchanged
 		// triggers keep running and re-read the new version on their next fire.

--- a/packages/cli/src/workflows/publication/workflow-publication-applier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-applier.ts
@@ -70,9 +70,10 @@ export class WorkflowPublicationApplier {
 
 		// A record means "reconcile to this version", not "apply edge old→new", so
 		// augment the version diff with actual local state: re-enqueueing the same
-		// version (startup, retry, crash recovery) must re-register the desired live
-		// triggers that aren't actually running, which a pure version diff misses.
-		const unregistered = this.workflowTriggerActivator.getUnregisteredLiveTriggerNodeIds(
+		// version (startup, retry, crash recovery) must re-register the desired
+		// non-webhook triggers that aren't actually running, which a pure version
+		// diff misses.
+		const unregistered = this.workflowTriggerActivator.getUnregisteredNonWebhookTriggerNodeIds(
 			record.workflowId,
 			desiredTriggerNodes,
 		);

--- a/packages/cli/src/workflows/publication/workflow-publication-applier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-applier.ts
@@ -14,33 +14,13 @@ import { computeTriggerDiff } from '@/workflows/publication/trigger-diff';
 import { WorkflowTriggerActivator } from '@/workflows/triggers/workflow-trigger-activator';
 
 /**
- * Applies a single workflow publication outbox record by reconciling the
- * workflow's triggers to match the version being published. It computes a
- * trigger-level diff between the currently published version and the new version
- * and applies only the necessary operations: removing deleted triggers, adding
- * new ones, and re-applying modified ones (remove-then-add) while leaving
- * unchanged triggers running.
- *
- * This is the only class that knows the remove → advance published version → add
- * ordering invariant, and the only one that touches `workflow_published_version`.
- * It writes no outbox statuses; instead it returns a {@link PublicationResult}
- * for {@link PublicationStatusReporter} to turn into terminal state.
- *
- * The caller must uphold these invariants for `apply` to behave correctly:
- *
- * - **Serialized per workflow.** Two concurrent `apply` calls for the same
- *   workflow would race on the published version and on trigger registration,
- *   leaving the in-memory triggers inconsistent with `workflow_published_version`.
- *   The outbox claim guarantees this: a workflow with an in-progress record is
- *   never claimed again, and records are processed in FIFO (enqueue) order.
- * - **Runs on the instance that owns trigger execution (the leader).**
- *   (De)activation mutates in-memory webhook/poll registrations, so it must run
- *   where those triggers actually fire. The consumer only polls on the leader.
- * - **The currently registered triggers match the published version.** The diff
- *   is computed against `oldVersion` (= the row in `workflow_published_version`)
- *   and the remove step deregisters from it, so the triggers running in memory
- *   must correspond to that version; otherwise the wrong triggers are
- *   (de)registered.
+ * Reconciles a workflow's triggers to a published version, one outbox record at
+ * a time. This is the only class that knows the remove → advance published
+ * version → add ordering invariant, and the only one that touches
+ * `workflow_published_version`. It writes no outbox statuses; instead each
+ * {@link WorkflowPublicationApplier.apply} call returns a
+ * {@link PublicationResult} for {@link PublicationStatusReporter} to turn into
+ * terminal state.
  */
 @Service()
 export class WorkflowPublicationApplier {
@@ -51,6 +31,31 @@ export class WorkflowPublicationApplier {
 		private readonly workflowTriggerActivator: WorkflowTriggerActivator,
 	) {}
 
+	/**
+	 * Reconciles the workflow's triggers to the version requested by `record`. It
+	 * computes a trigger-level diff between the currently published version and the
+	 * requested version, augments it with any desired non-webhook trigger that is
+	 * missing locally, and applies only the necessary operations: removing deleted
+	 * triggers, adding new ones, and re-applying modified ones (remove-then-add)
+	 * while leaving unchanged triggers running. The published version is advanced
+	 * between the remove and add steps.
+	 *
+	 * The caller must uphold these invariants for `apply` to behave correctly:
+	 *
+	 * - **Serialized per workflow.** Two concurrent `apply` calls for the same
+	 *   workflow would race on the published version and on trigger registration,
+	 *   leaving the in-memory triggers inconsistent with `workflow_published_version`.
+	 *   The outbox claim guarantees this: a workflow with an in-progress record is
+	 *   never claimed again, and records are processed in FIFO (enqueue) order.
+	 * - **Runs on the instance that owns trigger execution (the leader).**
+	 *   (De)activation mutates in-memory webhook/poll registrations, so it must run
+	 *   where those triggers actually fire. The consumer only polls on the leader.
+	 * - **The currently registered triggers match the published version.** The diff
+	 *   is computed against `oldVersion` (= the row in `workflow_published_version`)
+	 *   and the remove step deregisters from it, so the triggers running in memory
+	 *   must correspond to that version; otherwise the wrong triggers are
+	 *   (de)registered.
+	 */
 	async apply(record: WorkflowPublicationOutbox): Promise<PublicationResult> {
 		const { workflow, oldVersion, newVersion } = await this.resolveVersions(record);
 

--- a/packages/cli/src/workflows/publication/workflow-publication-applier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-applier.ts
@@ -68,11 +68,9 @@ export class WorkflowPublicationApplier {
 
 		const { toAdd, toRemove } = computeTriggerDiff(oldTriggerNodes, desiredTriggerNodes);
 
-		// A record means "reconcile to this version", not "apply edge old→new", so
-		// augment the version diff with actual local state: re-enqueueing the same
-		// version (startup, retry, crash recovery) must re-register the desired
-		// non-webhook triggers that aren't actually running, which a pure version
-		// diff misses.
+		// We also register triggers that are in our desired state that aren't
+		// present locally, even if they aren't in this version diff. This is
+		// necessary for startup/retry/crash recovery.
 		this.workflowTriggerActivator
 			.getUnregisteredNonWebhookTriggerNodeIds(record.workflowId, desiredTriggerNodes)
 			.forEach((nodeId) => toAdd.add(nodeId));

--- a/packages/cli/src/workflows/publication/workflow-publication-applier.ts
+++ b/packages/cli/src/workflows/publication/workflow-publication-applier.ts
@@ -73,11 +73,9 @@ export class WorkflowPublicationApplier {
 		// version (startup, retry, crash recovery) must re-register the desired
 		// non-webhook triggers that aren't actually running, which a pure version
 		// diff misses.
-		const unregistered = this.workflowTriggerActivator.getUnregisteredNonWebhookTriggerNodeIds(
-			record.workflowId,
-			desiredTriggerNodes,
-		);
-		for (const nodeId of unregistered) toAdd.add(nodeId);
+		this.workflowTriggerActivator
+			.getUnregisteredNonWebhookTriggerNodeIds(record.workflowId, desiredTriggerNodes)
+			.forEach((nodeId) => toAdd.add(nodeId));
 
 		// No trigger changed: advance the published version and finish. Unchanged
 		// triggers keep running and re-read the new version on their next fire.

--- a/packages/cli/src/workflows/triggers/__tests__/workflow-trigger-activator.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/workflow-trigger-activator.test.ts
@@ -76,7 +76,7 @@ describe('WorkflowTriggerActivator', () => {
 		expect(activator.getEnabledTriggerNodes(null)).toEqual([]);
 	});
 
-	describe('getUnregisteredLiveTriggerNodeIds', () => {
+	describe('getUnregisteredNonWebhookTriggerNodeIds', () => {
 		function activatorWith(nonWebhookTriggerRegistrar: NonWebhookTriggerRegistrar) {
 			return new WorkflowTriggerActivator(
 				logger,
@@ -92,12 +92,12 @@ describe('WorkflowTriggerActivator', () => {
 			);
 		}
 
-		test('returns desired live triggers not registered in memory', () => {
+		test('returns desired non-webhook triggers not registered in memory', () => {
 			const nonWebhookTriggerRegistrar = mock<NonWebhookTriggerRegistrar>();
 			nonWebhookTriggerRegistrar.getRegisteredTriggerNodeIds.mockReturnValue(new Set(['t']));
 			const activator = activatorWith(nonWebhookTriggerRegistrar);
 
-			const result = activator.getUnregisteredLiveTriggerNodeIds('wf-1', [
+			const result = activator.getUnregisteredNonWebhookTriggerNodeIds('wf-1', [
 				node('t', 'trigger'),
 				node('p', 'poll'),
 			]);
@@ -111,7 +111,7 @@ describe('WorkflowTriggerActivator', () => {
 			nonWebhookTriggerRegistrar.getRegisteredTriggerNodeIds.mockReturnValue(new Set());
 			const activator = activatorWith(nonWebhookTriggerRegistrar);
 
-			const result = activator.getUnregisteredLiveTriggerNodeIds('wf-1', [
+			const result = activator.getUnregisteredNonWebhookTriggerNodeIds('wf-1', [
 				node('t', 'trigger'),
 				node('w', 'webhook'),
 			]);
@@ -119,12 +119,12 @@ describe('WorkflowTriggerActivator', () => {
 			expect(result).toEqual(new Set(['t']));
 		});
 
-		test('returns empty when all desired live triggers are registered', () => {
+		test('returns empty when all desired non-webhook triggers are registered', () => {
 			const nonWebhookTriggerRegistrar = mock<NonWebhookTriggerRegistrar>();
 			nonWebhookTriggerRegistrar.getRegisteredTriggerNodeIds.mockReturnValue(new Set(['t', 'p']));
 			const activator = activatorWith(nonWebhookTriggerRegistrar);
 
-			const result = activator.getUnregisteredLiveTriggerNodeIds('wf-1', [
+			const result = activator.getUnregisteredNonWebhookTriggerNodeIds('wf-1', [
 				node('t', 'trigger'),
 				node('p', 'poll'),
 			]);

--- a/packages/cli/src/workflows/triggers/__tests__/workflow-trigger-activator.test.ts
+++ b/packages/cli/src/workflows/triggers/__tests__/workflow-trigger-activator.test.ts
@@ -76,6 +76,63 @@ describe('WorkflowTriggerActivator', () => {
 		expect(activator.getEnabledTriggerNodes(null)).toEqual([]);
 	});
 
+	describe('getUnregisteredLiveTriggerNodeIds', () => {
+		function activatorWith(nonWebhookTriggerRegistrar: NonWebhookTriggerRegistrar) {
+			return new WorkflowTriggerActivator(
+				logger,
+				mock<ErrorReporter>(),
+				createNodeTypes(),
+				mock<WorkflowRepository>(),
+				mock<WorkflowStaticDataService>(),
+				enabledWorkflowsConfig(),
+				mock<TriggerExecutionContextFactory>(),
+				mock<WebhookTriggerRegistrar>(),
+				nonWebhookTriggerRegistrar,
+				mock<TriggerCountService>(),
+			);
+		}
+
+		test('returns desired live triggers not registered in memory', () => {
+			const nonWebhookTriggerRegistrar = mock<NonWebhookTriggerRegistrar>();
+			nonWebhookTriggerRegistrar.getRegisteredTriggerNodeIds.mockReturnValue(new Set(['t']));
+			const activator = activatorWith(nonWebhookTriggerRegistrar);
+
+			const result = activator.getUnregisteredLiveTriggerNodeIds('wf-1', [
+				node('t', 'trigger'),
+				node('p', 'poll'),
+			]);
+
+			expect(result).toEqual(new Set(['p']));
+			expect(nonWebhookTriggerRegistrar.getRegisteredTriggerNodeIds).toHaveBeenCalledWith('wf-1');
+		});
+
+		test('excludes webhook nodes since they are not tracked in memory', () => {
+			const nonWebhookTriggerRegistrar = mock<NonWebhookTriggerRegistrar>();
+			nonWebhookTriggerRegistrar.getRegisteredTriggerNodeIds.mockReturnValue(new Set());
+			const activator = activatorWith(nonWebhookTriggerRegistrar);
+
+			const result = activator.getUnregisteredLiveTriggerNodeIds('wf-1', [
+				node('t', 'trigger'),
+				node('w', 'webhook'),
+			]);
+
+			expect(result).toEqual(new Set(['t']));
+		});
+
+		test('returns empty when all desired live triggers are registered', () => {
+			const nonWebhookTriggerRegistrar = mock<NonWebhookTriggerRegistrar>();
+			nonWebhookTriggerRegistrar.getRegisteredTriggerNodeIds.mockReturnValue(new Set(['t', 'p']));
+			const activator = activatorWith(nonWebhookTriggerRegistrar);
+
+			const result = activator.getUnregisteredLiveTriggerNodeIds('wf-1', [
+				node('t', 'trigger'),
+				node('p', 'poll'),
+			]);
+
+			expect(result).toEqual(new Set());
+		});
+	});
+
 	test('activates webhooks, non-webhook triggers, count, and persistence in order', async () => {
 		const callOrder: string[] = [];
 		jest.spyOn(WorkflowExpression.prototype, 'acquireIsolate').mockImplementation(async () => {

--- a/packages/cli/src/workflows/triggers/non-webhook-trigger-registrar.ts
+++ b/packages/cli/src/workflows/triggers/non-webhook-trigger-registrar.ts
@@ -58,6 +58,14 @@ export class NonWebhookTriggerRegistrar {
 	}
 
 	/**
+	 * Resolve the IDs of the active, poll, and schedule trigger nodes currently
+	 * registered in memory for the workflow.
+	 */
+	getRegisteredTriggerNodeIds(workflowId: WorkflowId) {
+		return this.activeWorkflowTriggers.getRegisteredTriggerNodeIds(workflowId);
+	}
+
+	/**
 	 * Build reusable trigger and poll execution functions for one activation.
 	 */
 	createRegistrationContext(

--- a/packages/cli/src/workflows/triggers/workflow-trigger-activator.ts
+++ b/packages/cli/src/workflows/triggers/workflow-trigger-activator.ts
@@ -74,24 +74,24 @@ export class WorkflowTriggerActivator {
 	}
 
 	/**
-	 * Returns the desired live-trigger nodes (active, schedule and poll triggers)
-	 * that are not currently registered in memory for the workflow. Webhook
-	 * triggers are excluded because they live in the `webhook_entity` table rather
-	 * than the in-memory registry. `desiredNodes` are the enabled trigger-like
-	 * nodes of the version being published.
+	 * Returns the desired non-webhook trigger nodes (active, schedule and poll
+	 * triggers) that are not currently registered in memory for the workflow.
+	 * Webhook triggers are excluded because they live in the `webhook_entity`
+	 * table rather than the in-memory registry. `desiredNodes` are the enabled
+	 * trigger-like nodes of the version being published.
 	 *
 	 * This is how publication reconciles a record ("be at version X") against
-	 * actual local state: a re-enqueued version whose live triggers were never (or
-	 * only partly) registered yields exactly the missing nodes to add.
+	 * actual local state: a re-enqueued version whose non-webhook triggers were
+	 * never (or only partly) registered yields exactly the missing nodes to add.
 	 */
-	getUnregisteredLiveTriggerNodeIds(
+	getUnregisteredNonWebhookTriggerNodeIds(
 		workflowId: WorkflowId,
 		desiredNodes: INode[],
 	): Set<INode['id']> {
 		const registered = this.nonWebhookTriggerRegistrar.getRegisteredTriggerNodeIds(workflowId);
 
 		const unregistered = new Set<INode['id']>();
-		for (const nodeId of this.getLiveTriggerNodeIds(desiredNodes)) {
+		for (const nodeId of this.getNonWebhookTriggerNodeIds(desiredNodes)) {
 			if (!registered.has(nodeId)) unregistered.add(nodeId);
 		}
 
@@ -99,10 +99,11 @@ export class WorkflowTriggerActivator {
 	}
 
 	/**
-	 * Filters the given nodes to the live-trigger nodes (active, schedule and poll
-	 * triggers), matching the registration logic in `NonWebhookTriggerRegistrar`.
+	 * Filters the given nodes to the non-webhook trigger nodes (active, schedule
+	 * and poll triggers), matching the registration logic in
+	 * `NonWebhookTriggerRegistrar`.
 	 */
-	private getLiveTriggerNodeIds(nodes: INode[]): string[] {
+	private getNonWebhookTriggerNodeIds(nodes: INode[]): string[] {
 		const workflow = new Workflow({
 			id: 'trigger-diff',
 			name: 'trigger-diff',

--- a/packages/cli/src/workflows/triggers/workflow-trigger-activator.ts
+++ b/packages/cli/src/workflows/triggers/workflow-trigger-activator.ts
@@ -74,6 +74,48 @@ export class WorkflowTriggerActivator {
 	}
 
 	/**
+	 * Returns the desired live-trigger nodes (active, schedule and poll triggers)
+	 * that are not currently registered in memory for the workflow. Webhook
+	 * triggers are excluded because they live in the `webhook_entity` table rather
+	 * than the in-memory registry. `desiredNodes` are the enabled trigger-like
+	 * nodes of the version being published.
+	 *
+	 * This is how publication reconciles a record ("be at version X") against
+	 * actual local state: a re-enqueued version whose live triggers were never (or
+	 * only partly) registered yields exactly the missing nodes to add.
+	 */
+	getUnregisteredLiveTriggerNodeIds(
+		workflowId: WorkflowId,
+		desiredNodes: INode[],
+	): Set<INode['id']> {
+		const registered = this.nonWebhookTriggerRegistrar.getRegisteredTriggerNodeIds(workflowId);
+
+		const unregistered = new Set<INode['id']>();
+		for (const nodeId of this.getLiveTriggerNodeIds(desiredNodes)) {
+			if (!registered.has(nodeId)) unregistered.add(nodeId);
+		}
+
+		return unregistered;
+	}
+
+	/**
+	 * Filters the given nodes to the live-trigger nodes (active, schedule and poll
+	 * triggers), matching the registration logic in `NonWebhookTriggerRegistrar`.
+	 */
+	private getLiveTriggerNodeIds(nodes: INode[]): string[] {
+		const workflow = new Workflow({
+			id: 'trigger-diff',
+			name: 'trigger-diff',
+			nodes,
+			connections: {},
+			active: false,
+			nodeTypes: this.nodeTypes,
+		});
+
+		return [...workflow.getTriggerNodes(), ...workflow.getPollNodes()].map((node) => node.id);
+	}
+
+	/**
 	 * Registers only the given trigger nodes (webhook and non-webhook) of the
 	 * given workflow version, leaving any other already-active triggers
 	 * untouched. The "add" side of a publication trigger diff; runs on the leader

--- a/packages/cli/test/integration/workflows/workflow-publication-outbox-consumer.test.ts
+++ b/packages/cli/test/integration/workflows/workflow-publication-outbox-consumer.test.ts
@@ -139,6 +139,71 @@ describe('WorkflowPublicationOutboxConsumer (integration)', () => {
 		expect(await outboxRepository.claimNextPendingRecord()).toBeNull();
 	});
 
+	test('re-registers only the live triggers missing from memory after a crash mid-add', async () => {
+		const owner = await createOwner();
+
+		const present = scheduleNode('present');
+		const missing = scheduleNode('missing');
+
+		const workflow = await createWorkflowWithHistory(
+			{ active: true, nodes: [present, missing] },
+			owner,
+		);
+		await setActiveVersion(workflow.id, workflow.versionId);
+		await publishedVersionRepository.setPublishedVersion(workflow.id, workflow.versionId);
+		await activeWorkflowManager.add(workflow.id, 'activate');
+
+		// Simulate a crash mid-add that left `missing` unregistered while `present`
+		// stayed live, then re-enqueue the SAME version (startup/retry/recovery).
+		await activeWorkflowTriggers.removeTriggers(workflow.id, new Set([missing.id]));
+		const presentResponse = activeWorkflowTriggers.get(workflow.id)?.get(present.id);
+		expect(presentResponse).toBeDefined();
+		expect(activeWorkflowTriggers.get(workflow.id)?.has(missing.id)).toBe(false);
+
+		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		const record = await outboxRepository.claimNextPendingRecord();
+
+		await consumer.processRecord(record!);
+
+		// `missing` got re-registered; `present` was left untouched (same response object).
+		const state = activeWorkflowTriggers.get(workflow.id);
+		expect(state?.has(missing.id)).toBe(true);
+		expect(state?.get(present.id)).toBe(presentResponse);
+
+		const row = await outboxRepository.findOneBy({ id: record!.id });
+		expect(row?.status).toBe('completed');
+		expect(await outboxRepository.claimNextPendingRecord()).toBeNull();
+	});
+
+	test('re-enqueueing an already fully-published version is a no-op marked completed', async () => {
+		const owner = await createOwner();
+
+		const trigger = scheduleNode('only');
+		const workflow = await createWorkflowWithHistory({ active: true, nodes: [trigger] }, owner);
+		await setActiveVersion(workflow.id, workflow.versionId);
+		await publishedVersionRepository.setPublishedVersion(workflow.id, workflow.versionId);
+		await activeWorkflowManager.add(workflow.id, 'activate');
+
+		const responseBefore = activeWorkflowTriggers.get(workflow.id)?.get(trigger.id);
+		expect(responseBefore).toBeDefined();
+
+		await outboxRepository.enqueue(workflow.id, workflow.versionId);
+		const record = await outboxRepository.claimNextPendingRecord();
+
+		await consumer.processRecord(record!);
+
+		// Nothing re-registered (same response object) and the version is unchanged.
+		expect(activeWorkflowTriggers.get(workflow.id)?.get(trigger.id)).toBe(responseBefore);
+		const published = await publishedVersionRepository.getPublishedVersionWithRelations(
+			workflow.id,
+		);
+		expect(published?.publishedVersionId).toBe(workflow.versionId);
+
+		const row = await outboxRepository.findOneBy({ id: record!.id });
+		expect(row?.status).toBe('completed');
+		expect(await outboxRepository.claimNextPendingRecord()).toBeNull();
+	});
+
 	test('does no trigger work when only non-trigger content changed', async () => {
 		const owner = await createOwner();
 

--- a/packages/cli/test/integration/workflows/workflow-publication-outbox-consumer.test.ts
+++ b/packages/cli/test/integration/workflows/workflow-publication-outbox-consumer.test.ts
@@ -139,7 +139,7 @@ describe('WorkflowPublicationOutboxConsumer (integration)', () => {
 		expect(await outboxRepository.claimNextPendingRecord()).toBeNull();
 	});
 
-	test('re-registers only the live triggers missing from memory after a crash mid-add', async () => {
+	test('re-registers only the non-webhook triggers missing from memory after a crash mid-add', async () => {
 		const owner = await createOwner();
 
 		const present = scheduleNode('present');

--- a/packages/core/src/execution-engine/__tests__/active-workflow-triggers.test.ts
+++ b/packages/core/src/execution-engine/__tests__/active-workflow-triggers.test.ts
@@ -671,6 +671,25 @@ describe('ActiveWorkflowTriggers', () => {
 		});
 	});
 
+	describe('getRegisteredTriggerNodeIds()', () => {
+		it('unions recorded trigger responses with registered cron node ids', async () => {
+			await addWorkflow({ triggerNodes: [mock<INode>({ id: 'trigger-a' })] });
+			scheduledTaskManager.getCronNodeIds.mockReturnValue(['poll-a']);
+
+			expect(activeWorkflowTriggers.getRegisteredTriggerNodeIds(workflowId)).toEqual(
+				new Set(['poll-a', 'trigger-a']),
+			);
+		});
+
+		it('returns only cron node ids when the workflow has no recorded triggers', () => {
+			scheduledTaskManager.getCronNodeIds.mockReturnValue(['poll-a']);
+
+			expect(activeWorkflowTriggers.getRegisteredTriggerNodeIds('other-wf')).toEqual(
+				new Set(['poll-a']),
+			);
+		});
+	});
+
 	describe('allActiveWorkflows()', () => {
 		it('should return all active workflow IDs', async () => {
 			await addWorkflow({ triggerNodes: [triggerNode] });

--- a/packages/core/src/execution-engine/__tests__/scheduled-task-manager.test.ts
+++ b/packages/core/src/execution-engine/__tests__/scheduled-task-manager.test.ts
@@ -160,6 +160,41 @@ describe('ScheduledTaskManager', () => {
 		expect(onTick).not.toHaveBeenCalled();
 	});
 
+	it('returns distinct node ids that currently have crons registered', () => {
+		const everySecond = '* * * * * *';
+		scheduledTaskManager.registerCron(
+			{
+				workflowId: workflow.id,
+				nodeId: 'node-a',
+				timezone: workflow.timezone,
+				expression: everyMinute,
+			},
+			onTick,
+		);
+		// Two crons on the same node (e.g. multiple poll times) collapse to one id.
+		scheduledTaskManager.registerCron(
+			{
+				workflowId: workflow.id,
+				nodeId: 'node-a',
+				timezone: workflow.timezone,
+				expression: everySecond,
+			},
+			onTick,
+		);
+		scheduledTaskManager.registerCron(
+			{
+				workflowId: workflow.id,
+				nodeId: 'node-b',
+				timezone: workflow.timezone,
+				expression: everyMinute,
+			},
+			onTick,
+		);
+
+		expect(scheduledTaskManager.getCronNodeIds(workflow.id).sort()).toEqual(['node-a', 'node-b']);
+		expect(scheduledTaskManager.getCronNodeIds('unknown-workflow')).toEqual([]);
+	});
+
 	it('should deregister CronJobs for a single node, leaving other nodes intact', () => {
 		const nodeA = 'node-a';
 		const nodeB = 'node-b';

--- a/packages/core/src/execution-engine/active-workflow-triggers.ts
+++ b/packages/core/src/execution-engine/active-workflow-triggers.ts
@@ -74,14 +74,12 @@ export class ActiveWorkflowTriggers {
 	 * state. Used by publication to reconcile a version against actual local state.
 	 */
 	getRegisteredTriggerNodeIds(workflowId: string): Set<string> {
-		const nodeIds = new Set<string>(this.scheduledTaskManager.getCronNodeIds(workflowId));
-
 		const triggers = this.activeTriggersByWorkflowId.get(workflowId);
-		for (const nodeId of triggers?.nodeIds ?? []) {
-			nodeIds.add(nodeId);
-		}
 
-		return nodeIds;
+		return new Set([
+			...this.scheduledTaskManager.getCronNodeIds(workflowId),
+			...(triggers?.nodeIds ?? []),
+		]);
 	}
 
 	/**

--- a/packages/core/src/execution-engine/active-workflow-triggers.ts
+++ b/packages/core/src/execution-engine/active-workflow-triggers.ts
@@ -67,6 +67,24 @@ export class ActiveWorkflowTriggers {
 	}
 
 	/**
+	 * Returns the ids of the trigger and poll nodes currently registered in memory
+	 * for the workflow. Unions the recorded trigger responses (active and schedule
+	 * triggers) with the nodes that have registered crons (poll triggers), since a
+	 * poll node lives only in the cron scheduler and never in the trigger-response
+	 * state. Used by publication to reconcile a version against actual local state.
+	 */
+	getRegisteredTriggerNodeIds(workflowId: string): Set<string> {
+		const nodeIds = new Set<string>(this.scheduledTaskManager.getCronNodeIds(workflowId));
+
+		const triggers = this.activeTriggersByWorkflowId.get(workflowId);
+		for (const nodeId of triggers?.nodeIds ?? []) {
+			nodeIds.add(nodeId);
+		}
+
+		return nodeIds;
+	}
+
+	/**
 	 * Makes a workflow active by registering all of its trigger and poll nodes.
 	 *
 	 * @param {string} workflowId The id of the workflow to activate

--- a/packages/core/src/execution-engine/scheduled-task-manager.ts
+++ b/packages/core/src/execution-engine/scheduled-task-manager.ts
@@ -152,6 +152,19 @@ export class ScheduledTaskManager {
 		return Array.from(this.cronsByWorkflow.keys());
 	}
 
+	/** Distinct node ids that currently have crons registered for the workflow. */
+	getCronNodeIds(workflowId: string): string[] {
+		const workflowCrons = this.cronsByWorkflow.get(workflowId);
+		if (!workflowCrons) return [];
+
+		const nodeIds = new Set<string>();
+		for (const cron of workflowCrons.values()) {
+			nodeIds.add(cron.ctx.nodeId);
+		}
+
+		return Array.from(nodeIds);
+	}
+
 	/** Deregister the crons registered for a single node of a workflow. */
 	deregisterCron(workflowId: string, nodeId: string) {
 		const workflowCrons = this.cronsByWorkflow.get(workflowId);

--- a/packages/core/src/execution-engine/workflow-active-triggers-state.ts
+++ b/packages/core/src/execution-engine/workflow-active-triggers-state.ts
@@ -32,6 +32,11 @@ export class WorkflowActiveTriggersState {
 		return this.triggersByNodeId.size === 0;
 	}
 
+	/** Ids of the nodes that have a recorded trigger response. */
+	get nodeIds(): IterableIterator<string> {
+		return this.triggersByNodeId.keys();
+	}
+
 	/** All recorded trigger responses, in insertion order. */
 	get triggerResponses(): IterableIterator<ITriggerResponse> {
 		return this.triggersByNodeId.values();


### PR DESCRIPTION
## Summary

Builds on top of #32170

PR 5/X on overhauling the trigger lifecycle during activation

Changes the semantics of what an outbox record represents:
"reconcile this workflow's triggers to version X" instead of "apply the edge old→new"

This is only done for non-webhook triggers. We could consider adding this reconciliation for webhooks in the future.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3421

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32233">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

