### PR TITLE
feat(core): Resolve the triggering user's private credentials over MCP OAuth

### DIFF
--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
@@ -156,6 +156,8 @@ export class McpTrigger extends Node {
 		const req = context.getRequestObject();
 		const resp = context.getResponseObject() as unknown as CompressionResponse;
 
+		let triggerAuthIdentity: { token: string; resource: string } | undefined;
+
 		if (context.getNodeParameter('authentication') === 'n8nOAuth2') {
 			if (context.getNode().typeVersion < 2) {
 				resp.writeHead(401);
@@ -166,6 +168,7 @@ export class McpTrigger extends Node {
 			if (authResult === 'handled') {
 				return { noWebhookResponse: true };
 			}
+			triggerAuthIdentity = { token: authResult.token, resource: authResult.resource };
 		} else {
 			try {
 				await validateWebhookAuthentication(context, 'authentication');
@@ -211,7 +214,11 @@ export class McpTrigger extends Node {
 							...(toolCallInfo && { mcpToolCall: toolCallInfo }),
 							...(messageId && { mcpMessageId: messageId }),
 						};
-						return { noWebhookResponse: true, workflowData: [[{ json: workflowData }]] };
+						return {
+							noWebhookResponse: true,
+							workflowData: [[{ json: workflowData }]],
+							triggerAuthIdentity,
+						};
 					}
 
 					if (needsListToolsRelay && relaySessionId && messageId) {
@@ -222,7 +229,10 @@ export class McpTrigger extends Node {
 								marker: MCP_LIST_TOOLS_REQUEST_MARKER,
 							},
 						};
-						return { noWebhookResponse: true, workflowData: [[{ json: workflowData }]] };
+						return {
+							noWebhookResponse: true,
+							workflowData: [[{ json: workflowData }]],
+						};
 					}
 				} else {
 					const connectedTools = await getConnectedTools(context, true);

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/McpTrigger.node.ts
@@ -156,8 +156,6 @@ export class McpTrigger extends Node {
 		const req = context.getRequestObject();
 		const resp = context.getResponseObject() as unknown as CompressionResponse;
 
-		let triggerAuthIdentity: { token: string; resource: string } | undefined;
-
 		if (context.getNodeParameter('authentication') === 'n8nOAuth2') {
 			if (context.getNode().typeVersion < 2) {
 				resp.writeHead(401);
@@ -168,7 +166,7 @@ export class McpTrigger extends Node {
 			if (authResult === 'handled') {
 				return { noWebhookResponse: true };
 			}
-			triggerAuthIdentity = { token: authResult.token, resource: authResult.resource };
+			await context.establishTriggerIdentity(authResult.token, authResult.resource);
 		} else {
 			try {
 				await validateWebhookAuthentication(context, 'authentication');
@@ -217,7 +215,6 @@ export class McpTrigger extends Node {
 						return {
 							noWebhookResponse: true,
 							workflowData: [[{ json: workflowData }]],
-							triggerAuthIdentity,
 						};
 					}
 

--- a/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/n8n-oauth2-auth.ts
+++ b/packages/@n8n/nodes-langchain/nodes/mcp/McpTrigger/n8n-oauth2-auth.ts
@@ -27,7 +27,16 @@ function sendUnauthorizedResponse(
 	resp.end();
 }
 
-export const n8nOAuth2Auth = async (context: IWebhookFunctions): Promise<'ok' | 'handled'> => {
+export const n8nOAuth2Auth = async (
+	context: IWebhookFunctions,
+): Promise<
+	| {
+			status: 'ok';
+			token: string;
+			resource: string;
+	  }
+	| 'handled'
+> => {
 	const webhookUrl = context.getNodeWebhookUrl('default');
 	if (!webhookUrl) {
 		throw new UnexpectedError('Webhook URL is not available');
@@ -58,5 +67,9 @@ export const n8nOAuth2Auth = async (context: IWebhookFunctions): Promise<'ok' | 
 		}
 		return 'handled';
 	}
-	return 'ok';
+	return {
+		status: 'ok',
+		token,
+		resource: resourceUrl,
+	};
 };

--- a/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/n8n-oauth/__tests__/n8n-oauth.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/n8n-oauth/__tests__/n8n-oauth.test.ts
@@ -1,0 +1,153 @@
+import type { Logger } from '@n8n/backend-common';
+import type { User } from '@n8n/db';
+import type { ContextEstablishmentOptions } from '@n8n/decorators';
+import { mock } from 'jest-mock-extended';
+import type { Cipher } from 'n8n-core';
+import type { ICredentialContext, INode, IRunExecutionData } from 'n8n-workflow';
+
+import type { AuthService } from '@/auth/auth.service';
+import type { OAuthTokenVerifierProxy } from '@/services/oauth-token-verifier-proxy.service';
+
+import { N8NIdentifier } from '../../../credential-resolvers/identifiers/n8n-identifier';
+import { N8NOAuth2Extractor, N8N_OAUTH_EXTRACTOR_NAME } from '../n8n-oauth-extractor';
+import { N8nOAuthIdentitySeeder } from '../n8n-oauth-seeder';
+
+const TOKEN = 'super-secret-oauth-token';
+const RESOURCE = 'https://host/mcp/workflow-a';
+
+const scopedLogger = (): jest.Mocked<Logger> => {
+	const logger = mock<Logger>();
+	logger.scoped.mockReturnValue(logger);
+	return logger;
+};
+
+// Faithful in-memory stand-in for Cipher: encryptV2 returns an opaque handle (never the
+// plaintext), decryptV2 resolves it back — so round-trips work while the raw token never
+// appears in the serialized run data.
+const createVaultCipher = (): jest.Mocked<Cipher> => {
+	const vault = new Map<string, string>();
+	let counter = 0;
+	const cipher = mock<Cipher>();
+	cipher.encryptV2.mockImplementation(async (data) => {
+		const plaintext = typeof data === 'string' ? data : JSON.stringify(data);
+		const handle = `enc:${counter++}`;
+		vault.set(handle, plaintext);
+		return handle;
+	});
+	cipher.decryptV2.mockImplementation(async (handle) => vault.get(handle) ?? 'not-json');
+	return cipher;
+};
+
+const makeTriggerNode = (): INode => ({
+	id: 'node-1',
+	name: 'MCP Trigger',
+	type: '@n8n/n8n-nodes-langchain.mcpTrigger',
+	typeVersion: 2,
+	position: [0, 0],
+	parameters: { authentication: 'n8nOAuth2' },
+});
+
+const makeRunExecutionData = (triggerNode: INode): IRunExecutionData =>
+	({
+		resultData: { runData: {} },
+		executionData: {
+			nodeExecutionStack: [{ node: triggerNode, data: { main: [] }, source: null }],
+			contextData: {},
+			waitingExecution: {},
+			waitingExecutionSource: {},
+			metadata: {},
+		},
+	}) as unknown as IRunExecutionData;
+
+describe('n8n-oauth identity seeding', () => {
+	describe('round-trip: seeder → extractor → identifier', () => {
+		it('propagates token + resource end-to-end and resolves the user', async () => {
+			const cipher = createVaultCipher();
+			const runExecutionData = makeRunExecutionData(makeTriggerNode());
+
+			// 1. Seed
+			await new N8nOAuthIdentitySeeder(scopedLogger(), cipher).seed(
+				runExecutionData,
+				TOKEN,
+				RESOURCE,
+			);
+
+			// 2. Extract (reads the item the seeder placed on the stack)
+			const triggerItems = runExecutionData.executionData!.nodeExecutionStack[0].data.main[0]!;
+			const result = await new N8NOAuth2Extractor(scopedLogger(), cipher).execute({
+				triggerItems,
+			} as ContextEstablishmentOptions);
+
+			expect(result.contextUpdate?.credentials).toEqual({
+				version: 1,
+				identity: TOKEN,
+				metadata: { source: 'n8n-oauth', resource: RESOURCE },
+			});
+			expect(triggerItems[0]).not.toHaveProperty('encryptedMetadata');
+
+			// 3. Identify (the extractor's metadata must satisfy the identifier's discriminated union;
+			// this is what catches a source-literal contract drift between the two)
+			const oauthVerifier = mock<OAuthTokenVerifierProxy>();
+			oauthVerifier.verifyOAuthAccessToken.mockResolvedValue({
+				user: mock<User>({ id: 'user-9' }),
+			});
+			const identifier = new N8NIdentifier(mock<AuthService>(), oauthVerifier);
+
+			const userId = await identifier.resolve(
+				result.contextUpdate!.credentials as ICredentialContext,
+				{},
+			);
+
+			expect(userId).toBe('user-9');
+			expect(oauthVerifier.verifyOAuthAccessToken).toHaveBeenCalledWith(TOKEN, RESOURCE);
+		});
+
+		it('throws and still deletes encryptedMetadata when the blob is invalid', async () => {
+			const extractor = new N8NOAuth2Extractor(scopedLogger(), createVaultCipher());
+			const item = { json: {}, encryptedMetadata: 'unknown-handle' };
+
+			await expect(
+				extractor.execute({ triggerItems: [item] } as unknown as ContextEstablishmentOptions),
+			).rejects.toThrow('No valid n8n OAuth authentication metadata could be extracted.');
+			expect(item).not.toHaveProperty('encryptedMetadata');
+		});
+	});
+
+	describe('N8nOAuthIdentitySeeder', () => {
+		it('persists only the encrypted blob — never the raw token', async () => {
+			const runExecutionData = makeRunExecutionData(makeTriggerNode());
+
+			await new N8nOAuthIdentitySeeder(scopedLogger(), createVaultCipher()).seed(
+				runExecutionData,
+				TOKEN,
+				RESOURCE,
+			);
+
+			expect(JSON.stringify(runExecutionData)).not.toContain(TOKEN);
+			expect(runExecutionData.executionData!.nodeExecutionStack[0].data.main[0]![0]).toHaveProperty(
+				'encryptedMetadata',
+			);
+		});
+
+		it('injects the hook on a clone without mutating the shared trigger node', async () => {
+			const triggerNode = makeTriggerNode();
+			const runExecutionData = makeRunExecutionData(triggerNode);
+
+			await new N8nOAuthIdentitySeeder(scopedLogger(), createVaultCipher()).seed(
+				runExecutionData,
+				TOKEN,
+				RESOURCE,
+			);
+
+			// Original node untouched (would otherwise leak the injected hook into the persisted snapshot)
+			expect(triggerNode.parameters).toEqual({ authentication: 'n8nOAuth2' });
+
+			const stackNode = runExecutionData.executionData!.nodeExecutionStack[0].node;
+			expect(stackNode).not.toBe(triggerNode);
+			expect(stackNode.parameters.executionsHooksVersion).toBe(1);
+			expect(stackNode.parameters.contextEstablishmentHooks).toEqual({
+				hooks: [{ hookName: N8N_OAUTH_EXTRACTOR_NAME, isAllowedToFail: true }],
+			});
+		});
+	});
+});

--- a/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/n8n-oauth/index.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/n8n-oauth/index.ts
@@ -1,0 +1,2 @@
+export * from './n8n-oauth-seeder';
+export * from './n8n-oauth-extractor';

--- a/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/n8n-oauth/metadata.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/n8n-oauth/metadata.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+export const EncryptedMetadataSchema = z.object({
+	encryptedMetadata: z.string(),
+});
+
+export const N8NOAuth2ExtractorMetadataSchema = z.object({
+	authToken: z.string(),
+	resource: z.string(),
+});
+
+export type EncryptedMetadata = z.infer<typeof EncryptedMetadataSchema>;
+export type N8NOAuth2ExtractorMetadata = z.infer<typeof N8NOAuth2ExtractorMetadataSchema>;

--- a/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/n8n-oauth/n8n-oauth-extractor.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/n8n-oauth/n8n-oauth-extractor.ts
@@ -1,0 +1,84 @@
+import { Logger } from '@n8n/backend-common';
+import {
+	ContextEstablishmentHook,
+	ContextEstablishmentOptions,
+	ContextEstablishmentResult,
+	HookDescription,
+	IContextEstablishmentHook,
+} from '@n8n/decorators';
+import { Cipher } from 'n8n-core';
+import { EncryptedMetadataSchema, N8NOAuth2ExtractorMetadataSchema } from './metadata';
+import { ensureError, jsonParse } from 'n8n-workflow';
+
+export const N8N_OAUTH_EXTRACTOR_NAME = 'N8nOAuthExtractor';
+
+@ContextEstablishmentHook()
+export class N8NOAuth2Extractor implements IContextEstablishmentHook {
+	constructor(
+		private readonly logger: Logger,
+		private readonly cipher: Cipher,
+	) {
+		this.logger = this.logger.scoped('dynamic-credentials');
+	}
+
+	hookDescription: HookDescription = {
+		name: N8N_OAUTH_EXTRACTOR_NAME,
+		displayName: 'N8N OAuth2 Extractor',
+		options: [],
+	};
+
+	isApplicableToTriggerNode(_nodeType: string): boolean {
+		// This extractor is not showing up in any UI for selection, it can only be used
+		// when referenced directly
+		return false;
+	}
+
+	async execute(options: ContextEstablishmentOptions): Promise<ContextEstablishmentResult> {
+		if (!options.triggerItems || options.triggerItems.length === 0) {
+			this.logger.debug('No trigger items found, skipping n8n OAuth extractor hook.');
+			throw new Error('No trigger items found, skipping n8n OAuth extractor hook.');
+		}
+		const [triggerItem] = options.triggerItems;
+
+		const encryptedMetadataResult = EncryptedMetadataSchema.safeParse(triggerItem);
+
+		// Always delete encryptedMetadata from the item
+		delete triggerItem.encryptedMetadata;
+
+		if (encryptedMetadataResult.success) {
+			try {
+				const decrypted = await this.cipher.decryptV2(
+					encryptedMetadataResult.data.encryptedMetadata,
+				);
+				const parsed = jsonParse(decrypted);
+				const n8nOAuthInformation = N8NOAuth2ExtractorMetadataSchema.safeParse(parsed);
+				if (n8nOAuthInformation.success) {
+					return {
+						triggerItems: options.triggerItems,
+						contextUpdate: {
+							credentials: {
+								version: 1,
+								identity: n8nOAuthInformation.data.authToken,
+								metadata: {
+									source: 'n8n-oauth',
+									resource: n8nOAuthInformation.data.resource,
+								},
+							},
+						},
+					};
+				} else {
+					this.logger.warn('Invalid format for encryptedMetadata in n8n OAuth extractor', {
+						errors: n8nOAuthInformation.error.errors,
+					});
+				}
+			} catch (error) {
+				this.logger.error('Failed to decrypt/parse encrypted n8n OAuth metadata', {
+					error: ensureError(error),
+				});
+			}
+		} else {
+			this.logger.warn('No encryptedMetadata found in trigger item for n8n OAuth extractor.');
+		}
+		throw new Error('No valid n8n OAuth authentication metadata could be extracted.');
+	}
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/n8n-oauth/n8n-oauth-seeder.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/n8n-oauth/n8n-oauth-seeder.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@n8n/backend-common';
 import { Service } from '@n8n/di';
 import { Cipher } from 'n8n-core';
-import { INode, IWebhookResponseData } from 'n8n-workflow';
+import { IRunExecutionData } from 'n8n-workflow';
 import { N8NOAuth2ExtractorMetadata } from './metadata';
 import { N8N_OAUTH_EXTRACTOR_NAME } from './n8n-oauth-extractor';
 import { TriggerAuthIdentitySeeder } from '@/services/trigger-auth-identity-seeder-proxy.service';
@@ -15,27 +15,50 @@ export class N8nOAuthIdentitySeeder implements TriggerAuthIdentitySeeder {
 		this.logger = this.logger.scoped('dynamic-credentials');
 	}
 
-	async seed(webhookResultData: IWebhookResponseData, triggerNode: INode): Promise<void> {
-		const item = webhookResultData.workflowData?.[0]?.[0];
-		if (webhookResultData.triggerAuthIdentity && item) {
-			const metadata: N8NOAuth2ExtractorMetadata = {
-				resource: webhookResultData.triggerAuthIdentity.resource,
-				authToken: webhookResultData.triggerAuthIdentity.token,
-			};
+	async seed(runExecutionData: IRunExecutionData, token: string, resource: string): Promise<void> {
+		const item = runExecutionData.executionData?.nodeExecutionStack?.[0]?.data?.main;
+		const metadata: N8NOAuth2ExtractorMetadata = {
+			resource,
+			authToken: token,
+		};
 
-			const encryptedMetadata = await this.cipher.encryptV2(metadata);
-			item.encryptedMetadata = encryptedMetadata;
-
-			triggerNode.parameters = {
-				...triggerNode.parameters,
-				executionsHooksVersion: 1,
-				contextEstablishmentHooks: {
-					hooks: [
+		const encryptedMetadata = await this.cipher.encryptV2(metadata);
+		if (item) {
+			this.logger.debug('Seeding n8n OAuth identity into trigger execution data.');
+			if (item?.[0]?.[0]) {
+				item[0][0].encryptedMetadata = encryptedMetadata;
+			} else if (item?.[0]) {
+				item[0].push({
+					encryptedMetadata,
+					json: {},
+				});
+			} else {
+				runExecutionData.executionData!.nodeExecutionStack[0].data.main = [
+					[
 						{
-							hookName: N8N_OAUTH_EXTRACTOR_NAME,
-							isAllowedToFail: true,
+							encryptedMetadata,
+							json: {},
 						},
 					],
+				];
+			}
+		}
+
+		if (runExecutionData.executionData?.nodeExecutionStack?.[0]) {
+			this.logger.debug('Seeding n8n OAuth identity into trigger node parameters.');
+			runExecutionData.executionData.nodeExecutionStack[0].node = {
+				...runExecutionData.executionData?.nodeExecutionStack?.[0].node,
+				parameters: {
+					...runExecutionData.executionData?.nodeExecutionStack?.[0].node.parameters,
+					executionsHooksVersion: 1,
+					contextEstablishmentHooks: {
+						hooks: [
+							{
+								hookName: N8N_OAUTH_EXTRACTOR_NAME,
+								isAllowedToFail: true,
+							},
+						],
+					},
 				},
 			};
 		}

--- a/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/n8n-oauth/n8n-oauth-seeder.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/context-establishment-hooks/n8n-oauth/n8n-oauth-seeder.ts
@@ -1,0 +1,43 @@
+import { Logger } from '@n8n/backend-common';
+import { Service } from '@n8n/di';
+import { Cipher } from 'n8n-core';
+import { INode, IWebhookResponseData } from 'n8n-workflow';
+import { N8NOAuth2ExtractorMetadata } from './metadata';
+import { N8N_OAUTH_EXTRACTOR_NAME } from './n8n-oauth-extractor';
+import { TriggerAuthIdentitySeeder } from '@/services/trigger-auth-identity-seeder-proxy.service';
+
+@Service()
+export class N8nOAuthIdentitySeeder implements TriggerAuthIdentitySeeder {
+	constructor(
+		private readonly logger: Logger,
+		private readonly cipher: Cipher,
+	) {
+		this.logger = this.logger.scoped('dynamic-credentials');
+	}
+
+	async seed(webhookResultData: IWebhookResponseData, triggerNode: INode): Promise<void> {
+		const item = webhookResultData.workflowData?.[0]?.[0];
+		if (webhookResultData.triggerAuthIdentity && item) {
+			const metadata: N8NOAuth2ExtractorMetadata = {
+				resource: webhookResultData.triggerAuthIdentity.resource,
+				authToken: webhookResultData.triggerAuthIdentity.token,
+			};
+
+			const encryptedMetadata = await this.cipher.encryptV2(metadata);
+			item.encryptedMetadata = encryptedMetadata;
+
+			triggerNode.parameters = {
+				...triggerNode.parameters,
+				executionsHooksVersion: 1,
+				contextEstablishmentHooks: {
+					hooks: [
+						{
+							hookName: N8N_OAUTH_EXTRACTOR_NAME,
+							isAllowedToFail: true,
+						},
+					],
+				},
+			};
+		}
+	}
+}

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/n8n-identifier.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/__tests__/n8n-identifier.test.ts
@@ -4,19 +4,22 @@ import { mock } from 'jest-mock-extended';
 
 import type { AuthService } from '@/auth/auth.service';
 import { AuthError } from '@/errors/response-errors/auth.error';
+import type { OAuthTokenVerifierProxy } from '@/services/oauth-token-verifier-proxy.service';
 
 import { N8NIdentifier } from '../n8n-identifier';
 
 describe('N8NIdentifier', () => {
 	let identifier: N8NIdentifier;
 	let mockAuthService: jest.Mocked<AuthService>;
+	let mockOAuthVerifier: jest.Mocked<OAuthTokenVerifierProxy>;
 
 	const mockUser = mock<User>({ id: 'user-123' });
 
 	beforeEach(() => {
 		mockAuthService = mock<AuthService>();
+		mockOAuthVerifier = mock<OAuthTokenVerifierProxy>();
 
-		identifier = new N8NIdentifier(mockAuthService);
+		identifier = new N8NIdentifier(mockAuthService, mockOAuthVerifier);
 	});
 
 	afterEach(() => {
@@ -313,6 +316,49 @@ describe('N8NIdentifier', () => {
 				};
 
 				await expect(identifier.resolve(context, {})).rejects.toThrow('Database connection failed');
+			});
+		});
+
+		describe('n8n-oauth branch', () => {
+			it('should verify the token for the resource audience and resolve the user', async () => {
+				mockOAuthVerifier.verifyOAuthAccessToken.mockResolvedValue({ user: mockUser });
+
+				const context = {
+					identity: 'oauth-access-token',
+					version: 1 as const,
+					metadata: {
+						source: 'n8n-oauth' as const,
+						resource: 'https://host/mcp/workflow-a',
+					},
+				};
+
+				const result = await identifier.resolve(context, {});
+
+				expect(result).toBe('user-123');
+				expect(mockOAuthVerifier.verifyOAuthAccessToken).toHaveBeenCalledWith(
+					'oauth-access-token',
+					'https://host/mcp/workflow-a',
+				);
+				expect(mockAuthService.authenticateUserByCookie).not.toHaveBeenCalled();
+				expect(mockAuthService.authenticateUserBasedOnToken).not.toHaveBeenCalled();
+			});
+
+			it('should throw CredentialResolverError when the token resolves to no user', async () => {
+				mockOAuthVerifier.verifyOAuthAccessToken.mockResolvedValue({
+					user: null,
+					context: { reason: 'invalid_token', auth_type: 'oauth' },
+				});
+
+				const context = {
+					identity: 'wrong-audience-token',
+					version: 1 as const,
+					metadata: {
+						source: 'n8n-oauth' as const,
+						resource: 'https://host/mcp/workflow-b',
+					},
+				};
+
+				await expect(identifier.resolve(context, {})).rejects.toThrow(CredentialResolverError);
 			});
 		});
 	});

--- a/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/n8n-identifier.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/credential-resolvers/identifiers/n8n-identifier.ts
@@ -4,6 +4,7 @@ import { ITokenIdentifier } from './identifier-interface';
 import { AuthService } from '@/auth/auth.service';
 import { z } from 'zod';
 import { CredentialResolverError } from '@n8n/decorators';
+import { OAuthTokenVerifierProxy } from '@/services/oauth-token-verifier-proxy.service';
 
 const ManualExecutionMetadataSchema = z.object({
 	source: z.literal('manual-execution'),
@@ -16,9 +17,15 @@ const RequestBoundMetadataSchema = z.object({
 	browserId: z.string().optional(),
 });
 
+const N8nOAuthMetadataSchema = z.object({
+	source: z.literal('n8n-oauth'),
+	resource: z.string(),
+});
+
 const N8NIdentifierMetadataSchema = z.discriminatedUnion('source', [
 	ManualExecutionMetadataSchema,
 	RequestBoundMetadataSchema,
+	N8nOAuthMetadataSchema,
 ]);
 
 /**
@@ -37,7 +44,10 @@ const N8NIdentifierMetadataSchema = z.discriminatedUnion('source', [
  */
 @Service()
 export class N8NIdentifier implements ITokenIdentifier {
-	constructor(private readonly authService: AuthService) {}
+	constructor(
+		private readonly authService: AuthService,
+		private readonly oauthTokenVerifierProxy: OAuthTokenVerifierProxy,
+	) {}
 
 	async validateOptions(_: Record<string, unknown>): Promise<void> {
 		return;
@@ -55,6 +65,19 @@ export class N8NIdentifier implements ITokenIdentifier {
 			// No HTTP request context at credential-resolution time; skip browserId/endpoint checks.
 			const user = await this.authService.authenticateUserByCookie(context.identity);
 			return user.id;
+		}
+
+		if (metadataResult.data.source === 'n8n-oauth') {
+			const user = await this.oauthTokenVerifierProxy.verifyOAuthAccessToken(
+				context.identity,
+				metadataResult.data.resource,
+			);
+			if (!user?.user) {
+				throw new CredentialResolverError(
+					`Invalid OAuth token for resource ${metadataResult.data.resource}`,
+				);
+			}
+			return user.user.id;
 		}
 
 		// Chat-hub / webhook run: validate the JWT together with the request-bound metadata

--- a/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.module.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/dynamic-credentials.module.ts
@@ -1,3 +1,4 @@
+import { TriggerAuthIdentitySeederProxy } from '@/services/trigger-auth-identity-seeder-proxy.service';
 import { LICENSE_FEATURES } from '@n8n/constants';
 import type { ModuleInterface } from '@n8n/decorators';
 import { BackendModule, OnShutdown } from '@n8n/decorators';
@@ -30,6 +31,13 @@ export class DynamicCredentialsModule implements ModuleInterface {
 			return;
 		}
 		await import('./dynamic-credentials.controller');
+
+		// Import the n8n oauth extractor and seeder
+		const { N8nOAuthIdentitySeeder } = await import('./context-establishment-hooks/n8n-oauth');
+
+		Container.get(TriggerAuthIdentitySeederProxy).registerSeeder(
+			Container.get(N8nOAuthIdentitySeeder),
+		);
 
 		// System resolver powers private credentials; OAuth/Slack resolvers and
 		// their management/identity-extractor surfaces are external-only.

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential-storage.service.test.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/__tests__/dynamic-credential-storage.service.test.ts
@@ -226,7 +226,6 @@ describe('DynamicCredentialStorageService', () => {
 					expect.objectContaining({
 						credentialId: 'cred-123',
 						resolverId: 'resolver-456',
-						identity: 'user-123',
 					}),
 				);
 			});

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-storage.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-storage.service.ts
@@ -71,6 +71,10 @@ export class DynamicCredentialStorageService implements IDynamicCredentialStorag
 				return this.handleMissingResolver(credentialStoreMetadata, resolverId);
 			}
 
+			this.logger.debug('Storing dynamic credentials using resolver', {
+				resolver: resolverEntity,
+			});
+
 			const decryptedConfig = await this.cipher.decryptV2(resolverEntity.config);
 			const resolverConfig = jsonParse<Record<string, unknown>>(decryptedConfig);
 
@@ -105,6 +109,12 @@ export class DynamicCredentialStorageService implements IDynamicCredentialStorag
 				identity: credentialContext.identity,
 			});
 		} catch (error) {
+			this.logger.error('Error storing dynamic credentials', {
+				error: error,
+				credentialId: credentialStoreMetadata.id,
+				resolverId: credentialStoreMetadata.resolverId,
+				identity: credentialContext.identity,
+			});
 			throw new CredentialStorageError(
 				`Failed to store dynamic credentials data for "${credentialStoreMetadata.name}"`,
 				{ cause: error },

--- a/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-storage.service.ts
+++ b/packages/cli/src/modules/dynamic-credentials.ee/services/dynamic-credential-storage.service.ts
@@ -71,10 +71,6 @@ export class DynamicCredentialStorageService implements IDynamicCredentialStorag
 				return this.handleMissingResolver(credentialStoreMetadata, resolverId);
 			}
 
-			this.logger.debug('Storing dynamic credentials using resolver', {
-				resolver: resolverEntity,
-			});
-
 			const decryptedConfig = await this.cipher.decryptV2(resolverEntity.config);
 			const resolverConfig = jsonParse<Record<string, unknown>>(decryptedConfig);
 
@@ -106,15 +102,8 @@ export class DynamicCredentialStorageService implements IDynamicCredentialStorag
 				credentialId: credentialStoreMetadata.id,
 				resolverId,
 				resolverSource: credentialStoreMetadata.resolverId ? 'credential' : 'workflow',
-				identity: credentialContext.identity,
 			});
 		} catch (error) {
-			this.logger.error('Error storing dynamic credentials', {
-				error: error,
-				credentialId: credentialStoreMetadata.id,
-				resolverId: credentialStoreMetadata.resolverId,
-				identity: credentialContext.identity,
-			});
 			throw new CredentialStorageError(
 				`Failed to store dynamic credentials data for "${credentialStoreMetadata.name}"`,
 				{ cause: error },

--- a/packages/cli/src/services/trigger-auth-identity-seeder-proxy.service.ts
+++ b/packages/cli/src/services/trigger-auth-identity-seeder-proxy.service.ts
@@ -1,8 +1,8 @@
 import { Service } from '@n8n/di';
-import type { INode, IWebhookResponseData } from 'n8n-workflow';
+import type { IRunExecutionData } from 'n8n-workflow';
 
 export interface TriggerAuthIdentitySeeder {
-	seed(webhookResultData: IWebhookResponseData, triggerNode: INode): Promise<void>;
+	seed(runExecutionData: IRunExecutionData, token: string, resource: string): Promise<void>;
 }
 
 @Service()
@@ -15,9 +15,9 @@ export class TriggerAuthIdentitySeederProxy implements TriggerAuthIdentitySeeder
 		this.seeder = seeder;
 	}
 
-	async seed(webhookResultData: IWebhookResponseData, triggerNode: INode): Promise<void> {
+	async seed(runExecutionData: IRunExecutionData, token: string, resource: string): Promise<void> {
 		if (this.seeder) {
-			return await this.seeder.seed(webhookResultData, triggerNode);
+			return await this.seeder.seed(runExecutionData, token, resource);
 		}
 		return;
 	}

--- a/packages/cli/src/services/trigger-auth-identity-seeder-proxy.service.ts
+++ b/packages/cli/src/services/trigger-auth-identity-seeder-proxy.service.ts
@@ -1,0 +1,24 @@
+import { Service } from '@n8n/di';
+import type { INode, IWebhookResponseData } from 'n8n-workflow';
+
+export interface TriggerAuthIdentitySeeder {
+	seed(webhookResultData: IWebhookResponseData, triggerNode: INode): Promise<void>;
+}
+
+@Service()
+export class TriggerAuthIdentitySeederProxy implements TriggerAuthIdentitySeeder {
+	private seeder: TriggerAuthIdentitySeeder | null = null;
+
+	constructor() {}
+
+	registerSeeder(seeder: TriggerAuthIdentitySeeder): void {
+		this.seeder = seeder;
+	}
+
+	async seed(webhookResultData: IWebhookResponseData, triggerNode: INode): Promise<void> {
+		if (this.seeder) {
+			return await this.seeder.seed(webhookResultData, triggerNode);
+		}
+		return;
+	}
+}

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -10,7 +10,12 @@ import type { Project } from '@n8n/db';
 import { Container } from '@n8n/di';
 import type express from 'express';
 import merge from 'lodash/merge';
-import { BinaryDataService, ErrorReporter, WAITING_TOKEN_QUERY_PARAM } from 'n8n-core';
+import {
+	BinaryDataService,
+	ErrorReporter,
+	establishExecutionContext,
+	WAITING_TOKEN_QUERY_PARAM,
+} from 'n8n-core';
 import type {
 	IBinaryData,
 	IDataObject,
@@ -545,6 +550,15 @@ export async function executeWebhook(
 		};
 	};
 
+	additionalData.establishTriggerIdentity = async (token: string, resource: string) => {
+		if (runExecutionData === undefined) {
+			throw new UnexpectedError('Execution data is not available to establish trigger identity');
+		}
+		await Container.get(TriggerAuthIdentitySeederProxy).seed(runExecutionData, token, resource);
+
+		await establishExecutionContext(workflow, runExecutionData, additionalData, executionMode);
+	};
+
 	let didSendResponse = false;
 	let runExecutionDataMerge = {};
 	try {
@@ -677,11 +691,6 @@ export async function executeWebhook(
 			}
 			return;
 		}
-
-		// Seed auth identity for trigger nodes before execution so that it can be used in the workflow
-		// this prepares the identity for usage in the workflow and also ensures that it gets properly
-		// linked to the execution for auditing and debugging purposes.
-		await Container.get(TriggerAuthIdentitySeederProxy).seed(webhookResultData, workflowStartNode);
 
 		// For "onReceived" mode, we need to defer response sending until after the execution
 		// is created, so that `$execution.id` is available in response data expressions.

--- a/packages/cli/src/webhooks/webhook-helpers.ts
+++ b/packages/cli/src/webhooks/webhook-helpers.ts
@@ -82,6 +82,7 @@ import {
 } from './webhook-response-headers';
 import { WebhookService } from './webhook.service';
 import type { IWebhookResponseCallbackData, WebhookRequest } from './webhook.types';
+import { TriggerAuthIdentitySeederProxy } from '@/services/trigger-auth-identity-seeder-proxy.service';
 
 // Type guards for MCP queue mode data validation
 interface McpToolCallPayload {
@@ -676,6 +677,11 @@ export async function executeWebhook(
 			}
 			return;
 		}
+
+		// Seed auth identity for trigger nodes before execution so that it can be used in the workflow
+		// this prepares the identity for usage in the workflow and also ensures that it gets properly
+		// linked to the execution for auditing and debugging purposes.
+		await Container.get(TriggerAuthIdentitySeederProxy).seed(webhookResultData, workflowStartNode);
 
 		// For "onReceived" mode, we need to defer response sending until after the execution
 		// is created, so that `$execution.id` is available in response data expressions.

--- a/packages/cli/src/workflows/workflow-validation.service.ts
+++ b/packages/cli/src/workflows/workflow-validation.service.ts
@@ -25,7 +25,7 @@ import type {
 	ICredentialType,
 } from 'n8n-workflow';
 
-import { STARTING_NODES } from '@/constants';
+import { MCP_TRIGGER_NODE_TYPE, STARTING_NODES } from '@/constants';
 import { CredentialTypes } from '@/credential-types';
 import { DynamicCredentialsProxy } from '@/credentials/dynamic-credentials-proxy';
 import type { NodeTypes } from '@/node-types';
@@ -420,7 +420,17 @@ export class WorkflowValidationService {
 			const isSubWorkflowTrigger = node.type === EXECUTE_WORKFLOW_TRIGGER_NODE_TYPE;
 			const isChatHubTrigger =
 				node.type === CHAT_TRIGGER_NODE_TYPE && node.parameters.availableInChat === true;
-			if (isSubWorkflowTrigger || isChatHubTrigger) {
+			const isMcpTrigger =
+				node.type === MCP_TRIGGER_NODE_TYPE && node.parameters.authentication === 'n8nOAuth2';
+			console.log('Trigger identity classification', {
+				node: node.name,
+				type: node.type,
+				isSubWorkflowTrigger,
+				isChatHubTrigger,
+				isMcpTrigger,
+				parameters: node.parameters,
+			});
+			if (isSubWorkflowTrigger || isChatHubTrigger || isMcpTrigger) {
 				hasExternalIdentityTrigger = true;
 				hasN8nIdentityTrigger = true;
 				continue;

--- a/packages/cli/src/workflows/workflow-validation.service.ts
+++ b/packages/cli/src/workflows/workflow-validation.service.ts
@@ -422,14 +422,6 @@ export class WorkflowValidationService {
 				node.type === CHAT_TRIGGER_NODE_TYPE && node.parameters.availableInChat === true;
 			const isMcpTrigger =
 				node.type === MCP_TRIGGER_NODE_TYPE && node.parameters.authentication === 'n8nOAuth2';
-			console.log('Trigger identity classification', {
-				node: node.name,
-				type: node.type,
-				isSubWorkflowTrigger,
-				isChatHubTrigger,
-				isMcpTrigger,
-				parameters: node.parameters,
-			});
 			if (isSubWorkflowTrigger || isChatHubTrigger || isMcpTrigger) {
 				hasExternalIdentityTrigger = true;
 				hasN8nIdentityTrigger = true;

--- a/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
+++ b/packages/core/src/execution-engine/node-execution-context/webhook-context.ts
@@ -158,6 +158,13 @@ export class WebhookContext extends NodeExecutionContext implements IWebhookFunc
 		return await this.additionalData.validateN8nOAuth2Token(token, resourceUrl);
 	}
 
+	async establishTriggerIdentity(token: string, resource: string): Promise<void> {
+		if (!this.additionalData.establishTriggerIdentity) {
+			throw new UnexpectedError('Trigger identity establishment is not available');
+		}
+		await this.additionalData.establishTriggerIdentity(token, resource);
+	}
+
 	async getInputConnectionData(
 		connectionType: AINodeConnectionType,
 		itemIndex: number,

--- a/packages/workflow/src/constants.ts
+++ b/packages/workflow/src/constants.ts
@@ -114,6 +114,7 @@ export const MEMORY_BUFFER_WINDOW_NODE_TYPE = '@n8n/n8n-nodes-langchain.memoryBu
 export const GUARDRAILS_NODE_TYPE = '@n8n/n8n-nodes-langchain.guardrails';
 export const MCP_CLIENT_TOOL_NODE_TYPE = '@n8n/n8n-nodes-langchain.mcpClientTool';
 export const MCP_CLIENT_NODE_TYPE = '@n8n/n8n-nodes-langchain.mcpClient';
+export const MCP_TRIGGER_NODE_TYPE = '@n8n/n8n-nodes-langchain.mcpTrigger';
 export const ANTHROPIC_LANGCHAIN_NODE_TYPE = '@n8n/n8n-nodes-langchain.anthropic';
 export const OLLAMA_LANGCHAIN_NODE_TYPE = '@n8n/n8n-nodes-langchain.ollama';
 export const GOOGLE_GEMINI_LANGCHAIN_NODE_TYPE = '@n8n/n8n-nodes-langchain.googleGemini';
@@ -127,6 +128,7 @@ export const MANUAL_TRIGGER_NODE_TYPES: readonly string[] = [
 	MANUAL_TRIGGER_NODE_TYPE,
 	MANUAL_CHAT_TRIGGER_LANGCHAIN_NODE_TYPE,
 	CHAT_TRIGGER_NODE_TYPE,
+	MCP_TRIGGER_NODE_TYPE,
 ];
 
 export const AI_VENDOR_NODE_TYPES = [

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -2810,6 +2810,7 @@ export interface IWebhookResponseData {
 	workflowData?: INodeExecutionData[][];
 	webhookResponse?: any;
 	noWebhookResponse?: boolean;
+	triggerAuthIdentity?: { token: string; resource: string };
 }
 
 export type WebhookResponseData = 'allEntries' | 'firstEntryJson' | 'firstEntryBinary' | 'noData';

--- a/packages/workflow/src/interfaces.ts
+++ b/packages/workflow/src/interfaces.ts
@@ -1356,6 +1356,7 @@ export interface IWebhookFunctions extends FunctionsBaseWithRequiredKeys<'getMod
 	getBodyData(): IDataObject;
 	getHeaderData(): IncomingHttpHeaders;
 	validateN8nOAuth2Token(token: string, resourceUrl: string): Promise<N8nOAuth2ValidationResult>;
+	establishTriggerIdentity(token: string, resource: string): Promise<void>;
 	getInputConnectionData(
 		connectionType: AINodeConnectionType,
 		itemIndex: number,
@@ -2810,7 +2811,6 @@ export interface IWebhookResponseData {
 	workflowData?: INodeExecutionData[][];
 	webhookResponse?: any;
 	noWebhookResponse?: boolean;
-	triggerAuthIdentity?: { token: string; resource: string };
 }
 
 export type WebhookResponseData = 'allEntries' | 'firstEntryJson' | 'firstEntryBinary' | 'noData';
@@ -3316,6 +3316,7 @@ export interface IWorkflowExecuteAdditionalData {
 		token: string,
 		resourceUrl: string,
 	) => Promise<N8nOAuth2ValidationResult>;
+	establishTriggerIdentity?(token: string, resource: string): Promise<void>;
 	currentNodeExecutionIndex: number;
 	httpResponse?: express.Response;
 	httpRequest?: express.Request;


### PR DESCRIPTION
## Summary

When a workflow is triggered through an **OAuth2-protected MCP Server Trigger**, its connected tools now run **as the authenticated caller** and resolve **that user's private credentials**. Before this change, a private credential used by an MCP tool failed at runtime with `Cannot resolve dynamic credentials without execution context`.

This reuses the existing private-credentials machinery — `N8NCredentialResolver` plus the `dynamic_credential_user_entry` per-user store, keyed by `(credentialId, userId, resolverId)`. The only new piece is the **token → userId** step, added as a new, surface-agnostic identity source `n8n-oauth`. Because storage is keyed by user, a credential connected once during a manual run resolves **identically** when the same user later triggers the workflow over MCP.

### Why / context

Part of the MCP-Trigger-OAuth initiative (IAM-801). It builds on the already-merged "OAuth-protect the MCP Trigger" work (the `n8n OAuth2` authentication option, the built-in OAuth 2.1 server, per-workflow protected resources). That work gates *who may call* an MCP server; this PR delivers the payoff — running the call *as that user*, with their own credentials.

### Key implementation decisions

- **Identity is established in the webhook process, before the tool runs.** MCP connected tools execute **inline inside the trigger's `webhook()`** (`handlePostMessage` → `tool.invoke`), which runs *before* the workflow execution context exists. A workflow-execution-time hook (the chat-hub extractor pattern) would be too late. So the node calls a new webhook capability `establishTriggerIdentity(token, resource)` right after auth, which **reuses the shared `establishExecutionContext`** — meaning any other context-establishment hooks still run too.
- **Encryption stays in cli/core.** The node only hands over `{ token, resource }`; the instance encryption key is never exposed to the node sandbox. The cli encrypts the identity onto the trigger item and injects the extractor hook.
- **One mechanism covers direct + queue + the post-webhook execution.** `establishExecutionContext` is idempotent (it early-returns if context is already set), and `runtimeData.credentials` travels with the enqueued execution data, so the worker honors it in queue mode. Verified manually in both modes.
- **Token verification is decoupled.** `N8NIdentifier` verifies via the existing `OAuthTokenVerifierProxy` port (no `dynamic-credentials.ee` → `oauth-server` module coupling) and checks the token's audience against the workflow's resource URL.
- **No plaintext token in stored data.** The raw bearer token never appears in persisted execution data or the queue payload — only an encrypted blob, which the extractor deletes from the trigger item after reading. Guarded by a regression test.
- The hook is injected on a **clone** of the trigger node, so the runtime injection never leaks into the persisted workflow snapshot.

### How it works (request flow)

1. `McpTrigger.webhook()` validates the OAuth2 token → `{ token, resource }`.
2. Node calls `context.establishTriggerIdentity(token, resource)` (before handling the tool call).
3. cli seeds an encrypted `{ authToken, resource }` blob onto the trigger item and injects the `N8nOAuthExtractor` hook.
4. `establishExecutionContext` runs the extractor → `runtimeData.credentials = { source: 'n8n-oauth', identity: <token>, resource }`.
5. The connected tool resolves its private credential → `N8NIdentifier` calls `verifyOAuthAccessToken(token, resource)` → `userId` → existing per-user storage lookup.

### How to test manually

Prerequisites: private credentials enabled; an instance with the MCP OAuth flow available.

1. Create a workflow with an **MCP Server Trigger** (v2+), Authentication = **n8n OAuth2**, and a connected tool node that uses a **private credential** (e.g. Google Drive). Publish it.
2. As user A, connect the private credential (e.g. via a manual run that connects it).
3. As user A, run the MCP OAuth flow against the workflow's MCP endpoint (discover → register → authorize → consent → token) and invoke the tool.
4. **Expected:** the tool executes using user A's private credential.
5. Edge cases:
   - A token minted for a *different* workflow's resource → resolution fails (audience check).
   - A different user B who has not connected the credential → error (or B's own data if they have connected it).
6. Repeat in **queue mode** (the worker executes the tool) — behavior is identical.

Automated coverage: unit tests for the `n8n-oauth` identifier branch, a seed → extract → identify round-trip (guards the identity contract that previously broke), and a security test asserting the raw token never appears in the serialized execution data.

### Related links

- closes https://linear.app/n8n/issue/IAM-801

## Review / Merge checklist

- [X] I have seen this code, I have run this code, and I take responsibility for this code.
- [X] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [X] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32432">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

