### PR TITLE
fix(core): Exclude published versions from workflow history prune

### DIFF
--- a/packages/@n8n/db/src/repositories/workflow-history.repository.ts
+++ b/packages/@n8n/db/src/repositories/workflow-history.repository.ts
@@ -2,7 +2,7 @@ import { Service } from '@n8n/di';
 import { DataSource, In, LessThan, Repository } from '@n8n/typeorm';
 import { DiffMetaData, DiffRule, groupWorkflows, SKIP_RULES } from 'n8n-workflow';
 
-import { WorkflowHistory, WorkflowEntity } from '../entities';
+import { WorkflowHistory, WorkflowEntity, WorkflowPublishedVersion } from '../entities';
 import { WorkflowPublishHistoryRepository } from './workflow-publish-history.repository';
 
 @Service()
@@ -39,13 +39,23 @@ export class WorkflowHistoryRepository extends Repository<WorkflowHistory> {
 			.where('w.activeVersionId IS NOT NULL')
 			.getQuery();
 
+		// Published versions carry an ON DELETE RESTRICT FK; deleting one aborts the
+		// whole statement, so they must be excluded like current and active versions.
+		const publishedVersionIdsSubquery = this.manager
+			.createQueryBuilder()
+			.subQuery()
+			.select('wpv.publishedVersionId')
+			.from(WorkflowPublishedVersion, 'wpv')
+			.getQuery();
+
 		const query = this.manager
 			.createQueryBuilder()
 			.delete()
 			.from(WorkflowHistory)
 			.where('createdAt < :date', { date })
 			.andWhere(`versionId NOT IN (${currentVersionIdsSubquery})`)
-			.andWhere(`versionId NOT IN (${activeVersionIdsSubquery})`);
+			.andWhere(`versionId NOT IN (${activeVersionIdsSubquery})`)
+			.andWhere(`versionId NOT IN (${publishedVersionIdsSubquery})`);
 
 		if (preserveNamedVersions) {
 			query.andWhere('name IS NULL');

--- a/packages/cli/test/integration/database/repositories/workflow-history.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/workflow-history.repository.test.ts
@@ -4,7 +4,7 @@ import {
 	createWorkflowWithHistory,
 	testDb,
 } from '@n8n/backend-test-utils';
-import { WorkflowHistoryRepository } from '@n8n/db';
+import { WorkflowHistoryRepository, WorkflowPublishedVersionRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { RULES, type INode } from 'n8n-workflow';
 import { v4 as uuid } from 'uuid';
@@ -26,7 +26,13 @@ describe('WorkflowHistoryRepository', () => {
 	});
 
 	beforeEach(async () => {
-		await testDb.truncate(['WorkflowPublishHistory', 'WorkflowHistory', 'WorkflowEntity', 'User']);
+		await testDb.truncate([
+			'WorkflowPublishedVersion',
+			'WorkflowPublishHistory',
+			'WorkflowHistory',
+			'WorkflowEntity',
+			'User',
+		]);
 	});
 
 	afterAll(async () => {
@@ -237,6 +243,119 @@ describe('WorkflowHistoryRepository', () => {
 			expect(redo.seen).toBe(3);
 		});
 	});
+	describe('deleteEarlierThanExceptCurrentAndActive', () => {
+		// Happy path: proves the setup deletes old, unreferenced versions while
+		// keeping the current version.
+		it('should delete old versions but keep the current version', async () => {
+			const vCurrent = uuid();
+			const vOld = uuid();
+
+			const tenDaysAgo = new Date();
+			tenDaysAgo.setDate(tenDaysAgo.getDate() - 10);
+
+			const oneDayAgo = new Date();
+			oneDayAgo.setDate(oneDayAgo.getDate() - 1);
+
+			const workflow = await createWorkflow({
+				versionId: vCurrent,
+				nodes: [{ ...testNode1, parameters: { a: 'current' } }],
+			});
+			// Old, unreferenced version (should be pruned)
+			await createWorkflowHistory(
+				{ ...workflow, versionId: vOld, nodes: [{ ...testNode1, parameters: { a: 'old' } }] },
+				undefined,
+				undefined,
+				{ createdAt: tenDaysAgo },
+			);
+			// Current version history (recent, excluded as workflow_entity.versionId)
+			await createWorkflowHistory(workflow);
+
+			const repository = Container.get(WorkflowHistoryRepository);
+			await repository.deleteEarlierThanExceptCurrentAndActive(oneDayAgo);
+
+			const remainingIds = (await repository.find()).map((r) => r.versionId);
+			expect(remainingIds).toContain(vCurrent);
+			expect(remainingIds).not.toContain(vOld);
+		});
+
+		// CAT-3293: a workflow_history row referenced by
+		// workflow_published_version.publishedVersionId carries an ON DELETE
+		// RESTRICT FK. When such a row ages past the prune window and is neither
+		// the current nor the active version, the prune DELETE targets it and
+		// SQLite aborts the whole statement with
+		// "SQLITE_CONSTRAINT: FOREIGN KEY constraint failed", which then recurs
+		// every hour. The prune must exclude published versions, mirroring the
+		// sibling pruneHistory() which already preserves them.
+		//
+		// How this state arises in production (published != current != active):
+		// the service layer normally keeps publishedVersionId in lockstep with
+		// activeVersionId (set together when activating, removed together when
+		// deactivating). The one place that breaks that invariant is the active
+		// workflow manager's activation-failure recovery
+		// (active-workflow-manager.ts: `update(workflowId, { active: false,
+		// activeVersionId: null })`), which nulls activeVersionId without removing
+		// the workflow_published_version row. A workflow that was published, then
+		// edited (advancing versionId), then failed to (re)activate on a
+		// restart/leadership change is left with a stale publishedVersionId
+		// pointing at an older history row. This also requires the
+		// `useWorkflowPublicationService` flag, which is off by default. We set up
+		// that end state directly here rather than driving the failure path; the
+		// query-level invariant is what this test pins down.
+		it('should preserve versions referenced by a published version', async () => {
+			const vCurrent = uuid();
+			const vPublished = uuid();
+			const vOther = uuid();
+
+			const tenDaysAgo = new Date();
+			tenDaysAgo.setDate(tenDaysAgo.getDate() - 10);
+
+			const oneDayAgo = new Date();
+			oneDayAgo.setDate(oneDayAgo.getDate() - 1);
+
+			const workflow = await createWorkflow({
+				versionId: vCurrent,
+				nodes: [{ ...testNode1, parameters: { a: 'current' } }],
+			});
+
+			// Old version that is still the published version (RESTRICT FK)
+			await createWorkflowHistory(
+				{
+					...workflow,
+					versionId: vPublished,
+					nodes: [{ ...testNode1, parameters: { a: 'published' } }],
+				},
+				undefined,
+				undefined,
+				{ createdAt: tenDaysAgo },
+			);
+			// Old version that is NOT referenced anywhere (should be pruned)
+			await createWorkflowHistory(
+				{ ...workflow, versionId: vOther, nodes: [{ ...testNode1, parameters: { a: 'other' } }] },
+				undefined,
+				undefined,
+				{ createdAt: tenDaysAgo },
+			);
+			// Current version history (recent)
+			await createWorkflowHistory(workflow);
+
+			// The published version has advanced away from current/active
+			await Container.get(WorkflowPublishedVersionRepository).setPublishedVersion(
+				workflow.id,
+				vPublished,
+			);
+
+			const repository = Container.get(WorkflowHistoryRepository);
+
+			// Must not throw SQLITE_CONSTRAINT: FOREIGN KEY constraint failed
+			await repository.deleteEarlierThanExceptCurrentAndActive(oneDayAgo);
+
+			const remainingIds = (await repository.find()).map((r) => r.versionId);
+			expect(remainingIds).toContain(vPublished); // preserved: referenced as published
+			expect(remainingIds).toContain(vCurrent); // preserved: current version
+			expect(remainingIds).not.toContain(vOther); // pruned: old and unreferenced
+		});
+	});
+
 	describe('getWorkflowIdsInRange', () => {
 		it('should return versions in range', async () => {
 			const now = Date.now();

--- a/packages/cli/test/integration/database/repositories/workflow-history.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/workflow-history.repository.test.ts
@@ -267,8 +267,10 @@ describe('WorkflowHistoryRepository', () => {
 				undefined,
 				{ createdAt: tenDaysAgo },
 			);
-			// Current version history (recent, excluded as workflow_entity.versionId)
-			await createWorkflowHistory(workflow);
+			// Current version history, also old — so it is a prune candidate by date
+			// and survives only via the current-version (workflow_entity.versionId)
+			// exclusion, not because it is too recent to delete.
+			await createWorkflowHistory(workflow, undefined, undefined, { createdAt: tenDaysAgo });
 
 			const repository = Container.get(WorkflowHistoryRepository);
 			await repository.deleteEarlierThanExceptCurrentAndActive(oneDayAgo);
@@ -278,29 +280,11 @@ describe('WorkflowHistoryRepository', () => {
 			expect(remainingIds).not.toContain(vOld);
 		});
 
-		// CAT-3293: a workflow_history row referenced by
+		// A workflow_history row referenced by
 		// workflow_published_version.publishedVersionId carries an ON DELETE
-		// RESTRICT FK. When such a row ages past the prune window and is neither
-		// the current nor the active version, the prune DELETE targets it and
-		// SQLite aborts the whole statement with
-		// "SQLITE_CONSTRAINT: FOREIGN KEY constraint failed", which then recurs
-		// every hour. The prune must exclude published versions, mirroring the
-		// sibling pruneHistory() which already preserves them.
-		//
-		// How this state arises in production (published != current != active):
-		// the service layer normally keeps publishedVersionId in lockstep with
-		// activeVersionId (set together when activating, removed together when
-		// deactivating). The one place that breaks that invariant is the active
-		// workflow manager's activation-failure recovery
-		// (active-workflow-manager.ts: `update(workflowId, { active: false,
-		// activeVersionId: null })`), which nulls activeVersionId without removing
-		// the workflow_published_version row. A workflow that was published, then
-		// edited (advancing versionId), then failed to (re)activate on a
-		// restart/leadership change is left with a stale publishedVersionId
-		// pointing at an older history row. This also requires the
-		// `useWorkflowPublicationService` flag, which is off by default. We set up
-		// that end state directly here rather than driving the failure path; the
-		// query-level invariant is what this test pins down.
+		// RESTRICT FK, so deleting it aborts the whole prune DELETE with
+		// "SQLITE_CONSTRAINT: FOREIGN KEY constraint failed". The prune must
+		// exclude published versions, mirroring the sibling pruneHistory().
 		it('should preserve versions referenced by a published version', async () => {
 			const vCurrent = uuid();
 			const vPublished = uuid();


### PR DESCRIPTION
## Summary

Fixes the recurring hourly `SQLITE_CONSTRAINT: FOREIGN KEY constraint failed` emitted by `WorkflowHistoryManager.prune()`.

## Root cause

`WorkflowHistoryRepository.deleteEarlierThanExceptCurrentAndActive()` built the hourly prune `DELETE` excluding only the **current** (`workflow_entity.versionId`) and **active** (`workflow_entity.activeVersionId`) versions. It did not exclude versions referenced by `workflow_published_version.publishedVersionId`, which carries an `onDelete: 'RESTRICT'` FK to `workflow_history`.

Once a published version's history row aged past the retention window while being neither current nor active, the prune targeted it, the RESTRICT FK aborted the whole statement, and it rolled back. The prune is a single instance-wide `DELETE`, so one orphaned published row blocked pruning for the **entire instance** — `workflow_history` grew unbounded and the error recurred every hour.

The sibling `pruneHistory()` already preserves published versions, so "don't prune published versions" is established intent this method simply omitted.

## How the state arises in production (published ≠ current ≠ active)

The service layer normally keeps `publishedVersionId` in lockstep with `activeVersionId` (set together on activation, removed together on deactivation). The divergence path is the active workflow manager's activation-failure recovery (`active-workflow-manager.ts`: `update(workflowId, { active: false, activeVersionId: null })`), which nulls `activeVersionId` **without** removing the `workflow_published_version` row. A workflow that was published, then edited (advancing `versionId`), then failed to (re)activate on a restart/leadership change is left with a stale `publishedVersionId` pointing at an older history row.

This requires `N8N_USE_WORKFLOW_PUBLICATION_SERVICE` (off by default). The regression test sets up that end state directly rather than driving the failure path; the query-level invariant is what it pins down.

## Fix

Add a third exclusion subquery for `workflow_published_version.publishedVersionId`, mirroring the existing current/active subqueries. Single statement (no N+1), engine-agnostic (Postgres/MySQL declare the same RESTRICT FK). `publishedVersionId` is non-null, so no `IS NOT NULL` guard is needed.

## Testing

- Regression test (added first, was failing on the constraint) now passes, alongside a happy-path test proving old unreferenced versions are still pruned while an *old* current version is preserved by the current-version exclusion.
- Verified end-to-end against a reproduced SQLite instance: old code aborts with the FK error; with the fix the prune runs clean, the old published row is preserved, and a genuinely-old orphan is still deleted.

```
cd packages/cli && pnpm test test/integration/database/repositories/workflow-history.repository.test.ts
```

## Follow-up

The sibling `pruneHistory()` sources its published-version set from a different table (`workflow_publish_history`, an audit log with a `SET NULL` FK) rather than the live `workflow_published_version` pointer. Tracked separately in CAT-3725.

Fixes https://github.com/n8n-io/n8n/issues/31334
https://linear.app/n8n/issue/CAT-3293