### PR TITLE
fix(editor): Add telemetry event for evaluation config wizard steps (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.test.ts
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.test.ts
@@ -758,6 +758,62 @@ describe('EvaluationsWizardSidepanel', () => {
 		).not.toBeInTheDocument();
 	});
 
+	describe('wizard step-view telemetry', () => {
+		const stepEvents = () =>
+			trackMock.mock.calls.filter(
+				([event]) => event === 'User viewed evaluation config wizard step',
+			);
+
+		it('tracks the scorers step once with step_name and 1-based step_index', async () => {
+			const store = useEvaluationsWizardSidepanelStore();
+			store.open(1);
+
+			renderComponent();
+			await nextTick();
+
+			const events = stepEvents();
+			expect(events).toHaveLength(1);
+			expect(events[0][1]).toEqual({
+				workflow_id: 'workflow-id',
+				step_name: 'setup_scorers',
+				step_index: 2,
+			});
+		});
+
+		it('tracks each step as the user advances, and dedupes a revisited step', async () => {
+			const store = useEvaluationsWizardSidepanelStore();
+			store.open(1);
+
+			renderComponent();
+			await nextTick();
+
+			store.setStep(2);
+			await nextTick();
+			// Going back to an already-viewed step must not emit a duplicate.
+			store.setStep(1);
+			await nextTick();
+
+			const events = stepEvents();
+			expect(events.map((call) => call[1])).toEqual([
+				{ workflow_id: 'workflow-id', step_name: 'setup_scorers', step_index: 2 },
+				{ workflow_id: 'workflow-id', step_name: 'add_test_cases', step_index: 3 },
+			]);
+		});
+
+		it('does not track a step while the run-first gate is showing', async () => {
+			// The execution probe (and thus the gate) only runs on steps 0 and 2.
+			mocks.sliceInputs = { fieldNames: [], values: {}, hasExecution: false };
+			const store = useEvaluationsWizardSidepanelStore();
+			store.open(2);
+
+			const { findByTestId } = renderComponent();
+			// Wait for the probe to settle and the gate to render.
+			await findByTestId('evaluations-wizard-sidepanel-gate');
+
+			expect(stepEvents()).toHaveLength(0);
+		});
+	});
+
 	describe('run-first gate', () => {
 		it('blocks the wizard with a run-first gate when the workflow has never run', async () => {
 			mocks.sliceInputs = { fieldNames: [], values: {}, hasExecution: false };

--- a/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.vue
+++ b/packages/frontend/editor-ui/src/features/ai/evaluation.ee/components/WizardSidepanel/EvaluationsWizardSidepanel.vue
@@ -356,6 +356,51 @@ watch(
 	{ immediate: true },
 );
 
+// Per-step metadata, indexed by activeStep (0-3); WizardStep is constrained to those values.
+const STEP_META = [
+	{
+		telemetryName: 'choose_system',
+		title: 'evaluations.wizardSidepanel.step.chooseSystem.title',
+		description: 'evaluations.wizardSidepanel.step.chooseSystem.description',
+	},
+	{
+		telemetryName: 'setup_scorers',
+		title: 'evaluations.wizardSidepanel.step.setupChecks.title',
+		description: 'evaluations.wizardSidepanel.step.setupChecks.description',
+	},
+	{
+		telemetryName: 'add_test_cases',
+		title: 'evaluations.wizardSidepanel.step.addTestCases.title',
+		description: 'evaluations.wizardSidepanel.step.addTestCases.description',
+	},
+	{
+		telemetryName: 'results',
+		title: 'evaluations.wizardSidepanel.step.results.title',
+		description: 'evaluations.wizardSidepanel.step.results.description',
+	},
+] as const;
+
+// Emit a view event when a step's content is shown (not while gated/loading).
+// Deduped per step, reset on close, so revisiting a step doesn't re-fire.
+const trackedSteps = new Set<number>();
+watch(
+	[() => wizardStore.isOpen, activeStep, showGate, showProbeLoading],
+	([isOpen, step, gated, loading]) => {
+		if (!isOpen) {
+			trackedSteps.clear();
+			return;
+		}
+		if (gated || loading || trackedSteps.has(step)) return;
+		trackedSteps.add(step);
+		telemetry.track('User viewed evaluation config wizard step', {
+			workflow_id: workflowDocumentStore.value?.workflowId,
+			step_name: STEP_META[step].telemetryName,
+			step_index: step + 1,
+		});
+	},
+	{ immediate: true },
+);
+
 // step0Complete: system chosen (node or slice)
 const step0Complete = computed(() => {
 	if (isSliceMode.value) {
@@ -392,28 +437,8 @@ function isLlmJudgeMetric(key: CannedMetricKey): boolean {
 	return LLM_JUDGE_METRIC_KEYS.has(key);
 }
 
-// Indexed by activeStep (0-3); WizardStep is constrained to those values.
-const STEP_I18N = [
-	{
-		title: 'evaluations.wizardSidepanel.step.chooseSystem.title',
-		description: 'evaluations.wizardSidepanel.step.chooseSystem.description',
-	},
-	{
-		title: 'evaluations.wizardSidepanel.step.setupChecks.title',
-		description: 'evaluations.wizardSidepanel.step.setupChecks.description',
-	},
-	{
-		title: 'evaluations.wizardSidepanel.step.addTestCases.title',
-		description: 'evaluations.wizardSidepanel.step.addTestCases.description',
-	},
-	{
-		title: 'evaluations.wizardSidepanel.step.results.title',
-		description: 'evaluations.wizardSidepanel.step.results.description',
-	},
-] as const;
-
-const titleKey = computed(() => STEP_I18N[activeStep.value].title);
-const descriptionKey = computed(() => STEP_I18N[activeStep.value].description);
+const titleKey = computed(() => STEP_META[activeStep.value].title);
+const descriptionKey = computed(() => STEP_META[activeStep.value].description);
 
 async function handleNext() {
 	const current = activeStep.value;


### PR DESCRIPTION
## Summary

Adds the `User viewed evaluation config wizard step` telemetry event to the Config Evals wizard. The rudder schema table `user_viewed_evaluation_config_wizard_step` already existed but was receiving no data because the matching `telemetry.track` call was never wired up.

The event fires each time a wizard step's content becomes visible, with:

- `workflow_id`
- `step_name` — one of `choose_system` / `setup_scorers` / `add_test_cases` / `results`
- `step_index` — 1-based (1–4)

(`user_id` and `timestamp` are added automatically by the telemetry plumbing.)

It is deduped per step and reset when the wizard closes, so reopening re-tracks but back/forth navigation within a session doesn't inflate the funnel. The event is suppressed while the first-run gate or probe-loading is showing, since the user can't yet see the step. This mirrors the existing in-component `User viewed evaluation results` watcher pattern.

Also unifies the previously-separate per-step i18n keys and the new telemetry names into a single `STEP_META` constant (one source of truth for step ordering).

## Related Linear ticket

https://linear.app/n8n/issue/TRUST-184

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32402">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->