### PR TITLE
test(core): Extend fixture extraction hook timeout to avoid flake (no-changelog)

### DIFF
--- a/packages/@n8n/workflow-sdk/src/codegen/code-generator.test.ts
+++ b/packages/@n8n/workflow-sdk/src/codegen/code-generator.test.ts
@@ -1879,10 +1879,13 @@ describe('code-generator', () => {
 		});
 
 		describe('composite node parameters roundtrip', () => {
-			// Ensure fixtures are extracted for tests that use real workflow files
+			// Ensure fixtures are extracted for tests that use real workflow files.
+			// Unpacking ~2000 workflow files is IO-bound and can take well over the
+			// default 10s hook timeout on a contended CI runner, so give it a
+			// generous budget to avoid flaky "Hook timed out" failures.
 			beforeAll(() => {
 				ensureFixtures();
-			});
+			}, 60_000);
 
 			it('preserves switchCase parameters through roundtrip', () => {
 				const json: WorkflowJSON = {

--- a/packages/@n8n/workflow-sdk/src/real-workflow.test.ts
+++ b/packages/@n8n/workflow-sdk/src/real-workflow.test.ts
@@ -86,7 +86,9 @@ function loadTestWorkflows(): TestWorkflow[] {
 const workflows = loadTestWorkflows();
 
 describe('Real Workflow Round-Trip', () => {
-	// Download fixtures if needed
+	// Download fixtures if needed. Unpacking ~2000 workflow files is IO-bound and
+	// can take well over the default 10s hook timeout on a contended CI runner, so
+	// give it a generous budget to avoid flaky "Hook timed out" failures.
 	beforeAll(() => {
 		try {
 			ensureFixtures();
@@ -99,7 +101,7 @@ describe('Real Workflow Round-Trip', () => {
 			}
 			throw error;
 		}
-	});
+	}, 60_000);
 
 	if (workflows.length === 0) {
 		it('should have fixtures available (run tests again after download)', () => {
@@ -250,9 +252,11 @@ describe('Real Workflow Round-Trip', () => {
 });
 
 describe('Real Workflow Patterns', () => {
+	// Generous timeout: fixture extraction is IO-bound and can exceed the default
+	// 10s hook timeout on a contended CI runner.
 	beforeAll(() => {
 		ensureFixtures();
-	});
+	}, 60_000);
 
 	it('should handle AI agent workflows with subnodes', () => {
 		expect(workflows.length).toBeGreaterThan(0);
@@ -330,9 +334,11 @@ describe('Real Workflow Patterns', () => {
 });
 
 describe('Expression Preservation', () => {
+	// Generous timeout: fixture extraction is IO-bound and can exceed the default
+	// 10s hook timeout on a contended CI runner.
 	beforeAll(() => {
 		ensureFixtures();
-	});
+	}, 60_000);
 
 	function extractExpressions(json: WorkflowJSON): string[] {
 		const expressions: string[] = [];


### PR DESCRIPTION
## Summary

`ensureFixtures()` synchronously unpacks ~2000 workflow files, which can exceed the default 10s `beforeAll` timeout on a contended CI runner (`Hook timed out in 10000ms`). #32099 fixed this for `codegen-roundtrip.test.ts` but missed the other 4 call sites — this gives them all a `60_000`ms budget.

## How to test

`pnpm --filter=@n8n/workflow-sdk test` — all green.

## Related

Follow-up to #32099 (same flake, missed call sites). Originally surfaced in #32251 CI.

## Checklist
- [x] PR title follows conventions
- [ ] Tests included

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32313">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

