### PR TITLE
fix(core): Request protected-resource scopes during MCP OAuth2 DCR

### DIFF
--- a/packages/cli/src/oauth/__tests__/oauth.service.test.ts
+++ b/packages/cli/src/oauth/__tests__/oauth.service.test.ts
@@ -3952,6 +3952,115 @@ describe('OauthService', () => {
 			});
 		});
 
+		describe('scope discovery from protected-resource metadata', () => {
+			// Real-world shape captured from the Atlassian remote MCP server: the
+			// protected-resource document (RFC 9728) advertises the scopes, while the
+			// authorization-server metadata (RFC 8414) omits scopes_supported entirely.
+			const ATLASSIAN_SERVER_URL = 'https://mcp.atlassian.com/v1/mcp/authv2';
+			const ATLASSIAN_AUTH_SERVER = 'https://auth.atlassian.com/VCeDsk8ZHncYF1g234fKtc4lNipbBhu3';
+			const RESOURCE_SCOPES = ['read:jira-work', 'search:confluence', 'offline_access'];
+
+			const mockProtectedResourceDiscovery = (scopes?: string[]) => {
+				jest.mocked(axios.get).mockResolvedValueOnce({
+					data: {
+						resource: ATLASSIAN_SERVER_URL,
+						authorization_servers: [ATLASSIAN_AUTH_SERVER],
+						...(scopes ? { scopes_supported: scopes } : {}),
+					},
+				});
+			};
+
+			// Authorization-server metadata WITHOUT scopes_supported and WITHOUT
+			// token_endpoint_auth_methods_supported, advertising S256 (→ PKCE).
+			const mockAuthServerWithoutScopes = () => {
+				jest.mocked(axios.get).mockResolvedValueOnce({
+					data: {
+						issuer: 'https://auth.atlassian.com',
+						authorization_endpoint: 'https://auth.atlassian.com/authorize',
+						token_endpoint: 'https://auth.atlassian.com/oauth/token',
+						registration_endpoint: 'https://auth.atlassian.com/dcr/register',
+						grant_types_supported: ['authorization_code', 'refresh_token'],
+						code_challenge_methods_supported: ['S256'],
+					},
+				});
+				jest.mocked(axios.post).mockResolvedValueOnce({
+					data: { client_id: 'registered-client-id' },
+				});
+			};
+
+			const runAtlassianFlow = async (credentialOverrides: Partial<OAuth2CredentialData> = {}) => {
+				const { ClientOAuth2 } = await import('@n8n/client-oauth2');
+				const pkceChallenge = await import('pkce-challenge');
+				jest.mocked(pkceChallenge.default).mockResolvedValue({
+					code_verifier: 'code_verifier',
+					code_challenge: 'code_challenge',
+				});
+				await mockClientOAuth2UriFromOptions();
+				jest.spyOn(service, 'encryptAndSaveData').mockResolvedValue(undefined);
+				jest.spyOn(service, 'getOAuthCredentials').mockResolvedValue(
+					// Under DCR the `scope` field is hidden and defaults to '' — the user
+					// cannot supply scopes, so the flow depends entirely on discovery.
+					makeDcrCredentials({
+						serverUrl: ATLASSIAN_SERVER_URL,
+						scope: '',
+						...credentialOverrides,
+					}),
+				);
+
+				await service.generateAOauth2AuthUri(credential, {
+					cid: credential.id,
+					origin: 'static-credential',
+					userId: 'user-id',
+				});
+
+				const registerPayload = (axios.post as jest.Mock).mock.calls[0][1];
+				const clientOptions = jest.mocked(ClientOAuth2).mock.calls[0][0];
+				const persisted = (service.encryptAndSaveData as jest.Mock).mock.calls[0][1];
+				return { registerPayload, clientOptions, persisted };
+			};
+
+			it('requests protected-resource scopes when the auth server omits scopes_supported', async () => {
+				mockProtectedResourceDiscovery(RESOURCE_SCOPES);
+				mockAuthServerWithoutScopes();
+
+				const { registerPayload, clientOptions, persisted } = await runAtlassianFlow();
+
+				// The auth server advertises S256 and omits token_endpoint_auth_methods_supported,
+				// so the public-client PKCE grant is selected.
+				expect(persisted.grantType).toBe('pkce');
+				// The scopes advertised by the protected resource are registered and requested.
+				expect(registerPayload.scope).toBe(RESOURCE_SCOPES.join(' '));
+				expect(persisted.scope).toBe(RESOURCE_SCOPES.join(' '));
+				// The authorize request carries the discovered scopes (space-delimited).
+				expect(clientOptions.scopes?.join(clientOptions.scopesSeparator)).toBe(
+					RESOURCE_SCOPES.join(' '),
+				);
+			});
+
+			it('falls back to authorization-server scopes when the protected resource omits them', async () => {
+				mockProtectedResourceDiscovery(); // no scopes_supported on the resource
+				jest.mocked(axios.get).mockResolvedValueOnce({
+					data: {
+						issuer: 'https://auth.atlassian.com',
+						authorization_endpoint: 'https://auth.atlassian.com/authorize',
+						token_endpoint: 'https://auth.atlassian.com/oauth/token',
+						registration_endpoint: 'https://auth.atlassian.com/dcr/register',
+						grant_types_supported: ['authorization_code', 'refresh_token'],
+						token_endpoint_auth_methods_supported: ['client_secret_basic'],
+						scopes_supported: ['openid', 'profile'],
+					},
+				});
+				jest.mocked(axios.post).mockResolvedValueOnce({
+					data: { client_id: 'registered-client-id', client_secret: 'registered-client-secret' },
+				});
+
+				const { registerPayload, persisted } = await runAtlassianFlow();
+
+				expect(registerPayload.scope).toBe('openid profile');
+				expect(persisted.scope).toBe('openid profile');
+			});
+		});
+
 		describe('convertCredentialToOptions', () => {
 			it('should include resource when credential has resource set', () => {
 				const options = (service as any).convertCredentialToOptions({

--- a/packages/cli/src/oauth/oauth.service.ts
+++ b/packages/cli/src/oauth/oauth.service.ts
@@ -693,8 +693,10 @@ export class OauthService {
 	): Promise<{
 		authorizationServerUrl: string;
 		discoveredResource: string | undefined;
+		discoveredScopes: string[] | undefined;
 	}> {
 		let discoveredResource: string | undefined;
+		let discoveredScopes: string[] | undefined;
 		let suppliedResourceUrl: string | undefined;
 
 		if (oauthCredentials.resourceUrl) {
@@ -717,11 +719,13 @@ export class OauthService {
 			}
 
 			discoveredResource = protectedResourceMetadata.resource;
+			discoveredScopes = protectedResourceMetadata.scopes_supported;
 
 			this.logger.debug('Protected resource discovery succeeded', {
 				resourceUrl: oauthCredentials.serverUrl,
 				...(oauthCredentials.useDynamicClientRegistration ? { authorizationServerUrl } : {}),
 				discoveredResource,
+				discoveredScopes,
 			});
 		} catch (error) {
 			if (error instanceof InvalidOAuthUrlError) {
@@ -753,7 +757,7 @@ export class OauthService {
 			csrfData.resource = resolvedResource;
 		}
 
-		return { authorizationServerUrl, discoveredResource };
+		return { authorizationServerUrl, discoveredResource, discoveredScopes };
 	}
 	/**
 	 * Mutates `csrfData` to include a `bindingHash` when browser binding is
@@ -786,17 +790,16 @@ export class OauthService {
 		const toUpdate: ICredentialDataDecryptedObject = {};
 
 		let authorizationServerUrl = oauthCredentials.serverUrl;
+		let discoveredScopes: string[] | undefined;
 
 		if (oauthCredentials.serverUrl) {
 			// Validate serverUrl to prevent SSRF attacks before any HTTP requests
 			this.validateOAuthUrlOrThrow(oauthCredentials.serverUrl);
 
-			const { authorizationServerUrl: resolvedAuthUrl } = await this.discoverAndResolveResource(
-				oauthCredentials,
-				csrfData,
-				authorizationServerUrl!,
-			);
+			const { authorizationServerUrl: resolvedAuthUrl, discoveredScopes: resolvedScopes } =
+				await this.discoverAndResolveResource(oauthCredentials, csrfData, authorizationServerUrl!);
 			authorizationServerUrl = resolvedAuthUrl;
+			discoveredScopes = resolvedScopes;
 		} else if (oauthCredentials.resourceUrl) {
 			// Static credential with no serverUrl – validate resource URL and wire it through
 			const resolvedResource = this.validateResourceUrlOrThrow(oauthCredentials.resourceUrl);
@@ -809,6 +812,7 @@ export class OauthService {
 				oauthCredentials,
 				authorizationServerUrl!,
 				toUpdate,
+				discoveredScopes,
 			);
 		}
 
@@ -863,6 +867,7 @@ export class OauthService {
 		oauthCredentials: OAuth2CredentialData,
 		authorizationServerUrl: string,
 		toUpdate: ICredentialDataDecryptedObject,
+		discoveredResourceScopes?: string[],
 	): Promise<void> {
 		// Step 2: Discover Authorization Server Metadata (RFC 8414 / OpenID Connect)
 		const dcrAuthorizationServerUrl = authorizationServerUrl ?? oauthCredentials.serverUrl;
@@ -931,7 +936,13 @@ export class OauthService {
 		oauthCredentials.accessTokenUrl = token_endpoint;
 		toUpdate.authUrl = authorization_endpoint;
 		toUpdate.accessTokenUrl = token_endpoint;
-		const scope = scopes_supported ? scopes_supported.join(' ') : undefined;
+		// Prefer the scopes advertised by the protected resource (RFC 9728) over the
+		// authorization server's scopes_supported (RFC 8414). Some servers only
+		// advertise the required scopes on the protected resource document.
+		const effectiveScopes = discoveredResourceScopes?.length
+			? discoveredResourceScopes
+			: scopes_supported;
+		const scope = effectiveScopes?.length ? effectiveScopes.join(' ') : undefined;
 		if (scope) {
 			oauthCredentials.scope = scope;
 			toUpdate.scope = scope;
@@ -1175,7 +1186,7 @@ export class OauthService {
 	 */
 	private async discoverProtectedResourceMetadata(
 		resourceUrl: string,
-	): Promise<{ authorization_servers: string[]; resource?: string }> {
+	): Promise<{ authorization_servers: string[]; resource?: string; scopes_supported?: string[] }> {
 		// Validate input to prevent SSRF (defense-in-depth)
 		this.validateOAuthUrlOrThrow(resourceUrl);
 
@@ -1215,9 +1226,18 @@ export class OauthService {
 						typeof rawResource === 'string'
 							? this.validateResourceUrlOrThrow(rawResource)
 							: undefined;
+					// Per RFC 9728 the protected resource advertises the scopes required to
+					// access it. Some authorization servers (e.g. Atlassian) omit
+					// scopes_supported from their RFC 8414 metadata, so these are the only
+					// scopes available for the request.
+					const rawScopes = (data as Record<string, unknown>).scopes_supported;
+					const scopes_supported = Array.isArray(rawScopes)
+						? rawScopes.filter((s): s is string => typeof s === 'string')
+						: undefined;
 					return {
 						authorization_servers: data.authorization_servers,
 						...(resource ? { resource } : {}),
+						...(scopes_supported?.length ? { scopes_supported } : {}),
 					};
 				}
 			} catch (error) {


### PR DESCRIPTION
## Summary

When connecting the **MCP Client Tool** node to an MCP server using OAuth 2.1 + Dynamic Client Registration (DCR), n8n derived the requested OAuth scopes **only** from the authorization server's RFC 8414 metadata (`scopes_supported`). Some MCP servers advertise the required scopes **only** on the RFC 9728 protected-resource document, leaving `scopes_supported` off their authorization-server metadata. Example: Atlassian/Jira

In that case n8n requested no scopes (falling back to an empty/`openid` scope), so the resulting token had no access to the protected resource and the node could not connect.

This PR propagates `scopes_supported` from the protected-resource metadata through the DCR flow and **prefers it** over the authorization server's `scopes_supported`:

- `discoverProtectedResourceMetadata` now returns `scopes_supported`
- `discoverAndResolveResource` surfaces the discovered scopes to the caller
- `generateAOauth2AuthUri` threads them into `performDynamicClientRegistration`, which uses resource-metadata scopes when present, otherwise the authorization-server scopes (existing behaviour)

The discovered scopes are carried into both the DCR `register` payload and the authorization request.


## How to test

Unit tests in `packages/cli/src/oauth/__tests__/oauth.service.test.ts` simulate the real-world discovery shape (scopes on the protected resource, none on the authorization server):

- `requests protected-resource scopes when the auth server omits scopes_supported` — the DCR register payload and authorize request now carry the discovered scopes
- `falls back to authorization-server scopes when the protected resource omits them` — regression guard for the existing path

```
cd packages/cli && pnpm test src/oauth/__tests__/oauth.service.test.ts
```

End-to-end (needs an Atlassian account): create an **MCP OAuth2 API** credential with Dynamic Client Registration enabled, server URL `https://mcp.atlassian.com/v1/mcp/authv2`, run the OAuth connect flow, and confirm the consent screen shows the Jira/Confluence scopes and the MCP Client node lists tools.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5217

fixes #31887

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32300">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->