### PR TITLE
perf(core): Move Instance AI clock out of the cached prompt prefix

### DIFF
--- a/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.test.ts
+++ b/packages/@n8n/instance-ai/src/agent/__tests__/system-prompt.test.ts
@@ -26,6 +26,12 @@ describe('getDateTimeSection', () => {
 });
 
 describe('getSystemPrompt', () => {
+	it('keeps the cached prefix free of the current date/time so it stays cacheable', () => {
+		const prompt = getSystemPrompt({});
+
+		expect(prompt).not.toContain('## Current Date and Time');
+	});
+
 	describe('first visible turn guidance', () => {
 		it('instructs the agent to send a concise sentence before the first tool call', () => {
 			const prompt = getSystemPrompt({});

--- a/packages/@n8n/instance-ai/src/agent/instance-agent.ts
+++ b/packages/@n8n/instance-ai/src/agent/instance-agent.ts
@@ -132,7 +132,6 @@ export async function createInstanceAgent(options: CreateInstanceAgentOptions): 
 		localGateway: context.localGatewayStatus,
 		toolSearchEnabled: hasDeferrableTools,
 		licenseHints: context.licenseHints,
-		timeZone: options.timeZone,
 		browserAvailable: browserToolNames.size > 0,
 		branchReadOnly: context.branchReadOnly,
 		workspaceRoot:

--- a/packages/@n8n/instance-ai/src/agent/system-prompt.ts
+++ b/packages/@n8n/instance-ai/src/agent/system-prompt.ts
@@ -12,8 +12,6 @@ interface SystemPromptOptions {
 	toolSearchEnabled?: boolean;
 	/** Human-readable hints about licensed features that are NOT available on this instance. */
 	licenseHints?: string[];
-	/** IANA time zone identifier for the current user (e.g. "Europe/Helsinki"). */
-	timeZone?: string;
 	browserAvailable?: boolean;
 	/** When true, the instance is in read-only mode (source control branchReadOnly). */
 	branchReadOnly?: boolean;
@@ -109,7 +107,6 @@ export function getSystemPrompt(options: SystemPromptOptions = {}): string {
 		localGateway,
 		toolSearchEnabled,
 		licenseHints,
-		timeZone,
 		browserAvailable,
 		branchReadOnly,
 		projectId,
@@ -117,7 +114,6 @@ export function getSystemPrompt(options: SystemPromptOptions = {}): string {
 	} = options;
 
 	return `You are the n8n Instance Agent — an AI assistant embedded in an n8n instance. You help users build, run, debug, and manage workflows through natural language.
-${getDateTimeSection(timeZone)}
 ${webhookBaseUrl && formBaseUrl ? getInstanceInfoSection(webhookBaseUrl, formBaseUrl) : ''}
 ${workspaceRoot ? `\n${getSandboxWorkspaceSection(workspaceRoot)}\n` : ''}
 

--- a/packages/@n8n/instance-ai/src/index.ts
+++ b/packages/@n8n/instance-ai/src/index.ts
@@ -5,6 +5,7 @@ import './source-map-filter';
 
 import type * as InstanceAgentMod from './agent/instance-agent';
 import type * as SubAgentFactoryMod from './agent/sub-agent-factory';
+import type * as SystemPromptMod from './agent/system-prompt';
 import type * as DomainAccessMod from './domain-access';
 import type * as McpClientManagerMod from './mcp/mcp-client-manager';
 import type * as TitleUtilsMod from './memory/title-utils';
@@ -93,6 +94,9 @@ const loadInstanceAgent = lazyModule(
 const loadDomainAccess = lazyModule(() => require('./domain-access') as typeof DomainAccessMod);
 const loadSubAgentFactory = lazyModule(
 	() => require('./agent/sub-agent-factory') as typeof SubAgentFactoryMod,
+);
+const loadSystemPrompt = lazyModule(
+	() => require('./agent/system-prompt') as typeof SystemPromptMod,
 );
 const loadSanitizeWebContent = lazyModule(
 	() => require('./tools/web-research/sanitize-web-content') as typeof SanitizeWebContentMod,
@@ -284,6 +288,9 @@ export const createInstanceAgent: typeof InstanceAgentMod.createInstanceAgent = 
 
 export const createSubAgent: typeof SubAgentFactoryMod.createSubAgent = lazyFunction(
 	() => loadSubAgentFactory().createSubAgent,
+);
+export const getDateTimeSection: typeof SystemPromptMod.getDateTimeSection = lazyFunction(
+	() => loadSystemPrompt().getDateTimeSection,
 );
 export const createAllTools: typeof ToolsMod.createAllTools = lazyFunction(
 	() => loadTools().createAllTools,

--- a/packages/@n8n/instance-ai/src/types.ts
+++ b/packages/@n8n/instance-ai/src/types.ts
@@ -1354,6 +1354,4 @@ export interface CreateInstanceAgentOptions {
 	 * Intended for tests and fallback paths that need the full toolset visible immediately.
 	 */
 	disableDeferredTools?: boolean;
-	/** IANA time zone for the current user (e.g. "Europe/Helsinki"). Falls back to instance default. */
-	timeZone?: string;
 }

--- a/packages/cli/src/modules/instance-ai/__tests__/internal-messages.test.ts
+++ b/packages/cli/src/modules/instance-ai/__tests__/internal-messages.test.ts
@@ -1,4 +1,8 @@
-import { cleanStoredUserMessage, AUTO_FOLLOW_UP_MESSAGE } from '../internal-messages';
+import {
+	cleanStoredUserMessage,
+	withCurrentDateTime,
+	AUTO_FOLLOW_UP_MESSAGE,
+} from '../internal-messages';
 
 describe('cleanStoredUserMessage', () => {
 	it('returns plain text unchanged', () => {
@@ -41,5 +45,20 @@ describe('cleanStoredUserMessage', () => {
 	it('does not strip task blocks that are not at the beginning', () => {
 		const stored = 'Some text\n<running-tasks>\ntask\n</running-tasks>\n\nMore text';
 		expect(cleanStoredUserMessage(stored)).toBe(stored);
+	});
+
+	it('strips the appended <current-date-time> block', () => {
+		const stored = withCurrentDateTime(
+			'Build me a workflow',
+			'\n## Current Date and Time\n\n2026-06-17T10:00+02:00',
+		);
+		expect(stored).toContain('<current-date-time>');
+		expect(cleanStoredUserMessage(stored)).toBe('Build me a workflow');
+	});
+
+	it('strips both a leading task block and the appended date/time block', () => {
+		const enriched = '<running-tasks>\n[task info]\n</running-tasks>\n\nUser message';
+		const stored = withCurrentDateTime(enriched, '\n2026-06-17T10:00+02:00');
+		expect(cleanStoredUserMessage(stored)).toBe('User message');
 	});
 });

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -99,7 +99,7 @@ import { InstanceAiMemoryService } from './instance-ai-memory.service';
 import { InstanceAiSettingsService } from './instance-ai-settings.service';
 import { InstanceAiAdapterService } from './instance-ai.adapter.service';
 import { resolveOutputRedaction } from './output-redaction-config';
-import { AUTO_FOLLOW_UP_MESSAGE } from './internal-messages';
+import { AUTO_FOLLOW_UP_MESSAGE, withCurrentDateTime } from './internal-messages';
 import { INSTANCE_AI_RUN_TIMEOUT_REASON, InstanceAiLivenessService } from './liveness';
 import { InstanceAiMcpRegistryService } from './mcp';
 import { InstanceAiPendingConfirmationRepository } from './repositories/instance-ai-pending-confirmation.repository';
@@ -3725,7 +3725,11 @@ export class InstanceAiService {
 						: enrichedMessage;
 
 			// Carry "now" on the per-turn input, not the cached system prefix, so the prefix stays cacheable.
-			const fullMessage = `${messageBody}\n${getDateTimeSection(timeZone ?? this.defaultTimeZone)}`;
+			// Wrapped so the parser strips it from the displayed user message on history reload.
+			const fullMessage = withCurrentDateTime(
+				messageBody,
+				getDateTimeSection(timeZone ?? this.defaultTimeZone),
+			);
 
 			const promptBuildRun = tracing
 				? await tracing.startChildRun(tracing.messageRun, {
@@ -3816,7 +3820,6 @@ export class InstanceAiService {
 				memoryConfig,
 				memory,
 				checkpointStore: this.checkpointStore,
-				timeZone: timeZone ?? this.defaultTimeZone,
 			});
 
 			const streamOptions = this.buildOrchestratorAgentStreamOptions(user, threadId, runId, signal);
@@ -4484,7 +4487,6 @@ export class InstanceAiService {
 				memoryConfig: this.createAgentMemoryOptions(),
 				memory: environment.memory,
 				checkpointStore: this.checkpointStore,
-				timeZone: this.runState.getTimeZone(orphan.threadId) ?? this.defaultTimeZone,
 			});
 		} catch (error: unknown) {
 			return { kind: 'agent-failure', error };

--- a/packages/cli/src/modules/instance-ai/instance-ai.service.ts
+++ b/packages/cli/src/modules/instance-ai/instance-ai.service.ts
@@ -35,6 +35,7 @@ import {
 	buildAgentTreeFromEvents,
 	classifyAttachments,
 	buildAttachmentManifest,
+	getDateTimeSection,
 	isParseableAttachment,
 	enrichMessageWithBackgroundTasks,
 	InstanceAiTerminalResponseGuard,
@@ -3716,12 +3717,15 @@ export class InstanceAiService {
 				attachmentManifest = buildAttachmentManifest(classifiedAttachments);
 			}
 
-			const fullMessage =
+			const messageBody =
 				!message && hasParseableAttachment
 					? `The user attached file(s) without a message. Inspect the first parseable attachment with parse-file and provide a concise summary.\n\n${attachmentManifest}`
 					: attachmentManifest
 						? `${enrichedMessage}\n\n${attachmentManifest}`
 						: enrichedMessage;
+
+			// Carry "now" on the per-turn input, not the cached system prefix, so the prefix stays cacheable.
+			const fullMessage = `${messageBody}\n${getDateTimeSection(timeZone ?? this.defaultTimeZone)}`;
 
 			const promptBuildRun = tracing
 				? await tracing.startChildRun(tracing.messageRun, {

--- a/packages/cli/src/modules/instance-ai/internal-messages.ts
+++ b/packages/cli/src/modules/instance-ai/internal-messages.ts
@@ -15,12 +15,20 @@ export const AUTO_FOLLOW_UP_MESSAGE = '(continue)';
 const TASK_CONTEXT_BLOCK =
 	/^(?:<running-tasks>\n[\s\S]*?\n<\/running-tasks>|<planned-task-follow-up[\s\S]*?\n<\/planned-task-follow-up>|<planning-blueprint>\n[\s\S]*?\n<\/planning-blueprint>|<background-task-completed>\n[\s\S]*?\n<\/background-task-completed>|<workflow-verification-follow-up>\n[\s\S]*?\n<\/workflow-verification-follow-up>|<workflow-setup-required>\n[\s\S]*?\n<\/workflow-setup-required>)\n\n/;
 
+/** Matches the per-turn date/time block the service appends to the user message. */
+const CURRENT_DATE_TIME_BLOCK = /\n*<current-date-time>[\s\S]*?<\/current-date-time>\s*$/;
+
+/** Append the per-turn clock as a tagged suffix the parser strips before display. */
+export function withCurrentDateTime(message: string, dateTimeSection: string): string {
+	return `${message}\n\n<current-date-time>${dateTimeSection}\n</current-date-time>`;
+}
+
 /**
  * Recover the original user text from a stored message that may contain
  * internal enrichment. Returns `null` for auto-follow-up messages that
  * should be hidden from the UI entirely.
  */
 export function cleanStoredUserMessage(stored: string): string | null {
-	const text = stored.replace(TASK_CONTEXT_BLOCK, '');
+	const text = stored.replace(TASK_CONTEXT_BLOCK, '').replace(CURRENT_DATE_TIME_BLOCK, '');
 	return text === AUTO_FOLLOW_UP_MESSAGE ? null : text;
 }


### PR DESCRIPTION
## Summary

Follow-up to #32404. That PR truncated the Instance AI system-prompt clock to the minute so the cached prefix stayed byte-stable within a cache TTL. This removes the workaround entirely by taking the clock **out of the cached prefix**.

`getDateTimeSection()` was the second line of the system prompt, which is the single `ephemeral` cache breakpoint. Any moving byte before the breakpoint invalidates the whole otherwise-static prefix. Instead of stabilizing the moving byte, we render "now" on the **per-turn user input** — the same uncached seam that already carries the attachment manifest and running-tasks context. The system prefix is now fully static and served from cache every turn.

### Changes
- `system-prompt.ts`: drop `getDateTimeSection()` from `getSystemPrompt()` and remove the now-unused `timeZone` option.
- `instance-agent.ts` / `types.ts`: stop passing `timeZone` to `getSystemPrompt`, and drop the now-dead `timeZone` field from `CreateInstanceAgentOptions`.
- `index.ts`: export `getDateTimeSection` (lazy, mirrors existing pattern).
- `instance-ai.service.ts`: append the clock to the per-turn message body via `withCurrentDateTime()`.
- `internal-messages.ts`: wrap the clock in a `<current-date-time>` block that `cleanStoredUserMessage` strips on history reload, reusing the existing task-context strip protocol — so the timestamp is **not** shown in the displayed user message.

`getDateTimeSection` is unchanged (minute precision) and still tested.

### Trade-off
Background/planned-task follow-up turns (`<background-task-completed>`, etc.) don't go through the per-turn `fullMessage` path, so they read "now" from the triggering user turn in history rather than a freshly-injected timestamp. Fine for interactive use; a detached task firing much later sees a slightly stale clock. Left out of scope (same boundary as the deferred sub-agent path).

## How to test

- `pnpm --filter @n8n/instance-ai test src/agent/__tests__/system-prompt.test.ts`
  - New assertion: `getSystemPrompt()` no longer contains `## Current Date and Time`.
- `pnpm --filter n8n test src/modules/instance-ai/__tests__/internal-messages.test.ts`
  - New assertions: the `<current-date-time>` block is stripped on reload, including alongside a leading task block.

## Related Linear tickets, Github issues, and Community forum posts

Follow-up from the cost investigation behind #32404.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] Docs updated or follow-up ticket created.
- [x] Tests included.
- [ ] PR Labeled with `Backport to Beta`, `Backport to Stable`, or `Backport to v1` (if the PR is an urgent fix that needs to be backported)
