### PR TITLE
fix(core): Prevent template literals adding a space before interpolation

### DIFF
--- a/packages/@n8n/tournament/src/ExpressionBuilder.ts
+++ b/packages/@n8n/tournament/src/ExpressionBuilder.ts
@@ -2,7 +2,7 @@ import type { namedTypes } from 'ast-types';
 import { builders as b } from 'ast-types';
 import type { ExpressionKind, StatementKind } from 'ast-types/lib/gen/kinds';
 import type { types } from 'recast';
-import { parse, visit, print } from 'recast';
+import { parse, visit, print, prettyPrint } from 'recast';
 
 import type { TournamentHooks } from './ast';
 import { splitExpression } from './ExpressionSplitter';
@@ -83,6 +83,31 @@ const hasTemplateString = (node: types.namedTypes.ASTNode) => {
 	});
 
 	return hasTemp;
+};
+
+// Detects template literals that span multiple lines (i.e. contain a real
+// newline that `fixStringNewLines` will escape). recast's incremental printer
+// (`print`) reuses the original source and inserts a spurious space before
+// `${...}` when the preceding quasi was reprinted and ends in an identifier
+// character (e.g. `chk_${x}` -> `chk_ ${x}`). Pretty-printing the whole program
+// avoids that source-reuse path. We only opt into it when needed so every other
+// expression keeps its existing output untouched.
+// See https://github.com/n8n-io/n8n/issues/32262
+const hasMultilineTemplateString = (node: types.namedTypes.ASTNode) => {
+	let hasMultiline = false;
+
+	visit(node, {
+		visitTemplateElement(path) {
+			if (path.node.value.raw.includes('\n')) {
+				hasMultiline = true;
+				return false;
+			}
+			this.traverse(path);
+			return;
+		},
+	});
+
+	return hasMultiline;
 };
 
 const wrapInErrorHandler = (node: StatementKind) => {
@@ -197,6 +222,12 @@ export const getExpressionCode = (
 		.filter((c) => c.type === 'code')
 		.some((c) => hasTemplateString(c.parsed));
 
+	// Must be computed before `fixStringNewLines` runs, since that escapes the
+	// real newlines we're looking for here.
+	const hasMultilineTempString = chunks
+		.filter((c) => c.type === 'code')
+		.some((c) => hasMultilineTemplateString(c.parsed));
+
 	// So for compatibility we parse expressions the same way that `tmpl` does.
 	// This means we always have an initial text chunk but if there's only a blank
 	// text chunk and a code chunk then we want to return the actual value of the
@@ -290,5 +321,7 @@ export const getExpressionCode = (
 		newProg.body.push(retData);
 	}
 
-	return [print(newProg).code, { has: { function: hasFn, templateString: hasTempString } }];
+	const code = hasMultilineTempString ? prettyPrint(newProg).code : print(newProg).code;
+
+	return [code, { has: { function: hasFn, templateString: hasTempString } }];
 };

--- a/packages/@n8n/tournament/test/Es6Syntax.test.ts
+++ b/packages/@n8n/tournament/test/Es6Syntax.test.ts
@@ -21,6 +21,22 @@ describe('ES6 Syntax', () => {
 		expect(result).toBe('abc 123 def');
 	});
 
+	// https://github.com/n8n-io/n8n/issues/32262
+	test('multiline template literal does not add a space before ${} after an identifier char', () => {
+		const result = t.execute('{{ `\nchk_${id}` }}', { id: 123 });
+
+		expect(result).toBe('\nchk_123');
+	});
+
+	test('multiline template literal interpolation stays correct inside a map callback', () => {
+		const result = t.execute(
+			'{{ people.map(p => `\nchk_${p.id}\nchk-${p.id}\n${p.first_name}_${p.id}`).join("") }}',
+			{ people: [{ id: '123', first_name: 'John' }] },
+		);
+
+		expect(result).toBe('\nchk_123\nchk-123\nJohn_123');
+	});
+
 	test('spread operator', () => {
 		const result = t.execute('{{ Math.max(...[1, 2, 3]) }}', {});
 


### PR DESCRIPTION
## Summary

Multiline JS template literals where a fixed string ending in a word character is immediately followed by an interpolation (like `` `chk_${id}` ``) render with an extra space after that character, so you get `chk_ 123` instead of `chk_123`.

What's happening: the expression compiler escapes real newlines inside template literals (`fixStringNewLines`), which marks those quasis as reprinted. recast's incremental printer (`print`) then reuses the surrounding original source and adds a token-separating space before `${...}` whenever the reprinted quasi ends in a word character (`_`, a letter, or a digit). That lines up exactly with the three cases in the report:

- `chk_${person.id}` becomes `chk_ 123` (ends in `_`, has the leading newline so it gets reprinted, space added)
- `chk-${person.id}` stays `chk-123` (`-` is not a word char, no space)
- `${person.first_name}_${person.id}` stays `John_123` (that `_` quasi has no newline, so it is not reprinted)

The fix pretty-prints the whole program instead of using the incremental printer, which skips the source-reuse path that introduces the space. To keep the change small, it only switches to `prettyPrint` when a code chunk actually contains a multiline template literal, so every other expression keeps its existing output unchanged. The `\n`-escaped output is preserved.

## How to test

Import the example workflow from the issue and run it. The first block now shows `chk_123` with no stray space.

Unit tests were added in `packages/@n8n/tournament/test/Es6Syntax.test.ts` covering the minimal case and the `.map(...)` callback case from the report:

```
cd packages/@n8n/tournament && pnpm test
```

## Related Linear tickets, Github issues, and Community forum posts

Closes #32262


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32268">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

