### PR TITLE
test: Make TextClassifier delayBetweenBatches test deterministic

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/test/TextClassifier.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/chains/TextClassifier/test/TextClassifier.node.test.ts
@@ -1,4 +1,5 @@
 import { FakeChatModel } from '@langchain/core/utils/testing';
+import * as n8nWorkflow from 'n8n-workflow';
 import type { IExecuteFunctions, INode } from 'n8n-workflow';
 import type { Mock, Mocked } from 'vitest';
 import { mock } from 'vitest-mock-extended';
@@ -9,6 +10,14 @@ import { TextClassifier } from '../TextClassifier.node';
 vi.mock('../processItem', () => ({
 	processItem: vi.fn(),
 }));
+
+vi.mock('n8n-workflow', async (importOriginal) => {
+	const actual = await importOriginal<typeof n8nWorkflow>();
+	return {
+		...actual,
+		sleep: vi.fn().mockResolvedValue(undefined),
+	};
+});
 
 describe('TextClassifier Node', () => {
 	let node: TextClassifier;
@@ -146,11 +155,11 @@ describe('TextClassifier Node', () => {
 
 			(processItem as Mock).mockResolvedValue({ test: true });
 
-			const startTime = Date.now();
 			await node.execute.call(mockExecuteFunction);
-			const endTime = Date.now();
 
-			expect(endTime - startTime).toBeGreaterThanOrEqual(200);
+			// 6 items with batchSize 2 => 3 batches => a delay after every batch but the last
+			expect(n8nWorkflow.sleep).toHaveBeenCalledTimes(2);
+			expect(n8nWorkflow.sleep).toHaveBeenCalledWith(100);
 		});
 
 		it('should handle errors in batch processing', async () => {


### PR DESCRIPTION
## Summary

The unit test `TextClassifier Node > execute > should respect delayBetweenBatches` was flaky. It measured wall-clock elapsed time around `node.execute()` and asserted it took at least 200ms (6 items, batchSize 2 → 3 batches → 2 delays × 100ms). Relying on the wall clock and real `sleep()` made it sensitive to timer granularity and scheduling jitter, so it occasionally clocked 199ms and failed:

```
AssertionError: expected 199 to be greater than or equal to 200
 ❯ nodes/chains/TextClassifier/test/TextClassifier.node.test.ts:153:32
```

## Fix

Mock `sleep` from `n8n-workflow` and assert it is invoked the correct number of times with the configured delay, instead of measuring real elapsed time. This tests the actual batching contract deterministically and removes the real wait (suite now runs in ~12ms).

## Related

https://linear.app/n8n/issue/AI-2569

## Review / Merge checklist

- [x] Tests included.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32234">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

