### PR TITLE
perf(core): Stabilize Instance AI prompt-cache prefix across turns

### DIFF
--- a/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.test.ts
@@ -1,4 +1,29 @@
-import { getSystemPrompt } from '../system-prompt';
+import { getDateTimeSection, getSystemPrompt } from '../system-prompt';
+
+describe('getDateTimeSection', () => {
+	afterEach(() => vi.useRealTimers());
+
+	it('renders the current time at minute precision (no seconds/milliseconds)', () => {
+		vi.useFakeTimers().setSystemTime(new Date('2026-06-16T14:59:11.396Z'));
+
+		const section = getDateTimeSection('UTC');
+
+		expect(section).toContain('2026-06-16T14:59');
+		// The sub-minute portion must be dropped so the cached prefix stays stable.
+		expect(section).not.toContain('14:59:11');
+		expect(section).not.toContain('.396');
+	});
+
+	it('is byte-stable across sub-minute calls', () => {
+		vi.useFakeTimers().setSystemTime(new Date('2026-06-16T14:59:01.000Z'));
+		const first = getDateTimeSection('UTC');
+
+		vi.setSystemTime(new Date('2026-06-16T14:59:58.999Z'));
+		const second = getDateTimeSection('UTC');
+
+		expect(second).toBe(first);
+	});
+});
 
 describe('getSystemPrompt', () => {
 	describe('first visible turn guidance', () => {

--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -24,8 +24,6 @@ interface SystemPromptOptions {
 
 export function getDateTimeSection(timeZone?: string): string {
 	const now = timeZone ? DateTime.now().setZone(timeZone) : DateTime.now();
-	// ponytail: truncate to the minute so this line stays byte-stable within a
-	// prompt-cache TTL window — sub-minute precision busts the cached prefix.
 	const isoTime = now
 		.startOf('minute')
 		.toISO({ includeOffset: true, suppressSeconds: true, suppressMilliseconds: true });

--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -24,7 +24,11 @@ interface SystemPromptOptions {
 
 export function getDateTimeSection(timeZone?: string): string {
 	const now = timeZone ? DateTime.now().setZone(timeZone) : DateTime.now();
-	const isoTime = now.toISO({ includeOffset: true });
+	// ponytail: truncate to the minute so this line stays byte-stable within a
+	// prompt-cache TTL window — sub-minute precision busts the cached prefix.
+	const isoTime = now
+		.startOf('minute')
+		.toISO({ includeOffset: true, suppressSeconds: true, suppressMilliseconds: true });
 	const tzLabel = timeZone ? ` (timezone: ${timeZone})` : '';
 	return `
 ## Current Date and Time


### PR DESCRIPTION
## Summary

The Instance AI system prompt embeds the current time near the top of the cached block:

```ts
// system-prompt.ts — getDateTimeSection()
const isoTime = now.toISO({ includeOffset: true }); // → 2026-06-16T14:59:11.396+02:00
```

`toISO()` emits **millisecond** precision, and that line sits at the second line of the system prompt — inside the single `ephemeral` cache breakpoint on the system message. Anthropic prompt caching requires an exact byte-prefix match up to the breakpoint, so a sub-minute timestamp invalidates the **entire** (large, otherwise-static) system block every time the prompt is rebuilt (once per turn/resume). The orchestrator then re-writes the whole prefix at the cache-write rate instead of reading it back.

The fix truncates the rendered time to the minute so the line stays byte-stable within a cache TTL window:

```ts
const isoTime = now
  .startOf('minute')
  .toISO({ includeOffset: true, suppressSeconds: true, suppressMilliseconds: true });
// → 2026-06-16T14:59+02:00
```

Minute precision keeps "now" accurate for the agent's scheduling references while letting the static prefix be served from cache. (A coarser bucket, or moving the clock out of the cached prefix entirely, would save more — left as a follow-up.)

### Scope note
The observation-log timestamps (`@n8n/agents` observation-log-renderer) were also suspected, but they render `createdAt` as a stable absolute `HH:MM` and `renderObservationLog` is deterministic, so re-rendering is byte-identical — not a cache-bust source. No change made there.

## How to test

- `pnpm --filter @n8n/instance-ai test src/agent/__tests__/system-prompt.test.ts`
- New tests assert the date section renders at minute precision (no seconds/ms) and is byte-stable across sub-minute calls.

## Related Linear tickets, Github issues, and Community forum posts

None yet — surfaced from a production cost investigation. Happy to file a ticket if wanted.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32404">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->