### PR TITLE
fix(core): Validate duplicate node property declarations via resolveOneOfSchemas (no-changelog)

### DIFF
--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.test.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.test.ts
@@ -14,6 +14,7 @@ import {
 	mergeDisplayOptions,
 	extractDefaultsForDisplayOptions,
 } from './generate-zod-schemas';
+import * as schemaHelpers from '../validation/schema-helpers';
 
 describe('mapPropertyToZodSchema for resourceLocator', () => {
 	it('returns resourceLocatorValueSchema when no modes are specified', () => {
@@ -328,6 +329,101 @@ describe('generateConditionalSchemaLine', () => {
 		const line = generateConditionalSchemaLine(prop, allProperties);
 
 		expect(line).not.toContain('defaults:');
+	});
+});
+
+describe('duplicate property declarations with mutually-exclusive displayOptions', () => {
+	const baseNode = {
+		group: ['transform'] as string[],
+		inputs: ['main'] as string[],
+		outputs: ['main'] as string[],
+	};
+
+	// Mirrors the Summarize node: `fieldsToSplitBy` is declared twice so it can
+	// carry a different label in each output mode. The two declarations are OR
+	// alternatives — the field is visible when EITHER matches — so merging their
+	// show/hide into a single condition produces a self-contradicting predicate.
+	const dupPropNode: NodeTypeDescription = {
+		...baseNode,
+		name: 'n8n-nodes-base.dupProp',
+		displayName: 'Dup Prop',
+		version: 1,
+		properties: [
+			{
+				displayName: 'Fields to Split By',
+				name: 'fieldsToSplitBy',
+				type: 'string',
+				default: '',
+				displayOptions: { hide: { '/options.outputFormat': ['singleItem'] } },
+			},
+			{
+				displayName: 'Fields to Group By',
+				name: 'fieldsToSplitBy',
+				type: 'string',
+				default: '',
+				displayOptions: { show: { '/options.outputFormat': ['singleItem'] } },
+			},
+			{
+				displayName: 'Options',
+				name: 'options',
+				type: 'collection',
+				default: {},
+				options: [
+					{
+						displayName: 'Output Format',
+						name: 'outputFormat',
+						type: 'options',
+						default: 'separateItems',
+						options: [
+							{ name: 'Separate Items', value: 'separateItems' },
+							{ name: 'Single Item', value: 'singleItem' },
+						],
+					} as NodeProperty,
+				],
+			},
+		],
+	};
+
+	function loadFactory(code: string): (helpers: Record<string, unknown>) => {
+		safeParse: (val: unknown) => { success: boolean };
+	} {
+		const module = { exports: {} as unknown };
+		// eslint-disable-next-line @typescript-eslint/no-implied-eval
+		const fn = new Function('module', 'exports', code) as (m: unknown, e: unknown) => void;
+		fn(module, module.exports);
+		return module.exports as (helpers: Record<string, unknown>) => {
+			safeParse: (val: unknown) => { success: boolean };
+		};
+	}
+
+	it('emits resolveOneOfSchemas instead of a self-contradicting single resolveSchema', () => {
+		const code = generateSingleVersionSchemaFile(dupPropNode, 1);
+
+		expect(code).toContain('resolveOneOfSchemas(');
+		// The buggy merge combined both declarations into one show+hide on the same key
+		expect(code).not.toMatch(
+			/"show":\{"\/options\.outputFormat":\["singleItem"\]\},"hide":\{"\/options\.outputFormat":\["singleItem"\]\}/,
+		);
+	});
+
+	it('validates a default-reliant config that relies on the default output mode', () => {
+		const code = generateSingleVersionSchemaFile(dupPropNode, 1);
+		const factory = loadFactory(code);
+
+		// `options` is empty, so outputFormat falls back to its default
+		// (separateItems) — exactly how a canvas-authored node looks.
+		const parameters = { fieldsToSplitBy: 'name', options: {} };
+		const schema = factory({
+			...schemaHelpers,
+			parameters,
+			resolveSchema: (cfg: Parameters<typeof schemaHelpers.resolveSchema>[0]) =>
+				schemaHelpers.resolveSchema(cfg),
+			resolveOneOfSchemas: (cfg: Parameters<typeof schemaHelpers.resolveOneOfSchemas>[0]) =>
+				schemaHelpers.resolveOneOfSchemas(cfg),
+		});
+
+		const result = schema.safeParse({ parameters });
+		expect(result.success).toBe(true);
 	});
 });
 
@@ -759,7 +855,7 @@ describe('generateDiscriminatorSchemaFile with displayOptions', () => {
 		);
 
 		// CommonJS: resolveSchema is included in the require destructure
-		expect(code).toContain('resolveSchema }');
+		expect(code).toContain('resolveSchema, resolveOneOfSchemas }');
 	});
 
 	it('uses resolveSchema for properties with remaining displayOptions', () => {
@@ -859,7 +955,7 @@ describe('generateDiscriminatorSchemaFile with displayOptions', () => {
 
 		// CommonJS module.exports for factory function with all helpers as parameters
 		expect(code).toContain('module.exports = function getSchema({ parameters, z,');
-		expect(code).toContain('resolveSchema }');
+		expect(code).toContain('resolveSchema, resolveOneOfSchemas }');
 		expect(code).toContain('return z.object({');
 	});
 
@@ -1000,7 +1096,7 @@ describe('generateSingleVersionSchemaFile', () => {
 
 		// Should generate a factory function with all helpers as parameters (CommonJS)
 		expect(code).toContain('module.exports = function getSchema({ parameters, z,');
-		expect(code).toContain('resolveSchema }');
+		expect(code).toContain('resolveSchema, resolveOneOfSchemas }');
 		expect(code).toContain('return z.object({');
 	});
 

--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.test.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.test.ts
@@ -406,6 +406,73 @@ describe('duplicate property declarations with mutually-exclusive displayOptions
 		);
 	});
 
+	it('uses the surviving declaration displayOptions when another duplicate is fully disabled', () => {
+		const node: NodeTypeDescription = {
+			...baseNode,
+			name: 'n8n-nodes-base.singleActiveDupProp',
+			displayName: 'Single Active Dup Prop',
+			version: 1,
+			properties: [
+				{
+					displayName: 'Special Field',
+					name: 'specialField',
+					type: 'string',
+					default: '',
+					displayOptions: { show: { mode: ['legacy'] } },
+					disabledOptions: { show: { mode: ['legacy'] } },
+				},
+				{
+					displayName: 'Special Field',
+					name: 'specialField',
+					type: 'string',
+					default: '',
+					displayOptions: { show: { mode: ['modern'] } },
+				},
+				{
+					displayName: 'Mode',
+					name: 'mode',
+					type: 'options',
+					default: 'modern',
+					options: [
+						{ name: 'Legacy', value: 'legacy' },
+						{ name: 'Modern', value: 'modern' },
+					],
+				},
+			],
+		};
+
+		const code = generateSingleVersionSchemaFile(node, 1);
+
+		expect(code).not.toContain('resolveOneOfSchemas(');
+		expect(code).toContain('displayOptions: {"show":{"mode":["modern"]}}');
+		expect(code).not.toContain('displayOptions: {"show":{"mode":["legacy","modern"]}}');
+
+		const factory = loadFactory(code);
+		const legacyParameters = { mode: 'legacy', specialField: 'value' };
+		const legacySchema = factory({
+			...schemaHelpers,
+			parameters: legacyParameters,
+			resolveSchema: (cfg: Parameters<typeof schemaHelpers.resolveSchema>[0]) =>
+				schemaHelpers.resolveSchema(cfg),
+			resolveOneOfSchemas: (cfg: Parameters<typeof schemaHelpers.resolveOneOfSchemas>[0]) =>
+				schemaHelpers.resolveOneOfSchemas(cfg),
+		});
+
+		expect(legacySchema.safeParse({ parameters: legacyParameters }).success).toBe(false);
+
+		const modernParameters = { mode: 'modern', specialField: 'value' };
+		const modernSchema = factory({
+			...schemaHelpers,
+			parameters: modernParameters,
+			resolveSchema: (cfg: Parameters<typeof schemaHelpers.resolveSchema>[0]) =>
+				schemaHelpers.resolveSchema(cfg),
+			resolveOneOfSchemas: (cfg: Parameters<typeof schemaHelpers.resolveOneOfSchemas>[0]) =>
+				schemaHelpers.resolveOneOfSchemas(cfg),
+		});
+
+		expect(modernSchema.safeParse({ parameters: modernParameters }).success).toBe(true);
+	});
+
 	it('validates a default-reliant config that relies on the default output mode', () => {
 		const code = generateSingleVersionSchemaFile(dupPropNode, 1);
 		const factory = loadFactory(code);

--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.ts
@@ -24,6 +24,7 @@ import {
 	filterPropertiesForVersion,
 	buildDiscriminatorTree,
 	extractAIInputTypesFromBuilderHint,
+	narrowDisplayOptionsByDisabled,
 } from './generate-types';
 
 // =============================================================================
@@ -971,6 +972,145 @@ export function generateConditionalSchemaLine(
 	return `${INDENT}${propName}: resolveSchema({ parameters, schema: ${zodSchema}, required: ${required}, displayOptions: ${displayOptionsStr}${defaultsStr} }),`;
 }
 
+/**
+ * Collect every raw declaration for each property name, preserving order.
+ * Mirrors `mergePropertiesByName`'s filtering so the keys line up with it.
+ *
+ * @param properties - Array of node properties, possibly with duplicates
+ * @returns Map of property name to its list of declarations
+ */
+export function collectDeclarationsByName(properties: NodeProperty[]): Map<string, NodeProperty[]> {
+	const byName = new Map<string, NodeProperty[]>();
+	for (const prop of properties) {
+		if (DISPLAY_ONLY_PROPERTY_TYPES.has(prop.type)) {
+			continue;
+		}
+		const list = byName.get(prop.name);
+		if (list) {
+			list.push(prop);
+		} else {
+			byName.set(prop.name, [prop]);
+		}
+	}
+	return byName;
+}
+
+type DisplayOptionsValue = NonNullable<NodeProperty['displayOptions']>;
+
+/** One declaration of a multiply-declared property, with its resolved displayOptions. */
+interface SchemaVariant {
+	prop: NodeProperty;
+	displayOptions: DisplayOptionsValue;
+}
+
+/**
+ * Generate a schema property line using the resolveOneOfSchemas helper.
+ * Used when a property name is declared multiple times with mutually-exclusive
+ * displayOptions — the declarations are OR alternatives, so the field is visible
+ * when any variant matches. resolveOneOfSchemas picks the first matching variant.
+ *
+ * Each variant carries its OWN schema, required flag and displayOptions: the
+ * declarations can differ (e.g. an agent's `text` is required with an empty
+ * default in one mode but optional with a `$json` default in another).
+ *
+ * @param variants - The per-declaration variants (>= 2)
+ * @param allProperties - All properties at this level (used to extract defaults)
+ * @returns Generated code line for the property using resolveOneOfSchemas, or ''
+ */
+export function generateOneOfSchemaLine(
+	variants: SchemaVariant[],
+	allProperties: NodeProperty[] = [],
+): string {
+	const propName = quotePropertyName(variants[0].prop.name);
+
+	const variantStrs: string[] = [];
+	for (const { prop, displayOptions } of variants) {
+		const zodSchema = mapPropertyToZodSchema(prop);
+		if (!zodSchema) {
+			return '';
+		}
+		const required = !isPropertyOptional(prop);
+		const displayOptionsStr = JSON.stringify(displayOptions);
+		const defaults = extractDefaultsForDisplayOptions(displayOptions, allProperties);
+		const defaultsStr =
+			Object.keys(defaults).length > 0 ? `, defaults: ${JSON.stringify(defaults)}` : '';
+		variantStrs.push(
+			`{ schema: ${zodSchema}, required: ${required}, displayOptions: ${displayOptionsStr}${defaultsStr} }`,
+		);
+	}
+
+	return `${INDENT}${propName}: resolveOneOfSchemas({ parameters, variants: [${variantStrs.join(', ')}] }),`;
+}
+
+/**
+ * Generate the schema line for a property, accounting for duplicate declarations.
+ *
+ * The genuine multi-declaration case — the same property name declared two or
+ * more times, each conditional on mutually-exclusive displayOptions — is the only
+ * case that needs resolveOneOfSchemas. Merging those into one show/hide produces
+ * a self-contradicting predicate, so we emit one variant per declaration instead.
+ *
+ * Each declaration's `disabledOptions` is narrowed into its displayOptions first
+ * (matching the type-generation path), so the runtime visibility agrees with the
+ * emitted `.d.ts`. Every other case keeps the historical single-merged-schema
+ * behavior so this change stays scoped to the bug it fixes.
+ *
+ * @param mergedProp - The merged property for this name
+ * @param declarations - All raw declarations sharing this name
+ * @param allProperties - All properties at this level (used to extract defaults)
+ * @param keysToStrip - displayOptions keys that are implicit and should be removed
+ * @returns Generated code line, INDENT-prefixed (empty string if not mappable)
+ */
+export function generateMergedSchemaLine(
+	mergedProp: NodeProperty,
+	declarations: NodeProperty[],
+	allProperties: NodeProperty[],
+	keysToStrip: string[],
+): string {
+	const variants: SchemaVariant[] = [];
+	let allConditional = true;
+	for (const decl of declarations) {
+		const { displayOptions: narrowed, fullyDisabled } = narrowDisplayOptionsByDisabled(decl);
+		if (fullyDisabled) {
+			// Never settable in any visible state — not a real variant
+			continue;
+		}
+		if (!narrowed) {
+			allConditional = false;
+			break;
+		}
+		const stripped = stripDiscriminatorKeysFromDisplayOptions(narrowed, keysToStrip);
+		if (!stripped) {
+			// Conditions were all implicit (e.g. only @version) — not the bug case
+			allConditional = false;
+			break;
+		}
+		variants.push({ prop: decl, displayOptions: stripped });
+	}
+
+	if (allConditional && variants.length >= 2) {
+		const line = generateOneOfSchemaLine(variants, allProperties);
+		if (line) {
+			return line;
+		}
+	}
+
+	// Historical behavior: a single merged schema using the merged displayOptions
+	if (mergedProp.displayOptions) {
+		const stripped = stripDiscriminatorKeysFromDisplayOptions(
+			mergedProp.displayOptions,
+			keysToStrip,
+		);
+		if (stripped) {
+			return generateConditionalSchemaLine(
+				{ ...mergedProp, displayOptions: stripped },
+				allProperties,
+			);
+		}
+	}
+	return generateSchemaPropertyLine(mergedProp, isPropertyOptional(mergedProp));
+}
+
 // =============================================================================
 // Schema Generation Result Types
 // =============================================================================
@@ -1166,6 +1306,7 @@ export function generateSingleVersionSchemaFile(
 	// Add resolveSchema if we need it
 	if (needsResolveSchema) {
 		helpers.push('resolveSchema');
+		helpers.push('resolveOneOfSchemas');
 	}
 
 	// Add subnode schema imports if this is an AI node
@@ -1265,34 +1406,14 @@ export function generateSingleVersionSchemaFile(
 	// Group properties by name, merging displayOptions and nested options for duplicates
 	const propsByName = mergePropertiesByName(filteredProperties);
 	const allPropsArray = Array.from(propsByName.values());
+	// @version is implicit in the file path, so strip it from displayOptions
+	const declarationsByName = collectDeclarationsByName(filteredProperties);
 
 	for (const prop of allPropsArray) {
-		if (prop.displayOptions) {
-			// Strip @version since it's implicit in the file path
-			const strippedDisplayOptions = stripDiscriminatorKeysFromDisplayOptions(prop.displayOptions, [
-				'@version',
-			]);
-			if (strippedDisplayOptions) {
-				const propWithStripped: NodeProperty = {
-					...prop,
-					displayOptions: strippedDisplayOptions,
-				};
-				const propLine = generateConditionalSchemaLine(propWithStripped, allPropsArray);
-				if (propLine) {
-					lines.push(INDENT + propLine);
-				}
-			} else {
-				// No remaining conditions after stripping @version - use static schema
-				const propLine = generateSchemaPropertyLine(prop, isPropertyOptional(prop));
-				if (propLine) {
-					lines.push(INDENT + propLine);
-				}
-			}
-		} else {
-			const propLine = generateSchemaPropertyLine(prop, isPropertyOptional(prop));
-			if (propLine) {
-				lines.push(INDENT + propLine);
-			}
+		const declarations = declarationsByName.get(prop.name) ?? [prop];
+		const propLine = generateMergedSchemaLine(prop, declarations, allPropsArray, ['@version']);
+		if (propLine) {
+			lines.push(INDENT + propLine);
 		}
 	}
 
@@ -1423,6 +1544,7 @@ export function generateDiscriminatorSchemaFile(
 	// Add resolveSchema if properties have displayOptions OR AI inputs have displayOptions
 	if (hasRemainingDisplayOptions || hasConditionalAiInputs) {
 		helpers.push('resolveSchema');
+		helpers.push('resolveOneOfSchemas');
 	}
 
 	// Add subnode schema imports if this combo has AI inputs
@@ -1542,32 +1664,12 @@ export function generateDiscriminatorSchemaFile(
 	// Generate schema for each merged property
 	// Convert propsByName to array for extractDefaultsForDisplayOptions
 	const allPropsArray = Array.from(propsByName.values());
+	const declarationsByName = collectDeclarationsByName(props);
 	for (const prop of allPropsArray) {
-		if (prop.displayOptions) {
-			const strippedDisplayOptions = stripDiscriminatorKeysFromDisplayOptions(
-				prop.displayOptions,
-				discriminatorKeys,
-			);
-			if (strippedDisplayOptions) {
-				const propWithStrippedOptions: NodeProperty = {
-					...prop,
-					displayOptions: strippedDisplayOptions,
-				};
-				const propLine = generateConditionalSchemaLine(propWithStrippedOptions, allPropsArray);
-				if (propLine) {
-					lines.push(INDENT.repeat(2) + propLine);
-				}
-			} else {
-				const propLine = generateSchemaPropertyLine(prop, isPropertyOptional(prop));
-				if (propLine) {
-					lines.push(INDENT.repeat(2) + propLine);
-				}
-			}
-		} else {
-			const propLine = generateSchemaPropertyLine(prop, isPropertyOptional(prop));
-			if (propLine) {
-				lines.push(INDENT.repeat(2) + propLine);
-			}
+		const declarations = declarationsByName.get(prop.name) ?? [prop];
+		const propLine = generateMergedSchemaLine(prop, declarations, allPropsArray, discriminatorKeys);
+		if (propLine) {
+			lines.push(INDENT.repeat(2) + propLine);
 		}
 	}
 

--- a/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.ts
+++ b/packages/@n8n/workflow-sdk/src/generate-types/generate-zod-schemas.ts
@@ -834,6 +834,14 @@ type MergeableDisplayOptions = {
 	hide?: Record<string, unknown[]>;
 };
 
+function cloneDisplayOptionsValues(values: Record<string, unknown[]>): Record<string, unknown[]> {
+	const clone: Record<string, unknown[]> = {};
+	for (const [key, optionValues] of Object.entries(values)) {
+		clone[key] = [...optionValues];
+	}
+	return clone;
+}
+
 /**
  * Merge two displayOptions objects by combining their show/hide conditions.
  * Used when multiple properties share the same name but have different visibility conditions.
@@ -846,7 +854,13 @@ export function mergeDisplayOptions(
 	existing: MergeableDisplayOptions,
 	incoming: MergeableDisplayOptions,
 ): MergeableDisplayOptions {
-	const merged: MergeableDisplayOptions = { ...existing };
+	const merged: MergeableDisplayOptions = {};
+	if (existing.show) {
+		merged.show = cloneDisplayOptionsValues(existing.show);
+	}
+	if (existing.hide) {
+		merged.hide = cloneDisplayOptionsValues(existing.hide);
+	}
 
 	// Merge 'show' conditions
 	if (incoming.show) {
@@ -1052,8 +1066,8 @@ export function generateOneOfSchemaLine(
  *
  * Each declaration's `disabledOptions` is narrowed into its displayOptions first
  * (matching the type-generation path), so the runtime visibility agrees with the
- * emitted `.d.ts`. Every other case keeps the historical single-merged-schema
- * behavior so this change stays scoped to the bug it fixes.
+ * emitted `.d.ts`. If disabledOptions leaves only one settable duplicate
+ * declaration, that declaration still owns the generated predicate.
  *
  * @param mergedProp - The merged property for this name
  * @param declarations - All raw declarations sharing this name
@@ -1090,6 +1104,14 @@ export function generateMergedSchemaLine(
 
 	if (allConditional && variants.length >= 2) {
 		const line = generateOneOfSchemaLine(variants, allProperties);
+		if (line) {
+			return line;
+		}
+	}
+
+	if (allConditional && variants.length === 1 && declarations.length > 1) {
+		const [{ prop, displayOptions }] = variants;
+		const line = generateConditionalSchemaLine({ ...prop, displayOptions }, allProperties);
 		if (line) {
 			return line;
 		}


### PR DESCRIPTION
## Summary

When a node declares the **same property name multiple times with mutually-exclusive `displayOptions`** (an OR-alternative pattern used across nodes — e.g. Summarize's `fieldsToSplitBy`, BigQuery's `sqlQuery`), the SDK schema generator merged both declarations into a single `show`+`hide` condition on the same key. That produces a self-contradicting predicate the field can *never* satisfy, so the validator rejected **working, canvas-authored nodes** as blocking `INVALID_PARAMETER` errors:

- BigQuery: `Field "parameters.sqlQuery": only allowed when … /options.useLegacySql=true`
- Summarize: `Field "parameters.fieldsToSplitBy": only allowed when /options.outputFormat="singleItem"`

In the AI builder this caused the agent to repeatedly "fix" nodes the user never touched, often breaking them, until its submit budget was exhausted.

The generator now emits `resolveOneOfSchemas` (which already existed for exactly this purpose) with **one variant per declaration**, each carrying its own schema, `required` flag and `disabledOptions`-narrowed `displayOptions`, so the field is valid when any variant matches. The behavior now agrees with the type-generation path (`tryMergeUxForkVariants` / `narrowDisplayOptionsByDisabled`). Non-duplicate properties keep the historical single-merged-schema behavior, so the change is scoped to the bug.

## How to test

- `cd packages/@n8n/workflow-sdk && pnpm test src/generate-types src/validation` (644 pass)
- New coverage in `generate-zod-schemas.test.ts` (`duplicate property declarations with mutually-exclusive displayOptions`) asserts the generated schema uses `resolveOneOfSchemas` and that a default-reliant config validates.
- Manual: in the AI builder, ask it to make a small edit to an existing workflow that contains a Summarize or BigQuery node configured on the canvas — it should no longer flag those untouched nodes as invalid.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-491

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32274">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->