### PR TITLE
fix(core): Handle malformed agent tool calls

### DIFF
--- a/packages/@n8n/agents/src/__tests__/integration/agent-runtime-conversion.test.ts
+++ b/packages/@n8n/agents/src/__tests__/integration/agent-runtime-conversion.test.ts
@@ -93,7 +93,7 @@ describe('toAiMessages + fromAiMessages — round-trip', () => {
 		expect(toolCallPart.providerMetadata).toEqual(providerMetadata);
 	});
 
-	it('coerces replayed tool-call inputs to objects for provider requests', () => {
+	it('sanitizes replayed non-object tool-call inputs for provider requests', () => {
 		const input: Message[] = [
 			{
 				role: 'assistant',
@@ -142,12 +142,7 @@ describe('toAiMessages + fromAiMessages — round-trip', () => {
 			}
 		).content;
 
-		expect(assistantParts.map((part) => part.input)).toEqual([
-			{ query: 'n8n' },
-			{ value: ['a', 'b'] },
-			{},
-			{ value: 'plain-text' },
-		]);
+		expect(assistantParts.map((part) => part.input)).toEqual([{ query: 'n8n' }, {}, {}, {}]);
 	});
 
 	it('preserves content tool outputs when building tool ModelMessages', () => {

--- a/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
+++ b/packages/@n8n/agents/src/runtime/__tests__/agent-runtime.test.ts
@@ -273,12 +273,26 @@ function makeGenerateWithToolCall(toolCallId: string, toolName: string, input: u
 			messages: [
 				{
 					role: 'assistant',
-					content: [{ type: 'tool-call', toolCallId, toolName, args: input }],
+					content: [{ type: 'tool-call', toolCallId, toolName, args: input, input }],
 				},
 			],
 		},
 		toolCalls: [{ toolCallId, toolName, input }],
 	};
+}
+
+function getFirstReplayedToolCallInput(callIndex: number) {
+	const callArgs = generateText.mock.calls[callIndex][0] as {
+		messages: Array<{ role: string; content: unknown }>;
+	};
+	const assistantMessage = callArgs.messages.find((message) => message.role === 'assistant');
+	if (!assistantMessage || !Array.isArray(assistantMessage.content)) return undefined;
+
+	const toolCall = assistantMessage.content.find(
+		(part): part is { type: 'tool-call'; input?: unknown } =>
+			typeof part === 'object' && part !== null && Reflect.get(part, 'type') === 'tool-call',
+	);
+	return toolCall?.input;
 }
 
 /** Build an interruptible tool that suspends on first call and returns on resume. */
@@ -951,6 +965,7 @@ function makeGenerateWithToolCalls(
 						toolCallId: tc.toolCallId,
 						toolName: tc.toolName,
 						args: tc.args,
+						input: tc.args,
 					})),
 				},
 			],
@@ -2723,6 +2738,109 @@ describe('AgentRuntime — runtime JSON Schema input validation', () => {
 		expect(assistantMsg).toBeDefined();
 		const call = assistantMsg.content.find((c) => c.type === 'tool-call') as ContentToolCall;
 		expect(call.state).toBe('resolved');
+	});
+
+	it('parses stringified JSON object tool input before validating and replaying', async () => {
+		const handlerFn = vi.fn().mockResolvedValue({ ok: true });
+		const tool: BuiltTool = {
+			name: 'json_tool',
+			description: 'json tool',
+			inputSchema: {
+				type: 'object',
+				properties: { id: { type: 'string' } },
+				required: ['id'],
+			},
+			handler: handlerFn,
+		};
+
+		generateText
+			.mockResolvedValueOnce(makeGenerateWithToolCall('tc-1', 'json_tool', '{"id":"abc"}'))
+			.mockResolvedValueOnce(makeGenerateSuccess('done'));
+
+		const runtime = new AgentRuntime({
+			name: 'test',
+			model: 'openai/gpt-4o-mini',
+			instructions: 'test',
+			tools: [tool],
+		});
+
+		const result = await runtime.generate('go');
+		expect(result.finishReason).toBe('stop');
+		expect(handlerFn).toHaveBeenCalledWith(
+			expect.objectContaining({ id: 'abc' }),
+			expect.anything(),
+		);
+		expect(getFirstReplayedToolCallInput(1)).toEqual({ id: 'abc' });
+	});
+
+	it('surfaces malformed string tool input as a retryable tool error', async () => {
+		const handlerFn = vi.fn().mockResolvedValue({ ok: true });
+		const tool: BuiltTool = {
+			name: 'json_tool',
+			description: 'json tool',
+			handler: handlerFn,
+		};
+
+		generateText
+			.mockResolvedValueOnce(makeGenerateWithToolCall('tc-1', 'json_tool', '{bad json'))
+			.mockResolvedValueOnce(makeGenerateSuccess('done'));
+
+		const runtime = new AgentRuntime({
+			name: 'test',
+			model: 'openai/gpt-4o-mini',
+			instructions: 'test',
+			tools: [tool],
+		});
+
+		const result = await runtime.generate('go');
+		expect(result.finishReason).toBe('stop');
+		expect(handlerFn).not.toHaveBeenCalled();
+		expect(getFirstReplayedToolCallInput(1)).toEqual({});
+
+		const assistantMsg = result.messages.find(
+			(m) =>
+				isLlmMessage(m) && m.role === 'assistant' && m.content.some((c) => c.type === 'tool-call'),
+		) as Message;
+		const call = assistantMsg.content.find((c) => c.type === 'tool-call') as ContentToolCall;
+		expect(call.state).toBe('rejected');
+		expect(call.state === 'rejected' && call.error).toContain(
+			'Tool input must be a valid JSON object string.',
+		);
+	});
+
+	it('surfaces stringified non-object tool input as a retryable tool error', async () => {
+		const handlerFn = vi.fn().mockResolvedValue({ ok: true });
+		const tool: BuiltTool = {
+			name: 'json_tool',
+			description: 'json tool',
+			handler: handlerFn,
+		};
+
+		generateText
+			.mockResolvedValueOnce(makeGenerateWithToolCall('tc-1', 'json_tool', '["not an object"]'))
+			.mockResolvedValueOnce(makeGenerateSuccess('done'));
+
+		const runtime = new AgentRuntime({
+			name: 'test',
+			model: 'openai/gpt-4o-mini',
+			instructions: 'test',
+			tools: [tool],
+		});
+
+		const result = await runtime.generate('go');
+		expect(result.finishReason).toBe('stop');
+		expect(handlerFn).not.toHaveBeenCalled();
+		expect(getFirstReplayedToolCallInput(1)).toEqual({});
+
+		const assistantMsg = result.messages.find(
+			(m) =>
+				isLlmMessage(m) && m.role === 'assistant' && m.content.some((c) => c.type === 'tool-call'),
+		) as Message;
+		const call = assistantMsg.content.find((c) => c.type === 'tool-call') as ContentToolCall;
+		expect(call.state).toBe('rejected');
+		expect(call.state === 'rejected' && call.error).toContain(
+			'Tool input must be a JSON object, got array.',
+		);
 	});
 
 	it('surfaces a validation error as a tool error outcome when LLM provides the wrong type', async () => {

--- a/packages/@n8n/agents/src/runtime/agent-runtime.ts
+++ b/packages/@n8n/agents/src/runtime/agent-runtime.ts
@@ -57,7 +57,7 @@ import { loadAi } from './lazy-ai';
 import { createFilteredLogger } from './logger';
 import { saveMessagesToThread } from './memory-store';
 import { AgentMessageList, type SerializedMessageList } from './message-list';
-import { fromAiFinishReason, fromAiMessages } from './messages';
+import { fromAiFinishReason, fromAiMessages, normalizeToolInputForModel } from './messages';
 import { createModel } from './model-factory';
 import {
 	runObservationLogObserver,
@@ -2324,6 +2324,12 @@ export class AgentRuntime {
 		if (countToolCall) {
 			this.incrementToolCallCount(executionCounter);
 		}
+
+		const normalizedToolInput = normalizeToolInputForModel(toolInput);
+		if (!normalizedToolInput.ok) {
+			return makeToolError(new Error(normalizedToolInput.error));
+		}
+		toolInput = normalizedToolInput.input;
 
 		if (builtTool.inputSchema) {
 			const result = await parseWithSchema(builtTool.inputSchema, toolInput);

--- a/packages/@n8n/agents/src/runtime/agent-runtime.ts
+++ b/packages/@n8n/agents/src/runtime/agent-runtime.ts
@@ -336,6 +336,13 @@ interface ToolCallError {
 	error: unknown;
 }
 
+interface RuntimeToolCall {
+	toolCallId: string;
+	toolName: string;
+	input: JSONObject;
+	providerExecuted?: boolean;
+}
+
 /** Result of executing a batch of tool calls (before persistence). */
 interface ToolCallBatchResult {
 	results: ToolCallSuccess[];
@@ -1931,8 +1938,29 @@ export class AgentRuntime {
 			executionCounter,
 			abortSignal,
 		} = ctx;
-		const executableCalls = toolCalls.filter((tc) => !tc.providerExecuted);
-		const providerExecutedCount = toolCalls.length - executableCalls.length;
+		const errors: ToolCallError[] = [];
+		const runtimeToolCalls: RuntimeToolCall[] = [];
+
+		for (const toolCall of toolCalls) {
+			const normalizedInput = normalizeToolInputForModel(toolCall.input);
+			if (!normalizedInput.ok) {
+				const error = new Error(normalizedInput.error);
+				this.incrementToolCallCount(executionCounter);
+				list.setToolCallError(toolCall.toolCallId, error);
+				errors.push({
+					toolCallId: toolCall.toolCallId,
+					toolName: toolCall.toolName,
+					input: normalizedInput.input,
+					error,
+				});
+				continue;
+			}
+
+			runtimeToolCalls.push({ ...toolCall, input: normalizedInput.input });
+		}
+
+		const executableCalls = runtimeToolCalls.filter((tc) => !tc.providerExecuted);
+		const providerExecutedCount = runtimeToolCalls.length - executableCalls.length;
 		for (let i = 0; i < providerExecutedCount; i++) {
 			this.incrementToolCallCount(executionCounter);
 		}
@@ -1940,7 +1968,6 @@ export class AgentRuntime {
 		const unexecutedIds = new Set(executableCalls.map((tc) => tc.toolCallId));
 		const results: ToolCallSuccess[] = [];
 		const suspensions: ToolCallSuspension[] = [];
-		const errors: ToolCallError[] = [];
 		const pending: Record<string, PendingToolCall> = {};
 
 		for (let batchStart = 0; batchStart < executableCalls.length; ) {
@@ -1958,7 +1985,7 @@ export class AgentRuntime {
 						await this.processToolCall(
 							tc.toolCallId,
 							tc.toolName,
-							tc.input as JSONValue,
+							tc.input,
 							toolMap,
 							list,
 							runId,
@@ -1981,7 +2008,7 @@ export class AgentRuntime {
 			for (let i = 0; i < settledResults.length; i++) {
 				const result = settledResults[i];
 				const tc = batch[i];
-				const toolInput = tc.input as JSONValue;
+				const toolInput = tc.input;
 
 				if (result.status === 'rejected') {
 					list.setToolCallError(tc.toolCallId, result.reason);
@@ -2037,7 +2064,7 @@ export class AgentRuntime {
 						suspended: false,
 						toolCallId: tc.toolCallId,
 						toolName: tc.toolName,
-						input: tc.input as JSONValue,
+						input: tc.input,
 					};
 				}
 				break;
@@ -2324,12 +2351,6 @@ export class AgentRuntime {
 		if (countToolCall) {
 			this.incrementToolCallCount(executionCounter);
 		}
-
-		const normalizedToolInput = normalizeToolInputForModel(toolInput);
-		if (!normalizedToolInput.ok) {
-			return makeToolError(new Error(normalizedToolInput.error));
-		}
-		toolInput = normalizedToolInput.input;
 
 		if (builtTool.inputSchema) {
 			const result = await parseWithSchema(builtTool.inputSchema, toolInput);

--- a/packages/@n8n/agents/src/runtime/messages.ts
+++ b/packages/@n8n/agents/src/runtime/messages.ts
@@ -63,7 +63,7 @@ function describeValue(value: unknown): string {
 	return typeof value;
 }
 
-export function normalizeToolInputForModel(value: JSONValue): ToolInputNormalizationResult {
+export function normalizeToolInputForModel(value: unknown): ToolInputNormalizationResult {
 	if (typeof value === 'string') {
 		try {
 			const parsed: unknown = JSON.parse(value);
@@ -209,16 +209,20 @@ function fromAiContent(part: AiContentPart): MessageContent | undefined {
 		case 'reasoning':
 			base = { type: 'reasoning', text: part.text };
 			break;
-		case 'tool-call':
+		case 'tool-call': {
+			const normalizedInput = normalizeToolInputForModel(part.input);
 			base = {
 				type: 'tool-call',
 				toolCallId: part.toolCallId,
 				toolName: part.toolName,
-				input: part.input as JSONValue,
+				input: normalizedInput.input,
 				providerExecuted: part.providerExecuted,
-				state: 'pending',
+				...(normalizedInput.ok
+					? { state: 'pending' as const }
+					: { state: 'rejected' as const, error: normalizedInput.error }),
 			};
 			break;
+		}
 		case 'tool-result':
 			return undefined;
 		// Ignore these types, because HITL is handled by our runtime

--- a/packages/@n8n/agents/src/runtime/messages.ts
+++ b/packages/@n8n/agents/src/runtime/messages.ts
@@ -20,7 +20,7 @@ import type {
 	Message,
 	MessageContent,
 } from '../types/sdk/message';
-import type { JSONValue } from '../types/utils/json';
+import type { JSONObject, JSONValue } from '../types/utils/json';
 
 /** Reasoning content part — mirrors @ai-sdk/provider-utils ReasoningPart (not re-exported by 'ai'). */
 type ReasoningPart = { type: 'reasoning'; text: string };
@@ -53,30 +53,55 @@ function isToolCall(block: MessageContent): block is ContentToolCall {
 	return block.type === 'tool-call';
 }
 
-/**
- * Parse a JSONValue that may be a stringified JSON object back into
- * its parsed form. Non-string values pass through unchanged.
- */
-function parseJsonValue(value: JSONValue): unknown {
-	if (typeof value === 'string') {
-		try {
-			return JSON.parse(value);
-		} catch {
-			return value;
-		}
-	}
-	return value;
+type ToolInputNormalizationResult =
+	| { ok: true; input: JSONObject }
+	| { ok: false; input: JSONObject; error: string };
+
+function describeValue(value: unknown): string {
+	if (Array.isArray(value)) return 'array';
+	if (value === null) return 'null';
+	return typeof value;
 }
 
-function toToolInputObject(value: JSONValue): Record<string, unknown> {
-	const parsed = parseJsonValue(value);
-	if (isRecord(parsed)) return parsed;
-	if (parsed === null || parsed === undefined) return {};
-	return { value: parsed };
+export function normalizeToolInputForModel(value: JSONValue): ToolInputNormalizationResult {
+	if (typeof value === 'string') {
+		try {
+			const parsed: unknown = JSON.parse(value);
+			if (isJsonObject(parsed)) return { ok: true, input: parsed };
+			return {
+				ok: false,
+				input: {},
+				error: `Tool input must be a JSON object, got ${describeValue(parsed)}.`,
+			};
+		} catch {
+			return {
+				ok: false,
+				input: {},
+				error: 'Tool input must be a valid JSON object string.',
+			};
+		}
+	}
+
+	if (isJsonObject(value)) return { ok: true, input: value };
+	if (value === null || value === undefined) return { ok: true, input: {} };
+
+	return {
+		ok: false,
+		input: {},
+		error: `Tool input must be a JSON object, got ${describeValue(value)}.`,
+	};
+}
+
+function toToolInputObject(value: JSONValue): JSONObject {
+	return normalizeToolInputForModel(value).input;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isJsonObject(value: unknown): value is JSONObject {
+	return isRecord(value);
 }
 
 function getRecord(value: unknown): Record<string, unknown> | undefined {

--- a/packages/@n8n/instance-ai/src/tools/nodes/__tests__/node-search-engine.test.ts
+++ b/packages/@n8n/instance-ai/src/tools/nodes/__tests__/node-search-engine.test.ts
@@ -59,6 +59,15 @@ const agentNode = makeNode({
 	},
 });
 
+const openAiNode = makeNode({
+	name: '@n8n/n8n-nodes-langchain.openAi',
+	displayName: 'OpenAI',
+	description: 'OpenAI node for chat, assistants, and legacy operations',
+	builderHint: {
+		searchHint: 'For text generation, reasoning and tools, use AI Agent with OpenAI Chat Model',
+	},
+});
+
 const openAiLmNode = makeNode({
 	name: '@n8n/n8n-nodes-langchain.lmChatOpenAi',
 	displayName: 'OpenAI Chat Model',
@@ -126,6 +135,7 @@ const allNodes = [
 	setNode,
 	slackNode,
 	agentNode,
+	openAiNode,
 	openAiLmNode,
 	memoryNode,
 	embeddingNode,
@@ -192,6 +202,18 @@ describe('NodeSearchEngine', () => {
 			const agentResult = results.find((r) => r.name === '@n8n/n8n-nodes-langchain.agent');
 			expect(agentResult).toBeDefined();
 			expect(agentResult?.builderHintMessage).toBe('Use an AI Agent for autonomous task execution');
+		});
+
+		it('should include builder search hint when present', () => {
+			const results = engine.searchByName('OpenAI');
+			const openAiResult = results.find((r) => r.name === '@n8n/n8n-nodes-langchain.openAi');
+			expect(openAiResult).toBeDefined();
+			expect(openAiResult?.builderHintMessage).toBe(
+				'For text generation, reasoning and tools, use AI Agent with OpenAI Chat Model',
+			);
+			expect(engine.formatResult(openAiResult!)).toContain(
+				'<builder_hint>For text generation, reasoning and tools, use AI Agent with OpenAI Chat Model</builder_hint>',
+			);
 		});
 
 		it('should NOT surface builderHint.extraTypeDefContent in search results', () => {

--- a/packages/@n8n/instance-ai/src/tools/nodes/node-search-engine.ts
+++ b/packages/@n8n/instance-ai/src/tools/nodes/node-search-engine.ts
@@ -81,6 +81,23 @@ function getBuilderHintMessage(
 	return builderHint?.message ?? builderHint?.searchHint;
 }
 
+function toNodeSearchResult(node: SearchableNodeType, score: number): NodeSearchResult {
+	const subnodeRequirements = extractSubnodeRequirements(node.builderHint?.inputs);
+	const builderHintMessage = getBuilderHintMessage(node.builderHint);
+
+	return {
+		name: node.name,
+		displayName: node.displayName,
+		description: node.description ?? 'No description available',
+		version: getLatestVersion(node.version),
+		inputs: node.inputs,
+		outputs: node.outputs,
+		score,
+		...(builderHintMessage && { builderHintMessage }),
+		...(subnodeRequirements.length > 0 && { subnodeRequirements }),
+	};
+}
+
 function dedupeNodes(nodes: SearchableNodeType[]): SearchableNodeType[] {
 	const dedupeCache: Record<string, SearchableNodeType> = {};
 	nodes.forEach((node) => {
@@ -262,21 +279,7 @@ export class NodeSearchEngine {
 
 		const results = this.fuzzySearchNodes(query, this.nodeTypes, limit)
 			.slice(0, limit)
-			.map(({ item, score }): NodeSearchResult => {
-				const subnodeRequirements = extractSubnodeRequirements(item.builderHint?.inputs);
-				const builderHintMessage = getBuilderHintMessage(item.builderHint);
-				return {
-					name: item.name,
-					displayName: item.displayName,
-					description: item.description ?? 'No description available',
-					version: getLatestVersion(item.version),
-					inputs: item.inputs,
-					outputs: item.outputs,
-					score,
-					...(builderHintMessage && { builderHintMessage }),
-					...(subnodeRequirements.length > 0 && { subnodeRequirements }),
-				};
-			});
+			.map(({ item, score }) => toNodeSearchResult(item, score));
 		this.nameSearchCache.set(cacheKey, results);
 		return cloneSearchResults(results);
 	}
@@ -313,21 +316,7 @@ export class NodeSearchEngine {
 			const results = nodesWithConnectionType
 				.sort((a, b) => b.connectionScore - a.connectionScore)
 				.slice(0, limit)
-				.map(({ nodeType, connectionScore }) => {
-					const subnodeRequirements = extractSubnodeRequirements(nodeType.builderHint?.inputs);
-					const builderHintMessage = getBuilderHintMessage(nodeType.builderHint);
-					return {
-						name: nodeType.name,
-						displayName: nodeType.displayName,
-						version: getLatestVersion(nodeType.version),
-						description: nodeType.description ?? 'No description available',
-						inputs: nodeType.inputs,
-						outputs: nodeType.outputs,
-						score: connectionScore,
-						...(builderHintMessage && { builderHintMessage }),
-						...(subnodeRequirements.length > 0 && { subnodeRequirements }),
-					};
-				});
+				.map(({ nodeType, connectionScore }) => toNodeSearchResult(nodeType, connectionScore));
 			this.connectionSearchCache.set(cacheKey, results);
 			return cloneSearchResults(results);
 		}
@@ -342,20 +331,7 @@ export class NodeSearchEngine {
 				(result) => result.nodeType.name === item.name,
 			);
 			const connectionScore = connectionResult?.connectionScore ?? 0;
-			const subnodeRequirements = extractSubnodeRequirements(item.builderHint?.inputs);
-			const builderHintMessage = getBuilderHintMessage(item.builderHint);
-
-			return {
-				name: item.name,
-				version: getLatestVersion(item.version),
-				displayName: item.displayName,
-				description: item.description ?? 'No description available',
-				inputs: item.inputs,
-				outputs: item.outputs,
-				score: connectionScore + nameScore,
-				...(builderHintMessage && { builderHintMessage }),
-				...(subnodeRequirements.length > 0 && { subnodeRequirements }),
-			};
+			return toNodeSearchResult(item, connectionScore + nameScore);
 		});
 		this.connectionSearchCache.set(cacheKey, results);
 		return cloneSearchResults(results);

--- a/packages/@n8n/instance-ai/src/tools/nodes/node-search-engine.ts
+++ b/packages/@n8n/instance-ai/src/tools/nodes/node-search-engine.ts
@@ -75,6 +75,12 @@ function extractSubnodeRequirements(inputs?: BuilderHintInputs): SubnodeRequirem
 		}));
 }
 
+function getBuilderHintMessage(
+	builderHint?: SearchableNodeType['builderHint'],
+): string | undefined {
+	return builderHint?.message ?? builderHint?.searchHint;
+}
+
 function dedupeNodes(nodes: SearchableNodeType[]): SearchableNodeType[] {
 	const dedupeCache: Record<string, SearchableNodeType> = {};
 	nodes.forEach((node) => {
@@ -258,6 +264,7 @@ export class NodeSearchEngine {
 			.slice(0, limit)
 			.map(({ item, score }): NodeSearchResult => {
 				const subnodeRequirements = extractSubnodeRequirements(item.builderHint?.inputs);
+				const builderHintMessage = getBuilderHintMessage(item.builderHint);
 				return {
 					name: item.name,
 					displayName: item.displayName,
@@ -266,7 +273,7 @@ export class NodeSearchEngine {
 					inputs: item.inputs,
 					outputs: item.outputs,
 					score,
-					...(item.builderHint?.message && { builderHintMessage: item.builderHint.message }),
+					...(builderHintMessage && { builderHintMessage }),
 					...(subnodeRequirements.length > 0 && { subnodeRequirements }),
 				};
 			});
@@ -308,6 +315,7 @@ export class NodeSearchEngine {
 				.slice(0, limit)
 				.map(({ nodeType, connectionScore }) => {
 					const subnodeRequirements = extractSubnodeRequirements(nodeType.builderHint?.inputs);
+					const builderHintMessage = getBuilderHintMessage(nodeType.builderHint);
 					return {
 						name: nodeType.name,
 						displayName: nodeType.displayName,
@@ -316,9 +324,7 @@ export class NodeSearchEngine {
 						inputs: nodeType.inputs,
 						outputs: nodeType.outputs,
 						score: connectionScore,
-						...(nodeType.builderHint?.message && {
-							builderHintMessage: nodeType.builderHint.message,
-						}),
+						...(builderHintMessage && { builderHintMessage }),
 						...(subnodeRequirements.length > 0 && { subnodeRequirements }),
 					};
 				});
@@ -337,6 +343,7 @@ export class NodeSearchEngine {
 			);
 			const connectionScore = connectionResult?.connectionScore ?? 0;
 			const subnodeRequirements = extractSubnodeRequirements(item.builderHint?.inputs);
+			const builderHintMessage = getBuilderHintMessage(item.builderHint);
 
 			return {
 				name: item.name,
@@ -346,7 +353,7 @@ export class NodeSearchEngine {
 				inputs: item.inputs,
 				outputs: item.outputs,
 				score: connectionScore + nameScore,
-				...(item.builderHint?.message && { builderHintMessage: item.builderHint.message }),
+				...(builderHintMessage && { builderHintMessage }),
 				...(subnodeRequirements.length > 0 && { subnodeRequirements }),
 			};
 		});

--- a/packages/@n8n/instance-ai/src/tools/nodes/node-search-engine.types.ts
+++ b/packages/@n8n/instance-ai/src/tools/nodes/node-search-engine.types.ts
@@ -66,6 +66,7 @@ export interface SearchableNodeType {
 	};
 	builderHint?: {
 		message?: string;
+		searchHint?: string;
 		inputs?: BuilderHintInputs;
 		/**
 		 * Multi-line content variations emitted into generated `.d.ts` only;
@@ -104,7 +105,7 @@ export interface NodeSearchResult {
 	score: number;
 	inputs: string[] | string;
 	outputs: string[] | string;
-	/** General hint message for workflow builders (from builderHint.message). */
+	/** General hint message for workflow builders (from builderHint.message/searchHint). */
 	builderHintMessage?: string;
 	/** Subnode requirements extracted from builderHint.inputs. */
 	subnodeRequirements?: SubnodeRequirement[];


### PR DESCRIPTION
## Summary

Handles malformed agent tool-call input without crashing the next model request.

- Parses valid stringified JSON object tool inputs before schema validation and replay.
- Turns malformed JSON strings and stringified non-object inputs into model-visible tool errors so the agent can retry.
- Replays rejected malformed tool calls with an empty object input instead of malformed assistant tool-use content.
- Surfaces `builderHint.searchHint` in Instance AI node search results, including the OpenAI node guidance.

## How to test

Targeted checks run:

```bash
cd packages/@n8n/agents && pnpm test src/runtime/__tests__/agent-runtime.test.ts
cd packages/@n8n/instance-ai && pnpm test src/tools/nodes/__tests__/node-search-engine.test.ts
cd packages/@n8n/agents && pnpm exec eslint src/runtime/messages.ts src/runtime/agent-runtime.ts src/runtime/__tests__/agent-runtime.test.ts --quiet
cd packages/@n8n/instance-ai && pnpm exec eslint src/tools/nodes/node-search-engine.ts src/tools/nodes/node-search-engine.types.ts src/tools/nodes/__tests__/node-search-engine.test.ts --quiet
```

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-446

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32276">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->