### PR TITLE
feat(core): Add telemetry for import/export on server CLI

### DIFF
--- a/packages/cli/src/commands/export/workflow.ts
+++ b/packages/cli/src/commands/export/workflow.ts
@@ -12,6 +12,7 @@ import { BaseCommand } from '../base-command';
 import type { IWorkflowWithVersionMetadata } from '@/interfaces';
 
 import '../../zod-alias-support';
+import { EventService } from '@/events/event.service';
 
 const flagsSchema = z.object({
 	all: z.boolean().describe('Export all workflows').optional(),
@@ -170,6 +171,16 @@ export class ExportWorkflowsCommand extends BaseCommand<z.infer<typeof flagsSche
 				this.logger.info(fileContents);
 			}
 		}
+
+		const selector = flags.all ? 'all' : flags.id ? 'id' : 'projectId';
+
+		Container.get(EventService).emit('server-cli-export', {
+			selector,
+			published: flags.published ?? false,
+			separate: flags.separate ?? false,
+			backup: flags.backup ?? false,
+			workflowCount: workflowsToExport.length,
+		});
 	}
 
 	async catch(error: Error) {

--- a/packages/cli/src/commands/import/workflow.ts
+++ b/packages/cli/src/commands/import/workflow.ts
@@ -20,6 +20,7 @@ import { BaseCommand } from '../base-command';
 import { UM_FIX_INSTRUCTION } from '@/constants';
 import type { IWorkflowToImport, IWorkflowWithVersionMetadata } from '@/interfaces';
 import { ImportService } from '@/services/import.service';
+import { EventService } from '@/events/event.service';
 
 function assertHasWorkflowsToImport(
 	workflows: unknown[],
@@ -152,6 +153,12 @@ export class ImportWorkflowsCommand extends BaseCommand<z.infer<typeof flagsSche
 		});
 
 		this.reportSuccess(workflows.length);
+
+		Container.get(EventService).emit('server-cli-import', {
+			activeState: flags.activeState,
+			workflowCount: workflows.length,
+			separate: flags.separate,
+		});
 	}
 
 	private async checkRelations(workflows: IWorkflowBase[], projectId?: string, userId?: string) {

--- a/packages/cli/src/events/maps/relay.event-map.ts
+++ b/packages/cli/src/events/maps/relay.event-map.ts
@@ -1037,4 +1037,22 @@ export type RelayEventMap = {
 	};
 
 	// #endregion
+
+	// #region Server CLI
+
+	'server-cli-import': {
+		activeState: 'false' | 'fromJson';
+		workflowCount: number;
+		separate: boolean;
+	};
+
+	'server-cli-export': {
+		selector: 'all' | 'id' | 'projectId';
+		published: boolean;
+		separate: boolean;
+		backup: boolean;
+		workflowCount: number;
+	};
+
+	// #endregion
 } & AiEventMap;

--- a/packages/cli/src/events/relays/telemetry.event-relay.ts
+++ b/packages/cli/src/events/relays/telemetry.event-relay.ts
@@ -164,6 +164,8 @@ export class TelemetryEventRelay extends EventRelay {
 			'workflow-activated': (event) => this.workflowActivated(event),
 			'workflow-deactivated': (event) => this.workflowDeactivated(event),
 			'server-started': async () => await this.serverStarted(),
+			'server-cli-import': (event) => this.serverCliImportCommand(event),
+			'server-cli-export': (event) => this.serverCliExportCommand(event),
 			'session-started': (event) => this.sessionStarted(event),
 			'instance-stopped': () => this.instanceStopped(),
 			'instance-owner-setup': async (event) => await this.instanceOwnerSetup(event),
@@ -1898,6 +1900,38 @@ export class TelemetryEventRelay extends EventRelay {
 		this.telemetry.track('User deleted custom role', {
 			user_id: userId,
 			role_slug: roleSlug,
+		});
+	}
+
+	// #endregion
+
+	// #region Server CLI
+
+	private serverCliImportCommand({
+		activeState,
+		workflowCount,
+		separate,
+	}: RelayEventMap['server-cli-import']) {
+		this.telemetry.track('User imported workflows via server cli', {
+			active_state: activeState,
+			workflow_count: workflowCount,
+			separate,
+		});
+	}
+
+	private serverCliExportCommand({
+		selector,
+		published,
+		separate,
+		backup,
+		workflowCount,
+	}: RelayEventMap['server-cli-export']) {
+		this.telemetry.track('User exported workflows via server cli', {
+			selector,
+			published,
+			separate,
+			backup,
+			workflow_count: workflowCount,
 		});
 	}
 


### PR DESCRIPTION
## Summary

Adds two telemetry events to track usage of the import:workflow and export:workflow server CLI commands.

- `server-cli-import` — emitted after a successful `n8n import:workflow` run. Captures activeState (whether imported workflows are activated based on their JSON or forced inactive), workflowCount (number of workflows imported), and separate (whether files were read from a directory).
- `server-cli-export` — emitted after a successful `n8n export:workflow` run. Captures selector (all | id | projectId), published (whether the published/active version was exported), separate, backup, and workflowCount.
Both events fire only on success — early-return validation paths and file I/O errors skip the emit.


## Related Linear tickets, Github issues, and Community forum posts

Closes LIGO-719

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
  - No unit tests added, as unit test setup for these commands is lacking a bunch of mocks.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32297">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

