### PR TITLE
fix(core): Surface form submission errors instead of failing silently

### DIFF
--- a/packages/cli/src/webhooks/__tests__/webhook-form-data.test.ts
+++ b/packages/cli/src/webhooks/__tests__/webhook-form-data.test.ts
@@ -5,6 +5,7 @@ import { createServer } from 'node:http';
 import request from 'supertest';
 import type TestAgent from 'supertest/lib/agent';
 
+import { ContentTooLargeError } from '@/errors/response-errors/content-too-large.error';
 import { rawBodyReader } from '@/middlewares';
 
 import { createMultiFormDataParser } from '../webhook-form-data';
@@ -164,23 +165,22 @@ describe('webhook-form-data', () => {
 			testServer.assertHasBeenCalled();
 		});
 
-		it('should reject with an error when file exceeds maxFileSize', async () => {
+		it('should reject with a 413 error when a single file exceeds the limit', async () => {
 			const oneByteInMb = 1 / 1024 / 1024;
 			const parseFn = createMultiFormDataParser(oneByteInMb);
 
 			await testServer
 				.sendRequestToHandler(async (req) => {
-					await expect(parseFn(req)).rejects.toThrow(/maxFileSize/);
+					const rejection = parseFn(req);
+					await expect(rejection).rejects.toBeInstanceOf(ContentTooLargeError);
+					await expect(rejection).rejects.toMatchObject({ httpStatusCode: 413 });
 				})
 				.attach('file', oneKbData, 'file.txt');
 
 			testServer.assertHasBeenCalled();
 		});
 
-		it('should reject with an error when total file size exceeds limit', async () => {
-			// Simulate the real-world scenario from #28069: a file upload that
-			// exceeds the configured limit should surface the actual formidable
-			// error instead of silently returning empty data.
+		it('should reject with a 413 error when the total upload size exceeds the limit', async () => {
 			const twoKbData = Buffer.alloc(2 * 1024, 'x');
 			const oneKbInMb = 1 / 1024;
 			const parseFn = createMultiFormDataParser(oneKbInMb);
@@ -188,10 +188,8 @@ describe('webhook-form-data', () => {
 			await testServer
 				.sendRequestToHandler(async (req) => {
 					const rejection = parseFn(req);
-					await expect(rejection).rejects.toThrow();
-					await expect(rejection).rejects.toMatchObject({
-						httpCode: 413,
-					});
+					await expect(rejection).rejects.toBeInstanceOf(ContentTooLargeError);
+					await expect(rejection).rejects.toMatchObject({ httpStatusCode: 413 });
 				})
 				.attach('file', twoKbData, 'large-upload.bin');
 

--- a/packages/cli/src/webhooks/webhook-form-data.ts
+++ b/packages/cli/src/webhooks/webhook-form-data.ts
@@ -1,6 +1,22 @@
 import formidable from 'formidable';
 import type { IncomingMessage } from 'http';
 
+import { ContentTooLargeError } from '@/errors/response-errors/content-too-large.error';
+
+// formidable flags "payload too large" conditions (a file too big, the total
+// upload too big, too many files/fields) with `httpCode: 413`. n8n's error
+// classifier reads `httpStatusCode`, not formidable's `httpCode`, so without
+// this mapping these surface as a generic 500 instead of a 413.
+const isPayloadTooLargeError = (error: unknown): boolean =>
+	typeof error === 'object' && error !== null && 'httpCode' in error && error.httpCode === 413;
+
+const mapFormParseError = (error: unknown): Error => {
+	if (isPayloadTooLargeError(error)) {
+		return new ContentTooLargeError('The submitted form data exceeds the allowed size.');
+	}
+	return error instanceof Error ? error : new Error(String(error));
+};
+
 const normalizeFormData = <T>(values: Record<string, T | T[]>) => {
 	for (const key in values) {
 		const value = values[key];
@@ -30,7 +46,7 @@ export const createMultiFormDataParser = (maxFormDataSizeInMb: number) => {
 		return await new Promise((resolve, reject) => {
 			form.parse(req, (error, data, files) => {
 				if (error) {
-					reject(error);
+					reject(mapFormParseError(error));
 					return;
 				}
 				normalizeFormData(data);

--- a/packages/cli/templates/form-trigger.handlebars
+++ b/packages/cli/templates/form-trigger.handlebars
@@ -1086,13 +1086,20 @@
 								document.querySelector('#submitted-form').style.display = 'block';
 								document.querySelector('#submitted-header').textContent = 'Problem submitting response';
 								document.querySelector('#submitted-content').textContent =
-									'Please try again or contact support if the problem persists';
+									response.status === 413
+										? 'The files you are trying to upload are too large. Please reduce the total size and try again.'
+										: 'Please try again or contact support if the problem persists';
 							}
 
 							return;
 						})
 						.catch(function (error) {
 							console.error('Error:', error);
+							form.style.display = 'none';
+							document.querySelector('#submitted-form').style.display = 'block';
+							document.querySelector('#submitted-header').textContent = 'Problem submitting response';
+							document.querySelector('#submitted-content').textContent =
+								'The form could not be submitted. Please check your connection and try again, or contact support if the problem persists.';
 						})
 						.finally(() => {
 							if (window.location.href.includes('form-waiting')) {


### PR DESCRIPTION
## Summary

A Form Trigger submission that failed at the **network level** (e.g. an upstream proxy resetting the connection mid-upload of a large file) previously only did `console.error(...)` in the submit handler's `.catch`. The result: the submit button stayed in its loading state and the user got **no feedback at all** — the silent "form refreshed and lost my data" behaviour reported in the issue.

This PR surfaces those failures:

- **`form-trigger.handlebars`** — the `.catch` branch now shows the existing `#submitted-form` error card ("Problem submitting response") with a connection-oriented message, instead of failing silently. The HTTP-error branch additionally shows a size-specific message on a `413`.
- **`webhook-form-data.ts`** — uploads that exceed the configured size limit were being reported to the client as a generic **500**. formidable flags its "payload too large" conditions with `httpCode: 413`, but n8n's error classifier reads `httpStatusCode` (not formidable's `httpCode`), so the 413 was lost. These errors are now mapped to a `ContentTooLargeError` (413), so the form can surface a "files are too large" message for the self-hosted size-limit case too.

No behaviour change for successful submissions.

## How to test

Set up a workflow with a **Form Trigger** node containing a **File** input, then:

1. **Silent network failure (the reported bug, due to request failing on cloud):** open the form, fill it in, then in DevTools → Network use **Block request URL** on the form POST (or switch to Offline) and submit.
   - Before: button spins, nothing happens.
   - After: "Problem submitting response" card appears.
2. **Size limit → 413 message:** run n8n with `N8N_FORMDATA_FILE_SIZE_MAX=1` and upload a >1 MB file.
   - Before: generic "Problem submitting response".
   - After: "The files you are trying to upload are too large…".
3. A normal small submission still succeeds unchanged.

Unit tests: `cd packages/cli && pnpm jest src/webhooks/__tests__/webhook-form-data.test.ts`

## Related Linear tickets, Github issues, and Community forum posts

- https://linear.app/n8n/issue/NODE-5249
- fixes #32078

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32305">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->