### PR TITLE
fix: correct wrong operation defaults in five nodes-base nodes

### DIFF
--- a/packages/nodes-base/nodes/Bitwarden/descriptions/EventDescription.ts
+++ b/packages/nodes-base/nodes/Bitwarden/descriptions/EventDescription.ts
@@ -6,7 +6,7 @@ export const eventOperations: INodeProperties[] = [
 		name: 'operation',
 		type: 'options',
 		noDataExpression: true,
-		default: 'get',
+		default: 'getAll',
 		options: [
 			{
 				name: 'Get Many',

--- a/packages/nodes-base/nodes/Mautic/CompanyContactDescription.ts
+++ b/packages/nodes-base/nodes/Mautic/CompanyContactDescription.ts
@@ -25,7 +25,7 @@ export const companyContactOperations: INodeProperties[] = [
 				action: 'Remove a company contact',
 			},
 		],
-		default: 'create',
+		default: 'add',
 	},
 ];
 

--- a/packages/nodes-base/nodes/Microsoft/Outlook/v1/FolderMessageDecription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Outlook/v1/FolderMessageDecription.ts
@@ -19,7 +19,7 @@ export const folderMessageOperations: INodeProperties[] = [
 				action: 'Get many folder messages',
 			},
 		],
-		default: 'create',
+		default: 'getAll',
 	},
 ];
 

--- a/packages/nodes-base/nodes/N8n/AuditDescription.ts
+++ b/packages/nodes-base/nodes/N8n/AuditDescription.ts
@@ -6,7 +6,7 @@ export const auditOperations: INodeProperties[] = [
 		name: 'operation',
 		type: 'options',
 		noDataExpression: true,
-		default: 'get',
+		default: 'generate',
 		displayOptions: {
 			show: {
 				resource: ['audit'],

--- a/packages/nodes-base/nodes/Spotify/Spotify.node.ts
+++ b/packages/nodes-base/nodes/Spotify/Spotify.node.ts
@@ -563,7 +563,7 @@ export class Spotify implements INodeType {
 						action: 'Search tracks by keyword',
 					},
 				],
-				default: 'track',
+				default: 'get',
 			},
 			{
 				displayName: 'Track ID',


### PR DESCRIPTION
## Summary

Five `type: 'options'` operation selectors in `nodes-base` declare a `default` value that doesn't exist in their own `options` list. When a user adds one of these nodes to a workflow, the Operation dropdown opens with nothing selected because the stored default is invalid.

This is a copy-paste issue — each default was left as a generic value (like `'track'` or `'get'`) that matched a sibling resource, not the resource it actually applies to.

## Changes

| Node | Resource | Old default | New default |
|------|----------|-------------|-------------|
| Spotify | Track | `'track'` | `'get'` |
| Bitwarden | Event | `'get'` | `'getAll'` |
| Mautic | Company Contact | `'create'` | `'add'` |
| Outlook v1 | Folder Message | `'create'` | `'getAll'` |
| n8n | Audit | `'get'` | `'generate'` |

Each change is a one-token fix to the first valid option value for that resource's operation selector.

## Why this is safe

The `default` value on an operation parameter only applies when a node is first added to a workflow. It has no effect on already-saved workflows, so this fix cannot break existing configurations.

## Testing

Verified that each new default matches an existing `options[].value` in the corresponding operation selector.

Closes #32347


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

