### PR TITLE
fix(core): Validate credential type when binding credentials on package import (no-changelog)

### DIFF
--- a/packages/cli/src/modules/n8n-packages/__tests__/import-pipeline.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/import-pipeline.integration.test.ts
@@ -4,6 +4,7 @@ import {
 	createTeamProject,
 	createWorkflow,
 	mockInstance,
+	randomCredentialPayload,
 	testDb,
 	testModules,
 } from '@n8n/backend-test-utils';
@@ -1198,6 +1199,53 @@ describe('ImportPipeline credential resolution', () => {
 		expect(workflow.nodes[0].credentials?.[PACKAGE_GITHUB_CREDENTIAL_TYPE]?.id).toBe(
 			targetCredential.id,
 		);
+	});
+
+	it('blocks an explicit credential binding whose target type differs from the requirement', async () => {
+		const owner = await createOwner();
+		const personalProject = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(
+			owner.id,
+		);
+		// The bound target is a real, accessible credential — but a different type
+		// than the workflow node's githubApi slot requires.
+		const mismatchedCredential = await saveOwnedCredential(
+			randomCredentialPayload({ type: 'slackApi' }),
+			{ project: personalProject },
+		);
+
+		await expect(
+			importPackage({
+				user: owner,
+				credentialBindings: new Map([['source-credential', mismatchedCredential.id]]),
+				packageBuffer: await buildImportPackageBuffer(
+					[
+						serializedWorkflowWithCredential({
+							id: 'wf-wrong-type-binding',
+							name: 'Wrong type binding',
+							credentialId: 'source-credential',
+							credentialName: 'Source GitHub',
+						}),
+					],
+					{ sourceId },
+				),
+			}),
+		).rejects.toMatchObject({
+			meta: {
+				issues: expect.arrayContaining([
+					expect.objectContaining({
+						type: 'credential-unresolved',
+						kind: 'type_mismatch',
+						sourceId: 'source-credential',
+						targetId: mismatchedCredential.id,
+						expectedType: PACKAGE_GITHUB_CREDENTIAL_TYPE,
+						actualType: 'slackApi',
+					}),
+				]),
+			},
+		});
+
+		// The import is gated before anything is written.
+		expect(await Container.get(WorkflowRepository).count()).toBe(0);
 	});
 
 	it('reports mixed unknown_type and not_found failures in one response', async () => {

--- a/packages/cli/src/modules/n8n-packages/engine/import-pipeline.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/import-pipeline.ts
@@ -140,11 +140,13 @@ export class ImportPipeline {
 
 		const credentialFailures: BlockingIssue[] = this.credentialImporter
 			.blockingFailures(credentialResolution, credentialRequest)
-			.map(({ kind, sourceId, targetId, usedByWorkflows }) => ({
+			.map(({ kind, sourceId, targetId, expectedType, actualType, usedByWorkflows }) => ({
 				type: 'credential-unresolved',
 				kind,
 				sourceId,
 				...(targetId ? { targetId } : {}),
+				...(expectedType ? { expectedType } : {}),
+				...(actualType ? { actualType } : {}),
 				usedByWorkflows,
 			}));
 

--- a/packages/cli/src/modules/n8n-packages/entities/credential/__tests__/credential-importer.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/credential/__tests__/credential-importer.test.ts
@@ -15,7 +15,8 @@ type UsableCredential = Awaited<
 	ReturnType<CredentialsService['getCredentialsAUserCanUseInAWorkflow']>
 >[number];
 
-const usable = (id: string): UsableCredential => ({ id }) as UsableCredential;
+const usable = (id: string, type = 'githubApi'): UsableCredential =>
+	({ id, type }) as UsableCredential;
 
 describe('CredentialImporter', () => {
 	const credentialsFinderService = mock<CredentialsFinderService>();

--- a/packages/cli/src/modules/n8n-packages/entities/credential/__tests__/credential-matcher.test.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/credential/__tests__/credential-matcher.test.ts
@@ -16,7 +16,8 @@ type UsableCredential = Awaited<
 	ReturnType<CredentialsService['getCredentialsAUserCanUseInAWorkflow']>
 >[number];
 
-const usable = (id: string): UsableCredential => ({ id }) as UsableCredential;
+const usable = (id: string, type = 'githubApi'): UsableCredential =>
+	({ id, type }) as UsableCredential;
 
 const credentialsFinderService = mock<CredentialsFinderService>();
 const sharedCredentialsRepository = mock<SharedCredentialsRepository>();
@@ -127,7 +128,7 @@ describe('IdBasedCredentialMatcher', () => {
 
 	it('resolves global credentials usable in the target project', async () => {
 		credentialsService.getCredentialsAUserCanUseInAWorkflow.mockResolvedValue([
-			usable('cred-global'),
+			usable('cred-global', 'httpBasicAuth'),
 		]);
 
 		const result = await matcherFactory.getMatcher('id-only').match(
@@ -227,6 +228,34 @@ describe('IdBasedCredentialMatcher', () => {
 		expect(result.successes).toEqual(new Map());
 		expect(result.failures).toEqual([
 			{ ...createFailure(requirement, 'not_found'), targetId: 'target-missing' },
+		]);
+	});
+
+	it('should report a type mismatch when an explicit binding targets a credential of a different type', async () => {
+		credentialsService.getCredentialsAUserCanUseInAWorkflow.mockResolvedValue([
+			usable('target-cred', 'slackApi'),
+		]);
+
+		const requirement = {
+			id: 'source-cred',
+			name: 'Source GitHub',
+			type: 'githubApi',
+			usedByWorkflows: ['wf-1'],
+		};
+
+		const result = await matcherFactory.getMatcher('id-only').match([requirement], {
+			...context,
+			credentialBindings: new Map([['source-cred', 'target-cred']]),
+		});
+
+		expect(result.successes).toEqual(new Map());
+		expect(result.failures).toEqual([
+			{
+				...createFailure(requirement, 'type_mismatch'),
+				targetId: 'target-cred',
+				expectedType: 'githubApi',
+				actualType: 'slackApi',
+			},
 		]);
 	});
 });

--- a/packages/cli/src/modules/n8n-packages/entities/credential/credential-matcher.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/credential/credential-matcher.ts
@@ -17,6 +17,19 @@ export interface CredentialMatcherContext {
 	credentialBindings?: ImportBindingMap;
 }
 
+/**
+ * A target-project credential a matcher located for a package reference, before
+ * type compatibility is enforced. {@link CredentialMatcher.match} compares
+ * `targetType` against the reference's required type and only then accepts the
+ * binding — a credential whose id is reachable but whose type differs cannot
+ * satisfy the node's credential slot (n8n resolves node credentials by exact
+ * `{ id, type }`), so binding it would silently produce an empty credential.
+ */
+export interface ResolvedCredentialMatch {
+	targetId: string;
+	targetType: string;
+}
+
 export abstract class CredentialMatcher {
 	constructor(
 		protected readonly credentialsFinderService: CredentialsFinderService,
@@ -31,24 +44,45 @@ export abstract class CredentialMatcher {
 		const orphanFailures = orphanBindingFailures(context.credentialBindings, requirements);
 		const { known, unknownTypeFailures } = partitionByKnownType(requirements, this.credentialTypes);
 
-		const successes = await this.resolve(known, context);
+		const located = await this.resolve(known, context);
 
-		const notFoundFailures = known
-			.filter((reference) => !successes.has(reference.id))
-			.map((reference) =>
-				createNotFoundFailure(reference, context.credentialBindings?.get(reference.id)),
-			);
+		const successes: ImportBindingMap = new Map();
+		const notFoundFailures: CredentialResolutionFailure[] = [];
+		const typeMismatchFailures: CredentialResolutionFailure[] = [];
+
+		for (const reference of known) {
+			const match = located.get(reference.id);
+			if (match === undefined) {
+				notFoundFailures.push(
+					createNotFoundFailure(reference, context.credentialBindings?.get(reference.id)),
+				);
+			} else if (match.targetType !== reference.type) {
+				typeMismatchFailures.push(createTypeMismatchFailure(reference, match));
+			} else {
+				successes.set(reference.id, match.targetId);
+			}
+		}
 
 		return {
 			successes,
-			failures: [...orphanFailures, ...unknownTypeFailures, ...notFoundFailures],
+			failures: [
+				...orphanFailures,
+				...unknownTypeFailures,
+				...notFoundFailures,
+				...typeMismatchFailures,
+			],
 		};
 	}
 
+	/**
+	 * Locates the target-project credential each known reference points at, keyed by
+	 * the reference's source id. Returns only references that resolve to a reachable,
+	 * usable credential; type compatibility is enforced by {@link match}, not here.
+	 */
 	protected abstract resolve(
 		known: PackageCredentialRequirement[],
 		context: CredentialMatcherContext,
-	): Promise<ImportBindingMap>;
+	): Promise<Map<string, ResolvedCredentialMatch>>;
 }
 
 function partitionByKnownType(
@@ -82,6 +116,23 @@ function createNotFoundFailure(
 ): CredentialResolutionFailure {
 	const failure = createFailure(reference, 'not_found');
 	return requestedTargetId === undefined ? failure : { ...failure, targetId: requestedTargetId };
+}
+
+/**
+ * The resolved credential exists and is usable but its type does not match what
+ * the package's workflow node requires. Carries both types so the caller can
+ * report which binding is wrong rather than reporting a misleading "not found".
+ */
+function createTypeMismatchFailure(
+	reference: PackageCredentialRequirement,
+	match: ResolvedCredentialMatch,
+): CredentialResolutionFailure {
+	return {
+		...createFailure(reference, 'type_mismatch'),
+		targetId: match.targetId,
+		expectedType: reference.type,
+		actualType: match.targetType,
+	};
 }
 
 /**

--- a/packages/cli/src/modules/n8n-packages/entities/credential/credential.types.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/credential/credential.types.ts
@@ -14,12 +14,20 @@ export interface WorkflowCredentialRequirement {
 	credentialType: string;
 }
 
-export type CredentialResolutionFailureKind = 'not_found' | 'unknown_type' | 'source_not_found';
+export type CredentialResolutionFailureKind =
+	| 'not_found'
+	| 'unknown_type'
+	| 'source_not_found'
+	| 'type_mismatch';
 
 export type CredentialResolutionFailure = {
 	kind: CredentialResolutionFailureKind;
 	sourceId: string;
 	targetId?: string;
+	/** For `type_mismatch`: the credential type the package's workflow node requires. */
+	expectedType?: string;
+	/** For `type_mismatch`: the actual type of the resolved target credential. */
+	actualType?: string;
 	usedByWorkflows: string[];
 };
 

--- a/packages/cli/src/modules/n8n-packages/entities/credential/id-based-credential-matcher.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/credential/id-based-credential-matcher.ts
@@ -6,8 +6,11 @@ import { CredentialTypes } from '@/credential-types';
 import { CredentialsFinderService } from '@/credentials/credentials-finder.service';
 import { CredentialsService } from '@/credentials/credentials.service';
 
-import { CredentialMatcher, type CredentialMatcherContext } from './credential-matcher';
-import type { ImportBindingMap } from '../../n8n-packages.types';
+import {
+	CredentialMatcher,
+	type CredentialMatcherContext,
+	type ResolvedCredentialMatch,
+} from './credential-matcher';
 import type { PackageCredentialRequirement } from '../../spec/requirements.schema';
 
 @Service()
@@ -24,11 +27,13 @@ export class IdBasedCredentialMatcher extends CredentialMatcher {
 	protected async resolve(
 		known: PackageCredentialRequirement[],
 		context: CredentialMatcherContext,
-	): Promise<ImportBindingMap> {
+	): Promise<Map<string, ResolvedCredentialMatch>> {
+		if (known.length === 0) {
+			return new Map();
+		}
+
 		const bindings = context.credentialBindings;
-		const targetIds = known.map((reference) => bindings?.get(reference.id) ?? reference.id);
-		const resolvableIds = await this.findResolvableCredentialIds(
-			targetIds,
+		const usableTypesById = await this.findUsableCredentialTypesById(
 			context.targetProject,
 			context.user,
 		);
@@ -36,29 +41,23 @@ export class IdBasedCredentialMatcher extends CredentialMatcher {
 		return new Map(
 			known.flatMap((reference) => {
 				const targetId = bindings?.get(reference.id) ?? reference.id;
-				if (!resolvableIds.has(targetId)) return [];
-				return [[reference.id, targetId] as const];
+				const targetType = usableTypesById.get(targetId);
+				if (targetType === undefined) return [];
+				return [[reference.id, { targetId, targetType }] as const];
 			}),
 		);
 	}
 
-	private async findResolvableCredentialIds(
-		candidateIds: string[],
+	/** Maps each credential the user can use in the target project to its type. */
+	private async findUsableCredentialTypesById(
 		targetProject: Project,
 		user: User,
-	): Promise<Set<string>> {
-		const uniqueIds = new Set(candidateIds);
-		if (uniqueIds.size === 0) {
-			return new Set();
-		}
-
+	): Promise<Map<string, string>> {
 		const usableCredentials = await this.credentialsService.getCredentialsAUserCanUseInAWorkflow(
 			user,
 			{ projectId: targetProject.id },
 		);
 
-		return new Set(
-			usableCredentials.map((credential) => credential.id).filter((id) => uniqueIds.has(id)),
-		);
+		return new Map(usableCredentials.map((credential) => [credential.id, credential.type]));
 	}
 }

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
@@ -88,9 +88,13 @@ export type BlockingIssue =
 	  }
 	| {
 			type: 'credential-unresolved';
-			kind: 'not_found' | 'unknown_type' | 'source_not_found';
+			kind: 'not_found' | 'unknown_type' | 'source_not_found' | 'type_mismatch';
 			sourceId: string;
 			targetId?: string;
+			/** For `type_mismatch`: the credential type the package's workflow node requires. */
+			expectedType?: string;
+			/** For `type_mismatch`: the actual type of the resolved target credential. */
+			actualType?: string;
 			usedByWorkflows: string[];
 	  };
 

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/schemas/importBlockingIssue.yml
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/schemas/importBlockingIssue.yml
@@ -71,11 +71,21 @@ oneOf:
           - not_found
           - unknown_type
           - source_not_found
+          - type_mismatch
       sourceId:
         type: string
       targetId:
         type: string
         description: Target credential id for an explicit credential binding.
+      expectedType:
+        type: string
+        description: >
+          For `type_mismatch`: the credential type the package's workflow node
+          requires.
+      actualType:
+        type: string
+        description: >
+          For `type_mismatch`: the actual type of the resolved target credential.
       usedByWorkflows:
         type: array
         items:


### PR DESCRIPTION
## Summary

Explicit credential bindings on package import were validated only for **accessibility** (does the target credential exist and is it usable?), never for **type**. Binding a workflow node's credential slot to a target credential of a different type — e.g. a Slack credential where the node requires GitHub — resolved successfully: the import succeeded (and the workflow could even be published), but the node's credential id was rewritten while its type slot was left unchanged. n8n resolves a node credential by exact `{ id, type }`, so the node then referenced a credential that does not exist under that type, and the credential rendered **empty**.

This PR enforces credential type compatibility during resolution, surfaced as a blocking `type_mismatch` issue (consistent with how `not_found` / `unknown_type` already block under the `must-preexist` policy):

- The type-match policy is centralized in `CredentialMatcher.match`: `resolve()` now only *locates* candidate credentials (with their type), and `match()` classifies each reference as **success** (type matches), **type_mismatch** (type differs), or **not_found** (no usable credential). Future matchers inherit the rule automatically.
- `type_mismatch` carries `expectedType` / `actualType` so the error states exactly which binding is wrong, rather than a misleading "not found".
- Threaded the new kind + fields through `BlockingIssue`, the import pipeline, and the public-API OpenAPI schema.

Applies to both explicit bindings and the default id-only path (defense in depth; it cannot regress the same-instance round-trip, where id → type is unchanged).

## How to test

Covered by automated tests in `packages/cli`:

- `entities/credential/__tests__/credential-matcher.test.ts` — type mismatch via an explicit binding and via an id-only match.
- `entities/credential/__tests__/credential-importer.test.ts` — `must-preexist` treats a wrong-type binding as blocking.
- `__tests__/import-pipeline.integration.test.ts` — end-to-end: a wrong-type binding is rejected with a `type_mismatch` blocking issue and **nothing is written**.

Manual reproduction of the original bug:
1. Export a workflow that uses a credential of type A (e.g. GitHub/Google).
2. Import the package with an explicit credential binding pointing the source credential at a target credential of a **different** type (e.g. Slack).
3. **Before:** the import succeeds, the workflow is created/published, but the node's credential renders empty.
   **After:** the import is rejected (HTTP 422) with a `credential-unresolved` / `type_mismatch` issue listing `expectedType` and `actualType`.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/LIGO-727

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [ ] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32383">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->