### PR TITLE
feat(core): Show required scope badge on Swagger UI operations

### DIFF
--- a/packages/cli/src/public-api/index.ts
+++ b/packages/cli/src/public-api/index.ts
@@ -20,6 +20,61 @@ import { createN8nPackageMulterOptions } from '@/modules/n8n-packages/utils/impo
 
 import { sendPublicApiErrorResponse } from './v1/public-api-error-response';
 
+// Renders `x-required-scope` as a badge on each operation. swagger-ui-express
+// serializes this function's source into the page, so it must be self-contained:
+// no closures, no imports.
+type ImmutableLike = { get(key: string): unknown };
+type ImmutableListLike = { toJS(): string[] };
+type SwaggerUiSystem = {
+	React: {
+		createElement(component: unknown, props: unknown): unknown;
+		useEffect(effect: () => undefined | (() => void), deps: unknown[]): void;
+	};
+	specSelectors?: {
+		specJson(): { getIn(path: string[]): ImmutableLike | null | undefined };
+	};
+};
+type OperationSummaryProps = { specPath?: ImmutableListLike };
+
+function scopeBadgePlugin() {
+	const wrapOperationSummary =
+		(originalComponent: unknown, system: SwaggerUiSystem) => (props: OperationSummaryProps) => {
+			const pathArr = props.specPath?.toJS ? props.specPath.toJS() : null;
+			const op = pathArr ? (system.specSelectors?.specJson().getIn(pathArr) ?? null) : null;
+			const rawScope = op?.get ? op.get('x-required-scope') : null;
+			const scope = typeof rawScope === 'string' ? rawScope : null;
+			const method = pathArr ? pathArr[2] : null;
+			const pathStr = pathArr ? pathArr[1] : null;
+			system.React.useEffect(() => {
+				if (!scope || scope === 'none' || !method || !pathStr) return;
+				const candidates = document.querySelectorAll('.opblock-summary-' + method);
+				let target: Element | null = null;
+				for (const c of candidates) {
+					const pathEl = c.querySelector('.opblock-summary-path');
+					if (pathEl && pathEl.getAttribute('data-path') === pathStr) {
+						target =
+							c.querySelector('.opblock-summary-path-description-wrapper') ??
+							c.querySelector('.opblock-summary-description');
+						break;
+					}
+				}
+				if (!target) return;
+				const existing = target.querySelector(':scope > .x-scope-badge');
+				if (existing) existing.remove();
+				const badge = document.createElement('span');
+				badge.className = 'x-scope-badge';
+				badge.textContent = scope;
+				target.appendChild(badge);
+				return () => {
+					badge.remove();
+				};
+			}, [scope, method, pathStr]);
+			return system.React.createElement(originalComponent, props);
+		};
+	// eslint-disable-next-line @typescript-eslint/naming-convention -- Swagger UI plugin keys are PascalCase
+	return { wrapComponents: { OperationSummary: wrapOperationSummary } };
+}
+
 function createLazySwaggerMiddleware(
 	openApiSpecPath: string,
 	publicApiEndpoint: string,
@@ -47,14 +102,18 @@ function createLazySwaggerMiddleware(
 			const swaggerThemePath = path.join(__dirname, 'swagger-theme.css');
 			const swaggerThemeCss = await fs.readFile(swaggerThemePath, { encoding: 'utf-8' });
 
+			const swaggerSetupOpts = {
+				customCss: swaggerThemeCss,
+				customSiteTitle: 'n8n Public API UI',
+				customfavIcon: `${n8nPath}favicon.ico`,
+				swaggerOptions: {
+					plugins: [scopeBadgePlugin],
+				},
+			};
 			cachedRouter = express.Router();
 			cachedRouter.use(
-				serveFiles(swaggerDocument),
-				setup(swaggerDocument, {
-					customCss: swaggerThemeCss,
-					customSiteTitle: 'n8n Public API UI',
-					customfavIcon: `${n8nPath}favicon.ico`,
-				}),
+				serveFiles(swaggerDocument, swaggerSetupOpts),
+				setup(swaggerDocument, swaggerSetupOpts),
 			);
 		}
 

--- a/packages/cli/src/public-api/swagger-theme.css
+++ b/packages/cli/src/public-api/swagger-theme.css
@@ -24,3 +24,17 @@
 .swagger-ui select {
 	border-color: #ff6d5a;
 }
+
+.swagger-ui .x-scope-badge {
+	display: inline-block;
+	margin-left: 12px;
+	padding: 2px 10px;
+	background: #ff6d5a;
+	color: #fff;
+	border-radius: 12px;
+	font-size: 11px;
+	font-weight: 600;
+	font-family: monospace;
+	letter-spacing: 0.3px;
+	vertical-align: middle;
+}


### PR DESCRIPTION
## Summary

Renders the `x-required-scope` value (added in #32231) as a small salmon pill next to each operation's description in the Public API Swagger UI. Discoverability for API key scope requirements without having to expand each row or read the YAML.

- Adds a tiny Swagger UI plugin that wraps `OperationSummary`, looks up `x-required-scope` via `system.specSelectors.specJson()`, and injects a `<span class="x-scope-badge">` into the `.opblock-summary-path-description-wrapper`.
- Wires the plugin through both `serveFiles` and `setup` (swagger-ui-express's `serveFiles` builds its own initOptions, so passing options to only `setup` would be dropped on the floor for `swagger-ui-init.js`).
- Adds `.x-scope-badge` styling to `packages/cli/src/public-api/swagger-theme.css` (salmon `#ff6d5a` background, white monospace text, matching the existing n8n / OAS 3.0 badge style).

The plugin function source is `.toString()`-serialized into the served HTML by `swagger-ui-express`, so it is self-contained — no closures, no imports, untyped wrt the Swagger UI runtime API.

## How to test

1. `pnpm --filter n8n build && pnpm start`
2. Open http://localhost:5678/api/v1/docs/
3. Expand any tag group (e.g. **User**, **Workflow**).
4. Each operation summary row should show a salmon pill on the right of the description, e.g. `Retrieve all users  [user:list]`.
5. `GET /credentials/schema/{credentialTypeName}` and `GET /discover` (annotated `x-required-scope: none`) should have no pill.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-696/userenforcemfa-api-scope-is-exposed-publicly-but-has-no-public

## Demo

<img width="3012" height="1648" alt="CleanShot 2026-06-15 at 12 14 10@2x" src="https://github.com/user-attachments/assets/45647d19-f96a-43ad-a41c-ea0c9158f888" />

Stacked on #32231 (the parity test + YAML annotations). Review/merge that first.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32240">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

