### PR TITLE
fix(core): Resolve filter options version from node typeVersion for programmatically-built workflows

### DIFF
--- a/packages/nodes-base/nodes/Filter/V2/FilterV2.node.ts
+++ b/packages/nodes-base/nodes/Filter/V2/FilterV2.node.ts
@@ -52,8 +52,8 @@ export class FilterV2 implements INodeType {
 						propertyHint: `Must always contain these three sibling keys:
 - combinator: 'and' or 'or', default to 'and'
 - conditions: [ a list of condition objects ]
-- options: { caseSensitive: true, leftValue: '', typeValidation: 'strict', version: 1 }
-e.g.: { combinator: 'and', options: { caseSensitive: true, leftValue: '', typeValidation: 'strict', version: 2 }, conditions: [{ leftValue: expr('{{ $json.field }}'), rightValue: 'value', operator: { type: 'string', operation: 'equals' } }] }`,
+- options: { caseSensitive: true, leftValue: '', typeValidation: 'strict', version: 3 }
+e.g.: { combinator: 'and', options: { caseSensitive: true, leftValue: '', typeValidation: 'strict', version: 3 }, conditions: [{ leftValue: expr('{{ $json.field }}'), rightValue: 'value', operator: { type: 'string', operation: 'equals' } }] }`,
 					},
 				},
 				{

--- a/packages/nodes-base/nodes/If/V2/IfV2.node.ts
+++ b/packages/nodes-base/nodes/If/V2/IfV2.node.ts
@@ -52,8 +52,8 @@ export class IfV2 implements INodeType {
 						propertyHint: `Must always contain these three sibling keys:
 - combinator: 'and' or 'or', default to 'and'
 - conditions: [ a list of condition objects ]
-- options: { caseSensitive: true, leftValue: '', typeValidation: 'strict', version: 1 }
-e.g.: { combinator: 'and', options: { caseSensitive: true, leftValue: '', typeValidation: 'strict', version: 2 }, conditions: [{ leftValue: expr('{{ $json.field }}'), rightValue: 'value', operator: { type: 'string', operation: 'equals' } }] }`,
+- options: { caseSensitive: true, leftValue: '', typeValidation: 'strict', version: 3 }
+e.g.: { combinator: 'and', options: { caseSensitive: true, leftValue: '', typeValidation: 'strict', version: 3 }, conditions: [{ leftValue: expr('{{ $json.field }}'), rightValue: 'value', operator: { type: 'string', operation: 'equals' } }] }`,
 					},
 				},
 				{

--- a/packages/nodes-base/nodes/Switch/V3/SwitchV3.node.ts
+++ b/packages/nodes-base/nodes/Switch/V3/SwitchV3.node.ts
@@ -180,7 +180,7 @@ export default workflow('id', 'name')
 					type: 'fixedCollection',
 					builderHint: {
 						propertyHint:
-							"Use `rules.values` (NOT `rules.rules`). Each rule needs `outputKey` and a complete `conditions` object with these three sibling keys: `combinator` ('and' | 'or'), `conditions` (array of condition objects), `options` (`{ caseSensitive, leftValue, typeValidation }`). Same shape as IF. Wire rule outputs by zero-based index with `.onCase(index, target)`; `outputKey` is the visible output label, not the `.onCase()` argument. Unwired cases silently drop their items. Default `caseSensitive: false` for string equality, only set `true` when specifically requested or confirmed by the user.",
+							"Use `rules.values` (NOT `rules.rules`). Each rule needs `outputKey` and a complete `conditions` object with these three sibling keys: `combinator` ('and' | 'or'), `conditions` (array of condition objects), `options` (`{ caseSensitive, leftValue, typeValidation, version: 3 }`). Same shape as IF. Wire rule outputs by zero-based index with `.onCase(index, target)`; `outputKey` is the visible output label, not the `.onCase()` argument. Unwired cases silently drop their items. Default `caseSensitive: false` for string equality, only set `true` when specifically requested or confirmed by the user.",
 					},
 					typeOptions: {
 						multipleValues: true,

--- a/packages/workflow/src/node-helpers.ts
+++ b/packages/workflow/src/node-helpers.ts
@@ -12,6 +12,7 @@ import { isExpression } from './expressions/expression-helpers';
 import { NodeConnectionTypes } from './interfaces';
 import type {
 	FieldType,
+	FilterTypeOptions,
 	IContextObject,
 	INode,
 	INodeCredentialDescription,
@@ -663,6 +664,38 @@ type GetNodeParametersOptions = {
  * @param {boolean} returnNoneDisplayed If also values which should not be displayed should be returned
  * @param {GetNodeParametersOptions} options Optional properties
  */
+/**
+ * Resolves the filter options version from a node's typeOptions.filter.version spec and its
+ * typeVersion. The spec may be a static number or an n8n expression string like
+ * '={{ $nodeVersion >= 2.3 ? 3 : 1 }}'. Falls back to 1 when the spec is absent or cannot be
+ * evaluated.
+ */
+function resolveFilterVersion(
+	versionSpec: FilterTypeOptions['version'] | undefined,
+	nodeTypeVersion: number,
+): 1 | 2 | 3 {
+	if (typeof versionSpec === 'number') {
+		const v = versionSpec as number;
+		if (v === 1 || v === 2 || v === 3) return v;
+	}
+	if (
+		typeof versionSpec === 'string' &&
+		versionSpec.startsWith('={{') &&
+		versionSpec.endsWith('}}')
+	) {
+		const expr = versionSpec.slice(3, -2).trim();
+		try {
+			// Expression only references $nodeVersion — safe to evaluate against trusted node definitions
+			// eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+			const result = new Function('$nodeVersion', `return ${expr}`)(nodeTypeVersion) as unknown;
+			if (result === 1 || result === 2 || result === 3) return result;
+		} catch {
+			// fall through to default
+		}
+	}
+	return 1;
+}
+
 // eslint-disable-next-line complexity
 export function getNodeParameters(
 	nodePropertiesArray: INodeProperties[],
@@ -796,7 +829,10 @@ export function getNodeParameters(
 						caseSensitive: true,
 						leftValue: '',
 						typeValidation: 'strict',
-						version: 1,
+						version: resolveFilterVersion(
+							nodeProperties.typeOptions?.filter?.version,
+							node?.typeVersion ?? 1,
+						),
 					};
 					const filter = deepCopy(nodeValues[nodeProperties.name]) as Record<string, unknown>;
 					filter.combinator ??= 'and';

--- a/packages/workflow/test/node-helpers.test.ts
+++ b/packages/workflow/test/node-helpers.test.ts
@@ -6693,6 +6693,15 @@ describe('NodeHelpers', () => {
 			default: {},
 		};
 
+		const filterPropertyWithVersionExpr: INodeProperties = {
+			...filterProperty,
+			typeOptions: {
+				filter: {
+					version: '={{ $nodeVersion >= 2.3 ? 3 : $nodeVersion >= 2.2 ? 2 : 1 }}',
+				},
+			},
+		};
+
 		it('should add missing combinator and options to a filter parameter', () => {
 			const result = getNodeParameters(
 				[filterProperty],
@@ -6731,6 +6740,64 @@ describe('NodeHelpers', () => {
 					],
 				},
 			});
+		});
+
+		it('should resolve filter version from typeOptions expression and node typeVersion', () => {
+			const result = getNodeParameters(
+				[filterPropertyWithVersionExpr],
+				{ conditions: { conditions: [] } },
+				true,
+				false,
+				{ typeVersion: 2.3 },
+				null,
+			);
+			expect(result?.conditions).toMatchObject({ options: { version: 3 } });
+		});
+
+		it('should resolve filter version 2 for intermediate typeVersion', () => {
+			const result = getNodeParameters(
+				[filterPropertyWithVersionExpr],
+				{ conditions: { conditions: [] } },
+				true,
+				false,
+				{ typeVersion: 2.2 },
+				null,
+			);
+			expect(result?.conditions).toMatchObject({ options: { version: 2 } });
+		});
+
+		it('should resolve filter version 1 for old typeVersion', () => {
+			const result = getNodeParameters(
+				[filterPropertyWithVersionExpr],
+				{ conditions: { conditions: [] } },
+				true,
+				false,
+				{ typeVersion: 2.0 },
+				null,
+			);
+			expect(result?.conditions).toMatchObject({ options: { version: 1 } });
+		});
+
+		it('should not overwrite explicit options.version set by builder', () => {
+			const result = getNodeParameters(
+				[filterPropertyWithVersionExpr],
+				{
+					conditions: {
+						conditions: [],
+						options: {
+							caseSensitive: true,
+							leftValue: '',
+							typeValidation: 'strict',
+							version: 2,
+						},
+					},
+				},
+				true,
+				false,
+				{ typeVersion: 2.3 },
+				null,
+			);
+			expect(result?.conditions).toMatchObject({ options: { version: 2 } });
 		});
 
 		it('should preserve existing combinator and options', () => {


### PR DESCRIPTION
## Summary

When an `If`, `Filter`, or `Switch` node is built programmatically (by the AI builder, via the public API, or any workflow-as-code path), the engine patch in `getNodeParameters` that fills in missing `conditions.options` was hardcoding `version: 1` regardless of the node's actual `typeVersion`.

The `options.version` field (1 / 2 / 3) controls type-coercion semantics at execution time:

| Version | Boolean coercion (loose mode) | Empty string / array as number |
|---------|-------------------------------|-------------------------------|
| **1** | `Boolean(value)` — `"false"` → `true` | `""` / `[]` → coerced to `0` |
| **2** | Attempts proper type validation first | same as v1 |
| **3** | same as v2 | `""` / `[]` → `null` |

Current default typeVersions — If/Filter `2.3`, Switch `3.4` — map to filter version **3** via the expression in `typeOptions.filter.version`. So nodes built through the UI always got v3 semantics, but the same node built programmatically silently fell back to v1, producing different results under loose type validation.

**Changes:**

- `packages/workflow/src/node-helpers.ts`: Replace the hardcoded `version: 1` fallback with a `resolveFilterVersion()` helper that evaluates `typeOptions.filter.version` against `node.typeVersion`. The expression is always a numeric ternary over `$nodeVersion` from trusted node definitions, evaluated via `new Function`.
- `packages/nodes-base/nodes/If/V2/IfV2.node.ts` and `FilterV2.node.ts`: Update `builderHint` examples from `version: 1` / `version: 2` to `version: 3` (correct for the current default typeVersion 2.3).
- `packages/nodes-base/nodes/Switch/V3/SwitchV3.node.ts`: Add `version: 3` to the `options` shape in the `builderHint` (it was previously omitted entirely).
- 4 new unit tests covering version resolution from expression, fallback for old typeVersions, and that an explicitly-set `options.version` is never overwritten.

## How to test

1. Create an `If` node programmatically (e.g. via the public API or the AI builder) with `typeVersion: 2.3`, a boolean condition, and **no** `options.version` in the conditions value.
2. Run it against an item where the left value is the string `"false"` and the operator is `boolean equals true`.
3. **Before:** the item routes to the `true` branch (v1 coercion: `Boolean("false")` → `true`).
4. **After:** the item routes to the `false` branch (v3 coercion: `"false"` parses as boolean `false`).

Unit tests: `pnpm --filter n8n-workflow test node-helpers`

## Related Linear tickets, Github issues, and Community forum posts

<!-- No Linear ticket — discovered during investigation of AI builder vs UI behaviour gap. -->

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32266">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->