### PR TITLE
fix(Telegram Trigger Node): Apply chat/user ID filters to all update types

### DIFF
--- a/packages/nodes-base/nodes/Telegram/IEvent.ts
+++ b/packages/nodes-base/nodes/Telegram/IEvent.ts
@@ -18,8 +18,27 @@ interface EventBody {
 	};
 }
 
+interface CallbackQuery {
+	from?: {
+		id: number;
+	};
+	message?: EventBody;
+}
+
+interface QueryWithFrom {
+	from?: {
+		id: number;
+	};
+}
+
 export interface IEvent {
 	message?: EventBody;
+	edited_message?: EventBody;
 	channel_post?: EventBody;
+	edited_channel_post?: EventBody;
+	callback_query?: CallbackQuery;
+	inline_query?: QueryWithFrom;
+	pre_checkout_query?: QueryWithFrom;
+	shipping_query?: QueryWithFrom;
 	download_link?: string;
 }

--- a/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
+++ b/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
@@ -19,8 +19,8 @@ export class TelegramTrigger implements INodeType {
 		name: 'telegramTrigger',
 		icon: 'file:telegram.svg',
 		group: ['trigger'],
-		version: [1, 1.1, 1.2, 1.3],
-		defaultVersion: 1.3,
+		version: [1, 1.1, 1.2, 1.3, 1.4],
+		defaultVersion: 1.4,
 		subtitle: '=Updates: {{$parameter["updates"].join(", ")}}',
 		description: 'Starts the workflow on a Telegram update',
 		defaults: {
@@ -291,12 +291,16 @@ export class TelegramTrigger implements INodeType {
 			if (additionalFields.chatIds) {
 				const chatIds = additionalFields.chatIds as string;
 				const splitIds = chatIds.split(',').map((chatId) => chatId.trim());
+				// Versions < 1.4 only resolve the chat ID from `message` updates; later
+				// versions resolve it from every update type that carries a chat.
 				const chatId =
-					bodyData.message?.chat?.id ??
-					bodyData.edited_message?.chat?.id ??
-					bodyData.channel_post?.chat?.id ??
-					bodyData.edited_channel_post?.chat?.id ??
-					bodyData.callback_query?.message?.chat?.id;
+					nodeVersion >= 1.4
+						? (bodyData.message?.chat?.id ??
+							bodyData.edited_message?.chat?.id ??
+							bodyData.channel_post?.chat?.id ??
+							bodyData.edited_channel_post?.chat?.id ??
+							bodyData.callback_query?.message?.chat?.id)
+						: bodyData.message?.chat?.id;
 				if (!splitIds.includes(String(chatId))) {
 					return {};
 				}
@@ -305,15 +309,19 @@ export class TelegramTrigger implements INodeType {
 			if (additionalFields.userIds) {
 				const userIds = additionalFields.userIds as string;
 				const splitIds = userIds.split(',').map((userId) => userId.trim());
+				// Versions < 1.4 only resolve the user ID from `message` updates; later
+				// versions resolve it from every update type that carries a sender.
 				const userId =
-					bodyData.message?.from?.id ??
-					bodyData.edited_message?.from?.id ??
-					bodyData.channel_post?.from?.id ??
-					bodyData.edited_channel_post?.from?.id ??
-					bodyData.callback_query?.from?.id ??
-					bodyData.inline_query?.from?.id ??
-					bodyData.pre_checkout_query?.from?.id ??
-					bodyData.shipping_query?.from?.id;
+					nodeVersion >= 1.4
+						? (bodyData.message?.from?.id ??
+							bodyData.edited_message?.from?.id ??
+							bodyData.channel_post?.from?.id ??
+							bodyData.edited_channel_post?.from?.id ??
+							bodyData.callback_query?.from?.id ??
+							bodyData.inline_query?.from?.id ??
+							bodyData.pre_checkout_query?.from?.id ??
+							bodyData.shipping_query?.from?.id)
+						: bodyData.message?.from?.id;
 				if (!splitIds.includes(String(userId))) {
 					return {};
 				}

--- a/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
+++ b/packages/nodes-base/nodes/Telegram/TelegramTrigger.node.ts
@@ -291,7 +291,13 @@ export class TelegramTrigger implements INodeType {
 			if (additionalFields.chatIds) {
 				const chatIds = additionalFields.chatIds as string;
 				const splitIds = chatIds.split(',').map((chatId) => chatId.trim());
-				if (!splitIds.includes(String(bodyData.message?.chat?.id))) {
+				const chatId =
+					bodyData.message?.chat?.id ??
+					bodyData.edited_message?.chat?.id ??
+					bodyData.channel_post?.chat?.id ??
+					bodyData.edited_channel_post?.chat?.id ??
+					bodyData.callback_query?.message?.chat?.id;
+				if (!splitIds.includes(String(chatId))) {
 					return {};
 				}
 			}
@@ -299,7 +305,16 @@ export class TelegramTrigger implements INodeType {
 			if (additionalFields.userIds) {
 				const userIds = additionalFields.userIds as string;
 				const splitIds = userIds.split(',').map((userId) => userId.trim());
-				if (!splitIds.includes(String(bodyData.message?.from?.id))) {
+				const userId =
+					bodyData.message?.from?.id ??
+					bodyData.edited_message?.from?.id ??
+					bodyData.channel_post?.from?.id ??
+					bodyData.edited_channel_post?.from?.id ??
+					bodyData.callback_query?.from?.id ??
+					bodyData.inline_query?.from?.id ??
+					bodyData.pre_checkout_query?.from?.id ??
+					bodyData.shipping_query?.from?.id;
+				if (!splitIds.includes(String(userId))) {
 					return {};
 				}
 			}

--- a/packages/nodes-base/nodes/Telegram/tests/TelegramTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/TelegramTrigger.node.test.ts
@@ -174,6 +174,221 @@ describe('TelegramTrigger', () => {
 
 			expect(responseData).toEqual({ workflowData: [[{ json: mockResult }]] });
 		});
+
+		test('should pass chatIds filter for callback_query events', async () => {
+			mockResult.callback_query = {
+				from: { id: 777 },
+				message: {
+					chat: { id: 555 },
+					from: { id: 123 },
+				},
+			};
+
+			const { responseData } = await testWebhookTriggerNode(TelegramTrigger, {
+				workflow: mock<Workflow>({ id: '1', active: true }),
+				node: mock<INode>({
+					id: '2',
+					parameters: {
+						additionalFields: {
+							download: false,
+							chatIds: '555',
+						},
+					},
+				}),
+				headerData: {
+					'x-telegram-bot-api-secret-token': '1_2',
+				},
+				bodyData: {
+					callback_query: {
+						from: { id: 777 },
+						message: {
+							chat: { id: 555 },
+							from: { id: 123 },
+						},
+					},
+				},
+			});
+
+			expect(responseData).toEqual({ workflowData: [[{ json: mockResult }]] });
+		});
+
+		test('should pass userIds filter for callback_query events', async () => {
+			mockResult.callback_query = {
+				from: { id: 777 },
+				message: {
+					chat: { id: 555 },
+					from: { id: 123 },
+				},
+			};
+
+			const { responseData } = await testWebhookTriggerNode(TelegramTrigger, {
+				workflow: mock<Workflow>({ id: '1', active: true }),
+				node: mock<INode>({
+					id: '2',
+					parameters: {
+						additionalFields: {
+							download: false,
+							userIds: '777',
+						},
+					},
+				}),
+				headerData: {
+					'x-telegram-bot-api-secret-token': '1_2',
+				},
+				bodyData: {
+					callback_query: {
+						from: { id: 777 },
+						message: {
+							chat: { id: 555 },
+							from: { id: 123 },
+						},
+					},
+				},
+			});
+
+			expect(responseData).toEqual({ workflowData: [[{ json: mockResult }]] });
+		});
+
+		test('should reject callback_query when chatId does not match', async () => {
+			const { responseData } = await testWebhookTriggerNode(TelegramTrigger, {
+				workflow: mock<Workflow>({ id: '1', active: true }),
+				node: mock<INode>({
+					id: '2',
+					parameters: {
+						additionalFields: {
+							download: false,
+							chatIds: '999',
+						},
+					},
+				}),
+				headerData: {
+					'x-telegram-bot-api-secret-token': '1_2',
+				},
+				bodyData: {
+					callback_query: {
+						from: { id: 777 },
+						message: {
+							chat: { id: 555 },
+							from: { id: 123 },
+						},
+					},
+				},
+			});
+
+			expect(responseData).toEqual({});
+		});
+
+		test('should pass chatIds filter for edited_message events', async () => {
+			mockResult.edited_message = {
+				chat: { id: 555 },
+				from: { id: 666 },
+			};
+
+			const { responseData } = await testWebhookTriggerNode(TelegramTrigger, {
+				workflow: mock<Workflow>({ id: '1', active: true }),
+				node: mock<INode>({
+					id: '2',
+					parameters: {
+						additionalFields: {
+							download: false,
+							chatIds: '555',
+						},
+					},
+				}),
+				headerData: {
+					'x-telegram-bot-api-secret-token': '1_2',
+				},
+				bodyData: {
+					edited_message: {
+						chat: { id: 555 },
+						from: { id: 666 },
+					},
+				},
+			});
+
+			expect(responseData).toEqual({ workflowData: [[{ json: mockResult }]] });
+		});
+
+		test('should pass chatIds filter for channel_post events', async () => {
+			mockResult.channel_post = {
+				chat: { id: 555 },
+				from: { id: 666 },
+			};
+
+			const { responseData } = await testWebhookTriggerNode(TelegramTrigger, {
+				workflow: mock<Workflow>({ id: '1', active: true }),
+				node: mock<INode>({
+					id: '2',
+					parameters: {
+						additionalFields: {
+							download: false,
+							chatIds: '555',
+						},
+					},
+				}),
+				headerData: {
+					'x-telegram-bot-api-secret-token': '1_2',
+				},
+				bodyData: {
+					channel_post: {
+						chat: { id: 555 },
+						from: { id: 666 },
+					},
+				},
+			});
+
+			expect(responseData).toEqual({ workflowData: [[{ json: mockResult }]] });
+		});
+
+		test('should reject events without a resolvable chat ID when chatIds filter is active', async () => {
+			const { responseData } = await testWebhookTriggerNode(TelegramTrigger, {
+				workflow: mock<Workflow>({ id: '1', active: true }),
+				node: mock<INode>({
+					id: '2',
+					parameters: {
+						additionalFields: {
+							download: false,
+							chatIds: '555',
+						},
+					},
+				}),
+				headerData: {
+					'x-telegram-bot-api-secret-token': '1_2',
+				},
+				bodyData: {
+					inline_query: {
+						from: { id: 777 },
+					},
+				},
+			});
+
+			expect(responseData).toEqual({});
+		});
+
+		test('should reject events without a resolvable user ID when userIds filter is active', async () => {
+			const { responseData } = await testWebhookTriggerNode(TelegramTrigger, {
+				workflow: mock<Workflow>({ id: '1', active: true }),
+				node: mock<INode>({
+					id: '2',
+					parameters: {
+						additionalFields: {
+							download: false,
+							userIds: '777',
+						},
+					},
+				}),
+				headerData: {
+					'x-telegram-bot-api-secret-token': '1_2',
+				},
+				bodyData: {
+					poll: {
+						id: 'poll1',
+					},
+				},
+			});
+
+			expect(responseData).toEqual({});
+		});
 	});
 
 	describe('create', () => {

--- a/packages/nodes-base/nodes/Telegram/tests/TelegramTrigger.node.test.ts
+++ b/packages/nodes-base/nodes/Telegram/tests/TelegramTrigger.node.test.ts
@@ -389,6 +389,101 @@ describe('TelegramTrigger', () => {
 
 			expect(responseData).toEqual({});
 		});
+
+		describe('version 1.3 (legacy filter resolution)', () => {
+			test('should drop callback_query when chatIds filter is set, matching only message updates', async () => {
+				const { responseData } = await testWebhookTriggerNode(TelegramTrigger, {
+					workflow: mock<Workflow>({ id: '1', active: true }),
+					node: mock<INode>({
+						id: '2',
+						typeVersion: 1.3,
+						parameters: {
+							additionalFields: {
+								download: false,
+								chatIds: '555',
+							},
+						},
+					}),
+					headerData: {
+						'x-telegram-bot-api-secret-token': '1_2',
+					},
+					bodyData: {
+						callback_query: {
+							from: { id: 777 },
+							message: {
+								chat: { id: 555 },
+								from: { id: 123 },
+							},
+						},
+					},
+				});
+
+				expect(responseData).toEqual({});
+			});
+
+			test('should drop callback_query when userIds filter is set, matching only message updates', async () => {
+				const { responseData } = await testWebhookTriggerNode(TelegramTrigger, {
+					workflow: mock<Workflow>({ id: '1', active: true }),
+					node: mock<INode>({
+						id: '2',
+						typeVersion: 1.3,
+						parameters: {
+							additionalFields: {
+								download: false,
+								userIds: '777',
+							},
+						},
+					}),
+					headerData: {
+						'x-telegram-bot-api-secret-token': '1_2',
+					},
+					bodyData: {
+						callback_query: {
+							from: { id: 777 },
+							message: {
+								chat: { id: 555 },
+								from: { id: 123 },
+							},
+						},
+					},
+				});
+
+				expect(responseData).toEqual({});
+			});
+
+			test('should still pass message updates matching the chatIds filter', async () => {
+				mockResult.message = {
+					chat: { id: 555 },
+					from: { id: 666 },
+				};
+
+				const { responseData } = await testWebhookTriggerNode(TelegramTrigger, {
+					workflow: mock<Workflow>({ id: '1', active: true }),
+					node: mock<INode>({
+						id: '2',
+						typeVersion: 1.3,
+						parameters: {
+							additionalFields: {
+								download: false,
+								chatIds: '555',
+								userIds: '666',
+							},
+						},
+					}),
+					headerData: {
+						'x-telegram-bot-api-secret-token': '1_2',
+					},
+					bodyData: {
+						message: {
+							chat: { id: 555 },
+							from: { id: 666 },
+						},
+					},
+				});
+
+				expect(responseData).toEqual({ workflowData: [[{ json: mockResult }]] });
+			});
+		});
 	});
 
 	describe('create', () => {


### PR DESCRIPTION
## Summary

The **Restrict to Chat IDs** and **Restrict to User IDs** filters in the Telegram Trigger node only read `bodyData.message`, so any non-message update (e.g. a `callback_query` from an inline keyboard click, `edited_message`, `channel_post`) was dropped even when it originated from an allowed chat/user.

This PR resolves the chat and user IDs from every relevant Telegram update type via nullish coalescing, so the filters apply consistently across all update types.

The filters **fail closed**: when an update type has no resolvable chat/user ID, the configured restriction still rejects it rather than letting it bypass the filter.

Changes:
- `IEvent.ts` — extend the interface with the additional update types (`edited_message`, `edited_channel_post`, `callback_query`, `inline_query`, `pre_checkout_query`, `shipping_query`).
- `TelegramTrigger.node.ts` — resolve `chatId`/`userId` from all update types before checking the allowlist.
- Tests — cover callback_query/edited_message/channel_post passing the filters, mismatch rejection, and fail-closed behavior for ID-less updates.

## How to test

1. Create a workflow with a Telegram Trigger node.
2. Set **Trigger On** to include both **Message** and **Callback Query**.
3. Add a specific chat ID (e.g. a group ID starting with `-100…`) to **Restrict to Chat IDs**.
4. Send an inline keyboard to that chat and click a button.
5. The node now triggers on the callback query (previously it was silently dropped).
6. Conversely, a callback query from a non-allowed chat is still rejected.

Unit tests:
```bash
cd packages/nodes-base && pnpm test TelegramTrigger
```

## Related Linear tickets, Github issues, and Community forum posts

fixes #26795
https://linear.app/n8n/issue/GHC-7190

## Review / Merge checklist

- [ ] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [x] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32417">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->