### PR TITLE
refactor: Replace deprecated ApplicationError in task-runner, frontend, and @n8n/* packages (no-changelog)

### DIFF
--- a/packages/@n8n/ai-utilities/src/utils/follow-redirects.ts
+++ b/packages/@n8n/ai-utilities/src/utils/follow-redirects.ts
@@ -1,4 +1,4 @@
-import { ApplicationError } from 'n8n-workflow';
+import { OperationalError } from 'n8n-workflow';
 
 const DEFAULT_MAX_REDIRECTS = 20;
 
@@ -45,7 +45,7 @@ export async function fetchFollowingRedirects(
 
 		hops += 1;
 		if (hops > maxRedirects) {
-			throw new ApplicationError(`Too many redirects (max ${maxRedirects})`);
+			throw new OperationalError(`Too many redirects (max ${maxRedirects})`);
 		}
 
 		await response.body?.cancel().catch(() => {});

--- a/packages/@n8n/ai-workflow-builder.ee/src/test/workflow-builder-agent.test.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/test/workflow-builder-agent.test.ts
@@ -4,7 +4,7 @@ import type { MemorySaver } from '@langchain/langgraph';
 import { GraphRecursionError } from '@langchain/langgraph';
 import type { Logger } from '@n8n/backend-common';
 import type { INodeTypeDescription } from 'n8n-workflow';
-import { ApplicationError, OperationalError } from 'n8n-workflow';
+import { OperationalError, UserError } from 'n8n-workflow';
 import type { Mock, MockedClass, MockedFunction } from 'vitest';
 import { mock } from 'vitest-mock-extended';
 
@@ -200,7 +200,7 @@ describe('WorkflowBuilderAgent', () => {
 			await expect(async () => {
 				const generator = agent.chat(mockPayload);
 				await generator.next();
-			}).rejects.toThrow(ApplicationError);
+			}).rejects.toThrow(UserError);
 		});
 
 		it('should handle 401 expired token error from LangChain MODEL_AUTHENTICATION', async () => {
@@ -220,11 +220,11 @@ describe('WorkflowBuilderAgent', () => {
 			await expect(async () => {
 				const generator = agent.chat(mockPayload);
 				await generator.next();
-			}).rejects.toThrow(ApplicationError);
+			}).rejects.toThrow(UserError);
 		});
 
 		it('should not treat generic 401 errors as expired token errors', async () => {
-			// A generic 401 without lc_error_code should be rethrown as-is, not converted to ApplicationError
+			// A generic 401 without lc_error_code should be rethrown as-is, not converted to UserError
 			const generic401Error = Object.assign(new Error('Unauthorized'), { status: 401 });
 
 			mockCreateStreamProcessor.mockImplementation(() => {

--- a/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
+++ b/packages/@n8n/ai-workflow-builder.ee/src/workflow-builder-agent.ts
@@ -9,8 +9,8 @@ import { Command, GraphRecursionError } from '@langchain/langgraph';
 import type { SelectedNodeContext } from '@n8n/api-types';
 import type { Logger } from '@n8n/backend-common';
 import {
-	ApplicationError,
 	OperationalError,
+	UserError,
 	type INodeTypeDescription,
 	type IRunExecutionData,
 	type ITelemetryTrackProperties,
@@ -645,12 +645,12 @@ export class WorkflowBuilderAgent {
 
 		// If it's not an abort error, check for GraphRecursionError
 		if (error instanceof GraphRecursionError) {
-			throw new ApplicationError(WORKFLOW_TOO_COMPLEX_ERROR);
+			throw new UserError(WORKFLOW_TOO_COMPLEX_ERROR);
 		}
 
 		// Check for 401 expired token errors (typically from long-running generations)
 		if (this.isTokenExpiredError(error)) {
-			throw new ApplicationError(WORKFLOW_TOO_COMPLEX_ERROR);
+			throw new UserError(WORKFLOW_TOO_COMPLEX_ERROR);
 		}
 
 		// Re-throw any other errors

--- a/packages/@n8n/task-runner/src/health-check-server.ts
+++ b/packages/@n8n/task-runner/src/health-check-server.ts
@@ -1,4 +1,4 @@
-import { ApplicationError } from '@n8n/errors';
+import { OperationalError } from 'n8n-workflow';
 import { createServer } from 'node:http';
 
 export class HealthCheckServer {
@@ -11,7 +11,7 @@ export class HealthCheckServer {
 		return await new Promise<void>((resolve, reject) => {
 			const portInUseErrorHandler = (error: NodeJS.ErrnoException) => {
 				if (error.code === 'EADDRINUSE') {
-					reject(new ApplicationError(`Port ${port} is already in use`));
+					reject(new OperationalError(`Port ${port} is already in use`));
 				} else {
 					reject(error);
 				}

--- a/packages/@n8n/task-runner/src/node-types.ts
+++ b/packages/@n8n/task-runner/src/node-types.ts
@@ -1,5 +1,5 @@
 import {
-	ApplicationError,
+	UnexpectedError,
 	type IDataObject,
 	type INodeType,
 	type INodeTypeDescription,
@@ -42,7 +42,7 @@ export class TaskRunnerNodeTypes implements INodeTypes {
 
 	// This isn't used in Workflow from what I can see
 	getByName(_nodeType: string): INodeType | IVersionedNodeType {
-		throw new ApplicationError('Unimplemented `getByName`', { level: 'error' });
+		throw new UnexpectedError('Unimplemented `getByName`');
 	}
 
 	getByNameAndVersion(nodeType: string, version?: number): INodeType {
@@ -61,7 +61,7 @@ export class TaskRunnerNodeTypes implements INodeTypes {
 
 	// This isn't used in Workflow from what I can see
 	getKnownTypes(): IDataObject {
-		throw new ApplicationError('Unimplemented `getKnownTypes`', { level: 'error' });
+		throw new UnexpectedError('Unimplemented `getKnownTypes`');
 	}
 
 	addNodeTypeDescriptions(nodeTypeDescriptions: INodeTypeDescription[]) {

--- a/packages/@n8n/task-runner/src/task-runner.ts
+++ b/packages/@n8n/task-runner/src/task-runner.ts
@@ -1,5 +1,5 @@
 import { isSerializedBuffer, toBuffer } from 'n8n-core';
-import { ApplicationError, ensureError, randomInt } from 'n8n-workflow';
+import { ensureError, OperationalError, randomInt, UnexpectedError } from 'n8n-workflow';
 import { nanoid } from 'nanoid';
 import { EventEmitter } from 'node:events';
 import { type MessageEvent, WebSocket } from 'ws';
@@ -420,7 +420,7 @@ export abstract class TaskRunner extends EventEmitter {
 	}
 
 	async executeTask(_taskParams: TaskParams, _signal: AbortSignal): Promise<TaskResultData> {
-		throw new ApplicationError('Unimplemented');
+		throw new UnexpectedError('Unimplemented');
 	}
 
 	async requestNodeTypes<T = unknown>(
@@ -559,7 +559,7 @@ export abstract class TaskRunner extends EventEmitter {
 
 		while (this.runningTasks.size > 0) {
 			if (Date.now() - start > maxWaitTimeInMs) {
-				throw new ApplicationError('Timeout while waiting for tasks to finish');
+				throw new OperationalError('Timeout while waiting for tasks to finish');
 			}
 
 			await new Promise((resolve) => setTimeout(resolve, 100));

--- a/packages/frontend/editor-ui/src/features/ndv/parameters/utils/buttonParameter.utils.ts
+++ b/packages/frontend/editor-ui/src/features/ndv/parameters/utils/buttonParameter.utils.ts
@@ -1,5 +1,5 @@
 import type { Schema } from '@/Interface';
-import { ApplicationError, type INode, type INodeExecutionData } from 'n8n-workflow';
+import { UserError, type INode, type INodeExecutionData } from 'n8n-workflow';
 import { useDataSchema } from '@/app/composables/useDataSchema';
 import { executionDataToJson } from '@/app/utils/nodeTypesUtils';
 import { generateCodeForPrompt } from '@/features/ai/assistant/assistant.api';
@@ -226,7 +226,7 @@ export async function generateCodeForAiTransform(
 
 		value = code;
 	} else {
-		throw new ApplicationError('AI code generation is not enabled');
+		throw new UserError('AI code generation is not enabled');
 	}
 
 	if (value === undefined) return;

--- a/packages/frontend/editor-ui/src/features/workflows/templates/utils/workflowSamples.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/templates/utils/workflowSamples.ts
@@ -1,4 +1,4 @@
-import { ApplicationError, type INodeTypeNameVersion } from 'n8n-workflow';
+import { UnexpectedError, type INodeTypeNameVersion } from 'n8n-workflow';
 import type { WorkflowDataWithTemplateId } from '@/Interface';
 import { isWorkflowDataWithTemplateId } from './typeGuards';
 /* eslint-disable import-x/extensions */
@@ -13,7 +13,7 @@ import apiFundamentalsJson from './samples/tutorial/api_fundamentals.json';
 
 const getWorkflowJson = (json: unknown): WorkflowDataWithTemplateId => {
 	if (!isWorkflowDataWithTemplateId(json)) {
-		throw new ApplicationError('Invalid workflow template JSON structure');
+		throw new UnexpectedError('Invalid workflow template JSON structure');
 	}
 
 	return json;


### PR DESCRIPTION
## Summary

Replaces the remaining `throw new ApplicationError(...)` calls in `@n8n/task-runner`, `frontend/editor-ui`, `@n8n/ai-utilities`, and `@n8n/ai-workflow-builder` with the non-deprecated `UserError` / `OperationalError` / `UnexpectedError` classes from `n8n-workflow`. Part of the project to migrate away from the deprecated `ApplicationError`.

Mapping applied:

| Location | Throw | New class | Rationale |
|---|---|---|---|
| `task-runner/node-types.ts` | `Unimplemented getByName` / `getKnownTypes` | `UnexpectedError` | Internal invariant; methods are never expected to be called |
| `task-runner/task-runner.ts` | `Unimplemented` (abstract `executeTask`) | `UnexpectedError` | Code invariant — overridden by subclasses |
| `task-runner/task-runner.ts` | `Timeout while waiting for tasks to finish` | `OperationalError` | Transient runtime condition |
| `task-runner/health-check-server.ts` | `Port … is already in use` | `OperationalError` | Transient environment condition |
| `editor-ui/buttonParameter.utils.ts` | `AI code generation is not enabled` | `UserError` | User-driven NDV flow guard |
| `editor-ui/workflowSamples.ts` | `Invalid workflow template JSON structure` | `UnexpectedError` | Validates statically-bundled JSON; a failure is a build invariant, not user input |
| `ai-utilities/follow-redirects.ts` | `Too many redirects` | `OperationalError` | Transient network behaviour |
| `ai-workflow-builder/workflow-builder-agent.ts` | `WORKFLOW_TOO_COMPLEX_ERROR` (×2) | `UserError` | Surfaced to the user as guidance |

`nodes-langchain` throws are intentionally out of scope (handled by PR 1g / CAT-3249).

## How to test

No behavioural change — error messages are unchanged. Covered by existing unit tests; `pnpm typecheck`, `pnpm lint`, and `pnpm test` pass in each affected package. The `workflow-builder-agent` test assertions were updated from `ApplicationError` to `UserError`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3250

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32364">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

