### PR TITLE
fix(nodes): Correct invalid operation defaults and enable lint rule

### DIFF
--- a/packages/nodes-base/eslint.config.mjs
+++ b/packages/nodes-base/eslint.config.mjs
@@ -115,6 +115,7 @@ export default defineConfig(
 			'n8n-nodes-base/node-param-default-wrong-for-fixed-collection': 'error',
 			'n8n-nodes-base/node-param-default-wrong-for-fixed-collection': 'error',
 			'n8n-nodes-base/node-param-default-wrong-for-multi-options': 'error',
+			'n8n-nodes-base/node-param-default-wrong-for-options': 'error',
 			'n8n-nodes-base/node-param-default-wrong-for-number': 'error',
 			'n8n-nodes-base/node-param-default-wrong-for-simplify': 'error',
 			'n8n-nodes-base/node-param-default-wrong-for-string': 'error',

--- a/packages/nodes-base/nodes/Bitwarden/descriptions/EventDescription.ts
+++ b/packages/nodes-base/nodes/Bitwarden/descriptions/EventDescription.ts
@@ -6,7 +6,7 @@ export const eventOperations: INodeProperties[] = [
 		name: 'operation',
 		type: 'options',
 		noDataExpression: true,
-		default: 'get',
+		default: 'getAll',
 		options: [
 			{
 				name: 'Get Many',

--- a/packages/nodes-base/nodes/Mautic/CompanyContactDescription.ts
+++ b/packages/nodes-base/nodes/Mautic/CompanyContactDescription.ts
@@ -25,7 +25,7 @@ export const companyContactOperations: INodeProperties[] = [
 				action: 'Remove a company contact',
 			},
 		],
-		default: 'create',
+		default: 'add',
 	},
 ];
 

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v1/FolderMessageDecription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v1/FolderMessageDecription.ts
@@ -19,7 +19,7 @@ export const folderMessageOperations: INodeProperties[] = [
 				action: 'Get many folder messages',
 			},
 		],
-		default: 'create',
+		default: 'getAll',
 	},
 ];
 

--- a/packages/nodes-base/nodes/N8n/AuditDescription.ts
+++ b/packages/nodes-base/nodes/N8n/AuditDescription.ts
@@ -6,7 +6,7 @@ export const auditOperations: INodeProperties[] = [
 		name: 'operation',
 		type: 'options',
 		noDataExpression: true,
-		default: 'get',
+		default: 'generate',
 		displayOptions: {
 			show: {
 				resource: ['audit'],

--- a/packages/nodes-base/nodes/Spotify/Spotify.node.ts
+++ b/packages/nodes-base/nodes/Spotify/Spotify.node.ts
@@ -563,7 +563,7 @@ export class Spotify implements INodeType {
 						action: 'Search tracks by keyword',
 					},
 				],
-				default: 'track',
+				default: 'get',
 			},
 			{
 				displayName: 'Track ID',


### PR DESCRIPTION
## Summary

Fixes five built-in nodes that declare an operation `default` value not present in their own `options` list — a copy-paste leftover from sibling resource descriptions. Also enables the existing ESLint rule that would have caught this at lint time.

### Affected nodes

| Node | Resource | `default` before | `default` after | Valid option values |
|---|---|---|---|---|
| Spotify | Track | `'track'` | `'get'` | `get`, `getAudioFeatures`, `search` |
| Bitwarden | Event | `'get'` | `'getAll'` | `getAll` |
| Mautic | Company Contact | `'create'` | `'add'` | `add`, `remove` |
| Microsoft Outlook v1 | Folder Message | `'create'` | `'getAll'` | `getAll` |
| n8n | Audit | `'get'` | `'generate'` | `generate` |

### Root cause

The ESLint rule `node-param-default-wrong-for-options` exists in `eslint-plugin-n8n-nodes-base` but was not enabled in `packages/nodes-base/eslint.config.mjs`. The sibling rules for `boolean`, `collection`, `multi-options`, `number`, and `string` types are all enabled — only the plain `options` variant was missing, allowing copy-paste defaults to go undetected.

### Changes

1. Fix the five incorrect default values listed above
2. Enable `n8n-nodes-base/node-param-default-wrong-for-options` as `error` in the nodes ESLint config

Closes #32347

## Test plan

- [x] Verify each `default` value now matches a valid `options[].value` in the same parameter definition
- [ ] Run `pnpm lint` in `packages/nodes-base` — the new rule should pass with the fixes applied
- [ ] Add a Spotify node to a workflow, set Resource = Track → verify "Get" is pre-selected in Operation dropdown
- [ ] Add a Bitwarden node, set Resource = Event → verify "Get Many" is pre-selected
- [ ] Add a Mautic node, set Resource = Company Contact → verify "Add" is pre-selected
- [ ] Add a Microsoft Outlook node, set Resource = Folder Message → verify "Get Many" is pre-selected
- [ ] Add an n8n node, set Resource = Audit → verify "Generate" is pre-selected

🤖 Generated with [Claude Code Best](https://github.com/claude-code-best/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32405">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

