### PR TITLE
fix(editor): Dismiss what's new call out on load (no-changelog)

### DIFF
--- a/packages/frontend/editor-ui/src/app/stores/versions.store.test.ts
+++ b/packages/frontend/editor-ui/src/app/stores/versions.store.test.ts
@@ -17,10 +17,12 @@ vi.mock('vue-router', async (importOriginal) => ({
 
 vi.mock('@/app/composables/useToast', () => {
 	const showToast = vi.fn();
+	const showMessage = vi.fn();
 	return {
 		useToast: () => {
 			return {
 				showToast,
+				showMessage,
 			};
 		},
 	};
@@ -137,6 +139,27 @@ describe('versions.store', () => {
 			);
 
 			expect(versionsStore.whatsNewArticles).toEqual([whatsNewArticle]);
+		});
+
+		it('should dismiss the callout as soon as it is shown', async () => {
+			vi.spyOn(versionsApi, 'getWhatsNewSection').mockResolvedValue(whatsNew);
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			vi.mocked(useUsersStore).mockReturnValue({ currentUser: null } as any);
+
+			const rootStore = useRootStore();
+			rootStore.setVersionCli(currentVersionName);
+			rootStore.setInstanceId(instanceId);
+
+			const versionsStore = useVersionsStore();
+			versionsStore.initialize(settings);
+
+			await versionsStore.fetchWhatsNew();
+
+			// The callout has been shown ...
+			expect(toast.showMessage).toHaveBeenCalled();
+			// ... and is immediately marked as dismissed so it does not reappear on the
+			// next load, even though the user never explicitly closed it.
+			expect(versionsStore.shouldShowWhatsNewCallout()).toBe(false);
 		});
 
 		it("should not fetch What's new articles if version notifications are disabled", async () => {

--- a/packages/frontend/editor-ui/src/app/stores/versions.store.ts
+++ b/packages/frontend/editor-ui/src/app/stores/versions.store.ts
@@ -218,10 +218,11 @@ export const useVersionsStore = defineStore(STORES.VERSIONS, () => {
 									data: { articleId },
 								});
 							},
-							onClose: () => {
-								dismissWhatsNewCallout();
-							},
 						});
+
+						// Mark the callout as dismissed as soon as it is shown, so it does not
+						// keep reappearing on subsequent loads for users who simply ignore it.
+						dismissWhatsNewCallout();
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
The What's New callout was only persisted as dismissed via its onClose handler, so users who ignored the callout (without clicking or closing it) would see it reappear on every load. Mark it dismissed as soon as it is shown so it no longer reappears for users who simply ignore it.

https://claude.ai/code/session_01J9G28PzBY6TPAArASimvtz

## How to test
1. Open n8n with a what's new notification unread
2. Don't click it
3. Reload n8n -> the notification should be gone
4. Add a new entry that is newer -> The notification should show again
5. Remove the localStorage entry -> the notification should be back after reload

## Related Linear tickets, Github issues, and Community forum posts
https://n8nio.slack.com/archives/C035PCSN74K/p1781598301952679

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [X] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [X] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32415">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->