### PR TITLE
ci: Deepen CI filter fetch until merge base is reachable

### DIFF
--- a/.github/actions/ci-filter/__tests__/ci-filter.test.ts
+++ b/.github/actions/ci-filter/__tests__/ci-filter.test.ts
@@ -331,6 +331,113 @@ describe('getChangedFiles', () => {
 	});
 });
 
+// --- getChangedFiles deep merge-base (shallow clone, stale base) ---
+
+describe('getChangedFiles (shallow clone, stale base)', () => {
+	const builderDir = mkdtempSync(join(tmpdir(), 'ci-filter-build-'));
+	const remoteDir = mkdtempSync(join(tmpdir(), 'ci-filter-remote-shallow-'));
+	const repoDir = mkdtempSync(join(tmpdir(), 'ci-filter-shallow-'));
+	const originalCwd = process.cwd();
+	const originalStep = process.env.CI_FILTER_DEEPEN_STEP;
+	const git = (args: string[], cwd: string) =>
+		execFileSync('git', args, { cwd, stdio: 'pipe' }).toString().trim();
+
+	before(() => {
+		execFileSync('git', ['init', '--bare', '-b', 'main', remoteDir], { stdio: 'pipe' });
+		git(['init', '-b', 'main'], builderDir);
+		git(['config', 'user.email', 'test@test.local'], builderDir);
+		git(['config', 'user.name', 'test'], builderDir);
+		git(['remote', 'add', 'origin', remoteDir], builderDir);
+
+		// Common ancestor (the merge base the PR diverged from)
+		writeFileSync(join(builderDir, 'shared.ts'), 'shared\n');
+		git(['add', '.'], builderDir);
+		git(['commit', '-m', 'root'], builderDir);
+		git(['push', 'origin', 'main'], builderDir);
+
+		// PR branch off root, adds a file
+		git(['checkout', '-b', 'pr-branch'], builderDir);
+		writeFileSync(join(builderDir, 'pr-only.ts'), 'pr\n');
+		git(['add', '.'], builderDir);
+		git(['commit', '-m', 'PR change'], builderDir);
+		git(['push', 'origin', 'pr-branch'], builderDir);
+
+		// master drifts forward, burying the merge base behind several commits
+		git(['checkout', 'main'], builderDir);
+		for (let i = 1; i <= 6; i++) {
+			writeFileSync(join(builderDir, 'shared.ts'), `shared\ndrift ${i}\n`);
+			git(['commit', '-am', `drift ${i}`], builderDir);
+		}
+		git(['push', 'origin', 'main'], builderDir);
+
+		// Shallow checkout of the PR side, mirroring CI's depth-1 clone
+		git(['clone', '--depth=1', '--branch', 'pr-branch', `file://${remoteDir}`, repoDir], originalCwd);
+		git(['config', 'user.email', 'test@test.local'], repoDir);
+		git(['config', 'user.name', 'test'], repoDir);
+		// Tiny step so the deepen loop has to iterate to reach the merge base
+		process.env.CI_FILTER_DEEPEN_STEP = '1';
+		process.chdir(repoDir);
+	});
+
+	after(() => {
+		process.chdir(originalCwd);
+		if (originalStep === undefined) delete process.env.CI_FILTER_DEEPEN_STEP;
+		else process.env.CI_FILTER_DEEPEN_STEP = originalStep;
+		rmSync(builderDir, { recursive: true, force: true });
+		rmSync(remoteDir, { recursive: true, force: true });
+		rmSync(repoDir, { recursive: true, force: true });
+	});
+
+	it('resolves PR-only files when the merge base is beyond the shallow boundary', () => {
+		assert.equal(git(['rev-parse', '--is-shallow-repository'], repoDir), 'true');
+		const changed = getChangedFiles('main');
+		assert.deepEqual(changed, ['pr-only.ts']);
+	});
+});
+
+// --- getChangedFiles unrelated histories ---
+
+describe('getChangedFiles (unrelated histories)', () => {
+	const remoteDir = mkdtempSync(join(tmpdir(), 'ci-filter-remote-unrelated-'));
+	const repoDir = mkdtempSync(join(tmpdir(), 'ci-filter-unrelated-'));
+	const originalCwd = process.cwd();
+	const git = (args: string[], cwd: string = repoDir) =>
+		execFileSync('git', args, { cwd, stdio: 'pipe' }).toString().trim();
+
+	before(() => {
+		execFileSync('git', ['init', '--bare', '-b', 'main', remoteDir], { stdio: 'pipe' });
+		git(['init', '-b', 'main'], repoDir);
+		git(['config', 'user.email', 'test@test.local']);
+		git(['config', 'user.name', 'test']);
+		git(['remote', 'add', 'origin', remoteDir]);
+
+		// Remote main has its own root
+		writeFileSync(join(repoDir, 'main.ts'), 'main\n');
+		git(['add', '.']);
+		git(['commit', '-m', 'main root']);
+		git(['push', 'origin', 'main']);
+
+		// Local HEAD is an orphan branch sharing no ancestor with main
+		git(['checkout', '--orphan', 'feature']);
+		git(['rm', '-q', '-rf', '.']);
+		writeFileSync(join(repoDir, 'feature.ts'), 'feature\n');
+		git(['add', '.']);
+		git(['commit', '-m', 'feature root']);
+
+		process.chdir(repoDir);
+	});
+
+	after(() => {
+		process.chdir(originalCwd);
+		rmSync(remoteDir, { recursive: true, force: true });
+		rmSync(repoDir, { recursive: true, force: true });
+	});
+
+	it('throws once history is exhausted with no common ancestor', () => {
+		assert.throws(() => getChangedFiles('main'), /unrelated histories/);
+	});
+});
+
 // --- runValidate ---
 
 describe('runValidate', () => {

--- a/.github/actions/ci-filter/ci-filter.mjs
+++ b/.github/actions/ci-filter/ci-filter.mjs
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process';
-import { appendFileSync } from 'node:fs';
+import { appendFileSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { resolve } from 'node:path';
 
@@ -104,7 +104,7 @@ export function getChangedFiles(baseRef) {
 	// direction, so files added to base-branch after the PR diverged show up as
 	// "changed" — spuriously triggering path-filtered jobs. The merge base
 	// scopes the diff to PR-only changes.
-	execSync(`git fetch --no-tags --prune --deepen=200 origin ${baseRef}`, { stdio: 'pipe' });
+	fetchUntilMergeBase(baseRef);
 	const output = execSync('git diff --name-only --merge-base FETCH_HEAD HEAD', {
 		encoding: 'utf-8',
 	});
@@ -112,6 +112,71 @@ export function getChangedFiles(baseRef) {
 		.split('\n')
 		.map((f) => f.trim())
 		.filter(Boolean);
+}
+
+/**
+ * Deepen the shallow clone until the merge base between the fetched base ref
+ * (FETCH_HEAD) and HEAD is reliably reachable.
+ *
+ * A single fixed deepen is not enough for stale PRs whose divergence point is
+ * older than the shallow boundary. We fetch with an exponentially growing
+ * window (doubling each round) until the merge base resolves, or until the full
+ * history has been fetched — at which point no common ancestor means the
+ * histories are unrelated.
+ */
+function fetchUntilMergeBase(baseRef) {
+	let step = Number(process.env.CI_FILTER_DEEPEN_STEP) || 200;
+	execSync(`git fetch --no-tags --prune --deepen=${step} origin ${baseRef}`, { stdio: 'pipe' });
+
+	while (!hasReliableMergeBase()) {
+		if (!isShallow()) {
+			throw new Error(
+				`No merge base between FETCH_HEAD and HEAD after fetching the full history of "${baseRef}" (unrelated histories).`,
+			);
+		}
+		step *= 2;
+		execSync(`git fetch --no-tags --prune --deepen=${step} origin ${baseRef}`, { stdio: 'pipe' });
+	}
+}
+
+function isShallow() {
+	return (
+		execSync('git rev-parse --is-shallow-repository', { encoding: 'utf-8' }).trim() === 'true'
+	);
+}
+
+/**
+ * True when a merge base exists AND does not sit on the shallow boundary.
+ * In a shallow repo `git merge-base` can return a grafted boundary commit whose
+ * sub-history is truncated; that result is unreliable, so we must deepen further
+ * before trusting it.
+ */
+function hasReliableMergeBase() {
+	let base;
+	try {
+		base = execSync('git merge-base FETCH_HEAD HEAD', { encoding: 'utf-8' }).trim();
+	} catch {
+		return false; // no common ancestor reachable yet
+	}
+	if (!base) return false;
+	return !readShallowBoundaries().has(base);
+}
+
+function readShallowBoundaries() {
+	try {
+		const shallowPath = execSync('git rev-parse --git-path shallow', {
+			encoding: 'utf-8',
+		}).trim();
+		const content = readFileSync(shallowPath, 'utf-8');
+		return new Set(
+			content
+				.split('\n')
+				.map((l) => l.trim())
+				.filter(Boolean),
+		);
+	} catch {
+		return new Set(); // no shallow file => complete repo
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary

The CI filter (`.github/actions/ci-filter`) scopes the changed-file diff to PR-only changes via `git diff --merge-base FETCH_HEAD HEAD`, after a single shallow `git fetch --deepen=200`.

On PRs whose base branch diverged **more than 200 commits ago**, the merge base falls outside the shallow boundary. The diff is then computed incorrectly, so path-filtered CI jobs get mis-fired or skipped. (DEVP-447)

## Changes

- `getChangedFiles` now deepens the fetch in an **exponentially growing window** (200 → 400 → 800 → …) until the merge base is reliably reachable, instead of a single fixed deepen.
- Guards against trusting a **grafted shallow-boundary commit** as the merge base (its sub-history is truncated, so it can be wrong).
- Throws a clear error if the full history is fetched with no common ancestor (unrelated histories).
- The common case (recent PR) still resolves on the first fetch — no regression; only stale PRs pay the extra cost.
- Added tests covering a shallow stale-base clone and the unrelated-histories case.

https://linear.app/n8n/issue/DEVP-447

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/n8n-io/n8n/pull/32459">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/n8n-io/n8n/pull/32459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

