### PR TITLE
fix(editor): Prevent parameter wipe when switching nodes in the NDV

### DIFF
--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.test.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.test.ts
@@ -207,6 +207,51 @@ describe('ParameterInputList', () => {
 		expect(getByTestId('parameter-input')).not.toBe(beforeInput);
 	});
 
+	it('does not wipe parameters of the newly selected node when switching nodes (#23862)', async () => {
+		// Two nodes of the same type. Parameter "b" only displays when "a" === "show".
+		// Node A shows it, Node B hides it. Switching A -> B must NOT emit a cleanup
+		// valueChanged(value: undefined) attributed to Node B, which would silently
+		// delete Node B's data (the IF-node content-loss reported in #23862).
+		const parameters: INodeProperties[] = [
+			{ displayName: 'A', name: 'a', type: 'string', default: '' },
+			{
+				displayName: 'B',
+				name: 'b',
+				type: 'string',
+				default: '',
+				displayOptions: { show: { a: ['show'] } },
+			},
+		];
+
+		const firstNode: INodeUi = { ...TEST_NODE_NO_ISSUES, id: 'node-a', name: 'Node A' };
+		const secondNode: INodeUi = { ...TEST_NODE_NO_ISSUES, id: 'node-b', name: 'Node B' };
+
+		ndvStore.activeNode = firstNode;
+		const { emitted, rerender } = renderComponent({
+			props: {
+				path: 'parameters',
+				parameters,
+				nodeValues: { parameters: { a: 'show', b: 'value-A' } },
+			},
+		});
+		await flushPromises();
+
+		// Switch to Node B, whose values hide parameter "b".
+		ndvStore.activeNode = secondNode;
+		await rerender({
+			path: 'parameters',
+			parameters,
+			nodeValues: { parameters: { a: 'hide', b: 'value-B' } },
+		});
+		// Allow the throttled (200ms) parameter watcher to run.
+		await new Promise((resolve) => setTimeout(resolve, 300));
+		await flushPromises();
+
+		const valueChangedEmits = (emitted('valueChanged') ?? []) as Array<[{ value?: unknown }]>;
+		const cleanupEmits = valueChangedEmits.filter(([payload]) => payload.value === undefined);
+		expect(cleanupEmits).toEqual([]);
+	});
+
 	it('renders fixed collection inputs correctly', async () => {
 		ndvStore.activeNode = TEST_NODE_NO_ISSUES;
 		const { getAllByTestId, findByText } = renderComponent({

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/components/ParameterInputList.vue
@@ -167,8 +167,12 @@ interface ParameterComputedData {
 
 const parameterItems = ref<ParameterComputedData[]>([]);
 
-// Track previous parameter names for cleanup when parameters are removed from display
+// Track previous parameter names (and the node they belong to) for cleanup when
+// parameters are removed from display. The node name guards the cleanup against
+// running on an active-node switch, which would wipe the newly selected node's
+// values (#23862).
 let previousParameterNames: string[] = [];
+let previousNodeName: string | undefined;
 
 throttledWatch(
 	[() => props.parameters, () => props.nodeValues, node],
@@ -239,21 +243,28 @@ throttledWatch(
 
 		// Get new parameter names
 		const newParameterNames = parameterItems.value.map((paramData) => paramData.parameter.name);
+		const currentNodeName = node.value?.name;
 
-		// Clean up removed parameters - emit valueChanged for parameters that no longer display
-		// This handles the edge-case when a parameter display depends on another field with an expression
-		for (const parameter of previousParameterNames) {
-			if (!newParameterNames.includes(parameter)) {
-				emit('valueChanged', {
-					name: `${props.path}.${parameter}`,
-					node: ndvStore.value.activeNode?.name || '',
-					value: undefined,
-				});
+		// Clean up removed parameters - emit valueChanged for parameters that no longer display.
+		// This handles the edge-case when a parameter display depends on another field with an
+		// expression. Only do this within the same node: when the active node changes, a parameter
+		// that no longer displays belongs to the previous node, so emitting a cleanup here would
+		// delete the newly selected node's value instead (#23862).
+		if (currentNodeName === previousNodeName) {
+			for (const parameter of previousParameterNames) {
+				if (!newParameterNames.includes(parameter)) {
+					emit('valueChanged', {
+						name: `${props.path}.${parameter}`,
+						node: currentNodeName || '',
+						value: undefined,
+					});
+				}
 			}
 		}
 
-		// Update previous names for next comparison
+		// Update previous names/node for next comparison
 		previousParameterNames = newParameterNames;
+		previousNodeName = currentNodeName;
 	},
 	{ throttle: 200, immediate: true },
 );


### PR DESCRIPTION
## Summary

In the Node Details View, `ParameterInputList` runs a throttled watcher that emits a `valueChanged` cleanup (value `undefined`) for any parameter that stopped being displayed since the previous run. That cleanup is correct within a single node, for example when a field hides another field via an expression.

The problem is that the watcher is throttled (200ms) and reads the live active node. When the active node changes, for example via the floating node arrows, a parameter that no longer displays actually belongs to the previous node, but the cleanup is emitted against the newly selected node and deletes its value. With two adjacent IF nodes this silently wiped a node's conditions, as reported in #23862.

The watcher now records which node a parameter set belongs to and only runs the cleanup when the node is unchanged. On a node switch it refreshes its baseline without emitting any write.

## How to test

1. Create two IF nodes.
2. Configure conditions on the first IF node.
3. Open the second IF node and configure different conditions.
4. Using the floating node arrows, switch back and forth between the two IF nodes without closing the NDV.
5. Both nodes keep their own conditions. Before this fix, one node's conditions were overwritten and lost.

Automated coverage lives in `ParameterInputList.test.ts`. The new test switches the active node while a conditionally displayed parameter is shown and asserts that no cleanup `valueChanged(undefined)` is emitted against the newly selected node. It fails before the fix and passes after.

## Related Linear tickets, Github issues, and Community forum posts

fixes #23862

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created. _Not applicable. This is an internal bug fix with no user-facing, API, or documented behavior change, so there is nothing to add to n8n-docs and no follow-up ticket is needed._
- [x] Tests included.
