### PR TITLE
fix(ai-builder): Reject discarded workflow branch builders 

### DIFF
--- a/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
+++ b/packages/@n8n/instance-ai/skills/workflow-builder/SKILL.md
@@ -448,11 +448,15 @@ Follow these rules strictly when generating workflows:
    strings, fake API keys, hardcoded auth values, invented credential IDs, or
    raw `mock-*` IDs.
 2. Skip-on-empty is n8n's default behaviour: when a node outputs zero items,
-   downstream nodes simply do not run and the branch ends silently. Trust it —
-   do not add `alwaysOutputData: true` just to keep a chain alive, and do not
-   add an IF gate before a loop only to check whether items exist. To make an
-   outcome happen even with zero items, wire it via the control-flow rule
-   below.
+   downstream nodes simply do not run and the branch ends silently. Trust it
+   for polling/scheduled work, loops, filters, and per-item processing. Use
+   `alwaysOutputData: true` when the empty result is meaningful and the
+   workflow must continue, such as an optional lookup that sets a
+   boolean/default value or a dedicated "no results" path. Put the flag on the
+   producer that can output zero items, and make the next node explicitly
+   handle the empty marker instead of blindly reading fields. After an optional
+   lookup, use `nodeJson(sourceNode, 'field')` to read the original upstream
+   data; `$json` may be the empty marker.
 3. Use `executeOnce: true` for a node that receives many items but should run
    once, such as a summary notification, report generation, shared-context
    fetch, or API call that does not vary per input item. Duplicate
@@ -472,9 +476,10 @@ Follow these rules strictly when generating workflows:
      output never fires. The fix goes on the PRODUCER, not the consumer:
      `alwaysOutputData: true` in the config of the node whose output can be
      empty (the fetch or the filter) makes it emit one empty-marker item
-     (empty `$json`) instead of ending the branch; an IF then separates that
-     marker from real items. Putting the flag on the node you want to run
-     does nothing. Example:
+     (empty `$json`) instead of ending the branch. Then either use an IF to
+     separate that marker from real items, or use a safe Set node to compute a
+     boolean/default value after an optional lookup. Putting the flag on the
+     node you want to run does nothing. Example:
      `node({ type: 'n8n-nodes-base.httpRequest', config: { alwaysOutputData: true, name: 'Fetch Posts', parameters: { /* ... */ } } })`
    - A Filter or IF only selects items; it does not perform the requested side
      effect. If the user asks to archive, update, delete, send, or create only

--- a/packages/@n8n/workflow-sdk/src/ast-interpreter/interpreter.test.ts
+++ b/packages/@n8n/workflow-sdk/src/ast-interpreter/interpreter.test.ts
@@ -768,6 +768,115 @@ describe('AST Interpreter', () => {
 		});
 	});
 
+	describe('interpretSDKCode - control-flow branch builders', () => {
+		let sdkFunctions: SDKFunctions;
+
+		type BranchBuilder = {
+			_isIfElseBuilder: true;
+			trueBranch?: unknown;
+			falseBranch?: unknown;
+			onTrue(target: unknown): BranchBuilder;
+			onFalse(target: unknown): BranchBuilder;
+		};
+
+		function createBranchBuilder(initial?: {
+			trueBranch?: unknown;
+			falseBranch?: unknown;
+		}): BranchBuilder {
+			const builder: BranchBuilder = {
+				_isIfElseBuilder: true,
+				trueBranch: initial?.trueBranch,
+				falseBranch: initial?.falseBranch,
+				onTrue: vi.fn((target: unknown) => {
+					builder.trueBranch = target;
+					return builder;
+				}),
+				onFalse: vi.fn((target: unknown) => {
+					builder.falseBranch = target;
+					return builder;
+				}),
+			};
+			return builder;
+		}
+
+		beforeEach(() => {
+			sdkFunctions = createMockSDKFunctions();
+			sdkFunctions.node = vi.fn((config: { type?: string; config?: { name?: string } }) => {
+				const nodeName = config.config?.name ?? config.type ?? 'Node';
+				if (config.type === 'n8n-nodes-base.if') {
+					return {
+						name: nodeName,
+						onTrue: vi.fn((target: unknown) => createBranchBuilder({ trueBranch: target })),
+						onFalse: vi.fn((target: unknown) => createBranchBuilder({ falseBranch: target })),
+					};
+				}
+				return { name: nodeName };
+			});
+		});
+
+		it('rejects discarded IF branch builders', () => {
+			const code = `
+				const ifNode = node({ type: 'n8n-nodes-base.if', version: 2.2, config: { name: 'Check' } });
+				const yes = node({ type: 'n8n-nodes-base.noOp', version: 1, config: { name: 'Yes' } });
+				ifNode.onTrue(yes);
+				export default ifNode;
+			`;
+
+			expect(() => interpretSDKCode(code, sdkFunctions)).toThrow(
+				'Discarded control-flow branch builder',
+			);
+		});
+
+		it('allows mutating a named IF branch builder before export', () => {
+			const code = `
+				const ifNode = node({ type: 'n8n-nodes-base.if', version: 2.2, config: { name: 'Check' } });
+				const yes = node({ type: 'n8n-nodes-base.noOp', version: 1, config: { name: 'Yes' } });
+				const no = node({ type: 'n8n-nodes-base.noOp', version: 1, config: { name: 'No' } });
+				const branch = ifNode.onTrue(yes);
+				branch.onFalse(no);
+				export default branch;
+			`;
+
+			const result = interpretSDKCode(code, sdkFunctions) as {
+				trueBranch?: { name?: string };
+				falseBranch?: { name?: string };
+			};
+
+			expect(result.trueBranch?.name).toBe('Yes');
+			expect(result.falseBranch?.name).toBe('No');
+		});
+
+		it('allows cursor branch chaining on a workflow builder expression statement', () => {
+			sdkFunctions.workflow = vi.fn((id: string, name: string) => {
+				const wf: {
+					id: string;
+					name: string;
+					to(target: unknown): unknown;
+					onTrue(target: unknown): unknown;
+					onFalse(target: unknown): unknown;
+				} = {
+					id,
+					name,
+					to: vi.fn(() => wf),
+					onTrue: vi.fn(() => wf),
+					onFalse: vi.fn(() => wf),
+				};
+				return wf;
+			});
+
+			const code = `
+				const wf = workflow('id', 'name');
+				const ifNode = node({ type: 'n8n-nodes-base.if', version: 2.2, config: { name: 'Check' } });
+				const yes = node({ type: 'n8n-nodes-base.noOp', version: 1, config: { name: 'Yes' } });
+				const no = node({ type: 'n8n-nodes-base.noOp', version: 1, config: { name: 'No' } });
+				wf.to(ifNode).onTrue(yes).onFalse(no);
+				export default wf;
+			`;
+
+			expect(() => interpretSDKCode(code, sdkFunctions)).not.toThrow();
+		});
+	});
+
 	describe('Security - method allowlist enforcement', () => {
 		let sdkFunctions: SDKFunctions;
 

--- a/packages/@n8n/workflow-sdk/src/ast-interpreter/interpreter.ts
+++ b/packages/@n8n/workflow-sdk/src/ast-interpreter/interpreter.ts
@@ -76,6 +76,7 @@ class SDKInterpreter {
 					break;
 				case 'ExpressionStatement':
 					result = this.evaluate(stmt.expression);
+					this.assertNoDiscardedBranchBuilder(stmt.expression, result);
 					break;
 				case 'ExportDefaultDeclaration':
 					return this.evaluate(stmt.declaration as ESTree.Expression);
@@ -85,6 +86,62 @@ class SDKInterpreter {
 		}
 
 		return result;
+	}
+
+	private isBranchBuilder(value: unknown): boolean {
+		return (
+			typeof value === 'object' &&
+			value !== null &&
+			(('_isIfElseBuilder' in value &&
+				(value as { _isIfElseBuilder?: unknown })._isIfElseBuilder === true) ||
+				('_isSwitchCaseBuilder' in value &&
+					(value as { _isSwitchCaseBuilder?: unknown })._isSwitchCaseBuilder === true))
+		);
+	}
+
+	private getRootMemberObject(node: ESTree.Expression): ESTree.Expression | undefined {
+		if (node.type !== 'CallExpression' || node.callee.type !== 'MemberExpression') {
+			return undefined;
+		}
+
+		const object = node.callee.object;
+		if (object.type === 'CallExpression') {
+			return this.getRootMemberObject(object) ?? object;
+		}
+
+		if (object.type === 'Super') {
+			return undefined;
+		}
+
+		return object;
+	}
+
+	private isCallOnNamedBranchBuilder(expression: ESTree.Expression): boolean {
+		const root = this.getRootMemberObject(expression);
+		if (!root || root.type !== 'Identifier') {
+			return false;
+		}
+
+		const resolvedName = this.renamedVariables.get(root.name) ?? root.name;
+		if (!this.variables.has(resolvedName)) {
+			return false;
+		}
+
+		return this.isBranchBuilder(this.variables.get(resolvedName));
+	}
+
+	private assertNoDiscardedBranchBuilder(expression: ESTree.Expression, value: unknown): void {
+		if (!this.isBranchBuilder(value) || this.isCallOnNamedBranchBuilder(expression)) {
+			return;
+		}
+
+		throw new InterpreterError(
+			'Discarded control-flow branch builder. ' +
+				'Calls like `ifNode.onTrue(...)`, `ifNode.onFalse(...)`, and `switchNode.onCase(...)` return a branch builder; they do not mutate the node when the return value is ignored. ' +
+				'Pass the chained builder to `.to(...)`/`.add(...)`, or use cursor chaining like `workflow(...).to(ifNode).onTrue(yes).onFalse(no)`.',
+			expression.loc ?? undefined,
+			this.sourceCode,
+		);
 	}
 
 	/**

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-patterns.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-patterns.ts
@@ -110,7 +110,7 @@ export default workflow('id', 'name')
 <zero_item_safety>
 When a node returns 0 items, downstream nodes are skipped for that execution. **This is usually the correct behavior** — the scheduler / trigger fires again later, and when there is data, the chain runs normally. Don't paper over an empty result with \`alwaysOutputData: true\` by default.
 
-**\`alwaysOutputData: true\` forces a synthetic \`{json: {}}\` item downstream.** This is a footgun: downstream nodes will try to read fields that don't exist, HTTP requests will hit \`GET undefined\`, and loops will run once on a fake item. Use it *only* when the empty case has its own dedicated branch that you want to execute.
+**\`alwaysOutputData: true\` forces a synthetic \`{json: {}}\` item downstream.** This is a footgun when downstream nodes blindly read fields that may not exist. Use it only when "no items" is meaningful and the next node explicitly handles the empty marker, such as an optional lookup that sets a boolean/default value or a dedicated no-results branch.
 
 **Correct pattern — no \`alwaysOutputData\`:**
 \`\`\`javascript
@@ -155,7 +155,50 @@ workflow('search', 'Search').add(trigger).to(search).to(
 );
 \`\`\`
 
-**When to use \`alwaysOutputData: true\`:** only when you've paired it with an explicit empty-case branch, AND the downstream branch doesn't blindly read item fields.
+**Correct pattern — optional lookup must continue:**
+\`\`\`javascript
+// Form submission continues whether or not a matching customer row exists.
+const lookupCustomer = node({
+  type: 'n8n-nodes-base.dataTable',
+  version: 1.1,
+  config: {
+    name: 'Look Up Customer',
+    alwaysOutputData: true,              // no-match is handled by Mark Returning below
+    parameters: {
+      resource: 'row',
+      operation: 'get',
+      dataTableId: { __rl: true, mode: 'name', value: 'Customers' },
+      matchType: 'allConditions',
+      filters: { conditions: [{ keyName: 'email', condition: 'eq', keyValue: nodeJson(formTrigger, 'email') }] },
+      returnAll: false,
+      limit: 1
+    }
+  }
+});
+
+const markReturning = node({
+  type: 'n8n-nodes-base.set',
+  version: 3.4,
+  config: {
+    name: 'Mark Returning',
+    parameters: {
+      assignments: {
+        assignments: [{ id: 'is_returning', name: 'is_returning', type: 'boolean', value: expr('{{ $json.id !== undefined && $json.id !== null }}') }]
+      },
+      includeOtherFields: false
+    }
+  }
+});
+
+workflow('signup', 'Signup')
+  .add(formTrigger)
+  .to(lookupCustomer)
+  .to(markReturning)
+  .to(nextFormPage);
+// Use nodeJson(formTrigger, 'email') later; after a no-match lookup, $json is the empty marker.
+\`\`\`
+
+**When to use \`alwaysOutputData: true\`:** when the empty result itself is meaningful and the next node handles the empty marker safely — an explicit empty-case branch, or a safe flag/default computation after an optional lookup.
 
 **When NOT to use it:**
 - Scheduled/polling triggers where the "no work" case should silently skip

--- a/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-rules.ts
+++ b/packages/@n8n/workflow-sdk/src/prompts/sdk-reference/workflow-rules.ts
@@ -16,11 +16,12 @@ export const WORKFLOW_RULES = `Follow these rules strictly when generating workf
    - Example: \`credentials: { slackApi: newCredential('Slack Bot') }\`
    - The credential type must match what the node expects
 
-2. **Trust empty item lists — don't synthesize fake items**
+2. **Trust empty item lists — keep optional lookups explicit**
    - When a query returns 0 items, downstream nodes simply don't run for that execution. For scheduled or polling triggers this is the correct "nothing to do this round" signal — the next run will execute normally when data appears.
-   - DO NOT add \`alwaysOutputData: true\` just to "keep the chain alive." Forcing an empty \`{}\` item downstream is what causes \`undefined\` reads, failed HTTP calls to \`GET undefined\`, and Code-node crashes on missing fields.
+   - Do not add \`alwaysOutputData: true\` just to keep loops or per-item processing alive. Forcing an empty \`{}\` item downstream can cause \`undefined\` reads, failed HTTP calls to \`GET undefined\`, and Code-node crashes on missing fields.
+   - Use \`alwaysOutputData: true\` when "no match" is meaningful data the workflow must continue with — for example an optional lookup that computes a boolean/default value, or a dedicated "no results" notification path. Put the flag on the producer that can output zero items, and make the next node explicitly handle the empty marker instead of blindly reading fields.
    - DO NOT add an IF gate before a loop to check "has items?" — loops (\`splitInBatches\`, per-item nodes, \`filter\`) already no-op on empty input. The gate is redundant and adds a failure surface.
-   - \`alwaysOutputData: true\` is only correct when you specifically need a downstream branch to run on the "empty" case — e.g. a dedicated "no matches found" notification path. In that case, pair it with an \`IF\` that explicitly checks for the empty case and routes accordingly. Never use it as a default.
+   - If an optional lookup is followed by more user-input or write steps, preserve the original upstream data with \`nodeJson(sourceNode, 'field')\`; after an empty lookup, \`$json\` is the empty marker, not the original item.
    - To drop invalid items mid-pipeline, use a \`filter\` node. A \`filter\` that rejects everything emits 0 items and the chain correctly stops — no \`IF\` + \`splitInBatches\` composition needed.
 
 3. **Use \`executeOnce: true\` for single-execution nodes**

--- a/packages/@n8n/workflow-sdk/src/workflow-builder/control-flow-builders/branch-cursor.test.ts
+++ b/packages/@n8n/workflow-sdk/src/workflow-builder/control-flow-builders/branch-cursor.test.ts
@@ -18,6 +18,22 @@ export default workflow('w', 'W')
 		expect(() => parseWorkflowCode(code)).not.toThrow();
 	});
 
+	it('rejects discarded IF node branch builders', () => {
+		const code = `
+const start = trigger({ type: 'n8n-nodes-base.manualTrigger', version: 1, config: { name: 'Start' } });
+const ifNode = ifElse({ version: 2.3, config: { name: 'Check' } });
+const yes = node({ type: 'n8n-nodes-base.noOp', version: 1, config: { name: 'Yes' } });
+const no = node({ type: 'n8n-nodes-base.noOp', version: 1, config: { name: 'No' } });
+
+ifNode.onTrue(yes);
+ifNode.onFalse(no);
+
+export default workflow('id', 'Test').add(start).to(ifNode);
+`;
+
+		expect(() => parseWorkflowCode(code)).toThrow('Discarded control-flow branch builder');
+	});
+
 	it('wires both IF outputs when branching off the cursor', () => {
 		const t = trigger({ type: 'n8n-nodes-base.manualTrigger', version: 1, config: {} });
 		const ifNode = ifElse({ version: 2.3, config: { name: 'My IF' } });


### PR DESCRIPTION
## Summary

This tightens up two workflow-builder rough edges:

- fails fast when SDK code calls `ifNode.onTrue(...)`, `ifNode.onFalse(...)`, or `switchNode.onCase(...)` as a standalone statement and then drops the returned branch builder
- clarifies when `alwaysOutputData` is the right tool for optional lookups that must continue, without encouraging fake empty items in loops or per-item flows

The docs now call out the safe optional lookup pattern: put `alwaysOutputData` on the lookup node, immediately compute a safe flag/default, and use `nodeJson(...)` when later nodes need original upstream data.


## How to test

<!--
Describe all steps needed to test the changes.
Include an example workflow if the changes affect Workflow builder, execution or a Node, that can be tested with a workflow.
-->

## Related Linear tickets, Github issues, and Community forum posts

<!--
Include links to **Linear ticket** or Github issue or Community forum post.
Important in order to close *automatically* and provide context to reviewers.
https://linear.app/n8n/issue/[TICKET-ID]
-->
<!-- Use "closes #<issue-number>", "fixes #<issue-number>", or "resolves #<issue-number>" to automatically close issues when the PR is merged. -->


## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md)) <!--
   **Remember, the title automatically goes into the changelog.
   Use `(no-changelog)` otherwise.**
-->
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [x] Tests included. <!--
   A bug is not considered fixed, unless a test is added to prevent it from happening again.
   A feature is not complete without tests.
-->
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32442">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32442?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

