### PR TITLE
fix(core): Implement workflow-folder-conflict handling in import process

### DIFF
--- a/packages/cli/src/modules/n8n-packages/__tests__/import-pipeline.integration.test.ts
+++ b/packages/cli/src/modules/n8n-packages/__tests__/import-pipeline.integration.test.ts
@@ -254,10 +254,15 @@ describe('ImportPipeline routing matrix', () => {
 		);
 		const folder = await createFolder(personalProject, { name: 'Imports' });
 
-		await importPackage({
+		const result = await importPackage({
 			user: owner,
 			folderId: folder.id,
 			packageBuffer: await singleWorkflowPackage(),
+		});
+
+		expect(result.workflows[0]).toMatchObject({
+			status: 'created',
+			parentFolderId: folder.id,
 		});
 
 		const workflow = await Container.get(WorkflowRepository).findOneOrFail({
@@ -265,6 +270,60 @@ describe('ImportPipeline routing matrix', () => {
 			relations: ['parentFolder'],
 		});
 		expect(workflow.parentFolder?.id).toBe(folder.id);
+	});
+
+	it('blocks folder import when a matching workflow already exists elsewhere in the project', async () => {
+		const owner = await createOwner();
+		const personalProject = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(
+			owner.id,
+		);
+		const folder = await createFolder(personalProject, { name: 'Target Folder' });
+
+		const firstImport = await importPackage({
+			user: owner,
+			packageBuffer: await buildImportPackageBuffer([
+				serializedWorkflow({ id: 'wf-root', name: 'Root Workflow' }),
+			]),
+			workflowIdPolicy: WorkflowIdPolicy.Source,
+		});
+		expect(firstImport.workflows[0].parentFolderId).toBeNull();
+
+		const workflowRepo = Container.get(WorkflowRepository);
+		const countBefore = await workflowRepo.count();
+
+		await expect(
+			importPackage({
+				user: owner,
+				folderId: folder.id,
+				packageBuffer: await buildImportPackageBuffer([
+					serializedWorkflow({ id: 'wf-root', name: 'Folder Workflow' }),
+				]),
+				workflowConflictPolicy: WorkflowConflictPolicy.NewVersion,
+				workflowIdPolicy: WorkflowIdPolicy.Source,
+			}),
+		).rejects.toMatchObject({
+			message: expect.stringContaining('Import blocked'),
+			meta: {
+				issues: [
+					{
+						type: 'workflow-folder-conflict',
+						sourceWorkflowId: 'wf-root',
+						existingWorkflowId: 'wf-root',
+						existingParentFolderId: null,
+						targetFolderId: folder.id,
+						name: 'Root Workflow',
+					},
+				],
+			},
+		});
+
+		expect(await workflowRepo.count()).toBe(countBefore);
+		const stored = await workflowRepo.findOneOrFail({
+			where: { id: 'wf-root' },
+			relations: ['parentFolder'],
+		});
+		expect(stored.name).toBe('Root Workflow');
+		expect(stored.parentFolder).toBeNull();
 	});
 
 	it('lands in the team project root when projectId is given and the user has scope', async () => {
@@ -487,28 +546,25 @@ describe('ImportPipeline workflowIdPolicy: source', () => {
 		expect(await Container.get(WorkflowRepository).findOneBy({ id: 'STILTON' })).toBeNull();
 	});
 
-	it('updates in place without moving folders when re-imported into a different folder', async () => {
+	it('updates in place when re-imported into the same folder', async () => {
 		const owner = await createOwner();
 		const personalProject = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(
 			owner.id,
 		);
-		const folderA = await createFolder(personalProject, { name: 'Folder A' });
-		const folderB = await createFolder(personalProject, { name: 'Folder B' });
+		const folder = await createFolder(personalProject, { name: 'Imports' });
 
-		// Initial import lands STILTON in folder A.
 		await importPackage({
 			user: owner,
-			folderId: folderA.id,
+			folderId: folder.id,
 			packageBuffer: await buildImportPackageBuffer([
 				serializedWorkflow({ id: 'STILTON', name: 'Stilton v1' }),
 			]),
 			workflowIdPolicy: WorkflowIdPolicy.Source,
 		});
 
-		// Re-import targets folder B, but the matched workflow must stay in folder A.
 		const reimport = await importPackage({
 			user: owner,
-			folderId: folderB.id,
+			folderId: folder.id,
 			packageBuffer: await buildImportPackageBuffer([
 				serializedWorkflow({ id: 'STILTON', name: 'Stilton v2' }),
 			]),
@@ -516,14 +572,18 @@ describe('ImportPipeline workflowIdPolicy: source', () => {
 			workflowIdPolicy: WorkflowIdPolicy.Source,
 		});
 
-		expect(reimport.workflows[0]).toMatchObject({ localId: 'STILTON', status: 'updated' });
+		expect(reimport.workflows[0]).toMatchObject({
+			localId: 'STILTON',
+			status: 'updated',
+			parentFolderId: folder.id,
+		});
 
 		const stored = await Container.get(WorkflowRepository).findOneOrFail({
 			where: { id: 'STILTON' },
 			relations: ['parentFolder'],
 		});
 		expect(stored.name).toBe('Stilton v2');
-		expect(stored.parentFolder?.id).toBe(folderA.id);
+		expect(stored.parentFolder?.id).toBe(folder.id);
 	});
 
 	it('blocks the import when the source id already exists in a different project', async () => {
@@ -751,8 +811,13 @@ describe('ImportPipeline workflow conflict policy', () => {
 				localId: existing.id,
 				status:
 					workflowConflictPolicy === WorkflowConflictPolicy.NewVersion ? 'updated' : 'skipped',
+				parentFolderId: folder.id,
 			});
-			expect(freshSummary).toMatchObject({ status: 'created', name: 'Fresh workflow' });
+			expect(freshSummary).toMatchObject({
+				status: 'created',
+				name: 'Fresh workflow',
+				parentFolderId: null,
+			});
 
 			const workflows = await Container.get(WorkflowRepository).find();
 			expect(workflows).toHaveLength(2);
@@ -1258,6 +1323,39 @@ describe('ImportPipeline workflow publishing policy', () => {
 			parameters: {},
 		},
 	];
+
+	it.each<WorkflowPublishingPolicyValue>([
+		WorkflowPublishingPolicy.PreservePublishedState,
+		WorkflowPublishingPolicy.MatchSource,
+		WorkflowPublishingPolicy.PublishAll,
+		WorkflowPublishingPolicy.UnpublishAll,
+	])('returns parentFolderId for folder imports under "%s"', async (workflowPublishingPolicy) => {
+		const owner = await createOwner();
+		const personalProject = await Container.get(ProjectRepository).getPersonalProjectForUserOrFail(
+			owner.id,
+		);
+		const folder = await createFolder(personalProject, { name: 'Published imports' });
+
+		const result = await importPackage({
+			user: owner,
+			folderId: folder.id,
+			packageBuffer: await buildImportPackageBuffer([
+				serializedWorkflow({
+					id: 'wf-fresh',
+					name: 'Fresh workflow',
+					isPublished: false,
+					nodes: scheduleTriggerNodes(),
+				}),
+			]),
+			workflowConflictPolicy: 'fail',
+			workflowPublishingPolicy,
+		});
+
+		expect(result.workflows[0]).toMatchObject({
+			status: 'created',
+			parentFolderId: folder.id,
+		});
+	});
 
 	it.each<WorkflowPublishingPolicyValue>([
 		WorkflowPublishingPolicy.PreservePublishedState,

--- a/packages/cli/src/modules/n8n-packages/engine/import-blocked.error.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/import-blocked.error.ts
@@ -12,7 +12,10 @@ export function toImportBlockedError(
 
 	if (
 		issues.some(
-			(issue) => issue.type === 'workflow-conflict' || issue.type === 'workflow-id-conflict',
+			(issue) =>
+				issue.type === 'workflow-conflict' ||
+				issue.type === 'workflow-id-conflict' ||
+				issue.type === 'workflow-folder-conflict',
 		)
 	) {
 		return new ConflictError(message, undefined, { issues });

--- a/packages/cli/src/modules/n8n-packages/engine/import-pipeline.ts
+++ b/packages/cli/src/modules/n8n-packages/engine/import-pipeline.ts
@@ -138,6 +138,13 @@ export class ImportPipeline {
 			...conflict,
 		}));
 
+		const workflowFolderConflicts: BlockingIssue[] = workflowPlan.folderConflicts.map(
+			(conflict) => ({
+				type: 'workflow-folder-conflict',
+				...conflict,
+			}),
+		);
+
 		const credentialFailures: BlockingIssue[] = this.credentialImporter
 			.blockingFailures(credentialResolution, credentialRequest)
 			.map(({ kind, sourceId, targetId, usedByWorkflows }) => ({
@@ -148,7 +155,12 @@ export class ImportPipeline {
 				usedByWorkflows,
 			}));
 
-		return [...workflowConflicts, ...workflowIdConflicts, ...credentialFailures];
+		return [
+			...workflowConflicts,
+			...workflowIdConflicts,
+			...workflowFolderConflicts,
+			...credentialFailures,
+		];
 	}
 
 	private buildResult(

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-import.types.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-import.types.ts
@@ -50,6 +50,14 @@ export interface WorkflowConflict {
 	name: string;
 }
 
+export interface WorkflowFolderConflict {
+	sourceWorkflowId: string;
+	existingWorkflowId: string;
+	existingParentFolderId: string | null;
+	targetFolderId: string;
+	name: string;
+}
+
 /**
  * The planned actions for a batch of workflows, plus any conflicts that abort
  * the import before anything is written.
@@ -58,6 +66,7 @@ export interface WorkflowImportPlan {
 	items: WorkflowPlanItem[];
 	conflicts: WorkflowConflict[];
 	idConflicts: WorkflowIdConflict[];
+	folderConflicts: WorkflowFolderConflict[];
 }
 
 export interface WorkflowImportOutcome {

--- a/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-importer.ts
+++ b/packages/cli/src/modules/n8n-packages/entities/workflow/workflow-importer.ts
@@ -14,6 +14,7 @@ import type {
 	PersistedWorkflowPlanItem,
 	PreparedWorkflow,
 	WorkflowConflict,
+	WorkflowFolderConflict,
 	WorkflowImportContext,
 	WorkflowImportOutcome,
 	WorkflowImportPlan,
@@ -59,6 +60,7 @@ export class WorkflowImporter {
 
 		const items: WorkflowPlanItem[] = [];
 		const conflicts: WorkflowConflict[] = [];
+		const folderConflicts: WorkflowFolderConflict[] = [];
 		// `source`-policy ids that would be freshly created — candidates for a
 		// global id collision check below. Blocked creates are excluded: they
 		// already report a workflow-conflict for the same workflow.
@@ -85,11 +87,24 @@ export class WorkflowImporter {
 					name: existing.name,
 				});
 			}
+
+			if (context.folderId && existing) {
+				const existingParentFolderId = existing.parentFolder?.id ?? null;
+				if (existingParentFolderId !== context.folderId) {
+					folderConflicts.push({
+						sourceWorkflowId: workflow.sourceWorkflowId,
+						existingWorkflowId: existing.id,
+						existingParentFolderId,
+						targetFolderId: context.folderId,
+						name: existing.name,
+					});
+				}
+			}
 		}
 
 		const idConflicts = await this.collectIdConflicts(sourceCreateIds);
 
-		return { items, conflicts, idConflicts };
+		return { items, conflicts, idConflicts, folderConflicts };
 	}
 
 	/**
@@ -155,6 +170,13 @@ export class WorkflowImporter {
 			context.publishingPolicy,
 		);
 
+		// Publish reloads the workflow without parentFolder; restore it for the import summary.
+		workflow.parentFolder =
+			workflow.parentFolder ??
+			savedWorkflow.parentFolder ??
+			(item.action === 'update' ? item.existing.parentFolder : null) ??
+			null;
+
 		return {
 			status: item.action === 'create' ? 'created' : 'updated',
 			workflow,
@@ -179,13 +201,10 @@ export class WorkflowImporter {
 		}
 
 		const entity = prepareEntityForPersist(item.entity, credentialBindings);
-		const workflow = await this.workflowService.update(context.user, entity, item.existing.id, {
+		return await this.workflowService.update(context.user, entity, item.existing.id, {
 			publicApi: true,
 			source: 'import',
 		});
-		// update() doesn't re-hydrate parentFolder; carry over the existing folder for the result.
-		workflow.parentFolder = item.existing.parentFolder;
-		return workflow;
 	}
 }
 

--- a/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
+++ b/packages/cli/src/modules/n8n-packages/n8n-packages.types.ts
@@ -87,6 +87,14 @@ export type BlockingIssue =
 			name: string;
 	  }
 	| {
+			type: 'workflow-folder-conflict';
+			sourceWorkflowId: string;
+			existingWorkflowId: string;
+			existingParentFolderId: string | null;
+			targetFolderId: string;
+			name: string;
+	  }
+	| {
 			type: 'credential-unresolved';
 			kind: 'not_found' | 'unknown_type' | 'source_not_found';
 			sourceId: string;

--- a/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/schemas/importBlockingIssue.yml
+++ b/packages/cli/src/public-api/v1/handlers/n8n-packages/spec/schemas/importBlockingIssue.yml
@@ -54,6 +54,38 @@ oneOf:
       name:
         type: string
   - type: object
+    description: >
+      A workflow whose source id already matches one in the target project but
+      lives outside the requested import folder. Folder-targeted imports cannot
+      update workflows in place at a different location.
+    required:
+      - type
+      - sourceWorkflowId
+      - existingWorkflowId
+      - existingParentFolderId
+      - targetFolderId
+      - name
+    properties:
+      type:
+        type: string
+        enum:
+          - workflow-folder-conflict
+      sourceWorkflowId:
+        type: string
+      existingWorkflowId:
+        type: string
+      existingParentFolderId:
+        type: string
+        nullable: true
+        description: >
+          Folder that currently contains the matched workflow, or null when it
+          lives at the project root.
+      targetFolderId:
+        type: string
+        description: Folder the import was requested to land in.
+      name:
+        type: string
+  - type: object
     description: A credential reference that could not be resolved in the target project.
     required:
       - type


### PR DESCRIPTION
## Summary

This PR returns a conflict error when trying to import workflows into a folder, which sits in a project that already contains the workflow (identified by sourceWorkflowId). It adds a new error type `workflow-folder-conflict` which gets returned in the response.

The error response also holds information about the workflow that exists already and in which folder (if applicable).

This PR also makes sure to return the folder ID on succesful imports which was missing previously.

## Screenshots
<img width="400"  alt="Screenshot 2026-06-16 at 15 30 41" src="https://github.com/user-attachments/assets/cb02af2f-beec-47b0-8241-e6cc18680f1b" />


## How to test

1. Export a workflow
2. Try to re-import into a folder within the same project
3. Should error

Importing into a folder in different project should work fine.

## Related Linear tickets, Github issues, and Community forum posts

Fixes [LIGO-728](https://linear.app/n8n/issue/LIGO-728/import-into-a-folder-does-not-always-work
)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [x] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32391">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->