### PR TITLE
fix(node-dev): fail build on TypeScript errors

### DIFF
--- a/packages/node-dev/src/Build.ts
+++ b/packages/node-dev/src/Build.ts
@@ -92,8 +92,20 @@ export async function buildFiles({
 		// when the main process does
 		process.on('exit', () => buildProcess.kill());
 
-		await new Promise<void>((resolve) => {
-			buildProcess.on('exit', resolve);
+		await new Promise<void>((resolve, reject) => {
+			buildProcess.on('error', reject);
+			buildProcess.on('close', (code, signal) => {
+				if (code === 0) {
+					resolve();
+					return;
+				}
+
+				const processName = watch ? 'TypeScript watch process' : 'TypeScript build';
+				const reason =
+					code === null && signal !== null ? `signal ${signal}` : `exit code ${code ?? 'unknown'}`;
+
+				reject(new Error(`${processName} failed with ${reason}`));
+			});
 		});
 	} catch (error) {
 		// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment


### PR DESCRIPTION
## Summary
- reject `n8n-node-dev build` when the TypeScript process exits with a non-zero code
- handle spawn errors instead of letting a failed compiler invocation look successful
- keep watch mode behavior intact; it only fails if the watcher process exits/fails

## Testing
- `npm exec --yes pnpm@10.32.1 -- --filter n8n-node-dev lint`
- `npm exec --yes pnpm@10.32.1 -- --filter n8n-node-dev typecheck`
- `npm exec --yes pnpm@10.32.1 -- --filter n8n-node-dev test` (passes with no tests found)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32265">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

