### PR TITLE
fix(core): Skip MCP credential check for personal-project owners

### DIFF
--- a/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts
@@ -79,7 +79,10 @@ type DataTableOpsMock = {
 };
 
 describe('create-workflow-from-code MCP tool', () => {
-	const user = Object.assign(new User(), { id: 'user-1' });
+	const user = Object.assign(new User(), {
+		id: 'user-1',
+		role: { slug: 'global:member', scopes: [] },
+	});
 	let workflowCreationService: WorkflowCreationService;
 	let createWorkflowMock: jest.Mock;
 	let urlService: UrlService;
@@ -716,6 +719,42 @@ describe('create-workflow-from-code MCP tool', () => {
 
 				expect(result.isError).toBeUndefined();
 				expect(workflowCreationService.createWorkflow).toHaveBeenCalled();
+			});
+
+			test('skips the check for a privileged user building in their personal project', async () => {
+				const originalRole = user.role;
+				user.role = {
+					slug: 'global:owner',
+					scopes: [{ slug: 'credential:list' }],
+				} as typeof user.role;
+				try {
+					// The credential belongs to another project and is not reachable, so it
+					// would normally be rejected.
+					(credentialsService.getCredentialsAUserCanUseInAWorkflow as jest.Mock).mockResolvedValue(
+						[],
+					);
+					(credentialsService.getOne as jest.Mock).mockResolvedValue({
+						id: 'cross-project-cred',
+						name: 'GitHub account',
+						type: 'githubApi',
+					});
+
+					mockParseAndValidate.mockResolvedValue({
+						workflow: {
+							...mockWorkflowJson,
+							nodes: [httpNodeWithGithub('cross-project-cred')],
+						},
+					});
+
+					// projectId omitted, so it lands in the user's personal project where the
+					// runtime gate bypasses credential checks. The build must succeed.
+					const result = await callHandler({ code: 'const wf = ...' });
+
+					expect(result.isError).toBeUndefined();
+					expect(workflowCreationService.createWorkflow).toHaveBeenCalled();
+				} finally {
+					user.role = originalRole;
+				}
 			});
 		});
 

--- a/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
+++ b/packages/cli/src/modules/mcp/__tests__/update-workflow.tool.test.ts
@@ -1061,6 +1061,54 @@ describe('update-workflow MCP tool', () => {
 				expect(workflowService.update).not.toHaveBeenCalled();
 			});
 
+			test('skips the check for a privileged user editing their personal-project workflow', async () => {
+				const privilegedUser = userWithScopes(['credential:list']);
+				(sharedWorkflowRepository.getWorkflowOwningProject as jest.Mock).mockResolvedValue({
+					id: 'project-1',
+					type: 'personal',
+				});
+				findWorkflowMock.mockResolvedValue(
+					Object.assign(buildExistingWorkflow(), {
+						nodes: [makeNode({ id: 's', name: 'Slack', type: 'n8n-nodes-base.slack' })],
+						connections: {},
+					}),
+				);
+
+				const tool = createUpdateWorkflowTool(
+					privilegedUser,
+					workflowFinderService,
+					workflowService,
+					urlService,
+					telemetry,
+					nodeTypes,
+					credentialsService,
+					sharedWorkflowRepository,
+					collaborationService,
+					dataTableOps as never,
+					tagService,
+					globalConfig,
+				);
+
+				const result = await callHandler(
+					{
+						workflowId: 'wf-1',
+						operations: [
+							{
+								type: 'setNodeCredential',
+								nodeName: 'Slack',
+								credentialKey: 'slackApi',
+								credentialId: 'cred-other-project',
+								credentialName: 'Other Project Slack',
+							},
+						],
+					},
+					tool,
+				);
+
+				expect(result.isError).toBeUndefined();
+				expect(workflowService.update).toHaveBeenCalled();
+			});
+
 			test('rejects addNode with an unknown credential id', async () => {
 				const result = await callHandler({
 					workflowId: 'wf-1',

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/create-workflow-from-code.tool.ts
@@ -3,7 +3,10 @@ import z from 'zod';
 
 import { buildInvalidAiToolSourceErrorResponse } from './connection-structure-check';
 import { MCP_CREATE_WORKFLOW_FROM_CODE_TOOL, CODE_BUILDER_VALIDATE_TOOL } from './constants';
-import { validateWorkflowCredentialReferences } from './credential-validation';
+import {
+	mcpCredentialCheckBypassed,
+	validateWorkflowCredentialReferences,
+} from './credential-validation';
 import { autoPopulateNodeCredentials, stripNullCredentialStubs } from './credentials-auto-assign';
 import { validateDataTableReferencesForWorkflow } from './data-table-validation';
 import { sanitizeSkillsUsed } from './skills-used';
@@ -242,19 +245,21 @@ export const createCreateWorkflowFromCodeTool = (
 					effectiveProjectId,
 				);
 
-			// Explicit credential ids in the generated code bypass auto-assignment,
-			// so verify they're reachable from the target project. This matches the
-			// runtime permission gate and prevents persisting a cross-project id that
-			// would only fail at execution time.
-			const credentialCheck = await validateWorkflowCredentialReferences(
-				newWorkflow.nodes,
-				user,
-				credentialsService,
-				nodeTypes,
-				effectiveProjectId,
-			);
-			if (!credentialCheck.ok) {
-				throw new Error(credentialCheck.error);
+			if (!mcpCredentialCheckBypassed(landingProject, user)) {
+				// Explicit credential ids in the generated code bypass auto-assignment,
+				// so verify they're reachable from the target project. This matches the
+				// runtime permission gate and prevents persisting a cross-project id that
+				// would only fail at execution time.
+				const credentialCheck = await validateWorkflowCredentialReferences(
+					newWorkflow.nodes,
+					user,
+					credentialsService,
+					nodeTypes,
+					effectiveProjectId,
+				);
+				if (!credentialCheck.ok) {
+					throw new Error(credentialCheck.error);
+				}
 			}
 
 			const savedWorkflow = await workflowCreationService.createWorkflow(user, newWorkflow, {

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/credential-validation.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/credential-validation.ts
@@ -1,4 +1,5 @@
-import type { User } from '@n8n/db';
+import type { Project, User } from '@n8n/db';
+import { hasGlobalScope } from '@n8n/permissions';
 import type { INode, INodeTypeDescription, IWorkflowBase } from 'n8n-workflow';
 import { NodeHelpers } from 'n8n-workflow';
 
@@ -7,6 +8,26 @@ import { NotFoundError } from '@/errors/response-errors/not-found.error';
 import type { NodeTypes } from '@/node-types';
 
 import type { PartialUpdateOperation } from './workflow-operations';
+
+/**
+ * Mirrors the runtime credential permission gate's bypass
+ * (`CredentialsPermissionChecker`): when a workflow lives in the personal
+ * project of a user privileged enough to use any credential (global
+ * `credential:list`), the runtime skips all credential checks. The build-time
+ * validator must skip them too, otherwise it rejects a workflow the runtime
+ * would happily execute.
+ *
+ * The calling user's scope is used as a proxy for the project owner's: for
+ * create the workflow can only land in the user's own personal project, and for
+ * update the common case is the owner editing their own personal-project
+ * workflow, so user and owner coincide.
+ */
+export function mcpCredentialCheckBypassed(
+	homeProject: Pick<Project, 'type'> | null | undefined,
+	user: User,
+): boolean {
+	return homeProject?.type === 'personal' && hasGlobalScope(user, 'credential:list');
+}
 
 export interface CredentialValidationFailure {
 	ok: false;
@@ -80,22 +101,15 @@ function nodeAcceptsCredentialKey(
 		return true;
 	}
 
-	const nodeCredentialType = parameters?.nodeCredentialType;
-	if (
-		typeof nodeCredentialType === 'string' &&
-		nodeCredentialType === credentialKey &&
-		declaresCredentialSelect(description, 'nodeCredentialType')
-	) {
-		return true;
-	}
-
-	const genericAuthType = parameters?.genericAuthType;
-	if (
-		typeof genericAuthType === 'string' &&
-		genericAuthType === credentialKey &&
-		declaresCredentialSelect(description, 'genericAuthType')
-	) {
-		return true;
+	for (const selector of ['nodeCredentialType', 'genericAuthType'] as const) {
+		const value = parameters?.[selector];
+		if (
+			typeof value === 'string' &&
+			value === credentialKey &&
+			declaresCredentialSelect(description, selector)
+		) {
+			return true;
+		}
 	}
 
 	return false;
@@ -159,7 +173,7 @@ async function buildProjectCredentialClassifier(
 		}
 
 		const cached = fallbackCache.get(credentialId);
-		if (cached) return cached;
+		if (cached !== undefined) return cached;
 
 		let classification: CredentialClassification;
 		try {
@@ -223,37 +237,36 @@ function describeCredentialProblem(
  * should be checked as a safe fallback.
  */
 function computeActiveCredentialTypes(node: INode, nodeTypes: NodeTypes): Set<string> | null {
-	let description: INodeTypeDescription;
 	try {
-		description = nodeTypes.getByNameAndVersion(node.type, node.typeVersion).description;
+		const description = nodeTypes.getByNameAndVersion(node.type, node.typeVersion).description;
+		const activeTypes = new Set<string>();
+
+		for (const credDef of description.credentials ?? []) {
+			if (NodeHelpers.displayParameter(node.parameters, credDef, node, description)) {
+				activeTypes.add(credDef.name);
+			}
+		}
+
+		// Nodes using a predefined credential type (e.g. HTTP Request) declare the
+		// active credential via the nodeCredentialType parameter rather than the
+		// static credentials array.
+		const { nodeCredentialType } = node.parameters;
+		if (typeof nodeCredentialType === 'string' && nodeCredentialType) {
+			activeTypes.add(nodeCredentialType);
+		}
+
+		// Generic credential types (e.g. HTTP Request with
+		// authentication=genericCredentialType) live in genericAuthType.
+		const { genericAuthType } = node.parameters;
+		if (typeof genericAuthType === 'string' && genericAuthType) {
+			activeTypes.add(genericAuthType);
+		}
+
+		return activeTypes;
 	} catch {
+		// If we can't resolve the node type, fall back to checking all credentials.
 		return null;
 	}
-
-	const activeTypes = new Set<string>();
-
-	for (const credDef of description.credentials ?? []) {
-		if (NodeHelpers.displayParameter(node.parameters, credDef, node, description)) {
-			activeTypes.add(credDef.name);
-		}
-	}
-
-	// Nodes using a predefined credential type (e.g. HTTP Request) declare the
-	// active credential via the nodeCredentialType parameter rather than the
-	// static credentials array.
-	const { nodeCredentialType } = node.parameters;
-	if (typeof nodeCredentialType === 'string' && nodeCredentialType) {
-		activeTypes.add(nodeCredentialType);
-	}
-
-	// Generic credential types (e.g. HTTP Request with
-	// authentication=genericCredentialType) live in genericAuthType.
-	const { genericAuthType } = node.parameters;
-	if (typeof genericAuthType === 'string' && genericAuthType) {
-		activeTypes.add(genericAuthType);
-	}
-
-	return activeTypes;
 }
 
 /**

--- a/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
+++ b/packages/cli/src/modules/mcp/tools/workflow-builder/update-workflow.tool.ts
@@ -8,7 +8,7 @@ import { USER_CALLED_MCP_TOOL_EVENT } from '../../mcp.constants';
 import type { ToolDefinition, UserCalledMCPToolEventPayload } from '../../mcp.types';
 import { buildInvalidAiToolSourceErrorResponse } from './connection-structure-check';
 import { MCP_UPDATE_WORKFLOW_TOOL } from './constants';
-import { validateCredentialReferences } from './credential-validation';
+import { mcpCredentialCheckBypassed, validateCredentialReferences } from './credential-validation';
 import { autoPopulateNodeCredentials } from './credentials-auto-assign';
 import { validateDataTableReferencesForUpdate } from './data-table-validation';
 import { sanitizeSkillsUsed } from './skills-used';
@@ -304,16 +304,24 @@ export const createUpdateWorkflowTool = (
 				throw new Error(result.error);
 			}
 
-			const credentialCheck = await validateCredentialReferences(
-				strictOperations,
-				existingWorkflow,
-				user,
-				credentialsService,
-				nodeTypes,
-				{ workflowId: existingWorkflow.id },
+			// Skip the credential check when the runtime permission gate would
+			// (workflow in the personal project of a user with global
+			// `credential:list`), so we don't reject an edit the runtime would run.
+			const owningProject = await sharedWorkflowRepository.getWorkflowOwningProject(
+				existingWorkflow.id,
 			);
-			if (!credentialCheck.ok) {
-				throw new Error(credentialCheck.error);
+			if (!mcpCredentialCheckBypassed(owningProject, user)) {
+				const credentialCheck = await validateCredentialReferences(
+					strictOperations,
+					existingWorkflow,
+					user,
+					credentialsService,
+					nodeTypes,
+					{ workflowId: existingWorkflow.id },
+				);
+				if (!credentialCheck.ok) {
+					throw new Error(credentialCheck.error);
+				}
 			}
 
 			const invalidToolSourceResponse = buildInvalidAiToolSourceErrorResponse(


### PR DESCRIPTION
## Summary

Follow-up to #32353 (merged), which made the MCP workflow-builder reject a credential at build time when it isn't reachable from the workflow's project, with the goal of matching the runtime permission gate (`CredentialsPermissionChecker`).

The runtime gate has a bypass the build-time validator did not replicate: when a workflow lives in the **personal project of a user with global `credential:list`** (instance owners/admins), it skips all credential checks (`credentials-permission-checker.ts`, the early `return` in `check()`). Because `getCredentialsAUserCanUseInAWorkflow` intersects the user's readable credentials with the project's credentials and has no such bypass, the MCP validator rejected a build the runtime would actually run.

### Repro (before this PR)

Owner (global `credential:list`) builds a workflow in their **personal project** referencing a GitHub credential that lives in a team project:

- `create_workflow_from_code` returns `credential '...' is not usable in this workflow's project` and refuses to save.
- The same workflow created via REST and executed gets past the credential gate and only fails at the GitHub API call (401 Bad credentials on the test token), proving the runtime would run it.

### Change

- Add a shared `mcpCredentialCheckBypassed(homeProject, user)` helper that mirrors the runtime bypass (personal project + global `credential:list`).
- `create_workflow_from_code` skips the check when the target project qualifies (it has the `Project` in hand).
- `update_workflow` resolves the workflow's owning project via `SharedWorkflowRepository.getWorkflowOwningProject` and skips the check in the same case.
- Team-project workflows still enforce the project-scope check.

The check uses the calling user's scope as a proxy for the project owner's: create can only target the user's own personal project, and the common update case is the owner editing their own personal-project workflow. The rare case of an admin editing another user's personal-project workflow is noted in a comment for reviewers to weigh in on.

Also includes a small alignment fix carried over from review: `computeActiveCredentialTypes` now wraps its whole body in the try/catch (matching the runtime helper) so a node with no parameters falls back to check-all instead of throwing.

## How to test

Unit tests cover both paths:
- personal-project + privileged user skips the check (create and update)
- team-project workflows still reject cross-project credentials

\`\`\`
cd packages/cli && pnpm test src/modules/mcp/__tests__/credential-validation.test.ts src/modules/mcp/__tests__/create-workflow-from-code.tool.test.ts src/modules/mcp/__tests__/update-workflow.tool.test.ts
\`\`\`

## Related

- Builds on #32353
- https://linear.app/n8n/issue/ADO-5424

## Review / Merge checklist

- [ ] Decide whether the calling-user proxy is acceptable, or whether the owner's scope should be resolved (admin-edits-another-user's-personal-workflow edge case).

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32427">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32427?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

