### PR TITLE
fix(editor): Hide function info-box tooltip while typing arguments

### DIFF
--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/tooltips/InfoBoxTooltip.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/tooltips/InfoBoxTooltip.ts
@@ -93,6 +93,29 @@ function findActiveArgIndex(node: SyntaxNode, index: number) {
 	return -1;
 }
 
+function isArgSlotEmpty(argList: SyntaxNode, pos: number): boolean {
+	const separators: SyntaxNode[] = [];
+	const expressions: SyntaxNode[] = [];
+	for (let child = argList.firstChild; child; child = child.nextSibling) {
+		if (child.name === '(' || child.name === ',' || child.name === ')') {
+			separators.push(child);
+		} else {
+			expressions.push(child);
+		}
+	}
+
+	// Resolve the slot bracketing the caret, delimited by the surrounding separators.
+	let slotStart = argList.from;
+	let slotEnd = argList.to;
+	for (const separator of separators) {
+		if (separator.to <= pos) slotStart = separator.to;
+		if (separator.from >= pos && slotEnd === argList.to) slotEnd = separator.from;
+	}
+
+	// The slot is empty when no argument expression overlaps it.
+	return !expressions.some((expression) => expression.from < slotEnd && expression.to > slotStart);
+}
+
 const createStateReader = (state: EditorState) => (node?: SyntaxNode | null) => {
 	return node ? state.sliceDoc(node.from, node.to) : '';
 };
@@ -191,6 +214,12 @@ function getTooltipContext(state: EditorState): TooltipContext | null {
 		return null;
 	}
 
+	// Only surface the cursor info-box while the active argument slot is still empty; hide it as
+	// soon as a value is being written. The hover-on-name path is unaffected (it doesn't call this).
+	if (!isArgSlotEmpty(argList, pos)) {
+		return null;
+	}
+
 	const callExpression = findNearestCallExpression(argList);
 	if (!callExpression) {
 		return null;
@@ -246,7 +275,7 @@ const cursorInfoBoxTooltip = StateField.define<{
 		const ctx = getTooltipContext(state);
 		return {
 			tooltip: null,
-			contextKey: ctx ? `${ctx.globalPosition}:${ctx.methodName}` : null,
+			contextKey: ctx ? `${ctx.globalPosition}:${ctx.methodName}:${ctx.argIndex}` : null,
 		};
 	},
 
@@ -273,7 +302,7 @@ const cursorInfoBoxTooltip = StateField.define<{
 		if (!tr.docChanged && !tr.selection) return value;
 
 		const ctx = getTooltipContext(tr.state);
-		const newContextKey = ctx ? `${ctx.globalPosition}:${ctx.methodName}` : null;
+		const newContextKey = ctx ? `${ctx.globalPosition}:${ctx.methodName}:${ctx.argIndex}` : null;
 
 		// Context changed - clear tooltip, ViewPlugin will load new one async
 		if (newContextKey !== value.contextKey) {
@@ -294,7 +323,7 @@ const asyncTooltipLoader = ViewPlugin.define((view) => {
 		const ctx = getTooltipContext(view.state);
 		if (!ctx) return;
 
-		const contextKey = `${ctx.globalPosition}:${ctx.methodName}`;
+		const contextKey = `${ctx.globalPosition}:${ctx.methodName}:${ctx.argIndex}`;
 		const currentField = view.state.field(cursorInfoBoxTooltip, false);
 
 		// If we already have a tooltip or context hasn't changed, skip

--- a/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/tooltips/infoBoxTooltip.test.ts
+++ b/packages/frontend/editor-ui/src/features/shared/editors/plugins/codemirror/tooltips/infoBoxTooltip.test.ts
@@ -58,11 +58,9 @@ describe('Infobox tooltips', () => {
 			expect(highlightedArgIndex(tooltips[0].view)).toBe(0);
 		});
 
-		test('should show a tooltip for: {{ $max(1,2,3,|) }}', async () => {
+		test('should NOT show a tooltip for: {{ $max(1, 2|) }} (caret inside a non-empty arg)', async () => {
 			const tooltips = await cursorTooltips('{{ $max(1, 2|) }}');
-			expect(tooltips.length).toBe(1);
-			expect(infoBoxHeader(tooltips[0].view)).toHaveTextContent('$max(...numbers)');
-			expect(highlightedArgIndex(tooltips[0].view)).toBe(0);
+			expect(tooltips.length).toBe(0);
 		});
 
 		test('should NOT show a tooltip for: {{ $json.str|.includes("test") }}', async () => {
@@ -78,12 +76,10 @@ describe('Infobox tooltips', () => {
 			expect(highlightedArgIndex(tooltips[0].view)).toBe(0);
 		});
 
-		test('should show a tooltip for: {{ $json.str.includes("tes|t") }}', async () => {
+		test('should NOT show a tooltip for: {{ $json.str.includes("tes|t") }} (caret inside a non-empty arg)', async () => {
 			vi.spyOn(workflowHelpers, 'resolveParameter').mockResolvedValue('a string');
 			const tooltips = await cursorTooltips('{{ $json.str.includes("tes|t") }}');
-			expect(tooltips.length).toBe(1);
-			expect(infoBoxHeader(tooltips[0].view)).toHaveTextContent('includes(searchString, start?)');
-			expect(highlightedArgIndex(tooltips[0].view)).toBe(0);
+			expect(tooltips.length).toBe(0);
 		});
 
 		test('should show a tooltip for: {{ $json.str.includes("test",|) }}', async () => {
@@ -92,6 +88,33 @@ describe('Infobox tooltips', () => {
 			expect(tooltips.length).toBe(1);
 			expect(infoBoxHeader(tooltips[0].view)).toHaveTextContent('includes(searchString, start?)');
 			expect(highlightedArgIndex(tooltips[0].view)).toBe(1);
+		});
+
+		test('should show a tooltip for an empty slot after a comma: {{ $max(1,|) }}', async () => {
+			const tooltips = await cursorTooltips('{{ $max(1,|) }}');
+			expect(tooltips.length).toBe(1);
+			expect(infoBoxHeader(tooltips[0].view)).toHaveTextContent('$max(...numbers)');
+		});
+
+		test('should NOT show a tooltip while typing a value: {{ $max(1|) }}', async () => {
+			const tooltips = await cursorTooltips('{{ $max(1|) }}');
+			expect(tooltips.length).toBe(0);
+		});
+
+		test('should NOT show a tooltip before an existing value: {{ $max(|1) }}', async () => {
+			const tooltips = await cursorTooltips('{{ $max(|1) }}');
+			expect(tooltips.length).toBe(0);
+		});
+
+		test('should show a tooltip for a whitespace-only slot: {{ $max( | ) }}', async () => {
+			const tooltips = await cursorTooltips('{{ $max( | ) }}');
+			expect(tooltips.length).toBe(1);
+			expect(infoBoxHeader(tooltips[0].view)).toHaveTextContent('$max(...numbers)');
+		});
+
+		test('should NOT show the outer tooltip inside a nested arrow body: {{ $input.all().map(e => { return e.j|son }) }}', async () => {
+			const tooltips = await cursorTooltips('{{ $input.all().map(e => { return e.j|son }) }}');
+			expect(tooltips.length).toBe(0);
 		});
 	});
 


### PR DESCRIPTION
## Summary

In the expression editor, the cursor "info-box" tooltip (function signature/docs) was shown whenever the caret sat anywhere inside a function's argument list and never dismissed while typing, so it stayed pinned over the code — especially painful in nested/multi-line calls like `{{ $input.all().map(e => { ... }) }}`. This PR shows the info-box **only when the active argument slot is empty** (right after `(` or `,`) and hides it as soon as a value is being written; because resolution targets the innermost `ArgList`, nested calls (e.g. `JSON.stringify(...)` inside `.map(...)`) behave correctly. The hover-on-method-name tooltip is a separate code path and is unchanged.

## How to test

1. Open an expression field and type `{{ $input.all().map(e => {` then keep typing the body — the `map` info-box must **not** stay over your code.
2. Type `{{ $max(` → info-box appears (empty slot); type `1` → it disappears; type `,` → it reappears for the next param.
3. Hover the `$max` method name → the hover tooltip still appears.
4. `pnpm --filter n8n-editor-ui test infoBoxTooltip` → all pass.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-2302

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32371">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

