### PR TITLE
fix(editor): Polish API key scope picker radio alignment, contrast and form spacing

### DIFF
--- a/packages/frontend/@n8n/design-system/src/components/N8nRadioGroup/RadioGroup.vue
+++ b/packages/frontend/@n8n/design-system/src/components/N8nRadioGroup/RadioGroup.vue
@@ -100,7 +100,7 @@ function onValueChange(value: string) {
 
 .item {
 	display: flex;
-	align-items: flex-start;
+	align-items: center;
 	gap: var(--spacing--2xs);
 	width: 100%;
 	margin: 0;
@@ -132,7 +132,6 @@ function onValueChange(value: string) {
 	justify-content: center;
 	width: 16px;
 	height: 16px;
-	margin-top: 1px;
 	border: 1px solid var(--color--foreground--shade-1);
 	border-radius: var(--radius--full);
 	transition: border-color 0.15s ease;
@@ -166,6 +165,8 @@ function onValueChange(value: string) {
 
 .description {
 	font-size: var(--font-size--2xs);
-	color: var(--color--text--tint-1);
+	// Use the base text color (not a lighter tint) so the description keeps
+	// WCAG AA contrast; the smaller font size provides the visual hierarchy.
+	color: var(--color--text);
 }
 </style>

--- a/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyCreateOrEditModal.vue
+++ b/packages/frontend/editor-ui/src/features/settings/apiKeys/components/ApiKeyCreateOrEditModal.vue
@@ -491,7 +491,7 @@ async function handleEnterKey(event: KeyboardEvent) {
 .form {
 	display: flex;
 	flex-direction: column;
-	gap: var(--spacing--xs);
+	gap: var(--spacing--md);
 }
 
 .expirationSection {


### PR DESCRIPTION
## Summary

Follow-up to the API key scope-picker redesign (#32167) and the `N8nRadioGroup` component (#32390). These three polish/a11y fixes were authored after #32390 was merged into the scope-picker branch, so they didn't make it onto `master`. This re-applies them.

- **Radio dot alignment** — `N8nRadioGroup` `.item` used `align-items: flex-start` with a `1px` top margin on the indicator, so the dot sat above the label's vertical center. Center it instead.
- **Description contrast (WCAG AA)** — the option description used `--color--text--tint-1` (neutral-500), which only reaches ~2.7:1 on a light surface and fails the accessibility check (flagged "Serious" in the design-system review). Switch to the base `--color--text`; the smaller font size keeps the visual hierarchy.
- **Modal form spacing** — bump the create/edit API key modal's form gap from `--spacing--xs` to `--spacing--md` so the **Label**, **Expiration** and **Scopes** groups read as distinct sections.

## How to test

1. **Settings → API → Create API key**: the All / Read only / Custom radio dots are vertically centered with their labels, and the Label / Expiration / Scopes groups have clear separation.
2. Storybook `Modules/RadioGroup` → *With Descriptions*: the description text now passes the WCAG AA contrast check.

No behavior changes — CSS only. lint (eslint + stylelint) pass; the changes were verified live in the running editor.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/IAM-822


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32420">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

