### PR TITLE
feat(editor): Add N8nRadioGroup and use it for the API key scope picker

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nRadioGroup/RadioGroup.stories.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nRadioGroup/RadioGroup.stories.ts
@@ -1,0 +1,72 @@
+import type { StoryFn } from '@storybook/vue3-vite';
+import { action } from 'storybook/actions';
+
+import N8nRadioGroup from './RadioGroup.vue';
+
+export default {
+	title: 'Modules/RadioGroup',
+	component: N8nRadioGroup,
+	argTypes: {
+		orientation: {
+			control: 'select',
+			options: ['vertical', 'horizontal'],
+		},
+		disabled: {
+			control: 'boolean',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'An accessible vertical (or horizontal) single-choice radio list built on reka-ui. Each option supports an optional description.',
+			},
+		},
+	},
+};
+
+const methods = {
+	onUpdate: action('update:modelValue'),
+};
+
+const Template: StoryFn = (args, { argTypes }) => ({
+	setup: () => ({ args }),
+	props: Object.keys(argTypes),
+	components: { N8nRadioGroup },
+	template: `<n8n-radio-group v-model="val" v-bind="args" @update:modelValue="onUpdate">
+		</n8n-radio-group>`,
+	methods,
+	data() {
+		return {
+			val: 'all',
+		};
+	},
+});
+
+export const Default = Template.bind({});
+Default.args = {
+	options: [
+		{ value: 'all', label: 'All' },
+		{ value: 'readOnly', label: 'Read only' },
+		{ value: 'custom', label: 'Custom' },
+	],
+};
+
+export const WithDescriptions = Template.bind({});
+WithDescriptions.args = {
+	options: [
+		{ value: 'all', label: 'All', description: 'Grant every available scope' },
+		{ value: 'readOnly', label: 'Read only', description: 'Read and list scopes only' },
+		{ value: 'custom', label: 'Custom', description: 'Pick scopes individually' },
+	],
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+	disabled: true,
+	options: [
+		{ value: 'all', label: 'All' },
+		{ value: 'readOnly', label: 'Read only' },
+		{ value: 'custom', label: 'Custom' },
+	],
+};

--- a/packages/frontend/@n8n/design-system/src/components/N8nRadioGroup/RadioGroup.test.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nRadioGroup/RadioGroup.test.ts
@@ -1,0 +1,80 @@
+import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/vue';
+
+import N8nRadioGroup from './RadioGroup.vue';
+
+const options = [
+	{ value: 'all', label: 'All' },
+	{ value: 'readOnly', label: 'Read only' },
+	{ value: 'custom', label: 'Custom' },
+];
+
+describe('N8nRadioGroup', () => {
+	it('renders one accessible radio per option', () => {
+		const { getAllByRole } = render(N8nRadioGroup, { props: { modelValue: 'all', options } });
+
+		expect(getAllByRole('radio')).toHaveLength(3);
+	});
+
+	it('renders option descriptions when provided', () => {
+		const { getByText } = render(N8nRadioGroup, {
+			props: {
+				modelValue: 'custom',
+				options: [{ value: 'custom', label: 'Custom', description: 'Pick scopes individually' }],
+			},
+		});
+
+		expect(getByText('Pick scopes individually')).toBeInTheDocument();
+	});
+
+	it('marks the option matching modelValue as checked', () => {
+		const { getByRole } = render(N8nRadioGroup, { props: { modelValue: 'readOnly', options } });
+
+		expect(getByRole('radio', { name: 'Read only' })).toBeChecked();
+		expect(getByRole('radio', { name: 'All' })).not.toBeChecked();
+	});
+
+	it('emits update:modelValue with the selected value', async () => {
+		const { getByRole, emitted } = render(N8nRadioGroup, { props: { modelValue: 'all', options } });
+
+		await userEvent.click(getByRole('radio', { name: 'Custom' }));
+
+		expect(emitted('update:modelValue')?.at(-1)).toEqual(['custom']);
+	});
+
+	it('does not emit for a disabled option', async () => {
+		const { getByRole, emitted } = render(N8nRadioGroup, {
+			props: {
+				modelValue: 'all',
+				options: [
+					{ value: 'all', label: 'All' },
+					{ value: 'custom', label: 'Custom', disabled: true },
+				],
+			},
+		});
+
+		await userEvent.click(getByRole('radio', { name: 'Custom' }));
+
+		expect(emitted('update:modelValue')).toBeUndefined();
+	});
+
+	it('disables every option when the group is disabled', async () => {
+		const { getByRole, emitted } = render(N8nRadioGroup, {
+			props: { modelValue: 'all', options, disabled: true },
+		});
+
+		expect(getByRole('radio', { name: 'Custom' })).toBeDisabled();
+
+		await userEvent.click(getByRole('radio', { name: 'Custom' }));
+
+		expect(emitted('update:modelValue')).toBeUndefined();
+	});
+
+	it('forwards testId to the radio item element', () => {
+		const { getByTestId } = render(N8nRadioGroup, {
+			props: { modelValue: 'all', options: [{ value: 'all', label: 'All', testId: 'mode-all' }] },
+		});
+
+		expect(getByTestId('mode-all')).toHaveAttribute('role', 'radio');
+	});
+});

--- a/packages/frontend/@n8n/design-system/src/components/N8nRadioGroup/RadioGroup.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nRadioGroup/RadioGroup.vue
@@ -85,7 +85,7 @@ function onValueChange(value: string) {
 
 .root {
 	display: flex;
-	gap: var(--spacing--2xs);
+	gap: var(--spacing--4xs);
 }
 
 .vertical {

--- a/packages/frontend/@n8n/design-system/src/components/N8nRadioGroup/RadioGroup.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nRadioGroup/RadioGroup.vue
@@ -1,0 +1,171 @@
+<script lang="ts">
+export interface RadioGroupOption<Value extends string = string> {
+	value: Value;
+	label: string;
+	/** Optional helper text rendered under the label. */
+	description?: string;
+	disabled?: boolean;
+	/** Forwarded to the radio item element as `data-test-id`. */
+	testId?: string;
+}
+</script>
+
+<script lang="ts" setup generic="Value extends string">
+import { RadioGroupIndicator, RadioGroupItem, RadioGroupRoot } from 'reka-ui';
+
+const props = withDefaults(
+	defineProps<{
+		modelValue?: Value;
+		options: Array<RadioGroupOption<Value>>;
+		/** @default vertical */
+		orientation?: 'vertical' | 'horizontal';
+		disabled?: boolean;
+		name?: string;
+		/** Accessible name for the radio group. */
+		ariaLabel?: string;
+	}>(),
+	{
+		orientation: 'vertical',
+		disabled: false,
+	},
+);
+
+const emit = defineEmits<{
+	'update:modelValue': [value: Value];
+}>();
+
+defineSlots<{
+	/** Override the rendered content of a single option (label + description by default). */
+	option?: (props: RadioGroupOption<Value>) => unknown;
+}>();
+
+function onValueChange(value: string) {
+	const option = props.options.find((o) => o.value === value);
+	if (option && !option.disabled) {
+		emit('update:modelValue', option.value);
+	}
+}
+</script>
+
+<template>
+	<RadioGroupRoot
+		:model-value="modelValue"
+		:disabled="disabled"
+		:orientation="orientation"
+		:name="name"
+		:aria-label="ariaLabel"
+		:class="[$style.root, $style[orientation]]"
+		@update:model-value="onValueChange"
+	>
+		<RadioGroupItem
+			v-for="option in options"
+			:key="option.value"
+			:value="option.value"
+			:disabled="disabled || option.disabled"
+			:class="$style.item"
+			:data-test-id="option.testId"
+		>
+			<span :class="$style.circle">
+				<RadioGroupIndicator :class="$style.dot" />
+			</span>
+			<span :class="$style.content">
+				<slot name="option" v-bind="option">
+					<span :class="$style.label">{{ option.label }}</span>
+					<span v-if="option.description" :class="$style.description">{{
+						option.description
+					}}</span>
+				</slot>
+			</span>
+		</RadioGroupItem>
+	</RadioGroupRoot>
+</template>
+
+<style lang="scss" module>
+@use '../../css/mixins/focus';
+
+.root {
+	display: flex;
+	gap: var(--spacing--2xs);
+}
+
+.vertical {
+	flex-direction: column;
+	align-items: flex-start;
+}
+
+.horizontal {
+	flex-direction: row;
+	align-items: center;
+}
+
+.item {
+	display: flex;
+	align-items: flex-start;
+	gap: var(--spacing--2xs);
+	width: 100%;
+	margin: 0;
+	padding: var(--spacing--4xs) 0;
+	background: transparent;
+	border: none;
+	text-align: left;
+	color: var(--color--text);
+	font: inherit;
+	line-height: 1.3;
+	cursor: pointer;
+	border-radius: var(--radius--sm);
+
+	&:focus-visible {
+		@include focus.focus-ring;
+		outline-offset: 2px;
+	}
+
+	&[data-disabled] {
+		cursor: not-allowed;
+		opacity: 0.5;
+	}
+}
+
+.circle {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 16px;
+	height: 16px;
+	margin-top: 1px;
+	border: 1px solid var(--color--foreground--shade-1);
+	border-radius: var(--radius--full);
+	transition: border-color 0.15s ease;
+
+	.item:hover:not([data-disabled]) & {
+		border-color: var(--color--primary);
+	}
+
+	.item[data-state='checked'] & {
+		border-color: var(--color--primary);
+	}
+}
+
+.dot {
+	width: 8px;
+	height: 8px;
+	border-radius: var(--radius--full);
+	background-color: var(--color--primary);
+}
+
+.content {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacing--5xs);
+}
+
+.label {
+	font-size: var(--font-size--sm);
+	color: var(--color--text);
+}
+
+.description {
+	font-size: var(--font-size--2xs);
+	color: var(--color--text--tint-1);
+}
+</style>

--- a/packages/frontend/@n8n/design-system/src/components/N8nRadioGroup/index.ts
+++ b/packages/frontend/@n8n/design-system/src/components/N8nRadioGroup/index.ts
@@ -1,0 +1,4 @@
+import N8nRadioGroup from './RadioGroup.vue';
+
+export default N8nRadioGroup;
+export type { RadioGroupOption } from './RadioGroup.vue';

--- a/packages/frontend/@n8n/design-system/src/components/index.ts
+++ b/packages/frontend/@n8n/design-system/src/components/index.ts
@@ -83,6 +83,8 @@ export {
 export { default as N8nPulse } from './N8nPulse';
 export { default as N8nSendStopButton } from './N8nSendStopButton';
 export { default as N8nRadioButtons } from './N8nRadioButtons';
+export { default as N8nRadioGroup } from './N8nRadioGroup';
+export type { RadioGroupOption } from './N8nRadioGroup';
 export { default as N8nRoute } from './N8nRoute';
 export { default as N8nRecycleScroller } from './N8nRecycleScroller';
 export { default as N8nResizeWrapper } from './N8nResizeWrapper';

--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyCreateOrEditModal.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyCreateOrEditModal.test.ts
@@ -239,9 +239,7 @@ describe('ApiKeyCreateOrEditModal', () => {
 		expect(saveButton).toBeInTheDocument();
 
 		// All available scopes should be pre-selected for new keys
-		await retry(() =>
-			expect(getByTestId('scopes-mode-all').querySelector('input[type="radio"]')).toBeChecked(),
-		);
+		await retry(() => expect(getByTestId('scopes-mode-all')).toBeChecked());
 
 		await userEvent.type(inputLabel, 'new label');
 

--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyScopes.test.ts
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyScopes.test.ts
@@ -22,16 +22,13 @@ const readOnlyScopes: ApiKeyScope[] = [
 
 const renderComponent = createComponentRenderer(ApiKeyScopes);
 
-const getRadioInput = (element: HTMLElement) =>
-	element.querySelector<HTMLInputElement>('input[type="radio"]') as HTMLInputElement;
-
 describe('ApiKeyScopes', () => {
 	it('selects "All" when every scope is selected and collapses the scope tree by default', () => {
 		const { getByTestId, queryByTestId } = renderComponent({
 			props: { modelValue: availableScopes, availableScopes },
 		});
 
-		expect(getRadioInput(getByTestId('scopes-mode-all'))).toBeChecked();
+		expect(getByTestId('scopes-mode-all')).toBeChecked();
 		expect(getByTestId('scopes-count')).toBeInTheDocument();
 		expect(queryByTestId('scopes-search')).not.toBeInTheDocument();
 		expect(queryByTestId('scope-group-workflowsAndExecutions')).not.toBeInTheDocument();
@@ -42,7 +39,7 @@ describe('ApiKeyScopes', () => {
 			props: { modelValue: readOnlyScopes, availableScopes },
 		});
 
-		expect(getRadioInput(getByTestId('scopes-mode-read-only'))).toBeChecked();
+		expect(getByTestId('scopes-mode-read-only')).toBeChecked();
 	});
 
 	it('selects "Custom" and shows the scope tree for partial selections', () => {
@@ -50,7 +47,7 @@ describe('ApiKeyScopes', () => {
 			props: { modelValue: ['workflow:read'], availableScopes },
 		});
 
-		expect(getRadioInput(getByTestId('scopes-mode-custom'))).toBeChecked();
+		expect(getByTestId('scopes-mode-custom')).toBeChecked();
 		expect(getByTestId('scopes-search')).toBeInTheDocument();
 		expect(getByTestId('scope-group-workflowsAndExecutions')).toBeInTheDocument();
 		expect(getByTestId('scope-group-members')).toBeInTheDocument();
@@ -61,7 +58,7 @@ describe('ApiKeyScopes', () => {
 			props: { modelValue: ['workflow:read'], availableScopes },
 		});
 
-		await userEvent.click(getRadioInput(getByTestId('scopes-mode-all')));
+		await userEvent.click(getByTestId('scopes-mode-all'));
 
 		expect(emitted('update:modelValue').at(-1)).toEqual([availableScopes]);
 	});
@@ -71,7 +68,7 @@ describe('ApiKeyScopes', () => {
 			props: { modelValue: availableScopes, availableScopes },
 		});
 
-		await userEvent.click(getRadioInput(getByTestId('scopes-mode-read-only')));
+		await userEvent.click(getByTestId('scopes-mode-read-only'));
 
 		expect(emitted('update:modelValue').at(-1)).toEqual([readOnlyScopes]);
 	});
@@ -81,10 +78,10 @@ describe('ApiKeyScopes', () => {
 			props: { modelValue: availableScopes, availableScopes },
 		});
 
-		await userEvent.click(getRadioInput(getByTestId('scopes-mode-custom')));
+		await userEvent.click(getByTestId('scopes-mode-custom'));
 
 		expect(emitted('update:modelValue').at(-1)).toEqual([[]]);
-		expect(getRadioInput(getByTestId('scopes-mode-custom'))).toBeChecked();
+		expect(getByTestId('scopes-mode-custom')).toBeChecked();
 	});
 
 	it('expands a group and toggles a single scope', async () => {
@@ -186,16 +183,16 @@ describe('ApiKeyScopes', () => {
 			props: { modelValue: availableScopes, availableScopes },
 		});
 
-		await userEvent.click(getRadioInput(getByTestId('scopes-mode-custom')));
-		expect(getRadioInput(getByTestId('scopes-mode-custom'))).toBeChecked();
+		await userEvent.click(getByTestId('scopes-mode-custom'));
+		expect(getByTestId('scopes-mode-custom')).toBeChecked();
 
 		// Parent pushes a selection that happens to equal the read-only set.
 		// The radio must NOT silently flip away from Custom because the user
 		// explicitly picked it.
 		await rerender({ modelValue: readOnlyScopes, availableScopes });
 
-		expect(getRadioInput(getByTestId('scopes-mode-custom'))).toBeChecked();
-		expect(getRadioInput(getByTestId('scopes-mode-read-only'))).not.toBeChecked();
+		expect(getByTestId('scopes-mode-custom')).toBeChecked();
+		expect(getByTestId('scopes-mode-read-only')).not.toBeChecked();
 	});
 
 	it('recovers from an initial Custom inference once props hydrate to match All', async () => {
@@ -205,7 +202,7 @@ describe('ApiKeyScopes', () => {
 			props: { modelValue: [] as ApiKeyScope[], availableScopes: [] as ApiKeyScope[] },
 		});
 
-		expect(getRadioInput(getByTestId('scopes-mode-custom'))).toBeChecked();
+		expect(getByTestId('scopes-mode-custom')).toBeChecked();
 		// Custom starts with the tree open.
 		expect(getByTestId('scopes-search')).toBeInTheDocument();
 
@@ -213,8 +210,8 @@ describe('ApiKeyScopes', () => {
 		// User never picked Custom, so the radio must flip to All.
 		await rerender({ modelValue: availableScopes, availableScopes });
 
-		expect(getRadioInput(getByTestId('scopes-mode-all'))).toBeChecked();
-		expect(getRadioInput(getByTestId('scopes-mode-custom'))).not.toBeChecked();
+		expect(getByTestId('scopes-mode-all')).toBeChecked();
+		expect(getByTestId('scopes-mode-custom')).not.toBeChecked();
 		// The programmatic mode flip must also collapse the tree, not just move the radio.
 		expect(queryByTestId('scopes-search')).not.toBeInTheDocument();
 	});
@@ -254,11 +251,11 @@ describe('ApiKeyScopes', () => {
 			props: { modelValue: availableScopes, availableScopes },
 		});
 
-		expect(getRadioInput(getByTestId('scopes-mode-all'))).toBeChecked();
+		expect(getByTestId('scopes-mode-all')).toBeChecked();
 
 		await rerender({ modelValue: ['workflow:read'] as ApiKeyScope[], availableScopes });
 
-		expect(getRadioInput(getByTestId('scopes-mode-custom'))).toBeChecked();
+		expect(getByTestId('scopes-mode-custom')).toBeChecked();
 	});
 
 	it('disables the mode radios and scope checkboxes when disabled', async () => {
@@ -266,7 +263,7 @@ describe('ApiKeyScopes', () => {
 			props: { modelValue: ['workflow:read'] as ApiKeyScope[], availableScopes, disabled: true },
 		});
 
-		expect(getRadioInput(getByTestId('scopes-mode-all'))).toBeDisabled();
+		expect(getByTestId('scopes-mode-all')).toBeDisabled();
 		expect(getByTestId('scope-group-workflowsAndExecutions')).toBeDisabled();
 
 		await userEvent.click(getByTestId('scope-group-toggle-workflowsAndExecutions'));

--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyScopes.vue
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyScopes.vue
@@ -6,7 +6,6 @@ import { useI18n } from '@n8n/i18n';
 import type { BaseTextKey } from '@n8n/i18n';
 import type { ApiKeyScope } from '@n8n/permissions';
 
-import { ElRadio, ElRadioGroup } from 'element-plus';
 import {
 	N8nBadge,
 	N8nCheckbox,
@@ -14,7 +13,9 @@ import {
 	N8nIconButton,
 	N8nInput,
 	N8nInputLabel,
+	N8nRadioGroup,
 } from '@n8n/design-system';
+import type { RadioGroupOption } from '@n8n/design-system';
 
 import {
 	classifyScope,
@@ -108,7 +109,21 @@ function emitScopes(scopes: ApiKeyScope[]) {
 	emit('update:modelValue', scopes);
 }
 
-function onModeChange(newMode: string | number | boolean | undefined) {
+const modeOptions = computed<Array<RadioGroupOption<ApiKeyScopeSelectionMode>>>(() => [
+	{ value: 'all', label: i18n.baseText('settings.api.scopes.all'), testId: 'scopes-mode-all' },
+	{
+		value: 'readOnly',
+		label: i18n.baseText('settings.api.scopes.readOnly'),
+		testId: 'scopes-mode-read-only',
+	},
+	{
+		value: 'custom',
+		label: i18n.baseText('settings.api.scopes.custom'),
+		testId: 'scopes-mode-custom',
+	},
+]);
+
+function onModeChange(newMode: ApiKeyScopeSelectionMode) {
 	userPickedCustom.value = newMode === 'custom';
 
 	if (newMode === 'all') {
@@ -168,24 +183,14 @@ function toggleScope(scope: ApiKeyScope, checked: boolean) {
 <template>
 	<div data-test-id="api-key-scopes">
 		<N8nInputLabel :label="i18n.baseText('settings.api.scopes.label')" color="text-dark">
-			<ElRadioGroup
+			<N8nRadioGroup
 				v-model="mode"
-				:class="$style.radioGroup"
+				:options="modeOptions"
 				:disabled="disabled"
 				:aria-label="i18n.baseText('settings.api.scopes.label')"
 				data-test-id="scopes-mode-radio"
-				@change="onModeChange"
-			>
-				<ElRadio label="all" data-test-id="scopes-mode-all">
-					{{ i18n.baseText('settings.api.scopes.all') }}
-				</ElRadio>
-				<ElRadio label="readOnly" data-test-id="scopes-mode-read-only">
-					{{ i18n.baseText('settings.api.scopes.readOnly') }}
-				</ElRadio>
-				<ElRadio label="custom" data-test-id="scopes-mode-custom">
-					{{ i18n.baseText('settings.api.scopes.custom') }}
-				</ElRadio>
-			</ElRadioGroup>
+				@update:model-value="onModeChange"
+			/>
 		</N8nInputLabel>
 
 		<div :class="$style.customSection">
@@ -270,18 +275,6 @@ function toggleScope(scope: ApiKeyScope, checked: boolean) {
 </template>
 
 <style module lang="scss">
-.radioGroup {
-	display: flex;
-	flex-direction: column;
-	align-items: flex-start;
-	gap: var(--spacing--2xs);
-
-	:global(.el-radio) {
-		margin-right: 0;
-		height: auto;
-	}
-}
-
 .customSection {
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
## Summary

Stacked on #32167. Adds a reusable, accessible radio-list component to the design system and uses it in the API key scope picker, so that picker no longer imports `element-plus` directly.

**`N8nRadioGroup`** (`@n8n/design-system`)
- Vertical (default) or horizontal single-choice radio list, wrapping reka-ui's `RadioGroupRoot` / `RadioGroupItem` / `RadioGroupIndicator` — keyboard arrow navigation, roving tabindex, and ARIA come from the primitive. (The existing `N8nRadioButtons` is a segmented *pill* control with no keyboard nav, so it doesn't fit a radio list.)
- API: `modelValue` (v-model), `options: { value, label, description?, disabled?, testId? }[]`, `orientation`, `disabled`, `name`, `ariaLabel`, plus an `#option` slot. Styled with design tokens and the shared focus mixin.
- Story (`Modules/RadioGroup`) + unit tests.

**API key scope picker** (`ApiKeyScopes.vue`)
- Swaps the direct `ElRadio` / `ElRadioGroup` imports for `N8nRadioGroup`. Public API and behaviour are unchanged; the radio item is now a `role="radio"` element, so the affected tests query it directly instead of a nested `input`.

Why a new component instead of extending `N8nRadioButtons`: that component is a horizontal segmented control used at 22 call sites and has no real keyboard a11y — conflating the two affordances would risk regressions and still require rebuilding the semantics reka-ui gives for free.

## How to test

1. `pnpm --filter @n8n/design-system test -- RadioGroup` (7 tests); view the `Modules/RadioGroup` story in Storybook.
2. `pnpm --filter n8n-editor-ui test -- apiKeys` (69 tests).
3. Settings → API → **Create API key**: the All / Read only / Custom selector now renders as a radio list, is keyboard-navigable (arrow keys), and behaves exactly as before.

Verified locally: lint, typecheck, and the above suites pass for both packages.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-822

Targets #32167 (review/merge here first) so the design-system component can be signed off separately before it folds into the scope-picker PR.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32390">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

