### PR TITLE
feat(Microsoft Teams Node): Accept the generic Microsoft OAuth2 (Graph) credential

### DIFF
--- a/packages/nodes-base/nodes/Microsoft/Teams/MicrosoftTeamsTrigger.node.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/MicrosoftTeamsTrigger.node.ts
@@ -39,6 +39,20 @@ export class MicrosoftTeamsTrigger implements INodeType {
 			{
 				name: 'microsoftTeamsOAuth2Api',
 				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['microsoftTeamsOAuth2Api'],
+					},
+				},
+			},
+			{
+				name: 'microsoftOAuth2Api',
+				required: true,
+				displayOptions: {
+					show: {
+						authentication: ['microsoftOAuth2Api'],
+					},
+				},
 			},
 		],
 		inputs: [],
@@ -52,6 +66,25 @@ export class MicrosoftTeamsTrigger implements INodeType {
 			},
 		],
 		properties: [
+			{
+				displayName: 'Authentication',
+				name: 'authentication',
+				type: 'options',
+				noDataExpression: true,
+				options: [
+					{
+						name: 'Teams OAuth2',
+						value: 'microsoftTeamsOAuth2Api',
+					},
+					{
+						name: 'Microsoft OAuth2 (Graph)',
+						value: 'microsoftOAuth2Api',
+						description:
+							'Generic Microsoft Graph credential. Add the Teams change-notification scopes (e.g. ChannelMessage.Read.All, Chat.Read, Subscription.Read.All) and grant admin consent on the credential. See the docs for the full scope string.',
+					},
+				],
+				default: 'microsoftTeamsOAuth2Api',
+			},
 			{
 				displayName: 'Trigger On',
 				name: 'event',

--- a/packages/nodes-base/nodes/Microsoft/Teams/test/authentication.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/test/authentication.test.ts
@@ -1,0 +1,74 @@
+import type { INodeCredentialDescription, INodeProperties } from 'n8n-workflow';
+
+import { MicrosoftTeamsTrigger } from '../MicrosoftTeamsTrigger.node';
+import { versionDescription } from '../v2/actions/versionDescription';
+
+/**
+ * These tests pin the backward-compatibility contract introduced alongside the
+ * generic `microsoftOAuth2Api` credential option: the `authentication` selector
+ * must default to the value that gates the existing `microsoftTeamsOAuth2Api`
+ * credential, so workflows saved before the selector existed keep authenticating
+ * against the Teams credential after the default is backfilled.
+ */
+const cases: Array<{
+	name: string;
+	properties: INodeProperties[];
+	credentials: INodeCredentialDescription[];
+}> = [
+	{
+		name: 'Microsoft Teams action (v2)',
+		properties: versionDescription.properties,
+		credentials: versionDescription.credentials ?? [],
+	},
+	{
+		name: 'Microsoft Teams Trigger',
+		properties: new MicrosoftTeamsTrigger().description.properties,
+		credentials: new MicrosoftTeamsTrigger().description.credentials ?? [],
+	},
+];
+
+describe.each(cases)('$name authentication selector', ({ properties, credentials }) => {
+	const authProperty = properties.find((property) => property.name === 'authentication');
+
+	it('should expose an authentication options selector', () => {
+		expect(authProperty).toBeDefined();
+		expect(authProperty?.type).toBe('options');
+		expect(authProperty?.noDataExpression).toBe(true);
+	});
+
+	it('should offer both the Teams and the generic Microsoft credential', () => {
+		const values = (authProperty?.options ?? []).map((option) =>
+			'value' in option ? option.value : undefined,
+		);
+		expect(values).toContain('microsoftTeamsOAuth2Api');
+		expect(values).toContain('microsoftOAuth2Api');
+	});
+
+	it('should default to the Teams credential (backward compatibility)', () => {
+		expect(authProperty?.default).toBe('microsoftTeamsOAuth2Api');
+	});
+
+	it('should gate each credential behind its matching authentication value', () => {
+		const teamsCredential = credentials.find(
+			(credential) => credential.name === 'microsoftTeamsOAuth2Api',
+		);
+		const genericCredential = credentials.find(
+			(credential) => credential.name === 'microsoftOAuth2Api',
+		);
+
+		expect(teamsCredential?.displayOptions?.show?.authentication).toEqual([
+			'microsoftTeamsOAuth2Api',
+		]);
+		expect(genericCredential?.displayOptions?.show?.authentication).toEqual(['microsoftOAuth2Api']);
+		expect(teamsCredential?.required).toBe(true);
+		expect(genericCredential?.required).toBe(true);
+	});
+
+	it('should keep the default aligned with the Teams credential gate value', () => {
+		const credentialGatedByDefault = credentials.find((credential) =>
+			credential.displayOptions?.show?.authentication?.includes(authProperty?.default as string),
+		);
+
+		expect(credentialGatedByDefault?.name).toBe('microsoftTeamsOAuth2Api');
+	});
+});

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/versionDescription.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/actions/versionDescription.ts
@@ -25,11 +25,44 @@ export const versionDescription: INodeTypeDescription = {
 		{
 			name: 'microsoftTeamsOAuth2Api',
 			required: true,
+			displayOptions: {
+				show: {
+					authentication: ['microsoftTeamsOAuth2Api'],
+				},
+			},
+		},
+		{
+			name: 'microsoftOAuth2Api',
+			required: true,
+			displayOptions: {
+				show: {
+					authentication: ['microsoftOAuth2Api'],
+				},
+			},
 		},
 	],
 	waitingNodeTooltip: SEND_AND_WAIT_WAITING_TOOLTIP,
 	webhooks: sendAndWaitWebhooksDescription,
 	properties: [
+		{
+			displayName: 'Authentication',
+			name: 'authentication',
+			type: 'options',
+			noDataExpression: true,
+			options: [
+				{
+					name: 'Teams OAuth2',
+					value: 'microsoftTeamsOAuth2Api',
+				},
+				{
+					name: 'Microsoft OAuth2 (Graph)',
+					value: 'microsoftOAuth2Api',
+					description:
+						'Generic Microsoft Graph credential. Add the Teams Graph scopes (e.g. Chat.ReadWrite, ChannelMessage.Read.All, Group.ReadWrite.All) and grant admin consent on the credential. See the docs for the full scope string.',
+				},
+			],
+			default: 'microsoftTeamsOAuth2Api',
+		},
 		{
 			displayName: 'Resource',
 			name: 'resource',

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/test/transport/index.test.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/test/transport/index.test.ts
@@ -1,8 +1,10 @@
-import { mockDeep } from 'vitest-mock-extended';
-import type { IExecuteFunctions, INode } from 'n8n-workflow';
-
-import { microsoftApiRequest } from '../../transport/index';
+import type { IExecuteFunctions, IHookFunctions, ILoadOptionsFunctions, INode } from 'n8n-workflow';
 import type { Mock, Mocked } from 'vitest';
+import { mockDeep } from 'vitest-mock-extended';
+
+import { MicrosoftTeamsTrigger } from '../../../MicrosoftTeamsTrigger.node';
+import { getTeams } from '../../methods/listSearch';
+import { getTeamsCredentialType, microsoftApiRequest } from '../../transport/index';
 
 describe('Microsoft Teams Transport', () => {
 	let mockExecuteFunctions: Mocked<IExecuteFunctions>;
@@ -23,6 +25,7 @@ describe('Microsoft Teams Transport', () => {
 			parameters: {},
 		};
 		mockExecuteFunctions.getNode.mockReturnValue(mockNode);
+		mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftTeamsOAuth2Api');
 		vi.clearAllMocks();
 	});
 
@@ -206,6 +209,203 @@ describe('Microsoft Teams Transport', () => {
 					}),
 				);
 			});
+		});
+
+		describe('authentication credential resolution', () => {
+			beforeEach(() => {
+				mockRequestOAuth2.mockResolvedValue({ data: 'test' });
+				mockExecuteFunctions.getCredentials.mockResolvedValue({
+					graphApiBaseUrl: 'https://graph.microsoft.us',
+				});
+			});
+
+			it('should use microsoftTeamsOAuth2Api when authentication is not set (backward compatibility)', async () => {
+				mockExecuteFunctions.getNodeParameter.mockReturnValue(undefined);
+
+				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/teams');
+
+				expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith('microsoftTeamsOAuth2Api');
+				expect(mockRequestOAuth2).toHaveBeenCalledWith(
+					'microsoftTeamsOAuth2Api',
+					expect.anything(),
+				);
+			});
+
+			it('should use microsoftTeamsOAuth2Api when explicitly selected', async () => {
+				mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftTeamsOAuth2Api');
+
+				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/teams');
+
+				expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith('microsoftTeamsOAuth2Api');
+				expect(mockRequestOAuth2).toHaveBeenCalledWith(
+					'microsoftTeamsOAuth2Api',
+					expect.anything(),
+				);
+			});
+
+			it('should use microsoftOAuth2Api when the generic credential is selected', async () => {
+				mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
+
+				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/teams');
+
+				expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith('microsoftOAuth2Api');
+				expect(mockRequestOAuth2).toHaveBeenCalledWith('microsoftOAuth2Api', expect.anything());
+			});
+
+			it('should resolve the credential name from the authentication parameter at index 0', async () => {
+				mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
+
+				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/teams');
+
+				expect(mockExecuteFunctions.getNodeParameter).toHaveBeenCalledWith('authentication', 0);
+			});
+
+			it('should honor graphApiBaseUrl from the generic credential (sovereign cloud)', async () => {
+				mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
+
+				await microsoftApiRequest.call(mockExecuteFunctions, 'GET', '/teams');
+
+				expect(mockExecuteFunctions.getCredentials).toHaveBeenCalledWith('microsoftOAuth2Api');
+				expect(mockRequestOAuth2).toHaveBeenCalledWith(
+					'microsoftOAuth2Api',
+					expect.objectContaining({
+						uri: 'https://graph.microsoft.us/teams',
+					}),
+				);
+			});
+		});
+	});
+
+	describe('getTeamsCredentialType', () => {
+		it('should default to microsoftTeamsOAuth2Api when authentication is undefined', () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue(undefined);
+
+			expect(getTeamsCredentialType.call(mockExecuteFunctions)).toBe('microsoftTeamsOAuth2Api');
+		});
+
+		it('should return microsoftTeamsOAuth2Api when selected', () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftTeamsOAuth2Api');
+
+			expect(getTeamsCredentialType.call(mockExecuteFunctions)).toBe('microsoftTeamsOAuth2Api');
+		});
+
+		it('should return microsoftOAuth2Api when the generic credential is selected', () => {
+			mockExecuteFunctions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
+
+			expect(getTeamsCredentialType.call(mockExecuteFunctions)).toBe('microsoftOAuth2Api');
+		});
+	});
+
+	describe('listSearch credential routing', () => {
+		let mockLoadOptions: Mocked<ILoadOptionsFunctions>;
+		let loadOptionsRequestOAuth2: Mock;
+
+		beforeEach(() => {
+			mockLoadOptions = mockDeep<ILoadOptionsFunctions>();
+			loadOptionsRequestOAuth2 = vi.fn().mockResolvedValue({ value: [] });
+			mockLoadOptions.helpers.requestOAuth2 = loadOptionsRequestOAuth2;
+			mockLoadOptions.getCredentials.mockResolvedValue({ graphApiBaseUrl: '' });
+		});
+
+		it('should route list-search requests through the selected generic credential', async () => {
+			mockLoadOptions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
+
+			await getTeams.call(mockLoadOptions);
+
+			expect(mockLoadOptions.getCredentials).toHaveBeenCalledWith('microsoftOAuth2Api');
+			expect(loadOptionsRequestOAuth2).toHaveBeenCalledWith(
+				'microsoftOAuth2Api',
+				expect.anything(),
+			);
+		});
+
+		it('should default list-search requests to the Teams credential', async () => {
+			mockLoadOptions.getNodeParameter.mockReturnValue(undefined);
+
+			await getTeams.call(mockLoadOptions);
+
+			expect(mockLoadOptions.getCredentials).toHaveBeenCalledWith('microsoftTeamsOAuth2Api');
+			expect(loadOptionsRequestOAuth2).toHaveBeenCalledWith(
+				'microsoftTeamsOAuth2Api',
+				expect.anything(),
+			);
+		});
+	});
+
+	describe('microsoftApiRequest under a webhook hook (IHookFunctions) context', () => {
+		let mockHookFunctions: Mocked<IHookFunctions>;
+		let hookRequestOAuth2: Mock;
+
+		beforeEach(() => {
+			mockHookFunctions = mockDeep<IHookFunctions>();
+			hookRequestOAuth2 = vi.fn().mockResolvedValue({ value: [] });
+			mockHookFunctions.helpers.requestOAuth2 = hookRequestOAuth2;
+			mockHookFunctions.getCredentials.mockResolvedValue({ graphApiBaseUrl: '' });
+			mockHookFunctions.getNode.mockReturnValue(mockNode);
+		});
+
+		it('should resolve the generic credential when selected', async () => {
+			mockHookFunctions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
+
+			await microsoftApiRequest.call(mockHookFunctions, 'GET', '/v1.0/subscriptions');
+
+			expect(mockHookFunctions.getCredentials).toHaveBeenCalledWith('microsoftOAuth2Api');
+			expect(hookRequestOAuth2).toHaveBeenCalledWith('microsoftOAuth2Api', expect.anything());
+		});
+
+		it('should default to the Teams credential', async () => {
+			mockHookFunctions.getNodeParameter.mockReturnValue(undefined);
+
+			await microsoftApiRequest.call(mockHookFunctions, 'GET', '/v1.0/subscriptions');
+
+			expect(mockHookFunctions.getCredentials).toHaveBeenCalledWith('microsoftTeamsOAuth2Api');
+			expect(hookRequestOAuth2).toHaveBeenCalledWith('microsoftTeamsOAuth2Api', expect.anything());
+		});
+	});
+
+	// Drives the real Trigger hook through the real transport (no transport mock) to pin the
+	// webhook hook -> microsoftApiRequest -> credential-resolution wiring end to end.
+	describe('Trigger webhook hooks credential routing (end-to-end)', () => {
+		let mockHookFunctions: Mocked<IHookFunctions>;
+		let hookRequestOAuth2: Mock;
+
+		beforeEach(() => {
+			mockHookFunctions = mockDeep<IHookFunctions>();
+			hookRequestOAuth2 = vi.fn().mockResolvedValue({});
+			mockHookFunctions.helpers.requestOAuth2 = hookRequestOAuth2;
+			mockHookFunctions.getCredentials.mockResolvedValue({ graphApiBaseUrl: '' });
+			mockHookFunctions.getNode.mockReturnValue(mockNode);
+			mockHookFunctions.getWorkflowStaticData.mockReturnValue({ subscriptionIds: ['sub-1'] });
+		});
+
+		it('should delete subscriptions through the selected generic credential', async () => {
+			mockHookFunctions.getNodeParameter.mockReturnValue('microsoftOAuth2Api');
+
+			const result = await new MicrosoftTeamsTrigger().webhookMethods.default.delete.call(
+				mockHookFunctions,
+			);
+
+			expect(result).toBe(true);
+			expect(mockHookFunctions.getCredentials).toHaveBeenCalledWith('microsoftOAuth2Api');
+			expect(hookRequestOAuth2).toHaveBeenCalledWith(
+				'microsoftOAuth2Api',
+				expect.objectContaining({ method: 'DELETE' }),
+			);
+		});
+
+		it('should default subscription deletes to the Teams credential (backward compatibility)', async () => {
+			mockHookFunctions.getNodeParameter.mockReturnValue(undefined);
+
+			const result = await new MicrosoftTeamsTrigger().webhookMethods.default.delete.call(
+				mockHookFunctions,
+			);
+
+			expect(result).toBe(true);
+			expect(mockHookFunctions.getCredentials).toHaveBeenCalledWith('microsoftTeamsOAuth2Api');
+			expect(hookRequestOAuth2).toHaveBeenCalledWith(
+				'microsoftTeamsOAuth2Api',
+				expect.objectContaining({ method: 'DELETE' }),
+			);
 		});
 	});
 });

--- a/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
+++ b/packages/nodes-base/nodes/Microsoft/Teams/v2/transport/index.ts
@@ -11,6 +11,28 @@ import { NodeApiError } from 'n8n-workflow';
 
 import { capitalize } from '../../../../../utils/utilities';
 
+export type TeamsCredentialType = 'microsoftTeamsOAuth2Api' | 'microsoftOAuth2Api';
+
+/**
+ * Resolves which credential type the node is configured to use. Defaults to the
+ * node-specific `microsoftTeamsOAuth2Api` so existing workflows (and nodes saved
+ * before the `authentication` selector existed) keep working unchanged, while
+ * allowing the generic `microsoftOAuth2Api` (Graph) credential to be selected.
+ *
+ * Shared by the action node (v2), its `listSearch` helpers and the Trigger's
+ * webhook hooks, since all of them authenticate through `microsoftApiRequest`.
+ */
+export function getTeamsCredentialType(
+	this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions,
+): TeamsCredentialType {
+	// `0` is the execute item index; in load-options getNodeParameter has no itemIndex
+	// arg, so don't switch this to the 3-arg `(name, itemIndex, default)` form. Anything
+	// other than the generic value (incl. legacy nodes) resolves to the Teams credential.
+	return this.getNodeParameter('authentication', 0) === 'microsoftOAuth2Api'
+		? 'microsoftOAuth2Api'
+		: 'microsoftTeamsOAuth2Api';
+}
+
 export async function microsoftApiRequest(
 	this: IExecuteFunctions | ILoadOptionsFunctions | IHookFunctions,
 	method: IHttpRequestMethods,
@@ -20,7 +42,8 @@ export async function microsoftApiRequest(
 	uri?: string,
 	headers: IDataObject = {},
 ): Promise<any> {
-	const credentials = await this.getCredentials('microsoftTeamsOAuth2Api');
+	const credentialType = getTeamsCredentialType.call(this);
+	const credentials = await this.getCredentials(credentialType);
 	const baseUrl = (
 		typeof credentials.graphApiBaseUrl === 'string' && credentials.graphApiBaseUrl !== ''
 			? credentials.graphApiBaseUrl
@@ -40,7 +63,7 @@ export async function microsoftApiRequest(
 		if (Object.keys(headers).length !== 0) {
 			options.headers = Object.assign({}, options.headers, headers);
 		}
-		return await this.helpers.requestOAuth2.call(this, 'microsoftTeamsOAuth2Api', options);
+		return await this.helpers.requestOAuth2.call(this, credentialType, options);
 	} catch (error) {
 		const errorOptions: IDataObject = {};
 		if (error.error?.error) {


### PR DESCRIPTION
## Summary

Lets the **Microsoft Teams action node (v2)** and the **Microsoft Teams Trigger** node authenticate with **either** the existing node-specific `microsoftTeamsOAuth2Api` credential (default) **or** the generic `microsoftOAuth2Api` ("Microsoft OAuth2 API", Graph) credential, selected via a new **Authentication** dropdown.

This is **additive and non-breaking**: `microsoftTeamsOAuth2Api` stays as the default, so every already-saved Teams workflow keeps working unchanged. The generic credential lets Entra-managed / enterprise tenants drive Teams from a single, centrally-administered Graph app registration with explicitly-consented delegated permissions.

Mirrors the pattern just merged for the **Microsoft Excel 365** node (ENT-56, #32434) and the in-flight **Microsoft OneDrive** work (ENT-53).

### What changed

- **`v2/transport/index.ts`** — added a `getTeamsCredentialType()` helper that resolves the credential name from the `authentication` node parameter, defaulting to `microsoftTeamsOAuth2Api`. Both auth sites in `microsoftApiRequest` (`getCredentials` and `requestOAuth2`) now use it. Because **every** auth path — the action node's `execute`, all `listSearch` pickers, and the Trigger's `checkExists` / `create` / `delete` webhook hooks — funnels through `microsoftApiRequest`, parameterizing this one function covers the whole node and trigger.
- **`v2/actions/versionDescription.ts`** (action v2) and **`MicrosoftTeamsTrigger.node.ts`** (Trigger) — split the single `credentials[]` entry into two `displayOptions`-gated entries and added an `authentication` options property (`default: 'microsoftTeamsOAuth2Api'`).

### Backward compatibility (the critical bit)

Saved Teams nodes have no stored `authentication` parameter and there is no DB migration for node parameters. They keep working because `options`-type properties are default-backfilled when the workflow is built — **and** because the new property's default (`microsoftTeamsOAuth2Api`) equals the value that gates the existing Teams credential. `getTeamsCredentialType` is also defensive: anything other than the exact generic value (including a legacy/undefined value) resolves to `microsoftTeamsOAuth2Api`. This contract is pinned by dedicated tests.

> **Sovereign cloud:** v2 already honors `credentials.graphApiBaseUrl`, so selecting the generic credential picks up US Gov / DOD / China endpoints automatically (covered by a test).

## How to test

1. Open a **Microsoft Teams** node (v2) or a **Microsoft Teams Trigger** node.
2. The new **Authentication** dropdown shows **Teams OAuth2** (default) and **Microsoft OAuth2 (Graph)**; the matching credential field renders for each choice.
3. With **Teams OAuth2**, behavior is unchanged. With **Microsoft OAuth2 (Graph)**, create a generic `microsoftOAuth2Api` credential whose scope string includes the Teams Graph delegated scopes (see Follow-ups) and grant Entra admin consent for the `.All` permissions.
4. Verify an action (e.g. *Channel Message → Get Many*) and a Trigger event (e.g. *New Channel Message*) both succeed via the selected credential.
5. **Backward compat:** an existing Teams workflow saved before this change executes unchanged (resolves to `microsoftTeamsOAuth2Api`).

Automated coverage (`packages/nodes-base`, all green — lint `--quiet` 0 errors, `tsc --noEmit` clean):

- `nodes/Microsoft/Teams/v2/test/transport/index.test.ts` — credential resolution (default/explicit/generic), `getNodeParameter('authentication', 0)`, sovereign base URL, `listSearch` routing, `microsoftApiRequest` under an `IHookFunctions` context, and the **real** Trigger `delete` webhook hook driven end-to-end through the transport.
- `nodes/Microsoft/Teams/test/authentication.test.ts` — descriptor contract for **both** nodes: selector exists, both options present, default equals the Teams credential's gate value.

## Screenshots

### New credential creation page

<img width="1211" height="763" alt="image" src="https://github.com/user-attachments/assets/bfccb97c-69c6-40c9-a5c9-1391f9bb8366" />

### Trigger node usage

<img width="1807" height="879" alt="image" src="https://github.com/user-attachments/assets/417eb1cb-83ee-40b4-a7c4-3d00b694a660" />

### Action node usage

<img width="1807" height="879" alt="image" src="https://github.com/user-attachments/assets/d9620731-7af1-47e8-8164-900ec211ba31" />

### Generic credential retrieving data

<img width="1299" height="892" alt="image" src="https://github.com/user-attachments/assets/0ac3b84d-1dd5-4e63-9c6a-649c5d6f2d32" />

## Related Linear tickets, Github issues, and Community forum posts

https://linear.app/n8n/issue/ENT-58/microsoft-teams-node-accept-the-generic-microsoft-oauth2-graph

## Follow-ups (not in this PR)

- **Docs** (`n8n-io/n8n-docs`): document the new Authentication option, the exact Teams delegated scope string, and the per-event Entra admin-consent steps — companion to the Excel/OneDrive docs PR (#4827). Candidate scope string from the ticket:
  `openid offline_access User.Read.All Group.ReadWrite.All Chat.ReadWrite ChannelMessage.Read.All Channel.Create ChannelMessage.Send ChatMessage.Send Tasks.ReadWrite Team.ReadBasic.All Channel.ReadBasic.All TeamMember.Read.All Subscription.Read.All`
- **Teams action v1** (legacy) stays on `microsoftTeamsOAuth2Api` only — out of scope per the ticket.

## Review / Merge checklist

- [x] I have seen this code, I have run this code, and I take responsibility for this code.
- [x] PR title and summary are descriptive.
- [ ] [Docs updated](https://github.com/n8n-io/n8n-docs) or follow-up ticket created. *(docs follow-up noted above)*
- [x] Tests included.
- [ ] PR Labeled with `Backport to ...` (not needed — additive feature).


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32455">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32455?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

