### PR TITLE
docs: Fix evaluated dates (typos) in date-extensions examples

### DIFF
--- a/packages/@n8n/expression-runtime/src/extensions/date-extensions.ts
+++ b/packages/@n8n/expression-runtime/src/extensions/date-extensions.ts
@@ -435,7 +435,7 @@ toDateTime.doc = {
 	examples: [
 		{
 			example: "jsDate = new Date('2024-03-30T18:49')\njsDate.toDateTime().plus(5, 'days')",
-			evaluated: '[DateTime: 2024-05-05T18:49:00.000Z]',
+			evaluated: '[DateTime: 2024-03-05T18:49:00.000Z]',
 		},
 	],
 	returnType: 'DateTime',
@@ -449,11 +449,11 @@ minus.doc = {
 	examples: [
 		{
 			example: "dt = '2024-03-30T18:49'.toDateTime()\ndt.minus(7, 'days')",
-			evaluated: '[DateTime: 2024-04-23T18:49:00.000Z]',
+			evaluated: '[DateTime: 2024-03-23T18:49:00.000Z]',
 		},
 		{
 			example: "dt = '2024-03-30T18:49'.toDateTime()\ndt.minus(4, 'years')",
-			evaluated: '[DateTime: 2020-04-30T18:49:00.000Z]',
+			evaluated: '[DateTime: 2020-03-30T18:49:00.000Z]',
 		},
 	],
 	section: 'edit',

--- a/packages/@n8n/expression-runtime/src/extensions/date-extensions.ts
+++ b/packages/@n8n/expression-runtime/src/extensions/date-extensions.ts
@@ -435,7 +435,7 @@ toDateTime.doc = {
 	examples: [
 		{
 			example: "jsDate = new Date('2024-03-30T18:49')\njsDate.toDateTime().plus(5, 'days')",
-			evaluated: '[DateTime: 2024-03-05T18:49:00.000Z]',
+			evaluated: '[DateTime: 2024-04-05T18:49:00.000Z]',
 		},
 	],
 	returnType: 'DateTime',


### PR DESCRIPTION
## Summary

Fix typos:
<img width="331" height="239" alt="image" src="https://github.com/user-attachments/assets/6a0283d1-ed5e-45dd-8e86-d941a37e8cdd" />


## How to test

------------

## Related Linear tickets, Github issues, and Community forum posts

---------------


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32273">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32273?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

