### PR TITLE
fix(core): Support multi-word queries in node-catalog search (no-changelog)

### DIFF
--- a/packages/@n8n/ai-utilities/src/node-catalog/__tests__/search-engine.test.ts
+++ b/packages/@n8n/ai-utilities/src/node-catalog/__tests__/search-engine.test.ts
@@ -770,6 +770,30 @@ describe('CodeBuilderNodeSearchEngine', () => {
 			expect(results[0].builderHintMessage).toBe('Use with output parser for structured output');
 		});
 
+		it('should filter out null/undefined entries in builderHint.inputs', () => {
+			const agentNode = createNodeType({
+				name: '@n8n/n8n-nodes-langchain.agent',
+				displayName: 'AI Agent',
+				builderHint: {
+					inputs: {
+						ai_languageModel: { required: true },
+						// JSON-sourced data can carry `null`; a Partial config can be `undefined`.
+						// Both must be skipped instead of throwing on `config.required`.
+						ai_memory: undefined,
+						ai_tool: null,
+					} as unknown as NonNullable<INodeTypeDescription['builderHint']>['inputs'],
+				},
+			});
+			const engine = new CodeBuilderNodeSearchEngine([agentNode]);
+
+			const results = engine.searchByName('agent');
+
+			expect(results).toHaveLength(1);
+			expect(results[0].subnodeRequirements).toEqual([
+				{ connectionType: 'ai_languageModel', required: true },
+			]);
+		});
+
 		it('should not include subnodeRequirements for nodes without builderHint.inputs', () => {
 			const basicNode = createNodeType({
 				name: 'n8n-nodes-base.httpRequest',

--- a/packages/@n8n/ai-utilities/src/node-catalog/__tests__/search-engine.test.ts
+++ b/packages/@n8n/ai-utilities/src/node-catalog/__tests__/search-engine.test.ts
@@ -253,6 +253,114 @@ describe('CodeBuilderNodeSearchEngine', () => {
 		});
 	});
 
+	describe('searchByName - multi-word queries', () => {
+		// Nodes representative of the real-world queries that previously returned
+		// no results (tracked via MCP `queriesWithNoResults` telemetry). Before the
+		// multi-word split, sublimeSearch matched the whole query as one ordered
+		// subsequence against a single field, so none of these resolved.
+		const multiWordNodes = [
+			createNodeType({
+				name: 'n8n-nodes-base.webhook',
+				displayName: 'Webhook',
+				description: 'Starts the workflow on a webhook call',
+				group: ['trigger'],
+			}),
+			createNodeType({
+				name: 'n8n-nodes-base.telegram',
+				displayName: 'Telegram',
+				description: 'Sends data to Telegram',
+			}),
+			createNodeType({
+				name: '@n8n/n8n-nodes-langchain.lmChatAnthropic',
+				displayName: 'Anthropic Chat Model',
+				description: 'Language model from Anthropic',
+				outputs: ['ai_languageModel'],
+			}),
+			createNodeType({
+				name: 'n8n-nodes-base.set',
+				displayName: 'Edit Fields',
+				description: 'Modify, add, or remove item fields',
+			}),
+			createNodeType({
+				name: 'n8n-nodes-base.code',
+				displayName: 'Code',
+				description: 'Run custom JavaScript code',
+			}),
+			createNodeType({
+				name: 'n8n-nodes-base.gmail',
+				displayName: 'Gmail',
+				description: 'Consume the Gmail API',
+			}),
+			createNodeType({
+				name: 'n8n-nodes-base.googleSheets',
+				displayName: 'Google Sheets',
+				description: 'Read, update and write data to Google Sheets',
+			}),
+			createNodeType({
+				name: 'n8n-nodes-base.slack',
+				displayName: 'Slack',
+				description: 'Consume the Slack API',
+			}),
+			createNodeType({
+				name: '@n8n/n8n-nodes-langchain.agent',
+				displayName: 'AI Agent',
+				description: 'Generates an action plan and executes it',
+			}),
+			createNodeType({
+				name: '@n8n/n8n-nodes-langchain.memoryBufferWindow',
+				displayName: 'Simple Memory',
+				description: 'Stores the last N messages in a buffer window',
+				codex: { alias: ['Window Buffer Memory'] },
+				outputs: ['ai_memory'],
+			}),
+		];
+
+		let engine: CodeBuilderNodeSearchEngine;
+
+		beforeEach(() => {
+			engine = new CodeBuilderNodeSearchEngine(multiWordNodes);
+		});
+
+		it.each([
+			['webhook trigger', 'n8n-nodes-base.webhook'],
+			['telegram send message', 'n8n-nodes-base.telegram'],
+			['anthropic claude', '@n8n/n8n-nodes-langchain.lmChatAnthropic'],
+			['set edit fields', 'n8n-nodes-base.set'],
+			['code javascript', 'n8n-nodes-base.code'],
+			['gmail send email', 'n8n-nodes-base.gmail'],
+			['google sheets append', 'n8n-nodes-base.googleSheets'],
+			['slack send message', 'n8n-nodes-base.slack'],
+			['langchain agent', '@n8n/n8n-nodes-langchain.agent'],
+			['ai agent langchain', '@n8n/n8n-nodes-langchain.agent'],
+			['memory buffer window', '@n8n/n8n-nodes-langchain.memoryBufferWindow'],
+			['window buffer memory', '@n8n/n8n-nodes-langchain.memoryBufferWindow'],
+		])('resolves "%s" to %s (previously no results)', (query, expectedNodeName) => {
+			const results = engine.searchByName(query);
+
+			expect(results.map((r) => r.name)).toContain(expectedNodeName);
+		});
+
+		it('splits a multi-word query and merges per-term matches', () => {
+			// "webhook" matches the trigger, "trigger" alone does not narrow it away
+			const results = engine.searchByName('webhook trigger');
+
+			expect(results.map((r) => r.name)).toContain('n8n-nodes-base.webhook');
+		});
+
+		it('matches an alias term within a multi-word query', () => {
+			// Only the alias "Window Buffer Memory" carries these words in this order
+			const results = engine.searchByName('window buffer memory');
+
+			expect(results.map((r) => r.name)).toContain('@n8n/n8n-nodes-langchain.memoryBufferWindow');
+		});
+
+		it('still returns no results for genuinely unknown multi-word queries', () => {
+			const results = engine.searchByName('nonexistent imaginary integration');
+
+			expect(results).toEqual([]);
+		});
+	});
+
 	describe('searchByConnectionType', () => {
 		it('should find nodes with exact connection type match', () => {
 			const results = searchEngine.searchByConnectionType(NodeConnectionTypes.AiTool);

--- a/packages/@n8n/ai-utilities/src/node-catalog/search-engine.ts
+++ b/packages/@n8n/ai-utilities/src/node-catalog/search-engine.ts
@@ -95,17 +95,19 @@ function getLatestVersion(version: number | number[]): number {
 	return Array.isArray(version) ? Math.max(...version) : version;
 }
 
-/**
- * Extract subnode requirements from builderHint.inputs
- */
 function extractSubnodeRequirements(inputs?: BuilderHintInputs): SubnodeRequirement[] {
 	if (!inputs) return [];
 
-	return Object.entries(inputs).map(([connectionType, config]) => ({
-		connectionType,
-		required: config.required,
-		...(config.displayOptions && { displayOptions: config.displayOptions }),
-	}));
+	return Object.entries(inputs)
+		.filter(
+			(entry): entry is [string, NonNullable<(typeof entry)[1]>] =>
+				entry[1] !== null && entry[1] !== undefined,
+		)
+		.map(([connectionType, config]) => ({
+			connectionType,
+			required: config.required,
+			...(config.displayOptions && { displayOptions: config.displayOptions }),
+		}));
 }
 
 function dedupeNodes(nodes: LeanNodeTypeDescription[]): LeanNodeTypeDescription[] {

--- a/packages/@n8n/ai-utilities/src/node-catalog/search-engine.ts
+++ b/packages/@n8n/ai-utilities/src/node-catalog/search-engine.ts
@@ -41,11 +41,11 @@ const DEFAULT_SUBNODES: Record<string, string[]> = {
 };
 
 /**
- * Search keys configuration for sublimeSearch.
- * Keys are ordered by importance with corresponding weights.
+ * Search keys for sublimeSearch.
  *
- * NOTE: `description` is intentionally NOT a sublimeSearch key. This mirrors the
- * Instance AI `NodeSearchEngine`, which `fuzzySearchNodes` below was ported from.
+ * `description` is intentionally excluded: with the per-word splitting in
+ * `fuzzySearchNodes`, fuzzy-matching short terms against long descriptions is too
+ * noisy (the `descriptionMatchScore` substring fallback covers it instead).
  */
 const NODE_SEARCH_KEYS = [
 	{ key: 'displayName', weight: 1.5 },

--- a/packages/@n8n/ai-utilities/src/node-catalog/search-engine.ts
+++ b/packages/@n8n/ai-utilities/src/node-catalog/search-engine.ts
@@ -41,14 +41,16 @@ const DEFAULT_SUBNODES: Record<string, string[]> = {
 };
 
 /**
- * Search keys configuration for sublimeSearch
- * Keys are ordered by importance with corresponding weights
+ * Search keys configuration for sublimeSearch.
+ * Keys are ordered by importance with corresponding weights.
+ *
+ * NOTE: `description` is intentionally NOT a sublimeSearch key. This mirrors the
+ * Instance AI `NodeSearchEngine`, which `fuzzySearchNodes` below was ported from.
  */
 const NODE_SEARCH_KEYS = [
 	{ key: 'displayName', weight: 1.5 },
 	{ key: 'name', weight: 1.3 },
 	{ key: 'codex.alias', weight: 1.0 },
-	{ key: 'description', weight: 0.7 },
 ];
 
 /**
@@ -59,6 +61,26 @@ function getTypeName(nodeName: string): string {
 	if (!nodeName) return '';
 	const lastDotIndex = nodeName.lastIndexOf('.');
 	return lastDotIndex >= 0 ? nodeName.substring(lastDotIndex + 1) : nodeName;
+}
+
+/**
+ * Count how many query terms appear as substrings of a node's description.
+ * Used as a fallback for nodes the fuzzy/name passes miss, since `description`
+ * is no longer a sublimeSearch key (see {@link NODE_SEARCH_KEYS}).
+ */
+function descriptionMatchScore(
+	description: string | undefined,
+	queryLower: string,
+	queryTerms: string[],
+): number {
+	if (!description) return 0;
+	const descriptionLower = description.toLowerCase();
+	if (queryTerms.length === 0) return descriptionLower.includes(queryLower) ? 1 : 0;
+	let matches = 0;
+	for (const term of queryTerms) {
+		if (descriptionLower.includes(term)) matches += 1;
+	}
+	return matches;
 }
 
 /**
@@ -123,10 +145,117 @@ export class CodeBuilderNodeSearchEngine {
 	}
 
 	/**
-	 * Search nodes by name, display name, or description
-	 * Always return the latest version of a node
+	 * Fuzzy-search a list of nodes by query, handling multi-word queries by
+	 * splitting into individual terms and merging results. Falls back to
+	 * description keyword matching and direct type-name / display-name matching
+	 * for nodes the fuzzy search missed.
+	 *
+	 * Ported from the Instance AI `NodeSearchEngine` so code-builder / MCP node
+	 * search resolves natural-language multi-word queries (e.g. "telegram send
+	 * message", "ai agent langchain") instead of returning no results — these
+	 * previously failed because sublimeSearch matched the whole query string as a
+	 * single ordered character subsequence against one field.
+	 */
+	private fuzzySearchNodes(
+		query: string,
+		candidates: LeanNodeTypeDescription[],
+		limit?: number,
+	): Array<{ item: LeanNodeTypeDescription; score: number }> {
+		const queryLower = query.toLowerCase().trim();
+		const queryTerms = queryLower.split(/\s+/).filter((t) => t.length > 1);
+		const isMultiWord = queryTerms.length > 1;
+
+		type ScoredNode = { item: LeanNodeTypeDescription; score: number };
+		let searchResults: ScoredNode[];
+
+		// For multi-word queries, search each term individually then merge.
+		// sublimeSearch breaks down on multi-word queries because it tries to
+		// fuzzy-match the entire string as one character sequence.
+		if (isMultiWord) {
+			const scoreMap = new Map<string, ScoredNode>();
+			for (const term of queryTerms) {
+				const termResults = sublimeSearch<LeanNodeTypeDescription>(
+					term,
+					candidates,
+					NODE_SEARCH_KEYS,
+				).slice(0, limit);
+				for (const r of termResults) {
+					const existing = scoreMap.get(r.item.name);
+					if (!existing || r.score > existing.score) {
+						scoreMap.set(r.item.name, { item: r.item, score: r.score });
+					}
+				}
+			}
+			searchResults = [...scoreMap.values()];
+		} else {
+			searchResults = sublimeSearch<LeanNodeTypeDescription>(query, candidates, NODE_SEARCH_KEYS);
+		}
+
+		const fuzzyResultNames = new Set(searchResults.map((r) => r.item.name));
+
+		// Description keyword fallback for nodes the fuzzy pass missed
+		const remainingDescriptionMatches =
+			limit === undefined ? Number.POSITIVE_INFINITY : Math.max(0, limit - searchResults.length);
+		if (remainingDescriptionMatches > 0) {
+			const descriptionResults: ScoredNode[] = [];
+			for (const item of candidates) {
+				if (fuzzyResultNames.has(item.name)) continue;
+				const score = descriptionMatchScore(item.description, queryLower, queryTerms);
+				if (score === 0) continue;
+				descriptionResults.push({ item, score });
+				fuzzyResultNames.add(item.name);
+				if (descriptionResults.length >= remainingDescriptionMatches) break;
+			}
+			searchResults = [...searchResults, ...descriptionResults];
+		}
+
+		// Direct type name / display name match — catches nodes fuzzy search missed.
+		// `displayName` is guarded against undefined to tolerate malformed node types.
+		const typeNameMatches = candidates
+			.filter((node) => {
+				if (fuzzyResultNames.has(node.name)) return false;
+				const typeName = getTypeName(node.name).toLowerCase();
+				const displayName = (node.displayName ?? '').toLowerCase();
+				if (typeName === queryLower || displayName === queryLower) return true;
+				return queryTerms.some(
+					(term) =>
+						typeName === term ||
+						typeName.includes(term) ||
+						displayName === term ||
+						displayName.includes(term),
+				);
+			})
+			.map((item) => ({ item, score: 0 }));
+
+		// Merge and sort: exact type/display name matches first, then by fuzzy score
+		const allResults = [...searchResults, ...typeNameMatches];
+		allResults.sort((a, b) => {
+			const typeNameA = getTypeName(a.item.name).toLowerCase();
+			const displayNameA = (a.item.displayName ?? '').toLowerCase();
+			const typeNameB = getTypeName(b.item.name).toLowerCase();
+			const displayNameB = (b.item.displayName ?? '').toLowerCase();
+			const exactA =
+				typeNameA === queryLower ||
+				displayNameA === queryLower ||
+				queryTerms.some((t) => typeNameA === t || displayNameA === t);
+			const exactB =
+				typeNameB === queryLower ||
+				displayNameB === queryLower ||
+				queryTerms.some((t) => typeNameB === t || displayNameB === t);
+			if (exactA && !exactB) return -1;
+			if (!exactA && exactB) return 1;
+			return b.score - a.score;
+		});
+
+		return allResults;
+	}
+
+	/**
+	 * Search nodes by name, display name, alias, or description.
+	 * Always return the latest version of a node.
 	 * @param query - The search query string
 	 * @param limit - Maximum number of results to return
+	 * @param nodeFilter - Optional predicate restricting which node IDs are searched
 	 * @returns Array of matching nodes sorted by relevance
 	 */
 	searchByName(
@@ -138,36 +267,7 @@ export class CodeBuilderNodeSearchEngine {
 			? this.nodeTypes.filter((node) => nodeFilter(node.name))
 			: this.nodeTypes;
 
-		// Use sublimeSearch for fuzzy matching
-		const searchResults = sublimeSearch<LeanNodeTypeDescription>(
-			query,
-			nodeTypes,
-			NODE_SEARCH_KEYS,
-		);
-
-		const queryLower = query.toLowerCase().trim();
-		const fuzzyResultNames = new Set(searchResults.map((r) => r.item.name));
-
-		// Direct type name match on all nodeTypes (catches nodes sublimeSearch ranked too low)
-		const typeNameMatches = nodeTypes
-			.filter((node) => {
-				if (fuzzyResultNames.has(node.name)) return false;
-				return getTypeName(node.name).toLowerCase() === queryLower;
-			})
-			.map((item) => ({ item, score: 0 }));
-
-		// Merge and sort: exact type name matches first, then by fuzzy score
-		const allResults = [...searchResults, ...typeNameMatches];
-		allResults.sort((a, b) => {
-			const exactA = getTypeName(a.item.name).toLowerCase() === queryLower;
-			const exactB = getTypeName(b.item.name).toLowerCase() === queryLower;
-			if (exactA && !exactB) return -1;
-			if (!exactA && exactB) return 1;
-			return b.score - a.score;
-		});
-
-		// Apply limit and map to result format
-		return allResults
+		return this.fuzzySearchNodes(query, nodeTypes, limit)
 			.slice(0, limit)
 			.map(
 				({
@@ -238,9 +338,9 @@ export class CodeBuilderNodeSearchEngine {
 				});
 		}
 
-		// Apply name filter using sublimeSearch
+		// Apply name filter using the same multi-word-aware fuzzy search as searchByName
 		const nodeTypesOnly = nodesWithConnectionType.map((result) => result.nodeType);
-		const nameFilteredResults = sublimeSearch(nameFilter, nodeTypesOnly, NODE_SEARCH_KEYS);
+		const nameFilteredResults = this.fuzzySearchNodes(nameFilter, nodeTypesOnly, limit);
 
 		// Combine connection score with name score
 		return nameFilteredResults


### PR DESCRIPTION
## Summary
MCP's `search_workflow_nodes` returned **no results** for common multi-word queries — e.g. `telegram send message`, `gmail send email`, `google sheets append`, `ai agent langchain` as visible in the telemetry:

<img width="316" height="281" alt="image" src="https://github.com/user-attachments/assets/4a69510e-8ec1-45e0-b9fd-c2f8abe95411" />


Cause: the code-builder/MCP search engine (`CodeBuilderNodeSearchEngine` in `@n8n/ai-utilities`) passed the whole query string to `sublimeSearch`, which only matches an ordered character subsequence of a single field — so natural-language multi-word queries never matched.

Fix — port the multi-word algorithm already used by Instance AI's `NodeSearchEngine`:
- split the query into terms, fuzzy-search each, and merge by best score;
- add substring fallbacks on description and type/display name;
- drop `description` from the fuzzy keys (per-word fuzzy matching of long descriptions is noisy; the substring fallback covers it).

Also hardens `extractSubnodeRequirements` to skip nullish `builderHint.inputs` entries.

Both engines are now algorithmically identical; extracting the shared matcher is tracked in ADO-5421.


## How to test
Run `search_workflow_nodes` with multi-word queries (`telegram send message`, `gmail send email`, `ai agent langchain`) — each now returns the expected node instead of "No nodes found". Single-word queries are unchanged.

Unit tests:
```bash
pnpm --filter @n8n/ai-utilities test src/node-catalog/__tests__/search-engine.test.ts
```

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32299">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

