### PR TITLE
feat(editor): Rename n8n Connect usage table header from Model to Resource

### DIFF
--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4638,7 +4638,7 @@
 	"settings.n8nConnect.usage.refresh": "Refresh",
 	"settings.n8nConnect.usage.col.date": "Date",
 	"settings.n8nConnect.usage.col.provider": "Provider",
-	"settings.n8nConnect.usage.col.model": "Model",
+	"settings.n8nConnect.usage.col.model": "Resource",
 	"settings.n8nConnect.usage.col.inputTokens": "Input Tokens",
 	"settings.n8nConnect.usage.col.outputTokens": "Output Tokens",
 	"settings.n8nConnect.usage.col.cost": "Cost (USD)",

--- a/packages/frontend/@n8n/i18n/src/locales/en.json
+++ b/packages/frontend/@n8n/i18n/src/locales/en.json
@@ -4638,7 +4638,7 @@
 	"settings.n8nConnect.usage.refresh": "Refresh",
 	"settings.n8nConnect.usage.col.date": "Date",
 	"settings.n8nConnect.usage.col.provider": "Provider",
-	"settings.n8nConnect.usage.col.model": "Resource",
+	"settings.n8nConnect.usage.col.resource": "Resource",
 	"settings.n8nConnect.usage.col.inputTokens": "Input Tokens",
 	"settings.n8nConnect.usage.col.outputTokens": "Output Tokens",
 	"settings.n8nConnect.usage.col.cost": "Cost (USD)",

--- a/packages/frontend/editor-ui/src/features/ai/gateway/views/SettingsAiGatewayView.vue
+++ b/packages/frontend/editor-ui/src/features/ai/gateway/views/SettingsAiGatewayView.vue
@@ -62,7 +62,7 @@ const tableHeaders = ref<Array<TableHeader<AiGatewayUsageEntry>>>([
 		resize: false,
 	},
 	{
-		title: i18n.baseText('settings.n8nConnect.usage.col.model'),
+		title: i18n.baseText('settings.n8nConnect.usage.col.resource'),
 		key: 'model',
 		width: 220,
 		disableSort: true,


### PR DESCRIPTION
## Summary

Renames the n8n Connect usage history table header from **Model** to **Resource** to account for non-model providers (e.g. `firecrawl`). Visual text only — the underlying `model` API field and data column key are unchanged.

## How to test

Open **Settings → n8n Connect** and confirm the usage table header reads **Resource**.

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/RLY-103

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive. ([conventions](../blob/master/.github/pull_request_title_conventions.md))
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created.
- [ ] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)

🤖 PR Summary generated by AI