### PR TITLE
fix(core): Apply PII scrubber on telemetry (no-changelog)

### DIFF
--- a/packages/@n8n/instance-ai/src/tracing/__tests__/langsmith-tracing.test.ts
+++ b/packages/@n8n/instance-ai/src/tracing/__tests__/langsmith-tracing.test.ts
@@ -615,6 +615,26 @@ describe('createInstanceAiTraceContext', () => {
 		expect(serialized).toContain('[REDACTED]');
 	});
 
+	it('redacts PII (email, credit-card, SSN) from telemetry strings', () => {
+		const span = {
+			attributes: {
+				'ai.operationId': 'ai.streamText.doStream',
+				'ai.response.text': 'reach me at jane.doe@example.com about card 4111 1111 1111 1111',
+				'ai.prompt.messages': JSON.stringify([{ role: 'user', content: 'my ssn is 123-45-6789' }]),
+			},
+		};
+
+		const redacted = redactLangSmithTelemetrySpan(span) as {
+			attributes: Record<string, unknown>;
+		};
+		const serialized = JSON.stringify(redacted.attributes);
+
+		expect(serialized).not.toContain('jane.doe@example.com');
+		expect(serialized).not.toContain('4111 1111 1111 1111');
+		expect(serialized).not.toContain('123-45-6789');
+		expect(serialized).toContain('[REDACTED]');
+	});
+
 	it('uses cache-only Anthropic input tokens for LangSmith prompt totals', () => {
 		const span = {
 			attributes: {

--- a/packages/@n8n/instance-ai/src/tracing/trace-payloads.ts
+++ b/packages/@n8n/instance-ai/src/tracing/trace-payloads.ts
@@ -1,5 +1,10 @@
-import type { AttributeValue, RuntimeSkillRegistry } from '@n8n/agents';
-import { scrubSecretsInText } from '@n8n/utils';
+import {
+	redactText,
+	SUPPORTED_PII_CATEGORIES,
+	type AttributeValue,
+	type RedactionOptions,
+	type RuntimeSkillRegistry,
+} from '@n8n/agents';
 import { createHash } from 'node:crypto';
 
 import {
@@ -21,6 +26,20 @@ const MAX_TRACE_ARRAY_ITEMS = 20;
 const MAX_TRACE_OBJECT_KEYS = 30;
 const SENSITIVE_TELEMETRY_KEY_PATTERN =
 	/(api[_-]?key|authorization|bearer|cookie|credentials?|password|secret|access[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?token|auth[_-]?token|(?:^|[._-])token$)/i;
+
+/**
+ * Telemetry/tracing redaction policy. Deliberately stricter than the
+ * user-facing output policy `DEFAULT_OUTPUT_REDACTION_OPTIONS`.
+ */
+export const DEFAULT_TELEMETRY_REDACTION_OPTIONS: RedactionOptions = {
+	secrets: true,
+	detect: SUPPORTED_PII_CATEGORIES,
+};
+
+/** Redact secrets + all PII from a free-text telemetry value before it egresses. */
+function scrubTelemetryText(value: string): string {
+	return redactText(value, DEFAULT_TELEMETRY_REDACTION_OPTIONS).text;
+}
 
 const LANGSMITH_TRACE_NAME = 'langsmith.trace.name';
 const LANGSMITH_SPAN_KIND = 'langsmith.span.kind';
@@ -133,7 +152,7 @@ function redactTelemetryJsonValue(
 	}
 
 	if (typeof value === 'string') {
-		return scrubSecretsInText(value);
+		return scrubTelemetryText(value);
 	}
 
 	if (typeof value === 'number' || typeof value === 'boolean' || value === null) {
@@ -187,11 +206,11 @@ function redactTelemetryAttribute(key: string, value: unknown): unknown {
 			const parsed: unknown = JSON.parse(trimmed);
 			return JSON.stringify(redactTelemetryJsonValue(parsed, key, 0, maxDepth));
 		} catch {
-			return scrubSecretsInText(value);
+			return scrubTelemetryText(value);
 		}
 	}
 
-	return scrubSecretsInText(value);
+	return scrubTelemetryText(value);
 }
 
 function parseTelemetryJson(value: unknown): unknown {


### PR DESCRIPTION
## Summary

Apply PII scrubber on telemetry and make values redacted by it not end up there.
This is to be followed with more scrubber cateogries as separate PRs.

## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

Have langsmith set up, send a message containing an email -> check telemetry and confirm it has been redacted

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-474

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32438">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32438?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

