### PR TITLE
fix: prevent silent refresh on large form uploads

### DIFF
--- a/packages/cli/templates/form-trigger.handlebars
+++ b/packages/cli/templates/form-trigger.handlebars
@@ -1085,14 +1085,30 @@
 								form.style.display = 'none';
 								document.querySelector('#submitted-form').style.display = 'block';
 								document.querySelector('#submitted-header').textContent = 'Problem submitting response';
-								document.querySelector('#submitted-content').textContent =
-									'Please try again or contact support if the problem persists';
+								let errorMessage = 'Please try again or contact support if the problem persists';
+								if (response.status === 413) {
+									errorMessage = 'The files you are trying to upload are too large.';
+								}
+								document.querySelector('#submitted-content').textContent = errorMessage;
+								
+								// Stop polling for execution status
+								clearTimeout(timeoutId);
+								interval = 0;
 							}
 
 							return;
 						})
 						.catch(function (error) {
 							console.error('Error:', error);
+							form.style.display = 'none';
+							document.querySelector('#submitted-form').style.display = 'block';
+							document.querySelector('#submitted-header').textContent = 'Problem submitting response';
+							document.querySelector('#submitted-content').textContent =
+								'A network error occurred. The files you are trying to upload might be too large, or there is a network issue. Please try again or contact support.';
+							
+							// Stop polling for execution status
+							clearTimeout(timeoutId);
+							interval = 0;
 						})
 						.finally(() => {
 							if (window.location.href.includes('form-waiting')) {


### PR DESCRIPTION
Summary
This PR fixes an issue where uploading large files (e.g., > 100 MB) in a Form or Form Trigger node caused the form to silently refresh, discarding all user inputs without displaying any error message.

The root cause was a race condition in form-trigger.handlebars. When a fetch POST request failed due to payload size limits (e.g., a 413 Payload Too Large from a proxy like Nginx, or an aborted connection), the catch or non-200 else block executed but failed to stop the checkExecutionStatus interval loop.

Because the interval wasn't cleared, the finally block scheduled the next checkExecutionStatus poll. The server then responded with "form-waiting" (since the upload never succeeded), which the polling function interpreted as an instruction to reload the page via window.location.replace(). This caused the form to silently refresh.

This PR properly halts the polling loop on error (interval = 0; clearTimeout(timeoutId);) and displays specific error messages for HTTP 413 errors and generic network errors.

How to test
Build a workflow with a Form node or Form Trigger node containing a file input.
Execute the workflow and open the form.
Upload several large files (e.g., 5 files of 25 MB each, or a payload exceeding your proxy's client_max_body_size or n8n's N8N_PAYLOAD_SIZE_MAX).
Submit the form.
Instead of the form silently refreshing and losing input data, verify that the form halts the submission and properly displays:
"The files you are trying to upload are too large." (if a 413 error is returned)
"A network error occurred. The files you are trying to upload might be too large, or there is a network issue. Please try again or contact support." (if the connection was aborted / TypeError: Failed to fetch occurred).
Related Linear tickets, Github issues, and Community forum posts
Fixes #15329 Fixes #16676

Review / Merge checklist
 I have seen this code, I have run this code, and I take responsibility for this code.
 PR title and summary are descriptive. (
conventions
)
 [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
 Tests included.
 PR Labeled with Backport to Beta, Backport to Stable, or Backport to v1 (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32269">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

