### PR TITLE
fix(core): Time out stalled HTTP response body reads

### DIFF
--- a/packages/@n8n/backend-network/src/http/__tests__/binary-buffer.test.ts
+++ b/packages/@n8n/backend-network/src/http/__tests__/binary-buffer.test.ts
@@ -1,8 +1,10 @@
+import { HttpRequestConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
 import { UnexpectedError } from 'n8n-workflow';
 import { Readable } from 'node:stream';
 import { createGunzip } from 'node:zlib';
 
-import { binaryToBuffer } from '../binary-buffer';
+import { binaryToBuffer, streamToBuffer } from '../binary-buffer';
 
 describe('binaryToBuffer', () => {
 	it('should handle buffer objects', async () => {
@@ -29,5 +31,79 @@ describe('binaryToBuffer', () => {
 		const promise = binaryToBuffer(body);
 		await expect(promise).rejects.toThrow(UnexpectedError);
 		await expect(promise).rejects.toThrow('Failed to decompress response');
+	});
+
+	it(
+		'should reject when a stream closes without ending (truncated body)',
+		{ timeout: 1000 },
+		async () => {
+			// Mirrors a half-open socket / truncated proxied body: some data arrives,
+			// then the underlying stream is destroyed without a clean 'end'. Such a
+			// stream emits only 'close' (no 'end', no 'error').
+			const body = new Readable({ read() {} });
+			body.push(Buffer.from('partial body'));
+			setImmediate(() => body.destroy());
+
+			const promise = binaryToBuffer(body);
+			await expect(promise).rejects.toThrow(UnexpectedError);
+			await expect(promise).rejects.toThrow('closed before completing');
+		},
+	);
+});
+
+describe('streamToBuffer inactivity timeout', () => {
+	it('rejects when a stream stops producing data', { timeout: 1000 }, async () => {
+		// A keep-alive socket with an unsatisfied length / a stalled decompression:
+		// a chunk arrives, then nothing — no 'end', 'error' or 'close'.
+		const stream = new Readable({ read() {} });
+		stream.push(Buffer.from('partial body'));
+
+		const promise = streamToBuffer(stream, 100);
+		await expect(promise).rejects.toThrow(UnexpectedError);
+		await expect(promise).rejects.toThrow('timed out');
+	});
+
+	it('rejects when a stream never produces any data', { timeout: 1000 }, async () => {
+		const stream = new Readable({ read() {} });
+
+		const promise = streamToBuffer(stream, 100);
+		await expect(promise).rejects.toThrow('timed out');
+	});
+
+	it('does not interrupt a stream that keeps producing data', { timeout: 2000 }, async () => {
+		// Emits a chunk every 40ms for ~200ms, then ends. The 300ms inactivity
+		// timeout must never fire because the stream keeps making progress; the
+		// wide margin keeps the test robust against scheduling jitter on CI.
+		let remaining = 5;
+		const stream = new Readable({
+			read() {
+				setTimeout(() => {
+					if (remaining-- > 0) this.push(Buffer.from('chunk'));
+					else this.push(null);
+				}, 40);
+			},
+		});
+
+		expect((await streamToBuffer(stream, 300)).toString()).toBe('chunkchunkchunkchunkchunk');
+	});
+
+	it('does not time out when disabled (non-positive timeout)', async () => {
+		const stream = Readable.from(Buffer.from('done'));
+		expect((await streamToBuffer(stream, 0)).toString()).toBe('done');
+	});
+
+	it('falls back to responseBodyReadTimeout from config when no timeout is given', async () => {
+		Container.set(
+			HttpRequestConfig,
+			Object.assign(new HttpRequestConfig(), { responseBodyReadTimeout: 100 }),
+		);
+		try {
+			const stream = new Readable({ read() {} });
+			stream.push(Buffer.from('partial body'));
+
+			await expect(streamToBuffer(stream)).rejects.toThrow('timed out');
+		} finally {
+			Container.set(HttpRequestConfig, new HttpRequestConfig());
+		}
 	});
 });

--- a/packages/@n8n/backend-network/src/http/__tests__/legacy-request.test.ts
+++ b/packages/@n8n/backend-network/src/http/__tests__/legacy-request.test.ts
@@ -1,8 +1,14 @@
 import type { Logger } from '@n8n/backend-common';
+import { HttpRequestConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
 import nock from 'nock';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type { Readable } from 'node:stream';
 import { mock } from 'vitest-mock-extended';
 
 import type { SsrfBridge, SsrfProtectionService } from '../../ssrf';
+import { binaryToString } from '../binary-string';
 import { OutboundHttp } from '../outbound-http';
 
 function makeFacade(): OutboundHttp {
@@ -294,5 +300,102 @@ describe('OutboundHttp.requests requestLegacy', () => {
 				client.requestLegacy({ url: 'https://blocked.com/data', allowedDomains: '*.example.com' }),
 			).rejects.toThrow('Domain not allowed');
 		});
+	});
+
+	describe('body drain', () => {
+		let server: Server;
+		let port: number;
+
+		beforeAll(async () => {
+			nock.enableNetConnect('127.0.0.1');
+			// Sends headers (so axios resolves the response with the body as a
+			// stream) then a partial body that never reaches the declared
+			// Content-Length, holding the socket open. The body stream then emits
+			// neither 'end', 'error' nor 'close' — replicating the stalled proxy
+			// response that hangs the caller forever. `/stall` returns 403 (error
+			// path, drained internally), `/stall-200` returns 200 (success path,
+			// drained by the caller).
+			server = createServer((req, res) => {
+				const status = (req.url ?? '').startsWith('/stall-200') ? 200 : 403;
+				res.writeHead(status, { 'content-type': 'text/plain', 'content-length': '1000' });
+				res.write('partial body');
+				// intentionally never end the response and never close the socket
+			});
+			await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+			port = (server.address() as AddressInfo).port;
+		});
+
+		afterAll(async () => {
+			server.closeAllConnections();
+			await new Promise<void>((resolve) => server.close(() => resolve()));
+			nock.disableNetConnect();
+		});
+
+		beforeEach(() => {
+			// Bound the body-read drain to a short deadline so the test stays fast.
+			Container.set(
+				HttpRequestConfig,
+				Object.assign(new HttpRequestConfig(), { responseBodyReadTimeout: 500 }),
+			);
+		});
+
+		afterEach(() => {
+			Container.set(HttpRequestConfig, new HttpRequestConfig());
+		});
+
+		it(
+			'rejects instead of hanging when the error-response body never terminates',
+			{ timeout: 5000 },
+			async () => {
+				// No per-request `timeout`: axios then sets no socket timeout, so nothing
+				// tears the stalled body stream down — without the guard it hangs forever.
+				const client = makeFacade().requests({ ssrf: 'disabled' });
+
+				await expect(
+					client.requestLegacy({ url: `http://127.0.0.1:${port}/stall`, useStream: true }),
+				).rejects.toThrow(/timed out/i);
+			},
+		);
+
+		it(
+			'bounds the error-body read by responseBodyReadTimeout even with a larger per-request timeout',
+			{ timeout: 5000 },
+			async () => {
+				// The HTTP Request node always sets a per-request timeout (default 300_000ms).
+				// The configured guard must still apply, so the read aborts at ~500ms here,
+				// not at the 30s request timeout.
+				const client = makeFacade().requests({ ssrf: 'disabled' });
+				const start = Date.now();
+
+				await expect(
+					client.requestLegacy({
+						url: `http://127.0.0.1:${port}/stall`,
+						useStream: true,
+						timeout: 30_000,
+					}),
+				).rejects.toThrow(/timed out/i);
+				expect(Date.now() - start).toBeLessThan(3000);
+			},
+		);
+
+		it(
+			'guards a stalled success-response (2xx) body that the caller drains',
+			{ timeout: 5000 },
+			async () => {
+				// A 2xx is not thrown, so requestLegacy returns the body stream and the
+				// caller drains it. The guard must still bound it.
+				const client = makeFacade().requests({ ssrf: 'disabled' });
+				const start = Date.now();
+
+				const body = (await client.requestLegacy({
+					url: `http://127.0.0.1:${port}/stall-200`,
+					useStream: true,
+					timeout: 30_000,
+				})) as Readable;
+
+				await expect(binaryToString(body)).rejects.toThrow(/timed out/i);
+				expect(Date.now() - start).toBeLessThan(3000);
+			},
+		);
 	});
 });

--- a/packages/@n8n/backend-network/src/http/axios/__tests__/user-agent.test.ts
+++ b/packages/@n8n/backend-network/src/http/axios/__tests__/user-agent.test.ts
@@ -25,6 +25,7 @@ describe('outbound-user-agent', () => {
 			Container.set(HttpRequestConfig, {
 				enforceGlobalUserAgent: false,
 				globalUserAgentValue: '',
+				responseBodyReadTimeout: 300_000,
 			});
 
 			expect(getDefaultN8nOutboundUserAgent()).toBe('n8n');
@@ -34,6 +35,7 @@ describe('outbound-user-agent', () => {
 			Container.set(HttpRequestConfig, {
 				enforceGlobalUserAgent: false,
 				globalUserAgentValue: 'some-custom-value',
+				responseBodyReadTimeout: 300_000,
 			});
 
 			expect(getDefaultN8nOutboundUserAgent()).toBe('n8n');
@@ -43,6 +45,7 @@ describe('outbound-user-agent', () => {
 			Container.set(HttpRequestConfig, {
 				enforceGlobalUserAgent: true,
 				globalUserAgentValue: '',
+				responseBodyReadTimeout: 300_000,
 			});
 
 			expect(getDefaultN8nOutboundUserAgent()).toMatch(
@@ -54,6 +57,7 @@ describe('outbound-user-agent', () => {
 			Container.set(HttpRequestConfig, {
 				enforceGlobalUserAgent: true,
 				globalUserAgentValue: 'AcmeCorp/1.0',
+				responseBodyReadTimeout: 300_000,
 			});
 
 			expect(getDefaultN8nOutboundUserAgent()).toBe('AcmeCorp/1.0');
@@ -74,6 +78,7 @@ describe('outbound-user-agent', () => {
 			di.Container.set(config.HttpRequestConfig, {
 				enforceGlobalUserAgent: true,
 				globalUserAgentValue: '',
+				responseBodyReadTimeout: 300_000,
 			});
 
 			expect(mod.getDefaultN8nOutboundUserAgent()).toBe(

--- a/packages/@n8n/backend-network/src/http/binary-buffer.ts
+++ b/packages/@n8n/backend-network/src/http/binary-buffer.ts
@@ -1,17 +1,79 @@
+import { HttpRequestConfig } from '@n8n/config';
+import { Container } from '@n8n/di';
 import { UnexpectedError } from 'n8n-workflow';
 import type { Readable } from 'stream';
 
-/** Converts a readable stream to a buffer */
-export async function streamToBuffer(stream: Readable): Promise<Buffer> {
+/**
+ * Converts a readable stream to a buffer, rejecting if the stream stalls.
+ *
+ * The inactivity timeout exists because a request `timeout` only covers the
+ * response headers, leaving a never-terminating body able to hang the caller
+ * forever. It resets on each chunk (so a slow-but-progressing download isn't
+ * cut off) — meaning it bounds inactivity, not total read time; a stream that
+ * keeps trickling data is intentionally not capped. `idleTimeoutMs` defaults to
+ * `HttpRequestConfig.responseBodyReadTimeout`.
+ */
+export async function streamToBuffer(stream: Readable, idleTimeoutMs?: number): Promise<Buffer> {
+	const timeout = idleTimeoutMs ?? Container.get(HttpRequestConfig).responseBodyReadTimeout;
+	const useTimer = Number.isFinite(timeout) && timeout > 0;
+
 	return await new Promise<Buffer>((resolve, reject) => {
 		const chunks: Buffer[] = [];
-		stream.on('data', (chunk: Buffer) => chunks.push(chunk));
-		stream.on('end', () => resolve(Buffer.concat(chunks)));
-		stream.once('error', (cause) => {
-			if ('code' in cause && cause.code === 'Z_DATA_ERROR')
-				reject(new UnexpectedError('Failed to decompress response', { cause }));
-			else reject(cause);
-		});
+		let settled = false;
+		let timer: NodeJS.Timeout | undefined;
+
+		const clearTimer = () => {
+			if (timer) clearTimeout(timer);
+			timer = undefined;
+		};
+		const armTimer = () => {
+			if (!useTimer) return;
+			clearTimer();
+			timer = setTimeout(() => {
+				stream.destroy();
+				settle(() =>
+					reject(new UnexpectedError(`Response body timed out after ${timeout}ms without data`)),
+				);
+			}, timeout);
+			// Don't let the watchdog keep the event loop alive on its own.
+			timer.unref?.();
+		};
+
+		const onData = (chunk: Buffer) => {
+			chunks.push(chunk);
+			armTimer();
+		};
+		const onEnd = () => settle(() => resolve(Buffer.concat(chunks)));
+		const onError = (cause: Error & { code?: string }) =>
+			settle(() =>
+				reject(
+					cause.code === 'Z_DATA_ERROR'
+						? new UnexpectedError('Failed to decompress response', { cause })
+						: cause,
+				),
+			);
+		// A stream that closes without a clean 'end' (half-open socket, truncated
+		// body) emits 'close' but neither 'end' nor 'error'. Without this exit the
+		// promise would never settle and the caller would hang indefinitely.
+		const onClose = () =>
+			settle(() => reject(new UnexpectedError('Stream closed before completing')));
+
+		function settle(action: () => void) {
+			if (settled) return;
+			settled = true;
+			clearTimer();
+			stream.off('data', onData);
+			stream.off('end', onEnd);
+			stream.off('error', onError);
+			stream.off('close', onClose);
+			action();
+		}
+
+		stream.on('data', onData);
+		stream.once('end', onEnd);
+		stream.once('error', onError);
+		stream.once('close', onClose);
+		armTimer();
 	});
 }
 

--- a/packages/@n8n/config/src/configs/http-request.config.ts
+++ b/packages/@n8n/config/src/configs/http-request.config.ts
@@ -27,4 +27,12 @@ export class HttpRequestConfig {
 	 */
 	@Env('N8N_GLOBAL_USER_AGENT_VALUE')
 	globalUserAgentValue: string = '';
+
+	/**
+	 * Inactivity timeout (ms) for reading an HTTP response body, since the request
+	 * `timeout` only covers the response headers. Resets on each received chunk, so
+	 * it bounds a stalled body without interrupting a slow-but-progressing download.
+	 */
+	@Env('N8N_HTTP_RESPONSE_BODY_READ_TIMEOUT')
+	responseBodyReadTimeout: number = 300_000;
 }

--- a/packages/@n8n/config/test/config.test.ts
+++ b/packages/@n8n/config/test/config.test.ts
@@ -521,6 +521,7 @@ describe('GlobalConfig', () => {
 		httpRequest: {
 			enforceGlobalUserAgent: false,
 			globalUserAgentValue: '',
+			responseBodyReadTimeout: 300000,
 		},
 		redis: {
 			prefix: 'n8n',
@@ -667,6 +668,7 @@ describe('GlobalConfig', () => {
 			httpRequest: {
 				enforceGlobalUserAgent: true,
 				globalUserAgentValue: 'AcmeCorp/1.0',
+				responseBodyReadTimeout: 300000,
 			},
 		});
 		expect(readFileSyncMock).not.toHaveBeenCalled();

--- a/packages/core/src/execution-engine/node-execution-context/utils/__tests__/outbound-user-agent.integration.test.ts
+++ b/packages/core/src/execution-engine/node-execution-context/utils/__tests__/outbound-user-agent.integration.test.ts
@@ -30,6 +30,7 @@ describe('Outbound User-Agent (httpRequest integration)', () => {
 		Container.set(HttpRequestConfig, {
 			enforceGlobalUserAgent: false,
 			globalUserAgentValue: '',
+			responseBodyReadTimeout: 300_000,
 		});
 
 		const scope = nock(baseUrl, {
@@ -49,6 +50,7 @@ describe('Outbound User-Agent (httpRequest integration)', () => {
 		Container.set(HttpRequestConfig, {
 			enforceGlobalUserAgent: true,
 			globalUserAgentValue: '',
+			responseBodyReadTimeout: 300_000,
 		});
 
 		const scope = nock(baseUrl, {
@@ -70,6 +72,7 @@ describe('Outbound User-Agent (httpRequest integration)', () => {
 		Container.set(HttpRequestConfig, {
 			enforceGlobalUserAgent: true,
 			globalUserAgentValue: 'AcmeCorp/2.0',
+			responseBodyReadTimeout: 300_000,
 		});
 
 		const scope = nock(baseUrl, {
@@ -93,6 +96,7 @@ describe('Outbound User-Agent (httpRequest integration)', () => {
 		Container.set(HttpRequestConfig, {
 			enforceGlobalUserAgent: true,
 			globalUserAgentValue: '',
+			responseBodyReadTimeout: 300_000,
 		});
 		expect(getDefaultN8nOutboundUserAgent()).toMatch(
 			/^Mozilla\/5\.0 \(compatible; n8n\/.+; \+https:\/\/n8n\.io\/\)$/,
@@ -127,6 +131,7 @@ describe('Outbound User-Agent (proxyRequestToAxios integration)', () => {
 		Container.set(HttpRequestConfig, {
 			enforceGlobalUserAgent: false,
 			globalUserAgentValue: '',
+			responseBodyReadTimeout: 300_000,
 		});
 
 		const scope = nock(baseUrl, {
@@ -150,6 +155,7 @@ describe('Outbound User-Agent (proxyRequestToAxios integration)', () => {
 		Container.set(HttpRequestConfig, {
 			enforceGlobalUserAgent: true,
 			globalUserAgentValue: '',
+			responseBodyReadTimeout: 300_000,
 		});
 
 		const scope = nock(baseUrl, {
@@ -175,6 +181,7 @@ describe('Outbound User-Agent (proxyRequestToAxios integration)', () => {
 		Container.set(HttpRequestConfig, {
 			enforceGlobalUserAgent: true,
 			globalUserAgentValue: 'AcmeCorp/2.0',
+			responseBodyReadTimeout: 300_000,
 		});
 
 		const scope = nock(baseUrl, {
@@ -198,6 +205,7 @@ describe('Outbound User-Agent (proxyRequestToAxios integration)', () => {
 		Container.set(HttpRequestConfig, {
 			enforceGlobalUserAgent: true,
 			globalUserAgentValue: 'AcmeCorp/2.0',
+			responseBodyReadTimeout: 300_000,
 		});
 
 		const scope = nock(baseUrl, {


### PR DESCRIPTION
## Summary

When an HTTP response body never finishes streaming, `streamToBuffer` (which backs the HTTP Request node's body drain via `binaryToString`/`binaryToBuffer`) would wait forever. It only settled on the stream's `end` or `error` event, with no exit for:

- a stream that **closes without a clean `end`** (half-open socket, truncated body), or
- a stream that **never terminates** (keep-alive with an unsatisfied `Content-Length`, a stalled `zlib` decompression).

The result: the HTTP Request node sits in **Running** indefinitely. Node- and workflow-level **Timeouts don't help**, because a request `timeout` only covers up to receipt of the response headers — the body drain afterwards had no bound of its own. In queue mode each stuck execution permanently consumes a worker concurrency slot.

This PR bounds the body read in `streamToBuffer`:

- Adds an **inactivity timeout** that rides on the existing `data` listener — it resets on every chunk, so a slow-but-progressing download is never interrupted; only a stalled stream is aborted. On inactivity the stream is destroyed and the read rejects.
- Adds a **`close`-without-`end`** exit, so a truncated/half-open body rejects instead of hanging.
- The timeout is configurable via the new `HttpRequestConfig.responseBodyReadTimeout` (env `N8N_HTTP_RESPONSE_BODY_READ_TIMEOUT`), **default 5 minutes**.

Because the fix lives in the shared `streamToBuffer`, it covers both the error path (4xx/5xx) and the success path for all buffering consumers (text/JSON/autodetect/in-memory binary), regardless of status code or node config.

**Note:** the timeout is inactivity-based, not an absolute cap (a continuously-trickling stream is intentionally not capped, so legitimate large downloads aren't cut off). Filesystem/S3 binary mode that streams the body to disk via `pipe()` does not go through `streamToBuffer` and is not bounded by this timeout.

## How to test

1. Run the mock server below (reproduces a stalled forward-proxy response).
2. Start n8n with a short bound so you don't wait 5 minutes: `N8N_HTTP_RESPONSE_BODY_READ_TIMEOUT=5000 pnpm start`.
3. Add an **HTTP Request** node pointing at `http://127.0.0.1:7659/stall` (default Response Format = Autodetect uses the streaming path). Use `/stall-200` to exercise the success-code path.
4. **Before:** the node stays in *Running* indefinitely. **After:** it fails after ~5s instead of hanging.

<details>
<summary>Mock server (<code>node stall-server.mjs</code>)</summary>

```js
import { createServer } from 'node:http';

// Squid-style error page (small, complete).
const ERROR_HTML = '<html><body><h1>Access Denied</h1></body></html>\n';

const server = createServer((req, res) => {
  const url = (req.url ?? '/').split('?')[0];

  // Complete, well-formed response — settles correctly (control).
  if (url === '/ok') {
    const buf = Buffer.from(ERROR_HTML);
    res.writeHead(403, { 'content-type': 'text/html', 'content-length': String(buf.length) });
    res.end(buf);
    return;
  }

  // Declares a large Content-Length, sends only a fragment, then holds the
  // socket open forever -> the body stream never emits 'end'/'error'/'close'.
  // `/stall` = 403 (error path), `/stall-200` = 200 (success path).
  if (url === '/stall' || url === '/stall-200') {
    res.writeHead(url === '/stall-200' ? 200 : 403, {
      'content-type': 'text/html',
      'content-length': '100000',
    });
    res.write(ERROR_HTML); // far fewer than 100000 bytes
    return; // never res.end(), never destroy the socket
  }

  res.writeHead(404).end('unknown endpoint\n');
});

server.listen(7659, '127.0.0.1', () => {
  console.log('stall-server on http://127.0.0.1:7659  (endpoints: /stall /stall-200 /ok)');
});
```

</details>

Automated coverage:
- `packages/@n8n/backend-network` — unit tests for `streamToBuffer` (inactivity timeout, `close`-without-`end`, progressing stream not interrupted, config default).
- `packages/core` — integration tests driving `proxyRequestToAxios` against a real stalled HTTP server (error 4xx and success 2xx body-drain paths).

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/NODE-5231

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI