### PR TITLE
refactor(core): Migrate SAML IdP metadata fetch to outbound HTTP factory (no-changelog)

### DIFF
--- a/packages/cli/src/modules/sso-saml/__tests__/saml.service.ee.test.ts
+++ b/packages/cli/src/modules/sso-saml/__tests__/saml.service.ee.test.ts
@@ -1,13 +1,11 @@
 import type { SamlPreferences } from '@n8n/api-types';
+import type { HttpRequestClient, OutboundHttp } from '@n8n/backend-network';
 import { mockInstance, mockLogger } from '@n8n/backend-test-utils';
 import type { GlobalConfig } from '@n8n/config';
 import { SettingsRepository } from '@n8n/db';
 import type { UserRepository, Settings, User } from '@n8n/db';
 import { Container } from '@n8n/di';
-import axios from 'axios';
 import type express from 'express';
-import type { HttpProxyAgent } from 'http-proxy-agent';
-import type { HttpsProxyAgent } from 'https-proxy-agent';
 import { mock } from 'jest-mock-extended';
 import type { Cipher, InstanceSettings } from 'n8n-core';
 import { CREDENTIAL_BLANKING_VALUE } from 'n8n-workflow';
@@ -26,9 +24,6 @@ import { InvalidSamlMetadataError } from '../errors/invalid-saml-metadata.error'
 import * as samlHelpers from '../saml-helpers';
 import { SamlValidator } from '../saml-validator';
 import { SamlService } from '../saml.service.ee';
-
-jest.mock('axios');
-const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 const InvalidSamlSetting: Settings = {
 	loadOnStartup: true,
@@ -168,6 +163,8 @@ describe('SamlService', () => {
 	let provisioningService: ProvisioningService;
 	let cipher: Cipher;
 	let cacheService: jest.Mocked<CacheService>;
+	let outboundHttp: jest.Mocked<OutboundHttp>;
+	let httpRequest: jest.Mock;
 	const validator = new SamlValidator(mock());
 	const logger = mockLogger();
 
@@ -221,6 +218,9 @@ describe('SamlService', () => {
 			data.replace('encrypted:', ''),
 		) as Cipher['decryptV2'];
 		cacheService = mock<CacheService>();
+		httpRequest = jest.fn();
+		outboundHttp = mock<OutboundHttp>();
+		outboundHttp.requests.mockReturnValue(mock<HttpRequestClient>({ request: httpRequest }));
 
 		jest
 			.spyOn(ssoHelpers, 'reloadAuthenticationMethod')
@@ -237,6 +237,7 @@ describe('SamlService', () => {
 			provisioningService,
 			cipher,
 			cacheService,
+			outboundHttp,
 		);
 		// Mock GlobalConfig container access
 		Container.set(require('@n8n/config').GlobalConfig, globalConfig);
@@ -750,7 +751,7 @@ describe('SamlService', () => {
 		});
 
 		test('does throw `BadRequestError` when a metadata url is not returning correct metadata', async () => {
-			mockedAxios.get.mockResolvedValue({ status: 200, data: 'NOT VALID SAML METADATA' });
+			httpRequest.mockResolvedValue({ statusCode: 200, body: 'NOT VALID SAML METADATA' });
 			await expect(
 				samlService.setSamlPreferences({
 					metadataUrl: 'https://www.some.url',
@@ -764,7 +765,7 @@ describe('SamlService', () => {
 				metadataUrl: metadataUrlTestData,
 			});
 
-			mockedAxios.get.mockResolvedValue({ status: 200, data: 'NOT VALID SAML METADATA' });
+			httpRequest.mockResolvedValue({ statusCode: 200, body: 'NOT VALID SAML METADATA' });
 			await expect(
 				samlService.setSamlPreferences({
 					metadataUrl: 'https://www.some.url',
@@ -791,7 +792,7 @@ describe('SamlService', () => {
 		});
 
 		test('does throw `InvalidSamlMetadataUrlError` when the metadata url does not return success on http call', async () => {
-			mockedAxios.get.mockResolvedValue({ status: 400, data: '' });
+			httpRequest.mockResolvedValue({ statusCode: 400, body: '' });
 			await expect(
 				samlService.setSamlPreferences({
 					metadataUrl: 'https://www.some.url',
@@ -805,7 +806,7 @@ describe('SamlService', () => {
 				metadataUrl: metadataUrlTestData,
 			});
 
-			mockedAxios.get.mockResolvedValue({ status: 400 });
+			httpRequest.mockResolvedValue({ statusCode: 400 });
 			await expect(
 				samlService.setSamlPreferences({
 					metadataUrl: 'https://www.some.url',
@@ -1520,201 +1521,66 @@ describe('SamlService', () => {
 		});
 	});
 
-	describe('proxy configuration', () => {
-		const originalEnv = process.env;
+	describe('fetchMetadataFromUrl', () => {
 		const validMetadataXml =
 			'<?xml version="1.0" encoding="UTF-8" standalone="no"?>\n<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" entityID="https://saml.example.com/entityid" validUntil="2035-05-07T13:33:47.181Z">\n  <md:IDPSSODescriptor WantAuthnRequestsSigned="true" protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol">\n    <md:KeyDescriptor use="signing">\n      <ds:KeyInfo xmlns:ds="http://www.w3.org/2000/09/xmldsig#">\n        <ds:X509Data>\n          <ds:X509Certificate>MIIC4jCCAcoCCQC33wnybT5QZDANBgkqhkiG9w0BAQsFADAyMQswCQYDVQQGEwJV\nSzEPMA0GA1UECgwGQm94eUhRMRIwEAYDVQQDDAlNb2NrIFNBTUwwIBcNMjIwMjI4\nMjE0NjM4WhgPMzAyMTA3MDEyMTQ2MzhaMDIxCzAJBgNVBAYTAlVLMQ8wDQYDVQQK\nDAZCb3h5SFExEjAQBgNVBAMMCU1vY2sgU0FNTDCCASIwDQYJKoZIhvcNAQEBBQAD\nggEPADCCAQoCggEBALGfYettMsct1T6tVUwTudNJH5Pnb9GGnkXi9Zw/e6x45DD0\nRuRONbFlJ2T4RjAE/uG+AjXxXQ8o2SZfb9+GgmCHuTJFNgHoZ1nFVXCmb/Hg8Hpd\n4vOAGXndixaReOiq3EH5XvpMjMkJ3+8+9VYMzMZOjkgQtAqO36eAFFfNKX7dTj3V\npwLkvz6/KFCq8OAwY+AUi4eZm5J57D31GzjHwfjH9WTeX0MyndmnNB1qV75qQR3b\n2/W5sGHRv+9AarggJkF+ptUkXoLtVA51wcfYm6hILptpde5FQC8RWY1YrswBWAEZ\nNfyrR4JeSweElNHg4NVOs4TwGjOPwWGqzTfgTlECAwEAATANBgkqhkiG9w0BAQsF\nAAOCAQEAAYRlYflSXAWoZpFfwNiCQVE5d9zZ0DPzNdWhAybXcTyMf0z5mDf6FWBW\n5Gyoi9u3EMEDnzLcJNkwJAAc39Apa4I2/tml+Jy29dk8bTyX6m93ngmCgdLh5Za4\nkhuU3AM3L63g7VexCuO7kwkjh/+LqdcIXsVGO6XDfu2QOs1Xpe9zIzLpwm/RNYeX\nUjbSj5ce/jekpAw7qyVVL4xOyh8AtUW1ek3wIw1MJvEgEPt0d16oshWJpoS1OT8L\nr/22SvYEo3EmSGdTVGgk3x3s+A0qWAqTcyjr7Q4s/GKYRFfomGwz0TZ4Iw1ZN99M\nm0eo2USlSRTVl7QHRTuiuSThHpLKQQ==</ds:X509Certificate>\n        </ds:X509Data>\n      </ds:KeyInfo>\n    </md:KeyDescriptor>\n    <md:NameIDFormat>urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress</md:NameIDFormat>\n    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://mocksaml.com/api/saml/sso"/>\n    <md:SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://mocksaml.com/api/saml/sso"/>\n  </md:IDPSSODescriptor>\n</md:EntityDescriptor>';
 
+		type SamlServicePrivate = { _samlPreferences: SamlPreferences };
+
 		beforeEach(() => {
-			// Reset environment before each test
-			process.env = { ...originalEnv };
-			jest.restoreAllMocks();
 			jest.spyOn(samlService, 'loadSamlify').mockResolvedValue(undefined);
+			jest.spyOn(samlService['validator'], 'validateMetadata').mockResolvedValue(true);
 		});
 
-		afterEach(() => {
-			// Restore original environment after each test
-			process.env = originalEnv;
-		});
-
-		test('should use proxy when HTTP_PROXY environment variable is set for HTTP URLs', async () => {
-			// Set HTTP proxy environment variable
-			const proxyUrl = 'http://proxy.example.com:8080';
-			process.env.HTTP_PROXY = proxyUrl;
-
-			// Use an HTTP metadata URL
-			const metadataUrl = 'http://saml.example.com/metadata';
-
-			// Mock the preferences to include a metadataUrl
-			type SamlServicePrivate = { _samlPreferences: SamlPreferences };
+		test('fetches metadata with SSRF protection disabled', async () => {
+			const metadataUrl = 'https://saml.example.com/metadata';
 			(samlService as unknown as SamlServicePrivate)._samlPreferences = {
 				metadata: mockSamlConfig.metadata,
 				metadataUrl,
+				ignoreSSL: false,
 			} as SamlPreferences;
 
-			// Mock axios response
-			mockedAxios.get.mockResolvedValue({
-				status: 200,
-				data: validMetadataXml,
-			});
-
-			// Mock validator
-			jest.spyOn(samlService['validator'], 'validateMetadata').mockResolvedValue(true);
+			httpRequest.mockResolvedValue({ statusCode: 200, body: validMetadataXml });
 
 			const result = await samlService.fetchMetadataFromUrl();
 
 			expect(result).toBe(validMetadataXml);
-
-			// Verify that axios.get was called with the correct URL and agents
-			expect(mockedAxios.get).toHaveBeenCalledWith(
-				metadataUrl,
-				expect.objectContaining({
-					httpAgent: expect.any(Object),
-					httpsAgent: expect.any(Object),
-				}),
-			);
-
-			// Get the actual call arguments to verify the agents
-			const callArgs = mockedAxios.get.mock.calls[0];
-			if (!callArgs?.[1]) {
-				throw new Error('Expected axios.get to be called with arguments');
-			}
-
-			const { httpAgent, httpsAgent } = callArgs[1];
-
-			// Verify that both agents are created
-			expect(httpAgent).toBeDefined();
-			expect(httpsAgent).toBeDefined();
-
-			// Verify the httpAgent has proxy configuration
-			expect(httpAgent).toHaveProperty('proxy');
-			const httpProxyAgent = httpAgent as unknown as HttpProxyAgent<string>;
-			expect(httpProxyAgent.proxy).toBeDefined();
-			expect(httpProxyAgent.proxy.href).toBe(`${proxyUrl}/`);
-
-			// The httpsAgent should also have the proxy (both are created with same proxy)
-			expect(httpsAgent).toHaveProperty('proxy');
-			const httpsProxyAgent = httpsAgent as unknown as HttpsProxyAgent<string>;
-			expect(httpsProxyAgent.proxy.href).toBe(`${proxyUrl}/`);
+			// The metadata URL is admin-configured, so SSRF protection is disabled.
+			expect(outboundHttp.requests).toHaveBeenCalledWith({ ssrf: 'disabled' });
+			expect(httpRequest).toHaveBeenCalledWith({
+				url: metadataUrl,
+				method: 'GET',
+				skipSslCertificateValidation: false,
+				returnFullResponse: true,
+			});
 		});
 
-		test('should use proxy when HTTPS_PROXY environment variable is set for HTTPS URLs', async () => {
-			// Set HTTPS proxy environment variable
-			const proxyUrl = 'https://proxy.example.com:8080';
-			process.env.HTTPS_PROXY = proxyUrl;
-
-			// Use an HTTPS metadata URL
+		test('skips SSL certificate validation when ignoreSSL is enabled', async () => {
 			const metadataUrl = 'https://saml.example.com/metadata';
-
-			// Mock the preferences to include a metadataUrl
-			type SamlServicePrivate = { _samlPreferences: SamlPreferences };
 			(samlService as unknown as SamlServicePrivate)._samlPreferences = {
 				metadata: mockSamlConfig.metadata,
 				metadataUrl,
 				ignoreSSL: true,
 			} as SamlPreferences;
 
-			// Mock axios response
-			mockedAxios.get.mockResolvedValue({
-				status: 200,
-				data: validMetadataXml,
-			});
-
-			// Mock validator
-			jest.spyOn(samlService['validator'], 'validateMetadata').mockResolvedValue(true);
+			httpRequest.mockResolvedValue({ statusCode: 200, body: validMetadataXml });
 
 			const result = await samlService.fetchMetadataFromUrl();
 
 			expect(result).toBe(validMetadataXml);
-
-			// Verify that axios.get was called with the correct URL and agents
-			expect(mockedAxios.get).toHaveBeenCalledWith(
-				metadataUrl,
-				expect.objectContaining({
-					httpAgent: expect.any(Object),
-					httpsAgent: expect.any(Object),
-				}),
+			expect(httpRequest).toHaveBeenCalledWith(
+				expect.objectContaining({ skipSslCertificateValidation: true }),
 			);
-
-			// Get the actual call arguments to verify the agents
-			const callArgs = mockedAxios.get.mock.calls[0];
-			if (!callArgs?.[1]) {
-				throw new Error('Expected axios.get to be called with arguments');
-			}
-
-			const { httpAgent, httpsAgent } = callArgs[1];
-
-			// Verify that both agents are created
-			expect(httpAgent).toBeDefined();
-			expect(httpsAgent).toBeDefined();
-
-			// Verify the httpsAgent has proxy configuration
-			expect(httpsAgent).toHaveProperty('proxy');
-			const httpsProxyAgent = httpsAgent as unknown as HttpsProxyAgent<string>;
-			expect(httpsProxyAgent.proxy).toBeDefined();
-			expect(httpsProxyAgent.proxy.href).toBe(`${proxyUrl}/`);
-
-			// Verify that the httpsAgent has the correct rejectUnauthorized setting when ignoreSSL is true
-			// HttpsProxyAgent stores connection options in connectOpts, not options
-			const httpsAgentWithConnectOpts = httpsProxyAgent as unknown as {
-				connectOpts?: { rejectUnauthorized?: boolean };
-			};
-			expect(httpsAgentWithConnectOpts.connectOpts?.rejectUnauthorized).toBe(false);
-
-			// The httpAgent should also have the proxy (both are created with same proxy)
-			expect(httpAgent).toHaveProperty('proxy');
-			const httpProxyAgent = httpAgent as unknown as HttpProxyAgent<string>;
-			expect(httpProxyAgent.proxy.href).toBe(`${proxyUrl}/`);
 		});
 
-		test('should work without proxy when no proxy environment variables are set', async () => {
-			// Ensure no proxy env vars are set
-			delete process.env.HTTP_PROXY;
-			delete process.env.HTTPS_PROXY;
-			delete process.env.ALL_PROXY;
-
-			// Mock the preferences to include a metadataUrl
-			type SamlServicePrivate = { _samlPreferences: SamlPreferences };
+		test('throws BadRequestError when no metadata URL is set', async () => {
 			(samlService as unknown as SamlServicePrivate)._samlPreferences = {
 				metadata: mockSamlConfig.metadata,
-				metadataUrl: 'https://saml.example.com/metadata',
-				ignoreSSL: false,
+				metadataUrl: '',
 			} as SamlPreferences;
 
-			// Mock axios response
-			mockedAxios.get.mockResolvedValue({
-				status: 200,
-				data: validMetadataXml,
-			});
-
-			// Mock validator
-			jest.spyOn(samlService['validator'], 'validateMetadata').mockResolvedValue(true);
-
-			const result = await samlService.fetchMetadataFromUrl();
-
-			expect(result).toBe(validMetadataXml);
-
-			// Verify that axios.get was called with agents
-			expect(mockedAxios.get).toHaveBeenCalledWith(
-				'https://saml.example.com/metadata',
-				expect.objectContaining({
-					httpAgent: expect.any(Object),
-					httpsAgent: expect.any(Object),
-				}),
-			);
-
-			// Get the actual call arguments to verify the agents are NOT proxy agents
-			const callArgs = mockedAxios.get.mock.calls[0];
-			if (!callArgs?.[1]) {
-				throw new Error('Expected axios.get to be called with arguments');
-			}
-
-			const { httpAgent, httpsAgent } = callArgs[1];
-
-			// When no proxy is configured, regular http/https Agents are created
-			// These should NOT have a proxy property
-			expect(httpAgent).not.toHaveProperty('proxy');
-			expect(httpsAgent).not.toHaveProperty('proxy');
+			await expect(samlService.fetchMetadataFromUrl()).rejects.toThrowError(BadRequestError);
+			expect(httpRequest).not.toHaveBeenCalled();
 		});
 	});
 

--- a/packages/cli/src/modules/sso-saml/saml.service.ee.ts
+++ b/packages/cli/src/modules/sso-saml/saml.service.ee.ts
@@ -1,12 +1,11 @@
 import type { SamlPreferences, SamlPreferencesAttributeMapping } from '@n8n/api-types';
 import { Logger } from '@n8n/backend-common';
-import { createHttpProxyAgent, createHttpsProxyAgent } from '@n8n/backend-network';
+import { OutboundHttp } from '@n8n/backend-network';
 import { GlobalConfig } from '@n8n/config';
 import type { Settings, User } from '@n8n/db';
 import { isValidEmail, SettingsRepository, UserRepository } from '@n8n/db';
 import { OnPubSubEvent } from '@n8n/decorators';
 import { Container, Service } from '@n8n/di';
-import axios from 'axios';
 import { createPublicKey, randomBytes, X509Certificate } from 'crypto';
 import type express from 'express';
 import { Cipher, InstanceSettings } from 'n8n-core';
@@ -103,6 +102,7 @@ export class SamlService {
 		private readonly provisioningService: ProvisioningService,
 		private readonly cipher: Cipher,
 		private readonly cacheService: CacheService,
+		private readonly outboundHttp: OutboundHttp,
 	) {}
 
 	/**
@@ -682,23 +682,18 @@ export class SamlService {
 		const shouldIgnoreSSL = ignoreSSL ?? this._samlPreferences.ignoreSSL;
 		if (!url) throw new BadRequestError('Error fetching SAML Metadata, no Metadata URL set');
 		try {
-			// Create a proxy-aware HTTPS agent that respects HTTP_PROXY, HTTPS_PROXY, and NO_PROXY
-			// environment variables while also supporting SSL certificate validation options
-			const httpsAgent = createHttpsProxyAgent(
-				null, // Uses proxy from environment variables
-				url,
-				{
-					rejectUnauthorized: !shouldIgnoreSSL,
-				},
-			);
-			const httpAgent = createHttpProxyAgent(null, url);
-
-			const response = await axios.get(url, {
-				httpsAgent,
-				httpAgent,
-			});
-			if (response.status === 200 && response.data) {
-				const xml = (await response.data) as string;
+			const response = await this.outboundHttp
+				.requests({
+					ssrf: 'disabled', // The metadata URL is admin-configured and may point at an internal IdP, so SSRF protection is disabled.
+				})
+				.request({
+					url,
+					method: 'GET',
+					skipSslCertificateValidation: shouldIgnoreSSL,
+					returnFullResponse: true,
+				});
+			if (response.statusCode === 200 && response.body) {
+				const xml = response.body as string;
 				const validationResult = await this.validator.validateMetadata(xml);
 				if (!validationResult) {
 					throw new BadRequestError(`Data received from ${url} is not valid SAML metadata.`);

--- a/packages/cli/test/integration/saml/saml.api.test.ts
+++ b/packages/cli/test/integration/saml/saml.api.test.ts
@@ -4,6 +4,7 @@
 jest.unmock('node:fs');
 
 import type { SamlPreferences } from '@n8n/api-types';
+import { type LocalServer, startServer } from '@n8n/backend-network/testing';
 import {
 	createTeamProject,
 	getProjectRoleForUser,
@@ -24,6 +25,9 @@ import { Container } from '@n8n/di';
 import type express from 'express';
 import { CREDENTIAL_BLANKING_VALUE } from 'n8n-workflow';
 
+import { TEMPLATES_DIR } from '@/constants';
+import { BadRequestError } from '@/errors/response-errors/bad-request.error';
+import { ProvisioningService } from '@/modules/provisioning.ee/provisioning.service.ee';
 import {
 	EC_TEST_CERTIFICATE,
 	EC_TEST_PRIVATE_KEY,
@@ -31,10 +35,6 @@ import {
 	RSA_TEST_CERTIFICATE,
 	RSA_TEST_PRIVATE_KEY,
 } from '@/modules/sso-saml/__tests__/saml-signing-test-fixtures';
-
-import { TEMPLATES_DIR } from '@/constants';
-import { BadRequestError } from '@/errors/response-errors/bad-request.error';
-import { ProvisioningService } from '@/modules/provisioning.ee/provisioning.service.ee';
 import { setSamlLoginEnabled } from '@/modules/sso-saml/saml-helpers';
 import { SamlService } from '@/modules/sso-saml/saml.service.ee';
 import {
@@ -43,7 +43,7 @@ import {
 } from '@/sso.ee/sso-helpers';
 import { createHandlebarsEngine } from '@/utils/handlebars.util';
 
-import { sampleConfig } from './sample-metadata';
+import { sampleConfig, sampleMetadata } from './sample-metadata';
 import { createOwner, createUser } from '../shared/db/users';
 import type { SuperAgentTest } from '../shared/types';
 import * as utils from '../shared/utils/';
@@ -456,6 +456,68 @@ describe('POST /sso/saml/config/test round-trip', () => {
 		// the token is single-use.
 		const consumed = await Container.get(SamlService).consumePendingTestConfig(testId);
 		expect(consumed).toBeUndefined();
+	});
+});
+
+// A real loopback HTTP server stands in for the IdP's metadata endpoint
+describe('SAML metadata URL fetch (real HTTP round-trip)', () => {
+	let metadataServer: LocalServer;
+	let metadataServerUrl: string;
+	let statusToServe: number;
+	let bodyToServe: string;
+
+	beforeAll(async () => {
+		metadataServer = await startServer((_req, res) => {
+			res.writeHead(statusToServe, { 'content-type': 'application/xml' });
+			res.end(bodyToServe);
+		});
+		metadataServerUrl = `${metadataServer.url}/idp/metadata`;
+	});
+
+	afterAll(async () => await metadataServer.close());
+
+	beforeEach(async () => {
+		metadataServer.clear();
+		statusToServe = 200;
+		bodyToServe = sampleMetadata;
+		await enableSaml(false);
+		await Container.get(SamlService).reset();
+	});
+
+	test('fetchMetadataFromUrl returns the XML served over a real socket', async () => {
+		const samlService = Container.get(SamlService);
+
+		const xml = await samlService.fetchMetadataFromUrl(metadataServerUrl);
+
+		expect(metadataServer.captured).toEqual(['/idp/metadata']);
+		expect(xml).toBe(sampleMetadata);
+	});
+
+	test('POST /sso/saml/config with metadataUrl fetches and persists the metadata', async () => {
+		await authOwnerAgent
+			.post('/sso/saml/config')
+			.send({
+				...sampleConfig,
+				metadata: '',
+				metadataUrl: metadataServerUrl,
+				loginEnabled: true,
+			})
+			.expect(200);
+
+		expect(metadataServer.captured.length).toBeGreaterThanOrEqual(1);
+
+		const samlService = Container.get(SamlService);
+		expect(samlService.samlPreferences.metadataUrl).toBe(metadataServerUrl);
+		expect(samlService.samlPreferences.metadata).toBe(sampleMetadata);
+	});
+
+	test('fetchMetadataFromUrl throws when the endpoint serves invalid metadata', async () => {
+		bodyToServe = 'this is not SAML metadata';
+
+		await expect(
+			Container.get(SamlService).fetchMetadataFromUrl(metadataServerUrl),
+		).rejects.toThrowError(BadRequestError);
+		expect(metadataServer.captured).toEqual(['/idp/metadata']);
 	});
 });
 


### PR DESCRIPTION
## Summary

Migrates the SAML IdP metadata fetch in `SamlService` to the `OutboundHttp` factory from `@n8n/backend-network`, replacing the direct `axios` call wired with manually-constructed proxy agents.

This is a behavior-preserving refactor. No functional change.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/CAT-3370

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] Tests included.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32381">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->