### PR TITLE
fix(core): Hide resource URL for synthetic OAuth2 credentials for MCP registry tools

### DIFF
--- a/packages/cli/src/modules/mcp-registry/__tests__/node-description-transform.test.ts
+++ b/packages/cli/src/modules/mcp-registry/__tests__/node-description-transform.test.ts
@@ -403,6 +403,12 @@ describe('serverToCredentialDescription', () => {
 					default: 'https://mcp.notion.com/mcp',
 				},
 				{
+					displayName: 'Resource URL',
+					name: 'resourceUrl',
+					type: 'hidden',
+					default: '',
+				},
+				{
 					displayName: 'Allowed HTTP Request Domains',
 					name: 'allowedHttpRequestDomains',
 					type: 'hidden',

--- a/packages/cli/src/modules/mcp-registry/node-description-transform.ts
+++ b/packages/cli/src/modules/mcp-registry/node-description-transform.ts
@@ -110,6 +110,12 @@ function serverToOAuth2CredentialDescription(server: McpRegistryServer): ICreden
 				type: 'hidden',
 				default: remote.endpointUrl,
 			},
+			{
+				displayName: 'Resource URL',
+				name: 'resourceUrl',
+				type: 'hidden',
+				default: '',
+			},
 			...buildDomainRestrictionProperties(remote.hostname),
 		],
 	};


### PR DESCRIPTION
## Summary

A [PR](https://github.com/n8n-io/n8n/pull/30924) was merged recently that added an optional `Resource URL` parameter to the MCP OAuth2 credential type. This change doesn't break the credentials themselves, since if this parameter is omitted - it works just like before. However, since it's a new configurable parameter, it broke the Quick connect style connection UX for MCP registry tools:
<img width="960" height="570" alt="01" src="https://github.com/user-attachments/assets/e7adde3a-73e9-4c17-b993-0f67b78e2c75" />
<img width="960" height="570" alt="02" src="https://github.com/user-attachments/assets/b02b6a82-ed1b-40d1-8645-dde9def64349" />

This is because `Connect to <service>` one-click option appears only if the credential doesn't have any parameters that the user themselves can configure. Since `Resource URL` is server-dependent, similar to `Server URL`, we make it hidden and empty by default. In the future we can leverage this parameter to specify `Resource URL` for servers that fail the discovery process based on `Server URL` alone

After making the parameter `hidden` the UI looks like before:
<img width="960" height="570" alt="03" src="https://github.com/user-attachments/assets/ac71ad13-772d-43c5-878b-c438314673c0" />


## How to test

1. Launch n8n and add an AI Agent node to the workflow
2. Click on "+" to add a tool, go to the "MCP servers" section
3. Add one of the available tools
4. Observe that instead of `Connect to ...` you see a default `No credentials yet` state
5. Try the same thing on this branch
6. Observer that now it shows a `Connect to ...` button instead

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32351">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

