### PR TITLE
test(e2e): docker cache-impact probe (stacked on DEVP-262) (no-changelog)

### DIFF
--- a/packages/testing/playwright/tests/e2e/auth/admin-smoke.spec.ts
+++ b/packages/testing/playwright/tests/e2e/auth/admin-smoke.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '../../../fixtures/base';
 
+// cache-impact probe: trivial test-only change to force a docker rebuild (DEVP-262)
 test.describe(
 	'Admin user',
 	{


### PR DESCRIPTION
Stacked on #32279 to measure docker build-cache impact: a trivial test-only change that forces `prepare-docker` to rebuild the n8n image (new SHA, `compiled/` identical except buildTime). The native rebuild step time vs the cold baseline shows the ccache impact. Throwaway — do not merge.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32334">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

