### PR TITLE
chore: Type-check @n8n/performance benchmarks

### DIFF
--- a/packages/testing/performance/benchmarks/expression-engine/micro.bench.ts
+++ b/packages/testing/performance/benchmarks/expression-engine/micro.bench.ts
@@ -16,7 +16,7 @@ import {
 	DollarSignValidator,
 	PrototypeSanitizer,
 	ThisSanitizer,
-} from 'n8n-workflow/src/expression-sandboxing';
+} from 'n8n-workflow/expression-sandboxing';
 
 // Top-level await — vitest bench doesn't support beforeAll
 const evaluator = new ExpressionEvaluator({

--- a/packages/testing/performance/package.json
+++ b/packages/testing/performance/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "format": "biome format --write .",
     "format:check": "biome ci .",
+    "typecheck": "tsc --noEmit",
     "bench": "vitest bench --run",
     "bench:baseline": "node scripts/save-baseline.mjs",
     "bench:compare": "vitest bench --run --outputJson ./profiles/benchmark-results.json && node scripts/check-regression.mjs"

--- a/packages/testing/performance/tsconfig.json
+++ b/packages/testing/performance/tsconfig.json
@@ -1,0 +1,10 @@
+{
+	"extends": "../../../tsconfig.json",
+	"compilerOptions": {
+		"module": "esnext",
+		"moduleResolution": "bundler",
+		"types": ["node"]
+	},
+	"include": ["benchmarks/**/*.ts"],
+	"exclude": ["**/dist/**/*", "**/node_modules/**/*"]
+}

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -16,6 +16,11 @@
       "import": "./dist/esm/common/index.js",
       "require": "./dist/cjs/common/index.js"
     },
+    "./expression-sandboxing": {
+      "types": "./dist/esm/expression-sandboxing.d.ts",
+      "import": "./dist/esm/expression-sandboxing.js",
+      "require": "./dist/cjs/expression-sandboxing.js"
+    },
     "./*": "./*"
   },
   "scripts": {


### PR DESCRIPTION
## Summary

- The `@n8n/performance` package had no `tsconfig.json` and no `typecheck` script, so it wasn't being type-checked. As a result, `packages/testing/performance/benchmarks/expression-engine/micro.bench.ts` was importing `ThisSanitizer`, `PrototypeSanitizer`, `DollarSignValidator` from `n8n-workflow/src/expression-sandboxing` — a path that only resolved at runtime via the `"./*": "./*"` catch-all export in `n8n-workflow`'s `package.json`, with no `types` condition.
- Added a proper typed `./expression-sandboxing` subpath export to `n8n-workflow` and updated the bench's import to `n8n-workflow/expression-sandboxing`.
- Added a minimal `tsconfig.json` and `typecheck` script to `@n8n/performance` so the package is type-checkable and won't drift again.

## Test plan

- [x] `tsc --noEmit` in `packages/testing/performance` exits 0.
- [ ] CI typecheck job passes.
- [ ] `pnpm --filter=@n8n/performance bench` still runs (runtime resolution unchanged — both subpath exports point at the same dist files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32361">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

