### PR TITLE
refactor(editor): Make node-group connection guards side-effect-free

### DIFF
--- a/packages/frontend/editor-ui/src/app/composables/canvasConnectionReplacement.utils.test.ts
+++ b/packages/frontend/editor-ui/src/app/composables/canvasConnectionReplacement.utils.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { Connection } from '@vue-flow/core';
+
+import { replaceCanvasConnection } from './canvasConnectionReplacement.utils';
+import type { INodeUi } from '@/Interface';
+
+vi.mock('@/features/workflows/canvas/canvas.utils', () => ({
+	createCanvasConnectionHandleString: vi.fn(() => 'handle'),
+	mapCanvasConnectionToLegacyConnection: vi.fn(() => [
+		{ node: 'A', type: 'main', index: 0 },
+		{ node: 'B', type: 'main', index: 0 },
+	]),
+	mapLegacyConnectionToCanvasConnection: vi.fn(() => ({
+		source: 's',
+		target: 't',
+		sourceHandle: '',
+		targetHandle: '',
+	})),
+	parseCanvasConnectionHandleString: vi.fn(() => ({ type: 'main', index: 0, mode: 'outputs' })),
+}));
+
+function makeNode(id: string): INodeUi {
+	return {
+		id,
+		name: id,
+		type: 'n8n-nodes-base.noOp',
+		typeVersion: 1,
+		position: [0, 0],
+		parameters: {},
+	} as INodeUi;
+}
+
+function connection(source: string, target: string): Connection {
+	return { source, target, sourceHandle: '', targetHandle: '' };
+}
+
+function buildInput(overrides: Record<string, unknown> = {}) {
+	return {
+		connectionToRemove: connection('a', 'b'),
+		addBeforeRemoval: [connection('a', 'x')],
+		addAfterRemoval: [connection('x', 'b')],
+		workflowDocumentStore: {
+			getNodeById: (id: string) => makeNode(id),
+		},
+		createConnection: vi.fn(),
+		deleteConnection: vi.fn(),
+		isConnectionAllowed: () => true,
+		enforceNodeGroupConnectionPolicy: vi.fn(() => true),
+		...overrides,
+	} as unknown as Parameters<typeof replaceCanvasConnection>[0];
+}
+
+describe('replaceCanvasConnection', () => {
+	it('routes the change through enforceNodeGroupConnectionPolicy and proceeds when allowed', () => {
+		const policy = vi.fn(() => true);
+		const input = buildInput({ enforceNodeGroupConnectionPolicy: policy });
+
+		const result = replaceCanvasConnection(input);
+
+		expect(result).toBe(true);
+		expect(policy).toHaveBeenCalledWith(
+			expect.objectContaining({
+				connectionsToRemove: expect.any(Array),
+				connectionsToAdd: expect.any(Array),
+			}),
+		);
+		expect(input.createConnection).toHaveBeenCalled();
+		expect(input.deleteConnection).toHaveBeenCalled();
+	});
+
+	it('aborts without touching connections when the policy rejects the change', () => {
+		const input = buildInput({ enforceNodeGroupConnectionPolicy: vi.fn(() => false) });
+
+		const result = replaceCanvasConnection(input);
+
+		expect(result).toBe(false);
+		expect(input.createConnection).not.toHaveBeenCalled();
+		expect(input.deleteConnection).not.toHaveBeenCalled();
+	});
+});

--- a/packages/frontend/editor-ui/src/app/composables/canvasConnectionReplacement.utils.ts
+++ b/packages/frontend/editor-ui/src/app/composables/canvasConnectionReplacement.utils.ts
@@ -1,6 +1,6 @@
 import type { Connection } from '@vue-flow/core';
 import uniq from 'lodash/uniq';
-import type { IConnection, IConnections, NodeConnectionType } from 'n8n-workflow';
+import type { IConnection, NodeConnectionType } from 'n8n-workflow';
 import { NodeConnectionTypes } from 'n8n-workflow';
 
 import type { INodeUi } from '@/Interface';
@@ -13,7 +13,6 @@ import {
 } from '@/features/workflows/canvas/canvas.utils';
 
 type WorkflowDocumentConnectionAccess = {
-	connectionsBySourceNode: IConnections;
 	getNodeById: (id: string) => INodeUi | undefined;
 };
 
@@ -59,11 +58,10 @@ type CanvasConnectionReplacementDependencies = {
 		sourceConnection: IConnection,
 		targetConnection: IConnection,
 	) => boolean;
-	isConnectionReplacementAllowedForNodeGroups: (replacement: {
+	enforceNodeGroupConnectionPolicy: (params: {
 		nodeIds: string[];
-		connectionsToRemove: Array<[IConnection, IConnection]>;
-		connectionsToAdd: Array<[IConnection, IConnection]>;
-		connectionsBySourceNode: IConnections;
+		connectionsToRemove?: Array<[IConnection, IConnection]>;
+		connectionsToAdd?: Array<[IConnection, IConnection]>;
 	}) => boolean;
 };
 
@@ -194,7 +192,7 @@ export function replaceCanvasConnection({
 	createConnection,
 	deleteConnection,
 	isConnectionAllowed,
-	isConnectionReplacementAllowedForNodeGroups,
+	enforceNodeGroupConnectionPolicy,
 	connectionToRemove,
 	addBeforeRemoval,
 	addAfterRemoval,
@@ -221,13 +219,15 @@ export function replaceCanvasConnection({
 		...additions.flatMap(({ sourceNode, targetNode }) => [sourceNode.id, targetNode.id]),
 	]);
 
-	const isReplacementAllowed = isConnectionReplacementAllowedForNodeGroups({
-		nodeIds,
-		connectionsToRemove: [removal.mappedConnection],
-		connectionsToAdd: additions.map(({ mappedConnection }) => mappedConnection),
-		connectionsBySourceNode: workflowDocumentStore.connectionsBySourceNode,
-	});
-	if (!isReplacementAllowed) return false;
+	if (
+		!enforceNodeGroupConnectionPolicy({
+			nodeIds,
+			connectionsToRemove: [removal.mappedConnection],
+			connectionsToAdd: additions.map(({ mappedConnection }) => mappedConnection),
+		})
+	) {
+		return false;
+	}
 
 	for (const connection of addBeforeRemoval) {
 		createConnection(connection, { trackHistory, validateNodeGroups: false });

--- a/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
+++ b/packages/frontend/editor-ui/src/app/composables/useCanvasOperations.ts
@@ -220,9 +220,10 @@ export function useCanvasOperations() {
 	const clipboard = useClipboard();
 	const { uniqueNodeName } = useUniqueNodeName();
 	const {
-		isConnectionChangeAllowedForNodeGroups,
+		isConnectionRemovalAllowedForNodeGroups,
 		isConnectionReplacementAllowedForNodeGroups,
 		isNodeReplacementAllowedForNodeGroups,
+		applyNodeGroupAutoExtend,
 	} = useCanvasNodeGroupOperationGuards();
 
 	const router = useRouter();
@@ -1089,7 +1090,7 @@ export function useCanvasOperations() {
 			createConnection,
 			deleteConnection,
 			isConnectionAllowed,
-			isConnectionReplacementAllowedForNodeGroups,
+			enforceNodeGroupConnectionPolicy,
 		});
 	}
 
@@ -1989,6 +1990,30 @@ export function useCanvasOperations() {
 	 * Connection operations
 	 */
 
+	// Checks a connection change against node groups and applies any required
+	// auto-extend, returning whether the change may proceed.
+	function enforceNodeGroupConnectionPolicy(params: {
+		nodeIds: string[];
+		connectionsToRemove?: Array<[IConnection, IConnection]>;
+		connectionsToAdd?: Array<[IConnection, IConnection]>;
+	}): boolean {
+		const decision = isConnectionReplacementAllowedForNodeGroups({
+			nodeIds: params.nodeIds,
+			connectionsToRemove: params.connectionsToRemove ?? [],
+			connectionsToAdd: params.connectionsToAdd ?? [],
+			connectionsBySourceNode: workflowDocumentStore.value.connectionsBySourceNode,
+		});
+		switch (decision.outcome) {
+			case 'abort':
+				return false;
+			case 'auto-extend':
+				applyNodeGroupAutoExtend(decision.autoExtend);
+				return true;
+			case 'proceed':
+				return true;
+		}
+	}
+
 	function createConnection(
 		connection: Connection,
 		{ trackHistory = false, keepPristine = false, validateNodeGroups = true } = {},
@@ -2011,11 +2036,9 @@ export function useCanvasOperations() {
 
 		if (
 			validateNodeGroups &&
-			!isConnectionChangeAllowedForNodeGroups({
+			!enforceNodeGroupConnectionPolicy({
 				nodeIds: [sourceNode.id, targetNode.id],
-				connection: mappedConnection,
-				connectionsBySourceNode: workflowDocumentStore.value.connectionsBySourceNode,
-				action: 'add',
+				connectionsToAdd: [mappedConnection],
 			})
 		) {
 			return;
@@ -2138,11 +2161,10 @@ export function useCanvasOperations() {
 
 		if (
 			validateNodeGroups &&
-			!isConnectionChangeAllowedForNodeGroups({
+			!isConnectionRemovalAllowedForNodeGroups({
 				nodeIds: [sourceNode.id, targetNode.id],
 				connection: mappedConnection,
 				connectionsBySourceNode: workflowDocumentStore.value.connectionsBySourceNode,
-				action: 'remove',
 			})
 		) {
 			return;

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupOperationGuards.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/composables/useCanvasNodeGroupOperationGuards.ts
@@ -21,6 +21,14 @@ import { useWorkflowsStore } from '@/app/stores/workflows.store';
 type ConnectionChangeAction = 'add' | 'remove';
 type InvalidGroupValidationResult = Extract<GroupValidationResult, { valid: false }>;
 type InvalidAffectedGroup = { group: IWorkflowGroup; result: InvalidGroupValidationResult };
+
+export type NodeGroupAutoExtend = { group: IWorkflowGroup; candidateId: string };
+
+export type NodeGroupConnectionGuardResult =
+	| { outcome: 'proceed' }
+	| { outcome: 'auto-extend'; autoExtend: NodeGroupAutoExtend }
+	| { outcome: 'abort' };
+
 type ExtractableErrorCode = NonNullable<
 	Extract<
 		InvalidGroupValidationResult,
@@ -260,27 +268,10 @@ export function useCanvasNodeGroupOperationGuards() {
 		});
 	}
 
-	function tryAutoExtendInvalidGroup({
-		invalidAffectedGroup,
-		endpointIds,
-		connectionsBySourceNode,
-	}: {
-		invalidAffectedGroup: InvalidAffectedGroup;
-		endpointIds: string[];
-		connectionsBySourceNode: IConnections;
-	}): boolean {
-		const candidateId = getAutoExtendCandidate({
-			failingGroup: invalidAffectedGroup.group,
-			endpointIds,
-			connectionsBySourceNode,
-		});
-
-		if (candidateId === undefined) return false;
-
-		workflowDocumentStore.value.addNodesToGroup(invalidAffectedGroup.group.id, [candidateId]);
-		showAutoExtendedToast(invalidAffectedGroup.group, candidateId);
-
-		return true;
+	// Adds the node to the group and notifies the user
+	function applyNodeGroupAutoExtend({ group, candidateId }: NodeGroupAutoExtend) {
+		workflowDocumentStore.value.addNodesToGroup(group.id, [candidateId]);
+		showAutoExtendedToast(group, candidateId);
 	}
 
 	function isConnectionReplacementAllowedForNodeGroups({
@@ -297,11 +288,11 @@ export function useCanvasNodeGroupOperationGuards() {
 		connectionsBySourceNode: IConnections;
 		allowAutoExtend?: boolean;
 		blockedTitleKey?: BaseTextKey;
-	}): boolean {
-		if (!isCanvasNodeGroupingEnabled.value) return true;
+	}): NodeGroupConnectionGuardResult {
+		if (!isCanvasNodeGroupingEnabled.value) return { outcome: 'proceed' };
 
 		const affectedGroups = getAffectedNodeGroups(nodeIds);
-		if (affectedGroups.length === 0) return true;
+		if (affectedGroups.length === 0) return { outcome: 'proceed' };
 
 		const candidateConnections = applyConnectionChangesToCandidate({
 			connectionsBySourceNode,
@@ -310,43 +301,46 @@ export function useCanvasNodeGroupOperationGuards() {
 		});
 
 		const invalidAffectedGroup = findInvalidGroup(affectedGroups, candidateConnections);
-		if (!invalidAffectedGroup) return true;
+		if (!invalidAffectedGroup) return { outcome: 'proceed' };
 
-		if (
-			allowAutoExtend &&
-			tryAutoExtendInvalidGroup({
-				invalidAffectedGroup,
+		if (allowAutoExtend) {
+			const candidateId = getAutoExtendCandidate({
+				failingGroup: invalidAffectedGroup.group,
 				endpointIds: nodeIds,
 				connectionsBySourceNode: candidateConnections,
-			})
-		) {
-			return true;
+			});
+			if (candidateId !== undefined) {
+				return {
+					outcome: 'auto-extend',
+					autoExtend: { group: invalidAffectedGroup.group, candidateId },
+				};
+			}
 		}
 
 		showConnectionChangeBlockedToast(blockedTitleKey, invalidAffectedGroup);
 
-		return false;
+		return { outcome: 'abort' };
 	}
 
-	function isConnectionChangeAllowedForNodeGroups({
+	function isConnectionRemovalAllowedForNodeGroups({
 		nodeIds,
 		connection,
 		connectionsBySourceNode,
-		action,
 	}: {
 		nodeIds: string[];
 		connection: [IConnection, IConnection];
 		connectionsBySourceNode: IConnections;
-		action: ConnectionChangeAction;
 	}): boolean {
-		return isConnectionReplacementAllowedForNodeGroups({
-			nodeIds,
-			connectionsToRemove: action === 'remove' ? [connection] : [],
-			connectionsToAdd: action === 'add' ? [connection] : [],
-			connectionsBySourceNode,
-			allowAutoExtend: action === 'add',
-			blockedTitleKey: BLOCKED_TITLE_KEY[action],
-		});
+		return (
+			isConnectionReplacementAllowedForNodeGroups({
+				nodeIds,
+				connectionsToRemove: [connection],
+				connectionsToAdd: [],
+				connectionsBySourceNode,
+				allowAutoExtend: false,
+				blockedTitleKey: BLOCKED_TITLE_KEY.remove,
+			}).outcome === 'proceed'
+		);
 	}
 
 	function isNodeReplacementAllowedForNodeGroups({
@@ -409,8 +403,9 @@ export function useCanvasNodeGroupOperationGuards() {
 	}
 
 	return {
-		isConnectionChangeAllowedForNodeGroups,
+		isConnectionRemovalAllowedForNodeGroups,
 		isConnectionReplacementAllowedForNodeGroups,
 		isNodeReplacementAllowedForNodeGroups,
+		applyNodeGroupAutoExtend,
 	};
 }


### PR DESCRIPTION
## Summary

The node-group connection guards `isConnectionChangeAllowedForNodeGroups` and `isConnectionReplacementAllowedForNodeGroups` read like pure predicates (`is…Allowed…`), but they were not: when a connection change would invalidate a group they auto-extended the group as a side effect (via `tryAutoExtendInvalidGroup`) — mutating state with `addNodesToGroup(...)` and showing an "auto-extended" toast.

This change makes the guards honest. The replacement guard now returns a decision instead of acting:

```ts
type NodeGroupConnectionGuardResult =
  | { outcome: 'proceed' }
  | { outcome: 'auto-extend'; autoExtend: { group; candidateId } }
  | { outcome: 'abort' };
```

The auto-extend side effect (mutation + toast) moves to the callers: `enforceNodeGroupConnectionPolicy` in `useCanvasOperations` interprets the result and calls `applyNodeGroupAutoExtend` when the guard asks for it. The removal-only path is split out into `isConnectionRemovalAllowedForNodeGroups`.

This is a **behavior-neutral refactor** — no functional change. It exists to unblock clean canvas undo/redo history tracking for node groups in ADO-5273: with the guard pure, the history pushes land in the callers where the mutation lives, instead of needing a `trackHistory` flag threaded through a "validation" predicate.

## How to test

Behavior should be unchanged. With the `CANVAS_NODES_GROUPING_EXPERIMENT` flag enabled:

1. Create a chain A → B → C, group B and C.
2. Add a connection A → C → the group auto-extends to include A and the "extended" toast shows (same as before).
3. Make a connection change that would invalidate a group with no valid extension → the change is blocked and the blocked toast shows (same as before).

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-5431](https://linear.app/n8n/issue/ADO-5431/refactor-make-node-group-connection-guards-side-effect-free)

Blocks [ADO-5273](https://linear.app/n8n/issue/ADO-5273/feature-add-node-groups-actions-to-history-commands-on-canvas)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [x] Tests included.


<a href="https://stagereview.app/n8n-io/n8n/pull/32378">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->
