### PR TITLE
fix(Hunter Node): Handle multiOptions string coercion in domain search filters

### DIFF
--- a/packages/nodes-base/nodes/Hunter/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Hunter/GenericFunctions.ts
@@ -9,6 +9,28 @@ import type {
 } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
 
+// A multiOptions parameter normally resolves to an array. When its value comes
+// from an expression that is wrapped in surrounding text/whitespace, n8n
+// switches to string interpolation and the array is coerced to a comma-joined
+// string. Accept both shapes so the node degrades gracefully instead of
+// throwing a low-level "join is not a function" TypeError.
+export function toMultiOptionsCsv(value: unknown): string {
+	if (Array.isArray(value)) {
+		return value
+			.map((entry) => String(entry).trim())
+			.filter((entry) => entry.length > 0)
+			.join(',');
+	}
+	if (typeof value === 'string') {
+		return value
+			.split(',')
+			.map((entry) => entry.trim())
+			.filter((entry) => entry.length > 0)
+			.join(',');
+	}
+	return '';
+}
+
 export async function hunterApiRequest(
 	this: IHookFunctions | IExecuteFunctions | ILoadOptionsFunctions,
 	method: IHttpRequestMethods,

--- a/packages/nodes-base/nodes/Hunter/Hunter.node.ts
+++ b/packages/nodes-base/nodes/Hunter/Hunter.node.ts
@@ -7,7 +7,7 @@ import type {
 } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 
-import { hunterApiRequest, hunterApiRequestAllItems } from './GenericFunctions';
+import { hunterApiRequest, hunterApiRequestAllItems, toMultiOptionsCsv } from './GenericFunctions';
 
 export class Hunter implements INodeType {
 	description: INodeTypeDescription = {
@@ -295,10 +295,10 @@ export class Hunter implements INodeType {
 						qs.type = filters.type;
 					}
 					if (filters.seniority) {
-						qs.seniority = (filters.seniority as string[]).join(',');
+						qs.seniority = toMultiOptionsCsv(filters.seniority);
 					}
 					if (filters.department) {
-						qs.department = (filters.department as string[]).join(',');
+						qs.department = toMultiOptionsCsv(filters.department);
 					}
 					if (returnAll) {
 						responseData = await hunterApiRequestAllItems.call(

--- a/packages/nodes-base/nodes/Hunter/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Hunter/test/GenericFunctions.test.ts
@@ -1,0 +1,46 @@
+import { toMultiOptionsCsv } from '../GenericFunctions';
+
+describe('Hunter > GenericFunctions', () => {
+	describe('toMultiOptionsCsv', () => {
+		it('joins array values', () => {
+			expect(toMultiOptionsCsv(['junior', 'senior'])).toBe('junior,senior');
+		});
+
+		it('trims entries inside an array (interpolated array elements)', () => {
+			expect(toMultiOptionsCsv(['junior ', ' senior'])).toBe('junior,senior');
+		});
+
+		it('coerces non-string array entries via String()', () => {
+			expect(toMultiOptionsCsv([1, 2, 3])).toBe('1,2,3');
+		});
+
+		it('accepts a comma-joined string (the whitespace-expression coercion case)', () => {
+			expect(toMultiOptionsCsv('junior,senior')).toBe('junior,senior');
+		});
+
+		it('trims whitespace around each entry in a comma-string', () => {
+			expect(toMultiOptionsCsv(' junior , senior ')).toBe('junior,senior');
+		});
+
+		it('drops empty entries from an array', () => {
+			expect(toMultiOptionsCsv(['junior', '', '  ', 'senior'])).toBe('junior,senior');
+		});
+
+		it('drops empty entries from a string', () => {
+			expect(toMultiOptionsCsv('junior,,senior')).toBe('junior,senior');
+		});
+
+		it('returns an empty string for an empty array', () => {
+			expect(toMultiOptionsCsv([])).toBe('');
+		});
+
+		it('returns an empty string for an empty string', () => {
+			expect(toMultiOptionsCsv('')).toBe('');
+		});
+
+		it('returns an empty string for non-string non-array values', () => {
+			expect(toMultiOptionsCsv(undefined)).toBe('');
+			expect(toMultiOptionsCsv(null)).toBe('');
+		});
+	});
+});


### PR DESCRIPTION
## Summary

The **Seniority** and **Department** filters of the Hunter node's *Domain Search* operation are `multiOptions` parameters, so they normally resolve to arrays. The node consumed them directly with `.join(',')`:

```ts
qs.seniority = (filters.seniority as string[]).join(',');
qs.department = (filters.department as string[]).join(',');
```

When those values come from an expression that is wrapped in surrounding text or whitespace, n8n switches to string interpolation and coerces the array to a comma-joined string. `.join` then does not exist on the value, and the node throws a low-level:

```
TypeError: (filters.seniority as string[]).join is not a function
```

instead of running the search.

This PR adds a small `toMultiOptionsCsv(value: unknown)` helper to the Hunter `GenericFunctions` that accepts **both** shapes — an array or a comma-separated string — trims each entry, drops empties, and returns a normalized CSV string. Both call sites use it so the node degrades gracefully.

This is the same `multiOptions`-coercion class recently fixed for the Slack node (#31269), the Zulip node (#31492), and the TheHiveProject node (#31580).

### How to test

1. Add a **Hunter → Domain Search** node.
2. Set **Seniority** or **Department** to an expression wrapped with trailing whitespace, e.g. `{{ $json.seniority }} ` where `$json.seniority` is `["junior", "senior"]`.
3. Execute the node.
   - **Before:** `TypeError: ...join is not a function`.
   - **After:** values are normalized to `junior,senior` and the request proceeds.

Unit tests cover array input, comma-string input, per-entry trimming, non-string coercion, empty-entry dropping, and empty/undefined/null values.

## Related Linear tickets, Github issues, and Community forum posts

Related class of bug: #31269 (Slack node), #31492 (Zulip node), and #31580 (TheHiveProject node) `multiOptions` normalization.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.