### PR TITLE
fix(editor): Clear selection box when collapsing a node group (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.test.ts
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.test.ts
@@ -28,6 +28,7 @@ import { canvasEventBus } from '@/features/workflows/canvas/canvas.eventBus';
 import { createEventBus } from '@n8n/utils/event-bus';
 import { usePostHog } from '@/app/stores/posthog.store';
 import { GROUP_PADDING_Y_BOTTOM, GROUP_PADDING_Y_TOP } from '../stores/canvasNodeGroups.constants';
+import { NodeGroupViewKey, type CanvasNodeGroupView } from '../composables/useCanvasNodeGroupView';
 
 let workflowDocumentStore: ReturnType<typeof useWorkflowDocumentStore>;
 
@@ -226,6 +227,49 @@ describe('Canvas', () => {
 		await waitFor(() =>
 			expect(getSelectedNodes.value.map(({ id }) => id).sort()).toEqual([groupNode.id, node.id]),
 		);
+	});
+
+	it('should clear selected members when their group is collapsed', async () => {
+		vi.spyOn(usePostHog(), 'isFeatureEnabled').mockImplementation(
+			(name) => name === CANVAS_NODES_GROUPING_EXPERIMENT.name,
+		);
+		vi.spyOn(workflowDocumentStore, 'getGroupById').mockReturnValue({
+			id: 'g1',
+			name: 'Group 1',
+			nodeIds: ['node-1'],
+		});
+
+		let collapsed = false;
+		const nodeGroupView = {
+			isGroupCollapsed: () => collapsed,
+			toggleCollapsed: () => {
+				collapsed = !collapsed;
+			},
+			getVisualOffsetForNode: () => ({ x: 0, y: 0 }),
+			getVisualOffsetForComponent: () => ({ x: 0, y: 0 }),
+			syncLayoutComponents: () => {},
+			settleManualNodePositions: (events: unknown) => events,
+			commitMovedPushSourceEffects: () => [],
+		} as unknown as CanvasNodeGroupView;
+
+		const node = createCanvasNodeElement({ id: 'node-1' });
+		const groupNode = createCanvasGroupNode({ selectable: true });
+		const eventBus = createEventBus<CanvasEventBusEvents>();
+
+		const { container, getByTestId } = renderComponent({
+			props: { nodes: [node, groupNode], eventBus },
+			global: { provide: { [NodeGroupViewKey as symbol]: nodeGroupView } },
+		});
+
+		await waitFor(() => expect(container.querySelectorAll('.vue-flow__node')).toHaveLength(2));
+
+		const { getSelectedNodes } = useVueFlow(canvasId);
+		eventBus.emit('nodes:selectAll');
+		await waitFor(() => expect(getSelectedNodes.value.map(({ id }) => id)).toContain('node-1'));
+
+		await fireEvent.click(getByTestId('canvas-node-group-toggle'));
+
+		await waitFor(() => expect(getSelectedNodes.value.map(({ id }) => id)).not.toContain('node-1'));
 	});
 
 	it('should expand a selected collapsed group to its members when copying', async () => {

--- a/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
+++ b/packages/frontend/editor-ui/src/features/workflows/canvas/components/Canvas.vue
@@ -618,8 +618,19 @@ function onSelectionDrag(event: NodeDragEvent) {
 function onCanvasGroupToggle(groupId: string) {
 	injectedNodeGroupView?.toggleCollapsed(groupId);
 
-	// Expanding makes the title bar non-selectable, so drop any selection lingering on it.
-	if (injectedNodeGroupView && !injectedNodeGroupView.isGroupCollapsed(groupId)) {
+	if (!injectedNodeGroupView) return;
+
+	if (injectedNodeGroupView.isGroupCollapsed(groupId)) {
+		// Collapsing hides the members, so drop them from the selection to clear the lingering box.
+		const memberNodeIds = workflowDocumentStore.value.getGroupById(groupId)?.nodeIds ?? [];
+		const selectedMembers = memberNodeIds
+			.map((nodeId) => findNode(nodeId))
+			.filter((node): node is NonNullable<typeof node> => node?.selected ?? false);
+		if (selectedMembers.length > 0) {
+			removeSelectedNodes(selectedMembers);
+		}
+	} else {
+		// Expanding makes the title bar non-selectable, so drop any selection lingering on it.
 		const groupNode = findNode(`${CANVAS_NODE_GROUP_ID_PREFIX}${groupId}`);
 		if (groupNode) {
 			removeSelectedNodes([groupNode]);


### PR DESCRIPTION
## Summary

Collapsing a node group whose member nodes were selected left VueFlow's selection box (the marquee bounding rectangle) floating on the canvas, because the now-hidden members stayed marked as selected.

`onCanvasGroupToggle` only cleared selection when expanding a group (dropping the title-bar node). This adds the missing collapse branch: when a group is collapsed, its selected member nodes are removed from the VueFlow selection, so the box clears. The existing expand behavior is preserved.

## How to test

1. Enable the Canvas grouping experiment.
2. On the canvas, select the member nodes of a group (some or all).
3. Collapse the group.
4. The selection box clears (previously it persisted around the collapsed group).
5. Expand the group again - the title bar isn't left selected (existing behavior, unchanged)

## Related Linear tickets, Github issues, and Community forum posts

Closes [ADO-5413](https://linear.app/n8n/issue/ADO-5413)

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32396?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32396">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->