### PR TITLE
fix: prevent silent refresh on large form uploads

### DIFF
--- a/packages/cli/templates/form-trigger.handlebars
+++ b/packages/cli/templates/form-trigger.handlebars
@@ -1085,14 +1085,30 @@
 								form.style.display = 'none';
 								document.querySelector('#submitted-form').style.display = 'block';
 								document.querySelector('#submitted-header').textContent = 'Problem submitting response';
-								document.querySelector('#submitted-content').textContent =
-									'Please try again or contact support if the problem persists';
+								let errorMessage = 'Please try again or contact support if the problem persists';
+								if (response.status === 413) {
+									errorMessage = 'The files you are trying to upload are too large.';
+								}
+								document.querySelector('#submitted-content').textContent = errorMessage;
+								
+								// Stop polling for execution status
+								clearTimeout(timeoutId);
+								interval = 0;
 							}
 
 							return;
 						})
 						.catch(function (error) {
 							console.error('Error:', error);
+							form.style.display = 'none';
+							document.querySelector('#submitted-form').style.display = 'block';
+							document.querySelector('#submitted-header').textContent = 'Problem submitting response';
+							document.querySelector('#submitted-content').textContent =
+								'A network error occurred. The files you are trying to upload might be too large, or there is a network issue. Please try again or contact support.';
+							
+							// Stop polling for execution status
+							clearTimeout(timeoutId);
+							interval = 0;
 						})
 						.finally(() => {
 							if (window.location.href.includes('form-waiting')) {

--- a/packages/cli/templates/form-trigger.handlebars
+++ b/packages/cli/templates/form-trigger.handlebars
@@ -1024,6 +1024,22 @@
 						headers,
 					})
 						.then(async function (response) {
+							if (response.status !== 200) {
+								form.style.display = 'none';
+								document.querySelector('#submitted-form').style.display = 'block';
+								document.querySelector('#submitted-header').textContent = 'Problem submitting response';
+								let errorMessage = 'Please try again or contact support if the problem persists';
+								if (response.status === 413) {
+									errorMessage = 'The files you are trying to upload are too large.';
+								}
+								document.querySelector('#submitted-content').textContent = errorMessage;
+								
+								// Stop polling for execution status
+								clearTimeout(timeoutId);
+								interval = 0;
+								return;
+							}
+
 							const useResponseData = document.getElementById("useResponseData").value;
 
 							if (useResponseData === "true") {
@@ -1081,19 +1097,6 @@
 									form.style.display = 'none';
 									document.querySelector('#submitted-form').style.display = 'block';
 								}
-							} else {
-								form.style.display = 'none';
-								document.querySelector('#submitted-form').style.display = 'block';
-								document.querySelector('#submitted-header').textContent = 'Problem submitting response';
-								let errorMessage = 'Please try again or contact support if the problem persists';
-								if (response.status === 413) {
-									errorMessage = 'The files you are trying to upload are too large.';
-								}
-								document.querySelector('#submitted-content').textContent = errorMessage;
-								
-								// Stop polling for execution status
-								clearTimeout(timeoutId);
-								interval = 0;
 							}
 
 							return;


### PR DESCRIPTION
## Summary

This PR fixes an issue where uploading large files (for example, files larger than 100 MB) in a Form or Form Trigger node caused the form to silently refresh, discarding all user inputs without displaying any error message.

### Root cause

The issue was caused by a race condition in `form-trigger.handlebars`.

When a `fetch` POST request failed due to payload size limits (such as an HTTP `413 Payload Too Large` response from a proxy like Nginx, or an aborted connection), the `catch` block or non-200 response handler executed but failed to stop the `checkExecutionStatus` interval loop.

Because the interval continued running, the `finally` block scheduled another `checkExecutionStatus` poll. Since the upload never completed successfully, the server responded with `"form-waiting"`, which the polling logic interpreted as an instruction to reload the page using `window.location.replace()`.

As a result, the form refreshed silently and all user-entered data was lost.

### Fix

This PR properly halts the polling loop on upload failure by clearing the timeout and resetting the interval state:

* `interval = 0`
* `clearTimeout(timeoutId)`

It also improves user feedback by displaying specific error messages for:

* HTTP `413 Payload Too Large` responses
* Generic network or aborted connection failures

## How to test

1. Create a workflow with a Form node or Form Trigger node containing a file upload input.
2. Execute the workflow and open the form.
3. Upload several large files (for example, 5 files of 25 MB each), or exceed your proxy's `client_max_body_size` / `N8N_PAYLOAD_SIZE_MAX`.
4. Submit the form.

### Expected behavior

Instead of silently refreshing and losing all input data, the form should stop submission and display one of the following messages:

* `"The files you are trying to upload are too large."`
* `"A network error occurred. The files you are trying to upload might be too large, or there is a network issue. Please try again or contact support."`

## Related issues

Fixes #15329
Fixes #16676

## Review / Merge checklist

* [ ] I have seen this code, I have run this code, and I take responsibility for this code.
* [x] PR title and summary are descriptive.
* [ ] Docs updated or follow-up ticket created.
* [ ] Tests included.
* [ ] PR labeled with Backport to Beta, Backport to Stable, or Backport to v1 (if required).


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32270">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

