### PR TITLE
ci: Fix CLA bot concurrency skips

### DIFF
--- a/.github/workflows/ci-cla-check.yml
+++ b/.github/workflows/ci-cla-check.yml
@@ -39,23 +39,21 @@ permissions:
   statuses: write
 
 concurrency:
-  # Concurrency is evaluated BEFORE the job-level `if` below. A comment that
-  # isn't `/cla-check` still creates a run that joins the PR's group (issue
-  # number == PR number) and, with cancel-in-progress, cancels the in-progress
-  # pull_request_target check — then gets skipped by the `if` and does nothing,
-  # leaving the "CLA Check" status stuck on pending. Route those non-actionable
-  # comment runs to a unique group (run_id) so they never cancel a real check.
-  # `/cla-check` comments keep the PR's group so a manual re-check supersedes.
+  # Concurrency is evaluated BEFORE the job-level `if` below, so a comment that
+  # isn't `/cla-check` (e.g. a bot's "StageReview" comment) still creates a run.
+  # If that run shared the PR's group (issue number == PR number) it would, with
+  # cancel-in-progress, cancel the in-progress pull_request_target check — then
+  # get skipped by the `if` and do nothing, leaving the "CLA Check" status stuck
+  # on pending. Keep comment-triggered runs in their own group so they can only
+  # ever cancel each other, never the PR push check that gates the merge. PR
+  # pushes, merge_group and dispatch keep the head-based group (push debounce).
   group: >-
-    cla-check-${{
-      (github.event_name == 'issue_comment' && !startsWith(github.event.comment.body, '/cla-check'))
-      && github.run_id
+    cla-check-${{ github.event_name == 'issue_comment'
+      && format('comment-{0}', github.event.issue.number)
       || github.event.pull_request.number
-      || github.event.issue.number
       || github.event.merge_group.head_sha
       || github.event.inputs.pr_number
-      || github.ref
-    }}
+      || github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/ci-cla-check.yml
+++ b/.github/workflows/ci-cla-check.yml
@@ -39,7 +39,23 @@ permissions:
   statuses: write
 
 concurrency:
-  group: cla-check-${{ github.event.pull_request.number || github.event.issue.number || github.event.merge_group.head_sha || github.event.inputs.pr_number || github.ref }}
+  # Concurrency is evaluated BEFORE the job-level `if` below. A comment that
+  # isn't `/cla-check` still creates a run that joins the PR's group (issue
+  # number == PR number) and, with cancel-in-progress, cancels the in-progress
+  # pull_request_target check — then gets skipped by the `if` and does nothing,
+  # leaving the "CLA Check" status stuck on pending. Route those non-actionable
+  # comment runs to a unique group (run_id) so they never cancel a real check.
+  # `/cla-check` comments keep the PR's group so a manual re-check supersedes.
+  group: >-
+    cla-check-${{
+      (github.event_name == 'issue_comment' && !startsWith(github.event.comment.body, '/cla-check'))
+      && github.run_id
+      || github.event.pull_request.number
+      || github.event.issue.number
+      || github.event.merge_group.head_sha
+      || github.event.inputs.pr_number
+      || github.ref
+    }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
## Summary

The concurrency of the CLA bot workflow was evaluated BEFORE the if block that gates CLA checks. This caused a race condition where the initial CLA check was cancelled due to a comment from stagereview, and then the stagereview run was skipped due to not matching the criteria of the if block in the workflow.

This caused a CLA check to not have passed without a retry or a new comment on the PR.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32309">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

