### PR TITLE
docs: Add installation guide for n8n Claude Code plugin

### DIFF
--- a/.claude/plugins/n8n/INSTALL.md
+++ b/.claude/plugins/n8n/INSTALL.md
@@ -1,0 +1,136 @@
+# Using the n8n Claude Code plugin in other projects
+
+## What this is
+
+The n8n team has a set of handy Claude Code skills (`n8n:linear-issue`, `n8n:create-pr`,
+`n8n:create-issue`, and more). They're packaged as a **plugin** that lives inside the n8n
+repo. By default these skills only work when you're inside the n8n repo — this guide
+shows how to use them in *any* project.
+
+> Everything is namespaced with an `n8n:` prefix — so you call skills like `n8n:create-pr`,
+> commands like `/n8n:plan`, and agents like `n8n:developer`. That prefix is the whole reason
+> these ship as a plugin (it avoids clashes with your personal or other plugins' skills).
+
+## How it works (the one thing to know)
+
+The plugin isn't downloaded from the internet. It lives in a folder inside the n8n repo:
+
+```
+.claude/plugins/n8n
+```
+
+So "installing it" really means: point Claude Code at that folder, on an up-to-date copy
+of the repo. Once you do that, the skills follow you into every project.
+
+---
+
+## Step 1 — Keep an up-to-date copy of the repo on disk
+
+The plugin folder needs to be on the latest `master`. The easiest way is a **worktree** —
+a second copy of the repo locked to `master`, so you never have to switch branches in your
+main checkout.
+
+Run this once:
+
+```bash
+git -C ~/Projects/n8n worktree add ~/Projects/n8n-master master
+```
+
+Now the latest plugin always lives at:
+
+```
+~/Projects/n8n-master/.claude/plugins/n8n
+```
+
+> **Heads up — symlinks.** Most of the plugin's skills are symlinks to `.agents/skills/` in the
+> same repo. A worktree includes that folder, so the links resolve fine. The only place this bites
+> is **Windows**: check out with symlinks enabled (`git config core.symlinks true` + Developer Mode
+> or WSL), or git writes the links as broken text stubs.
+
+## Step 2 — Tell Claude Code about it
+
+First, register the marketplace (do this once, in any Claude Code session):
+
+```
+/plugin marketplace add ~/Projects/n8n-master/.claude/plugins/n8n
+```
+
+Then install the plugin. Here's where you choose **how widely** you want it — pick one:
+
+### Option A — Globally (available in every project)
+
+This is the usual choice. Run:
+
+```
+/plugin install n8n@n8n
+```
+
+When it asks where to install, pick **user**. That makes the n8n skills available no matter
+which repo you open — you only do this once.
+
+### Option B — Only in one specific repo
+
+Use this if you want the skills in just one other project (for example, to keep it committed
+and shared with that project's teammates). Open Claude Code **inside that repo**, then run:
+
+```
+/plugin install n8n@n8n
+```
+
+When it asks where to install, pick **project**. The plugin is now active only in that repo.
+Repeat per repo if you want it in several.
+
+> **In short:** `user` = everywhere, just for you · `project` = this one repo, shareable with the team.
+
+After either option, restart Claude Code (or run `/plugin` and reload).
+
+## Step 3 — Check it worked
+
+```
+/help
+```
+
+You should see the n8n skills in the list (look for the `n8n:` prefix). Try `n8n:create-pr` to confirm.
+
+---
+
+## Keeping it fresh
+
+When the team updates the skills, refresh your copy:
+
+```bash
+git -C ~/Projects/n8n-master pull --ff-only origin master
+```
+
+Then in Claude Code:
+
+```
+/plugin marketplace update n8n
+```
+
+> **Seeing only one skill, or things look broken?**
+> That just means your copy of the repo is out of date. Run the two commands above to
+> update it — nothing is actually broken.
+
+---
+
+## Removing it
+
+```
+/plugin uninstall n8n@n8n
+```
+
+---
+
+## Quick reference
+
+| I want to… | Command |
+|---|---|
+| Set up the repo copy (once) | `git -C ~/Projects/n8n worktree add ~/Projects/n8n-master master` |
+| Register the marketplace (once) | `/plugin marketplace add ~/Projects/n8n-master/.claude/plugins/n8n` |
+| Add it **globally** (every project) | `/plugin install n8n@n8n` → pick **user** |
+| Add it **to one repo** | open that repo, `/plugin install n8n@n8n` → pick **project** |
+| Update it | `git -C ~/Projects/n8n-master pull --ff-only origin master` then `/plugin marketplace update n8n` |
+| Check it's installed | `/help` (look for `n8n:` skills) |
+| Remove it | `/plugin uninstall n8n@n8n` |
+

--- a/.claude/plugins/n8n/INSTALL.md
+++ b/.claude/plugins/n8n/INSTALL.md
@@ -1,63 +1,86 @@
 # Using the n8n Claude Code plugin in other projects
 
-## What this is
+We have a set of Claude Code skills (`n8n:human-like-code-review`, `n8n:create-pr`,
+`n8n:reproduce-bug`, and more). Inside the n8n repo, the plugin is picked up automatically.
+This guide shows how to use the plugin in other projects.
+See [plugin README](README.md) for full details.
 
-The n8n team has a set of handy Claude Code skills (`n8n:linear-issue`, `n8n:create-pr`,
-`n8n:create-issue`, and more). They're packaged as a **plugin** that lives inside the n8n
-repo. By default these skills only work when you're inside the n8n repo — this guide
-shows how to use them in *any* project.
-
-> Everything is namespaced with an `n8n:` prefix — so you call skills like `n8n:create-pr`,
-> commands like `/n8n:plan`, and agents like `n8n:developer`. That prefix is the whole reason
+> Everything is namespaced with an `n8n:` prefix — so you call skills like `/n8n:human-like-code-review`,
+> commands like `/n8n:plan`, and agents like `n8n:developer`. That prefix is the reason
 > these ship as a plugin (it avoids clashes with your personal or other plugins' skills).
 
-## How it works (the one thing to know)
+## How it works
 
-The plugin isn't downloaded from the internet. It lives in a folder inside the n8n repo:
+The plugin isn't published to Claude's public marketplace. You register a **local** copy
+from an n8n repo checkout.
 
-```
-.claude/plugins/n8n
-```
-
-So "installing it" really means: point Claude Code at that folder, on an up-to-date copy
-of the repo. Once you do that, the skills follow you into every project.
+"Installing" it means pointing Claude Code at `.claude/plugins/n8n` inside that checkout.
+The plugin folder must stay inside a full n8n repo — skills symlink to `.agents/skills/`.
 
 ---
 
-## Step 1 — Keep an up-to-date copy of the repo on disk
+## Step 1 — Choose a plugin source
 
-The plugin folder needs to be on the latest `master`. The easiest way is a **worktree** —
-a second copy of the repo locked to `master`, so you never have to switch branches in your
-main checkout.
+Pick where Claude Code should read the plugin from.
 
-Run this once:
+### Option A — Use your existing checkout (usual for n8n contributors)
 
-```bash
-git -C ~/Projects/n8n worktree add ~/Projects/n8n-master master
+If you already have the n8n repo on disk, point at the plugin folder there:
+
+```
+<your-n8n-checkout>/.claude/plugins/n8n
 ```
 
-Now the latest plugin always lives at:
+For example:
+
+```
+~/Projects/n8n/.superset/n8n/foul-skate/.claude/plugins/n8n
+```
+
+Skills follow whatever branch that checkout is on. Pull or rebase when you want updates.
+
+### Option B — Dedicated checkout on `master` (optional)
+
+Use this when you want a stable plugin source that always tracks team `master`, without
+switching branches in your main working copy.
+
+Clone the repo (or add a worktree):
+
+```bash
+git clone https://github.com/n8n-io/n8n.git ~/Projects/n8n-master
+# or, from an existing clone:
+# git worktree add ~/Projects/n8n-master master
+```
+
+Plugin path:
 
 ```
 ~/Projects/n8n-master/.claude/plugins/n8n
 ```
 
-> **Heads up — symlinks.** Most of the plugin's skills are symlinks to `.agents/skills/` in the
-> same repo. A worktree includes that folder, so the links resolve fine. The only place this bites
-> is **Windows**: check out with symlinks enabled (`git config core.symlinks true` + Developer Mode
-> or WSL), or git writes the links as broken text stubs.
+Replace with your path.
 
-## Step 2 — Tell Claude Code about it
+> **Windows:** enable [Developer Mode](https://learn.microsoft.com/en-us/windows/advanced-settings/developer-mode#enable-developer-mode) and symlinks (`git config --global core.symlinks true`) before checkout — otherwise skill symlinks become plain-text stubs and Claude Code cannot load them.
 
-First, register the marketplace (do this once, in any Claude Code session):
+---
+
+## Step 2 — Install
+
+Register the marketplace in Claude Code (use the path from Step 1):
+
+```
+/plugin marketplace add <path-to>/.claude/plugins/n8n
+```
+
+Example with a dedicated checkout:
 
 ```
 /plugin marketplace add ~/Projects/n8n-master/.claude/plugins/n8n
 ```
 
-Then install the plugin. Here's where you choose **how widely** you want it — pick one:
+Then install the plugin. You can choose where it should be available.
 
-### Option A — Globally (available in every project)
+### Globally (available in every project)
 
 This is the usual choice. Run:
 
@@ -65,41 +88,44 @@ This is the usual choice. Run:
 /plugin install n8n@n8n
 ```
 
-When it asks where to install, pick **user**. That makes the n8n skills available no matter
-which repo you open — you only do this once.
+When it asks where to install, pick **user**. That makes the n8n skills available no matter which repo you open — you only do this once.
 
-### Option B — Only in one specific repo
+### Only in one specific repo
 
-Use this if you want the skills in just one other project (for example, to keep it committed
-and shared with that project's teammates). Open Claude Code **inside that repo**, then run:
+Open Claude Code **inside that repo**, then run:
 
 ```
 /plugin install n8n@n8n
 ```
 
-When it asks where to install, pick **project**. The plugin is now active only in that repo.
-Repeat per repo if you want it in several.
-
-> **In short:** `user` = everywhere, just for you · `project` = this one repo, shareable with the team.
+When it asks where to install, pick **project**. Repeat per repo if you want it in several.
 
 After either option, restart Claude Code (or run `/plugin` and reload).
 
-## Step 3 — Check it worked
+## Step 3 — Verify
+
+In Claude Code:
 
 ```
 /help
 ```
 
-You should see the n8n skills in the list (look for the `n8n:` prefix). Try `n8n:create-pr` to confirm.
+You should see the n8n skills in the list (look for the `n8n:` prefix). Try `/n8n:human-like-code-review` to confirm.
 
 ---
 
-## Keeping it fresh
+## Keeping it up-to-date
 
-When the team updates the skills, refresh your copy:
+Refresh the checkout you registered in Step 1, then reload the plugin in Claude Code.
 
 ```bash
-git -C ~/Projects/n8n-master pull --ff-only origin master
+git -C <your-n8n-checkout> pull
+```
+
+For a dedicated `master` checkout:
+
+```bash
+git -C ~/Projects/n8n-master pull origin master
 ```
 
 Then in Claude Code:
@@ -108,9 +134,9 @@ Then in Claude Code:
 /plugin marketplace update n8n
 ```
 
-> **Seeing only one skill, or things look broken?**
-> That just means your copy of the repo is out of date. Run the two commands above to
-> update it — nothing is actually broken.
+> **Seeing only one skill, or things look broken?** Your checkout may be behind, or skill
+> symlinks may be broken. Pull the latest changes and run
+> `node scripts/sync-agent-skill-links.mjs --check` from the repo root.
 
 ---
 
@@ -119,18 +145,3 @@ Then in Claude Code:
 ```
 /plugin uninstall n8n@n8n
 ```
-
----
-
-## Quick reference
-
-| I want to… | Command |
-|---|---|
-| Set up the repo copy (once) | `git -C ~/Projects/n8n worktree add ~/Projects/n8n-master master` |
-| Register the marketplace (once) | `/plugin marketplace add ~/Projects/n8n-master/.claude/plugins/n8n` |
-| Add it **globally** (every project) | `/plugin install n8n@n8n` → pick **user** |
-| Add it **to one repo** | open that repo, `/plugin install n8n@n8n` → pick **project** |
-| Update it | `git -C ~/Projects/n8n-master pull --ff-only origin master` then `/plugin marketplace update n8n` |
-| Check it's installed | `/help` (look for `n8n:` skills) |
-| Remove it | `/plugin uninstall n8n@n8n` |
-

--- a/.claude/plugins/n8n/README.md
+++ b/.claude/plugins/n8n/README.md
@@ -4,6 +4,8 @@ Shared commands and agents for n8n development, plus Claude Code skill links.
 All plugin items are namespaced under `n8n:` to avoid collisions with personal
 or third-party plugins.
 
+To use the plugin in outside the n8n repository, see [INSTALL.md](INSTALL.md).
+
 ## Usage
 
 Skills, commands, and agents are auto-discovered by Claude Code from this


### PR DESCRIPTION
## Summary

This adds a guide on how to install the n8n Claude plugin for usage it in other repos (n8n-private, or other projects).


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32412">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->