### PR TITLE
ci: Fix forced patch PR creation on dispatch

### DIFF
--- a/.github/workflows/release-create-patch-pr.yml
+++ b/.github/workflows/release-create-patch-pr.yml
@@ -8,6 +8,11 @@ on:
         description: 'Release Track'
         required: true
         type: string
+      force:
+        description: 'Create the PR even when there are no actionable commits'
+        required: false
+        type: boolean
+        default: false
 
   workflow_dispatch:
     inputs:
@@ -16,6 +21,11 @@ on:
         required: true
         type: choice
         options: [stable, beta, v1]
+      force:
+        description: 'Create the PR even when there are no actionable commits'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   determine-version-info:
@@ -46,7 +56,7 @@ jobs:
   skip-release-pr:
     name: Skip release PR (no new commits)
     needs: [determine-version-info]
-    if: needs.determine-version-info.outputs.should_update != 'true' && github.event_name != 'workflow_dispatch'
+    if: needs.determine-version-info.outputs.should_update != 'true' && !inputs.force
     runs-on: ubuntu-latest
     steps:
       - name: Log skip reason
@@ -55,7 +65,7 @@ jobs:
   create-release-pr:
     name: Create release PR
     needs: [determine-version-info]
-    if: needs.determine-version-info.outputs.should_update == 'true' || github.event_name == 'workflow_dispatch'
+    if: needs.determine-version-info.outputs.should_update == 'true' || inputs.force
     uses: ./.github/workflows/release-create-pr.yml
     secrets: inherit
     with:

--- a/.github/workflows/release-schedule-patch-prs.yml
+++ b/.github/workflows/release-schedule-patch-prs.yml
@@ -15,3 +15,4 @@ jobs:
     secrets: inherit
     with:
       track: ${{ matrix.track }}
+      force: ${{ github.event_name == 'workflow_dispatch' }}


### PR DESCRIPTION
## Summary

The skip/create gating in `release-create-patch-pr.yml` was keyed on `github.event_name`. Because that workflow is invoked via `workflow_call` from the `release-schedule-patch-prs.yml` matrix parent, `github.event_name` inside it reflects the **caller's** trigger, not its own — it is never `workflow_call`.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up to #32032.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32298">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

