### PR TITLE
feat(editor): Render the workflow execution preview natively instead of in an iframe

### DIFF
--- a/packages/frontend/editor-ui/src/app/constants/limits.ts
+++ b/packages/frontend/editor-ui/src/app/constants/limits.ts
@@ -3,3 +3,9 @@ export const MAX_DISPLAY_DATA_SIZE = 1024 * 1024; // 1 MB
 export const MAX_DISPLAY_DATA_SIZE_SCHEMA_VIEW = 1024 * 1024 * 4; // 4 MB
 export const MAX_DISPLAY_DATA_SIZE_LOGS_VIEW = 1024 * 512; // 512 KB
 export const MAX_DISPLAY_ITEMS_AUTO_ALL = 250;
+/**
+ * Upper bound on the number of executions an execution-preview session keeps in
+ * memory. Each retained execution holds a per-execution run-data store; once a
+ * load would exceed this, the least-recently-used one is evicted.
+ */
+export const MAX_PREVIEW_EXECUTIONS_IN_MEMORY = 10;

--- a/packages/frontend/editor-ui/src/app/stores/executionData.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/executionData.store.ts
@@ -67,6 +67,15 @@ export function getExecutionDataStoreId(id: ExecutionDataId) {
 }
 
 /**
+ * Reports whether an execution data store currently exists for this id without
+ * instantiating one. Use this to peek before calling `useExecutionDataStore`,
+ * which would otherwise register an empty store as a side effect.
+ */
+export function hasExecutionDataStore(id: ExecutionDataId): boolean {
+	return getActivePinia()?.state.value[getExecutionDataStoreId(id)] !== undefined;
+}
+
+/**
  * Creates an execution data store keyed by execution id.
  *
  * Multiple instances live concurrently (active execution, displayed execution,

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -119,6 +119,21 @@ export function createWorkflowDocumentId(
 }
 
 /**
+ * Synthetic version token for the execution preview's workflow document.
+ * The preview hydrates the workflow snapshot embedded in an execution, which
+ * may differ from `latest` — keying by this token guarantees the preview can
+ * never collide with the editor's `{workflowId}@latest` document store.
+ */
+export const EXECUTION_PREVIEW_VERSION = 'execution-preview';
+
+/**
+ * The only sanctioned constructor for execution-preview document ids.
+ */
+export function createExecutionPreviewDocumentId(workflowId: string): WorkflowDocumentId {
+	return createWorkflowDocumentId(workflowId, EXECUTION_PREVIEW_VERSION);
+}
+
+/**
  * Gets the store ID for a workflow document store.
  */
 export function getWorkflowDocumentStoreId(id: string) {

--- a/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/workflowDocument.store.ts
@@ -119,18 +119,40 @@ export function createWorkflowDocumentId(
 }
 
 /**
- * Synthetic version token for the execution preview's workflow document.
- * The preview hydrates the workflow snapshot embedded in an execution, which
- * may differ from `latest` — keying by this token guarantees the preview can
- * never collide with the editor's `{workflowId}@latest` document store.
+ * Synthetic version-token namespace for an execution preview's workflow
+ * document. The preview hydrates the workflow snapshot embedded in an
+ * execution — the workflow *as it ran* — which can differ node-for-node
+ * between executions as the workflow evolves. Keying by this namespace both
+ * guarantees the preview can never collide with the editor's
+ * `{workflowId}@latest` document, and, combined with the snapshot's own
+ * version below, gives each executed version its own document store.
  */
 export const EXECUTION_PREVIEW_VERSION = 'execution-preview';
 
 /**
+ * Builds the version token for an execution-preview document. Includes the
+ * executed workflow's version so distinct versions get distinct stores —
+ * switching between executions of different versions then never re-hydrates
+ * (and re-shapes) a shared store. Falls back to the bare namespace for legacy
+ * executions whose snapshot carries no versionId.
+ */
+export function createExecutionPreviewDocumentVersion(workflowVersionId?: string): string {
+	return workflowVersionId
+		? `${EXECUTION_PREVIEW_VERSION}/${workflowVersionId}`
+		: EXECUTION_PREVIEW_VERSION;
+}
+
+/**
  * The only sanctioned constructor for execution-preview document ids.
  */
-export function createExecutionPreviewDocumentId(workflowId: string): WorkflowDocumentId {
-	return createWorkflowDocumentId(workflowId, EXECUTION_PREVIEW_VERSION);
+export function createExecutionPreviewDocumentId(
+	workflowId: string,
+	workflowVersionId?: string,
+): WorkflowDocumentId {
+	return createWorkflowDocumentId(
+		workflowId,
+		createExecutionPreviewDocumentVersion(workflowVersionId),
+	);
 }
 
 /**

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/ExecutionPreviewHost.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/ExecutionPreviewHost.test.ts
@@ -1,0 +1,187 @@
+import { defineComponent, h, inject, ref, shallowRef, type Ref, type ShallowRef } from 'vue';
+import { createTestingPinia } from '@pinia/testing';
+import { waitFor } from '@testing-library/vue';
+import { createComponentRenderer } from '@/__tests__/render';
+import {
+	EditorEnabledFeaturesKey,
+	WorkflowDocumentStoreKey,
+	WorkflowIdKey,
+} from '@/app/constants/injectionKeys';
+import type { WorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
+import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
+import ExecutionPreviewHost from './ExecutionPreviewHost.vue';
+
+const {
+	mockDocumentStore,
+	mockLoad,
+	mockDispose,
+	mockSetActiveNodeName,
+	mockUnsetActiveNodeName,
+	injected,
+} = vi.hoisted(() => ({
+	mockDocumentStore: {
+		documentId: 'test-workflow@execution-preview',
+		workflowId: 'test-workflow',
+		getNodeById: vi.fn(),
+	},
+	mockLoad: vi.fn(),
+	mockDispose: vi.fn(),
+	mockSetActiveNodeName: vi.fn(),
+	mockUnsetActiveNodeName: vi.fn(),
+	injected: {
+		workflowId: undefined as Ref<string> | undefined,
+		documentStore: undefined as ShallowRef<WorkflowDocumentStore | null> | undefined,
+		enabledFeatures: undefined as Ref<Record<string, unknown>> | undefined,
+	},
+}));
+
+// Reactive refs must be created after the vue import is initialized — at
+// module scope here, not inside vi.hoisted.
+const mockPreview = {
+	documentStore: shallowRef<unknown>(null),
+	execution: shallowRef<unknown>(null),
+	isLoading: ref(false),
+	loadError: ref<Error | null>(null),
+	isProductionExecutionPreview: ref(false),
+};
+
+vi.mock('@/features/execution/executions/composables/useExecutionPreviewDocument', () => ({
+	useExecutionPreviewDocument: vi.fn(() => ({
+		...mockPreview,
+		load: mockLoad,
+		dispose: mockDispose,
+	})),
+}));
+
+vi.mock('@/features/ndv/shared/ndv.store', () => ({
+	useNDVStore: vi.fn(() => ({
+		setActiveNodeName: mockSetActiveNodeName,
+		unsetActiveNodeName: mockUnsetActiveNodeName,
+	})),
+}));
+
+vi.mock('@/app/views/NodeView.vue', () => ({
+	default: defineComponent({
+		name: 'NodeViewStub',
+		setup() {
+			injected.workflowId = inject(WorkflowIdKey);
+			injected.documentStore = inject(WorkflowDocumentStoreKey);
+			injected.enabledFeatures = inject(EditorEnabledFeaturesKey);
+			return () => h('div', { 'data-test-id': 'node-view-stub' });
+		},
+	}),
+}));
+
+vi.mock('@/features/execution/logs/components/LogsPanel.vue', () => ({
+	default: defineComponent({
+		name: 'LogsPanelStub',
+		props: { isReadOnly: { type: Boolean, default: false } },
+		setup(props) {
+			return () =>
+				h('div', {
+					'data-test-id': 'logs-panel-stub',
+					'data-read-only': String(props.isReadOnly),
+				});
+		},
+	}),
+}));
+
+const renderComponent = createComponentRenderer(ExecutionPreviewHost, {
+	global: {
+		plugins: [createTestingPinia()],
+	},
+});
+
+describe('ExecutionPreviewHost', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockPreview.documentStore.value = null;
+		mockPreview.execution.value = null;
+		mockPreview.isLoading.value = false;
+		mockLoad.mockImplementation(async () => {
+			mockPreview.documentStore.value = mockDocumentStore;
+			mockPreview.execution.value = { id: 'execution-1' } as IExecutionResponse;
+		});
+	});
+
+	it('loads the execution on mount and renders the scoped subtree', async () => {
+		const { getByTestId } = renderComponent({
+			props: { workflowId: 'test-workflow', executionId: 'execution-1' },
+		});
+
+		expect(mockLoad).toHaveBeenCalledTimes(1);
+
+		await waitFor(() => expect(getByTestId('node-view-stub')).toBeInTheDocument());
+
+		// The subtree is scoped to the preview's stores via provides
+		expect(injected.workflowId?.value).toBe('test-workflow');
+		expect(injected.documentStore?.value).toBe(mockDocumentStore);
+		expect(injected.enabledFeatures?.value).toEqual({
+			readOnly: true,
+			aiAssistant: false,
+			aiBuilder: false,
+			askAi: false,
+			executionSuccessToasts: false,
+			executionErrorToasts: false,
+		});
+	});
+
+	it('renders the read-only logs panel once execution data is present', async () => {
+		const { getByTestId } = renderComponent({
+			props: { workflowId: 'test-workflow', executionId: 'execution-1' },
+		});
+
+		await waitFor(() =>
+			expect(getByTestId('logs-panel-stub')).toHaveAttribute('data-read-only', 'true'),
+		);
+	});
+
+	it('shows the loading state until the document store exists', async () => {
+		mockLoad.mockImplementation(async () => {});
+
+		const { queryByTestId } = renderComponent({
+			props: { workflowId: 'test-workflow', executionId: 'execution-1' },
+		});
+
+		await waitFor(() => expect(mockLoad).toHaveBeenCalled());
+		expect(queryByTestId('node-view-stub')).not.toBeInTheDocument();
+		expect(queryByTestId('logs-panel-stub')).not.toBeInTheDocument();
+	});
+
+	it('re-loads when the execution id changes and closes any open NDV', async () => {
+		const { rerender } = renderComponent({
+			props: { workflowId: 'test-workflow', executionId: 'execution-1' },
+		});
+
+		await waitFor(() => expect(mockLoad).toHaveBeenCalledTimes(1));
+
+		await rerender({ executionId: 'execution-2' });
+
+		await waitFor(() => expect(mockLoad).toHaveBeenCalledTimes(2));
+		expect(mockUnsetActiveNodeName).toHaveBeenCalled();
+	});
+
+	it('opens the deep-linked node in the NDV after loading', async () => {
+		mockDocumentStore.getNodeById.mockReturnValue({ name: 'Deep Linked Node' });
+
+		renderComponent({
+			props: { workflowId: 'test-workflow', executionId: 'execution-1', nodeId: 'node-123' },
+		});
+
+		await waitFor(() =>
+			expect(mockSetActiveNodeName).toHaveBeenCalledWith('Deep Linked Node', 'other'),
+		);
+		expect(mockDocumentStore.getNodeById).toHaveBeenCalledWith('node-123');
+	});
+
+	it('disposes the preview stores on unmount', async () => {
+		const { unmount } = renderComponent({
+			props: { workflowId: 'test-workflow', executionId: 'execution-1' },
+		});
+
+		await waitFor(() => expect(mockLoad).toHaveBeenCalled());
+		unmount();
+
+		expect(mockDispose).toHaveBeenCalledTimes(1);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/ExecutionPreviewHost.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/ExecutionPreviewHost.test.ts
@@ -1,4 +1,13 @@
-import { defineComponent, h, inject, ref, shallowRef, type Ref, type ShallowRef } from 'vue';
+import {
+	defineComponent,
+	h,
+	inject,
+	onBeforeUnmount,
+	ref,
+	shallowRef,
+	type Ref,
+	type ShallowRef,
+} from 'vue';
 import { createTestingPinia } from '@pinia/testing';
 import { waitFor } from '@testing-library/vue';
 import { createComponentRenderer } from '@/__tests__/render';
@@ -9,6 +18,7 @@ import {
 } from '@/app/constants/injectionKeys';
 import type { WorkflowDocumentStore } from '@/app/stores/workflowDocument.store';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
+import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
 import ExecutionPreviewHost from './ExecutionPreviewHost.vue';
 
 const {
@@ -23,6 +33,8 @@ const {
 		documentId: 'test-workflow@execution-preview',
 		workflowId: 'test-workflow',
 		getNodeById: vi.fn(),
+		connectionsBySourceNode: {},
+		setConnections: vi.fn(),
 	},
 	mockLoad: vi.fn(),
 	mockDispose: vi.fn(),
@@ -31,6 +43,7 @@ const {
 	injected: {
 		workflowId: undefined as Ref<string> | undefined,
 		documentStore: undefined as ShallowRef<WorkflowDocumentStore | null> | undefined,
+		documentStoreOnBeforeUnmount: undefined as WorkflowDocumentStore | null | undefined,
 		enabledFeatures: undefined as Ref<Record<string, unknown>> | undefined,
 	},
 }));
@@ -67,6 +80,9 @@ vi.mock('@/app/views/NodeView.vue', () => ({
 			injected.workflowId = inject(WorkflowIdKey);
 			injected.documentStore = inject(WorkflowDocumentStoreKey);
 			injected.enabledFeatures = inject(EditorEnabledFeaturesKey);
+			onBeforeUnmount(() => {
+				injected.documentStoreOnBeforeUnmount = injected.documentStore?.value;
+			});
 			return () => h('div', { 'data-test-id': 'node-view-stub' });
 		},
 	}),
@@ -98,6 +114,9 @@ describe('ExecutionPreviewHost', () => {
 		mockPreview.documentStore.value = null;
 		mockPreview.execution.value = null;
 		mockPreview.isLoading.value = false;
+		mockPreview.loadError.value = null;
+		injected.documentStoreOnBeforeUnmount = undefined;
+		mockDispose.mockImplementation(() => {});
 		mockLoad.mockImplementation(async () => {
 			mockPreview.documentStore.value = mockDocumentStore;
 			mockPreview.execution.value = { id: 'execution-1' } as IExecutionResponse;
@@ -148,6 +167,20 @@ describe('ExecutionPreviewHost', () => {
 		expect(queryByTestId('logs-panel-stub')).not.toBeInTheDocument();
 	});
 
+	it('shows an error state when loading the execution fails', async () => {
+		mockLoad.mockImplementation(async () => {
+			mockPreview.loadError.value = new Error('Not found');
+		});
+
+		const { getByTestId, queryByTestId } = renderComponent({
+			props: { workflowId: 'test-workflow', executionId: 'execution-1' },
+		});
+
+		await waitFor(() => expect(getByTestId('execution-preview-error')).toBeInTheDocument());
+		expect(queryByTestId('node-view-stub')).not.toBeInTheDocument();
+		expect(queryByTestId('logs-panel-stub')).not.toBeInTheDocument();
+	});
+
 	it('re-loads when the execution id changes and closes any open NDV', async () => {
 		const { rerender } = renderComponent({
 			props: { workflowId: 'test-workflow', executionId: 'execution-1' },
@@ -183,5 +216,74 @@ describe('ExecutionPreviewHost', () => {
 		unmount();
 
 		expect(mockDispose).toHaveBeenCalledTimes(1);
+	});
+
+	it('keeps the preview document injected until child teardown completes', async () => {
+		mockDispose.mockImplementation(() => {
+			mockPreview.documentStore.value = null;
+		});
+
+		const { getByTestId, unmount } = renderComponent({
+			props: { workflowId: 'test-workflow', executionId: 'execution-1' },
+		});
+
+		await waitFor(() => expect(getByTestId('node-view-stub')).toBeInTheDocument());
+		unmount();
+
+		expect(injected.documentStoreOnBeforeUnmount).toBe(mockDocumentStore);
+		expect(mockDispose).toHaveBeenCalledTimes(1);
+		expect(mockPreview.documentStore.value).toBeNull();
+	});
+
+	it('defers the fit until canvas re-init when switching to a different workflow version', async () => {
+		const emitSpy = vi.spyOn(canvasEventBus, 'emit');
+		const documentIds = [
+			'test-workflow@execution-preview/v1',
+			'test-workflow@execution-preview/v2',
+		];
+		let loadIndex = 0;
+		mockLoad.mockImplementation(async () => {
+			mockPreview.documentStore.value = {
+				...mockDocumentStore,
+				documentId: documentIds[Math.min(loadIndex, documentIds.length - 1)],
+			};
+			mockPreview.execution.value = { id: `execution-${loadIndex + 1}` } as IExecutionResponse;
+			loadIndex += 1;
+		});
+
+		const { rerender } = renderComponent({
+			props: { workflowId: 'test-workflow', executionId: 'execution-1' },
+		});
+		// Let the first-load fit land, then clear so we assert only on the switch.
+		await waitFor(() => expect(emitSpy).toHaveBeenCalledWith('fitView'));
+		emitSpy.mockClear();
+
+		await rerender({ executionId: 'execution-2' });
+
+		await waitFor(() => expect(emitSpy).toHaveBeenCalledWith('fitView:onNodesInit'));
+		expect(emitSpy).toHaveBeenCalledWith('setConnections:onNodesInit', expect.anything());
+		expect(emitSpy).not.toHaveBeenCalledWith('fitView');
+	});
+
+	it('fits immediately when switching between executions of the same version', async () => {
+		const emitSpy = vi.spyOn(canvasEventBus, 'emit');
+		mockLoad.mockImplementation(async () => {
+			mockPreview.documentStore.value = {
+				...mockDocumentStore,
+				documentId: 'test-workflow@execution-preview/v1',
+			};
+			mockPreview.execution.value = { id: 'execution' } as IExecutionResponse;
+		});
+
+		const { rerender } = renderComponent({
+			props: { workflowId: 'test-workflow', executionId: 'execution-1' },
+		});
+		await waitFor(() => expect(mockLoad).toHaveBeenCalledTimes(1));
+
+		emitSpy.mockClear();
+		await rerender({ executionId: 'execution-2' });
+
+		await waitFor(() => expect(emitSpy).toHaveBeenCalledWith('fitView'));
+		expect(emitSpy).not.toHaveBeenCalledWith('fitView:onNodesInit');
 	});
 });

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/ExecutionPreviewHost.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/ExecutionPreviewHost.vue
@@ -1,6 +1,8 @@
 <script lang="ts" setup>
-import { computed, nextTick, onBeforeUnmount, onMounted, provide, watch } from 'vue';
-import { N8nIcon } from '@n8n/design-system';
+import { computed, nextTick, onMounted, onUnmounted, provide, watch } from 'vue';
+import { deepCopy } from 'n8n-workflow';
+import { useI18n } from '@n8n/i18n';
+import { N8nIcon, N8nText } from '@n8n/design-system';
 import NodeView from '@/app/views/NodeView.vue';
 import LogsPanel from '@/features/execution/logs/components/LogsPanel.vue';
 import {
@@ -18,6 +20,8 @@ const props = defineProps<{
 	executionId: string;
 	nodeId?: string;
 }>();
+
+const i18n = useI18n();
 
 // These provides scope every injection-aware consumer in this subtree
 // (NodeView/canvas render data, NDV, logs) to the preview's isolated stores.
@@ -49,6 +53,7 @@ provide(
 
 const isReady = computed(() => preview.documentStore.value !== null);
 const hasExecutionData = computed(() => preview.execution.value !== null);
+const hasLoadError = computed(() => preview.loadError.value !== null && !preview.isLoading.value);
 
 function openDeepLinkedNode() {
 	const documentStore = preview.documentStore.value;
@@ -71,22 +76,39 @@ async function loadExecution() {
 
 	await preview.load();
 
-	if (!preview.documentStore.value) {
+	const documentStore = preview.documentStore.value;
+	if (!documentStore) {
 		return;
 	}
 
 	openDeepLinkedNode();
 
-	// Wait for NodeView/canvas to mount (first load) before requesting fit.
-	await nextTick();
-	canvasEventBus.emit('fitView');
+	const isVersionSwitch =
+		previousDocumentId !== undefined && previousDocumentId !== documentStore.documentId;
+
+	if (isVersionSwitch) {
+		// Switching to an execution of a different workflow version recreates the
+		// node set under the persistent canvas. VueFlow drops edges applied before
+		// the new node handles exist and won't re-fit a viewport it already
+		// initialized, so defer both the connection re-apply and the fit to its
+		// next onNodesInitialized — the same recipe useWorkflowImport uses.
+		const connections = deepCopy(documentStore.connectionsBySourceNode);
+		documentStore.setConnections({});
+		canvasEventBus.emit('setConnections:onNodesInit', connections);
+		canvasEventBus.emit('fitView:onNodesInit');
+	} else {
+		// First load (the canvas mounts and self-fits) or a same-version switch
+		// (graph unchanged and already measured): an immediate fit is correct.
+		await nextTick();
+		canvasEventBus.emit('fitView');
+	}
 }
 
 onMounted(loadExecution);
 watch(() => props.executionId, loadExecution);
 watch(() => props.nodeId, openDeepLinkedNode);
 
-onBeforeUnmount(() => {
+onUnmounted(() => {
 	preview.dispose();
 });
 </script>
@@ -102,6 +124,16 @@ onBeforeUnmount(() => {
 			</div>
 			<LogsPanel v-if="hasExecutionData" :class="$style.logs" :is-read-only="true" />
 		</template>
+		<div
+			v-else-if="hasLoadError"
+			:class="$style.centerState"
+			data-test-id="execution-preview-error"
+		>
+			<N8nIcon icon="triangle-alert" color="danger" :size="48" />
+			<N8nText color="text-dark" :bold="true">
+				{{ i18n.baseText('nodeView.showError.openExecution.title') }}
+			</N8nText>
+		</div>
 		<div v-else :class="$style.centerState">
 			<N8nIcon icon="loader-circle" :size="80" spin />
 		</div>

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/ExecutionPreviewHost.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/ExecutionPreviewHost.vue
@@ -1,0 +1,151 @@
+<script lang="ts" setup>
+import { computed, nextTick, onBeforeUnmount, onMounted, provide, watch } from 'vue';
+import { N8nIcon } from '@n8n/design-system';
+import NodeView from '@/app/views/NodeView.vue';
+import LogsPanel from '@/features/execution/logs/components/LogsPanel.vue';
+import {
+	EditorEnabledFeaturesKey,
+	WorkflowDocumentStoreKey,
+	WorkflowIdKey,
+	type EditorEnabledFeatures,
+} from '@/app/constants/injectionKeys';
+import { useExecutionPreviewDocument } from '@/features/execution/executions/composables/useExecutionPreviewDocument';
+import { useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
+
+const props = defineProps<{
+	workflowId: string;
+	executionId: string;
+	nodeId?: string;
+}>();
+
+// These provides scope every injection-aware consumer in this subtree
+// (NodeView/canvas render data, NDV, logs) to the preview's isolated stores.
+// Unlike WorkflowCanvasHost — whose body composables inject the host's own
+// provides and therefore need an outer/body split — nothing in this setup
+// injects these keys, so providing and rendering live in one component.
+provide(
+	WorkflowIdKey,
+	computed(() => props.workflowId),
+);
+
+const preview = useExecutionPreviewDocument({ executionId: () => props.executionId });
+provide(WorkflowDocumentStoreKey, preview.documentStore);
+
+// Mirrors the old iframe knobs: the preview is always read-only, AI editing
+// affordances are superseded, and execution result toasts are owned by the
+// preview itself (the loader surfaces failed-execution toasts on open).
+provide(
+	EditorEnabledFeaturesKey,
+	computed<EditorEnabledFeatures>(() => ({
+		readOnly: true,
+		aiAssistant: false,
+		aiBuilder: false,
+		askAi: false,
+		executionSuccessToasts: false,
+		executionErrorToasts: false,
+	})),
+);
+
+const isReady = computed(() => preview.documentStore.value !== null);
+const hasExecutionData = computed(() => preview.execution.value !== null);
+
+function openDeepLinkedNode() {
+	const documentStore = preview.documentStore.value;
+	if (!documentStore || !props.nodeId) {
+		return;
+	}
+	const node = documentStore.getNodeById(props.nodeId);
+	if (node) {
+		useNDVStore(documentStore.documentId).setActiveNodeName(node.name, 'other');
+	}
+}
+
+async function loadExecution() {
+	// Parity with the iframe (which was recreated per execution): close any
+	// open NDV before swapping the displayed execution.
+	const previousDocumentId = preview.documentStore.value?.documentId;
+	if (previousDocumentId) {
+		useNDVStore(previousDocumentId).unsetActiveNodeName();
+	}
+
+	await preview.load();
+
+	if (!preview.documentStore.value) {
+		return;
+	}
+
+	openDeepLinkedNode();
+
+	// Wait for NodeView/canvas to mount (first load) before requesting fit.
+	await nextTick();
+	canvasEventBus.emit('fitView');
+}
+
+onMounted(loadExecution);
+watch(() => props.executionId, loadExecution);
+watch(() => props.nodeId, openDeepLinkedNode);
+
+onBeforeUnmount(() => {
+	preview.dispose();
+});
+</script>
+
+<template>
+	<div :class="$style.host" data-test-id="execution-preview-host">
+		<template v-if="isReady">
+			<div :class="$style.canvas">
+				<NodeView />
+				<div v-if="preview.isLoading.value" :class="$style.loadingOverlay">
+					<N8nIcon icon="loader-circle" :size="48" spin />
+				</div>
+			</div>
+			<LogsPanel v-if="hasExecutionData" :class="$style.logs" :is-read-only="true" />
+		</template>
+		<div v-else :class="$style.centerState">
+			<N8nIcon icon="loader-circle" :size="80" spin />
+		</div>
+	</div>
+</template>
+
+<style lang="scss" module>
+.host {
+	position: relative;
+	width: 100%;
+	height: 100%;
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+}
+
+.canvas {
+	position: relative;
+	flex: 1;
+	min-height: 0;
+	display: flex;
+}
+
+.loadingOverlay {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background-color: var(--canvas--color--background);
+	opacity: 0.75;
+}
+
+.logs {
+	flex-shrink: 0;
+}
+
+.centerState {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: var(--spacing--xs);
+	flex: 1;
+	min-height: 0;
+}
+</style>

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/ExecutionPreviewHost.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/ExecutionPreviewHost.vue
@@ -143,6 +143,10 @@ onUnmounted(() => {
 <style lang="scss" module>
 .host {
 	position: relative;
+	// Own stacking context so the canvas (VueFlow renders panes that capture
+	// pointer events) stays below the absolutely-positioned execution actions
+	// bar overlaid on top of it by the parent.
+	z-index: 0;
 	width: 100%;
 	height: 100%;
 	display: flex;

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsPreview.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsPreview.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
 import WorkflowExecutionAnnotationPanel from './WorkflowExecutionAnnotationPanel.ee.vue';
 import WorkflowExecutionAnnotationTags from './WorkflowExecutionAnnotationTags.ee.vue';
-import WorkflowPreview from '@/app/components/WorkflowPreview.vue';
+import ExecutionPreviewHost from './ExecutionPreviewHost.vue';
 import { useExecutionDebugging } from '../../composables/useExecutionDebugging';
 import type { IExecutionUIData } from '../../composables/useExecutionHelpers';
 import { useExecutionHelpers } from '../../composables/useExecutionHelpers';
@@ -421,14 +421,7 @@ const onVoteClick = async (voteValue: AnnotationVote) => {
 			</div>
 		</div>
 
-		<WorkflowPreview
-			:key="executionId"
-			mode="execution"
-			loader-type="spinner"
-			:execution-id="executionId"
-			:execution-mode="execution?.mode || ''"
-			:node-id="nodeId"
-		/>
+		<ExecutionPreviewHost :workflow-id="workflowId" :execution-id="executionId" :node-id="nodeId" />
 	</div>
 </template>
 

--- a/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsPreview.vue
+++ b/packages/frontend/editor-ui/src/features/execution/executions/components/workflow/WorkflowExecutionsPreview.vue
@@ -434,6 +434,9 @@ const onVoteClick = async (voteValue: AnnotationVote) => {
 
 .executionDetails {
 	position: absolute;
+	// Stack above the native canvas below it; the canvas owns its own stacking
+	// context, so without this its panes would intercept clicks on these actions.
+	z-index: 1;
 	padding: var(--spacing--md);
 	width: 100%;
 	display: flex;

--- a/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionPreviewDocument.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionPreviewDocument.test.ts
@@ -7,6 +7,7 @@ import { createTestNode, createTestWorkflow } from '@/__tests__/mocks';
 import { mockedStore } from '@/__tests__/utils';
 import type { IWorkflowDb } from '@/Interface';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
+import { MAX_PREVIEW_EXECUTIONS_IN_MEMORY } from '@/app/constants';
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
 	createExecutionPreviewDocumentId,
@@ -68,6 +69,24 @@ function createExecution(overrides: Partial<IExecutionResponse> = {}): IExecutio
 		},
 		...overrides,
 	} as IExecutionResponse;
+}
+
+function executionDataStoreLives(executionId: string): boolean {
+	return (
+		getActivePinia()!.state.value[getExecutionDataStoreId(createExecutionDataId(executionId))] !==
+		undefined
+	);
+}
+
+function createDeferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (reason?: unknown) => void;
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+		resolve = resolvePromise;
+		reject = rejectPromise;
+	});
+
+	return { promise, resolve, reject };
 }
 
 describe('useExecutionPreviewDocument', () => {
@@ -185,6 +204,63 @@ describe('useExecutionPreviewDocument', () => {
 
 		expect(preview.loadError.value?.message).toBe('Not found');
 		expect(preview.documentStore.value).toBeNull();
+		expect(preview.execution.value).toBeNull();
+	});
+
+	it('does not leave an execution data store behind when the fetch fails', async () => {
+		workflowsStore.getExecution = vi.fn().mockRejectedValue(new Error('Not found'));
+
+		const preview = useExecutionPreviewDocument({ executionId: () => EXECUTION_ID });
+		await preview.load();
+
+		// The reuse peek must not instantiate a store for an id that never loaded.
+		expect(executionDataStoreLives(EXECUTION_ID)).toBe(false);
+	});
+
+	it('clears the rendered preview when the latest execution fetch fails after a successful load', async () => {
+		const executionId = ref(EXECUTION_ID);
+		workflowsStore.getExecution = vi.fn(async (id: string) => {
+			if (id === 'execution-2') {
+				throw new Error('Not found');
+			}
+			return createExecution({ id });
+		});
+
+		const preview = useExecutionPreviewDocument({ executionId });
+		await preview.load();
+		expect(preview.documentStore.value).not.toBeNull();
+		expect(preview.execution.value?.id).toBe(EXECUTION_ID);
+
+		executionId.value = 'execution-2';
+		await preview.load();
+
+		expect(preview.loadError.value?.message).toBe('Not found');
+		expect(preview.documentStore.value).toBeNull();
+		expect(preview.execution.value).toBeNull();
+	});
+
+	it('does not let an older failed request clear a newer successful preview', async () => {
+		const delayedFailure = createDeferred<IExecutionResponse>();
+		const executionId = ref('execution-late-failure');
+		workflowsStore.getExecution = vi.fn((id: string) =>
+			id === 'execution-late-failure'
+				? delayedFailure.promise
+				: Promise.resolve(createExecution({ id: 'execution-current' })),
+		);
+
+		const preview = useExecutionPreviewDocument({ executionId });
+		const lateFailureLoad = preview.load();
+
+		executionId.value = 'execution-current';
+		await preview.load();
+		expect(preview.execution.value?.id).toBe('execution-current');
+
+		delayedFailure.reject(new Error('Late failure'));
+		await lateFailureLoad;
+
+		expect(preview.loadError.value).toBeNull();
+		expect(preview.documentStore.value).not.toBeNull();
+		expect(preview.execution.value?.id).toBe('execution-current');
 	});
 
 	it('disposes all preview stores on dispose()', async () => {
@@ -224,6 +300,30 @@ describe('useExecutionPreviewDocument', () => {
 		const editorExecutionData = useExecutionDataStore(createExecutionDataId(EXECUTION_ID));
 		expect(editorExecutionData.execution?.id).toBe(EXECUTION_ID);
 		expect(editorStateStore.activeExecution?.id).toBe(EXECUTION_ID);
+	});
+
+	it('releases retained execution data stores on dispose() even when the latest load failed', async () => {
+		const executionId = ref(EXECUTION_ID);
+		workflowsStore.getExecution = vi.fn(async (id: string) => {
+			if (id === 'execution-2') {
+				throw new Error('Not found');
+			}
+			return createExecution({ id });
+		});
+
+		const preview = useExecutionPreviewDocument({ executionId });
+		await preview.load();
+		expect(executionDataStoreLives(EXECUTION_ID)).toBe(true);
+
+		// The latest load fails and nulls documentStore; dispose() must still
+		// resolve the workflow id (from the tracked id, not documentStore) and
+		// release the previously-loaded execution's data store.
+		executionId.value = 'execution-2';
+		await preview.load();
+		expect(preview.documentStore.value).toBeNull();
+
+		preview.dispose();
+		expect(executionDataStoreLives(EXECUTION_ID)).toBe(false);
 	});
 
 	it('leaves no preview pinia state behind after repeated load/dispose cycles', async () => {
@@ -292,5 +392,94 @@ describe('useExecutionPreviewDocument', () => {
 		preview.dispose();
 		expect(pinia.state.value[getWorkflowDocumentStoreId(idV1)]).toBeUndefined();
 		expect(pinia.state.value[getWorkflowDocumentStoreId(idV2)]).toBeUndefined();
+	});
+
+	describe('in-memory execution cap', () => {
+		it('evicts the least-recently-used execution once the in-memory cap is exceeded', async () => {
+			workflowsStore.getExecution = vi.fn(async (id: string) => createExecution({ id }));
+
+			const executionId = ref('exec-0');
+			const preview = useExecutionPreviewDocument({ executionId });
+
+			// Load one more than the cap (exec-0 … exec-10).
+			for (let index = 0; index <= MAX_PREVIEW_EXECUTIONS_IN_MEMORY; index++) {
+				executionId.value = `exec-${index}`;
+				await preview.load();
+			}
+
+			// The oldest (exec-0) is evicted; the newest and the second-oldest survive.
+			expect(executionDataStoreLives('exec-0')).toBe(false);
+			expect(executionDataStoreLives('exec-1')).toBe(true);
+			expect(executionDataStoreLives(`exec-${MAX_PREVIEW_EXECUTIONS_IN_MEMORY}`)).toBe(true);
+		});
+
+		it('never evicts an execution the editor still references, even when it is the oldest', async () => {
+			workflowsStore.getExecution = vi.fn(async (id: string) => createExecution({ id }));
+
+			// The editor displays exec-0 (e.g. the user ran it, then opened the
+			// executions tab). Disposing its data store would blank the editor.
+			const editorStateStore = useWorkflowExecutionStateStore(
+				createWorkflowDocumentId(WORKFLOW_ID),
+			);
+			editorStateStore.setWorkflowExecutionData(createExecution({ id: 'exec-0', mode: 'manual' }));
+
+			const executionId = ref('exec-0');
+			const preview = useExecutionPreviewDocument({ executionId });
+			for (let index = 0; index <= MAX_PREVIEW_EXECUTIONS_IN_MEMORY; index++) {
+				executionId.value = `exec-${index}`;
+				await preview.load();
+			}
+
+			// exec-0 is protected, so exec-1 is evicted as the oldest evictable.
+			expect(executionDataStoreLives('exec-0')).toBe(true);
+			expect(executionDataStoreLives('exec-1')).toBe(false);
+		});
+
+		it('protects a re-selected execution from being the next eviction victim', async () => {
+			const getExecution = vi.fn(async (id: string) => createExecution({ id }));
+			workflowsStore.getExecution = getExecution;
+
+			const executionId = ref('exec-0');
+			const preview = useExecutionPreviewDocument({ executionId });
+
+			// Fill exactly to the cap (exec-0 … exec-9): no eviction yet.
+			for (let index = 0; index < MAX_PREVIEW_EXECUTIONS_IN_MEMORY; index++) {
+				executionId.value = `exec-${index}`;
+				await preview.load();
+			}
+			const fetchesAfterFill = getExecution.mock.calls.length;
+
+			// Re-select the oldest: reused from memory (no refetch) and now MRU.
+			executionId.value = 'exec-0';
+			await preview.load();
+			expect(getExecution.mock.calls.length).toBe(fetchesAfterFill);
+
+			// The next load evicts exec-1 (now the oldest), not the re-selected exec-0.
+			executionId.value = 'exec-10';
+			await preview.load();
+
+			expect(executionDataStoreLives('exec-0')).toBe(true);
+			expect(executionDataStoreLives('exec-1')).toBe(false);
+		});
+
+		it('refetches an execution that was evicted and then re-selected', async () => {
+			const getExecution = vi.fn(async (id: string) => createExecution({ id }));
+			workflowsStore.getExecution = getExecution;
+
+			const executionId = ref('exec-0');
+			const preview = useExecutionPreviewDocument({ executionId });
+			for (let index = 0; index <= MAX_PREVIEW_EXECUTIONS_IN_MEMORY; index++) {
+				executionId.value = `exec-${index}`;
+				await preview.load();
+			}
+			expect(executionDataStoreLives('exec-0')).toBe(false);
+			const fetchesBefore = getExecution.mock.calls.length;
+
+			// exec-0's data store was disposed, so re-selecting it refetches.
+			executionId.value = 'exec-0';
+			await preview.load();
+			expect(getExecution).toHaveBeenCalledWith('exec-0');
+			expect(getExecution.mock.calls.length).toBe(fetchesBefore + 1);
+		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionPreviewDocument.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionPreviewDocument.test.ts
@@ -1,0 +1,248 @@
+import { setActivePinia, getActivePinia } from 'pinia';
+import { createTestingPinia } from '@pinia/testing';
+import { mock } from 'vitest-mock-extended';
+import { STORES } from '@n8n/stores';
+import { createTestNode, createTestWorkflow } from '@/__tests__/mocks';
+import { mockedStore } from '@/__tests__/utils';
+import type { IWorkflowDb } from '@/Interface';
+import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	createExecutionPreviewDocumentId,
+	createWorkflowDocumentId,
+	getWorkflowDocumentStoreId,
+	useWorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
+import {
+	getWorkflowExecutionStateStoreId,
+	useWorkflowExecutionStateStore,
+} from '@/app/stores/workflowExecutionState.store';
+import {
+	createExecutionDataId,
+	getExecutionDataStoreId,
+	useExecutionDataStore,
+} from '@/app/stores/executionData.store';
+import { useExecutionPreviewDocument } from './useExecutionPreviewDocument';
+
+vi.mock('@/app/composables/useToast', () => {
+	const showMessage = vi.fn();
+	const showError = vi.fn();
+	return {
+		useToast: () => ({ showMessage, showError }),
+	};
+});
+
+vi.mock('@/app/composables/useTelemetry', () => ({
+	useTelemetry: () => ({ track: vi.fn() }),
+}));
+
+vi.mock('@/app/composables/useExternalHooks', () => ({
+	useExternalHooks: () => ({ run: vi.fn() }),
+}));
+
+const WORKFLOW_ID = 'test-workflow';
+const EXECUTION_ID = 'execution-1';
+
+function createExecution(overrides: Partial<IExecutionResponse> = {}): IExecutionResponse {
+	return {
+		id: EXECUTION_ID,
+		workflowData: createTestWorkflow({
+			id: WORKFLOW_ID,
+			name: 'Executed Workflow',
+			nodes: [createTestNode({ name: 'Node A' })],
+			connections: {},
+			pinData: { 'Node A': [{ json: { pinned: true } }] },
+		}),
+		finished: true,
+		mode: 'production',
+		status: 'success',
+		startedAt: new Date(),
+		createdAt: new Date(),
+		data: {
+			resultData: {
+				runData: {
+					'Node A': [],
+				},
+			},
+		},
+		...overrides,
+	} as IExecutionResponse;
+}
+
+describe('useExecutionPreviewDocument', () => {
+	let workflowsStore: ReturnType<typeof mockedStore<typeof useWorkflowsStore>>;
+
+	beforeEach(() => {
+		setActivePinia(
+			createTestingPinia({
+				stubActions: false,
+				initialState: {
+					[STORES.NODE_TYPES]: {},
+					[STORES.WORKFLOWS]: {
+						workflowId: WORKFLOW_ID,
+						workflow: mock<IWorkflowDb>({
+							id: WORKFLOW_ID,
+							nodes: [],
+							connections: {},
+							tags: [],
+							usedCredentials: [],
+						}),
+					},
+					[STORES.SETTINGS]: {
+						settings: { enterprise: {} },
+					},
+				},
+			}),
+		);
+		workflowsStore = mockedStore(useWorkflowsStore);
+		workflowsStore.getExecution = vi.fn().mockResolvedValue(createExecution());
+	});
+
+	it('hydrates the synthetic execution-preview document, never the editor document', async () => {
+		const editorDocumentStore = useWorkflowDocumentStore(createWorkflowDocumentId(WORKFLOW_ID));
+		editorDocumentStore.setNodes([createTestNode({ name: 'Editor Node' })]);
+		editorDocumentStore.setName('Editor Workflow');
+
+		const preview = useExecutionPreviewDocument({ executionId: () => EXECUTION_ID });
+		await preview.load();
+
+		expect(preview.documentStore.value?.documentId).toBe(
+			createExecutionPreviewDocumentId(WORKFLOW_ID),
+		);
+		expect(preview.documentStore.value?.allNodes.map((node) => node.name)).toEqual(['Node A']);
+		expect(preview.execution.value?.id).toBe(EXECUTION_ID);
+
+		// The editor's document store is untouched
+		expect(editorDocumentStore.allNodes.map((node) => node.name)).toEqual(['Editor Node']);
+		expect(editorDocumentStore.name).toBe('Editor Workflow');
+		expect(workflowsStore.workflowId).toBe(WORKFLOW_ID);
+	});
+
+	it('does not touch the editor execution-state store when loading', async () => {
+		const editorStateStore = useWorkflowExecutionStateStore(createWorkflowDocumentId(WORKFLOW_ID));
+		const editorExecution = createExecution({ id: 'editor-execution', mode: 'manual' });
+		editorStateStore.setWorkflowExecutionData(editorExecution);
+
+		const preview = useExecutionPreviewDocument({ executionId: () => EXECUTION_ID });
+		await preview.load();
+
+		expect(editorStateStore.displayedExecutionId).toBe('editor-execution');
+		expect(editorStateStore.activeExecution?.id).toBe('editor-execution');
+
+		const previewStateStore = useWorkflowExecutionStateStore(
+			createExecutionPreviewDocumentId(WORKFLOW_ID),
+		);
+		expect(previewStateStore.displayedExecutionId).toBe(EXECUTION_ID);
+	});
+
+	it('clears pin data on the preview document for production executions', async () => {
+		const preview = useExecutionPreviewDocument({ executionId: () => EXECUTION_ID });
+		await preview.load();
+
+		expect(preview.isProductionExecutionPreview.value).toBe(true);
+		expect(preview.documentStore.value?.getPinDataSnapshot()).toEqual({});
+	});
+
+	it('keeps pin data on the preview document for manual executions', async () => {
+		workflowsStore.getExecution = vi.fn().mockResolvedValue(createExecution({ mode: 'manual' }));
+
+		const preview = useExecutionPreviewDocument({ executionId: () => EXECUTION_ID });
+		await preview.load();
+
+		expect(preview.isProductionExecutionPreview.value).toBe(false);
+		expect(preview.documentStore.value?.getPinDataSnapshot()).toEqual({
+			'Node A': [{ json: { pinned: true } }],
+		});
+	});
+
+	it('reuses already-loaded terminal executions without re-fetching', async () => {
+		const preview = useExecutionPreviewDocument({ executionId: () => EXECUTION_ID });
+		await preview.load();
+		expect(workflowsStore.getExecution).toHaveBeenCalledTimes(1);
+
+		await preview.load();
+		expect(workflowsStore.getExecution).toHaveBeenCalledTimes(1);
+	});
+
+	it('re-fetches non-terminal executions', async () => {
+		workflowsStore.getExecution = vi
+			.fn()
+			.mockResolvedValue(createExecution({ status: 'waiting', finished: false }));
+
+		const preview = useExecutionPreviewDocument({ executionId: () => EXECUTION_ID });
+		await preview.load();
+		await preview.load();
+
+		expect(workflowsStore.getExecution).toHaveBeenCalledTimes(2);
+	});
+
+	it('sets loadError and keeps the document store empty when the fetch fails', async () => {
+		workflowsStore.getExecution = vi.fn().mockRejectedValue(new Error('Not found'));
+
+		const preview = useExecutionPreviewDocument({ executionId: () => EXECUTION_ID });
+		await preview.load();
+
+		expect(preview.loadError.value?.message).toBe('Not found');
+		expect(preview.documentStore.value).toBeNull();
+	});
+
+	it('disposes all preview stores on dispose()', async () => {
+		const preview = useExecutionPreviewDocument({ executionId: () => EXECUTION_ID });
+		await preview.load();
+
+		const previewDocumentId = createExecutionPreviewDocumentId(WORKFLOW_ID);
+		const pinia = getActivePinia()!;
+
+		expect(pinia.state.value[getWorkflowDocumentStoreId(previewDocumentId)]).toBeDefined();
+		expect(pinia.state.value[getWorkflowExecutionStateStoreId(previewDocumentId)]).toBeDefined();
+		expect(
+			pinia.state.value[getExecutionDataStoreId(createExecutionDataId(EXECUTION_ID))],
+		).toBeDefined();
+
+		preview.dispose();
+
+		expect(pinia.state.value[getWorkflowDocumentStoreId(previewDocumentId)]).toBeUndefined();
+		expect(pinia.state.value[getWorkflowExecutionStateStoreId(previewDocumentId)]).toBeUndefined();
+		expect(
+			pinia.state.value[getExecutionDataStoreId(createExecutionDataId(EXECUTION_ID))],
+		).toBeUndefined();
+		expect(preview.documentStore.value).toBeNull();
+	});
+
+	it('keeps execution data alive on dispose() when the editor still references it', async () => {
+		// The editor displays the same execution the preview loaded (e.g. the
+		// user ran the workflow manually, then opened it in the executions tab).
+		const editorStateStore = useWorkflowExecutionStateStore(createWorkflowDocumentId(WORKFLOW_ID));
+		editorStateStore.setWorkflowExecutionData(createExecution({ mode: 'manual' }));
+
+		const preview = useExecutionPreviewDocument({ executionId: () => EXECUTION_ID });
+		await preview.load();
+		preview.dispose();
+
+		// The shared per-execution data store survives — the editor still reads it
+		const editorExecutionData = useExecutionDataStore(createExecutionDataId(EXECUTION_ID));
+		expect(editorExecutionData.execution?.id).toBe(EXECUTION_ID);
+		expect(editorStateStore.activeExecution?.id).toBe(EXECUTION_ID);
+	});
+
+	it('leaves no preview pinia state behind after repeated load/dispose cycles', async () => {
+		const pinia = getActivePinia()!;
+
+		// First cycle lazily instantiates shared editor-scope stores (inject
+		// fallbacks); baseline after it so the loop asserts steady state.
+		const firstPreview = useExecutionPreviewDocument({ executionId: () => EXECUTION_ID });
+		await firstPreview.load();
+		firstPreview.dispose();
+		const statesBefore = Object.keys(pinia.state.value).sort();
+		expect(statesBefore.filter((key) => key.includes('execution-preview'))).toEqual([]);
+
+		for (let i = 0; i < 3; i++) {
+			const preview = useExecutionPreviewDocument({ executionId: () => EXECUTION_ID });
+			await preview.load();
+			preview.dispose();
+		}
+
+		const statesAfter = Object.keys(pinia.state.value).sort();
+		expect(statesAfter).toEqual(statesBefore);
+	});
+});

--- a/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionPreviewDocument.test.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionPreviewDocument.test.ts
@@ -1,3 +1,4 @@
+import { ref } from 'vue';
 import { setActivePinia, getActivePinia } from 'pinia';
 import { createTestingPinia } from '@pinia/testing';
 import { mock } from 'vitest-mock-extended';
@@ -107,7 +108,7 @@ describe('useExecutionPreviewDocument', () => {
 		await preview.load();
 
 		expect(preview.documentStore.value?.documentId).toBe(
-			createExecutionPreviewDocumentId(WORKFLOW_ID),
+			createExecutionPreviewDocumentId(WORKFLOW_ID, 'v1'),
 		);
 		expect(preview.documentStore.value?.allNodes.map((node) => node.name)).toEqual(['Node A']);
 		expect(preview.execution.value?.id).toBe(EXECUTION_ID);
@@ -130,7 +131,7 @@ describe('useExecutionPreviewDocument', () => {
 		expect(editorStateStore.activeExecution?.id).toBe('editor-execution');
 
 		const previewStateStore = useWorkflowExecutionStateStore(
-			createExecutionPreviewDocumentId(WORKFLOW_ID),
+			createExecutionPreviewDocumentId(WORKFLOW_ID, 'v1'),
 		);
 		expect(previewStateStore.displayedExecutionId).toBe(EXECUTION_ID);
 	});
@@ -190,7 +191,7 @@ describe('useExecutionPreviewDocument', () => {
 		const preview = useExecutionPreviewDocument({ executionId: () => EXECUTION_ID });
 		await preview.load();
 
-		const previewDocumentId = createExecutionPreviewDocumentId(WORKFLOW_ID);
+		const previewDocumentId = createExecutionPreviewDocumentId(WORKFLOW_ID, 'v1');
 		const pinia = getActivePinia()!;
 
 		expect(pinia.state.value[getWorkflowDocumentStoreId(previewDocumentId)]).toBeDefined();
@@ -244,5 +245,52 @@ describe('useExecutionPreviewDocument', () => {
 
 		const statesAfter = Object.keys(pinia.state.value).sort();
 		expect(statesAfter).toEqual(statesBefore);
+	});
+
+	it('gives each executed workflow version its own document store and disposes them all', async () => {
+		const pinia = getActivePinia()!;
+
+		// Two executions of the same workflow that ran against different versions
+		// — and therefore different node sets.
+		workflowsStore.getExecution = vi.fn(async (id: string) =>
+			id === 'execution-v2'
+				? createExecution({
+						id: 'execution-v2',
+						workflowData: createTestWorkflow({
+							id: WORKFLOW_ID,
+							versionId: 'v2',
+							nodes: [createTestNode({ name: 'Node B' })],
+							connections: {},
+						}),
+					})
+				: createExecution(),
+		);
+
+		const executionId = ref(EXECUTION_ID);
+		const preview = useExecutionPreviewDocument({ executionId });
+
+		await preview.load();
+		expect(preview.documentStore.value?.documentId).toBe(
+			createExecutionPreviewDocumentId(WORKFLOW_ID, 'v1'),
+		);
+
+		// Switching to an execution of a different version hydrates a distinct
+		// store rather than re-shaping the v1 one.
+		executionId.value = 'execution-v2';
+		await preview.load();
+		expect(preview.documentStore.value?.documentId).toBe(
+			createExecutionPreviewDocumentId(WORKFLOW_ID, 'v2'),
+		);
+		expect(preview.documentStore.value?.allNodes.map((node) => node.name)).toEqual(['Node B']);
+
+		const idV1 = createExecutionPreviewDocumentId(WORKFLOW_ID, 'v1');
+		const idV2 = createExecutionPreviewDocumentId(WORKFLOW_ID, 'v2');
+		expect(pinia.state.value[getWorkflowDocumentStoreId(idV1)]).toBeDefined();
+		expect(pinia.state.value[getWorkflowDocumentStoreId(idV2)]).toBeDefined();
+
+		// dispose() releases every version's document store, not just the last.
+		preview.dispose();
+		expect(pinia.state.value[getWorkflowDocumentStoreId(idV1)]).toBeUndefined();
+		expect(pinia.state.value[getWorkflowDocumentStoreId(idV2)]).toBeUndefined();
 	});
 });

--- a/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionPreviewDocument.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionPreviewDocument.ts
@@ -132,6 +132,18 @@ export function useExecutionPreviewDocument(options: UseExecutionPreviewDocument
 	);
 
 	function getReusableExecution(executionId: string): IExecutionResponse | null {
+		// Only reuse executions THIS preview session loaded. Other entries in the
+		// app-wide, execution-id-keyed data store belong to the editor — e.g. the
+		// workflow's own last manual run — whose `workflowData` shares live node
+		// references with the editor document (its snapshot exposes `allNodes` by
+		// reference). An unsaved editor edit after the run (toggling a node, etc.)
+		// mutates those nodes in place, so reusing that entry would render the
+		// editor's current state instead of the executed snapshot. Falling through
+		// to a fresh fetch yields the immutable server-side snapshot, matching the
+		// iframe preview this replaced, which always re-fetched.
+		if (!loadedExecutionIds.has(executionId)) {
+			return null;
+		}
 		const executionDataId = createExecutionDataId(executionId);
 		// Peek only — never instantiate here. A bare `useExecutionDataStore()`
 		// would register an empty store for ids whose load never completes (the
@@ -166,13 +178,31 @@ export function useExecutionPreviewDocument(options: UseExecutionPreviewDocument
 				throw new Error(`Execution with id "${executionId}" could not be found!`);
 			}
 
-			// Toast parity with useCanvasOperations.openExecution()
-			if (data.status === 'error' && data.data?.resultData.error) {
+			// Surface the execution's error the same way the editor canvas did when
+			// the iframe loaded it: openExecution() for node-level errors, and
+			// NodeView's `open:execution` handler for workflow-level errors on
+			// unfinished executions (crashed / out-of-memory). The native preview no
+			// longer drives the canvas event bus, so we toast both here.
+			const resultData = data.data?.resultData;
+			if (data.status === 'error' && resultData?.error) {
 				const { title, message } = getExecutionErrorToastConfiguration({
-					error: data.data.resultData.error,
-					lastNodeExecuted: data.data.resultData.lastNodeExecuted,
+					error: resultData.error,
+					lastNodeExecuted: resultData.lastNodeExecuted,
 				});
 				toast.showMessage({ title, message, type: 'error', duration: 0 });
+			} else if (!data.finished && resultData?.error) {
+				// Skip when a node already captured the error — it shows on the node.
+				const nodeErrorFound = Object.values(resultData.runData ?? {}).some((tasks) =>
+					tasks.some((task) => task.error),
+				);
+				if (!nodeErrorFound) {
+					toast.showMessage({
+						title: i18n.baseText('nodeView.showError.workflowError'),
+						message: resultData.error.message,
+						type: 'error',
+						duration: 0,
+					});
+				}
 			}
 
 			const workflowId = data.workflowData.id;

--- a/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionPreviewDocument.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionPreviewDocument.ts
@@ -1,0 +1,231 @@
+import { computed, ref, shallowRef, toValue, type MaybeRefOrGetter } from 'vue';
+import { isTerminalExecutionStatus } from 'n8n-workflow';
+import type { IWorkflowDb } from '@/Interface';
+import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
+import { useI18n } from '@n8n/i18n';
+import { useToast } from '@/app/composables/useToast';
+import { useTelemetry } from '@/app/composables/useTelemetry';
+import { useExternalHooks } from '@/app/composables/useExternalHooks';
+import { useWorkflowNormalization } from '@/app/composables/useWorkflowNormalization';
+import { useWorkflowsStore } from '@/app/stores/workflows.store';
+import {
+	createExecutionPreviewDocumentId,
+	createWorkflowDocumentId,
+	disposeWorkflowDocumentStore,
+	EXECUTION_PREVIEW_VERSION,
+	useWorkflowDocumentStore,
+	type WorkflowDocumentStore,
+} from '@/app/stores/workflowDocument.store';
+import {
+	disposeWorkflowExecutionStateStore,
+	useWorkflowExecutionStateStore,
+} from '@/app/stores/workflowExecutionState.store';
+import {
+	createExecutionDataId,
+	disposeExecutionDataStore,
+	useExecutionDataStore,
+} from '@/app/stores/executionData.store';
+import { disposeNDVStore, useNDVStore } from '@/features/ndv/shared/ndv.store';
+import { getExecutionErrorToastConfiguration } from '@/features/execution/executions/executions.utils';
+
+export interface UseExecutionPreviewDocumentOptions {
+	executionId: MaybeRefOrGetter<string>;
+}
+
+/**
+ * Loads an execution for read-only preview into a fully isolated set of
+ * stores, keyed by the synthetic `{workflowId}@execution-preview` document id.
+ *
+ * This is the side-effect-free counterpart of
+ * `useCanvasOperations.openExecution()` (which serves "Debug in editor" and
+ * deliberately writes the editor's `{workflowId}@latest` stores): it performs
+ * NO `resetWorkspace`, NO `initState`, NO `workflowsStore.setWorkflowId`, and
+ * NO `uiStore.markStateClean` — loading a preview must never affect the
+ * editor's (possibly dirty) state, which stays alive across the
+ * editor/executions tab switch (`keepWorkflowAlive`).
+ */
+export function useExecutionPreviewDocument(options: UseExecutionPreviewDocumentOptions) {
+	const i18n = useI18n();
+	const toast = useToast();
+	const telemetry = useTelemetry();
+	const externalHooks = useExternalHooks();
+	const workflowsStore = useWorkflowsStore();
+	const { normalizeWorkflowData } = useWorkflowNormalization();
+
+	/** Provide this under `WorkflowDocumentStoreKey`; null until the first load completes. */
+	const documentStore = shallowRef<WorkflowDocumentStore | null>(null);
+	const execution = shallowRef<IExecutionResponse | null>(null);
+	const isLoading = ref(false);
+	const loadError = ref<Error | null>(null);
+
+	/**
+	 * Every execution id this preview session has loaded. Per-execution data
+	 * stores are keyed app-wide by bare execution id, so previously viewed
+	 * executions render instantly when re-selected — they are released in
+	 * `dispose()`, except ids the editor's own state store still references.
+	 */
+	const loadedExecutionIds = new Set<string>();
+	let latestLoadRequestId = 0;
+
+	/**
+	 * Production executions hide pin data and render production-only UI.
+	 * Derived from the execution itself (the per-instance
+	 * `useNodeHelpers().isProductionExecutionPreview` ref never reliably
+	 * crossed composable instances).
+	 */
+	const isProductionExecutionPreview = computed(
+		() => execution.value !== null && !['manual', 'evaluation'].includes(execution.value.mode),
+	);
+
+	function getReusableExecution(executionId: string): IExecutionResponse | null {
+		const executionDataStore = useExecutionDataStore(createExecutionDataId(executionId));
+		const snapshot = executionDataStore.getExecutionSnapshot();
+		// Only terminal executions are safe to reuse without a re-fetch —
+		// waiting/running ones may have progressed since they were loaded.
+		return snapshot && isTerminalExecutionStatus(snapshot.status) ? snapshot : null;
+	}
+
+	async function load(): Promise<void> {
+		const executionId = toValue(options.executionId);
+		const requestId = ++latestLoadRequestId;
+
+		isLoading.value = true;
+		loadError.value = null;
+
+		try {
+			const data =
+				getReusableExecution(executionId) ?? (await workflowsStore.getExecution(executionId));
+
+			// Drop stale responses if the selected execution changed mid-flight.
+			if (requestId !== latestLoadRequestId) {
+				return;
+			}
+
+			if (data === undefined) {
+				throw new Error(`Execution with id "${executionId}" could not be found!`);
+			}
+
+			// Toast parity with useCanvasOperations.openExecution()
+			if (data.status === 'error' && data.data?.resultData.error) {
+				const { title, message } = getExecutionErrorToastConfiguration({
+					error: data.data.resultData.error,
+					lastNodeExecuted: data.data.resultData.lastNodeExecuted,
+				});
+				toast.showMessage({ title, message, type: 'error', duration: 0 });
+			}
+
+			const workflowId = data.workflowData.id;
+			const documentId = createExecutionPreviewDocumentId(workflowId);
+
+			if (import.meta.env.DEV && documentId === createWorkflowDocumentId(workflowId)) {
+				throw new Error(
+					'useExecutionPreviewDocument: preview document id must never equal the editor document id',
+				);
+			}
+
+			// Hydrate the scoped document from the workflow snapshot embedded in
+			// the execution (the workflow as it was when it ran — not `latest`).
+			// The synthetic versionId satisfies hydrate()'s id/version validation,
+			// same pattern as the workflow-diff feature.
+			const scopedDocumentStore = useWorkflowDocumentStore(documentId);
+			const { nodes, connections } = normalizeWorkflowData(data.workflowData);
+			scopedDocumentStore.hydrate({
+				...data.workflowData,
+				nodes,
+				connections,
+				versionId: EXECUTION_PREVIEW_VERSION,
+			} as IWorkflowDb);
+
+			useWorkflowExecutionStateStore(documentId).setWorkflowExecutionData(data);
+			loadedExecutionIds.add(executionId);
+
+			// Production executions never show pin data (parity with openExecution)
+			if (!['manual', 'evaluation'].includes(data.mode)) {
+				scopedDocumentStore.setPinData({});
+			}
+
+			execution.value = data;
+			documentStore.value = scopedDocumentStore;
+
+			void externalHooks.run('execution.open', {
+				workflowId: data.workflowData.id,
+				workflowName: data.workflowData.name,
+				executionId,
+			});
+			telemetry.track('User opened read-only execution', {
+				workflow_id: data.workflowData.id,
+				execution_mode: data.mode,
+				execution_finished: data.finished,
+			});
+		} catch (error) {
+			if (requestId === latestLoadRequestId) {
+				loadError.value = error instanceof Error ? error : new Error(String(error));
+				toast.showError(error, i18n.baseText('nodeView.showError.openExecution.title'));
+			}
+		} finally {
+			if (requestId === latestLoadRequestId) {
+				isLoading.value = false;
+			}
+		}
+	}
+
+	/**
+	 * Execution ids the editor's `{workflowId}@latest` session still references
+	 * — e.g. the user ran the workflow manually and then previewed that same
+	 * execution. Releasing those would blank the editor's displayed run data.
+	 */
+	function getEditorReferencedExecutionIds(workflowId: string): Set<string> {
+		const editorStateStore = useWorkflowExecutionStateStore(createWorkflowDocumentId(workflowId));
+		const ids = new Set<string>();
+		for (const id of [
+			editorStateStore.activeExecutionId,
+			editorStateStore.displayedExecutionId,
+			editorStateStore.previousExecutionId,
+			editorStateStore.lastSuccessfulExecutionId,
+		]) {
+			if (typeof id === 'string') {
+				ids.add(id);
+			}
+		}
+		return ids;
+	}
+
+	function dispose() {
+		latestLoadRequestId += 1;
+
+		const scopedDocumentStore = documentStore.value;
+		if (scopedDocumentStore) {
+			const editorReferencedIds = getEditorReferencedExecutionIds(scopedDocumentStore.workflowId);
+			for (const executionId of loadedExecutionIds) {
+				if (editorReferencedIds.has(executionId)) {
+					continue;
+				}
+				disposeExecutionDataStore(useExecutionDataStore(createExecutionDataId(executionId)));
+			}
+
+			const documentId = scopedDocumentStore.documentId;
+			// NDV store first: its setup instantiates the document and
+			// execution-state stores for its id, so disposing it afterwards
+			// would re-create what was just removed.
+			disposeNDVStore(useNDVStore(documentId));
+			disposeWorkflowExecutionStateStore(useWorkflowExecutionStateStore(documentId));
+			disposeWorkflowDocumentStore(scopedDocumentStore);
+		}
+
+		loadedExecutionIds.clear();
+		documentStore.value = null;
+		execution.value = null;
+		loadError.value = null;
+		isLoading.value = false;
+	}
+
+	return {
+		documentStore,
+		execution,
+		isLoading,
+		loadError,
+		isProductionExecutionPreview,
+		load,
+		dispose,
+	};
+}

--- a/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionPreviewDocument.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionPreviewDocument.ts
@@ -10,10 +10,11 @@ import { useWorkflowNormalization } from '@/app/composables/useWorkflowNormaliza
 import { useWorkflowsStore } from '@/app/stores/workflows.store';
 import {
 	createExecutionPreviewDocumentId,
+	createExecutionPreviewDocumentVersion,
 	createWorkflowDocumentId,
 	disposeWorkflowDocumentStore,
-	EXECUTION_PREVIEW_VERSION,
 	useWorkflowDocumentStore,
+	type WorkflowDocumentId,
 	type WorkflowDocumentStore,
 } from '@/app/stores/workflowDocument.store';
 import {
@@ -65,6 +66,13 @@ export function useExecutionPreviewDocument(options: UseExecutionPreviewDocument
 	 * `dispose()`, except ids the editor's own state store still references.
 	 */
 	const loadedExecutionIds = new Set<string>();
+
+	/**
+	 * Every preview document id this session has hydrated — one per distinct
+	 * executed workflow version (executions of the same version share a store).
+	 * All are released in `dispose()`.
+	 */
+	const loadedDocumentIds = new Set<WorkflowDocumentId>();
 	let latestLoadRequestId = 0;
 
 	/**
@@ -115,7 +123,11 @@ export function useExecutionPreviewDocument(options: UseExecutionPreviewDocument
 			}
 
 			const workflowId = data.workflowData.id;
-			const documentId = createExecutionPreviewDocumentId(workflowId);
+			// Key by the executed workflow version so executions that ran against
+			// different versions (different nodes) never share — and re-shape — one
+			// document store.
+			const documentVersion = createExecutionPreviewDocumentVersion(data.workflowData.versionId);
+			const documentId = createExecutionPreviewDocumentId(workflowId, data.workflowData.versionId);
 
 			if (import.meta.env.DEV && documentId === createWorkflowDocumentId(workflowId)) {
 				throw new Error(
@@ -125,19 +137,21 @@ export function useExecutionPreviewDocument(options: UseExecutionPreviewDocument
 
 			// Hydrate the scoped document from the workflow snapshot embedded in
 			// the execution (the workflow as it was when it ran — not `latest`).
-			// The synthetic versionId satisfies hydrate()'s id/version validation,
-			// same pattern as the workflow-diff feature.
+			// The synthetic versionId mirrors the document's version segment so it
+			// satisfies hydrate()'s id/version validation, same pattern as the
+			// workflow-diff feature.
 			const scopedDocumentStore = useWorkflowDocumentStore(documentId);
 			const { nodes, connections } = normalizeWorkflowData(data.workflowData);
 			scopedDocumentStore.hydrate({
 				...data.workflowData,
 				nodes,
 				connections,
-				versionId: EXECUTION_PREVIEW_VERSION,
+				versionId: documentVersion,
 			} as IWorkflowDb);
 
 			useWorkflowExecutionStateStore(documentId).setWorkflowExecutionData(data);
 			loadedExecutionIds.add(executionId);
+			loadedDocumentIds.add(documentId);
 
 			// Production executions never show pin data (parity with openExecution)
 			if (!['manual', 'evaluation'].includes(data.mode)) {
@@ -193,25 +207,29 @@ export function useExecutionPreviewDocument(options: UseExecutionPreviewDocument
 	function dispose() {
 		latestLoadRequestId += 1;
 
-		const scopedDocumentStore = documentStore.value;
-		if (scopedDocumentStore) {
-			const editorReferencedIds = getEditorReferencedExecutionIds(scopedDocumentStore.workflowId);
+		// Every preview document shares the executions-tab workflow id, so any
+		// loaded store resolves the editor-referenced ids we must not release.
+		const workflowId = documentStore.value?.workflowId;
+		if (workflowId !== undefined) {
+			const editorReferencedIds = getEditorReferencedExecutionIds(workflowId);
 			for (const executionId of loadedExecutionIds) {
 				if (editorReferencedIds.has(executionId)) {
 					continue;
 				}
 				disposeExecutionDataStore(useExecutionDataStore(createExecutionDataId(executionId)));
 			}
-
-			const documentId = scopedDocumentStore.documentId;
-			// NDV store first: its setup instantiates the document and
-			// execution-state stores for its id, so disposing it afterwards
-			// would re-create what was just removed.
-			disposeNDVStore(useNDVStore(documentId));
-			disposeWorkflowExecutionStateStore(useWorkflowExecutionStateStore(documentId));
-			disposeWorkflowDocumentStore(scopedDocumentStore);
 		}
 
+		// One document scope per executed version. NDV store first: its setup
+		// instantiates the document and execution-state stores for its id, so
+		// disposing it afterwards would re-create what was just removed.
+		for (const documentId of loadedDocumentIds) {
+			disposeNDVStore(useNDVStore(documentId));
+			disposeWorkflowExecutionStateStore(useWorkflowExecutionStateStore(documentId));
+			disposeWorkflowDocumentStore(useWorkflowDocumentStore(documentId));
+		}
+
+		loadedDocumentIds.clear();
 		loadedExecutionIds.clear();
 		documentStore.value = null;
 		execution.value = null;

--- a/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionPreviewDocument.ts
+++ b/packages/frontend/editor-ui/src/features/execution/executions/composables/useExecutionPreviewDocument.ts
@@ -2,6 +2,7 @@ import { computed, ref, shallowRef, toValue, type MaybeRefOrGetter } from 'vue';
 import { isTerminalExecutionStatus } from 'n8n-workflow';
 import type { IWorkflowDb } from '@/Interface';
 import type { IExecutionResponse } from '@/features/execution/executions/executions.types';
+import { MAX_PREVIEW_EXECUTIONS_IN_MEMORY } from '@/app/constants';
 import { useI18n } from '@n8n/i18n';
 import { useToast } from '@/app/composables/useToast';
 import { useTelemetry } from '@/app/composables/useTelemetry';
@@ -24,6 +25,7 @@ import {
 import {
 	createExecutionDataId,
 	disposeExecutionDataStore,
+	hasExecutionDataStore,
 	useExecutionDataStore,
 } from '@/app/stores/executionData.store';
 import { disposeNDVStore, useNDVStore } from '@/features/ndv/shared/ndv.store';
@@ -76,6 +78,50 @@ export function useExecutionPreviewDocument(options: UseExecutionPreviewDocument
 	let latestLoadRequestId = 0;
 
 	/**
+	 * The workflow id shared by every execution this session previews (all
+	 * documents/executions belong to the executions-tab workflow). Captured on
+	 * each successful load so `dispose()` can still resolve the editor-referenced
+	 * ids to protect even after a failed load nulled `documentStore`.
+	 */
+	let previewWorkflowId: string | undefined;
+
+	/**
+	 * Marks an execution as most-recently-used. `Set` preserves insertion order
+	 * but `add()` is a no-op for an existing key, so re-add it to move it to the
+	 * tail (the front is then the least-recently-used eviction candidate).
+	 */
+	function touchLoadedExecution(executionId: string): void {
+		loadedExecutionIds.delete(executionId);
+		loadedExecutionIds.add(executionId);
+	}
+
+	/**
+	 * Caps retained per-execution data stores at `MAX_PREVIEW_EXECUTIONS_IN_MEMORY`
+	 * by disposing the least-recently-used ones. Never evicts the execution just
+	 * loaded, nor any the editor's `{workflowId}@latest` session still references
+	 * (disposing those would blank the editor's run data) — when all retained ids
+	 * are protected the count simply stays above the cap.
+	 */
+	function evictLeastRecentlyUsedExecutions(currentExecutionId: string, workflowId: string): void {
+		const protectedExecutionIds = getEditorReferencedExecutionIds(workflowId);
+		protectedExecutionIds.add(currentExecutionId);
+
+		let retainedCount = loadedExecutionIds.size;
+		// Snapshot oldest-first; the loop mutates loadedExecutionIds.
+		for (const candidateExecutionId of [...loadedExecutionIds]) {
+			if (retainedCount <= MAX_PREVIEW_EXECUTIONS_IN_MEMORY) {
+				break;
+			}
+			if (protectedExecutionIds.has(candidateExecutionId)) {
+				continue;
+			}
+			disposeExecutionDataStore(useExecutionDataStore(createExecutionDataId(candidateExecutionId)));
+			loadedExecutionIds.delete(candidateExecutionId);
+			retainedCount -= 1;
+		}
+	}
+
+	/**
 	 * Production executions hide pin data and render production-only UI.
 	 * Derived from the execution itself (the per-instance
 	 * `useNodeHelpers().isProductionExecutionPreview` ref never reliably
@@ -86,8 +132,15 @@ export function useExecutionPreviewDocument(options: UseExecutionPreviewDocument
 	);
 
 	function getReusableExecution(executionId: string): IExecutionResponse | null {
-		const executionDataStore = useExecutionDataStore(createExecutionDataId(executionId));
-		const snapshot = executionDataStore.getExecutionSnapshot();
+		const executionDataId = createExecutionDataId(executionId);
+		// Peek only — never instantiate here. A bare `useExecutionDataStore()`
+		// would register an empty store for ids whose load never completes (the
+		// request is superseded as stale, or the fetch fails), and those untracked
+		// stores would escape `dispose()`.
+		if (!hasExecutionDataStore(executionDataId)) {
+			return null;
+		}
+		const snapshot = useExecutionDataStore(executionDataId).getExecutionSnapshot();
 		// Only terminal executions are safe to reuse without a re-fetch —
 		// waiting/running ones may have progressed since they were loaded.
 		return snapshot && isTerminalExecutionStatus(snapshot.status) ? snapshot : null;
@@ -123,6 +176,7 @@ export function useExecutionPreviewDocument(options: UseExecutionPreviewDocument
 			}
 
 			const workflowId = data.workflowData.id;
+			previewWorkflowId = workflowId;
 			// Key by the executed workflow version so executions that ran against
 			// different versions (different nodes) never share — and re-shape — one
 			// document store.
@@ -150,7 +204,8 @@ export function useExecutionPreviewDocument(options: UseExecutionPreviewDocument
 			} as IWorkflowDb);
 
 			useWorkflowExecutionStateStore(documentId).setWorkflowExecutionData(data);
-			loadedExecutionIds.add(executionId);
+			touchLoadedExecution(executionId);
+			evictLeastRecentlyUsedExecutions(executionId, workflowId);
 			loadedDocumentIds.add(documentId);
 
 			// Production executions never show pin data (parity with openExecution)
@@ -174,6 +229,8 @@ export function useExecutionPreviewDocument(options: UseExecutionPreviewDocument
 		} catch (error) {
 			if (requestId === latestLoadRequestId) {
 				loadError.value = error instanceof Error ? error : new Error(String(error));
+				documentStore.value = null;
+				execution.value = null;
 				toast.showError(error, i18n.baseText('nodeView.showError.openExecution.title'));
 			}
 		} finally {
@@ -207,11 +264,11 @@ export function useExecutionPreviewDocument(options: UseExecutionPreviewDocument
 	function dispose() {
 		latestLoadRequestId += 1;
 
-		// Every preview document shares the executions-tab workflow id, so any
-		// loaded store resolves the editor-referenced ids we must not release.
-		const workflowId = documentStore.value?.workflowId;
-		if (workflowId !== undefined) {
-			const editorReferencedIds = getEditorReferencedExecutionIds(workflowId);
+		// Every preview document shares the executions-tab workflow id. Use the
+		// tracked id rather than `documentStore.value` — the latter is nulled by a
+		// failed load, which would otherwise skip releasing the retained stores.
+		if (previewWorkflowId !== undefined) {
+			const editorReferencedIds = getEditorReferencedExecutionIds(previewWorkflowId);
 			for (const executionId of loadedExecutionIds) {
 				if (editorReferencedIds.has(executionId)) {
 					continue;
@@ -231,6 +288,7 @@ export function useExecutionPreviewDocument(options: UseExecutionPreviewDocument
 
 		loadedDocumentIds.clear();
 		loadedExecutionIds.clear();
+		previewWorkflowId = undefined;
 		documentStore.value = null;
 		execution.value = null;
 		loadError.value = null;

--- a/packages/testing/playwright/pages/ExecutionsPage.ts
+++ b/packages/testing/playwright/pages/ExecutionsPage.ts
@@ -2,7 +2,6 @@ import type { Locator } from '@playwright/test';
 
 import { BasePage } from './BasePage';
 import { LogsPanel } from './components/LogsPanel';
-import { RunDataPanel } from './components/RunDataPanel';
 
 export class ExecutionsPage extends BasePage {
 	async goto(projectId?: string) {
@@ -11,9 +10,6 @@ export class ExecutionsPage extends BasePage {
 	}
 
 	readonly logsPanel = new LogsPanel(this.getPreview().getByTestId('logs-panel'));
-	// The NDV teleports to the app-level modals root, so a node's output panel
-	// opened from the native preview lives outside the preview host.
-	readonly outputPanel = new RunDataPanel(this.page.getByTestId('ndv').getByTestId('output-panel'));
 
 	async clickDebugInEditorButton(): Promise<void> {
 		await this.clickButtonByName('Debug in editor');

--- a/packages/testing/playwright/pages/ExecutionsPage.ts
+++ b/packages/testing/playwright/pages/ExecutionsPage.ts
@@ -10,8 +10,8 @@ export class ExecutionsPage extends BasePage {
 		await this.page.goto(url);
 	}
 
-	readonly logsPanel = new LogsPanel(this.getPreviewIframe().getByTestId('logs-panel'));
-	readonly outputPanel = new RunDataPanel(this.getPreviewIframe().getByTestId('output-panel'));
+	readonly logsPanel = new LogsPanel(this.getPreview().getByTestId('logs-panel'));
+	readonly outputPanel = new RunDataPanel(this.getPreview().getByTestId('output-panel'));
 
 	async clickDebugInEditorButton(): Promise<void> {
 		await this.clickButtonByName('Debug in editor');
@@ -34,8 +34,12 @@ export class ExecutionsPage extends BasePage {
 		return this.page.getByTestId('auto-refresh-checkbox');
 	}
 
-	getPreviewIframe() {
-		return this.page.getByTestId('workflow-preview-iframe').contentFrame();
+	getPreview(): Locator {
+		return this.page.getByTestId('execution-preview-host');
+	}
+
+	getPreviewCanvasNodes(): Locator {
+		return this.getPreview().getByTestId('canvas-node');
 	}
 
 	async clickLastExecutionItem(): Promise<void> {
@@ -83,10 +87,11 @@ export class ExecutionsPage extends BasePage {
 	}
 
 	/**
-	 * Get error notifications in the preview iframe
+	 * Get error notifications shown while previewing an execution. The preview
+	 * renders natively, so its notifications surface at the app level.
 	 */
 	getErrorNotificationsInPreview(): Locator {
-		return this.getPreviewIframe().locator('.el-notification:has(.el-notification--error)');
+		return this.page.locator('.el-notification:has(.el-notification--error)');
 	}
 
 	getFirstExecutionItem(): Locator {
@@ -116,7 +121,7 @@ export class ExecutionsPage extends BasePage {
 	}
 
 	async openNodeExecutionDetails(name: string): Promise<void> {
-		await this.getPreviewIframe()
+		await this.getPreview()
 			.locator(`[data-test-id="canvas-node"][data-node-name="${name}"]`)
 			.dblclick();
 	}

--- a/packages/testing/playwright/pages/ExecutionsPage.ts
+++ b/packages/testing/playwright/pages/ExecutionsPage.ts
@@ -11,7 +11,9 @@ export class ExecutionsPage extends BasePage {
 	}
 
 	readonly logsPanel = new LogsPanel(this.getPreview().getByTestId('logs-panel'));
-	readonly outputPanel = new RunDataPanel(this.getPreview().getByTestId('output-panel'));
+	// The NDV teleports to the app-level modals root, so a node's output panel
+	// opened from the native preview lives outside the preview host.
+	readonly outputPanel = new RunDataPanel(this.page.getByTestId('ndv').getByTestId('output-panel'));
 
 	async clickDebugInEditorButton(): Promise<void> {
 		await this.clickButtonByName('Debug in editor');

--- a/packages/testing/playwright/tests/e2e/redaction-enforcement/redaction-enforcement.spec.ts
+++ b/packages/testing/playwright/tests/e2e/redaction-enforcement/redaction-enforcement.spec.ts
@@ -57,7 +57,7 @@ async function openExecutionOutput(
 ): Promise<Locator> {
 	await n8n.navigate.toExecution(workflowId, executionId);
 	await n8n.executions.openNodeExecutionDetails(DATA_NODE);
-	return n8n.executions.outputPanel.getDataContainer();
+	return n8n.ndv.outputPanel.getDataContainer();
 }
 
 test.describe(

--- a/packages/testing/playwright/tests/e2e/workflows/executions/list.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/executions/list.spec.ts
@@ -192,8 +192,7 @@ test.describe('Workflow Executions', () => {
 			await n8n.canvas.clickExecutionsTab();
 			await executionDetailPromise;
 
-			const iframe = n8n.executions.getPreviewIframe();
-			await expect(iframe.locator('body')).not.toBeEmpty();
+			await expect(n8n.executions.getPreview()).toBeVisible();
 
 			await n8n.executions.getErrorNotificationsInPreview().first().waitFor({ timeout: 5000 });
 
@@ -233,26 +232,26 @@ test.describe('Workflow Executions', () => {
 			await n8n.canvas.clickExecutionsTab();
 			await executionsResponsePromise;
 
-			const iframe = n8n.executions.getPreviewIframe();
-			await expect(iframe.locator('body')).toBeAttached();
+			const preview = n8n.executions.getPreview();
+			await expect(preview).toBeAttached();
 
 			await n8n.executions.getExecutionItems().nth(2).click();
-			await expect(iframe.locator('body')).toBeAttached();
+			await expect(preview).toBeAttached();
 
 			await n8n.executions.getExecutionItems().nth(4).click();
-			await expect(iframe.locator('body')).toBeAttached();
+			await expect(preview).toBeAttached();
 
 			await n8n.executions.getExecutionItems().nth(6).click();
-			await expect(iframe.locator('body')).toBeAttached();
+			await expect(preview).toBeAttached();
 
 			await n8n.page.goBack();
-			await expect(iframe.locator('body')).toBeAttached();
+			await expect(preview).toBeAttached();
 
 			await n8n.page.goBack();
-			await expect(iframe.locator('body')).toBeAttached();
+			await expect(preview).toBeAttached();
 
 			await n8n.page.goBack();
-			await expect(iframe.locator('body')).toBeAttached();
+			await expect(preview).toBeAttached();
 
 			await n8n.page.goBack();
 

--- a/packages/testing/playwright/tests/e2e/workflows/executions/preview-isolation.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/executions/preview-isolation.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '../../../../fixtures/base';
+
+test.describe('Execution preview isolation', () => {
+	test.beforeEach(async ({ n8n }) => {
+		await n8n.start.fromImportedWorkflow('Test_workflow_4_executions_view.json');
+	});
+
+	test('should preserve unsaved editor changes while previewing an execution', async ({ n8n }) => {
+		await n8n.executionsComposer.createExecutions(1);
+
+		// Make an unsaved editor change: enable the (initially disabled) Error node
+		await n8n.canvas.toggleNodeEnabled('Error');
+		await expect(n8n.canvas.disabledNodes()).toHaveCount(0);
+
+		await n8n.canvas.clickExecutionsTab();
+		await expect(n8n.executions.getExecutionItems().first()).toBeVisible();
+		await n8n.executions.clickLastExecutionItem();
+
+		// The preview renders natively with the executed workflow snapshot
+		await expect(n8n.executions.getPreview()).toBeVisible();
+		await expect(n8n.executions.getPreviewCanvasNodes().first()).toBeVisible();
+
+		// The snapshot still has the Error node disabled — the editor's unsaved
+		// change must not leak into the preview
+		await expect(n8n.canvas.disabledNodes()).toHaveCount(1);
+
+		// The logs panel renders natively inside the preview
+		await expect(n8n.executions.logsPanel.getOverviewStatus()).toBeVisible();
+
+		// A node can be inspected in the read-only NDV
+		await n8n.canvas.openNode('Code');
+		await expect(n8n.ndv.container).toBeVisible();
+		await expect(n8n.ndv.getOutputPanel()).toBeVisible();
+		await n8n.ndv.clickBackToCanvasButton();
+
+		// Back in the editor, the unsaved change (and the workflow itself) is intact
+		await n8n.canvas.clickEditorTab();
+		await expect(n8n.canvas.getCanvasNodes()).toHaveCount(3);
+		await expect(n8n.canvas.disabledNodes()).toHaveCount(0);
+	});
+
+	test('should keep the preview working when switching between executions', async ({ n8n }) => {
+		await n8n.executionsComposer.createExecutions(3);
+
+		await n8n.canvas.clickExecutionsTab();
+		await expect(n8n.executions.getExecutionItems().first()).toBeVisible();
+
+		await n8n.executions.getExecutionItems().nth(0).click();
+		await expect(n8n.executions.getPreviewCanvasNodes().first()).toBeVisible();
+
+		await n8n.executions.getExecutionItems().nth(1).click();
+		await expect(n8n.executions.getPreviewCanvasNodes().first()).toBeVisible();
+
+		// Switching back re-renders instantly from the already-loaded execution
+		await n8n.executions.getExecutionItems().nth(0).click();
+		await expect(n8n.executions.getPreviewCanvasNodes().first()).toBeVisible();
+	});
+});

--- a/packages/testing/playwright/tests/e2e/workflows/executions/preview-isolation.spec.ts
+++ b/packages/testing/playwright/tests/e2e/workflows/executions/preview-isolation.spec.ts
@@ -25,6 +25,7 @@ test.describe('Execution preview isolation', () => {
 		await expect(n8n.canvas.disabledNodes()).toHaveCount(1);
 
 		// The logs panel renders natively inside the preview
+		await n8n.executions.logsPanel.open();
 		await expect(n8n.executions.logsPanel.getOverviewStatus()).toBeVisible();
 
 		// A node can be inspected in the read-only NDV


### PR DESCRIPTION
## Summary

PR 2/4 of the iframe → native preview migration (parent: [CAT-3416](https://linear.app/n8n/issue/CAT-3416)). The executions tab now renders the selected execution through an **isolated native host** instead of the `/workflows/demo` iframe.

### Why the iframe existed

`WorkflowExecutionsPreview.vue` rendered `WorkflowPreview.vue`, which booted the **entire editor app a second time** in an `<iframe src="/workflows/demo">` driven by postMessage. Its only purpose was state isolation: the second app instance has its own Pinia, so loading an execution couldn't clobber the editor's (possibly dirty) stores. The cost was a full duplicate app boot per preview, postMessage races, focus/scroll hacks, and `contentFrame()` e2e selectors.

### How scoped stores replace it

The merged "Scope execution-state reads" refactor ([CAT-3417](https://linear.app/n8n/issue/CAT-3417), #32219) made every NDV/logs execution read resolve through the injected workflow document scope. Isolation can therefore come from a **scoped store instance** rather than a window boundary: the preview hydrates a synthetic `{workflowId}@execution-preview` document and provides it to its subtree, so the real `NodeView` + `LogsPanel` render against the preview's stores while the editor's `{workflowId}@latest` stores stay untouched.

### Changes

- **`workflowDocument.store.ts`** — `EXECUTION_PREVIEW_VERSION` + `createExecutionPreviewDocumentId(workflowId)`, the sole constructor of the synthetic preview id (can never equal the editor's `@latest` id).
- **`useExecutionPreviewDocument.ts`** (+tests) — the isolated loader. It is the **side-effect-free** counterpart of `useCanvasOperations.openExecution()` (which serves "Debug in editor" and deliberately writes the editor's stores): **no** `resetWorkspace`, `initState`, `setWorkflowId`, or `markStateClean`. It reuses an already-loaded terminal execution snapshot (else a pure `getExecution` GET with a stale-response guard), hydrates the scoped document from the workflow snapshot embedded in the execution, sets the execution data on the scoped state store, clears pin data for non-manual/evaluation modes, and keeps failed-execution toast + telemetry parity.
- **`ExecutionPreviewHost.vue`** (+tests) — provides `WorkflowIdKey`, `WorkflowDocumentStoreKey` (the loader's ref), and a read-only `EditorEnabledFeaturesKey`, and renders `NodeView` + read-only `LogsPanel` behind a readiness gate. Re-loads on `executionId` change via a **watcher (not `:key`)** so previously viewed executions re-render instantly under a thin loading overlay instead of an iframe-style white flash; handles deep-link `nodeId`, fits the view after mount, and disposes on unmount.
- **`WorkflowExecutionsPreview.vue`** — swaps the `<WorkflowPreview mode="execution">` block for `<ExecutionPreviewHost>`. Header overlay, running/new spinner branches, and retry/delete/stop/debug emits are unchanged.
- **Playwright** — `ExecutionsPage` exposes `getPreview()` (the native `execution-preview-host` testid) in place of `getPreviewIframe()/contentFrame()`; preview error notifications now read at app level (they surface natively). New `preview-isolation.spec.ts` covers the two guarantees below.

### Isolation guarantees (the acceptance criterion)

The editor and executions tab share `layout: 'workflow'` with `keepWorkflowAlive: true`, so the editor's possibly-dirty stores stay alive while previewing. Loading a preview must never touch them. Two subtleties are handled explicitly:

- **Shared per-execution data store**: `executionData` stores are keyed by **bare execution id**, app-wide. If the user ran the workflow in the editor and then previews that same execution, both scopes reference the *same* store — so `dispose()` skips releasing any execution id the editor's state store still references (active/displayed/previous/lastSuccessful).
- **Disposal order**: the NDV store is disposed *first* (its setup re-instantiates the document and state stores for its id), then the state store, then the document store.

## How to test

1. Run a workflow in the editor, open the **Executions** tab, select an execution → it renders in `execution-preview-host` (no `workflow-preview-iframe`), with success borders, run counts, a read-only NDV showing output data, and the logs panel.
2. Make an unsaved editor change (e.g. enable a disabled node), preview an execution, then return to the editor → the unsaved change survives and the preview showed the executed *snapshot*, not the dirty editor state.
3. Switch between executions → the preview re-renders instantly without a white flash.

Verified locally: editor-ui `pnpm typecheck` ✓, full `pnpm test` (editor-ui) ✓, playwright `typecheck` + `lint` + `janitor` ✓. The e2e specs run in CI.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3418

Part of https://linear.app/n8n/issue/CAT-3416 (iframe → native preview migration, PR 2 of 4). Follow-ups: native history & template previews (3/4), then retiring `WorkflowPreview.vue` (4/4).

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32296">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

