### PR TITLE
feat(core): Add more supported PII redaction patterns (no-changelog)

### DIFF
--- a/packages/@n8n/agents/src/sdk/__tests__/guardrails.test.ts
+++ b/packages/@n8n/agents/src/sdk/__tests__/guardrails.test.ts
@@ -78,6 +78,21 @@ describe('redactText', () => {
 			const { text } = redactText('ssn 123-45-6789', { detect: ['ssn-us'] });
 			expect(text).toBe('ssn [REDACTED]');
 		});
+
+		it('redacts E.164 phone numbers, compact and formatted', () => {
+			const { text, matches } = redactText('intl +15551234567', { detect: ['phone'] });
+			expect(text).toBe('intl [REDACTED]');
+			expect(matches).toEqual([{ category: 'phone' }]);
+			expect(redactText('call +1 (555) 123-4567', { detect: ['phone'] }).text).toBe(
+				'call [REDACTED]',
+			);
+		});
+
+		it('does not redact non-E.164 numbers (no leading +) or dates/IDs', () => {
+			// NANP without a leading + is intentionally not E.164.
+			const input = 'call 555-123-4567 on 2024-01-15 ticket 12345';
+			expect(redactText(input, { detect: ['phone'] }).text).toBe(input);
+		});
 	});
 
 	describe('redactionOptionsFromGuardrail', () => {

--- a/packages/@n8n/agents/src/sdk/__tests__/guardrails.test.ts
+++ b/packages/@n8n/agents/src/sdk/__tests__/guardrails.test.ts
@@ -93,6 +93,62 @@ describe('redactText', () => {
 			const input = 'call 555-123-4567 on 2024-01-15 ticket 12345';
 			expect(redactText(input, { detect: ['phone'] }).text).toBe(input);
 		});
+
+		it('redacts a checksum-valid IBAN (spaced or compact) but not an invalid one', () => {
+			expect(redactText('pay GB82 WEST 1234 5698 7654 32 today', { detect: ['iban'] }).text).toBe(
+				'pay [REDACTED] today',
+			);
+			// Lower/mixed-case compact IBANs must still be located and redacted.
+			expect(redactText('pay gb82west12345698765432 today', { detect: ['iban'] }).text).toBe(
+				'pay [REDACTED] today',
+			);
+			expect(redactText('pay Gb82WEST12345698765432 today', { detect: ['iban'] }).text).toBe(
+				'pay [REDACTED] today',
+			);
+			const invalid = 'iban GB99WEST12345698765432';
+			expect(redactText(invalid, { detect: ['iban'] }).text).toBe(invalid);
+		});
+
+		it('redacts crypto wallet addresses (ETH, BTC bech32, BTC base58)', () => {
+			expect(
+				redactText('to 0x52908400098527886E0F7030069857D2E4169EE7', {
+					detect: ['crypto-wallet'],
+				}).text,
+			).toBe('to [REDACTED]');
+			expect(
+				redactText('to bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq', { detect: ['crypto-wallet'] })
+					.text,
+			).toBe('to [REDACTED]');
+			expect(
+				redactText('to 1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa', { detect: ['crypto-wallet'] }).text,
+			).toBe('to [REDACTED]');
+		});
+
+		it('does not redact a base58 string with a broken checksum', () => {
+			const input = 'addr 1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNb';
+			expect(redactText(input, { detect: ['crypto-wallet'] }).text).toBe(input);
+		});
+
+		it('redacts IPv4 and IPv6 addresses but not out-of-range octets', () => {
+			expect(redactText('host 192.168.0.1 and 2001:db8::1', { detect: ['ip'] }).text).toBe(
+				'host [REDACTED] and [REDACTED]',
+			);
+			const invalid = 'ver 999.888.777.666';
+			expect(redactText(invalid, { detect: ['ip'] }).text).toBe(invalid);
+		});
+
+		it('redacts a MAC address', () => {
+			const { text, matches } = redactText('mac 01:23:45:67:89:AB', { detect: ['mac'] });
+			expect(text).toBe('mac [REDACTED]');
+			expect(matches).toEqual([{ category: 'mac' }]);
+		});
+
+		it('redacts a full URL', () => {
+			expect(
+				redactText('see https://internal.example.com/admin?token=abc123 ok', { detect: ['url'] })
+					.text,
+			).toBe('see [REDACTED] ok');
+		});
 	});
 
 	describe('redactionOptionsFromGuardrail', () => {

--- a/packages/@n8n/agents/src/sdk/guardrails/patterns.ts
+++ b/packages/@n8n/agents/src/sdk/guardrails/patterns.ts
@@ -1,4 +1,5 @@
 import { SECRET_VALUE_PATTERNS } from '@n8n/utils';
+import { z, type ZodType } from 'zod';
 
 import type { PiiDetectionType } from '../../types';
 
@@ -59,9 +60,35 @@ export function passesLuhn(candidate: string): boolean {
 }
 
 /**
- * Conservative, high-confidence PII patterns. Phone numbers and physical
- * addresses are intentionally omitted — they are too false-positive-prone for
- * free-form agent prose. New {@link PiiDetectionType} categories slot in here.
+ * Adapt a Zod schema into a {@link RedactionPattern} `validate` gate: the
+ * pattern's regex *locates* a candidate substring in free-form text (Zod cannot
+ * scan prose), then the schema *confirms* it before redaction. Lets a rule
+ * express its confidence check declaratively — including a `z.string().regex(…)`
+ * — instead of as ad-hoc code (cf. {@link passesLuhn}). An optional `normalize`
+ * step runs on the located substring before validation (e.g. stripping the
+ * separators a regex tolerated so the schema sees a canonical value).
+ */
+export function zodGuard(
+	schema: ZodType,
+	normalize?: (match: string) => string,
+): (match: string) => boolean {
+	return (match) => schema.safeParse(normalize ? normalize(match) : match).success;
+}
+
+/**
+ * Confidence gate for phone candidates, encoding the **E.164** standard: a
+ * leading `+`, a non-zero country code, and 7–15 digits total. This mirrors
+ * Zod 4's `z.e164()`; expressed here as a classic-Zod regex because the repo is
+ * on Zod 3.25, where `e164()` isn't exposed on the default `zod` import.
+ * Validation runs on the digit/`+`-only normalized form (separators stripped).
+ */
+const PHONE_SCHEMA = z.string().regex(/^\+[1-9]\d{6,14}$/);
+
+/**
+ * Conservative, high-confidence PII patterns. Phone detection is best-effort:
+ * only well-structured (E.164) formats are matched. New {@link PiiDetectionType}
+ * categories slot in here; a category may map to `undefined` to declare it
+ * before a pattern exists, in which case it is excluded from detection.
  */
 const PII_PATTERNS: Readonly<Record<PiiDetectionType, RedactionPattern | undefined>> = {
 	email: {
@@ -81,16 +108,23 @@ const PII_PATTERNS: Readonly<Record<PiiDetectionType, RedactionPattern | undefin
 		// national IDs each get their own `ssn-<cc>` category (e.g. a future `ssn-uk`).
 		regex: /\b\d{3}-\d{2}-\d{4}\b/g,
 	},
-	// Deferred — too noisy for prose; declared so the type stays exhaustive.
-	phone: undefined,
-	address: undefined,
+	phone: {
+		category: 'phone',
+		// Best-effort, E.164 only: a leading `+` then 7–15 digits, tolerating
+		// the spaces/parens/dots/dashes people write between groups
+		// (e.g. `+1 (555) 123-4567`). Requiring the `+` keeps false positives
+		// low — bare digit runs (IDs, dates, NANP without `+`) are not matched.
+		// `zodGuard` normalizes to the digit/`+`-only form, then validates E.164.
+		regex: /\+\d(?:[\s().-]*\d){6,14}\b/g,
+		validate: zodGuard(PHONE_SCHEMA, (match) => match.replace(/[^\d+]/g, '')),
+	},
 };
 
 /**
- * PII categories that actually have a detection pattern today. `phone` and
- * `address` are part of {@link PiiDetectionType} but not yet implemented, so
- * they are excluded here — callers should treat this as the source of truth
- * for what redaction can detect.
+ * PII categories that actually have a detection pattern today — the source of
+ * truth for what redaction can detect. Any {@link PiiDetectionType} mapped to
+ * `undefined` in {@link PII_PATTERNS} (declared but not yet implemented) is
+ * excluded here.
  */
 export const SUPPORTED_PII_CATEGORIES: PiiDetectionType[] = (
 	Object.keys(PII_PATTERNS) as PiiDetectionType[]

--- a/packages/@n8n/agents/src/sdk/guardrails/patterns.ts
+++ b/packages/@n8n/agents/src/sdk/guardrails/patterns.ts
@@ -1,4 +1,5 @@
 import { SECRET_VALUE_PATTERNS } from '@n8n/utils';
+import { createHash } from 'node:crypto';
 import { z, type ZodType } from 'zod';
 
 import type { PiiDetectionType } from '../../types';
@@ -85,6 +86,70 @@ export function zodGuard(
 const PHONE_SCHEMA = z.string().regex(/^\+[1-9]\d{6,14}$/);
 
 /**
+ * IBAN mod-97 checksum (ISO 13616): drop spaces, move the first 4 chars to the
+ * end, map letters A–Z → 10–35, and confirm the big-integer value mod 97 === 1.
+ */
+export function passesIbanChecksum(candidate: string): boolean {
+	const compact = candidate.replace(/\s/g, '').toUpperCase();
+	if (!/^[A-Z]{2}\d{2}[A-Z0-9]{11,30}$/.test(compact)) return false;
+
+	const rearranged = compact.slice(4) + compact.slice(0, 4);
+	let remainder = 0;
+	for (let i = 0; i < rearranged.length; i++) {
+		const code = rearranged.charCodeAt(i);
+		const value = code >= 65 ? code - 55 : code - 48; // 'A'→10 … 'Z'→35, '0'→0 … '9'→9
+		remainder = value > 9 ? (remainder * 100 + value) % 97 : (remainder * 10 + value) % 97;
+	}
+	return remainder === 1;
+}
+
+const BASE58_ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+function base58Decode(input: string): Uint8Array | undefined {
+	const bytes: number[] = [];
+	for (let i = 0; i < input.length; i++) {
+		let carry = BASE58_ALPHABET.indexOf(input[i]);
+		if (carry === -1) return undefined;
+		for (let j = 0; j < bytes.length; j++) {
+			carry += bytes[j] * 58;
+			bytes[j] = carry & 0xff;
+			carry >>= 8;
+		}
+		while (carry > 0) {
+			bytes.push(carry & 0xff);
+			carry >>= 8;
+		}
+	}
+	for (let i = 0; i < input.length && input[i] === '1'; i++) bytes.push(0);
+	return Uint8Array.from(bytes.reverse());
+}
+
+/** Bitcoin Base58Check: the trailing 4 bytes are the SHA-256d checksum of the payload. */
+function passesBase58Check(candidate: string): boolean {
+	const decoded = base58Decode(candidate);
+	if (!decoded || decoded.length < 5) return false;
+	const payload = decoded.subarray(0, decoded.length - 4);
+	const checksum = decoded.subarray(decoded.length - 4);
+	const hash = createHash('sha256').update(createHash('sha256').update(payload).digest()).digest();
+	for (let i = 0; i < 4; i++) if (hash[i] !== checksum[i]) return false;
+	return true;
+}
+
+/** Ethereum (`0x`+40 hex), Bitcoin bech32 (`bc1`/`tb1`), or Bitcoin Base58Check address. */
+function isCryptoWallet(match: string): boolean {
+	if (/^0x[0-9a-fA-F]{40}$/.test(match)) return true; // ETH — `0x`+40 hex is distinctive
+	if (/^(?:bc1|tb1)[023456789acdefghjklmnpqrstuvwxyz]{11,71}$/.test(match)) return true; // bech32
+	return passesBase58Check(match); // legacy P2PKH/P2SH — checksum-gated
+}
+
+/** IPv4 with octets ≤ 255, or a colon-delimited IPv6 (shape already constrained by the regex). */
+function isIpAddress(match: string): boolean {
+	if (match.includes(':')) return true;
+	const octets = match.split('.');
+	return octets.length === 4 && octets.every((o) => /^\d{1,3}$/.test(o) && Number(o) <= 255);
+}
+
+/**
  * Conservative, high-confidence PII patterns. Phone detection is best-effort:
  * only well-structured (E.164) formats are matched. New {@link PiiDetectionType}
  * categories slot in here; a category may map to `undefined` to declare it
@@ -117,6 +182,43 @@ const PII_PATTERNS: Readonly<Record<PiiDetectionType, RedactionPattern | undefin
 		// `zodGuard` normalizes to the digit/`+`-only form, then validates E.164.
 		regex: /\+\d(?:[\s().-]*\d){6,14}\b/g,
 		validate: zodGuard(PHONE_SCHEMA, (match) => match.replace(/[^\d+]/g, '')),
+	},
+	iban: {
+		category: 'iban',
+		// Two forms: the compact (un-spaced) IBAN is matched case-insensitively so
+		// lower/mixed-case IBANs are caught — with no internal spaces it can't bleed
+		// into a following word. The spaced, group-of-4 form is matched upper-case
+		// only: spaced IBANs are written upper-case by convention, and that keeps the
+		// greedy body from swallowing following lower-case prose (which would fail the
+		// checksum and suppress redaction, since the engine doesn't retry sub-matches).
+		// `passesIbanChecksum` upper-cases, strips spaces, and verifies mod-97.
+		regex: /\b[A-Za-z]{2}\d{2}[A-Za-z0-9]{11,30}\b|\b[A-Z]{2}\d{2}(?: [A-Z0-9]{1,4}){2,8}\b/g,
+		validate: passesIbanChecksum,
+	},
+	'crypto-wallet': {
+		category: 'crypto-wallet',
+		// Ethereum `0x…40hex`, Bitcoin bech32 `bc1…`/`tb1…`, or Bitcoin Base58Check.
+		regex:
+			/\b(?:0x[0-9a-fA-F]{40}|(?:bc1|tb1)[023456789acdefghjklmnpqrstuvwxyz]{11,71}|[13][1-9A-HJ-NP-Za-km-z]{25,34})\b/g,
+		validate: isCryptoWallet,
+	},
+	// `mac` is declared before `ip`: a MAC is colon-delimited hex and would also
+	// match the IPv6 branch, so matching it as `mac` first keeps the category right.
+	mac: {
+		category: 'mac',
+		regex: /\b(?:[0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}\b/g,
+	},
+	ip: {
+		category: 'ip',
+		// IPv4 (octets validated) or IPv6 (full and `::`-compressed forms).
+		regex:
+			/\b(?:\d{1,3}\.){3}\d{1,3}\b|\b(?:[A-Fa-f0-9]{1,4}:){2,7}[A-Fa-f0-9]{1,4}\b|\b(?:[A-Fa-f0-9]{1,4}:){1,7}:(?:[A-Fa-f0-9]{1,4})?\b/g,
+		validate: isIpAddress,
+	},
+	url: {
+		category: 'url',
+		// Whole http(s) URL. Stops at whitespace and common trailing delimiters.
+		regex: /\bhttps?:\/\/[^\s<>"')\]}]+/g,
 	},
 };
 

--- a/packages/@n8n/agents/src/types/sdk/guardrail.ts
+++ b/packages/@n8n/agents/src/types/sdk/guardrail.ts
@@ -1,6 +1,15 @@
 export type GuardrailType = 'pii' | 'prompt-injection' | 'moderation' | 'custom';
 export type GuardrailStrategy = 'block' | 'redact' | 'warn';
-export type PiiDetectionType = 'email' | 'phone' | 'credit-card' | 'ssn-us';
+export type PiiDetectionType =
+	| 'email'
+	| 'phone'
+	| 'credit-card'
+	| 'ssn-us'
+	| 'iban'
+	| 'crypto-wallet'
+	| 'ip'
+	| 'mac'
+	| 'url';
 
 export interface BuiltGuardrail {
 	readonly name: string;

--- a/packages/@n8n/agents/src/types/sdk/guardrail.ts
+++ b/packages/@n8n/agents/src/types/sdk/guardrail.ts
@@ -1,6 +1,6 @@
 export type GuardrailType = 'pii' | 'prompt-injection' | 'moderation' | 'custom';
 export type GuardrailStrategy = 'block' | 'redact' | 'warn';
-export type PiiDetectionType = 'email' | 'phone' | 'credit-card' | 'ssn-us' | 'address';
+export type PiiDetectionType = 'email' | 'phone' | 'credit-card' | 'ssn-us';
 
 export interface BuiltGuardrail {
 	readonly name: string;

--- a/packages/@n8n/config/src/configs/instance-ai.config.ts
+++ b/packages/@n8n/config/src/configs/instance-ai.config.ts
@@ -148,7 +148,7 @@ export class InstanceAiConfig {
 	@Env('N8N_INSTANCE_AI_OUTPUT_REDACTION_SECRETS')
 	outputRedactionSecrets: boolean = true;
 
-	/** Comma-separated PII categories to redact from agent output. Available: email, phone, credit-card, ssn-us. Empty = no PII scanning. */
+	/** Comma-separated PII categories to redact from agent output. Available: email, phone, credit-card, ssn-us, iban, crypto-wallet, ip, mac, url. Empty = no PII scanning. */
 	@Env('N8N_INSTANCE_AI_OUTPUT_REDACTION_PII')
 	outputRedactionPii: string = 'credit-card';
 

--- a/packages/@n8n/config/src/configs/instance-ai.config.ts
+++ b/packages/@n8n/config/src/configs/instance-ai.config.ts
@@ -148,7 +148,7 @@ export class InstanceAiConfig {
 	@Env('N8N_INSTANCE_AI_OUTPUT_REDACTION_SECRETS')
 	outputRedactionSecrets: boolean = true;
 
-	/** Comma-separated PII categories to redact from agent output. Available: email, credit-card, ssn-us. Empty = no PII scanning. */
+	/** Comma-separated PII categories to redact from agent output. Available: email, phone, credit-card, ssn-us. Empty = no PII scanning. */
 	@Env('N8N_INSTANCE_AI_OUTPUT_REDACTION_PII')
 	outputRedactionPii: string = 'credit-card';
 

--- a/packages/cli/src/modules/instance-ai/__tests__/output-redaction-config.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/output-redaction-config.test.ts
@@ -35,10 +35,10 @@ describe('resolveOutputRedaction', () => {
 		);
 	});
 
-	it('drops not-yet-implemented categories (phone, address)', () => {
+	it('drops unsupported categories (e.g. address, which has no detector)', () => {
 		expect(
 			resolveOutputRedaction(config({ outputRedactionPii: 'email,phone,address,ssn-us' })),
-		).toMatchObject({ detect: ['email', 'ssn-us'] });
+		).toMatchObject({ detect: ['email', 'phone', 'ssn-us'] });
 	});
 
 	it('honors the secrets toggle and an empty PII list', () => {


### PR DESCRIPTION
## Summary

Add more patterns for redacting certain PII patterns from instance AI messages
- `phone` numbers
- `iban` accounts
- `crypto-wallet` strings
- `ip` addresses
- `mac` addresses
- `url` addresses

These are used on telemetry redaction by default, but user could enable them on `N8N_INSTANCE_AI_OUTPUT_REDACTION_PII` too if they like to.

Related: https://github.com/n8n-io/n8n/pull/32438

## How to test

Have these on at `N8N_INSTANCE_AI_OUTPUT_REDACTION_PII`, confirm AI outputs redact these.
(Or just trust the unit tests...)

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/INS-474

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32441">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

