### PR TITLE
feat(MCP Server Trigger Node): Add n8n OAuth2 authentication option

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
@@ -1,8 +1,9 @@
-import { getConnectedTools } from '@utils/helpers';
 import { WebhookAuthorizationError } from 'n8n-nodes-base/dist/nodes/Webhook/error';
 import { validateWebhookAuthentication } from 'n8n-nodes-base/dist/nodes/Webhook/utils';
 import type { INodeTypeDescription, IWebhookFunctions, IWebhookResponseData } from 'n8n-workflow';
 import { NodeConnectionTypes, Node, nodeNameToToolName } from 'n8n-workflow';
+
+import { getConnectedTools } from '@utils/helpers';
 
 import { McpServer, MCP_LIST_TOOLS_REQUEST_MARKER } from './McpServer';
 import { n8nOAuth2Auth } from './n8n-oauth2-auth';
@@ -95,7 +96,7 @@ export class McpTrigger extends Node {
 						// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
 						name: 'n8n OAuth2',
 						value: 'n8nOAuth2',
-						description: 'Protect this MCP server with the instance’s built-in OAuth 2.1 server',
+						description: 'Protect this MCP server with the built-in OAuth 2.1 server',
 						displayOptions: { show: { '@version': [{ _cnd: { gte: 2 } }] } },
 					},
 				],

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
@@ -1,11 +1,12 @@
-import { McpServer, MCP_LIST_TOOLS_REQUEST_MARKER } from './McpServer';
-import type { CompressionResponse } from './transport';
+import { getConnectedTools } from '@utils/helpers';
 import { WebhookAuthorizationError } from 'n8n-nodes-base/dist/nodes/Webhook/error';
 import { validateWebhookAuthentication } from 'n8n-nodes-base/dist/nodes/Webhook/utils';
 import type { INodeTypeDescription, IWebhookFunctions, IWebhookResponseData } from 'n8n-workflow';
 import { NodeConnectionTypes, Node, nodeNameToToolName } from 'n8n-workflow';
 
-import { getConnectedTools } from '@utils/helpers';
+import { McpServer, MCP_LIST_TOOLS_REQUEST_MARKER } from './McpServer';
+import { n8nOAuth2Auth } from './n8n-oauth2-auth';
+import type { CompressionResponse } from './transport';
 
 const MCP_SSE_SETUP_PATH = 'sse';
 const MCP_SSE_MESSAGES_PATH = 'messages';
@@ -89,6 +90,14 @@ export class McpTrigger extends Node {
 					{ name: 'None', value: 'none' },
 					{ name: 'Bearer Auth', value: 'bearerAuth' },
 					{ name: 'Header Auth', value: 'headerAuth' },
+					{
+						// n8n is a brand name and should be lowercase
+						// eslint-disable-next-line n8n-nodes-base/node-param-display-name-miscased
+						name: 'n8n OAuth2',
+						value: 'n8nOAuth2',
+						description: 'Protect this MCP server with the instance’s built-in OAuth 2.1 server',
+						displayOptions: { show: { '@version': [{ _cnd: { gte: 2 } }] } },
+					},
 				],
 				default: 'none',
 				description: 'The way to authenticate',
@@ -146,15 +155,27 @@ export class McpTrigger extends Node {
 		const req = context.getRequestObject();
 		const resp = context.getResponseObject() as unknown as CompressionResponse;
 
-		try {
-			await validateWebhookAuthentication(context, 'authentication');
-		} catch (error) {
-			if (error instanceof WebhookAuthorizationError) {
-				resp.writeHead(error.responseCode);
-				resp.end(error.message);
+		if (context.getNodeParameter('authentication') === 'n8nOAuth2') {
+			if (context.getNode().typeVersion < 2) {
+				resp.writeHead(401);
+				resp.end('OAuth2 authentication requires mcp trigger node v2.0 or higher');
 				return { noWebhookResponse: true };
 			}
-			throw error;
+			const authResult = await n8nOAuth2Auth(context);
+			if (authResult === 'handled') {
+				return { noWebhookResponse: true };
+			}
+		} else {
+			try {
+				await validateWebhookAuthentication(context, 'authentication');
+			} catch (error) {
+				if (error instanceof WebhookAuthorizationError) {
+					resp.writeHead(error.responseCode);
+					resp.end(error.message);
+					return { noWebhookResponse: true };
+				}
+				throw error;
+			}
 		}
 
 		const node = context.getNode();

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__tests__/McpTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__tests__/McpTrigger.node.test.ts
@@ -1,4 +1,9 @@
-import type { INode, IWebhookFunctions, ICredentialDataDecryptedObject } from 'n8n-workflow';
+import type {
+	INode,
+	INodePropertyOptions,
+	IWebhookFunctions,
+	ICredentialDataDecryptedObject,
+} from 'n8n-workflow';
 import type { Mock, Mocked } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
@@ -87,10 +92,19 @@ describe('McpTrigger', () => {
 			expect(authParam).toBeDefined();
 			expect(authParam?.type).toBe('options');
 			expect(authParam?.default).toBe('none');
-			expect(authParam?.options).toHaveLength(3);
+			expect(authParam?.options).toHaveLength(4);
 			expect(authParam?.builderHint).toEqual({
 				propertyHint: INBOUND_TRIGGER_AUTHENTICATION_BUILDER_HINT,
 			});
+		});
+
+		it('should gate the n8nOAuth2 option to node version 2 and above', () => {
+			const authParam = mcpTrigger.description.properties?.find((p) => p.name === 'authentication');
+			const options = authParam?.options as INodePropertyOptions[];
+			const oauthOption = options.find((o) => o.value === 'n8nOAuth2');
+
+			expect(oauthOption).toBeDefined();
+			expect(oauthOption?.displayOptions).toEqual({ show: { '@version': [{ _cnd: { gte: 2 } }] } });
 		});
 
 		it('should define webhook endpoints', () => {
@@ -371,6 +385,97 @@ describe('McpTrigger', () => {
 
 			expect(resp.writeHead).toHaveBeenCalledWith(401);
 			expect(resp.end).toHaveBeenCalledWith('Unauthorized');
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+	});
+
+	describe('n8nOAuth2 authentication', () => {
+		const resourceUrl = 'https://n8n.example.com/mcp/abc';
+		const prmUrl = 'https://n8n.example.com/.well-known/oauth-protected-resource/mcp/abc';
+
+		function setupContext(opts: { typeVersion: number; headers?: Record<string, string> }) {
+			const req = createMockRequest({ path: '/mcp/abc', headers: opts.headers ?? {} });
+			const resp = createMockResponse();
+			const node = mock<INode>({ typeVersion: opts.typeVersion, name: 'MCP Server Trigger' });
+
+			mockContext.getNodeParameter.mockReturnValue('n8nOAuth2');
+			mockContext.getNodeWebhookUrl.mockReturnValue(resourceUrl);
+			mockContext.getWebhookName.mockReturnValue('setup');
+			mockContext.getRequestObject.mockReturnValue(req as never);
+			mockContext.getResponseObject.mockReturnValue(resp as never);
+			mockContext.getNode.mockReturnValue(node);
+			return { req, resp, node };
+		}
+
+		it('fails closed with 401 on node version below 2', async () => {
+			const { resp } = setupContext({ typeVersion: 1.1 });
+
+			const result = await mcpTrigger.webhook(mockContext);
+
+			expect(resp.writeHead).toHaveBeenCalledWith(401);
+			expect(mockContext.validateN8nOAuth2Token).not.toHaveBeenCalled();
+			expect(mockMcpServer.handleSetupRequest).not.toHaveBeenCalled();
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		it('returns 401 with resource_metadata and no error when the bearer token is missing', async () => {
+			const { resp } = setupContext({ typeVersion: 2 });
+
+			const result = await mcpTrigger.webhook(mockContext);
+
+			expect(resp.writeHead).toHaveBeenCalledWith(401, {
+				'WWW-Authenticate': `Bearer realm="n8n MCP Server", resource_metadata="${prmUrl}"`,
+			});
+			expect(mockContext.validateN8nOAuth2Token).not.toHaveBeenCalled();
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		it('returns 401 with error="invalid_token" when the token is rejected', async () => {
+			const { resp } = setupContext({
+				typeVersion: 2,
+				headers: { authorization: 'Bearer bad-token' },
+			});
+			mockContext.validateN8nOAuth2Token.mockResolvedValue({
+				valid: false,
+				reason: 'invalid_token',
+			});
+
+			const result = await mcpTrigger.webhook(mockContext);
+
+			expect(mockContext.validateN8nOAuth2Token).toHaveBeenCalledWith('bad-token', resourceUrl);
+			expect(resp.writeHead).toHaveBeenCalledWith(401, {
+				'WWW-Authenticate': `Bearer realm="n8n MCP Server", error="invalid_token", resource_metadata="${prmUrl}"`,
+			});
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		it('returns 503 when the token verifier is unavailable', async () => {
+			const { resp } = setupContext({
+				typeVersion: 2,
+				headers: { authorization: 'Bearer some-token' },
+			});
+			mockContext.validateN8nOAuth2Token.mockResolvedValue({
+				valid: false,
+				reason: 'verifier_unavailable',
+			});
+
+			const result = await mcpTrigger.webhook(mockContext);
+
+			expect(resp.status).toHaveBeenCalledWith(503);
+			expect(resp.writeHead).not.toHaveBeenCalled();
+			expect(result).toEqual({ noWebhookResponse: true });
+		});
+
+		it('proceeds to MCP dispatch when the token is valid', async () => {
+			setupContext({ typeVersion: 2, headers: { authorization: 'Bearer good-token' } });
+			mockContext.validateN8nOAuth2Token.mockResolvedValue({
+				valid: true,
+				user: { id: 'u1', email: 'u@example.com', firstName: 'U', lastName: 'One' },
+			});
+
+			const result = await mcpTrigger.webhook(mockContext);
+
+			expect(mockMcpServer.handleSetupRequest).toHaveBeenCalled();
 			expect(result).toEqual({ noWebhookResponse: true });
 		});
 	});

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__tests__/McpTrigger.node.test.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/__tests__/McpTrigger.node.test.ts
@@ -444,7 +444,7 @@ describe('McpTrigger', () => {
 
 			expect(mockContext.validateN8nOAuth2Token).toHaveBeenCalledWith('bad-token', resourceUrl);
 			expect(resp.writeHead).toHaveBeenCalledWith(401, {
-				'WWW-Authenticate': `Bearer realm="n8n MCP Server", error="invalid_token", resource_metadata="${prmUrl}"`,
+				'WWW-Authenticate': `Bearer realm="n8n MCP Server", resource_metadata="${prmUrl}", error="invalid_token"`,
 			});
 			expect(result).toEqual({ noWebhookResponse: true });
 		});

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/n8n-oauth2-auth.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/n8n-oauth2-auth.ts
@@ -22,10 +22,11 @@ export const n8nOAuth2Auth = async (context: IWebhookFunctions): Promise<'ok' | 
 	const resourceUrl = trimTrailingSlash(webhookUrl);
 
 	const u = new URL(resourceUrl);
+
 	const prmUrl = `${u.origin}/.well-known/oauth-protected-resource${u.pathname}`;
 
-	const req = context.getRequestObject();
 	const resp = context.getResponseObject();
+	const req = context.getRequestObject();
 
 	const authHeader = req.headers['authorization'];
 	const token = getBearerToken(authHeader);

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/n8n-oauth2-auth.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/n8n-oauth2-auth.ts
@@ -1,0 +1,53 @@
+import { UnexpectedError, type IWebhookFunctions } from 'n8n-workflow';
+
+function trimTrailingSlash(url: string): string {
+	return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+function getBearerToken(headerValue: string | undefined): string | null {
+	if (!headerValue) return null;
+	const split = headerValue.split(' ');
+	if (split.length !== 2 || split[0].toLowerCase() !== 'bearer') {
+		return null;
+	}
+	return split[1];
+}
+
+export const n8nOAuth2Auth = async (context: IWebhookFunctions): Promise<'ok' | 'handled'> => {
+	const webhookUrl = context.getNodeWebhookUrl('default');
+	if (!webhookUrl) {
+		throw new UnexpectedError('Webhook URL is not available');
+	}
+
+	const resourceUrl = trimTrailingSlash(webhookUrl);
+
+	const u = new URL(resourceUrl);
+	const prmUrl = `${u.origin}/.well-known/oauth-protected-resource${u.pathname}`;
+
+	const req = context.getRequestObject();
+	const resp = context.getResponseObject();
+
+	const authHeader = req.headers['authorization'];
+	const token = getBearerToken(authHeader);
+	if (!token) {
+		resp.writeHead(401, {
+			'WWW-Authenticate': `Bearer realm="n8n MCP Server", resource_metadata="${prmUrl}"`,
+		});
+		resp.end();
+		return 'handled';
+	}
+
+	const validationResult = await context.validateN8nOAuth2Token(token, resourceUrl);
+	if (validationResult.valid) {
+		return 'ok';
+	}
+	if (validationResult.reason === 'invalid_token') {
+		resp.writeHead(401, {
+			'WWW-Authenticate': `Bearer realm="n8n MCP Server", error="invalid_token", resource_metadata="${prmUrl}"`,
+		});
+		resp.end();
+	} else {
+		resp.status(503).send('OAuth token validation is not available');
+	}
+	return 'handled';
+};

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/n8n-oauth2-auth.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/n8n-oauth2-auth.ts
@@ -13,6 +13,20 @@ function getBearerToken(headerValue: string | undefined): string | null {
 	return split[1];
 }
 
+function sendUnauthorizedResponse(
+	resp: ReturnType<IWebhookFunctions['getResponseObject']>,
+	prmUrl: string,
+	error?: string,
+) {
+	const authenticateHeader =
+		`Bearer realm="n8n MCP Server", resource_metadata="${prmUrl}"` +
+		(error ? `, error="${error}"` : '');
+	resp.writeHead(401, {
+		'WWW-Authenticate': authenticateHeader,
+	});
+	resp.end();
+}
+
 export const n8nOAuth2Auth = async (context: IWebhookFunctions): Promise<'ok' | 'handled'> => {
 	const webhookUrl = context.getNodeWebhookUrl('default');
 	if (!webhookUrl) {
@@ -31,24 +45,18 @@ export const n8nOAuth2Auth = async (context: IWebhookFunctions): Promise<'ok' | 
 	const authHeader = req.headers['authorization'];
 	const token = getBearerToken(authHeader);
 	if (!token) {
-		resp.writeHead(401, {
-			'WWW-Authenticate': `Bearer realm="n8n MCP Server", resource_metadata="${prmUrl}"`,
-		});
-		resp.end();
+		sendUnauthorizedResponse(resp, prmUrl);
 		return 'handled';
 	}
 
 	const validationResult = await context.validateN8nOAuth2Token(token, resourceUrl);
-	if (validationResult.valid) {
-		return 'ok';
+	if (!validationResult.valid) {
+		if (validationResult.reason === 'invalid_token') {
+			sendUnauthorizedResponse(resp, prmUrl, 'invalid_token');
+		} else {
+			resp.status(503).send('OAuth token validation is not available');
+		}
+		return 'handled';
 	}
-	if (validationResult.reason === 'invalid_token') {
-		resp.writeHead(401, {
-			'WWW-Authenticate': `Bearer realm="n8n MCP Server", error="invalid_token", resource_metadata="${prmUrl}"`,
-		});
-		resp.end();
-	} else {
-		resp.status(503).send('OAuth token validation is not available');
-	}
-	return 'handled';
+	return 'ok';
 };

--- a/packages/cli/src/modules/__tests__/main-only-modules.test.ts
+++ b/packages/cli/src/modules/__tests__/main-only-modules.test.ts
@@ -12,15 +12,10 @@ import '../oauth-server/oauth-server.module';
 describe('main-only modules', () => {
 	const metadata = Container.get(ModuleMetadata);
 
-	test.each([
-		'sso-oidc',
-		'sso-saml',
-		'source-control',
-		'provisioning',
-		'breaking-changes',
-		'mcp',
-		'oauth-server',
-	])('%s should only run on main', (moduleName) => {
-		expect(metadata.get(moduleName)?.instanceTypes).toEqual(['main']);
-	});
+	test.each(['sso-oidc', 'sso-saml', 'source-control', 'provisioning', 'breaking-changes', 'mcp'])(
+		'%s should only run on main',
+		(moduleName) => {
+			expect(metadata.get(moduleName)?.instanceTypes).toEqual(['main']);
+		},
+	);
 });

--- a/packages/cli/src/modules/oauth-server/__tests__/oauth-server.module.test.ts
+++ b/packages/cli/src/modules/oauth-server/__tests__/oauth-server.module.test.ts
@@ -1,0 +1,13 @@
+import { ModuleMetadata } from '@n8n/decorators';
+import { Container } from '@n8n/di';
+
+// Importing the module runs the @BackendModule decorator, registering its metadata.
+import '../oauth-server.module';
+
+describe('OAuthServerModule', () => {
+	it('initializes on both main and webhook instances so the token verifier is available in queue mode', () => {
+		const entry = Container.get(ModuleMetadata).get('oauth-server');
+
+		expect(entry?.instanceTypes).toEqual(['main', 'webhook']);
+	});
+});

--- a/packages/cli/src/modules/oauth-server/oauth-server.module.ts
+++ b/packages/cli/src/modules/oauth-server/oauth-server.module.ts
@@ -2,6 +2,7 @@ import { ProtectedResourceRegistry } from '@/services/protected-resource.registr
 import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule } from '@n8n/decorators';
 import { Container } from '@n8n/di';
+import { InstanceSettings } from 'n8n-core';
 
 /**
  * Shared OAuth 2.1 authorization server.
@@ -11,12 +12,15 @@ import { Container } from '@n8n/di';
  * documents for the protected resources registered in the
  * `ProtectedResourceRegistry` (e.g. the instance MCP server).
  */
-@BackendModule({ name: 'oauth-server', instanceTypes: ['main'] })
+@BackendModule({ name: 'oauth-server', instanceTypes: ['main', 'webhook'] })
 export class OAuthServerModule implements ModuleInterface {
 	async init() {
-		await import('./oauth.controller');
-		await import('./oauth-consent.controller');
-		await import('./oauth-clients.controller');
+		// Only import controllers in the main process, since the webhook process doesn't run an HTTP server and doesn't need them.
+		if (Container.get(InstanceSettings).instanceType === 'main') {
+			await import('./oauth.controller');
+			await import('./oauth-consent.controller');
+			await import('./oauth-clients.controller');
+		}
 
 		// Register the token service as the OAuth token verifier provider, so
 		// protected-resource modules verify bearer tokens through the core

--- a/packages/cli/src/services/__tests__/oauth-token-verifier-proxy.service.test.ts
+++ b/packages/cli/src/services/__tests__/oauth-token-verifier-proxy.service.test.ts
@@ -11,7 +11,7 @@ describe('OAuthTokenVerifierProxy', () => {
 		const result = await proxy.verifyOAuthAccessToken('some-token', 'https://n8n.example.com');
 
 		expect(result.user).toBeNull();
-		expect(result.context).toMatchObject({ reason: 'unknown_error', auth_type: 'oauth' });
+		expect(result.context).toMatchObject({ reason: 'verifier_not_registered', auth_type: 'oauth' });
 	});
 
 	it('should delegate to the registered provider', async () => {

--- a/packages/cli/src/services/oauth-token-verifier-proxy.service.ts
+++ b/packages/cli/src/services/oauth-token-verifier-proxy.service.ts
@@ -9,7 +9,8 @@ export type AuthFailureReason =
 	| 'token_not_found_in_db'
 	| 'user_not_found'
 	| 'user_id_not_in_auth_info'
-	| 'unknown_error';
+	| 'unknown_error'
+	| 'verifier_not_registered';
 
 export type Mcpauth_type = 'oauth' | 'api_key' | 'unknown';
 
@@ -61,7 +62,7 @@ export class OAuthTokenVerifierProxy implements OAuthTokenVerifier {
 			return {
 				user: null,
 				context: {
-					reason: 'unknown_error',
+					reason: 'verifier_not_registered',
 					auth_type: 'oauth',
 					error_details: 'No OAuth token verifier is registered on this instance',
 				},

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -58,6 +58,7 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { UnprocessableRequestError } from '@/errors/response-errors/unprocessable.error';
 import { EventService } from '@/events/event.service';
 import { parseBody } from '@/middlewares';
+import { OAuthTokenVerifierProxy } from '@/services/oauth-token-verifier-proxy.service';
 import { OwnershipService } from '@/services/ownership.service';
 import { WorkflowStatisticsService } from '@/services/workflow-statistics.service';
 import { WaitTracker } from '@/wait-tracker';
@@ -78,7 +79,6 @@ import {
 } from './webhook-response-headers';
 import { WebhookService } from './webhook.service';
 import type { IWebhookResponseCallbackData, WebhookRequest } from './webhook.types';
-import { OAuthTokenVerifierProxy } from '@/services/oauth-token-verifier-proxy.service';
 
 // Type guards for MCP queue mode data validation
 interface McpToolCallPayload {

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -58,7 +58,10 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import { UnprocessableRequestError } from '@/errors/response-errors/unprocessable.error';
 import { EventService } from '@/events/event.service';
 import { parseBody } from '@/middlewares';
-import { OAuthTokenVerifierProxy } from '@/services/oauth-token-verifier-proxy.service';
+import {
+	AuthFailureReason,
+	OAuthTokenVerifierProxy,
+} from '@/services/oauth-token-verifier-proxy.service';
 import { OwnershipService } from '@/services/ownership.service';
 import { WorkflowStatisticsService } from '@/services/workflow-statistics.service';
 import { WaitTracker } from '@/wait-tracker';
@@ -528,10 +531,14 @@ export async function executeWebhook(
 				},
 			};
 		}
+		const VERIFIER_UNAVAILABLE_REASONS: AuthFailureReason[] = [
+			'verifier_not_registered',
+			'unknown_error',
+		];
 		return {
 			valid: false,
 			reason:
-				result.context?.reason === 'verifier_not_registered'
+				result.context?.reason && VERIFIER_UNAVAILABLE_REASONS.includes(result.context.reason)
 					? 'verifier_unavailable'
 					: 'invalid_token',
 		};

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -78,6 +78,7 @@ import {
 } from './webhook-response-headers';
 import { WebhookService } from './webhook.service';
 import type { IWebhookResponseCallbackData, WebhookRequest } from './webhook.types';
+import { OAuthTokenVerifierProxy } from '@/services/oauth-token-verifier-proxy.service';
 
 // Type guards for MCP queue mode data validation
 interface McpToolCallPayload {
@@ -510,6 +511,29 @@ export async function executeWebhook(
 			email: user.email,
 			firstName: user.firstName,
 			lastName: user.lastName,
+		};
+	};
+
+	additionalData.validateN8nOAuth2Token = async (token: string, resourceUrl: string) => {
+		const oauthTokenVerifierProxy = Container.get(OAuthTokenVerifierProxy);
+		const result = await oauthTokenVerifierProxy.verifyOAuthAccessToken(token, resourceUrl);
+		if (result.user) {
+			return {
+				valid: true,
+				user: {
+					id: result.user.id,
+					email: result.user.email,
+					firstName: result.user.firstName,
+					lastName: result.user.lastName,
+				},
+			};
+		}
+		return {
+			valid: false,
+			reason:
+				result.context?.reason === 'verifier_not_registered'
+					? 'verifier_unavailable'
+					: 'invalid_token',
 		};
 	};
 

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -59,7 +59,7 @@ import { UnprocessableRequestError } from '@/errors/response-errors/unprocessabl
 import { EventService } from '@/events/event.service';
 import { parseBody } from '@/middlewares';
 import {
-	AuthFailureReason,
+	type AuthFailureReason,
 	OAuthTokenVerifierProxy,
 } from '@/services/oauth-token-verifier-proxy.service';
 import { OwnershipService } from '@/services/ownership.service';

--- a/packages/cli/src/workflow-execute-additional-data.ts
+++ b/packages/cli/src/workflow-execute-additional-data.ts
@@ -669,6 +669,8 @@ export async function getBase({
 		webhookBaseUrl: urlBaseWebhook + globalConfig.endpoints.webhook,
 		webhookWaitingBaseUrl: urlBaseWebhook + globalConfig.endpoints.webhookWaiting,
 		webhookTestBaseUrl: urlBaseWebhook + globalConfig.endpoints.webhookTest,
+		mcpBaseUrl: urlBaseWebhook + globalConfig.endpoints.mcp,
+		mcpTestBaseUrl: urlBaseWebhook + globalConfig.endpoints.mcpTest,
 		currentNodeParameters,
 		executionTimeoutTimestamp,
 		userId,

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/webhook-helper-functions.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/webhook-helper-functions.test.ts
@@ -147,4 +147,53 @@ describe('Webhook Helper Functions', () => {
 			expect(expression.getSimpleParameterValue).toHaveBeenCalled();
 		});
 	});
+
+	describe('getNodeWebhookUrl for MCP nodes', () => {
+		const mcpBaseUrl = 'http://localhost:5678/mcp';
+		const mcpTestBaseUrl = 'http://localhost:5678/mcp-test';
+		const additionalData = mock<IWorkflowExecuteAdditionalData>({
+			webhookBaseUrl: 'http://localhost:5678/webhook',
+			webhookTestBaseUrl: 'http://localhost:5678/webhook-test',
+			mcpBaseUrl,
+			mcpTestBaseUrl,
+		});
+
+		test.each([
+			{
+				description: 'uses the dedicated MCP base URL for production',
+				isTest: false,
+				expected: `${mcpBaseUrl}/workflow-id/test-node/mcp`,
+			},
+			{
+				description: 'uses the dedicated MCP test base URL for test',
+				isTest: true,
+				expected: `${mcpTestBaseUrl}/workflow-id/test-node/mcp`,
+			},
+		])('$description', ({ isTest, expected }) => {
+			node.webhookId = undefined;
+			const webhookDescription = mock<IWebhookDescription>({
+				name: 'default',
+				isFullPath: false,
+				nodeType: 'mcp',
+				path: 'mcp',
+			});
+			nodeType.description.webhooks = [webhookDescription];
+			nodeTypes.getByNameAndVersion.mockReturnValueOnce(nodeType);
+			expression.getSimpleParameterValue.mockImplementation((_node, parameterValue) =>
+				parameterValue === 'mcp' ? 'mcp' : parameterValue,
+			);
+
+			const result = getNodeWebhookUrl(
+				'default',
+				workflow,
+				node,
+				additionalData,
+				'manual',
+				{},
+				isTest,
+			);
+
+			expect(result).toEqual(expected);
+		});
+	});
 });

--- a/packages/core/src/execution-engine/node-execution-context/utils/webhook-helper-functions.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/webhook-helper-functions.ts
@@ -39,13 +39,15 @@ export function getNodeWebhookUrl(
 	additionalKeys: IWorkflowDataProxyAdditionalKeys,
 	isTest?: boolean,
 ): string | undefined {
-	let baseUrl = additionalData.webhookBaseUrl;
-	if (isTest === true) {
-		baseUrl = additionalData.webhookTestBaseUrl;
-	}
-
 	const webhookDescription = getWebhookDescription(name, workflow, node);
 	if (webhookDescription === undefined) return;
+
+	let baseUrl: string;
+	if (webhookDescription.nodeType === 'mcp') {
+		baseUrl = isTest === true ? additionalData.mcpTestBaseUrl : additionalData.mcpBaseUrl;
+	} else {
+		baseUrl = isTest === true ? additionalData.webhookTestBaseUrl : additionalData.webhookBaseUrl;
+	}
 
 	const path = workflow.expression.getSimpleParameterValue(
 		node,

--- a/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
@@ -13,6 +13,7 @@ import type {
 	IWebhookData,
 	IWebhookFunctions,
 	IWorkflowExecuteAdditionalData,
+	N8nOAuth2ValidationResult,
 	WebhookType,
 	Workflow,
 	WorkflowExecuteMode,
@@ -138,6 +139,16 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 			throw new UnexpectedError('Cookie auth validation is not available');
 		}
 		return await this.additionalData.validateCookieAuth(cookieValue);
+	}
+
+	async validateN8nOAuth2Token(
+		token: string,
+		resourceUrl: string,
+	): Promise<N8nOAuth2ValidationResult> {
+		if (!this.additionalData.validateN8nOAuth2Token) {
+			throw new UnexpectedError('OAuth2 token validation is not available');
+		}
+		return await this.additionalData.validateN8nOAuth2Token(token, resourceUrl);
 	}
 
 	async getInputConnectionData(

--- a/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
@@ -120,6 +120,12 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 	}
 
 	getNodeWebhookUrl(name: WebhookType): string | undefined {
+		// MCP webhooks are served under dedicated /mcp and /mcp-test endpoints; the OAuth
+		// resource URL must match the endpoint the request actually arrived on. Other webhook
+		// types keep their existing behaviour (production base) here.
+		const isTest =
+			this.webhookData.webhookDescription.nodeType === 'mcp' ? this.webhookData.isTest : undefined;
+
 		return getNodeWebhookUrl(
 			name,
 			this.workflow,
@@ -127,6 +133,7 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 			this.additionalData,
 			this.mode,
 			this.additionalKeys,
+			isTest,
 		);
 	}
 

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -147,6 +147,10 @@ export interface IUser {
 	lastName: string;
 }
 
+export type N8nOAuth2ValidationResult =
+	| { valid: true; user: IUser }
+	| { valid: false; reason: 'invalid_token' | 'verifier_unavailable' };
+
 export type ProjectSharingData = {
 	id: string;
 	name: string | null;
@@ -1351,6 +1355,7 @@ export interface IHookFunctions
 export interface IWebhookFunctions extends FunctionsBaseWithRequiredKeys<'getMode'> {
 	getBodyData(): IDataObject;
 	getHeaderData(): IncomingHttpHeaders;
+	validateN8nOAuth2Token(token: string, resourceUrl: string): Promise<N8nOAuth2ValidationResult>;
 	getInputConnectionData(
 		connectionType: AINodeConnectionType,
 		itemIndex: number,
@@ -3306,6 +3311,10 @@ export interface IWorkflowExecuteAdditionalData {
 		runExecutionData: IRunExecutionData,
 		alias: string,
 	): Promise<IDataObject[string] | undefined>;
+	validateN8nOAuth2Token?: (
+		token: string,
+		resourceUrl: string,
+	) => Promise<N8nOAuth2ValidationResult>;
 	currentNodeExecutionIndex: number;
 	httpResponse?: express.Response;
 	httpRequest?: express.Request;

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -3327,6 +3327,8 @@ export interface IWorkflowExecuteAdditionalData {
 	webhookBaseUrl: string;
 	webhookWaitingBaseUrl: string;
 	webhookTestBaseUrl: string;
+	mcpBaseUrl: string;
+	mcpTestBaseUrl: string;
 	currentNodeParameters?: INodeParameters;
 	executionTimeoutTimestamp?: number;
 	userId?: string;


### PR DESCRIPTION
Adds `n8n OAuth2` as an `Authentication` option on the **MCP Server Trigger** node (typeVersion ≥ 2). When selected, every request to that workflow's MCP endpoint must carry a valid bearer token scoped to the workflow's protected-resource URL. Missing/invalid tokens are rejected with `401` and a per-workflow `WWW-Authenticate` header pointing at the resource's metadata document; if the instance's OAuth server is unavailable the request fails with `503`. The gate runs **before** any MCP dispatch, so `initialize`, `tools/list`, and no-credential tools are all protected.

Because nodes can't import `cli` (where the DB-backed token service lives), `cli` injects a `validateN8nOAuth2Token(token, resourceUrl)` helper onto the webhook execution context — the same pattern as the existing `validateCookieAuth`.

### Why

This is **slice 4 of 5** of [IAM-799](https://linear.app/n8n/issue/IAM-799) (OAuth-protect the MCP Trigger per-workflow). It depends on the per-workflow protected-resource resolver from IAM-817 (already merged), which is what lets a token be minted and audience-checked against a specific workflow's resource. This slice is the part that makes the protection **user-visible and enforced** on the node.

It is gated to v2+ because v1 splits the trigger into `/sse` + `/messages` sub-paths, which would yield two different audiences for one logical resource.

### How to test manually

Prerequisites: an n8n instance with the `oauth-server` module enabled.

1. Create a workflow with an **MCP Server Trigger** (node version 2), set **Authentication → n8n OAuth2**, and activate it.
2. **Unauthenticated request** → POST to the node's MCP URL with no `Authorization` header. Expect `401` with
   `WWW-Authenticate: Bearer realm="n8n MCP Server", resource_metadata="<origin>/.well-known/oauth-protected-resource/mcp/<path>"`.
3. **Discovery** → `GET` that `resource_metadata` URL. Expect `200` and `resource` equal to the node's MCP URL.
4. **Happy path** → run the OAuth 2.1 PKCE flow (dynamic client registration → authorize → consent → token) for that resource indicator, then call the MCP endpoint with `Authorization: Bearer <token>`. Expect `initialize` / `tools/list` to succeed.
5. **Rejected token** → reuse a token minted for a *different* resource, or an expired one. Expect `401` with `error="invalid_token"` in the `WWW-Authenticate` header.
6. **Queue mode** → run a dedicated **webhook** process and repeat step 4; token validation must work there too (the `oauth-server` module now registers its verifier on webhook instances).
7. **Version gating** → on a v1 MCP Server Trigger, confirm the `n8n OAuth2` option is hidden in the UI.

Edge case: a v1 node with `authentication: "n8nOAuth2"` injected via workflow JSON import fails closed with `401` (the UI gate is cosmetic; the server enforces it).

### Key implementation decisions

- **Helper-injection over import**: the node calls `context.validateN8nOAuth2Token(...)`, which `cli` injects in `executeWebhook` via `OAuthTokenVerifierProxy` — mirrors `validateCookieAuth`, keeps the node free of a `cli` dependency.
- **Discriminated result, not a thrown error**: `N8nOAuth2ValidationResult` distinguishes `invalid_token` from `verifier_unavailable` without leaking *why* a token failed (RFC 6750). Invalid/expired/wrong-audience all collapse to `invalid_token` for the client.
- **503 vs 401**: a missing verifier (OAuth server disabled / not registered) is a server misconfiguration → `503` with no `WWW-Authenticate`, distinct from a client auth failure → `401`.
- **Module split for queue mode**: `oauth-server` now runs on `['main', 'webhook']`, but only registers the token-verifier provider on webhook processes — the `/authorize`, `/token`, consent and DCR controllers (and the protected-resource discovery docs) remain main-only. Dedicated-webhook deployments must route `/.well-known/*`, `/authorize`, `/token`, `/register` to the main instance.
- **Correct resource URL**: MCP webhooks are served under dedicated `/mcp` and `/mcp-test` endpoints, so `getNodeWebhookUrl` now resolves MCP nodes against `mcpBaseUrl` / `mcpTestBaseUrl`. This makes the token audience and the advertised metadata URL match the endpoint the request actually arrived on (and what IAM-817 registers).
- **Defense in depth on version gating**: the option is hidden in the UI via per-option `displayOptions` (`@version` ≥ 2), and the webhook handler additionally fails closed on v1.


## Related Linear tickets, Github issues, and Community forum posts

closes  https://linear.app/n8n/issue/IAM-818

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32326">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

