### PR TITLE
feat(editor): Use an action menu for API key row actions

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -3366,6 +3366,7 @@
 	"settings.api.columns.lastUsed": "Last used",
 	"settings.api.columns.actions": "Actions",
 	"settings.api.actions.edit": "Edit",
+	"settings.api.actions.view": "View",
 	"settings.api.actions.revoke": "Revoke",
 	"settings.api.expiration.never": "Never",
 	"settings.api.lastUsed.never": "Never",

--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyTable.vue
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyTable.vue
@@ -4,7 +4,8 @@ import { useI18n } from '@n8n/i18n';
 import { DateTime } from 'luxon';
 import type { ApiKey } from '@n8n/api-types';
 import type { TableHeader, TableOptions } from '@n8n/design-system/components/N8nDataTableServer';
-import { N8nButton, N8nDataTableServer, N8nText } from '@n8n/design-system';
+import { N8nActionDropdown, N8nDataTableServer, N8nText } from '@n8n/design-system';
+import type { ActionDropdownItem } from '@n8n/design-system';
 
 import ApiKeyLabelCell from './ApiKeyLabelCell.vue';
 import ApiKeyOwnerCell from './ApiKeyOwnerCell.vue';
@@ -50,6 +51,41 @@ function onRowClick(_event: MouseEvent, payload: { item: ApiKey }) {
 	emit('edit', payload.item);
 }
 
+type ApiKeyAction = 'edit' | 'view' | 'revoke';
+
+function getRowActions(apiKey: ApiKey): Array<ActionDropdownItem<ApiKeyAction>> {
+	const actions: Array<ActionDropdownItem<ApiKeyAction>> = [];
+	if (isOwn(apiKey)) {
+		actions.push({
+			id: 'edit',
+			label: i18n.baseText('settings.api.actions.edit'),
+			icon: 'square-pen',
+			testId: 'api-key-edit-action',
+		});
+	} else {
+		// Non-owners open the same modal, which renders read-only based on ownership.
+		actions.push({
+			id: 'view',
+			label: i18n.baseText('settings.api.actions.view'),
+			icon: 'eye',
+			testId: 'api-key-view-action',
+		});
+	}
+	actions.push({
+		id: 'revoke',
+		label: i18n.baseText('settings.api.actions.revoke'),
+		icon: 'trash-2',
+		testId: 'api-key-revoke-action',
+		divided: true,
+	});
+	return actions;
+}
+
+function onAction(action: ApiKeyAction, apiKey: ApiKey) {
+	if (action === 'revoke') emit('revoke', apiKey);
+	else emit('edit', apiKey);
+}
+
 const rows = computed(() => props.apiKeys);
 
 // `resize: false` everywhere — these columns are fixed-shape and the resizer
@@ -76,7 +112,7 @@ const headers = ref<Array<TableHeader<ApiKey>>>([
 		title: '',
 		key: 'actions',
 		align: 'end',
-		width: 130,
+		width: 80,
 		disableSort: true,
 		resize: false,
 		value: () => undefined,
@@ -95,7 +131,6 @@ const headers = ref<Array<TableHeader<ApiKey>>>([
 			:items-length="itemsLength"
 			:loading="loading"
 			:page-sizes="[10, 25, 50]"
-			:row-props="{ class: $style.row }"
 			@update:options="emit('update:options', $event)"
 			@click:row="onRowClick"
 		>
@@ -119,21 +154,13 @@ const headers = ref<Array<TableHeader<ApiKey>>>([
 				</N8nText>
 			</template>
 			<template #[`item.actions`]="{ item }">
-				<div :class="$style.rowActions">
-					<N8nButton
-						v-if="isOwn(item)"
-						variant="outline"
-						size="mini"
-						:label="i18n.baseText('settings.api.actions.edit')"
-						data-test-id="api-key-edit-action"
-						@click.stop="emit('edit', item)"
-					/>
-					<N8nButton
-						variant="outline"
-						size="mini"
-						:label="i18n.baseText('settings.api.actions.revoke')"
-						data-test-id="api-key-revoke-action"
-						@click.stop="emit('revoke', item)"
+				<div :class="$style.rowActions" @click.stop>
+					<N8nActionDropdown
+						:items="getRowActions(item)"
+						placement="bottom-end"
+						activator-size="small"
+						data-test-id="api-key-actions-toggle"
+						@select="(action) => onAction(action, item)"
 					/>
 				</div>
 			</template>
@@ -144,14 +171,6 @@ const headers = ref<Array<TableHeader<ApiKey>>>([
 <style lang="scss" module>
 .rowActions {
 	display: flex;
-	gap: var(--spacing--2xs);
 	justify-content: flex-end;
-	opacity: 0;
-	transition: opacity var(--transition--fast);
-}
-
-.row:hover .rowActions,
-.row:focus-within .rowActions {
-	opacity: 1;
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/views/SettingsApiView.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/views/SettingsApiView.test.ts
@@ -22,6 +22,31 @@ vi.mock('@/app/composables/useTelemetry', () => {
 	};
 });
 
+// Reka UI's dropdown menu doesn't open in jsdom (no pointer-capture support), so the
+// row action menu can't be driven through the real component. Stub it to render its
+// items directly as buttons keyed by their testId, emitting `select` on click.
+vi.mock('@n8n/design-system', async (importOriginal) => {
+	const original = await importOriginal<object>();
+	return {
+		...original,
+		N8nActionDropdown: {
+			name: 'N8nActionDropdown',
+			props: { items: { type: Array, required: true } },
+			emits: ['select'],
+			template: `
+				<div>
+					<button
+						v-for="item in items"
+						:key="item.id"
+						:data-test-id="item.testId"
+						@click="$emit('select', item.id)"
+					>{{ item.label }}</button>
+				</div>
+			`,
+		},
+	};
+});
+
 setActivePinia(createTestingPinia());
 
 const settingsStore = mockedStore(useSettingsStore);
@@ -160,8 +185,7 @@ describe('SettingsApiView', () => {
 
 		renderComponent(SettingsApiView);
 
-		const revokeButton = screen.getByTestId('api-key-revoke-action');
-		await fireEvent.click(revokeButton);
+		await fireEvent.click(screen.getByTestId('api-key-revoke-action'));
 
 		expect(screen.getByText(/Revoke "test-key-1" API key/)).toBeInTheDocument();
 	});
@@ -352,8 +376,8 @@ describe('SettingsApiView', () => {
 			const { track } = useTelemetry();
 
 			await fireEvent.click(screen.getByTestId('api-key-revoke-action'));
-			// The alert dialog renders via a portal — there are now two buttons labelled
-			// "Revoke" in the document: the row action (index 0) and the modal action.
+			// The confirm dialog renders via a portal. Take the last "Revoke" button so we
+			// click the modal's confirm action rather than the stubbed menu item.
 			const revokeButtons = await screen.findAllByRole('button', { name: 'Revoke' });
 			await fireEvent.click(revokeButtons[revokeButtons.length - 1]);
 


### PR DESCRIPTION
## Summary

- Replace the inline Edit/Revoke buttons in each API key row with a single three-dots action menu (`N8nActionDropdown`).
- Owned keys show **Edit** and **Revoke**; keys owned by another user show **View** (opens the existing read-only modal) and **Revoke**, matching the per-row action affordance to the row-click behaviour.

## Review notes

- Menu uses the standard `N8nActionDropdown`, so its text size and spacing follow the design-system default (consistent with every other action menu in n8n) rather than pixel-matching the Figma.
- `SettingsApiView.test.ts` stubs `N8nActionDropdown` via `vi.mock('@n8n/design-system')` (the established pattern, since Reka UI's menu does not open in jsdom).

## Test plan

- [ ] Settings → n8n API: each key row shows a single kebab menu instead of inline buttons.
- [ ] Owned key: menu offers Edit + Revoke; Edit opens the edit modal, Revoke opens the revoke confirm modal.
- [ ] Key owned by another user (admin view): menu offers View + Revoke; View opens the read-only modal.
- [ ] Clicking the kebab does not trigger the row's click-to-edit.
- [ ] `pnpm --filter n8n-editor-ui test SettingsApiView` passes.

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32339">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

