### PR TITLE
test(core): Stabilize timezone-sensitive insights integration tests

### DIFF
--- a/packages/cli/src/modules/insights/__tests__/insights.service.integration.test.ts
+++ b/packages/cli/src/modules/insights/__tests__/insights.service.integration.test.ts
@@ -372,7 +372,7 @@ describe('InsightsService (Integration)', () => {
 					type: 'success',
 					value: 1,
 					periodUnit: 'hour',
-					periodStart: now.minus({ days: 13, hours: 23 }),
+					periodStart: now.minus({ days: 14 }).startOf('day').plus({ hours: 1 }),
 				});
 				await createCompactedInsightsEvent(workflow, {
 					type: 'success',
@@ -580,7 +580,7 @@ describe('InsightsService (Integration)', () => {
 					type: 'success',
 					value: 1,
 					periodUnit: 'hour',
-					periodStart: now.minus({ days: 13, hours: 23 }),
+					periodStart: now.minus({ days: 14 }).startOf('day').plus({ hours: 1 }),
 				});
 
 				// Out of date range insight (should not be included)
@@ -743,7 +743,7 @@ describe('InsightsService (Integration)', () => {
 					type: workflow === workflow1 ? 'success' : 'failure',
 					value: 1,
 					periodUnit: 'hour',
-					periodStart: now.minus({ days: 13, hours: 23 }),
+					periodStart: now.minus({ days: 14 }).startOf('day').plus({ hours: 1 }),
 				});
 
 				// Out of date range insight (should not be included)
@@ -901,7 +901,7 @@ describe('InsightsService (Integration)', () => {
 					type: workflow === workflow1 ? 'success' : 'failure',
 					value: 1,
 					periodUnit: 'hour',
-					periodStart: now.minus({ days: 13, hours: 23 }),
+					periodStart: now.minus({ days: 14 }).startOf('day').plus({ hours: 1 }),
 				});
 
 				// Out of date range insight (should not be included)


### PR DESCRIPTION
## Summary

Fixes a time-of-day flake in `insights.service.integration.test.ts`. The "barely in range" insights events were seeded relative to the live wall clock with `now.minus({ days: 13, hours: 23 })`, then asserted against a day bucket computed from `now.minus({ days: 14 }).startOf('day')`.

Those two anchors are 1 hour apart. When the suite runs in the **23:00–24:00 UTC window**, that 1-hour gap straddles midnight, so the seeded event lands in a different `startOf('day')` bucket than the assertion expects, and the test fails:

```
Expected: "2026-05-31T00:00:00.000Z"
Received: "2026-06-01T00:00:00.000Z"
```

(Observed in [this CI run](https://github.com/n8n-io/n8n/actions/runs/27514730089/job/81321493887), which executed at 23:08 UTC — the May→June rollover was incidental; the real trigger is the time of day.)

The fix anchors the event to the same day boundary the assertion uses, then adds 1 hour:

```diff
- periodStart: now.minus({ days: 13, hours: 23 }),
+ periodStart: now.minus({ days: 14 }).startOf('day').plus({ hours: 1 }),
```

This keeps the event "barely in range" while making it land deterministically in the `now - 14d` day bucket regardless of what time of day the suite runs. All 4 occurrences of the pattern in the file were updated for consistency (2 drove the failing day-bucket assertions; the other 2 are total-count tests that couldn't flake but share the same fragile pattern).

A repo-wide sweep found no other callsites with the same asymmetric seed-vs-bucket pattern.

## How to test

```bash
cd packages/cli
pnpm test:integration src/modules/insights/__tests__/insights.service.integration.test.ts
```

All 25 tests pass. To reproduce the original failure, pin luxon's clock to a late-UTC time (e.g. `Settings.now = () => Date.UTC(2026, 5, 14, 23, 8, 14)`) and run against the pre-fix code — the two `getInsightsByTime` grouping tests fail with the date mismatch above; with the fix in place they pass under the same clock.

## Related Linear tickets, Github issues, and Community forum posts

n/a — flaky test fix.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32314">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32314?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

