### PR TITLE
perf(core): Improve performance of pre-execution workflow checks

### DIFF
--- a/packages/testing/performance/README.md
+++ b/packages/testing/performance/README.md
@@ -77,6 +77,7 @@ my operation    20,000   0.04   0.20   0.05   0.10  ±0.5%   10000
 | Area | What it measures | Why it matters |
 |------|------------------|----------------|
 | Expression Engine | `={{ }}` evaluation speed | Runs for every node parameter |
+| Workflow graph traversal | `getChildNodes` / `getParentNodes` on branching graphs | Runs on every execution (`checkReadyForExecution`) and across the editor; must stay linear in graph size |
 
 
 ## Tips

--- a/packages/testing/performance/benchmarks/workflow-graph/traversal.bench.ts
+++ b/packages/testing/performance/benchmarks/workflow-graph/traversal.bench.ts
@@ -1,0 +1,75 @@
+/**
+ * Workflow graph traversal benchmarks.
+ *
+ * `getChildNodes` / `getParentNodes` (via `getConnectedNodes`) run on every
+ * execution through `checkReadyForExecution`, and in several other places.
+ * On branching graphs the traversal must stay linear in the graph size, so a node
+ * reachable through many paths must be expanded once, not once per path.
+ */
+import { bench, describe } from 'vitest';
+import { getChildNodes, getParentNodes, mapConnectionsByDestination } from 'n8n-workflow';
+import type { IConnections } from 'n8n-workflow';
+
+const MAIN = 'main';
+
+function link(conn: IConnections, from: string, to: string): void {
+	conn[from] = conn[from] ?? { [MAIN]: [[]] };
+	conn[from][MAIN][0]!.push({ node: to, type: MAIN, index: 0 });
+}
+
+/** A -> B -> C -> ... single path, `length` nodes after the start. */
+function linearChain(length: number): IConnections {
+	const conn: IConnections = {};
+	for (let i = 0; i < length; i++) link(conn, `n${i}`, `n${i + 1}`);
+	return conn;
+}
+
+/** start -> {aN, bN} -> mN -> {aN+1, bN+1} -> ... : 2^diamonds paths to the last node. */
+function diamondChain(diamonds: number): IConnections {
+	const conn: IConnections = {};
+	let cur = 'start';
+	for (let i = 0; i < diamonds; i++) {
+		const a = `a${i}`;
+		const b = `b${i}`;
+		const next = `m${i}`;
+		link(conn, cur, a);
+		link(conn, cur, b);
+		link(conn, a, next);
+		link(conn, b, next);
+		cur = next;
+	}
+	return conn;
+}
+
+/** A trigger fanning out to `width` parallel branches that each rejoin a sink. */
+function wideFanOut(width: number): IConnections {
+	const conn: IConnections = {};
+	for (let i = 0; i < width; i++) {
+		link(conn, 'trigger', `branch${i}`);
+		link(conn, `branch${i}`, 'sink');
+	}
+	return conn;
+}
+
+describe('Workflow graph traversal', () => {
+	const linear = linearChain(500);
+	bench('getChildNodes: linear chain (500 nodes)', () => {
+		getChildNodes(linear, 'n0');
+	});
+
+	const wide = wideFanOut(184);
+	bench('getChildNodes: wide fan-out (184 branches into one sink)', () => {
+		getChildNodes(wide, 'trigger');
+	});
+
+	// exponential paths, must stay linear.
+	const diamonds = diamondChain(14); // 2^14 ≈ 16k paths, 42 nodes
+	bench('getChildNodes: diamond chain (14 diamonds, 42 nodes)', () => {
+		getChildNodes(diamonds, 'start');
+	});
+
+	const diamondsByDestination = mapConnectionsByDestination(diamonds);
+	bench('getParentNodes: diamond chain (14 diamonds, 42 nodes)', () => {
+		getParentNodes(diamondsByDestination, 'm13');
+	});
+});

--- a/packages/testing/performance/benchmarks/workflow-graph/traversal.bench.ts
+++ b/packages/testing/performance/benchmarks/workflow-graph/traversal.bench.ts
@@ -53,7 +53,7 @@ function wideFanOut(width: number): IConnections {
 
 describe('Workflow graph traversal', () => {
 	const linear = linearChain(500);
-	bench('getChildNodes: linear chain (500 nodes)', () => {
+	bench('getChildNodes: linear chain (501 nodes)', () => {
 		getChildNodes(linear, 'n0');
 	});
 
@@ -63,13 +63,13 @@ describe('Workflow graph traversal', () => {
 	});
 
 	// exponential paths, must stay linear.
-	const diamonds = diamondChain(14); // 2^14 ≈ 16k paths, 42 nodes
-	bench('getChildNodes: diamond chain (14 diamonds, 42 nodes)', () => {
+	const diamonds = diamondChain(14); // 2^14 ≈ 16k paths, 43 nodes
+	bench('getChildNodes: diamond chain (14 diamonds, 43 nodes)', () => {
 		getChildNodes(diamonds, 'start');
 	});
 
 	const diamondsByDestination = mapConnectionsByDestination(diamonds);
-	bench('getParentNodes: diamond chain (14 diamonds, 42 nodes)', () => {
+	bench('getParentNodes: diamond chain (14 diamonds, 43 nodes)', () => {
 		getParentNodes(diamondsByDestination, 'm13');
 	});
 });

--- a/packages/workflow/src/common/get-connected-nodes.ts
+++ b/packages/workflow/src/common/get-connected-nodes.ts
@@ -2,29 +2,59 @@ import { NodeConnectionTypes } from '../interfaces';
 import type { IConnections, NodeConnectionType } from '../interfaces';
 
 /**
- * Gets all the nodes which are connected nodes starting from
- * the given one
+ * Returns the names of all nodes reachable from `nodeName` by following the
+ * given connection type, excluding `nodeName` itself. Each node appears once,
+ * ordered deepest-descendant first. Cycles are safe — a node is never listed as
+ * its own descendant.
  *
- * @param {NodeConnectionType} [type='main']
- * @param {*} [depth=-1]
+ * @param {NodeConnectionType} [connectionType='main'] a specific type, or 'ALL' / 'ALL_NON_MAIN'
+ * @param {number} [depth=-1] how many hops to follow; -1 for unlimited
  */
 export function getConnectedNodes(
 	connections: IConnections,
 	nodeName: string,
 	connectionType: NodeConnectionType | 'ALL' | 'ALL_NON_MAIN' = NodeConnectionTypes.Main,
 	depth = -1,
-	checkedNodesIncoming?: string[],
 ): string[] {
-	const newDepth = depth === -1 ? depth : depth - 1;
+	// Memoize each node's expansion so it is computed once
+	return collectConnectedNodes(
+		connections,
+		nodeName,
+		connectionType,
+		depth,
+		new Set<string>(),
+		new Map<string, string[]>(),
+	);
+}
+
+function collectConnectedNodes(
+	connections: IConnections,
+	nodeName: string,
+	connectionType: NodeConnectionType | 'ALL' | 'ALL_NON_MAIN',
+	depth: number,
+	currentPath: Set<string>,
+	memo: Map<string, string[]>,
+): string[] {
 	if (depth === 0) {
 		// Reached max depth
 		return [];
 	}
 
 	if (!connections.hasOwnProperty(nodeName)) {
-		// Node does not have incoming connections
+		// Node has no connections to follow
 		return [];
 	}
+
+	// The expansion of a node depends only on the node and the remaining depth,
+	// so cache by both. With unlimited depth (-1) the key is stable, so every
+	// node is expanded exactly once.
+	const memoKey = `${depth}:${nodeName}`;
+	const cached = memo.get(memoKey);
+	if (cached !== undefined) {
+		return cached;
+	}
+
+	const newDepth = depth === -1 ? depth : depth - 1;
 
 	let types: NodeConnectionType[];
 	if (connectionType === 'ALL') {
@@ -43,25 +73,18 @@ export function getConnectedNodes(
 	let parentNodeName: string;
 	const returnNodes: string[] = [];
 
+	currentPath.add(nodeName);
+
 	types.forEach((type) => {
 		if (!connections[nodeName].hasOwnProperty(type)) {
-			// Node does not have incoming connections of given type
+			// Node does not have any connections of given type
 			return;
 		}
-
-		const checkedNodes = checkedNodesIncoming ? [...checkedNodesIncoming] : [];
-
-		if (checkedNodes.includes(nodeName)) {
-			// Node got checked already before
-			return;
-		}
-
-		checkedNodes.push(nodeName);
 
 		connections[nodeName][type].forEach((connectionsByIndex) => {
 			connectionsByIndex?.forEach((connection) => {
-				if (checkedNodes.includes(connection.node)) {
-					// Node got checked already before
+				if (currentPath.has(connection.node)) {
+					// Node is an ancestor on the current path, so skip it
 					return;
 				}
 
@@ -75,12 +98,13 @@ export function getConnectedNodes(
 				}
 				returnNodes.unshift(connection.node);
 
-				addNodes = getConnectedNodes(
+				addNodes = collectConnectedNodes(
 					connections,
 					connection.node,
 					connectionType,
 					newDepth,
-					checkedNodes,
+					currentPath,
+					memo,
 				);
 
 				for (i = addNodes.length; i--; i > 0) {
@@ -101,6 +125,9 @@ export function getConnectedNodes(
 			});
 		});
 	});
+
+	currentPath.delete(nodeName);
+	memo.set(memoKey, returnNodes);
 
 	return returnNodes;
 }

--- a/packages/workflow/src/common/get-connected-nodes.ts
+++ b/packages/workflow/src/common/get-connected-nodes.ts
@@ -16,7 +16,6 @@ export function getConnectedNodes(
 	connectionType: NodeConnectionType | 'ALL' | 'ALL_NON_MAIN' = NodeConnectionTypes.Main,
 	depth = -1,
 ): string[] {
-	// Memoize each node's expansion so it is computed once
 	return collectConnectedNodes(
 		connections,
 		nodeName,

--- a/packages/workflow/src/workflow.ts
+++ b/packages/workflow/src/workflow.ts
@@ -612,9 +612,8 @@ export class Workflow {
 		nodeName: string,
 		connectionType: NodeConnectionType | 'ALL' | 'ALL_NON_MAIN' = NodeConnectionTypes.Main,
 		depth = -1,
-		checkedNodesIncoming?: string[],
 	): string[] {
-		return getConnectedNodes(connections, nodeName, connectionType, depth, checkedNodesIncoming);
+		return getConnectedNodes(connections, nodeName, connectionType, depth);
 	}
 
 	/**

--- a/packages/workflow/test/get-child-nodes.test.ts
+++ b/packages/workflow/test/get-child-nodes.test.ts
@@ -1,5 +1,6 @@
 import fc from 'fast-check';
 
+import { connectionsFromEdges, reachableMain } from './graph/graph-fixtures';
 import { getChildNodes } from '../src/common/get-child-nodes';
 import { getParentNodes } from '../src/common/get-parent-nodes';
 import { mapConnectionsByDestination } from '../src/common/map-connections-by-destination';
@@ -270,36 +271,8 @@ describe('getChildNodes', () => {
 describe('getChildNodes — properties (fast-check)', () => {
 	const Main = NodeConnectionTypes.Main;
 
-	/** Build source-indexed main connections from index-pair edges (all on output 0). */
-	const buildConnections = (edges: Array<[number, number]>): IConnections => {
-		const conns: IConnections = {};
-		for (const [from, to] of edges) {
-			const src = `n${from}`;
-			if (!conns[src]) conns[src] = {};
-			if (!conns[src][Main]) conns[src][Main] = [[]];
-			conns[src][Main][0]!.push({ node: `n${to}`, type: Main, index: 0 });
-		}
-		return conns;
-	};
-
-	/** Model oracle: main-reachable nodes from `start`, excluding `start` itself. */
-	const reachableMain = (conns: IConnections, start: string): Set<string> => {
-		const seen = new Set<string>();
-		const stack = [start];
-		while (stack.length) {
-			const node = stack.pop()!;
-			for (const output of conns[node]?.[Main] ?? []) {
-				for (const connection of output ?? []) {
-					if (!seen.has(connection.node)) {
-						seen.add(connection.node);
-						stack.push(connection.node);
-					}
-				}
-			}
-		}
-		seen.delete(start); // a node is never its own child, even via a cycle
-		return seen;
-	};
+	// `connectionsFromEdges` (index-pair graph builder) and `reachableMain` (model
+	// oracle) are shared with get-connected-nodes.test.ts via ./graph/graph-fixtures.
 
 	// Deliberately tiny, overlapping domains so paths collide (diamonds & cycles).
 	const graph = fc.integer({ min: 1, max: 5 }).chain((nodeCount) =>
@@ -323,7 +296,7 @@ describe('getChildNodes — properties (fast-check)', () => {
 	it('COMPLETE_AND_SOUND — result set equals the main-reachable set', () => {
 		fc.assert(
 			fc.property(graph, ({ edges, start }) => {
-				const conns = buildConnections(edges);
+				const conns = connectionsFromEdges(edges);
 				expect(new Set(getChildNodes(conns, `n${start}`))).toEqual(
 					reachableMain(conns, `n${start}`),
 				);
@@ -334,7 +307,7 @@ describe('getChildNodes — properties (fast-check)', () => {
 	it('NO_SELF_NO_DUPES — start is excluded and every node appears at most once', () => {
 		fc.assert(
 			fc.property(graph, ({ edges, start }) => {
-				const result = getChildNodes(buildConnections(edges), `n${start}`);
+				const result = getChildNodes(connectionsFromEdges(edges), `n${start}`);
 				expect(result).not.toContain(`n${start}`);
 				expect(new Set(result).size).toBe(result.length);
 			}),
@@ -344,7 +317,7 @@ describe('getChildNodes — properties (fast-check)', () => {
 	it('DEPTH_1_IS_DIRECT — depth 1 returns exactly the direct successors', () => {
 		fc.assert(
 			fc.property(graph, ({ edges, start }) => {
-				const conns = buildConnections(edges);
+				const conns = connectionsFromEdges(edges);
 				const direct = new Set(
 					(conns[`n${start}`]?.[Main] ?? []).flatMap((o) => (o ?? []).map((c) => c.node)),
 				);
@@ -357,7 +330,7 @@ describe('getChildNodes — properties (fast-check)', () => {
 	it('DEPTH_MONOTONIC — a deeper traversal never drops a node', () => {
 		fc.assert(
 			fc.property(graph, fc.integer({ min: 1, max: 5 }), ({ edges, start }, k) => {
-				const conns = buildConnections(edges);
+				const conns = connectionsFromEdges(edges);
 				const deeper = new Set(getChildNodes(conns, `n${start}`, Main, k + 1));
 				for (const node of getChildNodes(conns, `n${start}`, Main, k)) {
 					expect(deeper.has(node)).toBe(true);
@@ -369,7 +342,7 @@ describe('getChildNodes — properties (fast-check)', () => {
 	it('CHILD_PARENT_DUALITY — c is a child of s ⇔ s is a parent of c in the inverted graph', () => {
 		fc.assert(
 			fc.property(graph, ({ nodeCount, edges, start }) => {
-				const conns = buildConnections(edges);
+				const conns = connectionsFromEdges(edges);
 				const inverted = mapConnectionsByDestination(conns);
 				const children = new Set(getChildNodes(conns, `n${start}`));
 				for (let i = 0; i < nodeCount; i++) {

--- a/packages/workflow/test/get-connected-nodes.test.ts
+++ b/packages/workflow/test/get-connected-nodes.test.ts
@@ -1,3 +1,8 @@
+// NOTE: Diagrams in this file have been created with https://asciiflow.com/#/
+// If you update the tests, please update the diagrams as well.
+// If you add a test, please create a new diagram.
+// ────► denotes a `main` connection from source to destination.
+
 import { getChildNodes } from '../src/common/get-child-nodes';
 import { getConnectedNodes } from '../src/common/get-connected-nodes';
 import { getParentNodes } from '../src/common/get-parent-nodes';
@@ -20,6 +25,14 @@ function conns(map: Record<string, string[]>): IConnections {
  * A chain of diamonds: start -> {aN, bN} -> mN -> {aN+1, bN+1} -> ...
  * Each fan-out/fan-in doubles the number of distinct paths to the next merge
  * node, so the last node is reachable by 2^diamonds paths.
+ *
+ *  ┌─────┐     ┌────┐
+ *  │start├────►│ a0 ├────┐
+ *  └──┬──┘     └────┘    │    ┌────┐
+ *     │                  ├───►│ m0 ├───► (next diamond: m0 -> {a1, b1} -> m1 -> ...)
+ *     │        ┌────┐    │    └────┘
+ *     └───────►│ b0 ├────┘
+ *              └────┘
  */
 function buildDiamondChain(diamonds: number): IConnections {
 	const conn: IConnections = {};
@@ -114,7 +127,13 @@ describe('getConnectedNodes', () => {
 		});
 
 		it('should return all reachable nodes and terminate on a multi-node cycle', () => {
-			// A -> B -> C -> A, plus C -> D. Reachable from A: B, C, D; not A.
+			// C -> A closes a cycle; C -> D leaves it. Reachable from A: B, C, D; not A.
+			//
+			//  ┌───┐     ┌───┐     ┌───┐     ┌───┐
+			//  │ A ├────►│ B ├────►│ C ├────►│ D │
+			//  └─▲─┘     └───┘     └─┬─┘     └───┘
+			//    │                   │
+			//    └───────────────────┘
 			const cyclic = conns({ A: ['B'], B: ['C'], C: ['A', 'D'] });
 
 			const result = getConnectedNodes(cyclic, 'A');
@@ -124,6 +143,11 @@ describe('getConnectedNodes', () => {
 		});
 
 		it('should exclude the start node on a self-loop', () => {
+			//   ┌──┐
+			//   │  ▼
+			//  ┌┴───┐     ┌───┐
+			//  │ A  ├────►│ B │
+			//  └────┘     └───┘
 			const selfLoop = conns({ A: ['A', 'B'] });
 
 			expect(getChildNodes(selfLoop, 'A')).toEqual(['B']);
@@ -132,7 +156,13 @@ describe('getConnectedNodes', () => {
 
 	describe('result ordering', () => {
 		it('should order a diamond deepest-first with the shared node listed once', () => {
-			//   root -> {mid1, mid2} -> leaf
+			//  ┌────┐     ┌──────┐
+			//  │root├────►│ mid1 ├────┐
+			//  └──┬─┘     └──────┘    │   ┌──────┐
+			//     │                   ├──►│ leaf │
+			//     │       ┌──────┐    │   └──────┘
+			//     └──────►│ mid2 ├────┘
+			//             └──────┘
 			const diamond = conns({ root: ['mid1', 'mid2'], mid1: ['leaf'], mid2: ['leaf'] });
 
 			expect(getChildNodes(diamond, 'root')).toEqual(['leaf', 'mid2', 'mid1']);
@@ -144,7 +174,13 @@ describe('getConnectedNodes', () => {
 		});
 
 		it('should order a shortcut diamond consistently when a node is both a direct child and a descendant', () => {
-			// root -> leaf  AND  root -> mid -> leaf
+			// `leaf` is both a direct child of `root` and a descendant via `mid`.
+			//
+			//  ┌────┐     ┌─────┐     ┌──────┐
+			//  │root├────►│ mid ├────►│ leaf │
+			//  └──┬─┘     └─────┘     └───▲──┘
+			//     │                       │
+			//     └───────────────────────┘
 			const shortcut = conns({ root: ['mid', 'leaf'], mid: ['leaf'] });
 
 			expect(getChildNodes(shortcut, 'root')).toEqual(['leaf', 'mid']);
@@ -157,7 +193,14 @@ describe('getConnectedNodes', () => {
 
 	describe('depth limit', () => {
 		// leaf is reachable via a 1-hop and a 3-hop path:
-		//   root -> leaf            and  root -> m1 -> m2 -> leaf
+		//
+		//  ┌────┐     ┌────┐     ┌────┐
+		//  │root├────►│ m1 ├────►│ m2 │
+		//  └──┬─┘     └────┘     └─┬──┘
+		//     │                    │
+		//     │       ┌──────┐     │
+		//     └──────►│ leaf │◄────┘
+		//             └──────┘
 		const graph = conns({ root: ['leaf', 'm1'], m1: ['m2'], m2: ['leaf'] });
 
 		it.each([1, 2, 3, 4, -1])('should return the nodes reachable within depth %s', (depth) => {
@@ -175,6 +218,10 @@ describe('getConnectedNodes', () => {
 	});
 
 	describe('return value', () => {
+		// The traversal memoizes node expansions internally and the returned array
+		// is a memo entry. The memo is per-call, so mutating one call's result must
+		// never affect a later call. Guards against a future regression that caches
+		// the memo across calls and hands back the raw cached array by reference.
 		it('should not leak mutations of the returned array into later calls', () => {
 			const diamond = conns({ root: ['mid1', 'mid2'], mid1: ['leaf'], mid2: ['leaf'] });
 

--- a/packages/workflow/test/get-connected-nodes.test.ts
+++ b/packages/workflow/test/get-connected-nodes.test.ts
@@ -3,6 +3,7 @@
 // If you add a test, please create a new diagram.
 // ────► denotes a `main` connection from source to destination.
 
+import { connectionsFromMap, diamondChain, reachableWithinDepth } from './graph/graph-fixtures';
 import { getChildNodes } from '../src/common/get-child-nodes';
 import { getConnectedNodes } from '../src/common/get-connected-nodes';
 import { getParentNodes } from '../src/common/get-parent-nodes';
@@ -11,72 +12,6 @@ import type { IConnections } from '../src/interfaces';
 import { NodeConnectionTypes } from '../src/interfaces';
 
 const Main = NodeConnectionTypes.Main;
-
-/** Build source-indexed main connections from a {from: [to, ...]} description. */
-function conns(map: Record<string, string[]>): IConnections {
-	const out: IConnections = {};
-	for (const [from, tos] of Object.entries(map)) {
-		out[from] = { [Main]: [tos.map((node) => ({ node, type: Main, index: 0 }))] };
-	}
-	return out;
-}
-
-/**
- * A chain of diamonds: start -> {aN, bN} -> mN -> {aN+1, bN+1} -> ...
- * Each fan-out/fan-in doubles the number of distinct paths to the next merge
- * node, so the last node is reachable by 2^diamonds paths.
- *
- *  ┌─────┐     ┌────┐
- *  │start├────►│ a0 ├────┐
- *  └──┬──┘     └────┘    │    ┌────┐
- *     │                  ├───►│ m0 ├───► (next diamond: m0 -> {a1, b1} -> m1 -> ...)
- *     │        ┌────┐    │    └────┘
- *     └───────►│ b0 ├────┘
- *              └────┘
- */
-function buildDiamondChain(diamonds: number): IConnections {
-	const conn: IConnections = {};
-	const link = (from: string, to: string) => {
-		conn[from] = conn[from] ?? { [Main]: [[]] };
-		conn[from][Main][0]!.push({ node: to, type: Main, index: 0 });
-	};
-	let cur = 'start';
-	for (let i = 0; i < diamonds; i++) {
-		const a = `a${i}`;
-		const b = `b${i}`;
-		const next = `m${i}`;
-		link(cur, a);
-		link(cur, b);
-		link(a, next);
-		link(b, next);
-		cur = next;
-	}
-	return conn;
-}
-
-/** Reference reachability: main-reachable nodes from `start` within `depth` hops
- * (-1 = unlimited), excluding `start`. Independent of the code under test. */
-function reachableWithinDepth(conn: IConnections, start: string, depth: number): Set<string> {
-	const seen = new Set<string>();
-	let frontier = [start];
-	let remaining = depth;
-	while (frontier.length && remaining !== 0) {
-		const nextFrontier: string[] = [];
-		for (const node of frontier) {
-			for (const output of conn[node]?.[Main] ?? []) {
-				for (const connection of output ?? []) {
-					if (connection.node !== start && !seen.has(connection.node)) {
-						seen.add(connection.node);
-						nextFrontier.push(connection.node);
-					}
-				}
-			}
-		}
-		frontier = nextFrontier;
-		if (remaining > 0) remaining -= 1;
-	}
-	return seen;
-}
 
 describe('getConnectedNodes', () => {
 	describe('traversal cost', () => {
@@ -98,7 +33,7 @@ describe('getConnectedNodes', () => {
 		it('should read the connections map a linear number of times on a branching graph', () => {
 			const diamonds = 20; // last node reachable by 2^20 ≈ 1e6 paths
 			const nodeCount = diamonds * 3;
-			const { proxy, reads } = countReads(buildDiamondChain(diamonds));
+			const { proxy, reads } = countReads(diamondChain(diamonds));
 
 			const result = getChildNodes(proxy, 'start');
 
@@ -108,24 +43,14 @@ describe('getConnectedNodes', () => {
 
 		it('should complete on a graph with exponentially many paths', () => {
 			const diamonds = 30; // 2^30 ≈ 1e9 paths
-			const result = getChildNodes(buildDiamondChain(diamonds), 'start');
+			const result = getChildNodes(diamondChain(diamonds), 'start');
 
 			expect(result).toHaveLength(diamonds * 3);
 			expect(new Set(result).size).toBe(result.length);
 		});
 	});
 
-	describe('reachable set', () => {
-		it('should list each reachable node once across overlapping diamonds', () => {
-			const result = getChildNodes(buildDiamondChain(4), 'start');
-
-			expect(new Set(result).size).toBe(result.length);
-			expect(result).not.toContain('start');
-			expect(new Set(result)).toEqual(
-				new Set(['a0', 'b0', 'm0', 'a1', 'b1', 'm1', 'a2', 'b2', 'm2', 'a3', 'b3', 'm3']),
-			);
-		});
-
+	describe('cycles', () => {
 		it('should return all reachable nodes and terminate on a multi-node cycle', () => {
 			// C -> A closes a cycle; C -> D leaves it. Reachable from A: B, C, D; not A.
 			//
@@ -134,7 +59,7 @@ describe('getConnectedNodes', () => {
 			//  └─▲─┘     └───┘     └─┬─┘     └───┘
 			//    │                   │
 			//    └───────────────────┘
-			const cyclic = conns({ A: ['B'], B: ['C'], C: ['A', 'D'] });
+			const cyclic = connectionsFromMap({ A: ['B'], B: ['C'], C: ['A', 'D'] });
 
 			const result = getConnectedNodes(cyclic, 'A');
 
@@ -148,7 +73,7 @@ describe('getConnectedNodes', () => {
 			//  ┌┴───┐     ┌───┐
 			//  │ A  ├────►│ B │
 			//  └────┘     └───┘
-			const selfLoop = conns({ A: ['A', 'B'] });
+			const selfLoop = connectionsFromMap({ A: ['A', 'B'] });
 
 			expect(getChildNodes(selfLoop, 'A')).toEqual(['B']);
 		});
@@ -163,7 +88,11 @@ describe('getConnectedNodes', () => {
 			//     │       ┌──────┐    │   └──────┘
 			//     └──────►│ mid2 ├────┘
 			//             └──────┘
-			const diamond = conns({ root: ['mid1', 'mid2'], mid1: ['leaf'], mid2: ['leaf'] });
+			const diamond = connectionsFromMap({
+				root: ['mid1', 'mid2'],
+				mid1: ['leaf'],
+				mid2: ['leaf'],
+			});
 
 			expect(getChildNodes(diamond, 'root')).toEqual(['leaf', 'mid2', 'mid1']);
 			expect(getParentNodes(mapConnectionsByDestination(diamond), 'leaf')).toEqual([
@@ -181,7 +110,7 @@ describe('getConnectedNodes', () => {
 			//  └──┬─┘     └─────┘     └───▲──┘
 			//     │                       │
 			//     └───────────────────────┘
-			const shortcut = conns({ root: ['mid', 'leaf'], mid: ['leaf'] });
+			const shortcut = connectionsFromMap({ root: ['mid', 'leaf'], mid: ['leaf'] });
 
 			expect(getChildNodes(shortcut, 'root')).toEqual(['leaf', 'mid']);
 			expect(getParentNodes(mapConnectionsByDestination(shortcut), 'leaf')).toEqual([
@@ -201,7 +130,12 @@ describe('getConnectedNodes', () => {
 			// `shared` has a child, so it enters the traversal's path tracking during
 			// expansion. If a node were left in that tracking after being expanded,
 			// sibling `y` would skip `shared` as a phantom ancestor and reorder the result.
-			const graph = conns({ root: ['x', 'y'], x: ['shared'], y: ['shared'], shared: ['leaf'] });
+			const graph = connectionsFromMap({
+				root: ['x', 'y'],
+				x: ['shared'],
+				y: ['shared'],
+				shared: ['leaf'],
+			});
 
 			expect(getChildNodes(graph, 'root')).toEqual(['leaf', 'shared', 'y', 'x']);
 		});
@@ -217,7 +151,7 @@ describe('getConnectedNodes', () => {
 		//     │       ┌──────┐     │
 		//     └──────►│ leaf │◄────┘
 		//             └──────┘
-		const graph = conns({ root: ['leaf', 'm1'], m1: ['m2'], m2: ['leaf'] });
+		const graph = connectionsFromMap({ root: ['leaf', 'm1'], m1: ['m2'], m2: ['leaf'] });
 
 		it.each([1, 2, 3, 4, -1])('should return the nodes reachable within depth %s', (depth) => {
 			const result = getChildNodes(graph, 'root', Main, depth);
@@ -239,7 +173,11 @@ describe('getConnectedNodes', () => {
 		// never affect a later call. Guards against a future regression that caches
 		// the memo across calls and hands back the raw cached array by reference.
 		it('should not leak mutations of the returned array into later calls', () => {
-			const diamond = conns({ root: ['mid1', 'mid2'], mid1: ['leaf'], mid2: ['leaf'] });
+			const diamond = connectionsFromMap({
+				root: ['mid1', 'mid2'],
+				mid1: ['leaf'],
+				mid2: ['leaf'],
+			});
 
 			const first = getChildNodes(diamond, 'root');
 			first.push('INJECTED');

--- a/packages/workflow/test/get-connected-nodes.test.ts
+++ b/packages/workflow/test/get-connected-nodes.test.ts
@@ -1,0 +1,188 @@
+import { getChildNodes } from '../src/common/get-child-nodes';
+import { getConnectedNodes } from '../src/common/get-connected-nodes';
+import { getParentNodes } from '../src/common/get-parent-nodes';
+import { mapConnectionsByDestination } from '../src/common/map-connections-by-destination';
+import type { IConnections } from '../src/interfaces';
+import { NodeConnectionTypes } from '../src/interfaces';
+
+const Main = NodeConnectionTypes.Main;
+
+/** Build source-indexed main connections from a {from: [to, ...]} description. */
+function conns(map: Record<string, string[]>): IConnections {
+	const out: IConnections = {};
+	for (const [from, tos] of Object.entries(map)) {
+		out[from] = { [Main]: [tos.map((node) => ({ node, type: Main, index: 0 }))] };
+	}
+	return out;
+}
+
+/**
+ * A chain of diamonds: start -> {aN, bN} -> mN -> {aN+1, bN+1} -> ...
+ * Each fan-out/fan-in doubles the number of distinct paths to the next merge
+ * node, so the last node is reachable by 2^diamonds paths.
+ */
+function buildDiamondChain(diamonds: number): IConnections {
+	const conn: IConnections = {};
+	const link = (from: string, to: string) => {
+		conn[from] = conn[from] ?? { [Main]: [[]] };
+		conn[from][Main][0]!.push({ node: to, type: Main, index: 0 });
+	};
+	let cur = 'start';
+	for (let i = 0; i < diamonds; i++) {
+		const a = `a${i}`;
+		const b = `b${i}`;
+		const next = `m${i}`;
+		link(cur, a);
+		link(cur, b);
+		link(a, next);
+		link(b, next);
+		cur = next;
+	}
+	return conn;
+}
+
+/** Reference reachability: main-reachable nodes from `start` within `depth` hops
+ * (-1 = unlimited), excluding `start`. Independent of the code under test. */
+function reachableWithinDepth(conn: IConnections, start: string, depth: number): Set<string> {
+	const seen = new Set<string>();
+	let frontier = [start];
+	let remaining = depth;
+	while (frontier.length && remaining !== 0) {
+		const nextFrontier: string[] = [];
+		for (const node of frontier) {
+			for (const output of conn[node]?.[Main] ?? []) {
+				for (const connection of output ?? []) {
+					if (connection.node !== start && !seen.has(connection.node)) {
+						seen.add(connection.node);
+						nextFrontier.push(connection.node);
+					}
+				}
+			}
+		}
+		frontier = nextFrontier;
+		if (remaining > 0) remaining -= 1;
+	}
+	return seen;
+}
+
+describe('getConnectedNodes', () => {
+	describe('traversal cost', () => {
+		// Counts reads of the connections map: the traversal touches it O(V + E)
+		// times. An implementation that re-expands nodes once per path reads it
+		// exponentially more often, never near this bound.
+		function countReads(conn: IConnections): { proxy: IConnections; reads: () => number } {
+			let reads = 0;
+			const proxy = new Proxy(conn, {
+				get(target, prop, receiver) {
+					reads += 1;
+					// eslint-disable-next-line @typescript-eslint/no-unsafe-return -- trap forwards the raw property value
+					return Reflect.get(target, prop, receiver);
+				},
+			});
+			return { proxy, reads: () => reads };
+		}
+
+		it('should read the connections map a linear number of times on a branching graph', () => {
+			const diamonds = 20; // last node reachable by 2^20 ≈ 1e6 paths
+			const nodeCount = diamonds * 3;
+			const { proxy, reads } = countReads(buildDiamondChain(diamonds));
+
+			const result = getChildNodes(proxy, 'start');
+
+			expect(result).toHaveLength(nodeCount);
+			expect(reads()).toBeLessThan(nodeCount * 20);
+		});
+
+		it('should complete on a graph with exponentially many paths', () => {
+			const diamonds = 30; // 2^30 ≈ 1e9 paths
+			const result = getChildNodes(buildDiamondChain(diamonds), 'start');
+
+			expect(result).toHaveLength(diamonds * 3);
+			expect(new Set(result).size).toBe(result.length);
+		});
+	});
+
+	describe('reachable set', () => {
+		it('should list each reachable node once across overlapping diamonds', () => {
+			const result = getChildNodes(buildDiamondChain(4), 'start');
+
+			expect(new Set(result).size).toBe(result.length);
+			expect(result).not.toContain('start');
+			expect(new Set(result)).toEqual(
+				new Set(['a0', 'b0', 'm0', 'a1', 'b1', 'm1', 'a2', 'b2', 'm2', 'a3', 'b3', 'm3']),
+			);
+		});
+
+		it('should return all reachable nodes and terminate on a multi-node cycle', () => {
+			// A -> B -> C -> A, plus C -> D. Reachable from A: B, C, D; not A.
+			const cyclic = conns({ A: ['B'], B: ['C'], C: ['A', 'D'] });
+
+			const result = getConnectedNodes(cyclic, 'A');
+
+			expect(new Set(result)).toEqual(new Set(['B', 'C', 'D']));
+			expect(result).not.toContain('A');
+		});
+
+		it('should exclude the start node on a self-loop', () => {
+			const selfLoop = conns({ A: ['A', 'B'] });
+
+			expect(getChildNodes(selfLoop, 'A')).toEqual(['B']);
+		});
+	});
+
+	describe('result ordering', () => {
+		it('should order a diamond deepest-first with the shared node listed once', () => {
+			//   root -> {mid1, mid2} -> leaf
+			const diamond = conns({ root: ['mid1', 'mid2'], mid1: ['leaf'], mid2: ['leaf'] });
+
+			expect(getChildNodes(diamond, 'root')).toEqual(['leaf', 'mid2', 'mid1']);
+			expect(getParentNodes(mapConnectionsByDestination(diamond), 'leaf')).toEqual([
+				'root',
+				'mid2',
+				'mid1',
+			]);
+		});
+
+		it('should order a shortcut diamond consistently when a node is both a direct child and a descendant', () => {
+			// root -> leaf  AND  root -> mid -> leaf
+			const shortcut = conns({ root: ['mid', 'leaf'], mid: ['leaf'] });
+
+			expect(getChildNodes(shortcut, 'root')).toEqual(['leaf', 'mid']);
+			expect(getParentNodes(mapConnectionsByDestination(shortcut), 'leaf')).toEqual([
+				'root',
+				'mid',
+			]);
+		});
+	});
+
+	describe('depth limit', () => {
+		// leaf is reachable via a 1-hop and a 3-hop path:
+		//   root -> leaf            and  root -> m1 -> m2 -> leaf
+		const graph = conns({ root: ['leaf', 'm1'], m1: ['m2'], m2: ['leaf'] });
+
+		it.each([1, 2, 3, 4, -1])('should return the nodes reachable within depth %s', (depth) => {
+			const result = getChildNodes(graph, 'root', Main, depth);
+
+			expect(new Set(result)).toEqual(reachableWithinDepth(graph, 'root', depth));
+		});
+
+		it('should order results deepest-first across depth boundaries', () => {
+			expect(getChildNodes(graph, 'root', Main, 1)).toEqual(['m1', 'leaf']);
+			expect(getChildNodes(graph, 'root', Main, 2)).toEqual(['m2', 'm1', 'leaf']);
+			expect(getChildNodes(graph, 'root', Main, 3)).toEqual(['leaf', 'm2', 'm1']);
+			expect(getChildNodes(graph, 'root')).toEqual(['leaf', 'm2', 'm1']);
+		});
+	});
+
+	describe('return value', () => {
+		it('should not leak mutations of the returned array into later calls', () => {
+			const diamond = conns({ root: ['mid1', 'mid2'], mid1: ['leaf'], mid2: ['leaf'] });
+
+			const first = getChildNodes(diamond, 'root');
+			first.push('INJECTED');
+			first.length = 0;
+
+			expect(getChildNodes(diamond, 'root')).toEqual(['leaf', 'mid2', 'mid1']);
+		});
+	});
+});

--- a/packages/workflow/test/get-connected-nodes.test.ts
+++ b/packages/workflow/test/get-connected-nodes.test.ts
@@ -189,6 +189,22 @@ describe('getConnectedNodes', () => {
 				'mid',
 			]);
 		});
+
+		it('should keep ordering correct when an internal node is shared across sibling branches', () => {
+			//  ┌────┐     ┌───┐
+			//  │root├────►│ x ├────┐
+			//  └──┬─┘     └───┘    │   ┌────────┐     ┌──────┐
+			//     │                ├──►│ shared ├────►│ leaf │
+			//     │       ┌───┐    │   └────────┘     └──────┘
+			//     └──────►│ y ├────┘
+			//             └───┘
+			// `shared` has a child, so it enters the traversal's path tracking during
+			// expansion. If a node were left in that tracking after being expanded,
+			// sibling `y` would skip `shared` as a phantom ancestor and reorder the result.
+			const graph = conns({ root: ['x', 'y'], x: ['shared'], y: ['shared'], shared: ['leaf'] });
+
+			expect(getChildNodes(graph, 'root')).toEqual(['leaf', 'shared', 'y', 'x']);
+		});
 	});
 
 	describe('depth limit', () => {

--- a/packages/workflow/test/graph/graph-fixtures.ts
+++ b/packages/workflow/test/graph/graph-fixtures.ts
@@ -1,0 +1,93 @@
+import type { IConnections } from '../../src/interfaces';
+import { NodeConnectionTypes } from '../../src/interfaces';
+
+const Main = NodeConnectionTypes.Main;
+
+/** Build source-indexed main connections from a `{ from: [to, ...] }` adjacency map. */
+export function connectionsFromMap(map: Record<string, string[]>): IConnections {
+	const out: IConnections = {};
+	for (const [from, tos] of Object.entries(map)) {
+		out[from] = { [Main]: [tos.map((node) => ({ node, type: Main, index: 0 }))] };
+	}
+	return out;
+}
+
+/** Build source-indexed main connections from `[from, to]` index pairs (nodes named `n<i>`). */
+export function connectionsFromEdges(edges: Array<[number, number]>): IConnections {
+	const out: IConnections = {};
+	for (const [from, to] of edges) {
+		const src = `n${from}`;
+		out[src] ??= {};
+		out[src][Main] ??= [[]];
+		out[src][Main][0]!.push({ node: `n${to}`, type: Main, index: 0 });
+	}
+	return out;
+}
+
+/**
+ * A chain of diamonds: start -> {aN, bN} -> mN -> {aN+1, bN+1} -> ...
+ * Each fan-out/fan-in doubles the number of distinct paths to the next merge
+ * node, so the last node is reachable by 2^diamonds paths.
+ *
+ *  ┌─────┐     ┌────┐
+ *  │start├────►│ a0 ├────┐
+ *  └──┬──┘     └────┘    │    ┌────┐
+ *     │                  ├───►│ m0 ├───► (next diamond: m0 -> {a1, b1} -> m1 -> ...)
+ *     │        ┌────┐    │    └────┘
+ *     └───────►│ b0 ├────┘
+ *              └────┘
+ */
+export function diamondChain(diamonds: number): IConnections {
+	const conn: IConnections = {};
+	const link = (from: string, to: string) => {
+		conn[from] ??= { [Main]: [[]] };
+		conn[from][Main][0]!.push({ node: to, type: Main, index: 0 });
+	};
+	let cur = 'start';
+	for (let i = 0; i < diamonds; i++) {
+		const a = `a${i}`;
+		const b = `b${i}`;
+		const next = `m${i}`;
+		link(cur, a);
+		link(cur, b);
+		link(a, next);
+		link(b, next);
+		cur = next;
+	}
+	return conn;
+}
+
+/**
+ * Reference oracle: main-reachable nodes from `start` within `depth` hops
+ * (-1 = unlimited), excluding `start` itself. Independent of the code under test.
+ */
+export function reachableWithinDepth(
+	conn: IConnections,
+	start: string,
+	depth: number,
+): Set<string> {
+	const seen = new Set<string>();
+	let frontier = [start];
+	let remaining = depth;
+	while (frontier.length && remaining !== 0) {
+		const nextFrontier: string[] = [];
+		for (const node of frontier) {
+			for (const output of conn[node]?.[Main] ?? []) {
+				for (const connection of output ?? []) {
+					if (connection.node !== start && !seen.has(connection.node)) {
+						seen.add(connection.node);
+						nextFrontier.push(connection.node);
+					}
+				}
+			}
+		}
+		frontier = nextFrontier;
+		if (remaining > 0) remaining -= 1;
+	}
+	return seen;
+}
+
+/** All main-reachable nodes from `start`, excluding `start` itself. */
+export function reachableMain(conn: IConnections, start: string): Set<string> {
+	return reachableWithinDepth(conn, start, -1);
+}


### PR DESCRIPTION

## Summary

Currently, when executing a workflow, we revalidate the entire workflow graph via `checkReadyForExecution`, which indirectly calls `getConnectedNodes`; `getConnectedNodes` itself is also called in a number of places, like the editor. For large branching graphs with diamonds (e.g. the graph splits and rejoins), `getConnectedNodes` hits its worst case and is extremely slow, due to being exponential time O(2^n) with number of diamonds in the graph.

This PR makes the traversal linear in time, by memoising each node's result once across the whole traversal and tracking the current path in a shared set, instead of maintaining a list of visited nodes for every branch.

Benchmark: `packages/testing/performance/benchmarks/workflow-graph/traversal.bench.ts`
(42-node graph, 2^14 ~= 16k paths; local wall-clock).

| Graph | Structure | Nodes | Before | After | Speedup |
| --- | --- | --- | --- | --- | --- |
| Diamond chain - children | 14 stacked diamonds (each node fans out to 2, then those fan back in to 1), walked forward from the start node; 2^14 (~16k) distinct paths reach the final node | 43 | 12.4 ms | 0.047 ms | ~265x |
| Diamond chain - parents | Same graph, walked backward from the final node (`getParentNodes`) | 43 | 12.9 ms | 0.043 ms | ~304x |
| Wide fan-out | 1 trigger -> 184 parallel branches -> 1 shared sink (broad and shallow, single fan-in) | 186 | 0.11 ms | 0.13 ms | unaffected |
| Linear chain | Single path n0 -> n1 -> ... -> n500, no branching | 501 | ~17 ms | ~17 ms | unaffected |

For a workflow of similar size to the one reported in https://github.com/n8n-io/n8n/issues/32250:

| | Before | After |
| --- | --- | --- |
| Execution start (validation before first node runs) | ~43.7 s | ~25 ms |

By diamond count:

| Diamonds | Nodes | Before | After |
| --- | --- | --- | --- |
| 15 | 46 | 25 ms | 0.19 ms |
| 18 | 55 | 201 ms | 0.12 ms |
| 20 | 61 | 872 ms | 0.43 ms |
| 22 | 67 | 3.7 s | 0.14 ms |
| 24 | 73 | 15.3 s | 0.21 ms |
| 30 | 91 | (minutes) | 0.31 ms |

## How to test

- Create a workflow with several diamonds (see attached workflow)
- Execute manually
- Observe the spinner spin for a long time

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

https://linear.app/n8n/issue/CAT-3437

Closes https://github.com/n8n-io/n8n/issues/32250

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
[cat-3437-repro-24-diamonds.json](https://github.com/user-attachments/files/28996433/cat-3437-repro-24-diamonds.json)

