### PR TITLE
fix(core): Allow publishing workflows that use private credentials

### DIFF
--- a/packages/cli/src/workflows/__tests__/workflow-validation.service.test.ts
+++ b/packages/cli/src/workflows/__tests__/workflow-validation.service.test.ts
@@ -678,6 +678,24 @@ describe('WorkflowValidationService', () => {
 				trigger: async () => ({ closeFunction: async () => {} }),
 			}) as unknown as INodeType;
 
+		const SYSTEM_RESOLVER = 'system-resolver';
+		const CUSTOM_RESOLVER = 'custom-resolver';
+
+		// The effective resolver is decided at the workflow level (settings override or
+		// the seeded system resolver); the credential's own resolverId is not consulted.
+		const useSystemResolver = () => {
+			mockDynamicCredentialsProxy.getSystemResolverId.mockReturnValue(SYSTEM_RESOLVER);
+			mockDynamicCredentialsProxy.getEffectiveResolverId.mockReturnValue(SYSTEM_RESOLVER);
+		};
+		const useCustomResolver = () => {
+			mockDynamicCredentialsProxy.getSystemResolverId.mockReturnValue(SYSTEM_RESOLVER);
+			mockDynamicCredentialsProxy.getEffectiveResolverId.mockReturnValue(CUSTOM_RESOLVER);
+		};
+		const useNoResolver = () => {
+			mockDynamicCredentialsProxy.getSystemResolverId.mockReturnValue(null);
+			mockDynamicCredentialsProxy.getEffectiveResolverId.mockReturnValue(null);
+		};
+
 		beforeEach(() => {
 			mockNodeTypes = mock<NodeTypes>();
 		});
@@ -706,7 +724,7 @@ describe('WorkflowValidationService', () => {
 			expect(result.isValid).toBe(true);
 		});
 
-		it('should return invalid when a dynamic credential has no resolver configured', async () => {
+		it('should return invalid when no resolver is configured', async () => {
 			const nodes: INode[] = [
 				createNode('Webhook', 'n8n-nodes-base.webhook', {
 					parameters: hooksParameters,
@@ -717,8 +735,9 @@ describe('WorkflowValidationService', () => {
 			];
 
 			mockCredentialsRepository.find.mockResolvedValue([
-				{ id: 'cred-1', name: 'My OAuth2', resolverId: null } as any,
+				{ id: 'cred-1', name: 'My OAuth2' } as any,
 			]);
+			useNoResolver();
 
 			const result = await service.validateDynamicCredentials(nodes, mockNodeTypes);
 
@@ -728,33 +747,30 @@ describe('WorkflowValidationService', () => {
 			expect(result.error).toContain('resolver');
 		});
 
-		it('should return valid when credential has no resolver but the proxy provides a system resolver', async () => {
+		it('should return valid when the proxy provides a system resolver and the trigger is compatible', async () => {
 			const nodes: INode[] = [
-				createNode('Webhook', 'n8n-nodes-base.webhook', {
-					parameters: hooksParameters,
-				}),
+				createNode('Manual', 'n8n-nodes-base.manualTrigger'),
 				createNode('HTTP', 'n8n-nodes-base.httpRequest', {
 					credentials: { oAuth2Api: { id: 'cred-1' } },
 				}),
 			];
 
 			mockCredentialsRepository.find.mockResolvedValue([
-				{ id: 'cred-1', name: 'My OAuth2', resolverId: null } as any,
+				{ id: 'cred-1', name: 'My OAuth2' } as any,
 			]);
+			useSystemResolver();
 
 			mockNodeTypes.getByNameAndVersion.mockImplementation(((type: string) => {
-				if (type === 'n8n-nodes-base.webhook') return createTriggerNodeType();
+				if (type === 'n8n-nodes-base.manualTrigger') return createTriggerNodeType();
 				return {} as INodeType;
 			}) as any);
-
-			mockDynamicCredentialsProxy.getEffectiveResolverId.mockReturnValue('system-resolver');
 
 			const result = await service.validateDynamicCredentials(nodes, mockNodeTypes);
 
 			expect(result.isValid).toBe(true);
 		});
 
-		it('should return valid when credential has no resolver but workflow settings provide one', async () => {
+		it('should return valid when workflow settings provide a custom resolver and a trigger has extractor hooks', async () => {
 			const nodes: INode[] = [
 				createNode('Webhook', 'n8n-nodes-base.webhook', {
 					parameters: hooksParameters,
@@ -765,34 +781,9 @@ describe('WorkflowValidationService', () => {
 			];
 
 			mockCredentialsRepository.find.mockResolvedValue([
-				{ id: 'cred-1', name: 'My OAuth2', resolverId: null } as any,
+				{ id: 'cred-1', name: 'My OAuth2' } as any,
 			]);
-
-			mockNodeTypes.getByNameAndVersion.mockImplementation(((type: string) => {
-				if (type === 'n8n-nodes-base.webhook') return createTriggerNodeType();
-				return {} as INodeType;
-			}) as any);
-
-			const result = await service.validateDynamicCredentials(nodes, mockNodeTypes, {
-				credentialResolverId: 'workflow-resolver-1',
-			});
-
-			expect(result.isValid).toBe(true);
-		});
-
-		it('should return valid when resolvable credentials are used with a trigger that has extractor hooks', async () => {
-			const nodes: INode[] = [
-				createNode('Webhook', 'n8n-nodes-base.webhook', {
-					parameters: hooksParameters,
-				}),
-				createNode('HTTP', 'n8n-nodes-base.httpRequest', {
-					credentials: { oAuth2Api: { id: 'cred-1' } },
-				}),
-			];
-
-			mockCredentialsRepository.find.mockResolvedValue([
-				{ id: 'cred-1', name: 'My OAuth2', resolverId: 'resolver-1' } as any,
-			]);
+			useCustomResolver();
 
 			mockNodeTypes.getByNameAndVersion.mockImplementation(((type: string) => {
 				if (type === 'n8n-nodes-base.webhook') return createTriggerNodeType();
@@ -804,7 +795,7 @@ describe('WorkflowValidationService', () => {
 			expect(result.isValid).toBe(true);
 		});
 
-		it('should return invalid when resolvable credentials are used with a trigger without extractor hooks', async () => {
+		it('should return invalid when a custom resolver is used with a trigger without extractor hooks', async () => {
 			const nodes: INode[] = [
 				createNode('Schedule', 'n8n-nodes-base.scheduleTrigger'),
 				createNode('HTTP', 'n8n-nodes-base.httpRequest', {
@@ -813,8 +804,9 @@ describe('WorkflowValidationService', () => {
 			];
 
 			mockCredentialsRepository.find.mockResolvedValue([
-				{ id: 'cred-1', name: 'My OAuth2', resolverId: 'resolver-1' } as any,
+				{ id: 'cred-1', name: 'My OAuth2' } as any,
 			]);
+			useCustomResolver();
 
 			mockNodeTypes.getByNameAndVersion.mockImplementation(((type: string) => {
 				if (type === 'n8n-nodes-base.scheduleTrigger') return createTriggerNodeType();
@@ -829,7 +821,7 @@ describe('WorkflowValidationService', () => {
 			expect(result.error).toContain('identity extractor');
 		});
 
-		it('should return invalid when webhook trigger has no hooks configured', async () => {
+		it('should return invalid when a custom resolver is used with a webhook trigger without hooks', async () => {
 			const nodes: INode[] = [
 				createNode('Webhook', 'n8n-nodes-base.webhook'),
 				createNode('HTTP', 'n8n-nodes-base.httpRequest', {
@@ -838,8 +830,9 @@ describe('WorkflowValidationService', () => {
 			];
 
 			mockCredentialsRepository.find.mockResolvedValue([
-				{ id: 'cred-1', name: 'My OAuth2', resolverId: 'resolver-1' } as any,
+				{ id: 'cred-1', name: 'My OAuth2' } as any,
 			]);
+			useCustomResolver();
 
 			mockNodeTypes.getByNameAndVersion.mockImplementation(((type: string) => {
 				if (type === 'n8n-nodes-base.webhook') return createTriggerNodeType();
@@ -853,6 +846,101 @@ describe('WorkflowValidationService', () => {
 			expect(result.error).toContain('identity extractor');
 		});
 
+		it('should return invalid when a system-resolved credential is used under a schedule trigger', async () => {
+			const nodes: INode[] = [
+				createNode('Schedule', 'n8n-nodes-base.scheduleTrigger'),
+				createNode('HTTP', 'n8n-nodes-base.httpRequest', {
+					credentials: { oAuth2Api: { id: 'cred-1' } },
+				}),
+			];
+
+			mockCredentialsRepository.find.mockResolvedValue([
+				{ id: 'cred-1', name: 'My OAuth2' } as any,
+			]);
+			useSystemResolver();
+
+			mockNodeTypes.getByNameAndVersion.mockImplementation(((type: string) => {
+				if (type === 'n8n-nodes-base.scheduleTrigger') return createTriggerNodeType();
+				return {} as INodeType;
+			}) as any);
+
+			const result = await service.validateDynamicCredentials(nodes, mockNodeTypes);
+
+			expect(result.isValid).toBe(false);
+			expect(result.error).toContain('private credentials');
+			expect(result.error).toContain('"My OAuth2"');
+			expect(result.error).toContain('manually');
+		});
+
+		it('should return valid when a system-resolved credential is used under a manual trigger', async () => {
+			const nodes: INode[] = [
+				createNode('Manual', 'n8n-nodes-base.manualTrigger'),
+				createNode('HTTP', 'n8n-nodes-base.httpRequest', {
+					credentials: { oAuth2Api: { id: 'cred-1' } },
+				}),
+			];
+
+			mockCredentialsRepository.find.mockResolvedValue([
+				{ id: 'cred-1', name: 'My OAuth2' } as any,
+			]);
+			useSystemResolver();
+
+			mockNodeTypes.getByNameAndVersion.mockImplementation(((type: string) => {
+				if (type === 'n8n-nodes-base.manualTrigger') return createTriggerNodeType();
+				return {} as INodeType;
+			}) as any);
+
+			const result = await service.validateDynamicCredentials(nodes, mockNodeTypes);
+
+			expect(result.isValid).toBe(true);
+		});
+
+		it('should return valid when a system-resolved credential is used under an Execute Workflow Trigger', async () => {
+			const nodes: INode[] = [
+				createNode('When Executed by Another Workflow', 'n8n-nodes-base.executeWorkflowTrigger'),
+				createNode('HTTP', 'n8n-nodes-base.httpRequest', {
+					credentials: { oAuth2Api: { id: 'cred-1' } },
+				}),
+			];
+
+			mockCredentialsRepository.find.mockResolvedValue([
+				{ id: 'cred-1', name: 'My OAuth2' } as any,
+			]);
+			useSystemResolver();
+
+			mockNodeTypes.getByNameAndVersion.mockImplementation(((type: string) => {
+				if (type === 'n8n-nodes-base.executeWorkflowTrigger') return createTriggerNodeType();
+				return {} as INodeType;
+			}) as any);
+
+			const result = await service.validateDynamicCredentials(nodes, mockNodeTypes);
+
+			expect(result.isValid).toBe(true);
+		});
+
+		it('should return valid when the trigger is an Execute Workflow Trigger (sub-workflow inherits identity context)', async () => {
+			const nodes: INode[] = [
+				createNode('When Executed by Another Workflow', 'n8n-nodes-base.executeWorkflowTrigger'),
+				createNode('Google Drive', 'n8n-nodes-base.googleDrive', {
+					credentials: { googleDriveOAuth2Api: { id: 'cred-1' } },
+				}),
+			];
+
+			mockCredentialsRepository.find.mockResolvedValue([
+				{ id: 'cred-1', name: 'Google Drive account 45' } as any,
+			]);
+			useCustomResolver();
+
+			mockNodeTypes.getByNameAndVersion.mockImplementation(((type: string) => {
+				if (type === 'n8n-nodes-base.executeWorkflowTrigger') return createTriggerNodeType();
+				return {} as INodeType;
+			}) as any);
+
+			const result = await service.validateDynamicCredentials(nodes, mockNodeTypes);
+
+			expect(result.isValid).toBe(true);
+		});
+
 		it('should return valid when Chat Trigger with availableInChat is the trigger', async () => {
 			const nodes: INode[] = [
 				createNode('Chat Trigger', '@n8n/n8n-nodes-langchain.chatTrigger', {
@@ -864,8 +952,9 @@ describe('WorkflowValidationService', () => {
 			];
 
 			mockCredentialsRepository.find.mockResolvedValue([
-				{ id: 'cred-1', name: 'Google Calendar account 56', resolverId: 'resolver-1' } as any,
+				{ id: 'cred-1', name: 'Google Calendar account 56' } as any,
 			]);
+			useCustomResolver();
 
 			mockNodeTypes.getByNameAndVersion.mockImplementation(((type: string) => {
 				if (type === '@n8n/n8n-nodes-langchain.chatTrigger') return createTriggerNodeType();
@@ -877,7 +966,7 @@ describe('WorkflowValidationService', () => {
 			expect(result.isValid).toBe(true);
 		});
 
-		it('should return invalid when Chat Trigger does not have availableInChat set', async () => {
+		it('should return invalid when a custom resolver is used with a Chat Trigger without availableInChat', async () => {
 			const nodes: INode[] = [
 				createNode('Chat Trigger', '@n8n/n8n-nodes-langchain.chatTrigger'),
 				createNode('Google Calendar', 'n8n-nodes-base.googleCalendar', {
@@ -886,8 +975,9 @@ describe('WorkflowValidationService', () => {
 			];
 
 			mockCredentialsRepository.find.mockResolvedValue([
-				{ id: 'cred-1', name: 'Google Calendar account 56', resolverId: 'resolver-1' } as any,
+				{ id: 'cred-1', name: 'Google Calendar account 56' } as any,
 			]);
+			useCustomResolver();
 
 			mockNodeTypes.getByNameAndVersion.mockImplementation(((type: string) => {
 				if (type === '@n8n/n8n-nodes-langchain.chatTrigger') return createTriggerNodeType();

--- a/packages/cli/src/workflows/workflow-validation.service.ts
+++ b/packages/cli/src/workflows/workflow-validation.service.ts
@@ -12,6 +12,8 @@ import {
 	isTriggerLikeNode,
 	toExecutionContextEstablishmentHookParameter,
 	CHAT_TRIGGER_NODE_TYPE,
+	EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE,
+	MANUAL_TRIGGER_NODE_TYPES,
 } from 'n8n-workflow';
 import { FULL_ACCESS_NODE_TYPES } from 'n8n-core';
 import type {
@@ -45,6 +47,21 @@ export interface WorkflowStatus {
 	exists: boolean;
 	isPublished: boolean;
 	name?: string;
+}
+
+/** Formats credential names as a quoted, comma-separated list for error messages. */
+function formatCredentialNames(credentials: Array<{ name: string }>): string {
+	return credentials.map((c) => `"${c.name}"`).join(', ');
+}
+
+/** Whether a node's parameters declare at least one context establishment hook. */
+function hasContextEstablishmentHook(parameters: INode['parameters']): boolean {
+	const hookParams = toExecutionContextEstablishmentHookParameter(parameters);
+	return (
+		hookParams !== null &&
+		hookParams.success &&
+		hookParams.data.contextEstablishmentHooks.hooks.length > 0
+	);
 }
 
 @Service()
@@ -289,88 +306,139 @@ export class WorkflowValidationService {
 	}
 
 	/**
-	 * Validates that workflows using dynamic (resolvable) credentials have:
-	 * 1. A resolver configured on each dynamic credential.
-	 * 2. At least one trigger node with context establishment hooks configured.
-	 * These hooks extract identity from trigger data (e.g., bearer tokens from HTTP headers)
-	 * and are required for dynamic credential resolution.
+	 * Validates that a workflow using dynamic (resolvable) credentials has a
+	 * resolver configured and a trigger that provides the identity it needs.
+	 *
+	 * The resolver is workflow-level (`settings.credentialResolverId` override or
+	 * the seeded system resolver):
+	 * - A custom resolver (OAuth, Slack, …) keys on an external identity extracted
+	 *   from trigger data, so it needs a trigger with a context establishment hook.
+	 * - The default/system resolver keys on the n8n user identity, so it needs a
+	 *   manual, chat, or sub-workflow trigger.
 	 */
 	async validateDynamicCredentials(
 		nodes: INode[],
 		nodeTypes: NodeTypes,
 		workflowSettings?: IWorkflowSettings,
 	): Promise<WorkflowValidationResult> {
-		const credentialIds = new Set<string>();
-		for (const node of nodes) {
-			if (node.disabled) continue;
-			for (const credName of Object.keys(node.credentials ?? {})) {
-				const credData = node.credentials?.[credName];
-				if (credData?.id) {
-					credentialIds.add(credData.id);
-				}
-			}
-		}
-
+		const credentialIds = this.collectCredentialIds(nodes);
 		if (credentialIds.size === 0) {
 			return { isValid: true };
 		}
 
 		const resolvableCredentials = await this.credentialsRepository.find({
 			where: { id: In([...credentialIds]), isResolvable: true },
-			select: ['id', 'name', 'resolverId'],
+			select: ['id', 'name'],
 		});
 
 		if (resolvableCredentials.length === 0) {
 			return { isValid: true };
 		}
 
-		const errors: string[] = [];
+		const credNames = formatCredentialNames(resolvableCredentials);
 
-		// A credential is covered if it has its own resolver OR the workflow has a defined resolver
-		// (workflow override, or the seeded system resolver looked up via the proxy).
+		// Workflow override if present, otherwise the seeded system resolver (null when neither).
 		const workflowResolverId =
 			this.dynamicCredentialsProxy.getEffectiveResolverId(workflowSettings);
+		const triggers = this.classifyTriggerIdentities(nodes, nodeTypes);
+
+		const error = this.getDynamicCredentialsError(workflowResolverId, credNames, triggers);
+
+		return error
+			? { isValid: false, error: `Cannot publish workflow: ${error}` }
+			: { isValid: true };
+	}
+
+	/**
+	 * Returns the publish error for the workflow's resolvable credentials, or
+	 * `undefined` when they are valid.
+	 */
+	private getDynamicCredentialsError(
+		workflowResolverId: string | null,
+		credNames: string,
+		triggers: { hasExternalIdentityTrigger: boolean; hasN8nIdentityTrigger: boolean },
+	): string | undefined {
 		if (!workflowResolverId) {
-			const credentialsWithoutResolver = resolvableCredentials.filter((c) => !c.resolverId);
-			if (credentialsWithoutResolver.length > 0) {
-				const credNames = credentialsWithoutResolver.map((c) => `"${c.name}"`).join(', ');
-				errors.push(`dynamic credentials (${credNames}) require a resolver to be configured.`);
-			}
+			return `dynamic credentials (${credNames}) require a resolver to be configured.`;
 		}
 
-		const hasExtractorHook = nodes.some((node) => {
-			if (node.disabled) return false;
+		const { hasExternalIdentityTrigger, hasN8nIdentityTrigger } = triggers;
+
+		if (workflowResolverId === this.dynamicCredentialsProxy.getSystemResolverId()) {
+			// System resolver: needs the n8n user identity.
+			return hasN8nIdentityTrigger
+				? undefined
+				: `private credentials (${credNames}) are only supported in workflows triggered manually, via chat, or as a sub-workflow.`;
+		}
+
+		// Custom resolver: needs an external identity from the trigger.
+		return hasExternalIdentityTrigger
+			? undefined
+			: `dynamic credentials (${credNames}) require a trigger with an identity extractor configured. Please configure an identity extractor on the trigger node.`;
+	}
+
+	/** Collects the ids of all credentials referenced by enabled nodes. */
+	private collectCredentialIds(nodes: INode[]): Set<string> {
+		const credentialIds = new Set<string>();
+		for (const node of nodes) {
+			if (node.disabled) continue;
+			for (const credName of Object.keys(node.credentials ?? {})) {
+				const credId = node.credentials?.[credName]?.id;
+				if (credId) {
+					credentialIds.add(credId);
+				}
+			}
+		}
+		return credentialIds;
+	}
+
+	/**
+	 * Classifies a workflow's triggers by the identity they can provide:
+	 * - `hasExternalIdentityTrigger`: external identity (context hook, Chat Hub, sub-workflow).
+	 * - `hasN8nIdentityTrigger`: n8n user identity (manual/chat, Chat Hub, sub-workflow).
+	 *
+	 * This mirrors how the engine establishes identity at runtime: keep it in sync
+	 * with `execution-context.ts` (manual/parent inheritance) and the identity sources
+	 * accepted by the resolvers' identifiers (e.g. `N8NIdentifier`). When a new trigger
+	 * or identity source is added there, it must be reflected here too. A follow-up
+	 * tracks making this declarative instead of hardcoded.
+	 */
+	private classifyTriggerIdentities(
+		nodes: INode[],
+		nodeTypes: NodeTypes,
+	): { hasExternalIdentityTrigger: boolean; hasN8nIdentityTrigger: boolean } {
+		let hasExternalIdentityTrigger = false;
+		let hasN8nIdentityTrigger = false;
+
+		for (const node of nodes) {
+			if (node.disabled) continue;
 			const nodeType = nodeTypes.getByNameAndVersion(node.type, node.typeVersion);
-			if (!nodeType || !isTriggerLikeNode(nodeType)) return false;
+			if (!nodeType || !isTriggerLikeNode(nodeType)) continue;
 
-			// Chat Trigger nodes with availableInChat have identity injected at runtime by Chat Hub
-			if (node.type === CHAT_TRIGGER_NODE_TYPE && node.parameters.availableInChat === true) {
-				return true;
+			// Sub-workflows inherit identity from the parent; Chat Hub injects it.
+			// Both satisfy either family.
+			const isSubWorkflowTrigger = node.type === EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE;
+			const isChatHubTrigger =
+				node.type === CHAT_TRIGGER_NODE_TYPE && node.parameters.availableInChat === true;
+			if (isSubWorkflowTrigger || isChatHubTrigger) {
+				hasExternalIdentityTrigger = true;
+				hasN8nIdentityTrigger = true;
+				continue;
 			}
 
-			const hookParams = toExecutionContextEstablishmentHookParameter(node.parameters);
-			return (
-				hookParams !== null &&
-				hookParams.success &&
-				hookParams.data.contextEstablishmentHooks.hooks.length > 0
-			);
-		});
+			// Manual/chat triggers run with the n8n user identity.
+			if (MANUAL_TRIGGER_NODE_TYPES.includes(node.type)) {
+				hasN8nIdentityTrigger = true;
+				continue;
+			}
 
-		if (!hasExtractorHook) {
-			const credNames = resolvableCredentials.map((c) => `"${c.name}"`).join(', ');
-			errors.push(
-				`dynamic credentials (${credNames}) require a trigger with an identity extractor configured. Please configure an identity extractor on the trigger node.`,
-			);
+			// Any other trigger with a context establishment hook provides external identity.
+			if (hasContextEstablishmentHook(node.parameters)) {
+				hasExternalIdentityTrigger = true;
+			}
 		}
 
-		if (errors.length > 0) {
-			return {
-				isValid: false,
-				error: `Cannot publish workflow: ${errors.join(' ')}`,
-			};
-		}
-
-		return { isValid: true };
+		return { hasExternalIdentityTrigger, hasN8nIdentityTrigger };
 	}
 
 	/**

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.test.ts
@@ -826,6 +826,7 @@ describe('useNodeHelpers()', () => {
 		const MANUAL_CHAT_TRIGGER = '@n8n/n8n-nodes-langchain.manualChatTrigger';
 		const CHAT_TRIGGER = '@n8n/n8n-nodes-langchain.chatTrigger';
 		const WEBHOOK_TRIGGER = 'n8n-nodes-base.webhook';
+		const EXECUTE_WORKFLOW_TRIGGER = 'n8n-nodes-base.executeWorkflowTrigger';
 
 		const notionNodeType: INodeTypeDescription = {
 			displayName: 'Notion',
@@ -1027,6 +1028,16 @@ describe('useNodeHelpers()', () => {
 			it('does not warn when a private credential is used under a chat trigger', () => {
 				mockConnectedPrivateCred(true);
 				mockDocumentStore.workflowTriggerNodes = [buildTriggerNode(CHAT_TRIGGER)];
+
+				const { getNodeCredentialIssues } = useNodeHelpers();
+				const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);
+
+				expect(result).toBeNull();
+			});
+
+			it('does not warn when a private credential is used under an execute workflow trigger', () => {
+				mockConnectedPrivateCred(true);
+				mockDocumentStore.workflowTriggerNodes = [buildTriggerNode(EXECUTE_WORKFLOW_TRIGGER)];
 
 				const { getNodeCredentialIssues } = useNodeHelpers();
 				const result = getNodeCredentialIssues(buildNotionNode(), notionNodeType);

--- a/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useNodeHelpers.ts
@@ -6,6 +6,7 @@ import {
 	NodeHelpers,
 	NodeConnectionTypes,
 	MANUAL_TRIGGER_NODE_TYPES,
+	EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE,
 	nodeIssuesToString,
 } from 'n8n-workflow';
 import type {
@@ -420,7 +421,12 @@ export function useNodeHelpers() {
 	function workflowHasIncompatibleTrigger(): boolean {
 		const triggers = workflowDocumentStore.value.workflowTriggerNodes;
 		return triggers.some(
-			(trigger) => !trigger.disabled && !MANUAL_TRIGGER_NODE_TYPES.includes(trigger.type),
+			(trigger) =>
+				!trigger.disabled &&
+				!MANUAL_TRIGGER_NODE_TYPES.includes(trigger.type) &&
+				// Sub-workflows inherit the identity context from the parent execution,
+				// so a private credential resolves as long as the parent provides one.
+				trigger.type !== EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE,
 		);
 	}
 


### PR DESCRIPTION
## Summary

Two checks wrongly rejected workflows that use a private (dynamic / resolvable) credential, even though resolution would succeed at runtime. The required identity differs by resolver family: **custom** resolvers (OAuth, Slack, …) key on an external identity extracted from trigger data, so they still need a trigger with an identity-extractor hook; the **default/system** resolver keys on the n8n user identity, which only exists for **manual, chat, or sub-workflow** executions, so those credentials no longer need an extractor hook but are still rejected under incompatible triggers (e.g. Schedule). An **Execute Workflow Trigger** now satisfies both families since a sub-workflow inherits identity from its parent execution, and the **frontend** node-issue check (`workflowHasIncompatibleTrigger`) no longer flags it as incompatible.

## How to test

1. Connect a private (resolvable) credential resolved by the default/system resolver (e.g. a Google Drive OAuth2 credential connected by you).
2. Build a **sub-workflow** whose entry point is the **Execute Workflow Trigger** node and add a node using that credential → no node issue in the editor, and the workflow publishes successfully.
3. Use the same private credential in a **manually-triggered** or **chat-triggered** workflow → publishes successfully.
4. Use it under a **Schedule** trigger → still correctly blocked (private credentials need a manual/chat/sub-workflow trigger).
5. With a credential pointing at a **custom resolver** and a trigger that has an identity extractor hook → publishes; without the extractor → still blocked.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-825

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI