### PR TITLE
fix(core): Prevent queue recovery from marking waiting executions as crashed

### DIFF
--- a/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
+++ b/packages/@n8n/db/src/repositories/__tests__/execution.repository.test.ts
@@ -386,7 +386,7 @@ describe('ExecutionRepository', () => {
 
 			expect(entityManager.update).toHaveBeenCalledWith(
 				ExecutionEntity,
-				{ id: In(executionIds) },
+				{ id: In(executionIds), status: In(['new', 'running', 'unknown']) },
 				expect.objectContaining({ status: 'crashed', waitTill: null }),
 			);
 		});

--- a/packages/@n8n/db/src/repositories/execution.repository.ts
+++ b/packages/@n8n/db/src/repositories/execution.repository.ts
@@ -32,7 +32,11 @@ import type {
 	IRunExecutionData,
 	IRunExecutionDataAll,
 } from 'n8n-workflow';
-import { migrateRunExecutionData, UnexpectedError } from 'n8n-workflow';
+import {
+	CRASHABLE_EXECUTION_STATUSES,
+	migrateRunExecutionData,
+	UnexpectedError,
+} from 'n8n-workflow';
 
 import {
 	AnnotationTagEntity,
@@ -354,7 +358,10 @@ export class ExecutionRepository extends Repository<ExecutionEntity> {
 			// NOTE: if a slice goes past the end of the array, it just returns up til the end.
 			const batch: string[] = executionIds.slice(processed, processed + MAX_UPDATE_BATCH_SIZE);
 			await this.update(
-				{ id: In(batch) },
+				// Guard against overwriting executions that have since moved to a `waiting` or
+				// terminal status: recovery can race a `running` -> `waiting` transition and flag a
+				// healthy execution as dangling, but only genuinely in-progress rows should be crashed
+				{ id: In(batch), status: In(CRASHABLE_EXECUTION_STATUSES) },
 				{
 					status: 'crashed',
 					stoppedAt: new Date(),

--- a/packages/cli/test/integration/database/repositories/execution.repository.test.ts
+++ b/packages/cli/test/integration/database/repositories/execution.repository.test.ts
@@ -2,7 +2,7 @@ import { createWorkflow, testDb } from '@n8n/backend-test-utils';
 import { ExecutionDataRepository, ExecutionRepository } from '@n8n/db';
 import { Container } from '@n8n/di';
 import { stringify } from 'flatted';
-import type { IRunExecutionData, IRunExecutionDataAll } from 'n8n-workflow';
+import type { ExecutionStatus, IRunExecutionData, IRunExecutionDataAll } from 'n8n-workflow';
 
 describe('ExecutionRepository', () => {
 	beforeAll(async () => {
@@ -182,6 +182,101 @@ describe('ExecutionRepository', () => {
 			});
 
 			expect(executions).toHaveLength(2);
+		});
+	});
+
+	describe('markAsCrashed', () => {
+		const createExecution = async (status: ExecutionStatus, extra: { waitTill?: Date } = {}) => {
+			const workflow = await createWorkflow();
+			const { identifiers } = await Container.get(ExecutionRepository).insert({
+				workflowId: workflow.id,
+				mode: 'manual',
+				startedAt: new Date(),
+				status,
+				finished: status === 'success',
+				createdAt: new Date(),
+				...extra,
+			});
+			return identifiers[0].id as string;
+		};
+
+		it('should crash in-progress and indeterminate executions', async () => {
+			const executionRepo = Container.get(ExecutionRepository);
+			const newId = await createExecution('new');
+			const runningId = await createExecution('running');
+			const unknownId = await createExecution('unknown');
+
+			await executionRepo.markAsCrashed([newId, runningId, unknownId]);
+
+			const [newExec, runningExec, unknownExec] = await Promise.all([
+				executionRepo.findOneBy({ id: newId }),
+				executionRepo.findOneBy({ id: runningId }),
+				executionRepo.findOneBy({ id: unknownId }),
+			]);
+
+			expect(newExec?.status).toBe('crashed');
+			expect(runningExec?.status).toBe('crashed');
+			expect(unknownExec?.status).toBe('crashed');
+		});
+
+		it('should not overwrite a waiting execution or clear its waitTill', async () => {
+			const executionRepo = Container.get(ExecutionRepository);
+			const waitTill = new Date(Date.now() + 1000 * 60 * 60);
+			const waitingId = await createExecution('waiting', { waitTill });
+
+			await executionRepo.markAsCrashed([waitingId]);
+
+			const waitingExec = await executionRepo.findOneBy({ id: waitingId });
+			expect(waitingExec?.status).toBe('waiting');
+			expect(waitingExec?.waitTill?.getTime()).toBe(waitTill.getTime());
+		});
+
+		it('should not overwrite executions in a terminal status', async () => {
+			const executionRepo = Container.get(ExecutionRepository);
+			const successId = await createExecution('success');
+			const errorId = await createExecution('error');
+			const canceledId = await createExecution('canceled');
+			const crashedId = await createExecution('crashed');
+
+			await executionRepo.markAsCrashed([successId, errorId, canceledId, crashedId]);
+
+			const [successExec, errorExec, canceledExec, crashedExec] = await Promise.all([
+				executionRepo.findOneBy({ id: successId }),
+				executionRepo.findOneBy({ id: errorId }),
+				executionRepo.findOneBy({ id: canceledId }),
+				executionRepo.findOneBy({ id: crashedId }),
+			]);
+
+			expect(successExec?.status).toBe('success');
+			expect(errorExec?.status).toBe('error');
+			expect(canceledExec?.status).toBe('canceled');
+			expect(crashedExec?.status).toBe('crashed');
+		});
+
+		it('should crash only the crashable executions in a mixed batch', async () => {
+			const executionRepo = Container.get(ExecutionRepository);
+			const waitTill = new Date(Date.now() + 1000 * 60 * 60);
+			const runningId = await createExecution('running');
+			const waitingId = await createExecution('waiting', { waitTill });
+			const successId = await createExecution('success');
+
+			await executionRepo.markAsCrashed([runningId, waitingId, successId]);
+
+			const [runningExec, waitingExec, successExec] = await Promise.all([
+				executionRepo.findOneBy({ id: runningId }),
+				executionRepo.findOneBy({ id: waitingId }),
+				executionRepo.findOneBy({ id: successId }),
+			]);
+
+			// the running execution is crashed, with its lifecycle fields updated
+			expect(runningExec?.status).toBe('crashed');
+			expect(runningExec?.stoppedAt).toBeInstanceOf(Date);
+			expect(runningExec?.waitTill).toBeNull();
+
+			// the waiting and terminal executions in the same batch are left untouched
+			expect(waitingExec?.status).toBe('waiting');
+			expect(waitingExec?.waitTill?.getTime()).toBe(waitTill.getTime());
+			expect(successExec?.status).toBe('success');
 		});
 	});
 });

--- a/packages/workflow/src/execution-status.ts
+++ b/packages/workflow/src/execution-status.ts
@@ -15,6 +15,13 @@ export const TERMINAL_EXECUTION_STATUSES = ['canceled', 'crashed', 'error', 'suc
 
 export type TerminalExecutionStatus = (typeof TERMINAL_EXECUTION_STATUSES)[number];
 
+/**
+ * Statuses that may be overwritten to `crashed` by recovery. These are the in-progress
+ * and indeterminate states; `waiting` and the terminal statuses are deliberately excluded
+ * so a legitimately paused or finished execution is never marked as crashed.
+ */
+export const CRASHABLE_EXECUTION_STATUSES = ['new', 'running', 'unknown'] as const;
+
 export function isTerminalExecutionStatus(
 	status: ExecutionStatus | undefined,
 ): status is TerminalExecutionStatus {


### PR DESCRIPTION

## Summary

Currently, in queue model, there is a race condition during recovery from queue that can cause executions
to be marked as `crashed` if they were previously `running`, but transitioned to `waiting` by the time `markAsCrashed` is executed. This PR changes the update in `markAsCrashed` to ensure only executions that are still eligible to be crashed are updated to `crashed`.

<!--
Describe what the PR does.
Photos and videos are recommended.
-->

## How to test

Very narrow window for reproduction; this helps make it deterministic:

```diff
diff --git a/packages/cli/src/scaling/scaling.service.ts b/packages/cli/src/scaling/scaling.service.ts
--- a/packages/cli/src/scaling/scaling.service.ts
+++ b/packages/cli/src/scaling/scaling.service.ts
@@ -607,11 +607,17 @@ export class ScalingService {
      async recoverFromQueue() {
              const { waitMs, batchSize } = this.queueRecoveryContext;

              const storedIds = await this.executionRepository.getInProgressExecutionIds(batchSize);

              if (storedIds.length === 0) {
                      this.logger.debug('Completed queue recovery check, no dangling executions');
                      return waitMs;
              }

+             for (let i = 0; i < 60; i++) {
+                     const rows = await Promise.all(storedIds.map((id) => this.executionRepository.findOneBy({ id })));
+                     if (rows.some((e) => e?.status === 'waiting')) break;
+                     await sleep(1000);
+             }
+
              const runningJobs = await this.findJobsByStatus(['active', 'waiting']);
              const queuedIds = new Set(runningJobs.map((job) => job.data.executionId));

              const danglingIds = storedIds.filter((id) => !queuedIds.has(id));
```

- Have a `running` execution
- Trigger recovery from queue (invoke `recoverFromQueue` from `scaling.service.ts`, happens every 3 hours normally)
- Have execution move to a waiting state e.g. Wait node (within a minute of calling `recoverFromQueue` if using the patch above)
- Execution eventually marked as `crashed`, from `waiting`.

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32316">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

