### PR TITLE
feat(core): Expand secret redaction patterns (JWT, PEM keys, vendor tokens, URL creds)

### DIFF
--- a/packages/@n8n/utils/src/scrub-secrets.test.ts
+++ b/packages/@n8n/utils/src/scrub-secrets.test.ts
@@ -43,6 +43,28 @@ describe('scrubSecretsInText', () => {
 		expect(scrubSecretsInText('AKIAIOSFODNN7EXAMPLE is the key')).toBe('[REDACTED] is the key');
 	});
 
+	it('redacts a PEM private-key block', () => {
+		const pem = `-----BEGIN PRIVATE KEY-----\n${'FAKEKEYMATERIAL'}\n-----END PRIVATE KEY-----`;
+		expect(scrubSecretsInText(`key:\n${pem}\ndone`)).toBe('key:\n[REDACTED]\ndone');
+	});
+
+	it('redacts a JWT', () => {
+		const jwt = `${join('eyJ', 'hbGciOiJIUzI1NiJ9')}.${join('eyJ', 'zdWIiOiIxMjMifQ')}.${'c2lnbmF0dXJl'}`;
+		expect(scrubSecretsInText(`token ${jwt} end`)).toBe('token [REDACTED] end');
+	});
+
+	it('redacts Stripe, Google, and GitHub fine-grained tokens', () => {
+		expect(scrubSecretsInText(join('sk', '_live_abcdefghijklmnop1234'))).toBe('[REDACTED]');
+		expect(scrubSecretsInText(join('AIza', 'B'.repeat(35)))).toBe('[REDACTED]');
+		expect(scrubSecretsInText(join('github_pat_', 'A'.repeat(30)))).toBe('[REDACTED]');
+	});
+
+	it('redacts credentials embedded in a URL, keeping scheme and host', () => {
+		const out = scrubSecretsInText('fetch https://alice:s3cretPass@db.example.com/items');
+		expect(out).not.toContain('s3cretPass');
+		expect(out).toBe('fetch https://[REDACTED]@db.example.com/items');
+	});
+
 	it('redacts generic key=value assignments regardless of separator', () => {
 		expect(scrubSecretsInText('password=hunter2 and api_key:abc')).toBe(
 			'[REDACTED] and [REDACTED]',

--- a/packages/@n8n/utils/src/scrub-secrets.ts
+++ b/packages/@n8n/utils/src/scrub-secrets.ts
@@ -16,16 +16,29 @@ export const SECRET_KEYS =
 	'password|passwd|secret|credentials?|api[_-]?key|authorization|access[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?token|auth[_-]?token';
 
 export const SECRET_VALUE_PATTERNS: readonly RegExp[] = [
+	// PEM private-key blocks (RSA/EC/DSA/OpenSSH/PGP). Whole block, multiline.
+	/-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----[\s\S]*?-----END (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----/g,
+	// JWTs: `eyJ<header>.eyJ<payload>.<signature>` (both leading segments are
+	// base64url of a `{"` object, which makes this highly distinctive).
+	/\beyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,
 	// Authorization-header substrings: `Bearer <token>`, `Basic <token>`, `Token <token>`
 	/\b(?:Bearer|Basic|Token)\s+[A-Za-z0-9._~+/=-]{12,}/gi,
 	// OpenAI / Anthropic API keys
 	/\bsk-(?:ant-|proj-)?[A-Za-z0-9_-]{16,}/g,
+	// Stripe secret/restricted/publishable keys (`sk_live_…`, `rk_test_…`, …)
+	/\b(?:sk|rk|pk)_(?:live|test)_[A-Za-z0-9]{16,}/g,
+	// Google API keys
+	/\bAIza[0-9A-Za-z_-]{35}\b/g,
 	// Slack tokens (xoxb, xoxp, xoxa, xoxr, xoxs, xoxo)
 	/\bxox[abprso]-[A-Za-z0-9-]{10,}/g,
 	// GitHub tokens (ghp, ghs, gho, ghr, ghu)
 	/\bgh[psoru]_[A-Za-z0-9]{20,}/g,
+	// GitHub fine-grained personal access tokens
+	/\bgithub_pat_[A-Za-z0-9_]{22,}/g,
 	// AWS access key id
 	/\bAKIA[0-9A-Z]{16}\b/g,
+	// Credentials embedded in a URL: `scheme://user:password@` — redact the userinfo.
+	/(?<=:\/\/)[^\s:/@]+:[^\s:/@]+(?=@)/g,
 	// JSON-shaped `"key": "value"` — matches the quoted field as a whole.
 	// Run before the loose pattern so nested objects like
 	// `{"credentials": {"apiKey": "..."}}` don't have the outer key consume


### PR DESCRIPTION
## Summary

Add detectors to SECRET_VALUE_PATTERNS so the shared secret scrubber (used by Instance AI output/telemetry redaction) covers:
- PEM private-key blocks
- JWTs
- Stripe (sk_/rk_/pk_)
- Google (AIza)
- GitHub fine-grained PATs
- credentials embedded in URLs (scheme://user:pass@ - redacting  the userinfo).

Related: https://github.com/n8n-io/n8n/pull/32438

## How to test

Test this somewhere where the secrets redaction is applied - like on instance AI - and see if the patterns are caught.
Honestly unit tests cover this pretty well.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-474

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32440">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

