### PR TITLE
fix(core): Exclude error workflow executions from billable execution count

### DIFF
--- a/packages/cli/src/services/__tests__/workflow-statistics.service.integration.test.ts
+++ b/packages/cli/src/services/__tests__/workflow-statistics.service.integration.test.ts
@@ -15,7 +15,6 @@ import {
 	type EntityManager,
 	type EntityMetadata,
 } from '@n8n/typeorm';
-import { createUser } from '@test-integration/db/users';
 import { mocked } from 'jest-mock';
 import { mock } from 'jest-mock-extended';
 import {
@@ -30,6 +29,7 @@ import { EventService } from '@/events/event.service';
 import { OwnershipService } from '@/services/ownership.service';
 import { UserService } from '@/services/user.service';
 import { WorkflowStatisticsService } from '@/services/workflow-statistics.service';
+import { createUser } from '@test-integration/db/users';
 
 describe('WorkflowStatisticsService', () => {
 	describe('workflowExecutionCompleted', () => {
@@ -93,7 +93,7 @@ describe('WorkflowStatisticsService', () => {
 			},
 		);
 
-		test.each<WorkflowExecuteMode>(['manual', 'integrated', 'internal'])(
+		test.each<WorkflowExecuteMode>(['manual', 'integrated', 'internal', 'error'])(
 			'should upsert `count`, but not `rootCount` for execution mode %s',
 			async (mode) => {
 				// ARRANGE
@@ -126,28 +126,26 @@ describe('WorkflowStatisticsService', () => {
 			},
 		);
 
-		test.each<WorkflowExecuteMode>(['chat', 'error'])(
-			'should not upsert production statistics for execution mode %s',
-			async (mode) => {
-				for (const status of ['success', 'error', 'crashed'] as const) {
-					await testDb.truncate(['WorkflowStatistics']);
+		test('should not upsert production statistics for chat execution mode', async () => {
+			const mode: WorkflowExecuteMode = 'chat';
+			for (const status of ['success', 'error', 'crashed'] as const) {
+				await testDb.truncate(['WorkflowStatistics']);
 
-					const runData: IRun = {
-						finished: status === 'success',
-						status,
-						data: createEmptyRunExecutionData(),
-						mode,
-						startedAt: new Date(),
-						storedAt: 'db',
-					};
+				const runData: IRun = {
+					finished: status === 'success',
+					status,
+					data: createEmptyRunExecutionData(),
+					mode,
+					startedAt: new Date(),
+					storedAt: 'db',
+				};
 
-					await workflowStatisticsService.workflowExecutionCompleted(workflow, runData);
+				await workflowStatisticsService.workflowExecutionCompleted(workflow, runData);
 
-					const statistics = await workflowStatisticsRepository.find();
-					expect(statistics).toHaveLength(0);
-				}
-			},
-		);
+				const statistics = await workflowStatisticsRepository.find();
+				expect(statistics).toHaveLength(0);
+			}
+		});
 
 		test.each<ExecutionStatus>(['success', 'crashed', 'error'])(
 			'should upsert `count` and `rootCount` for execution status %s',

--- a/packages/cli/src/services/__tests__/workflow-statistics.service.integration.test.ts
+++ b/packages/cli/src/services/__tests__/workflow-statistics.service.integration.test.ts
@@ -62,7 +62,7 @@ describe('WorkflowStatisticsService', () => {
 			await settingsRepository.delete({ key: 'instance.firstProductionFailure' });
 		});
 
-		test.each<WorkflowExecuteMode>(['cli', 'error', 'retry', 'trigger', 'webhook', 'evaluation'])(
+		test.each<WorkflowExecuteMode>(['cli', 'retry', 'trigger', 'webhook', 'evaluation'])(
 			'should upsert `count` and `rootCount` for execution mode %s',
 			async (mode) => {
 				// ARRANGE
@@ -126,25 +126,28 @@ describe('WorkflowStatisticsService', () => {
 			},
 		);
 
-		it('should not upsert statistics for execution mode chat', async () => {
-			// ARRANGE
-			const runData: IRun = {
-				finished: true,
-				status: 'success',
-				data: createEmptyRunExecutionData(),
-				mode: 'chat',
-				startedAt: new Date(),
-				storedAt: 'db',
-			};
+		test.each<WorkflowExecuteMode>(['chat', 'error'])(
+			'should not upsert production statistics for execution mode %s',
+			async (mode) => {
+				for (const status of ['success', 'error', 'crashed'] as const) {
+					await testDb.truncate(['WorkflowStatistics']);
 
-			// ACT
-			await workflowStatisticsService.workflowExecutionCompleted(workflow, runData);
-			await workflowStatisticsService.workflowExecutionCompleted(workflow, runData);
+					const runData: IRun = {
+						finished: status === 'success',
+						status,
+						data: createEmptyRunExecutionData(),
+						mode,
+						startedAt: new Date(),
+						storedAt: 'db',
+					};
 
-			// ASSERT
-			const statistics = await workflowStatisticsRepository.find();
-			expect(statistics).toHaveLength(0);
-		});
+					await workflowStatisticsService.workflowExecutionCompleted(workflow, runData);
+
+					const statistics = await workflowStatisticsRepository.find();
+					expect(statistics).toHaveLength(0);
+				}
+			},
+		);
 
 		test.each<ExecutionStatus>(['success', 'crashed', 'error'])(
 			'should upsert `count` and `rootCount` for execution status %s',

--- a/packages/cli/src/services/workflow-statistics.service.ts
+++ b/packages/cli/src/services/workflow-statistics.service.ts
@@ -6,12 +6,13 @@ import {
 	WorkflowStatisticsRepository,
 } from '@n8n/db';
 import { Service } from '@n8n/di';
-import type {
-	ExecutionStatus,
-	INode,
-	IRun,
-	IWorkflowBase,
-	WorkflowExecuteMode,
+import {
+	isCompletedExecutionStatus,
+	type ExecutionStatus,
+	type INode,
+	type IRun,
+	type IWorkflowBase,
+	type WorkflowExecuteMode,
 } from 'n8n-workflow';
 
 import { EventService } from '@/events/event.service';
@@ -34,7 +35,7 @@ const isStatusRootExecution = {
 
 const isModeRootExecution = {
 	cli: true,
-	error: true,
+	error: false,
 	retry: true,
 	trigger: true,
 	webhook: true,
@@ -55,21 +56,36 @@ const isModeRootExecution = {
 	agent: false,
 } satisfies Record<WorkflowExecuteMode, boolean>;
 
+const EXCLUDED_FROM_EXECUTION_LIMIT_MODES: WorkflowExecuteMode[] = ['chat', 'error'];
+
+function getStatisticsNameForCompletedRun(runData: IRun): StatisticsNames | null {
+	if (EXCLUDED_FROM_EXECUTION_LIMIT_MODES.includes(runData.mode)) {
+		return null;
+	}
+
+	if (!isCompletedExecutionStatus(runData.status)) {
+		return null;
+	}
+
+	const isManualExecution = runData.mode === 'manual';
+	if (isManualExecution) {
+		return runData.status === 'success'
+			? StatisticsNames.manualSuccess
+			: StatisticsNames.manualError;
+	}
+
+	return runData.status === 'success'
+		? StatisticsNames.productionSuccess
+		: StatisticsNames.productionError;
+}
+
+function isRootExecutionForRun(runData: IRun): boolean {
+	return isModeRootExecution[runData.mode] && isStatusRootExecution[runData.status];
+}
+
 type WorkflowStatisticsEvents = {
 	nodeFetchedData: { workflowId: string; node: INode };
 	workflowExecutionCompleted: { workflowData: IWorkflowBase; fullRunData: IRun };
-	'telemetry.onFirstProductionWorkflowSuccess': {
-		project_id: string;
-		workflow_id: string;
-		user_id: string;
-	};
-	'telemetry.onFirstWorkflowDataLoad': {
-		user_id: string;
-		project_id: string;
-		workflow_id: string;
-		node_type: string;
-		node_id: string;
-	};
 };
 
 @Service()
@@ -98,112 +114,101 @@ export class WorkflowStatisticsService extends TypedEmitter<WorkflowStatisticsEv
 	}
 
 	async workflowExecutionCompleted(workflowData: IWorkflowBase, runData: IRun): Promise<void> {
-		// Determine the name of the statistic
-		const isSuccess = runData.status === 'success';
-		const isError = runData.status === 'error' || runData.status === 'crashed';
-		const manualExecution = runData.mode === 'manual';
-		const chatExecution = runData.mode === 'chat';
+		const statisticsName = getStatisticsNameForCompletedRun(runData);
+		if (!statisticsName) return;
 
-		if (chatExecution) {
-			// Chat workflows are short lived and not counted towards execution limits.
-			return;
-		}
-
-		let name: StatisticsNames;
-		const isRootExecution =
-			isModeRootExecution[runData.mode] && isStatusRootExecution[runData.status];
-
-		// Only record statistics for terminal statuses (success, error, crashed)
-		// Skip non-terminal statuses like waiting, running, new, etc.
-		if (isSuccess) {
-			name = manualExecution ? StatisticsNames.manualSuccess : StatisticsNames.productionSuccess;
-		} else if (isError) {
-			name = manualExecution ? StatisticsNames.manualError : StatisticsNames.productionError;
-		} else {
-			return;
-		}
-
-		// Get the workflow id
 		const workflowId = workflowData.id;
 		if (!workflowId) return;
 
 		try {
 			const upsertResult = await this.repository.upsertWorkflowStatistics(
-				name,
+				statisticsName,
 				workflowId,
-				isRootExecution,
+				isRootExecutionForRun(runData),
 				workflowData.name,
 			);
 
-			if (name === StatisticsNames.productionSuccess && upsertResult === 'insert') {
-				const project = await this.ownershipService.getWorkflowProjectCached(workflowId);
-				let userId: string | null = null;
+			if (upsertResult !== 'insert') return;
 
-				if (project.type === 'personal') {
-					const owner = await this.ownershipService.getPersonalProjectOwnerCached(project.id);
-					userId = owner?.id ?? null;
-
-					if (owner && !owner.settings?.userActivated) {
-						await this.userService.updateSettings(owner.id, {
-							firstSuccessfulWorkflowId: workflowId,
-							userActivated: true,
-							userActivatedAt: runData.startedAt.getTime(),
-						});
-					}
-				}
-
-				this.eventService.emit('first-production-workflow-succeeded', {
-					projectId: project.id,
-					workflowId,
-					userId,
-				});
-			}
-
-			if (name === StatisticsNames.productionError && upsertResult === 'insert') {
-				// Check if this is the first production failure and if error workflows are configured
-				const instanceHadProductionFailure = await this.settingsRepository.findByKey(
-					'instance.firstProductionFailure',
-				);
-
-				if (
-					!instanceHadProductionFailure &&
-					!(await this.workflowRepository.hasAnyWorkflowsWithErrorWorkflow())
-				) {
-					// This is the first production failure ever on this instance
-					const project = await this.ownershipService.getWorkflowProjectCached(workflowId);
-
-					// Get owner: personal project owner if available, otherwise instance owner
-					let owner =
-						project.type === 'personal'
-							? await this.ownershipService.getPersonalProjectOwnerCached(project.id)
-							: null;
-
-					owner ??= await this.ownershipService.getInstanceOwner();
-
-					// Store the flag to prevent future emissions
-					await this.settingsRepository.save({
-						key: 'instance.firstProductionFailure',
-						value: JSON.stringify({
-							workflowId,
-							projectId: project.id,
-							userId: owner.id,
-							timestamp: runData.startedAt.getTime(),
-						}),
-						loadOnStartup: false,
-					});
-
-					// Emit the event
-					this.eventService.emit('instance-first-production-workflow-failed', {
-						projectId: project.id,
-						workflowId,
-						workflowName: workflowData.name,
-						userId: owner.id,
-					});
-				}
+			if (statisticsName === StatisticsNames.productionSuccess) {
+				await this.emitFirstProductionWorkflowSucceeded(workflowId, runData);
+			} else if (statisticsName === StatisticsNames.productionError) {
+				await this.emitInstanceFirstProductionWorkflowFailed(workflowData, workflowId, runData);
 			}
 		} catch (error) {
 			this.logger.debug('Unable to fire first workflow telemetry event');
 		}
+	}
+
+	private async emitFirstProductionWorkflowSucceeded(
+		workflowId: string,
+		runData: IRun,
+	): Promise<void> {
+		const project = await this.ownershipService.getWorkflowProjectCached(workflowId);
+		let userId: string | null = null;
+
+		if (project.type === 'personal') {
+			const owner = await this.ownershipService.getPersonalProjectOwnerCached(project.id);
+			userId = owner?.id ?? null;
+
+			if (owner && !owner.settings?.userActivated) {
+				await this.userService.updateSettings(owner.id, {
+					firstSuccessfulWorkflowId: workflowId,
+					userActivated: true,
+					userActivatedAt: runData.startedAt.getTime(),
+				});
+			}
+		}
+
+		this.eventService.emit('first-production-workflow-succeeded', {
+			projectId: project.id,
+			workflowId,
+			userId,
+		});
+	}
+
+	private async emitInstanceFirstProductionWorkflowFailed(
+		workflowData: IWorkflowBase,
+		workflowId: string,
+		runData: IRun,
+	): Promise<void> {
+		const instanceHadProductionFailure = await this.settingsRepository.findByKey(
+			'instance.firstProductionFailure',
+		);
+
+		if (
+			instanceHadProductionFailure ||
+			(await this.workflowRepository.hasAnyWorkflowsWithErrorWorkflow())
+		) {
+			return;
+		}
+
+		const project = await this.ownershipService.getWorkflowProjectCached(workflowId);
+
+		let owner =
+			project.type === 'personal'
+				? await this.ownershipService.getPersonalProjectOwnerCached(project.id)
+				: null;
+
+		owner ??= await this.ownershipService.getInstanceOwner();
+
+		await this.settingsRepository.save({
+			key: 'instance.firstProductionFailure',
+			value: JSON.stringify({
+				workflowId,
+				projectId: project.id,
+				userId: owner.id,
+				timestamp: runData.startedAt.getTime(),
+			}),
+			loadOnStartup: false,
+		});
+
+		this.eventService.emit('instance-first-production-workflow-failed', {
+			projectId: project.id,
+			workflowId,
+			workflowName: workflowData.name,
+			userId: owner.id,
+		});
 	}
 
 	async nodeFetchedData(workflowId: string | undefined | null, node: INode): Promise<void> {

--- a/packages/cli/src/services/workflow-statistics.service.ts
+++ b/packages/cli/src/services/workflow-statistics.service.ts
@@ -35,7 +35,6 @@ const isStatusRootExecution = {
 
 const isModeRootExecution = {
 	cli: true,
-	error: false,
 	retry: true,
 	trigger: true,
 	webhook: true,
@@ -45,6 +44,8 @@ const isModeRootExecution = {
 	integrated: false,
 
 	// error workflows
+	error: false,
+
 	internal: false,
 
 	manual: false,
@@ -56,14 +57,9 @@ const isModeRootExecution = {
 	agent: false,
 } satisfies Record<WorkflowExecuteMode, boolean>;
 
-const EXCLUDED_FROM_EXECUTION_LIMIT_MODES: WorkflowExecuteMode[] = ['chat', 'error'];
-
 function getStatisticsNameForCompletedRun(runData: IRun): StatisticsNames | null {
-	if (EXCLUDED_FROM_EXECUTION_LIMIT_MODES.includes(runData.mode)) {
-		return null;
-	}
-
-	if (!isCompletedExecutionStatus(runData.status)) {
+	const isChatExecution = runData.mode === 'chat';
+	if (isChatExecution || !isCompletedExecutionStatus(runData.status)) {
 		return null;
 	}
 

--- a/packages/workflow/src/execution-status.ts
+++ b/packages/workflow/src/execution-status.ts
@@ -10,10 +10,14 @@ export const ExecutionStatusList = [
 ] as const;
 
 export type ExecutionStatus = (typeof ExecutionStatusList)[number];
+export type CompletedExecutionStatus = 'crashed' | 'error' | 'success';
+export type TerminalExecutionStatus = CompletedExecutionStatus | 'canceled';
 
-export const TERMINAL_EXECUTION_STATUSES = ['canceled', 'crashed', 'error', 'success'] as const;
-
-export type TerminalExecutionStatus = (typeof TERMINAL_EXECUTION_STATUSES)[number];
+export function isCompletedExecutionStatus(
+	status: ExecutionStatus,
+): status is CompletedExecutionStatus {
+	return status === 'crashed' || status === 'error' || status === 'success';
+}
 
 export function isTerminalExecutionStatus(
 	status: ExecutionStatus | undefined,


### PR DESCRIPTION
## Summary

[Outdated] Initial approach (Removed the row from workflow statistics altogether)
https://www.loom.com/share/677dd545e52249af90de29a3d9b707a2

Final approach (Kept the record with `rootCount` being `0`)
https://www.loom.com/share/e4a57e87e1234fd69d6cef885b446b91

Error workflow executions (workflows triggered by the **Error Trigger** node, i.e. executions with mode `error`) must not count as billable executions, regardless of whether they succeed or fail. *Failed parent* executions remain billable.

This PR stops error-triggered executions from incrementing workflow statistics (production execution counts), aligning them with how `chat` executions are already excluded:

- Added `EXCLUDED_FROM_EXECUTION_LIMIT_MODES = ['chat', 'error']` and gate statistics recording on it in `WorkflowStatisticsService`.
- Set `error` mode to `false` in `isModeRootExecution` so error executions are never counted as root executions.
- Extracted `getStatisticsNameForCompletedRun` and `isRootExecutionForRun` helpers, and split the first-success / first-failure telemetry emission into dedicated private methods to keep `workflowExecutionCompleted` readable.
- Added `CompletedExecutionStatus` type and `isCompletedExecutionStatus` type guard in `n8n-workflow`, replacing the `TERMINAL_EXECUTION_STATUSES` constant usage for the completed-status check.

### How to test

1. Set up a workflow with an Error Trigger node as its own error workflow (or assign it as the error workflow of another workflow).
2. Trigger a production failure on the parent workflow so the error workflow runs.
3. Confirm the error-triggered execution does **not** increment production execution statistics (and does not appear in Insights "production executions"), while the failed parent execution still does.
4. Regression: confirm sub-workflow exclusion behaviour is unchanged.

See updated integration tests in `workflow-statistics.service.integration.test.ts`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-714

Originating bug: https://linear.app/n8n/issue/LIGO-513

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32315">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->