### PR TITLE
fix(instance-ai): keep system prompt cacheable by coarsening timestamp

### DIFF
--- a/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.test.ts
@@ -1,6 +1,57 @@
-import { getSystemPrompt } from '../system-prompt';
+import { getDateTimeSection, getSystemPrompt } from '../system-prompt';
+
+describe('getDateTimeSection', () => {
+	// This section is emitted at the head of the `cacheControl: ephemeral` system prompt
+	// (both the orchestrator and every sub-agent). If it carries a volatile, sub-hour
+	// timestamp the cached prefix changes on every request, so the large system block is
+	// re-written instead of read from the Anthropic prompt cache on every turn.
+	// These tests pin the section to a stable, hour-coarsened granularity.
+
+	it('does not embed a millisecond- or second-precision timestamp', () => {
+		const section = getDateTimeSection('Europe/Helsinki');
+
+		// No fractional seconds (e.g. ".123") and no non-zero seconds/minutes component.
+		expect(section).not.toMatch(/\d{2}:\d{2}:\d{2}\.\d{3}/); // HH:MM:SS.mmm
+		expect(section).not.toMatch(/T\d{2}:\d{2}:\d{2}/); // HH:MM:SS
+		// Time-of-day must be coarsened to the top of the hour: HH:00.
+		expect(section).toMatch(/T\d{2}:00/);
+	});
+
+	it('is stable across calls within the same hour', () => {
+		// Two back-to-back calls separated by real time must produce identical output,
+		// otherwise the cache prefix would be invalidated between requests.
+		const first = getDateTimeSection('Europe/Helsinki');
+		const second = getDateTimeSection('Europe/Helsinki');
+
+		expect(first).toBe(second);
+	});
+
+	it('still tells the model the value is approximate / rounded', () => {
+		const section = getDateTimeSection();
+
+		expect(section).toContain('## Current Date and Time');
+		expect(section).toContain('rounded to the hour');
+		expect(section).toContain('use this date and time');
+	});
+});
 
 describe('getSystemPrompt', () => {
+	describe('cache-prefix stability', () => {
+		it('does not place a volatile sub-hour timestamp in the cached system prompt', () => {
+			const prompt = getSystemPrompt({ timeZone: 'Europe/Helsinki' });
+
+			expect(prompt).not.toMatch(/T\d{2}:\d{2}:\d{2}/); // no HH:MM:SS
+			expect(prompt).not.toMatch(/\d{2}:\d{2}:\d{2}\.\d{3}/); // no millis
+		});
+
+		it('produces an identical prompt across back-to-back builds within the hour', () => {
+			const a = getSystemPrompt({ timeZone: 'Europe/Helsinki' });
+			const b = getSystemPrompt({ timeZone: 'Europe/Helsinki' });
+
+			expect(a).toBe(b);
+		});
+	});
+
 	describe('first visible turn guidance', () => {
 		it('instructs the agent to send a concise sentence before the first tool call', () => {
 			const prompt = getSystemPrompt({});

--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -24,12 +24,18 @@ interface SystemPromptOptions {
 
 export function getDateTimeSection(timeZone?: string): string {
 	const now = timeZone ? DateTime.now().setZone(timeZone) : DateTime.now();
-	const isoTime = now.toISO({ includeOffset: true });
+	// Coarsen to hour granularity (drop minutes/seconds/ms) so this section — which
+	// sits at the head of the `cacheControl: ephemeral` system prompt — stays stable
+	// across requests within the same hour. A millisecond-precise timestamp here would
+	// change on every turn, invalidating the prompt-cache prefix and forcing a full
+	// re-write of the large cached system block on every instance-AI request.
+	const coarseTime = now.startOf('hour');
+	const isoTime = coarseTime.toISO({ includeOffset: true, suppressSeconds: true });
 	const tzLabel = timeZone ? ` (timezone: ${timeZone})` : '';
 	return `
 ## Current Date and Time
 
-The user's current local date and time is: ${isoTime}${tzLabel}.
+The user's current local date and time is approximately: ${isoTime}${tzLabel} (rounded to the hour).
 When you need to reference "now", use this date and time.`;
 }
 


### PR DESCRIPTION
## Summary

`@n8n/instance-ai` attaches its system prompt with `providerOptions.anthropic.cacheControl.type = 'ephemeral'` (`instance-agent.ts:151-155`, and the sub-agent equivalent at `sub-agent-factory.ts:82-86`). Anthropic's prompt cache matches on a **prefix**, but the very first dynamic block of that prompt is a millisecond-precision timestamp:

```ts
// system-prompt.ts (before)
const isoTime = now.toISO({ includeOffset: true }); // e.g. 2026-06-16T19:42:07.913+03:00
```

…rendered at the head of `getSystemPrompt` (`system-prompt.ts:124`). The agent is rebuilt per run/turn, so this value changes every request, invalidating the cache prefix. The result: the large system block is a cache **write-every-turn / read-never** — full input-token price paid on every turn instead of the discounted cache-read price. This is a default-on path, so it affects every Instance-AI / AI Assistant user.

The fix coarsens `getDateTimeSection` to hour granularity (date + hour + offset, no minutes/seconds/ms) so the cached prefix is stable across all requests within the same hour. The section now reads "approximately: `2026-06-16T19:00+03:00` (rounded to the hour)", which still gives the model an accurate "now" for relative-date reasoning. One function change fixes both the orchestrator (`system-prompt.ts`) and every delegated sub-agent (`sub-agent-factory.ts`, which imports the same helper).

No public API or schema change. No `any`/`as` introduced.

**Alternative considered:** moving the timestamp out of the system prompt onto the last user message. Rejected for this minimal patch because the orchestrator user message is assembled in `packages/cli` (outside this package) and sub-agents have no user-message channel (their task is baked into the cached `instructions`). Coarsening fixes both paths in one place; happy to do the larger move-out if preferred.

## How to test

No user-facing workflow change. To verify the cache-prefix stability:

1. From `packages/@n8n/instance-ai`, run the unit tests:
   ```bash
   pnpm test src/agent/__tests__/system-prompt.test.ts
   ```
   The new `getDateTimeSection` / `getSystemPrompt > cache-prefix stability` cases assert the prompt contains no `HH:MM:SS` (or millisecond) timestamp and that two back-to-back builds produce byte-identical output.
2. Optional manual check: instrument an Instance-AI request against the Anthropic API and confirm `cache_read_input_tokens` is now non-zero on the second+ turn of a thread (previously it stayed at 0 because the prefix changed each turn).

## Related Linear tickets, Github issues, and Community forum posts

N/A — no linked Linear ticket or GitHub issue. Per `AGENTS.md`, external contributors are asked not to self-create Linear tickets; happy to have one assigned and linked here.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. — N/A (no docs cover this internal prompt detail)
- [x] Tests included. — `packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.test.ts`
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported) — maintainer discretion; this is a cost / no-behaviour-change fix.


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32414">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

