### PR TITLE
feat(core): Enforce node group validity on workflow create and update (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts
@@ -458,6 +458,50 @@ describe('createBuildWorkflowTool', () => {
 		);
 	});
 
+	it('forwards removeNodeGroups to the workflow update', async () => {
+		const reportBuildOutcome = vi.fn(
+			async () => await Promise.resolve({ type: 'verify' as const, workflowId: 'wf-1' }),
+		);
+		const suspend = vi.fn();
+		const context = {
+			userId: 'user-1',
+			runId: 'run-1',
+			workflowService: {
+				updateFromWorkflowJSON: vi.fn(async () => await Promise.resolve({ id: 'wf-1' })),
+				clearAiTemporary: vi.fn(async () => await Promise.resolve()),
+			},
+			credentialService: {},
+			nodeService: {},
+			dataTableService: {},
+			executionService: {},
+			workflowBuildContext: {
+				threadId: 'thread-1',
+				runId: 'run-1',
+				taskId: 'task-1',
+				workItemId: 'wi-1',
+				allowPostPlanWorkflowCreate: true,
+				workflowTaskService: {
+					reportBuildOutcome,
+				},
+			},
+			permissions: { updateWorkflow: 'ask' },
+			logger: { warn: vi.fn() },
+		} as unknown as InstanceAiContext;
+
+		const tool = createBuildWorkflowTool(context);
+		await executeTool(
+			tool,
+			{ workflowId: 'wf-1', code: 'workflow code', removeNodeGroups: ['My Group'] },
+			{ suspend },
+		);
+
+		expect(context.workflowService.updateFromWorkflowJSON).toHaveBeenCalledWith(
+			'wf-1',
+			expect.objectContaining({ name: 'Generated workflow' }),
+			{ removeNodeGroups: ['My Group'] },
+		);
+	});
+
 	it('does not finalize the planned task when saving a supporting workflow', async () => {
 		const reportBuildOutcome = vi.fn<
 			(outcome: WorkflowBuildOutcome) => Promise<{ type: 'verify'; workflowId: string }>

--- a/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
+++ b/packages/@n8n/instance-ai/src/tools/workflows/build-workflow.tool.ts
@@ -88,6 +88,14 @@ export const buildWorkflowInputSchema = z.object({
 			'Set true when saving a supporting sub-workflow that will be referenced by the main workflow. ' +
 				'In a planned build task, this completes the task only when the task itself is marked isSupportingWorkflow; otherwise save the main workflow later.',
 		),
+	removeNodeGroups: z
+		.array(z.string())
+		.optional()
+		.describe(
+			'Names of node groups to dissolve when updating an existing workflow. Use only when a save was ' +
+				'rejected because your change would break a node group and the change is intended. Dissolving ' +
+				'removes the grouping only — the nodes stay in the workflow.',
+		),
 });
 
 const triggerNodeOutputSchema = z.object({
@@ -684,10 +692,15 @@ export function createBuildWorkflowTool(context: InstanceAiContext) {
 				};
 
 				if (workflowId) {
+					const removeNodeGroups = input.removeNodeGroups;
+					const updateOptions = {
+						...(projectId ? { projectId } : {}),
+						...(removeNodeGroups && removeNodeGroups.length > 0 ? { removeNodeGroups } : {}),
+					};
 					const updated = await context.workflowService.updateFromWorkflowJSON(
 						workflowId,
 						json,
-						projectId ? { projectId } : undefined,
+						Object.keys(updateOptions).length > 0 ? updateOptions : undefined,
 					);
 					lastCodeVersionId = updated.versionId;
 					return await createSuccessResponse(updated.id);

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -269,11 +269,13 @@ export interface InstanceAiWorkflowService {
 		json: WorkflowJSON,
 		options?: { projectId?: string; markAsAiTemporary?: boolean },
 	): Promise<WorkflowDetail>;
-	/** Update a workflow from SDK-produced WorkflowJSON. */
+	/** Update a workflow from SDK-produced WorkflowJSON. `removeNodeGroups`
+	 *  dissolves the named node groups as part of the save — the grouping is
+	 *  removed while the grouped nodes stay in the workflow. */
 	updateFromWorkflowJSON(
 		workflowId: string,
 		json: WorkflowJSON,
-		options?: { projectId?: string },
+		options?: { projectId?: string; removeNodeGroups?: string[] },
 	): Promise<WorkflowDetail>;
 	archive(workflowId: string): Promise<void>;
 	unarchive(workflowId: string): Promise<void>;

--- a/packages/cli/src/__tests__/workflow-helpers.test.ts
+++ b/packages/cli/src/__tests__/workflow-helpers.test.ts
@@ -22,6 +22,7 @@ import { VariablesService } from '@/environments.ee/variables/variables.service.
 import { ExecutionPersistence } from '@/executions/execution-persistence';
 import { OwnershipService } from '@/services/ownership.service';
 import {
+	extendWorkflowNodeGroups,
 	getLastExecutedNodeData,
 	getLastExecutedNodeRuns,
 	getVariables,
@@ -458,6 +459,15 @@ describe('validateWorkflowStructure', () => {
 const makeGroupNode = (id: string, type = 'test') =>
 	({ id, name: id, type, typeVersion: 1, position: [0, 0], parameters: {} }) as INode;
 
+const makeNodeTypes = (descriptions: Record<string, Partial<INodeTypeDescription>>): INodeTypes =>
+	({
+		getByNameAndVersion(type: string) {
+			const description = descriptions[type];
+			if (!description) throw new UnexpectedError(`Unknown node type "${type}"`);
+			return { description } as INodeType;
+		},
+	}) as INodeTypes;
+
 const mainConnections = (...pairs: Array<[string, string]>): IConnections =>
 	pairs.reduce<IConnections>((connections, [from, to]) => {
 		const existing = connections[from]?.main?.[0] ?? [];
@@ -481,13 +491,7 @@ describe('validateWorkflowNodeGroups', () => {
 		testTrigger: { group: ['trigger'], inputs: [], outputs: [NodeConnectionTypes.Main] },
 	};
 
-	const nodeTypes = {
-		getByNameAndVersion(type: string) {
-			const description = nodeTypeDescriptions[type];
-			if (!description) throw new UnexpectedError(`Unknown node type "${type}"`);
-			return { description } as INodeType;
-		},
-	} as INodeTypes;
+	const nodeTypes = makeNodeTypes(nodeTypeDescriptions);
 
 	it('should pass when nodeGroups is undefined', () => {
 		expect(() =>
@@ -753,6 +757,120 @@ describe('repairWorkflowNodeGroups', () => {
 				nodeGroups: [{ id: 'g1', name: 'Group 1', nodeIds: [] }],
 			}),
 		).toEqual([]);
+	});
+});
+
+describe('extendWorkflowNodeGroups', () => {
+	const makeNode = makeGroupNode;
+
+	const nodeTypes = makeNodeTypes({
+		test: {
+			group: ['transform'],
+			inputs: [NodeConnectionTypes.Main],
+			outputs: [NodeConnectionTypes.Main],
+		},
+	});
+
+	it('should return undefined when there are no candidate nodes', () => {
+		expect(
+			extendWorkflowNodeGroups(
+				{
+					nodes: [makeNode('A'), makeNode('B')],
+					connections: {},
+					nodeGroups: [{ id: 'g1', name: 'Group 1', nodeIds: ['A', 'B'] }],
+				},
+				new Set(),
+				nodeTypes,
+			),
+		).toBeUndefined();
+	});
+
+	it('should return undefined when all groups are already valid', () => {
+		expect(
+			extendWorkflowNodeGroups(
+				{
+					nodes: [makeNode('A'), makeNode('B'), makeNode('M')],
+					connections: mainConnections(['A', 'B'], ['B', 'M']),
+					nodeGroups: [{ id: 'g1', name: 'Group 1', nodeIds: ['A', 'B'] }],
+				},
+				new Set(['M']),
+				nodeTypes,
+			),
+		).toBeUndefined();
+	});
+
+	it('should absorb a node inserted between two grouped nodes', () => {
+		expect(
+			extendWorkflowNodeGroups(
+				{
+					nodes: [makeNode('A'), makeNode('M'), makeNode('B')],
+					connections: mainConnections(['A', 'M'], ['M', 'B']),
+					nodeGroups: [{ id: 'g1', name: 'Group 1', nodeIds: ['A', 'B'] }],
+				},
+				new Set(['M']),
+				nodeTypes,
+			),
+		).toEqual([{ id: 'g1', name: 'Group 1', nodeIds: ['A', 'B', 'M'] }]);
+	});
+
+	it('should absorb a chain of inserted nodes', () => {
+		expect(
+			extendWorkflowNodeGroups(
+				{
+					nodes: [makeNode('A'), makeNode('M1'), makeNode('M2'), makeNode('B')],
+					connections: mainConnections(['A', 'M1'], ['M1', 'M2'], ['M2', 'B']),
+					nodeGroups: [{ id: 'g1', name: 'Group 1', nodeIds: ['A', 'B'] }],
+				},
+				new Set(['M1', 'M2']),
+				nodeTypes,
+			),
+		).toEqual([{ id: 'g1', name: 'Group 1', nodeIds: ['A', 'B', 'M1', 'M2'] }]);
+	});
+
+	it('should not absorb new nodes that are not needed to keep the group valid', () => {
+		// N hangs off B and is tried first (node order), but the shrink pass drops it
+		expect(
+			extendWorkflowNodeGroups(
+				{
+					nodes: [makeNode('A'), makeNode('N'), makeNode('M'), makeNode('B')],
+					connections: mainConnections(['A', 'M'], ['M', 'B'], ['B', 'N']),
+					nodeGroups: [{ id: 'g1', name: 'Group 1', nodeIds: ['A', 'B'] }],
+				},
+				new Set(['N', 'M']),
+				nodeTypes,
+			),
+		).toEqual([{ id: 'g1', name: 'Group 1', nodeIds: ['A', 'B', 'M'] }]);
+	});
+
+	it('should leave a group unchanged when extension cannot make it valid', () => {
+		expect(
+			extendWorkflowNodeGroups(
+				{
+					nodes: [makeNode('A'), makeNode('M'), makeNode('B')],
+					connections: mainConnections(['A', 'M']),
+					nodeGroups: [{ id: 'g1', name: 'Group 1', nodeIds: ['A', 'B'] }],
+				},
+				new Set(['M']),
+				nodeTypes,
+			),
+		).toBeUndefined();
+	});
+
+	it('should not absorb nodes that belong to another group', () => {
+		expect(
+			extendWorkflowNodeGroups(
+				{
+					nodes: [makeNode('A'), makeNode('M'), makeNode('B')],
+					connections: mainConnections(['A', 'M'], ['M', 'B']),
+					nodeGroups: [
+						{ id: 'g1', name: 'Group 1', nodeIds: ['A', 'B'] },
+						{ id: 'g2', name: 'Group 2', nodeIds: ['M'] },
+					],
+				},
+				new Set(['M']),
+				nodeTypes,
+			),
+		).toBeUndefined();
 	});
 });
 

--- a/packages/cli/src/__tests__/workflow-helpers.test.ts
+++ b/packages/cli/src/__tests__/workflow-helpers.test.ts
@@ -2,13 +2,20 @@ import { MAX_PINNED_DATA_SIZE, MAX_WORKFLOW_SIZE, MAX_EXPECTED_REQUEST_SIZE } fr
 import { mockInstance } from '@n8n/backend-test-utils';
 import type { CredentialsEntity, IExecutionResponse, Project, Variables } from '@n8n/db';
 import { CredentialsRepository } from '@n8n/db';
-import type {
-	ExecutionError,
-	IRun,
-	ITaskData,
-	IWorkflowBase,
-	IWorkflowSettings,
-	RelatedExecution,
+import {
+	NodeConnectionTypes,
+	UnexpectedError,
+	type ExecutionError,
+	type IConnections,
+	type INode,
+	type INodeType,
+	type INodeTypes,
+	type INodeTypeDescription,
+	type IRun,
+	type ITaskData,
+	type IWorkflowBase,
+	type IWorkflowSettings,
+	type RelatedExecution,
 } from 'n8n-workflow';
 
 import { VariablesService } from '@/environments.ee/variables/variables.service.ee';
@@ -20,6 +27,7 @@ import {
 	getVariables,
 	preserveInputOverride,
 	removeDefaultValues,
+	repairWorkflowNodeGroups,
 	replaceInvalidCredentials,
 	shouldRestartParentExecution,
 	updateParentExecutionWithChildResults,
@@ -447,71 +455,304 @@ describe('validateWorkflowStructure', () => {
 	});
 });
 
+const makeGroupNode = (id: string, type = 'test') =>
+	({ id, name: id, type, typeVersion: 1, position: [0, 0], parameters: {} }) as INode;
+
+const mainConnections = (...pairs: Array<[string, string]>): IConnections =>
+	pairs.reduce<IConnections>((connections, [from, to]) => {
+		const existing = connections[from]?.main?.[0] ?? [];
+		return {
+			...connections,
+			[from]: {
+				main: [[...existing, { node: to, type: NodeConnectionTypes.Main, index: 0 }]],
+			},
+		};
+	}, {});
+
 describe('validateWorkflowNodeGroups', () => {
-	const makeNode = (id: string) =>
-		({ id, name: `Node ${id}`, type: 'test', position: [0, 0], parameters: {} }) as never;
+	const makeNode = makeGroupNode;
+
+	const nodeTypeDescriptions: Record<string, Partial<INodeTypeDescription>> = {
+		test: {
+			group: ['transform'],
+			inputs: [NodeConnectionTypes.Main],
+			outputs: [NodeConnectionTypes.Main],
+		},
+		testTrigger: { group: ['trigger'], inputs: [], outputs: [NodeConnectionTypes.Main] },
+	};
+
+	const nodeTypes = {
+		getByNameAndVersion(type: string) {
+			const description = nodeTypeDescriptions[type];
+			if (!description) throw new UnexpectedError(`Unknown node type "${type}"`);
+			return { description } as INodeType;
+		},
+	} as INodeTypes;
 
 	it('should pass when nodeGroups is undefined', () => {
 		expect(() =>
-			validateWorkflowNodeGroups({ nodes: [makeNode('n1')], nodeGroups: undefined }),
+			validateWorkflowNodeGroups(
+				{ nodes: [makeNode('n1')], connections: {}, nodeGroups: undefined },
+				nodeTypes,
+			),
 		).not.toThrow();
 	});
 
 	it('should pass when nodeGroups is empty', () => {
 		expect(() =>
-			validateWorkflowNodeGroups({ nodes: [makeNode('n1')], nodeGroups: [] }),
+			validateWorkflowNodeGroups(
+				{ nodes: [makeNode('n1')], connections: {}, nodeGroups: [] },
+				nodeTypes,
+			),
 		).not.toThrow();
 	});
 
-	it('should pass when all nodeIds reference existing nodes', () => {
+	it('should pass when all nodeIds reference connected existing nodes', () => {
 		expect(() =>
-			validateWorkflowNodeGroups({
-				nodes: [makeNode('n1'), makeNode('n2')],
-				nodeGroups: [{ id: 'g1', name: 'Group 1', nodeIds: ['n1', 'n2'] }],
-			}),
+			validateWorkflowNodeGroups(
+				{
+					nodes: [makeNode('n1'), makeNode('n2')],
+					connections: mainConnections(['n1', 'n2']),
+					nodeGroups: [{ id: 'g1', name: 'Group 1', nodeIds: ['n1', 'n2'] }],
+				},
+				nodeTypes,
+			),
+		).not.toThrow();
+	});
+
+	it('should pass for a single-node group', () => {
+		expect(() =>
+			validateWorkflowNodeGroups(
+				{
+					nodes: [makeNode('n1')],
+					connections: {},
+					nodeGroups: [{ id: 'g1', name: 'Group 1', nodeIds: ['n1'] }],
+				},
+				nodeTypes,
+			),
 		).not.toThrow();
 	});
 
 	it('should throw when a nodeId does not reference an existing node', () => {
 		expect(() =>
-			validateWorkflowNodeGroups({
-				nodes: [makeNode('n1')],
-				nodeGroups: [{ id: 'g1', name: 'My Group', nodeIds: ['n1', 'n999'] }],
-			}),
+			validateWorkflowNodeGroups(
+				{
+					nodes: [makeNode('n1')],
+					connections: {},
+					nodeGroups: [{ id: 'g1', name: 'My Group', nodeIds: ['n1', 'n999'] }],
+				},
+				nodeTypes,
+			),
 		).toThrow('Group "My Group" references node ID "n999" that does not exist in the workflow.');
 	});
 
 	it('should throw for the first invalid nodeId found', () => {
 		expect(() =>
-			validateWorkflowNodeGroups({
-				nodes: [],
-				nodeGroups: [{ id: 'g1', name: 'Empty Group', nodeIds: ['bad1', 'bad2'] }],
-			}),
+			validateWorkflowNodeGroups(
+				{
+					nodes: [],
+					connections: {},
+					nodeGroups: [{ id: 'g1', name: 'Empty Group', nodeIds: ['bad1', 'bad2'] }],
+				},
+				nodeTypes,
+			),
 		).toThrow('Group "Empty Group" references node ID "bad1"');
 	});
 
 	it('should throw when a node belongs to multiple groups', () => {
 		expect(() =>
-			validateWorkflowNodeGroups({
-				nodes: [makeNode('n1'), makeNode('n2')],
-				nodeGroups: [
-					{ id: 'g1', name: 'Group A', nodeIds: ['n1'] },
-					{ id: 'g2', name: 'Group B', nodeIds: ['n1', 'n2'] },
-				],
-			}),
+			validateWorkflowNodeGroups(
+				{
+					nodes: [makeNode('n1'), makeNode('n2')],
+					connections: mainConnections(['n1', 'n2']),
+					nodeGroups: [
+						{ id: 'g1', name: 'Group A', nodeIds: ['n1'] },
+						{ id: 'g2', name: 'Group B', nodeIds: ['n1', 'n2'] },
+					],
+				},
+				nodeTypes,
+			),
 		).toThrow('Node "n1" belongs to multiple groups: "Group A" and "Group B".');
 	});
 
 	it('should throw when group names are not unique', () => {
 		expect(() =>
-			validateWorkflowNodeGroups({
+			validateWorkflowNodeGroups(
+				{
+					nodes: [makeNode('n1')],
+					connections: {},
+					nodeGroups: [
+						{ id: 'g1', name: 'Duplicate', nodeIds: ['n1'] },
+						{ id: 'g2', name: 'Duplicate', nodeIds: [] },
+					],
+				},
+				nodeTypes,
+			),
+		).toThrow('Duplicate node group name "Duplicate".');
+	});
+
+	it('should throw when a group has no nodes', () => {
+		expect(() =>
+			validateWorkflowNodeGroups(
+				{
+					nodes: [makeNode('n1')],
+					connections: {},
+					nodeGroups: [{ id: 'g1', name: 'Empty Group', nodeIds: [] }],
+				},
+				nodeTypes,
+			),
+		).toThrow('Group "Empty Group" must contain at least one node.');
+	});
+
+	it('should throw when grouped nodes are not connected to each other', () => {
+		expect(() =>
+			validateWorkflowNodeGroups(
+				{
+					nodes: [makeNode('n1'), makeNode('n2'), makeNode('n3')],
+					connections: mainConnections(['n1', 'n2'], ['n2', 'n3']),
+					nodeGroups: [{ id: 'g1', name: 'Split Group', nodeIds: ['n1', 'n3'] }],
+				},
+				nodeTypes,
+			),
+		).toThrow('The nodes in group "Split Group" are not all connected to each other.');
+	});
+
+	it('should throw when a group contains a trigger node', () => {
+		expect(() =>
+			validateWorkflowNodeGroups(
+				{
+					nodes: [makeNode('t1', 'testTrigger'), makeNode('n2')],
+					connections: mainConnections(['t1', 'n2']),
+					nodeGroups: [{ id: 'g1', name: 'Trigger Group', nodeIds: ['t1', 'n2'] }],
+				},
+				nodeTypes,
+			),
+		).toThrow('Group "Trigger Group" contains trigger node(s) "t1".');
+	});
+
+	it('should throw when a non-main connection crosses the group boundary', () => {
+		const connections: IConnections = {
+			...mainConnections(['n1', 'n2']),
+			a1: { ai_tool: [[{ node: 'n1', type: NodeConnectionTypes.AiTool, index: 0 }]] },
+		};
+
+		expect(() =>
+			validateWorkflowNodeGroups(
+				{
+					nodes: [makeNode('a1'), makeNode('n1'), makeNode('n2')],
+					connections,
+					nodeGroups: [{ id: 'g1', name: 'Tool Group', nodeIds: ['n1', 'n2'] }],
+				},
+				nodeTypes,
+			),
+		).toThrow(
+			'The "ai_tool" connection between "a1" and "n1" crosses the boundary of group "Tool Group".',
+		);
+	});
+
+	it('should throw when a group has multiple entry points', () => {
+		expect(() =>
+			validateWorkflowNodeGroups(
+				{
+					nodes: [makeNode('o1'), makeNode('o2'), makeNode('x'), makeNode('y')],
+					connections: mainConnections(['o1', 'x'], ['o2', 'y']),
+					nodeGroups: [{ id: 'g1', name: 'Wide Group', nodeIds: ['x', 'y'] }],
+				},
+				nodeTypes,
+			),
+		).toThrow('Group "Wide Group" has multiple entry points');
+	});
+
+	it('should throw when a connection from outside goes to a non-entry node', () => {
+		expect(() =>
+			validateWorkflowNodeGroups(
+				{
+					nodes: [makeNode('o1'), makeNode('x'), makeNode('y')],
+					connections: mainConnections(['x', 'y'], ['o1', 'y']),
+					nodeGroups: [{ id: 'g1', name: 'Side Group', nodeIds: ['x', 'y'] }],
+				},
+				nodeTypes,
+			),
+		).toThrow('Node "y" in group "Side Group" receives a connection from outside the group.');
+	});
+
+	it('should tolerate unknown node types and still validate connectivity', () => {
+		const nodes = [makeNode('u1', 'unknown-type'), makeNode('u2', 'unknown-type')];
+
+		expect(() =>
+			validateWorkflowNodeGroups(
+				{
+					nodes,
+					connections: mainConnections(['u1', 'u2']),
+					nodeGroups: [{ id: 'g1', name: 'Unknown Group', nodeIds: ['u1', 'u2'] }],
+				},
+				nodeTypes,
+			),
+		).not.toThrow();
+
+		expect(() =>
+			validateWorkflowNodeGroups(
+				{
+					nodes,
+					connections: {},
+					nodeGroups: [{ id: 'g1', name: 'Unknown Group', nodeIds: ['u1', 'u2'] }],
+				},
+				nodeTypes,
+			),
+		).toThrow('The nodes in group "Unknown Group" are not all connected to each other.');
+	});
+});
+
+describe('repairWorkflowNodeGroups', () => {
+	const makeNode = makeGroupNode;
+
+	it('should return undefined when nodeGroups is undefined', () => {
+		expect(
+			repairWorkflowNodeGroups({ nodes: [makeNode('n1')], nodeGroups: undefined }),
+		).toBeUndefined();
+	});
+
+	it('should return undefined when nodeGroups is empty', () => {
+		expect(repairWorkflowNodeGroups({ nodes: [makeNode('n1')], nodeGroups: [] })).toBeUndefined();
+	});
+
+	it('should return undefined when all grouped nodes exist', () => {
+		expect(
+			repairWorkflowNodeGroups({
+				nodes: [makeNode('n1'), makeNode('n2')],
+				nodeGroups: [{ id: 'g1', name: 'Group 1', nodeIds: ['n1', 'n2'] }],
+			}),
+		).toBeUndefined();
+	});
+
+	it('should drop node IDs that no longer exist from a group', () => {
+		expect(
+			repairWorkflowNodeGroups({
+				nodes: [makeNode('n1')],
+				nodeGroups: [{ id: 'g1', name: 'Group 1', nodeIds: ['n1', 'n2'] }],
+			}),
+		).toEqual([{ id: 'g1', name: 'Group 1', nodeIds: ['n1'] }]);
+	});
+
+	it('should dissolve a group whose nodes are all gone', () => {
+		expect(
+			repairWorkflowNodeGroups({
 				nodes: [makeNode('n1')],
 				nodeGroups: [
-					{ id: 'g1', name: 'Duplicate', nodeIds: ['n1'] },
-					{ id: 'g2', name: 'Duplicate', nodeIds: [] },
+					{ id: 'g1', name: 'Group A', nodeIds: ['n1'] },
+					{ id: 'g2', name: 'Group B', nodeIds: ['n2'] },
 				],
 			}),
-		).toThrow('Duplicate node group name "Duplicate".');
+		).toEqual([{ id: 'g1', name: 'Group A', nodeIds: ['n1'] }]);
+	});
+
+	it('should dissolve a group that is already empty', () => {
+		expect(
+			repairWorkflowNodeGroups({
+				nodes: [makeNode('n1')],
+				nodeGroups: [{ id: 'g1', name: 'Group 1', nodeIds: [] }],
+			}),
+		).toEqual([]);
 	});
 });
 

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -1115,6 +1115,7 @@ import type { WorkflowService } from '@/workflows/workflow.service';
 import type { License } from '@/license';
 import type { RoleService } from '@/services/role.service';
 
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { InstanceAiAdapterService } from '../instance-ai.adapter.service';
 import { userHasScopes } from '@/permissions.ee/check-access';
 
@@ -1982,6 +1983,25 @@ describe('createWorkflowAdapter', () => {
 
 		const updateData = mockWorkflowService.update.mock.calls[0]?.[1] as { nodes: INode[] };
 		expect(updateData.nodes[0].credentials).toBeUndefined();
+	});
+
+	it('propagates node group validation errors from workflowService.update so the agent can recover', async () => {
+		const { adapter, mockWorkflowService } = createWorkflowAdapterForTests();
+		mockWorkflowService.update.mockRejectedValueOnce(
+			new BadRequestError(
+				'The nodes in group "My Group" are not all connected to each other. Grouped nodes must form a single connected sequence.',
+			),
+		);
+
+		const workflow = {
+			name: 'Test',
+			nodes: [],
+			connections: {},
+		} as unknown as WorkflowJSON;
+
+		await expect(adapter.updateFromWorkflowJSON('wf-new', workflow)).rejects.toThrow(
+			'The nodes in group "My Group" are not all connected to each other.',
+		);
 	});
 
 	it('clears the AI-builder temporary marker when promoting the main workflow', async () => {

--- a/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts
@@ -1517,6 +1517,7 @@ function createWorkflowAdapterForTests(overrides?: {
 		create: jest.fn().mockImplementation((data: Record<string, unknown>) => data),
 		save: jest.fn().mockResolvedValue(savedWorkflow),
 		update: jest.fn().mockResolvedValue(undefined),
+		findOne: jest.fn().mockResolvedValue(null),
 		manager: {
 			transaction: jest.fn(
 				async (
@@ -2002,6 +2003,41 @@ describe('createWorkflowAdapter', () => {
 		await expect(adapter.updateFromWorkflowJSON('wf-new', workflow)).rejects.toThrow(
 			'The nodes in group "My Group" are not all connected to each other.',
 		);
+	});
+
+	it('dissolves the requested node groups when updating', async () => {
+		const { adapter, mockWorkflowService, mockWorkflowRepository } =
+			createWorkflowAdapterForTests();
+		mockWorkflowRepository.findOne.mockResolvedValue({
+			id: 'wf-new',
+			nodeGroups: [
+				{ id: 'g1', name: 'Group 1', nodeIds: ['n1'] },
+				{ id: 'g2', name: 'Group 2', nodeIds: ['n2'] },
+			],
+		});
+
+		const workflow = { name: 'Test', nodes: [], connections: {} } as unknown as WorkflowJSON;
+		await adapter.updateFromWorkflowJSON('wf-new', workflow, { removeNodeGroups: ['Group 1'] });
+
+		const updateData = mockWorkflowService.update.mock.calls[0]?.[1] as {
+			nodeGroups?: unknown;
+		};
+		expect(updateData.nodeGroups).toEqual([{ id: 'g2', name: 'Group 2', nodeIds: ['n2'] }]);
+	});
+
+	it('rejects removal of a node group that does not exist', async () => {
+		const { adapter, mockWorkflowService, mockWorkflowRepository } =
+			createWorkflowAdapterForTests();
+		mockWorkflowRepository.findOne.mockResolvedValue({
+			id: 'wf-new',
+			nodeGroups: [{ id: 'g1', name: 'Group 1', nodeIds: ['n1'] }],
+		});
+
+		const workflow = { name: 'Test', nodes: [], connections: {} } as unknown as WorkflowJSON;
+		await expect(
+			adapter.updateFromWorkflowJSON('wf-new', workflow, { removeNodeGroups: ['Missing'] }),
+		).rejects.toThrow('Cannot remove node group(s) "Missing": not found in this workflow.');
+		expect(mockWorkflowService.update).not.toHaveBeenCalled();
 	});
 
 	it('clears the AI-builder temporary marker when promoting the main workflow', async () => {

--- a/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.adapter.service.ts
@@ -79,6 +79,7 @@ import {
 	type INodePropertyOptions,
 	type INodeTypeDescription,
 	type IConnections,
+	type IWorkflowGroup,
 	type IWorkflowSettings,
 	type IPinData,
 	type IWorkflowExecutionDataProcess,
@@ -97,6 +98,7 @@ import {
 	SCHEDULE_TRIGGER_NODE_TYPE,
 	TimeoutExecutionCancelledError,
 	UnexpectedError,
+	UserError,
 	jsonParse,
 } from 'n8n-workflow';
 
@@ -645,7 +647,7 @@ export class InstanceAiAdapterService {
 			async updateFromWorkflowJSON(
 				workflowId: string,
 				json: WorkflowJSON,
-				_options?: { projectId?: string },
+				options?: { projectId?: string; removeNodeGroups?: string[] },
 			) {
 				assertNotReadOnly();
 				// Strip redactionPolicy if the user lacks the required directional scope —
@@ -675,6 +677,31 @@ export class InstanceAiAdapterService {
 					}
 				}
 
+				// Dissolve the requested node groups: keep the stored groups except the
+				// named ones, so the rest of the save is validated against the result.
+				let nodeGroupsUpdate: IWorkflowGroup[] | undefined;
+				const removeNodeGroups = options?.removeNodeGroups ?? [];
+				if (removeNodeGroups.length > 0) {
+					const storedWorkflow = await workflowRepository.findOne({
+						where: { id: workflowId },
+						select: ['id', 'nodeGroups'],
+					});
+					const storedGroups = storedWorkflow?.nodeGroups ?? [];
+					const storedNames = new Set(storedGroups.map((group) => group.name));
+					const missing = removeNodeGroups.filter((name) => !storedNames.has(name));
+					if (missing.length > 0) {
+						throw new UserError(
+							`Cannot remove node group(s) ${missing.map((name) => `"${name}"`).join(', ')}: not found in this workflow. Existing groups: ${
+								storedGroups.length > 0
+									? storedGroups.map((group) => `"${group.name}"`).join(', ')
+									: 'none'
+							}.`,
+						);
+					}
+					const namesToRemove = new Set(removeNodeGroups);
+					nodeGroupsUpdate = storedGroups.filter((group) => !namesToRemove.has(group.name));
+				}
+
 				const nodes = sanitizeCredentialReferencesForSave(json.nodes);
 				let updateData = workflowRepository.create({
 					name: json.name,
@@ -682,6 +709,7 @@ export class InstanceAiAdapterService {
 					connections: json.connections as unknown as IConnections,
 					settings,
 					pinData: sdkPinDataToRuntime(json.pinData),
+					...(nodeGroupsUpdate !== undefined ? { nodeGroups: nodeGroupsUpdate } : {}),
 				} as Partial<WorkflowEntity>);
 
 				let updated: WorkflowEntity;

--- a/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
@@ -438,6 +438,61 @@ describe('update-workflow MCP tool', () => {
 			expect(response.error).toContain('group "My Group"');
 		});
 
+		test('dissolves a node group via removeNodeGroup', async () => {
+			findWorkflowMock.mockResolvedValue(
+				Object.assign(buildExistingWorkflow(), {
+					nodeGroups: [
+						{ id: 'g1', name: 'My Group', nodeIds: ['a'] },
+						{ id: 'g2', name: 'Other Group', nodeIds: ['b'] },
+					],
+				}),
+			);
+
+			const result = await callHandler({
+				workflowId: 'wf-1',
+				operations: [{ type: 'removeNodeGroup', groupName: 'My Group' }],
+			});
+
+			expect(result.isError).toBeUndefined();
+			const saved = updateMock.mock.calls[0][1] as WorkflowEntity;
+			expect(saved.nodeGroups).toEqual([{ id: 'g2', name: 'Other Group', nodeIds: ['b'] }]);
+		});
+
+		test('returns an error for removeNodeGroup with an unknown group name', async () => {
+			findWorkflowMock.mockResolvedValue(
+				Object.assign(buildExistingWorkflow(), {
+					nodeGroups: [{ id: 'g1', name: 'My Group', nodeIds: ['a'] }],
+				}),
+			);
+
+			const result = await callHandler({
+				workflowId: 'wf-1',
+				operations: [{ type: 'removeNodeGroup', groupName: 'Missing' }],
+			});
+
+			const response = parseResult(result);
+			expect(result.isError).toBe(true);
+			expect(response.error).toContain("node group 'Missing' not found");
+			expect(updateMock).not.toHaveBeenCalled();
+		});
+
+		test('does not touch nodeGroups when no group operations run', async () => {
+			findWorkflowMock.mockResolvedValue(
+				Object.assign(buildExistingWorkflow(), {
+					nodeGroups: [{ id: 'g1', name: 'My Group', nodeIds: ['a'] }],
+				}),
+			);
+
+			const result = await callHandler({
+				workflowId: 'wf-1',
+				operations: [{ type: 'setWorkflowMetadata', name: 'Renamed' }],
+			});
+
+			expect(result.isError).toBeUndefined();
+			const saved = updateMock.mock.calls[0][1] as WorkflowEntity;
+			expect(saved.nodeGroups).toBeUndefined();
+		});
+
 		test('tracks telemetry on success with op metadata', async () => {
 			await callHandler({
 				workflowId: 'wf-1',

--- a/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
@@ -7,6 +7,7 @@ import { createUpdateWorkflowTool } from '../tools/workflow-builder/update-workf
 
 import { CollaborationService } from '@/collaboration/collaboration.service';
 import { CredentialsService } from '@/credentials/credentials.service';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
 import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { NodeTypes } from '@/node-types';
 import { TagService } from '@/services/tag.service';
@@ -418,6 +419,23 @@ describe('update-workflow MCP tool', () => {
 			const response = parseResult(result);
 			expect(result.isError).toBe(true);
 			expect(response.error).toBe("Workflow not found or you don't have permission to access it.");
+		});
+
+		test('returns a recoverable error when the update would leave a node group invalid', async () => {
+			updateMock.mockRejectedValueOnce(
+				new BadRequestError(
+					'The nodes in group "My Group" are not all connected to each other. Grouped nodes must form a single connected sequence.',
+				),
+			);
+
+			const result = await callHandler({
+				workflowId: 'wf-1',
+				operations: [{ type: 'removeConnection', source: 'A', target: 'B' }],
+			});
+
+			const response = parseResult(result);
+			expect(result.isError).toBe(true);
+			expect(response.error).toContain('group "My Group"');
 		});
 
 		test('tracks telemetry on success with op metadata', async () => {

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -16,6 +16,7 @@ import {
 	applyOperations,
 	partialUpdateOperationSchema,
 	toWorkflowSlice,
+	type ApplyOperationsSuccess,
 	type PartialUpdateOperation,
 } from './workflow-operations';
 
@@ -49,6 +50,7 @@ const operationTypeSchema = z.enum([
 	'setWorkflowMetadata',
 	'addTags',
 	'removeTags',
+	'removeNodeGroup',
 ]);
 
 const positionInputSchema = z.array(z.number()).length(2).describe('Canvas [x, y].');
@@ -117,6 +119,12 @@ const operationInputSchema = z
 		name: z.string().max(128).optional().describe('Only used for setWorkflowMetadata.'),
 		description: z.string().max(255).optional().describe('Only used for setWorkflowMetadata.'),
 		names: z.array(z.string()).optional().describe('For addTags / removeTags.'),
+		groupName: z
+			.string()
+			.optional()
+			.describe(
+				"For removeNodeGroup: name of the node group to dissolve. Only the grouping is removed — the group's nodes stay in the workflow. Use when an update was rejected because it would break a node group and the change is intended.",
+			),
 	})
 	.describe('Workflow update operation. Provide fields matching type.');
 
@@ -212,6 +220,31 @@ const outputSchema = {
 		),
 	note: z.string().optional(),
 } satisfies z.ZodRawShape;
+
+function buildWorkflowUpdateEntity(
+	result: ApplyOperationsSuccess,
+	existingWorkflow: WorkflowEntity,
+	hasNonTagOperations: boolean,
+): WorkflowEntity {
+	const workflowUpdateData = new WorkflowEntity();
+	Object.assign(workflowUpdateData, {
+		name: result.workflow.name,
+		...(result.workflow.description !== undefined
+			? { description: result.workflow.description }
+			: {}),
+		nodes: result.workflow.nodes,
+		connections: result.workflow.connections,
+		...(result.nodeGroups !== undefined ? { nodeGroups: result.nodeGroups } : {}),
+		meta: hasNonTagOperations
+			? {
+					...(existingWorkflow.meta ?? {}),
+					aiBuilderAssisted: true,
+					builderVariant: 'mcp',
+				}
+			: (existingWorkflow.meta ?? {}),
+	});
+	return workflowUpdateData;
+}
 
 /**
  * MCP tool that updates a workflow by applying a small list of named operations
@@ -343,22 +376,11 @@ export const createUpdateWorkflowTool = (
 				(op) => op.type !== 'addTags' && op.type !== 'removeTags',
 			);
 
-			const workflowUpdateData = new WorkflowEntity();
-			Object.assign(workflowUpdateData, {
-				name: result.workflow.name,
-				...(result.workflow.description !== undefined
-					? { description: result.workflow.description }
-					: {}),
-				nodes: result.workflow.nodes,
-				connections: result.workflow.connections,
-				meta: hasNonTagOperations
-					? {
-							...(existingWorkflow.meta ?? {}),
-							aiBuilderAssisted: true,
-							builderVariant: 'mcp',
-						}
-					: (existingWorkflow.meta ?? {}),
-			});
+			const workflowUpdateData = buildWorkflowUpdateEntity(
+				result,
+				existingWorkflow,
+				hasNonTagOperations,
+			);
 
 			resolveNodeWebhookIds(workflowUpdateData, nodeTypes);
 

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/workflow-operations.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/workflow-operations.ts
@@ -4,6 +4,7 @@ import type {
 	INode,
 	INodeParameters,
 	IWorkflowBase,
+	IWorkflowGroup,
 	NodeConnectionType,
 } from 'n8n-workflow';
 import { isSafeObjectProperty, NodeConnectionTypes } from 'n8n-workflow';
@@ -184,6 +185,14 @@ export const partialUpdateOperationSchema = z.discriminatedUnion('type', [
 			.max(50)
 			.describe('Tag names to detach from the workflow. Unknown names are ignored.'),
 	}),
+	z.object({
+		type: z.literal('removeNodeGroup'),
+		groupName: z
+			.string()
+			.describe(
+				"Name of the node group to dissolve. Only the grouping is removed — the group's nodes stay in the workflow. Use this when an update was rejected because it would break a node group and the change is intended.",
+			),
+	}),
 ]);
 
 export type PartialUpdateOperation = z.infer<typeof partialUpdateOperationSchema>;
@@ -195,6 +204,8 @@ interface WorkflowSlice {
 	connections: IConnections;
 	/** Existing tag names on the workflow. Undefined when not loaded; tag ops require this. */
 	tagNames?: string[];
+	/** Existing node groups on the workflow. */
+	nodeGroups?: IWorkflowGroup[];
 }
 
 export interface ApplyOperationsSuccess {
@@ -203,6 +214,8 @@ export interface ApplyOperationsSuccess {
 	addedNodeNames: string[];
 	/** Final tag set after applying tag ops. Undefined means "leave unchanged". */
 	tagNames?: string[];
+	/** Final node groups after applying group ops. Undefined means "leave unchanged". */
+	nodeGroups?: IWorkflowGroup[];
 }
 
 export interface ApplyOperationsFailure {
@@ -219,6 +232,7 @@ const cloneWorkflow = (workflow: WorkflowSlice): WorkflowSlice => ({
 	nodes: workflow.nodes.map((node) => structuredClone(node)),
 	connections: structuredClone(workflow.connections),
 	tagNames: workflow.tagNames ? [...workflow.tagNames] : undefined,
+	nodeGroups: workflow.nodeGroups ? structuredClone(workflow.nodeGroups) : undefined,
 });
 
 const isPlainObject = (value: unknown): value is Record<string, unknown> =>
@@ -404,6 +418,7 @@ export function applyOperations(
 	// Tag set is null until the first tag op runs; that keeps "no tag ops"
 	// distinguishable from "tag ops applied to an empty set" at return time.
 	let tagSet: Set<string> | null = null;
+	let nodeGroupsChanged = false;
 
 	for (let i = 0; i < operations.length; i++) {
 		const op = operations[i];
@@ -604,6 +619,23 @@ export function applyOperations(
 				break;
 			}
 
+			case 'removeNodeGroup': {
+				const groups = workflow.nodeGroups ?? [];
+				const index = groups.findIndex((group) => group.name === op.groupName);
+				if (index === -1) {
+					return fail(
+						i,
+						`node group '${op.groupName}' not found. Existing groups: ${
+							groups.length > 0 ? groups.map((g) => `'${g.name}'`).join(', ') : 'none'
+						}`,
+					);
+				}
+				groups.splice(index, 1);
+				workflow.nodeGroups = groups;
+				nodeGroupsChanged = true;
+				break;
+			}
+
 			default: {
 				op satisfies never;
 				return fail(i, 'unknown operation type');
@@ -620,6 +652,7 @@ export function applyOperations(
 		workflow,
 		addedNodeNames: [...addedNodeNames],
 		tagNames: tagSet !== null ? [...tagSet] : undefined,
+		nodeGroups: nodeGroupsChanged ? (workflow.nodeGroups ?? []) : undefined,
 	};
 }
 
@@ -645,5 +678,6 @@ export function toWorkflowSlice(
 		nodes: workflow.nodes,
 		connections: workflow.connections,
 		tagNames,
+		nodeGroups: workflow.nodeGroups,
 	};
 }

--- a/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
+++ b/packages/cli/src/modules/source-control.ee/__tests__/source-control-import.service.ee.test.ts
@@ -104,6 +104,7 @@ describe('SourceControlImportService', () => {
 		dataTableColumnRepository,
 		dataTableDDLService,
 		redactionEnforcementService,
+		mock(),
 	);
 
 	const globMock = fastGlob.default as unknown as jest.Mock<Promise<string[]>, string[]>;

--- a/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
+++ b/packages/cli/src/modules/source-control.ee/source-control-import.service.ee.ts
@@ -49,6 +49,7 @@ import { DataTableDDLService } from '@/modules/data-table/data-table-ddl.service
 import { DataTableRepository } from '@/modules/data-table/data-table.repository';
 import { isValidColumnName, isValidDataTableId } from '@/modules/data-table/utils/sql-utils';
 import { RedactionEnforcementService } from '@/modules/redaction/redaction-enforcement.service';
+import { NodeTypes } from '@/node-types';
 import { isUniqueConstraintError } from '@/response-helper';
 import { TagService } from '@/services/tag.service';
 import { assertNever } from '@/utils';
@@ -140,6 +141,7 @@ export class SourceControlImportService {
 		private readonly dataTableColumnRepository: DataTableColumnRepository,
 		private readonly dataTableDDLService: DataTableDDLService,
 		private readonly redactionEnforcementService: RedactionEnforcementService,
+		private readonly nodeTypes: NodeTypes,
 	) {
 		this.gitFolder = path.join(instanceSettings.n8nFolder, SOURCE_CONTROL_GIT_FOLDER);
 		this.workflowExportFolder = path.join(this.gitFolder, SOURCE_CONTROL_WORKFLOW_EXPORT_FOLDER);
@@ -754,7 +756,7 @@ export class SourceControlImportService {
 		importedWorkflow.nodeGroups ??= [];
 
 		try {
-			validateWorkflowNodeGroups(importedWorkflow);
+			validateWorkflowNodeGroups(importedWorkflow, this.nodeTypes);
 		} catch {
 			this.logger.warn(
 				`Workflow file ${candidate.file} has invalid nodeGroups, resetting to empty`,

--- a/packages/cli/src/workflow-helpers.ts
+++ b/packages/cli/src/workflow-helpers.ts
@@ -6,13 +6,18 @@ import {
 	formatWorkflowStructureIssuePath,
 	resolveNodeWebhookId,
 	safeParseWorkflowStructure,
+	validateNodeSelectionForGrouping,
+	type ExtractableErrorResult,
 	type IDataObject,
+	type INode,
 	type INodeCredentialsDetails,
 	type INodeTypes,
 	type IRun,
 	type ITaskData,
 	type IWorkflowBase,
+	type IWorkflowGroup,
 	type IWorkflowSettings,
+	type NodeGroupValidationResult,
 	type RelatedExecution,
 	type WorkflowStructureIssue,
 } from 'n8n-workflow';
@@ -138,13 +143,49 @@ export function resolveNodeWebhookIds(workflow: IWorkflowBase, nodeTypes: INodeT
 }
 
 /**
+ * Reconciles nodeGroups with the workflow's current node set: node IDs that no
+ * longer exist are removed from their groups and groups left without any nodes
+ * are dissolved, mirroring the canvas behavior when nodes are deleted.
+ * Returns the repaired groups, or `undefined` when no repair was needed.
+ */
+export function repairWorkflowNodeGroups(
+	workflow: Pick<IWorkflowBase, 'nodes' | 'nodeGroups'>,
+): IWorkflowGroup[] | undefined {
+	const { nodeGroups, nodes } = workflow;
+	if (!nodeGroups || nodeGroups.length === 0) return undefined;
+
+	const nodeIds = new Set(nodes.map((n) => n.id).filter(Boolean));
+	let changed = false;
+	const repairedGroups: IWorkflowGroup[] = [];
+
+	for (const group of nodeGroups) {
+		const remainingNodeIds = group.nodeIds.filter((nodeId) => nodeIds.has(nodeId));
+		if (remainingNodeIds.length === 0) {
+			changed = true;
+		} else if (remainingNodeIds.length === group.nodeIds.length) {
+			repairedGroups.push(group);
+		} else {
+			changed = true;
+			repairedGroups.push({ ...group, nodeIds: remainingNodeIds });
+		}
+	}
+
+	return changed ? repairedGroups : undefined;
+}
+
+/**
  * Validates nodeGroups: unique group names, all referenced node IDs exist,
- * and each node belongs to at most one group.
+ * each node belongs to at most one group, and each group satisfies the
+ * grouping rules enforced on the canvas (connected nodes, single main
+ * entry/exit, no triggers, no non-main connections crossing the boundary).
  * Note for frontend: Must be called after `addNodeIds` since nodes created via the API
  * may not have IDs until that step assigns them.
  */
-export function validateWorkflowNodeGroups(workflow: Pick<IWorkflowBase, 'nodes' | 'nodeGroups'>) {
-	const { nodeGroups, nodes } = workflow;
+export function validateWorkflowNodeGroups(
+	workflow: Pick<IWorkflowBase, 'nodes' | 'connections' | 'nodeGroups'>,
+	nodeTypes: INodeTypes,
+) {
+	const { nodeGroups, nodes, connections } = workflow;
 	if (!nodeGroups || nodeGroups.length === 0) return;
 
 	const nodeIds = new Set(nodes.map((n) => n.id).filter(Boolean));
@@ -157,6 +198,10 @@ export function validateWorkflowNodeGroups(workflow: Pick<IWorkflowBase, 'nodes'
 			throw new BadRequestError(`Duplicate node group name "${group.name}".`);
 		}
 		seenGroupNames.add(group.name);
+
+		if (group.nodeIds.length === 0) {
+			throw new BadRequestError(`Group "${group.name}" must contain at least one node.`);
+		}
 
 		for (const nodeId of group.nodeIds) {
 			// All referenced nodes must exist
@@ -175,6 +220,74 @@ export function validateWorkflowNodeGroups(workflow: Pick<IWorkflowBase, 'nodes'
 			nodeToGroup.set(nodeId, group.name);
 		}
 	}
+
+	// Same graph rules the canvas enforces when creating a group
+	const nodesById = new Map(nodes.map((node) => [node.id, node]));
+	const getNodeType = (node: INode) => {
+		try {
+			return nodeTypes.getByNameAndVersion(node.type, node.typeVersion).description;
+		} catch {
+			// Unknown node type (e.g. not installed): skip type-dependent rules
+			return null;
+		}
+	};
+
+	for (const group of nodeGroups) {
+		const memberNodes = group.nodeIds
+			.map((nodeId) => nodesById.get(nodeId))
+			.filter((node): node is INode => node !== undefined);
+
+		const result = validateNodeSelectionForGrouping({
+			nodes: memberNodes,
+			connectionsBySourceNode: connections,
+			getNodeType,
+		});
+
+		if (!result.valid) {
+			throw new BadRequestError(formatNodeGroupValidationError(group.name, result));
+		}
+	}
+}
+
+function formatNodeGroupValidationError(
+	groupName: string,
+	result: Exclude<NodeGroupValidationResult, { valid: true }>,
+): string {
+	switch (result.reason) {
+		case 'trigger-selected':
+			return `Group "${groupName}" contains trigger node(s) ${formatNodeNames(result.triggers)}. Trigger nodes cannot be part of a group.`;
+		case 'node-already-grouped':
+			return `Group "${groupName}" contains nodes that already belong to another group.`;
+		case 'multiple-input-branches':
+			return `Node "${result.node}" cannot be the first node of group "${groupName}" because it has more than one main input.`;
+		case 'multiple-output-branches':
+			return `Node "${result.node}" cannot be the last node of group "${groupName}" because it has more than one main output.`;
+		case 'non-main-boundary':
+			return `The "${result.connection.type}" connection between "${result.connection.source}" and "${result.connection.target}" crosses the boundary of group "${groupName}". Non-main connections must stay fully inside or outside a group.`;
+		case 'invalid-subgraph':
+			return formatInvalidSubgraphError(groupName, result.errors[0]);
+	}
+}
+
+function formatInvalidSubgraphError(groupName: string, error?: ExtractableErrorResult): string {
+	switch (error?.errorCode) {
+		case 'Multiple Input Nodes':
+			return `Group "${groupName}" has multiple entry points (${formatNodeNames([...error.nodes])}). A group can have only one entry node.`;
+		case 'Multiple Output Nodes':
+			return `Group "${groupName}" has multiple exit points (${formatNodeNames([...error.nodes])}). A group can have only one exit node.`;
+		case 'Input Edge To Non-Root Node':
+			return `Node "${error.node}" in group "${groupName}" receives a connection from outside the group. Connections into a group must go to its first node.`;
+		case 'Output Edge From Non-Leaf Node':
+			return `Node "${error.node}" in group "${groupName}" sends a connection outside the group. Connections out of a group must come from its last node.`;
+		case 'No Continuous Path From Root To Leaf In Selection':
+			return `The nodes in group "${groupName}" are not all connected to each other. Grouped nodes must form a single connected sequence.`;
+		default:
+			return `Group "${groupName}" is not a valid selection of nodes.`;
+	}
+}
+
+function formatNodeNames(names: string[]): string {
+	return names.map((name) => `"${name}"`).join(', ');
 }
 
 /**

--- a/packages/cli/src/workflow-helpers.ts
+++ b/packages/cli/src/workflow-helpers.ts
@@ -8,6 +8,7 @@ import {
 	safeParseWorkflowStructure,
 	validateNodeSelectionForGrouping,
 	type ExtractableErrorResult,
+	type IConnections,
 	type IDataObject,
 	type INode,
 	type INodeCredentialsDetails,
@@ -223,14 +224,7 @@ export function validateWorkflowNodeGroups(
 
 	// Same graph rules the canvas enforces when creating a group
 	const nodesById = new Map(nodes.map((node) => [node.id, node]));
-	const getNodeType = (node: INode) => {
-		try {
-			return nodeTypes.getByNameAndVersion(node.type, node.typeVersion).description;
-		} catch {
-			// Unknown node type (e.g. not installed): skip type-dependent rules
-			return null;
-		}
-	};
+	const getNodeType = buildGetNodeType(nodeTypes);
 
 	for (const group of nodeGroups) {
 		const memberNodes = group.nodeIds
@@ -247,6 +241,117 @@ export function validateWorkflowNodeGroups(
 			throw new BadRequestError(formatNodeGroupValidationError(group.name, result));
 		}
 	}
+}
+
+/**
+ * Extends node groups with newly added nodes when that restores a group's
+ * validity — the backend counterpart of the canvas auto-extend behavior when
+ * a node is inserted between grouped nodes. Groups that are already valid, or
+ * that cannot be made valid by absorbing candidate nodes, are left untouched.
+ * Returns the extended groups, or `undefined` when no group was extended.
+ */
+export function extendWorkflowNodeGroups(
+	workflow: Pick<IWorkflowBase, 'nodes' | 'connections' | 'nodeGroups'>,
+	candidateNodeIds: Set<string>,
+	nodeTypes: INodeTypes,
+): IWorkflowGroup[] | undefined {
+	const { nodeGroups, nodes, connections } = workflow;
+	if (!nodeGroups || nodeGroups.length === 0 || candidateNodeIds.size === 0) return undefined;
+
+	const getNodeType = buildGetNodeType(nodeTypes);
+	const nodesById = new Map(nodes.map((node) => [node.id, node]));
+	const neighborsByNodeName = buildUndirectedNeighborsByNodeName(connections);
+	const groupedNodeIds = new Set(nodeGroups.flatMap((group) => group.nodeIds));
+
+	const isValidSelection = (memberIds: Set<string>) => {
+		const memberNodes = [...memberIds]
+			.map((nodeId) => nodesById.get(nodeId))
+			.filter((node): node is INode => node !== undefined);
+		return validateNodeSelectionForGrouping({
+			nodes: memberNodes,
+			connectionsBySourceNode: connections,
+			getNodeType,
+		}).valid;
+	};
+
+	// Candidates in workflow node order, excluding nodes that belong to a group
+	const availableCandidateIds = nodes
+		.map((node) => node.id)
+		.filter((nodeId) => candidateNodeIds.has(nodeId) && !groupedNodeIds.has(nodeId));
+
+	let changed = false;
+	const extendedGroups = nodeGroups.map((group) => {
+		const memberIds = new Set(group.nodeIds);
+		if (memberIds.size === 0 || isValidSelection(memberIds)) return group;
+
+		const isAdjacentToMember = (nodeId: string) => {
+			const neighbors = neighborsByNodeName.get(nodesById.get(nodeId)?.name ?? '');
+			if (!neighbors) return false;
+			return [...memberIds].some((memberId) => {
+				const member = nodesById.get(memberId);
+				return member !== undefined && neighbors.has(member.name);
+			});
+		};
+
+		// Grow: absorb adjacent candidates one at a time until the group is valid
+		const absorbedNodeIds: string[] = [];
+		while (!isValidSelection(memberIds)) {
+			const next = availableCandidateIds.find(
+				(nodeId) => !memberIds.has(nodeId) && isAdjacentToMember(nodeId),
+			);
+			if (next === undefined) return group; // extension cannot make this group valid
+			memberIds.add(next);
+			absorbedNodeIds.push(next);
+		}
+
+		// Shrink: drop absorbed nodes that turn out to be unnecessary
+		for (const nodeId of absorbedNodeIds) {
+			const withoutNode = new Set(memberIds);
+			withoutNode.delete(nodeId);
+			if (isValidSelection(withoutNode)) memberIds.delete(nodeId);
+		}
+
+		changed = true;
+		return {
+			...group,
+			nodeIds: [...group.nodeIds, ...absorbedNodeIds.filter((nodeId) => memberIds.has(nodeId))],
+		};
+	});
+
+	return changed ? extendedGroups : undefined;
+}
+
+function buildGetNodeType(nodeTypes: INodeTypes) {
+	return (node: INode) => {
+		try {
+			return nodeTypes.getByNameAndVersion(node.type, node.typeVersion).description;
+		} catch {
+			// Unknown node type (e.g. not installed): skip type-dependent rules
+			return null;
+		}
+	};
+}
+
+function buildUndirectedNeighborsByNodeName(connections: IConnections): Map<string, Set<string>> {
+	const neighbors = new Map<string, Set<string>>();
+	const link = (from: string, to: string) => {
+		const set = neighbors.get(from) ?? new Set<string>();
+		set.add(to);
+		neighbors.set(from, set);
+	};
+
+	for (const [sourceNodeName, connectionsByType] of Object.entries(connections)) {
+		for (const connectionsByOutputIndex of Object.values(connectionsByType)) {
+			for (const outputConnections of connectionsByOutputIndex) {
+				for (const connection of outputConnections ?? []) {
+					link(sourceNodeName, connection.node);
+					link(connection.node, sourceNodeName);
+				}
+			}
+		}
+	}
+
+	return neighbors;
 }
 
 function formatNodeGroupValidationError(

--- a/packages/cli/src/workflows/__tests__/workflow.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.test.ts
@@ -363,6 +363,25 @@ describe('WorkflowService', () => {
 			);
 		});
 
+		test('should persist extended nodeGroups when auto-extend changes them', async () => {
+			setupExistingWorkflow();
+			const extendedNodeGroups = [{ id: 'g1', name: 'Group 1', nodeIds: ['n1', 'n2'] }];
+			jest.mocked(WorkflowHelpers.extendWorkflowNodeGroups).mockReturnValueOnce(extendedNodeGroups);
+
+			const user = mock<User>();
+			await workflowService.update(user, { nodes: [] } as unknown as WorkflowEntity, 'workflow-1', {
+				forceSave: true,
+			});
+
+			expect(workflowRepositoryMock.update).toHaveBeenCalledWith(
+				'workflow-1',
+				expect.objectContaining({
+					nodeGroups: extendedNodeGroups,
+					versionId: expect.not.stringMatching('v1'),
+				}),
+			);
+		});
+
 		test('should throw BadRequestError for invalid workflow structure', async () => {
 			setupExistingWorkflow();
 			jest.mocked(WorkflowHelpers.validateWorkflowStructure).mockImplementationOnce(() => {

--- a/packages/cli/src/workflows/__tests__/workflow.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow.service.test.ts
@@ -334,10 +334,33 @@ describe('WorkflowService', () => {
 				forceSave: true,
 			});
 
-			expect(WorkflowHelpers.validateWorkflowNodeGroups).toHaveBeenCalledWith({
-				nodes: [],
-				nodeGroups: existingNodeGroups,
+			// `existingWorkflow.connections` is a jest-mock-extended deep proxy, which breaks
+			// toHaveBeenCalledWith's structural equality, so assert by reference instead.
+			const [validatedWorkflow, nodeTypesArg] = jest.mocked(
+				WorkflowHelpers.validateWorkflowNodeGroups,
+			).mock.calls[0];
+			expect(validatedWorkflow).toMatchObject({ nodes: [], nodeGroups: existingNodeGroups });
+			expect(validatedWorkflow.connections).toBe(existingWorkflow.connections);
+			expect(nodeTypesArg).toBeDefined();
+		});
+
+		test('should persist repaired nodeGroups when repair changes them', async () => {
+			setupExistingWorkflow();
+			const repairedNodeGroups = [{ id: 'g1', name: 'Group 1', nodeIds: ['n1'] }];
+			jest.mocked(WorkflowHelpers.repairWorkflowNodeGroups).mockReturnValueOnce(repairedNodeGroups);
+
+			const user = mock<User>();
+			await workflowService.update(user, { nodes: [] } as unknown as WorkflowEntity, 'workflow-1', {
+				forceSave: true,
 			});
+
+			expect(workflowRepositoryMock.update).toHaveBeenCalledWith(
+				'workflow-1',
+				expect.objectContaining({
+					nodeGroups: repairedNodeGroups,
+					versionId: expect.not.stringMatching('v1'),
+				}),
+			);
 		});
 
 		test('should throw BadRequestError for invalid workflow structure', async () => {

--- a/packages/cli/src/workflows/workflow-creation.service.ts
+++ b/packages/cli/src/workflows/workflow-creation.service.ts
@@ -122,7 +122,7 @@ export class WorkflowCreationService {
 		WorkflowHelpers.addNodeIds(newWorkflow);
 		WorkflowHelpers.resolveNodeWebhookIds(newWorkflow, this.nodeTypes);
 		WorkflowHelpers.validateWorkflowStructure(newWorkflow);
-		WorkflowHelpers.validateWorkflowNodeGroups(newWorkflow);
+		WorkflowHelpers.validateWorkflowNodeGroups(newWorkflow, this.nodeTypes);
 
 		if ('pinData' in newWorkflow) {
 			WorkflowHelpers.validatePinDataSize(newWorkflow);

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -372,6 +372,17 @@ export class WorkflowService {
 			);
 		}
 
+		// Reconcile node groups with the effective node set: nodes removed by this
+		// update are dropped from their groups and emptied groups are dissolved,
+		// mirroring the canvas behavior when nodes are deleted.
+		const repairedNodeGroups = WorkflowHelpers.repairWorkflowNodeGroups({
+			nodes: workflowUpdateData.nodes ?? workflow.nodes,
+			nodeGroups: workflowUpdateData.nodeGroups ?? workflow.nodeGroups,
+		});
+		if (repairedNodeGroups) {
+			workflowUpdateData.nodeGroups = repairedNodeGroups;
+		}
+
 		// Update the workflow's version when changing nodes, connections, or nodeGroups
 		const hasNodesKey = 'nodes' in workflowUpdateData;
 		const hasConnectionsKey = 'connections' in workflowUpdateData;
@@ -407,10 +418,14 @@ export class WorkflowService {
 			nodes: workflowUpdateData.nodes ?? workflow.nodes,
 			connections: workflowUpdateData.connections ?? workflow.connections,
 		});
-		WorkflowHelpers.validateWorkflowNodeGroups({
-			nodes: workflowUpdateData.nodes ?? workflow.nodes,
-			nodeGroups: workflowUpdateData.nodeGroups ?? workflow.nodeGroups,
-		});
+		WorkflowHelpers.validateWorkflowNodeGroups(
+			{
+				nodes: workflowUpdateData.nodes ?? workflow.nodes,
+				connections: workflowUpdateData.connections ?? workflow.connections,
+				nodeGroups: workflowUpdateData.nodeGroups ?? workflow.nodeGroups,
+			},
+			this.nodeTypes,
+		);
 
 		// Strip redactionPolicy if instance lacks data-redaction license
 		if (

--- a/packages/cli/src/workflows/workflow.service.ts
+++ b/packages/cli/src/workflows/workflow.service.ts
@@ -372,15 +372,36 @@ export class WorkflowService {
 			);
 		}
 
-		// Reconcile node groups with the effective node set: nodes removed by this
-		// update are dropped from their groups and emptied groups are dissolved,
-		// mirroring the canvas behavior when nodes are deleted.
+		// Reconcile node groups with the effective node set, mirroring the canvas
+		// behavior: nodes removed by this update are dropped from their groups
+		// (emptied groups are dissolved), and newly added nodes are absorbed into
+		// a group when that is what keeps the group valid (e.g. a node inserted
+		// between two grouped nodes).
+		const effectiveNodes = workflowUpdateData.nodes ?? workflow.nodes;
 		const repairedNodeGroups = WorkflowHelpers.repairWorkflowNodeGroups({
-			nodes: workflowUpdateData.nodes ?? workflow.nodes,
+			nodes: effectiveNodes,
 			nodeGroups: workflowUpdateData.nodeGroups ?? workflow.nodeGroups,
 		});
 		if (repairedNodeGroups) {
 			workflowUpdateData.nodeGroups = repairedNodeGroups;
+		}
+		const storedNodeIds = new Set(workflow.nodes.map((node) => node.id));
+		const newNodeIds = new Set(
+			effectiveNodes
+				.map((node) => node.id)
+				.filter((nodeId) => Boolean(nodeId) && !storedNodeIds.has(nodeId)),
+		);
+		const extendedNodeGroups = WorkflowHelpers.extendWorkflowNodeGroups(
+			{
+				nodes: effectiveNodes,
+				connections: workflowUpdateData.connections ?? workflow.connections,
+				nodeGroups: workflowUpdateData.nodeGroups ?? workflow.nodeGroups,
+			},
+			newNodeIds,
+			this.nodeTypes,
+		);
+		if (extendedNodeGroups) {
+			workflowUpdateData.nodeGroups = extendedNodeGroups;
 		}
 
 		// Update the workflow's version when changing nodes, connections, or nodeGroups

--- a/packages/cli/test/integration/environments/source-control-import.service.test.ts
+++ b/packages/cli/test/integration/environments/source-control-import.service.test.ts
@@ -113,6 +113,7 @@ describe('SourceControlImportService', () => {
 			mock(),
 			mock(),
 			mock(), // redactionEnforcementService
+			mock(), // nodeTypes
 		);
 	});
 


### PR DESCRIPTION
## Summary

Node groups (behind the `083_canvas_nodes_grouping` experiment) currently have their graph rules enforced only on the canvas. The backend `validateWorkflowNodeGroups` helper only checked structural invariants (unique names, referenced nodes exist, no node in two groups), so the public API, instance-ai, and instance-mcp could persist workflows whose groups violate the canvas rules.

This PR closes that gap at the shared service layer — every write surface inherits the behavior — and gives agent surfaces a deliberate escape hatch:

- **Graph-rule validation**: `validateWorkflowNodeGroups` (`packages/cli/src/workflow-helpers.ts`) now also runs `validateNodeSelectionForGrouping` from `n8n-workflow` per group — the same rules the canvas enforces: members must form a connected subgraph with a single main entry/exit, no trigger nodes, and no non-main connections crossing the group boundary. Violations are rejected with a `BadRequestError` whose message names the group, the offending nodes, and the broken rule, so AI agents (instance-ai `build-workflow`, MCP `update-workflow`) can recover and continue. Empty groups are rejected. Unknown node types (e.g. not-installed community nodes) degrade gracefully, like on the canvas.
- **Auto-repair on update**: `repairWorkflowNodeGroups` mirrors the canvas behavior on node deletion — node IDs that no longer exist are dropped from their groups and emptied groups are dissolved. `WorkflowService.update` runs it on the merged state (payload + DB), so e.g. an AI agent deleting a grouped leaf node just works (the group shrinks and is persisted, with a version bump + history entry).
- **Auto-extend on update**: `extendWorkflowNodeGroups` is the inverse — when newly added nodes are what keeps a group valid (e.g. a node inserted between two grouped nodes), they are absorbed into the group, mirroring the canvas auto-extend behavior. A grow-then-shrink pass keeps the extension minimal (unrelated new nodes hanging off a group member are not absorbed). Only edits that genuinely break a group's structure (splitting connectivity, multi-entry/exit, non-main boundary crossings) are rejected.
- **Agent ungroup escape hatch**: when a rejected change is intended, agents can explicitly dissolve a group (the grouping is removed, the nodes stay):
  - instance-mcp: new `removeNodeGroup` operation (by group name) on the `update-workflow` tool.
  - instance-ai: new optional `removeNodeGroups` input on the `build-workflow` tool, threaded through `updateFromWorkflowJSON` to the adapter, which filters the stored groups. Unknown group names are rejected with a message listing the existing groups.
- **Call sites**: `WorkflowService.update` validates the merged effective state (nodes/connections/groups, falling back to the stored workflow for absent keys), `WorkflowCreationService.createWorkflow` stays strict (no repair/extend), and source-control import keeps its existing lenient behavior (invalid groups are reset to `[]` with a warning — now also covering graph-rule violations).

Because the internal REST API, the public API, instance-mcp tools, and the instance-ai adapter all persist through `WorkflowCreationService.createWorkflow` / `WorkflowService.update`, the enforcement and reconciliation apply to all surfaces from one place.

## How to test

Unit/integration coverage:
- `packages/cli/src/__tests__/workflow-helpers.test.ts` — graph rules (disconnected group, trigger in group, non-main boundary, multiple entry points, outside connection to a non-entry node, unknown node types, empty group), repair behavior, and auto-extend behavior (insert between grouped nodes, chain insertion, minimal extension, unfixable groups, nodes in other groups).
- `packages/cli/src/workflows/__tests__/workflow.service.test.ts` — merged-state validation call and persistence of repaired/extended groups with version bump.
- `packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts` — group-validation rejections surface as recoverable errors; `removeNodeGroup` dissolves a group, rejects unknown names, and group state is untouched when no group ops run.
- `packages/cli/src/modules/instance-ai/__tests__/instance-ai.adapter.service.test.ts` and `packages/@n8n/instance-ai/src/tools/workflows/__tests__/build-workflow.tool.test.ts` — rejection propagation to the agent error channel and `removeNodeGroups` forwarding/filtering.

Manual check: with the grouping experiment enabled, create a workflow with a group in the editor, then via the API (`PATCH /rest/workflows/:id`):
- send a nodes/connections payload that removes a connection between two grouped nodes → 400 with the group message;
- remove a grouped leaf node from `nodes` → 200, group no longer references it;
- insert a new node between two grouped nodes (rewiring through it) → 200, group now contains the new node.

## Related Linear tickets, Github issues, and Community forum posts

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

🤖 Generated with [Claude Code](https://claude.com/claude-code)