### PR TITLE
feat(editor): Node groups design tweaks (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.test.ts
@@ -25,6 +25,7 @@ vi.mock('@vue-flow/core', () => ({
 	useVueFlow: () => ({
 		getSelectedNodes: selectedNodesRef,
 		removeSelectedNodes: removeSelectedNodesMock,
+		viewport: { value: { x: 0, y: 0, zoom: 1 } },
 	}),
 }));
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.vue
@@ -5,6 +5,7 @@ import { N8nIcon, N8nIconButton, N8nInlineTextEdit, N8nTooltip } from '@n8n/desi
 import { Handle, Position, useVueFlow } from '@vue-flow/core';
 import KeyboardShortcutTooltip from '@/app/components/KeyboardShortcutTooltip.vue';
 import CanvasNodeStatusMark from '../nodes/render-types/parts/CanvasNodeStatusMark.vue';
+import { useZoomAdjustedValues } from '../../../composables/useZoomAdjustedValues';
 import {
 	GROUP_HEADER_HEIGHT as HEADER_HEIGHT,
 	GROUP_PADDING_Y_BOTTOM as PADDING_Y_BOTTOM,
@@ -136,7 +137,11 @@ const toggleLabel = computed(() =>
 		: i18n.baseText('canvas.nodeGroup.collapse'),
 );
 
-const { getSelectedNodes, removeSelectedNodes } = useVueFlow();
+const { getSelectedNodes, removeSelectedNodes, viewport } = useVueFlow();
+
+// Match the zoom-adjusted border opacity normal nodes use
+const { calculateNodeBorderOpacityStyle } = useZoomAdjustedValues(viewport);
+const nodeBorderOpacityStyle = calculateNodeBorderOpacityStyle();
 
 // Clear unrelated pre-existing selection before VueFlow snapshots which
 // nodes to drag — otherwise those nodes ride along with the group drag.
@@ -165,6 +170,7 @@ function onWrapperPointerDown(event: PointerEvent) {
 		:style="{
 			width: '100%',
 			height: `${HEADER_HEIGHT}px`,
+			...nodeBorderOpacityStyle,
 		}"
 		data-test-id="canvas-node-group"
 		:data-group-id="group.id"

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.vue
@@ -349,7 +349,7 @@ function onWrapperPointerDown(event: PointerEvent) {
 	flex: 1;
 	min-width: 0;
 	height: 100%;
-	font-size: var(--font-size--sm);
+	font-size: var(--font-size--md);
 	font-weight: var(--font-weight--medium);
 }
 

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.vue
@@ -349,6 +349,11 @@ function onWrapperPointerDown(event: PointerEvent) {
 	flex-shrink: 0;
 }
 
+/*  Don't render the aria-expanded toggle as "pressed" while inactive */
+.toggle[aria-expanded='true']:not(:hover):not(:active) {
+	background-color: transparent;
+}
+
 .title {
 	display: flex;
 	align-items: center;

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/groups/CanvasNodeGroupTitleBar.vue
@@ -407,7 +407,7 @@ function onWrapperPointerDown(event: PointerEvent) {
 	position: absolute;
 	left: 0;
 	width: 100%;
-	background: transparent;
+	background: var(--background--hover);
 	@include styles.canvas-node-border(dashed);
 	border-top: none;
 	border-radius: 0 0 var(--radius--lg) var(--radius--lg);

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/elements/nodes/render-types/CanvasNodeDefault.vue
@@ -29,7 +29,7 @@ const emit = defineEmits<{
 }>();
 
 const { initialized, viewport, isExperimentalNdvActive } = useCanvas();
-const { calculateNodeBorderOpacity } = useZoomAdjustedValues(viewport);
+const { calculateNodeBorderOpacityStyle } = useZoomAdjustedValues(viewport);
 const route = useRoute();
 const {
 	id,
@@ -106,14 +106,13 @@ const nodeSize = computed(() =>
 	),
 );
 
-const nodeBorderOpacity = calculateNodeBorderOpacity();
+const nodeBorderOpacityStyle = calculateNodeBorderOpacityStyle();
 
 const styles = computed(() => ({
 	'--canvas-node--width': `${nodeSize.value.width}px`,
 	'--canvas-node--height': `${nodeSize.value.height}px`,
 	'--node--icon--size': `${iconSize.value}px`,
-	'--canvas-node--border--opacity-light': nodeBorderOpacity.value.light,
-	'--canvas-node--border--opacity-dark': nodeBorderOpacity.value.dark,
+	...nodeBorderOpacityStyle.value,
 }));
 
 const dataTestId = computed(() => {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useZoomAdjustedValues.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useZoomAdjustedValues.test.ts
@@ -151,23 +151,27 @@ describe(useZoomAdjustedValues, () => {
 		});
 	});
 
-	describe('calculateNodeBorderOpacity', () => {
-		it('should return base opacity values at zoom 1.0', () => {
+	describe('calculateNodeBorderOpacityStyle', () => {
+		it('should map base opacity values to CSS custom properties at zoom 1.0', () => {
 			const viewport = createViewport(1.0);
-			const { calculateNodeBorderOpacity } = useZoomAdjustedValues(viewport);
+			const { calculateNodeBorderOpacityStyle } = useZoomAdjustedValues(viewport);
 
-			const opacity = calculateNodeBorderOpacity();
-			expect(opacity.value.light).toBe('0.100');
-			expect(opacity.value.dark).toBe('0.200');
+			const style = calculateNodeBorderOpacityStyle();
+			expect(style.value).toEqual({
+				'--canvas-node--border--opacity-light': '0.100',
+				'--canvas-node--border--opacity-dark': '0.200',
+			});
 		});
 
-		it('should return max opacity values at minimum zoom', () => {
+		it('should map max opacity values to CSS custom properties at minimum zoom', () => {
 			const viewport = createViewport(0.2);
-			const { calculateNodeBorderOpacity } = useZoomAdjustedValues(viewport);
+			const { calculateNodeBorderOpacityStyle } = useZoomAdjustedValues(viewport);
 
-			const opacity = calculateNodeBorderOpacity();
-			expect(opacity.value.light).toBe('0.700');
-			expect(opacity.value.dark).toBe('0.700');
+			const style = calculateNodeBorderOpacityStyle();
+			expect(style.value).toEqual({
+				'--canvas-node--border--opacity-light': '0.700',
+				'--canvas-node--border--opacity-dark': '0.700',
+			});
 		});
 	});
 });

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useZoomAdjustedValues.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useZoomAdjustedValues.ts
@@ -86,10 +86,21 @@ export function useZoomAdjustedValues(viewport: Ref<ViewportTransform>) {
 		});
 	}
 
+	/**
+	 * Zoom-adjusted node border opacity mapped to the CSS custom properties
+	 */
+	function calculateNodeBorderOpacityStyle() {
+		const opacity = calculateNodeBorderOpacity();
+		return computed(() => ({
+			'--canvas-node--border--opacity-light': opacity.value.light,
+			'--canvas-node--border--opacity-dark': opacity.value.dark,
+		}));
+	}
+
 	return {
 		calculateZoomAdjustedValue,
 		calculateEdgeLightness,
 		calculateHandleLightness,
-		calculateNodeBorderOpacity,
+		calculateNodeBorderOpacityStyle,
 	};
 }


### PR DESCRIPTION
## Summary

- Make group titles font size same as Node names
- Use the same border effect when zooming out as normal nodes use
- Add translucent background to groups
- Fix the bug with the collapse button remaining pressed for expanded groups
    - This one comes from how system design component works with `aria-expanded` - hopefully we'll have a proper fix later

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-5317](https://linear.app/n8n/issue/ADO-5317/feature-design-tweaks)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32324">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

