### PR TITLE
feat(Microsoft OneDrive Node): Support the generic Microsoft OAuth2 credential

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/OneDrive/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/GenericFunctions.ts
@@ -10,6 +10,8 @@ import type {
 } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
 
+export type OneDriveCredentialType = 'microsoftOneDriveOAuth2Api' | 'microsoftOAuth2Api';
+
 /**
  * Resolves which credential type the node is configured to use. Defaults to the
  * node-specific `microsoftOneDriveOAuth2Api` so existing workflows (and nodes
@@ -18,8 +20,13 @@ import { NodeApiError } from 'n8n-workflow';
  */
 export function getOneDriveCredentialType(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions,
-): string {
-	return (this.getNodeParameter('authentication', 0) as string) || 'microsoftOneDriveOAuth2Api';
+): OneDriveCredentialType {
+	// `0` is the item index in execute context but the fallback value in poll/
+	// load-options context. The `|| default` guard yields the same result in all
+	// three regardless of which slot `0` lands in, so we don't pass it as an
+	// explicit fallback argument (which would be the `options` arg for poll).
+	const selected = this.getNodeParameter('authentication', 0) as OneDriveCredentialType;
+	return selected || 'microsoftOneDriveOAuth2Api';
 }
 
 export async function microsoftApiRequest(

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/GenericFunctions.ts
@@ -10,6 +10,18 @@ import type {
 } from 'n8n-workflow';
 import { NodeApiError } from 'n8n-workflow';
 
+/**
+ * Resolves which credential type the node is configured to use. Defaults to the
+ * node-specific `microsoftOneDriveOAuth2Api` so existing workflows (and nodes
+ * without the `authentication` selector) keep working unchanged, while allowing
+ * the generic `microsoftOAuth2Api` (Graph) credential to be selected.
+ */
+export function getOneDriveCredentialType(
+	this: IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions,
+): string {
+	return (this.getNodeParameter('authentication', 0) as string) || 'microsoftOneDriveOAuth2Api';
+}
+
 export async function microsoftApiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions,
 	method: IHttpRequestMethods,
@@ -21,7 +33,8 @@ export async function microsoftApiRequest(
 	headers: IDataObject = {},
 	option: IDataObject = { json: true },
 ): Promise<any> {
-	const credentials = await this.getCredentials('microsoftOneDriveOAuth2Api');
+	const credentialType = getOneDriveCredentialType.call(this);
+	const credentials = await this.getCredentials(credentialType);
 	const baseUrl = (
 		typeof credentials.graphApiBaseUrl === 'string' && credentials.graphApiBaseUrl !== ''
 			? credentials.graphApiBaseUrl
@@ -47,7 +60,7 @@ export async function microsoftApiRequest(
 		if (Object.keys(body as IDataObject).length === 0) {
 			delete options.body;
 		}
-		return await this.helpers.requestOAuth2.call(this, 'microsoftOneDriveOAuth2Api', options);
+		return await this.helpers.requestOAuth2.call(this, credentialType, options);
 	} catch (error) {
 		throw new NodeApiError(this.getNode(), error as JsonObject);
 	}
@@ -151,7 +164,7 @@ export async function getPath(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions,
 	itemId: string,
 ): Promise<string> {
-	const credentials = await this.getCredentials('microsoftOneDriveOAuth2Api');
+	const credentials = await this.getCredentials(getOneDriveCredentialType.call(this));
 	const baseUrl = (
 		typeof credentials.graphApiBaseUrl === 'string' && credentials.graphApiBaseUrl !== ''
 			? credentials.graphApiBaseUrl

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/GenericFunctions.ts
@@ -21,10 +21,8 @@ export type OneDriveCredentialType = 'microsoftOneDriveOAuth2Api' | 'microsoftOA
 export function getOneDriveCredentialType(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions,
 ): OneDriveCredentialType {
-	// `0` is the item index in execute context but the fallback value in poll/
-	// load-options context. The `|| default` guard yields the same result in all
-	// three regardless of which slot `0` lands in, so we don't pass it as an
-	// explicit fallback argument (which would be the `options` arg for poll).
+	// getNodeParameter's signature is different in execute vs load options/poll contexts
+	// using `|| default` so it works in all contexts
 	const selected = this.getNodeParameter('authentication', 0) as OneDriveCredentialType;
 	return selected || 'microsoftOneDriveOAuth2Api';
 }
@@ -33,7 +31,6 @@ export async function microsoftApiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IPollFunctions,
 	method: IHttpRequestMethods,
 	resource: string,
-
 	body: any = {},
 	qs: IDataObject = {},
 	uri?: string,

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDrive.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDrive.node.ts
@@ -33,9 +33,42 @@ export class MicrosoftOneDrive implements INodeType {
 			{
 				name: 'microsoftOneDriveOAuth2Api',
 				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['microsoftOneDriveOAuth2Api'],
+					},
+				},
+			},
+			{
+				name: 'microsoftOAuth2Api',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['microsoftOAuth2Api'],
+					},
+				},
 			},
 		],
 		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				noDataExpression: true,
+				options: [
+					{
+						name: 'OneDrive OAuth2',
+						value: 'microsoftOneDriveOAuth2Api',
+					},
+					{
+						name: 'Microsoft OAuth2 (Graph)',
+						value: 'microsoftOAuth2Api',
+						description:
+							'Generic Microsoft Graph credential. Enable the scopes this node needs (e.g. Files.ReadWrite.All) on the credential.',
+					},
+				],
+				default: 'microsoftOneDriveOAuth2Api',
+			},
 			{
 				displayName: 'Resource',
 				name: 'resource',

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDriveTrigger.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/MicrosoftOneDriveTrigger.node.ts
@@ -8,7 +8,12 @@ import {
 	NodeConnectionTypes,
 } from 'n8n-workflow';
 
-import { getPath, microsoftApiRequest, microsoftApiRequestAllItemsDelta } from './GenericFunctions';
+import {
+	getOneDriveCredentialType,
+	getPath,
+	microsoftApiRequest,
+	microsoftApiRequestAllItemsDelta,
+} from './GenericFunctions';
 import { triggerDescription } from './TriggerDescription';
 
 export class MicrosoftOneDriveTrigger implements INodeType {
@@ -27,12 +32,47 @@ export class MicrosoftOneDriveTrigger implements INodeType {
 			{
 				name: 'microsoftOneDriveOAuth2Api',
 				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['microsoftOneDriveOAuth2Api'],
+					},
+				},
+			},
+			{
+				name: 'microsoftOAuth2Api',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['microsoftOAuth2Api'],
+					},
+				},
 			},
 		],
 		polling: true,
 		inputs: [],
 		outputs: [NodeConnectionTypes.Main],
-		properties: [...triggerDescription],
+		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				noDataExpression: true,
+				options: [
+					{
+						name: 'OneDrive OAuth2',
+						value: 'microsoftOneDriveOAuth2Api',
+					},
+					{
+						name: 'Microsoft OAuth2 (Graph)',
+						value: 'microsoftOAuth2Api',
+						description:
+							'Generic Microsoft Graph credential. Enable the scopes this node needs (e.g. Files.ReadWrite.All) on the credential.',
+					},
+				],
+				default: 'microsoftOneDriveOAuth2Api',
+			},
+			...triggerDescription,
+		],
 	};
 
 	methods = {
@@ -43,7 +83,7 @@ export class MicrosoftOneDriveTrigger implements INodeType {
 		const workflowData = this.getWorkflowStaticData('node');
 		let responseData: IDataObject[];
 
-		const credentials = await this.getCredentials('microsoftOneDriveOAuth2Api');
+		const credentials = await this.getCredentials(getOneDriveCredentialType.call(this));
 		const baseUrl = (
 			typeof credentials.graphApiBaseUrl === 'string' && credentials.graphApiBaseUrl !== ''
 				? credentials.graphApiBaseUrl

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/test/GenericFunctions.test.ts
@@ -1,5 +1,5 @@
 import { mockDeep } from 'jest-mock-extended';
-import type { IExecuteFunctions, INode } from 'n8n-workflow';
+import type { IExecuteFunctions, INode, IWorkflowMetadata } from 'n8n-workflow';
 
 import { microsoftApiRequest, getPath } from '../GenericFunctions';
 
@@ -24,7 +24,7 @@ describe('Microsoft OneDrive GenericFunctions', () => {
 		mockExecuteFunctions.getNode.mockReturnValue(mockNode);
 		mockExecuteFunctions.getWorkflow.mockReturnValue({
 			id: 'test-workflow-id',
-		} as any);
+		} as IWorkflowMetadata);
 		jest.clearAllMocks();
 	});
 
@@ -255,6 +255,20 @@ describe('Microsoft OneDrive GenericFunctions', () => {
 				expect.anything(),
 			);
 		});
+
+		it('should fall back to microsoftOneDriveOAuth2Api when authentication is an empty string', async () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue('');
+
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/drive');
+
+			expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith(
+				'microsoftOneDriveOAuth2Api',
+			);
+			expect(mockRequestOAuth2).toHaveBeenCalledWith(
+				'microsoftOneDriveOAuth2Api',
+				expect.anything(),
+			);
+		});
 	});
 
 	describe('getPath', () => {
@@ -335,6 +349,26 @@ describe('Microsoft OneDrive GenericFunctions', () => {
 						json: true,
 					}),
 				);
+			});
+		});
+
+		describe('credential type selection', () => {
+			it('should use the generic microsoftOAuth2Api credential when selected', async () => {
+				const mockResponse = {
+					name: 'test-item',
+					folder: {},
+					parentReference: { path: '/drive/root:/folder' },
+				};
+				mockRequestOAuth2.mockResolvedValue(mockResponse);
+				mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
+				mockExecuteFunctions.getCredentials.mockResolvedValue({
+					oauthTokenData: { access_token: 'test-access-token' },
+				});
+
+				await getPath.call(mockExecuteFunctions, 'item-id-123');
+
+				expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith('microsoftOAuth2Api');
+				expect(mockRequestOAuth2).toHaveBeenCalledWith('microsoftOAuth2Api', expect.anything());
 			});
 		});
 	});

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/test/GenericFunctions.test.ts
@@ -1,7 +1,8 @@
 import { mockDeep } from 'jest-mock-extended';
-import type { IExecuteFunctions, INode, IWorkflowMetadata } from 'n8n-workflow';
+import get from 'lodash/get';
+import type { IExecuteFunctions, INode, IPollFunctions, IWorkflowMetadata } from 'n8n-workflow';
 
-import { microsoftApiRequest, getPath } from '../GenericFunctions';
+import { microsoftApiRequest, getPath, getOneDriveCredentialType } from '../GenericFunctions';
 
 describe('Microsoft OneDrive GenericFunctions', () => {
 	let mockExecuteFunctions: jest.Mocked<IExecuteFunctions>;
@@ -370,6 +371,30 @@ describe('Microsoft OneDrive GenericFunctions', () => {
 				expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith('microsoftOAuth2Api');
 				expect(mockRequestOAuth2).toHaveBeenCalledWith('microsoftOAuth2Api', expect.anything());
 			});
+		});
+	});
+
+	describe('getOneDriveCredentialType context semantics', () => {
+		const savedParameters = {}; // pre-existing node: no `authentication` persisted
+
+		it('resolves the default credential in EXECUTE context (node)', () => {
+			// signature: (name, itemIndex, fallbackValue, options) - see execute-context.ts
+			const executeCtx = {
+				getNodeParameter: (name: string, _itemIndex: number, fallbackValue?: unknown) =>
+					get(savedParameters, name, fallbackValue),
+			} as IExecuteFunctions;
+
+			expect(getOneDriveCredentialType.call(executeCtx)).toBe('microsoftOneDriveOAuth2Api');
+		});
+
+		it('resolves the default credential in POLL context (trigger)', () => {
+			// signature: (name, fallbackValue, options) - see node-execution-context.ts
+			const pollCtx = {
+				getNodeParameter: (name: string, fallbackValue?: unknown) =>
+					get(savedParameters, name, fallbackValue),
+			} as IPollFunctions;
+
+			expect(getOneDriveCredentialType.call(pollCtx)).toBe('microsoftOneDriveOAuth2Api');
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/test/GenericFunctions.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/test/GenericFunctions.test.ts
@@ -211,6 +211,52 @@ describe('Microsoft OneDrive GenericFunctions', () => {
 		});
 	});
 
+	describe('credential type selection', () => {
+		beforeEach(() => {
+			mockRequestOAuth2.mockResolvedValue({ data: 'test' });
+			mockExecuteFunctions.getCredentials.mockResolvedValue({
+				oauthTokenData: { access_token: 'test-access-token' },
+			});
+		});
+
+		it('should use the generic microsoftOAuth2Api credential when selected', async () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
+
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/drive');
+
+			expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith('microsoftOAuth2Api');
+			expect(mockRequestOAuth2).toHaveBeenCalledWith('microsoftOAuth2Api', expect.anything());
+		});
+
+		it('should use the microsoftOneDriveOAuth2Api credential when selected', async () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftOneDriveOAuth2Api');
+
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/drive');
+
+			expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith(
+				'microsoftOneDriveOAuth2Api',
+			);
+			expect(mockRequestOAuth2).toHaveBeenCalledWith(
+				'microsoftOneDriveOAuth2Api',
+				expect.anything(),
+			);
+		});
+
+		it('should fall back to microsoftOneDriveOAuth2Api when authentication is not set', async () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue(undefined);
+
+			await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/drive');
+
+			expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith(
+				'microsoftOneDriveOAuth2Api',
+			);
+			expect(mockRequestOAuth2).toHaveBeenCalledWith(
+				'microsoftOneDriveOAuth2Api',
+				expect.anything(),
+			);
+		});
+	});
+
 	describe('getPath', () => {
 		describe('graphApiBaseUrl from credentials', () => {
 			it('should use base URL from credentials', async () => {

--- a/packages/nodes-base/nodes/Microsoft/OneDrive/test/MicrosoftOneDriveTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/OneDrive/test/MicrosoftOneDriveTrigger.node.test.ts
@@ -1,0 +1,79 @@
+import { mockDeep, type DeepMockProxy } from 'jest-mock-extended';
+import type { IPollFunctions, INode } from 'n8n-workflow';
+
+import { microsoftApiRequest } from '../GenericFunctions';
+import type * as GenericFunctions from '../GenericFunctions';
+import { MicrosoftOneDriveTrigger } from '../MicrosoftOneDriveTrigger.node';
+
+jest.mock('../GenericFunctions', () => {
+	const actual = jest.requireActual<typeof GenericFunctions>('../GenericFunctions');
+	return {
+		...actual,
+		microsoftApiRequest: jest.fn(),
+		microsoftApiRequestAllItemsDelta: jest.fn(),
+		getPath: jest.fn(),
+	};
+});
+
+describe('MicrosoftOneDriveTrigger', () => {
+	let trigger: MicrosoftOneDriveTrigger;
+	let pollFunctions: DeepMockProxy<IPollFunctions>;
+	let params: Record<string, string | boolean | undefined>;
+
+	const driveItem = {
+		id: 'file-1',
+		name: 'doc.txt',
+		file: { mimeType: 'text/plain' },
+		fileSystemInfo: {},
+		parentReference: { path: '/drive/root:' },
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+		trigger = new MicrosoftOneDriveTrigger();
+		pollFunctions = mockDeep<IPollFunctions>();
+
+		jest.mocked(microsoftApiRequest).mockResolvedValue({ value: [driveItem] });
+
+		pollFunctions.getWorkflowStaticData.mockReturnValue({});
+		pollFunctions.getMode.mockReturnValue('manual');
+		pollFunctions.getNode.mockReturnValue({ name: 'OneDrive Trigger' } as INode);
+		pollFunctions.getCredentials.mockResolvedValue({
+			oauthTokenData: { access_token: 'test-access-token' },
+		});
+
+		params = {
+			authentication: 'microsoftOneDriveOAuth2Api',
+			event: 'fileCreated',
+			watch: 'anyFile',
+			watchFolder: false,
+			'options.folderChild': false,
+			simple: false,
+		};
+		pollFunctions.getNodeParameter.mockImplementation((name) => params[name]);
+	});
+
+	it('should use the microsoftOneDriveOAuth2Api credential when selected', async () => {
+		params.authentication = 'microsoftOneDriveOAuth2Api';
+
+		await trigger.poll.call(pollFunctions);
+
+		expect(pollFunctions.getCredentials).toHaveBeenCalledWith('microsoftOneDriveOAuth2Api');
+	});
+
+	it('should use the generic microsoftOAuth2Api credential when selected', async () => {
+		params.authentication = 'microsoftOAuth2Api';
+
+		await trigger.poll.call(pollFunctions);
+
+		expect(pollFunctions.getCredentials).toHaveBeenCalledWith('microsoftOAuth2Api');
+	});
+
+	it('should fall back to microsoftOneDriveOAuth2Api when authentication is not set', async () => {
+		params.authentication = undefined;
+
+		await trigger.poll.call(pollFunctions);
+
+		expect(pollFunctions.getCredentials).toHaveBeenCalledWith('microsoftOneDriveOAuth2Api');
+	});
+});


### PR DESCRIPTION
## Summary

The Microsoft OneDrive **node and trigger** now accept the generic **Microsoft OAuth2 API** (`microsoftOAuth2Api`) credential in addition to the existing node-specific `microsoftOneDriveOAuth2Api` credential. This lets users drive OneDrive with a single, reusable Microsoft Graph credential (carrying the right scopes, e.g. `Files.ReadWrite.All`) instead of a OneDrive-only credential — the first step toward sharing one Graph credential across the Microsoft 365 nodes.

An `Authentication` selector on the node/trigger chooses between the two credentials. The option values are the credential names, and a resolver (`getOneDriveCredentialType`) routes every request through the selected credential. It **defaults to `microsoftOneDriveOAuth2Api`**, so existing workflows are unaffected (no node version bump required).

Both credentials extend `oAuth2Api`, and `microsoftOAuth2Api` defines `graphApiBaseUrl` (inherited by the OneDrive credential), so `requestOAuth2` and the sovereign-cloud base URL handling work unchanged on both paths.

## How to test

1. Create a **Microsoft OAuth2 API** credential (generic), setting the **Scope** field to include `Files.ReadWrite.All` (plus `openid offline_access`).
2. Add a **Microsoft OneDrive** node, set **Authentication → Microsoft OAuth2 (Graph)**, and select the credential above.
3. Run a representative operation (e.g. `File: Upload` to a valid folder, or `File: Get`) — it should succeed.
4. Switch **Authentication → OneDrive OAuth2** with an existing `microsoftOneDriveOAuth2Api` credential and confirm it still works unchanged.
5. Repeat steps 2–4 with the **Microsoft OneDrive Trigger**.
6. `cd packages/nodes-base && pnpm test OneDrive` — all tests pass, including the credential-selection cases for `microsoftApiRequest`, `getPath`, and the trigger `poll()`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-53

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32295">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->