### PR TITLE
fix: Removes phantom telemetry profile caused by missing user id fallback

### DIFF
--- a/packages/cli/src/posthog/__tests__/posthog.test.ts
+++ b/packages/cli/src/posthog/__tests__/posthog.test.ts
@@ -82,6 +82,32 @@ describe('PostHog', () => {
 		});
 	});
 
+	it('does not capture when userId equals instanceId', async () => {
+		const ph = new PostHogClient(instanceSettings, globalConfig);
+		await ph.init();
+
+		ph.track({
+			userId: instanceId,
+			event: 'Instance started',
+			properties: { instance_id: instanceId },
+		});
+
+		expect(PostHog.prototype.capture).not.toHaveBeenCalled();
+	});
+
+	it('does not capture when userId is empty', async () => {
+		const ph = new PostHogClient(instanceSettings, globalConfig);
+		await ph.init();
+
+		ph.track({
+			userId: '',
+			event: 'Some event',
+			properties: {},
+		});
+
+		expect(PostHog.prototype.capture).not.toHaveBeenCalled();
+	});
+
 	it('sends $groupidentify event when distinctId is provided', async () => {
 		const properties = { name: 'test-instance' } as Record<string, string | number>;
 

--- a/packages/cli/src/posthog/__tests__/posthog.test.ts
+++ b/packages/cli/src/posthog/__tests__/posthog.test.ts
@@ -82,16 +82,16 @@ describe('PostHog', () => {
 		});
 	});
 
-	it('sends $groupidentify event with instance group', async () => {
+	it('sends $groupidentify event when distinctId is provided', async () => {
 		const properties = { name: 'test-instance' } as Record<string, string | number>;
 
 		const ph = new PostHogClient(instanceSettings, globalConfig);
 		await ph.init();
 
-		ph.groupIdentify({ instanceId, properties });
+		ph.groupIdentify({ instanceId, distinctId: `${instanceId}#user-1`, properties });
 
 		expect(PostHog.prototype.capture).toHaveBeenCalledWith({
-			distinctId: instanceId,
+			distinctId: `${instanceId}#user-1`,
 			event: '$groupidentify',
 			sendFeatureFlags: true,
 			properties: {
@@ -101,6 +101,17 @@ describe('PostHog', () => {
 			},
 			groups: { company: instanceId },
 		});
+	});
+
+	it('does not send $groupidentify when no distinctId is provided', async () => {
+		const properties = { name: 'test-instance' } as Record<string, string | number>;
+
+		const ph = new PostHogClient(instanceSettings, globalConfig);
+		await ph.init();
+
+		ph.groupIdentify({ instanceId, properties });
+
+		expect(PostHog.prototype.capture).not.toHaveBeenCalled();
 	});
 
 	describe('getFeatureFlags', () => {

--- a/packages/cli/src/posthog/__tests__/posthog.test.ts
+++ b/packages/cli/src/posthog/__tests__/posthog.test.ts
@@ -103,7 +103,7 @@ describe('PostHog', () => {
 		});
 	});
 
-	it('does not send $groupidentify when no distinctId is provided', async () => {
+	it('falls back to company_instanceId and disables person profile when no distinctId is provided', async () => {
 		const properties = { name: 'test-instance' } as Record<string, string | number>;
 
 		const ph = new PostHogClient(instanceSettings, globalConfig);
@@ -111,7 +111,18 @@ describe('PostHog', () => {
 
 		ph.groupIdentify({ instanceId, properties });
 
-		expect(PostHog.prototype.capture).not.toHaveBeenCalled();
+		expect(PostHog.prototype.capture).toHaveBeenCalledWith({
+			distinctId: `company_${instanceId}`,
+			event: '$groupidentify',
+			sendFeatureFlags: true,
+			properties: {
+				$group_type: 'company',
+				$group_key: instanceId,
+				$group_set: properties,
+				$process_person_profile: false,
+			},
+			groups: { company: instanceId },
+		});
 	});
 
 	describe('getFeatureFlags', () => {

--- a/packages/cli/src/posthog/index.ts
+++ b/packages/cli/src/posthog/index.ts
@@ -71,16 +71,17 @@ export class PostHogClient {
 		distinctId?: string;
 		properties: Record<string, string | number> | undefined;
 	}): void {
-		if (!instanceId || !distinctId) return;
+		if (!instanceId) return;
 
 		this.postHog?.capture({
-			distinctId,
+			distinctId: distinctId ?? `${POSTHOG_GROUP_TYPE_INSTANCE}_${instanceId}`,
 			event: '$groupidentify',
 			sendFeatureFlags: true,
 			properties: {
 				$group_type: POSTHOG_GROUP_TYPE_INSTANCE,
 				$group_key: instanceId,
 				$group_set: properties,
+				...(!distinctId && { $process_person_profile: false }),
 			},
 			groups: {
 				[POSTHOG_GROUP_TYPE_INSTANCE]: instanceId,

--- a/packages/cli/src/posthog/index.ts
+++ b/packages/cli/src/posthog/index.ts
@@ -49,6 +49,8 @@ export class PostHogClient {
 	}
 
 	track(payload: { userId: string; event: string; properties: ITelemetryTrackProperties }): void {
+		if (!payload.userId || payload.userId === this.instanceSettings.instanceId) return;
+
 		const instanceId = payload?.properties?.instance_id;
 
 		this.postHog?.capture({

--- a/packages/cli/src/posthog/index.ts
+++ b/packages/cli/src/posthog/index.ts
@@ -71,10 +71,10 @@ export class PostHogClient {
 		distinctId?: string;
 		properties: Record<string, string | number> | undefined;
 	}): void {
-		if (!instanceId) return;
+		if (!instanceId || !distinctId) return;
 
 		this.postHog?.capture({
-			distinctId: distinctId || instanceId,
+			distinctId,
 			event: '$groupidentify',
 			sendFeatureFlags: true,
 			properties: {

--- a/packages/cli/src/telemetry/__tests__/telemetry.test.ts
+++ b/packages/cli/src/telemetry/__tests__/telemetry.test.ts
@@ -616,7 +616,7 @@ describe('Telemetry', () => {
 	});
 
 	describe('Rudderstack', () => {
-		test('should not call rudderStack.identify() when no userId is provided', () => {
+		test('should fall back to instanceId for rudderStack.identify() when no userId is provided', () => {
 			const traits = {
 				name: 'Test User',
 				age: 30,
@@ -625,7 +625,11 @@ describe('Telemetry', () => {
 
 			telemetry.identify(traits);
 
-			expect(mockRudderStack.identify).not.toHaveBeenCalled();
+			expect(mockRudderStack.identify).toHaveBeenCalledWith({
+				userId: instanceId,
+				traits: { ...traits, instanceId },
+				context: { ip: '0.0.0.0' },
+			});
 		});
 
 		test('should call rudderStack.identify() with composite userId when userId is provided', () => {
@@ -644,10 +648,17 @@ describe('Telemetry', () => {
 			});
 		});
 
-		test('should not call rudderStack.group() when no userId is provided', () => {
-			telemetry.groupIdentify({ traits: { version: '1.0' } });
+		test('should fall back to instanceId for rudderStack.group() when no userId is provided', () => {
+			const traits = { version: '1.0' } as Record<string, string | number>;
 
-			expect(mockRudderStack.group).not.toHaveBeenCalled();
+			telemetry.groupIdentify({ traits });
+
+			expect(mockRudderStack.group).toHaveBeenCalledWith({
+				groupId: instanceId,
+				userId: instanceId,
+				traits,
+				context: { ip: '0.0.0.0' },
+			});
 		});
 
 		test('should call rudderStack.group() with composite userId when userId is provided', () => {

--- a/packages/cli/src/telemetry/__tests__/telemetry.test.ts
+++ b/packages/cli/src/telemetry/__tests__/telemetry.test.ts
@@ -616,7 +616,7 @@ describe('Telemetry', () => {
 	});
 
 	describe('Rudderstack', () => {
-		test("should call rudderStack.identify() with a fake IP address to instruct Rudderstack to not use the user's IP address", () => {
+		test('should not call rudderStack.identify() when no userId is provided', () => {
 			const traits = {
 				name: 'Test User',
 				age: 30,
@@ -625,15 +625,42 @@ describe('Telemetry', () => {
 
 			telemetry.identify(traits);
 
-			const expectedArgs = {
-				userId: instanceId,
-				traits: { ...traits, instanceId },
-				context: {
-					ip: '0.0.0.0', // RudderStack anonymized IP
-				},
+			expect(mockRudderStack.identify).not.toHaveBeenCalled();
+		});
+
+		test('should call rudderStack.identify() with composite userId when userId is provided', () => {
+			const traits = {
+				name: 'Test User',
+				age: 30,
+				isActive: true,
 			};
 
-			expect(mockRudderStack.identify).toHaveBeenCalledWith(expectedArgs);
+			telemetry.identify(traits, 'user-123');
+
+			expect(mockRudderStack.identify).toHaveBeenCalledWith({
+				userId: `${instanceId}#user-123`,
+				traits: { ...traits, instanceId },
+				context: { ip: '0.0.0.0' },
+			});
+		});
+
+		test('should not call rudderStack.group() when no userId is provided', () => {
+			telemetry.groupIdentify({ traits: { version: '1.0' } });
+
+			expect(mockRudderStack.group).not.toHaveBeenCalled();
+		});
+
+		test('should call rudderStack.group() with composite userId when userId is provided', () => {
+			const traits = { version: '1.0' } as Record<string, string | number>;
+
+			telemetry.groupIdentify({ userId: 'user-123', traits });
+
+			expect(mockRudderStack.group).toHaveBeenCalledWith({
+				groupId: instanceId,
+				userId: `${instanceId}#user-123`,
+				traits,
+				context: { ip: '0.0.0.0' },
+			});
 		});
 
 		test("should call rudderStack.track() with a fake IP address to instruct Rudderstack to not use the user's IP address", () => {

--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -389,7 +389,7 @@ export class Telemetry {
 		await Promise.all([this.postHog.stop(), this.rudderStack?.flush()]);
 	}
 
-	// Used for either adding properties to group (no userId provided), or attaching user to instance group (userId provided)
+	// Sets instance group properties and attaches user to instance group.
 	groupIdentify({
 		userId,
 		traits,
@@ -408,10 +408,10 @@ export class Telemetry {
 			});
 		}
 
-		if (this.rudderStack) {
+		if (this.rudderStack && userId) {
 			this.rudderStack.group({
 				groupId: instanceId,
-				userId: userId ? `${instanceId}#${userId}` : instanceId, // Rudderstack requires a userId for group calls, using instanceId as fallback
+				userId: `${instanceId}#${userId}`,
 				traits,
 				context: {
 					ip: '0.0.0.0',
@@ -427,12 +427,11 @@ export class Telemetry {
 		const { instanceId } = this.instanceSettings;
 		if (!instanceId) return;
 
-		if (this.rudderStack) {
+		if (this.rudderStack && userId) {
 			this.rudderStack.identify({
-				userId: userId ? `${instanceId}#${userId}` : instanceId, // If no userId provided, falling back to instanceId for cross-compatibility
+				userId: `${instanceId}#${userId}`,
 				traits: { ...traits, instanceId },
 				context: {
-					// provide a fake IP address to instruct RudderStack to not use the user's IP address
 					ip: '0.0.0.0',
 				},
 			});

--- a/packages/cli/src/telemetry/index.ts
+++ b/packages/cli/src/telemetry/index.ts
@@ -408,10 +408,10 @@ export class Telemetry {
 			});
 		}
 
-		if (this.rudderStack && userId) {
+		if (this.rudderStack) {
 			this.rudderStack.group({
 				groupId: instanceId,
-				userId: `${instanceId}#${userId}`,
+				userId: userId ? `${instanceId}#${userId}` : instanceId, // Rudderstack requires a userId for group calls, using instanceId as fallback
 				traits,
 				context: {
 					ip: '0.0.0.0',
@@ -427,9 +427,9 @@ export class Telemetry {
 		const { instanceId } = this.instanceSettings;
 		if (!instanceId) return;
 
-		if (this.rudderStack && userId) {
+		if (this.rudderStack) {
 			this.rudderStack.identify({
-				userId: `${instanceId}#${userId}`,
+				userId: userId ? `${instanceId}#${userId}` : instanceId, // If no userId provided, falling back to instanceId for cross-compatibility
 				traits: { ...traits, instanceId },
 				context: {
 					ip: '0.0.0.0',

--- a/packages/frontend/editor-ui/src/app/stores/posthog.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/posthog.store.ts
@@ -123,19 +123,19 @@ export const usePostHog = defineStore('posthog', () => {
 	const identify = () => {
 		const instanceId = rootStore.instanceId;
 		const user = usersStore.currentUser;
+		if (!user) return;
+
 		const versionCli = rootStore.versionCli;
 		const traits: Record<string, string | number> = {
 			instance_id: instanceId,
 			version_cli: versionCli,
 		};
 
-		if (user && typeof user.createdAt === 'string') {
+		if (typeof user.createdAt === 'string') {
 			traits.created_at_timestamp = new Date(user.createdAt).getTime();
 		}
 
-		// For PostHog, main ID _cannot_ be `undefined` as done for RudderStack.
-		const id = user ? `${instanceId}#${user.id}` : instanceId;
-		window.posthog?.identify?.(id, traits);
+		window.posthog?.identify?.(`${instanceId}#${user.id}`, traits);
 	};
 
 	const trackExperiment = (featFlags: FeatureFlags, name: string) => {


### PR DESCRIPTION
## Summary
A legacy fallback condition on missing user ID during telemetry calls (identify / groupIdentify) was causing phantom user profiles where `user ID` = `instance ID`, causing confusion on telemetry. This PR removes the fallback, enforcing strict existence of a user ID before identifying users.

## Related Linear tickets, Github issues, and Community forum posts
https://linear.app/n8n/issue/GROP-1/investigate-missing-properties-in-posthog-recordings


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32344">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32344?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

