### PR TITLE
chore: Add pnpm sync:skill-links alias (no-changelog)

### DIFF
--- a/.agents/skills/AGENTS.md
+++ b/.agents/skills/AGENTS.md
@@ -34,7 +34,6 @@ actionable error. (OpenCode reads `.agents/skills` directly and is unaffected.)
   tool availability checks.
 - Put harness-specific workflows, such as MCP setup commands, in real
   directories under the matching harness path.
-- Run `node scripts/sync-agent-skill-links.mjs` after adding or removing shared
-  skills to update Claude plugin symlinks.
-- Run `node scripts/sync-agent-skill-links.mjs --check` before submitting
-  changes.
+- Run `pnpm sync:skill-links` after adding or removing shared skills to update
+  Claude plugin symlinks.
+- Run `pnpm check:skill-links` before submitting changes.

--- a/.agents/skills/create-skill/SKILL.md
+++ b/.agents/skills/create-skill/SKILL.md
@@ -22,7 +22,7 @@ Skills are markdown (plus optional scripts) that teach the agent a focused workf
 
 **Do not** put custom skills in `~/.cursor/skills-cursor/`—that is reserved for Cursor’s built-in skills.
 
-Prefer **`.agents/skills/`** for anything that should match how the rest of the team works. Run `node scripts/sync-agent-skill-links.mjs` after adding or removing shared skills.
+Prefer **`.agents/skills/`** for anything that should match how the rest of the team works. Run `pnpm sync:skill-links` after adding or removing shared skills.
 
 ## Before you write: gather requirements
 

--- a/.claude/plugins/n8n/README.md
+++ b/.claude/plugins/n8n/README.md
@@ -43,9 +43,8 @@ skills or overrides remain real directories in this plugin path.
 └── README.md
 ```
 
-Run `node scripts/sync-agent-skill-links.mjs` after adding or removing shared
-skills. Run `node scripts/sync-agent-skill-links.mjs --check` before submitting
-changes.
+Run `pnpm sync:skill-links` after adding or removing shared skills. Run
+`pnpm check:skill-links` before submitting changes.
 
 ## Design Decisions
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lint:affected": "turbo run lint --affected",
     "lint:fix": "turbo run lint:fix",
     "lint:ci": "turbo run lint lint:styles",
+    "sync:skill-links": "node scripts/sync-agent-skill-links.mjs",
     "check:skill-links": "node scripts/sync-agent-skill-links.mjs --check",
     "optimize-svg": "find ./packages -name '*.svg' ! -name 'pipedrive.svg' -print0 | xargs -0 -P16 -L20 npx svgo",
     "setup-backend-module": "node scripts/ensure-zx.mjs && zx scripts/backend-module/setup.mjs",


### PR DESCRIPTION
## Summary

Small follow-up to #30541 (Unify agent skill sources).

The skill-link sync script only had a pnpm alias for the verify variant (`pnpm check:skill-links`); the sync/fix action could only be run as `node scripts/sync-agent-skill-links.mjs`. This adds a matching `pnpm sync:skill-links` alias and updates the skill docs (`.agents/skills/AGENTS.md`, the plugin README, and the `create-skill` guide) to reference the pnpm commands consistently.

No behavior change — purely a convenience alias + doc wording.

## How to test

```bash
pnpm sync:skill-links   # creates/repairs the Claude plugin symlinks
pnpm check:skill-links  # verify-only (already wired into pre-commit)
```

Both should report the skill links are valid on a clean checkout.

## Related

Follow-up to #30541.

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32382">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->